### PR TITLE
soc: stm32f446 : update default gpio configuration

### DIFF
--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f446xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f446xx
@@ -14,10 +14,10 @@ config NUM_IRQS
 if GPIO_STM32
 
 config GPIO_STM32_PORTE
-	default n
+	default y
 
 config GPIO_STM32_PORTH
-	default n
+	default y
 
 endif # GPIO_STM32
 


### PR DESCRIPTION
Fix GPIO default configuration for F446.
Default config for GPIO should be `y`.


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>