### PR TITLE
lib: os: make snprintk fns generally available

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -5274,6 +5274,7 @@ extern void k_mem_domain_remove_thread(k_tid_t thread);
 
 /** @} */
 
+#ifdef CONFIG_PRINTK
 /**
  * @brief Emit a character buffer to the console device
  *
@@ -5283,6 +5284,7 @@ extern void k_mem_domain_remove_thread(k_tid_t thread);
  * @req K-MISC-006
  */
 __syscall void k_str_out(char *c, size_t n);
+#endif
 
 /**
  * @brief Disable preservation of floating point context information.

--- a/include/sys/printk.h
+++ b/include/sys/printk.h
@@ -47,13 +47,6 @@ extern "C" {
 #ifdef CONFIG_PRINTK
 extern __printf_like(1, 2) void printk(const char *fmt, ...);
 extern __printf_like(1, 0) void vprintk(const char *fmt, va_list ap);
-extern __printf_like(3, 4) int snprintk(char *str, size_t size,
-					const char *fmt, ...);
-extern __printf_like(3, 0) int vsnprintk(char *str, size_t size,
-					  const char *fmt, va_list ap);
-
-extern __printf_like(3, 0) void z_vprintk(int (*out)(int f, void *c), void *ctx,
-					 const char *fmt, va_list ap);
 #else
 static inline __printf_like(1, 2) void printk(const char *fmt, ...)
 {
@@ -65,27 +58,15 @@ static inline __printf_like(1, 0) void vprintk(const char *fmt, va_list ap)
 	ARG_UNUSED(fmt);
 	ARG_UNUSED(ap);
 }
-
-static inline __printf_like(3, 4) int snprintk(char *str, size_t size,
-					       const char *fmt, ...)
-{
-	ARG_UNUSED(str);
-	ARG_UNUSED(size);
-	ARG_UNUSED(fmt);
-	return 0;
-}
-
-static inline __printf_like(3, 0) int vsnprintk(char *str, size_t size,
-						const char *fmt, va_list ap)
-{
-	ARG_UNUSED(str);
-	ARG_UNUSED(size);
-	ARG_UNUSED(fmt);
-	ARG_UNUSED(ap);
-
-	return 0;
-}
 #endif
+
+extern __printf_like(3, 4) int snprintk(char *str, size_t size,
+					const char *fmt, ...);
+extern __printf_like(3, 0) int vsnprintk(char *str, size_t size,
+					  const char *fmt, va_list ap);
+
+extern __printf_like(3, 0) void z_vprintk(int (*out)(int f, void *c), void *ctx,
+					 const char *fmt, va_list ap);
 
 #ifdef __cplusplus
 }

--- a/lib/os/CMakeLists.txt
+++ b/lib/os/CMakeLists.txt
@@ -11,6 +11,7 @@ zephyr_sources(
   fdtable.c
   hex.c
   mempool.c
+  printk.c
   rb.c
   sem.c
   thread_entry.c
@@ -19,8 +20,6 @@ zephyr_sources(
   )
 
 zephyr_sources_ifdef(CONFIG_JSON_LIBRARY json.c)
-
-zephyr_sources_if_kconfig(printk.c)
 
 zephyr_sources_if_kconfig(ring_buffer.c)
 

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -37,6 +37,7 @@ static void _printk_hex_ulong(out_func_t out, void *ctx,
 			      const unsigned long long num, enum pad_type padding,
 			      int min_width);
 
+#ifdef CONFIG_PRINTK
 /**
  * @brief Default character output routine that does nothing
  * @param c Character to swallow
@@ -84,6 +85,7 @@ void *__printk_get_hook(void)
 {
 	return _char_out;
 }
+#endif /* CONFIG_PRINTK */
 
 static void print_err(out_func_t out, void *ctx)
 {
@@ -285,6 +287,7 @@ still_might_format:
 	}
 }
 
+#ifdef CONFIG_PRINTK
 #ifdef CONFIG_USERSPACE
 struct buf_out_context {
 	int count;
@@ -348,7 +351,7 @@ void vprintk(const char *fmt, va_list ap)
 
 	z_vprintk(char_out, &ctx, fmt, ap);
 }
-#endif
+#endif /* CONFIG_USERSPACE */
 
 void z_impl_k_str_out(char *c, size_t n)
 {
@@ -366,7 +369,7 @@ static inline void z_vrfy_k_str_out(char *c, size_t n)
 	z_impl_k_str_out((char *)c, n);
 }
 #include <syscalls/k_str_out_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 /**
  * @brief Output a string
@@ -403,6 +406,7 @@ void printk(const char *fmt, ...)
 	}
 	va_end(ap);
 }
+#endif /* CONFIG_PRINTK */
 
 /**
  * @brief Output an unsigned long long in hex format


### PR DESCRIPTION
The intention of disabling CONFIG_PRINTK is that all
invocations of it will compile to nothing, saving a lot
of runtime overhead and footprint since all the format
strings are completely dropped; instances of printk()
and related functions are no-ops.

However, some subsystems need snprintk() for string
processing, since the snprintf() implementations in even
minimal C library are too costly in text footprint or
stack usage for some applications. This processing is
required for the application to even function.

This patch continues to have disabling  CONFIG_PRINTK to
cause the non snprintk functions to become no-ops, but
now we always compile the necessary bits for snprintk(),
relying on gc-sections to discard them if unused.

z_vprintk() is now unconditionally defined in the header
since it is not tied to any particular output sink and
is intended for users who know exactly what they are
doing (it's in zephyr private scope).

Relates to: #21564

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>