### PR TITLE
tests: queue: fix SMP issue

### DIFF
--- a/tests/kernel/queue/src/main.c
+++ b/tests/kernel/queue/src/main.c
@@ -42,7 +42,7 @@ void test_main(void)
 	k_thread_resource_pool_assign(k_current_get(), &test_pool);
 
 	ztest_test_suite(queue_api,
-			 ztest_unit_test(test_queue_supv_to_user),
+			 ztest_1cpu_unit_test(test_queue_supv_to_user),
 			 ztest_user_unit_test(test_queue_alloc_prepend_user),
 			 ztest_user_unit_test(test_queue_alloc_append_user),
 			 ztest_unit_test(test_auto_free),


### PR DESCRIPTION
test_queue_supv_to_user() invokes a child thread which does some
work which must take place before the call to k_queue_cancel_wait()
is called by the parent.

However, with SMP enabled, the child thread will just run on another
CPU and we have a race between when child_thread_get() calls
k_queue_get(q, K_FOREVER) and the parent calls k_queue_cancel_wait().
If the parent thread gets there first, the whole test hangs as
the call to k_queue_get(q, K_FOREVER) sits forever.

The fix is to have test_queue_supv_to_user() be a 1cpu test, which
ensures that only one CPU is used.

It's not clear to me why this wasn't causing CI failures on other
SMP targets, but I am able to reproduce reliably on qemu_x86_64
with my user mode patches applied.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>