### PR TITLE
sockets: tls: Fix net_context referencing

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1174,6 +1174,10 @@ static int ztls_socket(int family, int type, int proto)
 		ctx->tls->tls_version = tls_proto;
 	}
 
+	if (proto == IPPROTO_TCP) {
+		net_context_ref(ctx);
+	}
+
 	z_finalize_fd(
 		fd, ctx, (const struct fd_op_vtable *)&tls_sock_fd_op_vtable);
 
@@ -1298,6 +1302,7 @@ int ztls_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 	}
 
 	net_context_set_accepting(child, false);
+	net_context_ref(child);
 
 	z_finalize_fd(
 		fd, child, (const struct fd_op_vtable *)&tls_sock_fd_op_vtable);


### PR DESCRIPTION
TLS sockets did not increase refcount of a net_context running TCP,
which could lead to a crash upon TCP disconnection.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>