### PR TITLE
tests: drivers: counter: counter_basic_api: Fix single_shot_alarm

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -348,8 +348,14 @@ void test_single_shot_alarm_instance(const char *dev_name, bool set_top)
 	top_cfg.callback = NULL;
 	top_cfg.user_data = NULL;
 	err = counter_set_top_value(dev, &top_cfg);
-	zassert_equal(0, err, "%s: Setting top value to default failed",
-			dev_name);
+	if (err == -ENOTSUP) {
+		/* If resetting is not support, attempt without reset. */
+		top_cfg.flags = COUNTER_TOP_CFG_DONT_RESET;
+		err = counter_set_top_value(dev, &top_cfg);
+
+	}
+	zassert_true((err == 0) || (err == -ENOTSUP),
+			"%s: Setting top value to default failed", dev_name);
 
 	err = counter_stop(dev);
 	zassert_equal(0, err, "%s: Counter failed to stop", dev_name);


### PR DESCRIPTION
test_single_shot_alarm_instance may fail due to not supported setting
of top_value in call to counter_set_top_value.
Modified to accept not supported case.

Fixes #21745

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>