### PR TITLE
bluetooth: l2cap_br: l2cap channel used wrong cid when removing

### DIFF
--- a/subsys/bluetooth/host/l2cap_br.c
+++ b/subsys/bluetooth/host/l2cap_br.c
@@ -1049,7 +1049,7 @@ static struct bt_l2cap_br_chan *l2cap_br_remove_tx_cid(struct bt_conn *conn,
 	}
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&conn->channels, chan, node) {
-		if (BR_CHAN(chan)->rx.cid == cid) {
+		if (BR_CHAN(chan)->tx.cid == cid) {
 			sys_slist_remove(&conn->channels, prev, &chan->node);
 			return BR_CHAN(chan);
 		}


### PR DESCRIPTION
In bt_l2cap_br_chan, rx.cid is the local cid and tx.cid is the
remote cid. According to Core-5.0 Vol3.Part A 4.6-4.7,
l2cap_br_remove_tx_cid should be searched using tx.cid

Signed-off-by: ZhongYao Luo <LuoZhongYao@gmail.com>