### PR TITLE
[TOPIC-GPIO] drivers: sensor: bmi160: convert to new GPIO API

### DIFF
--- a/drivers/sensor/bmi160/bmi160.c
+++ b/drivers/sensor/bmi160/bmi160.c
@@ -901,6 +901,7 @@ const struct bmi160_device_config bmi160_config = {
 #if defined(CONFIG_BMI160_TRIGGER)
 	.gpio_port = DT_INST_0_BOSCH_BMI160_INT_GPIOS_CONTROLLER,
 	.int_pin = DT_INST_0_BOSCH_BMI160_INT_GPIOS_PIN,
+	.int_flags = DT_INST_0_BOSCH_BMI160_INT_GPIOS_FLAGS,
 #endif
 };
 

--- a/drivers/sensor/bmi160/bmi160.h
+++ b/drivers/sensor/bmi160/bmi160.h
@@ -386,7 +386,8 @@ struct bmi160_range {
 struct bmi160_device_config {
 #if defined(CONFIG_BMI160_TRIGGER)
 	const char *gpio_port;
-	u8_t int_pin;
+	gpio_pin_t int_pin;
+	gpio_devicetree_flags_t int_flags;
 #endif
 };
 

--- a/drivers/sensor/bmi160/bmi160_trigger.c
+++ b/drivers/sensor/bmi160/bmi160_trigger.c
@@ -301,15 +301,15 @@ int bmi160_trigger_mode_init(struct device *dev)
 	}
 
 	gpio_pin_configure(bmi160->gpio, cfg->int_pin,
-			   GPIO_DIR_IN | GPIO_INT | GPIO_INT_EDGE |
-			   GPIO_INT_ACTIVE_LOW | GPIO_INT_DEBOUNCE);
+			   GPIO_INPUT | cfg->int_flags);
 
 	gpio_init_callback(&bmi160->gpio_cb,
 			   bmi160_gpio_callback,
 			   BIT(cfg->int_pin));
 
 	gpio_add_callback(bmi160->gpio, &bmi160->gpio_cb);
-	gpio_pin_enable_callback(bmi160->gpio, cfg->int_pin);
+	gpio_pin_interrupt_configure(bmi160->gpio, cfg->int_pin,
+				     GPIO_INT_EDGE_TO_ACTIVE);
 
 	return bmi160_byte_write(dev, BMI160_REG_INT_OUT_CTRL,
 				 BMI160_INT1_OUT_EN | BMI160_INT1_EDGE_CTRL);

--- a/dts/bindings/sensor/bosch,bmi160.yaml
+++ b/dts/bindings/sensor/bosch,bmi160.yaml
@@ -14,3 +14,7 @@ properties:
     int-gpios:
       type: phandle-array
       required: false
+      description: |
+        This property specifies the connection for INT1, because the
+        Zephyr driver maps all interrupts to INT1.  The signal defaults
+        to output low when produced by the sensor.


### PR DESCRIPTION
**NOTE** This is untested as there is no sample, the driver only supports the SPI interface, and the breakout that I have and the neonkey that has it on-board only support I2C.

Document interrupt signal and replace legacy calls with new API.

