### PR TITLE
[topic-gpio] tests: bluetooth: mesh: Convert to new GPIO API

### DIFF
--- a/tests/bluetooth/mesh/src/microbit.c
+++ b/tests/bluetooth/mesh/src/microbit.c
@@ -33,10 +33,13 @@ static void configure_button(void)
 	gpio = device_get_binding(DT_ALIAS_SW0_GPIOS_CONTROLLER);
 
 	gpio_pin_configure(gpio, DT_ALIAS_SW0_GPIOS_PIN,
-			   (GPIO_DIR_IN | GPIO_INT | GPIO_INT_EDGE |
-			    GPIO_INT_ACTIVE_LOW));
+			   DT_ALIAS_SW0_GPIOS_FLAGS | GPIO_INPUT);
 
-	gpio_init_callback(&button_cb, button_pressed, BIT(DT_ALIAS_SW0_GPIOS_PIN));
+	gpio_init_callback(&button_cb, button_pressed,
+			   BIT(DT_ALIAS_SW0_GPIOS_PIN));
+
+	gpio_pin_interrupt_configure(gpio, DT_ALIAS_SW0_GPIOS_PIN,
+				     GPIO_INT_EDGE_TO_ACTIVE);
 
 	gpio_add_callback(gpio, &button_cb);
 }
@@ -52,7 +55,8 @@ void board_output_number(bt_mesh_output_action_t action, u32_t number)
 
 	oob_number = number;
 
-	gpio_pin_enable_callback(gpio, DT_ALIAS_SW0_GPIOS_PIN);
+	gpio_pin_interrupt_configure(gpio, DT_ALIAS_SW0_GPIOS_PIN,
+				     GPIO_INT_EDGE_TO_ACTIVE);
 
 	mb_display_image(disp, MB_DISPLAY_MODE_DEFAULT, K_FOREVER, &arrow, 1);
 }
@@ -67,7 +71,8 @@ void board_prov_complete(void)
 					 { 0, 1, 1, 1, 0 });
 
 
-	gpio_pin_disable_callback(gpio, DT_ALIAS_SW0_GPIOS_PIN);
+	gpio_pin_interrupt_configure(gpio, DT_ALIAS_SW0_GPIOS_PIN,
+				     GPIO_INT_DISABLE);
 
 	mb_display_image(disp, MB_DISPLAY_MODE_DEFAULT, K_SECONDS(10),
 			 &arrow, 1);


### PR DESCRIPTION
Use the new API and replace the enable/disable callback calls with pin
interrupt configuration instead.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>