### PR TITLE
manifest: mcuboot upgrade

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -77,7 +77,7 @@ manifest:
       revision: 3776c158fe138a72c97c187e4d31c81c37884be9
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: pull/5/head
+      revision: 36e9029ff01d1e64a77d2e2a0bb9e2cc75ab97c8
       path: bootloader/mcuboot
     - name: mcumgr
       revision: d4e97cd4fc80ff949415062b1c83fd42929e8fe4


### PR DESCRIPTION
Upgraded mcuboot to version which have following issue
fixed:
Redundant 'source "$(ZEPHYR_BASE)/Kconfig.zephyr"
in 'boot/zephyr/Kconfig'
https://github.com/JuulLabs-OSS/mcuboot/pull/649

Within this version upgrade the default swap algorithm for nRF devices
was changed to `move swap` instead of `swap using scratch`.
https://github.com/JuulLabs-OSS/mcuboot/pull/645

Moved mcuboot code to non-deprecated GPIO API if it available.  This avoids
deprecation warnings in the build.
https://github.com/JuulLabs-OSS/mcuboot/pull/648

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>