### PR TITLE
boards: arm: 96b_wistrio: Use stm32flash runner

### DIFF
--- a/boards/arm/96b_wistrio/board.cmake
+++ b/boards/arm/96b_wistrio/board.cmake
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(stm32flash "--baud-rate=115200" "--start-addr=0x08000000")
+
+include(${ZEPHYR_BASE}/boards/common/stm32flash.board.cmake)

--- a/boards/arm/96b_wistrio/doc/96b_wistrio.rst
+++ b/boards/arm/96b_wistrio/doc/96b_wistrio.rst
@@ -123,16 +123,6 @@ The default SPI mapping is:
 Programming and Debugging
 *************************
 
-Building
-========
-
-Here is an example for building the :ref:`hello_world` application.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: 96b_wistrio
-   :goals: build
-
 Flashing
 ========
 
@@ -161,13 +151,12 @@ More detailed information on activating the ROM bootloader can be found in
 Chapter 29 of Application note `AN2606`_. The ROM bootloader supports flashing
 via UART, and I2C protocols.
 
-For flashing, `stm32flash`_ command line utility can be used. The following
-command will flash the ``zephyr.bin`` binary to the WisTrio board using UART
-and starts its execution:
+Here is an example for building and flashing the :ref:`hello_world` application using `stm32flash`_ command line utility:
 
-.. code-block:: console
-
-   $ stm32flash -w zephyr.bin -v -g 0x08000000 -e 255 /dev/ttyUSB0
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: 96b_wistrio
+   :goals: build flash
 
 Using SWD debugger:
 -------------------


### PR DESCRIPTION
This feature is mentioned [here](https://github.com/zephyrproject-rtos/zephyr/pull/18981#issuecomment-545347334).

``` console
root:zephyr# west build -b 96b_wistrio samples/hello_world/
root:zephyr# west flash -r stm32flash --device /dev/ttyUSB0
-- west flash: rebuilding
ninja: no work to do.
-- west flash: using runner stm32flash
-- runners.stm32flash: Board: write 10172 bytes starting at 0x08000000
stm32flash 0.5

http://stm32flash.sourceforge.net/

Using Parser : Raw BINARY
Interface serial_posix: 115200 8E1
Version      : 0x31
Option 1     : 0x00
Option 2     : 0x00
Device ID    : 0x0429 (STM32L1xxx6(8/B)A)
- RAM        : 32KiB  (4096b reserved by bootloader)
- Flash      : 128KiB (size first sector: 16x256)
- Option RAM : 32b
- System RAM : 4KiB
Write to memory
Erasing memory
Wrote address 0x080027bc (100.00%) Done.

-- runners.stm32flash: Board: finished 'write' .
root:zephyr#
```

```
*** Booting Zephyr OS build zephyr-v1.13.0-13077-gdbd1f9f13785  ***
Hello World! 96b_wistrio
```