### PR TITLE
Bluetooth: Mesh: Fix PreviousAddress endianess in Friend Request

### DIFF
--- a/subsys/bluetooth/mesh/lpn.c
+++ b/subsys/bluetooth/mesh/lpn.c
@@ -304,7 +304,7 @@ static int send_friend_req(struct bt_mesh_lpn *lpn)
 		.criteria    = LPN_CRITERIA,
 		.recv_delay  = LPN_RECV_DELAY,
 		.poll_to     = LPN_POLL_TO,
-		.prev_addr   = lpn->old_friend,
+		.prev_addr   = sys_cpu_to_be16(lpn->old_friend),
 		.num_elem    = comp->elem_count,
 		.lpn_counter = sys_cpu_to_be16(lpn->counter),
 	};


### PR DESCRIPTION
The upper transport layer is using big endian ordering. The
PreviousAddress field of a Friend Request message should therefore
be converted to native endianess using `sys_cpu_to_be16()`.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>