### PR TITLE
boards: arm: Add arduino header to all frdm and mimxrt boards

### DIFF
--- a/boards/arm/frdm_k22f/frdm_k22f.yaml
+++ b/boards/arm/frdm_k22f/frdm_k22f.yaml
@@ -8,6 +8,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
+  - arduino_gpio
   - gpio
   - i2c
   - nvs

--- a/boards/arm/frdm_k82f/frdm_k82f.dts
+++ b/boards/arm/frdm_k82f/frdm_k82f.dts
@@ -74,6 +74,35 @@
 			gpios = <&gpioc 6 GPIO_INT_ACTIVE_LOW>;
 		};
 	};
+
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpiob 0 0>,	/* A0 */
+			   <1 0 &gpiob 1 0>,	/* A1 */
+			   <2 0 &gpioc 1 0>,	/* A2 */
+			   <3 0 &gpioc 2 0>,	/* A3 */
+			   <4 0 &gpiob 3 0>,	/* A4 */
+			   <5 0 &gpiob 2 0>,	/* A5 */
+			   <6 0 &gpiob 16 0>,	/* D0 */
+			   <7 0 &gpiob 17 0>,	/* D1 */
+			   <8 0 &gpioc 12 0>,	/* D2 */
+			   <9 0 &gpiod 0 0>,	/* D3 */
+			   <10 0 &gpioc 11 0>,	/* D4 */
+			   <11 0 &gpioc 10 0>,	/* D5 */
+			   <12 0 &gpioc 8 0>,	/* D6 */
+			   <13 0 &gpioc 9 0>,	/* D7 */
+			   <14 0 &gpioc 3 0>,	/* D8 */
+			   <15 0 &gpioc 5 0>,	/* D9 */
+			   <16 0 &gpiod 4 0>,	/* D10 */
+			   <17 0 &gpiod 2 0>,	/* D11 */
+			   <18 0 &gpiod 3 0>,	/* D12 */
+			   <19 0 &gpiod 1 0>,	/* D13 */
+			   <20 0 &gpioa 1 0>,	/* D14 */
+			   <21 0 &gpioa 2 0>;	/* D15 */
+	};
 };
 
 &flash0 {

--- a/boards/arm/frdm_k82f/frdm_k82f.yaml
+++ b/boards/arm/frdm_k82f/frdm_k82f.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 192
 flash: 256
 supported:
+  - arduino_gpio
   - gpio
   - hwinfo
   - i2c

--- a/boards/arm/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.dts
@@ -59,6 +59,35 @@
 			gpios = <&gpioa 17 GPIO_INT_ACTIVE_LOW>;
 		};
 	};
+
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpiob 0 0>,	/* A0 */
+			   <1 0 &gpiob 1 0>,	/* A1 */
+			   <2 0 &gpiob 2 0>,	/* A2 */
+			   <3 0 &gpiob 3 0>,	/* A3 */
+			   <4 0 &gpioc 2 0>,	/* A4 */
+			   <5 0 &gpioc 1 0>,	/* A5 */
+			   <6 0 &gpioa 1 0>,	/* D0 */
+			   <7 0 &gpioa 2 0>,	/* D1 */
+			   <8 0 &gpiod 4 0>,	/* D2 */
+			   <9 0 &gpioa 12 0>,	/* D3 */
+			   <10 0 &gpioa 4 0>,	/* D4 */
+			   <11 0 &gpioa 5 0>,	/* D5 */
+			   <12 0 &gpioc 8 0>,	/* D6 */
+			   <13 0 &gpioc 9 0>,	/* D7 */
+			   <14 0 &gpioa 13 0>,	/* D8 */
+			   <15 0 &gpiod 5 0>,	/* D9 */
+			   <16 0 &gpiod 0 0>,	/* D10 */
+			   <17 0 &gpiod 2 0>,	/* D11 */
+			   <18 0 &gpiod 3 0>,	/* D12 */
+			   <19 0 &gpiod 1 0>,	/* D13 */
+			   <20 0 &gpioe 0 0>,	/* D14 */
+			   <21 0 &gpioe 1 0>;	/* D15 */
+	};
 };
 
 &cpu0 {

--- a/boards/arm/frdm_kl25z/frdm_kl25z.yaml
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.yaml
@@ -14,6 +14,7 @@ testing:
     - bluetooth
 supported:
   - adc
+  - arduino_gpio
   - gpio
   - hwinfo
   - i2c

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -61,6 +61,34 @@
 			gpios = <&gpioc 5 GPIO_INT_ACTIVE_LOW>;
 		};
 	};
