### PR TITLE
Bluetooth: controller: Add set adv param cmd param validation

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -704,6 +704,13 @@ config BT_CTLR_SW_SWITCH_SINGLE_TIMER
 	  PPI channels for the controller, resulting in 4 channels
 	  less left for other uses
 
+config BT_CTLR_PARAM_CHECK
+	bool "Enable HCI Command Parameter checking"
+	default y if BT_HCI_RAW
+	help
+	  Enable code checking HCI Command Parameters. This is not needed in
+	  combined host plus controller builds, saving some code space.
+
 if BT_CONN
 
 config BT_CTLR_FAST_ENC

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -939,6 +939,20 @@ static void le_set_adv_param(struct net_buf *buf, struct net_buf **evt)
 
 	min_interval = sys_le16_to_cpu(cmd->min_interval);
 
+	if (IS_ENABLED(CONFIG_BT_CTLR_PARAM_CHECK) &&
+	    (cmd->type != BT_LE_ADV_DIRECT_IND)) {
+		u16_t max_interval = sys_le16_to_cpu(cmd->max_interval);
+
+		if ((min_interval > max_interval) ||
+		    (min_interval < 0x0020) ||
+		    (max_interval > 0x4000)) {
+			ccst = hci_cmd_complete(evt, sizeof(*ccst));
+			ccst->status = BT_HCI_ERR_INVALID_PARAM;
+
+			return;
+		}
+	}
+
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	status = ll_adv_params_set(0, 0, min_interval, cmd->type,
 				   cmd->own_addr_type, cmd->direct_addr.type,


### PR DESCRIPTION
Added implementation to validate HCI LE Set Advertising
Parameters Command parameters.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>