### PR TITLE
subsys/settings: small documentation correction

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1980,7 +1980,7 @@ PREDEFINED             = "CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT" \
                          "CONFIG_SCHED_CPU_MASK" \
                          "CONFIG_SCHED_DEADLINE" \
                          "CONFIG_SCHED_DEADLINE" \
-                         "CONFIG_SETTINGS_RUNTIME=y" \
+                         "CONFIG_SETTINGS_RUNTIME" \
                          "CONFIG_SMP" \
                          "CONFIG_SPI_ASYNC" \
                          "CONFIG_SYS_CLOCK_EXISTS" \

--- a/samples/subsys/settings/README.rst
+++ b/samples/subsys/settings/README.rst
@@ -29,8 +29,9 @@ application for the qemu_x86.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/settings
+   :host-os: unix
    :board: qemu_x86
-   :goals: build flash
+   :goals: run
    :compact:
 
 After running the image to the board the output on the console shows the


### PR DESCRIPTION
* fix: include settings RT API documentation into doxygen build
* corrected: doc on how to building and running the `samples/subsys/settings sample`.
