### PR TITLE
subsys/fs/fatfs: Fix mount of unformatted big volumes

### DIFF
--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -343,7 +343,7 @@ static int fatfs_mount(struct fs_mount_t *mountp)
 		u8_t work[_MAX_SS];
 
 		res = f_mkfs(&mountp->mnt_point[1],
-				(FM_FAT | FM_SFD), 0, work, sizeof(work));
+				(FM_ANY | FM_SFD), 0, work, sizeof(work));
 		if (res == FR_OK) {
 			res = f_mount((FATFS *)mountp->fs_data,
 					&mountp->mnt_point[1], 1);


### PR DESCRIPTION
Attempting to mount, as FAT, unformatted volume would invoke formatting.
The formatting would fail for volumes that are too big to be handled
by FAT12, which has been selected as only allowed format.
This patch allows driver to select smallest possible FAT format that
can handle the volume size.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>