### PR TITLE
soc: psoc6: kconfig: Do not select CPU_CORTEX_M_HAS_DWT on Cortex-M0

### DIFF
--- a/soc/arm/cypress/Kconfig
+++ b/soc/arm/cypress/Kconfig
@@ -8,11 +8,14 @@ choice
 config SOC_PSOC6_M0
 	bool "SOC_PSOC6_M0"
 	select CPU_CORTEX_M0PLUS
+	select CPU_CORTEX_M_HAS_SYSTICK
 	select CPU_CORTEX_M_HAS_VTOR
 
 config SOC_PSOC6_M4
 	bool "SOC_PSOC6_M4"
 	select CPU_CORTEX_M4
+	select CPU_CORTEX_M_HAS_DWT
+	select CPU_CORTEX_M_HAS_SYSTICK
 
 endchoice
 

--- a/soc/arm/cypress/psoc6/Kconfig.series
+++ b/soc/arm/cypress/psoc6/Kconfig.series
@@ -6,8 +6,6 @@
 config SOC_SERIES_PSOC62
 	bool "Cypress PSoC6 series MCU"
 	select SOC_FAMILY_PSOC6
-	select CPU_CORTEX_M_HAS_SYSTICK
-	select CPU_CORTEX_M_HAS_DWT
 	select HAS_CYPRESS_DRIVERS
 	help
 	  Enable support for Cypress PSoC6 MCU series


### PR DESCRIPTION
CPU_CORTEX_M_HAS_DWT depends on

    !CPU_CORTEX_M0 && !CPU_CORTEX_M0PLUS

, but SOC_SERIES_PSOC62 unconditionally selects it, even for
SOC_PSOC6_M0. This forces CPU_CORTEX_M_HAS_DWT on on Cortex-M0.

Fix it by moving the selects for CPU capabilities to the more specific
SOC_PSOC6_{M0,M4} symbols. This seems more readable than adding a
condition to the 'select CPU_CORTEX_M_HAS_DWT'.