### PR TITLE
BT: Provide user pre-initialization callback in bt_enable

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -53,6 +53,15 @@ extern "C" {
  */
 typedef void (*bt_ready_cb_t)(int err);
 
+/**
+ * @typedef bt_preinit_cb_t
+ * @brief Pre-initialization callback before enabling Bluetooth
+ *
+ * @param user context
+ * @return Zero on success or (negative) error code otherwise.
+ */
+typedef int (*bt_preinit_cb_t)(void *data);
+
 /** @brief Enable Bluetooth
  *
  *  Enable Bluetooth. Must be the called before any calls that
@@ -60,10 +69,14 @@ typedef void (*bt_ready_cb_t)(int err);
  *
  *  @param cb Callback to notify completion or NULL to perform the
  *  enabling synchronously.
+ *  @param preinit Before officially enabling Bluetooth, call this
+ *  callback to initialize a specific device. If it is NULL,
+ *  no pre-initialization is required.
+ *  @param data Callback context data
  *
  *  @return Zero on success or (negative) error code otherwise.
  */
-int bt_enable(bt_ready_cb_t cb);
+int bt_enable(bt_ready_cb_t cb, bt_preinit_cb_t preinit, void *data);
 
 /** @brief Set Bluetooth Device Name
  *

--- a/samples/bluetooth/beacon/src/main.c
+++ b/samples/bluetooth/beacon/src/main.c
@@ -67,7 +67,7 @@ void main(void)
 	printk("Starting Beacon Demo\n");
 
 	/* Initialize the Bluetooth Subsystem */
-	err = bt_enable(bt_ready);
+	err = bt_enable(bt_ready, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 	}

--- a/samples/bluetooth/central/src/main.c
+++ b/samples/bluetooth/central/src/main.c
@@ -102,7 +102,7 @@ void main(void)
 {
 	int err;
 
-	err = bt_enable(NULL);
+	err = bt_enable(NULL, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;

--- a/samples/bluetooth/central_hr/src/main.c
+++ b/samples/bluetooth/central_hr/src/main.c
@@ -224,7 +224,7 @@ static struct bt_conn_cb conn_callbacks = {
 void main(void)
 {
 	int err;
-	err = bt_enable(NULL);
+	err = bt_enable(NULL, NULL, NULL);
 
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);

--- a/samples/bluetooth/eddystone/src/main.c
+++ b/samples/bluetooth/eddystone/src/main.c
@@ -680,7 +680,7 @@ void main(void)
 	k_delayed_work_init(&idle_work, idle_timeout);
 
 	/* Initialize the Bluetooth Subsystem */
-	err = bt_enable(bt_ready);
+	err = bt_enable(bt_ready, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 	}

--- a/samples/bluetooth/handsfree/src/main.c
+++ b/samples/bluetooth/handsfree/src/main.c
@@ -120,7 +120,7 @@ void main(void)
 
 	handsfree_enable();
 
-	err = bt_enable(bt_ready);
+	err = bt_enable(bt_ready, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 	}

--- a/samples/bluetooth/ibeacon/src/main.c
+++ b/samples/bluetooth/ibeacon/src/main.c
@@ -67,7 +67,7 @@ void main(void)
 	printk("Starting iBeacon Demo\n");
 
 	/* Initialize the Bluetooth Subsystem */
-	err = bt_enable(bt_ready);
+	err = bt_enable(bt_ready, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 	}

--- a/samples/bluetooth/mesh/src/main.c
+++ b/samples/bluetooth/mesh/src/main.c
@@ -204,7 +204,7 @@ void main(void)
 	printk("Initializing...\n");
 
 	/* Initialize the Bluetooth Subsystem */
-	err = bt_enable(bt_ready);
+	err = bt_enable(bt_ready, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 	}

--- a/samples/bluetooth/mesh_demo/src/main.c
+++ b/samples/bluetooth/mesh_demo/src/main.c
@@ -287,7 +287,7 @@ void main(void)
 	printk("Unicast address: 0x%04x\n", addr);
 
 	/* Initialize the Bluetooth Subsystem */
-	err = bt_enable(bt_ready);
+	err = bt_enable(bt_ready, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 	}

--- a/samples/bluetooth/peripheral/src/main.c
+++ b/samples/bluetooth/peripheral/src/main.c
@@ -323,7 +323,7 @@ void main(void)
 {
 	int err;
 
-	err = bt_enable(bt_ready);
+	err = bt_enable(bt_ready, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;

--- a/samples/bluetooth/peripheral_csc/src/main.c
+++ b/samples/bluetooth/peripheral_csc/src/main.c
@@ -400,7 +400,7 @@ void main(void)
 {
 	int err;
 
-	err = bt_enable(bt_ready);
+	err = bt_enable(bt_ready, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;

--- a/samples/bluetooth/peripheral_dis/src/main.c
+++ b/samples/bluetooth/peripheral_dis/src/main.c
@@ -82,7 +82,7 @@ void main(void)
 {
 	int err;
 
-	err = bt_enable(NULL);
+	err = bt_enable(NULL, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;

--- a/samples/bluetooth/peripheral_esp/src/main.c
+++ b/samples/bluetooth/peripheral_esp/src/main.c
@@ -437,7 +437,7 @@ void main(void)
 {
 	int err;
 
-	err = bt_enable(bt_ready);
+	err = bt_enable(bt_ready, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;

--- a/samples/bluetooth/peripheral_hids/src/main.c
+++ b/samples/bluetooth/peripheral_hids/src/main.c
@@ -131,7 +131,7 @@ void main(void)
 {
 	int err;
 
-	err = bt_enable(bt_ready);
+	err = bt_enable(bt_ready, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;

--- a/samples/bluetooth/peripheral_hr/src/main.c
+++ b/samples/bluetooth/peripheral_hr/src/main.c
@@ -115,7 +115,7 @@ void main(void)
 {
 	int err;
 
-	err = bt_enable(bt_ready);
+	err = bt_enable(bt_ready, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;

--- a/samples/bluetooth/peripheral_ht/src/main.c
+++ b/samples/bluetooth/peripheral_ht/src/main.c
@@ -108,7 +108,7 @@ void main(void)
 {
 	int err;
 
-	err = bt_enable(bt_ready);
+	err = bt_enable(bt_ready, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;

--- a/samples/bluetooth/peripheral_sc_only/src/main.c
+++ b/samples/bluetooth/peripheral_sc_only/src/main.c
@@ -126,7 +126,7 @@ void main(void)
 {
 	int err;
 
-	err = bt_enable(NULL);
+	err = bt_enable(NULL, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;

--- a/samples/bluetooth/scan_adv/src/main.c
+++ b/samples/bluetooth/scan_adv/src/main.c
@@ -39,7 +39,7 @@ void main(void)
 	printk("Starting Scanner/Advertiser Demo\n");
 
 	/* Initialize the Bluetooth Subsystem */
-	err = bt_enable(NULL);
+	err = bt_enable(NULL, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;

--- a/samples/boards/bbc_microbit/pong/src/ble.c
+++ b/samples/boards/bbc_microbit/pong/src/ble.c
@@ -521,7 +521,7 @@ void ble_init(void)
 {
 	int err;
 
-	err = bt_enable(NULL);
+	err = bt_enable(NULL, NULL, NULL);
 	if (err) {
 		printk("Enabling Bluetooth failed (err %d)\n", err);
 		return;

--- a/samples/boards/nrf52/mesh/onoff-app/src/main.c
+++ b/samples/boards/nrf52/mesh/onoff-app/src/main.c
@@ -640,7 +640,7 @@ void main(void)
 	init_led(3, DT_ALIAS_LED3_GPIOS_CONTROLLER, DT_ALIAS_LED3_GPIOS_PIN);
 
 	/* Initialize the Bluetooth Subsystem */
-	err = bt_enable(bt_ready);
+	err = bt_enable(bt_ready, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 	}

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
@@ -179,7 +179,7 @@ void main(void)
 	ps_settings_init();
 
 	/* Initialize the Bluetooth Subsystem */
-	err = bt_enable(NULL);
+	err = bt_enable(NULL, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;

--- a/samples/boards/reel_board/mesh_badge/src/main.c
+++ b/samples/boards/reel_board/mesh_badge/src/main.c
@@ -203,7 +203,7 @@ void main(void)
 	printk("Starting Board Demo\n");
 
 	/* Initialize the Bluetooth Subsystem */
-	err = bt_enable(bt_ready);
+	err = bt_enable(bt_ready, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;

--- a/samples/subsys/mgmt/mcumgr/smp_svr/src/main.c
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/src/main.c
@@ -152,7 +152,7 @@ void main(void)
 
 #ifdef CONFIG_MCUMGR_SMP_BT
 	/* Enable Bluetooth. */
-	rc = bt_enable(bt_ready);
+	rc = bt_enable(bt_ready, NULL, NULL);
 	if (rc != 0) {
 		printk("Bluetooth init failed (err %d)\n", rc);
 		return;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -5103,7 +5103,7 @@ static void hci_rx_thread(void)
 }
 #endif /* !CONFIG_BT_RECV_IS_RX_THREAD */
 
-int bt_enable(bt_ready_cb_t cb)
+int bt_enable(bt_ready_cb_t cb, bt_preinit_cb_t preinit, void *data)
 {
 	int err;
 
@@ -5156,6 +5156,13 @@ int bt_enable(bt_ready_cb_t cb)
 	}
 
 	bt_monitor_send(BT_MONITOR_OPEN_INDEX, NULL, 0);
+
+	if (preinit) {
+		err = preinit(data);
+		if (err) {
+			return err;
+		}
+	}
 
 	if (!cb) {
 		return bt_init();

--- a/subsys/bluetooth/host/l2cap_br.c
+++ b/subsys/bluetooth/host/l2cap_br.c
@@ -1049,7 +1049,7 @@ static struct bt_l2cap_br_chan *l2cap_br_remove_tx_cid(struct bt_conn *conn,
 	}
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&conn->channels, chan, node) {
-		if (BR_CHAN(chan)->rx.cid == cid) {
+		if (BR_CHAN(chan)->tx.cid == cid) {
 			sys_slist_remove(&conn->channels, prev, &chan->node);
 			return BR_CHAN(chan);
 		}

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -514,7 +514,7 @@ static int cmd_init(const struct shell *shell, size_t argc, char *argv[])
 {
 	int err;
 
-	err = bt_enable(NULL);
+	err = bt_enable(NULL, NULL, NULL);
 	if (err && err != -EALREADY) {
 		shell_error(shell, "Bluetooth init failed (err %d)", err);
 		return 0;

--- a/subsys/net/lib/config/bt_settings.c
+++ b/subsys/net/lib/config/bt_settings.c
@@ -36,7 +36,7 @@ int z_net_config_bt_setup(void)
 	struct device *dev;
 	int err;
 
-	err = bt_enable(NULL);
+	err = bt_enable(NULL, NULL, NULL);
 	if (err < 0 && err != -EALREADY) {
 		return err;
 	}

--- a/tests/bluetooth/bluetooth/CMakeLists.txt
+++ b/tests/bluetooth/bluetooth/CMakeLists.txt
@@ -6,4 +6,4 @@ set(NO_QEMU_SERIAL_BT_SERVER 1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(bluetooth)
 
-target_sources(app PRIVATE src/bluetooth.c)
+target_sources(app PRIVATE src/bluetooth.c src/preinit.c)

--- a/tests/bluetooth/bluetooth/src/preinit.c
+++ b/tests/bluetooth/bluetooth/src/preinit.c
@@ -1,7 +1,5 @@
-/* bluetooth.c - Bluetooth smoke test */
-
 /*
- * Copyright (c) 2015-2016 Intel Corporation.
+ * Copyright (c) 2019 ZhongYao Luo
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -22,7 +20,7 @@ static int driver_open(void)
 	TC_PRINT("driver: %s\n", __func__);
 
 	/* Indicate that there is no real Bluetooth device */
-	return EXPECTED_ERROR;
+	return 0;
 }
 
 static int driver_send(struct net_buf *buf)
@@ -42,18 +40,24 @@ static void driver_init(void)
 	bt_hci_driver_register(&drv);
 }
 
-void test_bluetooth_entry(void)
+static int bluetooth_preinit(void *data)
+{
+	TC_PRINT("preinit: %s\n", __func__);
+	return EXPECTED_ERROR;
+}
+
+void test_bluetooth_preinit_entry(void)
 {
 	driver_init();
 
-	zassert_true((bt_enable(NULL, NULL, NULL) == EXPECTED_ERROR),
+	zassert_true((bt_enable(NULL, bluetooth_preinit, NULL) == EXPECTED_ERROR),
 			"bt_enable failed");
 }
 
 /*test case main entry*/
 void test_main(void)
 {
-	ztest_test_suite(test_bluetooth,
-			ztest_unit_test(test_bluetooth_entry));
-	ztest_run_test_suite(test_bluetooth);
+	ztest_test_suite(test_bluetooth_preinit,
+			ztest_unit_test(test_bluetooth_preinit_entry));
+	ztest_run_test_suite(test_bluetooth_preinit);
 }

--- a/tests/bluetooth/bluetooth/testcase.yaml
+++ b/tests/bluetooth/bluetooth/testcase.yaml
@@ -2,3 +2,8 @@ tests:
   bluetooth.general:
     platform_whitelist: qemu_x86 qemu_cortex_m3 native_posix native_posix_64
     tags: bluetooth
+
+tests:
+  bluetooth.preinit:
+    platform_whitelist: qemu_x86 qemu_cortex_m3 native_posix native_posix_64
+    tags: bluetooth

--- a/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect1.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect1.c
@@ -363,7 +363,7 @@ static void test_con1_main(void)
 {
 	int err;
 
-	err = bt_enable(NULL);
+	err = bt_enable(NULL, NULL, NULL);
 
 	if (err) {
 		FAIL("Bluetooth init failed (err %d)\n", err);

--- a/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect2.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect2.c
@@ -148,7 +148,7 @@ static void test_con2_main(void)
 	static int notify_count;
 	int err;
 
-	err = bt_enable(bt_ready);
+	err = bt_enable(bt_ready, NULL, NULL);
 	if (err) {
 		FAIL("Bluetooth init failed (err %d)\n", err);
 		return;

--- a/tests/bluetooth/ctrl_user_ext/src/main.c
+++ b/tests/bluetooth/ctrl_user_ext/src/main.c
@@ -15,7 +15,7 @@
 
 void test_ctrl_user_ext(void)
 {
-	zassert_false(bt_enable(NULL), "Bluetooth ctrl_user_ext failed");
+	zassert_false(bt_enable(NULL, NULL, NULL), "Bluetooth ctrl_user_ext failed");
 }
 
 /*test case main entry*/

--- a/tests/bluetooth/hci_prop_evt/src/main.c
+++ b/tests/bluetooth/hci_prop_evt/src/main.c
@@ -347,7 +347,7 @@ static void test_hci_prop_evt_entry(void)
 	bt_hci_driver_register(&drv);
 
 	/* Go! Wait until Bluetooth initialization is done  */
-	zassert_true((bt_enable(NULL) == 0),
+	zassert_true((bt_enable(NULL, NULL, NULL) == 0),
 		     "bt_enable failed");
 
 	/* Register the prop callback */

--- a/tests/bluetooth/init/src/main.c
+++ b/tests/bluetooth/init/src/main.c
@@ -15,7 +15,7 @@
 
 void test_init(void)
 {
-	zassert_false(bt_enable(NULL), "Bluetooth init failed");
+	zassert_false(bt_enable(NULL, NULL, NULL), "Bluetooth init failed");
 }
 
 /*test case main entry*/

--- a/tests/bluetooth/mesh/src/main.c
+++ b/tests/bluetooth/mesh/src/main.c
@@ -221,7 +221,7 @@ void main(void)
 	printk("Initializing...\n");
 
 	/* Initialize the Bluetooth Subsystem */
-	err = bt_enable(bt_ready);
+	err = bt_enable(bt_ready, NULL, NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 	}

--- a/tests/bluetooth/tester/src/gap.c
+++ b/tests/bluetooth/tester/src/gap.c
@@ -794,7 +794,7 @@ static void tester_init_gap_cb(int err)
 
 u8_t tester_init_gap(void)
 {
-	if (bt_enable(tester_init_gap_cb) < 0) {
+	if (bt_enable(tester_init_gap_cb, NULL, NULL) < 0) {
 		return BTP_STATUS_FAILED;
 	}
 


### PR DESCRIPTION
Most Bluetooth devices use hci vendor-specific commands to
download patches, write bluetooth addresses, etc. before
they officially start work. Modified bt_enable function has
provided support

Signed-off-by: ZhongYao Luo <LuoZhongYao@gmail.com>