### PR TITLE
Bluetooth: GATT: Fix not clearing stored data when unpairing

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -4137,11 +4137,9 @@ int bt_gatt_store_ccc(u8_t id, const bt_addr_le_t *addr)
 		char id_str[4];
 
 		u8_to_dec(id_str, sizeof(id_str), id);
-		bt_settings_encode_key(key, sizeof(key), "ccc",
-				       (bt_addr_le_t *)addr, id_str);
+		bt_settings_encode_key(key, sizeof(key), "ccc", addr, id_str);
 	} else {
-		bt_settings_encode_key(key, sizeof(key), "ccc",
-				       (bt_addr_le_t *)addr, NULL);
+		bt_settings_encode_key(key, sizeof(key), "ccc", addr, NULL);
 	}
 
 	if (save.count) {
@@ -4392,10 +4390,10 @@ static int bt_gatt_clear_ccc(u8_t id, const bt_addr_le_t *addr)
 
 			u8_to_dec(id_str, sizeof(id_str), id);
 			bt_settings_encode_key(key, sizeof(key), "ccc",
-					       (bt_addr_le_t *)addr, id_str);
+					       addr, id_str);
 		} else {
 			bt_settings_encode_key(key, sizeof(key), "ccc",
-				       (bt_addr_le_t *)addr, NULL);
+					       addr, NULL);
 		}
 
 		return settings_delete(key);
@@ -4421,10 +4419,10 @@ static int bt_gatt_clear_cf(u8_t id, const bt_addr_le_t *addr)
 
 			u8_to_dec(id_str, sizeof(id_str), id);
 			bt_settings_encode_key(key, sizeof(key), "cf",
-					       (bt_addr_le_t *)addr, id_str);
+					       addr, id_str);
 		} else {
 			bt_settings_encode_key(key, sizeof(key), "cf",
-					       (bt_addr_le_t *)addr, NULL);
+					       addr, NULL);
 		}
 
 		return settings_delete(key);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1862,9 +1862,7 @@ static void unpair(u8_t id, const bt_addr_le_t *addr)
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-		bt_gatt_clear(id, addr);
-	}
+	bt_gatt_clear(id, addr);
 }
 
 static void unpair_remote(const struct bt_bond_info *info, void *data)

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -21,7 +21,7 @@
 
 #if defined(CONFIG_BT_SETTINGS_USE_PRINTK)
 void bt_settings_encode_key(char *path, size_t path_size, const char *subsys,
-			    bt_addr_le_t *addr, const char *key)
+			    const bt_addr_le_t *addr, const char *key)
 {
 	if (key) {
 		snprintk(path, path_size,
@@ -41,7 +41,7 @@ void bt_settings_encode_key(char *path, size_t path_size, const char *subsys,
 }
 #else
 void bt_settings_encode_key(char *path, size_t path_size, const char *subsys,
-			    bt_addr_le_t *addr, const char *key)
+			    const bt_addr_le_t *addr, const char *key)
 {
 	size_t len = 3;
 

--- a/subsys/bluetooth/host/settings.h
+++ b/subsys/bluetooth/host/settings.h
@@ -12,7 +12,7 @@
 
 /* Helpers for keys containing a bdaddr */
 void bt_settings_encode_key(char *path, size_t path_size, const char *subsys,
-			    bt_addr_le_t *addr, const char *key);
+			    const bt_addr_le_t *addr, const char *key);
 int bt_settings_decode_key(const char *key, bt_addr_le_t *addr);
 
 void bt_settings_save_id(void);


### PR DESCRIPTION
GATT data shall not be considered conditional to BT_SETTINGS since
the data is stored in RAM it must also be cleared when unpairing.

Fixes #22514

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>