### PR TITLE
shell: kconfig: Fix SEGGER_SYSTEMVIEW/SHELL_BACKEND_RTT build issue

### DIFF
--- a/subsys/debug/Kconfig.segger
+++ b/subsys/debug/Kconfig.segger
@@ -16,6 +16,7 @@ if USE_SEGGER_RTT
 
 config SEGGER_SYSTEMVIEW
 	bool "Segger SystemView support"
+	select CONSOLE
 	select RTT_CONSOLE
 	select THREAD_MONITOR
 	select THREAD_STACK_INFO

--- a/subsys/shell/Kconfig.backends
+++ b/subsys/shell/Kconfig.backends
@@ -115,6 +115,7 @@ endif # SHELL_BACKEND_SERIAL
 config SHELL_BACKEND_RTT
 	bool "Enable RTT backend"
 	select USE_SEGGER_RTT
+	select CONSOLE
 	select RTT_CONSOLE
 	help
 	  Enable RTT backend.


### PR DESCRIPTION
RTT_CONSOLE depends on CONSOLE, but SEGGER_SYSTEMVIEW and
SHELL_BACKEND_RTT select RTT_CONSOLE without also selecting CONSOLE.

This leads to a build failure in drivers/console/rtt_console.c (compiled
if RTT_CONSOLE is enabled) unless CONSOLE is enabled some other way.
Symbols like CONFIG_RTT_RETRY_DELAY_MS won't be defined, because they
depend on CONSOLE.

Came up in https://github.com/zephyrproject-rtos/zephyr/pull/21860. This
fix was verified there.

(Would be nice to get rid of some 'select's in the console subsystem at
some point. This is a quick fix.)