### PR TITLE
doc: dts: Remove 'title:' from binding example

### DIFF
--- a/doc/guides/dts/index.rst
+++ b/doc/guides/dts/index.rst
@@ -673,7 +673,6 @@ This should now be written like this:
 
 .. code-block:: yaml
 
-   title: ...
    description: ...
 
    compatible: "company,device"
@@ -688,7 +687,6 @@ This should now be written like this:
            required: false
 
    child-binding:
-       title: ...
        description: ...
 
        properties:


### PR DESCRIPTION
'title:' was deprecated in commit 2934ee2cda ("dts: bindings: Remove
'title:' and put all info. into 'description:'"). Overlooked leftover.