### PR TITLE
drivers: adc: mcux_adc12: fix DT_INST_2_* usage

### DIFF
--- a/drivers/adc/adc_mcux_adc12.c
+++ b/drivers/adc/adc_mcux_adc12.c
@@ -343,22 +343,23 @@ static void mcux_adc12_config_func_1(struct device *dev)
 #if DT_INST_2_NXP_KINETIS_ADC12
 static void mcux_adc12_config_func_2(struct device *dev);
 
-ASSERT_WITHIN_RANGE(DT_INST_2_NXP_KINETIS_ADC12_ADC_CLK_SOURCE, 0, 3,
+ASSERT_WITHIN_RANGE(DT_INST_2_NXP_KINETIS_ADC12_CLK_SOURCE, 0, 3,
 		    "Invalid clock source");
-ASSERT_ADC12_CLK_DIV_VALID(DT_INST_2_NXP_KINETIS_ADC12_ADC_CLK_DIVIDER,
+ASSERT_ADC12_CLK_DIV_VALID(DT_INST_2_NXP_KINETIS_ADC12_CLK_DIVIDER,
 			   "Invalid clock divider");
-ASSERT_WITHIN_RANGE(DT_INST_2_NXP_KINETIS_ADC12_ADC_SAMPLE_TIME, 2, 256,
+ASSERT_WITHIN_RANGE(DT_INST_2_NXP_KINETIS_ADC12_SAMPLE_TIME, 2, 256,
 		    "Invalid sample time");
 static const struct mcux_adc12_config mcux_adc12_config_2 = {
-	.base = (ADC_Type *)DT_INST_2_NXP_KINETIS_ADC12_ADC_BASE_ADDRESS,
-	.clock_src = TO_ADC12_CLOCK_SRC(DT_INST_2_NXP_KINETIS_ADC12_ADC_CLK_SOURCE),
-	.clock_div = TO_ADC12_CLOCK_DIV(DT_INST_2_NXP_KINETIS_ADC12_ADC_CLK_DIVIDER),
-#if DT_INST_2_NXP_KINETIS_ADC12_ADC_ALTERNATE_VOLTAGE_REFERENCE == 1
+	.base = (ADC_Type *)DT_INST_2_NXP_KINETIS_ADC12_BASE_ADDRESS,
+	.clock_src = TO_ADC12_CLOCK_SRC(DT_INST_2_NXP_KINETIS_ADC12_CLK_SOURCE),
+	.clock_div =
+		TO_ADC12_CLOCK_DIV(DT_INST_2_NXP_KINETIS_ADC12_CLK_DIVIDER),
+#if DT_INST_2_NXP_KINETIS_ADC12_ALTERNATE_VOLTAGE_REFERENCE == 1
 	.ref_src = kADC12_ReferenceVoltageSourceValt,
 #else
 	.ref_src = kADC12_ReferenceVoltageSourceVref,
 #endif
-	.sample_clk_count = DT_INST_2_NXP_KINETIS_ADC12_ADC_SAMPLE_TIME,
+	.sample_clk_count = DT_INST_2_NXP_KINETIS_ADC12_SAMPLE_TIME,
 	.irq_config_func = mcux_adc12_config_func_2,
 };
 
@@ -368,17 +369,17 @@ static struct mcux_adc12_data mcux_adc12_data_2 = {
 	ADC_CONTEXT_INIT_SYNC(mcux_adc12_data_2, ctx),
 };
 
-DEVICE_AND_API_INIT(mcux_adc12_2, DT_INST_2_NXP_KINETIS_ADC12_ADC_LABEL,
+DEVICE_AND_API_INIT(mcux_adc12_2, DT_INST_2_NXP_KINETIS_ADC12_LABEL,
 		    &mcux_adc12_init, &mcux_adc12_data_2, &mcux_adc12_config_2,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_adc12_driver_api);
 
 static void mcux_adc12_config_func_2(struct device *dev)
 {
-	IRQ_CONNECT(DT_INST_2_NXP_KINETIS_ADC12_ADC_IRQ,
-		    DT_INST_2_NXP_KINETIS_ADC12_ADC_IRQ_PRIORITY, mcux_adc12_isr,
+	IRQ_CONNECT(DT_INST_2_NXP_KINETIS_ADC12_IRQ_0,
+		    DT_INST_2_NXP_KINETIS_ADC12_IRQ_0_PRIORITY, mcux_adc12_isr,
 		    DEVICE_GET(mcux_adc12_2), 0);
 
-	irq_enable(DT_INST_2_NXP_KINETIS_ADC12_ADC_IRQ);
+	irq_enable(DT_INST_2_NXP_KINETIS_ADC12_IRQ_0);
 }
 #endif /* DT_INST_2_NXP_KINETIS_ADC12 */


### PR DESCRIPTION
Fix the usage of DT_INST_2_* defines in the NXP MCUX ADC12 ADC driver.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>