### PR TITLE
kconfig: Replace defconfig singe-symbol 'if's with 'depends on'

### DIFF
--- a/boards/arc/em_starterkit/Kconfig.defconfig
+++ b/boards/arc/em_starterkit/Kconfig.defconfig
@@ -48,19 +48,13 @@ endif # I2C_DW
 
 endif # I2C
 
-if SERIAL
-
 config UART_NS16550
 	default y
-
-endif # SERIAL
-
-if UART_CONSOLE
+	depends on SERIAL
 
 config UART_NS16550_PORT_1
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 if SPI
 

--- a/boards/arc/emsdp/Kconfig.defconfig
+++ b/boards/arc/emsdp/Kconfig.defconfig
@@ -26,18 +26,12 @@ endif # GPIO_DW
 
 endif # GPIO
 
-if SERIAL
-
 config UART_NS16550
 	default y
-
-endif # SERIAL
-
-if UART_CONSOLE
+	depends on SERIAL
 
 config UART_NS16550_PORT_0
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 endif # BOARD_EMSDP

--- a/boards/arc/hsdk/Kconfig.defconfig
+++ b/boards/arc/hsdk/Kconfig.defconfig
@@ -11,12 +11,9 @@ if GPIO
 config GPIO_DW
 	default y
 
-if GPIO_DW
-
 config GPIO_DW_0
 	default y
-
-endif # GPIO_DW
+	depends on GPIO_DW
 
 endif # GPIO
 

--- a/boards/arc/iotdk/Kconfig.defconfig
+++ b/boards/arc/iotdk/Kconfig.defconfig
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_IOTDK
-
 config BOARD
 	default "iotdk"
-
-endif # BOARD_IOTDK
+	depends on BOARD_IOTDK

--- a/boards/arc/nsim/Kconfig.defconfig
+++ b/boards/arc/nsim/Kconfig.defconfig
@@ -5,12 +5,8 @@ if BOARD_NSIM
 config BOARD
 	default "nsim"
 
-if SERIAL
-
 config UART_NSIM
 	default y
-
-endif # SERIAL
-
+	depends on SERIAL
 
 endif # BOARD_NSIM

--- a/boards/arm/96b_argonkey/Kconfig.defconfig
+++ b/boards/arm/96b_argonkey/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_96B_ARGONKEY
 config BOARD
 	default "96b_argonkey"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 if I2C
 

--- a/boards/arm/96b_avenger96/Kconfig.defconfig
+++ b/boards/arm/96b_avenger96/Kconfig.defconfig
@@ -8,18 +8,12 @@ if BOARD_96B_AVENGER96
 config BOARD
 	default "96b_avenger96"
 
-if UART_CONSOLE
-
 config UART_7
 	default y
-
-endif # UART_CONSOLE
-
-if SERIAL
+	depends on UART_CONSOLE
 
 config UART_4
 	default y
-
-endif # SERIAL
+	depends on SERIAL
 
 endif # BOARD_96B_AVENGER96

--- a/boards/arm/96b_carbon/Kconfig.defconfig
+++ b/boards/arm/96b_carbon/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_96B_CARBON
 config BOARD
 	default "96b_carbon"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 if SERIAL
 

--- a/boards/arm/96b_meerkat96/Kconfig.defconfig
+++ b/boards/arm/96b_meerkat96/Kconfig.defconfig
@@ -8,19 +8,13 @@ if BOARD_96B_MEERKAT96
 config BOARD
 	default "96b_meerkat96"
 
-if GPIO_IMX
-
 config GPIO_IMX_PORT_1
 	default y
-
-endif # GPIO_IMX
-
-if UART_IMX
+	depends on GPIO_IMX
 
 config UART_IMX_UART_1
 	default y
-
-endif # UART_IMX
+	depends on UART_IMX
 
 if !XIP
 config FLASH_SIZE

--- a/boards/arm/96b_neonkey/Kconfig.defconfig
+++ b/boards/arm/96b_neonkey/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_96B_NEONKEY
 config BOARD
 	default "96b_neonkey"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 if I2C
 

--- a/boards/arm/96b_nitrogen/Kconfig.defconfig
+++ b/boards/arm/96b_nitrogen/Kconfig.defconfig
@@ -8,19 +8,13 @@ if BOARD_96B_NITROGEN
 config BOARD
 	default "96b_nitrogen"
 
-if I2C
-
 config I2C_0
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_1
 	default y
-
-endif # SPI
+	depends on SPI
 
 config BT_CTLR
 	default BT

--- a/boards/arm/96b_stm32_sensor_mez/Kconfig.defconfig
+++ b/boards/arm/96b_stm32_sensor_mez/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_96B_STM32_SENSOR_MEZ
 config BOARD
 	default "96b_stm32_sensor_mez"
 
-if UART_CONSOLE
-
 config UART_4
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 if I2C
 

--- a/boards/arm/96b_wistrio/Kconfig.defconfig
+++ b/boards/arm/96b_wistrio/Kconfig.defconfig
@@ -8,18 +8,12 @@ if BOARD_96B_WISTRIO
 config BOARD
 	default "96b_wistrio"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
-
-if I2C
+	depends on UART_CONSOLE
 
 config I2C_1
 	default y
-
-endif # I2C
+	depends on I2C
 
 endif # BOARD_96B_WISTRIO

--- a/boards/arm/actinius_icarus/Kconfig.defconfig
+++ b/boards/arm/actinius_icarus/Kconfig.defconfig
@@ -8,33 +8,21 @@ if BOARD_ACTINIUS_ICARUS || BOARD_ACTINIUS_ICARUS_NS
 config BOARD
 	default "actinius_icarus"
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if I2C
+	depends on ADC
 
 config I2C_2
 	default y
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_0
 	default y
-
-endif # PWM
-
-if SPI
+	depends on PWM
 
 config SPI_3
 	default y
-
-endif # SPI
+	depends on SPI
 
 # For the secure version of the board the firmware is linked at the beginning
 # of the flash, or into the code-partition defined in DT if it is intended to
@@ -49,12 +37,9 @@ endif # SPI
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
 
-if BOARD_ACTINIUS_ICARUS && TRUSTED_EXECUTION_SECURE
-
 config FLASH_LOAD_SIZE
 	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
-endif # BOARD_ACTINIUS_ICARUS && TRUSTED_EXECUTION_SECURE
+	depends on BOARD_ACTINIUS_ICARUS && TRUSTED_EXECUTION_SECURE
 
 if BOARD_ACTINIUS_ICARUS_NS
 

--- a/boards/arm/adafruit_feather_m0_basic_proto/Kconfig.defconfig
+++ b/boards/arm/adafruit_feather_m0_basic_proto/Kconfig.defconfig
@@ -3,9 +3,6 @@
 # Copyright (c) 2018 Henrik Brix Andersen <henrik@brixandersen.dk>
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_ADAFRUIT_FEATHER_M0_BASIC_PROTO
-
 config BOARD
 	default "adafruit_feather_m0_basic_proto"
-
-endif
+	depends on BOARD_ADAFRUIT_FEATHER_M0_BASIC_PROTO

--- a/boards/arm/adafruit_trinket_m0/Kconfig.defconfig
+++ b/boards/arm/adafruit_trinket_m0/Kconfig.defconfig
@@ -3,9 +3,6 @@
 # Copyright (c) 2018 Google LLC.
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_ADAFRUIT_TRINKET_M0
-
 config BOARD
 	default "adafruit_trinket_m0"
-
-endif
+	depends on BOARD_ADAFRUIT_TRINKET_M0

--- a/boards/arm/arduino_due/Kconfig.defconfig
+++ b/boards/arm/arduino_due/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_ARDUINO_DUE
 config BOARD
 	default "arduino_due"
 
-if GPIO
-
 config GPIO_SAM
 	default y
-
-endif # GPIO
+	depends on GPIO
 
 if I2C
 

--- a/boards/arm/arduino_zero/Kconfig.defconfig
+++ b/boards/arm/arduino_zero/Kconfig.defconfig
@@ -3,9 +3,6 @@
 # Copyright (c) 2017 Google LLC.
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_ARDUINO_ZERO
-
 config BOARD
 	default "arduino_zero"
-
-endif # BOARD_ARDUINO_ZERO
+	depends on BOARD_ARDUINO_ZERO

--- a/boards/arm/atsamd20_xpro/Kconfig.defconfig
+++ b/boards/arm/atsamd20_xpro/Kconfig.defconfig
@@ -3,9 +3,6 @@
 # Copyright (c) 2018 Sean Nyekjaer
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_ATSAMD20_XPRO
-
 config BOARD
 	default "atsamd20_xpro"
-
-endif # BOARD_ATSAMD20_XPRO
+	depends on BOARD_ATSAMD20_XPRO

--- a/boards/arm/atsamd21_xpro/Kconfig.defconfig
+++ b/boards/arm/atsamd21_xpro/Kconfig.defconfig
@@ -3,9 +3,6 @@
 # Copyright (c) 2018 Bryan O'Donoghue
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_ATSAMD21_XPRO
-
 config BOARD
 	default "atsamd21_xpro"
-
-endif # BOARD_ATSAMD21_XPRO
+	depends on BOARD_ATSAMD21_XPRO

--- a/boards/arm/atsame54_xpro/Kconfig.defconfig
+++ b/boards/arm/atsame54_xpro/Kconfig.defconfig
@@ -3,9 +3,6 @@
 # Copyright (c) 2019 Benjamin Valentin
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_ATSAME54_XPRO
-
 config BOARD
 	default "atsame54_xpro"
-
-endif # BOARD_ATSAME54_XPRO
+	depends on BOARD_ATSAME54_XPRO

--- a/boards/arm/b_l072z_lrwan1/Kconfig.defconfig
+++ b/boards/arm/b_l072z_lrwan1/Kconfig.defconfig
@@ -8,23 +8,17 @@ if BOARD_B_L072Z_LRWAN1
 config BOARD
 	default "b_l072z_lrwan1"
 
-if SERIAL
 config UART_1
 	default y
+	depends on SERIAL
 
-endif # SERIAL
-
-if UART_CONSOLE
 config UART_2
 	default y
+	depends on UART_CONSOLE
 
-endif # UART_CONSOLE
-
-if I2C
 config I2C_1
 	default y
-
-endif # I2C
+	depends on I2C
 
 if SPI
 config SPI_1

--- a/boards/arm/bbc_microbit/Kconfig.defconfig
+++ b/boards/arm/bbc_microbit/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_BBC_MICROBIT
 config BOARD
 	default "bbc_microbit"
 
-if I2C
-
 config I2C_0
 	default y
-
-endif # I2C
+	depends on I2C
 
 config BT_CTLR
 	default BT

--- a/boards/arm/bcm958401m2/Kconfig.defconfig
+++ b/boards/arm/bcm958401m2/Kconfig.defconfig
@@ -1,11 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Copyright 2020 Broadcom.
-#
-
-if BOARD_VALKYRIE_BCM958401M2
 
 config BOARD
 	default "bcm958401m2"
-
-endif
+	depends on BOARD_VALKYRIE_BCM958401M2

--- a/boards/arm/bl652_dvk/Kconfig.defconfig
+++ b/boards/arm/bl652_dvk/Kconfig.defconfig
@@ -8,26 +8,17 @@ if BOARD_BL652_DVK
 config BOARD
 	default "bl652_dvk"
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if I2C
+	depends on ADC
 
 config I2C_0
 	default y
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_0
 	default y
-
-endif # PWM
+	depends on PWM
 
 if SPI
 

--- a/boards/arm/bl654_dvk/Kconfig.defconfig
+++ b/boards/arm/bl654_dvk/Kconfig.defconfig
@@ -8,26 +8,17 @@ if BOARD_BL654_DVK
 config BOARD
 	default "bl654_dvk"
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if I2C
+	depends on ADC
 
 config I2C_0
 	default y
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_0
 	default y
-
-endif # PWM
+	depends on PWM
 
 if SPI
 
@@ -49,12 +40,9 @@ config USB_DEVICE_STACK
 
 endif # USB
 
-if IEEE802154
-
 config IEEE802154_NRF5
 	default y
-
-endif # IEEE802154
+	depends on IEEE802154
 
 config BT_CTLR
 	default BT

--- a/boards/arm/cc1352r1_launchxl/Kconfig.defconfig
+++ b/boards/arm/cc1352r1_launchxl/Kconfig.defconfig
@@ -8,11 +8,8 @@ if BOARD_CC1352R1_LAUNCHXL
 config BOARD
 	default "cc1352r1_launchxl"
 
-if SPI
-
 config SPI_0
 	default y
-
-endif # SPI
+	depends on SPI
 
 endif # BOARD_CC1352R1_LAUNCHXL

--- a/boards/arm/cc26x2r1_launchxl/Kconfig.defconfig
+++ b/boards/arm/cc26x2r1_launchxl/Kconfig.defconfig
@@ -8,11 +8,8 @@ if BOARD_CC26X2R1_LAUNCHXL
 config BOARD
 	default "cc26x2r1_launchxl"
 
-if SPI
-
 config SPI_0
 	default y
-
-endif # SPI
+	depends on SPI
 
 endif # BOARD_CC26X2R1_LAUNCHXL

--- a/boards/arm/cc3220sf_launchxl/Kconfig.defconfig
+++ b/boards/arm/cc3220sf_launchxl/Kconfig.defconfig
@@ -7,11 +7,8 @@ if BOARD_CC3220SF_LAUNCHXL
 config BOARD
 	default "cc3220sf_launchxl"
 
-if I2C
-
 config I2C_CC32XX
 	default y
-
-endif # I2C
+	depends on I2C
 
 endif # BOARD_CC3220SF_LAUNCHXL

--- a/boards/arm/cc3235sf_launchxl/Kconfig.defconfig
+++ b/boards/arm/cc3235sf_launchxl/Kconfig.defconfig
@@ -8,11 +8,8 @@ if BOARD_CC3235SF_LAUNCHXL
 config BOARD
 	default "cc3235sf_launchxl"
 
-if I2C
-
 config I2C_CC32XX
 	default y
-
-endif # I2C
+	depends on I2C
 
 endif # BOARD_CC3235SF_LAUNCHXL

--- a/boards/arm/colibri_imx7d_m4/Kconfig.defconfig
+++ b/boards/arm/colibri_imx7d_m4/Kconfig.defconfig
@@ -33,12 +33,9 @@ config GPIO_IMX_PORT_7
 
 endif # GPIO_IMX
 
-if UART_IMX
-
 config UART_IMX_UART_2
 	default y
-
-endif # UART_IMX
+	depends on UART_IMX
 
 if I2C_IMX
 
@@ -56,12 +53,9 @@ config I2C_4
 
 endif # I2C_IMX
 
-if PWM_IMX
-
 config PWM_1
 	default y
-
-endif # PWM_IMX
+	depends on PWM_IMX
 
 if !XIP
 config FLASH_SIZE

--- a/boards/arm/cy8ckit_062_wifi_bt_m0/Kconfig.defconfig
+++ b/boards/arm/cy8ckit_062_wifi_bt_m0/Kconfig.defconfig
@@ -8,15 +8,8 @@ if BOARD_CY8CKIT_062_WIFI_BT_M0
 config BOARD
 	default "cy8ckit_062_wifi_bt_m0"
 
-if GPIO
-
-endif # GPIO
-
-if UART_PSOC6
-
 config UART_PSOC6_UART_6
 	default y
-
-endif # UART_PSOC6
+	depends on UART_PSOC6
 
 endif # BOARD_CY8CKIT_062_WIFI_BT_M0

--- a/boards/arm/cy8ckit_062_wifi_bt_m4/Kconfig.defconfig
+++ b/boards/arm/cy8ckit_062_wifi_bt_m4/Kconfig.defconfig
@@ -8,15 +8,8 @@ if BOARD_CY8CKIT_062_WIFI_BT_M4
 config BOARD
 	default "cy8ckit_062_wifi_bt_m4"
 
-if GPIO
-
-endif # GPIO
-
-if UART_PSOC6
-
 config UART_PSOC6_UART_5
 	default y
-
-endif # UART_PSOC6
+	depends on UART_PSOC6
 
 endif # BOARD_CY8CKIT_062_WIFI_BT_M4

--- a/boards/arm/decawave_dwm1001_dev/Kconfig.defconfig
+++ b/boards/arm/decawave_dwm1001_dev/Kconfig.defconfig
@@ -8,33 +8,21 @@ if BOARD_DECAWAVE_DWM1001_DEV
 config BOARD
 	default "decawave_dwm1001_dev"
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if I2C
+	depends on ADC
 
 config I2C_0
 	default y
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_0
 	default y
-
-endif # PWM
-
-if SPI
+	depends on PWM
 
 config SPI_1
 	default y
-
-endif # SPI
+	depends on SPI
 
 config BT_CTLR
 	default BT

--- a/boards/arm/degu_evk/Kconfig.defconfig
+++ b/boards/arm/degu_evk/Kconfig.defconfig
@@ -36,12 +36,9 @@ config UART_SHELL_ON_DEV_NAME
 
 endif # USB
 
-if IEEE802154
-
 config IEEE802154_NRF5
 	default y
-
-endif # IEEE802154
+	depends on IEEE802154
 
 if I2C
 
@@ -53,30 +50,19 @@ config I2C_1
 
 endif # I2C
 
-if I2C_0
-
 choice I2C_0_NRF_TYPE
 	default I2C_0_NRF_TWIM
-
+	depends on I2C_0
 endchoice
-
-endif # I2C_0
-
-if I2C_1
 
 choice I2C_1_NRF_TYPE
 	default I2C_1_NRF_TWIM
-
+	depends on I2C_1
 endchoice
-
-endif # I2C_1
-
-if ADC
 
 config ADC_0
 	default y
-
-endif # ADC
+	depends on ADC
 
 if DISK_ACCESS_FLASH
 

--- a/boards/arm/disco_l475_iot1/Kconfig.defconfig
+++ b/boards/arm/disco_l475_iot1/Kconfig.defconfig
@@ -8,28 +8,18 @@ if BOARD_DISCO_L475_IOT1
 config BOARD
 	default "disco_l475_iot1"
 
-if STM32_LPTIM_TIMER
-
 choice STM32_LPTIM_CLOCK
 	default STM32_LPTIM_CLOCK_LSE
-
+	depends on STM32_LPTIM_TIMER
 endchoice
-
-endif #STM32_LPTIM_TIMER
-
-if UART_CONSOLE
 
 config UART_1
 	default y
-
-endif # UART_CONSOLE
-
-if SERIAL
+	depends on UART_CONSOLE
 
 config UART_4
 	default y
-
-endif # SERIAL
+	depends on SERIAL
 
 if I2C
 
@@ -57,12 +47,9 @@ config SPI_3
 
 endif # SPI
 
-if PWM
-
 config PWM_STM32_2
 	default y
-
-endif # PWM
+	depends on PWM
 
 choice LIS3MDL_TRIGGER_MODE
 	default LIS3MDL_TRIGGER_NONE
@@ -72,14 +59,10 @@ choice HTS221_TRIGGER_MODE
 	default HTS221_TRIGGER_NONE
 endchoice
 
-
-if LSM6DSL
-
 choice LSM6DSL_TRIGGER_MODE
 	default LSM6DSL_TRIGGER_GLOBAL_THREAD
+	depends on LSM6DSL
 endchoice
-
-endif # LSM6DSL
 
 if BT
 

--- a/boards/arm/dragino_lsn50/Kconfig.defconfig
+++ b/boards/arm/dragino_lsn50/Kconfig.defconfig
@@ -8,11 +8,8 @@ if BOARD_DRAGINO_LSN50
 config BOARD
 	default "dragino_lsn50"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 endif # BOARD_DRAGINO_LSN50

--- a/boards/arm/efm32gg_stk3701a/Kconfig.defconfig
+++ b/boards/arm/efm32gg_stk3701a/Kconfig.defconfig
@@ -46,12 +46,9 @@ config GPIO_GECKO_PORTI
 
 endif # GPIO_GECKO
 
-if COUNTER
-
 config COUNTER_GECKO_RTCC
 	default y
-
-endif # COUNTER
+	depends on COUNTER
 
 if NETWORKING
 

--- a/boards/arm/efm32pg_stk3402a/Kconfig.defconfig
+++ b/boards/arm/efm32pg_stk3402a/Kconfig.defconfig
@@ -38,11 +38,8 @@ config GPIO_GECKO_PORTF
 
 endif # GPIO_GECKO
 
-if COUNTER
-
 config COUNTER_GECKO_RTCC
 	default y
-
-endif # COUNTER
+	depends on COUNTER
 
 endif # BOARD_EFM32PG_STK3402A || BOARD_EFM32PG_STK3402A_JG

--- a/boards/arm/efr32_slwstk6061a/Kconfig.defconfig
+++ b/boards/arm/efr32_slwstk6061a/Kconfig.defconfig
@@ -14,12 +14,9 @@ config CMU_HFXO_FREQ
 config CMU_LFXO_FREQ
 	default 32768
 
-if LOG_BACKEND_SWO
-
 config LOG_BACKEND_SWO_FREQ_HZ
 	default 875000
-
-endif # LOG_BACKEND_SWO
+	depends on LOG_BACKEND_SWO
 
 if GPIO_GECKO
 
@@ -43,11 +40,8 @@ config GPIO_GECKO_PORTF
 
 endif # GPIO_GECKO
 
-if COUNTER
-
 config COUNTER_GECKO_RTCC
 	default y
-
-endif # COUNTER
+	depends on COUNTER
 
 endif # BOARD_EFR32_SLWSTK6061A

--- a/boards/arm/efr32mg_sltb004a/Kconfig.defconfig
+++ b/boards/arm/efr32mg_sltb004a/Kconfig.defconfig
@@ -30,11 +30,8 @@ config GPIO_GECKO_PORTK
 
 endif # GPIO_GECKO
 
-if COUNTER
-
 config COUNTER_GECKO_RTCC
 	default y
-
-endif # COUNTER
+	depends on COUNTER
 
 endif # BOARD_EFR32MG_SLTB004A

--- a/boards/arm/frdm_k22f/Kconfig.defconfig
+++ b/boards/arm/frdm_k22f/Kconfig.defconfig
@@ -20,12 +20,9 @@ config MCG_VDIV0
 config MCG_FCRDIV
 	default 0
 
-if UART_MCUX
-
 config UART_MCUX_1
 	default y if UART_CONSOLE
-
-endif # UART_MCUX
+	depends on UART_MCUX
 
 if PINMUX_MCUX
 
@@ -65,32 +62,20 @@ config GPIO_MCUX_PORTE
 
 endif # GPIO_MCUX
 
-if I2C
-
 config I2C_0
 	default y
-
-endif # I2C
-
-if ADC
+	depends on I2C
 
 config ADC_0
 	default y
-
-endif # ADC
-
-if PWM_MCUX_FTM
+	depends on ADC
 
 config PWM_3
 	default y
