### PR TITLE
sockets: tls: set TLS_CREDENTIALS when using non-native stack

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -48,7 +48,7 @@ config NET_SOCKETS_DNS_TIMEOUT
 
 config NET_SOCKETS_SOCKOPT_TLS
 	bool "Enable TCP TLS socket option support [EXPERIMENTAL]"
-	select TLS_CREDENTIALS if NET_NATIVE
+	imply TLS_CREDENTIALS
 	select MBEDTLS if NET_NATIVE
 	help
 	  Enable TLS socket option support which automatically establishes


### PR DESCRIPTION
When is NET_SOCKETS_SOCKOPT_TLS set, it should set TLS_CREDENTIALS
even when NET_NATIVE=n, so that platforms that use socket offloading
can continue to set TLS credentials.

Fixes #22390

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>