### PR TITLE
kconfig: add CODE_SEMC for CODE_LOCATION

### DIFF
--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -64,6 +64,16 @@ config SPI_MCUX_LPSPI
 	default y if HAS_MCUX_LPSPI
 	depends on SPI
 
+if CODE_SEMC
+
+config FLASH_SIZE
+	default $(dt_node_reg_size_int,/memory@80000000,0,K)
+
+config FLASH_BASE_ADDRESS
+	default $(dt_node_reg_addr_hex,/memory@80000000)
+
+endif # CODE_SEMC
+
 if CODE_ITCM
 
 config FLASH_SIZE

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -375,6 +375,9 @@ choice CODE_LOCATION
 	prompt "Code location selection"
 	default CODE_ITCM
 
+config CODE_SEMC
+	bool "Link code into external SEMC-controlled memory"
+
 config CODE_ITCM
 	bool "Link code into internal instruction tightly coupled memory (ITCM)"
 


### PR DESCRIPTION
Add CODE_SEMC to support nxp-rt series
code run in external sdram.

Signed-off-by: Frank Li <lgl88911@163.com>