### PR TITLE
NFCT support for nRF53

### DIFF
--- a/modules/Kconfig.nordic
+++ b/modules/Kconfig.nordic
@@ -81,7 +81,8 @@ config NRFX_LPCOMP
 config NRFX_NFCT
 	bool "Enable NFCT driver"
 	depends on HAS_HW_NRF_NFCT
-	select NRFX_TIMER4
+	select NRFX_TIMER4 if SOC_SERIES_NRF52X
+	select NRFX_TIMER2 if SOC_SERIES_NRF53X
 
 config NRFX_NVMC
 	bool "Enable NVMC driver"

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -23,6 +23,7 @@ config SOC_NRF5340_CPUAPP
 	select HAS_HW_NRF_GPIOTE
 	select HAS_HW_NRF_I2S
 	select HAS_HW_NRF_IPC
+	select HAS_HW_NRF_NFCT
 	select HAS_HW_NRF_PDM
 	select HAS_HW_NRF_POWER
 	select HAS_HW_NRF_PWM0


### PR DESCRIPTION
PR scope:
- Activated appropriate Timer instance for NFCT driver on nRF5340.
- Added the NFCT Peripheral capability to the Application Core Kconfig of the nRF5340 SoC.