### PR TITLE
power: add DEVICE_PM_LOW_POWER_STATE for device power management

### DIFF
--- a/subsys/power/device.c
+++ b/subsys/power/device.c
@@ -66,6 +66,24 @@ int sys_pm_suspend_devices(void)
 	return 0;
 }
 
+int sys_pm_low_power_devices(void)
+{
+	for (int i = device_count - 1; i >= 0; i--) {
+		int idx = device_ordered_list[i];
+
+		device_retval[i] = device_set_power_state(&pm_device_list[idx],
+						DEVICE_PM_LOW_POWER_STATE,
+						NULL, NULL);
+		if (device_retval[i]) {
+			LOG_DBG("%s did not enter low power state",
+				pm_device_list[idx].config->name);
+			return device_retval[i];
+		}
+	}
+
+	return 0;
+}
+
 int sys_pm_force_suspend_devices(void)
 {
 	for (int i = device_count - 1; i >= 0; i--) {

--- a/subsys/power/device.c
+++ b/subsys/power/device.c
@@ -57,7 +57,7 @@ int sys_pm_suspend_devices(void)
 						DEVICE_PM_SUSPEND_STATE,
 						NULL, NULL);
 		if (device_retval[i]) {
-			LOG_ERR("%s suspend operation failed\n",
+			LOG_DBG("%s did not enter suspend state",
 					pm_device_list[idx].config->name);
 			return device_retval[i];
 		}
@@ -75,7 +75,7 @@ int sys_pm_force_suspend_devices(void)
 					DEVICE_PM_FORCE_SUSPEND_STATE,
 					NULL, NULL);
 		if (device_retval[i]) {
-			LOG_ERR("%s force suspend operation failed\n",
+			LOG_ERR("%s force suspend operation failed",
 				pm_device_list[idx].config->name);
 			return device_retval[i];
 		}

--- a/subsys/power/policy/pm_policy.h
+++ b/subsys/power/policy/pm_policy.h
@@ -16,27 +16,27 @@ extern "C" {
 /**
  * @brief Function to create device PM list
  */
-extern  void sys_pm_create_device_list(void);
+void sys_pm_create_device_list(void);
 
 /**
  * @brief Function to suspend the devices in PM device list
  */
-extern int sys_pm_suspend_devices(void);
+int sys_pm_suspend_devices(void);
 
 /**
  * @brief Function to force suspend the devices in PM device list
  */
-extern int sys_pm_force_suspend_devices(void);
+int sys_pm_force_suspend_devices(void);
 
 /**
  * @brief Function to resume the devices in PM device list
  */
-extern void sys_pm_resume_devices(void);
+void sys_pm_resume_devices(void);
 
 /**
  * @brief Function to get the next PM state based on the ticks
  */
-extern enum power_states sys_pm_policy_next_state(s32_t ticks);
+enum power_states sys_pm_policy_next_state(s32_t ticks);
 
 #ifdef __cplusplus
 }

--- a/subsys/power/policy/pm_policy.h
+++ b/subsys/power/policy/pm_policy.h
@@ -24,6 +24,11 @@ void sys_pm_create_device_list(void);
 int sys_pm_suspend_devices(void);
 
 /**
+ * @brief Function to put the devices in PM device list in low power state
+ */
+int sys_pm_low_power_devices(void);
+
+/**
  * @brief Function to force suspend the devices in PM device list
  */
 int sys_pm_force_suspend_devices(void);
@@ -37,6 +42,12 @@ void sys_pm_resume_devices(void);
  * @brief Function to get the next PM state based on the ticks
  */
 enum power_states sys_pm_policy_next_state(s32_t ticks);
+
+/**
+ * @brief Function to determine whether to put devices in low
+ *        power state, given the system PM state.
+ */
+bool sys_pm_policy_low_power_devices(enum power_states pm_state);
 
 #ifdef __cplusplus
 }

--- a/subsys/power/policy/policy_dummy.c
+++ b/subsys/power/policy/policy_dummy.c
@@ -38,3 +38,8 @@ enum power_states sys_pm_policy_next_state(s32_t ticks)
 	LOG_DBG("No suitable power state found!");
 	return SYS_POWER_STATE_ACTIVE;
 }
+
+__weak bool sys_pm_policy_low_power_devices(enum power_states pm_state)
+{
+	return sys_pm_is_sleep_state(pm_state);
+}

--- a/subsys/power/policy/policy_residency.c
+++ b/subsys/power/policy/policy_residency.c
@@ -58,3 +58,8 @@ enum power_states sys_pm_policy_next_state(s32_t ticks)
 	LOG_DBG("No suitable power state found!");
 	return SYS_POWER_STATE_ACTIVE;
 }
+
+__weak bool sys_pm_policy_low_power_devices(enum power_states pm_state)
+{
+	return sys_pm_is_sleep_state(pm_state);
+}

--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -106,6 +106,7 @@ enum power_states _sys_suspend(s32_t ticks)
 		/* Suspend peripherals. */
 		if (sys_pm_suspend_devices()) {
 			LOG_DBG("Some devices didn't enter suspend state!");
+			sys_pm_resume_devices();
 			sys_pm_notify_power_state_exit(pm_state);
 			pm_state = SYS_POWER_STATE_ACTIVE;
 			return pm_state;

--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -105,7 +105,7 @@ enum power_states _sys_suspend(s32_t ticks)
 #if CONFIG_DEVICE_POWER_MANAGEMENT
 		/* Suspend peripherals. */
 		if (sys_pm_suspend_devices()) {
-			LOG_ERR("System level device suspend failed!");
+			LOG_DBG("Some devices didn't enter suspend state!");
 			sys_pm_notify_power_state_exit(pm_state);
 			pm_state = SYS_POWER_STATE_ACTIVE;
 			return pm_state;


### PR DESCRIPTION
when system going to sleep state(not deep sleep), make peripherals
go to DEVICE_PM_LOW_POWER_STATE state which need less time than
DEVICE_PM_SUSPEND_STATE to save more power in the sleep state.

Fixes: #17838.