### PR TITLE
samples: bluetooth: peripheral_hr: Fix advertising UUID16 service list

### DIFF
--- a/samples/bluetooth/peripheral_hr/src/main.c
+++ b/samples/bluetooth/peripheral_hr/src/main.c
@@ -26,7 +26,7 @@ struct bt_conn *default_conn;
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-	BT_DATA_BYTES(BT_DATA_UUID16_ALL, 0x0d, 0x18, 0x0f, 0x18, 0x05, 0x18),
+	BT_DATA_BYTES(BT_DATA_UUID16_ALL, 0x0d, 0x18, 0x0f, 0x18, 0x0a, 0x18),
 };
 
 static void connected(struct bt_conn *conn, u8_t err)


### PR DESCRIPTION
CTS UUID was used instead of DIS UUID

Signed-off-by: Nick Ward <nix.ward@gmail.com>