### PR TITLE
drivers: counter: mcux_gpt: Add count-up flag

### DIFF
--- a/drivers/counter/counter_mcux_gpt.c
+++ b/drivers/counter/counter_mcux_gpt.c
@@ -208,6 +208,7 @@ static const struct counter_driver_api mcux_gpt_driver_api = {
 			.max_top_value = UINT32_MAX,				\
 			.freq = 25000000,					\
 			.channels = 1,						\
+			.flags = COUNTER_CONFIG_INFO_COUNT_UP,			\
 		},								\
 	};									\
 										\


### PR DESCRIPTION
The GPT based counter is a count up timer.
This fixes counter_basic_api tests.

Fixes: #21351
Signed-off-by: Loic Poulain <loic.poulain@linaro.org>