### PR TITLE
include: respect line limit in api pointer initialization

### DIFF
--- a/include/audio/codec.h
+++ b/include/audio/codec.h
@@ -133,7 +133,8 @@ struct audio_codec_api {
 static inline int audio_codec_configure(struct device *dev,
 		struct audio_codec_cfg *cfg)
 {
-	const struct audio_codec_api *api = (const struct audio_codec_api *)dev->driver_api;
+	const struct audio_codec_api *api =
+		(const struct audio_codec_api *)dev->driver_api;
 
 	return api->configure(dev, cfg);
 }
@@ -149,7 +150,8 @@ static inline int audio_codec_configure(struct device *dev,
  */
 static inline void audio_codec_start_output(struct device *dev)
 {
-	const struct audio_codec_api *api = (const struct audio_codec_api *)dev->driver_api;
+	const struct audio_codec_api *api =
+		(const struct audio_codec_api *)dev->driver_api;
 
 	api->start_output(dev);
 }
@@ -165,7 +167,8 @@ static inline void audio_codec_start_output(struct device *dev)
  */
 static inline void audio_codec_stop_output(struct device *dev)
 {
-	const struct audio_codec_api *api = (const struct audio_codec_api *)dev->driver_api;
+	const struct audio_codec_api *api =
+		(const struct audio_codec_api *)dev->driver_api;
 
 	api->stop_output(dev);
 }
@@ -185,7 +188,8 @@ static inline void audio_codec_stop_output(struct device *dev)
 static inline int audio_codec_set_property(struct device *dev, audio_property_t property,
 		audio_channel_t channel, audio_property_value_t val)
 {
-	const struct audio_codec_api *api = (const struct audio_codec_api *)dev->driver_api;
+	const struct audio_codec_api *api =
+		(const struct audio_codec_api *)dev->driver_api;
 
 	return api->set_property(dev, property, channel, val);
 }
@@ -203,7 +207,8 @@ static inline int audio_codec_set_property(struct device *dev, audio_property_t 
  */
 static inline int audio_codec_apply_properties(struct device *dev)
 {
-	const struct audio_codec_api *api = (const struct audio_codec_api *)dev->driver_api;
+	const struct audio_codec_api *api =
+		(const struct audio_codec_api *)dev->driver_api;
 
 	return api->apply_properties(dev);
 }

--- a/include/audio/dmic.h
+++ b/include/audio/dmic.h
@@ -225,7 +225,8 @@ static inline u32_t dmic_build_clk_skew_map(u8_t pdm, u8_t skew)
  */
 static inline int dmic_configure(struct device *dev, struct dmic_cfg *cfg)
 {
-	const struct _dmic_ops *api = (const struct _dmic_ops *)dev->driver_api;
+	const struct _dmic_ops *api =
+		(const struct _dmic_ops *)dev->driver_api;
 
 	return api->configure(dev, cfg);
 }
@@ -242,7 +243,8 @@ static inline int dmic_configure(struct device *dev, struct dmic_cfg *cfg)
  */
 static inline int dmic_trigger(struct device *dev, enum dmic_trigger cmd)
 {
-	const struct _dmic_ops *api = (const struct _dmic_ops *)dev->driver_api;
+	const struct _dmic_ops *api =
+		(const struct _dmic_ops *)dev->driver_api;
 
 	return api->trigger(dev, cmd);
 }
@@ -264,7 +266,8 @@ static inline int dmic_trigger(struct device *dev, enum dmic_trigger cmd)
 static inline int dmic_read(struct device *dev, u8_t stream, void **buffer,
 		size_t *size, s32_t timeout)
 {
-	const struct _dmic_ops *api = (const struct _dmic_ops *)dev->driver_api;
+	const struct _dmic_ops *api =
+		(const struct _dmic_ops *)dev->driver_api;
 
 	return api->read(dev, stream, buffer, size, timeout);
 }

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -542,7 +542,8 @@ static inline
 enum can_state z_impl_can_get_state(struct device *dev,
 				    struct can_bus_err_cnt *err_cnt)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->driver_api;
+	const struct can_driver_api *api =
+		(const struct can_driver_api *)dev->driver_api;
 
 	return api->get_state(dev, err_cnt);
 }
@@ -563,7 +564,8 @@ __syscall int can_recover(struct device *dev, s32_t timeout);
 
 static inline int z_impl_can_recover(struct device *dev, s32_t timeout)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->driver_api;
+	const struct can_driver_api *api =
+		(const struct can_driver_api *)dev->driver_api;
 
 	return api->recover(dev, timeout);
 }
@@ -588,7 +590,8 @@ static inline
 void can_register_state_change_isr(struct device *dev,
 				   can_state_change_isr_t isr)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->driver_api;
+	const struct can_driver_api *api =
+		(const struct can_driver_api *)dev->driver_api;
 
 	return api->register_state_change_isr(dev, isr);
 }

