### PR TITLE
usb: stm32: added usb_dc_detach code

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -846,8 +846,9 @@ int usb_dc_ep_mps(const u8_t ep)
 
 int usb_dc_detach(void)
 {
-	LOG_ERR("Not implemented");
-
+	HAL_PCD_DeInit(&usb_dc_stm32_state.pcd);
+	HAL_PCD_EP_Close(&usb_dc_stm32_state.pcd, EP0_IN);
+	HAL_PCD_EP_Close(&usb_dc_stm32_state.pcd, EP0_OUT);
 	return 0;
 }
 


### PR DESCRIPTION
The usb device is now deinit. The stoping happens
inside the deinit function call. As well the
endpoints are getting closed.

After deinit the usb periphal wil go to deepsleep.
That might save some power.

Signed-off-by: Stefan Jaritz <stefan@kokoontech.com>