### PR TITLE
samples: net: wpanusb: Enable atsamr21_xpro board

### DIFF
--- a/boards/arm/atsamr21_xpro/doc/index.rst
+++ b/boards/arm/atsamr21_xpro/doc/index.rst
@@ -151,6 +151,10 @@ externally connected SPI devices.
 | SLP_TR      | PA20 (OUT, GPIO output)                                                                  |
 +-------------+------------------------------------------------------------------------------------------+
 
+Zephyr provide several samples that can use this technology. You can check
+:ref:`wpanusb-sample` and :ref:`wpan_serial-sample` examples as starting
+points.
+
 Programming and Debugging
 *************************
 

--- a/samples/net/wpanusb/README.rst
+++ b/samples/net/wpanusb/README.rst
@@ -16,7 +16,8 @@ Requirements
 ************
 
 - a Zephyr board with supported 802.15.4 radio and supported USB driver
-  (such as the :ref:`nrf52840_pca10056`) connected via USB to a Linux host
+  (such as the :ref:`nrf52840_pca10056` or :ref:`atsamr21_xpro`)
+  connected via USB to a Linux host
 - wpanusb Linux kernel driver (in the process of being open sourced)
 - wpan-tools (available for all Linux distributions)
 

--- a/samples/net/wpanusb/boards/atsamr21_xpro.conf
+++ b/samples/net/wpanusb/boards/atsamr21_xpro.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2019, Gerson Fernando Budke
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_NET_CONFIG_IEEE802154_DEV_NAME="RF2XX_0"


### PR DESCRIPTION
This enable wpanusb sample with atsamr21_xpro board using with rf2xx driver.
required: #21353