### PR TITLE
drivers: spi: kconfig: Turn pointless 'menuconfig' into 'config'

### DIFF
--- a/drivers/spi/Kconfig.mcux_flexcomm
+++ b/drivers/spi/Kconfig.mcux_flexcomm
@@ -1,11 +1,8 @@
-#
 # Copyright (c) 2016, Freescale Semiconductor, Inc.
 # Copyright (c) 2017,2019, NXP
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
-menuconfig SPI_MCUX_FLEXCOMM
+config SPI_MCUX_FLEXCOMM
 	bool "MCUX FLEXCOMM SPI driver"
 	depends on HAS_MCUX_FLEXCOMM
 	help


### PR DESCRIPTION
Same deal as in commit 677f1e6 ("config: Turn pointless/confusing
'menuconfig's into 'config's"), for a newly-introduced SPI_MCUX_FLEXCOMM
symbol.

Also clean up the header to be consistent with recent cleanups.