### PR TITLE
drivers: modem: ublox-sara-r4: fix modem reset

### DIFF
--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -755,10 +755,11 @@ static void modem_reset(void)
 #endif
 
 	/* bring down network interface */
-	if(mdata.net_iface)
-	  atomic_clear_bit(mdata.net_iface->if_dev->flags, NET_IF_UP);
-	else
-	  LOG_WRN("mdata.net_iface = NULL");
+	if (mdata.net_iface) {
+		atomic_clear_bit(mdata.net_iface->if_dev->flags, NET_IF_UP);
+	} else {
+		LOG_WRN("mdata.net_iface = NULL");
+	}
 
 restart:
 	/* stop RSSI delay work */
@@ -828,23 +829,23 @@ restart:
 	/* wait for +CREG: 1(normal) or 5(roaming) */
 	counter = 0;
 	while (counter++ < 40 && mdata.ev_creg != 1 && mdata.ev_creg != 5) {
+		if (counter == 20) {
+			LOG_WRN("Force restart of RF functionality");
 
-	  if(counter == 20) {
-	    LOG_WRN("Force restart of RF functionality");
+			/* Disable RF temporarily */
+			ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler,
+				NULL, 0, "AT+CFUN=0", &mdata.sem_response,
+				MDM_CMD_TIMEOUT);
 
-	    /* Disable RF temporarily */
-	    ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler,
-				 NULL, 0, "AT+CFUN=0", &mdata.sem_response,
-				 MDM_CMD_TIMEOUT);
-	    k_sleep(K_SECONDS(1));
+			k_sleep(K_SECONDS(1));
 
-	    /* Enable RF */
-	    ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler,
-				 NULL, 0, "AT+CFUN=1", &mdata.sem_response,
-				 MDM_CMD_TIMEOUT);	    
-	  }
-	  
-	  k_sleep(K_SECONDS(1));
+			/* Enable RF */
+			ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler,
+				NULL, 0, "AT+CFUN=1", &mdata.sem_response,
+				MDM_CMD_TIMEOUT);
+		}
+
+		k_sleep(K_SECONDS(1));
 	}
 
 	/* query modem RSSI */
@@ -886,8 +887,9 @@ restart:
 	LOG_INF("Network is ready.");
 
 	/* Set iface up */
-	if(mdata.net_iface)
-	  net_if_up(mdata.net_iface);
+	if (mdata.net_iface) {
+		net_if_up(mdata.net_iface);
+	}
 
 	/* start RSSI query */
 	k_delayed_work_submit_to_queue(&modem_workq,

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -755,7 +755,10 @@ static void modem_reset(void)
 #endif
 
 	/* bring down network interface */
-	atomic_clear_bit(mdata.net_iface->if_dev->flags, NET_IF_UP);
+	if(mdata.net_iface)
+	  atomic_clear_bit(mdata.net_iface->if_dev->flags, NET_IF_UP);
+	else
+	  LOG_WRN("mdata.net_iface = NULL");
 
 restart:
 	/* stop RSSI delay work */
@@ -824,8 +827,24 @@ restart:
 
 	/* wait for +CREG: 1(normal) or 5(roaming) */
 	counter = 0;
-	while (counter++ < 20 && mdata.ev_creg != 1 && mdata.ev_creg != 5) {
-		k_sleep(K_SECONDS(1));
+	while (counter++ < 40 && mdata.ev_creg != 1 && mdata.ev_creg != 5) {
+
+	  if(counter == 20) {
+	    LOG_WRN("Force restart of RF functionality");
+
+	    /* Disable RF temporarily */
+	    ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler,
+				 NULL, 0, "AT+CFUN=0", &mdata.sem_response,
+				 MDM_CMD_TIMEOUT);
+	    k_sleep(K_SECONDS(1));
+
+	    /* Enable RF */
+	    ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler,
+				 NULL, 0, "AT+CFUN=1", &mdata.sem_response,
+				 MDM_CMD_TIMEOUT);	    
+	  }
+	  
+	  k_sleep(K_SECONDS(1));
 	}
 
 	/* query modem RSSI */
@@ -867,7 +886,8 @@ restart:
 	LOG_INF("Network is ready.");
 
 	/* Set iface up */
-	net_if_up(mdata.net_iface);
+	if(mdata.net_iface)
+	  net_if_up(mdata.net_iface);
 
 	/* start RSSI query */
 	k_delayed_work_submit_to_queue(&modem_workq,


### PR DESCRIPTION
This fixes two problems in modem_reset():

- mdata.net_iface is used without checking that it is valid.
  Now, we validate mdata_net_iface before usage, and give a warning
  if it was not set.

- if the modem does not perform network registration within the
  given time of 20s, in the previous implementation the driver
  gave up.
  Now, the driver disables RF for a second, enables it again and
  gives the modem another 20s to register. This has been seen
  to help in roaming situations.

Tested on Sara R4.

Signed-off-by: Hans Wilmers <hans@wilmers.no>