### PR TITLE
settings: Reduction of settings_src_register function

### DIFF
--- a/subsys/settings/src/settings_store.c
+++ b/subsys/settings/src/settings_store.c
@@ -26,15 +26,7 @@ extern struct k_mutex settings_lock;
 
 void settings_src_register(struct settings_store *cs)
 {
-	sys_snode_t *prev, *cur;
-
-	prev = NULL;
-
-	SYS_SLIST_FOR_EACH_NODE(&settings_load_srcs, cur) {
-		prev = cur;
-	}
-
-	sys_slist_insert(&settings_load_srcs, prev, &cs->cs_next);
+	sys_slist_append(&settings_load_srcs, &cs->cs_next);
 }
 
 void settings_dst_register(struct settings_store *cs)


### PR DESCRIPTION
The contentes of the function has been reduced with use of
sys_slist_append instead of sys_slist_insert.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>