### PR TITLE
arch: arm: cortex_r: linker.ld: Fix ROM section names

### DIFF
--- a/include/arch/arm/aarch32/cortex_r/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_r/scripts/linker.ld
@@ -33,41 +33,30 @@
   #define _DATA_IN_ROM
 #endif
 
-#if !defined(SKIP_TO_KINETIS_FLASH_CONFIG)
-  #define SKIP_TO_KINETIS_FLASH_CONFIG
-#endif
-
 #if !defined(CONFIG_XIP) && (CONFIG_FLASH_SIZE == 0)
-#define ROM_ADDR RAM_ADDR
+  #define ROM_ADDR RAM_ADDR
 #else
-#define ROM_ADDR (CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET)
+  #define ROM_ADDR (CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET)
 #endif
 
-#ifdef CONFIG_HAS_TI_CCFG
-  #define CCFG_SIZE 88
-  #define ROM_SIZE (CONFIG_FLASH_SIZE*1K - CONFIG_FLASH_LOAD_OFFSET - \
-		    CCFG_SIZE)
-  #define CCFG_ADDR (ROM_ADDR + ROM_SIZE)
-#else
 #if CONFIG_FLASH_LOAD_SIZE > 0
   #define ROM_SIZE CONFIG_FLASH_LOAD_SIZE
 #else
   #define ROM_SIZE (CONFIG_FLASH_SIZE*1K - CONFIG_FLASH_LOAD_OFFSET)
 #endif
-#endif
 
 #if defined(CONFIG_XIP)
-	#if defined(CONFIG_IS_BOOTLOADER)
-		#define RAM_SIZE (CONFIG_BOOTLOADER_SRAM_SIZE * 1K)
-		#define RAM_ADDR (CONFIG_SRAM_BASE_ADDRESS + \
-			(CONFIG_SRAM_SIZE * 1K - RAM_SIZE))
-	#else
-		#define RAM_SIZE (CONFIG_SRAM_SIZE * 1K)
-		#define RAM_ADDR CONFIG_SRAM_BASE_ADDRESS
-	#endif
+  #if defined(CONFIG_IS_BOOTLOADER)
+    #define RAM_SIZE (CONFIG_BOOTLOADER_SRAM_SIZE * 1K)
+    #define RAM_ADDR (CONFIG_SRAM_BASE_ADDRESS + \
+                     (CONFIG_SRAM_SIZE * 1K - RAM_SIZE))
+  #else
+    #define RAM_SIZE (CONFIG_SRAM_SIZE * 1K)
+    #define RAM_ADDR CONFIG_SRAM_BASE_ADDRESS
+  #endif
 #else
-	#define RAM_SIZE (CONFIG_SRAM_SIZE * 1K - CONFIG_BOOTLOADER_SRAM_SIZE * 1K)
-	#define RAM_ADDR CONFIG_SRAM_BASE_ADDRESS
+  #define RAM_SIZE (CONFIG_SRAM_SIZE * 1K - CONFIG_BOOTLOADER_SRAM_SIZE * 1K)
+  #define RAM_ADDR CONFIG_SRAM_BASE_ADDRESS
 #endif
 
 /* Set alignment to CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE
@@ -81,37 +70,29 @@ _region_min_align = 4;
 #endif
 
 #if defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT)
-#define MPU_ALIGN(region_size) \
+  #define MPU_ALIGN(region_size) \
     . = ALIGN(_region_min_align); \
-    . = ALIGN( 1 << LOG2CEIL(region_size))
+    . = ALIGN(1 << LOG2CEIL(region_size))
 #else
-#define MPU_ALIGN(region_size) \
+  #define MPU_ALIGN(region_size) \
     . = ALIGN(_region_min_align)
 #endif
 
 MEMORY
-    {
-    FLASH                 (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
-#ifdef CONFIG_HAS_TI_CCFG
-    FLASH_CCFG            (rwx): ORIGIN = CCFG_ADDR, LENGTH = CCFG_SIZE
-#endif
+{
+    FLASH    (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
 #ifdef DT_CCM_BASE_ADDRESS
-    CCM                   (rw) : ORIGIN = DT_CCM_BASE_ADDRESS, LENGTH = DT_CCM_SIZE * 1K
+    CCM      (rw) : ORIGIN = DT_CCM_BASE_ADDRESS, LENGTH = DT_CCM_SIZE * 1K
 #endif
-    SRAM                  (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
-#ifdef CONFIG_BT_STM32_IPM
-    SRAM1                 (rw) : ORIGIN = RAM1_ADDR, LENGTH = RAM1_SIZE
-    SRAM2                 (rw) : ORIGIN = RAM2_ADDR, LENGTH = RAM2_SIZE
-#endif
+    SRAM     (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
     /* Used by and documented in include/linker/intlist.ld */
