### PR TITLE
boards: arm: nrf5340_dk: include soc.h in nrf5340_cpunet_reset.c

### DIFF
--- a/boards/arm/nrf5340_dk_nrf5340/nrf5340_cpunet_reset.c
+++ b/boards/arm/nrf5340_dk_nrf5340/nrf5340_cpunet_reset.c
@@ -8,6 +8,8 @@
 #include <init.h>
 #include <logging/log.h>
 
+#include <soc.h>
+
 LOG_MODULE_REGISTER(nrf5340_dk_nrf5340_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
 
 #if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)


### PR DESCRIPTION
We need to include soc.h in nrf5340_cpunet_reset.c, to include
the nRF5340 device headers. Fixes a compilation error when we
build with CONFIG_ARM_MPU=n.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>