### PR TITLE
sys: util: Add IF_ENABLED() macro

### DIFF
--- a/drivers/clock_control/nrf_power_clock.c
+++ b/drivers/clock_control/nrf_power_clock.c
@@ -351,21 +351,20 @@ static const struct nrf_clock_control_config config = {
 			.start_tsk = NRF_CLOCK_TASK_HFCLKSTART,
 			.started_evt = NRF_CLOCK_EVENT_HFCLKSTARTED,
 			.stop_tsk = NRF_CLOCK_TASK_HFCLKSTOP,
-			COND_CODE_1(CONFIG_LOG, (.name = "hfclk",), ())
+			IF_ENABLED(CONFIG_LOG, (.name = "hfclk",))
 		},
 		[CLOCK_CONTROL_NRF_TYPE_LFCLK] = {
 			.start_tsk = NRF_CLOCK_TASK_LFCLKSTART,
 			.started_evt = NRF_CLOCK_EVENT_LFCLKSTARTED,
 			.stop_tsk = NRF_CLOCK_TASK_LFCLKSTOP,
-			COND_CODE_1(CONFIG_LOG, (.name = "lfclk",), ())
-			.start_handler =
-			IS_ENABLED(
-			    CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION) ?
-					z_nrf_clock_calibration_start : NULL,
-			.stop_handler =
-			IS_ENABLED(
-			    CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION) ?
-					z_nrf_clock_calibration_stop : NULL
+			IF_ENABLED(CONFIG_LOG, (.name = "lfclk",))
+			IF_ENABLED(
+				CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION,
+				(
+				.start_handler = z_nrf_clock_calibration_start,
+				.stop_handler = z_nrf_clock_calibration_stop,
+				)
+			)
 		}
 	}
 };

--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -676,10 +676,10 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 		},							       \
 		.ch_data = counter##idx##_ch_data,			       \
 		.rtc = NRF_RTC##idx,					       \
