### PR TITLE
Add feather header

### DIFF
--- a/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
+++ b/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <nordic/nrf52840_qiaa.dtsi>
+#include "feather_connector.dtsi"
 
 / {
 	model = "Adafruit Feather nRF52840 Express";

--- a/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.yaml
+++ b/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.yaml
@@ -14,3 +14,6 @@ supported:
   - ieee802154
   - watchdog
   - counter
+  - feather_serial
+  - feather_i2c
+  - feather_spi

--- a/boards/arm/adafruit_feather_nrf52840/feather_connector.dtsi
+++ b/boards/arm/adafruit_feather_nrf52840/feather_connector.dtsi
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020 Richard Osterloh <richard.osterloh@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	feather_header: connector {
+		compatible = "adafruit-feather-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 4 0>,	/* A0 */
+			   <1 0 &gpio0 5 0>,	/* A1 */
+			   <2 0 &gpio0 30 0>,	/* A2 */
+			   <3 0 &gpio0 28 0>,	/* A3 */
+			   <4 0 &gpio0 2 0>,	/* A4 */
+			   <5 0 &gpio0 3 0>,	/* A5 */
+			   <6 0 &gpio0 14 0>,	/* SCK */
+			   <7 0 &gpio0 13 0>,	/* MOSI */
+			   <8 0 &gpio0 15 0>,	/* MISO */
+			   <9 0 &gpio0 24 0>,	/* RXD */
+			   <10 0 &gpio0 25 0>,	/* TXD */
+			   <11 0 &gpio0 10 0>,	/* D2 (NFC2) */
+			   <12 0 &gpio0 12 0>,	/* SDA */
+			   <13 0 &gpio0 11 0>,	/* SCL */
+			   <14 0 &gpio1 8 0>,	/* D5 */
+			   <15 0 &gpio0 7 0>,	/* D6 */
+			   <16 0 &gpio0 26 0>,	/* D9 */
+			   <17 0 &gpio0 27 0>,	/* D10 */
+			   <18 0 &gpio0 6 0>,	/* D11 */
+			   <19 0 &gpio0 8 0>,	/* D12 */
+			   <20 0 &gpio1 9 0>;	/* D13 */
+	};
+};
+
+feather_serial: &uart0 {};
+feather_i2c: &i2c0 {};
+feather_spi: &spi1 {};

--- a/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.dts
+++ b/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/f4/stm32f405Xg.dtsi>
+#include "feather_connector.dtsi"
 
 / {
 	model = "Adafruit Feather STM32F405 Express";

--- a/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.yaml
+++ b/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.yaml
@@ -12,3 +12,6 @@ supported:
   - i2c
   - spi
   - usb
+  - feather_serial
+  - feather_i2c
+  - feather_spi

--- a/boards/arm/adafruit_feather_stm32f405/feather_connector.dtsi
+++ b/boards/arm/adafruit_feather_stm32f405/feather_connector.dtsi
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020 Richard Osterloh <richard.osterloh@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	feather_header: connector {
+		compatible = "adafruit-feather-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpioa 4 0>,	/* A0 */
+			   <1 0 &gpioa 5 0>,	/* A1 */
+			   <2 0 &gpioa 6 0>,	/* A2 */
+			   <3 0 &gpioa 7 0>,	/* A3 */
+			   <4 0 &gpioc 4 0>,	/* A4 */
+			   <5 0 &gpioc 5 0>,	/* A5 */
+			   <6 0 &gpiob 13 0>,	/* SCK */
+			   <7 0 &gpiob 15 0>,	/* MOSI */
+			   <8 0 &gpiob 14 0>,	/* MISO */
+			   <9 0 &gpiob 11 0>,	/* RX */
+			   <10 0 &gpiob 10 0>,	/* TX */
+			   <11 0 &gpioa 8 0>,	/* B0 (NC) */
+			   <12 0 &gpiob 7 0>,	/* SDA */
+			   <13 0 &gpiob 6 0>,	/* SCL */
+			   <14 0 &gpioc 7 0>,	/* D5 */
+			   <15 0 &gpioc 6 0>,	/* D6 */
+			   <16 0 &gpioc 5 0>,	/* D9 */
+			   <17 0 &gpioc 4 0>,	/* D10 */
+			   <18 0 &gpioc 3 0>,	/* D11 */
+			   <19 0 &gpioc 2 0>,	/* D12 */
+			   <20 0 &gpioc 1 0>;	/* D13 */
+	};
+};
+
+feather_serial: &usart3 {};
+feather_i2c: &i2c1 {};
+feather_spi: &spi2 {};

