### PR TITLE
arm: cortex-m: fix MPU region validation

### DIFF
--- a/samples/application_development/code_relocation/src/main.c
+++ b/samples/application_development/code_relocation/src/main.c
@@ -25,10 +25,12 @@ void disable_mpu_rasr_xn(void)
 	 * would most likely be set at index 2.
 	 */
 	for (index = 0U; index < 8; index++) {
+		int key = irq_lock();
 		MPU->RNR = index;
 		if (MPU->RASR & MPU_RASR_XN_Msk) {
 			MPU->RASR ^= MPU_RASR_XN_Msk;
 		}
+		irq_unlock(key);
 	}
 
 }


### PR DESCRIPTION
We need to lock interrupts around programming the MPU index into
RNR and reading values  out of RASR/RBAR/RLAR, in case we
get scheduled or take an interrupt in between these two
operations.

Addresses #22275 for ARM Cortex-M.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>