### PR TITLE
doc: fix misspellings in docs

### DIFF
--- a/arch/arm/core/cortex_m/mpu/Kconfig
+++ b/arch/arm/core/cortex_m/mpu/Kconfig
@@ -27,7 +27,7 @@ config ARM_MPU
 	  memory map when programming dynamic memory regions (e.g. PRIV stack
 	  guard, user thread stack, and application memory domains), if the
 	  system requires PRIV access policy different from the access policy
-	  of the ARMv8-M background memory map. The allication developer may
+	  of the ARMv8-M background memory map. The application developer may
 	  enforce full PRIV (kernel) memory partition by enabling the
 	  CONFIG_MPU_GAP_FILLING option.
 	  By not enforcing full partition, MPU may leave part of kernel

--- a/doc/guides/build/index.rst
+++ b/doc/guides/build/index.rst
@@ -5,7 +5,7 @@ Build Overview
 
 The Zephyr build process can be divided into two main phases: a
 configuration phase (driven by *CMake*) and a build phase (driven by
-*Make* or *Ninja*). We will descibe the build phase using *Make* as
+*Make* or *Ninja*). We will describe the build phase using *Make* as
 example.
 
 

--- a/include/drivers/espi.h
+++ b/include/drivers/espi.h
@@ -555,7 +555,7 @@ static inline int z_impl_espi_read_lpc_request(struct device *dev,
  * @brief Writes data to a LPC peripheral which generates an eSPI transaction.
  *
  * This routine provides a generic interface to write data to a block which
- * triggers an eSPI transacion. The eSPI packet is assembled by the HW
+ * triggers an eSPI transaction. The eSPI packet is assembled by the HW
  * block.
  *
  * @param dev Pointer to the device structure for the driver instance.


### PR DESCRIPTION
Fix misspellings in docs (and Kconfig and headers processed into docs)
missed during regular reviews.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>