### PR TITLE
sanitycheck: improve summary output

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2414,7 +2414,7 @@ class TestSuite:
             "{}{} of {}{} tests passed ({:.2%}), {}{}{} failed, {} skipped with {}{}{} warnings in {:.2f} seconds".format(
                 Fore.RED if failed else Fore.GREEN,
                 self.total_tests - self.total_failed - self.total_skipped,
-                self.total_tests,
+                self.total_tests - self.total_skipped,
                 Fore.RESET,
                 pass_rate,
                 Fore.RED if self.total_failed else Fore.RESET,


### PR DESCRIPTION
Show how many tests passed out of those that were actually
performed, not including skipped tests (which we also report
a count of)

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>