### PR TITLE
shell: fix race condition in shell instance initialization

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1071,13 +1071,6 @@ static int instance_init(const struct shell *shell, const void *p_config,
 	__ASSERT_NO_MSG((shell->shell_flag == SHELL_FLAG_CRLF_DEFAULT) ||
 			(shell->shell_flag == SHELL_FLAG_OLF_CRLF));
 
-	int err = shell->iface->api->init(shell->iface, p_config,
-					  transport_evt_handler,
-					  (void *) shell);
-	if (err != 0) {
-		return err;
-	}
-
 	memset(shell->ctx, 0, sizeof(*shell->ctx));
 	shell->ctx->prompt = shell->default_prompt;
 
@@ -1107,7 +1100,9 @@ static int instance_init(const struct shell *shell, const void *p_config,
 	shell->ctx->vt100_ctx.cons.name_len = shell_strlen(shell->ctx->prompt);
 	flag_use_colors_set(shell, IS_ENABLED(CONFIG_SHELL_VT100_COLORS));
 
-	return 0;
+	return shell->iface->api->init(shell->iface, p_config,
+				       transport_evt_handler,
+				       (void *) shell);
 }
 
 static int instance_uninit(const struct shell *shell)


### PR DESCRIPTION
So far shell transport was initialized early before any k_poll events
and signals. transport_evt_handler() was passed as callback to transport
initializer and could be executed right away. This was true for example
with shell_uart when it enabled interrupts on RX and there were already
some bytes to read. As a result executed transport_evt_handler() is
operating on uninitialized k_poll signals.

Address this race condition by simply initializing shell transport when
everything is ready for processing data, i.e. on the end of shell
instance initialization.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>