### PR TITLE
west.yml: update hal stm32g4xx module

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
       revision: fa481784b3c49780f18d50bafe00390ccb62b2ec
       path: modules/hal/st
     - name: hal_stm32
-      revision: 92bdc131f915e53c19c03c65ae275fb0c9c7ee91
+      revision: 566f4eb616f9e61bec01aca9918cace4b01e11b5
       path: modules/hal/stm32
     - name: hal_ti
       revision: 879c7d08ffc6cd18737847030b906cffe3b0a8fb


### PR DESCRIPTION
This updates the stm32cube/stm32g4xx/drivers to wa the issue #21715
This requires the https://github.com/zephyrproject-rtos/hal_stm32/pull/34

Signed-off-by: Francois Ramu <francois.ramu@st.com>