### PR TITLE
interrupt_controller: gic: Support multiple GIC versions

### DIFF
--- a/drivers/interrupt_controller/CMakeLists.txt
+++ b/drivers/interrupt_controller/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_sources_ifdef(CONFIG_ARCV2_INTERRUPT_UNIT    intc_arcv2_irq_unit.c)
-zephyr_sources_ifdef(CONFIG_GIC                     intc_gic_400.c)
+zephyr_sources_ifdef(CONFIG_GIC                     intc_gic.c)
 zephyr_sources_ifdef(CONFIG_IOAPIC                  intc_ioapic.c)
 zephyr_sources_ifdef(CONFIG_LOAPIC                  intc_loapic.c intc_system_apic.c)
 zephyr_sources_ifdef(CONFIG_LOAPIC_SPURIOUS_VECTOR  intc_loapic_spurious.S)

--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -39,13 +39,6 @@ config VEXRISCV_LITEX_IRQ
 	help
 	  IRQ implementation for LiteX VexRiscv
 
-config GIC
-	bool "ARM Generic Interrupt Controller (GIC)"
-	depends on CPU_CORTEX_R
-	help
-	  The ARM Generic Interrupt Controller works with Cortex-A and
-	  Cortex-R processors.
-
 source "drivers/interrupt_controller/Kconfig.multilevel"
 
 source "drivers/interrupt_controller/Kconfig.loapic"
@@ -59,5 +52,7 @@ source "drivers/interrupt_controller/Kconfig.cavs"
 source "drivers/interrupt_controller/Kconfig.rv32m1"
 
 source "drivers/interrupt_controller/Kconfig.sam0"
+
+source "drivers/interrupt_controller/Kconfig.gic"
 
 endmenu

--- a/drivers/interrupt_controller/Kconfig.gic
+++ b/drivers/interrupt_controller/Kconfig.gic
@@ -1,0 +1,39 @@
+# ARM Generic Interrupt Controller (GIC) configuration
+
+# Copyright (c) 2019 Stephanos Ioannidis <root@stephanos.io>
+# SPDX-License-Identifier: Apache-2.0
+
+if CPU_CORTEX
+
+config GIC
+	bool
+
+config GIC_V1
+	bool
+	select GIC
+	help
+	  The ARM Generic Interrupt Controller v1 (e.g. PL390) works with the
+	  ARM Cortex-family processors.
+
+config GIC_V2
+	bool
+	select GIC
+	help
+	  The ARM Generic Interrupt Controller v2 (e.g. GIC-400) works with the
+	  ARM Cortex-family processors.
+
+config GIC_V3
+	bool
+	select GIC
+	help
+	  The ARM Generic Interrupt Controller v3 (e.g. GIC-500 and GIC-600)
+	  works with the ARM Cortex-family processors.
+
+config GIC_VER
+	int
+	depends on GIC
+	default 1 if GIC_V1
+	default 2 if GIC_V2
+	default 3 if GIC_V3
+
+endif # CPU_CORTEX

