### PR TITLE
Bluetooth: Skip address setting for passive scan

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -509,6 +509,13 @@ struct bt_le_scan_cb {
  *  Start LE scanning with given parameters and provide results through
  *  the specified callback.
  *
+ *  Note: The LE scanner by default does not use the Identity Address of the
+ *        local device when :option:`CONFIG_BT_PRIVACY` is disabled. This is to
+ *        prevent the active scanner from disclosing the identity information
+ *        when requesting additional information from advertisers.
+ *        In order to enable directed advertiser reports then
+ *        :option:`CONFIG_BT_SCAN_WITH_IDENTITY` must be enabled.
+ *
  *  @param param Scan parameters.
  *  @param cb Callback to notify scan results. May be NULL if callback
  *            registration through @ref bt_le_scan_cb_register is preferred.

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -474,8 +474,10 @@ config BT_SCAN_WITH_IDENTITY
 	  Enable this if you want to perform active scanning using the local
 	  identity address as the scanner address. By default the stack will
 	  always use a non-resolvable private address (NRPA) in order to avoid
-	  disclosing local identity information. However, if the use case
-	  requires disclosing it then enable this option.
+	  disclosing local identity information. By not scanning with the
+	  identity address the scanner will receive directed advertise reports
+	  for for the local identity. If this use case is required, then enable
+	  this option.
 
 config BT_DEVICE_NAME_DYNAMIC
 	bool "Allow to set Bluetooth device name on runtime"

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -6178,13 +6178,17 @@ int bt_le_adv_stop(void)
 		return err;
 	}
 
-	if (!IS_ENABLED(CONFIG_BT_PRIVACY)) {
-		/* If active scan is ongoing set NRPA */
-		if (atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING) &&
-		    atomic_test_bit(bt_dev.flags, BT_DEV_ACTIVE_SCAN)) {
+#if defined(CONFIG_BT_OBSERVER)
+	if (!IS_ENABLED(CONFIG_BT_PRIVACY) &&
+	    !IS_ENABLED(CONFIG_BT_SCAN_WITH_IDENTITY)) {
+		/* If scan is ongoing set back NRPA */
+		if (atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING)) {
+			set_le_scan_enable(BT_HCI_LE_SCAN_DISABLE);
 			le_set_private_addr(bt_dev.adv_id);
+			set_le_scan_enable(BT_HCI_LE_SCAN_ENABLE);
 		}
 	}
+#endif /* defined(CONFIG_BT_OBSERVER) */
 
 	return 0;
 }

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3786,6 +3786,14 @@ static void le_adv_report(struct net_buf *buf)
 		info = net_buf_pull_mem(buf, sizeof(*info));
 		rssi = info->data[info->length];
 
+		if (!IS_ENABLED(CONFIG_BT_PRIVACY) &&
+		    !IS_ENABLED(CONFIG_BT_SCAN_WITH_IDENTITY) &&
+		    atomic_test_bit(bt_dev.flags, BT_DEV_EXPLICIT_SCAN) &&
+		    info->evt_type == BT_LE_ADV_DIRECT_IND) {
+			BT_DBG("Dropped direct adv report");
+			continue;
+		}
+
 		BT_DBG("%s event %u, len %u, rssi %d dBm",
 		       bt_addr_le_str(&info->addr),
 		       info->evt_type, info->length, rssi);

--- a/tests/bluetooth/hci_prop_evt/src/main.c
+++ b/tests/bluetooth/hci_prop_evt/src/main.c
@@ -198,6 +198,9 @@ static const struct cmd_handler cmds[] = {
 	{ BT_HCI_OP_LE_RAND,
 	  sizeof(struct bt_hci_rp_le_rand),
 	  generic_success },
+	{ BT_HCI_OP_LE_SET_RANDOM_ADDRESS,
+	  sizeof(struct bt_hci_cp_le_set_random_address),
+	  generic_success },
 };
 
 /* HCI driver open. */


### PR DESCRIPTION
The passive scanner isn't actually using the advertising address, and
doesn't need to set it during scan initialization.

set_random_addr always fails if there's an active advertiser, which
would cause needless complications for the Bluetooth Mesh LPN case.

Fixes #22088.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>