### PR TITLE
drivers: gpio: Add support to samv71 soc

### DIFF
--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -78,7 +78,9 @@ static int gpio_sam_config_pin(Pio * const pio, u32_t mask, int flags)
 		pio->PIO_PUDR = mask;
 	}
 
-#if defined(CONFIG_SOC_SERIES_SAM4S) || defined(CONFIG_SOC_SERIES_SAME70)
+#if defined(CONFIG_SOC_SERIES_SAM4S) || \
+	defined(CONFIG_SOC_SERIES_SAME70) || \
+	defined(CONFIG_SOC_SERIES_SAMV71)
 	/* Setup Pull-down resistor. */
 	if ((flags & GPIO_PUD_MASK) == GPIO_PUD_PULL_DOWN) {
 		pio->PIO_PPDER = mask;
@@ -94,7 +96,9 @@ static int gpio_sam_config_pin(Pio * const pio, u32_t mask, int flags)
 	} else {
 		pio->PIO_SCIFSR = mask;
 	}
-#elif defined(CONFIG_SOC_SERIES_SAM4S) || defined(CONFIG_SOC_SERIES_SAME70)
+#elif defined(CONFIG_SOC_SERIES_SAM4S) || \
+	defined(CONFIG_SOC_SERIES_SAME70) || \
+	defined(CONFIG_SOC_SERIES_SAMV71)
 	/* Setup debounce. */
 	if (flags & GPIO_INT_DEBOUNCE) {
 		pio->PIO_IFSCER = mask;


### PR DESCRIPTION
Enable samv71 MCU gpio specifics.
Need merge #21319 first to add missing symbols for Kconfig.

This is part of series to enable SAMV71 platform: #21319