### PR TITLE
soc: arm: nordic: Remove enabling of temperature sensor

### DIFF
--- a/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.series
@@ -14,7 +14,4 @@ config SOC_SERIES
 config NUM_IRQS
 	default 26
 
-config TEMP_NRF5
-	default SENSOR
-
 endif # SOC_SERIES_NRF51X

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
@@ -10,7 +10,4 @@ source "soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52*"
 config SOC_SERIES
 	default "nrf52"
 
-config TEMP_NRF5
-	default SENSOR
-
 endif # SOC_SERIES_NRF52X


### PR DESCRIPTION
nrf51 and nrf52 by default was enabling temperature sensor if sensor
API was enabled. It was causing code size increase even when
temperature sensor was not touched by anyone. Removed default enabling
of temperature sensor for both series.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>