+
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = /* A0 cannot be muxed as gpio */
+			   <1 0 &gpiob 18 0>,	/* A1 */
+			   <2 0 &gpiob 2 0>,	/* A2 */
+			   <3 0 &gpiob 3 0>,	/* A3 */
+			   <4 0 &gpiob 1 0>,	/* A4 */
+			   <6 0 &gpioc 6 0>,	/* D0 */
+			   <7 0 &gpioc 7 0>,	/* D1 */
+			   <8 0 &gpioc 19 0>,	/* D2 */
+			   <9 0 &gpioc 16 0>,	/* D3 */
+			   <10 0 &gpioc 4 0>,	/* D4 */
+			   <11 0 &gpioc 17 0>,	/* D5 */
+			   <12 0 &gpioc 18 0>,	/* D6 */
+			   <13 0 &gpioa 1 0>,	/* D7 */
+			   <14 0 &gpioa 0 0>,	/* D8 */
+			   <15 0 &gpioc 1 0>,	/* D9 */
+			   <16 0 &gpioa 19 0>,	/* D10 */
+			   <17 0 &gpioa 16 0>,	/* D11 */
+			   <18 0 &gpioa 17 0>,	/* D12 */
+			   <19 0 &gpioa 18 0>,	/* D13 */
+			   <20 0 &gpioc 3 0>,	/* D14 */
+			   <21 0 &gpioc 2 0>;	/* D15 */
+	};
 };
 
 &adc0 {

--- a/boards/arm/frdm_kw41z/frdm_kw41z.yaml
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.yaml
@@ -8,6 +8,7 @@ toolchain:
   - xtools
 supported:
   - adc
+  - arduino_gpio
   - counter
   - gpio
   - hwinfo

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -45,6 +45,35 @@
 			gpios = <&gpio2 9 GPIO_INT_ACTIVE_LOW>;
 		};
 	};
+
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio1 29 0>,	/* A0 */
+			   <1 0 &gpio1 14 0>,	/* A1 */
+			   <2 0 &gpio1 28 0>,	/* A2 */
+			   <3 0 &gpio1 26 0>,	/* A3 */
+			   <4 0 &gpio1 31 0>,	/* A4 */
+			   <5 0 &gpio1 30 0>,	/* A5 */
+			   <6 0 &gpio3 1 0>,	/* D0 */
+			   <7 0 &gpio3 0 0>,	/* D1 */
+			   <8 0 &gpio2 20 0>,	/* D2 */
+			   <9 0 &gpio2 26 0>,	/* D3 */
+			   <10 0 &gpio3 2 0>,	/* D4 */
+			   <11 0 &gpio2 27 0>,	/* D5 */
+			   <12 0 &gpio1 27 0>,	/* D6 */
+			   <13 0 &gpio1 15 0>,	/* D7 */
+			   <14 0 &gpio2 21 0>,	/* D8 */
+			   <15 0 &gpio2 22 0>,	/* D9 */
+			   <16 0 &gpio1 11 0>,	/* D10 */
+			   <17 0 &gpio1 12 0>,	/* D11 */
+			   <18 0 &gpio1 13 0>,	/* D12 */
+			   <19 0 &gpio1 10 0>,	/* D13 */
+			   <20 0 &gpio1 31 0>,	/* D14 */
+			   <21 0 &gpio1 30 0>;	/* D15 */
+	};
 };
 
 arduino_serial: &uart4 {};

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.yaml
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.yaml
@@ -15,6 +15,7 @@ toolchain:
 ram: 32
 flash: 16384
 supported:
