### PR TITLE
logging: Fix forcing printk processing with RTT

### DIFF
--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -429,7 +429,7 @@ endif # LOG_BACKEND_RTT_BUFFER
 # interrupted by an interrupt.
 config LOG_BACKEND_RTT_FORCE_PRINTK
 	bool
-	default y if LOG_BACKEND_RTT_BUFFER = 0
+	default y if LOG_BACKEND_RTT_BUFFER = 0 && RTT_CONSOLE
 	select LOG_PRINTK
 
 endif # LOG_BACKEND_RTT


### PR DESCRIPTION
Printk should be processed by the logger if RTT logger backend is
used and RTT console. It is not necessary if console has different
transport.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>