### PR TITLE
doc: add ZEPHYR_DOXYGEN to doxyfile PREDEFINED

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1959,8 +1959,14 @@ INCLUDE_FILE_PATTERNS  =
 # is assumed. To prevent a macro definition from being undefined via #undef or
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
+#
+# Zephyr users: please avoid pre-defining additional CONFIG_ options
+# here. If you need some text that's guarded by preprocessor macros to
+# show up in Doxygen, test whether the ZEPHYR_DOXYGEN macro is defined
+# instead.
 
-PREDEFINED             = "CONFIG_SYS_CLOCK_EXISTS=y" \
+PREDEFINED             = "ZEPHYR_DOXYGEN=1" \
+                         "CONFIG_SYS_CLOCK_EXISTS=y" \
                          "CONFIG_THREAD_MONITOR=y" \
                          "CONFIG_SCHED_CPU_MASK=y" \
                          "CONFIG_SCHED_DEADLINE=y" \


### PR DESCRIPTION
This PR relates to https://github.com/zephyrproject-rtos/zephyr/pull/21090/files#r362927696

It's a commonplace in Zephyr code that docstrings for functions are
inside preprocessor conditional statements. One undesirable effect of
this is that those docstrings aren't discovered by doxygen itself, and
are thus unavailable to our .rst pages, unless doxygen believes the
conditionals evaluate to true.

Doxygen provides a PREDEFINED configuration option in its doxyfile
format to handle situations like this: this option forces doxygen to
consider certain macros defined to configurable values.

Up to now, Zephyr has been adding CONFIG options to this list in a
peacemeal way to handle doxygen problems as they occur.

A cleaner way to handle this is just to include ZEPHYR_DOXYGEN=1 in
PREDEFINED, so that C files can just make sure doxygen doc strings are
always specified when that is true.
