### PR TITLE
drivers/pinmux: stm32: Add i2c4 pinmux to stm32f7.h

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -49,6 +49,7 @@ config NET_SOCKETS_DNS_TIMEOUT
 config NET_SOCKETS_SOCKOPT_TLS
 	bool "Enable TCP TLS socket option support [EXPERIMENTAL]"
 	select TLS_CREDENTIALS
+	select MBEDTLS if NET_NATIVE
 	help
 	  Enable TLS socket option support which automatically establishes
 	  a TLS connection to the remote host.


### PR DESCRIPTION
Add all i2c4 gpio mapping to pinmux to enable i2c4 on stm32f7 based boards