### PR TITLE
coverage: do not dump coverage data by default

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -285,8 +285,10 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 	/* Mark nonessenrial since main() has no more work to do */
 	z_main_thread.base.user_options &= ~K_ESSENTIAL;
 
+#ifdef CONFIG_COVERAGE_DUMP
 	/* Dump coverage data once the main() has exited. */
 	gcov_coverage_dump();
+#endif
 } /* LCOV_EXCL_LINE ... because we just dumped final coverage data */
 
 /* LCOV_EXCL_START */

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1744,6 +1744,7 @@ class TestInstance:
             if enable_coverage:
                 if platform.name in coverage_platform:
                     content = content + "\nCONFIG_COVERAGE=y"
+                    content = content + "\nCONFIG_COVERAGE_DUMP=y"
 
             if enable_asan:
                 if platform.type == "native":

--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -57,6 +57,12 @@ config COVERAGE_GCOV
 	  can be read by gcov utility. For more details see gcovr.com .
 endif
 
+config COVERAGE_DUMP
+	bool "Dump coverage data on exit"
+	depends on COVERAGE_GCOV
+	help
+	  Dump collected coverage information to console on exit.
+
 config TEST_USERSPACE
 	bool "Indicate that this test exercises user mode"
 	help


### PR DESCRIPTION
Only dump data when we are interested in the analysing coverage. By
default just collect the data.

CONFIG_COVERAGE_DUMP is used to control this behaviour.

This will help speed up sanitycheck and will avoid lots of noise in the
log when some tests with coverage enabled failed. Dumping data to
console is also suspected to be one of the reason why qemu hangs in CI.