### PR TITLE
tests: userspace: test syscall irq context

### DIFF
--- a/tests/kernel/mem_protect/userspace/src/test_syscall.h
+++ b/tests/kernel/mem_protect/userspace/src/test_syscall.h
@@ -10,6 +10,7 @@
 __syscall void stack_info_get(char **start_addr, size_t *size);
 __syscall int check_perms(void *addr, size_t size, int write);
 __syscall void missing_syscall(void);
+__syscall void check_syscall_context(void);
 
 #include <syscalls/test_syscall.h>
 


### PR DESCRIPTION
Interrupts should not be locked when servicing a system call,
and the kernel should not think we are in an interrupt handler
either.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>