### PR TITLE
dts: Replace deprecated DT_INVENTEK_* macros with DT_ALIAS_*

### DIFF
--- a/drivers/wifi/eswifi/eswifi_bus_spi.c
+++ b/drivers/wifi/eswifi/eswifi_bus_spi.c
@@ -226,7 +226,7 @@ int eswifi_spi_init(struct eswifi_dev *eswifi)
 	struct eswifi_spi_data *spi = &eswifi_spi0; /* Static instance */
 
 	/* SPI DEV */
-	spi->spi_dev = device_get_binding(DT_INVENTEK_ESWIFI_ESWIFI0_BUS_NAME);
+	spi->spi_dev = device_get_binding(DT_ALIAS_ESWIFI0_BUS_NAME);
 	if (!spi->spi_dev) {
 		LOG_ERR("Failed to initialize SPI driver");
 		return -ENODEV;
@@ -234,26 +234,26 @@ int eswifi_spi_init(struct eswifi_dev *eswifi)
 
 	/* SPI DATA READY PIN */
 	spi->dr.dev = device_get_binding(
-			DT_INVENTEK_ESWIFI_ESWIFI0_DATA_GPIOS_CONTROLLER);
+			DT_ALIAS_ESWIFI0_DATA_GPIOS_CONTROLLER);
 	if (!spi->dr.dev) {
 		LOG_ERR("Failed to initialize GPIO driver: %s",
-			    DT_INVENTEK_ESWIFI_ESWIFI0_DATA_GPIOS_CONTROLLER);
+			    DT_ALIAS_ESWIFI0_DATA_GPIOS_CONTROLLER);
 		return -ENODEV;
 	}
-	spi->dr.pin = DT_INVENTEK_ESWIFI_ESWIFI0_DATA_GPIOS_PIN;
+	spi->dr.pin = DT_ALIAS_ESWIFI0_DATA_GPIOS_PIN;
 	gpio_pin_configure(spi->dr.dev, spi->dr.pin,
-			   DT_INVENTEK_ESWIFI_ESWIFI0_DATA_GPIOS_FLAGS |
+			   DT_ALIAS_ESWIFI0_DATA_GPIOS_FLAGS |
 			   GPIO_INPUT);
 
 	/* SPI CONFIG/CS */
-	spi->spi_cfg.frequency = DT_INVENTEK_ESWIFI_ESWIFI0_SPI_MAX_FREQUENCY;
+	spi->spi_cfg.frequency = DT_ALIAS_ESWIFI0_SPI_MAX_FREQUENCY;
 	spi->spi_cfg.operation = (SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB |
 				  SPI_WORD_SET(16) | SPI_LINES_SINGLE |
 				  SPI_HOLD_ON_CS | SPI_LOCK_ON);
-	spi->spi_cfg.slave = DT_INVENTEK_ESWIFI_ESWIFI0_BASE_ADDRESS;
+	spi->spi_cfg.slave = DT_ALIAS_ESWIFI0_BASE_ADDRESS;
 	spi->spi_cs.gpio_dev =
-		device_get_binding(DT_INVENTEK_ESWIFI_ESWIFI0_CS_GPIOS_CONTROLLER);
-	spi->spi_cs.gpio_pin = DT_INVENTEK_ESWIFI_ESWIFI0_CS_GPIOS_PIN;
+		device_get_binding(DT_ALIAS_ESWIFI0_CS_GPIOS_CONTROLLER);
+	spi->spi_cs.gpio_pin = DT_ALIAS_ESWIFI0_CS_GPIOS_PIN;
 	spi->spi_cs.delay = 1000U;
 	spi->spi_cfg.cs = &spi->spi_cs;
 

--- a/drivers/wifi/eswifi/eswifi_bus_spi.c
+++ b/drivers/wifi/eswifi/eswifi_bus_spi.c
@@ -226,7 +226,7 @@ int eswifi_spi_init(struct eswifi_dev *eswifi)
 	struct eswifi_spi_data *spi = &eswifi_spi0; /* Static instance */
 
 	/* SPI DEV */
