### PR TITLE
Sanitycheck stuff

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -3361,11 +3361,16 @@ Artificially long but functional example:
         default=os.path.join(os.getcwd(), "sanity-out"),
         help="Output directory for logs and binaries. "
              "Default is 'sanity-out' in the current directory. "
-             "This directory will be deleted unless '--no-clean' is set.")
+             "This directory will be cleaned unless '--no-clean' is set. "
+             "The '--clobber-output' option controls what cleaning does.")
+    parser.add_argument(
+        "-c", "--clobber-output", action="store_true",
+        help="Cleaning the output directory will simply delete it instead "
+             "of the default policy of renaming.")
     parser.add_argument(
         "-n", "--no-clean", action="store_true",
-        help="Do not delete the outdir before building. Will result in "
-             "faster compilation since builds will be incremental")
+        help="Re-use the outdir before building. Will result in "
+             "faster compilation since builds will be incremental.")
     case_select.add_argument(
         "-T", "--testcase-root", action="append", default=[],
         help="Base directory to recursively search for test cases. All "
@@ -3920,12 +3925,16 @@ def main():
         if os.path.exists(options.outdir):
             print("Keeping artifacts untouched")
     elif os.path.exists(options.outdir):
-        for i in range(1, 100):
-            new_out = options.outdir + ".{}".format(i)
-            if not os.path.exists(new_out):
-                print("Renaming output directory to {}".format(new_out))
-                shutil.move(options.outdir, new_out)
-                break
+        if options.clobber_output:
+            print("Deleting output directory {}".format(options.outdir))
+            shutil.rmtree(options.outdir)
+        else:
+            for i in range(1, 100):
+                new_out = options.outdir + ".{}".format(i)
+                if not os.path.exists(new_out):
+                    print("Renaming output directory to {}".format(new_out))
+                    shutil.move(options.outdir, new_out)
+                    break
 
     os.makedirs(options.outdir, exist_ok=True)
 

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -4309,4 +4309,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    finally:
+        os.system("stty sane")

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -3918,12 +3918,12 @@ def main():
     # Cleanup
     if options.no_clean or options.only_failed or options.test_only:
         if os.path.exists(options.outdir):
-            logger.info("Keeping artifacts untouched")
+            print("Keeping artifacts untouched")
     elif os.path.exists(options.outdir):
         for i in range(1, 100):
             new_out = options.outdir + ".{}".format(i)
             if not os.path.exists(new_out):
-                logger.info("Renaming output directory to {}".format(new_out))
+                print("Renaming output directory to {}".format(new_out))
                 shutil.move(options.outdir, new_out)
                 break
 

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1996,7 +1996,7 @@ class ProjectBuilder(FilterBuilder):
 
     @staticmethod
     def log_info(filename, inline_logs):
-        filename = os.path.relpath(os.path.realpath(filename))
+        filename = os.path.abspath(os.path.realpath(filename))
         if inline_logs:
             logger.info("{:-^100}".format(filename))
 


### PR DESCRIPTION
- Always invoke 'stty sane' before exiting the script.
- Fix problem where artifact management printouts were being dropped due to the logger not being set up
- Add a command line option to support the old behavior of deleting the out directory if
present and -n not supplied
- Use absolute paths for log files, makes it much simpler to examine them from another terminal