### PR TITLE
soc: arm: stm32g4 disable sleep mode

### DIFF
--- a/soc/arm/st_stm32/stm32g4/soc.c
+++ b/soc/arm/st_stm32/stm32g4/soc.c
@@ -41,6 +41,9 @@ static int stm32g4_init(struct device *arg)
 	/* At reset, system core clock is set to 16 MHz from HSI */
 	SystemCoreClock = 16000000;
 
+	/* allow reflashing board */
+	LL_DBGMCU_EnableDBGSleepMode();
+
 	return 0;
 }
 


### PR DESCRIPTION
This patch allows successive reflashing operation
on nucleo_g431rb boards

Fixes #21681

Signed-off-by: Francois Ramu <francois.ramu@st.com>