### PR TITLE
Bluetooth: ATT: Fix handling ATT response

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -344,7 +344,7 @@ static void att_process(struct bt_att *att)
 
 static u8_t att_handle_rsp(struct bt_att *att, void *pdu, u16_t len, u8_t err)
 {
-	bt_att_func_t func;
+	bt_att_func_t func = NULL;
 	void *params;
 
 	BT_DBG("err 0x%02x len %u: %s", err, len, bt_hex(pdu, len));
@@ -378,11 +378,12 @@ static u8_t att_handle_rsp(struct bt_att *att, void *pdu, u16_t len, u8_t err)
 	att_req_destroy(att->req);
 	att->req = NULL;
 
-	func(att->chan.chan.conn, err, pdu, len, params);
-
 process:
 	/* Process pending requests */
 	att_process(att);
+	if (func) {
+		func(att->chan.chan.conn, err, pdu, len, params);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
The callback function may modify the att->req and it has to be called after the att_process. The att_process does not re-check if att->req is still NULL.