### PR TITLE
stm32 devicetree: support for parity 

### DIFF
--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -19,6 +19,8 @@ struct uart_stm32_config {
 	struct stm32_pclken pclken;
 	/* initial hardware flow control, 1 for RTS/CTS */
 	bool hw_flow_control;
+	/* initial parity, 0 for none, 1 for odd, 2 for even */
+	int  parity;
 };
 
 /* driver data */

--- a/dts/bindings/serial/st,stm32-lpuart.yaml
+++ b/dts/bindings/serial/st,stm32-lpuart.yaml
@@ -13,3 +13,9 @@ properties:
 
     clocks:
       required: true
+
+    parity:
+      required: false
+      type: int
+      description: Configures the parity of the adapter. Value 0 for none, 1 for odd and 2 for even parity.
+      default: 0

--- a/dts/bindings/serial/st,stm32-uart.yaml
+++ b/dts/bindings/serial/st,stm32-uart.yaml
@@ -10,3 +10,9 @@ properties:
 
     interrupts:
       required: true
+
+    parity:
+      required: false
+      type: int
+      description: Configures the parity of the adapter. Value 0 for none, 1 for odd and 2 for even parity.
+      default: 0

--- a/dts/bindings/serial/st,stm32-usart.yaml
+++ b/dts/bindings/serial/st,stm32-usart.yaml
@@ -10,3 +10,9 @@ properties:
 
     interrupts:
       required: true
+
+    parity:
+      required: false
+      type: int
+      description: Configures the parity of the adapter. Value 0 for none, 1 for odd and 2 for even parity.
+      default: 0


### PR DESCRIPTION
Dear all,

I placed this pull request for as request of comments. I will gladly edit this futher, but before doing more work i would like to ask your opinion on the subject.

As far as i know, there is currently no way to define "default" UART parity from the device tree. I need the feature to work with certain (HC-05) bluetooth adapter that i want to keep in certain settings (15200 8E1 - same as stm32 system bootloader - whose settings cannot be modified).

Now i am pretty sure the setting should be at device tree, and actually not on stm32 bindings, but on general uart bindings. Now the pull on general bindings sounds so large i am sure i have no time, so this is suggestion of adding the support to stm32 only.

In addition this commit has edited fixup (`soc/arm/st_stm32/stm32f1/dts_fixup.h`)only for STM32F1 (that seems to be required for compile ok) - i am not sure are those fixup files meant for manual editing

Thanks for your time,
Pauli