### PR TITLE
include: dfu: Add extern "C" in mcuboot.h

### DIFF
--- a/include/dfu/mcuboot.h
+++ b/include/dfu/mcuboot.h
@@ -13,6 +13,10 @@
 
 #include <zephyr/types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** Attempt to boot the contents of slot 0. */
 #define BOOT_SWAP_TYPE_NONE     1
 
@@ -176,5 +180,9 @@ int boot_request_upgrade(int permanent);
  * @return 0 on success, negative errno code on fail.
  */
 int boot_erase_img_bank(u8_t area_id);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* ZEPHYR_INCLUDE_DFU_MCUBOOT_H_ */


### PR DESCRIPTION
I ran into a build failure trying to use Zephyr's MCUmgr.  It was a
missing symbol at link time, and since I am using C++, I looked to see
if it was a name mangling issue.  The mcuboot.h header file was missing
`extern "C"` guards, which was the root cause of the issue.

This commit adds C++ support to mcuboot.h by adding in `extern "C"`
guards.  I validated this change by building and running my DFU
application with MCUmgr successfully.

Signed-off-by: Brooks Prumo <brooks@prumo.org>