### PR TITLE
drivers: uart: Enable rx byte counting timer only in active power state

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1266,6 +1266,9 @@ static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
 		uarte_nrfx_pins_enable(dev, true);
 		nrf_uarte_enable(uarte);
 #ifdef CONFIG_UART_ASYNC_API
+		if (hw_rx_counting_enabled(get_dev_data(dev))) {
+			nrfx_timer_enable(&get_dev_config(dev)->timer);
+		}
 		if (get_dev_data(dev)->async) {
 			return;
 		}
@@ -1287,6 +1290,9 @@ static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
 		 * only sent after each RX if async UART API is used.
 		 */
 #ifdef CONFIG_UART_ASYNC_API
+		if (hw_rx_counting_enabled(get_dev_data(dev))) {
+			nrfx_timer_disable(&get_dev_config(dev)->timer);
+		}
 		if (get_dev_data(dev)->async) {
 			nrf_uarte_disable(uarte);
 			uarte_nrfx_pins_enable(dev, false);


### PR DESCRIPTION
Nrfx_uarte uses a hardware timer/counter to count received bytes.
Keeping this timer enabled increases power consumption for some nRF SoCs.

This change disables the timer when the appropriate power states are set.

Signed-off-by: Audun Korneliussen <audun.korneliussen@nordicsemi.no>