### PR TITLE
[TOPIC-GPIO] sensor: adxl372: update for new GPIO API

### DIFF
--- a/drivers/sensor/adxl372/adxl372.c
+++ b/drivers/sensor/adxl372/adxl372.c
@@ -939,6 +939,7 @@ static const struct adxl372_dev_config adxl372_config = {
 #ifdef CONFIG_ADXL372_TRIGGER
 	.gpio_port = DT_INST_0_ADI_ADXL372_INT1_GPIOS_CONTROLLER,
 	.int_gpio = DT_INST_0_ADI_ADXL372_INT1_GPIOS_PIN,
+	.int_flags = DT_INST_0_ADI_ADXL372_INT1_GPIOS_FLAGS,
 #endif
 
 	.max_peak_detect_mode = IS_ENABLED(CONFIG_ADXL372_PEAK_DETECT_MODE),

--- a/drivers/sensor/adxl372/adxl372.h
+++ b/drivers/sensor/adxl372/adxl372.h
@@ -320,12 +320,13 @@ struct adxl372_dev_config {
 	u32_t spi_max_frequency;
 #if defined(DT_INST_0_ADI_ADXL372_CS_GPIOS_CONTROLLER)
 	const char *gpio_cs_port;
-	u8_t cs_gpio;
+	gpio_pin_t cs_gpio;
 #endif
 #endif /* CONFIG_ADXL372_SPI */
 #ifdef CONFIG_ADXL372_TRIGGER
 	const char *gpio_port;
-	u8_t int_gpio;
+	gpio_pin_t int_gpio;
+	gpio_devicetree_flags_t int_flags;
 #endif
 	bool max_peak_detect_mode;
 

--- a/drivers/sensor/adxl372/adxl372_trigger.c
+++ b/drivers/sensor/adxl372/adxl372_trigger.c
@@ -45,7 +45,8 @@ static void adxl372_thread_cb(void *arg)
 		drv_data->drdy_handler(dev, &drv_data->drdy_trigger);
 	}
 
-	gpio_pin_enable_callback(drv_data->gpio, cfg->int_gpio);
+	gpio_pin_interrupt_configure(drv_data->gpio, cfg->int_gpio,
+				     GPIO_INT_EDGE_TO_ACTIVE);
 }
 
 static void adxl372_gpio_callback(struct device *dev,
@@ -55,7 +56,8 @@ static void adxl372_gpio_callback(struct device *dev,
 		CONTAINER_OF(cb, struct adxl372_data, gpio_cb);
 	const struct adxl372_dev_config *cfg = dev->config->config_info;
 
-	gpio_pin_disable_callback(dev, cfg->int_gpio);
+	gpio_pin_interrupt_configure(drv_data->gpio, cfg->int_gpio,
+				     GPIO_INT_DISABLE);
 
 #if defined(CONFIG_ADXL372_TRIGGER_OWN_THREAD)
 	k_sem_give(&drv_data->gpio_sem);
@@ -97,7 +99,8 @@ int adxl372_trigger_set(struct device *dev,
 	u8_t int_mask, int_en, status1, status2;
 	int ret;
 
-	gpio_pin_disable_callback(drv_data->gpio, cfg->int_gpio);
+	gpio_pin_interrupt_configure(drv_data->gpio, cfg->int_gpio,
+				     GPIO_INT_DISABLE);
 
 	switch (trig->type) {
 	case SENSOR_TRIG_THRESHOLD:
@@ -127,7 +130,8 @@ int adxl372_trigger_set(struct device *dev,
 
 	adxl372_get_status(dev, &status1, &status2, NULL); /* Clear status */
 out:
-	gpio_pin_enable_callback(drv_data->gpio, cfg->int_gpio);
+	gpio_pin_interrupt_configure(drv_data->gpio, cfg->int_gpio,
+				     GPIO_INT_EDGE_TO_ACTIVE);
 
 	return ret;
 }
@@ -145,8 +149,7 @@ int adxl372_init_interrupt(struct device *dev)
 	}
 
 	gpio_pin_configure(drv_data->gpio, cfg->int_gpio,
-			   GPIO_DIR_IN | GPIO_INT | GPIO_INT_EDGE |
-			   GPIO_INT_ACTIVE_HIGH | GPIO_INT_DEBOUNCE);
+			   GPIO_INPUT | cfg->int_flags);
 
 	gpio_init_callback(&drv_data->gpio_cb,
 			   adxl372_gpio_callback,

--- a/dts/bindings/sensor/adi,adxl372-i2c.yaml
+++ b/dts/bindings/sensor/adi,adxl372-i2c.yaml
@@ -11,3 +11,7 @@ properties:
     int1-gpios:
       type: phandle-array
       required: false
+      description: |
+        The INT1 signal defaults to active high as produced by the
+        sensor.  The property value should ensure the flags properly
+        describe the signal that is presented to the driver.

--- a/dts/bindings/sensor/adi,adxl372-spi.yaml
+++ b/dts/bindings/sensor/adi,adxl372-spi.yaml
@@ -12,3 +12,7 @@ properties:
     int1-gpios:
       type: phandle-array
       required: false
+      description: |
+        The INT1 signal defaults to active high as produced by the
+        sensor.  The property value should ensure the flags properly
+        describe the signal that is presented to the driver.

--- a/samples/sensor/adxl372/nrf52_pca10040.overlay
+++ b/samples/sensor/adxl372/nrf52_pca10040.overlay
@@ -5,12 +5,12 @@
  */
 
 &spi2 {
-
+	cs-gpios = <&gpio0 22 0>;
 	adxl372@0 {
 		compatible = "adi,adxl372";
 		reg = <0>;
 		spi-max-frequency = <8000000>;
 		label = "ADXL372";
-		int1-gpios = <&gpio0 6 0>;
+		int1-gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
 	};
 };


### PR DESCRIPTION
Update sample overlay for missing chip select and to deconflict with
UART TXD.  Add GPIO flags to configuration state.  Replace callback
enable with interrupt enable.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>