-
-endif # PWM_MCUX_FTM
-
-if SPI
+	depends on PWM_MCUX_FTM
 
 config SPI_0
 	default y
-
-endif # SPI
+	depends on SPI
 
 endif # BOARD_FRDM_K22F

--- a/boards/arm/frdm_k64f/Kconfig.defconfig
+++ b/boards/arm/frdm_k64f/Kconfig.defconfig
@@ -68,40 +68,25 @@ config GPIO_MCUX_PORTE
 
 endif # GPIO_MCUX
 
-if I2C
-
 config I2C_0
 	default y
-
-endif # I2C
-
-if ADC
+	depends on I2C
 
 config ADC_1
 	default y
-
-endif # ADC
-
-if SENSOR
+	depends on ADC
 
 config TEMP_KINETIS
 	default y
-
-endif # SENSOR
-
-if PWM_MCUX_FTM
+	depends on SENSOR
 
 config PWM_3
 	default y
-
-endif # PWM_MCUX_FTM
-
-if SPI
+	depends on PWM_MCUX_FTM
 
 config SPI_0
 	default y
-
-endif # SPI
+	depends on SPI
 
 if NETWORKING
 
@@ -113,11 +98,8 @@ config ETH_MCUX_0
 
 endif # NETWORKING
 
-if CAN
-
 config CAN_0
 	default y
-
-endif # CAN
+	depends on CAN
 
 endif # BOARD_FRDM_K64F

--- a/boards/arm/frdm_k82f/Kconfig.defconfig
+++ b/boards/arm/frdm_k82f/Kconfig.defconfig
@@ -30,12 +30,9 @@ config SPI_NOR
 
 endif # FXOS8700
 
-if FXOS8700
-
 config FXOS8700_DRDY_INT1
 	default y
-
-endif # FXOS8700
+	depends on FXOS8700
 
 if GPIO_MCUX
 
@@ -56,12 +53,9 @@ config GPIO_MCUX_PORTE
 
 endif # GPIO_MCUX
 
-if I2C
-
 config I2C_3
 	default y
-
-endif # I2C
+	depends on I2C
 
 if PINMUX_MCUX
 
@@ -82,25 +76,16 @@ config PINMUX_MCUX_PORTE
 
 endif # PINMUX_MCUX
 
-if PWM_MCUX_FTM
-
 config PWM_3
 	default y
-
-endif # PWM_MCUX_FTM
-
-if SPI
+	depends on PWM_MCUX_FTM
 
 config SPI_1
 	default y
-
-endif # SPI
-
-if UART_MCUX_LPUART
+	depends on SPI
 
 config UART_MCUX_LPUART_4
 	default y if UART_CONSOLE
-
-endif # UART_MCUX_LPUART
+	depends on UART_MCUX_LPUART
 
 endif # BOARD_FRDM_K82F

--- a/boards/arm/frdm_kl25z/Kconfig.defconfig
+++ b/boards/arm/frdm_kl25z/Kconfig.defconfig
@@ -61,25 +61,16 @@ config GPIO_MCUX_PORTE
 
 endif # GPIO_MCUX
 
-if UART_MCUX_LPSCI
-
 config UART_MCUX_LPSCI_0
 	default y if UART_CONSOLE
-
-endif # UART_MCUX_LPSCI
-
-if I2C
+	depends on UART_MCUX_LPSCI
 
 config I2C_0
 	default y
-
-endif # I2C
-
-if ADC
+	depends on I2C
 
 config ADC_0
 	default y
-
-endif # ADC
+	depends on ADC
 
 endif # BOARD_FRDM_KL25Z

--- a/boards/arm/frdm_kw41z/Kconfig.defconfig
+++ b/boards/arm/frdm_kw41z/Kconfig.defconfig
@@ -43,39 +43,24 @@ config GPIO_MCUX_PORTC
 
 endif # GPIO_MCUX
 
-if UART_MCUX_LPUART
-
 config UART_MCUX_LPUART_0
 	default y if UART_CONSOLE
-
-endif # UART_MCUX
-
-if I2C
+	depends on UART_MCUX_LPUART
 
 config I2C_1
 	default y
-
-endif # I2C
-
-if ADC
+	depends on I2C
 
 config ADC_0
 	default y
-
-endif # ADC
-
-if FXOS8700
+	depends on ADC
 
 config FXOS8700_DRDY_INT1
 	default y
-
-endif # FXOS8700
-
-if SPI
+	depends on FXOS8700
 
 config SPI_0
 	default y
-
-endif # SPI
+	depends on SPI
 
 endif # BOARD_FRDM_KW41Z

--- a/boards/arm/google_kukui/Kconfig.defconfig
+++ b/boards/arm/google_kukui/Kconfig.defconfig
@@ -8,11 +8,8 @@ if BOARD_GOOGLE_KUKUI
 config BOARD
 	default "google_kukui"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 endif # BOARD_GOOGLE_KUKUI

--- a/boards/arm/hexiwear_k64/Kconfig.defconfig
+++ b/boards/arm/hexiwear_k64/Kconfig.defconfig
@@ -88,12 +88,9 @@ config BATTERY_SENSE
 
 endif # ADC
 
-if PWM_MCUX_FTM
-
 config PWM_3
 	default y
-
-endif # PWM_MCUX_FTM
+	depends on PWM_MCUX_FTM
 
 if SPI
 
@@ -108,11 +105,8 @@ config SPI_2
 
 endif # SPI
 
-if NET_L2_ETHERNET
-
 config ETH_MCUX_0
 	default y
-
-endif # NET_L2_ETHERNET
+	depends on NET_L2_ETHERNET
 
 endif # BOARD_HEXIWEAR_K64

--- a/boards/arm/hexiwear_kw40z/Kconfig.defconfig
+++ b/boards/arm/hexiwear_kw40z/Kconfig.defconfig
@@ -43,25 +43,16 @@ config GPIO_MCUX_PORTC
 
 endif # GPIO_MCUX
 
-if UART_MCUX_LPUART
-
 config UART_MCUX_LPUART_0
 	default y
-
-endif # UART_MCUX
-
-if I2C
+	depends on UART_MCUX_LPUART
 
 config I2C_1
 	default y
-
-endif # I2C
-
-if ADC
+	depends on I2C
 
 config ADC_0
 	default y
-
-endif # ADC
+	depends on ADC
 
 endif # BOARD_HEXIWEAR_KW40Z

--- a/boards/arm/holyiot_yj16019/Kconfig.defconfig
+++ b/boards/arm/holyiot_yj16019/Kconfig.defconfig
@@ -14,19 +14,13 @@ config GPIO_AS_PINRESET
 config UART_NRFX
 	default n
 
-if PWM
-
 config PWM_0
 	default y
-
-endif # PWM
-
-if IEEE802154
+	depends on PWM
 
 config IEEE802154_NRF5
 	default y
-
-endif # IEEE802154
+	depends on IEEE802154
 
 config BT_CTLR
 	default BT

--- a/boards/arm/lpcxpresso54114/Kconfig.defconfig
+++ b/boards/arm/lpcxpresso54114/Kconfig.defconfig
@@ -9,12 +9,9 @@ config BOARD
 	default "lpcxpresso54114_m4" if BOARD_LPCXPRESSO54114_M4
 	default "lpcxpresso54114_m0" if BOARD_LPCXPRESSO54114_M0
 
-if UART_MCUX_FLEXCOMM
-
 config UART_MCUX_FLEXCOMM_0
 	default y if UART_CONSOLE
-
-endif # UART_MCUX_FLEXCOMM
+	depends on UART_MCUX_FLEXCOMM
 
 if PINMUX_MCUX_LPC
 
@@ -36,11 +33,8 @@ config GPIO_MCUX_LPC_PORT1
 
 endif # GPIO_MCUX_LPC
 
-if SPI
-
 config SPI_5
 	default y
-
-endif # SPI
+	depends on SPI
 
 endif # BOARD_LPCXPRESSO54114_M4 || BOARD_LPCXPRESSO54114_M0

--- a/boards/arm/lpcxpresso55s69/Kconfig.defconfig
+++ b/boards/arm/lpcxpresso55s69/Kconfig.defconfig
@@ -9,12 +9,9 @@ config BOARD
 	default "lpcxpresso55S69_cpu0" if BOARD_LPCXPRESSO55S69_CPU0
 	default "lpcxpresso55S69_cpu1" if BOARD_LPCXPRESSO55S69_CPU1
 
-if UART_MCUX_FLEXCOMM
-
 config UART_MCUX_FLEXCOMM_0
 	default y if UART_CONSOLE
-
-endif # UART_MCUX_FLEXCOMM
+	depends on UART_MCUX_FLEXCOMM
 
 if PINMUX_MCUX_LPC
 
@@ -36,11 +33,8 @@ config GPIO_MCUX_LPC_PORT1
 
 endif # GPIO_MCUX_LPC
 
-if SPI
-
 config SPI_8
 	default y
-
-endif # SPI
+	depends on SPI
 
 endif # BOARD_LPCXPRESSO55S69_CPU0 || BOARD_LPCXPRESSO55S69_CPU1

--- a/boards/arm/mec1501modular_assy6885/Kconfig.defconfig
+++ b/boards/arm/mec1501modular_assy6885/Kconfig.defconfig
@@ -6,12 +6,9 @@ if BOARD_MEC1501MODULAR_ASSY6885
 config BOARD
 	default "mec1501modular_assy6885"
 
-if UART_NS16550
-
 config UART_NS16550_PORT_1
 	default y if UART_CONSOLE
-
-endif
+	depends on UART_NS16550
 
 if PINMUX_XEC
 
@@ -58,13 +55,10 @@ config GPIO_XEC_GPIO240_276
 
 endif # GPIO_XEC
 
-if ESPI_XEC
-
 #PS/2 driver is compiled in terms of this flag.
 config ESPI_PERIPHERAL_8042_KBC
 	default y
-
-endif #ESPI_XEC
+	depends on ESPI_XEC
 
 if RTOS_TIMER
 

--- a/boards/arm/mec15xxevb_assy6853/Kconfig.defconfig
+++ b/boards/arm/mec15xxevb_assy6853/Kconfig.defconfig
@@ -6,12 +6,9 @@ if BOARD_MEC15XXEVB_ASSY6853
 config BOARD
 	default "mec15xxevb_assy6853"
 
-if UART_NS16550
-
 config UART_NS16550_PORT_2
 	default y if UART_CONSOLE
-
-endif
+	depends on UART_NS16550
 
 if PINMUX_XEC
 
@@ -58,12 +55,9 @@ config GPIO_XEC_GPIO240_276
 
 endif # GPIO_XEC
 
-if ESPI
-
 config ESPI_XEC
 	default y
-
-endif # ESPI
+	depends on ESPI
 
 if RTOS_TIMER
 

--- a/boards/arm/mec2016evb_assy6797/Kconfig.defconfig
+++ b/boards/arm/mec2016evb_assy6797/Kconfig.defconfig
@@ -6,11 +6,8 @@ if BOARD_MEC2016EVB_ASSY6797
 config BOARD
 	default "mec2016evb_assy6797"
 
-if UART_NS16550
-
 config UART_NS16550_PORT_0
 	default y if UART_CONSOLE
-
-endif
+	depends on UART_NS16550
 
 endif # BOARD_MEC2016EVB_ASSY6797

--- a/boards/arm/mikroe_mini_m4_for_stm32/Kconfig.defconfig
+++ b/boards/arm/mikroe_mini_m4_for_stm32/Kconfig.defconfig
@@ -8,19 +8,13 @@ if BOARD_MIKROE_MINI_M4_FOR_STM32
 config BOARD
 	default "mikroe_mini_m4_for_stm32"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
-
-if I2C
+	depends on UART_CONSOLE
 
 config I2C_2
 	default y
-
-endif # I2C
+	depends on I2C
 
 if SPI
 
@@ -32,18 +26,12 @@ config SPI_STM32_INTERRUPT
 
 endif # SPI
 
-if PWM
-
 config PWM_STM32_3
 	default y
-
-endif # PWM
-
-if USB
+	depends on PWM
 
 config USB_DC_STM32
 	default y
-
-endif # USB
+	depends on USB
 
 endif # BOARD_MIKROE_MINI_M4_FOR_STM32

--- a/boards/arm/mimxrt1010_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1010_evk/Kconfig.defconfig
@@ -22,18 +22,12 @@ config GPIO_MCUX_IGPIO_2
 
 endif # GPIO_MCUX_IGPIO
 
-if I2C_MCUX_LPI2C
-
 config I2C_1
 	default y
-
-endif # I2C_MCUX_LPI2C
-
-if UART_MCUX_LPUART
+	depends on I2C_MCUX_LPI2C
 
 config UART_MCUX_LPUART_1
 	default y
-
-endif # UART_MCUX_LPUART
+	depends on UART_MCUX_LPUART
 
 endif # BOARD_MIMXRT1010_EVK

--- a/boards/arm/mimxrt1015_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1015_evk/Kconfig.defconfig
@@ -22,12 +22,9 @@ config GPIO_MCUX_IGPIO_3
 
 endif # GPIO_MCUX_IGPIO
 
-if I2C_MCUX_LPI2C
-
 config I2C_1
 	default y
-
-endif # I2C_MCUX_LPI2C
+	depends on I2C_MCUX_LPI2C
 
 if UART_MCUX_LPUART
 

--- a/boards/arm/mimxrt1050_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1050_evk/Kconfig.defconfig
@@ -16,12 +16,9 @@ choice DATA_LOCATION
 	default DATA_SEMC
 endchoice
 
-if DISK_ACCESS_USDHC
-
 config DISK_ACCESS_USDHC1
 	default y
-
-endif # DISK_ACCESS_USDHC
+	depends on DISK_ACCESS_USDHC
 
 if GPIO_MCUX_IGPIO
 
@@ -45,19 +42,13 @@ endif # GPIO_MCUX_IGPIO
 config I2C
 	default y if LVGL
 
-if I2C_MCUX_LPI2C
-
 config I2C_1
 	default y
-
-endif # I2C_MCUX_LPI2C
-
-if SPI_MCUX_LPSPI
+	depends on I2C_MCUX_LPI2C
 
 config SPI_3
 	default y
-
-endif # SPI_MCUX_LPSPI
+	depends on SPI_MCUX_LPSPI
 
 if UART_MCUX_LPUART
 

--- a/boards/arm/mimxrt1060_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1060_evk/Kconfig.defconfig
@@ -30,12 +30,9 @@ endif # GPIO_MCUX_IGPIO
 config I2C
 	default y if LVGL
 
-if I2C_MCUX_LPI2C
-
 config I2C_1
 	default y
-
-endif # I2C_MCUX_LPI2C
+	depends on I2C_MCUX_LPI2C
 
 if UART_MCUX_LPUART
 

--- a/boards/arm/mimxrt1064_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1064_evk/Kconfig.defconfig
@@ -29,19 +29,13 @@ endif # GPIO_MCUX_IGPIO
 config I2C
 	default y if LVGL
 
-if I2C_MCUX_LPI2C
-
 config I2C_1
 	default y
-
-endif # I2C_MCUX_LPI2C
-
-if UART_MCUX_LPUART
+	depends on I2C_MCUX_LPI2C
 
 config UART_MCUX_LPUART_1
 	default y
-
-endif # UART_MCUX_LPUART
+	depends on UART_MCUX_LPUART
 
 config KSCAN
 	default y if LVGL
@@ -95,11 +89,8 @@ endchoice
 
 endif # LVGL
 
-if PWM_MCUX
-
 config FLEXPWM2_PWM3
 	default y
-
-endif
+	depends on PWM_MCUX
 
 endif # BOARD_MIMXRT1064_EVK

--- a/boards/arm/mm_swiftio/Kconfig.defconfig
+++ b/boards/arm/mm_swiftio/Kconfig.defconfig
@@ -16,12 +16,9 @@ choice DATA_LOCATION
 	default DATA_SEMC
 endchoice
 
-if DISK_ACCESS_USDHC
-
 config DISK_ACCESS_USDHC1
 	default y
-
-endif # DISK_ACCESS_USDHC
+	depends on DISK_ACCESS_USDHC
 
 if GPIO_MCUX_IGPIO
 
@@ -42,12 +39,8 @@ config GPIO_MCUX_IGPIO_5
 
 endif # GPIO_MCUX_IGPIO
 
-if UART_MCUX_LPUART
-
 config UART_MCUX_LPUART_1
 	default y
-
-endif # UART_MCUX_LPUART
-
+	depends on UART_MCUX_LPUART
 
 endif # BOARD_MM_SWIFTIO

--- a/boards/arm/mps2_an385/Kconfig.defconfig
+++ b/boards/arm/mps2_an385/Kconfig.defconfig
@@ -35,12 +35,9 @@ config UART_INTERRUPT_DRIVEN
 
 endif # SERIAL
 
-if WATCHDOG
-
 config WDOG_CMSDK_APB
 	default y
-
-endif # WATCHDOG
+	depends on WATCHDOG
 
 if COUNTER
 
@@ -52,11 +49,8 @@ config TIMER_DTMR_CMSDK_APB
 
 endif # COUNTER
 
-if I2C
-
 config I2C_SBCON
 	default y
-
-endif # I2C
+	depends on I2C
 
 endif

--- a/boards/arm/mps2_an521/Kconfig.defconfig
+++ b/boards/arm/mps2_an521/Kconfig.defconfig
@@ -36,18 +36,12 @@ config UART_INTERRUPT_DRIVEN
 
 endif # SERIAL
 
-if WATCHDOG
-
 config WDOG_CMSDK_APB
 	default y
-
-endif # WATCHDOG
-
-if I2C
+	depends on WATCHDOG
 
 config I2C_SBCON
 	default y
-
-endif # I2C
+	depends on I2C
 
 endif

--- a/boards/arm/msp_exp432p401r_launchxl/Kconfig.defconfig
+++ b/boards/arm/msp_exp432p401r_launchxl/Kconfig.defconfig
@@ -2,9 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_MSP_EXP432P401R_LAUNCHXL
-
 config BOARD
 	default "msp_exp432p401r_launchxl"
-
-endif # BOARD_MSP_EXP432P401R_LAUNCHXL
+	depends on BOARD_MSP_EXP432P401R_LAUNCHXL

--- a/boards/arm/nrf51_ble400/Kconfig.defconfig
+++ b/boards/arm/nrf51_ble400/Kconfig.defconfig
@@ -8,19 +8,13 @@ if BOARD_NRF51_BLE400
 config BOARD
 	default "nrf51_ble400"
 
-if I2C
-
 config I2C_0
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_1
 	default y
-
-endif # SPI
+	depends on SPI
 
 config BT_CTLR
 	default BT

--- a/boards/arm/nrf51_pca10028/Kconfig.defconfig
+++ b/boards/arm/nrf51_pca10028/Kconfig.defconfig
@@ -8,26 +8,17 @@ if BOARD_NRF51_PCA10028
 config BOARD
 	default "nrf51_pca10028"
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if I2C
+	depends on ADC
 
 config I2C_0
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_1
 	default y
-
-endif # SPI
+	depends on SPI
 
 config BT_CTLR
 	default BT

--- a/boards/arm/nrf51_pca10031/Kconfig.defconfig
+++ b/boards/arm/nrf51_pca10031/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_NRF51_PCA10031
 config BOARD
 	default "nrf51_pca10031"
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
+	depends on ADC
 
 config BT_CTLR
 	default BT

--- a/boards/arm/nrf51_vbluno51/Kconfig.defconfig
+++ b/boards/arm/nrf51_vbluno51/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_NRF51_VBLUNO51
 config BOARD
 	default "nrf51_vbluno51"
 
-if I2C
-
 config I2C_0
 	default y
-
-endif # I2C
+	depends on I2C
 
 config BT_CTLR
 	default BT

--- a/boards/arm/nrf52810_pca10040/Kconfig.defconfig
+++ b/boards/arm/nrf52810_pca10040/Kconfig.defconfig
@@ -8,25 +8,16 @@ if BOARD_NRF52810_PCA10040
 config BOARD
 	default "nrf52810_pca10040"
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if I2C
+	depends on ADC
 
 config I2C_0
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_0
 	default y
-
-endif # SPI
+	depends on SPI
 
 endif # BOARD_NRF52810_PCA10040

--- a/boards/arm/nrf52811_pca10056/Kconfig.defconfig
+++ b/boards/arm/nrf52811_pca10056/Kconfig.defconfig
@@ -11,39 +11,24 @@ config BOARD
 config BT_CTLR
 	default BT
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if I2C
+	depends on ADC
 
 config I2C_0
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_0
 	default y
-
-endif # SPI
-
-if PWM
+	depends on SPI
 
 config PWM_0
 	default y
-
-endif # PWM
-
-if IEEE802154
+	depends on PWM
 
 config IEEE802154_NRF5
 	default y
-
-endif # IEEE802154
+	depends on IEEE802154
 
 endif # BOARD_NRF52811_PCA10056

--- a/boards/arm/nrf52832_mdk/Kconfig.defconfig
+++ b/boards/arm/nrf52832_mdk/Kconfig.defconfig
@@ -8,19 +8,13 @@ if BOARD_NRF52832_MDK
 config BOARD
 	default "nrf52832_mdk"
 
-if I2C
-
 config I2C_0
 	default y
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_0
 	default y
-
-endif # PWM
+	depends on PWM
 
 config BT_CTLR
 	default BT

--- a/boards/arm/nrf52833_pca10100/Kconfig.defconfig
+++ b/boards/arm/nrf52833_pca10100/Kconfig.defconfig
@@ -8,26 +8,17 @@ if BOARD_NRF52833_PCA10100
 config BOARD
 	default "nrf52833_pca10100"
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if I2C
+	depends on ADC
 
 config I2C_0
 	default y
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_0
 	default y
-
-endif # PWM
+	depends on PWM
 
 if SPI
 
@@ -49,12 +40,9 @@ config USB_DEVICE_STACK
 
 endif # USB
 
-if IEEE802154
-
 config IEEE802154_NRF5
 	default y
-
-endif # IEEE802154
+	depends on IEEE802154
 
 config BT_CTLR
 	default BT

--- a/boards/arm/nrf52840_blip/Kconfig.defconfig
+++ b/boards/arm/nrf52840_blip/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_NRF52840_BLIP
 config BOARD
 	default "nrf52840_blip"
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
+	depends on ADC
 
 if USB
 
@@ -25,35 +22,23 @@ config USB_DEVICE_STACK
 
 endif # USB
 
-if IEEE802154
-
 config IEEE802154_NRF5
 	default y
-
-endif # IEEE802154
+	depends on IEEE802154
 
 config BT_CTLR
 	default BT
 
-if PWM
-
 config PWM_0
 	default y
-
-endif # PWM
-
-if I2C
+	depends on PWM
 
 config I2C_0
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_1
 	default y
-
-endif # SPI
+	depends on SPI
 
 endif # BOARD_NRF52840_BLIP

