### PR TITLE
Bluetooth: smp: Added Legacy only pairing and Legacy OOB pairing support

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -605,6 +605,20 @@ void bt_set_bondable(bool enable);
 void bt_set_oob_data_flag(bool enable);
 
 /**
+ * @brief Set OOB Temporary Key to be used for pairing
+ *
+ * This function allows to set OOB data for the LE legacy pairing procedure. The
+ * function should only be called in response to the oob_data_request() callback
+ * provided that the legacy method is user pairing.
+ *
+ * @param conn Connection object
+ * @param tk Pointer to 16 byte long TK array
+ *
+ * @return Zero on success or -EINVAL if NULL
+ */
+int bt_le_oob_set_legacy_tk(struct bt_conn *conn, const u8_t *tk);
+
+/**
  * @brief Set OOB data during LE SC pairing procedure
  *
  * This function allows to set OOB data during the LE SC pairing procedure. The

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -283,7 +283,6 @@ config BT_SMP
 	select TINYCRYPT_AES
 	select TINYCRYPT_AES_CMAC
 	select BT_RPA
-	select BT_ECC
 	help
 	  This option enables support for the Security Manager Protocol
 	  (SMP), making it possible to pair devices over LE.
@@ -328,6 +327,20 @@ config BT_SMP_SC_ONLY
 	  for services that only require Security Mode 1 Level 1 (no security).
 	  Security Mode 1 Level 4 stands for authenticated LE Secure Connections
 	  pairing with encryption. Enabling this option disables legacy pairing.
+
+config BT_SMP_OOB_LEGACY_PAIR_ONLY
+	bool "Force Out Of Band Legacy pairing"
+	depends on !(BT_SMP_SC_PAIR_ONLY || BT_SMP_SC_ONLY)
+	help
+	  This option disables Legacy and LE SC pairing and forces legacy OOB.
+
+config BT_SMP_DISABLE_LEGACY_JW_PASSKEY
+	bool "Forbid usage of insecure legacy pairing methods"
+	depends on !(BT_SMP_SC_PAIR_ONLY || BT_SMP_SC_ONLY || \
+		     BT_SMP_OOB_LEGACY_PAIR_ONLY)
+	help
+	  This option disables Just Works and Passkey legacy pairing methods to
+	  increase security.
 
 config BT_SMP_ALLOW_UNAUTH_OVERWRITE
 	bool "Allow unauthenticated pairing for paired device"
@@ -509,6 +522,7 @@ endif # BT_HCI_HOST
 
 config BT_ECC
 	bool "Enable ECDH key generation support"
+	default y if !BT_SMP_OOB_LEGACY_PAIR_ONLY
 	help
 	  This option adds support for ECDH HCI commands.
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1109,6 +1109,11 @@ int bt_conn_set_security(struct bt_conn *conn, bt_security_t sec)
 		return -EOPNOTSUPP;
 	}
 
+	if (IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY) &&
+	    sec > BT_SECURITY_L3) {
+		return -EOPNOTSUPP;
+	}
+
 	/* nothing to do */
 	if (conn->sec_level >= sec || conn->required_sec_level >= sec) {
 		return 0;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -6561,7 +6561,8 @@ int bt_le_oob_get_local(u8_t id, struct bt_le_oob *oob)
 	}
 
 
