### PR TITLE
modules: hal: nordic: Define NRFX_ASSERT as __ASSERT_NO_MSG

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -222,7 +222,7 @@ static int twi_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 			}
 		}
 	} else {
-		assert(ctrl_command == DEVICE_PM_GET_POWER_STATE);
+		__ASSERT_NO_MSG(ctrl_command == DEVICE_PM_GET_POWER_STATE);
 		*((u32_t *)context) = get_dev_data(dev)->pm_state;
 	}
 

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -196,7 +196,7 @@ static int twim_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 			}
 		}
 	} else {
-		assert(ctrl_command == DEVICE_PM_GET_POWER_STATE);
+		__ASSERT_NO_MSG(ctrl_command == DEVICE_PM_GET_POWER_STATE);
 		*((u32_t *)context) = get_dev_data(dev)->pm_state;
 	}
 

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -295,7 +295,7 @@ static int pwm_nrfx_set_power_state(u32_t new_state,
 		}
 		break;
 	default:
-		assert(false);
+		__ASSERT_NO_MSG(false);
 		break;
 	}
 	return err;
@@ -320,7 +320,7 @@ static int pwm_nrfx_pm_control(struct device *dev,
 			}
 		}
 	} else {
-		assert(ctrl_command == DEVICE_PM_GET_POWER_STATE);
+		__ASSERT_NO_MSG(ctrl_command == DEVICE_PM_GET_POWER_STATE);
 		*((u32_t *)context) = (*current_state);
 	}
 

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -1026,9 +1026,9 @@ static void uart_nrfx_set_power_state(struct device *dev, u32_t new_state)
 		nrf_uart_enable(uart0_addr);
 		nrf_uart_task_trigger(uart0_addr, NRF_UART_TASK_STARTRX);
 	} else {
-		assert(new_state == DEVICE_PM_LOW_POWER_STATE ||
-		       new_state == DEVICE_PM_SUSPEND_STATE ||
-		       new_state == DEVICE_PM_OFF_STATE);
+		__ASSERT_NO_MSG(new_state == DEVICE_PM_LOW_POWER_STATE ||
+				new_state == DEVICE_PM_SUSPEND_STATE ||
+				new_state == DEVICE_PM_OFF_STATE);
 		nrf_uart_disable(uart0_addr);
 		uart_nrfx_pins_enable(dev, false);
 	}
@@ -1047,7 +1047,7 @@ static int uart_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 			current_state = new_state;
 		}
 	} else {
-		assert(ctrl_command == DEVICE_PM_GET_POWER_STATE);
+		__ASSERT_NO_MSG(ctrl_command == DEVICE_PM_GET_POWER_STATE);
 		*((u32_t *)context) = current_state;
 	}
 

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1285,9 +1285,9 @@ static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
 #endif
 		nrf_uarte_task_trigger(uarte, NRF_UARTE_TASK_STARTRX);
 	} else {
-		assert(new_state == DEVICE_PM_LOW_POWER_STATE ||
-		       new_state == DEVICE_PM_SUSPEND_STATE ||
-		       new_state == DEVICE_PM_OFF_STATE);
+		__ASSERT_NO_MSG(new_state == DEVICE_PM_LOW_POWER_STATE ||
+				new_state == DEVICE_PM_SUSPEND_STATE ||
+				new_state == DEVICE_PM_OFF_STATE);
 
 		/* if pm is already not active, driver will stay indefinitely
 		 * in while loop waiting for event NRF_UARTE_EVENT_RXTO
@@ -1332,7 +1332,7 @@ static int uarte_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 			data->pm_state = new_state;
 		}
 	} else {
-		assert(ctrl_command == DEVICE_PM_GET_POWER_STATE);
+		__ASSERT_NO_MSG(ctrl_command == DEVICE_PM_GET_POWER_STATE);
 		*((u32_t *)context) = data->pm_state;
 	}
 

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -311,7 +311,7 @@ static int spi_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 			}
 		}
 	} else {
-		assert(ctrl_command == DEVICE_PM_GET_POWER_STATE);
+		__ASSERT_NO_MSG(ctrl_command == DEVICE_PM_GET_POWER_STATE);
 		*((u32_t *)context) = get_dev_data(dev)->pm_state;
 	}
 

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -350,7 +350,7 @@ static int spim_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 			}
 		}
 	} else {
-		assert(ctrl_command == DEVICE_PM_GET_POWER_STATE);
+		__ASSERT_NO_MSG(ctrl_command == DEVICE_PM_GET_POWER_STATE);
 		*((u32_t *)context) = get_dev_data(dev)->pm_state;
 	}
 

--- a/west.yml
+++ b/west.yml
@@ -47,7 +47,7 @@ manifest:
       revision: a12d92816a53a521d79cefcf5c38b9dc8a4fed6e
       path: modules/hal/cypress
     - name: hal_nordic
-      revision: 12d7647870888e4cb0e421f2b26884c2e76915ac
+      revision: 62f9c632209ce9438edfcfdcee7a846344359647
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 3b54187649cc9b37161d49918f1ad28ff7c7f830


### PR DESCRIPTION
Update hal_nordic's revision, so that NRFX_ASSERT uses __ASSERT_NO_MSG
directly, not through the assert macro that comes from from libc,
as the definition of the latter might be different when some specific
libc version is used, and this could generate troubles.

Replace also uses of assert() with __ASSERT_NO_MSG() in nrfx driver
shims that use this macro without including the corresponding header
file (i.e. that implicitly rely on assert.h being included from
nrfx_glue.h, which is no longer the case).

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>

---
https://github.com/zephyrproject-rtos/hal_nordic/pull/24 needs to be merged first.

Fixes #22541