### PR TITLE
dts: lora: Use device-tree to select RTC for LoRa

### DIFF
--- a/boards/arm/96b_wistrio/96b_wistrio.dts
+++ b/boards/arm/96b_wistrio/96b_wistrio.dts
@@ -57,6 +57,11 @@
 	};
 };
 
+&rtc {
+	status = "okay";
+	#lora-rtc-cells = <0>;
+};
+
 &spi1 {
 	status = "okay";
 	cs-gpios = <&gpiob 0 0>;
@@ -72,12 +77,11 @@
 			<&gpioh 0 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
 			<&gpioc 13 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
 		spi-max-frequency = <1000000>;
+		lora-rtcs = <&rtc>;
 	};
 };
 
-&rtc {
-	status = "okay";
-};
+
 
 &eeprom {
 	status = "okay";

--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -491,9 +491,11 @@ static int sx1276_lora_init(struct device *dev)
 		return -EIO;
 	}
 
-	dev_data.counter = device_get_binding(DT_RTC_0_NAME);
+	dev_data.counter =
+	      device_get_binding(DT_INST_0_SEMTECH_SX1276_LORA_RTCS_CONTROLLER);
 	if (!dev_data.counter) {
-		LOG_ERR("Cannot get pointer to %s device", DT_RTC_0_NAME);
+		LOG_ERR("Cannot get pointer to %s device",
+			DT_INST_0_SEMTECH_SX1276_LORA_RTCS_CONTROLLER);
 		return -EIO;
 	}
 

--- a/dts/bindings/lora/semtech,sx1276.yaml
+++ b/dts/bindings/lora/semtech,sx1276.yaml
@@ -24,3 +24,8 @@ properties:
         Up to six pins that produce service interrupts from the modem.
 
         These signals are normally active-high.
+
+    lora-rtcs:
+      type: phandle-array
+      required: true
+      description: RTC to be used for the LoRa driver


### PR DESCRIPTION
Use the device-tree to define which RTC should be used
by the LoRa driver.