### PR TITLE
gen_defines: close files before exit

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -77,6 +77,8 @@ def main():
 
     print("Devicetree configuration written to " + args.conf_out)
 
+    conf_file.close()
+    header_file.close()
 
 def parse_args():
     # Returns parsed command-line arguments


### PR DESCRIPTION
In some cases, we've seen the output files be truncated when the python
script has been rebuilt into a .pex before running it -- likely due
to buffering.

Closing files explicitly is the right thing to do anyway, so let's do it.

Signed-off-by: Olof Johansson <olof@lixom.net>