### PR TITLE
west.yml: Update hal_stm32 with latest STM32Cube packages

### DIFF
--- a/drivers/flash/flash_stm32wbx.c
+++ b/drivers/flash/flash_stm32wbx.c
@@ -175,12 +175,12 @@ int flash_stm32_check_status(struct device *dev)
 	u32_t error = 0;
 
 	/* Save Flash errors */
-	error = (regs->sr & FLASH_FLAG_SR_ERROR);
+	error = (regs->sr & FLASH_FLAG_SR_ERRORS);
 	error |= (regs->eccr & FLASH_FLAG_ECCC);
 
 	/* Clear systematic Option and Enginneering bits validity error */
 	if (error & FLASH_FLAG_OPTVERR) {
-		regs->sr |= FLASH_FLAG_SR_ERROR;
+		regs->sr |= FLASH_FLAG_SR_ERRORS;
 		return 0;
 	}
 

--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
       revision: fa481784b3c49780f18d50bafe00390ccb62b2ec
       path: modules/hal/st
     - name: hal_stm32
-      revision: 566f4eb616f9e61bec01aca9918cace4b01e11b5
+      revision: 2f1923cb2067bbddb89716896cf27d7c2245f580
       path: modules/hal/stm32
     - name: hal_ti
       revision: 879c7d08ffc6cd18737847030b906cffe3b0a8fb


### PR DESCRIPTION
Update hal_stm32 to new version including lastest STM32Cube packages.

CF https://github.com/zephyrproject-rtos/hal_stm32/pull/33

Includes the following:
- stm32cube: update stm32wb to version V1.3.0 (commit 374333f)
- stm32cube: update stm32g0 to version V1.3.0 (commit e209cea)
- stm32cube: update stm32f0 to version V1.11.0 (commit 08833e5)
- stm32cube: update stm32f3 to version V1.11.0 (commit 2a412a4)
- stm32cube: update stm32h7xx cube version to V1.5.0 (commit a08d1dc)
- stm32cube: update stm32f2xx cube version to V1.8.0 (commit b4226d5)
- stm32cube: update stm32f1xx cube version to V1.8.0 (commit a515c67)

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>