### PR TITLE
soc: arm: cleanup redundant Kconfig symbol selections

### DIFF
--- a/soc/arm/atmel_sam0/samd51/Kconfig.series
+++ b/soc/arm/atmel_sam0/samd51/Kconfig.series
@@ -7,8 +7,6 @@ config SOC_SERIES_SAMD51
 	bool "Atmel SAMD51 MCU"
 	select CPU_CORTEX_M4
 	select SOC_FAMILY_SAM0
-	select CPU_CORTEX_M_HAS_SYSTICK
-	select CPU_CORTEX_M_HAS_VTOR
 	select CPU_CORTEX_M_HAS_DWT
 	select ASF
 	help

--- a/soc/arm/atmel_sam0/same51/Kconfig.series
+++ b/soc/arm/atmel_sam0/same51/Kconfig.series
@@ -7,8 +7,6 @@ config SOC_SERIES_SAME51
 	bool "Atmel SAME51 MCU"
 	select CPU_CORTEX_M4
 	select SOC_FAMILY_SAM0
-	select CPU_CORTEX_M_HAS_SYSTICK
-	select CPU_CORTEX_M_HAS_VTOR
 	select CPU_CORTEX_M_HAS_DWT
 	select ASF
 	help

--- a/soc/arm/atmel_sam0/same53/Kconfig.series
+++ b/soc/arm/atmel_sam0/same53/Kconfig.series
@@ -7,8 +7,6 @@ config SOC_SERIES_SAME53
 	bool "Atmel SAME53 MCU"
 	select CPU_CORTEX_M4
 	select SOC_FAMILY_SAM0
-	select CPU_CORTEX_M_HAS_SYSTICK
-	select CPU_CORTEX_M_HAS_VTOR
 	select CPU_CORTEX_M_HAS_DWT
 	select ASF
 	help

--- a/soc/arm/atmel_sam0/same54/Kconfig.series
+++ b/soc/arm/atmel_sam0/same54/Kconfig.series
@@ -7,8 +7,6 @@ config SOC_SERIES_SAME54
 	bool "Atmel SAME54 MCU"
 	select CPU_CORTEX_M4
 	select SOC_FAMILY_SAM0
-	select CPU_CORTEX_M_HAS_SYSTICK
-	select CPU_CORTEX_M_HAS_VTOR
 	select CPU_CORTEX_M_HAS_DWT
 	select ASF
 	help

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.series
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.series
@@ -6,7 +6,6 @@
 config SOC_SERIES_CC13X2_CC26X2
 	bool "TI SimpleLink Family CC13x2 / CC26x2"
 	select CPU_CORTEX_M4
-	select CPU_CORTEX_M_HAS_SYSTICK
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_FPU
 	select SOC_FAMILY_TISIMPLELINK


### PR DESCRIPTION
CPU_CORTEX_M_SYSTICK and CPU_CORTEX_M_HAS_VTOR are not
required for SoCs implementing the ARMv7-M architecture.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>