### PR TITLE
Bluetooth: shell: kconfig: Do not select FLASH_SHELL from BT_SHELL

### DIFF
--- a/subsys/bluetooth/shell/Kconfig
+++ b/subsys/bluetooth/shell/Kconfig
@@ -6,7 +6,6 @@
 config BT_SHELL
 	bool "Enable Bluetooth shell"
 	select SHELL
-	select FLASH_SHELL
 	help
 	  Activate shell module that provides Bluetooth commands to the
 	  console.


### PR DESCRIPTION
Fixes some selects with unsatisfied dependencies. FLASH_SHELL depends on
FLASH_PAGE_LAYOUT, but only FLASH_SHELL is selected. The select was
introduced in commit 3aa2a1c6db ("flash: make flash shell generic").

Spoke to Johan Hedberg. The BT_SHELL code does not depend on
FLASH_SHELL. He didn't think people would assume that BT_SHELL by itself
enables the FLASH_SHELL commands either.

Just remove the select.