### PR TITLE
drivers: sensors: Fix compilation after HAL update

### DIFF
--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -185,7 +185,7 @@ static int qdec_nrfx_init(struct device *dev)
 #endif
 		.ledpre             = DT_NORDIC_NRF_QDEC_QDEC_0_LED_PRE,
 		.ledpol             = NRF_QDEC_LEPOL_ACTIVE_HIGH,
-		.interrupt_priority = NRFX_QDEC_CONFIG_IRQ_PRIORITY,
+		.interrupt_priority = NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY,
 		.dbfen              = 0, /* disabled */
 		.sample_inten       = 0, /* disabled */
 	};


### PR DESCRIPTION
hal_nordic update 1e8103ae require changes to sensor code,
to make it compile.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>