### PR TITLE
CODEOWNERS: Add @nandojve for /drivers/ieee802154/rf2xx

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -140,6 +140,7 @@
 /drivers/i2c/*litex*                      @mateusz-holenko @kgugala @pgielda
 /drivers/i2s/i2s_ll_stm32*                @avisconti
 /drivers/ieee802154/                      @jukkar @tbursztyka
+/drivers/ieee802154/ieee802154_rf2xx*     @jukkar @tbursztyka @nandojve
 /drivers/interrupt_controller/            @andrewboie
 /drivers/*/intc_vexriscv_litex.c          @mateusz-holenko @kgugala @pgielda
 /drivers/ipm/ipm_mhu*                     @karl-zh


### PR DESCRIPTION
Add myself as code owner for Atmel AT86RF2xx driver as requested on #21763.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>