### PR TITLE
Unbreak a few regressions in SMP/IPI

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -783,6 +783,7 @@ void *z_get_next_switch_handle(void *interrupted)
 	set_current(z_get_next_ready_thread());
 #endif
 
+	wait_for_switch(_current);
 	return _current->switch_handle;
 }
 #endif

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -674,6 +674,10 @@ void z_thread_priority_set(struct k_thread *thread, int prio)
 {
 	bool need_sched = z_set_prio(thread, prio);
 
+#if defined(CONFIG_SMP) && defined(CONFIG_SCHED_IPI_SUPPORTED)
+	arch_sched_ipi();
+#endif
+
 	if (need_sched && _current->base.sched_locked == 0) {
 		z_reschedule_unlocked();
 	}
@@ -1185,6 +1189,10 @@ void z_impl_k_wakeup(k_tid_t thread)
 
 	z_mark_thread_as_not_suspended(thread);
 	z_ready_thread(thread);
+
+#if defined(CONFIG_SMP) && defined(CONFIG_SCHED_IPI_SUPPORTED)
+	arch_sched_ipi();
+#endif
 
 	if (!arch_is_in_isr()) {
 		z_reschedule_unlocked();


### PR DESCRIPTION
Two regressions snuck into the change to thread abort without IPI.  One is major but obvious, the other relatively minor.