### PR TITLE
dts: bindings: Remove document separators and description boilerplate

### DIFF
--- a/dts/bindings/ps2/microchip,xec-ps2.yaml
+++ b/dts/bindings/ps2/microchip,xec-ps2.yaml
@@ -13,4 +13,3 @@ properties:
 
     interrupts:
       required: true
-...

--- a/dts/bindings/pwm/microchip,xec-pwm.yaml
+++ b/dts/bindings/pwm/microchip,xec-pwm.yaml
@@ -13,5 +13,3 @@ properties:
 
     label:
       required: true
-
-...

--- a/dts/bindings/rng/atmel,sam-trng.yaml
+++ b/dts/bindings/rng/atmel,sam-trng.yaml
@@ -1,8 +1,7 @@
 # Copyright (c) 2018, Aurelien Jarno
 # SPDX-License-Identifier: Apache-2.0
 
-description: |
-    This binding gives a base representation of the Atmel SAM RNG
+description: Atmel SAM RNG
 
 compatible: "atmel,sam-trng"
 

--- a/dts/bindings/sensor/st,lsm303dlhc-accel.yaml
+++ b/dts/bindings/sensor/st,lsm303dlhc-accel.yaml
@@ -1,8 +1,7 @@
 # Copyright (c) 2018 Philémon Jaermann
 # SPDX-License-Identifier: Apache-2.0
 
-description: |
-    This binding gives a base representation of LSM303DLHC acceleration sensor
+description: LSM303DLHC acceleration sensor
 
 compatible: "st,lsm303dlhc-accel"
 

--- a/dts/bindings/wifi/inventek,eswifi.yaml
+++ b/dts/bindings/wifi/inventek,eswifi.yaml
@@ -1,8 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-description: |
-    This binding gives the base representation of es-WiFi module
+description: es-WiFi module
 
 compatible: "inventek,eswifi"
 


### PR DESCRIPTION
Fix some newly-introduced stuff.

```
dts: bindings: Remove redundant document separators

Not needed. Prevent them from being copy-pasted.
```

```
dts: bindings: Remove "provides a base representation" from bindings

Newly-introduced stuff. See
https://github.com/zephyrproject-rtos/zephyr/pull/20793.
```