### PR TITLE
Bluetooth: controller: split: Fix missing version ind state reset

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -4095,6 +4095,9 @@ static int version_ind_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 		/* Mark for buffer for release */
 		rx->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
 	} else if (!conn->llcp_version.rx) {
+		/* procedure request acked */
+		conn->llcp_version.ack = conn->llcp_version.req;
+
 		/* Procedure complete */
 		conn->procedure_expire = 0U;
 	} else {


### PR DESCRIPTION
Fix implementation for the missing reset of version
information procedure request state value.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>