### PR TITLE
net: openthread: Move OT CMake configuration into OT repo

### DIFF
--- a/subsys/net/lib/openthread/CMakeLists.txt
+++ b/subsys/net/lib/openthread/CMakeLists.txt
@@ -1,37 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(platform)
-
-# Obtain OpenThread repository root directory
-execute_process(
-    COMMAND
-    ${WEST} list -f {posixpath} openthread
-    OUTPUT_VARIABLE ot_root_dir OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-# Include OpenThread headers
-zephyr_system_include_directories(${ot_root_dir}/include)
-zephyr_system_include_directories(${ot_root_dir}/examples/platforms)
-
-# Determine which libs should be linked in
-set(ot_libs "")
-
-if(CONFIG_OPENTHREAD_FTD)
-set(cli_lib openthread-cli-ftd)
-elseif(CONFIG_OPENTHREAD_MTD)
-set(cli_lib openthread-cli-mtd)
-endif()
-
-if(CONFIG_OPENTHREAD_SHELL)
-list(APPEND ot_libs ${cli_lib})
-endif()
-
-if(CONFIG_OPENTHREAD_FTD)
-list(APPEND ot_libs openthread-ftd)
-elseif(CONFIG_OPENTHREAD_MTD)
-list(APPEND ot_libs openthread-mtd)
-endif()
-
-list(APPEND ot_libs openthread-platform-utils-static)
-
-zephyr_link_libraries(${ot_libs})

--- a/west.yml
+++ b/west.yml
@@ -92,7 +92,7 @@ manifest:
       revision: 9b591b289e1f37339bd038b5a1f0e6c8ad39c63a
       path: modules/lib/open-amp
     - name: openthread
-      revision: 5496d9df4866e7761f3d06e5ea284d4acdeb4544
+      revision: 05aaccc6e0db0fe17ac4beed2a2aacc9a9af167c
       path: modules/lib/openthread
     - name: segger
       revision: 6fcf61606d6012d2c44129edc033f59331e268bc


### PR DESCRIPTION
It was pointed out, that it's a Zephyr convention to keep all module-related CMake configuration within the module repository (my bad). This PR fixes what I did wrong for OpenThread.

DNM until OT dependency is merged.