### PR TITLE
samples: drivers: fix build of spi_fujitsu_fram sample

### DIFF
--- a/samples/drivers/spi_fujitsu_fram/sample.yaml
+++ b/samples/drivers/spi_fujitsu_fram/sample.yaml
@@ -5,4 +5,4 @@ tests:
     tags: drivers fram
     harness: fram
     depends_on: gpio spi
-    filter: CONFIG_SPI_1
+    filter: dt_alias_exists("spi-1")

--- a/samples/drivers/spi_fujitsu_fram/src/main.c
+++ b/samples/drivers/spi_fujitsu_fram/src/main.c
@@ -143,7 +143,7 @@ void main(void)
 
 	printk("fujitsu FRAM example application\n");
 
-	spi = device_get_binding(DT_SPI_1_NAME);
+	spi = device_get_binding(DT_ALIAS_SPI_1_LABEL);
 	if (!spi) {
 		printk("Could not find SPI driver\n");
 		return;


### PR DESCRIPTION
Use DTS filtering and get binding based on DTS variable.

Fixes #22128