### PR TITLE
drivers: sensor: bme680: delete un-reach code

### DIFF
--- a/drivers/sensor/bme680/bme680.c
+++ b/drivers/sensor/bme680/bme680.c
@@ -276,7 +276,7 @@ static int bme680_channel_get(struct device *dev, enum sensor_channel chan,
 
 static int bme680_read_compensation(struct bme680_data *data)
 {
-	u8_t buff[BME680_LEN_COEFF_ALL] = {0};
+	u8_t buff[BME680_LEN_COEFF_ALL] = { 0 };
 	int err = 0;
 
 	err = bme680_reg_read(data, BME680_REG_COEFF1, buff, BME680_LEN_COEFF1);

--- a/drivers/sensor/bme680/bme680.c
+++ b/drivers/sensor/bme680/bme680.c
@@ -187,7 +187,7 @@ static u8_t bme680_calc_gas_wait(u16_t dur)
 static int bme680_sample_fetch(struct device *dev, enum sensor_channel chan)
 {
 	struct bme680_data *data = dev->driver_data;
-	u8_t buff[BME680_LEN_FIELD] = { 0 };
+	u8_t buff[BME680_LEN_FIELD] = {0};
 	u8_t gas_range;
 	u32_t adc_temp, adc_press;
 	u16_t adc_hum, adc_gas_res;

--- a/drivers/sensor/bme680/bme680.c
+++ b/drivers/sensor/bme680/bme680.c
@@ -27,14 +27,12 @@ static int bme680_reg_read(struct bme680_data *data, u8_t start, u8_t *buf,
 {
 	return i2c_burst_read(data->i2c_master, data->i2c_slave_addr, start,
 			      buf, size);
-	//return 0;
 }
 
 static int bme680_reg_write(struct bme680_data *data, u8_t reg, u8_t val)
 {
 	return i2c_reg_write_byte(data->i2c_master, data->i2c_slave_addr,
 				  reg, val);
-	//return 0;
 }
 
 static void bme680_calc_temp(struct bme680_data *data, u32_t adc_temp)

--- a/drivers/sensor/bme680/bme680.c
+++ b/drivers/sensor/bme680/bme680.c
@@ -27,14 +27,12 @@ static int bme680_reg_read(struct bme680_data *data, u8_t start, u8_t *buf,
 {
 	return i2c_burst_read(data->i2c_master, data->i2c_slave_addr, start,
 			      buf, size);
-	return 0;
 }
 
 static int bme680_reg_write(struct bme680_data *data, u8_t reg, u8_t val)
 {
 	return i2c_reg_write_byte(data->i2c_master, data->i2c_slave_addr,
 				  reg, val);
-	return 0;
 }
 
 static void bme680_calc_temp(struct bme680_data *data, u32_t adc_temp)

--- a/drivers/sensor/bme680/bme680.c
+++ b/drivers/sensor/bme680/bme680.c
@@ -27,12 +27,14 @@ static int bme680_reg_read(struct bme680_data *data, u8_t start, u8_t *buf,
 {
 	return i2c_burst_read(data->i2c_master, data->i2c_slave_addr, start,
 			      buf, size);
+	//return 0;
 }
 
 static int bme680_reg_write(struct bme680_data *data, u8_t reg, u8_t val)
 {
 	return i2c_reg_write_byte(data->i2c_master, data->i2c_slave_addr,
 				  reg, val);
+	//return 0;
 }
 
 static void bme680_calc_temp(struct bme680_data *data, u32_t adc_temp)

--- a/drivers/sensor/bme680/bme680.c
+++ b/drivers/sensor/bme680/bme680.c
@@ -276,7 +276,7 @@ static int bme680_channel_get(struct device *dev, enum sensor_channel chan,
 
 static int bme680_read_compensation(struct bme680_data *data)
 {
-	u8_t buff[BME680_LEN_COEFF_ALL];
+	u8_t buff[BME680_LEN_COEFF_ALL] = {0};
 	int err = 0;
 
 	err = bme680_reg_read(data, BME680_REG_COEFF1, buff, BME680_LEN_COEFF1);


### PR DESCRIPTION
deleted can not reach code '	return 0;' 。
Signed-off-by: David Lin <linpeng1577@gmail.com>