### PR TITLE
Bluetooth: Host: Fix duplicate whitelist entries issue

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2044,10 +2044,6 @@ int bt_conn_create_auto_le(const struct bt_le_conn_param *param)
 		return -EALREADY;
 	}
 
-	if (!bt_dev.le.wl_entries) {
-		return -EINVAL;
-	}
-
 	/* Don't start initiator if we have general discovery procedure. */
 	conn = bt_conn_lookup_state_le(NULL, BT_CONN_CONNECT_SCAN);
 	if (conn) {

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -84,13 +84,6 @@ struct bt_dev_le {
 	 */
 	u8_t                    rl_entries;
 #endif /* CONFIG_BT_SMP */
-
-#if defined(CONFIG_BT_WHITELIST)
-	/* Size of the controller whitelist. */
-	u8_t			wl_size;
-	/* Number of entries in the resolving list. */
-	u8_t			wl_entries;
-#endif /* CONFIG_BT_WHITELIST */
 };
 
 #if defined(CONFIG_BT_BREDR)


### PR DESCRIPTION
If the whitelist already exists in the controller then the controller
should not add the device tot the whitelist and should return success.
In that case the counting of entries in the whitelist in the host will
be wrong.

Remove all whitelist counting in the host, and instead rely on the error
reported by the controller for this.
The controller should return error if the whitelist is full.
The controller should return error if use of whitelist was requested but
the whitelist was empty.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>