### PR TITLE
include: net: ethernet.h: Clarify checksum offloading options

### DIFF
--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -82,10 +82,10 @@ struct net_eth_addr {
 
 /** Ethernet hardware capabilities */
 enum ethernet_hw_caps {
-	/** TX Checksum offloading supported */
+	/** TX Checksum offloading supported for all of IPv4, UDP, TCP */
 	ETHERNET_HW_TX_CHKSUM_OFFLOAD	= BIT(0),
 
-	/** RX Checksum offloading supported */
+	/** RX Checksum offloading supported for all of IPv4, UDP, TCP */
 	ETHERNET_HW_RX_CHKSUM_OFFLOAD	= BIT(1),
 
 	/** VLAN supported */


### PR DESCRIPTION
Both ETHERNET_HW_TX_CHKSUM_OFFLOAD and ETHERNET_HW_RX_CHKSUM_OFFLOAD
apply to all of IPv4, UDP, and TCP heafers (there's no checksum in
IPv6 header). Consequently, these options should be enabled only for
hardware which supports offloading for all of these options. (And
hardware which has fine-grained control over individual protocol
headers, should enable them all).

Based on the handling in the current source code and discussion
in #21269.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>