### PR TITLE
gpio: restore missing legacy devicetree direction flag

### DIFF
--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -267,6 +267,7 @@ extern "C" {
  * @deprecated Replace with `GPIO_INPUT`.
  */
 /* Deprecated in 2.2 release */
+#undef GPIO_DIR_IN
 #define GPIO_DIR_IN __DEPRECATED_MACRO			GPIO_INPUT
 
 /** Legacy flag indicating pin is configured as output.

--- a/include/dt-bindings/gpio/gpio.h
+++ b/include/dt-bindings/gpio/gpio.h
@@ -81,6 +81,7 @@
  *
  * Following defines are deprecated and shouldn't be used in DTS files.
  */
+#define GPIO_DIR_IN             (1 << 8) /* GPIO_INPUT */
 #define GPIO_DIR_OUT            (1 << 9) /* GPIO_OUTPUT */
 #define GPIO_PUD_PULL_UP	GPIO_PULL_UP
 #define GPIO_PUD_PULL_DOWN	GPIO_PULL_DOWN


### PR DESCRIPTION
GPIO_DIR_OUT is deprecated but allowed in devicetree bindings because
some in-tree bindings provided it in the past.  GPIO_DIR_IN was the
former explicit way of representing the default direction.  Put it
back so symmetry is maintained.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>