### PR TITLE
sanitycheck: add option to allow re-running single tests multiple times

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2001,6 +2001,7 @@ class ProjectBuilder(FilterBuilder):
         self.cleanup = kwargs.get('cleanup', False)
         self.coverage = kwargs.get('coverage', False)
         self.inline_logs = kwargs.get('inline_logs', False)
+        self.rerun = kwargs.get('rerun', 1)
 
     @staticmethod
     def log_info(filename, inline_logs):
@@ -2110,8 +2111,25 @@ class ProjectBuilder(FilterBuilder):
         # Run the generated binary using one of the supported handlers
         elif op == "run":
             logger.debug("run test: %s" % self.instance.name)
-            self.run()
-            self.instance.status, _ = self.instance.handler.get_state()
+            count = 0
+            passed = 0
+            failed = 0
+            for count in range(self.rerun):
+                count = count + 1
+                self.run()
+                self.instance.status, _ = self.instance.handler.get_state()
+                if self.instance.status in ['failed', 'timeout']:
+                    failed += 1
+                else:
+                    passed += 1
+                if self.rerun > 1:
+                    logger.info("Ran {} ({}/{} {:02.2f}% passrate): {}".format(
+                        self.instance.name,
+                        count,
+                        self.rerun,
+                        (passed / count) * 100,
+                        self.instance.status))
+
             pipeline.put({
                 "op": "report",
                 "test": self.instance,
@@ -2323,6 +2341,7 @@ class TestSuite:
         self.extra_args = []
         self.inline_logs = False
         self.enable_sizes_report = False
+        self.rerun = 1
 
         # Keep track of which test cases we've filtered out and why
         self.testcases = {}
@@ -2926,7 +2945,8 @@ class TestSuite:
                                         cmake_only=self.cmake_only,
                                         cleanup=self.cleanup,
                                         valgrind=self.enable_valgrind,
-                                        inline_logs=self.inline_logs
+                                        inline_logs=self.inline_logs,
+                                        rerun=self.rerun
                                         )
                     future_to_test[executor.submit(pb.process, message)] = test.name
 
@@ -3456,6 +3476,11 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
         "--disable-unrecognized-section-test", action="store_true",
         default=False,
         help="Skip the 'unrecognized section' test.")
+
+    parser.add_argument("--number-of-runs", type=int, default=1,
+        help="""Run tests multiple times and report intermediate results
+                (This option makes sense with one test only)""")
+
     parser.add_argument("-R", "--enable-asserts", action="store_true",
                         default=True,
                         help="deprecated, left for compatibility")
@@ -4075,6 +4100,7 @@ def main():
     suite.inline_logs = options.inline_logs
     suite.enable_size_report = options.enable_size_report
     suite.extra_args = options.extra_args
+    suite.rerun = options.number_of_runs
 
     # Set number of jobs
     if options.jobs:


### PR DESCRIPTION
Using --number-of-runs <int> we now can run a single test multiple times
to test for reproducibility and to catch sporadic failures.

The output looks like this:

```
i9:zephyr(rerun_sc): sanitycheck -p mps2_an385 -T tests/kernel/tickless/tickless_concept/ --number-of-runs 10
Renaming output directory to /home/nashif/Work/zephyrproject/zephyr/sanity-out.17
INFO    - JOBS: 20
INFO    - Building initial testcase list...
INFO    - 1 test configurations selected, 0 configurations discarded due to filters.
INFO    - Adding tasks to the queue...
INFO    - Ran mps2_an385/tests/kernel/tickless/tickless_concept/kernel.tickless.concept (1/10 100.00% passrate): passed
INFO    - Ran mps2_an385/tests/kernel/tickless/tickless_concept/kernel.tickless.concept (2/10 100.00% passrate): passed
INFO    - Ran mps2_an385/tests/kernel/tickless/tickless_concept/kernel.tickless.concept (3/10 100.00% passrate): passed
INFO    - Ran mps2_an385/tests/kernel/tickless/tickless_concept/kernel.tickless.concept (4/10 100.00% passrate): passed
INFO    - Ran mps2_an385/tests/kernel/tickless/tickless_concept/kernel.tickless.concept (5/10 100.00% passrate): passed
INFO    - Ran mps2_an385/tests/kernel/tickless/tickless_concept/kernel.tickless.concept (6/10 100.00% passrate): passed
INFO    - Ran mps2_an385/tests/kernel/tickless/tickless_concept/kernel.tickless.concept (7/10 100.00% passrate): passed
INFO    - Ran mps2_an385/tests/kernel/tickless/tickless_concept/kernel.tickless.concept (8/10 100.00% passrate): passed
INFO    - Ran mps2_an385/tests/kernel/tickless/tickless_concept/kernel.tickless.concept (9/10 100.00% passrate): passed
INFO    - Ran mps2_an385/tests/kernel/tickless/tickless_concept/kernel.tickless.concept (10/10 100.00% passrate): passed
INFO    - Total complete:    1/   1  100%  skipped:    0, failed:    0
INFO    - 1 of 1 tests passed (100.00%), 0 failed, 0 skipped with 0 warnings in 54.65 seconds
INFO    - In total 1 test cases were executed on 1 out of total 219 platforms (0.46%)
```
