### PR TITLE
Revert "github: For now limit doc publish to master"

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -8,8 +8,6 @@ on:
   schedule:
     - cron:  '50 22 * * *'
   push:
-    branches:
-    - master
     tags:
     - '*'
 


### PR DESCRIPTION
This branch filter doesn't work as expected with tag.  Need to test this
more on testing tree to find a combo or solution that works properly.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>