### PR TITLE
Crypto fixes

### DIFF
--- a/subsys/random/rand32_ctr_drbg.c
+++ b/subsys/random/rand32_ctr_drbg.c
@@ -82,7 +82,11 @@ static int ctr_drbg_initialize(void)
 
 	u8_t entropy[TC_AES_KEY_SIZE + TC_AES_BLOCK_SIZE];
 
-	entropy_get_entropy(entropy_driver, (void *)&entropy, sizeof(entropy));
+	ret = entropy_get_entropy(entropy_driver, (void *)&entropy,
+				  sizeof(entropy));
+	if (ret != 0) {
+		return -EIO;
+	}
 
 	ret = tc_ctr_prng_init(&ctr_ctx,
 			       (uint8_t *)&entropy,


### PR DESCRIPTION
- Ensure that sys_crand_get is getting data from entropy device only
https://github.com/zephyrproject-rtos/zephyr/issues/22223

- Fix csprng entropy initialization when using TinyCrypt