### PR TITLE
arch: arm: aarch64: linker.ld: Remove redundant text section offset

### DIFF
--- a/include/arch/arm/aarch64/scripts/linker.ld
+++ b/include/arch/arm/aarch64/scripts/linker.ld
@@ -117,8 +117,6 @@ SECTIONS
     SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
 	{
 
-	. = CONFIG_TEXT_SECTION_OFFSET;
-
 #if defined(CONFIG_SW_VECTOR_RELAY)
 	KEEP(*(.vector_relay_table))
 	KEEP(*(".vector_relay_table.*"))


### PR DESCRIPTION
This commit removes the redundant text section offset specification in
the AArch64 linker script.

The text section offset is already specified by the
`text_section_offset.ld`, which is included by
`arch/common/CMakeLists.txt`.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>