### PR TITLE
[TOPIC-GPIO] drivers: sensor: tmp007: convert to new GPIO API

### DIFF
--- a/drivers/sensor/tmp007/tmp007.h
+++ b/drivers/sensor/tmp007/tmp007.h
@@ -40,6 +40,7 @@ struct tmp007_data {
 #ifdef CONFIG_TMP007_TRIGGER
 	struct device *gpio;
 	struct gpio_callback gpio_cb;
+	struct device *dev;
 
 	sensor_trigger_handler_t drdy_handler;
 	struct sensor_trigger drdy_trigger;
@@ -53,7 +54,6 @@ struct tmp007_data {
 	struct k_thread thread;
 #elif defined(CONFIG_TMP007_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;
-	struct device *dev;
 #endif
 
 #endif /* CONFIG_TMP007_TRIGGER */

--- a/drivers/sensor/tmp007/tmp007_trigger.c
+++ b/drivers/sensor/tmp007/tmp007_trigger.c
@@ -17,6 +17,18 @@ extern struct tmp007_data tmp007_driver;
 #include <logging/log.h>
 LOG_MODULE_DECLARE(TMP007, CONFIG_SENSOR_LOG_LEVEL);
 
+static inline void setup_int(struct device *dev,
+			     bool enable)
+{
+	struct tmp007_data *data = dev->driver_data;
+
+	gpio_pin_interrupt_configure(data->gpio,
+				     DT_INST_0_TI_TMP007_INT_GPIOS_PIN,
+				     enable
+				     ? GPIO_INT_LEVEL_ACTIVE
+				     : GPIO_INT_DISABLE);
+}
+
 int tmp007_attr_set(struct device *dev,
 		    enum sensor_channel chan,
 		    enum sensor_attribute attr,
@@ -55,7 +67,7 @@ static void tmp007_gpio_callback(struct device *dev,
 	struct tmp007_data *drv_data =
 		CONTAINER_OF(cb, struct tmp007_data, gpio_cb);
 
-	gpio_pin_disable_callback(dev, DT_INST_0_TI_TMP007_INT_GPIOS_PIN);
+	setup_int(drv_data->dev, false);
 
 #if defined(CONFIG_TMP007_TRIGGER_OWN_THREAD)
 	k_sem_give(&drv_data->gpio_sem);
@@ -84,7 +96,7 @@ static void tmp007_thread_cb(void *arg)
 		drv_data->th_handler(dev, &drv_data->th_trigger);
 	}
 
-	gpio_pin_enable_callback(drv_data->gpio, DT_INST_0_TI_TMP007_INT_GPIOS_PIN);
+	setup_int(dev, true);
 }
 
 #ifdef CONFIG_TMP007_TRIGGER_OWN_THREAD
@@ -118,7 +130,7 @@ int tmp007_trigger_set(struct device *dev,
 {
 	struct tmp007_data *drv_data = dev->driver_data;
 
-	gpio_pin_disable_callback(drv_data->gpio, DT_INST_0_TI_TMP007_INT_GPIOS_PIN);
+	setup_int(dev, false);
 
 	if (trig->type == SENSOR_TRIG_DATA_READY) {
 		drv_data->drdy_handler = handler;
@@ -128,7 +140,7 @@ int tmp007_trigger_set(struct device *dev,
 		drv_data->th_trigger = *trig;
 	}
 
-	gpio_pin_enable_callback(drv_data->gpio, DT_INST_0_TI_TMP007_INT_GPIOS_PIN);
+	setup_int(dev, true);
 
 	return 0;
 }
@@ -143,6 +155,8 @@ int tmp007_init_interrupt(struct device *dev)
 		return -EIO;
 	}
 
+	drv_data->dev = dev;
+
 	/* setup gpio interrupt */
 	drv_data->gpio = device_get_binding(DT_INST_0_TI_TMP007_INT_GPIOS_CONTROLLER);
 	if (drv_data->gpio == NULL) {
@@ -152,8 +166,8 @@ int tmp007_init_interrupt(struct device *dev)
 	}
 
 	gpio_pin_configure(drv_data->gpio, DT_INST_0_TI_TMP007_INT_GPIOS_PIN,
-			   GPIO_DIR_IN | GPIO_INT | GPIO_INT_LEVEL |
-			   GPIO_INT_ACTIVE_HIGH | GPIO_INT_DEBOUNCE);
+			   DT_INST_0_TI_TMP007_INT_GPIOS_FLAGS
+			   | GPIO_INT_LEVEL_ACTIVE);
 
 	gpio_init_callback(&drv_data->gpio_cb,
 			   tmp007_gpio_callback,
@@ -174,7 +188,6 @@ int tmp007_init_interrupt(struct device *dev)
 			0, K_NO_WAIT);
 #elif defined(CONFIG_TMP007_TRIGGER_GLOBAL_THREAD)
 	drv_data->work.handler = tmp007_work_cb;
-	drv_data->dev = dev;
 #endif
 
 	return 0;

--- a/dts/bindings/sensor/ti,tmp007.yaml
+++ b/dts/bindings/sensor/ti,tmp007.yaml
@@ -13,3 +13,6 @@ properties:
     int-gpios:
       type: phandle-array
       required: false
+      description: |
+        Identifies the ALERT signal, which is active-low open drain when
+        produced by the sensor.


### PR DESCRIPTION
Use the new pin and interrupt configuration API.

NOTE: Because hardware is not available this has been build-tested only.