### PR TITLE
IPv6 routing fixes when VLAN is enabled

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -228,6 +228,7 @@ config NET_ROUTE
 config NET_ROUTING
 	bool
 	depends on NET_ROUTE
+	default y if NET_VLAN
 	help
 	  Allow IPv6 routing between different network interfaces and
 	  technologies. Currently this has limited use as some entity

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -115,8 +115,11 @@ static sys_slist_t timestamp_callbacks;
 #if CONFIG_NET_IF_LOG_LEVEL >= LOG_LEVEL_DBG
 #define debug_check_packet(pkt)						\
 	do {								\
-		NET_DBG("Processing (pkt %p, prio %d) network packet",	\
-			pkt, net_pkt_priority(pkt));			\
+		NET_DBG("Processing (pkt %p, prio %d) network packet "	\
+			"iface %p/%d",					\
+			pkt, net_pkt_priority(pkt),			\
+			net_pkt_iface(pkt),				\
+			net_if_get_by_iface(net_pkt_iface(pkt)));	\
 									\
 		NET_ASSERT(pkt->frags);					\
 	} while (0)


### PR DESCRIPTION
If VLAN is enabled, then IPv6 packets were sent to wrong network interface. In order to select the proper network interface, the routing support needs to be enabled.