### PR TITLE
dts: bindings: semtech,sx1276: Remove redundant document separator

### DIFF
--- a/dts/bindings/lora/semtech,sx1276.yaml
+++ b/dts/bindings/lora/semtech,sx1276.yaml
@@ -1,8 +1,5 @@
-#
 # Copyright (c) 2019, Manivannan Sadhasivam
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 description: Semtech SX1276 LoRa Modem
 
@@ -18,4 +15,3 @@ properties:
     dio-gpios:
       type: phandle-array
       required: true
-...


### PR DESCRIPTION
Not needed. Bindings are never concatenated together.

Makes the https://github.com/zephyrproject-rtos/ci-tools/pull/123 check
clean, though it only looks at changed files in PRs.

Clean up the header too.