### PR TITLE
libc: thread-safe newlib

### DIFF
--- a/arch/arm/core/swap.c
+++ b/arch/arm/core/swap.c
@@ -54,6 +54,9 @@ int arch_swap(unsigned int key)
 	irq_unlock(key);
 #endif
 
+#ifdef CONFIG_NEWLIB_LIBC
+	_impure_ptr = &_current->base.k_reent;
+#endif
 	/* Context switch is performed here. Returning implies the
 	 * thread has been context-switched-in again.
 	 */

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -493,6 +493,10 @@ struct _thread_base {
 	u8_t cpu_mask;
 #endif
 
+#ifdef CONFIG_NEWLIB_LIBC
+	struct _reent k_reent;
+#endif
+
 	/* data returned by APIs */
 	void *swap_data;
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -503,6 +503,10 @@ void z_setup_new_thread(struct k_thread *new_thread,
 #endif
 #endif
 
+#ifdef CONFIG_NEWLIB_LIBC
+	_REENT_INIT_PTR(&new_thread->base.k_reent);
+#endif
+
 	arch_new_thread(new_thread, stack, stack_size, entry, p1, p2, p3,
 			  prio, options);
 

--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -64,6 +64,17 @@ config NEWLIB_LIBC_ALIGNED_HEAP_SIZE
 	  If this is left at 0, then remaining system RAM will be used for this
 	  area and it may not be possible to program it as an MPU region.
 
+config NEWLIB_LIBC_DYNAMIC_LOCK_MEM_SIZE
+	int "Newlib size of the memory reserved for dynamic locks"
+	default 0
+	help
+	  Size of the memory which is reserved for newlib to create synchronization
+	  locks to maintain thread-safe operation. The number of locks required
+	  depends on the number of concurrent calls to functions provided by
+	  newlib. The size of one lock is 32 Byte.
+
+	  If this is left at 0, only malloc will be thread-safe
+
 config NEWLIB_LIBC_FLOAT_PRINTF
 	bool "Build with newlib float printf"
 	help


### PR DESCRIPTION
The aim of this PR is to utilize the functionalty provided by newlib for thread-safety. 

RFC #21519

## Relevant Links

### Documentation
[Newlib Documentation on __malloc_lock](https://sourceware.org/newlib/libc.html#g_t_005f_005fmalloc_005flock)

[Newlib Documentation on Reentrancy](https://sourceware.org/newlib/libc.html#Reentrancy)

### Mailing Lists
[Newlib discussion on `--enable-newlib-retargetable-locking`](https://newlib.sourceware.narkive.com/s5jTeAUp/patch-newlib-allow-locking-routine-to-be-retargeted)

[[PATCH, newlib] Allow locking routine to be retargeted](https://sourceware.org/ml/newlib/2016/msg01165.html)

[What are the __retarget_lock functions?](http://sourceware-org.1504.n7.nabble.com/What-are-the-retarget-lock-functions-td531854.html)