### PR TITLE
shell: kconfig: Have SHELL_BACKEND_RTT depend on USE_SEGGER_RTT

### DIFF
--- a/subsys/shell/Kconfig.backends
+++ b/subsys/shell/Kconfig.backends
@@ -114,9 +114,9 @@ endif # SHELL_BACKEND_SERIAL
 
 config SHELL_BACKEND_RTT
 	bool "Enable RTT backend"
-	select USE_SEGGER_RTT
 	select CONSOLE
 	select RTT_CONSOLE
+	depends on USE_SEGGER_RTT
 	help
 	  Enable RTT backend.
 


### PR DESCRIPTION
Have SHELL_BACKEND_RTT depend on USE_SEGGER_RTT instead of selecting it,
to fix some selects of USE_SEGGER_RTT with unsatisfied dependencies.
USE_SEGGER_RTT was being forced on without checking HAS_SEGGER_RTT.

This means configuration files now have to enable both USE_SEGGER_RTT
and SHELL_BACKEND_RTT to enable SHELL_BACKEND_RTT. At least
samples/subsys/shell/shell_module/prj_minimal_rtt.conf does.

(The original version of this commit added a dependency on
HAS_SEGGER_RTT to SHELL_BACKEND_RTT instead, but Krzysztof Chruscinski
suggested depending on USE_SEGGER_RTT instead.)

Footnote: 'depends on' conditions get propagated to properties, so this
change is the same as adding '... if USE_SEGGER_RTT' to all properties
(and the prompt).