### PR TITLE
doc: remove extra space after nested list

### DIFF
--- a/doc/static/zephyr-custom.css
+++ b/doc/static/zephyr-custom.css
@@ -44,7 +44,7 @@ div.rst-other-versions dl {
 }
 
 /* tweak spacing after a toctree, fixing issue from sphinx-tabs */
-.toctree-wrapper ul, .section ul {
+.toctree-wrapper ul, ul.simple ol.simple {
    margin-bottom: 24px !important;
 }
 


### PR DESCRIPTION
Remove extra spacing after a nested list.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>