### PR TITLE
unify Arduino devicetree specification for SPI-capable shields

### DIFF
--- a/boards/arm/nrf52833_pca10100/nrf52833_pca10100.dts
+++ b/boards/arm/nrf52833_pca10100/nrf52833_pca10100.dts
@@ -189,6 +189,7 @@ arduino_spi: &spi3 {
 	sck-pin = <23>;
 	miso-pin = <22>;
 	mosi-pin = <21>;
+	cs-gpios = <&arduino_header 16 0>; /* D10 */
 };
 
 &flash0 {

--- a/boards/arm/nrf52833_pca10100/nrf52833_pca10100.yaml
+++ b/boards/arm/nrf52833_pca10100/nrf52833_pca10100.yaml
@@ -8,6 +8,9 @@ toolchain:
   - xtools
 supported:
   - adc
+  - arduino_gpio
+  - arduino_i2c
+  - arduino_spi
   - usb_device
   - ble
   - gpio

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -218,6 +218,7 @@ arduino_spi: &spi3 {
 	sck-pin = <47>;
 	miso-pin = <46>;
 	mosi-pin = <45>;
+	cs-gpios = <&arduino_header 16 0>; /* D10 */
 };
 
 &flash0 {

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.yaml
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.yaml
@@ -10,6 +10,7 @@ supported:
   - adc
   - arduino_gpio
   - arduino_i2c
+  - arduino_spi
   - usb_device
   - usb_cdc
   - ble

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -180,6 +180,7 @@ arduino_spi: &spi2 {
 	sck-pin = <25>;
 	mosi-pin = <23>;
 	miso-pin = <24>;
+	cs-gpios = <&arduino_header 16 0>; /* D10 */
 };
 
 &flash0 {

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.yaml
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.yaml
@@ -12,6 +12,7 @@ supported:
   - adc
   - arduino_gpio
   - arduino_i2c
+  - arduino_spi
   - counter
   - nvs
   - i2c

--- a/boards/arm/reel_board/dts/reel_board.dtsi
+++ b/boards/arm/reel_board/dts/reel_board.dtsi
@@ -159,7 +159,7 @@ arduino_spi: &spi3 {
 	sck-pin = <47>;
 	miso-pin = <46>;
 	mosi-pin = <45>;
-	cs-gpios = <&arduino_header 16 0>;
+	cs-gpios = <&arduino_header 16 0>; /* D10 */
 };
 
 &flash0 {


### PR DESCRIPTION
Following up on a discussion in #21610 this PR unifies the minimal support for using SPI-based Arduino shields in each board devicetree that provides an `arduino_spi` label.  The changes are:

* Provide a `cs-gpios` property identifying the [standard](https://www.circuito.io/blog/arduino-uno-pinout/) Arduino Uno SPI chip select on D10 in all boards that provide `arduino_spi`;
* Replace GPIO specifiers in one shield that inappropriately used a specific board's GPIO controller directly;
* Remove the redundant `cs-gpios` properties from shields.
