### PR TITLE
cmake: Add option for exporting build metadata to Make

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1497,6 +1497,11 @@ add_subdirectory(cmake/flash)
 add_subdirectory(cmake/usage)
 add_subdirectory(cmake/reports)
 
+add_subdirectory_ifdef(
+  CONFIG_MAKEFILE_EXPORTS
+  cmake/makefile_exports
+  )
+
 if(NOT CONFIG_TEST)
 if(CONFIG_ASSERT AND (NOT CONFIG_FORCE_NO_ASSERT))
   message(WARNING "__ASSERT() statements are globally ENABLED")

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -332,6 +332,12 @@ config APPLICATION_DEFINED_SYSCALL
 	  Scan additional folders inside application source folder
 	  for application defined syscalls.
 
+config MAKEFILE_EXPORTS
+	bool "Generate build metadata files named Makefile.exports"
+	help
+	  Generates a file with build information that can be read by
+	  third party Makefile-based build systems.
+
 endmenu
 endmenu
 

--- a/cmake/makefile_exports/CMakeLists.txt
+++ b/cmake/makefile_exports/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright (c) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+set(exports
+  "
+CC = ${CMAKE_C_COMPILER}
+CXX = ${CMAKE_CXX_COMPILER}
+OBJCOPY = ${CMAKE_OBJCOPY}
+OBJDUMP = ${CMAKE_OBJDUMP}
+AS = ${CMAKE_AS}
+AR = ${CMAKE_AR}
+NM = ${CMAKE_NM}
+GDB = ${CMAKE_GDB}
+Z_CFLAGS = -I$<JOIN:$<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>, -I> -isystem $<JOIN:$<TARGET_PROPERTY:zephyr_interface,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>, -isystem > -D$<JOIN:$<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_DEFINITIONS>, -D> $<JOIN:$<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS>, >
+"
+  )
+
+# file(GENERATE writes a file at Generation time. Also, it writes one
+# file per detected configuration, in this case, each COMPILE_LANGUAGE
+# is a new configuration.
+#
+# We use 'file(GENERATE' instead of configure_file because we want to
+# generate the file after Configure-time to have all the
+# metadata. Also, we don't use 'add_custom_command' because it cannot
+# read the generator expressions that we use.
+file(GENERATE
+  OUTPUT  ${CMAKE_BINARY_DIR}/Makefile.exports.$<COMPILE_LANGUAGE>
+  CONTENT "${exports}"
+)


### PR DESCRIPTION
Add an opt-in feature that will generate a Makefile with build
variables like CC, and KBUILD_CFLAGS for consumption by third-party
Make-based build systems.

This emulates the 'outputexports' target that KBuild supported and is
supported for the same reasons that KBuild supported it. Easier
integration with third-party build systems.

This fixes #4917