### PR TITLE
Bluetooth: controller: Fix settings dependency

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -313,7 +313,7 @@ config BT_CTLR_TX_PWR_DYNAMIC_CONTROL
 
 config BT_CTLR_SETTINGS
 	bool "Settings System"
-	depends on BT_SETTINGS
+	depends on SETTINGS
 	help
 	  Enable use of settings system in controller.
 


### PR DESCRIPTION
BT_CTLR_SETTINGS should not depend on BT_SETTINGS as this will prevent
using settings system in the controller in a controller only build.
(BT_SETTINGS depends on BT_HCI_HOST)

Signed-off-by: Thomas Ebert Hansen <thoh@oticon.com>