### PR TITLE
dts: fix up type comments in binding-template.yaml

### DIFF
--- a/dts/binding-template.yaml
+++ b/dts/binding-template.yaml
@@ -89,7 +89,7 @@ on-bus: <string describing bus type, e.g. "i2c">
 #   <property name>:
 #     required: <true | false>
 #     type: <string | int | boolean | array | uint8-array | string-array |
-#            phandle | phandles | phandle-array | compound>
+#            phandle | phandles | phandle-array | path | compound>
 #     description: <description of the property>
 #     enum:
 #       - <item1>
@@ -101,33 +101,14 @@ on-bus: <string describing bus type, e.g. "i2c">
 #
 # These types are available:
 #
-#   - 'type: int' is for properties that are assigned a single 32-bit value,
-#     like
-#
-#         frequency = <100>;
-#
-#   - 'type: array' is for properties that are assigned zero or more 32-bit
-#     values, like
-#
-#         pin-config = <1 2 3>;
-#
-#   - 'type: uint8-array' is for properties that are assigned zero or more
-#     bytes with the [] syntax, like
-#
-#         lookup-table = [89 AB CD EF];
-#
-#     Each byte is given in hex.
-#
-#     This type is called 'bytestring' in the Devicetree specification.
-#
 #   - 'type: string' is for properties that are assigned a single string, like
 #
 #         ident = "foo";
 #
-#   - 'type: string-array' if for properties that are assigned zero or more
-#     strings, like
+#   - 'type: int' is for properties that are assigned a single 32-bit value,
+#     like
 #
-#         idents = "foo", "bar", "baz";
+#         frequency = <100>;
 #
 #   - 'type: boolean' is for properties used as flags that don't take a value,
 #     like
@@ -143,6 +124,25 @@ on-bus: <string describing bus type, e.g. "i2c">
 #     properties, don't use #ifdef in tests. Do this instead:
 #
 #         #if DT_SOME_BOOLEAN_PROP == 1
+#
+#   - 'type: array' is for properties that are assigned zero or more 32-bit
+#     values, like
+#
+#         pin-config = <1 2 3>;
+#
+#   - 'type: uint8-array' is for properties that are assigned zero or more
+#     bytes with the [] syntax, like
+#
+#         lookup-table = [89 AB CD EF];
+#
+#     Each byte is given in hex.
+#
+#     This type is called 'bytestring' in the Devicetree specification.
+#
+#   - 'type: string-array' if for properties that are assigned zero or more
+#     strings, like
+#
+#         idents = "foo", "bar", "baz";
 #
 #   - 'type: phandle' is for properties that are assigned a single phandle,
 #     like


### PR DESCRIPTION
@galak I'm targeting master since this is a documentation fix, as this file is included in the [devicetree docs page](https://docs.zephyrproject.org/latest/guides/dts/index.html#devicetree-bindings)

List the details for each type in the order they appear in the summary
of all types. Add the missing 'path' value to the summary.
