### PR TITLE
sample: net: gsm_modem: Add sample.yaml file

### DIFF
--- a/samples/net/gsm_modem/sample.yaml
+++ b/samples/net/gsm_modem/sample.yaml
@@ -1,0 +1,11 @@
+common:
+  harness: net
+  depends_on: serial-net
+  tags: net ppp modem gsm
+sample:
+  description: Sample for generic GSM modem
+  name: Generic GSM modem using PPP
+tests:
+  sample.net.ppp.gsm.modem:
+    extra_configs:
+      - CONFIG_TEST_RANDOM_GENERATOR=y


### PR DESCRIPTION
sample.yaml is needed so that we can do some sanity checks
for the GSM modem code.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>