### PR TITLE
dts: edtlib: Turn global spi_dev_cs_gpio() into Node.spi_cs_gpio

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -549,7 +549,7 @@ def write_irqs(node):
 def write_spi_dev(node):
     # Writes SPI device GPIO chip select data if there is any
 
-    cs_gpio = edtlib.spi_dev_cs_gpio(node)
+    cs_gpio = node.spi_cs_gpio
     if cs_gpio is not None:
         write_phandle_val_list_entry(node, cs_gpio, None, "CS_GPIOS")
 


### PR DESCRIPTION
spi_dev_cs_gpio() takes a Node and returns the chip select GPIO for it.
Having that information available directly from Node is neater, so turn
it into a Node.spi_cs_gpio property instead.

That gets rid of the only public global function in edtlib, which might
make the API design clearer too.

Tested with the sensortile_box board, which uses SPI chip select.