### PR TITLE
tests: drivers: counter: counter_basic_api: Fix teardown function

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -95,7 +95,13 @@ static void counter_tear_down_instance(const char *dev_name)
 
 	top_cfg.ticks = counter_get_max_top_value(dev);
 	err = counter_set_top_value(dev, &top_cfg);
-	zassert_equal(0, err,
+	if (err == -ENOTSUP) {
+		/* If resetting is not support, attempt without reset. */
+		top_cfg.flags = COUNTER_TOP_CFG_DONT_RESET;
+		err = counter_set_top_value(dev, &top_cfg);
+
+	}
+	zassert_true((err == 0) || (err == -ENOTSUP),
 			"%s: Setting top value to default failed", dev_name);
 
 	err = counter_stop(dev);


### PR DESCRIPTION
Teardown may fail due to not supported setting of top_value.
Modified to accept not supported case.

Partially fixes #21745 

It fixes error caught in teardown function.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>