### PR TITLE
[TOPIC-GPIO] clean up API declarations

### DIFF
--- a/drivers/adc/adc_lmp90xxx.c
+++ b/drivers/adc/adc_lmp90xxx.c
@@ -112,7 +112,7 @@ struct lmp90xxx_config {
 	struct spi_config spi_cfg;
 	const char *drdyb_dev_name;
 	gpio_pin_t drdyb_pin;
-	gpio_devicetree_flags_t drdyb_flags;
+	gpio_dt_flags_t drdyb_flags;
 	u8_t rtd_current;
 	u8_t resolution;
 	u8_t channels;

--- a/drivers/eeprom/eeprom_at2x.c
+++ b/drivers/eeprom/eeprom_at2x.c
@@ -41,7 +41,7 @@ struct eeprom_at2x_config {
 	const char *spi_cs_dev_name;
 	u8_t spi_cs_pin;
 	gpio_pin_t wp_gpio_pin;
-	gpio_devicetree_flags_t wp_gpio_flags;
+	gpio_dt_flags_t wp_gpio_flags;
 	const char *wp_gpio_name;
 	size_t size;
 	size_t pagesize;

--- a/drivers/ethernet/eth_enc28j60_priv.h
+++ b/drivers/ethernet/eth_enc28j60_priv.h
@@ -216,7 +216,7 @@
 struct eth_enc28j60_config {
 	const char *gpio_port;
 	u8_t gpio_pin;
-	gpio_devicetree_flags_t gpio_flags;
+	gpio_dt_flags_t gpio_flags;
 	const char *spi_port;
 	u8_t spi_cs_pin;
 	const char *spi_cs_port;

--- a/drivers/ethernet/eth_enc424j600_priv.h
+++ b/drivers/ethernet/eth_enc424j600_priv.h
@@ -275,7 +275,7 @@
 struct enc424j600_config {
 	const char *gpio_port;
 	u8_t gpio_pin;
-	gpio_devicetree_flags_t gpio_flags;
+	gpio_dt_flags_t gpio_flags;
 	const char *spi_port;
 	u8_t spi_cs_pin;
 	const char *spi_cs_port;

--- a/drivers/gpio/gpio_cc13xx_cc26xx.c
+++ b/drivers/gpio/gpio_cc13xx_cc26xx.c
@@ -41,14 +41,10 @@ static int gpio_cc13xx_cc26xx_port_set_bits_raw(struct device *port,
 static int gpio_cc13xx_cc26xx_port_clear_bits_raw(struct device *port,
 	u32_t mask);
 
-static int gpio_cc13xx_cc26xx_config(struct device *port, int access_op,
+static int gpio_cc13xx_cc26xx_config(struct device *port,
 				     u32_t pin, int flags)
 {
 	u32_t config = 0;
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
 
 	__ASSERT_NO_MSG(pin < NUM_IO_MAX);
 

--- a/drivers/gpio/gpio_cc13xx_cc26xx.c
+++ b/drivers/gpio/gpio_cc13xx_cc26xx.c
@@ -104,52 +104,6 @@ static int gpio_cc13xx_cc26xx_config(struct device *port, int access_op,
 	return 0;
 }
 
-static int gpio_cc13xx_cc26xx_write(struct device *port, int access_op,
-				    u32_t pin, u32_t value)
-{
-	switch (access_op) {
-	case GPIO_ACCESS_BY_PIN:
-		__ASSERT_NO_MSG(pin < NUM_IO_MAX);
-		if (value) {
-			GPIO_setDio(pin);
-		} else {
-			GPIO_clearDio(pin);
-		}
-		break;
-	case GPIO_ACCESS_BY_PORT:
-		if (value) {
-			GPIO_setMultiDio(GPIO_DIO_ALL_MASK);
-		} else {
-			GPIO_clearMultiDio(GPIO_DIO_ALL_MASK);
-		}
-		break;
-	default:
-		return -EINVAL;
-	}
-
-	return 0;
-}
-
-static int gpio_cc13xx_cc26xx_read(struct device *port, int access_op,
-				   u32_t pin, u32_t *value)
-{
-	__ASSERT_NO_MSG(value != NULL);
-
-	switch (access_op) {
-	case GPIO_ACCESS_BY_PIN:
-		__ASSERT_NO_MSG(pin < NUM_IO_MAX);
-		*value = GPIO_readDio(pin);
-		break;
-	case GPIO_ACCESS_BY_PORT:
-		*value = GPIO_readMultiDio(GPIO_DIO_ALL_MASK);
-		break;
-	default:
-		return -EINVAL;
-	}
-
-	return 0;
-}
-
 static int gpio_cc13xx_cc26xx_port_get_raw(struct device *port, u32_t *value)
 {
 	__ASSERT_NO_MSG(value != NULL);
@@ -311,8 +265,6 @@ static int gpio_cc13xx_cc26xx_init(struct device *dev)
 
 static const struct gpio_driver_api gpio_cc13xx_cc26xx_driver_api = {
 	.config = gpio_cc13xx_cc26xx_config,
-	.write = gpio_cc13xx_cc26xx_write,
-	.read = gpio_cc13xx_cc26xx_read,
 	.port_get_raw = gpio_cc13xx_cc26xx_port_get_raw,
 	.port_set_masked_raw = gpio_cc13xx_cc26xx_port_set_masked_raw,
 	.port_set_bits_raw = gpio_cc13xx_cc26xx_port_set_bits_raw,

--- a/drivers/gpio/gpio_cc13xx_cc26xx.c
+++ b/drivers/gpio/gpio_cc13xx_cc26xx.c
@@ -42,7 +42,8 @@ static int gpio_cc13xx_cc26xx_port_clear_bits_raw(struct device *port,
 	u32_t mask);
 
 static int gpio_cc13xx_cc26xx_config(struct device *port,
-				     u32_t pin, int flags)
+				     gpio_pin_t pin,
+				     gpio_flags_t flags)
 {
 	u32_t config = 0;
 
@@ -141,7 +142,7 @@ static int gpio_cc13xx_cc26xx_port_toggle_bits(struct device *port, u32_t mask)
 }
 
 static int gpio_cc13xx_cc26xx_pin_interrupt_configure(struct device *port,
-		unsigned int pin, enum gpio_int_mode mode,
+		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
 	struct gpio_cc13xx_cc26xx_data *data = port->driver_data;
@@ -184,7 +185,7 @@ static int gpio_cc13xx_cc26xx_manage_callback(struct device *port,
 }
 
 static int gpio_cc13xx_cc26xx_enable_callback(struct device *port,
-					      u32_t pin)
+					      gpio_pin_t pin)
 {
 	struct gpio_cc13xx_cc26xx_data *data = port->driver_data;
 
@@ -195,7 +196,7 @@ static int gpio_cc13xx_cc26xx_enable_callback(struct device *port,
 }
 
 static int gpio_cc13xx_cc26xx_disable_callback(struct device *port,
-					       u32_t pin)
+					       gpio_pin_t pin)
 {
 	struct gpio_cc13xx_cc26xx_data *data = port->driver_data;
 
@@ -260,7 +261,7 @@ static int gpio_cc13xx_cc26xx_init(struct device *dev)
 }
 
 static const struct gpio_driver_api gpio_cc13xx_cc26xx_driver_api = {
-	.config = gpio_cc13xx_cc26xx_config,
+	.pin_configure = gpio_cc13xx_cc26xx_config,
 	.port_get_raw = gpio_cc13xx_cc26xx_port_get_raw,
 	.port_set_masked_raw = gpio_cc13xx_cc26xx_port_set_masked_raw,
 	.port_set_bits_raw = gpio_cc13xx_cc26xx_port_set_bits_raw,

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -70,7 +70,8 @@ static int gpio_cc32xx_port_set_bits_raw(struct device *port, u32_t mask);
 static int gpio_cc32xx_port_clear_bits_raw(struct device *port, u32_t mask);
 
 static inline int gpio_cc32xx_config(struct device *port,
-				   u32_t pin, int flags)
+				     gpio_pin_t pin,
+				     gpio_flags_t flags)
 {
 	const struct gpio_cc32xx_config *gpio_config = DEV_CFG(port);
 	unsigned long port_base = gpio_config->port_base;
@@ -160,7 +161,7 @@ static int gpio_cc32xx_port_toggle_bits(struct device *port, u32_t mask)
 }
 
 static int gpio_cc32xx_pin_interrupt_configure(struct device *port,
-		unsigned int pin, enum gpio_int_mode mode,
+		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
 	const struct gpio_cc32xx_config *gpio_config = DEV_CFG(port);
@@ -209,7 +210,7 @@ static int gpio_cc32xx_manage_callback(struct device *dev,
 
 
 static int gpio_cc32xx_enable_callback(struct device *dev,
-				    u32_t pin)
+				    gpio_pin_t pin)
 {
 	struct gpio_cc32xx_data *data = DEV_DATA(dev);
 
@@ -222,7 +223,7 @@ static int gpio_cc32xx_enable_callback(struct device *dev,
 
 
 static int gpio_cc32xx_disable_callback(struct device *dev,
-				     u32_t pin)
+				     gpio_pin_t pin)
 {
 	struct gpio_cc32xx_data *data = DEV_DATA(dev);
 
@@ -258,7 +259,7 @@ static void gpio_cc32xx_port_isr(void *arg)
 }
 
 static const struct gpio_driver_api api_funcs = {
-	.config = gpio_cc32xx_config,
+	.pin_configure = gpio_cc32xx_config,
 	.port_get_raw = gpio_cc32xx_port_get_raw,
 	.port_set_masked_raw = gpio_cc32xx_port_set_masked_raw,
 	.port_set_bits_raw = gpio_cc32xx_port_set_bits_raw,

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -70,7 +70,7 @@ static int gpio_cc32xx_port_set_bits_raw(struct device *port, u32_t mask);
 static int gpio_cc32xx_port_clear_bits_raw(struct device *port, u32_t mask);
 
 static inline int gpio_cc32xx_config(struct device *port,
-				   int access_op, u32_t pin, int flags)
+				   u32_t pin, int flags)
 {
 	const struct gpio_cc32xx_config *gpio_config = DEV_CFG(port);
 	unsigned long port_base = gpio_config->port_base;
@@ -84,10 +84,6 @@ static inline int gpio_cc32xx_config(struct device *port,
 	}
 
 	if ((flags & (GPIO_PULL_UP | GPIO_PULL_DOWN)) != 0) {
-		return -ENOTSUP;
-	}
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -107,50 +107,6 @@ static inline int gpio_cc32xx_config(struct device *port,
 	return 0;
 }
 
-static inline int gpio_cc32xx_write(struct device *port,
-				    int access_op, u32_t pin, u32_t value)
-{
-	const struct gpio_cc32xx_config *gpio_config = DEV_CFG(port);
-	unsigned long port_base = gpio_config->port_base;
-
-	__ASSERT(pin < 8, "Invalid pin number - only 8 pins per port");
-
-	if (access_op == GPIO_ACCESS_BY_PIN) {
-		value = value << pin;
-		/* Bitpack external GPIO pin number for GPIOPinWrite API: */
-		pin = 1 << pin;
-
-		MAP_GPIOPinWrite(port_base, (unsigned char)pin,
-			(unsigned char)value);
-	} else {
-		return -ENOTSUP;
-	}
-
-	return 0;
-}
-
-static inline int gpio_cc32xx_read(struct device *port,
-				   int access_op, u32_t pin, u32_t *value)
-{
-	const struct gpio_cc32xx_config *gpio_config = DEV_CFG(port);
-	unsigned long port_base = gpio_config->port_base;
-	long status;
-	unsigned char pin_packed;
-
-	__ASSERT(pin < 8, "Invalid pin number - only 8 pins per port");
-
-	if (access_op == GPIO_ACCESS_BY_PIN) {
-		/* Bitpack external GPIO pin number for GPIOPinRead API: */
-		pin_packed = 1 << pin;
-		status =  MAP_GPIOPinRead(port_base, pin_packed);
-		*value = status >> pin;
-	} else {
-		return -ENOTSUP;
-	}
-
-	return 0;
-}
-
 static int gpio_cc32xx_port_get_raw(struct device *port, u32_t *value)
 {
 	const struct gpio_cc32xx_config *gpio_config = DEV_CFG(port);
@@ -307,8 +263,6 @@ static void gpio_cc32xx_port_isr(void *arg)
 
 static const struct gpio_driver_api api_funcs = {
 	.config = gpio_cc32xx_config,
-	.write = gpio_cc32xx_write,
-	.read = gpio_cc32xx_read,
 	.port_get_raw = gpio_cc32xx_port_get_raw,
 	.port_set_masked_raw = gpio_cc32xx_port_set_masked_raw,
 	.port_set_bits_raw = gpio_cc32xx_port_set_bits_raw,

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -88,7 +88,7 @@ static int gpio_cmsdk_ahb_port_toggle_bits(struct device *dev, u32_t mask)
 	return 0;
 }
 
-static int cmsdk_ahb_gpio_config(struct device *dev, u32_t mask, int flags)
+static int cmsdk_ahb_gpio_config(struct device *dev, u32_t mask, gpio_flags_t flags)
 {
 	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config->config_info;
 
@@ -136,13 +136,14 @@ static int cmsdk_ahb_gpio_config(struct device *dev, u32_t mask, int flags)
  * @return 0 if successful, failed otherwise
  */
 static int gpio_cmsdk_ahb_config(struct device *dev,
-				 u32_t pin, int flags)
+				 gpio_pin_t pin,
+				 gpio_flags_t flags)
 {
 	return cmsdk_ahb_gpio_config(dev, BIT(pin), flags);
 }
 
 static int gpio_cmsdk_ahb_pin_interrupt_configure(struct device *dev,
-		unsigned int pin, enum gpio_int_mode mode,
+		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
 	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config->config_info;
@@ -207,7 +208,7 @@ static int gpio_cmsdk_ahb_manage_callback(struct device *dev,
 }
 
 static int gpio_cmsdk_ahb_enable_callback(struct device *dev,
-					  u32_t pin)
+					  gpio_pin_t pin)
 {
 	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config->config_info;
 
@@ -217,7 +218,7 @@ static int gpio_cmsdk_ahb_enable_callback(struct device *dev,
 }
 
 static int gpio_cmsdk_ahb_disable_callback(struct device *dev,
-					   u32_t pin)
+					   gpio_pin_t pin)
 {
 	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config->config_info;
 
@@ -227,7 +228,7 @@ static int gpio_cmsdk_ahb_disable_callback(struct device *dev,
 }
 
 static const struct gpio_driver_api gpio_cmsdk_ahb_drv_api_funcs = {
-	.config = gpio_cmsdk_ahb_config,
+	.pin_configure = gpio_cmsdk_ahb_config,
 	.port_get_raw = gpio_cmsdk_ahb_port_get_raw,
 	.port_set_masked_raw = gpio_cmsdk_ahb_port_set_masked_raw,
 	.port_set_bits_raw = gpio_cmsdk_ahb_port_set_bits_raw,

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -130,29 +130,15 @@ static int cmsdk_ahb_gpio_config(struct device *dev, u32_t mask, int flags)
  * @brief Configure pin or port
  *
  * @param dev Device struct
- * @param access_op Access operation (pin or port)
  * @param pin The pin number
  * @param flags Flags of pin or port
  *
  * @return 0 if successful, failed otherwise
  */
-static int gpio_cmsdk_ahb_config(struct device *dev, int access_op,
+static int gpio_cmsdk_ahb_config(struct device *dev,
 				 u32_t pin, int flags)
 {
-	int ret = 0;
-
-	switch (access_op) {
-	case GPIO_ACCESS_BY_PIN:
-		ret = cmsdk_ahb_gpio_config(dev, BIT(pin), flags);
-		break;
-	case GPIO_ACCESS_BY_PORT:
-		ret = cmsdk_ahb_gpio_config(dev, (0xFFFF), flags);
-		break;
-	default:
-		return -ENOTSUP;
-	}
-
-	return ret;
+	return cmsdk_ahb_gpio_config(dev, BIT(pin), flags);
 }
 
 static int gpio_cmsdk_ahb_pin_interrupt_configure(struct device *dev,

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -350,39 +350,6 @@ static inline int gpio_dw_config(struct device *port, int access_op,
 	return 0;
 }
 
-static inline int gpio_dw_write(struct device *port, int access_op,
-				u32_t pin, u32_t value)
-{
-	struct gpio_dw_runtime *context = port->driver_data;
-	u32_t base_addr = dw_base_to_block_base(context->base_addr);
-	u32_t port_base_addr = context->base_addr;
-	u32_t data_port = dw_get_data_port(port_base_addr);
-
-	if (GPIO_ACCESS_BY_PIN == access_op) {
-		dw_set_bit(base_addr, data_port, pin, value);
-	} else {
-		dw_write(base_addr, data_port, value);
-	}
-
-	return 0;
-}
-
-static inline int gpio_dw_read(struct device *port, int access_op,
-			       u32_t pin, u32_t *value)
-{
-	struct gpio_dw_runtime *context = port->driver_data;
-	u32_t base_addr = dw_base_to_block_base(context->base_addr);
-	u32_t port_base_addr = context->base_addr;
-	u32_t ext_port = dw_get_ext_port(port_base_addr);
-
-	*value = dw_read(base_addr, ext_port);
-
-	if (GPIO_ACCESS_BY_PIN == access_op) {
-		*value = !!(*value & BIT(pin));
-	}
-	return 0;
-}
-
 static int gpio_dw_port_get_raw(struct device *port, u32_t *value)
 {
 	struct gpio_dw_runtime *context = port->driver_data;
@@ -585,8 +552,6 @@ static void gpio_dw_isr(void *arg)
 
 static const struct gpio_driver_api api_funcs = {
 	.config = gpio_dw_config,
-	.write = gpio_dw_write,
-	.read = gpio_dw_read,
 	.port_get_raw = gpio_dw_port_get_raw,
 	.port_set_masked_raw = gpio_dw_port_set_masked_raw,
 	.port_set_bits_raw = gpio_dw_port_set_bits_raw,

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -301,17 +301,7 @@ static inline void dw_pin_config(struct device *port,
 	}
 }
 
-static inline void dw_port_config(struct device *port, int flags)
-{
-	const struct gpio_dw_config *config = port->config->config_info;
-	int i;
-
-	for (i = 0; i < config->bits; i++) {
-		dw_pin_config(port, i, flags);
-	}
-}
-
-static inline int gpio_dw_config(struct device *port, int access_op,
+static inline int gpio_dw_config(struct device *port,
 				 u32_t pin, int flags)
 {
 	const struct gpio_dw_config *config = port->config->config_info;
@@ -341,11 +331,7 @@ static inline int gpio_dw_config(struct device *port, int access_op,
 		return -ENOTSUP;
 	}
 
-	if (GPIO_ACCESS_BY_PIN == access_op) {
-		dw_pin_config(port, pin, flags);
-	} else {
-		dw_port_config(port, flags);
-	}
+	dw_pin_config(port, pin, flags);
 
 	return 0;
 }

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -205,7 +205,7 @@ static inline u32_t dw_get_dir_port(u32_t base_addr)
 }
 
 static int gpio_dw_pin_interrupt_configure(struct device *port,
-		unsigned int pin, enum gpio_int_mode mode,
+		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
 	struct gpio_dw_runtime *context = port->driver_data;
@@ -302,7 +302,8 @@ static inline void dw_pin_config(struct device *port,
 }
 
 static inline int gpio_dw_config(struct device *port,
-				 u32_t pin, int flags)
+				 gpio_pin_t pin,
+				 gpio_flags_t flags)
 {
 	const struct gpio_dw_config *config = port->config->config_info;
 	u32_t io_flags;
@@ -419,7 +420,7 @@ static inline int gpio_dw_manage_callback(struct device *port,
 }
 
 static inline int gpio_dw_enable_callback(struct device *port,
-					  u32_t pin)
+					  gpio_pin_t pin)
 {
 	struct gpio_dw_runtime *context = port->driver_data;
 	u32_t base_addr = dw_base_to_block_base(context->base_addr);
@@ -436,7 +437,7 @@ static inline int gpio_dw_enable_callback(struct device *port,
 }
 
 static inline int gpio_dw_disable_callback(struct device *port,
-					   u32_t pin)
+					   gpio_pin_t pin)
 {
 	struct gpio_dw_runtime *context = port->driver_data;
 	u32_t base_addr = dw_base_to_block_base(context->base_addr);
@@ -537,7 +538,7 @@ static void gpio_dw_isr(void *arg)
 }
 
 static const struct gpio_driver_api api_funcs = {
-	.config = gpio_dw_config,
+	.pin_configure = gpio_dw_config,
 	.port_get_raw = gpio_dw_port_get_raw,
 	.port_set_masked_raw = gpio_dw_port_set_masked_raw,
 	.port_set_bits_raw = gpio_dw_port_set_bits_raw,

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -56,7 +56,8 @@ struct gpio_esp32_data {
 };
 
 static int gpio_esp32_config(struct device *dev,
-			     u32_t pin, int flags)
+			     gpio_pin_t pin,
+			     gpio_flags_t flags)
 {
 	struct gpio_esp32_data *data = dev->driver_data;
 	u32_t io_pin = pin + data->port.pin_offset; /* Range from 0 - 39 */
@@ -212,7 +213,7 @@ static int convert_int_type(enum gpio_int_mode mode,
 }
 
 static int gpio_esp32_pin_interrupt_configure(struct device *port,
-					      unsigned int pin,
+					      gpio_pin_t pin,
 					      enum gpio_int_mode mode,
 					      enum gpio_int_trig trig)
 {
@@ -258,7 +259,7 @@ static int gpio_esp32_manage_callback(struct device *dev,
 }
 
 static int gpio_esp32_enable_callback(struct device *dev,
-				      u32_t pin)
+				      gpio_pin_t pin)
 {
 	struct gpio_esp32_data *data = dev->driver_data;
 
@@ -268,7 +269,7 @@ static int gpio_esp32_enable_callback(struct device *dev,
 }
 
 static int gpio_esp32_disable_callback(struct device *dev,
-				       u32_t pin)
+				       gpio_pin_t pin)
 {
 	struct gpio_esp32_data *data = dev->driver_data;
 
@@ -318,7 +319,7 @@ static int gpio_esp32_init(struct device *device)
 }
 
 static const struct gpio_driver_api gpio_esp32_driver = {
-	.config = gpio_esp32_config,
+	.pin_configure = gpio_esp32_config,
 	.port_get_raw = gpio_esp32_port_get_raw,
 	.port_set_masked_raw = gpio_esp32_port_set_masked_raw,
 	.port_set_bits_raw = gpio_esp32_port_set_bits_raw,

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -55,7 +55,7 @@ struct gpio_esp32_data {
 	sys_slist_t cb;
 };
 
-static int gpio_esp32_config(struct device *dev, int access_op,
+static int gpio_esp32_config(struct device *dev,
 			     u32_t pin, int flags)
 {
 	struct gpio_esp32_data *data = dev->driver_data;
@@ -63,10 +63,6 @@ static int gpio_esp32_config(struct device *dev, int access_op,
 	u32_t *reg = GET_GPIO_PIN_REG(io_pin);
 	u32_t func;
 	int r;
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
 
 	/* Query pinmux to validate pin number. */
 	r = pinmux_pin_get(data->pinmux, io_pin, &func);

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -117,42 +117,6 @@ static int gpio_esp32_config(struct device *dev, int access_op,
 	return 0;
 }
 
-static int gpio_esp32_write(struct device *dev, int access_op,
-			    u32_t pin, u32_t value)
-{
-	struct gpio_esp32_data *data = dev->driver_data;
-	u32_t v;
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
-
-	v = BIT(pin - data->port.pin_offset);
-	if (value) {
-		*data->port.set_reg = v;
-	} else {
-		*data->port.clear_reg = v;
-	}
-
-	return 0;
-}
-
-static int gpio_esp32_read(struct device *dev, int access_op,
-			   u32_t pin, u32_t *value)
-{
-	struct gpio_esp32_data *data = dev->driver_data;
-	u32_t v;
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
-
-	v = *data->port.input_reg;
-	*value = !!(v & BIT(pin - data->port.pin_offset));
-
-	return 0;
-}
-
 static int gpio_esp32_port_get_raw(struct device *port, u32_t *value)
 {
 	struct gpio_esp32_data *data = port->driver_data;
@@ -359,8 +323,6 @@ static int gpio_esp32_init(struct device *device)
 
 static const struct gpio_driver_api gpio_esp32_driver = {
 	.config = gpio_esp32_config,
-	.write = gpio_esp32_write,
-	.read = gpio_esp32_read,
 	.port_get_raw = gpio_esp32_port_get_raw,
 	.port_set_masked_raw = gpio_esp32_port_set_masked_raw,
 	.port_set_bits_raw = gpio_esp32_port_set_bits_raw,

--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -145,51 +145,6 @@ static int gpio_gecko_configure(struct device *dev,
 	return 0;
 }
 
-static int gpio_gecko_write(struct device *dev,
-			    int access_op, u32_t pin, u32_t value)
-{
-	const struct gpio_gecko_config *config = dev->config->config_info;
-	GPIO_P_TypeDef *gpio_base = config->gpio_base;
-
-	if (access_op == GPIO_ACCESS_BY_PIN) {
-		if (value) {
-			/* Set the data output for the corresponding pin.
-			 * Writing zeros to the other bits leaves the data
-			 * output unchanged for the other pins.
-			 */
-			GPIO_PinOutSet(config->gpio_index, pin);
-		} else {
-			/* Clear the data output for the corresponding pin.
-			 * Writing zeros to the other bits leaves the data
-			 * output unchanged for the other pins.
-			 */
-			GPIO_PinOutClear(config->gpio_index, pin);
-		}
-	} else { /* GPIO_ACCESS_BY_PORT */
-		/* Write the data output for all the pins */
-		gpio_base->DOUT = value;
-	}
-
-	return 0;
-}
-
-static int gpio_gecko_read(struct device *dev,
-			   int access_op, u32_t pin, u32_t *value)
-{
-	const struct gpio_gecko_config *config = dev->config->config_info;
-	GPIO_P_TypeDef *gpio_base = config->gpio_base;
-
-	*value = gpio_base->DIN;
-
-	if (access_op == GPIO_ACCESS_BY_PIN) {
-		*value = (*value & BIT(pin)) >> pin;
-	}
-
-	/* nothing more to do for GPIO_ACCESS_BY_PORT */
-
-	return 0;
-}
-
 static int gpio_gecko_port_get_raw(struct device *dev, u32_t *value)
 {
 	const struct gpio_gecko_config *config = dev->config->config_info;
@@ -351,8 +306,6 @@ static void gpio_gecko_common_isr(void *arg)
 
 static const struct gpio_driver_api gpio_gecko_driver_api = {
 	.config = gpio_gecko_configure,
-	.write = gpio_gecko_write,
-	.read = gpio_gecko_read,
 	.port_get_raw = gpio_gecko_port_get_raw,
 	.port_set_masked_raw = gpio_gecko_port_set_masked_raw,
 	.port_set_bits_raw = gpio_gecko_port_set_bits_raw,

--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -71,7 +71,8 @@ static inline void gpio_gecko_add_port(struct gpio_gecko_common_data *data,
 }
 
 static int gpio_gecko_configure(struct device *dev,
-				u32_t pin, int flags)
+				gpio_pin_t pin,
+				gpio_flags_t flags)
 {
 	const struct gpio_gecko_config *config = dev->config->config_info;
 	GPIO_Port_TypeDef gpio_index = config->gpio_index;
@@ -182,7 +183,7 @@ static int gpio_gecko_port_toggle_bits(struct device *dev, u32_t mask)
 }
 
 static int gpio_gecko_pin_interrupt_configure(struct device *dev,
-		unsigned int pin, enum gpio_int_mode mode,
+		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
 	const struct gpio_gecko_config *config = dev->config->config_info;
@@ -233,7 +234,7 @@ static int gpio_gecko_manage_callback(struct device *dev,
 }
 
 static int gpio_gecko_enable_callback(struct device *dev,
-				      u32_t pin)
+				      gpio_pin_t pin)
 {
 	struct gpio_gecko_data *data = dev->driver_data;
 
@@ -244,7 +245,7 @@ static int gpio_gecko_enable_callback(struct device *dev,
 }
 
 static int gpio_gecko_disable_callback(struct device *dev,
-				       u32_t pin)
+				       gpio_pin_t pin)
 {
 	struct gpio_gecko_data *data = dev->driver_data;
 
@@ -282,7 +283,7 @@ static void gpio_gecko_common_isr(void *arg)
 
 
 static const struct gpio_driver_api gpio_gecko_driver_api = {
-	.config = gpio_gecko_configure,
+	.pin_configure = gpio_gecko_configure,
 	.port_get_raw = gpio_gecko_port_get_raw,
 	.port_set_masked_raw = gpio_gecko_port_set_masked_raw,
 	.port_set_bits_raw = gpio_gecko_port_set_bits_raw,

--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -71,18 +71,12 @@ static inline void gpio_gecko_add_port(struct gpio_gecko_common_data *data,
 }
 
 static int gpio_gecko_configure(struct device *dev,
-				int access_op, u32_t pin, int flags)
+				u32_t pin, int flags)
 {
 	const struct gpio_gecko_config *config = dev->config->config_info;
-	GPIO_P_TypeDef *gpio_base = config->gpio_base;
 	GPIO_Port_TypeDef gpio_index = config->gpio_index;
 	GPIO_Mode_TypeDef mode;
 	unsigned int out = 0U;
-
-	/* Setting interrupt flags for a complete port is not implemented */
-	if ((flags & GPIO_INT_ENABLE) && (access_op == GPIO_ACCESS_BY_PORT)) {
-		return -ENOTSUP;
-	}
 
 	if (flags & GPIO_OUTPUT) {
 		/* Following modes enable both output and input */
@@ -123,24 +117,7 @@ static int gpio_gecko_configure(struct device *dev,
 	 * 0 - pin is input, 1 - pin is output
 	 */
 
-	if (access_op == GPIO_ACCESS_BY_PIN) {
-		GPIO_PinModeSet(gpio_index, pin, mode, out);
-	} else {	/* GPIO_ACCESS_BY_PORT */
-		gpio_base->MODEL = GECKO_GPIO_MODEL(7, mode)
-			| GECKO_GPIO_MODEL(6, mode) | GECKO_GPIO_MODEL(5, mode)
-			| GECKO_GPIO_MODEL(4, mode) | GECKO_GPIO_MODEL(3, mode)
-			| GECKO_GPIO_MODEL(2, mode) | GECKO_GPIO_MODEL(1, mode)
-			| GECKO_GPIO_MODEL(0, mode);
-		gpio_base->MODEH = GECKO_GPIO_MODEH(15, mode)
-			| GECKO_GPIO_MODEH(14, mode)
-			| GECKO_GPIO_MODEH(13, mode)
-			| GECKO_GPIO_MODEH(12, mode)
-			| GECKO_GPIO_MODEH(11, mode)
-			| GECKO_GPIO_MODEH(10, mode)
-			| GECKO_GPIO_MODEH(9, mode)
-			| GECKO_GPIO_MODEH(8, mode);
-		gpio_base->DOUT = (out ? 0xFFFF : 0x0000);
-	}
+	GPIO_PinModeSet(gpio_index, pin, mode, out);
 
 	return 0;
 }

--- a/drivers/gpio/gpio_handlers.c
+++ b/drivers/gpio/gpio_handlers.c
@@ -7,11 +7,11 @@
 #include <drivers/gpio.h>
 #include <syscall_handler.h>
 
-static inline int z_vrfy_gpio_config(struct device *port, int access_op,
+static inline int z_vrfy_gpio_config(struct device *port,
 				    u32_t pin, gpio_flags_t flags)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_GPIO(port, config));
-	return z_impl_gpio_config((struct device *)port, access_op, pin, flags);
+	return z_impl_gpio_config((struct device *)port, pin, flags);
 }
 #include <syscalls/gpio_config_mrsh.c>
 

--- a/drivers/gpio/gpio_handlers.c
+++ b/drivers/gpio/gpio_handlers.c
@@ -10,7 +10,7 @@
 static inline int z_vrfy_gpio_config(struct device *port,
 				     gpio_pin_t pin, gpio_flags_t flags)
 {
-	Z_OOPS(Z_SYSCALL_DRIVER_GPIO(port, config));
+	Z_OOPS(Z_SYSCALL_DRIVER_GPIO(port, pin_configure));
 	return z_impl_gpio_config((struct device *)port, pin, flags);
 }
 #include <syscalls/gpio_config_mrsh.c>
@@ -69,14 +69,14 @@ static inline int z_vrfy_gpio_pin_interrupt_configure(struct device *port,
 #include <syscalls/gpio_pin_interrupt_configure_mrsh.c>
 
 static inline int z_vrfy_gpio_enable_callback(struct device *port,
-					     u32_t pin)
+					     gpio_pin_t pin)
 {
 	return z_impl_gpio_enable_callback((struct device *)port, pin);
 }
 #include <syscalls/gpio_enable_callback_mrsh.c>
 
 static inline int z_vrfy_gpio_disable_callback(struct device *port,
-					      u32_t pin)
+					      gpio_pin_t pin)
 {
 	return z_impl_gpio_disable_callback((struct device *)port, pin);
 }

--- a/drivers/gpio/gpio_handlers.c
+++ b/drivers/gpio/gpio_handlers.c
@@ -8,7 +8,7 @@
 #include <syscall_handler.h>
 
 static inline int z_vrfy_gpio_config(struct device *port,
-				    u32_t pin, gpio_flags_t flags)
+				     gpio_pin_t pin, gpio_flags_t flags)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_GPIO(port, config));
 	return z_impl_gpio_config((struct device *)port, pin, flags);
@@ -59,7 +59,8 @@ static inline int z_vrfy_gpio_port_toggle_bits(struct device *port,
 #include <syscalls/gpio_port_toggle_bits_mrsh.c>
 
 static inline int z_vrfy_gpio_pin_interrupt_configure(struct device *port,
-		unsigned int pin, unsigned int flags)
+						      gpio_pin_t pin,
+						      gpio_flags_t flags)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_GPIO(port, pin_interrupt_configure));
 	return z_impl_gpio_pin_interrupt_configure((struct device *)port, pin,

--- a/drivers/gpio/gpio_ht16k33.c
+++ b/drivers/gpio/gpio_ht16k33.c
@@ -53,30 +53,6 @@ static int gpio_ht16k33_cfg(struct device *dev, int access_op,
 	return 0;
 }
 
-static int gpio_ht16k33_write(struct device *dev, int access_op,
-			      u32_t pin, u32_t value)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(access_op);
-	ARG_UNUSED(pin);
-	ARG_UNUSED(value);
-
-	/* Keyscan is input-only */
-	return -ENOTSUP;
-}
-
-static int gpio_ht16k33_read(struct device *dev, int access_op,
-			     u32_t pin, u32_t *value)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(access_op);
-	ARG_UNUSED(pin);
-	ARG_UNUSED(value);
-
-	/* Keyscan only supports interrupt mode */
-	return -ENOTSUP;
-}
-
 static int gpio_ht16k33_port_get_raw(struct device *port,
 				     gpio_port_value_t *value)
 {
@@ -206,8 +182,6 @@ static int gpio_ht16k33_init(struct device *dev)
 
 static const struct gpio_driver_api gpio_ht16k33_api = {
 	.config = gpio_ht16k33_cfg,
-	.write = gpio_ht16k33_write,
-	.read = gpio_ht16k33_read,
 	.port_get_raw = gpio_ht16k33_port_get_raw,
 	.port_set_masked_raw = gpio_ht16k33_port_set_masked_raw,
 	.port_set_bits_raw = gpio_ht16k33_port_set_bits_raw,

--- a/drivers/gpio/gpio_ht16k33.c
+++ b/drivers/gpio/gpio_ht16k33.c
@@ -37,11 +37,10 @@ struct gpio_ht16k33_data {
 	sys_slist_t callbacks;
 };
 
-static int gpio_ht16k33_cfg(struct device *dev, int access_op,
+static int gpio_ht16k33_cfg(struct device *dev,
 			    u32_t pin, int flags)
 {
 	ARG_UNUSED(dev);
-	ARG_UNUSED(access_op);
 	ARG_UNUSED(pin);
 
 	/* Keyscan is input-only */

--- a/drivers/gpio/gpio_ht16k33.c
+++ b/drivers/gpio/gpio_ht16k33.c
@@ -38,7 +38,8 @@ struct gpio_ht16k33_data {
 };
 
 static int gpio_ht16k33_cfg(struct device *dev,
-			    u32_t pin, int flags)
+			    gpio_pin_t pin,
+			    gpio_flags_t flags)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(pin);
@@ -105,7 +106,7 @@ static int gpio_ht16k33_port_toggle_bits(struct device *port,
 }
 
 static int gpio_ht16k33_pin_interrupt_configure(struct device *port,
-						unsigned int pin,
+						gpio_pin_t pin,
 						enum gpio_int_mode int_mode,
 						enum gpio_int_trig int_trig)
 {
@@ -136,14 +137,14 @@ static int gpio_ht16k33_manage_callback(struct device *dev,
 }
 
 static int gpio_ht16k33_enable_callback(struct device *dev,
-					u32_t pin)
+					gpio_pin_t pin)
 {
 	/* All callbacks are always enabled */
 	return 0;
 }
 
 static int gpio_ht16k33_disable_callback(struct device *dev,
-					u32_t pin)
+					gpio_pin_t pin)
 {
 	/* Individual callbacks can not be disabled */
 	return -ENOTSUP;
@@ -180,7 +181,7 @@ static int gpio_ht16k33_init(struct device *dev)
 }
 
 static const struct gpio_driver_api gpio_ht16k33_api = {
-	.config = gpio_ht16k33_cfg,
+	.pin_configure = gpio_ht16k33_cfg,
 	.port_get_raw = gpio_ht16k33_port_get_raw,
 	.port_set_masked_raw = gpio_ht16k33_port_set_masked_raw,
 	.port_set_bits_raw = gpio_ht16k33_port_set_bits_raw,

--- a/drivers/gpio/gpio_imx.c
+++ b/drivers/gpio/gpio_imx.c
@@ -28,15 +28,11 @@ struct imx_gpio_data {
 	u32_t pin_callback_enables;
 };
 
-static int imx_gpio_configure(struct device *port, int access_op, u32_t pin,
+static int imx_gpio_configure(struct device *port, u32_t pin,
 			      int flags)
 {
 	const struct imx_gpio_config *config = port->config->config_info;
 	GPIO_Type *base = config->base;
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
 
 	if (((flags & GPIO_INPUT) != 0U) && ((flags & GPIO_OUTPUT) != 0U)) {
 		return -ENOTSUP;

--- a/drivers/gpio/gpio_imx.c
+++ b/drivers/gpio/gpio_imx.c
@@ -28,8 +28,8 @@ struct imx_gpio_data {
 	u32_t pin_callback_enables;
 };
 
-static int imx_gpio_configure(struct device *port, u32_t pin,
-			      int flags)
+static int imx_gpio_configure(struct device *port, gpio_pin_t pin,
+			      gpio_flags_t flags)
 {
 	const struct imx_gpio_config *config = port->config->config_info;
 	GPIO_Type *base = config->base;
@@ -122,7 +122,7 @@ static int imx_gpio_port_toggle_bits(struct device *port, gpio_port_pins_t pins)
 }
 
 static int imx_gpio_pin_interrupt_configure(struct device *port,
-					    unsigned int pin,
+					    gpio_pin_t pin,
 					    enum gpio_int_mode mode,
 					    enum gpio_int_trig trig)
 {
@@ -186,7 +186,7 @@ static int imx_gpio_manage_callback(struct device *port,
 }
 
 static int imx_gpio_enable_callback(struct device *port,
-				    u32_t pin)
+				    gpio_pin_t pin)
 {
 	const struct imx_gpio_config *config = port->config->config_info;
 	struct imx_gpio_data *data = port->driver_data;
@@ -198,7 +198,7 @@ static int imx_gpio_enable_callback(struct device *port,
 }
 
 static int imx_gpio_disable_callback(struct device *port,
-				     u32_t pin)
+				     gpio_pin_t pin)
 {
 	const struct imx_gpio_config *config = port->config->config_info;
 	struct imx_gpio_data *data = port->driver_data;
@@ -223,7 +223,7 @@ static void imx_gpio_port_isr(void *arg)
 }
 
 static const struct gpio_driver_api imx_gpio_driver_api = {
-	.config = imx_gpio_configure,
+	.pin_configure = imx_gpio_configure,
 	.port_get_raw = imx_gpio_port_get_raw,
 	.port_set_masked_raw = imx_gpio_port_set_masked_raw,
 	.port_set_bits_raw = imx_gpio_port_set_bits_raw,

--- a/drivers/gpio/gpio_imx.c
+++ b/drivers/gpio/gpio_imx.c
@@ -70,35 +70,6 @@ static int imx_gpio_configure(struct device *port, int access_op, u32_t pin,
 	return 0;
 }
 
-static int imx_gpio_write(struct device *port,
-			  int access_op, u32_t pin, u32_t value)
-{
-	const struct imx_gpio_config *config = port->config->config_info;
-
-	if (access_op == GPIO_ACCESS_BY_PIN) {
-		GPIO_WritePinOutput(config->base, pin,
-					(gpio_pin_action_t)value);
-	} else { /* GPIO_ACCESS_BY_PORT */
-		GPIO_WritePortOutput(config->base, value);
-	}
-
-	return 0;
-}
-
-static int imx_gpio_read(struct device *port,
-			 int access_op, u32_t pin, u32_t *value)
-{
-	const struct imx_gpio_config *config = port->config->config_info;
-
-	if (access_op == GPIO_ACCESS_BY_PIN) {
-		*value = GPIO_ReadPinInput(config->base, pin);
-	} else { /* GPIO_ACCESS_BY_PORT */
-		*value = GPIO_ReadPortInput(config->base);
-	}
-
-	return 0;
-}
-
 static int imx_gpio_port_get_raw(struct device *port, u32_t *value)
 {
 	const struct imx_gpio_config *config = port->config->config_info;
@@ -257,8 +228,6 @@ static void imx_gpio_port_isr(void *arg)
 
 static const struct gpio_driver_api imx_gpio_driver_api = {
 	.config = imx_gpio_configure,
-	.write = imx_gpio_write,
-	.read = imx_gpio_read,
 	.port_get_raw = imx_gpio_port_get_raw,
 	.port_set_masked_raw = imx_gpio_port_set_masked_raw,
 	.port_set_bits_raw = imx_gpio_port_set_bits_raw,

--- a/drivers/gpio/gpio_intel_apl.c
+++ b/drivers/gpio/gpio_intel_apl.c
@@ -363,66 +363,6 @@ static int gpio_intel_apl_pin_interrupt_configure(struct device *dev,
 	return 0;
 }
 
-static int gpio_intel_apl_write(struct device *dev, int access_op,
-				u32_t pin, u32_t value)
-{
-	const struct gpio_intel_apl_config *cfg = dev->config->config_info;
-	struct gpio_intel_apl_data *data = dev->driver_data;
-	u32_t raw_pin, reg, val;
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
-
-	pin = k_array_index_sanitize(pin, cfg->num_pins + 1);
-
-	raw_pin = cfg->pin_offset + pin;
-
-	if (!check_perm(dev, raw_pin)) {
-		return -EINVAL;
-	}
-
-	reg = cfg->reg_base + data->pad_base + (raw_pin * 8U);
-	val = sys_read32(reg);
-
-	if (value) {
-		val |= PAD_CFG0_TXSTATE;
-	} else {
-		val &= ~PAD_CFG0_TXSTATE;
-	}
-
-	sys_write32(val, reg);
-
-	return 0;
-}
-
-static int gpio_intel_apl_read(struct device *dev, int access_op,
-			       u32_t pin, u32_t *value)
-{
-	const struct gpio_intel_apl_config *cfg = dev->config->config_info;
-	struct gpio_intel_apl_data *data = dev->driver_data;
-	u32_t raw_pin, reg, val;
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
-
-	pin = k_array_index_sanitize(pin, cfg->num_pins + 1);
-
-	raw_pin = cfg->pin_offset + pin;
-
-	if (!check_perm(dev, raw_pin)) {
-		return -EINVAL;
-	}
-
-	reg = cfg->reg_base + data->pad_base + (raw_pin * 8U);
-	val = sys_read32(reg);
-
-	*value = (val & PAD_CFG0_RXSTATE) >> PAD_CFG0_RXSTATE_POS;
-
-	return 0;
-}
-
 static int gpio_intel_apl_manage_callback(struct device *dev,
 					  struct gpio_callback *callback,
 					  bool set)
@@ -598,8 +538,6 @@ static int gpio_intel_apl_port_get_raw(struct device *dev, u32_t *value)
 
 static const struct gpio_driver_api gpio_intel_apl_api = {
 	.config = gpio_intel_apl_config,
-	.write = gpio_intel_apl_write,
-	.read = gpio_intel_apl_read,
 	.manage_callback = gpio_intel_apl_manage_callback,
 	.enable_callback = gpio_intel_apl_enable_callback,
 	.disable_callback = gpio_intel_apl_disable_callback,

--- a/drivers/gpio/gpio_intel_apl.c
+++ b/drivers/gpio/gpio_intel_apl.c
@@ -206,7 +206,7 @@ static int gpio_intel_apl_isr(struct device *dev)
 }
 
 static int gpio_intel_apl_config(struct device *dev,
-				 u32_t pin, int flags)
+				 gpio_pin_t pin, gpio_flags_t flags)
 {
 	const struct gpio_intel_apl_config *cfg = dev->config->config_info;
 	struct gpio_intel_apl_data *data = dev->driver_data;
@@ -280,7 +280,7 @@ static int gpio_intel_apl_config(struct device *dev,
 }
 
 static int gpio_intel_apl_pin_interrupt_configure(struct device *dev,
-		unsigned int pin, enum gpio_int_mode mode,
+		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
 	const struct gpio_intel_apl_config *cfg = dev->config->config_info;
@@ -369,7 +369,7 @@ static int gpio_intel_apl_manage_callback(struct device *dev,
 }
 
 static int gpio_intel_apl_enable_callback(struct device *dev,
-					  u32_t pin)
+					  gpio_pin_t pin)
 {
 	const struct gpio_intel_apl_config *cfg = dev->config->config_info;
 	u32_t raw_pin, reg;
@@ -394,7 +394,7 @@ static int gpio_intel_apl_enable_callback(struct device *dev,
 }
 
 static int gpio_intel_apl_disable_callback(struct device *dev,
-					   u32_t pin)
+					   gpio_pin_t pin)
 {
 	const struct gpio_intel_apl_config *cfg = dev->config->config_info;
 	u32_t raw_pin, reg;
@@ -533,7 +533,7 @@ static int gpio_intel_apl_port_get_raw(struct device *dev, u32_t *value)
 }
 
 static const struct gpio_driver_api gpio_intel_apl_api = {
-	.config = gpio_intel_apl_config,
+	.pin_configure = gpio_intel_apl_config,
 	.manage_callback = gpio_intel_apl_manage_callback,
 	.enable_callback = gpio_intel_apl_enable_callback,
 	.disable_callback = gpio_intel_apl_disable_callback,

--- a/drivers/gpio/gpio_intel_apl.c
+++ b/drivers/gpio/gpio_intel_apl.c
@@ -205,16 +205,12 @@ static int gpio_intel_apl_isr(struct device *dev)
 	return 0;
 }
 
-static int gpio_intel_apl_config(struct device *dev, int access_op,
+static int gpio_intel_apl_config(struct device *dev,
 				 u32_t pin, int flags)
 {
 	const struct gpio_intel_apl_config *cfg = dev->config->config_info;
 	struct gpio_intel_apl_data *data = dev->driver_data;
 	u32_t raw_pin, reg, cfg0, cfg1;
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
 
 	/* Only support push-pull mode */
 	if ((flags & GPIO_SINGLE_ENDED) != 0U) {

--- a/drivers/gpio/gpio_litex.c
+++ b/drivers/gpio/gpio_litex.c
@@ -24,8 +24,6 @@ LOG_MODULE_REGISTER(gpio_litex);
 
 static const char *LITEX_LOG_REG_SIZE_NGPIOS_MISMATCH =
 	"Cannot handle all of the gpios with the register of given size\n";
-static const char *LITEX_LOG_WRONG_DIR =
-	"Direction chosen in device tree do not match with the operation\n";
 static const char *LITEX_LOG_CANNOT_CHANGE_DIR =
 	"Cannot change port direction selected in device tree\n";
 
@@ -133,39 +131,6 @@ static int gpio_litex_configure(struct device *dev, int access_op,
 	return 0;
 }
 
-static int gpio_litex_write(struct device *dev, int access_op,
-			    u32_t pin, u32_t value)
-{
-	const struct gpio_litex_cfg *gpio_config = DEV_GPIO_CFG(dev);
-
-	if (!gpio_config->port_is_output) {
-		LOG_ERR("%s", LITEX_LOG_WRONG_DIR);
-		return -EINVAL;
-	}
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
-
-	set_bit(gpio_config, pin, value);
-
-	return 0;
-}
-
-static int gpio_litex_read(struct device *dev, int access_op,
-			   u32_t pin, u32_t *value)
-{
-	const struct gpio_litex_cfg *gpio_config = DEV_GPIO_CFG(dev);
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
-
-	*value = get_bit(gpio_config, pin);
-
-	return 0;
-}
-
 static int gpio_litex_port_get_raw(struct device *dev, gpio_port_value_t *value)
 {
 	const struct gpio_litex_cfg *gpio_config = DEV_GPIO_CFG(dev);
@@ -242,8 +207,6 @@ static int gpio_litex_pin_interrupt_configure(struct device *dev,
 
 static const struct gpio_driver_api gpio_litex_driver_api = {
 	.config = gpio_litex_configure,
-	.write = gpio_litex_write,
-	.read = gpio_litex_read,
 	.port_get_raw = gpio_litex_port_get_raw,
 	.port_set_masked_raw = gpio_litex_port_set_masked_raw,
 	.port_set_bits_raw = gpio_litex_port_set_bits_raw,

--- a/drivers/gpio/gpio_litex.c
+++ b/drivers/gpio/gpio_litex.c
@@ -90,7 +90,7 @@ static int gpio_litex_init(struct device *dev)
 }
 
 static int gpio_litex_configure(struct device *dev,
-				u32_t pin, int flags)
+				gpio_pin_t pin, gpio_flags_t flags)
 {
 	const struct gpio_litex_cfg *gpio_config = DEV_GPIO_CFG(dev);
 
@@ -189,7 +189,7 @@ static int gpio_litex_port_toggle_bits(struct device *dev,
 }
 
 static int gpio_litex_pin_interrupt_configure(struct device *dev,
-				   unsigned int pin,
+				   gpio_pin_t pin,
 				   enum gpio_int_mode mode,
 				   enum gpio_int_trig trig)
 {
@@ -202,7 +202,7 @@ static int gpio_litex_pin_interrupt_configure(struct device *dev,
 }
 
 static const struct gpio_driver_api gpio_litex_driver_api = {
-	.config = gpio_litex_configure,
+	.pin_configure = gpio_litex_configure,
 	.port_get_raw = gpio_litex_port_get_raw,
 	.port_set_masked_raw = gpio_litex_port_set_masked_raw,
 	.port_set_bits_raw = gpio_litex_port_set_bits_raw,

--- a/drivers/gpio/gpio_litex.c
+++ b/drivers/gpio/gpio_litex.c
@@ -89,14 +89,10 @@ static int gpio_litex_init(struct device *dev)
 	return 0;
 }
 
-static int gpio_litex_configure(struct device *dev, int access_op,
+static int gpio_litex_configure(struct device *dev,
 				u32_t pin, int flags)
 {
 	const struct gpio_litex_cfg *gpio_config = DEV_GPIO_CFG(dev);
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
 
 	if (flags & ~SUPPORTED_FLAGS) {
 		return -ENOTSUP;

--- a/drivers/gpio/gpio_lmp90xxx.c
+++ b/drivers/gpio/gpio_lmp90xxx.c
@@ -33,7 +33,7 @@ struct gpio_lmp90xxx_data {
 };
 
 static int gpio_lmp90xxx_config(struct device *dev,
-				u32_t pin, int flags)
+				gpio_pin_t pin, gpio_flags_t flags)
 {
 	struct gpio_lmp90xxx_data *data = dev->driver_data;
 	int err = 0;
@@ -122,7 +122,7 @@ static int gpio_lmp90xxx_port_toggle_bits(struct device *dev,
 }
 
 static int gpio_lmp90xxx_pin_interrupt_configure(struct device *dev,
-						 unsigned int pin,
+						 gpio_pin_t pin,
 						 enum gpio_int_mode mode,
 						 enum gpio_int_trig trig)
 {
@@ -150,7 +150,7 @@ static int gpio_lmp90xxx_init(struct device *dev)
 }
 
 static const struct gpio_driver_api gpio_lmp90xxx_api = {
-	.config = gpio_lmp90xxx_config,
+	.pin_configure = gpio_lmp90xxx_config,
 	.port_set_masked_raw = gpio_lmp90xxx_port_set_masked_raw,
 	.port_set_bits_raw = gpio_lmp90xxx_port_set_bits_raw,
 	.port_clear_bits_raw = gpio_lmp90xxx_port_clear_bits_raw,

--- a/drivers/gpio/gpio_lmp90xxx.c
+++ b/drivers/gpio/gpio_lmp90xxx.c
@@ -32,15 +32,11 @@ struct gpio_lmp90xxx_data {
 	struct device *parent;
 };
 
-static int gpio_lmp90xxx_config(struct device *dev, int access_op,
+static int gpio_lmp90xxx_config(struct device *dev,
 				u32_t pin, int flags)
 {
 	struct gpio_lmp90xxx_data *data = dev->driver_data;
 	int err = 0;
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
 
 	if (pin > LMP90XXX_GPIO_MAX) {
 		return -EINVAL;

--- a/drivers/gpio/gpio_lmp90xxx.c
+++ b/drivers/gpio/gpio_lmp90xxx.c
@@ -84,46 +84,6 @@ static int gpio_lmp90xxx_config(struct device *dev, int access_op,
 	return err;
 }
 
-static int gpio_lmp90xxx_write(struct device *dev, int access_op,
-			       u32_t pin, u32_t value)
-{
-	struct gpio_lmp90xxx_data *data = dev->driver_data;
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
-
-	if (pin > LMP90XXX_GPIO_MAX) {
-		return -EINVAL;
-	}
-
-	return lmp90xxx_gpio_set_pin_value(data->parent, pin,
-					   value ? true : false);
-}
-
-static int gpio_lmp90xxx_read(struct device *dev, int access_op,
-			      u32_t pin, u32_t *value)
-{
-	struct gpio_lmp90xxx_data *data = dev->driver_data;
-	bool set;
-	int err;
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
-
-	if (pin > LMP90XXX_GPIO_MAX) {
-		return -EINVAL;
-	}
-
-	err = lmp90xxx_gpio_get_pin_value(data->parent, pin, &set);
-	if (!err) {
-		*value = set ? 1 : 0;
-	}
-
-	return err;
-}
-
 static int gpio_lmp90xxx_port_get_raw(struct device *dev,
 				      gpio_port_value_t *value)
 {
@@ -195,8 +155,6 @@ static int gpio_lmp90xxx_init(struct device *dev)
 
 static const struct gpio_driver_api gpio_lmp90xxx_api = {
 	.config = gpio_lmp90xxx_config,
-	.write = gpio_lmp90xxx_write,
-	.read = gpio_lmp90xxx_read,
 	.port_set_masked_raw = gpio_lmp90xxx_port_set_masked_raw,
 	.port_set_bits_raw = gpio_lmp90xxx_port_set_bits_raw,
 	.port_clear_bits_raw = gpio_lmp90xxx_port_clear_bits_raw,

--- a/drivers/gpio/gpio_mchp_xec.c
+++ b/drivers/gpio/gpio_mchp_xec.c
@@ -45,7 +45,7 @@ struct gpio_xec_config {
 };
 
 static int gpio_xec_configure(struct device *dev,
-			      u32_t pin, int flags)
+			      gpio_pin_t pin, gpio_flags_t flags)
 {
 	const struct gpio_xec_config *config = dev->config->config_info;
 	__IO u32_t *current_pcr1;
@@ -124,7 +124,7 @@ static int gpio_xec_configure(struct device *dev,
 }
 
 static int gpio_xec_pin_interrupt_configure(struct device *dev,
-		unsigned int pin, enum gpio_int_mode mode,
+		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
 	const struct gpio_xec_config *config = dev->config->config_info;
@@ -277,7 +277,7 @@ static int gpio_xec_manage_callback(struct device *dev,
 }
 
 static int gpio_xec_enable_callback(struct device *dev,
-				    u32_t pin)
+				    gpio_pin_t pin)
 {
 	struct gpio_xec_data *data = dev->driver_data;
 
@@ -287,7 +287,7 @@ static int gpio_xec_enable_callback(struct device *dev,
 }
 
 static int gpio_xec_disable_callback(struct device *dev,
-				     u32_t pin)
+				     gpio_pin_t pin)
 {
 	struct gpio_xec_data *data = dev->driver_data;
 
@@ -317,7 +317,7 @@ static void gpio_gpio_xec_port_isr(void *arg)
 }
 
 static const struct gpio_driver_api gpio_xec_driver_api = {
-	.config = gpio_xec_configure,
+	.pin_configure = gpio_xec_configure,
 	.port_get_raw = gpio_xec_port_get_raw,
 	.port_set_masked_raw = gpio_xec_port_set_masked_raw,
 	.port_set_bits_raw = gpio_xec_port_set_bits_raw,

--- a/drivers/gpio/gpio_mchp_xec.c
+++ b/drivers/gpio/gpio_mchp_xec.c
@@ -45,7 +45,7 @@ struct gpio_xec_config {
 };
 
 static int gpio_xec_configure(struct device *dev,
-			      int access_op, u32_t pin, int flags)
+			      u32_t pin, int flags)
 {
 	const struct gpio_xec_config *config = dev->config->config_info;
 	__IO u32_t *current_pcr1;
@@ -72,20 +72,16 @@ static int gpio_xec_configure(struct device *dev,
 	 */
 	mask |= MCHP_GPIO_CTRL_DIR_MASK;
 	mask |= MCHP_GPIO_CTRL_INPAD_DIS_MASK;
-	if (access_op == GPIO_ACCESS_BY_PIN) {
-		if ((flags & GPIO_OUTPUT) != 0U) {
-			if ((flags & GPIO_OUTPUT_INIT_HIGH) != 0U) {
-				*gpio_out_reg |= BIT(pin);
-			} else if ((flags & GPIO_OUTPUT_INIT_LOW) != 0U) {
-				*gpio_out_reg &= ~BIT(pin);
-			}
-			pcr1 |= MCHP_GPIO_CTRL_DIR_OUTPUT;
-		} else {
-			/* GPIO_INPUT */
-			pcr1 |= MCHP_GPIO_CTRL_DIR_INPUT;
+	if ((flags & GPIO_OUTPUT) != 0U) {
+		if ((flags & GPIO_OUTPUT_INIT_HIGH) != 0U) {
+			*gpio_out_reg |= BIT(pin);
+		} else if ((flags & GPIO_OUTPUT_INIT_LOW) != 0U) {
+			*gpio_out_reg &= ~BIT(pin);
 		}
-	} else { /* GPIO_ACCESS_BY_PORT is not supported */
-		return -ENOTSUP;
+		pcr1 |= MCHP_GPIO_CTRL_DIR_OUTPUT;
+	} else {
+		/* GPIO_INPUT */
+		pcr1 |= MCHP_GPIO_CTRL_DIR_INPUT;
 	}
 
 	/* Figure out the pullup/pulldown configuration and keep it in the

--- a/drivers/gpio/gpio_mchp_xec.c
+++ b/drivers/gpio/gpio_mchp_xec.c
@@ -209,36 +209,6 @@ static int gpio_xec_pin_interrupt_configure(struct device *dev,
 	return 0;
 }
 
-static int gpio_xec_write(struct device *dev,
-			  int access_op, u32_t pin, u32_t value)
-{
-	const struct gpio_xec_config *config = dev->config->config_info;
-
-	/* GPIO output registers are used for writing */
-	__IO u32_t *gpio_base = GPIO_OUT_BASE(config);
-
-	if (access_op == GPIO_ACCESS_BY_PIN) {
-		if (value) {
-			/* Set the data output for the corresponding pin.
-			 * Writing zeros to the other bits leaves the data
-			 * output unchanged for the other pins
-			 */
-			*gpio_base |= BIT(pin);
-		} else {
-			/* Clear the data output for the corresponding pin.
-			 * Writing zeros to the other bits leaves the data
-			 * output unchanged for the other pins
-			 */
-			*gpio_base &= ~BIT(pin);
-		}
-	} else { /* GPIO_ACCESS_BY_PORT not supported */
-		return -EINVAL;
-	}
-
-	return 0;
-
-}
-
 static int gpio_xec_port_set_masked_raw(struct device *dev, u32_t mask,
 					u32_t value)
 {
@@ -300,18 +270,6 @@ static int gpio_xec_port_get_raw(struct device *dev, u32_t *value)
 	return 0;
 }
 
-static int gpio_xec_read(struct device *dev,
-			 int access_op, u32_t pin, u32_t *value)
-{
-	gpio_xec_port_get_raw(dev, value);
-
-	if (access_op == GPIO_ACCESS_BY_PIN) {
-		*value = (*value & BIT(pin)) >> pin;
-	}
-
-	return 0;
-}
-
 static int gpio_xec_manage_callback(struct device *dev,
 				    struct gpio_callback *callback, bool set)
 {
@@ -364,8 +322,6 @@ static void gpio_gpio_xec_port_isr(void *arg)
 
 static const struct gpio_driver_api gpio_xec_driver_api = {
 	.config = gpio_xec_configure,
-	.write = gpio_xec_write,
-	.read = gpio_xec_read,
 	.port_get_raw = gpio_xec_port_get_raw,
 	.port_set_masked_raw = gpio_xec_port_set_masked_raw,
 	.port_set_bits_raw = gpio_xec_port_set_bits_raw,

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -116,51 +116,6 @@ static int gpio_mcux_configure(struct device *dev,
 	return 0;
 }
 
-static int gpio_mcux_write(struct device *dev,
-			   int access_op, u32_t pin, u32_t value)
-{
-	const struct gpio_mcux_config *config = dev->config->config_info;
-	GPIO_Type *gpio_base = config->gpio_base;
-
-	if (access_op == GPIO_ACCESS_BY_PIN) {
-		if (value) {
-			/* Set the data output for the corresponding pin.
-			 * Writing zeros to the other bits leaves the data
-			 * output unchanged for the other pins.
-			 */
-			gpio_base->PSOR = BIT(pin);
-		} else {
-			/* Clear the data output for the corresponding pin.
-			 * Writing zeros to the other bits leaves the data
-			 * output unchanged for the other pins.
-			 */
-			gpio_base->PCOR = BIT(pin);
-		}
-	} else { /* GPIO_ACCESS_BY_PORT */
-		/* Write the data output for all the pins */
-		gpio_base->PDOR = value;
-	}
-
-	return 0;
-}
-
-static int gpio_mcux_read(struct device *dev,
-			  int access_op, u32_t pin, u32_t *value)
-{
-	const struct gpio_mcux_config *config = dev->config->config_info;
-	GPIO_Type *gpio_base = config->gpio_base;
-
-	*value = gpio_base->PDIR;
-
-	if (access_op == GPIO_ACCESS_BY_PIN) {
-		*value = (*value & BIT(pin)) >> pin;
-	}
-
-	/* nothing more to do for GPIO_ACCESS_BY_PORT */
-
-	return 0;
-}
-
 static int gpio_mcux_port_get_raw(struct device *dev, u32_t *value)
 {
 	const struct gpio_mcux_config *config = dev->config->config_info;
@@ -327,8 +282,6 @@ static void gpio_mcux_port_isr(void *arg)
 
 static const struct gpio_driver_api gpio_mcux_driver_api = {
 	.config = gpio_mcux_configure,
-	.write = gpio_mcux_write,
-	.read = gpio_mcux_read,
 	.port_get_raw = gpio_mcux_port_get_raw,
 	.port_set_masked_raw = gpio_mcux_port_set_masked_raw,
 	.port_set_bits_raw = gpio_mcux_port_set_bits_raw,

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -32,7 +32,7 @@ struct gpio_mcux_data {
 };
 
 static int gpio_mcux_configure(struct device *dev,
-			       u32_t pin, int flags)
+			       gpio_pin_t pin, gpio_flags_t flags)
 {
 	const struct gpio_mcux_config *config = dev->config->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
@@ -183,8 +183,8 @@ static u32_t get_port_pcr_irqc_value_from_flags(struct device *dev,
 }
 
 static int gpio_mcux_pin_interrupt_configure(struct device *dev,
-		unsigned int pin, enum gpio_int_mode mode,
-		enum gpio_int_trig trig)
+					     gpio_pin_t pin, enum gpio_int_mode mode,
+					     enum gpio_int_trig trig)
 {
 	const struct gpio_mcux_config *config = dev->config->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
@@ -226,7 +226,7 @@ static int gpio_mcux_manage_callback(struct device *dev,
 }
 
 static int gpio_mcux_enable_callback(struct device *dev,
-				     u32_t pin)
+				     gpio_pin_t pin)
 {
 	struct gpio_mcux_data *data = dev->driver_data;
 
@@ -236,7 +236,7 @@ static int gpio_mcux_enable_callback(struct device *dev,
 }
 
 static int gpio_mcux_disable_callback(struct device *dev,
-				      u32_t pin)
+				      gpio_pin_t pin)
 {
 	struct gpio_mcux_data *data = dev->driver_data;
 
@@ -263,7 +263,7 @@ static void gpio_mcux_port_isr(void *arg)
 
 
 static const struct gpio_driver_api gpio_mcux_driver_api = {
-	.config = gpio_mcux_configure,
+	.pin_configure = gpio_mcux_configure,
 	.port_get_raw = gpio_mcux_port_get_raw,
 	.port_set_masked_raw = gpio_mcux_port_set_masked_raw,
 	.port_set_bits_raw = gpio_mcux_port_set_bits_raw,

--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -63,34 +63,6 @@ static int mcux_igpio_configure(struct device *dev,
 	return 0;
 }
 
-static int mcux_igpio_write(struct device *dev,
-			   int access_op, u32_t pin, u32_t value)
-{
-	const struct mcux_igpio_config *config = dev->config->config_info;
-
-	if (access_op == GPIO_ACCESS_BY_PIN) {
-		GPIO_PinWrite(config->base, pin, value);
-	} else { /* GPIO_ACCESS_BY_PORT */
-		config->base->DR = value;
-	}
-
-	return 0;
-}
-
-static int mcux_igpio_read(struct device *dev,
-			  int access_op, u32_t pin, u32_t *value)
-{
-	const struct mcux_igpio_config *config = dev->config->config_info;
-
-	if (access_op == GPIO_ACCESS_BY_PIN) {
-		*value = GPIO_PinRead(config->base, pin);
-	} else { /* GPIO_ACCESS_BY_PORT */
-		*value = config->base->DR;
-	}
-
-	return 0;
-}
-
 static int mcux_igpio_port_get_raw(struct device *dev, u32_t *value)
 {
 	const struct mcux_igpio_config *config = dev->config->config_info;
@@ -233,8 +205,6 @@ static void mcux_igpio_port_isr(void *arg)
 
 static const struct gpio_driver_api mcux_igpio_driver_api = {
 	.config = mcux_igpio_configure,
-	.write = mcux_igpio_write,
-	.read = mcux_igpio_read,
 	.port_get_raw = mcux_igpio_port_get_raw,
 	.port_set_masked_raw = mcux_igpio_port_set_masked_raw,
 	.port_set_bits_raw = mcux_igpio_port_set_bits_raw,

--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -29,7 +29,7 @@ struct mcux_igpio_data {
 };
 
 static int mcux_igpio_configure(struct device *dev,
-			       int access_op, u32_t pin, int flags)
+			       u32_t pin, int flags)
 {
 	const struct mcux_igpio_config *config = dev->config->config_info;
 	GPIO_Type *base = config->base;
@@ -43,10 +43,6 @@ static int mcux_igpio_configure(struct device *dev,
 	}
 
 	if (((flags & GPIO_PULL_UP) != 0) || ((flags & GPIO_PULL_DOWN) != 0)) {
-		return -ENOTSUP;
-	}
-
-	if (access_op == GPIO_ACCESS_BY_PORT) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -29,7 +29,7 @@ struct mcux_igpio_data {
 };
 
 static int mcux_igpio_configure(struct device *dev,
-			       u32_t pin, int flags)
+				gpio_pin_t pin, gpio_flags_t flags)
 {
 	const struct mcux_igpio_config *config = dev->config->config_info;
 	GPIO_Type *base = config->base;
@@ -111,7 +111,7 @@ static int mcux_igpio_port_toggle_bits(struct device *dev, u32_t mask)
 }
 
 static int mcux_igpio_pin_interrupt_configure(struct device *dev,
-		unsigned int pin, enum gpio_int_mode mode,
+		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
 	const struct mcux_igpio_config *config = dev->config->config_info;
@@ -165,7 +165,7 @@ static int mcux_igpio_manage_callback(struct device *dev,
 }
 
 static int mcux_igpio_enable_callback(struct device *dev,
-				     u32_t pin)
+				     gpio_pin_t pin)
 {
 	struct mcux_igpio_data *data = dev->driver_data;
 
@@ -175,7 +175,7 @@ static int mcux_igpio_enable_callback(struct device *dev,
 }
 
 static int mcux_igpio_disable_callback(struct device *dev,
-				      u32_t pin)
+				      gpio_pin_t pin)
 {
 	struct mcux_igpio_data *data = dev->driver_data;
 
@@ -200,7 +200,7 @@ static void mcux_igpio_port_isr(void *arg)
 }
 
 static const struct gpio_driver_api mcux_igpio_driver_api = {
-	.config = mcux_igpio_configure,
+	.pin_configure = mcux_igpio_configure,
 	.port_get_raw = mcux_igpio_port_get_raw,
 	.port_set_masked_raw = mcux_igpio_port_set_masked_raw,
 	.port_set_bits_raw = mcux_igpio_port_set_bits_raw,

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -102,45 +102,6 @@ static int gpio_mcux_lpc_configure(struct device *dev, int access_op, u32_t pin,
 	return 0;
 }
 
-static int gpio_mcux_lpc_write(struct device *dev, int access_op, u32_t pin,
-			       u32_t value)
-{
-	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
-	GPIO_Type *gpio_base = config->gpio_base;
-	u32_t port = config->port_no;
-
-	/* Check for an invalid pin number */
-	if (pin >= ARRAY_SIZE(gpio_base->B[port])) {
-		return -EINVAL;
-	}
-
-	if (access_op == GPIO_ACCESS_BY_PIN) {
-		/* Set/Clear the data output for the respective pin */
-		gpio_base->B[port][pin] = value;
-	} else { /* return an error for all other options */
-		return -EINVAL;
-	}
-
-	return 0;
-}
-
-static int gpio_mcux_lpc_read(struct device *dev, int access_op, u32_t pin,
-			      u32_t *value)
-{
-	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
-	GPIO_Type *gpio_base = config->gpio_base;
-
-	*value = gpio_base->PIN[config->port_no];
-
-	if (access_op == GPIO_ACCESS_BY_PIN) {
-		*value = (*value & BIT(pin)) >> pin;
-	} else { /* return an error for all other options */
-		return -EINVAL;
-	}
-
-	return 0;
-}
-
 static int gpio_mcux_lpc_port_get_raw(struct device *dev, u32_t *value)
 {
 	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
@@ -380,8 +341,6 @@ static int gpio_mcux_lpc_init(struct device *dev)
 
 static const struct gpio_driver_api gpio_mcux_lpc_driver_api = {
 	.config = gpio_mcux_lpc_configure,
-	.write = gpio_mcux_lpc_write,
-	.read = gpio_mcux_lpc_read,
 	.port_get_raw = gpio_mcux_lpc_port_get_raw,
 	.port_set_masked_raw = gpio_mcux_lpc_port_set_masked_raw,
 	.port_set_bits_raw = gpio_mcux_lpc_port_set_bits_raw,

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -56,8 +56,8 @@ struct gpio_mcux_lpc_data {
 	u32_t isr_list_idx;
 };
 
-static int gpio_mcux_lpc_configure(struct device *dev, u32_t pin,
-				   int flags)
+static int gpio_mcux_lpc_configure(struct device *dev, gpio_pin_t pin,
+				   gpio_flags_t flags)
 {
 	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
@@ -227,7 +227,7 @@ static void gpio_mcux_lpc_port_isr(void *arg);
 
 
 static int gpio_mcux_lpc_pin_interrupt_configure(struct device *dev,
-		unsigned int pin, enum gpio_int_mode mode,
+		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
 	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
@@ -299,7 +299,7 @@ static int gpio_mcux_lpc_manage_cb(struct device *port,
 }
 
 static int gpio_mcux_lpc_enable_cb(struct device *port,
-				   u32_t pin)
+				   gpio_pin_t pin)
 {
 	struct gpio_mcux_lpc_data *data = port->driver_data;
 
@@ -309,7 +309,7 @@ static int gpio_mcux_lpc_enable_cb(struct device *port,
 }
 
 static int gpio_mcux_lpc_disable_cb(struct device *port,
-				    u32_t pin)
+				    gpio_pin_t pin)
 {
 	struct gpio_mcux_lpc_data *data = port->driver_data;
 
@@ -336,7 +336,7 @@ static int gpio_mcux_lpc_init(struct device *dev)
 }
 
 static const struct gpio_driver_api gpio_mcux_lpc_driver_api = {
-	.config = gpio_mcux_lpc_configure,
+	.pin_configure = gpio_mcux_lpc_configure,
 	.port_get_raw = gpio_mcux_lpc_port_get_raw,
 	.port_set_masked_raw = gpio_mcux_lpc_port_set_masked_raw,
 	.port_set_bits_raw = gpio_mcux_lpc_port_set_bits_raw,

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -56,7 +56,7 @@ struct gpio_mcux_lpc_data {
 	u32_t isr_list_idx;
 };
 
-static int gpio_mcux_lpc_configure(struct device *dev, int access_op, u32_t pin,
+static int gpio_mcux_lpc_configure(struct device *dev, u32_t pin,
 				   int flags)
 {
 	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
@@ -84,20 +84,16 @@ static int gpio_mcux_lpc_configure(struct device *dev, int access_op, u32_t pin,
 	}
 
 	/* supports access by pin now,you can add access by port when needed */
-	if (access_op == GPIO_ACCESS_BY_PIN) {
-		if (flags & GPIO_OUTPUT_INIT_HIGH) {
-			gpio_base->SET[port] = BIT(pin);
-		}
-
-		if (flags & GPIO_OUTPUT_INIT_LOW) {
-			gpio_base->CLR[port] = BIT(pin);
-		}
-
-		/* input-0,output-1 */
-		WRITE_BIT(gpio_base->DIR[port], pin, flags & GPIO_OUTPUT);
-	} else {
-		return -EINVAL;
+	if (flags & GPIO_OUTPUT_INIT_HIGH) {
+		gpio_base->SET[port] = BIT(pin);
 	}
+
+	if (flags & GPIO_OUTPUT_INIT_LOW) {
+		gpio_base->CLR[port] = BIT(pin);
+	}
+
+	/* input-0,output-1 */
+	WRITE_BIT(gpio_base->DIR[port], pin, flags & GPIO_OUTPUT);
 
 	return 0;
 }

--- a/drivers/gpio/gpio_mmio32.c
+++ b/drivers/gpio/gpio_mmio32.c
@@ -30,7 +30,7 @@
 #include <errno.h>
 
 static int gpio_mmio32_config(struct device *dev,
-					u32_t pin, int flags)
+			      gpio_pin_t pin, gpio_flags_t flags)
 {
 	struct gpio_mmio32_context *context = dev->driver_data;
 	const struct gpio_mmio32_config *config = context->config;
@@ -143,7 +143,7 @@ static int gpio_mmio32_port_toggle_bits(struct device *dev, u32_t mask)
 }
 
 static int gpio_mmio32_pin_interrupt_configure(struct device *dev,
-		unsigned int pin, enum gpio_int_mode mode,
+		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
 	if (mode != GPIO_INT_MODE_DISABLED) {
@@ -154,7 +154,7 @@ static int gpio_mmio32_pin_interrupt_configure(struct device *dev,
 }
 
 static const struct gpio_driver_api gpio_mmio32_api = {
-	.config = gpio_mmio32_config,
+	.pin_configure = gpio_mmio32_config,
 	.port_get_raw = gpio_mmio32_port_get_raw,
 	.port_set_masked_raw = gpio_mmio32_port_set_masked_raw,
 	.port_set_bits_raw = gpio_mmio32_port_set_bits_raw,

--- a/drivers/gpio/gpio_mmio32.c
+++ b/drivers/gpio/gpio_mmio32.c
@@ -29,7 +29,7 @@
 #include <drivers/gpio/gpio_mmio32.h>
 #include <errno.h>
 
-static int gpio_mmio32_config(struct device *dev, int access_op,
+static int gpio_mmio32_config(struct device *dev,
 					u32_t pin, int flags)
 {
 	struct gpio_mmio32_context *context = dev->driver_data;

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -127,7 +127,7 @@ static int gpiote_pin_int_cfg(struct device *port, u32_t pin)
 	return res;
 }
 
-static int gpio_nrfx_config(struct device *port, int access_op,
+static int gpio_nrfx_config(struct device *port,
 			    u32_t pin, int flags)
 {
 	NRF_GPIO_Type *reg = get_port_cfg(port)->port;
@@ -135,8 +135,6 @@ static int gpio_nrfx_config(struct device *port, int access_op,
 	nrf_gpio_pin_drive_t drive;
 	nrf_gpio_pin_dir_t dir;
 	nrf_gpio_pin_input_t input;
-	u8_t from_pin;
-	u8_t to_pin;
 
 	switch (flags & (GPIO_DS_LOW_MASK | GPIO_DS_HIGH_MASK |
 			 GPIO_OPEN_DRAIN)) {
@@ -187,27 +185,16 @@ static int gpio_nrfx_config(struct device *port, int access_op,
 		? NRF_GPIO_PIN_INPUT_CONNECT
 		: NRF_GPIO_PIN_INPUT_DISCONNECT;
 
-	if (access_op == GPIO_ACCESS_BY_PORT) {
-		from_pin = 0U;
-		to_pin   = 31U;
-	} else {
-		from_pin = pin;
-		to_pin   = pin;
-	}
-
-	for (u8_t curr_pin = from_pin; curr_pin <= to_pin; ++curr_pin) {
-		if ((flags & GPIO_OUTPUT) != 0) {
-			if ((flags & GPIO_OUTPUT_INIT_HIGH) != 0) {
-				nrf_gpio_port_out_set(reg, BIT(curr_pin));
-			} else if ((flags & GPIO_OUTPUT_INIT_LOW) != 0) {
-				nrf_gpio_port_out_clear(reg, BIT(curr_pin));
-			}
+	if ((flags & GPIO_OUTPUT) != 0) {
+		if ((flags & GPIO_OUTPUT_INIT_HIGH) != 0) {
+			nrf_gpio_port_out_set(reg, BIT(pin));
+		} else if ((flags & GPIO_OUTPUT_INIT_LOW) != 0) {
+			nrf_gpio_port_out_clear(reg, BIT(pin));
 		}
-
-		nrf_gpio_cfg(NRF_GPIO_PIN_MAP(get_port_cfg(port)->port_num,
-					      curr_pin),
-			     dir, input, pull, drive, NRF_GPIO_PIN_NOSENSE);
 	}
+
+	nrf_gpio_cfg(NRF_GPIO_PIN_MAP(get_port_cfg(port)->port_num, pin),
+		     dir, input, pull, drive, NRF_GPIO_PIN_NOSENSE);
 
 	return 0;
 }

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -212,45 +212,6 @@ static int gpio_nrfx_config(struct device *port, int access_op,
 	return 0;
 }
 
-static int gpio_nrfx_write(struct device *port, int access_op,
-			   u32_t pin, u32_t value)
-{
-	NRF_GPIO_Type *reg = get_port_cfg(port)->port;
-	struct gpio_nrfx_data *data = get_port_data(port);
-
-	if (access_op == GPIO_ACCESS_BY_PORT) {
-		nrf_gpio_port_out_write(reg, value ^ data->common.invert);
-	} else {
-		if ((value > 0) ^ ((BIT(pin) & data->common.invert) != 0)) {
-			nrf_gpio_port_out_set(reg, BIT(pin));
-		} else {
-			nrf_gpio_port_out_clear(reg, BIT(pin));
-		}
-	}
-
-	return 0;
-}
-
-static int gpio_nrfx_read(struct device *port, int access_op,
-			  u32_t pin, u32_t *value)
-{
-	NRF_GPIO_Type *reg = get_port_cfg(port)->port;
-	struct gpio_nrfx_data *data = get_port_data(port);
-
-	u32_t dir = nrf_gpio_port_dir_read(reg);
-	u32_t port_in = nrf_gpio_port_in_read(reg) & ~dir;
-	u32_t port_out = nrf_gpio_port_out_read(reg) & dir;
-	u32_t port_val = (port_in | port_out) ^ data->common.invert;
-
-	if (access_op == GPIO_ACCESS_BY_PORT) {
-		*value = port_val;
-	} else {
-		*value = (port_val & BIT(pin)) ? 1 : 0;
-	}
-
-	return 0;
-}
-
 static int gpio_nrfx_port_get_raw(struct device *port, u32_t *value)
 {
 	NRF_GPIO_Type *reg = get_port_cfg(port)->port;
@@ -361,8 +322,6 @@ static inline int gpio_nrfx_pin_disable_callback(struct device *port,
 
 static const struct gpio_driver_api gpio_nrfx_drv_api_funcs = {
 	.config = gpio_nrfx_config,
-	.write = gpio_nrfx_write,
-	.read = gpio_nrfx_read,
 	.port_get_raw = gpio_nrfx_port_get_raw,
 	.port_set_masked_raw = gpio_nrfx_port_set_masked_raw,
 	.port_set_bits_raw = gpio_nrfx_port_set_bits_raw,

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -128,7 +128,7 @@ static int gpiote_pin_int_cfg(struct device *port, u32_t pin)
 }
 
 static int gpio_nrfx_config(struct device *port,
-			    u32_t pin, int flags)
+			    gpio_pin_t pin, gpio_flags_t flags)
 {
 	NRF_GPIO_Type *reg = get_port_cfg(port)->port;
 	nrf_gpio_pin_pull_t pull;
@@ -250,7 +250,7 @@ static int gpio_nrfx_port_toggle_bits(struct device *port, u32_t mask)
 }
 
 static int gpio_nrfx_pin_interrupt_configure(struct device *port,
-		unsigned int pin, enum gpio_int_mode mode,
+		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
 	struct gpio_nrfx_data *data = get_port_data(port);
@@ -296,19 +296,19 @@ static int gpio_nrfx_pin_manage_callback(struct device *port,
 }
 
 static inline int gpio_nrfx_pin_enable_callback(struct device *port,
-						u32_t pin)
+						gpio_pin_t pin)
 {
 	return gpio_nrfx_pin_manage_callback(port, pin, true);
 }
 
 static inline int gpio_nrfx_pin_disable_callback(struct device *port,
-						 u32_t pin)
+						 gpio_pin_t pin)
 {
 	return gpio_nrfx_pin_manage_callback(port, pin, false);
 }
 
 static const struct gpio_driver_api gpio_nrfx_drv_api_funcs = {
-	.config = gpio_nrfx_config,
+	.pin_configure = gpio_nrfx_config,
 	.port_get_raw = gpio_nrfx_port_get_raw,
 	.port_set_masked_raw = gpio_nrfx_port_set_masked_raw,
 	.port_set_bits_raw = gpio_nrfx_port_set_bits_raw,

--- a/drivers/gpio/gpio_pca95xx.c
+++ b/drivers/gpio/gpio_pca95xx.c
@@ -299,13 +299,12 @@ static int setup_pin_pullupdown(struct device *dev, u32_t pin, int flags)
  * @brief Configure pin or port
  *
  * @param dev Device struct of the PCA95XX
- * @param access_op Access operation (pin or port)
  * @param pin The pin number
  * @param flags Flags of pin or port
  *
  * @return 0 if successful, failed otherwise
  */
-static int gpio_pca95xx_config(struct device *dev, int access_op,
+static int gpio_pca95xx_config(struct device *dev,
 				 u32_t pin, int flags)
 {
 	int ret;
@@ -317,11 +316,6 @@ static int gpio_pca95xx_config(struct device *dev, int access_op,
 		dev->config->config_info;
 	u16_t i2c_addr = config->i2c_slave_addr;
 #endif
-
-	/* only support config by pin */
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
 
 	/* Does not support disconnected pin */
 	if ((flags & (GPIO_INPUT | GPIO_OUTPUT)) == GPIO_DISCONNECTED) {

--- a/drivers/gpio/gpio_pca95xx.c
+++ b/drivers/gpio/gpio_pca95xx.c
@@ -305,7 +305,7 @@ static int setup_pin_pullupdown(struct device *dev, u32_t pin, int flags)
  * @return 0 if successful, failed otherwise
  */
 static int gpio_pca95xx_config(struct device *dev,
-				 u32_t pin, int flags)
+			       gpio_pin_t pin, gpio_flags_t flags)
 {
 	int ret;
 	struct gpio_pca95xx_drv_data * const drv_data =
@@ -441,7 +441,7 @@ static int gpio_pca95xx_port_toggle_bits(struct device *dev, u32_t mask)
 }
 
 static int gpio_pca95xx_pin_interrupt_configure(struct device *dev,
-						  unsigned int pin,
+						  gpio_pin_t pin,
 						  enum gpio_int_mode mode,
 						  enum gpio_int_trig trig)
 {
@@ -449,7 +449,7 @@ static int gpio_pca95xx_pin_interrupt_configure(struct device *dev,
 }
 
 static const struct gpio_driver_api gpio_pca95xx_drv_api_funcs = {
-	.config = gpio_pca95xx_config,
+	.pin_configure = gpio_pca95xx_config,
 	.port_get_raw = gpio_pca95xx_port_get_raw,
 	.port_set_masked_raw = gpio_pca95xx_port_set_masked_raw,
 	.port_set_bits_raw = gpio_pca95xx_port_set_bits_raw,

--- a/drivers/gpio/gpio_rv32m1.c
+++ b/drivers/gpio/gpio_rv32m1.c
@@ -70,7 +70,7 @@ static u32_t get_port_pcr_irqc_value_from_flags(struct device *dev,
 }
 
 static int gpio_rv32m1_configure(struct device *dev,
-				 u32_t pin, int flags)
+				 gpio_pin_t pin, gpio_flags_t flags)
 {
 	const struct gpio_rv32m1_config *config = dev->config->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
@@ -206,7 +206,7 @@ static int gpio_rv32m1_port_toggle_bits(struct device *dev, u32_t mask)
 }
 
 static int gpio_rv32m1_pin_interrupt_configure(struct device *dev,
-		unsigned int pin, enum gpio_int_mode mode,
+		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
 	const struct gpio_rv32m1_config *config = dev->config->config_info;
@@ -245,7 +245,7 @@ static int gpio_rv32m1_manage_callback(struct device *dev,
 }
 
 static int gpio_rv32m1_enable_callback(struct device *dev,
-				     u32_t pin)
+				     gpio_pin_t pin)
 {
 	struct gpio_rv32m1_data *data = dev->driver_data;
 
@@ -255,7 +255,7 @@ static int gpio_rv32m1_enable_callback(struct device *dev,
 }
 
 static int gpio_rv32m1_disable_callback(struct device *dev,
-				      u32_t pin)
+				      gpio_pin_t pin)
 {
 	struct gpio_rv32m1_data *data = dev->driver_data;
 
@@ -304,7 +304,7 @@ static int gpio_rv32m1_init(struct device *dev)
 }
 
 static const struct gpio_driver_api gpio_rv32m1_driver_api = {
-	.config = gpio_rv32m1_configure,
+	.pin_configure = gpio_rv32m1_configure,
 	.port_get_raw = gpio_rv32m1_port_get_raw,
 	.port_set_masked_raw = gpio_rv32m1_port_set_masked_raw,
 	.port_set_bits_raw = gpio_rv32m1_port_set_bits_raw,

--- a/drivers/gpio/gpio_rv32m1.c
+++ b/drivers/gpio/gpio_rv32m1.c
@@ -177,51 +177,6 @@ static int gpio_rv32m1_configure(struct device *dev,
 
 	return 0;
 }
-static int gpio_rv32m1_write(struct device *dev,
-			   int access_op, u32_t pin, u32_t value)
-{
-	const struct gpio_rv32m1_config *config = dev->config->config_info;
-	GPIO_Type *gpio_base = config->gpio_base;
-
-	if (access_op == GPIO_ACCESS_BY_PIN) {
-		if (value) {
-			/* Set the data output for the corresponding pin.
-			 * Writing zeros to the other bits leaves the data
-			 * output unchanged for the other pins.
-			 */
-			gpio_base->PSOR = BIT(pin);
-		} else {
-			/* Clear the data output for the corresponding pin.
-			 * Writing zeros to the other bits leaves the data
-			 * output unchanged for the other pins.
-			 */
-			gpio_base->PCOR = BIT(pin);
-		}
-	} else { /* GPIO_ACCESS_BY_PORT */
-		/* Write the data output for all the pins */
-		gpio_base->PDOR = value;
-	}
-
-	return 0;
-}
-
-static int gpio_rv32m1_read(struct device *dev,
-			  int access_op, u32_t pin, u32_t *value)
-{
-	const struct gpio_rv32m1_config *config = dev->config->config_info;
-	GPIO_Type *gpio_base = config->gpio_base;
-
-	*value = gpio_base->PDIR;
-
-	if (access_op == GPIO_ACCESS_BY_PIN) {
-		*value = (*value & BIT(pin)) >> pin;
-	}
-
-	/* nothing more to do for GPIO_ACCESS_BY_PORT */
-
-	return 0;
-}
-
 static int gpio_rv32m1_port_get_raw(struct device *dev, u32_t *value)
 {
 	const struct gpio_rv32m1_config *config = dev->config->config_info;
@@ -373,8 +328,6 @@ static int gpio_rv32m1_init(struct device *dev)
 
 static const struct gpio_driver_api gpio_rv32m1_driver_api = {
 	.config = gpio_rv32m1_configure,
-	.write = gpio_rv32m1_write,
-	.read = gpio_rv32m1_read,
 	.port_get_raw = gpio_rv32m1_port_get_raw,
 	.port_set_masked_raw = gpio_rv32m1_port_set_masked_raw,
 	.port_set_bits_raw = gpio_rv32m1_port_set_bits_raw,

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -127,23 +127,10 @@ static int gpio_sam_port_configure(struct device *dev, u32_t mask, int flags)
 	return 0;
 }
 
-static int gpio_sam_config(struct device *dev, int access_op, u32_t pin,
+static int gpio_sam_config(struct device *dev, u32_t pin,
 			   int flags)
 {
-	int ret;
-
-	switch (access_op) {
-	case GPIO_ACCESS_BY_PIN:
-		ret = gpio_sam_port_configure(dev, BIT(pin), flags);
-		break;
-	case GPIO_ACCESS_BY_PORT:
-		ret = gpio_sam_port_configure(dev, GPIO_SAM_ALL_PINS, flags);
-		break;
-	default:
-		ret = -ENOTSUP;
-	}
-
-	return ret;
+	return gpio_sam_port_configure(dev, BIT(pin), flags);
 }
 
 static int gpio_sam_port_get_raw(struct device *dev, u32_t *value)

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -36,7 +36,8 @@ struct gpio_sam_runtime {
 
 #define GPIO_SAM_ALL_PINS    0xFFFFFFFF
 
-static int gpio_sam_port_configure(struct device *dev, u32_t mask, int flags)
+static int gpio_sam_port_configure(struct device *dev, u32_t mask,
+				   gpio_flags_t flags)
 {
 	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
 	Pio * const pio = cfg->regs;
@@ -127,8 +128,8 @@ static int gpio_sam_port_configure(struct device *dev, u32_t mask, int flags)
 	return 0;
 }
 
-static int gpio_sam_config(struct device *dev, u32_t pin,
-			   int flags)
+static int gpio_sam_config(struct device *dev, gpio_pin_t pin,
+			   gpio_flags_t flags)
 {
 	return gpio_sam_port_configure(dev, BIT(pin), flags);
 }
@@ -236,7 +237,7 @@ static int gpio_sam_port_interrupt_configure(struct device *dev, u32_t mask,
 }
 
 static int gpio_sam_pin_interrupt_configure(struct device *dev,
-		unsigned int pin, enum gpio_int_mode mode,
+		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
 	return gpio_sam_port_interrupt_configure(dev, BIT(pin), mode, trig);
@@ -265,7 +266,7 @@ static int gpio_sam_manage_callback(struct device *port,
 }
 
 static int gpio_sam_enable_callback(struct device *port,
-				    u32_t pin)
+				    gpio_pin_t pin)
 {
 	const struct gpio_sam_config * const cfg = DEV_CFG(port);
 	Pio * const pio = cfg->regs;
@@ -276,7 +277,7 @@ static int gpio_sam_enable_callback(struct device *port,
 }
 
 static int gpio_sam_disable_callback(struct device *port,
-				     u32_t pin)
+				     gpio_pin_t pin)
 {
 	const struct gpio_sam_config * const cfg = DEV_CFG(port);
 	Pio * const pio = cfg->regs;
@@ -287,7 +288,7 @@ static int gpio_sam_disable_callback(struct device *port,
 }
 
 static const struct gpio_driver_api gpio_sam_api = {
-	.config = gpio_sam_config,
+	.pin_configure = gpio_sam_config,
 	.port_get_raw = gpio_sam_port_get_raw,
 	.port_set_masked_raw = gpio_sam_port_set_masked_raw,
 	.port_set_bits_raw = gpio_sam_port_set_bits_raw,

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -146,54 +146,6 @@ static int gpio_sam_config(struct device *dev, int access_op, u32_t pin,
 	return ret;
 }
 
-static int gpio_sam_write(struct device *dev, int access_op, u32_t pin,
-			  u32_t value)
-{
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
-	Pio * const pio = cfg->regs;
-	u32_t mask = 1 << pin;
-
-	switch (access_op) {
-	case GPIO_ACCESS_BY_PIN:
-		if (value) {
-			/* Set the pin. */
-			pio->PIO_SODR = mask;
-		} else {
-			/* Clear the pin. */
-			pio->PIO_CODR = mask;
-		}
-		break;
-	case GPIO_ACCESS_BY_PORT:
-		pio->PIO_ODSR = value;
-		break;
-	default:
-		return -ENOTSUP;
-	}
-
-	return 0;
-}
-
-static int gpio_sam_read(struct device *dev, int access_op, u32_t pin,
-			 u32_t *value)
-{
-	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
-	Pio * const pio = cfg->regs;
-
-	*value = pio->PIO_PDSR;
-
-	switch (access_op) {
-	case GPIO_ACCESS_BY_PIN:
-		*value = (*value >> pin) & 1;
-		break;
-	case GPIO_ACCESS_BY_PORT:
-		break;
-	default:
-		return -ENOTSUP;
-	}
-
-	return 0;
-}
-
 static int gpio_sam_port_get_raw(struct device *dev, u32_t *value)
 {
 	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
@@ -349,8 +301,6 @@ static int gpio_sam_disable_callback(struct device *port,
 
 static const struct gpio_driver_api gpio_sam_api = {
 	.config = gpio_sam_config,
-	.write = gpio_sam_write,
-	.read = gpio_sam_read,
 	.port_get_raw = gpio_sam_port_get_raw,
 	.port_set_masked_raw = gpio_sam_port_set_masked_raw,
 	.port_set_bits_raw = gpio_sam_port_set_bits_raw,

--- a/drivers/gpio/gpio_sam0.c
+++ b/drivers/gpio/gpio_sam0.c
@@ -50,7 +50,7 @@ static void gpio_sam0_isr(u32_t pins, void *arg)
 }
 #endif
 
-static int gpio_sam0_config(struct device *dev, int access_op, u32_t pin,
+static int gpio_sam0_config(struct device *dev, u32_t pin,
 			    int flags)
 {
 	const struct gpio_sam0_config *config = DEV_CFG(dev);

--- a/drivers/gpio/gpio_sam0.c
+++ b/drivers/gpio/gpio_sam0.c
@@ -105,30 +105,6 @@ static int gpio_sam0_config(struct device *dev, int access_op, u32_t pin,
 	return 0;
 }
 
-static int gpio_sam0_write(struct device *dev, int access_op, u32_t pin,
-			   u32_t value)
-{
-	const struct gpio_sam0_config *config = DEV_CFG(dev);
-
-	if (value != 0U) {
-		config->regs->OUTSET.reg = BIT(pin);
-	} else {
-		config->regs->OUTCLR.reg = BIT(pin);
-	}
-
-	return 0;
-}
-
-static int gpio_sam0_read(struct device *dev, int access_op, u32_t pin,
-			  u32_t *value)
-{
-	const struct gpio_sam0_config *config = DEV_CFG(dev);
-
-	*value = (config->regs->IN.reg & BIT(pin)) != 0;
-
-	return 0;
-}
-
 static int gpio_sam0_port_get_raw(struct device *dev,
 				  gpio_port_value_t *value)
 {
@@ -307,8 +283,6 @@ static u32_t gpio_sam0_get_pending_int(struct device *dev)
 
 static const struct gpio_driver_api gpio_sam0_api = {
 	.config = gpio_sam0_config,
-	.write = gpio_sam0_write,
-	.read = gpio_sam0_read,
 	.port_get_raw = gpio_sam0_port_get_raw,
 	.port_set_masked_raw = gpio_sam0_port_set_masked_raw,
 	.port_set_bits_raw = gpio_sam0_port_set_bits_raw,

--- a/drivers/gpio/gpio_sam0.c
+++ b/drivers/gpio/gpio_sam0.c
@@ -50,8 +50,8 @@ static void gpio_sam0_isr(u32_t pins, void *arg)
 }
 #endif
 
-static int gpio_sam0_config(struct device *dev, u32_t pin,
-			    int flags)
+static int gpio_sam0_config(struct device *dev, gpio_pin_t pin,
+			    gpio_flags_t flags)
 {
 	const struct gpio_sam0_config *config = DEV_CFG(dev);
 	PortGroup *regs = config->regs;
@@ -160,7 +160,7 @@ static int gpio_sam0_port_toggle_bits(struct device *dev,
 #ifdef CONFIG_SAM0_EIC
 
 static int gpio_sam0_pin_interrupt_configure(struct device *dev,
-					     unsigned int pin,
+					     gpio_pin_t pin,
 					     enum gpio_int_mode mode,
 					     enum gpio_int_trig trig)
 {
@@ -258,14 +258,14 @@ static int gpio_sam0_manage_callback(struct device *dev,
 	return gpio_manage_callback(&data->callbacks, callback, set);
 }
 
-int gpio_sam0_enable_callback(struct device *dev, u32_t pin)
+int gpio_sam0_enable_callback(struct device *dev, gpio_pin_t pin)
 {
 	const struct gpio_sam0_config *config = DEV_CFG(dev);
 
 	return sam0_eic_enable_interrupt(config->id, pin);
 }
 
-int gpio_sam0_disable_callback(struct device *dev, u32_t pin)
+int gpio_sam0_disable_callback(struct device *dev, gpio_pin_t pin)
 {
 	const struct gpio_sam0_config *config = DEV_CFG(dev);
 
@@ -282,7 +282,7 @@ static u32_t gpio_sam0_get_pending_int(struct device *dev)
 #endif
 
 static const struct gpio_driver_api gpio_sam0_api = {
-	.config = gpio_sam0_config,
+	.pin_configure = gpio_sam0_config,
 	.port_get_raw = gpio_sam0_port_get_raw,
 	.port_set_masked_raw = gpio_sam0_port_set_masked_raw,
 	.port_set_bits_raw = gpio_sam0_port_set_bits_raw,

--- a/drivers/gpio/gpio_sifive.c
+++ b/drivers/gpio/gpio_sifive.c
@@ -198,83 +198,6 @@ static int gpio_sifive_config(struct device *dev,
 	return 0;
 }
 
-/**
- * @brief Set the pin
- *
- * @param dev Device struct
- * @param access_op Access operation
- * @param pin The pin number
- * @param value Value to set (0 or 1)
- *
- * @return 0 if successful, failed otherwise
- */
-static int gpio_sifive_write(struct device *dev,
-			    int access_op,
-			    u32_t pin,
-			    u32_t value)
-{
-	volatile struct gpio_sifive_t *gpio = DEV_GPIO(dev);
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
-
-	if (pin >= SIFIVE_PINMUX_PINS)
-		return -EINVAL;
-
-	/* If pin is configured as input return with error */
-	if (gpio->in_en & BIT(pin)) {
-		return -EINVAL;
-	}
-
-	if (value) {
-		gpio->out_val |= BIT(pin);
-	} else {
-		gpio->out_val &= ~BIT(pin);
-	}
-
-	return 0;
-}
-
-/**
- * @brief Read the pin
- *
- * @param dev Device struct
- * @param access_op Access operation
- * @param pin The pin number
- * @param value Value of input pin(s)
- *
- * @return 0 if successful, failed otherwise
- */
-static int gpio_sifive_read(struct device *dev,
-			   int access_op,
-			   u32_t pin,
-			   u32_t *value)
-{
-	volatile struct gpio_sifive_t *gpio = DEV_GPIO(dev);
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
-
-	if (pin >= SIFIVE_PINMUX_PINS) {
-		return -EINVAL;
-	}
-
-	/*
-	 * If gpio is configured as output,
-	 * read gpio value from out_val register,
-	 * otherwise read gpio value from in_val register
-	 */
-	if (gpio->out_en & BIT(pin)) {
-		*value = !!(gpio->out_val & BIT(pin));
-	} else {
-		*value = !!(gpio->in_val & BIT(pin));
-	}
-
-	return 0;
-}
-
 static int gpio_sifive_port_get_raw(struct device *dev,
 				   gpio_port_value_t *value)
 {
@@ -439,8 +362,6 @@ static int gpio_sifive_disable_callback(struct device *dev,
 
 static const struct gpio_driver_api gpio_sifive_driver = {
 	.config                  = gpio_sifive_config,
-	.write                   = gpio_sifive_write,
-	.read                    = gpio_sifive_read,
 	.port_get_raw            = gpio_sifive_port_get_raw,
 	.port_set_masked_raw     = gpio_sifive_port_set_masked_raw,
 	.port_set_bits_raw       = gpio_sifive_port_set_bits_raw,

--- a/drivers/gpio/gpio_sifive.c
+++ b/drivers/gpio/gpio_sifive.c
@@ -153,8 +153,8 @@ static void gpio_sifive_irq_handler(void *arg)
  * @return 0 if successful, failed otherwise
  */
 static int gpio_sifive_config(struct device *dev,
-			     u32_t pin,
-			     int flags)
+			      gpio_pin_t pin,
+			      gpio_flags_t flags)
 {
 	volatile struct gpio_sifive_t *gpio = DEV_GPIO(dev);
 
@@ -244,7 +244,7 @@ static int gpio_sifive_port_toggle_bits(struct device *dev,
 }
 
 static int gpio_sifive_pin_interrupt_configure(struct device *dev,
-					      unsigned int pin,
+					      gpio_pin_t pin,
 					      enum gpio_int_mode mode,
 					      enum gpio_int_trig trig)
 {
@@ -325,7 +325,7 @@ static int gpio_sifive_manage_callback(struct device *dev,
 }
 
 static int gpio_sifive_enable_callback(struct device *dev,
-				      u32_t pin)
+				      gpio_pin_t pin)
 {
 	const struct gpio_sifive_config *cfg = DEV_GPIO_CFG(dev);
 
@@ -340,7 +340,7 @@ static int gpio_sifive_enable_callback(struct device *dev,
 }
 
 static int gpio_sifive_disable_callback(struct device *dev,
-				       u32_t pin)
+				       gpio_pin_t pin)
 {
 	const struct gpio_sifive_config *cfg = DEV_GPIO_CFG(dev);
 
@@ -355,7 +355,7 @@ static int gpio_sifive_disable_callback(struct device *dev,
 }
 
 static const struct gpio_driver_api gpio_sifive_driver = {
-	.config                  = gpio_sifive_config,
+	.pin_configure           = gpio_sifive_config,
 	.port_get_raw            = gpio_sifive_port_get_raw,
 	.port_set_masked_raw     = gpio_sifive_port_set_masked_raw,
 	.port_set_bits_raw       = gpio_sifive_port_set_bits_raw,

--- a/drivers/gpio/gpio_sifive.c
+++ b/drivers/gpio/gpio_sifive.c
@@ -147,22 +147,16 @@ static void gpio_sifive_irq_handler(void *arg)
  * @brief Configure pin
  *
  * @param dev Device structure
- * @param access_op Access operation
  * @param pin The pin number
  * @param flags Flags of pin or port
  *
  * @return 0 if successful, failed otherwise
  */
 static int gpio_sifive_config(struct device *dev,
-			     int access_op,
 			     u32_t pin,
 			     int flags)
 {
 	volatile struct gpio_sifive_t *gpio = DEV_GPIO(dev);
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
 
 	if (pin >= SIFIVE_PINMUX_PINS) {
 		return -EINVAL;

--- a/drivers/gpio/gpio_stellaris.c
+++ b/drivers/gpio/gpio_stellaris.c
@@ -79,7 +79,7 @@ static void gpio_stellaris_isr(void *arg)
 }
 
 static int gpio_stellaris_configure(struct device *dev,
-				    u32_t pin, int flags)
+				    gpio_pin_t pin, gpio_flags_t flags)
 {
 	const struct gpio_stellaris_config *cfg = DEV_CFG(dev);
 	u32_t base = cfg->base;
@@ -177,7 +177,7 @@ static int gpio_stellaris_port_toggle_bits(struct device *dev, u32_t mask)
 }
 
 static int gpio_stellaris_pin_interrupt_configure(struct device *dev,
-		unsigned int pin, enum gpio_int_mode mode,
+		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
 	const struct gpio_stellaris_config *cfg = DEV_CFG(dev);
@@ -218,7 +218,7 @@ static int gpio_stellaris_init(struct device *dev)
 }
 
 static int gpio_stellaris_enable_callback(struct device *dev,
-					  u32_t pin)
+					  gpio_pin_t pin)
 {
 	const struct gpio_stellaris_config * const cfg = DEV_CFG(dev);
 	u32_t base = cfg->base;
@@ -229,7 +229,7 @@ static int gpio_stellaris_enable_callback(struct device *dev,
 }
 
 static int gpio_stellaris_disable_callback(struct device *dev,
-					   u32_t pin)
+					   gpio_pin_t pin)
 {
 	const struct gpio_stellaris_config * const cfg = DEV_CFG(dev);
 	u32_t base = cfg->base;
@@ -251,7 +251,7 @@ static int gpio_stellaris_manage_callback(struct device *dev,
 }
 
 static const struct gpio_driver_api gpio_stellaris_driver_api = {
-	.config = gpio_stellaris_configure,
+	.pin_configure = gpio_stellaris_configure,
 	.port_get_raw = gpio_stellaris_port_get_raw,
 	.port_set_masked_raw = gpio_stellaris_port_set_masked_raw,
 	.port_set_bits_raw = gpio_stellaris_port_set_bits_raw,

--- a/drivers/gpio/gpio_stellaris.c
+++ b/drivers/gpio/gpio_stellaris.c
@@ -78,7 +78,7 @@ static void gpio_stellaris_isr(void *arg)
 	sys_write32(int_stat, GPIO_REG_ADDR(base, GPIO_ICR_OFFSET));
 }
 
-static int gpio_stellaris_configure(struct device *dev, int access_op,
+static int gpio_stellaris_configure(struct device *dev,
 				    u32_t pin, int flags)
 {
 	const struct gpio_stellaris_config *cfg = DEV_CFG(dev);
@@ -91,11 +91,6 @@ static int gpio_stellaris_configure(struct device *dev, int access_op,
 
 	if ((flags & GPIO_SINGLE_ENDED) != 0) {
 		return -ENOTSUP;
-	}
-
-	/* Supports access by pin now,you can add access by port when needed */
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -EINVAL;
 	}
 
 	/* Check for pin availability */

--- a/drivers/gpio/gpio_stellaris.c
+++ b/drivers/gpio/gpio_stellaris.c
@@ -127,44 +127,6 @@ static int gpio_stellaris_configure(struct device *dev, int access_op,
 	return 0;
 }
 
-static int gpio_stellaris_write(struct device *dev,
-				int access_op, u32_t pin, u32_t value)
-{
-	const struct gpio_stellaris_config *cfg = DEV_CFG(dev);
-	u32_t base = cfg->base;
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -EINVAL;
-	}
-
-	/* Set/Clear the data output for the respective pin */
-	if (value) {
-		sys_set_bit(GPIO_RW_ADDR(base, GPIO_DATA_OFFSET, pin),
-			    pin);
-	} else {
-		sys_clear_bit(GPIO_RW_ADDR(base, GPIO_DATA_OFFSET, pin),
-			      pin);
-	}
-
-	return 0;
-}
-
-static int gpio_stellaris_read(struct device *dev,
-			       int access_op, u32_t pin, u32_t *value)
-{
-	const struct gpio_stellaris_config *cfg = DEV_CFG(dev);
-	u32_t base = cfg->base;
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -EINVAL;
-	}
-
-	*value = sys_test_bit(GPIO_RW_ADDR(base, GPIO_DATA_OFFSET, pin),
-			      pin);
-
-	return 0;
-}
-
 static int gpio_stellaris_port_get_raw(struct device *dev, u32_t *value)
 {
 	const struct gpio_stellaris_config *cfg = DEV_CFG(dev);
@@ -295,8 +257,6 @@ static int gpio_stellaris_manage_callback(struct device *dev,
 
 static const struct gpio_driver_api gpio_stellaris_driver_api = {
 	.config = gpio_stellaris_configure,
-	.write = gpio_stellaris_write,
-	.read = gpio_stellaris_read,
 	.port_get_raw = gpio_stellaris_port_get_raw,
 	.port_set_masked_raw = gpio_stellaris_port_set_masked_raw,
 	.port_set_bits_raw = gpio_stellaris_port_set_bits_raw,

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -381,16 +381,12 @@ static int gpio_stm32_port_toggle_bits(struct device *dev,
 /**
  * @brief Configure pin or port
  */
-static int gpio_stm32_config(struct device *dev, int access_op,
+static int gpio_stm32_config(struct device *dev,
 			     u32_t pin, int flags)
 {
 	const struct gpio_stm32_config *cfg = dev->config->config_info;
 	int err = 0;
 	int pincfg;
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
 
 #if defined(CONFIG_STM32H7_DUAL_CORE)
 	while (LL_HSEM_1StepLock(HSEM, LL_HSEM_ID_1)) {

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -382,7 +382,7 @@ static int gpio_stm32_port_toggle_bits(struct device *dev,
  * @brief Configure pin or port
  */
 static int gpio_stm32_config(struct device *dev,
-			     u32_t pin, int flags)
+			     gpio_pin_t pin, gpio_flags_t flags)
 {
 	const struct gpio_stm32_config *cfg = dev->config->config_info;
 	int err = 0;
@@ -420,7 +420,7 @@ release_lock:
 }
 
 static int gpio_stm32_pin_interrupt_configure(struct device *dev,
-		unsigned int pin, enum gpio_int_mode mode,
+		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
 	const struct gpio_stm32_config *cfg = dev->config->config_info;
@@ -493,7 +493,7 @@ static int gpio_stm32_manage_callback(struct device *dev,
 }
 
 static int gpio_stm32_enable_callback(struct device *dev,
-				      u32_t pin)
+				      gpio_pin_t pin)
 {
 	struct gpio_stm32_data *data = dev->driver_data;
 
@@ -503,7 +503,7 @@ static int gpio_stm32_enable_callback(struct device *dev,
 }
 
 static int gpio_stm32_disable_callback(struct device *dev,
-				       u32_t pin)
+				       gpio_pin_t pin)
 {
 	struct gpio_stm32_data *data = dev->driver_data;
 
@@ -513,7 +513,7 @@ static int gpio_stm32_disable_callback(struct device *dev,
 }
 
 static const struct gpio_driver_api gpio_stm32_driver = {
-	.config = gpio_stm32_config,
+	.pin_configure = gpio_stm32_config,
 	.port_get_raw = gpio_stm32_port_get_raw,
 	.port_set_masked_raw = gpio_stm32_port_set_masked_raw,
 	.port_set_bits_raw = gpio_stm32_port_set_bits_raw,

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -423,47 +423,6 @@ release_lock:
 	return err;
 }
 
-/**
- * @brief Set the pin or port output
- */
-static int gpio_stm32_write(struct device *dev, int access_op,
-			    u32_t pin, u32_t value)
-{
-	const struct gpio_stm32_config *cfg = dev->config->config_info;
-	GPIO_TypeDef *gpio = (GPIO_TypeDef *)cfg->base;
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
-
-	pin = stm32_pinval_get(pin);
-	if (value != 0U) {
-		LL_GPIO_SetOutputPin(gpio, pin);
-	} else {
-		LL_GPIO_ResetOutputPin(gpio, pin);
-	}
-
-	return 0;
-}
-
-/**
- * @brief Read the pin or port status
- */
-static int gpio_stm32_read(struct device *dev, int access_op,
-			   u32_t pin, u32_t *value)
-{
-	const struct gpio_stm32_config *cfg = dev->config->config_info;
-	GPIO_TypeDef *gpio = (GPIO_TypeDef *)cfg->base;
-
-	if (access_op != GPIO_ACCESS_BY_PIN) {
-		return -ENOTSUP;
-	}
-
-	*value = (LL_GPIO_ReadInputPort(gpio) >> pin) & 0x1;
-
-	return 0;
-}
-
 static int gpio_stm32_pin_interrupt_configure(struct device *dev,
 		unsigned int pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
@@ -559,8 +518,6 @@ static int gpio_stm32_disable_callback(struct device *dev,
 
 static const struct gpio_driver_api gpio_stm32_driver = {
 	.config = gpio_stm32_config,
-	.write = gpio_stm32_write,
-	.read = gpio_stm32_read,
 	.port_get_raw = gpio_stm32_port_get_raw,
 	.port_set_masked_raw = gpio_stm32_port_set_masked_raw,
 	.port_set_bits_raw = gpio_stm32_port_set_bits_raw,

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -111,7 +111,6 @@ static inline int i2c_reg_write_word_be(struct device *dev, u16_t dev_addr,
 }
 
 static int sx1509b_config(struct device *dev,
-			  int access_op, /* unused */
 			  u32_t pin,
 			  int flags)
 {

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -111,8 +111,8 @@ static inline int i2c_reg_write_word_be(struct device *dev, u16_t dev_addr,
 }
 
 static int sx1509b_config(struct device *dev,
-			  u32_t pin,
-			  int flags)
+			  gpio_pin_t pin,
+			  gpio_flags_t flags)
 {
 	const struct sx1509b_config *cfg = dev->config->config_info;
 	struct sx1509b_drv_data *drv_data = dev->driver_data;
@@ -312,7 +312,7 @@ static int port_toggle_bits(struct device *dev,
 }
 
 static int pin_interrupt_configure(struct device *dev,
-				   unsigned int pin,
+				   gpio_pin_t pin,
 				   enum gpio_int_mode mode,
 				   enum gpio_int_trig trig)
 {
@@ -397,7 +397,7 @@ out:
 }
 
 static const struct gpio_driver_api api_table = {
-	.config = sx1509b_config,
+	.pin_configure = sx1509b_config,
 	.port_get_raw = port_get,
 	.port_set_masked_raw = port_set_masked,
 	.port_set_bits_raw = port_set_bits,

--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -29,7 +29,7 @@ extern DioIrqHandler *DioIrq[];
 struct sx1276_dio {
 	const char *port;
 	gpio_pin_t pin;
-	gpio_devicetree_flags_t flags;
+	gpio_dt_flags_t flags;
 };
 
 static struct sx1276_dio sx1276_dios[] =

--- a/drivers/sensor/adxl362/adxl362.h
+++ b/drivers/sensor/adxl362/adxl362.h
@@ -181,7 +181,7 @@ struct adxl362_config {
 #if defined(CONFIG_ADXL362_TRIGGER)
 	const char *gpio_port;
 	gpio_pin_t int_gpio;
-	gpio_devicetree_flags_t int_flags;
+	gpio_dt_flags_t int_flags;
 	u8_t int1_config;
 	u8_t int2_config;
 #endif

--- a/drivers/sensor/adxl372/adxl372.h
+++ b/drivers/sensor/adxl372/adxl372.h
@@ -326,7 +326,7 @@ struct adxl372_dev_config {
 #ifdef CONFIG_ADXL372_TRIGGER
 	const char *gpio_port;
 	gpio_pin_t int_gpio;
-	gpio_devicetree_flags_t int_flags;
+	gpio_dt_flags_t int_flags;
 #endif
 	bool max_peak_detect_mode;
 

--- a/drivers/sensor/amg88xx/amg88xx.h
+++ b/drivers/sensor/amg88xx/amg88xx.h
@@ -71,7 +71,7 @@ struct amg88xx_config {
 #ifdef CONFIG_AMG88XX_TRIGGER
 	char *gpio_name;
 	u8_t gpio_pin;
-	gpio_devicetree_flags_t gpio_flags;
+	gpio_dt_flags_t gpio_flags;
 #endif
 	u8_t i2c_address;
 };

--- a/drivers/sensor/bmc150_magn/bmc150_magn.h
+++ b/drivers/sensor/bmc150_magn/bmc150_magn.h
@@ -89,7 +89,7 @@ struct bmc150_magn_config {
 #if defined(CONFIG_BMC150_MAGN_TRIGGER_DRDY)
 	char *gpio_drdy_dev_name;
 	gpio_pin_t gpio_drdy_int_pin;
-	gpio_devicetree_flags_t gpio_drdy_int_flags;
+	gpio_dt_flags_t gpio_drdy_int_flags;
 #endif
 	u16_t i2c_slave_addr;
 	char *i2c_master_dev_name;

--- a/drivers/sensor/bmg160/bmg160.h
+++ b/drivers/sensor/bmg160/bmg160.h
@@ -183,7 +183,7 @@ struct bmg160_device_config {
 	u8_t i2c_speed;
 #ifdef CONFIG_BMG160_TRIGGER
 	gpio_pin_t int_pin;
-	gpio_devicetree_flags_t int_flags;
+	gpio_dt_flags_t int_flags;
 	const char *gpio_port;
 #endif
 };

--- a/drivers/sensor/bmi160/bmi160.h
+++ b/drivers/sensor/bmi160/bmi160.h
@@ -387,7 +387,7 @@ struct bmi160_device_config {
 #if defined(CONFIG_BMI160_TRIGGER)
 	const char *gpio_port;
 	gpio_pin_t int_pin;
-	gpio_devicetree_flags_t int_flags;
+	gpio_dt_flags_t int_flags;
 #endif
 };
 

--- a/drivers/sensor/dht/dht.h
+++ b/drivers/sensor/dht/dht.h
@@ -20,7 +20,7 @@ struct dht_data {
 
 struct dht_config {
 	const char *ctrl;
-	gpio_devicetree_flags_t flags;
+	gpio_dt_flags_t flags;
 	gpio_pin_t pin;
 };
 

--- a/drivers/sensor/fxas21002/fxas21002.h
+++ b/drivers/sensor/fxas21002/fxas21002.h
@@ -61,7 +61,7 @@ struct fxas21002_config {
 #ifdef CONFIG_FXAS21002_TRIGGER
 	char *gpio_name;
 	u8_t gpio_pin;
-	gpio_devicetree_flags_t gpio_flags;
+	gpio_dt_flags_t gpio_flags;
 #endif
 	u8_t i2c_address;
 	u8_t whoami;

--- a/drivers/sensor/fxos8700/fxos8700.h
+++ b/drivers/sensor/fxos8700/fxos8700.h
@@ -124,12 +124,12 @@ struct fxos8700_config {
 #ifdef CONFIG_FXOS8700_TRIGGER
 	char *gpio_name;
 	u8_t gpio_pin;
-	gpio_devicetree_flags_t gpio_flags;
+	gpio_dt_flags_t gpio_flags;
 #endif
 	u8_t i2c_address;
 	char *reset_name;
 	u8_t reset_pin;
-	gpio_devicetree_flags_t reset_flags;
+	gpio_dt_flags_t reset_flags;
 	enum fxos8700_mode mode;
 	enum fxos8700_power_mode power_mode;
 	enum fxos8700_range range;

--- a/drivers/sensor/lis2ds12/lis2ds12.h
+++ b/drivers/sensor/lis2ds12/lis2ds12.h
@@ -87,7 +87,7 @@ struct lis2ds12_config {
 #ifdef CONFIG_LIS2DS12_TRIGGER
 	const char *irq_port;
 	gpio_pin_t irq_pin;
-	gpio_devicetree_flags_t irq_flags;
+	gpio_dt_flags_t irq_flags;
 #endif
 };
 

--- a/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro.h
+++ b/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro.h
@@ -216,7 +216,7 @@ struct lsm9ds0_gyro_config {
 #if CONFIG_LSM9DS0_GYRO_TRIGGER_DRDY
 	char *gpio_drdy_dev_name;
 	gpio_pin_t gpio_drdy_int_pin;
-	gpio_devicetree_flags_t gpio_drdy_int_flags;
+	gpio_dt_flags_t gpio_drdy_int_flags;
 #endif
 };
 

--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -552,10 +552,6 @@ enum gpio_int_trig {
 
 struct gpio_driver_api {
 	int (*config)(struct device *port, int access_op, u32_t pin, int flags);
-	int (*write)(struct device *port, int access_op, u32_t pin,
-		     u32_t value);
-	int (*read)(struct device *port, int access_op, u32_t pin,
-		    u32_t *value);
 	int (*port_get_raw)(struct device *port, gpio_port_value_t *value);
 	int (*port_set_masked_raw)(struct device *port, gpio_port_pins_t mask,
 				   gpio_port_value_t value);

--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -428,7 +428,7 @@ typedef u8_t gpio_pin_t;
  * bits of the full flags field, so use a reduced-size type to record
  * that part of a GPIOS property.
  */
-typedef u8_t gpio_devicetree_flags_t;
+typedef u8_t gpio_dt_flags_t;
 
 /**
  * @brief Provides a type to hold GPIO configuration flags.

--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -416,8 +416,8 @@ typedef u32_t gpio_port_value_t;
 /**
  * @brief Provides a type to hold a GPIO pin index.
  *
- * This can be used to record the pin number from a devicetree GPIOS
- * property.
+ * This reduced-size type is sufficient to record a pin number,
+ * e.g. from a devicetree GPIOS property.
  */
 typedef u8_t gpio_pin_t;
 
@@ -560,11 +560,11 @@ struct gpio_driver_api {
 	u32_t (*get_pending_int)(struct device *dev);
 };
 
-__syscall int gpio_config(struct device *port, u32_t pin,
+__syscall int gpio_config(struct device *port, gpio_pin_t pin,
 			  gpio_flags_t flags);
 
 static inline int z_impl_gpio_config(struct device *port,
-				    u32_t pin, gpio_flags_t flags)
+				     gpio_pin_t pin, gpio_flags_t flags)
 {
 	const struct gpio_driver_api *api =
 		(const struct gpio_driver_api *)port->driver_api;
@@ -639,10 +639,12 @@ static inline int z_impl_gpio_disable_callback(struct device *port,
  * @retval -EWOULDBLOCK if operation would block.
  */
 __syscall int gpio_pin_interrupt_configure(struct device *port,
-		unsigned int pin, gpio_flags_t flags);
+					   gpio_pin_t pin,
+					   gpio_flags_t flags);
 
 static inline int z_impl_gpio_pin_interrupt_configure(struct device *port,
-		unsigned int pin, gpio_flags_t flags)
+						      gpio_pin_t pin,
+						      gpio_flags_t flags)
 {
 	const struct gpio_driver_api *api =
 		(const struct gpio_driver_api *)port->driver_api;
@@ -706,7 +708,7 @@ static inline int z_impl_gpio_pin_interrupt_configure(struct device *port,
  * @retval -EIO I/O error when accessing an external GPIO chip.
  * @retval -EWOULDBLOCK if operation would block.
  */
-static inline int gpio_pin_configure(struct device *port, u32_t pin,
+static inline int gpio_pin_configure(struct device *port, gpio_pin_t pin,
 				     gpio_flags_t flags)
 {
 	const struct gpio_driver_api *api =
@@ -1035,7 +1037,7 @@ static inline int gpio_port_set_clr_bits(struct device *port,
  * @retval -EIO I/O error when accessing an external GPIO chip.
  * @retval -EWOULDBLOCK if operation would block.
  */
-static inline int gpio_pin_get_raw(struct device *port, unsigned int pin)
+static inline int gpio_pin_get_raw(struct device *port, gpio_pin_t pin)
 {
 	const struct gpio_driver_config *const cfg =
 		(const struct gpio_driver_config *)port->config->config_info;
@@ -1073,7 +1075,7 @@ static inline int gpio_pin_get_raw(struct device *port, unsigned int pin)
  * @retval -EIO I/O error when accessing an external GPIO chip.
  * @retval -EWOULDBLOCK if operation would block.
  */
-static inline int gpio_pin_get(struct device *port, unsigned int pin)
+static inline int gpio_pin_get(struct device *port, gpio_pin_t pin)
 {
 	const struct gpio_driver_config *const cfg =
 		(const struct gpio_driver_config *)port->config->config_info;
@@ -1107,7 +1109,7 @@ static inline int gpio_pin_get(struct device *port, unsigned int pin)
  * @retval -EIO I/O error when accessing an external GPIO chip.
  * @retval -EWOULDBLOCK if operation would block.
  */
-static inline int gpio_pin_set_raw(struct device *port, unsigned int pin,
+static inline int gpio_pin_set_raw(struct device *port, gpio_pin_t pin,
 				   int value)
 {
 	const struct gpio_driver_config *const cfg =
@@ -1148,7 +1150,7 @@ static inline int gpio_pin_set_raw(struct device *port, unsigned int pin,
  * @retval -EIO I/O error when accessing an external GPIO chip.
  * @retval -EWOULDBLOCK if operation would block.
  */
-static inline int gpio_pin_set(struct device *port, unsigned int pin, int value)
+static inline int gpio_pin_set(struct device *port, gpio_pin_t pin, int value)
 {
 	const struct gpio_driver_config *const cfg =
 		(const struct gpio_driver_config *)port->config->config_info;
@@ -1176,7 +1178,7 @@ static inline int gpio_pin_set(struct device *port, unsigned int pin, int value)
  * @retval -EIO I/O error when accessing an external GPIO chip.
  * @retval -EWOULDBLOCK if operation would block.
  */
-static inline int gpio_pin_toggle(struct device *port, unsigned int pin)
+static inline int gpio_pin_toggle(struct device *port, gpio_pin_t pin)
 {
 	const struct gpio_driver_config *const cfg =
 		(const struct gpio_driver_config *)port->config->config_info;
@@ -1321,7 +1323,7 @@ static inline int gpio_remove_callback(struct device *port,
  */
 /* Deprecated in 2.2 release */
 __deprecated static inline int gpio_pin_enable_callback(struct device *port,
-							u32_t pin)
+							gpio_pin_t pin)
 {
 	return gpio_enable_callback(port, pin);
 }
@@ -1337,7 +1339,7 @@ __deprecated static inline int gpio_pin_enable_callback(struct device *port,
  */
 /* Deprecated in 2.2 release */
 __deprecated static inline int gpio_pin_disable_callback(struct device *port,
-							 u32_t pin)
+							 gpio_pin_t pin)
 {
 	return gpio_disable_callback(port, pin);
 }

--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2019-2020 Nordic Semiconductor ASA
  * Copyright (c) 2019 Piotr Mienkowski
  * Copyright (c) 2017 ARM Ltd
  * Copyright (c) 2015-2016 Intel Corporation.
@@ -544,19 +545,19 @@ enum gpio_int_trig {
 };
 
 struct gpio_driver_api {
-	int (*config)(struct device *port, u32_t pin, int flags);
+	int (*pin_configure)(struct device *port, gpio_pin_t pin, gpio_flags_t flags);
 	int (*port_get_raw)(struct device *port, gpio_port_value_t *value);
 	int (*port_set_masked_raw)(struct device *port, gpio_port_pins_t mask,
 				   gpio_port_value_t value);
 	int (*port_set_bits_raw)(struct device *port, gpio_port_pins_t pins);
 	int (*port_clear_bits_raw)(struct device *port, gpio_port_pins_t pins);
 	int (*port_toggle_bits)(struct device *port, gpio_port_pins_t pins);
-	int (*pin_interrupt_configure)(struct device *port, unsigned int pin,
+	int (*pin_interrupt_configure)(struct device *port, gpio_pin_t pin,
 				       enum gpio_int_mode, enum gpio_int_trig);
 	int (*manage_callback)(struct device *port, struct gpio_callback *cb,
 			       bool set);
-	int (*enable_callback)(struct device *port, u32_t pin);
-	int (*disable_callback)(struct device *port, u32_t pin);
+	int (*enable_callback)(struct device *port, gpio_pin_t pin);
+	int (*disable_callback)(struct device *port, gpio_pin_t pin);
 	u32_t (*get_pending_int)(struct device *dev);
 };
 
@@ -569,13 +570,13 @@ static inline int z_impl_gpio_config(struct device *port,
 	const struct gpio_driver_api *api =
 		(const struct gpio_driver_api *)port->driver_api;
 
-	return api->config(port, pin, (int)flags);
+	return api->pin_configure(port, pin, flags);
 }
 
-__syscall int gpio_enable_callback(struct device *port, u32_t pin);
+__syscall int gpio_enable_callback(struct device *port, gpio_pin_t pin);
 
 static inline int z_impl_gpio_enable_callback(struct device *port,
-					     u32_t pin)
+					     gpio_pin_t pin)
 {
 	const struct gpio_driver_api *api =
 		(const struct gpio_driver_api *)port->driver_api;
@@ -593,11 +594,10 @@ static inline int z_impl_gpio_enable_callback(struct device *port,
 	return api->enable_callback(port, pin);
 }
 
-__syscall int gpio_disable_callback(struct device *port,
-				    u32_t pin);
+__syscall int gpio_disable_callback(struct device *port, gpio_pin_t pin);
 
 static inline int z_impl_gpio_disable_callback(struct device *port,
-					      u32_t pin)
+					      gpio_pin_t pin)
 {
 	const struct gpio_driver_api *api =
 		(const struct gpio_driver_api *)port->driver_api;

--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -392,13 +392,6 @@ extern "C" {
 
 /** @} */
 
-/** @cond INTERNAL_HIDDEN */
-#define GPIO_ACCESS_BY_PIN 0
-#define GPIO_ACCESS_BY_PORT 1
-/**
- * @endcond
- */
-
 /**
  * @brief Identifies a set of pins associated with a port.
  *
@@ -551,7 +544,7 @@ enum gpio_int_trig {
 };
 
 struct gpio_driver_api {
-	int (*config)(struct device *port, int access_op, u32_t pin, int flags);
+	int (*config)(struct device *port, u32_t pin, int flags);
 	int (*port_get_raw)(struct device *port, gpio_port_value_t *value);
 	int (*port_set_masked_raw)(struct device *port, gpio_port_pins_t mask,
 				   gpio_port_value_t value);
@@ -567,16 +560,16 @@ struct gpio_driver_api {
 	u32_t (*get_pending_int)(struct device *dev);
 };
 
-__syscall int gpio_config(struct device *port, int access_op, u32_t pin,
+__syscall int gpio_config(struct device *port, u32_t pin,
 			  gpio_flags_t flags);
 
-static inline int z_impl_gpio_config(struct device *port, int access_op,
+static inline int z_impl_gpio_config(struct device *port,
 				    u32_t pin, gpio_flags_t flags)
 {
 	const struct gpio_driver_api *api =
 		(const struct gpio_driver_api *)port->driver_api;
 
-	return api->config(port, access_op, pin, (int)flags);
+	return api->config(port, pin, (int)flags);
 }
 
 __syscall int gpio_enable_callback(struct device *port, u32_t pin);
@@ -754,7 +747,7 @@ static inline int gpio_pin_configure(struct device *port, u32_t pin,
 	__ASSERT((cfg->port_pin_mask & (gpio_port_pins_t)BIT(pin)) != 0U,
 		 "Unsupported pin");
 
-	ret = gpio_config(port, GPIO_ACCESS_BY_PIN, pin, flags);
+	ret = gpio_config(port, pin, flags);
 	if (ret != 0) {
 		return ret;
 	}

--- a/subsys/disk/disk_access_spi_sdhc.c
+++ b/subsys/disk/disk_access_spi_sdhc.c
@@ -28,7 +28,7 @@ struct sdhc_spi_data {
 	struct spi_config cfg;
 	struct device *cs;
 	u32_t pin;
-	gpio_devicetree_flags_t flags;
+	gpio_dt_flags_t flags;
 
 	bool high_capacity;
 	u32_t sector_count;

--- a/subsys/disk/disk_access_usdhc.c
+++ b/subsys/disk/disk_access_usdhc.c
@@ -439,11 +439,11 @@ struct usdhc_client_info {
 struct usdhc_board_config {
 	struct device *pwr_gpio;
 	u32_t pwr_pin;
-	gpio_devicetree_flags_t pwr_flags;
+	gpio_dt_flags_t pwr_flags;
 
 	struct device *detect_gpio;
 	u32_t detect_pin;
-	gpio_devicetree_flags_t detect_flags;
+	gpio_dt_flags_t detect_flags;
 	struct gpio_callback detect_cb;
 };
 
@@ -2230,7 +2230,7 @@ static void usdhc_cd_gpio_cb(struct device *dev,
 }
 
 static int usdhc_cd_gpio_init(struct device *detect_gpio,
-	u32_t pin, gpio_devicetree_flags_t flags,
+	u32_t pin, gpio_dt_flags_t flags,
 	struct gpio_callback *callback)
 {
 	int ret;


### PR DESCRIPTION
Completes the updates to public and internal API to use typedefs, described in #21789.