### PR TITLE
kconfig: Remove '# Hidden' comments on promptless symbols

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -253,9 +253,7 @@ config NOCACHE_MEMORY
 endif # ARCH_HAS_NOCACHE_MEMORY_SUPPORT
 
 menu "Interrupt Configuration"
-#
-# Interrupt related configs
-#
+
 config DYNAMIC_INTERRUPTS
 	bool "Enable installation of IRQs at runtime"
 	help
@@ -314,7 +312,6 @@ config GEN_IRQ_START_VECTOR
 	  This is a hidden option which needs to be set per architecture and
 	  left alone.
 
-
 config IRQ_OFFLOAD
 	bool "Enable IRQ offload"
 	depends on TEST
@@ -330,6 +327,7 @@ endmenu
 #
 # Architecture Capabilities
 #
+
 config ARCH_HAS_TRUSTED_EXECUTION
 	bool
 
@@ -362,57 +360,51 @@ config ARCH_HAS_THREAD_ABORT
 # Hidden PM feature configs which are to be selected by
 # individual SoC.
 #
+
 config HAS_SYS_POWER_STATE_SLEEP_1
-	# Hidden
 	bool
 	help
 	  This option signifies that the target supports the SYS_POWER_STATE_SLEEP_1
 	  configuration option.
 
 config HAS_SYS_POWER_STATE_SLEEP_2
-	# Hidden
 	bool
 	help
 	  This option signifies that the target supports the SYS_POWER_STATE_SLEEP_2
 	  configuration option.
 
 config HAS_SYS_POWER_STATE_SLEEP_3
-	# Hidden
 	bool
 	help
 	  This option signifies that the target supports the SYS_POWER_STATE_SLEEP_3
 	  configuration option.
 
 config HAS_SYS_POWER_STATE_DEEP_SLEEP_1
-	# Hidden
 	bool
 	help
 	  This option signifies that the target supports the SYS_POWER_STATE_DEEP_SLEEP_1
 	  configuration option.
 
 config HAS_SYS_POWER_STATE_DEEP_SLEEP_2
-	# Hidden
 	bool
 	help
 	  This option signifies that the target supports the SYS_POWER_STATE_DEEP_SLEEP_2
 	  configuration option.
 
 config HAS_SYS_POWER_STATE_DEEP_SLEEP_3
-	# Hidden
 	bool
 	help
 	  This option signifies that the target supports the SYS_POWER_STATE_DEEP_SLEEP_3
 	  configuration option.
 
 config BOOTLOADER_CONTEXT_RESTORE_SUPPORTED
-	# Hidden
 	bool
 	help
 	  This option signifies that the target has options of bootloaders
 	  that support context restore upon resume from deep sleep
 
-
-# End hidden CPU family configs
+#
+# Hidden CPU family configs
 #
 
 config CPU_HAS_TEE
@@ -497,10 +489,6 @@ config FP_SHARING
 	  registers.
 
 endif # FLOAT
-
-#
-# End hidden PM feature configs
-#
 
 config ARCH
 	string

--- a/drivers/ethernet/Kconfig.e1000
+++ b/drivers/ethernet/Kconfig.e1000
@@ -9,7 +9,6 @@ menuconfig ETH_E1000
 	help
 	  Enable Intel(R) PRO/1000 Gigabit Ethernet driver.
 
-# Hidden option
 config ETH_NIC_MODEL
 	string
 	default "e1000"

--- a/drivers/ethernet/Kconfig.smsc911x
+++ b/drivers/ethernet/Kconfig.smsc911x
@@ -6,7 +6,6 @@ menuconfig ETH_SMSC911X
 	help
 	  Enable driver for SMSC/LAN911x/9220 family of chips.
 
-# Hidden option
 config ETH_NIC_MODEL
 	string
 	default "lan9118"

--- a/drivers/ethernet/Kconfig.stellaris
+++ b/drivers/ethernet/Kconfig.stellaris
@@ -8,7 +8,6 @@ menuconfig ETH_STELLARIS
 	help
 	  Stellaris on-board Ethernet Controller
 
-# Hidden option
 config ETH_NIC_MODEL
 	string
 	default "stellaris"


### PR DESCRIPTION
How prompts work is better documented nowadays, and these comments might
not be that helpful if you don't know.

There are lots promptless symbols that don't have a comment.

Also fix up some comments in arch/Kconfig that seem misplaced/redundant,
and clean up some whitespace (no blank line after a comment makes it
look like it only applies to the symbol directly after it to me).