### PR TITLE
Bluetooth: Fix adv scan random addr

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -440,6 +440,7 @@ config BT_MAX_PAIRED
 config BT_CREATE_CONN_TIMEOUT
 	int "Timeout for pending LE Create Connection command in seconds"
 	default 3
+	range 1 BT_RPA_TIMEOUT if BT_PRIVACY
 	range 1 65535
 
 config BT_CONN_PARAM_UPDATE_TIMEOUT

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1978,22 +1978,11 @@ int bt_conn_get_remote_info(struct bt_conn *conn,
 	}
 }
 
-static int bt_hci_disconnect(struct bt_conn *conn, u8_t reason)
+static int conn_disconnect(struct bt_conn *conn, u8_t reason)
 {
-	struct net_buf *buf;
-	struct bt_hci_cp_disconnect *disconn;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_DISCONNECT, sizeof(*disconn));
-	if (!buf) {
-		return -ENOBUFS;
-	}
-
-	disconn = net_buf_add(buf, sizeof(*disconn));
-	disconn->handle = sys_cpu_to_le16(conn->handle);
-	disconn->reason = reason;
-
-	err = bt_hci_cmd_send(BT_HCI_OP_DISCONNECT, buf);
+	err = bt_hci_disconnect(conn->handle, reason);
 	if (err) {
 		return err;
 	}
@@ -2088,7 +2077,7 @@ int bt_conn_disconnect(struct bt_conn *conn, u8_t reason)
 
 		return 0;
 	case BT_CONN_CONNECTED:
-		return bt_hci_disconnect(conn, reason);
+		return conn_disconnect(conn, reason);
 	case BT_CONN_DISCONNECT:
 		return 0;
 	case BT_CONN_DISCONNECTED:

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2652,12 +2652,14 @@ int bt_conn_init(void)
 				continue;
 			}
 
+#if !defined(CONFIG_BT_WHITELIST)
 			if (atomic_test_bit(conn->flags,
 					    BT_CONN_AUTO_CONNECT)) {
 				/* Only the default identity is supported */
 				conn->id = BT_ID_DEFAULT;
 				bt_conn_set_state(conn, BT_CONN_CONNECT_SCAN);
 			}
+#endif /* !defined(CONFIG_BT_WHITELIST) */
 		}
 	}
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2126,6 +2126,10 @@ int bt_conn_create_auto_le(const struct bt_le_conn_param *param)
 		return -EINVAL;
 	}
 
