### PR TITLE
drivers: modem: gsm: Fix uart_pipe.h location

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -12,7 +12,7 @@ LOG_MODULE_REGISTER(gsm_ppp, CONFIG_NET_PPP_LOG_LEVEL);
 #include <sys/ring_buffer.h>
 #include <sys/util.h>
 #include <net/ppp.h>
-#include <console/uart_pipe.h>
+#include <drivers/console/uart_pipe.h>
 #include <drivers/uart.h>
 
 #include "modem_context.h"


### PR DESCRIPTION
The uart_pipe.h was moved to drivers/console/uart_pipe.h and that
was missed by sanity.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>