### PR TITLE
soc: arm: nordic_nrf: Add workaround for nrf52 anomaly 132

### DIFF
--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_CIAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_CIAA
@@ -11,4 +11,8 @@ config SOC
 config NUM_IRQS
 	default 39
 
+config NRF52_ANOMALY_132_WORKAROUND
+	bool
+	default y
+
 endif # SOC_NRF52832_CIAA

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAA
@@ -11,4 +11,8 @@ config SOC
 config NUM_IRQS
 	default 39
 
+config NRF52_ANOMALY_132_WORKAROUND
+	bool
+	default y
+
 endif # SOC_NRF52832_QFAA

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAB
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAB
@@ -11,4 +11,8 @@ config SOC
 config NUM_IRQS
 	default 39
 
+config NRF52_ANOMALY_132_WORKAROUND
+	bool
+	default y
+
 endif # SOC_NRF52832_QFAB


### PR DESCRIPTION
Anomaly 132 states that there is a certain window after stopping
low frequency RC clock when starting it again will fail. Even though,
zephyr has low frequency clock always on (due to system clock using
it) workaround shall be applied as anomaly applies also to system
reset when LF clock was active. If system reset occurs then if clock
is started 225us to 330us after the reset it will fail to start.

Anomaly applies to RC source only but if XTAL is used then RC is also
started to act as LF clock source until XTAL is ready. XTAL startup
time is much longer (~1ms vs 250ms). It means that without workaround
applied and when XTAL is used then if conditions are met then system
clock will be available after 250 ms. As application may not expect that
workaround is applied for both sources.

Workaround mechanism requires that startup time is measured. Systick is
used for that (so far not used on nrf52 series). It is started just
after the reset and clock_control driver checks if it is running and
if startup time is within specied window then LF clock starting is
delayed. Workaround is applied only if software reset occured.

Fixes #21493.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>