### PR TITLE
[TOPIC-GPIO] drivers: ti_hdc: convert to new GPIO API

### DIFF
--- a/boards/arm/reel_board/dts/reel_board.dtsi
+++ b/boards/arm/reel_board/dts/reel_board.dtsi
@@ -132,7 +132,7 @@ arduino_i2c: &i2c0 {
 		compatible = "ti,hdc","ti,hdc1010";
 		reg = <0x43>;
 		label = "HDC1010";
-		drdy-gpios = <&gpio0 22 GPIO_PUD_PULL_UP>;
+		drdy-gpios = <&gpio0 22 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 	};
 
 	apds9960@39 {

--- a/drivers/sensor/ti_hdc/ti_hdc.c
+++ b/drivers/sensor/ti_hdc/ti_hdc.c
@@ -26,7 +26,9 @@ static void ti_hdc_gpio_callback(struct device *dev,
 
 	ARG_UNUSED(pins);
 
-	gpio_pin_disable_callback(dev, DT_INST_0_TI_HDC_DRDY_GPIOS_PIN);
+	gpio_pin_interrupt_configure(drv_data->gpio,
+				     DT_INST_0_TI_HDC_DRDY_GPIOS_PIN,
+				     GPIO_INT_DISABLE);
 	k_sem_give(&drv_data->data_sem);
 }
 #endif
@@ -39,7 +41,9 @@ static int ti_hdc_sample_fetch(struct device *dev, enum sensor_channel chan)
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 
 #if defined(DT_INST_0_TI_HDC_DRDY_GPIOS_CONTROLLER)
-	gpio_pin_enable_callback(drv_data->gpio, DT_INST_0_TI_HDC_DRDY_GPIOS_PIN);
+	gpio_pin_interrupt_configure(drv_data->gpio,
+				     DT_INST_0_TI_HDC_DRDY_GPIOS_PIN,
+				     GPIO_INT_EDGE_TO_ACTIVE);
 #endif
 
 	buf[0] = TI_HDC_REG_TEMP;
@@ -150,11 +154,7 @@ static int ti_hdc_init(struct device *dev)
 	}
 
 	gpio_pin_configure(drv_data->gpio, DT_INST_0_TI_HDC_DRDY_GPIOS_PIN,
-			   GPIO_DIR_IN | GPIO_INT | GPIO_INT_EDGE |
-#if defined(DT_INST_0_TI_HDC_DRDY_GPIOS_FLAGS)
-			   DT_INST_0_TI_HDC_DRDY_GPIOS_FLAGS |
-#endif
-			   GPIO_INT_ACTIVE_LOW | GPIO_INT_DEBOUNCE);
+			   GPIO_INPUT | DT_INST_0_TI_HDC_DRDY_GPIOS_FLAGS);
 
 	gpio_init_callback(&drv_data->gpio_cb,
 			   ti_hdc_gpio_callback,
@@ -164,6 +164,10 @@ static int ti_hdc_init(struct device *dev)
 		LOG_DBG("Failed to set GPIO callback");
 		return -EIO;
 	}
+
+	gpio_pin_interrupt_configure(drv_data->gpio,
+				     DT_INST_0_TI_HDC_DRDY_GPIOS_PIN,
+				     GPIO_INT_EDGE_TO_ACTIVE);
 #endif
 
 	LOG_INF("Initialized device successfully");

--- a/dts/bindings/sensor/ti,hdc.yaml
+++ b/dts/bindings/sensor/ti,hdc.yaml
@@ -11,3 +11,8 @@ properties:
     drdy-gpios:
       type: phandle-array
       required: false
+      description: Data ready pin.
+
+        The DRDYn pin of HDC sensor is open-drain, active low.
+        If connected directly the MCU pin should be configured
+        as pull-up, active low.


### PR DESCRIPTION
Convert TI HDC sensor driver to new GPIO API.