--- a/include/drivers/interrupt_controller/gic.h
+++ b/include/drivers/interrupt_controller/gic.h
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2019 Stephanos Ioannidis <root@stephanos.io>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_GIC_H_
+#define ZEPHYR_INCLUDE_DRIVERS_GIC_H_
+
+#include <arch/cpu.h>
+
+/*
+ * GIC Register Interface Base Addresses
+ */
+
+#define GIC_DIST_BASE	DT_INST_0_ARM_GIC_BASE_ADDRESS_0
+#define GIC_CPU_BASE	DT_INST_0_ARM_GIC_BASE_ADDRESS_1
+
+/*
+ * GIC Distributor Interface
+ */
+
+/*
+ * 0x000  Distributor Control Register
+ * v1		ICDDCR
+ * v2/v3	GICD_CTLR
+ */
+#define	GICD_CTLR		(GIC_DIST_BASE +   0x0)
+
+/*
+ * 0x004  Interrupt Controller Type Register
+ * v1		ICDICTR
+ * v2/v3	GICD_TYPER
+ */
+#define	GICD_TYPER		(GIC_DIST_BASE +   0x4)
+
+/*
+ * 0x008  Distributor Implementer Identification Register
+ * v1		ICDIIDR
+ * v2/v3	GICD_IIDR
+ */
+#define	GICD_IIDR		(GIC_DIST_BASE +   0x8)
+
+/*
+ * 0x080  Interrupt Group Registers
+ * v1		ICDISRn
+ * v2/v3	GICD_IGROUPRn
+ */
+#define	GICD_IGROUPRn		(GIC_DIST_BASE +  0x80)
+
+/*
+ * 0x100  Interrupt Set-Enable Reigsters
+ * v1		ICDISERn
+ * v2/v3	GICD_ISENABLERn
+ */
+#define	GICD_ISENABLERn		(GIC_DIST_BASE + 0x100)
+
+/*
+ * 0x180  Interrupt Clear-Enable Registers
+ * v1		ICDICERn
+ * v2/v3	GICD_ICENABLERn
+ */
+#define	GICD_ICENABLERn		(GIC_DIST_BASE + 0x180)
+
+/*
+ * 0x200  Interrupt Set-Pending Registers
+ * v1		ICDISPRn
+ * v2/v3	GICD_ISPENDRn
+ */
+#define	GICD_ISPENDRn		(GIC_DIST_BASE + 0x200)
+
+/*
+ * 0x280  Interrupt Clear-Pending Registers
+ * v1		ICDICPRn
+ * v2/v3	GICD_ICPENDRn
+ */
+#define	GICD_ICPENDRn		(GIC_DIST_BASE + 0x280)
+
+/*
+ * 0x300  Interrupt Set-Active Registers
+ * v1		ICDABRn
+ * v2/v3	GICD_ISACTIVERn
+ */
+#define	GICD_ISACTIVERn		(GIC_DIST_BASE + 0x300)
+
+#if CONFIG_GIC_VER >= 2
+/*
+ * 0x380  Interrupt Clear-Active Registers
+ * v2/v3	GICD_ICACTIVERn
+ */
+#define	GICD_ICACTIVERn		(GIC_DIST_BASE + 0x380)
+#endif
+
+/*
+ * 0x400  Interrupt Priority Registers
+ * v1		ICDIPRn
+ * v2/v3	GICD_IPRIORITYRn
+ */
+#define	GICD_IPRIORITYRn	(GIC_DIST_BASE + 0x400)
+
+/*
+ * 0x800  Interrupt Processor Targets Registers
+ * v1		ICDIPTRn
+ * v2/v3	GICD_ITARGETSRn
+ */
+#define	GICD_ITARGETSRn		(GIC_DIST_BASE + 0x800)
+
+/*
+ * 0xC00  Interrupt Configuration Registers
+ * v1		ICDICRn
+ * v2/v3	GICD_ICFGRn
+ */
+#define	GICD_ICFGRn		(GIC_DIST_BASE + 0xc00)
+
+/*
+ * 0xF00  Software Generated Interrupt Register
+ * v1		ICDSGIR
+ * v2/v3	GICD_SGIR
+ */
+#define	GICD_SGIR		(GIC_DIST_BASE + 0xf00)
+
+/*
+ * GIC CPU Interface
+ */
+
+#if CONFIG_GIC_VER <= 2
+
+/*
+ * 0x0000  CPU Interface Control Register
+ * v1		ICCICR
+ * v2/v3	GICC_CTLR
+ */
+#define GICC_CTLR		(GIC_CPU_BASE +    0x0)
+
+/*
+ * 0x0004  Interrupt Priority Mask Register
+ * v1		ICCPMR
+ * v2/v3	GICC_PMR
+ */
+#define GICC_PMR		(GIC_CPU_BASE +    0x4)
+
+/*
+ * 0x0008  Binary Point Register
+ * v1		ICCBPR
+ * v2/v3	GICC_BPR
+ */
+#define GICC_BPR		(GIC_CPU_BASE +    0x8)
+
+/*
+ * 0x000C  Interrupt Acknowledge Register
+ * v1		ICCIAR
+ * v2/v3	GICC_IAR
+ */
+#define GICC_IAR		(GIC_CPU_BASE +    0xc)
+
+/*
+ * 0x0010  End of Interrupt Register
+ * v1		ICCEOIR
+ * v2/v3	GICC_EOIR
+ */
+#define GICC_EOIR		(GIC_CPU_BASE +   0x10)
+
+
+/*
+ * Helper Constants
+ */
+
+#define	GIC_SPI_INT_BASE	32
+
+/* GICC_CTLR */
+#define GICC_CTLR_ENABLEGRP0	BIT(0)
+#define GICC_CTLR_ENABLEGRP1	BIT(1)
+
+#define GICC_CTLR_ENABLE_MASK	(GICC_CTLR_ENABLEGRP0 | GICC_CTLR_ENABLEGRP1)
+
+#if defined(CONFIG_GIC_V2)
+
+#define GICC_CTLR_FIQBYPDISGRP0	BIT(5)
+#define GICC_CTLR_IRQBYPDISGRP0	BIT(6)
+#define GICC_CTLR_FIQBYPDISGRP1	BIT(7)
+#define GICC_CTLR_IRQBYPDISGRP1	BIT(8)
+
+#define GICC_CTLR_BYPASS_MASK	(GICC_CTLR_FIQBYPDISGRP0 | \
+				 GICC_CTLR_IRQBYPDISGRP1 | \
+				 GICC_CTLR_FIQBYPDISGRP1 | \
+				 GICC_CTLR_IRQBYPDISGRP1)
+
+#endif /* CONFIG_GIC_V2 */
+
+/* GICC_IAR */
+#define	GICC_IAR_SPURIOUS	1023
+
+/* GICC_ICFGR */
+#define GICC_ICFGR_MASK		BIT_MASK(2)
+#define GICC_ICFGR_TYPE		BIT(1)
+
+#endif /* CONFIG_GIC_VER <= 2 */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_GIC_H_ */

--- a/soc/arm/xilinx_zynqmp/Kconfig.soc
+++ b/soc/arm/xilinx_zynqmp/Kconfig.soc
@@ -4,6 +4,6 @@
 config SOC_XILINX_ZYNQMP
 	bool "Xilinx ZynqMP"
 	select CPU_CORTEX_R5
-	select GIC
+	select GIC_V1
 	select MULTI_LEVEL_INTERRUPTS
 	select 2ND_LEVEL_INTERRUPTS


### PR DESCRIPTION
```
drivers: interrupt_controller: Refactor GIC configurations

The current GIC configuration scheme is designed to support only one
specific type and version of GIC (i.e. GIC-400 that implements the
GICv2 interface).

This commit adds a set of GIC version configuration symbols that can
be selected by the SoC configuration to specify which version of GIC
interface is implemented in the SoC.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```

```
interrupt_controller: gic: Support multiple GIC versions

The current GIC driver implementation only supports the GIC-400, which
implements the GICv2 interface.

This commit refactors the GIC driver to support multiple GIC versions
and adds GICv1 interface support (GICv1 and GICv2 interfaces are very
similar).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```
