### PR TITLE
arch: arc: fix the bug that idle thread blocks other threads

### DIFF
--- a/arch/arc/core/fast_irq.S
+++ b/arch/arc/core/fast_irq.S
@@ -155,8 +155,6 @@ SECTION_FUNC(TEXT, _firq_exit)
 	bl z_check_stack_sentinel
 #endif
 
-#ifdef CONFIG_PREEMPT_ENABLED
-
 #ifdef CONFIG_SMP
 	bl z_arc_smp_switch_in_isr
 	/* r0 points to new thread, r1 points to old thread */
@@ -171,8 +169,6 @@ SECTION_FUNC(TEXT, _firq_exit)
 #endif
 	/* fall to no rescheduling */
 
-#endif /* CONFIG_PREEMPT_ENABLED */
-
 .balign 4
 _firq_no_reschedule:
 	pop sp
@@ -185,8 +181,6 @@ _firq_no_reschedule:
 	_pop_irq_stack_frame
 #endif
 	rtie
-
-#ifdef CONFIG_PREEMPT_ENABLED
 
 .balign 4
 _firq_reschedule:
@@ -353,5 +347,3 @@ _firq_return_from_firq:
 
 	/* LP registers are already restored, just switch back to bank 0 */
 	rtie
-
-#endif /* CONFIG_PREEMPT_ENABLED */

--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -114,7 +114,6 @@ _exc_return:
  * exception comes out,  thread context?irq_context?nest irq context?
  */
 
-#ifdef CONFIG_PREEMPT_ENABLED
 #ifdef CONFIG_SMP
 	bl z_arc_smp_switch_in_isr
 	breq r0, 0, _exc_return_from_exc
@@ -187,7 +186,6 @@ _exc_return:
 
 	/* Assumption: r2 has current thread */
 	b _rirq_common_interrupt_swap
-#endif
 
 _exc_return_from_exc:
 	ld_s r0, [sp, ___isf_t_pc_OFFSET]

--- a/arch/arc/core/regular_irq.S
+++ b/arch/arc/core/regular_irq.S
@@ -266,8 +266,6 @@ SECTION_FUNC(TEXT, _rirq_exit)
 	bl z_check_stack_sentinel
 #endif
 
-#ifdef CONFIG_PREEMPT_ENABLED
-
 #ifdef CONFIG_SMP
 	bl z_arc_smp_switch_in_isr
 	/* r0 points to new thread, r1 points to old thread */
@@ -403,8 +401,6 @@ _rirq_return_from_coop:
 	/* stack now has the IRQ stack frame layout, pointing to sp */
 	/* rtie will pop the rest from the stack */
 	rtie
-
-#endif /* CONFIG_PREEMPT_ENABLED */
 
 .balign 4
 _rirq_return_from_firq:


### PR DESCRIPTION
* for COOP_SCHED case, i.e., PREEMPT_ENABLED is not enabled, the
  idle thread will block other threads which is not correct.

* remove the check of PREEMPT_ENABLED in the epilogue of irq and
  exception handling. Let the scheduler (should_preempt()) decide
  whether the thread should be preempted.

Fixes #22316