### PR TITLE
few changes for MQTT

### DIFF
--- a/samples/net/mqtt_publisher/src/main.c
+++ b/samples/net/mqtt_publisher/src/main.c
@@ -382,15 +382,15 @@ static int process_mqtt_and_sleep(struct mqtt_client *client, int timeout)
 		wait(remaining);
 
 		rc = mqtt_live(client);
-		if (rc != 0) {
+		if (rc != 0 && rc != -EAGAIN) {
 			PRINT_RESULT("mqtt_live", rc);
 			return rc;
-		}
-
-		rc = mqtt_input(client);
-		if (rc != 0) {
-			PRINT_RESULT("mqtt_input", rc);
-			return rc;
+		} else if (rc == 0) {
+			rc = mqtt_input(client);
+			if (rc != 0) {
+				PRINT_RESULT("mqtt_input", rc);
+				return rc;
+			}
 		}
 
 		remaining = timeout + start_time - k_uptime_get();

--- a/subsys/net/lib/mqtt/mqtt.c
+++ b/subsys/net/lib/mqtt/mqtt.c
@@ -581,6 +581,7 @@ int mqtt_live(struct mqtt_client *client)
 {
 	int err_code = 0;
 	u32_t elapsed_time;
+	bool ping_sent = false;
 
 	NULL_PARAM_CHECK(client);
 
@@ -591,11 +592,16 @@ int mqtt_live(struct mqtt_client *client)
 	if ((client->keepalive > 0) &&
 	    (elapsed_time >= (client->keepalive * 1000))) {
 		err_code = mqtt_ping(client);
+		ping_sent = true;
 	}
 
 	mqtt_mutex_unlock(client);
 
-	return err_code;
+	if (ping_sent) {
+		return err_code;
+	} else {
+		return -EAGAIN;
+	}
 }
 
 u32_t mqtt_keepalive_time_left(const struct mqtt_client *client)


### PR DESCRIPTION
While debugging the SARA-R4 modem I ended up testing the MQTT library.

It parses the data coming from the network in a very specific way and if the recv() function ever returns 0, it considers the connection disconnected.

With these fixes, the SARA-R4 could use the MQTT library successfully.