### PR TITLE
subsys/mgmt: Enabling mynewt-core version of tinycbor

### DIFF
--- a/include/mgmt/buf.h
+++ b/include/mgmt/buf.h
@@ -8,8 +8,8 @@
 #define ZEPHYR_INCLUDE_MGMT_BUF_H_
 
 #include <inttypes.h>
-#include "cbor_encoder_writer.h"
-#include "cbor_decoder_reader.h"
+#include "tinycbor/cbor.h"
+#include "tinycbor/cbor_buf_writer.h"
 struct net_buf;
 
 struct cbor_nb_reader {

--- a/modules/Kconfig.tinycbor
+++ b/modules/Kconfig.tinycbor
@@ -8,16 +8,6 @@ config TINYCBOR
 
 if TINYCBOR
 
-config CBOR_NO_DFLT_WRITER
-	bool "No default writer support"
-	help
-	  This option specifies whether a default writer exists.
-
-config CBOR_NO_DFLT_READER
-	bool "No default reader support"
-	help
-	  This option specifies whether a default reader exists.
-
 config CBOR_ENCODER_NO_CHECK_USER
 	bool "No encoder checks for user args for validity"
 	help

--- a/subsys/mgmt/buf.c
+++ b/subsys/mgmt/buf.c
@@ -8,7 +8,7 @@
 #include <string.h>
 #include "net/buf.h"
 #include "mgmt/buf.h"
-#include "compilersupport_p.h"
+#include <tinycbor/compilersupport_p.h>
 
 NET_BUF_POOL_DEFINE(pkt_pool, CONFIG_MCUMGR_BUF_COUNT, CONFIG_MCUMGR_BUF_SIZE,
 		    CONFIG_MCUMGR_BUF_USER_DATA_SIZE, NULL);
@@ -117,16 +117,6 @@ cbor_nb_reader_cpy(struct cbor_decoder_reader *d, char *dst, int offset,
 	return (uintptr_t)memcpy(dst, cnr->nb->data + offset, len);
 }
 
-static uintptr_t
-cbor_nb_get_string_chunk(struct cbor_decoder_reader *d, int offset,
-			 size_t *len)
-{
-	struct cbor_nb_reader *cnr;
-
-	cnr = (struct cbor_nb_reader *) d;
-	return (uintptr_t)cnr->nb->data + offset;
-}
-
 void
 cbor_nb_reader_init(struct cbor_nb_reader *cnr,
 		    struct net_buf *nb)
@@ -137,7 +127,6 @@ cbor_nb_reader_init(struct cbor_nb_reader *cnr,
 	cnr->r.get64 = &cbor_nb_reader_get64;
 	cnr->r.cmp = &cbor_nb_reader_cmp;
 	cnr->r.cpy = &cbor_nb_reader_cpy;
-	cnr->r.get_string_chunk = &cbor_nb_get_string_chunk;
 
 	cnr->nb = nb;
 	cnr->r.message_size = nb->len;

--- a/west.yml
+++ b/west.yml
@@ -77,10 +77,10 @@ manifest:
       revision: cf7020eb4c7ef93319f2d6d2403a21e12a879bf6
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: v1.5.0
+      revision: 470e2f3d5bdcb1892d76a534a745186fd8ff5aab
       path: bootloader/mcuboot
     - name: mcumgr
-      revision: 0a7149965a5684a539213e9295115d6ee90be716
+      revision: 301892dad2eb97294f634b632c4ab6a6c56426b5
       path: modules/lib/mcumgr
     - name: net-tools
       revision: 4bff01084d225996e4aae84b98be5969e2f9f33d
@@ -102,7 +102,7 @@ manifest:
       path: modules/debug/segger
     - name: tinycbor
       path: modules/lib/tinycbor
-      revision: 0fc68fceacd1efc1ce809c5880c380f3d98b7b6e
+      revision: 3cb8555348358d437893d3ab8e8de4e3b916afae
     - name: littlefs
       path: modules/fs/littlefs
       revision: fe9572dd5a9fcf93a249daa4233012692bd2881d


### PR DESCRIPTION
_NOTE: This PR depends on changes provided by listed below PRs, to the other projects, and also serves as the umbrella PR that gathers them in west.yml.
Other PRs:
tinycbor: https://github.com/zephyrproject-rtos/tinycbor/pull/11
~mcumgr: https://github.com/zephyrproject-rtos/mcumgr/pull/9~
upstream mcumgr: https://github.com/apache/mynewt-mcumgr/pull/71 (merged)
upstream mcuboot: https://github.com/JuulLabs-OSS/mcuboot/pull/633 (merged)

Missing: Update west.yml so it points to PRs in mcumgr/mcuboot in zephyproject-rtos with the latest upstream changes from both repos.

This PR provides changes that are required after replacing Tinycbor with copy of source code from mynewt-core. The Tinycbor has been replaced with mynewt-core version to reduce maintenance effort; by replacing it the Zephy specific changes have been reduced to small patch over mynewt codebase.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>