### PR TITLE
samples: i2c_scanner: support output like i2c_detect

### DIFF
--- a/samples/drivers/i2c_scanner/src/main.c
+++ b/samples/drivers/i2c_scanner/src/main.c
@@ -23,9 +23,9 @@
 void main(void)
 {
 	struct device *i2c_dev;
-	u8_t cnt = 0;
+	u8_t cnt = 0, first = 0x04, last = 0x77;
 
-	printk("Starting i2c scanner...\n");
+	printk("Starting i2c scanner...\n\n");
 
 	i2c_dev = device_get_binding(I2C_DEV);
 	if (!i2c_dev) {
@@ -33,20 +33,32 @@ void main(void)
 		return;
 	}
 
-	for (u8_t i = 4; i <= 0x77; i++) {
-		struct i2c_msg msgs[1];
-		u8_t dst;
+	printk("     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f\n");
+	for (u8_t i = 0; i <= last; i += 16) {
+		printk("%02x: ", i);
+		for (u8_t j = 0; j < 16; j++) {
+			if (i + j < first || i + j > last) {
+				printk("   ");
+				continue;
+			}
 
-		/* Send the address to read from */
-		msgs[0].buf = &dst;
-		msgs[0].len = 0U;
-		msgs[0].flags = I2C_MSG_WRITE | I2C_MSG_STOP;
+			struct i2c_msg msgs[1];
+			u8_t dst;
 
-		if (i2c_transfer(i2c_dev, &msgs[0], 1, i) == 0) {
-			printk("0x%2x FOUND\n", i);
-			++cnt;
+			/* Send the address to read from */
+			msgs[0].buf = &dst;
+			msgs[0].len = 0U;
+			msgs[0].flags = I2C_MSG_WRITE | I2C_MSG_STOP;
+			if (i2c_transfer(i2c_dev, &msgs[0], 1, i + j) == 0) {
+				printk("%02x ", i + j);
+				++cnt;
+			} else {
+				printk("-- ");
+			}
 		}
+		printk("\n");
 	}
-	printk("%u devices found on %s\n", cnt, I2C_DEV);
+
+	printk("\n%u devices found on %s\n", cnt, I2C_DEV);
 
 }


### PR DESCRIPTION
Supports output in the same format as the `i2c_detect` command.

**before**
```
*** Booting Zephyr OS build zephyr-v1.13.0-12273-gb413223a66ed  ***
Starting i2c scanner...
0x3c FOUND
1 devices found on I2C_1
```

**after**
```
*** Booting Zephyr OS build zephyr-v1.13.0-12273-gb413223a66ed  ***
Starting i2c scanner...

     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:             -- -- -- -- -- -- -- -- -- -- -- -- 
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
30: -- -- -- -- -- -- -- -- -- -- -- -- 3c -- -- -- 
40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --                             
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --                             
70: -- -- -- -- -- -- -- --                                                     
                                                                                
1 devices found on I2C_1
```