### PR TITLE
Bluetooth: host: Fix net buf assert on att encrypt change event

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2268,9 +2268,7 @@ struct bt_att_req *bt_att_req_alloc(s32_t timeout)
 
 	BT_DBG("req %p", req);
 
-	req->func = NULL;
-	req->destroy = NULL;
-	req->user_data = NULL;
+	memset(req, 0, sizeof(*req));
 
 	return req;
 }


### PR DESCRIPTION
Fix assert in net_buf triggered on att encrypt change event.

	ASSERTION FAIL [net_buf_simple_headroom(buf) >= len] @
	  ZEPHYR_BASE/subsys/net/buf.c:881

This happens because when the att request was allocated, it was not
properly initialized and req->retrying was left as true.
This caused the att encrypt change handling to assume an att request
needed to be resent, starting resending with an invalid request and
request buffer.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>