### PR TITLE
CODEOWNERS: Add @pfalcon for subsys/net/lib/config/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -363,7 +363,7 @@
 /subsys/net/lib/                          @jukkar @tbursztyka @pfalcon
 /subsys/net/lib/dns/                      @jukkar @tbursztyka @pfalcon
 /subsys/net/lib/lwm2m/                    @mike-scott
-/subsys/net/lib/config/                   @jukkar @tbursztyka
+/subsys/net/lib/config/                   @jukkar @tbursztyka @pfalcon
 /subsys/net/lib/mqtt/                     @jukkar @tbursztyka @rlubos
 /subsys/net/lib/openthread/               @rlubos
 /subsys/net/lib/coap/                     @rveerama1


### PR DESCRIPTION
net/lib/config/ is important generic part of the network stack, and
should be reviewed by the same people as net/lib/. (Besides, I
originally factored out this lib in the first place.)

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>