### PR TITLE
boards: arm: reel_board: add spi cs gpio

### DIFF
--- a/boards/arm/reel_board/dts/reel_board.dtsi
+++ b/boards/arm/reel_board/dts/reel_board.dtsi
@@ -159,6 +159,7 @@ arduino_spi: &spi3 {
 	sck-pin = <47>;
 	miso-pin = <46>;
 	mosi-pin = <45>;
+	cs-gpios = <&arduino_header 16 0>;
 };
 
 &flash0 {


### PR DESCRIPTION
Add SPI CS GPIO line to reel_board device tree. This is needed to make the board work with Arduino SPI compatible shields.

Tested on reel_board (1507.1) and reel_board_v2 (1507.2).

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>