### PR TITLE
tests: lib: os: onoff: address Coverity complaint

### DIFF
--- a/tests/lib/onoff/src/main.c
+++ b/tests/lib/onoff/src/main.c
@@ -805,6 +805,8 @@ static void test_async(void)
 	cli[0].result = 1 + start_state.retval;
 	zassert_equal(cli_result(&cli[0]), -EAGAIN,
 		      "fetch failed");
+	zassert_false(start_state.notify == NULL,
+		      "start invoked");
 	notify(&start_state);
 	zassert_equal(cli_result(&cli[0]), start_state.retval,
 		      "start notified");


### PR DESCRIPTION
Coverity believes that a field is null when it isn't.  Duplicate the assert from 20 lines up in hopes it learns better.

Fixes #22432 if Coverity pays attention to zassert.