### PR TITLE
tests: drivers: uart: config api

### DIFF
--- a/tests/drivers/uart/uart_basic_api/CMakeLists.txt
+++ b/tests/drivers/uart/uart_basic_api/CMakeLists.txt
@@ -6,6 +6,7 @@ project(uart_basic_api)
 
 target_sources(app PRIVATE
     src/main.c
+    src/test_uart_config.c
     src/test_uart_poll.c
     )
 target_sources_ifdef(CONFIG_UART_INTERRUPT_DRIVEN app PRIVATE src/test_uart_fifo.c)

--- a/tests/drivers/uart/uart_basic_api/src/main.c
+++ b/tests/drivers/uart/uart_basic_api/src/main.c
@@ -14,11 +14,17 @@
 #include "test_uart.h"
 
 #ifdef CONFIG_SHELL
+TC_CMD_DEFINE(test_uart_configure)
+TC_CMD_DEFINE(test_uart_config_get)
 TC_CMD_DEFINE(test_uart_fifo_read)
 TC_CMD_DEFINE(test_uart_fifo_fill)
 TC_CMD_DEFINE(test_uart_poll_in)
 TC_CMD_DEFINE(test_uart_poll_out)
 
+SHELL_CMD_REGISTER(test_uart_configure, NULL, NULL,
+			TC_CMD_ITEM(test_uart_configure));
+SHELL_CMD_REGISTER(test_uart_config_get, NULL, NULL,
+			TC_CMD_ITEM(test_uart_config_get));
 SHELL_CMD_REGISTER(test_uart_fifo_read, NULL, NULL,
 			TC_CMD_ITEM(test_uart_fifo_read));
 SHELL_CMD_REGISTER(test_uart_fifo_fill, NULL, NULL,
@@ -45,6 +51,8 @@ void test_main(void)
 {
 #ifndef CONFIG_SHELL
 	ztest_test_suite(uart_basic_test,
+			 ztest_unit_test(test_uart_configure),
+			 ztest_unit_test(test_uart_config_get),
 			 ztest_unit_test(test_uart_fifo_fill),
 			 ztest_unit_test(test_uart_fifo_read),
 			 ztest_unit_test(test_uart_poll_in),

--- a/tests/drivers/uart/uart_basic_api/src/test_uart.h
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016 Intel Corporation
+ * Copyright (c) 2020 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -19,6 +20,8 @@
 
 #define UART_DEVICE_NAME CONFIG_UART_CONSOLE_ON_DEV_NAME
 
+void test_uart_configure(void);
+void test_uart_config_get(void);
 void test_uart_poll_out(void);
 void test_uart_fifo_fill(void);
 void test_uart_fifo_read(void);

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_config.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_config.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * @addtogroup t_uart_basic
+ * @{
+ * @defgroup t_uart_config test_uart_config
+ * @brief TestPurpose: verify UART configure API settings
+ * @details
+ * - Test Steps
+ *   - Configure: test_uart_configure( )
+ *   - Configure Get: test_uart_config_get( )
+ * - Expected Results
+ *   -# When test UART CONFIG Configure, the value of configurations actually
+ *      set will be equal to the original configuration values (from device
+ *      tree or run-time configuration to modify those loaded initially from
+ *      device tree)
+ *   -# When test UART CONFIG Configure Get, the app will get/retrieve the
+ *      value of configurations stored at location and to be passed to UART
+ *      CONFIG Configure
+ * @}
+ */
+
+#include "test_uart.h"
+struct uart_config uart_cfg_check;
+
+/* test UART configure (set configuration) */
+static int test_configure(void)
+{
+	const struct uart_config uart_cfg = {
+		.baudrate = 115200,
+		.parity = UART_CFG_PARITY_NONE,
+		.stop_bits = UART_CFG_STOP_BITS_1,
+		.data_bits = UART_CFG_DATA_BITS_8,
+		.flow_ctrl = UART_CFG_FLOW_CTRL_NONE
+	};
+
+	struct device *uart_dev = device_get_binding(UART_DEVICE_NAME);
+
+	if (!uart_dev) {
+		TC_PRINT("Cannot get UART device\n");
+		return TC_FAIL;
+	}
+
+	TC_PRINT("This is a configure test.\n");
+
+	/* Verify configure() - set device configuration using data in cfg */
+	/* 0 if successful, - error code otherwise */
+	int ret = uart_configure(uart_dev, &uart_cfg);
+
+	/* Confirm the values provided are the values set*/
+	/* so get the configurations from the device and check */
+	uart_config_get(uart_dev, &uart_cfg_check);
+	if (memcmp(&uart_cfg, &uart_cfg_check, sizeof(uart_cfg)) != 0) {
+		return TC_FAIL;
+	}
+
+	return (ret == 0) ? TC_PASS : TC_FAIL;
+}
+
+/* test UART configure get (retrieve configuration) */
+static int test_config_get(void)
+{
+	struct device *uart_dev = device_get_binding(UART_DEVICE_NAME);
+	struct uart_config uart_cfg;
+
+	if (!uart_dev) {
+		TC_PRINT("Cannot get UART device\n");
+		return TC_FAIL;
+	}
+
+	TC_PRINT("This is a configure_get test.\n");
+
+	/* Verify uart_config_get() - get device configuration, put in cfg */
+	/* 0 if successful, - error code otherwise */
+	int ret = uart_config_get(uart_dev, &uart_cfg);
+
+	/* Confirm the values from device are the values put in cfg*/
+	if (memcmp(&uart_cfg, &uart_cfg_check, sizeof(uart_cfg)) != 0) {
+		return TC_FAIL;
+	}
+	return (ret == 0) ? TC_PASS : TC_FAIL;
+
+}
+
+void test_uart_configure(void)
+{
+	zassert_true(test_configure() == TC_PASS, NULL);
+}
+
+void test_uart_config_get(void)
+{
+	zassert_true(test_config_get() == TC_PASS, NULL);
+}


### PR DESCRIPTION
The UART API now supports configure and configure_get functions,
however no tests were written for those functions. This
commit adds the framework and implementing tests for configure
and configure_get for UART API.

Fixes (#12872)

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>