### PR TITLE
Bluetooth: controller: split: openisa: fix missing include

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -27,6 +27,7 @@
 #include "lll.h"
 #include "lll_vendor.h"
 #include "lll_adv.h"
+#include "lll_conn.h"
 #include "lll_chan.h"
 #include "lll_filter.h"
 


### PR DESCRIPTION
If CONFIG_BT_CTLR_CONN_RSSI is enabled, then lll_conn.h should
be included as well. Otherwise, struct lll_conn is unknown
at the compile unit level. This has been reproduced by
compiling the hci_uart sample, where the following error occurs:

lll_adv.c: In function 'isr_rx_pdu':
lll_adv.c:722:13: error: dereferencing pointer to incomplete
                         type 'struct lll_conn'
    lll->conn->rssi_latest =  radio_rssi_get();
             ^~

Signed-off-by: Alex Porosanu <alexandru.porosanu@nxp.com>