### PR TITLE
nucleo_g071rc: Enable automatic flashing 

### DIFF
--- a/boards/arm/nucleo_g071rb/board.cmake
+++ b/boards/arm/nucleo_g071rb/board.cmake
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 board_runner_args(pyocd "--target=stm32g071rb")
+board_runner_args(pyocd "--flash-opt=-O reset_type=hw")
+board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -13,7 +13,7 @@ packaging
 ply>=3.10
 pyelftools>=0.24
 pykwalify
-pyocd>=0.21.0
+pyocd>=0.24.0
 pyserial
 pytest
 sphinx>=1.7.5


### PR DESCRIPTION
Flashing board nucleo_g071rb requires additional instructions to be provided to pyocd in order to enable flashing without holding the reset button.
Update nucleo_g071rb runners options to provide requested instructions.
Update pyocd version to allow reception of these new options.

