### PR TITLE
gui: Add BGR565 pixel format support to lvgl

### DIFF
--- a/lib/gui/lvgl/lvgl_display.c
+++ b/lib/gui/lvgl/lvgl_display.c
@@ -30,6 +30,7 @@ int set_lvgl_rendering_cb(lv_disp_drv_t *disp_drv)
 		disp_drv->set_px_cb = lvgl_set_px_cb_24bit;
 		break;
 	case PIXEL_FORMAT_RGB_565:
+	case PIXEL_FORMAT_BGR_565:
 		disp_drv->flush_cb = lvgl_flush_cb_16bit;
 		disp_drv->rounder_cb = NULL;
 #ifdef CONFIG_LVGL_COLOR_DEPTH_16


### PR DESCRIPTION
Adds support for the BGR565 pixel format to lvgl. This fixes the lvgl
sample for mimxrt10{50,60,64}_evk boards, which were broken when the
mcux elcdif display driver was modified in commit
9041b0f1192a59bd31befba7dac52b103f4af978 to return the BGR565 pixel
format instead of RGB565.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>