### PR TITLE
Update documentation related to linking the code partition

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -389,8 +389,6 @@ config BOOTLOADER_MCUBOOT
 	      for the MCUboot image header
 	    * Activating SW_VECTOR_RELAY on Cortex-M0 (or Armv8-M baseline)
 	      targets with no built-in vector relocation mechanisms
-	    * Including dts/common/mcuboot.overlay when building the Device
-	      Tree in order to place and link the image at the slot0 offset
 
 config BOOTLOADER_ESP_IDF
 	bool "ESP-IDF bootloader support"

--- a/boards/arm/efr32_slwstk6061a/efr32_slwstk6061a.dts
+++ b/boards/arm/efr32_slwstk6061a/efr32_slwstk6061a.dts
@@ -108,11 +108,6 @@
 
 &flash0 {
 	/*
-	 * If the chosen node has no zephyr,code-partition property, the
-	 * application image link uses the entire flash device. If a
-	 * zephyr,code-partition property is defined, the application link
-	 * will be restricted to that partition.
-	 *
 	 * For more information, see:
 	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
 	 */

--- a/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
+++ b/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
@@ -143,15 +143,6 @@
 };
 
 &flash0 {
-	/*
-	 * If chosen's zephyr,code-partition
-	 * is unset, the image will be linked
-	 * into the entire flash device.  If
-	 * it points to an individual
-	 * partition, the code will be linked
-	 * to, and restricted to that
-	 * partition.
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained.dts
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained.dts
@@ -92,15 +92,6 @@
 };
 
 &flash0 {
-	/*
-	 * If chosen's zephyr,code-partition
-	 * is unset, the image will be linked
-	 * into the entire flash device.  If
-	 * it points to an individual
-	 * partition, the code will be linked
-	 * to, and restricted to that
-	 * partition.
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/doc/guides/dts/flash_partitions.inc
+++ b/doc/guides/dts/flash_partitions.inc
@@ -140,10 +140,7 @@ partition, add this to a device tree overlay:
 		};
 	};
 
-If the ``chosen`` node has no ``zephyr,code-partition`` property, the
-application image link uses the entire flash device. If a
-``zephyr,code-partition`` property is defined, the application link
-will be restricted to that partition.
+Then, enable the :option:`CONFIG_USE_DT_CODE_PARTITION` Kconfig option.
 
 Flash Partition Macros
 ======================


### PR DESCRIPTION
The method used to link code partition, as defined by zephyr,code-partition has been modified in Zephyr 1.14. Update the "Linking Zephyr Within a Partition" section to reflect the change. Also remove any remaining outdated documentation embedded in board dts files.

Update description of BOOTLOADER_MCUBOOT Kconfig option.

This fixes #13151 in master.