### PR TITLE
doc: update gsg with sdk v0.11.0

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -304,15 +304,15 @@ including: compiler, assembler, linker, and their dependencies.
          .. code-block:: bash
 
             cd ~
-            wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.10.3/zephyr-sdk-0.10.3-setup.run
+            wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.11.0/zephyr-sdk-0.11.0-setup.run
 
       #. Run the installation binary, installing the SDK in your home
-         folder :file:`~/zephyr-sdk-0.10.3`:
+         folder :file:`~/zephyr-sdk-0.11.0`:
 
          .. code-block:: bash
 
-            chmod +x zephyr-sdk-0.10.3-setup.run
-            ./zephyr-sdk-0.10.3-setup.run -- -d ~/zephyr-sdk-0.10.3
+            chmod +x zephyr-sdk-0.11.0-setup.run
+            ./zephyr-sdk-0.11.0-setup.run -- -d ~/zephyr-sdk-0.11.0
 
       #. Set environment variables to let the build system know where to
          find the toolchain programs:
@@ -320,7 +320,7 @@ including: compiler, assembler, linker, and their dependencies.
          .. code-block:: bash
 
             export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-            export ZEPHYR_SDK_INSTALL_DIR=~/zephyr-sdk-0.10.3
+            export ZEPHYR_SDK_INSTALL_DIR=~/zephyr-sdk-0.11.0
 
       The SDK contains a udev rules file that provides information
       needed to identify boards and grant hardware access permission to flash

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -236,19 +236,19 @@ Follow these steps to install the Zephyr SDK:
 
    .. code-block:: console
 
-      wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.10.3/zephyr-sdk-0.10.3-setup.run
+      wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.11.0/zephyr-sdk-0.11.0-setup.run
 
-   (You can change *0.10.3* to another version if needed; the `Zephyr
+   (You can change *0.11.0* to another version if needed; the `Zephyr
    Downloads`_ page contains all available SDK releases.)
 
 #. Run the installation binary, installing the SDK at
-   :file:`~/zephyr-sdk-0.10.3`:
+   :file:`~/zephyr-sdk-0.11.0`:
 
    .. code-block:: console
 
       cd <sdk download directory>
-      chmod +x zephyr-sdk-0.10.3-setup.run
-      ./zephyr-sdk-0.10.3-setup.run -- -d ~/zephyr-sdk-0.10.3
+      chmod +x zephyr-sdk-0.11.0-setup.run
+      ./zephyr-sdk-0.11.0-setup.run -- -d ~/zephyr-sdk-0.11.0
 
    You can pick another directory if you want. If this fails, make sure
    Zephyr's dependencies were installed as described in `Install Requirements
@@ -257,7 +257,7 @@ Follow these steps to install the Zephyr SDK:
 #. Set these :ref:`environment variables <env_vars>`:
 
    - set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``zephyr``
-   - set :envvar:`ZEPHYR_SDK_INSTALL_DIR` to :file:`$HOME/zephyr-sdk-0.10.3`
+   - set :envvar:`ZEPHYR_SDK_INSTALL_DIR` to :file:`$HOME/zephyr-sdk-0.11.0`
      (or wherever you chose to install the SDK)
 
 If you ever want to uninstall the SDK, just remove the directory where you


### PR DESCRIPTION
We are now using 0.11.0, so update the getting started guide.