### PR TITLE
Update nRF 802.15.4 radio driver

### DIFF
--- a/boards/arm/nrf52811_pca10056/Kconfig.defconfig
+++ b/boards/arm/nrf52811_pca10056/Kconfig.defconfig
@@ -39,4 +39,11 @@ config PWM_0
 
 endif # PWM
 
+if IEEE802154
+
+config IEEE802154_NRF5
+	default y
+
+endif # IEEE802154
+
 endif # BOARD_NRF52811_PCA10056

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52811_QFAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52811_QFAA
@@ -11,4 +11,7 @@ config SOC
 config NUM_IRQS
 	default 30
 
+config NET_CONFIG_IEEE802154_DEV_NAME
+	default IEEE802154_NRF5_DRV_NAME
+
 endif # SOC_NRF52811_QFAA

--- a/west.yml
+++ b/west.yml
@@ -47,7 +47,7 @@ manifest:
       revision: a12d92816a53a521d79cefcf5c38b9dc8a4fed6e
       path: modules/hal/cypress
     - name: hal_nordic
-      revision: 8506c348b6da91a9f53bcbb181ecd82b752b9eed
+      revision: a1f24a4ee9774fe96390f2c6473b490c88b01ef6
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 9bfbe35aad79fdf552dbdae47a894e26be7c022c


### PR DESCRIPTION
This PR introduces the latest version of the nRF 802.15.4 radio driver, including support for the nRF52811 chip. 

Additionally, update default config for `nrf52811_pca10056` board / `nRF52811` SoC, to enable the driver automatically when 802.15.4 subsystem is enabled, as other Nordic 802.15.4-compliant boards do.