### PR TITLE
tests/kernel/fatal: add volatile to prevent compiler optimization

### DIFF
--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -82,7 +82,7 @@ void alt_thread1(void)
 	 * and xtensa
 	 */
 	{
-		long illegal = 0;
+		volatile long illegal = 0;
 		((void(*)(void))&illegal)();
 	}
 #endif


### PR DESCRIPTION
In RISC-V arch, the program jumps to the memory address of zero-initialized local variable to trigger a "illegal instruction" in `alt_thread1()`. If the initialization of this variable is optimized, program will jump to the memory address contains the random value. This will cause the unexpected behavior in the program, and may make the testcase failed.
(For example, write to lowest bytes of stack to break the checking of STACK_SENTINEL.)

Currently, initialization of local variable 'illegal' is optimized when using riscv64 toolchain in zephyr-sdk to compile original program.

The following is the disassembly of this function:
```
0000000020400240 <alt_thread1>:
    20400240:   1101                    addi    sp,sp,-32
    20400242:   5fc00797                auipc   a5,0x5fc00
    20400246:   e207a723                sw      zero,-466(a5) # 80000070 <expected_reason>
    2040024a:   ec06                    sd      ra,24(sp)
    2040024c:   003c                    addi    a5,sp,8
    2040024e:   9782                    jalr    a5
    20400250:   60e2                    ld      ra,24(sp)
    20400252:   4785                    li      a5,1
    20400254:   5fc00717                auipc   a4,0x5fc00
    20400258:   f4f72a23                sw      a5,-172(a4) # 800001a8 <rv>
    2040025c:   6105                    addi    sp,sp,32
    2040025e:   8082                    ret
```
program jumps to `illegal` variable at instruction `jalr a5`.
`illegal` variable is at `$sp+8`, but `$sp+8` is not initialized in `alt_thread1` function.

After adding volatile to the program and compile it, riscv64 compiler will generate
a instruction `sd      zero,8(sp)` to initialize the `illegal` variable at `$sp+8`
