### PR TITLE
drivers/flash: stm32: Fix faulty register access

### DIFF
--- a/drivers/flash/flash_stm32wbx.c
+++ b/drivers/flash/flash_stm32wbx.c
@@ -175,12 +175,12 @@ int flash_stm32_check_status(struct device *dev)
 	u32_t error = 0;
 
 	/* Save Flash errors */
-	error = (regs->sr & FLASH_FLAG_SR_ERRORS);
-	error |= (regs->eccr & FLASH_FLAG_ECCC);
+	error = (regs->SR & FLASH_FLAG_SR_ERRORS);
+	error |= (regs->ECCR & FLASH_FLAG_ECCC);
 
 	/* Clear systematic Option and Enginneering bits validity error */
 	if (error & FLASH_FLAG_OPTVERR) {
-		regs->sr |= FLASH_FLAG_SR_ERRORS;
+		regs->SR |= FLASH_FLAG_SR_ERRORS;
 		return 0;
 	}
 


### PR DESCRIPTION
Merge of conflicting PRs lead to compilation issue.
Fix this.

Fixes #22297

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>