### PR TITLE
SAMV71 Add missing drivers dependency

### DIFF
--- a/boards/arm/sam_v71_xult/doc/index.rst
+++ b/boards/arm/sam_v71_xult/doc/index.rst
@@ -98,9 +98,6 @@ Programming and Debugging
 *************************
 
 Flashing the Zephyr project onto SAM V71 MCU requires the `OpenOCD tool`_.
-Support for Atmel SAM E microcontroller series was added in OpenOCD release
-0.10.0, which was added in Zephyr SDK 0.9.2.
-
 By default a factory new SAM V71 chip will boot the `SAM-BA`_ boot loader
 located in the ROM, not the flashed image. This is determined by the value
 of GPNVM1 (General-Purpose NVM bit 1). The flash procedure will ensure that
@@ -177,4 +174,4 @@ SAM V71 Product Page:
     http://openocd.org/
 
 .. _SAM-BA:
-    http://www.atmel.com/tools/ATMELSAM-BAIN-SYSTEMPROGRAMMER.aspx
+    https://www.microchip.com/developmenttools/ProductDetails/PartNO/SAM-BA%20In-system%20Programmer

--- a/drivers/flash/Kconfig.sam
+++ b/drivers/flash/Kconfig.sam
@@ -9,6 +9,7 @@ config SOC_FLASH_SAM
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_DRIVER_ENABLED
 	depends on SOC_FAMILY_SAM
-	depends on SOC_SERIES_SAME70
+	depends on SOC_SERIES_SAME70 || \
+		   SOC_SERIES_SAMV71
 	help
 	  Enable the Atmel SAM series internal flash driver.

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -54,7 +54,10 @@ static int gpio_sam_port_configure(struct device *dev, u32_t mask,
 		pio->PIO_IDR = mask;
 		/* Disable pull-up. */
 		pio->PIO_PUDR = mask;
-#if defined(CONFIG_SOC_SERIES_SAM4S) || defined(CONFIG_SOC_SERIES_SAME70)
+#if defined(CONFIG_SOC_SERIES_SAM4S) || \
+	defined(CONFIG_SOC_SERIES_SAM4E) || \
+	defined(CONFIG_SOC_SERIES_SAME70) || \
+	defined(CONFIG_SOC_SERIES_SAMV71)
 		/* Disable pull-down. */
 		pio->PIO_PPDDR = mask;
 #endif
@@ -93,7 +96,10 @@ static int gpio_sam_port_configure(struct device *dev, u32_t mask,
 	 * Clear both pulls, then enable the one we need.
 	 */
 	pio->PIO_PUDR = mask;
-#if defined(CONFIG_SOC_SERIES_SAM4S) || defined(CONFIG_SOC_SERIES_SAME70)
+#if defined(CONFIG_SOC_SERIES_SAM4S) || \
+	defined(CONFIG_SOC_SERIES_SAM4E) || \
+	defined(CONFIG_SOC_SERIES_SAME70) || \
+	defined(CONFIG_SOC_SERIES_SAMV71)
 	pio->PIO_PPDDR = mask;
 #endif
 	if (flags & GPIO_PULL_UP) {

--- a/drivers/i2s/Kconfig.sam_ssc
+++ b/drivers/i2s/Kconfig.sam_ssc
@@ -47,7 +47,8 @@ config I2S_SAM_SSC_0_DMA_TX_CHANNEL
 
 choice I2S_SAM_SSC_0_PIN_TD_SELECT
 	prompt "TD pin"
-	depends on SOC_SERIES_SAME70
+	depends on SOC_SERIES_SAME70 || \
+		   SOC_SERIES_SAMV71
 
 	config I2S_SAM_SSC_0_PIN_TD_PB5
 		bool "PB5"

--- a/drivers/serial/Kconfig.uart_sam
+++ b/drivers/serial/Kconfig.uart_sam
@@ -28,10 +28,11 @@ config UART_SAM_PORT_1
 	help
 	  Enable UART1 at boot.
 
-choice UART_SAME70_PORT_1_PIN_TX
+choice UART_SAM_PORT_1_PIN_TX
 	prompt "TX pin"
-	depends on SOC_SERIES_SAME70
 	depends on UART_SAM_PORT_1
+	depends on SOC_SERIES_SAME70 || \
+		   SOC_SERIES_SAMV71
 
 	config UART_SAM_PORT_1_PIN_TX_PA4
 		bool "PA4"
@@ -48,6 +49,8 @@ endchoice
 config UART_SAM_PORT_2
 	bool "Enable UART2"
 	depends on UART_SAM
+	depends on SOC_SERIES_SAME70 || \
+		   SOC_SERIES_SAMV71
 	help
 	  Enable UART2 at boot
 
@@ -56,13 +59,16 @@ config UART_SAM_PORT_2
 config UART_SAM_PORT_3
 	bool "Enable UART3"
 	depends on UART_SAM
+	depends on SOC_SERIES_SAME70 || \
+		   SOC_SERIES_SAMV71
 	help
 	  Enable UART3 at boot
 
-choice UART_SAME70_PORT_3_PIN_TX
+choice UART_SAM_PORT_3_PIN_TX
 	prompt "TX pin"
-	depends on SOC_SERIES_SAME70
 	depends on UART_SAM_PORT_3
+	depends on SOC_SERIES_SAME70 || \
+		   SOC_SERIES_SAMV71
 
 	config UART_SAM_PORT_3_PIN_TX_PD30
 		bool "PD30"
@@ -76,13 +82,16 @@ endchoice
 config UART_SAM_PORT_4
 	bool "Enable UART4"
 	depends on UART_SAM
+	depends on SOC_SERIES_SAME70 || \
+		   SOC_SERIES_SAMV71
 	help
 	  Enable UART4 at boot
 
-choice UART_SAME70_PORT_4_PIN_TX
+choice UART_SAM_PORT_4_PIN_TX
 	prompt "TX pin"
-	depends on SOC_SERIES_SAME70
 	depends on UART_SAM_PORT_4
+	depends on SOC_SERIES_SAME70 || \
+		   SOC_SERIES_SAMV71
 
 	config UART_SAM_PORT_4_PIN_TX_PD3
 		bool "PD3"

--- a/drivers/serial/Kconfig.usart_sam
+++ b/drivers/serial/Kconfig.usart_sam
@@ -32,5 +32,7 @@ config USART_SAM_PORT_1
 config USART_SAM_PORT_2
 	bool "Enable USART2"
 	depends on USART_SAM
+	depends on SOC_SERIES_SAME70 || \
+		   SOC_SERIES_SAMV71
 	help
 	  Enable USART2 at boot


### PR DESCRIPTION
This will enable the missing compatible drivers already on Zephyr for SAMV71. This drivers are the same and have been used by SAME70. It will fix missing config on GPIO driver for four Atmel SAM SoC. The series of depends on at Kconfig files will enable only valid options since is it a shared configuration.
The last change will fix SAM-BA link on documentation to right place at MHCP web site.
