### PR TITLE
samples/bluetooth: peripheral: Add nucleo_wb55rg as a target + minor fix

### DIFF
--- a/samples/bluetooth/peripheral/sample.yaml
+++ b/samples/bluetooth/peripheral/sample.yaml
@@ -6,7 +6,7 @@ tests:
     harness: bluetooth
     platform_whitelist: qemu_cortex_m3 qemu_x86 nucleo_wb55rg
     tags: bluetooth
-  sample.bluetooth.peripheral_hr.x_nucleo_idb05a1_shield:
+  sample.bluetooth.peripheral.x_nucleo_idb05a1_shield:
     harness: bluetooth
     platform_whitelist: nucleo_l4r5zi
     depends_on: arduino_spi arduino_gpio

--- a/samples/bluetooth/peripheral/sample.yaml
+++ b/samples/bluetooth/peripheral/sample.yaml
@@ -4,7 +4,7 @@ sample:
 tests:
   sample.bluetooth.peripheral:
     harness: bluetooth
-    platform_whitelist: qemu_cortex_m3 qemu_x86
+    platform_whitelist: qemu_cortex_m3 qemu_x86 nucleo_wb55rg
     tags: bluetooth
   sample.bluetooth.peripheral_hr.x_nucleo_idb05a1_shield:
     harness: bluetooth


### PR DESCRIPTION
commit 95feb92
```
Author: Erwan Gouriou <erwan.gouriou@linaro.org>
Date:   Wed Jan 15 12:14:37 2020 +0100

    samples: bluetooth: Add nucleo_wb55rg as test target for peripheral
    
    Aim is to ensure build of stm32 hci_ipm driver.
    
    Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org
```

commit 9bdd452
```
Author: Erwan Gouriou <erwan.gouriou@linaro.org>
Date:   Wed Jan 15 12:15:46 2020 +0100

    samples: bluetooth/peripheral: Fix test variant name
    
    Replace ..peripheral_hr.. by ..peripheral..
    
    
    Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>
```