### PR TITLE
sanitycheck: hardware map added support of the microchip board

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -3749,7 +3749,9 @@ class HardwareMap:
         'Atmel Corp.',
         'Texas Instruments',
         'Silicon Labs',
-        'NXP Semiconductors'
+        'NXP Semiconductors',
+        'Microchip Technology Inc.',
+        'FTDI'
     ]
 
     runner_mapping = {
@@ -3763,6 +3765,10 @@ class HardwareMap:
         ],
         'openocd': [
             'STM32 STLink', '^XDS110.*'
+        ],
+        'dediprog': [
+            'TTL232R-3V3',
+            'MCP2200 USB Serial Port Emulator'
         ]
     }
 


### PR DESCRIPTION
Added support of the Microchip with FTDI serial devices to be able
create a hardware map for them. In the future that hardware map
for the Microchip board will let run automatic Sanitycheck tests on it.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>