### PR TITLE
sanitycheck: Use logger and avoid using global options

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,5 +1,6 @@
 Pillow
 PyYAML>=5.1
+anytree
 breathe>=4.9.1
 colorama
 docutils>=0.14
@@ -19,6 +20,7 @@ sphinx>=1.7.5
 sphinx_rtd_theme
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter
+tabulate
 west>=0.6.2
 wheel>=0.30.0
 # "win32" is used for 64-bit Windows as well

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2269,6 +2269,7 @@ class TestSuite:
         self.enable_valgrind = False
         self.extra_args = []
         self.inline_logs = False
+        self.enable_sizes_report = False
 
         # Keep track of which test cases we've filtered out and why
         self.testcases = {}
@@ -2821,7 +2822,7 @@ class TestSuite:
 
         return "DONE FEEDING"
 
-    def execute(self, test_only, cmake_only, enable_size_report):
+    def execute(self):
         def calc_one_elf_size(instance):
             if instance.status not in ["failed", "skipped"]:
                 if instance.platform.type != "native":
@@ -2842,7 +2843,7 @@ class TestSuite:
 
             # start a future for a thread which sends work in through the queue
             future_to_test = {
-                    executor.submit(self.add_tasks_to_queue, test_only): 'FEEDER DONE'}
+                    executor.submit(self.add_tasks_to_queue, self.test_only): 'FEEDER DONE'}
 
             while future_to_test:
                 # check for status of the futures which are currently working
@@ -2885,7 +2886,7 @@ class TestSuite:
                     # remove the now completed future
                     del future_to_test[future]
 
-        if enable_size_report and not cmake_only:
+        if self.enable_size_report and not self.cmake_only:
             # Parallelize size calculation
             executor = concurrent.futures.ThreadPoolExecutor(self.jobs)
             futures = [executor.submit(calc_one_elf_size, instance)
@@ -3989,18 +3990,18 @@ def main():
 
     # Set testsuite options from command line.
     suite.build_only = options.build_only
+    suite.cmake_only = options.cmake_only
+    suite.test_only = options.test_only
     suite.enable_slow = options.enable_slow
     suite.device_testing = options.device_testing
     suite.fixture = options.fixture
     suite.enable_asan = options.enable_asan
     suite.enable_lsan = options.enable_lsan
     suite.enable_coverage = options.enable_coverage
-    suite.coverage_platorm = ['me']
-    suite.cmake_only = options.cmake_only
     suite.enable_valgrind = options.enable_valgrind
     suite.coverage_platform = options.coverage_platform
     suite.inline_logs = options.inline_logs
-
+    suite.enable_size_report = options.enable_size_report
 
     # Set number of jobs
     if options.jobs:
@@ -4238,7 +4239,7 @@ def main():
             suite.total_done = suite.total_tests - suite.total_failed
             suite.total_failed = 0
 
-        suite.execute(options.test_only, options.cmake_only, options.enable_size_report)
+        suite.execute()
         print("")
 
         retries = retries - 1

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -535,6 +535,13 @@ class BinaryHandler(Handler):
 
         self.terminated = False
 
+        # Tool options
+        self.valgrind = False
+        self.lsan = False
+        self.asan = False
+        self.coverage = False
+
+
     def try_kill_process_by_pid(self):
         if self.pid_fn:
             pid = int(open(self.pid_fn).read())
@@ -586,7 +593,7 @@ class BinaryHandler(Handler):
             command = [self.binary]
 
         run_valgrind = False
-        if options.enable_valgrind and shutil.which("valgrind"):
+        if self.valgrind and shutil.which("valgrind"):
             command = ["valgrind", "--error-exitcode=2",
                        "--leak-check=full",
                        "--suppressions="+ZEPHYR_BASE+"/scripts/valgrind.supp",
@@ -601,10 +608,10 @@ class BinaryHandler(Handler):
         start_time = time.time()
 
         env = os.environ.copy()
-        if options.enable_asan:
+        if self.asan:
             env["ASAN_OPTIONS"] = "log_path=stdout:" + \
                     env.get("ASAN_OPTIONS", "")
-            if not options.enable_lsan:
+            if not self.lsan:
                 env["ASAN_OPTIONS"] += "detect_leaks=0"
         with subprocess.Popen(command, stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE, cwd=self.build_dir, env=env) as proc:
@@ -620,7 +627,7 @@ class BinaryHandler(Handler):
 
         handler_time = time.time() - start_time
 
-        if options.enable_coverage:
+        if self.coverage:
             subprocess.call(["GCOV_PREFIX=" + self.build_dir,
                 "gcov", self.sourcedir, "-b", "-s", self.build_dir], shell=True)
 
@@ -2008,8 +2015,15 @@ class ProjectBuilder(FilterBuilder):
             instance.handler = BinaryHandler(instance, "unit")
             instance.handler.binary = os.path.join(instance.build_dir, "testbinary")
         elif instance.platform.type == "native":
-            instance.handler = BinaryHandler(instance, "native")
-            instance.handler.binary = os.path.join(instance.build_dir, "zephyr", "zephyr.exe")
+            handler = BinaryHandler(instance, "native")
+
+            handler.asan = options.enable_lsan
+            handler.valgrind = options.enable_valgrind
+            handler.lsan = options.enable_lsan
+            handler.coverage = options.enable_coverage
+
+            handler.binary = os.path.join(instance.build_dir, "zephyr", "zephyr.exe")
+            instance.handler = handler
         elif instance.platform.simulation == "nsim":
             if find_executable("nsimdrv"):
                 instance.handler = BinaryHandler(instance, "nsim")

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -3478,7 +3478,7 @@ class CoverageTool:
     @staticmethod
     def retrieve_gcov_data(intput_file):
         if VERBOSE:
-            print("Working on %s" %intput_file)
+            logger.debug("Working on %s" %intput_file)
         extracted_coverage_info = {}
         capture_data = False
         capture_complete = False
@@ -3512,7 +3512,7 @@ class CoverageTool:
     @staticmethod
     def create_gcda_files(extracted_coverage_info):
         if VERBOSE:
-            print("Generating gcda files")
+            logger.debug("Generating gcda files")
         for filename, hexdump_val in extracted_coverage_info.items():
             # if kobject_hash is given for coverage gcovr fails
             # hence skipping it problem only in gcovr v4.1
@@ -3748,7 +3748,7 @@ class HardwareMap:
         from serial.tools import list_ports
 
         serial_devices = list_ports.comports()
-        print("Scanning connected hardware...")
+        logger.info("Scanning connected hardware...")
         for d in serial_devices:
             if d.manufacturer in self.manufacturer:
 
@@ -3776,7 +3776,7 @@ class HardwareMap:
                 s_dev['connected'] = True
                 self.detected.append(s_dev)
             else:
-                print("- Unsupported device (%s): %s" %(d.manufacturer, d))
+                logger.warning("Unsupported device (%s): %s" %(d.manufacturer, d))
 
     def write_map(self, hwm_file):
         # use existing map
@@ -3798,7 +3798,8 @@ class HardwareMap:
                 new = list(filter(lambda n:  not n.get('match', False), self.detected))
                 hwm = hwm + new
 
-                print("\nRegistered devices:")
+                logger.info("Registered devices:")
+                print("")
                 table = []
                 header = ["Platform", "ID", "Serial device"]
                 for p in sorted(hwm, key = lambda i: i['platform']):
@@ -3862,7 +3863,7 @@ def main():
     if options.timestamps:
         formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
     else:
-        formatter = logging.Formatter('%(levelname)s - %(message)s')
+        formatter = logging.Formatter('%(levelname)-7s - %(message)s')
 
     formatter_file = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     ch.setFormatter(formatter)
@@ -3881,7 +3882,8 @@ def main():
     if not options.device_testing and options.hardware_map:
         hwm.load_hardware_map(options.hardware_map)
 
-        print("\nAvailable devices:")
+        logger.info("Available devices:")
+        print("")
         table = []
         header = ["Platform", "ID", "Serial device"]
         for p in hwm.connected_hardware:

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -209,9 +209,7 @@ if not ZEPHYR_BASE:
 
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts", "dts"))
 import edtlib
-
 import logging
-
 
 hw_map_local = threading.Lock()
 report_lock = threading.Lock()
@@ -251,6 +249,7 @@ else:
     COLOR_RED = ""
     COLOR_GREEN = ""
     COLOR_YELLOW = ""
+
 
 class CMakeCacheEntry:
     '''Represents a CMake cache entry.
@@ -407,6 +406,7 @@ class CMakeCache:
     def __iter__(self):
         return iter(self._entries.values())
 
+
 class SanityCheckException(Exception):
     pass
 
@@ -414,9 +414,11 @@ class SanityCheckException(Exception):
 class SanityRuntimeError(SanityCheckException):
     pass
 
+
 class ConfigurationError(SanityCheckException):
     def __init__(self, cfile, message):
         SanityCheckException.__init__(self, cfile + ": " + message)
+
 
 class BuildError(SanityCheckException):
     pass
@@ -427,6 +429,7 @@ class ExecutionError(SanityCheckException):
 
 
 log_file = None
+
 
 # Debug Functions
 def info(what, show_time=True):
@@ -459,6 +462,7 @@ def verbose(what):
     if VERBOSE >= 2:
         info(what)
 
+
 class HarnessImporter:
 
     def __init__(self, name):
@@ -470,6 +474,7 @@ class HarnessImporter:
             my_class = getattr(module, "Test")
 
         self.instance = my_class()
+
 
 class Handler:
     def __init__(self, instance, type_str="build"):
@@ -520,6 +525,7 @@ class Handler:
                 cw.writerow(harness.fieldnames)
                 for instance in harness.recording:
                     cw.writerow(instance)
+
 
 class BinaryHandler(Handler):
     def __init__(self, instance, type_str):
@@ -643,6 +649,7 @@ class BinaryHandler(Handler):
             self.instance.reason = "Handler timeout"
 
         self.record(harness)
+
 
 class DeviceHandler(Handler):
 
@@ -849,6 +856,7 @@ class DeviceHandler(Handler):
 
         self.record(harness)
 
+
 class QEMUHandler(Handler):
     """Spawns a thread to monitor QEMU output from pipes
 
@@ -1016,6 +1024,7 @@ class QEMUHandler(Handler):
 
     def get_fifo(self):
         return self.fifo_fn
+
 
 class SizeCalculator:
 
@@ -1258,6 +1267,7 @@ testcase_valid_keys = {"tags": {"type": "set", "required": False},
                        "harness_config": {"type": "map", "default": {}}
                        }
 
+
 class SanityConfigParser:
     """Class to read test case files with semantic checking
     """
@@ -1458,14 +1468,13 @@ class Platform:
             if not os.environ.get(env, None):
                 self.env_satisfied = False
 
-
     def __repr__(self):
         return "<%s on %s>" % (self.name, self.arch)
+
 
 class TestCase(object):
     """Class representing a test application
     """
-
 
     def __init__(self):
         """TestCase constructor.
@@ -1528,7 +1537,7 @@ class TestCase(object):
             # This is in ZEPHYR_BASE, so include path in name for uniqueness
             # FIXME: We should not depend on path of test for unique names.
             relative_tc_root = os.path.relpath(canonical_testcase_root,
-                                         start=canonical_zephyr_base)
+                                               start=canonical_zephyr_base)
         else:
             relative_tc_root = ""
 
@@ -1630,7 +1639,6 @@ class TestCase(object):
 
         if not results:
             self.cases.append(self.id)
-
 
     def __str__(self):
         return self.name
@@ -1853,11 +1861,11 @@ class CMake():
 
     def run_cmake(self, args=[]):
 
-        verbose("Running cmake on %s for %s" %(self.source_dir, self.platform.name))
+        verbose("Running cmake on %s for %s" % (self.source_dir,
+                                                self.platform.name))
+        ldflags = "-Wl,--fatal-warnings"
 
-        ldflags="-Wl,--fatal-warnings"
-
-        #fixme: add additional cflags based on options
+        # fixme: add additional cflags based on options
         cmake_args = [
                 '-B{}'.format(self.build_dir),
                 '-S{}'.format(self.source_dir),
@@ -1901,7 +1909,6 @@ class CMake():
             self.instance.status = "failed"
             self.instance.reason = "Cmake build failure"
             results = {"returncode": p.returncode}
-
 
         if out:
             with open(os.path.join(self.build_dir, self.log), "a") as log:
@@ -2042,7 +2049,6 @@ class ProjectBuilder(FilterBuilder):
                 else:
                     pipeline.put({"op": "build", "test": self.instance})
 
-
         elif op == "build":
             verbose("build test: %s" %self.instance.name)
             results = self.build()
@@ -2182,6 +2188,7 @@ class ProjectBuilder(FilterBuilder):
 
 pipeline = queue.LifoQueue()
 
+
 class BoundedExecutor(concurrent.futures.ThreadPoolExecutor):
     """BoundedExecutor behaves as a ThreadPoolExecutor which will block on
     calls to submit() once the limit given as "bound" work items are queued for
@@ -2191,14 +2198,14 @@ class BoundedExecutor(concurrent.futures.ThreadPoolExecutor):
     """
     def __init__(self, bound, max_workers, **kwargs):
         super().__init__(max_workers)
-        #self.executor = ThreadPoolExecutor(max_workers=max_workers)
+        # self.executor = ThreadPoolExecutor(max_workers=max_workers)
         self.semaphore = BoundedSemaphore(bound + max_workers)
 
     def submit(self, fn, *args, **kwargs):
         self.semaphore.acquire()
         try:
             future = super().submit(fn, *args, **kwargs)
-        except:
+        except Exception:
             self.semaphore.release()
             raise
         else:
@@ -2218,7 +2225,7 @@ class TestSuite:
 
         self.roots = testcase_roots
         if not isinstance(board_root_list, list):
-            self.board_roots= [board_root_list]
+            self.board_roots = [board_root_list]
         else:
             self.board_roots = board_root_list
 
@@ -2232,9 +2239,9 @@ class TestSuite:
         self.load_errors = 0
         self.instances = dict()
 
-        self.total_tests = 0 # number of test instances
-        self.total_cases = 0 # number of test cases
-        self.total_done = 0 # tests completed
+        self.total_tests = 0  # number of test instances
+        self.total_cases = 0  # number of test cases
+        self.total_done = 0  # tests completed
         self.total_failed = 0
         self.total_skipped = 0
 
@@ -2261,12 +2268,10 @@ class TestSuite:
         self.total_tests = len(self.instances)
         self.total_cases = len(self.testcases)
 
-
     def compare_metrics(self, filename):
         # name, datatype, lower results better
         interesting_metrics = [("ram_size", int, True),
                                ("rom_size", int, True)]
-
 
         if not os.path.exists(filename):
             info("Cannot compare metrics, %s not found" % filename)
@@ -2397,8 +2402,6 @@ class TestSuite:
         if log_file:
             log_file.close()
 
-
-
     def add_configurations(self):
 
         for board_root in self.board_roots:
@@ -2447,7 +2450,6 @@ class TestSuite:
             sys.exit(2)
 
         return toolchain
-
 
     def add_testcases(self):
         for root in self.roots:
@@ -2523,7 +2525,6 @@ class TestSuite:
 
         return True
 
-
     def get_platform(self, name):
         selected_platform = None
         for platform in self.platforms:
@@ -2580,7 +2581,6 @@ class TestSuite:
                 instance.create_overlay(platform)
                 instance_list.append(instance)
             self.add_instances(instance_list)
-
 
     def apply_filters(self):
 
@@ -2829,7 +2829,6 @@ class TestSuite:
                 instance.metrics["handler_time"] = instance.handler.duration if instance.handler else 0
                 instance.metrics["unrecognized"] = []
 
-
     def discard_report(self, filename):
 
         try:
@@ -2849,7 +2848,6 @@ class TestSuite:
                            "platform": instance.platform.name,
                            "reason": reason}
                 cw.writerow(rowdict)
-
 
     def target_report(self, outdir):
         run = "Sanitycheck"
@@ -2931,7 +2929,6 @@ class TestSuite:
             result = ET.tostring(eleTestsuites)
             with open(os.path.join(outdir, platform + ".xml"), 'wb') as f:
                 f.write(result)
-
 
     def xunit_report(self, filename):
         fails = 0
@@ -3017,7 +3014,6 @@ class TestSuite:
         result = ET.tostring(eleTestsuites)
         with open(filename, 'wb') as report:
             report.write(result)
-
 
     def csv_report(self, filename):
         with open(filename, "wt") as csvfile:
@@ -3791,7 +3787,7 @@ class HardwareMap:
                 s_dev['serial'] = d.device
                 s_dev['product'] = d.product
                 s_dev['runner'] = 'unknown'
-                for runner in self.runner_mapping.keys():
+                for runner,_ in self.runner_mapping.items():
                     products = self.runner_mapping.get(runner)
                     if d.product in products:
                         s_dev['runner'] = runner
@@ -3843,9 +3839,6 @@ class HardwareMap:
             # create new file
             with open(hwm_file, 'w') as yaml_file:
                 yaml.dump(self.detected, yaml_file, default_flow_style=False)
-
-        return
-
 
 
 run_individual_tests = None

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -594,7 +594,7 @@ class BinaryHandler(Handler):
             # When a process is killed, the default handler returns 128 + SIGTERM
             # so in that case the return code itself is not meaningful
             self.set_state("failed", handler_time)
-            self.instance.reason = "Handler Error"
+            self.instance.reason = "Failed"
         elif run_valgrind and self.returncode == 2:
             self.set_state("failed", handler_time)
             self.instance.reason = "Valgrind error"
@@ -602,7 +602,7 @@ class BinaryHandler(Handler):
             self.set_state(harness.state, handler_time)
         else:
             self.set_state("timeout", handler_time)
-            self.instance.reason = "Handler timeout"
+            self.instance.reason = "Timeout"
 
         self.record(harness)
 
@@ -745,6 +745,7 @@ class DeviceHandler(Handler):
             )
         except serial.SerialException as e:
             self.set_state("failed", 0)
+            self.instance.reason = "Failed"
             logger.error("Serial device error: %s" % (str(e)))
             self.make_device_available(serial_device)
             return
@@ -793,16 +794,21 @@ class DeviceHandler(Handler):
         if ser.isOpen():
             ser.close()
 
+        handler_time = time.time() - start_time
+
         if out_state == "timeout":
             for c in self.instance.testcase.cases:
                 if c not in harness.tests:
                     harness.tests[c] = "BLOCK"
 
-        handler_time = time.time() - start_time
+            self.instance.reason = "Timeout"
 
         self.instance.results = harness.tests
+
         if harness.state:
             self.set_state(harness.state, handler_time)
+            if  harness.state == "failed":
+                self.instance.reason = "Failed"
         else:
             self.set_state(out_state, handler_time)
 
@@ -915,6 +921,10 @@ class QEMUHandler(Handler):
         logger.debug("QEMU complete (%s) after %f seconds" %
                      (out_state, handler_time))
         handler.set_state(out_state, handler_time)
+        if out_state == "timeout":
+            handler.instance.reason = "Timeout"
+        elif out_state == "failed":
+            handler.instance.reason = "Failed"
 
         log_out_fp.close()
         out_fp.close()
@@ -1985,9 +1995,9 @@ class ProjectBuilder(FilterBuilder):
 
         if os.path.exists(v_log) and "Valgrind" in self.instance.reason:
             self.log_info("{}".format(v_log), inline_logs)
-        elif os.path.exists(d_log):
+        elif os.path.exists(d_log) and os.path.getsize(d_log) > 0:
             self.log_info("{}".format(d_log), inline_logs)
-        elif os.path.exists(h_log):
+        elif os.path.exists(h_log) and os.path.getsize(h_log) > 0:
             self.log_info("{}".format(h_log), inline_logs)
         else:
             self.log_info("{}".format(b_log), inline_logs)

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -3873,14 +3873,12 @@ class HardwareMap:
             with open(hwm_file, 'w') as yaml_file:
                 yaml.dump(self.detected, yaml_file, default_flow_style=False)
 
-run_individual_tests = None
 options = None
 
 def main():
     start_time = time.time()
     global VERBOSE
     global options
-    global run_individual_tests
 
     options = parse_arguments()
 

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2557,7 +2557,7 @@ class TestSuite:
             self.add_instances(instance_list)
 
         tests_to_run = len(self.instances)
-        info("%d tests passed already, retyring %d tests" %(total_tests - tests_to_run, tests_to_run))
+        info("%d tests passed already, retrying %d tests" %(total_tests - tests_to_run, tests_to_run))
 
     def load_from_file(self, file):
         try:

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -189,6 +189,7 @@ import glob
 import serial
 import concurrent
 import xml.etree.ElementTree as ET
+import logging
 from collections import OrderedDict
 from itertools import islice
 from pathlib import Path
@@ -209,14 +210,11 @@ if not ZEPHYR_BASE:
 
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts", "dts"))
 import edtlib
-import logging
 
 hw_map_local = threading.Lock()
 report_lock = threading.Lock()
 
 
-log_format = "%(levelname)s %(name)s::%(module)s.%(funcName)s():%(lineno)d: %(message)s"
-logging.basicConfig(format=log_format, level=30)
 
 # Use this for internal comparisons; that's what canonicalization is
 # for. Don't use it when invoking other components of the build system
@@ -250,6 +248,14 @@ else:
     COLOR_GREEN = ""
     COLOR_YELLOW = ""
 
+
+logger = logging.getLogger('sanitycheck')
+#coloredlogs.install(level='INFO', logger=logger, fmt="%(levelname)s %(message)s")
+logger.setLevel(logging.DEBUG)
+
+
+#log_format = "%(levelname)s %(message)s"
+#logging.basicConfig(format=log_format, level=logging.INFO)
 
 class CMakeCacheEntry:
     '''Represents a CMake cache entry.
@@ -427,40 +433,10 @@ class BuildError(SanityCheckException):
 class ExecutionError(SanityCheckException):
     pass
 
-
-log_file = None
-
-
 # Debug Functions
-def info(what, show_time=True):
-    if options.timestamps and show_time:
-        date = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        what = "{}: {}".format(date, what)
+def info(what):
     sys.stdout.write(what + "\n")
     sys.stdout.flush()
-    if log_file:
-        log_file.write(what + "\n")
-        log_file.flush()
-
-
-def error(what):
-    if options.timestamps:
-        date = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
-        what = "{}: {}".format(date, what)
-    sys.stderr.write(COLOR_RED + what + COLOR_NORMAL + "\n")
-    if log_file:
-        log_file(what + "\n")
-        log_file.flush()
-
-
-def debug(what):
-    if VERBOSE >= 1:
-        info(what)
-
-
-def verbose(what):
-    if VERBOSE >= 2:
-        info(what)
 
 
 class HarnessImporter:
@@ -565,7 +541,7 @@ class BinaryHandler(Handler):
     def _output_reader(self, proc, harness):
         log_out_fp = open(self.log, "wt")
         for line in iter(proc.stdout.readline, b''):
-            verbose("OUTPUT: {0}".format(line.decode('utf-8').rstrip()))
+            logger.debug("OUTPUT: {0}".format(line.decode('utf-8').rstrip()))
             log_out_fp.write(line.decode('utf-8'))
             log_out_fp.flush()
             harness.handle(line.decode('utf-8').rstrip())
@@ -601,9 +577,9 @@ class BinaryHandler(Handler):
                        ] + command
             run_valgrind = True
 
-        verbose("Spawning process: " +
+        logger.debug("Spawning process: " +
                 " ".join(shlex.quote(word) for word in command) + os.linesep +
-                "Spawning process in directory: " + self.build_dir)
+                "in directory: " + self.build_dir)
 
         start_time = time.time()
 
@@ -615,7 +591,7 @@ class BinaryHandler(Handler):
                 env["ASAN_OPTIONS"] += "detect_leaks=0"
         with subprocess.Popen(command, stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE, cwd=self.build_dir, env=env) as proc:
-            verbose("Spawning BinaryHandler Thread for %s" % self.name)
+            logger.debug("Spawning BinaryHandler Thread for %s" % self.name)
             t = threading.Thread(target=self._output_reader, args=(proc, harness, ), daemon=True)
             t.start()
             t.join(self.timeout)
@@ -677,7 +653,7 @@ class DeviceHandler(Handler):
             readable, _, _ = select.select(readlist, [], [], self.timeout)
 
             if halt_fileno in readable:
-                verbose('halted')
+                logger.debug('halted')
                 ser.close()
                 break
             if ser_fileno not in readable:
@@ -696,7 +672,7 @@ class DeviceHandler(Handler):
             # is available yet.
             if serial_line:
                 sl = serial_line.decode('utf-8', 'ignore')
-                verbose("DEVICE: {0}".format(sl.rstrip()))
+                logger.debug("DEVICE: {0}".format(sl.rstrip()))
 
                 log_out_fp.write(sl)
                 log_out_fp.flush()
@@ -795,7 +771,7 @@ class DeviceHandler(Handler):
                     )
         except serial.SerialException as e:
             self.set_state("failed", 0)
