### PR TITLE
Bluetooth: controller: define adv channel access address as macro in pdu.h

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -6603,7 +6603,7 @@ again:
 	 * It shall not be a sequence that differs from the advertising channel
 	 * packets Access Address by only one bit.
 	 */
-	adv_aa_check = access_addr ^ 0x8e89bed6;
+	adv_aa_check = access_addr ^ PDU_AC_ACCESS_ADDR;
 	if (util_ones_count_get((u8_t *)&adv_aa_check,
 				sizeof(adv_aa_check)) <= 1) {
 		goto again;
@@ -6719,7 +6719,7 @@ static void event_adv(u32_t ticks_at_expire, u32_t remainder,
 		      u16_t lazy, void *context)
 {
 	u32_t remainder_us;
-	u32_t aa = 0x8e89bed6;
+	u32_t aa = PDU_AC_ACCESS_ADDR;
 
 	ARG_UNUSED(remainder);
 	ARG_UNUSED(lazy);
@@ -7151,7 +7151,7 @@ static void event_scan(u32_t ticks_at_expire, u32_t remainder, u16_t lazy,
 {
 	u32_t remainder_us;
 	u32_t ret;
-	u32_t aa = 0x8e89bed6;
+	u32_t aa = PDU_AC_ACCESS_ADDR;
 
 	ARG_UNUSED(remainder);
 	ARG_UNUSED(lazy);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -120,7 +120,7 @@ static int init_reset(void)
 static int prepare_cb(struct lll_prepare_param *prepare_param)
 {
 	struct lll_adv *lll = prepare_param->param;
-	u32_t aa = sys_cpu_to_le32(0x8e89bed6);
+	u32_t aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	u32_t ticks_at_event, ticks_at_start;
 	struct evt_hdr *evt;
 	u32_t remainder_us;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -119,7 +119,7 @@ static int init_reset(void)
 static int prepare_cb(struct lll_prepare_param *prepare_param)
 {
 	struct lll_scan *lll = prepare_param->param;
-	u32_t aa = sys_cpu_to_le32(0x8e89bed6);
+	u32_t aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	u32_t ticks_at_event, ticks_at_start;
 	struct node_rx_pdu *node_rx;
 	struct evt_hdr *evt;

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -118,7 +118,7 @@ static int init_reset(void)
 static int prepare_cb(struct lll_prepare_param *prepare_param)
 {
 	struct lll_adv *lll = prepare_param->param;
-	u32_t aa = sys_cpu_to_le32(0x8e89bed6);
+	u32_t aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	u32_t ticks_at_event, ticks_at_start;
 	struct evt_hdr *evt;
 	u32_t remainder_us;

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -118,7 +118,7 @@ static int init_reset(void)
 static int prepare_cb(struct lll_prepare_param *prepare_param)
 {
 	struct lll_scan *lll = prepare_param->param;
-	u32_t aa = sys_cpu_to_le32(0x8e89bed6);
+	u32_t aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	u32_t ticks_at_event, ticks_at_start;
 	struct node_rx_pdu *node_rx;
 	struct evt_hdr *evt;

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -18,6 +18,8 @@
 #define PDU_AC_LL_HEADER_SIZE  (offsetof(struct pdu_adv, payload))
 /* Advertisement channel maximum PDU size */
 #define PDU_AC_SIZE_MAX        (PDU_AC_LL_HEADER_SIZE + PDU_AC_PAYLOAD_SIZE_MAX)
+/* Advertisement channel Access Address */
+#define PDU_AC_ACCESS_ADDR     0x8e89bed6
 
 #define ACCESS_ADDR_SIZE        4
 #define ADVA_SIZE               6

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -819,7 +819,7 @@ again:
 	 * It shall not be a sequence that differs from the advertising channel
 	 * packets Access Address by only one bit.
 	 */
-	adv_aa_check = aa ^ 0x8e89bed6;
+	adv_aa_check = aa ^ PDU_AC_ACCESS_ADDR;
 	if (util_ones_count_get((u8_t *)&adv_aa_check,
 				sizeof(adv_aa_check)) <= 1) {
 		goto again;


### PR DESCRIPTION
The new macro is PDU_AC_ACCESS_ADDR

```
$ grep -Rin 8e89bed6 *
subsys/bluetooth/controller/ll_sw/pdu.h:22:#define PDU_AC_ACCESS_ADDR     0x8e89bed6
$ grep -Ri PDU_AC_ACCESS_ADDR *
subsys/bluetooth/controller/ll_sw/pdu.h:22:#define PDU_AC_ACCESS_ADDR     0x8e89bed6
subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c:122:	u32_t aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c:123:	u32_t aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
subsys/bluetooth/controller/ll_sw/ctrl.c:6606:	adv_aa_check = access_addr ^ PDU_AC_ACCESS_ADDR;
subsys/bluetooth/controller/ll_sw/ctrl.c:6722:	u32_t aa = PDU_AC_ACCESS_ADDR;
subsys/bluetooth/controller/ll_sw/ctrl.c:7154:	u32_t aa = PDU_AC_ACCESS_ADDR;
subsys/bluetooth/controller/ll_sw/ull_master.c:822:	adv_aa_check = aa ^ PDU_AC_ACCESS_ADDR;
subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c:121:	u32_t aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c:121:	u32_t aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
```

Signed-off-by: Christopher Friedt <chrisfriedt@gmail.com>