### PR TITLE
bluetooth: select BT_RPMSG_NRF53 for non-secure variant of nrf5340

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -103,7 +103,7 @@ if BT_RPMSG
 
 config BT_RPMSG_NRF53
 	bool "nRF53 configuration of RPMsg"
-	default y if BOARD_NRF5340_DK_NRF5340_CPUAPP
+	default y if (BOARD_NRF5340_DK_NRF5340_CPUAPP || BOARD_NRF5340_DK_NRF5340_CPUAPPNS)
 	select IPM
 	select IPM_NRFX
 	select IPM_MSG_CH_1_ENABLE


### PR DESCRIPTION
Prior to this you would get compilation error when building
samples for the nrf5340_dk_nrf5340_cpuappns board.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>