-	if (IS_ENABLED(CONFIG_BT_SMP)) {
+	if (IS_ENABLED(CONFIG_BT_SMP) &&
+	    !IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
 		err = bt_smp_le_oob_generate_sc_data(&oob->le_sc_data);
 		if (err) {
 			return err;
@@ -6579,6 +6580,7 @@ int bt_le_oob_set_legacy_tk(struct bt_conn *conn, const u8_t *tk)
 }
 #endif /* !defined(CONFIG_BT_SMP_SC_PAIR_ONLY) */
 
+#if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
 int bt_le_oob_set_sc_data(struct bt_conn *conn,
 			  const struct bt_le_oob_sc_data *oobd_local,
 			  const struct bt_le_oob_sc_data *oobd_remote)
@@ -6600,4 +6602,5 @@ int bt_le_oob_get_sc_data(struct bt_conn *conn,
 
 	return bt_smp_le_oob_get_sc_data(conn, oobd_local, oobd_remote);
 }
+#endif /* !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY) */
 #endif /* defined(CONFIG_BT_SMP) */

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -6572,6 +6572,13 @@ int bt_le_oob_get_local(u8_t id, struct bt_le_oob *oob)
 }
 
 #if defined(CONFIG_BT_SMP)
+#if !defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
+int bt_le_oob_set_legacy_tk(struct bt_conn *conn, const u8_t *tk)
+{
+	return bt_smp_le_oob_set_tk(conn, tk);
+}
+#endif /* !defined(CONFIG_BT_SMP_SC_PAIR_ONLY) */
+
 int bt_le_oob_set_sc_data(struct bt_conn *conn,
 			  const struct bt_le_oob_sc_data *oobd_local,
 			  const struct bt_le_oob_sc_data *oobd_remote)
@@ -6593,4 +6600,4 @@ int bt_le_oob_get_sc_data(struct bt_conn *conn,
 
 	return bt_smp_le_oob_get_sc_data(conn, oobd_local, oobd_remote);
 }
-#endif
+#endif /* defined(CONFIG_BT_SMP) */

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -80,13 +80,25 @@
 #endif /* CONFIG_BT_BONDABLE */
 
 #if defined(CONFIG_BT_BREDR)
+
 #define BT_SMP_AUTH_MASK_SC	0x2f
-#define BT_SMP_AUTH_DEFAULT (BT_SMP_AUTH_BONDING_FLAGS | BT_SMP_AUTH_SC |\
-			     BT_SMP_AUTH_CT2)
+#if defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
+#define BT_SMP_AUTH_DEFAULT (BT_SMP_AUTH_BONDING_FLAGS | BT_SMP_AUTH_CT2)
 #else
+#define BT_SMP_AUTH_DEFAULT (BT_SMP_AUTH_BONDING_FLAGS | BT_SMP_AUTH_CT2 |\
+			     BT_SMP_AUTH_SC)
+#endif /* CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY */
+
+#else
+
 #define BT_SMP_AUTH_MASK_SC	0x0f
+#if defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
+#define BT_SMP_AUTH_DEFAULT (BT_SMP_AUTH_BONDING_FLAGS)
+#else
 #define BT_SMP_AUTH_DEFAULT (BT_SMP_AUTH_BONDING_FLAGS | BT_SMP_AUTH_SC)