--- a/boards/arm/nrf52840_mdk/Kconfig.defconfig
+++ b/boards/arm/nrf52840_mdk/Kconfig.defconfig
@@ -8,26 +8,17 @@ if BOARD_NRF52840_MDK
 config BOARD
 	default "nrf52840_mdk"
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if I2C
+	depends on ADC
 
 config I2C_0
 	default y
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_0
 	default y
-
-endif # PWM
+	depends on PWM
 
 if USB
 
@@ -39,12 +30,9 @@ config USB_DEVICE_STACK
 
 endif # USB
 
-if IEEE802154
-
 config IEEE802154_NRF5
 	default y
-
-endif # IEEE802154
+	depends on IEEE802154
 
 config BT_CTLR
 	default BT

--- a/boards/arm/nrf52840_papyr/Kconfig.defconfig
+++ b/boards/arm/nrf52840_papyr/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_NRF52840_PAPYR
 config BOARD
 	default "nrf52840_papyr"
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
+	depends on ADC
 
 if USB
 
@@ -25,33 +22,21 @@ config USB_DEVICE_STACK
 
 endif # USB
 
-if IEEE802154
-
 config IEEE802154_NRF5
 	default y
-
-endif # IEEE802154
-
-if PWM
+	depends on IEEE802154
 
 config PWM_0
 	default y
-
-endif # PWM
-
-if I2C
+	depends on PWM
 
 config I2C_0
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_1
 	default y
-
-endif # SPI
+	depends on SPI
 
 config BT_CTLR
 	default BT

--- a/boards/arm/nrf52840_pca10056/Kconfig.defconfig
+++ b/boards/arm/nrf52840_pca10056/Kconfig.defconfig
@@ -8,26 +8,17 @@ if BOARD_NRF52840_PCA10056
 config BOARD
 	default "nrf52840_pca10056"
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if I2C
+	depends on ADC
 
 config I2C_0
 	default y
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_0
 	default y
-
-endif # PWM
+	depends on PWM
 
 if SPI
 
@@ -52,12 +43,9 @@ config USB_DEVICE_STACK
 
 endif # USB
 
-if IEEE802154
-
 config IEEE802154_NRF5
 	default y
-
-endif # IEEE802154
+	depends on IEEE802154
 
 config BT_CTLR
 	default BT

--- a/boards/arm/nrf52840_pca10059/Kconfig.defconfig
+++ b/boards/arm/nrf52840_pca10059/Kconfig.defconfig
@@ -9,8 +9,6 @@ if BOARD_NRF52840_PCA10059
 config BOARD
 	default "nrf52840_pca10059"
 
-if BOARD_HAS_NRF5_BOOTLOADER && !USE_DT_CODE_PARTITION
-
 # To let the nRF5 bootloader load an application, the application
 # must be linked after Nordic MBR, that is factory-programmed on the board.
 
@@ -24,29 +22,19 @@ if BOARD_HAS_NRF5_BOOTLOADER && !USE_DT_CODE_PARTITION
 
 config FLASH_LOAD_OFFSET
 	default 0x1000
-
-endif # BOARD_HAS_NRF5_BOOTLOADER && !USE_DT_CODE_PARTITION
-
-if ADC
+	depends on BOARD_HAS_NRF5_BOOTLOADER && !USE_DT_CODE_PARTITION
 
 config ADC_0
 	default y
-
-endif # ADC
-
-if I2C
+	depends on ADC
 
 config I2C_0
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_1
 	default y
-
-endif # SPI
+	depends on SPI
 
 if USB
 
@@ -58,12 +46,9 @@ config USB_DEVICE_STACK
 
 endif # USB
 
-if IEEE802154
-
 config IEEE802154_NRF5
 	default y
-
-endif # IEEE802154
+	depends on IEEE802154
 
 config BT_CTLR
 	default BT

--- a/boards/arm/nrf52840_pca10090/Kconfig.defconfig
+++ b/boards/arm/nrf52840_pca10090/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_NRF52840_PCA10090
 config BOARD
 	default "nrf52840_pca10090"
 
-if IEEE802154
-
 config IEEE802154_NRF5
 	default y
-
-endif # IEEE802154
+	depends on IEEE802154
 
 config BT_CTLR
 	default BT

--- a/boards/arm/nrf52_blenano2/Kconfig.defconfig
+++ b/boards/arm/nrf52_blenano2/Kconfig.defconfig
@@ -8,21 +8,14 @@ if BOARD_NRF52_BLENANO2
 config BOARD
 	default "nrf52_blenano2"
 
-if I2C
-
 config I2C_0
 	default y
-
-if I2C_0
+	depends on I2C
 
 choice I2C_0_NRF_TYPE
 	default I2C_0_NRF_TWIM
-
+	depends on I2C_0
 endchoice
-
-endif # I2C_0
-
-endif # I2C
 
 config BT_CTLR
 	default BT

--- a/boards/arm/nrf52_pca10040/Kconfig.defconfig
+++ b/boards/arm/nrf52_pca10040/Kconfig.defconfig
@@ -8,26 +8,17 @@ if BOARD_NRF52_PCA10040
 config BOARD
 	default "nrf52_pca10040"
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if I2C
+	depends on ADC
 
 config I2C_0
 	default y
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_0
 	default y
-
-endif # PWM
+	depends on PWM
 
 if SPI
 

--- a/boards/arm/nrf52_pca20020/Kconfig.defconfig
+++ b/boards/arm/nrf52_pca20020/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_NRF52_PCA20020
 config BOARD
 	default "nrf52_pca20020"
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
+	depends on ADC
 
 config I2C
 	default y
@@ -26,20 +23,15 @@ config I2C_0
 config I2C_1
 	default y
 
-if I2C_0
-
 choice I2C_0_NRF_TYPE
 	default I2C_0_NRF_TWIM
-
+	depends on I2C_0
 endchoice
-
-endif # I2C_0
 
 if I2C_1
 
 choice I2C_1_NRF_TYPE
 	default I2C_1_NRF_TWIM
-
 endchoice
 
 config GPIO_SX1509B

--- a/boards/arm/nrf52_vbluno52/Kconfig.defconfig
+++ b/boards/arm/nrf52_vbluno52/Kconfig.defconfig
@@ -13,14 +13,10 @@ if I2C
 config I2C_0
 	default y
 
-if I2C_0
-
 choice I2C_0_NRF_TYPE
 	default I2C_0_NRF_TWIM
-
+	depends on I2C_0
 endchoice
-
-endif # I2C_0
 
 endif # I2C
 

--- a/boards/arm/nrf5340_dk_nrf5340/Kconfig.defconfig
+++ b/boards/arm/nrf5340_dk_nrf5340/Kconfig.defconfig
@@ -8,33 +8,21 @@ if BOARD_NRF5340_DK_NRF5340_CPUAPP || BOARD_NRF5340_DK_NRF5340_CPUAPPNS
 config BOARD
 	default "nrf5340_dk_nrf5340_cpuapp"
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if I2C
+	depends on ADC
 
 config I2C_1
 	default y
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_0
 	default y
-
-endif # PWM
-
-if SPI
+	depends on PWM
 
 config SPI_2
 	default y
-
-endif # SPI
+	depends on SPI
 
 # Code Partition:
 #
@@ -86,9 +74,6 @@ endif # BOARD_NRF5340_DK_NRF5340_CPUAPPNS
 
 endif # BOARD_NRF5340_DK_NRF5340_CPUAPP || BOARD_NRF5340_DK_NRF5340_CPUAPPNS
 
-if BOARD_NRF5340_DK_NRF5340_CPUNET
-
 config BOARD
 	default "nrf5340_dk_nrf5340_cpunet"
-
-endif # BOARD_NRF5340_DK_NRF5340_CPUNET
+	depends on BOARD_NRF5340_DK_NRF5340_CPUNET

--- a/boards/arm/nrf9160_pca10090/Kconfig.defconfig
+++ b/boards/arm/nrf9160_pca10090/Kconfig.defconfig
@@ -8,33 +8,21 @@ if BOARD_NRF9160_PCA10090 || BOARD_NRF9160_PCA10090NS
 config BOARD
 	default "nrf9160_pca10090"
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if I2C
+	depends on ADC
 
 config I2C_2
 	default y
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_0
 	default y
-
-endif # PWM
-
-if SPI
+	depends on PWM
 
 config SPI_3
 	default y
-
-endif # SPI
+	depends on SPI
 
 # For the secure version of the board the firmware is linked at the beginning
 # of the flash, or into the code-partition defined in DT if it is intended to
@@ -49,12 +37,9 @@ endif # SPI
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
 
-if BOARD_NRF9160_PCA10090 && TRUSTED_EXECUTION_SECURE
-
 config FLASH_LOAD_SIZE
 	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
-endif # BOARD_NRF9160_PCA10090 && TRUSTED_EXECUTION_SECURE
+	depends on BOARD_NRF9160_PCA10090 && TRUSTED_EXECUTION_SECURE
 
 if BOARD_NRF9160_PCA10090NS
 

--- a/boards/arm/nucleo_f030r8/Kconfig.defconfig
+++ b/boards/arm/nucleo_f030r8/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_NUCLEO_F030R8
 config BOARD
 	default "nucleo_f030r8"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 # Disable ports D and F to allow kernel test cases common and
 # contex to run on nucleo_f030r8.

--- a/boards/arm/nucleo_f070rb/Kconfig.defconfig
+++ b/boards/arm/nucleo_f070rb/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_NUCLEO_F070RB
 config BOARD
 	default "nucleo_f070rb"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 if I2C
 

--- a/boards/arm/nucleo_f091rc/Kconfig.defconfig
+++ b/boards/arm/nucleo_f091rc/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_NUCLEO_F091RC
 config BOARD
 	default "nucleo_f091rc"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 if I2C
 
@@ -38,11 +35,8 @@ config SPI_STM32_INTERRUPT
 
 endif # SPI
 
-if ADC
-
 config ADC_1
 	default y
-
-endif # ADC
+	depends on ADC
 
 endif # BOARD_NUCLEO_F091RC

--- a/boards/arm/nucleo_f103rb/Kconfig.defconfig
+++ b/boards/arm/nucleo_f103rb/Kconfig.defconfig
@@ -8,19 +8,13 @@ if BOARD_NUCLEO_F103RB
 config BOARD
 	default "nucleo_f103rb"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
-
-if PWM
+	depends on UART_CONSOLE
 
 config PWM_STM32_1
 	default y
-
-endif # PWM
+	depends on PWM
 
 if SPI
 
@@ -32,11 +26,8 @@ config SPI_2
 
 endif
 
-if ADC
-
 config ADC_1
 	default y
-
-endif # ADC
+	depends on ADC
 
 endif # BOARD_NUCLEO_F103RB

--- a/boards/arm/nucleo_f207zg/Kconfig.defconfig
+++ b/boards/arm/nucleo_f207zg/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_NUCLEO_F207ZG
 config BOARD
 	default "nucleo_f207zg"
 
-if UART_CONSOLE
-
 config UART_3
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 if NETWORKING
 
@@ -25,18 +22,12 @@ config ETH_STM32_HAL
 
 endif # NETWORKING
 
-if SERIAL
-
 config UART_6
 	default y
-
-endif # SERIAL
-
-if ADC
+	depends on SERIAL
 
 config ADC_1
 	default y
-
-endif # ADC
+	depends on ADC
 
 endif # BOARD_NUCLEO_F207ZG

--- a/boards/arm/nucleo_f302r8/Kconfig.defconfig
+++ b/boards/arm/nucleo_f302r8/Kconfig.defconfig
@@ -8,46 +8,28 @@ if BOARD_NUCLEO_F302R8
 config BOARD
 	default "nucleo_f302r8"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
-
-if SERIAL
+	depends on UART_CONSOLE
 
 config UART_3
 	default y
-
-endif # SERIAL
-
-if I2C
+	depends on SERIAL
 
 config I2C_1
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_2
 	default y
-
-endif # SPI
-
-if PWM
+	depends on SPI
 
 config PWM_STM32_2
 	default y
-
-endif # PWM
-
-if ADC
+	depends on PWM
 
 config ADC_1
 	default y
-
-endif # ADC
+	depends on ADC
 
 endif # BOARD_NUCLEO_F302R8

--- a/boards/arm/nucleo_f334r8/Kconfig.defconfig
+++ b/boards/arm/nucleo_f334r8/Kconfig.defconfig
@@ -8,19 +8,13 @@ if BOARD_NUCLEO_F334R8
 config BOARD
 	default "nucleo_f334r8"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
-
-if I2C
+	depends on UART_CONSOLE
 
 config I2C_1
 	default y
-
-endif # I2C
+	depends on I2C
 
 if SPI
 

--- a/boards/arm/nucleo_f401re/Kconfig.defconfig
+++ b/boards/arm/nucleo_f401re/Kconfig.defconfig
@@ -9,19 +9,13 @@ if BOARD_NUCLEO_F401RE
 config BOARD
 	default "nucleo_f401re"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
-
-if I2C
+	depends on UART_CONSOLE
 
 config I2C_1
 	default y
-
-endif # I2C
+	depends on I2C
 
 if SPI
 
@@ -36,12 +30,9 @@ config SPI_STM32_INTERRUPT
 
 endif # SPI
 
-if PWM
-
 config PWM_STM32_2
 	default y
-
-endif # PWM
+	depends on PWM
 
 if WATCHDOG
 
@@ -53,11 +44,8 @@ config IWDG_STM32
 
 endif # WATCHDOG
 
-if ADC
-
 config ADC_1
 	default y
-
-endif # ADC
+	depends on ADC
 
 endif # BOARD_NUCLEO_F401RE

--- a/boards/arm/nucleo_f411re/Kconfig.defconfig
+++ b/boards/arm/nucleo_f411re/Kconfig.defconfig
@@ -8,19 +8,13 @@ if BOARD_NUCLEO_F411RE
 config BOARD
 	default "nucleo_f411re"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
-
-if I2C
+	depends on UART_CONSOLE
 
 config I2C_1
 	default y
-
-endif # I2C
+	depends on I2C
 
 if SPI
 

--- a/boards/arm/nucleo_f412zg/Kconfig.defconfig
+++ b/boards/arm/nucleo_f412zg/Kconfig.defconfig
@@ -8,33 +8,21 @@ if BOARD_NUCLEO_F412ZG
 config BOARD
 	default "nucleo_f412zg"
 
-if UART_CONSOLE
-
 config UART_3
 	default y
-
-endif # UART_CONSOLE
-
-if SERIAL
+	depends on UART_CONSOLE
 
 config UART_6
 	default y
-
-endif # SERIAL
-
-if I2C
+	depends on SERIAL
 
 config I2C_1
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_1
 	default y
-
-endif # SPI
+	depends on SPI
 
 if NETWORKING
 
@@ -49,11 +37,8 @@ config USB_DEVICE_NETWORK_ECM
 
 endif # NETWORKING
 
-if PWM
-
 config PWM_STM32_2
 	default y
-
-endif # PWM
+	depends on PWM
 
 endif # BOARD_NUCLEO_F412ZG

--- a/boards/arm/nucleo_f413zh/Kconfig.defconfig
+++ b/boards/arm/nucleo_f413zh/Kconfig.defconfig
@@ -8,34 +8,21 @@ if BOARD_NUCLEO_F413ZH
 config BOARD
 	default "nucleo_f413zh"
 
-
-if UART_CONSOLE
-
 config UART_3
 	default y
-
-endif # UART_CONSOLE
-
-if SERIAL
+	depends on UART_CONSOLE
 
 config UART_6
 	default y
-
-endif # SERIAL
-
-if I2C
+	depends on SERIAL
 
 config I2C_1
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_1
 	default y
-
-endif # SPI
+	depends on SPI
 
 if NETWORKING
 
@@ -50,11 +37,8 @@ config USB_DEVICE_NETWORK_ECM
 
 endif # NETWORKING
 
-if PWM
-
 config PWM_STM32_2
 	default y
-
-endif # PWM
+	depends on PWM
 
 endif # BOARD_NUCLEO_F413ZH

--- a/boards/arm/nucleo_f429zi/Kconfig.defconfig
+++ b/boards/arm/nucleo_f429zi/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_NUCLEO_F429ZI
 config BOARD
 	default "nucleo_f429zi"
 
-if UART_CONSOLE
-
 config UART_3
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 if NETWORKING
 
@@ -25,32 +22,20 @@ config ETH_STM32_HAL
 
 endif # NETWORKING
 
-if SERIAL
-
 config UART_6
 	default y
-
-endif # SERIAL
-
-if I2C
+	depends on SERIAL
 
 config I2C_1
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_1
 	default y
-
-endif # SPI
-
-if PWM
+	depends on SPI
 
 config PWM_STM32_1
 	default y
-
-endif # PWM
+	depends on PWM
 
 endif # BOARD_NUCLEO_F429ZI

--- a/boards/arm/nucleo_f446re/Kconfig.defconfig
+++ b/boards/arm/nucleo_f446re/Kconfig.defconfig
@@ -8,19 +8,13 @@ if BOARD_NUCLEO_F446RE
 config BOARD
 	default "nucleo_f446re"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
-
-if I2C
+	depends on UART_CONSOLE
 
 config I2C_1
 	default y
-
-endif # I2C
+	depends on I2C
 
 if SPI
 

--- a/boards/arm/nucleo_f746zg/Kconfig.defconfig
+++ b/boards/arm/nucleo_f746zg/Kconfig.defconfig
@@ -8,19 +8,13 @@ if BOARD_NUCLEO_F746ZG
 config BOARD
 	default "nucleo_f746zg"
 
-if UART_CONSOLE
-
 config UART_3
 	default y
-
-endif # UART_CONSOLE
-
-if SERIAL
+	depends on UART_CONSOLE
 
 config UART_6
 	default y
-
-endif # SERIAL
+	depends on SERIAL
 
 if NETWORKING
 
@@ -32,39 +26,24 @@ config ETH_STM32_HAL
 
 endif # NETWORKING
 
-if I2C
-
 config I2C_1
 	default y
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_STM32_1
 	default y
-
-endif # PWM
-
-if SPI
+	depends on PWM
 
 config SPI_1
 	default y
-
-endif # SPI
-
-if CAN
+	depends on SPI
 
 config CAN_1
 	default y
-
-endif # CAN
-
-if ADC
+	depends on CAN
 
 config ADC_1
 	default y
-
-endif # ADC
+	depends on ADC
 
 endif # BOARD_NUCLEO_F746ZG

--- a/boards/arm/nucleo_f756zg/Kconfig.defconfig
+++ b/boards/arm/nucleo_f756zg/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_NUCLEO_F756ZG
 config BOARD
 	default "nucleo_f756zg"
 
-if UART_CONSOLE
-
 config UART_3
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 if SERIAL
 
@@ -35,25 +32,16 @@ config ETH_STM32_HAL
 
 endif # NETWORKING
 
-if I2C
-
 config I2C_1
 	default y
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_STM32_1
 	default y
-
-endif # PWM
-
-if SPI
+	depends on PWM
 
 config SPI_1
 	default y
-
-endif # SPI
+	depends on SPI
 
 endif # BOARD_NUCLEO_F756ZG

--- a/boards/arm/nucleo_f767zi/Kconfig.defconfig
+++ b/boards/arm/nucleo_f767zi/Kconfig.defconfig
@@ -8,19 +8,13 @@ if BOARD_NUCLEO_F767ZI
 config BOARD
 	default "nucleo_f767zi"
 
-if UART_CONSOLE
-
 config UART_3
 	default y
-
-endif # UART_CONSOLE
-
-if SERIAL
+	depends on UART_CONSOLE
 
 config UART_6
 	default y
-
-endif # SERIAL
+	depends on SERIAL
 
 if NETWORKING
 
@@ -32,39 +26,24 @@ config ETH_STM32_HAL
 
 endif # NETWORKING
 
-if I2C
-
 config I2C_1
 	default y
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_STM32_1
 	default y
-
-endif # PWM
-
-if SPI
+	depends on PWM
 
 config SPI_1
 	default y
-
-endif # SPI
-
-if CAN
+	depends on SPI
 
 config CAN_1
 	default y
-
-endif # CAN
-
-if ADC
+	depends on CAN
 
 config ADC_1
 	default y
-
-endif # ADC
+	depends on ADC
 
 endif # BOARD_NUCLEO_F767ZI

--- a/boards/arm/nucleo_g071rb/Kconfig.defconfig
+++ b/boards/arm/nucleo_g071rb/Kconfig.defconfig
@@ -9,11 +9,8 @@ if BOARD_NUCLEO_G071RB
 config BOARD
 	default "nucleo_g071rb"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 endif # BOARD_NUCLEO_G071RB

--- a/boards/arm/nucleo_g431rb/Kconfig.defconfig
+++ b/boards/arm/nucleo_g431rb/Kconfig.defconfig
@@ -8,26 +8,17 @@ if BOARD_NUCLEO_G431RB
 config BOARD
 	default "nucleo_g431rb"
 
-if UART_CONSOLE
-
 config LPUART_1
 	default y
-
-endif # UART_CONSOLE
-
-if I2C
+	depends on UART_CONSOLE
 
 config I2C_1
 	default y
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_STM32_2
 	default y
-
-endif # PWM
+	depends on PWM
 
 if SPI
 

--- a/boards/arm/nucleo_g474re/Kconfig.defconfig
+++ b/boards/arm/nucleo_g474re/Kconfig.defconfig
@@ -8,26 +8,17 @@ if BOARD_NUCLEO_G474RE
 config BOARD
 	default "nucleo_g474re"
 
-if UART_CONSOLE
-
 config LPUART_1
 	default y
-
-endif # UART_CONSOLE
-
-if I2C
+	depends on UART_CONSOLE
 
 config I2C_1
 	default y
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_STM32_2
 	default y
-
-endif # PWM
+	depends on PWM
 
 if SPI
 

--- a/boards/arm/nucleo_l053r8/Kconfig.defconfig
+++ b/boards/arm/nucleo_l053r8/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_NUCLEO_L053R8
 config BOARD
 	default "nucleo_l053r8"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 # Disable ports D and H to allow kernel test cases common and
 # contex to run on nucleo_l053r8.
@@ -28,12 +25,9 @@ config GPIO_STM32_PORTH
 
 endif # GPIO
 
-if I2C
-
 config I2C_1
 	default y
-
-endif # I2C
+	depends on I2C
 
 if SPI
 

--- a/boards/arm/nucleo_l073rz/Kconfig.defconfig
+++ b/boards/arm/nucleo_l073rz/Kconfig.defconfig
@@ -8,19 +8,13 @@ if BOARD_NUCLEO_L073RZ
 config BOARD
 	default "nucleo_l073rz"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
-
-if I2C
+	depends on UART_CONSOLE
 
 config I2C_1
 	default y
-
-endif # I2C
+	depends on I2C
 
 if SPI
 
@@ -32,11 +26,8 @@ config SPI_STM32_INTERRUPT
 
 endif # SPI
 
-if ADC
-
 config ADC_1
 	default y
