### PR TITLE
dts: arm: st: h7: stm32h753.dtsi

### DIFF
--- a/dts/arm/st/h7/stm32h753.dtsi
+++ b/dts/arm/st/h7/stm32h753.dtsi
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2020 Moonkwun Jung
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/h7/stm32h7.dtsi>
+
+/ {
+	cpus {
+		/delete-node/ cpu@1;
+	};
+
+	/* 512KB SRAM0 @ 24000000 */
+	sram0: memory@24000000 {
+		compatible = "mmio-sram";
+		reg = <0x24000000 DT_SIZE_K(512)>;
+	};
+
+	/* 128KB SRAM1 @ 30000000 */
+	sram1: memory@30000000 {
+		compatible = "mmio-sram";
+		reg = <0x30000000 DT_SIZE_K(128)>;
+	};
+
+	/* 128KB SRAM2 @ 30020000 */
+	sram2: memory@30020000 {
+		compatible = "mmio-sram";
+		reg = <0x30020000 DT_SIZE_K(128)>;
+	};
+
+	/* 32KB SRAM3 @ 30040000 */
+	sram3: memory@30040000 {
+		compatible = "mmio-sram";
+		reg = <0x30040000 DT_SIZE_K(32)>;
+	};
+
+	/* 64KB SRAM4 @ 38000000 */
+	sram4: memory@38000000 {
+		compatible = "mmio-sram";
+		reg = <0x38000000 DT_SIZE_K(64)>;
+	};
+
+	/* 4KB BackupSRAM @ 38800000 */
+	Backupsram4: memory@38800000 {
+		compatible = "mmio-sram";
+		reg = <0x38800000 DT_SIZE_K(4)>;
+	};
+
+	/* 128KB DTCM @ 20000000 */
+	dtcm: memory@20000000 {
+		compatible = "arm,dtcm";
+		reg = <0x20000000 DT_SIZE_K(128)>;
+	};
+
+	soc {
+		i2c1: i2c@0x40005400 {
+			compatible = "st,stm32-i2c-v2";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40005400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00200000>;
+			interrupts = <31 0>, <32 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+			label = "I2C_1";
+		};
+
+		i2c2: i2c@0x40005800 {
+			compatible = "st,stm32-i2c-v2";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40005800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00400000>;
+			interrupts = <33 0>, <34 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+			label = "I2C_2";
+		};
+
+		i2c3: i2c@0x40005C00 {
+			compatible = "st,stm32-i2c-v2";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40005C00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00800000>;
+			interrupts = <72 0>, <73 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+			label = "I2C_3";
+		};
+
+		i2c4: i2c@0x58001C00 {
+			compatible = "st,stm32-i2c-v2";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x58001C00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB4 0x01000000>;
+			interrupts = <95 0>, <96 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+			label = "I2C_4";
+		};
+	};
+};

--- a/dts/arm/st/h7/stm32h753Xi.dtsi
+++ b/dts/arm/st/h7/stm32h753Xi.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2020 Moonkwun Jung <mkainyh@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/h7/stm32h753.dtsi>
+
+/ {
+	soc {
+		flash-controller@52002000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(1024)>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
fixes #21845. For using STM32H753I_EVAL board, add stm32h753.dtsi.
Add SRAM, DTCM , I2C address.

Signed-off-by: Moonkwun Jung <mkainyh@gmail.com>