### PR TITLE
Console: Enable more than 255 character long inputs

### DIFF
--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -233,7 +233,7 @@ enum {
 
 static atomic_t esc_state;
 static unsigned int ansi_val, ansi_val_2;
-static u8_t cur, end;
+static u16_t cur, end;
 
 static void handle_ansi(u8_t byte, char *line)
 {


### PR DESCRIPTION
Due to current cursor/end being uint8, setting the parameter CONFIG_CONSOLE_INPUT_MAX_LINE_LEN above 255 has no effect and even leads to strange effects by means of cut off lines.