### PR TITLE
[RFC] DT: emit ordinals

### DIFF
--- a/dts/binding-template.yaml
+++ b/dts/binding-template.yaml
@@ -7,6 +7,13 @@ description: |
 # Used to map nodes to bindings
 compatible: "manufacturer,device"
 
+# Set this to a truthy value if this binding is describing a node that
+# has a struct device representation within the Zephyr device
+# hierarchy.
+#
+# (This is used to track dependencies between such devices.)
+is-device: true
+
 # The 'compatible' above would match this node:
 #
 #     device {

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -484,9 +484,9 @@ class EDT:
                 _err("malformed or empty '{}' in {}"
                      .format(prop, binding_path))
 
-        ok_top = {"title", "description", "compatible", "properties", "#cells",
-                  "bus", "on-bus", "parent-bus", "child-bus", "parent", "child",
-                  "child-binding", "sub-node"}
+        ok_top = {"title", "description", "compatible", "is-device",
+                  "properties", "#cells", "bus", "on-bus", "parent-bus",
+                  "child-bus", "parent", "child", "child-binding", "sub-node"}
 
         for prop in binding:
             if prop not in ok_top and not prop.endswith("-cells"):
@@ -645,6 +645,10 @@ class Node:
     name:
       The name of the node
 
+    is_device:
+      True if the node's binding signals that it corresponds to a Zephyr
+      device model struct device. False otherwise.
+
     unit_addr:
       An integer with the ...@<unit-address> portion of the node name,
       translated through any 'ranges' properties on parent nodes, or None if
@@ -754,6 +758,11 @@ class Node:
     def name(self):
         "See the class docstring"
         return self._node.name
+
+    @property
+    def is_device(self):
+        "See the class docstring"
+        return self._binding and self._binding.get('is-device', False)
 
     @property
     def unit_addr(self):

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -52,6 +52,7 @@ def main():
                 continue
 
             write_node_comment(node)
+            write_deps(node)
             write_regs(node)
             write_irqs(node)
             write_props(node)
@@ -164,6 +165,21 @@ def relativize(path):
     except ValueError:
         # Not within ZEPHYR_BASE
         return path
+
+
+def write_deps(node):
+    # Writes dependency ordinal information for the node.
+
+    def dep_ords(nodes):
+        return [node.dep_ordinal for node in nodes]
+
+    out_node(node, 'ORDINAL', node.dep_ordinal)
+    out_node_init(node, 'REQUIRES_NODES', dep_ords(node.depends_on))
+    out_node_init(node, 'REQUIRES_DEVS',
+                  dep_ords([n for n in node.depends_on if n.is_device]))
+    out_node_init(node, 'SUPPORTS_NODES', dep_ords(node.required_by))
+    out_node_init(node, 'SUPPORTS_DEVS',
+                  dep_ords([n for n in node.required_by if n.is_device]))
 
 
 def write_regs(node):


### PR DESCRIPTION
Emit dependency ordinals for devices in devicetree.

The idea is we can start using these for hierarchical device management, so also extend the bindings language to express when nodes correspond to Zephyr devices. This lets us emit structure initializers that let devices track their dependencies in a ROM friendly way.

Going this way will let us use `__device_<ORDINAL>` as the identifier for each struct device with a DT-aware device init macro in the same style as #20253, but with dependency info implicitly embedded in the number. It remains to be seen how that would best fit into the existing init levels and priorities.

This also lets us resolve devices at build time if their ordinals are known constants. It would require a look up table to get a device from its ordinal in the general case.