### PR TITLE
logging: rtt: Improve synchronous mode

### DIFF
--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -64,7 +64,7 @@ static u8_t *line_pos;
 static u8_t char_buf[CHAR_BUF_SIZE];
 static int drop_cnt;
 static int drop_warn;
-static bool sync_mode;
+static bool panic_mode;
 static bool host_present;
 
 static int data_out_block_mode(u8_t *data, size_t length, void *ctx);
@@ -73,12 +73,22 @@ static int data_out_drop_mode(u8_t *data, size_t length, void *ctx);
 static int char_out_drop_mode(u8_t data);
 static int line_out_drop_mode(void);
 
+static inline bool is_sync_mode(void)
+{
+	return IS_ENABLED(CONFIG_LOG_IMMEDIATE) || panic_mode;
+}
+
+static inline bool is_panic_mode(void)
+{
+	return panic_mode;
+}
+
 static int data_out_drop_mode(u8_t *data, size_t length, void *ctx)
 {
 	(void) ctx;
 	u8_t *pos;
 
-	if (sync_mode) {
+	if (is_sync_mode()) {
 		return data_out_block_mode(data, length, ctx);
 	}
 
@@ -163,7 +173,7 @@ static void on_failed_write(int retry_cnt)
 {
 	if (retry_cnt == 0) {
 		host_present = false;
-	} else if (sync_mode) {
+	} else if (is_sync_mode()) {
 		k_busy_wait(USEC_PER_MSEC *
 				CONFIG_LOG_BACKEND_RTT_RETRY_DELAY_MS);
 	} else {
@@ -174,7 +184,7 @@ static void on_failed_write(int retry_cnt)
 static void on_write(int retry_cnt)
 {
 	host_present = true;
-	if (sync_mode) {
+	if (is_panic_mode()) {
 		/* In panic mode block on each write until host reads it. This
 		 * way it is ensured that if system resets all messages are read
 		 * by the host. While pending on data being read by the host we
@@ -190,18 +200,17 @@ static void on_write(int retry_cnt)
 
 static int data_out_block_mode(u8_t *data, size_t length, void *ctx)
 {
-	int ret;
+	int ret = 0;
 	int retry_cnt = CONFIG_LOG_BACKEND_RTT_RETRY_CNT;
 
 	do {
-		if (!sync_mode) {
+		if (!is_sync_mode()) {
 			RTT_LOCK();
 		}
 
 		ret = SEGGER_RTT_WriteSkipNoLock(CONFIG_LOG_BACKEND_RTT_BUFFER,
 						 data, length);
-
-		if (!sync_mode) {
+		if (!is_sync_mode()) {
 			RTT_UNLOCK();
 		}
 
@@ -213,7 +222,7 @@ static int data_out_block_mode(u8_t *data, size_t length, void *ctx)
 		}
 	} while ((ret == 0) && host_present);
 
-	return length;
+	return ((ret == 0) && host_present) ? 0 : length;
 }
 
 LOG_OUTPUT_DEFINE(log_output, IS_ENABLED(CONFIG_LOG_BACKEND_RTT_MODE_BLOCK) ?
@@ -243,14 +252,13 @@ static void log_backend_rtt_init(void)
 	}
 
 	host_present = true;
-	sync_mode = IS_ENABLED(CONFIG_LOG_IMMEDIATE) ? true : false;
 	line_pos = line_buf;
 }
 
 static void panic(struct log_backend const *const backend)
 {
 	log_backend_std_panic(&log_output);
-	sync_mode = true;
+	panic_mode = true;
 }
 
 static void dropped(const struct log_backend *const backend, u32_t cnt)


### PR DESCRIPTION
RTT backend was treating synchronous mode (LOG_IMMEDIATE) and panic mode
in the same way. That lead to decreased bandwidth since after each transfer
operation backend was pending until RTT data is read by the host. It is
vital only in panic mode to ensure that device do not reset before all data
is read by the host. In synchronous mode that degrades performance significantly.

Added distinction between those two modes.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>