### PR TITLE
drivers: ieee802154: mcr20a: convert to DT_INST defines

### DIFF
--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -1370,23 +1370,23 @@ static inline int configure_spi(struct device *dev)
 		return -ENODEV;
 	}
 
-#if defined(DT_NXP_MCR20A_0_CS_GPIOS_CONTROLLER)
+#if defined(DT_INST_0_NXP_MCR20A_CS_GPIOS_CONTROLLER)
 	mcr20a->cs_ctrl.gpio_dev = device_get_binding(
-		DT_NXP_MCR20A_0_CS_GPIOS_CONTROLLER);
+		DT_INST_0_NXP_MCR20A_CS_GPIOS_CONTROLLER);
 	if (!mcr20a->cs_ctrl.gpio_dev) {
 		LOG_ERR("Unable to get GPIO SPI CS device");
 		return -ENODEV;
 	}
 
-	mcr20a->cs_ctrl.gpio_pin = DT_NXP_MCR20A_0_CS_GPIOS_PIN;
+	mcr20a->cs_ctrl.gpio_pin = DT_INST_0_NXP_MCR20A_CS_GPIOS_PIN;
 	mcr20a->cs_ctrl.delay = 0U;
 
 	mcr20a->spi_cfg.cs = &mcr20a->cs_ctrl;
 
 	LOG_DBG("SPI GPIO CS configured on %s:%u",
-		DT_NXP_MCR20A_0_CS_GPIOS_CONTROLLER,
-		DT_NXP_MCR20A_0_CS_GPIOS_PIN);
-#endif /* DT_NXP_MCR20A_0_CS_GPIOS_CONTROLLER */
+		DT_INST_0_NXP_MCR20A_CS_GPIOS_CONTROLLER,
+		DT_INST_0_NXP_MCR20A_CS_GPIOS_PIN);
+#endif /* DT_INST_0_NXP_MCR20A_CS_GPIOS_CONTROLLER */
 
 	mcr20a->spi_cfg.frequency = DT_INST_0_NXP_MCR20A_SPI_MAX_FREQUENCY;
 	mcr20a->spi_cfg.operation = SPI_WORD_SET(8);

--- a/drivers/ieee802154/ieee802154_mcr20a.h
+++ b/drivers/ieee802154/ieee802154_mcr20a.h
@@ -25,7 +25,7 @@ struct mcr20a_context {
 	struct gpio_callback irqb_cb;
 	struct device *spi;
 	struct spi_config spi_cfg;
-#if defined(DT_NXP_MCR20A_0_CS_GPIOS_CONTROLLER)
+#if defined(DT_INST_0_NXP_MCR20A_CS_GPIOS_CONTROLLER)
 	struct spi_cs_control cs_ctrl;
 #endif
 	u8_t mac_addr[8];


### PR DESCRIPTION
Convert driver to use DT_INST_ defines.  There was just one case for
CS_GPIOS that wasn't using DT_INST defines already.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>