### PR TITLE
settings: fix possible uninitialized variable

### DIFF
--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -306,7 +306,7 @@ static int settings_fcb_save_priv(struct settings_store *cs, const char *name,
 	struct settings_fcb *cf = (struct settings_fcb *)cs;
 	struct fcb_entry_ctx loc;
 	int len;
-	int rc;
+	int rc = 0;
 	int i;
 	u8_t wbs;
 

--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -226,7 +226,7 @@ static int settings_line_raw_read_until(off_t seek, char *out, size_t len_req,
 	size_t exp_size, read_size;
 	u8_t rbs = settings_io_cb.rwbs;
 	off_t off;
-	int rc;
+	int rc = 0;
 
 	if (len_req == 0) {
 		return -EINVAL;
@@ -428,7 +428,7 @@ int settings_line_name_read(char *out, size_t len_req, size_t *len_read,
 int settings_line_entry_copy(void *dst_ctx, off_t dst_off, void *src_ctx,
 			     off_t src_off, size_t len)
 {
-	int rc;
+	int rc = 0;
 	char buf[16];
 	size_t chunk_size;
 
@@ -474,7 +474,7 @@ static int settings_line_cmp(char const *val, size_t val_len,
 	size_t len_read, exp_len;
 	size_t rem;
 	char buf[16];
-	int rc;
+	int rc = 0;
 	off_t off = 0;
 
 	if (val_len == 0) {


### PR DESCRIPTION
Fix serveral cases in `subsys/settings` where a possible uninitialized variable may be used.
In some of these it cannot happen, but gcc still complains (if `-Wextra` is given) with:

```
'rc' may be used uninitialized in this function [-Werror=maybe-uninitialized]
```
