### PR TITLE
sanitycheck: leave non-tty terminal unmodified on exit

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -4365,4 +4365,5 @@ if __name__ == "__main__":
     try:
         main()
     finally:
-        os.system("stty sane")
+        if os.isatty(1): # stdout is interactive
+            os.system("stty sane")


### PR DESCRIPTION
#21655 broke `sanitycheck --help | less` since the terminal reconfiguration set by the pager was reverted after sanitycheck exited but while the pager was still active.  This PR makes the reset conditional on the terminal output being interactive.