### PR TITLE
Bluetooth: controller: split: Fix uninitialized advertiser rl_idx

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -707,7 +707,7 @@ u8_t ll_adv_enable(u8_t enable)
 #endif /* CONFIG_BT_PERIPHERAL */
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
-	adv->rl_idx = rl_idx;
+	lll->rl_idx = rl_idx;
 #else
 	ARG_UNUSED(rl_idx);
 #endif /* CONFIG_BT_CTLR_PRIVACY */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
@@ -25,7 +25,6 @@ struct ll_adv_set {
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	u8_t  own_addr_type:2;
 	u8_t  id_addr_type:1;
-	u8_t  rl_idx;
 	u8_t  id_addr[BDADDR_SIZE];
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 };


### PR DESCRIPTION
Fix uninitialized advertiser rl_idx used to check own identity
in CONNECT_IND received for directed advertisements.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>