### PR TITLE
drivers: interrupt_controller: stm32: Missing break statement

### DIFF
--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -181,6 +181,7 @@ void stm32_exti_trigger(int line, int trigger)
 	case STM32_EXTI_TRIG_BOTH:
 		LL_EXTI_EnableRisingTrig_0_31(1 << line);
 		LL_EXTI_EnableFallingTrig_0_31(1 << line);
+		break;
 	default:
 		__ASSERT_NO_MSG(trigger);
 	}


### PR DESCRIPTION
Fix missing break statement is missing in switch/case.

Fixes #22646

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>