### PR TITLE
Fixes #22482 - c++ compile error using LOG_BACKEND_DEFINE 

### DIFF
--- a/include/logging/log_backend.h
+++ b/include/logging/log_backend.h
@@ -76,8 +76,8 @@ extern const struct log_backend __log_backends_end[0];
 #define LOG_BACKEND_DEFINE(_name, _api, _autostart)			       \
 	static struct log_backend_control_block UTIL_CAT(backend_cb_, _name) = \
 	{								       \
-		.active = false,					       \
 		.id = 0,						       \
+		.active = false,					       \
 	};								       \
 	static const Z_STRUCT_SECTION_ITERABLE(log_backend, _name) =	       \
 	{								       \


### PR DESCRIPTION
Fix c++ compile error by placing init structure members in declaration order.  Built and ran in qemu emulator.

Signed-off-by: Glenn Engel <glenne@engel.org>