### PR TITLE
kconfig: Remove '# hidden' comment on ARCH_HAS_CUSTOM_BUSY_WAIT

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -515,7 +515,6 @@ config SWAP_NONATOMIC
 
 config ARCH_HAS_CUSTOM_BUSY_WAIT
 	bool
-	# hidden
 	help
 	  It's possible that an architecture port cannot or does not want to use
 	  the provided k_busy_wait(), but instead must do something custom. It must


### PR DESCRIPTION
Straggler. See commit 41713244b3 ("kconfig: Remove '# Hidden' comments
on promptless symbols").