### PR TITLE
Bluetooth:RFCOMM: Fix length errors when payload exceeds 127

### DIFF
--- a/subsys/bluetooth/host/rfcomm.c
+++ b/subsys/bluetooth/host/rfcomm.c
@@ -1431,7 +1431,7 @@ int bt_rfcomm_dlc_send(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 		hdr = net_buf_push(buf, sizeof(*hdr) + 1);
 		len = (u16_t *)&hdr->length;
 		*len = BT_RFCOMM_SET_LEN_16(sys_cpu_to_le16(buf->len -
-							    sizeof(*hdr) + 1));
+							    sizeof(*hdr) - 1));
 	} else {
 		hdr = net_buf_push(buf, sizeof(*hdr));
 		hdr->length = BT_RFCOMM_SET_LEN_8(buf->len - sizeof(*hdr));


### PR DESCRIPTION
`hdr->length` is the length of the payload, it should be
`buf->len - sizeof(*hdr) - 1` or `buf->len - (sizeof(*hdr) + 1)`

Signed-off-by: ZhongYao Luo <LuoZhongYao@gmail.com>

PS:  When using zephry to implement the iap2 protocol, when iOS sends RequestAuthenticationCertificate, zephry responds to AuthenticationCertificate, iOS will no longer send new data, and AuthenticationCertificate exceeds 127. After using this patch, it works fine.