### PR TITLE
west.yaml: Update hal_nxp to MCUXpresso SDK 2.7.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -86,7 +86,7 @@ manifest:
       revision: 00dd4fab1a00f2f6e995ef3f2e7c3814689f8885
       path: modules/fs/nffs
     - name: hal_nxp
-      revision: ef000ff5d902c938e3d4763155b0511b043017c8
+      revision: 1e6520c0b06b674190f4a574761dd9c5f4b02142
       path: modules/hal/nxp
     - name: open-amp
       revision: 9b591b289e1f37339bd038b5a1f0e6c8ad39c63a


### PR DESCRIPTION
Updates hal_nxp to pick up MCUXpresso SDK 2.7.0 for all available SoCs.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Depends on zephyrproject-rtos/hal_nxp#26