### PR TITLE
drivers/usb/device: stm32: Update due to API change on F0/F3/L0

### DIFF
--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -30,7 +30,7 @@ config USB_DC_STM32
 	bool "USB device controller driver for STM32 devices"
 	depends on SOC_FAMILY_STM32
 	select USB_DEVICE_DRIVER
-	select USE_STM32_LL_USB if !SOC_SERIES_STM32F0X && !SOC_SERIES_STM32F3X && !SOC_SERIES_STM32L0X
+	select USE_STM32_LL_USB
 	select USE_STM32_HAL_PCD
 	select USE_STM32_HAL_PCD_EX
 	help

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -60,20 +60,6 @@ LOG_MODULE_REGISTER(usb_dc_stm32);
 #endif
 
 /*
- * USB LL API provides the EP_TYPE_* defines. STM32Cube does not
- * provide USB LL API for STM32F0, STM32F3 and STM32L0 families.
- * Map EP_TYPE_* defines to PCD_EP_TYPE_* defines
- */
-#if defined(CONFIG_SOC_SERIES_STM32F3X) || \
-	defined(CONFIG_SOC_SERIES_STM32F0X) || \
-	defined(CONFIG_SOC_SERIES_STM32L0X)
-#define EP_TYPE_CTRL PCD_EP_TYPE_CTRL
-#define EP_TYPE_ISOC PCD_EP_TYPE_ISOC
-#define EP_TYPE_BULK PCD_EP_TYPE_BULK
-#define EP_TYPE_INTR PCD_EP_TYPE_INTR
-#endif
-
-/*
  * USB and USB_OTG_FS are defined in STM32Cube HAL and allows to distinguish
  * between two kind of USB DC. STM32 F0, F3, L0 and G4 series support USB device
  * controller. STM32 F4 and F7 series support USB_OTG_FS device controller.


### PR DESCRIPTION
Following update of STM32Cube packages for series F0/L0/F3,
a new file ll_usb.h is now available for these series.
As a consequence, specific hanlding is no more requested for this
series is stm32 usb_device driver.

Fixes #21962

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>