### PR TITLE
drivers: serial: ns16550 implement configure APIs

### DIFF
--- a/drivers/serial/uart_ns16550_port_x.h
+++ b/drivers/serial/uart_ns16550_port_x.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010, 2012-2015 Wind River Systems, Inc.
- * Copyright (c) 2019 Intel Corp.
+ * Copyright (c) 2019-2020 Intel Corp.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -12,10 +12,11 @@ static void irq_config_func_@NUM@(struct device *port);
 #endif
 
 static const struct uart_ns16550_device_config uart_ns16550_dev_cfg_@NUM@ = {
-	.sys_clk_freq = DT_UART_NS16550_PORT_@NUM@_CLK_FREQ,
+	.devconf.port = DT_UART_NS16550_PORT_@NUM@_BASE_ADDR,
+	.devconf.sys_clk_freq = DT_UART_NS16550_PORT_@NUM@_CLK_FREQ,
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	.irq_config_func = irq_config_func_@NUM@,
+	.devconf.irq_config_func = irq_config_func_@NUM@,
 #endif
 
 #ifdef DT_UART_NS16550_PORT_@NUM@_PCP
@@ -30,8 +31,7 @@ static const struct uart_ns16550_device_config uart_ns16550_dev_cfg_@NUM@ = {
 };
 
 static struct uart_ns16550_dev_data_t uart_ns16550_dev_data_@NUM@ = {
-	.port = DT_UART_NS16550_PORT_@NUM@_BASE_ADDR,
-	.baud_rate = DT_UART_NS16550_PORT_@NUM@_BAUD_RATE,
+	.uart_config.baudrate = DT_UART_NS16550_PORT_@NUM@_BAUD_RATE,
 	.options = CONFIG_UART_NS16550_PORT_@NUM@_OPTIONS,
 
 #ifdef DT_UART_NS16550_PORT_@NUM@_DLF


### PR DESCRIPTION
The UART configure API was added to uart.h and this PR implements the initial
framework for the configure API for the ns16550 uart. This includes the configure()
and config_get() functions and uart device configuration structures of the uart
configure API for the ns16550. 

The NS16550 UART driver is currently hard-coded as 8-n-1 with no flow control.
The baud rate is set by what is in DTS. This PR moves away from hard-coded and
strictly DTS to configurable using the UART configure API. 

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>