### PR TITLE
drivers: nrf: Add catch for nRF53 serial peripheral interferences

### DIFF
--- a/drivers/i2c/Kconfig.nrfx
+++ b/drivers/i2c/Kconfig.nrfx
@@ -16,11 +16,12 @@ if I2C_NRFX
 
 # In most Nordic SoCs, SPI and TWI peripherals with the same instance number
 # share certain resources and therefore cannot be used at the same time
-# (in nRF91 Series this limitation concerns UART peripherals as well).
+# (in nRF91 and nRF53 Series this limitation concerns UART peripherals as well).
 # In nRF52810 though, there are only single instances of these peripherals
 # and they are arranged in a different way, so this limitation does not apply.
 if I2C_0 && (SOC_NRF52810 || \
-             (!SPI_0 && !(SOC_SERIES_NRF91X && UART_0_NRF_UARTE)))
+	(!SPI_0 && !(SOC_SERIES_NRF91X && UART_0_NRF_UARTE)) || \
+	(!SPI_0 && !(SOC_SERIES_NRF53X && UART_0_NRF_UARTE)))
 
 choice I2C_0_NRF_TYPE
 	prompt "I2C Port 0 Driver type"
@@ -47,8 +48,10 @@ endif # I2C_0 && (SOC_NRF52810 || ...
 
 # In Nordic SoCs, SPI and TWI peripherals with the same instance number
 # share certain resources and therefore cannot be used at the same time
-# (in nRF91 Series this limitation concerns UART peripherals as well).
-if I2C_1 && !SPI_1 && !(SOC_SERIES_NRF91X && UART_1_NRF_UARTE)
+# (in nRF91 and nRF53 Series this limitation concerns UART peripherals as well).
+if I2C_1 && !SPI_1 && \
+	!(SOC_SERIES_NRF91X && UART_1_NRF_UARTE) && \
+	!(SOC_SERIES_NRF53X && UART_1_NRF_UARTE)
 
 choice I2C_1_NRF_TYPE
 	prompt "I2C Port 1 Driver type"
@@ -71,12 +74,14 @@ config I2C_1_NRF_TWIM
 
 endchoice
 
-endif # I2C_1 && !SPI_1 && !(SOC_SERIES_NRF91X && UART_1_NRF_UARTE)
+endif # I2C_1 && !SPI_1 && !(SOC_SERIES_NRF91X && UART_1_NRF_UARTE) && ...
 
 # In Nordic SoCs, SPI and TWI peripherals with the same instance number
 # share certain resources and therefore cannot be used at the same time
-# (in nRF91 Series this limitation concerns UART peripherals as well).
-if I2C_2 && !SPI_2 && !(SOC_SERIES_NRF91X && UART_2_NRF_UARTE)
+# (in nRF91 and nRF53 Series this limitation concerns UART peripherals as well).
+if I2C_2 && !SPI_2 && \
+	!(SOC_SERIES_NRF91X && UART_2_NRF_UARTE) && \
+	!(SOC_SERIES_NRF53X && UART_2_NRF_UARTE)
 
 choice I2C_2_NRF_TYPE
 	prompt "I2C Port 2 Driver type"
@@ -92,12 +97,14 @@ config I2C_2_NRF_TWIM
 
 endchoice
 
-endif # I2C_2 && !SPI_2 && !(SOC_SERIES_NRF91X && UART_2_NRF_UARTE)
+endif # I2C_2 && !SPI_2 && !(SOC_SERIES_NRF91X && UART_2_NRF_UARTE) && ...
 
 # In Nordic SoCs, SPI and TWI peripherals with the same instance number
 # share certain resources and therefore cannot be used at the same time
-# (in nRF91 Series SoCs this limitation concerns UART peripherals as well).
-if I2C_3 && !SPI_3 && !(SOC_SERIES_NRF91X && UART_3_NRF_UARTE)
+# (in nRF91 and nRF53 Series this limitation concerns UART peripherals as well).
+if I2C_3 && !SPI_3 && \
+	!(SOC_SERIES_NRF91X && UART_3_NRF_UARTE) && \
+	!(SOC_SERIES_NRF53X && UART_3_NRF_UARTE)
 
 choice I2C_3_NRF_TYPE
 	prompt "I2C Port 3 Driver type"
@@ -113,6 +120,6 @@ config I2C_3_NRF_TWIM
 
 endchoice
 
