### PR TITLE
drivers: espi: xec: Add support for eSPI OOB channel operations

### DIFF
--- a/drivers/espi/espi_mchp_xec.c
+++ b/drivers/espi/espi_mchp_xec.c
@@ -34,6 +34,10 @@
 #define ESPI_XEC_PORT80_BAR_ADDRESS 0x00800000
 #define ESPI_XEC_PORT81_BAR_ADDRESS 0x00810000
 
+#define MAX_OOB_BUFFER_SIZE         128
+/* 1s */
+#define MAX_OOB_TIMEOUT             1000
+
 LOG_MODULE_REGISTER(espi, CONFIG_ESPI_LOG_LEVEL);
 
 struct espi_isr {
@@ -50,6 +54,8 @@ struct espi_xec_config {
 
 struct espi_xec_data {
 	sys_slist_t callbacks;
+	struct k_sem tx_lock;
+	struct k_sem rx_lock;
 	u8_t plt_rst_asserted;
 	u8_t espi_rst_asserted;
 	u8_t sx_state;
@@ -178,6 +184,9 @@ static const struct xec_signal vw_tbl[] = {
 	[ESPI_VWIRE_SIGNAL_DNX_WARN]      = {MCHP_MSVW08, ESPI_VWIRE_SRC_ID1,
 					     ESPI_MASTER_TO_SLAVE},
 };
+
+static u32_t slave_rx_mem[MAX_OOB_BUFFER_SIZE];
+static u32_t slave_tx_mem[MAX_OOB_BUFFER_SIZE];
 
 static int espi_xec_configure(struct device *dev, struct espi_cfg *cfg)
 {
@@ -397,6 +406,81 @@ static int espi_xec_receive_vwire(struct device *dev,
 	return 0;
 }
 
+static int espi_xec_send_oob(struct device *dev, struct espi_oob_packet pckt)
+{
+	int ret;
+	struct espi_xec_data *data = (struct espi_xec_data *)(dev->driver_data);
+	u8_t err_mask = MCHP_ESPI_OOB_TX_STS_IBERR |
+			MCHP_ESPI_OOB_TX_STS_OVRUN |
+			MCHP_ESPI_OOB_TX_STS_BADREQ;
+
+	LOG_DBG("%s\n", __func__);
+
+	if (!(ESPI_OOB_REGS->TX_STS & MCHP_ESPI_OOB_TX_STS_CHEN)) {
+		LOG_WRN("OOB channel is disabled\n");
+		return -EIO;
+	}
+
+	if (ESPI_OOB_REGS->TX_STS & MCHP_ESPI_OOB_TX_STS_BUSY) {
+		LOG_WRN("OOB channel is busy\n");
+		return -EBUSY;
+	}
+
+	if (pckt.len > MAX_OOB_BUFFER_SIZE) {
+		return -EINVAL;
+	}
+
+	memcpy(slave_tx_mem, pckt.buf, pckt.len);
+
+	ESPI_OOB_REGS->TX_LEN = pckt.len;
+	ESPI_OOB_REGS->TX_CTRL = MCHP_ESPI_OOB_TX_CTRL_START;
+	LOG_DBG("%s %d\n", __func__, ESPI_OOB_REGS->TX_LEN);
+
+	/* Wait until ISR or timeout */
+	ret = k_sem_take(&data->tx_lock, MAX_OOB_TIMEOUT);
+	if (ret == -EAGAIN) {
+		return -ETIMEDOUT;
+	}
+
+	if (ESPI_OOB_REGS->TX_STS & err_mask) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int espi_xec_receive_oob(struct device *dev,
+				struct espi_oob_packet pckt)
+{
+	int ret;
+	u8_t err_mask = MCHP_ESPI_OOB_RX_STS_IBERR |
+			MCHP_ESPI_OOB_RX_STS_OVRUN;
+	struct espi_xec_data *data = (struct espi_xec_data *)(dev->driver_data);
+
+	LOG_DBG("%s\n", __func__);
+
+
+	if (ESPI_OOB_REGS->TX_STS & err_mask) {
+		return -EIO;
+	}
+
+	/* Wait until ISR or timeout */
+	ret = k_sem_take(&data->rx_lock, MAX_OOB_TIMEOUT);
+	if (ret == -EAGAIN) {
+		return -ETIMEDOUT;
+	}
+
+	/* Check if buffer passed to driver can fit the received packet */
+	if (ESPI_OOB_REGS->RX_LEN > pckt.len) {
+		return -EIO;
+	}
+
+	pckt.len = ESPI_OOB_REGS->RX_LEN;
+	memcpy(pckt.buf, slave_rx_mem, pckt.len);
+
+	return 0;
+}
+
 static int espi_xec_manage_callback(struct device *dev,
 				    struct espi_callback *callback, bool set)
 {
@@ -427,15 +511,16 @@ static void espi_init_oob(struct device *dev)
 	MCHP_GIRQ_ENSET(config->bus_girq_id) = (MCHP_ESPI_OOB_UP_GIRQ_VAL |
 			MCHP_ESPI_OOB_DN_GIRQ_VAL);
 
-	ESPI_OOB_REGS->TX_ADDR_MSW = ESPI_XEC_OOB_ADDR_MSW;
-	ESPI_OOB_REGS->RX_ADDR_MSW = ESPI_XEC_OOB_ADDR_MSW;
-	ESPI_OOB_REGS->TX_ADDR_LSW = ESPI_XEC_OOB_ADDR_LSW;
-	ESPI_OOB_REGS->RX_ADDR_LSW = ESPI_XEC_OOB_ADDR_LSW;
-	ESPI_OOB_REGS->RX_LEN = (ESPI_XEC_OOB_RX_LEN &
-				 ESPI_XEC_OOB_RX_LEN_MASK);
+	ESPI_OOB_REGS->TX_ADDR_MSW = 0;
+	ESPI_OOB_REGS->RX_ADDR_MSW = 0;
+	ESPI_OOB_REGS->TX_ADDR_LSW = (u32_t)&slave_tx_mem[0];
+	ESPI_OOB_REGS->RX_ADDR_LSW = (u32_t)&slave_rx_mem[0];
+	ESPI_OOB_REGS->RX_LEN = 0x00FF0000;
+	ESPI_OOB_REGS->RX_CTRL |= MCHP_ESPI_OOB_RX_CTRL_AVAIL;
 
 	/* Enable OOB Tx channel enable change status interrupt */
 	ESPI_OOB_REGS->TX_IEN |= MCHP_ESPI_OOB_TX_IEN_CHG_EN;
+
 	ESPI_CAP_REGS->OOB_RDY = 1;
 }
 #endif
@@ -592,33 +677,37 @@ static void espi_vwire_chanel_isr(struct device *dev)
 static void espi_oob_down_isr(struct device *dev)
 {
 	u32_t status;
-
-	LOG_DBG("%s\n", __func__);
+	struct espi_xec_data *data = (struct espi_xec_data *)(dev->driver_data);
 
 	status = ESPI_OOB_REGS->RX_STS;
+
+	LOG_DBG("%s %x\n", __func__, status);
 	if (status & MCHP_ESPI_OOB_RX_STS_DONE) {
-		ESPI_OOB_REGS->RX_IEN = ~MCHP_ESPI_OOB_RX_IEN;
+		ESPI_OOB_REGS->RX_STS |= MCHP_ESPI_OOB_RX_STS_DONE;
+
+		k_sem_give(&data->rx_lock);
 	}
 }
 
 static void espi_oob_up_isr(struct device *dev)
 {
 	u32_t status;
-
-	LOG_DBG("%s\n", __func__);
+	struct espi_xec_data *data = (struct espi_xec_data *)(dev->driver_data);
 
 	status = ESPI_OOB_REGS->TX_STS;
+	LOG_DBG("%s sts:%x\n", __func__, status);
 
 	if (status & MCHP_ESPI_OOB_TX_STS_DONE) {
 		ESPI_OOB_REGS->TX_STS |= MCHP_ESPI_OOB_TX_STS_DONE;
+		k_sem_give(&data->tx_lock);
 	}
 
 	if (status & MCHP_ESPI_OOB_TX_STS_CHG_EN) {
 		if (status & MCHP_ESPI_OOB_TX_STS_CHEN) {
 			espi_init_oob(dev);
-			ESPI_OOB_REGS->TX_IEN |= MCHP_ESPI_OOB_TX_IEN_CHG_EN;
 
-			/* Re-enable interrupts */
+			ESPI_OOB_REGS->TX_IEN = MCHP_ESPI_OOB_TX_IEN_CHG_EN |
+						MCHP_ESPI_OOB_TX_IEN_DONE;
 			ESPI_OOB_REGS->RX_IEN |= MCHP_ESPI_OOB_RX_IEN;
 		}
 		ESPI_OOB_REGS->TX_STS |= MCHP_ESPI_OOB_TX_STS_CHG_EN;
@@ -873,6 +962,8 @@ static const struct espi_driver_api espi_xec_driver_api = {
 	.get_channel_status = espi_xec_channel_ready,
 	.send_vwire = espi_xec_send_vwire,
 	.receive_vwire = espi_xec_receive_vwire,
+	.send_oob = espi_xec_send_oob,
+	.receive_oob = espi_xec_receive_oob,
 	.manage_callback = espi_xec_manage_callback,
 	.read_lpc_request = espi_xec_read_lpc_request,
 	.write_lpc_request = espi_xec_write_lpc_request,
@@ -914,6 +1005,9 @@ static int espi_xec_init(struct device *dev)
 #ifdef CONFIG_ESPI_OOB_CHANNEL
 	ESPI_CAP_REGS->GLB_CAP0 |= MCHP_ESPI_GBL_CAP0_OOB_SUPP;
 	ESPI_CAP_REGS->OOB_CAP |= MCHP_ESPI_OOB_CAP_MAX_PLD_SZ_73;
+
+	k_sem_init(&data->tx_lock, 0, 1);
+	k_sem_init(&data->rx_lock, 0, 1);
 #else
 	ESPI_CAP_REGS->GLB_CAP0 &= ~MCHP_ESPI_GBL_CAP0_OOB_SUPP;
 #endif

--- a/samples/drivers/espi/src/main.c
+++ b/samples/drivers/espi/src/main.c
@@ -6,11 +6,24 @@
 
 #include <errno.h>
 #include <zephyr.h>
-#include <sys/printk.h>
 #include <device.h>
 #include <soc.h>
 #include <drivers/gpio.h>
 #include <drivers/espi.h>
+#include <logging/log_ctrl.h>
+#include <logging/log.h>
+LOG_MODULE_DECLARE(espi, CONFIG_ESPI_LOG_LEVEL);
+
+#define DEST_SLV_ADDR  0x02
+#define SRC_SLV_ADDR   0x21
+#define OOB_CMDCODE    0x01
+
+struct oob_header {
+	u8_t dest_slave_addr;
+	u8_t oob_cmd_code;
+	u8_t byte_cnt;
+	u8_t src_slave_addr;
+};
 
 #ifdef CONFIG_ESPI_GPIO_DEV_NEEDED
 static struct device *gpio_dev0;
@@ -19,7 +32,6 @@ static struct device *gpio_dev1;
 #endif
 
 static struct device *espi_dev;
-
 static struct espi_callback espi_bus_cb;
 static struct espi_callback vw_rdy_cb;
 static struct espi_callback vw_cb;
@@ -31,7 +43,7 @@ static void espi_reset_handler(struct device *dev,
 			       struct espi_event event)
 {
 	if (event.evt_type == ESPI_BUS_RESET) {
-		printk("\neSPI BUS reset %d", event.evt_data);
+		LOG_INF("\neSPI BUS reset %d", event.evt_data);
 	}
 }
 
@@ -41,7 +53,7 @@ static void espi_ch_handler(struct device *dev, struct espi_callback *cb,
 {
 	if (event.evt_type == ESPI_BUS_EVENT_CHANNEL_READY) {
 		if (event.evt_details == ESPI_CHANNEL_VWIRE) {
-			printk("\nVW channel is ready\n");
+			LOG_INF("\nVW channel is ready");
 		}
 	}
 }
@@ -52,7 +64,7 @@ static void vwire_handler(struct device *dev, struct espi_callback *cb,
 {
 	if (event.evt_type == ESPI_BUS_EVENT_VWIRE_RECEIVED) {
 		if (event.evt_details == ESPI_VWIRE_SIGNAL_PLTRST) {
-			printk("\nPLT_RST changed %d\n", event.evt_data);
+			LOG_INF("\nPLT_RST changed %d\n", event.evt_data);
 		}
 	}
 }
@@ -68,14 +80,15 @@ static void periph_handler(struct device *dev, struct espi_callback *cb,
 
 		switch (peripheral) {
 		case ESPI_PERIPHERAL_DEBUG_PORT80:
-			printk("Postcode %x\n", event.evt_data);
+			LOG_INF("Postcode %x\n", event.evt_data);
 			break;
 		case ESPI_PERIPHERAL_HOST_IO:
-			printk("ACPI %x\n", event.evt_data);
+			LOG_INF("ACPI %x\n", event.evt_data);
+			espi_remove_callback(espi_dev, &p80_cb);
 			break;
 		default:
-			printk("\n%s periph 0x%x [%x]\n", __func__, peripheral,
-			       event.evt_data);
+			LOG_INF("\n%s periph 0x%x [%x]\n", __func__, peripheral,
+				event.evt_data);
 		}
 	}
 }
@@ -94,12 +107,12 @@ int espi_init(void)
 
 	ret = espi_config(espi_dev, &cfg);
 	if (ret) {
-		printk("Failed to configure eSPI slave! error (%d)\n", ret);
+		LOG_INF("Failed to configure eSPI slave! error (%d)\n", ret);
 	} else {
-		printk("eSPI slave configured successfully!\n");
+		LOG_INF("eSPI slave configured successfully!");
 	}
 
-	printk("eSPI test - callbacks initialization... ");
+	LOG_INF("eSPI test - callbacks initialization... ");
 	espi_init_callback(&espi_bus_cb, espi_reset_handler, ESPI_BUS_RESET);
 	espi_init_callback(&vw_rdy_cb, espi_ch_handler,
 			   ESPI_BUS_EVENT_CHANNEL_READY);
@@ -107,14 +120,14 @@ int espi_init(void)
 			   ESPI_BUS_EVENT_VWIRE_RECEIVED);
 	espi_init_callback(&p80_cb, periph_handler,
 			   ESPI_BUS_PERIPHERAL_NOTIFICATION);
-	printk("complete\n");
+	LOG_INF("complete");
 
-	printk("eSPI test - callbacks registration... ");
+	LOG_INF("eSPI test - callbacks registration... ");
 	espi_add_callback(espi_dev, &espi_bus_cb);
 	espi_add_callback(espi_dev, &vw_rdy_cb);
 	espi_add_callback(espi_dev, &vw_cb);
 	espi_add_callback(espi_dev, &p80_cb);
-	printk("complete\n");
+	LOG_INF("complete");
 
 	return ret;
 }
@@ -160,7 +173,7 @@ int wait_for_vwire(struct device *espi_dev, enum espi_vwire_signal signal,
 	do {
 		ret = espi_receive_vwire(espi_dev, signal, &level);
 		if (ret) {
-			printk("Failed to read %x %d", signal, ret);
+			LOG_WRN("Failed to read %x %d", signal, ret);
 			return -EIO;
 		}
 
@@ -173,7 +186,7 @@ int wait_for_vwire(struct device *espi_dev, enum espi_vwire_signal signal,
 	} while (loop_cnt > 0);
 
 	if (loop_cnt == 0) {
-		printk("VWIRE %d! is %x\n", signal, level);
+		LOG_WRN("VWIRE %d! is %x\n", signal, level);
 		return -ETIMEDOUT;
 	}
 
@@ -184,85 +197,117 @@ int espi_handshake(void)
 {
 	int ret;
 
-	printk("eSPI test - Handshake with eSPI master...\n");
+	LOG_INF("eSPI test - Handshake with eSPI master...");
 	ret = wait_for_vwire(espi_dev, ESPI_VWIRE_SIGNAL_SUS_WARN,
 			     CONFIG_ESPI_VIRTUAL_WIRE_TIMEOUT, 1);
 	if (ret) {
-		printk("SUS_WARN Timeout!\n");
+		LOG_WRN("SUS_WARN Timeout");
 		return ret;
 	}
 
-	printk("\t1st phase completed\n");
+	LOG_INF("\t1st phase completed");
 	ret = wait_for_vwire(espi_dev, ESPI_VWIRE_SIGNAL_SLP_S5,
 			     CONFIG_ESPI_VIRTUAL_WIRE_TIMEOUT, 1);
 	if (ret) {
-		printk("SLP_S5 Timeout!\n");
+		LOG_WRN("SLP_S5 Timeout");
 		return ret;
 	}
 
 	ret = wait_for_vwire(espi_dev, ESPI_VWIRE_SIGNAL_SLP_S4,
 			     CONFIG_ESPI_VIRTUAL_WIRE_TIMEOUT, 1);
 	if (ret) {
-		printk("SLP_S4 Timeout!\n");
+		LOG_WRN("SLP_S4 Timeout");
 		return ret;
 	}
 
 	ret = wait_for_vwire(espi_dev, ESPI_VWIRE_SIGNAL_SLP_S3,
 			     CONFIG_ESPI_VIRTUAL_WIRE_TIMEOUT, 1);
 	if (ret) {
-		printk("SLP_S3 Timeout!\n");
+		LOG_WRN("SLP_S3 Timeout");
 		return ret;
 	}
 
-	printk("\t2nd phase completed\n");
+	LOG_INF("\t2nd phase completed");
 	return 0;
 }
 
-void main(void)
+int get_pch_temp(struct device *dev)
 {
+	struct espi_oob_packet req_pckt;
+	struct espi_oob_packet resp_pckt;
+	struct oob_header oob_hdr;
+	struct oob_header rsp;
 	int ret;
 
-	k_sleep(K_MSEC(500));
+	oob_hdr.dest_slave_addr = DEST_SLV_ADDR;
+	oob_hdr.oob_cmd_code = OOB_CMDCODE;
+	oob_hdr.byte_cnt = 1;
+	oob_hdr.src_slave_addr = SRC_SLV_ADDR;
+
+	/* Packetize OOB request */
+	req_pckt.buf = (u8_t *)&oob_hdr;
+	req_pckt.len = sizeof(struct oob_header);
+	resp_pckt.buf = (u8_t *)&rsp;
+	resp_pckt.len = 0;
+
+	ret = espi_send_oob(dev, req_pckt);
+	if (ret) {
+		LOG_WRN("espi_send_oob failed %d\n", ret);
+		return ret;
+	}
+
+	ret = espi_receive_oob(dev, resp_pckt);
+	if (ret) {
+		LOG_WRN("espi_receive_oob failed %d\n", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int espi_test(void)
+{
+	int ret;
 
 #ifdef CONFIG_ESPI_GPIO_DEV_NEEDED
 	gpio_dev0 = device_get_binding(CONFIG_ESPI_GPIO_DEV0);
 	if (!gpio_dev0) {
-		printk("Fail to find: %s!\n", CONFIG_ESPI_GPIO_DEV0);
-		return;
+		LOG_WRN("Fail to find: %s!\n", CONFIG_ESPI_GPIO_DEV0);
+		return -1;
 	}
 
 	gpio_dev1 = device_get_binding(CONFIG_ESPI_GPIO_DEV1);
 	if (!gpio_dev1) {
-		printk("Fail to find: %s!\n", CONFIG_ESPI_GPIO_DEV1);
-		return;
+		LOG_WRN("Fail to find: %s!\n", CONFIG_ESPI_GPIO_DEV1);
+		return -1;
 	}
 
 #endif
 	espi_dev = device_get_binding(CONFIG_ESPI_DEV);
 	if (!espi_dev) {
-		printk("Fail to find %s!\n", CONFIG_ESPI_DEV);
-		return;
+		LOG_WRN("Fail to find %s\n", CONFIG_ESPI_DEV);
+		return 1;
 	}
 
-	printk("Hello eSPI test! %s\n", CONFIG_BOARD);
+	LOG_INF("Hello eSPI test! %s\n", CONFIG_BOARD);
 
 #ifdef CONFIG_ESPI_GPIO_DEV_NEEDED
 	ret = gpio_pin_configure(gpio_dev0, CONFIG_PWRGD_PIN, GPIO_DIR_IN);
 	if (ret) {
-		printk("Unable to configure PWRGD %d\n", CONFIG_PWRGD_PIN);
-		return;
+		printk("Unable to configure %d:%d\n", CONFIG_PWRGD_PIN, ret);
+		return ret;
 	}
 
 	ret = gpio_pin_configure(gpio_dev1, CONFIG_ESPI_INIT_PIN, GPIO_DIR_OUT);
 	if (ret) {
-		printk("Unable to configure RSMRST %d\n", CONFIG_ESPI_INIT_PIN);
-		return;
+		LOG_WRN("Unable to config %d: %d\n", CONFIG_ESPI_INIT_PIN, ret);
+		return ret;
 	}
 
 	ret = gpio_pin_write(gpio_dev1, CONFIG_ESPI_INIT_PIN, 0);
 	if (ret) {
-		printk("Unable to initialize %d\n", CONFIG_ESPI_INIT_PIN);
-		return;
+		LOG_WRN("Unable to initialize %d\n", CONFIG_ESPI_INIT_PIN);
+		return -1;
 	}
 #endif
 
@@ -271,19 +316,30 @@ void main(void)
 #ifdef CONFIG_ESPI_GPIO_DEV_NEEDED
 	ret = wait_for_pin(gpio_dev0, CONFIG_PWRGD_PIN, PWR_SEQ_TIMEOUT, 1);
 	if (ret) {
-		printk("RSMRST_PWRGD timeout!\n");
-		return;
+		printk("RSMRST_PWRGD timeout!");
+		return ret;
 	}
 
 	ret = gpio_pin_write(gpio_dev1, CONFIG_ESPI_INIT_PIN, 1);
 	if (ret) {
 		printk("Failed to write %x %d\n", CONFIG_ESPI_INIT_PIN, ret);
-		return;
+		return ret;
 	}
 #endif
 
 	ret = espi_handshake();
 	if (ret) {
-		printk("Test failed %d\n", ret);
+		LOG_PANIC();
+		return ret;
 	}
+
+	/* Attempt anyways to test failure case */
+	get_pch_temp(espi_dev);
+
+	return 0;
+}
+
+void main(void)
+{
+	espi_test();
 }


### PR DESCRIPTION
Add support for eSPI OOB channel operations

Implement send/receive out-of-band packet APIs
Update eSPI sample driver with usage for eSPI OOB driver APIs