### PR TITLE
Bluetooth: controller: split: fix HCI read_max_data_len

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1341,8 +1341,8 @@ static void le_read_max_data_len(struct net_buf *buf, struct net_buf **evt)
 
 	rp->max_tx_octets = sys_cpu_to_le16(max_tx_octets);
 	rp->max_tx_time = sys_cpu_to_le16(max_tx_time);
-	rp->max_tx_octets = sys_cpu_to_le16(max_tx_octets);
-	rp->max_tx_time = sys_cpu_to_le16(max_tx_time);
+	rp->max_rx_octets = sys_cpu_to_le16(max_rx_octets);
+	rp->max_rx_time = sys_cpu_to_le16(max_rx_time);
 	rp->status = 0x00;
 }
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */


### PR DESCRIPTION
In the function le_read_max_data_len the rx-component is not set.
This PR fixes this
The problem does not exist in the v1.14-branch

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>