### PR TITLE
arch: arm: aarch64: linker.ld: Fix ROM section names

### DIFF
--- a/include/arch/arm/aarch64/scripts/linker.ld
+++ b/include/arch/arm/aarch64/scripts/linker.ld
@@ -34,65 +34,65 @@
 #endif
 
 #if !defined(CONFIG_XIP) && (CONFIG_FLASH_SIZE == 0)
-#define ROM_ADDR RAM_ADDR
+  #define ROM_ADDR RAM_ADDR
 #else
-#define ROM_ADDR (CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET)
+  #define ROM_ADDR (CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET)
 #endif
 
 #if CONFIG_FLASH_LOAD_SIZE > 0
   #define ROM_SIZE CONFIG_FLASH_LOAD_SIZE
 #else
-  #define ROM_SIZE (CONFIG_FLASH_SIZE*1K - CONFIG_FLASH_LOAD_OFFSET)
+  #define ROM_SIZE (CONFIG_FLASH_SIZE * 1K - CONFIG_FLASH_LOAD_OFFSET)
 #endif
 
 #if defined(CONFIG_XIP)
-	#if defined(CONFIG_IS_BOOTLOADER)
-		#define RAM_SIZE (CONFIG_BOOTLOADER_SRAM_SIZE * 1K)
-		#define RAM_ADDR (CONFIG_SRAM_BASE_ADDRESS + \
-			(CONFIG_SRAM_SIZE * 1K - RAM_SIZE))
-	#else
-		#define RAM_SIZE (CONFIG_SRAM_SIZE * 1K)
-		#define RAM_ADDR CONFIG_SRAM_BASE_ADDRESS
-	#endif
+  #if defined(CONFIG_IS_BOOTLOADER)
+    #define RAM_SIZE (CONFIG_BOOTLOADER_SRAM_SIZE * 1K)
+    #define RAM_ADDR (CONFIG_SRAM_BASE_ADDRESS + \
+                     (CONFIG_SRAM_SIZE * 1K - RAM_SIZE))
+  #else
+    #define RAM_SIZE (CONFIG_SRAM_SIZE * 1K)
+    #define RAM_ADDR CONFIG_SRAM_BASE_ADDRESS
+  #endif
 #else
-	#define RAM_SIZE (CONFIG_SRAM_SIZE * 1K - CONFIG_BOOTLOADER_SRAM_SIZE * 1K)
-	#define RAM_ADDR CONFIG_SRAM_BASE_ADDRESS
+  #define RAM_SIZE (CONFIG_SRAM_SIZE * 1K - CONFIG_BOOTLOADER_SRAM_SIZE * 1K)
+  #define RAM_ADDR CONFIG_SRAM_BASE_ADDRESS
 #endif
 
 /* Set alignment to CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE
  * to make linker section alignment comply with MPU granularity.
  */
 #if defined(CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE)
-_region_min_align = CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE;
+  _region_min_align = CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE;
 #else
-/* If building without MPU support, use default 4-byte alignment. */
-_region_min_align = 4;
+  /* If building without MPU support, use default 4-byte alignment. */
+  _region_min_align = 4;
 #endif
 
 #if defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT)
-#define MPU_ALIGN(region_size) \
+  #define MPU_ALIGN(region_size) \
     . = ALIGN(_region_min_align); \
     . = ALIGN( 1 << LOG2CEIL(region_size))
 #else
-#define MPU_ALIGN(region_size) \
+  #define MPU_ALIGN(region_size) \
     . = ALIGN(_region_min_align)
 #endif
 
 MEMORY
