### PR TITLE
dts: gen_defines.py: Generate unquoted versions of string props

### DIFF
--- a/dts/binding-template.yaml
+++ b/dts/binding-template.yaml
@@ -129,6 +129,12 @@ parent-bus: <string describing bus type, e.g. "i2c">
 #
 #         ident = "foo";
 #
+#     Properties with 'type: string' generate two macros in the generated
+#     header: one with a quoted value, and one with an unquoted value where all
+#     non-alphanumeric characters are replaced with underscores. The identifier
+#     for the unquoted version has an *_UNQUOTED suffix. It can be useful for
+#     token pasting and the like.
+#
 #   - 'type: string-array' if for properties that are assigned zero or more
 #     strings, like
 #

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -221,6 +221,7 @@ def write_props(node):
             out_dev(node, ident, 1 if prop.val else 0)
         elif prop.type == "string":
             out_dev_s(node, ident, prop.val)
+            out_dev(node, ident + "_UNQUOTED", to_ident(prop.val))
         elif prop.type == "int":
             out_dev(node, ident, prop.val)
         elif prop.type == "array":


### PR DESCRIPTION
For each `type: string` property, generate an additional `*_UNQUOTED`
macro that with an unquoted value. This can be useful with token pasting
and the like.

Motivated by https://github.com/zephyrproject-rtos/zephyr/issues/21273,
where there's this:

    variant:
        type: string
        required: true
        enum:
            - "epd1p54"
            - "epd1p54b"
            - "epd1p54c"
            - "epd4p2"
            # ...

Depending on the selection, an identifier like `epd1p56b_init` should be
generated.

The macros below now get generated, where the `*_UNQUOTED` version could
be token-pasted to generate `epd1p56b_init`.

    #define DT_..._VARIANT "epd1p54b"
    #define DT_..._VARIANT_UNQUOTED epd1p54b

Something like `*_ID` could've been used instead of `*_UNQUOTED` too, but
`*_UNQUOTED` is nice in that it's greppable and makes the magic stick out
more.

Supporting commit:

```
Rename str2ident() to to_upper_ident() and add a new to_ident() function
that just replaces non-alphanumeric characters with underscores, without
uppercasing the string.

to_ident() will be used in the next commit.

Also simplify the underscore replacement a bit with a regex, and explain
why '+' is replaced with 'PLUS'.
```