### PR TITLE
canbus: canopen: process RPDOs in real-time thread

### DIFF
--- a/subsys/canbus/canopen/canopen_sync.c
+++ b/subsys/canbus/canopen/canopen_sync.c
@@ -33,6 +33,7 @@ static void canopen_sync_thread(void *p1, void *p2, void *p3)
 		if (CO && CO->CANmodule[0] && CO->CANmodule[0]->CANnormal) {
 			CO_LOCK_OD();
 			sync = CO_process_SYNC(CO, elapsed);
+			CO_process_RPDO(CO, sync);
 			CO_process_TPDO(CO, sync, elapsed);
 			CO_UNLOCK_OD();
 		}


### PR DESCRIPTION
Add processing of RPDOs to the high-priority CANopen processing thread.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>