### PR TITLE
soc: mec1501: fix build failure

### DIFF
--- a/soc/arm/microchip_mec/mec1501/power.c
+++ b/soc/arm/microchip_mec/mec1501/power.c
@@ -76,7 +76,6 @@ static void z_power_soc_deep_sleep(void)
 
 }
 
-#endif
 
 /*
  * Light Sleep
@@ -97,6 +96,7 @@ static void z_power_soc_sleep(void)
 	__NOP();
 	__NOP();
 }
+#endif
 
 /*
  * Called from _sys_suspend(s32_t ticks) in subsys/power.c


### PR DESCRIPTION
When CONFIG_SYS_POWER_DEEP_SLEEP_STATES is not set, we have an unused
function that causes a build failure.
Enclose that function in the #ifdef.