### PR TITLE
Misc IPv6 neighbor fixes when using VLANs

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -925,8 +925,13 @@ static void eth_iface_init(struct net_if *iface)
 			     sizeof(context->mac_addr),
 			     NET_LINK_ETHERNET);
 
-	/* For VLAN, this value is only used to get the correct L2 driver */
-	context->iface = iface;
+	/* For VLAN, this value is only used to get the correct L2 driver.
+	 * The iface pointer in context should contain the main interface
+	 * if the VLANs are enabled.
+	 */
+	if (context->iface == NULL) {
+		context->iface = iface;
+	}
 
 	ethernet_init(iface);
 	net_if_flag_set(iface, NET_IF_NO_AUTO_START);

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -397,7 +397,12 @@ static void eth_iface_init(struct net_if *iface)
 	struct eth_context *ctx = net_if_get_device(iface)->driver_data;
 	struct net_linkaddr *ll_addr = eth_get_mac(ctx);
 
-	ctx->iface = iface;
+	/* The iface pointer in context should contain the main interface
+	 * if the VLANs are enabled.
+	 */
+	if (ctx->iface == NULL) {
+		ctx->iface = iface;
+	}
 
 	ethernet_init(iface);
 

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1656,8 +1656,13 @@ static void eth0_iface_init(struct net_if *iface)
 	int result;
 	int i;
 
-	/* For VLAN, this value is only used to get the correct L2 driver */
-	dev_data->iface = iface;
+	/* For VLAN, this value is only used to get the correct L2 driver.
+	 * The iface pointer in context should contain the main interface
+	 * if the VLANs are enabled.
+	 */
+	if (dev_data->iface == NULL) {
+		dev_data->iface = iface;
+	}
 
 	ethernet_init(iface);
 

--- a/samples/net/sockets/echo_server/src/vlan.c
+++ b/samples/net/sockets/echo_server/src/vlan.c
@@ -55,26 +55,34 @@ static int setup_iface(struct net_if *iface, const char *ipv6_addr,
 		LOG_ERR("Cannot enable VLAN for tag %d (%d)", vlan_tag, ret);
 	}
 
-	if (net_addr_pton(AF_INET6, ipv6_addr, &addr6)) {
-		LOG_ERR("Invalid address: %s", ipv6_addr);
-		return -EINVAL;
+	if (IS_ENABLED(CONFIG_NET_IPV6)) {
+		if (net_addr_pton(AF_INET6, ipv6_addr, &addr6)) {
+			LOG_ERR("Invalid address: %s", ipv6_addr);
+			return -EINVAL;
+		}
+
+		ifaddr = net_if_ipv6_addr_add(iface, &addr6,
+					      NET_ADDR_MANUAL, 0);
+		if (!ifaddr) {
+			LOG_ERR("Cannot add %s to interface %p",
+				ipv6_addr, iface);
+			return -EINVAL;
+		}
 	}
 
-	ifaddr = net_if_ipv6_addr_add(iface, &addr6, NET_ADDR_MANUAL, 0);
-	if (!ifaddr) {
-		LOG_ERR("Cannot add %s to interface %p", ipv6_addr, iface);
-		return -EINVAL;
-	}
+	if (IS_ENABLED(CONFIG_NET_IPV4)) {
+		if (net_addr_pton(AF_INET, ipv4_addr, &addr4)) {
+			LOG_ERR("Invalid address: %s", ipv6_addr);
+			return -EINVAL;
+		}
 
-	if (net_addr_pton(AF_INET, ipv4_addr, &addr4)) {
-		LOG_ERR("Invalid address: %s", ipv6_addr);
-		return -EINVAL;
-	}
-
-	ifaddr = net_if_ipv4_addr_add(iface, &addr4, NET_ADDR_MANUAL, 0);
-	if (!ifaddr) {
-		LOG_ERR("Cannot add %s to interface %p", ipv4_addr, iface);
-		return -EINVAL;
+		ifaddr = net_if_ipv4_addr_add(iface, &addr4,
+					      NET_ADDR_MANUAL, 0);
+		if (!ifaddr) {
+			LOG_ERR("Cannot add %s to interface %p",
+				ipv4_addr, iface);
+			return -EINVAL;
+		}
 	}
 
 	LOG_DBG("Interface %p VLAN tag %d setup done.", iface, vlan_tag);

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -1816,11 +1816,12 @@ int net_ipv6_send_ns(struct net_if *iface,
 		llao_len = 0U;
 	} else {
 		if (!src) {
-			src = net_if_ipv6_select_src_addr(iface, dst);
+			src = net_if_ipv6_select_src_addr(iface, tgt);
 		}
 
 		if (net_ipv6_is_addr_unspecified(src)) {
-			NET_DBG("No source address for NS");
+			NET_DBG("No source address for NS (tgt %s)",
+				log_strdup(net_sprint_ipv6_addr(tgt)));
 			ret = -EINVAL;
 
 			goto drop;


### PR DESCRIPTION
While testing #22278 I noticed some issues in neighbor cache when VLANs were enabled:
* When sending NS to check reachability of incomplete state neighbor, we used destination IPv6 address to select the source IPv6 address to use. Unfortunately that address is typically a multicast address so it is better to use target IPv6 address for source address selection.
* Some of the neighbors were always in INCOMPLETE state
* Only one network interface had IPv6 link local address assigned to it
* echo-server with VLAN enabled but IPv6 or IPv4 disabled was causing compile error

The system now allocates a random IPv6 link local address to VLAN network interfaces as neighbor discovery does not work properly if the ll address is missing.