### PR TITLE
net : socket : make socket_tls depend on mbedtls

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -48,6 +48,7 @@ config NET_SOCKETS_DNS_TIMEOUT
 
 config NET_SOCKETS_SOCKOPT_TLS
 	bool "Enable TCP TLS socket option support [EXPERIMENTAL]"
+	depends on MBEDTLS
 	select TLS_CREDENTIALS
 	help
 	  Enable TLS socket option support which automatically establishes


### PR DESCRIPTION
Socket_tls.c is depending on mbedtls.  If mbedtls is not configured, socket_tls gives compile issues

Signed-off-by: Wim Van Loocke denv8029@gmail.com