### PR TITLE
modify bug 21812

### DIFF
--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_dynamic_direct_interrupts.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_dynamic_direct_interrupts.c
@@ -36,6 +36,9 @@ void test_arm_dynamic_direct_interrupts(void)
 	 */
 	ARM_IRQ_DIRECT_DYNAMIC_CONNECT(DIRECT_ISR_OFFSET, 0, 0, no_reschedule);
 
+	/* Ensure the IRQ is disabled before enabling it at run time */
+        irq_disable(DIRECT_ISR_OFFSET);
+
 	/* Attach the ISR handler at run time. */
 	irq_connect_dynamic(DIRECT_ISR_OFFSET, 0 /* highest priority */,
 		arm_direct_isr_handler_0,


### PR DESCRIPTION
Signed-off-by: bo.zheng <box.zheng@intel.com>
In the function irq_connect_dynamic, it will check if the irq is disable. If the irq is enable ,it will assert.
So before invoking the function irq_connect_dynamic, it must disable the irq. 