### PR TITLE
reel_board: enable SPI and display controller driver by default

### DIFF
--- a/boards/arm/reel_board/Kconfig.defconfig
+++ b/boards/arm/reel_board/Kconfig.defconfig
@@ -84,4 +84,11 @@ config BT_CTLR
 
 endif # BT
 
+if DISPLAY
+
+config SSD16XX
+	default y
+
+endif #DISPLAY
+
 endif # BOARD_REEL_BOARD || BOARD_REEL_BOARD_V2

--- a/boards/arm/reel_board/reel_board_defconfig
+++ b/boards/arm/reel_board/reel_board_defconfig
@@ -11,6 +11,9 @@ CONFIG_ARM_MPU=y
 # enable GPIO
 CONFIG_GPIO=y
 
+# enable SPI
+CONFIG_SPI=y
+
 # enable uart driver
 CONFIG_SERIAL=y
 CONFIG_UART_0_NRF_UART=y

--- a/boards/arm/reel_board/reel_board_v2_defconfig
+++ b/boards/arm/reel_board/reel_board_v2_defconfig
@@ -11,6 +11,9 @@ CONFIG_ARM_MPU=y
 # enable GPIO
 CONFIG_GPIO=y
 
+# enable SPI
+CONFIG_SPI=y
+
 # enable uart driver
 CONFIG_SERIAL=y
 CONFIG_UART_0_NRF_UART=y


### PR DESCRIPTION
Enable SPI and display controller driver by default.