### PR TITLE
drivers: adc: adc_stm32: fix clock setup

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -532,7 +532,7 @@ static int adc_stm32_init(struct device *dev)
 	defined(CONFIG_SOC_SERIES_STM32L4X) || \
 	defined(CONFIG_SOC_SERIES_STM32WBX) || \
 	defined(CONFIG_SOC_SERIES_STM32G4X)
-	LL_ADC_SetCommonClock(__LL_ADC_COMMON_INSTANCE(),
+	LL_ADC_SetCommonClock(__LL_ADC_COMMON_INSTANCE(adc),
 			LL_ADC_CLOCK_SYNC_PCLK_DIV4);
 #endif
 


### PR DESCRIPTION
Fix clock setup for stm32 f3, l4, wb and g4 series.

The macro __LL_ADC_COMMON_INSTANCE() is called without argument, which
leads to a compile error. Fix by passing adc parameter.

Signed-off-by: Thomas Schmid <tom@lfence.de>