### PR TITLE
scripts/sanitycheck: be more fair with dividing subsets

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -4283,12 +4283,21 @@ def main():
                             key=lambda x: x[0][x[0].find("/") + 1:]))
 
         subset, sets = options.subset.split("/")
+        subset = int(subset)
+        sets = int(sets)
         total = len(suite.instances)
-        per_set = round(total / int(sets))
-        start = (int(subset) - 1) * per_set
-        if subset == sets:
-            end = total
+        per_set = int(total / sets)
+        num_extra_sets = total - (per_set * sets)
+
+        # Try and be more fair for rounding error with integer division
+        # so the last subset doesn't get overloaded, we add 1 extra to
+        # subsets 1..num_extra_sets.
+        if subset <= num_extra_sets:
+            start = (subset - 1) * (per_set + 1)
+            end = start + per_set + 1
         else:
+            base = num_extra_sets * (per_set + 1)
+            start = ((subset - num_extra_sets - 1) * per_set) + base
             end = start + per_set
 
         sliced_instances = islice(suite.instances.items(), start, end)


### PR DESCRIPTION
Since we do interger division to determine how many items are in each
set, its possible we can have bad rounding error and the last set having
a much larger amount of items compared to all other sets.

For example, total = 3740, sets = 300:
	per_set = 3740 / 300 = 12.466 = 12
	last_set = 3740 - 299 * 12 = 152

So instead of doing simple division, we add on extra item to the early
sets and we've exhausted the rounding error:

	num_extra_sets = total - per_set * sets
		   140 = 3740 - 12 * 300

So the first 140 subsets will have 13 per_set, and the last 160 will
have 12 per_set.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>