### PR TITLE
doc: Add reference in toplevel README.rst to install_py_requirements

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -114,12 +114,11 @@ Documentation presentation theme
 ********************************
 
 Sphinx supports easy customization of the generated documentation
-appearance through the use of themes.  Replace the theme files and do
+appearance through the use of themes. Replace the theme files and do
 another ``make htmldocs`` and the output layout and style is changed.
 The ``read-the-docs`` theme is installed as part of the
-``requirements.txt`` list above, and will be used if it's available, for
-local doc generation.
-
+:ref:`install_py_requirements` step you took in the getting started
+guide.
 
 Running the documentation processors
 ************************************

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -246,6 +246,8 @@ directory using west:
          cd zephyrproject
          west update
 
+.. _install_py_requirements:
+
 .. rst-class:: numbered-step
 
 Install needed Python packages


### PR DESCRIPTION
In the section 'Documentation presentation theme' put a reference to
'install_py_requirements' section in the getting start guide.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>