### PR TITLE
Bluetooth: L2CAP: Cleanup & fixes

### DIFF
--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -90,7 +90,7 @@ struct bt_l2cap_chan {
 	/** Channel connection reference */
 	struct bt_conn			*conn;
 	/** Channel operations reference */
-	struct bt_l2cap_chan_ops	*ops;
+	const struct bt_l2cap_chan_ops	*ops;
 	sys_snode_t			node;
 	bt_l2cap_chan_destroy_t		destroy;
 	/* Response Timeout eXpired (RTX) timer */

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2208,7 +2208,7 @@ static void bt_att_encrypt_change(struct bt_l2cap_chan *chan,
 static int bt_att_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 {
 	int i;
-	static struct bt_l2cap_chan_ops ops = {
+	static const struct bt_l2cap_chan_ops ops = {
 		.connected = bt_att_connected,
 		.disconnected = bt_att_disconnected,
 		.recv = bt_att_recv,

--- a/subsys/bluetooth/host/avdtp.c
+++ b/subsys/bluetooth/host/avdtp.c
@@ -191,7 +191,7 @@ int bt_avdtp_l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 /*A2DP Layer interface */
 int bt_avdtp_connect(struct bt_conn *conn, struct bt_avdtp *session)
 {
-	static struct bt_l2cap_chan_ops ops = {
+	static const struct bt_l2cap_chan_ops ops = {
 		.connected = bt_avdtp_l2cap_connected,
 		.disconnected = bt_avdtp_l2cap_disconnected,
 		.encrypt_change = bt_avdtp_l2cap_encrypt_changed,
@@ -224,7 +224,7 @@ int bt_avdtp_l2cap_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 {
 	struct bt_avdtp *session = NULL;
 	int result;
-	static struct bt_l2cap_chan_ops ops = {
+	static const struct bt_l2cap_chan_ops ops = {
 		.connected = bt_avdtp_l2cap_connected,
 		.disconnected = bt_avdtp_l2cap_disconnected,
 		.recv = bt_avdtp_l2cap_recv,

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1880,7 +1880,7 @@ static void l2cap_disconnected(struct bt_l2cap_chan *chan)
 static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 {
 	int i;
-	static struct bt_l2cap_chan_ops ops = {
+	static const struct bt_l2cap_chan_ops ops = {
 		.connected = l2cap_connected,
 		.disconnected = l2cap_disconnected,
 		.recv = l2cap_recv,

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -110,12 +110,12 @@ static struct bt_l2cap_le_chan *l2cap_chan_alloc_cid(struct bt_conn *conn,
 	 * No action needed if there's already a CID allocated, e.g. in
 	 * the case of a fixed channel.
 	 */
-	if (ch && ch->rx.cid > 0) {
+	if (ch->rx.cid > 0) {
 		return ch;
 	}
 
 	for (cid = L2CAP_LE_CID_DYN_START; cid <= L2CAP_LE_CID_DYN_END; cid++) {
-		if (ch && !bt_l2cap_le_lookup_rx_cid(conn, cid)) {
+		if (!bt_l2cap_le_lookup_rx_cid(conn, cid)) {
 			ch->rx.cid = cid;
 			return ch;
 		}

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -786,7 +786,7 @@ static void l2cap_chan_tx_give_credits(struct bt_l2cap_le_chan *chan,
 		k_sem_give(&chan->tx.credits);
 	}
 
-	if (atomic_test_and_set_bit(chan->chan.status, BT_L2CAP_STATUS_OUT) &&
+	if (!atomic_test_and_set_bit(chan->chan.status, BT_L2CAP_STATUS_OUT) &&
 	    chan->chan.ops->status) {
 		chan->chan.ops->status(&chan->chan, chan->chan.status);
 	}

--- a/subsys/bluetooth/host/l2cap_br.c
+++ b/subsys/bluetooth/host/l2cap_br.c
@@ -1515,7 +1515,7 @@ void bt_l2cap_br_recv(struct bt_conn *conn, struct net_buf *buf)
 static int l2cap_br_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 {
 	int i;
-	static struct bt_l2cap_chan_ops ops = {
+	static const struct bt_l2cap_chan_ops ops = {
 		.connected = l2cap_br_connected,
 		.disconnected = l2cap_br_disconnected,
 		.recv = l2cap_br_recv,

--- a/subsys/bluetooth/host/rfcomm.c
+++ b/subsys/bluetooth/host/rfcomm.c
@@ -1567,7 +1567,7 @@ static void rfcomm_session_rtx_timeout(struct k_work *work)
 static struct bt_rfcomm_session *rfcomm_session_new(bt_rfcomm_role_t role)
 {
 	int i;
-	static struct bt_l2cap_chan_ops ops = {
+	static const struct bt_l2cap_chan_ops ops = {
 		.connected = rfcomm_connected,
 		.disconnected = rfcomm_disconnected,
 		.recv = rfcomm_recv,

--- a/subsys/bluetooth/host/sdp.c
+++ b/subsys/bluetooth/host/sdp.c
@@ -1388,7 +1388,7 @@ static int bt_sdp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
  */
 static int bt_sdp_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 {
-	static struct bt_l2cap_chan_ops ops = {
+	static const struct bt_l2cap_chan_ops ops = {
 		.connected = bt_sdp_connected,
 		.disconnected = bt_sdp_disconnected,
 		.recv = bt_sdp_recv,
@@ -1888,7 +1888,7 @@ static void sdp_client_disconnected(struct bt_l2cap_chan *chan)
 		     sizeof(*session) - sizeof(session->chan));
 }
 
-static struct bt_l2cap_chan_ops sdp_client_chan_ops = {
+static const struct bt_l2cap_chan_ops sdp_client_chan_ops = {
 		.connected = sdp_client_connected,
 		.disconnected = sdp_client_disconnected,
 		.recv = sdp_client_receive,

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -1564,7 +1564,7 @@ static bool br_sc_supported(void)
 
 static int bt_smp_br_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 {
-	static struct bt_l2cap_chan_ops ops = {
+	static const struct bt_l2cap_chan_ops ops = {
 		.connected = bt_smp_br_connected,
 		.disconnected = bt_smp_br_disconnected,
 		.recv = bt_smp_br_recv,
@@ -5242,7 +5242,7 @@ void bt_smp_update_keys(struct bt_conn *conn)
 static int bt_smp_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 {
 	int i;
-	static struct bt_l2cap_chan_ops ops = {
+	static const struct bt_l2cap_chan_ops ops = {
 		.connected = bt_smp_connected,
 		.disconnected = bt_smp_disconnected,
 		.encrypt_change = bt_smp_encrypt_change,

--- a/subsys/bluetooth/host/smp_null.c
+++ b/subsys/bluetooth/host/smp_null.c
@@ -68,7 +68,7 @@ static int bt_smp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 static int bt_smp_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 {
 	int i;
-	static struct bt_l2cap_chan_ops ops = {
+	static const struct bt_l2cap_chan_ops ops = {
 		.recv = bt_smp_recv,
 	};
 

--- a/subsys/bluetooth/shell/bredr.c
+++ b/subsys/bluetooth/shell/bredr.c
@@ -230,7 +230,7 @@ static struct net_buf *l2cap_alloc_buf(struct bt_l2cap_chan *chan)
 	return net_buf_alloc(&data_pool, K_FOREVER);
 }
 
-static struct bt_l2cap_chan_ops l2cap_ops = {
+static const struct bt_l2cap_chan_ops l2cap_ops = {
 	.alloc_buf	= l2cap_alloc_buf,
 	.recv		= l2cap_recv,
 	.connected	= l2cap_connected,

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -255,7 +255,7 @@ static struct net_buf *ipsp_alloc_buf(struct bt_l2cap_chan *chan)
 	return net_pkt_get_reserve_rx_data(BUF_TIMEOUT);
 }
 
-static struct bt_l2cap_chan_ops ipsp_ops = {
+static const struct bt_l2cap_chan_ops ipsp_ops = {
 	.alloc_buf	= ipsp_alloc_buf,
 	.recv		= ipsp_recv,
 	.connected	= ipsp_connected,

--- a/tests/bluetooth/tester/src/l2cap.c
+++ b/tests/bluetooth/tester/src/l2cap.c
@@ -110,7 +110,7 @@ static void disconnected_cb(struct bt_l2cap_chan *l2cap_chan)
 		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
 }
 
-static struct bt_l2cap_chan_ops l2cap_ops = {
+static const struct bt_l2cap_chan_ops l2cap_ops = {
 	.alloc_buf	= alloc_buf_cb,
 	.recv		= recv_cb,
 	.connected	= connected_cb,


### PR DESCRIPTION
Three patches: two fixes and an update to make the chan_ops const in order to save memory.