### PR TITLE
[TOPIC-GPIO] drivers: gpio: Add LiteX GPIO driver

### DIFF
--- a/drivers/gpio/Kconfig.litex
+++ b/drivers/gpio/Kconfig.litex
@@ -3,7 +3,7 @@
 # Copyright (c) 2019 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig GPIO_LITEX
+config GPIO_LITEX
 	bool "Litex GPIO driver"
 	depends on SOC_RISCV32_LITEX_VEXRISCV
 	select HAS_DTS_GPIO


### PR DESCRIPTION
Avoid newly added warning about menuconfig without menu entries.

This will be squashed into the creating commit in the next rebase.

Sorry about the review noise; hit create before confirming the base branch.