-
-endif # ADC
+	depends on ADC
 
 endif # BOARD_NUCLEO_L073RZ

--- a/boards/arm/nucleo_l152re/Kconfig.defconfig
+++ b/boards/arm/nucleo_l152re/Kconfig.defconfig
@@ -9,18 +9,12 @@ if BOARD_NUCLEO_L152RE
 config BOARD
 	default "nucleo_l152re"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
-
-if I2C
+	depends on UART_CONSOLE
 
 config I2C_1
 	default y
-
-endif # I2C
+	depends on I2C
 
 endif # BOARD_NUCLEO_L152RE

--- a/boards/arm/nucleo_l432kc/Kconfig.defconfig
+++ b/boards/arm/nucleo_l432kc/Kconfig.defconfig
@@ -9,19 +9,13 @@ if BOARD_NUCLEO_L432KC
 config BOARD
 	default "nucleo_l432kc"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
-
-if PWM
+	depends on UART_CONSOLE
 
 config PWM_STM32_2
 	default y
-
-endif # PWM
+	depends on PWM
 
 if SPI
 
@@ -33,11 +27,8 @@ config SPI_STM32_INTERRUPT
 
 endif # SPI
 
-if CAN
-
 config CAN_1
 	default y
-
-endif # CAN
+	depends on CAN
 
 endif # BOARD_NUCLEO_L432KC

--- a/boards/arm/nucleo_l452re/Kconfig.defconfig
+++ b/boards/arm/nucleo_l452re/Kconfig.defconfig
@@ -9,19 +9,13 @@ if BOARD_NUCLEO_L452RE
 config BOARD
 	default "nucleo_l452re"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
-
-if PWM
+	depends on UART_CONSOLE
 
 config PWM_STM32_2
 	default y
-
-endif # PWM
+	depends on PWM
 
 if SPI
 
@@ -33,11 +27,8 @@ config SPI_STM32_INTERRUPT
 
 endif # SPI
 
-if CAN
-
 config CAN_1
 	default y
-
-endif # CAN
+	depends on CAN
 
 endif # BOARD_NUCLEO_L452RE

--- a/boards/arm/nucleo_l476rg/Kconfig.defconfig
+++ b/boards/arm/nucleo_l476rg/Kconfig.defconfig
@@ -9,12 +9,9 @@ if BOARD_NUCLEO_L476RG
 config BOARD
 	default "nucleo_l476rg"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 if SPI
 
@@ -26,25 +23,16 @@ config SPI_STM32_INTERRUPT
 
 endif # SPI
 
-if I2C
-
 config I2C_1
 	default y
-
-endif # SPI
-
-if PWM
+	depends on I2C
 
 config PWM_STM32_2
 	default y
-
-endif # PWM
-
-if ADC
+	depends on PWM
 
 config ADC_1
 	default y
-
-endif # ADC
+	depends on ADC
 
 endif # BOARD_NUCLEO_L476RG

--- a/boards/arm/nucleo_l496zg/Kconfig.defconfig
+++ b/boards/arm/nucleo_l496zg/Kconfig.defconfig
@@ -8,26 +8,17 @@ if BOARD_NUCLEO_L496ZG
 config BOARD
 	default "nucleo_l496zg"
 
-if UART_CONSOLE
+config LPUART_1
+	default y
+	depends on UART_CONSOLE
 
 config LPUART_1
 	default y
-
-endif # UART_CONSOLE
-
-if SERIAL
-
-config LPUART_1
-	default y
-
-endif # SERIAL
-
-if I2C
+	depends on SERIAL
 
 config I2C_1
 	default y
-
-endif # I2C
+	depends on I2C
 
 if SPI
 

--- a/boards/arm/nucleo_l4r5zi/Kconfig.defconfig
+++ b/boards/arm/nucleo_l4r5zi/Kconfig.defconfig
@@ -8,28 +8,18 @@ if BOARD_NUCLEO_L4R5ZI
 config BOARD
 	default "nucleo_l4r5zi"
 
-if STM32_LPTIM_TIMER
-
 choice STM32_LPTIM_CLOCK
 	default STM32_LPTIM_CLOCK_LSI
-
+	depends on STM32_LPTIM_TIMER
 endchoice
-
-endif #STM32_LPTIM_TIMER
-
-if UART_CONSOLE
 
 config LPUART_1
 	default y
-
-endif # UART_CONSOLE
-
-if I2C
+	depends on UART_CONSOLE
 
 config I2C_1
 	default y
-
-endif # I2C
+	depends on I2C
 
 if SPI
 
@@ -41,12 +31,9 @@ config SPI_STM32_INTERRUPT
 
 endif # SPI
 
-if PWM
-
 config PWM_STM32_2
 	default y
-
-endif # PWM
+	depends on PWM
 
 if NETWORKING
 

--- a/boards/arm/nucleo_wb55rg/Kconfig.defconfig
+++ b/boards/arm/nucleo_wb55rg/Kconfig.defconfig
@@ -11,28 +11,18 @@ config BOARD
 config CLOCK_STM32_LSE
 	default y
 
-if STM32_LPTIM_TIMER
-
 choice STM32_LPTIM_CLOCK
 	default STM32_LPTIM_CLOCK_LSE
-
+	depends on STM32_LPTIM_TIMER
 endchoice
-
-endif #STM32_LPTIM_TIMER
-
-if UART_CONSOLE
 
 config UART_1
 	default y
-
-endif # UART_CONSOLE
-
-if SERIAL
+	depends on UART_CONSOLE
 
 config LPUART_1
 	default y
-
-endif # SERIAL
+	depends on SERIAL
 
 if I2C
 
@@ -44,34 +34,21 @@ config I2C_3
 
 endif # I2C
 
-if SPI
-
 config SPI_1
 	default y
-
-endif # SPI
-
-if ADC
+	depends on SPI
 
 config ADC_1
 	default y
-
-endif # ADC
-
-if BT_DEBUG_MONITOR
+	depends on ADC
 
 config LPUART_1
 	default y
-
-endif # BT_DEBUG_MONITOR
-
-if BT
+	depends on BT_DEBUG_MONITOR
 
 choice BT_HCI_BUS_TYPE
 	default BT_STM32_IPM
-
+	depends on BT
 endchoice
-
-endif # BT
 
 endif # BOARD_NUCLEO_WB55RG

--- a/boards/arm/olimex_stm32_e407/Kconfig.defconfig
+++ b/boards/arm/olimex_stm32_e407/Kconfig.defconfig
@@ -8,11 +8,8 @@ if BOARD_OLIMEX_STM32_E407
 config BOARD
 	default "olimex_stm32_e407"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 endif # BOARD_OLIMEX_STM32_E407

--- a/boards/arm/olimex_stm32_h407/Kconfig.defconfig
+++ b/boards/arm/olimex_stm32_h407/Kconfig.defconfig
@@ -8,11 +8,8 @@ if BOARD_OLIMEX_STM32_H407
 config BOARD
 	default "olimex_stm32_h407"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 endif # BOARD_OLIMEX_STM32_H407

--- a/boards/arm/olimex_stm32_p405/Kconfig.defconfig
+++ b/boards/arm/olimex_stm32_p405/Kconfig.defconfig
@@ -8,18 +8,12 @@ if BOARD_OLIMEX_STM32_P405
 config BOARD
 	default "olimex_stm32_p405"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
-
-if CAN
+	depends on UART_CONSOLE
 
 config CAN_1
 	default y
-
-endif # CAN
+	depends on CAN
 
 endif # BOARD_OLIMEX_STM32_P405

--- a/boards/arm/olimexino_stm32/Kconfig.defconfig
+++ b/boards/arm/olimexino_stm32/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_OLIMEXINO_STM32
 config BOARD
 	default "olimexino_stm32"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 if I2C
 
@@ -38,18 +35,12 @@ config SPI_2
 
 endif # SPI
 
-if PWM
-
 config PWM_STM32_1
 	default y
-
-endif # PWM
-
-if CAN
+	depends on PWM
 
 config CAN_1
 	default y
-
-endif # CAN
+	depends on CAN
 
 endif # BOARD_OLIMEXINO_STM32

--- a/boards/arm/particle_argon/Kconfig.defconfig
+++ b/boards/arm/particle_argon/Kconfig.defconfig
@@ -8,26 +8,17 @@ if BOARD_PARTICLE_ARGON
 config BOARD
 	default "particle_argon"
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if I2C
+	depends on ADC
 
 config I2C_0
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_2
 	default y
-
-endif # SPI
+	depends on SPI
 
 if USB
 
@@ -39,12 +30,9 @@ config USB_DEVICE_STACK
 
 endif # USB
 
-if IEEE802154
-
 config IEEE802154_NRF5
 	default y
-
-endif # IEEE802154
+	depends on IEEE802154
 
 config BT_CTLR
 	default BT

--- a/boards/arm/particle_boron/Kconfig.defconfig
+++ b/boards/arm/particle_boron/Kconfig.defconfig
@@ -8,26 +8,17 @@ if BOARD_PARTICLE_BORON
 config BOARD
 	default "particle_boron"
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if I2C
+	depends on ADC
 
 config I2C_0
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_2
 	default y
-
-endif # SPI
+	depends on SPI
 
 if USB
 
@@ -39,12 +30,9 @@ config USB_DEVICE_STACK
 
 endif # USB
 
-if IEEE802154
-
 config IEEE802154_NRF5
 	default y
-
-endif # IEEE802154
+	depends on IEEE802154
 
 config BT_CTLR
 	default BT

--- a/boards/arm/particle_xenon/Kconfig.defconfig
+++ b/boards/arm/particle_xenon/Kconfig.defconfig
@@ -9,26 +9,17 @@ if BOARD_PARTICLE_XENON
 config BOARD
 	default "particle_xenon"
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if I2C
+	depends on ADC
 
 config I2C_0
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_2
 	default y
-
-endif # SPI
+	depends on SPI
 
 if USB
 
@@ -40,12 +31,9 @@ config USB_DEVICE_STACK
 
 endif # USB
 
-if IEEE802154
-
 config IEEE802154_NRF5
 	default y
-
-endif # IEEE802154
+	depends on IEEE802154
 
 config BT_CTLR
 	default BT

--- a/boards/arm/pico_pi_m4/Kconfig.defconfig
+++ b/boards/arm/pico_pi_m4/Kconfig.defconfig
@@ -8,13 +8,9 @@ if BOARD_PICO_PI_M4
 config BOARD
 	default "pico_pi_m4"
 
-if UART_IMX
-
 config UART_IMX_UART_6
 	default y
-
-endif # UART_IMX
-
+	depends on UART_IMX
 
 if !XIP
 config FLASH_SIZE

--- a/boards/arm/reel_board/Kconfig.defconfig
+++ b/boards/arm/reel_board/Kconfig.defconfig
@@ -20,32 +20,21 @@ config I2C_0
 config I2C_1
 	default n
 
-if I2C_0
-
 choice I2C_0_NRF_TYPE
 	default I2C_0_NRF_TWIM
-
+	depends on I2C_0
 endchoice
-
-endif # I2C_0
-
-if I2C_1
 
 choice I2C_1_NRF_TYPE
 	default I2C_1_NRF_TWIM
-
+	depends on I2C_1
 endchoice
-
-endif # I2C_1
 
 endif # I2C
 
-if PWM
-
 config PWM_0
 	default y
-
-endif # PWM
+	depends on PWM
 
 if SPI
 
@@ -70,25 +59,16 @@ config USB_DEVICE_STACK
 
 endif # USB
 
-if IEEE802154
-
 config IEEE802154_NRF5
 	default y
-
-endif # IEEE802154
-
-if BT
+	depends on IEEE802154
 
 config BT_CTLR
 	default y
-
-endif # BT
-
-if DISPLAY
+	depends on BT
 
 config SSD16XX
 	default y
-
-endif #DISPLAY
+	depends on DISPLAY
 
 endif # BOARD_REEL_BOARD || BOARD_REEL_BOARD_V2

--- a/boards/arm/sam4e_xpro/Kconfig.defconfig
+++ b/boards/arm/sam4e_xpro/Kconfig.defconfig
@@ -8,25 +8,16 @@ if BOARD_SAM4E_XPRO
 config BOARD
 	default "sam4e_xpro"
 
-if GPIO
-
 config GPIO_SAM
 	default y
-
-endif # GPIO
-
-if I2C
+	depends on GPIO
 
 config I2C_SAM_TWI
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_SAM
 	default y
-
-endif # SPI
+	depends on SPI
 
 endif # BOARD_SAM4E_XPRO

--- a/boards/arm/sam_e70_xplained/Kconfig.defconfig
+++ b/boards/arm/sam_e70_xplained/Kconfig.defconfig
@@ -15,6 +15,7 @@ config I2S_SAM_SSC_0_DMA_RX_CHANNEL
 
 config I2S_SAM_SSC_0_DMA_TX_CHANNEL
 	default 23
+
 endif # I2S
 
 if ETH_SAM_GMAC
@@ -42,19 +43,13 @@ config ETH_SAM_GMAC_MAC_I2C_EEPROM
 
 endif # ETH_SAM_GMAC
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if I2C
+	depends on ADC
 
 config I2C_0
 	default y
-
-endif # I2C
+	depends on I2C
 
 if NETWORKING
 
@@ -66,16 +61,10 @@ config ETH_SAM_GMAC
 
 endif # NETWORKING
 
-if SPI
-
-if SPI_SAM_PORT_0
-
 config SPI_SAME70_PORT_0_PIN_CS3
 	bool
 	default y
-
-endif # SPI_SAM_PORT_0
-
-endif # SPI
+	depends on SPI
+	depends on SPI_SAM_PORT_0
 
 endif # BOARD_SAM_E70_XPLAINED

--- a/boards/arm/sam_v71_xult/Kconfig.defconfig
+++ b/boards/arm/sam_v71_xult/Kconfig.defconfig
@@ -43,19 +43,13 @@ config ETH_SAM_GMAC_MAC_I2C_EEPROM
 
 endif # ETH_SAM_GMAC
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if I2C
+	depends on ADC
 
 config I2C_0
 	default y
-
-endif # I2C
+	depends on I2C
 
 if NETWORKING
 
@@ -67,16 +61,10 @@ config ETH_SAM_GMAC
 
 endif # NETWORKING
 
-if SPI
-
-if SPI_SAM_PORT_0
-
 config SPI_SAMV71_PORT_0_PIN_CS1
 	bool
 	default y
-
-endif # SPI_SAM_PORT_0
-
-endif # SPI
+	depends on SPI
+	depends on SPI_SAM_PORT_0
 
 endif # BOARD_SAM_V71_XULT

--- a/boards/arm/sensortile_box/Kconfig.defconfig
+++ b/boards/arm/sensortile_box/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_SENSORTILE_BOX
 config BOARD
 	default "sensortile_box"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 if I2C
 
@@ -36,12 +33,9 @@ config SPI_3
 config SPI_STM32_INTERRUPT
 	default y
 
-if LIS2MDL
-
 config LIS2MDL_SPI_FULL_DUPLEX
 	default y
-
-endif # LIS2MDL
+	depends on LIS2MDL
 
 endif # SPI
 

--- a/boards/arm/steval_fcu001v1/Kconfig.defconfig
+++ b/boards/arm/steval_fcu001v1/Kconfig.defconfig
@@ -8,27 +8,16 @@ if BOARD_STEVAL_FCU001V1
 config BOARD
 	default "steval_fcu001v1"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
-
-if I2C
+	depends on UART_CONSOLE
 
 config I2C_2
 	default y
-
-endif # I2C
-
-
-if PWM
+	depends on I2C
 
 config PWM_STM32_2
 	default y
-
-endif # PWM
-
+	depends on PWM
 
 endif # BOARD_STEVAL_FCU001V1

--- a/boards/arm/stm3210c_eval/Kconfig.defconfig
+++ b/boards/arm/stm3210c_eval/Kconfig.defconfig
@@ -8,11 +8,8 @@ if BOARD_STM3210C_EVAL
 config BOARD
 	default "stm3210c_eval"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 endif # BOARD_STM3210C_EVAL

--- a/boards/arm/stm32373c_eval/Kconfig.defconfig
+++ b/boards/arm/stm32373c_eval/Kconfig.defconfig
@@ -8,11 +8,8 @@ if BOARD_STM32373C_EVAL
 config BOARD
 	default "stm32373c_eval"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 endif # BOARD_STM32373C_EVAL

--- a/boards/arm/stm32_min_dev/Kconfig.defconfig
+++ b/boards/arm/stm32_min_dev/Kconfig.defconfig
@@ -9,12 +9,9 @@ config BOARD
 	default "stm32_min_dev_blue" if BOARD_STM32_MIN_DEV_BLUE
 	default "stm32_min_dev_black" if BOARD_STM32_MIN_DEV_BLACK
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 if I2C
 
@@ -26,12 +23,9 @@ config I2C_2
 
 endif # I2C
 
-if PWM
-
 config PWM_STM32_1
 	default y
-
-endif # PWM
+	depends on PWM
 
 if SPI
 

--- a/boards/arm/stm32f030_demo/Kconfig.defconfig
+++ b/boards/arm/stm32f030_demo/Kconfig.defconfig
@@ -6,11 +6,8 @@ if BOARD_STM32F030_DEMO
 config BOARD
 	default "stm32f030_demo"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 endif # BOARD_STM32F030_DEMO

--- a/boards/arm/stm32f072_eval/Kconfig.defconfig
+++ b/boards/arm/stm32f072_eval/Kconfig.defconfig
@@ -8,11 +8,8 @@ if BOARD_STM32F072_EVAL
 config BOARD
 	default "stm32f072_eval"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 endif # BOARD_STM32F072_EVAL

--- a/boards/arm/stm32f072b_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f072b_disco/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_STM32F072B_DISCO
 config BOARD
 	default "stm32f072b_disco"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 if I2C
 
@@ -35,11 +32,8 @@ config SPI_STM32_INTERRUPT
 
 endif # SPI
 
-if CAN
-
 config CAN_1
 	default y
-
-endif # CAN
+	depends on CAN
 
 endif # BOARD_STM32F072B_DISCO

--- a/boards/arm/stm32f0_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f0_disco/Kconfig.defconfig
@@ -8,11 +8,8 @@ if BOARD_STM32F0_DISCO
 config BOARD
 	default "stm32f0_disco"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 endif # BOARD_STM32F0_DISCO

--- a/boards/arm/stm32f3_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f3_disco/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_STM32F3_DISCO
 config BOARD
 	default "stm32f3_disco"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 if I2C
 
@@ -35,11 +32,8 @@ config SPI_2
 
 endif # SPI
 
-if CAN
-
 config CAN_1
 	default y
-
-endif # CAN
+	depends on CAN
 
 endif # BOARD_STM32F3_DISCO

--- a/boards/arm/stm32f411e_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f411e_disco/Kconfig.defconfig
@@ -8,19 +8,12 @@ if BOARD_STM32F411E_DISCO
 config BOARD
 	default "stm32f411e_disco"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-
-if PWM
+	depends on UART_CONSOLE
 
 config PWM_STM32_4
 	default y
-
-endif # PWM
-
-endif # UART_CONSOLE
+	depends on PWM
 
 endif # BOARD_STM32F411E_DISCO

--- a/boards/arm/stm32f412g_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f412g_disco/Kconfig.defconfig
@@ -7,11 +7,8 @@ if BOARD_STM32F412G_DISCO
 config BOARD
 	default "stm32f412g_disco"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 endif # BOARD_STM32F412G_DISCO

--- a/boards/arm/stm32f429i_disc1/Kconfig.defconfig
+++ b/boards/arm/stm32f429i_disc1/Kconfig.defconfig
@@ -8,25 +8,16 @@ if BOARD_STM32F429I_DISC1
 config BOARD
 	default "stm32f429i_disc1"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
-
-if I2C
+	depends on UART_CONSOLE
 
 config I2C_3
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_5
 	default y
-
-endif # SPI
+	depends on SPI
 
 endif # BOARD_STM32F429I_DISC1

--- a/boards/arm/stm32f469i_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f469i_disco/Kconfig.defconfig
@@ -8,19 +8,13 @@ if BOARD_STM32F469I_DISCO
 config BOARD
 	default "stm32f469i_disco"
 
-if UART_CONSOLE
-
 config UART_3
 	default y
-
-endif # UART_CONSOLE
-
-if SERIAL
+	depends on UART_CONSOLE
 
 config UART_6
 	default y
-
-endif # SERIAL
+	depends on SERIAL
 
 if SPI
 
@@ -32,11 +26,8 @@ config SPI_2
 
 endif # SPI
 
-if I2C
-
 config I2C_1
 	default y
-
-endif # I2C
+	depends on I2C
 
 endif # BOARD_STM32F469I_DISCO

--- a/boards/arm/stm32f4_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f4_disco/Kconfig.defconfig
@@ -8,25 +8,16 @@ if BOARD_STM32F4_DISCO
 config BOARD
 	default "stm32f4_disco"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
-
-if PWM
+	depends on UART_CONSOLE
 
 config PWM_STM32_2
 	default y
-
-endif # PWM
-
-if CAN
+	depends on PWM
 
 config CAN_2
 	default y
-
-endif # CAN
+	depends on CAN
 
 endif # BOARD_STM32F4_DISCO

--- a/boards/arm/stm32f723e_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f723e_disco/Kconfig.defconfig
@@ -8,19 +8,13 @@ if BOARD_STM32F723E_DISCO
 config BOARD
 	default "stm32f723e_disco"
 
-if UART_CONSOLE
-
 config UART_6
 	default y
-
-endif # UART_CONSOLE
-
-if SERIAL
+	depends on UART_CONSOLE
 
 config UART_2
 	default y
-
-endif # SERIAL
+	depends on SERIAL
 
 if SPI
 

--- a/boards/arm/stm32f746g_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f746g_disco/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_STM32F746G_DISCO
 config BOARD
 	default "stm32f746g_disco"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 if NETWORKING
 
@@ -25,32 +22,20 @@ config ETH_STM32_HAL
 
 endif # NETWORKING
 
-if SERIAL
-
 config UART_6
 	default y
-
-endif # SERIAL
-
-if I2C
+	depends on SERIAL
 
 config I2C_1
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_2
 	default y
-
-endif # SPI
-
-if PWM
+	depends on SPI
 
 config PWM_STM32_1
 	default y
-
-endif # PWM
+	depends on PWM
 
 endif # BOARD_STM32F746G_DISCO

--- a/boards/arm/stm32f769i_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f769i_disco/Kconfig.defconfig
@@ -8,26 +8,17 @@ if BOARD_STM32F769I_DISCO
 config BOARD
 	default "stm32f769i_disco"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
-
-if SERIAL
+	depends on UART_CONSOLE
 
 config UART_6
 	default y
-
-endif # SERIAL
-
-if I2C
+	depends on SERIAL
 
 config I2C_1
 	default y
-
-endif # I2C
+	depends on I2C
 
 if SPI
 

