### PR TITLE
boards: arc: Load Elf with OpenOCD by default

### DIFF
--- a/boards/arc/em_starterkit/board.cmake
+++ b/boards/arc/em_starterkit/board.cmake
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(openocd "--use-elf")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arc/emsdp/board.cmake
+++ b/boards/arc/emsdp/board.cmake
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(openocd "--use-elf")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arc/hsdk/board.cmake
+++ b/boards/arc/hsdk/board.cmake
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(openocd "--use-elf")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arc/iotdk/board.cmake
+++ b/boards/arc/iotdk/board.cmake
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(openocd "--use-elf")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)


### PR DESCRIPTION
Now when ARC development boards are switched to generic OpenOCD
runner we need to explicitly instruct the runner to load Elf but not
binary image (which is a default for OpenOCD runner).

This might be done either manually adding `--use-elf` option to
west's command line or that might be added by default fro affected
boards, which we do exactly now.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/22888.