### PR TITLE
console: kconfig: Have CONSOLE_HANDLER dep. on SERIAL_SUPPORT_INTERRUPT

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -38,7 +38,7 @@ config CONSOLE_HAS_DRIVER
 
 config CONSOLE_HANDLER
 	bool "Enable console input handler"
-	depends on UART_CONSOLE
+	depends on UART_CONSOLE && SERIAL_SUPPORT_INTERRUPT
 	select UART_INTERRUPT_DRIVEN
 	help
 	  This option enables console input handler allowing to write simple


### PR DESCRIPTION
CONSOLE_HANDLER was unconditionally selecting UART_INTERRUPT_DRIVEN (and
depends on it in the code), but UART_INTERRUPT_DRIVEN depends on
SERIAL && SERIAL_SUPPORT_INTERRUPT.

Add a SERIAL_SUPPORT_INTERRUPT dependency to CONSOLE_HANDLER.
CONSOLE_HANDLER already depends on UART_CONSOLE, which depends on
SERIAL, so a SERIAL dependency does not need to be added.

This avoids some selects with unsatisfied dependencies in CI.