### PR TITLE
Bluetooth: ATT: Fix ATT corrupting mem_slab structure after free

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2128,8 +2128,6 @@ static void att_timeout(struct k_work *work)
 	/* Consider the channel disconnected */
 	bt_gatt_disconnected(ch->chan.conn);
 	ch->chan.conn = NULL;
-
-	k_mem_slab_free(&att_slab, (void **)&att);
 }
 
 static void bt_att_connected(struct bt_l2cap_chan *chan)
@@ -2161,8 +2159,6 @@ static void bt_att_disconnected(struct bt_l2cap_chan *chan)
 	att_reset(att);
 
 	bt_gatt_disconnected(ch->chan.conn);
-
-	k_mem_slab_free(&att_slab, (void **)&att);
 }
 
 #if defined(CONFIG_BT_SMP)
@@ -2238,7 +2234,17 @@ static int bt_att_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 	return 0;
 }
 
-BT_L2CAP_CHANNEL_DEFINE(att_fixed_chan, BT_L2CAP_CID_ATT, bt_att_accept, NULL);
+void bt_att_destroy(struct bt_l2cap_chan *chan)
+{
+	struct bt_att *att = ATT_CHAN(chan);
+
+	BT_DBG("chan %p", chan);
+
+	k_mem_slab_free(&att_slab, (void **)&att);
+}
+
+BT_L2CAP_CHANNEL_DEFINE(att_fixed_chan, BT_L2CAP_CID_ATT, bt_att_accept,
+			bt_att_destroy);
 
 void bt_att_init(void)
 {

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2238,7 +2238,7 @@ static int bt_att_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 	return 0;
 }
 
-BT_L2CAP_CHANNEL_DEFINE(att_fixed_chan, BT_L2CAP_CID_ATT, bt_att_accept);
+BT_L2CAP_CHANNEL_DEFINE(att_fixed_chan, BT_L2CAP_CID_ATT, bt_att_accept, NULL);
 
 void bt_att_init(void)
 {

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -257,7 +257,6 @@ destroy:
 		chan->destroy(chan);
 	}
 
-	atomic_clear(chan->status);
 }
 
 static void l2cap_rtx_timeout(struct k_work *work)
@@ -315,6 +314,7 @@ static bool l2cap_chan_add(struct bt_conn *conn, struct bt_l2cap_chan *chan,
 	}
 
 	k_delayed_work_init(&chan->rtx_work, l2cap_rtx_timeout);
+	atomic_clear(chan->status);
 
 	bt_l2cap_chan_add(conn, chan, destroy);
 

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -354,7 +354,7 @@ void bt_l2cap_connected(struct bt_conn *conn)
 		ch->rx.cid = fchan->cid;
 		ch->tx.cid = fchan->cid;
 
-		if (!l2cap_chan_add(conn, chan, NULL)) {
+		if (!l2cap_chan_add(conn, chan, fchan->destroy)) {
 			return;
 		}
 
@@ -1919,7 +1919,7 @@ static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 	return -ENOMEM;
 }
 
-BT_L2CAP_CHANNEL_DEFINE(le_fixed_chan, BT_L2CAP_CID_LE_SIG, l2cap_accept);
+BT_L2CAP_CHANNEL_DEFINE(le_fixed_chan, BT_L2CAP_CID_LE_SIG, l2cap_accept, NULL);
 
 void bt_l2cap_init(void)
 {

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -202,12 +202,14 @@ struct bt_l2cap_le_credits {
 struct bt_l2cap_fixed_chan {
 	u16_t		cid;
 	int (*accept)(struct bt_conn *conn, struct bt_l2cap_chan **chan);
+	bt_l2cap_chan_destroy_t destroy;
 };
 
-#define BT_L2CAP_CHANNEL_DEFINE(_name, _cid, _accept)		\
+#define BT_L2CAP_CHANNEL_DEFINE(_name, _cid, _accept, _destroy)         \
 	const Z_STRUCT_SECTION_ITERABLE(bt_l2cap_fixed_chan, _name) = { \
-				.cid = _cid,			\
-				.accept = _accept,		\
+				.cid = _cid,                            \
+				.accept = _accept,                      \
+				.destroy = _destroy,                    \
 			}
 
 /* Need a name different than bt_l2cap_fixed_chan for a different section */

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -5311,10 +5311,10 @@ static bool le_sc_supported(void)
 	       BT_CMD_TEST(bt_dev.supported_commands, 34, 2);
 }
 
-BT_L2CAP_CHANNEL_DEFINE(smp_fixed_chan, BT_L2CAP_CID_SMP, bt_smp_accept);
+BT_L2CAP_CHANNEL_DEFINE(smp_fixed_chan, BT_L2CAP_CID_SMP, bt_smp_accept, NULL);
 #if defined(CONFIG_BT_BREDR)
 BT_L2CAP_CHANNEL_DEFINE(smp_br_fixed_chan, BT_L2CAP_CID_BR_SMP,
-			bt_smp_br_accept);
+			bt_smp_br_accept, NULL);
 #endif /* CONFIG_BT_BREDR */
 
 int bt_smp_init(void)

--- a/subsys/bluetooth/host/smp_null.c
+++ b/subsys/bluetooth/host/smp_null.c
@@ -93,7 +93,7 @@ static int bt_smp_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 	return -ENOMEM;
 }
 
-BT_L2CAP_CHANNEL_DEFINE(smp_fixed_chan, BT_L2CAP_CID_SMP, bt_smp_accept);
+BT_L2CAP_CHANNEL_DEFINE(smp_fixed_chan, BT_L2CAP_CID_SMP, bt_smp_accept, NULL);
 
 int bt_smp_init(void)
 {


### PR DESCRIPTION
Fix ATT releasing the att structure back to the memory slab allocator
before the structure is actually ready to be released. The memory slab
allocator will write context data inside the freed slab which is
currently being overwritten by l2cap during channel teardown.

This manifests as an "Unable to allocate ATT context for conn" when
reconnecting with multiple connections.

Since the l2cap channel is embedded inside of the ATT context and l2cap
still has a valid referenc to the l2cap channel we need to release the
ATT context at a later time.
This should be fixed by implementing the channel destroy function and
releasing the channel there.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>