-            error("Serial device err: %s" %(str(e)))
+            logger.error("Serial device err: %s" %(str(e)))
             self.make_device_available(serial_device)
             return
 
@@ -812,9 +788,8 @@ class DeviceHandler(Handler):
                             args=(ser, read_pipe, harness))
         t.start()
 
-        logging.debug('Flash command: %s', command)
-
         d_log = "{}/device.log".format(self.instance.build_dir)
+        logger.debug('Flash command: %s', command)
         try:
             stdout = stderr = None
             with subprocess.Popen(command, stderr=subprocess.PIPE, stdout=subprocess.PIPE) as proc:
@@ -939,7 +914,7 @@ class QEMUHandler(Handler):
             log_out_fp.write(line)
             log_out_fp.flush()
             line = line.strip()
-            verbose("QEMU: %s" % line)
+            logger.debug("QEMU: %s" % line)
 
             harness.handle(line)
             if harness.state:
@@ -965,7 +940,7 @@ class QEMUHandler(Handler):
         handler.record(harness)
 
         handler_time = time.time() - start_time
-        verbose("QEMU complete (%s) after %f seconds" %
+        logger.debug("QEMU complete (%s) after %f seconds" %
                 (out_state, handler_time))
         handler.set_state(out_state, handler_time)
 
@@ -1010,16 +985,16 @@ class QEMUHandler(Handler):
 
         self.instance.results = harness.tests
         self.thread.daemon = True
-        verbose("Spawning QEMUHandler Thread for %s" % self.name)
+        logger.debug("Spawning QEMUHandler Thread for %s" % self.name)
         self.thread.start()
         subprocess.call(["stty", "sane"])
 
-        verbose("Running %s (%s)" %(self.name, self.type_str))
+        logger.debug("Running %s (%s)" %(self.name, self.type_str))
         command = [get_generator()[0]]
         command += ["-C", self.build_dir, "run"]
 
         with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self.build_dir) as proc:
-            verbose("Spawning QEMUHandler Thread for %s" % self.name)
+            logger.debug("Spawning QEMUHandler Thread for %s" % self.name)
             proc.wait()
             self.returncode = proc.returncode
 
@@ -1620,20 +1595,20 @@ class TestCase(object):
             try:
                 _subcases, warnings = self.scan_file(filename)
                 if warnings:
-                    error("%s: %s" % (filename, warnings))
+                    logger.error("%s: %s" % (filename, warnings))
                 if _subcases:
                     subcases += _subcases
             except ValueError as e:
-                error("%s: can't find: %s" % (filename, e))
+                logger.error("%s: can't find: %s" % (filename, e))
         for filename in glob.glob(os.path.join(path, "*.c")):
             try:
                 _subcases, warnings = self.scan_file(filename)
                 if warnings:
-                    error("%s: %s" % (filename, warnings))
+                    logger.error("%s: %s" % (filename, warnings))
                 if _subcases:
                     subcases += _subcases
             except ValueError as e:
-                error("%s: can't find: %s" % (filename, e))
+                logger.error("%s: can't find: %s" % (filename, e))
         return subcases
 
     def parse_subcases(self, test_path):
@@ -1805,7 +1780,7 @@ class CMake():
 
     def run_build(self, args=[]):
 
-        verbose("Building %s for %s" % (self.source_dir, self.platform.name))
+        logger.debug("Building %s for %s" % (self.source_dir, self.platform.name))
 
         cmake_args = []
         cmake_args.extend(args)
@@ -1850,7 +1825,7 @@ class CMake():
 
             if log_msg:
                 if log_msg.find(overflow_flash) > 0 or log_msg.find(overflow_ram) > 0:
-                    verbose("RAM/ROM Overflow")
+                    logger.debug("RAM/ROM Overflow")
                     self.instance.status = "skipped"
                     self.instance.reason = "overflow"
                 else:
@@ -1866,9 +1841,8 @@ class CMake():
 
     def run_cmake(self, args=[]):
 
-        verbose("Running cmake on %s for %s" % (self.source_dir,
-                                                self.platform.name))
         ldflags = "-Wl,--fatal-warnings"
+        logger.debug("Running cmake on %s for %s" %(self.source_dir, self.platform.name))
 
         # fixme: add additional cflags based on options
         cmake_args = [
@@ -2054,7 +2028,7 @@ class ProjectBuilder(FilterBuilder):
                 pipeline.put({"op": "report", "test": self.instance})
             else:
                 if self.instance.name in results['filter'] and results['filter'][self.instance.name]:
-                    verbose("filtering %s" % self.instance.name)
+                    logger.debug("filtering %s" % self.instance.name)
                     self.instance.status = "skipped"
                     self.instance.reason = "filter"
                     pipeline.put({"op": "report", "test": self.instance})
@@ -2062,7 +2036,7 @@ class ProjectBuilder(FilterBuilder):
                     pipeline.put({"op": "build", "test": self.instance})
 
         elif op == "build":
-            verbose("build test: %s" %self.instance.name)
+            logger.debug("build test: %s" %self.instance.name)
             results = self.build()
 
             if results.get('returncode', 1) > 0:
@@ -2074,7 +2048,7 @@ class ProjectBuilder(FilterBuilder):
                     pipeline.put({"op": "report", "test": self.instance})
         # Run the generated binary using one of the supported handlers
         elif op == "run":
-            verbose("run test: %s" %self.instance.name)
+            logger.debug("run test: %s" %self.instance.name)
             self.run()
             self.instance.status, _ = self.instance.handler.get_state()
             pipeline.put({
@@ -2106,7 +2080,7 @@ class ProjectBuilder(FilterBuilder):
                         instance.testcase.name,
                         COLOR_RED,
                         COLOR_NORMAL,
-                        instance.reason), False)
+                        instance.reason))
             if not VERBOSE:
                 log_info_file(instance)
         elif instance.status == "skipped":
@@ -2129,7 +2103,7 @@ class ProjectBuilder(FilterBuilder):
                 else:
                     more_info = "build"
 