-	spi->spi_dev = device_get_binding(DT_ALIAS_ESWIFI0_BUS_NAME);
+	spi->spi_dev = device_get_binding(DT_INST_0_INVENTEK_ESWIFI_BUS_NAME);
 	if (!spi->spi_dev) {
 		LOG_ERR("Failed to initialize SPI driver");
 		return -ENODEV;
@@ -234,26 +234,26 @@ int eswifi_spi_init(struct eswifi_dev *eswifi)
 
 	/* SPI DATA READY PIN */
 	spi->dr.dev = device_get_binding(
-			DT_ALIAS_ESWIFI0_DATA_GPIOS_CONTROLLER);
+			DT_INST_0_INVENTEK_ESWIFI_DATA_GPIOS_CONTROLLER);
 	if (!spi->dr.dev) {
 		LOG_ERR("Failed to initialize GPIO driver: %s",
-			    DT_ALIAS_ESWIFI0_DATA_GPIOS_CONTROLLER);
+			    DT_INST_0_INVENTEK_ESWIFI_DATA_GPIOS_CONTROLLER);
 		return -ENODEV;
 	}
-	spi->dr.pin = DT_ALIAS_ESWIFI0_DATA_GPIOS_PIN;
+	spi->dr.pin = DT_INST_0_INVENTEK_ESWIFI_DATA_GPIOS_PIN;
 	gpio_pin_configure(spi->dr.dev, spi->dr.pin,
-			   DT_ALIAS_ESWIFI0_DATA_GPIOS_FLAGS |
+			   DT_INST_0_INVENTEK_ESWIFI_DATA_GPIOS_FLAGS |
 			   GPIO_INPUT);
 
 	/* SPI CONFIG/CS */
-	spi->spi_cfg.frequency = DT_ALIAS_ESWIFI0_SPI_MAX_FREQUENCY;
+	spi->spi_cfg.frequency = DT_INST_0_INVENTEK_ESWIFI_SPI_MAX_FREQUENCY;
 	spi->spi_cfg.operation = (SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB |
 				  SPI_WORD_SET(16) | SPI_LINES_SINGLE |
 				  SPI_HOLD_ON_CS | SPI_LOCK_ON);
-	spi->spi_cfg.slave = DT_ALIAS_ESWIFI0_BASE_ADDRESS;
+	spi->spi_cfg.slave = DT_INST_0_INVENTEK_ESWIFI_BASE_ADDRESS;
 	spi->spi_cs.gpio_dev =
-		device_get_binding(DT_ALIAS_ESWIFI0_CS_GPIOS_CONTROLLER);
-	spi->spi_cs.gpio_pin = DT_ALIAS_ESWIFI0_CS_GPIOS_PIN;
+		device_get_binding(DT_INST_0_INVENTEK_ESWIFI_CS_GPIOS_CONTROLLER);
+	spi->spi_cs.gpio_pin = DT_INST_0_INVENTEK_ESWIFI_CS_GPIOS_PIN;
 	spi->spi_cs.delay = 1000U;
 	spi->spi_cfg.cs = &spi->spi_cs;
 

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -638,27 +638,27 @@ static int eswifi_init(struct device *dev)
 	eswifi->bus->init(eswifi);
 
 	eswifi->resetn.dev = device_get_binding(
-			DT_INVENTEK_ESWIFI_ESWIFI0_RESETN_GPIOS_CONTROLLER);
+			DT_ALIAS_ESWIFI0_RESETN_GPIOS_CONTROLLER);
 	if (!eswifi->resetn.dev) {
 		LOG_ERR("Failed to initialize GPIO driver: %s",
-			    DT_INVENTEK_ESWIFI_ESWIFI0_RESETN_GPIOS_CONTROLLER);
+			    DT_ALIAS_ESWIFI0_RESETN_GPIOS_CONTROLLER);
 		return -ENODEV;
 	}
-	eswifi->resetn.pin = DT_INVENTEK_ESWIFI_ESWIFI0_RESETN_GPIOS_PIN;
+	eswifi->resetn.pin = DT_ALIAS_ESWIFI0_RESETN_GPIOS_PIN;
 	gpio_pin_configure(eswifi->resetn.dev, eswifi->resetn.pin,
-			   DT_INVENTEK_ESWIFI_ESWIFI0_RESETN_GPIOS_FLAGS |
+			   DT_ALIAS_ESWIFI0_RESETN_GPIOS_FLAGS |
 			   GPIO_OUTPUT_INACTIVE);
 
 	eswifi->wakeup.dev = device_get_binding(
-			DT_INVENTEK_ESWIFI_ESWIFI0_WAKEUP_GPIOS_CONTROLLER);
+			DT_ALIAS_ESWIFI0_WAKEUP_GPIOS_CONTROLLER);
 	if (!eswifi->wakeup.dev) {
 		LOG_ERR("Failed to initialize GPIO driver: %s",
-			    DT_INVENTEK_ESWIFI_ESWIFI0_WAKEUP_GPIOS_CONTROLLER);
+			    DT_ALIAS_ESWIFI0_WAKEUP_GPIOS_CONTROLLER);
 		return -ENODEV;
 	}
