### PR TITLE
hwinfo_get_device_id use HAL instead of direct register access to read values.

### DIFF
--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -27,7 +27,7 @@ config HWINFO_STM32
 config HWINFO_NRF
 	bool "NRF device ID"
 	default y
-	depends on (SOC_SERIES_NRF52X || SOC_SERIES_NRF51X)
+	depends on SOC_FAMILY_NRF
 	help
 	  Enable Nordic NRF hwinfo driver.
 

--- a/drivers/hwinfo/hwinfo_nrf.c
+++ b/drivers/hwinfo/hwinfo_nrf.c
@@ -7,6 +7,7 @@
 #include <soc.h>
 #include <drivers/hwinfo.h>
 #include <string.h>
+#include <hal/nrf_ficr.h>
 
 struct nrf_uid {
 	u32_t id[2];
@@ -16,8 +17,8 @@ ssize_t z_impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
 {
 	struct nrf_uid dev_id;
 
-	dev_id.id[0] = NRF_FICR->DEVICEID[0];
-	dev_id.id[1] = NRF_FICR->DEVICEID[1];
+	dev_id.id[0] = nrf_ficr_deviceid_get(NRF_FICR, 0);
+	dev_id.id[1] = nrf_ficr_deviceid_get(NRF_FICR, 1);
 
 	if (length > sizeof(dev_id.id)) {
 		length = sizeof(dev_id.id);


### PR DESCRIPTION
When reading HWINFO for Nordic devices use HAL for reading device id values.
Do not depend HWINFO_NRF on each Nordic SoC family, instead depend on Nordic family as a whole.