### PR TITLE
west: commands: sign: look for imgtool.py in path

### DIFF
--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -261,7 +261,7 @@ class ImgtoolSigner(Signer):
                                 format(args.tool_path))
             tool_path = args.tool_path
         else:
-            tool_path = shutil.which('imgtool')
+            tool_path = shutil.which('imgtool') or shutil.which('imgtool.py')
             if not tool_path:
                 log.die('imgtool not found; either install it',
                         '(e.g. "pip3 install imgtool") or provide --tool-path')


### PR DESCRIPTION
If 'imgtool' is not found in PATH look for 'imgtool.py' before bailing out.

This allows adding the mcuboot/scripts directory to PATH and have 'west sign -t imgtool' automatically locate the 'imgtool.py' script.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>