### PR TITLE
zsock_accept_ctx: release fd on failure

### DIFF
--- a/subsys/net/lib/sockets/sockets.c.bak
+++ b/subsys/net/lib/sockets/sockets.c.bak
@@ -425,7 +425,6 @@ int zsock_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 
 	ctx = k_fifo_get(&parent->accept_q, timeout);
 	if (ctx == NULL) {
-		z_free_fd(fd);
 		errno = EAGAIN;
 		return -1;
 	}
@@ -435,7 +434,6 @@ int zsock_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 	if (last_pkt) {
 		if (net_pkt_eof(last_pkt)) {
 			sock_set_eof(ctx);
-			z_free_fd(fd);
 			errno = ECONNABORTED;
 			return -1;
 		}
@@ -443,7 +441,6 @@ int zsock_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 
 	if (net_context_is_closing(ctx)) {
 		errno = ECONNABORTED;
-		z_free_fd(fd);
 		return -1;
 	}
 
@@ -465,7 +462,6 @@ int zsock_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 		} else if (ctx->remote.sa_family == AF_INET6) {
 			*addrlen = sizeof(struct sockaddr_in6);
 		} else {
-			z_free_fd(fd);
 			errno = ENOTSUP;
 			return -1;
 		}


### PR DESCRIPTION
zsock_accept_ctx  calls z_reserve_fd on entry
added a call to z_free_fd when zsock_accept_ctx  fails prior to calling
z_finalize_fd, leaving the fd hanging

Fixes [#22366](https://github.com/zephyrproject-rtos/zephyr/issues/22366)

Signed-off-by Inbar Bratspiess <inbar.anson.bratspiess@330plus.net>