### PR TITLE
stm32: clock control: fix on H7 + style edit

### DIFF
--- a/boards/arm/stm32h747i_disco/Kconfig.defconfig
+++ b/boards/arm/stm32h747i_disco/Kconfig.defconfig
@@ -50,6 +50,7 @@ endif # STM32H7_DUAL_CORE
 
 if UART_CONSOLE
 
+# Change this to assign UART_1 (console) to M4 core
 config UART_1
 	default y if BOARD_STM32H747I_DISCO_M7
 
@@ -57,6 +58,7 @@ endif # UART_CONSOLE
 
 if SERIAL
 
+# Change this to assign UART_8 to M4 core
 config UART_8
 	default y if BOARD_STM32H747I_DISCO_M7
 

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m4.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m4.dts
@@ -41,3 +41,13 @@
 		sw0 = &joy_center;
 	};
 };
+
+&usart1 {
+	current-speed = <115200>;
+	/* status = "okay"; */
+};
+
+&uart8 {
+	current-speed = <115200>;
+	/* status = "okay"; */
+};

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m4_defconfig
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m4_defconfig
@@ -13,3 +13,11 @@ CONFIG_GPIO=y
 
 # clock configuration
 CONFIG_CLOCK_CONTROL=y
+
+# By default SERIAL peripherals are assigned to m7
+
+# enable uart driver
+#CONFIG_SERIAL=y
+# console
+#CONFIG_CONSOLE=y
+#CONFIG_UART_CONSOLE=y

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7_defconfig
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7_defconfig
@@ -29,9 +29,10 @@ CONFIG_CLOCK_STM32_PLL_P_DIVISOR=2
 CONFIG_CLOCK_STM32_PLL_Q_DIVISOR=4
 CONFIG_CLOCK_STM32_PLL_R_DIVISOR=2
 
+# Disable following to assign serial ports to m4 core
+
 # enable uart driver
 CONFIG_SERIAL=y
-
 # console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -350,11 +350,13 @@ static int stm32_clock_control_init(struct device *dev)
 	LL_RCC_MSI_Disable();
 
 #elif CONFIG_CLOCK_STM32_PLL_SRC_HSE
-	int hse_bypass = LL_UTILS_HSEBYPASS_OFF;
+	int hse_bypass;
 
-#ifdef CONFIG_CLOCK_STM32_HSE_BYPASS
-	hse_bypass = LL_UTILS_HSEBYPASS_ON;
-#endif /* CONFIG_CLOCK_STM32_HSE_BYPASS */
+	if (IS_ENABLED(CONFIG_CLOCK_STM32_HSE_BYPASS)) {
+		hse_bypass = LL_UTILS_HSEBYPASS_ON;
+	} else {
+		hse_bypass = LL_UTILS_HSEBYPASS_OFF;
+	}
 
 	/* Switch to PLL with HSE as clock source */
 	LL_PLL_ConfigSystemClock_HSE(
@@ -376,11 +378,11 @@ static int stm32_clock_control_init(struct device *dev)
 	/* Enable HSE if not enabled */
 	if (LL_RCC_HSE_IsReady() != 1) {
 		/* Check if need to enable HSE bypass feature or not */
-#ifdef CONFIG_CLOCK_STM32_HSE_BYPASS
-		LL_RCC_HSE_EnableBypass();
-#else
-		LL_RCC_HSE_DisableBypass();
-#endif /* CONFIG_CLOCK_STM32_HSE_BYPASS */
+		if (IS_ENABLED(CONFIG_CLOCK_STM32_HSE_BYPASS)) {
+			LL_RCC_HSE_EnableBypass();
+		} else {
+			LL_RCC_HSE_DisableBypass();
+		}
 
 		/* Enable HSE */
 		LL_RCC_HSE_Enable();

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -217,11 +217,6 @@ static int stm32_clock_control_init(struct device *dev)
 #if !defined(CONFIG_CPU_CORTEX_M4)
 
 #ifdef CONFIG_CLOCK_STM32_SYSCLK_SRC_PLL
-	/* Power Configuration */
-	LL_PWR_ConfigSupply(LL_PWR_DIRECT_SMPS_SUPPLY);
-	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
-	while (LL_PWR_IsActiveFlag_VOS() == 0) {
-	}
 
 #ifdef CONFIG_CLOCK_STM32_PLL_SRC_HSE
 

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -220,11 +220,11 @@ static int stm32_clock_control_init(struct device *dev)
 
 #ifdef CONFIG_CLOCK_STM32_PLL_SRC_HSE
 
-#ifdef CONFIG_CLOCK_STM32_HSE_BYPASS
-	LL_RCC_HSE_EnableBypass();
-#else
-	LL_RCC_HSE_DisableBypass();
-#endif /* CONFIG_CLOCK_STM32_HSE_BYPASS */
+	if (IS_ENABLED(CONFIG_CLOCK_STM32_HSE_BYPASS)) {
+		LL_RCC_HSE_EnableBypass();
+	} else {
+		LL_RCC_HSE_DisableBypass();
+	}
 
 	/* Enable HSE oscillator */
 	LL_RCC_HSE_Enable();

--- a/soc/arm/st_stm32/stm32h7/soc_m7.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m7.c
@@ -85,6 +85,14 @@ static int stm32h7_init(struct device *arg)
 	/* At reset, system core clock is set to 64 MHz from HSI */
 	SystemCoreClock = 64000000;
 
+	/* Power Configuration */
+#ifdef SMPS
+	LL_PWR_ConfigSupply(LL_PWR_DIRECT_SMPS_SUPPLY);
+#endif
+	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
+	while (LL_PWR_IsActiveFlag_VOS() == 0) {
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
soc: stm32h7: Move PWR init code in soc init function
    
  Move PWR init code out of clock control driver and
  put SMPS related function under SMPS condition as it
  is not supported by all soc variants of the series.
    
Fixes #22363

Additionally:
Rework CONFIG_CLOCK_STM32_HSE_BYPASS related code to make
this part of the code more readable.
    
Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>