### PR TITLE
boards: up_squared_adsp: fix mis-used logical operator

### DIFF
--- a/boards/xtensa/up_squared_adsp/bootloader/boot_loader.c
+++ b/boards/xtensa/up_squared_adsp/bootloader/boot_loader.c
@@ -116,7 +116,7 @@ static int32_t lp_sram_init(void)
 	idelay(delay_count);
 
 	lspgctl_value = shim_read(LSPGCTL);
-	shim_write(LSPGCTL, lspgctl_value & !LPSRAM_MASK(0));
+	shim_write(LSPGCTL, lspgctl_value & ~LPSRAM_MASK(0));
 
 	/* add some delay before checking the status */
 	idelay(delay_count);


### PR DESCRIPTION
In the bootloader code, there is a mis-used logical operator
which should be bitwise operator. So fix it.

Fixes #22651
Coverity-CID: 208198

Signed-off-by: Daniel Leung <daniel.leung@intel.com>