### PR TITLE
Bluetooth: controller: Make BT_CTLR_DTM directly selectable

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -482,7 +482,7 @@ config BT_ADV_SET
 	  Maximum supported advertising sets.
 
 config BT_CTLR_DTM
-	bool
+	bool "Direct Test Mode"
 	help
 	  Enable support for Direct Test Mode in the Controller.
 


### PR DESCRIPTION
There is no code dependency on BT_CTLR_DTM_HCI for direct test
mode. Make BT_CTLR_DTM directly selectable to avoid building
unnecessary code.

Somewhat related issue: #4120

Signed-off-by: Jacob Siverskog <jacob@teenage.engineering>