### PR TITLE
net: ieee802154: Sort out fragmentation tests

### DIFF
--- a/boards/x86/qemu_x86/qemu_x86.yaml
+++ b/boards/x86/qemu_x86/qemu_x86.yaml
@@ -10,5 +10,6 @@ supported:
   - pci
   - nvs
   - netif:serial-net
+  - ieee802154
 testing:
   default: true

--- a/subsys/net/ip/6lo.c
+++ b/subsys/net/ip/6lo.c
@@ -1353,7 +1353,7 @@ static bool uncompress_IPHC_header(struct net_pkt *pkt)
 		frag = pkt->buffer;
 		net_buf_add(frag, diff);
 		cursor = frag->data + diff;
-		memmove(cursor, frag->data, frag->len);
+		memmove(cursor, frag->data, frag->len - diff);
 	} else {
 		NET_DBG("Not enough tailroom. Get new fragment");
 		cursor =  pkt->buffer->data;

--- a/tests/net/ieee802154/fragment/src/main.c
+++ b/tests/net/ieee802154/fragment/src/main.c
@@ -166,7 +166,7 @@ int net_fragment_dev_init(struct device *dev)
 
 static void net_fragment_iface_init(struct net_if *iface)
 {
-	u8_t mac[8] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xaa, 0xbb};
+	static u8_t mac[8] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xaa, 0xbb};
 
 	net_if_set_link_addr(iface, mac, 8, NET_LINK_IEEE802154);
 }
@@ -230,6 +230,7 @@ static bool compare_data(struct net_pkt *pkt, struct net_fragment_data *data)
 
 static struct net_pkt *create_pkt(struct net_fragment_data *data)
 {
+	static u16_t dummy_short_addr;
 	struct net_pkt *pkt;
 	struct net_buf *buf;
 	u32_t bytes, pos;
@@ -286,6 +287,15 @@ static struct net_pkt *create_pkt(struct net_fragment_data *data)
 			buf = net_pkt_get_frag(pkt, K_FOREVER);
 		}
 	}
+
+	/* Setup link layer addresses. */
+	net_pkt_lladdr_dst(pkt)->addr = (u8_t *)&dummy_short_addr;
+	net_pkt_lladdr_dst(pkt)->len = sizeof(dummy_short_addr);
+	net_pkt_lladdr_dst(pkt)->type = NET_LINK_IEEE802154;
+
+	memcpy(net_pkt_lladdr_src(pkt),
+	       net_if_get_link_addr(net_if_get_default()),
+	       sizeof(struct net_linkaddr));
 
 	return pkt;
 }


### PR DESCRIPTION
Fragmentation tests in `tests/net/ieee802154` failed due to asserts on LL addresses and a memory corruption issue. This appears to be happening since the recent 6lowpan rework.

@jukkar It seems that these tests are not automatically executed during the sanity-check, that's why it went so long unnoticed. A short investigation showed up that the ieee802514 tests have the following dependency: `depends_on: ieee802154`, yet no emulated qemu board sets `ieee802154` in their capabilities. IMO we could fix it in this PR as well. Shall we add the capability to any of the boards or remove the dependency? The latter should be no harm, as the tests seem to provide either dummy network interface or dummy ieee802154 driver.

Fixes #19761.