### PR TITLE
canbus: canopen: Fix broken CANOPEN_STORAGE_HANDLER_ERASES_EEPROM ref.

### DIFF
--- a/subsys/canbus/canopen/Kconfig
+++ b/subsys/canbus/canopen/Kconfig
@@ -60,7 +60,6 @@ config CANOPEN_STORAGE
 config CANOPEN_STORAGE_HANDLER_ERASES_EEPROM
 	bool "Erase CANopen object dictionary EEPROM entries in storage handler"
 	depends on CANOPEN_STORAGE
-	default n
 	help
 	  Erase CANopen object dictionary EEPROM entries upon write to
 	  object dictionary index 0x1011 subindex 1.

--- a/subsys/canbus/canopen/canopen_storage.c
+++ b/subsys/canbus/canopen/canopen_storage.c
@@ -100,7 +100,7 @@ static CO_SDO_abortCode_t canopen_odf_1011(CO_ODF_arg_t *odf_arg)
 		LOG_DBG("deleted object dictionary ROM entries");
 	}
 
-#ifdef CANOPEN_STORAGE_HANDLER_ERASES_EEPROM
+#ifdef CONFIG_CANOPEN_STORAGE_HANDLER_ERASES_EEPROM
 	err = canopen_storage_erase(CANOPEN_STORAGE_EEPROM);
 	if (err == -ENOENT) {
 		LOG_DBG("no object dictionary EEPROM entries to delete");


### PR DESCRIPTION
Missing CONFIG_ prefix in #ifdef, leading to some dead code.

Found by scripts/kconfig/lint.py, which flagged it as unused.

Piggyback removal of a redundant 'default n'.