-#endif
+#endif /* CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY */
+
+#endif /* CONFIG_BT_BREDR */
 
 enum pairing_method {
 	JUST_WORKS,		/* JustWorks pairing */
@@ -209,6 +221,7 @@ static const u8_t gen_method_legacy[5 /* remote */][5 /* local */] = {
 };
 #endif /* CONFIG_BT_SMP_SC_PAIR_ONLY */
 
+#if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
 /* based on table 2.8 Core Spec 2.3.5.1 Vol. 3 Part H */
 static const u8_t gen_method_sc[5 /* remote */][5 /* local */] = {
 	{ JUST_WORKS, JUST_WORKS, PASSKEY_INPUT, JUST_WORKS, PASSKEY_INPUT },
@@ -220,6 +233,7 @@ static const u8_t gen_method_sc[5 /* remote */][5 /* local */] = {
 	{ PASSKEY_DISPLAY, PASSKEY_CONFIRM, PASSKEY_INPUT, JUST_WORKS,
 	  PASSKEY_CONFIRM },
 };
+#endif /* !CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY */
 
 static const u8_t sc_debug_public_key[64] = {
 	0xe6, 0x9d, 0x35, 0x0e, 0x48, 0x01, 0x03, 0xcc, 0xdb, 0xfd, 0xf4, 0xac,
@@ -347,13 +361,14 @@ static bool smp_keys_check(struct bt_conn *conn)
 
 static u8_t get_pair_method(struct bt_smp *smp, u8_t remote_io)
 {
-	struct bt_smp_pairing *req, *rsp;
-
 #if !defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
 	if (!atomic_test_bit(smp->flags, SMP_FLAG_SC)) {
 		return legacy_get_pair_method(smp, remote_io);
 	}
 #endif
+
+#if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
+	struct bt_smp_pairing *req, *rsp;
 
 	req = (struct bt_smp_pairing *)&smp->preq[1];
 	rsp = (struct bt_smp_pairing *)&smp->prsp[1];
@@ -375,6 +390,9 @@ static u8_t get_pair_method(struct bt_smp *smp, u8_t remote_io)
 	}
 
 	return gen_method_sc[remote_io][get_io_capa()];
+#else
+	return JUST_WORKS;
+#endif
 }
 
 static enum bt_security_err auth_err_get(u8_t smp_err)
@@ -683,6 +701,17 @@ static bool update_keys_check(struct bt_smp *smp)
 
 	if (!conn->le.keys) {
 		conn->le.keys = bt_keys_get_addr(conn->id, &conn->le.dst);
+	}
+
+	if (IS_ENABLED(CONFIG_BT_SMP_DISABLE_LEGACY_JW_PASSKEY) &&
+	    !atomic_test_bit(smp->flags, SMP_FLAG_SC) &&
+	    smp->method != LEGACY_OOB) {
+		return false;
+	}
+
+	if (IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY) &&
+	    smp->method != LEGACY_OOB) {
+		return false;
 	}
 
 	if (!conn->le.keys ||
@@ -2533,7 +2562,9 @@ static int smp_init(struct bt_smp *smp)
 
 	atomic_set_bit(&smp->allowed_cmds, BT_SMP_CMD_PAIRING_FAIL);
 
+#if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
 	sc_public_key = bt_pub_key_get();
+#endif
 
 	return 0;
 }
@@ -3808,6 +3839,10 @@ static u8_t smp_security_request(struct bt_smp *smp, struct net_buf *buf)
 
 static u8_t generate_dhkey(struct bt_smp *smp)
 {
+	if (IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
+		return BT_SMP_ERR_UNSPECIFIED;
+	}
+
 	if (bt_dh_key_gen(smp->pkey, bt_smp_dhkey_ready)) {
 		return BT_SMP_ERR_UNSPECIFIED;
 	}
@@ -4951,6 +4986,7 @@ int bt_smp_le_oob_set_tk(struct bt_conn *conn, const u8_t *tk)
 }
 #endif /* !defined(CONFIG_BT_SMP_SC_PAIR_ONLY) */
 
+#if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
 int bt_smp_le_oob_generate_sc_data(struct bt_le_oob_sc_data *le_sc_oob)
 {
 	int err;
@@ -4984,7 +5020,9 @@ int bt_smp_le_oob_generate_sc_data(struct bt_le_oob_sc_data *le_sc_oob)
 
 	return 0;
 }
+#endif /* !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY) */
 
+#if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
 static bool le_sc_oob_data_check(struct bt_smp *smp, bool oobd_local_present,
 				 bool oobd_remote_present)
 {
@@ -5088,6 +5126,7 @@ int bt_smp_le_oob_get_sc_data(struct bt_conn *conn,
 
 	return 0;
 }
+#endif /* !CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY */
 
 int bt_smp_auth_cancel(struct bt_conn *conn)
 {
@@ -5357,6 +5396,10 @@ static bool le_sc_supported(void)
 	 * "LE Read Local P-256 Public Key" and "LE Generate DH Key" commands.
 	 * Otherwise LE SC are not supported.
 	 */
+	if (IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
+		return false;
+	}
+
 	return BT_CMD_TEST(bt_dev.supported_commands, 34, 1) &&
 	       BT_CMD_TEST(bt_dev.supported_commands, 34, 2);
 }
@@ -5381,7 +5424,9 @@ int bt_smp_init(void)
 
 	BT_DBG("LE SC %s", sc_supported ? "enabled" : "disabled");
 
-	bt_pub_key_gen(&pub_key_cb);
+	if (!IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
+		bt_pub_key_gen(&pub_key_cb);
+	}
 
 	return smp_self_test();
 }

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -95,6 +95,7 @@ enum pairing_method {
 	PASSKEY_CONFIRM,	/* Passkey confirm */
 	PASSKEY_ROLE,		/* Passkey Entry depends on role */
 	LE_SC_OOB,		/* LESC Out of Band */
+	LEGACY_OOB,		/* Legacy Out of Band */
 };
 
 enum {
@@ -2142,6 +2143,11 @@ static u8_t legacy_get_pair_method(struct bt_smp *smp, u8_t remote_io)
 	req = (struct bt_smp_pairing *)&smp->preq[1];
 	rsp = (struct bt_smp_pairing *)&smp->prsp[1];
 
+	/* if both sides have OOB data use OOB */
+	if ((req->oob_flag & rsp->oob_flag) & BT_SMP_OOB_DATA_MASK) {
+		return LEGACY_OOB;
+	}
+
 	/* if none side requires MITM use JustWorks */
 	if (!((req->auth_req | rsp->auth_req) & BT_SMP_AUTH_MITM)) {
 		return JUST_WORKS;
@@ -2182,6 +2188,19 @@ static u8_t legacy_request_tk(struct bt_smp *smp)
 	}
 
 	switch (smp->method) {
+	case LEGACY_OOB:
+		if (bt_auth && bt_auth->oob_data_request) {
+			struct bt_conn_oob_info info = {
+				.type = BT_CONN_OOB_LE_LEGACY,
+			};
+
+			atomic_set_bit(smp->flags, SMP_FLAG_USER);
+			bt_auth->oob_data_request(smp->chan.chan.conn, &info);
+		} else {
+			return BT_SMP_ERR_OOB_NOT_AVAIL;
+		}
+
+		break;
 	case PASSKEY_DISPLAY:
 		if (IS_ENABLED(CONFIG_BT_FIXED_PASSKEY) &&
 		    fixed_passkey != BT_PASSKEY_INVALID) {
@@ -2355,11 +2374,8 @@ static u8_t legacy_pairing_confirm(struct bt_smp *smp)
 	return 0;
 }
 
-static void legacy_passkey_entry(struct bt_smp *smp, unsigned int passkey)
+static void legacy_user_tk_entry(struct bt_smp *smp)
 {
-	passkey = sys_cpu_to_le32(passkey);
-	memcpy(smp->tk, &passkey, sizeof(passkey));
-
 	if (!atomic_test_and_clear_bit(smp->flags, SMP_FLAG_CFM_DELAYED)) {
 		return;
 	}
@@ -2379,6 +2395,14 @@ static void legacy_passkey_entry(struct bt_smp *smp, unsigned int passkey)
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
 		atomic_set_bit(&smp->allowed_cmds, BT_SMP_CMD_PAIRING_RANDOM);
 	}
+}
+
+static void legacy_passkey_entry(struct bt_smp *smp, unsigned int passkey)
+{
+	passkey = sys_cpu_to_le32(passkey);
+	memcpy(smp->tk, &passkey, sizeof(passkey));
+
+	legacy_user_tk_entry(smp);
 }
 
 static u8_t smp_encrypt_info(struct bt_smp *smp, struct net_buf *buf)
@@ -4903,6 +4927,30 @@ int bt_smp_auth_passkey_confirm(struct bt_conn *conn)
 	return 0;
 }
 
+#if !defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
+int bt_smp_le_oob_set_tk(struct bt_conn *conn, const u8_t *tk)
+{
+	struct bt_smp *smp;
+
+	smp = smp_chan_get(conn);
+	if (!smp || !tk) {
+		return -EINVAL;
+	}
+
+	BT_DBG("%s", bt_hex(tk, 16));
+
+	if (!atomic_test_and_clear_bit(smp->flags, SMP_FLAG_USER)) {
+		return -EINVAL;
+	}
+
+	memcpy(smp->tk, tk, 16*sizeof(u8_t));
+
+	legacy_user_tk_entry(smp);
+
+	return 0;
+}
+#endif /* !defined(CONFIG_BT_SMP_SC_PAIR_ONLY) */
+
 int bt_smp_le_oob_generate_sc_data(struct bt_le_oob_sc_data *le_sc_oob)
 {
 	int err;
@@ -5061,6 +5109,7 @@ int bt_smp_auth_cancel(struct bt_conn *conn)
 	case PASSKEY_CONFIRM:
 		return smp_error(smp, BT_SMP_ERR_CONFIRM_FAILED);
 	case LE_SC_OOB:
+	case LEGACY_OOB:
 		return smp_error(smp, BT_SMP_ERR_OOB_NOT_AVAIL);
 	case JUST_WORKS:
 		return smp_error(smp, BT_SMP_ERR_UNSPECIFIED);
@@ -5236,6 +5285,7 @@ void bt_smp_update_keys(struct bt_conn *conn)
 	case PASSKEY_INPUT:
 	case PASSKEY_CONFIRM:
 	case LE_SC_OOB:
+	case LEGACY_OOB:
 		conn->le.keys->flags |= BT_KEYS_AUTHENTICATED;
 		break;
 	case JUST_WORKS:

--- a/subsys/bluetooth/host/smp.h
+++ b/subsys/bluetooth/host/smp.h
@@ -138,6 +138,7 @@ int bt_smp_auth_passkey_confirm(struct bt_conn *conn);
 int bt_smp_auth_pairing_confirm(struct bt_conn *conn);
 int bt_smp_auth_cancel(struct bt_conn *conn);
 
+int bt_smp_le_oob_set_tk(struct bt_conn *conn, const u8_t *tk);
 int bt_smp_le_oob_generate_sc_data(struct bt_le_oob_sc_data *le_sc_oob);
 int bt_smp_le_oob_set_sc_data(struct bt_conn *conn,
 			      const struct bt_le_oob_sc_data *oobd_local,

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -303,6 +303,10 @@ static void bt_ready(int err)
 		settings_load();
 	}
 
+	if (IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
+		bt_set_oob_data_flag(true);
+	}
+
 #if defined(CONFIG_BT_CONN)
 	default_conn = NULL;
 
@@ -1048,7 +1052,7 @@ static int cmd_oob_remote(const struct shell *shell, size_t argc,
 			sizeof(oob_remote.le_sc_data.c));
 		bt_set_oob_data_flag(true);
 	} else {
-		shell_error(shell, "legacy not implemented (%d)", argc);
+		shell_help(shell);
 		return -ENOEXEC;
 	}
 
@@ -1267,6 +1271,7 @@ static void auth_pairing_confirm(struct bt_conn *conn)
 	shell_print(ctx_shell, "Confirm pairing for %s", addr);
 }
 
