### PR TITLE
net: ipv6: Add routing according to interface prefix

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -327,6 +327,20 @@ static enum net_verdict ipv6_route_packet(struct net_pkt *pkt,
 			return NET_OK;
 		}
 	} else {
+		struct net_if *iface = NULL;
+		int ret;
+
+		if (net_if_ipv6_addr_onlink(&iface, &hdr->dst)) {
+			ret = net_route_packet_if(pkt, iface);
+			if (ret < 0) {
+				NET_DBG("Cannot re-route pkt %p "
+					"at iface %p (%d)",
+					pkt, net_pkt_iface(pkt), ret);
+			} else {
+				return NET_OK;
+			}
+		}
+
 		NET_DBG("No route to %s pkt %p dropped",
 			log_strdup(net_sprint_ipv6_addr(&hdr->dst)), pkt);
 	}

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -417,6 +417,7 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 	net_pkt_set_ipv6_ext_len(pkt, 0);
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv6_hdr));
 	net_pkt_set_ipv6_hop_limit(pkt, NET_IPV6_HDR(pkt)->hop_limit);
+	net_pkt_set_family(pkt, PF_INET6);
 
 	if (!net_ipv6_is_my_addr(&hdr->dst) &&
 	    !net_ipv6_is_my_maddr(&hdr->dst) &&
@@ -520,7 +521,6 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 	}
 
 	net_pkt_set_ipv6_ext_len(pkt, ext_len);
-	net_pkt_set_family(pkt, PF_INET6);
 
 	switch (nexthdr) {
 	case IPPROTO_ICMPV6:

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -825,6 +825,24 @@ int net_route_packet(struct net_pkt *pkt, struct in6_addr *nexthop)
 	return net_send_data(pkt);
 }
 
+int net_route_packet_if(struct net_pkt *pkt, struct net_if *iface)
+{
+	/* The destination is reachable via iface. But since no valid nexthop
+	 * is known, net_pkt_lladdr_dst(pkt) cannot be set here.
+	 */
+
+	net_pkt_set_orig_iface(pkt, net_pkt_iface(pkt));
+	net_pkt_set_iface(pkt, iface);
+
+	net_pkt_set_forwarding(pkt, true);
+
+	net_pkt_lladdr_src(pkt)->addr = net_pkt_lladdr_if(pkt)->addr;
+	net_pkt_lladdr_src(pkt)->type = net_pkt_lladdr_if(pkt)->type;
+	net_pkt_lladdr_src(pkt)->len = net_pkt_lladdr_if(pkt)->len;
+
+	return net_send_data(pkt);
+}
+
 void net_route_init(void)
 {
 	NET_DBG("Allocated %d routing entries (%zu bytes)",

--- a/subsys/net/ip/route.h
+++ b/subsys/net/ip/route.h
@@ -262,6 +262,16 @@ bool net_route_get_info(struct net_if *iface,
  */
 int net_route_packet(struct net_pkt *pkt, struct in6_addr *nexthop);
 
+/**
+ * @brief Send the network packet to network via the given interface.
+ *
+ * @param pkt Network packet to send.
+ * @param iface The network interface the packet should be sent on.
+ *
+ * @return 0 if there was no error, <0 if the packet could not be sent.
+ */
+int net_route_packet_if(struct net_pkt *pkt, struct net_if *iface);
+
 #if defined(CONFIG_NET_ROUTE) && defined(CONFIG_NET_NATIVE)
 void net_route_init(void);
 #else


### PR DESCRIPTION
If no other route is found, the network interface prefixes are
evaluated. If a matching interface is found, the packet is sent out on
this interface.

This is a RFC to collect comments and thoughts before proceeding. Maybe someone can even test on a different hardware/setup.