### PR TITLE
arch: arm: cortex_r: Add CMSIS support

### DIFF
--- a/include/arch/arm/aarch32/cortex_r/cmsis.h
+++ b/include/arch/arm/aarch32/cortex_r/cmsis.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020 Stephanos Ioannidis <root@stephanos.io>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief CMSIS interface file
+ *
+ * This header contains the interface to the ARM CMSIS Core headers.
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_CORTEX_R_CMSIS_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_CORTEX_R_CMSIS_H_
+
+#include <soc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef __CR_REV
+#define __CR_REV                0U
+#endif
+
+#ifndef __FPU_PRESENT
+#define __FPU_PRESENT           CONFIG_CPU_HAS_FPU
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#if defined(CONFIG_CPU_CORTEX_R4)
+#include <core_cr4.h>
+#elif defined(CONFIG_CPU_CORTEX_R5)
+#include <core_cr5.h>
+#else
+#error "Unknown Cortex-R device"
+#endif
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_CORTEX_R_CMSIS_H_ */

--- a/include/arch/arm/aarch32/cortex_r/cpu.h
+++ b/include/arch/arm/aarch32/cortex_r/cpu.h
@@ -31,7 +31,4 @@
 
 #define FPEXC_EN	(1 << 30)
 
-#define __ISB()	__asm__ volatile ("isb sy" : : : "memory")
-#define __DMB()	__asm__ volatile ("dmb sy" : : : "memory")
-
 #endif

--- a/include/arch/arm/aarch32/cortex_r/sys_io.h
+++ b/include/arch/arm/aarch32/cortex_r/sys_io.h
@@ -16,6 +16,7 @@
 
 #include <zephyr/types.h>
 #include <sys/sys_io.h>
+#include <arch/arm/aarch32/cortex_r/cmsis.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/arm/xilinx_zynqmp/soc.c
+++ b/soc/arm/xilinx_zynqmp/soc.c
@@ -8,6 +8,7 @@
 #include <kernel.h>
 #include <device.h>
 #include <init.h>
+#include <arch/arm/aarch32/cortex_r/cmsis.h>
 
 /**
  *
@@ -34,9 +35,8 @@ void z_platform_init(void)
 	/*
 	 * Use normal exception vectors address range (0x0-0x1C).
 	 */
-	__asm__ volatile(
-		"mrc p15, 0, r0, c1, c0, 0;"		/* SCTLR */
-		"bic r0, r0, #" TOSTR(HIVECS) ";"	/* Clear HIVECS */
-		"mcr p15, 0, r0, c1, c0, 0;"
-		: : : "memory");
+	unsigned int sctlr = __get_SCTLR();
+
+	sctlr &= ~SCTLR_V_Msk;
+	__set_SCTLR(sctlr);
 }

--- a/soc/arm/xilinx_zynqmp/soc.h
+++ b/soc/arm/xilinx_zynqmp/soc.h
@@ -8,13 +8,7 @@
 #ifndef _BOARD__H_
 #define _BOARD__H_
 
-#include <sys/util.h>
-
-#ifndef _ASMLANGUAGE
-
-#include <device.h>
-#include <sys/util.h>
-
-#endif /* !_ASMLANGUAGE */
+/* Define CMSIS configurations */
+#define __CR_REV		1U
 
 #endif /* _BOARD__H_ */


### PR DESCRIPTION
```
arch: arm: cortex_r: Add CMSIS support

This commit adds the CMSIS-Core(R) support to the Zephyr RTOS Cortex-R
architecture port.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```

```
soc: arm: xilinx_zynqmp: Use CMSIS-Core(R)

This commit updates the `xilinx_zynqmp` SoC initialisation code to use
the CMSIS-Core(R) features.

In addition, it also defines the Core IP revision value for the SoC as
specified in the Zynq UltraScale+ Device Technical Reference Manual.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```