### PR TITLE
dts: stm32: Define stm32l073 as stm32l072 superset

### DIFF
--- a/dts/arm/st/l0/stm32l073.dtsi
+++ b/dts/arm/st/l0/stm32l073.dtsi
@@ -1,82 +1,8 @@
 /*
  * Copyright (c) 2018 Ilya Tagunov <tagunil@gmail.com>
+ * Copyright (c) 2020 Linaro Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <st/l0/stm32l0.dtsi>
-
-/ {
-	soc {
-		pinctrl: pin-controller@50000000 {
-			gpioe: gpio@50001000 {
-				compatible = "st,stm32-gpio";
-				gpio-controller;
-				#gpio-cells = <2>;
-				reg = <0x48001000 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_IOP 0x00000010>;
-				label = "GPIOE";
-			};
-		};
-
-		i2c2: i2c@40005800 {
-			compatible = "st,stm32-i2c-v2";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00400000>;
-			interrupts = <24 0>;
-			interrupt-names = "combined";
-			status = "disabled";
-			label= "I2C_2";
-		};
-
-		i2c3: i2c@40007800 {
-			compatible = "st,stm32-i2c-v2";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40007800 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x40000000>;
-			interrupts = <21 0>;
-			interrupt-names = "combined";
-			status = "disabled";
-			label= "I2C_3";
-		};
-
-		spi2: spi@40003800 {
-			compatible = "st,stm32-spi";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
-			interrupts = <26 3>;
-			status = "disabled";
-			label = "SPI_2";
-		};
-
-		usb: usb@40005c00 {
-			compatible = "st,stm32-usb";
-			reg = <0x40005c00 0x400>;
-			interrupts = <31 0>;
-			interrupt-names = "usb";
-			num-bidir-endpoints = <8>;
-			ram-size = <1024>;
-			phys = <&otgfs_phy>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00800000>;
-			status = "disabled";
-			label= "USB";
-		};
-
-		eeprom: eeprom@8080000{
-			reg = <0x08080000 DT_SIZE_K(6)>;
-		};
-	};
-
-	otgfs_phy: otgfs_phy {
-		compatible = "usb-nop-xceiv";
-		#phy-cells = <0>;
-		label = "OTGFS_PHY";
-	};
-};
+#include <st/l0/stm32l072.dtsi>


### PR DESCRIPTION
STM32L073 soc variant is a STM32L072 with LCD peripheral.
Reflect this in dts definition by including stm32l072.dtsi
in stm32l073.dtsi.
This also allows to fix an issue on stm32l073 gpioe which
declared wrong reg definition.


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>