### PR TITLE
Convert Kinetis GPIO driver to DT_INST defines

### DIFF
--- a/boards/arm/frdm_k22f/Kconfig.defconfig
+++ b/boards/arm/frdm_k22f/Kconfig.defconfig
@@ -39,25 +39,6 @@ config PINMUX_MCUX_PORTE
 
 endif # PINMUX_MCUX
 
-if GPIO_MCUX
-
-config GPIO_MCUX_PORTA
-	default y
-
-config GPIO_MCUX_PORTB
-	default y
-
-config GPIO_MCUX_PORTC
-	default y
-
-config GPIO_MCUX_PORTD
-	default y
-
-config GPIO_MCUX_PORTE
-	default y
-
-endif # GPIO_MCUX
-
 config I2C_0
 	default y
 	depends on I2C

--- a/boards/arm/frdm_k22f/frdm_k22f.dts
+++ b/boards/arm/frdm_k22f/frdm_k22f.dts
@@ -122,6 +122,26 @@ arduino_spi: &spi0 {
 	num-bidir-endpoints = <8>;
 };
 
+&gpioa {
+	status = "okay";
+};
+
+&gpiob {
+	status = "okay";
+};
+
+&gpioc {
+	status = "okay";
+};
+
+&gpiod {
+	status = "okay";
+};
+
+&gpioe {
+	status = "okay";
+};
+
 &flash0 {
 	/*
 	 * For more information, see:

--- a/boards/arm/frdm_k64f/Kconfig.defconfig
+++ b/boards/arm/frdm_k64f/Kconfig.defconfig
@@ -39,25 +39,6 @@ config PINMUX_MCUX_PORTE
 
 endif # PINMUX_MCUX
 
-if GPIO_MCUX
-
-config GPIO_MCUX_PORTA
-	default y
-
-config GPIO_MCUX_PORTB
-	default y
-
-config GPIO_MCUX_PORTC
-	default y
-
-config GPIO_MCUX_PORTD
-	default y
-
-config GPIO_MCUX_PORTE
-	default y
-
-endif # GPIO_MCUX
-
 config I2C_0
 	default y
 	depends on I2C

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -139,6 +139,26 @@ arduino_spi: &spi0 {
 	num-bidir-endpoints = <8>;
 };
 
+&gpioa {
+	status = "okay";
+};
+
+&gpiob {
+	status = "okay";
+};
+
+&gpioc {
+	status = "okay";
+};
+
+&gpiod {
+	status = "okay";
+};
+
+&gpioe {
+	status = "okay";
+};
+
 &flash0 {
 	/*
 	 * For more information, see:

--- a/boards/arm/frdm_k82f/Kconfig.defconfig
+++ b/boards/arm/frdm_k82f/Kconfig.defconfig
@@ -34,25 +34,6 @@ config FXOS8700_DRDY_INT1
 	default y
 	depends on FXOS8700
 
-if GPIO_MCUX
-
-config GPIO_MCUX_PORTA
-	default y
-
-config GPIO_MCUX_PORTB
-	default y
-
-config GPIO_MCUX_PORTC
-	default y
-
-config GPIO_MCUX_PORTD
-	default y
-
-config GPIO_MCUX_PORTE
-	default y
-
-endif # GPIO_MCUX
-
 config I2C_3
 	default y
 	depends on I2C

--- a/boards/arm/frdm_k82f/frdm_k82f.dts
+++ b/boards/arm/frdm_k82f/frdm_k82f.dts
@@ -106,6 +106,26 @@
 	};
 };
 
+&gpioa {
+	status = "okay";
+};
+
+&gpiob {
+	status = "okay";
+};
+
+&gpioc {
+	status = "okay";
+};
+
+&gpiod {
+	status = "okay";
+};
+
+&gpioe {
+	status = "okay";
+};
+
 &flash0 {
 	/*
 	 * For more information, see:

--- a/boards/arm/frdm_kl25z/Kconfig.defconfig
+++ b/boards/arm/frdm_kl25z/Kconfig.defconfig
@@ -42,25 +42,6 @@ config PINMUX_MCUX_PORTE
 
 endif # PINMUX_MCUX
 
-if GPIO_MCUX
-
-config GPIO_MCUX_PORTA
-	default y
-
-config GPIO_MCUX_PORTB
-	default y
-
-config GPIO_MCUX_PORTC
-	default n
-
-config GPIO_MCUX_PORTD
-	default y
-
-config GPIO_MCUX_PORTE
-	default n
-
-endif # GPIO_MCUX
-
 config UART_MCUX_LPSCI_0
 	default y if UART_CONSOLE
 	depends on UART_MCUX_LPSCI

--- a/boards/arm/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.dts
@@ -105,6 +105,18 @@
 	current-speed = <115200>;
 };
 
+&gpioa {
+	status = "okay";
+};
+
+&gpiob {
+	status = "okay";
+};
+
+&gpiod {
+	status = "okay";
+};
+
 &usbotg {
 	compatible = "nxp,kinetis-usbd";
 	status = "okay";

--- a/boards/arm/frdm_kw41z/Kconfig.defconfig
+++ b/boards/arm/frdm_kw41z/Kconfig.defconfig
@@ -30,19 +30,6 @@ config PINMUX_MCUX_PORTC
 
 endif # PINMUX_MCUX
 
-if GPIO_MCUX
-
-config GPIO_MCUX_PORTA
-	default y
-
-config GPIO_MCUX_PORTB
-	default n
-
-config GPIO_MCUX_PORTC
-	default y
-
-endif # GPIO_MCUX
-
 config I2C_1
 	default y
 	depends on I2C

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -99,3 +99,11 @@
 	status = "okay";
 	current-speed = <115200>;
 };
+
+&gpioa {
+	status = "okay";
+};
+
+&gpioc {
+	status = "okay";
+};

--- a/boards/arm/hexiwear_k64/Kconfig.defconfig
+++ b/boards/arm/hexiwear_k64/Kconfig.defconfig
@@ -39,25 +39,6 @@ config PINMUX_MCUX_PORTE
 
 endif # PINMUX_MCUX
 
-if GPIO_MCUX
-
-config GPIO_MCUX_PORTA
-	default y if MAX30101
-
-config GPIO_MCUX_PORTB
-	default y
-
-config GPIO_MCUX_PORTC
-	default y
-
-config GPIO_MCUX_PORTD
-	default y
-
-config GPIO_MCUX_PORTE
-	default y
-
-endif # GPIO_MCUX
-
 if I2C
 
 config I2C_0

--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -79,6 +79,7 @@
 	status = "okay";
 
 	max30101@57 {
+		status = "disabled";
 		compatible = "max,max30101";
 		reg = <0x57>;
 		label = "MAX30101";
@@ -113,6 +114,22 @@
 &uart4 {
 	status = "okay";
 	current-speed = <115200>;
+};
+
+&gpiob {
+	status = "okay";
+};
+
+&gpioc {
+	status = "okay";
+};
+
+&gpiod {
+	status = "okay";
+};
+
+&gpioe {
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/arm/hexiwear_k64/pinmux.c
+++ b/boards/arm/hexiwear_k64/pinmux.c
@@ -13,10 +13,6 @@ static int hexiwear_k64_pinmux_init(struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-#ifdef CONFIG_PINMUX_MCUX_PORTA
-	struct device *porta =
-		device_get_binding(CONFIG_PINMUX_MCUX_PORTA_NAME);
-#endif
 #ifdef CONFIG_PINMUX_MCUX_PORTB
 	struct device *portb =
 		device_get_binding(CONFIG_PINMUX_MCUX_PORTB_NAME);
@@ -87,7 +83,10 @@ static int hexiwear_k64_pinmux_init(struct device *dev)
 	pinmux_pin_set(porte, 25, PORT_PCR_MUX(kPORT_MuxAlt3));
 #endif
 
-#ifdef CONFIG_MAX30101
+#if defined(CONFIG_MAX30101) && DT_HAS_NODE(DT_NODELABEL(gpioa))
+	struct device *porta =
+		device_get_binding(CONFIG_PINMUX_MCUX_PORTA_NAME);
+
 	/* LDO - MAX30101 power supply */
 	pinmux_pin_set(porta, 29, PORT_PCR_MUX(kPORT_MuxAsGpio));
 

--- a/boards/arm/hexiwear_kw40z/Kconfig.defconfig
+++ b/boards/arm/hexiwear_kw40z/Kconfig.defconfig
@@ -30,19 +30,6 @@ config PINMUX_MCUX_PORTC
 
 endif # PINMUX_MCUX
 
-if GPIO_MCUX
-
-config GPIO_MCUX_PORTA
-	default y
-
-config GPIO_MCUX_PORTB
-	default n
-
-config GPIO_MCUX_PORTC
-	default y if "$(dt_nodelabel_enabled,lpuart0)" || "$(dt_nodelabel_enabled,i2c1)"
-
-endif # GPIO_MCUX
-
 config I2C_1
 	default y
 	depends on I2C

--- a/boards/arm/hexiwear_kw40z/hexiwear_kw40z.dts
+++ b/boards/arm/hexiwear_kw40z/hexiwear_kw40z.dts
@@ -26,3 +26,11 @@
 	status = "okay";
 	current-speed = <115200>;
 };
