### PR TITLE
cmake: west: Fix ZEPHYR_EXTRA_MODULES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,6 +466,11 @@ if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)
     string(REGEX REPLACE "\"(.*)\":\".*\"" "\\1" module_name ${module})
     string(REGEX REPLACE "\".*\":\"(.*)\"" "\\1" module_path ${module})
 
+    if(NOT module_name)
+      # When the module_name is missing create it from the module_path
+      string(REGEX REPLACE "/" "__" module_name ${module_path})
+    endif()
+
     list(APPEND module_names ${module_name})
 
     string(TOUPPER ${module_name} MODULE_NAME_UPPER)


### PR DESCRIPTION
When ZEPHYR_EXTRA_MODULES is used the module_name does not exist,
there is only a module_path. This causes issues ever since a re-write
required module_name to be set.

It also causes issues when 2 extra modules are defined because we set
the binary directory based on the module name, and without a module
name we would re-use the same binary directory (which is not
supported).

This fixes these issues by infering a module name from the module path
when it is missing.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>