### PR TITLE
settings: Deprecate base64 in fs backed settings

### DIFF
--- a/doc/releases/release-notes-2.2.rst
+++ b/doc/releases/release-notes-2.2.rst
@@ -24,6 +24,10 @@ API Changes
 Deprecated in this release
 ==========================
 
+* Settings
+
+  * SETTINGS_USE_BASE64, encoding values in base64 is marked for removal.
+
 Stable API changes in this release
 ==================================
 
@@ -300,4 +304,3 @@ release:
 
 .. comment  List derived from GitHub Issue query: ...
    * :github:`issuenumber` - issue title
-

--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -34,10 +34,12 @@ config SETTINGS_ENCODE_LEN
 	bool
 
 config SETTINGS_USE_BASE64
-	bool "encoding value using base64"
+	bool "encoding value using base64 (deprecated)"
 	depends on SETTINGS
 	select BASE64
 	help
+	  This option has been deprecated and will not be supported
+	  in future releases.
 	  Enables values encoding using Base64.
 
 choice


### PR DESCRIPTION
Encoding of values with use of base64 has been marked as deprecated and
will be removed in future releases.

GH Issue #18927

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>