### PR TITLE
samples: sockets: echo: Include stdlib.h

### DIFF
--- a/samples/net/sockets/echo/src/socket_echo.c
+++ b/samples/net/sockets/echo/src/socket_echo.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <errno.h>
 
 #ifndef __ZEPHYR__


### PR DESCRIPTION
Include stdlib.h to suppress a missing declaration
warning for exit() when compiled as a Linux target.

Signed-off-by: Oleg Zhurakivskyy <oleg.zhurakivskyy@intel.com>