### PR TITLE
ci: do not display timestamps

### DIFF
--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -20,7 +20,7 @@
 
 set -xe
 
-sanitycheck_options=" --inline-logs -N --timestamps -v"
+sanitycheck_options=" --inline-logs -N -v"
 export BSIM_OUT_PATH="${BSIM_OUT_PATH:-/opt/bsim/}"
 if [ ! -d "${BSIM_OUT_PATH}" ]; then
         unset BSIM_OUT_PATH


### PR DESCRIPTION
With timestamps enabled, the log in shippable is very difficult to read,
so remove those and enable them when needed for debugging only.