### PR TITLE
cmake: extra_flags: fix EXTRA_CPPFLAGS being applied as macros

### DIFF
--- a/cmake/extra_flags.cmake
+++ b/cmake/extra_flags.cmake
@@ -7,7 +7,7 @@ separate_arguments(EXTRA_CXXFLAGS_AS_LIST UNIX_COMMAND ${EXTRA_CXXFLAGS})
 separate_arguments(EXTRA_AFLAGS_AS_LIST   UNIX_COMMAND ${EXTRA_AFLAGS})
 
 if(EXTRA_CPPFLAGS)
-  zephyr_compile_definitions(${EXTRA_CPPFLAGS_AS_LIST})
+  zephyr_compile_options(${EXTRA_CPPFLAGS_AS_LIST})
 endif()
 if(EXTRA_LDFLAGS)
   zephyr_link_libraries(${EXTRA_LDFLAGS_AS_LIST})


### PR DESCRIPTION
The EXTRA_CPPFLAGS is applied via zephyr_compile_definitions()
instead of zephyr_compile_options(), which makes all specified
options as macros. So fix it.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>