### PR TITLE
dts: edtlib: Require properties to have 'required: true/false'

### DIFF
--- a/dts/binding-template.yaml
+++ b/dts/binding-template.yaml
@@ -84,12 +84,13 @@ on-bus: <string describing bus type, e.g. "i2c">
 # special-cased properties like 'reg', only properties listed here will
 # generate output.
 #
-# A typical property entry looks like this:
+# A typical property entry looks like this. The 'type:' and 'required:' keys
+# are required.
 #
 #   <property name>:
-#     required: <true | false>
 #     type: <string | int | boolean | array | uint8-array | string-array |
 #            phandle | phandles | phandle-array | path | compound>
+#     required: <true | false>
 #     description: <description of the property>
 #     enum:
 #       - <item1>

--- a/dts/bindings/dma/nxp,mcux-edma.yaml
+++ b/dts/bindings/dma/nxp,mcux-edma.yaml
@@ -22,10 +22,12 @@ properties:
 
     nxp,mem2mem:
       type: boolean
+      required: false
       description: If the DMA controller supports memory to memory transfer
 
     nxp,a_on:
       type: boolean
+      required: false
       description: If the DMA controller supports always on
 
     "#dma-cells":

--- a/dts/bindings/dma/st,stm32-dma.yaml
+++ b/dts/bindings/dma/st,stm32-dma.yaml
@@ -16,6 +16,7 @@ properties:
 
     st,mem2mem:
       type: boolean
+      required: false
       description: If the DMA controller V1 supports memory to memory transfer
 
     "#dma-cells":

--- a/dts/bindings/ethernet/atmel,sam-gmac.yaml
+++ b/dts/bindings/ethernet/atmel,sam-gmac.yaml
@@ -19,6 +19,7 @@ properties:
 
     max-frame-size:
         type: int
+        required: false
         description:
           Maximum transfer unit (IEEE defined MTU), rather than the
           maximum frame size (there\'s contradiction in the Devicetree

--- a/dts/bindings/ethernet/silabs,gecko-ethernet.yaml
+++ b/dts/bindings/ethernet/silabs,gecko-ethernet.yaml
@@ -90,12 +90,15 @@ properties:
     # PHY control pins
     location-phy_pwr_enable:
       type: array
+      required: false
       description: PHY power enable individual pin configuration defined as <port pin>
 
     location-phy_reset:
       type: array
+      required: false
       description: PHY reset individual pin configuration defined as <port pin>
 
     location-phy_interrupt:
       type: array
+      required: false
       description: PHY interrupt individual pin configuration defined as <port pin>

--- a/dts/bindings/sensor/aosong,dht.yaml
+++ b/dts/bindings/sensor/aosong,dht.yaml
@@ -27,6 +27,7 @@ properties:
 
   dht22:
     type: boolean
+    required: false
     description: |
       Set to identify sensor as a DHT22/AM2303.  Leave unset to identify
       sensor as a DHT11.

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -701,6 +701,10 @@ class EDT:
 
         for prop_name, options in binding["properties"].items():
             for key in options:
+                if not options.keys() & {"required", "category"}:
+                    _err("missing 'required: true/false' for '{}' in "
+                         "'properties:' in {}".format(prop_name, binding_path))
+
                 if key == "category":
                     self._warn(
                         "please put 'required: {}' instead of 'category: {}' "
@@ -1808,7 +1812,7 @@ def _check_prop_type_and_default(prop_name, prop_type, required, default,
     # named 'prop_name'
 
     if prop_type is None:
-        _err("missing 'type:' for '{}' in 'properties' in {}"
+        _err("missing 'type:' for '{}' in 'properties:' in {}"
              .format(prop_name, binding_path))
 
     ok_types = {"boolean", "int", "array", "uint8-array", "string",


### PR DESCRIPTION
Having no 'required:' key for a property works the same as having
'required: false' at the moment, though it's undocumented.

Instead, require properties to have 'required: true/false'. Almost all
bindings already seem to assume it's required.

Could have turned a missing 'required:'  into a warning instead of an
error as well, but I think it might be overkill since so few places
skipped it.

Also list 'type:' before 'required:' in dts/binding-template.yaml, to
match what most bindings do.