### PR TITLE
driver: uart: ns16550: Setting default options

### DIFF
--- a/drivers/serial/uart_ns16550_port_x.h
+++ b/drivers/serial/uart_ns16550_port_x.h
@@ -32,6 +32,10 @@ static const struct uart_ns16550_device_config uart_ns16550_dev_cfg_@NUM@ = {
 
 static struct uart_ns16550_dev_data_t uart_ns16550_dev_data_@NUM@ = {
 	.uart_config.baudrate = DT_UART_NS16550_PORT_@NUM@_BAUD_RATE,
+	.uart_config.parity = UART_CFG_PARITY_NONE,
+	.uart_config.stop_bits = UART_CFG_STOP_BITS_1,
+	.uart_config.data_bits = UART_CFG_DATA_BITS_8,
+	.uart_config.flow_ctrl = UART_CFG_FLOW_CTRL_NONE,
 	.options = CONFIG_UART_NS16550_PORT_@NUM@_OPTIONS,
 
 #ifdef DT_UART_NS16550_PORT_@NUM@_DLF


### PR DESCRIPTION
Commit 68a235932f93c432638d94a641f923f1210e992f changed this driver to
not use hard-coded options. The problem was that these options were
never being set. This commit just set an initial value that can be
changed later.

Fix 68a235932f93c432638d94a641f923f1210e992f

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>