### PR TITLE
doc: remove documentation reviewer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -99,7 +99,7 @@
 # All cmake related files
 /cmake/                                   @SebastianBoe @nashif
 /CMakeLists.txt                           @SebastianBoe @nashif
-/doc/                                     @dbkinder
+# /doc/                                     @dbkinder
 /doc/guides/coccinelle.rst                @himanshujha199640 @JuliaLawall
 /doc/CMakeLists.txt                       @carlescufi
 /doc/scripts/                             @carlescufi
@@ -415,5 +415,5 @@
 /tests/subsys/settings/                   @nvlsianpu
 /tests/subsys/shell/                      @jakub-uC @nordic-krch
 # Get all docs reviewed
-*.rst                                     @dbkinder
-*posix*.rst                               @dbkinder @aescolar
+# *.rst                                     @dbkinder
+*posix*.rst                               @aescolar


### PR DESCRIPTION
As of January 2020, David is no longer working on the Zephyr
documentation, so he should not be automatically added as reviewer.
I've commented out rather than removed the lines so when a replacement
is found, the lines can easily be added back.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>