### PR TITLE
samples: canbus: canopen: reduce default timeout in main thread

### DIFF
--- a/samples/subsys/canbus/canopen/src/main.c
+++ b/samples/subsys/canbus/canopen/src/main.c
@@ -249,7 +249,7 @@ void main(void)
 		CO_CANsetNormalMode(CO->CANmodule[0]);
 
 		while (true) {
-			timeout = 50U; /* default timeout in milliseconds */
+			timeout = 1U; /* default timeout in milliseconds */
 			timestamp = k_uptime_get();
 			reset = CO_process(CO, (uint16_t)elapsed, &timeout);
 


### PR DESCRIPTION
Reduce the default timeout in the CANopen sample from 50 milliseconds to 1 millisecond. This vastly improves performance of the sample and matches the example code present in the CANopenNode stack.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>