### PR TITLE
tests: arch: arm_irq_vector_table: fix test for nRF53-based platforms

### DIFF
--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -17,14 +17,14 @@
 #define _ISR_OFFSET 0
 
 #if defined(CONFIG_SOC_SERIES_NRF51X) || defined(CONFIG_SOC_SERIES_NRF52X)
-/* The customized solution for nRF5X-based platforms
- * requires that the POWER_CLOCK_IRQn line equals 0.
+/* The customized solution for nRF51X-based and nRF52X-based
+ * platforms requires that the POWER_CLOCK_IRQn line equals 0.
  */
 BUILD_ASSERT_MSG(POWER_CLOCK_IRQn == 0,
 	"POWER_CLOCK_IRQn != 0. Consider rework manual vector table.");
 
-/* The customized solution for nRF5X-based platforms
- * requires that the RTC1 IRQ line equals 17.
+/* The customized solution for nRF51X-based and nRF52X-based
+ * platforms requires that the RTC1 IRQ line equals 17.
  */
 BUILD_ASSERT_MSG(RTC1_IRQn == 17,
 	 "RTC1_IRQn != 17. Consider rework manual vector table.");

--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -46,20 +46,28 @@ BUILD_ASSERT_MSG(TIMER0_IRQn == 8,
 
 #endif
 
-#elif defined(CONFIG_SOC_SERIES_NRF91X)
-/* The customized solution for nRF91X-based platforms
- * requires that the POWER_CLOCK_IRQn line equals 5.
+#elif defined(CONFIG_SOC_SERIES_NRF53X) || defined(CONFIG_SOC_SERIES_NRF91X)
+/* The customized solution for nRF91X-based and nRF53X-based
+ * platforms requires that the POWER_CLOCK_IRQn line equals 5.
  */
 BUILD_ASSERT_MSG(CLOCK_POWER_IRQn == 5,
 	"POWER_CLOCK_IRQn != 5."
 	"Consider rework manual vector table.");
 
+#if !defined(CONFIG_SOC_NRF5340_CPUNET)
 /* The customized solution for nRF91X-based platforms
  * requires that the RTC1 IRQ line equals 21.
  */
 BUILD_ASSERT_MSG(RTC1_IRQn == 21,
 	 "RTC1_IRQn != 21. Consider rework manual vector table.");
 
+#else /* CONFIG_SOC_NRF5340_CPUNET */
+/* The customized solution for nRF5340_CPUNET
+ * requires that the RTC1 IRQ line equals 22.
+ */
+BUILD_ASSERT_MSG(RTC1_IRQn == 22,
+	 "RTC1_IRQn != 22. Consider rework manual vector table.");
+#endif
 #undef _ISR_OFFSET
 /* Interrupt lines 8-10 is the first set of consecutive interrupts implemented
  * in nRF9160 SOC.
@@ -193,13 +201,22 @@ vth __irq_vector_table _irq_vector_table[] = {
 	rtc1_nrf_isr
 };
 #endif /* CONFIG_BOARD_QEMU_CORTEX_M0 */
-#elif defined(CONFIG_SOC_SERIES_NRF91X)
+#elif defined(CONFIG_SOC_SERIES_NRF53X) || defined(CONFIG_SOC_SERIES_NRF91X)
+#ifndef CONFIG_SOC_NRF5340_CPUNET
 vth __irq_vector_table _irq_vector_table[] = {
 	0, 0, 0, 0, 0, nrf_power_clock_isr, 0, 0,
 	isr0, isr1, isr2,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	rtc1_nrf_isr
 };
+#else
+vth __irq_vector_table _irq_vector_table[] = {
+	0, 0, 0, 0, 0, nrf_power_clock_isr, 0, 0,
+	isr0, isr1, isr2,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	rtc1_nrf_isr
+};
+#endif
 #endif
 #elif defined(CONFIG_SOC_SERIES_CC13X2_CC26X2)
 /* TI CC13x2/CC26x2 based platforms also employ a Hardware RTC peripheral
@@ -216,7 +233,7 @@ vth __irq_vector_table _irq_vector_table[] = {
 vth __irq_vector_table _irq_vector_table[] = {
 	isr0, isr1, isr2
 };
-#endif /* CONFIG_SOC_SERIES_NRF52X || CONFIG_SOC_SERIES_NRF91X */
+#endif /* CONFIG_SOC_FAMILY_NRF */
 
 /**
  * @}


### PR DESCRIPTION
The commit fixes the test for nRF5340-based platforms by
customizing the ISR offset and the IRQ vector table.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Fixes #22914