### PR TITLE
drivers: gpio: Add sam4e defines

### DIFF
--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -79,8 +79,10 @@ static int gpio_sam_config_pin(Pio * const pio, u32_t mask, int flags)
 	}
 
 #if defined(CONFIG_SOC_SERIES_SAM4S) || \
+	defined(CONFIG_SOC_SERIES_SAM4E) || \
 	defined(CONFIG_SOC_SERIES_SAME70) || \
 	defined(CONFIG_SOC_SERIES_SAMV71)
+
 	/* Setup Pull-down resistor. */
 	if ((flags & GPIO_PUD_MASK) == GPIO_PUD_PULL_DOWN) {
 		pio->PIO_PPDER = mask;
@@ -97,8 +99,10 @@ static int gpio_sam_config_pin(Pio * const pio, u32_t mask, int flags)
 		pio->PIO_SCIFSR = mask;
 	}
 #elif defined(CONFIG_SOC_SERIES_SAM4S) || \
+	defined(CONFIG_SOC_SERIES_SAM4E) || \
 	defined(CONFIG_SOC_SERIES_SAME70) || \
 	defined(CONFIG_SOC_SERIES_SAMV71)
+
 	/* Setup debounce. */
 	if (flags & GPIO_INT_DEBOUNCE) {
 		pio->PIO_IFSCER = mask;


### PR DESCRIPTION
Enable sam4e MCU gpio specifics.
Need merge #20551 first to add missing symbols for Kconfig.

This is part of series to enable SAM4E platform: #20551