### PR TITLE
[TOPIC-GPIO] disk: Convert sdhc spi driver to new gpio api

### DIFF
--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -78,7 +78,7 @@ uext_serial: &usart1 {};
 
 &spi2 {
 	status = "okay";
-	cs-gpios = <&gpiod 2 0>;
+	cs-gpios = <&gpiod 2 GPIO_ACTIVE_HIGH>;
 
 	sdhc0: sdhc@0 {
 		compatible = "zephyr,mmc-spi-slot";

--- a/samples/subsys/fs/fat_fs/nrf52840_blip.overlay
+++ b/samples/subsys/fs/fat_fs/nrf52840_blip.overlay
@@ -6,7 +6,7 @@
 
 &spi1 {
         status = "okay";
-        cs-gpios = <&gpio0 17 0>;
+        cs-gpios = <&gpio0 17 GPIO_ACTIVE_HIGH>;
 
         sdhc0: sdhc@0 {
                 compatible = "zephyr,mmc-spi-slot";

--- a/subsys/disk/disk_access_spi_sdhc.c
+++ b/subsys/disk/disk_access_spi_sdhc.c
@@ -28,6 +28,7 @@ struct sdhc_spi_data {
 	struct spi_config cfg;
 	struct device *cs;
 	u32_t pin;
+	gpio_devicetree_flags_t flags;
 
 	bool high_capacity;
 	u32_t sector_count;
@@ -71,7 +72,7 @@ static int sdhc_spi_trace(struct sdhc_spi_data *data, int dir, int err,
 /* Asserts or deasserts chip select */
 static void sdhc_spi_set_cs(struct sdhc_spi_data *data, int value)
 {
-	gpio_pin_write(data->cs, data->pin, value);
+	gpio_pin_set(data->cs, data->pin, value);
 }
 
 /* Receives a fixed number of bytes */
@@ -775,10 +776,12 @@ static int sdhc_spi_init(struct device *dev)
 	__ASSERT_NO_MSG(data->cs != NULL);
 
 	data->pin = DT_INST_0_ZEPHYR_MMC_SPI_SLOT_CS_GPIOS_PIN;
+	data->flags = DT_INST_0_ZEPHYR_MMC_SPI_SLOT_CS_GPIOS_FLAGS;
 
 	disk_spi_sdhc_init(dev);
 
-	return gpio_pin_configure(data->cs, data->pin, GPIO_DIR_OUT);
+	return gpio_pin_configure(data->cs, data->pin,
+				  GPIO_OUTPUT_INACTIVE | data->flags);
 }
 
 static int disk_spi_sdhc_access_status(struct disk_info *disk)


### PR DESCRIPTION
Converts the sdhc spi driver to the new gpio api. Updates device trees
for the olimexino_stm32 and nrf52840_blip boards to set appropriate
active high/low polarity for the spi chip select pin.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

@pabigot @henrikbrixandersen @ydamigos Will you please test this patch? I do not have the hardware, so I can only verify that it builds.