### PR TITLE
subsys/logging: Fix xtensa simcall assembly

### DIFF
--- a/subsys/logging/log_backend_xtensa_sim.c
+++ b/subsys/logging/log_backend_xtensa_sim.c
@@ -22,20 +22,15 @@ static u8_t buf[CHAR_BUF_SIZE];
 
 static int char_out(u8_t *data, size_t length, void *ctx)
 {
-	register int a1 __asm__ ("a2") = SYS_write;
-	register int b1 __asm__ ("a3") = 1;
-	register int c1 __asm__ ("a4") = (int) data;
-	register int d1 __asm__ ("a5") = length;
-	register int ret_val __asm__ ("a2");
-	register int ret_err __asm__ ("a3");
+	register int a2 __asm__ ("a2") = SYS_write;
+	register int a3 __asm__ ("a3") = 1;
+	register int a4 __asm__ ("a4") = (int) data;
+	register int a5 __asm__ ("a5") = length;
 
-	__asm__ __volatile__ (
-			"simcall\n"
-			"mov %0, a2\n"
-			"mov %1, a3\n"
-			: "=a" (ret_val), "=a" (ret_err), "+r"(a1), "+r"(b1)
-			: "r"(c1), "r"(d1)
-			: "memory");
+	__asm__ volatile("simcall"
+			 : "=a"(a2), "=a"(a3)
+			 : "a"(a2), "a"(a3), "a"(a4), "a"(a5));
+
 	return length;
 }
 


### PR DESCRIPTION
This construction was causing errors with recent gccs.  If you look
carefully, it's generating the sequence:

  simcall
  mov a2, a2
  mov a3, a3

...which is nonsensical.  And now gcc is complaining about it with:

    subsys/logging/log_backend_xtensa_sim.c:44:2:
        error: invalid hard register usage between output operands

Just emit a single simcall instruction and let the assembly
constraints do their job.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>