### PR TITLE
kconfig: rv32m1: Remove redundant ENTROPY_GENERATOR dependency

### DIFF
--- a/drivers/entropy/Kconfig.rv32m1
+++ b/drivers/entropy/Kconfig.rv32m1
@@ -5,7 +5,7 @@
 
 config ENTROPY_RV32M1_TRNG
 	bool "RV32M1 TRNG driver"
-	depends on ENTROPY_GENERATOR && SOC_OPENISA_RV32M1_RISCV32
+	depends on SOC_OPENISA_RV32M1_RISCV32
 	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the true random number generator (TRNG)


### PR DESCRIPTION
Kconfig.rv32m1 is already 'source'd within an 'if ENTROPY_GENERATOR', so
ENTROPY_RV32M1_TRNG does not need a 'depends on ENTROPY_GENERATOR'.

Flagged by https://github.com/zephyrproject-rtos/ci-tools/pull/128.