### PR TITLE
net: if: Add option to set ppp as default network if

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -642,6 +642,9 @@ config NET_DEFAULT_IF_CANBUS_RAW
 	bool "Socket CAN interface"
 	depends on NET_L2_CANBUS_RAW
 
+config NET_DEFAULT_IF_PPP
+	bool "PPP interface"
+	depends on NET_L2_PPP
 
 endchoice
 

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -436,6 +436,9 @@ struct net_if *net_if_get_default(void)
 #if defined(CONFIG_NET_DEFAULT_IF_CANBUS)
 	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(CANBUS));
 #endif
+#if defined(CONFIG_NET_DEFAULT_IF_PPP)
+	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(PPP));
+#endif
 
 	return iface ? iface : __net_if_start;
 }


### PR DESCRIPTION
Now the ppp interface can be selected as the default network interface.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>