### PR TITLE
ci: bump docker image to 0.11.3 for west 0.7.0

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -20,7 +20,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.11.2
+        image_tag: v0.11.3
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 


### PR DESCRIPTION
Update to using docker image 0.11.3 so we are using west 0.7.0

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>