### PR TITLE
kernel: sched: assert when k_sleep invoked from interrupt context

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1020,6 +1020,8 @@ s32_t z_impl_k_sleep(int ms)
 {
 	s32_t ticks;
 
+	__ASSERT(!arch_is_in_isr(), "");
+
 	if (ms == K_FOREVER) {
 		k_thread_suspend(_current);
 		return K_FOREVER;


### PR DESCRIPTION
Fix a gap where `k_sleep(K_FOREVER)` could execute a code path that would not verify that the call was not from interrupt context.

Background in #21341.