### PR TITLE
soc: arm: nordic_nrf: Add reset reason handling library

### DIFF
--- a/soc/arm/nordic_nrf/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/CMakeLists.txt
@@ -4,4 +4,5 @@ add_subdirectory(${SOC_SERIES})
 
 zephyr_sources(
   validate_base_addresses.c
+  nrf_reset_reason.c
   )

--- a/soc/arm/nordic_nrf/nrf51/soc.c
+++ b/soc/arm/nordic_nrf/nrf51/soc.c
@@ -18,6 +18,7 @@
 #include <hal/nrf_power.h>
 #include <soc/nrfx_coredep.h>
 #include <logging/log.h>
+#include <../soc/arm/nordic_nrf/nrf_reset_reason.h>
 
 #ifdef CONFIG_RUNTIME_NMI
 extern void z_arm_nmi_init(void);
@@ -52,6 +53,9 @@ static int nordicsemi_nrf51_init(struct device *arg)
 	NMI_INIT();
 
 	irq_unlock(key);
+
+	/* Read to ensure that reset reason is cleared. */
+	(void)nrf_reset_reason_get();
 
 	return 0;
 }

--- a/soc/arm/nordic_nrf/nrf52/soc.c
+++ b/soc/arm/nordic_nrf/nrf52/soc.c
@@ -17,6 +17,7 @@
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 #include <hal/nrf_power.h>
 #include <soc/nrfx_coredep.h>
+#include <../soc/arm/nordic_nrf/nrf_reset_reason.h>
 #include <logging/log.h>
 
 #ifdef CONFIG_RUNTIME_NMI
@@ -74,6 +75,9 @@ static int nordicsemi_nrf52_init(struct device *arg)
 	NMI_INIT();
 
 	irq_unlock(key);
+
+	/* Read to ensure that reset reason is cleared. */
+	(void)nrf_reset_reason_get();
 
 	return 0;
 }

--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -16,6 +16,7 @@
 #include <init.h>
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 #include <soc/nrfx_coredep.h>
+#include <../soc/arm/nordic_nrf/nrf_reset_reason.h>
 #include <logging/log.h>
 
 #ifdef CONFIG_RUNTIME_NMI
@@ -82,6 +83,9 @@ static int nordicsemi_nrf53_init(struct device *arg)
 	NMI_INIT();
 
 	irq_unlock(key);
+
+	/* Read to ensure that reset reason is cleared. */
+	(void)nrf_reset_reason_get();
 
 	return 0;
 }

--- a/soc/arm/nordic_nrf/nrf91/soc.c
+++ b/soc/arm/nordic_nrf/nrf91/soc.c
@@ -16,6 +16,7 @@
 #include <init.h>
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 #include <soc/nrfx_coredep.h>
+#include <../soc/arm/nordic_nrf/nrf_reset_reason.h>
 #include <logging/log.h>
 
 #ifdef CONFIG_RUNTIME_NMI
@@ -53,6 +54,9 @@ static int nordicsemi_nrf91_init(struct device *arg)
 	NMI_INIT();
 
 	irq_unlock(key);
+
+	/* Read to ensure that reset reason is cleared. */
+	(void)nrf_reset_reason_get();
 
 	return 0;
 }

