### PR TITLE
kernel: thread: fix string for _THREAD_PRESTART

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -280,7 +280,7 @@ const char *k_thread_state_str(k_tid_t thread_id)
 		return "pending";
 		break;
 	case _THREAD_PRESTART:
-		return "restart";
+		return "prestart";
 		break;
 	case _THREAD_DEAD:
 		return "dead";


### PR DESCRIPTION
_THREAD_PRESTART means the thread was not started yet and is being
setup, for example this is the case when starting a thread with a
timeout. We do not have a 'restart' thread state.