### PR TITLE
fix the bugs in interrupt handling and mpu buffer validate

### DIFF
--- a/arch/arc/core/fast_irq.S
+++ b/arch/arc/core/fast_irq.S
@@ -207,12 +207,36 @@ _firq_reschedule:
 	 * point, so when switching back to register bank 0, it will contain the
 	 * registers from the interrupted thread.
 	 */
-
+#if defined(CONFIG_USERSPACE)
+/* when USERSPACE is configured, here need to consider the case where firq comes
+ * out in user mode, according to ARCv2 ISA and nsim, the following micro ops
+ * will be executed:
+ *	sp<-reg bank1'sp
+ *      switch between sp and _ARC_V2_USER_SP
+ * then:
+ *      sp is the sp of kernel stack of interrupted thread
+ *      _ARC_V2_USER_SP is reg bank1'sp
+ *      the sp of user stack of interrupted thread is reg bank0'sp
+ * if firq comes out in kernel mode, the following micro ops will be executed:
+ *      sp<-reg bank'sp
+ * so, sw needs to do necessary handling to set up the correct sp
+ */
+	lr r0, [_ARC_V2_AUX_IRQ_ACT]
+	bbit0 r0, 31, _firq_from_kernel
+	aex sp, [_ARC_V2_USER_SP]
+	lr r0, [_ARC_V2_STATUS32]
+	and r0, r0, ~_ARC_V2_STATUS32_RB(7)
+	kflag r0
+	aex sp, [_ARC_V2_USER_SP]
+	b _firq_create_irq_stack_frame
+_firq_from_kernel:
+#endif
 	/* chose register bank #0 */
 	lr r0, [_ARC_V2_STATUS32]
 	and r0, r0, ~_ARC_V2_STATUS32_RB(7)
 	kflag r0
 
+_firq_create_irq_stack_frame:
 	/* we're back on the outgoing thread's stack */
 	_create_irq_stack_frame
 
@@ -225,6 +249,7 @@ _firq_reschedule:
 	st_s r0, [sp, ___isf_t_status32_OFFSET]
 
 	st ilink, [sp, ___isf_t_pc_OFFSET] /* ilink into pc */
+
 #ifdef CONFIG_SMP
 /*
  * load r0, r1 from irq stack
@@ -233,6 +258,16 @@ _firq_reschedule:
 	ld r0, [r2, -4]
 	ld r1, [r2, -8]
 #endif
+#endif
+
+#if defined(CONFIG_USERSPACE)
+/*
+ * need to remember the user/kernel status of interrupted thread, will be
+ * restored when thread switched back
+ */
+	lr r3, [_ARC_V2_AUX_IRQ_ACT]
+	and r3, r3, 0x80000000
+	push_s r3
 #endif
 
 #ifdef CONFIG_SMP
@@ -299,6 +334,16 @@ _firq_return_from_coop:
 .balign 4
 _firq_return_from_rirq:
 _firq_return_from_firq:
+
+#if defined(CONFIG_USERSPACE)
+/*
+ * need to recover the user/kernel status of interrupted thread
+ */
+	pop_s r3
+	lr r2, [_ARC_V2_AUX_IRQ_ACT]
+	or r2, r2, r3
+	sr r2, [_ARC_V2_AUX_IRQ_ACT]
+#endif
 
 	_pop_irq_stack_frame
 

--- a/arch/arc/core/mpu/arc_mpu_v3_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_v3_internal.h
@@ -656,7 +656,7 @@ int arc_core_mpu_get_max_domain_partition_regions(void)
 int arc_core_mpu_buffer_validate(void *addr, size_t size, int write)
 {
 	int r_index;
-
+	int key = arch_irq_lock();
 
 	/*
 	 * For ARC MPU v3, overlapping is not supported.
@@ -667,13 +667,17 @@ int arc_core_mpu_buffer_validate(void *addr, size_t size, int write)
 	/*  match and the area is in one region */
 	if (r_index >= 0 && r_index == _mpu_probe((u32_t)addr + (size - 1))) {
 		if (_is_user_accessible_region(r_index, write)) {
-			return 0;
+			r_index = 0;
 		} else {
-			return -EPERM;
+			r_index = -EPERM;
 		}
+	} else {
+		r_index = -EPERM;
 	}
 
-	return -EPERM;
+	arch_irq_unlock(key);
+
+	return r_index;
 }
 #endif /* CONFIG_USERSPACE */
 

--- a/arch/arc/core/regular_irq.S
+++ b/arch/arc/core/regular_irq.S
@@ -303,6 +303,15 @@ _rirq_reschedule:
 	lr r3, [_ARC_V2_SEC_STAT]
 	push_s r3
 #endif
+
+#if defined(CONFIG_USERSPACE)
+/*
+ * need to remember the user/kernel status of interrupted thread
+ */
+	lr r3, [_ARC_V2_AUX_IRQ_ACT]
+	and r3, r3, 0x80000000
+	push_s r3
+#endif
 	/* _save_callee_saved_regs expects outgoing thread in r2 */
 	_save_callee_saved_regs
 
@@ -400,6 +409,15 @@ _rirq_return_from_coop:
 .balign 4
 _rirq_return_from_firq:
 _rirq_return_from_rirq:
+#if defined(CONFIG_USERSPACE)
+/*
+ * need to recover the user/kernel status of interrupted thread
+ */
+	pop_s r3
+	lr r2, [_ARC_V2_AUX_IRQ_ACT]
+	or r2, r2, r3
+	sr r2, [_ARC_V2_AUX_IRQ_ACT]
+#endif
 #ifdef CONFIG_ARC_SECURE_FIRMWARE
 	/* here need to recover SEC_STAT.IRM bit */
 	pop_s r3

--- a/arch/arc/core/switch.S
+++ b/arch/arc/core/switch.S
@@ -162,6 +162,16 @@ return_loc:
 _switch_return_from_rirq:
 _switch_return_from_firq:
 
+#if defined(CONFIG_USERSPACE)
+/*
+ * need to recover the user/kernel status of interrupted thread
+ */
+	pop_s r3
+	lr r2, [_ARC_V2_AUX_IRQ_ACT]
+	or r2, r2, r3
+	sr r2, [_ARC_V2_AUX_IRQ_ACT]
+#endif
+
 #ifdef CONFIG_ARC_SECURE_FIRMWARE
 	/* here need to recover SEC_STAT.IRM bit */
 	pop_s r3


### PR DESCRIPTION
This PR fixes #22288

It includes two parts
    * the bug in interrupt handling when interrupt comes out in user mode when USER_SPACE is configured. The root cause it that the switch between aux_user_sp/aux_sec_k_sp and sp relies on 
the correct vaule of aux_irq_act' U bit.
    * the bug in mpu v3' driver, the access to mpu regs should be atomic, mpu buffer validate is not procted by a lock, other mpu apis are protected by high level zephyr API, e.g. mem domain.

With this PR, the test in #22288 is passed.


