### PR TITLE
flashing: do not give bossac the offset parameter if not explicitly provided.

### DIFF
--- a/scripts/west_commands/runners/bossac.py
+++ b/scripts/west_commands/runners/bossac.py
@@ -15,7 +15,7 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end for bossac.'''
 
     def __init__(self, cfg, bossac='bossac', port=DEFAULT_BOSSAC_PORT,
-            offset=0):
+            offset=None):
         super(BossacBinaryRunner, self).__init__(cfg)
         self.bossac = bossac
         self.port = port
@@ -33,7 +33,7 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
     def do_add_parser(cls, parser):
         parser.add_argument('--bossac', default='bossac',
                             help='path to bossac, default is bossac')
-        parser.add_argument('--offset', default=0,
+        parser.add_argument('--offset', default=None,
                             help='start erase/write/read/verify operation '
                                  'at flash OFFSET; OFFSET must be aligned '
                                  ' to a flash page boundary')
@@ -56,8 +56,9 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
                     'ospeed', '1200', 'cs8', '-cstopb', 'ignpar', 'eol', '255',
                     'eof', '255']
         cmd_flash = [self.bossac, '-p', self.port, '-R', '-e', '-w', '-v',
-                     '-o', '%s' % self.offset,
                      '-b', self.cfg.bin_file]
+        if self.offset is not None:
+            cmd_flash += ['-o', '%s' % self.offset]
 
         self.check_call(cmd_stty)
         self.check_call(cmd_flash)

--- a/scripts/west_commands/tests/test_bossac.py
+++ b/scripts/west_commands/tests/test_bossac.py
@@ -15,7 +15,13 @@ EXPECTED_COMMANDS = [
     ['stty', '-F', TEST_BOSSAC_PORT, 'raw', 'ispeed', '1200', 'ospeed', '1200',
      'cs8', '-cstopb', 'ignpar', 'eol', '255', 'eof', '255'],
     ['bossac', '-p', TEST_BOSSAC_PORT, '-R', '-e', '-w', '-v',
-     '-o', str(TEST_OFFSET), '-b', RC_KERNEL_BIN],
+     '-b', RC_KERNEL_BIN],
+]
+EXPECTED_COMMANDS_WITH_OFFSET = [
+    ['stty', '-F', TEST_BOSSAC_PORT, 'raw', 'ispeed', '1200', 'ospeed', '1200',
+     'cs8', '-cstopb', 'ignpar', 'eol', '255', 'eof', '255'],
+    ['bossac', '-p', TEST_BOSSAC_PORT, '-R', '-e', '-w', '-v',
+     '-b', RC_KERNEL_BIN, '-o', str(TEST_OFFSET)],
 ]
 
 def require_patch(program):
@@ -28,11 +34,23 @@ def test_bossac_init(cc, req, runner_config):
     runner = BossacBinaryRunner(runner_config, port=TEST_BOSSAC_PORT,
                                 offset=TEST_OFFSET)
     runner.run('flash')
-    assert cc.call_args_list == [call(x) for x in EXPECTED_COMMANDS]
+    assert cc.call_args_list == [call(x) for x in EXPECTED_COMMANDS_WITH_OFFSET]
 
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
 def test_bossac_create(cc, req, runner_config):
+    '''Test commands using a runner created from command line parameters.'''
+    args = ['--bossac-port', str(TEST_BOSSAC_PORT)]
+    parser = argparse.ArgumentParser()
+    BossacBinaryRunner.add_parser(parser)
+    arg_namespace = parser.parse_args(args)
+    runner = BossacBinaryRunner.create(runner_config, arg_namespace)
+    runner.run('flash')
+    assert cc.call_args_list == [call(x) for x in EXPECTED_COMMANDS]
+
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
+@patch('runners.core.ZephyrBinaryRunner.check_call')
+def test_bossac_create_with_offset(cc, req, runner_config):
     '''Test commands using a runner created from command line parameters.'''
     args = ['--bossac-port', str(TEST_BOSSAC_PORT),
             '--offset', str(TEST_OFFSET)]
@@ -41,4 +59,4 @@ def test_bossac_create(cc, req, runner_config):
     arg_namespace = parser.parse_args(args)
     runner = BossacBinaryRunner.create(runner_config, arg_namespace)
     runner.run('flash')
-    assert cc.call_args_list == [call(x) for x in EXPECTED_COMMANDS]
+    assert cc.call_args_list == [call(x) for x in EXPECTED_COMMANDS_WITH_OFFSET]


### PR DESCRIPTION
Doesn't feed bossac the offset parameter unless explicitly requested. This allows the runner to play nicely with earlier versions of bossac.

Fixes: #22171

Signed-off-by: Kuba Sanak <contact@kuba.fyi>