### PR TITLE
drivers: watchdog: add system calls

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -187,7 +187,8 @@
 /drivers/i2c/i2c_rv32m1_lpi2c*            @henrikbrixandersen
 /drivers/i2c/*sam0*                       @Sizurka
 /drivers/i2c/i2c_dw*                      @dcpleung
-/drivers/*/*xec*                     @franciscomunoz @albertofloyd @scottwcpg
+/drivers/*/*xec*                          @franciscomunoz @albertofloyd @scottwcpg
+/drivers/watchdog/wdt_handlers.c          @andrewboie
 /drivers/wifi/                            @jukkar @tbursztyka @pfalcon
 /drivers/wifi/eswifi/                     @loicpoulain
 /dts/arc/                                 @vonhust @ruuddw @iriszzw

--- a/drivers/watchdog/wdt_handlers.c
+++ b/drivers/watchdog/wdt_handlers.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <drivers/watchdog.h>
+#include <syscall_handler.h>
+
+static inline int z_vrfy_wdt_setup(struct device *dev, u8_t options)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_WDT(dev, wdt_setup));
+	return z_impl_wdt_setup(dev, options);
+}
+
+#include <syscalls/wdt_setup.c>
+
+static inline int z_vrfy_wdt_disable(struct device *dev)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_WDT(dev, wdt_disable));
+	return z_impl_wdt_disable(dev);
+}
+
+#include <syscalls/wdt_disable.c>
+
+static inline int z_vrfy_wdt_feed(struct device *dev)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_WDT(dev, wdt_feed));
+	return z_impl_wdt_feed(dev);
+}
+
+#include <syscalls/wdt_feed.c>

--- a/include/drivers/watchdog.h
+++ b/include/drivers/watchdog.h
@@ -160,7 +160,9 @@ struct wdt_driver_api {
  * @retval -ENOTSUP If any of the set options is not supported.
  * @retval -EBUSY If watchdog instance has been already setup.
  */
-static inline int wdt_setup(struct device *dev, u8_t options)
+__syscall int wdt_setup(struct device *dev, u8_t options);
+
+static inline int z_impl_wdt_setup(struct device *dev, u8_t options)
 {
 	const struct wdt_driver_api *api =
 		(const struct wdt_driver_api *)dev->driver_api;
@@ -181,7 +183,9 @@ static inline int wdt_setup(struct device *dev, u8_t options)
  * @retval -EFAULT If watchdog instance is not enabled.
  * @retval -EPERM If watchdog can not be disabled directly by application code.
  */
-static inline int wdt_disable(struct device *dev)
+__syscall int wdt_disable(struct device *dev);
+
+static inline int z_impl_wdt_disable(struct device *dev)
 {
 	const struct wdt_driver_api *api =
 		(const struct wdt_driver_api *)dev->driver_api;
@@ -229,7 +233,9 @@ static inline int wdt_install_timeout(struct device *dev,
  * @retval 0 If successful.
  * @retval -EINVAL If there is no installed timeout for supplied channel.
  */
-static inline int wdt_feed(struct device *dev, int channel_id)
+__syscall int wdt_feed(struct device *dev, int channel_id);
+
+static inline int z_impl_wdt_feed(struct device *dev, int channel_id)
 {
 	const struct wdt_driver_api *api =
 		(const struct wdt_driver_api *)dev->driver_api;
@@ -244,5 +250,7 @@ static inline int wdt_feed(struct device *dev, int channel_id)
 /**
  * @}
  */
+
+#include <syscalls/watchdog.h>
 
 #endif /* _ZEPHYR_WATCHDOG_H__ */

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -113,6 +113,7 @@ subsystems = [
     "can_driver_api",
     "ptp_clock_driver_api",
     "eeprom_driver_api",
+    "wdt_driver_api",
 
     # Fake 'sample driver' subsystem, used by tests/samples
     "sample_driver_api"


### PR DESCRIPTION
wdt_install_timeout() was skipped as it installs an ISR-context
callback handler function. The rest are simple wrappers.

Fixes: #21432

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>