### PR TITLE
dts: boards: Define dts aliases at soc level for nxp socs

### DIFF
--- a/boards/arm/96b_meerkat96/96b_meerkat96.dts
+++ b/boards/arm/96b_meerkat96/96b_meerkat96.dts
@@ -39,13 +39,10 @@
 	};
 
 	aliases {
-		gpio-1 = &gpio1;
 		led0   = &green_led_0;
 		led1   = &green_led_1;
 		led2   = &green_led_2;
 		led3   = &green_led_3;
-		uart-1 = &uart1;
-		mu-b   = &mub;
 	};
 };
 

--- a/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
+++ b/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
@@ -13,14 +13,8 @@
 	compatible = "nxp,mcimx7d_m4";
 
 	aliases {
-		gpio-1 = &gpio1;
-		gpio-2 = &gpio2;
-		uart-2 = &uart2;
 		led0   = &green_led;
 		sw0    = &user_switch_1;
-		i2c-4  = &i2c4;
-		pwm-1  = &pwm1;
-		mu-b   = &mub;
 	};
 
 	chosen {

--- a/boards/arm/frdm_k22f/frdm_k22f.dts
+++ b/boards/arm/frdm_k22f/frdm_k22f.dts
@@ -13,24 +13,6 @@
 	compatible = "nxp,mk22f12", "nxp,k22f", "nxp,k2x";
 
 	aliases {
-		adc-0 = &adc0;
-		pwm-0 = &pwm0;
-		pwm-1 = &pwm1;
-		pwm-2 = &pwm2;
-		pwm-3 = &pwm3;
-		uart-0 = &uart0;
-		pinmux-a = &pinmux_a;
-		pinmux-b = &pinmux_b;
-		pinmux-c = &pinmux_c;
-		pinmux-d = &pinmux_d;
-		pinmux-e = &pinmux_e;
-		gpio-a = &gpioa;
-		gpio-b = &gpiob;
-		gpio-c = &gpioc;
-		gpio-d = &gpiod;
-		gpio-e = &gpioe;
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
 		led0 = &green_led;
 		led1 = &blue_led;
 		led2 = &red_led;

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -9,34 +9,11 @@
 	compatible = "nxp,mk64f12", "nxp,k64f", "nxp,k6x";
 
 	aliases {
-		adc-0 = &adc0;
-		adc-1 = &adc1;
-		pwm-0 = &pwm0;
-		pwm-1 = &pwm1;
-		pwm-2 = &pwm2;
-		pwm-3 = &pwm3;
-		uart-0 = &uart0;
-		uart-3 = &uart3;
-		pinmux-a = &pinmux_a;
-		pinmux-b = &pinmux_b;
-		pinmux-c = &pinmux_c;
-		pinmux-d = &pinmux_d;
-		pinmux-e = &pinmux_e;
-		gpio-a = &gpioa;
-		gpio-b = &gpiob;
-		gpio-c = &gpioc;
-		gpio-d = &gpiod;
-		gpio-e = &gpioe;
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		i2c-2 = &i2c2;
 		led0 = &green_led;
 		led1 = &blue_led;
 		led2 = &red_led;
 		sw0 = &user_button_3;
 		sw1 = &user_button_2;
-		eth = &eth;
-		can-0 = &can0;
 	};
 
 	chosen {

--- a/boards/arm/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.dts
@@ -9,15 +9,6 @@
 	compatible = "nxp,frdm-kl25z", "nxp,kl25z", "nxp,mkl25z4";
 
 	aliases {
-		adc-0 = &adc0;
-		uart-0 = &uart0;
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		gpio-a = &gpioa;
-		gpio-b = &gpiob;
-		gpio-c = &gpioc;
-		gpio-d = &gpiod;
-		gpio-e = &gpioe;
 		led0 = &green_led;
 		led1 = &blue_led;
 		led2 = &red_led;

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -9,22 +9,11 @@
 	compatible = "nxp,kw41z", "nxp,mkw41z4";
 
 	aliases {
-		adc-0 = &adc0;
-		lpuart-0 = &lpuart0;
-		pinmux-a = &pinmux_a;
-		pinmux-b = &pinmux_b;
-		pinmux-c = &pinmux_c;
-		gpio-a = &gpioa;
-		gpio-b = &gpiob;
-		gpio-c = &gpioc;
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
 		led0 = &green_led;
 		led1 = &blue_led;
 		led2 = &red_led;
 		sw0 = &user_button_3;
 		sw1 = &user_button_4;
-		rtc-0 = &rtc0;
 	};
 
 	chosen {

--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -10,27 +10,6 @@
 	compatible = "nxp,hexiwear", "nxp,k64f", "nxp,k6x";
 
 	aliases {
-		adc-0 = &adc0;
-		adc-1 = &adc1;
-		pwm-0 = &pwm0;
-		pwm-1 = &pwm1;
-		pwm-2 = &pwm2;
-		pwm-3 = &pwm3;
-		uart-0 = &uart0;
-		uart-4 = &uart4;
-		pinmux-a = &pinmux_a;
-		pinmux-b = &pinmux_b;
-		pinmux-c = &pinmux_c;
-		pinmux-d = &pinmux_d;
-		pinmux-e = &pinmux_e;
-		gpio-a = &gpioa;
-		gpio-b = &gpiob;
-		gpio-c = &gpioc;
-		gpio-d = &gpiod;
-		gpio-e = &gpioe;
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		i2c-2 = &i2c2;
 		led0 = &green_led;
 		led1 = &blue_led;
 		led2 = &red_led;

--- a/boards/arm/hexiwear_kw40z/hexiwear_kw40z.dts
+++ b/boards/arm/hexiwear_kw40z/hexiwear_kw40z.dts
@@ -8,19 +8,6 @@
 	model = "Hexiwear KW40 board";
 	compatible = "nxp,kw40z", "nxp,mkw40z4";
 
-	aliases {
-		adc-0 = &adc0;
-		lpuart-0 = &lpuart0;
-		pinmux-a = &pinmux_a;
-		pinmux-b = &pinmux_b;
-		pinmux-c = &pinmux_c;
-		gpio-a = &gpioa;
-		gpio-b = &gpiob;
-		gpio-c = &gpioc;
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-	};
-
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/lpcxpresso54114/lpcxpresso54114.dtsi
+++ b/boards/arm/lpcxpresso54114/lpcxpresso54114.dtsi
@@ -6,12 +6,9 @@
 
 / {
 	aliases{
-		usart-0 = &usart0;
-		mailbox-0 = &mailbox0;
 		led0 = &red_led;
 		led1 = &green_led;
 		led2 = &blue_led;
-		spi-5 = &spi5;
 	};
 
 	leds {

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69.dtsi
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69.dtsi
@@ -6,11 +6,9 @@
 
 / {
 	aliases{
-		usart-0 = &usart0;
 		led0 = &red_led;
 		led1 = &green_led;
 		led2 = &blue_led;
-		spi-8 = &spi8;
 	};
 
 	leds {

--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -13,11 +13,6 @@
 	compatible = "nxp,mimxrt1010";
 
 	aliases {
-		gpio-1= &gpio1;
-		gpio-2= &gpio2_rt1010;
-		gpio-5= &gpio5;
-		i2c-1 = &i2c1;
-		uart-1 = &uart1;
 		led0 = &green_led;
 		sw0 = &user_button;
 	};

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -13,14 +13,6 @@
 	compatible = "nxp,mimxrt1015";
 
 	aliases {
-		gpio-1= &gpio1;
-		gpio-2= &gpio2;
-		gpio-3= &gpio3;
-		gpio-4= &gpio4;
-		gpio-5= &gpio5;
-		i2c-1 = &i2c1;
-		uart-1 = &uart1;
-		uart-4 = &uart4;
 		led0 = &green_led;
 		sw0 = &user_button;
 	};

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -13,17 +13,8 @@
 	compatible = "nxp,mimxrt1021";
 
 	aliases {
-		gpio-1= &gpio1;
-		gpio-2= &gpio2;
-		gpio-3= &gpio3;
-		gpio-4= &gpio4;
-		gpio-5= &gpio5;
-		i2c-1 = &i2c1;
-		i2c-4 = &i2c4;
-		uart-1 = &uart1;
 		led0 = &green_led;
 		sw0 = &user_button;
-		eth = &eth;
 	};
 
 	chosen {

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -13,18 +13,8 @@
 	compatible = "nxp,mimxrt1052";
 
 	aliases {
-		gpio-1= &gpio1;
-		gpio-2= &gpio2;
-		gpio-3= &gpio3;
-		gpio-4= &gpio4;
-		gpio-5= &gpio5;
-		i2c-1 = &i2c1;
-		uart-1 = &uart1;
-		uart-3 = &uart3;
 		led0 = &green_led;
 		sw0 = &user_button;
-		spi-3 = &spi3;
-		eth = &eth;
 	};
 
 	chosen {

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -13,15 +13,8 @@
 	compatible = "nxp,mimxrt1062";
 
 	aliases {
-		gpio-1= &gpio1;
-		gpio-2= &gpio2;
-		gpio-3= &gpio3;
-		gpio-4= &gpio4;
-		gpio-5= &gpio5;
-		uart-1 = &uart1;
 		led0 = &green_led;
 		sw0 = &user_button;
-		eth = &eth;
 	};
 
 	chosen {

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -13,16 +13,9 @@
 	compatible = "nxp,mimxrt1064";
 
 	aliases {
-		gpio-1= &gpio1;
-		gpio-2= &gpio2;
-		gpio-3= &gpio3;
-		gpio-4= &gpio4;
-		gpio-5= &gpio5;
-		uart-1 = &uart1;
 		led0 = &green_led;
 		pwm-led0 = &green_pwm_led;
 		sw0 = &user_button;
-		eth = &eth;
 	};
 
 	chosen {

--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -13,7 +13,6 @@
 	compatible = "nxp,mimxrt1052";
 
 	aliases {
-		uart-1 = &uart1;
 		led0 = &green_led;
 		led1 = &red_led;
 		led2 = &blue_led;

--- a/boards/arm/udoo_neo_full_m4/udoo_neo_full_m4.dts
+++ b/boards/arm/udoo_neo_full_m4/udoo_neo_full_m4.dts
@@ -31,14 +31,7 @@
 	compatible = "nxp,mcimx6x_m4";
 
 	aliases {
-		uart-5 = &uart5;
-		gpio-4 = &gpio4;
-		gpio-5 = &gpio5;
-		gpio-6 = &gpio6;
 		led0 = &red_led;
-		mu-b = &mub;
-		epit-1 = &epit1;
-		epit-2 = &epit2;
 	};
 
 	chosen {

--- a/boards/arm/usb_kw24d512/usb_kw24d512.dts
+++ b/boards/arm/usb_kw24d512/usb_kw24d512.dts
@@ -9,18 +9,6 @@
 	compatible = "nxp,usb-kw24d512", "nxp,kw24d512", "nxp,kw2xd";
 
 	aliases {
-		uart-0 = &uart0;
-		pinmux-a = &pinmux_a;
-		pinmux-b = &pinmux_b;
-		pinmux-c = &pinmux_c;
-		pinmux-d = &pinmux_d;
-		pinmux-e = &pinmux_e;
-		gpio-a = &gpioa;
-		gpio-b = &gpiob;
-		gpio-c = &gpioc;
-		gpio-d = &gpiod;
-		gpio-e = &gpioe;
-		i2c-0 = &i2c0;
 		led0 = &led_0;
 		led1 = &led_1;
 		sw0 = &user_button_1;

--- a/boards/arm/warp7_m4/warp7_m4.dts
+++ b/boards/arm/warp7_m4/warp7_m4.dts
@@ -13,12 +13,7 @@
 	compatible = "nxp,mcimx7d_m4";
 
 	aliases {
-		gpio-7 = &gpio7;
-		uart-2 = &uart2;
-		uart-6 = &uart6;
 		sw0    = &user_switch_1;
-		i2c-4  = &i2c4;
-		mu-b   = &mub;
 	};
 
 	chosen {

--- a/dts/arm/nxp/nxp_imx6sx_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx6sx_m4.dtsi
@@ -9,6 +9,25 @@
 #include <dt-bindings/rdc/imx_rdc.h>
 
 / {
+	aliases {
+		epit-1 = &epit1;
+		epit-2 = &epit2;
+		gpio-1 = &gpio1;
+		gpio-2 = &gpio2;
+		gpio-3 = &gpio3;
+		gpio-4 = &gpio4;
+		gpio-5 = &gpio5;
+		gpio-6 = &gpio6;
+		gpio-7 = &gpio7;
+		mu-b = &mub;
+		uart-1 = &uart1;
+		uart-2 = &uart2;
+		uart-3 = &uart3;
+		uart-4 = &uart4;
+		uart-5 = &uart5;
+		uart-6 = &uart6;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/nxp_imx7d_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx7d_m4.dtsi
@@ -10,6 +10,32 @@
 #include <dt-bindings/rdc/imx_rdc.h>
 
 / {
+	aliases {
+		gpio-1 = &gpio1;
+		gpio-2 = &gpio2;
+		gpio-3 = &gpio3;
+		gpio-4 = &gpio4;
+		gpio-5 = &gpio5;
+		gpio-6 = &gpio6;
+		gpio-7 = &gpio7;
+		i2c-1 = &i2c1;
+		i2c-2 = &i2c2;
+		i2c-3 = &i2c3;
+		i2c-4 = &i2c4;
+		mu-b   = &mub;
+		pwm-1 = &pwm1;
+		pwm-2 = &pwm2;
+		pwm-3 = &pwm3;
+		pwm-4 = &pwm4;
+		uart-1 = &uart1;
+		uart-2 = &uart2;
+		uart-3 = &uart3;
+		uart-4 = &uart4;
+		uart-5 = &uart5;
+		uart-6 = &uart6;
+		uart-7 = &uart7;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -13,6 +13,30 @@
 / {
 
 	aliases {
+		adc-0 = &adc0;
+		gpio-a = &gpioa;
+		gpio-b = &gpiob;
+		gpio-c = &gpioc;
+		gpio-d = &gpiod;
+		gpio-e = &gpioe;
+		i2c-0 = &i2c0;
+		i2c-1 = &i2c1;
+		pinmux-a = &pinmux_a;
+		pinmux-b = &pinmux_b;
+		pinmux-c = &pinmux_c;
+		pinmux-d = &pinmux_d;
+		pinmux-e = &pinmux_e;
+		pwm-0 = &pwm0;
+		pwm-1 = &pwm1;
+		pwm-2 = &pwm2;
+		pwm-3 = &pwm3;
+		spi-0 = &spi0;
+		spi-1 = &spi1;
+		uart-0 = &uart0;
+		uart-1 = &uart1;
+		uart-2 = &uart2;
+		uart-3 = &uart3;
+		usbd-0 = &usbd;
 		watchdog0 = &wdog;
 	};
 

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -9,6 +9,37 @@
 / {
 
 	aliases {
+		adc-0 = &adc0;
+		adc-1 = &adc1;
+		can-0 = &can0;
+		eth = &eth;
+		gpio-a = &gpioa;
+		gpio-b = &gpiob;
+		gpio-c = &gpioc;
+		gpio-d = &gpiod;
+		gpio-e = &gpioe;
+		i2c-0 = &i2c0;
+		i2c-1 = &i2c1;
+		i2c-2 = &i2c2;
+		pinmux-a = &pinmux_a;
+		pinmux-b = &pinmux_b;
+		pinmux-c = &pinmux_c;
+		pinmux-d = &pinmux_d;
+		pinmux-e = &pinmux_e;
+		pwm-0 = &pwm0;
+		pwm-1 = &pwm1;
+		pwm-2 = &pwm2;
+		pwm-3 = &pwm3;
+		spi-0 = &spi0;
+		spi-1 = &spi1;
+		spi-2 = &spi2;
+		uart-0 = &uart0;
+		uart-1 = &uart1;
+		uart-2 = &uart2;
+		uart-3 = &uart3;
+		uart-4 = &uart4;
+		uart-5 = &uart5;
+		usbd-0 = &usbd;
 		watchdog0 = &wdog;
 	};
 

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -6,6 +6,19 @@
 #include <dt-bindings/i2c/i2c.h>
 
 / {
+	aliases {
+		adc-0 = &adc0;
+		gpio-a = &gpioa;
+		gpio-b = &gpiob;
+		gpio-c = &gpioc;
+		gpio-d = &gpiod;
+		gpio-e = &gpioe;
+		i2c-0 = &i2c0;
+		i2c-1 = &i2c1;
+		uart-0 = &uart0;
+		usbd-0 = &usbd;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -8,6 +8,28 @@
 
 / {
 	aliases {
+		adc-0 = &adc0;
+		gpio-a = &gpioa;
+		gpio-b = &gpiob;
+		gpio-c = &gpioc;
+		gpio-d = &gpiod;
+		gpio-e = &gpioe;
+		i2c-0 = &i2c0;
+		i2c-1 = &i2c1;
+		pinmux-a = &pinmux_a;
+		pinmux-b = &pinmux_b;
+		pinmux-c = &pinmux_c;
+		pinmux-d = &pinmux_d;
+		pinmux-e = &pinmux_e;
+		pwm-0 = &pwm0;
+		pwm-1 = &pwm1;
+		pwm-2 = &pwm2;
+		spi-0 = &spi0;
+		spi-1 = &spi1;
+		uart-0 = &uart0;
+		uart-1 = &uart1;
+		uart-2 = &uart2;
+		usbd-0 = &usbd;
 		watchdog0 = &wdog;
 	};
 

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -6,6 +6,24 @@
 #include <dt-bindings/i2c/i2c.h>
 
 / {
+	aliases {
+		adc-0 = &adc0;
+		gpio-a = &gpioa;
+		gpio-b = &gpiob;
+		gpio-c = &gpioc;
+		i2c-0 = &i2c0;
+		i2c-1 = &i2c1;
+		pinmux-a = &pinmux_a;
+		pinmux-b = &pinmux_b;
+		pinmux-c = &pinmux_c;
+		pwm-0 = &pwm0;
+		pwm-1 = &pwm1;
+		pwm-2 = &pwm2;
+		spi-0 = &spi0;
+		spi-1 = &spi1;
+		uart-0 = &lpuart0;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -6,6 +6,25 @@
 #include <dt-bindings/i2c/i2c.h>
 
 / {
+	aliases {
+		adc-0 = &adc0;
+		gpio-a = &gpioa;
+		gpio-b = &gpiob;
+		gpio-c = &gpioc;
+		i2c-0 = &i2c0;
+		i2c-1 = &i2c1;
+		pinmux-a = &pinmux_a;
+		pinmux-b = &pinmux_b;
+		pinmux-c = &pinmux_c;
+		pwm-0 = &pwm0;
+		pwm-1 = &pwm1;
+		pwm-2 = &pwm2;
+		rtc-0 = &rtc0;
+		spi-0 = &spi0;
+		spi-1 = &spi1;
+		uart-0 = &lpuart0;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/nxp_lpc54xxx.dtsi
+++ b/dts/arm/nxp/nxp_lpc54xxx.dtsi
@@ -7,6 +7,14 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
+	aliases{
+		gpio-0 = &gpio0;
+		gpio-1 = &gpio1;
+		mailbox-0 = &mailbox0;
+		spi-5 = &spi5;
+		usart-0 = &usart0;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/nxp_lpc55S6x.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x.dtsi
@@ -9,6 +9,15 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
+	aliases{
+		gpio-0 = &gpio0;
+		gpio-1 = &gpio1;
+		gpio-2 = &gpio2;
+		gpio-3 = &gpio3;
+		spi-8 = &spi8;
+		usart-0 = &usart0;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -10,6 +10,33 @@
 #include <dt-bindings/i2c/i2c.h>
 
 / {
+	aliases {
+		eth = &eth;
+		gpio-1 = &gpio1;
+		gpio-2 = &gpio2;
+		gpio-3 = &gpio3;
+		gpio-4 = &gpio4;
+		gpio-5 = &gpio5;
+		i2c-1 = &i2c1;
+		i2c-2 = &i2c2;
+		i2c-3 = &i2c3;
+		i2c-4 = &i2c4;
+		spi-1 = &spi1;
+		spi-2 = &spi2;
+		spi-3 = &spi3;
+		spi-4 = &spi4;
+		uart-1 = &uart1;
+		uart-2 = &uart2;
+		uart-3 = &uart3;
+		uart-4 = &uart4;
+		uart-5 = &uart5;
+		uart-6 = &uart6;
+		uart-7 = &uart7;
+		uart-8 = &uart8;
+		usbd-1 = &usbd1;
+		usbd-2 = &usbd2;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/nxp_rt1010.dtsi
+++ b/dts/arm/nxp/nxp_rt1010.dtsi
@@ -72,6 +72,10 @@
 };
 
 / {
+	aliases {
+		gpio-2 = &gpio2_rt1010;
+	};
+
 	soc {
 		gpio2_rt1010: gpio@42000000 {
 			compatible = "nxp,imx-gpio";


### PR DESCRIPTION
Defines device tree aliases for on-chip peripherals at the soc level
instead of the board level for all nxp socs. The eliminates some
duplicate code in the board level device trees, and will allow drivers
to use device-tree generated macros directly instead of through dts
fixups.