### PR TITLE
editorconfig: Set max_line_length to 80

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+max_line_length = 80
 
 # C
 [*.{c,h}]


### PR DESCRIPTION
This way editors like emacs can highlight lines that are too long.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>