### PR TITLE
usb: hid: Make it possible to specify HID debug level

### DIFF
--- a/subsys/usb/class/hid/Kconfig
+++ b/subsys/usb/class/hid/Kconfig
@@ -22,6 +22,10 @@ module = USB_HID
 default-count = 1
 source "subsys/usb/class/Kconfig.template.composite_device_number"
 
+module = USB_HID
+module-str = usb hid
+source "subsys/logging/Kconfig.template.log_config"
+
 config ENABLE_HID_INT_OUT_EP
 	bool "Enable USB HID Device Interrupt OUT Endpoint"
 	help

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
+#define LOG_LEVEL CONFIG_USB_HID_LOG_LEVEL
 #include <logging/log.h>
 LOG_MODULE_REGISTER(usb_hid);
 


### PR DESCRIPTION
Until now HID class derived log level from USB stack.
By this commit new Kconfig option for HID specific log
level is introduced.

This change will be useful when debugging composite devices.
User have a possibility to enable different log level on each part
of the stack.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>