### PR TITLE
kernel: add a work queue that runs on the main thread.

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3110,6 +3110,18 @@ extern struct k_work_q k_sys_work_q;
  * INTERNAL_HIDDEN @endcond
  */
 
+#ifdef CONFIG_MAIN_THREAD_WORK_QUEUE
+/**
+ * @brief The main thread work queue.
+ *
+ * This work queue, if enabled by CONFIG_MAIN_THREAD_WORK_QUEUE, is executed on
+ * the main thread after the application's main function returns. Work items can
+ * be submitted to this queue at initialization levels greater than or equal to
+ * _SYS_INIT_LEVEL_POST_KERNEL.
+ */
+extern struct k_work_q k_main_work_q;
+#endif
+
 #define Z_WORK_INITIALIZER(work_handler) \
 	{ \
 	._reserved = NULL, \

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -82,6 +82,15 @@ config MAIN_THREAD_PRIORITY
 	  Priority at which the initialization thread runs, including the start
 	  of the main() function. main() can then change its priority if desired.
 
+config MAIN_THREAD_WORK_QUEUE
+	bool "Start a work queue on the main thread"
+	default n
+	help
+	  If enabled, a work queue ('k_main_work_q') is started on the main
+	  thread after the application's main function returns. Work items can
+	  be submitted to this work queue at initialization levels
+	  _SYS_INIT_LEVEL_POST_KERNEL and beyond.
+
 config COOP_ENABLED
 	def_bool (NUM_COOP_PRIORITIES != 0)
 


### PR DESCRIPTION
Add an optional work queue that runs on the main thread after the
application's main() function returns, to allow for the reuse of stack
memory allocated for initialization.

Resolves #21322.

Signed-off-by: Josh Gao <josh@jmgao.dev>