### PR TITLE
sanitycheck: make pyserial optional

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -185,7 +185,6 @@ import time
 import csv
 import yaml
 import glob
-import serial
 import concurrent
 import xml.etree.ElementTree as ET
 import logging
@@ -194,6 +193,11 @@ from collections import OrderedDict
 from itertools import islice
 from pathlib import Path
 from distutils.spawn import find_executable
+
+try:
+    import serial
+except ImportError:
+    print("Install pyserial python module with pip to use --device-testing option.")
 
 try:
     from anytree import Node, RenderTree, find


### PR DESCRIPTION
We only need pyserial python module if we are doing device testing.
Treat it similar to how we treat tabulate module.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>