### PR TITLE
kconfig: Turn pointless 'menuconfig's into 'config's

### DIFF
--- a/boards/arm/mimxrt1010_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1010_evk/Kconfig.defconfig
@@ -1,9 +1,7 @@
-# Kconfig - MIMXRT1010-EVK board
-#
+# MIMXRT1010-EVK board
+
 # Copyright (c) 2019, NXP
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 if BOARD_MIMXRT1010_EVK
 

--- a/boards/arm/mm_swiftio/Kconfig.defconfig
+++ b/boards/arm/mm_swiftio/Kconfig.defconfig
@@ -1,9 +1,7 @@
-# Kconfig - MM-SWIFTIO board
-#
+# MM-SWIFTIO board
+
 # Copyright (c) 2019, MADMACHINE LIMITED
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 if BOARD_MM_SWIFTIO
 

--- a/drivers/entropy/Kconfig.litex
+++ b/drivers/entropy/Kconfig.litex
@@ -3,7 +3,7 @@
 # Copyright (c) 2019 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig ENTROPY_LITEX_RNG
+config ENTROPY_LITEX_RNG
 	bool "PRBS RNG driver"
 	depends on SOC_RISCV32_LITEX_VEXRISCV
 	select ENTROPY_HAS_DRIVER

--- a/drivers/i2c/Kconfig.litex
+++ b/drivers/i2c/Kconfig.litex
@@ -1,10 +1,7 @@
-#
 # Copyright (c) 2019 Antmicro <www.antmicro.com>
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
-menuconfig I2C_LITEX
+config I2C_LITEX
 	bool "LiteX I2C driver"
 	depends on SOC_RISCV32_LITEX_VEXRISCV
 	select HAS_DTS_I2C

--- a/drivers/i2c/Kconfig.xec
+++ b/drivers/i2c/Kconfig.xec
@@ -3,7 +3,7 @@
 # Copyright (c) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig I2C_XEC
+config I2C_XEC
 	bool "XEC Microchip I2C driver"
 	depends on SOC_FAMILY_MEC
 	help

--- a/drivers/spi/Kconfig.gecko
+++ b/drivers/spi/Kconfig.gecko
@@ -1,11 +1,9 @@
-# Kconfig.gecko - Gecko SPI configuration option
-#
-# Copyright (c) 2019 Christian Taedcke <hacking@taedcke.com>
-#
-# SPDX-License-Identifier: Apache-2.0
-#
+# Gecko SPI configuration option
 
-menuconfig SPI_GECKO
+# Copyright (c) 2019 Christian Taedcke <hacking@taedcke.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config SPI_GECKO
 	bool "Gecko SPI controller driver"
 	depends on HAS_SILABS_GECKO
 	depends on GPIO_GECKO

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1010
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1010
@@ -1,9 +1,7 @@
-# Kconfig - i.MX RT1010
-#
+# i.MX RT1010
+
 # Copyright (c) 2019, NXP
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 if SOC_MIMXRT1011
 


### PR DESCRIPTION
Same deal as in commit 677f1e6 ("config: Turn pointless/confusing
'menuconfig's into 'config's"), for a newly-introduced stuff.

Also clean up headers to be consistent with recent cleanups.