### PR TITLE
drivers: eth: e1000: Include sys/types.h for ssize_t

### DIFF
--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -9,7 +9,7 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
-#include <unistd.h>
+#include <sys/types.h>
 #include <zephyr.h>
 #include <net/ethernet.h>
 #include <ethernet/eth_stats.h>


### PR DESCRIPTION
echo_server app doesn't compile (it uses newlib which lacks unistd.h),
let's switch to a more fine-grained include here.

Signed-off-by: Oleg Zhurakivskyy <oleg.zhurakivskyy@intel.com>