### PR TITLE
drivers: modem: Add support for commands that don't have a line ending

### DIFF
--- a/drivers/modem/modem_cmd_handler.h
+++ b/drivers/modem/modem_cmd_handler.h
@@ -31,6 +31,18 @@ static int name_(struct modem_cmd_handler_data *data, u16_t len, \
 	.func = func_cb_, \
 	.arg_count = acount_, \
 	.delim = adelim_, \
+	.direct = false, \
+}
+
+#define MODEM_CMD_DIRECT_DEFINE(name_) MODEM_CMD_DEFINE(name_)
+
+#define MODEM_CMD_DIRECT(cmd_, func_cb_) { \
+	.cmd = cmd_, \
+	.cmd_len = (u16_t)sizeof(cmd_)-1, \
+	.func = func_cb_, \
+	.arg_count = 0, \
+	.delim = "", \
+	.direct = true, \
 }
 
 #define CMD_RESP	0
@@ -47,6 +59,7 @@ struct modem_cmd {
 	const char *delim;
 	u16_t cmd_len;
 	u16_t arg_count;
+	bool direct;
 };
 
 #define SETUP_CMD(cmd_send_, match_cmd_, func_cb_, num_param_, delim_) { \


### PR DESCRIPTION
The reason I did want this functionality is to support the esp32 and esp8266 wifi modems (https://github.com/zephyrproject-rtos/zephyr/pull/21492).

The current `modem_cmd_handler.c` expects to always find a `\r\n` after a command and never "inside" a command. The esp8266 does however deliver data in binary format so it can contain `\r\n` inside the payload. For example, when receiving 8 bytes on linkid 0, it could look something like: `+IPD,0,8:foo\r\nbar`.

I try to solve this by supporting command handlers that gets called as soon as the incoming data matches some start sequence. The handler will then be called over and over as more data becomes available. The handler then decides that is has received all the data it needs and the processed bytes can be removed.

I'm not that fond of the name "direct"-wording so if anyone else has a suggestions, don't be shy :)