### PR TITLE
dts: edtlib/gen_defines: Fix API design re. dtc flags

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -34,7 +34,10 @@ def main():
     args = parse_args()
 
     try:
-        edt = edtlib.EDT(args.dts, args.bindings_dirs)
+        edt = edtlib.EDT(args.dts, args.bindings_dirs,
+                         # Suppress this warning if it's suppressed in dtc
+                         warn_reg_unit_address_mismatch=
+                             "-Wno-simple_bus_reg" not in args.dtc_flags)
     except edtlib.EDTError as e:
         sys.exit(f"devicetree error: {e}")
 
@@ -45,7 +48,6 @@ def main():
     conf_file = open(args.conf_out, "w", encoding="utf-8")
     header_file = open(args.header_out, "w", encoding="utf-8")
     flash_area_num = 0
-    edtlib.dtc_flags = args.dtc_flags
 
     write_top_comment(edt)
 
@@ -90,7 +92,9 @@ def parse_args():
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--dts", required=True, help="DTS file")
-    parser.add_argument("--dtc-flags", help="extra device tree parameters")
+    parser.add_argument("--dtc-flags",
+                        help="'dtc' devicetree compiler flags, some of which "
+                             "might be respected here")
     parser.add_argument("--bindings-dirs", nargs='+', required=True,
                         help="directory with bindings in YAML format, "
                         "we allow multiple")


### PR DESCRIPTION
It's better to allow per-instance EDT configuration than to set a global
variable on the edtlib module. Enable/disable the warning for reg/unit
address mismatches via a flag to EDT.\_\_init__(), instead of via a global
variable. That makes it consistent too.

Another option would be to pass the 'dtc' flags to EDT.\_\_init__(), but
it makes the interface a bit ugly. Maybe if it needs to emulate lots of
other flags later.

Clarify that edtlib itself isn't meant to have any state in the comment
at the top of the module.