### PR TITLE
Nrf5340 cpu app fix ram partitioning

### DIFF
--- a/boards/arm/nrf5340_dk_nrf5340/Kconfig.defconfig
+++ b/boards/arm/nrf5340_dk_nrf5340/Kconfig.defconfig
@@ -36,23 +36,41 @@ config SPI_2
 
 endif # SPI
 
+# Code Partition:
+#
 # For the secure version of the board the firmware is linked at the beginning
 # of the flash, or into the code-partition defined in DT if it is intended to
 # be loaded by MCUboot. If the secure firmware is to be combined with a non-
 # secure image (TRUSTED_EXECUTION_SECURE=y), the secure FW image shall always
 # be restricted to the size of its code partition.
+#
 # For the non-secure version of the board, the firmware
 # must be linked into the code-partition (non-secure) defined in DT, regardless.
 # Apply this configuration below by setting the Kconfig symbols used by
 # the linker according to the information extracted from DT partitions.
 
+# SRAM Partition:
+#
+# If the secure firmware is to be combined with a non-secure image
+# (TRUSTED_EXECUTION_SECURE=y), the secure FW image SRAM shall always
+# be restricted to the secure image SRAM partition (sram-secure-partition).
+# Otherwise (if TRUSTED_EXECUTION_SECURE is not set) the whole sram0 may be
+# used by the image.
+#
+# For the non-secure version of the board, the firmware image SRAM is
+# always restricted to the allocated non-secure SRAM partition.
+#
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
+DT_CHOSEN_Z_SRAM_PARTITION := zephyr,sram-secure-partition
 
 if BOARD_NRF5340_DK_NRF5340_CPUAPP && TRUSTED_EXECUTION_SECURE
 
 config FLASH_LOAD_SIZE
 	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
+
+config SRAM_SIZE
+	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_SRAM_PARTITION),0,K)
 
 endif # BOARD_NRF5340_DK_NRF5340_CPUAPP && TRUSTED_EXECUTION_SECURE
 

--- a/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpuapp.dts
+++ b/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpuapp.dts
@@ -13,5 +13,6 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,sram-secure-partition = &sram0_s;
 	};
 };

--- a/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpuapp_common.dts
@@ -184,6 +184,3 @@
 
 /* Include partition configuration file */
 #include "nrf5340_dk_nrf5340_cpuapp_partition_conf.dts"
-
-/* Include shared RAM configuration file */
-#include "nrf5340_dk_nrf5340_shared_sram_planning_conf.dts"

--- a/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpuapp_common.dts
@@ -163,11 +163,22 @@
 	};
 };
 
-/ {
-	/* SRAM allocated to the Non-Secure image */
-	sram0_ns: memory@20020000 {
-		device_type = "memory";
-		compatible = "mmio-sram";
+&sram0 {
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* SRAM allocated to the Secure image */
+		sram0_s: memory@20000000 {
+			label = "secure_sram_partition";
+		};
+
+		/* SRAM allocated to the Non-Secure image */
+		sram0_ns: memory@20010000 {
+			label = "non_secure_sram_partition";
+		};
 	};
 };
 

--- a/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpuapp_partition_conf.dts
+++ b/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpuapp_partition_conf.dts
@@ -39,16 +39,19 @@
 
 /* Default SRAM planning when building for nRF5340 with
  * ARM TrustZone-M support
- * - Lowest 64 kB SRAM allocated to Secure image (sram0)
- * - Middle 64 kB SRAM allocated as Shared memory (sram0_shared)
+ * - Lowest 64 kB SRAM allocated to Secure image (sram0_s)
+ * - Middle 384 kB allocated to Non-Secure image (sram0_ns)
+ * - Upper 64 kB SRAM allocated as Shared memory (sram0_shared)
  *   (see nrf5340_dk_nrf5340_shared_sram_planning_conf.dts)
- * - Upper 384 kB allocated to Non-Secure image (sram0_ns)
  */
-
 &sram0 {
-	reg = <0x20000000 DT_SIZE_K(64)>;
+	reg = <0x20000000 DT_SIZE_K(448)>;
+};
+
+&sram0_s {
+	reg = <0x20000000 0x10000>;
 };
 
 &sram0_ns {
-	reg = <0x20020000 DT_SIZE_K(384)>;
+	reg = <0x20010000 0x60000>;
 };

--- a/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpuapp_partition_conf.dts
+++ b/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpuapp_partition_conf.dts
@@ -55,3 +55,6 @@
 &sram0_ns {
 	reg = <0x20010000 0x60000>;
 };
+
+/* Include shared RAM configuration file */
+#include "nrf5340_dk_nrf5340_shared_sram_planning_conf.dts"

--- a/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_shared_sram_planning_conf.dts
+++ b/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_shared_sram_planning_conf.dts
@@ -18,9 +18,9 @@
 	};
 
 	/* SRAM allocated to shared memory */
-	sram0_shared: memory@20010000 {
+	sram0_shared: memory@20070000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
-		reg = <0x20010000 DT_SIZE_K(64)>;
+		reg = <0x20070000 DT_SIZE_K(64)>;
 	};
 };

--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -62,6 +62,7 @@
 
 	soc {
 		sram0: memory@20000000 {
+			device_type = "memory";
 			compatible = "mmio-sram";
 		};
 

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -64,6 +64,7 @@
 
 	soc {
 		sram1: memory@21000000 {
+			device_type = "memory";
 			compatible = "mmio-sram";
 		};
 


### PR DESCRIPTION
Reason for this patch:
For nrf5340 builds without support for Trusted Execution (ARM TrustZone) we would like to use all available SRAM for the single (default secure) image. Right now the SRAM for the secure image is limited to the lowest 64 kB, regardless of whether we build with TrustZone support.

In addition to the above: the shared SRAM with the Network MCU has been moved to the upper part of the Application MCU SRAM. So for builds without TrustZone, the whole SRAM below the shared partition can be given to the single image.