### PR TITLE
boards: pca10056: remove conflicting spi2 node

### DIFF
--- a/boards/arm/nrf52840_pca10056/Kconfig.defconfig
+++ b/boards/arm/nrf52840_pca10056/Kconfig.defconfig
@@ -34,9 +34,6 @@ if SPI
 config SPI_1
 	default y
 
-config SPI_2
-	default y
-
 config SPI_3
 	default y
 

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -186,10 +186,10 @@ arduino_i2c: &i2c0 {
 
 &spi2 {
 	compatible = "nordic,nrf-spi";
-	status = "okay";
-	sck-pin = <42>;
-	mosi-pin = <43>;
-	miso-pin = <44>;
+	status = "disabled";
+	sck-pin = <19>;
+	mosi-pin = <20>;
+	miso-pin = <21>;
 };
 
 &qspi {


### PR DESCRIPTION
Commit 5b4f4253c196
("drivers: flash: add Nordic JEDEC QSPI NOR flash driver")'
added SPI2 pin properties wich are in conflict with CS pin
of the SPI3, pin D9, and pin D8 routed to Arduino connector
of the pca10056 board. This change has broken any shield
support on this board. Remove conflicting SPI2 node.