### PR TITLE
drivers: spi: sifive: Fix comment to match ifdef

### DIFF
--- a/drivers/spi/spi_sifive.c
+++ b/drivers/spi/spi_sifive.c
@@ -259,7 +259,7 @@ static struct spi_driver_api spi_sifive_api = {
 SPI_INIT(0);
 
 #endif /* DT_INST_0_SIFIVE_SPI0_LABEL */
-#endif /* !DT_SIFIVE_SPI0_0_ROM */
+#endif /* !CONFIG_SIFIVE_SPI_0_ROM */
 
 #ifdef DT_INST_1_SIFIVE_SPI0_LABEL
 


### PR DESCRIPTION
The endif comment didn't match the actual ifdef define.  Fix the comment
to match.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>