### PR TITLE
bluetooth: host: fix RPMsg driver headeroom configuration

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -113,6 +113,7 @@ config BT_HCI_RESERVE
 	int
 	default 0 if BT_H4
 	default 1 if BT_H5
+	default 1 if BT_RPMSG
 	default 1 if BT_SPI
 	default 1 if BT_STM32_IPM
 	default 1 if BT_USERCHAN


### PR DESCRIPTION
Fixed configuration of BT_HCI_RESERVE for the RPMsg HCI driver.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>