### PR TITLE
STM32G4x/STM32L4Rx/STM32L4Sx: Fix sys clock frequency and boost voltage for highest clock frequencies

### DIFF
--- a/drivers/clock_control/clock_stm32g4.c
+++ b/drivers/clock_control/clock_stm32g4.c
@@ -29,6 +29,11 @@ void config_pll_init(LL_UTILS_PLLInitTypeDef *pllinit)
 	pllinit->PLLM = pllm(CONFIG_CLOCK_STM32_PLL_M_DIVISOR);
 	pllinit->PLLN = CONFIG_CLOCK_STM32_PLL_N_MULTIPLIER;
 	pllinit->PLLR = pllr(CONFIG_CLOCK_STM32_PLL_R_DIVISOR);
+
+	/* set power boost mode for sys clock greater than 150MHz */
+	if (sys_clock_hw_cycles_per_sec() >= MHZ(150)) {
+		LL_PWR_EnableRange1BoostMode();
+	}
 }
 #endif /* CONFIG_CLOCK_STM32_SYSCLK_SRC_PLL */
 

--- a/drivers/clock_control/clock_stm32l4_wb.c
+++ b/drivers/clock_control/clock_stm32l4_wb.c
@@ -30,6 +30,12 @@ void config_pll_init(LL_UTILS_PLLInitTypeDef *pllinit)
 	pllinit->PLLM = pllm(CONFIG_CLOCK_STM32_PLL_M_DIVISOR);
 	pllinit->PLLN = CONFIG_CLOCK_STM32_PLL_N_MULTIPLIER;
 	pllinit->PLLR = pllr(CONFIG_CLOCK_STM32_PLL_R_DIVISOR);
+#ifdef PWR_CR5_R1MODE
+	/* set power boost mode for sys clock greater than 80MHz */
+	if (sys_clock_hw_cycles_per_sec() >= MHZ(80)) {
+		LL_PWR_EnableRange1BoostMode();
+	}
+#endif /* PWR_CR5_R1MODE */
 }
 #endif /* CONFIG_CLOCK_STM32_SYSCLK_SRC_PLL */
 

--- a/west.yml
+++ b/west.yml
@@ -62,7 +62,7 @@ manifest:
       revision: fa481784b3c49780f18d50bafe00390ccb62b2ec
       path: modules/hal/st
     - name: hal_stm32
-      revision: 94d735c2613f5d17b64b78a15f0b0191e4474eb0
+      revision: dee4413253623ec575bb8b58abd56f91afe903bb
       path: modules/hal/stm32
     - name: hal_ti
       revision: b25d4b83b16e52f501f8cd360f4efb8c31ffb578


### PR DESCRIPTION
This patch enables the main regulator boost voltage for sys clock highest frequency.

For STM32G4xx series, boost mode when sys clock is higher than 150MHz
For STM32L4Rx or STM32L4Sx series, boost mode when sys clock is higher than 80MHz

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/22245

Signed-off-by: Francois Ramu <francois.ramu@st.com>