### PR TITLE
bluetooth: controller: openisa/RV32M1: fix LL scheduling

### DIFF
--- a/boards/riscv/rv32m1_vega/doc/index.rst
+++ b/boards/riscv/rv32m1_vega/doc/index.rst
@@ -152,7 +152,6 @@ with this board:
    - **no 2 Mbps PHY**
    - no 512/256 Kbps PHY
    - **no LL Privacy**
-   - no mesh support
    - **no power-save**
    - no TX power adjustment
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/cntr.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/cntr.c
@@ -104,7 +104,12 @@ u32_t cntr_cnt_get(void)
 
 void cntr_cmp_set(u8_t cmp, u32_t value)
 {
-	cnt_diff = cntr_cnt_get();
+	/*
+	 * When the LPTMR is enabled, the first increment will take an
+	 * additional one or two prescaler clock cycles due to
+	 * synchronization logic.
+	 */
+	cnt_diff = cntr_cnt_get() + 1;
 	LPTMR1->CSR &= ~LPTMR_CSR_TEN_MASK;
 
 	value -= cnt_diff;

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/ticker.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/ticker.h
@@ -7,9 +7,13 @@
 
 #define HAL_TICKER_CNTR_CLK_FREQ_HZ 32768U
 
-#define HAL_TICKER_CNTR_CMP_OFFSET_MIN 3
+#define HAL_TICKER_CNTR_CMP_OFFSET_MIN 2
 
-#define HAL_TICKER_CNTR_SET_LATENCY 0
+#define HAL_TICKER_CNTR_SET_LATENCY 1
+/*
+ * When the LPTMR is enabled, the first increment will take an additional
+ * one or two prescaler clock cycles due to synchronization logic.
+ */
 
 #define HAL_TICKER_US_TO_TICKS(x) \
 	( \

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_vendor.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_vendor.h
@@ -6,20 +6,20 @@
 
 #define EVENT_OVERHEAD_XTAL_US        1500
 #define EVENT_OVERHEAD_PREEMPT_US     0    /* if <= min, then dynamic preempt */
-#define EVENT_OVERHEAD_PREEMPT_MIN_US 0
+#define EVENT_OVERHEAD_PREEMPT_MIN_US 150
 #define EVENT_OVERHEAD_PREEMPT_MAX_US EVENT_OVERHEAD_XTAL_US
 #define EVENT_OVERHEAD_START_US       300
 /* Worst-case time margin needed after event end-time in the air
  * (done/preempt race margin + power-down/chain delay)
  */
 #define EVENT_OVERHEAD_END_US         40
-#define EVENT_JITTER_US               64
+#define EVENT_JITTER_US               16
 /* Ticker resolution margin
  * Needed due to the lack of fine timing resolution in ticker_start
- * and ticker_update. Set to 32 us, which is ~1 tick with 131072 Hz
+ * and ticker_update. Set to 32 us, which is ~1 tick with 32768 Hz
  * clock.
  */
-#define EVENT_TICKER_RES_MARGIN_US    128
+#define EVENT_TICKER_RES_MARGIN_US    32
 
 #define EVENT_RX_JITTER_US(phy) 16    /* Radio Rx timing uncertainty */
 #define EVENT_RX_TO_US(phy) ((((((phy)&0x03) + 4)<<3)/BIT((((phy)&0x3)>>1))) + \


### PR DESCRIPTION
- avoid spourious radio interrupts by fixing ISR set, waiting for idle, command configuration
- adjust counter to account for missing increment
- change preemption instant to avoid missing the deadline in LLL
- decrese EVENT_JITTER_US and EVENT_TICKER_RES_MARGIN_US (same as Nordic)

Continuous scanning and connections are working fine now.

Signed-off-by: George Stefan <george.stefan@nxp.com>