+  - arduino_gpio
   - counter
   - gpio
   - hwinfo

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -53,6 +53,35 @@
 			gpios = <&gpio5 0 GPIO_INT_ACTIVE_LOW>;
 		};
 	};
+
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio1 26 0>,	/* A0 */
+			   <1 0 &gpio1 27 0>,	/* A1 */
+			   <2 0 &gpio1 28 0>,	/* A2 */
+			   <3 0 &gpio1 29 0>,	/* A3 */
+			   <4 0 &gpio1 31 0>,	/* A4 */
+			   <5 0 &gpio1 30 0>,	/* A5 */
+			   <6 0 &gpio1 25 0>,	/* D0 */
+			   <7 0 &gpio1 24 0>,	/* D1 */
+			   <8 0 &gpio1 9 0>,	/* D2 */
+			   <9 0 &gpio1 7 0>,	/* D3 */
+			   <10 0 &gpio1 5 0>,	/* D4 */
+			   <11 0 &gpio1 6 0>,	/* D5 */
+			   <12 0 &gpio1 14 0>,	/* D6 */
+			   <13 0 &gpio1 22 0>,	/* D7 */
+			   <14 0 &gpio1 23 0>,	/* D8 */
+			   <15 0 &gpio1 15 0>,	/* D9 */
+			   <16 0 &gpio1 11 0>,	/* D10 */
+			   <17 0 &gpio1 12 0>,	/* D11 */
+			   <18 0 &gpio1 13 0>,	/* D12 */
+			   <19 0 &gpio1 10 0>,	/* D13 */
+			   <20 0 &gpio3 23 0>,	/* D14 */
+			   <21 0 &gpio3 22 0>;	/* D15 */
+	};
 };
 
 arduino_serial: &uart2 {};

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.yaml
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.yaml
@@ -15,6 +15,7 @@ toolchain:
 ram: 32768
 flash: 8192
 supported:
