### PR TITLE
kernel/thread: Don't clobber arch initialization of switch_handle

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -517,9 +517,13 @@ void z_setup_new_thread(struct k_thread *new_thread,
 	arch_new_thread(new_thread, stack, stack_size, entry, p1, p2, p3,
 			  prio, options);
 
-#ifdef CONFIG_SMP
-	/* switch handle must be non-null except when inside z_swap() */
-	new_thread->switch_handle = new_thread;
+#ifdef CONFIG_USE_SWITCH
+	/* switch_handle must be non-null except when inside z_swap()
+	 * for synchronization reasons.  Historically some notional
+	 * USE_SWITCH architectures have actually ignored the field
+	 */
+	__ASSERT(new_thread->switch_handle != NULL,
+		 "arch layer failed to initialize switch_handle");
 #endif
 
 #ifdef CONFIG_THREAD_USERSPACE_LOCAL_DATA


### PR DESCRIPTION
The recent synchronization work required that the kernel guarantee
switch_handle is non-null, but it did it in a way that works for ARC
and x86_64 but would clobber the work xtensa had already done to
populate that field.

Add a test, and clarify that this is a fallback and that really this
is the arch layer's job.  The use of switch_handle == thread has
become a common convention, but it's not a requirement of the API;
xtensa uses a stack pointer instead.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>