### PR TITLE
riscv: use standard MSTATUS

### DIFF
--- a/arch/riscv/core/cpu_idle.c
+++ b/arch/riscv/core/cpu_idle.c
@@ -19,7 +19,7 @@
 
 void __weak arch_cpu_idle(void)
 {
-	irq_unlock(SOC_MSTATUS_IEN);
+	irq_unlock(MSTATUS_IEN);
 }
 
 void __weak arch_cpu_atomic_idle(unsigned int key)

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -98,7 +98,7 @@ SECTION_FUNC(exception.entry, __irq_wrapper)
 	RV_OP_STOREREG t0, __z_arch_esf_t_mepc_OFFSET(sp)
 
 	/* Save SOC-specific MSTATUS register */
-	csrr t0, SOC_MSTATUS_REG
+	csrr t0, mstatus
 	RV_OP_STOREREG t0, __z_arch_esf_t_mstatus_OFFSET(sp)
 
 #ifdef CONFIG_RISCV_SOC_CONTEXT_SAVE
@@ -426,7 +426,7 @@ no_reschedule:
 
 	/* Restore SOC-specific MSTATUS register */
 	RV_OP_LOADREG t0, __z_arch_esf_t_mstatus_OFFSET(sp)
-	csrw SOC_MSTATUS_REG, t0
+	csrw mstatus, t0
 
 	/* Restore caller-saved registers from thread stack */
 	RV_OP_LOADREG ra, __z_arch_esf_t_ra_OFFSET(sp)

--- a/arch/riscv/core/swap.S
+++ b/arch/riscv/core/swap.S
@@ -93,7 +93,7 @@ SECTION_FUNC(exception.other, arch_swap)
 	 * Unlock irq, following IRQ lock state in a0 register.
 	 * Use atomic instruction csrrs to do so.
 	 */
-	andi a0, a0, SOC_MSTATUS_IEN
+	andi a0, a0, MSTATUS_IEN
 	csrrs t0, mstatus, a0
 
 	/* Set value of return register a0 to value of register t2 */

--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -45,7 +45,7 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	 *
 	 * Given that context switching is performed via a system call exception
 	 * within the RISCV architecture implementation, initially set:
-	 * 1) MSTATUS to SOC_MSTATUS_DEF_RESTORE in the thread stack to enable
+	 * 1) MSTATUS to MSTATUS_DEF_RESTORE in the thread stack to enable
 	 *    interrupts when the newly created thread will be scheduled;
 	 * 2) MEPC to the address of the z_thread_entry_wrapper in the thread
 	 *    stack.
@@ -57,7 +57,7 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	 *    counter will be restored following the MEPC value set within the
 	 *    thread stack.
 	 */
-	stack_init->mstatus = SOC_MSTATUS_DEF_RESTORE;
+	stack_init->mstatus = MSTATUS_DEF_RESTORE;
 	stack_init->mepc = (ulong_t)z_thread_entry_wrapper;
 
 	thread->callee_saved.sp = (ulong_t)stack_init;

--- a/drivers/interrupt_controller/intc_vexriscv_litex.c
+++ b/drivers/interrupt_controller/intc_vexriscv_litex.c
@@ -45,10 +45,10 @@ static inline void vexriscv_litex_irq_setie(u32_t ie)
 {
 	if (ie) {
 		__asm__ volatile ("csrrs x0, mstatus, %0"
-				:: "r"(SOC_MSTATUS_IEN));
+				:: "r"(MSTATUS_IEN));
 	} else {
 		__asm__ volatile ("csrrc x0, mstatus, %0"
-				:: "r"(SOC_MSTATUS_IEN));
+				:: "r"(MSTATUS_IEN));
 	}
 }
 

--- a/soc/riscv/openisa_rv32m1/soc_ri5cy.h
+++ b/soc/riscv/openisa_rv32m1/soc_ri5cy.h
@@ -50,13 +50,6 @@
  */
 
 /*
- * MSTATUS CSR number. (Note this is the standard value in the RISC-V
- * privileged ISA v1.10).
- */
-#define SOC_MSTATUS_REG RI5CY_MSTATUS
-/* MSTATUS's interrupt enable mask. This is also standard. */
-#define SOC_MSTATUS_IEN (1U << 3)
-/*
  * Exception code mask. Use of the bottom five bits is a subset of
  * what the standard allocates (which is XLEN-1 bits).
  */
@@ -70,19 +63,4 @@
 #define SOC_ERET mret
 /* The ecall exception number. This is a standard value. */
 #define SOC_MCAUSE_ECALL_EXP 11
-/*
- * Default MSTATUS value to write when scheduling in a new thread for
- * the first time.
- *
- * - Preserve machine privileges in MPP. If you see any documentation
- *   telling you that MPP is read-only on this SoC, don't believe its
- *   lies.
- * - Enable interrupts when exiting from exception into a new thread
- *   by setting MPIE now, so it will be copied into IE on mret.
- */
-#define RI5CY_MSTATUS_MPP_M     (0x3U << 11)
-#define RI5CY_MSTATUS_MPIE_EN   (1U << 7)
-#define SOC_MSTATUS_DEF_RESTORE (RI5CY_MSTATUS_MPP_M |	\
-				 RI5CY_MSTATUS_MPIE_EN)
-
 #endif /* SOC_RISCV32_OPENISA_RV32M1_SOC_RI5CY_H_ */

