### PR TITLE
sanitycheck: do not log stderr from BinaryHandler

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -576,9 +576,6 @@ class BinaryHandler(Handler):
                 t.join()
             proc.wait()
             self.returncode = proc.returncode
-            _, stderr = proc.communicate(timeout=30)
-            if stderr:
-                logger.error(stderr.decode())
 
         handler_time = time.time() - start_time
 


### PR DESCRIPTION
stderr from the binary handler (native_posix for example) was redirected
to the logger as errors, this is confusing the console and users, so
remove this.

Fixes #21784