### PR TITLE
Bluetooth: EDTT: Handle unknown response

### DIFF
--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/hci_test_app/src/main.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/hci_test_app/src/main.c
@@ -64,10 +64,10 @@ static void error_response(int error)
 #else
 #define BT_BUF_ACL_SIZE BT_L2CAP_BUF_SIZE(60)
 #endif
-NET_BUF_POOL_DEFINE(hci_cmd_pool, CONFIG_BT_HCI_CMD_COUNT,
-		    BT_BUF_RX_SIZE, BT_BUF_USER_DATA_MIN, NULL);
-NET_BUF_POOL_DEFINE(hci_data_pool, CONFIG_BT_CTLR_TX_BUFFERS+4,
-		    BT_BUF_ACL_SIZE, BT_BUF_USER_DATA_MIN, NULL);
+NET_BUF_POOL_FIXED_DEFINE(hci_cmd_pool, CONFIG_BT_HCI_CMD_COUNT,
+			  BT_BUF_RX_SIZE, NULL);
+NET_BUF_POOL_FIXED_DEFINE(hci_data_pool, CONFIG_BT_CTLR_TX_BUFFERS + 4,
+			  BT_BUF_ACL_SIZE, NULL);
 
 /**
  * @brief Allocate buffer for HCI command and fill in opCode for the command
@@ -159,12 +159,11 @@ static void echo(u16_t size)
 	}
 }
 
-NET_BUF_POOL_DEFINE(event_pool, 32, BT_BUF_RX_SIZE + 4,
-		    BT_BUF_USER_DATA_MIN, NULL);
+NET_BUF_POOL_FIXED_DEFINE(event_pool, 32, BT_BUF_RX_SIZE + 4, NULL);
 static K_FIFO_DEFINE(event_queue);
 static K_FIFO_DEFINE(rx_queue);
-NET_BUF_POOL_DEFINE(data_pool, CONFIG_BT_CTLR_RX_BUFFERS + 14,
-		    BT_BUF_ACL_SIZE + 4, BT_BUF_USER_DATA_MIN, NULL);
+NET_BUF_POOL_FIXED_DEFINE(data_pool, CONFIG_BT_CTLR_RX_BUFFERS + 14,
+			  BT_BUF_ACL_SIZE + 4, NULL);
 static K_FIFO_DEFINE(data_queue);
 
 /**

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/hci.test_list
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/hci.test_list
@@ -1,7 +1,7 @@
 # Copyright 2019 Oticon A/S
 # SPDX-License-Identifier: Apache-2.0
 
-#HCI/CCO/BV-07-C #See GH issue #22085
+HCI/CCO/BV-07-C
 HCI/CCO/BV-09-C
 HCI/CCO/BV-10-C
 HCI/CCO/BV-11-C
@@ -27,5 +27,5 @@ HCI/DSU/BV-03-C
 HCI/DSU/BV-04-C
 HCI/DSU/BV-05-C
 HCI/DSU/BV-06-C
-#HCI/GEV/BV-01-C #See GH issue #22085
+HCI/GEV/BV-01-C
 HCI/HFC/BV-04-C

--- a/west.yml
+++ b/west.yml
@@ -117,7 +117,7 @@ manifest:
       path: modules/hal/xtensa
     - name: edtt
       path: tools/edtt
-      revision: 5fb6617815c7909f01988d10d6bc4789253f31f6
+      revision: d2d79a375082451adeedc01bcbbe5a7714d1556b
 
   self:
     path: zephyr


### PR DESCRIPTION
Related to: https://github.com/EDTTool/EDTT/pull/11
I'm not sure how to handle the west manifest with the zephyr mirror.

Update HCI test application to give the same unsupported command RSP from the command complete and command status HCI events.

Enabled the tests that now are able to pass.

Remove deprecated defines and added some debug tracing that I had been using.

Fixes: #22085