-		COND_CODE_1(DT_NORDIC_NRF_RTC_RTC_##idx##_PPI_WRAP,	       \
-			    (.use_ppi = true,), ())			       \
-		COND_CODE_1(CONFIG_COUNTER_RTC_CUSTOM_TOP_SUPPORT,	       \
-		  (.fixed_top = DT_NORDIC_NRF_RTC_RTC_##idx##_FIXED_TOP,), ()) \
+		IF_ENABLED(DT_NORDIC_NRF_RTC_RTC_##idx##_PPI_WRAP,	       \
+			    (.use_ppi = true,))				       \
+		IF_ENABLED(CONFIG_COUNTER_RTC_CUSTOM_TOP_SUPPORT,	       \
+		  (.fixed_top = DT_NORDIC_NRF_RTC_RTC_##idx##_FIXED_TOP,))     \
 		LOG_INSTANCE_PTR_INIT(log, LOG_MODULE_NAME, idx)	       \
 	};								       \
 	DEVICE_AND_API_INIT(rtc_##idx,					       \

--- a/drivers/ipm/ipm_nrfx_ipc.c
+++ b/drivers/ipm/ipm_nrfx_ipc.c
@@ -227,8 +227,7 @@ DEVICE_AND_API_INIT(vipm_nrf_##_idx, "IPM_"#_idx,			\
 		    &vipm_nrf_##_idx##_driver_api)
 
 #define VIPM_DEVICE(_idx, _)						\
-	COND_CODE_1(IS_ENABLED(CONFIG_IPM_MSG_CH_##_idx##_ENABLE),	\
-		    (VIPM_DEVICE_1(_idx);), ())
+	IF_ENABLED(CONFIG_IPM_MSG_CH_##_idx##_ENABLE, (VIPM_DEVICE_1(_idx);))
 
 UTIL_LISTIFY(NRFX_IPC_ID_MAX_VALUE, VIPM_DEVICE, _);
 

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -475,67 +475,66 @@ static const struct uart_driver_api uart_esp32_api = {
 #define ESP32_UART_IRQ_HANDLER(idx)
 
 #endif
-
-#define ESP32_UART_INIT(idx)								      \
-ESP32_UART_IRQ_HANDLER_DECL(idx);							      \
-static const struct uart_esp32_config uart_esp32_cfg_port_##idx = {			      \
-	.dev_conf = {									      \
-		.base = (u8_t *)DT_INST_##idx##_ESPRESSIF_ESP32_UART_BASE_ADDRESS,	      \
-		.sys_clk_freq = DT_INST_0_CADENCE_TENSILICA_XTENSA_LX6_CLOCK_FREQUENCY,	      \
-		ESP32_UART_IRQ_HANDLER_FUNC(idx)					      \
-	},										      \
-											      \
-	.peripheral = {									      \
-		.clk = DPORT_UART##idx##_CLK_EN,					      \
-		.rst = DPORT_UART##idx##_RST,						      \
-	},										      \
-											      \
-	.signals = {									      \
-		.tx_out = U##idx##TXD_OUT_IDX,						      \
-		.rx_in = U##idx##RXD_IN_IDX,						      \
-		.rts_out = U##idx##RTS_OUT_IDX,						      \
-		.cts_in = U##idx##CTS_IN_IDX,						      \
-	},										      \
-											      \
-	.pins = {									      \
-		.tx = DT_INST_##idx##_ESPRESSIF_ESP32_UART_TX_PIN,			      \
-		.rx = DT_INST_##idx##_ESPRESSIF_ESP32_UART_RX_PIN,			      \
-		COND_CODE_1(IS_ENABLED(DT_INST_##idx##_ESPRESSIF_ESP32_UART_HW_FLOW_CONTROL), \
-			    (.rts = DT_INST_##idx##_ESPRESSIF_ESP32_UART_RTS_PIN,	      \
-			     .cts = DT_INST_##idx##_ESPRESSIF_ESP32_UART_CTS_PIN,	      \
-			    ),								      \
-			    (.rts = 0,							      \
-			     .cts = 0							      \
-			    ))								      \
-	},										      \
-											      \
-	.irq = {									      \
-		.source = ETS_UART##idx##_INTR_SOURCE,					      \
-		.line = DT_UART_ESP32_PORT_##idx##_IRQ_0,				      \
-	}										      \
-};											      \
-											      \
-static struct uart_esp32_data uart_esp32_data_##idx = {					      \
-	.uart_config = {								      \
-		.baudrate = DT_INST_##idx##_ESPRESSIF_ESP32_UART_CURRENT_SPEED,		      \
-		.parity = UART_CFG_PARITY_NONE,						      \
-		.stop_bits = UART_CFG_STOP_BITS_1,					      \
-		.data_bits = UART_CFG_DATA_BITS_8,					      \
-		COND_CODE_1(IS_ENABLED(DT_INST_##idx##_ESPRESSIF_ESP32_UART_HW_FLOW_CONTROL), \
-			    (.flow_ctrl = UART_CFG_FLOW_CTRL_RTS_CTS),			      \
-			    (.flow_ctrl = UART_CFG_FLOW_CTRL_NONE))			      \
-	}										      \
-};											      \
-											      \
-DEVICE_AND_API_INIT(uart_esp32_##idx,							      \
-		    DT_INST_##idx##_ESPRESSIF_ESP32_UART_LABEL,				      \
-		    uart_esp32_init,							      \
-		    &uart_esp32_data_##idx,						      \
-		    &uart_esp32_cfg_port_##idx,						      \
-		    PRE_KERNEL_1,							      \
-		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,					      \
-		    &uart_esp32_api);							      \
-											      \
+#define ESP32_UART_INIT(idx)						       \
+ESP32_UART_IRQ_HANDLER_DECL(idx);					       \
+static const struct uart_esp32_config uart_esp32_cfg_port_##idx = {	       \
+	.dev_conf = {							       \
+		.base =							       \
+		    (u8_t *)DT_INST_##idx##_ESPRESSIF_ESP32_UART_BASE_ADDRESS, \
+		.sys_clk_freq =						       \
+			DT_INST_0_CADENCE_TENSILICA_XTENSA_LX6_CLOCK_FREQUENCY \
+		ESP32_UART_IRQ_HANDLER_FUNC(idx)			       \
+	},								       \
+									       \
+	.peripheral = {							       \
+		.clk = DPORT_UART##idx##_CLK_EN,			       \
+		.rst = DPORT_UART##idx##_RST,				       \
+	},								       \
+									       \
+	.signals = {							       \
+		.tx_out = U##idx##TXD_OUT_IDX,				       \
+		.rx_in = U##idx##RXD_IN_IDX,				       \
+		.rts_out = U##idx##RTS_OUT_IDX,				       \
+		.cts_in = U##idx##CTS_IN_IDX,				       \
+	},								       \
+									       \
+	.pins = {							       \
+		.tx = DT_INST_##idx##_ESPRESSIF_ESP32_UART_TX_PIN,	       \
+		.rx = DT_INST_##idx##_ESPRESSIF_ESP32_UART_RX_PIN,	       \
+		IF_ENABLED(						       \
+			DT_INST_##idx##_ESPRESSIF_ESP32_UART_HW_FLOW_CONTROL,  \
+			(.rts = DT_INST_##idx##_ESPRESSIF_ESP32_UART_RTS_PIN,  \
+			.cts = DT_INST_##idx##_ESPRESSIF_ESP32_UART_CTS_PIN,   \
+			))						       \
+	},								       \
+									       \
+	.irq = {							       \
+		.source = ETS_UART##idx##_INTR_SOURCE,			       \
+		.line = DT_UART_ESP32_PORT_##idx##_IRQ_0,		       \
+	}								       \
+};									       \
+									       \
+static struct uart_esp32_data uart_esp32_data_##idx = {			       \
+	.uart_config = {						       \
+		.baudrate = DT_INST_##idx##_ESPRESSIF_ESP32_UART_CURRENT_SPEED,\
+		.parity = UART_CFG_PARITY_NONE,				       \
+		.stop_bits = UART_CFG_STOP_BITS_1,			       \
+		.data_bits = UART_CFG_DATA_BITS_8,			       \
+		.flow_ctrl = IS_ENABLED(				       \
+			DT_INST_##idx##_ESPRESSIF_ESP32_UART_HW_FLOW_CONTROL) ?\
+			UART_CFG_FLOW_CTRL_RTS_CTS : UART_CFG_FLOW_CTRL_NONE   \
+	}								       \
+};									       \
+									       \
+DEVICE_AND_API_INIT(uart_esp32_##idx,					       \
+		    DT_INST_##idx##_ESPRESSIF_ESP32_UART_LABEL,		       \
+		    uart_esp32_init,					       \
+		    &uart_esp32_data_##idx,				       \
+		    &uart_esp32_cfg_port_##idx,				       \
+		    PRE_KERNEL_1,					       \
+		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			       \
+		    &uart_esp32_api);					       \
+									       \
 ESP32_UART_IRQ_HANDLER(idx)
 
 #ifdef DT_INST_0_ESPRESSIF_ESP32_UART

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -376,12 +376,11 @@ static int spim_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 			: NRF_GPIO_PIN_NOPULL)
 
 #define SPI_NRFX_SPIM_EXTENDED_CONFIG(idx)				\
-	COND_CODE_1(IS_ENABLED(NRFX_SPIM_EXTENDED_ENABLED),		\
+	IF_ENABLED(NRFX_SPIM_EXTENDED_ENABLED,				\
 		(.dcx_pin = NRFX_SPIM_PIN_NOT_USED,			\
-		 COND_CODE_1(SPIM##idx##_FEATURE_RXDELAY_PRESENT,	\
-			(.rx_delay = CONFIG_SPI_##idx##_NRF_RX_DELAY,),	\
-			())),						\
-		())
+		 IF_ENABLED(SPIM##idx##_FEATURE_RXDELAY_PRESENT,	\
+			(.rx_delay = CONFIG_SPI_##idx##_NRF_RX_DELAY,))	\
+		))
 
 #define SPI_NRFX_SPIM_DEVICE(idx)					       \
 	BUILD_ASSERT_MSG(						       \

--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -306,7 +306,7 @@ static inline char *log_strdup(const char *str)
 #define _LOG_ARG1(arg1, ...) arg1
 
 #define _LOG_MODULE_CONST_DATA_CREATE(_name, _level)			     \
-	COND_CODE_1(LOG_IN_CPLUSPLUS, (extern), ())			     \
+	IF_ENABLED(LOG_IN_CPLUSPLUS, (extern))				     \
 	const struct log_source_const_data LOG_ITEM_CONST_DATA(_name)	     \
 	__attribute__ ((section("." STRINGIFY(LOG_ITEM_CONST_DATA(_name))))) \
 	__attribute__((used)) = {					     \
@@ -322,11 +322,8 @@ static inline char *log_strdup(const char *str)
 	__attribute__((used))
 
 #define _LOG_MODULE_DYNAMIC_DATA_COND_CREATE(_name)		\
-	COND_CODE_1(						\
-		CONFIG_LOG_RUNTIME_FILTERING,			\
-		(_LOG_MODULE_DYNAMIC_DATA_CREATE(_name);),	\
-		()						\
-		)
+	IF_ENABLED(CONFIG_LOG_RUNTIME_FILTERING,		\
+		  (_LOG_MODULE_DYNAMIC_DATA_CREATE(_name);))
 
 #define _LOG_MODULE_DATA_CREATE(_name, _level)			\
 	_LOG_MODULE_CONST_DATA_CREATE(_name, _level);		\

--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -324,6 +324,25 @@ u8_t u8_to_dec(char *buf, u8_t buflen, u8_t value);
 	__COND_CODE(_XXXX##_flag, _if_1_code, _else_code)
 
 /**
+ * @brief Insert code if flag is defined and equals 1.
+ *
+ * Usage example:
+ *
+ * IF_ENABLED(CONFIG_FLAG, (u32_t foo;))
+ *
+ * It can be considered as more compact alternative to:
+ *
+ * \#if defined(CONFIG_FLAG) && (CONFIG_FLAG == 1)
+ *	u32_t foo;
+ * \#endif
+ *
+ * @param _flag		Evaluated flag
+ * @param _code		Code used if flag exists and equal 1. Argument must be
+ *			in brackets.
+ */
+#define IF_ENABLED(_flag, _code) \
+	COND_CODE_1(_flag, _code, ())
+/**
  * @brief Insert code depending on result of flag evaluation.
  *
  * See @ref COND_CODE_1 for details.

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -110,6 +110,25 @@ void test_COND_CODE_0(void)
 	zassert_true((y3 == 1), NULL);
 }
 
+void test_IF_ENABLED(void)
+{
+	#define test_IF_ENABLED_FLAG_A 1
+	#define test_IF_ENABLED_FLAG_B 0
+
+	IF_ENABLED(test_IF_ENABLED_FLAG_A, (goto skipped;))
+	/* location should be skipped if IF_ENABLED macro is correct. */
+	zassert_false(true, "location should be skipped");
+skipped:
+	IF_ENABLED(test_IF_ENABLED_FLAG_B, (zassert_false(true, "");))
+
+	IF_ENABLED(test_IF_ENABLED_FLAG_C, (zassert_false(true, "");))
+
+	zassert_true(true, "");
+
+	#undef test_IF_ENABLED_FLAG_A
+	#undef test_IF_ENABLED_FLAG_B
+}
+
 void test_UTIL_LISTIFY(void)
 {
 	int i = 0;
@@ -157,6 +176,7 @@ void test_main(void)
 			 ztest_unit_test(test_u8_to_dec),
 			 ztest_unit_test(test_COND_CODE_1),
 			 ztest_unit_test(test_COND_CODE_0),
+			 ztest_unit_test(test_IF_ENABLED),
 			 ztest_unit_test(test_UTIL_LISTIFY),
 			 ztest_unit_test(test_z_max_z_min)
 	);


### PR DESCRIPTION
Added macro for code inserting based on configuration flag. This macro is wrapper around `COND_CODE_1()`. Macro can be seen as an alternative to ifdef

Example:
```
#if defined(CONFIG_FOO) && (CONFIG_FOO == 1)
u32_t foo;
#endif
```
can be replaced with:
```
IF_ENABLED(CONFIG_FOO, (u32_t foo;))
```

Compared to standard ifdef approach, `IF_ENABLED()` can also be used inside other macros, like:
```
#define FOO_DEFINE(_name) \
   struct foo { \
       IF_ENABLED(CONFIG_FOO_FEATURE, (.value = CONFIG_FOO_VALUE,) \
   }
```

PR contains:
- macro implementation
- test for new macro
- replacing all applicable `COND_CODE_1` usages with `IF_ENABLED`, cleanup around `COND_CODE_1` usage.