### PR TITLE
[TOPIC-GPIO] drivers: sensor: bma280: convert to new GPIO API

### DIFF
--- a/drivers/sensor/bma280/bma280.h
+++ b/drivers/sensor/bma280/bma280.h
@@ -121,6 +121,7 @@ struct bma280_data {
 	s8_t temp_sample;
 
 #ifdef CONFIG_BMA280_TRIGGER
+	struct device *dev;
 	struct device *gpio;
 	struct gpio_callback gpio_cb;
 
@@ -136,7 +137,6 @@ struct bma280_data {
 	struct k_sem gpio_sem;
 #elif defined(CONFIG_BMA280_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;
-	struct device *dev;
 #endif
 
 #endif /* CONFIG_BMA280_TRIGGER */


### PR DESCRIPTION
Use the new pin and interrupt configuration API.
    
NOTE: Because hardware is not available this has been build-tested only.

~NOTE: This PR includes #22103 along with a dummy sample used for testing.  The only commit that should be merged is the one titled: "drivers: sensor: bma280: convert to new GPIO API".  The PR will be marked DNM until the topic branch is rebased on a master that includes #22103.~