### PR TITLE
tests: gpio_basic_api: fix filter to exclude boards without overlay

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/testcase.yaml
+++ b/tests/drivers/gpio/gpio_basic_api/testcase.yaml
@@ -4,5 +4,4 @@ tests:
     depends_on: gpio
     harness: console
     min_flash: 34
-    filter: dt_compat_enabled("test,gpio_basic_api") or
-            dt_alias_exists("gpio-0") or dt_alias_exists("gpio-1")
+    filter: dt_compat_enabled("test,gpio_basic_api")


### PR DESCRIPTION
The test case no longer permits inferring input and output pins based
only on the presence of GPIO aliases.  Stop allowing presence of GPIO
aliases to enable the test.

Fixes #22622