### PR TITLE
sanitycheck: print total number cases by logger in --list-tests

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -4117,7 +4117,7 @@ def main():
                             t = Node(test, parent=subarea)
 
             if options.list_tests:
-                print("{} total.".format(cnt))
+                logger.info("{} total.".format(cnt))
 
             if options.test_tree:
                 for pre, _, node in RenderTree(testsuite):


### PR DESCRIPTION
When printed all testcases by sanitycheck, I changed _total number_
to be printed by `logger`, not by `print` function. It is necessary,
because if all testcases will be written into the file,
total number string is going to the file too, and necessary to delete
it. Now, if necessary to write testcases using --list-tests
into a file, only testcases will be written into that file,
without any additional information.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>