### PR TITLE
drivers: flash: Build STM32 flash support only when selected

### DIFF
--- a/drivers/flash/CMakeLists.txt
+++ b/drivers/flash/CMakeLists.txt
@@ -15,7 +15,7 @@ zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_NIOS2_QSPI soc_flash_nios2_qspi.c)
 zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_GECKO flash_gecko.c)
 zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_RV32M1 soc_flash_rv32m1.c)
 
-if(CONFIG_CLOCK_CONTROL_STM32_CUBE)
+if(CONFIG_SOC_FLASH_STM32)
   zephyr_sources(flash_stm32.c)
 
   zephyr_sources_ifdef(CONFIG_SOC_SERIES_STM32F0X flash_stm32f0x.c)


### PR DESCRIPTION
The current configuration causes the STM32 flash support always to be built, even if an unrelated flash driver, by example the SPI_NOR driver is selected.

This behaviour gets especially problematic (build failure) if the flash hardware of the given MCU is not yet supported (e.g. STM32F2).

The suggested change should ensure that STM32 flash support only is built when it actually is selected.

Signed-off-by: Marco Peter <marco@peter-net.ch>