### PR TITLE
scripts: gen_defines.py: Add support for phandle(s)

### DIFF
--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -8,6 +8,12 @@
 #ifndef DEVICETREE_H
 #define DEVICETREE_H
 
+/* concatenate the values of the arguments into one */
+#define _DT_PHANDLE_GET_PROP(phandle, prop) phandle ## _ ## prop
+
+/* Given a phandle define and a property name get back the actual value */
+#define DT_PHANDLE_GET_PROP(phandle, prop) _DT_PHANDLE_GET_PROP(phandle, prop)
+
 #include <devicetree_unfixed.h>
 #include <devicetree_fixups.h>
 

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -242,6 +242,19 @@ def write_props(node):
         elif prop.type == "uint8-array":
             out_node_init(node, ident,
                           [f"0x{b:02x}" for b in prop.val])
+        elif prop.type == "phandle":
+            # Generates a define that gives the canonical prefix of
+            # the node pointed to by the phandle.  This can be used with
+            # some preprocessor magic to access all the properties of the
+            # node pointed to by the phandle:
+            #
+            # #define DT_...<PROP> DT_<IDENT of phandle node>
+            out_node(node, ident, "DT_" + node_ident(prop.val))
+        elif prop.type == "phandles":
+            # similar to 'phandle' except for it being an array so we
+            # postfix the property name with the index number
+            for i, val in enumerate(prop.val):
+                out_node(node, f"{ident}_{i}", "DT_" + node_ident(val))
         else:  # prop.type == "phandle-array"
             write_phandle_val_list(prop)
 
@@ -265,7 +278,7 @@ def should_write(prop):
 
     # For these, Property.val becomes an edtlib.Node, a list of edtlib.Nodes,
     # or None. Nothing is generated for them at the moment.
-    if prop.type in {"phandle", "phandles", "path", "compound"}:
+    if prop.type in {"path", "compound"}:
         return False
 
     # Skip properties that we handle elsewhere


### PR DESCRIPTION
Generate a 'define' alias for phandle(s):

```
#define DT_<IDENT>_<PROP_NAME> DT_IDENT(phandle)
```

For example:

```
port = <&pinmux_a>;
ports = <&pinmux_a &pinmux_b>;
```

This would generate something like:

```
#define DT_GPIO_400FF000_PORT DT_PINMUX_40049000
```

For phandles we generate a set of defines:

```
#define DT_<IDENT>_<PROP_NAME>_<n> DT_IDENT(phandle(n))
```

This would generate something like:

```
#define DT_GPIO_400FF000_PORTS_0 DT_PINMUX_40049000
#define DT_GPIO_400FF000_PORTS_1 DT_PINMUX_4004a000
```