### PR TITLE
USB: Trivial cleanup and hwinfo fix

### DIFF
--- a/subsys/usb/class/loopback.c
+++ b/subsys/usb/class/loopback.c
@@ -77,8 +77,7 @@ static void loopback_out_cb(u8_t ep, enum usb_dc_ep_cb_status_code ep_status)
 	usb_read(ep, loopback_buf, bytes_to_read, NULL);
 }
 
-static void loopback_in_cb(u8_t ep,
-				enum usb_dc_ep_cb_status_code ep_status)
+static void loopback_in_cb(u8_t ep, enum usb_dc_ep_cb_status_code ep_status)
 {
 	if (usb_write(ep, loopback_buf, CONFIG_LOOPBACK_BULK_EP_MPS, NULL)) {
 		LOG_DBG("ep 0x%x", ep);

--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -326,10 +326,14 @@ static void usb_fix_ascii_sn_string_descriptor(struct usb_sn_descriptor *sn)
 	}
 
 	runtime_sn_len = strlen(runtime_sn);
+	if (!runtime_sn_len) {
+		return;
+	}
+
 	default_sn_len = strlen(CONFIG_USB_DEVICE_SN);
 
 	if (runtime_sn_len != default_sn_len) {
-		LOG_ERR("the new SN descriptor doesn't has the same "
+		LOG_ERR("the new SN descriptor doesn't have the same "
 			"length as CONFIG_USB_DEVICE_SN");
 		return;
 	}

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -212,8 +212,6 @@ static bool usb_handle_request(struct usb_setup_packet *setup,
 	u32_t type = REQTYPE_GET_TYPE(setup->bmRequestType);
 	usb_request_handler handler = usb_dev.req_handlers[type];
 
-	LOG_DBG("** %d **", type);
-
 	if (type >= MAX_NUM_REQ_HANDLERS) {
 		LOG_DBG("Error Incorrect iType %d", type);
 		return false;
@@ -286,7 +284,7 @@ static void usb_handle_control_transfer(u8_t ep,
 	u32_t chunk = 0U;
 	struct usb_setup_packet *setup = &usb_dev.setup;
 
-	LOG_DBG("ep %x, status %x", ep, ep_status);
+	LOG_DBG("ep 0x%02x, status 0x%02x", ep, ep_status);
 
 	if (ep == USB_CONTROL_OUT_EP0 && ep_status == USB_DC_EP_SETUP) {
 		u16_t length;

--- a/tests/subsys/usb/bos/src/test_bos.c
+++ b/tests/subsys/usb/bos/src/test_bos.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
 #include <ztest.h>
 #include <tc_util.h>
 
@@ -14,32 +13,8 @@
 
 #include <usb/bos.h>
 
-/* Helpers */
-static void hexdump(const u8_t *data, size_t len)
-{
-	int n = 0;
-
-	while (len--) {
-		if (n % 16 == 0) {
-			printk("%08X ", n);
-		}
-
-		printk("%02X ", *data++);
-
-		n++;
-		if (n % 8 == 0) {
-			if (n % 16 == 0) {
-				printk("\n");
-			} else {
-				printk(" ");
-			}
-		}
-	}
-
-	if (n % 16) {
-		printk("\n");
-	}
-}
+#include <logging/log.h>
+LOG_MODULE_REGISTER(test_main, LOG_LEVEL_DBG);
 
 /*
  * Compare old style USB BOS definition with section aligned
@@ -203,9 +178,11 @@ static void test_usb_bos_macros(void)
 
 	/* usb_bos_fix_total_length(); corrected with register */
 
-	hexdump((void *)hdr, len);
-	hexdump((void *)&webusb_bos_descriptor, sizeof(cap_webusb));
-	hexdump((void *)&webusb_bos_descriptor_2, sizeof(cap_msosv2));
+	LOG_HEXDUMP_DBG((void *)hdr, len, "Header");
+	LOG_HEXDUMP_DBG((void *)&webusb_bos_descriptor, sizeof(cap_webusb),
+			"webusb cap");
+	LOG_HEXDUMP_DBG((void *)&webusb_bos_descriptor_2, sizeof(cap_msosv2),
+			"webusb cap msos v2");
 
 	zassert_true(len ==
 		     sizeof(struct usb_bos_descriptor) +
@@ -239,7 +216,7 @@ static void test_usb_bos(void)
 		     "Wrong data");
 }
 
-/*test case main entry*/
+/* test case main entry */
 void test_main(void)
 {
 	/* Prepare webusb_bos_descriptor_2 */

--- a/tests/subsys/usb/desc_sections/src/desc_sections.c
+++ b/tests/subsys/usb/desc_sections/src/desc_sections.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
 #include <ztest.h>
 #include <tc_util.h>
 
@@ -13,9 +12,8 @@
 #include <usb/usb_common.h>
 #include <usb_descriptor.h>
 
-#define LOG_LEVEL LOG_LEVEL_DBG
 #include <logging/log.h>
-LOG_MODULE_REGISTER(test_main);
+LOG_MODULE_REGISTER(test_main, LOG_LEVEL_DBG);
 
 #ifdef CONFIG_USB_COMPOSITE_DEVICE
 #error Do not use composite configuration

--- a/tests/subsys/usb/device/src/main.c
+++ b/tests/subsys/usb/device/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
 #include <ztest.h>
 #include <tc_util.h>
 
@@ -187,7 +186,7 @@ static void test_usb_dc_api_read_write(void)
 			  TC_PASS, "usb_write(INVALID_EP)");
 }
 
-/*test case main entry*/
+/* test case main entry */
 void test_main(void)
 {
 	int ret;

--- a/tests/subsys/usb/os_desc/src/usb_osdesc.c
+++ b/tests/subsys/usb/os_desc/src/usb_osdesc.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
 #include <ztest.h>
 #include <tc_util.h>
 
@@ -140,7 +139,7 @@ static void test_osdesc_feature(void)
 	test_handle_os_desc_feature();
 }
 
-/*test case main entry*/
+/* test case main entry */
 void test_main(void)
 {
 	ztest_test_suite(test_osdesc,


### PR DESCRIPTION
Trivial cleanups and fix for native_posix missing hwinfo.