### PR TITLE
drivers: usb_dc_stm32: added usb_dc_detach code

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -846,8 +846,7 @@ int usb_dc_ep_mps(const u8_t ep)
 
 int usb_dc_detach(void)
 {
-	LOG_ERR("Not implemented");
-
+	HAL_PCD_DeInit(&usb_dc_stm32_state.pcd);
 	return 0;
 }
 
@@ -990,10 +989,17 @@ void HAL_PCDEx_SetConnectionState(PCD_HandleTypeDef *hpcd, uint8_t state)
 
 	usb_disconnect = device_get_binding(
 				DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_CONTROLLER);
-
 	gpio_pin_configure(usb_disconnect,
-			   DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_PIN,
-			   DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_FLAGS |
-			   (state ? GPIO_OUTPUT_ACTIVE : GPIO_OUTPUT_INACTIVE));
+			   DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_PIN, GPIO_DIR_OUT);
+
+	if (state) {
+		gpio_pin_write(usb_disconnect,
+			       DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_PIN,
+			       DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_FLAGS);
+	} else {
+		gpio_pin_write(usb_disconnect,
+			       DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_PIN,
+			       !DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_FLAGS);
+	}
 }
 #endif /* USB && CONFIG_USB_DC_STM32_DISCONN_ENABLE */

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -989,10 +989,17 @@ void HAL_PCDEx_SetConnectionState(PCD_HandleTypeDef *hpcd, uint8_t state)
 
 	usb_disconnect = device_get_binding(
 				DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_CONTROLLER);
-
 	gpio_pin_configure(usb_disconnect,
-			   DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_PIN,
-			   DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_FLAGS |
-			   (state ? GPIO_OUTPUT_ACTIVE : GPIO_OUTPUT_INACTIVE));
+			   DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_PIN, GPIO_DIR_OUT);
+
+	if (state) {
+		gpio_pin_write(usb_disconnect,
+			       DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_PIN,
+			       DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_FLAGS);
+	} else {
+		gpio_pin_write(usb_disconnect,
+			       DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_PIN,
+			       !DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_FLAGS);
+	}
 }
 #endif /* USB && CONFIG_USB_DC_STM32_DISCONN_ENABLE */

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -846,8 +846,7 @@ int usb_dc_ep_mps(const u8_t ep)
 
 int usb_dc_detach(void)
 {
-	LOG_ERR("Not implemented");
-
+	HAL_PCD_DeInit(&usb_dc_stm32_state.pcd);
 	return 0;
 }
 

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -989,17 +989,10 @@ void HAL_PCDEx_SetConnectionState(PCD_HandleTypeDef *hpcd, uint8_t state)
 
 	usb_disconnect = device_get_binding(
 				DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_CONTROLLER);
-	gpio_pin_configure(usb_disconnect,
-			   DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_PIN, GPIO_DIR_OUT);
 
-	if (state) {
-		gpio_pin_write(usb_disconnect,
-			       DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_PIN,
-			       DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_FLAGS);
-	} else {
-		gpio_pin_write(usb_disconnect,
-			       DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_PIN,
-			       !DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_FLAGS);
-	}
+	gpio_pin_configure(usb_disconnect,
+			   DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_PIN,
+			   DT_INST_0_ST_STM32_USB_DISCONNECT_GPIOS_FLAGS |
+			   (state ? GPIO_OUTPUT_ACTIVE : GPIO_OUTPUT_INACTIVE));
 }
 #endif /* USB && CONFIG_USB_DC_STM32_DISCONN_ENABLE */


### PR DESCRIPTION
there is not so much to do if we detaching. At least we can run
'HAL_PCD_DeInit' to deinit the device. That will save some power.

Signed-off-by: Stefan Jaritz <stefan@kokoontech.com>