### PR TITLE
ci: move to using SDK 0.11.0

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -4,7 +4,7 @@ compiler: gcc
 
 env:
     global:
-        - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.10.3
+        - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.11.0
         - ZEPHYR_TOOLCHAIN_VARIANT=zephyr
         - MATRIX_BUILDS="5"
     matrix:
@@ -20,7 +20,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.11.0
+        image_tag: v0.11.1
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 

--- a/boards/arm/qemu_cortex_r5/board.cmake
+++ b/boards/arm/qemu_cortex_r5/board.cmake
@@ -2,18 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# FIXME++: This forces the CI to use the Xilinx QEMU included in the Zephyr SDK
-#          0.11.0-alpha-8 for testing. This should be removed once the Zephyr
-#          SDK 0.11.0 release is mainlined.
-set(CI_QEMU_PATH
-  /opt/sdk/zephyr-sdk-0.11.0-alpha-8/sysroots/x86_64-pokysdk-linux/usr/bin
-  )
-
-if(EXISTS ${CI_QEMU_PATH})
-  set(ENV{QEMU_BIN_PATH} ${CI_QEMU_PATH})
-endif()
-# FIXME--
-
 set(EMU_PLATFORM qemu)
 set(QEMU_ARCH xilinx-aarch64)
 

--- a/cmake/toolchain/zephyr/0.11/Kconfig
+++ b/cmake/toolchain/zephyr/0.11/Kconfig
@@ -5,4 +5,4 @@
 
 config TOOLCHAIN_ZEPHYR_0_11
 	def_bool y
-	select HAS_NEWLIB_LIBC_NANO
+	select HAS_NEWLIB_LIBC_NANO if (ARC || ARM || RISCV)


### PR DESCRIPTION
Move to docker image 0.11.1 to get final release of SDK 0.11.0.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>