### PR TITLE
kconfig: Make BUILD_NO_GAP_FILL independent

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -341,7 +341,6 @@ config BUILD_OUTPUT_S19
 
 config BUILD_NO_GAP_FILL
 	bool "Don't fill gaps in generated hex/bin/s19 files."
-	depends on BUILD_OUTPUT_HEX || BUILD_OUTPUT_BIN || BUILD_OUTPUT_S19
 
 config BUILD_OUTPUT_STRIPPED
 	bool "Build a stripped binary"


### PR DESCRIPTION
Even though it looks logical to not expose `BUILD_NO_GAP_FILL` when we don't expect to use `objcopy` for creation of `.bin`, `.hex` etc in reality generation of at least zephyr.hex happens if one wants to use `openocd` runner, see `CMakeLists.txt`:
```
if(CONFIG_BUILD_OUTPUT_HEX OR BOARD_FLASH_RUNNER STREQUAL openocd)
  set(out_hex_cmd    "")
  set(out_hex_byprod "")
  set(out_hex_sections_remove
    .comment
    COMMON
    .eh_frame
    )
  bintools_objcopy(
    RESULT_CMD_LIST    out_hex_cmd
    RESULT_BYPROD_LIST out_hex_byprod
    STRIP_ALL
    GAP_FILL           ${GAP_FILL}
    TARGET_OUTPUT      "ihex"
    SECTION_REMOVE     ${out_hex_sections_remove}
    FILE_INPUT         ${KERNEL_ELF_NAME}
    FILE_OUTPUT        ${KERNEL_HEX_NAME}
    )
  list(APPEND
    post_build_commands
    ${out_hex_cmd}
    )
  list(APPEND
    post_build_byproducts
    ${KERNEL_HEX_NAME}
    ${out_hex_byprod}
    )
endif()
```

So if there's a good reason to disable gap filling (like funny memory map wit huuuuge holes) let's keep that opportunity instead of relying on sanity of all the other code.