### PR TITLE
kconfig: Remove log backend options from MCUMGR configuration

### DIFF
--- a/subsys/mgmt/Kconfig.mcumgr
+++ b/subsys/mgmt/Kconfig.mcumgr
@@ -61,38 +61,6 @@ if MCUMGR_CMD_IMG_MGMT
 	  command.
 endif
 
-menuconfig MCUMGR_CMD_LOG_MGMT
-	bool "Enable mcumgr handlers for log management"
-	help
-	  Enables mcumgr handlers for log management
-
-if MCUMGR_CMD_LOG_MGMT
-config LOG_MGMT_CHUNK_SIZE
-	int "Maximum chunk size for log downloads"
-	default 512
-	help
-	  Limits the maximum chunk size for log downloads, in bytes.  A buffer of
-	  this size gets allocated on the stack during handling of the log show command.
-
-config LOG_MGMT_NAME_LEN
-	int "Maximum log name length"
-	default 64
-	help
-	  Limits the maximum length of log names, in bytes.  If a log's name length
-	  exceeds this number, it gets truncated in management responses.  A buffer
-	  of this size gets allocated on the stack during handling of all log
-	  management commands.
-
-config LOG_MGMT_BODY_LEN
-	int "Maximum log body length"
-	default 128
-	help
-	  Limits the maximum length of log entry bodies, in bytes.  If a log
-	  entry's body length exceeds this number, it gets truncated in management
-	  responses.  A buffer of this size gets allocated on the stack during
-	  handling of the log show command.
-endif
-
 menuconfig MCUMGR_CMD_OS_MGMT
 	bool "Enable mcumgr handlers for OS management"
 	select REBOOT


### PR DESCRIPTION
The log handler source does not compile for quite long now.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>