### PR TITLE
Bluetooth: Mesh: Fix provisioning buffer initialization

### DIFF
--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -304,6 +304,10 @@ int bt_mesh_init(const struct bt_mesh_prov *prov,
 		return err;
 	}
 
+	if (IS_ENABLED(CONFIG_BT_MESH_PROXY)) {
+		bt_mesh_proxy_init();
+	}
+
 	if (IS_ENABLED(CONFIG_BT_MESH_PROV)) {
 		err = bt_mesh_prov_init(prov);
 		if (err) {
@@ -315,10 +319,6 @@ int bt_mesh_init(const struct bt_mesh_prov *prov,
 	bt_mesh_trans_init();
 	bt_mesh_beacon_init();
 	bt_mesh_adv_init();
-
-	if (IS_ENABLED(CONFIG_BT_MESH_PROXY)) {
-		bt_mesh_proxy_init();
-	}
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		bt_mesh_settings_init();


### PR DESCRIPTION
When PB-GATT support has been enabled the provisioning code "borrows"
the buffer from the proxy code. However, the way that initialization
was happening the proxy buffers were initialized only after
provisioning initialization, resulting in a corrupted buffer with
buf->data pointing to NULL. Reorder the initialization calls so that
proxy is done first and provisioning only after it.

Fixes #22207

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>