### PR TITLE
net: icmpv6: fix add own IP addr to nbr cache

### DIFF
--- a/subsys/net/ip/ipv6.h
+++ b/subsys/net/ip/ipv6.h
@@ -318,14 +318,14 @@ struct in6_addr *net_ipv6_nbr_lookup_by_index(struct net_if *iface,
  */
 #if defined(CONFIG_NET_IPV6_NBR_CACHE) && defined(CONFIG_NET_NATIVE_IPV6)
 struct net_nbr *net_ipv6_nbr_add(struct net_if *iface,
-				 struct in6_addr *addr,
-				 struct net_linkaddr *lladdr,
+				 const struct in6_addr *addr,
+				 const struct net_linkaddr *lladdr,
 				 bool is_router,
 				 enum net_ipv6_nbr_state state);
 #else
 static inline struct net_nbr *net_ipv6_nbr_add(struct net_if *iface,
-					       struct in6_addr *addr,
-					       struct net_linkaddr *lladdr,
+					       const struct in6_addr *addr,
+					       const struct net_linkaddr *lladdr,
 					       bool is_router,
 					       enum net_ipv6_nbr_state state)
 {

--- a/subsys/net/ip/nbr.c
+++ b/subsys/net/ip/nbr.c
@@ -84,7 +84,7 @@ struct net_nbr *net_nbr_get(struct net_nbr_table *table)
 }
 
 int net_nbr_link(struct net_nbr *nbr, struct net_if *iface,
-		 struct net_linkaddr *lladdr)
+		 const struct net_linkaddr *lladdr)
 {
 	int i, avail = -1;
 

--- a/subsys/net/ip/nbr.h
+++ b/subsys/net/ip/nbr.h
@@ -178,7 +178,7 @@ struct net_nbr *net_nbr_lookup(struct net_nbr_table *table,
  * @return 0 if ok, <0 if linking failed
  */
 int net_nbr_link(struct net_nbr *nbr, struct net_if *iface,
-		 struct net_linkaddr *lladdr);
+		 const struct net_linkaddr *lladdr);
 
 /**
  * @brief Unlink a neighbor from specific link layer address.


### PR DESCRIPTION
This commit fixes a problem where our own IP address
is added to the cache instead of the senders.
This bug was due to a swap of the address in the original packet.
The swapping of the address is now removed.