### PR TITLE
posix: add zephyr_linker_sources() support

### DIFF
--- a/include/arch/posix/linker.ld
+++ b/include/arch/posix/linker.ld
@@ -22,13 +22,43 @@
 SECTIONS
  {
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-rom-start.ld>
+
 #include <linker/common-rom.ld>
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-rodata.ld>
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-rwdata.ld>
+
 #include <linker/common-ram.ld>
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-ram-sections.ld>
 
 #include <arch/posix/native_tasks.ld>
 
  __data_ram_end = .;
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-noinit.ld>
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-sections.ld>
 
  } INSERT AFTER .data;
 


### PR DESCRIPTION
Add snippets sections in linker script, so we add support for
zephyr_linker_sources() in native_posix arch.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>