### PR TITLE
usb: netusb: Replace IS_ENABLED(VERBOSE_DEBUG) with just VERBOSE_DEBUG

### DIFF
--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -253,7 +253,7 @@ static int ecm_send(struct net_pkt *pkt)
 	size_t len = net_pkt_get_len(pkt);
 	int ret;
 
-	if (IS_ENABLED(VERBOSE_DEBUG)) {
+	if (VERBOSE_DEBUG) {
 		net_pkt_hexdump(pkt, "<");
 	}
 
@@ -310,7 +310,7 @@ static void ecm_read_cb(u8_t ep, int size, void *priv)
 		goto done;
 	}
 
-	if (IS_ENABLED(VERBOSE_DEBUG)) {
+	if (VERBOSE_DEBUG) {
 		net_pkt_hexdump(pkt, ">");
 	}
 

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -419,7 +419,7 @@ static void rndis_bulk_out(u8_t ep, enum usb_dc_ep_cb_status_code ep_status)
 	if (!rndis.in_pkt_len) {
 		LOG_DBG("Assembled full RNDIS packet");
 
-		if (IS_ENABLED(VERBOSE_DEBUG)) {
+		if (VERBOSE_DEBUG) {
 			net_pkt_hexdump(rndis.in_pkt, ">");
 		}
 
@@ -831,7 +831,7 @@ static int handle_encapsulated_cmd(u8_t *data, u32_t len)
 {
 	struct tlv *msg = (void *)data;
 
-	if (IS_ENABLED(VERBOSE_DEBUG)) {
+	if (VERBOSE_DEBUG) {
 		net_hexdump("CMD >", data, len);
 	}
 
@@ -878,7 +878,7 @@ static int handle_encapsulated_rsp(u8_t **data, u32_t *len)
 		return -ENODATA;
 	}
 
-	if (IS_ENABLED(VERBOSE_DEBUG)) {
+	if (VERBOSE_DEBUG) {
 		net_hexdump("RSP <", buf->data, buf->len);
 	}
 
@@ -973,7 +973,7 @@ static int rndis_send(struct net_pkt *pkt)
 		return -EPIPE;
 	}
 
-	if (IS_ENABLED(VERBOSE_DEBUG)) {
+	if (VERBOSE_DEBUG) {
 		net_pkt_hexdump(pkt, "<");
 	}
 


### PR DESCRIPTION
IS_ENABLED() is only useful for macros that might be undefined.
VERBOSE_DEBUG is defined at the top of these files.

Also makes it harder to confuse for for Kconfig references.