### PR TITLE
kernel: k_thread_abort() adjustments

### DIFF
--- a/kernel/thread_abort.c
+++ b/kernel/thread_abort.c
@@ -38,9 +38,7 @@ void z_impl_k_thread_abort(k_tid_t thread)
 		 * for "is _current dead" and we don't want one for
 		 * performance reasons.
 		 */
-		struct k_spinlock lock = {};
-
-		z_swap(&lock, k_spin_lock(&lock));
+		z_swap_unlocked();
 	} else {
 		z_reschedule_unlocked();
 	}

--- a/kernel/thread_abort.c
+++ b/kernel/thread_abort.c
@@ -42,14 +42,6 @@ void z_impl_k_thread_abort(k_tid_t thread)
 
 		z_swap(&lock, k_spin_lock(&lock));
 	} else {
-		/* Really, there's no good reason for this to be a
-		 * scheduling point if we aren't aborting _current (by
-		 * definition, no higher priority thread is runnable,
-		 * because we're running!).  But it always has been
-		 * and is thus part of our API, and we have tests that
-		 * rely on k_thread_abort() scheduling out of
-		 * cooperative threads.
-		 */
 		z_reschedule_unlocked();
 	}
 }


### PR DESCRIPTION
z_reschedule_unlocked() is a no-op if the caller is
cooperative, because the logic that maintains the ready queue
ensures that the co-op thread is always at the front unless
some special handling is done like in k_yield(), which does
not happen here.

Also use z_swap_unlocked() in k_thread_abort(), it does the same
thing with a dummy spinlock.