--- a/soc/arm/nordic_nrf/nrf_reset_reason.c
+++ b/soc/arm/nordic_nrf/nrf_reset_reason.c
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <hal/nrf_power.h>
+#if NRF_POWER_HAS_RESETREAS == 0
+#include <hal/nrf_reset.h>
+#endif
+
+#if (NRF_POWER_HAS_RESETREAS == 0)
+#if CONFIG_SOC_NRF5340_CPUAPP || CONFIG_SOC_NRF5340_CPUNET
+#define NET_RESET_REASON_MASK \
+	(NRF_RESET_RESETREAS_LSREQ_MASK | NRF_RESET_RESETREAS_LLOCKUP_MASK | \
+	NRF_RESET_RESETREAS_LDOG_MASK | NRF_RESET_RESETREAS_MFORCEOFF_MASK | \
+	NRF_RESET_RESETREAS_LCTRLAP_MASK)
+#else
+#error "Unsupported SoC"
+#endif
+#endif
+
+#define RESET_REASON_INVALID 0xFFFFFFFF
+
+static u32_t reset_reason = RESET_REASON_INVALID;
+
+static u32_t reset_reason_get(void)
+{
+#if NRF_POWER_HAS_RESETREAS
+	return nrf_power_resetreas_get(NRF_POWER);
+#else
+	u32_t reason = nrf_reset_resetreas_get(NRF_RESET);
+	u32_t mask = IS_ENABLED(CONFIG_SOC_NRF5340_CPUNET) ?
+			NET_RESET_REASON_MASK : ~NET_RESET_REASON_MASK;
+	return reason & mask;
+#endif
+}
+
+static void reset_reason_clear(u32_t reason)
+{
+#if NRF_POWER_HAS_RESETREAS
+	nrf_power_resetreas_clear(NRF_POWER, reason);
+#else
+	nrf_reset_resetreas_clear(NRF_RESET, reason);
+#endif
+}
+
+static void reset_reason_init(void)
+{
+	/* Check if reset reason is already done. */
+	if (reset_reason != RESET_REASON_INVALID) {
+		return;
+	}
+
+	reset_reason = reset_reason_get();
+	if (!IS_ENABLED(CONFIG_IS_BOOTLOADER)) {
+		/* If in bootloader do not clear to allow application
+		 * to read it.
+		 */
+		reset_reason_clear(reset_reason);
+	}
+}
+
+u32_t nrf_reset_reason_get(void)
+{
+	reset_reason_init();
+	return reset_reason;
+}
+
+/** @brief Return primary reset reason.
+ *
+ * @return lowest bit set from reset reason mask.
+ */
+u32_t nrf_reset_reason_primary_get(void)
+{
+	return BIT(__builtin_ctz(nrf_reset_reason_get()));
+}
+
+const char * nrf_reset_reason_get_name(u32_t reason)
+{
+	__ASSERT(__builtin_popcount(reason) > 1, "0 or single bit set only.");
+
+	switch(reason) {
+#if NRF_POWER_HAS_RESETREAS
+		case NRF_POWER_RESETREAS_RESETPIN_MASK:
+			return "reset pin";
+		case NRF_POWER_RESETREAS_DOG_MASK:
+			return "watchdog";
+		case NRF_POWER_RESETREAS_SREQ_MASK:
+			return "soft";
+		case NRF_POWER_RESETREAS_LOCKUP_MASK:
+			return "lockup";
+		case NRF_POWER_RESETREAS_OFF_MASK:
+			return "gpio";
+#if defined(POWER_RESETREAS_LPCOMP_Msk)
+		case NRF_POWER_RESETREAS_LPCOMP_MASK:
+			return "lpcomp";
+#endif
+		case NRF_POWER_RESETREAS_DIF_MASK:
+			return "debug";
+#if defined(POWER_RESETREAS_NFC_Msk)
+		case NRF_POWER_RESETREAS_NFC_MASK:
+			return "nfc";
+#endif
+#if defined(POWER_RESETREAS_VBUS_Msk)
+		case NRF_POWER_RESETREAS_VBUS_MASK:
+			return "vbus";
+#endif
+#else /* NRF_POWER_HAS_RESETREAS */
+#if CONFIG_SOC_NRF5340_CPUAPP
+		case NRF_RESET_RESETREAS_RESETPIN_MASK:
+			return "reset pin";
+		case NRF_RESET_RESETREAS_DOG0_MASK:
+			return "watchdog0";
+		case NRF_RESET_RESETREAS_CTRLAP_MASK:
+			return "ctrl-ap";
+		case NRF_RESET_RESETREAS_SREQ_MASK:
+			return "soft";
+		case NRF_RESET_RESETREAS_LOCKUP_MASK:
+			return "lockup";
+		case NRF_RESET_RESETREAS_OFF_MASK:
+			return "gpio";
+		case NRF_RESET_RESETREAS_LPCOMP_MASK:
+			return "lpcomp";
+		case NRF_RESET_RESETREAS_DIF_MASK:
+			return "debug";
+		case NRF_RESET_RESETREAS_NFC_MASK:
+			return "nfc";
+		case NRF_RESET_RESETREAS_DOG1_MASK:
+			return "watchdog1";
+		case NRF_RESET_RESETREAS_VBUS_MASK:
+			return "vbus";
+#elif CONFIG_SOC_NRF5340_CPUNET
+		case NRF_RESET_RESETREAS_LSREQ_MASK:
+			return "soft";
+    		case NRF_RESET_RESETREAS_LLOCKUP_MASK:
+		    	return "lockup";
+    		case NRF_RESET_RESETREAS_LDOG_MASK:
+		    	return "watchdog";
+    		case NRF_RESET_RESETREAS_MFORCEOFF_MASK:
+		    	return "force off";
+    		case NRF_RESET_RESETREAS_LCTRLAP_MASK:
+		    	return "ctrl-ap";
+#else
+#error "Unsupported SoC"
+#endif
+#endif /* NRF_POWER_HAS_RESETREAS */
+		default:
+			return "power on";
+	}
+}

