### PR TITLE
dts: bindings: nxp,lpc-iap: Remove deprecated 'title' field

### DIFF
--- a/dts/bindings/flash_controller/nxp,lpc-iap.yaml
+++ b/dts/bindings/flash_controller/nxp,lpc-iap.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP LPC In Application Programming Flash Memory (IAP)
-
-description: |
-    This binding gives for the NXP LPC Flash Memory Controller
+description: NXP LPC IAP (In-Application Programming) flash memory controller
 
 compatible: "nxp,lpc-iap"
 


### PR DESCRIPTION
Merge all the information into 'description:' and remove 'title:'.
Gets rid of a deprecation warning.

See commit 2934ee2cda ("dts: bindings: Remove 'title:' and put all info.
into 'description:'").