### PR TITLE
spi: stm32: deduplicate code creating SPI instances

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -498,230 +498,52 @@ static int spi_stm32_init(struct device *dev)
 	return 0;
 }
 
-#ifdef CONFIG_SPI_1
-
 #ifdef CONFIG_SPI_STM32_INTERRUPT
-static void spi_stm32_irq_config_func_1(struct device *port);
-#endif
-
-static const struct spi_stm32_config spi_stm32_cfg_1 = {
-	.spi = (SPI_TypeDef *) DT_SPI_1_BASE_ADDRESS,
-	.pclken = {
-		.enr = DT_SPI_1_CLOCK_BITS,
-		.bus = DT_SPI_1_CLOCK_BUS
-	},
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-	.irq_config = spi_stm32_irq_config_func_1,
-#endif
-};
-
-static struct spi_stm32_data spi_stm32_dev_data_1 = {
-	SPI_CONTEXT_INIT_LOCK(spi_stm32_dev_data_1, ctx),
-	SPI_CONTEXT_INIT_SYNC(spi_stm32_dev_data_1, ctx),
-};
-
-DEVICE_AND_API_INIT(spi_stm32_1, DT_SPI_1_NAME, &spi_stm32_init,
-		    &spi_stm32_dev_data_1, &spi_stm32_cfg_1,
-		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
-		    &api_funcs);
-
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-static void spi_stm32_irq_config_func_1(struct device *dev)
-{
-	IRQ_CONNECT(DT_SPI_1_IRQ, DT_SPI_1_IRQ_PRI,
-		    spi_stm32_isr, DEVICE_GET(spi_stm32_1), 0);
-	irq_enable(DT_SPI_1_IRQ);
+#define STM32_SPI_IRQ_HANDLER_DECL(id)					\
+	static void spi_stm32_irq_config_func_##id(struct device *dev)
+#define STM32_SPI_IRQ_HANDLER_FUNC(id)					\
+	.irq_config_func = uart_stm32_irq_config_func_##id,
+#define STM32_SPI_IRQ_HANDLER(id)					\
+static void uart_stm32_irq_config_func_##id(struct device *dev)		\
+{									\
+	IRQ_CONNECT(DT_SPI_##id##_IRQ, DT_SPI_##id##_IRQ_PRI,		\
+		    spi_stm32_isr, DEVICE_GET(spi_stm32_##id), 0);	\
+	irq_enable(DT_SPI_##id##_IRQ);					\
 }
+#else
+#define STM32_SPI_IRQ_HANDLER_DECL(id)
+#define STM32_SPI_IRQ_HANDLER_FUNC(id)
+#define STM32_SPI_IRQ_HANDLER(id)
 #endif
 
-#endif /* CONFIG_SPI_1 */
+#define __STM32_SPI_INIT(id)						\
+STM32_SPI_IRQ_HANDLER_DECL(id);						\
+									\
+static const struct spi_stm32_config spi_stm32_cfg_##id = {		\
+	.spi = (SPI_TypeDef *) DT_SPI_##id##_BASE_ADDRESS,		\
+	.pclken = {							\
+		.enr = DT_SPI_##id##_CLOCK_BITS,			\
+		.bus = DT_SPI_##id##_CLOCK_BUS				\
+	},								\
+	STM32_SPI_IRQ_HANDLER_FUNC(id)					\
+};									\
+									\
+static struct spi_stm32_data spi_stm32_dev_data_##id = {		\
+	SPI_CONTEXT_INIT_LOCK(spi_stm32_dev_data_##id, ctx),		\
+	SPI_CONTEXT_INIT_SYNC(spi_stm32_dev_data_##id, ctx),		\
+};									\
+									\
+DEVICE_AND_API_INIT(spi_stm32_##id, DT_SPI_##id##_NAME, &spi_stm32_init, \
+		    &spi_stm32_dev_data_##id, &spi_stm32_cfg_##id,	\
+		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,		\
+		    &api_funcs)
 
-#ifdef CONFIG_SPI_2
+#define STM32_SPI_INIT(id)						\
+	COND_CODE_1(CONFIG_SPI_##id, (__STM32_SPI_INIT(id)), ())
 
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-static void spi_stm32_irq_config_func_2(struct device *port);
-#endif
-
-static const struct spi_stm32_config spi_stm32_cfg_2 = {
-	.spi = (SPI_TypeDef *) DT_SPI_2_BASE_ADDRESS,
-	.pclken = {
-		.enr = DT_SPI_2_CLOCK_BITS,
-		.bus = DT_SPI_2_CLOCK_BUS
-	},
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-	.irq_config = spi_stm32_irq_config_func_2,
-#endif
-};
-
-static struct spi_stm32_data spi_stm32_dev_data_2 = {
-	SPI_CONTEXT_INIT_LOCK(spi_stm32_dev_data_2, ctx),
-	SPI_CONTEXT_INIT_SYNC(spi_stm32_dev_data_2, ctx),
-};
-
-DEVICE_AND_API_INIT(spi_stm32_2, DT_SPI_2_NAME, &spi_stm32_init,
-		    &spi_stm32_dev_data_2, &spi_stm32_cfg_2,
-		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
-		    &api_funcs);
-
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-static void spi_stm32_irq_config_func_2(struct device *dev)
-{
-	IRQ_CONNECT(DT_SPI_2_IRQ, DT_SPI_2_IRQ_PRI,
-		    spi_stm32_isr, DEVICE_GET(spi_stm32_2), 0);
-	irq_enable(DT_SPI_2_IRQ);
-}
-#endif
-
-#endif /* CONFIG_SPI_2 */
-
-#ifdef CONFIG_SPI_3
-
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-static void spi_stm32_irq_config_func_3(struct device *port);
-#endif
-
-static const  struct spi_stm32_config spi_stm32_cfg_3 = {
-	.spi = (SPI_TypeDef *) DT_SPI_3_BASE_ADDRESS,
-	.pclken = {
-		.enr = DT_SPI_3_CLOCK_BITS,
-		.bus = DT_SPI_3_CLOCK_BUS
-	},
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-	.irq_config = spi_stm32_irq_config_func_3,
-#endif
-};
-
-static struct spi_stm32_data spi_stm32_dev_data_3 = {
-	SPI_CONTEXT_INIT_LOCK(spi_stm32_dev_data_3, ctx),
-	SPI_CONTEXT_INIT_SYNC(spi_stm32_dev_data_3, ctx),
-};
-
-DEVICE_AND_API_INIT(spi_stm32_3, DT_SPI_3_NAME, &spi_stm32_init,
-		    &spi_stm32_dev_data_3, &spi_stm32_cfg_3,
-		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
-		    &api_funcs);
-
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-static void spi_stm32_irq_config_func_3(struct device *dev)
-{
-	IRQ_CONNECT(DT_SPI_3_IRQ, DT_SPI_3_IRQ_PRI,
-		    spi_stm32_isr, DEVICE_GET(spi_stm32_3), 0);
-	irq_enable(DT_SPI_3_IRQ);
-}
-#endif
-
-#endif /* CONFIG_SPI_3 */
-
-#ifdef CONFIG_SPI_4
-
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-static void spi_stm32_irq_config_func_4(struct device *port);
-#endif
-
-static const  struct spi_stm32_config spi_stm32_cfg_4 = {
-	.spi = (SPI_TypeDef *) DT_SPI_4_BASE_ADDRESS,
-	.pclken = {
-		.enr = DT_SPI_4_CLOCK_BITS,
-		.bus = DT_SPI_4_CLOCK_BUS
-	},
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-	.irq_config = spi_stm32_irq_config_func_4,
-#endif
-};
-
-static struct spi_stm32_data spi_stm32_dev_data_4 = {
-	SPI_CONTEXT_INIT_LOCK(spi_stm32_dev_data_4, ctx),
-	SPI_CONTEXT_INIT_SYNC(spi_stm32_dev_data_4, ctx),
-};
-
-DEVICE_AND_API_INIT(spi_stm32_4, DT_SPI_4_NAME, &spi_stm32_init,
-		    &spi_stm32_dev_data_4, &spi_stm32_cfg_4,
-		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
-		    &api_funcs);
-
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-static void spi_stm32_irq_config_func_4(struct device *dev)
-{
-	IRQ_CONNECT(DT_SPI_4_IRQ, DT_SPI_4_IRQ_PRI,
-		    spi_stm32_isr, DEVICE_GET(spi_stm32_4), 0);
-	irq_enable(DT_SPI_4_IRQ);
-}
-#endif
-
-#endif /* CONFIG_SPI_4 */
-
-#ifdef CONFIG_SPI_5
-
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-static void spi_stm32_irq_config_func_5(struct device *port);
-#endif
-
-static const  struct spi_stm32_config spi_stm32_cfg_5 = {
-	.spi = (SPI_TypeDef *) DT_SPI_5_BASE_ADDRESS,
-	.pclken = {
-		.enr = DT_SPI_5_CLOCK_BITS,
-		.bus = DT_SPI_5_CLOCK_BUS
-	},
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-	.irq_config = spi_stm32_irq_config_func_5,
-#endif
-};
-
-static struct spi_stm32_data spi_stm32_dev_data_5 = {
-	SPI_CONTEXT_INIT_LOCK(spi_stm32_dev_data_5, ctx),
-	SPI_CONTEXT_INIT_SYNC(spi_stm32_dev_data_5, ctx),
-};
-
-DEVICE_AND_API_INIT(spi_stm32_5, DT_SPI_5_NAME, &spi_stm32_init,
-		    &spi_stm32_dev_data_5, &spi_stm32_cfg_5,
-		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
-		    &api_funcs);
-
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-static void spi_stm32_irq_config_func_5(struct device *dev)
-{
-	IRQ_CONNECT(DT_SPI_5_IRQ, DT_SPI_5_IRQ_PRI,
-		    spi_stm32_isr, DEVICE_GET(spi_stm32_5), 0);
-	irq_enable(DT_SPI_5_IRQ);
-}
-#endif
-
-#endif /* CONFIG_SPI_5 */
-
-#ifdef CONFIG_SPI_6
-
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-static void spi_stm32_irq_config_func_6(struct device *port);
-#endif
-
-static const  struct spi_stm32_config spi_stm32_cfg_6 = {
-	.spi = (SPI_TypeDef *) DT_SPI_6_BASE_ADDRESS,
-	.pclken = {
-		.enr = DT_SPI_6_CLOCK_BITS,
-		.bus = DT_SPI_6_CLOCK_BUS
-	},
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-	.irq_config = spi_stm32_irq_config_func_6,
-#endif
-};
-
-static struct spi_stm32_data spi_stm32_dev_data_6 = {
-	SPI_CONTEXT_INIT_LOCK(spi_stm32_dev_data_6, ctx),
-	SPI_CONTEXT_INIT_SYNC(spi_stm32_dev_data_6, ctx),
-};
-
-DEVICE_AND_API_INIT(spi_stm32_6, DT_SPI_6_NAME, &spi_stm32_init,
-		    &spi_stm32_dev_data_6, &spi_stm32_cfg_6,
-		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
-		    &api_funcs);
-
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-static void spi_stm32_irq_config_func_6(struct device *dev)
-{
-	IRQ_CONNECT(DT_SPI_6_IRQ, DT_SPI_6_IRQ_PRI,
-		    spi_stm32_isr, DEVICE_GET(spi_stm32_6), 0);
-	irq_enable(DT_SPI_6_IRQ);
-}
-#endif
-
-#endif /* CONFIG_SPI_6 */
+STM32_SPI_INIT(1)
+STM32_SPI_INIT(2)
+STM32_SPI_INIT(3)
+STM32_SPI_INIT(4)
+STM32_SPI_INIT(5)
+STM32_SPI_INIT(6)


### PR DESCRIPTION
Create new instances of SPI using single STM32_SPI_INIT() macro
invocation, similar as it is done for STM32 UART driver. Add also
implicit '#ifdef CONFIG_SPI_id' check, so it further reduces required
lines of code for each SPI instance definition.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>