### PR TITLE
x86: up-level QEMU arch_system_halt()

### DIFF
--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -11,6 +11,19 @@
 #include <logging/log.h>
 LOG_MODULE_DECLARE(os);
 
+#if defined(CONFIG_BOARD_QEMU_X86) || defined(CONFIG_BOARD_QEMU_X86_64)
+FUNC_NORETURN void arch_system_halt(unsigned int reason)
+{
+	ARG_UNUSED(reason);
+
+	/* Causes QEMU to exit. We passed the following on the command line:
+	 * -device isa-debug-exit,iobase=0xf4,iosize=0x04
+	 */
+	sys_out32(0, 0xf4);
+	CODE_UNREACHABLE;
+}
+#endif
+
 static inline uintptr_t esf_get_sp(const z_arch_esf_t *esf)
 {
 #ifdef CONFIG_X86_64

--- a/arch/x86/core/ia32/fatal.c
+++ b/arch/x86/core/ia32/fatal.c
@@ -22,20 +22,6 @@ LOG_MODULE_DECLARE(os);
 
 __weak void z_debug_fatal_hook(const z_arch_esf_t *esf) { ARG_UNUSED(esf); }
 
-
-#ifdef CONFIG_BOARD_QEMU_X86
-FUNC_NORETURN void arch_system_halt(unsigned int reason)
-{
-	ARG_UNUSED(reason);
-
-	/* Causes QEMU to exit. We passed the following on the command line:
-	 * -device isa-debug-exit,iobase=0xf4,iosize=0x04
-	 */
-	sys_out32(0, 0xf4);
-	CODE_UNREACHABLE;
-}
-#endif
-
 void z_x86_spurious_irq(const z_arch_esf_t *esf)
 {
 	int vector = z_irq_controller_isr_vector_get();


### PR DESCRIPTION
qemu_x86_64 will exit the emulator on a fatal system error,
like qemu_x86 already does.

Improves CI times when tests fail since sanitycheck will not
need to wait for the timeout to expire.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>