### PR TITLE
net: lwm2m: add optional timestamp resources to some IPSO objects

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig.ipso
+++ b/subsys/net/lib/lwm2m/Kconfig.ipso
@@ -8,6 +8,14 @@ menuconfig LWM2M_IPSO_SUPPORT
 
 if LWM2M_IPSO_SUPPORT
 
+config LWM2M_IPSO_TIMESTAMP_EXTENSIONS
+	bool "Nonstandard IPSO object Timestamp resources"
+	help
+	  If you enable this option, various IPSO objects supported below
+	  will optionally include timestamp resources (ID 5518).
+	  This is an LWM2M protocol extension which can be useful to associate
+	  times with events. If unsure, leave at the default n.
+
 config LWM2M_IPSO_TEMP_SENSOR
 	bool "IPSO Temperature Sensor Support"
 	help
@@ -23,6 +31,13 @@ config LWM2M_IPSO_TEMP_SENSOR_INSTANCE_COUNT
 	help
 	  This setting establishes the total count of IPSO Temperature
 	  Sensor instances available to the LWM2M client.
+
+config LWM2M_IPSO_TEMP_SENSOR_TIMESTAMP
+	bool "Add timestamp resources to IPSO temperature objects"
+	default y
+	depends on LWM2M_IPSO_TEMP_SENSOR && LWM2M_IPSO_TIMESTAMP_EXTENSIONS
+	help
+	  Add a non-standard timestamp resource to each temperature object.
 
 config LWM2M_IPSO_LIGHT_CONTROL
 	bool "IPSO Light Control Support"
@@ -52,6 +67,13 @@ config LWM2M_IPSO_ACCELEROMETER_INSTANCE_COUNT
 	help
 	  This setting establishes the total count of IPSO Accelerometer
 	  instances available to the LWM2M client.
+
+config LWM2M_IPSO_ACCELEROMETER_TIMESTAMP
+	bool "Add timestamp resources to IPSO accelerometer objects"
+	default y
+	depends on LWM2M_IPSO_ACCELEROMETER && LWM2M_IPSO_TIMESTAMP_EXTENSIONS
+	help
+	  Add a non-standard timestamp resource to each accelerometer object.
 
 config LWM2M_IPSO_BUZZER
 	bool "IPSO Buzzer Support"
@@ -93,6 +115,13 @@ config LWM2M_IPSO_ONOFF_SWITCH_INSTANCE_COUNT
 	  This setting establishes the total count of IPSO On/Off Switch
 	  instances available to the LWM2M client.
 
+config LWM2M_IPSO_ONOFF_SWITCH_TIMESTAMP
+	bool "Add a timestamp resource to IPSO on/off switch objects"
+	default y
+	depends on LWM2M_IPSO_ONOFF_SWITCH && LWM2M_IPSO_TIMESTAMP_EXTENSIONS
+	help
+	  Add a non-standard timestamp resource to each on/off switch object.
+
 config LWM2M_IPSO_PUSH_BUTTON
 	bool "IPSO Push Button Support"
 	help
@@ -107,5 +136,12 @@ config LWM2M_IPSO_PUSH_BUTTON_INSTANCE_COUNT
 	help
 	  This setting establishes the total count of IPSO Push Button
 	  instances available to the LWM2M client.
+
+config LWM2M_IPSO_PUSH_BUTTON_TIMESTAMP
+	bool "Add a timestamp resource to IPSO Push Button objects"
+	default y
+	depends on LWM2M_IPSO_PUSH_BUTTON && LWM2M_IPSO_TIMESTAMP_EXTENSIONS
+	help
+	  Add a non-standard timestamp resource to each Push Button object.
 
 endif # LWM2M_LWM2M_IPSO_SUPPORT

--- a/subsys/net/lib/lwm2m/ipso_accelerometer.c
+++ b/subsys/net/lib/lwm2m/ipso_accelerometer.c
@@ -21,6 +21,11 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include "lwm2m_object.h"
 #include "lwm2m_engine.h"
 
+#ifdef CONFIG_LWM2M_IPSO_ACCELEROMETER_TIMESTAMP
+#define ADD_TIMESTAMPS 1
+#else
+#define ADD_TIMESTAMPS 0
+#endif
 /* Server resource IDs */
 #define ACCEL_X_VALUE_ID			5702
 #define ACCEL_Y_VALUE_ID			5703
@@ -28,8 +33,13 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define ACCEL_SENSOR_UNITS_ID			5701
 #define ACCEL_MIN_RANGE_VALUE_ID		5603
 #define ACCEL_MAX_RANGE_VALUE_ID		5604
+#if ADD_TIMESTAMPS
+#define ACCEL_TIMESTAMP_ID			5518
 
+#define ACCEL_MAX_ID		7
+#else
 #define ACCEL_MAX_ID		6
