### PR TITLE
boards: nucleo_wb55rg: Add openocd support and set to default runner

### DIFF
--- a/boards/arm/nucleo_wb55rg/board.cmake
+++ b/boards/arm/nucleo_wb55rg/board.cmake
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 board_runner_args(pyocd "--target=stm32wb55rgvx")
 
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nucleo_wb55rg/doc/nucleo_wb55rg.rst
+++ b/boards/arm/nucleo_wb55rg/doc/nucleo_wb55rg.rst
@@ -233,8 +233,10 @@ Flashing
 ========
 
 Nucleo WB55RG board includes an ST-LINK/V2-1 embedded debug tool
-interface.  This interface is not yet supported by the openocd version.
-Instead, support can be enabled on pyocd by adding "pack" support with
+interface.  This interface is supported by the openocd version included in the
+Zephyr SDK since v0.11.0.
+
+If you prefer, you can use pyocd, but it requires to enable "pack" support with
 the following pyocd command:
 
 .. code-block:: console

--- a/boards/arm/nucleo_wb55rg/support/openocd.cfg
+++ b/boards/arm/nucleo_wb55rg/support/openocd.cfg
@@ -1,0 +1,7 @@
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32wbx.cfg]
+
+reset_config srst_only


### PR DESCRIPTION
Flashing stm32wb SoCs is available since Zephyr SDK-0.11.0.
Enables it on nuclmeo_wb55rg and set it as default as it is
faster in flashing and support doesn't require additional
action (vs pyocd package support).

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>