### PR TITLE
[TOPIC-GPIO] usb_dc_stm32: Convert usb disconnect gpio to new gpio api

### DIFF
--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -91,7 +91,7 @@ uext_serial: &usart1 {};
 
 &usb {
 	status = "okay";
-	disconnect-gpios = <&gpioc 12 0>;
+	disconnect-gpios = <&gpioc 12 GPIO_ACTIVE_LOW>;
 };
 
 &timers1 {

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -990,17 +990,10 @@ void HAL_PCDEx_SetConnectionState(PCD_HandleTypeDef *hpcd, uint8_t state)
 
 	usb_disconnect = device_get_binding(
 				DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_CONTROLLER);
-	gpio_pin_configure(usb_disconnect,
-			   DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_PIN, GPIO_DIR_OUT);
 
-	if (state) {
-		gpio_pin_write(usb_disconnect,
-			       DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_PIN,
-			       DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_FLAGS);
-	} else {
-		gpio_pin_write(usb_disconnect,
-			       DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_PIN,
-			       !DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_FLAGS);
-	}
+	gpio_pin_configure(usb_disconnect,
+			   DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_PIN,
+			   DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_FLAGS |
+			   (state ? GPIO_OUTPUT_ACTIVE : GPIO_OUTPUT_INACTIVE));
 }
 #endif /* USB && CONFIG_USB_DC_STM32_DISCONN_ENABLE */


### PR DESCRIPTION
Convert usb disconnect gpio to new gpio api.
Updates device tree for the olimexino_stm32.

Tested on olimexino_stm32 using cdc_acm.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>