-endif # I2C_3 && !SPI_3 && !(SOC_SERIES_NRF91X && UART_3_NRF_UARTE)
+endif # I2C_3 && !SPI_3 && !(SOC_SERIES_NRF91X && UART_3_NRF_UARTE) && ...
 
 endif # I2C_NRFX

--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -32,10 +32,10 @@ config UART_0_NRF_UART
 
 config UART_0_NRF_UARTE
 	bool "nRF UARTE 0"
-	# In nRF91 Series SoCs, UART peripherals share certain resources with
+	# In nRF91 and nRF53 Series SoCs, UART peripherals share certain resources with
 	# SPI and TWI peripherals having the same instance number, and therefore
 	# these cannot be used simultaneously.
-	depends on HAS_HW_NRF_UARTE0 && !(SOC_SERIES_NRF91X && (SPI_0 || I2C_0))
+	depends on HAS_HW_NRF_UARTE0 && !((SOC_SERIES_NRF91X || SOC_SERIES_NRF53X) && (SPI_0 || I2C_0))
 	select NRF_UARTE_PERIPHERAL
 	help
 	  Enable nRF UART with EasyDMA on port 0.
@@ -106,10 +106,10 @@ endif # UART_0_NRF_UART || UART_0_NRF_UARTE
 # ----------------- port 1 -----------------
 config UART_1_NRF_UARTE
 	bool "nRF UARTE 1"
-	# In nRF91 Series SoCs, UART peripherals share certain resources with
+	# In nRF91 and nRF53 Series SoCs, UART peripherals share certain resources with
 	# SPI and TWI peripherals having the same instance number, and therefore
 	# these cannot be used simultaneously.
-	depends on HAS_HW_NRF_UARTE1 && !(SOC_SERIES_NRF91X && (SPI_1 || I2C_1))
+	depends on HAS_HW_NRF_UARTE1 && !((SOC_SERIES_NRF91X || SOC_SERIES_NRF53X) && (SPI_1 || I2C_1))
 	select NRF_UARTE_PERIPHERAL
 	help
 	  Enable nRF UART with EasyDMA on port 1.
@@ -178,10 +178,10 @@ endif # UART_1_NRF_UARTE
 # ----------------- port 2 -----------------
 config UART_2_NRF_UARTE
 	bool "nRF UARTE 2"
-	# In nRF91 Series SoCs, UART peripherals share certain resources with
+	# In nRF91 and nRF53 Series SoCs, UART peripherals share certain resources with
 	# SPI and TWI peripherals having the same instance number, and therefore
 	# these cannot be used simultaneously.
-	depends on HAS_HW_NRF_UARTE2 && !(SOC_SERIES_NRF91X && (SPI_2 || I2C_2))
+	depends on HAS_HW_NRF_UARTE2 && !((SOC_SERIES_NRF91X || SOC_SERIES_NRF53X) && (SPI_2 || I2C_2))
 	select NRF_UARTE_PERIPHERAL
 	help
 	  Enable nRF UART with EasyDMA on port 2.
@@ -249,10 +249,10 @@ endif # UART_2_NRF_UARTE
 # ----------------- port 3 -----------------
 config UART_3_NRF_UARTE
 	bool "nRF UARTE 3"
-	# In nRF91 Series SoCs, UART peripherals share certain resources with
+	# In nRF91 and nRF53 Series SoCs, UART peripherals share certain resources with
 	# SPI and TWI peripherals having the same instance number, and therefore
 	# these cannot be used simultaneously.
-	depends on HAS_HW_NRF_UARTE3 && !(SOC_SERIES_NRF91X && (SPI_3 || I2C_3))
+	depends on HAS_HW_NRF_UARTE3 && !((SOC_SERIES_NRF91X || SOC_SERIES_NRF53X) && (SPI_3 || I2C_3))
 	select NRF_UARTE_PERIPHERAL
 	help
 	  Enable nRF UART with EasyDMA on port 3.

--- a/drivers/spi/Kconfig.nrfx
+++ b/drivers/spi/Kconfig.nrfx
@@ -27,11 +27,12 @@ config SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58
 
 # In most Nordic SoCs, SPI and TWI peripherals with the same instance number
 # share certain resources and therefore cannot be used at the same time
