### PR TITLE
driver: uart: ns16550: Simplify drv_cmd function

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -793,20 +793,14 @@ static int uart_ns16550_line_ctrl_set(struct device *dev,
  */
 static int uart_ns16550_drv_cmd(struct device *dev, u32_t cmd, u32_t p)
 {
-	struct uart_ns16550_dev_data_t * const dev_data = DEV_DATA(dev);
-
-	ARG_UNUSED(dev_data);
-
-	switch (cmd) {
-
 #ifdef UART_NS16550_DLF_ENABLED
-	case CMD_SET_DLF:
+	if (cmd == CMD_SET_DLF) {
+		struct uart_ns16550_dev_data_t * const dev_data = DEV_DATA(dev);
 		dev_data->dlf = p;
 		OUTBYTE(DLF(dev), dev_data->dlf);
 		return 0;
-#endif
-
 	}
+#endif
 
 	return -ENOTSUP;
 }


### PR DESCRIPTION
There is only one possible command, so just use if instead of switch
to avoid several MISRA-C violations and also avoid set dev_data wrongly
unused when UART_NS16550_DLF_ENABLED is defined.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>