### PR TITLE
doc: releases: add python 3.6 requirement to notes

### DIFF
--- a/doc/releases/release-notes-2.2.rst
+++ b/doc/releases/release-notes-2.2.rst
@@ -237,7 +237,9 @@ Bluetooth
 Build and Infrastructure
 ************************
 
-* <TBD>
+* The minimum Python version supported by Zephyr's build system and tools is
+  now 3.6.
+* <Other items TBD>
 
 Libraries / Subsystems
 ***********************


### PR DESCRIPTION
Add a release notes line item about the move to Python 3.6.
