### PR TITLE
logging: Fix synchronous logging in thread context

### DIFF
--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -49,8 +49,8 @@ void log_msg_pool_init(void)
 	k_mem_slab_init(&log_msg_pool, log_msg_pool_buf, MSG_SIZE, NUM_OF_MSGS);
 }
 
-/* Return true if interrupts were locked in the context of this call. */
-static bool is_irq_locked(void)
+/* Return true if interrupts were unlocked in the context of this call. */
+static bool is_irq_unlocked(void)
 {
 	unsigned int key = arch_irq_lock();
 	bool ret = arch_irq_unlocked(key);
@@ -68,7 +68,7 @@ static bool block_on_alloc(void)
 		return false;
 	}
 
-	return (!k_is_in_isr() && !is_irq_locked());
+	return (!k_is_in_isr() && is_irq_unlocked());
 }
 
 union log_msg_chunk *log_msg_chunk_alloc(void)


### PR DESCRIPTION
Due to flipped logic is_irq_locked function was returning true then
interrupts were unlocked. Because of that CONFIG_LOG_BLOCK_IN_THREAD
feature was not working correctly and wasn't locking thread context
when log message buffer pool was empty.

Fixes #21514.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>