### PR TITLE
Add feature bits for SMI support

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -44,6 +44,9 @@ config BT_CTLR_MIN_USED_CHAN_SUPPORT
 config BT_CTLR_DTM_HCI_SUPPORT
 	bool
 
+config BT_CTLR_SMI_SUPPORT
+	bool
+
 config BT_CTLR_XTAL_ADVANCED_SUPPORT
 	bool
 
@@ -493,6 +496,18 @@ config BT_CTLR_DTM_HCI
 	select BT_CTLR_DTM
 	help
 	  Enable support for Direct Test Mode over the HCI transport.
+
+config BT_CTLR_SMI_RX
+	bool "Stable modulation index - Receiver"
+	depends on BT_CTLR_SMI_SUPPORT
+	help
+	  Enable support for Bluetooth 5.0 SMI RX in the Controller.
+
+config BT_CTLR_SMI_TX
+	bool "Stable modulation index - Transmitter"
+	depends on BT_CTLR_SMI_SUPPORT
+	help
+	  Enable support for Bluetooth 5.0 SMI TX in the Controller.
 
 if BT_LL_SW_SPLIT || BT_LL_SW_LEGACY
 

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -509,6 +509,12 @@ config BT_CTLR_SMI_TX
 	help
 	  Enable support for Bluetooth 5.0 SMI TX in the Controller.
 
+config BT_CTLR_SMI_TX_SETTING
+	bool "Stable modulation index - Transmitter as setting"
+	depends on BT_CTLR_SMI_TX && BT_CTLR_SETTINGS
+	help
+	  Enable support for Bluetooth 5.0 SMI TX through a system setting.
+
 if BT_LL_SW_SPLIT || BT_LL_SW_LEGACY
 
 config BT_CTLR_ADVANCED_FEATURES

--- a/subsys/bluetooth/controller/include/ll_feat.h
+++ b/subsys/bluetooth/controller/include/ll_feat.h
@@ -91,7 +91,12 @@
 #endif /* !CONFIG_BT_CTLR_SMI_RX */
 
 #if defined(CONFIG_BT_CTLR_SMI_TX)
+#if defined(CONFIG_BT_CTLR_SMI_TX_SETTING)
+#define LL_FEAT_BIT_SMI_TX (ll_settings_smi_tx() ? \
+			    BIT64(BT_LE_FEAT_BIT_SMI_TX) : 0)
+#else /* !CONFIG_BT_CTLR_SMI_TX_SETTING */
 #define LL_FEAT_BIT_SMI_TX BIT64(BT_LE_FEAT_BIT_SMI_TX)
+#endif /* !CONFIG_BT_CTLR_SMI_TX_SETTING */
 #else /* !CONFIG_BT_CTLR_SMI_TX */
 #define LL_FEAT_BIT_SMI_TX 0
 #endif /* !CONFIG_BT_CTLR_SMI_TX */

--- a/subsys/bluetooth/controller/include/ll_feat.h
+++ b/subsys/bluetooth/controller/include/ll_feat.h
@@ -84,6 +84,18 @@
 #define LL_FEAT_BIT_PHY_CODED 0
 #endif /* !CONFIG_BT_CTLR_PHY_CODED */
 
+#if defined(CONFIG_BT_CTLR_SMI_RX)
+#define LL_FEAT_BIT_SMI_RX BIT64(BT_LE_FEAT_BIT_SMI_RX)
+#else /* !CONFIG_BT_CTLR_SMI_RX */
+#define LL_FEAT_BIT_SMI_RX 0
+#endif /* !CONFIG_BT_CTLR_SMI_RX */
+
+#if defined(CONFIG_BT_CTLR_SMI_TX)
+#define LL_FEAT_BIT_SMI_TX BIT64(BT_LE_FEAT_BIT_SMI_TX)
+#else /* !CONFIG_BT_CTLR_SMI_TX */
+#define LL_FEAT_BIT_SMI_TX 0
+#endif /* !CONFIG_BT_CTLR_SMI_TX */
+
 #define LL_FEAT_BIT_MASK         0x1FFFF
 #define LL_FEAT_BIT_MASK_VALID   0x1CF2F
 #define LL_FEAT                  (LL_FEAT_BIT_ENC | \
