### PR TITLE
sanitycheck: point to correct gcov path

### DIFF
--- a/doc/guides/coverage.rst
+++ b/doc/guides/coverage.rst
@@ -122,6 +122,13 @@ You may postprocess these with your preferred tools. For example:
    lcov --capture --directory ./ --output-file lcov.info -q --rc lcov_branch_coverage=1
    genhtml lcov.info --output-directory lcov_html -q --ignore-errors source --branch-coverage --highlight --legend
 
+.. note::
+
+   You need a recent version of lcov (at least 1.14) with support for
+   intermediate text format. Such packages exist in recent Linux distributions.
+
+   Alternatively, you can use gcovr (at least version 4.2).
+
 Sanitycheck coverage reports
 ****************************
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -4,7 +4,7 @@ anytree
 breathe>=4.9.1
 colorama
 docutils>=0.14
-gcovr
+gcovr>=4.2
 git-spindle>=2.0
 gitlint
 intelhex

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2126,7 +2126,7 @@ class ProjectBuilder(FilterBuilder):
             with report_lock:
                 self.report_out()
 
-            if self.cleanup and self.instance.status == "passed":
+            if self.cleanup and not self.coverage and self.instance.status == "passed":
                 pipeline.put({
                     "op": "cleanup",
                     "test": self.instance
@@ -4361,7 +4361,7 @@ def main():
                 options.gcov_tool = "gcov"
             else:
                 options.gcov_tool = os.path.join(os.environ["ZEPHYR_SDK_INSTALL_DIR"],
-                                                 "i586-zephyr-elf/bin/i586-zephyr-elf-gcov")
+                                                 "x86_64-zephyr-elf/bin/x86_64-zephyr-elf-gcov")
 
         logger.info("Generating coverage files...")
         coverage_tool = CoverageTool.factory(options.coverage_tool)


### PR DESCRIPTION
The SDK has a new path for x86 gcov, point to the new binary. Also, do
not clean artifacts when running coverage.

Fixes #22534