### PR TITLE
CODEOWNERS: Add aescolar to tests/bluetooth/bsim_bt/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -394,6 +394,7 @@
 /tests/boards/native_posix/               @aescolar
 /tests/boards/intel_s1000_crb/            @dcpleung @sathishkuttan
 /tests/bluetooth/                         @joerchan @jhedberg @Vudentz
+/tests/bluetooth/bsim_bt/                 @joerchan @jhedberg @Vudentz @aescolar
 /tests/posix/                             @pfalcon
 /tests/crypto/                            @ceolin
 /tests/crypto/mbedtls/                    @nashif @ceolin


### PR DESCRIPTION
Add aescolar to be automatically added for reviews
for changes in tests/bluetooth/bsim_bt/

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>