### PR TITLE
west.yml: update mcuboot to use non-deprecated GPIO flags

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -77,7 +77,7 @@ manifest:
       revision: 3776c158fe138a72c97c187e4d31c81c37884be9
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: 54c1e3fb6ba4dcf7b315943bcfcda1e10a4042f5
+      revision: pull/5/head
       path: bootloader/mcuboot
     - name: mcumgr
       revision: d4e97cd4fc80ff949415062b1c83fd42929e8fe4


### PR DESCRIPTION
Upcoming deprecation will produce build failures as long as the deprecated flags are used.  This PR references a pending change that supports both old and new flags in mcuboot.