### PR TITLE
bluetooth: host: Add callback to notify of RPA changes

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -204,6 +204,28 @@ int bt_id_reset(u8_t id, bt_addr_le_t *addr, u8_t *irk);
  */
 int bt_id_delete(u8_t id);
 
+/** @typedef bt_le_rpa_cb_t
+ *  @brief Callback type for reporting RPA changes.
+ *
+ *  A function of this type can be registered using the
+ *  bt_le_rpa_cb_register() function and will be called any time the
+ *  local random private address is updated.
+ *
+ *  @param addr Updated random private address.
+ */
+typedef void bt_le_rpa_cb_t(const bt_addr_t *addr);
+
+/** @brief Register RPA update callback.
+ *
+ *  Adds a callback to monitor RPA changes.
+ *
+ *  This callback will be called when the random private address is
+ *  modified.
+ *
+ *  @param cb Callback struct. Must point to static memory.
+ */
+void bt_le_rpa_cb_register(bt_le_rpa_cb_t *cb);
+
 /* Advertising API */
 
 /** Description of different data types that can be encoded into

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -81,6 +81,8 @@ struct bt_dev bt_dev = {
 
 static bt_ready_cb_t ready_cb;
 
+static bt_le_rpa_cb_t *rpa_change_cb;
+
 static bt_le_scan_cb_t *scan_dev_found_cb;
 
 #if defined(CONFIG_BT_OBSERVER)
@@ -511,6 +513,11 @@ int bt_addr_le_from_str(const char *str, const char *type, bt_addr_le_t *addr)
 	return 0;
 }
 
+void bt_le_rpa_cb_register(bt_le_rpa_cb_t *cb)
+{
+	rpa_change_cb = cb;
+}
+
 #if defined(CONFIG_BT_PRIVACY)
 /* this function sets new RPA only if current one is no longer valid */
 static int le_set_private_addr(u8_t id)
@@ -529,6 +536,11 @@ static int le_set_private_addr(u8_t id)
 		if (!err) {
 			atomic_set_bit(bt_dev.flags, BT_DEV_RPA_VALID);
 		}
+	}
+
+	/* run callback to notify of rpa change */
+	if (rpa_change_cb) {
+		rpa_change_cb(&rpa);
 	}
 
 	/* restart timer even if failed to set new RPA */


### PR DESCRIPTION
Add a callback to be called any time the random private address
is modified, so to notify the application of any changes.

Signed-off-by: François Delawarde <fnde@oticon.com>