### PR TITLE
logging: fix LOG_HEXDUMP_* in C++.

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -223,7 +223,7 @@ extern "C" {
 /******************************************************************************/
 /****************** Defiinitions used by minimal logging **********************/
 /******************************************************************************/
-void log_minimal_hexdump_print(int level, const char *data, size_t size);
+void log_minimal_hexdump_print(int level, const void *data, size_t size);
 
 #define Z_LOG_TO_PRINTK(_level, fmt, ...) do {				     \
 		printk("%c: " fmt "\n", z_log_minimal_level_to_char(_level), \
@@ -314,8 +314,8 @@ static inline char z_log_minimal_level_to_char(int level)
 				   (_level <= LOG_RUNTIME_FILTER(_filter))) {  \
 				struct log_msg_ids src_level = {	       \
 					.level = _level,		       \
+					.domain_id = CONFIG_LOG_DOMAIN_ID,     \
 					.source_id = _id,		       \
-					.domain_id = CONFIG_LOG_DOMAIN_ID      \
 				};					       \
 									       \
 				if (is_user_context) {			       \
@@ -548,9 +548,7 @@ void log_n(const char *str,
  * @param length	Data length.
  * @param src_level	Log identification.
  */
-void log_hexdump(const char *str,
-		 const u8_t *data,
-		 u32_t length,
+void log_hexdump(const char *str, const void *data, u32_t length,
 		 struct log_msg_ids src_level);
 
 /** @brief Process log message synchronously.
@@ -569,7 +567,7 @@ void log_string_sync(struct log_msg_ids src_level, const char *fmt, ...);
  * @param len		Data length.
  */
 void log_hexdump_sync(struct log_msg_ids src_level, const char *metadata,
-		      const u8_t *data, u32_t len);
+		      const void *data, u32_t len);
 
 /**
  * @brief Writes a generic log message to the log.
@@ -647,7 +645,7 @@ __syscall void z_log_string_from_user(u32_t src_level_val, const char *str);
  * @param len		Data length.
  */
 void log_hexdump_from_user(struct log_msg_ids src_level, const char *metadata,
-			   const u8_t *data, u32_t len);
+			   const void *data, u32_t len);
 
 /* Internal function used by log_hexdump_from_user(). */
 __syscall void z_log_hexdump_from_user(u32_t src_level_val,

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -309,15 +309,15 @@ void log_n(const char *str,
 	}
 }
 
-void log_hexdump(const char *str,
-		 const u8_t *data,
-		 u32_t length,
+void log_hexdump(const char *str, const void *data, u32_t length,
 		 struct log_msg_ids src_level)
 {
 	if (IS_ENABLED(CONFIG_LOG_FRONTEND)) {
-		log_frontend_hexdump(str, data, length, src_level);
+		log_frontend_hexdump(str, (const u8_t *)data, length,
+				     src_level);
 	} else {
-		struct log_msg *msg = log_msg_hexdump_create(str, data, length);
+		struct log_msg *msg =
+			log_msg_hexdump_create(str, (const u8_t *)data, length);
 
 		if (msg == NULL) {
 			return;
@@ -429,10 +429,11 @@ void log_string_sync(struct log_msg_ids src_level, const char *fmt, ...)
 }
 
 void log_hexdump_sync(struct log_msg_ids src_level, const char *metadata,
-		      const u8_t *data, u32_t len)
+		      const void *data, u32_t len)
 {
 	if (IS_ENABLED(CONFIG_LOG_FRONTEND)) {
-		log_frontend_hexdump(metadata, data, len, src_level);
+		log_frontend_hexdump(metadata, (const u8_t *)data, len,
+				     src_level);
 	} else {
 		struct log_backend const *backend;
 		u32_t timestamp = timestamp_func();
@@ -441,9 +442,9 @@ void log_hexdump_sync(struct log_msg_ids src_level, const char *metadata,
 			backend = log_backend_get(i);
 
 			if (log_backend_is_active(backend)) {
-				log_backend_put_sync_hexdump(backend, src_level,
-							timestamp, metadata,
-							data, len);
+				log_backend_put_sync_hexdump(
+					backend, src_level, timestamp, metadata,
+					(const u8_t *)data, len);
 			}
 		}
 	}
@@ -1089,7 +1090,7 @@ void z_vrfy_z_log_hexdump_from_user(u32_t src_level_val, const char *metadata,
 #include <syscalls/z_log_hexdump_from_user_mrsh.c>
 
 void log_hexdump_from_user(struct log_msg_ids src_level, const char *metadata,
-			   const u8_t *data, u32_t len)
+			   const void *data, u32_t len)
 {
 	union {
 		struct log_msg_ids structure;
@@ -1098,7 +1099,8 @@ void log_hexdump_from_user(struct log_msg_ids src_level, const char *metadata,
 
 	__ASSERT_NO_MSG(sizeof(src_level) <= sizeof(u32_t));
 	src_level_union.structure = src_level;
-	z_log_hexdump_from_user(src_level_union.value, metadata, data, len);
+	z_log_hexdump_from_user(src_level_union.value, metadata,
+				(const u8_t *)data, len);
 }
 #else
 void z_impl_z_log_string_from_user(u32_t src_level_val, const char *str)
@@ -1139,7 +1141,7 @@ void log_generic_from_user(struct log_msg_ids src_level,
 }
 
 void log_hexdump_from_user(struct log_msg_ids src_level, const char *metadata,
-			   const u8_t *data, u32_t len)
+			   const void *data, u32_t len)
 {
 	ARG_UNUSED(src_level);
 	ARG_UNUSED(metadata);

--- a/subsys/logging/log_minimal.c
+++ b/subsys/logging/log_minimal.c
@@ -34,8 +34,9 @@ static void minimal_hexdump_line_print(const char *data, size_t length)
 	printk("\n");
 }
 
-void log_minimal_hexdump_print(int level, const char *data, size_t size)
+void log_minimal_hexdump_print(int level, const void *_data, size_t size)
 {
+	const char *data = (const char *)_data;
 	while (size > 0) {
 		printk("%c: ", z_log_minimal_level_to_char(level));
 		minimal_hexdump_line_print(data, size);


### PR DESCRIPTION
Previously, there were two issues when attempting to use LOG_HEXDUMP_*
from C++. First, C++ is restrictive about implicit pointer coercion, so
use const void* instead of const char* in our hexdump helper. Second,
the soon-to-be-standardized C++20 version of designated initializers
requires that the designators appear in the same order as they are
declared in the type being initialized.

(Also, clang-format the __LOG_HEXDUMP macro.)

Signed-off-by: Josh Gao <josh@jmgao.dev>