### PR TITLE
Bluetooth: host: Use direct connection if not host resolving list

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2214,9 +2214,24 @@ struct bt_conn *bt_conn_create_le(const bt_addr_le_t *peer,
 start_scan:
 	bt_conn_set_param_le(conn, param);
 
-	bt_conn_set_state(conn, BT_CONN_CONNECT_SCAN);
+#if defined(CONFIG_BT_SMP)
+	if (!bt_dev.le.rl_size || bt_dev.le.rl_entries > bt_dev.le.rl_size) {
+		bt_conn_set_state(conn, BT_CONN_CONNECT_SCAN);
 
-	bt_le_scan_update(true);
+		bt_le_scan_update(true);
+
+		return conn;
+	}
+#endif
+	if (bt_le_direct_conn(conn)) {
+		bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
+		bt_conn_unref(conn);
+
+		bt_le_scan_update(false);
+		return NULL;
+	}
+
+	bt_conn_set_state(conn, BT_CONN_CONNECT);
 
 	return conn;
 }

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -813,8 +813,7 @@ int bt_le_auto_conn_cancel(void)
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_CREATE_CONN_CANCEL, buf, NULL);
 }
 #endif /* defined(CONFIG_BT_WHITELIST) */
-
-static int hci_le_create_conn(const struct bt_conn *conn)
+int bt_le_direct_conn(const struct bt_conn *conn)
 {
 	struct net_buf *buf;
 	struct bt_hci_cp_le_create_conn *cp;
@@ -1634,7 +1633,7 @@ static void check_pending_conn(const bt_addr_le_t *id_addr,
 	}
 
 	bt_addr_le_copy(&conn->le.resp_addr, addr);
-	if (hci_le_create_conn(conn)) {
+	if (bt_le_direct_conn(conn)) {
 		goto failed;
 	}
 

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -185,6 +185,7 @@ bool bt_le_conn_params_valid(const struct bt_le_conn_param *param);
 
 int bt_le_scan_update(bool fast_scan);
 
+int bt_le_direct_conn(const struct bt_conn *conn);
 int bt_le_auto_conn(const struct bt_le_conn_param *conn_param);
 int bt_le_auto_conn_cancel(void);
 


### PR DESCRIPTION
Start initiator immediately instead of scanning for device first.
If the host resolving list is used we need to go via scanner to resolve
the address.

Fixes: #20698