### PR TITLE
net: openthread: Update OpenThread version and better CMake integration

### DIFF
--- a/drivers/ieee802154/CMakeLists.txt
+++ b/drivers/ieee802154/CMakeLists.txt
@@ -9,12 +9,3 @@ zephyr_sources_ifdef(CONFIG_IEEE802154_CC1200 ieee802154_cc1200.c)
 zephyr_sources_ifdef(CONFIG_IEEE802154_CC13XX_CC26XX ieee802154_cc13xx_cc26xx.c)
 zephyr_sources_ifdef(CONFIG_IEEE802154_RF2XX ieee802154_rf2xx.c)
 zephyr_sources_ifdef(CONFIG_IEEE802154_RF2XX ieee802154_rf2xx_iface.c)
-
-if(CONFIG_NET_L2_OPENTHREAD)
-  # This driver calls DEVICE_INIT with the context of openthread. The
-  # context of openthread is defined in one of OpenThread's header
-  # files so we need express that this driver depends on OpenThread
-  # being downloaded to make sure that we don't build this driver
-  # before all of it's header file dependencies are met.
-  add_dependencies(${ZEPHYR_CURRENT_LIBRARY} ot)
-endif()

--- a/subsys/net/l2/openthread/CMakeLists.txt
+++ b/subsys/net/l2/openthread/CMakeLists.txt
@@ -11,7 +11,3 @@ zephyr_library_sources(
   openthread.c
   openthread_utils.c
   )
-
-add_dependencies(subsys__net__ip__l2__openthread
-  ot
-  )

--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(net_l2_openthread, CONFIG_OPENTHREAD_L2_LOG_LEVEL);
 #include <init.h>
 #include <sys/util.h>
 #include <sys/__assert.h>
+#include <version.h>
 
 #include <openthread/cli.h>
 #include <openthread/ip6.h>
@@ -58,6 +59,9 @@ LOG_MODULE_REGISTER(net_l2_openthread, CONFIG_OPENTHREAD_L2_LOG_LEVEL);
 #else
 #define OT_POLL_PERIOD 0
 #endif
+
+#define PACKAGE_NAME "Zephyr"
+#define PACKAGE_VERSION KERNEL_VERSION_STRING
 
 extern void platformShellInit(otInstance *aInstance);
 

--- a/subsys/net/lib/openthread/CMakeLists.txt
+++ b/subsys/net/lib/openthread/CMakeLists.txt
@@ -1,3 +1,37 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(platform)
+
+# Obtain OpenThread repository root directory
+execute_process(
+    COMMAND
+    ${WEST} list -f {posixpath} openthread
+    OUTPUT_VARIABLE ot_root_dir OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Include OpenThread headers
+zephyr_system_include_directories(${ot_root_dir}/include)
+zephyr_system_include_directories(${ot_root_dir}/examples/platforms)
+
+# Determine which libs should be linked in
+set(ot_libs "")
+
+if(CONFIG_OPENTHREAD_FTD)
+set(cli_lib openthread-cli-ftd)
+elseif(CONFIG_OPENTHREAD_MTD)
+set(cli_lib openthread-cli-mtd)
+endif()
+
+if(CONFIG_OPENTHREAD_SHELL)
+list(APPEND ot_libs ${cli_lib})
+endif()
+
+if(CONFIG_OPENTHREAD_FTD)
+list(APPEND ot_libs openthread-ftd)
+elseif(CONFIG_OPENTHREAD_MTD)
+list(APPEND ot_libs openthread-mtd)
+endif()
+
+list(APPEND ot_libs openthread-platform-utils-static)
+
+zephyr_link_libraries(${ot_libs})

--- a/subsys/net/lib/openthread/platform/CMakeLists.txt
+++ b/subsys/net/lib/openthread/platform/CMakeLists.txt
@@ -13,7 +13,3 @@ zephyr_library_sources(
   )
 
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_SHELL shell.c)
-
-# The source files here use header files from the OpenThread project
-# target_link_libraries(app ot_lib) # Better?
-add_dependencies(openthread_platform ot)

--- a/west.yml
+++ b/west.yml
@@ -89,7 +89,7 @@ manifest:
       revision: 9b591b289e1f37339bd038b5a1f0e6c8ad39c63a
       path: modules/lib/open-amp
     - name: openthread
-      revision: 882e7074b5986027b85cb4f3ba1dc563a11ca013
+      revision: 5496d9df4866e7761f3d06e5ea284d4acdeb4544
       path: modules/lib/openthread
     - name: segger
       revision: 6fcf61606d6012d2c44129edc033f59331e268bc


### PR DESCRIPTION
OpenThread recently introduced CMake build system into its repostiory so we no longer need autotools to build OpenThread libraries and can integrate them natively.

The corresponding PR in the OpenThread repository: https://github.com/zephyrproject-rtos/openthread/pull/3

DNM until the OT PR is merged so I can update the commit sha in the manifest.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>