### PR TITLE
Bluetooth: Mesh: Select PRINTK when BT_SETTINGS is enabled

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -8,6 +8,7 @@ menuconfig BT_MESH
 	select TINYCRYPT
 	select TINYCRYPT_AES
 	select TINYCRYPT_AES_CMAC
+	select PRINTK if BT_SETTINGS
 	depends on BT_OBSERVER && BT_BROADCASTER
 	help
 	  This option enables Bluetooth Mesh support. The specific


### PR DESCRIPTION
Bluetooth Mesh settings code use `printk()` extensively and fail to store
some of the settings if it is not available. Make sure `printk()` is
available by selecting `PRINTK` when `BT_SETTINGS` is enabled.

Note: I wonder if we can use `snprintf()` instead or as a fallback to `snprintk()`. This is especially true for the `bt_settings_encode_key()` function which has an open-coded fallback.
