### PR TITLE
drivers: sensor: bme280: Add CS control when using SPI

### DIFF
--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -347,6 +347,20 @@ static inline int bme280_spi_init(struct bme280_data *data)
 	data->spi_cfg.frequency = DT_INST_0_BOSCH_BME280_SPI_MAX_FREQUENCY;
 	data->spi_cfg.slave = DT_INST_0_BOSCH_BME280_BASE_ADDRESS;
 
+#if defined(DT_INST_0_BOSCH_BME280_CS_GPIOS_CONTROLLER)
+	data->spi_cs_control.gpio_dev =
+		device_get_binding(DT_INST_0_BOSCH_BME280_CS_GPIOS_CONTROLLER);
+	if (!data->spi_cs_control.gpio_dev) {
+		LOG_ERR("Unable to get GPIO SPI CS device");
+		return -ENODEV;
+	}
+
+	data->spi_cs_control.gpio_pin = DT_INST_0_BOSCH_BME280_CS_GPIOS_PIN;
+	data->spi_cs_control.delay = 0U;
+
+	data->spi_cfg.cs = &data->spi_cs_control;
+#endif /* DT_INST_0_BOSCH_BME280_CS_GPIOS_CONTROLLER */
+
 	return 0;
 }
 #endif

--- a/drivers/sensor/bme280/bme280.h
+++ b/drivers/sensor/bme280/bme280.h
@@ -107,6 +107,9 @@ struct bme280_data {
 #elif defined DT_BOSCH_BME280_BUS_SPI
 	struct device *spi;
 	struct spi_config spi_cfg;
+#if defined(DT_INST_0_BOSCH_BME280_CS_GPIOS_CONTROLLER)
+	struct spi_cs_control spi_cs_control;
+#endif
 #else
 #error "BME280 device type not specified"
 #endif


### PR DESCRIPTION
Adds BME280 SPI chip select pin control if chip select is
configured for the device in the device tree.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>