### PR TITLE
soc: posix: Fix function name typo

### DIFF
--- a/boards/posix/native_posix/irq_ctrl.c
+++ b/boards/posix/native_posix/irq_ctrl.c
@@ -238,7 +238,7 @@ static void irq_raising_from_hw_now(void)
 }
 
 /**
- * Set/Raise an interrupt inmediately.
+ * Set/Raise an interrupt immediately.
  * Like hw_irq_ctrl_set_irq() but awake immediately the CPU instead of in
  * 1 delta cycle
  *

--- a/soc/posix/inf_clock/soc.c
+++ b/soc/posix/inf_clock/soc.c
@@ -13,7 +13,7 @@
  * the HW models.
  *
  * The HW models raising an interrupt will "awake the cpu" by calling
- * poisix_interrupt_raised() which will transfer control to the irq handler,
+ * posix_interrupt_raised() which will transfer control to the irq handler,
  * which will run inside SW/Zephyr contenxt. After which a arch_swap() to
  * whatever Zephyr thread may follow.  Again, once Zephyr is done, control is
  * given back to the HW models.

--- a/soc/posix/inf_clock/soc.c
+++ b/soc/posix/inf_clock/soc.c
@@ -14,7 +14,7 @@
  *
  * The HW models raising an interrupt will "awake the cpu" by calling
  * posix_interrupt_raised() which will transfer control to the irq handler,
- * which will run inside SW/Zephyr contenxt. After which a arch_swap() to
+ * which will run inside SW/Zephyr context. After which a arch_swap() to
  * whatever Zephyr thread may follow.  Again, once Zephyr is done, control is
  * given back to the HW models.
  *


### PR DESCRIPTION
It's a trivial fix for a typo in the comment.

Signed-off-by: Yasushi SHOJI <y-shoji@ispace-inc.com>