+	if (!bt_le_scan_random_addr_check()) {
+		return -EINVAL;
+	}
+
 	conn = bt_conn_add_le(BT_ID_DEFAULT, BT_ADDR_LE_NONE);
 	if (!conn) {
 		return -ENOMEM;
@@ -2204,6 +2208,10 @@ struct bt_conn *bt_conn_create_le(const bt_addr_le_t *peer,
 		return NULL;
 	}
 
+	if (!bt_le_scan_random_addr_check()) {
+		return NULL;
+	}
+
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, peer);
 	if (conn) {
 		/* Connection object already exists.
@@ -2269,6 +2277,10 @@ int bt_le_set_auto_conn(const bt_addr_le_t *addr,
 	}
 
 	if (param && !bt_le_conn_params_valid(param)) {
+		return -EINVAL;
+	}
+
+	if (!bt_le_scan_random_addr_check()) {
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2248,6 +2248,8 @@ struct bt_conn *bt_conn_create_le(const bt_addr_le_t *peer,
 		return conn;
 	}
 #endif
+	bt_conn_set_state(conn, BT_CONN_CONNECT);
+
 	if (bt_le_direct_conn(conn)) {
 		bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
 		bt_conn_unref(conn);
@@ -2255,8 +2257,6 @@ struct bt_conn *bt_conn_create_le(const bt_addr_le_t *peer,
 		bt_le_scan_update(false);
 		return NULL;
 	}
-
-	bt_conn_set_state(conn, BT_CONN_CONNECT);
 
 	return conn;
 }

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2253,6 +2253,7 @@ struct bt_conn *bt_conn_create_le(const bt_addr_le_t *peer,
 		return conn;
 	}
 #endif
+
 	bt_conn_set_state(conn, BT_CONN_CONNECT);
 
 	if (bt_le_create_conn(conn)) {

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -607,7 +607,8 @@ static void rpa_timeout(struct k_work *work)
 	atomic_clear_bit(bt_dev.flags, BT_DEV_RPA_VALID);
 
 	/* IF no roles using the RPA is running we can stop the RPA timer */
-	if (!(atomic_test_bit(bt_dev.flags, BT_DEV_ADVERTISING) ||
+	if (!((atomic_test_bit(bt_dev.flags, BT_DEV_ADVERTISING) &&
+	       !atomic_test_bit(bt_dev.flags, BT_DEV_ADVERTISING_IDENTITY)) ||
 	      atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING) ||
 	      (atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING) &&
 	       atomic_test_bit(bt_dev.flags, BT_DEV_ACTIVE_SCAN)))) {
@@ -6172,7 +6173,8 @@ void bt_le_adv_resume(void)
 
 	bt_conn_set_state(adv_conn, BT_CONN_CONNECT_ADV);
 
-	if (IS_ENABLED(CONFIG_BT_PRIVACY)) {
+	if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
+	    !atomic_test_bit(bt_dev.flags, BT_DEV_ADVERTISING_IDENTITY)) {
 		le_set_private_addr(bt_dev.adv_id);
 	}
 

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -42,7 +42,7 @@ enum {
 	BT_DEV_ACTIVE_SCAN,
 	BT_DEV_SCAN_FILTER_DUP,
 	BT_DEV_SCAN_WL,
-	BT_DEV_AUTO_CONN,
+	BT_DEV_INITIATING,
 
 	BT_DEV_RPA_VALID,
 
@@ -187,9 +187,8 @@ bool bt_le_conn_params_valid(const struct bt_le_conn_param *param);
 
 int bt_le_scan_update(bool fast_scan);
 
-int bt_le_direct_conn(const struct bt_conn *conn);
-int bt_le_auto_conn(const struct bt_le_conn_param *conn_param);
-int bt_le_auto_conn_cancel(void);
+int bt_le_create_conn(const struct bt_conn *conn);
+int bt_le_create_conn_cancel(void);
 
 bool bt_addr_le_is_bonded(u8_t id, const bt_addr_le_t *addr);
 const bt_addr_le_t *bt_lookup_id_addr(u8_t id, const bt_addr_le_t *addr);

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -181,6 +181,8 @@ extern struct bt_dev bt_dev;
 extern const struct bt_conn_auth_cb *bt_auth;
 #endif /* CONFIG_BT_SMP || CONFIG_BT_BREDR */
 
+int bt_hci_disconnect(u16_t handle, u8_t reason);
+
 bool bt_le_conn_params_valid(const struct bt_le_conn_param *param);
 
 int bt_le_scan_update(bool fast_scan);

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -36,6 +36,7 @@ enum {
 	BT_DEV_ADVERTISING,
 	BT_DEV_ADVERTISING_NAME,
 	BT_DEV_ADVERTISING_CONNECTABLE,
+	BT_DEV_ADVERTISING_IDENTITY,
 	BT_DEV_KEEP_ADVERTISING,
 	BT_DEV_SCANNING,
 	BT_DEV_EXPLICIT_SCAN,
@@ -210,3 +211,4 @@ int bt_le_adv_start_internal(const struct bt_le_adv_param *param,
 			     const struct bt_data *sd, size_t sd_len,
 			     const bt_addr_le_t *peer);
 void bt_le_adv_resume(void);
+bool bt_le_scan_random_addr_check(void);

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -657,6 +657,8 @@ static int cmd_advertise(const struct shell *shell, size_t argc, char *argv[])
 			param.options |= BT_LE_ADV_OPT_FILTER_SCAN_REQ;
 		} else if (!strcmp(arg, "wl-conn")) {
 			param.options |= BT_LE_ADV_OPT_FILTER_CONN;
+		} else if (!strcmp(arg, "identity")) {
+			param.options |= BT_LE_ADV_OPT_USE_IDENTITY;
 		} else {
 			goto fail;
 		}
@@ -1696,8 +1698,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 #if defined(CONFIG_BT_BROADCASTER)
 	SHELL_CMD_ARG(advertise, NULL,
 		      "<type: off, on, scan, nconn> [mode: discov, non_discov] "
-		      "[whitelist: wl, wl-scan, wl-conn]",
-		      cmd_advertise, 2, 2),
+		      "[whitelist: wl, wl-scan, wl-conn] [identity]",
+		      cmd_advertise, 2, 3),
 #if defined(CONFIG_BT_PERIPHERAL)
 	SHELL_CMD_ARG(directed-adv, NULL, HELP_ADDR_LE " [mode: low]",
 		      cmd_directed_adv, 3, 1),


### PR DESCRIPTION
Handle multirole scenarios where multiple roles might use the same random address
in the controller, but using different identities.

Handle scanner active at RPA timeout:
Fix RPA timeout handling when the scanner is active. An active scanner
must be restarted at RPA timeout otherwise the Set Random Address
command will fail.

Handle starting roles with different random address:
Handle starting of advertiser and scanner or initiator when advertiser
is using a different identity than the default identity to generate the
random resolvable address in the controller.
We need to handle this only for the privacy case because the random
address is set in the RPA timeout handler and not from the API.
When privacy is disabled we can return error code from the LE Set Random
Address HCI command instead.

Handle initiator at RPA timeout:
Handle initiator role when RPA timeout expires. For direct connect
establishment procedure we make sure the RPA is refreshed when starting
initiator and limit the timeout to the RPA timeout.
For auto establishment procedure we cancel the initiator and restart it
again in the connection complete event that is generated when canceling
an initiator.

Handle advertiser with Identity switches to RPA
Fix advertiser requested to use the identity address while privacy
feature is enabled will change to using RPA address when advertise is
resumed or when RPA timeout occurred.
RPA timeout does not need to run when advertiser is using identity.