### PR TITLE
Enable BLE controller conformance (EDTT) tests in CI

### DIFF
--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -26,6 +26,8 @@ if [ ! -d "${BSIM_OUT_PATH}" ]; then
         unset BSIM_OUT_PATH
 fi
 export BSIM_COMPONENTS_PATH="${BSIM_OUT_PATH}/components/"
+export EDTT_PATH="${EDTT_PATH:-../tools/edtt}"
+
 bsim_bt_test_results_file="./bsim_bt_out/bsim_results.xml"
 west_commands_results_file="./pytest_out/west_commands.xml"
 

--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -126,7 +126,7 @@ function on_complete() {
 function run_bsim_bt_tests() {
 	WORK_DIR=${ZEPHYR_BASE}/bsim_bt_out tests/bluetooth/bsim_bt/compile.sh
 	RESULTS_FILE=${ZEPHYR_BASE}/${bsim_bt_test_results_file} \
-	SEARCH_PATH=tests/bluetooth/bsim_bt/bsim_test_app/tests_scripts \
+	SEARCH_PATH=tests/bluetooth/bsim_bt/ \
 	tests/bluetooth/bsim_bt/run_parallel.sh
 }
 

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/hci.test_list
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/hci.test_list
@@ -1,7 +1,7 @@
 # Copyright 2019 Oticon A/S
 # SPDX-License-Identifier: Apache-2.0
 
-HCI/CCO/BV-07-C
+#HCI/CCO/BV-07-C #See GH issue #22085
 HCI/CCO/BV-09-C
 HCI/CCO/BV-10-C
 HCI/CCO/BV-11-C
@@ -27,5 +27,5 @@ HCI/DSU/BV-03-C
 HCI/DSU/BV-04-C
 HCI/DSU/BV-05-C
 HCI/DSU/BV-06-C
-HCI/GEV/BV-01-C
+#HCI/GEV/BV-01-C #See GH issue #22085
 HCI/HFC/BV-04-C

--- a/west.yml
+++ b/west.yml
@@ -117,7 +117,7 @@ manifest:
       path: modules/hal/xtensa
     - name: edtt
       path: tools/edtt
-      revision: dd4dd502ef2fbeced6ef7faaba562a7ddca45632
+      revision: 5fb6617815c7909f01988d10d6bc4789253f31f6
 
   self:
     path: zephyr


### PR DESCRIPTION
Enable the BLE controller tests in CI (EDTT tests), so we avoid regressions in the controller.
These tests where added to Zephyr's tree in #21751 
The tests use BabbleSim to simulate the physical layer, and run in CI using the nrf52_bsim (though they can use other off-tree simulated targets).
Running these tests in CI adds approx. 1 min extra runtime to the 1st minion

Background in short: The BT spec specifies a set of conformance tests controllers needs to pass to be qualified and BT certified. Running the real set of tests requires certified, horrendously expensive HW, and quite a bit of time (in the order of hours).
These tests do not cover the whole test spec: only around 1/3 is implemented so far, and some of them are not possible to implement directly using this method as they require "illegal" behavior from a test controller.
In these tests both sides of the test (DUT and tester) are zephyr controllers, so some issues may be hidden. But lacking any other reference controller we can simulate in CI this is certainly still adding a lot of value.
These tests are certainly *not* certified, and cannot be used for any purpose more than sanity testing/quick regression testing of the controller. Any BT certification will still require running the tests with a proper tester (e.g. EBQ), following proper procedures.

Note that this PR also disables the currently failing INQUIRY HCI tests (see #22085 for more info) as otherwise CI would break right away.

Note: LL/CON/INI/BV-24-C was already disabled (as the test implementation needs to be investigated)