### PR TITLE
json: fix unnamed fields in initializers for GCC < 4.6

### DIFF
--- a/include/data/json.h
+++ b/include/data/json.h
@@ -169,9 +169,11 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = (sizeof(#field_name_) - 1), \
 		.type = JSON_TOK_OBJECT_START, \
 		.offset = offsetof(struct_, field_name_), \
-		.object = { \
-			.sub_descr = sub_descr_, \
-			.sub_descr_len = ARRAY_SIZE(sub_descr_), \
+		{ \
+			.object = { \
+				.sub_descr = sub_descr_, \
+				.sub_descr_len = ARRAY_SIZE(sub_descr_), \
+			}, \
 		}, \
 	}
 
@@ -209,13 +211,18 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = sizeof(#field_name_) - 1, \
 		.type = JSON_TOK_LIST_START, \
 		.offset = offsetof(struct_, field_name_), \
-		.array = { \
-			.element_descr = &(struct json_obj_descr) { \
-				.align_shift = Z_ALIGN_SHIFT(struct_), \
-				.type = elem_type_, \
-				.offset = offsetof(struct_, len_field_), \
+		{ \
+			.array = { \
+				.element_descr = &(struct json_obj_descr) { \
+					.align_shift = \
+						Z_ALIGN_SHIFT(struct_), \
+					.type = elem_type_, \
+					.offset = \
+						offsetof(struct_, \
+							 len_field_), \
+				}, \
+				.n_elements = (max_len_), \
 			}, \
-			.n_elements = (max_len_), \
 		}, \
 	}
 
@@ -266,17 +273,25 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = sizeof(#field_name_) - 1, \
 		.type = JSON_TOK_LIST_START, \
 		.offset = offsetof(struct_, field_name_), \
-		.array = { \
-			.element_descr = &(struct json_obj_descr) { \
-				.align_shift = Z_ALIGN_SHIFT(struct_), \
-				.type = JSON_TOK_OBJECT_START, \
-				.offset = offsetof(struct_, len_field_), \
-				.object = { \
-					.sub_descr = elem_descr_, \
-					.sub_descr_len = elem_descr_len_, \
+		{ \
+			.array = { \
+				.element_descr = &(struct json_obj_descr) { \
+					.align_shift = \
+						Z_ALIGN_SHIFT(struct_), \
+					.type = JSON_TOK_OBJECT_START, \
+					.offset = offsetof(struct_, \
+							   len_field_), \
+					{ \
+						.object = { \
+							.sub_descr = \
+								elem_descr_, \
+							.sub_descr_len = \
+							    elem_descr_len_, \
+						}, \
+					}, \
 				}, \
+				.n_elements = (max_len_), \
 			}, \
-			.n_elements = (max_len_), \
 		}, \
 	}
 
@@ -336,17 +351,25 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = sizeof(#field_name_) - 1, \
 		.type = JSON_TOK_LIST_START, \
 		.offset = offsetof(struct_, field_name_), \
-		.array = { \
-			.element_descr = &(struct json_obj_descr) { \
-				.align_shift = Z_ALIGN_SHIFT(struct_), \
-				.type = JSON_TOK_LIST_START, \
-				.offset = offsetof(struct_, len_field_), \
-				.object = { \
-					.sub_descr = elem_descr_, \
-					.sub_descr_len = elem_descr_len_, \
+		{ \
+			.array = { \
+				.element_descr = &(struct json_obj_descr) { \
+					.align_shift = \
+						Z_ALIGN_SHIFT(struct_), \
+					.type = JSON_TOK_LIST_START, \
+					.offset = offsetof(struct_, \
+							   len_field_), \
+					{ \
+						.object = { \
+							.sub_descr = \
+								elem_descr_, \
+							.sub_descr_len = \
+							    elem_descr_len_, \
+						}, \
+					}, \
 				}, \
+				.n_elements = (max_len_), \
 			}, \
-			.n_elements = (max_len_), \
 		}, \
 	}
 
@@ -401,9 +424,11 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = (sizeof(json_field_name_) - 1), \
 		.type = JSON_TOK_OBJECT_START, \
 		.offset = offsetof(struct_, struct_field_name_), \
-		.object = { \
-			.sub_descr = sub_descr_, \
-			.sub_descr_len = ARRAY_SIZE(sub_descr_), \
+		{ \
+			.object = { \
+				.sub_descr = sub_descr_, \
+				.sub_descr_len = ARRAY_SIZE(sub_descr_), \
+			}, \
 		}, \
 	}
 
@@ -437,13 +462,17 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = sizeof(json_field_name_) - 1, \
 		.type = JSON_TOK_LIST_START, \
 		.offset = offsetof(struct_, struct_field_name_), \
-		.array = { \
-			.element_descr = &(struct json_obj_descr) { \
-				.align_shift = Z_ALIGN_SHIFT(struct_), \
-				.type = elem_type_, \
-				.offset = offsetof(struct_, len_field_), \
+		{ \
+			.array = { \
+				.element_descr = &(struct json_obj_descr) { \
+					.align_shift = \
+						Z_ALIGN_SHIFT(struct_), \
+					.type = elem_type_, \
+					.offset = offsetof(struct_, \
+							   len_field_), \
+				}, \
+				.n_elements = (max_len_), \
 			}, \
-			.n_elements = (max_len_), \
 		}, \
 	}
 
@@ -503,16 +532,26 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = sizeof(json_field_name_) - 1, \
 		.type = JSON_TOK_LIST_START, \
 		.offset = offsetof(struct_, struct_field_name_), \
-		.element_descr = &(struct json_obj_descr) { \
-			.align_shift = Z_ALIGN_SHIFT(struct_), \
-			.type = JSON_TOK_OBJECT_START, \
-			.offset = offsetof(struct_, len_field_), \
-			.object = { \
-				.sub_descr = elem_descr_, \
-				.sub_descr_len = elem_descr_len_, \
+		{ \
+			.array = { \
+				.element_descr = &(struct json_obj_descr) { \
+					.align_shift = \
+						Z_ALIGN_SHIFT(struct_), \
+					.type = JSON_TOK_OBJECT_START, \
+					.offset = offsetof(struct_, \
+							   len_field_), \
+					{ \
+						.object = { \
+							.sub_descr = \
+								elem_descr_, \
+							.sub_descr_len = \
+							    elem_descr_len_, \
+						}, \
+					}, \
+				}, \
+				.n_elements = (max_len_), \
 			}, \
 		}, \
-		.n_elements = (max_len_), \
 	}
 
 /**


### PR DESCRIPTION
The unnamed unions inside json_obj_descr struct causes issues
with the initializer macros due to bug described here:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=10676
The issue is that for GCC < 4.6, it cannot handle unnamed
fields in initializers. So apply the workarounds described
in the bug report.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>