### PR TITLE
[topic-gpio] drivers: audio: tlv320dac310x: Convert to the new GPIO API

### DIFF
--- a/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
+++ b/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
@@ -41,7 +41,7 @@
 		compatible = "ti,tlv320dac";
 		reg = <0x18>;
 		label = "TLV320DAC";
-		reset-gpios = <&gpio0 4 0>;
+		reset-gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/drivers/audio/tlv320dac310x.c
+++ b/drivers/audio/tlv320dac310x.c
@@ -22,9 +22,6 @@ LOG_MODULE_REGISTER(tlv320dac310x);
 #define CODEC_OUTPUT_VOLUME_MAX		0
 #define CODEC_OUTPUT_VOLUME_MIN		(-78 * 2)
 
-#define CODEC_RESET_PIN_ASSERT		0
-#define CODEC_RESET_PIN_DEASSERT	1
-
 struct codec_driver_config {
 	struct device	*i2c_device;
 	const char	*i2c_dev_name;
@@ -108,12 +105,11 @@ static int codec_configure(struct device *dev,
 		return -EINVAL;
 	}
 
-	/* configure reset GPIO */
+	/* Configure reset GPIO, and set the line to inactive, which will also
+	 * de-assert the reset line and thus enable the codec.
+	 */
 	gpio_pin_configure(dev_cfg->gpio_device, dev_cfg->gpio_pin,
-				     dev_cfg->gpio_flags | GPIO_DIR_OUT);
-	/* de-assert reset */
-	gpio_pin_write(dev_cfg->gpio_device, dev_cfg->gpio_pin,
-				 CODEC_RESET_PIN_DEASSERT);
+			   dev_cfg->gpio_flags | GPIO_OUTPUT_INACTIVE);
 
 	codec_soft_reset(dev);
 


### PR DESCRIPTION
Convert to the new GPIO API using raw access, since the driver has
macros to define the raw value that is to be written to the pin.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>