### PR TITLE
cmake: Fix cache directory detection

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -1497,10 +1497,12 @@ function(find_appropriate_cache_directory dir)
     if(DEFINED ENV{${env_var}})
       set(env_dir $ENV{${env_var}})
 
-      check_if_directory_is_writeable(${env_dir} ok)
+      set(test_user_dir ${env_dir}/${env_suffix_${env_var}})
+
+      check_if_directory_is_writeable(${test_user_dir} ok)
       if(${ok})
         # The directory is write-able
-        set(user_dir ${env_dir}/${env_suffix_${env_var}})
+        set(user_dir ${test_user_dir})
         break()
       else()
         # The directory was not writeable, keep looking for a suitable


### PR DESCRIPTION
To detect where the cache directory has been located we have been
checking if $HOME is writable, and if it is assuming that $HOME/.cache
must be writable as well.

This is broken in environments where $HOME is owned by users and
$HOME/.cache is owned by admin. To fix this we check $HOME/.cache for
write-ability instead.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>