### PR TITLE
bluetooth: Selecting ENTROPY_GENERATOR for crypto

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -152,6 +152,7 @@ comment "BLE Controller configuration"
 config BT_CTLR_CRYPTO
 	bool "Enable crypto functions in Controller"
 	default y
+	select ENTROPY_GENERATOR
 	help
 	  Use random number generation and AES encryption support functions
 	  provided by the controller.


### PR DESCRIPTION
Bluetooth sample with controller crypto, requires sys_rand32_get that
used to be linked with Tinycrypt. The selection, within Kconfig of
Tinycrypt, that has been enabling compilation of the symbol has
been removed and thus preventing controller crypto to link.
    
This commit moves the selection to BT_CTLR_CRYPTO.
