### PR TITLE
i2c_ll_stm32: Add timeout to I2C read/write functions

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -289,27 +289,28 @@ static void i2c_stm32_irq_config_func_##name(struct device *dev)	\
 
 #endif /* CONFIG_I2C_STM32_INTERRUPT */
 
-#define STM32_I2C_INIT(name)						\
-STM32_I2C_IRQ_HANDLER_DECL(name);					\
-									\
-static const struct i2c_stm32_config i2c_stm32_cfg_##name = {		\
-	.i2c = (I2C_TypeDef *)DT_REG_ADDR(DT_NODELABEL(name)),		\
-	.pclken = {							\
-		.enr = DT_CLOCKS_CELL(DT_NODELABEL(name), bits),	\
-		.bus = DT_CLOCKS_CELL(DT_NODELABEL(name), bus),		\
-	},								\
-	STM32_I2C_IRQ_HANDLER_FUNCTION(name)				\
-	.bitrate = DT_PROP(DT_NODELABEL(name), clock_frequency),	\
-};									\
-									\
-static struct i2c_stm32_data i2c_stm32_dev_data_##name;			\
-									\
-DEVICE_AND_API_INIT(i2c_stm32_##name, DT_LABEL(DT_NODELABEL(name)),	\
-		    &i2c_stm32_init, &i2c_stm32_dev_data_##name,	\
-		    &i2c_stm32_cfg_##name,				\
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
-		    &api_funcs);					\
-									\
+#define STM32_I2C_INIT(name)						  \
+STM32_I2C_IRQ_HANDLER_DECL(name);					  \
+									  \
+static const struct i2c_stm32_config i2c_stm32_cfg_##name = {		  \
+	.i2c = (I2C_TypeDef *)DT_REG_ADDR(DT_NODELABEL(name)),		  \
+	.pclken = {							  \
+		.enr = DT_CLOCKS_CELL(DT_NODELABEL(name), bits),	  \
+		.bus = DT_CLOCKS_CELL(DT_NODELABEL(name), bus),		  \
+	},								  \
+	STM32_I2C_IRQ_HANDLER_FUNCTION(name)				  \
+	.bitrate = DT_PROP(DT_NODELABEL(name), clock_frequency),	  \
+	.timeout = DT_PROP_OR(DT_NODELABEL(name), timeout_ms, UINT32_MAX) \
+	};								  \
+									  \
+static struct i2c_stm32_data i2c_stm32_dev_data_##name;			  \
+									  \
+DEVICE_AND_API_INIT(i2c_stm32_##name, DT_LABEL(DT_NODELABEL(name)),	  \
+		    &i2c_stm32_init, &i2c_stm32_dev_data_##name,	  \
+		    &i2c_stm32_cfg_##name,				  \
+		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	  \
+		    &api_funcs);					  \
+									  \
 STM32_I2C_IRQ_HANDLER(name)
 
 /* I2C instances declaration */

--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -9,8 +9,6 @@
 #ifndef ZEPHYR_DRIVERS_I2C_I2C_LL_STM32_H_
 #define ZEPHYR_DRIVERS_I2C_I2C_LL_STM32_H_
 
-#define STM32_I2C_TIMEOUT_USEC  1000
-
 typedef void (*irq_config_func_t)(struct device *port);
 
 struct i2c_stm32_config {
@@ -20,6 +18,7 @@ struct i2c_stm32_config {
 	struct stm32_pclken pclken;
 	I2C_TypeDef *i2c;
 	uint32_t bitrate;
+	uint32_t timeout;
 };
 
 struct i2c_stm32_data {

--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -9,6 +9,8 @@
 #ifndef ZEPHYR_DRIVERS_I2C_I2C_LL_STM32_H_
 #define ZEPHYR_DRIVERS_I2C_I2C_LL_STM32_H_
 
+#define STM32_I2C_TIMEOUT_USEC  1000
+
 typedef void (*irq_config_func_t)(struct device *port);
 
 struct i2c_stm32_config {

--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -23,9 +23,6 @@ LOG_MODULE_REGISTER(i2c_ll_stm32_v1);
 
 #include "i2c-priv.h"
 
-#define STM32_I2C_TRANSFER_TIMEOUT_MSEC  500
-
-#define STM32_I2C_TIMEOUT_USEC  1000
 #define I2C_REQUEST_WRITE       0x00
 #define I2C_REQUEST_READ        0x01
 #define HEADER                  0xF0

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -399,8 +399,7 @@ int stm32_i2c_msg_write(struct device *dev, struct i2c_msg *msg,
 	stm32_i2c_enable_transfer_interrupts(dev);
 	LL_I2C_EnableIT_TX(i2c);
 
-	err = k_sem_take(&data->device_sync_sem,
-			 K_MSEC(STM32_I2C_TIMEOUT_USEC / 1000));
+	err = k_sem_take(&data->device_sync_sem, K_USEC(cfg->timeout));
 	if (err < 0) {
 		if (LL_I2C_IsEnabledReloadMode(i2c)) {
 			LL_I2C_DisableReloadMode(i2c);
@@ -457,8 +456,7 @@ int stm32_i2c_msg_read(struct device *dev, struct i2c_msg *msg,
 	stm32_i2c_enable_transfer_interrupts(dev);
 	LL_I2C_EnableIT_RX(i2c);
 
-	err = k_sem_take(&data->device_sync_sem,
-			 K_MSEC(STM32_I2C_TIMEOUT_USEC / 1000));
+	err = k_sem_take(&data->device_sync_sem, K_USEC(cfg->timeout));
 	if (err < 0) {
 		if (LL_I2C_IsEnabledReloadMode(i2c)) {
 			LL_I2C_DisableReloadMode(i2c);

--- a/dts/bindings/i2c/st,stm32-i2c-v1.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v1.yaml
@@ -13,3 +13,8 @@ properties:
 
     interrupts:
       required: true
+
+    timeout-us:
+      type: int
+      required: false
+      description: Transaction timeout in microseconds

--- a/dts/bindings/i2c/st,stm32-i2c-v2.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v2.yaml
@@ -13,3 +13,8 @@ properties:
 
     interrupts:
       required: true
+
+    timeout-us:
+      type: int
+      required: false
+      description: Transaction timeout in microseconds


### PR DESCRIPTION
Add timeout to I2C read/write functions in interrupt
mode.

Get timeout value from DT.

i2c_ll_stm32_v2: Add transaction timeout to polling 
mode.

Fixes #21293

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>