### PR TITLE
bluetooth: controller: Guard SW based privacy config by Zephyr LL

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -403,21 +403,6 @@ config BT_CTLR_RL_SIZE
 	  Set the size of the Resolving List for LE Controller-based Privacy.
 	  On nRF5x-based controllers, the hardware imposes a limit of 8 devices.
 
-config BT_CTLR_SW_DEFERRED_PRIVACY
-	bool "LE Controller-based Software Privacy"
-	depends on BT_CTLR_PRIVACY
-	help
-	  Enable support for software based deferred privacy calculations.
-
-config BT_CTLR_RPA_CACHE_SIZE
-	int "LE Controller-based Software Privacy Resolving List size"
-	depends on BT_CTLR_SW_DEFERRED_PRIVACY
-	default 8
-	range 1 64
-	help
-	  Set the size of the Known Unknown Resolving List for LE
-	  Controller-based Software deferred Privacy.
-
 config BT_CTLR_EXT_SCAN_FP
 	bool "LE Extended Scanner Filter Policies"
 	depends on BT_OBSERVER && BT_CTLR_EXT_SCAN_FP_SUPPORT
@@ -510,6 +495,21 @@ config BT_CTLR_FILTER
 	default y
 	help
 	  Enable support for controller device whitelist feature
+
+config BT_CTLR_SW_DEFERRED_PRIVACY
+	bool "LE Controller-based Software Privacy"
+	depends on BT_CTLR_PRIVACY
+	help
+	  Enable support for software based deferred privacy calculations.
+
+config BT_CTLR_RPA_CACHE_SIZE
+	int "LE Controller-based Software Privacy Resolving List size"
+	depends on BT_CTLR_SW_DEFERRED_PRIVACY
+	default 8
+	range 1 64
+	help
+	  Set the size of the Known Unknown Resolving List for LE
+	  Controller-based Software deferred Privacy.
 
 config BT_CTLR_DATA_LENGTH_CLEAR
 	bool "Data Length Support (Cleartext only)"


### PR DESCRIPTION
SW based privacy is an implementation detail in the zephyr link layers.
Therefore it should not be visible when selecting an out-of-tree
controller.

Signed-off-by: Rubin Gerritsen <Rubin.Gerritsen@nordicsemi.no>