### PR TITLE
[TOPIC-GPIO] drivers: ssd16xx: convert to new GPIO API

### DIFF
--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -67,9 +67,9 @@
 		height = <120>;
 		pp-width-bits = <8>;
 		pp-height-bits = <8>;
-		reset-gpios = <&gpio0 15 0>;
-		dc-gpios = <&gpio0 16 0>;
-		busy-gpios = <&gpio0 14 0>;
+		reset-gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+		dc-gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+		busy-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
 		gdv = [10 0a];
 		sdv = [19];
 		vcom = <0xa8>;

--- a/boards/arm/reel_board/reel_board_v2.dts
+++ b/boards/arm/reel_board/reel_board_v2.dts
@@ -43,9 +43,9 @@
 		height = <120>;
 		pp-width-bits = <8>;
 		pp-height-bits = <16>;
-		reset-gpios = <&gpio0 15 0>;
-		dc-gpios = <&gpio0 16 0>;
-		busy-gpios = <&gpio0 14 0>;
+		reset-gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+		dc-gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+		busy-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
 		gdv = [15];
 		sdv = [41 a8 32];
 		vcom = <0x26>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b1.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b1.overlay
@@ -17,9 +17,9 @@
 		height = <120>;
 		pp-width-bits = <8>;
 		pp-height-bits = <8>;
-		dc-gpios = <&arduino_header 15 0>;	/* D9 */
-		reset-gpios = <&arduino_header 14 0>;	/* D8 */
-		busy-gpios = <&arduino_header 13 0>;	/* D7 */
+		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
+		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
+		busy-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;	/* D7 */
 		gdv = [10 0a];
 		sdv = [19];
 		vcom = <0xa8>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b72.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b72.overlay
@@ -17,9 +17,9 @@
 		height = <120>;
 		pp-width-bits = <8>;
 		pp-height-bits = <16>;
-		dc-gpios = <&arduino_header 15 0>;	/* D9 */
-		reset-gpios = <&arduino_header 14 0>;	/* D8 */
-		busy-gpios = <&arduino_header 13 0>;	/* D7 */
+		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
+		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
+		busy-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;	/* D7 */
 		gdv = [15];
 		sdv = [41 a8 32];
 		vcom = <0x26>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh029a1.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh029a1.overlay
@@ -17,9 +17,9 @@
 		height = <128>;
 		pp-width-bits = <16>;
 		pp-height-bits = <16>;
-		dc-gpios = <&arduino_header 15 0>;	/* D9 */
-		reset-gpios = <&arduino_header 14 0>;	/* D8 */
-		busy-gpios = <&arduino_header 13 0>;	/* D7 */
+		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
+		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
+		busy-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;	/* D7 */
 		gdv = [16];
 		sdv = [0a];
 		vcom = <0xa8>;

--- a/dts/bindings/display/solomon,ssd1673fb.yaml
+++ b/dts/bindings/display/solomon,ssd1673fb.yaml
@@ -61,14 +61,29 @@ properties:
     reset-gpios:
       type: phandle-array
       required: true
+      description: RESET pin.
+
+        The RESET pin of SSD16XX is active low.
+        If connected directly the MCU pin should be configured
+        as active low.
 
     dc-gpios:
       type: phandle-array
       required: true
+      description: DC pin.
+
+        The DC pin of SSD16XX is active low (transmission command byte).
+        If connected directly the MCU pin should be configured
+        as active low.
 
     busy-gpios:
       type: phandle-array
       required: true
+      description: BUSY pin.
+
+        The BUSY pin of SSD16XX is active high.
+        If connected directly the MCU pin should be configured
+        as active high.
 
     lut-initial:
       type: uint8-array


### PR DESCRIPTION
Convert SSD16XX sensor driver to new GPIO API.

TODO: shield overlays, but first the gpio branch has to be rebased on master