### PR TITLE
Add NXP Kinetis SoC temperature sensor driver

### DIFF
--- a/boards/arm/frdm_k64f/Kconfig.defconfig
+++ b/boards/arm/frdm_k64f/Kconfig.defconfig
@@ -82,6 +82,13 @@ config ADC_1
 
 endif # ADC
 
+if SENSOR
+
+config TEMP_KINETIS
+	default y
+
+endif # SENSOR
+
 if PWM_MCUX_FTM
 
 config PWM_3

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -103,6 +103,10 @@ arduino_serial: &uart3 {
 	status = "okay";
 };
 
+&temp1 {
+	status = "okay";
+};
+
 arduino_i2c: &i2c0 {
 	status = "okay";
 

--- a/boards/arm/twr_ke18f/Kconfig.defconfig
+++ b/boards/arm/twr_ke18f/Kconfig.defconfig
@@ -87,6 +87,13 @@ config ADC_0
 
 endif # ADC
 
+if SENSOR
+
+config TEMP_KINETIS
+	default y
+
+endif # SENSOR
+
 if PWM
 
 config PWM_0

--- a/boards/arm/twr_ke18f/twr_ke18f.dts
+++ b/boards/arm/twr_ke18f/twr_ke18f.dts
@@ -195,6 +195,10 @@
 	sample-time = <12>;
 };
 
