### PR TITLE
net: config: init: fix NET_NATIVE=n behavior

### DIFF
--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -315,7 +315,7 @@ static bool check_interface(struct net_if *iface)
 	return false;
 }
 #else
-static void check_interface(struct net_if *iface)
+static bool check_interface(struct net_if *iface)
 {
 	k_sem_reset(&counter);
 	k_sem_give(&waiter);


### PR DESCRIPTION
commit e3dc05f14d51 ("net: config: Wait network interface to come up")
introduced check_interface() function, which accidentally has 2
different signatures depending on CONFIG_NET_NATIVE selection.

Let's fix the second signature to be correct.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/22693

Signed-off-by: Michael Scott <mike@foundries.io>