### PR TITLE
Bluetooth: Host: Adding valid param check in send_conn_le_param_update()

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -214,6 +214,11 @@ static int send_conn_le_param_update(struct bt_conn *conn,
 	       conn->le.features[0], param->interval_min,
 	       param->interval_max, param->latency, param->timeout);
 
+	/* Proceed only if connection parameters contains valid values*/
+	if (!bt_le_conn_params_valid(param)) {
+		return -EINVAL;
+	}
+
 	/* Use LE connection parameter request if both local and remote support
 	 * it; or if local role is master then use LE connection update.
 	 */


### PR DESCRIPTION
Send connection parameter update request only if it contains the valid
range of values for connection intervals, latency and timeout.

Fixes: #21057 

Signed-off-by: Kiran Paramaswaran <kipm@oticon.com>