### PR TITLE
shields: ssd1306: add support for SH1106 based 128x64 display

### DIFF
--- a/boards/shields/ssd1306/Kconfig.defconfig
+++ b/boards/shields/ssd1306/Kconfig.defconfig
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-if SHIELD_SSD1306_128X64 || SHIELD_SSD1306_128X32
+if SHIELD_SSD1306_128X64 || SHIELD_SSD1306_128X32 || SHIELD_SH1106_128X64
 
 if DISPLAY
 
@@ -10,6 +10,10 @@ config I2C
 
 config SSD1306
 	default y
+
+choice SSD1306_CONTROLLER_TYPE
+	default SSD1306_SH1106_COMPATIBLE if SHIELD_SH1106_128X64
+endchoice
 
 if LVGL
 
@@ -20,13 +24,14 @@ config LVGL_HOR_RES
 	default 128
 
 config LVGL_VER_RES
-	default 64 if SHIELD_SSD1306_128X64
 	default 32 if SHIELD_SSD1306_128X32
+	default 64
 
 config LVGL_VDB_SIZE
 	default 64
 
 config LVGL_DPI
+	default 116 if SHIELD_SH1106_128X64
 	default 148
 
 config LVGL_BITS_PER_PIXEL

--- a/boards/shields/ssd1306/Kconfig.shield
+++ b/boards/shields/ssd1306/Kconfig.shield
@@ -6,3 +6,6 @@ config SHIELD_SSD1306_128X32
 
 config SHIELD_SSD1306_128X64
 	def_bool $(shields_list_contains,ssd1306_128x64)
+
+config SHIELD_SH1106_128X64
+	def_bool $(shields_list_contains,sh1106_128x64)

--- a/boards/shields/ssd1306/doc/index.rst
+++ b/boards/shields/ssd1306/doc/index.rst
@@ -11,6 +11,23 @@ based on SSD1306 controller. These displays have an I2C interface and
 usually only four pins: GND, VCC, SCL and SDA. Display pins can be
 connected to the pin header of a board using jumper wires.
 
+Current supported displays
+==========================
+
++---------------------+---------------------+---------------------+
+| Display             | Controller /        | Shield Designation  |
+|                     | Driver              |                     |
++=====================+=====================+=====================+
+| No Name             | SSD1306 /           | ssd1306_128x64      |
+| 128x64 pixel        | ssd1306             |                     |
++---------------------+---------------------+---------------------+
+| No Name             | SSD1306 /           | ssd1306_128x32      |
+| 128x32 pixel        | ssd1306             |                     |
++---------------------+---------------------+---------------------+
+| No Name             | SH1106 /            | sh1106_128x64       |
+| 128x64 pixel        | ssd1306             |                     |
++---------------------+---------------------+---------------------+
+
 Requirements
 ************
 

--- a/boards/shields/ssd1306/sh1106_128x64.overlay
+++ b/boards/shields/ssd1306/sh1106_128x64.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2019 PHYTEC Messtechnik GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&arduino_i2c {
+	status = "ok";
+
+	ssd1306@3c {
+		compatible = "solomon,ssd1306fb";
+		reg = <0x3c>;
+		label = "SSD1306";
+		width = <128>;
+		height = <64>;
+		segment-offset = <2>;
+		page-offset = <0>;
+		display-offset = <0>;
+		multiplex-ratio = <63>;
+		segment-remap;
+		com-invdir;
+		prechargep = <0x22>;
+	};
+};

--- a/drivers/display/Kconfig.ssd1306
+++ b/drivers/display/Kconfig.ssd1306
@@ -18,7 +18,7 @@ config SSD1306_DEFAULT_CONTRAST
 	help
 	  SSD16XX default contrast.
 
-choice
+choice SSD1306_CONTROLLER_TYPE
 	prompt "Display controller type"
 	default SSD1306_DEFAULT
 	help

--- a/drivers/display/ssd1306.c
+++ b/drivers/display/ssd1306.c
@@ -40,12 +40,6 @@ LOG_MODULE_REGISTER(ssd1306, CONFIG_DISPLAY_LOG_LEVEL);
 #define SSD1306_PANEL_VCOM_DESEL_LEVEL	0x20
 #define SSD1306_PANEL_PUMP_VOLTAGE	SSD1306_SET_PUMP_VOLTAGE_90
 
-#if defined(CONFIG_SSD1306_SH1106_COMPATIBLE)
-#define SSD1306_PANEL_NUMOF_COLUMS	132
-#else
-#define SSD1306_PANEL_NUMOF_COLUMS	128
-#endif
-
 #ifndef SSD1306_ADDRESSING_MODE
 #define SSD1306_ADDRESSING_MODE		(SSD1306_SET_MEM_ADDRESSING_HORIZONTAL)
 #endif
@@ -185,48 +179,11 @@ static int ssd1306_suspend(const struct device *dev)
 				 SSD1306_DISPLAY_OFF);
 }
 
