### PR TITLE
drivers: watchdog: Fix callback call on STM32 WWDG enable

### DIFF
--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -151,6 +151,9 @@ static int wwdg_stm32_setup(struct device *dev, u8_t options)
 		return -ENOTSUP;
 	}
 
+	/* Ensure that Early Wakeup Interrupt Flag is cleared */
+	LL_WWDG_ClearFlag_EWKUP(wwdg);
+
 	/* Enable the WWDG */
 	LL_WWDG_Enable(wwdg);
 


### PR DESCRIPTION
When using the EWIF it's a good idea to clear it before enabling the
watchdog. Otherwise, the watchdog callback will be called upon watchdog
enable if EWIF is enabled. This patch fixes this case.

Signed-off-by: Ioannis Konstantelias <ikonstadel@gmail.com>