### PR TITLE
samples: net: echo_client: handle net if mtu

### DIFF
--- a/samples/net/sockets/echo_client/src/common.h
+++ b/samples/net/sockets/echo_client/src/common.h
@@ -20,6 +20,7 @@ struct data {
 		struct k_delayed_work transmit;
 		u32_t expecting;
 		u32_t counter;
+		u32_t mtu;
 	} udp;
 
 	struct {

--- a/samples/net/sockets/echo_client/src/echo-client.c
+++ b/samples/net/sockets/echo_client/src/echo-client.c
@@ -198,6 +198,8 @@ static void event_handler(struct net_mgmt_event_callback *cb,
 		LOG_INF("Network connected");
 
 		connected = true;
+		conf.ipv4.udp.mtu = net_if_get_mtu(iface);
+		conf.ipv6.udp.mtu = conf.ipv4.udp.mtu;
 		k_sem_give(&run_app);
 
 		return;

--- a/samples/net/sockets/echo_client/src/udp.c
+++ b/samples/net/sockets/echo_client/src/udp.c
@@ -32,7 +32,8 @@ static int send_udp_data(struct data *data)
 
 	do {
 		data->udp.expecting = sys_rand32_get() % ipsum_len;
-	} while (data->udp.expecting == 0U);
+	} while (data->udp.expecting == 0U ||
+		 data->udp.expecting > data->udp.mtu);
 
 	ret = send(data->udp.sock, lorem_ipsum, data->udp.expecting, 0);
 


### PR DESCRIPTION
UDP portion of the echo_client sends 1 packet with the sample data.
(TCP can send chunks of it depending on the response of the send()
function.)  Not every network interface can send a UDP packet large
enough to handle the size of the sample data.

Let's make sure to account for the network interface MTU when deciding
the amount of sample data to send.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/22447

Signed-off-by: Michael Scott <mike@foundries.io>