-# (in nRF91 Series this limitation concerns UART peripherals as well).
+# (in nRF91 and nRF53 Series this limitation concerns UART peripherals as well).
 # In nRF52810 though, there are only single instances of these peripherals
 # and they are arranged in a different way, so this limitation does not apply.
 if SPI_0 && (SOC_NRF52810 || \
-             (!I2C_0 && !(SOC_SERIES_NRF91X && UART_0_NRF_UARTE)))
+	(!I2C_0 && !(SOC_SERIES_NRF91X && UART_0_NRF_UARTE)) ||\
+	(!I2C_0 && !(SOC_SERIES_NRF53X && UART_0_NRF_UARTE)))
 
 choice
 	prompt "SPI Port 0 Driver type"
@@ -81,9 +82,10 @@ endif # SPI_0 && (SOC_NRF52810 || ...
 
 # In Nordic SoCs, SPI and TWI peripherals with the same instance number
 # share certain resources and therefore cannot be used at the same time
-# (in nRF91 Series this limitation concerns UART peripherals as well).
-if SPI_1 && !I2C_1 && !(SOC_SERIES_NRF91X && UART_1_NRF_UARTE)
-
+# (in nRF91 and nRF53 Series this limitation concerns UART peripherals as well).
+if SPI_1 && !I2C_1 && \
+	!(SOC_SERIES_NRF91X && UART_1_NRF_UARTE) && \
+	!(SOC_SERIES_NRF53X && UART_1_NRF_UARTE)
 choice
 	prompt "SPI Port 1 Driver type"
 
@@ -128,13 +130,14 @@ config SPI_1_NRF_ORC
 
 endif # SPI_1_NRF_SPI || SPI_1_NRF_SPIM || SPI_1_NRF_SPIS
 
-endif # SPI_1 && !I2C_1 && !(SOC_SERIES_NRF91X && UART_1_NRF_UARTE)
+endif # SPI_1 && !I2C_1 && !(SOC_SERIES_NRF91X && UART_1_NRF_UARTE) && ...
 
 # In Nordic SoCs, SPI and TWI peripherals with the same instance number
 # share certain resources and therefore cannot be used at the same time
-# (in nRF91 Series this limitation concerns UART peripherals as well).
-if SPI_2 && !I2C_2 && !(SOC_SERIES_NRF91X && UART_2_NRF_UARTE)
-
+# (in nRF91 and nRF53 Series this limitation concerns UART peripherals as well).
+if SPI_2 && !I2C_2 && \
+	!(SOC_SERIES_NRF91X && UART_2_NRF_UARTE) && \
+	!(SOC_SERIES_NRF53X && UART_2_NRF_UARTE)
 choice
 	prompt "SPI Port 2 Driver type"
 
@@ -179,12 +182,14 @@ config SPI_2_NRF_ORC
 
 endif # SPI_2_NRF_SPI || SPI_2_NRF_SPIM || SPI_2_NRF_SPIS
 
-endif # SPI_2 && !I2C_2 && !(SOC_SERIES_NRF91X && UART_2_NRF_UARTE)
+endif # SPI_2 && !I2C_2 && !(SOC_SERIES_NRF91X && UART_2_NRF_UARTE) && ...
 
 # In Nordic SoCs, SPI and TWI peripherals with the same instance number
 # share certain resources and therefore cannot be used at the same time
-# (in nRF91 Series this limitation concerns UART peripherals as well).
-if SPI_3 && !I2C_3 && !(SOC_SERIES_NRF91X && UART_3_NRF_UARTE)
+# (in nRF91 and nRF53 Series this limitation concerns UART peripherals as well).
+if SPI_3 && !I2C_3 && \
+	!(SOC_SERIES_NRF91X && UART_3_NRF_UARTE) && \
+	!(SOC_SERIES_NRF53X && UART_3_NRF_UARTE)
 
 choice
 	prompt "SPI Port 3 Driver type"
@@ -230,7 +235,7 @@ config SPI_3_NRF_RX_DELAY
 	  edge of SCK (leading or trailing, depending on the CPHA setting used)
 	  until the input serial data on MISO is actually sampled.
 
-endif # SPI_3 && !I2C_3 && !(SOC_SERIES_NRF91X && UART_3_NRF_UARTE)
+endif # SPI_3 && !I2C_3 && !(SOC_SERIES_NRF91X && UART_3_NRF_UARTE) && ...
 
 if NRFX_SPIM
 


### PR DESCRIPTION
Serial types of the same number share resources on the nRF53 series. Add the same catches that were provided for the nRF91.
Signed-off-by: Marciano C. Preciado marciano@passive-logic.com