### PR TITLE
adc: common: handle gain of 128 in adc_gain_invert()

### DIFF
--- a/drivers/adc/adc_common.c
+++ b/drivers/adc/adc_common.c
@@ -28,6 +28,7 @@ int adc_gain_invert(enum adc_gain gain,
 		[ADC_GAIN_16] = {.mul = 1, .div = 16},
 		[ADC_GAIN_32] = {.mul = 1, .div = 32},
 		[ADC_GAIN_64] = {.mul = 1, .div = 64},
+		[ADC_GAIN_128] = {.mul = 1, .div = 128},
 	};
 	int rv = -EINVAL;
 


### PR DESCRIPTION
Add missing entry for ADC_GAIN_128 in the adc_gain_invert() function.

This fixes 4420c5ed40f4363b58e1fb800a8b6be483f7b1fe.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>