### PR TITLE
Bluetooth: controller: split: Fix central assert on multiple reconnections

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -134,7 +134,7 @@ void lll_conn_isr_abort(void *param);
 void lll_conn_rx_pkt_set(struct lll_conn *lll);
 void lll_conn_tx_pkt_set(struct lll_conn *lll, struct pdu_data *pdu_data_tx);
 void lll_conn_pdu_tx_prep(struct lll_conn *lll, struct pdu_data **pdu_data_tx);
-void lll_conn_flush(struct lll_conn *lll);
+void lll_conn_flush(u16_t handle, struct lll_conn *lll);
 
 extern void ull_conn_lll_ack_enqueue(u16_t handle, struct node_tx *tx);
 extern u16_t ull_conn_lll_max_tx_octets_get(struct lll_conn *lll);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -801,7 +801,7 @@ static struct pdu_data *empty_tx_enqueue(struct lll_conn *lll)
 	return p;
 }
 
-void lll_conn_flush(struct lll_conn *lll)
+void lll_conn_flush(u16_t handle, struct lll_conn *lll)
 {
 	/* Nothing to be flushed */
 }

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_conn.c
@@ -798,7 +798,7 @@ static struct pdu_data *empty_tx_enqueue(struct lll_conn *lll)
 	return p;
 }
 
-void lll_conn_flush(struct lll_conn *lll)
+void lll_conn_flush(u16_t handle, struct lll_conn *lll)
 {
 	/* Nothing to be flushed */
 }

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -828,29 +828,16 @@ void ll_rx_mem_release(void **node_rx)
 		case NODE_RX_TYPE_TERMINATE:
 		{
 			struct ll_conn *conn;
-			struct lll_conn *lll;
 			memq_link_t *link;
 
-			/* Get the connection context */
 			conn = ll_conn_get(rx_free->handle);
-			lll = &conn->lll;
 
-			/* Invalidate the connection context */
-			lll->handle = 0xFFFF;
-
-			/* Demux and flush Tx PDUs that remain enqueued in
-			 * thread context
-			 */
-			ull_conn_tx_demux(UINT8_MAX);
-
-			/* De-initialize tx memq and release the used link */
-			LL_ASSERT(!lll->link_tx_free);
-			link = memq_deinit(&lll->memq_tx.head,
-					   &lll->memq_tx.tail);
+			LL_ASSERT(!conn->lll.link_tx_free);
+			link = memq_deinit(&conn->lll.memq_tx.head,
+					   &conn->lll.memq_tx.tail);
 			LL_ASSERT(link);
-			lll->link_tx_free = link;
+			conn->lll.link_tx_free = link;
 
-			/* Release the connection context to free pool */
 			ll_conn_release(conn);
 		}
 		break;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1714,6 +1714,9 @@ static void conn_cleanup(struct ll_conn *conn, u8_t reason)
 	LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
 		  (ticker_status == TICKER_STATUS_BUSY));
 
+	/* Invalidate the connection context */
+	lll->handle = 0xFFFF;
+
 	/* Demux and flush Tx PDUs that remain enqueued in thread context */
 	ull_conn_tx_demux(UINT8_MAX);
 }
@@ -1742,9 +1745,6 @@ static void tx_lll_flush(void *param)
 	memq_link_t *link;
 
 	lll_conn_flush(lll);
-
-	/* Invalidate the connection context */
-	lll->handle = 0xFFFF;
 
 	link = memq_dequeue(lll->memq_tx.tail, &lll->memq_tx.head,
 			    (void **)&tx);

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1739,12 +1739,13 @@ static void tx_ull_flush(struct ll_conn *conn)
 static void tx_lll_flush(void *param)
 {
 	struct ll_conn *conn = (void *)HDR_LLL2EVT(param);
+	u16_t handle = ll_conn_handle_get(conn);
 	struct lll_conn *lll = param;
 	struct node_rx_pdu *rx;
 	struct node_tx *tx;
 	memq_link_t *link;
 
-	lll_conn_flush(lll);
+	lll_conn_flush(handle, lll);
 
 	link = memq_dequeue(lll->memq_tx.tail, &lll->memq_tx.head,
 			    (void **)&tx);

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1713,6 +1713,9 @@ static void conn_cleanup(struct ll_conn *conn, u8_t reason)
 				    ticker_op_stop_cb, (void *)lll);
 	LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
 		  (ticker_status == TICKER_STATUS_BUSY));
+
+	/* Demux and flush Tx PDUs that remain enqueued in thread context */
+	ull_conn_tx_demux(UINT8_MAX);
 }
 
 static void tx_ull_flush(struct ll_conn *conn)
@@ -1739,6 +1742,9 @@ static void tx_lll_flush(void *param)
 	memq_link_t *link;
 
 	lll_conn_flush(lll);
+
+	/* Invalidate the connection context */
+	lll->handle = 0xFFFF;
 
 	link = memq_dequeue(lll->memq_tx.tail, &lll->memq_tx.head,
 			    (void **)&tx);


### PR DESCRIPTION
This reverts commit 7417e6e.
This reverts commit d3e3f8d.

Updated the lll_conn_flush interface to pass the connection
handle while the LLL connection context stored handle has
been invalidated.

Fixes #22003.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>