### PR TITLE
printk: Allow passing handling of string format specifier to the logger

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -616,6 +616,32 @@ u32_t log_get_strdup_pool_utilization(void);
  */
 u32_t log_get_strdup_longest_string(void);
 
+/* Internal function. See log_handle_string. */
+bool z_log_handle_string(printk_out_func_t out, void *ctx, char *str);
+
+/**
+ * @brief Process duplicated string cadidate.
+ *
+ * Function is called by the string formatter when string format specifier is
+ * detected. Based on the address, logger determines if it is a duplicate
+ * and process it only in that case.
+ *
+ * @param out	Output function.
+ * @param ctx	Context passed to the output function.
+ * @param s	String.
+ *
+ * @return True if string was processed by the logger, false otherwise.
+ */
+static inline bool log_handle_string(printk_out_func_t out, void *ctx, char *s)
+{
+	if (!IS_ENABLED(CONFIG_LOG) || IS_ENABLED(CONFIG_LOG_IMMEDIATE) ||
+		IS_ENABLED(CONFIG_LOG_MINIMAL)) {
+		return false;
+	}
+
+	return z_log_handle_string(out, ctx, s);
+}
+
 /** @brief Indicate to the log core that one log message has been dropped.
  */
 void log_dropped(void);

--- a/include/sys/printk.h
+++ b/include/sys/printk.h
@@ -87,6 +87,8 @@ static inline __printf_like(3, 0) int vsnprintk(char *str, size_t size,
 }
 #endif
 
+typedef int (*printk_out_func_t)(int c, void *ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -931,6 +931,19 @@ void log_free(void *str)
 	}
 }
 
+bool z_log_handle_string(printk_out_func_t out, void *ctx, char *str)
+{
+	if (!log_is_strdup(str)) {
+		return false;
+	}
+
+	while (*str) {
+		out((int)(*str++), ctx);
+	}
+
+	return true;
+}
+
 #if defined(CONFIG_USERSPACE)
 void z_impl_z_log_string_from_user(u32_t src_level_val, const char *str)
 {


### PR DESCRIPTION
I would really like to get read of dedicate pool for string duplicates and use logger message pool. RAM usage is very inefficient and it's hard to tune actual buffer size. It would be much better to keep those strings in the message pool but that means that they are stored in fragmented chunks and straight forward string format specifier processing won't handle that. This PR enables forwarding strings to the logger. Logger based on the address determines if it is a string duplicate and if yes processes it else do nothing.