### PR TITLE
include: Fixes #1205, C++ usage of sensor.h

### DIFF
--- a/include/drivers/sensor.h
+++ b/include/drivers/sensor.h
@@ -345,7 +345,8 @@ static inline int z_impl_sensor_attr_set(struct device *dev,
 					enum sensor_attribute attr,
 					const struct sensor_value *val)
 {
-	const struct sensor_driver_api *api = dev->driver_api;
+	const struct sensor_driver_api *api =
+		(const struct sensor_driver_api *)dev->driver_api;
 
 	if (api->attr_set == NULL) {
 		return -ENOTSUP;
@@ -375,7 +376,8 @@ static inline int sensor_trigger_set(struct device *dev,
 				     struct sensor_trigger *trig,
 				     sensor_trigger_handler_t handler)
 {
-	const struct sensor_driver_api *api = dev->driver_api;
+	const struct sensor_driver_api *api =
+		(const struct sensor_driver_api *)dev->driver_api;
 
 	if (api->trigger_set == NULL) {
 		return -ENOTSUP;
@@ -404,7 +406,8 @@ __syscall int sensor_sample_fetch(struct device *dev);
 
 static inline int z_impl_sensor_sample_fetch(struct device *dev)
 {
-	const struct sensor_driver_api *api = dev->driver_api;
+	const struct sensor_driver_api *api =
+		(const struct sensor_driver_api *)dev->driver_api;
 
 	return api->sample_fetch(dev, SENSOR_CHAN_ALL);
 }
@@ -434,7 +437,8 @@ __syscall int sensor_sample_fetch_chan(struct device *dev,
 static inline int z_impl_sensor_sample_fetch_chan(struct device *dev,
 						 enum sensor_channel type)
 {
-	const struct sensor_driver_api *api = dev->driver_api;
+	const struct sensor_driver_api *api =
+		(const struct sensor_driver_api *)dev->driver_api;
 
 	return api->sample_fetch(dev, type);
 }
@@ -468,7 +472,8 @@ static inline int z_impl_sensor_channel_get(struct device *dev,
 					   enum sensor_channel chan,
 					   struct sensor_value *val)
 {
-	const struct sensor_driver_api *api = dev->driver_api;
+	const struct sensor_driver_api *api =
+		(const struct sensor_driver_api *)dev->driver_api;
 
 	return api->channel_get(dev, chan, val);
 }


### PR DESCRIPTION
I ran into issue #1205 earlier today and realized the fix was to simply
provide the proper casts.  The issue is that C++ is less permissive than
C here, erroring when trying to implicitly convert from `void *` to
`struct gpio_driver_api *`.  The same cast is done in
include/drivers/gpio.h, which is why I did that here as well.

This fix was validated by compiling my C++ application successfully and
also successfully running my app on my board, interacting with sensors.

Signed-off-by: Brooks Prumo <brooks@prumo.org>