### PR TITLE
doc: remove 'Creating redirect:' build output

### DIFF
--- a/doc/extensions/zephyr/html_redirects.py
+++ b/doc/extensions/zephyr/html_redirects.py
@@ -58,7 +58,6 @@ def create_redirect_pages(app, docname):
     for (old_url, new_url) in app.config.html_redirect_pages:
         if old_url.startswith('/'):
             old_url = old_url[1:]
-        print("Creating redirect: %s.html to %s.html" % (old_url, new_url))
 
         new_url = app.builder.get_relative_uri(old_url, new_url)
         out_file = app.builder.get_outfilename(old_url)


### PR DESCRIPTION
This is noisy and getting in the way when I try to read the actual
warnings and errors in the output.