### PR TITLE
ipm: Move include headers to the right place

### DIFF
--- a/drivers/console/ipm_console_receiver.c
+++ b/drivers/console/ipm_console_receiver.c
@@ -6,12 +6,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <errno.h>
-
 #include <kernel.h>
+#include <device.h>
+#include <stdio.h>
+#include <errno.h>
 #include <sys/ring_buffer.h>
 #include <sys/printk.h>
-#include <stdio.h>
 #include <drivers/ipm.h>
 #include <drivers/console/ipm_console.h>
 #include <sys/__assert.h>

--- a/drivers/console/ipm_console_sender.c
+++ b/drivers/console/ipm_console_sender.c
@@ -6,9 +6,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <errno.h>
-
 #include <kernel.h>
+#include <device.h>
+#include <errno.h>
 #include <sys/printk.h>
 #include <drivers/ipm.h>
 #include <drivers/console/ipm_console.h>

--- a/drivers/ipm/ipm_nrfx_ipc.c
+++ b/drivers/ipm/ipm_nrfx_ipc.c
@@ -5,6 +5,7 @@
  */
 
 #include <string.h>
+#include <device.h>
 #include <drivers/ipm.h>
 #include <nrfx_ipc.h>
 #include "ipm_nrfx_ipc.h"

--- a/include/drivers/ipm.h
+++ b/include/drivers/ipm.h
@@ -20,9 +20,6 @@
  * @{
  */
 
-#include <kernel.h>
-#include <device.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/samples/bluetooth/hci_rpmsg/src/main.c
+++ b/samples/bluetooth/hci_rpmsg/src/main.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include <zephyr.h>
+#include <device.h>
 #include <arch/cpu.h>
 #include <sys/byteorder.h>
 #include <logging/log.h>

--- a/samples/subsys/ipc/ipm_mhu_dual_core/src/main.c
+++ b/samples/subsys/ipc/ipm_mhu_dual_core/src/main.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr.h>
+#include <device.h>
 #include <sys/printk.h>
 #include <drivers/ipm.h>
 

--- a/samples/subsys/ipc/openamp/remote/src/main.c
+++ b/samples/subsys/ipc/openamp/remote/src/main.c
@@ -7,12 +7,12 @@
  */
 
 #include <zephyr.h>
-#include <drivers/ipm.h>
-#include <sys/printk.h>
 #include <device.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <drivers/ipm.h>
+#include <sys/printk.h>
 
 #include <openamp/open_amp.h>
 #include <metal/device.h>

--- a/samples/subsys/ipc/openamp/src/main.c
+++ b/samples/subsys/ipc/openamp/src/main.c
@@ -7,13 +7,13 @@
  */
 
 #include <zephyr.h>
-#include <drivers/ipm.h>
-#include <sys/printk.h>
 #include <device.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <init.h>
+#include <drivers/ipm.h>
+#include <sys/printk.h>
 
 #include <openamp/open_amp.h>
 #include <metal/device.h>

--- a/tests/drivers/ipm/src/ipm_dummy.c
+++ b/tests/drivers/ipm/src/ipm_dummy.c
@@ -7,10 +7,10 @@
  */
 
 #include <zephyr.h>
-#include <drivers/ipm.h>
 #include <errno.h>
 #include <device.h>
 #include <init.h>
+#include <drivers/ipm.h>
 #include <sys/printk.h>
 #include <irq_offload.h>
 

--- a/tests/drivers/ipm/src/main.c
+++ b/tests/drivers/ipm/src/main.c
@@ -5,11 +5,11 @@
  */
 
 #include <zephyr.h>
-#include <drivers/ipm.h>
-#include <drivers/console/ipm_console.h>
 #include <device.h>
 #include <init.h>
 #include <stdio.h>
+#include <drivers/ipm.h>
+#include <drivers/console/ipm_console.h>
 
 #include <tc_util.h>
 #include "ipm_dummy.h"


### PR DESCRIPTION
Moves device.h header from ipm.h to the right places.