### PR TITLE
logging: fix warning of array subscript having type `char`

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -109,7 +109,7 @@ static u32_t count_s(const char *str, u32_t nargs)
 	while ((curr = *str++) && arg < nargs) {
 		if (curr == '%') {
 			arm = !arm;
-		} else if (arm && isalpha(curr)) {
+		} else if (arm && isalpha((int)curr)) {
 			if (curr == 's') {
 				mask |= BIT(arg);
 			}


### PR DESCRIPTION
In the count_s() function, with -Wchar-subscripts, GCC warns
about array subscript having type ‘char’ with the isalpha()
call. Since isalpha() takes an int, so do a type-cast there
to get rid of the warning.

This happens on XCC which is based on GCC 4.2.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>