### PR TITLE
 power: add system power management direct trigger mode

### DIFF
--- a/include/power/power.h
+++ b/include/power/power.h
@@ -155,7 +155,7 @@ static inline void _sys_pm_idle_exit_notification_disable(void)
  *		subsequent suspend operations or
  *		SYS_POWER_STATE_AUTO.
  */
-extern void sys_pm_force_power_state(enum power_states state);
+void sys_pm_force_power_state(enum power_states state);
 
 /**
  * @brief Put processor into a power state.
@@ -163,7 +163,7 @@ extern void sys_pm_force_power_state(enum power_states state);
  * This function implements the SoC specific details necessary
  * to put the processor into available power states.
  */
-extern void sys_set_power_state(enum power_states state);
+void sys_set_power_state(enum power_states state);
 
 #ifdef CONFIG_SYS_PM_DEBUG
 /**
@@ -171,7 +171,7 @@ extern void sys_set_power_state(enum power_states state);
  *
  * Dump Low Power states debug info like LPS entry count and residencies.
  */
-extern void sys_pm_dump_debug_info(void);
+void sys_pm_dump_debug_info(void);
 
 #endif /* CONFIG_SYS_PM_DEBUG */
 
@@ -186,7 +186,7 @@ extern void sys_pm_dump_debug_info(void);
  *
  * @param [in] state Power state to be disabled.
  */
-extern void sys_pm_ctrl_disable_state(enum power_states state);
+void sys_pm_ctrl_disable_state(enum power_states state);
 
 /**
  * @brief Enable particular power state
@@ -199,7 +199,7 @@ extern void sys_pm_ctrl_disable_state(enum power_states state);
  *
  * @param [in] state Power state to be enabled.
  */
-extern void sys_pm_ctrl_enable_state(enum power_states state);
+void sys_pm_ctrl_enable_state(enum power_states state);
 
 /**
  * @brief Check if particular power state is enabled
@@ -208,7 +208,7 @@ extern void sys_pm_ctrl_enable_state(enum power_states state);
  *
  * @param [in] state Power state.
  */
-extern bool sys_pm_ctrl_is_state_enabled(enum power_states state);
+bool sys_pm_ctrl_is_state_enabled(enum power_states state);
 
 #endif /* CONFIG_SYS_PM_STATE_LOCK */
 
@@ -283,7 +283,7 @@ void _sys_resume(void);
  * @return Power state which was entered or SYS_POWER_STATE_ACTIVE if SoC was
  *         kept in the active state.
  */
-extern enum power_states _sys_suspend(s32_t ticks);
+enum power_states _sys_suspend(s32_t ticks);
 
 /**
  * @brief Do any SoC or architecture specific post ops after sleep state exits.
@@ -293,7 +293,7 @@ extern enum power_states _sys_suspend(s32_t ticks);
  * interrupts after resuming from sleep state. In future, the enabling
  * of interrupts may be moved into the kernel.
  */
-extern void _sys_pm_power_state_exit_post_ops(enum power_states state);
+void _sys_pm_power_state_exit_post_ops(enum power_states state);
 
 /**
  * @brief Application defined function for power state entry
@@ -301,7 +301,7 @@ extern void _sys_pm_power_state_exit_post_ops(enum power_states state);
  * Application defined function for doing any target specific operations
  * for power state entry.
  */
-extern void sys_pm_notify_power_state_entry(enum power_states state);
+void sys_pm_notify_power_state_entry(enum power_states state);
 
 /**
  * @brief Application defined function for sleep state exit
@@ -309,7 +309,7 @@ extern void sys_pm_notify_power_state_entry(enum power_states state);
  * Application defined function for doing any target specific operations
  * for sleep state exit.
  */
-extern void sys_pm_notify_power_state_exit(enum power_states state);
+void sys_pm_notify_power_state_exit(enum power_states state);
 
 /**
  * @}

--- a/include/power/power.h
+++ b/include/power/power.h
@@ -146,14 +146,13 @@ static inline void _sys_pm_idle_exit_notification_disable(void)
 /**
  * @brief Force usage of given power state.
  *
- * This function overrides decision made by PM policy
- * forcing usage of given power state in all subsequent
- * suspend operations. Forcing the SYS_POWER_STATE_AUTO
- * state restores normal operation.
+ * This function overrides decision made by PM policy forcing
+ * usage of given power state in the ongoing suspend operation.
+ * And before the end of suspend, the state of forced_pm_state
+ * is cleared with interrupt disabled.
  *
- * @param state Power state which should be used in all
- *		subsequent suspend operations or
- *		SYS_POWER_STATE_AUTO.
+ * @param state Power state which should be used in the ongoing
+ *		suspend operation or SYS_POWER_STATE_AUTO.
  */
 void sys_pm_force_power_state(enum power_states state);
 

--- a/include/power/power.h
+++ b/include/power/power.h
@@ -151,6 +151,9 @@ static inline void _sys_pm_idle_exit_notification_disable(void)
  * And before the end of suspend, the state of forced_pm_state
  * is cleared with interrupt disabled.
  *
+ * If enabled SYS_PM_DIRECT_FORCE_MODE, this function can only
+ * run in thread context.
+ *
  * @param state Power state which should be used in the ongoing
  *		suspend operation or SYS_POWER_STATE_AUTO.
  */

--- a/subsys/power/Kconfig
+++ b/subsys/power/Kconfig
@@ -8,6 +8,14 @@ config SYS_PM_STATE_LOCK
 	  Power States while doing any critical work or needs quick
 	  response from hardware resources.
 
+config SYS_PM_DIRECT_FORCE_MODE
+	bool "Enable system power management direct force trigger mode"
+	help
+	  Enable system power management direct force trigger mode. In
+	  this mode application thread can directly put system in sleep
+	  or deep sleep mode instead of waiting for idle thread to do
+	  it, so that it can reduce latency to enter low power mode.
+
 config SYS_PM_DEBUG
 	bool "Enable System Power Management debug hooks"
 	help

--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -152,6 +152,8 @@ enum power_states _sys_suspend(s32_t ticks)
 
 	if (!post_ops_done) {
 		post_ops_done = 1;
+		/* clear forced_pm_state */
+		forced_pm_state = SYS_POWER_STATE_AUTO;
 		sys_pm_notify_power_state_exit(pm_state);
 		_sys_pm_power_state_exit_post_ops(pm_state);
 	}

--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -80,7 +80,13 @@ void sys_pm_force_power_state(enum power_states state)
 		 state <  SYS_POWER_STATE_MAX,
 		 "Invalid power state %d!", state);
 
+#ifdef CONFIG_SYS_PM_DIRECT_FORCE_MODE
+	(void)arch_irq_lock();
 	forced_pm_state = state;
+	_sys_suspend(K_FOREVER);
+#else
+	forced_pm_state = state;
+#endif
 }
 
 enum power_states _sys_suspend(s32_t ticks)


### PR DESCRIPTION
Add system power management direct trigger mode. In this mode
application thread can directly put system in sleep or deep
sleep mode instead of waiting for idle thread to do it, so that
it can reduce latency to enter low power mode.

Fixes: #20125.

Signed-off-by: Wentong Wu <wentong.wu@intel.com>