### PR TITLE
console: Have CONSOLE_GET{CHAR,LINE} dep. on SERIAL_SUPPORT_INTERRUPT

### DIFF
--- a/subsys/console/Kconfig
+++ b/subsys/console/Kconfig
@@ -11,7 +11,7 @@ if CONSOLE_SUBSYS
 choice
 	prompt "Console 'get' function selection"
 	optional
-	depends on UART_CONSOLE
+	depends on UART_CONSOLE && SERIAL_SUPPORT_INTERRUPT
 
 config CONSOLE_GETCHAR
 	bool "Character by character input and output"


### PR DESCRIPTION
Overlooked dependency in commit 97de99adca ("console: kconfig: Have
CONSOLE_{GETCHAR,GETLINE} depend on UART_CONSOLE"). CONSOLE_GETCHAR and
CONSOLE_GETLINE select CONSOLE_HANDLER, which selects
UART_INTERRUPT_DRIVEN, which depends on SERIAL_SUPPORT_INTERRUPT.

Fixed some selects with unsatisfied dependencies in CI.

(CONSOLE_HANDLER also depends on SERIAL, but it's redundant, since it
already depends on UART_CONSOLE, which depends on SERIAL. This is
simplified in https://github.com/zephyrproject-rtos/zephyr/pull/22116.)