### PR TITLE
More SMP race fixing

### DIFF
--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -263,6 +263,16 @@ __resume:
 #endif
 	pushq _thread_offset_to_rip(%rdi)	/* RIP */
 
+#ifdef CONFIG_ASSERT
+	/* Poison the old thread's saved RIP pointer with a
+	 * recognizable value near NULL, to easily catch reuse of the
+	 * thread object across CPUs in SMP.  Strictly speaking this
+	 * is not an assertion, but it's very cheap and worth having
+	 * on during routine testing.
+	 */
+	movq $0xB9, _thread_offset_to_rip(%rdi)
+#endif
+
 	movq _thread_offset_to_rbx(%rdi), %rbx
 	movq _thread_offset_to_rbp(%rdi), %rbp
 	movq _thread_offset_to_r12(%rdi), %r12

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -37,7 +37,6 @@ BUILD_ASSERT(K_LOWEST_APPLICATION_THREAD_PRIO
 #endif
 
 void z_sched_init(void);
-void z_add_thread_to_ready_q(struct k_thread *thread);
 void z_move_thread_to_end_of_prio_q(struct k_thread *thread);
 void z_remove_thread_from_ready_q(struct k_thread *thread);
 int z_is_thread_time_slicing(struct k_thread *thread);
@@ -61,6 +60,8 @@ void z_time_slice(int ticks);
 void z_reset_time_slice(void);
 void z_sched_abort(struct k_thread *thread);
 void z_sched_ipi(void);
+void z_sched_start(struct k_thread *thread);
+void z_ready_thread(struct k_thread *thread);
 
 static inline void z_pend_curr_unlocked(_wait_q_t *wait_q, s32_t timeout)
 {
@@ -244,14 +245,6 @@ static inline bool _is_valid_prio(int prio, void *entry_point)
 	}
 
 	return true;
-}
-
-static ALWAYS_INLINE void z_ready_thread(struct k_thread *thread)
-{
-	if (z_is_thread_ready(thread)) {
-		z_add_thread_to_ready_q(thread);
-		sys_trace_thread_ready(thread);
-	}
 }
 
 static inline void _ready_one_thread(_wait_q_t *wq)

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -113,8 +113,8 @@ void z_impl_k_sem_give(struct k_sem *sem)
 	sys_trace_void(SYS_TRACE_ID_SEMA_GIVE);
 
 	if (thread != NULL) {
-		z_ready_thread(thread);
 		arch_thread_return_value_set(thread, 0);
+		z_ready_thread(thread);
 	} else {
 		sem->count += (sem->count != sem->limit) ? 1U : 0U;
 		handle_poll_events(sem);

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -369,16 +369,7 @@ void z_check_stack_sentinel(void)
 #ifdef CONFIG_MULTITHREADING
 void z_impl_k_thread_start(struct k_thread *thread)
 {
-	k_spinlock_key_t key = k_spin_lock(&lock); /* protect kernel queues */
-
-	if (z_has_thread_started(thread)) {
-		k_spin_unlock(&lock, key);
-		return;
-	}
-
-	z_mark_thread_as_started(thread);
-	z_ready_thread(thread);
-	z_reschedule(&lock, key);
+	z_sched_start(thread);
 }
 
 #ifdef CONFIG_USERSPACE

--- a/samples/userspace/shared_mem/src/enc.h
+++ b/samples/userspace/shared_mem/src/enc.h
@@ -23,15 +23,15 @@ short char_to_index(char c);
 int calc_rev_wheel(BYTE *wheel, BYTE *backpath);
 char enig_enc(char pt);
 
-extern BYTE W1[26];
-extern BYTE W2[26];
-extern BYTE W3[26];
-extern BYTE R[26];
-extern BYTE W1R[26];
-extern BYTE W2R[26];
-extern BYTE W3R[26];
-extern int IW1;
-extern int IW2;
-extern int IW3;
+extern volatile BYTE W1[26];
+extern volatile BYTE W2[26];
+extern volatile BYTE W3[26];
+extern volatile BYTE R[26];
+extern volatile BYTE W1R[26];
+extern volatile BYTE W2R[26];
+extern volatile BYTE W3R[26];
+extern volatile int IW1;
+extern volatile int IW2;
+extern volatile int IW3;
 
 #endif

--- a/samples/userspace/shared_mem/src/main.c
+++ b/samples/userspace/shared_mem/src/main.c
@@ -34,34 +34,34 @@ struct k_mem_domain dom0, dom1, dom2;
  * the names are symbolic for the memory partitions
  * purpose.
  */
-_app_red_b BYTE fBUFIN;
-_app_red_b BYTE BUFIN[63];
+volatile _app_red_b BYTE fBUFIN;
+volatile _app_red_b BYTE BUFIN[63];
 
-_app_blk_b BYTE fBUFOUT;
-_app_blk_b BYTE BUFOUT[63];
+volatile _app_blk_b BYTE fBUFOUT;
+volatile _app_blk_b BYTE BUFOUT[63];
 
 /* declare and set wheel and reflector  */
 /* To use add definition ALTMSG */
 #ifdef ALTMSG
-_app_enc_d BYTE W1[26] = START_WHEEL;
+volatile _app_enc_d BYTE W1[26] = START_WHEEL;
 #else
-_app_enc_d BYTE W1[26] = START_WHEEL2;
+volatile _app_enc_d BYTE W1[26] = START_WHEEL2;
 #endif
-_app_enc_d BYTE W2[26] = START_WHEEL;
-_app_enc_d BYTE W3[26] = START_WHEEL;
-_app_enc_d BYTE R[26] = REFLECT;
+volatile _app_enc_d BYTE W2[26] = START_WHEEL;
+volatile _app_enc_d BYTE W3[26] = START_WHEEL;
+volatile _app_enc_d BYTE R[26] = REFLECT;
 
-_app_enc_b int IW1;
-_app_enc_b int IW2;
-_app_enc_b int IW3;
+volatile _app_enc_b int IW1;
+volatile _app_enc_b int IW2;
+volatile _app_enc_b int IW3;
 
 /*
  *   calculated by the enc thread at init and when the wheels
  *   change.
  */
-_app_enc_b BYTE W1R[26];
-_app_enc_b BYTE W2R[26];
-_app_enc_b BYTE W3R[26];
+volatile _app_enc_b BYTE W1R[26];
+volatile _app_enc_b BYTE W2R[26];
+volatile _app_enc_b BYTE W3R[26];
 
 /*
  *	sync threads
@@ -78,8 +78,8 @@ struct k_thread ct_thread;
 K_THREAD_STACK_DEFINE(ct_stack, STACKSIZE);
 
 _app_enc_d char encMSG[] = "ENC!\n";
-_app_enc_b char enc_pt[50];  /* Copy form shared pt */
-_app_enc_b char enc_ct[50]; /* Copy to shared ct */
+volatile _app_enc_b char enc_pt[50];  /* Copy form shared pt */
+volatile _app_enc_b char enc_ct[50]; /* Copy to shared ct */
 
 _app_user_d char ptMSG[] = "PT: message to encrypt\n";
 
@@ -181,7 +181,7 @@ void enc(void)
 		if (fBUFIN == 1) { /* 1 is process text */
 			printk("ENC Thread Received Data\n");
 			/* copy message form shared mem and clear flag */
-			memcpy(&enc_pt, BUFIN, SAMP_BLOCKSIZE);
+			memcpy((void *)&enc_pt, (void *)BUFIN, SAMP_BLOCKSIZE);
 			printk("ENC PT MSG: %s\n", (char *)&enc_pt);
 			fBUFIN = 0;
 			/* reset wheel: probably better as a flag option  */
@@ -189,7 +189,7 @@ void enc(void)
 			IW2 = 2;
 			IW3 = 3;
 			/* encode */
-			memset(&enc_ct, 0, SAMP_BLOCKSIZE); /* clear memory */
+			memset((void *)&enc_ct, 0, SAMP_BLOCKSIZE);
 			for (index = 0, index_out = 0; index < SAMP_BLOCKSIZE; index++) {
 				if (enc_pt[index] == '\0') {
 					enc_ct[index_out] = '\0';
@@ -202,10 +202,11 @@ void enc(void)
 			}
 			/* test for CT flag */
 			while (fBUFOUT != 0) {
-				k_sleep(K_MSEC(100));
+				k_sleep(K_MSEC(1));
 			}
 			/* ct thread has cleared the buffer */
-			memcpy(&BUFOUT, &enc_ct, SAMP_BLOCKSIZE);
+			memcpy((void *)&BUFOUT, (void *)&enc_ct,
+			       SAMP_BLOCKSIZE);
 			fBUFOUT = 1;
 
 		}
@@ -221,13 +222,13 @@ void enc(void)
 void pt(void)
 {
 
-	k_sleep(K_MSEC(2000));
+	k_sleep(K_MSEC(20));
 	while (1) {
 		k_sem_take(&allforone, K_FOREVER);
 		if (fBUFIN == 0) { /* send message to encode */
 			printk("\nPT Sending Message 1\n");
-			memset(&BUFIN, 0, SAMP_BLOCKSIZE);
-			memcpy(&BUFIN, &ptMSG, sizeof(ptMSG));
+			memset((void *)&BUFIN, 0, SAMP_BLOCKSIZE);
+			memcpy((void *)&BUFIN, (void *)&ptMSG, sizeof(ptMSG));
 /* strlen should not be used if user provided data, needs a max length set  */
 			fBUFIN = 1;
 		}
@@ -235,12 +236,12 @@ void pt(void)
 		k_sem_take(&allforone, K_FOREVER);
 		if (fBUFIN == 0) { /* send message to decode  */
 			printk("\nPT Sending Message 1'\n");
-			memset(&BUFIN, 0, SAMP_BLOCKSIZE);
-			memcpy(&BUFIN, &ptMSG2, sizeof(ptMSG2));
+			memset((void *)&BUFIN, 0, SAMP_BLOCKSIZE);
+			memcpy((void *)&BUFIN, (void *)&ptMSG2, sizeof(ptMSG2));
 			fBUFIN = 1;
 		}
 		k_sem_give(&allforone);
-		k_sleep(K_MSEC(5000));
+		k_sleep(K_MSEC(50));
 	}
 }
 
@@ -257,8 +258,8 @@ void ct(void)
 		k_sem_take(&allforone, K_FOREVER);
 		if (fBUFOUT == 1) {
 			printk("CT Thread Receivedd Message\n");
-			memset(&tbuf, 0, sizeof(tbuf));
-			memcpy(&tbuf, BUFOUT, SAMP_BLOCKSIZE);
+			memset((void *)&tbuf, 0, sizeof(tbuf));
+			memcpy((void *)&tbuf, (void *)BUFOUT, SAMP_BLOCKSIZE);
 			fBUFOUT = 0;
 			printk("CT MSG: %s\n", (char *)&tbuf);
 		}

--- a/tests/kernel/mem_protect/stackprot/src/main.c
+++ b/tests/kernel/mem_protect/stackprot/src/main.c
@@ -126,6 +126,11 @@ void test_create_alt_thread(void)
 	k_thread_create(&alt_thread_data, alt_thread_stack_area, STACKSIZE,
 			(k_thread_entry_t)alternate_thread, NULL, NULL, NULL,
 			K_PRIO_COOP(1), K_USER, K_NO_WAIT);
+
+	/* Note that this sleep is required on SMP platforms where
+	 * that thread will execute asynchronously!
+	 */
+	k_sleep(K_MSEC(100));
 }
 
 void test_main(void)


### PR DESCRIPTION
Found some more via code inspection, looking carefully at problematic code paths and some targetted instrumentation (one, RIP poisoning, is included here -- I have another that validates that the thread status bits are only modified inside the scheduler lock, but that's a pretty messy hack still).

I'm still seeing occasional failures, but on my dev box it's down to one failure on some test every 8-10 sanitycheck runs.  My laptop does a bit worse, maybe 1 in 3-5 runs or so.

But these issues can be everywhere in the code base.   This is going to be a long slog.