### PR TITLE
[topic-gpio] drivers: hmc5883l: update to new GPIO API

### DIFF
--- a/drivers/sensor/hmc5883l/hmc5883l_trigger.c
+++ b/drivers/sensor/hmc5883l/hmc5883l_trigger.c
@@ -23,8 +23,9 @@ int hmc5883l_trigger_set(struct device *dev,
 
 	__ASSERT_NO_MSG(trig->type == SENSOR_TRIG_DATA_READY);
 
-	gpio_pin_disable_callback(drv_data->gpio,
-				  DT_INST_0_HONEYWELL_HMC5883L_INT_GPIOS_PIN);
+	gpio_pin_interrupt_configure(drv_data->gpio,
+				     DT_INST_0_HONEYWELL_HMC5883L_INT_GPIOS_PIN,
+				     GPIO_INT_DISABLE);
 
 	drv_data->data_ready_handler = handler;
 	if (handler == NULL) {
@@ -33,8 +34,9 @@ int hmc5883l_trigger_set(struct device *dev,
 
 	drv_data->data_ready_trigger = *trig;
 
-	gpio_pin_enable_callback(drv_data->gpio,
-				 DT_INST_0_HONEYWELL_HMC5883L_INT_GPIOS_PIN);
+	gpio_pin_interrupt_configure(drv_data->gpio,
+				     DT_INST_0_HONEYWELL_HMC5883L_INT_GPIOS_PIN,
+				     GPIO_INT_EDGE_TO_ACTIVE);
 
 	return 0;
 }
@@ -47,8 +49,9 @@ static void hmc5883l_gpio_callback(struct device *dev,
 
 	ARG_UNUSED(pins);
 
-	gpio_pin_disable_callback(dev,
-				  DT_INST_0_HONEYWELL_HMC5883L_INT_GPIOS_PIN);
+	gpio_pin_interrupt_configure(dev,
+				     DT_INST_0_HONEYWELL_HMC5883L_INT_GPIOS_PIN,
+				     GPIO_INT_DISABLE);
 
 #if defined(CONFIG_HMC5883L_TRIGGER_OWN_THREAD)
 	k_sem_give(&drv_data->gpio_sem);
@@ -67,8 +70,9 @@ static void hmc5883l_thread_cb(void *arg)
 					     &drv_data->data_ready_trigger);
 	}
 
-	gpio_pin_enable_callback(drv_data->gpio,
-				 DT_INST_0_HONEYWELL_HMC5883L_INT_GPIOS_PIN);
+	gpio_pin_interrupt_configure(drv_data->gpio,
+				     DT_INST_0_HONEYWELL_HMC5883L_INT_GPIOS_PIN,
+				     GPIO_INT_EDGE_TO_ACTIVE);
 }
 
 #ifdef CONFIG_HMC5883L_TRIGGER_OWN_THREAD
@@ -111,8 +115,8 @@ int hmc5883l_init_interrupt(struct device *dev)
 
 	gpio_pin_configure(drv_data->gpio,
 			   DT_INST_0_HONEYWELL_HMC5883L_INT_GPIOS_PIN,
-			   GPIO_DIR_IN | GPIO_INT | GPIO_INT_EDGE |
-			   GPIO_INT_ACTIVE_LOW | GPIO_INT_DEBOUNCE);
+			   GPIO_INPUT |
+			   DT_INST_0_HONEYWELL_HMC5883L_INT_GPIOS_FLAGS);
 
 	gpio_init_callback(&drv_data->gpio_cb,
 			   hmc5883l_gpio_callback,
@@ -136,8 +140,9 @@ int hmc5883l_init_interrupt(struct device *dev)
 	drv_data->dev = dev;
 #endif
 
-	gpio_pin_enable_callback(drv_data->gpio,
-				 DT_INST_0_HONEYWELL_HMC5883L_INT_GPIOS_PIN);
+	gpio_pin_interrupt_configure(drv_data->gpio,
+				     DT_INST_0_HONEYWELL_HMC5883L_INT_GPIOS_PIN,
+				     GPIO_INT_EDGE_TO_ACTIVE);
 
 	return 0;
 }

--- a/dts/bindings/sensor/honeywell,hmc5883l.yaml
+++ b/dts/bindings/sensor/honeywell,hmc5883l.yaml
@@ -11,3 +11,8 @@ properties:
     int-gpios:
       type: phandle-array
       required: false
+      description: DRDY pin
+
+        This pin is active low, with an internal pullup in the sensor.
+        The property value should ensure the flags properly describe
+        the signal that is presented to the driver.

--- a/samples/sensor/hmc5883l/boards/frdm_k64f.overlay
+++ b/samples/sensor/hmc5883l/boards/frdm_k64f.overlay
@@ -8,7 +8,7 @@
 	hmc5883l@1e {
 		compatible = "honeywell,hmc5883l";
 		reg = <0x1E>;
-		int-gpios = <&gpioc 12 0>;
+		int-gpios = <&gpioc 12 GPIO_ACTIVE_LOW>;
 		label = "HMC5883L";
 	};
 };


### PR DESCRIPTION
This commit updates the HMC5883L driver to use the new GPIO API.

Tested on frdm_k64f.

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>