+#if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
 static const char *oob_config_str(int oob_config)
 {
 	switch (oob_config) {
@@ -1281,6 +1286,7 @@ static const char *oob_config_str(int oob_config)
 		return "no";
 	}
 }
+#endif /* !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY) */
 
 static void auth_pairing_oob_data_request(struct bt_conn *conn,
 					  struct bt_conn_oob_info *oob_info)
@@ -1294,6 +1300,7 @@ static void auth_pairing_oob_data_request(struct bt_conn *conn,
 		return;
 	}
 
+#if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
 	if (oob_info->type == BT_CONN_OOB_LE_SC) {
 		struct bt_le_oob_sc_data *oobd_local =
 			oob_info->lesc.oob_config != BT_CONN_OOB_REMOTE_ONLY
@@ -1329,10 +1336,12 @@ static void auth_pairing_oob_data_request(struct bt_conn *conn,
 		bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
 		shell_print(ctx_shell, "Set %s OOB SC data for %s, ",
 			    oob_config_str(oob_info->lesc.oob_config), addr);
-	} else {
-		shell_print(ctx_shell, "Legacy OOB not supported");
-		bt_conn_auth_cancel(conn);
+		return;
 	}
+#endif /* CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY */
+
+	bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
+	shell_print(ctx_shell, "Legacy OOB TK requested from remote %s", addr);
 }
 
 static void auth_pairing_complete(struct bt_conn *conn, bool bonded)
