### PR TITLE
Bluetooth: L2CAP: Remove use of k_sem for credits

### DIFF
--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -118,7 +118,7 @@ struct bt_l2cap_le_endpoint {
 	/** Endpoint initial credits */
 	u16_t				init_credits;
 	/** Endpoint credits */
-	struct k_sem			credits;
+	atomic_t			credits;
 };
 
 /** @brief LE L2CAP Channel structure. */


### PR DESCRIPTION
With the changes that introduced a queue k_sem is only used with
K_NO_WAIT which means it is no longer possible to wait/block for credits
so the usage of k_sem is no longer needed and can be safely replaced
with atomic_t just to count the available credits at a given instant.

Fixes #19922

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>