### PR TITLE
console: kconfig: Have CONSOLE_{GETCHAR,GETLINE} depend on UART_CONSOLE

### DIFF
--- a/subsys/console/Kconfig
+++ b/subsys/console/Kconfig
@@ -11,6 +11,7 @@ if CONSOLE_SUBSYS
 choice
 	prompt "Console 'get' function selection"
 	optional
+	depends on UART_CONSOLE
 
 config CONSOLE_GETCHAR
 	bool "Character by character input and output"


### PR DESCRIPTION
CONSOLE_GETCHAR and CONSOLE_GETLINE select CONSOLE_HANDLER and
UART_CONSOLE_DEBUG_SERVER_HOOKS, which depend on UART_CONSOLE, but
UART_CONSOLE is n for some boards, giving a select with unsatisfied
dependencies and a warning. Triggers in CI.

Looking at the code, CONSOLE_{GETCHAR,GETLINE} also depend on
UART_CONSOLE there. Add a 'depends on UART_CONSOLE' to the 'choice' that
contains them.

Maybe the samples/subsys/console/{echo,getchar}/ samples shouldn't be
run on some boards that they're currently run on, but there's still the
issue that CONSOLE_{GETCHAR,GETLINE} shouldn't be shown in menuconfig
when they don't apply.