### PR TITLE
drivers: ieee802154: rf2xx: Add GPIO dependency

### DIFF
--- a/drivers/ieee802154/Kconfig.rf2xx
+++ b/drivers/ieee802154/Kconfig.rf2xx
@@ -10,6 +10,7 @@ menuconfig  IEEE802154_RF2XX
 	bool "ATMEL RF2XX Driver support"
 	depends on NETWORKING
 	select SPI
+	select GPIO
 	select NET_L2_IEEE802154_SUB_GHZ
 
 if IEEE802154_RF2XX


### PR DESCRIPTION
The rf2xx driver needs GPIO driver to works. The RST, SLPTR and INT
are mandatory signals and driver uses DT to configure them. This add
the GPIO dependency on Kconfig.rf2xx file.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>