### PR TITLE
samples: cmsis_rtos_v1: Grow stack size to the maximum allowed

### DIFF
--- a/samples/portability/cmsis_rtos_v1/philosophers/src/main.c
+++ b/samples/portability/cmsis_rtos_v1/philosophers/src/main.c
@@ -72,7 +72,7 @@ osSemaphoreId forks[NUM_PHIL];
 
 #define fork(x) (forks[x])
 
-#define STACK_SIZE 512
+#define STACK_SIZE CONFIG_CMSIS_THREAD_MAX_STACK_SIZE
 
 #if DEBUG_PRINTF
 #define PR_DEBUG printk


### PR DESCRIPTION
Some architectures require more space on the stack when running samples
and tests while the philosopher test (cmsis_rtos_v1) is still using a
fixed-size stack size.
    
Since the test is going to use CMSIS v1 we cannot directly use
CONFIG_TEST_EXTRA_STACKSIZE to grow the stack size because the extra
space allocated can excess the maximum size allowed by CMSIS and defined
by CONFIG_CMSIS_THREAD_MAX_STACK_SIZE, causing the sample to halt on the
assertion (thread_def->stacksize <= CONFIG_CMSIS_THREAD_MAX_STACK_SIZE).
    
To avoid this problem (and align the test to what has been already done
on the philosopher test using CMSISv2) we set the stack size to the
maximum allowed size of CONFIG_CMSIS_THREAD_MAX_STACK_SIZE.


@andrewboie this commit together with setting `CMSIS_THREAD_MAX_STACK_SIZE`, `CMSIS_V2_THREAD_MAX_STACK_SIZE` and `CMSIS_V2_THREAD_DYNAMIC_STACK_SIZE` in the aarch64 port is enough to pass all the `cmsis_rtos` tests.