### PR TITLE
userspace: fix incorrect linker routing

### DIFF
--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -234,6 +234,7 @@ def write_gperf_table(fp, eh, objs, static_begin, static_end):
 
     # Generate the array of already mapped thread indexes
     fp.write('\n')
+    fp.write('Z_GENERIC_SECTION(.kobject_data.data) ')
     fp.write('u8_t _thread_idx_map[%d] = {' % (thread_max_bytes))
 
     for i in range(0, thread_max_bytes):


### PR DESCRIPTION
The _thread_idx_map bitfield which has '1' set for free
thread indexes really needs to live in the
data section reserved for kernel object metadata, as this
is a part of memory that is allowed to shift addresses
between zephyr_prebuilt.elf and zephyr.elf.

However, if an application defines enough static threads
that there are no free indexes, the entire bitfield will
be zeroed and the bitfield will end up in the main BSS
section.

Force this data to always be in the .kobject_data.data
section regardless of its contents.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>