-    {
-    FLASH                 (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
+{
+    FLASH     (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
 #ifdef DT_CCM_BASE_ADDRESS
-    CCM                   (rw) : ORIGIN = DT_CCM_BASE_ADDRESS, LENGTH = DT_CCM_SIZE * 1K
+    CCM       (rw) : ORIGIN = DT_CCM_BASE_ADDRESS, LENGTH = DT_CCM_SIZE * 1K
 #endif
-    SRAM                  (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
+    SRAM      (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
     /* Used by and documented in include/linker/intlist.ld */
-    IDT_LIST  (wx)      : ORIGIN = (RAM_ADDR + RAM_SIZE), LENGTH = 2K
-    }
+    IDT_LIST  (wx) : ORIGIN = (RAM_ADDR + RAM_SIZE), LENGTH = 2K
+}
 
 ENTRY(CONFIG_KERNEL_ENTRY)
 
 SECTIONS
-    {
+{
 
 #include <linker/rel-sections.ld>
 
@@ -101,42 +101,42 @@ SECTIONS
      * before text section.
      */
     SECTION_PROLOGUE(.plt,,)
-	{
-	*(.plt)
-	}
+    {
+        *(.plt)
+    }
 
     SECTION_PROLOGUE(.iplt,,)
-	{
-	*(.iplt)
-	}
+    {
+        *(.iplt)
+    }
 
     GROUP_START(ROMABLE_REGION)
 
-	_image_rom_start = ROM_ADDR;
+    _image_rom_start = ROM_ADDR;
 
     SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
-	{
+    {
 
 #if defined(CONFIG_SW_VECTOR_RELAY)
-	KEEP(*(.vector_relay_table))
-	KEEP(*(".vector_relay_table.*"))
-	KEEP(*(.vector_relay_handler))
-	KEEP(*(".vector_relay_handler.*"))
+        KEEP(*(.vector_relay_table))
+        KEEP(*(".vector_relay_table.*"))
+        KEEP(*(.vector_relay_handler))
+        KEEP(*(".vector_relay_handler.*"))
 #endif
 
-	_vector_start = .;
-	KEEP(*(.exc_vector_table))
-	KEEP(*(".exc_vector_table.*"))
+        _vector_start = .;
+        KEEP(*(.exc_vector_table))
+        KEEP(*(".exc_vector_table.*"))
 
-	KEEP(*(IRQ_VECTOR_TABLE))
+        KEEP(*(IRQ_VECTOR_TABLE))
 
-	KEEP(*(.vectors))
+        KEEP(*(.vectors))
 
-	KEEP(*(.openocd_dbg))
-	KEEP(*(".openocd_dbg.*"))
+        KEEP(*(.openocd_dbg))
+        KEEP(*(".openocd_dbg.*"))
 
-	_vector_end = .;
-	} GROUP_LINK_IN(ROMABLE_REGION)
+        _vector_end = .;
+    } GROUP_LINK_IN(ROMABLE_REGION)
 
 #ifdef CONFIG_CODE_DATA_RELOCATION
 
@@ -145,59 +145,59 @@ SECTIONS
 #endif /* CONFIG_CODE_DATA_RELOCATION */
 
     SECTION_PROLOGUE(_TEXT_SECTION_NAME_2,,)
-	{
-	_image_text_start = .;
-	*(.text)
-	*(".text.*")
-	*(.gnu.linkonce.t.*)
+    {
+        _image_text_start = .;
+        *(.text)
+        *(".text.*")
+        *(.gnu.linkonce.t.*)
 
-	/*
-	 * These are here according to 'arm-zephyr-elf-ld --verbose',
-	 * after .gnu.linkonce.t.*
-	 */
-	*(.glue_7t) *(.glue_7) *(.vfp11_veneer) *(.v4_bx)
+        /*
+         * These are here according to 'arm-zephyr-elf-ld --verbose',
+         * after .gnu.linkonce.t.*
+         */
+        *(.glue_7t) *(.glue_7) *(.vfp11_veneer) *(.v4_bx)
 
 #include <linker/priv_stacks-text.ld>
 #include <linker/kobject-text.ld>
 
-	} GROUP_LINK_IN(ROMABLE_REGION)
+    } GROUP_LINK_IN(ROMABLE_REGION)
 
-	_image_text_end = .;
+    _image_text_end = .;
 
 #if defined (CONFIG_CPLUSPLUS)
-	SECTION_PROLOGUE(.ARM.extab,,)
-	{
-	/*
-	 * .ARM.extab section containing exception unwinding information.
-	 */
-	*(.ARM.extab* .gnu.linkonce.armextab.*)
-	} GROUP_LINK_IN(ROMABLE_REGION)
+    SECTION_PROLOGUE(.ARM.extab,,)
+    {
+        /*
+         * .ARM.extab section containing exception unwinding information.
+         */
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } GROUP_LINK_IN(ROMABLE_REGION)
 #endif
 
-	SECTION_PROLOGUE(.ARM.exidx,,)
-	{
-	/*
-	 * This section, related to stack and exception unwinding, is placed
-	 * explicitly to prevent it from being shared between multiple regions.
-	 * It  must be defined for gcc to support 64-bit math and avoid
-	 * section overlap.
-	 */
-	__exidx_start = .;
+    SECTION_PROLOGUE(.ARM.exidx,,)
+    {
+        /*
+         * This section, related to stack and exception unwinding, is placed
+         * explicitly to prevent it from being shared between multiple regions.
+         * It  must be defined for gcc to support 64-bit math and avoid
+         * section overlap.
+         */
+        __exidx_start = .;
 #if defined (__GCC_LINKER_CMD__)
-	*(.ARM.exidx* gnu.linkonce.armexidx.*)
+        *(.ARM.exidx* gnu.linkonce.armexidx.*)
 #endif
-	__exidx_end = .;
-	} GROUP_LINK_IN(ROMABLE_REGION)
+        __exidx_end = .;
+    } GROUP_LINK_IN(ROMABLE_REGION)
 
-	_image_rodata_start = .;
+        _image_rodata_start = .;
 
 #include <linker/common-rom.ld>
 
     SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
-	{
-	*(.rodata)
-	*(".rodata.*")
-	*(.gnu.linkonce.r.*)
+    {
+        *(.rodata)
+        *(".rodata.*")
+        *(.gnu.linkonce.r.*)
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
@@ -215,24 +215,24 @@ SECTIONS
 #include <linker/priv_stacks-rom.ld>
 #include <linker/kobject-rom.ld>
 
-	/*
-	 * For XIP images, in order to avoid the situation when __data_rom_start
-	 * is 32-bit aligned, but the actual data is placed right after rodata
-	 * section, which may not end exactly at 32-bit border, pad rodata
-	 * section, so __data_rom_start points at data and it is 32-bit aligned.
-	 *
-	 * On non-XIP images this may enlarge image size up to 3 bytes. This
-	 * generally is not an issue, since modern ROM and FLASH memory is
-	 * usually 4k aligned.
-	 */
-	. = ALIGN(4);
-	} GROUP_LINK_IN(ROMABLE_REGION)
+        /*
+         * For XIP images, in order to avoid the situation when __data_rom_start
+         * is 32-bit aligned, but the actual data is placed right after rodata
+         * section, which may not end exactly at 32-bit border, pad rodata
+         * section, so __data_rom_start points at data and it is 32-bit aligned.
+         *
+         * On non-XIP images this may enlarge image size up to 3 bytes. This
+         * generally is not an issue, since modern ROM and FLASH memory is
+         * usually 4k aligned.
+         */
+        . = ALIGN(4);
+    } GROUP_LINK_IN(ROMABLE_REGION)
 
 #include <linker/cplusplus-rom.ld>
 
-	_image_rodata_end = .;
-	MPU_ALIGN(_image_rodata_end -_image_rom_start);
-	_image_rom_end = .;
+    _image_rodata_end = .;
+    MPU_ALIGN(_image_rodata_end -_image_rom_start);
+    _image_rom_end = .;
 
     GROUP_END(ROMABLE_REGION)
 
@@ -241,21 +241,21 @@ SECTIONS
      * before data section.
      */
     SECTION_PROLOGUE(.got,,)
-	{
-	*(.got.plt)
-	*(.igot.plt)
-	*(.got)
-	*(.igot)
-	}
+    {
+        *(.got.plt)
+        *(.igot.plt)
+        *(.got)
+        *(.igot)
+    }
 
     GROUP_START(RAMABLE_REGION)
 
-	. = RAM_ADDR;
-	/* Align the start of image SRAM with the
-	 * minimum granularity required by MPU.
-	 */
-	. = ALIGN(_region_min_align);
-	_image_ram_start = .;
+    . = RAM_ADDR;
+    /* Align the start of image SRAM with the
+     * minimum granularity required by MPU.
+     */
+    . = ALIGN(_region_min_align);
+    _image_ram_start = .;
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
@@ -268,24 +268,24 @@ SECTIONS
 
 #include <app_smem.ld>
 
-	_app_smem_size = _app_smem_end - _app_smem_start;
-	_app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
+    _app_smem_size = _app_smem_end - _app_smem_start;
+    _app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
 #endif  /* CONFIG_USERSPACE */
 
     SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
-	{
+    {
         /*
          * For performance, BSS section is assumed to be 4 byte aligned and
          * a multiple of 4 bytes
          */
         . = ALIGN(4);
-	__bss_start = .;
-	__kernel_ram_start = .;
+        __bss_start = .;
+        __kernel_ram_start = .;
 
-	*(.bss)
-	*(".bss.*")
-	*(COMMON)
-	*(".kernel_bss.*")
+        *(.bss)
+        *(".bss.*")
+        *(COMMON)
+        *(".kernel_bss.*")
 
 #ifdef CONFIG_CODE_DATA_RELOCATION
 #include <linker_sram_bss_relocate.ld>
@@ -294,19 +294,19 @@ SECTIONS
         /*
          * As memory is cleared in words only, it is simpler to ensure the BSS
          * section ends on a 4 byte boundary. This wastes a maximum of 3 bytes.
-		 */
-	__bss_end = ALIGN(4);
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+                 */
+        __bss_end = ALIGN(4);
+    } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
     SECTION_PROLOGUE(_NOINIT_SECTION_NAME,(NOLOAD),)
-        {
+    {
         /*
          * This section is used for non-initialized objects that
          * will not be cleared during the boot process.
          */
         *(.noinit)
         *(".noinit.*")
-	*(".kernel_noinit.*")
+        *(".kernel_noinit.*")
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
@@ -316,14 +316,14 @@ SECTIONS
 #include <soc-noinit.ld>
 #endif
 
-        } GROUP_LINK_IN(RAMABLE_REGION)
+    } GROUP_LINK_IN(RAMABLE_REGION)
 
     SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
-	{
-	__data_ram_start = .;
-	*(.data)
-	*(".data.*")
-	*(".kernel.*")
+    {
+        __data_ram_start = .;
+        *(.data)
+        *(".data.*")
+        *(".kernel.*")
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
@@ -342,7 +342,7 @@ SECTIONS
 #include <linker_sram_data_relocate.ld>
 #endif
 
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+    } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
     __data_rom_start = LOADADDR(_DATA_SECTION_NAME);
 
@@ -380,58 +380,44 @@ SECTIONS
 #include <linker/debug-sections.ld>
 
     SECTION_PROLOGUE(.ARM.attributes, 0,)
-	{
-	KEEP(*(.ARM.attributes))
-	KEEP(*(.gnu.attributes))
-	}
+    {
+        KEEP(*(.ARM.attributes))
+        KEEP(*(.gnu.attributes))
+    }
 
-	/DISCARD/ : { *(.note.GNU-stack) }
+    /DISCARD/ : { *(.note.GNU-stack) }
 
 #if defined(CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS)
+
 #if CONFIG_ARM_NSC_REGION_BASE_ADDRESS != 0
-	#define NSC_ALIGN . = ABSOLUTE(CONFIG_ARM_NSC_REGION_BASE_ADDRESS)
-#elif defined(CONFIG_CPU_HAS_NRF_IDAU)
-	/* The nRF9160 needs the NSC region to be at the end of a 32 kB region. */
-	#define NSC_ALIGN . = ALIGN(0x8000) - (1 << LOG2CEIL(__sg_size))
+    #define NSC_ALIGN . = ABSOLUTE(CONFIG_ARM_NSC_REGION_BASE_ADDRESS)
 #else
-	#define NSC_ALIGN . = ALIGN(4)
+    #define NSC_ALIGN . = ALIGN(4)
 #endif
 
-#ifdef CONFIG_CPU_HAS_NRF_IDAU
-	#define NSC_ALIGN_END . = ALIGN(0x8000)
-#else
-	#define NSC_ALIGN_END . = ALIGN(4)
-#endif
+    #define NSC_ALIGN_END . = ALIGN(4)
 
-SECTION_PROLOGUE(.gnu.sgstubs,,)
-{
-	NSC_ALIGN;
-	__sg_start = .;
-	/* No input section necessary, since the Secure Entry Veneers are
-	   automatically placed after the .gnu.sgstubs output section. */
-} GROUP_LINK_IN(ROMABLE_REGION)
-__sg_end = .;
-__sg_size = __sg_end - __sg_start;
-NSC_ALIGN_END;
-__nsc_size = . - __sg_start;
+    SECTION_PROLOGUE(.gnu.sgstubs,,)
+    {
+        NSC_ALIGN;
+        __sg_start = .;
+        /* No input section necessary, since the Secure Entry Veneers are
+           automatically placed after the .gnu.sgstubs output section. */
+    } GROUP_LINK_IN(ROMABLE_REGION)
+    __sg_end = .;
+    __sg_size = __sg_end - __sg_start;
+    NSC_ALIGN_END;
+    __nsc_size = . - __sg_start;
 
-#ifdef CONFIG_CPU_HAS_NRF_IDAU
-	ASSERT(1 << LOG2CEIL(0x8000 - (__sg_start % 0x8000))
-			 == (0x8000 - (__sg_start % 0x8000))
-		&& (0x8000 - (__sg_start % 0x8000)) >= 32
-		&& (0x8000 - (__sg_start % 0x8000)) <= 4096,
-		"The Non-Secure Callable region size must be a power of 2 \
-between 32 and 4096 bytes.")
-#endif
 #endif /* CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS */
 
-/* Must be last in romable region */
-SECTION_PROLOGUE(.last_section,(NOLOAD),)
-{
-} GROUP_LINK_IN(ROMABLE_REGION)
+    /* Must be last in romable region */
+    SECTION_PROLOGUE(.last_section,(NOLOAD),)
+    {
+    } GROUP_LINK_IN(ROMABLE_REGION)
 
-/* To provide the image size as a const expression,
- * calculate this value here. */
-_flash_used = LOADADDR(.last_section) - _image_rom_start;
+    /* To provide the image size as a const expression,
+     * calculate this value here. */
+    _flash_used = LOADADDR(.last_section) - _image_rom_start;
 
-    }
+}

--- a/include/arch/arm/aarch64/scripts/linker.ld
+++ b/include/arch/arm/aarch64/scripts/linker.ld
@@ -114,7 +114,7 @@ SECTIONS
 
     _image_rom_start = ROM_ADDR;
 
-    SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
+    SECTION_PROLOGUE(rom_start,,)
     {
 
 #if defined(CONFIG_SW_VECTOR_RELAY)
@@ -144,7 +144,7 @@ SECTIONS
 
 #endif /* CONFIG_CODE_DATA_RELOCATION */
 
-    SECTION_PROLOGUE(_TEXT_SECTION_NAME_2,,)
+    SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
     {
         _image_text_start = .;
         *(.text)

--- a/include/arch/arm/aarch64/scripts/linker.ld
+++ b/include/arch/arm/aarch64/scripts/linker.ld
@@ -132,10 +132,10 @@ SECTIONS
 
         KEEP(*(.vectors))
 
+        _vector_end = .;
+
         KEEP(*(.openocd_dbg))
         KEEP(*(".openocd_dbg.*"))
-
-        _vector_end = .;
     } GROUP_LINK_IN(ROMABLE_REGION)
 
 #ifdef CONFIG_CODE_DATA_RELOCATION


### PR DESCRIPTION
This commit fixes the improper naming of the ROM sections.

1. Rename the first ROM section, which was previously named using the
  `_TEXT_SECTION_NAME` definition, to `rom_start`, as this section does
  not actually represent the text section.

2. Rename the second ROM section, which was previously named
  `_TEXT_SECTION_NAME_2` which supposedly refers to the definition of
  the same name that does not exist, to `_TEXT_SECTION_NAME`. Note that
  this is indeed the section that contains the text section from the
  source image.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>