### PR TITLE
samples: sensor: fix test identifier

### DIFF
--- a/samples/sensor/sensor_shell/sample.yaml
+++ b/samples/sensor/sensor_shell/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Shell Sensor Module Sample
 tests:
-  test:
+  sample.sensor.shell:
     filter: ( CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT )
     tags: shell
     harness: keyboard


### PR DESCRIPTION
use sample.sensor.shell instead of test.