### PR TITLE
spinlock: Make SPIN_VALIDATE a Kconfig option.

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -650,7 +650,7 @@ void *z_get_next_switch_handle(void *interrupted)
 #endif
 			_current_cpu->swap_ok = 0;
 			set_current(th);
-#ifdef SPIN_VALIDATE
+#ifdef CONFIG_SPIN_VALIDATE
 			/* Changed _current!  Update the spinlock
 			 * bookeeping so the validation doesn't get
 			 * confused when the "wrong" thread tries to

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -853,7 +853,7 @@ FUNC_NORETURN void k_thread_user_mode_enter(k_thread_entry_t entry,
 /* These spinlock assertion predicates are defined here because having
  * them in spinlock.h is a giant header ordering headache.
  */
-#ifdef SPIN_VALIDATE
+#ifdef CONFIG_SPIN_VALIDATE
 bool z_spin_lock_valid(struct k_spinlock *l)
 {
 	uintptr_t thread_cpu = l->thread_cpu;
@@ -879,8 +879,7 @@ void z_spin_lock_set_owner(struct k_spinlock *l)
 {
 	l->thread_cpu = _current_cpu->id | (uintptr_t)_current;
 }
-
-#endif
+#endif /* CONFIG_SPIN_VALIDATE */
 
 int z_impl_k_float_disable(struct k_thread *thread)
 {

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -163,6 +163,16 @@ config ASSERT_LEVEL
 	  Level 1: on + warning in every file that includes __assert.h
 	  Level 2: on + no warning
 
+config SPIN_VALIDATE
+	bool "Enable spinlock validation"
+	depends on ASSERT
+	depends on MP_NUM_CPUS < 4
+	default y if !FLASH || FLASH_SIZE > 32
+	help
+	  There's a spinlock validation framework available when asserts are
+	  enabled. It adds a relatively hefty overhead (about 3k or so) to
+	  kernel code size, don't use on platforms known to be small.
+
 config FORCE_NO_ASSERT
 	bool "Force-disable no assertions"
 	help


### PR DESCRIPTION
SPIN_VALIDATE is, as it was previously, enabled per default when having
less than 4 CPUs and either having no flash or a flash size greater than
32kB.

Small targets, which needs to have asserts enabled, can chose to have
the spinlock validation enabled or not and thereby decide whether the
overhead added is acceptable or not.
