### PR TITLE
dts: edtlib: remove diagnostic on required with default

### DIFF
--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -1604,11 +1604,6 @@ def _check_prop_type_and_default(prop_name, prop_type, required, default,
     if default is None:
         return
 
-    if required:
-        _err("'default:' for '{}' in 'properties:' in {} is meaningless in "
-             "combination with 'required: true'"
-             .format(prop_name, binding_path))
-
     if prop_type in {"boolean", "compound", "phandle", "phandles",
                      "phandle-array"}:
         _err("'default:' can't be combined with 'type: {}' for '{}' in "


### PR DESCRIPTION
A property may be optional with a default in a base yaml, then overridden to be required in a subordinate file.  Don't prevent this by complaining about having a default on a required property.

Closes #21181 

Previously discussed at https://github.com/zephyrproject-rtos/zephyr/pull/20115#discussion_r353561517