### PR TITLE
console: tty: add confirmation of write completion

### DIFF
--- a/subsys/console/tty.c
+++ b/subsys/console/tty.c
@@ -41,6 +41,10 @@ static void tty_uart_isr(void *user_data)
 			if (tty->tx_get >= tty->tx_ringbuf_sz) {
 				tty->tx_get = 0U;
 			}
+
+			while (!uart_irq_tx_complete(dev)) {
+			}
+
 			k_sem_give(&tty->tx_sem);
 		}
 	}


### PR DESCRIPTION
In my case I had to control the GPIO after the output of the UART TX was done.
When writing with `tty_write()` and controlling GPIO, GPIO is controlled in the middle of UART TX data.

This PR causes `tty_write()` to return after the Tx is done.

The following is a test with sample code that can reproduce symptoms.
**Yellow lines**: PB6(UART1_TX)
**Blue lines**: PB5(GPIO)  

**[Before]**
```
west init zephyrproject -m https://github.com/KwonTae-young/zephyr/ --mr tty_tc_sample
cd zephyrproject
west update
cd zephyr
git checkout 0fef5f7093eac2a435faf7a1ba94549948165a06
source zephyr-env.sh
mkdir samples/tty_tc_gpio/build
cd samples/tty_tc_gpio/build
cmake -DBOARD=stm32f4_disco ..
make -j8 flash
```
![Tek002 png_000](https://user-images.githubusercontent.com/10510127/71403148-2fe6bf00-2672-11ea-84bb-5179a93501bb.png)  
![Tek002 png_001](https://user-images.githubusercontent.com/10510127/71403155-3412dc80-2672-11ea-84e7-521d4b34cc86.png)  



**[After]**
```
west init zephyrproject -m https://github.com/KwonTae-young/zephyr/ --mr tty_tc_sample
cd zephyrproject
west update
cd zephyr
source zephyr-env.sh
mkdir samples/tty_tc_gpio/build
cd samples/tty_tc_gpio/build
cmake -DBOARD=stm32f4_disco ..
make -j8 flash
```
![Tek002 png_002](https://user-images.githubusercontent.com/10510127/71403173-3ffe9e80-2672-11ea-82fb-8ab5b3dbe105.png)  
![Tek002 png_003](https://user-images.githubusercontent.com/10510127/71403179-43922580-2672-11ea-946c-bc07f2b6b27f.png)  

