### PR TITLE
doc: fix links to www.zephyrproject.org

### DIFF
--- a/doc/404.rst
+++ b/doc/404.rst
@@ -38,7 +38,7 @@ If you got this error by following a link, please let us know by sending
 us a message using this `contact us form`_, or send an email message to
 info@zephyrproject.org
 
-.. _contact us form: https://www.zephyrproject.org/about/#contact-us
+.. _contact us form: https://www.zephyrproject.org/contact-us/
 
 .. raw:: html
 

--- a/doc/_templates/zversions.html
+++ b/doc/_templates/zversions.html
@@ -18,7 +18,7 @@
             <a href="https://www.zephyrproject.org/">Project Home</a>
           </dd>
           <dd>
-            <a href="https://www.zephyrproject.org/developers/#downloads">Downloads</a>
+            <a href="https://github.com/zephyrproject-rtos/sdk-ng/releases">SDK</a>
           </dd>
           <dd>
             <a href="https://github.com/zephyrproject-rtos/zephyr/releases">Releases</a>

--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -33,7 +33,7 @@ this, check out articles such as `Why choose Apache 2.0 licensing`_ and
 `Top 10 Apache License Questions Answered`_).
 
 .. _Why choose Apache 2.0 licensing:
-   https://www.zephyrproject.org/about/#faq
+   https://www.zephyrproject.org/faqs/#1571346989065-9216c551-f523
 
 .. _Top 10 Apache License Questions Answered:
    https://www.whitesourcesoftware.com/whitesource-blog/top-10-apache-license-questions-answered/
@@ -694,7 +694,7 @@ other than the Apache 2.0 license needs to be fully understood in
 context and approved by the `Zephyr governing board`_.
 
 .. _Zephyr governing board:
-   https://www.zephyrproject.org/about/organization
+   https://www.zephyrproject.org/governance/
 
 By carefully reviewing potential contributions and also enforcing a
 :ref:`DCO` for contributed code, we ensure that

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -286,7 +286,7 @@ A toolchain includes necessary tools used to build Zephyr applications
 including: compiler, assembler, linker, and their dependencies.
 
 
-.. _Zephyr Downloads: https://www.zephyrproject.org/developers/#downloads
+.. _Zephyr SDK Downloads: https://github.com/zephyrproject-rtos/sdk-ng/releases
 
 .. tabs::
 

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -288,5 +288,5 @@ To make sure this variable is unset, run:
 
    unset ZEPHYR_SDK_INSTALL_DIR
 
-.. _Zephyr Downloads: https://www.zephyrproject.org/developers/#downloads
+.. _Zephyr Downloads: https://github.com/zephyrproject-rtos/sdk-ng/releases
 .. _CMake Downloads: https://cmake.org/download

--- a/doc/guides/debugging/host-tools.rst
+++ b/doc/guides/debugging/host-tools.rst
@@ -60,7 +60,7 @@ These debug host tools are compatible with the following debug probes:
 Check if your SoC is listed in `OpenOCD Supported Devices`_.
 
 .. note:: On Linux, openocd is available though the `Zephyr SDK
-   <https://www.zephyrproject.org/developers/#downloads>`_.
+   <https://github.com/zephyrproject-rtos/sdk-ng/releases>`_.
    Windows users should use the following steps to install
    openocd:
 


### PR DESCRIPTION
Lots of broken links after the website update. Fix them or point to
alternatives.