### PR TITLE
 drivers: eth: native_posix: Yield to avoid deadlocks in RX

### DIFF
--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -375,6 +375,7 @@ static void eth_rx(struct eth_context *ctx)
 		if (net_if_is_up(ctx->iface)) {
 			while (!eth_wait_data(ctx->dev_fd)) {
 				read_data(ctx, ctx->dev_fd);
+				k_yield();
 			}
 		}
 


### PR DESCRIPTION
TCP segment with several EOL TCP options causes echo server to block and
use 100% of CPU. This patch fixes that issue by using k_yield to let
also other threads to run.

Fixes #21949

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>