### PR TITLE
dma: configures the support of dma memory to memory mode

### DIFF
--- a/drivers/dma/Kconfig.stm32
+++ b/drivers/dma/Kconfig.stm32
@@ -8,7 +8,6 @@ config DMA_STM32
 	bool "Enable STM32 DMA driver"
 	select DYNAMIC_INTERRUPTS
 	depends on SOC_FAMILY_STM32
-	depends on HEAP_MEM_POOL_SIZE != 0
 	help
 	  DMA driver for STM32 series SoCs.
 

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -11,51 +11,18 @@
  *        implemented in dma_stm32_v*.c
  */
 
-#include "dma_stm32.h"
-
-#define LOG_LEVEL CONFIG_DMA_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(dma_stm32);
-
+#include <soc.h>
+#include <init.h>
+#include <drivers/dma.h>
+#include <drivers/clock_control.h>
 #include <drivers/clock_control/stm32_clock_control.h>
 
-static u32_t table_m_size[] = {
-	LL_DMA_MDATAALIGN_BYTE,
-	LL_DMA_MDATAALIGN_HALFWORD,
-	LL_DMA_MDATAALIGN_WORD,
-};
+#include "dma_stm32.h"
 
-static u32_t table_p_size[] = {
-	LL_DMA_PDATAALIGN_BYTE,
-	LL_DMA_PDATAALIGN_HALFWORD,
-	LL_DMA_PDATAALIGN_WORD,
-};
+#include <logging/log.h>
+LOG_MODULE_REGISTER(dma_stm32, CONFIG_DMA_LOG_LEVEL);
 
-struct dma_stm32_stream {
-	u32_t direction;
-	bool source_periph;
-	bool busy;
-	u32_t src_size;
-	u32_t dst_size;
-	void *callback_arg;
-	void (*dma_callback)(void *arg, u32_t id,
-			     int error_code);
-};
-
-struct dma_stm32_data {
-	int max_streams;
-	struct dma_stm32_stream *streams;
-};
-
-struct dma_stm32_config {
-	struct stm32_pclken pclken;
-	void (*config_irq)(struct device *dev);
-	bool support_m2m;
-	u32_t base;
-};
-
-/* Maximum data sent in single transfer (Bytes) */
-#define DMA_STM32_MAX_DATA_ITEMS		0xffff
+#include <drivers/clock_control/stm32_clock_control.h>
 
 static void dma_stm32_dump_stream_irq(struct device *dev, u32_t id)
 {

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -117,7 +117,7 @@ static void dma_stm32_irq_handler(void *arg)
 	}
 }
 
