### PR TITLE
[TOPIC-GPIO] drivers: sensor: Convert fxos8700 to new gpio api

### DIFF
--- a/boards/arm/bbc_microbit/bbc_microbit.dts
+++ b/boards/arm/bbc_microbit/bbc_microbit.dts
@@ -67,8 +67,8 @@
 		compatible = "nxp,fxos8700","nxp,mma8653fc";
 		reg = <0x1d>;
 		label = "MMA8653FC";
-		int1-gpios = <&gpio0 28 0>;
-		int2-gpios = <&gpio0 27 0>;
+		int1-gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
+		int2-gpios = <&gpio0 27 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/boards/arm/frdm_k22f/frdm_k22f.dts
+++ b/boards/arm/frdm_k22f/frdm_k22f.dts
@@ -116,8 +116,8 @@
 		compatible = "nxp,fxos8700";
 		reg = <0x1d>;
 		label = "FXOS8700";
-		int1-gpios = <&gpiod 0 0>;
-		int2-gpios = <&gpiod 1 0>;
+		int1-gpios = <&gpiod 0 GPIO_ACTIVE_LOW>;
+		int2-gpios = <&gpiod 1 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -133,8 +133,8 @@ arduino_i2c: &i2c0 {
 		compatible = "nxp,fxos8700";
 		reg = <0x1d>;
 		label = "FXOS8700";
-		int1-gpios = <&gpioc 6 0>;
-		int2-gpios = <&gpioc 13 0>;
+		int1-gpios = <&gpioc 6 GPIO_ACTIVE_LOW>;
+		int2-gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/boards/arm/frdm_k82f/frdm_k82f.dts
+++ b/boards/arm/frdm_k82f/frdm_k82f.dts
@@ -116,7 +116,7 @@
 		compatible = "nxp,fxos8700";
 		reg = <0x1c>;
 		label = "FXOS8700";
-		int1-gpios = <&gpioc 13 0>;
+		int1-gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/boards/arm/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.dts
@@ -75,8 +75,8 @@
 		compatible = "nxp,fxos8700","nxp,mma8451q";
 		reg = <0x1d>;
 		label = "MMA8451Q";
-		int1-gpios = <&gpioa 14 0>;
-		int2-gpios = <&gpioa 15 0>;
+		int1-gpios = <&gpioa 14 GPIO_ACTIVE_LOW>;
+		int2-gpios = <&gpioa 15 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -74,7 +74,7 @@
 		compatible = "nxp,fxos8700";
 		reg = <0x1f>;
 		label = "FXOS8700";
-		int1-gpios = <&gpioc 1 0>;
+		int1-gpios = <&gpioc 1 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -112,8 +112,8 @@
 		compatible = "nxp,fxos8700";
 		reg = <0x1e>;
 		label = "FXOS8700";
-		int1-gpios = <&gpioc 1 0>;
-		int2-gpios = <&gpiod 13 0>;
+		int1-gpios = <&gpioc 1 GPIO_ACTIVE_LOW>;
+		int2-gpios = <&gpiod 13 GPIO_ACTIVE_LOW>;
 	};
 
 	fxas21002@20 {

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -98,8 +98,8 @@ arduino_serial: &uart3 {};
 		 * Note that if you populate them, they conflict with LCD and
 		 * Ethernet interrupt gpios.
 		 */
-		int1-gpios = <&gpio1 10 0>;
-		int2-gpios = <&gpio1 11 0>;
+		int1-gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		int2-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/boards/arm/reel_board/dts/reel_board.dtsi
+++ b/boards/arm/reel_board/dts/reel_board.dtsi
@@ -113,8 +113,8 @@ arduino_i2c: &i2c0 {
 		compatible = "nxp,fxos8700","nxp,mma8652fc";
 		reg = <0x1d>;
 		label = "MMA8652FC";
-		int1-gpios = <&gpio0 24 0>;
-		int2-gpios = <&gpio0 25 0>;
+		int1-gpios = <&gpio0 24 GPIO_ACTIVE_LOW>;
+		int2-gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
 	};
 
 	ti_hdc@43 {

--- a/boards/arm/twr_ke18f/twr_ke18f.dts
+++ b/boards/arm/twr_ke18f/twr_ke18f.dts
@@ -173,7 +173,7 @@
 		compatible = "nxp,fxos8700";
 		reg = <0x1d>;
 		label = "FXOS8700";
-		reset-gpios = <&gpioc 15 0>;
+		reset-gpios = <&gpioc 15 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/boards/arm/twr_kv58f220m/twr_kv58f220m.dts
+++ b/boards/arm/twr_kv58f220m/twr_kv58f220m.dts
@@ -113,8 +113,8 @@
 		compatible = "nxp,fxos8700";
 		reg = <0x1c>;
 		label = "FXOS8700";
-		int1-gpios = <&gpioc 18 0>;
-		int2-gpios = <&gpioc 19 0>;
+		int1-gpios = <&gpioc 18 GPIO_ACTIVE_LOW>;
+		int2-gpios = <&gpioc 19 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/boards/arm/warp7_m4/warp7_m4.dts
+++ b/boards/arm/warp7_m4/warp7_m4.dts
@@ -60,7 +60,7 @@
 		compatible = "nxp,fxos8700";
 		reg = <0x1e>;
 		label = "FXOS8700";
-		int1-gpios = <&gpio7 0 0>;
+		int1-gpios = <&gpio7 0 GPIO_ACTIVE_LOW>;
 	};
 
 	fxas21002@20 {

--- a/boards/riscv/rv32m1_vega/rv32m1_vega.dtsi
+++ b/boards/riscv/rv32m1_vega/rv32m1_vega.dtsi
@@ -103,9 +103,9 @@ arduino_i2c: &i2c0 {
 		compatible = "nxp,fxos8700";
 		reg = <0x1e>;
 		label = "FXOS8700";
-		reset-gpios = <&gpioe 27 0>;
-		int1-gpios = <&gpioe 1 0>;
-		int2-gpios = <&gpioe 22 0>;
+		reset-gpios = <&gpioe 27 GPIO_ACTIVE_HIGH>;
+		int1-gpios = <&gpioe 1 GPIO_ACTIVE_LOW>;
+		int2-gpios = <&gpioe 22 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/drivers/sensor/fxos8700/fxos8700.c
+++ b/drivers/sensor/fxos8700/fxos8700.c
@@ -390,14 +390,16 @@ static int fxos8700_init(struct device *dev)
 			return -EINVAL;
 		}
 
-		gpio_pin_configure(rst, config->reset_pin, GPIO_DIR_OUT);
-		gpio_pin_write(rst, config->reset_pin, 1);
+		gpio_pin_configure(rst, config->reset_pin,
+				   GPIO_OUTPUT_INACTIVE | config->reset_flags);
+
+		gpio_pin_set(rst, config->reset_pin, 1);
 		/* The datasheet does not mention how long to pulse
 		 * the RST pin high in order to reset. Stay on the
 		 * safe side and pulse for 1 millisecond.
 		 */
 		k_busy_wait(USEC_PER_MSEC);
-		gpio_pin_write(rst, config->reset_pin, 0);
+		gpio_pin_set(rst, config->reset_pin, 0);
 	} else {
 		/* Software reset the sensor. Upon issuing a software
 		 * reset command over the I2C interface, the sensor
@@ -524,9 +526,11 @@ static const struct fxos8700_config fxos8700_config = {
 #ifdef DT_INST_0_NXP_FXOS8700_RESET_GPIOS_CONTROLLER
 	.reset_name = DT_INST_0_NXP_FXOS8700_RESET_GPIOS_CONTROLLER,
 	.reset_pin = DT_INST_0_NXP_FXOS8700_RESET_GPIOS_PIN,
+	.reset_flags = DT_INST_0_NXP_FXOS8700_RESET_GPIOS_FLAGS,
 #else
 	.reset_name = NULL,
 	.reset_pin = 0,
+	.reset_flags = 0,
 #endif
 #ifdef CONFIG_FXOS8700_MODE_ACCEL
 	.mode = FXOS8700_MODE_ACCEL,
@@ -564,9 +568,11 @@ static const struct fxos8700_config fxos8700_config = {
 #ifdef CONFIG_FXOS8700_DRDY_INT1
 	.gpio_name = DT_INST_0_NXP_FXOS8700_INT1_GPIOS_CONTROLLER,
 	.gpio_pin = DT_INST_0_NXP_FXOS8700_INT1_GPIOS_PIN,
+	.gpio_flags = DT_INST_0_NXP_FXOS8700_INT1_GPIOS_FLAGS,
 #else
 	.gpio_name = DT_INST_0_NXP_FXOS8700_INT2_GPIOS_CONTROLLER,
 	.gpio_pin = DT_INST_0_NXP_FXOS8700_INT2_GPIOS_PIN,
+	.gpio_flags = DT_INST_0_NXP_FXOS8700_INT2_GPIOS_FLAGS,
 #endif
 #endif
 #ifdef CONFIG_FXOS8700_PULSE

--- a/drivers/sensor/fxos8700/fxos8700.h
+++ b/drivers/sensor/fxos8700/fxos8700.h
@@ -124,10 +124,12 @@ struct fxos8700_config {
 #ifdef CONFIG_FXOS8700_TRIGGER
 	char *gpio_name;
 	u8_t gpio_pin;
+	gpio_devicetree_flags_t gpio_flags;
 #endif
 	u8_t i2c_address;
 	char *reset_name;
 	u8_t reset_pin;
+	gpio_devicetree_flags_t reset_flags;
 	enum fxos8700_mode mode;
 	enum fxos8700_power_mode power_mode;
 	enum fxos8700_range range;

--- a/drivers/sensor/fxos8700/fxos8700_trigger.c
+++ b/drivers/sensor/fxos8700/fxos8700_trigger.c
@@ -21,7 +21,8 @@ static void fxos8700_gpio_callback(struct device *dev,
 		return;
 	}
 
-	gpio_pin_disable_callback(dev, data->gpio_pin);
+	gpio_pin_interrupt_configure(data->gpio, data->gpio_pin,
+				     GPIO_INT_DISABLE);
 
 #if defined(CONFIG_FXOS8700_TRIGGER_OWN_THREAD)
 	k_sem_give(&data->trig_sem);
@@ -147,7 +148,8 @@ static void fxos8700_handle_int(void *arg)
 	}
 #endif
 
-	gpio_pin_enable_callback(data->gpio, config->gpio_pin);
+	gpio_pin_interrupt_configure(data->gpio, config->gpio_pin,
+				     GPIO_INT_EDGE_TO_ACTIVE);
 }
 
 #ifdef CONFIG_FXOS8700_TRIGGER_OWN_THREAD
@@ -387,15 +389,15 @@ int fxos8700_trigger_init(struct device *dev)
 	data->gpio_pin = config->gpio_pin;
 
 	gpio_pin_configure(data->gpio, config->gpio_pin,
-			   GPIO_DIR_IN | GPIO_INT | GPIO_INT_EDGE |
-			   GPIO_INT_ACTIVE_LOW | GPIO_INT_DEBOUNCE);
+			   GPIO_INPUT | config->gpio_flags);
 
 	gpio_init_callback(&data->gpio_cb, fxos8700_gpio_callback,
 			   BIT(config->gpio_pin));
 
 	gpio_add_callback(data->gpio, &data->gpio_cb);
 
-	gpio_pin_enable_callback(data->gpio, config->gpio_pin);
+	gpio_pin_interrupt_configure(data->gpio, config->gpio_pin,
+				     GPIO_INT_EDGE_TO_ACTIVE);
 
 	return 0;
 }

--- a/dts/bindings/sensor/nxp,fxos8700.yaml
+++ b/dts/bindings/sensor/nxp,fxos8700.yaml
@@ -15,11 +15,23 @@ properties:
     reset-gpios:
       type: phandle-array
       required: false
+      description: RST pin
+        This pin defaults to active high when consumed by the sensor.
+        The property value should ensure the flags properly describe
+        the signal that is presented to the driver.
 
     int1-gpios:
       type: phandle-array
       required: false
+      description: INT1 pin
+        This pin defaults to active low when produced by the sensor.
+        The property value should ensure the flags properly describe
+        the signal that is presented to the driver.
 
     int2-gpios:
       type: phandle-array
       required: false
+      description: INT2 pin
+        This pin defaults to active low when produced by the sensor.
+        The property value should ensure the flags properly describe
+        the signal that is presented to the driver.


### PR DESCRIPTION
Converts the fxos8700 sensor driver to the new gpio api. Updates device
trees for all boards with this sensor to active low gpio interrupts by
default (one less i2c transaction than active high), but the driver now
supports active high gpio interrupts if needed.

Tested on frdm_k64f and rv32m1_vega_ri5cy boards. The latter verifies
that the reset output works correctly.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>