### PR TITLE
Bluetooth: Kconfig: Fix error in buffer pool sizes

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -62,9 +62,9 @@ config BT_DISCARDABLE_BUF_COUNT
 
 config BT_DISCARDABLE_BUF_SIZE
 	int "Size of discardable event buffers"
-	range 44 257
+	range 45 257
 	default 257 if BT_BREDR
-	default 44
+	default 45
 	help
 	  Size of buffers in the separate discardable event buffer pool.
 	  The minimum size is set based on the Advertising Report. Setting

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -160,6 +160,7 @@ NET_BUF_POOL_FIXED_DEFINE(hci_rx_pool, CONFIG_BT_RX_BUF_COUNT,
 
 #if defined(CONFIG_BT_CONN)
 #define NUM_COMLETE_EVENT_SIZE BT_BUF_SIZE(                            \
+	sizeof(struct bt_hci_evt_hdr) +                                \
 	sizeof(struct bt_hci_cp_host_num_completed_packets) +          \
 	CONFIG_BT_MAX_CONN * sizeof(struct bt_hci_handle_count))
 /* Dedicated pool for HCI_Number_of_Completed_Packets. This event is always


### PR DESCRIPTION
Fix error in calculation of the minimum discardable buffer size. For
the LE Advertising Report the maximum payload is 31 bytes plus
additional data in the event gives an event size of 41 bytes (given that
num_reports is 1). Since this is a meta event we need to include the
sub-event code, plus the event header of 2 bytes. Total of 44 bytes.

This is a regression from afa9c42d75 where we forgot th 1 byte for the
RSSI that is appended after the data. Easy to miss since it is not part
of the struct.

Fix error in calculation of the num complete buffer size. Here we forgot
to include the 2 byte event header.

This is a regression from 89981b07c8.