### PR TITLE
shell: Remove deprecated macros

### DIFF
--- a/doc/releases/release-notes-2.2.rst
+++ b/doc/releases/release-notes-2.2.rst
@@ -52,6 +52,12 @@ Stable API changes in this release
 Removed APIs in this release
 ============================
 
+* Shell
+
+  * SHELL_CREATE_STATIC_SUBCMD_SET (deprecated), replaced by
+    SHELL_STATIC_SUBCMD_SET_CREATE
+  * SHELL_CREATE_DYNAMIC_CMD (deprecated), replaced by SHELL_DYNAMIC_CMD_CREATE
+
 Kernel
 ******
 

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -224,23 +224,6 @@ struct shell_static_entry {
 	}
 
 /**
- * @brief Deprecated macro for creating a subcommand set.
- *
- * It must be used outside of any function body.
- *
- * @param[in] name	Name of the subcommand set.
- */
-#define SHELL_CREATE_STATIC_SUBCMD_SET(name)			\
-	__DEPRECATED_MACRO					\
-	static const struct shell_static_entry shell_##name[];	\
-	static const struct shell_cmd_entry name = {		\
-		.is_dynamic = false,				\
-		.u.entry = shell_##name				\
-	};							\
-	static const struct shell_static_entry shell_##name[] =
-
-
-/**
  * @brief Define ending subcommands set.
  *
  */
@@ -257,15 +240,6 @@ struct shell_static_entry {
 		.is_dynamic = true,			\
 		.u = { .dynamic_get = get }		\
 	}
-
-/**
- * @brief Deprecated macro for creating a dynamic entry.
- *
- * @param[in] name	Name of the dynamic entry.
- * @param[in] get	Pointer to the function returning dynamic commands array
- */
-#define SHELL_CREATE_DYNAMIC_CMD(name, get)		\
-	__DEPRECATED_MACRO SHELL_DYNAMIC_CMD_CREATE(name, get)
 
 /**
  * @brief Initializes a shell command with arguments.


### PR DESCRIPTION
Remove deprecated macros and add a note to the release notes to this
effect.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>