### PR TITLE
net: icmpv4: drop requests on NET_OFFLOAD interfaces

### DIFF
--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -508,6 +508,10 @@ int net_icmpv4_send_echo_request(struct net_if *iface,
 	const struct in_addr *src;
 	struct net_pkt *pkt;
 
+	if (IS_ENABLED(CONFIG_NET_OFFLOAD) && net_if_is_ip_offloaded(iface)) {
+		return -ENOTSUP;
+	}
+
 	if (!iface->config.ip.ipv4) {
 		return -EINVAL;
 	}


### PR DESCRIPTION
NET_OFFLOAD interfaces do not handle ICMP request. Request to send ICMP
packet resulted in NULL pointer dereference in net_if_tx() later
on. Prevent that by detecting NET_OFFLOAD interfaces early in icmpv4
module.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>