-            info("{:>{}}/{} {:<25} {:<50} {} ({})".format(
+            logger.info("{:>{}}/{} {:<25} {:<50} {} ({})".format(
                 self.suite.total_done, total_tests_width, self.suite.total_tests, instance.platform.name,
                 instance.testcase.name, status, more_info))
 
@@ -2276,7 +2250,7 @@ class TestSuite:
                                ("rom_size", int, True)]
 
         if not os.path.exists(filename):
-            info("Cannot compare metrics, %s not found" % filename)
+            logger.info("Cannot compare metrics, %s not found" % filename)
             return []
 
         results = []
@@ -2332,7 +2306,7 @@ class TestSuite:
                 warnings += 1
 
         if warnings:
-            info("Deltas based on metrics from last %s" %
+            logger.warning("Deltas based on metrics from last %s" %
                  ("release" if not last_metrics else "run"))
 
     def summary(self, unrecognized_sections):
@@ -2341,7 +2315,7 @@ class TestSuite:
             if instance.status == "failed":
                 failed += 1
             elif instance.metrics.get("unrecognized") and not unrecognized_sections:
-                info("%sFAILED%s: %s has unrecognized binary sections: %s" %
+                logger.error("%sFAILED%s: %s has unrecognized binary sections: %s" %
                      (COLOR_RED, COLOR_NORMAL, instance.name,
                       str(instance.metrics.get("unrecognized", []))))
                 failed += 1
@@ -2351,7 +2325,7 @@ class TestSuite:
         else:
             pass_rate = 0
 
-        info("{}{} of {}{} tests passed ({:.2%}), {}{}{} failed, {} skipped with {}{}{} warnings in {:.2f} seconds".format(
+        logger.info("{}{} of {}{} tests passed ({:.2%}), {}{}{} failed, {} skipped with {}{}{} warnings in {:.2f} seconds".format(
             COLOR_RED if failed else COLOR_GREEN,
             self.total_tests - self.total_failed - self.total_skipped,
             self.total_tests,
@@ -2368,7 +2342,7 @@ class TestSuite:
 
         self.total_platforms = len(self.platforms)
         if self.platforms:
-            info("In total {} test cases were executed on {} out of total {} platforms ({:02.2f}%)".format(
+            logger.info("In total {} test cases were executed on {} out of total {} platforms ({:02.2f}%)".format(
                 self.total_cases,
                 len(self.selected_platforms),
                 self.total_platforms,
@@ -2401,19 +2375,16 @@ class TestSuite:
         if options.release:
             self.csv_report(RELEASE_DATA)
 
-        if log_file:
-            log_file.close()
-
     def add_configurations(self):
 
         for board_root in self.board_roots:
             board_root = os.path.abspath(board_root)
 
-            debug("Reading platform configuration files under %s..." %
+            logger.debug("Reading platform configuration files under %s..." %
                 board_root)
 
             for file in glob.glob(os.path.join(board_root, "*", "*", "*.yaml")):
-                verbose("Found platform configuration " + file)
+                logger.debug("Found plaform configuration " + file)
                 try:
                     platform = Platform()
                     platform.load(file)
@@ -2423,7 +2394,7 @@ class TestSuite:
                             self.default_platforms.append(platform.name)
 
                 except RuntimeError as e:
-                    error("E: %s: can't load: %s" % (file, e))
+                    logger.error("E: %s: can't load: %s" % (file, e))
                     self.load_errors += 1
 
 
@@ -2457,10 +2428,10 @@ class TestSuite:
         for root in self.roots:
             root = os.path.abspath(root)
 
-            debug("Reading test case configuration files under %s..." %root)
+            logger.debug("Reading test case configuration files under %s..." %root)
 
             for dirpath, dirnames, filenames in os.walk(root, topdown=True):
-                verbose("scanning %s" % dirpath)
+                logger.debug("scanning %s" % dirpath)
                 if 'sample.yaml' in filenames:
                     filename = 'sample.yaml'
                 elif 'testcase.yaml' in filenames:
@@ -2468,7 +2439,7 @@ class TestSuite:
                 else:
                     continue
 
-                verbose("Found possible test case in " + dirpath)
+                logger.debug("Found possible test case in " + dirpath)
 
                 dirnames[:] = []
                 tc_path = os.path.join(dirpath, filename)
@@ -2521,7 +2492,7 @@ class TestSuite:
                     self.testcases[tc.name] = tc
 
         except Exception as e:
-            error("E: %s: can't load (skipping): %s" % (tc_data_file, e))
+            logger.error("%s: can't load (skipping): %s" % (tc_data_file, e))
             self.load_errors += 1
             return False
 
@@ -2560,7 +2531,7 @@ class TestSuite:
             self.add_instances(instance_list)
 
         tests_to_run = len(self.instances)
-        info("%d tests passed already, retrying %d tests" %(total_tests - tests_to_run, tests_to_run))
+        logger.info("%d tests passed already, retrying %d tests" %(total_tests - tests_to_run, tests_to_run))
 
     def load_from_file(self, file):
         try:
@@ -2595,10 +2566,10 @@ class TestSuite:
         tag_filter = options.tag
         exclude_tag = options.exclude_tag
 
-        verbose("platform filter: " + str(platform_filter))
-        verbose("    arch_filter: " + str(arch_filter))
-        verbose("     tag_filter: " + str(tag_filter))
-        verbose("    exclude_tag: " + str(exclude_tag))
+        logger.debug("platform filter: " + str(platform_filter))
+        logger.debug("    arch_filter: " + str(arch_filter))
+        logger.debug("     tag_filter: " + str(tag_filter))
+        logger.debug("    exclude_tag: " + str(exclude_tag))
 
         default_platforms = False
 
@@ -2608,14 +2579,14 @@ class TestSuite:
             platforms = self.platforms
 
         if options.all:
-            info("Selecting all possible platforms per test case")
+            logger.info("Selecting all possible platforms per test case")
             # When --all used, any --platform arguments ignored
             platform_filter = []
         elif not platform_filter:
-            info("Selecting default platforms per test case")
+            logger.info("Selecting default platforms per test case")
             default_platforms = True
 
-        info("Building initial testcase list...")
+        logger.info("Building initial testcase list...")
 
         for tc_name, tc in self.testcases.items():
             # list of instances per testcase, aka configurations.
@@ -2779,7 +2750,7 @@ class TestSuite:
 
                 instance.metrics["handler_time"] = instance.handler.duration if instance.handler else 0
 
-        info("Adding tasks to the queue...")
+        logger.info("Adding tasks to the queue...")
         # We can use a with statement to ensure threads are cleaned up promptly
         with BoundedExecutor(bound=self.jobs, max_workers=self.jobs) as executor:
 
@@ -2813,7 +2784,7 @@ class TestSuite:
 
                     else:
                         if data:
-                            verbose(data)
+                            logger.debug(data)
 
                     # remove the now completed future
                     del future_to_test[future]
@@ -2837,7 +2808,7 @@ class TestSuite:
             if self.discards is None:
                 raise SanityRuntimeError("apply_filters() hasn't been run!")
         except Exception as e:
-            error(str(e))
+            logger.error(str(e))
             sys.exit(2)
 
         with open(filename, "wt") as csvfile:
@@ -3196,7 +3167,7 @@ Artificially long but functional example:
 
     parser.add_argument("--timestamps",
             action="store_true",
-            help="Print all messages with time stamps")
+            help="Print all messages with time stamps (Option is deprecated)")
 
     parser.add_argument(
         "-r", "--release", action="store_true",
@@ -3440,7 +3411,7 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
 def log_info(filename):
     filename = os.path.relpath(os.path.realpath(filename))
     if options.inline_logs:
-        info("{:-^100}".format(filename))
+        logger.info("{:-^100}".format(filename))
 
         try:
             with open(filename) as fp:
@@ -3448,12 +3419,11 @@ def log_info(filename):
         except Exception as e:
             data = "Unable to read log data (%s)\n" % (str(e))
 
-        sys.stdout.write(data)
-        if log_file:
-            log_file.write(data)
-        info("{:-^100}".format(filename))
+        logger.error(data)
+
+        logger.info("{:-^100}".format(filename))
     else:
-        info("\n\tsee: " + COLOR_YELLOW + filename + COLOR_NORMAL)
+        logger.info("\n\tsee: " + COLOR_YELLOW + filename + COLOR_NORMAL)
 
 
 def log_info_file(instance):
@@ -3474,18 +3444,18 @@ def log_info_file(instance):
 
 
 def size_report(sc):
-    info(sc.filename)
-    info("SECTION NAME             VMA        LMA     SIZE  HEX SZ TYPE")
+    logger.info(sc.filename)
+    logger.info("SECTION NAME             VMA        LMA     SIZE  HEX SZ TYPE")
     for i in range(len(sc.sections)):
         v = sc.sections[i]
 
-        info("%-17s 0x%08x 0x%08x %8d 0x%05x %-7s" %
+        logger.info("%-17s 0x%08x 0x%08x %8d 0x%05x %-7s" %
              (v["name"], v["virt_addr"], v["load_addr"], v["size"], v["size"],
               v["type"]))
 
-    info("Totals: %d bytes (ROM), %d bytes (RAM)" %
+    logger.info("Totals: %d bytes (ROM), %d bytes (RAM)" %
          (sc.rom_size, sc.ram_size))
-    info("")
+    logger.info("")
 
 class CoverageTool:
     """ Base class for every supported coverage tool
@@ -3500,7 +3470,7 @@ class CoverageTool:
             return Lcov()
         if tool == 'gcovr':
             return Gcovr()
-        error("Unsupported coverage tool specified: {}".format(tool))
+        logger.error("Unsupported coverage tool specified: {}".format(tool))
 
     @staticmethod
     def retrieve_gcov_data(intput_file):
@@ -3562,14 +3532,14 @@ class CoverageTool:
             extracted_coverage_info = gcov_data['data']
             if capture_complete:
                 self.__class__.create_gcda_files(extracted_coverage_info)
-                verbose("Gcov data captured: {}".format(filename))
+                logger.debug("Gcov data captured: {}".format(filename))
             else:
-                error("Gcov data capture incomplete: {}".format(filename))
+                logger.error("Gcov data capture incomplete: {}".format(filename))
 
         with open(os.path.join(outdir, "coverage.log"), "a") as coveragelog:
             ret = self._generate(outdir, coveragelog)
             if ret == 0:
-                info("HTML report generated: {}".format(
+                logger.info("HTML report generated: {}".format(
                     os.path.join(outdir, "coverage", "index.html")))
 
 
@@ -3702,7 +3672,7 @@ def export_tests(filename, tests):
                         }
                 cw.writerow(rowdict)
             else:
-                info("{} can't be exported".format(test))
+                logger.info("{} can't be exported".format(test))
 
 
 def native_and_unit_first(a, b):
@@ -3843,16 +3813,56 @@ class HardwareMap:
                 yaml.dump(self.detected, yaml_file, default_flow_style=False)
 
 
-run_individual_tests = None
-options = None
-
 def main():
     start_time = time.time()
-    global VERBOSE, log_file
+    global VERBOSE
     global options
     global run_individual_tests
 
-    options = parse_arguments()
+    options = options = parse_arguments()
+
+    # Cleanup
+    if options.no_clean or options.only_failed or options.test_only:
+        if os.path.exists(options.outdir):
+            logger.info("Keeping artifacts untouched")
+    elif os.path.exists(options.outdir):
+        for i in range(1,100):
+            new_out = options.outdir + ".{}".format(i)
+            if not os.path.exists(new_out):
+                logger.info("Renaming output directory to {}".format(new_out))
+                shutil.move(options.outdir, new_out)
+                break
+
+    os.makedirs(options.outdir, exist_ok=True)
+
+    # create file handler which logs even debug messages
+    if options.log_file:
+        fh = logging.FileHandler(options.log_file)
+    else:
+        fh = logging.FileHandler(os.path.join(options.outdir, "sanitycheck.log"))
+
+    fh.setLevel(logging.DEBUG)
+
+    # create console handler with a higher log level
+    ch = logging.StreamHandler()
+
+
+    VERBOSE += options.verbose
+    if VERBOSE > 1:
+        ch.setLevel(logging.DEBUG)
+    else:
+        ch.setLevel(logging.INFO)
+
+
+    # create formatter and add it to the handlers
+    formatter = logging.Formatter('%(levelname)s - %(message)s')
+    formatter_file = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    ch.setFormatter(formatter)
+    fh.setFormatter(formatter_file)
+
+    # add the handlers to logger
+    logger.addHandler(ch)
+    logger.addHandler(fh)
 
     hwm = HardwareMap()
     if options.generate_hardware_map:
@@ -3874,11 +3884,11 @@ def main():
         return
 
     if options.west_runner and not options.west_flash:
-        error("west-runner requires west-flash to be enabled")
+        logger.error("west-runner requires west-flash to be enabled")
         sys.exit(1)
 
     if options.west_flash and not options.device_testing:
-        error("west-flash requires device-testing to be enabled")
+        logger.error("west-flash requires device-testing to be enabled")
         sys.exit(1)
 
     if options.coverage:
@@ -3892,31 +3902,15 @@ def main():
             size_report(SizeCalculator(fn, []))
         sys.exit(0)
 
-    VERBOSE += options.verbose
-
-    if options.log_file:
-        log_file = open(options.log_file, "w")
 
     if options.subset:
         subset, sets = options.subset.split("/")
         if int(subset) > 0 and int(sets) >= int(subset):
-            info("Running only a subset: %s/%s" % (subset, sets))
+            logger.info("Running only a subset: %s/%s" % (subset, sets))
         else:
-            error("You have provided a wrong subset value: %s." % options.subset)
+            logger.error("You have provided a wrong subset value: %s." % options.subset)
             return
 
-    # Cleanup
-
-    if options.no_clean or options.only_failed or options.test_only:
-        if os.path.exists(options.outdir):
-            info("Keeping artifacts untouched")
-    elif os.path.exists(options.outdir):
-        for i in range(1,100):
-            new_out = options.outdir + ".{}".format(i)
-            if not os.path.exists(new_out):
-                info("Renaming output directory to {}".format(new_out))
-                shutil.move(options.outdir, new_out)
-                break
 
     if not options.testcase_root:
         options.testcase_root = [os.path.join(ZEPHYR_BASE, "tests"),
@@ -3936,7 +3930,7 @@ def main():
         suite.jobs = multiprocessing.cpu_count() * 2
     else:
         suite.jobs = multiprocessing.cpu_count()
-    info("JOBS: %d" % suite.jobs)
+    logger.info("JOBS: %d" % suite.jobs)
 
     suite.add_testcases()
     suite.add_configurations()
@@ -3955,7 +3949,7 @@ def main():
             if options.platform and len(options.platform) == 1:
                 hwm.load_device_from_cmdline(options.device_serial, options.platform[0])
             else:
-                error("""When --device-testing is used with --device-serial, only one
+                logger.error("""When --device-testing is used with --device-serial, only one
                       platform is allowed""")
 
 
@@ -4007,11 +4001,11 @@ def main():
                     run_individual_tests.append(sti.name)
 
             if run_individual_tests:
-                info("Running the following tests:")
+                logger.info("Running the following tests:")
                 for test in run_individual_tests:
                     print(" - {}".format(test))
             else:
-                info("Tests not found")
+                logger.info("Tests not found")
                 return
 
         elif options.list_tests or options.test_tree:
@@ -4078,7 +4072,7 @@ def main():
         for i, reason in discards.items():
             if options.platform and i.platform.name not in options.platform:
                 continue
-            debug(
+            logger.debug(
                 "{:<25} {:<50} {}SKIPPED{}: {}".format(
                     i.platform.name,
                     i.testcase.name,
@@ -4119,7 +4113,7 @@ def main():
         suite.csv_report(options.save_tests)
         return
 
-    info("%d test configurations selected, %d configurations discarded due to filters." %
+    logger.info("%d test configurations selected, %d configurations discarded due to filters." %
         (len(suite.instances), len(discards)))
 
     if options.device_testing:
@@ -4135,7 +4129,7 @@ def main():
 
     if options.dry_run:
         duration = time.time() - start_time
-        info("Completed in %d seconds" % (duration))
+        logger.info("Completed in %d seconds" % (duration))
         return
 
     retries = options.retry_failed + 1
@@ -4148,13 +4142,13 @@ def main():
         completed += 1
 
         if completed > 1:
-            info("%d Iteration:" %(completed ))
+            logger.info("%d Iteration:" %(completed ))
             time.sleep(60) # waiting for the system to settle down
             suite.total_done = suite.total_tests - suite.total_failed
             suite.total_failed = 0
 
         suite.execute()
-        info("", False)
+        print("")
 
         retries = retries - 1
         if retries == 0 or suite.total_failed == 0:
@@ -4181,7 +4175,7 @@ def main():
                 options.gcov_tool = os.path.join(os.environ["ZEPHYR_SDK_INSTALL_DIR"],
                     "i586-zephyr-elf/bin/i586-zephyr-elf-gcov")
 
-        info("Generating coverage files...")
+        logger.info("Generating coverage files...")
         coverage_tool = CoverageTool.factory(options.coverage_tool)
         coverage_tool.add_ignore_file('generated')
         coverage_tool.add_ignore_directory('tests')

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1642,40 +1642,42 @@ class TestInstance:
         self.name = os.path.join(platform.name, testcase.name)
         self.build_dir = os.path.join(outdir, platform.name, testcase.name)
 
-        self.build_only = self.check_build_or_run()
-        self.run = not self.build_only
+        self.build_only = True
+        self.run = False
 
         self.results = {}
 
     def __lt__(self, other):
         return self.name < other.name
 
-    def check_build_or_run(self):
+    def check_build_or_run(self, build_only=False, enable_slow=False, device_testing=False, fixture=[]):
+
         # right now we only support building on windows. running is still work
         # in progress.
-
         if os.name == 'nt':
-            return True
+            self.build_only = True
+            self.run = False
+            return
 
-        build_only = True
+        _build_only = True
 
         # we asked for build-only on the command line
-        if options.build_only:
-            return True
-
-        # The testcase is designed to be build only.
-        if self.testcase.build_only:
-            return True
+        if build_only or self.testcase.build_only:
+            self.build_only = True
+            self.run = False
+            return
 
         # Do not run slow tests:
-        skip_slow = self.testcase.slow and not options.enable_slow
+        skip_slow = self.testcase.slow and not enable_slow
         if skip_slow:
-            return True
+            self.build_only = True
+            self.run = False
+            return
 
         runnable =bool(self.testcase.type == "unit" or \
             self.platform.type == "native" or \
             self.platform.simulation in ["nsim", "renode", "qemu"] or \
-            options.device_testing)
+            device_testing)
 
         if self.platform.simulation == "nsim":
             if not find_executable("nsimdrv"):
@@ -1692,20 +1694,22 @@ class TestInstance:
             # command-line, then we need to run the test, not just build it.
             if "fixture" in self.testcase.harness_config:
                 fixture = self.testcase.harness_config['fixture']
-                if fixture in options.fixture:
-                    build_only = False
+                if fixture in fixture:
+                    _build_only = False
                 else:
-                    build_only = True
+                    _build_only = True
             else:
-                build_only = False
+                _build_only = False
         elif self.testcase.harness:
-            build_only = True
+            _build_only = True
         else:
-            build_only = False
+            _build_only = False
 
-        return not (not build_only and runnable)
+        self.build_only = not (not _build_only and runnable)
+        self.run = not self.build_only
+        return
 
-    def create_overlay(self, platform):
+    def create_overlay(self, platform, enable_asan=False, enable_coverage=False, coverage_platform=[]):
         # Create this in a "sanitycheck/" subdirectory otherwise this
         # will pass this overlay to kconfig.py *twice* and kconfig.cmake
         # will silently give that second time precedence over any
@@ -1713,17 +1717,18 @@ class TestInstance:
         subdir = os.path.join(self.build_dir, "sanitycheck")
         os.makedirs(subdir, exist_ok=True)
         file = os.path.join(subdir, "testcase_extra.conf")
+
         with open(file, "w") as f:
             content = ""
 
             if self.testcase.extra_configs:
                 content = "\n".join(self.testcase.extra_configs)
 
-            if options.enable_coverage:
-                if platform.name in options.coverage_platform:
+            if enable_coverage:
+                if platform.name in coverage_platform:
                     content = content + "\nCONFIG_COVERAGE=y"
 
-            if options.enable_asan:
+            if enable_asan:
                 if platform.type == "native":
                     content = content + "\nCONFIG_ASAN=y"
 
@@ -1963,12 +1968,20 @@ class FilterBuilder(CMake):
 
 class ProjectBuilder(FilterBuilder):
 
-    def __init__(self, suite, instance):
+    def __init__(self, suite, instance, **kwargs):
         super().__init__(instance.testcase, instance.platform, instance.testcase.source_dir, instance.build_dir)
 
         self.log = "build.log"
         self.instance = instance
         self.suite = suite
+
+        self.lsan = kwargs.get('lsan', False)
+        self.asan = kwargs.get('asan', False)
+        self.valgrind = kwargs.get('valgrind', False)
+        self.extra_args = kwargs.get('extra_args', [])
+        self.device_testing = kwargs.get('device_testing', False)
+        self.cmake_only = kwargs.get('cmake_only', False)
+        self.coverage = kwargs.get('coverage', False)
 
     def setup_handler(self):
 
@@ -1986,10 +1999,10 @@ class ProjectBuilder(FilterBuilder):
         elif instance.platform.type == "native":
             handler = BinaryHandler(instance, "native")
 
-            handler.asan = options.enable_lsan
-            handler.valgrind = options.enable_valgrind
-            handler.lsan = options.enable_lsan
-            handler.coverage = options.enable_coverage
+            handler.asan = self.asan
+            handler.valgrind = self.valgrind
+            handler.lsan = self.lsan
+            handler.coverage = self.coverage
 
             handler.binary = os.path.join(instance.build_dir, "zephyr", "zephyr.exe")
             instance.handler = handler
@@ -2002,7 +2015,7 @@ class ProjectBuilder(FilterBuilder):
                 instance.handler = BinaryHandler(instance, "renode")
                 instance.handler.pid_fn = os.path.join(instance.build_dir, "renode.pid")
                 instance.handler.call_make_run = True
-        elif options.device_testing:
+        elif self.device_testing:
             instance.handler = DeviceHandler(instance, "device")
 
         if instance.handler:
@@ -2019,7 +2032,7 @@ class ProjectBuilder(FilterBuilder):
             results = self.cmake()
             if self.instance.status == "failed":
                 pipeline.put({"op": "report", "test": self.instance})
-            elif options.cmake_only:
+            elif self.cmake_only:
                 pipeline.put({"op": "report", "test": self.instance})
             else:
                 if self.instance.name in results['filter'] and results['filter'][self.instance.name]:
@@ -2086,7 +2099,7 @@ class ProjectBuilder(FilterBuilder):
             status = COLOR_GREEN + "PASSED" + COLOR_NORMAL
 
         if VERBOSE or not TERMINAL:
-            if options.cmake_only:
+            if self.cmake_only:
                 more_info = "cmake"
             elif instance.status == "skipped":
                 more_info = instance.reason
@@ -2126,9 +2139,7 @@ class ProjectBuilder(FilterBuilder):
 
         instance = self.instance
         args = self.testcase.extra_args[:]
-
-        if options.extra_args:
-            args += options.extra_args
+        args += self.extra_args
 
         if instance.handler:
             args += instance.handler.args
@@ -2143,8 +2154,8 @@ class ProjectBuilder(FilterBuilder):
                 del args[idx]
                 idx += 1
 
-        if (self.testcase.extra_configs or options.coverage or
-                options.enable_asan):
+        if (self.testcase.extra_configs or self.coverage or
+                self.asan):
             args.append("OVERLAY_CONFIG=\"%s %s\"" %(overlays,
                         os.path.join(instance.build_dir,
                                      "sanitycheck", "testcase_extra.conf")))
@@ -2211,6 +2222,19 @@ class TestSuite:
         else:
             self.board_roots = board_root_list
 
+        # Testsuite Options
+        self.coverage_platform = []
+        self.build_only = False
+        self.cmake_only = False
+        self.enable_slow = False
+        self.device_testing = False
+        self.fixture = []
+        self.enable_coverage = False
+        self.enable_lsan = False
+        self.enable_asan = False
+        self.enable_valgrind = False
+        self.extra_args = []
+
         # Keep track of which test cases we've filtered out and why
         self.testcases = {}
         self.platforms = []
@@ -2235,6 +2259,9 @@ class TestSuite:
 
         # hardcoded for now
         self.connected_hardware = []
+
+    def config(self):
+        logger.info("coverage platform: {}".format(self.coverage_platform))
 
     # Debug Functions
     @staticmethod
@@ -2351,30 +2378,31 @@ class TestSuite:
                 (100 * len(self.selected_platforms) / len(self.platforms))
             ))
 
-    def save_reports(self):
+    def save_reports(self, name, report_dir, no_update, release, only_failed):
         if not self.instances:
             return
 
-        report_name = "sanitycheck"
-        if options.report_name:
-            report_name = options.report_name
+        if name:
+            report_name = name
+        else:
+            report_name = "sanitycheck"
 
-        if options.report_dir:
-            os.makedirs(options.report_dir, exist_ok=True)
-            filename = os.path.join(options.report_dir, report_name)
-            outdir = options.report_dir
+        if report_dir:
+            os.makedirs(report_dir, exist_ok=True)
+            filename = os.path.join(report_dir, report_name)
+            outdir = report_dir
         else:
             filename = os.path.join(self.outdir, report_name)
             outdir = self.outdir
 
-        if not options.no_update:
-            self.xunit_report(filename + ".xml")
+        if not no_update:
+            self.xunit_report(filename + ".xml", only_failed)
             self.csv_report(filename + ".csv")
             self.target_report(outdir)
             if self.discards:
                 self.discard_report(filename + "_discard.csv")
 
-        if options.release:
+        if release:
             self.csv_report(RELEASE_DATA)
 
     def add_configurations(self):
@@ -2528,7 +2556,13 @@ class TestSuite:
                 test = row["test"]
                 platform = self.get_platform(row["platform"])
                 instance = TestInstance(self.testcases[test], platform, self.outdir)
-                instance.create_overlay(platform)
+                instance.check_build_or_run(
+                    self.build_only,
+                    self.enable_slow,
+                    self.device_testing,
+                    self.fixture
+                    )
+                instance.create_overlay(platform, self.enable_asan, self.enable_coverage, self.coverage_platform)
                 instance_list.append(instance)
             self.add_instances(instance_list)
 
@@ -2553,7 +2587,13 @@ class TestSuite:
                 test = row["test"]
                 platform = self.get_platform(row["platform"])
                 instance = TestInstance(self.testcases[test], platform, self.outdir)
-                instance.create_overlay(platform)
+                instance.check_build_or_run(
+                    self.build_only,
+                    self.enable_slow,
+                    self.device_testing,
+                    self.fixture
+                    )
+                instance.create_overlay(platform, self.enable_asan, self.enable_coverage, self.coverage_platform)
                 instance_list.append(instance)
             self.add_instances(instance_list)
 
@@ -2598,6 +2638,12 @@ class TestSuite:
             instance_list = []
             for plat in platforms:
                 instance = TestInstance(tc, plat, self.outdir)
+                instance.check_build_or_run(
+                    self.build_only,
+                    self.enable_slow,
+                    self.device_testing,
+                    self.fixture
+                    )
 
                 if (plat.arch == "unit") != (tc.type == "unit"):
                     # Discard silently
@@ -2717,7 +2763,7 @@ class TestSuite:
                 self.add_instances(instance_list)
 
         for _, case in self.instances.items():
-            case.create_overlay(case.platform)
+            case.create_overlay(case.platform, self.enable_asan, self.enable_coverage, self.coverage_platform)
 
         self.discards = discards
         self.selected_platforms = set(p.platform.name for p in self.instances.values())
@@ -2728,9 +2774,9 @@ class TestSuite:
         for instance in instance_list:
             self.instances[instance.name] = instance
 
-    def add_tasks_to_queue(self):
+    def add_tasks_to_queue(self, test_only=False):
         for instance in self.instances.values():
-            if options.test_only:
+            if test_only:
                 if instance.run:
                     pipeline.put({"op": "run", "test": instance, "status": "built"})
             else:
@@ -2740,7 +2786,7 @@ class TestSuite:
 
         return "DONE FEEDING"
 
-    def execute(self):
+    def execute(self, test_only, cmake_only, enable_size_report):
         def calc_one_elf_size(instance):
             if instance.status not in ["failed", "skipped"]:
                 if instance.platform.type != "native":
@@ -2761,7 +2807,7 @@ class TestSuite:
 
             # start a future for a thread which sends work in through the queue
             future_to_test = {
-                    executor.submit(self.add_tasks_to_queue): 'FEEDER DONE'}
+                    executor.submit(self.add_tasks_to_queue, test_only): 'FEEDER DONE'}
 
             while future_to_test:
                 # check for status of the futures which are currently working
@@ -2776,7 +2822,16 @@ class TestSuite:
                     test = message['test']
 
                     # Start the load operation and mark the future with its URL
-                    pb = ProjectBuilder(self, test)
+                    pb = ProjectBuilder(self,
+                        test,
+                        lsan = self.enable_lsan,
+                        asan = self.enable_asan,
+                        coverage = self.enable_coverage,
+                        extra_args = self.extra_args,
+                        device_testing = self.device_testing,
+                        cmake_only = self.cmake_only,
+                        valgrind = self.enable_valgrind
+                        )
                     future_to_test[executor.submit(pb.process, message)] = test.name
 
                 # process any completed futures
@@ -2794,7 +2849,7 @@ class TestSuite:
                     # remove the now completed future
                     del future_to_test[future]
 
-        if options.enable_size_report and not options.cmake_only:
+        if enable_size_report and not cmake_only:
             # Parallelize size calculation
             executor = concurrent.futures.ThreadPoolExecutor(self.jobs)
             futures = [executor.submit(calc_one_elf_size, instance)
@@ -2908,7 +2963,7 @@ class TestSuite:
             with open(os.path.join(outdir, platform + ".xml"), 'wb') as f:
                 f.write(result)
 
-    def xunit_report(self, filename):
+    def xunit_report(self, filename, append=False):
         fails = 0
         passes = 0
         errors = 0
@@ -2930,7 +2985,6 @@ class TestSuite:
 
         run = "Sanitycheck"
         eleTestsuite = None
-        append = options.only_failed
 
         # When we re-run the tests, we re-use the results and update only with
         # the newly run tests.
@@ -3931,9 +3985,21 @@ def main():
     if options.show_footprint or options.compare_report or options.release:
         options.enable_size_report = True
 
-    suite = TestSuite(options.board_root,
-                      options.testcase_root,
-                      options.outdir)
+    suite = TestSuite(options.board_root, options.testcase_root, options.outdir)
+
+    # Set testsuite options from command line.
+    suite.build_only = options.build_only
+    suite.enable_slow = options.enable_slow
+    suite.device_testing = options.device_testing
+    suite.fixture = options.fixture
+    suite.enable_asan = options.enable_asan
+    suite.enable_lsan = options.enable_lsan
+    suite.enable_coverage = options.enable_coverage
+    suite.coverage_platorm = ['me']
+    suite.cmake_only = options.cmake_only
+    suite.enable_valgrind = options.enable_valgrind
+    suite.coverage_platform = options.coverage_platform
+
 
     # Set number of jobs
     if options.jobs:
@@ -4171,7 +4237,7 @@ def main():
             suite.total_done = suite.total_tests - suite.total_failed
             suite.total_failed = 0
 
-        suite.execute()
+        suite.execute(options.test_only, options.cmake_only, options.enable_size_report)
         print("")
 
         retries = retries - 1
@@ -4217,7 +4283,12 @@ def main():
         print(tabulate(table, headers=header, tablefmt="github"))
 
 
-    suite.save_reports()
+    suite.save_reports(options.report_name,
+                       options.report_dir,
+                       options.no_update,
+                       options.release,
+                       options.only_failed)
+
     if suite.total_failed or (suite.warnings and options.warnings_as_errors):
         sys.exit(1)
 

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -198,6 +198,10 @@ try:
 except ImportError:
     print("Install the anytree module to use the --test-tree option")
 
+try:
+    from tabulate import tabulate
+except ImportError:
+    print("Install tabulate python module with pip to use --device-testing option.")
 
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 if not ZEPHYR_BASE:
@@ -694,14 +698,14 @@ class DeviceHandler(Handler):
 
     def device_is_available(self, device):
         for i in self.suite.connected_hardware:
-            if i['platform'] == device and i['available'] and i['connected']:
+            if i['platform'] == device and i['available'] and i['serial']:
                 return True
 
         return False
 
     def get_available_device(self, device):
         for i in self.suite.connected_hardware:
-            if i['platform'] == device and i['available']:
+            if i['platform'] == device and i['available'] and i['serial']:
                 i['available'] = False
                 i['counter'] += 1
                 return i
@@ -2206,6 +2210,7 @@ class TestSuite:
         # Keep track of which test cases we've filtered out and why
         self.testcases = {}
         self.platforms = []
+        self.selected_platforms = []
         self.default_platforms = []
         self.outdir = os.path.abspath(outdir)
         self.discards = None
@@ -2339,14 +2344,13 @@ class TestSuite:
             COLOR_NORMAL,
             self.duration))
 
-        platforms = set(p.platform for p in self.instances.values())
         self.total_platforms = len(self.platforms)
         if self.platforms:
             info("In total {} test cases were executed on {} out of total {} platforms ({:02.2f}%)".format(
                 self.total_cases,
-                len(platforms),
+                len(self.selected_platforms),
                 self.total_platforms,
-                (100 * len(platforms) / len(self.platforms))
+                (100 * len(self.selected_platforms) / len(self.platforms))
             ))
 
     def save_reports(self):
@@ -2378,24 +2382,7 @@ class TestSuite:
         if log_file:
             log_file.close()
 
-    def load_hardware_map_from_cmdline(self, serial, platform):
-        device = {
-            "serial": serial,
-            "platform": platform,
-            "counter": 0,
-            "available": True,
-            "connected": True
-        }
-        self.connected_hardware = [device]
 
-    def load_hardware_map(self, map_file):
-        with open(map_file, 'r') as stream:
-            try:
-                self.connected_hardware = yaml.safe_load(stream)
-            except yaml.YAMLError as exc:
-                print(exc)
-        for i in self.connected_hardware:
-            i['counter'] = 0
 
     def add_configurations(self):
 
@@ -2406,7 +2393,7 @@ class TestSuite:
                 board_root)
 
             for file in glob.glob(os.path.join(board_root, "*", "*", "*.yaml")):
-                verbose("Found plaform configuration " + file)
+                verbose("Found platform configuration " + file)
                 try:
                     platform = Platform()
                     platform.load(file)
@@ -2740,6 +2727,7 @@ class TestSuite:
             case.create_overlay(case.platform)
 
         self.discards = discards
+        self.selected_platforms = set(p.platform.name for p in self.instances.values())
 
         return discards
 
@@ -3718,6 +3706,121 @@ def native_and_unit_first(a, b):
     return (a > b) - (a < b)
 
 
+class HardwareMap:
+    manufacturer = [
+        'ARM',
+        'SEGGER',
+        'MBED',
+        'STMicroelectronics',
+        'Atmel Corp.',
+        'Texas Instruments',
+        'Silicon Labs',
+        'NXP Semiconductors'
+        ]
+
+    runner_mapping = {
+        'pyocd': [
+            'DAPLink CMSIS-DAP',
+            'MBED CMSIS-DAP'
+        ],
+        'jlink': [
+            'J-Link',
+            'J-Link OB'
+        ],
+        'openocd': [
+            'STM32 STLink', '^XDS110.*'
+        ]
+    }
+
+    def __init__(self):
+        self.detected = []
+        self.connected_hardware = []
+
+    def load_device_from_cmdline(self, serial, platform):
+        device = {
+            "serial": serial,
+            "platform": platform,
+            "counter": 0,
+            "available": True,
+            "connected": True
+        }
+        self.connected_hardware.append(device)
+
+    def load_hardware_map(self, map_file):
+        with open(map_file, 'r') as stream:
+            try:
+                self.connected_hardware = yaml.safe_load(stream)
+            except yaml.YAMLError as exc:
+                print(exc)
+        for i in self.connected_hardware:
+            i['counter'] = 0
+
+    def scan_hw(self):
+        from serial.tools import list_ports
+
+        serial_devices = list_ports.comports()
+        for d in serial_devices:
+            if d.manufacturer in self.manufacturer:
+
+                # TI XDS110 can have multiple serial devices for a single board
+                # assume endpoint 0 is the serial, skip all others
+                if d.manufacturer == 'Texas Instruments' and not d.location.endswith('0'):
+                    continue
+                s_dev = {}
+                s_dev['platform'] = "unknown"
+                s_dev['id'] = d.serial_number
+                s_dev['serial'] = d.device
+                s_dev['product'] = d.product
+                s_dev['runner'] = 'unknown'
+                for runner in self.runner_mapping.keys():
+                    products = self.runner_mapping.get(runner)
+                    if d.product in products:
+                        s_dev['runner'] = runner
+                        continue
+                    # Try regex matching
+                    for p in products:
+                        if re.match(p, d.product):
+                            s_dev['runner'] = runner
+
+                s_dev['available'] = True
+                s_dev['connected'] = True
+                self.detected.append(s_dev)
+            else:
+                print("Unsupported device (%s): %s" %(d.manufacturer, d))
+
+    def write_map(self, hwm_file):
+        # use existing map
+        if os.path.exists(hwm_file):
+            with open(hwm_file, 'r') as yaml_file:
+                hwm = yaml.load(yaml_file, Loader=yaml.FullLoader)
+                # disconnect everything
+                for h in hwm:
+                    h['connected'] = False
+                    h['serial'] = None
+
+                for d in self.detected:
+                    for h in hwm:
+                        if d['id'] == h['id'] and d['product'] == h['product']:
+                            print("Already in map: %s (%s)" %(d['product'], d['id']))
+                            h['connected'] = True
+                            h['serial'] = d['serial']
+                            d['match'] = True
+
+                new = list(filter(lambda n:  not n.get('match', False), self.detected))
+                hwm = hwm + new
+
+            with open(hwm_file, 'w') as yaml_file:
+                yaml.dump(hwm, yaml_file, default_flow_style=False)
+
+        else:
+            # create new file
+            with open(hwm_file, 'w') as yaml_file:
+                yaml.dump(self.detected, yaml_file, default_flow_style=False)
+
+        return
+
+
+
 run_individual_tests = None
 options = None
 
@@ -3729,74 +3832,24 @@ def main():
 
     options = parse_arguments()
 
-
+    hwm = HardwareMap()
     if options.generate_hardware_map:
-        from serial.tools import list_ports
-        serial_devices = list_ports.comports()
-        filtered = []
-        for d in serial_devices:
-            if d.manufacturer in ['ARM', 'SEGGER', 'MBED', 'STMicroelectronics',
-                                  'Atmel Corp.', 'Texas Instruments',
-                                  'Silicon Labs', 'NXP Semiconductors']:
-                # TI XDS110 can have multiple serial devices for a single board
-                # assume endpoint 0 is the serial, skip all others
-                if d.manufacturer == 'Texas Instruments' and not d.location.endswith('0'):
-                    continue
-                s_dev = {}
-                s_dev['platform'] = "unknown"
-                s_dev['id'] = d.serial_number
-                s_dev['serial'] = d.device
-                s_dev['product'] = d.product
-                if s_dev['product'] in ['DAPLink CMSIS-DAP', 'MBED CMSIS-DAP']:
-                    s_dev['runner'] = "pyocd"
-                elif s_dev['product'] in ['J-Link', 'J-Link OB']:
-                    s_dev['runner'] = "jlink"
-                elif s_dev['product'] in ['STM32 STLink']:
-                    s_dev['runner'] = "openocd"
-                elif s_dev['product'].startswith('XDS110'):
-                    s_dev['runner'] = "openocd"
-                else:
-                    s_dev['runner'] = "unknown"
-                s_dev['available'] = True
-                s_dev['connected'] = True
-                filtered.append(s_dev)
-            else:
-                print("Unsupported device (%s): %s" %(d.manufacturer, d))
-
-        if os.path.exists(options.generate_hardware_map):
-            # use existing map
-
-            with open(options.generate_hardware_map, 'r') as yaml_file:
-                hwm = yaml.load(yaml_file, Loader=yaml.FullLoader)
-                # disconnect everything
-                for h in hwm:
-                    h['connected'] = False
-                    h['serial'] = None
-
-                for d in filtered:
-                    for h in hwm:
-                        if d['id'] == h['id'] and d['product'] == h['product']:
-                            print("Already in map: %s (%s)" %(d['product'], d['id']))
-                            h['connected'] = True
-                            h['serial'] = d['serial']
-                            d['match'] = True
-
-                new = list(filter(lambda n:  not n.get('match', False), filtered))
-                hwm = hwm + new
-
-                #import pprint
-                #pprint.pprint(hwm)
-            with open(options.generate_hardware_map, 'w') as yaml_file:
-                yaml.dump(hwm, yaml_file, default_flow_style=False)
-
-
-        else:
-            # create new file
-            with open(options.generate_hardware_map, 'w') as yaml_file:
-                yaml.dump(filtered, yaml_file, default_flow_style=False)
-
+        hwm.scan_hw()
+        hwm.write_map(options.generate_hardware_map)
         return
 
+    if not options.device_testing and options.hardware_map:
+        hwm.load_hardware_map(options.hardware_map)
+
+        print("\nAvailable devices:")
+        table = []
+        header = ["Platform", "ID", "Serial device"]
+        for p in hwm.connected_hardware:
+            platform = p.get('platform')
+            if p['connected']:
+                table.append([platform, p.get('id', None), p['serial']])
+        print(tabulate(table, headers=header, tablefmt="github"))
+        return
 
     if options.west_runner and not options.west_flash:
         error("west-runner requires west-flash to be enabled")
@@ -3857,17 +3910,17 @@ def main():
 
     if options.device_testing:
         if options.hardware_map:
-            suite.load_hardware_map(options.hardware_map)
+            hwm.load_hardware_map(options.hardware_map)
+            suite.connected_hardware = hwm.connected_hardware
             if not options.platform:
                 options.platform = []
-                for platform in suite.connected_hardware:
+                for platform in hwm.connected_hardware:
                     if platform['connected']:
                         options.platform.append(platform['platform'])
 
         elif options.device_serial: #back-ward compatibility
             if options.platform and len(options.platform) == 1:
-                suite.load_hardware_map_from_cmdline(options.device_serial,
-                                                    options.platform[0])
+                hwm.load_device_from_cmdline(options.device_serial, options.platform[0])
             else:
                 error("""When --device-testing is used with --device-serial, only one
                       platform is allowed""")
@@ -3974,6 +4027,7 @@ def main():
 
     if options.only_failed:
         suite.get_last_failed()
+        suite.selected_platforms = set(p.platform.name for p in suite.instances.values())
     elif options.load_tests:
         suite.load_from_file(options.load_tests)
     elif options.test_only:
@@ -4037,9 +4091,14 @@ def main():
 
     if options.device_testing:
         print("\nDevice testing on:")
+        table = []
+        header = ["Platform", "ID", "Serial device"]
         for p in suite.connected_hardware:
-            if p['connected']:
-                print("%s (%s) on %s" %(p['platform'], p.get('id', None), p['serial']))
+            platform = p.get('platform')
+            if p['connected'] and platform in suite.selected_platforms:
+                table.append([platform, p.get('id', None), p['serial']])
+        print(tabulate(table, headers=header, tablefmt="github"))
+        print("")
 
     if options.dry_run:
         duration = time.time() - start_time
@@ -4098,9 +4157,14 @@ def main():
 
     if options.device_testing:
         print("\nHardware distribution summary:\n")
-        for p in suite.connected_hardware:
-            if p['connected']:
-                print("%s (%s): %d" %(p['platform'], p.get('id', None), p['counter']))
+        table = []
+        header = ['Board', 'ID', 'Counter']
+        for p in hwm.connected_hardware:
+            if p['connected'] and p['platform'] in suite.selected_platforms:
+                row = [p['platform'], p.get('id', None), p['counter']]
+                table.append(row)
+        print(tabulate(table, headers=header, tablefmt="github"))
+
 
     suite.save_reports()
     if suite.total_failed or (suite.warnings and options.warnings_as_errors):

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2555,16 +2555,19 @@ class TestSuite:
                 instance_list.append(instance)
             self.add_instances(instance_list)
 
-    def apply_filters(self):
+    def apply_filters(self, **kwargs):
 
         toolchain = self.get_toolchain()
 
         discards = {}
-        platform_filter = options.platform
-        testcase_filter = run_individual_tests
-        arch_filter = options.arch
-        tag_filter = options.tag
-        exclude_tag = options.exclude_tag
+        platform_filter = kwargs.get('platform')
+        testcase_filter = kwargs.get('run_individual_tests')
+        arch_filter = kwargs.get('arch')
+        tag_filter = kwargs.get('tag')
+        exclude_tag = kwargs.get('exclude_tag')
+        all_filter = kwargs.get('all')
+        device_testing_filter = kwargs.get('device_testing')
+        force_toolchain = kwargs.get('force_toolchain')
 
         logger.debug("platform filter: " + str(platform_filter))
         logger.debug("    arch_filter: " + str(arch_filter))
@@ -2578,7 +2581,7 @@ class TestSuite:
         else:
             platforms = self.platforms
 
-        if options.all:
+        if all_filter:
             logger.info("Selecting all possible platforms per test case")
             # When --all used, any --platform arguments ignored
             platform_filter = []
@@ -2598,7 +2601,7 @@ class TestSuite:
                     # Discard silently
                     continue
 
-                if options.device_testing and instance.build_only:
+                if device_testing_filter and instance.build_only:
                     discards[instance] = "Not runnable on device"
                     continue
 
@@ -2657,7 +2660,7 @@ class TestSuite:
                     discards[instance] = "Environment ({}) not satisfied".format(", ".join(plat.env))
                     continue
 
-                if not options.force_toolchain \
+                if not force_toolchain \
                     and toolchain and (toolchain not in plat.supported_toolchains) \
                     and tc.type != 'unit':
                     discards[instance] = "Not supported by the toolchain"
@@ -3812,6 +3815,8 @@ class HardwareMap:
             with open(hwm_file, 'w') as yaml_file:
                 yaml.dump(self.detected, yaml_file, default_flow_style=False)
 
+run_individual_tests = None
+options = None
 
 def main():
     start_time = time.time()
@@ -3819,7 +3824,7 @@ def main():
     global options
     global run_individual_tests
 
-    options = options = parse_arguments()
+    options = parse_arguments()
 
     # Cleanup
     if options.no_clean or options.only_failed or options.test_only:
@@ -4061,7 +4066,19 @@ def main():
         last_run = os.path.join(options.outdir, "sanitycheck.csv")
         suite.load_from_file(last_run)
     else:
-        discards = suite.apply_filters()
+        discards = suite.apply_filters(
+            build_only=options.build_only,
+            enable_slow=options.enable_slow,
+            platform=options.platform,
+            arch=options.arch,
+            tag=options.tag,
+            exclude_tag=options.exclude_tag,
+            force_toolchain=options.force_toolchain,
+            all=options.all,
+            run_individual_tests=run_individual_tests,
+            device_testing=options.device_testing
+
+        )
 
     if VERBOSE > 1 and discards:
         # if we are using command line platform filter, no need to list every

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -235,12 +235,8 @@ RELEASE_DATA = os.path.join(ZEPHYR_BASE, "scripts", "sanity_chk",
 
 
 logger = logging.getLogger('sanitycheck')
-# coloredlogs.install(level='INFO', logger=logger, fmt="%(levelname)s %(message)s")
 logger.setLevel(logging.DEBUG)
 
-
-# log_format = "%(levelname)s %(message)s"
-# logging.basicConfig(format=log_format, level=logging.INFO)
 
 class CMakeCacheEntry:
     '''Represents a CMake cache entry.
@@ -707,7 +703,6 @@ class DeviceHandler(Handler):
             command = [get_generator()[0], "-C", self.build_dir, "flash"]
 
         while not self.device_is_available(self.instance.platform.name):
-            #logger.debug("Waiting for device to become available...")
             time.sleep(1)
 
         hardware = self.get_available_device(self.instance.platform.name)

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2254,16 +2254,6 @@ class TestSuite:
         # hardcoded for now
         self.connected_hardware = []
 
-
-        if options.jobs:
-            self.jobs = options.jobs
-        elif options.build_only:
-            self.jobs = multiprocessing.cpu_count() * 2
-        else:
-            self.jobs = multiprocessing.cpu_count()
-
-        info("JOBS: %d" % self.jobs)
-
     def update(self):
         self.total_tests = len(self.instances)
         self.total_cases = len(self.testcases)
@@ -3925,6 +3915,16 @@ def main():
         options.enable_size_report = True
 
     suite = TestSuite(options.board_root, options.testcase_root, options.outdir)
+
+    # Set number of jobs
+    if options.jobs:
+        suite.jobs = options.jobs
+    elif options.build_only:
+        suite.jobs = multiprocessing.cpu_count() * 2
+    else:
+        suite.jobs = multiprocessing.cpu_count()
+    info("JOBS: %d" % suite.jobs)
+
     suite.add_testcases()
     suite.add_configurations()
 

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -189,6 +189,7 @@ import serial
 import concurrent
 import xml.etree.ElementTree as ET
 import logging
+from colorama import Fore
 from collections import OrderedDict
 from itertools import islice
 from pathlib import Path
@@ -232,18 +233,6 @@ VERBOSE = 0
 RELEASE_DATA = os.path.join(ZEPHYR_BASE, "scripts", "sanity_chk",
                             "sanity_last_release.csv")
 
-if os.isatty(sys.stdout.fileno()):
-    TERMINAL = True
-    COLOR_NORMAL = '\033[0m'
-    COLOR_RED = '\033[91m'
-    COLOR_GREEN = '\033[92m'
-    COLOR_YELLOW = '\033[93m'
-else:
-    TERMINAL = False
-    COLOR_NORMAL = ""
-    COLOR_RED = ""
-    COLOR_GREEN = ""
-    COLOR_YELLOW = ""
 
 logger = logging.getLogger('sanitycheck')
 # coloredlogs.install(level='INFO', logger=logger, fmt="%(levelname)s %(message)s")
@@ -1990,7 +1979,7 @@ class ProjectBuilder(FilterBuilder):
 
             logger.info("{:-^100}".format(filename))
         else:
-            logger.error("see: " + COLOR_YELLOW + filename + COLOR_NORMAL)
+            logger.error("see: " + Fore.YELLOW + filename + Fore.RESET)
 
     def log_info_file(self, inline_logs):
         build_dir = self.instance.build_dir
@@ -2104,26 +2093,26 @@ class ProjectBuilder(FilterBuilder):
 
         if instance.status in ["failed", "timeout"]:
             self.suite.total_failed += 1
-            if VERBOSE or not TERMINAL:
-                status = COLOR_RED + "FAILED " + COLOR_NORMAL + instance.reason
+            if VERBOSE:
+                status = Fore.RED + "FAILED " + Fore.RESET + instance.reason
             else:
                 print("")
                 logger.error(
                     "{:<25} {:<50} {}FAILED{}: {}".format(
                         instance.platform.name,
                         instance.testcase.name,
-                        COLOR_RED,
-                        COLOR_NORMAL,
+                        Fore.RED,
+                        Fore.RESET,
                         instance.reason))
             if not VERBOSE:
                 self.log_info_file(self.inline_logs)
         elif instance.status == "skipped":
             self.suite.total_skipped += 1
-            status = COLOR_YELLOW + "SKIPPED" + COLOR_NORMAL
+            status = Fore.YELLOW + "SKIPPED" + Fore.RESET
         else:
-            status = COLOR_GREEN + "PASSED" + COLOR_NORMAL
+            status = Fore.GREEN + "PASSED" + Fore.RESET
 
-        if VERBOSE or not TERMINAL:
+        if VERBOSE:
             if self.cmake_only:
                 more_info = "cmake"
             elif instance.status == "skipped":
@@ -2145,17 +2134,17 @@ class ProjectBuilder(FilterBuilder):
                 self.log_info_file(self.inline_logs)
         else:
             sys.stdout.write("\rINFO    - Total complete: %s%4d/%4d%s  %2d%%  skipped: %s%4d%s, failed: %s%4d%s" % (
-                COLOR_GREEN,
+                Fore.GREEN,
                 self.suite.total_done,
                 self.suite.total_tests,
-                COLOR_NORMAL,
+                Fore.RESET,
                 int((float(self.suite.total_done) / self.suite.total_tests) * 100),
-                COLOR_YELLOW if self.suite.total_skipped > 0 else COLOR_NORMAL,
+                Fore.YELLOW if self.suite.total_skipped > 0 else Fore.RESET,
                 self.suite.total_skipped,
-                COLOR_NORMAL,
-                COLOR_RED if self.suite.total_failed > 0 else COLOR_NORMAL,
+                Fore.RESET,
+                Fore.RED if self.suite.total_failed > 0 else Fore.RESET,
                 self.suite.total_failed,
-                COLOR_NORMAL
+                Fore.RESET
             )
                              )
         sys.stdout.flush()
@@ -2357,8 +2346,8 @@ class TestSuite:
                     continue
 
                 logger.info("{:<25} {:<60} {}{}{}: {} {:<+4}, is now {:6} {:+.2%}".format(
-                    i.platform.name, i.testcase.name, COLOR_YELLOW,
-                    "INFO" if all_deltas else "WARNING", COLOR_NORMAL,
+                    i.platform.name, i.testcase.name, Fore.YELLOW,
+                    "INFO" if all_deltas else "WARNING", Fore.RESET,
                     metric, delta, value, percentage))
                 warnings += 1
 
@@ -2373,7 +2362,7 @@ class TestSuite:
                 failed += 1
             elif instance.metrics.get("unrecognized") and not unrecognized_sections:
                 logger.error("%sFAILED%s: %s has unrecognized binary sections: %s" %
-                             (COLOR_RED, COLOR_NORMAL, instance.name,
+                             (Fore.RED, Fore.RESET, instance.name,
                               str(instance.metrics.get("unrecognized", []))))
                 failed += 1
 
@@ -2385,18 +2374,18 @@ class TestSuite:
 
         logger.info(
             "{}{} of {}{} tests passed ({:.2%}), {}{}{} failed, {} skipped with {}{}{} warnings in {:.2f} seconds".format(
-                COLOR_RED if failed else COLOR_GREEN,
+                Fore.RED if failed else Fore.GREEN,
                 self.total_tests - self.total_failed - self.total_skipped,
                 self.total_tests,
-                COLOR_NORMAL,
+                Fore.RESET,
                 pass_rate,
-                COLOR_RED if self.total_failed else COLOR_NORMAL,
+                Fore.RED if self.total_failed else Fore.RESET,
                 self.total_failed,
-                COLOR_NORMAL,
+                Fore.RESET,
                 self.total_skipped,
-                COLOR_YELLOW if self.warnings else COLOR_NORMAL,
+                Fore.YELLOW if self.warnings else Fore.RESET,
                 self.warnings,
-                COLOR_NORMAL,
+                Fore.RESET,
                 self.duration))
 
         self.total_platforms = len(self.platforms)
@@ -4157,8 +4146,8 @@ def main():
                 "{:<25} {:<50} {}SKIPPED{}: {}".format(
                     i.platform.name,
                     i.testcase.name,
-                    COLOR_YELLOW,
-                    COLOR_NORMAL,
+                    Fore.YELLOW,
+                    Fore.RESET,
                     reason))
 
     if options.report_excluded:

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -182,7 +182,6 @@ import concurrent.futures
 from threading import BoundedSemaphore
 import queue
 import time
-import datetime
 import csv
 import yaml
 import glob
@@ -194,6 +193,7 @@ from collections import OrderedDict
 from itertools import islice
 from pathlib import Path
 from distutils.spawn import find_executable
+
 try:
     from anytree import Node, RenderTree, find
 except ImportError:
@@ -214,8 +214,6 @@ import edtlib
 hw_map_local = threading.Lock()
 report_lock = threading.Lock()
 
-
-
 # Use this for internal comparisons; that's what canonicalization is
 # for. Don't use it when invoking other components of the build system
 # to avoid confusing and hard to trace inconsistencies in error messages
@@ -228,7 +226,6 @@ sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/"))
 
 from sanity_chk import scl
 from sanity_chk import expr_parser
-
 
 VERBOSE = 0
 
@@ -248,14 +245,13 @@ else:
     COLOR_GREEN = ""
     COLOR_YELLOW = ""
 
-
 logger = logging.getLogger('sanitycheck')
-#coloredlogs.install(level='INFO', logger=logger, fmt="%(levelname)s %(message)s")
+# coloredlogs.install(level='INFO', logger=logger, fmt="%(levelname)s %(message)s")
 logger.setLevel(logging.DEBUG)
 
 
-#log_format = "%(levelname)s %(message)s"
-#logging.basicConfig(format=log_format, level=logging.INFO)
+# log_format = "%(levelname)s %(message)s"
+# logging.basicConfig(format=log_format, level=logging.INFO)
 
 class CMakeCacheEntry:
     '''Represents a CMake cache entry.
@@ -334,7 +330,7 @@ class CMakeCacheEntry:
             except ValueError as exc:
                 args = exc.args + ('on line {}: {}'.format(line_no, line),)
                 raise ValueError(args) from exc
-        elif type_ in ['STRING','INTERNAL']:
+        elif type_ in ['STRING', 'INTERNAL']:
             # If the value is a CMake list (i.e. is a string which
             # contains a ';'), convert to a Python list.
             if ';' in value:
@@ -512,7 +508,6 @@ class BinaryHandler(Handler):
         self.asan = False
         self.coverage = False
 
-
     def try_kill_process_by_pid(self):
         if self.pid_fn:
             pid = int(open(self.pid_fn).read())
@@ -542,8 +537,8 @@ class BinaryHandler(Handler):
             harness.handle(line.decode('utf-8').rstrip())
             if harness.state:
                 try:
-                    #POSIX arch based ztests end on their own,
-                    #so let's give it up to 100ms to do so
+                    # POSIX arch based ztests end on their own,
+                    # so let's give it up to 100ms to do so
                     proc.wait(0.1)
                 except subprocess.TimeoutExpired:
                     self.terminate(proc)
@@ -567,27 +562,27 @@ class BinaryHandler(Handler):
         if self.valgrind and shutil.which("valgrind"):
             command = ["valgrind", "--error-exitcode=2",
                        "--leak-check=full",
-                       "--suppressions="+ZEPHYR_BASE+"/scripts/valgrind.supp",
-                       "--log-file="+self.build_dir+"/valgrind.log"
+                       "--suppressions=" + ZEPHYR_BASE + "/scripts/valgrind.supp",
+                       "--log-file=" + self.build_dir + "/valgrind.log"
                        ] + command
             run_valgrind = True
 
         logger.debug("Spawning process: " +
-                " ".join(shlex.quote(word) for word in command) + os.linesep +
-                "in directory: " + self.build_dir)
+                     " ".join(shlex.quote(word) for word in command) + os.linesep +
+                     "in directory: " + self.build_dir)
 
         start_time = time.time()
 
         env = os.environ.copy()
         if self.asan:
             env["ASAN_OPTIONS"] = "log_path=stdout:" + \
-                    env.get("ASAN_OPTIONS", "")
+                                  env.get("ASAN_OPTIONS", "")
             if not self.lsan:
                 env["ASAN_OPTIONS"] += "detect_leaks=0"
         with subprocess.Popen(command, stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE, cwd=self.build_dir, env=env) as proc:
+                              stderr=subprocess.PIPE, cwd=self.build_dir, env=env) as proc:
             logger.debug("Spawning BinaryHandler Thread for %s" % self.name)
-            t = threading.Thread(target=self._output_reader, args=(proc, harness, ), daemon=True)
+            t = threading.Thread(target=self._output_reader, args=(proc, harness,), daemon=True)
             t.start()
             t.join(self.timeout)
             if t.is_alive():
@@ -600,7 +595,7 @@ class BinaryHandler(Handler):
 
         if self.coverage:
             subprocess.call(["GCOV_PREFIX=" + self.build_dir,
-                "gcov", self.sourcedir, "-b", "-s", self.build_dir], shell=True)
+                             "gcov", self.sourcedir, "-b", "-s", self.build_dir], shell=True)
 
         self.try_kill_process_by_pid()
 
@@ -611,8 +606,8 @@ class BinaryHandler(Handler):
         self.instance.results = harness.tests
 
         if not self.terminated and self.returncode != 0:
-            #When a process is killed, the default handler returns 128 + SIGTERM
-            #so in that case the return code itself is not meaningful
+            # When a process is killed, the default handler returns 128 + SIGTERM
+            # so in that case the return code itself is not meaningful
             self.set_state("failed", handler_time)
             self.instance.reason = "Handler Error"
         elif run_valgrind and self.returncode == 2:
@@ -652,7 +647,7 @@ class DeviceHandler(Handler):
                 ser.close()
                 break
             if ser_fileno not in readable:
-                continue        # Timeout.
+                continue  # Timeout.
 
             serial_line = None
             try:
@@ -722,7 +717,6 @@ class DeviceHandler(Handler):
         else:
             command = [get_generator()[0], "-C", self.build_dir, "flash"]
 
-
         while not self.device_is_available(self.instance.platform.name):
             time.sleep(1)
 
@@ -745,28 +739,28 @@ class DeviceHandler(Handler):
             elif runner == "openocd" and product == "STM32 STLink":
                 command.append('--')
                 command.append("--cmd-pre-init")
-                command.append("hla_serial %s" %(board_id))
+                command.append("hla_serial %s" % (board_id))
             elif runner == "openocd" and product == "EDBG CMSIS-DAP":
                 command.append('--')
                 command.append("--cmd-pre-init")
-                command.append("cmsis_dap_serial %s" %(board_id))
+                command.append("cmsis_dap_serial %s" % (board_id))
             elif runner == "jlink":
-                command.append("--tool-opt=-SelectEmuBySN  %s" %(board_id))
+                command.append("--tool-opt=-SelectEmuBySN  %s" % (board_id))
 
         serial_device = hardware['serial']
 
         try:
             ser = serial.Serial(
-                    serial_device,
-                    baudrate=115200,
-                    parity=serial.PARITY_NONE,
-                    stopbits=serial.STOPBITS_ONE,
-                    bytesize=serial.EIGHTBITS,
-                    timeout=self.timeout
-                    )
+                serial_device,
+                baudrate=115200,
+                parity=serial.PARITY_NONE,
+                stopbits=serial.STOPBITS_ONE,
+                bytesize=serial.EIGHTBITS,
+                timeout=self.timeout
+            )
         except serial.SerialException as e:
             self.set_state("failed", 0)
-            logger.error("Serial device error: %s" %(str(e)))
+            logger.error("Serial device error: %s" % (str(e)))
             self.make_device_available(serial_device)
             return
 
@@ -780,7 +774,7 @@ class DeviceHandler(Handler):
         start_time = time.time()
 
         t = threading.Thread(target=self.monitor_serial, daemon=True,
-                            args=(ser, read_pipe, harness))
+                             args=(ser, read_pipe, harness))
         t.start()
 
         d_log = "{}/device.log".format(self.instance.build_dir)
@@ -798,14 +792,14 @@ class DeviceHandler(Handler):
                             dlog_fp.write(stderr.decode())
                 except subprocess.TimeoutExpired:
                     proc.kill()
-                    (stdout, stderr)  = proc.communicate()
+                    (stdout, stderr) = proc.communicate()
                     self.instance.reason = "Device issue (Timeout)"
 
             with open(d_log, "w") as dlog_fp:
                 dlog_fp.write(stderr.decode())
 
         except subprocess.CalledProcessError:
-            os.write(write_pipe, b'x')    # halt the thread
+            os.write(write_pipe, b'x')  # halt the thread
 
         t.join(self.timeout)
         if t.is_alive():
@@ -841,7 +835,6 @@ class QEMUHandler(Handler):
     for these to collect whether the test passed or failed.
     """
 
-
     def __init__(self, instance, type_str):
         """Constructor
 
@@ -852,7 +845,6 @@ class QEMUHandler(Handler):
         self.fifo_fn = os.path.join(instance.build_dir, "qemu-fifo")
 
         self.pid_fn = os.path.join(instance.build_dir, "qemu.pid")
-
 
     @staticmethod
     def _thread(handler, timeout, outdir, logfile, fifo_fn, pid_fn, results, harness):
@@ -925,7 +917,7 @@ class QEMUHandler(Handler):
                 # coverage is enabled since dumping this information can
                 # take some time.
                 if not timeout_extended or harness.capture_coverage:
-                    timeout_extended= True
+                    timeout_extended = True
                     if harness.capture_coverage:
                         timeout_time = time.time() + 30
                     else:
@@ -936,7 +928,7 @@ class QEMUHandler(Handler):
 
         handler_time = time.time() - start_time
         logger.debug("QEMU complete (%s) after %f seconds" %
-                (out_state, handler_time))
+                     (out_state, handler_time))
         handler.set_state(out_state, handler_time)
 
         log_out_fp.close()
@@ -984,7 +976,7 @@ class QEMUHandler(Handler):
         self.thread.start()
         subprocess.call(["stty", "sane"])
 
-        logger.debug("Running %s (%s)" %(self.name, self.type_str))
+        logger.debug("Running %s (%s)" % (self.name, self.type_str))
         command = [get_generator()[0]]
         command += ["-C", self.build_dir, "run"]
 
@@ -1002,7 +994,6 @@ class QEMUHandler(Handler):
 
 
 class SizeCalculator:
-
     alloc_sections = [
         "bss",
         "noinit",
@@ -1010,7 +1001,7 @@ class SizeCalculator:
         "app_noinit",
         "ccm_bss",
         "ccm_noinit"
-        ]
+    ]
 
     rw_sections = [
         "datas",
@@ -1057,7 +1048,7 @@ class SizeCalculator:
         "_GCOV_BSS_SECTION_NAME",
         "gcov",
         "nocache"
-        ]
+    ]
 
     # These get copied into RAM only on non-XIP
     ro_sections = [
@@ -1078,7 +1069,7 @@ class SizeCalculator:
         "vectors",
         "net_socket_register",
         "net_ppp_proto"
-        ]
+    ]
 
     def __init__(self, filename, extra_sections):
         """Constructor
@@ -1101,7 +1092,7 @@ class SizeCalculator:
         # GREP can not be used as it returns an error if the symbol is not
         # found.
         is_xip_command = "nm " + filename + \
-            " | awk '/CONFIG_XIP/ { print $3 }'"
+                         " | awk '/CONFIG_XIP/ { print $3 }'"
         is_xip_output = subprocess.check_output(
             is_xip_command, shell=True, stderr=subprocess.STDOUT).decode(
             "utf-8").strip()
@@ -1156,15 +1147,15 @@ class SizeCalculator:
         for line in objdump_output:
             words = line.split()
 
-            if not words:               # Skip lines that are too short
+            if not words:  # Skip lines that are too short
                 continue
 
             index = words[0]
-            if not index[0].isdigit():        # Skip lines that do not start
-                continue                        # with a digit
+            if not index[0].isdigit():  # Skip lines that do not start
+                continue  # with a digit
 
-            name = words[1]                     # Skip lines with section names
-            if name[0] == '.':                # starting with '.'
+            name = words[1]  # Skip lines with section names
+            if name[0] == '.':  # starting with '.'
                 continue
 
             # TODO this doesn't actually reflect the size in flash or RAM as
@@ -1214,9 +1205,9 @@ class SizeCalculator:
 # XXX Be sure to update __doc__ if you change any of this!!
 
 platform_valid_keys = {
-                       "supported_toolchains": {"type": "list", "default": []},
-                       "env": {"type": "list", "default": []}
-                       }
+    "supported_toolchains": {"type": "list", "default": []},
+    "env": {"type": "list", "default": []}
+}
 
 testcase_valid_keys = {"tags": {"type": "set", "required": False},
                        "type": {"type": "str", "default": "integration"},
@@ -1265,7 +1256,6 @@ class SanityConfigParser:
             self.tests = self.data['tests']
         if 'common' in self.data:
             self.common = self.data['common']
-
 
     def _cast_value(self, value, typestr):
         if isinstance(value, str):
@@ -1377,7 +1367,7 @@ class SanityConfigParser:
                 except ValueError:
                     raise ConfigurationError(
                         self.filename, "bad %s value '%s' for key '%s' in name '%s'" %
-                        (kinfo["type"], d[k], k, name))
+                                       (kinfo["type"], d[k], k, name))
 
         return d
 
@@ -1388,7 +1378,7 @@ class Platform:
     Maps directly to BOARD when building"""
 
     platform_schema = scl.yaml_load(os.path.join(ZEPHYR_BASE,
-            "scripts","sanity_chk","platform-schema.yaml"))
+                                                 "scripts", "sanity_chk", "platform-schema.yaml"))
 
     def __init__(self):
         """Constructor.
@@ -1503,7 +1493,6 @@ class TestCase(object):
         self.min_flash = None
         self.extra_sections = None
 
-
     @staticmethod
     def get_unique(testcase_root, workdir, name):
 
@@ -1529,7 +1518,7 @@ class TestCase(object):
             br"^\s*ztest_test_suite\(\s*(?P<suite_name>[a-zA-Z0-9_]+)\s*,",
             re.MULTILINE)
         stc_regex = re.compile(
-            br"^\s*"		# empy space at the beginning is ok
+            br"^\s*"  # empy space at the beginning is ok
             # catch the case where it is declared in the same sentence, e.g:
             #
             # ztest_test_suite(mutex_complex, ztest_user_unit_test(TESTNAME));
@@ -1554,9 +1543,10 @@ class TestCase(object):
 
         with open(inf_name) as inf:
             if os.name == 'nt':
-                mmap_args = {'fileno':inf.fileno(), 'length':0, 'access':mmap.ACCESS_READ}
+                mmap_args = {'fileno': inf.fileno(), 'length': 0, 'access': mmap.ACCESS_READ}
             else:
-                mmap_args = {'fileno':inf.fileno(), 'length':0, 'flags':mmap.MAP_PRIVATE, 'prot':mmap.PROT_READ, 'offset':0}
+                mmap_args = {'fileno': inf.fileno(), 'length': 0, 'flags': mmap.MAP_PRIVATE, 'prot': mmap.PROT_READ,
+                             'offset': 0}
 
             with contextlib.closing(mmap.mmap(**mmap_args)) as main_c:
                 # contextlib makes pylint think main_c isn't subscriptable
@@ -1581,7 +1571,7 @@ class TestCase(object):
                 _matches = re.findall(
                     stc_regex,
                     main_c[suite_regex_match.end():suite_run_match.start()])
-                matches = [ match.decode().replace("test_", "") for match in _matches ]
+                matches = [match.decode().replace("test_", "") for match in _matches]
                 return matches, warnings
 
     def scan_path(self, path):
@@ -1674,10 +1664,10 @@ class TestInstance:
             self.run = False
             return
 
-        runnable =bool(self.testcase.type == "unit" or \
-            self.platform.type == "native" or \
-            self.platform.simulation in ["nsim", "renode", "qemu"] or \
-            device_testing)
+        runnable = bool(self.testcase.type == "unit" or \
+                        self.platform.type == "native" or \
+                        self.platform.simulation in ["nsim", "renode", "qemu"] or \
+                        device_testing)
 
         if self.platform.simulation == "nsim":
             if not find_executable("nsimdrv"):
@@ -1693,8 +1683,8 @@ class TestInstance:
             # if we have a fixture that is also being supplied on the
             # command-line, then we need to run the test, not just build it.
             if "fixture" in self.testcase.harness_config:
-                fixture = self.testcase.harness_config['fixture']
-                if fixture in fixture:
+                fixture_cfg = self.testcase.harness_config['fixture']
+                if fixture_cfg in fixture:
                     _build_only = False
                 else:
                     _build_only = True
@@ -1755,7 +1745,6 @@ class TestInstance:
 
 
 class CMake():
-
     config_re = re.compile('(CONFIG_[A-Za-z0-9_]+)[=]\"?([^\"]*)\"?$')
     dt_re = re.compile('([A-Za-z0-9_]+)[=]\"?([^\"]*)\"?$')
 
@@ -1801,7 +1790,7 @@ class CMake():
 
         results = {}
         if p.returncode == 0:
-            msg = "Finished building %s for %s" %(self.source_dir, self.platform.name)
+            msg = "Finished building %s for %s" % (self.source_dir, self.platform.name)
 
             self.instance.status = "passed"
             results = {'msg': msg, "returncode": p.returncode, "instance": self.instance}
@@ -1833,26 +1822,26 @@ class CMake():
                     self.instance.reason = "Build failure"
 
             results = {
-                    "returncode": p.returncode,
-                    "instance": self.instance,
-                    }
+                "returncode": p.returncode,
+                "instance": self.instance,
+            }
 
         return results
 
     def run_cmake(self, args=[]):
 
         ldflags = "-Wl,--fatal-warnings"
-        logger.debug("Running cmake on %s for %s" %(self.source_dir, self.platform.name))
+        logger.debug("Running cmake on %s for %s" % (self.source_dir, self.platform.name))
 
         # fixme: add additional cflags based on options
         cmake_args = [
-                '-B{}'.format(self.build_dir),
-                '-S{}'.format(self.source_dir),
-                '-DEXTRA_CFLAGS="-Werror ',
-                '-DEXTRA_AFLAGS=-Wa,--fatal-warnings',
-                '-DEXTRA_LDFLAGS="{}'.format(ldflags),
-                '-G{}'.format(get_generator()[1])
-                ]
+            '-B{}'.format(self.build_dir),
+            '-S{}'.format(self.source_dir),
+            '-DEXTRA_CFLAGS="-Werror ',
+            '-DEXTRA_AFLAGS=-Wa,--fatal-warnings',
+            '-DEXTRA_LDFLAGS="{}'.format(ldflags),
+            '-G{}'.format(get_generator()[1])
+        ]
 
         if options.cmake_only:
             cmake_args.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=1")
@@ -1880,7 +1869,7 @@ class CMake():
 
         if p.returncode == 0:
             filter_results = self.parse_generated()
-            msg = "Finished building %s for %s" %(self.source_dir, self.platform.name)
+            msg = "Finished building %s for %s" % (self.source_dir, self.platform.name)
 
             results = {'msg': msg, 'filter': filter_results}
 
@@ -1984,7 +1973,8 @@ class ProjectBuilder(FilterBuilder):
         self.coverage = kwargs.get('coverage', False)
         self.inline_logs = kwargs.get('inline_logs', False)
 
-    def log_info(self, filename, inline_logs):
+    @staticmethod
+    def log_info(filename, inline_logs):
         filename = os.path.relpath(os.path.realpath(filename))
         if inline_logs:
             logger.info("{:-^100}".format(filename))
@@ -2078,7 +2068,7 @@ class ProjectBuilder(FilterBuilder):
                     pipeline.put({"op": "build", "test": self.instance})
 
         elif op == "build":
-            logger.debug("build test: %s" %self.instance.name)
+            logger.debug("build test: %s" % self.instance.name)
             results = self.build()
 
             if results.get('returncode', 1) > 0:
@@ -2090,7 +2080,7 @@ class ProjectBuilder(FilterBuilder):
                     pipeline.put({"op": "report", "test": self.instance})
         # Run the generated binary using one of the supported handlers
         elif op == "run":
-            logger.debug("run test: %s" %self.instance.name)
+            logger.debug("run test: %s" % self.instance.name)
             self.run()
             self.instance.status, _ = self.instance.handler.get_state()
             pipeline.put({
@@ -2099,7 +2089,7 @@ class ProjectBuilder(FilterBuilder):
                 "state": "executed",
                 "status": self.instance.status,
                 "reason": self.instance.reason}
-                )
+            )
 
         # Report results and output progress to screen
         elif op == "report":
@@ -2151,22 +2141,22 @@ class ProjectBuilder(FilterBuilder):
                 instance.testcase.name, status, more_info))
 
             if instance.status in ["failed", "timeout"]:
-                self.log_info_file(inline_logs)
+                self.log_info_file(self.inline_logs)
         else:
             sys.stdout.write("\rINFO    - Total complete: %s%4d/%4d%s  %2d%%  skipped: %s%4d%s, failed: %s%4d%s" % (
-                        COLOR_GREEN,
-                        self.suite.total_done,
-                        self.suite.total_tests,
-                        COLOR_NORMAL,
-                        int((float(self.suite.total_done) / self.suite.total_tests) * 100),
-                        COLOR_YELLOW if self.suite.total_skipped > 0 else COLOR_NORMAL,
-                        self.suite.total_skipped,
-                        COLOR_NORMAL,
-                        COLOR_RED if self.suite.total_failed > 0 else COLOR_NORMAL,
-                        self.suite.total_failed,
-                        COLOR_NORMAL
-                        )
-                    )
+                COLOR_GREEN,
+                self.suite.total_done,
+                self.suite.total_tests,
+                COLOR_NORMAL,
+                int((float(self.suite.total_done) / self.suite.total_tests) * 100),
+                COLOR_YELLOW if self.suite.total_skipped > 0 else COLOR_NORMAL,
+                self.suite.total_skipped,
+                COLOR_NORMAL,
+                COLOR_RED if self.suite.total_failed > 0 else COLOR_NORMAL,
+                self.suite.total_failed,
+                COLOR_NORMAL
+            )
+                             )
         sys.stdout.flush()
 
     def cmake(self):
@@ -2190,9 +2180,9 @@ class ProjectBuilder(FilterBuilder):
 
         if (self.testcase.extra_configs or self.coverage or
                 self.asan):
-            args.append("OVERLAY_CONFIG=\"%s %s\"" %(overlays,
-                        os.path.join(instance.build_dir,
-                                     "sanitycheck", "testcase_extra.conf")))
+            args.append("OVERLAY_CONFIG=\"%s %s\"" % (overlays,
+                                                      os.path.join(instance.build_dir,
+                                                                   "sanitycheck", "testcase_extra.conf")))
 
         results = self.run_cmake(args)
         return results
@@ -2223,6 +2213,7 @@ class BoundedExecutor(concurrent.futures.ThreadPoolExecutor):
     :param bound: Integer - the maximum number of items in the work queue
     :param max_workers: Integer - the size of the thread pool
     """
+
     def __init__(self, bound, max_workers, **kwargs):
         super().__init__(max_workers)
         # self.executor = ThreadPoolExecutor(max_workers=max_workers)
@@ -2341,7 +2332,7 @@ class TestSuite:
                 delta = instance.metrics.get(metric, 0) - mtype(sm[metric])
                 if delta == 0:
                     continue
-                results.append((instance, metric, instance.metrics.get(metric, 0 ), delta,
+                results.append((instance, metric, instance.metrics.get(metric, 0), delta,
                                 lower_better))
         return results
 
@@ -2356,23 +2347,23 @@ class TestSuite:
         if deltas and show_footprint:
             for i, metric, value, delta, lower_better in deltas:
                 if not all_deltas and ((delta < 0 and lower_better) or
-                                            (delta > 0 and not lower_better)):
+                                       (delta > 0 and not lower_better)):
                     continue
 
                 percentage = (float(delta) / float(value - delta))
                 if not all_deltas and (percentage <
-                                            (footprint_threshold / 100.0)):
+                                       (footprint_threshold / 100.0)):
                     continue
 
-                info("{:<25} {:<60} {}{}{}: {} {:<+4}, is now {:6} {:+.2%}".format(
-                     i.platform.name, i.testcase.name, COLOR_YELLOW,
-                     "INFO" if all_deltas else "WARNING", COLOR_NORMAL,
-                     metric, delta, value, percentage))
+                logger.info("{:<25} {:<60} {}{}{}: {} {:<+4}, is now {:6} {:+.2%}".format(
+                    i.platform.name, i.testcase.name, COLOR_YELLOW,
+                    "INFO" if all_deltas else "WARNING", COLOR_NORMAL,
+                    metric, delta, value, percentage))
                 warnings += 1
 
         if warnings:
             logger.warning("Deltas based on metrics from last %s" %
-                 ("release" if not last_metrics else "run"))
+                           ("release" if not last_metrics else "run"))
 
     def summary(self, unrecognized_sections):
         failed = 0
