### PR TITLE
libc: newlibc: Implement dummy _gettimeofday to link

### DIFF
--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -358,3 +358,13 @@ void *_sbrk_r(struct _reent *r, int count)
 	return _sbrk(count);
 }
 #endif /* CONFIG_XTENSA */
+
+struct timeval;
+
+int _gettimeofday(struct timeval *__tp, void *__tzp)
+{
+	ARG_UNUSED(__tp);
+	ARG_UNUSED(__tzp);
+
+	return -1;
+}


### PR DESCRIPTION
With the change in SDK 0.11.1 to newlib to remove
-DMISSING_SYSCALL_NAMES we now need to implement a version of
_gettimeofday.  Previously with pre SDK 0.11.1 we had a recursive mess
of _gettimeofday_r -> gettimeofday -> _gettimeofday_r.  (which are all
implemented in newlib and thus we didn't get a link error).

With SDK 0.11.1 we have: _gettimeofday_r -> _gettimeofday.  And we
should provide a version of _gettimeofday.

Fixes #22484

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>