### PR TITLE
kernel: move test of kernel startup state to more visible location

### DIFF
--- a/doc/reference/drivers/index.rst
+++ b/doc/reference/drivers/index.rst
@@ -361,6 +361,9 @@ leading zeroes or sign (e.g. 32), or an equivalent symbolic name (e.g.
 ``\#define MY_INIT_PRIO 32``); symbolic expressions are *not* permitted (e.g.
 ``CONFIG_KERNEL_INIT_PRIORITY_DEFAULT + 5``).
 
+Drivers and other system utilities can determine whether startup is
+still in pre-kernel states by using the :cpp:func:`k_is_pre_kernel()`
+function.
 
 System Drivers
 **************

--- a/include/init.h
+++ b/include/init.h
@@ -25,22 +25,6 @@ extern "C" {
 #define _SYS_INIT_LEVEL_POST_KERNEL	2
 #define _SYS_INIT_LEVEL_APPLICATION	3
 
-extern s8_t z_sys_device_level;
-
-/**
- * @brief Test whether startup is in the before-main-task phase.
- *
- * This impacts which services are available for use, and the context
- * in which functions are run.
- *
- * @return true if and only if start up is still running pre-kernel
- * initialization.
- */
-static inline bool k_is_pre_kernel(void)
-{
-	return (z_sys_device_level < _SYS_INIT_LEVEL_POST_KERNEL);
-}
-
 /* A counter is used to avoid issues when two or more system devices
  * are declared in the same C file with the same init function.
  */

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1296,6 +1296,24 @@ extern bool k_is_in_isr(void);
 __syscall int k_is_preempt_thread(void);
 
 /**
+ * @brief Test whether startup is in the before-main-task phase.
+ *
+ * This routine allows the caller to customize its actions, depending on
+ * whether it being invoked before the kernel is fully active.
+ *
+ * @note Can be called by ISRs.
+ *
+ * @return true if invoked before post-kernel initialization
+ * @return false if invoked during/after post-kernel initialization
+ */
+static inline bool k_is_pre_kernel(void)
+{
+	extern bool z_sys_post_kernel; /* in init.c */
+
+	return !z_sys_post_kernel;
+}
+
+/**
  * @}
  */
 

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -23,8 +23,6 @@ extern u32_t __device_busy_end[];
 #define DEVICE_BUSY_SIZE (__device_busy_end - __device_busy_start)
 #endif
 
-s8_t z_sys_device_level;
-
 /**
  * @brief Execute all the device initialization functions at a given level
  *
@@ -48,7 +46,6 @@ void z_sys_device_do_config_level(s32_t level)
 		__device_init_end,
 	};
 
-	z_sys_device_level = level;
 	for (info = config_levels[level]; info < config_levels[level+1];
 								info++) {
 		int retval;

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -212,6 +212,8 @@ void z_data_copy(void)
 
 /* LCOV_EXCL_STOP */
 
+bool z_sys_post_kernel;
+
 /**
  *
  * @brief Mainline for kernel's background thread
@@ -232,6 +234,8 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 #else
 	static const unsigned int boot_delay;
 #endif
+
+	z_sys_post_kernel = true;
 
 	z_sys_device_do_config_level(_SYS_INIT_LEVEL_POST_KERNEL);
 #if CONFIG_STACK_POINTER_RANDOM


### PR DESCRIPTION
The original implementation left this function hidden in init.h which
prevented it from showing up in documentation.  Move it to kernel.h,
and document it consistent with the other functions that allow caller
customization based on context.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>