### PR TITLE
cpp: fix constexpr and noexcept for C++98

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -50,7 +50,7 @@
 
 #if defined(__cplusplus)
 template < class T, size_t N >
-constexpr size_t ARRAY_SIZE(T(&)[N]) { return N; }
+CONSTEXPR size_t ARRAY_SIZE(T(&)[N]) { return N; }
 
 #else
 /* Evaluates to number of elements in an array; compile error if not

--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -188,4 +188,18 @@
 		iterator < _CONCAT(_##struct_type, _list_end); }); \
 	     iterator++)
 
+/*
+ * Both constexpr and noexcept are introduced in C++11.
+ * So need a workaround for C++98.
+ */
+#if defined(__cplusplus)
+  #ifdef CONFIG_STD_CPP98
+    #define CONSTEXPR
+    #define NOEXCEPT
+  #else
+    #define CONSTEXPR constexpr
+    #define NOEXCEPT noexcept
+  #endif
+#endif /* __cplusplus */
+
 #endif /* ZEPHYR_INCLUDE_TOOLCHAIN_COMMON_H_ */

--- a/subsys/cpp/cpp_new.cpp
+++ b/subsys/cpp/cpp_new.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <stdlib.h>
+#include <toolchain.h>
 
 void* operator new(size_t size)
 {
@@ -16,23 +17,23 @@ void* operator new[](size_t size)
 	return malloc(size);
 }
 
-void operator delete(void* ptr) noexcept
+void operator delete(void* ptr) NOEXCEPT
 {
 	free(ptr);
 }
 
-void operator delete[](void* ptr) noexcept
+void operator delete[](void* ptr) NOEXCEPT
 {
 	free(ptr);
 }
 
 #if (__cplusplus > 201103L)
-void operator delete(void* ptr, size_t) noexcept
+void operator delete(void* ptr, size_t) NOEXCEPT
 {
 	free(ptr);
 }
 
-void operator delete[](void* ptr, size_t) noexcept
+void operator delete[](void* ptr, size_t) NOEXCEPT
 {
 	free(ptr);
 }


### PR DESCRIPTION
The keywords constexpr and noexcept are only defined for
C++11 and later. So don't use it when compiling for C++98.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>