### PR TITLE
arch: arm: mpu: no dynamic MPU re-program in swap if not required

### DIFF
--- a/arch/arm/core/aarch32/swap_helper.S
+++ b/arch/arm/core/aarch32/swap_helper.S
@@ -198,7 +198,7 @@ out_fp_endif:
     cpsie i
 _thread_irq_disabled:
 
-#if defined(CONFIG_ARM_MPU)
+#if defined(CONFIG_MPU_STACK_GUARD) || defined(CONFIG_USERSPACE)
     /* Re-program dynamic memory map */
     push {r2,lr}
     mov r0, r2
@@ -278,7 +278,7 @@ in_fp_endif:
     isb
 #endif
 
-#if defined (CONFIG_ARM_MPU)
+#if defined(CONFIG_MPU_STACK_GUARD) || defined(CONFIG_USERSPACE)
     /* Re-program dynamic memory map */
     push {r2,lr}
     mov r0, r2 /* _current thread */

--- a/arch/arm/core/aarch32/thread.c
+++ b/arch/arm/core/aarch32/thread.c
@@ -404,7 +404,7 @@ void arch_switch_to_main_thread(struct k_thread *main_thread,
 
 	/* the ready queue cache already contains the main thread */
 
-#ifdef CONFIG_ARM_MPU
+#if defined(CONFIG_MPU_STACK_GUARD) || defined(CONFIG_USERSPACE)
 	/*
 	 * If stack protection is enabled, make sure to set it
 	 * before jumping to thread entry function


### PR DESCRIPTION
Dynamic MPU regions are used in build configurations with User
mode or MPU-based stack-overflow guards. If these features are
disabled, we skip calling the ARM function for re-programming
the MPU peripheral during context-switch. We also skip doing
this when jumping to main thread (although this brings limited
performace gain as it is called once in the boot cycle)

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>