### PR TITLE
Bluetooth: HCI: Fix allow Zephyr VS HCI commands in host-only build

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -12,8 +12,8 @@ config BT_HAS_HCI_VS
 
 config BT_HCI_VS
 	bool "Zephyr HCI Vendor-Specific Commands"
-	depends on BT_HAS_HCI_VS
-	default y
+	depends on BT_HAS_HCI_VS || !BT_CTLR
+	default y if BT_HAS_HCI_VS
 	help
 	  Enable support for the Zephyr HCI Vendor-Specific Commands in the
 	  Host and/or Controller. This enables Set Version Information,


### PR DESCRIPTION
Fix unable to select the Zephyr Vendor-Specific HCI commands support in
host-only build. Set VS HCI support as default on if it is known that
the controller supports it. Otherwise set it to off, this means that
VS HCI support will be default off in host-only builds.
Change default value of VS HCI detection to always on in host-only build
since we cannot be sure of VS HCI support in this case. This option is
only available in host-only builds when VS HCI has been enabled.

Fixes: #21996

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>