### PR TITLE
[TOPIC-GPIO] drivers: lora: update for new GPIO API

### DIFF
--- a/boards/arm/96b_wistrio/96b_wistrio.dts
+++ b/boards/arm/96b_wistrio/96b_wistrio.dts
@@ -65,9 +65,12 @@
 		compatible = "semtech,sx1276";
 		reg = <0>;
 		label = "sx1276";
-		reset-gpios = <&gpiob 13 0>;
-		dio-gpios = <&gpioa 11 0 &gpiob 1 0 &gpioa 3 0
-			     &gpioh 0 0 &gpioc 13 0>;
+		reset-gpios = <&gpiob 13 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		dio-gpios = <&gpioa 11 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
+			<&gpiob 1 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
+			<&gpioa 3 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
+			<&gpioh 0 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
+			<&gpioc 13 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
 		spi-max-frequency = <1000000>;
 	};
 };

--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -16,9 +16,8 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(sx1276);
 
-#define SX1276_MAX_DIO		5
-
 #define GPIO_RESET_PIN		DT_INST_0_SEMTECH_SX1276_RESET_GPIOS_PIN
+#define GPIO_RESET_FLAGS	DT_INST_0_SEMTECH_SX1276_RESET_GPIOS_FLAGS
 #define GPIO_CS_PIN		DT_INST_0_SEMTECH_SX1276_CS_GPIOS_PIN
 
 #define SX1276_REG_PA_CONFIG			0x09
@@ -27,21 +26,20 @@ LOG_MODULE_REGISTER(sx1276);
 
 extern DioIrqHandler *DioIrq[];
 
-int sx1276_dio_pins[SX1276_MAX_DIO] = {
-	DT_INST_0_SEMTECH_SX1276_DIO_GPIOS_PIN_0,
-	DT_INST_0_SEMTECH_SX1276_DIO_GPIOS_PIN_1,
-	DT_INST_0_SEMTECH_SX1276_DIO_GPIOS_PIN_2,
-	DT_INST_0_SEMTECH_SX1276_DIO_GPIOS_PIN_3,
-	DT_INST_0_SEMTECH_SX1276_DIO_GPIOS_PIN_4,
+struct sx1276_dio {
+	const char *port;
+	gpio_pin_t pin;
+	gpio_devicetree_flags_t flags;
 };
 
-static char sx1276_dio_ports[SX1276_MAX_DIO][6] = {
-	DT_INST_0_SEMTECH_SX1276_DIO_GPIOS_CONTROLLER_0,
-	DT_INST_0_SEMTECH_SX1276_DIO_GPIOS_CONTROLLER_1,
-	DT_INST_0_SEMTECH_SX1276_DIO_GPIOS_CONTROLLER_2,
-	DT_INST_0_SEMTECH_SX1276_DIO_GPIOS_CONTROLLER_3,
-	DT_INST_0_SEMTECH_SX1276_DIO_GPIOS_CONTROLLER_4,
-};
+static struct sx1276_dio sx1276_dios[] =
+#ifdef DT_INST_0_SEMTECH_SX1276_DIO_GPIOS_PIN_0
+	DT_INST_0_SEMTECH_SX1276_DIO_GPIOS
+#else
+	{DT_INST_0_SEMTECH_SX1276_DIO_GPIOS}
+#endif
+	;
+#define SX1276_MAX_DIO ARRAY_SIZE(sx1276_dios)
 
 struct sx1276_data {
 	struct device *counter;
@@ -84,13 +82,12 @@ void SX1276SetAntSw(u8_t opMode)
 void SX1276Reset(void)
 {
 	gpio_pin_configure(dev_data.reset, GPIO_RESET_PIN,
-			   GPIO_DIR_OUT | GPIO_PUD_NORMAL);
-	gpio_pin_write(dev_data.reset, GPIO_RESET_PIN, 0);
+			   GPIO_OUTPUT_ACTIVE | GPIO_RESET_FLAGS);
 
 	k_sleep(1);
 
-	gpio_pin_configure(dev_data.reset, GPIO_RESET_PIN,
-			   GPIO_DIR_IN | GPIO_PUD_NORMAL);
+	gpio_pin_set(dev_data.reset, GPIO_RESET_PIN, 0);
+
 	k_sleep(6);
 }
 
@@ -148,7 +145,7 @@ static void sx1276_irq_callback(struct device *dev,
 	pin = find_lsb_set(pins) - 1;
 
 	for (i = 0; i < SX1276_MAX_DIO; i++) {
-		if (pin == sx1276_dio_pins[i]) {
+		if (pin == sx1276_dios[i].pin) {
 			(*DioIrq[i])(NULL);
 		}
 	}
@@ -161,27 +158,28 @@ void SX1276IoIrqInit(DioIrqHandler **irqHandlers)
 
 	/* Setup DIO gpios */
 	for (i = 0; i < SX1276_MAX_DIO; i++) {
-		dev_data.dio_dev[i] = device_get_binding(sx1276_dio_ports[i]);
+		dev_data.dio_dev[i] = device_get_binding(sx1276_dios[i].port);
 		if (dev_data.dio_dev[i] == NULL) {
 			LOG_ERR("Cannot get pointer to %s device",
-				sx1276_dio_ports[i]);
+				sx1276_dios[i].port);
 			return;
 		}
 
-		gpio_pin_configure(dev_data.dio_dev[i], sx1276_dio_pins[i],
-				   GPIO_DIR_IN | GPIO_INT | GPIO_INT_EDGE |
-				   GPIO_INT_DEBOUNCE | GPIO_INT_ACTIVE_HIGH);
+		gpio_pin_configure(dev_data.dio_dev[i], sx1276_dios[i].pin,
+				   GPIO_INPUT | GPIO_INT_DEBOUNCE
+				   | sx1276_dios[i].flags);
 
 		gpio_init_callback(&callbacks[i],
 				   sx1276_irq_callback,
-				   BIT(sx1276_dio_pins[i]));
+				   BIT(sx1276_dios[i].pin));
 
 		if (gpio_add_callback(dev_data.dio_dev[i], &callbacks[i]) < 0) {
 			LOG_ERR("Could not set gpio callback.");
 			return;
 		}
-		gpio_pin_enable_callback(dev_data.dio_dev[i],
-					 sx1276_dio_pins[i]);
+		gpio_pin_interrupt_configure(dev_data.dio_dev[i],
+					     sx1276_dios[i].pin,
+					     GPIO_INT_EDGE_TO_ACTIVE);
 	}
 
 }
