### PR TITLE
x86: fix stack traces on x86_64

### DIFF
--- a/arch/x86/core/Kconfig.ia32
+++ b/arch/x86/core/Kconfig.ia32
@@ -274,4 +274,11 @@ config X86_DYNAMIC_IRQ_STUBS
 
 endmenu
 
+config X86_EXCEPTION_STACK_TRACE
+	bool
+	default y
+	depends on EXCEPTION_STACK_TRACE
+	help
+	  Internal config to enable runtime stack traces on fatal exceptions.
+
 endif # !X86_64

--- a/arch/x86/core/Kconfig.intel64
+++ b/arch/x86/core/Kconfig.intel64
@@ -32,6 +32,14 @@ config EXCEPTION_STACK_SIZE
 	  support limited call-tree depth and must fit into the low core,
 	  so they are typically smaller than the ISR stacks.
 
+config X86_EXCEPTION_STACK_TRACE
+	bool
+	default y
+	depends on EXCEPTION_STACK_TRACE
+	depends on NO_OPTIMIZATIONS
+	help
+	  Internal config to enable runtime stack traces on fatal exceptions.
+
 config SCHED_IPI_VECTOR
 	int "IDT vector to use for scheduler IPI"
 	default 33

--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -57,7 +57,7 @@ bool z_x86_check_stack_bounds(uintptr_t addr, size_t size, u16_t cs)
 #endif
 
 #ifdef CONFIG_EXCEPTION_DEBUG
-#if defined(CONFIG_EXCEPTION_STACK_TRACE)
+#if defined(CONFIG_X86_EXCEPTION_STACK_TRACE)
 struct stack_frame {
 	uintptr_t next;
 	uintptr_t ret_addr;
@@ -111,7 +111,7 @@ static void unwind_stack(uintptr_t base_ptr, u16_t cs)
 		base_ptr = frame->next;
 	}
 }
-#endif /* CONFIG_EXCEPTION_STACK_TRACE */
+#endif /* CONFIG_X86_EXCEPTION_STACK_TRACE */
 
 #ifdef CONFIG_X86_64
 static void dump_regs(const z_arch_esf_t *esf)
@@ -127,11 +127,11 @@ static void dump_regs(const z_arch_esf_t *esf)
 	LOG_ERR("RSP: 0x%016lx RFLAGS: 0x%016lx CS: 0x%04lx CR3: %p", esf->rsp,
 		esf->rflags, esf->cs & 0xFFFFU, z_x86_page_tables_get());
 
-#ifdef CONFIG_EXCEPTION_STACK_TRACE
+#ifdef CONFIG_X86_EXCEPTION_STACK_TRACE
 	LOG_ERR("call trace:");
 #endif
 	LOG_ERR("RIP: 0x%016lx", esf->rip);
-#ifdef CONFIG_EXCEPTION_STACK_TRACE
+#ifdef CONFIG_X86_EXCEPTION_STACK_TRACE
 	unwind_stack(esf->rbp, esf->cs);
 #endif
 }
@@ -145,11 +145,11 @@ static void dump_regs(const z_arch_esf_t *esf)
 	LOG_ERR("EFLAGS: 0x%08x CS: 0x%04x CR3: %p", esf->eflags,
 		esf->cs & 0xFFFFU, z_x86_page_tables_get());
 
-#ifdef CONFIG_EXCEPTION_STACK_TRACE
+#ifdef CONFIG_X86_EXCEPTION_STACK_TRACE
 	LOG_ERR("call trace:");
 #endif
 	LOG_ERR("EIP: 0x%08x", esf->eip);
-#ifdef CONFIG_EXCEPTION_STACK_TRACE
+#ifdef CONFIG_X86_EXCEPTION_STACK_TRACE
 	unwind_stack(esf->ebp, esf->cs);
 #endif
 }


### PR DESCRIPTION
Runtime stack traces (at least as currently implemented)
don't work on x86_64 normally as RBP is treated as a general-
purpose register. Depend on CONFIG_NO_OPTIMIZATIONS to enable
this on 64-bit.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>