### PR TITLE
doc: native_posix: Add mention about virtual USB

### DIFF
--- a/boards/posix/native_posix/doc/index.rst
+++ b/boards/posix/native_posix/doc/index.rst
@@ -516,6 +516,11 @@ The following peripherals are currently provided with this board:
   must be powered down and support Bluetooth Low Energy (i.e. support the
   Bluetooth specification version 4.0 or greater).
 
+**USB controller**:
+  It's possible to use the Virtual USB controller working over USB/IP
+  protocol. More information can be found in
+  :ref:`Testing USB over USP/IP in native_posix <testing_USB_native_posix>`.
+
 **Display driver**:
   A display driver is provided that creates a window on the host machine to
   render display content.

--- a/doc/reference/usb/index.rst
+++ b/doc/reference/usb/index.rst
@@ -123,6 +123,8 @@ the vendor requests:
 The class driver waits for the :makevar:`USB_DC_CONFIGURED` device status code
 before transmitting any data.
 
+.. _testing_USB_native_posix:
+
 Testing USB over USP/IP in native_posix
 ***************************************
 


### PR DESCRIPTION
Add information and link to Virtual USB controller.

Fixes #13232.

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>