### PR TITLE
samples: net: google_iot_mqtt: Do not compile by sanitycheck

### DIFF
--- a/samples/net/cloud/google_iot_mqtt/sample.yaml
+++ b/samples/net/cloud/google_iot_mqtt/sample.yaml
@@ -1,8 +1,6 @@
 sample:
   description: MQTT sample app to Google IoT cloud
   name: google_iot_mqtt
-tests:
-  sample.net.cloud.google_iot_mqtt:
-    harness: net
-    platform_whitelist: frdm_k64f
-    tags: net mqtt cloud
+common:
+  tags: net mqtt cloud
+  harness: net


### PR DESCRIPTION
The sample needs key.c file but that cannot be generated by
sanitychecker. So disable compilation by sanitycheck.
Eventually we should make it possible to compile the sample
using some pre-defined values so that the sample will not
bit-rot but that is for later.

Fixes #21450

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>