### PR TITLE
[TOPIC-GPIO] drivers: gdew075t7: convert to new GPIO API

### DIFF
--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdew075t7.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdew075t7.overlay
@@ -15,9 +15,9 @@
 		reg = <0>;
 		width = <800>;
 		height = <480>;
-		dc-gpios = <&arduino_header 15 0>;	/* D9 */
-		reset-gpios = <&arduino_header 14 0>;	/* D8 */
-		busy-gpios = <&arduino_header 13 0>;	/* D7 */
+		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
+		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
+		busy-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>;	/* D7 */
 		pwr = [07 07 3f 3f];
 		softstart = [17 17 17 17];
 		cdi = <07>;

--- a/dts/bindings/display/gooddisplay,gd7965.yaml
+++ b/dts/bindings/display/gooddisplay,gd7965.yaml
@@ -21,14 +21,29 @@ properties:
     reset-gpios:
       type: phandle-array
       required: true
+      description: RESET pin.
+
+        The RESET pin of GD7965 is active low.
+        If connected directly the MCU pin should be configured
+        as active low.
 
     dc-gpios:
       type: phandle-array
       required: true
+      description: DC pin.
+
+        The DC pin of GD7965 is active low (transmission command byte).
+        If connected directly the MCU pin should be configured
+        as active low.
 
     busy-gpios:
       type: phandle-array
       required: true
+      description: BUSY pin.
+
+        The BUSY pin of GD7965 is active low.
+        If connected directly the MCU pin should be configured
+        as active low.
 
     pwr:
       type: uint8-array


### PR DESCRIPTION
Convert GD7965 controller driver to new GPIO API. Based on #22033