### PR TITLE
kconfig: NXP IMX: Remove unused HAS_IMX_{RDC,CCM} symbols

### DIFF
--- a/modules/Kconfig.imx
+++ b/modules/Kconfig.imx
@@ -10,16 +10,6 @@ config HAS_IMX_HAL
 
 if HAS_IMX_HAL
 
-config HAS_IMX_RDC
-	bool
-	help
-	  Set if the RDC module is present in the SoC.
-
-config HAS_IMX_CCM
-	bool
-	help
-	  Set if the CCM module is present in the SoC.
-
 config HAS_IMX_GPIO
 	bool
 	help


### PR DESCRIPTION
The HAS_IMX_{RDC,CCM} symbols were added to ext/hal/nxp/imx/Kconfig in
commit 3afc2b6c61 ("ext/hal/nxp/imx: Import the nxp imx7 freertos bsp"),
and later copied over to modules/Kconfig.imx in commit 12438e1047 ("ext:
hal: Make NXP HALs a Zephyr module").

Never used.