### PR TITLE
modules: hal: nordic: Fix nrfx log messages

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -47,7 +47,7 @@ manifest:
       revision: a12d92816a53a521d79cefcf5c38b9dc8a4fed6e
       path: modules/hal/cypress
     - name: hal_nordic
-      revision: 4a1401d1e1cae0bc464eeb9b3e091efec50bf6c9
+      revision: 12d7647870888e4cb0e421f2b26884c2e76915ac
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 9bfbe35aad79fdf552dbdae47a894e26be7c022c


### PR DESCRIPTION
Update revision of the hal_nordic module, so that `uint32_t` arguments
are casted to `unsigned long` in nrfx log messages.
This is done  to avoid warnings about providing an argument of type
`uint32_t` (which is `unsigned int`) where a `long unsigned int` one
is expected.

---
https://github.com/zephyrproject-rtos/hal_nordic/pull/21 needs to go in first.