### PR TITLE
samples: fxos8700-hid: Fix using gpio_pin_get()

### DIFF
--- a/samples/sensor/fxos8700-hid/src/main.c
+++ b/samples/sensor/fxos8700-hid/src/main.c
@@ -118,6 +118,8 @@ int callbacks_configure(struct device *gpio, u32_t pin, int flags,
 			void (*handler)(struct device*, struct gpio_callback*,
 			u32_t), struct gpio_callback *callback, u32_t *val)
 {
+	int ret;
+
 	if (!gpio) {
 		LOG_ERR("Could not find PORT");
 		return -ENXIO;
@@ -125,10 +127,15 @@ int callbacks_configure(struct device *gpio, u32_t pin, int flags,
 
 	gpio_pin_configure(gpio, pin,
 			   GPIO_INPUT | GPIO_INT_DEBOUNCE | flags);
-	*val = gpio_pin_get(gpio, pin);
-	if (*val < 0) {
-		return *val;
+
+	ret = gpio_pin_get(gpio, pin);
+	if (ret < 0) {
+		LOG_ERR("Failed to get the state of pin %u, error: %d",
+			pin, ret);
+		return ret;
 	}
+
+	*val = (u8_t)ret;
 
 	gpio_init_callback(callback, handler, BIT(pin));
 	gpio_add_callback(gpio, callback);


### PR DESCRIPTION
Fix using unsigned with gpio_pin_get(). Closes Coverity issue:
```
...
128             *val = gpio_pin_get(gpio, pin);
>>>     CID 208206:  Control flow issues  (NO_EFFECT)
>>>     This less-than-zero comparison of an unsigned value is never true. "*val < 0U".
129             if (*val < 0) {
...
```