### PR TITLE
scripts: cmake: move print from python to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1479,6 +1479,8 @@ if(HEX_FILES_TO_MERGE)
 
   add_custom_target(mergehex ALL DEPENDS ${MERGED_HEX_NAME})
   list(APPEND FLASH_DEPS mergehex)
+
+  message(VERBOSE "Merging hex files: ${HEX_FILES_TO_MERGE}")
 endif()
 
 if(EMU_PLATFORM)

--- a/scripts/mergehex.py
+++ b/scripts/mergehex.py
@@ -29,8 +29,6 @@ def merge_hex_files(output, input_hex_files, overlap):
         except AddressOverlapError:
             raise AddressOverlapError("{} has merge issues".format(hex_file_path))
 
-        print("Merged {}".format(hex_file_path))
-
     ih.write_hex_file(output)
 
 


### PR DESCRIPTION
Prior to this all hex files included in a merge would
be printed on every invokation of cmake.

Allow the user to explicitly require this information
by moving the print to a VERBOSE-only cmake message.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>