### PR TITLE
[TOPIC-GPIO] usb: convert VBUS control to new GPIO API

### DIFF
--- a/dts/bindings/usb/usb-controller.yaml
+++ b/dts/bindings/usb/usb-controller.yaml
@@ -22,3 +22,8 @@ properties:
 
     label:
       required: true
+
+    vbus-gpios:
+      type: phandle-array
+      required: false
+      description: Control VBUS via GPIO pin.

--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -105,30 +105,6 @@ config USB_MAX_POWER
 	  Set bMaxPower value in the Standard Configuration Descriptor,
 	  the result is 2mA times the value provided.
 
-menuconfig USB_VBUS_GPIO
-	bool "Control VBUS via GPIO pin"
-	depends on GPIO
-	help
-	  The USB VBUS signal is connected via a GPIO pin.
-
-if USB_VBUS_GPIO
-
-config USB_VBUS_GPIO_DEV_NAME
-	string "GPIO Device"
-	default "GPIO_0"
-	help
-	  The device name of the GPIO device to which the USB_VBUS_EN signal is
-	  connected.
-
-config USB_VBUS_GPIO_PIN_NUM
-	int "GPIO pin number"
-	default 0
-	help
-	  The number of the GPIO pin to which the USB_VBUS_EN signal is
-	  connected.
-
-endif # USB_VBUS_GPIO
-
 source "subsys/usb/class/Kconfig"
 
 endif # USB_DEVICE_STACK

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -61,9 +61,7 @@
 #include <sys/util.h>
 #include <sys/__assert.h>
 #include <init.h>
-#if defined(CONFIG_USB_VBUS_GPIO)
 #include <drivers/gpio.h>
-#endif
 #include <sys/byteorder.h>
 #include <usb/usb_device.h>
 #include <usb/usbstruct.h>
@@ -994,26 +992,27 @@ static void forward_status_cb(enum usb_dc_status_code status, const u8_t *param)
  */
 static int usb_vbus_set(bool on)
 {
-#if defined(CONFIG_USB_VBUS_GPIO)
+#ifdef DT_ALIAS_USBD_0_VBUS_GPIOS_CONTROLLER
 	int ret = 0;
 	struct device *gpio_dev;
 
-	gpio_dev = device_get_binding(CONFIG_USB_VBUS_GPIO_DEV_NAME);
+	gpio_dev = device_get_binding(DT_ALIAS_USBD_0_VBUS_GPIOS_CONTROLLER);
 	if (!gpio_dev) {
 		LOG_DBG("USB requires GPIO. Cannot find %s!",
-			CONFIG_USB_VBUS_GPIO_DEV_NAME);
+			DT_ALIAS_USBD_0_VBUS_GPIOS_CONTROLLER);
 		return -ENODEV;
 	}
 
 	/* Enable USB IO */
-	ret = gpio_pin_configure(gpio_dev, CONFIG_USB_VBUS_GPIO_PIN_NUM,
-				 GPIO_DIR_OUT);
+	ret = gpio_pin_configure(gpio_dev, DT_ALIAS_USBD_0_VBUS_GPIOS_PIN,
+				 GPIO_OUTPUT |
+				 DT_ALIAS_USBD_0_VBUS_GPIOS_FLAGS);
 	if (ret) {
 		return ret;
 	}
 
-	ret = gpio_pin_write(gpio_dev, CONFIG_USB_VBUS_GPIO_PIN_NUM,
-			     on == true ? 1 : 0);
+	ret = gpio_pin_set(gpio_dev, DT_ALIAS_USBD_0_VBUS_GPIOS_PIN,
+			   on == true ? 1 : 0);
 	if (ret) {
 		return ret;
 	}


### PR DESCRIPTION
Use DT for VBUS control and convert it to new GPIO API.