### PR TITLE
Deprecate TI cc2650

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1512,6 +1512,13 @@ if(CONFIG_BOARD_DEPRECATED_RELEASE)
   )
 endif()
 
+if(CONFIG_SOC_DEPRECATED_RELEASE)
+  message(WARNING "
+      WARNING:  The SoC '${SOC_NAME}' is deprecated and will be
+      removed in version ${CONFIG_SOC_DEPRECATED_RELEASE}"
+  )
+endif()
+
 # In CMake projects, 'CMAKE_BUILD_TYPE' usually determines the
 # optimization flag, but in Zephyr it is determined through
 # Kconfig. Here we give a warning when there is a mismatch between the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1505,10 +1505,10 @@ if(CONFIG_ASSERT AND (NOT CONFIG_FORCE_NO_ASSERT))
 endif()
 endif()
 
-if(CONFIG_BOARD_DEPRECATED)
+if(CONFIG_BOARD_DEPRECATED_RELEASE)
   message(WARNING "
       WARNING:  The board '${BOARD}' is deprecated and will be
-      removed in version ${CONFIG_BOARD_DEPRECATED}"
+      removed in version ${CONFIG_BOARD_DEPRECATED_RELEASE}"
   )
 endif()
 

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-config BOARD_DEPRECATED
+config BOARD_DEPRECATED_RELEASE
 	string
 	help
 	  This hidden option is set in the board configuration and indicates

--- a/boards/arm/cc2650_sensortag/Kconfig.defconfig
+++ b/boards/arm/cc2650_sensortag/Kconfig.defconfig
@@ -7,4 +7,7 @@ if BOARD_CC2650_SENSORTAG
 config BOARD
 	default "cc2650_sensortag"
 
+config BOARD_DEPRECATED_RELEASE
+	default "2.2.0"
+
 endif # BOARD_CC2650_SENSORTAG

--- a/soc/Kconfig
+++ b/soc/Kconfig
@@ -71,3 +71,11 @@ config SOC_RWDATA_LD
 	  under include/arch/.
 
 endif # ARC || ARM || X86 || NIOS2 || RISCV
+
+config SOC_DEPRECATED_RELEASE
+	string
+	help
+	  This hidden option is set in the SoC configuration and indicates
+	  the Zephyr release that the SoC configuration will be removed.
+	  When set, any build for that SoC will generate a clearly visible
+	  deprecation warning.

--- a/soc/arm/ti_simplelink/cc2650/Kconfig.soc
+++ b/soc/arm/ti_simplelink/cc2650/Kconfig.soc
@@ -17,4 +17,10 @@ config TI_CCFG_PRESENT
 	bool
 	default y
 
+config SOC
+	default "cc2650"
+
+config SOC_DEPRECATED_RELEASE
+	default "2.2.0"
+
 endif # SOC_SERIES_CC2650


### PR DESCRIPTION
Adding Kconfig settings to inform anyone trying to build for this
platform of its pending deprecation in 2.2.0.