### PR TITLE
Bluetooth: doc: Document whitelist initiator and notification callback

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -295,6 +295,11 @@ struct bt_conn *bt_conn_create_le(const bt_addr_le_t *peer,
 /** @brief Automatically connect to remote devices in whitelist.
  *
  *  This uses the Auto Connection Establishment procedure.
+ *  The procedure will continue until a single connection is established or the
+ *  procedure is stopped through @ref bt_conn_create_auto_stop.
+ *  To establish connections to all devices in the whitelist the procedure
+ *  should be started again in the connected callback after a new connection has
+ *  been established.
  *
  *  @param param Initial connection parameters.
  *

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -1261,6 +1261,9 @@ struct bt_gatt_subscribe_params;
  *  @param params Subscription parameters.
  *  @param data Attribute value data. If NULL then subscription was removed.
  *  @param length Attribute value length.
+ *
+ *  @return BT_GATT_ITER_CONTINUE to continue receiving value notifications.
+ *          BT_GATT_ITER_STOP to unsubscribe from value notifications.
  */
 typedef u8_t (*bt_gatt_notify_func_t)(struct bt_conn *conn,
 				      struct bt_gatt_subscribe_params *params,


### PR DESCRIPTION
 - Document the possible return values of the notify callback and the action it takes.
 - Add documentation for the whitelist initiator behaviour, describing the one-shot behaviour.
    
