### PR TITLE
cmake: assert: Reduce the verbosity of the assert warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1501,12 +1501,7 @@ add_subdirectory(cmake/reports)
 
 if(NOT CONFIG_TEST)
 if(CONFIG_ASSERT AND (NOT CONFIG_FORCE_NO_ASSERT))
-  message(WARNING "
-      ------------------------------------------------------------
-      --- WARNING:  __ASSERT() statements are globally ENABLED ---
-      --- The kernel will run more slowly and use more memory  ---
-      ------------------------------------------------------------"
-  )
+  message(WARNING "__ASSERT() statements are globally ENABLED")
 endif()
 endif()
 


### PR DESCRIPTION
The warning about CONFIG_ASSERT being enabled is too loud. This patch
reduces it's verbosity and omits the explanation about performance as
this is believed to be obvious.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>