### PR TITLE
Bluetooth: Mesh: Support reliable sending when publishing

### DIFF
--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -396,7 +396,8 @@ struct bt_mesh_model_pub {
 
 	u16_t addr;         /**< Publish Address. */
 	u16_t key:12,       /**< Publish AppKey Index. */
-	      cred:1;       /**< Friendship Credentials Flag. */
+	      cred:1,       /**< Friendship Credentials Flag. */
+	      send_rel:1;   /**< Force reliable sending (segment acks) */
 
 	u8_t  ttl;          /**< Publish Time to Live. */
 	u8_t  retransmit;   /**< Retransmit Count & Interval Steps. */

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -705,6 +705,7 @@ int bt_mesh_model_publish(struct bt_mesh_model *model)
 	struct bt_mesh_model_pub *pub = model->pub;
 	struct bt_mesh_app_key *key;
 	struct bt_mesh_msg_ctx ctx = {
+		.send_rel = pub->send_rel,
 	};
 	struct bt_mesh_net_tx tx = {
 		.ctx = &ctx,


### PR DESCRIPTION
Until now the choice of reliable sending (segmented messages with
acks) was implicitly dependent on the size of the payload. Add a new
member to the bt_mesh_model_pub to force using segment acks even when
the payload would fit a single unsegmented message.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>