### PR TITLE
github: Rename GitHub workflow action

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Linaro Limited.
 # SPDX-License-Identifier: Apache-2.0
 
-name: Documentation
+name: Documentation GitHub Workflow
 
 on: [pull_request, push]
 


### PR DESCRIPTION
GitHub checks need to be uniquely named, and 'Documentation' conflicts
with the ci-tool name.  Rename this while we are running both so the
names don't conflict.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>