### PR TITLE
manifest: mcuboot 1.5.0 revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -77,7 +77,7 @@ manifest:
       revision: cf7020eb4c7ef93319f2d6d2403a21e12a879bf6
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: 970840ccf5d80616d514bec76d87d836da05c03b
+      revision: v1.5.0
       path: bootloader/mcuboot
     - name: mcumgr
       revision: d4e97cd4fc80ff949415062b1c83fd42929e8fe4


### PR DESCRIPTION
Introduce exact 1.5.0 mcuboot release version
Difference to previous reference:
- imgtool: fix passing --erased-val with 0xff value
- mcuboot internal sim patches (not affected zephyr)
- release note ect.
- introduced default recovery trigger pin configuration for nRF5340

** No mcuboot embedded C code changes at all. **

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>