@@ -2381,29 +2372,31 @@ class TestSuite:
                 failed += 1
             elif instance.metrics.get("unrecognized") and not unrecognized_sections:
                 logger.error("%sFAILED%s: %s has unrecognized binary sections: %s" %
-                     (COLOR_RED, COLOR_NORMAL, instance.name,
-                      str(instance.metrics.get("unrecognized", []))))
+                             (COLOR_RED, COLOR_NORMAL, instance.name,
+                              str(instance.metrics.get("unrecognized", []))))
                 failed += 1
 
         if self.total_tests and self.total_tests != self.total_skipped:
-            pass_rate = (float(self.total_tests - self.total_failed - self.total_skipped)/ float(self.total_tests - self.total_skipped))
+            pass_rate = (float(self.total_tests - self.total_failed - self.total_skipped) / float(
+                self.total_tests - self.total_skipped))
         else:
             pass_rate = 0
 
-        logger.info("{}{} of {}{} tests passed ({:.2%}), {}{}{} failed, {} skipped with {}{}{} warnings in {:.2f} seconds".format(
-            COLOR_RED if failed else COLOR_GREEN,
-            self.total_tests - self.total_failed - self.total_skipped,
-            self.total_tests,
-            COLOR_NORMAL,
-            pass_rate,
-            COLOR_RED if self.total_failed else COLOR_NORMAL,
-            self.total_failed,
-            COLOR_NORMAL,
-            self.total_skipped,
-            COLOR_YELLOW if self.warnings else COLOR_NORMAL,
-            self.warnings,
-            COLOR_NORMAL,
-            self.duration))
+        logger.info(
+            "{}{} of {}{} tests passed ({:.2%}), {}{}{} failed, {} skipped with {}{}{} warnings in {:.2f} seconds".format(
+                COLOR_RED if failed else COLOR_GREEN,
+                self.total_tests - self.total_failed - self.total_skipped,
+                self.total_tests,
+                COLOR_NORMAL,
+                pass_rate,
+                COLOR_RED if self.total_failed else COLOR_NORMAL,
+                self.total_failed,
+                COLOR_NORMAL,
+                self.total_skipped,
+                COLOR_YELLOW if self.warnings else COLOR_NORMAL,
+                self.warnings,
+                COLOR_NORMAL,
+                self.duration))
 
         self.total_platforms = len(self.platforms)
         if self.platforms:
