### PR TITLE
drivers: modem: sara-r4: fix APN setting for U2 modem

### DIFF
--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -753,7 +753,7 @@ static void modem_reset(void)
 #if defined(CONFIG_MODEM_UBLOX_SARA_U2)
 		/* set the APN */
 		SETUP_CMD_NOHANDLE("AT+UPSD=0,1,\""
-				CONFIG_MODEM_UBLOX_SARA_R4_MANUAL_MCCMNO "\""),
+				CONFIG_MODEM_UBLOX_SARA_R4_APN "\""),
 		/* set dynamic IP */
 		SETUP_CMD_NOHANDLE("AT+UPSD=0,7,\"0.0.0.0\""),
 		/* activate the GPRS connection */


### PR DESCRIPTION
usage of AT+UPSD command per UBX-17003787(R15) command reference is:
AT+UPSD=<profile_id>, <param_tag>, <param_val>

For AT+UPSD=0, 1, "<value>": we are setting value to MCCMNO, which
is technically incorrect.  <param_tag> of 1 means:

1: APN - <param_val> defines the APN text string, e.g.
"apn.provider.com"; the maximum length is 99. The factory-programmed
value is an empty string.

Let's use APN here instead.  This fixes a +CME ERROR: 113 when
connecting with U2 modem.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/22689

Signed-off-by: Michael Scott <mike@foundries.io>