### PR TITLE
kernel: fatal: unlock IRQs in early return points in z_fatal_error

### DIFF
--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -156,9 +156,11 @@ void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 				/* Abort the thread only on STACK Sentinel check fail. */
 #if defined(CONFIG_STACK_SENTINEL)
 				if (reason != K_ERR_STACK_CHK_FAIL) {
+					arch_irq_unlock(key);
 					return;
 				}
 #else
+				arch_irq_unlock(key);
 				return;
 #endif /* CONFIG_STACK_SENTINEL */
 			}


### PR DESCRIPTION
We need to unlock IRQs in early return points of
z_fatal_error() functions; not only at the normal
return point.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Fixes #22828