### PR TITLE
cmake: Add target for generating header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -623,6 +623,14 @@ add_custom_target(${DRIVER_VALIDATION_H_TARGET} DEPENDS ${DRV_VALIDATION})
 include($ENV{ZEPHYR_BASE}/cmake/kobj.cmake)
 gen_kobj(KOBJ_INCLUDE_PATH)
 
+# Add a pseudo-target that is up-to-date when all generated headers
+# are up-to-date.
+
+add_custom_target(zephyr_generated_headers)
+add_dependencies(zephyr_generated_headers
+  offsets_h
+  )
+
 # Generate offsets.c.obj from offsets.c
 # Generate offsets.h     from offsets.c.obj
 
@@ -665,7 +673,7 @@ get_property(ZEPHYR_LIBS_PROPERTY GLOBAL PROPERTY ZEPHYR_LIBS)
 
 foreach(zephyr_lib ${ZEPHYR_LIBS_PROPERTY})
   # TODO: Could this become an INTERFACE property of zephyr_interface?
-  add_dependencies(${zephyr_lib} ${OFFSETS_H_TARGET})
+  add_dependencies(${zephyr_lib} zephyr_generated_headers)
 endforeach()
 
 get_property(OUTPUT_FORMAT        GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT)
@@ -680,7 +688,7 @@ configure_linker_script(
   ${PRIV_STACK_DEP}
   ${APP_SMEM_ALIGNED_DEP}
   ${CODE_RELOCATION_DEP}
-  ${OFFSETS_H_TARGET}
+  zephyr_generated_headers
   )
 
 add_custom_target(
@@ -1085,7 +1093,7 @@ if(CONFIG_USERSPACE)
     ${CODE_RELOCATION_DEP}
     ${APP_SMEM_UNALIGNED_DEP}
     ${APP_SMEM_UNALIGNED_LD}
-    ${OFFSETS_H_TARGET}
+    zephyr_generated_headers
     )
 
   add_custom_target(
@@ -1139,7 +1147,7 @@ if(CONFIG_USERSPACE AND CONFIG_ARM)
     ${CODE_RELOCATION_DEP}
     ${APP_SMEM_ALIGNED_DEP}
     ${APP_SMEM_ALIGNED_LD}
-    ${OFFSETS_H_TARGET}
+    zephyr_generated_headers
     )
 
   add_custom_target(
@@ -1197,7 +1205,7 @@ else()
     ${PRIV_STACK_DEP}
     ${CODE_RELOCATION_DEP}
     ${ZEPHYR_PREBUILT_EXECUTABLE}
-    ${OFFSETS_H_TARGET}
+    zephyr_generated_headers
     )
 
   set(LINKER_PASS_FINAL_SCRIPT_TARGET linker_pass_final_script_target)

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -58,6 +58,6 @@ target_include_directories(kernel PRIVATE
   ${ZEPHYR_BASE}/arch/${ARCH}/include
   )
 
-add_dependencies(kernel ${OFFSETS_H_TARGET})
+add_dependencies(kernel zephyr_generated_headers)
 
 target_link_libraries(kernel zephyr_interface)

--- a/tests/subsys/settings/fs/src/CMakeLists.txt
+++ b/tests/subsys/settings/fs/src/CMakeLists.txt
@@ -6,7 +6,9 @@ zephyr_library_named(settings_test_fs)
 # zephyr_library() is here in "app-mode", see
 # https://github.com/zephyrproject-rtos/zephyr/issues/19582
 # Random build failures without this, depends on the number of threads.
-add_dependencies(    settings_test_fs offsets_h)
+add_dependencies(settings_test_fs
+  zephyr_generated_headers
+  )
 
 FILE(GLOB fssources *.c )
 zephyr_library_sources(${fssources})

--- a/tests/subsys/settings/functional/src/CMakeLists.txt
+++ b/tests/subsys/settings/functional/src/CMakeLists.txt
@@ -12,4 +12,7 @@ zephyr_library_sources(settings_basic_test.c)
 # zephyr_library() is here in "app-mode", see
 # https://github.com/zephyrproject-rtos/zephyr/issues/19582
 # Random build failures without this, depends on the number of threads.
-add_dependencies(      settings_func_test offsets_h)
+add_dependencies(
+  settings_func_test
+  zephyr_generated_headers
+  )

--- a/tests/subsys/settings/src/CMakeLists.txt
+++ b/tests/subsys/settings/src/CMakeLists.txt
@@ -6,7 +6,10 @@ zephyr_library_named(settings_test)
 # zephyr_library() is here in "app-mode", see
 # https://github.com/zephyrproject-rtos/zephyr/issues/19582
 # Random build failures without this, depends on the number of threads.
-add_dependencies(    settings_test offsets_h)
+add_dependencies(
+  settings_test
+  zephyr_generated_headers
+  )
 
 FILE(GLOB mysources *.c )
 zephyr_library_sources(${mysources})


### PR DESCRIPTION
Before C sources can be compiled any generated header that they
include must be generated. Currently, the target 'offsets_h' happens
to depend directly or indirectly on all generated headers.

This means that to compile safely, one can simply depend on
'offsets_h'. But this is coincidental and might not be true in the
future.

To be able to safely depend on a target that represents all generated
headers being ready we introduce the target
'zephyr_generated_headers'.

Any third-party build scripts can now safely depend on
'zephyr_generated_headers' and be protected from any internal changes
to the build system, like the removal of offsets_h.
