### PR TITLE
dts: arm: nxp: ke1xf: fix LPO clock frequency

### DIFF
--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -114,7 +114,7 @@
 			lpo: lpo128k {
 			/* LPO clock */
 				compatible = "fixed-clock";
-				clock-frequency = <125000>;
+				clock-frequency = <128000>;
 				#clock-cells = <0>;
 			};
 		};


### PR DESCRIPTION
The frequency of the Low Power Oscillator (LPO) is 128kHz, not 125kHz.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>