### PR TITLE
kconfig: Remove redundant $ZEPHYR_BASE from 'source's

### DIFF
--- a/samples/net/updatehub/Kconfig
+++ b/samples/net/updatehub/Kconfig
@@ -20,4 +20,4 @@ config UPDATEHUB_POLLING
 	  intervention.
 endif #!UPDATEHUB_MANUAL
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
+source "Kconfig.zephyr"

--- a/samples/subsys/fs/littlefs/Kconfig
+++ b/samples/subsys/fs/littlefs/Kconfig
@@ -1,9 +1,11 @@
 # Copyright (c) 2019 Peter Bigot Consulting, LLC
 # SPDX-License-Identifier: Apache-2.0
 
+mainmenu "littlefs sample"
+
 config APP_WIPE_STORAGE
 	bool "Option to clear the flash area before mounting"
 	help
 	  Use this to force an existing file system to be created.
 
-source "$ZEPHYR_BASE/Kconfig"
+source "Kconfig.zephyr"

--- a/tests/kernel/profiling/profiling_api/Kconfig
+++ b/tests/kernel/profiling/profiling_api/Kconfig
@@ -10,4 +10,4 @@ config KERNEL_PROFILING_API_TEST
 	  test to profile idle thread will be executed.
 
 # Include Zephyr's Kconfig.
-source "$ZEPHYR_BASE/Kconfig"
+source "Kconfig"


### PR DESCRIPTION
The $srctree environment variable is already set to point to the Zephyr
root, so no need to do

    source "$(ZEPHYR_BASE)/Kconfig.zephyr"

in samples. Just

    source "Kconfig.zephyr"

works.

(Things would break if $srctree was set to anything else, because every
'source' in the Kconfig files will be relative to it.)

Also add a 'mainmenu' title to the littlefs sample. It shows up at the
top of menuconfig/guiconfig. Source Kconfig.zephyr instead of Kconfig to
avoid overriding it.

As a sidenote, $(FOO) is better $FOO in Kconfig. $FOO is legacy syntax
that Kconfiglib only supports to be compatible with old Linux kernels.
$(FOO) uses the Kconfig preprocessor.