--- a/include/drivers/eeprom.h
+++ b/include/drivers/eeprom.h
@@ -60,7 +60,8 @@ __syscall int eeprom_read(struct device *dev, off_t offset, void *data,
 static inline int z_impl_eeprom_read(struct device *dev, off_t offset,
 				     void *data, size_t len)
 {
-	const struct eeprom_driver_api *api = (const struct eeprom_driver_api *)dev->driver_api;
+	const struct eeprom_driver_api *api =
+		(const struct eeprom_driver_api *)dev->driver_api;
 
 	return api->read(dev, offset, data, len);
 }
@@ -81,7 +82,8 @@ __syscall int eeprom_write(struct device *dev, off_t offset, const void *data,
 static inline int z_impl_eeprom_write(struct device *dev, off_t offset,
 				      const void *data, size_t len)
 {
-	const struct eeprom_driver_api *api = (const struct eeprom_driver_api *)dev->driver_api;
+	const struct eeprom_driver_api *api =
+		(const struct eeprom_driver_api *)dev->driver_api;
 
 	return api->write(dev, offset, data, len);
 }
@@ -97,7 +99,8 @@ __syscall size_t eeprom_get_size(struct device *dev);
 
 static inline size_t z_impl_eeprom_get_size(struct device *dev)
 {
-	const struct eeprom_driver_api *api = (const struct eeprom_driver_api *)dev->driver_api;
+	const struct eeprom_driver_api *api =
+		(const struct eeprom_driver_api *)dev->driver_api;
 
 	return api->size(dev);
 }

--- a/include/drivers/flash.h
+++ b/include/drivers/flash.h
@@ -101,7 +101,8 @@ __syscall int flash_read(struct device *dev, off_t offset, void *data,
 static inline int z_impl_flash_read(struct device *dev, off_t offset, void *data,
 			     size_t len)
 {
-	const struct flash_driver_api *api = (const struct flash_driver_api *)dev->driver_api;
+	const struct flash_driver_api *api =
+		(const struct flash_driver_api *)dev->driver_api;
 
 	return api->read(dev, offset, data, len);
 }
@@ -125,7 +126,8 @@ __syscall int flash_write(struct device *dev, off_t offset, const void *data,
 static inline int z_impl_flash_write(struct device *dev, off_t offset,
 				    const void *data, size_t len)
 {
-	const struct flash_driver_api *api = (const struct flash_driver_api *)dev->driver_api;
+	const struct flash_driver_api *api =
+		(const struct flash_driver_api *)dev->driver_api;
 
 	return api->write(dev, offset, data, len);
 }
@@ -156,7 +158,8 @@ __syscall int flash_erase(struct device *dev, off_t offset, size_t size);
 static inline int z_impl_flash_erase(struct device *dev, off_t offset,
 				    size_t size)
 {
-	const struct flash_driver_api *api = (const struct flash_driver_api *)dev->driver_api;
+	const struct flash_driver_api *api =
+		(const struct flash_driver_api *)dev->driver_api;
 
 	return api->erase(dev, offset, size);
 }
@@ -199,7 +202,8 @@ __syscall int flash_write_protection_set(struct device *dev, bool enable);
 static inline int z_impl_flash_write_protection_set(struct device *dev,
 						   bool enable)
 {
-	const struct flash_driver_api *api = (const struct flash_driver_api *)dev->driver_api;
+	const struct flash_driver_api *api =
+		(const struct flash_driver_api *)dev->driver_api;
 
 	return api->write_protection(dev, enable);
 }
@@ -286,7 +290,8 @@ __syscall size_t flash_get_write_block_size(struct device *dev);
 
 static inline size_t z_impl_flash_get_write_block_size(struct device *dev)
 {
-	const struct flash_driver_api *api = (const struct flash_driver_api *)dev->driver_api;
+	const struct flash_driver_api *api =
+		(const struct flash_driver_api *)dev->driver_api;
 
 	return api->write_block_size;
 }

--- a/include/drivers/gna.h
+++ b/include/drivers/gna.h
@@ -137,7 +137,8 @@ struct gna_driver_api {
  */
 static inline int gna_configure(struct device *dev, struct gna_config *cfg)
 {
-	const struct gna_driver_api *api = (const struct gna_driver_api *)dev->driver_api;
+	const struct gna_driver_api *api =
+		(const struct gna_driver_api *)dev->driver_api;
 
 	return api->configure(dev, cfg);
 }
@@ -158,7 +159,8 @@ static inline int gna_configure(struct device *dev, struct gna_config *cfg)
 static inline int gna_register_model(struct device *dev,
 		struct gna_model_info *model, void **model_handle)
 {
-	const struct gna_driver_api *api = (const struct gna_driver_api *)dev->driver_api;
+	const struct gna_driver_api *api =
+		(const struct gna_driver_api *)dev->driver_api;
 
 	return api->register_model(dev, model, model_handle);
 }
@@ -178,7 +180,8 @@ static inline int gna_register_model(struct device *dev,
  */
 static inline int gna_deregister_model(struct device *dev, void *model)
 {
-	const struct gna_driver_api *api = (const struct gna_driver_api *)dev->driver_api;
+	const struct gna_driver_api *api =
+		(const struct gna_driver_api *)dev->driver_api;
 
 	return api->deregister_model(dev, model);
 }
@@ -200,7 +203,8 @@ static inline int gna_deregister_model(struct device *dev, void *model)
 static inline int gna_infer(struct device *dev, struct gna_inference_req *req,
 	gna_callback callback)
 {
-	const struct gna_driver_api *api = (const struct gna_driver_api *)dev->driver_api;
+	const struct gna_driver_api *api =
+		(const struct gna_driver_api *)dev->driver_api;
 
 	return api->infer(dev, req, callback);
 }

--- a/include/drivers/i2s.h
+++ b/include/drivers/i2s.h
@@ -352,7 +352,8 @@ __syscall int i2s_configure(struct device *dev, enum i2s_dir dir,
 static inline int z_impl_i2s_configure(struct device *dev, enum i2s_dir dir,
 				      struct i2s_config *cfg)
 {
-	const struct i2s_driver_api *api = (const struct i2s_driver_api *)dev->driver_api;
+	const struct i2s_driver_api *api =
+		(const struct i2s_driver_api *)dev->driver_api;
 
 	return api->configure(dev, dir, cfg);
 }
@@ -368,7 +369,8 @@ static inline int z_impl_i2s_configure(struct device *dev, enum i2s_dir dir,
 static inline struct i2s_config *i2s_config_get(struct device *dev,
 						enum i2s_dir dir)
 {
-	const struct i2s_driver_api *api = (const struct i2s_driver_api *)dev->driver_api;
+	const struct i2s_driver_api *api =
+		(const struct i2s_driver_api *)dev->driver_api;
 
 	return api->config_get(dev, dir);
 }
@@ -407,7 +409,8 @@ static inline struct i2s_config *i2s_config_get(struct device *dev,
 static inline int i2s_read(struct device *dev, void **mem_block,
 				 size_t *size)
 {
-	const struct i2s_driver_api *api = (const struct i2s_driver_api *)dev->driver_api;
+	const struct i2s_driver_api *api =
+		(const struct i2s_driver_api *)dev->driver_api;
 
 	return api->read(dev, mem_block, size);
 }
@@ -466,7 +469,8 @@ __syscall int i2s_buf_read(struct device *dev, void *buf, size_t *size);
  */
 static inline int i2s_write(struct device *dev, void *mem_block, size_t size)
 {
-	const struct i2s_driver_api *api = (const struct i2s_driver_api *)dev->driver_api;
+	const struct i2s_driver_api *api =
+		(const struct i2s_driver_api *)dev->driver_api;
 
 	return api->write(dev, mem_block, size);
 }
@@ -511,7 +515,8 @@ __syscall int i2s_trigger(struct device *dev, enum i2s_dir dir,
 static inline int z_impl_i2s_trigger(struct device *dev, enum i2s_dir dir,
 				    enum i2s_trigger_cmd cmd)
 {
-	const struct i2s_driver_api *api = (const struct i2s_driver_api *)dev->driver_api;
+	const struct i2s_driver_api *api =
+		(const struct i2s_driver_api *)dev->driver_api;
 
 	return api->trigger(dev, dir, cmd);
 }

--- a/include/drivers/ipm.h
+++ b/include/drivers/ipm.h
@@ -134,7 +134,8 @@ __syscall int ipm_send(struct device *ipmdev, int wait, u32_t id,
 static inline int z_impl_ipm_send(struct device *ipmdev, int wait, u32_t id,
 			   const void *data, int size)
 {
-	const struct ipm_driver_api *api = (const struct ipm_driver_api *)ipmdev->driver_api;
+	const struct ipm_driver_api *api =
+		(const struct ipm_driver_api *)ipmdev->driver_api;
 
 	return api->send(ipmdev, wait, id, data, size);
 }
@@ -150,7 +151,8 @@ static inline int z_impl_ipm_send(struct device *ipmdev, int wait, u32_t id,
 static inline void ipm_register_callback(struct device *ipmdev,
 					 ipm_callback_t cb, void *context)
 {
-	const struct ipm_driver_api *api = (const struct ipm_driver_api *)ipmdev->driver_api;
+	const struct ipm_driver_api *api =
+		(const struct ipm_driver_api *)ipmdev->driver_api;
 
 	api->register_callback(ipmdev, cb, context);
 }
@@ -169,7 +171,8 @@ __syscall int ipm_max_data_size_get(struct device *ipmdev);
 
 static inline int z_impl_ipm_max_data_size_get(struct device *ipmdev)
 {
-	const struct ipm_driver_api *api = (const struct ipm_driver_api *)ipmdev->driver_api;
+	const struct ipm_driver_api *api =
+		(const struct ipm_driver_api *)ipmdev->driver_api;
 
 	return api->max_data_size_get(ipmdev);
 }
@@ -189,7 +192,8 @@ __syscall u32_t ipm_max_id_val_get(struct device *ipmdev);
 
 static inline u32_t z_impl_ipm_max_id_val_get(struct device *ipmdev)
 {
-	const struct ipm_driver_api *api = (const struct ipm_driver_api *)ipmdev->driver_api;
+	const struct ipm_driver_api *api =
+		(const struct ipm_driver_api *)ipmdev->driver_api;
 
 	return api->max_id_val_get(ipmdev);
 }
@@ -207,7 +211,8 @@ __syscall int ipm_set_enabled(struct device *ipmdev, int enable);
 
 static inline int z_impl_ipm_set_enabled(struct device *ipmdev, int enable)
 {
-	const struct ipm_driver_api *api = (const struct ipm_driver_api *)ipmdev->driver_api;
+	const struct ipm_driver_api *api =
+		(const struct ipm_driver_api *)ipmdev->driver_api;
 
 	return api->set_enabled(ipmdev, enable);
 }

--- a/include/drivers/led.h
+++ b/include/drivers/led.h
@@ -77,7 +77,8 @@ __syscall int led_blink(struct device *dev, u32_t led,
 static inline int z_impl_led_blink(struct device *dev, u32_t led,
 			    u32_t delay_on, u32_t delay_off)
 {
-	const struct led_driver_api *api = (const struct led_driver_api *)dev->driver_api;
+	const struct led_driver_api *api =
+		(const struct led_driver_api *)dev->driver_api;
 
 	return api->blink(dev, led, delay_on, delay_off);
 }
@@ -99,7 +100,8 @@ __syscall int led_set_brightness(struct device *dev, u32_t led,
 static inline int z_impl_led_set_brightness(struct device *dev, u32_t led,
 				     u8_t value)
 {
-	const struct led_driver_api *api = (const struct led_driver_api *)dev->driver_api;
+	const struct led_driver_api *api =
+		(const struct led_driver_api *)dev->driver_api;
 
 	return api->set_brightness(dev, led, value);
 }
@@ -117,7 +119,8 @@ __syscall int led_on(struct device *dev, u32_t led);
 
 static inline int z_impl_led_on(struct device *dev, u32_t led)
 {
-	const struct led_driver_api *api = (const struct led_driver_api *)dev->driver_api;
+	const struct led_driver_api *api =
+		(const struct led_driver_api *)dev->driver_api;
 
 	return api->on(dev, led);
 }
@@ -135,7 +138,8 @@ __syscall int led_off(struct device *dev, u32_t led);
 
 static inline int z_impl_led_off(struct device *dev, u32_t led)
 {
-	const struct led_driver_api *api = (const struct led_driver_api *)dev->driver_api;
+	const struct led_driver_api *api =
+		(const struct led_driver_api *)dev->driver_api;
 
 	return api->off(dev, led);
 }

--- a/include/irq_nextlevel.h
+++ b/include/irq_nextlevel.h
@@ -51,7 +51,8 @@ struct irq_next_level_api {
  */
 static inline void irq_enable_next_level(struct device *dev, u32_t irq)
 {
-	const struct irq_next_level_api *api = (const struct irq_next_level_api *)dev->driver_api;
+	const struct irq_next_level_api *api =
+		(const struct irq_next_level_api *)dev->driver_api;
 
 	api->intr_enable(dev, irq);
 }
@@ -68,7 +69,8 @@ static inline void irq_enable_next_level(struct device *dev, u32_t irq)
  */
 static inline void irq_disable_next_level(struct device *dev, u32_t irq)
 {
-	const struct irq_next_level_api *api = (const struct irq_next_level_api *)dev->driver_api;
+	const struct irq_next_level_api *api =
+		(const struct irq_next_level_api *)dev->driver_api;
 
 	api->intr_disable(dev, irq);
 }
@@ -85,7 +87,8 @@ static inline void irq_disable_next_level(struct device *dev, u32_t irq)
  */
 static inline unsigned int irq_is_enabled_next_level(struct device *dev)
 {
-	const struct irq_next_level_api *api = (const struct irq_next_level_api *)dev->driver_api;
+	const struct irq_next_level_api *api =
+		(const struct irq_next_level_api *)dev->driver_api;
 
 	return api->intr_get_state(dev);
 }
@@ -106,7 +109,8 @@ static inline unsigned int irq_is_enabled_next_level(struct device *dev)
 static inline void irq_set_priority_next_level(struct device *dev, u32_t irq,
 		u32_t prio, u32_t flags)
 {
-	const struct irq_next_level_api *api = (const struct irq_next_level_api *)dev->driver_api;
+	const struct irq_next_level_api *api =
+		(const struct irq_next_level_api *)dev->driver_api;
 
 	if (api->intr_set_priority)
 		api->intr_set_priority(dev, irq, prio, flags);
@@ -125,7 +129,8 @@ static inline void irq_set_priority_next_level(struct device *dev, u32_t irq,
 static inline unsigned int irq_line_is_enabled_next_level(struct device *dev,
 							  unsigned int irq)
 {
-	const struct irq_next_level_api *api = (const struct irq_next_level_api *)dev->driver_api;
+	const struct irq_next_level_api *api =
+		(const struct irq_next_level_api *)dev->driver_api;
 
 	return api->intr_get_line_state(dev, irq);
 }

--- a/include/ptp_clock.h
+++ b/include/ptp_clock.h
@@ -39,7 +39,8 @@ struct ptp_clock_driver_api {
  */
 static inline int ptp_clock_set(struct device *dev, struct net_ptp_time *tm)
 {
-	const struct ptp_clock_driver_api *api = (const struct ptp_clock_driver_api *)dev->driver_api;
+	const struct ptp_clock_driver_api *api =
+		(const struct ptp_clock_driver_api *)dev->driver_api;
 
 	return api->set(dev, tm);
 }
@@ -57,7 +58,8 @@ __syscall int ptp_clock_get(struct device *dev, struct net_ptp_time *tm);
 static inline int z_impl_ptp_clock_get(struct device *dev,
 				       struct net_ptp_time *tm)
 {
-	const struct ptp_clock_driver_api *api = (const struct ptp_clock_driver_api *)dev->driver_api;
+	const struct ptp_clock_driver_api *api =
+		(const struct ptp_clock_driver_api *)dev->driver_api;
 
 	return api->get(dev, tm);
 }
@@ -72,7 +74,8 @@ static inline int z_impl_ptp_clock_get(struct device *dev,
  */
 static inline int ptp_clock_adjust(struct device *dev, int increment)
 {
-	const struct ptp_clock_driver_api *api = (const struct ptp_clock_driver_api *)dev->driver_api;
+	const struct ptp_clock_driver_api *api =
+		(const struct ptp_clock_driver_api *)dev->driver_api;
 
 	return api->adjust(dev, increment);
 }
@@ -87,7 +90,8 @@ static inline int ptp_clock_adjust(struct device *dev, int increment)
  */
 static inline int ptp_clock_rate_adjust(struct device *dev, float rate)
 {
-	const struct ptp_clock_driver_api *api = (const struct ptp_clock_driver_api *)dev->driver_api;
+	const struct ptp_clock_driver_api *api =
+		(const struct ptp_clock_driver_api *)dev->driver_api;
 
 	return api->rate_adjust(dev, rate);
 }

--- a/include/shared_irq.h
+++ b/include/shared_irq.h
@@ -59,7 +59,8 @@ struct shared_irq_runtime {
 static inline int shared_irq_isr_register(struct device *dev, isr_t isr_func,
 				 struct device *isr_dev)
 {
-	const struct shared_irq_driver_api *api = (const struct shared_irq_driver_api *)dev->driver_api;
+	const struct shared_irq_driver_api *api =
+		(const struct shared_irq_driver_api *)dev->driver_api;
 
 	return api->isr_register(dev, isr_func, isr_dev);
 }
@@ -71,7 +72,8 @@ static inline int shared_irq_isr_register(struct device *dev, isr_t isr_func,
  */
 static inline int shared_irq_enable(struct device *dev, struct device *isr_dev)
 {
-	const struct shared_irq_driver_api *api = (const struct shared_irq_driver_api *)dev->driver_api;
+	const struct shared_irq_driver_api *api =
+		(const struct shared_irq_driver_api *)dev->driver_api;
 
 	return api->enable(dev, isr_dev);
 }
@@ -83,7 +85,8 @@ static inline int shared_irq_enable(struct device *dev, struct device *isr_dev)
  */
 static inline int shared_irq_disable(struct device *dev, struct device *isr_dev)
 {
-	const struct shared_irq_driver_api *api = (const struct shared_irq_driver_api *)dev->driver_api;
+	const struct shared_irq_driver_api *api =
+		(const struct shared_irq_driver_api *)dev->driver_api;
 
 	return api->disable(dev, isr_dev);
 }


### PR DESCRIPTION
The automated process used in #21391 to remove implicit casts resulted in code that exceeded the documented line length limits.  Break the assignment into two lines where this happened.