### PR TITLE
doc: release notes: RISC-V release notes for 2.2

### DIFF
--- a/doc/releases/release-notes-2.2.rst
+++ b/doc/releases/release-notes-2.2.rst
@@ -152,7 +152,12 @@ Architectures
 
 * RISC-V:
 
-  * <TBD>
+  * Added GPIO driver for LiteX VexRiscv
+  * Fixed Ethernet networking for LiteX VexRiscv
+  * Added Programmable Interrupt Controller support for SweRV
+  * Fixed invalid channel bug for RV32M1 interrupt controller
+  * Added PWM support for RV32M1
+  * Optimized reads of MTIME/MTIMECMP on 64-bit RISC-V
 
 * x86:
 


### PR DESCRIPTION
Adds 2.2 release notes for the RISC-V architecture.