### PR TITLE
drivers: modem: Fix gpio compile errors with modem shell

### DIFF
--- a/drivers/modem/modem_context.h
+++ b/drivers/modem/modem_context.h
@@ -18,6 +18,7 @@
 #include <net/buf.h>
 #include <net/net_ip.h>
 #include <sys/ring_buffer.h>
+#include <drivers/gpio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/modem/modem_pin.c
+++ b/drivers/modem/modem_pin.c
@@ -44,7 +44,8 @@ int modem_pin_config(struct modem_context *ctx, u32_t pin, bool enable)
 
 	return gpio_pin_configure(ctx->pins[pin].gpio_port_dev,
 				  ctx->pins[pin].pin,
-				  enable ? cts->pins[pin].flags : GPIO_INPUT);
+				  enable ? ctx->pins[pin].init_flags :
+					   GPIO_INPUT);
 }
 
 int modem_pin_init(struct modem_context *ctx)


### PR DESCRIPTION
Compile errors because of missing include file and typos
when accessing variables in the modem_pin struct.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>