### PR TITLE
west.yml: hal_stm32: stm32 hci lib update

### DIFF
--- a/boards/arm/nucleo_wb55rg/board.cmake
+++ b/boards/arm/nucleo_wb55rg/board.cmake
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 board_runner_args(pyocd "--target=stm32wb55rgvx")
 
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nucleo_wb55rg/doc/nucleo_wb55rg.rst
+++ b/boards/arm/nucleo_wb55rg/doc/nucleo_wb55rg.rst
@@ -233,8 +233,10 @@ Flashing
 ========
 
 Nucleo WB55RG board includes an ST-LINK/V2-1 embedded debug tool
-interface.  This interface is not yet supported by the openocd version.
-Instead, support can be enabled on pyocd by adding "pack" support with
+interface.  This interface is supported by the openocd version included in the
+Zephyr SDK since v0.11.0.
+
+If you prefer, you can use pyocd, but it requires to enable "pack" support with
 the following pyocd command:
 
 .. code-block:: console

--- a/boards/arm/nucleo_wb55rg/support/openocd.cfg
+++ b/boards/arm/nucleo_wb55rg/support/openocd.cfg
@@ -1,0 +1,7 @@
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32wbx.cfg]
+
+reset_config srst_only

--- a/west.yml
+++ b/west.yml
@@ -62,7 +62,7 @@ manifest:
       revision: fa481784b3c49780f18d50bafe00390ccb62b2ec
       path: modules/hal/st
     - name: hal_stm32
-      revision: 2f1923cb2067bbddb89716896cf27d7c2245f580
+      revision: 94d735c2613f5d17b64b78a15f0b0191e4474eb0
       path: modules/hal/stm32
     - name: hal_ti
       revision: c9fd9faeaba28c23998a83b37054805259dd8de8


### PR DESCRIPTION
Update hal_stm32 for STM32WB HCI lib update to v1.3.0

cf https://github.com/zephyrproject-rtos/hal_stm32/pull/35

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>