### PR TITLE
tests : timer_api : Prevent compiler optimization

### DIFF
--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -57,7 +57,7 @@ static void init_timer_data(void)
 static void duration_expire(struct k_timer *timer)
 {
 	/** TESTPOINT: expire function */
-	s64_t interval = k_uptime_delta(&tdata.timestamp);
+	volatile s64_t interval = k_uptime_delta(&tdata.timestamp);
 
 	tdata.expire_cnt++;
 	if (tdata.expire_cnt == 1) {


### PR DESCRIPTION
The local variable 'interval' in timer's callback function
should not be optimized by compiler.
fix #21813

Signed-off-by: Ying ming <mingx.ying@intel.com>