### PR TITLE
net: sockets: Rework ioctl poll helpers error handling

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -980,12 +980,9 @@ static int zsock_poll_prepare_ctx(struct net_context *ctx,
 				  struct k_poll_event **pev,
 				  struct k_poll_event *pev_end)
 {
-	int ret = 0;
-
 	if (pfd->events & ZSOCK_POLLIN) {
 		if (*pev == pev_end) {
-			errno = ENOMEM;
-			return -1;
+			return -ENOMEM;
 		}
 
 		(*pev)->obj = &ctx->recv_q;
@@ -996,19 +993,17 @@ static int zsock_poll_prepare_ctx(struct net_context *ctx,
 	}
 
 	if (pfd->events & ZSOCK_POLLOUT) {
-		errno = EALREADY;
-		ret = -1;
+		return -EALREADY;
 	}
 
 	/* If socket is already in EOF, it can be reported
 	 * immediately, so we tell poll() to short-circuit wait.
 	 */
 	if (sock_is_eof(ctx)) {
-		errno = EALREADY;
-		return -1;
+		return -EALREADY;
 	}
 
-	return ret;
+	return 0;
 }
 
 static int zsock_poll_update_ctx(struct net_context *ctx,
@@ -1058,6 +1053,7 @@ int z_impl_zsock_poll(struct zsock_pollfd *fds, int nfds, int timeout)
 	pev = poll_events;
 	for (pfd = fds, i = nfds; i--; pfd++) {
 		struct net_context *ctx;
+		int result;
 
 		/* Per POSIX, negative fd's are just ignored */
 		if (pfd->fd < 0) {
@@ -1070,20 +1066,19 @@ int z_impl_zsock_poll(struct zsock_pollfd *fds, int nfds, int timeout)
 			continue;
 		}
 
-		if (z_fdtable_call_ioctl(vtable, ctx, ZFD_IOCTL_POLL_PREPARE,
-					 pfd, &pev, pev_end) < 0) {
+		result = z_fdtable_call_ioctl(vtable, ctx,
+					      ZFD_IOCTL_POLL_PREPARE,
+					      pfd, &pev, pev_end);
+		if (result == -EALREADY) {
 			/* If POLL_PREPARE returned with EALREADY, it means
 			 * it already detected that some socket is ready. In
 			 * this case, we still perform a k_poll to pick up
 			 * as many events as possible, but without any wait.
-			 * TODO: optimize, use ret value, instead of setting
-			 * errno.
 			 */
-			if (errno == EALREADY) {
-				timeout = K_NO_WAIT;
-				continue;
-			}
-
+			timeout = K_NO_WAIT;
+			continue;
+		} else if (result != 0) {
+			errno = -result;
 			return -1;
 		}
 	}
@@ -1104,6 +1099,7 @@ int z_impl_zsock_poll(struct zsock_pollfd *fds, int nfds, int timeout)
 		pev = poll_events;
 		for (pfd = fds, i = nfds; i--; pfd++) {
 			struct net_context *ctx;
+			int result;
 
 			pfd->revents = 0;
 
@@ -1118,13 +1114,14 @@ int z_impl_zsock_poll(struct zsock_pollfd *fds, int nfds, int timeout)
 				continue;
 			}
 
-			if (z_fdtable_call_ioctl(vtable, ctx, ZFD_IOCTL_POLL_UPDATE,
-						 pfd, &pev) < 0) {
-				if (errno == EAGAIN) {
-					retry = true;
-					continue;
-				}
-
+			result = z_fdtable_call_ioctl(vtable, ctx,
+						      ZFD_IOCTL_POLL_UPDATE,
+						      pfd, &pev);
+			if (result == -EAGAIN) {
+				retry = true;
+				continue;
+			} else if (result != 0) {
+				errno = -result;
 				return -1;
 			}
 

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1699,8 +1699,7 @@ static int ztls_poll_prepare_ctx(struct net_context *ctx,
 
 	if (pfd->events & ZSOCK_POLLIN) {
 		if (*pev == pev_end) {
-			errno = ENOMEM;
-			return -1;
+			return -ENOMEM;
 		}
 
 		/* DTLS client should wait for the handshake to complete before
@@ -1725,8 +1724,7 @@ static int ztls_poll_prepare_ctx(struct net_context *ctx,
 		 * immediately, so we tell poll() to short-circuit wait.
 		 */
 		if (sock_is_eof(ctx)) {
-			errno = EALREADY;
-			return -1;
+			return -EALREADY;
 		}
 
 		/* If there already is mbedTLS data to read, there is no
@@ -1735,8 +1733,7 @@ static int ztls_poll_prepare_ctx(struct net_context *ctx,
 		 */
 		if (!IS_LISTENING(ctx)) {
 			if (mbedtls_ssl_get_bytes_avail(&ctx->tls->ssl) > 0) {
-				errno = EALREADY;
-				return -1;
+				return -EALREADY;
 			}
 		}
 	}
@@ -1829,8 +1826,7 @@ next:
 
 again:
 	(*pev)++;
-	errno = EAGAIN;
-	return -1;
+	return -EAGAIN;
 }
 
 int ztls_getsockopt_ctx(struct net_context *ctx, int level, int optname,


### PR DESCRIPTION
Make `ioctl` handlers of `ZFD_IOCTL_POLL_PREPARE` and `ZFD_IOCTL_POLL_UPDATE` return an error code instead of setting errno variable, as suggested in one of the TODOs.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>