### PR TITLE
drivers/eeprom: stm32: Added support for L0 Series

### DIFF
--- a/boards/arm/nucleo_l053r8/doc/index.rst
+++ b/boards/arm/nucleo_l053r8/doc/index.rst
@@ -92,6 +92,8 @@ The Zephyr nucleo_l053r8 board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi controller                      |
 +-----------+------------+-------------------------------------+
+| EEPROM    | on-chip    | eeprom                              |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported in this Zephyr port.
 

--- a/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
+++ b/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
@@ -38,6 +38,7 @@
 	aliases {
 		led0 = &green_led_2;
 		sw0 = &user_button;
+		eeprom-0 = &eeprom;
 	};
 };
 
@@ -56,5 +57,9 @@
 };
 
 &spi1 {
+	status = "okay";
+};
+
+&eeprom {
 	status = "okay";
 };

--- a/boards/arm/nucleo_l053r8/nucleo_l053r8.yaml
+++ b/boards/arm/nucleo_l053r8/nucleo_l053r8.yaml
@@ -13,5 +13,6 @@ supported:
   - gpio
   - i2c
   - spi
+  - eeprom
 ram: 8
 flash: 64

--- a/drivers/eeprom/Kconfig.stm32
+++ b/drivers/eeprom/Kconfig.stm32
@@ -3,9 +3,9 @@
 
 config EEPROM_STM32
 	bool "STM32 EEPROM driver"
-	depends on SOC_SERIES_STM32L1X
+	depends on SOC_SERIES_STM32L0X || SOC_SERIES_STM32L1X
 	default y
 	select USE_STM32_HAL_FLASH
 	select USE_STM32_HAL_FLASH_EX
 	help
-	  Enable EEPROM support on the STM32 L1 family of processors.
+	  Enable EEPROM support on the STM32 L0, L1 family of processors.

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -190,6 +190,12 @@
 			status = "disabled";
 			label = "DMA_1";
 		};
+
+		eeprom: eeprom@8080000{
+			compatible = "st,stm32-eeprom";
+			status = "disabled";
+			label = "EEPROM_0";
+		};
 	};
 };
 

--- a/dts/arm/st/l0/stm32l053.dtsi
+++ b/dts/arm/st/l0/stm32l053.dtsi
@@ -31,5 +31,9 @@
 			status = "disabled";
 			label = "SPI_2";
 		};
+
+		eeprom: eeprom@8080000{
+			reg = <0x08080000 DT_SIZE_K(2)>;
+		};
 	};
 };

--- a/dts/arm/st/l0/stm32l072.dtsi
+++ b/dts/arm/st/l0/stm32l072.dtsi
@@ -69,6 +69,10 @@
 			status = "disabled";
 			label= "USB";
 		};
+
+		eeprom: eeprom@8080000{
+			reg = <0x08080000 DT_SIZE_K(6)>;
+		};
 	};
 
 	otgfs_phy: otgfs_phy {

--- a/dts/arm/st/l0/stm32l073.dtsi
+++ b/dts/arm/st/l0/stm32l073.dtsi
@@ -68,6 +68,10 @@
 			status = "disabled";
 			label= "USB";
 		};
+
+		eeprom: eeprom@8080000{
+			reg = <0x08080000 DT_SIZE_K(6)>;
+		};
 	};
 
 	otgfs_phy: otgfs_phy {


### PR DESCRIPTION
Add EEPROM support in the L0 Series.
The function has been tested on the `nucleo_l053r8` board.

``` console
$ west build -b nucleo_l053r8 tests/drivers/eeprom
$ wets flash
```
```
*** Booting Zephyr OS build zephyr-v1.13.0-13221-gebaed210c786  ***
Running test suite eeprom_api
===================================================================                                        
starting test - test_size                                                                                  
PASS - test_size                                                                                           
===================================================================                                        
starting test - test_out_of_bounds                                                                         
W: attempt to write past device boundary                                                                   
PASS - test_out_of_bounds                                                                                  
===================================================================                                        
starting test - test_write_and_verify                                                                      
PASS - test_write_and_verify                                                                               
===================================================================                                        
starting test - test_zero_length_write                                                                     
PASS - test_zero_length_write                                                                              
===================================================================                                        
Test suite eeprom_api succeeded                                                                            
===================================================================                                        
PROJECT EXECUTION SUCCESSFUL
```