+  - arduino_gpio
   - counter
   - gpio
   - hwinfo

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -55,6 +55,35 @@
 		};
 	};
 
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio1 26 0>,	/* A0 */
+			   <1 0 &gpio1 27 0>,	/* A1 */
+			   <2 0 &gpio1 20 0>,	/* A2 */
+			   <3 0 &gpio1 21 0>,	/* A3 */
+			   <4 0 &gpio1 17 0>,	/* A4 */
+			   <5 0 &gpio1 16 0>,	/* A5 */
+			   <6 0 &gpio1 23 0>,	/* D0 */
+			   <7 0 &gpio1 22 0>,	/* D1 */
+			   <8 0 &gpio1 11 0>,	/* D2 */
+			   <9 0 &gpio1 24 0>,	/* D3 */
+			   <10 0 &gpio1 9 0>,	/* D4 */
+			   <11 0 &gpio1 10 0>,	/* D5 */
+			   <12 0 &gpio1 18 0>,	/* D6 */
+			   <13 0 &gpio1 19 0>,	/* D7 */
+			   <14 0 &gpio1 3 0>,	/* D8 */
+			   <15 0 &gpio1 2 0>,	/* D9 */
+			   <16 0 &gpio3 13 0>,	/* D10 */
+			   <17 0 &gpio3 14 0>,	/* D11 */
+			   <18 0 &gpio3 15 0>,	/* D12 */
+			   <19 0 &gpio3 12 0>,	/* D13 */
+			   <20 0 &gpio1 1 0>,	/* D14 */
+			   <21 0 &gpio1 0 0>;	/* D15 */
+	};
+
 	panel {
 		compatible = "rocktech,rk043fn02h-ct";
 		port {

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
@@ -15,6 +15,7 @@ toolchain:
 ram: 32768
 flash: 65536
 supported:
+  - arduino_gpio
   - counter
   - display
   - gpio

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.yaml
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.yaml
@@ -15,6 +15,7 @@ toolchain:
 ram: 32768
 flash: 8192
 supported:
+  - arduino_gpio
   - counter
   - display
   - gpio

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -52,6 +52,35 @@
 		};
 	};
 
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio1 26 0>,	/* A0 */
+			   <1 0 &gpio1 27 0>,	/* A1 */
+			   <2 0 &gpio1 20 0>,	/* A2 */
+			   <3 0 &gpio1 21 0>,	/* A3 */
+			   <4 0 &gpio1 17 0>,	/* A4 */
+			   <5 0 &gpio1 16 0>,	/* A5 */
+			   <6 0 &gpio1 23 0>,	/* D0 */
+			   <7 0 &gpio1 22 0>,	/* D1 */
+			   <8 0 &gpio1 11 0>,	/* D2 */
+			   <9 0 &gpio1 24 0>,	/* D3 */
+			   <10 0 &gpio1 9 0>,	/* D4 */
+			   <11 0 &gpio1 10 0>,	/* D5 */
+			   <12 0 &gpio1 18 0>,	/* D6 */
+			   <13 0 &gpio1 19 0>,	/* D7 */
+			   <14 0 &gpio1 3 0>,	/* D8 */
+			   <15 0 &gpio1 2 0>,	/* D9 */
+			   <16 0 &gpio3 13 0>,	/* D10 */
+			   <17 0 &gpio3 14 0>,	/* D11 */
+			   <18 0 &gpio3 15 0>,	/* D12 */
+			   <19 0 &gpio3 12 0>,	/* D13 */
+			   <20 0 &gpio1 17 0>,	/* D14 */
+			   <21 0 &gpio1 16 0>;	/* D15 */
+	};
+
 	panel {
 		compatible = "rocktech,rk043fn02h-ct";
 		port {

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.yaml
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.yaml
@@ -15,6 +15,7 @@ toolchain:
 ram: 32768
 flash: 8192
 supported:
+  - arduino_gpio
   - counter
   - display
   - gpio

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.yaml
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.yaml
@@ -15,6 +15,7 @@ toolchain:
 ram: 32768
 flash: 65536
 supported:
+  - arduino_gpio
   - counter
   - display
   - gpio

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -61,6 +61,35 @@
 		};
 	};
 
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio1 26 0>,	/* A0 */
+			   <1 0 &gpio1 27 0>,	/* A1 */
+			   <2 0 &gpio1 20 0>,	/* A2 */
+			   <3 0 &gpio1 21 0>,	/* A3 */
+			   <4 0 &gpio1 17 0>,	/* A4 */
+			   <5 0 &gpio1 16 0>,	/* A5 */
+			   <6 0 &gpio1 23 0>,	/* D0 */
+			   <7 0 &gpio1 22 0>,	/* D1 */
+			   <8 0 &gpio1 11 0>,	/* D2 */
+			   <9 0 &gpio1 24 0>,	/* D3 */
+			   <10 0 &gpio1 9 0>,	/* D4 */
+			   <11 0 &gpio1 10 0>,	/* D5 */
+			   <12 0 &gpio1 18 0>,	/* D6 */
+			   <13 0 &gpio1 19 0>,	/* D7 */
+			   <14 0 &gpio1 3 0>,	/* D8 */
+			   <15 0 &gpio1 2 0>,	/* D9 */
+			   <16 0 &gpio3 13 0>,	/* D10 */
+			   <17 0 &gpio3 14 0>,	/* D11 */
+			   <18 0 &gpio3 15 0>,	/* D12 */
+			   <19 0 &gpio3 12 0>,	/* D13 */
+			   <20 0 &gpio1 17 0>,	/* D14 */
+			   <21 0 &gpio1 16 0>;	/* D15 */
+	};
+
 	panel {
 		compatible = "rocktech,rk043fn02h-ct";
 		port {

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.yaml
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.yaml
@@ -15,6 +15,7 @@ toolchain:
 ram: 32768
 flash: 4096
 supported:
+  - arduino_gpio
   - counter
   - display
   - gpio


### PR DESCRIPTION
Adds a device tree nexus node to define which gpio pins are mapped from
the soc to the arduino header.

The frdm_kw41z board excludes the arduino A0 pin because it cannot be
muxed as a gpio on the soc.