@@ -458,12 +456,12 @@ static int sx1276_lora_init(struct device *dev)
 		return -EIO;
 	}
 
-	ret = gpio_pin_configure(dev_data.reset, GPIO_RESET_PIN, GPIO_DIR_OUT);
-
 	/* Perform soft reset */
-	gpio_pin_write(dev_data.reset, GPIO_RESET_PIN, 0);
+	ret = gpio_pin_configure(dev_data.reset, GPIO_RESET_PIN,
+				 GPIO_OUTPUT_ACTIVE | GPIO_RESET_FLAGS);
+
 	k_sleep(100);
-	gpio_pin_write(dev_data.reset, GPIO_RESET_PIN, 1);
+	gpio_pin_set(dev_data.reset, GPIO_RESET_PIN, 0);
 	k_sleep(100);
 
 	ret = sx1276_read(SX1276_REG_VERSION, &regval, 1);

--- a/dts/bindings/lora/semtech,sx1276.yaml
+++ b/dts/bindings/lora/semtech,sx1276.yaml
@@ -14,8 +14,17 @@ properties:
     reset-gpios:
       type: phandle-array
       required: true
+      description: |
+        GPIO connected to the sensor NRST signal.
+
+        This signal is open-drain, active-low as interpreted by the
+        modem.
 
     dio-gpios:
       type: phandle-array
       required: true
+      description: |
+        Up to six pins that produce service interrupts from the modem.
+
+        These signals are normally active-high.
 ...


### PR DESCRIPTION
Update the lora/sx1276 driver to the new GPIO API, using configured
active level and the replacement interrupt and active-sensitive set
APIs.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>