### PR TITLE
sanitycheck: change distribution of tests per set

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -3154,7 +3154,7 @@ class TestSuite:
                           "rom_size"]
             cw = csv.DictWriter(csvfile, fieldnames, lineterminator=os.linesep)
             cw.writeheader()
-            for instance in sorted(self.instances.values()):
+            for instance in self.instances.values():
                 rowdict = {"test": instance.testcase.name,
                            "arch": instance.platform.arch,
                            "platform": instance.platform.name,
@@ -3812,23 +3812,6 @@ def export_tests(filename, tests):
                 logger.info("{} can't be exported".format(test))
 
 
-def native_and_unit_first(a, b):
-    if a[0].startswith('unit_testing'):
-        return -1
-    if b[0].startswith('unit_testing'):
-        return 1
-    if a[0].startswith('native_posix'):
-        return -1
-    if b[0].startswith('native_posix'):
-        return 1
-    if a[0].split("/", 1)[0].endswith("_bsim"):
-        return -1
-    if b[0].split("/", 1)[0].endswith("_bsim"):
-        return 1
-
-    return (a > b) - (a < b)
-
-
 class HardwareMap:
 
     schema_path = os.path.join(ZEPHYR_BASE, "scripts", "sanity_chk", "hwmap-schema.yaml")
@@ -4278,8 +4261,9 @@ def main():
         return
 
     if options.subset:
-        # suite.instances = OrderedDict(sorted(suite.instances.items(),
-        #                    key=cmp_to_key(native_and_unit_first)))
+        suite.instances = OrderedDict(sorted(suite.instances.items(),
+                            key=lambda x: x[0][x[0].find("/") + 1:]))
+
         subset, sets = options.subset.split("/")
         total = len(suite.instances)
         per_set = round(total / int(sets))


### PR DESCRIPTION
Sort by testcase name and path and not by platforms. This way we do not
have the same platform executing on CI system causing failures to
overload.