@@ -2447,7 +2440,7 @@ class TestSuite:
             board_root = os.path.abspath(board_root)
 
             logger.debug("Reading platform configuration files under %s..." %
-                board_root)
+                         board_root)
 
             for file in glob.glob(os.path.join(board_root, "*", "*", "*.yaml")):
                 logger.debug("Found plaform configuration " + file)
@@ -2462,7 +2455,6 @@ class TestSuite:
                 except RuntimeError as e:
                     logger.error("E: %s: can't load: %s" % (file, e))
                     self.load_errors += 1
-
 
     def get_all_tests(self):
         tests = []
@@ -2494,7 +2486,7 @@ class TestSuite:
         for root in self.roots:
             root = os.path.abspath(root)
 
-            logger.debug("Reading test case configuration files under %s..." %root)
+            logger.debug("Reading test case configuration files under %s..." % root)
 
             for dirpath, dirnames, filenames in os.walk(root, topdown=True):
                 logger.debug("scanning %s" % dirpath)
@@ -2576,7 +2568,7 @@ class TestSuite:
         last_run = os.path.join(self.outdir, "sanitycheck.csv")
         try:
             if not os.path.exists(last_run):
-                raise SanityRuntimeError("Couldn't find last sanitycheck run.: %s" %last_run)
+                raise SanityRuntimeError("Couldn't find last sanitycheck run.: %s" % last_run)
         except Exception as e:
             print(str(e))
             sys.exit(2)
