### PR TITLE
net: config: Initialize semaphore before it's used

### DIFF
--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -376,10 +376,6 @@ int net_config_init(const char *app_info, u32_t flags, s32_t timeout)
 #endif
 	}
 
-	setup_ipv4(iface);
-	setup_dhcpv4(iface);
-	setup_ipv6(iface, flags);
-
 	if (flags & NET_CONFIG_NEED_IPV6) {
 		need++;
 	}
@@ -389,6 +385,10 @@ int net_config_init(const char *app_info, u32_t flags, s32_t timeout)
 	}
 
 	k_sem_init(&counter, need, UINT_MAX);
+
+	setup_ipv4(iface);
+	setup_dhcpv4(iface);
+	setup_ipv6(iface, flags);
 
 	/* Loop here until we are ready to continue. As we might need
 	 * to wait multiple events, sleep smaller amounts of data.


### PR DESCRIPTION
Functions like `setup_ipv4` or `setup_ipv6` might already use the
`counter` semaphore, therefore it should be initialized before these
functions are called.

As a result of this issue, the network stack could stall until timeout
under certain circumstances (e.g. when OpenThread was used).

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>