### PR TITLE
usb: avoid unnecessary error messages when switching to alternate iface

### DIFF
--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -341,7 +341,7 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data * const cfg)
 	if (ep_idx && (dev_data.ep_ctrl[ep_idx].status.in_enabled ||
 	    dev_data.ep_ctrl[ep_idx].status.out_enabled)) {
 		LOG_WRN("endpoint already configured");
-		return -EBUSY;
+		return -EALREADY;
 	}
 
 	LOG_DBG("ep %x, mps %d, type %d", cfg->ep_addr, cfg->ep_mps,
@@ -531,7 +531,7 @@ int usb_dc_ep_enable(const u8_t ep)
 	if (ep_idx && (dev_data.ep_ctrl[ep_idx].status.in_enabled ||
 	    dev_data.ep_ctrl[ep_idx].status.out_enabled)) {
 		LOG_WRN("endpoint 0x%x already enabled", ep);
-		return -EBUSY;
+		return -EALREADY;
 	}
 
 	if (EP_ADDR2DIR(ep) == USB_EP_DIR_OUT) {

--- a/drivers/usb/device/usb_dc_mcux_ehci.c
+++ b/drivers/usb/device/usb_dc_mcux_ehci.c
@@ -232,7 +232,7 @@ int usb_dc_ep_enable(const u8_t ep)
 	}
 	if (s_Device.eps[ep_abs_idx].ep_occupied) {
 		LOG_WRN("endpoint 0x%x already enabled", ep);
-		return -EBUSY;
+		return -EALREADY;
 	}
 
 	if ((EP_ADDR2IDX(ep) != USB_CONTROL_ENDPOINT) && (EP_ADDR2DIR(ep) == USB_EP_DIR_OUT)) {

--- a/drivers/usb/device/usb_dc_sam0.c
+++ b/drivers/usb/device/usb_dc_sam0.c
@@ -494,7 +494,7 @@ int usb_dc_ep_enable(const u8_t ep)
 
 	if (ep_num >= USB_NUM_ENDPOINTS) {
 		LOG_ERR("endpoint index/address out of range");
-		return -1;
+		return -EINVAL;
 	}
 
 	if (for_in) {
@@ -519,7 +519,7 @@ int usb_dc_ep_disable(u8_t ep)
 
 	if (ep_num >= USB_NUM_ENDPOINTS) {
 		LOG_ERR("endpoint index/address out of range");
-		return -1;
+		return -EINVAL;
 	}
 
 	endpoint->EPINTENCLR.reg = USB_DEVICE_EPINTENCLR_TRCPT0


### PR DESCRIPTION
When audio device is enumerated host invokes set_interface request
to alternate with 0 endpoints associated. That operation lead to
disable never enabled endpoints. With previous solution error message
will appear.

This commit limits error messages to be present only if endpoint
was configured/enabled before and there was a problem when trying
to configure/enable it for the first time.

* Kinetis driver was updated with return error value when ep was
already configured/enabled.

* nxp driver updated with return error value when ep was already
enabled

* sam0 driver updated with reutrn codes instead of magic numbers.

This is fix patch to  #21741