### PR TITLE
Bluetooth: Mesh: Skip publish if update fails

### DIFF
--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -424,6 +424,9 @@ struct bt_mesh_model_pub {
 	 *  @ref bt_mesh_model_pub.msg with a valid publication
 	 *  message.
 	 *
+	 *  If the callback returns non-zero, the publication is skipped
+	 *  and will resume on the next periodic publishing interval.
+	 *
 	 *  @param mod The Model the Publication Context belogs to.
 	 *
 	 *  @return Zero on success or (negative) error code otherwise.


### PR DESCRIPTION
Allow models to skip a periodic publish interval by returning an error
from the publish update callback.

Previously, an error return from publish update would cancel periodic
publishing. This can't be recovered from, and as such, no valid model
implementation could return an error from this callback, and there was
no way to skip a periodic publish.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>