### PR TITLE
cmake: print version to stdout, not stderr

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -54,7 +54,7 @@ else()
   set(PROJECT_VERSION ${PROJECT_VERSION_WITHOUT_TWEAK})
 endif()
 
-message("Zephyr version: ${PROJECT_VERSION}")
+message(STATUS "Zephyr version: ${PROJECT_VERSION}")
 
 set(MAJOR ${PROJECT_VERSION_MAJOR}) # Temporary convenience variable
 set(MINOR ${PROJECT_VERSION_MINOR}) # Temporary convenience variable


### PR DESCRIPTION
The version message from cmake is not an error and should not go to
stderr.