### PR TITLE
dts/bindings: ti,tmp116: Use 'required' instead of 'category' key

### DIFF
--- a/dts/bindings/sensor/ti,tmp116.yaml
+++ b/dts/bindings/sensor/ti,tmp116.yaml
@@ -9,6 +9,6 @@ include: i2c-device.yaml
 
 properties:
     alert-gpios:
-      type: compound
-      category: optional
+      type: phandle-array
+      required: false
       description: ALERT pin


### PR DESCRIPTION
'category' is deprecated. See commit fcd665a26c ("dts: bindings: Have
'required: true/false' instead of 'category: ...'").

Also change the type of 'alert-gpios' from 'compound' to
'phandle-array', which matches other bindings.