### PR TITLE
net: ipv6: Address and prefixes timeout immediately

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1266,7 +1266,7 @@ static void address_lifetime_timeout(struct k_work *work)
 		is_timeout = address_manage_timeout(current, current_time,
 						    &next_timeout);
 		if (!is_timeout) {
-			if (next_timeout < timeout_update) {
+			if ((s32_t)(next_timeout - timeout_update) < 0) {
 				timeout_update = next_timeout;
 				found = true;
 			}
@@ -1826,7 +1826,7 @@ static void prefix_lifetime_timeout(struct k_work *work)
 		is_timeout = prefix_manage_timeout(current, current_time,
 						   &next_timeout);
 		if (!is_timeout) {
-			if (next_timeout < timeout_update) {
+			if ((s32_t)(next_timeout - timeout_update) < 0) {
 				timeout_update = next_timeout;
 				found = true;
 			}


### PR DESCRIPTION
After enabling CONFIG_NET_IF_LOG_LEVEL_DBG=y, I started to see
constant stream of these messages. The system prints two msg
every millisecond.

<dbg> net_if.prefix_lifetime_timeout: Waiting for 2147483547 ms
<dbg> net_if.address_lifetime_timeout: Waiting for 2147483547 ms

Not sure what has changed in the system but refactoring the
check fixes the issue.

Fixes #22732

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>