### PR TITLE
tests: net: mqtt: Fix failure at disconnect

### DIFF
--- a/tests/net/lib/mqtt_publisher/src/test_mqtt_publish.c
+++ b/tests/net/lib/mqtt_publisher/src/test_mqtt_publish.c
@@ -288,7 +288,6 @@ static int test_disconnect(void)
 	}
 
 	wait(APP_SLEEP_MSECS);
-	mqtt_input(&client_ctx);
 
 	return TC_PASS;
 }

--- a/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
+++ b/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
@@ -413,10 +413,6 @@ static int test_disconnect(void)
 	}
 
 	wait(APP_SLEEP_MSECS);
-	rc = mqtt_input(&client_ctx);
-	if (rc != 0) {
-		return TC_FAIL;
-	}
 
 	if (connected) {
 		return TC_FAIL;

--- a/tests/net/lib/mqtt_subscriber/src/test_mqtt_subscribe.c
+++ b/tests/net/lib/mqtt_subscriber/src/test_mqtt_subscribe.c
@@ -296,7 +296,6 @@ static int test_disconnect(void)
 	}
 
 	wait(APP_SLEEP_MSECS);
-	mqtt_input(&client_ctx);
 
 	return TC_PASS;
 }


### PR DESCRIPTION
It's no longer needed to call `mqtt_input` after `mqtt_disconnect`.
Doing this will actually return an error as the MQTT connection is no
longer active after calling `mqtt_disconnect`.

Fixes #22360

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>