### PR TITLE
[TOPIC-GPIO] disk: Convert usdhc driver to new gpio api

### DIFF
--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -125,6 +125,6 @@ arduino_serial: &uart3 {};
 
 &usdhc1 {
 	status = "okay";
-	pwr-gpios = <&gpio1 5 0>;
-	cd-gpios = <&gpio2 28 0>;
+	pwr-gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+	cd-gpios = <&gpio2 28 GPIO_ACTIVE_LOW>;
 };

--- a/dts/bindings/mmc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/mmc/nxp,imx-usdhc.yaml
@@ -18,11 +18,17 @@ properties:
       type: phandle-array
       required: false
       description: Power pin
+        This pin defaults to active high when consumed by the SD card. The
+        property value should ensure the flags properly describe the signal
+        that is presented to the driver.
 
     cd-gpios:
       type: phandle-array
       required: false
       description: Detect pin
+        This pin defaults to active low when produced by the SD card. The
+        property value should ensure the flags properly describe the signal
+        that is presented to the driver.
 
     label:
       required: true

--- a/subsys/disk/disk_access_usdhc.c
+++ b/subsys/disk/disk_access_usdhc.c
@@ -439,10 +439,11 @@ struct usdhc_client_info {
 struct usdhc_board_config {
 	struct device *pwr_gpio;
 	u32_t pwr_pin;
-	int pwr_flags;
+	gpio_devicetree_flags_t pwr_flags;
 
 	struct device *detect_gpio;
 	u32_t detect_pin;
+	gpio_devicetree_flags_t detect_flags;
 	struct gpio_callback detect_cb;
 };
 
@@ -711,8 +712,6 @@ enum usdhc_reset {
 		USDHC_RESET_TUNING),
 	/*!< All reset types */
 };
-
-#define HOST_CARD_INSERT_CD_LEVEL (0U)
 
 static void usdhc_millsec_delay(unsigned int cycles_to_wait)
 {
@@ -2226,17 +2225,17 @@ static void usdhc_cd_gpio_cb(struct device *dev,
 	struct usdhc_board_config *board_cfg =
 		CONTAINER_OF(cb, struct usdhc_board_config, detect_cb);
 
-	gpio_pin_disable_callback(dev, board_cfg->detect_pin);
-
+	gpio_pin_interrupt_configure(dev, board_cfg->detect_pin,
+				     GPIO_INT_DISABLE);
 }
 
 static int usdhc_cd_gpio_init(struct device *detect_gpio,
-	u32_t pin, struct gpio_callback *callback)
+	u32_t pin, gpio_devicetree_flags_t flags,
+	struct gpio_callback *callback)
 {
 	int ret;
 
-	ret = gpio_pin_configure(detect_gpio, pin,
-		GPIO_DIR_IN | GPIO_INT_DOUBLE_EDGE);
+	ret = gpio_pin_configure(detect_gpio, pin, GPIO_INPUT | flags);
 	if (ret)
 		return ret;
 
@@ -2616,6 +2615,8 @@ static int usdhc_board_access_init(struct usdhc_priv *priv)
 		}
 		priv->board_cfg.detect_pin =
 			DT_INST_0_NXP_IMX_USDHC_CD_GPIOS_PIN;
+		priv->board_cfg.detect_flags =
+			DT_INST_0_NXP_IMX_USDHC_CD_GPIOS_FLAGS;
 #endif
 
 	} else if (priv->nusdhc == 1) {
@@ -2641,6 +2642,8 @@ static int usdhc_board_access_init(struct usdhc_priv *priv)
 		}
 		priv->board_cfg.detect_pin =
 			DT_INST_1_NXP_IMX_USDHC_CD_GPIOS_PIN;
+		priv->board_cfg.detect_flags =
+			DT_INST_1_NXP_IMX_USDHC_CD_GPIOS_FLAGS;
 #endif
 	} else {
 		return -ENODEV;
@@ -2649,6 +2652,7 @@ static int usdhc_board_access_init(struct usdhc_priv *priv)
 	if (priv->board_cfg.pwr_gpio) {
 		ret = gpio_pin_configure(priv->board_cfg.pwr_gpio,
 				priv->board_cfg.pwr_pin,
+				GPIO_OUTPUT_ACTIVE |
 				priv->board_cfg.pwr_flags);
 		if (ret) {
 			return ret;
@@ -2658,13 +2662,6 @@ static int usdhc_board_access_init(struct usdhc_priv *priv)
 		 * maybe could be shorter
 		 */
 		k_busy_wait(100000);
-		if (priv->board_cfg.pwr_flags & (GPIO_DIR_OUT)) {
-			ret = gpio_pin_write(priv->board_cfg.pwr_gpio,
-				priv->board_cfg.pwr_pin, 1);
-			if (ret) {
-				return ret;
-			}
-		}
 	}
 
 	if (!priv->board_cfg.detect_gpio) {
@@ -2674,18 +2671,20 @@ static int usdhc_board_access_init(struct usdhc_priv *priv)
 
 	ret = usdhc_cd_gpio_init(priv->board_cfg.detect_gpio,
 			priv->board_cfg.detect_pin,
+			priv->board_cfg.detect_flags,
 			&priv->board_cfg.detect_cb);
 	if (ret) {
 		return ret;
 	}
-	ret = gpio_pin_read(priv->board_cfg.detect_gpio,
-			priv->board_cfg.detect_pin,
-			&gpio_level);
-	if (ret) {
+	ret = gpio_pin_get(priv->board_cfg.detect_gpio,
+			   priv->board_cfg.detect_pin);
+	if (ret < 0) {
 		return ret;
 	}
 
-	if (gpio_level != HOST_CARD_INSERT_CD_LEVEL) {
+	gpio_level = ret;
+
+	if (gpio_level == 0) {
 		priv->inserted = false;
 		LOG_ERR("NO SD inserted!\r\n");
 


### PR DESCRIPTION
Converts the usdhc driver to the new gpio api. Updates the
device tree for the mimxrt1050_evk board to set appropriate active
high/low polarity for the power and card detect pins.

Note that the driver doesn't actually support interrupts yet. It
initializes a gpio callback for the card detect pin, but never actually
enables the gpio interrupt. This incomplete behavior is left as-is,
since the purpose of this patch is only to convert the driver to the new
gpio api, not to add new features.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

@JunYangNXP please review