### PR TITLE
drivers: usb: sam: Add support to samv71 soc

### DIFF
--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -41,7 +41,8 @@ config USB_DC_SAM0
 
 config USB_DC_SAM
 	bool "SAM series USB HS Device Controller driver"
-	depends on SOC_SERIES_SAME70
+	depends on SOC_SERIES_SAME70 || \
+		   SOC_SERIES_SAMV71
 	select USB_DEVICE_DRIVER
 	help
 	  SAM family USB HS device controller Driver.


### PR DESCRIPTION
Add depends on SOC_SERIES_SAMV71 to enable usb driver for samv71 soc.
Need merge #21319 first to add missing symbols for Kconfig.

This is part of series to enable SAMV71 platform: #21319