### PR TITLE
boards: arm: Replaces a non-working web link

### DIFF
--- a/boards/arm/actinius_icarus/doc/index.rst
+++ b/boards/arm/actinius_icarus/doc/index.rst
@@ -118,7 +118,7 @@ References
 .. target-notes::
 
 .. _IDAU:
-   https://developer.arm.com/products/architecture/cpu-architecture/m-profile/docs/100690/latest/attribution-units-sau-and-idau
+   https://developer.arm.com/docs/100690/latest/attribution-units-sau-and-idau
 
 .. _Icarus Product Website:
    https://www.actinius.com/icarus

--- a/boards/arm/mps2_an521/doc/index.rst
+++ b/boards/arm/mps2_an521/doc/index.rst
@@ -448,7 +448,7 @@ serial port:
    https://developer.arm.com/products/system-design/subsystems/corelink-sse-200-subsystem
 
 .. _IDAU:
-   https://developer.arm.com/products/architecture/cpu-architecture/m-profile/docs/100690/latest/attribution-units-sau-and-idau
+   https://developer.arm.com/docs/100690/latest/attribution-units-sau-and-idau
 
 .. _AMBA®:
    https://developer.arm.com/products/architecture/system-architectures/amba

--- a/boards/arm/nrf5340_dk_nrf5340/doc/index.rst
+++ b/boards/arm/nrf5340_dk_nrf5340/doc/index.rst
@@ -265,7 +265,7 @@ References
 .. target-notes::
 
 .. _IDAU:
-   https://developer.arm.com/products/architecture/cpu-architecture/m-profile/docs/100690/latest/attribution-units-sau-and-idau
+   https://developer.arm.com/docs/100690/latest/attribution-units-sau-and-idau
 .. _nRF5340 DK website:
    https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF5340-PDK
 .. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com

--- a/boards/arm/nrf9160_pca10090/doc/index.rst
+++ b/boards/arm/nrf9160_pca10090/doc/index.rst
@@ -198,6 +198,6 @@ References
 .. target-notes::
 
 .. _IDAU:
-   https://developer.arm.com/products/architecture/cpu-architecture/m-profile/docs/100690/latest/attribution-units-sau-and-idau
+   https://developer.arm.com/docs/100690/latest/attribution-units-sau-and-idau
 .. _nRF91 DK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF9160-DK
 .. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com

--- a/boards/arm/v2m_musca/doc/index.rst
+++ b/boards/arm/v2m_musca/doc/index.rst
@@ -437,7 +437,7 @@ serial port:
    http://srecord.sourceforge.net/man/man1/srec_cat.html
 
 .. _IDAU:
-   https://developer.arm.com/products/architecture/cpu-architecture/m-profile/docs/100690/latest/attribution-units-sau-and-idau
+   https://developer.arm.com/docs/100690/latest/attribution-units-sau-and-idau
 
 .. _AMBA®:
    https://developer.arm.com/products/architecture/system-architectures/amba

--- a/boards/arm/v2m_musca_b1/doc/index.rst
+++ b/boards/arm/v2m_musca_b1/doc/index.rst
@@ -403,7 +403,7 @@ serial port:
    http://srecord.sourceforge.net/man/man1/srec_cat.html
 
 .. _IDAU:
-   https://developer.arm.com/products/architecture/cpu-architecture/m-profile/docs/100690/latest/attribution-units-sau-and-idau
+   https://developer.arm.com/docs/100690/latest/attribution-units-sau-and-idau
 
 .. _AMBA®:
    https://developer.arm.com/products/architecture/system-architectures/amba


### PR DESCRIPTION
The web link for the Attribution units is broken.
Replacing it with a working version.

Signed-off-by: Romit Dasgupta <romlinux@gmail.com>