### PR TITLE
boards: arm: Convert hexiwear_k64 to new gpio api

### DIFF
--- a/boards/arm/hexiwear_k64/pinmux.c
+++ b/boards/arm/hexiwear_k64/pinmux.c
@@ -59,8 +59,7 @@ static int hexiwear_k64_pinmux_init(struct device *dev)
 	struct device *gpiob =
 	       device_get_binding(DT_NXP_KINETIS_GPIO_GPIO_B_LABEL);
 
-	gpio_pin_configure(gpiob, 12, GPIO_DIR_OUT);
-	gpio_pin_write(gpiob, 12, 0);
+	gpio_pin_configure(gpiob, 12, GPIO_OUTPUT_LOW);
 #endif
 
 #if CONFIG_I2C_1
@@ -95,8 +94,7 @@ static int hexiwear_k64_pinmux_init(struct device *dev)
 	struct device *gpioa =
 	       device_get_binding(DT_NXP_KINETIS_GPIO_GPIO_A_LABEL);
 
-	gpio_pin_configure(gpioa, 29, GPIO_DIR_OUT);
-	gpio_pin_write(gpioa, 29, 1);
+	gpio_pin_configure(gpioa, 29, GPIO_OUTPUT_HIGH);
 #endif
 
 #ifdef CONFIG_BATTERY_SENSE
@@ -105,8 +103,7 @@ static int hexiwear_k64_pinmux_init(struct device *dev)
 	struct device *gpioc =
 	       device_get_binding(DT_NXP_KINETIS_GPIO_GPIO_C_LABEL);
 
-	gpio_pin_configure(gpioc, 14, GPIO_DIR_OUT);
-	gpio_pin_write(gpioc, 14, 0);
+	gpio_pin_configure(gpioc, 14, GPIO_OUTPUT_LOW);
 #endif
 
 	return 0;


### PR DESCRIPTION
Converts the hexiwear_k64 board to the new gpio api.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>