### PR TITLE
kconfig: modules: Remove redundant MBEDTLS dep on. TLS menu

### DIFF
--- a/modules/Kconfig.tls-generic
+++ b/modules/Kconfig.tls-generic
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menu "TLS configuration"
-	depends on MBEDTLS
 
 menu "Supported TLS version"
 


### PR DESCRIPTION
Kconfig.tls-generic is already 'source'd within an 'if MBEDTLS' in
modules/Kconfig.mbedtls (the 'if' covers most of the file).

Flagged by https://github.com/zephyrproject-rtos/ci-tools/pull/128.