### PR TITLE
samples: nrf: battery: extend to support measuring Vdd directly

### DIFF
--- a/samples/boards/nrf/battery/README.rst
+++ b/samples/boards/nrf/battery/README.rst
@@ -1,0 +1,81 @@
+.. _boards_nrf_battery:
+
+Battery Voltage Measurement
+###########################
+
+Overview
+********
+
+This sample demonstrates using Nordic configurations of the Zephyr ADC
+infrastructure to measure the voltage of the device power supply.  Two
+power supply configurations are supported:
+
+* If the board devicetree has a ``/vbatt`` node with compatible
+  ``voltage-divider`` then the voltage is measured using that divider.
+* Otherwise the power source is assumed to be directly connected to the
+  digital voltage signal, and the internal source for ``Vdd`` is
+  selected.
+
+An example of a devicetree node describing a voltage divider for battery
+monitoring is:
+
+.. code-block:: none
+
+   / {
+   	vbatt {
+   		compatible = "voltage-divider";
+   		io-channels = <&adc 4>;
+   		output-ohms = <180000>;
+   		full-ohms = <(1500000 + 180000)>;
+   		power-gpios = <&sx1509b 4 0>;
+   	};
+   };
+
+Note that in many cases where there is no voltage divider the digital
+voltage will be fed from a regulator that provides a fixed voltage
+regardless of source voltage, rather than by the source directly.  In
+configuration involving a regulator the measured voltage will be
+constant.
+
+The sample provides discharge curves that map from a measured voltage to
+an estimate of remaining capacity.  The correct curve depends on the
+battery source: a standard LiPo cell requires a curve that is different
+from a standard alkaline battery.  Curves can be measured, or estimated
+using the data sheet for the battery.
+
+Application Details
+===================
+
+The application initializes battery measurement on startup, then loops
+displaying the battery status every five seconds.
+
+Requirements
+************
+
+A Nordic-based board, optionally with a voltage divider specified in its
+devicetree configuration as noted above.
+
+Building and Running
+********************
+
+The code can be found in :zephyr_file:`samples/boards/nrf/battery`.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/boards/nrf/battery
+   :board: nrf52_pca20020
+   :goals: build flash
+   :compact:
+
+
+Sample Output
+=============
+
+.. code-block:: console
+
+   *** Booting Zephyr OS build zephyr-v2.2.0-318-g84219bdc1ac2  ***
+   [0:00:00.016]: 4078 mV; 10000 pptt
+   [0:00:04.999]: 4078 mV; 10000 pptt
+   [0:00:09.970]: 4078 mV; 10000 pptt
+   [0:00:14.939]: 4069 mV; 10000 pptt
+   [0:00:19.910]: 4078 mV; 10000 pptt
+   [0:00:24.880]: 4069 mV; 10000 pptt

