### PR TITLE
posix: fix unistd.h extern C brace mismatch

### DIFF
--- a/include/posix/unistd.h
+++ b/include/posix/unistd.h
@@ -15,11 +15,13 @@
 
 #ifdef CONFIG_POSIX_API
 #include <fs/fs.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#ifdef CONFIG_POSIX_API
 /* File related operations */
 extern int close(int file);
 extern ssize_t write(int file, const void *buffer, size_t count);
@@ -37,9 +39,9 @@ static inline int gethostname(char *buf, size_t len)
 {
 	return zsock_gethostname(buf, len);
 }
-#endif
+#endif /* CONFIG_NETWORKING */
 
-#endif
+#endif /* CONFIG_POSIX_API */
 
 unsigned sleep(unsigned int seconds);
 int usleep(useconds_t useconds);


### PR DESCRIPTION
If unistd.h is included while CONFIG_POSIX_API is not
defined, there is a mismatch of extern C braces that will
cause compile errors

Signed-off-by: Nicholas Lowell <nlowell@lexmark.com>