### PR TITLE
Fix deprecated macro conversion in network statistics

### DIFF
--- a/include/sys_clock.h
+++ b/include/sys_clock.h
@@ -83,7 +83,7 @@ extern void z_enable_sys_clock(void);
 #define sys_clock_hw_cycles_per_tick() __DEPRECATED_MACRO \
 	((int)k_ticks_to_cyc_floor32(1U))
 #define SYS_CLOCK_HW_CYCLES_TO_NS64(t) __DEPRECATED_MACRO \
-	k_cyc_to_ns_floor64((u64_t)(X))
+	k_cyc_to_ns_floor64((u64_t)(t))
 #define SYS_CLOCK_HW_CYCLES_TO_NS(t) __DEPRECATED_MACRO \
 	((u32_t)k_cyc_to_ns_floor64(t))
 

--- a/subsys/net/ip/net_stats.h
+++ b/subsys/net/ip/net_stats.h
@@ -342,7 +342,7 @@ static inline void net_stats_update_rx_time(struct net_if *iface,
 	u32_t diff = end_time - start_time;
 
 	UPDATE_STAT(iface, stats.rx_time.sum +=
-		    SYS_CLOCK_HW_CYCLES_TO_NS64(diff) / NSEC_PER_USEC);
+		    k_cyc_to_ns_floor64(diff) / 1000);
 	UPDATE_STAT(iface, stats.rx_time.count += 1);
 }
 #else


### PR DESCRIPTION
This fixes compilation error when enabling network packet RX time statistics.