### PR TITLE
cmake: restore BOARD.dts_compiled

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -173,14 +173,16 @@ if(SUPPORTS_DTS)
   execute_process(
     COMMAND ${DTC}
     -O dts
-    -o - # Write output to stdout, which we discard below
+    # BOARD.dts_compiled isn't read further by these scripts. However,
+    # it's useful for debugging, as it's a clean view of the entire
+    # devicetree in DTS format, so we keep it around.
+    -o ${BOARD}.dts_compiled
     -b 0
     -E unit_address_vs_reg
     ${DTC_NO_WARN_UNIT_ADDR}
     ${DTC_WARN_UNIT_ADDR_IF_ENABLED}
     ${EXTRA_DTC_FLAGS} # User settable
     ${BOARD}.dts.pre.tmp
-    OUTPUT_QUIET # Discard stdout
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
     RESULT_VARIABLE ret
     )

--- a/doc/guides/dts/index.rst
+++ b/doc/guides/dts/index.rst
@@ -229,8 +229,9 @@ from the base devicetree, if needed.
 .. note::
 
    The preprocessed and concatenated DTS sources are stored in
-   :file:`zephyr/<BOARD>.dts.pre.tmp` in the build directory. Looking at this
-   file can be handy for debugging.
+   :file:`zephyr/<BOARD>.dts.pre.tmp` in the build directory. The final merged
+   devicetree in DTS format is in :file:`zephyr/<BOARD>.dts_compiled`.
+   These files can be useful for debugging.
 
 The merged devicetree, along with any :ref:`bindings <bindings>` referenced
 from it, is used to generate C preprocessor macros. This is handled by the


### PR DESCRIPTION
It's fine that we don't use that file further in these scripts, but removing this
file from the build directory entirely when we already have the data
handy doesn't make sense. It can be very useful for debugging what the
final devicetree looks like.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/22272

(when dtc is installed)