--- a/soc/riscv/openisa_rv32m1/soc_zero_riscy.h
+++ b/soc/riscv/openisa_rv32m1/soc_zero_riscy.h
@@ -38,13 +38,6 @@
  */
 
 /*
- * MSTATUS CSR number. (Note this is the standard value in the RISC-V
- * privileged ISA v1.10).
- */
-#define SOC_MSTATUS_REG ZERO_RISCY_MSTATUS
-/* MSTATUS's interrupt enable mask. This is also standard. */
-#define SOC_MSTATUS_IEN (1U << 3)
-/*
  * Exception code mask. Use of the bottom five bits is a subset of
  * what the standard allocates (which is XLEN-1 bits).
  */
@@ -58,19 +51,5 @@
 #define SOC_ERET mret
 /* The ecall exception number. This is a standard value. */
 #define SOC_MCAUSE_ECALL_EXP 11
-/*
- * Default MSTATUS value to write when scheduling in a new thread for
- * the first time.
- *
- * - Preserve machine privileges in MPP. If you see any documentation
- *   telling you that MPP is read-only on this SoC, don't believe its
- *   lies.
- * - Enable interrupts when exiting from exception into a new thread
- *   by setting MPIE now, so it will be copied into IE on mret.
- */
-#define ZERO_RISCY_MSTATUS_MPP_M     (0x3U << 11)
-#define ZERO_RISCY_MSTATUS_MPIE_EN   (1U << 7)
-#define SOC_MSTATUS_DEF_RESTORE (ZERO_RISCY_MSTATUS_MPP_M |	\
-				 ZERO_RISCY_MSTATUS_MPIE_EN)
 
 #endif /* SOC_RISCV32_OPENISA_RV32M1_SOC_ZERO_RISCY_H_ */

--- a/soc/riscv/openisa_rv32m1/wdog.S
+++ b/soc/riscv/openisa_rv32m1/wdog.S
@@ -6,7 +6,7 @@
 
 #include <linker/sections.h>
 #include <toolchain.h>
-#include <soc.h>
+#include <arch/cpu.h>
 
 /* Exports */
 GTEXT(_WdogInit)
@@ -39,7 +39,7 @@ GTEXT(_WdogInit)
  */
 SECTION_FUNC(TEXT, _WdogInit)
 	/* Disable interrupts if they're on. This is timing-sensitive code. */
-	csrrc t0, mstatus, SOC_MSTATUS_IEN
+	csrrc t0, mstatus, MSTATUS_IEN
 
 	/* Get base address. */
 	li t1, WDOG_BASE

--- a/soc/riscv/riscv-privilege/common/idle.c
+++ b/soc/riscv/riscv-privilege/common/idle.c
@@ -7,7 +7,7 @@
 
 #include <toolchain.h>
 #include <irq.h>
-#include <soc.h>
+#include <arch/cpu.h>
 
 #include <debug/tracing.h>
 
@@ -33,7 +33,7 @@ static ALWAYS_INLINE void riscv_idle(unsigned int key)
  */
 void arch_cpu_idle(void)
 {
-	riscv_idle(SOC_MSTATUS_IEN);
+	riscv_idle(MSTATUS_IEN);
 }
 
 /**

--- a/soc/riscv/riscv-privilege/common/soc_common.h
+++ b/soc/riscv/riscv-privilege/common/soc_common.h
@@ -20,26 +20,6 @@
 /* Exception numbers */
 #define RISCV_MACHINE_ECALL_EXP      11 /* Machine ECALL instruction */
 
-/*
- * SOC-specific MSTATUS related info
- */
-/* MSTATUS register to save/restore upon interrupt/exception/context switch */
-#define SOC_MSTATUS_REG              mstatus
-
-#define SOC_MSTATUS_IEN              (1 << 3) /* Machine Interrupt Enable bit */
-
-/* Previous Privilege Mode - Machine Mode */
-#define SOC_MSTATUS_MPP_M_MODE       (3 << 11)
-/* Interrupt Enable Bit in Previous Privilege Mode */
-#define SOC_MSTATUS_MPIE             (1 << 7)
-
-/*
- * Default MSTATUS register value to restore from stack
- * upon scheduling a thread for the first time
- */
-#define SOC_MSTATUS_DEF_RESTORE      (SOC_MSTATUS_MPP_M_MODE | SOC_MSTATUS_MPIE)
-
-
 /* SOC-specific MCAUSE bitfields */
 #ifdef CONFIG_64BIT
 /* Interrupt Mask */


### PR DESCRIPTION
This is no longer needed, since all in-tree platforms are only using
the standard mstatus formats. Remove it to avoid the complexity.

Signed-off-by: Olof Johansson <olof@lixom.net>