### PR TITLE
cmake: west version must be 0.7.1

### DIFF
--- a/cmake/host-tools.cmake
+++ b/cmake/host-tools.cmake
@@ -38,7 +38,7 @@ else()
   # even after output is one line.
   message(STATUS "Found west: ${WEST} (found suitable version \"${west_version}\", minimum required is \"${MIN_WEST_VERSION}\")")
 
-  if (${west_version} VERSION_GREATER_EQUAL "0.7.0")
+  if (${west_version} VERSION_GREATER_EQUAL "0.7.1")
     execute_process(
       COMMAND ${WEST}  topdir
       OUTPUT_VARIABLE  WEST_TOPDIR


### PR DESCRIPTION
West topdir 0.7.0 uses windows path style in Windows causing a failure
in CMake.
This is fixed in west, 0.7.1.

This fix ensures that west topdir is only used when
west version is >= 0.7.1.

See: 
https://github.com/zephyrproject-rtos/west/pull/375
https://github.com/zephyrproject-rtos/west/pull/376

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>