+&temp0 {
+	status = "okay";
+};
+
 &can0 {
 	status = "okay";
 	bus-speed = <125000>;

--- a/drivers/sensor/CMakeLists.txt
+++ b/drivers/sensor/CMakeLists.txt
@@ -60,6 +60,7 @@ add_subdirectory_ifdef(CONFIG_TMP007		tmp007)
 add_subdirectory_ifdef(CONFIG_TMP112		tmp112)
 add_subdirectory_ifdef(CONFIG_TMP116		tmp116)
 add_subdirectory_ifdef(CONFIG_VL53L0X		vl53l0x)
+add_subdirectory_ifdef(CONFIG_TEMP_KINETIS	nxp_kinetis_temp)
 
 zephyr_sources_ifdef(CONFIG_USERSPACE sensor_handlers.c)
 zephyr_sources_ifdef(CONFIG_SENSOR_SHELL sensor_shell.c)

--- a/drivers/sensor/Kconfig
+++ b/drivers/sensor/Kconfig
@@ -149,4 +149,6 @@ source "drivers/sensor/tmp116/Kconfig"
 
 source "drivers/sensor/vl53l0x/Kconfig"
 
+source "drivers/sensor/nxp_kinetis_temp/Kconfig"
+
 endif # SENSOR

--- a/drivers/sensor/nxp_kinetis_temp/CMakeLists.txt
+++ b/drivers/sensor/nxp_kinetis_temp/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources_ifdef(CONFIG_TEMP_KINETIS temp_kinetis.c)

--- a/drivers/sensor/nxp_kinetis_temp/Kconfig
+++ b/drivers/sensor/nxp_kinetis_temp/Kconfig
@@ -1,0 +1,31 @@
+# NXP Kinetis temperature sensor configuration options
+
+# Copyright (c) 2020 Vestas Wind Systems A/S
+# SPDX-License-Identifier: Apache-2.0
+
+config TEMP_KINETIS
+	bool "NXP Kinetis Temperature Sensor"
+	depends on (ADC && SOC_FAMILY_KINETIS)
+	help
+	  Enable driver for NXP Kinetis temperature sensor.
+
+if TEMP_KINETIS
+
+config TEMP_KINETIS_RESOLUTION
+	int "ADC resolution"
+	default 16 if HAS_MCUX_ADC16
+	default 12 if HAS_MCUX_ADC12
+	help
+	  ADC resolution to use for the temperature sensor and bandgap
+	  voltage readings.
+
+config TEMP_KINETIS_OVERSAMPLING
+	int "ADC oversampling"
+	default 0
+	range 0 5
+	help
+	  ADC oversampling to use for the temperature sensor and
+	  bandgap voltage readings. Oversampling can help in providing
+	  more stable readings.
+
+endif # TEMP_KINETIS

--- a/drivers/sensor/nxp_kinetis_temp/temp_kinetis.c
+++ b/drivers/sensor/nxp_kinetis_temp/temp_kinetis.c
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2020 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <device.h>
+#include <drivers/sensor.h>
+#include <drivers/adc.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(temp_kinetis, CONFIG_SENSOR_LOG_LEVEL);
+
+/*
+ * Driver assumptions:
+ * - ADC samples are in u16_t format
+ * - Both ADC channels (sensor and bandgap) are on the same ADC instance
+ *
+ * See NXP Application Note AN3031 for details on calculations.
+ */
+
+/* Two ADC samples required for each reading, sensor value and bandgap value */
+#define TEMP_KINETIS_ADC_SAMPLES 2
+
+struct temp_kinetis_config {
+	const char *adc_dev_name;
+	u8_t sensor_adc_ch;
+	u8_t bandgap_adc_ch;
+	int bandgap_mv;
+	int vtemp25_mv;
+	int slope_cold_uv;
+	int slope_hot_uv;
+	struct adc_sequence adc_seq;
+};
+
+struct temp_kinetis_data {
+	struct device *adc;
+	u16_t buffer[TEMP_KINETIS_ADC_SAMPLES];
+};
+
+static int temp_kinetis_sample_fetch(struct device *dev,
+				     enum sensor_channel chan)
+{
+	const struct temp_kinetis_config *config = dev->config->config_info;
+	struct temp_kinetis_data *data = dev->driver_data;
+	int err;
+
+	/* Always read both sensor and bandgap voltage in one go */
+	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_DIE_TEMP &&
+	    chan != SENSOR_CHAN_VOLTAGE) {
+		return -ENOTSUP;
+	}
+
+	err = adc_read(data->adc, &config->adc_seq);
+	if (err) {
+		LOG_ERR("failed to read ADC channels (err %d)", err);
+		return err;
+	}
+
+	LOG_DBG("sensor = %d, bandgap = %d", data->buffer[0], data->buffer[1]);
+
+	return 0;
+}
+
+static int temp_kinetis_channel_get(struct device *dev,
+				    enum sensor_channel chan,
+				    struct sensor_value *val)
+{
+	const struct temp_kinetis_config *config = dev->config->config_info;
+	struct temp_kinetis_data *data = dev->driver_data;
+	u16_t adcr_vdd = BIT_MASK(config->adc_seq.resolution);
+	u16_t adcr_temp25;
+	s32_t temp_mc;
+	s32_t vdd_mv;
+	int slope_uv;
+	u16_t m;
+
+	if (chan != SENSOR_CHAN_VOLTAGE && chan != SENSOR_CHAN_DIE_TEMP) {
+		return -ENOTSUP;
+	}
+
+	/* VDD (or VREF, but AN3031 calls it VDD) in millivolts */
+	vdd_mv = (adcr_vdd * config->bandgap_mv) / data->buffer[1];
+
+	if (chan == SENSOR_CHAN_VOLTAGE) {
+		val->val1 = vdd_mv / 1000;
+		val->val2 = (vdd_mv % 1000) * 1000;
+		return 0;
+	}
+
+	/* ADC result for temperature = 25 degrees Celsius */
+	adcr_temp25 = (adcr_vdd * config->vtemp25_mv) / vdd_mv;
+
+	/* Determine which slope to use */
+	if (data->buffer[0] > adcr_temp25) {
+		slope_uv = config->slope_cold_uv;
+	} else {
+		slope_uv = config->slope_hot_uv;
+	}
+
+	/* m x 1000 */
+	m = (adcr_vdd * slope_uv) / vdd_mv;
+
+	/* Temperature in milli degrees Celsius */
+	temp_mc = 25000 - ((data->buffer[0] - adcr_temp25) * 1000000) / m;
+
+	val->val1 = temp_mc / 1000;
+	val->val2 = (temp_mc % 1000) * 1000;
+
+	return 0;
+}
+
+static const struct sensor_driver_api temp_kinetis_driver_api = {
+	.sample_fetch = temp_kinetis_sample_fetch,
+	.channel_get = temp_kinetis_channel_get,
+};
+
+static int temp_kinetis_init(struct device *dev)
+{
+	const struct temp_kinetis_config *config = dev->config->config_info;
+	struct temp_kinetis_data *data = dev->driver_data;
+	int err;
+	int i;
+	const struct adc_channel_cfg ch_cfg[] = {
+		{
+			.gain = ADC_GAIN_1,
+			.reference = ADC_REF_INTERNAL,
+			.acquisition_time = ADC_ACQ_TIME_DEFAULT,
+			.channel_id = config->sensor_adc_ch,
+			.differential = 0,
+		},
+		{
+			.gain = ADC_GAIN_1,
+			.reference = ADC_REF_INTERNAL,
+			.acquisition_time = ADC_ACQ_TIME_DEFAULT,
+			.channel_id = config->bandgap_adc_ch,
+			.differential = 0,
+		},
+	};
+
+	memset(&data->buffer, 0, ARRAY_SIZE(data->buffer));
+
+	data->adc = device_get_binding(config->adc_dev_name);
+	if (!data->adc) {
+		LOG_ERR("could not get ADC device");
+		return -EINVAL;
+	}
+
+	for (i = 0; i < ARRAY_SIZE(ch_cfg); i++) {
+		err = adc_channel_setup(data->adc, &ch_cfg[i]);
+		if (err) {
+			LOG_ERR("failed to configure ADC channel (err %d)",
+				err);
+			return err;
+		}
+	}
+
+	return 0;
+}
+
+#ifdef DT_INST_0_NXP_KINETIS_TEMPERATURE
+BUILD_ASSERT_MSG(DT_INST_0_NXP_KINETIS_TEMPERATURE_SENSOR_IO_CHANNELS_INPUT <
+		 DT_INST_0_NXP_KINETIS_TEMPERATURE_BANDGAP_IO_CHANNELS_INPUT,
+		 "This driver assumes sensor ADC channel to come before "
+		 "bandgap ADC channel");
+
+static struct temp_kinetis_data temp_kinetis_data_0;
+
+static const struct temp_kinetis_config temp_kinetis_config_0 = {
+	.adc_dev_name =
+		DT_INST_0_NXP_KINETIS_TEMPERATURE_IO_CHANNELS_CONTROLLER_0,
+	.sensor_adc_ch =
+		DT_INST_0_NXP_KINETIS_TEMPERATURE_SENSOR_IO_CHANNELS_INPUT,
+	.bandgap_adc_ch =
+		DT_INST_0_NXP_KINETIS_TEMPERATURE_BANDGAP_IO_CHANNELS_INPUT,
+	.bandgap_mv = DT_INST_0_NXP_KINETIS_TEMPERATURE_BANDGAP_VOLTAGE / 1000,
+	.vtemp25_mv = DT_INST_0_NXP_KINETIS_TEMPERATURE_VTEMP25 / 1000,
+	.slope_cold_uv = DT_INST_0_NXP_KINETIS_TEMPERATURE_SENSOR_SLOPE_COLD,
+	.slope_hot_uv = DT_INST_0_NXP_KINETIS_TEMPERATURE_SENSOR_SLOPE_HOT,
+	.adc_seq = {
+		.options = NULL,
+		.channels =
+	BIT(DT_INST_0_NXP_KINETIS_TEMPERATURE_SENSOR_IO_CHANNELS_INPUT) |
+	BIT(DT_INST_0_NXP_KINETIS_TEMPERATURE_BANDGAP_IO_CHANNELS_INPUT),
+		.buffer = &temp_kinetis_data_0.buffer,
+		.buffer_size = sizeof(temp_kinetis_data_0.buffer),
+		.resolution = CONFIG_TEMP_KINETIS_RESOLUTION,
+		.oversampling = CONFIG_TEMP_KINETIS_OVERSAMPLING,
+		.calibrate = false,
+	},
+};
+
+DEVICE_AND_API_INIT(temp_kinetis, DT_INST_0_NXP_KINETIS_TEMPERATURE_LABEL,
+		    temp_kinetis_init, &temp_kinetis_data_0,
+		    &temp_kinetis_config_0, POST_KERNEL,
+		    CONFIG_SENSOR_INIT_PRIORITY,
+		    &temp_kinetis_driver_api);
+
+#endif /* DT_INST_0_NXP_KINETIS_TEMPERATURE */

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -73,6 +73,30 @@
 		reg = <0x20000000 0x30000>;
 	};
 