+
+&gpioa {
+	status = "okay";
+};
+
+&gpioc {
+	status = "okay";
+};

--- a/boards/arm/ip_k66f/Kconfig.defconfig
+++ b/boards/arm/ip_k66f/Kconfig.defconfig
@@ -30,14 +30,4 @@ config PINMUX_MCUX_PORTB
 
 endif # PINMUX_MCUX
 
-if GPIO_MCUX
-
-config GPIO_MCUX_PORTA
-	default y
-
-config GPIO_MCUX_PORTB
-	default y
-
-endif # GPIO_MCUX
-
 endif # BOARD_IP_K66F

--- a/boards/arm/ip_k66f/ip_k66f.dts
+++ b/boards/arm/ip_k66f/ip_k66f.dts
@@ -41,6 +41,14 @@
 	clock-frequency = <120000000>;
 };
 
+&gpioa {
+	status = "okay";
+};
+
+&gpiob {
+	status = "okay";
+};
+
 &flash0 {
 	/*
 	 * For more information, see:

--- a/boards/arm/twr_ke18f/Kconfig.defconfig
+++ b/boards/arm/twr_ke18f/Kconfig.defconfig
@@ -51,25 +51,6 @@ config PINMUX_MCUX_PORTE
 
 endif # PINMUX_MCUX
 
-if GPIO_MCUX
-
-config GPIO_MCUX_PORTA
-	default y
-
-config GPIO_MCUX_PORTB
-	default y
-
-config GPIO_MCUX_PORTC
-	default y
-
-config GPIO_MCUX_PORTD
-	default y
-
-config GPIO_MCUX_PORTE
-	default y
-
-endif # GPIO_MCUX
-
 config ADC_0
 	default y
 	depends on ADC

--- a/boards/arm/twr_ke18f/twr_ke18f.dts
+++ b/boards/arm/twr_ke18f/twr_ke18f.dts
@@ -205,6 +205,26 @@
 	bus-speed = <125000>;
 };
 
+&gpioa {
+	status = "okay";
+};
+
+&gpiob {
+	status = "okay";
+};
+
+&gpioc {
+	status = "okay";
+};
+
+&gpiod {
+	status = "okay";
+};
+
+&gpioe {
+	status = "okay";
+};
+
 &flash0 {
 	/*
 	 * For more information, see:

--- a/boards/arm/twr_kv58f220m/Kconfig.defconfig
+++ b/boards/arm/twr_kv58f220m/Kconfig.defconfig
@@ -20,25 +20,6 @@ config MCG_VDIV0
 config MCG_FCRDIV
 	default 1
 
-if GPIO_MCUX
-
-config GPIO_MCUX_PORTA
-	default y
-
-config GPIO_MCUX_PORTB
-	default y
-
-config GPIO_MCUX_PORTC
-	default y
-
-config GPIO_MCUX_PORTD
-	default y
-
-config GPIO_MCUX_PORTE
-	default y
-
-endif # GPIO_MCUX
-
 config I2C_1
 	default y
 	depends on I2C

--- a/boards/arm/twr_kv58f220m/twr_kv58f220m.dts
+++ b/boards/arm/twr_kv58f220m/twr_kv58f220m.dts
@@ -73,6 +73,26 @@
 	};
 };
 
+&gpioa {
+	status = "okay";
+};
+
+&gpiob {
+	status = "okay";
+};
+
+&gpioc {
+	status = "okay";
+};
+
+&gpiod {
+	status = "okay";
+};
+
+&gpioe {
+	status = "okay";
+};
+
 &flash0 {
 	/*
 	 * For more information, see:

--- a/boards/arm/usb_kw24d512/Kconfig.defconfig
+++ b/boards/arm/usb_kw24d512/Kconfig.defconfig
@@ -40,25 +40,6 @@ config PINMUX_MCUX_PORTD
 
 endif # PINMUX_MCUX
 
-if GPIO_MCUX
-
-config GPIO_MCUX_PORTA
-	default y
-
-config GPIO_MCUX_PORTB
-	default y
-
-config GPIO_MCUX_PORTC
-	default y
-
-config GPIO_MCUX_PORTD
-	default y
-
-config GPIO_MCUX_PORTE
-	default y
-
-endif # GPIO_MCUX
-
 if I2C
 
 config I2C_0

--- a/boards/arm/usb_kw24d512/usb_kw24d512.dts
+++ b/boards/arm/usb_kw24d512/usb_kw24d512.dts
@@ -69,3 +69,23 @@
 	status = "okay";
 	num-bidir-endpoints = <8>;
 };
+
+&gpioa {
+	status = "okay";
+};
+
+&gpiob {
+	status = "okay";
+};
+
+&gpioc {
+	status = "okay";
+};
+
+&gpiod {
+	status = "okay";
+};
+
+&gpioe {
+	status = "okay";
+};

--- a/drivers/gpio/Kconfig.mcux
+++ b/drivers/gpio/Kconfig.mcux
@@ -4,42 +4,8 @@
 # Copyright (c) 2017, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig GPIO_MCUX
+config GPIO_MCUX
 	bool "MCUX GPIO driver"
 	select HAS_DTS_GPIO
 	help
 	  Enable the MCUX pinmux driver.
-
-if GPIO_MCUX
-
-config GPIO_MCUX_PORTA
-	bool "Port A"
-	depends on PINMUX_MCUX_PORTA
-	help
-	  Enable Port A.
-
-config GPIO_MCUX_PORTB
-	bool "Port B"
-	depends on PINMUX_MCUX_PORTB
-	help
-	  Enable Port B.
-
-config GPIO_MCUX_PORTC
-	bool "Port C"
-	depends on PINMUX_MCUX_PORTC
-	help
-	  Enable Port C.
-
-config GPIO_MCUX_PORTD
-	bool "Port D"
-	depends on PINMUX_MCUX_PORTD
-	help
-	  Enable Port D.
-
-config GPIO_MCUX_PORTE
-	bool "Port E"
-	depends on PINMUX_MCUX_PORTE
-	help
-	  Enable Port E.
-
-endif # GPIO_MCUX

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -277,182 +277,45 @@ static const struct gpio_driver_api gpio_mcux_driver_api = {
 	.disable_callback = gpio_mcux_disable_callback,
 };
 
-#ifdef CONFIG_GPIO_MCUX_PORTA
-static int gpio_mcux_porta_init(struct device *dev);
+#define GPIO_MCUX_IRQ_INIT(n)						\
+	do {								\
+		IRQ_CONNECT(DT_INST_IRQN(n),				\
+			    DT_INST_IRQ(n, priority),			\
+			    gpio_mcux_port_isr,				\
+			    DEVICE_GET(gpio_mcux_port##n), 0);		\
+									\
+		irq_enable(DT_INST_IRQN(n));				\
+	} while (0)
 
-static const struct gpio_mcux_config gpio_mcux_porta_config = {
-	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(0),
-	},
-	.gpio_base = (GPIO_Type *) DT_NXP_KINETIS_GPIO_GPIO_A_BASE_ADDRESS,
-	.port_base = PORTA,
-#ifdef DT_NXP_KINETIS_GPIO_GPIO_A_IRQ_0
-	.flags = GPIO_INT_ENABLE,
-#else
-	.flags = 0,
-#endif
-};
+#define GPIO_PORT_BASE_ADDR(n) DT_REG_ADDR(DT_INST_PHANDLE(n, nxp_kinetis_port))
 
-static struct gpio_mcux_data gpio_mcux_porta_data;
+#define GPIO_DEVICE_INIT_MCUX(n)					\
+	static int gpio_mcux_port## n ## _init(struct device *dev);	\
+									\
+	static const struct gpio_mcux_config gpio_mcux_port## n ## _config = {\
+		.common = {						\
+			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),\
+		},							\
+		.gpio_base = (GPIO_Type *) DT_INST_REG_ADDR(n),		\
+		.port_base = (PORT_Type *) GPIO_PORT_BASE_ADDR(n),	\
+		.flags = UTIL_AND(DT_INST_IRQ_HAS_IDX(n, 0), GPIO_INT_ENABLE),\
+	};								\
+									\
+	static struct gpio_mcux_data gpio_mcux_port## n ##_data;	\
+									\
+	DEVICE_AND_API_INIT(gpio_mcux_port## n, DT_INST_LABEL(n),	\
+			    gpio_mcux_port## n ##_init,			\
+			    &gpio_mcux_port## n ##_data,		\
+			    &gpio_mcux_port## n##_config,		\
+			    POST_KERNEL,				\
+			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
+			    &gpio_mcux_driver_api);			\
+									\
+	static int gpio_mcux_port## n ##_init(struct device *dev)	\
+	{								\
+		IF_ENABLED(DT_INST_IRQ_HAS_IDX(n, 0),			\
+			(GPIO_MCUX_IRQ_INIT(n);))			\
+		return 0;						\
+	}
 
-DEVICE_AND_API_INIT(gpio_mcux_porta, DT_NXP_KINETIS_GPIO_GPIO_A_LABEL,
-		    gpio_mcux_porta_init,
-		    &gpio_mcux_porta_data, &gpio_mcux_porta_config,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
-		    &gpio_mcux_driver_api);
-
-static int gpio_mcux_porta_init(struct device *dev)
-{
-#ifdef DT_NXP_KINETIS_GPIO_GPIO_A_IRQ_0
-	IRQ_CONNECT(DT_NXP_KINETIS_GPIO_GPIO_A_IRQ_0, DT_NXP_KINETIS_GPIO_GPIO_A_IRQ_0_PRIORITY,
-		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_porta), 0);
-
-	irq_enable(DT_NXP_KINETIS_GPIO_GPIO_A_IRQ_0);
-#endif
-	return 0;
-}
-#endif /* CONFIG_GPIO_MCUX_PORTA */
-
-#ifdef CONFIG_GPIO_MCUX_PORTB
-static int gpio_mcux_portb_init(struct device *dev);
-
-static const struct gpio_mcux_config gpio_mcux_portb_config = {
-	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(1),
-	},
-	.gpio_base = (GPIO_Type *) DT_NXP_KINETIS_GPIO_GPIO_B_BASE_ADDRESS,
-	.port_base = PORTB,
-#ifdef DT_NXP_KINETIS_GPIO_GPIO_B_IRQ_0
-	.flags = GPIO_INT_ENABLE,
-#else
-	.flags = 0,
-#endif
-};
-
-static struct gpio_mcux_data gpio_mcux_portb_data;
-
-DEVICE_AND_API_INIT(gpio_mcux_portb, DT_NXP_KINETIS_GPIO_GPIO_B_LABEL,
-		    gpio_mcux_portb_init,
-		    &gpio_mcux_portb_data, &gpio_mcux_portb_config,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
-		    &gpio_mcux_driver_api);
-
-static int gpio_mcux_portb_init(struct device *dev)
-{
-#ifdef DT_NXP_KINETIS_GPIO_GPIO_B_IRQ_0
-	IRQ_CONNECT(DT_NXP_KINETIS_GPIO_GPIO_B_IRQ_0, DT_NXP_KINETIS_GPIO_GPIO_B_IRQ_0_PRIORITY,
-		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_portb), 0);
-
-	irq_enable(DT_NXP_KINETIS_GPIO_GPIO_B_IRQ_0);
-#endif
-	return 0;
-}
-#endif /* CONFIG_GPIO_MCUX_PORTB */
-
-#ifdef CONFIG_GPIO_MCUX_PORTC
-static int gpio_mcux_portc_init(struct device *dev);
-
-static const struct gpio_mcux_config gpio_mcux_portc_config = {
-	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(2),
-	},
-	.gpio_base = (GPIO_Type *) DT_NXP_KINETIS_GPIO_GPIO_C_BASE_ADDRESS,
-	.port_base = PORTC,
-#ifdef DT_NXP_KINETIS_GPIO_GPIO_C_IRQ_0
-	.flags = GPIO_INT_ENABLE,
-#else
-	.flags = 0,
-#endif
-};
-
-static struct gpio_mcux_data gpio_mcux_portc_data;
-
-DEVICE_AND_API_INIT(gpio_mcux_portc, DT_NXP_KINETIS_GPIO_GPIO_C_LABEL,
-		    gpio_mcux_portc_init,
-		    &gpio_mcux_portc_data, &gpio_mcux_portc_config,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
-		    &gpio_mcux_driver_api);
-
-static int gpio_mcux_portc_init(struct device *dev)
-{
-#ifdef DT_NXP_KINETIS_GPIO_GPIO_C_IRQ_0
-	IRQ_CONNECT(DT_NXP_KINETIS_GPIO_GPIO_C_IRQ_0, DT_NXP_KINETIS_GPIO_GPIO_C_IRQ_0_PRIORITY,
-		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_portc), 0);
-
-	irq_enable(DT_NXP_KINETIS_GPIO_GPIO_C_IRQ_0);
-#endif
-	return 0;
-}
-#endif /* CONFIG_GPIO_MCUX_PORTC */
-
-#ifdef CONFIG_GPIO_MCUX_PORTD
-static int gpio_mcux_portd_init(struct device *dev);
-
-static const struct gpio_mcux_config gpio_mcux_portd_config = {
-	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(3),
-	},
-	.gpio_base = (GPIO_Type *) DT_NXP_KINETIS_GPIO_GPIO_D_BASE_ADDRESS,
-	.port_base = PORTD,
-#ifdef DT_NXP_KINETIS_GPIO_GPIO_D_IRQ_0
-	.flags = GPIO_INT_ENABLE,
-#else
-	.flags = 0,
-#endif
-};
-
-static struct gpio_mcux_data gpio_mcux_portd_data;
-
-DEVICE_AND_API_INIT(gpio_mcux_portd, DT_NXP_KINETIS_GPIO_GPIO_D_LABEL,
-		    gpio_mcux_portd_init,
-		    &gpio_mcux_portd_data, &gpio_mcux_portd_config,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
-		    &gpio_mcux_driver_api);
-
-static int gpio_mcux_portd_init(struct device *dev)
-{
-#ifdef DT_NXP_KINETIS_GPIO_GPIO_D_IRQ_0
-	IRQ_CONNECT(DT_NXP_KINETIS_GPIO_GPIO_D_IRQ_0, DT_NXP_KINETIS_GPIO_GPIO_D_IRQ_0_PRIORITY,
-		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_portd), 0);
-
-	irq_enable(DT_NXP_KINETIS_GPIO_GPIO_D_IRQ_0);
-#endif
-	return 0;
-}
-#endif /* CONFIG_GPIO_MCUX_PORTD */
-
-#ifdef CONFIG_GPIO_MCUX_PORTE
-static int gpio_mcux_porte_init(struct device *dev);
-
-static const struct gpio_mcux_config gpio_mcux_porte_config = {
-	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(4),
-	},
-	.gpio_base = (GPIO_Type *) DT_NXP_KINETIS_GPIO_GPIO_E_BASE_ADDRESS,
-	.port_base = PORTE,
-#ifdef DT_NXP_KINETIS_GPIO_GPIO_E_IRQ_0
-	.flags = GPIO_INT_ENABLE,
-#else
-	.flags = 0,
-#endif
-};
-
-static struct gpio_mcux_data gpio_mcux_porte_data;
-
-DEVICE_AND_API_INIT(gpio_mcux_porte, DT_NXP_KINETIS_GPIO_GPIO_E_LABEL,
-		    gpio_mcux_porte_init,
-		    &gpio_mcux_porte_data, &gpio_mcux_porte_config,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
-		    &gpio_mcux_driver_api);
-
-static int gpio_mcux_porte_init(struct device *dev)
-{
-#ifdef DT_NXP_KINETIS_GPIO_GPIO_E_IRQ_0
-	IRQ_CONNECT(DT_NXP_KINETIS_GPIO_GPIO_E_IRQ_0, DT_NXP_KINETIS_GPIO_GPIO_E_IRQ_0_PRIORITY,
-		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_porte), 0);
-
-	irq_enable(DT_NXP_KINETIS_GPIO_GPIO_E_IRQ_0);
-#endif
-	return 0;
-}
-#endif /* CONFIG_GPIO_MCUX_PORTE */
+DT_INST_FOREACH(GPIO_DEVICE_INIT_MCUX)

