### PR TITLE
dtc: Support opting-out of installing dtc

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -159,6 +159,7 @@ if(SUPPORTS_DTS)
   # themselves, so we don't rely on the C compiler otherwise.
   #
 
+  if(DTC)
   set(DTC_WARN_UNIT_ADDR_IF_ENABLED "")
   check_dtc_flag("-Wunique_unit_address_if_enabled" check)
   if (check)
@@ -186,6 +187,7 @@ if(SUPPORTS_DTS)
   if(NOT "${ret}" STREQUAL "0")
     message(FATAL_ERROR "command failed with return code: ${ret}")
   endif()
+  endif(DTC)
 
   #
   # Run gen_defines.py to create a .conf file and a header file

--- a/cmake/host-tools.cmake
+++ b/cmake/host-tools.cmake
@@ -47,7 +47,7 @@ else()
   endif()
 endif()
 
-# Search for the must-have program dtc on PATH and in
+# dtc is an optional dependency. Search for it on PATH and in
 # TOOLCHAIN_HOME. Usually DTC will be provided by an SDK, but for
 # SDK-less projects like gnuarmemb, it is up to the user to install
 # dtc.
@@ -55,10 +55,8 @@ find_program(
   DTC
   dtc
   )
-if(${DTC} STREQUAL DTC-NOTFOUND)
-  message(FATAL_ERROR "Unable to find dtc")
-endif()
 
+if(DTC)
 # Parse the 'dtc --version' and make sure it is at least MIN_DTC_VERSION
 set(MIN_DTC_VERSION 1.4.6)
 execute_process(
@@ -75,6 +73,7 @@ if(${CMAKE_MATCH_1} VERSION_LESS ${MIN_DTC_VERSION})
     for how to use the SDK's dtc alongside a custom toolchain."
   )
 endif()
+endif(DTC)
 
 find_program(
   GPERF


### PR DESCRIPTION
dtc is only used for static analysis (producing warnings) of the
DeviceTree sources. This means that valid Zephyr firmware can sanely
be built without it.

For some users, for instance Windows users that are not permitted to
use Chocolatey, installing dtc is problematic and installing it is not
worth the DT warnings that it provides.

To make using Zephyr easier for these users we make using DTC
recommended and opt-out, instead of mandatory.

Will update docs if this approach is accepted.