-static u32_t dma_stm32_width_config(struct dma_config *config,
+static int dma_stm32_width_config(struct dma_config *config,
 				    bool source_periph,
 				    DMA_TypeDef *dma,
 				    LL_DMA_InitTypeDef *DMA_InitStruct,

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -605,14 +605,17 @@ static void dma_stm32_config_irq_0(struct device *dev)
 	IRQ_INIT(0, 4);
 #ifdef DT_INST_0_ST_STM32_DMA_IRQ_5
 	IRQ_INIT(0, 5);
+#ifdef DT_INST_0_ST_STM32_DMA_IRQ_6
 	IRQ_INIT(0, 6);
 #ifdef DT_INST_0_ST_STM32_DMA_IRQ_7
 	IRQ_INIT(0, 7);
-#endif
-#endif
-/* Either 5 or 7 or 8 channels for DMA1 across all stm32 series. */
+#endif /* DT_INST_0_ST_STM32_DMA_IRQ_5 */
+#endif /* DT_INST_0_ST_STM32_DMA_IRQ_6 */
+#endif /* DT_INST_0_ST_STM32_DMA_IRQ_7 */
+/* Either 5 or 6 or 7 or 8 channels for DMA across all stm32 series. */
 }
-#endif
+#endif /* DT_INST_0_ST_STM32_DMA */
+
 
 #ifdef DT_INST_1_ST_STM32_DMA
 DMA_INIT(1);
@@ -621,7 +624,6 @@ static void dma_stm32_config_irq_1(struct device *dev)
 {
 	struct dma_stm32_data *data = dev->driver_data;
 
-#ifdef DT_INST_1_ST_STM32_DMA_IRQ_0
 	IRQ_INIT(1, 0);
 	IRQ_INIT(1, 1);
 	IRQ_INIT(1, 2);
@@ -629,12 +631,13 @@ static void dma_stm32_config_irq_1(struct device *dev)
 	IRQ_INIT(1, 4);
 #ifdef DT_INST_1_ST_STM32_DMA_IRQ_5
 	IRQ_INIT(1, 5);
+#ifdef DT_INST_1_ST_STM32_DMA_IRQ_6
 	IRQ_INIT(1, 6);
 #ifdef DT_INST_1_ST_STM32_DMA_IRQ_7
 	IRQ_INIT(1, 7);
-#endif
-#endif
-#endif
-/* Either 0 or 5 or 7 or 8 channels for DMA1 across all stm32 series. */
+#endif /* DT_INST_1_ST_STM32_DMA_IRQ_5 */
+#endif /* DT_INST_1_ST_STM32_DMA_IRQ_6 */
+#endif /* DT_INST_1_ST_STM32_DMA_IRQ_7 */
+/* Either 5 or 6 or 7 or 8 channels for DMA across all stm32 series. */
 }
-#endif
+#endif /* DT_INST_1_ST_STM32_DMA */

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -257,12 +257,14 @@ static int dma_stm32_configure(struct device *dev, u32_t id,
 		return -EINVAL;
 	}
 
+#ifdef CONFIG_DMA_STM32_V1
 	if ((stream->direction == MEMORY_TO_MEMORY) &&
 		(!dev_config->support_m2m)) {
 		LOG_ERR("Memcopy not supported for device %s",
 			dev->config->name);
 		return -ENOTSUP;
 	}
+#endif /* CONFIG_DMA_STM32_V1 */
 
 	if (config->source_data_size != 4U &&
 	    config->source_data_size != 2U &&

--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -4,8 +4,46 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/dma.h>
-#include <soc.h>
+#ifndef DMA_STM32_H_
+#define DMA_STM32_H_
+
+static u32_t table_m_size[] = {
+	LL_DMA_MDATAALIGN_BYTE,
+	LL_DMA_MDATAALIGN_HALFWORD,
+	LL_DMA_MDATAALIGN_WORD,
+};
+
+static u32_t table_p_size[] = {
+	LL_DMA_PDATAALIGN_BYTE,
+	LL_DMA_PDATAALIGN_HALFWORD,
+	LL_DMA_PDATAALIGN_WORD,
+};
+
+/* Maximum data sent in single transfer (Bytes) */
+#define DMA_STM32_MAX_DATA_ITEMS	0xffff
+
+struct dma_stm32_stream {
+	u32_t direction;
+	bool source_periph;
+	bool busy;
+	u32_t src_size;
+	u32_t dst_size;
+	void *callback_arg;
+	void (*dma_callback)(void *arg, u32_t id,
+			     int error_code);
+};
+
+struct dma_stm32_data {
+	int max_streams;
+	struct dma_stm32_stream *streams;
+};
+
+struct dma_stm32_config {
+	struct stm32_pclken pclken;
+	void (*config_irq)(struct device *dev);
+	bool support_m2m;
+	u32_t base;
+};
 
 extern u32_t table_ll_stream[];
 extern u32_t (*func_ll_is_active_tc[])(DMA_TypeDef *DMAx);
@@ -30,3 +68,5 @@ u32_t stm32_dma_get_fifo_threshold(u16_t fifo_mode_control);
 u32_t stm32_dma_get_mburst(struct dma_config *config, bool source_periph);
 u32_t stm32_dma_get_pburst(struct dma_config *config, bool source_periph);
 #endif
+
+#endif /* DMA_STM32_H_*/

--- a/drivers/dma/dma_stm32_v2.c
+++ b/drivers/dma/dma_stm32_v2.c
@@ -21,8 +21,15 @@ u32_t table_ll_stream[] = {
 	LL_DMA_CHANNEL_3,
 	LL_DMA_CHANNEL_4,
 	LL_DMA_CHANNEL_5,
+#if defined(LL_DMA_CHANNEL_6)
 	LL_DMA_CHANNEL_6,
+#endif /* LL_DMA_CHANNEL_6 */
+#if defined(LL_DMA_CHANNEL_7)
 	LL_DMA_CHANNEL_7,
+#endif /* LL_DMA_CHANNEL_7 */
+#if defined(LL_DMA_CHANNEL_8)
+	LL_DMA_CHANNEL_8,
+#endif
 };
 
 void (*func_ll_clear_ht[])(DMA_TypeDef *DMAx) = {
@@ -31,8 +38,15 @@ void (*func_ll_clear_ht[])(DMA_TypeDef *DMAx) = {
 	LL_DMA_ClearFlag_HT3,
 	LL_DMA_ClearFlag_HT4,
 	LL_DMA_ClearFlag_HT5,
+#if defined(LL_DMA_IFCR_CHTIF6)
 	LL_DMA_ClearFlag_HT6,
+#endif /* LL_DMA_IFCR_CHTIF6 */
+#if defined(LL_DMA_IFCR_CHTIF7)
 	LL_DMA_ClearFlag_HT7,
+#endif /* LL_DMA_IFCR_CHTIF7 */
+#if defined(LL_DMA_IFCR_CHTIF8)
+	LL_DMA_ClearFlag_HT8,
+#endif /* LL_DMA_IFCR_CHTIF8 */
 };
 
 void (*func_ll_clear_tc[])(DMA_TypeDef *DMAx) = {
@@ -41,8 +55,15 @@ void (*func_ll_clear_tc[])(DMA_TypeDef *DMAx) = {
 	LL_DMA_ClearFlag_TC3,
 	LL_DMA_ClearFlag_TC4,
 	LL_DMA_ClearFlag_TC5,
+#if defined(LL_DMA_IFCR_CTCIF6)
 	LL_DMA_ClearFlag_TC6,
+#endif /* LL_DMA_IFCR_CTCIF6 */
+#if defined(LL_DMA_IFCR_CTCIF7)
 	LL_DMA_ClearFlag_TC7,
+#endif /* LL_DMA_IFCR_CTCIF7 */
+#if defined(LL_DMA_IFCR_CTCIF8)
+	LL_DMA_ClearFlag_TC8,
+#endif /* LL_DMA_IFCR_CTCIF8 */
 };
 
 u32_t (*func_ll_is_active_ht[])(DMA_TypeDef *DMAx) = {
@@ -51,8 +72,15 @@ u32_t (*func_ll_is_active_ht[])(DMA_TypeDef *DMAx) = {
 	LL_DMA_IsActiveFlag_HT3,
 	LL_DMA_IsActiveFlag_HT4,
 	LL_DMA_IsActiveFlag_HT5,
+#if defined(LL_DMA_ISR_HTIF6)
 	LL_DMA_IsActiveFlag_HT6,
+#endif /* LL_DMA_ISR_HTIF6 */
+#if defined(LL_DMA_ISR_HTIF7)
 	LL_DMA_IsActiveFlag_HT7,
+#endif /* LL_DMA_ISR_HTIF7 */
+#if defined(LL_DMA_ISR_HTIF8)
+	LL_DMA_IsActiveFlag_HT8,
+#endif /* LL_DMA_ISR_HTIF8 */
 };
 
 u32_t (*func_ll_is_active_tc[])(DMA_TypeDef *DMAx) = {
@@ -61,8 +89,15 @@ u32_t (*func_ll_is_active_tc[])(DMA_TypeDef *DMAx) = {
 	LL_DMA_IsActiveFlag_TC3,
 	LL_DMA_IsActiveFlag_TC4,
 	LL_DMA_IsActiveFlag_TC5,
+#if defined(LL_DMA_ISR_TCIF6)
 	LL_DMA_IsActiveFlag_TC6,
+#endif /* LL_DMA_ISR_TCIF6 */
+#if defined(LL_DMA_ISR_TCIF7)
 	LL_DMA_IsActiveFlag_TC7,
+#endif /* LL_DMA_ISR_TCIF7 */
+#if defined(LL_DMA_ISR_TCIF8)
+	LL_DMA_IsActiveFlag_TC8,
+#endif /* LL_DMA_ISR_TCIF8 */
 };
 
 static void (*func_ll_clear_te[])(DMA_TypeDef *DMAx) = {
@@ -71,8 +106,15 @@ static void (*func_ll_clear_te[])(DMA_TypeDef *DMAx) = {
 	LL_DMA_ClearFlag_TE3,
 	LL_DMA_ClearFlag_TE4,
 	LL_DMA_ClearFlag_TE5,
+#if defined(LL_DMA_IFCR_CTEIF6)
 	LL_DMA_ClearFlag_TE6,
+#endif /* LL_DMA_IFCR_CTEIF6 */
+#if defined(LL_DMA_IFCR_CTEIF7)
 	LL_DMA_ClearFlag_TE7,
+#endif /* LL_DMA_IFCR_CTEIF7 */
+#if defined(LL_DMA_IFCR_CTEIF8)
+	LL_DMA_ClearFlag_TE8,
+#endif /* LL_DMA_IFCR_CTEIF8 */
 };
 
 static void (*func_ll_clear_gi[])(DMA_TypeDef *DMAx) = {
@@ -81,8 +123,15 @@ static void (*func_ll_clear_gi[])(DMA_TypeDef *DMAx) = {
 	LL_DMA_ClearFlag_GI3,
 	LL_DMA_ClearFlag_GI4,
 	LL_DMA_ClearFlag_GI5,
+#if defined(LL_DMA_IFCR_CGIF6)
 	LL_DMA_ClearFlag_GI6,
+#endif /* LL_DMA_IFCR_CGIF6 */
+#if defined(LL_DMA_IFCR_CGIF7)
 	LL_DMA_ClearFlag_GI7,
+#endif /* LL_DMA_IFCR_CGIF7 */
+#if defined(LL_DMA_IFCR_CGIF8)
+	LL_DMA_ClearFlag_GI8,
+#endif /* LL_DMA_IFCR_CGIF8 */
 };
 
 static u32_t (*func_ll_is_active_te[])(DMA_TypeDef *DMAx) = {
@@ -91,8 +140,15 @@ static u32_t (*func_ll_is_active_te[])(DMA_TypeDef *DMAx) = {
 	LL_DMA_IsActiveFlag_TE3,
 	LL_DMA_IsActiveFlag_TE4,
 	LL_DMA_IsActiveFlag_TE5,
+#if defined(LL_DMA_IFCR_CTEIF6)
 	LL_DMA_IsActiveFlag_TE6,
+#endif /* LL_DMA_IFCR_CTEIF6 */
+#if defined(LL_DMA_IFCR_CTEIF7)
 	LL_DMA_IsActiveFlag_TE7,
+#endif /* LL_DMA_IFCR_CTEIF7 */
+#if defined(LL_DMA_IFCR_CTEIF8)
+	LL_DMA_IsActiveFlag_TE8,
+#endif /* LL_DMA_IFCR_CTEIF8 */
 };
 
 
@@ -102,8 +158,16 @@ static u32_t (*func_ll_is_active_gi[])(DMA_TypeDef *DMAx) = {
 	LL_DMA_IsActiveFlag_GI3,
 	LL_DMA_IsActiveFlag_GI4,
 	LL_DMA_IsActiveFlag_GI5,
+#if defined(LL_DMA_IFCR_CGIF6)
 	LL_DMA_IsActiveFlag_GI6,
+#endif /* LL_DMA_IFCR_CGIF6 */
+#if defined(LL_DMA_IFCR_CGIF7)
 	LL_DMA_IsActiveFlag_GI7,
+#endif /* LL_DMA_IFCR_CGIF7 */
+#if defined(LL_DMA_IFCR_CGIF8)
+	LL_DMA_IsActiveFlag_GI8,
+#endif /* LL_DMA_IFCR_CGIF8 */
+
 };
 
 void stm32_dma_dump_stream_irq(DMA_TypeDef *dma, u32_t id)

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -317,7 +317,6 @@
 			reg = <0x40020000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x1>;
 			interrupts = <9 0 10 0 10 0 11 0 11 0>;
-			st,mem2mem;
 			status = "disabled";
 			label = "DMA_1";
 		};

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -265,7 +265,6 @@
 			reg = <0x40020000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x1>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0>;
-			st,mem2mem;
 			status = "disabled";
 			label = "DMA_1";
 		};

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -322,7 +322,6 @@
 			reg = <0x40020000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x1>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0>;
-			st,mem2mem;
 			status = "disabled";
 			label = "DMA_1";
 		};

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -186,7 +186,6 @@
 			reg = <0x40020000 0x400>;
 			interrupts = <9 0 10 0 10 0 11 0 11 0 11 0 11 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x1>;
-			st,mem2mem;
 			status = "disabled";
 			label = "DMA_1";
 		};

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -316,7 +316,6 @@
 			reg = <0x40020000 0x400>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x1>;
-			st,mem2mem;
 			status = "disabled";
 			label = "DMA_1";
 		};
@@ -327,7 +326,6 @@
 			reg = <0x40020400 0x400>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0 68 0 69 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x2>;
-			st,mem2mem;
 			status = "disabled";
 			label = "DMA_2";
 		};

--- a/dts/bindings/dma/st,stm32-dma.yaml
+++ b/dts/bindings/dma/st,stm32-dma.yaml
@@ -24,6 +24,11 @@ properties:
 # Parameter syntax of stm32 follows the dma client dts syntax
 # in the Linux kernel declared in
 # https://git.kernel.org/pub/scm/linux/kernel/git/devicetree/devicetree-rebasing.git/plain/Bindings/dma/stm32-dma.txt
+#
+# channel: DMA channel
+# slot: DMA stream of the DMA channel for DMA V1 or for DMA V2 with MUX peripheral request else NA
+# channel-config: configuration of the selected DMA channel
+# features: fifo threshold if relevant for DMA V1 or TBD for DMA V2
 
 dma-cells:
   - channel

--- a/dts/bindings/dma/st,stm32-dma.yaml
+++ b/dts/bindings/dma/st,stm32-dma.yaml
@@ -16,7 +16,7 @@ properties:
 
     st,mem2mem:
       type: boolean
-      description: If the controller supports memory to memory transfer
+      description: If the DMA controller V1 supports memory to memory transfer
 
     "#dma-cells":
       const: 4

--- a/include/dt-bindings/dma/stm32_dma.h
+++ b/include/dt-bindings/dma/stm32_dma.h
@@ -4,8 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 /* macros for channel-config */
+#define STM32_DMA_CONFIG_DIRECTION(config)		(config & 0x3 << 6)
 #define STM32_DMA_CONFIG_PERIPH_ADDR_INC(config)	(config & 0x1 << 9)
 #define STM32_DMA_CONFIG_MEM_ADDR_INC(config)		(config & 0x1 << 10)
+#define STM32_DMA_CONFIG_PERIPH_DATA_SIZE(config)	(config & (0x3 << 11))
+#define STM32_DMA_CONFIG_MEM_DATA_SIZE(config)		(config & (0x3 << 13))
 #define STM32_DMA_CONFIG_PERIPH_INC_FIXED(config)	(config & 0x1 << 15)
 #define STM32_DMA_CONFIG_PRIORITY(config)		((config >> 16) & 0x3)
 

--- a/soc/arm/st_stm32/common/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/common/Kconfig.defconfig.series
@@ -113,6 +113,9 @@ if DMA
 config DMA_STM32
 	default y
 
+config HEAP_MEM_POOL_SIZE
+	default 1024
+
 endif # DMA
 
 endif # SOC_FAMILY_STM32


### PR DESCRIPTION
Refine the #20824 dma mem-to-mem transfer operations on STM32WB series.
Tested on nucleo_wb55rg with dma tests loop_transfer and chan_blen_transfer.

This PR prepares  the introduction of the dmamux for stm32 soc series #22021

Signed-off-by: Francois Ramu <francois.ramu@st.com>