### PR TITLE
github: Fix daily/release doc publish workflow

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -64,6 +64,7 @@ jobs:
         pip3 install 'breathe>=4.9.1' 'docutils>=0.14' \
                      'sphinx>=1.7.5' sphinx_rtd_theme sphinx-tabs \
                      sphinxcontrib-svg2pdfconverter 'west>=0.6.2'
+        pip3 install pyelftools
 
     - name: west setup
       run: |


### PR DESCRIPTION
We now need pyelftools to build the docs.  See the following commit:

commit 83b346edefc37615d241de7f5b807b9bf96201d1
Author: Alexey Brodkin <abrodkin@synopsys.com>
Date:   Fri Feb 7 11:37:25 2020 +0300

    runners: opeocd: Allow loading Elf-files

Match the update to doc-build.yml to `pip3 install pyelftools`.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>