### PR TITLE
boards: arm: nrf5340_dk_nrf5340: Configurable powering on Network MCU.

### DIFF
--- a/boards/arm/nrf5340_dk_nrf5340/CMakeLists.txt
+++ b/boards/arm/nrf5340_dk_nrf5340/CMakeLists.txt
@@ -1,7 +1,8 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA.
 # SPDX-License-Identifier: Apache-2.0
 
-if (CONFIG_BOARD_NRF5340_DK_NRF5340_CPUAPP)
+if ((CONFIG_BOARD_NRF5340_DK_NRF5340_CPUAPP OR CONFIG_BOARD_NRF5340_DK_NRF5340_CPUAPPNS)
+    AND CONFIG_BOARD_ENABLE_CPUNET)
 zephyr_library()
 zephyr_library_sources(nrf5340_cpunet_reset.c)
 endif()

--- a/boards/arm/nrf5340_dk_nrf5340/Kconfig
+++ b/boards/arm/nrf5340_dk_nrf5340/Kconfig
@@ -30,6 +30,19 @@ config HEAP_MEM_POOL_SIZE
 config BT_HAS_HCI_VS
 	default y if BT
 
+config BOARD_ENABLE_CPUNET
+	bool "Enable nRF53 Network MCU"
+	help
+	  This option enables releasing the Network 'force off' signal, which
+	  as a consequence will power up the Network MCU during system boot.
+	  Additionally, the option allocates GPIO pins that will be used by UARTE
+	  of the Network MCU.
+	  Note: The non-secure image can only be started by the secure firmware,
+	  so when this option is used with the non-secure version of the board,
+	  the application needs to take into consideration, that the secure firmware
+	  may already have started the Network MCU.
+	default y if (BT || NET_L2_IEEE802154)
+
 endif # BOARD_NRF5340_DK_NRF5340_CPUAPP || BOARD_NRF5340_DK_NRF5340_CPUAPPNS
 
 if BOARD_NRF5340_DK_NRF5340_CPUNET


### PR DESCRIPTION
Added a configuration option for enabling the nRF53 Network MCU.
Some applications will just run on the Application MCU, then
Network MCU should stay off. By deafult Network MCU
will be enabled when BLE or IEEE 802.15.4 are used.

Signed-off-by: Michał Grochala <michal.grochala@nordicsemi.no>