### PR TITLE
dts: edtlib: Turn Node.instance_no into EDT.compat2enabled

### DIFF
--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -295,6 +295,31 @@
 	};
 
 	//
+	// For testing EDT.compat2enabled
+	//
+
+	compat2enabled {
+		foo-1 {
+			status = "okay";
+			compatible = "compat2enabled";
+		};
+		foo-disabled {
+			status = "disabled";
+			compatible = "compat2enabled";
+		};
+		foo-2 {
+			// No 'status', which is also treated as enabled
+			compatible = "compat2enabled";
+		};
+		// Should not create an entry in compat2enabled, since all nodes
+		// with the compatible are disabled
+		bar {
+			status = "disabled";
+			compatible = "compat2enabled-disabled";
+		};
+	};
+
+	//
 	// For testing 'bus:' and 'on-bus:'
 	//
 

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -165,6 +165,15 @@ warning: "#cells:" in test-bindings/deprecated.yaml is deprecated and will be re
                  "OrderedDict([('foos', <Property, name: foos, type: phandle-array, value: [<ControllerAndData, controller: <Node /deprecated in 'test.dts', binding test-bindings/deprecated.yaml>, data: OrderedDict([('foo', 1), ('bar', 2)])>]>)])")
 
     #
+    # Test EDT.compat2enabled
+    #
+
+    verify_streq(edt.compat2enabled["compat2enabled"], "[<Node /compat2enabled/foo-1 in 'test.dts', no binding>, <Node /compat2enabled/foo-2 in 'test.dts', no binding>]")
+
+    if "compat2enabled-disabled" in edt.compat2enabled:
+        fail("'compat2enabled-disabled' should not appear in edt.compat2enabled")
+
+    #
     # Test Node.props (derived from DT and 'properties:' in the binding)
     #
 


### PR DESCRIPTION
Add an EDT.compat2enabled attribute that maps compatibles to enabled
devicetree nodes that implement them. For example,
EDT.compat2enabled["foo"] is a list of all enabled nodes with "foo" in
the 'compatible' property.

The old Node.instance_no functionality can be implemented in terms of
EDT.compat2enabled, so remove Node.instance_no. EDT.compat2enabled is
more flexible and easier to understand.

Simplify main() in gen_defines.py by using EDT.compat2enabled to
generate the DT_COMPAT_<compatible> existence macros. The behavior is
slightly different now, as DT_COMPAT_<compatible> is generated for
enabled nodes that don't have a binding as well, but that might be an
improvement overall. It probably doesn't hurt at least.

EDT.compat2enabled simplifies the implementation of the new
$(dt_compat_get_str) preprocessor function in
https://github.com/zephyrproject-rtos/zephyr/pull/21560. That was the
original motivation.