### PR TITLE
net: mqtt: hostname in mqtt_sec_config is declared with const

### DIFF
--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -338,7 +338,7 @@ struct mqtt_sec_config {
 	/** Peer hostname for ceritificate verification.
 	 *  May be NULL to skip hostname verification.
 	 */
-	char *hostname;
+	const char *hostname;
 };
 
 /** @brief MQTT transport type. */


### PR DESCRIPTION
A minor fix. 
struct mqtt_sec_config declares a member hostname as char*.
There seems to be no reason not to declare the member as a const char*
