### PR TITLE
soc: arm: nxp: ke1xf: add option for keeping watchdog enabled at boot

### DIFF
--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.soc
@@ -78,6 +78,25 @@ config SOC_PART_NUMBER_KINETIS_KE1XF
 	  number selection choice defines the default value for this
 	  string.
 
+config WDOG_ENABLE_AT_BOOT
+	bool "Keep watchdog timer enabled at boot"
+	depends on WDOG_INIT
+	help
+	  Keep the watchdog timer enabled at boot with the internal
+	  128kHz LPO clock (and a prescaler of 256) as clock
+	  source. The application can take over control of the
+	  watchdog timer after boot and install a different timeout,
+	  if needed.
+
+config WDOG_INITIAL_TIMEOUT
+	int "Initial timeout for the watchdog timer in milliseconds"
+	depends on WDOG_ENABLE_AT_BOOT
+	range 2 131070
+	default 2048
+	help
+	  Initial timeout value for the watchdog timer in
+	  milliseconds.
+
 config KINETIS_KE1XF_ENABLE_CODE_CACHE
 	bool "Enable the code cache"
 	default y

--- a/soc/arm/nxp_kinetis/ke1xf/soc.c
+++ b/soc/arm/nxp_kinetis/ke1xf/soc.c
@@ -273,8 +273,15 @@ void z_arm_watchdog_init(void)
 	 * Watchdog reconfiguration only takes effect after writing to
 	 * both TOVAL and CS registers.
 	 */
+#ifdef CONFIG_WDOG_ENABLE_AT_BOOT
+	WDOG->TOVAL = CONFIG_WDOG_INITIAL_TIMEOUT >> 1;
+	WDOG->CS = WDOG_CS_PRES(1) | WDOG_CS_CLK(1) | WDOG_CS_WAIT(1) |
+		   WDOG_CS_EN(1) | WDOG_CS_UPDATE(1);
+#else /* !CONFIG_WDOG_ENABLE_AT_BOOT */
 	WDOG->TOVAL = 1024;
 	WDOG->CS = WDOG_CS_EN(0) | WDOG_CS_UPDATE(1);
+#endif /* !CONFIG_WDOG_ENABLE_AT_BOOT */
+
 	while (!(WDOG->CS & WDOG_CS_RCS_MASK)) {
 		;
 	}


### PR DESCRIPTION
Add option for keeping the watchdog timer of the NXP Kinetis KE1xF SoC series enabled at boot with a configurable, initial timeout.

This removes the risk of failure from when `z_arm_watchdog_init()` disables the watchdog timer until the application code configures a timeout and re-enables the watchdog timer.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>