### PR TITLE
dts: gen_defines.py: Support generating static initializers for nodes

### DIFF
--- a/dts/binding-template.yaml
+++ b/dts/binding-template.yaml
@@ -73,6 +73,48 @@ bus: <string describing bus type, e.g. "i2c">
 # device to have different bindings depending on what bus it appears on.
 on-bus: <string describing bus type, e.g. "i2c">
 
+# If 'generate-child-initializer: true' appears in the binding for a node, then
+# static initializers will be generated for the child nodes of the node, along
+# with a static initializer for an array with the child nodes.
+#
+# As an example, take the following devicetree. Assume that the binding for
+# 'foos' contains 'generate-child-initializer: true', and that it gives the
+# foo_0 and foo_1 nodes a binding via 'child-binding:' (see below).
+#
+#     / {
+#             foos@0 {
+#                     compatible = "foos";
+#                     foo_0 {
+#                             int = <0>;
+#                             string = "foo";
+#                     };
+#                     foo_1 {
+#                             int = <1>;
+#                             array = <2 3>;
+#                     };
+#             };
+#     };
+#
+# These additional static initializers will then be generated, along with
+# aliases. The order of the properties in the initializer matches the order in
+# the devicetree.
+#
+#     /* Initializer for foo_0 */
+#     #define DT_FOOS_0_FOO_0_INIT   {DT_FOOS_0_FOO_0_INT, DT_FOOS_0_FOO_0_STRING}
+#     /* Initializer for foo_1 */
+#     #define DT_FOOS_0_FOO_1_INIT   {DT_FOOS_0_FOO_1_INT, DT_FOOS_0_FOO_1_ARRAY}
+#     /* Initializer for the children of foos@0 */
+#     #define DT_FOOS_0_INIT         {DT_FOOS_0_FOO_0_INIT, DT_FOOS_0_FOO_1_INIT}
+#
+# The referenced macros initialize each property (note that these are always
+# generated):
+#
+#     #define DT_FOOS_0_FOO_0_INT    0
+#     #define DT_FOOS_0_FOO_0_STRING "foo"
+#     #define DT_FOOS_0_FOO_1_INT    1
+#     #define DT_FOOS_0_FOO_1_ARRAY  {2, 3}
+generate-child-initializer: true
+
 # 'properties' describes properties on the node, e.g.
 #
 #   reg = <1 2>;

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -486,7 +486,7 @@ class EDT:
 
         ok_top = {"title", "description", "compatible", "properties", "#cells",
                   "bus", "on-bus", "parent-bus", "child-bus", "parent", "child",
-                  "child-binding", "sub-node"}
+                  "child-binding", "sub-node", "generate-child-initializer"}
 
         for prop in binding:
             if prop not in ok_top and not prop.endswith("-cells"):
@@ -563,6 +563,11 @@ class EDT:
                        "'gpio-cells:', etc., instead. The name should match "
                        "the name of the corresponding phandle-array property "
                        "(see binding-template.yaml)".format(binding_path))
+
+        if "generate-child-initializer" in binding and \
+           not isinstance(binding["generate-child-initializer"], bool):
+            _err("malformed 'generate-child-initializer:' field in {} - "
+                 "should be true/false".format(binding_path))
 
         def ok_cells_val(val):
             # Returns True if 'val' is an okay value for '*-cells:' (or the
@@ -749,6 +754,10 @@ class Node:
     flash_controller:
       The flash controller for the node. Only meaningful for nodes representing
       flash partitions.