--- a/soc/arm/nordic_nrf/nrf_reset_reason.h
+++ b/soc/arm/nordic_nrf/nrf_reset_reason.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef NRF_RESET_REASON_H_
+#define NRF_RESET_REASON_H_
+
+#include <zephyr/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Return mask with reset reasons.
+ *
+ * On first attempt it clears hardware register.
+ *
+ * Normally, there should be only one reset reason present in the mask. If
+ * there is more than one then it means that reset occured while being in
+ * bootloader since bootloader does not clean reset reason. For example
+ * pin reset occured while bootloader was about to start application after
+ * waking up from system off (e.g. due to pin wakeup). Reset reasons are usually
+ * ordered in "importance".
+ *
+ * @return Reset reasons mask, 0 if power-on reset.
+ */
+u32_t nrf_reset_reason_get(void);
+
+/** @brief Get primary reset reason.
+ *
+ * If multiple reset reasons are set then the one with lowest bit mask is
+ * returned.
+ *
+ * @return Bit mask with one bit set.
+ */
+u32_t nrf_reset_reason_primary_get(void);
+
+/** @brief Get reset reason name.
+ *
+ * @param reason Reason bit mask. It should contain only one bit set.
+ *
+ * @return Name.
+ */
+const char * nrf_reset_reason_get_name(u32_t reason);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NRF_RESET_REASON_H_ */


### PR DESCRIPTION
Added module for handling reset reason. It reads out hardware register
and clears it. Actual reset reason can be retrieved using
nrf_reset_reason API.

I've put include file in`soc/arm/nordic_nrf` since there is no `include\soc` so far (should be?). Maybe it's intentional to keep `soc` includes away from main include folder.

General idea: read reset reason once and clear register, users can access reset reason through api.

Special cases
- nrf53. it seems (i did not test it) that `NRF_RESET->RESETREAS` contains application only reason for application and application+network on network. Because of that on network core reasons are being masked to only read/clear network specific reasons
- bootloader: it does not clear reset reason since it's likely that application expects reset reasons (e.g. gpio, nfc wakeup, pin reset, et.c). Bootloader reads them but do not clear them as it also may need to use it (e.g. skip hash checking on gpio wakeup). Because of that it may happen that there will be 2 reset reasons set (e.g. wakeup from gpio, before it is cleared pin reset occurs). In order to avoid confusion user can use `nrf_reset_reason_primary_get()` to get only one bit set, the most LSB bit assuming that they are ordered by "relevance" in the register. In case watchdog reset occurs in bootloader, application will start with primary reset reason being `watchdog` which might be confusing but it is a result of bootloader not clearing the reset reason. It's then bootloader responsibility to manually clean watchdog reset reason if it is aware of triggering it.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>