### PR TITLE
kconfig/devicetree: Print path to headers when configuring

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -74,10 +74,11 @@ def main():
 
     write_flash(edt)
 
-    print("Devicetree configuration written to " + args.conf_out)
-
     conf_file.close()
     header_file.close()
+
+    print(f"Devicetree header saved to '{args.header_out}'")
+
 
 def parse_args():
     # Returns parsed command-line arguments

--- a/scripts/kconfig/guiconfig.py
+++ b/scripts/kconfig/guiconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2019, Nordic Semiconductor ASA and Ulf Magnusson
 # SPDX-License-Identifier: ISC

--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -82,7 +82,7 @@ def main():
 
     # Write the merged configuration and the C header
     print(kconf.write_config(args.config_out))
-    kconf.write_autoconf(args.header_out)
+    print(kconf.write_autoconf(args.header_out))
 
     # Write the list of parsed Kconfig files to a file
     write_kconfig_filenames(kconf, args.kconfig_list_out)

--- a/scripts/kconfig/menuconfig.py
+++ b/scripts/kconfig/menuconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2018-2019, Nordic Semiconductor ASA and Ulf Magnusson
 # SPDX-License-Identifier: ISC


### PR DESCRIPTION
Change the output during CMake configure from

    Devicetree configuration written to .../devicetree.conf
    Parsing /home/ulf/z/z/Kconfig
    Loaded configuration '.../frdm_kw41z_defconfig'
    Merged configuration '.../prj.conf'
    Configuration saved to '.../.config'

to

    Devicetree header saved to '.../devicetree_unfixed.h'
    Parsing /home/ulf/z/z/Kconfig
    Loaded configuration '.../frdm_kw41z_defconfig'
    Merged configuration '.../prj.conf'
    Configuration saved to '.../.config'
    Kconfig header saved to '.../autoconf.h'

devicetree_unfixed.h is more useful to be aware of than devicetree.conf
(still hoping we can get rid of it at some point), and seeing the
Kconfig header clarifies things to.

"Saved" instead of "written" for consistency. Maybe it could say
"Kconfig configuration" instead of "configuration" too, though it gets a
bit spammy in other contexts where the message shows up.

Updates Kconfiglib (and menuconfig/guiconfig, just to sync) to upstream
revision 061e71f7d7, to get this commit in, which is used to print the
header path:

    Return a message from Kconfig.write_autoconf()

    Like for Kconfig.write_config() and Kconfig.write_min_config(),
    return a string from Kconfig.write_autoconf() with a message saying
    that the header got saved, or that there were no changes to it. Can
    be handy in tools.

    Also make the "no change" message for the various files more
    specific, by mentioning what type of file it is (configuration,
    header, etc.)

    Return True/False from Kconfig._write_if_changed() to indicate if
    the file was updated. This also allows it to be reused in
    Kconfig.write_min_config().