@@ -2597,13 +2589,13 @@ class TestSuite:
                     self.enable_slow,
                     self.device_testing,
                     self.fixture
-                    )
+                )
                 instance.create_overlay(platform, self.enable_asan, self.enable_coverage, self.coverage_platform)
                 instance_list.append(instance)
             self.add_instances(instance_list)
 
         tests_to_run = len(self.instances)
-        logger.info("%d tests passed already, retrying %d tests" %(total_tests - tests_to_run, tests_to_run))
+        logger.info("%d tests passed already, retrying %d tests" % (total_tests - tests_to_run, tests_to_run))
 
     def load_from_file(self, file):
         try:
@@ -2628,7 +2620,7 @@ class TestSuite:
                     self.enable_slow,
                     self.device_testing,
                     self.fixture
-                    )
+                )
                 instance.create_overlay(platform, self.enable_asan, self.enable_coverage, self.coverage_platform)
                 instance_list.append(instance)
             self.add_instances(instance_list)
@@ -2679,7 +2671,7 @@ class TestSuite:
                     self.enable_slow,
                     self.device_testing,
                     self.fixture
-                    )
+                )
 
                 if (plat.arch == "unit") != (tc.type == "unit"):
                     # Discard silently
@@ -2745,8 +2737,8 @@ class TestSuite:
                     continue
 
                 if not force_toolchain \
-                    and toolchain and (toolchain not in plat.supported_toolchains) \
-                    and tc.type != 'unit':
+                        and toolchain and (toolchain not in plat.supported_toolchains) \
+                        and tc.type != 'unit':
                     discards[instance] = "Not supported by the toolchain"
                     continue
 
@@ -2784,12 +2776,12 @@ class TestSuite:
                     b = set(tc.platform_whitelist)
                     c = a.intersection(b)
                     if c:
-                        aa = list( filter( lambda tc: tc.platform.name in c, instance_list))
+                        aa = list(filter(lambda tc: tc.platform.name in c, instance_list))
                         self.add_instances(aa)
                     else:
                         self.add_instances(instance_list[:1])
                 else:
-                    instances = list( filter( lambda tc: tc.platform.default, instance_list))
+                    instances = list(filter(lambda tc: tc.platform.default, instance_list))
                     self.add_instances(instances)
 
                 for instance in list(filter(lambda tc: not tc.platform.default, instance_list)):
@@ -2843,13 +2835,13 @@ class TestSuite:
 
             # start a future for a thread which sends work in through the queue
             future_to_test = {
-                    executor.submit(self.add_tasks_to_queue, self.test_only): 'FEEDER DONE'}
+                executor.submit(self.add_tasks_to_queue, self.test_only): 'FEEDER DONE'}
 
             while future_to_test:
                 # check for status of the futures which are currently working
                 done, _ = concurrent.futures.wait(
-                        future_to_test, timeout=0.25,
-                        return_when=concurrent.futures.FIRST_COMPLETED)
+                    future_to_test, timeout=0.25,
+                    return_when=concurrent.futures.FIRST_COMPLETED)
 
                 # if there is incoming work, start a new future
                 while not pipeline.empty():
@@ -2859,16 +2851,16 @@ class TestSuite:
 
                     # Start the load operation and mark the future with its URL
                     pb = ProjectBuilder(self,
-                        test,
-                        lsan = self.enable_lsan,
-                        asan = self.enable_asan,
-                        coverage = self.enable_coverage,
-                        extra_args = self.extra_args,
-                        device_testing = self.device_testing,
-                        cmake_only = self.cmake_only,
-                        valgrind = self.enable_valgrind,
-                        inline_logs = self.inline_logs
-                        )
+                                        test,
+                                        lsan=self.enable_lsan,
+                                        asan=self.enable_asan,
+                                        coverage=self.enable_coverage,
+                                        extra_args=self.extra_args,
+                                        device_testing=self.device_testing,
+                                        cmake_only=self.cmake_only,
+                                        valgrind=self.enable_valgrind,
+                                        inline_logs=self.inline_logs
+                                        )
                     future_to_test[executor.submit(pb.process, message)] = test.name
 
                 # process any completed futures
@@ -2923,7 +2915,7 @@ class TestSuite:
         run = "Sanitycheck"
         eleTestsuite = None
 
-        platforms = {inst.platform.name for _,inst in self.instances.items()}
+        platforms = {inst.platform.name for _, inst in self.instances.items()}
         for platform in platforms:
             errors = 0
             passes = 0
@@ -2948,10 +2940,10 @@ class TestSuite:
 
             eleTestsuites = ET.Element('testsuites')
             eleTestsuite = ET.SubElement(eleTestsuites, 'testsuite',
-                                        name=run, time="%f" % duration,
-                                        tests="%d" % (errors + passes + fails),
-                                        failures="%d" % fails,
-                                        errors="%d" % errors, skipped="%d" %skips)
+                                         name=run, time="%f" % duration,
+                                         tests="%d" % (errors + passes + fails),
+                                         failures="%d" % fails,
+                                         errors="%d" % errors, skipped="%d" % skips)
 
             handler_time = 0
 
