### PR TITLE
fs: nffs: increase maximum block size option to 32kB

### DIFF
--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -117,7 +117,7 @@ config NFFS_FILESYSTEM_MAX_AREAS
 
 config NFFS_FILESYSTEM_MAX_BLOCK_SIZE
 	int "Maximum block size"
-	range 16 2048
+	range 16 32768
 	default 2048
 	help
 	  This determines the maximum size of data block written to flash.


### PR DESCRIPTION
There is no clear reason to limit maximum block size to 2kB. Such
relatively low size implies that we need to have large number of blocks
in order to fill whole flash space available. This however means that
lot of hash entries need to be reserved and consume significant portion
of RAM memory.

Increase limit of maximum block size value that can be configured, so
project can use high capacity flash devices with reduced RAM memory
needed. Value of 32kB was chosen due to the 16-bit variable type that it
is stored in.