### PR TITLE
[TOPIC-GPIO]: Convert LMP90xxx ADC and GPIO drivers to new GPIO API

### DIFF
--- a/boards/shields/lmp90100_evb/lmp90100_evb.overlay
+++ b/boards/shields/lmp90100_evb/lmp90100_evb.overlay
@@ -16,10 +16,12 @@
 		/* drdyb-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>; */
 		#io-channel-cells = <2>;
 
-		gpio {
+		lmp90100_gpio: gpio {
 			compatible = "ti,lmp90xxx-gpio";
 			gpio-controller;
 			label = "LMP90100_GPIO";
+			/* Reduce to 6 if drdyb is used */
+			ngpios = <7>;
 			#gpio-cells = <2>;
 		};
 	};

--- a/drivers/adc/adc_lmp90xxx.c
+++ b/drivers/adc/adc_lmp90xxx.c
@@ -111,8 +111,8 @@ struct lmp90xxx_config {
 	u8_t spi_cs_pin;
 	struct spi_config spi_cfg;
 	const char *drdyb_dev_name;
-	u32_t drdyb_pin;
-	int drdyb_flags;
+	gpio_pin_t drdyb_pin;
+	gpio_devicetree_flags_t drdyb_flags;
 	u8_t rtd_current;
 	u8_t resolution;
 	u8_t channels;
@@ -990,8 +990,7 @@ static int lmp90xxx_init(struct device *dev)
 		}
 
 		err = gpio_pin_configure(drdyb_dev, config->drdyb_pin,
-					 (GPIO_DIR_IN | GPIO_INT |
-					 GPIO_INT_EDGE | config->drdyb_flags));
+					 GPIO_INPUT | config->drdyb_flags);
 		if (err) {
 			LOG_ERR("failed to configure DRDYB GPIO pin (err %d)",
 				err);
@@ -1015,10 +1014,10 @@ static int lmp90xxx_init(struct device *dev)
 			return err;
 		}
 
-		err = gpio_pin_enable_callback(drdyb_dev,
-					       config->drdyb_pin);
+		err = gpio_pin_interrupt_configure(drdyb_dev, config->drdyb_pin,
+						   GPIO_INT_EDGE_TO_ACTIVE);
 		if (err) {
-			LOG_ERR("failed to enable DRDBY callback (err %d)",
+			LOG_ERR("failed to configure DRDBY interrupt (err %d)",
 				err);
 			return -EINVAL;
 		}

--- a/include/drivers/adc/lmp90xxx.h
+++ b/include/drivers/adc/lmp90xxx.h
@@ -8,7 +8,7 @@
 #define ZEPHYR_INCLUDE_DRIVERS_ADC_LMP90XXX_H_
 
 #include <device.h>
-#include <zephyr/types.h>
+#include <drivers/gpio.h>
 
 /* LMP90xxx supports GPIO D0..D6 */
 #define LMP90XXX_GPIO_MAX 6
@@ -20,5 +20,18 @@ int lmp90xxx_gpio_set_input(struct device *dev, u8_t pin);
 int lmp90xxx_gpio_set_pin_value(struct device *dev, u8_t pin, bool value);
 
 int lmp90xxx_gpio_get_pin_value(struct device *dev, u8_t pin, bool *value);
+
+int lmp90xxx_gpio_port_get_raw(struct device *dev, gpio_port_value_t *value);
+
+int lmp90xxx_gpio_port_set_masked_raw(struct device *dev,
+				      gpio_port_pins_t mask,
+				      gpio_port_value_t value);
+
+int lmp90xxx_gpio_port_set_bits_raw(struct device *dev, gpio_port_pins_t pins);
+
+int lmp90xxx_gpio_port_clear_bits_raw(struct device *dev,
+				      gpio_port_pins_t pins);
+
+int lmp90xxx_gpio_port_toggle_bits(struct device *dev, gpio_port_pins_t pins);
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_ADC_LMP90XXX_H_ */


### PR DESCRIPTION
Convert both the GPIO controller part and the GPIO consumer (interrupt consumer) part of the TI LMP90xxx drivers to use the new GPIO API.