### PR TITLE
samples/boards/reel_board: unlook file write protection.

### DIFF
--- a/samples/boards/reel_board/mesh_badge/src/reel_board.c
+++ b/samples/boards/reel_board/mesh_badge/src/reel_board.c
@@ -575,6 +575,8 @@ static int erase_storage(void)
 	struct device *dev;
 
 	dev = device_get_binding(DT_FLASH_DEV_NAME);
+	
+	flash_write_protection_set(dev, false);
 
 	return flash_erase(dev, DT_FLASH_AREA_STORAGE_OFFSET,
 			   DT_FLASH_AREA_STORAGE_SIZE);

--- a/samples/boards/reel_board/mesh_badge/src/reel_board.c
+++ b/samples/boards/reel_board/mesh_badge/src/reel_board.c
@@ -575,7 +575,7 @@ static int erase_storage(void)
 	struct device *dev;
 
 	dev = device_get_binding(DT_FLASH_DEV_NAME);
-	
+
 	flash_write_protection_set(dev, false);
 
 	return flash_erase(dev, DT_FLASH_AREA_STORAGE_OFFSET,


### PR DESCRIPTION
By resetting the reel board (pressing user button with the reset button) the write protection is disabled and the displayed text will be erased. With active write protection the board remains in mesh-mode and there is no possibility to access it via bluetooth.

Signed-off-by: Juergen Koerner <juergen.koerner@t-online.de>