### PR TITLE
drivers: dma: stm32: add missing fifo operation

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -403,8 +403,10 @@ static int dma_stm32_configure(struct device *dev, u32_t id,
 
 #if defined(CONFIG_DMA_STM32_V1)
 	if (DMA_InitStruct.FIFOMode == LL_DMA_FIFOMODE_ENABLE) {
+		LL_DMA_EnableFifoMode(dma, table_ll_stream[id]);
 		LL_DMA_EnableIT_FE(dma, table_ll_stream[id]);
 	} else {
+		LL_DMA_DisableFifoMode(dma, table_ll_stream[id]);
 		LL_DMA_DisableIT_FE(dma, table_ll_stream[id]);
 	}
 #endif

--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -22,7 +22,6 @@ bool stm32_dma_is_irq_happened(DMA_TypeDef *dma, u32_t id);
 bool stm32_dma_is_unexpected_irq_happened(DMA_TypeDef *dma, u32_t id);
 void stm32_dma_enable_stream(DMA_TypeDef *dma, u32_t id);
 int stm32_dma_disable_stream(DMA_TypeDef *dma, u32_t id);
-void stm32_dma_enable_fifo(DMA_TypeDef *dma, u32_t id);
 void stm32_dma_config_channel_function(DMA_TypeDef *dma, u32_t id, u32_t slot);
 #ifdef CONFIG_DMA_STM32_V1
 void stm32_dma_disable_fifo_irq(DMA_TypeDef *dma, u32_t id);

--- a/drivers/dma/dma_stm32_v1.c
+++ b/drivers/dma/dma_stm32_v1.c
@@ -205,14 +205,6 @@ int stm32_dma_disable_stream(DMA_TypeDef *dma, u32_t id)
 	return -EAGAIN;
 }
 
-void stm32_dma_enable_fifo(DMA_TypeDef *dma, u32_t id)
-{
-	LL_DMA_EnableFifoMode(dma, table_ll_stream[id]);
-	LL_DMA_EnableIT_FE(dma, table_ll_stream[id]);
-	LL_DMA_SetFIFOThreshold(dma, table_ll_stream[id],
-			LL_DMA_FIFOTHRESHOLD_FULL);
-}
-
 void stm32_dma_disable_fifo_irq(DMA_TypeDef *dma, u32_t id)
 {
 	LL_DMA_DisableIT_FE(dma, table_ll_stream[id]);


### PR DESCRIPTION
The DMA driver of stm32 used to use `stm32_dma_enable_fifo()`,
which is located in dma_stm32_v1.c to set DMDIS bit, enable
interrupt generation and set FIFO threshold. Now since FIFO
threshold is initialized with `stm32_dma_get_fifo_threshold()`
and interrupt generation is also configured in dma_stm32.c, this
function will only have one job, to configure FIFO mode.
We can add FIFO mode operation in dma_stm32.c directly and
remove it from dma_stm32_v1.c.

Signed-off-by: Song Qiang <songqiang1304521@gmail.com>