### PR TITLE
scripts: west_commands: fix help text for flash

### DIFF
--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -122,7 +122,7 @@ def add_parser_common(parser_adder, command):
     # This is how we detect if the user provided them or not when
     # overriding values from the cached configuration.
 
-    command_verb = "flash" if command == "flash" else "debug"
+    command_verb = "flash" if command.name == "flash" else "debug"
 
     group.add_argument('--board-dir',
                        help='Zephyr board directory')


### PR DESCRIPTION
The 'command' variable points at a python command object, not a
string. Take its name so the help text for west flash -h correctly
says 'flash' instead of 'debug'.