### PR TITLE
usb: loopback: re-trigger usb_write on interface configuration

### DIFF
--- a/subsys/usb/class/loopback.c
+++ b/subsys/usb/class/loopback.c
@@ -104,9 +104,9 @@ static void loopback_status_cb(struct usb_cfg_data *cfg,
 	ARG_UNUSED(cfg);
 
 	switch (status) {
-	case USB_DC_CONFIGURED:
+	case USB_DC_INTERFACE:
 		loopback_in_cb(ep_cfg[LOOPBACK_IN_EP_IDX].ep_addr, 0);
-		LOG_DBG("USB device configured");
+		LOG_DBG("USB interface configured");
 		break;
 	case USB_DC_SET_HALT:
 		LOG_DBG("Set Feature ENDPOINT_HALT");


### PR DESCRIPTION
Re-trigger usb_write on interface configuration event.
testusb tool forwards Set Interface Request at beginning of every test. The correct way is to re-trigger on USB_DC_INTERFACE and not on USB_DC_CONFIGURED. This is also some kind of regression as it worked in v2.1.0