### PR TITLE
[TOPIC-GPIO] drivers: sensor: sx9500: convert to new GPIO API

### DIFF
--- a/drivers/sensor/sx9500/sx9500_trigger.c
+++ b/drivers/sensor/sx9500/sx9500_trigger.c
@@ -165,15 +165,15 @@ int sx9500_setup_interrupt(struct device *dev)
 	}
 
 	gpio_pin_configure(gpio, DT_INST_0_SEMTECH_SX9500_INT_GPIOS_PIN,
-			   GPIO_DIR_IN | GPIO_INT | GPIO_INT_EDGE |
-			   GPIO_INT_ACTIVE_LOW | GPIO_INT_DEBOUNCE);
+			   GPIO_INPUT | DT_INST_0_SEMTECH_SX9500_INT_GPIOS_FLAGS);
 
 	gpio_init_callback(&data->gpio_cb,
 			   sx9500_gpio_cb,
 			   BIT(DT_INST_0_SEMTECH_SX9500_INT_GPIOS_PIN));
 
 	gpio_add_callback(gpio, &data->gpio_cb);
-	gpio_pin_enable_callback(gpio, DT_INST_0_SEMTECH_SX9500_INT_GPIOS_PIN);
+	gpio_pin_interrupt_configure(gpio, DT_INST_0_SEMTECH_SX9500_INT_GPIOS_PIN,
+				     GPIO_INT_EDGE_TO_ACTIVE);
 
 #ifdef CONFIG_SX9500_TRIGGER_OWN_THREAD
 	k_thread_create(&sx9500_thread, sx9500_thread_stack,

--- a/dts/bindings/sensor/semtech,sx9500.yaml
+++ b/dts/bindings/sensor/semtech,sx9500.yaml
@@ -13,3 +13,6 @@ properties:
     int-gpios:
       type: phandle-array
       required: false
+      description: |
+        Connection for the NIRQ signal.  This signal is active-low when
+        produced by the sensor.

--- a/samples/sensor/sx9500/boards/frdm_k64f.overlay
+++ b/samples/sensor/sx9500/boards/frdm_k64f.overlay
@@ -8,7 +8,7 @@
 	sx9500@28 {
 		compatible = "semtech,sx9500";
 		reg = <0x28>;
-		int-gpios = <&gpioc 6 0>;
+		int-gpios = <&gpioc 6 GPIO_ACTIVE_LOW>;
 		label = "SX9500";
 	};
 };


### PR DESCRIPTION
Use the new pin and interrupt configuration API.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>