### PR TITLE
dts/bindings: ti,tmp116: Remove unused 'alert-gpios' property

### DIFF
--- a/dts/bindings/sensor/ti,tmp116.yaml
+++ b/dts/bindings/sensor/ti,tmp116.yaml
@@ -6,9 +6,3 @@ description: Texas Instruments TMP116 temperature sensor
 compatible: "ti,tmp116"
 
 include: i2c-device.yaml
-
-properties:
-    alert-gpios:
-      type: compound
-      required: false
-      description: ALERT pin


### PR DESCRIPTION
Johann Fischer pointed out that the driver for this sensor
(master/drivers/sensor/tmp116/tmp116.c) doesn't use GPIOs, in
https://github.com/zephyrproject-rtos/zephyr/pull/21605, though there
seems to be an ALERT pin from looking at the datasheet
(http://www.ti.com/lit/ds/symlink/tmp116.pdf).

Remove the unused property declaration.

I was originally just going to change a 'category: optional' to
'required: false' (and 'type: compound' to 'type: phandle-array').
Either solution is fine with me. Could keep the declaration if people
are planning to use it soon.