### PR TITLE
usb: samples: Do not depend remote wakeup on SoCs

### DIFF
--- a/samples/subsys/usb/hid-mouse/Kconfig
+++ b/samples/subsys/usb/hid-mouse/Kconfig
@@ -5,6 +5,6 @@ config USB_DEVICE_PID
 	default USB_PID_HID_MOUSE_SAMPLE
 
 config USB_DEVICE_REMOTE_WAKEUP
-	default y if (SOC_NRF52833 || SOC_NRF52840)
+	default y if NRFX_USBD
 
 source "Kconfig.zephyr"


### PR DESCRIPTION
Remote wakeup for Nordic SoCs should always be enabled.
Thus do not depend it for each SoC. Instead depend it on
chosen driver.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>