### PR TITLE
TCP2 reordered ACK

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1042,6 +1042,8 @@ next_state:
 		if (FL(&fl, &, ACK, th_ack(th) == conn->seq)) {
 			tcp_send_timer_cancel(conn);
 			next = TCP_ESTABLISHED;
+			net_context_set_state(conn->context,
+					      NET_CONTEXT_CONNECTED);
 			if (FL(&fl, &, PSH)) {
 				tcp_data_get(conn, pkt);
 			}
@@ -1055,6 +1057,8 @@ next_state:
 		if (FL(&fl, &, ACK, th_seq(th) == conn->ack)) {
 			tcp_send_timer_cancel(conn);
 			next = TCP_ESTABLISHED;
+			net_context_set_state(conn->context,
+					      NET_CONTEXT_CONNECTED);
 			if (FL(&fl, &, PSH)) {
 				tcp_data_get(conn, pkt);
 			}
@@ -1065,7 +1069,6 @@ next_state:
 		}
 		break;
 	case TCP_ESTABLISHED:
-		net_context_set_state(conn->context, NET_CONTEXT_CONNECTED);
 		if (!th && conn->snd->len) { /* TODO: Out of the loop */
 			ssize_t data_len;
 

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1055,6 +1055,8 @@ next_state:
 					      NET_CONTEXT_CONNECTED);
 			if (len) {
 				tcp_data_get(conn, pkt);
+				conn_ack(conn, + len);
+				tcp_out(conn, ACK);
 			}
 		}
 		break;

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1053,7 +1053,7 @@ next_state:
 			next = TCP_ESTABLISHED;
 			net_context_set_state(conn->context,
 					      NET_CONTEXT_CONNECTED);
