### PR TITLE
usb: stm32: added usb_dc_detach code

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -846,12 +846,9 @@ int usb_dc_ep_mps(const u8_t ep)
 
 int usb_dc_detach(void)
 {
-	// stop usb dev
 	HAL_PCD_Stop(&usb_dc_stm32_state.pcd);
-	// take care that the endpoints are closed (usb_dc_ep_disable)
 	HAL_PCD_EP_Close(&usb_dc_stm32_state.pcd, EP0_IN);
 	HAL_PCD_EP_Close(&usb_dc_stm32_state.pcd, EP0_OUT);
-	// now we deinit
 	HAL_PCD_DeInit(&usb_dc_stm32_state.pcd);
 	return 0;
 }

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -846,8 +846,13 @@ int usb_dc_ep_mps(const u8_t ep)
 
 int usb_dc_detach(void)
 {
-	LOG_ERR("Not implemented");
-
+	// stop usb dev
+	HAL_PCD_Stop(&usb_dc_stm32_state.pcd);
+	// take care that the endpoints are closed (usb_dc_ep_disable)
+	HAL_PCD_EP_Close(&usb_dc_stm32_state.pcd, EP0_IN);
+	HAL_PCD_EP_Close(&usb_dc_stm32_state.pcd, EP0_OUT);
+	// now we deinit
+	HAL_PCD_DeInit(&usb_dc_stm32_state.pcd);
 	return 0;
 }
 

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -846,10 +846,9 @@ int usb_dc_ep_mps(const u8_t ep)
 
 int usb_dc_detach(void)
 {
-	HAL_PCD_Stop(&usb_dc_stm32_state.pcd);
+	HAL_PCD_DeInit(&usb_dc_stm32_state.pcd);
 	HAL_PCD_EP_Close(&usb_dc_stm32_state.pcd, EP0_IN);
 	HAL_PCD_EP_Close(&usb_dc_stm32_state.pcd, EP0_OUT);
-	HAL_PCD_DeInit(&usb_dc_stm32_state.pcd);
 	return 0;
 }
 


### PR DESCRIPTION
Now detaching means, that the transfer endpoints are closed.
The usb device is stoped and deinit.

The usb periphal wil go to deepsleep after. That will save
some power.

Signed-off-by: Stefan Jaritz <stefan@kokoontech.com>