### PR TITLE
dts: added cryptocell to the dts file for nRF9160

### DIFF
--- a/dts/arm/nordic/nrf9160.dtsi
+++ b/dts/arm/nordic/nrf9160.dtsi
@@ -63,6 +63,8 @@
 		timer-0 = &timer0;
 		timer-1 = &timer1;
 		timer-2 = &timer2;
+		cc310 = &cryptocell;
+		arm-cryptocell-310 = &cryptocell310;
 	};
 
 	soc {
@@ -80,6 +82,21 @@
 		};
 
 		/* Additional Secure peripherals */
+		cryptocell: crypto@50840000 {
+			compatible = "nordic,nrf-cc310";
+			reg = <0x50840000 0x1000>;
+			label = "CRYPTOCELL";
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			cryptocell310: crypto@50841000 {
+				compatible = "arm,cryptocell-310";
+				reg = <0x50841000 0x1000>;
+				interrupts = <64 1>;
+				label = "CRYPTOCELL310";
+			};
+		};
+
 		gpiote: gpiote@5000d000 {
 			compatible = "nordic,nrf-gpiote";
 			reg = <0x5000d000 0x1000>;


### PR DESCRIPTION
This commit adds cryptocell definitions to the nRF9160 dts file.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>