### PR TITLE
dts: boards: Define dts aliases at soc level for lpc and i.mx 6/7 socs

### DIFF
--- a/boards/arm/96b_meerkat96/96b_meerkat96.dts
+++ b/boards/arm/96b_meerkat96/96b_meerkat96.dts
@@ -39,13 +39,10 @@
 	};
 
 	aliases {
-		gpio-1 = &gpio1;
 		led0   = &green_led_0;
 		led1   = &green_led_1;
 		led2   = &green_led_2;
 		led3   = &green_led_3;
-		uart-1 = &uart1;
-		mu-b   = &mub;
 	};
 };
 

--- a/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
+++ b/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
@@ -13,14 +13,8 @@
 	compatible = "nxp,mcimx7d_m4";
 
 	aliases {
-		gpio-1 = &gpio1;
-		gpio-2 = &gpio2;
-		uart-2 = &uart2;
 		led0   = &green_led;
 		sw0    = &user_switch_1;
-		i2c-4  = &i2c4;
-		pwm-1  = &pwm1;
-		mu-b   = &mub;
 	};
 
 	chosen {

--- a/boards/arm/lpcxpresso54114/lpcxpresso54114.dtsi
+++ b/boards/arm/lpcxpresso54114/lpcxpresso54114.dtsi
@@ -6,12 +6,9 @@
 
 / {
 	aliases{
-		usart-0 = &usart0;
-		mailbox-0 = &mailbox0;
 		led0 = &red_led;
 		led1 = &green_led;
 		led2 = &blue_led;
-		spi-5 = &spi5;
 	};
 
 	leds {

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69.dtsi
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69.dtsi
@@ -6,11 +6,9 @@
 
 / {
 	aliases{
-		usart-0 = &usart0;
 		led0 = &red_led;
 		led1 = &green_led;
 		led2 = &blue_led;
-		spi-8 = &spi8;
 	};
 
 	leds {

--- a/boards/arm/udoo_neo_full_m4/udoo_neo_full_m4.dts
+++ b/boards/arm/udoo_neo_full_m4/udoo_neo_full_m4.dts
@@ -31,14 +31,7 @@
 	compatible = "nxp,mcimx6x_m4";
 
 	aliases {
-		uart-5 = &uart5;
-		gpio-4 = &gpio4;
-		gpio-5 = &gpio5;
-		gpio-6 = &gpio6;
 		led0 = &red_led;
-		mu-b = &mub;
-		epit-1 = &epit1;
-		epit-2 = &epit2;
 	};
 
 	chosen {

--- a/boards/arm/warp7_m4/warp7_m4.dts
+++ b/boards/arm/warp7_m4/warp7_m4.dts
@@ -13,12 +13,7 @@
 	compatible = "nxp,mcimx7d_m4";
 
 	aliases {
-		gpio-7 = &gpio7;
-		uart-2 = &uart2;
-		uart-6 = &uart6;
 		sw0    = &user_switch_1;
-		i2c-4  = &i2c4;
-		mu-b   = &mub;
 	};
 
 	chosen {

--- a/dts/arm/nxp/nxp_imx6sx_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx6sx_m4.dtsi
@@ -9,6 +9,25 @@
 #include <dt-bindings/rdc/imx_rdc.h>
 
 / {
+	aliases {
+		epit-1 = &epit1;
+		epit-2 = &epit2;
+		gpio-1 = &gpio1;
+		gpio-2 = &gpio2;
+		gpio-3 = &gpio3;
+		gpio-4 = &gpio4;
+		gpio-5 = &gpio5;
+		gpio-6 = &gpio6;
+		gpio-7 = &gpio7;
+		mu-b = &mub;
+		uart-1 = &uart1;
+		uart-2 = &uart2;
+		uart-3 = &uart3;
+		uart-4 = &uart4;
+		uart-5 = &uart5;
+		uart-6 = &uart6;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/nxp_imx7d_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx7d_m4.dtsi
@@ -10,6 +10,32 @@
 #include <dt-bindings/rdc/imx_rdc.h>
 
 / {
+	aliases {
+		gpio-1 = &gpio1;
+		gpio-2 = &gpio2;
+		gpio-3 = &gpio3;
+		gpio-4 = &gpio4;
+		gpio-5 = &gpio5;
+		gpio-6 = &gpio6;
+		gpio-7 = &gpio7;
+		i2c-1 = &i2c1;
+		i2c-2 = &i2c2;
+		i2c-3 = &i2c3;
+		i2c-4 = &i2c4;
+		mu-b   = &mub;
+		pwm-1 = &pwm1;
+		pwm-2 = &pwm2;
+		pwm-3 = &pwm3;
+		pwm-4 = &pwm4;
+		uart-1 = &uart1;
+		uart-2 = &uart2;
+		uart-3 = &uart3;
+		uart-4 = &uart4;
+		uart-5 = &uart5;
+		uart-6 = &uart6;
+		uart-7 = &uart7;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/nxp_lpc54xxx.dtsi
+++ b/dts/arm/nxp/nxp_lpc54xxx.dtsi
@@ -7,6 +7,14 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
+	aliases{
+		gpio-0 = &gpio0;
+		gpio-1 = &gpio1;
+		mailbox-0 = &mailbox0;
+		spi-5 = &spi5;
+		usart-0 = &usart0;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/nxp_lpc55S6x.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x.dtsi
@@ -9,6 +9,15 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
+	aliases{
+		gpio-0 = &gpio0;
+		gpio-1 = &gpio1;
+		gpio-2 = &gpio2;
+		gpio-3 = &gpio3;
+		spi-8 = &spi8;
+		usart-0 = &usart0;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;


### PR DESCRIPTION
Defines device tree aliases for on-chip peripherals at the soc level
instead of the board level for all lpc and i.mx 6/7 socs. The eliminates some
duplicate code in the board level device trees, and will allow drivers
to use device-tree generated macros directly instead of through dts
fixups.

Signed-off-by: Maureen Helm maureen.helm@nxp.com

Resubmitting two commits from #21836 to see if it can finish CI without timing out