### PR TITLE
tracing: usb: Fix build issues.

### DIFF
--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -151,6 +151,7 @@ config TRACING_BACKEND_UART
 
 config TRACING_BACKEND_USB
 	bool "Enable USB backend"
+	depends on USB
 	depends on TRACING_ASYNC
 	help
 	  Use USB to output tracing data.

--- a/subsys/tracing/tracing_backend_usb.c
+++ b/subsys/tracing/tracing_backend_usb.c
@@ -10,7 +10,6 @@
 #include <sys/byteorder.h>
 #include <usb/usb_device.h>
 #include <usb/usb_common.h>
-#include <usb_descriptor.h>
 #include <tracing_core.h>
 #include <tracing_buffer.h>
 #include <tracing_backend.h>


### PR DESCRIPTION
1. Remove usb_descriptor.h as tracing_backend_usb.c doesn't have access
   to that include file.
2. Make TRACING_BACKEND_USB depend on USB being enabled.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>