### PR TITLE
modules: support tests/samples/boards in modules

### DIFF
--- a/doc/guides/modules.rst
+++ b/doc/guides/modules.rst
@@ -82,6 +82,26 @@ Each project in the ``west list`` output is tested like this:
        cmake: .
        kconfig: Kconfig
 
+- To execute both tests and samples available in modules, the Zephyr test runner
+  (sanitycheck) should be pointed to the directories containing those samples and
+  tests. This can be done by specifying the path to both samples and tests in the
+  :file:`zephyr/module.yml` file.  Additionally, if a module defines out of tree
+  boards, the module file can point sanitycheck to the path where those files
+  are maintained in the module. For example:
+
+
+  .. code-block:: yaml
+
+      build:
+        cmake: .
+      samples:
+        - samples
+      tests:
+        - tests
+      boards:
+        - boards
+
+
 - Otherwise (i.e. if the project has no :file:`zephyr/module.yml`), the
   build system looks for :file:`zephyr/CMakeLists.txt` and
   :file:`zephyr/Kconfig` files in the project. If both are present, the project

--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -97,6 +97,12 @@ function on_complete() {
 		cp ./sanity-out/sanitycheck.xml shippable/testresults/
 	fi
 
+	if [ -e ./module_tests/sanitycheck.xml ]; then
+		echo "Copy ./module_tests/sanitycheck.xml"
+		cp ./module_tests/sanitycheck.xml \
+			shippable/testresults/module_tests.xml
+	fi
+
 	if [ -e ${bsim_bt_test_results_file} ]; then
 		echo "Copy ${bsim_bt_test_results_file}"
 		cp ${bsim_bt_test_results_file} shippable/testresults/
@@ -123,6 +129,7 @@ function run_bsim_bt_tests() {
 }
 
 function get_tests_to_run() {
+	./scripts/zephyr_module.py --sanitycheck-out module_tests.args
 	./scripts/ci/get_modified_tests.py --commits ${commit_range} > modified_tests.args
 	./scripts/ci/get_modified_boards.py --commits ${commit_range} > modified_boards.args
 
@@ -266,6 +273,14 @@ if [ -n "$main_ci" ]; then
 	# Run a subset of tests based on matrix size
 	${sanitycheck} ${sanitycheck_options} --load-tests test_file.txt \
 		--subset ${matrix}/${matrix_builds} --retry-failed 3
+
+	# Run module tests on matrix #1
+	if [ "$matrix" = "1" ]; then
+		if [ -s module_tests.args ]; then
+			${sanitycheck} ${sanitycheck_options} \
+				+module_tests.args --outdir module_tests
+		fi
+	fi
 
 	# cleanup
 	rm -f test_file*

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -10,6 +10,11 @@ used as project list.
 
 Include file is generated for Kconfig using --kconfig-out.
 A <name>:<path> text file is generated for use with CMake using --cmake-out.
+
+Using --sanitycheck-out <filename> an argument file for sanitycheck script will
+be generated which would point to test and sample roots available in modules
+that can be included during a sanitycheck run. This allows testing code
+maintained in modules in addition to what is available in the main Zephyr tree.
 '''
 
 import argparse
@@ -30,7 +35,7 @@ METADATA_SCHEMA = '''
 type: map
 mapping:
   build:
-    required: true
+    required: false
     type: map
     mapping:
       cmake:
@@ -39,6 +44,21 @@ mapping:
       kconfig:
         required: false
         type: str
+  tests:
+    required: false
+    type: seq
+    sequence:
+      - type: str
+  samples:
+    required: false
+    type: seq
+    sequence:
+      - type: str
+  boards:
+    required: false
+    type: seq
+    sequence:
+      - type: str
 '''
 
 schema = yaml.safe_load(METADATA_SCHEMA)
@@ -55,12 +75,10 @@ def validate_setting(setting, module_path, filename=None):
     return True
 
 
-def process_module(module, cmake_out=None, kconfig_out=None):
-    cmake_setting = None
-    kconfig_setting = None
-
+def process_module(module):
     module_path = PurePath(module)
     module_yml = module_path.joinpath('zephyr/module.yml')
+
     if Path(module_yml).is_file():
         with Path(module_yml).open('r') as f:
             meta = yaml.safe_load(f.read())
@@ -72,49 +90,83 @@ def process_module(module, cmake_out=None, kconfig_out=None):
             sys.exit('ERROR: Malformed "build" section in file: {}\n{}'
                      .format(module_yml.as_posix(), e))
 
-        section = meta.get('build', dict())
-        cmake_setting = section.get('cmake', None)
-        if not validate_setting(cmake_setting, module, 'CMakeLists.txt'):
-            sys.exit('ERROR: "cmake" key in {} has folder value "{}" which '
-                     'does not contain a CMakeLists.txt file.'
-                     .format(module_yml.as_posix(), cmake_setting))
+        return meta
 
-        kconfig_setting = section.get('kconfig', None)
-        if not validate_setting(kconfig_setting, module):
-            sys.exit('ERROR: "kconfig" key in {} has value "{}" which does '
-                     'not point to a valid Kconfig file.'
-                     .format(module_yml.as_posix(), kconfig_setting))
+    return None
 
-    cmake_path = module_path.joinpath(cmake_setting or 'zephyr')
-    cmake_file = cmake_path.joinpath('CMakeLists.txt')
-    if Path(cmake_file).is_file() and cmake_out is not None:
-        cmake_out.write('\"{}\":\"{}\"\n'
-                        .format(module_path.name,
-                                Path(cmake_path).resolve().as_posix()))
 
-    kconfig_file = module_path.joinpath(kconfig_setting or 'zephyr/Kconfig')
-    if Path(kconfig_file).is_file() and kconfig_out is not None:
-        kconfig_out.write('osource "{}"\n\n'
-                          .format(Path(kconfig_file).resolve().as_posix()))
+def process_cmake(module, meta):
+    section = meta.get('build', dict())
+    module_path = PurePath(module)
+    module_yml = module_path.joinpath('zephyr/module.yml')
+    cmake_setting = section.get('cmake', None)
+    if not validate_setting(cmake_setting, module, 'CMakeLists.txt'):
+        sys.exit('ERROR: "cmake" key in {} has folder value "{}" which '
+                    'does not contain a CMakeLists.txt file.'
+                    .format(module_yml.as_posix(), cmake_setting))
+
+    cmake_path = os.path.join(module, cmake_setting or 'zephyr')
+    cmake_file = os.path.join(cmake_path, 'CMakeLists.txt')
+    if os.path.isfile(cmake_file):
+        return('\"{}\":\"{}\"\n'
+                        .format(module_path.name, Path(cmake_path).resolve().as_posix()))
+    else:
+        return ""
+
+def process_kconfig(module, meta):
+    section = meta.get('build', dict())
+    module_path = PurePath(module)
+    module_yml = module_path.joinpath('zephyr/module.yml')
+
+    kconfig_setting = section.get('kconfig', None)
+    if not validate_setting(kconfig_setting, module):
+        sys.exit('ERROR: "kconfig" key in {} has value "{}" which does '
+                    'not point to a valid Kconfig file.'
+                    .format(module_yml, kconfig_setting))
+
+
+    kconfig_file = os.path.join(module, kconfig_setting or 'zephyr/Kconfig')
+    if os.path.isfile(kconfig_file):
+        return 'osource "{}"\n\n'.format(Path(kconfig_file).resolve().as_posix())
+    else:
+        return ""
+
+def process_sanitycheck(module, meta):
+
+    out = ""
+    tests = meta.get('tests', [])
+    samples = meta.get('samples', [])
+    boards = meta.get('boards', [])
+
+    for pth in tests + samples:
+        if pth:
+            dir = os.path.join(module, pth)
+            out += '-T\n{}\n'.format(PurePath(os.path.abspath(dir)).as_posix())
+
+    for pth in boards:
+        if pth:
+            dir = os.path.join(module, pth)
+            out += '--board-root\n{}\n'.format(PurePath(os.path.abspath(dir)).as_posix())
+
+    return out
 
 
 def main():
-    kconfig_out_file = None
-    cmake_out_file = None
-
     parser = argparse.ArgumentParser(description='''
     Process a list of projects and create Kconfig / CMake include files for
     projects which are also a Zephyr module''')
 
     parser.add_argument('--kconfig-out',
-                        help='File to write with resulting KConfig import'
-                             'statements.')
+                        help="""File to write with resulting KConfig import
+                             statements.""")
+    parser.add_argument('--sanitycheck-out',
+                        help="""File to write with resulting sanitycheck parameters.""")
     parser.add_argument('--cmake-out',
-                        help='File to write with resulting <name>:<path>'
-                             'values to use for including in CMake')
+                        help="""File to write with resulting <name>:<path>
+                             values to use for including in CMake""")
     parser.add_argument('-m', '--modules', nargs='+',
-                        help='List of modules to parse instead of using `west'
-                             'list`')
+                        help="""List of modules to parse instead of using `west
+                             list`""")
     parser.add_argument('-x', '--extra-modules', nargs='+',
                         help='List of extra modules to parse')
     parser.add_argument('-w', '--west-path', default='west',
@@ -145,23 +197,33 @@ def main():
     if args.extra_modules is not None:
         projects += args.extra_modules
 
+
+    kconfig = ""
+    cmake = ""
+    sanitycheck = ""
+
+    for project in projects:
+        # Avoid including Zephyr base project as module.
+        if project == os.environ.get('ZEPHYR_BASE'):
+            continue
+
+        meta = process_module(project)
+        if meta:
+            kconfig += process_kconfig(project, meta)
+            cmake += process_cmake(project, meta)
+            sanitycheck += process_sanitycheck(project, meta)
+
     if args.kconfig_out:
-        kconfig_out_file = open(args.kconfig_out, 'w', encoding="utf-8")
+        with open(args.kconfig_out, 'w', encoding="utf-8") as fp:
+            fp.write(kconfig)
 
     if args.cmake_out:
-        cmake_out_file = open(args.cmake_out, 'w', encoding="utf-8")
+        with open(args.cmake_out, 'w', encoding="utf-8") as fp:
+            fp.write(cmake)
 
-    try:
-        for project in projects:
-            # Avoid including Zephyr base project as module.
-            if project != os.environ.get('ZEPHYR_BASE'):
-                process_module(project, cmake_out_file, kconfig_out_file)
-    finally:
-        if args.kconfig_out:
-            kconfig_out_file.close()
-        if args.cmake_out:
-            cmake_out_file.close()
-
+    if args.sanitycheck_out:
+        with open(args.sanitycheck_out, 'w', encoding="utf-8") as fp:
+            fp.write(sanitycheck)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Generate options for sanitycheck to run tests and samples in modules.
Use the --sanitycheck-out <file> to generate a file that can be supplied
to sanitycheck on the commandline which will add additional testroots
and boards if the module does contain out of tree boards.

the module.yaml file now accepts the following:

samples:
  path: samples
tests:
  path: tests
boards:
  path: boards


- [x] Finalize `module.yml` structure
- [x] Documentation needed
- [ ] Test/sample module needed