+	temp0: temp0 {
+		compatible = "nxp,kinetis-temperature";
+		io-channels = <&adc0 26>, <&adc0 27>;
+		io-channel-names = "SENSOR", "BANDGAP";
+		bandgap-voltage = <1000000>;
+		vtemp25 = <716000>;
+		sensor-slope-cold = <1620>;
+		sensor-slope-hot = <1620>;
+		label = "TEMP0";
+		status = "disabled";
+	};
+
+	temp1: temp1 {
+		compatible = "nxp,kinetis-temperature";
+		io-channels = <&adc1 26>, <&adc1 27>;
+		io-channel-names = "SENSOR", "BANDGAP";
+		bandgap-voltage = <1000000>;
+		vtemp25 = <716000>;
+		sensor-slope-cold = <1620>;
+		sensor-slope-hot = <1620>;
+		label = "TEMP1";
+		status = "disabled";
+	};
+
 	soc {
 
 		mpu@4000d000 {

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -51,6 +51,42 @@
 		};
 	};
 
+	temp0: temp0 {
+		compatible = "nxp,kinetis-temperature";
+		io-channels = <&adc0 26>, <&adc0 27>;
+		io-channel-names = "SENSOR", "BANDGAP";
+		bandgap-voltage = <1000000>;
+		vtemp25 = <740500>;
+		sensor-slope-cold = <1564>;
+		sensor-slope-hot = <1564>;
+		label = "TEMP0";
+		status = "disabled";
+	};
+
+	temp1: temp1 {
+		compatible = "nxp,kinetis-temperature";
+		io-channels = <&adc1 26>, <&adc1 27>;
+		io-channel-names = "SENSOR", "BANDGAP";
+		bandgap-voltage = <1000000>;
+		vtemp25 = <740500>;
+		sensor-slope-cold = <1564>;
+		sensor-slope-hot = <1564>;
+		label = "TEMP1";
+		status = "disabled";
+	};
+
+	temp2: temp2 {
+		compatible = "nxp,kinetis-temperature";
+		io-channels = <&adc2 26>, <&adc2 27>;
+		io-channel-names = "SENSOR", "BANDGAP";
+		bandgap-voltage = <1000000>;
+		vtemp25 = <740500>;
+		sensor-slope-cold = <1564>;
+		sensor-slope-hot = <1564>;
+		label = "TEMP2";
+		status = "disabled";
+	};
+
 	soc {
 		mpu: mpu@4000d000 {
 			compatible = "nxp,kinetis-mpu";

--- a/dts/bindings/sensor/nxp,kinetis-temperature.yaml
+++ b/dts/bindings/sensor/nxp,kinetis-temperature.yaml
@@ -1,0 +1,47 @@
+# Copyright (c) 2020 Vestas Wind Systems A/S
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP Kinetis temperature sensor
+
+compatible: "nxp,kinetis-temperature"
+
+include: base.yaml
+
+properties:
+    label:
+      required: true
+
+    io-channels:
+      type: phandle-array
+      required: true
+      description: ADC channels for temperature sensor and bandgap voltage
+
+    io-channel-names:
+      type: string-array
+      required: true
+      description: name of each ADC channel (SENSOR or BANDGAP)
+
+    bandgap-voltage:
+      type: int
+      required: true
+      description: Bandgap voltage in microvolts
+
+    vtemp25:
+      type: int
+      required: true
+      description: |
+          Temperature sensor voltage at 25 degrees Celcius in microvolts
+
+    sensor-slope-cold:
+      type: int
+      required: true
+      description: |
+          Temperature sensor slope in microvolts per degree Celsius for
+          temperatures below 25 degrees Celsius
+
+    sensor-slope-hot:
+      type: int
+      required: true
+      description: |
+          Temperature sensor slope in microvolts per degree Celsius for
+          temperatures above or equal to 25 degrees Celsius

--- a/soc/arm/nxp_kinetis/k6x/soc.c
+++ b/soc/arm/nxp_kinetis/k6x/soc.c
@@ -135,6 +135,11 @@ static int fsl_frdm_k64f_init(struct device *arg)
 	/* release I/O power hold to allow normal run state */
 	PMC->REGSC |= PMC_REGSC_ACKISO_MASK;
 
+#ifdef CONFIG_TEMP_KINETIS
+	/* enable bandgap buffer */
+	PMC->REGSC |= PMC_REGSC_BGBE_MASK;
+#endif /* CONFIG_TEMP_KINETIS */
+
 #if !defined(CONFIG_ARM_MPU)
 	/*
 	 * Disable memory protection and clear slave port errors.


### PR DESCRIPTION
This series of patches adds a driver for the internal temperature sensor present on the NXP Kinetis SoC series. The sensor value can be read using the SoC ADC instances and thus depends on ADC being enabled.

The driver has been tested and verified on the TWR-KE18F and FRDM-K64F boards, which are the ones I have available. It should be trivial to add support for other Kinetis SoCs/boards.