### PR TITLE
Bluetooth: L2CAP: Fix not queueing in case there are no credits

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -2038,8 +2038,11 @@ int bt_l2cap_chan_send(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		return bt_l2cap_br_chan_send(chan, buf);
 	}
 
-	/* Queue if there pending segments left from previous packets */
-	if (ch->tx_buf || !k_fifo_is_empty(&ch->tx_queue)) {
+	/* Queue if there are pending segments left from previous packet or
+	 * there are no credits available.
+	 */
+	if (ch->tx_buf || !k_fifo_is_empty(&ch->tx_queue) ||
+	    !atomic_get(&ch->tx.credits)) {
 		data_sent(buf)->len = 0;
 		net_buf_put(&ch->tx_queue, buf);
 		k_work_submit(&ch->tx_work);


### PR DESCRIPTION
This can happens if for example the remote peer have the initial credits
set to 0 which would cause bt_l2cap_chan_send to fail instead of just
queue the packets until more credits are given.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>