### PR TITLE
Bluetooth: controller: Fix rx buffer leak for LL Version priority event

### DIFF
--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -140,6 +140,13 @@ static void prio_recv_thread(void *p1, void *p2, void *p3)
 
 			buf = process_prio_evt(node_rx);
 			if (buf) {
+#if defined(CONFIG_BT_LL_SW_LEGACY)
+				radio_rx_fc_set(node_rx->hdr.handle, 0);
+#endif /* CONFIG_BT_LL_SW_LEGACY */
+
+				node_rx->hdr.next = NULL;
+				ll_rx_mem_release((void **)&node_rx);
+
 				BT_DBG("Priority event");
 				bt_recv_prio(buf);
 			} else {
@@ -211,11 +218,7 @@ static inline struct net_buf *encode_node(struct node_rx_pdu *node_rx,
 	}
 
 #if defined(CONFIG_BT_LL_SW_LEGACY)
-	{
-		extern u8_t radio_rx_fc_set(u16_t handle, u8_t fc);
-
-		radio_rx_fc_set(node_rx->hdr.handle, 0);
-	}
+	radio_rx_fc_set(node_rx->hdr.handle, 0);
 #endif /* CONFIG_BT_LL_SW_LEGACY */
 
 	node_rx->hdr.next = NULL;


### PR DESCRIPTION
Fix leak of the node_rx buffer when processing the LL version ind as a
priority event. This leak meant being able to establish new connections
was no longer possible, because there weren't enough events to process
the all the events during connection establishment. And instead the LL
ignored the connection request sent by the peer.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>