### PR TITLE
boards: nucleo_f746zg: Update reference for user manual

### DIFF
--- a/boards/arm/nucleo_f746zg/doc/index.rst
+++ b/boards/arm/nucleo_f746zg/doc/index.rst
@@ -217,7 +217,7 @@ You can debug an application in the usual way.  Here is an example for the
    https://www.st.com/en/evaluation-tools/nucleo-f746zg.html
 
 .. _STM32 Nucleo-144 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00105823.pdf
+   http://www.st.com/resource/en/user_manual/dm00244518.pdf
 
 .. _STM32F746ZG on www.st.com:
    https://www.st.com/content/st_com/en/products/microcontrollers/stm32-32-bit-arm-cortex-mcus/stm32-high-performance-mcus/stm32f7-series/stm32f7x6/stm32f746zg.html


### PR DESCRIPTION
Wrong reference was provided for board user manual.
Fix this.


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>