### PR TITLE
linker script: __data_rom_start alignment problem 

### DIFF
--- a/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -343,7 +343,7 @@ SECTIONS
 
 #endif  /* CONFIG_USERSPACE */
 
-    SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
+    SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME, ALIGN(4),)
 	{
 	__data_ram_start = .;
 	*(.data)


### PR DESCRIPTION
The alignment of the data segment should be determined by the
data segment itself, rather than relying on the previous segment
fix #21554 

Signed-off-by: ZhongYao Luo <LuoZhongYao@gmail.com>