### PR TITLE
Bluetooth: host: Rename scan recv callback info struct

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -447,7 +447,7 @@ struct bt_le_scan_param {
 };
 
 /** LE advertisement packet information */
-struct bt_le_adv_info {
+struct bt_le_scan_recv_info {
 	/** Advertiser LE address and type */
 	const bt_addr_le_t *addr;
 
@@ -466,7 +466,7 @@ struct bt_le_scan_cb {
 	 *  @param info Advertiser packet information.
 	 *  @param buf  Buffer containing advertiser data.
 	 */
-	void (*recv)(const struct bt_le_adv_info *info,
+	void (*recv)(const struct bt_le_scan_recv_info *info,
 		     struct net_buf_simple *buf);
 
 	sys_snode_t node;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3807,7 +3807,7 @@ static void le_adv_report(struct net_buf *buf)
 	while (num_reports--) {
 		struct bt_le_scan_cb *cb;
 		struct net_buf_simple_state state;
-		struct bt_le_adv_info adv_info;
+		struct bt_le_scan_recv_info adv_info;
 		bt_addr_le_t id_addr;
 		s8_t rssi;
 


### PR DESCRIPTION
Rename the scan recv callback info struct so that it reflects that it
is part of the scan recv callback. This will make it consistent with
future plans for advertising callbacks. Since this callback has not
been included in any official release yet it is best to rename it
now before it is released to avoid unnecessary deprecation of the name.

With the current draft the advertising extension API this name would
cause confusion as it appears to be part of the advertising API.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>