### PR TITLE
dts: arm: mec1501hsz: rename I2C nodes

### DIFF
--- a/boards/arm/mec1501modular_assy6885/Kconfig.defconfig
+++ b/boards/arm/mec1501modular_assy6885/Kconfig.defconfig
@@ -58,19 +58,6 @@ config GPIO_XEC_GPIO240_276
 
 endif # GPIO_XEC
 
-if I2C_XEC
-
-config I2C_XEC_0
-	default y
-
-config I2C_XEC_1
-	default y
-
-config I2C_XEC_2
-	default n
-
-endif # I2C
-
 if ESPI_XEC
 
 #PS/2 driver is compiled in terms of this flag.

--- a/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
+++ b/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
@@ -21,6 +21,10 @@
 
 	aliases {
 		pwm-0 = &pwm0;
+
+		i2c0 = &i2c_smb_0;
+		i2c1 = &i2c_smb_1;
+		i2c7 = &i2c_smb_2;
 	};
 };
 
@@ -33,18 +37,21 @@
 	status = "okay";
 };
 
-&i2c0 {
+&i2c_smb_0 {
 	status = "okay";
+	label = "I2C0";
 	port_sel = <0>;
 };
 
-&i2c1 {
+&i2c_smb_1 {
 	status = "okay";
+	label = "I2C1";
 	port_sel = <1>;
 };
 
-&i2c2 {
+&i2c_smb_2 {
 	status = "okay";
+	label = "I2C7";
 	port_sel = <7>;
 };
 

--- a/boards/arm/mec1501modular_assy6885/pinmux.c
+++ b/boards/arm/mec1501modular_assy6885/pinmux.c
@@ -11,33 +11,127 @@
 
 #include "soc.h"
 
+struct pinmux_ports_t {
+#ifdef CONFIG_PINMUX_XEC_GPIO000_036
+	struct device *porta;
+#endif
+#ifdef CONFIG_PINMUX_XEC_GPIO040_076
+	struct device *portb;
+#endif
+#ifdef CONFIG_PINMUX_XEC_GPIO100_136
+	struct device *portc;
+#endif
+#ifdef CONFIG_PINMUX_XEC_GPIO140_176
+	struct device *portd;
+#endif
+#ifdef CONFIG_PINMUX_XEC_GPIO200_236
+	struct device *porte;
+#endif
+#ifdef CONFIG_PINMUX_XEC_GPIO240_276
+	struct device *portf;
+#endif
+};
+
+static void i2c_pinmux(struct pinmux_ports_t *p, uint8_t port_sel)
+{
+	switch (port_sel) {
+#ifdef CONFIG_PINMUX_XEC_GPIO000_036
+	case 0:
+		pinmux_pin_set(p->porta, MCHP_GPIO_003, MCHP_GPIO_CTRL_MUX_F1);
+		pinmux_pin_set(p->porta, MCHP_GPIO_004, MCHP_GPIO_CTRL_MUX_F1);
+		break;
+#endif
+
+#ifdef CONFIG_PINMUX_XEC_GPIO100_136
+	case 1:
+		pinmux_pin_set(p->portc, MCHP_GPIO_130, MCHP_GPIO_CTRL_MUX_F1);
+		pinmux_pin_set(p->portc, MCHP_GPIO_131, MCHP_GPIO_CTRL_MUX_F1);
+		break;
+#endif
+
+#ifdef CONFIG_PINMUX_XEC_GPIO140_176
+	case 2:
+		pinmux_pin_set(p->portd, MCHP_GPIO_154, MCHP_GPIO_CTRL_MUX_F1);
+		pinmux_pin_set(p->portd, MCHP_GPIO_155, MCHP_GPIO_CTRL_MUX_F1);
+		break;
+#endif
+
+#ifdef CONFIG_PINMUX_XEC_GPIO000_036
+	case 3:
+		pinmux_pin_set(p->porta, MCHP_GPIO_007, MCHP_GPIO_CTRL_MUX_F1);
+		pinmux_pin_set(p->porta, MCHP_GPIO_010, MCHP_GPIO_CTRL_MUX_F1);
+		break;
+#endif
+
+#ifdef CONFIG_PINMUX_XEC_GPIO140_176
+	case 4:
+		pinmux_pin_set(p->portd, MCHP_GPIO_143, MCHP_GPIO_CTRL_MUX_F1);
+		pinmux_pin_set(p->portd, MCHP_GPIO_144, MCHP_GPIO_CTRL_MUX_F1);
+		break;
+#endif
+
+#ifdef CONFIG_PINMUX_XEC_GPIO140_176
+	case 5:
+		pinmux_pin_set(p->portd, MCHP_GPIO_141, MCHP_GPIO_CTRL_MUX_F1);
+		pinmux_pin_set(p->portd, MCHP_GPIO_142, MCHP_GPIO_CTRL_MUX_F1);
+		break;
+#endif
+
+#ifdef CONFIG_PINMUX_XEC_GPIO100_136
+#ifdef CONFIG_PINMUX_XEC_GPIO140_176
+	case 6:
+		pinmux_pin_set(p->portc, MCHP_GPIO_132, MCHP_GPIO_CTRL_MUX_F1);
+		pinmux_pin_set(p->portd, MCHP_GPIO_140, MCHP_GPIO_CTRL_MUX_F1);
+		break;
+#endif
+#endif
+
+#ifdef CONFIG_PINMUX_XEC_GPIO000_036
+	case 7:
+		pinmux_pin_set(p->porta, MCHP_GPIO_012, MCHP_GPIO_CTRL_MUX_F1);
+		pinmux_pin_set(p->porta, MCHP_GPIO_013, MCHP_GPIO_CTRL_MUX_F1);
+		break;
+#endif
+
+	default:
+		break;
+	}
+}
+
 static int board_pinmux_init(struct device *dev)
 {
 	ARG_UNUSED(dev);
+	struct pinmux_ports_t pinmux_ports;
 
 #ifdef CONFIG_PINMUX_XEC_GPIO000_036
 	struct device *porta =
 		device_get_binding(CONFIG_PINMUX_XEC_GPIO000_036_NAME);
+	pinmux_ports.porta = porta;
 #endif
 #ifdef CONFIG_PINMUX_XEC_GPIO040_076
 	struct device *portb =
 		device_get_binding(CONFIG_PINMUX_XEC_GPIO040_076_NAME);
+	pinmux_ports.portb = portb;
 #endif
 #ifdef CONFIG_PINMUX_XEC_GPIO100_136
 	struct device *portc =
 		device_get_binding(CONFIG_PINMUX_XEC_GPIO100_136_NAME);
+	pinmux_ports.portc = portc;
 #endif
 #ifdef CONFIG_PINMUX_XEC_GPIO140_176
 	struct device *portd =
 		device_get_binding(CONFIG_PINMUX_XEC_GPIO140_176_NAME);
+	pinmux_ports.portd = portd;
 #endif
 #ifdef CONFIG_PINMUX_XEC_GPIO200_236
 	struct device *porte =
 		device_get_binding(CONFIG_PINMUX_XEC_GPIO200_236_NAME);
+	pinmux_ports.porte = porte;
 #endif
 #ifdef CONFIG_PINMUX_XEC_GPIO240_276
 	struct device *portf =
 		device_get_binding(CONFIG_PINMUX_XEC_GPIO240_276_NAME);
+	pinmux_ports.portf = portf;
 #endif
 
 	/* Configure GPIO bank before usage
@@ -85,23 +179,29 @@ static int board_pinmux_init(struct device *dev)
 	pinmux_pin_set(portb, MCHP_GPIO_067, MCHP_GPIO_CTRL_MUX_F1);
 #endif /* CONFIG_ADC_XEC */
 
-#ifdef CONFIG_I2C_XEC_0
-	/* Set muxing, for I2C0 - SMB00 */
-	pinmux_pin_set(porta, MCHP_GPIO_003, MCHP_GPIO_CTRL_MUX_F1);
-	pinmux_pin_set(porta, MCHP_GPIO_004, MCHP_GPIO_CTRL_MUX_F1);
+#ifdef CONFIG_I2C_XEC
+
+#ifdef DT_INST_0_MICROCHIP_XEC_I2C
+	i2c_pinmux(&pinmux_ports, DT_INST_0_MICROCHIP_XEC_I2C_PORT_SEL);
 #endif
 
-#ifdef CONFIG_I2C_XEC_1
-	/* Set muxing for I2C1 - SMB01 */
-	pinmux_pin_set(portc, MCHP_GPIO_130, MCHP_GPIO_CTRL_MUX_F1);
-	pinmux_pin_set(portc, MCHP_GPIO_131, MCHP_GPIO_CTRL_MUX_F1);
+#ifdef DT_INST_1_MICROCHIP_XEC_I2C
+	i2c_pinmux(&pinmux_ports, DT_INST_1_MICROCHIP_XEC_I2C_PORT_SEL);
 #endif
 
-#ifdef CONFIG_I2C_XEC_2
-	/* Set muxing, for I2C2 - SMB04 */
-	pinmux_pin_set(portd, MCHP_GPIO_143, MCHP_GPIO_CTRL_MUX_F1);
-	pinmux_pin_set(portd, MCHP_GPIO_144, MCHP_GPIO_CTRL_MUX_F1);
+#ifdef DT_INST_2_MICROCHIP_XEC_I2C
+	i2c_pinmux(&pinmux_ports, DT_INST_2_MICROCHIP_XEC_I2C_PORT_SEL);
 #endif
+
+#ifdef DT_INST_3_MICROCHIP_XEC_I2C
+	i2c_pinmux(&pinmux_ports, DT_INST_3_MICROCHIP_XEC_I2C_PORT_SEL);
+#endif
+
+#ifdef DT_INST_4_MICROCHIP_XEC_I2C
+	i2c_pinmux(&pinmux_ports, DT_INST_4_MICROCHIP_XEC_I2C_PORT_SEL);
+#endif
+
+#endif /* CONFIG_I2C_XEC */
 
 #ifdef CONFIG_ESPI_XEC
 	mchp_pcr_periph_slp_ctrl(PCR_ESPI, MCHP_PCR_SLEEP_DIS);

--- a/boards/arm/mec15xxevb_assy6853/Kconfig.defconfig
+++ b/boards/arm/mec15xxevb_assy6853/Kconfig.defconfig
@@ -58,19 +58,6 @@ config GPIO_XEC_GPIO240_276
 
 endif # GPIO_XEC
 
-if I2C_XEC
-
-config I2C_XEC_0
-	default y
-
-config I2C_XEC_1
-	default y
-
-config I2C_XEC_2
-	default y
-
-endif # I2C
-
 if ESPI
 
 config ESPI_XEC

--- a/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
+++ b/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
@@ -20,6 +20,10 @@
 
 	aliases {
 		pwm-0 = &pwm0;
+
+		i2c0 = &i2c_smb_0;
+		i2c1 = &i2c_smb_1;
+		i2c7 = &i2c_smb_2;
 	};
 };
 
@@ -32,18 +36,21 @@
 	status = "okay";
 };
 
-&i2c0 {
+&i2c_smb_0 {
 	status = "okay";
-	port_sel = <1>;
-};
-
-&i2c1 {
-	status = "okay";
+	label = "I2C0";
 	port_sel = <0>;
 };
 
-&i2c2 {
+&i2c_smb_1 {
 	status = "okay";
+	label = "I2C1";
+	port_sel = <1>;
+};
+
+&i2c_smb_2 {
+	status = "okay";
+	label = "I2C7";
 	port_sel = <7>;
 };
 

--- a/boards/arm/mec15xxevb_assy6853/pinmux.c
+++ b/boards/arm/mec15xxevb_assy6853/pinmux.c
@@ -11,33 +11,127 @@
 
 #include "soc.h"
 
+struct pinmux_ports_t {
+#ifdef CONFIG_PINMUX_XEC_GPIO000_036
+	struct device *porta;
+#endif
+#ifdef CONFIG_PINMUX_XEC_GPIO040_076
+	struct device *portb;
+#endif
+#ifdef CONFIG_PINMUX_XEC_GPIO100_136
+	struct device *portc;
+#endif
+#ifdef CONFIG_PINMUX_XEC_GPIO140_176
+	struct device *portd;
+#endif
+#ifdef CONFIG_PINMUX_XEC_GPIO200_236
+	struct device *porte;
+#endif
+#ifdef CONFIG_PINMUX_XEC_GPIO240_276
+	struct device *portf;
+#endif
+};
+
+static void i2c_pinmux(struct pinmux_ports_t *p, uint8_t port_sel)
+{
+	switch (port_sel) {
+#ifdef CONFIG_PINMUX_XEC_GPIO000_036
+	case 0:
+		pinmux_pin_set(p->porta, MCHP_GPIO_003, MCHP_GPIO_CTRL_MUX_F1);
+		pinmux_pin_set(p->porta, MCHP_GPIO_004, MCHP_GPIO_CTRL_MUX_F1);
+		break;
+#endif
+
+#ifdef CONFIG_PINMUX_XEC_GPIO100_136
+	case 1:
+		pinmux_pin_set(p->portc, MCHP_GPIO_130, MCHP_GPIO_CTRL_MUX_F1);
+		pinmux_pin_set(p->portc, MCHP_GPIO_131, MCHP_GPIO_CTRL_MUX_F1);
+		break;
+#endif
+
+#ifdef CONFIG_PINMUX_XEC_GPIO140_176
+	case 2:
+		pinmux_pin_set(p->portd, MCHP_GPIO_154, MCHP_GPIO_CTRL_MUX_F1);
+		pinmux_pin_set(p->portd, MCHP_GPIO_155, MCHP_GPIO_CTRL_MUX_F1);
+		break;
+#endif
+
+#ifdef CONFIG_PINMUX_XEC_GPIO000_036
+	case 3:
+		pinmux_pin_set(p->porta, MCHP_GPIO_007, MCHP_GPIO_CTRL_MUX_F1);
+		pinmux_pin_set(p->porta, MCHP_GPIO_010, MCHP_GPIO_CTRL_MUX_F1);
+		break;
+#endif
+
+#ifdef CONFIG_PINMUX_XEC_GPIO140_176
+	case 4:
+		pinmux_pin_set(p->portd, MCHP_GPIO_143, MCHP_GPIO_CTRL_MUX_F1);
+		pinmux_pin_set(p->portd, MCHP_GPIO_144, MCHP_GPIO_CTRL_MUX_F1);
+		break;
+#endif
+
+#ifdef CONFIG_PINMUX_XEC_GPIO140_176
+	case 5:
+		pinmux_pin_set(p->portd, MCHP_GPIO_141, MCHP_GPIO_CTRL_MUX_F1);
+		pinmux_pin_set(p->portd, MCHP_GPIO_142, MCHP_GPIO_CTRL_MUX_F1);
+		break;
+#endif
+
+#ifdef CONFIG_PINMUX_XEC_GPIO100_136
+#ifdef CONFIG_PINMUX_XEC_GPIO140_176
+	case 6:
+		pinmux_pin_set(p->portc, MCHP_GPIO_132, MCHP_GPIO_CTRL_MUX_F1);
+		pinmux_pin_set(p->portd, MCHP_GPIO_140, MCHP_GPIO_CTRL_MUX_F1);
+		break;
+#endif
+#endif
+
+#ifdef CONFIG_PINMUX_XEC_GPIO000_036
+	case 7:
+		pinmux_pin_set(p->porta, MCHP_GPIO_012, MCHP_GPIO_CTRL_MUX_F1);
+		pinmux_pin_set(p->porta, MCHP_GPIO_013, MCHP_GPIO_CTRL_MUX_F1);
+		break;
+#endif
+
+	default:
+		break;
+	}
+}
+
 static int board_pinmux_init(struct device *dev)
 {
 	ARG_UNUSED(dev);
+	struct pinmux_ports_t pinmux_ports;
 
 #ifdef CONFIG_PINMUX_XEC_GPIO000_036
 	struct device *porta =
 		device_get_binding(CONFIG_PINMUX_XEC_GPIO000_036_NAME);
+	pinmux_ports.porta = porta;
 #endif
 #ifdef CONFIG_PINMUX_XEC_GPIO040_076
 	struct device *portb =
 		device_get_binding(CONFIG_PINMUX_XEC_GPIO040_076_NAME);
+	pinmux_ports.portb = portb;
 #endif
 #ifdef CONFIG_PINMUX_XEC_GPIO100_136
 	struct device *portc =
 		device_get_binding(CONFIG_PINMUX_XEC_GPIO100_136_NAME);
+	pinmux_ports.portc = portc;
 #endif
 #ifdef CONFIG_PINMUX_XEC_GPIO140_176
 	struct device *portd =
 		device_get_binding(CONFIG_PINMUX_XEC_GPIO140_176_NAME);
+	pinmux_ports.portd = portd;
 #endif
 #ifdef CONFIG_PINMUX_XEC_GPIO200_236
 	struct device *porte =
 		device_get_binding(CONFIG_PINMUX_XEC_GPIO200_236_NAME);
+	pinmux_ports.porte = porte;
 #endif
 #ifdef CONFIG_PINMUX_XEC_GPIO240_276
 	struct device *portf =
 		device_get_binding(CONFIG_PINMUX_XEC_GPIO240_276_NAME);
+	pinmux_ports.portf = portf;
 #endif
 
 	/* Configure GPIO bank before usage
@@ -95,23 +189,29 @@ static int board_pinmux_init(struct device *dev)
 	pinmux_pin_set(portb, MCHP_GPIO_067, MCHP_GPIO_CTRL_MUX_F1);
 #endif /* CONFIG_ADC_XEC */
 
-#ifdef CONFIG_I2C_XEC_0
-	/* Set muxing for I2C1 - SMB01 */
-	pinmux_pin_set(portc, MCHP_GPIO_130, MCHP_GPIO_CTRL_MUX_F1);
-	pinmux_pin_set(portc, MCHP_GPIO_131, MCHP_GPIO_CTRL_MUX_F1);
+#ifdef CONFIG_I2C_XEC
+
+#ifdef DT_INST_0_MICROCHIP_XEC_I2C
+	i2c_pinmux(&pinmux_ports, DT_INST_0_MICROCHIP_XEC_I2C_PORT_SEL);
 #endif
 
-#ifdef CONFIG_I2C_XEC_1
-	/* Set muxing, for I2C0 - SMB00 */
-	pinmux_pin_set(porta, MCHP_GPIO_003, MCHP_GPIO_CTRL_MUX_F1);
-	pinmux_pin_set(porta, MCHP_GPIO_004, MCHP_GPIO_CTRL_MUX_F1);
+#ifdef DT_INST_1_MICROCHIP_XEC_I2C
+	i2c_pinmux(&pinmux_ports, DT_INST_1_MICROCHIP_XEC_I2C_PORT_SEL);
 #endif
 
-#ifdef CONFIG_I2C_XEC_2
-	/* Set muxing, for I2C2 - SMB04 */
-	pinmux_pin_set(portd, MCHP_GPIO_143, MCHP_GPIO_CTRL_MUX_F1);
-	pinmux_pin_set(portd, MCHP_GPIO_144, MCHP_GPIO_CTRL_MUX_F1);
+#ifdef DT_INST_2_MICROCHIP_XEC_I2C
+	i2c_pinmux(&pinmux_ports, DT_INST_2_MICROCHIP_XEC_I2C_PORT_SEL);
 #endif
+
+#ifdef DT_INST_3_MICROCHIP_XEC_I2C
+	i2c_pinmux(&pinmux_ports, DT_INST_3_MICROCHIP_XEC_I2C_PORT_SEL);
+#endif
+
+#ifdef DT_INST_4_MICROCHIP_XEC_I2C
+	i2c_pinmux(&pinmux_ports, DT_INST_4_MICROCHIP_XEC_I2C_PORT_SEL);
+#endif
+
+#endif /* CONFIG_I2C_XEC */
 
 #ifdef CONFIG_ESPI_XEC
 	mchp_pcr_periph_slp_ctrl(PCR_ESPI, MCHP_PCR_SLEEP_DIS);

--- a/drivers/i2c/Kconfig.xec
+++ b/drivers/i2c/Kconfig.xec
@@ -8,25 +8,3 @@ menuconfig I2C_XEC
 	depends on SOC_FAMILY_MEC
 	help
 	  Enable the Microchip XEC I2C driver.
-
-if I2C_XEC
-
-config I2C_XEC_0
-	bool "Enable I2C XEC device 0"
-	help
-	  This tells the driver to configure the I2C device at boot, depending
-	  on the additional configuration options below.
-
-config I2C_XEC_1
-	bool "Enable I2C XEC device 1"
-	help
-	  This tells the driver to configure the I2C device at boot, depending
-	  on the additional configuration options below.
-
-config I2C_XEC_2
-	bool "Enable I2C XEC device 2"
-	help
-	  This tells the driver to configure the I2C device at boot, depending
-	  on the additional configuration options below.
-
-endif # I2C_XEC

--- a/drivers/i2c/i2c_mchp_xec.c
+++ b/drivers/i2c/i2c_mchp_xec.c
@@ -406,42 +406,6 @@ static const struct i2c_driver_api i2c_xec_driver_api = {
 #endif
 };
 
-#ifdef CONFIG_I2C_XEC_0
-static struct i2c_xec_data i2c_xec_data_0;
-static const struct i2c_xec_config i2c_xec_config_0 = {
-	.base_addr = DT_INST_0_MICROCHIP_XEC_I2C_BASE_ADDRESS,
-	.port_sel = DT_INST_0_MICROCHIP_XEC_I2C_PORT_SEL,
-};
-DEVICE_AND_API_INIT(i2c_xec_0, DT_INST_0_MICROCHIP_XEC_I2C_LABEL,
-			&i2c_xec_init, &i2c_xec_data_0, &i2c_xec_config_0,
-			POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,
-			&i2c_xec_driver_api);
-#endif /* CONFIG_I2C_XEC_0 */
-
-#ifdef CONFIG_I2C_XEC_1
-static struct i2c_xec_data i2c_xec_data_1;
-static const struct i2c_xec_config i2c_xec_config_1 = {
-	.base_addr	= DT_INST_1_MICROCHIP_XEC_I2C_BASE_ADDRESS,
-	.port_sel = DT_INST_1_MICROCHIP_XEC_I2C_PORT_SEL,
-};
-DEVICE_AND_API_INIT(i2c_xec_1, DT_INST_1_MICROCHIP_XEC_I2C_LABEL,
-			&i2c_xec_init, &i2c_xec_data_1, &i2c_xec_config_1,
-			POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,
-			&i2c_xec_driver_api);
-#endif /* CONFIG_I2C_XEC_1 */
-
-#ifdef CONFIG_I2C_XEC_2
-static struct i2c_xec_data i2c_xec_data_2;
-static const struct i2c_xec_config i2c_xec_config_2 = {
-	.base_addr	= DT_INST_2_MICROCHIP_XEC_I2C_BASE_ADDRESS,
-	.port_sel = DT_INST_2_MICROCHIP_XEC_I2C_PORT_SEL,
-};
-DEVICE_AND_API_INIT(i2c_xec_2, DT_INST_2_MICROCHIP_XEC_I2C_LABEL,
-			&i2c_xec_init, &i2c_xec_data_2, &i2c_xec_config_2,
-			POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,
-			&i2c_xec_driver_api);
-#endif /* CONFIG_I2C_XEC_2 */
-
 static int i2c_xec_init(struct device *dev)
 {
 	struct i2c_xec_data *data =
@@ -449,3 +413,36 @@ static int i2c_xec_init(struct device *dev)
 	data->pending_stop = 0;
 	return 0;
 }
+
+#define I2C_XEC_DEVICE(n)						\
+	static struct i2c_xec_data i2c_xec_data_##n;			\
+	static const struct i2c_xec_config i2c_xec_config_##n = {	\
+		.base_addr =						\
+			DT_INST_##n##_MICROCHIP_XEC_I2C_BASE_ADDRESS,	\
+		.port_sel = DT_INST_##n##_MICROCHIP_XEC_I2C_PORT_SEL,	\
+	};								\
+	DEVICE_AND_API_INIT(i2c_xec_##n,				\
+		DT_INST_##n##_MICROCHIP_XEC_I2C_LABEL,			\
+		&i2c_xec_init, &i2c_xec_data_##n, &i2c_xec_config_##n,	\
+		POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,			\
+		&i2c_xec_driver_api)
+
+#ifdef DT_INST_0_MICROCHIP_XEC_I2C
+I2C_XEC_DEVICE(0);
+#endif
+
+#ifdef DT_INST_1_MICROCHIP_XEC_I2C
+I2C_XEC_DEVICE(1);
+#endif
+
+#ifdef DT_INST_2_MICROCHIP_XEC_I2C
+I2C_XEC_DEVICE(2);
+#endif
+
+#ifdef DT_INST_3_MICROCHIP_XEC_I2C
+I2C_XEC_DEVICE(3);
+#endif
+
+#ifdef DT_INST_4_MICROCHIP_XEC_I2C
+I2C_XEC_DEVICE(4);
+#endif

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -29,6 +29,14 @@
 		reg = <0x00118000 0x8000>;
 	};
 
+	aliases {
+		i2c-smb-0 = &i2c_smb_0;
+		i2c-smb-1 = &i2c_smb_1;
+		i2c-smb-2 = &i2c_smb_2;
+		i2c-smb-3 = &i2c_smb_3;
+		i2c-smb-4 = &i2c_smb_4;
+	};
+
 	soc {
 		rtimer: timer@40007400 {
 			compatible = "microchip,xec-rtos-timer";
@@ -117,51 +125,57 @@
 			label="GPIO240_276";
 			#gpio-cells=<2>;
 		};
-		i2c0: i2c@40004000 {
+
+		i2c_smb_0: i2c@40004000 {
 			compatible = "microchip,xec-i2c";
 			reg = <0x40004000 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
-			label = "I2C_0";
+			label = "I2C_SMB_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
 		};
-		i2c1: i2c@40004400 {
+
+		i2c_smb_1: i2c@40004400 {
 			compatible = "microchip,xec-i2c";
 			reg = <0x40004400 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
-			label = "I2C_1";
+			label = "I2C_SMB_1";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
 		};
-		i2c2: i2c@40004800 {
+
+		i2c_smb_2: i2c@40004800 {
 			compatible = "microchip,xec-i2c";
 			reg = <0x40004800 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
-			label = "I2C_2";
+			label = "I2C_SMB_2";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
 		};
-		i2c3: i2c@40004c00 {
+
+		i2c_smb_3: i2c@40004c00 {
 			compatible = "microchip,xec-i2c";
 			reg = <0x40004C00 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
-			label = "I2C_3";
+			label = "I2C_SMB_3";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
 		};
-		i2c4: i2c@40005000 {
+
+		i2c_smb_4: i2c@40005000 {
 			compatible = "microchip,xec-i2c";
 			reg = <0x40005000 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
-			label = "I2C_4";
+			label = "I2C_SMB_4";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
 		};
+
 		espi0: espi@400f3400 {
 			compatible = "microchip,xec-espi";
 			reg = <0x400f3400 0x400>;


### PR DESCRIPTION
The I2C controllers on the MEC1501 SoC can be attached to different I2C output line. For example, the I2C #0 controller can be used with I2C7 physical lines out of SoC. The output selection is done by the attribute "port_sel". This renames the parent I2C nodes on the SoC side to refer to the controller themselves instead of the output lines to avoid confusion. The labels of these nodes are also renamed to reflect the controllers.
    
On the board level, the DTS labels are overwritten to indicate the actual output lines.
    
Aliases are also provided in both SoC and board levels to provide shortcuts to the DTS nodes.

Also, the driver instances are defined based on availability of DTS nodes instead of Kconfig. This provides a bit more flexibility in defining driver instances. Also, since the DTS defines 5 I2C controllers, the driver code is extended to cover all 5 if the controllers are enabled