### PR TITLE
scripts: kconfig: Add dt_compat_get_inst_prop method

### DIFF
--- a/drivers/ieee802154/Kconfig.rf2xx
+++ b/drivers/ieee802154/Kconfig.rf2xx
@@ -5,18 +5,20 @@
 
 menuconfig IEEE802154_RF2XX
 	bool "ATMEL RF2XX Driver support"
-	depends on NETWORKING
+	depends on NETWORKING && HAS_DTS
 	select SPI
 	select GPIO
 	select NET_L2_IEEE802154_SUB_GHZ if NET_L2_IEEE802154
 
 if IEEE802154_RF2XX
 
-config IEEE802154_RF2XX_DRV_NAME
-	string "ATMEL RF2XX Driver's name"
-	default "IEEE802154_rf2xx"
-	help
-	  This option sets the driver name
+# Workaround for not being able to have commas in macro arguments
+DT_IEEE802154_COMPAT_RF2XX := atmel,rf2xx
+
+config NET_CONFIG_IEEE802154_DEV_NAME
+	# Fetch 'label' property from instance 0, defaulting to "RF2XX_0"
+	default "$(dt_compat_get_inst_prop,label, \
+	         $(DT_IEEE802154_COMPAT_RF2XX),0,RF2XX_0)"
 
 config IEEE802154_RF2XX_RX_STACK_SIZE
 	int "Driver's internal RX thread stack size"

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -347,11 +347,52 @@ def shields_list_contains(kconf, _, shield):
     return "y" if shield in list.split(";") else "n"
 
 
+def dt_compat_get_inst_prop(kconf, _, prop, compat, inst, default=""):
+    """
+    This function takes a 'compat' and an 'inst'ance to search for an EDT node
+    that matchs. If it finds an EDT node, it will look to see if that node has
+    a name property by the name of 'prop'. If the 'prop' exists it will return
+    the string representation of that 'prop' otherwise a default passed value.
+    """
+    prop_s = prop.strip()
+    compat_s = compat.strip()
+    default_s = default.strip()
+
+    if doc_mode or edt is None:
+        return default_s
+
+    try:
+        inst_no = int(inst)
+    except ValueError:
+        _warn(kconf, "malformed instance number")
+
+        return default_s
+
+    if compat_s not in edt.compat2enabled:
+        return default_s
+
+    node_list = edt.compat2enabled[compat_s]
+    if inst_no >= len(node_list):
+        return default_s
+
+    node = node_list[inst_no]
+    if prop_s not in node.props:
+        return default_s
+
+    val = node.props[prop_s].val
+
+    if not isinstance(val, (str, int)):
+        _warn(kconf, ("substituting devicetree property value that's not "
+                        "a string or an int"))
+
+    return str(val)
+
 functions = {
         "dt_int_val": (dt_int_val, 1, 2),
         "dt_hex_val": (dt_hex_val, 1, 2),
         "dt_str_val": (dt_str_val, 1, 1),
         "dt_compat_enabled": (dt_compat_enabled, 1, 1),
+        "dt_compat_get_inst_prop": (dt_compat_get_inst_prop, 3, 4),
         "dt_chosen_label": (dt_chosen_label, 1, 1),
         "dt_chosen_enabled": (dt_chosen_enabled, 1, 1),
         "dt_chosen_reg_addr_int": (dt_chosen_reg, 1, 3),


### PR DESCRIPTION
The **dt_str_val** method has been deprecated. This add an alternative
that uses **compat** and **instance number** to find a node and than
return the string representation or a passed default value.

This is necessary becase **path** is valid only at SoC directory. For
instance, a driver for a SPI bus need search for a **compat** based on
the **instance** to determine the proper configuration.

depends on: #22215

Example: how determine the right interface name from the device tree
node label.

```
at DT:

&foo0 {
	compatible = "manufacturer,device"
	status = "disabled";
	label = "FOO_0";
};
&foo1 {
	compatible = "manufacturer,device"
	status = "okay";
	label = "FOO_1";
};

at Kconfig:

DT_FOO      := manufacturer,device
DT_FOO_INST := 0
DT_FOO_DEF  := "default string on not match/error - optional empty"

config FOO
	string "text"
	default "$(dt_compat_get_str, \
		 label, \
		 $(DT_FOO), \
		 $(DT_FOO_INST), \
		 $(DT_FOO_DEF))"

The result is CONFIG_FOO="FOO_1"
```
An example of use was delivered too.