### PR TITLE
interrupt_controller: dw: fix base address not defined in config

### DIFF
--- a/drivers/interrupt_controller/intc_dw.c
+++ b/drivers/interrupt_controller/intc_dw.c
@@ -126,6 +126,7 @@ static int dw_ictl_intr_get_line_state(struct device *dev, unsigned int irq)
 static void dw_ictl_config_irq(struct device *dev);
 
 static const struct dw_ictl_config dw_config = {
+	.base_addr = DT_INTC_DW_0_BASE_ADDR,
 	.numirqs = DT_INTC_DW_0_NUM_IRQS,
 	.isr_table_offset = CONFIG_DW_ISR_TBL_OFFSET,
 	.config_func = dw_ictl_config_irq,


### PR DESCRIPTION
During driver rewrite, the field to specify the base address of
the interrupt controller was dropped, which results in error in
device initialization due to accessing random address (or null).
Fix it by specifying the base address.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>