### PR TITLE
settings: Fix settings runtime read callback return value

### DIFF
--- a/subsys/settings/src/settings_runtime.c
+++ b/subsys/settings/src/settings_runtime.c
@@ -20,7 +20,7 @@ static ssize_t settings_runtime_read_cb(void *cb_arg, void *data, size_t len)
 	struct read_cb_arg *arg = (struct read_cb_arg *)cb_arg;
 
 	memcpy(data, arg->data, MIN(arg->len, len));
-	return len;
+	return MIN(arg->len, len);
 }
 
 int settings_runtime_set(const char *name, void *data, size_t len)


### PR DESCRIPTION
The settings runtime read callback should return the actual length of
the data that has been read.

Signed-off-by: François Delawarde <fnde@oticon.com>