### PR TITLE
drivers: eth: mcux: Disable HW accel checksum calc

### DIFF
--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -79,7 +79,6 @@ endchoice
 
 config ETH_MCUX_HW_ACCELERATION
 	bool "Enable hardware acceleration"
-	default y
 	help
 	  Enable hardware acceleration for the following:
 	  - IPv4, UDP and TCP checksum (both Rx and Tx)


### PR DESCRIPTION
Do not enable hardware accelerated checksum calculation by
default. It does not work for frdm-k64f and is causing
confusion among users.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>