### PR TITLE
drivers: clock_control: Add subsys argument to the callback

### DIFF
--- a/doc/releases/release-notes-2.2.rst
+++ b/doc/releases/release-notes-2.2.rst
@@ -61,6 +61,11 @@ Stable API changes in this release
     Usage of 8-bit write block size emulation is only recommended for
     compatibility with older storage contents.
 
+* Clock control
+
+  * The callback prototype (clock_control_cb_t) has now additional argument
+    (clock_control_subsys_t) indicating which clock subsystem got started.
+
 Removed APIs in this release
 ============================
 

--- a/drivers/clock_control/nrf_clock_calibration.c
+++ b/drivers/clock_control/nrf_clock_calibration.c
@@ -45,7 +45,9 @@ static int total_cnt; /* Total number of calibrations. */
 static int total_skips_cnt; /* Total number of skipped calibrations. */
 
 /* Callback called on hfclk started. */
-static void cal_hf_on_callback(struct device *dev, void *user_data);
+static void cal_hf_on_callback(struct device *dev,
+				clock_control_subsys_t subsys,
+				void *user_data);
 static struct clock_control_async_data cal_hf_on_data = {
 	.cb = cal_hf_on_callback
 };
@@ -238,7 +240,9 @@ out:
 /* Called when HFCLK XTAL is on. Schedules temperature measurement or triggers
  * calibration.
  */
-static void cal_hf_on_callback(struct device *dev, void *user_data)
+static void cal_hf_on_callback(struct device *dev,
+				clock_control_subsys_t subsys,
+				void *user_data)
 {
 	int key = irq_lock();
 

--- a/drivers/clock_control/nrf_power_clock.c
+++ b/drivers/clock_control/nrf_power_clock.c
@@ -281,7 +281,7 @@ static int clock_async_start(struct device *dev,
 		clock_irqs_enable();
 
 		if (already_started) {
-			data->cb(dev, data->user_data);
+			data->cb(dev, subsys, data->user_data);
 		}
 	}
 
@@ -403,7 +403,8 @@ static void clkstarted_handle(struct device *dev,
 	sub_data->started = true;
 
 	while ((async_data = list_get(&sub_data->list)) != NULL) {
-		async_data->cb(dev, async_data->user_data);
+		async_data->cb(dev, (clock_control_subsys_t)type,
+				async_data->user_data);
 	}
 }
 

--- a/drivers/sensor/nrf5/temp_nrf5.c
+++ b/drivers/sensor/nrf5/temp_nrf5.c
@@ -26,7 +26,8 @@ struct temp_nrf5_data {
 	struct device *clk_dev;
 };
 
-static void hfclk_on_callback(struct device *dev, void *user_data)
+static void hfclk_on_callback(struct device *dev, clock_control_subsys_t subsys,
+			      void *user_data)
 {
 	nrf_temp_task_trigger(NRF_TEMP, NRF_TEMP_TASK_START);
 }

--- a/include/drivers/clock_control.h
+++ b/include/drivers/clock_control.h
@@ -34,7 +34,6 @@ enum clock_control_status {
 	CLOCK_CONTROL_STATUS_UNKNOWN
 };
 
-typedef void (*clock_control_cb_t)(struct device *dev, void *user_data);
 
 /**
  * @cond INTERNAL_HIDDEN
@@ -47,6 +46,23 @@ typedef void (*clock_control_cb_t)(struct device *dev, void *user_data);
 /**
  * INTERNAL_HIDDEN @endcond
  */
+
+/**
+ * clock_control_subsys_t is a type to identify a clock controller sub-system.
+ * Such data pointed is opaque and relevant only to the clock controller
+ * driver instance being used.
+ */
+typedef void *clock_control_subsys_t;
+
+/** @brief Callback called on clock started.
+ *
+ * @param dev		Device structure whose driver controls the clock.
+ * @param subsys	Opaque data representing the clock.
+ * @param user_data	User data.
+ */
+typedef void (*clock_control_cb_t)(struct device *dev,
+				   clock_control_subsys_t subsys,
+				   void *user_data);
 
 /**
  * Define and initialize clock_control async data.
@@ -71,13 +87,6 @@ struct clock_control_async_data {
 	clock_control_cb_t cb;
 	void *user_data;
 };
-
-/**
- * clock_control_subsys_t is a type to identify a clock controller sub-system.
- * Such data pointed is opaque and relevant only to the clock controller
- * driver instance being used.
- */
-typedef void *clock_control_subsys_t;
 
 typedef int (*clock_control)(struct device *dev, clock_control_subsys_t sys);
 

--- a/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
+++ b/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
@@ -206,7 +206,9 @@ static bool async_capable(const char *dev_name, clock_control_subsys_t subsys)
 /*
  * Test checks that callbacks are called after clock is started.
  */
-static void clock_on_callback(struct device *dev, void *user_data)
+static void clock_on_callback(struct device *dev,
+				clock_control_subsys_t subsys,
+				void *user_data)
 {
 	bool *executed = (bool *)user_data;
 

--- a/tests/drivers/clock_control/nrf_clock_calibration/src/test_nrf_clock_calibration.c
+++ b/tests/drivers/clock_control/nrf_clock_calibration/src/test_nrf_clock_calibration.c
@@ -27,7 +27,9 @@ static void turn_off_clock(struct device *dev, clock_control_subsys_t subsys)
 	} while (err == 0);
 }
 
-static void lfclk_started_cb(struct device *dev, void *user_data)
+static void lfclk_started_cb(struct device *dev,
+			     clock_control_subsys_t subsys,
+			     void *user_data)
 {
 	*(bool *)user_data = true;
 }


### PR DESCRIPTION
Added subsys argument to the callback, updated one driver which
used it and test cases.

Fixes #22424.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>