### PR TITLE
net: icmpv4: Return ENETUNREACH when IPv4 is unavailable

### DIFF
--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -509,7 +509,7 @@ int net_icmpv4_send_echo_request(struct net_if *iface,
 	struct net_pkt *pkt;
 
 	if (!iface->config.ip.ipv4) {
-		return -EINVAL;
+		return -ENETUNREACH;
 	}
 
 	/* Take the first address of the network interface */

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -3155,7 +3155,7 @@ static int cmd_net_ping(const struct shell *shell, size_t argc, char *argv[])
 	if (IS_ENABLED(CONFIG_NET_IPV4)) {
 		ret = ping_ipv4(shell, host, count, interval);
 		if (ret) {
-			if (ret == -EIO) {
+			if (ret == -EIO || ret == -ENETUNREACH) {
 				PR_WARNING("Cannot send IPv4 ping\n");
 			} else if (ret == -EINVAL) {
 				PR_WARNING("Invalid IP address\n");


### PR DESCRIPTION
```
net_icmpv4_send_echo_request currently returns EINVAL (invalid
argument) when IPv4 is unavailable.

Since the availability of IPv4 has nothing to do with the arguments
provided to this function and the meaning of EINVAL in this case is
ambiguous, return the ENETUNREACH (network is unreachable) error
number instead.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```