### PR TITLE
Bluetooth: Mesh: Fix bug with storing node in CDB

### DIFF
--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -2260,6 +2260,7 @@ void bt_mesh_store_cdb_node(const struct bt_mesh_cdb_node *node)
 	}
 
 	free_slot->addr = node->addr;
+	free_slot->clear = false;
 
 	schedule_cdb_store(BT_MESH_CDB_NODES_PENDING);
 }


### PR DESCRIPTION
The free_slot->clear must be set to false since it could still be true
from previous use.

Signed-off-by: Tobias Svehagen <tobias.svehagen@gmail.com>