### PR TITLE
dts/bindings/sensor/aosong,dht.yaml: Remove 'title' key

### DIFF
--- a/dts/bindings/sensor/ti,tmp116.yaml
+++ b/dts/bindings/sensor/ti,tmp116.yaml
@@ -10,5 +10,5 @@ include: i2c-device.yaml
 properties:
     alert-gpios:
       type: compound
-      category: optional
+      required: false
       description: ALERT pin


### PR DESCRIPTION
Deprecated. See commit 2934ee2cda ("dts: bindings: Remove 'title:' and
put all info. into 'description:'").