### PR TITLE
samples: wpan_serial: Add rf2xx transceiver overlay

### DIFF
--- a/samples/net/wpan_serial/README.rst
+++ b/samples/net/wpan_serial/README.rst
@@ -13,7 +13,9 @@ Requirements
 ************
 
 The sample assumes that 802.15.4 radio and USB controller are supported on
-a board.
+a board. You can pick, for example, a transceiver such as a CC2520 or RF2xx
+using overlays, or by using an SoC with a built-in radio, such as a kw41z,
+nrf5, or samr21.
 
 Building and Running
 ********************
@@ -26,8 +28,39 @@ Building and Running
 
      $ sudo systemctl disable ModemManager.service
 
-#. Build and flash the sample Zephyr application to a board
-   with a 802.15.4 radio and USB controller
+#. Build the sample Zephyr application to a board with a 802.15.4 radio
+   and USB controller. There are configuration files for various setups
+   in the ``samples/net/wpan_serial`` directory:
+
+   - :file:`prj.conf`
+     This is the standard default config. This can be used by itself for
+     hardware which has native 802.15.4 support.
+
+   - :file:`overlay-cc2520.conf`
+     This overlay enables support for CC2520 transceiver
+
+   - :file:`overlay-rf2xx.conf`
+     This overlay enables support for RF2XX transceiver
+
+   To build the wpan_serial sample:
+
+   .. zephyr-app-commands::
+     :zephyr-app: samples/net/wpan_serial
+     :board: <board name>
+     :conf: "prj.conf [overlay-<RADIO>.conf]"
+     :goals: build
+     :compact:
+
+   Here's how to build and flash the sample for the Atmel SAM R21
+   Xplained Pro Development Kit. Note that for this SoC, you don't
+   need to include ``overlay-rf2xx.conf``.
+
+   .. zephyr-app-commands::
+     :zephyr-app: samples/net/wpan_serial
+     :board: atsamr21_xpro
+     :goals: build flash
+     :compact:
+
 #. Connect board to Linux PC, /dev/ttyACM[number] should appear.
 #. Run Contiki-based native border router (6lbr, native-router, etc)
    Example for Contiki:

--- a/samples/net/wpan_serial/overlay-rf2xx.conf
+++ b/samples/net/wpan_serial/overlay-rf2xx.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2019, Gerson Fernando Budke
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_IEEE802154_RF2XX=y
+CONFIG_NET_CONFIG_IEEE802154_DEV_NAME="RF2XX_0"

--- a/samples/net/wpan_serial/src/main.c
+++ b/samples/net/wpan_serial/src/main.c
@@ -447,7 +447,7 @@ static bool init_ieee802154(void)
 
 	ieee802154_dev = device_get_binding(CONFIG_NET_CONFIG_IEEE802154_DEV_NAME);
 	if (!ieee802154_dev) {
-		LOG_ERR("Cannot get CC250 device");
+		LOG_ERR("Cannot get ieee 802.15.4 device");
 		return false;
 	}
 


### PR DESCRIPTION
Add Atmel rf2xx transceiver and update documentation to add details how build and flash the application. The intention is differentiate between SoC and transceivers to help user understand what they need to do to build and flash successfully.