### PR TITLE
board: qemu_cortex_a53: Enable default testing

### DIFF
--- a/boards/arm/qemu_cortex_a53/qemu_cortex_a53.yaml
+++ b/boards/arm/qemu_cortex_a53/qemu_cortex_a53.yaml
@@ -8,5 +8,6 @@ toolchain:
   - cross-compile
 ram: 128
 testing:
+  default: true
   ignore_tags:
     - interrupt


### PR DESCRIPTION
QEMU Cortex-A53 is the default (and only) board for this architecture,
as such we should enable default testing.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>

Fixes #22682