### PR TITLE
sanitycheck: hardware map correct detected platform name

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -3802,7 +3802,7 @@ class HardwareMap:
                 if d.manufacturer == 'Texas Instruments' and not d.location.endswith('0'):
                     continue
                 s_dev = {}
-                s_dev['platform'] = "unknown"
+                s_dev['platform'] = d.manufacturer
                 s_dev['id'] = d.serial_number
                 s_dev['serial'] = d.device
                 s_dev['product'] = d.product


### PR DESCRIPTION
During hardware map generation it was unable to detect platform
name correctly. Result for each platform was unknown.
Now it will give manufacturer's name when serial device connected.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>