### PR TITLE
console: uart: Ifdef an include

### DIFF
--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -33,7 +33,9 @@
 #ifdef CONFIG_UART_CONSOLE_MCUMGR
 #include "mgmt/serial.h"
 #endif
+#ifdef CONFIG_USB_UART_CONSOLE
 #include <usb/usb_device.h>
+#endif
 
 static struct device *uart_console_dev;
 


### PR DESCRIPTION
usb-device.h must be included only if CONFIG_USB_UART_CONSOLE is
defined, otherwise it is not used and will pull a lot of usb code.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>