### PR TITLE
doc: Link to Documentation Generation from Documentation Guidelines

### DIFF
--- a/doc/guides/documentation/index.rst
+++ b/doc/guides/documentation/index.rst
@@ -3,6 +3,10 @@
 Documentation Guidelines
 ########################
 
+.. note::
+
+   For instructions on building the documentation, see :ref:`zephyr_doc`.
+
 Zephyr Project content is written using the `reStructuredText`_ markup
 language (.rst file extension) with Sphinx extensions, and processed
 using Sphinx to create a formatted standalone website.  Developers can
@@ -602,3 +606,5 @@ Put your right hand in
 See the :zephyr_raw:`doc/getting_started/index.rst` source file and compare
 with the :ref:`getting_started` to see a full example.  As implemented,
 only one set of numbered steps is intended per document.
+
+For instructions on building the documentation, see :ref:`zephyr_doc`.

--- a/doc/guides/index.rst
+++ b/doc/guides/index.rst
@@ -12,13 +12,13 @@ User and Developer Guides
    build/index
    c_library
    ../README.rst
+   documentation/index
    coccinelle.rst
    code-relocation.rst
    crypto/index
    debugging/index
    device_mgmt/index
    device_mgmt/dfu
-   documentation/index
    dts/index
    env_vars.rst
    coverage.rst


### PR DESCRIPTION
Two changes to make the Documentation Generation page easier to spot:

```
doc: Move Documentation Guidelines right after Documentation Generation

List Documentation Guidelines right after Documentation Generation in
the index for User and Developer Guides. Makes it easier to spot.
```

```
doc: Link to Documentation Generation from Documentation Guidelines

Gerson Fernando Budke missed the Documentation Generation page. Nice to
link to it from the Documentation Guidelines page, in case people are
looking for documentation information and find it first.

Maybe the two pages could be put under a common Documentation section
too, though it's nice to have Documentation Generation clearly visible
in the top-level User Guides index.

Co-authored-by: Gerson Fernando Budke <nandojve@gmail.com>
```