### PR TITLE
cmake: require python 3.6 or later

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -20,7 +20,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.9.1
+        image_tag: v0.10.1
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 

--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -13,10 +13,10 @@ endif()
 # that we need to work around until we upgrade to 3.13. Until then we
 # maintain a patched copy in our repo. Bug:
 # https://github.com/zephyrproject-rtos/zephyr/issues/11103
-set(PythonInterp_FIND_VERSION 3.4)
+set(PythonInterp_FIND_VERSION 3.6)
 set(PythonInterp_FIND_VERSION_COUNT 2)
 set(PythonInterp_FIND_VERSION_MAJOR 3)
-set(PythonInterp_FIND_VERSION_MINOR 4)
+set(PythonInterp_FIND_VERSION_MINOR 6)
 set(PythonInterp_FIND_VERSION_EXACT 0)
 set(PythonInterp_FIND_REQUIRED 1)
 include(${ZEPHYR_BASE}/cmake/backports/FindPythonInterp.cmake)

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -29,10 +29,11 @@ tools. First, make sure your development system OS is updated:
 
    .. group-tab:: Ubuntu
 
-      Use these commands to bring your Linux (Ubuntu) system up to date.
-      If you're using a different Linux distribution, use the appropriate
-      package manager for your OS.  (See :ref:`installation_linux` for
-      more information about other Linux distributions.)
+      This guide covers Ubuntu version 18.04 LTS and later. See
+      :ref:`installation_linux` for information about other Linux
+      distributions and older versions of Ubuntu.
+
+      Use these commands to bring your Ubuntu system up to date:
 
       .. code-block:: bash
 
@@ -94,16 +95,11 @@ We'll also install Zephyr's multi-purpose west tool.
 
                wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
 
-         b) Add the kitware repo corresponding to your Ubuntu LTS release (use
-            ``cat /etc/os-release`` to check):
+         b) Add the kitware repo corresponding to the Ubuntu 18.04 LTS release:
 
-            For Ubuntu Bionic Beaver (18.04) use::
+            .. code-block:: bash
 
-              sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
-
-            For Ubuntu Xenial Xerus (16.04) use::
-
-              sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ xenial main'
+               sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
 
          c) Then install the updated cmake using the usual apt commands:
 

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -192,6 +192,19 @@ more recent one by building from source, or use the one that is bundled in
 the :ref:`Zephyr SDK <zephyr_sdk>` by installing it and setting the
 :envvar:`ZEPHYR_SDK_INSTALL_DIR` environment variable.
 
+Python
+======
+
+Python 3.6 or later is required. Check what version you have by using ``python3
+--version``.
+
+If you have an older version, you will need to install a more recent Python 3.
+You can build from source, or use a backport from your distribution's package
+manager channels if one is available. Isolating this Python in a virtual
+environment is recommended to avoid interfering with your system Python.
+
+.. _pyenv: https://github.com/pyenv/pyenv
+
 .. _zephyr_sdk:
 
 Install the Zephyr Software Development Kit (SDK)


### PR DESCRIPTION
Zephyr currently requires Python 3.4 or later. The core Python team
declared version 3.4 hit End of Life (EOL) in March, so there's no
reason to continue to support it if that's causing a burden, which it
is.

This commit allows Zephyr's Python scripts to depend on features
present in version 3.6 or later.

This does skip support for a currently active version of Python:

- Python 3.5 is actively supported by the core Python devs until 09/2020
- Zephyr's 2.2 release, the first which could include this change, is
  tentatively scheduled for 02/2020.

However, almost all supported platforms are either unaffected, or
their users can upgrade easily:

- Windows users who need to can upgrade Python with:
  choco upgrade python

- macOS users who need to can upgrade Python with:
  brew upgrade python3

- Red Hat Enterprise Linux users who need to upgrade can use
  Software Collections (SCLs), e.g. as described here:
  https://developers.redhat.com/blog/2018/08/13/install-python3-rhel/

- CentOS Linux users also have access to SCLs, as described here:
  https://wiki.centos.org/AdditionalResources/Repositories/SCL

- Ubuntu's current long-term support (LTS) release (Bionic Beaver,
  version 18.04) ships with Python 3.6. It and all later versions of
  Ubuntu won't be affected by this change.

- Debian's current stable release (Buster, version 10) ships Python 3.7
  and likewise won't be affected.

The impact of this change is therefore biggest for older versions of
Linux. In particular, these are impacted:

- Older Ubuntu LTS releases.

  - Ubuntu 16.04 ships Python 3.5; it is still supported by Canonical.
  - Ubuntu 14.04 ships Python 3.4, which is EOL. This Ubuntu version
    is also no longer getting standard support from Canonical. Paying
    customers are receiving security updates only.

  https://wiki.ubuntu.com/Releases

- Older Debian versions.

  - Debian 9 (stretch) ships Python 3.5 and is still a supported
    Debian version.
  - Debian 8 (jessie) ships Python 3.4, which is EOL. This Debian
    version is no longer receiving mainline maintenance by the Debian
    project. LTS updates are provided by interested community
    volunteers only.

  https://wiki.debian.org/LTS

Affected Linux users will no longer have a system Python 3 which works
"out of the box" with Zephyr after this change. Some ideas for these
users are:

- Use Zephyr v2.1 or v1.14 LTS, which are maintained and still
  support Python 3.4
- Compile Python 3.6 or later from source and use it within a venv:
  https://docs.python.org/3/library/venv.html
- Use something like https://github.com/pyenv/pyenv

Python 3.6 has compelling new features which make writing Zephyr's
scripts easier, and which it would be good to be able to rely upon.
This motivates moving from Python 3.4 to 3.6 instead of 3.5.

My personal killer 3.6 features motivating skipping 3.5 (YMMV):

- Windows console and file system encodings are UTF-8 (PEPs 528 and
  529): Zephyr's scripts, and many utilities related to git, broadly
  assume strings are UTF-8, so this is very helpful
- os.PathLike and the file system path protocol (PEP 519) allow
  intermixing "smart" paths in pathlib with existing os.path based
  code
- f-strings (PEP 0498) are a wonderful and efficient string
  interpolation mechanism
- CPython dictionaries are insertion ordered as an implementation
  detail starting with 3.6, which in practice helps with
  reproducibility (and *all* Python implementations have insertion
  ordered dicts starting with 3.7)