--- a/boards/arm/nrf52_adafruit_feather/feather_connector.dtsi
+++ b/boards/arm/nrf52_adafruit_feather/feather_connector.dtsi
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020 Richard Osterloh <richard.osterloh@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	feather_header: connector {
+		compatible = "adafruit-feather-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 2 0>,	/* A0 */
+			   <1 0 &gpio0 3 0>,	/* A1 */
+			   <2 0 &gpio0 4 0>,	/* A2 */
+			   <3 0 &gpio0 5 0>,	/* A3 */
+			   <4 0 &gpio0 28 0>,	/* A4 */
+			   <5 0 &gpio0 29 0>,	/* A5 */
+			   <6 0 &gpio0 12 0>,	/* SCK */
+			   <7 0 &gpio0 13 0>,	/* MOSI */
+			   <8 0 &gpio0 14 0>,	/* MISO */
+			   <9 0 &gpio0 8 0>,	/* TXD */
+			   <10 0 &gpio0 6 0>,	/* RXD */
+			   <11 0 &gpio0 20 0>,	/* PIN_DFU */
+			   <12 0 &gpio0 25 0>,	/* SDA */
+			   <13 0 &gpio0 26 0>,	/* SCL */
+			   <14 0 &gpio0 27 0>,	/* P0.27 */
+			   <15 0 &gpio0 30 0>,	/* A6 */
+			   <16 0 &gpio0 31 0>,	/* A7 (VBAT ADC) */
+			   <17 0 &gpio0 11 0>,	/* P0.11 */
+			   <18 0 &gpio0 7 0>,	/* P0.07 */
+			   <19 0 &gpio0 15 0>,	/* P0.15 */
+			   <20 0 &gpio0 16 0>;	/* P0.16 */
+	};
+};
+
+feather_serial: &uart0 {};
+feather_i2c: &i2c0 {};

--- a/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
+++ b/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
@@ -7,6 +7,7 @@
 
 /dts-v1/;
 #include <nordic/nrf52832_qfaa.dtsi>
+#include "feather_connector.dtsi"
 
 / {
 	model = "nRF52 Adafruit Feather";

--- a/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.yaml
+++ b/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.yaml
@@ -8,3 +8,6 @@ toolchain:
   - xtools
 ram: 64
 flash: 512
+supported:
+  - feather_serial
+  - feather_i2c

--- a/dts/bindings/gpio/adafruit-feather-header.yaml
+++ b/dts/bindings/gpio/adafruit-feather-header.yaml
@@ -1,0 +1,39 @@
+# Copyright (c) 2020 Richard Osterloh
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    GPIO pins exposed on Adafruit Feather headers.
+
+    The Feather layout provides two headers, one each along
+    opposite edges of the board.
+    Proceeding counter-clockwise:
+    * A 16-pin header.  12 pins on this header are exposed
+      by this binding.
+    * A 12-pin header.  9 pins on this header are exposed
+      by this binding.
+
+    This binding provides a nexus mapping for 21 pins where parent pins 0
+    through 5 correspond to A0 through A5, and parent pins 6 through 20
+    correspond as depicted below:
+
+        - RESET
+        - 3V3
+        - 3V3
+        - GND
+        0 A0                     - VBAT
+        1 A1                     - EN
+        2 A2                     - VBUS
+        3 A3                     D13  20
+        4 A4                     D12  19
+        5 A5                     D11  18
+        6 SCK                    D10  17
+        7 MOSI                   D9   16
+        8 MISO                   D6   15
+        9 RX                     D5   14
+       10 TX                     SCL  13
+       11 D4                     SDA  12
+
+
+compatible: "adafruit-feather-header"
+
+include: [gpio-nexus.yaml, base.yaml]


### PR DESCRIPTION
Added feather header pinout and updated an example board using it.

![nRF52 Feather Pinout](https://cdn-learn.adafruit.com/assets/assets/000/043/921/original/microcontrollers_nRF52Pinout.png?1500272417) 