### PR TITLE
[TOPIC-GPIO] convert mpu6050 driver to new API

### DIFF
--- a/samples/sensor/mpu6050/boards/nrf52_pca10040.overlay
+++ b/samples/sensor/mpu6050/boards/nrf52_pca10040.overlay
@@ -10,6 +10,6 @@
 		reg = <0x68>;
 		status = "okay";
 		label = "MPU6050";
-		int-gpios = <&gpio0 11 0>;
+		int-gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
 	};
 };


### PR DESCRIPTION
This PR converts the MPU6050 driver to the new API.  Only the last commit is relevant; earlier commits back-port #21565 to the topic-gpio branch.