### PR TITLE
tests: gen_isr_table: do not plug ISR4 for TI cc13x2/cc26x2

### DIFF
--- a/tests/kernel/gen_isr_table/testcase.yaml
+++ b/tests/kernel/gen_isr_table/testcase.yaml
@@ -1,7 +1,8 @@
 tests:
   arch.interrupt.gen_isr_table:
     platform_exclude: nucleo_f103rb olimexino_stm32 stm32_min_dev_black
-        stm32_min_dev_blue usb_kw24d512 v2m_beetle
+        stm32_min_dev_blue usb_kw24d512 v2m_beetle cc1352r1_launchxl
+        cc26x2r1_launchxl
     filter: CONFIG_GEN_ISR_TABLES and CONFIG_ARMV7_M_ARMV8_M_MAINLINE
     tags: interrupt isr_table
   arch.interrupt.arc:


### PR DESCRIPTION
This test blindly tries to plug IRQ 34 (ISR4), which is being plugged
in the dpl layer. This causes a build failure, so we are changing the
test to not plug this interrupt.

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>