### PR TITLE
scripts: runners: fix invalid syntax

### DIFF
--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -83,7 +83,7 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
             return board_snr
         elif not sys.stdin.isatty():
             raise RuntimeError(
-                f'refusing to guess which of {len(snrs)} '
+                'refusing to guess which of {len(snrs)} '
                 'connected boards to use. (Interactive prompts '
                 'disabled since standard input is not a terminal.) '
                 'Please specify a serial number on the command line.')


### PR DESCRIPTION
Fix "SyntaxError: invalid syntax" introduced as regression in
commit e4768ad7e760 ("scripts: runners: nrfjprog: restrict when
we guess snr") as show below.

File "zephyr/scripts/west_commands/runners/nrfjprog.py", line 86
    f'refusing to guess which of {len(snrs)} '

Signed-off-by: Lianwei Wang <lianwei.wang@gm.com>