### PR TITLE
dts: edtlib: Add 'type: path' for path references

### DIFF
--- a/dts/binding-template.yaml
+++ b/dts/binding-template.yaml
@@ -182,9 +182,19 @@ on-bus: <string describing bus type, e.g. "i2c">
 #     All phandle-array properties support mapping through *-map properties,
 #     e.g. gpio-map. See the devicetree spec.
 #
+#   - 'type: path' is for properties that are assigned a path. Usually, this
+#     would be done with a path reference:
+#
+#         foo = &label;
+#
+#     Plain strings are accepted too, and are verified to be a path to an
+#     existing node:
+#
+#         foo = "/path/to/some/node";
+#
 #   - 'type: compound' is a catch-all for more complex types, e.g.
 #
-#         foo = <&label1>, [01 02];
+#         foo = <&label>, [01 02];
 #
 # 'type: array' and the other array types also allow splitting the value into
 # several <> blocks, e.g. like this:

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -1109,6 +1109,9 @@ class Node:
 
             return self._standard_phandle_val_list(prop)
 
+        if prop_type == "path":
+            return self.edt._node2enode[prop.to_path()]
+
         # prop_type == "compound". We have already checked that the 'type:'
         # value is valid, in _check_binding().
         #
@@ -1438,7 +1441,8 @@ class Property:
         - For 'type: int/array/string/string-array', 'val' is what you'd expect
           (a Python integer or string, or a list of them)
 
-        - For 'type: phandle', 'val' is the pointed-to Node instance
+        - For 'type: phandle' and 'type: path', 'val' is the pointed-to Node
+          instance
 
         - For 'type: phandles', 'val' is a list of the pointed-to Node
           instances
@@ -1651,7 +1655,7 @@ def _check_prop_type_and_default(prop_name, prop_type, required, default,
 
     ok_types = {"boolean", "int", "array", "uint8-array", "string",
                 "string-array", "phandle", "phandles", "phandle-array",
-                "compound"}
+                "path", "compound"}
 
     if prop_type not in ok_types:
         _err("'{}' in 'properties:' in {} has unknown type '{}', expected one "
@@ -1670,7 +1674,7 @@ def _check_prop_type_and_default(prop_name, prop_type, required, default,
         return
 
     if prop_type in {"boolean", "compound", "phandle", "phandles",
-                     "phandle-array"}:
+                     "phandle-array", "path"}:
         _err("'default:' can't be combined with 'type: {}' for '{}' in "
              "'properties:' in {}".format(prop_type, prop_name, binding_path))
 

--- a/scripts/dts/test-bindings/props.yaml
+++ b/scripts/dts/test-bindings/props.yaml
@@ -42,3 +42,6 @@ properties:
     # too
     foo-gpios:
         type: phandle-array
+
+    path:
+        type: path

--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -246,6 +246,7 @@
 		phandle-refs = < &{/props/ctrl-1} &{/props/ctrl-2} >;
 		phandle-array-foos = < &{/props/ctrl-1} 1 &{/props/ctrl-2} 2 3 >;
 		foo-gpios = < &{/props/ctrl-1} 1 >;
+		path = &{/props/ctrl-1};
 
 		ctrl-1 {
 			compatible = "phandle-array-controller-1";

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -211,6 +211,9 @@ warning: "#cells:" in test-bindings/deprecated.yaml is deprecated and will be re
     verify_streq(edt.get_node("/props").props["foo-gpios"],
                  "<Property, name: foo-gpios, type: phandle-array, value: [<ControllerAndData, controller: <Node /props/ctrl-1 in 'test.dts', binding test-bindings/phandle-array-controller-1.yaml>, data: OrderedDict([('gpio-one', 1)])>]>")
 
+    verify_streq(edt.get_node("/props").props["path"],
+                 "<Property, name: path, type: path, value: <Node /props/ctrl-1 in 'test.dts', binding test-bindings/phandle-array-controller-1.yaml>>")
+
     #
     # Test <prefix>-map, via gpio-map (the most common case)
     #


### PR DESCRIPTION
Add binding support for a 'path' property type, for properties that are
assigned node paths. Usually, paths are assigned with path references
like 'foo = &label' (common in /chosen), but plain strings are accepted
as well as long as they're valid paths.

The 'path' type is mostly for completeness at this point, but might be
useful for https://github.com/zephyrproject-rtos/zephyr/issues/21623.
The support is there already in dtlib.