### PR TITLE
Bluetooth: controller: split: Fix radio in use during flash op

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -574,6 +574,10 @@ static void isr_cleanup(void *param)
 	int err;
 
 	radio_isr_set(isr_race, param);
+	if (!radio_is_idle()) {
+		radio_disable();
+	}
+
 	radio_tmr_stop();
 
 	err = lll_clk_off();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -632,6 +632,10 @@ static void isr_cleanup(void *param)
 	int err;
 
 	radio_isr_set(isr_race, param);
+	if (!radio_is_idle()) {
+		radio_disable();
+	}
+
 	radio_tmr_stop();
 
 	err = lll_clk_off();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -636,6 +636,10 @@ static void isr_cleanup(void *param)
 #endif /* !CONFIG_BT_CTLR_SCAN_INDICATION */
 
 	radio_isr_set(isr_race, param);
+	if (!radio_is_idle()) {
+		radio_disable();
+	}
+
 	radio_tmr_stop();
 
 	err = lll_clk_off();


### PR DESCRIPTION
Fix a race condition in radio abort requested by flash
driver. It is possible that during abort function execution,
PPI setup to start radio fires. Hence, check explicitly in
cleanup function for radio being in use and disable it.

Fixes #22945.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>