### PR TITLE
kernel/sched: Move thread suspend and abort under the scheduler lock

### DIFF
--- a/kernel/thread_abort.c
+++ b/kernel/thread_abort.c
@@ -27,16 +27,6 @@ extern void z_thread_single_abort(struct k_thread *thread);
 #if !defined(CONFIG_ARCH_HAS_THREAD_ABORT)
 void z_impl_k_thread_abort(k_tid_t thread)
 {
-	/* We aren't trying to synchronize data access here (these
-	 * APIs are internally synchronized).  The original lock seems
-	 * to have been in place to prevent the thread from waking up
-	 * due to a delivered interrupt.  Leave a dummy spinlock in
-	 * place to do that.  This API should be revisted though, it
-	 * doesn't look SMP-safe as it stands.
-	 */
-	struct k_spinlock lock = {};
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
 	__ASSERT((thread->base.user_options & K_ESSENTIAL) == 0U,
 		 "essential thread aborted");
 
@@ -44,7 +34,13 @@ void z_impl_k_thread_abort(k_tid_t thread)
 	z_thread_monitor_exit(thread);
 
 	if (thread == _current && !arch_is_in_isr()) {
-		z_swap(&lock, key);
+		/* Direct use of swap: reschedule doesn't have a test
+		 * for "is _current dead" and we don't want one for
+		 * performance reasons.
+		 */
+		struct k_spinlock lock = {};
+
+		z_swap(&lock, k_spin_lock(&lock));
 	} else {
 		/* Really, there's no good reason for this to be a
 		 * scheduling point if we aren't aborting _current (by
@@ -54,7 +50,7 @@ void z_impl_k_thread_abort(k_tid_t thread)
 		 * rely on k_thread_abort() scheduling out of
 		 * cooperative threads.
 		 */
-		z_reschedule(&lock, key);
+		z_reschedule_unlocked();
 	}
 }
 #endif


### PR DESCRIPTION
Historically, these routines were placed in thread.c and would use the
scheduler via exported, synchronized functions (e.g. "remove from
ready queue").  But those steps were very fine grained, and there were
races where the thread could be seen by other contexts (in particular
under SMP) in an intermediate state.  It's not completely clear to me
that any of these were fatal bugs, but it's very hard to prove they
weren't.

At best, this is fragile.  Move the z_thread_single_suspend/abort()
functions into the scheduler and do the scheduler logic in a single
critical section.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>