### PR TITLE
shell: Fix SHELL_COND_CMD_ARG_REGISTER macro with NULL handler

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -162,7 +162,7 @@ struct shell_static_entry {
 					mandatory, optional) \
 		), \
 		(\
-		static shell_cmd_handler dummy_##syntax##handler \
+		static shell_cmd_handler dummy_##syntax##_handler \
 			__attribute__((unused)) = handler;\
 		static const struct shell_cmd_entry *dummy_subcmd_##syntax \
 			__attribute__((unused)) = subcmd\


### PR DESCRIPTION
Macro was failing when handler was NULL and else case was
hit because of attempt to concatenate with handler which was
set to NULL (which is ((void *)0)).

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>