### PR TITLE
spi-nor: binding, test, and devicetree updates

### DIFF
--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -194,7 +194,7 @@ arduino_i2c: &i2c0 {
 	mx25r64: mx25r6435f@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <33000000>;
 		label = "MX25R64";
 		jedec-id = [c2 28 17];
 		size = <67108864>;

--- a/dts/bindings/mtd/jedec,spi-nor-common.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor-common.yaml
@@ -1,0 +1,87 @@
+# Copyright (c) 2018 Peter Bigot Consulting, LLC
+# Copyright (c) 2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Common properties used by nodes describing M25P80-compatible SPI NOR
+# serial flash devices.
+
+properties:
+  jedec-id:
+    type: uint8-array
+    required: true
+    description: JEDEC ID as manufacturer ID, memory type, memory density
+
+  has-be32k:
+    type: boolean
+    required: false
+    description: Indicates the device supports the BE32K (0xD8) command
+
+  requires-ulbpr:
+    type: boolean
+    required: false
+    description: |
+      Indicates the device requires the ULBPR (0x98) command.
+
+      Some flash chips such as the Microchip SST26VF series have a block
+      protection register that initializes to write-protected.  Use this
+      property to indicate that the BPR must be unlocked before write
+      operations can proceed.
+
+  has-dpd:
+    type: boolean
+    required: false
+    description: |
+      Indicates the device supports the DPD (0xB9) command.
+
+      Use this property to indicate the flash chip supports the Deep
+      Power-Down mode that is entered by command 0xB9 to reduce power
+      consumption below normal standby levels.  Use of this property
+      implies that the RDPD (0xAB) Release from Deep Power Down command
+      is also supported.  (On some chips this command functions as Read
+      Electronic Signature; see t-enter-dpd).
+
+  dpd-wakeup-sequence:
+    type: array
+    required: false
+    description: |
+      Specifies wakeup durations for devices without RDPD.
+
+      Some devices (Macronix MX25R in particular) wake from deep power
+      down by a timed sequence of CSn toggles rather than the RDPD
+      command.  This property specifies three durations measured in
+      nanoseconds, in this order:
+      (1) tDPDD (Delay Time for Release from Deep Power-Down Mode)
+      (2) tCDRP (CSn Toggling Time before Release from Deep Power-Down Mode)
+      (3) tRDP (Recovery Time for Release from Deep Power-Down Mode)
+
+      Absence of this property indicates that the RDPD command should be
+      used to wake the chip from Deep Power-Down mode.
+
+  t-enter-dpd:
+    type: int
+    required: false
+    description: |
+      Duration required to complete the DPD command.
+
+      This provides the duration, in nanoseconds, that CSn must be
+      remain deasserted after issuing DPD before the chip will enter
+      deep power down.
+
+      If not provided the driver does not enforce a delay.
+
+  t-exit-dpd:
+    type: int
+    required: false
+    description: |
+      Duration required to complete the RDPD command.
+
+      This provides the duration, in nanoseconds, that CSn must be
+      remain deasserted after issuing RDPD before the chip will exit
+      deep power down and be ready to receive additional commands.
+
+      If not provided the driver does not enforce a delay.
+
+  size:
+    type: int
+    required: true
+    description: flash capacity in bits

--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -1,93 +1,17 @@
 # Copyright (c) 2018 Peter Bigot Consulting, LLC
+# Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: SPI NOR flash that supports the JEDEC CFI interface
+description: |
+  Properties supporting Zephyr spi-nor flash driver (over the Zephyr SPI
+  API) control of serial flash memories using the standard M25P80-based
+  command set.
 
 compatible: "jedec,spi-nor"
 
-include: spi-device.yaml
+include: [spi-device.yaml, "jedec,spi-nor-common.yaml"]
 
 properties:
-  jedec-id:
-    type: uint8-array
-    required: true
-    description: JEDEC ID as manufacturer ID, memory type, memory density
-
-  has-be32k:
-    type: boolean
-    required: false
-    description: Indicates the device supports the BE32K (0xD8) command
-
-  requires-ulbpr:
-    type: boolean
-    required: false
-    description: |
-      Indicates the device requires the ULBPR (0x98) command.
-
-      Some flash chips such as the Microchip SST26VF series have a block
-      protection register that initializes to write-protected.  Use this
-      property to indicate that the BPR must be unlocked before write
-      operations can proceed.
-
-  has-dpd:
-    type: boolean
-    required: false
-    description: |
-      Indicates the device supports the DPD (0xB9) command.
-
-      Use this property to indicate the flash chip supports the Deep
-      Power-Down mode that is entered by command 0xB9 to reduce power
-      consumption below normal standby levels.  Use of this property
-      implies that the RDPD (0xAB) Release from Deep Power Down command
-      is also supported.  (On some chips this command functions as Read
-      Electronic Signature; see t-enter-dpd).
-
-  dpd-wakeup-sequence:
-    type: array
-    required: false
-    description: |
-      Specifies wakeup durations for devices without RDPD.
-
-      Some devices (Macronix MX25R in particular) wake from deep power
-      down by a timed sequence of CSn toggles rather than the RDPD
-      command.  This property specifies three durations measured in
-      nanoseconds, in this order:
-      (1) tDPDD (Delay Time for Release from Deep Power-Down Mode)
-      (2) tCDRP (CSn Toggling Time before Release from Deep Power-Down Mode)
-      (3) tRDP (Recovery Time for Release from Deep Power-Down Mode)
-
-      Absence of this property indicates that the RDPD command should be
-      used to wake the chip from Deep Power-Down mode.
-
-  t-enter-dpd:
-    type: int
-    required: false
-    description: |
-      Duration required to complete the DPD command.
-
-      This provides the duration, in nanoseconds, that CSn must be
-      remain deasserted after issuing DPD before the chip will enter
-      deep power down.
-
-      If not provided the driver does not enforce a delay.
-
-  t-exit-dpd:
-    type: int
-    required: false
-    description: |
-      Duration required to complete the RDPD command.
-
-      This provides the duration, in nanoseconds, that CSn must be
-      remain deasserted after issuing RDPD before the chip will exit
-      deep power down and be ready to receive additional commands.
-
-      If not provided the driver does not enforce a delay.
-
-  size:
-    type: int
-    required: true
-    description: flash capacity in bits
-
   wp-gpios:
     type: phandle-array
     required: false

--- a/samples/drivers/spi_flash/src/main.c
+++ b/samples/drivers/spi_flash/src/main.c
@@ -8,6 +8,7 @@
 #include <drivers/flash.h>
 #include <device.h>
 #include <stdio.h>
+#include <string.h>
 
 #if (CONFIG_SPI_FLASH_W25QXXDV - 0)
 /* NB: W25Q16DV is a JEDEC spi-nor device, but has a separate driver. */
@@ -22,14 +23,14 @@
 
 #define FLASH_TEST_REGION_OFFSET 0xff000
 #define FLASH_SECTOR_SIZE        4096
-#define TEST_DATA_BYTE_0         0x55
-#define TEST_DATA_BYTE_1         0xaa
-#define TEST_DATA_LEN            2
 
 void main(void)
 {
+	const u8_t expected[] = { 0x55, 0xaa, 0x66, 0x99 };
+	const size_t len = sizeof(expected);
+	u8_t buf[sizeof(expected)];
 	struct device *flash_dev;
-	u8_t buf[TEST_DATA_LEN];
+	int rc;
 
 	printf("\n" FLASH_NAME " SPI flash testing\n");
 	printf("==========================\n");
@@ -37,7 +38,8 @@ void main(void)
 	flash_dev = device_get_binding(FLASH_DEVICE);
 
 	if (!flash_dev) {
-		printf("SPI flash driver %s was not found!\n", FLASH_DEVICE);
+		printf("SPI flash driver %s was not found!\n",
+		       FLASH_DEVICE);
 		return;
 	}
 
@@ -48,36 +50,46 @@ void main(void)
 	 */
 	printf("\nTest 1: Flash erase\n");
 	flash_write_protection_set(flash_dev, false);
-	if (flash_erase(flash_dev,
-			FLASH_TEST_REGION_OFFSET,
-			FLASH_SECTOR_SIZE) != 0) {
-		printf("   Flash erase failed!\n");
+
+	rc = flash_erase(flash_dev, FLASH_TEST_REGION_OFFSET,
+			 FLASH_SECTOR_SIZE);
+	if (rc != 0) {
+		printf("Flash erase failed! %d\n", rc);
 	} else {
-		printf("   Flash erase succeeded!\n");
+		printf("Flash erase succeeded!\n");
 	}
 
 	printf("\nTest 2: Flash write\n");
 	flash_write_protection_set(flash_dev, false);
 
-	buf[0] = TEST_DATA_BYTE_0;
-	buf[1] = TEST_DATA_BYTE_1;
-	printf("   Attempted to write %x %x\n", buf[0], buf[1]);
-	if (flash_write(flash_dev, FLASH_TEST_REGION_OFFSET, buf,
-	    TEST_DATA_LEN) != 0) {
-		printf("   Flash write failed!\n");
+	printf("Attempting to write %u bytes\n", len);
+	rc = flash_write(flash_dev, FLASH_TEST_REGION_OFFSET, expected, len);
+	if (rc != 0) {
+		printf("Flash write failed! %d\n", rc);
 		return;
 	}
 
-	if (flash_read(flash_dev, FLASH_TEST_REGION_OFFSET, buf,
-	    TEST_DATA_LEN) != 0) {
-		printf("   Flash read failed!\n");
+	memset(buf, 0, len);
+	rc = flash_read(flash_dev, FLASH_TEST_REGION_OFFSET, buf, len);
+	if (rc != 0) {
+		printf("Flash read failed! %d\n", rc);
 		return;
 	}
-	printf("   Data read %x %x\n", buf[0], buf[1]);
 
-	if ((buf[0] == TEST_DATA_BYTE_0) && (buf[1] == TEST_DATA_BYTE_1)) {
-		printf("   Data read matches with data written. Good!!\n");
+	if (memcmp(expected, buf, len) == 0) {
+		printf("Data read matches data written. Good!!\n");
 	} else {
-		printf("   Data read does not match with data written!!\n");
+		const u8_t *wp = expected;
+		const u8_t *rp = buf;
+		const u8_t *rpe = rp + len;
+
+		printf("Data read does not match data written!!\n");
+		while (rp < rpe) {
+			printf("%08x wrote %02x read %02x %s\n",
+			       FLASH_TEST_REGION_OFFSET + (rp - buf),
+			       *wp, *rp, (*rp == *wp) ? "match" : "MISMATCH");
+			++rp;
+			++wp;
+		}
 	}
 }


### PR DESCRIPTION
Fix the maximum SPI bus clock rate for the flash on the Nordic nRF52840-DK.

Rework the structure of the (formerly) JEDEC SPI NOR bindings so that the properties associated with the chip are separate from the properties associated with the bus, opening a path to QSPI drivers.  Also rework the documentation as the JEDEC CFI interface has nothing to do with these memories, which are based on the M25P80 chip interface.

Rework the spi-flash test so that it uses 4-byte transfers in the test (anticipating QSPI drivers that operate on 32-bit blocks) and to detect cases where the read-back "succeeded" only because the buffer used to write was re-used for read without clearing it.