### PR TITLE
cmake: dts fixups

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -32,6 +32,9 @@ list(APPEND
   ${BOARD_DIR}
   ${ZEPHYR_BASE}
   )
+list(REMOVE_DUPLICATES
+  DTS_ROOT
+  )
 
 list(REMOVE_DUPLICATES DTS_ROOT)
 
@@ -73,6 +76,7 @@ if(SUPPORTS_DTS)
     math(EXPR i "${i}+1")
   endforeach()
 
+  unset(DTS_ROOT_SYSTEM_INCLUDE_DIRS)
   foreach(dts_root ${DTS_ROOT})
     foreach(dts_root_path
         include
@@ -90,6 +94,7 @@ if(SUPPORTS_DTS)
     endforeach()
   endforeach()
 
+  unset(DTS_ROOT_BINDINGS)
   foreach(dts_root ${DTS_ROOT})
     set(full_path ${dts_root}/dts/bindings)
     if(EXISTS ${full_path})


### PR DESCRIPTION
Trivial dts.cmake cleanups.

@rlubos : I'm giving you the Author and Signed-off-by: because these changes were originally introduced by you downstream in https://github.com/NordicPlayground/fw-nrfconnect-zephyr/commit/1378a1c7ac89d13fa08bd45b1272a70060d90663#diff-cdbbe7fbb24a1beeba84666fe70402d7.