+
+    generate_child_initalizer:
+      True if the binding for the node has 'generate-child-initializer: true',
+      and False otherwise. See binding-template.yaml.
     """
     @property
     def name(self):
@@ -883,6 +892,12 @@ class Node:
         if controller.matching_compat == "soc-nv-flash":
             return controller.parent
         return controller
+
+    @property
+    def generate_child_initializer(self):
+        "See the class docstring"
+        return self._binding and \
+            bool(self._binding.get("generate-child-initializer"))
 
     def __repr__(self):
         return "<Node {} in '{}', {}>".format(

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -189,26 +189,7 @@ def write_props(node):
     # for the node
 
     for prop in node.props.values():
-        # Skip #size-cell and other property starting with #. Also skip mapping
-        # properties like 'gpio-map'.
-        if prop.name[0] == "#" or prop.name.endswith("-map"):
-            continue
-
-        # See write_clocks()
-        if prop.name == "clocks":
-            continue
-
-        # edtlib provides these as well (Property.val becomes an edtlib.Node
-        # and a list of edtlib.Nodes, respectively). Nothing is generated for
-        # them currently though.
-        if prop.type in {"phandle", "phandles"}:
-            continue
-
-        # Skip properties that we handle elsewhere
-        if prop.name in {
-            "reg", "compatible", "status", "interrupts",
-            "interrupt-controller", "gpio-controller"
-        }:
+        if not should_write(prop):
             continue
 
         if prop.description is not None:
@@ -233,12 +214,40 @@ def write_props(node):
         elif prop.type == "uint8-array":
             out_dev(node, ident,
                     "{ " + ", ".join("0x{:02x}".format(b) for b in prop.val) + " }")
-        elif prop.type == "phandle-array":
+        else:  # prop.type == "phandle-array"
             write_phandle_val_list(prop)
 
         # Generate DT_..._ENUM if there's an 'enum:' key in the binding
         if prop.enum_index is not None:
             out_dev(node, ident + "_ENUM", prop.enum_index)
+
+
+def should_write(prop):
+    # write_props() helper. Returns True if output should be generated for
+    # 'prop'.
+
+    # Skip #size-cell and other property starting with #. Also skip mapping
+    # properties like 'gpio-map'.
+    if prop.name[0] == "#" or prop.name.endswith("-map"):
+        return False
+
+    # See write_clocks()
+    if prop.name == "clocks":
+        return False
+
+    # For these, Property.val becomes an edtlib.Node, a list of edtlib.Nodes,
+    # and None, respectively. Nothing is generated for them though.
+    if prop.type in {"phandle", "phandles", "compound"}:
+        return False
+
+    # Skip properties that we handle elsewhere
+    if prop.name in {
+        "reg", "compatible", "status", "interrupts",
+        "interrupt-controller", "gpio-controller"
+    }:
+        return False
+
+    return True
 
 
 def write_bus(node):


### PR DESCRIPTION
Documentation (from the updated `dts/binding-template.yaml`):

```
If 'generate-child-initializer: true' appears in the binding for a node, then
static initializers will be generated for the child nodes of the node, along
with a static initializer for an array with the child nodes.

As an example, take the following devicetree. Assume that the binding for
'foos' contains 'generate-child-initializer: true', and that it gives the
foo_0 and foo_1 nodes a binding via 'child-binding:' (see below).

    / {
            foos@0 {
                    compatible = "foos";
                    foo_0 {
                            int = <0>;
                            string = "foo";
                    };
                    foo_1 {
                            int = <1>;
                            array = <2 3>;
                    };
            };
    };

These additional static initializers will then be generated, along with
aliases. The order of the properties in the initializer matches the order in
the devicetree.

    /* Initializer for foo_0 */
    #define DT_FOOS_0_FOO_0_INIT   {DT_FOOS_0_FOO_0_INT, DT_FOOS_0_FOO_0_STRING}
    /* Initializer for foo_1 */
    #define DT_FOOS_0_FOO_1_INIT   {DT_FOOS_0_FOO_1_INT, DT_FOOS_0_FOO_1_ARRAY}
    /* Initializer for the children of foos@0 */
    #define DT_FOOS_0_INIT         {DT_FOOS_0_FOO_0_INIT, DT_FOOS_0_FOO_1_INIT}

The referenced macros initialize each property (note that these are always
generated):

    #define DT_FOOS_0_FOO_0_INT    0
    #define DT_FOOS_0_FOO_0_STRING "foo"
    #define DT_FOOS_0_FOO_1_INT    1
    #define DT_FOOS_0_FOO_1_ARRAY  {2, 3}
```

Main commit:

```
dts: gen_defines.py: Support generating static initializers for nodes

Add a new 'generate-child-initializer' flag to bindings. When 'true',
static initializers will be generated for all child nodes of the node,
along with an initializer for an array that includes all the child
nodes.

This can be used to statically initialize structures and arrays derived
from devicetree data, e.g. for a list of LEDs.

See the updated documentation in doc/binding-template.yaml for more
information.

Fixes: #21239
```

Misc. refactoring:

```
dts: gen_defines.py: Add should_write() helper for properties

should_write() returns False for properties that are skipped in
write_properties().

Helps shorten write_properties() a bit. Want to keep it manageable when
adding some new stuff.
```

```
dts: gen_defines.py: Add helper for outputting {} initializers

The

    "{" + ", ".join(...) + "}"

pattern is in a bunch of places now. Add an out_dev_init() helper for
it, with the same parameters as out_dev().
```