-    IDT_LIST  (wx)      : ORIGIN = (RAM_ADDR + RAM_SIZE), LENGTH = 2K
-    }
+    IDT_LIST (wx) : ORIGIN = (RAM_ADDR + RAM_SIZE), LENGTH = 2K
+}
 
 ENTRY(CONFIG_KERNEL_ENTRY)
 
 SECTIONS
-    {
-
+{
 #include <linker/rel-sections.ld>
 
     /*
@@ -119,21 +100,21 @@ SECTIONS
      * before text section.
      */
     SECTION_PROLOGUE(.plt,,)
-	{
-	*(.plt)
-	}
+    {
+        *(.plt)
+    }
 
     SECTION_PROLOGUE(.iplt,,)
-	{
-	*(.iplt)
-	}
+    {
+        *(.iplt)
+    }
 
     GROUP_START(ROMABLE_REGION)
 
-	_image_rom_start = ROM_ADDR;
+    _image_rom_start = ROM_ADDR;
 
     SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
-	{
+    {
 
 /* Located in generated directory. This file is populated by calling
  * zephyr_linker_sources(ROM_START ...). This typically contains the vector
@@ -141,7 +122,7 @@ SECTIONS
  */
 #include <snippets-rom-start.ld>
 
-	} GROUP_LINK_IN(ROMABLE_REGION)
+    } GROUP_LINK_IN(ROMABLE_REGION)
 
 #ifdef CONFIG_CODE_DATA_RELOCATION
 
@@ -150,59 +131,59 @@ SECTIONS
 #endif /* CONFIG_CODE_DATA_RELOCATION */
 
     SECTION_PROLOGUE(_TEXT_SECTION_NAME_2,,)
-	{
-	_image_text_start = .;
-	*(.text)
-	*(".text.*")
-	*(.gnu.linkonce.t.*)
+    {
+        _image_text_start = .;
+        *(.text)
+        *(".text.*")
+        *(.gnu.linkonce.t.*)
 
-	/*
-	 * These are here according to 'arm-zephyr-elf-ld --verbose',
-	 * after .gnu.linkonce.t.*
-	 */
-	*(.glue_7t) *(.glue_7) *(.vfp11_veneer) *(.v4_bx)
+        /*
+         * These are here according to 'arm-zephyr-elf-ld --verbose',
+         * after .gnu.linkonce.t.*
+         */
+        *(.glue_7t) *(.glue_7) *(.vfp11_veneer) *(.v4_bx)
 
 #include <linker/priv_stacks-text.ld>
 #include <linker/kobject-text.ld>
 
-	} GROUP_LINK_IN(ROMABLE_REGION)
+    } GROUP_LINK_IN(ROMABLE_REGION)
 
-	_image_text_end = .;
+    _image_text_end = .;
 
 #if defined (CONFIG_CPLUSPLUS)
-	SECTION_PROLOGUE(.ARM.extab,,)
-	{
-	/*
-	 * .ARM.extab section containing exception unwinding information.
-	 */
-	*(.ARM.extab* .gnu.linkonce.armextab.*)
-	} GROUP_LINK_IN(ROMABLE_REGION)
+    SECTION_PROLOGUE(.ARM.extab,,)
+    {
+        /*
+         * .ARM.extab section containing exception unwinding information.
+         */
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } GROUP_LINK_IN(ROMABLE_REGION)
 #endif
 
-	SECTION_PROLOGUE(.ARM.exidx,,)
-	{
-	/*
-	 * This section, related to stack and exception unwinding, is placed
-	 * explicitly to prevent it from being shared between multiple regions.
-	 * It  must be defined for gcc to support 64-bit math and avoid
-	 * section overlap.
-	 */
-	__exidx_start = .;
+    SECTION_PROLOGUE(.ARM.exidx,,)
+    {
+        /*
+         * This section, related to stack and exception unwinding, is placed
+         * explicitly to prevent it from being shared between multiple regions.
+         * It  must be defined for gcc to support 64-bit math and avoid
+         * section overlap.
+         */
+        __exidx_start = .;
 #if defined (__GCC_LINKER_CMD__)
-	*(.ARM.exidx* gnu.linkonce.armexidx.*)
+        *(.ARM.exidx* gnu.linkonce.armexidx.*)
 #endif
-	__exidx_end = .;
-	} GROUP_LINK_IN(ROMABLE_REGION)
+        __exidx_end = .;
+    } GROUP_LINK_IN(ROMABLE_REGION)
 
-	_image_rodata_start = .;
+    _image_rodata_start = .;
 
 #include <linker/common-rom.ld>
 
     SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
-	{
-	*(.rodata)
-	*(".rodata.*")
-	*(.gnu.linkonce.r.*)
+    {
+        *(.rodata)
+        *(".rodata.*")
+        *(.gnu.linkonce.r.*)
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
@@ -220,65 +201,47 @@ SECTIONS
 #include <linker/priv_stacks-rom.ld>
 #include <linker/kobject-rom.ld>
 
-	/*
-	 * For XIP images, in order to avoid the situation when __data_rom_start
-	 * is 32-bit aligned, but the actual data is placed right after rodata
-	 * section, which may not end exactly at 32-bit border, pad rodata
-	 * section, so __data_rom_start points at data and it is 32-bit aligned.
-	 *
-	 * On non-XIP images this may enlarge image size up to 3 bytes. This
-	 * generally is not an issue, since modern ROM and FLASH memory is
-	 * usually 4k aligned.
-	 */
-	. = ALIGN(4);
-	} GROUP_LINK_IN(ROMABLE_REGION)
+        /*
+         * For XIP images, in order to avoid the situation when __data_rom_start
+         * is 32-bit aligned, but the actual data is placed right after rodata
+         * section, which may not end exactly at 32-bit border, pad rodata
+         * section, so __data_rom_start points at data and it is 32-bit aligned.
+         *
+         * On non-XIP images this may enlarge image size up to 3 bytes. This
+         * generally is not an issue, since modern ROM and FLASH memory is
+         * usually 4k aligned.
+         */
+        . = ALIGN(4);
+    } GROUP_LINK_IN(ROMABLE_REGION)
 
 #include <linker/cplusplus-rom.ld>
 
-	_image_rodata_end = .;
-	MPU_ALIGN(_image_rodata_end -_image_rom_start);
-	_image_rom_end = .;
+    _image_rodata_end = .;
+    MPU_ALIGN(_image_rodata_end -_image_rom_start);
+    _image_rom_end = .;
 
     GROUP_END(ROMABLE_REGION)
-
-/* Some TI SoCs have a special configuration footer, at the end of flash. */
-#ifdef CONFIG_HAS_TI_CCFG
-    SECTION_PROLOGUE(.ti_ccfg,,)
-    {
-    KEEP(*(TI_CCFG))
-    } > FLASH_CCFG
-#endif
 
     /*
      * These are here according to 'arm-zephyr-elf-ld --verbose',
      * before data section.
      */
     SECTION_PROLOGUE(.got,,)
-	{
-	*(.got.plt)
-	*(.igot.plt)
-	*(.got)
-	*(.igot)
-	}
+    {
+        *(.got.plt)
+        *(.igot.plt)
+        *(.got)
+        *(.igot)
+    }
 
     GROUP_START(RAMABLE_REGION)
 
-	. = RAM_ADDR;
-	/* Align the start of image SRAM with the
-	 * minimum granularity required by MPU.
-	 */
-	. = ALIGN(_region_min_align);
-	_image_ram_start = .;
-
-#if defined(CONFIG_SOC_SERIES_STM32F0X) && !defined(CONFIG_IS_BOOTLOADER)
-    /* Must be first in ramable region */
-	SECTION_PROLOGUE(.st_stm32f0x_vt,(NOLOAD),)
-	{
-        _ram_vector_start = .;
-        . += _vector_end - _vector_start;
-        _ram_vector_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
-#endif
+    . = RAM_ADDR;
+    /* Align the start of image SRAM with the
+     * minimum granularity required by MPU.
+     */
+    . = ALIGN(_region_min_align);
+    _image_ram_start = .;
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
@@ -291,24 +254,24 @@ SECTIONS
 
 #include <app_smem.ld>
 
-	_app_smem_size = _app_smem_end - _app_smem_start;
-	_app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
+    _app_smem_size = _app_smem_end - _app_smem_start;
+    _app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
 #endif  /* CONFIG_USERSPACE */
 
     SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
-	{
+    {
         /*
          * For performance, BSS section is assumed to be 4 byte aligned and
          * a multiple of 4 bytes
          */
         . = ALIGN(4);
-	__bss_start = .;
-	__kernel_ram_start = .;
+        __bss_start = .;
+        __kernel_ram_start = .;
 
-	*(.bss)
-	*(".bss.*")
-	*(COMMON)
-	*(".kernel_bss.*")
+        *(.bss)
+        *(".bss.*")
+        *(COMMON)
+        *(".kernel_bss.*")
 
 #ifdef CONFIG_CODE_DATA_RELOCATION
 #include <linker_sram_bss_relocate.ld>
@@ -317,19 +280,19 @@ SECTIONS
         /*
          * As memory is cleared in words only, it is simpler to ensure the BSS
          * section ends on a 4 byte boundary. This wastes a maximum of 3 bytes.
-		 */
-	__bss_end = ALIGN(4);
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+         */
+        __bss_end = ALIGN(4);
+    } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
     SECTION_PROLOGUE(_NOINIT_SECTION_NAME,(NOLOAD),)
-        {
+    {
         /*
          * This section is used for non-initialized objects that
          * will not be cleared during the boot process.
          */
         *(.noinit)
         *(".noinit.*")
-	*(".kernel_noinit.*")
+        *(".kernel_noinit.*")
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
@@ -339,14 +302,14 @@ SECTIONS
 #include <soc-noinit.ld>
 #endif
 
-        } GROUP_LINK_IN(RAMABLE_REGION)
+    } GROUP_LINK_IN(RAMABLE_REGION)
 
     SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
-	{
-	__data_ram_start = .;
-	*(.data)
-	*(".data.*")
-	*(".kernel.*")
+    {
+        __data_ram_start = .;
+        *(.data)
+        *(".data.*")
+        *(".kernel.*")
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
@@ -365,7 +328,7 @@ SECTIONS
 #include <linker_sram_data_relocate.ld>
 #endif
 
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+    } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
     __data_rom_start = LOADADDR(_DATA_SECTION_NAME);
 
@@ -403,18 +366,18 @@ SECTIONS
 #include <linker/debug-sections.ld>
 
     SECTION_PROLOGUE(.ARM.attributes, 0,)
-	{
-	KEEP(*(.ARM.attributes))
-	KEEP(*(.gnu.attributes))
-	}
-
-/* Must be last in romable region */
-SECTION_PROLOGUE(.last_section,(NOLOAD),)
-{
-} GROUP_LINK_IN(ROMABLE_REGION)
-
-/* To provide the image size as a const expression,
- * calculate this value here. */
-_flash_used = LOADADDR(.last_section) - _image_rom_start;
-
+    {
+        KEEP(*(.ARM.attributes))
+        KEEP(*(.gnu.attributes))
     }
+
+    /* Must be last in romable region */
+    SECTION_PROLOGUE(.last_section,(NOLOAD),)
+    {
+    } GROUP_LINK_IN(ROMABLE_REGION)
+
+    /* To provide the image size as a const expression,
+     * calculate this value here. */
+    _flash_used = LOADADDR(.last_section) - _image_rom_start;
+
+}

--- a/include/arch/arm/aarch32/cortex_r/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_r/scripts/linker.ld
@@ -113,7 +113,7 @@ SECTIONS
 
     _image_rom_start = ROM_ADDR;
 
-    SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
+    SECTION_PROLOGUE(rom_start,,)
     {
 
 /* Located in generated directory. This file is populated by calling
@@ -130,7 +130,7 @@ SECTIONS
 
 #endif /* CONFIG_CODE_DATA_RELOCATION */
 
-    SECTION_PROLOGUE(_TEXT_SECTION_NAME_2,,)
+    SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
     {
         _image_text_start = .;
         *(.text)


### PR DESCRIPTION
This commit fixes the improper naming of the ROM sections.

1. Rename the first ROM section, which was previously named using the
  `_TEXT_SECTION_NAME` definition, to `rom_start`, as this section does
  not actually represent the text section.

2. Rename the second ROM section, which was previously named
  `_TEXT_SECTION_NAME_2` which supposedly refers to the definition of
  the same name that does not exist, to `_TEXT_SECTION_NAME`. Note that
  this is indeed the section that contains the text section from the
  source image.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Addresses #21650 for Cortex-R.