### PR TITLE
add supported devices in SAMV71  board yaml file

### DIFF
--- a/boards/arm/sam_v71_xult/sam_v71_xult.yaml
+++ b/boards/arm/sam_v71_xult/sam_v71_xult.yaml
@@ -8,6 +8,9 @@ toolchain:
   - xtools
 supported:
   - netif:eth
+  - adc
   - gpio
+  - spi
   - watchdog
+  - usb_device
   - pwm


### PR DESCRIPTION
Added 'adc', 'spi' and 'usb_device' missing tests for SAMV71 platform.
Need merge #21319, #22397, #22398 and #22401 first.

This is part of series to enable SAMV71 platform: #21319

@galak 