### PR TITLE
scripts/sanitycheck: fix merging OVERLAY_CONFIG extra args

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2230,20 +2230,29 @@ class ProjectBuilder(FilterBuilder):
             args += instance.handler.args
 
         # merge overlay files into one variable
-        overlays = ""
-        idx = 0
-        for arg in args:
-            match = re.search('OVERLAY_CONFIG="(.*)"', arg)
-            if match:
-                overlays += match.group(1)
-                del args[idx]
-                idx += 1
+        def extract_overlays(args):
+            re_overlay = re.compile('OVERLAY_CONFIG=(.*)')
+            other_args = []
+            overlays = []
+            for arg in args:
+                match = re_overlay.search(arg)
+                if match:
+                    overlays.append(match.group(1).strip('\'"'))
+                else:
+                    other_args.append(arg)
+
+            args[:] = other_args
+            return overlays
+
+        overlays = extract_overlays(args)
 
         if (self.testcase.extra_configs or self.coverage or
                 self.asan):
-            args.append("OVERLAY_CONFIG=\"%s %s\"" % (overlays,
-                                                      os.path.join(instance.build_dir,
-                                                                   "sanitycheck", "testcase_extra.conf")))
+            overlays.append(os.path.join(instance.build_dir,
+                                         "sanitycheck", "testcase_extra.conf"))
+
+        if overlays:
+            args.append("OVERLAY_CONFIG=\"%s\"" % (" ".join(overlays)))
 
         results = self.run_cmake(args)
         return results


### PR DESCRIPTION
Overlay files were concatenated into single string with no whitespace
between them. If '--extra-args OVERLAY_CONFIG="overlay-1.conf"
--extra-args OVERLAY_CONFIG="overlay-2.conf"' was used, then the result
was OVERLAY_CONFIG="overlay-1.confoverlay-2.conf".

Another thing was that overlay extra args were not properly removed from
the list of regular arguments. As a result we had incorrect list of
overlays and incorrect list of other arguments.

Rework code to extract overlays in loop in a safe manner. Use for that a
list of strings instead of string directly. Join those string and form a
single OVERLAY_CONFIG argument just before running cmake.

Tested with following testcast.yaml line:

  extra_args: ARG1 OVERLAY_CONFIG="overlay-1.conf"
              ARG2 OVERLAY_CONFIG="overlay-2.conf"

Before this patch we got:

  args = ['OVERLAY_CONFIG="overlay-1.conf"',
    'OVERLAY_CONFIG="overlay-2.conf"']

After this patch we get:

  args = ['ARG1', 'ARG2',
    'OVERLAY_CONFIG="overlay-1.conf overlay-2.conf"']

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>