### PR TITLE
Bluetooth: samples: peripheral_dis: Sample requires BT_SETTINGS

### DIFF
--- a/samples/bluetooth/peripheral_dis/prj.conf
+++ b/samples/bluetooth/peripheral_dis/prj.conf
@@ -17,6 +17,7 @@ CONFIG_BT_GATT_DIS_SW_REV_STR="Zephyr Software"
 CONFIG_BT_DEVICE_NAME="DIS peripheral"
 
 # Below is setup to let DIS information be read from settings
+CONFIG_BT_SETTINGS=y
 CONFIG_SETTINGS_RUNTIME=y
 CONFIG_SETTINGS=y
 CONFIG_SETTINGS_NONE=y

--- a/samples/bluetooth/peripheral_dis/src/main.c
+++ b/samples/bluetooth/peripheral_dis/src/main.c
@@ -88,6 +88,10 @@ void main(void)
 		return;
 	}
 
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		settings_load();
+	}
+
 	settings_runtime_load();
 
 	printk("Bluetooth initialized\n");


### PR DESCRIPTION
The DIS service requires BT_SETTINGS otherwise it will not have a
settings handler. Instead DIS will only use Kconfig to set it's
values.

Fixes: #22478

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>