-	eswifi->wakeup.pin = DT_INVENTEK_ESWIFI_ESWIFI0_WAKEUP_GPIOS_PIN;
+	eswifi->wakeup.pin = DT_ALIAS_ESWIFI0_WAKEUP_GPIOS_PIN;
 	gpio_pin_configure(eswifi->wakeup.dev, eswifi->wakeup.pin,
-			   DT_INVENTEK_ESWIFI_ESWIFI0_WAKEUP_GPIOS_FLAGS |
+			   DT_ALIAS_ESWIFI0_WAKEUP_GPIOS_FLAGS |
 			   GPIO_OUTPUT_ACTIVE);
 
 	k_work_q_start(&eswifi->work_q, eswifi_work_q_stack,

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -638,27 +638,27 @@ static int eswifi_init(struct device *dev)
 	eswifi->bus->init(eswifi);
 
 	eswifi->resetn.dev = device_get_binding(
-			DT_ALIAS_ESWIFI0_RESETN_GPIOS_CONTROLLER);
+			DT_INST_0_INVENTEK_ESWIFI_RESETN_GPIOS_CONTROLLER);
 	if (!eswifi->resetn.dev) {
 		LOG_ERR("Failed to initialize GPIO driver: %s",
-			    DT_ALIAS_ESWIFI0_RESETN_GPIOS_CONTROLLER);
+			    DT_INST_0_INVENTEK_ESWIFI_RESETN_GPIOS_CONTROLLER);
 		return -ENODEV;
 	}
-	eswifi->resetn.pin = DT_ALIAS_ESWIFI0_RESETN_GPIOS_PIN;
+	eswifi->resetn.pin = DT_INST_0_INVENTEK_ESWIFI_RESETN_GPIOS_PIN;
 	gpio_pin_configure(eswifi->resetn.dev, eswifi->resetn.pin,
-			   DT_ALIAS_ESWIFI0_RESETN_GPIOS_FLAGS |
+			   DT_INST_0_INVENTEK_ESWIFI_RESETN_GPIOS_FLAGS |
 			   GPIO_OUTPUT_INACTIVE);
 
 	eswifi->wakeup.dev = device_get_binding(
-			DT_ALIAS_ESWIFI0_WAKEUP_GPIOS_CONTROLLER);
+			DT_INST_0_INVENTEK_ESWIFI_WAKEUP_GPIOS_CONTROLLER);
 	if (!eswifi->wakeup.dev) {
 		LOG_ERR("Failed to initialize GPIO driver: %s",
-			    DT_ALIAS_ESWIFI0_WAKEUP_GPIOS_CONTROLLER);
+			    DT_INST_0_INVENTEK_ESWIFI_WAKEUP_GPIOS_CONTROLLER);
 		return -ENODEV;
 	}
-	eswifi->wakeup.pin = DT_ALIAS_ESWIFI0_WAKEUP_GPIOS_PIN;
+	eswifi->wakeup.pin = DT_INST_0_INVENTEK_ESWIFI_WAKEUP_GPIOS_PIN;
 	gpio_pin_configure(eswifi->wakeup.dev, eswifi->wakeup.pin,
-			   DT_ALIAS_ESWIFI0_WAKEUP_GPIOS_FLAGS |
+			   DT_INST_0_INVENTEK_ESWIFI_WAKEUP_GPIOS_FLAGS |
 			   GPIO_OUTPUT_ACTIVE);
 
 	k_work_q_start(&eswifi->work_q, eswifi_work_q_stack,


### PR DESCRIPTION
*(This PR is not adding any new aliases. See the commit message and the explanation in a separate comment. It's a standalone improvement, which will make later improvements much easier.)*

scripts/dts/gen_defines.py currently generates prefixes from properties
in aliases/ in two formats:

    DT_ALIAS_<property>_*
    DT_<compatible of pointed-to node>_<property>_*

For example, 'aliases { usart-0 = &usart0; }' generates

    DT_ALIAS_USART_0_*
    DT_NXP_LPC_USART_USART_0_*

when the &usart0 node has 'compatible = "nxp,lpc-usart"'.

The second form exists for backwards compatibility. It's spammy and hard
to read, and easy to confuse for DT_\<compatible>\_\<unit address>_*, which
also gets generated for devicetree nodes.

The code in gen_defines.py that generates the deprecated form has a
'# TODO: See if we can remove or deprecate this form' Comment over it.

Update all macros that come from /aliases to use the DT_ALIAS_* form,
for macros prefixed with DT_INVENTEK_*.