### PR TITLE
samples: bluetooth: add missing VEGABoard overlays

### DIFF
--- a/samples/bluetooth/ipsp/rv32m1_vega_ri5cy.overlay
+++ b/samples/bluetooth/ipsp/rv32m1_vega_ri5cy.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lptmr1 {
+	interrupt-parent = <&intmux0_ch2>;
+};
+
+&intmux0_ch2 {
+	status = "okay";
+};
+
+&intmux0_ch3 {
+	status = "okay";
+};
+
+&generic_fsk {
+	interrupt-parent = <&intmux0_ch3>;
+	status = "okay";
+};

--- a/samples/bluetooth/mesh/rv32m1_vega_ri5cy.overlay
+++ b/samples/bluetooth/mesh/rv32m1_vega_ri5cy.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lptmr1 {
+	interrupt-parent = <&intmux0_ch2>;
+};
+
+&intmux0_ch2 {
+	status = "okay";
+};
+
+&intmux0_ch3 {
+	status = "okay";
+};
+
+&generic_fsk {
+	interrupt-parent = <&intmux0_ch3>;
+	status = "okay";
+};

--- a/samples/bluetooth/mesh_demo/rv32m1_vega_ri5cy.overlay
+++ b/samples/bluetooth/mesh_demo/rv32m1_vega_ri5cy.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lptmr1 {
+	interrupt-parent = <&intmux0_ch2>;
+};
+
+&intmux0_ch2 {
+	status = "okay";
+};
+
+&intmux0_ch3 {
+	status = "okay";
+};
+
+&generic_fsk {
+	interrupt-parent = <&intmux0_ch3>;
+	status = "okay";
+};

--- a/samples/bluetooth/peripheral_hids/rv32m1_vega_ri5cy.overlay
+++ b/samples/bluetooth/peripheral_hids/rv32m1_vega_ri5cy.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lptmr1 {
+	interrupt-parent = <&intmux0_ch2>;
+};
+
+&intmux0_ch2 {
+	status = "okay";
+};
+
+&intmux0_ch3 {
+	status = "okay";
+};
+
+&generic_fsk {
+	interrupt-parent = <&intmux0_ch3>;
+	status = "okay";
+};

--- a/samples/bluetooth/peripheral_sc_only/rv32m1_vega_ri5cy.overlay
+++ b/samples/bluetooth/peripheral_sc_only/rv32m1_vega_ri5cy.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lptmr1 {
+	interrupt-parent = <&intmux0_ch2>;
+};
+
+&intmux0_ch2 {
+	status = "okay";
+};
+
+&intmux0_ch3 {
+	status = "okay";
+};
+
+&generic_fsk {
+	interrupt-parent = <&intmux0_ch3>;
+	status = "okay";
+};


### PR DESCRIPTION
The default DTS of VEGABoard does not enable the necessary nodes
for the SW LL to function; as such an overlay is needed for
each sample that is intended to be run on the VEGABoard. Some
of the samples miss this overlay so this patch adds them.

Signed-off-by: Alex Porosanu <alexandru.porosanu@nxp.com>