### PR TITLE
tests: drivers: counter: Add clock stabilization nRF

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -801,6 +801,12 @@ void test_cancelled_alarm_does_not_expire(void)
 
 void test_main(void)
 {
+	/* Give required clocks some time to stabilize. In particular, nRF SoCs
+	 * need such delay for the Xtal LF clock source to start and for this
+	 * test to use the correct timing.
+	 */
+	k_busy_wait(USEC_PER_MSEC * 300);
+
 	ztest_test_suite(test_counter,
 		ztest_unit_test(test_set_top_value_with_alarm),
 		ztest_unit_test(test_single_shot_alarm_notop),


### PR DESCRIPTION
Xtal LF clock source starts hundreds of milliseconds. When it is
not start, test may fail due to wrong timing. Added pending
on LF clock being start in test setup.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>
Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>