### PR TITLE
Trivial renaming of 1 char variables in kernel

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3654,7 +3654,7 @@ void k_msgq_init(struct k_msgq *q, char *buffer, size_t msg_size,
  * k_msgq_cleanup(), or if userspace is enabled and the msgq object loses
  * all of its references.
  *
- * @param q Address of the message queue.
+ * @param msgq Address of the message queue.
  * @param msg_size Message size (in bytes).
  * @param max_msgs Maximum number of messages that can be queued.
  *
@@ -3663,16 +3663,18 @@ void k_msgq_init(struct k_msgq *q, char *buffer, size_t msg_size,
  *	an integer overflow.
  * @req K-MSGQ-002
  */
-__syscall int k_msgq_alloc_init(struct k_msgq *q, size_t msg_size,
+__syscall int k_msgq_alloc_init(struct k_msgq *msgq, size_t msg_size,
 				u32_t max_msgs);
 
 /**
- * @brief Cleanup message queue
+ * @brief Release allocated buffer for a queue
  *
  * Releases memory allocated for the ring buffer.
- * @param q
+ *
+ * @param msgq message queue to cleanup
+ *
  */
-void k_msgq_cleanup(struct k_msgq *q);
+void k_msgq_cleanup(struct k_msgq *msgq);
 
 /**
  * @brief Send a message to a message queue.
@@ -3681,7 +3683,7 @@ void k_msgq_cleanup(struct k_msgq *q);
  *
  * @note Can be called by ISRs.
  *
- * @param q Address of the message queue.
+ * @param msgq Address of the message queue.
  * @param data Pointer to the message.
  * @param timeout Non-negative waiting period to add the message (in
  *                milliseconds), or one of the special values K_NO_WAIT and
@@ -3692,7 +3694,7 @@ void k_msgq_cleanup(struct k_msgq *q);
  * @retval -EAGAIN Waiting period timed out.
  * @req K-MSGQ-002
  */
-__syscall int k_msgq_put(struct k_msgq *q, void *data, s32_t timeout);
+__syscall int k_msgq_put(struct k_msgq *msgq, void *data, s32_t timeout);
 
 /**
  * @brief Receive a message from a message queue.
@@ -3702,7 +3704,7 @@ __syscall int k_msgq_put(struct k_msgq *q, void *data, s32_t timeout);
  *
  * @note Can be called by ISRs, but @a timeout must be set to K_NO_WAIT.
  *
- * @param q Address of the message queue.
+ * @param msgq Address of the message queue.
  * @param data Address of area to hold the received message.
  * @param timeout Non-negative waiting period to receive the message (in
  *                milliseconds), or one of the special values K_NO_WAIT and
@@ -3713,7 +3715,7 @@ __syscall int k_msgq_put(struct k_msgq *q, void *data, s32_t timeout);
  * @retval -EAGAIN Waiting period timed out.
  * @req K-MSGQ-002
  */
-__syscall int k_msgq_get(struct k_msgq *q, void *data, s32_t timeout);
+__syscall int k_msgq_get(struct k_msgq *msgq, void *data, s32_t timeout);
 
 /**
  * @brief Peek/read a message from a message queue.
@@ -3723,14 +3725,14 @@ __syscall int k_msgq_get(struct k_msgq *q, void *data, s32_t timeout);
  *
  * @note Can be called by ISRs.
  *
- * @param q Address of the message queue.
+ * @param msgq Address of the message queue.
  * @param data Address of area to hold the message read from the queue.
  *
  * @retval 0 Message read.
  * @retval -ENOMSG Returned when the queue has no message.
  * @req K-MSGQ-002
  */
-__syscall int k_msgq_peek(struct k_msgq *q, void *data);
+__syscall int k_msgq_peek(struct k_msgq *msgq, void *data);
 
 /**
  * @brief Purge a message queue.
@@ -3739,12 +3741,12 @@ __syscall int k_msgq_peek(struct k_msgq *q, void *data);
  * buffer. Any threads that are blocked waiting to send a message to the
  * message queue are unblocked and see an -ENOMSG error code.
  *
- * @param q Address of the message queue.
+ * @param msgq Address of the message queue.
  *
  * @return N/A
  * @req K-MSGQ-002
  */
-__syscall void k_msgq_purge(struct k_msgq *q);
+__syscall void k_msgq_purge(struct k_msgq *msgq);
 
 /**
  * @brief Get the amount of free space in a message queue.
@@ -3752,30 +3754,31 @@ __syscall void k_msgq_purge(struct k_msgq *q);
  * This routine returns the number of unused entries in a message queue's
  * ring buffer.
  *
- * @param q Address of the message queue.
+ * @param msgq Address of the message queue.
  *
  * @return Number of unused ring buffer entries.
  * @req K-MSGQ-002
  */
-__syscall u32_t k_msgq_num_free_get(struct k_msgq *q);
+__syscall u32_t k_msgq_num_free_get(struct k_msgq *msgq);
 
 /**
  * @brief Get basic attributes of a message queue.
  *
  * This routine fetches basic attributes of message queue into attr argument.
  *
- * @param q Address of the message queue.
+ * @param msgq Address of the message queue.
  * @param attrs pointer to message queue attribute structure.
  *
  * @return N/A
  * @req K-MSGQ-003
  */
-__syscall void  k_msgq_get_attrs(struct k_msgq *q, struct k_msgq_attrs *attrs);
+__syscall void  k_msgq_get_attrs(struct k_msgq *msgq,
+				 struct k_msgq_attrs *attrs);
 
 
-static inline u32_t z_impl_k_msgq_num_free_get(struct k_msgq *q)
+static inline u32_t z_impl_k_msgq_num_free_get(struct k_msgq *msgq)
 {
-	return q->max_msgs - q->used_msgs;
+	return msgq->max_msgs - msgq->used_msgs;
 }
 
 /**
@@ -3783,16 +3786,16 @@ static inline u32_t z_impl_k_msgq_num_free_get(struct k_msgq *q)
  *
  * This routine returns the number of messages in a message queue's ring buffer.
  *
- * @param q Address of the message queue.
+ * @param msgq Address of the message queue.
  *
  * @return Number of messages.
  * @req K-MSGQ-002
  */
-__syscall u32_t k_msgq_num_used_get(struct k_msgq *q);
+__syscall u32_t k_msgq_num_used_get(struct k_msgq *msgq);
 
-static inline u32_t z_impl_k_msgq_num_used_get(struct k_msgq *q)
+static inline u32_t z_impl_k_msgq_num_used_get(struct k_msgq *msgq)
 {
-	return q->used_msgs;
+	return msgq->used_msgs;
 }
 
 /** @} */

--- a/include/sys/math_extras_impl.h
+++ b/include/sys/math_extras_impl.h
@@ -146,7 +146,7 @@ static inline bool size_mul_overflow(size_t a, size_t b, size_t *result)
  *			return NULL;
  *		}
  *
- *		struct k_thread *t = NULL;
+ *		struct k_thread *thread = NULL;
  *		sys_dlist_t *l =
  *			&pq->queues[u32_count_trailing_zeros(pq->bitmask)];
  *

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -255,10 +255,10 @@ static ALWAYS_INLINE void z_ready_thread(struct k_thread *thread)
 
 static inline void _ready_one_thread(_wait_q_t *wq)
 {
-	struct k_thread *th = z_unpend_first_thread(wq);
+	struct k_thread *thread = z_unpend_first_thread(wq);
 
-	if (th != NULL) {
-		z_ready_thread(th);
+	if (thread != NULL) {
+		z_ready_thread(thread);
 	}
 }
 

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -296,15 +296,15 @@ void __weak main(void)
 /* LCOV_EXCL_STOP */
 
 #if defined(CONFIG_MULTITHREADING)
-static void init_idle_thread(struct k_thread *thr, k_thread_stack_t *stack)
+static void init_idle_thread(struct k_thread *thread, k_thread_stack_t *stack)
 {
-	z_setup_new_thread(thr, stack,
+	z_setup_new_thread(thread, stack,
 			  CONFIG_IDLE_STACK_SIZE, idle, NULL, NULL, NULL,
 			  K_LOWEST_THREAD_PRIO, K_ESSENTIAL, IDLE_THREAD_NAME);
-	z_mark_thread_as_started(thr);
+	z_mark_thread_as_started(thread);
 
 #ifdef CONFIG_SMP
-	thr->base.is_idle = 1U;
+	thread->base.is_idle = 1U;
 #endif
 }
 #endif /* CONFIG_MULTITHREADING */

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -299,30 +299,31 @@ const char *k_thread_state_str(k_tid_t thread_id)
 }
 
 #ifdef CONFIG_USERSPACE
-static inline int z_vrfy_k_thread_name_copy(k_tid_t t, char *buf, size_t size)
+static inline int z_vrfy_k_thread_name_copy(k_tid_t thread,
+					    char *buf, size_t size)
 {
 #ifdef CONFIG_THREAD_NAME
 	size_t len;
-	struct _k_object *ko = z_object_find(t);
+	struct _k_object *ko = z_object_find(thread);
 
 	/* Special case: we allow reading the names of initialized threads
 	 * even if we don't have permission on them
 	 */
-	if (t == NULL || ko->type != K_OBJ_THREAD ||
+	if (thread == NULL || ko->type != K_OBJ_THREAD ||
 	    (ko->flags & K_OBJ_FLAG_INITIALIZED) == 0) {
 		return -EINVAL;
 	}
 	if (Z_SYSCALL_MEMORY_WRITE(buf, size) != 0) {
 		return -EFAULT;
 	}
-	len = strlen(t->name);
+	len = strlen(thread->name);
 	if (len + 1 > size) {
 		return -ENOSPC;
 	}
 
-	return z_user_to_copy((void *)buf, t->name, len + 1);
+	return z_user_to_copy((void *)buf, thread->name, len + 1);
 #else
-	ARG_UNUSED(t);
+	ARG_UNUSED(thread);
 	ARG_UNUSED(buf);
 	ARG_UNUSED(size);
 	return -ENOSYS;

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -340,11 +340,11 @@ void z_object_wordlist_foreach(_wordlist_cb_func_t func, void *context)
 }
 #endif /* CONFIG_DYNAMIC_OBJECTS */
 
-static int thread_index_get(struct k_thread *t)
+static int thread_index_get(struct k_thread *thread)
 {
 	struct _k_object *ko;
 
-	ko = z_object_find(t);
+	ko = z_object_find(thread);
 
 	if (ko == NULL) {
 		return -1;


### PR DESCRIPTION
t->thread
th->thread
q->msgq

All for the sake of readibility. No functional changes.