### PR TITLE
drivers: gpio_sx1509b: correct handling of initialized output

### DIFF
--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -179,8 +179,10 @@ static int sx1509b_config(struct device *dev,
 		pins->dir &= ~BIT(pin);
 		if ((flags & GPIO_OUTPUT_INIT_LOW) != 0) {
 			pins->data &= ~BIT(pin);
+			data_first = true;
 		} else if ((flags & GPIO_OUTPUT_INIT_HIGH) != 0) {
 			pins->data |= BIT(pin);
+			data_first = true;
 		}
 	} else {
 		pins->dir |= BIT(pin);


### PR DESCRIPTION
The data_first flag was intended to be set when the configuration
requires setting the output value before setting the direction.
Respect the intent.

Fixes #22640