### PR TITLE
west.yml: hal_ti: fix SemaphoreP_create/construct to initialize count

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
       revision: 94d735c2613f5d17b64b78a15f0b0191e4474eb0
       path: modules/hal/stm32
     - name: hal_ti
-      revision: ab9b289a109a9cac9c222a22176d22bf14d982e7
+      revision: b25d4b83b16e52f501f8cd360f4efb8c31ffb578
       path: modules/hal/ti
     - name: libmetal
       revision: 45e630d6152824f807d3f919958605c4626cbdff


### PR DESCRIPTION
Updating west.yml to point to fixed versions of SempahoreP_create/
SemaphoreP_construct that correctly initialize the semaphore count.

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>