### PR TITLE
drivers: watchdog: fix system call handlers build

### DIFF
--- a/drivers/watchdog/CMakeLists.txt
+++ b/drivers/watchdog/CMakeLists.txt
@@ -10,3 +10,5 @@ zephyr_sources_ifdef(CONFIG_WDT_NRFX wdt_nrfx.c)
 zephyr_sources_ifdef(CONFIG_WDT_MCUX_WDOG wdt_mcux_wdog.c)
 zephyr_sources_ifdef(CONFIG_WDT_MCUX_WDOG32 wdt_mcux_wdog32.c)
 zephyr_sources_ifdef(CONFIG_WDT_XEC wdt_mchp_xec.c)
+
+zephyr_sources_ifdef(CONFIG_USERSPACE wdt_handlers.c)

--- a/drivers/watchdog/wdt_handlers.c
+++ b/drivers/watchdog/wdt_handlers.c
@@ -9,24 +9,24 @@
 
 static inline int z_vrfy_wdt_setup(struct device *dev, u8_t options)
 {
-	Z_OOPS(Z_SYSCALL_DRIVER_WDT(dev, wdt_setup));
+	Z_OOPS(Z_SYSCALL_DRIVER_WDT(dev, setup));
 	return z_impl_wdt_setup(dev, options);
 }
 
-#include <syscalls/wdt_setup.c>
+#include <syscalls/wdt_setup_mrsh.c>
 
 static inline int z_vrfy_wdt_disable(struct device *dev)
 {
-	Z_OOPS(Z_SYSCALL_DRIVER_WDT(dev, wdt_disable));
+	Z_OOPS(Z_SYSCALL_DRIVER_WDT(dev, disable));
 	return z_impl_wdt_disable(dev);
 }
 
-#include <syscalls/wdt_disable.c>
+#include <syscalls/wdt_disable_mrsh.c>
 
-static inline int z_vrfy_wdt_feed(struct device *dev)
+static inline int z_vrfy_wdt_feed(struct device *dev, int channel_id)
 {
-	Z_OOPS(Z_SYSCALL_DRIVER_WDT(dev, wdt_feed));
-	return z_impl_wdt_feed(dev);
+	Z_OOPS(Z_SYSCALL_DRIVER_WDT(dev, feed));
+	return z_impl_wdt_feed(dev, channel_id);
 }
 
-#include <syscalls/wdt_feed.c>
+#include <syscalls/wdt_feed_mrsh.c>


### PR DESCRIPTION
A directive to compile the system call handlers for the
watchdog subsystem was omitted from CMakeLists.txt, causing
the handlers not to be compiled and some issues in the C
file undetected.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>