### PR TITLE
Revert "boards: nxp: pinmux: enable ftm pwm outputs based on DT_INST_* defines"

### DIFF
--- a/boards/arm/frdm_k64f/pinmux.c
+++ b/boards/arm/frdm_k64f/pinmux.c
@@ -122,7 +122,7 @@ static int frdm_k64f_pinmux_init(struct device *dev)
 	pinmux_pin_set(portb, 10, PORT_PCR_MUX(kPORT_PinDisabledOrAnalog));
 #endif
 
-#ifdef DT_NXP_KINETIS_FTM_PWM_3_BASE_ADDRESS
+#ifdef CONFIG_PWM_3
 	pinmux_pin_set(portc,  8, PORT_PCR_MUX(kPORT_MuxAlt3));
 	pinmux_pin_set(portc,  9, PORT_PCR_MUX(kPORT_MuxAlt3));
 #endif

--- a/boards/arm/frdm_k82f/pinmux.c
+++ b/boards/arm/frdm_k82f/pinmux.c
@@ -33,7 +33,7 @@ static int frdm_k82f_pinmux_init(struct device *dev)
 		device_get_binding(CONFIG_PINMUX_MCUX_PORTE_NAME);
 #endif
 
-#ifdef DT_NXP_KINETIS_FTM_PWM_3_BASE_ADDRESS
+#ifdef CONFIG_PWM_3
 	/* Red, green, blue LEDs as PWM channels */
 	pinmux_pin_set(portc,  8, PORT_PCR_MUX(kPORT_MuxAlt3));
 	pinmux_pin_set(portc,  9, PORT_PCR_MUX(kPORT_MuxAlt3));

--- a/boards/arm/hexiwear_k64/pinmux.c
+++ b/boards/arm/hexiwear_k64/pinmux.c
@@ -34,7 +34,7 @@ static int hexiwear_k64_pinmux_init(struct device *dev)
 		device_get_binding(CONFIG_PINMUX_MCUX_PORTE_NAME);
 #endif
 
-#ifdef DT_NXP_KINETIS_FTM_PWM_3_BASE_ADDRESS
+#ifdef CONFIG_PWM_3
 	/* Red, green, blue LEDs as PWM channels */
 	pinmux_pin_set(portc,  8, PORT_PCR_MUX(kPORT_MuxAlt3));
 	pinmux_pin_set(portc,  9, PORT_PCR_MUX(kPORT_MuxAlt3));

--- a/boards/arm/twr_ke18f/pinmux.c
+++ b/boards/arm/twr_ke18f/pinmux.c
@@ -34,31 +34,31 @@ static int twr_ke18f_pinmux_init(struct device *dev)
 		device_get_binding(CONFIG_PINMUX_MCUX_PORTE_NAME);
 #endif
 
-#ifdef DT_NXP_KINETIS_FTM_PWM_0_BASE_ADDRESS
+#ifdef CONFIG_PWM_0
 	/* Tri-color LED as PWM */
 	pinmux_pin_set(portb, 5, PORT_PCR_MUX(kPORT_MuxAlt2));
 	pinmux_pin_set(portd, 15, PORT_PCR_MUX(kPORT_MuxAlt2));
 	pinmux_pin_set(portd, 16, PORT_PCR_MUX(kPORT_MuxAlt2));
-#else /* !DT_NXP_KINETIS_FTM_PWM_0_BASE_ADDRESS */
+#else /* !CONFIG_PWM_0 */
 	/* Tri-color LED as GPIO */
 	pinmux_pin_set(portb, 5, PORT_PCR_MUX(kPORT_MuxAsGpio));
 	pinmux_pin_set(portd, 15, PORT_PCR_MUX(kPORT_MuxAsGpio));
 	pinmux_pin_set(portd, 16, PORT_PCR_MUX(kPORT_MuxAsGpio));
-#endif /* !DT_NXP_KINETIS_FTM_PWM_0_BASE_ADDRESS */
+#endif /* !CONFIG_PWM_0 */
 
-#ifdef DT_NXP_KINETIS_FTM_PWM_3_BASE_ADDRESS
+#ifdef CONFIG_PWM_3
 	/* User LEDs as PWM */
 	pinmux_pin_set(portc, 10, PORT_PCR_MUX(kPORT_MuxAlt2));
 	pinmux_pin_set(portc, 11, PORT_PCR_MUX(kPORT_MuxAlt2));
 	pinmux_pin_set(portc, 12, PORT_PCR_MUX(kPORT_MuxAlt2));
 	pinmux_pin_set(portc, 13, PORT_PCR_MUX(kPORT_MuxAlt2));
-#else /* !DT_NXP_KINETIS_FTM_PWM_3_BASE_ADDRESS */
+#else /* !CONFIG_PWM_3 */
 	/* User LEDs as GPIO */
 	pinmux_pin_set(portc, 10, PORT_PCR_MUX(kPORT_MuxAsGpio));
 	pinmux_pin_set(portc, 11, PORT_PCR_MUX(kPORT_MuxAsGpio));
 	pinmux_pin_set(portc, 12, PORT_PCR_MUX(kPORT_MuxAsGpio));
 	pinmux_pin_set(portc, 13, PORT_PCR_MUX(kPORT_MuxAsGpio));
-#endif /* !DT_NXP_KINETIS_FTM_PWM_3_BASE_ADDRESS */
+#endif /* !CONFIG_PWM_3 */
 
 	/* Buttons */
 	pinmux_pin_set(portd, 3, PORT_PCR_MUX(kPORT_MuxAsGpio));


### PR DESCRIPTION
The DT_INST_* defines for the PWM controllers enabled in the device tree are always defined causing the LED pins to always be set as PWM outputs in the pinmux. Revert to using CONFIG_PWM_* for pinmux configuration for now.

This reverts commit eb42a24dc69cb5b0a24c7ce5bc4d76d281377f72.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>