### PR TITLE
debug: tracing: Fix time returned by CPU stats module

### DIFF
--- a/subsys/debug/tracing/cpu_stats.c
+++ b/subsys/debug/tracing/cpu_stats.c
@@ -62,10 +62,9 @@ void cpu_stats_get_ns(struct cpu_stats *cpu_stats_ns)
 	int key = irq_lock();
 
 	cpu_stats_update_counters();
-	cpu_stats_ns->idle = (u32_t)k_cyc_to_ns_floor64(stats_hw_tick.idle);
-	cpu_stats_ns->non_idle = (u32_t)k_cyc_to_ns_floor64(
-					  stats_hw_tick.non_idle);
-	cpu_stats_ns->sched = (u32_t)k_cyc_to_ns_floor64(stats_hw_tick.sched);
+	cpu_stats_ns->idle = k_cyc_to_ns_floor64(stats_hw_tick.idle);
+	cpu_stats_ns->non_idle = k_cyc_to_ns_floor64(stats_hw_tick.non_idle);
+	cpu_stats_ns->sched = k_cyc_to_ns_floor64(stats_hw_tick.sched);
 	irq_unlock(key);
 }
 


### PR DESCRIPTION
Function cpu_stats_get_ns from CPU stats module returns
invalid time, because of unnecessary conversion into u32_t.
Higher bits of time value are removed during this conversion.
All time values are u64_t, so there is no need to convert anything.

Signed-off-by: Dominik Kilian <Dominik.Kilian@nordicsemi.no>