### PR TITLE
sanitycheck: Update section names for memory size calculation

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1075,7 +1075,6 @@ class SizeCalculator:
         'log_const_sections',
         "font_entry_sections",
         "priv_stacks_noinit",
-        "_TEXT_SECTION_NAME_2",
         "_GCOV_BSS_SECTION_NAME",
         "gcov",
         "nocache"
@@ -1083,6 +1082,7 @@ class SizeCalculator:
 
     # These get copied into RAM only on non-XIP
     ro_sections = [
+        "rom_start",
         "text",
         "ctors",
         "init_array",


### PR DESCRIPTION
This commit updates the section names for memory size calculation in
the sanitycheck script as follows:

1. Remove `_TEXT_SECTION_NAME_2` section, which no longer exists, from
  the `rw_sections`.

2. Add `rom_start` section, which mostly contains read-only data such
  as the exception vector table, to the `ro_sections`.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

NOTE: This PR should be merged after #22672 and #22673 are merged.