### PR TITLE
kernel: device: Add const qualifier to device_config

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -101,7 +101,7 @@ extern "C" {
 #ifndef CONFIG_DEVICE_POWER_MANAGEMENT
 #define DEVICE_AND_API_INIT(dev_name, drv_name, init_fn, data, cfg_info,  \
 			    level, prio, api)				  \
-	static struct device_config _CONCAT(__config_, dev_name) __used	  \
+	static const struct device_config _CONCAT(__config_, dev_name) __used \
 	__attribute__((__section__(".devconfig.init"))) = {		  \
 		.name = drv_name, .init = (init_fn),			  \
 		.config_info = (cfg_info)				  \
@@ -272,7 +272,7 @@ struct device_config {
  * @param driver_data driver instance data. For driver use only
  */
 struct device {
-	struct device_config *config;
+	const struct device_config *config;
 	const void *driver_api;
 	void *driver_data;
 };

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -49,7 +49,7 @@ void z_sys_device_do_config_level(s32_t level)
 	for (info = config_levels[level]; info < config_levels[level+1];
 								info++) {
 		int retval;
-		struct device_config *device_conf = info->config;
+		const struct device_config *device_conf = info->config;
 
 		retval = device_conf->init(info);
 		if (retval != 0) {


### PR DESCRIPTION
Device config structure is placed in rom section but there was
no const prefix used. Lack of prefix suggested that structure
is in ram (ram_report is also fooled). Added const prefix to
explicitly inform that it goes to rom.

See https://github.com/zephyrproject-rtos/zephyr/issues/21670#issuecomment-576547880

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>