### PR TITLE
Bluetooth: Mesh: Add Minimum Period Constraint of Publish

### DIFF
--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -404,6 +404,7 @@ struct bt_mesh_model_pub {
 	u8_t  period_div:4, /**< Divisor for the Period. */
 	      fast_period:1,/**< Use FastPeriodDivisor */
 	      count:3;      /**< Retransmissions left. */
+	u8_t  min_period;   /**< Minimum Period of Publish. */
 
 	u32_t period_start; /**< Start of the current period. */
 

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -57,7 +57,7 @@ void bt_mesh_model_foreach(void (*func)(struct bt_mesh_model *mod,
 
 s32_t bt_mesh_model_pub_period_get(struct bt_mesh_model *mod)
 {
-	int period;
+	int period, min_period;
 
 	if (!mod->pub) {
 		return 0;
@@ -85,7 +85,10 @@ s32_t bt_mesh_model_pub_period_get(struct bt_mesh_model *mod)
 	}
 
 	if (mod->pub->fast_period) {
-		return period >> mod->pub->period_div;
+		period >>= mod->pub->period_div;
+		min_period = (int)1 << mod->pub->min_period;
+
+		return MAX(period, min_period);
 	} else {
 		return period;
 	}

--- a/subsys/bluetooth/mesh/health_srv.c
+++ b/subsys/bluetooth/mesh/health_srv.c
@@ -348,6 +348,8 @@ static int health_pub_update(struct bt_mesh_model *mod)
 		pub->fast_period = 0U;
 	}
 
+	pub->min_period = 0U;
+
 	return 0;
 }
 


### PR DESCRIPTION
According Mesh Model Specification Section 4.1.3 Sensor Cadence

The Status Min Interval field is a 1-octet value that shall
control the minimum interval between publishing two consecutive
Sensor Status messages.

This change will not have any impact on the current implementation.

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>