### PR TITLE
Bluetooth: Mesh: Make model publication struct more compact

### DIFF
--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -395,13 +395,13 @@ struct bt_mesh_model_pub {
 	struct bt_mesh_model *mod;
 
 	u16_t addr;         /**< Publish Address. */
-	u16_t key;          /**< Publish AppKey Index. */
+	u16_t key:12,       /**< Publish AppKey Index. */
+	      cred:1;       /**< Friendship Credentials Flag. */
 
 	u8_t  ttl;          /**< Publish Time to Live. */
 	u8_t  retransmit;   /**< Retransmit Count & Interval Steps. */
 	u8_t  period;       /**< Publish Period. */
 	u8_t  period_div:4, /**< Divisor for the Period. */
-	      cred:1,       /**< Friendship Credentials Flag. */
 	      fast_period:1,/**< Use FastPeriodDivisor */
 	      count:3;      /**< Retransmissions left. */
 


### PR DESCRIPTION
commit 42d330406e2c5a9440e introduced the FastPeriodDivisor value to
to the model publication struct. Based on the way it was grouped it
seems the intention was to fit it within the same octet as other bit
fields, but it actually makes the octet overflow by one bit. This ends
up creating another u8_t variable which in turn adds 24 bits of
padding after it.

To keep the size of the struct as compact as possible, group the flag
together with the key index, since that only requires 12 bits. Some
care is needed here, since the mesh stack does have special internal
key index values that require more than 12 bits such as BT_MESH_KEY_UNUSED
and BT_MESH_KEY_DEV. In this case restricting ourselves to 12 bits is
fine since the value in the model publication struct follows 1:1 the
value received in the Config Model Publication Set message, and there
the parameter is defined to be exactly 12 bits.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>