### PR TITLE
dts: boards: Define dts aliases at soc level for i.mx rt socs

### DIFF
--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -13,11 +13,6 @@
 	compatible = "nxp,mimxrt1010";
 
 	aliases {
-		gpio-1= &gpio1;
-		gpio-2= &gpio2_rt1010;
-		gpio-5= &gpio5;
-		i2c-1 = &i2c1;
-		uart-1 = &uart1;
 		led0 = &green_led;
 		sw0 = &user_button;
 	};

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -13,14 +13,6 @@
 	compatible = "nxp,mimxrt1015";
 
 	aliases {
-		gpio-1= &gpio1;
-		gpio-2= &gpio2;
-		gpio-3= &gpio3;
-		gpio-4= &gpio4;
-		gpio-5= &gpio5;
-		i2c-1 = &i2c1;
-		uart-1 = &uart1;
-		uart-4 = &uart4;
 		led0 = &green_led;
 		sw0 = &user_button;
 	};

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -13,17 +13,8 @@
 	compatible = "nxp,mimxrt1021";
 
 	aliases {
-		gpio-1= &gpio1;
-		gpio-2= &gpio2;
-		gpio-3= &gpio3;
-		gpio-4= &gpio4;
-		gpio-5= &gpio5;
-		i2c-1 = &i2c1;
-		i2c-4 = &i2c4;
-		uart-1 = &uart1;
 		led0 = &green_led;
 		sw0 = &user_button;
-		eth = &eth;
 	};
 
 	chosen {

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -13,18 +13,8 @@
 	compatible = "nxp,mimxrt1052";
 
 	aliases {
-		gpio-1= &gpio1;
-		gpio-2= &gpio2;
-		gpio-3= &gpio3;
-		gpio-4= &gpio4;
-		gpio-5= &gpio5;
-		i2c-1 = &i2c1;
-		uart-1 = &uart1;
-		uart-3 = &uart3;
 		led0 = &green_led;
 		sw0 = &user_button;
-		spi-3 = &spi3;
-		eth = &eth;
 	};
 
 	chosen {

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -13,15 +13,8 @@
 	compatible = "nxp,mimxrt1062";
 
 	aliases {
-		gpio-1= &gpio1;
-		gpio-2= &gpio2;
-		gpio-3= &gpio3;
-		gpio-4= &gpio4;
-		gpio-5= &gpio5;
-		uart-1 = &uart1;
 		led0 = &green_led;
 		sw0 = &user_button;
-		eth = &eth;
 	};
 
 	chosen {

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -13,16 +13,9 @@
 	compatible = "nxp,mimxrt1064";
 
 	aliases {
-		gpio-1= &gpio1;
-		gpio-2= &gpio2;
-		gpio-3= &gpio3;
-		gpio-4= &gpio4;
-		gpio-5= &gpio5;
-		uart-1 = &uart1;
 		led0 = &green_led;
 		pwm-led0 = &green_pwm_led;
 		sw0 = &user_button;
-		eth = &eth;
 	};
 
 	chosen {

--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -13,7 +13,6 @@
 	compatible = "nxp,mimxrt1052";
 
 	aliases {
-		uart-1 = &uart1;
 		led0 = &green_led;
 		led1 = &red_led;
 		led2 = &blue_led;

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -10,6 +10,33 @@
 #include <dt-bindings/i2c/i2c.h>
 
 / {
+	aliases {
+		eth = &eth;
+		gpio-1 = &gpio1;
+		gpio-2 = &gpio2;
+		gpio-3 = &gpio3;
+		gpio-4 = &gpio4;
+		gpio-5 = &gpio5;
+		i2c-1 = &i2c1;
+		i2c-2 = &i2c2;
+		i2c-3 = &i2c3;
+		i2c-4 = &i2c4;
+		spi-1 = &spi1;
+		spi-2 = &spi2;
+		spi-3 = &spi3;
+		spi-4 = &spi4;
+		uart-1 = &uart1;
+		uart-2 = &uart2;
+		uart-3 = &uart3;
+		uart-4 = &uart4;
+		uart-5 = &uart5;
+		uart-6 = &uart6;
+		uart-7 = &uart7;
+		uart-8 = &uart8;
+		usbd-1 = &usbd1;
+		usbd-2 = &usbd2;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/nxp_rt1010.dtsi
+++ b/dts/arm/nxp/nxp_rt1010.dtsi
@@ -72,6 +72,10 @@
 };
 
 / {
+	aliases {
+		gpio-2 = &gpio2_rt1010;
+	};
+
 	soc {
 		gpio2_rt1010: gpio@42000000 {
 			compatible = "nxp,imx-gpio";


### PR DESCRIPTION
Defines device tree aliases for on-chip peripherals at the soc level
instead of the board level for all i.mx rt socs. The eliminates some
duplicate code in the board level device trees, and will allow drivers
to use device-tree generated macros directly instead of through dts
fixups.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Resubmitting one commit from #21836 to see if it can finish CI without timing out