### PR TITLE
Bluetooth: Fix GATT CCC issue with multiple local identities

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2630,15 +2630,15 @@ u8_t bt_conn_index(struct bt_conn *conn)
 	return index;
 }
 
-struct bt_conn *bt_conn_lookup_id(u8_t id)
+struct bt_conn *bt_conn_lookup_index(u8_t index)
 {
 	struct bt_conn *conn;
 
-	if (id >= ARRAY_SIZE(conns)) {
+	if (index >= ARRAY_SIZE(conns)) {
 		return NULL;
 	}
 
-	conn = &conns[id];
+	conn = &conns[index];
 
 	if (!atomic_get(&conn->ref)) {
 		return NULL;

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -200,9 +200,9 @@ void bt_conn_disconnect_all(u8_t id);
 /* Look up an existing connection */
 struct bt_conn *bt_conn_lookup_handle(u16_t handle);
 
-/* Compare an address with bt_conn destination address */
-int bt_conn_addr_le_cmp(const struct bt_conn *conn, const bt_addr_le_t *peer);
-
+/* Check if the connection is with the given peer. */
+bool bt_conn_is_peer_addr_le(const struct bt_conn *conn, u8_t id,
+			     const bt_addr_le_t *peer);
 
 /* Helpers for identifying & looking up connections based on the the index to
  * the connection list. This is useful for O(1) lookups, but can't be used
@@ -214,7 +214,7 @@ struct bt_conn *bt_conn_lookup_index(u8_t index);
 /* Look up a connection state. For BT_ADDR_LE_ANY, returns the first connection
  * with the specific state
  */
-struct bt_conn *bt_conn_lookup_state_le(const bt_addr_le_t *peer,
+struct bt_conn *bt_conn_lookup_state_le(u8_t id, const bt_addr_le_t *peer,
 					const bt_conn_state_t state);
 
 /* Set connection object in certain state and perform action related to state */

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -208,8 +208,8 @@ int bt_conn_addr_le_cmp(const struct bt_conn *conn, const bt_addr_le_t *peer);
  * the connection list. This is useful for O(1) lookups, but can't be used
  * e.g. as the handle since that's assigned to us by the controller.
  */
-#define BT_CONN_ID_INVALID 0xff
-struct bt_conn *bt_conn_lookup_id(u8_t id);
+#define BT_CONN_INDEX_INVALID 0xff
+struct bt_conn *bt_conn_lookup_index(u8_t index);
 
 /* Look up a connection state. For BT_ADDR_LE_ANY, returns the first connection
  * with the specific state

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -138,7 +138,7 @@ struct acl_data {
 	u8_t  type;
 
 	/* Index into the bt_conn storage array */
-	u8_t  id;
+	u8_t  index;
 
 	/** ACL connection handle */
 	u16_t handle;
@@ -234,9 +234,10 @@ static void report_completed_packet(struct net_buf *buf)
 		return;
 	}
 
-	conn = bt_conn_lookup_id(acl(buf)->id);
+	conn = bt_conn_lookup_index(acl(buf)->index);
 	if (!conn) {
-		BT_WARN("Unable to look up conn with id 0x%02x", acl(buf)->id);
+		BT_WARN("Unable to look up conn with index 0x%02x",
+			acl(buf)->index);
 		return;
 	}
 
@@ -778,7 +779,7 @@ static void hci_acl(struct net_buf *buf)
 	flags = bt_acl_flags(handle);
 
 	acl(buf)->handle = bt_acl_handle(handle);
-	acl(buf)->id = BT_CONN_ID_INVALID;
+	acl(buf)->index = BT_CONN_INDEX_INVALID;
 
 	BT_DBG("handle %u len %u flags %u", acl(buf)->handle, len, flags);
 
@@ -795,7 +796,7 @@ static void hci_acl(struct net_buf *buf)
 		return;
 	}
 
-	acl(buf)->id = bt_conn_index(conn);
+	acl(buf)->index = bt_conn_index(conn);
 
 	bt_conn_recv(conn, buf, flags);
 	bt_conn_unref(conn);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -596,7 +596,8 @@ static void rpa_timeout(struct k_work *work)
 
 	if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
 		struct bt_conn *conn =
-			bt_conn_lookup_state_le(NULL, BT_CONN_CONNECT_SCAN);
+			bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
+						BT_CONN_CONNECT_SCAN);
 
 		if (conn) {
 			bt_conn_unref(conn);
@@ -1215,9 +1216,11 @@ static struct bt_conn *find_pending_connect(u8_t role, bt_addr_le_t *peer_addr)
 	 * CONNECT or DIR_ADV state associated with passed peer LE address.
 	 */
 	if (IS_ENABLED(CONFIG_BT_CENTRAL) && role == BT_HCI_ROLE_MASTER) {
-		conn = bt_conn_lookup_state_le(peer_addr, BT_CONN_CONNECT);
+		conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, peer_addr,
+					       BT_CONN_CONNECT);
 		if (IS_ENABLED(CONFIG_BT_WHITELIST) && !conn) {
-			conn = bt_conn_lookup_state_le(BT_ADDR_LE_NONE,
+			conn = bt_conn_lookup_state_le(BT_ID_DEFAULT,
+						       BT_ADDR_LE_NONE,
 						       BT_CONN_CONNECT_AUTO);
 		}
 
@@ -1225,10 +1228,11 @@ static struct bt_conn *find_pending_connect(u8_t role, bt_addr_le_t *peer_addr)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && role == BT_HCI_ROLE_SLAVE) {
-		conn = bt_conn_lookup_state_le(peer_addr,
+		conn = bt_conn_lookup_state_le(bt_dev.adv_id, peer_addr,
 					       BT_CONN_CONNECT_DIR_ADV);
 		if (!conn) {
-			conn = bt_conn_lookup_state_le(BT_ADDR_LE_NONE,
+			conn = bt_conn_lookup_state_le(bt_dev.adv_id,
+						       BT_ADDR_LE_NONE,
 						       BT_CONN_CONNECT_ADV);
 		}
 
@@ -1761,7 +1765,8 @@ static void check_pending_conn(const bt_addr_le_t *id_addr,
 		return;
 	}
 
-	conn = bt_conn_lookup_state_le(id_addr, BT_CONN_CONNECT_SCAN);
+	conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, id_addr,
+				       BT_CONN_CONNECT_SCAN);
 	if (!conn) {
 		return;
 	}
@@ -3083,7 +3088,7 @@ void bt_id_add(struct bt_keys *keys)
 		return;
 	}
 
-	conn = bt_conn_lookup_state_le(NULL, BT_CONN_CONNECT);
+	conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_CONNECT);
 	if (conn) {
 		atomic_set_bit(bt_dev.flags, BT_DEV_ID_PENDING);
 		keys->flags |= BT_KEYS_ID_PENDING_ADD;
@@ -3190,7 +3195,7 @@ void bt_id_del(struct bt_keys *keys)
 		return;
 	}
 
-	conn = bt_conn_lookup_state_le(NULL, BT_CONN_CONNECT);
+	conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_CONNECT);
 	if (conn) {
 		atomic_set_bit(bt_dev.flags, BT_DEV_ID_PENDING);
 		keys->flags |= BT_KEYS_ID_PENDING_DEL;
@@ -3736,13 +3741,15 @@ int bt_le_scan_update(bool fast_scan)
 		struct bt_conn *conn;
 
 		/* don't restart scan if we have pending connection */
-		conn = bt_conn_lookup_state_le(NULL, BT_CONN_CONNECT);
+		conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
+					       BT_CONN_CONNECT);
 		if (conn) {
 			bt_conn_unref(conn);
 			return 0;
 		}
 
-		conn = bt_conn_lookup_state_le(NULL, BT_CONN_CONNECT_SCAN);
+		conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
+					       BT_CONN_CONNECT_SCAN);
 		if (!conn) {
 			return 0;
 		}
@@ -6192,14 +6199,15 @@ int bt_le_adv_stop(void)
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
 		struct bt_conn *conn;
 
-		conn = bt_conn_lookup_state_le(BT_ADDR_LE_NONE,
+		conn = bt_conn_lookup_state_le(bt_dev.adv_id, BT_ADDR_LE_NONE,
 					       BT_CONN_CONNECT_ADV);
 		if (conn) {
 			bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
 			bt_conn_unref(conn);
 		}
 
-		conn = bt_conn_lookup_state_le(NULL, BT_CONN_CONNECT_DIR_ADV);
+		conn = bt_conn_lookup_state_le(bt_dev.adv_id, NULL,
+					       BT_CONN_CONNECT_DIR_ADV);
 		if (conn) {
 			bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
 			bt_conn_unref(conn);


### PR DESCRIPTION
Fix issue where a new connection with the same peer would use the CCC
from from first connection, despite different local identity.
Since there is no CCC for the new connection yet this caused the
application to think that CCC was enabled but the remote device had not
yet subscribed.
    
Fix this issue by making the id as an input to the peer address check
function. This will force us to make the check every time. This
might also fix similar issues not yes discovered as the ID check was
missing in a few other places as well.

Fixes: #23023