### PR TITLE
Fixup doc warnings with newer doxygen & sphinx

### DIFF
--- a/.known-issues/doc/bluetooth.conf
+++ b/.known-issues/doc/bluetooth.conf
@@ -48,3 +48,21 @@
 ^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
 ^.*bt_mesh_model.__unnamed__.*
 ^[- \t]*\^
+#
+# Bluetooth mesh pub struct definition
+#
+^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]bluetooth[/\\]mesh[/\\]access.rst):(?P<lineno>[0-9]+): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
+^.*bt_mesh_model_pub.*
+^[- \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
+^.*bt_mesh_model_pub.*
+^[- \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
+^.*bt_mesh_model_pub.*
+^[- \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
+^.*bt_mesh_model_pub.*
+^[- \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
+^.*bt_mesh_model_pub.*
+^[- \t]*\^

--- a/.known-issues/doc/duplicate.conf
+++ b/.known-issues/doc/duplicate.conf
@@ -1,6 +1,6 @@
 #
-^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]file_system[/\\]index.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.
+^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]file_system[/\\]index.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration(.*)
 #
-^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]peripherals[/\\]dma.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.
+^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]peripherals[/\\]dma.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration(.*)
 #
-^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]peripherals[/\\]sensor.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.
+^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]peripherals[/\\]sensor.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration(.*)

--- a/.known-issues/doc/networking.conf
+++ b/.known-issues/doc/networking.conf
@@ -67,4 +67,4 @@
 #
 # stray duplicate definition warnings
 #
-^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]networking[/\\]net_if.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.
+^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]networking[/\\]net_if.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration(.*)

--- a/include/bluetooth/mesh/health_cli.h
+++ b/include/bluetooth/mesh/health_cli.h
@@ -144,7 +144,13 @@ int bt_mesh_health_period_get(u16_t net_idx, u16_t addr, u16_t app_idx,
 
 /** @brief Set the target node's Health fast period divisor.
  *
- *  @copydetails bt_mesh_health_period_get
+ *  The health period divisor is used to increase the publish rate when a fault
+ *  is registered. Normally, the Health server will publish with the period in
+ *  the configured publish parameters. When a fault is registered, the publish
+ *  period is divided by (1 << divisor). For example, if the target node's
+ *  Health server is configured to publish with a period of 16 seconds, and the
+ *  Health fast period divisor is 5, the Health server will publish with an
+ *  interval of 500 ms when a fault is registered.
  *
  *  @param net_idx         Network index to encrypt with.
  *  @param addr            Target node element address.

--- a/include/irq_nextlevel.h
+++ b/include/irq_nextlevel.h
@@ -130,10 +130,6 @@ static inline unsigned int irq_line_is_enabled_next_level(struct device *dev,
 	return api->intr_get_line_state(dev, irq);
 }
 
-/**
- * @}
- */
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/logging/log_instance.h
+++ b/include/logging/log_instance.h
@@ -66,8 +66,6 @@ struct log_source_dynamic_data {
  * @brief Macro for initializing a pointer to the logger instance.
  */
 
-/** @} */
-
 #ifdef CONFIG_LOG
 
 #define LOG_INSTANCE_FULL_NAME(_module_name, _inst_name) \

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -197,6 +197,7 @@ static inline bool arch_is_in_isr(void);
 /**
  * @defgroup arch-benchmarking Architecture-specific benchmarking globals
  * @ingroup arch-interface
+ * @{
  */
 
 #ifdef CONFIG_EXECUTION_BENCHMARKING
@@ -218,6 +219,7 @@ extern u64_t arch_timing_value_swap_temp;
 /**
  * @defgroup arch-misc Miscellaneous architecture APIs
  * @ingroup arch-interface
+ * @{
  */
 
 /**

--- a/tests/kernel/fp_sharing/float_disable/src/k_float_disable.c
+++ b/tests/kernel/fp_sharing/float_disable/src/k_float_disable.c
@@ -252,6 +252,3 @@ void test_k_float_disable_irq(void)
 	ztest_test_skip();
 }
 #endif /* CONFIG_ARM && CONFIG_DYNAMIC_INTERRUPTS */
-/**
- * @}
- */

--- a/tests/kernel/mem_protect/futex/src/main.c
+++ b/tests/kernel/mem_protect/futex/src/main.c
@@ -458,4 +458,3 @@ void test_main(void)
 			 ztest_unit_test(test_futex_wait_nowait));
 	ztest_run_test_suite(test_futex);
 }
-/******************************************************************************/

--- a/tests/kernel/pipe/pipe_api/src/test_pipe_fail.c
+++ b/tests/kernel/pipe/pipe_api/src/test_pipe_fail.c
@@ -102,8 +102,3 @@ void test_pipe_user_get_fail(void)
 	get_fail(p);
 }
 #endif
-
-
-/**
- * @}
- */


### PR DESCRIPTION
If we build the docs with a newer sphinx version we get some additional warnings as well as some minor changes in how some warnings are formatted.  Fix things up to handle both issues.