### PR TITLE
soc: ti_simplelink: kconfig: Refactor CCFG flash block handling

### DIFF
--- a/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -39,7 +39,7 @@
 #define ROM_ADDR (CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET)
 #endif
 
-#ifdef CONFIG_TI_CCFG_PRESENT
+#ifdef CONFIG_HAS_TI_CCFG
 #define CCFG_SIZE 88
 #define ROM_SIZE (CONFIG_FLASH_SIZE*1K - CONFIG_FLASH_LOAD_OFFSET - \
 	CCFG_SIZE)
@@ -92,7 +92,7 @@ _region_min_align = 4;
 MEMORY
     {
     FLASH                 (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
-#ifdef CONFIG_TI_CCFG_PRESENT
+#ifdef CONFIG_HAS_TI_CCFG
     FLASH_CCFG            (rwx): ORIGIN = CCFG_ADDR, LENGTH = CCFG_SIZE
 #endif
 #ifdef DT_CCM_BASE_ADDRESS
@@ -246,7 +246,7 @@ SECTIONS
     GROUP_END(ROMABLE_REGION)
 
 /* Some TI SoCs have a special configuration footer, at the end of flash. */
-#ifdef CONFIG_TI_CCFG_PRESENT
+#ifdef CONFIG_HAS_TI_CCFG
     SECTION_PROLOGUE(.ti_ccfg,,)
     {
     KEEP(*(TI_CCFG))

--- a/include/arch/arm/aarch32/cortex_r/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_r/scripts/linker.ld
@@ -43,7 +43,7 @@
 #define ROM_ADDR (CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET)
 #endif
 
-#ifdef CONFIG_TI_CCFG_PRESENT
+#ifdef CONFIG_HAS_TI_CCFG
   #define CCFG_SIZE 88
   #define ROM_SIZE (CONFIG_FLASH_SIZE*1K - CONFIG_FLASH_LOAD_OFFSET - \
 		    CCFG_SIZE)
@@ -92,7 +92,7 @@ _region_min_align = 4;
 MEMORY
     {
     FLASH                 (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
-#ifdef CONFIG_TI_CCFG_PRESENT
+#ifdef CONFIG_HAS_TI_CCFG
     FLASH_CCFG            (rwx): ORIGIN = CCFG_ADDR, LENGTH = CCFG_SIZE
 #endif
 #ifdef DT_CCM_BASE_ADDRESS
@@ -242,7 +242,7 @@ SECTIONS
     GROUP_END(ROMABLE_REGION)
 
 /* Some TI SoCs have a special configuration footer, at the end of flash. */
-#ifdef CONFIG_TI_CCFG_PRESENT
+#ifdef CONFIG_HAS_TI_CCFG
     SECTION_PROLOGUE(.ti_ccfg,,)
     {
     KEEP(*(TI_CCFG))

--- a/soc/arm/ti_simplelink/Kconfig
+++ b/soc/arm/ti_simplelink/Kconfig
@@ -6,9 +6,17 @@ config SOC_FAMILY_TISIMPLELINK
 	bool
 
 if SOC_FAMILY_TISIMPLELINK
+
 config SOC_FAMILY
 	string
 	default "ti_simplelink"
 
 source "soc/arm/ti_simplelink/*/Kconfig.soc"
+
+config HAS_TI_CCFG
+	bool
+	help
+	  Selected when CCFG (Customer Configuration) registers
+	  appear at the end of flash
+
 endif # SOC_FAMILY_TISIMPLELINK

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.series
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.series
@@ -22,10 +22,6 @@ config SYS_CLOCK_TICKS_PER_SEC
 config NUM_IRQS
 	default 38
 
-config TI_CCFG_PRESENT
-	bool
-	default y
-
 config CC13X2_CC26X2_RTC_TIMER
 	default y
 

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.series
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.series
@@ -10,5 +10,6 @@ config SOC_SERIES_CC13X2_CC26X2
 	select CPU_HAS_FPU
 	select SOC_FAMILY_TISIMPLELINK
 	select HAS_CC13X2_CC26X2_SDK
+	select HAS_TI_CCFG
 	help
 	  Enable support for TI SimpleLink CC13x2 / CC26x2 SoCs


### PR DESCRIPTION
Instead of having TI_CCFG_PRESENT as a symbol that's only defined in
soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.series and y when
SOC_SERIES_CC13X2_CC26X2 is enabled, turn it into a helper symbol that's
selected by SOC_SERIES_CC13X2_CC26X2.

This avoids having a symbol that's only defined in a Kconfig.defconfig
file, which is confusing. It also makes things a bit more generic, in
case other boards with CCFGs are added.

Also rename it to HAS_TI_CCFG to be consistent with other helper
symbols, and add a help text.

Flagged by scripts/kconfig/lint.py.