### PR TITLE
samples: net: echo_client/echo_server: Fix bug in socket close for UDP.

### DIFF
--- a/samples/net/sockets/echo_client/src/udp.c
+++ b/samples/net/sockets/echo_client/src/udp.c
@@ -252,7 +252,7 @@ void stop_udp(void)
 		k_delayed_work_cancel(&conf.ipv6.udp.recv);
 		k_delayed_work_cancel(&conf.ipv6.udp.transmit);
 
-		if (conf.ipv6.udp.sock > 0) {
+		if (conf.ipv6.udp.sock >= 0) {
 			(void)close(conf.ipv6.udp.sock);
 		}
 	}
@@ -261,7 +261,7 @@ void stop_udp(void)
 		k_delayed_work_cancel(&conf.ipv4.udp.recv);
 		k_delayed_work_cancel(&conf.ipv4.udp.transmit);
 
-		if (conf.ipv4.udp.sock > 0) {
+		if (conf.ipv4.udp.sock >= 0) {
 			(void)close(conf.ipv4.udp.sock);
 		}
 	}

--- a/samples/net/sockets/echo_server/src/udp.c
+++ b/samples/net/sockets/echo_server/src/udp.c
@@ -202,14 +202,14 @@ void stop_udp(void)
 	 */
 	if (IS_ENABLED(CONFIG_NET_IPV6)) {
 		k_thread_abort(udp6_thread_id);
-		if (conf.ipv6.udp.sock > 0) {
+		if (conf.ipv6.udp.sock >= 0) {
 			(void)close(conf.ipv6.udp.sock);
 		}
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4)) {
 		k_thread_abort(udp4_thread_id);
-		if (conf.ipv4.udp.sock > 0) {
+		if (conf.ipv4.udp.sock >= 0) {
 			(void)close(conf.ipv4.udp.sock);
 		}
 	}


### PR DESCRIPTION
Fixed bug in udp.c in echo_client and echo_server sample.
The bug causes UDP sockets in echo_client to not close if socket id is 0.