### PR TITLE
UART Console: Add option to suppress echo of input

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -44,14 +44,6 @@ config CONSOLE_HANDLER
 	  This option enables console input handler allowing to write simple
 	  interaction between serial console and the OS.
 
-config UART_CONSOLE_SUPPRESS_ECHO
-	bool "Supresses echo of input data"
-	depends on UART_CONSOLE
-	default n
-	help
-	  Enable this option to suppress the echo of input characters
-	  on the UART console.
-
 config UART_CONSOLE
 	bool "Use UART for console"
 	depends on SERIAL && SERIAL_HAS_DRIVER
@@ -88,6 +80,14 @@ config UART_CONSOLE_MCUMGR
 	  and device management.  When enabled, the UART console does not
 	  process mcumgr frames, but it hands them up to a higher level module
 	  (e.g., the shell).  If unset, incoming mcumgr frames are dropped.
+
+config UART_CONSOLE_SUPPRESS_ECHO
+	bool "Suppresses echo of input data"
+	depends on UART_CONSOLE
+	default n
+	help
+	  Enable this option to suppress the echo of input characters
+	  on the UART console.
 
 config USB_UART_CONSOLE
 	bool "Use USB port for console outputs"

--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -43,6 +43,14 @@ config CONSOLE_HANDLER
 	help
 	  This option enables console input handler allowing to write simple
 	  interaction between serial console and the OS.
+	  
+config UART_CONSOLE_SUPPRESS_ECHO
+	bool "Supresses echo of input data"
+	depends on UART_CONSOLE
+	default n
+	help
+	  Enable this option to suppress the echo of input characters
+	  on the UART console.
 
 config UART_CONSOLE
 	bool "Use UART for console"

--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -43,7 +43,7 @@ config CONSOLE_HANDLER
 	help
 	  This option enables console input handler allowing to write simple
 	  interaction between serial console and the OS.
-	  
+
 config UART_CONSOLE_SUPPRESS_ECHO
 	bool "Supresses echo of input data"
 	depends on UART_CONSOLE

--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -170,8 +170,10 @@ static void insert_char(char *pos, char c, u8_t end)
 {
 	char tmp;
 
+#ifndef CONFIG_UART_CONSOLE_SUPPRESS_ECHO
 	/* Echo back to console */
 	uart_poll_out(uart_console_dev, c);
+#endif /* CONFIG_UART_CONSOLE_SUPPRESS_ECHO */
 
 	if (end == 0U) {
 		*pos = c;
@@ -184,7 +186,9 @@ static void insert_char(char *pos, char c, u8_t end)
 	cursor_save();
 
 	while (end-- > 0) {
+#ifndef CONFIG_UART_CONSOLE_SUPPRESS_ECHO
 		uart_poll_out(uart_console_dev, tmp);
+#endif /* CONFIG_UART_CONSOLE_SUPPRESS_ECHO */
 		c = *pos;
 		*(pos++) = tmp;
 		tmp = c;
@@ -196,11 +200,15 @@ static void insert_char(char *pos, char c, u8_t end)
 
 static void del_char(char *pos, u8_t end)
 {
+#ifndef CONFIG_UART_CONSOLE_SUPPRESS_ECHO
 	uart_poll_out(uart_console_dev, '\b');
+#endif /* CONFIG_UART_CONSOLE_SUPPRESS_ECHO */
 
 	if (end == 0U) {
+#ifndef CONFIG_UART_CONSOLE_SUPPRESS_ECHO
 		uart_poll_out(uart_console_dev, ' ');
 		uart_poll_out(uart_console_dev, '\b');
+#endif /* CONFIG_UART_CONSOLE_SUPPRESS_ECHO */
 		return;
 	}
 
@@ -208,10 +216,14 @@ static void del_char(char *pos, u8_t end)
 
 	while (end-- > 0) {
 		*pos = *(pos + 1);
+#ifndef CONFIG_UART_CONSOLE_SUPPRESS_ECHO
 		uart_poll_out(uart_console_dev, *(pos++));
+#endif /* CONFIG_UART_CONSOLE_SUPPRESS_ECHO */
 	}
 
+#ifndef CONFIG_UART_CONSOLE_SUPPRESS_ECHO
 	uart_poll_out(uart_console_dev, ' ');
+#endif /* CONFIG_UART_CONSOLE_SUPPRESS_ECHO */
 
 	/* Move cursor back to right place */
 	cursor_restore();
@@ -508,8 +520,10 @@ void uart_console_isr(struct device *unused)
 				break;
 			case '\r':
 				cmd->line[cur + end] = '\0';
+#ifndef CONFIG_UART_CONSOLE_SUPPRESS_ECHO
 				uart_poll_out(uart_console_dev, '\r');
 				uart_poll_out(uart_console_dev, '\n');
+#endif /* CONFIG_UART_CONSOLE_SUPPRESS_ECHO */
 				cur = 0U;
 				end = 0U;
 				k_fifo_put(lines_queue, cmd);


### PR DESCRIPTION
When using UART for "asynchronous" communication,
the echo of the input may break the output to read.

With the introduction of a new config option
CONFIG_UART_CONSOLE_SUPPRESS_ECHO,
the echo may be suppressed if needed.

Signed-off-by: Stefan Diewald <dwld@users.noreply.github.com>