### PR TITLE
cmake: allow appending dependencies to report targets

### DIFF
--- a/cmake/reports/CMakeLists.txt
+++ b/cmake/reports/CMakeLists.txt
@@ -14,5 +14,6 @@ foreach(report ram_report rom_report)
     --nm      ${CMAKE_NM}
     -o ${PROJECT_BINARY_DIR}
     DEPENDS ${logical_target_for_zephyr_elf}
+            $<TARGET_PROPERTY:zephyr_property_target,${report}_DEPENDENCIES>
     )
 endforeach()


### PR DESCRIPTION
To facilitate extending the generated reports without having to
patch this file, leverage generator-expression so that
dependencies can be added to the 'zephyr_property_target' target.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>