### PR TITLE
drivers: counter: add counter_get_value(), deprecate counter_read()

### DIFF
--- a/doc/releases/release-notes-2.2.rst
+++ b/doc/releases/release-notes-2.2.rst
@@ -140,7 +140,9 @@ Drivers and Sensors
 
 * Counter
 
-  * <TBD>
+  * The counter_read() API function is deprecated in favor of
+    counter_get_value(). The new API function adds a return value for
+    indicating whether the counter was read successfully.
 
 * Display
 

--- a/drivers/counter/counter_cmos.c
+++ b/drivers/counter/counter_cmos.c
@@ -124,11 +124,11 @@ static u32_t hinnant(int y, int m, int d)
 }
 
 /*
- * Returns the Unix epoch time (assuming UTC) read from the CMOS RTC.
+ * Get the Unix epoch time (assuming UTC) read from the CMOS RTC.
  * This function is long, but linear and easy to follow.
  */
 
-u32_t read(struct device *dev)
+int get_value(struct device *dev, u32_t *ticks)
 {
 	struct state state, state2;
 	u64_t *pun = (u64_t *) &state;
@@ -188,7 +188,8 @@ u32_t read(struct device *dev)
 	epoch += state.minute * 60; /* seconds per minute */
 	epoch += state.second;
 
-	return epoch;
+	*ticks = epoch;
+	return 0;
 }
 
 static int init(struct device *dev)
@@ -204,7 +205,7 @@ static const struct counter_config_info info = {
 };
 
 static const struct counter_driver_api api = {
-	.read = read
+	.get_value = get_value
 };
 
 DEVICE_AND_API_INIT(counter_cmos, "CMOS", init, NULL, &info,

--- a/drivers/counter/counter_gecko_rtcc.c
+++ b/drivers/counter/counter_gecko_rtcc.c
@@ -83,11 +83,12 @@ static int counter_gecko_stop(struct device *dev)
 	return 0;
 }
 
