### PR TITLE
treewide: avoid address-of-compound-literal idiom in headers

### DIFF
--- a/include/bluetooth/addr.h
+++ b/include/bluetooth/addr.h
@@ -32,12 +32,12 @@ typedef struct {
 	bt_addr_t a;
 } bt_addr_le_t;
 
-#define BT_ADDR_ANY     (&(bt_addr_t) { { 0, 0, 0, 0, 0, 0 } })
-#define BT_ADDR_NONE    (&(bt_addr_t) { \
-			 { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } })
-#define BT_ADDR_LE_ANY  (&(bt_addr_le_t) { 0, { { 0, 0, 0, 0, 0, 0 } } })
-#define BT_ADDR_LE_NONE (&(bt_addr_le_t) { 0, \
-			 { { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } } })
+#define BT_ADDR_ANY     ((bt_addr_t[]) { { { 0, 0, 0, 0, 0, 0 } } })
+#define BT_ADDR_NONE    ((bt_addr_t[]) { { \
+			 { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } } })
+#define BT_ADDR_LE_ANY  ((bt_addr_le_t[]) { { 0, { { 0, 0, 0, 0, 0, 0 } } } })
+#define BT_ADDR_LE_NONE ((bt_addr_le_t[]) { { 0, \
+			 { { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } } } })
 
 static inline int bt_addr_cmp(const bt_addr_t *a, const bt_addr_t *b)
 {

--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -321,11 +321,11 @@ struct bt_le_adv_param {
   * @param _int_max   Maximum advertising interval
   */
 #define BT_LE_ADV_PARAM(_options, _int_min, _int_max) \
-		(&(struct bt_le_adv_param) { \
+		((struct bt_le_adv_param[]) { { \
 			.options = (_options), \
 			.interval_min = (_int_min), \
 			.interval_max = (_int_max), \
-		 })
+		 } })
 
 #define BT_LE_ADV_CONN BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE, \
 				       BT_GAP_ADV_FAST_INT_MIN_2, \
@@ -452,12 +452,12 @@ struct bt_le_scan_param {
   * @param _window   Scan Window (N * 0.625 ms)
   */
 #define BT_LE_SCAN_PARAM(_type, _filter, _interval, _window) \
-		(&(struct bt_le_scan_param) { \
+		((struct bt_le_scan_param[]) { { \
 			.type = (_type), \
 			.filter_dup = (_filter), \
 			.interval = (_interval), \
 			.window = (_window), \
-		 })
+		 } })
 
 /** Helper macro to enable active scanning to discover new devices. */
 #define BT_LE_SCAN_ACTIVE BT_LE_SCAN_PARAM(BT_LE_SCAN_TYPE_ACTIVE, \

--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -46,12 +46,12 @@ struct bt_le_conn_param {
   * @param to       Supervision Timeout (N * 10 ms)
   */
 #define BT_LE_CONN_PARAM(int_min, int_max, lat, to) \
-	(&(struct bt_le_conn_param) { \
+	((struct bt_le_conn_param[]) { { \
 		.interval_min = (int_min), \
 		.interval_max = (int_max), \
 		.latency = (lat), \
 		.timeout = (to), \
-	 })
+	 } })
 
 /** Default LE connection parameters:
   *   Connection Interval: 30-50 ms
@@ -859,9 +859,9 @@ struct bt_br_conn_param {
   * @param role_switch True if role switch is allowed
   */
 #define BT_BR_CONN_PARAM(role_switch) \
-	(&(struct bt_br_conn_param) { \
+	((struct bt_br_conn_param[]) { { \
 		.allow_role_switch = (role_switch), \
-	 })
+	 } })
 
 /** Default BR/EDR connection parameters:
   *   Role switch allowed

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -546,9 +546,9 @@ ssize_t bt_gatt_attr_read_chrc(struct bt_conn *conn,
 #define BT_GATT_CHARACTERISTIC(_uuid, _props, _perm, _read, _write, _value) \
 	BT_GATT_ATTRIBUTE(BT_UUID_GATT_CHRC, BT_GATT_PERM_READ,		\
 			  bt_gatt_attr_read_chrc, NULL,			\
-			  (&(struct bt_gatt_chrc) { .uuid = _uuid,	\
-						    .value_handle = 0U, \
-						    .properties = _props, })), \
+			  ((struct bt_gatt_chrc[]) { { .uuid = _uuid,	\
+						       .value_handle = 0U, \
+						       .properties = _props, } })), \
 	BT_GATT_ATTRIBUTE(_uuid, _perm, _read, _write, _value)
 
 #if IS_ENABLED(CONFIG_BT_SETTINGS_CCC_LAZY_LOADING)
@@ -660,8 +660,8 @@ ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
  *  @param _perm CCC access permissions.
  */
 #define BT_GATT_CCC(_changed, _perm)				\
-	BT_GATT_CCC_MANAGED((&(struct _bt_gatt_ccc)			\
-		BT_GATT_CCC_INITIALIZER(_changed, NULL, NULL)), _perm)
+	BT_GATT_CCC_MANAGED(((struct _bt_gatt_ccc[])			\
+		{BT_GATT_CCC_INITIALIZER(_changed, NULL, NULL)}), _perm)
 
 /** @brief Read Characteristic Extended Properties Attribute helper
  *

--- a/include/bluetooth/uuid.h
+++ b/include/bluetooth/uuid.h
@@ -69,11 +69,11 @@ struct bt_uuid_128 {
 }
 
 #define BT_UUID_DECLARE_16(value) \
-	((struct bt_uuid *) (&(struct bt_uuid_16) BT_UUID_INIT_16(value)))
+	((struct bt_uuid *) ((struct bt_uuid_16[]) {BT_UUID_INIT_16(value)}))
 #define BT_UUID_DECLARE_32(value) \
-	((struct bt_uuid *) (&(struct bt_uuid_32) BT_UUID_INIT_32(value)))
+	((struct bt_uuid *) ((struct bt_uuid_32[]) {BT_UUID_INIT_32(value)}))
 #define BT_UUID_DECLARE_128(value...) \
-	((struct bt_uuid *) (&(struct bt_uuid_128) BT_UUID_INIT_128(value)))
+	((struct bt_uuid *) ((struct bt_uuid_128[]) {BT_UUID_INIT_128(value)}))
 
 #define BT_UUID_16(__u) CONTAINER_OF(__u, struct bt_uuid_16, uuid)
 #define BT_UUID_32(__u) CONTAINER_OF(__u, struct bt_uuid_32, uuid)

--- a/include/data/json.h
+++ b/include/data/json.h
@@ -213,14 +213,14 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.offset = offsetof(struct_, field_name_), \
 		{ \
 			.array = { \
-				.element_descr = &(struct json_obj_descr) { \
+				.element_descr = (struct json_obj_descr[]) { { \
 					.align_shift = \
 						Z_ALIGN_SHIFT(struct_), \
 					.type = elem_type_, \
 					.offset = \
 						offsetof(struct_, \
 							 len_field_), \
-				}, \
+				} }, \
 				.n_elements = (max_len_), \
 			}, \
 		}, \
@@ -275,7 +275,7 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.offset = offsetof(struct_, field_name_), \
 		{ \
 			.array = { \
-				.element_descr = &(struct json_obj_descr) { \
+				.element_descr = (struct json_obj_descr[]) { { \
 					.align_shift = \
 						Z_ALIGN_SHIFT(struct_), \
 					.type = JSON_TOK_OBJECT_START, \
@@ -289,7 +289,7 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 							    elem_descr_len_, \
 						}, \
 					}, \
-				}, \
+				} }, \
 				.n_elements = (max_len_), \
 			}, \
 		}, \
@@ -353,7 +353,7 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.offset = offsetof(struct_, field_name_), \
 		{ \
 			.array = { \
-				.element_descr = &(struct json_obj_descr) { \
+				.element_descr = (struct json_obj_descr[]) { { \
 					.align_shift = \
 						Z_ALIGN_SHIFT(struct_), \
 					.type = JSON_TOK_LIST_START, \
@@ -367,7 +367,7 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 							    elem_descr_len_, \
 						}, \
 					}, \
-				}, \
+				} }, \
 				.n_elements = (max_len_), \
 			}, \
 		}, \
@@ -464,13 +464,13 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.offset = offsetof(struct_, struct_field_name_), \
 		{ \
 			.array = { \
-				.element_descr = &(struct json_obj_descr) { \
+				.element_descr = (struct json_obj_descr[]) { { \
 					.align_shift = \
 						Z_ALIGN_SHIFT(struct_), \
 					.type = elem_type_, \
 					.offset = offsetof(struct_, \
 							   len_field_), \
-				}, \
+				} }, \
 				.n_elements = (max_len_), \
 			}, \
 		}, \
@@ -534,7 +534,7 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.offset = offsetof(struct_, struct_field_name_), \
 		{ \
 			.array = { \
-				.element_descr = &(struct json_obj_descr) { \
+				.element_descr = (struct json_obj_descr[]) { { \
 					.align_shift = \
 						Z_ALIGN_SHIFT(struct_), \
 					.type = JSON_TOK_OBJECT_START, \
@@ -548,7 +548,7 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 							    elem_descr_len_, \
 						}, \
 					}, \
-				}, \
+				} }, \
 				.n_elements = (max_len_), \
 			}, \
 		}, \


### PR DESCRIPTION
In C99 the construct `(T){init-list}` is called a *compound literal*, and is an lvalue.  In C++ it is simply a cast expression to non-rvalue  type, which is a prvalue.  In both languages the expression is a temporary, but in C99 taking its address is well-defined while in C++  it is an error diagnosed as "taking address of temporary".
    
Headers that may be used in C++ application code must avoid invalid expressions.  Replace all uses of `&(T){init-list}` in headers with the functionally equivalent but C++-legal `(T[]){{init-list}}`.

Fixes #18551 for existing code.
Fixes #5695 as this is the last missing feature.

Because most uses of this idiom are in macros Coccinelle is not useful for locating or rewriting instances.  They can be detected by:

    git grep -P '&\((?:[^)(]+|(?R))*+\)\s*[A-Z{]' include/