@@ -2962,8 +2954,9 @@ class TestSuite:
                 handler_time = instance.metrics.get('handler_time', 0)
                 for k in instance.results.keys():
                     eleTestcase = ET.SubElement(
-                            eleTestsuite, 'testcase', classname="%s:%s" %(instance.platform.name, os.path.basename(instance.testcase.name)),
-                            name="%s" % (k), time="%f" %handler_time)
+                        eleTestsuite, 'testcase',
+                        classname="%s:%s" % (instance.platform.name, os.path.basename(instance.testcase.name)),
+                        name="%s" % (k), time="%f" % handler_time)
                     if instance.results[k] in ['FAIL', 'BLOCK']:
                         el = None
 
@@ -2994,7 +2987,6 @@ class TestSuite:
                             'skipped',
                             type="skipped",
                             message="Skipped")
-
 
             result = ET.tostring(eleTestsuites)
             with open(os.path.join(outdir, platform + ".xml"), 'wb') as f:
@@ -3035,7 +3027,7 @@ class TestSuite:
                                          name=run, time="%f" % duration,
                                          tests="%d" % (errors + passes + fails + skips),
                                          failures="%d" % fails,
-                                         errors="%d" %(errors), skip="%s" %(skips))
+                                         errors="%d" % (errors), skip="%s" % (skips))
 
         for instance in self.instances.values():
 
@@ -3050,10 +3042,13 @@ class TestSuite:
             if instance.status != "failed" and instance.handler:
                 handler_time = instance.metrics.get("handler_time", 0)
 
+
             eleTestcase = ET.SubElement(
-                eleTestsuite, 'testcase', classname="%s:%s" %
-                (instance.platform.name, instance.testcase.name), name="%s" %
-                (instance.testcase.name), time="%f" %handler_time)
+                eleTestsuite,
+                'testcase',
+                classname="%s:%s" % (instance.platform.name, instance.testcase.name),
+                name="%s" % (instance.testcase.name),
+                time="%f" % handler_time)
 
             if instance.status == "failed":
                 failure = ET.SubElement(
@@ -3078,7 +3073,7 @@ class TestSuite:
                         failure.text = filtered_string
                         f.close()
             elif instance.status == "skipped":
-                ET.SubElement( eleTestcase, 'skipped', type="skipped", message="Skipped")
+                ET.SubElement(eleTestcase, 'skipped', type="skipped", message="Skipped")
 
         result = ET.tostring(eleTestsuites)
         with open(filename, 'wb') as report:
@@ -3111,7 +3106,6 @@ class TestSuite:
                     rowdict["rom_size"] = rom_size
                 cw.writerow(rowdict)
 
-
     def get_testcase(self, identifier):
         results = []
         for _, tc in self.testcases.items():
@@ -3122,7 +3116,6 @@ class TestSuite:
 
 
 def parse_arguments():
-
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -3142,34 +3135,34 @@ Artificially long but functional example:
     """)
 
     parser.add_argument("--force-toolchain", action="store_true",
-            help="Do not filter based on toolchain, use the set "
-            " toolchain unconditionally")
+                        help="Do not filter based on toolchain, use the set "
+                             " toolchain unconditionally")
     parser.add_argument(
         "-p", "--platform", action="append",
         help="Platform filter for testing. This option may be used multiple "
-        "times. Testcases will only be built/run on the platforms "
-        "specified. If this option is not used, then platforms marked "
-        "as default in the platform metadata file will be chosen "
-        "to build and test. ")
+             "times. Testcases will only be built/run on the platforms "
+             "specified. If this option is not used, then platforms marked "
+             "as default in the platform metadata file will be chosen "
+             "to build and test. ")
     parser.add_argument(
         "-a", "--arch", action="append",
         help="Arch filter for testing. Takes precedence over --platform. "
-        "If unspecified, test all arches. Multiple invocations "
-        "are treated as a logical 'or' relationship")
+             "If unspecified, test all arches. Multiple invocations "
+             "are treated as a logical 'or' relationship")
     parser.add_argument(
         "-t", "--tag", action="append",
         help="Specify tags to restrict which tests to run by tag value. "
-        "Default is to not do any tag filtering. Multiple invocations "
-        "are treated as a logical 'or' relationship")
+             "Default is to not do any tag filtering. Multiple invocations "
+             "are treated as a logical 'or' relationship")
     parser.add_argument("-e", "--exclude-tag", action="append",
                         help="Specify tags of tests that should not run. "
-                        "Default is to run all tests with all tags.")
+                             "Default is to run all tests with all tags.")
     case_select.add_argument(
         "-f",
         "--only-failed",
         action="store_true",
         help="Run only those tests that failed the previous sanity check "
-        "invocation.")
+             "invocation.")
 
     parser.add_argument(
         "--retry-failed", type=int, default=0,
@@ -3180,7 +3173,7 @@ Artificially long but functional example:
     test_xor_subtest.add_argument(
         "-s", "--test", action="append",
         help="Run only the specified test cases. These are named by "
-        "<path/relative/to/Zephyr/base/section.name.in.testcase.yaml>")
+             "<path/relative/to/Zephyr/base/section.name.in.testcase.yaml>")
 
     test_xor_subtest.add_argument(
         "--sub-test", action="append",
@@ -3194,7 +3187,7 @@ Artificially long but functional example:
     parser.add_argument(
         "-l", "--all", action="store_true",
         help="Build/test on all platforms. Any --platform arguments "
-        "ignored.")
+             "ignored.")
 
     parser.add_argument(
         "-o", "--report-dir",
@@ -3210,8 +3203,8 @@ Artificially long but functional example:
         """)
 
     parser.add_argument("--report-excluded",
-            action="store_true",
-            help="""List all tests that are never run based on current scope and
+                        action="store_true",
+                        help="""List all tests that are never run based on current scope and
             coverage. If you are looking for accurate results, run this with
             --all, but this will take a while...""")
 
@@ -3221,9 +3214,9 @@ Artificially long but functional example:
     parser.add_argument(
         "-B", "--subset",
         help="Only run a subset of the tests, 1/4 for running the first 25%%, "
-        "3/5 means run the 3rd fifth of the total. "
-        "This option is useful when running a large number of tests on "
-        "different hosts to speed up execution time.")
+             "3/5 means run the 3rd fifth of the total. "
+             "This option is useful when running a large number of tests on "
+             "different hosts to speed up execution time.")
 
     parser.add_argument(
         "-N", "--ninja", action="store_true",
@@ -3238,10 +3231,10 @@ Artificially long but functional example:
         """)
 
     parser.add_argument("--list-tags", action="store_true",
-            help="list all tags in selected tests")
+                        help="list all tags in selected tests")
 
     case_select.add_argument("--list-tests", action="store_true",
-        help="""List of all sub-test functions recursively found in
+                             help="""List of all sub-test functions recursively found in
         all --testcase-root arguments. Note different sub-tests can share
         the same section name and come from different directories.
         The output is flattened and reports --sub-test names only,
@@ -3250,27 +3243,26 @@ Artificially long but functional example:
         """)
 
     case_select.add_argument("--test-tree", action="store_true",
-        help="""Output the testsuite in a tree form""")
+                             help="""Output the testsuite in a tree form""")
 
     case_select.add_argument("--list-test-duplicates", action="store_true",
-        help="""List tests with duplicate identifiers.
+                             help="""List tests with duplicate identifiers.
         """)
 
     parser.add_argument("--export-tests", action="store",
-            metavar="FILENAME",
-            help="Export tests case meta-data to a file in CSV format.")
-
+                        metavar="FILENAME",
+                        help="Export tests case meta-data to a file in CSV format.")
 
     parser.add_argument("--timestamps",
-            action="store_true",
-            help="Print all messages with time stamps")
+                        action="store_true",
+                        help="Print all messages with time stamps")
 
     parser.add_argument(
         "-r", "--release", action="store_true",
         help="Update the benchmark database with the results of this test "
-        "run. Intended to be run by CI when tagging an official "
-        "release. This database is used as a basis for comparison "
-        "when looking for deltas in metrics such as footprint")
+             "run. Intended to be run by CI when tagging an official "
+             "release. This database is used as a basis for comparison "
+             "when looking for deltas in metrics such as footprint")
     parser.add_argument("-w", "--warnings-as-errors", action="store_true",
                         help="Treat warning conditions as errors")
     parser.add_argument(
@@ -3279,24 +3271,24 @@ Artificially long but functional example:
         action="count",
         default=0,
         help="Emit debugging information, call multiple times to increase "
-        "verbosity")
+             "verbosity")
     parser.add_argument(
         "-i", "--inline-logs", action="store_true",
         help="Upon test failure, print relevant log data to stdout "
-        "instead of just a path to it")
+             "instead of just a path to it")
     parser.add_argument("--log-file", metavar="FILENAME", action="store",
                         help="log also to file")
     parser.add_argument(
         "-m", "--last-metrics", action="store_true",
         help="Instead of comparing metrics from the last --release, "
-        "compare with the results of the previous sanity check "
-        "invocation")
+             "compare with the results of the previous sanity check "
+             "invocation")
     parser.add_argument(
         "-u",
         "--no-update",
         action="store_true",
         help="do not update the results of the last run of the sanity "
-        "checks")
+             "checks")
     case_select.add_argument(
         "-F",
         "--load-tests",
@@ -3327,38 +3319,38 @@ Artificially long but functional example:
     parser.add_argument(
         "-j", "--jobs", type=int,
         help="Number of jobs for building, defaults to number of CPU threads, "
-        "overcommited by factor 2 when --build-only")
+             "overcommited by factor 2 when --build-only")
 
     parser.add_argument(
-            "--show-footprint", action="store_true",
-            help="Show footprint statistics and deltas since last release."
-            )
+        "--show-footprint", action="store_true",
+        help="Show footprint statistics and deltas since last release."
+    )
     parser.add_argument(
         "-H", "--footprint-threshold", type=float, default=5,
         help="When checking test case footprint sizes, warn the user if "
-        "the new app size is greater then the specified percentage "
-        "from the last release. Default is 5. 0 to warn on any "
-        "increase on app size")
+             "the new app size is greater then the specified percentage "
+             "from the last release. Default is 5. 0 to warn on any "
+             "increase on app size")
     parser.add_argument(
         "-D", "--all-deltas", action="store_true",
         help="Show all footprint deltas, positive or negative. Implies "
-        "--footprint-threshold=0")
+             "--footprint-threshold=0")
     parser.add_argument(
         "-O", "--outdir",
-        default=os.path.join(os.getcwd(),"sanity-out"),
+        default=os.path.join(os.getcwd(), "sanity-out"),
         help="Output directory for logs and binaries. "
-        "Default is 'sanity-out' in the current directory. "
-        "This directory will be deleted unless '--no-clean' is set.")
+             "Default is 'sanity-out' in the current directory. "
+             "This directory will be deleted unless '--no-clean' is set.")
     parser.add_argument(
         "-n", "--no-clean", action="store_true",
         help="Do not delete the outdir before building. Will result in "
-        "faster compilation since builds will be incremental")
+             "faster compilation since builds will be incremental")
     case_select.add_argument(
         "-T", "--testcase-root", action="append", default=[],
         help="Base directory to recursively search for test cases. All "
-        "testcase.yaml files under here will be processed. May be "
-        "called multiple times. Defaults to the 'samples/' and "
-        "'tests/' directories at the base of the Zephyr tree.")
+             "testcase.yaml files under here will be processed. May be "
+             "called multiple times. Defaults to the 'samples/' and "
+             "'tests/' directories at the base of the Zephyr tree.")
 
     board_root_list = ["%s/boards" % ZEPHYR_BASE,
                        "%s/scripts/sanity_chk/boards" % ZEPHYR_BASE]
@@ -3372,12 +3364,12 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
     parser.add_argument(
         "-z", "--size", action="append",
         help="Don't run sanity  checks. Instead, produce a report to "
-        "stdout detailing RAM/ROM sizes on the specified filenames. "
-        "All other command line arguments ignored.")
+             "stdout detailing RAM/ROM sizes on the specified filenames. "
+             "All other command line arguments ignored.")
     parser.add_argument(
         "-S", "--enable-slow", action="store_true",
         help="Execute time-consuming test cases that have been marked "
-        "as 'slow' in testcase.yaml. Normally these are only built.")
+             "as 'slow' in testcase.yaml. Normally these are only built.")
     parser.add_argument(
         "--disable-unrecognized-section-test", action="store_true",
         default=False,
@@ -3487,21 +3479,22 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
 
     parser.add_argument("-C", "--coverage", action="store_true",
                         help="Generate coverage reports. Implies "
-                        "--enable_coverage.")
+                             "--enable_coverage.")
 
     parser.add_argument("--coverage-platform", action="append", default=[],
                         help="Plarforms to run coverage reports on. "
-                        "This option may be used multiple times. "
-                        "Default to what was selected with --platform.")
+                             "This option may be used multiple times. "
+                             "Default to what was selected with --platform.")
 
     parser.add_argument("--gcov-tool", default=None,
                         help="Path to the gcov tool to use for code coverage "
-                        "reports")
+                             "reports")
 
     parser.add_argument("--coverage-tool", choices=['lcov', 'gcovr'], default='lcov',
                         help="Tool to use to generate coverage report.")
 
     return parser.parse_args()
+
 
 def size_report(sc):
     logger.info(sc.filename)
@@ -3510,12 +3503,13 @@ def size_report(sc):
         v = sc.sections[i]
 
         logger.info("%-17s 0x%08x 0x%08x %8d 0x%05x %-7s" %
-             (v["name"], v["virt_addr"], v["load_addr"], v["size"], v["size"],
-              v["type"]))
+                    (v["name"], v["virt_addr"], v["load_addr"], v["size"], v["size"],
+                     v["type"]))
 
     logger.info("Totals: %d bytes (ROM), %d bytes (RAM)" %
-         (sc.rom_size, sc.ram_size))
+                (sc.rom_size, sc.ram_size))
     logger.info("")
+
 
 class CoverageTool:
     """ Base class for every supported coverage tool
@@ -3535,7 +3529,7 @@ class CoverageTool:
     @staticmethod
     def retrieve_gcov_data(intput_file):
         if VERBOSE:
-            logger.debug("Working on %s" %intput_file)
+            logger.debug("Working on %s" % intput_file)
         extracted_coverage_info = {}
         capture_data = False
         capture_complete = False
@@ -3561,7 +3555,7 @@ class CoverageTool:
                         continue
                 else:
                     continue
-                extracted_coverage_info.update({file_name:hex_dump})
+                extracted_coverage_info.update({file_name: hex_dump})
         if not capture_data:
             capture_complete = True
         return {'complete': capture_complete, 'data': extracted_coverage_info}
@@ -3574,7 +3568,7 @@ class CoverageTool:
             # if kobject_hash is given for coverage gcovr fails
             # hence skipping it problem only in gcovr v4.1
             if "kobject_hash" in filename:
-                filename = (filename[:-4]) +"gcno"
+                filename = (filename[:-4]) + "gcno"
                 try:
                     os.remove(filename)
                 except Exception:
@@ -3583,7 +3577,6 @@ class CoverageTool:
 
             with open(filename, 'wb') as fp:
                 fp.write(bytes.fromhex(hexdump_val))
-
 
     def generate(self, outdir):
         for filename in glob.glob("%s/**/handler.log" % outdir, recursive=True):
@@ -3725,11 +3718,11 @@ def export_tests(filename, tests):
             if len(data) > 1:
                 subsec = " ".join(data[1].split("_")).title()
                 rowdict = {
-                        "section": data[0].capitalize(),
-                        "subsection": subsec,
-                        "title": test,
-                        "reference": test
-                        }
+                    "section": data[0].capitalize(),
+                    "subsection": subsec,
+                    "title": test,
+                    "reference": test
+                }
                 cw.writerow(rowdict)
             else:
                 logger.info("{} can't be exported".format(test))
@@ -3744,9 +3737,9 @@ def native_and_unit_first(a, b):
         return -1
     if b[0].startswith('native_posix'):
         return 1
-    if a[0].split("/",1)[0].endswith("_bsim"):
+    if a[0].split("/", 1)[0].endswith("_bsim"):
         return -1
-    if b[0].split("/",1)[0].endswith("_bsim"):
+    if b[0].split("/", 1)[0].endswith("_bsim"):
         return 1
 
     return (a > b) - (a < b)
@@ -3762,7 +3755,7 @@ class HardwareMap:
         'Texas Instruments',
         'Silicon Labs',
         'NXP Semiconductors'
-        ]
+    ]
 
     runner_mapping = {
         'pyocd': [
@@ -3819,7 +3812,7 @@ class HardwareMap:
                 s_dev['serial'] = d.device
                 s_dev['product'] = d.product
                 s_dev['runner'] = 'unknown'
-                for runner,_ in self.runner_mapping.items():
+                for runner, _ in self.runner_mapping.items():
                     products = self.runner_mapping.get(runner)
                     if d.product in products:
                         s_dev['runner'] = runner
@@ -3833,7 +3826,7 @@ class HardwareMap:
                 s_dev['connected'] = True
                 self.detected.append(s_dev)
             else:
-                logger.warning("Unsupported device (%s): %s" %(d.manufacturer, d))
+                logger.warning("Unsupported device (%s): %s" % (d.manufacturer, d))
 
     def write_map(self, hwm_file):
         # use existing map
@@ -3852,18 +3845,17 @@ class HardwareMap:
                             h['serial'] = d['serial']
                             d['match'] = True
 
-                new = list(filter(lambda n:  not n.get('match', False), self.detected))
+                new = list(filter(lambda n: not n.get('match', False), self.detected))
                 hwm = hwm + new
 
                 logger.info("Registered devices:")
                 print("")
                 table = []
                 header = ["Platform", "ID", "Serial device"]
-                for p in sorted(hwm, key = lambda i: i['platform']):
+                for p in sorted(hwm, key=lambda i: i['platform']):
                     platform = p.get('platform')
                     table.append([platform, p.get('id', None), p.get('serial')])
                 print(tabulate(table, headers=header, tablefmt="github"))
-
 
             with open(hwm_file, 'w') as yaml_file:
                 yaml.dump(hwm, yaml_file, default_flow_style=False)
@@ -3873,7 +3865,9 @@ class HardwareMap:
             with open(hwm_file, 'w') as yaml_file:
                 yaml.dump(self.detected, yaml_file, default_flow_style=False)
 
+
 options = None
+
 
 def main():
     start_time = time.time()
@@ -3887,7 +3881,7 @@ def main():
         if os.path.exists(options.outdir):
             logger.info("Keeping artifacts untouched")
     elif os.path.exists(options.outdir):
-        for i in range(1,100):
+        for i in range(1, 100):
             new_out = options.outdir + ".{}".format(i)
             if not os.path.exists(new_out):
                 logger.info("Renaming output directory to {}".format(new_out))
@@ -3912,7 +3906,6 @@ def main():
         ch.setLevel(logging.DEBUG)
     else:
         ch.setLevel(logging.INFO)
-
 
     # create formatter and add it to the handlers
     if options.timestamps:
@@ -3967,7 +3960,6 @@ def main():
             size_report(SizeCalculator(fn, []))
         sys.exit(0)
 
-
     if options.subset:
         subset, sets = options.subset.split("/")
         if int(subset) > 0 and int(sets) >= int(subset):
@@ -3976,10 +3968,9 @@ def main():
             logger.error("You have provided a wrong subset value: %s." % options.subset)
             return
 
-
     if not options.testcase_root:
         options.testcase_root = [os.path.join(ZEPHYR_BASE, "tests"),
-                              os.path.join(ZEPHYR_BASE, "samples")]
+                                 os.path.join(ZEPHYR_BASE, "samples")]
 
     if options.show_footprint or options.compare_report or options.release:
         options.enable_size_report = True
@@ -4023,13 +4014,12 @@ def main():
                     if platform['connected']:
                         options.platform.append(platform['platform'])
 
-        elif options.device_serial: #back-ward compatibility
+        elif options.device_serial:  # back-ward compatibility
             if options.platform and len(options.platform) == 1:
                 hwm.load_device_from_cmdline(options.device_serial, options.platform[0])
             else:
                 logger.error("""When --device-testing is used with --device-serial, only one
                       platform is allowed""")
-
 
     if suite.load_errors:
         sys.exit(1)
@@ -4125,7 +4115,6 @@ def main():
                 for pre, _, node in RenderTree(testsuite):
                     print("%s%s" % (pre, node.name))
 
-
             return
 
     discards = []
@@ -4173,7 +4162,7 @@ def main():
     if options.report_excluded:
         all_tests = suite.get_all_tests()
         to_be_run = set()
-        for i,p in suite.instances.items():
+        for i, p in suite.instances.items():
             to_be_run.update(p.testcase.cases)
 
         if all_tests - to_be_run:
@@ -4184,7 +4173,7 @@ def main():
         return
 
     if options.subset:
-        #suite.instances = OrderedDict(sorted(suite.instances.items(),
+        # suite.instances = OrderedDict(sorted(suite.instances.items(),
         #                    key=cmp_to_key(native_and_unit_first)))
         subset, sets = options.subset.split("/")
         total = len(suite.instances)
@@ -4198,13 +4187,12 @@ def main():
         sliced_instances = islice(suite.instances.items(), start, end)
         suite.instances = OrderedDict(sliced_instances)
 
-
     if options.save_tests:
         suite.csv_report(options.save_tests)
         return
 
     logger.info("%d test configurations selected, %d configurations discarded due to filters." %
-        (len(suite.instances), len(discards)))
+                (len(suite.instances), len(discards)))
 
     if options.device_testing:
         print("\nDevice testing on:")
@@ -4232,8 +4220,8 @@ def main():
         completed += 1
 
         if completed > 1:
-            logger.info("%d Iteration:" %(completed ))
-            time.sleep(60) # waiting for the system to settle down
+            logger.info("%d Iteration:" % (completed))
+            time.sleep(60)  # waiting for the system to settle down
             suite.total_done = suite.total_tests - suite.total_failed
             suite.total_failed = 0
 
@@ -4245,7 +4233,7 @@ def main():
             break
 
     suite.misc_reports(options.compare_report, options.show_footprint,
-                options.all_deltas, options.footprint_threshold, options.last_metrics)
+                       options.all_deltas, options.footprint_threshold, options.last_metrics)
 
     suite.duration = time.time() - start_time
     suite.summary(options.disable_unrecognized_section_test)
@@ -4263,7 +4251,7 @@ def main():
                 options.gcov_tool = "gcov"
             else:
                 options.gcov_tool = os.path.join(os.environ["ZEPHYR_SDK_INSTALL_DIR"],
-                    "i586-zephyr-elf/bin/i586-zephyr-elf-gcov")
+                                                 "i586-zephyr-elf/bin/i586-zephyr-elf-gcov")
 
         logger.info("Generating coverage files...")
         coverage_tool = CoverageTool.factory(options.coverage_tool)
@@ -4282,7 +4270,6 @@ def main():
                 table.append(row)
         print(tabulate(table, headers=header, tablefmt="github"))
 
-
     suite.save_reports(options.report_name,
                        options.report_dir,
                        options.no_update,
@@ -4291,6 +4278,7 @@ def main():
 
     if suite.total_failed or (suite.warnings and options.warnings_as_errors):
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -517,9 +517,7 @@ class Handler:
 
     def record(self, harness):
         if harness.recording:
-            filename = os.path.join(options.outdir,
-                    self.instance.platform.name,
-                    self.instance.testcase.name, "recording.csv")
+            filename = os.path.join(self.build_dir, "recording.csv")
             with open(filename, "at") as csvfile:
                 cw = csv.writer(csvfile, harness.fieldnames, lineterminator=os.linesep)
                 cw.writerow(harness.fieldnames)
@@ -1653,7 +1651,7 @@ class TestInstance:
         out directory used is <outdir>/<platform>/<test case name>
     """
 
