### PR TITLE
dts: gen_defines.py: Do not crash on 'type: path' properties

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -238,8 +238,8 @@ def should_write(prop):
         return False
 
     # For these, Property.val becomes an edtlib.Node, a list of edtlib.Nodes,
-    # and None, respectively. Nothing is generated for them though.
-    if prop.type in {"phandle", "phandles", "compound"}:
+    # or None. Nothing is generated for them at the moment.
+    if prop.type in {"phandle", "phandles", "path", "compound"}:
         return False
 
     # Skip properties that we handle elsewhere


### PR DESCRIPTION
'type: path' was added to edtlib for completeness in commit 23a5b4963b
("dts: edtlib: Add 'type: path' for path references"). gen_defines.py
crashes if it's ever used though, because it gets confused for a
'type: phandle-array'.

Ignore 'type: path' properties in gen_defines.py, like how
'type: phandle' and 'type: phandles' are currently ignored too.

(Note that gen_defines.py is only one possible user of edtlib.)

Fixes: #22197