### PR TITLE
samples: drivers: soc_flash_nrf: add test harness

### DIFF
--- a/samples/drivers/soc_flash_nrf/sample.yaml
+++ b/samples/drivers/soc_flash_nrf/sample.yaml
@@ -3,7 +3,7 @@ sample:
 tests:
   sample.drivers.flash.soc_flash_nrf::
     platform_whitelist: nrf52_pca10040 nrf9160_pca10090 nrf9160_pca10090ns
-    tags: flash nrf52
+    tags: flash nrf52 nrf9160
     harness: console
     harness_config:
       type: multi_line

--- a/samples/drivers/soc_flash_nrf/sample.yaml
+++ b/samples/drivers/soc_flash_nrf/sample.yaml
@@ -4,3 +4,20 @@ tests:
   sample.drivers.flash.soc_flash_nrf::
     platform_whitelist: nrf52_pca10040 nrf9160_pca10090 nrf9160_pca10090ns
     tags: flash nrf52
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        -  "Flash erase succeeded"
+        -  "Data read: 1234"
+        -  "Data read matches data written. Good!"
+        -  "Flash erase succeeded"
+        -  "Data read: 1122"
+        -  "Data read matches data written. Good!"
+        -  "Flash erase succeeded"
+        -  "Data read: 1234"
+        -  "Data read: 1234"
+        -  "Data read matches data written. Good!"
+        -  "SoC flash consists of \\d+ pages."
+        -  "write-block-size = 1"


### PR DESCRIPTION
Added harness config to sample in order for the sanitycheck tool
to run and understand whether the samples output is as expected.

Signed-off-by: Łukasz Hejnak <lukasz.hejnak@nordicsemi.no>