--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -17,11 +17,6 @@
 
 	aliases {
 		adc-0 = &adc0;
-		gpio-a = &gpioa;
-		gpio-b = &gpiob;
-		gpio-c = &gpioc;
-		gpio-d = &gpiod;
-		gpio-e = &gpioe;
 		i2c-0 = &i2c0;
 		i2c-1 = &i2c1;
 		pinmux-a = &porta;
@@ -230,6 +225,7 @@
 
 		gpioa: gpio@400ff000 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff000 0x40>;
 			interrupts = <59 2>;
 			label = "GPIO_0";
@@ -240,6 +236,7 @@
 
 		gpiob: gpio@400ff040 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff040 0x40>;
 			interrupts = <60 2>;
 			label = "GPIO_1";
@@ -250,6 +247,7 @@
 
 		gpioc: gpio@400ff080 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff080 0x40>;
 			interrupts = <61 2>;
 			label = "GPIO_2";
@@ -260,6 +258,7 @@
 
 		gpiod: gpio@400ff0c0 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff0c0 0x40>;
 			interrupts = <62 2>;
 			label = "GPIO_3";
@@ -270,6 +269,7 @@
 
 		gpioe: gpio@400ff100 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff100 0x40>;
 			interrupts = <63 2>;
 			label = "GPIO_4";

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -293,6 +293,7 @@
 
 		gpioa: gpio@400ff000 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff000 0x40>;
 			interrupts = <59 2>;
 			label = "GPIO_0";
@@ -303,6 +304,7 @@
 
 		gpiob: gpio@400ff040 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff040 0x40>;
 			interrupts = <60 2>;
 			label = "GPIO_1";
@@ -313,6 +315,7 @@
 
 		gpioc: gpio@400ff080 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff080 0x40>;
 			interrupts = <61 2>;
 			label = "GPIO_2";
@@ -323,6 +326,7 @@
 
 		gpiod: gpio@400ff0c0 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff0c0 0x40>;
 			interrupts = <62 2>;
 			label = "GPIO_3";
@@ -333,6 +337,7 @@
 
 		gpioe: gpio@400ff100 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff100 0x40>;
 			interrupts = <63 2>;
 			label = "GPIO_4";

--- a/dts/arm/nxp/nxp_k8x.dtsi
+++ b/dts/arm/nxp/nxp_k8x.dtsi
@@ -13,11 +13,6 @@
 / {
 	aliases {
 		adc-0 = &adc0;
-		gpio-a = &gpioa;
-		gpio-b = &gpiob;
-		gpio-c = &gpioc;
-		gpio-d = &gpiod;
-		gpio-e = &gpioe;
 		i2c-0 = &i2c0;
 		i2c-1 = &i2c1;
 		i2c-2 = &i2c2;
@@ -106,6 +101,7 @@
 
 		gpioa: gpio@400ff000 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff000 0x40>;
 			interrupts = <59 2>;
 			label = "GPIO_0";
@@ -116,6 +112,7 @@
 
 		gpiob: gpio@400ff040 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff040 0x40>;
 			interrupts = <60 2>;
 			label = "GPIO_1";
@@ -126,6 +123,7 @@
 
 		gpioc: gpio@400ff080 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff080 0x40>;
 			interrupts = <61 2>;
 			label = "GPIO_2";
@@ -136,6 +134,7 @@
 
 		gpiod: gpio@400ff0c0 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff0c0 0x40>;
 			interrupts = <62 2>;
 			label = "GPIO_3";
@@ -146,6 +145,7 @@
 
 		gpioe: gpio@400ff100 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff100 0x40>;
 			interrupts = <63 2>;
 			label = "GPIO_4";

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -310,6 +310,7 @@
 
 		gpioa: gpio@400ff000 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff000 0x40>;
 			interrupts = <59 2>;
 			label = "GPIO_0";
@@ -320,6 +321,7 @@
 
 		gpiob: gpio@400ff040 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff040 0x40>;
 			interrupts = <60 2>;
 			label = "GPIO_1";
@@ -330,6 +332,7 @@
 
 		gpioc: gpio@400ff080 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff080 0x40>;
 			interrupts = <61 2>;
 			label = "GPIO_2";
@@ -340,6 +343,7 @@
 
 		gpiod: gpio@400ff0c0 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff0c0 0x40>;
 			interrupts = <62 2>;
 			label = "GPIO_3";
@@ -350,6 +354,7 @@
 
 		gpioe: gpio@400ff100 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff100 0x40>;
 			interrupts = <63 2>;
 			label = "GPIO_4";

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -8,11 +8,6 @@
 / {
 	aliases {
 		adc-0 = &adc0;
-		gpio-a = &gpioa;
-		gpio-b = &gpiob;
-		gpio-c = &gpioc;
-		gpio-d = &gpiod;
-		gpio-e = &gpioe;
 		i2c-0 = &i2c0;
 		i2c-1 = &i2c1;
 		uart-0 = &uart0;
@@ -137,6 +132,7 @@
 
 		gpioa: gpio@400ff000 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff000 0x40>;
 			interrupts = <30 2>;
 			label = "GPIO_0";
@@ -147,6 +143,7 @@
 
 		gpiob: gpio@400ff040 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff040 0x40>;
 			label = "GPIO_1";
 			gpio-controller;
@@ -156,6 +153,7 @@
 
 		gpioc: gpio@400ff080 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff080 0x40>;
 			label = "GPIO_2";
 			gpio-controller;
@@ -165,6 +163,7 @@
 
 		gpiod: gpio@400ff0c0 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff0c0 0x40>;
 			interrupts = <31 2>;
 			label = "GPIO_3";
@@ -175,6 +174,7 @@
 
 		gpioe: gpio@400ff100 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff100 0x40>;
 			label = "GPIO_4";
 			gpio-controller;

--- a/dts/arm/nxp/nxp_kv5x.dtsi
+++ b/dts/arm/nxp/nxp_kv5x.dtsi
@@ -12,11 +12,6 @@
 / {
 	aliases {
 		adc-0 = &adc0;
-		gpio-a = &gpioa;
-		gpio-b = &gpiob;
-		gpio-c = &gpioc;
-		gpio-d = &gpiod;
-		gpio-e = &gpioe;
 		i2c-0 = &i2c0;
 		i2c-1 = &i2c1;
 		pinmux-a = &porta;
@@ -97,6 +92,7 @@
 
 		gpioa: gpio@400ff000 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff000 0x40>;
 			interrupts = <59 2>;
 			label = "GPIO_0";
@@ -107,6 +103,7 @@
 
 		gpiob: gpio@400ff040 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff040 0x40>;
 			interrupts = <60 2>;
 			label = "GPIO_1";
@@ -117,6 +114,7 @@
 
 		gpioc: gpio@400ff080 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff080 0x40>;
 			interrupts = <61 2>;
 			label = "GPIO_2";
@@ -127,6 +125,7 @@
 
 		gpiod: gpio@400ff0c0 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff0c0 0x40>;
 			interrupts = <62 2>;
 			label = "GPIO_3";
@@ -137,6 +136,7 @@
 
 		gpioe: gpio@400ff100 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff100 0x40>;
 			interrupts = <63 2>;
 			label = "GPIO_4";

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -9,11 +9,6 @@
 / {
 	aliases {
 		adc-0 = &adc0;
-		gpio-a = &gpioa;
-		gpio-b = &gpiob;
-		gpio-c = &gpioc;
-		gpio-d = &gpiod;
-		gpio-e = &gpioe;
 		i2c-0 = &i2c0;
 		i2c-1 = &i2c1;
 		pinmux-a = &pinmux_a;
@@ -191,6 +186,7 @@
 
 		gpioa: gpio@400ff000 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff000 0x40>;
 			interrupts = <59 2>;
 			label = "GPIO_0";
@@ -201,6 +197,7 @@
 
 		gpiob: gpio@400ff040 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff040 0x40>;
 			interrupts = <60 2>;
 			label = "GPIO_1";
@@ -211,6 +208,7 @@
 
 		gpioc: gpio@400ff080 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff080 0x40>;
 			interrupts = <61 2>;
 			label = "GPIO_2";
@@ -221,6 +219,7 @@
 
 		gpiod: gpio@400ff0c0 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff0c0 0x40>;
 			interrupts = <62 2>;
 			label = "GPIO_3";
@@ -231,6 +230,7 @@
 
 		gpioe: gpio@400ff100 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff100 0x40>;
 			interrupts = <63 2>;
 			label = "GPIO_4";

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -8,9 +8,6 @@
 / {
 	aliases {
 		adc-0 = &adc0;
-		gpio-a = &gpioa;
-		gpio-b = &gpiob;
-		gpio-c = &gpioc;
 		i2c-0 = &i2c0;
 		i2c-1 = &i2c1;
 		pinmux-a = &porta;
@@ -142,6 +139,7 @@
 
 		gpioa: gpio@400ff000 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff000 0x40>;
 			interrupts = <30 2>;
 			label = "GPIO_0";
@@ -152,6 +150,7 @@
 
 		gpiob: gpio@400ff040 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff040 0x40>;
 			label = "GPIO_2";
 			gpio-controller;
@@ -161,6 +160,7 @@
 
 		gpioc: gpio@400ff080 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff080 0x40>;
 			interrupts = <31 2>;
 			label = "GPIO_3";

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -8,9 +8,6 @@
 / {
 	aliases {
 		adc-0 = &adc0;
-		gpio-a = &gpioa;
-		gpio-b = &gpiob;
-		gpio-c = &gpioc;
 		i2c-0 = &i2c0;
 		i2c-1 = &i2c1;
 		pinmux-a = &porta;
@@ -145,6 +142,7 @@
 
 		gpioa: gpio@400ff000 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff000 0x40>;
 			interrupts = <30 2>;
 			label = "GPIO_0";
@@ -155,6 +153,7 @@
 
 		gpiob: gpio@400ff040 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff040 0x40>;
 			label = "GPIO_1";
 			gpio-controller;
@@ -164,6 +163,7 @@
 
 		gpioc: gpio@400ff080 {
 			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
 			reg = <0x400ff080 0x40>;
 			interrupts = <31 2>;
 			label = "GPIO_2";

--- a/samples/sensor/max30101/boards/hexiwear_k64.overlay
+++ b/samples/sensor/max30101/boards/hexiwear_k64.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2019, Linaro Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&i2c0 {
+	max30101@57 {
+		status = "okay";
+	};
+};
+
+&gpioa {
+	status = "okay";
+};


### PR DESCRIPTION
This converts the Kinetis GPIO driver to be based on DT_INST defines.  We base this on PR #22770 as we utilize the phandle support to connect the GPIO controller node and PINMUX port nodes together.

Additionally we now utilize the device tree to determine which GPIO controller instances should be enabled and thus remove such config from Kconfig.