### PR TITLE
runners: openocd: don't throw when no config is provided

### DIFF
--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -30,7 +30,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                 config = default
         self.openocd_config = config
 
-        if path.exists(self.openocd_config):
+        if self.openocd_config is not None and path.exists(self.openocd_config):
             search_args = ['-s', path.dirname(self.openocd_config)]
         else:
             search_args = []


### PR DESCRIPTION
In some cases the config is already provided for us e.g. when setting OPENOCD_NRF5_SUBFAMILY. Also it looks like config was always supposed to be optional (there are checks for it in do_run()).
