### PR TITLE
drivers: i2c_slave: eeprom: fixes incorrect declaration

### DIFF
--- a/drivers/i2c/slave/eeprom_slave.c
+++ b/drivers/i2c/slave/eeprom_slave.c
@@ -212,7 +212,7 @@ static u8_t i2c_eeprom_slave_0_buffer[(DT_INST_0_ATMEL_AT24_SIZE)];
 static const struct i2c_eeprom_slave_config i2c_eeprom_slave_0_cfg = {
 	.controller_dev_name = DT_INST_0_ATMEL_AT24_BUS_NAME,
 	.address = DT_INST_0_ATMEL_AT24_BASE_ADDRESS,
-	.buffer_size = (DT_INST_0_ATMEL_AT24_SIZE * 1024),
+	.buffer_size = DT_INST_0_ATMEL_AT24_SIZE,
 	.buffer = i2c_eeprom_slave_0_buffer
 };
 
@@ -233,7 +233,7 @@ static u8_t i2c_eeprom_slave_1_buffer[(DT_INST_1_ATMEL_AT24_SIZE)];
 static const struct i2c_eeprom_slave_config i2c_eeprom_slave_1_cfg = {
 	.controller_dev_name = DT_INST_1_ATMEL_AT24_BUS_NAME,
 	.address = DT_INST_1_ATMEL_AT24_BASE_ADDRESS,
-	.buffer_size = (DT_INST_1_ATMEL_AT24_SIZE * 1024),
+	.buffer_size = DT_INST_1_ATMEL_AT24_SIZE,
 	.buffer = i2c_eeprom_slave_1_buffer
 };
 


### PR DESCRIPTION
This commit fixes an incorrect declaration of the
buffer_size member of the i2c_eeprom_slave_config
struct.

