### PR TITLE
samples: Remove stale 'random' driver sample.

### DIFF
--- a/samples/drivers/random/CMakeLists.txt
+++ b/samples/drivers/random/CMakeLists.txt
@@ -1,8 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-cmake_minimum_required(VERSION 3.13.1)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(random)
-
-FILE(GLOB app_sources src/*.c)
-target_sources(app PRIVATE ${app_sources})


### PR DESCRIPTION
This commit removes the CMakeLists.txt file for the stale 'random'
driver sample.

The 'random' driver sample was previously renamed to 'entropy'.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>