### PR TITLE
sanitycheck: support runtime artifact cleanup

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1998,6 +1998,7 @@ class ProjectBuilder(FilterBuilder):
         self.extra_args = kwargs.get('extra_args', [])
         self.device_testing = kwargs.get('device_testing', False)
         self.cmake_only = kwargs.get('cmake_only', False)
+        self.cleanup = kwargs.get('cleanup', False)
         self.coverage = kwargs.get('coverage', False)
         self.inline_logs = kwargs.get('inline_logs', False)
 
@@ -2123,6 +2124,38 @@ class ProjectBuilder(FilterBuilder):
         elif op == "report":
             with report_lock:
                 self.report_out()
+
+            if self.cleanup and self.instance.status == "passed":
+                pipeline.put({
+                    "op": "cleanup",
+                    "test": self.instance
+                })
+
+        elif op == "cleanup":
+            self.cleanup_artifacts()
+
+    def cleanup_artifacts(self):
+        logger.debug("Cleaning up {}".format(self.instance.build_dir))
+        whitelist = [
+            'zephyr/.config',
+            'handler.log',
+            'build.log',
+            'device.log',
+            ]
+        whitelist = [os.path.join(self.instance.build_dir, file) for file in whitelist]
+
+        for dirpath, dirnames, filenames in os.walk(self.instance.build_dir, topdown=False):
+            for name in filenames:
+                path = os.path.join(dirpath, name)
+                if path not in whitelist:
+                    os.remove(path)
+            # Remove empty directories and symbolic links to directories
+            for dir in dirnames:
+                path = os.path.join(dirpath, dir)
+                if os.path.islink(path):
+                    os.remove(path)
+                elif not os.listdir(path):
+                    os.rmdir(path)
 
     def report_out(self):
         total_tests_width = len(str(self.suite.total_tests))
@@ -2279,6 +2312,7 @@ class TestSuite:
         self.coverage_platform = []
         self.build_only = False
         self.cmake_only = False
+        self.cleanup = False
         self.enable_slow = False
         self.device_testing = False
         self.fixture = []
@@ -2886,6 +2920,7 @@ class TestSuite:
                                         extra_args=self.extra_args,
                                         device_testing=self.device_testing,
                                         cmake_only=self.cmake_only,
+                                        cleanup=self.cleanup,
                                         valgrind=self.enable_valgrind,
                                         inline_logs=self.inline_logs
                                         )
@@ -3344,6 +3379,10 @@ Artificially long but functional example:
     parser.add_argument(
         "--cmake-only", action="store_true",
         help="Only run cmake, do not build or run.")
+
+    parser.add_argument(
+        "-M", "--runtime-artifact-cleanup", action="store_true",
+        help="Delete artifacts of passing tests.")
 
     parser.add_argument(
         "-j", "--jobs", type=int,
@@ -4031,6 +4070,7 @@ def main():
     # Set testsuite options from command line.
     suite.build_only = options.build_only
     suite.cmake_only = options.cmake_only
+    suite.cleanup = options.runtime_artifact_cleanup
     suite.test_only = options.test_only
     suite.enable_slow = options.enable_slow
     suite.device_testing = options.device_testing


### PR DESCRIPTION
Using --runtime-artifact-cleanup, the script will now remove all
artifacts of passing tests. This is useful for running sanitycheck on
systems with little disk space.

Fixes #21922