### PR TITLE
samples: bluetooth: ipsp: Mark accepted socket correctly in accept()

### DIFF
--- a/samples/bluetooth/ipsp/src/main.c
+++ b/samples/bluetooth/ipsp/src/main.c
@@ -291,6 +291,8 @@ static void tcp_accepted(struct net_context *context,
 
 	NET_DBG("Accept called, context %p error %d", context, error);
 
+	net_context_set_accepting(context, false);
+
 	ret = net_context_recv(context, tcp_received, 0, NULL);
 	if (ret < 0) {
 		LOG_ERR("Cannot receive TCP packet (family %d)",


### PR DESCRIPTION
The TCP code expects that we know when the socket has called accept()
in order to continue connection attempt.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>