### PR TITLE
west.yml: Update ci-tools to add misc. new CI checks

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -29,7 +29,7 @@ manifest:
       revision: 5690f5b84495c8b657ff204c5c827df1ab9e12e3
       path: modules/hal/atmel
     - name: ci-tools
-      revision: 081d80d6e25366a311015f00418898a94bff6b64
+      revision: eb7f1e19eff28d486c64b850ef7b9dcd0331a7af
       path: tools/ci-tools
     - name: civetweb
       revision: 99129c5efc907ea613c4b73ccff07581feb58a7a


### PR DESCRIPTION
Gets these commits in:

    check_compliance.py: Detect refs to undef. symbols in samples and tests

    Extend the check for references to undefined Kconfig symbols to also
    detect undefined symbols in samples and tests.

    Samples and tests were skipped due to using separate Kconfig trees,
    which hid the symbols defined in them. Work around it by grepping
    for Kconfig symbol definitions in them instead.

    Keep properly parsing the main Kconfig tree, as it's needed to see
    symbol names that are stitched together with the Kconfig
    preprocessor.

    ------------------------------------------------------------------

    check_compliance.py: Detect bad header comments and other nits

    Add a generic kitchen-sink Nits test for various minor nits that
    aren't already covered by tools like checkpatch.pl and pylint. So
    far checks this:

     - Header comments in Kconfig files

     - Missing newlines at the end of various source files (probably a
       bad editor setting)

     - Leading/trailing blank lines in files

    ------------------------------------------------------------------

    check_compliance.py: Kconfig: Flag redundant $ZEPHYR_BASE in
    'source'

    'source's like

        source "$(ZEPHYR_BASE)/Kconfig.zephyr"

    can be simplified to

        source "Kconfig.zephyr"

    since $srctree already points to the Zephyr root.

    Flag it in the Nits test.

    This also avoids absolute paths showing up in some places.

    ------------------------------------------------------------------

    check_compliance.py: Improve error reporting for Git commands

    Similar improvements to
    https://github.com/zephyrproject-rtos/zephyr/pull/21577. No custom
    potentially-missing working directory is used here, but always
    including the exception message still feels more robust.

    Use err() instead of sys.exit() in git(), and have it include the
    command name, which is helpful in logs.