### PR TITLE
dts: arm: st: h7: stm32h753.dtsi

### DIFF
--- a/dts/arm/st/h7/stm32h753.dtsi
+++ b/dts/arm/st/h7/stm32h753.dtsi
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2020 Moonkwun Jung
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/h7/stm32h7.dtsi>
+
+/ {
+	/* 128KB DTCM @ 20000000, 128KB SRAM1 @ 30000000, 128KB */
+	sram0: memory@30000000 {
+		compatible = "mmio-sram";
+		reg = <0x20010000 DT_SIZE_K(256)>;
+	};
+
+	dtcm: memory@20000000 {
+		compatible = "arm,dtcm";
+		reg = <0x20000000 DT_SIZE_K(64)>;
+	};
+
+	soc {
+		i2c1: i2c@0x40005400 {
+			compatible = "st,stm32-i2c-v2";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40005400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x01000000>;
+			interrupts = <31 0>, <32 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+			label = "I2C_1";
+		};
+
+		i2c2: i2c@0x40005800 {
+			compatible = "st,stm32-i2c-v2";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40005800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x01000000>;
+			interrupts = <33 0>, <34 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+			label = "I2C_2";
+		};
+
+		i2c3: i2c@0x40005C00 {
+			compatible = "st,stm32-i2c-v2";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40005C00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x01000000>;
+			interrupts = <72 0>, <73 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+			label = "I2C_3";
+		};
+
+		i2c4: i2c@0x58001C00 {
+			compatible = "st,stm32-i2c-v2";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x58001C00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x01000000>;
+			interrupts = <95 0>, <96 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+			label = "I2C_4";
+		};
+	};
+};


### PR DESCRIPTION
For using STM32H753I_EVAL board, add stm32h753.dtsi. Add SRAM, DTCM , I2C address

Signed-off-by: Moonkwun Jung <mkainyh@gmail.com>