### PR TITLE
tests: Remove erroneous # before extern "C"

### DIFF
--- a/tests/subsys/fs/fcb/src/fcb_test.h
+++ b/tests/subsys/fs/fcb/src/fcb_test.h
@@ -17,7 +17,7 @@
 #include <errno.h>
 
 #ifdef __cplusplus
-#extern "C" {
+extern "C" {
 #endif
 
 #define TEST_FCB_FLASH_AREA_ID DT_FLASH_AREA_IMAGE_1_ID

--- a/tests/subsys/settings/fcb/src/settings_test.h
+++ b/tests/subsys/settings/fcb/src/settings_test.h
@@ -16,7 +16,7 @@
 #include <storage/flash_map.h>
 
 #ifdef __cplusplus
-#extern "C" {
+extern "C" {
 #endif
 
 #define SETTINGS_TEST_FCB_VAL_STR_CNT   64

--- a/tests/subsys/settings/fs/include/settings_test_fs.h
+++ b/tests/subsys/settings/fs/include/settings_test_fs.h
@@ -15,7 +15,7 @@
 #include "settings/settings.h"
 
 #ifdef __cplusplus
-#extern "C" {
+extern "C" {
 #endif
 
 extern u8_t val8;

--- a/tests/subsys/settings/nvs/src/settings_test.h
+++ b/tests/subsys/settings/nvs/src/settings_test.h
@@ -14,7 +14,7 @@
 #include "settings/settings.h"
 
 #ifdef __cplusplus
-#extern "C" {
+extern "C" {
 #endif
 
 #define SETTINGS_TEST_NVS_VAL_STR_CNT   64


### PR DESCRIPTION
A few test header files have C++ guards around them, but are incorrect.
Those files had a leading `#` placed before `extern`, which is
incorrect.  This commit simply removes those leading `#` characters.

Signed-off-by: Brooks Prumo <brooks@prumo.org>