### PR TITLE
gen_isr_tables: Improve error message

### DIFF
--- a/arch/common/gen_isr_tables.py
+++ b/arch/common/gen_isr_tables.py
@@ -303,7 +303,9 @@ def main():
                     table_index = irq1 - offset
 
             if swt[table_index] != (0, spurious_handler):
-                error("multiple registrations at table_index %d for irq %d (0x%x)" % (table_index, irq, irq))
+                error(f"multiple registrations at table_index {table_index} for irq {irq} (0x{irq:x})"
+                      + "\nHas IRQ_CONNECT or IRQ_DIRECT_CONNECT accidentally been invoked on the same irq multiple times?"
+                )
 
             swt[table_index] = (param, func)
 


### PR DESCRIPTION
Users are reportedly not able to understand how to debug the following
error message from gen_isr_tables:

`gen_isr_tables.py: multiple registrations at table_index 8 for irq 8`

Debugging these kinds of issues is difficult so we need to give
users as much information as possible.

To make it clearer that it could be an abuse of the 'IRQ_CONNECT' API
that is causing the issue we add this to the error message.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>