### PR TITLE
samples: arc_secure_services: fix sample.yaml

### DIFF
--- a/samples/boards/arc_secure_services/sample.yaml
+++ b/samples/boards/arc_secure_services/sample.yaml
@@ -4,6 +4,8 @@ sample:
   name: Designware ARC Secure monitor
 tests:
   sample.board.arc_secure_services:
+    # Requires multiple kernels in an AMP config. See README.rst
+    build_only: true
     platform_whitelist: nsim_sem em_starterkit_em7d_secure
     tags: secure
     harness: console


### PR DESCRIPTION
This test can't be evaluated with sanitycheck, it
requires special set-up on multiple AMP cores to
function properly. Add build_only tag.

Fixes: #19643
Fixes: #22317

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>