### PR TITLE
scripts: nrfjprog runner enhancements

### DIFF
--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -295,6 +295,12 @@ def do_run_common(command, args, runner_args, cached_runner_var):
     except MissingProgram as e:
         log.die('required program', e.filename,
                 'not found; install it or add its location to PATH')
+    except RuntimeError as re:
+        if not args.verbose:
+            log.die(re)
+        else:
+            log.err('verbose mode enabled, dumping stack:', fatal=True)
+            raise
 
 
 #

--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -60,26 +60,34 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
 
     def ensure_snr(self):
         if not self.snr:
-            self.snr = self.get_board_snr_from_user()
+            self.snr = self.get_board_snr()
 
-    def get_board_snr_from_user(self):
+    def get_board_snr(self):
+        # Use nrfjprog --ids to discover connected boards.
+        #
+        # If there's exactly one board connected, it's safe to assume
+        # the user wants that one. Otherwise, bail unless there are
+        # multiple boards and we are connected to a terminal, in which
+        # case use print() and input() to ask what the user wants.
+
         snrs = self.check_output(['nrfjprog', '--ids'])
         snrs = snrs.decode(sys.getdefaultencoding()).strip().splitlines()
-
         if not snrs:
             raise RuntimeError('"nrfjprog --ids" did not find a board; '
                                'is the board connected?')
-
-        if len(snrs) == 1:
+        elif len(snrs) == 1:
             board_snr = snrs[0]
             if board_snr == '0':
                 raise RuntimeError('"nrfjprog --ids" returned 0; '
                                    'is a debugger already connected?')
             return board_snr
+        elif not sys.stdin.isatty():
+            raise RuntimeError(
+                f'refusing to guess which of {len(snrs)} '
+                'connected boards to use. (Interactive prompts '
+                'disabled since standard input is not a terminal.) '
+                'Please specify a serial number on the command line.')
 
-        # Use of print() here is advised. We don't want to lose
-        # this information in a separate log -- this is
-        # interactive and requires a terminal.
         print('There are multiple boards connected.')
         for i, snr in enumerate(snrs, 1):
             print('{}. {}'.format(i, snr))
@@ -103,10 +111,7 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
         self.ensure_snr()
 
         commands = []
-        if self.snr is None:
-            raise ValueError("self.snr must not be None")
-        else:
-            board_snr = self.snr.lstrip("0")
+        board_snr = self.snr.lstrip("0")
 
         if not os.path.isfile(self.hex_):
             raise ValueError('Cannot flash; hex file ({}) does not exist. '.

--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -54,11 +54,9 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def create(cls, cfg, args):
-        ret = NrfJprogBinaryRunner(cfg, args.nrf_family, args.softreset,
-                                   args.snr, erase=args.erase,
-                                   tool_opt=args.tool_opt)
-        ret.ensure_snr()
-        return ret
+        return NrfJprogBinaryRunner(cfg, args.nrf_family, args.softreset,
+                                    args.snr, erase=args.erase,
+                                    tool_opt=args.tool_opt)
 
     def ensure_snr(self):
         if not self.snr:
@@ -101,6 +99,8 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
 
     def do_run(self, command, **kwargs):
         self.require('nrfjprog')
+
+        self.ensure_snr()
 
         commands = []
         if self.snr is None:

--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -88,6 +88,7 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
                 'disabled since standard input is not a terminal.) '
                 'Please specify a serial number on the command line.')
 
+        snrs = sorted(snrs)
         print('There are multiple boards connected.')
         for i, snr in enumerate(snrs, 1):
             print('{}. {}'.format(i, snr))

--- a/scripts/west_commands/tests/test_nrfjprog.py
+++ b/scripts/west_commands/tests/test_nrfjprog.py
@@ -241,7 +241,7 @@ def id_fn(test_case):
 
 @pytest.mark.parametrize('test_case', TEST_CASES, ids=id_fn)
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
-@patch('runners.nrfjprog.NrfJprogBinaryRunner.get_board_snr_from_user',
+@patch('runners.nrfjprog.NrfJprogBinaryRunner.get_board_snr',
        side_effect=get_board_snr_patch)
 @patch('runners.nrfjprog.NrfJprogBinaryRunner.check_call')
 def test_nrfjprog_init(cc, get_snr, req, test_case, runner_config):
@@ -262,7 +262,7 @@ def test_nrfjprog_init(cc, get_snr, req, test_case, runner_config):
 
 @pytest.mark.parametrize('test_case', TEST_CASES, ids=id_fn)
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
-@patch('runners.nrfjprog.NrfJprogBinaryRunner.get_board_snr_from_user',
+@patch('runners.nrfjprog.NrfJprogBinaryRunner.get_board_snr',
        side_effect=get_board_snr_patch)
 @patch('runners.nrfjprog.NrfJprogBinaryRunner.check_call')
 def test_nrfjprog_create(cc, get_snr, req, test_case, runner_config):

--- a/scripts/west_commands/tests/test_nrfjprog.py
+++ b/scripts/west_commands/tests/test_nrfjprog.py
@@ -219,10 +219,8 @@ TEST_CASES = [(f, sr, snr, e)
               for snr in (TEST_OVR_SNR, None)
               for e in (False, True)]
 
-
 def get_board_snr_patch():
     return TEST_DEF_SNR
-
 
 def require_patch(program):
     assert program == 'nrfjprog'
@@ -241,7 +239,6 @@ def id_fn(test_case):
             ret += 'Y' if x else 'N'
     return ret
 
-
 @pytest.mark.parametrize('test_case', TEST_CASES, ids=id_fn)
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 @patch('runners.nrfjprog.NrfJprogBinaryRunner.get_board_snr_from_user',
@@ -252,18 +249,16 @@ def test_nrfjprog_init(cc, get_snr, req, test_case, runner_config):
 
     runner = NrfJprogBinaryRunner(runner_config, family, softreset, snr,
                                   erase=erase)
-    if snr is None:
-        with pytest.raises(ValueError) as e:
-            runner.run('flash')
-        assert 'snr must not be None' in str(e.value)
-    else:
-        with patch('os.path.isfile', side_effect=os_path_isfile_patch):
-            runner.run('flash')
-        assert req.called
-        assert cc.call_args_list == [call(x) for x in
-                                     expected_commands(*test_case)]
-        get_snr.assert_not_called()
+    with patch('os.path.isfile', side_effect=os_path_isfile_patch):
+        runner.run('flash')
+    assert req.called
+    assert cc.call_args_list == [call(x) for x in
+                                 expected_commands(*test_case)]
 
+    if snr is None:
+        get_snr.assert_called_once_with()
+    else:
+        get_snr.assert_not_called()
 
 @pytest.mark.parametrize('test_case', TEST_CASES, ids=id_fn)
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)


### PR DESCRIPTION
A few trivial nrfjprog enhancements:

- avoid raising RuntimeError for no connected boards until the user actually runs the command (we need one additional patch in run_common.py to catch this properly as well)
- don't use input() if sys.stdin is not a tty, to make the script fail fast in automated deployments when --snr should have been used, but wasn't (@nashif I'm guessing your board farms won't be affected by this, but heads up)
- sort the list of IDs when prompting for one of several, for consistent output across runs

