### PR TITLE
sanitycheck: parse testcase names correctly

### DIFF
--- a/scripts/sanity_chk/harness.py
+++ b/scripts/sanity_chk/harness.py
@@ -126,7 +126,7 @@ class Test(Harness):
 
     def handle(self, line):
         match = result_re.match(line)
-        if match:
+        if match and match.group(2):
             name = "{}.{}".format(self.id, match.group(3))
             self.tests[name] = match.group(1)
 


### PR DESCRIPTION
We were parsing random FAIL messages from the output of test runs ad
testcases and capturing them in the xml output. Now we only parse the
name if it starts with test_.

Fixes #21162