### PR TITLE
Bluetooth: host: Remove toggling advertiser on advertise data update

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -5272,12 +5272,6 @@ int bt_set_name(const char *name)
 		struct bt_ad sd = { data, ARRAY_SIZE(data) };
 
 		set_ad(BT_HCI_OP_LE_SET_SCAN_RSP_DATA, &sd, 1);
-
-		/* Make sure the new name is set */
-		if (atomic_test_bit(bt_dev.flags, BT_DEV_ADVERTISING)) {
-			set_advertise_enable(false);
-			set_advertise_enable(true);
-		}
 	}
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {


### PR DESCRIPTION
Remove toggling the advertise enable state when the advertiser name has
been updated. Advertise and scan response data should be used by the
controller on subsequent advertising events.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>