### PR TITLE
Bluetooth: controller: Fix bug in LE create conn with filter policy

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -423,12 +423,14 @@ void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 {
 	u32_t conn_offset_us, conn_interval_us;
 	u8_t ticker_id_scan, ticker_id_conn;
+	u8_t peer_addr[BDADDR_SIZE];
 	u32_t ticks_slot_overhead;
 	u32_t ticks_slot_offset;
 	struct ll_scan_set *scan;
 	struct node_rx_cc *cc;
 	struct ll_conn *conn;
 	struct pdu_adv *pdu_tx;
+	u8_t peer_addr_type;
 	u32_t ticker_status;
 	u8_t chan_sel;
 
@@ -442,12 +444,12 @@ void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	u8_t own_addr_type = pdu_tx->tx_addr;
 	u8_t own_addr[BDADDR_SIZE];
-	u8_t peer_addr[BDADDR_SIZE];
 	u8_t rl_idx = ftr->rl_idx;
 
 	memcpy(own_addr, &pdu_tx->connect_ind.init_addr[0], BDADDR_SIZE);
-	memcpy(peer_addr, &pdu_tx->connect_ind.adv_addr[0], BDADDR_SIZE);
 #endif
+	peer_addr_type = pdu_tx->rx_addr;
+	memcpy(peer_addr, &pdu_tx->connect_ind.adv_addr[0], BDADDR_SIZE);
 
 	/* This is the chan sel bit from the received adv pdu */
 	chan_sel = pdu_tx->chan_sel;
@@ -475,8 +477,8 @@ void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 #else
 	if (1) {
 #endif /* CONFIG_BT_CTLR_PRIVACY */
-		cc->peer_addr_type = scan->lll.adv_addr_type;
-		memcpy(cc->peer_addr, scan->lll.adv_addr, BDADDR_SIZE);
+		cc->peer_addr_type = peer_addr_type;
+		memcpy(cc->peer_addr, &peer_addr[0], BDADDR_SIZE);
 	}
 
 	cc->interval = lll->interval;


### PR DESCRIPTION
Fix bug when connecting using whitelist and split controller.
The peer address was set to an all zeroes address.

Bug using shell:
bt init
bt wl-add <addr>
bt wl-connect on
Connected: 00:00:00:00:00:00 (public)

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>