### PR TITLE
dts: Replace deprecated DT_NXP_LPC_* macros with DT_ALIAS_*

### DIFF
--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -290,9 +290,9 @@ static void mcux_flexcomm_config_func_0(struct device *dev);
 #endif
 
 static const struct mcux_flexcomm_config mcux_flexcomm_0_config = {
-	.base = (USART_Type *)DT_NXP_LPC_USART_USART_0_BASE_ADDRESS,
+	.base = (USART_Type *)DT_ALIAS_USART_0_BASE_ADDRESS,
 	.clock_source = 0,
-	.baud_rate = DT_NXP_LPC_USART_USART_0_CURRENT_SPEED,
+	.baud_rate = DT_ALIAS_USART_0_CURRENT_SPEED,
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = mcux_flexcomm_config_func_0,
 #endif
@@ -300,7 +300,7 @@ static const struct mcux_flexcomm_config mcux_flexcomm_0_config = {
 
 static struct mcux_flexcomm_data mcux_flexcomm_0_data;
 
-DEVICE_AND_API_INIT(usart_0, DT_NXP_LPC_USART_USART_0_LABEL,
+DEVICE_AND_API_INIT(usart_0, DT_ALIAS_USART_0_LABEL,
 		    &mcux_flexcomm_init,
 		    &mcux_flexcomm_0_data, &mcux_flexcomm_0_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -309,11 +309,11 @@ DEVICE_AND_API_INIT(usart_0, DT_NXP_LPC_USART_USART_0_LABEL,
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void mcux_flexcomm_config_func_0(struct device *dev)
 {
-	IRQ_CONNECT(DT_NXP_LPC_USART_USART_0_IRQ_0,
-		    DT_NXP_LPC_USART_USART_0_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_ALIAS_USART_0_IRQ_0,
+		    DT_ALIAS_USART_0_IRQ_0_PRIORITY,
 		    mcux_flexcomm_isr, DEVICE_GET(usart_0), 0);
 
-	irq_enable(DT_NXP_LPC_USART_USART_0_IRQ_0);
+	irq_enable(DT_ALIAS_USART_0_IRQ_0);
 }
 #endif
 

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -269,7 +269,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 	static void spi_mcux_config_func_##id(struct device *dev);	\
 	static const struct spi_mcux_config spi_mcux_config_##id = {	\
 		.base =							\
-		(SPI_Type *)DT_NXP_LPC_SPI_SPI_##id##_BASE_ADDRESS,	\
+		(SPI_Type *)DT_ALIAS_SPI_##id##_BASE_ADDRESS,		\
 		.irq_config_func = spi_mcux_config_func_##id,		\
 	};								\
 	static struct spi_mcux_data spi_mcux_data_##id = {		\
@@ -277,7 +277,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 		SPI_CONTEXT_INIT_SYNC(spi_mcux_data_##id, ctx),		\
 	};								\
 	DEVICE_AND_API_INIT(spi_mcux_##id,				\
-			    DT_NXP_LPC_SPI_SPI_##id##_LABEL,		\
+			    DT_ALIAS_SPI_##id##_LABEL,			\
 			    &spi_mcux_init,				\
 			    &spi_mcux_data_##id,			\
 			    &spi_mcux_config_##id,			\
@@ -286,11 +286,11 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 			    &spi_mcux_driver_api);			\
 	static void spi_mcux_config_func_##id(struct device *dev)	\
 	{								\
-		IRQ_CONNECT(DT_NXP_LPC_SPI_SPI_##id##_IRQ_0,		\
-			    DT_NXP_LPC_SPI_SPI_##id##_IRQ_0_PRIORITY,	\
+		IRQ_CONNECT(DT_ALIAS_SPI_##id##_IRQ_0,			\
+			    DT_ALIAS_SPI_##id##_IRQ_0_PRIORITY,		\
 			    spi_mcux_isr, DEVICE_GET(spi_mcux_##id),	\
 			    0);						\
-		irq_enable(DT_NXP_LPC_SPI_SPI_##id##_IRQ_0);		\
+		irq_enable(DT_ALIAS_SPI_##id##_IRQ_0);			\
 	}
 
 #ifdef CONFIG_SPI_0


### PR DESCRIPTION
*(This PR is not adding any new aliases. See the commit message and the explanation in a separate comment. It's a standalone improvement, which will make later improvements much easier.)*

scripts/dts/gen_defines.py currently generates prefixes from properties in
aliases/ in two formats:

    DT_ALIAS_<property>_*
    DT_<compatible of pointed-to node>_<property>_*

For example, 'aliases { usart-0 = &usart0; }' generates

    DT_ALIAS_USART_0_*
    DT_NXP_LPC_USART_USART_0_*

when the &usart0 node has 'compatible = "nxp,lpc-usart"'.

The second form exists for backwards compatibility. It's spammy and hard
to read, and easy to confuse for DT_\<compatible>\_\<unit address>_*, which
also gets generated for devicetree nodes.

The code in gen_defines.py that generates the deprecated form has a
'# TODO: See if we can remove or deprecate this form' Comment over it.

Update all macros that come from /aliases to use the DT_ALIAS_* form,
for macros prefixed with DT_NXP_LPC_*.