### PR TITLE
arm: board: 96b_stm32_sensor_mez: enable USART3

### DIFF
--- a/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.dts
+++ b/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.dts
@@ -138,6 +138,11 @@
 	status = "okay";
 };
 
+&usart3 {
+	current-speed = <115200>;
+	status = "okay";
+};
+
 &uart4 {
 	current-speed = <115200>;
 	status = "okay";

--- a/boards/arm/96b_stm32_sensor_mez/doc/index.rst
+++ b/boards/arm/96b_stm32_sensor_mez/doc/index.rst
@@ -110,6 +110,20 @@ Serial Port
 On 96Boards STM32 Sensor Mezzanine, Zephyr console output is assigned to UART4
 exposed via on-board Micro USB connector. Default settings are 115200 8N1.
 
+The default USART mappings for the remaining ones are:
+
+- USART1: Connected to AP via UART0 on the 96Boards Low-Speed Header.
+        - TX: PA9
+        - RX: PA10
+
+- USART2: Connected to D0(RX) and D1(TX) on the Arduino Header.
+        - TX: PD5
+        - RX: PD6
+
+- USART3: Broken out to Grove connector J10.
+        - TX: PD8
+        - RX: PD9
+
 I2C
 ---
 

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -8,6 +8,15 @@
 
 / {
 	soc {
+		usart3: serial@40004800 {
+			compatible = "st,stm32-usart", "st,stm32-uart";
+			reg = <0x40004800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00040000>;
+			interrupts = <39 0>;
+			status = "disabled";
+			label = "UART_3";
+		};
+
 		uart4: serial@40004c00 {
 			compatible ="st,stm32-uart";
 			reg = <0x40004c00 0x400>;


### PR DESCRIPTION
This patchset enables USART3 on the 96Boards STM32 Mezzanine.
It is broken out to J10 Grove Connector.

Changes:

- Enabled USART3 in board dts.
- Updated board index.rst with uart pinouts.
- soc dtsi: enabled usart3.

Test: Tested USART3 as console at 115200 baud

Signed-off-by: Sahaj Sarup <sahaj.sarup@linaro.org>