### PR TITLE
treewide: avoid use of unsupported C++ specifiers

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -50,7 +50,10 @@
 
 #if defined(__cplusplus)
 template < class T, size_t N >
-constexpr size_t ARRAY_SIZE(T(&)[N]) { return N; }
+#if __cplusplus >= 201103L
+constexpr
+#endif /* >= C++11 */
+size_t ARRAY_SIZE(T(&)[N]) { return N; }
 
 #else
 /* Evaluates to number of elements in an array; compile error if not

--- a/subsys/cpp/cpp_new.cpp
+++ b/subsys/cpp/cpp_new.cpp
@@ -6,6 +6,12 @@
 
 #include <stdlib.h>
 
+#if __cplusplus < 201103L
+#define NOEXCEPT
+#else /* >= C++11 */
+#define NOEXCEPT noexcept
+#endif /* __cplusplus */
+
 void* operator new(size_t size)
 {
 	return malloc(size);
@@ -16,23 +22,23 @@ void* operator new[](size_t size)
 	return malloc(size);
 }
 
-void operator delete(void* ptr) noexcept
+void operator delete(void* ptr) NOEXCEPT
 {
 	free(ptr);
 }
 
-void operator delete[](void* ptr) noexcept
+void operator delete[](void* ptr) NOEXCEPT
 {
 	free(ptr);
 }
 
 #if (__cplusplus > 201103L)
-void operator delete(void* ptr, size_t) noexcept
+void operator delete(void* ptr, size_t) NOEXCEPT
 {
 	free(ptr);
 }
 
-void operator delete[](void* ptr, size_t) noexcept
+void operator delete[](void* ptr, size_t) NOEXCEPT
 {
 	free(ptr);
 }


### PR DESCRIPTION
constexpr and noexcept were introduced as specifiers in C++11.  Avoid
referencing them when compiling for earlier versions of the language.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>