### PR TITLE
x86: improve exception debugging

### DIFF
--- a/arch/x86/core/ia32/fatal.c
+++ b/arch/x86/core/ia32/fatal.c
@@ -93,21 +93,7 @@ NANO_CPU_INT_REGISTER(_kernel_oops_handler, NANO_SOFT_IRQ,
 FUNC_NORETURN static void generic_exc_handle(unsigned int vector,
 					     const z_arch_esf_t *pEsf)
 {
-	switch (vector) {
-	case IV_GENERAL_PROTECTION:
-		LOG_ERR("General Protection Fault");
-		break;
-	case IV_DEVICE_NOT_AVAILABLE:
-		LOG_ERR("Floating point unit not enabled");
-		break;
-	default:
-		LOG_ERR("CPU exception %d", vector);
-		break;
-	}
-	if ((BIT(vector) & _EXC_ERROR_CODE_FAULTS) != 0) {
-		LOG_ERR("Exception code: 0x%x", pEsf->errorCode);
-	}
-	z_x86_fatal_error(K_ERR_CPU_EXCEPTION, pEsf);
+	z_x86_unhandled_cpu_exception(vector, pEsf);
 }
 
 #define _EXC_FUNC(vector) \

--- a/arch/x86/core/intel64/fatal.c
+++ b/arch/x86/core/intel64/fatal.c
@@ -17,9 +17,7 @@ void z_x86_exception(z_arch_esf_t *esf)
 		z_x86_page_fault_handler(esf);
 		break;
 	default:
-		LOG_ERR("** CPU Exception %ld (code %ld/0x%lx) **",
-			esf->vector, esf->code, esf->code);
-		z_x86_fatal_error(K_ERR_CPU_EXCEPTION, esf);
+		z_x86_unhandled_cpu_exception(esf->vector, esf);
 		CODE_UNREACHABLE;
 	}
 }

--- a/arch/x86/include/kernel_arch_data.h
+++ b/arch/x86/include/kernel_arch_data.h
@@ -31,6 +31,8 @@
 #define IV_ALIGNMENT_CHECK 17
 #define IV_MACHINE_CHECK 18
 #define IV_SIMD_FP 19
+#define IV_VIRT_EXCEPTION 20
+#define IV_SECURITY_EXCEPTION 30
 
 #define IV_IRQS 32		/* start of vectors available for IRQs */
 #define IV_NR_VECTORS 256	/* total number of vectors */

--- a/arch/x86/include/kernel_arch_func.h
+++ b/arch/x86/include/kernel_arch_func.h
@@ -47,6 +47,12 @@ void z_x86_early_serial_init(void);
 void z_x86_paging_init(void);
 #endif /* CONFIG_X86_MMU */
 
+/* Called upon CPU exception that is unhandled and hence fatal; dump
+ * interesting info and call z_x86_fatal_error()
+ */
+FUNC_NORETURN void z_x86_unhandled_cpu_exception(uintptr_t vector,
+						 const z_arch_esf_t *esf);
+
 /* Called upon unrecoverable error; dump registers and transfer control to
  * kernel via z_fatal_error()
  */

--- a/include/arch/x86/ia32/segmentation.h
+++ b/include/arch/x86/ia32/segmentation.h
@@ -18,23 +18,6 @@
 extern "C" {
 #endif
 
-/*
- * Bitmask used to determine which exceptions result in an error code being
- * pushed onto the stack.  The following exception vectors push an error code:
- *
- *  Vector    Mnemonic    Description
- *  ------    -------     ----------------------
- *    8       #DF         Double Fault
- *    10      #TS         Invalid TSS
- *    11      #NP         Segment Not Present
- *    12      #SS         Stack Segment Fault
- *    13      #GP         General Protection Fault
- *    14      #PF         Page Fault
- *    17      #AC         Alignment Check
- */
-#define _EXC_ERROR_CODE_FAULTS	0x27d00U
-
-
 /* NOTE: We currently do not have definitions for 16-bit segment, currently
  * assume everything we are working with is 32-bit
  */


### PR DESCRIPTION
We now dump more information for less common cases,
and this is now centralized code for 32-bit/64-bit.
All of this code is now correctly wrapped around
CONFIG_EXCEPTION_DEBUG. Some cruft and unused defines
removed.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>