### PR TITLE
subsys: random: fix unused value warning

### DIFF
--- a/subsys/random/rand32_entropy_device.c
+++ b/subsys/random/rand32_entropy_device.c
@@ -80,7 +80,7 @@ static void rand_get(u8_t *dst, size_t outlen)
 			random_num = k_cycle_get_32();
 			if ((outlen-len) < sizeof(random_num)) {
 				blocksize = len;
-				(void *)memcpy(&(dst[random_num]),
+				(void)memcpy(&(dst[random_num]),
 						&random_num, blocksize);
 			} else {
 				*((u32_t *)&dst[len]) = random_num;

--- a/subsys/random/rand32_timer.c
+++ b/subsys/random/rand32_timer.c
@@ -71,7 +71,7 @@ void sys_rand_get(void *dst, size_t outlen)
 		ret = sys_rand32_get();
 		if ((outlen-len) < sizeof(ret)) {
 			blocksize = len;
-			(void *)memcpy(udst, &ret, blocksize);
+			(void)memcpy(udst, &ret, blocksize);
 		} else {
 			(*udst++) = ret;
 		}

--- a/subsys/random/rand32_timestamp.c
+++ b/subsys/random/rand32_timestamp.c
@@ -60,7 +60,7 @@ void sys_rand_get(void *dst, size_t outlen)
 		ret = sys_rand32_get();
 		if ((outlen-len) < sizeof(ret)) {
 			blocksize = len;
-			(void *)memcpy(udst, &ret, blocksize);
+			(void)memcpy(udst, &ret, blocksize);
 		} else {
 			(*udst++) = ret;
 		}

--- a/subsys/random/rand32_xoroshiro128.c
+++ b/subsys/random/rand32_xoroshiro128.c
@@ -107,7 +107,7 @@ void sys_rand_get(void *dst, size_t outlen)
 		ret = xoroshiro128_next();
 		if ((outlen-len) < sizeof(ret)) {
 			blocksize = len;
-			(void *)memcpy(udst, &ret, blocksize);
+			(void)memcpy(udst, &ret, blocksize);
 		} else {
 			(*udst++) = ret;
 		}


### PR DESCRIPTION
When using LLVM/Clang, it complains about memcpy() being
casted to (void *):

  warning: expression result unused; should this cast be to 'void'? [-Wunused-value]

So change those to (void) instead as the return of memcpy()
is not used anyway.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>