### PR TITLE
kconfig: Fix some formatting nits

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -128,7 +128,7 @@ config ARC_FIRQ_STACK_SIZE
 	help
 	  The size of firq stack.
 
-config 	ARC_HAS_STACK_CHECKING
+config ARC_HAS_STACK_CHECKING
 	bool "ARC has STACK_CHECKING"
 	default y
 	help

--- a/drivers/ieee802154/Kconfig.rf2xx
+++ b/drivers/ieee802154/Kconfig.rf2xx
@@ -1,12 +1,9 @@
-# Kconfig.rf2xx - ATMEL AT86RF23x/212x configuration options
-#
-#
-# Copyright (c) 2019 Gerson Fernando Budke
-#
-# SPDX-License-Identifier: Apache-2.0
-#
+# ATMEL AT86RF23x/212x configuration options
 
-menuconfig  IEEE802154_RF2XX
+# Copyright (c) 2019 Gerson Fernando Budke
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig IEEE802154_RF2XX
 	bool "ATMEL RF2XX Driver support"
 	depends on NETWORKING
 	select SPI

--- a/samples/net/cloud/mqtt_azure/Kconfig
+++ b/samples/net/cloud/mqtt_azure/Kconfig
@@ -1,10 +1,7 @@
-# Kconfig - Private config options for mqtt-azure sample app
+# Private config options for mqtt-azure sample app
 
-#
 # Copyright (c) 2019 Intel Corporation
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 mainmenu "Networking mqtt-azure sample application"
 


### PR DESCRIPTION
Same deal as in commit bd6e04411e ("kconfig: Clean up header comments
and make them consistent") and commit 1f38ea77ba ("kconfig: Clean up
'config  FOO' (two spaces) definitions"), for some newly-introduced
stuff.