### PR TITLE
tests: mem_slab: disable test on qemu_x86_coverage

### DIFF
--- a/tests/kernel/mem_slab/mslab_threadsafe/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab_threadsafe/testcase.yaml
@@ -1,3 +1,6 @@
 tests:
   kernel.memory_slabs.threadsafe:
     tags: kernel
+    # FIXME: This test is getting stuck on this platform on 30% of PRs, disable
+    # for now while we investigate
+    platform_exclude: qemu_x86_coverage


### PR DESCRIPTION
This test is getting stuck on this platform on 30% of PRs, disable
for now while we investigate