### PR TITLE
debug: stack: Add missing log_strdup

### DIFF
--- a/include/debug/stack.h
+++ b/include/debug/stack.h
@@ -107,7 +107,7 @@ static inline void log_stack_usage(const struct k_thread *thread)
 		}
 
 		LOG_INF("%p (%s):\tunused %zu\tusage %zu / %zu (%u %%)",
-			thread, tname, unused, size - unused, size,
+			thread, log_strdup(tname), unused, size - unused, size,
 			pcnt);
 	}
 #endif


### PR DESCRIPTION
Log call was missing log_strdup wrap around thread name which
is a string in RAM.

Fixes #22698.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>