### PR TITLE
[topic-gpio] samples: led_apa102c_bitbang: Convert to new GPIO API

### DIFF
--- a/samples/drivers/led_apa102c_bitbang/src/main.c
+++ b/samples/drivers/led_apa102c_bitbang/src/main.c
@@ -55,11 +55,11 @@ void send_rgb(struct device *gpio_dev, u32_t rgb)
 
 	for (i = 0; i < 32; i++) {
 		/* MSB goes in first */
-		gpio_pin_write(gpio_dev, GPIO_DATA_PIN, !!(rgb & 0x80000000));
+		gpio_pin_set_raw(gpio_dev, GPIO_DATA_PIN, !!(rgb & 0x80000000));
 
 		/* Latch data into LED */
-		gpio_pin_write(gpio_dev, GPIO_CLK_PIN, 1);
-		gpio_pin_write(gpio_dev, GPIO_CLK_PIN, 0);
+		gpio_pin_set_raw(gpio_dev, GPIO_CLK_PIN, 1);
+		gpio_pin_set_raw(gpio_dev, GPIO_CLK_PIN, 0);
 
 		rgb <<= 1;
 	}
@@ -79,12 +79,12 @@ void main(void)
 	}
 
 	/* Setup GPIO output */
-	ret = gpio_pin_configure(gpio_dev, GPIO_DATA_PIN, (GPIO_DIR_OUT));
+	ret = gpio_pin_configure(gpio_dev, GPIO_DATA_PIN, GPIO_OUTPUT);
 	if (ret) {
 		printk("Error configuring " GPIO_NAME "%d!\n", GPIO_DATA_PIN);
 	}
 
-	ret = gpio_pin_configure(gpio_dev, GPIO_CLK_PIN, (GPIO_DIR_OUT));
+	ret = gpio_pin_configure(gpio_dev, GPIO_CLK_PIN, GPIO_OUTPUT);
 	if (ret) {
 		printk("Error configuring " GPIO_NAME "%d!\n", GPIO_CLK_PIN);
 	}

--- a/samples/drivers/led_apa102c_bitbang/src/main.c
+++ b/samples/drivers/led_apa102c_bitbang/src/main.c
@@ -55,7 +55,7 @@ void send_rgb(struct device *gpio_dev, u32_t rgb)
 
 	for (i = 0; i < 32; i++) {
 		/* MSB goes in first */
-		gpio_pin_set_raw(gpio_dev, GPIO_DATA_PIN, !!(rgb & 0x80000000));
+		gpio_pin_set_raw(gpio_dev, GPIO_DATA_PIN, (rgb & BIT(31)) != 0);
 
 		/* Latch data into LED */
 		gpio_pin_set_raw(gpio_dev, GPIO_CLK_PIN, 1);


### PR DESCRIPTION
Conver to the new GPIO API, using raw access since there is no DT
definitions for this particular usage of the pins.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>