### PR TITLE
sanitycheck: support 'skipped' in 'passed' field in sanitycheck.csv

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2655,7 +2655,7 @@ class TestSuite:
             instance_list = []
             for row in cr:
                 total_tests += 1
-                if row["passed"] == "True":
+                if row["passed"] != "False":
                     continue
                 test = row["test"]
                 platform = self.get_platform(row["platform"])
@@ -2687,6 +2687,8 @@ class TestSuite:
             instance_list = []
             for row in cr:
                 if row["arch"] == "arch":
+                    continue
+                if row["passed"] == "skipped":
                     continue
                 test = row["test"]
                 platform = self.get_platform(row["platform"])
@@ -3187,7 +3189,10 @@ class TestSuite:
                     rowdict["passed"] = False
                     rowdict["status"] = instance.reason
                 else:
-                    rowdict["passed"] = True
+                    if instance.status == "skipped":
+                        rowdict["passed"] = "skipped"
+                    else:
+                        rowdict["passed"] = True
                     if instance.handler:
                         rowdict["handler_time"] = instance.metrics.get("handler_time", 0)
                     ram_size = instance.metrics.get("ram_size", 0)


### PR DESCRIPTION
Currently the passed field is either 'True' or 'False'.  However when we
run tests we also have the option of skipping tests for various reasons.
Currently we treat 'skipped' tests as 'True'.

There are a few cases in which we load sanitycheck.csv to determine
which tests to run:

1. --only-failed
2. --load-tests
3. --test-only

For the --test-only case the fact that we don't track 'skipped' ends up
causing usage errors.  One would expect the following to be equivalent:

   sanitycheck -p qemu_cortex_m0 -T samples/

vs

   sanitycheck --build-only -p qemu_cortex_m0 -T samples/
   sanitycheck --test-only -p qemu_cortex_m0 -T samples/

But the second will fail in --test-only since various jobs that are
meant to be skipped are re-tried.

So we can easily fix the situation by adding 'skipped' as an option in
the 'passed' field in the csv.  We change --only-failed to load tests
based on the 'passed' field being 'False'.  We change --load-tests and
--test-only to skip tests with the passed field being 'skipped'.

Fixes #22948

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>