### PR TITLE
soc: nrf5340: Fix busy waiting on nRF5340 application core

### DIFF
--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -42,6 +42,13 @@ static int nordicsemi_nrf53_init(struct device *arg)
 
 	ARG_UNUSED(arg);
 
+#if defined(CONFIG_SOC_NRF5340_CPUAPP)
+	/* Temporary workaround for incorrect SystemCoreClock initialization.
+	 * To be removed when system_nrf5340_application.c is corrected.
+	 */
+	SystemCoreClockUpdate();
+#endif
+
 	key = irq_lock();
 
 #ifdef CONFIG_NRF_ENABLE_CACHE


### PR DESCRIPTION
This patch adds a temporary workaround for the incorrect initialization
of the SystemCoreClock global variable that is done for the application
core of nRF5340 (see system_nrf5340_application.c) and that results in
k_busy_wait() producing delays of twice the requested time.
The problem is that the call to SystemCoreClockUpdate() that is done
at the end of SystemInit() correctly sets the value of SystemCoreClock
to reflect the hardware state after reset (HFCLK128M divided by 2),
but then the SystemCoreClock variable is initialized (by z_data_copy()
called from z_arm_prep_c()) to the __SYSTEM_CLOCK value that is defined
as 128000000. This in turn results in nrfx_coredep_delay_us() (used by
k_busy_wait() by default for nRF SoCs) delaying for twice the requested
number of microseconds.
The temporary workaround is to call SystemCoreClockUpdate() at a later
stage of the system initialization, in its nRF53 specific part.

Fixes #21082.