### PR TITLE
drivers: ieee802154: Add RX improvements

### DIFF
--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
@@ -81,7 +81,7 @@
 		compatible = "atmel,rf2xx";
 		reg = <0x0>;
 		label = "RF2XX_0";
-		spi-max-frequency = <8000000>;
+		spi-max-frequency = <6000000>;
 		irq-gpios = <&portb 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		reset-gpios = <&portb 15 GPIO_ACTIVE_LOW>;
 		slptr-gpios = <&porta 20 GPIO_ACTIVE_HIGH>;

--- a/drivers/ieee802154/ieee802154_rf2xx.h
+++ b/drivers/ieee802154/ieee802154_rf2xx.h
@@ -1,7 +1,7 @@
 /* ieee802154_rf2xx.h - IEEE 802.15.4 Driver definition for ATMEL RF2XX */
 
 /*
- * Copyright (c) 2019 Gerson Fernando Budke
+ * Copyright (c) 2019-2020 Gerson Fernando Budke
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -139,6 +139,7 @@ struct rf2xx_context {
 	u8_t pkt_ed;
 	s8_t trx_rssi_base;
 	u8_t trx_version;
+	u8_t rx_phr;
 };
 
 #endif /* ZEPHYR_DRIVERS_IEEE802154_IEEE802154_RF2XX_H_ */

--- a/drivers/ieee802154/ieee802154_rf2xx_iface.h
+++ b/drivers/ieee802154/ieee802154_rf2xx_iface.h
@@ -1,7 +1,7 @@
 /* ieee802154_rf2xx_iface.h - ATMEL RF2XX transceiver interface */
 
 /*
- * Copyright (c) 2019 Gerson Fernando Budke
+ * Copyright (c) 2019-2020 Gerson Fernando Budke
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -106,5 +106,20 @@ void rf2xx_iface_frame_read(struct device *dev,
 void rf2xx_iface_frame_write(struct device *dev,
 			     u8_t *data,
 			     u8_t length);
+
+/**
+ * @brief Reads sram data from the transceiver
+ *
+ * This function reads the sram data of the transceiver.
+ *
+ * @param[in]   dev     Transceiver device instance
+ * @param[in]   address Start address to be read
+ * @param[out]  data    Pointer to the location to store data
+ * @param[in]   length  Number of bytes to be read from the sram space
+ */
+void rf2xx_iface_sram_read(struct device *dev,
+			    u8_t address,
+			    u8_t *data,
+			    u8_t length);
 
 #endif /* ZEPHYR_DRIVERS_IEEE802154_IEEE802154_RF2XX_IFACE_H_ */


### PR DESCRIPTION
The current version of at86rf2xx RX implementation don't uses advanced capabilities offered by the transceiver. This introduces SRAM access space to gatter PHR information in parallel with transceiver frame reception. It allows improve RX reception by handling properlly the frame protection feature
removing transceiver states changes.

This change can improve RX response time significantly but will add a small delay at TX to make sure that transceiver isn't finishing RX ACK process on advanced reception mode. On the other hand, if we need a TX just after RX, this will guarantee that TX will be set ASAP after finish RX ACK process.

This was fully tested on HW and ready for merge.