### PR TITLE
Bluetooth: Mesh: fix next_period computation

### DIFF
--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -105,7 +105,7 @@ static s32_t next_period(struct bt_mesh_model *mod)
 
 	BT_DBG("Publishing took %ums", elapsed);
 
-	if (elapsed > period) {
+	if (elapsed >= period) {
 		BT_WARN("Publication sending took longer than the period");
 		/* Return smallest positive number since 0 means disabled */
 		return K_MSEC(1);


### PR DESCRIPTION
If the duration to publish is roughly the same as the period, we might
end up with elapsed == period, which returns 0 and cancel the periodic
publication. Instead 1 should be returned, just like when the elapsed
time is greater than the period.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>