### PR TITLE
WIP: Abolish Z_OOPS()

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -761,6 +761,25 @@ extern void k_thread_foreach_unlocked(
  * stack overflows this region and stack protection features may not detect this
  * situation.
  *
+ * Threads may not be created from interrupt service routines.
+ *
+ * When created from user mode, additional checks are performed:
+ *
+ * 1. The caller must have permission on both the target thread and stack
+ *    objects.
+ * 2. The target thread and stack objects must not be in use, the thread object
+ *    must either never have been run, or is currently in an aborted state. The
+ *    stack object must not be associated with any thread that doesn't meet the
+ *    previous criteria.
+ * 3. The provided stack size should be equal to or less than the amount of
+ *    stack space available in the provided stack object.
+ * 4. The options must contain K_USER, user threads may not create supervisor
+ *    threads.
+ * 5. The options must not contain K_ESSENTIAL, user threads are not allowed
+ *    to create essential threads.
+ * 6. The priority value provided must be valid and must be the same or worse
+ *    priority than the caller.
+ *
  * @param new_thread Pointer to uninitialized struct k_thread
  * @param stack Pointer to the stack space.
  * @param stack_size Stack size in bytes.
@@ -772,7 +791,8 @@ extern void k_thread_foreach_unlocked(
  * @param options Thread options.
  * @param delay Scheduling delay (in milliseconds), or K_NO_WAIT (for no delay).
  *
- * @return ID of new thread.
+ * @return ID of new thread, or NULL if an error occurred or bad parameters
+ *         were supplied.
  *
  * @req K-THREAD-001
  */

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3470,7 +3470,10 @@ struct k_sem {
  * @param limit Maximum permitted semaphore count.
  *
  * @retval 0 Semaphore created successfully
- * @retval -EINVAL Invalid values
+ * @retval -EINVAL limit is 0
+ * @retval -EINVAL intial_count is greater than limit
+ * @retval -EBADF Not a semaphore object (user mode only)
+ * @retval -EACCES No permission on target semaphore (user mode only)
  *
  * @req K-SEM-001
  */
@@ -3492,6 +3495,9 @@ __syscall int k_sem_init(struct k_sem *sem, unsigned int initial_count,
  * @retval 0 Semaphore taken.
  * @retval -EBUSY Returned without waiting.
  * @retval -EAGAIN Waiting period timed out.
+ * @retval -EBADF Not a semaphore object (user mode only)
+ * @retval -EACCES No permission on target semaphore (user mode only)
+ * @retval -EINVAL Semaphore is uninitialized (user mode only)
  * @req K-SEM-001
  */
 __syscall int k_sem_take(struct k_sem *sem, s32_t timeout);
@@ -3505,11 +3511,14 @@ __syscall int k_sem_take(struct k_sem *sem, s32_t timeout);
  * @note Can be called by ISRs.
  *
  * @param sem Address of the semaphore.
+ * @retval -EBADF Not a semaphore object (user mode only)
+ * @retval -EACCES No permission on target semaphore (user mode only)
+ * @retval -EINVAL Semaphore is uninitialized (user mode only)
+ * @retval 0 Success
  *
- * @return N/A
  * @req K-SEM-001
  */
-__syscall void k_sem_give(struct k_sem *sem);
+__syscall int k_sem_give(struct k_sem *sem);
 
 /**
  * @brief Reset a semaphore's count to zero.
@@ -3517,18 +3526,23 @@ __syscall void k_sem_give(struct k_sem *sem);
  * This routine sets the count of @a sem to zero.
  *
  * @param sem Address of the semaphore.
+ * @retval -EBADF Not a semaphore object (user mode only)
+ * @retval -EACCES No permission on target semaphore (user mode only)
+ * @retval -EINVAL Semaphore is uninitialized (user mode only)
+ * @retval 0 Success
  *
- * @return N/A
  * @req K-SEM-001
  */
-__syscall void k_sem_reset(struct k_sem *sem);
+__syscall int k_sem_reset(struct k_sem *sem);
 
 /**
  * @internal
  */
-static inline void z_impl_k_sem_reset(struct k_sem *sem)
+static inline int z_impl_k_sem_reset(struct k_sem *sem)
 {
 	sem->count = 0U;
+
+	return 0;
 }
 
 /**
@@ -3538,15 +3552,19 @@ static inline void z_impl_k_sem_reset(struct k_sem *sem)
  *
  * @param sem Address of the semaphore.
  *
+ * @retval -EBADF Not a semaphore object (user mode only)
+ * @retval -EACCES No permission on target semaphore (user mode only)
+ * @retval -EINVAL Semaphore is uninitialized (user mode only)
  * @return Current semaphore count.
+ *
  * @req K-SEM-001
  */
-__syscall unsigned int k_sem_count_get(struct k_sem *sem);
+__syscall int k_sem_count_get(struct k_sem *sem);
 
 /**
  * @internal
  */
-static inline unsigned int z_impl_k_sem_count_get(struct k_sem *sem)
+static inline int z_impl_k_sem_count_get(struct k_sem *sem)
 {
 	return sem->count;
 }

--- a/include/syscall_handler.h
+++ b/include/syscall_handler.h
@@ -43,7 +43,7 @@ enum _obj_init_check {
  *             or uninitialized state, or that we don't care
  * @return 0 If the object is valid
  *         -EBADF if not a valid object of the specified type
- *         -EPERM If the caller does not have permissions
+ *         -EACCES If the caller does not have permissions
  *         -EINVAL Object is not initialized
  */
 int z_object_validate(struct _k_object *ko, enum k_objects otype,
@@ -203,7 +203,7 @@ extern void *z_user_alloc_from_copy(const void *src, size_t size);
  * @param src Source memory buffer, in userspace
  * @param size Number of bytes to copy
  * @retval 0 On success
- * @retval EFAULT On memory access error
+ * @retval -EFAULT On memory access error
  */
 extern int z_user_from_copy(void *dst, const void *src, size_t size);
 
@@ -218,7 +218,7 @@ extern int z_user_from_copy(void *dst, const void *src, size_t size);
  * @param src Source memory buffer
  * @param size Number of bytes to copy
  * @retval 0 On success
- * @retval EFAULT On memory access error
+ * @retval -EFAULT On memory access error
  */
 extern int z_user_to_copy(void *dst, const void *src, size_t size);
 
@@ -250,9 +250,9 @@ extern char *z_user_string_alloc_copy(const char *src, size_t maxlen);
  * @param src Source string pointer, in userspace
  * @param maxlen Maximum size of the string including trailing NULL
  * @retval 0 on success
- * @retval EINVAL if the source string is too long with respect
+ * @retval -EINVAL if the source string is too long with respect
  *	to maxlen
- * @retval EFAULT On memory access error
+ * @retval -EFAULT On memory access error
  */
 extern int z_user_string_copy(char *dst, const char *src, size_t maxlen);
 

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -90,7 +90,12 @@ int z_impl_k_sem_init(struct k_sem *sem, unsigned int initial_count,
 int z_vrfy_k_sem_init(struct k_sem *sem, unsigned int initial_count,
 		      unsigned int limit)
 {
-	Z_OOPS(Z_SYSCALL_OBJ_INIT(sem, K_OBJ_SEM));
+	int ret = k_syscall_obj_init(sem, K_OBJ_SEM);
+
+	if (ret) {
+		return ret;
+	}
+
 	return z_impl_k_sem_init(sem, initial_count, limit);
 }
 #include <syscalls/k_sem_init_mrsh.c>
@@ -105,7 +110,7 @@ static inline void handle_poll_events(struct k_sem *sem)
 #endif
 }
 
-void z_impl_k_sem_give(struct k_sem *sem)
+int z_impl_k_sem_give(struct k_sem *sem)
 {
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	struct k_thread *thread = z_unpend_first_thread(&sem->wait_q);
@@ -122,13 +127,20 @@ void z_impl_k_sem_give(struct k_sem *sem)
 
 	sys_trace_end_call(SYS_TRACE_ID_SEMA_GIVE);
 	z_reschedule(&lock, key);
+
+	return 0;
 }
 
 #ifdef CONFIG_USERSPACE
-static inline void z_vrfy_k_sem_give(struct k_sem *sem)
+static inline int z_vrfy_k_sem_give(struct k_sem *sem)
 {
-	Z_OOPS(Z_SYSCALL_OBJ(sem, K_OBJ_SEM));
-	z_impl_k_sem_give(sem);
+	int ret = k_syscall_obj(sem, K_OBJ_SEM);
+
+	if (ret) {
+		return ret;
+	}
+
+	return z_impl_k_sem_give(sem);
 }
 #include <syscalls/k_sem_give_mrsh.c>
 #endif
@@ -165,21 +177,36 @@ out:
 #ifdef CONFIG_USERSPACE
 static inline int z_vrfy_k_sem_take(struct k_sem *sem, s32_t timeout)
 {
-	Z_OOPS(Z_SYSCALL_OBJ(sem, K_OBJ_SEM));
+	int ret = k_syscall_obj(sem, K_OBJ_SEM);
+
+	if (ret) {
+		return ret;
+	}
+
 	return z_impl_k_sem_take((struct k_sem *)sem, timeout);
 }
 #include <syscalls/k_sem_take_mrsh.c>
 
-static inline void z_vrfy_k_sem_reset(struct k_sem *sem)
+static inline int z_vrfy_k_sem_reset(struct k_sem *sem)
 {
-	Z_OOPS(Z_SYSCALL_OBJ(sem, K_OBJ_SEM));
-	z_impl_k_sem_reset(sem);
+	int ret = k_syscall_obj(sem, K_OBJ_SEM);
+
+	if (ret) {
+		return ret;
+	}
+
+	return z_impl_k_sem_reset(sem);
 }
 #include <syscalls/k_sem_reset_mrsh.c>
 
-static inline unsigned int z_vrfy_k_sem_count_get(struct k_sem *sem)
+static inline int z_vrfy_k_sem_count_get(struct k_sem *sem)
 {
-	Z_OOPS(Z_SYSCALL_OBJ(sem, K_OBJ_SEM));
+	int ret = k_syscall_obj(sem, K_OBJ_SEM);
+
+	if (ret) {
+		return ret;
+	}
+
 	return z_impl_k_sem_count_get(sem);
 }
 #include <syscalls/k_sem_count_get_mrsh.c>

--- a/tests/kernel/mem_protect/mem_protect/src/kobject.c
+++ b/tests/kernel/mem_protect/mem_protect/src/kobject.c
@@ -524,18 +524,18 @@ void kobject_test_user_2_14(void *p1, void *p2, void *p3)
 
 void kobject_test_user_1_14(void *p1, void *p2, void *p3)
 {
-	valid_fault = true;
-	USERSPACE_BARRIER;
+	k_tid_t ret;
 
-	k_thread_create(&kobject_test_14_tid,
-			kobject_stack_1,
-			KOBJECT_STACK_SIZE,
-			kobject_test_user_2_14,
-			NULL, NULL, NULL,
-			0, K_USER, K_NO_WAIT);
+	valid_fault = false;
 
-	zassert_unreachable("_SYSCALL_OBJ implementation failure.");
+	ret = k_thread_create(&kobject_test_14_tid,
+			      kobject_stack_1,
+			      KOBJECT_STACK_SIZE,
+			      kobject_test_user_2_14,
+			      NULL, NULL, NULL,
+			      0, K_USER, K_NO_WAIT);
 
+	zassert_equal(ret, NULL, "Z_SYSCALL_OBJ implementation failure.");
 }
 /**
  * @brief Test to reinitialize the k_thread object

--- a/tests/kernel/mem_protect/obj_validation/src/main.c
+++ b/tests/kernel/mem_protect/obj_validation/src/main.c
@@ -49,7 +49,7 @@ static int test_object(struct k_sem *sem, int retval)
 void object_permission_checks(struct k_sem *sem, bool skip_init)
 {
 	/* Should fail because we don't have perms on this object */
-	zassert_false(test_object(sem, -EPERM),
+	zassert_false(test_object(sem, -EACCES),
 		      "object should not have had permission granted");
 
 	k_object_access_grant(sem, k_current_get());

--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -67,7 +67,7 @@ int z_impl_string_copy(char *src)
 	if (!strcmp(src, kernel_string)) {
 		return 0;
 	} else {
-		return ESRCH;
+		return -ESRCH;
 	}
 }
 
@@ -211,13 +211,13 @@ void test_user_string_copy(void)
 	int ret;
 
 	ret = string_copy("asdkajshdazskjdh");
-	zassert_equal(ret, ESRCH, "got %d", ret);
+	zassert_equal(ret, -ESRCH, "got %d", ret);
 
 	ret = string_copy("asdkajshdazskjdhikfsdjhfskdjfhsdkfjhskdfjhdskfjhs");
-	zassert_equal(ret, EINVAL, "got %d", ret);
+	zassert_equal(ret, -EINVAL, "got %d", ret);
 
 	ret = string_copy(kernel_string);
-	zassert_equal(ret, EFAULT, "got %d", ret);
+	zassert_equal(ret, -EFAULT, "got %d", ret);
 
 	ret = string_copy("this is a kernel string");
 	zassert_equal(ret, 0, "string should have matched");
@@ -236,7 +236,7 @@ void test_to_copy(void)
 	int ret;
 
 	ret = to_copy(kernel_buf);
-	zassert_equal(ret, EFAULT, "should have faulted");
+	zassert_equal(ret, -EFAULT, "should have faulted");
 
 	ret = to_copy(buf);
 	zassert_equal(ret, 0, "copy should have been a success");


### PR DESCRIPTION
Work-in-progress patch to eliminate Z_OOPS() usage and have system calls always propagate return values.

See #17735 