### PR TITLE
tests: syscalls: exclude one case on nsim_sem

### DIFF
--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -169,9 +169,15 @@ void test_string_nlen(void)
 	zassert_equal(err, 0, "user string faulted");
 	zassert_equal(ret, strlen(user_string), "incorrect length returned");
 
+	/* Skip this scenario for nsim_sem emulated board, unfortunately
+	 * the emulator doesn't set up memory as specified in DTS and poking
+	 * this address doesn't fault
+	 */
+#if !(defined(CONFIG_BOARD_NSIM) && defined(CONFIG_SOC_NSIM_SEM))
 	/* Try to blow up the kernel */
 	ret = string_nlen((char *)0xFFFFFFF0, BUF_SIZE, &err);
 	zassert_equal(err, -1, "nonsense string address did not fault");
+#endif
 }
 
 /**


### PR DESCRIPTION
This works around an issue with this emulator's configuration where
there is no memory address that can be poked to generate a fault,
it is simulating memory for the entire address space.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>