### PR TITLE
dts: arm: st: h7: fix stm32h7 separate cores

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -27,11 +27,6 @@
 				arm,num-mpu-regions = <8>;
 			};
 		};
-		cpu@1 {
-			device_type = "cpu";
-			compatible = "arm,cortex-m4f";
-			reg = <1>;
-		};
 	};
 
 	soc {

--- a/dts/arm/st/h7/stm32h747.dtsi
+++ b/dts/arm/st/h7/stm32h747.dtsi
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <st/h7/stm32h7.dtsi>
+#include <st/h7/stm32h7_dualcore.dtsi>

--- a/dts/arm/st/h7/stm32h7_dualcore.dtsi
+++ b/dts/arm/st/h7/stm32h7_dualcore.dtsi
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2020 Moonkwun Jung
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/h7/stm32h7.dtsi>
+
+/ {
+	cpus {
+		cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m4f";
+			reg = <1>;
+		};
+	};
+};


### PR DESCRIPTION
Currently, only the stm32h747 soc is supported in the h7 foler.
The h7 series comes with both single core and dual core products.
This change moves C-M4 core out of stm32h7.dtsi so that it can be
included by single core STM32H7 soc description.

Signed-off-by: Moonkwun Jung <mkainyh@gmail.com>