### PR TITLE
Bluetooth: controller: legacy: Fix Tx Ctrl PDU leak

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -10207,6 +10207,9 @@ static void ctrl_tx_enqueue(struct connection *conn,
 static void ctrl_tx_sec_enqueue(struct connection *conn,
 				  struct radio_pdu_node_tx *node_tx)
 {
+	bool pause = false;
+
+#if defined(CONFIG_BT_CTLR_LE_ENC)
 	if (conn->pause_tx) {
 		if (!conn->pkt_tx_ctrl) {
 			/* As data PDU tx is paused and no control PDU in queue,
@@ -10232,8 +10235,6 @@ static void ctrl_tx_sec_enqueue(struct connection *conn,
 			conn->pkt_tx_last = node_tx;
 		}
 	} else {
-		bool pause = false;
-
 		/* check if Encryption Request is at head, it may have been
 		 * transmitted and not ack-ed. Hence, enqueue this control PDU
 		 * after control last marker and before data marker.
@@ -10243,12 +10244,20 @@ static void ctrl_tx_sec_enqueue(struct connection *conn,
 			struct pdu_data *pdu_data_tx;
 
 			pdu_data_tx = (void *)conn->pkt_tx_head->pdu_data;
-			if ((pdu_data_tx->ll_id == PDU_DATA_LLID_CTRL) &&
-			    (pdu_data_tx->llctrl.opcode ==
-			     PDU_DATA_LLCTRL_TYPE_ENC_REQ)) {
+			if ((conn->llcp_req != conn->llcp_ack) &&
+			    (conn->llcp_type == LLCP_ENCRYPTION) &&
+			    (pdu_data_tx->ll_id == PDU_DATA_LLID_CTRL) &&
+			    ((pdu_data_tx->llctrl.opcode ==
+			      PDU_DATA_LLCTRL_TYPE_ENC_REQ) ||
+			     (pdu_data_tx->llctrl.opcode ==
+			      PDU_DATA_LLCTRL_TYPE_PAUSE_ENC_REQ))) {
 				pause = true;
 			}
 		}
+
+#else /* !CONFIG_BT_CTLR_LE_ENC */
+	{
+#endif /* !CONFIG_BT_CTLR_LE_ENC */
 
 		ctrl_tx_pause_enqueue(conn, node_tx, pause);
 	}

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -10890,7 +10890,7 @@ static u8_t ping_resp_send(struct connection *conn)
 			   sizeof(struct pdu_data_llctrl_ping_rsp);
 	pdu_ctrl_tx->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_PING_RSP;
 
-	ctrl_tx_enqueue(conn, node_tx);
+	ctrl_tx_sec_enqueue(conn, node_tx);
 
 	return 0;
 }
@@ -10955,7 +10955,7 @@ static void length_resp_send(struct connection *conn,
 	pdu_ctrl_tx->llctrl.length_rsp.max_tx_time = eff_tx_time;
 #endif /* CONFIG_BT_CTLR_PHY */
 
-	ctrl_tx_enqueue(conn, node_tx);
+	ctrl_tx_sec_enqueue(conn, node_tx);
 }
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -357,7 +357,9 @@ static inline u8_t phy_upd_ind_recv(struct radio_pdu_node_rx *node_rx,
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 static void enc_req_reused_send(struct connection *conn,
 				struct radio_pdu_node_tx *node_tx);
+#if defined(CONFIG_BT_PERIPHERAL)
 static u8_t enc_rsp_send(struct connection *conn);
+#endif /* CONFIG_BT_PERIPHERAL */
 static u8_t start_enc_rsp_send(struct connection *conn,
 			       struct pdu_data *pdu_ctrl_tx);
 static u8_t pause_enc_rsp_send(struct connection *conn, u8_t req);
@@ -10635,6 +10637,7 @@ static void enc_req_reused_send(struct connection *conn,
 				sizeof(pdu_ctrl_tx->llctrl.enc_req.ivm), 0);
 }
 
+#if defined(CONFIG_BT_PERIPHERAL)
 static u8_t enc_rsp_send(struct connection *conn)
 {
 	struct radio_pdu_node_tx *node_tx;
@@ -10677,6 +10680,7 @@ static u8_t enc_rsp_send(struct connection *conn)
 
 	return 0;
 }
+#endif /* CONFIG_BT_PERIPHERAL */
 
 static u8_t start_enc_rsp_send(struct connection *conn,
 			       struct pdu_data *pdu_ctrl_tx)


### PR DESCRIPTION
Overlapping Feature Exchange requested by host with
Encryption Setup requested by the application caused the
controller to corrupt its Tx queue leading to Tx Ctrl PDU
buffers from leaking from the system.

Relates to #21299.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>