### PR TITLE
soc/board: correct EFM32GG11B erase-block-size

### DIFF
--- a/boards/arm/efm32gg_stk3701a/efm32gg_stk3701a.dts
+++ b/boards/arm/efm32gg_stk3701a/efm32gg_stk3701a.dts
@@ -132,10 +132,10 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* Set 6Kb of storage at the end of the 2048Kb of flash */
-		storage_partition: partition@1fe800 {
+		/* Set 12Kb of storage at the end of the 2048Kb of flash */
+		storage_partition: partition@1fd000 {
 			label = "storage";
-			reg = <0x001fe800 0x00001800>;
+			reg = <0x001fd000 0x00003000>;
 		};
 	};
 };

--- a/dts/arm/silabs/efm32gg11b.dtsi
+++ b/dts/arm/silabs/efm32gg11b.dtsi
@@ -40,7 +40,7 @@
 				compatible = "soc-nv-flash";
 				label = "FLASH_0";
 				write-block-size = <4>;
-				erase-block-size = <2048>;
+				erase-block-size = <4096>;
 			};
 		};
 


### PR DESCRIPTION
This PR corrects the incorrect `erase-block-size` value set for the EFM32GG11B family of SoCs. 

Additionally, to make sure the NVS example still works for the EFM32GG-STK3701A board, the size of the storage partition is increased to 3 times the `erase-block-size`, in this case 12KB (as this seems the minimum required to make the NVS example work)

Ideally this PR is merged before release 2.2 as it contains a fix for the newly added EFM32GG-STK3701A board.