### PR TITLE
kernel/sched: Move time slice handling to the scheduler IPI on SMP

### DIFF
--- a/include/kernel_structs.h
+++ b/include/kernel_structs.h
@@ -118,8 +118,8 @@ struct _cpu {
 #endif
 
 #ifdef CONFIG_TIMESLICING
-	/* number of ticks remaining in current time slice */
-	int slice_ticks;
+	/* tick count where current time slice expires */
+	s64_t slice_expires;
 #endif
 
 	u8_t id;

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -57,7 +57,7 @@ void *z_get_next_switch_handle(void *interrupted);
 struct k_thread *z_find_first_thread_to_unpend(_wait_q_t *wait_q,
 					      struct k_thread *from);
 void idle(void *a, void *b, void *c);
-void z_time_slice(int ticks);
+void z_time_slice(void);
 void z_reset_time_slice(void);
 void z_sched_abort(struct k_thread *thread);
 void z_sched_ipi(void);


### PR DESCRIPTION
The SMP model for timer drivers has a somewhat odd requirement that
the z_clock_announce() call be made on every CPU so that it can manage
timeslicing, even though only one CPU will see a positive tick count
and invoke the timeout callbacks.  In practice this is hard to make
work in a portable way for devices like HPET which are a single
device.

Instead, let the announce call be made on any CPU and invoke the
existing sched_ipi to prod the other CPUs.  Overhead is minimal (the
slice_ticks count needs to become a 64 bit expiration time, and the
IPI handler needs an extra test), and the timer drivers don't need to
worry about odd interrupt delivery settings.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>