### PR TITLE
DT: augment tree and use it to re-order macros

### DIFF
--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -712,6 +712,14 @@ class Node:
       The text from the 'label' property on the node, or None if the node has
       no 'label'
 
+    labels:
+      A list of all of the devicetree labels for the node, in the same order
+      as the labels appear, but with duplicates removed.
+
+      This corresponds to the actual devicetree source labels, unlike the
+      "label" attribute, which is the value of a devicetree property named
+      "label".
+
     parent:
       The Node instance for the devicetree parent of the Node, or None if the
       node is the root node
@@ -843,6 +851,11 @@ class Node:
         if "label" in self._node.props:
             return self._node.props["label"].to_string()
         return None
+
+    @property
+    def labels(self):
+        "See the class docstring"
+        return self._node.labels
 
     @property
     def parent(self):

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2019 Nordic Semiconductor ASA
+# Copyright (c) 2019 - 2020 Nordic Semiconductor ASA
 # Copyright (c) 2019 Linaro Limited
 # SPDX-License-Identifier: BSD-3-Clause
 
@@ -278,25 +278,74 @@ def relativize(path):
 
 
 def write_regs(node):
-    # Writes address/size output for the registers in the node's 'reg' property
+    # Writes address/size output for the registers in the node's 'reg'
+    # property. This is where the BASE_ADDRESS and SIZE macros come from.
 
-    def write_reg(reg, base_ident, val):
-        # Drop '_0' from the identifier if there's a single register, for
-        # backwards compatibility
-        if len(reg.node.regs) > 1:
-            ident = f"{base_ident}_{reg.node.regs.index(reg)}"
+    if not node.regs:
+        return
+
+    # This maps a reg_i (see below) to the "primary" BASE_ADDRESS and SIZE
+    # macros used to identify it, which look like:
+    #
+    #   DT_<PRIMARY_NODE_IDENTIFIER>_BASE_ADDRESS_<reg_i>
+    #   DT_<PRIMARY_NODE_IDENTIFIER>_SIZE_<reg_i>
+    #
+    # Or, for backwards compatibility if there's only one reg:
+    #
+    #   DT_<IDENT>_BASE_ADDRESS
+    #   DT_<IDENT>_SIZE
+    #
+    # It's up to augment_node() to decide which identifier for the
+    # node is its "primary" identifier, and which identifiers are
+    # "other" identifiers. The "other" identifier BASE_ADDRESS and
+    # SIZE macros are defined in terms of the "primary" ones.
+    reg_i2primary_addr_size = {}
+
+    def write_regs_for_ident(node, ident):
+        # Write BASE_ADDRESS and SIZE macros for a given identifier
+        # 'ident'. If we have already generated primary address and
+        # size macros and saved in them in primary_addrs and
+        # primary_sizes, we just reuse those. Otherwise (i.e. the
+        # first time this is called), they are generated from the
+        # actual reg.addr and reg.size attributes, and the names of
+        # the primary macros are saved.
+
+        for reg_i, reg in enumerate(node.regs):
+            # DT_<IDENT>_BASE_ADDRESS_<reg_i>
+            # DT_<IDENT>_SIZE_<reg_i>
+            prim_addr, prim_size = reg_i2primary_addr_size.get(reg_i,
+                                                               (None, None))
+            suffix = f"_{reg_i}" if len(node.regs) > 1 else ""
+
+            if prim_addr is not None:
+                write_reg(ident, reg, prim_addr, prim_size,
+                          "", suffix)
+            else:
+                prim_addr, prim_size = write_reg(ident, reg, None, None,
+                                                 "", suffix)
+                reg_i2primary_addr_size[reg_i] = (prim_addr, prim_size)
+
+            # DT_<IDENT>_<reg.name>_BASE_ADDRESS
+            # DT_<IDENT>_<reg.name>_SIZE
+            if reg.name:
+                write_reg(ident, reg, prim_addr, prim_size,
+                          f"{str2ident(reg.name)}_", "")
+
+    def write_reg(ident, reg, prim_addr, prim_size, prefix, suffix):
+        addr = hex(reg.addr) if prim_addr is None else prim_addr
+        size = reg.size if prim_size is None else prim_size
+
+        addr_ret = out(f"{ident}_{prefix}BASE_ADDRESS{suffix}", addr)
+        if size is not None and size != 0:
+            size_ret = out(f"{ident}_{prefix}SIZE{suffix}", size)
         else:
