### PR TITLE
kconfig: Remove some redundant single-item menus and ifs

### DIFF
--- a/arch/arm/core/aarch32/Kconfig
+++ b/arch/arm/core/aarch32/Kconfig
@@ -246,9 +246,6 @@ config ARM_ENTRY_VENEERS_LIB_NAME
 
 endmenu
 
-menu "Architecture Floating Point Options"
-depends on CPU_HAS_FPU
-
 choice
 	prompt "Floating point ABI"
 	default FP_HARDABI
@@ -268,8 +265,6 @@ config FP_SOFTABI
 	  point instructions are generated but soft-float calling conventions.
 
 endchoice
-
-endmenu
 
 source "arch/arm/core/aarch32/cortex_m/Kconfig"
 source "arch/arm/core/aarch32/cortex_r/Kconfig"

--- a/drivers/bluetooth/Kconfig
+++ b/drivers/bluetooth/Kconfig
@@ -9,9 +9,8 @@
 
 # Controller support is an HCI driver in itself, so these HCI driver
 # options are only applicable if controller support hasn't been enabled.
-if BT && ! BT_CTLR
-
 menu "Bluetooth Drivers"
+	depends on BT && !BT_CTLR
 
 if BT_HCI
 source "drivers/bluetooth/hci/Kconfig"
@@ -22,5 +21,3 @@ if BT_CUSTOM
 endif
 
 endmenu
-
-endif # BT && ! BT_CTLR

--- a/drivers/sensor/bme280/Kconfig
+++ b/drivers/sensor/bme280/Kconfig
@@ -7,13 +7,10 @@
 menuconfig BME280
 	bool "BME280/BMP280 sensor"
 	depends on I2C || SPI
-	default	n
 	help
 	  Enable driver for BME280 I2C-based or SPI-based temperature and pressure sensor.
 
 if BME280
-
-menu "Attributes"
 
 choice
 	prompt "BME280 temperature oversampling"
@@ -109,7 +106,5 @@ config BME280_FILTER_8
 config BME280_FILTER_16
 	bool "16"
 endchoice
-
-endmenu
 
 endif # BME280

--- a/drivers/sensor/bme680/Kconfig
+++ b/drivers/sensor/bme680/Kconfig
@@ -11,8 +11,6 @@ menuconfig BME680
 
 if BME680
 
-menu "BME680 Attributes"
-
 choice
 	prompt "BME680 temperature oversampling"
 	default BME680_TEMP_OVER_2X
@@ -111,7 +109,5 @@ config BME680_HEATR_DUR_LP
 config BME680_HEATR_DUR_ULP
 	bool "1943"
 endchoice
-
-endmenu # BME680 Attributes
 
 endif # BME680

--- a/drivers/sensor/lps22hb/Kconfig
+++ b/drivers/sensor/lps22hb/Kconfig
@@ -10,15 +10,11 @@ menuconfig LPS22HB
 
 if LPS22HB
 
-menu "Attributes"
-
 config LPS22HB_SAMPLING_RATE
 	int "Output data rate"
 	default 25
 	help
 	  Sensor output data rate expressed in samples per second.
 	  Data rates supported by the chip are 1, 10, 25, 50, 75.
-
-endmenu
 
 endif # LPS22HB

--- a/drivers/sensor/lps25hb/Kconfig
+++ b/drivers/sensor/lps25hb/Kconfig
@@ -10,15 +10,11 @@ menuconfig LPS25HB
 
 if LPS25HB
 
-menu "Attributes"
-
 config LPS25HB_SAMPLING_RATE
 	int "Output data rate"
 	default 25
 	help
 	  Sensor output data rate expressed in samples per second.
 	  Data rates supported by the chip are 1, 7, 13, 25.
-
-endmenu
 
 endif # LPS25HB

--- a/modules/Kconfig.tls-generic
+++ b/modules/Kconfig.tls-generic
@@ -4,9 +4,8 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-if MBEDTLS
-
 menu "TLS configuration"
+	depends on MBEDTLS
 
 menu "Supported TLS version"
 
@@ -325,5 +324,3 @@ config MBEDTLS_USER_CONFIG_FILE
 	  covered by the generic config file.
 
 endmenu
-
-endif # MBEDTLS

--- a/subsys/bluetooth/services/Kconfig
+++ b/subsys/bluetooth/services/Kconfig
@@ -3,9 +3,8 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-if BT_CONN
-
 menu "GATT Services"
+	depends on BT_CONN
 
 source "subsys/bluetooth/services/Kconfig.dis"
 
@@ -14,5 +13,3 @@ source "subsys/bluetooth/services/Kconfig.bas"
 source "subsys/bluetooth/services/Kconfig.hrs"
 
 endmenu
-
-endif # BT_CONN


### PR DESCRIPTION
A single `menu` within an `if` like

    if FOO

    menu "blah"

    ...

    endmenu

    endif

can be replaced with

    menu "blah"
            depends on FOO

    ...

    endmenu

Fix up all existing instances.

Also remove redundant extra menus underneath `menuconfig` symbols.
`menuconfig` already creates a menu.

Also remove the menu in `arch/arm/core/aarch32/Kconfig` around the
"Floating point ABI" choice. The choice depends on `FLOAT`, which depends
on `CPU_HAS_CPU`, so remove the `depends on CPU_HAS_FPU` too.

Piggyback removing a redundant `default n` for BME280.