### PR TITLE
net: sockets: tls: Add missing symbols for a few options

### DIFF
--- a/doc/reference/networking/mqtt.rst
+++ b/doc/reference/networking/mqtt.rst
@@ -144,7 +144,7 @@ additional configuration information:
 
    struct mqtt_sec_config *tls_config = &client_ctx.transport.tls.config;
 
-   tls_config->peer_verify = 2;
+   tls_config->peer_verify = TLS_PEER_VERIFY_REQUIRED;
    tls_config->cipher_list = NULL;
    tls_config->sec_tag_list = m_sec_tags;
    tls_config->sec_tag_count = ARRAY_SIZE(m_sec_tags);

--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -122,6 +122,15 @@ struct zsock_pollfd {
 
 /** @} */
 
+/* Valid values for TLS_PEER_VERIFY option */
+#define TLS_PEER_VERIFY_NONE 0 /**< Peer verification disabled. */
+#define TLS_PEER_VERIFY_OPTIONAL 1 /**< Peer verification optional. */
+#define TLS_PEER_VERIFY_REQUIRED 2 /**< Peer verification required. */
+
+/* Valid values for TLS_DTLS_ROLE option */
+#define TLS_DTLS_ROLE_CLIENT 0 /**< Client role in a DTLS session. */
+#define TLS_DTLS_ROLE_SERVER 1 /**< Server role in a DTLS session. */
+
 struct zsock_addrinfo {
 	struct zsock_addrinfo *ai_next;
 	int ai_flags;

--- a/lib/updatehub/updatehub.c
+++ b/lib/updatehub/updatehub.c
@@ -141,7 +141,7 @@ static bool start_coap_client(void)
 	}
 
 #if defined(CONFIG_UPDATEHUB_DTLS)
-	int verify = 0;
+	int verify = TLS_PEER_VERIFY_NONE;
 	sec_tag_t sec_list[] = { CA_CERTIFICATE_TAG };
 	int protocol = IPPROTO_DTLS_1_2;
 	char port[] = "5684";

--- a/samples/net/cloud/google_iot_mqtt/src/protocol.c
+++ b/samples/net/cloud/google_iot_mqtt/src/protocol.c
@@ -304,7 +304,7 @@ void mqtt_startup(char *hostname, int port)
 		struct mqtt_sec_config *tls_config =
 				&client->transport.tls.config;
 
-		tls_config->peer_verify = 2;
+		tls_config->peer_verify = TLS_PEER_VERIFY_REQUIRED;
 		tls_config->cipher_list = NULL;
 		tls_config->sec_tag_list = m_sec_tags;
 		tls_config->sec_tag_count = ARRAY_SIZE(m_sec_tags);

--- a/samples/net/cloud/mqtt_azure/src/main.c
+++ b/samples/net/cloud/mqtt_azure/src/main.c
@@ -176,7 +176,7 @@ static void client_init(struct mqtt_client *client)
 
 	tls_config = &client->transport.tls.config;
 
-	tls_config->peer_verify = 2;
+	tls_config->peer_verify = TLS_PEER_VERIFY_REQUIRED;
 	tls_config->cipher_list = NULL;
 	tls_config->sec_tag_list = m_sec_tags;
 	tls_config->sec_tag_count = ARRAY_SIZE(m_sec_tags);

--- a/samples/net/mqtt_publisher/src/main.c
+++ b/samples/net/mqtt_publisher/src/main.c
@@ -304,7 +304,7 @@ static void client_init(struct mqtt_client *client)
 
 	struct mqtt_sec_config *tls_config = &client->transport.tls.config;
 
-	tls_config->peer_verify = 2;
+	tls_config->peer_verify = TLS_PEER_VERIFY_REQUIRED;
 	tls_config->cipher_list = NULL;
 	tls_config->sec_tag_list = m_sec_tags;
 	tls_config->sec_tag_count = ARRAY_SIZE(m_sec_tags);

--- a/samples/net/sockets/echo_server/src/udp.c
+++ b/samples/net/sockets/echo_server/src/udp.c
@@ -55,7 +55,7 @@ static int start_udp_proto(struct data *data, struct sockaddr *bind_addr,
 		PSK_TAG,
 #endif
 	};
-	int role = 1;
+	int role = TLS_DTLS_ROLE_SERVER;
 
 	ret = setsockopt(data->udp.sock, SOL_TLS, TLS_SEC_TAG_LIST,
 			 sec_tag_list, sizeof(sec_tag_list));


### PR DESCRIPTION
`TLS_PEER_VERIFY` and `TLS_DTLS_ROLE` options accept specific values,
yet no symbols were defined for them. In result, magic numbers were used
in several places, making the code less readable.

Fix this issue, by adding the missing symbols to the `socket.h` header,
and using them in places where related socket options are set.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>