-            ident = base_ident
+            size_ret = None
 
-        out_node(node, ident, val,
-                 # Name alias from 'reg-names = ...'
-                 f"{str2ident(reg.name)}_{base_ident}" if reg.name else None)
+        return (addr_ret, size_ret)
 
-    for reg in node.regs:
-        write_reg(reg, "BASE_ADDRESS", hex(reg.addr))
-        if reg.size:
-            write_reg(reg, "SIZE", reg.size)
-
+    out_comment("BASE_ADDRESS and SIZE macros from the 'reg' property",
+                blank_before=False)
+    for_each_ident(node, write_regs_for_ident)
 
 def write_props(node):
     # Writes any properties defined in the "properties" section of the binding

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -62,6 +62,7 @@ def main():
             flash_area_num += 1
 
         if node.enabled and node.matching_compat:
+            augment_node(node)
             write_regs(node)
             write_irqs(node)
             write_props(node)
@@ -107,6 +108,86 @@ def parse_args():
                              "as a debugging aid)")
 
     return parser.parse_args()
+
+
+def augment_node(node):
+    # Augment an EDT node with these zephyr-specific attributes, which
+    # are used to generate macros from it:
+    #
+    # - z_primary_ident: a primary node identifier based on the node's
+    #   compatible, plus information from its unit address (or its
+    #   parent's unit address) or its name, and/or its bus.
+    #
+    # - z_other_idents: a list of other identifiers for the node,
+    #   besides z_primary_ident.
+    #
+    # - z_idents: a list of all identifiers, containing the primary and other
+    #   identifiers in that order.
+    #
+    # The z_other_idents list contains the following other attributes,
+    # concatenated in this order:
+    #
+    # - z_inst_idents: node identifiers based on the index of the node
+    #   within the EDT list of nodes for each compatible, e.g.:
+    #   ["INST_3_<NODE's_COMPAT>",
+    #    "INST_2_<NODE's_OTHER_COMPAT>"]
+    #
+    # - z_alias_idents: node identifiers based on any /aliases pointing to
+    #   the node in the devicetree source, e.g.:
+    #   ["DT_ALIAS_<NODE's_ALIAS_NAME>"]
+
+    # Add the <COMPAT>_<UNIT_ADDRESS> style legacy identifier.
+    node.z_primary_ident = node_ident(node)
+
+    # Add z_instances, which are used to create these macros:
+    #
+    # #define DT_INST_<N>_<COMPAT>_<DEFINE> <VAL>
+    inst_idents = []
+    for compat in node.compats:
+        instance_no = node.edt.compat2enabled[compat].index(node)
+        inst_idents.append(f"INST_{instance_no}_{str2ident(compat)}")
+    node.z_inst_idents = inst_idents
+
+    # Add z_aliases, which are used to create these macros:
+    #
+    # #define DT_ALIAS_<ALIAS>_<DEFINE> <VAL>
+    # #define DT_<COMPAT>_<ALIAS>_<DEFINE> <VAL>
+    #
+    # TODO: See if we can remove or deprecate the second form.
+    compat_s = str2ident(node.matching_compat)
+    alias_idents = []
+    for alias in node.aliases:
+        alias_ident = str2ident(alias)
+        alias_idents.append(f"ALIAS_{alias_ident}")
+        # NOTE: in some cases (e.g. PWM_LEDS_BLUE_PWM_LET for
+        # hexiwear_k64) this is a collision with node.z_primary_ident,
+        # making the all_idents checking below necessary.
+        alias_idents.append(f"{compat_s}_{alias_ident}")
+    node.z_alias_idents = alias_idents
+
+    # z_other_idents are all the other identifiers for the node. We
+    # use the term "other" instead of "alias" here because that
+    # overlaps with the node's true aliases in the DTS, which is just
+    # part of what makes up z_other_idents.
+    all_idents = set()
+    all_idents.add(node.z_primary_ident)
+    other_idents = []
+    for ident in node.z_inst_idents + node.z_alias_idents:
+        if ident not in all_idents:
+            other_idents.append(ident)
+            all_idents.add(ident)
+    node.z_other_idents = other_idents
+
+    node.z_idents = [node.z_primary_ident] + node.z_other_idents
+
+
+def for_each_ident(node, function):
+    # Call "function" on node.z_primary_ident, then on each of the
+    # identifiers in node.z_other_idents, in that order.
+
+    function(node, node.z_primary_ident)
+    for ident in node.z_other_idents:
+        function(node, ident)
 
 
 def write_top_comment(edt):

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -1139,7 +1139,7 @@ def out_define(ident, val, deprecation_msg, out_file):
     # out() helper for writing a #define. See out() for the meaning of
     # 'deprecation_msg'.
 
