### PR TITLE
cmake: toolchain: generalize exclusion of CXX options

### DIFF
--- a/cmake/compiler/clang/target_warnings.cmake
+++ b/cmake/compiler/clang/target_warnings.cmake
@@ -27,9 +27,9 @@ macro(toolchain_cc_warning_dw_1)
     -Wno-unused-parameter
     -Wmissing-declarations
     -Wmissing-format-attribute
-    -Wold-style-definition
     )
   zephyr_cc_option(
+    -Wold-style-definition
     -Wmissing-prototypes
     -Wmissing-include-dirs
     -Wunused-but-set-variable
@@ -115,3 +115,10 @@ endmacro()
 macro(toolchain_cc_cpp_warning_error_misra_sane dest_var_name)
   set_ifndef(${dest_var_name} "-Werror=vla")
 endmacro()
+
+# List the warnings that are not supported for C++ compilations
+
+list(APPEND CXX_EXCLUDED_OPTIONS
+  -Werror=implicit-int
+  -Wold-style-definition
+  )

--- a/cmake/compiler/gcc/target_warnings.cmake
+++ b/cmake/compiler/gcc/target_warnings.cmake
@@ -34,9 +34,9 @@ macro(toolchain_cc_warning_dw_1)
     -Wno-unused-parameter
     -Wmissing-declarations
     -Wmissing-format-attribute
-    -Wold-style-definition
     )
   zephyr_cc_option(
+    -Wold-style-definition
     -Wmissing-prototypes
     -Wmissing-include-dirs
     -Wunused-but-set-variable
@@ -108,3 +108,10 @@ endmacro()
 macro(toolchain_cc_cpp_warning_error_misra_sane dest_var_name)
   set_ifndef(${dest_var_name} "-Werror=vla")
 endmacro()
+
+# List the warnings that are not supported for C++ compilations
+
+list(APPEND CXX_EXCLUDED_OPTIONS
+  -Werror=implicit-int
+  -Wold-style-definition
+  )

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -851,10 +851,10 @@ function(zephyr_check_compiler_flag lang option check)
 endfunction()
 
 function(zephyr_check_compiler_flag_hardcoded lang option check exists)
-  # -Werror=implicit-int is not supported for CXX and we are not able
-  # to automatically test for it because it produces a warning
-  # instead of an error during the test.
-  if((${lang} STREQUAL CXX) AND ("${option}" STREQUAL -Werror=implicit-int))
+  # Various flags that are not supported for CXX may not be testable
+  # because they would produce a warning instead of an error during
+  # the test.  Exclude them by toolchain-specific blacklist.
+  if((${lang} STREQUAL CXX) AND ("${option}" IN_LIST CXX_EXCLUDED_OPTIONS))
     set(check 0 PARENT_SCOPE)
     set(exists 1 PARENT_SCOPE)
   else()


### PR DESCRIPTION
`-Wold-style-definition` is not a supported option for C++ builds.  To prevent it being passed:
* the list of compiler flags to be excluded from C++ builds is moved to be toolchain-specific;
* `-Wold-style-definition` is added to that list for gcc and clang;
* `-Wold-style-definition` is moved from `zephyr_compiler_options` to `zephyr_cc_option` so the option checking code is executed for it.

Fixes #16239
