### PR TITLE
toolchain: gcc: respect existing deprecated macro define

### DIFF
--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -209,7 +209,9 @@ do {                                                                    \
 /* Be *very* careful with this, you cannot filter out with -wno-deprecated,
  * which has implications for -Werror
  */
+#ifndef __DEPRECATED_MACRO
 #define __DEPRECATED_MACRO _Pragma("GCC warning \"Macro is deprecated\"")
+#endif
 
 /* These macros allow having ARM asm functions callable from thumb */
 


### PR DESCRIPTION
The __deprecated symbol can be pre-defined to avoid warnings of use of deprecated API in tests of that API.  Enable that same feature for macros that are deprecated.

This supports topic-gpio, where API is being deprecated but the current behavior cannot be implemented with the information provided to the deprecated API.  To support true deprecation this means the old implementation has to remain in-tree for the deprecation period, even though nothing in tree references it.  Consequently we need the ability to test the old API without causing CI to go into conniptions.