### PR TITLE
Bluetooth: controller: split: Force central cleanup on MIC error

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -999,7 +999,8 @@ void ull_conn_done(struct node_rx_event_done *done)
 			    0 ||
 #endif /* CONFIG_BT_PERIPHERAL */
 #if defined(CONFIG_BT_CENTRAL)
-			    conn->master.terminate_ack
+			    conn->master.terminate_ack ||
+			    (reason_peer == BT_HCI_ERR_TERM_DUE_TO_MIC_FAIL)
 #else /* CONFIG_BT_CENTRAL */
 			    1
 #endif /* CONFIG_BT_CENTRAL */


### PR DESCRIPTION
Since a peer MIC failure closes the event, it does not allow a terminate
acknowledge. For that reason a peer MIC fail for central role must force
a conn_cleanup.

Signed-off-by: Morten Priess <mtpr@oticon.com>