### PR TITLE
doc: s/devicetree/device tree/

### DIFF
--- a/doc/guides/dts/index.rst
+++ b/doc/guides/dts/index.rst
@@ -5,7 +5,7 @@ Devicetree
 
 Zephyr uses the *devicetree* data structure to describe the hardware available
 on a board, as well as its initial configuration in an application. Note that
-"devicetree" -- without spaces -- is preferred to "devicetree". The
+"devicetree" -- without spaces -- is preferred to "device tree". The
 `Devicetree specification`_ fully defines this data structure and its source
 and binary representations.
 


### PR DESCRIPTION
Commit 27e5dd13 fixed a bunch of uses of "device tree" in the
documentation, but accidentally hit the part of the documentation
that stated that "devicetree" should be preferred over "device tree".

Signed-off-by: Josh Gao <josh@jmgao.dev>

cc @mbolivar @dbkinder