### PR TITLE
Modify the max thread number according to CONFIG_MAX_THREAD_BYTES in gen_kobject_list.py.

### DIFF
--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -375,10 +375,10 @@ def main():
                              % args.kernel)
 
         thread_counter = eh.get_thread_counter()
-        if thread_counter > max_threads:
+        if thread_counter >= max_threads:
             sys.exit("Too many thread objects ({})\n"
                      "Increase CONFIG_MAX_THREAD_BYTES to {}"
-                     .format(thread_counter, -(-thread_counter // 8)))
+                     .format(thread_counter, -(-(thread_counter+1) // 8)))
 
         with open(args.gperf_output, "w") as fp:
             write_gperf_table(fp, eh, objs,


### PR DESCRIPTION
if the created threads' number just equal to the number
set by the CONFIG_MAX_THREAD_BYTES, then each thread will
map a bit in _thread_idx_map array, the generated
_thread_idx_map will all be zero, it will be alocated to
bss section as a zero initialized object in zephyr.elf,
not the kobject_data section in zephyr_prebuilt.elf,
this will cause the address shift between
zephyr_prebuilt.elf and zephyr.elf, so we can't find the
correct thread using z_object_find function.

for example, if the CONFIG_MAX_THREAD_BYTES=4, and we creates 32 threads dynamically totally,
then in scripts/gen_kobject_list.py,  for each thread, it will map a bit index in thread_idx_map, then the generated array _thread_idx_map is [0x0, 0x0, 0x, 0x0].
so in the finally generate file kobject_hash.c , the thread_idx_map array is [0x0, 0x0, 0x0, 0x0],  it's allocated to bss section because it's a zero initialized object.

So i modify the gen_kobject_list.py to report this error in build process when the created threads'numer just equal  to the number set by the CONFIG_MAX_THREAD_BYTES,  it will warn that to increase the CONFIG_MAX_THREAD_BYTES(+1), then the generated _thread_idx_map will be [0x0, 0x0, ..., 0x0, 0xFF], it won't be allocated to bss section again, then build and run this test again, it will be good.

Signed-off-by: peng1 chen <peng1.chen@intel.com>