### PR TITLE
tests: counter: Extend counter_basic_api timeout

### DIFF
--- a/tests/drivers/counter/counter_basic_api/testcase.yaml
+++ b/tests/drivers/counter/counter_basic_api/testcase.yaml
@@ -4,3 +4,4 @@ tests:
     depends_on: counter
     min_ram: 16
     platform_exclude: nucleo_f302r8
+    timeout: 400


### PR DESCRIPTION
Fixes a timeout failure on the frdm_k64f board.

test_short_relative_alarm iterates 100x through a 3 tick loop, but some
platforms like frdm_k64f have a 1 second counter tick period and
therefore need more time to finish this test.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #22626