### PR TITLE
arch: arm: Enable CMSIS-Core for Cortex-R by default

### DIFF
--- a/arch/arm/core/aarch32/Kconfig
+++ b/arch/arm/core/aarch32/Kconfig
@@ -28,6 +28,7 @@ config CPU_CORTEX_M
 config CPU_CORTEX_R
 	bool
 	select CPU_CORTEX
+	select HAS_CMSIS_CORE
 	select HAS_FLASH_LOAD_OFFSET
 	help
 	  This option signifies the use of a CPU of the Cortex-R family.


### PR DESCRIPTION
This commit enables the CMSIS-Core(R) processor interface driver for
the Cortex-R platforms by default.

The CMSIS-Core component provides a set of standard interface functions
to control the Cortex-R series processor cores and will be required by
the arch port as well as other CMSIS library components (e.g. CMSIS-DSP
and CMSIS-NN).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>