### PR TITLE
tests filesystem.fat.api: Do not run on native_posix_64

### DIFF
--- a/tests/subsys/fs/fat_fs_api/testcase.yaml
+++ b/tests/subsys/fs/fat_fs_api/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   filesystem.fat.api:
-    platform_whitelist: native_posix native_posix_64
+    platform_whitelist: native_posix
     tags: filesystem


### PR DESCRIPTION
The FAT FS code clearly does not support platforms where
long is 64bits. See
https://github.com/zephyrproject-rtos/fatfs/blob/master/include/integer.h#L30

So, do not try to run it in native_posix_64
Fixes #21536
Fixes #19231

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>