@@ -96,5 +108,7 @@
 				  LL_FEAT_BIT_EXT_SCAN | \
 				  LL_FEAT_BIT_PHY_2M | \
 				  LL_FEAT_BIT_PHY_CODED | \
+				  LL_FEAT_BIT_SMI_RX | \
+				  LL_FEAT_BIT_SMI_TX | \
 				  LL_FEAT_BIT_CHAN_SEL_2 | \
 				  LL_FEAT_BIT_MIN_USED_CHAN)

--- a/subsys/bluetooth/controller/include/ll_settings.h
+++ b/subsys/bluetooth/controller/include/ll_settings.h
@@ -21,3 +21,5 @@ static inline u16_t ll_settings_subversion_number(void)
 }
 
 #endif /* CONFIG_BT_CTLR_VERSION_SETTINGS */
+
+bool ll_settings_smi_tx(void);

--- a/subsys/bluetooth/controller/ll_sw/ll.c
+++ b/subsys/bluetooth/controller/ll_sw/ll.c
@@ -39,6 +39,7 @@
 #include "ll.h"
 #include "ll_feat.h"
 #include "ll_filter.h"
+#include "ll_settings.h"
 
 /* Global singletons */
 

--- a/subsys/bluetooth/controller/ll_sw/ll_settings.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_settings.c
@@ -32,6 +32,17 @@ u16_t ll_settings_subversion_number(void)
 
 #endif /* CONFIG_BT_CTLR_VERSION_SETTINGS */
 
+#if defined(CONFIG_BT_CTLR_SMI_TX_SETTING)
+
+static u8_t smi_tx;
+
+bool ll_settings_smi_tx(void)
+{
+	return smi_tx;
+}
+
+#endif /* CONFIG_BT_CTLR_SMI_TX_SETTING */
+
 static int ctlr_set(const char *name, size_t len_rd,
 		    settings_read_cb read_cb, void *store)
 {
@@ -62,6 +73,19 @@ static int ctlr_set(const char *name, size_t len_rd,
 		return 0;
 	}
 #endif /* CONFIG_BT_CTLR_VERSION_SETTINGS */
+
+#if defined(CONFIG_BT_CTLR_SMI_TX_SETTING)
+	if (!strncmp(name, "smi_tx", nlen)) {
+		len = read_cb(store, &smi_tx, sizeof(smi_tx));
+		if (len < 0) {
+			BT_ERR("Failed to read SMI TX flag from storage"
+			       " (err %d)", len);
+		} else {
+			BT_DBG("SMI TX flag set to %04x", smi_tx);
+		}
+		return 0;
+	}
+#endif /* CONFIG_BT_CTLR_SMI_TX_SETTING */
 
 	return 0;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -32,6 +32,7 @@
 #include "pdu.h"
 #include "ll.h"
 #include "ll_feat.h"
+#include "ll_settings.h"
 #include "lll.h"
 #include "lll_adv.h"
 #include "lll_scan.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -24,6 +24,7 @@
 #include "pdu.h"
 #include "ll.h"
 #include "ll_feat.h"
+#include "ll_settings.h"
 #include "lll.h"
 #include "lll_vendor.h"
 #include "lll_clock.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -21,6 +21,7 @@
 #include "pdu.h"
 #include "ll.h"
 #include "ll_feat.h"
+#include "ll_settings.h"
 
 #include "lll.h"
 #include "lll_vendor.h"


### PR DESCRIPTION
Enable setting features bits for Stable Modulation Index in controller features.

The SMI TX flag is supported as a setting. SMI TX is different than other controller features in that it does not necessarily imply any software changes; whether SMI TX is supported may be simply a matter of hardware calibration. This change supports using the same software on chips that do or do not support SMI TX depending on calibration.