### PR TITLE
soc: nordic: add HAS_HW_NRF_ACL for nrf53 net core

### DIFF
--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -53,6 +53,7 @@ config SOC_NRF5340_CPUAPP
 config SOC_NRF5340_CPUNET
 	depends on SOC_SERIES_NRF53X
 	bool
+	select HAS_HW_NRF_ACL
 	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_DPPIC
 	select HAS_HW_NRF_EGU0


### PR DESCRIPTION
The network core has the ACL peripheral, reflect this in the
SoC kconfig.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>