### PR TITLE
drivers: can: loopback: Use thread to send frames.

### DIFF
--- a/drivers/can/Kconfig.loopback
+++ b/drivers/can/Kconfig.loopback
@@ -18,10 +18,35 @@ config CAN_LOOPBACK_DEV_NAME
 
 config CAN_MAX_FILTER
 	int "Maximum number of concurrent active filters"
-	default 5
+	default 16
 	range 1 1024
 	help
 	  Defines the array size of the filters.
 	  Must be at least the size of concurrent reads.
+
+config CAN_LOOPBACK_TX_THREAD_STACK_SIZE
+	int "TX thread stack size"
+	default 256
+	help
+	  Stack size of the TX thread.
+	  The TX thread calls the callbacks of the receiver
+	  if the filter matches.
+
+config CAN_LOOPBACK_TX_THREAD_PRIORITY
+	int "TX thread priority"
+	default 2
+	help
+	  Priority of the TX thread.
+	  The TX thread calls the callbacks of the receiver
+	  if the filter matches.
+
+config CAN_LOOPBACK_TX_MSGQ_SIZE
+	int "TX message queue size"
+	default 16
+	help
+	  Number of TX frames that can be buffered.
+	  The send functions puts frame int this queue and TX thread takes the
+	  messages from this msgq and calls the respective receiver if the
+	  filter matches.
 
 endif # CAN_LOOPBACK


### PR DESCRIPTION
The loopback driver is a simple driver that can be used to test CAN subsystems.
The actual implementation sends frames in the same thread that calls the send function.
Some libraries have problems with that behavior.
This PR implements a dedicated thread that calls the callback for the receiving functions and a msgq in between the sender and the TX thread.