### PR TITLE
[backport 1.14] drivers: serial: add async API system calls

### DIFF
--- a/drivers/serial/uart_handlers.c
+++ b/drivers/serial/uart_handlers.c
@@ -38,6 +38,32 @@ Z_SYSCALL_HANDLER(uart_poll_out, dev, out_char)
 	return 0;
 }
 
+#ifdef CONFIG_UART_ASYNC_API
+/* callback_set() excluded as we don't allow ISR callback installation from
+ * user mode
+ *
+ * rx_buf_rsp() excluded as it's designed to be called from ISR callbacks
+ */
+Z_SYSCALL_HANDLER(uart_tx, dev, buf, len, timeout)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_UART(dev, tx));
+	Z_OOPS(Z_SYSCALL_MEMORY_READ(buf, len));
+	return z_impl_uart_tx((struct device *)dev, (u8_t *)buf, len, timeout);
+}
+
+UART_SIMPLE(tx_abort);
+
+Z_SYSCALL_HANDLER(uart_rx_enable, dev, buf, len, timeout)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_UART(dev, rx_enable));
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(buf, len));
+	return z_impl_uart_rx_enable((struct device *)dev, (u8_t *)buf, len,
+				     timeout);
+}
+
+UART_SIMPLE(rx_disable);
+#endif /* CONFIG_UART_ASYNC_API */
+
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 UART_SIMPLE_VOID(irq_tx_enable)
 UART_SIMPLE_VOID(irq_tx_disable)

--- a/include/uart.h
+++ b/include/uart.h
@@ -465,10 +465,11 @@ static inline int uart_callback_set(struct device *dev,
  * @retval -EBUSY There is already an ongoing transfer.
  * @retval 0	  If successful, negative errno code otherwise.
  */
-static inline int uart_tx(struct device *dev,
-			  const u8_t *buf,
-			  size_t len,
-			  u32_t timeout)
+__syscall int uart_tx(struct device *dev, const u8_t *buf, size_t len,
+		      u32_t timeout);
+
+static inline int z_impl_uart_tx(struct device *dev, const u8_t *buf,
+				 size_t len, u32_t timeout)
 
 {
 	const struct uart_driver_api *api =
@@ -487,7 +488,9 @@ static inline int uart_tx(struct device *dev,
  * @retval -EFAULT There is no active transmission.
  * @retval 0	   If successful, negative errno code otherwise.
  */
-static inline int uart_tx_abort(struct device *dev)
+__syscall int uart_tx_abort(struct device *dev);
+
+static inline int z_impl_uart_tx_abort(struct device *dev)
 {
 	const struct uart_driver_api *api =
 			(const struct uart_driver_api *)dev->driver_api;
@@ -511,8 +514,11 @@ static inline int uart_tx_abort(struct device *dev)
  * @retval 0	  If successful, negative errno code otherwise.
  *
  */
-static inline int uart_rx_enable(struct device *dev, u8_t *buf, size_t len,
-				 u32_t timeout)
+__syscall int uart_rx_enable(struct device *dev, u8_t *buf, size_t len,
+			     u32_t timeout);
+
+static inline int z_impl_uart_rx_enable(struct device *dev, u8_t *buf,
+					size_t len, u32_t timeout)
 {
 	const struct uart_driver_api *api =
 				(const struct uart_driver_api *)dev->driver_api;
@@ -557,7 +563,9 @@ static inline int uart_rx_buf_rsp(struct device *dev, u8_t *buf, size_t len)
  * @retval -EFAULT There is no active reception.
  * @retval 0	   If successful, negative errno code otherwise.
  */
-static inline int uart_rx_disable(struct device *dev)
+__syscall int uart_rx_disable(struct device *dev);
+
+static inline int z_impl_uart_rx_disable(struct device *dev)
 {
 	const struct uart_driver_api *api =
 			(const struct uart_driver_api *)dev->driver_api;


### PR DESCRIPTION
These were unintentionally omitted. We don't expose callback
registration or callback response APIs for security reasons.

Backporting this as some users on the LTS branch had noted
this omission, and we've been backporting other patches that
fix missing system calls.

Fixes #21431