+#endif
 
 #define MAX_INSTANCE_COUNT	CONFIG_LWM2M_IPSO_ACCELEROMETER_INSTANCE_COUNT
 
@@ -58,6 +68,9 @@ static struct lwm2m_engine_obj_field fields[] = {
 	OBJ_FIELD_DATA(ACCEL_SENSOR_UNITS_ID, R_OPT, STRING),
 	OBJ_FIELD_DATA(ACCEL_MIN_RANGE_VALUE_ID, R_OPT, FLOAT32),
 	OBJ_FIELD_DATA(ACCEL_MAX_RANGE_VALUE_ID, R_OPT, FLOAT32),
+#if ADD_TIMESTAMPS
+	OBJ_FIELD_DATA(ACCEL_TIMESTAMP_ID, RW_OPT, TIME),
+#endif
 };
 
 static struct lwm2m_engine_obj_inst inst[MAX_INSTANCE_COUNT];
@@ -116,6 +129,10 @@ static struct lwm2m_engine_obj_inst *accel_create(u16_t obj_inst_id)
 			  res_inst[avail], j,
 			  &accel_data[avail].max_range,
 			  sizeof(accel_data[avail].max_range));
+#if ADD_TIMESTAMPS
+	INIT_OBJ_RES_OPTDATA(ACCEL_TIMESTAMP_ID, res[avail], i,
+			     res_inst[avail], j);
+#endif
 
 	inst[avail].resources = res[avail];
 	inst[avail].resource_count = i;

--- a/subsys/net/lib/lwm2m/ipso_onoff_switch.c
+++ b/subsys/net/lib/lwm2m/ipso_onoff_switch.c
@@ -21,14 +21,25 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include "lwm2m_object.h"
 #include "lwm2m_engine.h"
 
+#ifdef CONFIG_LWM2M_IPSO_ONOFF_SWITCH_TIMESTAMP
+#define ADD_TIMESTAMPS 1
+#else
+#define ADD_TIMESTAMPS 0
+#endif
+
 /* resource IDs */
 #define SWITCH_DIGITAL_STATE_ID		5500
 #define SWITCH_DIGITAL_INPUT_COUNTER_ID	5501
 #define SWITCH_ON_TIME_ID		5852
 #define SWITCH_OFF_TIME_ID		5854
 #define SWITCH_APPLICATION_TYPE_ID	5750
+#if ADD_TIMESTAMPS
+#define SWITCH_TIMESTAMP_ID		5518
 
+#define SWITCH_MAX_ID			6
+#else
 #define SWITCH_MAX_ID			5
+#endif
 
 #define MAX_INSTANCE_COUNT	CONFIG_LWM2M_IPSO_ONOFF_SWITCH_INSTANCE_COUNT
 
@@ -58,6 +69,9 @@ static struct lwm2m_engine_obj_field fields[] = {
 	OBJ_FIELD_DATA(SWITCH_ON_TIME_ID, RW_OPT, U64),
 	OBJ_FIELD_DATA(SWITCH_OFF_TIME_ID, RW_OPT, U64),
 	OBJ_FIELD_DATA(SWITCH_APPLICATION_TYPE_ID, RW_OPT, STRING),
+#if ADD_TIMESTAMPS
+	OBJ_FIELD_DATA(SWITCH_TIMESTAMP_ID, RW_OPT, TIME),
+#endif
 };
 
 static struct lwm2m_engine_obj_inst inst[MAX_INSTANCE_COUNT];
@@ -213,6 +227,10 @@ static struct lwm2m_engine_obj_inst *switch_create(u16_t obj_inst_id)
 		     off_time_read_cb, NULL, time_post_write_cb, NULL);
 	INIT_OBJ_RES_OPTDATA(SWITCH_APPLICATION_TYPE_ID, res[avail], i,
 			     res_inst[avail], j);
+#if ADD_TIMESTAMPS
+	INIT_OBJ_RES_OPTDATA(SWITCH_TIMESTAMP_ID, res[avail], i,
+			     res_inst[avail], j);
+#endif
 
 	inst[avail].resources = res[avail];
 	inst[avail].resource_count = i;

--- a/subsys/net/lib/lwm2m/ipso_push_button.c
+++ b/subsys/net/lib/lwm2m/ipso_push_button.c
@@ -21,12 +21,23 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include "lwm2m_object.h"
 #include "lwm2m_engine.h"
 
+#ifdef CONFIG_LWM2M_IPSO_PUSH_BUTTON_TIMESTAMP
+#define ADD_TIMESTAMPS 1
+#else
+#define ADD_TIMESTAMPS 0
+#endif
+
 /* resource IDs */
 #define BUTTON_DIGITAL_STATE_ID		5500
 #define BUTTON_DIGITAL_INPUT_COUNTER_ID	5501
 #define BUTTON_APPLICATION_TYPE_ID	5750
