### PR TITLE
testsuite: Ifdef an include

### DIFF
--- a/subsys/testsuite/include/tc_util.h
+++ b/subsys/testsuite/include/tc_util.h
@@ -12,7 +12,9 @@
 #include <zephyr.h>
 
 #include <string.h>
+#ifdef CONFIG_SHELL
 #include <shell/shell.h>
+#endif
 #include <sys/printk.h>
 
 #if defined CONFIG_ZTEST_TC_UTIL_USER_OVERRIDE

--- a/tests/subsys/logging/log_output/src/log_output_test.c
+++ b/tests/subsys/logging/log_output/src/log_output_test.c
@@ -9,6 +9,7 @@
  * @brief Test log message
  */
 
+#include <logging/log.h>
 #include <logging/log_output.h>
 
 #include <tc_util.h>


### PR DESCRIPTION
shell.h must be included only if CONFIG_SHELL is
defined, otherwise this will pull unused code.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>