### PR TITLE
ci: github: doc: Add a GH workflow to test build the docs

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -1,0 +1,79 @@
+# Copyright (c) 2020 Linaro Limited.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Documentation
+
+on: [pull_request, push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Update PATH for west
+      run: |
+        echo "::add-path::$HOME/.local/bin"
+
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - name: install-pkgs
+      run: |
+        sudo apt-get install -y ninja-build doxygen
+
+    - name: cache-pip
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-doc-pip
+
+    - name: install-pip
+      run: |
+        pip3 install setuptools
+        pip3 install 'breathe>=4.9.1' 'docutils>=0.14' \
+                     'sphinx>=1.7.5' sphinx_rtd_theme sphinx-tabs \
+                     sphinxcontrib-svg2pdfconverter 'west>=0.6.2'
+
+    - name: cache-zephyr-modules
+      uses: actions/cache@v1
+      with:
+        path: ../modules
+        key: ${{ runner.os }}-zephyr-modules-${{ hashFiles('west.yml') }}
+
+    - name: cache-zephyr-tools
+      uses: actions/cache@v1
+      with:
+        path: ../tools
+        key: ${{ runner.os }}-zephyr-tools-${{ hashFiles('west.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-doc-zephyr-tools
+
+    - name: west setup
+      run: |
+        west init -l . || true
+        west update
+
+    - name: build-docs
+      run: |
+        source zephyr-env.sh
+        make htmldocs
+        tar cvf htmldocs.tar --directory=./doc/_build html
+
+    - name: upload-build
+      uses: actions/upload-artifact@master
+      continue-on-error: True
+      with:
+        name: htmldocs.tar
+        path: htmldocs.tar
+
+    - name: check-warns
+      run: |
+        if [ -s doc/_build/doc.warnings ]; then
+           docwarn=$(cat doc/_build/doc.warnings)
+           docwarn="${docwarn//'%'/'%25'}"
+           docwarn="${docwarn//$'\n'/'%0A'}"
+           docwarn="${docwarn//$'\r'/'%0D'}"
+           # We treat doc warnings as errors
+           echo "::error file=doc.warnings::$docwarn"
+           exit 1
+        fi


### PR DESCRIPTION
This github workflow will build the html docs on a pull request or push.
This is similar to the current ci-tools 'Documentation' check.  One
difference is this version produces a GH artifact of the html docs
instead of posting it to S3.  The artifact is a tarball that is than
zip'd (not gzip).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>