### PR TITLE
drivers: uart: native_posix: convert to DT_INST defines

### DIFF
--- a/drivers/serial/uart_native_posix.c
+++ b/drivers/serial/uart_native_posix.c
@@ -201,7 +201,8 @@ static int np_uart_0_init(struct device *dev)
 	d = (struct native_uart_status *)dev->driver_data;
 
 	if (IS_ENABLED(CONFIG_NATIVE_UART_0_ON_OWN_PTY)) {
-		int tty_fn = open_tty(d, DT_UART_0_DEV_NAME, auto_attach);
+		int tty_fn = open_tty(d, DT_INST_0_ZEPHYR_NATIVE_POSIX_UART_LABEL,
+				      auto_attach);
 
 		d->in_fd = tty_fn;
 		d->out_fd = tty_fn;
@@ -336,7 +337,7 @@ static int np_uart_tty_poll_in(struct device *dev, unsigned char *p_char)
 }
 
 DEVICE_AND_API_INIT(uart_native_posix0,
-	    DT_UART_0_DEV_NAME, &np_uart_0_init,
+	    DT_INST_0_ZEPHYR_NATIVE_POSIX_UART_LABEL, &np_uart_0_init,
 	    (void *)&native_uart_status_0, NULL,
 	    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 	    &np_uart_driver_api_0);


### PR DESCRIPTION
Convert driver to fully use DT_INST_ defines.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>