### PR TITLE
[TOPIC-GPIO] sensor: adxl362: update for new GPIO API

### DIFF
--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -794,6 +794,7 @@ static const struct adxl362_config adxl362_config = {
 #if defined(CONFIG_ADXL362_TRIGGER)
 	.gpio_port = DT_INST_0_ADI_ADXL362_INT1_GPIOS_CONTROLLER,
 	.int_gpio = DT_INST_0_ADI_ADXL362_INT1_GPIOS_PIN,
+	.int_flags = DT_INST_0_ADI_ADXL362_INT1_GPIOS_FLAGS,
 #endif
 };
 

--- a/drivers/sensor/adxl362/adxl362.h
+++ b/drivers/sensor/adxl362/adxl362.h
@@ -176,11 +176,12 @@ struct adxl362_config {
 	u16_t spi_slave;
 #if defined(DT_INST_0_ADI_ADXL362_CS_GPIOS_CONTROLLER)
 	const char *gpio_cs_port;
-	u8_t cs_gpio;
+	gpio_pin_t cs_gpio;
 #endif
 #if defined(CONFIG_ADXL362_TRIGGER)
 	const char *gpio_port;
-	u8_t int_gpio;
+	gpio_pin_t int_gpio;
+	gpio_devicetree_flags_t int_flags;
 	u8_t int1_config;
 	u8_t int2_config;
 #endif

--- a/drivers/sensor/adxl362/adxl362_trigger.c
+++ b/drivers/sensor/adxl362/adxl362_trigger.c
@@ -140,8 +140,7 @@ int adxl362_init_interrupt(struct device *dev)
 	}
 
 	gpio_pin_configure(drv_data->gpio, cfg->int_gpio,
-			   GPIO_DIR_IN | GPIO_INT | GPIO_INT_EDGE |
-			   GPIO_INT_ACTIVE_HIGH | GPIO_INT_DEBOUNCE);
+			   GPIO_INPUT | cfg->int_flags);
 
 	gpio_init_callback(&drv_data->gpio_cb,
 			   adxl362_gpio_callback,
@@ -165,7 +164,8 @@ int adxl362_init_interrupt(struct device *dev)
 	drv_data->dev = dev;
 #endif
 
-	gpio_pin_enable_callback(drv_data->gpio, cfg->int_gpio);
+	gpio_pin_interrupt_configure(drv_data->gpio, cfg->int_gpio,
+				     GPIO_INT_EDGE_TO_ACTIVE);
 
 	return 0;
 }

--- a/dts/bindings/sensor/adi,adxl362.yaml
+++ b/dts/bindings/sensor/adi,adxl362.yaml
@@ -11,3 +11,7 @@ properties:
     int1-gpios:
       type: phandle-array
       required: false
+      description: |
+        The INT1 signal defaults to active high as produced by the
+        sensor.  The property value should ensure the flags properly
+        describe the signal that is presented to the driver.

--- a/samples/sensor/adxl362/boards/nrf52_pca10040.overlay
+++ b/samples/sensor/adxl362/boards/nrf52_pca10040.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi1 {
+	status = "okay";
+	sck-pin = <25>;
+	mosi-pin = <23>;
+	miso-pin = <24>;
+	cs-gpios = <&gpio0 22 0>;
+
+	adxl362@0 {
+		compatible = "adi,adxl362";
+		label = "ADXL362";
+		spi-max-frequency = <8000000>;
+		reg = <0>;
+		int1-gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+	};
+};


### PR DESCRIPTION
Add a sample overlay.  Add GPIO flags to configuration state.  Replace
callback enable with interrupt enable.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>