-static u32_t counter_gecko_read(struct device *dev)
+static int counter_gecko_get_value(struct device *dev, u32_t *ticks)
 {
 	ARG_UNUSED(dev);
 
-	return RTCC_CounterGet();
+	*ticks = RTCC_CounterGet();
+	return 0;
 }
 
 static int counter_gecko_set_top_value(struct device *dev,
@@ -160,7 +161,7 @@ static u32_t counter_gecko_get_max_relative_alarm(struct device *dev)
 static int counter_gecko_set_alarm(struct device *dev, u8_t chan_id,
 				   const struct counter_alarm_cfg *alarm_cfg)
 {
-	u32_t count = counter_gecko_read(dev);
+	u32_t count = RTCC_CounterGet();
 	struct counter_gecko_data *const dev_data = DEV_DATA(dev);
 	u32_t top_value = counter_gecko_get_top_value(dev);
 	u32_t ccv;
@@ -309,7 +310,7 @@ static int counter_gecko_init(struct device *dev)
 static const struct counter_driver_api counter_gecko_driver_api = {
 	.start = counter_gecko_start,
 	.stop = counter_gecko_stop,
-	.read = counter_gecko_read,
+	.get_value = counter_gecko_get_value,
 	.set_alarm = counter_gecko_set_alarm,
 	.cancel_alarm = counter_gecko_cancel_alarm,
 	.set_top_value = counter_gecko_set_top_value,

--- a/drivers/counter/counter_handlers.c
+++ b/drivers/counter/counter_handlers.c
@@ -64,12 +64,14 @@ static inline u64_t z_vrfy_counter_ticks_to_us(const struct device *dev,
 }
 #include <syscalls/counter_ticks_to_us_mrsh.c>
 
-static inline u32_t z_vrfy_counter_read(struct device *dev)
+static inline int z_vrfy_counter_get_value(struct device *dev,
+					   u32_t *ticks)
 {
-	Z_OOPS(Z_SYSCALL_DRIVER_COUNTER(dev, read));
-	return z_impl_counter_read((struct device *)dev);
+	Z_OOPS(Z_SYSCALL_DRIVER_COUNTER(dev, get_value));
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(ticks, sizeof(ticks)));
+	return z_impl_counter_get_value((struct device *)dev, ticks);
 }
-#include <syscalls/counter_read_mrsh.c>
+#include <syscalls/counter_get_value_mrsh.c>
 
 static inline int z_vrfy_counter_set_channel_alarm(struct device *dev,
 			u8_t chan_id, const struct counter_alarm_cfg *alarm_cfg)

--- a/drivers/counter/counter_imx_epit.c
+++ b/drivers/counter/counter_imx_epit.c
@@ -86,14 +86,13 @@ static int imx_epit_stop(struct device *dev)
 	return 0;
 }
 
-static u32_t imx_epit_read(struct device *dev)
+static int imx_epit_get_value(struct device *dev, u32_t *ticks)
 {
 	EPIT_Type *base = get_epit_config(dev)->base;
-	u32_t value;
 
-	value = EPIT_GetCounterLoadValue(base) - EPIT_ReadCounter(base);
+	*ticks = EPIT_GetCounterLoadValue(base) - EPIT_ReadCounter(base);
 
-	return value;
+	return 0;
 }
 
 static int imx_epit_set_top_value(struct device *dev,
@@ -143,7 +142,7 @@ static u32_t imx_epit_get_max_relative_alarm(struct device *dev)
 static const struct counter_driver_api imx_epit_driver_api = {
 	.start = imx_epit_start,
 	.stop = imx_epit_stop,
-	.read = imx_epit_read,
+	.get_value = imx_epit_get_value,
 	.set_top_value = imx_epit_set_top_value,
 	.get_pending_int = imx_epit_get_pending_int,
 	.get_top_value = imx_epit_get_top_value,

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -112,6 +112,12 @@ static u32_t rtc_stm32_read(struct device *dev)
 	return ticks;
 }
 
+static int rtc_stm32_get_value(struct device *dev, u32_t *ticks)
+{
+	*ticks = rtc_stm32_read(dev);
+	return 0;
+}
+
 static int rtc_stm32_set_alarm(struct device *dev, u8_t chan_id,
 				const struct counter_alarm_cfg *alarm_cfg)
 {
@@ -353,7 +359,7 @@ static const struct rtc_stm32_config rtc_config = {
 static const struct counter_driver_api rtc_stm32_driver_api = {
 		.start = rtc_stm32_start,
 		.stop = rtc_stm32_stop,
-		.read = rtc_stm32_read,
+		.get_value = rtc_stm32_get_value,
 		.set_alarm = rtc_stm32_set_alarm,
 		.cancel_alarm = rtc_stm32_cancel_alarm,
 		.set_top_value = rtc_stm32_set_top_value,

--- a/drivers/counter/counter_mchp_xec.c
+++ b/drivers/counter/counter_mchp_xec.c
@@ -96,11 +96,12 @@ static int counter_xec_stop(struct device *dev)
 	return 0;
 }
 
-static u32_t counter_xec_read(struct device *dev)
+static int counter_xec_get_value(struct device *dev, u32_t *ticks)
 {
 	BTMR_Type *counter = COUNTER_XEC_REG_BASE(dev);
 
-	return counter->CNT;
+	*ticks = counter->CNT;
+	return 0;
 }
 
 static int counter_xec_set_alarm(struct device *dev, u8_t chan_id,
@@ -275,7 +276,7 @@ static void counter_xec_isr(struct device *dev)
 static const struct counter_driver_api counter_xec_api = {
 		.start = counter_xec_start,
 		.stop = counter_xec_stop,
-		.read = counter_xec_read,
+		.get_value = counter_xec_get_value,
 		.set_alarm = counter_xec_set_alarm,
 		.cancel_alarm = counter_xec_cancel_alarm,
 		.set_top_value = counter_xec_set_top_value,

--- a/drivers/counter/counter_mcux_gpt.c
+++ b/drivers/counter/counter_mcux_gpt.c
@@ -42,11 +42,12 @@ static int mcux_gpt_stop(struct device *dev)
 	return 0;
 }
 
-static u32_t mcux_gpt_read(struct device *dev)
+static int mcux_gpt_get_value(struct device *dev, u32_t *ticks)
 {
 	const struct mcux_gpt_config *config = dev->config->config_info;
 
-	return GPT_GetCurrentTimerCount(config->base);
+	*ticks = GPT_GetCurrentTimerCount(config->base);
+	return 0;
 }
 
 static int mcux_gpt_set_alarm(struct device *dev, u8_t chan_id,
@@ -55,7 +56,7 @@ static int mcux_gpt_set_alarm(struct device *dev, u8_t chan_id,
 	const struct mcux_gpt_config *config = dev->config->config_info;
 	struct mcux_gpt_data *data = dev->driver_data;
 
-	u32_t current = mcux_gpt_read(dev);
+	u32_t current = GPT_GetCurrentTimerCount(config->base);
 	u32_t ticks = alarm_cfg->ticks;
 
 	if (chan_id != 0) {
@@ -102,7 +103,7 @@ void mcux_gpt_isr(void *p)
 	struct device *dev = p;
 	const struct mcux_gpt_config *config = dev->config->config_info;
 	struct mcux_gpt_data *data = dev->driver_data;
-	u32_t current = mcux_gpt_read(dev);
+	u32_t current = GPT_GetCurrentTimerCount(config->base);
 	u32_t status;
 
 	status =  GPT_GetStatusFlags(config->base, kGPT_OutputCompare1Flag |
@@ -189,7 +190,7 @@ static int mcux_gpt_init(struct device *dev)
 static const struct counter_driver_api mcux_gpt_driver_api = {
 	.start = mcux_gpt_start,
 	.stop = mcux_gpt_stop,
-	.read = mcux_gpt_read,
+	.get_value = mcux_gpt_get_value,
 	.set_alarm = mcux_gpt_set_alarm,
 	.cancel_alarm = mcux_gpt_cancel_alarm,
 	.set_top_value = mcux_gpt_set_top_value,

--- a/drivers/counter/counter_mcux_rtc.c
+++ b/drivers/counter/counter_mcux_rtc.c
@@ -79,6 +79,12 @@ static u32_t mcux_rtc_read(struct device *dev)
 	return ticks;
 }
 
+static int mcux_rtc_get_value(struct device *dev, u32_t *ticks)
+{
+	*ticks = mcux_rtc_read(dev);
+	return 0;
+}
+
 static int mcux_rtc_set_alarm(struct device *dev, u8_t chan_id,
 			      const struct counter_alarm_cfg *alarm_cfg)
 {
@@ -245,7 +251,7 @@ static int mcux_rtc_init(struct device *dev)
 static const struct counter_driver_api mcux_rtc_driver_api = {
 	.start = mcux_rtc_start,
 	.stop = mcux_rtc_stop,
-	.read = mcux_rtc_read,
+	.get_value = mcux_rtc_get_value,
 	.set_alarm = mcux_rtc_set_alarm,
 	.cancel_alarm = mcux_rtc_cancel_alarm,
 	.set_top_value = mcux_rtc_set_top_value,

--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -97,6 +97,12 @@ static u32_t read(struct device *dev)
 	return nrf_rtc_counter_get(get_nrfx_config(dev)->rtc);
 }
 
+static int get_value(struct device *dev, u32_t *ticks)
+{
+	*ticks = read(dev);
+	return 0;
+}
+
 /* Return true if value equals 2^n - 1 */
 static inline bool is_bit_mask(u32_t val)
 {
@@ -637,7 +643,7 @@ static void irq_handler(struct device *dev)
 static const struct counter_driver_api counter_nrfx_driver_api = {
 	.start = start,
 	.stop = stop,
-	.read = read,
+	.get_value = get_value,
 	.set_alarm = set_channel_alarm,
 	.cancel_alarm = cancel_alarm,
 	.set_top_value = set_top_value,

--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -98,6 +98,12 @@ static u32_t read(struct device *dev)
 	return nrf_timer_cc_get(timer, COUNTER_READ_CC);
 }
 
+static int get_value(struct device *dev, u32_t *ticks)
+{
+	*ticks = read(dev);
+	return 0;
+}
+
 /* Return true if value equals 2^n - 1 */
 static inline bool is_bit_mask(u32_t val)
 {
@@ -365,7 +371,7 @@ static void irq_handler(struct device *dev)
 static const struct counter_driver_api counter_nrfx_driver_api = {
 	.start = start,
 	.stop = stop,
-	.read = read,
+	.get_value = get_value,
 	.set_alarm = set_alarm,
 	.cancel_alarm = cancel_alarm,
 	.set_top_value = set_top_value,

--- a/drivers/counter/counter_sam0_tc32.c
+++ b/drivers/counter/counter_sam0_tc32.c
@@ -113,6 +113,12 @@ static u32_t counter_sam0_tc32_read(struct device *dev)
 	return tc->COUNT.reg;
 }
 
+static int counter_sam0_tc32_get_value(struct device *dev, u32_t *ticks)
+{
+	*ticks = counter_sam0_tc32_read(dev);
+	return 0;
+}
+
 static void counter_sam0_tc32_relative_alarm(struct device *dev, u32_t ticks)
 {
 	struct counter_sam0_tc32_data *data = DEV_DATA(dev);
@@ -385,7 +391,7 @@ static int counter_sam0_tc32_initialize(struct device *dev)
 static const struct counter_driver_api counter_sam0_tc32_driver_api = {
 	.start = counter_sam0_tc32_start,
 	.stop = counter_sam0_tc32_stop,
-	.read = counter_sam0_tc32_read,
+	.get_value = counter_sam0_tc32_get_value,
 	.set_alarm = counter_sam0_tc32_set_alarm,
 	.cancel_alarm = counter_sam0_tc32_cancel_alarm,
 	.set_top_value = counter_sam0_tc32_set_top_value,

--- a/drivers/counter/timer_dtmr_cmsdk_apb.c
+++ b/drivers/counter/timer_dtmr_cmsdk_apb.c
@@ -59,13 +59,14 @@ static int dtmr_cmsdk_apb_stop(struct device *dev)
 	return 0;
 }
 
-static u32_t dtmr_cmsdk_apb_read(struct device *dev)
+static int dtmr_cmsdk_apb_get_value(struct device *dev, u32_t *ticks)
 {
 	const struct dtmr_cmsdk_apb_cfg * const cfg =
 						dev->config->config_info;
 	struct dtmr_cmsdk_apb_dev_data *data = dev->driver_data;
 
-	return data->load - cfg->dtimer->timer1value;
+	*ticks = data->load - cfg->dtimer->timer1value;
+	return 0;
 }
 
 static int dtmr_cmsdk_apb_set_top_value(struct device *dev,
@@ -123,7 +124,7 @@ static u32_t dtmr_cmsdk_apb_get_pending_int(struct device *dev)
 static const struct counter_driver_api dtmr_cmsdk_apb_api = {
 	.start = dtmr_cmsdk_apb_start,
 	.stop = dtmr_cmsdk_apb_stop,
-	.read = dtmr_cmsdk_apb_read,
+	.get_value = dtmr_cmsdk_apb_get_value,
 	.set_top_value = dtmr_cmsdk_apb_set_top_value,
 	.get_pending_int = dtmr_cmsdk_apb_get_pending_int,
 	.get_top_value = dtmr_cmsdk_apb_get_top_value,

--- a/drivers/counter/timer_tmr_cmsdk_apb.c
+++ b/drivers/counter/timer_tmr_cmsdk_apb.c
@@ -58,14 +58,15 @@ static int tmr_cmsdk_apb_stop(struct device *dev)
 	return 0;
 }
 
-static u32_t tmr_cmsdk_apb_read(struct device *dev)
+static int tmr_cmsdk_apb_get_value(struct device *dev, u32_t *ticks)
 {
 	const struct tmr_cmsdk_apb_cfg * const cfg =
 						dev->config->config_info;
 	struct tmr_cmsdk_apb_dev_data *data = dev->driver_data;
 
-	/* Return Counter Value */
-	return data->load - cfg->timer->value;
+	/* Get Counter Value */
+	*ticks = data->load - cfg->timer->value;
+	return 0;
 }
 
 static int tmr_cmsdk_apb_set_top_value(struct device *dev,
@@ -118,7 +119,7 @@ static u32_t tmr_cmsdk_apb_get_pending_int(struct device *dev)
 static const struct counter_driver_api tmr_cmsdk_apb_api = {
 	.start = tmr_cmsdk_apb_start,
 	.stop = tmr_cmsdk_apb_stop,
-	.read = tmr_cmsdk_apb_read,
+	.get_value = tmr_cmsdk_apb_get_value,
 	.set_top_value = tmr_cmsdk_apb_set_top_value,
 	.get_pending_int = tmr_cmsdk_apb_get_pending_int,
 	.get_top_value = tmr_cmsdk_apb_get_top_value,

--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -106,7 +106,16 @@ void BoardCriticalSectionEnd(uint32_t *mask)
 
 uint32_t RtcGetTimerElapsedTime(void)
 {
-	return counter_read(dev_data.counter);
+	u32_t ticks;
+	int err;
+
+	err = counter_get_value(dev_data.counter, &ticks);
+	if (err) {
+		LOG_ERR("Failed to read counter value (err %d)", err);
+		return 0;
+	}
+
+	return ticks;
 }
 
 u32_t RtcGetMinimumTimeout(void)

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -19,11 +19,20 @@ static void test_counter_interrupt_fn(struct device *counter_dev,
 				      u8_t chan_id, u32_t ticks,
 				      void *user_data)
 {
-	u32_t now_ticks = counter_read(counter_dev);
-	u64_t now_usec = counter_ticks_to_us(counter_dev, now_ticks);
-	int now_sec = (int)(now_usec / USEC_PER_SEC);
 	struct counter_alarm_cfg *config = user_data;
+	u32_t now_ticks;
+	u64_t now_usec;
+	int now_sec;
 	int err;
+
+	err = counter_get_value(counter_dev, &now_ticks);
+	if (err) {
+		printk("Failed to read counter value (err %d)", err);
+		return;
+	}
+
+	now_usec = counter_ticks_to_us(counter_dev, now_ticks);
+	now_sec = (int)(now_usec / USEC_PER_SEC);
 
 	printk("!!! Alarm !!!\n");
 	printk("Now: %u\n", now_sec);

--- a/tests/arch/x86/info/src/timer.c
+++ b/tests/arch/x86/info/src/timer.c
@@ -12,11 +12,21 @@
 static u32_t sync(struct device *cmos)
 {
 	u32_t this, last;
+	int err;
 
-	this = counter_read(cmos);
+	err = counter_get_value(cmos, &this);
+	if (err) {
+		printk("\tCan't read CMOS clock device.\n");
+		return 0;
+	}
+
 	do {
 		last = this;
-		this = counter_read(cmos);
+		err = counter_get_value(cmos, &this);
+		if (err) {
+			printk("\tCan't read CMOS clock device.\n");
+			return 0;
+		}
 	} while (last == this);
 
 	return z_timer_cycle_get_32();

--- a/tests/drivers/counter/counter_cmos/src/main.c
+++ b/tests/drivers/counter/counter_cmos/src/main.c
@@ -19,13 +19,19 @@ void test_cmos_rate(void)
 {
 	struct device *cmos;
 	u32_t start, elapsed;
+	int err;
 
 	cmos = device_get_binding("CMOS");
 	zassert_true(cmos != NULL, "can't find CMOS counter device");
 
-	start = counter_read(cmos);
+	err = counter_get_value(cmos, &start);
+	zassert_true(err == 0, "failed to read CMOS counter device");
+
 	k_sleep(DELAY_MS);
-	elapsed = counter_read(cmos) - start;
+
+	err = counter_get_value(cmos, &elapsed);
+	zassert_true(err == 0, "failed to read CMOS counter device");
+	elapsed -= start;
 
 	zassert_true(elapsed >= MIN_BOUND, "busted minimum bound");
 	zassert_true(elapsed <= MAX_BOUND, "busted maximum bound");


### PR DESCRIPTION
Introduce a new counter API function for reading the current counter value (counter_get_value()) and deprecate the former counter_read() in favor of this.

Update all drivers and calling code to match the new counter API.

The previous counter driver API function for reading the current value of the counter (counter_read()) did not support indicating whether the read suceeded. This is fine for counters internal to the SoC where the read always succeeds but insufficient for external counters (e.g. I2C or SPI slaves).

Fixes #21846.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>