### PR TITLE
canbus: isotp: Fix nullptr deref and wrong variable in assert (Coverity issues)

### DIFF
--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -432,6 +432,7 @@ static inline void receive_add_mem(struct isotp_recv_ctx *ctx, u8_t *data,
 	if (!ctx->act_frag) {
 		LOG_ERR("No fragmet left to append data");
 		receive_report_error(ctx, ISOTP_N_BUFFER_OVERFLW);
+		return;
 	}
 
 	net_buf_add_mem(ctx->act_frag, data + tailroom, len - tailroom);

--- a/tests/subsys/canbus/isotp/implementation/src/main.c
+++ b/tests/subsys/canbus/isotp/implementation/src/main.c
@@ -191,7 +191,7 @@ static void receive_test_data(struct isotp_recv_ctx *recv_ctx,
 		memset(data_buf, 0, sizeof(data_buf));
 		ret = isotp_recv(recv_ctx, data_buf, sizeof(data_buf),
 				 K_MSEC(1000));
-		zassert_true(data_buf >= 0, "recv error: %d", ret);
+		zassert_true(ret >= 0, "recv error: %d", ret);
 
 		zassert_true(remaining_len >= ret, "More data then expected");
 		check_data(data_buf, data_ptr, ret);


### PR DESCRIPTION
This PR is a fix for CID 208191(#22657) and CID 208192 (#22656)

fixes #22657 
fixes #22656