-    s = f"#define DT_{ident:40}"
+    s = f"#define DT_{ident:60}"
     if deprecation_msg:
         s += fr' __WARN("{deprecation_msg}")'
     s += f" {val}"

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -1005,56 +1005,20 @@ def write_spi_dev(node):
     # Writes SPI device GPIO chip select data if there is any
 
     cs_gpio = node.spi_cs_gpio
-    if cs_gpio is not None:
-        write_phandle_val_list_entry(node, cs_gpio, None, "CS_GPIOS")
+    if cs_gpio is None:
+        return
 
-
-def write_phandle_val_list_entry(node, entry, i, ident):
-    # write_spi_dev() helper.
-    #
-    # Adds 'i' as an index to identifiers unless it's None.
-    #
-    # 'entry' is an edtlib.ControllerAndData instance.
-    #
-    # Returns the identifier for the macro that provides the
-    # initializer for the entire entry.
-
-    initializer_vals = []
-    if entry.controller.label is not None:
-        ctrl_ident = ident + "_CONTROLLER"  # e.g. PWMS_CONTROLLER
-        if entry.name:
-            name_alias = f"{str2ident(entry.name)}_{ctrl_ident}"
+    primary_macros = None
+    def write_spi_dev_for_ident(node, ident):
+        nonlocal primary_macros
+        if primary_macros is None:
+            primary_macros = write_controller_and_data_primary(ident,
+                                                               "CS_GPIOS", cs_gpio, "")
         else:
-            name_alias = None
-        # Ugly backwards compatibility hack. Only add the index if there's
-        # more than one entry.
-        if i is not None:
-            ctrl_ident += f"_{i}"
-        initializer_vals.append(quote_str(entry.controller.label))
-        out_node_s(node, ctrl_ident, entry.controller.label, name_alias)
+            write_controller_and_data_other(ident, "CS_GPIOS", cs_gpio, "",
+                                            primary_macros)
 
-    for cell, val in entry.data.items():
-        cell_ident = f"{ident}_{str2ident(cell)}"  # e.g. PWMS_CHANNEL
-        if entry.name:
-            # From e.g. 'pwm-names = ...'
-            name_alias = f"{str2ident(entry.name)}_{cell_ident}"
-        else:
-            name_alias = None
-        # Backwards compatibility (see above)
-        if i is not None:
-            cell_ident += f"_{i}"
-        out_node(node, cell_ident, val, name_alias)
-
-    initializer_vals += entry.data.values()
-
-    initializer_ident = ident
-    if entry.name:
-        name_alias = f"{initializer_ident}_{str2ident(entry.name)}"
-    else:
-        name_alias = None
-    if i is not None:
-        initializer_ident += f"_{i}"
-    return out_node_init(node, initializer_ident, initializer_vals, name_alias)
+    for_each_ident(node, write_spi_dev_for_ident)
 
 
 def write_clocks(node):
@@ -1205,16 +1169,6 @@ def out_node_s(node, ident, s, name_alias=None, deprecation_msg=None):
     # Returns the generated macro name for 'ident'.
 
     return out_node(node, ident, quote_str(s), name_alias, deprecation_msg)
-
-
-def out_node_init(node, ident, elms, name_alias=None, deprecation_msg=None):
-    # Like out_node(), but generates an {e1, e2, ...} initializer with the
-    # elements in the iterable 'elms'.
-    #
-    # Returns the generated macro name for 'ident'.
-
-    return out_node(node, ident, "{" + ", ".join(map(str, elms)) + "}",
-                    name_alias, deprecation_msg)
 
 
 def out_s(ident, val):

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -891,10 +891,12 @@ def write_flash_partition_prefix(prefix, partition_node, index):
     for i, reg in enumerate(partition_node.regs):
         # Also add aliases that point to the first sector (TODO: get rid of the
         # aliases?)
