### PR TITLE
Fix notify connected invalid

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1692,8 +1692,13 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 			k_poll_signal_raise(&conn_change, 0);
 			/* The last ref will be dropped during cleanup */
 		} else if (old_state == BT_CONN_CONNECT) {
-			/* conn->err will be set in this case */
-			notify_connected(conn);
+			/* LE Create Connection command failed. This might be
+			 * directly from the API, don't notify application in
+			 * this case.
+			 */
+			if (conn->err) {
+				notify_connected(conn);
+			}
 			bt_conn_unref(conn);
 		} else if (old_state == BT_CONN_CONNECT_SCAN) {
 			/* this indicate LE Create Connection with peer address
@@ -2142,7 +2147,7 @@ int bt_conn_create_auto_le(const struct bt_le_conn_param *param)
 	err = bt_le_create_conn(conn);
 	if (err) {
 		BT_ERR("Failed to start whitelist scan");
-
+		conn->err = 0;
 		bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
 		bt_conn_unref(conn);
 		return err;
@@ -2257,6 +2262,7 @@ struct bt_conn *bt_conn_create_le(const bt_addr_le_t *peer,
 	bt_conn_set_state(conn, BT_CONN_CONNECT);
 
 	if (bt_le_create_conn(conn)) {
+		conn->err = 0;
 		bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
 		bt_conn_unref(conn);
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -914,6 +914,7 @@ int bt_le_create_conn(const struct bt_conn *conn)
 	}
 
 	cp = net_buf_add(buf, sizeof(*cp));
+	memset(cp, 0, sizeof(*cp));
 	cp->own_addr_type = own_addr_type;
 
 	if (use_filter) {


### PR DESCRIPTION
This is bugfix for 2 regressions introduced the recently. One of the bugs oncovered the other.

Fix problem where application was notified about a new connection being
established, but no connection has actually been made.
This occurred because the LE Create Connection command failed directly
from the API, in which case the state transition thinks the err is valid
and always notifies the application.

Introduced by:
6c1f52d for bt_conn_create_le
e9eebf0 for bt_conn_create_auto_le.

Fix LE Create Connection command giving out of range parameters to the
controller, this came back as 0x30 (Out of Range Parameters) status code
on the command from the controller.
This appears to be the min and max CE parameters in the command.
Revert back memset from 137f704