### PR TITLE
kernel: kconfig: Make SCHED_IPI_SUPPORTED invisible

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -722,7 +722,7 @@ config MP_NUM_CPUS
 	  multicpu API and SMP features.
 
 config SCHED_IPI_SUPPORTED
-	bool "Architecture supports broadcast interprocessor interrupts"
+	bool
 	help
 	  True if the architecture supports a call to
 	  arch_sched_ipi() to broadcast an interrupt that will call


### PR DESCRIPTION
Toggling this symbol probably doesn't make sense, because the
architecture is already known when Kconfig runs.

SCHED_IPI_SUPPORTED is enabled through being selected by the ARC_CONNECT
(maybe that one shouldn't be configurable either) and X86_64 symbols.

Note that it's not possible to disable the symbol when it's being
selected, so trying to turn it off on e.g. x86 64 won't work either.