### PR TITLE
net: ppp: Reset flags is_ipv6cp_up and is_ipcp_up in down functions

### DIFF
--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -404,6 +404,7 @@ static void ipcp_down(struct ppp_fsm *fsm)
 	}
 
 	ctx->is_network_up = false;
+	ctx->is_ipcp_up = false;
 
 	ppp_network_down(ctx, PPP_IP);
 }

--- a/subsys/net/l2/ppp/ipv6cp.c
+++ b/subsys/net/l2/ppp/ipv6cp.c
@@ -483,6 +483,7 @@ static void ipv6cp_down(struct ppp_fsm *fsm)
 	}
 
 	ctx->is_network_up = false;
+	ctx->is_ipv6cp_up = false;
 
 	ppp_network_down(ctx, PPP_IPV6);
 


### PR DESCRIPTION
Without this fix is it not possible to terminate pppd and restart
pppd afterwards without restarting the firmware, too.
