### PR TITLE
manifest: mcuboot version with fixed USB recovery

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -77,7 +77,7 @@ manifest:
       revision: 3776c158fe138a72c97c187e4d31c81c37884be9
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: 36e9029ff01d1e64a77d2e2a0bb9e2cc75ab97c8
+      revision: 970840ccf5d80616d514bec76d87d836da05c03b
       path: bootloader/mcuboot
     - name: mcumgr
       revision: d4e97cd4fc80ff949415062b1c83fd42929e8fe4


### PR DESCRIPTION
Since zephyrproject-rtos/zephyr#20375
Need to enable USB by the mcuboot code explicitly.

upsteram patch JuulLabs-OSS/mcuboot#651

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>