### PR TITLE
dts: stm32f3: Remap USB IRQ to avoid conflict with CAN

### DIFF
--- a/drivers/clock_control/clock_stm32f0_f3.c
+++ b/drivers/clock_control/clock_stm32f0_f3.c
@@ -77,6 +77,13 @@ void config_enable_default_clocks(void)
 	/* Enable System Configuration Controller clock. */
 	LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_SYSCFG);
 #endif
+#else
+#if defined(CONFIG_USB_DC_STM32) && defined(SYSCFG_CFGR1_USB_IT_RMP)
+	/* Enable System Configuration Controller clock. */
+	/* SYSCFG is required to remap IRQ to avoid conflicts with CAN */
+	/* cf §14.1.3, RM0316 */
+	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_SYSCFG);
+#endif
 #endif /* !CONFIG_SOC_SERIES_STM32F3X */
 }
 

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -386,6 +386,20 @@ int usb_dc_attach(void)
 
 	LOG_DBG("");
 
+#ifdef SYSCFG_CFGR1_USB_IT_RMP
+	/*
+	 * STM32F302/F303: USB IRQ collides with CAN_1 IRQ (§14.1.3, RM0316)
+	 * Remap IRQ by default to enable use of both IPs simultaneoulsy
+	 * This should be done before calling any HAL function
+	 */
+	if (LL_APB2_GRP1_IsEnabledClock(LL_APB2_GRP1_PERIPH_SYSCFG)) {
+		LL_SYSCFG_EnableRemapIT_USB();
+	} else {
+		LOG_ERR("System Configuration Controller clock is "
+			"disabled. Unable to enable IRQ remapping.");
+	}
+#endif
+
 	/*
 	 * For STM32F0 series SoCs on QFN28 and TSSOP20 packages enable PIN
 	 * pair PA11/12 mapped instead of PA9/10 (e.g. stm32f070x6)
@@ -395,7 +409,7 @@ int usb_dc_attach(void)
 		LL_SYSCFG_EnablePinRemap();
 	} else {
 		LOG_ERR("System Configuration Controller clock is "
-			"disable. Unable to enable pin remapping."
+			"disabled. Unable to enable pin remapping.");
 	}
 #endif
 

--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -8,6 +8,11 @@
 
 / {
 	soc {
+		usb: usb@40005c00 {
+			/* Remap USB_LP IRQ to enable use with CAN_1 */
+			interrupts = <75 0>;
+		};
+
 		i2c2: i2c@40005800 {
 			compatible = "st,stm32-i2c-v2";
 			clock-frequency = <I2C_BITRATE_STANDARD>;

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -8,6 +8,11 @@
 
 / {
 	soc {
+		usb: usb@40005c00 {
+			/* Remap USB_LP IRQ to enable use with CAN_1 */
+			interrupts = <75 0>;
+		};
+
 		i2c2: i2c@40005800 {
 			compatible = "st,stm32-i2c-v2";
 			clock-frequency = <I2C_BITRATE_STANDARD>;


### PR DESCRIPTION
On stm32f302/3 series, USB and CAN_1 share same IRQ lines.
To use USB and CAN_1 together, USB IRQ could be remap to other
line numbers, on which there is no conflict.
Remap the USB IRQ lines by default:
-Assign remap number in matching dtsi files
-Perform remap in usb driver init

Additionally, fix compilation issue in usb driver.

Fixes #22343

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>