### PR TITLE
boards: adafruit_trinket_m0: Remove tweak to flash address

### DIFF
--- a/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
+++ b/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
@@ -11,14 +11,6 @@
 	model = "Adafruit Trinket M0";
 	compatible = "adafruit,trinket-m0", "atmel,samd21e18a", "atmel,samd21";
 
-	soc {
-		nvmctrl: nvmctrl@41004000  {
-			flash0: flash@0 {
-				reg = <0x2000 0x3E000>;
-			};
-		};
-	};
-
 	chosen {
 		zephyr,console = &sercom0;
 		zephyr,shell-uart = &sercom0;


### PR DESCRIPTION
The board ships with a write protected bootloader so the flash base
address was artifically adjusted to skip that bootloader.  With commit
018bf777e75b7b6aafe32d672397cc7ee7250225:

    boards: arm: Make Adafruit boards use their DT-defined code partion.

We shouldn't need to artifically adjust the flash anymore.  So remove
this, nice side effect is it fixes a dts compile warning.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>