### PR TITLE
scripts: using Path and PurePath for path handling in zephyr modules

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -19,7 +19,7 @@ import yaml
 import pykwalify.core
 import subprocess
 import re
-from pathlib import PurePath
+from pathlib import Path, PurePath
 
 METADATA_SCHEMA = '''
 ## A pykwalify schema for basic validation of the structure of a
@@ -59,9 +59,10 @@ def process_module(module, cmake_out=None, kconfig_out=None):
     cmake_setting = None
     kconfig_setting = None
 
-    module_yml = os.path.join(module, 'zephyr/module.yml')
-    if os.path.isfile(module_yml):
-        with open(module_yml, 'r') as f:
+    module_path = PurePath(module)
+    module_yml = module_path.joinpath('zephyr/module.yml')
+    if Path(module_yml).is_file():
+        with Path(module_yml).open('r') as f:
             meta = yaml.safe_load(f.read())
 
         try:
@@ -69,33 +70,32 @@ def process_module(module, cmake_out=None, kconfig_out=None):
                 .validate()
         except pykwalify.errors.SchemaError as e:
             sys.exit('ERROR: Malformed "build" section in file: {}\n{}'
-                     .format(module_yml, e))
+                     .format(module_yml.as_posix(), e))
 
         section = meta.get('build', dict())
         cmake_setting = section.get('cmake', None)
         if not validate_setting(cmake_setting, module, 'CMakeLists.txt'):
             sys.exit('ERROR: "cmake" key in {} has folder value "{}" which '
                      'does not contain a CMakeLists.txt file.'
-                     .format(module_yml, cmake_setting))
+                     .format(module_yml.as_posix(), cmake_setting))
 
         kconfig_setting = section.get('kconfig', None)
         if not validate_setting(kconfig_setting, module):
             sys.exit('ERROR: "kconfig" key in {} has value "{}" which does '
                      'not point to a valid Kconfig file.'
-                     .format(module.yml, kconfig_setting))
+                     .format(module_yml.as_posix(), kconfig_setting))
 
-    cmake_path = os.path.join(module, cmake_setting or 'zephyr')
-    cmake_file = os.path.join(cmake_path, 'CMakeLists.txt')
-    if os.path.isfile(cmake_file) and cmake_out is not None:
+    cmake_path = module_path.joinpath(cmake_setting or 'zephyr')
+    cmake_file = cmake_path.joinpath('CMakeLists.txt')
+    if Path(cmake_file).is_file() and cmake_out is not None:
         cmake_out.write('\"{}\":\"{}\"\n'
-                        .format(os.path.basename(module), PurePath(
-                            os.path.abspath(cmake_path)).as_posix()))
+                        .format(module_path.name,
+                                Path(cmake_path).resolve().as_posix()))
 
-    kconfig_file = os.path.join(module, kconfig_setting or 'zephyr/Kconfig')
-    if os.path.isfile(kconfig_file) and kconfig_out is not None:
+    kconfig_file = module_path.joinpath(kconfig_setting or 'zephyr/Kconfig')
+    if Path(kconfig_file).is_file() and kconfig_out is not None:
         kconfig_out.write('osource "{}"\n\n'
-                          .format(PurePath(
-                              os.path.abspath(kconfig_file)).as_posix()))
+                          .format(Path(kconfig_file).resolve().as_posix()))
 
 
 def main():
@@ -129,7 +129,7 @@ def main():
         if p.returncode == 0:
             projects = out.decode(sys.getdefaultencoding()).splitlines()
         elif re.match((r'Error: .* is not in a west installation\.'
-                        '|FATAL ERROR: no west installation found from .*'),
+                       '|FATAL ERROR: no west installation found from .*'),
                       err.decode(sys.getdefaultencoding())):
             # Only accept the error from bootstrapper in the event we are
             # outside a west managed project.


### PR DESCRIPTION

Now using only Path and PurePath in zephyr_modules.py to handle module
processing.
This make the code cleaner as well as remove an issue where a module
name would become an empty string when module path contained trailing
path separators.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>