### PR TITLE
Revert apic changes

### DIFF
--- a/arch/x86/core/ia32/crt0.S
+++ b/arch/x86/core/ia32/crt0.S
@@ -236,9 +236,6 @@ __csSet:
 	lidt	z_x86_idt		/* load 32-bit operand size IDT */
 
 #ifdef CONFIG_LOAPIC
-	/* For BSP, cpu_number is 0 */
-	xorl	%eax, %eax
-	pushl	%eax
 	call	z_loapic_enable
 #endif
 

--- a/arch/x86/core/intel64/cpu.c
+++ b/arch/x86/core/intel64/cpu.c
@@ -144,8 +144,7 @@ FUNC_NORETURN void z_x86_cpu_init(struct x86_cpuboot *cpuboot)
 {
 	x86_sse_init(NULL);
 
-	/* The internal cpu_number is the index to x86_cpuboot[] */
-	z_loapic_enable((unsigned char)(cpuboot - x86_cpuboot));
+	z_loapic_enable();
 
 #ifdef CONFIG_USERSPACE
 	/* Set landing site for 'syscall' instruction */

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -71,26 +71,9 @@ static u32_t loapic_device_power_state = DEVICE_PM_ACTIVE_STATE;
  * Called from early assembly layer (e.g., crt0.S).
  */
 
-void z_loapic_enable(unsigned char cpu_number)
+void z_loapic_enable(void)
 {
 	s32_t loApicMaxLvt; /* local APIC Max LVT */
-
-#ifndef CONFIG_X2APIC
-	/*
-	 * in xAPIC and flat model, bits 24-31 in LDR (Logical APIC ID) are
-	 * bitmap of target logical APIC ID and it supports maximum 8 local
-	 * APICs.
-	 *
-	 * The logical APIC ID could be arbitrarily selected by system software
-	 * and is different from local APIC ID in local APIC ID register.
-	 *
-	 * We choose 0 for BSP, and the index to x86_cpuboot[] for secondary
-	 * CPUs.
-	 *
-	 * in X2APIC, LDR is read-only.
-	 */
-	x86_write_xapic(LOAPIC_LDR, 1 << (cpu_number + 24));
-#endif
 
 	/*
 	 * enable the local APIC. note that we use xAPIC mode here, since
@@ -116,7 +99,6 @@ void z_loapic_enable(unsigned char cpu_number)
 	/* reset the DFR, TPR, TIMER_CONFIG, and TIMER_ICR */
 
 #ifndef CONFIG_X2APIC
-	/* Flat model */
 	x86_write_loapic(LOAPIC_DFR, 0xffffffff);  /* no DFR in x2APIC mode */
 #endif
 

--- a/include/drivers/interrupt_controller/loapic.h
+++ b/include/drivers/interrupt_controller/loapic.h
@@ -54,7 +54,7 @@
 extern "C" {
 #endif
 
-extern void z_loapic_enable(unsigned char cpu_number);
+extern void z_loapic_enable(void);
 extern void z_loapic_int_vec_set(unsigned int irq, unsigned int vector);
 extern void z_loapic_irq_enable(unsigned int irq);
 extern void z_loapic_irq_disable(unsigned int irq);


### PR DESCRIPTION
Reverts #22848

With this PR merged, we are now seeing many tests getting stuck and timing out on qemu_x86_64. This needs to be properly investigated and the PR re-submitted.