### PR TITLE
drivers: counter: fix nRF prescaler overflow

### DIFF
--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -516,7 +516,7 @@ static u32_t get_pending_int(struct device *dev)
 	return 0;
 }
 
-static int init_rtc(struct device *dev, u8_t prescaler)
+static int init_rtc(struct device *dev, u32_t prescaler)
 {
 	struct device *clock;
 	const struct counter_nrfx_config *nrfx_config = get_nrfx_config(dev);


### PR DESCRIPTION
use `u16_t prescaler` instead of `u8_t prescaler` in `init_rtc` to be able to use the full 12 bit prescaler values.
fixes #22014.