### PR TITLE
west.yml: update hal_nxp to use full path to driver headers

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -86,7 +86,7 @@ manifest:
       revision: 30b7efa827b04d2e47840716b0372737fe7d6c92
       path: tools/net-tools
     - name: hal_nxp
-      revision: 7f45cbef08deca18b3931c087fd28ea34f45bade
+      revision: 62b46313b8e07e2d5062fd62f14ee9dfeb201b76
       path: modules/hal/nxp
     - name: open-amp
       revision: 9b591b289e1f37339bd038b5a1f0e6c8ad39c63a


### PR DESCRIPTION
Zephyr-specific files in mcux break when the drivers subdirectory is
no longer present in the include path.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>