### PR TITLE
drivers: lora: sx1276: Added support for RSSI and SNR in recv

### DIFF
--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -53,6 +53,8 @@ struct sx1276_data {
 	RadioEvents_t sx1276_event;
 	u8_t *rx_buf;
 	u8_t rx_len;
+	s8_t snr;
+	s16_t rssi;
 } dev_data;
 
 bool SX1276CheckRfFrequency(uint32_t frequency)
@@ -338,12 +340,14 @@ static void sx1276_rx_done(u8_t *payload, u16_t size, int16_t rssi, int8_t snr)
 
 	dev_data.rx_buf = payload;
 	dev_data.rx_len = size;
+	dev_data.rssi = rssi;
+	dev_data.snr = snr;
 
 	k_sem_give(&dev_data.data_sem);
 }
 
 static int sx1276_lora_recv(struct device *dev, u8_t *data, u8_t size,
-			    s32_t timeout)
+			    s32_t timeout, s16_t *rssi, s8_t *snr)
 {
 	int ret;
 
@@ -371,6 +375,14 @@ static int sx1276_lora_recv(struct device *dev, u8_t *data, u8_t size,
 	 * wise method to fix this!
 	 */
 	memcpy(data, dev_data.rx_buf, dev_data.rx_len);
+
+	if (rssi != NULL) {
+		*rssi = dev_data.rssi;
+	}
+
+	if (snr != NULL) {
+		*snr = dev_data.snr;
+	}
 
 	return dev_data.rx_len;
 }

--- a/include/drivers/lora.h
+++ b/include/drivers/lora.h
@@ -73,7 +73,7 @@ typedef int (*lora_api_send)(struct device *dev,
  * @see lora_recv() for argument descriptions.
  */
 typedef int (*lora_api_recv)(struct device *dev, u8_t *data, u8_t size,
-			     s32_t timeout);
+			     s32_t timeout, s16_t *rssi, s8_t *snr);
 
 struct lora_driver_api {
 	lora_api_config config;
@@ -127,14 +127,16 @@ static inline int lora_send(struct device *dev,
  * @param timeout   Timeout value in milliseconds. API also accepts, K_NO_WAIT
 		    for no wait time and K_FOREVER for blocking until
 		    data arrives.
+ * @param rssi      RSSI of received data
+ * @param snr       SNR of received data
  * @return Length of the data received on success, negative on error
  */
 static inline int lora_recv(struct device *dev, u8_t *data, u8_t size,
-			    s32_t timeout)
+			    s32_t timeout, s16_t *rssi, s8_t *snr)
 {
 	const struct lora_driver_api *api = dev->driver_api;
 
-	return api->recv(dev, data, size, timeout);
+	return api->recv(dev, data, size, timeout, rssi, snr);
 }
 
 #endif	/* ZEPHYR_INCLUDE_DRIVERS_LORA_H_ */

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -22,6 +22,8 @@ void main(void)
 	struct lora_modem_config config;
 	int ret, len;
 	u8_t data[MAX_DATA_LEN] = {0};
+	s16_t rssi;
+	s8_t snr;
 
 	lora_dev = device_get_binding(DT_INST_0_SEMTECH_SX1276_LABEL);
 	if (!lora_dev) {
@@ -45,12 +47,14 @@ void main(void)
 
 	while (1) {
 		/* Block until data arrives */
-		len = lora_recv(lora_dev, data, MAX_DATA_LEN, K_FOREVER);
+		len = lora_recv(lora_dev, data, MAX_DATA_LEN, K_FOREVER,
+				&rssi, &snr);
 		if (len < 0) {
 			LOG_ERR("LoRa receive failed");
 			return;
 		}
 
-		LOG_INF("Received data: %s", log_strdup(data));
+		LOG_INF("Received data: %s (RSSI:%ddBm, SNR:%ddBm)",
+			log_strdup(data), rssi, snr);
 	}
 }


### PR DESCRIPTION
[LoRaMac-node](https://github.com/Lora-net/LoRaMac-node) can get `RSSI` and `SNR` value through [RxDone()](https://github.com/Lora-net/LoRaMac-node/blob/develop/src/mac/LoRaMac.c#L806-L820).
``` c
static void OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr )
{
    RxDoneParams.LastRxDone = TimerGetCurrentTime( );
    RxDoneParams.Payload = payload;
    RxDoneParams.Size = size;
    RxDoneParams.Rssi = rssi;
    RxDoneParams.Snr = snr;

    LoRaMacRadioEvents.Events.RxDone = 1;

    if( ( MacCtx.MacCallbacks != NULL ) && ( MacCtx.MacCallbacks->MacProcessNotify != NULL ) )
    {
        MacCtx.MacCallbacks->MacProcessNotify( );
    }
}
```

This patch uses lora_recv() to get `RSSI` and `SNR` values.


**samples/drivers/lora/receive**
```
*** Booting Zephyr OS build zephyr-v1.13.0-13290-g890e9a30ebee  ***                                        
[00:00:00.222,000] <inf> sx1276: SX1276 Version:12 found                                                   
[00:00:01.086,000] <inf> lora_receive: Received data: helloworld (RSSI:-97dBm, SNR:7dBm)                   
[00:00:02.090,000] <inf> lora_receive: Received data: helloworld (RSSI:-100dBm, SNR:6dBm)                  
[00:00:03.094,000] <inf> lora_receive: Received data: helloworld (RSSI:-102dBm, SNR:5dBm)                  
[00:00:04.099,000] <inf> lora_receive: Received data: helloworld (RSSI:-97dBm, SNR:7dBm)                   
[00:00:05.103,000] <inf> lora_receive: Received data: helloworld (RSSI:-98dBm, SNR:8dBm)                   
[00:00:06.107,000] <inf> lora_receive: Received data: helloworld (RSSI:-98dBm, SNR:8dBm)                   
[00:00:07.111,000] <inf> lora_receive: Received data: helloworld (RSSI:-98dBm, SNR:8dBm)                   
[00:00:08.115,000] <inf> lora_receive: Received data: helloworld (RSSI:-98dBm, SNR:8dBm)                   
[00:00:09.119,000] <inf> lora_receive: Received data: helloworld (RSSI:-98dBm, SNR:8dBm)                   
[00:00:10.123,000] <inf> lora_receive: Received data: helloworld (RSSI:-98dBm, SNR:8dBm)                   
[00:00:11.127,000] <inf> lora_receive: Received data: helloworld (RSSI:-98dBm, SNR:8dBm)
```