### PR TITLE
drivers: ieee802154: rf2xx: Fix missing auto ACKs

### DIFF
--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -211,6 +211,14 @@ static void rf2xx_thread_main(void *arg)
 			k_timer_start(&ctx->trx_isr_timeout, K_MSEC(10), 0);
 		} else if (isr_status & (1 << RF2XX_TRX_END)) {
 			if (ctx->trx_state == RF2XX_TRX_PHY_BUSY_RX) {
+				/* Ensures that automatically ACK will be sent
+				 * when requested
+				 */
+				while (rf2xx_iface_reg_read(dev,
+							    RF2XX_TRX_STATUS_REG) ==
+				       RF2XX_TRX_PHY_STATUS_BUSY_RX_AACK) {
+				};
+
 				/* Set PLL_ON to avoid transceiver receive
 				 * new data until finish reading process
 				 */


### PR DESCRIPTION
The RF2XX driver not always sent ACK when a RX frame requests. This happen because RF2XX transceiver asserts TRX_END interrupt after confirm that the FCS is valid. The driver can now decode the frame but in parallel the radio still processing the ACK frame. This will sync the radio FSM state to ensure that ACK will be send.

Fixes #21659

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>