### PR TITLE
drivers: eth_mcux power down

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -295,8 +295,11 @@ static void eth_mcux_phy_event(struct eth_context *context)
 		if (context->enabled) {
 			eth_mcux_phy_enter_reset(context);
 		} else {
-			/* @todo, actually power down the PHY ? */
 			context->phy_state = eth_mcux_phy_state_initial;
+			net_eth_carrier_off(context->iface);
+			ENET_StartSMIWrite(ENET, phy_addr, PHY_BASICCONTROL_REG,
+						kENET_MiiWriteValidFrame,
+						PHY_BCTL_POWER_DOWN_MASK);
 		}
 		break;
 	case eth_mcux_phy_state_reset:

--- a/west.yml
+++ b/west.yml
@@ -83,7 +83,7 @@ manifest:
       revision: 00dd4fab1a00f2f6e995ef3f2e7c3814689f8885
       path: modules/fs/nffs
     - name: hal_nxp
-      revision: ef000ff5d902c938e3d4763155b0511b043017c8
+      revision: pull/24/head
       path: modules/hal/nxp
     - name: open-amp
       revision: 9b591b289e1f37339bd038b5a1f0e6c8ad39c63a


### PR DESCRIPTION
Power down PHY in eth_mcux driver and set carrier off.

Signed-off-by: Andrei Gansari <andrei.gansari@nxp.com>

Depends on zephyrproject-rtos/hal_nxp#24