### PR TITLE
[doc]: Fixing modules reference in 'Application Development' documentation

### DIFF
--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -126,7 +126,7 @@ subdirectories which are not described here.
 :file:`ext`
     Externally created code that has been integrated into Zephyr
     from other sources and that must live inside the zephyr repository unlike
-    `external projects <modules>`_
+    :ref:`external projects <modules>`.
 
 :file:`include`
     Include files for all public APIs, except those defined under :file:`lib`.


### PR DESCRIPTION
The reference to the modules guide was broken in the 'Application Development/Source Tree Structure' . This should fix it.

Signed-off-by: Jens Peter Schroer <jens@blixt.tech>