### PR TITLE
NXP Kinetis: Only perform early watchdog initialisation once

### DIFF
--- a/soc/arm/nxp_kinetis/Kconfig
+++ b/soc/arm/nxp_kinetis/Kconfig
@@ -151,4 +151,13 @@ config KINETIS_FLASH_CONFIG_FDPROT
 
 endif # KINETIS_FLASH_CONFIG
 
+config WDOG_INIT
+	bool
+	default y
+	help
+	  This processor enables the watchdog timer with a short
+	  window for configuration upon reset. Therefore, this
+	  requires that the watchdog be configured during reset
+	  handling.
+
 endif # SOC_FAMILY_KINETIS

--- a/soc/arm/nxp_kinetis/Kconfig
+++ b/soc/arm/nxp_kinetis/Kconfig
@@ -153,7 +153,7 @@ endif # KINETIS_FLASH_CONFIG
 
 config WDOG_INIT
 	bool
-	default y
+	default !BOOTLOADER_MCUBOOT
 	help
 	  This processor enables the watchdog timer with a short
 	  window for configuration upon reset. Therefore, this

--- a/soc/arm/nxp_kinetis/k2x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/k2x/Kconfig.soc
@@ -70,11 +70,4 @@ config K22_FLASH_CLOCK_DIVIDER
 	  This option specifies the divide value for the K64 flash clock from the
 	  system clock.
 
-config WDOG_INIT
-	def_bool y
-	help
-	  This processor enables the watchdog timer with a short timeout
-	  upon reset. Therefore, this requires that the watchdog be configured
-	  during reset handling.
-
 endif # SOC_SERIES_KINETIS_K2X

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.soc
@@ -97,11 +97,4 @@ config K64_FLASH_CLOCK_DIVIDER
 	  This option specifies the divide value for the K64 flash clock from the
 	  system clock.
 
-config WDOG_INIT
-	def_bool y
-	help
-	  This processor enables the watchdog timer with a short timeout
-	  upon reset. Therefore, this requires that the watchdog be configured
-	  during reset handling.
-
 endif # SOC_SERIES_KINETIS_K6X

--- a/soc/arm/nxp_kinetis/k8x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/k8x/Kconfig.soc
@@ -69,12 +69,4 @@ config K8X_FLASH_CLOCK_DIVIDER
 	  This option specifies the divide value for the K8x flash clock from the
 	  system clock.
 
-config WDOG_INIT
-	def_bool y
-	help
-	  This processor enables the watchdog timer with a short
-	  window for configuration upon reset. Therefore, this
-	  requires that the watchdog be configured during reset
-	  handling.
-
 endif # SOC_SERIES_KINETIS_K8X

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.soc
@@ -78,14 +78,6 @@ config SOC_PART_NUMBER_KINETIS_KE1XF
 	  number selection choice defines the default value for this
 	  string.
 
-config WDOG_INIT
-	def_bool y
-	help
-	  This processor enables the watchdog timer with a short
-	  window for configuration upon reset. Therefore, this
-	  requires that the watchdog be configured during reset
-	  handling.
-
 config KINETIS_KE1XF_ENABLE_CODE_CACHE
 	bool "Enable the code cache"
 	default y

--- a/soc/arm/nxp_kinetis/kl2x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/kl2x/Kconfig.soc
@@ -77,4 +77,12 @@ config SOC_PART_NUMBER_KINETIS_KL2X
 	  that you should not set directly. The part number selection choice defines
 	  the default value for this string.
 
+config WDOG_INIT
+	def_bool y
+	help
+	  This processor enables the watchdog timer with a short
+	  window for configuration upon reset. Therefore, this
+	  requires that the watchdog be configured during reset
+	  handling.
+
 endif # SOC_SERIES_KINETIS_KL2X

--- a/soc/arm/nxp_kinetis/kl2x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/kl2x/Kconfig.soc
@@ -77,12 +77,4 @@ config SOC_PART_NUMBER_KINETIS_KL2X
 	  that you should not set directly. The part number selection choice defines
 	  the default value for this string.
 
