### PR TITLE
net: mqtt: Simplify disconnect procedure

### DIFF
--- a/samples/net/mqtt_publisher/src/main.c
+++ b/samples/net/mqtt_publisher/src/main.c
@@ -445,10 +445,6 @@ static void publisher(void)
 	rc = mqtt_disconnect(&client_ctx);
 	PRINT_RESULT("mqtt_disconnect", rc);
 
-	wait(APP_SLEEP_MSECS);
-	rc = mqtt_input(&client_ctx);
-	PRINT_RESULT("mqtt_input", rc);
-
 	LOG_INF("Bye!");
 }
 

--- a/subsys/net/lib/mqtt/mqtt.c
+++ b/subsys/net/lib/mqtt/mqtt.c
@@ -45,8 +45,7 @@ static void disconnect_event_notify(struct mqtt_client *client, int result)
 	struct mqtt_evt evt;
 
 	/* Determine appropriate event to generate. */
-	if (MQTT_HAS_STATE(client, MQTT_STATE_CONNECTED) ||
-	    MQTT_HAS_STATE(client, MQTT_STATE_DISCONNECTING)) {
+	if (MQTT_HAS_STATE(client, MQTT_STATE_CONNECTED)) {
 		evt.type = MQTT_EVT_DISCONNECT;
 		evt.result = result;
 	} else {
@@ -451,7 +450,7 @@ int mqtt_disconnect(struct mqtt_client *client)
 		goto error;
 	}
 
-	MQTT_SET_STATE_EXCLUSIVE(client, MQTT_STATE_DISCONNECTING);
+	client_disconnect(client, 0);
 
 error:
 	mqtt_mutex_unlock(client);
@@ -586,16 +585,11 @@ int mqtt_live(struct mqtt_client *client)
 
 	mqtt_mutex_lock(client);
 
-	if (MQTT_HAS_STATE(client, MQTT_STATE_DISCONNECTING)) {
-		client_disconnect(client, 0);
-	} else {
-		elapsed_time = mqtt_elapsed_time_in_ms_get(
-					client->internal.last_activity);
-
-		if ((client->keepalive > 0) &&
-		    (elapsed_time >= (client->keepalive * 1000))) {
-			(void)mqtt_ping(client);
-		}
+	elapsed_time = mqtt_elapsed_time_in_ms_get(
+				client->internal.last_activity);
+	if ((client->keepalive > 0) &&
+	    (elapsed_time >= (client->keepalive * 1000))) {
+		(void)mqtt_ping(client);
 	}
 
 	mqtt_mutex_unlock(client);
@@ -613,9 +607,7 @@ int mqtt_input(struct mqtt_client *client)
 
 	MQTT_TRC("state:0x%08x", client->internal.state);
 
-	if (MQTT_HAS_STATE(client, MQTT_STATE_DISCONNECTING)) {
-		client_disconnect(client, 0);
-	} else if (MQTT_HAS_STATE(client, MQTT_STATE_TCP_CONNECTED)) {
+	if (MQTT_HAS_STATE(client, MQTT_STATE_TCP_CONNECTED)) {
 		err_code = client_read(client);
 	} else {
 		err_code = -EACCES;

--- a/subsys/net/lib/mqtt/mqtt_internal.h
+++ b/subsys/net/lib/mqtt/mqtt_internal.h
@@ -140,10 +140,6 @@ enum mqtt_state {
 
 	/** MQTT Connection successful. */
 	MQTT_STATE_CONNECTED            = 0x00000004,
-
-	/** TCP Disconnect has been requested, awaiting result of the request.
-	 */
-	MQTT_STATE_DISCONNECTING        = 0x00000008
 };
 
 /**@brief Notify application about MQTT event.


### PR DESCRIPTION
After sending the MQTT disconnect message, no response is expected,
therefore it makes little sense to delay the socket closure.

So far it was expected to call `mqtt_input` function after calling
`mqtt_disconnect` in order to close the socket, which is
counter-intuitive. Simplify this, by closing the socket right away
in the `mqtt_disconnect` function.