### PR TITLE
[needs testing] doc: Filter warnings due to Sphinx 1.8 + Breathe/sphinx_rtd_theme

### DIFF
--- a/.known-issues/doc/deprecated.conf
+++ b/.known-issues/doc/deprecated.conf
@@ -1,0 +1,7 @@
+# Probably due to Sphinx 1.8 + Breathe. See
+# https://github.com/sphinx-doc/sphinx/issues/5438
+docutils.*RemovedInSphinx30Warning: function based directive support is now deprecated. Use class based directive instead.
+# Sphinx 1.8 issue in sphinx_rtd_theme. Fixed by
+# https://github.com/readthedocs/sphinx_rtd_theme/commit/a49a812c8821123091166fae1897d702cdc2d627,
+# but it isn't in a release yet.
+sphinx_rtd_theme.*RemovedInSphinx30Warning: To modify script_files in the theme is deprecated. Please insert a <script> tag directly in your theme instead.


### PR DESCRIPTION
Breathe and sphinx_rtd_theme generate some new deprecation warnings with
Sphinx 1.8. Suppress them.

There's an upstream fix for the sphinx_rtd_theme issue, but it's not in
a sphinx_rtd_theme release yet. See the comment.