### PR TITLE
drivers: uart_gecko: added support for hardware flow control

### DIFF
--- a/drivers/serial/uart_gecko.c
+++ b/drivers/serial/uart_gecko.c
@@ -14,10 +14,8 @@
 
 #define USART_PREFIX cmuClock_USART
 #define UART_PREFIX cmuClock_UART
-#define CLOCK_ID_PRFX2(prefix, suffix) prefix##suffix
-#define CLOCK_ID_PRFX(prefix, suffix) CLOCK_ID_PRFX2(prefix, suffix)
-#define CLOCK_USART(id) CLOCK_ID_PRFX(USART_PREFIX, id)
-#define CLOCK_UART(id) CLOCK_ID_PRFX(UART_PREFIX, id)
+#define CLOCK_USART(id) _CONCAT(USART_PREFIX, id)
+#define CLOCK_UART(id) _CONCAT(UART_PREFIX, id)
 
 /* Helper define to determine if SOC supports hardware flow control */
 #if ((_SILICON_LABS_32B_SERIES > 0) || \

--- a/dts/bindings/serial/silabs,gecko-usart.yaml
+++ b/dts/bindings/serial/silabs,gecko-usart.yaml
@@ -28,3 +28,13 @@ properties:
       type: array
       required: true
       description: TX pin configuration defined as <location port pin>
+
+    location-rts:
+      type: array
+      required: false
+      description: RTS pin configuration defined as <location port pin>
+
+    location-cts:
+      type: array
+      required: false
+      description: CTS pin configuration defined as <location port pin>


### PR DESCRIPTION
Added support for hardware flow control in EFM32 UART driver.

Tested with samples/hello_world on efm32pg_stk3402a and further low level tests with uart_poll_in() and uart_poll_out() as in tests/drivers/uart/uart_basic_api/.

Signed-off-by: Timo Dammes <timo.dammes@lemonbeat.com>