### PR TITLE
arch: arm: cortex_m: Add CPU DWT feature symbol

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/Kconfig
+++ b/arch/arm/core/aarch32/cortex_m/Kconfig
@@ -70,6 +70,14 @@ config CPU_CORTEX_M_HAS_SYSTICK
 	help
 	  This option is enabled when the CPU implements the SysTick timer.
 
+config CPU_CORTEX_M_HAS_DWT
+	bool
+	depends on !CPU_CORTEX_M0 && !CPU_CORTEX_M0PLUS
+	default y
+	help
+	  This option signifies that the CPU implements the Data Watchpoint and
+	  Trace (DWT) feature.
+
 config CPU_CORTEX_M_HAS_BASEPRI
 	bool
 	depends on ARMV7_M_ARMV8_M_MAINLINE

--- a/soc/arm/arm/mps2/Kconfig.defconfig.mps2_an385
+++ b/soc/arm/arm/mps2/Kconfig.defconfig.mps2_an385
@@ -9,4 +9,7 @@ config SOC
 config NUM_IRQS
 	default 32
 
+config CPU_CORTEX_M_HAS_DWT
+	default n
+
 endif

--- a/soc/arm/arm/mps2/Kconfig.defconfig.mps2_an521
+++ b/soc/arm/arm/mps2/Kconfig.defconfig.mps2_an521
@@ -9,4 +9,7 @@ config SOC
 config NUM_IRQS
 	default 96
 
+config CPU_CORTEX_M_HAS_DWT
+	default n
+
 endif


### PR DESCRIPTION
```
This commit adds a Kconfig symbol for specifying whether the SoC
implements the CPU DWT feature.

The Data Watchpoint and Trace (DWT) is an optional debug unit for the
Cortex-M family cores (except ARMv6-M; i.e. M0 and M0+) that provides
watchpoints, data tracing and system profiling capabilities.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```