### PR TITLE
kernel: kconfig: Fix broken references to TICKLESS_KERNEL

### DIFF
--- a/boards/arm/qemu_cortex_m0/nrf_timer_timer.c
+++ b/boards/arm/qemu_cortex_m0/nrf_timer_timer.c
@@ -96,7 +96,7 @@ int z_clock_driver_init(struct device *device)
 	nrf_timer_task_trigger(TIMER, NRF_TIMER_TASK_CLEAR);
 	nrf_timer_task_trigger(TIMER, NRF_TIMER_TASK_START);
 
-	if (!IS_ENABLED(TICKLESS_KERNEL)) {
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		set_comparator(counter() + CYC_PER_TICK);
 	}
 

--- a/drivers/timer/legacy_api.h
+++ b/drivers/timer/legacy_api.h
@@ -48,7 +48,7 @@ static u32_t driver_uptime;
 
 u32_t z_clock_elapsed(void)
 {
-#ifdef TICKLESS_KERNEL
+#ifdef CONFIG_TICKLESS_KERNEL
 	return (u32_t)(z_clock_uptime() - driver_uptime);
 #else
 	return 0;

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -105,7 +105,7 @@ int z_clock_driver_init(struct device *device)
 	nrf_rtc_task_trigger(RTC, NRF_RTC_TASK_CLEAR);
 	nrf_rtc_task_trigger(RTC, NRF_RTC_TASK_START);
 
-	if (!IS_ENABLED(TICKLESS_KERNEL)) {
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		set_comparator(counter() + CYC_PER_TICK);
 	}
 


### PR DESCRIPTION
The CONFIG_ prefixes were missing on these.

Found with a work-in-progress scripts/kconfig/lint.py check.

This symbol is defined in kernel/Kconfig.