### PR TITLE
boards: litex_vexriscv: Remove unused /chosen/zephyr,timer property

### DIFF
--- a/boards/riscv/litex_vexriscv/litex_vexriscv.dts
+++ b/boards/riscv/litex_vexriscv/litex_vexriscv.dts
@@ -14,7 +14,6 @@
 	chosen {
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
-		zephyr,timer = &timer0;
 		zephyr,sram = &ram0;
 	};
 


### PR DESCRIPTION
Added in commit f9efca4b4f ("boards: riscv32: add LiteX VexRiscV
board"), never used