-        out(f"{prefix}_OFFSET_{i}", reg.addr,
-            aliases=[f"{prefix}_OFFSET"] if i == 0 else [])
-        out(f"{prefix}_SIZE_{i}", reg.size,
-            aliases=[f"{prefix}_SIZE"] if i == 0 else [])
+        offset = out(f"{prefix}_OFFSET_{i}", reg.addr)
+        if i == 0:
+            out(f"{prefix}_OFFSET", offset)
+        size = out(f"{prefix}_SIZE_{i}", reg.size)
+        if i == 0:
+            out(f"{prefix}_SIZE", size)
 
     controller = partition_node.flash_controller
     if controller.label is not None:
@@ -1110,13 +1112,9 @@ def out_s(ident, val):
     return out(ident, quote_str(val))
 
 
-def out(ident, val, aliases=(), deprecation_msg=None):
+def out(ident, val, deprecation_msg=None):
     # Writes '#define <ident> <val>' to the header and '<ident>=<val>' to the
     # the configuration file.
-    #
-    # Also writes any aliases listed in 'aliases' (an iterable). For the
-    # header, these look like '#define <alias> <ident>'. For the configuration
-    # file, the value is just repeated as '<alias>=<val>' for each alias.
     #
     # If a 'deprecation_msg' string is passed, the generated identifiers will
     # generate a warning if used, via __WARN(<deprecation_msg>)).
@@ -1133,14 +1131,6 @@ def out(ident, val, aliases=(), deprecation_msg=None):
     output_to_conf = not (isinstance(val, str) and val.startswith("{"))
     if output_to_conf:
         print(f"{primary_ident}={val}", file=conf_file)
-
-    for alias in aliases:
-        if alias != ident:
-            out_define(alias, "DT_" + ident, deprecation_msg, header_file)
-            if output_to_conf:
-                # For the configuration file, the value is just repeated for all
-                # the aliases
-                print(f"DT_{alias}={val}", file=conf_file)
 
     return primary_ident
 

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -147,6 +147,22 @@ def dt_chosen_enabled(kconf, _, chosen):
     node = edt.chosen_node(chosen)
     return "y" if node and node.enabled else "n"
 
+
+def dt_nodelabel_enabled(kconf, _, label):
+    """
+    This function takes a 'label' and returns "y" if we find an "enabled"
+    node that has a 'nodelabel' of 'label' in the EDT otherwise we return "n"
+    """
+    if doc_mode or edt is None:
+        return "n"
+
+    for node in edt.nodes:
+        if label in node.labels and node.enabled:
+            return "y"
+
+    return "n"
+
+
 def _node_reg_addr(node, index, unit):
     if not node:
         return 0
@@ -354,6 +370,7 @@ functions = {
         "dt_compat_enabled": (dt_compat_enabled, 1, 1),
         "dt_chosen_label": (dt_chosen_label, 1, 1),
         "dt_chosen_enabled": (dt_chosen_enabled, 1, 1),
+        "dt_nodelabel_enabled": (dt_nodelabel_enabled, 1, 1),
         "dt_chosen_reg_addr_int": (dt_chosen_reg, 1, 3),
         "dt_chosen_reg_addr_hex": (dt_chosen_reg, 1, 3),
         "dt_chosen_reg_size_int": (dt_chosen_reg, 1, 3),


### PR DESCRIPTION
This reorders the DT macros so they're easier to read.

I've tried to be careful about bisectability by making the output of this PR all the way up to the commit with shortlog `scripts: gen_defines: re-work write_bus() with augmented nodes` match the existing implementation exactly (other than the order in which macros are generated, and some additional comments). This carries forward some behavior I think is questionable, which I've left FIXME comments about.

I've run `sanitycheck --cmake-only -T samples` and wrote a [script to compare the macros](https://gist.github.com/mbolivar/af8256b7b6d2ea448e634075b262f883) before this PR and up to that commit, without any observed differences.

This new way of doing things is much more explicit about which macros are generated in the code, which should hopefully be more readable and make it easier to see things that could be removed.