### PR TITLE
Support pre/post flash scripting

### DIFF
--- a/scripts/sanity_chk/hwmap-schema.yaml
+++ b/scripts/sanity_chk/hwmap-schema.yaml
@@ -1,0 +1,32 @@
+type: seq
+sequence:
+  - type: map
+    required: no
+    mapping:
+      "available":
+        type: bool
+        required: true
+      "connected":
+        type: bool
+        required: true
+      "id":
+        type: str
+        required: true
+      "platform":
+        type: str
+        required: true
+      "product":
+        type: str
+        required: true
+      "runner":
+        type: str
+        required: true
+      "serial":
+        type: str
+        required: false
+      "post_script":
+        type: str
+        required: false
+      "pre_script":
+        type: str
+        required: false

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -3767,6 +3767,9 @@ def native_and_unit_first(a, b):
 
 
 class HardwareMap:
+
+    schema_path = os.path.join(ZEPHYR_BASE, "scripts", "sanity_chk", "hwmap-schema.yaml")
+
     manufacturer = [
         'ARM',
         'SEGGER',
@@ -3813,11 +3816,8 @@ class HardwareMap:
         self.connected_hardware.append(device)
 
     def load_hardware_map(self, map_file):
-        with open(map_file, 'r') as stream:
-            try:
-                self.connected_hardware = yaml.safe_load(stream)
-            except yaml.YAMLError as exc:
-                print(exc)
+        hwm_schema = scl.yaml_load(self.schema_path)
+        self.connected_hardware = scl.yaml_load_verify(map_file, hwm_schema)
         for i in self.connected_hardware:
             i['counter'] = 0
 

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -759,6 +759,21 @@ class DeviceHandler(Handler):
         read_pipe, write_pipe = os.pipe()
         start_time = time.time()
 
+
+        pre_script = hardware.get('pre_script')
+        post_script = hardware.get('post_script')
+
+        if pre_script:
+            with subprocess.Popen(pre_script, stderr=subprocess.PIPE, stdout=subprocess.PIPE) as proc:
+                try:
+                    (stdout, stderr) = proc.communicate(timeout=30)
+                    logger.debug(stdout.decode())
+
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    (stdout, stderr) = proc.communicate()
+                    logger.error("{} timed out".format(post_script))
+
         t = threading.Thread(target=self.monitor_serial, daemon=True,
                              args=(ser, read_pipe, harness))
         t.start()
@@ -811,6 +826,17 @@ class DeviceHandler(Handler):
                 self.instance.reason = "Failed"
         else:
             self.set_state(out_state, handler_time)
+
+        if post_script:
+            with subprocess.Popen(post_script, stderr=subprocess.PIPE, stdout=subprocess.PIPE) as proc:
+                try:
+                    (stdout, stderr) = proc.communicate(timeout=30)
+                    logger.debug(stdout.decode())
+
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    (stdout, stderr) = proc.communicate()
+                    logger.error("{} timed out".format(post_script))
 
         self.make_device_available(serial_device)
 


### PR DESCRIPTION
This is needed when a board needs to be reset using an external commands or
tools that are not part of the flash command. For example, power reset or
by poking a GPIO header on the board using external wiring.

add post_flash/pre_flash to the platform section in the hardware map. For
example:

```
- available: true
  connected: true
  id: OSHW000032254e4500128002ab98002784d1000097969900
  platform: reel_board
  post_script: /tmp/post_flash.sh
  pre_script: /tmp/pre_flash.sh
  product: DAPLink CMSIS-DAP
  runner: pyocd
  serial: /dev/ttyACM11
```


Also, add hardware map schema and verify it when loading existing hardware map.