### PR TITLE
boards: nucleo_f207zg: Enable automatic flashing

### DIFF
--- a/boards/arm/nucleo_f207zg/support/openocd.cfg
+++ b/boards/arm/nucleo_f207zg/support/openocd.cfg
@@ -1,6 +1,8 @@
 source [find interface/stlink.cfg]
 source [find target/stm32f2x.cfg]
 
+reset_config srst_only srst_nogate
+
 $_TARGETNAME configure -event gdb-attach {
         echo "Debugger attaching: halting execution"
         reset halt


### PR DESCRIPTION
Flashing board nucleo_f207zg requires additional instructions
to be provided to openocd in order to enable flashing without holding
the reset button.
Update nucleo_f207zg openocd config to provide requested instructions.


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>