-			if (FL(&fl, &, PSH)) {
+			if (len) {
 				tcp_data_get(conn, pkt);
 			}
 		}

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1080,7 +1080,7 @@ next_state:
 		if (!th && conn->snd->len) { /* TODO: Out of the loop */
 			ssize_t data_len;
 
-			tcp_out(conn, PSH, &data_len);
+			tcp_out(conn, PSH | ACK, &data_len);
 			conn_seq(conn, + data_len);
 			break;
 		}

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -529,16 +529,17 @@ static bool tcp_options_check(void *buf, ssize_t len)
 
 	for ( ; len >= 2; options += opt_len, len -= opt_len) {
 		opt = options[0];
-		opt_len = options[1];
+		opt_len = (opt == TCPOPT_PAD || opt == TCPOPT_NOP) ?
+			1 : options[1];
 
 		NET_DBG("opt: %hu, opt_len: %hu", (u16_t)opt, (u16_t)opt_len);
 
-		if (opt == TCPOPT_PAD) {
-			break;
+		if (opt == TCPOPT_PAD || opt == TCPOPT_NOP) {
+			continue;
 		}
-		if (opt == TCPOPT_NOP) {
-			opt_len = 1;
-		} else if (opt_len < 2 || opt_len > len) {
+
+		if (opt_len < 2 || opt_len > len) {
+			result = false;
 			break;
 		}
 

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -946,11 +946,11 @@ void tcp_input(struct net_pkt *pkt)
 
 static struct tcp *tcp_conn_new(struct net_pkt *pkt);
 
-static enum net_verdict tcp_pkt_received(struct net_conn *net_conn,
-						struct net_pkt *pkt,
-						union net_ip_header *ip,
-						union net_proto_header *proto,
-						void *user_data)
+static enum net_verdict tcp_recv(struct net_conn *net_conn,
+				 struct net_pkt *pkt,
+				 union net_ip_header *ip,
+				 union net_proto_header *proto,
+				 void *user_data)
 {
 	struct tcp *conn = ((struct net_context *)user_data)->tcp;
 	u8_t vhl = ip->ipv4->vhl;
@@ -1027,7 +1027,7 @@ static struct tcp *tcp_conn_new(struct net_pkt *pkt)
 				&context->remote, (void *)&context->local,
 				ntohs(conn->dst->sin.sin_port),/* local port */
 				ntohs(conn->src->sin.sin_port),/* remote port */
-				tcp_pkt_received, context,
+				tcp_recv, context,
 				&context->conn_handler);
 	if (ret < 0) {
 		NET_ERR("net_conn_register(): %d", ret);
@@ -1320,7 +1320,7 @@ int net_tcp_connect(struct net_context *context,
 				net_context_get_family(context),
 				remote_addr, local_addr,
 				ntohs(remote_port), ntohs(local_port),
-				tcp_pkt_received, context,
+				tcp_recv, context,
 				&context->conn_handler);
 	if (ret < 0) {
 		return ret;
@@ -1397,7 +1397,7 @@ int net_tcp_accept(struct net_context *context, net_tcp_accept_cb_t cb,
 				 &context->remote : NULL,
 				 &local_addr,
 				 remote_port, local_port,
-				 tcp_pkt_received, context,
+				 tcp_recv, context,
 				 &context->conn_handler);
 }
 

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1155,9 +1155,13 @@ next_state:
 static ssize_t _tcp_send(struct tcp *conn, const void *buf, size_t len,
 				int flags)
 {
+	int x = irq_lock();
+
 	tcp_win_append(conn, conn->snd, "SND", buf, len);
 
 	tcp_in(conn, NULL);
+
+	irq_unlock(x);
 
 	return len;
 }

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1065,7 +1065,7 @@ next_state:
 		 * ACK , shouldn't we go to SYN RECEIVED state? See Figure
 		 * 6 of RFC 793
 		 */
-		if (FL(&fl, &, ACK, th_seq(th) == conn->ack)) {
+		if (FL(&fl, &, ACK, th && th_seq(th) == conn->ack)) {
 			tcp_send_timer_cancel(conn);
 			next = TCP_ESTABLISHED;
 			net_context_set_state(conn->context,

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -735,8 +735,11 @@ static void tcp_chain(struct net_pkt *pkt, struct net_buf *head)
 	for ( ; head; head = head->frags) {
 		buf = net_pkt_get_frag(pkt, K_NO_WAIT);
 		memcpy(net_buf_add(buf, head->len), head->data, head->len);
+		NET_DBG("+%hu", head->len);
 		net_pkt_frag_add(pkt, buf);
 	}
+
+	NET_DBG("len=%zu byte(s)", net_pkt_get_len(pkt));
 }
 
 static void tcp_out(struct tcp *conn, u8_t flags, ...)

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1493,7 +1493,7 @@ static struct net_buf *tcp_win_pop(struct tcp_win *w, const char *name,
 	return out;
 }
 
-static ssize_t tcp_recv(int fd, void *buf, size_t len, int flags)
+static ssize_t tp_tcp_recv(int fd, void *buf, size_t len, int flags)
 {
 	struct tcp *conn = (void *)sys_slist_peek_head(&tcp_conns);
 	ssize_t bytes_received = conn->rcv->len;
@@ -1638,7 +1638,7 @@ bool tp_input(struct net_pkt *pkt)
 		if (is("RECV", tp->op)) {
 #define HEXSTR_SIZE 64
 			char hexstr[HEXSTR_SIZE];
-			ssize_t len = tcp_recv(0, buf, sizeof(buf), 0);
+			ssize_t len = tp_tcp_recv(0, buf, sizeof(buf), 0);
 
 			tp_init(conn, tp);
 			bin2hex(buf, len, hexstr, HEXSTR_SIZE);

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -337,11 +337,11 @@ static int tcp_conn_unref(struct tcp *conn)
 	tcp_free(conn->src);
 	tcp_free(conn->dst);
 
+	memset(conn, 0, sizeof(*conn));
+
 	sys_slist_find_and_remove(&tcp_conns, (sys_snode_t *)conn);
 
 	k_mem_slab_free(&tcp_conns_slab, (void **)&conn);
-
-	memset(conn, 0, sizeof(*conn));
 
 	irq_unlock(key);
 out:

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1141,18 +1141,6 @@ next_state:
 			   tcp_state_to_str(conn->state, true));
 	}
 
-	if (fl) {
-		th = NULL;
-		NET_WARN("Unconsumed flags: %s (%s) %s",
-			 log_strdup(tcp_flags(fl)),
-			 log_strdup(tcp_th(pkt)),
-			 log_strdup(tcp_conn_state(conn, NULL)));
-		tcp_out(conn, RST);
-		conn_state(conn, TCP_CLOSED);
-		next = 0;
-		goto next_state;
-	}
-
 	if (next) {
 		pkt = NULL;
 		th = NULL;

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -572,13 +572,13 @@ static size_t tcp_data_len(struct net_pkt *pkt)
 	struct net_ipv4_hdr *ip = ip_get(pkt);
 	struct tcphdr *th = th_get(pkt);
 	u8_t off = th->th_off;
-	ssize_t data_len = ntohs(ip->len) - sizeof(*ip) - off * 4;
+	ssize_t len = ntohs(ip->len) - sizeof(*ip) - off * 4;
 
 	if (off > 5 && false == tcp_options_check((th + 1), (off - 5) * 4)) {
-		data_len = 0;
+		len = 0;
 	}
 
-	return data_len > 0 ? data_len : 0;
+	return len > 0 ? len : 0;
 }
 
 static size_t tcp_data_get(struct tcp *conn, struct net_pkt *pkt)

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -510,10 +510,10 @@ static struct net_buf *tcp_win_peek(struct tcp *conn, struct tcp_win *w,
 
 static const char *tcp_conn_state(struct tcp *conn, struct net_pkt *pkt)
 {
-#define BUF_SIZE 64
+#define BUF_SIZE 80
 	static char buf[BUF_SIZE];
 
-	snprintk(buf, BUF_SIZE, "%s %s %u/%u", pkt ? tcp_th(pkt) : "",
+	snprintk(buf, BUF_SIZE, "%s [%s Seq=%u Ack=%u]", pkt ? tcp_th(pkt) : "",
 			tcp_state_to_str(conn->state, false),
 			conn->seq, conn->ack);
 #undef BUF_SIZE

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -181,41 +181,35 @@ static char *tcp_endpoint_to_string(union tcp_endpoint *ep)
 	return s;
 }
 
-static const char *tcp_flags(u8_t fl)
+static const char *tcp_flags(u8_t flags)
 {
-#define BUF_SIZE 80
+#define BUF_SIZE 25 /* 6 * 4 + 1 */
 	static char buf[BUF_SIZE];
-	size_t buf_size = BUF_SIZE;
-	char *s = buf;
-	*s = '\0';
+	int len = 0;
 
-	if (fl) {
-		if (fl & SYN) {
-			s += snprintk(s, buf_size, "SYN,");
-			buf_size -= s - buf;
+	buf[0] = '\0';
+
+	if (flags) {
+		if (flags & SYN) {
+			len += snprintk(buf + len, BUF_SIZE - len, "SYN,");
 		}
-		if (fl & FIN) {
-			s += snprintk(s, buf_size, "FIN,");
-			buf_size -= s - buf;
+		if (flags & FIN) {
+			len += snprintk(buf + len, BUF_SIZE - len, "FIN,");
 		}
-		if (fl & ACK) {
-			s += snprintk(s, buf_size, "ACK,");
-			buf_size -= s - buf;
+		if (flags & ACK) {
+			len += snprintk(buf + len, BUF_SIZE - len, "ACK,");
 		}
-		if (fl & PSH) {
-			s += snprintk(s, buf_size, "PSH,");
-			buf_size -= s - buf;
+		if (flags & PSH) {
+			len += snprintk(buf + len, BUF_SIZE - len, "PSH,");
 		}
-		if (fl & RST) {
-			s += snprintk(s, buf_size, "RST,");
-			buf_size -= s - buf;
+		if (flags & RST) {
+			len += snprintk(buf + len, BUF_SIZE - len, "RST,");
 		}
-		if (fl & URG) {
-			s += snprintk(s, buf_size, "URG,");
-			buf_size -= s - buf;
+		if (flags & URG) {
+			len += snprintk(buf + len, BUF_SIZE - len, "URG,");
 		}
-		s[strlen(s) - 1] = '\0';
-		s--;
+
+		buf[len - 1] = '\0'; /* delete the last comma */
 	}
 #undef BUF_SIZE
 	return buf;

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1154,6 +1154,7 @@ next_state:
 	}
 
 	if (next) {
+		pkt = NULL;
 		th = NULL;
 		conn_state(conn, next);
 		next = 0;

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1047,7 +1047,8 @@ next_state:
 		}
 		break;
 	case TCP_SYN_RECEIVED:
-		if (FL(&fl, &, ACK, th_ack(th) == conn->seq)) {
+		if (FL(&fl, &, ACK, th_ack(th) == conn->seq &&
+				th_seq(th) == conn->ack)) {
 			tcp_send_timer_cancel(conn);
 			next = TCP_ESTABLISHED;
 			net_context_set_state(conn->context,

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1017,6 +1017,7 @@ static void tcp_in(struct tcp *conn, struct net_pkt *pkt)
 {
 	struct tcphdr *th = th_get(pkt);
 	u8_t next = 0, fl = th ? th->th_flags : 0;
+	size_t len;
 
 	NET_DBG("%s", tcp_conn_state(conn, pkt));
 
@@ -1030,6 +1031,8 @@ static void tcp_in(struct tcp *conn, struct net_pkt *pkt)
 		conn_state(conn, TCP_CLOSED);
 	}
 next_state:
+	len = pkt ? tcp_data_len(pkt) : 0;
+
 	switch (conn->state) {
 	case TCP_LISTEN:
 		if (FL(&fl, ==, SYN)) {

--- a/subsys/net/ip/tcp2.h
+++ b/subsys/net/ip/tcp2.h
@@ -12,7 +12,7 @@
  * - net_tcp_listen()/net_tcp_accept() listen/accept
  * - At the reception of SYN on the listening net_context, a new pair
  *   of net_context/struct tcp registers a new net_conn handle
- *   with the tcp_pkt_received() as a callback
+ *   with the tcp_recv() as a callback
  * - net_tcp_queue() queues the data for the transmission
  * - The incoming data is delivered up through the context->recv_cb
  * - net_tcp_put() closes the connection

--- a/subsys/net/ip/tp.c
+++ b/subsys/net/ip/tp.c
@@ -435,15 +435,25 @@ void _tp_output(struct net_if *iface, void *data, size_t data_len,
 		const char *file, int line)
 {
 	struct net_pkt *pkt = tp_make(file, line);
-	struct net_buf *buf = net_pkt_get_frag(pkt, K_NO_WAIT);
+	size_t total = data_len, len;
+	struct net_buf *buf;
 
-	memcpy(net_buf_add(buf, data_len), data, data_len);
+	for ( ; total; total -= len, data = (u8_t *)data + len) {
 
-	net_pkt_frag_add(pkt, buf);
+		buf = net_pkt_get_frag(pkt, K_NO_WAIT);
+
+		len = MIN(buf->size, total);
+
+		memcpy(net_buf_add(buf, len), data, len);
+
+		net_pkt_frag_add(pkt, buf);
+	}
 
 	tp_pkt_adj(pkt, data_len);
 
 	pkt->iface = iface;
+
+	NET_ASSERT(net_pkt_get_len(pkt) <= net_if_get_mtu(pkt->iface));
 
 	tp_pkt_send(pkt);
 }


### PR DESCRIPTION
These patches fix the issue with the data packet being false
identified as a final ACK in case the final ACK
for the connection establishment arrives out of order.

There are a few other less significant fixes and refactorings.