### PR TITLE
drivers/adc: stm32: Don't enable ADC instance by default in driver

### DIFF
--- a/boards/arm/nucleo_f091rc/Kconfig.defconfig
+++ b/boards/arm/nucleo_f091rc/Kconfig.defconfig
@@ -38,4 +38,11 @@ config SPI_STM32_INTERRUPT
 
 endif # SPI
 
+if ADC
+
+config ADC_1
+	default y
+
+endif # ADC
+
 endif # BOARD_NUCLEO_F091RC

--- a/boards/arm/nucleo_f103rb/Kconfig.defconfig
+++ b/boards/arm/nucleo_f103rb/Kconfig.defconfig
@@ -32,4 +32,11 @@ config SPI_2
 
 endif
 
+if ADC
+
+config ADC_1
+	default y
+
+endif # ADC
+
 endif # BOARD_NUCLEO_F103RB

--- a/boards/arm/nucleo_f207zg/Kconfig.defconfig
+++ b/boards/arm/nucleo_f207zg/Kconfig.defconfig
@@ -32,4 +32,11 @@ config UART_6
 
 endif # SERIAL
 
+if ADC
+
+config ADC_1
+	default y
+
+endif # ADC
+
 endif # BOARD_NUCLEO_F207ZG

--- a/boards/arm/nucleo_f302r8/Kconfig.defconfig
+++ b/boards/arm/nucleo_f302r8/Kconfig.defconfig
@@ -43,4 +43,11 @@ config PWM_STM32_2
 
 endif # PWM
 
+if ADC
+
+config ADC_1
+	default y
+
+endif # ADC
+
 endif # BOARD_NUCLEO_F302R8

--- a/boards/arm/nucleo_f401re/Kconfig.defconfig
+++ b/boards/arm/nucleo_f401re/Kconfig.defconfig
@@ -53,4 +53,11 @@ config IWDG_STM32
 
 endif # WATCHDOG
 
+if ADC
+
+config ADC_1
+	default y
+
+endif # ADC
+
 endif # BOARD_NUCLEO_F401RE

--- a/boards/arm/nucleo_f746zg/Kconfig.defconfig
+++ b/boards/arm/nucleo_f746zg/Kconfig.defconfig
@@ -60,4 +60,11 @@ config CAN_1
 
 endif # CAN
 
+if ADC
+
+config ADC_1
+	default y
+
+endif # ADC
+
 endif # BOARD_NUCLEO_F746ZG

--- a/boards/arm/nucleo_f767zi/Kconfig.defconfig
+++ b/boards/arm/nucleo_f767zi/Kconfig.defconfig
@@ -60,4 +60,11 @@ config CAN_1
 
 endif # CAN
 
+if ADC
+
+config ADC_1
+	default y
+
+endif # ADC
+
 endif # BOARD_NUCLEO_F767ZI

--- a/boards/arm/nucleo_l073rz/Kconfig.defconfig
+++ b/boards/arm/nucleo_l073rz/Kconfig.defconfig
@@ -32,4 +32,11 @@ config SPI_STM32_INTERRUPT
 
 endif # SPI
 
+if ADC
+
+config ADC_1
+	default y
+
+endif # ADC
+
 endif # BOARD_NUCLEO_L073RZ

--- a/boards/arm/nucleo_l476rg/Kconfig.defconfig
+++ b/boards/arm/nucleo_l476rg/Kconfig.defconfig
@@ -40,4 +40,11 @@ config PWM_STM32_2
 
 endif # PWM
 
+if ADC
+
+config ADC_1
+	default y
+
+endif # ADC
+
 endif # BOARD_NUCLEO_L476RG

--- a/drivers/adc/Kconfig.stm32
+++ b/drivers/adc/Kconfig.stm32
@@ -5,18 +5,8 @@
 # Copyright (c) 2019 Song Qiang <songqiang1304521@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig ADC_STM32
+config ADC_STM32
 	bool "STM32 ADC driver"
 	depends on SOC_FAMILY_STM32
 	help
 	  Enable the driver implementation for the stm32xx ADC
-
-if ADC_STM32
-
-config ADC_1
-	prompt "ADC1"
-	default y
-	help
-	  Enable ADC1
-
-endif # ADC_STM32


### PR DESCRIPTION
ADC_1 peripheral instance was enabled by default in driver.
This is not the usual way to enable peripheral instances, as it
makes board configuration unclear.
Move activation in boards that are declaring ADC support.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>