--- a/boards/arm/stm32g0316_disco/Kconfig.defconfig
+++ b/boards/arm/stm32g0316_disco/Kconfig.defconfig
@@ -8,11 +8,8 @@ if BOARD_STM32G0316_DISCO
 config BOARD
 	default "stm32g0316_disco"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 endif # BOARD_STM32G0316_DISCO

--- a/boards/arm/stm32h747i_disco/Kconfig.defconfig
+++ b/boards/arm/stm32h747i_disco/Kconfig.defconfig
@@ -38,28 +38,21 @@ config CLOCK_STM32_D3PPRE
 config STM32H7_DUAL_CORE
 	default y
 
-# Dual core boot configuration
-if STM32H7_DUAL_CORE
-# Boot method is selected in common file to avoid desync issues
+# Dual core boot configuration. Boot method is selected in common file to avoid
+# desync issues.
 choice STM32H7_DUAL_CORE_BOOT
 	# Use out of the box config by default
 	# default STM32H7_BOOT_CM4_CM7
 	default STM32H7_BOOT_CM7_CM4GATED
+	depends on STM32H7_DUAL_CORE
 endchoice
-endif # STM32H7_DUAL_CORE
-
-if UART_CONSOLE
 
 config UART_1
 	default y if BOARD_STM32H747I_DISCO_M7
-
-endif # UART_CONSOLE
-
-if SERIAL
+	depends on UART_CONSOLE
 
 config UART_8
 	default y if BOARD_STM32H747I_DISCO_M7
-
-endif # SERIAL
+	depends on SERIAL
 
 endif # BOARD_STM32H747I_DISCO_M7

--- a/boards/arm/stm32l1_disco/Kconfig.defconfig
+++ b/boards/arm/stm32l1_disco/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_STM32L1_DISCO
 config BOARD
 	default "stm32l1_disco"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 if I2C
 
@@ -34,6 +31,5 @@ config SPI_2
 	default y
 
 endif # SPI
-
 
 endif # BOARD_STM32L1_DISCO

--- a/boards/arm/stm32l476g_disco/Kconfig.defconfig
+++ b/boards/arm/stm32l476g_disco/Kconfig.defconfig
@@ -8,11 +8,8 @@ if BOARD_STM32L476G_DISCO
 config BOARD
 	default "stm32l476g_disco"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 endif # BOARD_STM32L476G_DISCO

--- a/boards/arm/stm32l496g_disco/Kconfig.defconfig
+++ b/boards/arm/stm32l496g_disco/Kconfig.defconfig
@@ -9,26 +9,17 @@ if BOARD_STM32L496G_DISCO
 config BOARD
 	default "stm32l496g_disco"
 
-if UART_CONSOLE
-
 config UART_2
 	default y
-
-endif # UART_CONSOLE
-
-if SERIAL
+	depends on UART_CONSOLE
 
 config LPUART_1
 	default y
-
-endif # SERIAL
-
-if I2C
+	depends on SERIAL
 
 config I2C_1
 	default y
-
-endif # I2C
+	depends on I2C
 
 if SPI
 
@@ -40,11 +31,8 @@ config SPI_1
 
 endif # SPI
 
-if PWM
-
 config PWM_STM32_2
 	default y
-
-endif # PWM
+	depends on PWM
 
 endif # BOARD_STM32L496G_DISCO

--- a/boards/arm/stm32mp157c_dk2/Kconfig.defconfig
+++ b/boards/arm/stm32mp157c_dk2/Kconfig.defconfig
@@ -8,26 +8,17 @@ if BOARD_STM32MP157C_DK2
 config BOARD
 	default "stm32mp157c_dk2"
 
-if UART_CONSOLE
-
 config UART_3
 	default y
-
-endif # UART_CONSOLE
-
-if SERIAL
+	depends on UART_CONSOLE
 
 config UART_7
 	default y
-
-endif # SERIAL
-
-if I2C
+	depends on SERIAL
 
 config I2C_5
 	default y
-
-endif # I2C
+	depends on I2C
 
 if SPI
 

--- a/boards/arm/stm32vl_disco/Kconfig.defconfig
+++ b/boards/arm/stm32vl_disco/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_STM32VL_DISCO
 config BOARD
 	default "stm32vl_disco"
 
-if UART_CONSOLE
-
 config UART_1
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 if I2C
 

--- a/boards/arm/twr_ke18f/Kconfig.defconfig
+++ b/boards/arm/twr_ke18f/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_TWR_KE18F
 config BOARD
 	default "twr_ke18f"
 
-if UART_MCUX_LPUART
-
 config UART_MCUX_LPUART_0
 	default y if UART_CONSOLE
-
-endif # UART_MCUX_LPUART
+	depends on UART_MCUX_LPUART
 
 if I2C
 
@@ -35,12 +32,9 @@ config SPI_1
 
 endif # SPI_MCUX_LPSPI
 
-if CAN
-
 config CAN_0
 	default y
-
-endif # CAN
+	depends on CAN
 
 if PINMUX_MCUX
 
@@ -80,19 +74,13 @@ config GPIO_MCUX_PORTE
 
 endif # GPIO_MCUX
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if SENSOR
+	depends on ADC
 
 config TEMP_KINETIS
 	default y
-
-endif # SENSOR
+	depends on SENSOR
 
 if PWM
 

--- a/boards/arm/twr_kv58f220m/Kconfig.defconfig
+++ b/boards/arm/twr_kv58f220m/Kconfig.defconfig
@@ -39,12 +39,9 @@ config GPIO_MCUX_PORTE
 
 endif # GPIO_MCUX
 
-if I2C
-
 config I2C_1
 	default y
-
-endif # I2C
+	depends on I2C
 
 if PINMUX_MCUX
 
@@ -65,11 +62,8 @@ config PINMUX_MCUX_PORTE
 
 endif # PINMUX_MCUX
 
-if UART_MCUX
-
 config UART_MCUX_0
 	default y if UART_CONSOLE
-
-endif # UART_MCUX
+	depends on UART_MCUX
 
 endif # BOARD_TWR_KV58F220M

--- a/boards/arm/udoo_neo_full_m4/Kconfig.defconfig
+++ b/boards/arm/udoo_neo_full_m4/Kconfig.defconfig
@@ -55,11 +55,8 @@ config GPIO_IMX_PORT_7
 
 endif # GPIO_IMX
 
-if COUNTER_IMX_EPIT
-
 config COUNTER_IMX_EPIT_1
 	default y
-
-endif # COUNTER_IMX_EPIT
+	depends on COUNTER_IMX_EPIT
 
 endif # BOARD_UDOO_NEO_FULL_M4

--- a/boards/arm/usb_kw24d512/Kconfig.defconfig
+++ b/boards/arm/usb_kw24d512/Kconfig.defconfig
@@ -24,12 +24,9 @@ config MCG_VDIV0
 config MCG_FCRDIV
 	default 2
 
-if UART_MCUX
-
 config UART_MCUX_0
 	default y
-
-endif # UART_MCUX
+	depends on UART_MCUX
 
 if PINMUX_MCUX
 
@@ -76,33 +73,20 @@ config I2C_1
 
 endif # I2C
 
-if ADC
-
 config ADC_0
 	default y
-
-endif # ADC
-
-if PWM_MCUX_FTM
+	depends on ADC
 
 config PWM_1
 	default y
-
-endif # PWM_MCUX_FTM
-
-if SPI
+	depends on PWM_MCUX_FTM
 
 config SPI_1
 	default y
-
-endif # SPI
-
-if IEEE802154_MCR20A
+	depends on SPI
 
 config MCR20A_IS_PART_OF_KW2XD_SIP
 	default y
-
-endif # IEEE802154_MCR20A
-
+	depends on IEEE802154_MCR20A
 
 endif # BOARD_USB_KW24D512

--- a/boards/arm/v2m_beetle/Kconfig.defconfig
+++ b/boards/arm/v2m_beetle/Kconfig.defconfig
@@ -27,12 +27,9 @@ config GPIO_CMSDK_AHB_PORT3
 
 endif # GPIO
 
-if PINMUX
-
 config PINMUX_BEETLE
 	default y
-
-endif # PINMUX
+	depends on PINMUX
 
 if SERIAL
 
@@ -44,12 +41,9 @@ config UART_INTERRUPT_DRIVEN
 
 endif # SERIAL
 
-if WATCHDOG
-
 config WDOG_CMSDK_APB
 	default y
-
-endif # WATCHDOG
+	depends on WATCHDOG
 
 if COUNTER
 

--- a/boards/arm/warp7_m4/Kconfig.defconfig
+++ b/boards/arm/warp7_m4/Kconfig.defconfig
@@ -8,12 +8,9 @@ if BOARD_WARP7_M4
 config BOARD
 	default "warp7_m4"
 
-if GPIO_IMX
-
 config GPIO_IMX_PORT_7
 	default y
-
-endif # GPIO_IMX
+	depends on GPIO_IMX
 
 if UART_IMX
 
@@ -25,26 +22,17 @@ config UART_IMX_UART_6
 
 endif # UART_IMX
 
-if I2C_IMX
-
 config I2C_4
 	default y
-
-endif # I2C_IMX
-
-if FXOS8700
+	depends on I2C_IMX
 
 config FXOS8700_DRDY_INT1
 	default y
-
-endif # FXOS8700
-
-if FXAS21002
+	depends on FXOS8700
 
 config FXAS21002_DRDY_INT1
 	default y
-
-endif # FXAS21002
+	depends on FXAS21002
 
 if !XIP
 config FLASH_SIZE

--- a/boards/posix/native_posix/Kconfig.defconfig
+++ b/boards/posix/native_posix/Kconfig.defconfig
@@ -25,27 +25,18 @@ config ETH_NATIVE_POSIX
 
 endif # NETWORKING
 
-if ENTROPY_GENERATOR
-
 config FAKE_ENTROPY_NATIVE_POSIX
 	default y
-
-endif # ENTROPY_GENERATOR
-
-if BT_HCI
+	depends on ENTROPY_GENERATOR
 
 choice BT_HCI_BUS_TYPE
 	default BT_USERCHAN
+	depends on BT_HCI
 endchoice
-
-endif # BT_HCI
-
-if SERIAL
 
 config UART_NATIVE_POSIX
 	default y
-
-endif # SERIAL
+	depends on SERIAL
 
 if LOG
 
@@ -74,32 +65,20 @@ config UART_CONSOLE
 
 endif # CONSOLE
 
-if DISPLAY
-
 config SDL_DISPLAY
 	default y
-
-endif # DISPLAY
-
-if FLASH
+	depends on DISPLAY
 
 config FLASH_SIMULATOR
 	default y
-
-endif # FLASH
-
-if USB
+	depends on FLASH
 
 config USB_NATIVE_POSIX
 	default y
-
-endif # USB
-
-if EEPROM
+	depends on USB
 
 config EEPROM_SIMULATOR
 	default y
-
-endif # EEPROM
+	depends on EEPROM
 
 endif # BOARD_NATIVE_POSIX

--- a/boards/posix/nrf52_bsim/Kconfig.defconfig
+++ b/boards/posix/nrf52_bsim/Kconfig.defconfig
@@ -14,12 +14,9 @@ config OUTPUT_PRINT_MEMORY_USAGE
 config BOARD
 	default "nrf52_bsim"
 
-if BT
-
 config BT_CTLR
 	default y
-
-endif # BT
+	depends on BT
 
 if LOG
 

--- a/boards/riscv/hifive1/Kconfig.defconfig
+++ b/boards/riscv/hifive1/Kconfig.defconfig
@@ -8,11 +8,8 @@ config BOARD
 config SYS_CLOCK_TICKS_PER_SEC
 	default 128
 
-if PWM
-
 config PWM_SIFIVE
 	default y
-
-endif
+	depends on PWM
 
 endif

--- a/boards/riscv/hifive1_revb/Kconfig.defconfig
+++ b/boards/riscv/hifive1_revb/Kconfig.defconfig
@@ -18,19 +18,16 @@ config FLASH_LOAD_OFFSET
 config SYS_CLOCK_TICKS_PER_SEC
 	default 128
 
-if PWM
 config PWM_SIFIVE
 	default y
-endif
+	depends on PWM
 
-if SPI
 config SPI_SIFIVE
 	default y
-endif
+	depends on SPI
 
-if I2C
 config I2C_SIFIVE
 	default y
-endif
+	depends on I2C
 
 endif

--- a/boards/riscv/litex_vexriscv/Kconfig.defconfig
+++ b/boards/riscv/litex_vexriscv/Kconfig.defconfig
@@ -1,9 +1,6 @@
 # Copyright (c) 2018 - 2019 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_LITEX_VEXRISCV
-
 config BOARD
 	default "litex_vexriscv"
-
-endif
+	depends on BOARD_LITEX_VEXRISCV

--- a/boards/riscv/m2gl025_miv/Kconfig.defconfig
+++ b/boards/riscv/m2gl025_miv/Kconfig.defconfig
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_M2GL025_MIV
-
 config BOARD
 	default "m2gl025_miv"
-
-endif
+	depends on BOARD_M2GL025_MIV

--- a/boards/riscv/rv32m1_vega/Kconfig.defconfig
+++ b/boards/riscv/rv32m1_vega/Kconfig.defconfig
@@ -7,12 +7,9 @@ config BOARD
 	default "rv32m1_vega_ri5cy" if SOC_OPENISA_RV32M1_RI5CY
 	default "rv32m1_vega_zero_riscy" if SOC_OPENISA_RV32M1_ZERO_RISCY
 
-if UART_RV32M1_LPUART
-
 config UART_RV32M1_LPUART_0
 	default y if UART_CONSOLE
-
-endif # UART_RV32M1
+	depends on UART_RV32M1_LPUART
 
 if PINMUX_RV32M1
 
@@ -52,12 +49,9 @@ config GPIO_RV32M1_PORTE
 
 endif # GPIO_RV32M1
 
-if SERIAL
-
 config UART_RV32M1_LPUART
 	default y
-
-endif # SERIAL
+	depends on SERIAL
 
 if I2C
 
@@ -79,12 +73,9 @@ config SPI_1
 
 endif # SPI
 
-if PWM
-
 config PWM_2
 	default y
-
-endif # PWM
+	depends on PWM
 
 if BT
 

--- a/boards/shields/dfrobot_can_bus_v2_0/boards/nrf52_pca10040.defconfig
+++ b/boards/shields/dfrobot_can_bus_v2_0/boards/nrf52_pca10040.defconfig
@@ -1,9 +1,6 @@
 # Copyright (c) 2019 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_NRF52_PCA10040
-
 config CAN_1
 	default y
-
-endif # BOARD_NRF52_PCA10040
+	depends on BOARD_NRF52_PCA10040

--- a/boards/shields/frdm_cr20a/boards/frdm_k64f.defconfig
+++ b/boards/shields/frdm_cr20a/boards/frdm_k64f.defconfig
@@ -5,9 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if BOARD_FRDM_K64F
-
 config NET_L2_ETHERNET
 	default n
-
-endif # BOARD_FRDM_K64F
+	depends on BOARD_FRDM_K64F

--- a/boards/shields/link_board_eth/boards/reel_board.defconfig
+++ b/boards/shields/link_board_eth/boards/reel_board.defconfig
@@ -1,9 +1,6 @@
 # Copyright (c) 2019 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_REEL_BOARD
-
 config ETH_ENC424J600_0_GPIO_SPI_CS
 	default y
-
-endif # BOARD_REEL_BOARD
+	depends on BOARD_REEL_BOARD

--- a/boards/shields/sparkfun_sara_r4/boards/frdm_k64f.defconfig
+++ b/boards/shields/sparkfun_sara_r4/boards/frdm_k64f.defconfig
@@ -1,9 +1,6 @@
 # Copyright (c) 2019 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_FRDM_K64F
-
 config UART_MCUX_3
 	default y
-
-endif # BOARD_FRDM_K64F
+	depends on BOARD_FRDM_K64F

--- a/boards/shields/ssd1306/boards/reel_board.defconfig
+++ b/boards/shields/ssd1306/boards/reel_board.defconfig
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_REEL_BOARD
-
 choice I2C_0_NRF_TYPE
 	default I2C_0_NRF_TWI
+	depends on BOARD_REEL_BOARD
 endchoice
-
-endif # BOARD_REEL_BOARD

--- a/boards/shields/wnc_m14a2a/boards/frdm_k64f.defconfig
+++ b/boards/shields/wnc_m14a2a/boards/frdm_k64f.defconfig
@@ -1,9 +1,6 @@
 # Copyright (c) 2019 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_FRDM_K64F
-
 config UART_MCUX_2
 	default y
-
-endif # BOARD_FRDM_K64F
+	depends on BOARD_FRDM_K64F

--- a/boards/x86/acrn/Kconfig.defconfig
+++ b/boards/x86/acrn/Kconfig.defconfig
@@ -1,9 +1,6 @@
 # Copyright (c) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_ACRN
-
 config BOARD
 	default "acrn"
-
-endif # BOARD_ACRN
+	depends on BOARD_ACRN

--- a/boards/x86/qemu_x86/Kconfig.defconfig
+++ b/boards/x86/qemu_x86/Kconfig.defconfig
@@ -8,18 +8,12 @@ config BUILD_OUTPUT_BIN
 config BOARD
 	default "qemu_x86"
 
-if FLASH
-
 config FLASH_SIMULATOR
 	default y
-
-endif
+	depends on FLASH
 
 endif # BOARD_QEMU_X86
 
-if BOARD_QEMU_X86_64
-
 config BOARD
 	default "qemu_x86_64"
-
-endif # BOARD_QEMU_X86_64
+	depends on BOARD_QEMU_X86_64

--- a/boards/xtensa/esp32/Kconfig.defconfig
+++ b/boards/xtensa/esp32/Kconfig.defconfig
@@ -3,9 +3,6 @@
 # Copyright (c) 2017 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_ESP32
-
 config BOARD
 	default "esp32"
-
-endif # BOARD_ESP32
+	depends on BOARD_ESP32

--- a/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
+++ b/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
@@ -45,17 +45,13 @@ config CAVS_ISR_TBL_OFFSET
 config DW_ISR_TBL_OFFSET
 	default 3RD_LVL_ISR_TBL_OFFSET
 
-if DMA_DW
-
 config HEAP_MEM_POOL_SIZE
 	default 1024
+	depends on DMA_DW
 
-endif # DMA_DW
-
-if BOOTLOADER_MCUBOOT
 config TEXT_SECTION_OFFSET
 	default 0x100
-endif
+	depends on BOOTLOADER_MCUBOOT
 
 if USB
 config USB_DW
@@ -64,15 +60,13 @@ config USB_DW
 config USB_DW_USB_2_0
 	default y
 
-if USB_DEVICE_HID
 config USB_REQUEST_BUFFER_SIZE
 	default 128
-endif
+	depends on USB_DEVICE_HID
 
-if USB_DFU_CLASS
 config USB_REQUEST_BUFFER_SIZE
 	default 4096
-endif
+	depends on USB_DFU_CLASS
 
 config USB_DEVICE_STACK
 	default y
@@ -116,17 +110,13 @@ config I2C_0
 
 endif
 
-if DMA
-
 config DMA_DW
 	default y
+	depends on DMA
 
-endif
-
-if I2S
 config I2S_CAVS
 	default y
-endif
+	depends on I2S
 
 if AUDIO
 config AUDIO_CODEC
@@ -143,12 +133,9 @@ config AUDIO_INTEL_DMIC
 
 endif
 
-
-if NEURAL_NET_ACCEL
-
 config INTEL_GNA
 	default y
-endif
+	depends on NEURAL_NET_ACCEL
 
 if GPIO
 
@@ -186,11 +173,8 @@ config SPI_0
 
 endif
 
-if PINMUX
-
 config PINMUX_INTEL_S1000
 	default y
-
-endif
+	depends on PINMUX
 
 endif # BOARD_INTEL_S1000_CRB

--- a/boards/xtensa/odroid_go/Kconfig.defconfig
+++ b/boards/xtensa/odroid_go/Kconfig.defconfig
@@ -3,9 +3,6 @@
 # Copyright (c) 2019 Yannis Damigos
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_ODROID_GO
-
 config BOARD
 	default "odroid-go"
-
-endif # BOARD_ODROID_GO
+	depends on BOARD_ODROID_GO

--- a/boards/xtensa/up_squared_adsp/Kconfig.defconfig
+++ b/boards/xtensa/up_squared_adsp/Kconfig.defconfig
@@ -35,23 +35,16 @@ config 2ND_LVL_ISR_TBL_OFFSET
 config CAVS_ISR_TBL_OFFSET
 	default 2ND_LVL_ISR_TBL_OFFSET
 
-if DMA_DW
-
 config HEAP_MEM_POOL_SIZE
 	default 1024
-
-endif # DMA_DW
-
-if DMA
+	depends on DMA_DW
 
 config DMA_DW
 	default y
+	depends on DMA
 
-endif
-
-if I2S
 config I2S_CAVS
 	default y
-endif
+	depends on I2S
 
 endif # BOARD_UP_SQUARED_ADSP

--- a/boards/xtensa/xt-sim/Kconfig.defconfig
+++ b/boards/xtensa/xt-sim/Kconfig.defconfig
@@ -1,9 +1,6 @@
 # Copyright (c) 2016 Cadence Design Systems, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_XT_SIM
-
 config BOARD
 	default "xt-sim"
-
-endif # BOARD_SIMULATOR_XTENSA
+	depends on BOARD_XT_SIM

--- a/soc/arc/snps_arc_hsdk/Kconfig.defconfig
+++ b/soc/arc/snps_arc_hsdk/Kconfig.defconfig
@@ -36,19 +36,15 @@ config ARC_CONNECT
 config MP_NUM_CPUS
 	default 4
 
-if SMP
 # When SMP is enabled, use gfrc as wall clock, so sloppy
 # idle should be y
 config SYSTEM_CLOCK_SLOPPY_IDLE
 	default y
-endif
-
-if SERIAL
+	depends on SMP
 
 config UART_NS16550
 	default y
-
-endif # SERIAL
+	depends on SERIAL
 
 if UART_CONSOLE
 

--- a/soc/arc/snps_arc_iot/Kconfig.defconfig
+++ b/soc/arc/snps_arc_iot/Kconfig.defconfig
@@ -34,18 +34,12 @@ config HARVARD
 config ARC_FIRQ
 	default y
 
-if SERIAL
-
 config UART_NS16550
 	default y
-
-endif # SERIAL
-
-if UART_CONSOLE
+	depends on SERIAL
 
 config UART_NS16550_PORT_0
 	default y
-
-endif # UART_CONSOLE
+	depends on UART_CONSOLE
 
 endif # ARC_IOT

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em11d
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em11d
@@ -33,11 +33,8 @@ config MAIN_STACK_SIZE
 config IDLE_STACK_SIZE
 	default 2048
 
-if ZTEST
-
 config ZTEST_STACKSIZE
 	default 2048
