### PR TITLE
doc: work with west 0.7

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -16,7 +16,9 @@ file(TO_CMAKE_PATH "$ENV{ZEPHYR_BASE}" ZEPHYR_BASE)
 
 message(STATUS "Zephyr base: ${ZEPHYR_BASE}")
 if(DEFINED WEST)
-  message(STATUS "West: ${WEST}")
+  execute_process(COMMAND west --version
+    OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE WEST_VERSION)
+  message(STATUS "West: ${WEST} (west --version: \"${WEST_VERSION}\")")
 else()
   message(STATUS "West: not found")
 endif()

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -188,10 +188,14 @@ def main():
         if p.returncode == 0:
             projects = out.decode(sys.getdefaultencoding()).splitlines()
         elif re.match((r'Error: .* is not in a west installation\.'
-                       '|FATAL ERROR: no west installation found from .*'),
+                       '|FATAL ERROR: no west installation found from .*'
+                       '|FATAL ERROR: no west workspace.*'),
                       err.decode(sys.getdefaultencoding())):
-            # Only accept the error from bootstrapper in the event we are
-            # outside a west managed project.
+            # Only accept the error the event we are outside a west
+            # workspace.
+            #
+            # TODO: we can just use "west topdir" instead if we can
+            # depend on west 0.7.0 or later.
             projects = []
         else:
             print(err.decode(sys.getdefaultencoding()))


### PR DESCRIPTION
Add a print of the west version from the doc cmake list file, just like we have in the Zephyr cmake lists file. This will help diagnose issues.

Fix an issue where hard-coded regexes on the west output in zephyr_module.py were swallowing an error in the documentation build.