### PR TITLE
boards: arm: efm32wg_stk3800: add jlink flash runner support

### DIFF
--- a/boards/arm/efm32wg_stk3800/board.cmake
+++ b/boards/arm/efm32wg_stk3800/board.cmake
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(jlink "--device=EFM32WG990F256")
+
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Add support for flashing via the Segger J-Link OB.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>