### PR TITLE
Bluetooth: controller: Fix HCI LE Add Device to Whitelist

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ll_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.c
@@ -121,7 +121,7 @@ static u32_t wl_add(bt_addr_le_t *id_addr)
 
 	/* Duplicate  check */
 	if (i < ARRAY_SIZE(wl)) {
-		return BT_HCI_ERR_INVALID_PARAM;
+		return 0;
 	} else if (j >= ARRAY_SIZE(wl)) {
 		return BT_HCI_ERR_MEM_CAPACITY_EXCEEDED;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -785,7 +785,7 @@ static u32_t wl_add(bt_addr_le_t *id_addr)
 
 	/* Duplicate  check */
 	if (i < ARRAY_SIZE(wl)) {
-		return BT_HCI_ERR_INVALID_PARAM;
+		return 0;
 	} else if (j >= ARRAY_SIZE(wl)) {
 		return BT_HCI_ERR_MEM_CAPACITY_EXCEEDED;
 	}


### PR DESCRIPTION
According to BT Spec v5.1 Vol 2 Part E Section 7.8.16, if the
device is already in the White List, the controller should not
add the device to the White List and should return success.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>