### PR TITLE
drivers: serial: nrf_uarte: Allow TX only instance

### DIFF
--- a/dts/bindings/serial/nordic,nrf-uarte.yaml
+++ b/dts/bindings/serial/nordic,nrf-uarte.yaml
@@ -22,7 +22,7 @@ properties:
     rx-pin:
       type: int
       description: RX pin
-      required: true
+      required: false
 
     rts-pin:
       type: int


### PR DESCRIPTION
Extended nrf_uarte driver to support TX only UARTE instances.
When RX pin is not provided then RX is not started at all. This
allows to achieve low power with logging/console enabled.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>