### PR TITLE
x86: fix large Kconfig values on 64-bit

### DIFF
--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -398,7 +398,14 @@ do {                                                                    \
 		",%B0"                              \
 		"\n\t.type\t" #name ",%%object" :  : "n"(~(value)))
 
-#elif defined(CONFIG_X86) || defined(CONFIG_ARC) || defined(CONFIG_ARM64)
+#elif defined(CONFIG_X86)
+
+#define GEN_ABSOLUTE_SYM(name, value)               \
+	__asm__(".globl\t" #name "\n\t.equ\t" #name \
+		",%p0"                              \
+		"\n\t.type\t" #name ",@object" :  : "n"(value))
+
+#elif defined(CONFIG_ARC) || defined(CONFIG_ARM64)
 
 #define GEN_ABSOLUTE_SYM(name, value)               \
 	__asm__(".globl\t" #name "\n\t.equ\t" #name \


### PR DESCRIPTION
Use the special x86 operand modifier 'p' to print the raw value.
This fixes an issue on x86-64 where errors were generated
if a constant larger than INT_MAX was used.

Values larger than UINT_MAX are still unsupported (on any arch).

Fixes: #22542

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>