### PR TITLE
drivers: spi_nrfx_spim: Fix handling of extended SPIM configuration (2)

### DIFF
--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -362,7 +362,8 @@ static int spim_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 
 #define SPI_NRFX_SPIM_EXTENDED_CONFIG(idx)				\
 	COND_CODE_1(IS_ENABLED(NRFX_SPIM_EXTENDED_ENABLED),		\
-		(COND_CODE_1(SPIM##idx##_FEATURE_RXDELAY_PRESENT,	\
+		(.dcx_pin = NRFX_SPIM_PIN_NOT_USED,			\
+		 COND_CODE_1(SPIM##idx##_FEATURE_RXDELAY_PRESENT,	\
 			(.rx_delay = CONFIG_SPI_##idx##_NRF_RX_DELAY,),	\
 			())),						\
 		())


### PR DESCRIPTION
This is a follow-up to commit 84f823500517d84389345a68d6bae0d198c0ac2a.

Default initialization to 0 of the .dcx_pin field in the extended part
of the SPIM configuration is incorrect, because this means that pin 0
should be used as the D/CX line. For the SPIM instance that provides
the extended functionality, this results in undesired assignment of
the pin 0, and for the other SPIM instances, this causes that their
initialization fails with the NRFX_ERROR_NOT_SUPPORTED code.

This commit sets this field to NRFX_SPIM_PIN_NOT_USED, to indicate that
the D/CX line is not supposed to be used.

Relates to #21128.