### PR TITLE
dts: bindings: ps2: Replace 'should be 1/0' comments with 'const: 1/0'

### DIFF
--- a/dts/bindings/ps2/ps2.yaml
+++ b/dts/bindings/ps2/ps2.yaml
@@ -11,10 +11,10 @@ properties:
     "#address-cells":
       type: int
       required: true
-      description: should be 1.
+      const: 1
     "#size-cells":
       type: int
       required: true
-      description: should be 0.
+      const: 0
     label:
       required: true


### PR DESCRIPTION
Check with 'const:' that #address-cells is 1 and #size-cells is 0. That
way other values will get flagged by edtlib.