### PR TITLE
[TOPIC-GPIO] drivers: sensor: bmg160: convert to new GPIO API

### DIFF
--- a/drivers/sensor/bmg160/bmg160.c
+++ b/drivers/sensor/bmg160/bmg160.c
@@ -332,8 +332,9 @@ const struct bmg160_device_config bmg160_config = {
 	.i2c_addr = DT_INST_0_BOSCH_BMG160_BASE_ADDRESS,
 	.i2c_speed = BMG160_BUS_SPEED,
 #ifdef CONFIG_BMG160_TRIGGER
-	.gpio_port = DT_INST_0_BOSCH_BMG160_INT_GPIOS_CONTROLLER,
 	.int_pin = DT_INST_0_BOSCH_BMG160_INT_GPIOS_PIN,
+	.int_flags = DT_INST_0_BOSCH_BMG160_INT_GPIOS_FLAGS,
+	.gpio_port = DT_INST_0_BOSCH_BMG160_INT_GPIOS_CONTROLLER,
 #endif
 };
 

--- a/drivers/sensor/bmg160/bmg160.h
+++ b/drivers/sensor/bmg160/bmg160.h
@@ -179,13 +179,12 @@
 
 struct bmg160_device_config {
 	const char *i2c_port;
-#ifdef CONFIG_BMG160_TRIGGER
-	const char *gpio_port;
-#endif
 	u16_t i2c_addr;
 	u8_t i2c_speed;
 #ifdef CONFIG_BMG160_TRIGGER
-	u8_t int_pin;
+	gpio_pin_t int_pin;
+	gpio_devicetree_flags_t int_flags;
+	const char *gpio_port;
 #endif
 };
 


### PR DESCRIPTION
Use the new pin and interrupt configuration API.

NOTE: Because hardware is not available this has been build-tested only.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>