### PR TITLE
drivers: usb_dc_native_posix: fix control transfers with data.

### DIFF
--- a/drivers/usb/device/usb_dc_native_posix.c
+++ b/drivers/usb/device/usb_dc_native_posix.c
@@ -524,6 +524,10 @@ int handle_usb_control(struct usbip_header *hdr)
 	if (ep_cb) {
 		LOG_DBG("Call ep_cb");
 		ep_cb(ntohl(hdr->common.ep), USB_DC_EP_SETUP);
+		if (ntohl(hdr->common.command) == USBIP_CMD_SUBMIT &&
+		    hdr->u.submit.transfer_buffer_length != 0) {
+			ep_cb(ntohl(hdr->common.ep), USB_DC_EP_DATA_OUT);
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
Previously, if a control transfer had data, it would be unhandled and
left in the usbip socket to be interpreted as the next usbip packet,
leading to explosions.

Signed-off-by: Josh Gao <josh@jmgao.dev>