### PR TITLE
cmake: Have gperf be opt-out instead of mandatory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -797,6 +797,10 @@ if(CONFIG_ARM AND CONFIG_USERSPACE)
     )
   add_custom_target(priv_stacks DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${PRIV_STACKS})
 
+  if(${GPERF} STREQUAL GPERF-NOTFOUND)
+    message(FATAL_ERROR "Unable to find gperf")
+  endif()
+
   # Use gperf to generate C code (PRIV_STACKS_OUTPUT_SRC_PRE) which implements a
   # perfect hashtable based on PRIV_STACKS
   add_custom_command(

--- a/cmake/host-tools.cmake
+++ b/cmake/host-tools.cmake
@@ -75,13 +75,11 @@ if(${CMAKE_MATCH_1} VERSION_LESS ${MIN_DTC_VERSION})
 endif()
 endif(DTC)
 
+# gperf is an optional dependency
 find_program(
   GPERF
   gperf
   )
-if(${GPERF} STREQUAL GPERF-NOTFOUND)
-  message(FATAL_ERROR "Unable to find gperf")
-endif()
 
 # openocd is an optional dependency
 find_program(


### PR DESCRIPTION
gperf is only used when CONFIG_USERSPACE is enabled. Users that use
arch's that don't support CONFIG_USERSPACE, or happen to never
enable CONFIG_USERSPACE should not be artificially required to install
gperf.

This change makes gperf optional by moving it's presence-check to it's
usage.