### PR TITLE
net: stats: Fix RX traffic class time statistics update

### DIFF
--- a/subsys/net/ip/net_stats.h
+++ b/subsys/net/ip/net_stats.h
@@ -398,7 +398,7 @@ static inline void net_stats_update_tc_rx_time(struct net_if *iface,
 	u32_t diff = end_time - start_time;
 
 	UPDATE_STAT(iface, stats.tc.recv[tc].rx_time.sum +=
-		    SYS_CLOCK_HW_CYCLES_TO_NS64(diff) / NSEC_PER_USEC);
+		    k_cyc_to_ns_floor64(diff) / 1000);
 	UPDATE_STAT(iface, stats.tc.recv[tc].rx_time.count += 1);
 
 	net_stats_update_rx_time(iface, start_time, end_time);


### PR DESCRIPTION
The commit 8892406c1de21 ("kernel/sys_clock.h: Deprecate and convert
uses of old conversions") changed code to not use deprecated macro.
Unfortunately there was some changes done to RX TC stats update that
were missing from that commit. This commit fixes the issue and removes
the last user of the deprecated SYS_CLOCK_HW_CYCLES_TO_NS64() macro.

This is follow up to commit 5bbdf56769d6 ("net: stats: Fix RX time
statistics update") which failed to remove all users of the deprecated
macro.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>