### PR TITLE
nios2: add arch_irq_is_enabled()

### DIFF
--- a/arch/nios2/core/irq_manage.c
+++ b/arch/nios2/core/irq_manage.c
@@ -61,6 +61,13 @@ void arch_irq_disable(unsigned int irq)
 	irq_unlock(key);
 };
 
+int arch_irq_is_enabled(unsigned int irq)
+{
+	u32_t ienable;
+
+	ienable = z_nios2_creg_read(NIOS2_CR_IENABLE);
+	return ienable & BIT(irq);
+}
 
 /**
  * @brief Interrupt demux function


### PR DESCRIPTION
This arch API was never implemented on this architecture.

Fixes: #9994

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>