-
-endif # ZTEST
+	depends on ZTEST
 
 endif # SOC_EMSDP_EM11D

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em4
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em4
@@ -33,11 +33,8 @@ config MAIN_STACK_SIZE
 config IDLE_STACK_SIZE
 	default 2048
 
-if ZTEST
-
 config ZTEST_STACKSIZE
 	default 2048
-
-endif # ZTEST
+	depends on ZTEST
 
 endif # SOC_EMSDP_EM4

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em5d
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em5d
@@ -33,11 +33,8 @@ config MAIN_STACK_SIZE
 config IDLE_STACK_SIZE
 	default 2048
 
-if ZTEST
-
 config ZTEST_STACKSIZE
 	default 2048
-
-endif # ZTEST
+	depends on ZTEST
 
 endif # SOC_EMSDP_EM5D

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em6
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em6
@@ -33,11 +33,8 @@ config MAIN_STACK_SIZE
 config IDLE_STACK_SIZE
 	default 2048
 
-if ZTEST
-
 config ZTEST_STACKSIZE
 	default 2048
-
-endif # ZTEST
+	depends on ZTEST
 
 endif # SOC_EMSDP_EM6

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em7d
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em7d
@@ -33,11 +33,8 @@ config MAIN_STACK_SIZE
 config IDLE_STACK_SIZE
 	default 2048
 
-if ZTEST
-
 config ZTEST_STACKSIZE
 	default 2048
-
-endif # ZTEST
+	depends on ZTEST
 
 endif # SOC_EMSDP_EM7D

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em9d
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em9d
@@ -33,11 +33,8 @@ config MAIN_STACK_SIZE
 config IDLE_STACK_SIZE
 	default 2048
 
-if ZTEST
-
 config ZTEST_STACKSIZE
 	default 2048
-
-endif # ZTEST
+	depends on ZTEST
 
 endif # SOC_EMSDP_EM9D

--- a/soc/arc/snps_emsk/Kconfig.defconfig.em7d
+++ b/soc/arc/snps_emsk/Kconfig.defconfig.em7d
@@ -46,12 +46,9 @@ config MAIN_STACK_SIZE
 config IDLE_STACK_SIZE
 	default 2048
 
-if ZTEST
-
 config ZTEST_STACKSIZE
 	default 2048
-
-endif # ZTEST
+	depends on ZTEST
 
 endif # ARC_MPU_VER
 

--- a/soc/arc/snps_nsim/Kconfig.defconfig.em
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.em
@@ -44,12 +44,9 @@ config MAIN_STACK_SIZE
 config IDLE_STACK_SIZE
 	default 2048
 
-if ZTEST
-
 config ZTEST_STACKSIZE
 	default 2048
-
-endif # ZTEST
+	depends on ZTEST
 
 endif # ARC_MPU_VER
 

--- a/soc/arc/snps_nsim/Kconfig.defconfig.hs_smp
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.hs_smp
@@ -33,11 +33,10 @@ config ARC_CONNECT
 config MP_NUM_CPUS
 	default 2
 
-if SMP
 # When SMP is enabled, use gfrc as wall clock, so sloppy
 # idle should be y
 config SYSTEM_CLOCK_SLOPPY_IDLE
 	default y
-endif
+	depends on SMP
 
-endif #SOC_NSIM_HS_SMP
+endif # SOC_NSIM_HS_SMP

--- a/soc/arm/arm/beetle/Kconfig.defconfig.beetle_r0
+++ b/soc/arm/arm/beetle/Kconfig.defconfig.beetle_r0
@@ -3,9 +3,6 @@
 # Copyright (c) 2016 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_BEETLE_R0
-
 config SOC
 	default "beetle_r0"
-
-endif # SOC_BEETLE_R0
+	depends on SOC_BEETLE_R0

--- a/soc/arm/atmel_sam/Kconfig.defconfig
+++ b/soc/arm/atmel_sam/Kconfig.defconfig
@@ -5,9 +5,6 @@
 
 source "soc/arm/atmel_sam/*/Kconfig.defconfig.series"
 
-if SOC_FAMILY_SAM
-
 config WATCHDOG
 	default y
-
-endif
+	depends on SOC_FAMILY_SAM

--- a/soc/arm/atmel_sam/same70/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/same70/Kconfig.defconfig.series
@@ -44,54 +44,44 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 # device driver the default configuration will be placed in the board defconfig
 # file.
 
-if DMA
 config DMA_SAM_XDMAC
 	default y
-endif # DMA
+	depends on DMA
 
-if GPIO
 config GPIO_SAM
 	default y
-endif # GPIO
+	depends on GPIO
 
-if ADC
 config ADC_SAM_AFEC
 	default y
-endif # ADC
+	depends on ADC
 
-if I2C
 config I2C_SAM_TWIHS
 	default y
-endif # I2C
+	depends on I2C
 
-if I2S
 config I2S_SAM_SSC
 	default y
-endif # I2S
+	depends on I2S
 
-if SPI
 config SPI_SAM
 	default y
-endif # SPI
+	depends on SPI
 
-if USB
 config USB_DC_SAM
 	default y
-endif # USB
+	depends on USB
 
-if ENTROPY_GENERATOR
 config ENTROPY_SAM_RNG
 	default y
-endif # ENTROPY_GENERATOR
+	depends on ENTROPY_GENERATOR
 
-if FLASH
 config SOC_FLASH_SAM
 	default y
-endif # FLASH
+	depends on FLASH
 
-if PWM
 config PWM_SAM
 	default y
-endif # PWM
+	depends on PWM
 
 endif # SOC_SERIES_SAME70

--- a/soc/arm/atmel_sam/samv71/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/samv71/Kconfig.defconfig.series
@@ -45,54 +45,44 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 # device driver the default configuration will be placed in the board defconfig
 # file.
 
-if DMA
 config DMA_SAM_XDMAC
 	default y
-endif # DMA
+	depends on DMA
 
-if GPIO
 config GPIO_SAM
 	default y
-endif # GPIO
+	depends on GPIO
 
-if ADC
 config ADC_SAM_AFEC
 	default y
-endif # ADC
+	depends on ADC
 
-if I2C
 config I2C_SAM_TWIHS
 	default y
-endif # I2C
+	depends on I2C
 
-if I2S
 config I2S_SAM_SSC
 	default y
-endif # I2S
+	depends on I2S
 
-if SPI
 config SPI_SAM
 	default y
-endif # SPI
+	depends on SPI
 
-if USB
 config USB_DC_SAM
 	default y
-endif # USB
+	depends on USB
 
-if ENTROPY_GENERATOR
 config ENTROPY_SAM_RNG
 	default y
-endif # ENTROPY_GENERATOR
+	depends on ENTROPY_GENERATOR
 
-if FLASH
 config SOC_FLASH_SAM
 	default y
-endif # FLASH
+	depends on FLASH
 
-if PWM
 config PWM_SAM
 	default y
-endif # PWM
+	depends on PWM
 
 endif # SOC_SERIES_SAMV71

--- a/soc/arm/bcm_vk/valkyrie/Kconfig.defconfig.valkyrie_bcm58400
+++ b/soc/arm/bcm_vk/valkyrie/Kconfig.defconfig.valkyrie_bcm58400
@@ -1,11 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Copyright 2020 Broadcom.
-#
-
-if SOC_BCM58400
 
 config SOC
 	default "BCM58400"
-
-endif # SOC_BCM58400
+	depends on SOC_BCM58400

--- a/soc/arm/cypress/psoc6/Kconfig.defconfig.psoc6_m0
+++ b/soc/arm/cypress/psoc6/Kconfig.defconfig.psoc6_m0
@@ -8,11 +8,8 @@ if SOC_PSOC6_M0
 config SOC
 	default "psoc6_m0"
 
-if SERIAL
-
 config UART_PSOC6
 	default y
-
-endif # SERIAL
+	depends on SERIAL
 
 endif # SOC_PSOC6_M0

--- a/soc/arm/cypress/psoc6/Kconfig.defconfig.psoc6_m4
+++ b/soc/arm/cypress/psoc6/Kconfig.defconfig.psoc6_m4
@@ -8,11 +8,8 @@ if SOC_PSOC6_M4
 config SOC
 	default "psoc6_m4"
 
-if SERIAL
-
 config UART_PSOC6
 	default y
-
-endif # SERIAL
+	depends on SERIAL
 
 endif # SOC_PSOC6_M4

--- a/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.mec1501hsz
+++ b/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.mec1501hsz
@@ -8,85 +8,52 @@ if SOC_MEC1501_HSZ
 config SOC
 	default "mec1501hsz"
 
-if SERIAL
-
 config UART_NS16550
 	default y
-
-endif # SERIAL
-
-if PINMUX
+	depends on SERIAL
 
 config PINMUX_XEC
 	default y
-
-endif # PINMUX
+	depends on PINMUX
 
 config GPIO
 	default y
 
-if ADC
-
 config ADC_XEC
 	default y
-
-endif # ADC
-
-if GPIO
+	depends on ADC
 
 config GPIO_XEC
 	default y
-
-endif # GPIO
-
-if I2C
+	depends on GPIO
 
 config I2C_XEC
 	default y
-
-endif # I2C
-
-if ESPI
+	depends on I2C
 
 config ESPI_XEC
 	default y
-
-endif #ESPI
-
-if COUNTER
+	depends on ESPI
 
 config COUNTER_XEC
 	default y
-
-endif # COUNTER
-
-if PS2
+	depends on COUNTER
 
 config PS2_XEC
 	default y
-
-endif # PS2
-
-if PWM
+	depends on PS2
 
 config PWM_XEC
 	default y
-
-endif # PWM
-
-if KSCAN
+	depends on PWM
 
 config KSCAN_XEC
 	default y
-
-endif # KSCAN
-
-if SPI
+	depends on KSCAN
 
 config SPI_XEC_QMSPI
 	default y
-
-endif # SPI
+	depends on SPI
 
 if SOC_POWER_MANAGEMENT
 

--- a/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.series
+++ b/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.series
@@ -26,11 +26,8 @@ config ARCH_HAS_CUSTOM_BUSY_WAIT
 
 endif # RTOS_TIMER
 
-if !RTOS_TIMER
-
 config CORTEX_M_SYSTICK
 	default y
-
-endif # RTOS_TIMER
+	depends on !RTOS_TIMER
 
 endif # SOC_SERIES_MEC1501X

--- a/soc/arm/microchip_mec/mec1701/Kconfig.defconfig.mec1701qsz
+++ b/soc/arm/microchip_mec/mec1701/Kconfig.defconfig.mec1701qsz
@@ -11,11 +11,8 @@ config SOC
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 48000000
 
-if SERIAL
-
 config UART_NS16550
 	default y
-
-endif # SERIAL
+	depends on SERIAL
 
 endif # SOC_MEC1701_QSZ

--- a/soc/arm/nordic_nrf/Kconfig.defconfig
+++ b/soc/arm/nordic_nrf/Kconfig.defconfig
@@ -33,11 +33,8 @@ config SYS_POWER_MANAGEMENT
 config BUILD_OUTPUT_HEX
 	default y
 
-if SPI
-
 config GPIO
 	default y
-
-endif # SPI
+	depends on SPI
 
 endif # SOC_FAMILY_NRF

--- a/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAA
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAA
@@ -4,9 +4,6 @@
 # Copyright (c) 2016 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_NRF51822_QFAA
-
 config SOC
 	default "nRF51822_QFAA"
-
-endif # SOC_NRF51822_QFAA
+	depends on SOC_NRF51822_QFAA

--- a/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAB
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAB
@@ -4,9 +4,6 @@
 # Copyright (c) 2016 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_NRF51822_QFAB
-
 config SOC
 	default "nRF51822_QFAB"
-
-endif # SOC_NRF51822_QFAB
+	depends on SOC_NRF51822_QFAB

--- a/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAC
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAC
@@ -4,9 +4,6 @@
 # Copyright (c) 2016 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_NRF51822_QFAC
-
 config SOC
 	default "nRF51822_QFAC"
-
-endif # SOC_NRF51822_QFAC
+	depends on SOC_NRF51822_QFAC

--- a/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.mcimx6x_m4
+++ b/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.mcimx6x_m4
@@ -11,32 +11,20 @@ config SOC
 config FLOAT
 	default y
 
-if GPIO
-
 config GPIO_IMX
 	default y
-
-endif # GPIO
-
-if SERIAL
+	depends on GPIO
 
 config UART_IMX
 	default y
-
-endif # SERIAL
-
-if IPM
+	depends on SERIAL
 
 config IPM_IMX
 	default y
-
-endif # IPM
-
-if COUNTER
+	depends on IPM
 
 config COUNTER_IMX_EPIT
 	default y
-
-endif # COUNTER
+	depends on COUNTER
 
 endif # SOC_MCIMX6X_M4

--- a/soc/arm/nxp_imx/mcimx7_m4/Kconfig.defconfig.mcimx7_m4
+++ b/soc/arm/nxp_imx/mcimx7_m4/Kconfig.defconfig.mcimx7_m4
@@ -14,39 +14,24 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config GPIO
 	default y
 
-if GPIO
-
 config GPIO_IMX
 	default y
-
-endif # GPIO
-
-if SERIAL
+	depends on GPIO
 
 config UART_IMX
 	default y
-
-endif # SERIAL
-
-if I2C
+	depends on SERIAL
 
 config I2C_IMX
 	default y
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_IMX
 	default y
-
-endif # PWM
-
-if IPM
+	depends on PWM
 
 config IPM_IMX
 	default y
-
-endif # IPM
+	depends on IPM
 
 endif # SOC_MCIMX7_M4

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -11,68 +11,41 @@ config SOC_SERIES
 config TEXT_SECTION_OFFSET
 	default 0x2000 if BOOT_FLEXSPI_NOR || BOOT_SEMC_NOR
 
-if CLOCK_CONTROL
-
 config CLOCK_CONTROL_MCUX_CCM
 	default y if HAS_MCUX_CCM
-
-endif # CLOCK_CONTROL
-
-if DISK_ACCESS_SDHC
+	depends on CLOCK_CONTROL
 
 config DISK_ACCESS_USDHC
 	default y if (HAS_MCUX_USDHC1 || HAS_MCUX_USDHC2)
-
-endif # DISK_ACCESS_SDHC
-
-if DISPLAY
+	depends on DISK_ACCESS_SDHC
 
 config DISPLAY_MCUX_ELCDIF
 	default y if HAS_MCUX_ELCDIF
-
-endif # DISPLAY
-
-if GPIO
+	depends on DISPLAY
 
 config GPIO_MCUX_IGPIO
 	default y if HAS_MCUX_IGPIO
-
-endif # GPIO
-
-if ENTROPY_GENERATOR
+	depends on GPIO
 
 config ENTROPY_MCUX_TRNG
 	default y if HAS_MCUX_TRNG
-
-endif # ENTROPY_GENERATOR
-
-if I2C
+	depends on ENTROPY_GENERATOR
 
 config I2C_MCUX_LPI2C
 	default y if HAS_MCUX_LPI2C
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_MCUX
 	default y if HAS_MCUX_PWM
-
-endif # PWM
-
-if NET_L2_ETHERNET
+	depends on PWM
 
 config ETH_MCUX
 	default y if HAS_MCUX_ENET
-
-endif # NET_L2_ETHERNET
-
-if SERIAL
+	depends on NET_L2_ETHERNET
 
 config UART_MCUX_LPUART
 	default y if HAS_MCUX_LPUART
-
-endif # SERIAL
+	depends on SERIAL
 
 if COUNTER
 
@@ -87,12 +60,9 @@ config COUNTER_MCUX_GPT2
 
 endif # COUNTER
 
-if SPI
-
 config SPI_MCUX_LPSPI
 	default y if HAS_MCUX_LPSPI
-
-endif # SPI
+	depends on SPI
 
 if CODE_ITCM
 
@@ -154,19 +124,13 @@ config SRAM_BASE_ADDRESS
 
 endif # DATA_OCRAM
 
-if USB
-
 config USB_DC_NXP_EHCI
 	default y
-
-endif # USB
-
-if VIDEO
+	depends on USB
 
 config VIDEO_MCUX_CSI
 	default y if HAS_MCUX_CSI
-
-endif
+	depends on VIDEO
 
 source "soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt*"
 

--- a/soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.mk22f12
+++ b/soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.mk22f12
@@ -8,91 +8,55 @@ if SOC_MK22F51212
 config SOC
 	default "mk22f51212"
 
-if ADC
-
 config ADC_MCUX_ADC16
 	default y
-
-endif # ADC
-
-if CLOCK_CONTROL
+	depends on ADC
 
 config CLOCK_CONTROL_MCUX_SIM
 	default y
-
-endif # CLOCK_CONTROL
-
-if PINMUX
+	depends on CLOCK_CONTROL
 
 config PINMUX_MCUX
 	default y
-
-endif # PINMUX
+	depends on PINMUX
 
 config GPIO
 	default y
 
-if GPIO
-
 config GPIO_MCUX
 	default y
-
-endif # GPIO
-
-if I2C
+	depends on GPIO
 
 config I2C_MCUX
 	default y
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_MCUX_FTM
 	default y
-
-endif # PWM
-
-if SPI
+	depends on PWM
 
 config SPI_MCUX_DSPI
 	default y
-
-endif # SPI
-
-if ENTROPY_GENERATOR
+	depends on SPI
 
 config ENTROPY_MCUX_RNGA
 	default y
-
-endif # ENTROPY_GENERATOR
-
-if FLASH
+	depends on ENTROPY_GENERATOR
 
 config SOC_FLASH_MCUX
 	default y
-
-endif # FLASH
-
-if SERIAL
+	depends on FLASH
 
 config UART_MCUX
 	default y
-
-endif # SERIAL
-
-if USB
+	depends on SERIAL
 
 config USB_KINETIS
 	default y
-
-endif # USB
-
-if WATCHDOG
+	depends on USB
 
 config WDT_MCUX_WDOG
 	default y
-
-endif # WATCHDOG
+	depends on WATCHDOG
 
 endif # SOC_MK22F12

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk64f12
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk64f12
@@ -8,19 +8,13 @@ if SOC_MK64F12
 config SOC
 	default "mk64f12"
 
-if ADC
-
 config ADC_MCUX_ADC16
 	default y
-
-endif # ADC
-
-if CAN
+	depends on ADC
 
 config CAN_MCUX_FLEXCAN
 	default y
-
-endif # CAN
+	depends on CAN
 
 if CLOCK_CONTROL
 
@@ -32,94 +26,58 @@ config CLOCK_CONTROL_MCUX_MCG
 
 endif # CLOCK_CONTROL
 
-if PINMUX
-
 config PINMUX_MCUX
 	default y
-
-endif # PINMUX
+	depends on PINMUX
 
 config GPIO
 	default y
 
-if GPIO
-
 config GPIO_MCUX
 	default y
-
-endif # GPIO
-
-if I2C
+	depends on GPIO
 
 config I2C_MCUX
 	default y
-
-endif # I2C
-
-if PWM
+	depends on I2C
 
 config PWM_MCUX_FTM
 	default y
-
-endif # PWM
+	depends on PWM
 
 config SPI
 	default n
 
-if SPI
-
 config SPI_MCUX_DSPI
 	default y
-
-endif # SPI
-
-if NET_L2_ETHERNET
+	depends on SPI
 
 config ETH_MCUX
 	default y
-
-endif # NET_L2_ETHERNET
-
-if ENTROPY_GENERATOR
+	depends on NET_L2_ETHERNET
 
 config ENTROPY_MCUX_RNGA
 	default y
-
-endif # ENTROPY_GENERATOR
-
-if FLASH
+	depends on ENTROPY_GENERATOR
 
 config SOC_FLASH_MCUX
 	default y
-
-endif # FLASH
-
-if SERIAL
+	depends on FLASH
 
 config UART_MCUX
 	default y
-
-endif # SERIAL
-
-if USB
+	depends on SERIAL
 
 config USB_KINETIS
 	default y
-
-endif # USB
-
-if WATCHDOG
+	depends on USB
 
 config WDT_MCUX_WDOG
 	default y
-
-endif # WATCHDOG
-
-if COUNTER
+	depends on WATCHDOG
 
 config COUNTER_MCUX_RTC
 	default y
-
-endif # COUNTER
+	depends on COUNTER
 
 endif # SOC_MK64F12

--- a/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.mk80f25615
+++ b/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.mk80f25615
@@ -3,9 +3,6 @@
 # Copyright (c) 2019 SEAL AG
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_MK80F25615
-
 config SOC
 	default "mk80f25615"
-
-endif # SOC_MK80F25615
+	depends on SOC_MK80F25615

--- a/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.mk82f25615
+++ b/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.mk82f25615
@@ -3,9 +3,6 @@
 # Copyright (c) 2019 SEAL AG
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_MK82F25615
-
 config SOC
 	default "mk82f25615"
-
-endif # SOC_MK82F25615
+	depends on SOC_MK82F25615

--- a/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.series
+++ b/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.series
@@ -15,19 +15,13 @@ config NUM_IRQS
 config CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
 	default y
 
-if KINETIS_FLASH_CONFIG
-
 config KINETIS_FLASH_CONFIG_FOPT
 	default 0x3f
-
-endif # KINETIS_FLASH_CONFIG
-
-if ADC
+	depends on KINETIS_FLASH_CONFIG
 
 config ADC_MCUX_ADC16
 	default y
-
-endif # ADC
+	depends on ADC
 
 if CLOCK_CONTROL
 
@@ -39,78 +33,48 @@ config CLOCK_CONTROL_MCUX_SIM
 
 endif # CLOCK_CONTROL
 
-if ENTROPY_GENERATOR
-
 config ENTROPY_MCUX_TRNG
 	default y
-
-endif # ENTROPY_GENERATOR
-
-if FLASH
+	depends on ENTROPY_GENERATOR
 
 config SOC_FLASH_MCUX
 	default y
-
-endif # FLASH
+	depends on FLASH
 
 config GPIO
 	default y
 
-if GPIO
-
 config GPIO_MCUX
 	default y
-
-endif # GPIO
-
-if I2C
+	depends on GPIO
 
 config I2C_MCUX
 	default y
-
-endif # I2C
-
-if PINMUX
+	depends on I2C
 
 config PINMUX_MCUX
 	default y
-
-endif # PINMUX
-
-if PWM
+	depends on PINMUX
 
 config PWM_MCUX_FTM
 	default y
-
-endif # PWM
-
-if SERIAL
+	depends on PWM
 
 config UART_MCUX_LPUART
 	default y
-
-endif # SERIAL
-
-if SPI
+	depends on SERIAL
 
 config SPI_MCUX_DSPI
 	default y
-
-endif # SPI
-
-if USB
+	depends on SPI
 
 config USB_KINETIS
 	default y
-
-endif # USB
-
-if WATCHDOG
+	depends on USB
 
 config WDT_MCUX_WDOG
 	default y
