### PR TITLE
drivers/eeprom: stm32: Enables only for L1 series

### DIFF
--- a/drivers/eeprom/Kconfig.stm32
+++ b/drivers/eeprom/Kconfig.stm32
@@ -4,6 +4,7 @@
 config EEPROM_STM32
 	bool "STM32 EEPROM driver"
 	depends on SOC_SERIES_STM32L1X
+	default y
 	select USE_STM32_HAL_FLASH
 	select USE_STM32_HAL_FLASH_EX
 	help

--- a/soc/arm/st_stm32/common/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/common/Kconfig.defconfig.series
@@ -115,11 +115,4 @@ config DMA_STM32
 
 endif # DMA
 
-if EEPROM
-
-config EEPROM_STM32
-	default y
-
-endif # EEPROM
-
 endif # SOC_FAMILY_STM32


### PR DESCRIPTION
Setting EEPROM_STM32 with `default y` under `if SOC_FAMILY_STM32`
overrides `depends on SOC_SERIES_STM32L1X` in EEPROM_STM32
definition.
Then, if ever EEPROM is set in any file (as in
tests/drivers/build_all`), EEPROM_STM32 will be indeed set,
with potential issues on series where driver is not yet correctly
handled.

Fix this by removing EEPROM_STM32 definition in STM32 generic
file and set `default y` along with the `depends on` to keep
it effective.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>