### PR TITLE
sanitycheck: show which threads are stuck

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2905,8 +2905,7 @@ class TestSuite:
 
             while future_to_test:
                 # check for status of the futures which are currently working
-                done, _ = concurrent.futures.wait(
-                    future_to_test, timeout=0.25,
+                done, _ = concurrent.futures.wait(future_to_test, timeout=1,
                     return_when=concurrent.futures.FIRST_COMPLETED)
 
                 # if there is incoming work, start a new future
@@ -2915,7 +2914,6 @@ class TestSuite:
                     message = pipeline.get()
                     test = message['test']
 
-                    # Start the load operation and mark the future with its URL
                     pb = ProjectBuilder(self,
                                         test,
                                         lsan=self.enable_lsan,

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2905,7 +2905,7 @@ class TestSuite:
 
             while future_to_test:
                 # check for status of the futures which are currently working
-                done, _ = concurrent.futures.wait(future_to_test, timeout=1,
+                done, pending = concurrent.futures.wait(future_to_test, timeout=1,
                     return_when=concurrent.futures.FIRST_COMPLETED)
 
                 # if there is incoming work, start a new future
@@ -2943,6 +2943,18 @@ class TestSuite:
 
                     # remove the now completed future
                     del future_to_test[future]
+
+                for future in pending:
+                    test = future_to_test[future]
+
+                    try:
+                        future.result(timeout=180)
+                    except concurrent.futures.TimeoutError:
+                        logger.warning("{} stuck?".format(test))
+
+
+
+
 
         if self.enable_size_report and not self.cmake_only:
             # Parallelize size calculation


### PR DESCRIPTION
Print a warning if some threads are taking more time and seem to be stuck.