### PR TITLE
spi: stm32: Set behavior 16bits tx in 8 bits mode optional

### DIFF
--- a/drivers/spi/Kconfig.stm32
+++ b/drivers/spi/Kconfig.stm32
@@ -30,4 +30,11 @@ config SPI_STM32_USE_HW_SS
 	help
 	  Use Slave Select pin instead of software Slave Select.
 
+config SPI_STM32_8BITS_MODE_16BITS_TX
+	bool "Allow 16bit sends in 8bit mode if possible"
+	default n
+	  help
+	  Allow 16bit sends in 8bit mode if possible in master-only mode.
+	  For example, when receiving 24bits, 16bits can be sent in one go,
+	  then 8bits in the next saving time
 endif # SPI_STM32

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -79,8 +79,9 @@ static inline void spi_stm32_shift_m8(SPI_TypeDef *spi,
 	struct spi_context *ctx = &(data->ctx);
 	u16_t tx_frame = SPI_STM32_TX_NOP;
 	u16_t rx_frame;
-	bool xfer_16;
+	bool xfer_16 = false;
 
+#ifdef CONFIG_SPI_STM32_8BITS_MODE_16BITS_TX
 	if (spi_context_tx_buf_on(ctx) && spi_context_rx_buf_on(ctx)) {
 		xfer_16 = (MIN(ctx->tx_len, ctx->rx_len) > 1) ? true : false;
 	} else if (spi_context_tx_buf_on(ctx)) {
@@ -91,6 +92,7 @@ static inline void spi_stm32_shift_m8(SPI_TypeDef *spi,
 		/* Should never get here, but place case for it anyways */
 		return;
 	}
+#endif /* CONFIG_SPI_STM32_8BITS_MODE_16BITS_TX */
 
 #if defined(CONFIG_SPI_STM32_HAS_FIFO)
 	if (xfer_16) {

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -102,14 +102,6 @@ static inline void spi_stm32_shift_m8(SPI_TypeDef *spi,
 	}
 #endif
 
-	if (xfer_16 && spi_context_tx_buf_on(ctx)) {
-		tx_frame = UNALIGNED_GET((u16_t *)(ctx->tx_buf));
-		spi_context_update_tx(ctx, 1, 2);
-	} else if (spi_context_tx_buf_on(ctx)) {
-		tx_frame = UNALIGNED_GET((u8_t *)(ctx->tx_buf));
-		spi_context_update_tx(ctx, 1, 1);
-	}
-
 	while (!ll_func_tx_is_empty(spi)) {
 		/* NOP */
 	}
@@ -125,6 +117,14 @@ static inline void spi_stm32_shift_m8(SPI_TypeDef *spi,
 		}
 	}
 #endif
+
+	if (xfer_16 && spi_context_tx_on(ctx)) {
+		tx_frame = UNALIGNED_GET((u16_t *)(ctx->tx_buf));
+		spi_context_update_tx(ctx, 1, 2);
+	} else if (spi_context_tx_on(ctx)) {
+		tx_frame = UNALIGNED_GET((u8_t *)(ctx->tx_buf));
+		spi_context_update_tx(ctx, 1, 1);
+	}
 
 	if (xfer_16) {
 		LL_SPI_TransmitData16(spi, tx_frame);
@@ -140,14 +140,14 @@ static inline void spi_stm32_shift_m8(SPI_TypeDef *spi,
 		rx_frame = LL_SPI_ReceiveData16(spi);
 		if (spi_context_rx_buf_on(ctx)) {
 			UNALIGNED_PUT(rx_frame, (u16_t *)ctx->rx_buf);
-			spi_context_update_rx(ctx, 1, 2);
 		}
+		spi_context_update_rx(ctx, 1, 2);
 	} else {
 		rx_frame = LL_SPI_ReceiveData8(spi);
 		if (spi_context_rx_buf_on(ctx)) {
 			UNALIGNED_PUT(rx_frame, (u8_t *)ctx->rx_buf);
-			spi_context_update_rx(ctx, 1, 1);
 		}
+		spi_context_update_rx(ctx, 1, 1);
 	}
 }
 
@@ -156,11 +156,6 @@ static inline void spi_stm32_shift_m16(SPI_TypeDef *spi,
 {
 	u16_t tx_frame = SPI_STM32_TX_NOP;
 	u16_t rx_frame;
-
-	if (spi_context_tx_buf_on(&data->ctx)) {
-		tx_frame = UNALIGNED_GET((u16_t *)(data->ctx.tx_buf));
-		spi_context_update_tx(&data->ctx, 2, 1);
-	}
 
 	while (!ll_func_tx_is_empty(spi)) {
 		/* NOP */
@@ -178,6 +173,11 @@ static inline void spi_stm32_shift_m16(SPI_TypeDef *spi,
 	}
 #endif
 
+	if (spi_context_tx_on(&data->ctx)) {
+		tx_frame = UNALIGNED_GET((u16_t *)(data->ctx.tx_buf));
+		spi_context_update_tx(&data->ctx, 2, 1);
+	}
+
 	LL_SPI_TransmitData16(spi, tx_frame);
 
 	while (!ll_func_rx_is_not_empty(spi)) {
@@ -188,8 +188,9 @@ static inline void spi_stm32_shift_m16(SPI_TypeDef *spi,
 
 	if (spi_context_rx_buf_on(&data->ctx)) {
 		UNALIGNED_PUT(rx_frame, (u16_t *)data->ctx.rx_buf);
-		spi_context_update_rx(&data->ctx, 2, 1);
 	}
+	spi_context_update_rx(&data->ctx, 2, 1);
+
 }
 
 /* Shift a SPI frame as slave. */


### PR DESCRIPTION
commit 9986c18
Author: Erwan Gouriou <erwan.gouriou@linaro.org>
Date:   Mon Jan 6 14:26:43 2020 +0100
```
    spi: stm32: Fixes to shift frame function refactoring
    
    Refactoring of function spi_stm32_shift_m8/16 in PR #20948 which
    introduced optional behavior "Allow 16bit sends in 8bit mode if
    possible in master-only mode" has not been done with respecting
    previous function behavior.
    
    Fix newly created functions to respect flow of previous code:
    -Do not impact spi context before tx empty condition is verified
    -Update tx context and get tx_frame under spi_context_tx_on condition
    (not spi_context_tx_buf_on condition)
    -Always update rx context after data reception, not only under
    spi_context_rx_buf_on condition
    
    Last fix is known to fix regression on some cases.
    Two first changes may be conservative and revisited individually
    later on, aim is to minimize the changes in a first iteration.
    
    Fixes #21679
    
    Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>
```

commit 514d1cb
Author: Erwan Gouriou <erwan.gouriou@linaro.org>
Date:   Mon Jan 6 09:44:13 2020 +0100
```
    spi: stm32: Set behavior 16bits tx in 8 bits mode optional
    
    Behavior of sending 16bits in 8bits mode when possible is not working
    with all slaves, as it appears.
    should be
    It should be optional and not be active by default.
    
    Fixes #21546
    Fixes #21679
    
    Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>
```