-
-endif # WATCHDOG
+	depends on WATCHDOG
 
 source "soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.mk*"
 

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.mke14f16
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.mke14f16
@@ -3,9 +3,6 @@
 # Copyright (c) 2019 Vestas Wind Systems A/S
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_MKE14F16
-
 config SOC
 	default "mke14f16"
-
-endif # SOC_MKE14F16
+	depends on SOC_MKE14F16

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.mke16f16
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.mke16f16
@@ -8,11 +8,8 @@ if SOC_MKE16F16
 config SOC
 	default "mke16f16"
 
-if CAN
-
 config CAN_MCUX_FLEXCAN
 	default y
-
-endif # CAN
+	depends on CAN
 
 endif # SOC_MKE16F16

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.mke18f16
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.mke18f16
@@ -8,11 +8,8 @@ if SOC_MKE18F16
 config SOC
 	default "mke18f16"
 
-if CAN
-
 config CAN_MCUX_FLEXCAN
 	default y
-
-endif # CAN
+	depends on CAN
 
 endif # SOC_MKE18F16

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.series
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.series
@@ -15,12 +15,9 @@ config NUM_IRQS
 config CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
 	default y
 
-if KINETIS_FLASH_CONFIG
-
 config KINETIS_FLASH_CONFIG_FOPT
 	default 0x7d
-
-endif # KINETIS_FLASH_CONFIG
+	depends on KINETIS_FLASH_CONFIG
 
 if CLOCK_CONTROL
 
@@ -35,78 +32,48 @@ config CLOCK_CONTROL_MCUX_PCC
 
 endif # CLOCK_CONTROL
 
-if WATCHDOG
-
 config WDT_MCUX_WDOG32
 	default y
-
-endif # WATCHDOG
-
-if COUNTER
+	depends on WATCHDOG
 
 config COUNTER_MCUX_RTC
 	default y
-
-endif # COUNTER
-
-if PWM
+	depends on COUNTER
 
 config PWM_MCUX_FTM
 	default y
-
-endif # PWM
-
-if PINMUX
+	depends on PWM
 
 config PINMUX_MCUX
 	default y
-
-endif # PINMUX
+	depends on PINMUX
 
 config GPIO
 	default y
 
-if GPIO
-
 config GPIO_MCUX
 	default y
-
-endif # GPIO
-
-if FLASH
+	depends on GPIO
 
 config SOC_FLASH_MCUX
 	default y
-
-endif # FLASH
-
-if SERIAL
+	depends on FLASH
 
 config UART_MCUX_LPUART
 	default y
-
-endif # SERIAL
-
-if I2C
+	depends on SERIAL
 
 config I2C_MCUX_LPI2C
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_MCUX_LPSPI
 	default y
-
-endif # SPI
-
-if ADC
+	depends on SPI
 
 config ADC_MCUX_ADC12
 	default y
-
-endif # ADC
+	depends on ADC
 
 source "soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.mke*"
 

--- a/soc/arm/nxp_kinetis/kl2x/Kconfig.defconfig.mkl25z4
+++ b/soc/arm/nxp_kinetis/kl2x/Kconfig.defconfig.mkl25z4
@@ -11,60 +11,36 @@ config SOC
 config NUM_IRQS
 	default 32
 
-if ADC
-
 config ADC_MCUX_ADC16
 	default y
-
-endif # ADC
-
-if CLOCK_CONTROL
+	depends on ADC
 
 config CLOCK_CONTROL_MCUX_SIM
 	default y
-
-endif # CLOCK_CONTROL
-
-if PINMUX
+	depends on CLOCK_CONTROL
 
 config PINMUX_MCUX
 	default y
-
-endif # PINMUX
-
-if GPIO
+	depends on PINMUX
 
 config GPIO_MCUX
 	default y
-
-endif # GPIO
-
-if SERIAL
+	depends on GPIO
 
 config UART_MCUX_LPSCI
 	default y
-
-endif # SERIAL
-
-if I2C
+	depends on SERIAL
 
 config I2C_MCUX
 	default y
-
-endif # I2C
-
-if FLASH
+	depends on I2C
 
 config SOC_FLASH_MCUX
 	default y
-
-endif # FLASH
-
-if USB
+	depends on FLASH
 
 config USB_KINETIS
 	default y
-
-endif # USB
+	depends on USB
 
 endif # SOC_MKL25Z

--- a/soc/arm/nxp_kinetis/kv5x/Kconfig.defconfig.mkv56f24
+++ b/soc/arm/nxp_kinetis/kv5x/Kconfig.defconfig.mkv56f24
@@ -3,9 +3,6 @@
 # Copyright (c) 2019 SEAL AG
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_MKV56F24
-
 config SOC
 	default "mkv56f24"
-
-endif # SOC_MKV56F24
+	depends on SOC_MKV56F24

--- a/soc/arm/nxp_kinetis/kv5x/Kconfig.defconfig.mkv58f24
+++ b/soc/arm/nxp_kinetis/kv5x/Kconfig.defconfig.mkv58f24
@@ -3,9 +3,6 @@
 # Copyright (c) 2019 SEAL AG
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_MKV58F24
-
 config SOC
 	default "mkv58f24"
-
-endif # SOC_MKV58F24
+	depends on SOC_MKV58F24

--- a/soc/arm/nxp_kinetis/kv5x/Kconfig.defconfig.series
+++ b/soc/arm/nxp_kinetis/kv5x/Kconfig.defconfig.series
@@ -12,71 +12,44 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 121
 
-if ADC
-
 config ADC_MCUX_ADC16
 	default y
-
-endif # ADC
-
-if CLOCK_CONTROL
+	depends on ADC
 
 config CLOCK_CONTROL_MCUX_SIM
 	default y
-
-endif # CLOCK_CONTROL
-
-if FLASH
+	depends on CLOCK_CONTROL
 
 config SOC_FLASH_MCUX
 	default y
-
-endif # FLASH
+	depends on FLASH
 
 config GPIO
 	default y
 
-if GPIO
-
 config GPIO_MCUX
 	default y
-
-endif # GPIO
-
-if I2C
+	depends on GPIO
 
 config I2C_MCUX
 	default y
-
-endif # I2C
-
-if PINMUX
+	depends on I2C
 
 config PINMUX_MCUX
 	default y
-
-endif # PINMUX
-
-if PWM
+	depends on PINMUX
 
 config PWM_MCUX_FTM
 	default y
-
-endif # PWM
-
-if SERIAL
+	depends on PWM
 
 config UART_MCUX
 	default y
-
-endif # SERIAL
-
-if SPI
+	depends on SERIAL
 
 config SPI_MCUX_DSPI
 	default y
-
-endif # SPI
+	depends on SPI
 
 source "soc/arm/nxp_kinetis/kv5x/Kconfig.defconfig.mkv*"
 

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw2xd512
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw2xd512
@@ -5,29 +5,20 @@
 
 if SOC_MKW22D5 || SOC_MKW24D5
 
-if SOC_MKW22D5
-
 config SOC
 	default "mkw22d5"
-
-endif # SOC_MKW22D5
-
-if SOC_MKW24D5
+	depends on SOC_MKW22D5
 
 config SOC
 	default "mkw24d5"
-
-endif # SOC_MKW24D5
+	depends on SOC_MKW24D5
 
 config NUM_IRQS
 	default 65
 
-if ADC
-
 config ADC_MCUX_ADC16
 	default y
-
-endif # ADC
+	depends on ADC
 
 if CLOCK_CONTROL
 
@@ -39,77 +30,47 @@ config CLOCK_CONTROL_MCUX_MCG
 
 endif # CLOCK_CONTROL
 
-if PINMUX
-
 config PINMUX_MCUX
 	default y
-
-endif # PINMUX
-
-if GPIO
+	depends on PINMUX
 
 config GPIO_MCUX
 	default y
-
-endif # GPIO
-
-if I2C
+	depends on GPIO
 
 config I2C_MCUX
 	default y
-
-endif # I2C
+	depends on I2C
 
 config SPI
 	default y
 
-if PWM
-
 config PWM_MCUX_FTM
 	default y
-
-endif # PWM
-
-if SPI
+	depends on PWM
 
 config SPI_MCUX_DSPI
 	default y
-
-endif # SPI
-
-if ENTROPY_GENERATOR
+	depends on SPI
 
 config ENTROPY_MCUX_RNGA
 	default y
-
-endif # ENTROPY_GENERATOR
-
-if FLASH
+	depends on ENTROPY_GENERATOR
 
 config SOC_FLASH_MCUX
 	default y
-
-endif # FLASH
-
-if SERIAL
+	depends on FLASH
 
 config UART_MCUX
 	default y
-
-endif # SERIAL
-
-if USB
+	depends on SERIAL
 
 config USB_KINETIS
 	default y
-
-endif # USB
-
-if WATCHDOG
+	depends on USB
 
 config WDT_MCUX_WDOG
 	default y
-
-endif # WATCHDOG
+	depends on WATCHDOG
 
 endif # SOC_MKW2xD512

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw40z4
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw40z4
@@ -10,61 +10,37 @@ config SOC
 config NUM_IRQS
 	default 32
 
-if ADC
-
 config ADC_MCUX_ADC16
 	default y
-
-endif # ADC
-
-if CLOCK_CONTROL
+	depends on ADC
 
 config CLOCK_CONTROL_MCUX_SIM
 	default y
-
-endif # CLOCK_CONTROL
-
-if PINMUX
+	depends on CLOCK_CONTROL
 
 config PINMUX_MCUX
 	default y
-
-endif # PINMUX
-
-if GPIO
+	depends on PINMUX
 
 config GPIO_MCUX
 	default y
-
-endif # GPIO
-
-if SERIAL
+	depends on GPIO
 
 config UART_MCUX_LPUART
 	default y
-
-endif # SERIAL
-
-if I2C
+	depends on SERIAL
 
 config I2C_MCUX
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_MCUX_DSPI
 	default y
-
-endif # SPI
-
-if ENTROPY_GENERATOR
+	depends on SPI
 
 config ENTROPY_MCUX_TRNG
 	default y
-
-endif # ENTROPY_GENERATOR
+	depends on ENTROPY_GENERATOR
 
 choice CSPRNG_GENERATOR_CHOICE
 	default CTR_DRBG_CSPRNG_GENERATOR
@@ -77,11 +53,8 @@ endchoice
 config TINYCRYPT
 	default y
 
-if FLASH
-
 config SOC_FLASH_MCUX
 	default y
-
-endif # FLASH
+	depends on FLASH
 
 endif # SOC_MKW40Z4

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
@@ -11,82 +11,51 @@ config SOC
 config NUM_IRQS
 	default 32
 
-if ADC
-
 config ADC_MCUX_ADC16
 	default y
-
-endif # ADC
-
-if CLOCK_CONTROL
+	depends on ADC
 
 config CLOCK_CONTROL_MCUX_SIM
 	default y
-
-endif # CLOCK_CONTROL
-
-if COUNTER
+	depends on CLOCK_CONTROL
 
 config COUNTER_MCUX_RTC
 	default y
-
-endif # COUNTER
-
-if PINMUX
+	depends on COUNTER
 
 config PINMUX_MCUX
 	default y
-
-endif # PINMUX
-
-if GPIO
+	depends on PINMUX
 
 config GPIO_MCUX
 	default y
-
-endif # GPIO
-
-if SERIAL
+	depends on GPIO
 
 config UART_MCUX_LPUART
 	default y
-
-endif # SERIAL
-
-if I2C
+	depends on SERIAL
 
 config I2C_MCUX
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_MCUX_DSPI
 	default y
-
-endif # SPI
-
-if ENTROPY_GENERATOR
+	depends on SPI
 
 config ENTROPY_MCUX_TRNG
 	default y
-
-endif # ENTROPY_GENERATOR
-
-if FLASH
+	depends on ENTROPY_GENERATOR
 
 config SOC_FLASH_MCUX
 	default y
-
-endif # FLASH
+	depends on FLASH
 
 if NETWORKING
 
-if !NET_L2_OPENTHREAD
 config NET_L2_IEEE802154
 	default y
-endif # NET_L2_OPENTHREAD
+	depends on !NET_L2_OPENTHREAD
 
 config IEEE802154_KW41Z
 	default y
@@ -100,14 +69,13 @@ choice CSPRNG_GENERATOR_CHOICE
 	default CTR_DRBG_CSPRNG_GENERATOR
 endchoice
 
-if ENTROPY_GENERATOR
 #
 # MBEDTLS is larger but much faster than TinyCrypt so choose wisely
 #
 #config MBEDTLS
 config TINYCRYPT
 	default y
-endif
+	depends on ENTROPY_GENERATOR
 
 #
 # KW41Z TRNG entropy source cannot be used as a Hardware RNG source so

--- a/soc/arm/nxp_lpc/Kconfig.defconfig
+++ b/soc/arm/nxp_lpc/Kconfig.defconfig
@@ -3,9 +3,6 @@
 
 source "soc/arm/nxp_lpc/*/Kconfig.defconfig.series"
 
-if SPI
-
 config SPI_MCUX_FLEXCOMM
 	default y if HAS_MCUX_FLEXCOMM
-
-endif # SPI
+	depends on SPI

--- a/soc/arm/nxp_lpc/lpc54xxx/Kconfig.defconfig.lpc54114_m0
+++ b/soc/arm/nxp_lpc/lpc54xxx/Kconfig.defconfig.lpc54114_m0
@@ -8,28 +8,19 @@ if SOC_LPC54114_M0
 config SOC
 	default "lpc54114_m0"
 
-if PINMUX
-
 config PINMUX_MCUX_LPC
 	default n
-
-endif # PINMUX
+	depends on PINMUX
 
 config GPIO
 	default n
 
-if GPIO
-
 config GPIO_MCUX_LPC
 	default n
-
-endif # GPIO
-
-if SERIAL
+	depends on GPIO
 
 config UART_MCUX_FLEXCOMM
 	default n
-
-endif # SERIAL
+	depends on SERIAL
 
 endif # SOC_LPC54114_M0

--- a/soc/arm/nxp_lpc/lpc54xxx/Kconfig.defconfig.lpc54114_m4
+++ b/soc/arm/nxp_lpc/lpc54xxx/Kconfig.defconfig.lpc54114_m4
@@ -8,25 +8,16 @@ if SOC_LPC54114_M4
 config SOC
 	default "lpc54114"
 
-if PINMUX
-
 config PINMUX_MCUX_LPC
 	default y
-
-endif # PINMUX
-
-if GPIO
+	depends on PINMUX
 
 config GPIO_MCUX_LPC
 	default y
-
-endif # GPIO
-
-if SERIAL
+	depends on GPIO
 
 config UART_MCUX_FLEXCOMM
 	default y
-
-endif # SERIAL
+	depends on SERIAL
 
 endif # SOC_LPC54114_M4

--- a/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.lpc55S69_cpu0
+++ b/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.lpc55S69_cpu0
@@ -8,32 +8,20 @@ if SOC_LPC55S69_CPU0
 config SOC
 	default "lpc55S69_cpu0"
 
-if PINMUX
-
 config PINMUX_MCUX_LPC
 	default y
-
-endif # PINMUX
-
-if GPIO
+	depends on PINMUX
 
 config GPIO_MCUX_LPC
 	default y
-
-endif # GPIO
-
-if SERIAL
+	depends on GPIO
 
 config UART_MCUX_FLEXCOMM
 	default y
-
-endif # SERIAL
-
-if FLASH
+	depends on SERIAL
 
 config SOC_FLASH_MCUX
 	default y
-
-endif # FLASH
+	depends on FLASH
 
 endif # SOC_LPC55S69_CPU0

--- a/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.lpc55S69_cpu1
+++ b/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.lpc55S69_cpu1
@@ -8,28 +8,19 @@ if SOC_LPC55S69_CPU1
 config SOC
 	default "lpc55S69_cpu1"
 
-if PINMUX
-
 config PINMUX_MCUX_LPC
 	default n
-
-endif # PINMUX
+	depends on PINMUX
 
 config GPIO
 	default n
 
-if GPIO
-
 config GPIO_MCUX_LPC
 	default n
-
-endif # GPIO
-
-if SERIAL
+	depends on GPIO
 
 config UART_MCUX_FLEXCOMM
 	default n
-
-endif # SERIAL
+	depends on SERIAL
 
 endif # SOC_LPC55S69_CPU1

--- a/soc/arm/silabs_exx32/Kconfig.defconfig
+++ b/soc/arm/silabs_exx32/Kconfig.defconfig
@@ -2,9 +2,6 @@
 
 source "soc/arm/silabs_exx32/*/Kconfig.defconfig.series"
 
-if SYS_POWER_MANAGEMENT
-
 config SOC_GECKO_EMU
 	default y
-
-endif # SYS_POWER_MANAGEMENT
+	depends on SYS_POWER_MANAGEMENT

--- a/soc/arm/silabs_exx32/efm32gg11b/Kconfig.defconfig.efm32gg11b
+++ b/soc/arm/silabs_exx32/efm32gg11b/Kconfig.defconfig.efm32gg11b
@@ -3,12 +3,9 @@
 # Copyright (c) 2019 Oane Kingma
 # SPDX-License-Identifier: Apache-2.0
 
-if GPIO || LOG_BACKEND_SWO
-
 config GPIO_GECKO
 	default y
-
-endif # GPIO || LOG_BACKEND_SWO
+	depends on GPIO || LOG_BACKEND_SWO
 
 if SERIAL
 
@@ -20,16 +17,10 @@ config LEUART_GECKO
 
 endif # SERIAL
 
-if I2C
-
 config I2C_GECKO
 	default y
-
-endif # I2C
-
-if FLASH
+	depends on I2C
 
 config SOC_FLASH_GECKO
 	default y
-
-endif # FLASH
+	depends on FLASH

--- a/soc/arm/silabs_exx32/efm32hg/Kconfig.defconfig.efm32hg
+++ b/soc/arm/silabs_exx32/efm32hg/Kconfig.defconfig.efm32hg
@@ -3,30 +3,18 @@
 # Copyright (c) 2018 Marcio Montenegro
 # SPDX-License-Identifier: Apache-2.0
 
-if GPIO
-
 config GPIO_GECKO
 	default y
-
-endif # GPIO
-
-if SERIAL
+	depends on GPIO
 
 config UART_GECKO
 	default y
-
-endif # SERIAL
-
-if I2C
+	depends on SERIAL
 
 config I2C_GECKO
 	default y
-
-endif # I2C
-
-if FLASH
+	depends on I2C
 
 config SOC_FLASH_GECKO
 	default y
-
-endif # FLASH
+	depends on FLASH

--- a/soc/arm/silabs_exx32/efm32jg12b/Kconfig.defconfig.efm32jg12b
+++ b/soc/arm/silabs_exx32/efm32jg12b/Kconfig.defconfig.efm32jg12b
@@ -3,12 +3,9 @@
 # Copyright (c) 2019 Lemonbeat GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-if GPIO
-
 config GPIO_GECKO
 	default y
-
-endif # GPIO
+	depends on GPIO
 
 if SERIAL
 
@@ -20,16 +17,10 @@ config LEUART_GECKO
 
 endif # SERIAL
 
-if I2C
-
 config I2C_GECKO
 	default y
-
-endif # I2C
-
-if FLASH
+	depends on I2C
 
 config SOC_FLASH_GECKO
 	default y
-
-endif # FLASH
+	depends on FLASH

--- a/soc/arm/silabs_exx32/efm32pg12b/Kconfig.defconfig.efm32pg12b
+++ b/soc/arm/silabs_exx32/efm32pg12b/Kconfig.defconfig.efm32pg12b
@@ -3,12 +3,9 @@
 # Copyright (c) 2018 Christian Taedcke
 # SPDX-License-Identifier: Apache-2.0
 
-if GPIO
-
 config GPIO_GECKO
 	default y
-
-endif # GPIO
+	depends on GPIO
 
 if SERIAL
 
@@ -20,16 +17,10 @@ config LEUART_GECKO
 
 endif # SERIAL
 
-if I2C
-
 config I2C_GECKO
 	default y
-
-endif # I2C
-
-if FLASH
+	depends on I2C
 
 config SOC_FLASH_GECKO
 	default y
-
-endif # FLASH
+	depends on FLASH

--- a/soc/arm/silabs_exx32/efm32wg/Kconfig.defconfig.efm32wg
+++ b/soc/arm/silabs_exx32/efm32wg/Kconfig.defconfig.efm32wg
@@ -3,30 +3,18 @@
 # Copyright (c) 2017 Christian Taedcke
 # SPDX-License-Identifier: Apache-2.0
 
-if GPIO
-
 config GPIO_GECKO
 	default y
-
-endif # GPIO
-
-if SERIAL
+	depends on GPIO
 
 config UART_GECKO
 	default y
-
-endif # SERIAL
-
-if I2C
+	depends on SERIAL
 
 config I2C_GECKO
 	default y
-
-endif # I2C
-
-if FLASH
+	depends on I2C
 
 config SOC_FLASH_GECKO
 	default y
-
-endif # FLASH
+	depends on FLASH

--- a/soc/arm/silabs_exx32/efr32fg1p/Kconfig.defconfig.efr32fg1p
+++ b/soc/arm/silabs_exx32/efr32fg1p/Kconfig.defconfig.efr32fg1p
@@ -3,37 +3,22 @@
 # Copyright (c) 2018 Christian Taedcke
 # SPDX-License-Identifier: Apache-2.0
 
-if GPIO
-
 config GPIO_GECKO
 	default y
-
-endif # GPIO
-
-if SERIAL
+	depends on GPIO
 
 config UART_GECKO
 	default y
-
-endif # SERIAL
-
-if I2C
+	depends on SERIAL
 
 config I2C_GECKO
 	default y
-
-endif # I2C
-
-if FLASH
+	depends on I2C
 
 config SOC_FLASH_GECKO
 	default y
-
-endif # FLASH
-
-if SPI
+	depends on FLASH
 
 config SPI_GECKO
 	default y
-
-endif # SPI
+	depends on SPI

--- a/soc/arm/silabs_exx32/efr32mg12p/Kconfig.defconfig.efr32mg12p
+++ b/soc/arm/silabs_exx32/efr32mg12p/Kconfig.defconfig.efr32mg12p
@@ -3,12 +3,9 @@
 # Copyright (c) 2018 Diego Sueiro
 # SPDX-License-Identifier: Apache-2.0
 
-if GPIO
-
 config GPIO_GECKO
 	default y
-
-endif # GPIO
+	depends on GPIO
 
 if SERIAL
 
@@ -20,23 +17,14 @@ config LEUART_GECKO
 
 endif # SERIAL
 
-if I2C
-
 config I2C_GECKO
 	default y
-
-endif # I2C
-
-if FLASH
+	depends on I2C
 
 config SOC_FLASH_GECKO
 	default y
-
-endif # FLASH
-
-if SPI
+	depends on FLASH
 
 config SPI_GECKO
 	default y
-
-endif # SPI
+	depends on SPI