-#if defined(CONFIG_SSD1306_SH1106_COMPATIBLE)
-static int ssd1306_write_page(const struct device *dev, u8_t page,
-			      void const *data, size_t length)
-{
-	struct ssd1306_data *driver = dev->driver_data;
-	u8_t cmd_buf[] = {
-		SSD1306_CONTROL_BYTE_CMD,
-		SSD1306_SET_LOWER_COL_ADDRESS |
-		(DT_INST_0_SOLOMON_SSD1306FB_SEGMENT_OFFSET &
-		 SSD1306_SET_LOWER_COL_ADDRESS_MASK),
-		SSD1306_CONTROL_BYTE_CMD,
-		SSD1306_SET_HIGHER_COL_ADDRESS |
-		((DT_INST_0_SOLOMON_SSD1306FB_SEGMENT_OFFSET  >> 4) &
-		 SSD1306_SET_LOWER_COL_ADDRESS_MASK),
-		SSD1306_CONTROL_LAST_BYTE_CMD,
-		SSD1306_SET_PAGE_START_ADDRESS | page
-	};
-
-	if (page >= SSD1306_PANEL_NUMOF_PAGES) {
-		return -1;
-	}
-
-	if (length > SSD1306_PANEL_NUMOF_COLUMS) {
-		return -1;
-	}
-
-	if (i2c_write(driver->i2c, cmd_buf, sizeof(cmd_buf),
-		      DT_INST_0_SOLOMON_SSD1306FB_BASE_ADDRESS)) {
-		return -1;
-	}
-
-	return i2c_burst_write(driver->i2c,
-			       DT_INST_0_SOLOMON_SSD1306FB_BASE_ADDRESS,
-			       SSD1306_CONTROL_LAST_BYTE_DATA,
-			       data, length);
-}
-#endif
-
 static int ssd1306_write(const struct device *dev, const u16_t x, const u16_t y,
 			 const struct display_buffer_descriptor *desc,
 			 const void *buf)
 {
+	struct ssd1306_data *driver = dev->driver_data;
 	size_t buf_len;
 
 	if (desc->pitch < desc->width) {
@@ -245,14 +202,15 @@ static int ssd1306_write(const struct device *dev, const u16_t x, const u16_t y,
 		return -1;
 	}
 
-#if defined(CONFIG_SSD1306_DEFAULT)
-	struct ssd1306_data *driver = dev->driver_data;
-
 	if ((y & 0x7) != 0U) {
 		LOG_ERR("Unsupported origin");
 		return -1;
 	}
 
+	LOG_DBG("x %u, y %u, pitch %u, width %u, height %u, buf_len %u",
+		x, y, desc->pitch, desc->width, desc->height, buf_len);
+
+#if defined(CONFIG_SSD1306_DEFAULT)
 	u8_t cmd_buf[] = {
 		SSD1306_CONTROL_BYTE_CMD,
 		SSD1306_SET_MEM_ADDRESSING_MODE,
@@ -284,22 +242,41 @@ static int ssd1306_write(const struct device *dev, const u16_t x, const u16_t y,
 			       (u8_t *)buf, buf_len);
 
 #elif defined(CONFIG_SSD1306_SH1106_COMPATIBLE)
-	if (x != 0U && y != 0U) {
-		LOG_ERR("Unsupported origin");
-		return -1;
-	}
+	u8_t x_offset = x + DT_INST_0_SOLOMON_SSD1306FB_SEGMENT_OFFSET;
+	u8_t cmd_buf[] = {
+		SSD1306_CONTROL_BYTE_CMD,
+		SSD1306_SET_LOWER_COL_ADDRESS |
+			(x_offset & SSD1306_SET_LOWER_COL_ADDRESS_MASK),
+		SSD1306_CONTROL_BYTE_CMD,
+		SSD1306_SET_HIGHER_COL_ADDRESS |
+			((x_offset >> 4) & SSD1306_SET_LOWER_COL_ADDRESS_MASK),
+		SSD1306_CONTROL_LAST_BYTE_CMD,
+		SSD1306_SET_PAGE_START_ADDRESS | (y / 8)
+	};
+	u8_t *buf_ptr = (u8_t *)buf;
 
-	if (desc->buf_size !=
-	    (SSD1306_PANEL_NUMOF_PAGES * DT_INST_0_SOLOMON_SSD1306FB_WIDTH)) {
-		return -1;
-	}
+	for (u8_t n = 0; n < desc->height / 8; n++) {
+		cmd_buf[sizeof(cmd_buf) - 1] =
+			SSD1306_SET_PAGE_START_ADDRESS | (n + (y / 8));
+		LOG_HEXDUMP_DBG(cmd_buf, sizeof(cmd_buf), "cmd_buf");
 
-	for (size_t pidx = 0; pidx < SSD1306_PANEL_NUMOF_PAGES; pidx++) {
-		if (ssd1306_write_page(dev, pidx, buf,
-		    DT_INST_0_SOLOMON_SSD1306FB_WIDTH)) {
+		if (i2c_write(driver->i2c, cmd_buf, sizeof(cmd_buf),
+			      DT_INST_0_SOLOMON_SSD1306FB_BASE_ADDRESS)) {
 			return -1;
 		}
-		buf = (u8_t *)buf + DT_INST_0_SOLOMON_SSD1306FB_WIDTH;
+
+		if (i2c_burst_write(driver->i2c,
+				    DT_INST_0_SOLOMON_SSD1306FB_BASE_ADDRESS,
+				    SSD1306_CONTROL_LAST_BYTE_DATA,
+				    buf_ptr, desc->width)) {
+			return -1;
+		}
+
+		buf_ptr = buf_ptr + desc->width;
+		if (buf_ptr > ((u8_t *)buf + buf_len)) {
+			LOG_ERR("Exceeded buffer length");
+			return -1;
+		}
 	}
 #endif
 


### PR DESCRIPTION
Add support for SH1106 based 128x64 display.
~~WIP/Draft~~
~~Works with cfb but not with lvgl, some rework of the ssd1306 driver is necessary.~~