### PR TITLE
interrupt_controller: fixed IO APIC broadcasting issue

### DIFF
--- a/arch/x86/core/ia32/crt0.S
+++ b/arch/x86/core/ia32/crt0.S
@@ -236,6 +236,9 @@ __csSet:
 	lidt	z_x86_idt		/* load 32-bit operand size IDT */
 
 #ifdef CONFIG_LOAPIC
+	/* For BSP, cpu_number is 0 */
+	xorl	%eax, %eax
+	pushl	%eax
 	call	z_loapic_enable
 #endif
 

--- a/arch/x86/core/intel64/cpu.c
+++ b/arch/x86/core/intel64/cpu.c
@@ -144,7 +144,8 @@ FUNC_NORETURN void z_x86_cpu_init(struct x86_cpuboot *cpuboot)
 {
 	x86_sse_init(NULL);
 
-	z_loapic_enable();
+	/* The internal cpu_number is the index to x86_cpuboot[] */
+	z_loapic_enable((unsigned char)(cpuboot - x86_cpuboot));
 
 #ifdef CONFIG_USERSPACE
 	/* Set landing site for 'syscall' instruction */

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -69,6 +69,23 @@
 #define BIT_POS_FOR_IRQ_OPTION(irq, option) ((irq) * BITS_PER_IRQ + (option))
 #define SUSPEND_BITS_REQD (ROUND_UP((CONFIG_IOAPIC_NUM_RTES * BITS_PER_IRQ), 32))
 
+/*
+ * Destination field (bits[56:63]) defines a set of processors, which is
+ * used to be compared with local LDR to determine which local APICs accept
+ * the interrupt.
+ *
+ * XAPIC: in logical destination mode and flat model (determined by DFR).
+ * LDR bits[24:31] can accommodate up to 8 logical APIC IDs.
+ *
+ * X2APIC: in logical destination mode and cluster model.
+ * In this case, LDR is read-only to system software and supports up to 16
+ * logical IDs. (Cluster ID: don't care to IO APIC).
+ *
+ * In either case, regardless how many CPUs in the system, 0xff implies that
+ * it's intended to deliver to all possible 8 local APICs.
+ */
+#define DEFAULT_RTE_DEST	(0xFF << 24)
+
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 #include <power/power.h>
 u32_t ioapic_suspend_buf[SUSPEND_BITS_REQD / 32] = {0};
@@ -113,11 +130,11 @@ int _ioapic_init(struct device *unused)
 	 *
 	 * ((__IoApicGet(IOAPIC_VERS) & IOAPIC_MRE_MASK) >> 16) + 1
 	 */
-	rteValue = IOAPIC_EDGE | IOAPIC_HIGH | IOAPIC_FIXED | IOAPIC_INT_MASK |
-		   IOAPIC_PHYSICAL | 0 /* dummy vector */;
+	rteValue = IOAPIC_EDGE | IOAPIC_HIGH | IOAPIC_LOWEST | IOAPIC_INT_MASK |
+		   IOAPIC_LOGICAL | 0 /* dummy vector */;
 
 	for (ix = 0; ix < CONFIG_IOAPIC_NUM_RTES; ix++) {
-		ioApicRedSetHi(ix, 0xFF000000);
+		ioApicRedSetHi(ix, DEFAULT_RTE_DEST);
 		ioApicRedSetLo(ix, rteValue);
 	}
 #endif
@@ -232,17 +249,17 @@ int ioapic_resume_from_suspend(struct device *port)
 			/* Get the saved flags */
 			flags = restore_flags(irq);
 			/* Appending the flags that are never modified */
-			flags = flags | IOAPIC_FIXED | IOAPIC_PHYSICAL;
+			flags = flags | IOAPIC_LOWEST | IOAPIC_LOGICAL;
 
 			rteValue = (_irq_to_interrupt_vector[irq] &
 					IOAPIC_VEC_MASK) | flags;
 		} else {
 			/* Initialize the other RTEs to sane values */
 			rteValue = IOAPIC_EDGE | IOAPIC_HIGH |
-				IOAPIC_FIXED | IOAPIC_INT_MASK |
-				IOAPIC_PHYSICAL | 0 ; /* dummy vector*/
+				IOAPIC_LOWEST | IOAPIC_INT_MASK |
+				IOAPIC_LOGICAL | 0 ; /* dummy vector*/
 		}
