### PR TITLE
kconfig: Remove duplicated ARM_MPU dependency on CUSTOM_SECTION_ALIGN

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/mpu/Kconfig
+++ b/arch/arm/core/aarch32/cortex_m/mpu/Kconfig
@@ -84,7 +84,6 @@ config MPU_ALLOW_FLASH_WRITE
 
 config CUSTOM_SECTION_ALIGN
 	bool "Custom Section Align"
-	depends on ARM_MPU
 	help
 	  MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT(ARMv7-M) sometimes cause memory
 	  wasting in linker scripts defined memory sections. Use this symbol


### PR DESCRIPTION
CUSTOM_SECTION_ALIGN is already defined within an 'if ARM_MPU', so it
does not need a 'depends on ARM_MPU'.

Flagged by https://github.com/zephyrproject-rtos/ci-tools/pull/128.