### PR TITLE
Bluetooth: controller: split: Fix Tx Ctrl PDU leak

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1923,7 +1923,6 @@ static void ctrl_tx_sec_enqueue(struct ll_conn *conn, struct node_tx *tx)
 			conn->tx_data_last = tx;
 		}
 	} else {
-
 		/* check if Encryption Request is at head, enqueue this control
 		 * PDU after control last marker and before data marker.
 		 * This way it is paused until Encryption Setup completes.
@@ -1932,9 +1931,13 @@ static void ctrl_tx_sec_enqueue(struct ll_conn *conn, struct node_tx *tx)
 			struct pdu_data *pdu_data_tx;
 
 			pdu_data_tx = (void *)conn->tx_head->pdu;
-			if ((pdu_data_tx->ll_id == PDU_DATA_LLID_CTRL) &&
-			    (pdu_data_tx->llctrl.opcode ==
-			     PDU_DATA_LLCTRL_TYPE_ENC_REQ)) {
+			if ((conn->llcp_req != conn->llcp_ack) &&
+			    (conn->llcp_type == LLCP_ENCRYPTION) &&
+			    (pdu_data_tx->ll_id == PDU_DATA_LLID_CTRL) &&
+			    ((pdu_data_tx->llctrl.opcode ==
+			      PDU_DATA_LLCTRL_TYPE_ENC_REQ) ||
+			     (pdu_data_tx->llctrl.opcode ==
+			      PDU_DATA_LLCTRL_TYPE_PAUSE_ENC_REQ))) {
 				pause = true;
 			}
 		}

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -4406,7 +4406,7 @@ static void length_resp_send(struct ll_conn *conn, struct node_tx *tx,
 	pdu_tx->llctrl.length_rsp.max_tx_time = sys_cpu_to_le16(eff_tx_time);
 #endif /* CONFIG_BT_CTLR_PHY */
 
-	ctrl_tx_enqueue(conn, tx);
+	ctrl_tx_sec_enqueue(conn, tx);
 }
 
 static inline int length_req_rsp_recv(struct ll_conn *conn, memq_link_t *link,
@@ -4666,7 +4666,7 @@ static int ping_resp_send(struct ll_conn *conn, struct node_rx_pdu *rx)
 		      sizeof(struct pdu_data_llctrl_ping_rsp);
 	pdu_tx->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_PING_RSP;
 
-	ctrl_tx_enqueue(conn, tx);
+	ctrl_tx_sec_enqueue(conn, tx);
 
 	/* Mark for buffer for release */
 	rx->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -3321,6 +3321,7 @@ static inline void event_len_prep(struct ll_conn *conn)
 	}
 }
 
+#if defined(CONFIG_BT_CTLR_PHY)
 static u16_t calc_eff_time(u8_t max_octets, u8_t phy, u16_t default_time)
 {
 	u16_t time = PKT_US(max_octets, phy);
@@ -3337,6 +3338,7 @@ static u16_t calc_eff_time(u8_t max_octets, u8_t phy, u16_t default_time)
 
 	return eff_time;
 }
+#endif /* CONFIG_BT_CTLR_PHY */
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
 #if defined(CONFIG_BT_CTLR_PHY)
@@ -4463,8 +4465,6 @@ static inline int length_req_rsp_recv(struct ll_conn *conn, memq_link_t *link,
 		struct pdu_data_llctrl_length_req *lr;
 		u16_t max_rx_octets;
 		u16_t max_tx_octets;
-		u16_t max_rx_time;
-		u16_t max_tx_time;
 
 		lr = &pdu_rx->llctrl.length_req;
 
@@ -4487,6 +4487,9 @@ static inline int length_req_rsp_recv(struct ll_conn *conn, memq_link_t *link,
 		}
 
 #if defined(CONFIG_BT_CTLR_PHY)
+		u16_t max_rx_time;
+		u16_t max_tx_time;
+
 		/* use the minimal of our default_tx_time and
 		 * peer max_rx_time
 		 */


### PR DESCRIPTION
Overlapping Feature Exchange requested by host with
Encryption Setup requested by the application caused the
controller to corrupt its Tx queue leading to Tx Ctrl PDU
buffers from leaking from the system.

Fixes #21299.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>