### PR TITLE
[TOPIC-GPIO] drivers: ieee802154_rf2xx: convert to the new GPIO API

### DIFF
--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
@@ -82,10 +82,10 @@
 		reg = <0x0>;
 		label = "RF2XX_0";
 		spi-max-frequency = <8000000>;
-		irq-gpios = <&portb 0 0>;
-		reset-gpios = <&portb 15 0>;
-		slptr-gpios = <&porta 20 0>;
-		dig2-gpios = <&portb 17 0>;
+		irq-gpios = <&portb 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+		reset-gpios = <&portb 15 GPIO_ACTIVE_LOW>;
+		slptr-gpios = <&porta 20 GPIO_ACTIVE_HIGH>;
+		dig2-gpios = <&portb 17 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		status = "okay";
 	};
 };

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -455,7 +455,8 @@ static int rf2xx_start(struct device *dev)
 	struct rf2xx_context *ctx = dev->driver_data;
 
 	k_mutex_lock(&ctx->phy_mutex, K_FOREVER);
-	gpio_pin_enable_callback(ctx->irq_gpio, conf->irq.pin);
+	gpio_pin_interrupt_configure(ctx->irq_gpio, conf->irq.pin,
+				     GPIO_INT_EDGE_TO_ACTIVE);
 	rf2xx_trx_set_rx_state(dev);
 	k_mutex_unlock(&ctx->phy_mutex);
 
@@ -468,7 +469,8 @@ static int rf2xx_stop(struct device *dev)
 	struct rf2xx_context *ctx = dev->driver_data;
 
 	k_mutex_lock(&ctx->phy_mutex, K_FOREVER);
-	gpio_pin_disable_callback(ctx->irq_gpio, conf->irq.pin);
+	gpio_pin_interrupt_configure(ctx->irq_gpio, conf->irq.pin,
+				     GPIO_INT_DISABLE);
 	rf2xx_trx_set_state(dev, RF2XX_TRX_PHY_STATE_CMD_TRX_OFF);
 	k_mutex_unlock(&ctx->phy_mutex);
 
@@ -569,9 +571,10 @@ static inline int configure_gpios(struct device *dev)
 			conf->irq.devname);
 		return -EINVAL;
 	}
-	gpio_pin_configure(ctx->irq_gpio, conf->irq.pin,
-			   GPIO_DIR_IN | GPIO_INT | GPIO_INT_EDGE |
-			   GPIO_PUD_PULL_DOWN | GPIO_INT_ACTIVE_HIGH);
+	gpio_pin_configure(ctx->irq_gpio, conf->irq.pin, conf->irq.flags |
+			   GPIO_INPUT);
+	gpio_pin_interrupt_configure(ctx->irq_gpio, conf->irq.pin,
+				     GPIO_INT_EDGE_TO_ACTIVE);
 
 	/* Chip RESET line */
 	ctx->reset_gpio = device_get_binding(conf->reset.devname);
@@ -580,8 +583,8 @@ static inline int configure_gpios(struct device *dev)
 			conf->reset.devname);
 		return -EINVAL;
 	}
-	gpio_pin_configure(ctx->reset_gpio, conf->reset.pin,
-			   GPIO_DIR_OUT | GPIO_PUD_NORMAL | GPIO_POL_NORMAL);
+	gpio_pin_configure(ctx->reset_gpio, conf->reset.pin, conf->reset.flags |
+			   GPIO_OUTPUT_INACTIVE);
 
 	/* Chip SLPTR line */
 	ctx->slptr_gpio = device_get_binding(conf->slptr.devname);
@@ -590,8 +593,8 @@ static inline int configure_gpios(struct device *dev)
 			conf->slptr.devname);
 		return -EINVAL;
 	}
-	gpio_pin_configure(ctx->slptr_gpio, conf->slptr.pin,
-			   GPIO_DIR_OUT | GPIO_PUD_NORMAL | GPIO_POL_NORMAL);
+	gpio_pin_configure(ctx->slptr_gpio, conf->slptr.pin, conf->slptr.flags |
+			   GPIO_OUTPUT_INACTIVE);
 
 	/* Chip DIG2 line (Optional feature) */
 	ctx->dig2_gpio = device_get_binding(conf->dig2.devname);
@@ -599,9 +602,9 @@ static inline int configure_gpios(struct device *dev)
 		LOG_INF("Optional instance of %s device activated",
 			conf->dig2.devname);
 		gpio_pin_configure(ctx->dig2_gpio, conf->dig2.pin,
-				   GPIO_DIR_IN |
-				   GPIO_PUD_PULL_DOWN |
-				   GPIO_INT_ACTIVE_HIGH);
+				   conf->dig2.flags | GPIO_INPUT);
+		gpio_pin_interrupt_configure(ctx->dig2_gpio, conf->dig2.pin,
+					     GPIO_INT_EDGE_TO_ACTIVE);
 	}
 
 	/* Chip CLKM line (Optional feature) */
@@ -610,7 +613,7 @@ static inline int configure_gpios(struct device *dev)
 		LOG_INF("Optional instance of %s device activated",
 			conf->clkm.devname);
 		gpio_pin_configure(ctx->clkm_gpio, conf->clkm.pin,
-				   GPIO_DIR_IN | GPIO_PUD_NORMAL);
+				   conf->clkm.flags | GPIO_INPUT);
 	}
 
 	return 0;

--- a/drivers/ieee802154/ieee802154_rf2xx_iface.c
+++ b/drivers/ieee802154/ieee802154_rf2xx_iface.c
@@ -29,15 +29,15 @@ void rf2xx_iface_phy_rst(struct device *dev)
 	const struct rf2xx_context *ctx = dev->driver_data;
 
 	/* Ensure control lines have correct levels. */
-	gpio_pin_write(ctx->reset_gpio, conf->reset.pin, 1);
-	gpio_pin_write(ctx->slptr_gpio, conf->slptr.pin, 0);
+	gpio_pin_set(ctx->reset_gpio, conf->reset.pin, 0);
+	gpio_pin_set(ctx->slptr_gpio, conf->slptr.pin, 0);
 
 	/* Wait typical time of timer TR1. */
 	k_busy_wait(330);
 
-	gpio_pin_write(ctx->reset_gpio, conf->reset.pin, 0);
+	gpio_pin_set(ctx->reset_gpio, conf->reset.pin, 1);
 	k_busy_wait(10);
-	gpio_pin_write(ctx->reset_gpio, conf->reset.pin, 1);
+	gpio_pin_set(ctx->reset_gpio, conf->reset.pin, 0);
 }
 void rf2xx_iface_phy_tx_start(struct device *dev)
 {
@@ -45,11 +45,11 @@ void rf2xx_iface_phy_tx_start(struct device *dev)
 	const struct rf2xx_context *ctx = dev->driver_data;
 
 	/* Start TX transmission at rise edge */
-	gpio_pin_write(ctx->slptr_gpio, conf->slptr.pin, 1);
+	gpio_pin_set(ctx->slptr_gpio, conf->slptr.pin, 1);
 	/* 16.125[μs] delay to detect signal */
 	k_busy_wait(20);
 	/* restore initial pin state */
-	gpio_pin_write(ctx->slptr_gpio, conf->slptr.pin, 0);
+	gpio_pin_set(ctx->slptr_gpio, conf->slptr.pin, 0);
 }
 
 u8_t rf2xx_iface_reg_read(struct device *dev,


### PR DESCRIPTION
Use new GPIO configuration API, set pin active level in devicetree source.