### PR TITLE
Bluetooth: Mesh: Model start callback

### DIFF
--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -467,18 +467,19 @@ struct bt_mesh_model_cb {
 				  size_t len_rd, settings_read_cb read_cb,
 				  void *cb_arg);
 
-	/** @brief Callback called when all settings have been loaded.
+	/** @brief Callback called when the mesh is started.
 	 *
-	 *  This handler gets called after the settings have been loaded in
-	 *  full.
+	 *  This handler gets called after the node has been provisioned, or
+	 *  after all mesh data has been loaded from persistent storage.
 	 *
-	 *  @sa settings_handler::h_commit
+	 *  When this callback fires, the mesh model may start its behavior,
+	 *  and all Access APIs are ready for use.
 	 *
-	 *  @param model Model this callback belongs to.
+	 *  @param model      Model this callback belongs to.
 	 *
 	 *  @return 0 on success, error otherwise.
 	 */
-	int (*const settings_commit)(struct bt_mesh_model *model);
+	int (*const start)(struct bt_mesh_model *model);
 
 	/** @brief Model init callback.
 	 *

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -83,7 +83,7 @@ int bt_mesh_provision(const u8_t net_key[16], u16_t net_idx,
 		bt_mesh_store_iv(false);
 	}
 
-	bt_mesh_net_start();
+	bt_mesh_start();
 
 	return 0;
 }
@@ -323,6 +323,22 @@ int bt_mesh_init(const struct bt_mesh_prov *prov,
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		bt_mesh_settings_init();
 	}
+
+	return 0;
+}
+
+static void model_start(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
+			bool vnd, bool primary, void *user_data)
+{
+	if (mod->cb && mod->cb->start) {
+		mod->cb->start(mod);
+	}
+}
+
+int bt_mesh_start(void)
+{
+	bt_mesh_net_start();
+	bt_mesh_model_foreach(model_start, NULL);
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/mesh.h
+++ b/subsys/bluetooth/mesh/mesh.h
@@ -15,3 +15,5 @@
 #define BT_MESH_ADDR_IS_RFU(addr) ((addr) >= 0xff00 && (addr) <= 0xfffb)
 
 struct bt_mesh_net;
+
+int bt_mesh_start(void);

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -900,10 +900,6 @@ static void commit_mod(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 			k_delayed_work_submit(&mod->pub->timer, ms);
 		}
 	}
-
-	if (mod->cb && mod->cb->settings_commit)  {
-		mod->cb->settings_commit(mod);
-	}
 }
 
 static int mesh_commit(void)
@@ -963,7 +959,7 @@ static int mesh_commit(void)
 
 	atomic_set_bit(bt_mesh.flags, BT_MESH_VALID);
 
-	bt_mesh_net_start();
+	bt_mesh_start();
 
 	return 0;
 }


### PR DESCRIPTION
Replaces the Mesh model settings_commit callback with a start callback,
indicating that the mesh model behavior is ready to start. Everything
that was previously done in the settings_commit callback may be moved to
this callback, which gets called just after mesh settings are committed,
instead of in the middle of the process.

This resolves an issue where models had no context in which to start
their behavior, as the previous settings_commit call fired before the
mesh was declared valid, making access APIs inaccessible.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>