### PR TITLE
Bluetooth: controller: split: Fix DLE preparation routine

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -3187,7 +3187,8 @@ static inline void event_len_prep(struct ll_conn *conn)
 		    (!feature_coded_phy && !feature_phy_2m)) {
 			rx_time = PKT_US(LL_LENGTH_OCTETS_RX_MAX, 0);
 #if defined(CONFIG_BT_CTLR_PHY)
-			tx_time = conn->default_tx_time;
+			tx_time = MIN(PKT_US(LL_LENGTH_OCTETS_RX_MAX, 0),
+				      conn->default_tx_time);
 #else /* !CONFIG_BT_CTLR_PHY */
 			tx_time = PKT_US(conn->default_tx_octets, 0);
 #endif /* !CONFIG_BT_CTLR_PHY */


### PR DESCRIPTION
This fixes the EBQ tests LL/CON/MAS/BV-129-C and LL/CON/MAS/BV-130-C. 
These tests check behaviour for the DLE procedure when Encoded PHY or 
2M PHY are not supported.
See also BT core spec. Version 5.1, Vol6, Part B, Section 5.1.9

Note that LL/CON/MAS/BV-74-C, LL/CON/MAS/BV-76-C and LL/CON/MAS/BV-78-C 
still need a fix before passing conformancy test

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>