-config WDOG_INIT
-	def_bool y
-	help
-	  This processor enables the watchdog timer with a short
-	  window for configuration upon reset. Therefore, this
-	  requires that the watchdog be configured during reset
-	  handling.
-
 endif # SOC_SERIES_KINETIS_KL2X

--- a/soc/arm/nxp_kinetis/kl2x/soc.c
+++ b/soc/arm/nxp_kinetis/kl2x/soc.c
@@ -81,9 +81,6 @@ static int kl2x_init(struct device *arg)
 	/* disable interrupts */
 	oldLevel = irq_lock();
 
-	/* Disable the watchdog */
-	SIM->COPC = 0;
-
 	/* Initialize system clock to 48 MHz */
 	clock_init();
 
@@ -96,6 +93,12 @@ static int kl2x_init(struct device *arg)
 	/* restore interrupt state */
 	irq_unlock(oldLevel);
 	return 0;
+}
+
+void z_arm_watchdog_init(void)
+{
+	/* Disable the watchdog */
+	SIM->COPC = 0;
 }
 
 SYS_INIT(kl2x_init, PRE_KERNEL_1, 0);

--- a/soc/arm/nxp_kinetis/kv5x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/kv5x/Kconfig.soc
@@ -85,12 +85,4 @@ config KV5X_FLASH_CLOCK_DIVIDER
 	  This option specifies the divide value for the KV5X flash clock from the
 	  system clock.
 
-config WDOG_INIT
-	def_bool y
-	help
-	  This processor enables the watchdog timer with a short
-	  window for configuration upon reset. Therefore, this
-	  requires that the watchdog be configured during reset
-	  handling.
-
 endif # SOC_SERIES_KINETIS_KV5X

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.soc
@@ -113,11 +113,4 @@ config KW2XD_FLASH_CLOCK_DIVIDER
 
 endif # SOC_MKW24D5 || SOC_MKW22D5
 
-config WDOG_INIT
-	def_bool y
-	help
-	  This processor enables the watchdog timer with a short timeout
-	  upon reset. Therefore, this requires that the watchdog be configured
-	  during reset handling.
-
 endif # SOC_SERIES_KINETIS_KWX

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.soc
@@ -111,13 +111,13 @@ config KW2XD_FLASH_CLOCK_DIVIDER
 	  This option specifies the divide value for the KW2xD flash clock from
 	  the system clock.
 
+endif # SOC_MKW24D5 || SOC_MKW22D5
+
 config WDOG_INIT
 	def_bool y
 	help
 	  This processor enables the watchdog timer with a short timeout
 	  upon reset. Therefore, this requires that the watchdog be configured
 	  during reset handling.
-
-endif # SOC_MKW24D5 || SOC_MKW22D5
 
 endif # SOC_SERIES_KINETIS_KWX

--- a/soc/arm/nxp_kinetis/kwx/soc_kw4xz.c
+++ b/soc/arm/nxp_kinetis/kwx/soc_kw4xz.c
@@ -80,9 +80,6 @@ static int kwx_init(struct device *arg)
 	/* disable interrupts */
 	oldLevel = irq_lock();
 
-	/* Disable the watchdog */
-	SIM->COPC = 0;
-
 	/* Initialize system clock to 40 MHz */
 	clock_init();
 
@@ -95,6 +92,12 @@ static int kwx_init(struct device *arg)
 	/* restore interrupt state */
 	irq_unlock(oldLevel);
 	return 0;
+}
+
+void z_arm_watchdog_init(void)
+{
+	/* Disable the watchdog */
+	SIM->COPC = 0;
 }
 
 SYS_INIT(kwx_init, PRE_KERNEL_1, 0);


### PR DESCRIPTION
Currently, early watchdog initialisation (by calling `z_arm_watchdog_init`) is done by both the boot loader and the application. Early watchdog initialisation should be just that (early) and must happen a SoC specific number of clock cycles after reset.

This series of patches unifies the `CONFIG_WDOG_INIT` symbol across the NXP Kinetis series and disables it for applications to be chainloaded by MCUboot.

This has been tested to work with the `twr_ke18f` and `frdm_k64f` boards.