### PR TITLE
dts: gen_defines.py: Allow compile-time 'type: string' 'enum:' testing

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -236,9 +236,21 @@ def write_props(node):
         elif prop.type == "phandle-array":
             write_phandle_val_list(prop)
 
-        # Generate DT_..._ENUM if there's an 'enum:' key in the binding
         if prop.enum_index is not None:
+            # Generate
+            #
+            #   #define DT_..._ENUM <index in enum list, starting from 0>
+            #
+            # if the property has an 'enum:' key
             out_dev(node, ident + "_ENUM", prop.enum_index)
+            if prop.type == "string":
+                # For 'type: string' properties with an 'enum:' key, also
+                # generate
+                #
+                #   #define DT_..._ENUM_<str2ident(prop.val)> 1
+                #
+                # This allows the selection to be tested at compile time.
+                out_dev(node, ident + "_ENUM_" + str2ident(prop.val), 1)
 
 
 def write_bus(node):


### PR DESCRIPTION
For `type: string` properties, generate an additional macro

    #define DT_..._ENUM_<value> 1

This allows the value to be tested in the preprocessor.

For example, `maximum-speed = "high-speed"` will generate

    #define DT_...MAXIMUM_SPEED_ENUM_HIGH_SPEED 1