### PR TITLE
Bluetooth: controller: Remove compiler specific warning

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -3136,8 +3136,8 @@ static inline void event_len_prep(struct ll_conn *conn)
 		struct pdu_data_llctrl_length_req *lr;
 		struct pdu_data *pdu_ctrl_tx;
 		struct node_tx *tx;
-		u16_t rx_time;
-		u16_t tx_time;
+		u16_t rx_time = 0;
+		u16_t tx_time = 0;
 		/*
 		 * Using bool instead of u8_t increases code size
 		 * in this case.


### PR DESCRIPTION
Some compilers can't resolve the conditional if/else/else construction
in ull_conn event_len_prep function, and fail with an 'uninitialized
variables' error. The change has no functional impact.

Signed-off-by: Morten Priess <mtpr@oticon.com>