### PR TITLE
Bluetooth: controller: legacy: Fix controller address check

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_adv.c
@@ -411,12 +411,6 @@ u8_t ll_adv_enable(u8_t enable)
 	pdu_adv = (struct pdu_adv *)&radio_adv_data->data
 			[radio_adv_data->last][0];
 
-	if (pdu_adv->tx_addr) {
-		if (!mem_nz(ll_addr_get(1, NULL), BDADDR_SIZE)) {
-			return BT_HCI_ERR_INVALID_PARAM;
-		}
-	}
-
 	radio_scan_data = radio_scan_data_get();
 	pdu_scan = (struct pdu_adv *)&radio_scan_data->data
 			[radio_scan_data->last][0];
@@ -435,8 +429,14 @@ u8_t ll_adv_enable(u8_t enable)
 
 		/* AdvA, fill here at enable */
 		if (h->adv_addr) {
-			memcpy(ptr, ll_addr_get(pdu_adv->tx_addr, NULL),
-			       BDADDR_SIZE);
+			u8_t *tx_addr = ll_addr_get(pdu_adv->tx_addr, NULL);
+
+			/* TODO: Privacy check */
+			if (pdu_adv->tx_addr && !mem_nz(tx_addr, BDADDR_SIZE)) {
+				return BT_HCI_ERR_INVALID_PARAM;
+			}
+
+			memcpy(ptr, tx_addr, BDADDR_SIZE);
 		}
 
 		/* TODO: TargetA, fill here at enable */
@@ -460,9 +460,11 @@ u8_t ll_adv_enable(u8_t enable)
 
 			ll_rl_pdu_adv_update(rl_idx, pdu_adv);
 			ll_rl_pdu_adv_update(rl_idx, pdu_scan);
+
 			priv = true;
 		}
 #endif /* !CONFIG_BT_CTLR_PRIVACY */
+
 		if (!priv) {
 			memcpy(&pdu_adv->adv_ind.addr[0],
 			       ll_addr_get(pdu_adv->tx_addr, NULL),
@@ -470,6 +472,15 @@ u8_t ll_adv_enable(u8_t enable)
 			memcpy(&pdu_scan->scan_rsp.addr[0],
 			       ll_addr_get(pdu_adv->tx_addr, NULL),
 			       BDADDR_SIZE);
+		}
+
+		/* In case the local IRK was not set or no match was
+		 * found the fallback address was used instead, check
+		 * that a valid address has been set.
+		 */
+		if ((priv || pdu_adv->tx_addr) &&
+		    !mem_nz(&pdu_adv->adv_ind.addr[0], BDADDR_SIZE)) {
+			return BT_HCI_ERR_INVALID_PARAM;
 		}
 	}
 


### PR DESCRIPTION
Fix controllers address check in cases of controller-based privacy.
When controller has been instructed by the host to use privacy
the controller should look up the peer identity address and generate
an address based on the local IRK. In the case where no match
is found or the local IRK is all zeroes the controller shall use
the fallback address. If the fallback address is not valid the
controller shall return invalid params.

This commit fixes these issues:
 - Starting a private advertiser without valid random address set
   but a valid local IRK exists. In this case the advertiser should
   be able to advertise using the RPA regardless of a valid random
   or public address.
 - Starting a private advertiser with a fallback to the public
   address type or an adveriser using public address  does not
   check if a valid public address exists. The host cannot
   advertise with an all-zero public address.

Signed-off-by: Joakim Andersson <joerchan@gmail.com>
Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>