@@ -1656,6 +1665,7 @@ static int cmd_auth_passkey(const struct shell *shell,
 			    size_t argc, char *argv[])
 {
 	unsigned int passkey;
+	int err;
 
 	if (!default_conn) {
 		shell_print(shell, "Not connected");
@@ -1668,9 +1678,37 @@ static int cmd_auth_passkey(const struct shell *shell,
 		return -EINVAL;
 	}
 
-	bt_conn_auth_passkey_entry(default_conn, passkey);
+	err = bt_conn_auth_passkey_entry(default_conn, passkey);
+	if (err) {
+		shell_error(shell, "Failed to set passkey (%d)", err);
+		return err;
+	}
+
 	return 0;
 }
+
+#if !defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
+static int cmd_auth_oob_tk(const struct shell *shell, size_t argc, char *argv[])
+{
+	u8_t tk[16];
+	size_t len;
+	int err;
+
+	len = hex2bin(argv[1], strlen(argv[1]), tk, sizeof(tk));
+	if (len != sizeof(tk)) {
+		shell_error(shell, "TK should be 16 bytes");
+		return -EINVAL;
+	}
+
+	err = bt_le_oob_set_legacy_tk(default_conn, tk);
+	if (err) {
+		shell_error(shell, "Failed to set TK (%d)", err);
+		return err;
+	}
+
+	return 0;
+}
+#endif /* !defined(CONFIG_BT_SMP_SC_PAIR_ONLY) */
 #endif /* CONFIG_BT_SMP) || CONFIG_BT_BREDR */
 
 
@@ -1739,6 +1777,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 		      cmd_auth_passkey_confirm, 1, 0),
 	SHELL_CMD_ARG(auth-pairing-confirm, NULL, HELP_NONE,
 		      cmd_auth_pairing_confirm, 1, 0),
+#if !defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
+	SHELL_CMD_ARG(auth-oob-tk, NULL, "<tk>", cmd_auth_oob_tk, 2, 0),
+#endif /* !defined(CONFIG_BT_SMP_SC_PAIR_ONLY) */
 	SHELL_CMD_ARG(oob-remote, NULL,
 		      HELP_ADDR_LE" <oob rand> <oob confirm>",
 		      cmd_oob_remote, 3, 2),


### PR DESCRIPTION
- Added public API in `conn.h` as `bt_le_oob_set_legacy_tk(u8_t *tk)`
- Added new Kconfig options:
 
1.  `CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY` to force usage of legacy OOB pairing and free up memory

1.  `CONFIG_BT_SMP_DISABLE_LEGACY_JW_PASSKEY` to forbid the usage of the insecure legacy pairing methods

Fixes: #2585 