### PR TITLE
boards: bbc_microbit: add nrfjprog flash support

### DIFF
--- a/boards/arm/bbc_microbit/board.cmake
+++ b/boards/arm/bbc_microbit/board.cmake
@@ -1,4 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(pyocd "--target=nrf51")
+board_runner_args(nrfjprog "--nrf-family=NRF51")
+board_runner_args(jlink "--device=nrf51" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Segger offers J-Link firmware for the debug MCU on the BBC micro:bit.
If this firmware is installed, it allows programming via nrfjprog and
JLink. Add support for this in the board.cmake.

Leave the default at pyocd, to support the factory-programmed
firmware.

With this patch, users who have installed the JLink firmware can flash
this board with nrfjprog using:

$ west flash -r nrfjprog

And can flash or debug with jlink using:

$ west flash -r jlink
$ west debug -r jlink

As usual with runner overrides, you can omit the '-r {nrfjprog,jlink}'
if BOARD_FLASH_RUNNER as a CMake variable is set to nrfjprog or
BOARD_DEBUG_RUNNER is set to jlink.

For more details on this Segger firmware, see:

https://www.segger.com/products/debug-probes/j-link/models/other-j-links/bbc-microbit-j-link-upgrade/
