### PR TITLE
bluetooth: fix removal of needed subscriptions

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -3425,7 +3425,7 @@ static void gatt_write_ccc_rsp(struct bt_conn *conn, u8_t err,
 
 		SYS_SLIST_FOR_EACH_NODE_SAFE(&subscriptions, node, tmp) {
 			if (node == &params->node) {
-				gatt_subscription_remove(conn, tmp, params);
+				gatt_subscription_remove(conn, prev, params);
 				break;
 			}
 


### PR DESCRIPTION
Providing 'tmp', which was never updated, resulted in removeal of
subscriptions from the beginning.
Using the updated 'prev' resolves this.

Fixes #21375 

Signed-off-by: Marco Sterbik <madbadmax00@gmail.com>