### PR TITLE
Add system power management support to cc13x2/cc26x2

### DIFF
--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/CMakeLists.txt
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/CMakeLists.txt
@@ -4,3 +4,5 @@
 
 zephyr_sources(soc.c)
 zephyr_sources(ccfg.c)
+
+zephyr_library_sources_ifdef(CONFIG_SYS_POWER_MANAGEMENT    power.c)

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.series
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.series
@@ -12,5 +12,7 @@ config SOC_SERIES_CC13X2_CC26X2
 	select SOC_FAMILY_TISIMPLELINK
 	select HAS_CC13X2_CC26X2_SDK
 	select HAS_TI_CCFG
+	select HAS_SYS_POWER_STATE_SLEEP_1
+	select HAS_SYS_POWER_STATE_SLEEP_2
 	help
 	  Enable support for TI SimpleLink CC13x2 / CC26x2 SoCs

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/power.c
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/power.c
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2019 Linaro Limited.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr.h>
+#include <init.h>
+#include <power/power.h>
+
+#include <ti/drivers/Power.h>
+#include <ti/drivers/power/PowerCC26X2.h>
+
+#include <ti/drivers/dpl/ClockP.h>
+
+#include <ti/devices/cc13x2_cc26x2/driverlib/cpu.h>
+#include <ti/devices/cc13x2_cc26x2/driverlib/vims.h>
+#include <ti/devices/cc13x2_cc26x2/driverlib/sys_ctrl.h>
+
+#include <logging/log.h>
+#define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
+LOG_MODULE_REGISTER(soc);
+
+/* Configuring TI Power module to not use its policy function (we use Zephyr's
+ * instead), and disable oscillator calibration functionality for now.
+ */
+const PowerCC26X2_Config PowerCC26X2_config = {
+	.policyInitFxn      = NULL,
+	.policyFxn          = NULL,
+	.calibrateFxn       = NULL,
+	.enablePolicy       = false,
+	.calibrateRCOSC_LF  = false,
+	.calibrateRCOSC_HF  = false
+};
+
+extern PowerCC26X2_ModuleState PowerCC26X2_module;
+
+/*
+ * Power state mapping:
+ * SYS_POWER_STATE_SLEEP_1: Idle
+ * SYS_POWER_STATE_SLEEP_2: Standby
+ */
+
+/* Invoke Low Power/System Off specific Tasks */
+void sys_set_power_state(enum power_states state)
+{
+#ifdef CONFIG_SYS_POWER_SLEEP_STATES
+	u32_t modeVIMS;
+	u32_t constraints;
+#endif
+
+	LOG_DBG("SoC entering power state %d", state);
+
+	/* Switch to using PRIMASK instead of BASEPRI register, since
+	 * we are only able to wake up from standby while using PRIMASK.
+	 */
+	/* Set PRIMASK */
+	CPUcpsid();
+	/* Set BASEPRI to 0 */
+	irq_unlock(0);
+
+	switch (state) {
+#ifdef CONFIG_SYS_POWER_SLEEP_STATES
+	case SYS_POWER_STATE_SLEEP_1:
+		/* query the declared constraints */
+		constraints = Power_getConstraintMask();
+		/* 1. Get the current VIMS mode */
+		do {
+			modeVIMS = VIMSModeGet(VIMS_BASE);
+		} while (modeVIMS == VIMS_MODE_CHANGING);
+
+		/* 2. Configure flash to remain on in IDLE or not and keep
+		 *    VIMS powered on if it is configured as GPRAM
+		 * 3. Always keep cache retention ON in IDLE
+		 * 4. Turn off the CPU power domain
+		 * 5. Ensure any possible outstanding AON writes complete
+		 * 6. Enter IDLE
+		 */
+		if ((constraints & (1 << PowerCC26XX_NEED_FLASH_IN_IDLE)) ||
+			(modeVIMS == VIMS_MODE_DISABLED)) {
+			SysCtrlIdle(VIMS_ON_BUS_ON_MODE);
+		} else {
+			SysCtrlIdle(VIMS_ON_CPU_ON_MODE);
+		}
+
+		/* 7. Make sure MCU and AON are in sync after wakeup */
+		SysCtrlAonUpdate();
+		break;
+
+	case SYS_POWER_STATE_SLEEP_2:
+		/* schedule the wakeup event */
+		ClockP_start(ClockP_handle((ClockP_Struct *)
+			&PowerCC26X2_module.clockObj));
+
+		/* go to standby mode */
+		Power_sleep(PowerCC26XX_STANDBY);
+		ClockP_stop(ClockP_handle((ClockP_Struct *)
+			&PowerCC26X2_module.clockObj));
+		break;
+#endif
+	default:
+		LOG_DBG("Unsupported power state %u", state);
+		break;
+	}
+
+	LOG_DBG("SoC leaving power state %d", state);
+}
+
+/* Handle SOC specific activity after Low Power Mode Exit */
+void _sys_pm_power_state_exit_post_ops(enum power_states state)
+{
+	/*
+	 * System is now in active mode. Reenable interrupts which were disabled
+	 * when OS started idling code.
+	 */
+	CPUcpsie();
+}
+
+/* Initialize TI Power module */
+static int power_initialize(struct device *dev)
+{
+	unsigned int ret;
+
+	ARG_UNUSED(dev);
+
+	ret = irq_lock();
+	Power_init();
+	irq_unlock(ret);
+
+	return 0;
+}
+
+/*
+ *  ======== PowerCC26XX_schedulerDisable ========
+ */
+void PowerCC26XX_schedulerDisable(void)
+{
+	/*
+	 * We are leaving this empty because Zephyr's
+	 * scheduler would not get to run with interrupts being disabled
+	 * in the context of Power_sleep() in any case.
+	 */
+}
+
+/*
+ *  ======== PowerCC26XX_schedulerRestore ========
+ */
+void PowerCC26XX_schedulerRestore(void)
+{
+	/*
+	 * We are leaving this empty because Zephyr's
+	 * scheduler would not get to run with interrupts being disabled
+	 * in the context of Power_sleep() in any case.
+	 */
+}
+
+SYS_INIT(power_initialize, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/subsys/power/policy/CMakeLists.txt
+++ b/subsys/power/policy/CMakeLists.txt
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_sources_ifdef(CONFIG_SYS_PM_POLICY_DUMMY policy_dummy.c)
-zephyr_sources_ifdef(CONFIG_SYS_PM_POLICY_RESIDENCY policy_residency.c)
+zephyr_sources_ifdef(CONFIG_SYS_PM_POLICY_RESIDENCY_DEFAULT policy_residency.c)
+zephyr_sources_ifdef(CONFIG_SYS_PM_POLICY_RESIDENCY_CC13X2_CC26X2 policy_residency_cc13x2_cc26x2.c)

--- a/subsys/power/policy/Kconfig
+++ b/subsys/power/policy/Kconfig
@@ -7,6 +7,8 @@ choice
 
 config SYS_PM_POLICY_RESIDENCY
 	bool "PM Policy based on CPU residency"
+	select SYS_PM_POLICY_RESIDENCY_DEFAULT if !SOC_SERIES_CC13X2_CC26X2
+	select SYS_PM_POLICY_RESIDENCY_CC13X2_CC26X2 if SOC_SERIES_CC13X2_CC26X2
 	help
 	  Select this option for PM policy based on CPU residencies.
 
@@ -21,6 +23,16 @@ config SYS_PM_POLICY_APP
 	  When this option is selected, the application must provide PM policy.
 
 endchoice
+
+config SYS_PM_POLICY_RESIDENCY_DEFAULT
+	bool
+	help
+	  Use the default residency policy implementation
+
+config SYS_PM_POLICY_RESIDENCY_CC13X2_CC26X2
+	bool
+	help
+	  Use the residency policy implementation for TI CC13x2/CC26x2
 
 if SYS_PM_POLICY_RESIDENCY
 

--- a/subsys/power/policy/policy_residency_cc13x2_cc26x2.c
+++ b/subsys/power/policy/policy_residency_cc13x2_cc26x2.c
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2019 Linaro Limited.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <kernel.h>
+#include <sys/__assert.h>
+#include "pm_policy.h"
+
+#include <ti/devices/cc13x2_cc26x2/driverlib/sys_ctrl.h>
+
+#include <ti/drivers/Power.h>
+#include <ti/drivers/power/PowerCC26X2.h>
+
+#include <ti/drivers/dpl/ClockP.h>
+#include <ti/drivers/dpl/HwiP.h>
+#include <ti/drivers/dpl/SwiP.h>
+
+#define LOG_LEVEL CONFIG_SYS_PM_LOG_LEVEL
+#include <logging/log.h>
+LOG_MODULE_DECLARE(power);
+
+#define SECS_TO_TICKS		CONFIG_SYS_CLOCK_TICKS_PER_SEC
+
+/* Wakeup delay from standby in microseconds */
+#define WAKEDELAYSTANDBY    240
+
+extern PowerCC26X2_ModuleState PowerCC26X2_module;
+
+/* PM Policy based on SoC/Platform residency requirements */
+static const unsigned int pm_min_residency[] = {
+#ifdef CONFIG_SYS_POWER_SLEEP_STATES
+#ifdef CONFIG_HAS_SYS_POWER_STATE_SLEEP_1
+	CONFIG_SYS_PM_MIN_RESIDENCY_SLEEP_1 * SECS_TO_TICKS / MSEC_PER_SEC,
+#endif
+
+#ifdef CONFIG_HAS_SYS_POWER_STATE_SLEEP_2
+	CONFIG_SYS_PM_MIN_RESIDENCY_SLEEP_2 * SECS_TO_TICKS / MSEC_PER_SEC,
+#endif
+
+#endif /* CONFIG_SYS_POWER_SLEEP_STATES */
+};
+
+enum power_states sys_pm_policy_next_state(s32_t ticks)
+{
+	u32_t constraints;
+	bool disallowed = false;
+	int i;
+
+	/* check operating conditions, optimally choose DCDC versus GLDO */
+	SysCtrl_DCDC_VoltageConditionalControl();
+
+	/* query the declared constraints */
+	constraints = Power_getConstraintMask();
+
+	if ((ticks != K_FOREVER) && (ticks < pm_min_residency[0])) {
+		LOG_DBG("Not enough time for PM operations: %d", ticks);
+		return SYS_POWER_STATE_ACTIVE;
+	}
+
+	for (i = ARRAY_SIZE(pm_min_residency) - 1; i >= 0; i--) {
+#ifdef CONFIG_SYS_PM_STATE_LOCK
+		if (!sys_pm_ctrl_is_state_enabled((enum power_states)(i))) {
+			continue;
+		}
+#endif
+		if ((ticks == K_FOREVER) ||
+		    (ticks >= pm_min_residency[i])) {
+			/* Verify if Power module has constraints set to
+			 * disallow a state
+			 */
+			switch (i) {
+			case 0: /* Idle mode */
+				if ((constraints & (1 <<
+				    PowerCC26XX_DISALLOW_IDLE)) != 0) {
+					disallowed = true;
+				}
+				break;
+			case 1: /* Standby mode */
+				if ((constraints & (1 <<
+				    PowerCC26XX_DISALLOW_STANDBY)) != 0) {
+					disallowed = true;
+				}
+				/* Set timeout for wakeup event */
+				__ASSERT(
+				    CONFIG_SYS_PM_MIN_RESIDENCY_SLEEP_2 > 1,
+				    "CONFIG_SYS_PM_MIN_RESIDENCY_SLEEP_2 must "
+				    "be greater than 1.");
+				if (ticks != K_FOREVER) {
+					/* NOTE: Ideally we'd like to set a
+					 * timer to wake up just a little
+					 * earlier to take care of the wakeup
+					 * sequence, ie. by WAKEDELAYSTANDBY
+					 * microsecs. However, given
+					 * k_timer_start (called later by
+					 * ClockP_start) does not currently
+					 * have sub-millisecond accuracy, wakeup
+					 * would be at up to (WAKEDELAYSTANDBY
+					 * + 1 ms) ahead of the next timeout.
+					 * This also has the implication that
+					 * SYS_PM_MIN_RESIDENCY_SLEEP_2
+					 * must be greater than 1.
+					 */
+					ticks -= (WAKEDELAYSTANDBY *
+						CONFIG_SYS_CLOCK_TICKS_PER_SEC
+						+ 1000000) / 1000000;
+#if (CONFIG_SYS_CLOCK_TICKS_PER_SEC <= 1000)
+					/*
+					 * ClockP_setTimeout cannot handle any
+					 * more ticks
+					 */
+					ticks = MIN(ticks, UINT32_MAX / 1000 *
+						CONFIG_SYS_CLOCK_TICKS_PER_SEC);
+#endif
+					ClockP_setTimeout(ClockP_handle(
+						(ClockP_Struct *)
+						&PowerCC26X2_module.clockObj),
+						ticks);
+				}
+				break;
+			default:
+				/* This should never be reached */
+				LOG_ERR("Invalid sleep state detected\n");
+			}
+
+			if (disallowed) {
+				disallowed = false;
+				continue;
+			}
+
+			LOG_DBG("Selected power state %d "
+				"(ticks: %d, min_residency: %u)",
+				i, ticks, pm_min_residency[i]);
+			return (enum power_states)(i);
+		}
+	}
+
+	LOG_DBG("No suitable power state found!");
+	return SYS_POWER_STATE_ACTIVE;
+}


### PR DESCRIPTION
This PR adds system power management support for cc13x2/cc26x2 by leveraging TI's Power module. It implements idle and standby modes as sleep states 1 and 2.