### PR TITLE
[Backport to v1.14-branch] drivers: spi: Support PM busy state where relevant in DW

### DIFF
--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -340,6 +340,12 @@ static int transceive(struct device *dev,
 
 	spi_context_lock(&spi->ctx, asynchronous, signal);
 
+#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+	if (device_busy_check(dev) != (-EBUSY)) {
+		device_busy_set(dev);
+	}
+#endif /* CONFIG_DEVICE_POWER_MANAGEMENT */
+
 	/* Configure */
 	ret = spi_dw_configure(info, spi, config);
 	if (ret) {
@@ -424,6 +430,8 @@ static int transceive(struct device *dev,
 	ret = spi_context_wait_for_completion(&spi->ctx);
 out:
 	spi_context_release(&spi->ctx, ret);
+
+	device_busy_clear(dev);
 
 	return ret;
 }


### PR DESCRIPTION
Need to set device busy when enter into transceive function
in SPI DW driver.
In current SPI DW driver the transceive function don't set busy state,
but that is important for PM busy state.
This will lead to unexpected behaviors when system calls this
function and enter into idle state.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
Backport of #21587 to v1.14-branch