### PR TITLE
drivers: dma: stm32: Fix compiler warning

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -279,7 +279,7 @@ static int dma_stm32_configure(struct device *dev, u32_t id,
 					config->head_block->dest_address;
 	}
 
-	u16_t memory_addr_adj, periph_addr_adj;
+	u16_t memory_addr_adj = 0, periph_addr_adj = 0;
 
 	ret = dma_stm32_get_priority(config->channel_priority,
 				     &DMA_InitStruct.Priority);


### PR DESCRIPTION
When building the i2s tests on 96b_argonkey we get the following
warnings:

drivers/dma/dma_stm32.c: In function 'dma_stm32_configure':
drivers/dma/dma_stm32.c:181:2: error: 'periph_addr_adj' may be used
  uninitialized in this function [-Werror=maybe-uninitialized]
  181 |  switch (increment) {
      |  ^~~~~~
drivers/dma/dma_stm32.c:161:2: error: 'memory_addr_adj' may be used
   uninitialized in this function [-Werror=maybe-uninitialized]
  161 |  switch (increment) {
      |  ^~~~~~

Fix by initialzing periph_addr_adj and memory_addr_adj to 0.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>