### PR TITLE
scripts/requirements: Split out doc requirements into their own file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -379,6 +379,7 @@
 /scripts/net/                             @jukkar @pfl
 /scripts/process_gperf.py                 @andrewboie
 /scripts/gen_relocate_app.py              @wentongwu
+/scripts/requirements*.txt                @mbolivar @galak @nashif
 /scripts/tracing/                         @wentongwu
 /scripts/sanity_chk/                      @nashif
 /scripts/sanitycheck                      @nashif

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -114,12 +114,13 @@ Documentation presentation theme
 ********************************
 
 Sphinx supports easy customization of the generated documentation
-appearance through the use of themes.  Replace the theme files and do
+appearance through the use of themes. Replace the theme files and do
 another ``make htmldocs`` and the output layout and style is changed.
 The ``read-the-docs`` theme is installed as part of the
 ``requirements.txt`` list above, and will be used if it's available, for
 local doc generation.
 
+:ref:`install_py_requirements` step you took in the getting started guide.
 
 Running the documentation processors
 ************************************

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -246,6 +246,8 @@ directory using west:
          cd zephyrproject
          west update
 
+.. _install_py_requirements:
+
 .. rst-class:: numbered-step
 
 Install needed Python packages

--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -1,0 +1,24 @@
+# BASE: required to build or create images with zephyr
+#
+# While technically west isn't required its considered in base since its
+# part of the recommended workflow
+
+# used by various build scripts
+pyelftools>=0.24
+
+# used by dts generation to parse binding YAMLs, also used by
+# sanitycheck to parse YAMLs
+PyYAML>=5.1
+
+# used by west_commands
+packaging
+
+# intelhex used by mergehex.py
+intelhex
+
+# it's west
+west>=0.6.2
+
+# used for windows based 'menuconfig'
+# "win32" is used for 64-bit Windows as well
+windows-curses; sys_platform == "win32"

--- a/scripts/requirements-build-test.txt
+++ b/scripts/requirements-build-test.txt
@@ -1,0 +1,19 @@
+# BUILD-TEST: required to do build tests of zephyr
+#
+# things used by sanitycheck or other things like code coverage or python
+# testing
+
+# used by sanitycheck for ansi color
+colorama
+
+# python lex/yex used by sanitycheck
+ply>=3.10
+
+# optional, but used for validation of YAML
+pykwalify
+
+# used for code coverage
+gcovr>=4.2
+
+# used for west-command testing
+pytest

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,0 +1,6 @@
+breathe>=4.9.1
+docutils>=0.14
+sphinx>=1.7.5
+sphinx_rtd_theme
+sphinx-tabs
+sphinxcontrib-svg2pdfconverter

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,3 +1,5 @@
+# DOC: used to generate docs
+
 breathe>=4.9.1
 docutils>=0.14
 sphinx>=1.7.5

--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -1,0 +1,14 @@
+# EXTRAS: required to build or create images with zephyr
+
+# used by sanitycheck for --test-tree option
+anytree
+
+# helper for developers - check git commit messages
+gitlint
+
+# helper for developers
+junit2html
+
+# used by scripts/gen_cfb_font_header.py - helper script for user
+Pillow
+

--- a/scripts/requirements-run-test.txt
+++ b/scripts/requirements-run-test.txt
@@ -1,0 +1,12 @@
+# RUN-TEST: required to do run time tests of zephyr
+#
+# things used by sanitycheck or related in run time testing
+
+# used to connect to boards for console IO
+pyserial
+
+# used to flash & debug various boards
+pyocd>=0.24.0
+
+# used by sanitycheck for board/hardware map
+tabulate

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,22 +1,9 @@
-Pillow
-PyYAML>=5.1
-anytree
-colorama
-gcovr>=4.2
+# ????
 git-spindle>=2.0
-gitlint
-intelhex
-junit2html
-packaging
-ply>=3.10
-pyelftools>=0.24
-pykwalify
-pyocd>=0.24.0
-pyserial
-pytest
-tabulate
-west>=0.6.2
+# ????
 wheel>=0.30.0
-# "win32" is used for 64-bit Windows as well
-windows-curses; sys_platform == "win32"
+-r requirements-base.txt
+-r requirements-build-test.txt
 -r requirements-doc.txt
+-r requirements-run-test.txt
+-r requirements-extras.txt

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,9 +1,7 @@
 Pillow
 PyYAML>=5.1
 anytree
-breathe>=4.9.1
 colorama
-docutils>=0.14
 gcovr>=4.2
 git-spindle>=2.0
 gitlint
@@ -16,12 +14,9 @@ pykwalify
 pyocd>=0.24.0
 pyserial
 pytest
-sphinx>=1.7.5
-sphinx_rtd_theme
-sphinx-tabs
-sphinxcontrib-svg2pdfconverter
 tabulate
 west>=0.6.2
 wheel>=0.30.0
 # "win32" is used for 64-bit Windows as well
 windows-curses; sys_platform == "win32"
+-r requirements-doc.txt


### PR DESCRIPTION
Split the requirements.txt so we can manage different uses.  For
example if you don't need to build the docs you can ignore the
requirements in requirements-doc.txt, or if you ONLY need to build
the docs (for example CI doc job) you can just pay attention to
what's in requirements-doc.txt.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>