### PR TITLE
kconfig: Remove '# hidden' comments on promptless symbols

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -14,7 +14,7 @@ config ARCH
 #
 
 config CPU_ATOM
-	bool # hidden
+	bool
 	select CPU_HAS_FPU
 	select ARCH_HAS_STACK_PROTECTION if X86_MMU
 	select ARCH_HAS_USERSPACE if X86_MMU && !X86_64
@@ -22,14 +22,14 @@ config CPU_ATOM
 	  This option signifies the use of a CPU from the Atom family.
 
 config CPU_MINUTEIA
-	bool # hidden
+	bool
 	select ARCH_HAS_STACK_PROTECTION if X86_MMU
 	select ARCH_HAS_USERSPACE if X86_MMU && !X86_64
 	help
 	  This option signifies the use of a CPU from the Minute IA family.
 
 config CPU_APOLLO_LAKE
-	bool # hidden
+	bool
 	select CPU_HAS_FPU
 	select ARCH_HAS_STACK_PROTECTION if X86_MMU
 	select ARCH_HAS_USERSPACE if X86_MMU && !X86_64

--- a/drivers/eeprom/Kconfig
+++ b/drivers/eeprom/Kconfig
@@ -35,7 +35,7 @@ config EEPROM_NATIVE_POSIX
 	  Enable Native POSIX EEPROM driver.
 
 config EEPROM_AT2X
-	bool # hidden
+	bool
 	help
 	  Enable support for Atmel AT2x (and compatible) I2C/SPI
 	  EEPROMs.

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -496,7 +496,6 @@ endmenu
 
 config ARCH_HAS_CUSTOM_SWAP_TO_MAIN
 	bool
-	# hidden
 	help
 	  It's possible that an architecture port cannot use _Swap() to swap to
 	  the _main() thread, but instead must do something custom. It must

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -49,7 +49,6 @@ module-help = Enables offload layer to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 endif # NET_OFFLOAD
 
-# Hidden option
 config NET_RAW_MODE
 	bool
 	help


### PR DESCRIPTION
Same deal as in commit 41713244b3 ("kconfig: Remove '# Hidden' comments
on promptless symbols"). I forgot to do a case-insensitive search.