### PR TITLE
Fix cc32xx gpio driver to prevent spurious interrupts in gpio_basic_api test

### DIFF
--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -246,16 +246,12 @@ static void gpio_cc32xx_port_isr(void *arg)
 
 	enabled_int = int_status & data->pin_callback_enables;
 
-	/* Clear and Disable GPIO Interrupt */
-	MAP_GPIOIntDisable(config->port_base, int_status);
+	/* Clear GPIO Interrupt */
 	MAP_GPIOIntClear(config->port_base, int_status);
 
 	/* Call the registered callbacks */
 	gpio_fire_callbacks(&data->callbacks, (struct device *)dev,
 			     enabled_int);
-
-	/* Re-enable the interrupts */
-	MAP_GPIOIntEnable(config->port_base, int_status);
 }
 
 static const struct gpio_driver_api api_funcs = {

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -171,6 +171,13 @@ static int gpio_cc32xx_pin_interrupt_configure(struct device *port,
 
 	__ASSERT(pin < 8, "Invalid pin number - only 8 pins per port");
 
+	/*
+	 * disable interrupt prior to changing int type helps
+	 * prevent spurious interrupts observed when switching
+	 * to level-based
+	 */
+	MAP_GPIOIntDisable(port_base, (1 << pin));
+
 	if (mode != GPIO_INT_MODE_DISABLED) {
 		if (mode == GPIO_INT_MODE_EDGE) {
 			if (trig == GPIO_INT_TRIG_BOTH) {
@@ -187,14 +194,13 @@ static int gpio_cc32xx_pin_interrupt_configure(struct device *port,
 				int_type = GPIO_LOW_LEVEL;
 			}
 		}
+
 		MAP_GPIOIntTypeSet(port_base, (1 << pin), int_type);
 		MAP_GPIOIntClear(port_base, (1 << pin));
 		MAP_GPIOIntEnable(port_base, (1 << pin));
 
 		WRITE_BIT(data->pin_callback_enables, pin,
 			mode != GPIO_INT_MODE_DISABLED);
-	} else {
-		MAP_GPIOIntDisable(port_base, (1 << pin));
 	}
 
 	return 0;


### PR DESCRIPTION
Analyzing #22847 has shown that spurious interrupts are observed when invoking test_callback for level-based interrupt type. The test hangs due to interrupts being repeatedly fired. This is fixed by performing the following:

- Avoid unnecessarily disabling gpio interrupts when firing registered callbacks. This is an issue because gpio_basic_api's test_deprecated test case attempts to disable interrupts on a pin under certain conditions by invoking gpio_pin_configure(), which has no effect given they get re-enabled as soon as the callbacks are done firing.

- Disable gpio interrupts prior to changing the interrupt type in gpio_cc32xx_pin_interrupt_configure(), in case interrupts were already enabled by previous test cases.