### PR TITLE
dts: arm: st: l073: Fix gpioe reg field

### DIFF
--- a/dts/arm/st/l0/stm32l073.dtsi
+++ b/dts/arm/st/l0/stm32l073.dtsi
@@ -13,7 +13,7 @@
 				compatible = "st,stm32-gpio";
 				gpio-controller;
 				#gpio-cells = <2>;
-				reg = <0x48001000 0x400>;
+				reg = <0x50001000 0x400>;
 				clocks = <&rcc STM32_CLOCK_BUS_IOP 0x00000010>;
 				label = "GPIOE";
 			};


### PR DESCRIPTION
reg field from gpioe node was incorrect.

Signed-off-by: Ioannis Konstantelias <ikonstadel@gmail.com>