### PR TITLE
libc: permit users to supply their own malloc.

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -80,6 +80,15 @@ endif # NEWLIB_LIBC
 
 if MINIMAL_LIBC
 
+config MINIMAL_LIBC_MALLOC
+	bool "Enable minimal libc malloc implementation"
+	default y
+	help
+	  Enable the minimal libc's implementation of malloc, free, and realloc.
+	  Disable if you wish to provide your own implementations of these functions.
+
+if MINIMAL_LIBC_MALLOC
+
 config MINIMAL_LIBC_MALLOC_ARENA_SIZE
 	int "Size of the minimal libc malloc arena"
 	default 0
@@ -87,6 +96,22 @@ config MINIMAL_LIBC_MALLOC_ARENA_SIZE
 	  Indicate the size of the memory arena used for minimal libc's
 	  malloc() implementation. This size value must be compatible with
 	  a sys_mem_pool definition with nmax of 1 and minsz of 16.
+
+endif
+
+config MINIMAL_LIBC_CALLOC
+	bool "Enable minimal libc trivial calloc implementation"
+	default y
+	help
+	  Enable the minimal libc's trivial implementation of calloc, which
+	  forwards to malloc and memset.
+
+config MINIMAL_LIBC_REALLOCARRAY
+	bool "Enable minimal libc trivial reallocarray implementation"
+	default y
+	help
+	  Enable the minimal libc's trivial implementation of reallocarray, which
+	  forwards to realloc.
 
 config MINIMAL_LIBC_LL_PRINTF
 	bool "Build with minimal libc long long printf" if !64BIT


### PR DESCRIPTION
Severely memory constrained systems with known allocation patterns can
benefit from providing their own implementation of malloc with
specifically tuned bucket sizes. Provide a switch to allow users to
replace the default malloc implementation with their own.

Signed-off-by: Josh Gao <josh@jmgao.dev>