### PR TITLE
[backport 1.14] mempool: use k_malloc heap for ISR allocations

### DIFF
--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -214,9 +214,11 @@ extern void z_app_shmem_bss_zero(void);
  * memory on behalf of certain kernel and driver APIs. Memory reserved
  * in this way should be freed with k_free().
  *
+ * If called from an ISR, the k_malloc() system heap will be used if it exists.
+ *
  * @param size Memory allocation size
  * @return A pointer to the allocated memory, or NULL if there is insufficient
- * RAM in the pool or the thread has no resource pool assigned
+ * RAM in the pool or there is no pool to draw memory from
  */
 void *z_thread_malloc(size_t size);
 

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -208,14 +208,23 @@ void k_thread_system_pool_assign(struct k_thread *thread)
 {
 	thread->resource_pool = _HEAP_MEM_POOL;
 }
+#else
+#define _HEAP_MEM_POOL	NULL
 #endif
 
 void *z_thread_malloc(size_t size)
 {
 	void *ret;
+	struct k_mem_pool *pool;
 
-	if (_current->resource_pool != NULL) {
-		ret = k_mem_pool_malloc(_current->resource_pool, size);
+	if (k_is_in_isr()) {
+		pool = _HEAP_MEM_POOL;
+	} else {
+		pool = _current->resource_pool;
+	}
+
+	if (pool) {
+		ret = k_mem_pool_malloc(pool, size);
 	} else {
 		ret = NULL;
 	}


### PR DESCRIPTION
Fixes an issue where calling z_thread_malloc() would
borrow the resource pool of whatever thread happened
to be interrupted at the time.

I am backporting this to v1.14 as in its current form,
undefined behavior results when making a kernel API
call that does a memory allocation from a resource pool,
such as k_queue_alloc_append(), from an ISR.

In particular, this fixes adding a work item to a workqueue
running in user mode from an ISR, as reported on the mailing
list.