### PR TITLE
eth: mcux: Do not set carrier ON if interface is not known

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -334,8 +334,12 @@ static void eth_mcux_phy_event(struct eth_context *context)
 					  kENET_MiiReadValidFrame);
 			context->link_up = link_up;
 			context->phy_state = eth_mcux_phy_state_read_duplex;
-			net_eth_carrier_on(context->iface);
-			k_sleep(USEC_PER_MSEC);
+
+			/* Network interface might be NULL at this point */
+			if (context->iface) {
+				net_eth_carrier_on(context->iface);
+				k_sleep(USEC_PER_MSEC);
+			}
 		} else if (!link_up && context->link_up) {
 			LOG_INF("Link down");
 			context->link_up = link_up;


### PR DESCRIPTION
It is possible that the network interface is not yet resolved
when status of the PHY changes. In this case we must not call
net_eth_carrier_on() as that will cause a crash.
This was noticed with mimxrt1050_evk board.

Fixes: #21257

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>