### PR TITLE
soc: mec1501: Fix build failure due to missing z_power_soc_sleep()

### DIFF
--- a/soc/arm/microchip_mec/mec1501/power.c
+++ b/soc/arm/microchip_mec/mec1501/power.c
@@ -76,6 +76,9 @@ static void z_power_soc_deep_sleep(void)
 
 }
 
+#endif /* CONFIG_SYS_POWER_DEEP_SLEEP_STATES */
+
+#ifdef CONFIG_SYS_POWER_SLEEP_STATES
 
 /*
  * Light Sleep
@@ -96,7 +99,8 @@ static void z_power_soc_sleep(void)
 	__NOP();
 	__NOP();
 }
-#endif
+
+#endif /* CONFIG_SYS_POWER_SLEEP_STATES */
 
 /*
  * Called from _sys_suspend(s32_t ticks) in subsys/power.c


### PR DESCRIPTION
After commit 3765e46a40 ("soc: mec1501: fix build failure"),
z_power_soc_sleep() is only available if

    CONFIG_SYS_POWER_DEEP_SLEEP_STATES

is enabled, but it needs to be available whenever

    CONFIG_SYS_POWER_SLEEP_STATES

is enabled. Fix the #ifdefs.

Fixes this CI failure:

    .../soc/arm/microchip_mec/mec1501/power.c:111:3: error: implicit
    declaration of function 'z_power_soc_sleep'; did you mean
    'z_impl_k_sleep'? [-Werror=implicit-function-declaration]