### PR TITLE
Out of bounds array fix

### DIFF
--- a/drivers/spi/spi_oc_simple.c
+++ b/drivers/spi/spi_oc_simple.c
@@ -68,6 +68,10 @@ static int spi_oc_simple_configure(const struct spi_oc_simple_cfg *info,
 			break;
 		}
 
+    if (i == 12) {
+        i = 11;
+    }
+
 	sys_write8((DIVIDERS[i] >> 4) & 0x3, SPI_OC_SIMPLE_SPER(info));
 	spcr |= (DIVIDERS[i] & 0x3);
 

--- a/drivers/spi/spi_oc_simple.c
+++ b/drivers/spi/spi_oc_simple.c
@@ -65,12 +65,13 @@ static int spi_oc_simple_configure(const struct spi_oc_simple_cfg *info,
 	for (i = 0; i < 12; i++)
 		if ((config->frequency << (i + 1)) >
 		    CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC) {
-			break;
+				break;
 		}
 
-    if (i == 12) {
-        i = 11;
-    }
+	if (i == 11) {
+		i = 11;
+	}
+
 
 	sys_write8((DIVIDERS[i] >> 4) & 0x3, SPI_OC_SIMPLE_SPER(info));
 	spcr |= (DIVIDERS[i] & 0x3);


### PR DESCRIPTION
In drivers/spi/spi_oc_simple.c, the following array with 11 elements is defined:
```c
u8_t DIVIDERS[] = { 0x00,       /*   2  */
		    0x01,       /*   4  */
		    0x10,       /*   8  */
		    0x02,       /*  16  */
		    0x03,       /*  32  */
		    0x11,       /*  64  */
		    0x12,       /* 128  */
		    0x13,       /* 256  */
		    0x20,       /* 512  */
		    0x21,       /* 1024 */
		    0x22,       /* 2048 */
		    0x23 };     /* 4096 */
```
Which is later used as:
```c
/* Set clock divider */
	for (i = 0; i < 12; i++)
		if ((config->frequency << (i + 1)) >
		    CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC) {
			break;
		}
	sys_write8((DIVIDERS[i] >> 4) & 0x3, SPI_OC_SIMPLE_SPER(info));
	spcr |= (DIVIDERS[i] & 0x3);
```

If the condition in the for loop isn't true, the variable "i" will be 12 when DIVIDERS is indexed, which will be out of bounds