### PR TITLE
tests: interrupt: remove broken scenario

### DIFF
--- a/tests/kernel/interrupt/src/main.c
+++ b/tests/kernel/interrupt/src/main.c
@@ -65,7 +65,6 @@ void test_main(void)
 	ztest_test_suite(interrupt_feature,
 			ztest_unit_test(test_isr_dynamic),
 			ztest_unit_test(test_nested_isr),
-			ztest_unit_test(test_prevent_interruption)
 			);
 	ztest_run_test_suite(interrupt_feature);
 }

--- a/tests/kernel/interrupt/src/nested_irq.c
+++ b/tests/kernel/interrupt/src/nested_irq.c
@@ -129,27 +129,3 @@ void test_nested_isr(void)
 	ztest_test_skip();
 }
 #endif /* NO_TRIGGER_FROM_SW */
-
-static void timer_handler(struct k_timer *timer)
-{
-	ARG_UNUSED(timer);
-	check_lock_new = 0xBEEF;
-}
-
-static void offload_function(void *param)
-{
-	ARG_UNUSED(param);
-
-	zassert_true(k_is_in_isr(), "Not in IRQ context!");
-	k_timer_init(&timer, timer_handler, NULL);
-	k_busy_wait(MS_TO_US(1));
-	k_timer_start(&timer, DURATION, K_NO_WAIT);
-	zassert_not_equal(check_lock_new, check_lock_old,
-		"Interrupt locking didn't work properly");
-}
-
-void test_prevent_interruption(void)
-{
-	irq_offload(offload_function, NULL);
-	k_timer_stop(&timer);
-}


### PR DESCRIPTION
The author of this test case seems to have been under the
mistaken impression that interrupts are locked in ISRs, which
is untrue.

The only reason this ever passed, anywhere, was a race between
the timer firing and the zassert_not_equal() check in
offload_function.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>