### PR TITLE
sanitycheck: support pre/post flash scripts fix

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -802,6 +802,16 @@ class DeviceHandler(Handler):
         except subprocess.CalledProcessError:
             os.write(write_pipe, b'x')  # halt the thread
 
+        if post_script:
+            with subprocess.Popen(post_script, stderr=subprocess.PIPE, stdout=subprocess.PIPE) as proc:
+                try:
+                    (stdout, stderr) = proc.communicate(timeout=30)
+                    logger.debug(stdout.decode())
+
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    (stdout, stderr) = proc.communicate()
+
         t.join(self.timeout)
         if t.is_alive():
             out_state = "timeout"
@@ -826,17 +836,6 @@ class DeviceHandler(Handler):
                 self.instance.reason = "Failed"
         else:
             self.set_state(out_state, handler_time)
-
-        if post_script:
-            with subprocess.Popen(post_script, stderr=subprocess.PIPE, stdout=subprocess.PIPE) as proc:
-                try:
-                    (stdout, stderr) = proc.communicate(timeout=30)
-                    logger.debug(stdout.decode())
-
-                except subprocess.TimeoutExpired:
-                    proc.kill()
-                    (stdout, stderr) = proc.communicate()
-                    logger.error("{} timed out".format(post_script))
 
         self.make_device_available(serial_device)
 


### PR DESCRIPTION
Fix of the #21528
Post script was called to late, and sanitycheck didn't complete the run.
Now post script will be called earlier right after the west flash
finishes programming of the board.
I tested it on the Microchip board, pre script triggered reset
of the board, post script finished reset of the board.
In original code sanitycheck can't finish the run,
because post script was called too late, and it caused timeout error.
It was due to board was still in the reset mode after programming,
but it should be in the run mode to run the test and print the serial output.
That fix will solve issue for other boards too,
which need reset before and during programming.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>