### PR TITLE
Bluetooth: Fix minor scan issues

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -1586,7 +1586,7 @@ struct bt_hci_evt_le_phy_update_complete {
 
 #define BT_HCI_EVT_LE_EXT_ADVERTISING_REPORT    0x0d
 struct bt_hci_evt_le_ext_advertising_info {
-	u8_t         evt_type;
+	u16_t        evt_type;
 	bt_addr_le_t addr;
 	u8_t         prim_phy;
 	u8_t         sec_phy;

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2253,7 +2253,12 @@ struct bt_conn *bt_conn_create_le(const bt_addr_le_t *peer,
 	if (!bt_dev.le.rl_size || bt_dev.le.rl_entries > bt_dev.le.rl_size) {
 		bt_conn_set_state(conn, BT_CONN_CONNECT_SCAN);
 
-		bt_le_scan_update(true);
+		if (bt_le_scan_update(true)) {
+			bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
+			bt_conn_unref(conn);
+
+			return NULL;
+		}
 
 		return conn;
 	}

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3837,7 +3837,7 @@ static void le_adv_report(struct net_buf *buf)
 			id_addr.type -= BT_ADDR_LE_PUBLIC_ID;
 		} else {
 			bt_addr_le_copy(&id_addr,
-					bt_lookup_id_addr(bt_dev.adv_id,
+					bt_lookup_id_addr(BT_ID_DEFAULT,
 							  &info->addr));
 		}
 


### PR DESCRIPTION
Collection of small bugfixes.

1. Handle scan start failed and release the connection object in this case.

2.   Fix the scanner using the advertiser identity instead of the scanners
    identity, scanner always use BT_ID_DEFAULT.

3. Fix the size of the evt_type, this lead to error over serialized HCI
    where the event could not be interpreted correctly from the HCI
    controller