--- a/samples/boards/nrf/battery/src/battery.c
+++ b/samples/boards/nrf/battery/src/battery.c
@@ -57,13 +57,10 @@ struct divider_config {
 };
 
 static const struct divider_config divider_config = {
+#if DT_HAS_NODE(VBATT)
 	.io_channel = {
-#if DT_NODE_HAS_PROP(VBATT, io_channels)
 		DT_IO_CHANNELS_LABEL(VBATT),
 		DT_IO_CHANNELS_INPUT(VBATT),
-#else
-		DT_LABEL(DT_ALIAS(adc_0)),
-#endif
 	},
 #if DT_NODE_HAS_PROP(VBATT, power_gpios)
 	.power_gpios = {
@@ -74,6 +71,11 @@ static const struct divider_config divider_config = {
 #endif
 	.output_ohm = DT_PROP(VBATT, output_ohms),
 	.full_ohm = DT_PROP(VBATT, full_ohms),
+#else /* /vbatt exists */
+	.io_channel = {
+		DT_LABEL(DT_ALIAS(adc_0)),
+	},
+#endif /* /vbatt exists */
 };
 
 struct divider_data {

--- a/samples/boards/nrf/battery/src/battery.c
+++ b/samples/boards/nrf/battery/src/battery.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2019 Peter Bigot Consulting, LLC
- * Copyright (c) 2019 Nordic Semiconductor ASA
+ * Copyright (c) 2019-2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -46,16 +46,24 @@ struct gpio_channel_config {
 };
 
 struct divider_config {
-	const struct io_channel_config io_channel;
-	const struct gpio_channel_config power_gpios;
-	const u32_t output_ohm;
-	const u32_t full_ohm;
+	struct io_channel_config io_channel;
+	struct gpio_channel_config power_gpios;
+	/* output_ohm is used as a flag value: if it is nonzero then
+	 * the battery is measured through a voltage divider;
+	 * otherwise it is assumed to be directly connected to Vdd.
+	 */
+	u32_t output_ohm;
+	u32_t full_ohm;
 };
 
 static const struct divider_config divider_config = {
 	.io_channel = {
+#if DT_NODE_HAS_PROP(VBATT, io_channels)
 		DT_IO_CHANNELS_LABEL(VBATT),
 		DT_IO_CHANNELS_INPUT(VBATT),
+#else
+		DT_LABEL(DT_ALIAS(adc_0)),
+#endif
 	},
 #if DT_NODE_HAS_PROP(VBATT, power_gpios)
 	.power_gpios = {
@@ -86,6 +94,10 @@ static int divider_setup(void)
 	struct adc_sequence *asp = &ddp->adc_seq;
 	struct adc_channel_cfg *accp = &ddp->adc_cfg;
 	int rc;
+
+	if (iocp->label == NULL) {
+		return -ENOTSUP;
+	}
 
 	ddp->adc = device_get_binding(iocp->label);
 	if (ddp->adc == NULL) {
@@ -121,8 +133,14 @@ static int divider_setup(void)
 		.gain = BATTERY_ADC_GAIN,
 		.reference = ADC_REF_INTERNAL,
 		.acquisition_time = ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 40),
-		.input_positive = SAADC_CH_PSELP_PSELP_AnalogInput0 + iocp->channel,
 	};
+
+	if (cfg->output_ohm != 0) {
+		accp->input_positive = SAADC_CH_PSELP_PSELP_AnalogInput0
+			+ iocp->channel;
+	} else {
+		accp->input_positive = SAADC_CH_PSELP_PSELP_VDD;
+	}
 
 	asp->resolution = 14;
 #else /* CONFIG_ADC_var */
@@ -182,9 +200,16 @@ int battery_sample(void)
 					      ddp->adc_cfg.gain,
 					      sp->resolution,
 					      &val);
-			rc = val * (u64_t)dcp->full_ohm / dcp->output_ohm;
-			LOG_INF("raw %u ~ %u mV => %d mV\n",
-				ddp->raw, val, rc);
+
+			if (dcp->output_ohm != 0) {
+				rc = val * (u64_t)dcp->full_ohm
+					/ dcp->output_ohm;
+				LOG_INF("raw %u ~ %u mV => %d mV\n",
+					ddp->raw, val, rc);
+			} else {
+				rc = val;
+				LOG_INF("raw %u ~ %u mV\n", ddp->raw, val);
+			}
 		}
 	}
 

--- a/samples/boards/nrf/battery/src/main.c
+++ b/samples/boards/nrf/battery/src/main.c
@@ -12,18 +12,15 @@
 #include <zephyr.h>
 #include "battery.h"
 
-/** A discharge curve calibrated from LiPo batteries.
- *
- * Specifically ones like [Adafruit 3.7v 2000
- * mAh](https://www.adafruit.com/product/2011)
- */
-static const struct battery_level_point lipo[] = {
-
-	/* "Curve" here eyeballed from captured data for a full load
-	 * that started with a charge of 3.96 V and dropped about
-	 * linearly to 3.58 V over 15 hours.  It then dropped rapidly
-	 * to 3.10 V over one hour, at which point it stopped
-	 * transmitting.
+/** A discharge curve specific to the power source. */
+static const struct battery_level_point levels[] = {
+#ifdef DT_VOLTAGE_DIVIDER_VBATT_IO_CHANNELS
+	/* "Curve" here eyeballed from captured data for the [Adafruit
+	 * 3.7v 2000 mAh](https://www.adafruit.com/product/2011) LIPO
+	 * under full load that started with a charge of 3.96 V and
+	 * dropped about linearly to 3.58 V over 15 hours.  It then
+	 * dropped rapidly to 3.10 V over one hour, at which point it
+	 * stopped transmitting.
 	 *
 	 * Based on eyeball comparisons we'll say that 15/16 of life
 	 * goes between 3.95 and 3.55 V, and 1/16 goes between 3.55 V
@@ -33,6 +30,11 @@ static const struct battery_level_point lipo[] = {
 	{ 10000, 3950 },
 	{ 625, 3550 },
 	{ 0, 3100 },
+#else
+	/* Linear from maximum voltage to minimum voltage. */
+	{ 10000, 3600 },
+	{ 0, 1700 },
+#endif
 };
 
 static const char *now_str(void)
@@ -74,7 +76,7 @@ void main(void)
 			break;
 		}
 
-		unsigned int batt_pptt = battery_level_pptt(batt_mV, lipo);
+		unsigned int batt_pptt = battery_level_pptt(batt_mV, levels);
 
 		printk("[%s]: %d mV; %u pptt\n", now_str(),
 		       batt_mV, batt_pptt);


### PR DESCRIPTION
When the system is powered directly a measurement of Vdd provides the battery voltage.  This requires a different ADC configuration and level curve.

Originally provided as an alternative to support #22414, now updated to replace that PR.