### PR TITLE
samples: canbus: canopen: fix python package install instructions

### DIFF
--- a/samples/subsys/canbus/canopen/README.rst
+++ b/samples/subsys/canbus/canopen/README.rst
@@ -71,7 +71,7 @@ python-can backend as follows:
 
 .. code-block:: console
 
-   pip3 install --user canopen can
+   pip3 install --user canopen python-can
 
 Next, bring up the CAN interface on the test PC. On GNU/Linux, this
 can be done as follows:


### PR DESCRIPTION
Fix the Python3 CANopen module installation instructions to refer to the 'python-can' package instead of the nonexistent 'can' package.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>