--- a/soc/arm/st_stm32/common/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/common/Kconfig.defconfig.series
@@ -12,19 +12,13 @@ config CORTEX_M_SYSTICK
 	default n if STM32_LPTIM_TIMER
 	default y if !STM32_LPTIM_TIMER
 
-if CLOCK_CONTROL
-
 config CLOCK_CONTROL_STM32_CUBE
 	default y
-
-endif # CLOCK_CONTROL
-
-if SERIAL
+	depends on CLOCK_CONTROL
 
 config UART_STM32
 	default y
-
-endif # SERIAL
+	depends on SERIAL
 
 if GPIO
 
@@ -42,12 +36,9 @@ config GPIO_STM32_PORTC
 
 endif # GPIO
 
-if PINMUX
-
 config PINMUX_STM32
 	default y
-
-endif # PINMUX
+	depends on PINMUX
 
 if WATCHDOG
 
@@ -59,54 +50,33 @@ config WWDG_STM32
 
 endif # WATCHDOG
 
-if PWM
-
 config PWM_STM32
 	default y
-
-endif # PWM
-
-if SPI
+	depends on PWM
 
 config SPI_STM32
 	default y
-
-endif # SPI
-
-if I2C
+	depends on SPI
 
 config I2C_STM32
 	default y
-
-endif
-
-if USB
+	depends on I2C
 
 config USB_DC_STM32
 	default y
-
-endif # USB
-
-if COUNTER
+	depends on USB
 
 config COUNTER_RTC_STM32
 	default y
-
-endif # COUNTER
-
-if CAN
+	depends on COUNTER
 
 config CAN_STM32
 	default y
-
-endif
-
-if ADC
+	depends on CAN
 
 config ADC_STM32
 	default y
-
-endif # ADC
+	depends on ADC
 
 if DMA
 

--- a/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.series
@@ -24,18 +24,12 @@ config GPIO_STM32_PORTF
 
 endif # GPIO_STM32
 
-if I2C_STM32
-
 config I2C_STM32_V2
 	default y
-
-endif # I2C_STM32
-
-if DMA_STM32
+	depends on I2C_STM32
 
 config DMA_STM32_V2
 	default y
-
-endif # DMA
+	depends on DMA_STM32
 
 endif # SOC_SERIES_STM32F0X

--- a/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.series
@@ -12,27 +12,18 @@ source "soc/arm/st_stm32/stm32f1/Kconfig.defconfig.stm32f1*"
 config SOC_SERIES
 	default "stm32f1"
 
-if GPIO_STM32
-
 # GPIO ports A, B and C are set in ../common/Kconfig.defconfig.series
 
 config GPIO_STM32_PORTD
 	default y
-
-endif # GPIO_STM32
-
-if I2C_STM32
+	depends on GPIO_STM32
 
 config I2C_STM32_V1
 	default y
-
-endif # I2C_STM32
-
-if DMA_STM32
+	depends on I2C_STM32
 
 config DMA_STM32_V2
 	default y
-
-endif # DMA
+	depends on DMA_STM32
 
 endif # SOC_SERIES_STM32F1X

--- a/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.stm32f103xx
+++ b/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.stm32f103xx
@@ -11,12 +11,9 @@ config SOC
 config NUM_IRQS
 	default 43
 
-if GPIO_STM32
-
 config GPIO_STM32_PORTE
 	default y
-
-endif # GPIO_STM32
+	depends on GPIO_STM32
 
 endif # SOC_STM32F103XB || SOC_STM32F103X8
 

--- a/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.stm32f107xc
+++ b/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.stm32f107xc
@@ -11,11 +11,8 @@ config SOC
 config NUM_IRQS
 	default 68
 
-if GPIO_STM32
-
 config GPIO_STM32_PORTE
 	default y
-
-endif # GPIO_STM32
+	depends on GPIO_STM32
 
 endif # SOC_STM32F107XC

--- a/soc/arm/st_stm32/stm32f2/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f2/Kconfig.defconfig.series
@@ -36,11 +36,8 @@ config GPIO_STM32_PORTI
 
 endif # GPIO_STM32
 
-if DMA_STM32
-
 config DMA_STM32_V1
 	default y
-
-endif # DMA
+	depends on DMA_STM32
 
 endif # SOC_SERIES_STM32F2X

--- a/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.series
@@ -12,27 +12,18 @@ source "soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f3*"
 config SOC_SERIES
 	default "stm32f3"
 
-if GPIO_STM32
-
 # GPIO ports A, B and C are set in ../common/Kconfig.defconfig.series
 
 config GPIO_STM32_PORTD
 	default y
-
-endif # GPIO_STM32
-
-if I2C_STM32
+	depends on GPIO_STM32
 
 config I2C_STM32_V2
 	default y
-
-endif # I2C_STM32
-
-if DMA_STM32
+	depends on I2C_STM32
 
 config DMA_STM32_V2
 	default y
-
-endif # DMA
+	depends on DMA_STM32
 
 endif # SOC_SERIES_STM32F3X

--- a/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f302x8
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f302x8
@@ -11,11 +11,8 @@ config SOC
 config NUM_IRQS
 	default 82
 
-if GPIO_STM32
-
 config GPIO_STM32_PORTF
 	default y
-
-endif # GPIO_STM32
+	depends on GPIO_STM32
 
 endif # SOC_STM32F302X8

--- a/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f334x8
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f334x8
@@ -11,11 +11,8 @@ config SOC
 config NUM_IRQS
 	default 82
 
-if GPIO_STM32
-
 config GPIO_STM32_PORTF
 	default y
-
-endif # GPIO_STM32
+	depends on GPIO_STM32
 
 endif # SOC_STM32F334X8

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.series
@@ -27,18 +27,12 @@ config GPIO_STM32_PORTH
 
 endif # GPIO_STM32
 
-if I2C_STM32
-
 config I2C_STM32_V1
 	default y
-
-endif # I2C_STM32
-
-if DMA_STM32
+	depends on I2C_STM32
 
 config DMA_STM32_V1
 	default y
-
-endif # DMA
+	depends on DMA_STM32
 
 endif # SOC_SERIES_STM32F4X

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f405xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f405xx
@@ -24,11 +24,8 @@ config GPIO_STM32_PORTI
 
 endif # GPIO_STM32
 
-if ENTROPY_GENERATOR
-
 config ENTROPY_STM32_RNG
 	default y
-
-endif # ENTROPY_GENERATOR
+	depends on ENTROPY_GENERATOR
 
 endif # SOC_STM32F405XG

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f407xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f407xx
@@ -24,11 +24,8 @@ config GPIO_STM32_PORTI
 
 endif # GPIO_STM32
 
-if ENTROPY_GENERATOR
-
 config ENTROPY_STM32_RNG
 	default y
-
-endif # ENTROPY_GENERATOR
+	depends on ENTROPY_GENERATOR
 
 endif # SOC_STM32F407XG

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f412cg
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f412cg
@@ -24,11 +24,8 @@ config GPIO_STM32_PORTH
 
 endif # GPIO_STM32
 
-if ENTROPY_GENERATOR
-
 config ENTROPY_STM32_RNG
 	default y
-
-endif # ENTROPY_GENERATOR
+	depends on ENTROPY_GENERATOR
 
 endif # SOC_STM32F412CG

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f412zg
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f412zg
@@ -21,11 +21,8 @@ config GPIO_STM32_PORTG
 
 endif # GPIO_STM32
 
-if ENTROPY_GENERATOR
-
 config ENTROPY_STM32_RNG
 	default y
-
-endif # ENTROPY_GENERATOR
+	depends on ENTROPY_GENERATOR
 
 endif # SOC_STM32F412ZG

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f413xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f413xx
@@ -21,11 +21,8 @@ config GPIO_STM32_PORTG
 
 endif # GPIO_STM32
 
-if ENTROPY_GENERATOR
-
 config ENTROPY_STM32_RNG
 	default y
-
-endif # ENTROPY_GENERATOR
+	depends on ENTROPY_GENERATOR
 
 endif # SOC_STM32F413XX

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f415xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f415xx
@@ -11,11 +11,8 @@ config SOC
 config NUM_IRQS
 	default 82
 
-if CRYPTO
-
 config CRYPTO_STM32
 	default y
-
-endif # CRYPTO
+	depends on CRYPTO
 
 endif # SOC_STM32F415XX

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f417xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f417xx
@@ -24,18 +24,12 @@ config GPIO_STM32_PORTI
 
 endif # GPIO_STM32
 
-if ENTROPY_GENERATOR
-
 config ENTROPY_STM32_RNG
 	default y
-
-endif # ENTROPY_GENERATOR
-
-if CRYPTO
+	depends on ENTROPY_GENERATOR
 
 config CRYPTO_STM32
 	default y
-
-endif # CRYPTO
+	depends on CRYPTO
 
 endif # SOC_STM32F417XX

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f429xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f429xx
@@ -30,11 +30,8 @@ config GPIO_STM32_PORTK
 
 endif # GPIO_STM32
 
-if ENTROPY_GENERATOR
-
 config ENTROPY_STM32_RNG
 	default y
-
-endif # ENTROPY_GENERATOR
+	depends on ENTROPY_GENERATOR
 
 endif # SOC_STM32F429XX

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f437xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f437xx
@@ -30,18 +30,12 @@ config GPIO_STM32_PORTK
 
 endif # GPIO_STM32
 
-if ENTROPY_GENERATOR
-
 config ENTROPY_STM32_RNG
 	default y
-
-endif # ENTROPY_GENERATOR
-
-if CRYPTO
+	depends on ENTROPY_GENERATOR
 
 config CRYPTO_STM32
 	default y
-
-endif # CRYPTO
+	depends on CRYPTO
 
 endif # SOC_STM32F437XX

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f469xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f469xx
@@ -30,11 +30,8 @@ config GPIO_STM32_PORTK
 
 endif # GPIO_STM32
 
-if ENTROPY_GENERATOR
-
 config ENTROPY_STM32_RNG
 	default y
-
-endif # ENTROPY_GENERATOR
+	depends on ENTROPY_GENERATOR
 
 endif # SOC_STM32F469XX

--- a/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.series
@@ -36,25 +36,16 @@ config GPIO_STM32_PORTI
 
 endif # GPIO_STM32
 
-if I2C_STM32
-
 config I2C_STM32_V2
 	default y
-
-endif # I2C_STM32
-
-if ENTROPY_GENERATOR
+	depends on I2C_STM32
 
 config ENTROPY_STM32_RNG
 	default y
-
-endif # ENTROPY_GENERATOR
-
-if DMA_STM32
+	depends on ENTROPY_GENERATOR
 
 config DMA_STM32_V1
 	default y
-
-endif # DMA
+	depends on DMA_STM32
 
 endif # SOC_SERIES_STM32F7X

--- a/soc/arm/st_stm32/stm32g0/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32g0/Kconfig.defconfig.series
@@ -21,12 +21,9 @@ config GPIO_STM32_PORTD
 config GPIO_STM32_PORTF
 	default y
 
-if I2C_STM32
-
 config I2C_STM32_V2
 	default y
-
-endif # I2C_STM32
+	depends on I2C_STM32
 
 endif # GPIO_STM32
 

--- a/soc/arm/st_stm32/stm32g4/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32g4/Kconfig.defconfig.series
@@ -26,19 +26,13 @@ config GPIO_STM32_PORTF
 config GPIO_STM32_PORTG
 	default y
 
-if I2C_STM32
-
 config I2C_STM32_V2
 	default y
-
-endif # I2C_STM32
-
-if ENTROPY_GENERATOR
+	depends on I2C_STM32
 
 config ENTROPY_STM32_RNG
 	default y
-
-endif # ENTROPY_GENERATOR
+	depends on ENTROPY_GENERATOR
 
 endif # GPIO_STM32
 endif # SOC_SERIES_STM32G4X

--- a/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.series
@@ -18,18 +18,12 @@ if GPIO_STM32
 
 endif # GPIO_STM32
 
-if I2C_STM32
-
 config I2C_STM32_V2
 	default y
-
-endif # I2C_STM32
-
-if DMA_STM32
+	depends on I2C_STM32
 
 config DMA_STM32_V2
 	default y
-
-endif # DMA
+	depends on DMA_STM32
 
 endif # SOC_SERIES_STM32L0X

--- a/soc/arm/st_stm32/stm32l1/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l1/Kconfig.defconfig.series
@@ -10,11 +10,8 @@ source "soc/arm/st_stm32/stm32l1/Kconfig.defconfig.stm32l1*"
 config SOC_SERIES
 	default "stm32l1"
 
-if I2C_STM32
-
 config I2C_STM32_V1
 	default y
-
-endif # I2C_STM32
+	depends on I2C_STM32
 
 endif # SOC_SERIES_STM32L1X

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.series
@@ -14,34 +14,22 @@ config SOC_SERIES
 	default "stm32l4"
 
 
-if GPIO_STM32
-
 # GPIO ports A, B and C are set in ../common/Kconfig.defconfig.series
 
 config GPIO_STM32_PORTH
 	default y
-
-endif # GPIO_STM32
-
-if I2C_STM32
+	depends on GPIO_STM32
 
 config I2C_STM32_V2
 	default y
-
-endif # I2C_STM32
-
-if ENTROPY_GENERATOR
+	depends on I2C_STM32
 
 config ENTROPY_STM32_RNG
 	default y
-
-endif # ENTROPY_GENERATOR
-
-if DMA_STM32
+	depends on ENTROPY_GENERATOR
 
 config DMA_STM32_V2
 	default y
-
-endif # DMA
+	depends on DMA_STM32
 
 endif # SOC_SERIES_STM32L4X

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l432xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l432xx
@@ -12,11 +12,8 @@ config SOC
 config NUM_IRQS
 	default 83
 
-if GPIO_STM32
-
 config GPIO_STM32_PORTH
 	default y
-
-endif # GPIO_STM32
+	depends on GPIO_STM32
 
 endif # SOC_STM32L432XX

--- a/soc/arm/st_stm32/stm32mp1/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32mp1/Kconfig.defconfig.series
@@ -38,18 +38,12 @@ config GPIO_STM32_PORTK
 
 endif # GPIO_STM32
 
-if IPM
-
 config IPM_STM32_IPCC
 	default y
-
-endif # IPM
-
-if I2C_STM32
+	depends on IPM
 
 config I2C_STM32_V2
 	default y
-
-endif # I2C_STM32
+	depends on I2C_STM32
 
 endif # SOC_SERIES_STM32MP1X

--- a/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.series
@@ -23,11 +23,8 @@ config GPIO_STM32_PORTH
 
 endif # GPIO_STM32
 
-if I2C_STM32
-
 config I2C_STM32_V2
 	default y
-
-endif # I2C_STM32
+	depends on I2C_STM32
 
 endif # SOC_SERIES_STM32WBX

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.cc1352r
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.cc1352r
@@ -3,11 +3,7 @@
 # Copyright (c) 2019 Brett Witherspoon
 #
 # SPDX-License-Identifier: Apache-2.0
-#
-
-if SOC_CC1352R
 
 config SOC
 	default "cc1352r"
-
-endif # SOC_CC1352R
+	depends on SOC_CC1352R

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.cc2652r
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.cc2652r
@@ -3,9 +3,6 @@
 # Copyright (c) 2019 Brett Witherspoon
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_CC2652R
-
 config SOC
 	default "cc2652r"
-
-endif # SOC_CC2652R
+	depends on SOC_CC2652R

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.series
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.series
@@ -25,47 +25,29 @@ config NUM_IRQS
 config CC13X2_CC26X2_RTC_TIMER
 	default y
 
-if PINMUX
-
 config PINMUX_CC13XX_CC26XX
 	default y
-
-endif # PINMUX
-
-if GPIO
+	depends on PINMUX
 
 config GPIO_CC13XX_CC26XX
 	default y
-
-endif # GPIO
-
-if ENTROPY_GENERATOR
+	depends on GPIO
 
 config ENTROPY_CC13XX_CC26XX_RNG
 	default y
-
-endif # ENTROPY_GENERATOR
-
-if SERIAL
+	depends on ENTROPY_GENERATOR
 
 config UART_CC13XX_CC26XX
 	default y
-
-endif # SERIAL
-
-if I2C
+	depends on SERIAL
 
 config I2C_CC13XX_CC26XX
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_CC13XX_CC26XX
 	default y
-
-endif # SPI
+	depends on SPI
 
 if IEEE802154
 

--- a/soc/nios2/nios2f-zephyr/Kconfig.defconfig
+++ b/soc/nios2/nios2f-zephyr/Kconfig.defconfig
@@ -11,38 +11,26 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config ALTERA_AVALON_SYSID
 	def_bool y
 
-if SOC_FLASH_NIOS2_QSPI
-
 config ALTERA_AVALON_QSPI
 	def_bool y
-
-endif # SOC_FLASH_NIOS2_QSPI
-
-if I2C_NIOS2
+	depends on SOC_FLASH_NIOS2_QSPI
 
 config ALTERA_AVALON_I2C
 	def_bool y
-
-endif # I2C_NIOS2
-
-if DMA_NIOS2_MSGDMA
+	depends on I2C_NIOS2
 
 config ALTERA_AVALON_MSGDMA
 	def_bool y
-
-endif # DMA_NIOS2_MSGDMA
+	depends on DMA_NIOS2_MSGDMA
 
 if UART_NS16550
 
 config UART_NS16550_PORT_0
 	default y
 
-if UART_NS16550_PORT_0
-
 config UART_NS16550_PORT_0_OPTIONS
 	default 0
-
-endif # UART_NS16550_PORT_0
+	depends on UART_NS16550_PORT_0
 
 endif # UART_NS16550
 

--- a/soc/posix/inf_clock/Kconfig.defconfig
+++ b/soc/posix/inf_clock/Kconfig.defconfig
@@ -1,9 +1,6 @@
 # Copyright (c) 2017 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_POSIX
-
 config SOC
 	default "inf_clock"
-
-endif
+	depends on SOC_POSIX

--- a/soc/riscv/openisa_rv32m1/Kconfig.defconfig
+++ b/soc/riscv/openisa_rv32m1/Kconfig.defconfig
@@ -128,40 +128,25 @@ endif # MULTI_LEVEL_INTERRUPTS
 config PINMUX_RV32M1
 	default y
 
-if GPIO
-
 config GPIO_RV32M1
 	default y
-
-endif # GPIO
-
-if SERIAL
+	depends on GPIO
 
 config UART_RV32M1_LPUART
 	default y
-
-endif # SERIAL
-
-if I2C
+	depends on SERIAL
 
 config I2C_RV32M1_LPI2C
 	default y
-
-endif # I2C
-
-if SPI
+	depends on I2C
 
 config SPI_RV32M1_LPSPI
 	default y
-
-endif # SPI
-
-if PWM
+	depends on SPI
 
 config PWM_RV32M1_TPM
 	default y
-
-endif # PWM
+	depends on PWM
 
 if FLASH
 
@@ -176,11 +161,8 @@ config FLASH_BASE_ADDRESS
 
 endif # FLASH
 
-if ENTROPY_GENERATOR
-
 config ENTROPY_RV32M1_TRNG
 	default y
-
-endif # ENTROPY_GENERATOR
+	depends on ENTROPY_GENERATOR
 
 endif # SOC_OPENISA_RV32M1_RISCV32

--- a/soc/x86/apollo_lake/Kconfig.defconfig
+++ b/soc/x86/apollo_lake/Kconfig.defconfig
@@ -35,25 +35,16 @@ endif # APIC_TIMER
 config CLFLUSH_DETECT
 	default y if CACHE_FLUSHING
 
-if DYNAMIC_INTERRUPTS
-
 config X86_DYNAMIC_IRQ_STUBS
 	default 16
-
-endif # DYNAMIC_INTERRUPTS
-
-if I2C
+	depends on DYNAMIC_INTERRUPTS
 
 config I2C_DW
 	default y
-
-endif # I2C
-
-if GPIO
+	depends on I2C
 
 config GPIO_INTEL_APL
 	default y
-
-endif # GPIO
+	depends on GPIO
 
 endif # SOC_APOLLO_LAKE

--- a/soc/x86/atom/Kconfig.defconfig
+++ b/soc/x86/atom/Kconfig.defconfig
@@ -20,36 +20,28 @@ if UART_NS16550
 config UART_NS16550_PORT_0
 	default y
 
-if UART_NS16550_PORT_0
-
 config UART_NS16550_PORT_0_OPTIONS
 	default 0
-
-endif # UART_NS16550_PORT_0
+	depends on UART_NS16550_PORT_0
 
 config UART_NS16550_PORT_1
 	default y
 
-if UART_NS16550_PORT_1
-
 config UART_NS16550_PORT_1_OPTIONS
 	default 0
-
-endif # UART_NS16550_PORT_1
+	depends on UART_NS16550_PORT_1
 
 endif # UART_NS16550
 
 if BT_UART
 
-if UART_PIPE
-
 config UART_PIPE_ON_DEV_NAME
 	default "UART_1"
-
-endif
+	depends on UART_PIPE
 
 config BT_MONITOR_ON_DEV_NAME
 	default "UART_1" if BT_DEBUG_MONITOR
+
 endif
 
 endif

--- a/soc/x86/ia32/Kconfig.defconfig
+++ b/soc/x86/ia32/Kconfig.defconfig
@@ -20,22 +20,16 @@ if UART_NS16550
 config UART_NS16550_PORT_0
 	default y
 
-if UART_NS16550_PORT_0
-
 config UART_NS16550_PORT_0_OPTIONS
 	default 0
-
-endif # UART_NS16550_PORT_0
+	depends on UART_NS16550_PORT_0
 
 config UART_NS16550_PORT_1
 	default y
 
-if UART_NS16550_PORT_1
-
 config UART_NS16550_PORT_1_OPTIONS
 	default 0
-
-endif # UART_NS16550_PORT_1
+	depends on UART_NS16550_PORT_1
 
 endif # UART_NS16550
 

--- a/soc/xtensa/intel_apl_adsp/Kconfig.defconfig
+++ b/soc/xtensa/intel_apl_adsp/Kconfig.defconfig
@@ -32,13 +32,10 @@ config DYNAMIC_INTERRUPTS
 config LOG
 	default y
 
-if TEST
-
 # To prevent test uses TEST_LOGGING_MINIMAL
 config TEST_LOGGING_DEFAULTS
 	default n
-
-endif # TEST
+	depends on TEST
 
 if LOG
 


### PR DESCRIPTION
Same deal as in commit eddd98f ("kconfig: Replace some single-symbol
'if's with 'depends on'"), for all symbols defined within defconfig
files. See that commit for an explanation.

Maybe 'if's were used originally to mirror the 'if's in the main Kconfig
files, and then it got copied around by people assuming 'if' must work
differently from 'depends on'. It doesn't match in every spot at least.
Better to keep it simple and just consistently use 'depends on' when
it's a single symbol/choice I think. Helps reinforce that 'if' isn't
magic too.

Verified by printing all Kconfig menu nodes (symbols, choices, menus,
etc.) before and after the change and diffing (should show no
difference).