### PR TITLE
drivers/flash: fix warnings about missing casts in flash includes

### DIFF
--- a/include/drivers/flash.h
+++ b/include/drivers/flash.h
@@ -101,7 +101,7 @@ __syscall int flash_read(struct device *dev, off_t offset, void *data,
 static inline int z_impl_flash_read(struct device *dev, off_t offset, void *data,
 			     size_t len)
 {
-	const struct flash_driver_api *api = dev->driver_api;
+	const struct flash_driver_api *api = (const struct flash_driver_api*)dev->driver_api;
 
 	return api->read(dev, offset, data, len);
 }
@@ -125,7 +125,7 @@ __syscall int flash_write(struct device *dev, off_t offset, const void *data,
 static inline int z_impl_flash_write(struct device *dev, off_t offset,
 				    const void *data, size_t len)
 {
-	const struct flash_driver_api *api = dev->driver_api;
+	const struct flash_driver_api *api = (const struct flash_driver_api*)dev->driver_api;
 
 	return api->write(dev, offset, data, len);
 }
@@ -156,7 +156,7 @@ __syscall int flash_erase(struct device *dev, off_t offset, size_t size);
 static inline int z_impl_flash_erase(struct device *dev, off_t offset,
 				    size_t size)
 {
-	const struct flash_driver_api *api = dev->driver_api;
+	const struct flash_driver_api *api = (const struct flash_driver_api*)dev->driver_api;
 
 	return api->erase(dev, offset, size);
 }
@@ -182,7 +182,7 @@ __syscall int flash_write_protection_set(struct device *dev, bool enable);
 static inline int z_impl_flash_write_protection_set(struct device *dev,
 						   bool enable)
 {
-	const struct flash_driver_api *api = dev->driver_api;
+	const struct flash_driver_api *api = (const struct flash_driver_api*)dev->driver_api;
 
 	return api->write_protection(dev, enable);
 }
@@ -269,7 +269,7 @@ __syscall size_t flash_get_write_block_size(struct device *dev);
 
 static inline size_t z_impl_flash_get_write_block_size(struct device *dev)
 {
-	const struct flash_driver_api *api = dev->driver_api;
+	const struct flash_driver_api *api = (const struct flash_driver_api*)dev->driver_api;
 
 	return api->write_block_size;
 }


### PR DESCRIPTION
fix warnings about missing casts in /include/drivers/flash.h on the dev->driver_api

Fixes #21290