-    def __init__(self, testcase, platform, base_outdir):
+    def __init__(self, testcase, platform, outdir):
 
         self.testcase = testcase
         self.platform = platform
@@ -1662,10 +1660,10 @@ class TestInstance:
         self.reason = "N/A"
         self.metrics = dict()
         self.handler = None
-
+        self.outdir = outdir
 
         self.name = os.path.join(platform.name, testcase.name)
-        self.build_dir = os.path.join(base_outdir, platform.name, testcase.name)
+        self.build_dir = os.path.join(outdir, platform.name, testcase.name)
 
         self.build_only = self.check_build_or_run()
         self.run = not self.build_only
@@ -2376,8 +2374,8 @@ class TestSuite:
             filename = os.path.join(options.report_dir, report_name)
             outdir = options.report_dir
         else:
-            filename = os.path.join(options.outdir, report_name)
-            outdir = options.outdir
+            filename = os.path.join(self.outdir, report_name)
+            outdir = self.outdir
 
         if not options.no_update:
             self.xunit_report(filename + ".xml")
@@ -2524,7 +2522,7 @@ class TestSuite:
         return selected_platform
 
     def get_last_failed(self):
-        last_run = os.path.join(options.outdir, "sanitycheck.csv")
+        last_run = os.path.join(self.outdir, "sanitycheck.csv")
         try:
             if not os.path.exists(last_run):
                 raise SanityRuntimeError("Couldn't find last sanitycheck run.: %s" %last_run)
@@ -2899,7 +2897,7 @@ class TestSuite:
                                 'error',
                                 type="failure",
                                 message="failed")
-                        p = os.path.join(options.outdir, instance.platform.name, instance.testcase.name)
+                        p = os.path.join(self.outdir, instance.platform.name, instance.testcase.name)
                         log_file = os.path.join(p, "handler.log")
 
                         if os.path.exists(log_file):
@@ -2982,7 +2980,7 @@ class TestSuite:
                     'failure',
                     type="failure",
                     message=instance.reason)
-                p = ("%s/%s/%s" % (options.outdir, instance.platform.name, instance.testcase.name))
+                p = ("%s/%s/%s" % (self.outdir, instance.platform.name, instance.testcase.name))
                 bl = os.path.join(p, "build.log")
                 hl = os.path.join(p, "handler.log")
                 log_file = bl
@@ -3905,7 +3903,6 @@ def main():
                 info("Renaming output directory to {}".format(new_out))
                 shutil.move(options.outdir, new_out)
                 break
-                #shutil.rmtree("%s.old" %options.outdir)
 
     if not options.testcase_root:
         options.testcase_root = [os.path.join(ZEPHYR_BASE, "tests"),
@@ -3914,7 +3911,9 @@ def main():
     if options.show_footprint or options.compare_report or options.release:
         options.enable_size_report = True
 
-    suite = TestSuite(options.board_root, options.testcase_root, options.outdir)
+    suite = TestSuite(options.board_root,
+                      options.testcase_root,
+                      options.outdir)
 
     # Set number of jobs
     if options.jobs:

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2110,7 +2110,7 @@ class ProjectBuilder(FilterBuilder):
             if instance.status in ["failed", "timeout"]:
                 log_info_file(instance)
         else:
-            sys.stdout.write("\rtotal complete: %s%4d/%4d%s  %2d%%  skipped: %s%4d%s, failed: %s%4d%s" % (
+            sys.stdout.write("\rINFO - Total complete: %s%4d/%4d%s  %2d%%  skipped: %s%4d%s, failed: %s%4d%s" % (
                         COLOR_GREEN,
                         self.suite.total_done,
                         self.suite.total_tests,
@@ -3170,7 +3170,7 @@ Artificially long but functional example:
 
     parser.add_argument("--timestamps",
             action="store_true",
-            help="Print all messages with time stamps (Option is deprecated)")
+            help="Print all messages with time stamps")
 
     parser.add_argument(
         "-r", "--release", action="store_true",
@@ -3851,7 +3851,6 @@ def main():
     # create console handler with a higher log level
     ch = logging.StreamHandler()
 
-
     VERBOSE += options.verbose
     if VERBOSE > 1:
         ch.setLevel(logging.DEBUG)
@@ -3860,7 +3859,11 @@ def main():
 
 
     # create formatter and add it to the handlers
-    formatter = logging.Formatter('%(levelname)s - %(message)s')
+    if options.timestamps:
+        formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    else:
+        formatter = logging.Formatter('%(levelname)s - %(message)s')
+
     formatter_file = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     ch.setFormatter(formatter)
     fh.setFormatter(formatter_file)

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -718,6 +718,7 @@ class DeviceHandler(Handler):
             command = [get_generator()[0], "-C", self.build_dir, "flash"]
 
         while not self.device_is_available(self.instance.platform.name):
+            #logger.debug("Waiting for device to become available...")
             time.sleep(1)
 
         hardware = self.get_available_device(self.instance.platform.name)
@@ -4017,6 +4018,7 @@ def main():
         elif options.device_serial:  # back-ward compatibility
             if options.platform and len(options.platform) == 1:
                 hwm.load_device_from_cmdline(options.device_serial, options.platform[0])
+                suite.connected_hardware = hwm.connected_hardware
             else:
                 logger.error("""When --device-testing is used with --device-serial, only one
                       platform is allowed""")

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -3777,6 +3777,7 @@ class HardwareMap:
         from serial.tools import list_ports
 
         serial_devices = list_ports.comports()
+        print("Scanning connected hardware...")
         for d in serial_devices:
             if d.manufacturer in self.manufacturer:
 
@@ -3804,7 +3805,7 @@ class HardwareMap:
                 s_dev['connected'] = True
                 self.detected.append(s_dev)
             else:
-                print("Unsupported device (%s): %s" %(d.manufacturer, d))
+                print("- Unsupported device (%s): %s" %(d.manufacturer, d))
 
     def write_map(self, hwm_file):
         # use existing map
@@ -3819,13 +3820,21 @@ class HardwareMap:
                 for d in self.detected:
                     for h in hwm:
                         if d['id'] == h['id'] and d['product'] == h['product']:
-                            print("Already in map: %s (%s)" %(d['product'], d['id']))
                             h['connected'] = True
                             h['serial'] = d['serial']
                             d['match'] = True
 
                 new = list(filter(lambda n:  not n.get('match', False), self.detected))
                 hwm = hwm + new
+
+                print("\nRegistered devices:")
+                table = []
+                header = ["Platform", "ID", "Serial device"]
+                for p in sorted(hwm, key = lambda i: i['platform']):
+                    platform = p.get('platform')
+                    table.append([platform, p.get('id', None), p.get('serial')])
+                print(tabulate(table, headers=header, tablefmt="github"))
+
 
             with open(hwm_file, 'w') as yaml_file:
                 yaml.dump(hwm, yaml_file, default_flow_style=False)

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -433,11 +433,6 @@ class BuildError(SanityCheckException):
 class ExecutionError(SanityCheckException):
     pass
 
-# Debug Functions
-def info(what):
-    sys.stdout.write(what + "\n")
-    sys.stdout.flush()
-
 
 class HarnessImporter:
 
@@ -2240,6 +2235,12 @@ class TestSuite:
 
         # hardcoded for now
         self.connected_hardware = []
+
+    # Debug Functions
+    @staticmethod
+    def info(what):
+        sys.stdout.write(what + "\n")
+        sys.stdout.flush()
 
     def update(self):
         self.total_tests = len(self.instances)

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -771,7 +771,7 @@ class DeviceHandler(Handler):
                     )
         except serial.SerialException as e:
             self.set_state("failed", 0)
-            logger.error("Serial device err: %s" %(str(e)))
+            logger.error("Serial device error: %s" %(str(e)))
             self.make_device_available(serial_device)
             return
 
@@ -2074,8 +2074,9 @@ class ProjectBuilder(FilterBuilder):
             if VERBOSE or not TERMINAL:
                 status = COLOR_RED + "FAILED " + COLOR_NORMAL + instance.reason
             else:
-                info(
-                    "\n{:<25} {:<50} {}FAILED{}: {}".format(
+                print("")
+                logger.error(
+                    "{:<25} {:<50} {}FAILED{}: {}".format(
                         instance.platform.name,
                         instance.testcase.name,
                         COLOR_RED,
@@ -2110,7 +2111,7 @@ class ProjectBuilder(FilterBuilder):
             if instance.status in ["failed", "timeout"]:
                 log_info_file(instance)
         else:
-            sys.stdout.write("\rINFO - Total complete: %s%4d/%4d%s  %2d%%  skipped: %s%4d%s, failed: %s%4d%s" % (
+            sys.stdout.write("\rINFO    - Total complete: %s%4d/%4d%s  %2d%%  skipped: %s%4d%s, failed: %s%4d%s" % (
                         COLOR_GREEN,
                         self.suite.total_done,
                         self.suite.total_tests,
@@ -3426,7 +3427,7 @@ def log_info(filename):
 
         logger.info("{:-^100}".format(filename))
     else:
-        logger.info("\n\tsee: " + COLOR_YELLOW + filename + COLOR_NORMAL)
+        logger.error("see: " + COLOR_YELLOW + filename + COLOR_NORMAL)
 
 
 def log_info_file(instance):

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -801,11 +801,26 @@ class DeviceHandler(Handler):
         t.start()
 
         logging.debug('Flash command: %s', command)
+
+        d_log = "{}/device.log".format(self.instance.build_dir)
         try:
-            if VERBOSE and not runner:
-                subprocess.check_call(command)
-            else:
-                subprocess.check_output(command, stderr=subprocess.PIPE)
+            stdout = stderr = None
+            with subprocess.Popen(command, stderr=subprocess.PIPE, stdout=subprocess.PIPE) as proc:
+                try:
+                    (stdout, stderr) = proc.communicate(timeout=30)
+                    if VERBOSE:
+                        print(stdout.decode())
+                    if proc.returncode != 0:
+                        self.instance.reason = "Device issue (Flash?)"
+                        with open(d_log, "w") as dlog_fp:
+                            dlog_fp.write(stderr.decode())
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    (stdout, stderr)  = proc.communicate()
+                    self.instance.reason = "Device issue (Timeout)"
+
+            with open(d_log, "w") as dlog_fp:
+                dlog_fp.write(stderr.decode())
 
         except subprocess.CalledProcessError:
             os.write(write_pipe, b'x')    # halt the thread
@@ -3448,9 +3463,12 @@ def log_info_file(instance):
     h_log = "{}/handler.log".format(build_dir)
     b_log = "{}/build.log".format(build_dir)
     v_log = "{}/valgrind.log".format(build_dir)
+    d_log = "{}/device.log".format(build_dir)
 
     if os.path.exists(v_log) and "Valgrind" in instance.reason:
         log_info("{}".format(v_log))
+    elif os.path.exists(d_log):
+        log_info("{}".format(d_log))
     elif os.path.exists(h_log):
         log_info("{}".format(h_log))
     else:

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -790,8 +790,8 @@ class DeviceHandler(Handler):
             with subprocess.Popen(command, stderr=subprocess.PIPE, stdout=subprocess.PIPE) as proc:
                 try:
                     (stdout, stderr) = proc.communicate(timeout=30)
-                    if VERBOSE:
-                        print(stdout.decode())
+                    logger.debug(stdout.decode())
+
                     if proc.returncode != 0:
                         self.instance.reason = "Device issue (Flash?)"
                         with open(d_log, "w") as dlog_fp:

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1982,6 +1982,40 @@ class ProjectBuilder(FilterBuilder):
         self.device_testing = kwargs.get('device_testing', False)
         self.cmake_only = kwargs.get('cmake_only', False)
         self.coverage = kwargs.get('coverage', False)
+        self.inline_logs = kwargs.get('inline_logs', False)
+
+    def log_info(self, filename, inline_logs):
+        filename = os.path.relpath(os.path.realpath(filename))
+        if inline_logs:
+            logger.info("{:-^100}".format(filename))
+
+            try:
+                with open(filename) as fp:
+                    data = fp.read()
+            except Exception as e:
+                data = "Unable to read log data (%s)\n" % (str(e))
+
+            logger.error(data)
+
+            logger.info("{:-^100}".format(filename))
+        else:
+            logger.error("see: " + COLOR_YELLOW + filename + COLOR_NORMAL)
+
+    def log_info_file(self, inline_logs):
+        build_dir = self.instance.build_dir
+        h_log = "{}/handler.log".format(build_dir)
+        b_log = "{}/build.log".format(build_dir)
+        v_log = "{}/valgrind.log".format(build_dir)
+        d_log = "{}/device.log".format(build_dir)
+
+        if os.path.exists(v_log) and "Valgrind" in self.instance.reason:
+            self.log_info("{}".format(v_log), inline_logs)
+        elif os.path.exists(d_log):
+            self.log_info("{}".format(d_log), inline_logs)
+        elif os.path.exists(h_log):
+            self.log_info("{}".format(h_log), inline_logs)
+        else:
+            self.log_info("{}".format(b_log), inline_logs)
 
     def setup_handler(self):
 
@@ -2091,7 +2125,7 @@ class ProjectBuilder(FilterBuilder):
                         COLOR_NORMAL,
                         instance.reason))
             if not VERBOSE:
-                log_info_file(instance)
+                self.log_info_file(self.inline_logs)
         elif instance.status == "skipped":
             self.suite.total_skipped += 1
             status = COLOR_YELLOW + "SKIPPED" + COLOR_NORMAL
@@ -2117,7 +2151,7 @@ class ProjectBuilder(FilterBuilder):
                 instance.testcase.name, status, more_info))
 
             if instance.status in ["failed", "timeout"]:
-                log_info_file(instance)
+                self.log_info_file(inline_logs)
         else:
             sys.stdout.write("\rINFO    - Total complete: %s%4d/%4d%s  %2d%%  skipped: %s%4d%s, failed: %s%4d%s" % (
                         COLOR_GREEN,
@@ -2234,6 +2268,7 @@ class TestSuite:
         self.enable_asan = False
         self.enable_valgrind = False
         self.extra_args = []
+        self.inline_logs = False
 
         # Keep track of which test cases we've filtered out and why
         self.testcases = {}
@@ -2830,7 +2865,8 @@ class TestSuite:
                         extra_args = self.extra_args,
                         device_testing = self.device_testing,
                         cmake_only = self.cmake_only,
-                        valgrind = self.enable_valgrind
+                        valgrind = self.enable_valgrind,
+                        inline_logs = self.inline_logs
                         )
                     future_to_test[executor.submit(pb.process, message)] = test.name
 
@@ -3466,42 +3502,6 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
 
     return parser.parse_args()
 
-
-def log_info(filename):
-    filename = os.path.relpath(os.path.realpath(filename))
-    if options.inline_logs:
-        logger.info("{:-^100}".format(filename))
-
-        try:
-            with open(filename) as fp:
-                data = fp.read()
-        except Exception as e:
-            data = "Unable to read log data (%s)\n" % (str(e))
-
-        logger.error(data)
-
-        logger.info("{:-^100}".format(filename))
-    else:
-        logger.error("see: " + COLOR_YELLOW + filename + COLOR_NORMAL)
-
-
-def log_info_file(instance):
-    build_dir = instance.build_dir
-    h_log = "{}/handler.log".format(build_dir)
-    b_log = "{}/build.log".format(build_dir)
-    v_log = "{}/valgrind.log".format(build_dir)
-    d_log = "{}/device.log".format(build_dir)
-
-    if os.path.exists(v_log) and "Valgrind" in instance.reason:
-        log_info("{}".format(v_log))
-    elif os.path.exists(d_log):
-        log_info("{}".format(d_log))
-    elif os.path.exists(h_log):
-        log_info("{}".format(h_log))
-    else:
-        log_info("{}".format(b_log))
-
-
 def size_report(sc):
     logger.info(sc.filename)
     logger.info("SECTION NAME             VMA        LMA     SIZE  HEX SZ TYPE")
@@ -3999,6 +3999,7 @@ def main():
     suite.cmake_only = options.cmake_only
     suite.enable_valgrind = options.enable_valgrind
     suite.coverage_platform = options.coverage_platform
+    suite.inline_logs = options.inline_logs
 
 
     # Set number of jobs


### PR DESCRIPTION
Move away from custom output functions and use logging module instead. Cleanup
most usage of global options and instead pass arguments and/or use class
variables. This is needed to make unittesting of sanitycheck easier, right now
everything is being controlled via command line options.