### PR TITLE
tests: remove duplicate names for tests

### DIFF
--- a/samples/shields/x_nucleo_iks01a3/sensorhub/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a3/sensorhub/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: X-NUCLEO-IKS01A3 sensor shield
 tests:
-  sample.shields.x_nucleo_iks01a3:
+  sample.shields.x_nucleo_iks01a3.sensorhub:
     harness: shield
     tags: shield
     depends_on: arduino_i2c arduino_gpio

--- a/samples/shields/x_nucleo_iks01a3/standard/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a3/standard/sample.yaml
@@ -3,7 +3,7 @@ sample:
 common:
   min_ram: 16
 tests:
-  sample.shields.x_nucleo_iks01a3:
+  sample.shields.x_nucleo_iks01a3.standard:
     harness: shield
     tags: shield
     depends_on: arduino_i2c arduino_gpio

--- a/tests/subsys/settings/fcb/base64/testcase.yaml
+++ b/tests/subsys/settings/fcb/base64/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  system.settings.fcb:
+  system.settings.fcb.base64:
     platform_whitelist: nrf52840_pca10056 nrf52_pca10040 native_posix native_posix_64
     tags: settings_fcb

--- a/tests/subsys/settings/fcb/raw/testcase.yaml
+++ b/tests/subsys/settings/fcb/raw/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  system.settings.fcb:
+  system.settings.fcb.raw:
     platform_whitelist: nrf52840_pca10056 nrf52_pca10040 native_posix native_posix_64
     tags: settings_fcb

--- a/tests/subsys/settings/littlefs/base64/testcase.yaml
+++ b/tests/subsys/settings/littlefs/base64/testcase.yaml
@@ -2,6 +2,6 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 
 tests:
-  system.settings.littlefs:
+  system.settings.littlefs.base64:
     platform_whitelist: nrf52840_pca10056 native_posix native_posix_64
     tags: settings_fs filesystem

--- a/tests/subsys/settings/littlefs/raw/testcase.yaml
+++ b/tests/subsys/settings/littlefs/raw/testcase.yaml
@@ -2,6 +2,6 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 
 tests:
-  system.settings.littlefs:
+  system.settings.littlefs.raw:
     platform_whitelist: nrf52840_pca10056 native_posix native_posix_64
     tags: settings_fs settings_littlefs


### PR DESCRIPTION
After running command  --list-test-duplicates
I found out that some test cases have same names (duplicated).
To get rid of it, I decided to change names in .yaml files

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>