+#if ADD_TIMESTAMPS
+#define BUTTON_TIMESTAMP_ID		5518
 
+#define BUTTON_MAX_ID			4
+#else
 #define BUTTON_MAX_ID			3
+#endif
 
 #define MAX_INSTANCE_COUNT	CONFIG_LWM2M_IPSO_PUSH_BUTTON_INSTANCE_COUNT
 
@@ -51,6 +62,9 @@ static struct lwm2m_engine_obj_field fields[] = {
 	OBJ_FIELD_DATA(BUTTON_DIGITAL_STATE_ID, R, BOOL),
 	OBJ_FIELD_DATA(BUTTON_DIGITAL_INPUT_COUNTER_ID, R_OPT, U64),
 	OBJ_FIELD_DATA(BUTTON_APPLICATION_TYPE_ID, RW_OPT, STRING),
+#if ADD_TIMESTAMPS
+	OBJ_FIELD_DATA(BUTTON_TIMESTAMP_ID, RW_OPT, TIME),
+#endif
 };
 
 static struct lwm2m_engine_obj_inst inst[MAX_INSTANCE_COUNT];
@@ -139,6 +153,10 @@ static struct lwm2m_engine_obj_inst *button_create(u16_t obj_inst_id)
 			  sizeof(button_data[avail].counter));
 	INIT_OBJ_RES_OPTDATA(BUTTON_APPLICATION_TYPE_ID, res[avail], i,
 			     res_inst[avail], j);
+#if ADD_TIMESTAMPS
+	INIT_OBJ_RES_OPTDATA(BUTTON_TIMESTAMP_ID, res[avail], i,
+			     res_inst[avail], j);
+#endif
 
 	inst[avail].resources = res[avail];
 	inst[avail].resource_count = i;

--- a/subsys/net/lib/lwm2m/ipso_temp_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_temp_sensor.c
@@ -23,6 +23,12 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include "lwm2m_object.h"
 #include "lwm2m_engine.h"
 
+#ifdef CONFIG_LWM2M_IPSO_TEMP_SENSOR_TIMESTAMP
+#define ADD_TIMESTAMPS 1
+#else
+#define ADD_TIMESTAMPS 0
+#endif
+
 /* Server resource IDs */
 #define TEMP_SENSOR_VALUE_ID			5700
 #define TEMP_UNITS_ID				5701
@@ -31,8 +37,13 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define TEMP_MIN_RANGE_VALUE_ID			5603
 #define TEMP_MAX_RANGE_VALUE_ID			5604
 #define TEMP_RESET_MIN_MAX_MEASURED_VALUES_ID	5605
+#if ADD_TIMESTAMPS
+#define TEMP_TIMESTAMP_ID			5518
 
+#define TEMP_MAX_ID		8
+#else  /* !ADD_TIMESTAMPS */
 #define TEMP_MAX_ID		7
+#endif
 
 #define MAX_INSTANCE_COUNT	CONFIG_LWM2M_IPSO_TEMP_SENSOR_INSTANCE_COUNT
 
@@ -62,6 +73,9 @@ static struct lwm2m_engine_obj_field fields[] = {
 	OBJ_FIELD_DATA(TEMP_MIN_RANGE_VALUE_ID, R_OPT, FLOAT32),
 	OBJ_FIELD_DATA(TEMP_MAX_RANGE_VALUE_ID, R_OPT, FLOAT32),
 	OBJ_FIELD_EXECUTE_OPT(TEMP_RESET_MIN_MAX_MEASURED_VALUES_ID),
+#if ADD_TIMESTAMPS
+	OBJ_FIELD_DATA(TEMP_TIMESTAMP_ID, RW_OPT, TIME),
+#endif
 };
 
 static struct lwm2m_engine_obj_inst inst[MAX_INSTANCE_COUNT];
@@ -207,6 +221,10 @@ static struct lwm2m_engine_obj_inst *temp_sensor_create(u16_t obj_inst_id)
 			  sizeof(*max_range_value));
 	INIT_OBJ_RES_EXECUTE(TEMP_RESET_MIN_MAX_MEASURED_VALUES_ID,
 			     res[index], i, reset_min_max_measured_values_cb);
+#if ADD_TIMESTAMPS
+	INIT_OBJ_RES_OPTDATA(TEMP_TIMESTAMP_ID, res[index], i,
+			     res_inst[index], j);
+#endif
 
 	inst[index].resources = res[index];
 	inst[index].resource_count = i;


### PR DESCRIPTION
Based on work by @mike-scott 

Add a new Kconfig knob, CONFIG_LWM2M_IPSO_TIMESTAMP_EXTENSIONS. This
defaults to n. When enabled, various IPSO objects will by default have
the timestamp resource (5518) added to their representations. This can
be turned off on a per-object basis.

The idea of adding timestamp resources was originally suggested by
Hannes Tschofenig on this OMA page:

https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/429
