### PR TITLE
Bluetooth: Fix gatt db stored twice

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -310,6 +310,12 @@ struct bt_gatt_cpf {
  *  macros such as BT_GATT_PRIMARY_SERVICE, BT_GATT_CHARACTERISTIC,
  *  BT_GATT_DESCRIPTOR, etc.
  *
+ *  When using :option:`CONFIG_BT_GATT_CACHING` and :option:`CONFIG_BT_SETTINGS`
+ *  then all services that should be included in the GATT Database Hash
+ *  calculation should be added before calling @ref settings_load.
+ *  All services registered after settings_load will trigger a new database hash
+ *  calculation and a new hash stored.
+ *
  *  @param svc Service containing the available attributes
  *
  *  @return 0 in case of success or negative value in case of error.

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -597,6 +597,13 @@ static void db_hash_store(void)
 	BT_DBG("Database Hash stored");
 }
 
+/* Once the db_hash work has started we cannot cancel it anymore, so the
+ * assumption is made that the in-progress work cannot be pre-empted.
+ * This assumption should hold as long as calculation does not make any calls
+ * that would make it unready.
+ * If this assumption is no longer true we will have to solve the case where
+ * k_delayed_work_cancel failed because the work was in-progress but pre-empted.
+ */
 static void db_hash_gen(bool store)
 {
 	u8_t key[16] = {};
@@ -640,11 +647,13 @@ static ssize_t db_hash_read(struct bt_conn *conn,
 			    const struct bt_gatt_attr *attr,
 			    void *buf, u16_t len, u16_t offset)
 {
+	int err;
+
 	/* Check if db_hash is already pending in which case it shall be
-	 * generated immediately instead of waiting the work to complete.
+	 * generated immediately instead of waiting for the work to complete.
 	 */
-	if (k_delayed_work_remaining_get(&db_hash_work)) {
-		k_delayed_work_cancel(&db_hash_work);
+	err = k_delayed_work_cancel(&db_hash_work);
+	if (!err) {
 		db_hash_gen(true);
 	}
 
@@ -4439,9 +4448,11 @@ static int db_hash_set(const char *name, size_t len_rd,
 
 static int db_hash_commit(void)
 {
+	int err;
+
 	/* Stop work and generate the hash */
-	if (k_delayed_work_remaining_get(&db_hash_work)) {
-		k_delayed_work_cancel(&db_hash_work);
+	err = k_delayed_work_cancel(&db_hash_work);
+	if (!err) {
 		db_hash_gen(false);
 	}
 


### PR DESCRIPTION
Fix issue where an invalid (all zeroes) hash was written to settings
storage on reset. This caused the old value to written to zeroes, before
being written back to it's original value again immediately after.
This causes excessive flash wear.

This happens because the check if (k_delayed_work_remaining) returns the
amount of time until the work will execute. When that time has run out
the time is zero, but the work has not yet been executed.
We then write the invalid hash to flash, and then once the work-item
executes it will write the correct value.

@Vudentz @jhedberg
I have documented the behaviour with bt_gatt_service_register and settings_load.
At least that is how it works currently.
I'm not sure if this is the behaviour we wanted or not. @Vudentz Was this intentional or not? Is it documented somewhere else?

If it is not the behaviour we want then we should probably change, but maybe that change could wait until after the release?

Fixes: #22730