### PR TITLE
Bluetooth: Mesh: Fixes wrong subnet used for Friend Clear

### DIFF
--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -749,7 +749,7 @@ static void send_friend_clear(struct bt_mesh_friend *frnd)
 		.send_ttl = BT_MESH_TTL_MAX,
 	};
 	struct bt_mesh_net_tx tx = {
-		.sub  = &bt_mesh.sub[0],
+		.sub  = bt_mesh_subnet_get(frnd->net_idx),
 		.ctx  = &ctx,
 		.src  = bt_mesh_primary_addr(),
 		.xmit = bt_mesh_net_transmit_get(),


### PR DESCRIPTION
When Friend node tries to send Friend Clear message to other
Friend nodes, it should use the subnet information based on
the net_idx from friendship.

Fixes #21165

Signed-off-by: Maximus Liu <maximus.liu@gmail.com>