### PR TITLE
Fix K_FOREVER timout handling in UART Async API

### DIFF
--- a/drivers/serial/uart_handlers.c
+++ b/drivers/serial/uart_handlers.c
@@ -49,7 +49,7 @@ static inline void z_vrfy_uart_poll_out(struct device *dev,
  */
 
 static inline int z_vrfy_uart_tx(struct device *dev, const u8_t *buf,
-				 size_t len, u32_t timeout)
+				 size_t len, s32_t timeout)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_UART(dev, tx));
 	Z_OOPS(Z_SYSCALL_MEMORY_READ(buf, len));
@@ -61,7 +61,7 @@ UART_SIMPLE(tx_abort);
 #include <syscalls/uart_tx_abort_mrsh.c>
 
 static inline int z_vrfy_uart_rx_enable(struct device *dev, u8_t *buf,
-					size_t len, u32_t timeout)
+					size_t len, s32_t timeout)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_UART(dev, rx_enable));
 	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(buf, len));

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -70,7 +70,7 @@ struct uarte_async_cb {
 	u8_t *rx_next_buf;
 	u32_t rx_total_byte_cnt; /* Total number of bytes received */
 	u32_t rx_total_user_byte_cnt; /* Total number of bytes passed to user */
-	u32_t rx_timeout; /* Timeout set by user */
+	s32_t rx_timeout; /* Timeout set by user */
 	s32_t rx_timeout_slab; /* rx_timeout divided by RX_TIMEOUT_DIV */
 	s32_t rx_timeout_left; /* Current time left until user callback */
 	struct k_timer rx_timeout_timer;
@@ -470,7 +470,7 @@ static int uarte_nrfx_init(struct device *dev)
 }
 
 static int uarte_nrfx_tx(struct device *dev, const u8_t *buf, size_t len,
-			 u32_t timeout)
+			 s32_t timeout)
 {
 	struct uarte_nrfx_data *data = get_dev_data(dev);
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
@@ -486,7 +486,8 @@ static int uarte_nrfx_tx(struct device *dev, const u8_t *buf, size_t len,
 	data->async->tx_size = len;
 	nrf_uarte_tx_buffer_set(uarte, buf, len);
 	nrf_uarte_task_trigger(uarte, NRF_UARTE_TASK_STARTTX);
-	if (data->uart_config.flow_ctrl == UART_CFG_FLOW_CTRL_RTS_CTS) {
+	if (data->uart_config.flow_ctrl == UART_CFG_FLOW_CTRL_RTS_CTS
+	    && timeout != K_FOREVER) {
 		k_timer_start(&data->async->tx_timeout_timer, timeout,
 			      K_NO_WAIT);
 	}
@@ -508,7 +509,7 @@ static int uarte_nrfx_tx_abort(struct device *dev)
 }
 
 static int uarte_nrfx_rx_enable(struct device *dev, u8_t *buf, size_t len,
-				u32_t timeout)
+				s32_t timeout)
 {
 	struct uarte_nrfx_data *data = get_dev_data(dev);
 	const struct uarte_nrfx_config *cfg = get_dev_config(dev);
@@ -687,7 +688,7 @@ static void rxstarted_isr(struct device *dev)
 		.type = UART_RX_BUF_REQUEST,
 	};
 	user_callback(dev, &evt);
-	if (data->async->rx_timeout) {
+	if (data->async->rx_timeout != K_FOREVER) {
 		data->async->rx_timeout_left = data->async->rx_timeout;
 		k_timer_start(&data->async->rx_timeout_timer,
 			      data->async->rx_timeout_slab,

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -686,7 +686,7 @@ static int uart_sam0_callback_set(struct device *dev, uart_callback_t callback,
 }
 
 static int uart_sam0_tx(struct device *dev, const u8_t *buf, size_t len,
-			u32_t timeout)
+			s32_t timeout)
 {
 	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
 	const struct uart_sam0_dev_cfg *const cfg = DEV_CFG(dev);
@@ -744,7 +744,7 @@ static int uart_sam0_tx_abort(struct device *dev)
 }
 
 static int uart_sam0_rx_enable(struct device *dev, u8_t *buf, size_t len,
-			       u32_t timeout)
+			       s32_t timeout)
 {
 	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
 	const struct uart_sam0_dev_cfg *const cfg = DEV_CFG(dev);

--- a/include/drivers/uart.h
+++ b/include/drivers/uart.h
@@ -350,11 +350,11 @@ struct uart_driver_api {
 			    void *user_data);
 
 	int (*tx)(struct device *dev, const u8_t *buf, size_t len,
-		  u32_t timeout);
+		  s32_t timeout);
 	int (*tx_abort)(struct device *dev);
 
 	int (*rx_enable)(struct device *dev, u8_t *buf, size_t len,
-			 u32_t timeout);
+			 s32_t timeout);
 	int (*rx_buf_rsp)(struct device *dev, u8_t *buf, size_t len);
 	int (*rx_disable)(struct device *dev);
 
@@ -460,16 +460,17 @@ static inline int uart_callback_set(struct device *dev,
  * @param dev     UART device structure.
  * @param buf     Pointer to transmit buffer.
  * @param len     Length of transmit buffer.
- * @param timeout Timeout in milliseconds. Valid only if flow control is enabled
+ * @param timeout Timeout in milliseconds. Valid only if flow control is
+ *		  enabled. K_FOREVER disables timeout.
  *
  * @retval -EBUSY There is already an ongoing transfer.
  * @retval 0	  If successful, negative errno code otherwise.
  */
 __syscall int uart_tx(struct device *dev, const u8_t *buf, size_t len,
-		      u32_t timeout);
+		      s32_t timeout);
 
 static inline int z_impl_uart_tx(struct device *dev, const u8_t *buf,
-				 size_t len, u32_t timeout)
+				 size_t len, s32_t timeout)
 
 {
 	const struct uart_driver_api *api =
@@ -508,17 +509,17 @@ static inline int z_impl_uart_tx_abort(struct device *dev)
  * @param dev     UART device structure.
  * @param buf     Pointer to receive buffer.
  * @param len     Buffer length.
- * @param timeout Timeout in milliseconds.
+ * @param timeout Timeout in milliseconds. K_FOREVER disables timeout.
  *
  * @retval -EBUSY RX already in progress.
  * @retval 0	  If successful, negative errno code otherwise.
  *
  */
 __syscall int uart_rx_enable(struct device *dev, u8_t *buf, size_t len,
-			     u32_t timeout);
+			     s32_t timeout);
 
 static inline int z_impl_uart_rx_enable(struct device *dev, u8_t *buf,
-					size_t len, u32_t timeout)
+					size_t len, s32_t timeout)
 {
 	const struct uart_driver_api *api =
 				(const struct uart_driver_api *)dev->driver_api;

--- a/tests/drivers/uart/uart_async_api/src/main.c
+++ b/tests/drivers/uart/uart_async_api/src/main.c
@@ -33,6 +33,8 @@ void test_main(void)
 			 ztest_unit_test(test_long_buffers_setup),
 			 ztest_user_unit_test(test_long_buffers),
 			 ztest_unit_test(test_write_abort_setup),
-			 ztest_user_unit_test(test_write_abort));
+			 ztest_user_unit_test(test_write_abort),
+			 ztest_unit_test(test_forever_timeout_setup),
+			 ztest_user_unit_test(test_forever_timeout));
 	ztest_run_test_suite(uart_async_test);
 }

--- a/tests/drivers/uart/uart_async_api/src/test_uart.h
+++ b/tests/drivers/uart/uart_async_api/src/test_uart.h
@@ -32,6 +32,7 @@ void test_chained_read(void);
 void test_double_buffer(void);
 void test_read_abort(void);
 void test_write_abort(void);
+void test_forever_timeout(void);
 void test_long_buffers(void);
 void test_chained_write(void);
 
@@ -40,6 +41,7 @@ void test_chained_read_setup(void);
 void test_double_buffer_setup(void);
 void test_read_abort_setup(void);
 void test_write_abort_setup(void);
+void test_forever_timeout_setup(void);
 void test_long_buffers_setup(void);
 void test_chained_write_setup(void);
 


### PR DESCRIPTION
Timeout value was directly passed to workqueue or timer, if K_FOREVER was passed as timeout value it would result in assertion or instant execution of timer/delayed_work. 

To fix that proper types for timeout had to be used in UART async API and driver was modified to handle K_FOREVER case.