### PR TITLE
net: if: Make sure iface->if_dev is not null when accessing L2

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -550,7 +550,7 @@ enum net_verdict net_if_send_data(struct net_if *iface, struct net_pkt *pkt);
  */
 static inline const struct net_l2 * const net_if_l2(struct net_if *iface)
 {
-	if (!iface) {
+	if (!iface || !iface->if_dev) {
 		return NULL;
 	}
 


### PR DESCRIPTION
commit 971ae599130d ("net: pkt: Make sure iface is not null when
accessing L2") fixed net_if_l2 where iface was NULL, however if
iface->if_dev is NULL, the check breaks and returns an offset of
NULL (0x82 or so).  This is incorrect.

Let's add a check for iface->if_dev as well.

Signed-off-by: Michael Scott <mike@foundries.io>