### PR TITLE
cmake: Fix zephyr-sdk's with a single toolchain

### DIFF
--- a/cmake/toolchain/zephyr/0.11/generic.cmake
+++ b/cmake/toolchain/zephyr/0.11/generic.cmake
@@ -6,9 +6,29 @@ set(COMPILER gcc)
 set(LINKER ld)
 set(BINTOOLS gnu)
 
-set(CROSS_COMPILE_TARGET x86_64-${TOOLCHAIN_VENDOR}-elf)
-set(SYSROOT_TARGET       x86_64-${TOOLCHAIN_VENDOR}-elf)
+# Find some toolchain that is distributed with this particular SDK
 
-set(CROSS_COMPILE ${TOOLCHAIN_HOME}/${CROSS_COMPILE_TARGET}/bin/${CROSS_COMPILE_TARGET}-)
-set(SYSROOT_DIR ${ZEPHYR_SDK_INSTALL_DIR}/sysroots/${SYSROOT_TARGET}/usr)
+file(GLOB toolchain_paths
+  LIST_DIRECTORIES true
+  ${TOOLCHAIN_HOME}/xtensa/*/*-zephyr-elf
+  ${TOOLCHAIN_HOME}/*-zephyr-elf
+  ${TOOLCHAIN_HOME}/*-zephyr-eabi
+  )
+
+if(toolchain_paths)
+  list(GET toolchain_paths 0 some_toolchain_path)
+
+  get_filename_component(one_toolchain_root "${some_toolchain_path}" DIRECTORY)
+  get_filename_component(one_toolchain "${some_toolchain_path}" NAME)
+
+  set(CROSS_COMPILE_TARGET ${one_toolchain})
+  set(SYSROOT_TARGET	   ${one_toolchain})
+endif()
+
+if(NOT CROSS_COMPILE_TARGET)
+  message(FATAL_ERROR "Unable to find 'x86_64-zephyr-elf' or any other architecture in ${TOOLCHAIN_HOME}")
+endif()
+
+set(CROSS_COMPILE ${one_toolchain_root}/${CROSS_COMPILE_TARGET}/bin/${CROSS_COMPILE_TARGET}-)
+set(SYSROOT_DIR   ${one_toolchain_root}/${SYSROOT_TARGET}/${SYSROOT_TARGET})
 set(TOOLCHAIN_HAS_NEWLIB ON CACHE BOOL "True if toolchain supports newlib")


### PR DESCRIPTION
It used to be that zephyr-sdk's always contained all toolchains,
but as of recently it is also possible to download partial toolchains.

This patch fixes an issue where it was assumed that the zephyr sdk
contained an x86 toolchain. Now we loop over all known toolchains and
check for existence.

Note that the toolchain discovered by generic.cmake can be any generic
toolchain and does not need to be the same that is discovered by
target.cmake.

Fixes #22616

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>