### PR TITLE
[RFC][DNM] device: device api extension proposal

### DIFF
--- a/include/sys/onoff.h
+++ b/include/sys/onoff.h
@@ -423,6 +423,52 @@ static inline void onoff_client_init_callback(struct onoff_client *cli,
 	};
 }
 
+/** @brief Get onoff service from the device.
+ *
+ * @param dev Device.
+ * @param srv Location where service handler is stored.
+ *
+ * @retval 0 on success.
+ * @retval -ENOTSUP is API is not supported by the device.
+ */
+static inline int device_get_onoff_service(struct device *dev,
+						struct onoff_service **srv)
+{
+	if (!z_device_ext_api_supported(dev, DEVICE_EXT_API_ONOFF)) {
+		return -ENOTSUP;
+	}
+
+	*srv = (struct ononff_service *) z_device_ext_api_get_data(dev,
+							DEVICE_EXT_API_ONOFF);
+	return 0;
+}
+
+/** @brief Get onoff service from the device subsystem.
+ *
+ * Used when device has more than one onoff service.
+ *
+ * @param dev Device.
+ * @param subsys Subsys id.
+ * @param srv Location where service handler is stored.
+ *
+ * @retval 0 on success.
+ * @retval -ENOTSUP is API is not supported by the device.
+ */
+static inline int device_subsys_get_onoff_service(struct device *dev,
+						u32_t subsys,
+						struct onoff_service **srv)
+{
+	void **data;
+	if (!z_device_ext_api_supported(dev, DEVICE_EXT_API_ONOFF)) {
+		return -ENOTSUP;
+	}
+
+	data = (void **)z_device_ext_api_get_data(dev, DEVICE_EXT_API_ONOFF);
+	*srv = (struct ononff_service *)data[subsys];
+
+	return 0;
+}
+
 /**
  * @brief Request a reservation to use an on-off service.
  *

--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -6,8 +6,29 @@
 
 #include <zephyr.h>
 #include <sys/printk.h>
+#include <device.h>
+#include <sys/off.h>
 
 void main(void)
 {
-	printk("Hello World! %s\n", CONFIG_BOARD);
+	struct device *clock = device_get_binding("CLOCK");
+	struct device *spi = device_get_binding("SPI");
+	struct onoff_client client;
+	struct onoff_service *srv;
+	int err;
+
+	err = device_subsys_get_onoff_service(clock, subsys, &srv);
+	if (err < 0) {
+		LOG_ERR("Failed to get device onoff service (err: %d)", err);
+	}
+
+	err = onoff_request(srv, &client);
+
+	/* hypothetical another api supported by the device */
+	err = device_get_op_mngr(spi, &op_mngr);
+	if (err < 0) {
+
+	}
+
+	err = op_mngr_schedule(op_mngr, transaction);
 }


### PR DESCRIPTION
A draft showing how to handle external API with devices.

Short summary:
- device structure gets additional field - a pointer to extension api structure which contains mask of capabilities and pointer to data. if more than one extension is supported then data is an array of pointers associated with each api. https://github.com/zephyrproject-rtos/zephyr/blob/47ec30148aeedc61dcce6d2d1da3f3b0873473b6/include/device.h#L302
- device.h gets internal api for checking if device supports given extension (`z_device_ext_api_supported(dev, bitmask)`) and getting data associated with that extension (`z_device_ext_api_get_data(dev, bitmask)`) https://github.com/zephyrproject-rtos/zephyr/blob/47ec30148aeedc61dcce6d2d1da3f3b0873473b6/include/device.h#L328 
- external api (onoff service in that example) implements simple inline like `device_get_onoff_service(dev, &srv)` https://github.com/zephyrproject-rtos/zephyr/blob/47ec30148aeedc61dcce6d2d1da3f3b0873473b6/include/sys/onoff.h#L434

Example:
```
err = device_subsys_get_onoff_service(clock, subsys, &srv);
if (err < 0) {
    LOG_ERR("Failed to get device onoff service (err: %d)", err);
}

err = onoff_request(srv, &client);
```

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>