### PR TITLE
libc: newlib: Enable extensions

### DIFF
--- a/lib/libc/newlib/CMakeLists.txt
+++ b/lib/libc/newlib/CMakeLists.txt
@@ -26,6 +26,11 @@ if(LIBC_LIBRARY_DIR)
   set(LIBC_LIBRARY_DIR_FLAG -L${LIBC_LIBRARY_DIR})
 endif()
 
+# Enable extensions support in the newlib. This is required to allow the use
+# of various de facto standard functions, such as `strnlen`.
+zephyr_compile_definitions(_POSIX_C_SOURCE=200809)
+zephyr_compile_definitions(_XOPEN_SOURCE=700)
+
 # define __LINUX_ERRNO_EXTENSIONS__ so we get errno defines like -ESHUTDOWN
 # used by the network stack
 zephyr_compile_definitions(__LINUX_ERRNO_EXTENSIONS__)


### PR DESCRIPTION
This commit enables the following newlib extensions to allow the use
of various de facto standard functions:

* POSIX.1-2008 (_POSIX_C_SOURCE=200809)
* SUSv4; POSIX.1-2008 plus XSI (_XOPEN_SOURCE=700)

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>