-		ioApicRedSetHi(irq, 0xFF000000);
+		ioApicRedSetHi(irq, DEFAULT_RTE_DEST);
 		ioApicRedSetLo(irq, rteValue);
 	}
 	ioapic_device_power_state = DEVICE_PM_ACTIVE_STATE;
@@ -293,9 +310,9 @@ void z_ioapic_irq_set(unsigned int irq, unsigned int vector, u32_t flags)
 {
 	u32_t rteValue;   /* value to copy into redirection table entry */
 
-	rteValue = IOAPIC_FIXED | IOAPIC_INT_MASK | IOAPIC_PHYSICAL |
+	rteValue = IOAPIC_LOWEST | IOAPIC_INT_MASK | IOAPIC_LOGICAL |
 		   (vector & IOAPIC_VEC_MASK) | flags;
-	ioApicRedSetHi(irq, 0xFF000000);
+	ioApicRedSetHi(irq, DEFAULT_RTE_DEST);
 	ioApicRedSetLo(irq, rteValue);
 }
 

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -71,9 +71,26 @@ static u32_t loapic_device_power_state = DEVICE_PM_ACTIVE_STATE;
  * Called from early assembly layer (e.g., crt0.S).
  */
 
-void z_loapic_enable(void)
+void z_loapic_enable(unsigned char cpu_number)
 {
 	s32_t loApicMaxLvt; /* local APIC Max LVT */
+
+#ifndef CONFIG_X2APIC
+	/*
+	 * in xAPIC and flat model, bits 24-31 in LDR (Logical APIC ID) are
+	 * bitmap of target logical APIC ID and it supports maximum 8 local
+	 * APICs.
+	 *
+	 * The logical APIC ID could be arbitrarily selected by system software
+	 * and is different from local APIC ID in local APIC ID register.
+	 *
+	 * We choose 0 for BSP, and the index to x86_cpuboot[] for secondary
+	 * CPUs.
+	 *
+	 * in X2APIC, LDR is read-only.
+	 */
+	x86_write_xapic(LOAPIC_LDR, 1 << (cpu_number + 24));
+#endif
 
 	/*
 	 * enable the local APIC. note that we use xAPIC mode here, since
@@ -99,6 +116,7 @@ void z_loapic_enable(void)
 	/* reset the DFR, TPR, TIMER_CONFIG, and TIMER_ICR */
 
 #ifndef CONFIG_X2APIC
+	/* Flat model */
 	x86_write_loapic(LOAPIC_DFR, 0xffffffff);  /* no DFR in x2APIC mode */
 #endif
 

--- a/include/drivers/interrupt_controller/loapic.h
+++ b/include/drivers/interrupt_controller/loapic.h
@@ -54,7 +54,7 @@
 extern "C" {
 #endif
 
-extern void z_loapic_enable(void);
+extern void z_loapic_enable(unsigned char cpu_number);
 extern void z_loapic_int_vec_set(unsigned int irq, unsigned int vector);
 extern void z_loapic_irq_enable(unsigned int irq);
 extern void z_loapic_irq_disable(unsigned int irq);


### PR DESCRIPTION
Currently IO APIC is working in physical mode which is not good for SMP.

Tested with samples/subsys/console/echo, and checked if it can receive keyboard inputs. Results:

without these patches (head: bf3850c27092)
           acrn  qemu_x86   qemu_x86_64(1CPU -- 2 CPUs)  up_sqaured(1CPU -- 2 CPUs)
xapic       N       Y                                       Y               N                                Y            Y
x2apic     N       ?                                        ?               ?                                N            N

with these patches:
         acrn  qemu_x86   qemu_x86_64(1CPU -- 2 CPUs)  up_squared(1CPU -- 2 CPUs)
xapic      Y      Y                                        Y             Y                                Y             Y
x2apic    Y      ?                                         ?             ?                                Y             Y

Can't test X2APIC with QEMU due to following warning:
qemu-system-x86_64: warning: TCG doesn't support requested feature: CPUID.01H:ECX.x2apic [bit 21]


fixes #21156