### PR TITLE
kernel: random: ifdef z_early_boot_rand_get

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -424,6 +424,7 @@ static FUNC_NORETURN void switch_to_main_thread(void)
 }
 #endif /* CONFIG_MULTITHREADING */
 
+#if defined(CONFIG_ENTROPY_HAS_DRIVER) || defined(CONFIG_TEST_RANDOM_GENERATOR)
 void z_early_boot_rand_get(u8_t *buf, size_t length)
 {
 	int n = sizeof(u32_t);
@@ -479,6 +480,8 @@ sys_rand_fallback:
 		length -= n;
 	}
 }
+/* defined(CONFIG_ENTROPY_HAS_DRIVER) || defined(CONFIG_TEST_RANDOM_GENERATOR) */
+#endif
 
 /**
  *


### PR DESCRIPTION
This function had a to sys_rand_get() even without random source. As Zephyr is
built with linkage garbage collection and this function is called only if
either STACK_CANARIES or STACK_POINTER_RANDOM is enabled and these options
automatically enable a random source.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>