### PR TITLE
[TOPIC-GPIO]: sensors: mcp9808: update to new API

### DIFF
--- a/dts/bindings/sensor/microchip,mcp9808.yaml
+++ b/dts/bindings/sensor/microchip,mcp9808.yaml
@@ -13,3 +13,8 @@ properties:
     int-gpios:
       type: phandle-array
       required: false
+      description: |
+        The alert pin defaults to active low when produced by the
+        sensor, and is open-drain.  A pull-up may be appropriate.  The
+        property value should ensure the flags properly describe the
+        signal that is presented to the driver.

--- a/samples/sensor/mcp9808/boards/frdm_k64f.overlay
+++ b/samples/sensor/mcp9808/boards/frdm_k64f.overlay
@@ -8,7 +8,7 @@
 	mcp9808@18 {
 		compatible = "microchip,mcp9808";
 		reg = <0x18>;
-		int-gpios = <&gpioc 16 0>;
+		int-gpios = <&gpioc 16 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		label = "MCP9808";
 	};
 };

--- a/samples/sensor/mcp9808/boards/particle_xenon.overlay
+++ b/samples/sensor/mcp9808/boards/particle_xenon.overlay
@@ -8,7 +8,7 @@
 	mcp9808@18 {
 		compatible = "microchip,mcp9808";
 		reg = <0x18>;
-		int-gpios = <&gpio1 1 0>;
+		int-gpios = <&gpio1 1 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		label = "MCP9808";
 	};
 };


### PR DESCRIPTION
This PR includes two patches from master, plus #21547, that should disappear when the topic branch is rebased.  Only the last commit in the series is specific to the new API.