### PR TITLE
arch: arm: Fix Cortex-R power management interrupt handling

### DIFF
--- a/arch/arm/core/aarch32/isr_wrapper.S
+++ b/arch/arm/core/aarch32/isr_wrapper.S
@@ -77,7 +77,15 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 	 * state is not interrupted.  In each case, z_sys_power_save_idle_exit
 	 * is called with interrupts disabled.
 	 */
+
+     /*
+      * FIXME: Remove the Cortex-M conditional compilation checks for `cpsid i`
+      *        and `cpsie i` after the Cortex-R port is updated to support
+      *        interrupt nesting.  For more details, refer to the issue #21758.
+      */
+#if defined(CONFIG_CPU_CORTEX_M)
 	cpsid i  /* PRIMASK = 1 */
+#endif
 
 	/* is this a wakeup from idle ? */
 	ldr r2, =_kernel
@@ -110,8 +118,11 @@ _idle_state_cleared:
 #error Unknown ARM architecture
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 
+#if defined(CONFIG_CPU_CORTEX_M)
 	cpsie i		/* re-enable interrupts (PRIMASK = 0) */
 #endif
+
+#endif /* CONFIG_SYS_POWER_MANAGEMENT */
 
 #if defined(CONFIG_CPU_CORTEX_M)
 	mrs r0, IPSR	/* get exception number */


### PR DESCRIPTION
```
The system power management handling code in the '_isr_wrapper' enables
interrupts by executing the 'cpsie i' instruction, which causes a
system crash on the Cortex-R devices because the Cortex-R arch port
does not support nested interrupts at this time.

This commit restricts the interrupt state manipulations in the system
power management code to the Cortex-M arch, in order to prevent
interrupt nesting on other AArch32 family archs (only Cortex-R for
now).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```

p.s. I am planning to implement arch-level interrupt nesting support for the Cortex-R (and AArch32 Cortex-A) in the near future.