### PR TITLE
doc: getting_started: Add missing native_posix dependencies

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -79,7 +79,7 @@ We'll also install Zephyr's multi-purpose west tool.
             sudo apt install --no-install-recommends git cmake ninja-build gperf \
               ccache dfu-util device-tree-compiler wget \
               python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
-              make gcc gcc-multilib
+              make gcc gcc-multilib g++-multilib libsdl2-dev
 
       #. Verify the version of cmake installed on your system using::
 

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -79,7 +79,7 @@ need one.
          sudo apt-get install --no-install-recommends git cmake ninja-build gperf \
            ccache dfu-util device-tree-compiler wget \
            python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
-           make gcc gcc-multilib
+           make gcc gcc-multilib g++-multilib libsdl2-dev
 
    .. group-tab:: Fedora
 
@@ -87,7 +87,8 @@ need one.
 
          sudo dnf group install "Development Tools" "C Development Tools and Libraries"
          dnf install git cmake ninja-build gperf ccache dfu-util dtc wget \
-           python3-pip python3-tkinter xz file glibc-devel.i686 libstdc++-devel.i686
+           python3-pip python3-tkinter xz file glibc-devel.i686 libstdc++-devel.i686 \
+           SDL2-devel
 
    .. group-tab:: Clear Linux
 


### PR DESCRIPTION
For some time now we are building also the C++ samples in
native_posix in CI.
For those who want to run the whole suite locally, they
require g++-multilib, which was missing in the Ubuntu list
=> Add it.

Similarly the display sample is built in CI for
native_posix64, so add the 64bit SDL dev library to both
the Ubuntu and Fedora lists.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

Fixes #22519