### PR TITLE
kernel: use sched lock for k_thread_suspend/resume

### DIFF
--- a/samples/smp/pi/prj.conf
+++ b/samples/smp/pi/prj.conf
@@ -3,3 +3,6 @@ CONFIG_MAIN_THREAD_PRIORITY=11
 
 # Enable SMP
 CONFIG_SMP=y
+
+# Enable assertions, stack overflow checking, etc
+CONFIG_TEST=y

--- a/samples/smp/pi/src/main.c
+++ b/samples/smp/pi/src/main.c
@@ -17,7 +17,8 @@
 #define DIGITS_NUM	240
 
 #define LENGTH		((DIGITS_NUM / 4) * 14)
-#define STACK_SIZE	(LENGTH * sizeof(int) + 512)
+#define STACK_SIZE	((LENGTH * sizeof(int) + 512) + \
+			 CONFIG_TEST_EXTRA_STACKSIZE)
 
 #ifdef CONFIG_SMP
 #define CORES_NUM	CONFIG_MP_NUM_CPUS


### PR DESCRIPTION
This logic should be using the sched_lock and not its own
separate lock for these two functions.

Some simplications were made; z_thread_single_resume and
z_thread_single_suspend were only used in one place, and there was
some redundant logic for whether to reschedule in the suspend case.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>