### PR TITLE
drivers: ethernet: eth_sam_gmac: Fix priority queues

### DIFF
--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -20,9 +20,14 @@ config ETH_SAM_GMAC_NAME
 	  required by all driver API functions. Device name has to be unique.
 
 config ETH_SAM_GMAC_QUEUES
-	int "Number of hardware TX and RX queues"
+	int "Number of active hardware TX and RX queues"
 	default 1
-	range 1 3
+	range 1 1 if SOC_SERIES_SAM4E
+	range 1 3 if !SOC_SERIES_SAM4E && \
+		     !SOC_ATMEL_SAME70_REVB && \
+		     !SOC_ATMEL_SAMV71_REVB
+	range 1 6 if SOC_ATMEL_SAME70_REVB || \
+		     SOC_ATMEL_SAMV71_REVB
 	help
 	  Select the number of hardware queues used by the driver. Packets will be
 	  routed to appropriate queues based on their priority.
@@ -44,6 +49,9 @@ config ETH_SAM_GMAC_FORCED_QUEUE
 	default 0
 	range 0 1 if ETH_SAM_GMAC_QUEUES = 2
 	range 0 2 if ETH_SAM_GMAC_QUEUES = 3
+	range 0 3 if ETH_SAM_GMAC_QUEUES = 4
+	range 0 4 if ETH_SAM_GMAC_QUEUES = 5
+	range 0 5 if ETH_SAM_GMAC_QUEUES = 6
 	help
 	  Which queue to force the routing to. This affects both the TX and RX queues
 	  setup.

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -79,6 +79,14 @@ static struct gmac_desc rx_desc_que1[PRIORITY_QUEUE1_RX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
 static struct gmac_desc rx_desc_que2[PRIORITY_QUEUE2_RX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+#if GMAC_QUEUE_NUM > 3
+static struct gmac_desc rx_desc_que3[PRIORITY_QUEUE3_RX_DESC_COUNT]
+	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+static struct gmac_desc rx_desc_que4[PRIORITY_QUEUE4_RX_DESC_COUNT]
+	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+static struct gmac_desc rx_desc_que5[PRIORITY_QUEUE5_RX_DESC_COUNT]
+	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+#endif
 /* TX descriptors list */
 static struct gmac_desc tx_desc_que0[MAIN_QUEUE_TX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
@@ -86,6 +94,14 @@ static struct gmac_desc tx_desc_que1[PRIORITY_QUEUE1_TX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
 static struct gmac_desc tx_desc_que2[PRIORITY_QUEUE2_TX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+#if GMAC_QUEUE_NUM > 3
+static struct gmac_desc tx_desc_que3[PRIORITY_QUEUE3_TX_DESC_COUNT]
+	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+static struct gmac_desc tx_desc_que4[PRIORITY_QUEUE4_TX_DESC_COUNT]
+	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+static struct gmac_desc tx_desc_que5[PRIORITY_QUEUE5_TX_DESC_COUNT]
+	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+#endif
 
 /* RX buffer accounting list */
 static struct net_buf *rx_frag_list_que0[MAIN_QUEUE_RX_DESC_COUNT];
@@ -1702,7 +1718,7 @@ static void eth0_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 
 	/* Initialize GMAC queues */
-	for (i = 0; i < GMAC_QUEUE_NO; i++) {
+	for (i = 0; i < GMAC_QUEUE_NUM; i++) {
 		result = queue_init(cfg->regs, &dev_data->queue_list[i]);
 		if (result < 0) {
 			LOG_ERR("Unable to initialize ETH queue%d", i);
@@ -2050,6 +2066,38 @@ static struct eth_sam_dev_data eth0_data = {
 			}
 #endif
 #endif
+#endif
+#if GMAC_QUEUE_NUM > 3
+		}, {
+			.que_idx = GMAC_QUE_3,
+			.rx_desc_list = {
+				.buf = rx_desc_que3,
+				.len = ARRAY_SIZE(rx_desc_que3),
+			},
+			.tx_desc_list = {
+				.buf = tx_desc_que3,
+				.len = ARRAY_SIZE(tx_desc_que3),
+			},
+		}, {
+			.que_idx = GMAC_QUE_4,
+			.rx_desc_list = {
+				.buf = rx_desc_que4,
+				.len = ARRAY_SIZE(rx_desc_que4),
+			},
+			.tx_desc_list = {
+				.buf = tx_desc_que4,
+				.len = ARRAY_SIZE(tx_desc_que4),
+			},
+		}, {
+			.que_idx = GMAC_QUE_5,
+			.rx_desc_list = {
+				.buf = rx_desc_que5,
+				.len = ARRAY_SIZE(rx_desc_que5),
+			},
+			.tx_desc_list = {
+				.buf = tx_desc_que5,
+				.len = ARRAY_SIZE(tx_desc_que5),
+			},
 #endif
 		}
 	},

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -66,7 +66,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 	"due to the granularity of RX DMA"
 #endif
 
-#if (CONFIG_ETH_SAM_GMAC_BUF_RX_COUNT + 1) * CONFIG_ETH_SAM_GMAC_QUEUES \
+#if (CONFIG_ETH_SAM_GMAC_BUF_RX_COUNT + 1) * GMAC_ACTIVE_QUEUE_NUM \
 	> CONFIG_NET_BUF_RX_COUNT
 #error Not enough RX buffers to allocate descriptors for each HW queue
 #endif
@@ -75,59 +75,105 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 /* RX descriptors list */
 static struct gmac_desc rx_desc_que0[MAIN_QUEUE_RX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+#if GMAC_PRIORITY_QUEUE_NUM >= 1
 static struct gmac_desc rx_desc_que1[PRIORITY_QUEUE1_RX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+#endif
+#if GMAC_PRIORITY_QUEUE_NUM >= 2
 static struct gmac_desc rx_desc_que2[PRIORITY_QUEUE2_RX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
-#if GMAC_QUEUE_NUM > 3
+#endif
+#if GMAC_PRIORITY_QUEUE_NUM >= 3
 static struct gmac_desc rx_desc_que3[PRIORITY_QUEUE3_RX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+#endif
+#if GMAC_PRIORITY_QUEUE_NUM >= 4
 static struct gmac_desc rx_desc_que4[PRIORITY_QUEUE4_RX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+#endif
+#if GMAC_PRIORITY_QUEUE_NUM >= 5
 static struct gmac_desc rx_desc_que5[PRIORITY_QUEUE5_RX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
 #endif
+
 /* TX descriptors list */
 static struct gmac_desc tx_desc_que0[MAIN_QUEUE_TX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+#if GMAC_PRIORITY_QUEUE_NUM >= 1
 static struct gmac_desc tx_desc_que1[PRIORITY_QUEUE1_TX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+#endif
+#if GMAC_PRIORITY_QUEUE_NUM >= 2
 static struct gmac_desc tx_desc_que2[PRIORITY_QUEUE2_TX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
-#if GMAC_QUEUE_NUM > 3
+#endif
+#if GMAC_PRIORITY_QUEUE_NUM >= 3
 static struct gmac_desc tx_desc_que3[PRIORITY_QUEUE3_TX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+#endif
+#if GMAC_PRIORITY_QUEUE_NUM >= 4
 static struct gmac_desc tx_desc_que4[PRIORITY_QUEUE4_TX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+#endif
+#if GMAC_PRIORITY_QUEUE_NUM >= 5
 static struct gmac_desc tx_desc_que5[PRIORITY_QUEUE5_TX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
 #endif
 
 /* RX buffer accounting list */
 static struct net_buf *rx_frag_list_que0[MAIN_QUEUE_RX_DESC_COUNT];
-#if GMAC_PRIORITY_QUEUE_NO >= 1
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1
 static struct net_buf *rx_frag_list_que1[PRIORITY_QUEUE1_RX_DESC_COUNT];
 #endif
-#if GMAC_PRIORITY_QUEUE_NO == 2
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 2
 static struct net_buf *rx_frag_list_que2[PRIORITY_QUEUE2_RX_DESC_COUNT];
 #endif
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 3
+static struct net_buf *rx_frag_list_que3[PRIORITY_QUEUE3_RX_DESC_COUNT];
+#endif
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 4
+static struct net_buf *rx_frag_list_que4[PRIORITY_QUEUE4_RX_DESC_COUNT];
+#endif
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 5
+static struct net_buf *rx_frag_list_que5[PRIORITY_QUEUE5_RX_DESC_COUNT];
+#endif
+
 #if GMAC_MULTIPLE_TX_PACKETS == 1
 /* TX buffer accounting list */
 static struct net_buf *tx_frag_list_que0[MAIN_QUEUE_TX_DESC_COUNT];
-#if GMAC_PRIORITY_QUEUE_NO >= 1
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1
 static struct net_buf *tx_frag_list_que1[PRIORITY_QUEUE1_TX_DESC_COUNT];
 #endif
-#if GMAC_PRIORITY_QUEUE_NO == 2
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 2
 static struct net_buf *tx_frag_list_que2[PRIORITY_QUEUE2_TX_DESC_COUNT];
 #endif
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 3
+static struct net_buf *tx_frag_list_que3[PRIORITY_QUEUE3_TX_DESC_COUNT];
+#endif
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 4
+static struct net_buf *tx_frag_list_que4[PRIORITY_QUEUE4_TX_DESC_COUNT];
+#endif
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 5
+static struct net_buf *tx_frag_list_que5[PRIORITY_QUEUE5_TX_DESC_COUNT];
+#endif
+
 #if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
 /* TX frames accounting list */
 static struct net_pkt *tx_frame_list_que0[CONFIG_NET_PKT_TX_COUNT + 1];
-#if GMAC_PRIORITY_QUEUE_NO >= 1
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1
 static struct net_pkt *tx_frame_list_que1[CONFIG_NET_PKT_TX_COUNT + 1];
 #endif
-#if GMAC_PRIORITY_QUEUE_NO == 2
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 2
 static struct net_pkt *tx_frame_list_que2[CONFIG_NET_PKT_TX_COUNT + 1];
+#endif
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 3
+static struct net_pkt *tx_frame_list_que3[CONFIG_NET_PKT_TX_COUNT + 1];
+#endif
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 4
+static struct net_pkt *tx_frame_list_que4[CONFIG_NET_PKT_TX_COUNT + 1];
+#endif
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 5
+static struct net_pkt *tx_frame_list_que5[CONFIG_NET_PKT_TX_COUNT + 1];
 #endif
 #endif
 #endif
@@ -628,7 +674,7 @@ static void rx_error_handler(Gmac *gmac, struct gmac_queue *queue)
 	}
 
 	/* Set Receive Buffer Queue Pointer Register */
-	if (queue->que_idx == 0) {
+	if (queue->que_idx == GMAC_QUE_0) {
 		gmac->GMAC_RBQB = (u32_t)queue->rx_desc_list.buf;
 	} else {
 		gmac->GMAC_RBQBAPQ[queue->que_idx - 1] =
@@ -668,11 +714,11 @@ static int get_mck_clock_divisor(u32_t mck)
 	return mck_divisor;
 }
 
-#if GMAC_PRIORITY_QUEUE_NO >= 1
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1
 static int eth_sam_gmac_setup_qav(Gmac *gmac, int queue_id, bool enable)
 {
 	/* Verify queue id */
-	if (queue_id < 1 || queue_id > GMAC_PRIORITY_QUEUE_NO) {
+	if (queue_id < GMAC_QUE_1 || queue_id > GMAC_ACTIVE_PRIORITY_QUEUE_NUM) {
 		return -EINVAL;
 	}
 
@@ -696,7 +742,7 @@ static int eth_sam_gmac_setup_qav(Gmac *gmac, int queue_id, bool enable)
 static int eth_sam_gmac_get_qav_status(Gmac *gmac, int queue_id, bool *enabled)
 {
 	/* Verify queue id */
-	if (queue_id < 1 || queue_id > GMAC_PRIORITY_QUEUE_NO) {
+	if (queue_id < GMAC_QUE_1 || queue_id > GMAC_ACTIVE_PRIORITY_QUEUE_NUM) {
 		return -EINVAL;
 	}
 
@@ -715,7 +761,7 @@ static int eth_sam_gmac_setup_qav_idle_slope(Gmac *gmac, int queue_id,
 	u32_t cbscr_val;
 
 	/* Verify queue id */
-	if (queue_id < 1 || queue_id > GMAC_PRIORITY_QUEUE_NO) {
+	if (queue_id < GMAC_QUE_1 || queue_id > GMAC_ACTIVE_PRIORITY_QUEUE_NUM) {
 		return -EINVAL;
 	}
 
@@ -758,7 +804,7 @@ static int eth_sam_gmac_get_qav_idle_slope(Gmac *gmac, int queue_id,
 					   unsigned int *idle_slope)
 {
 	/* Verify queue id */
-	if (queue_id < 1 || queue_id > GMAC_PRIORITY_QUEUE_NO) {
+	if (queue_id < GMAC_QUE_1 || queue_id > GMAC_ACTIVE_PRIORITY_QUEUE_NUM) {
 		return -EINVAL;
 	}
 
@@ -808,7 +854,7 @@ static int eth_sam_gmac_setup_qav_delta_bandwidth(Gmac *gmac, int queue_id,
 	u32_t idle_slope;
 
 	/* Verify queue id */
-	if (queue_id < 1 || queue_id > GMAC_PRIORITY_QUEUE_NO) {
+	if (queue_id < GMAC_QUE_1 || queue_id > GMAC_ACTIVE_PRIORITY_QUEUE_NUM) {
 		return -EINVAL;
 	}
 
@@ -862,6 +908,7 @@ static void gmac_setup_ptp_clock_divisors(Gmac *gmac)
 static int gmac_init(Gmac *gmac, u32_t gmac_ncfgr_val)
 {
 	int mck_divisor;
+	u32_t idx;
 
 	mck_divisor = get_mck_clock_divisor(SOC_ATMEL_SAM_MCK_FREQ_HZ);
 	if (mck_divisor < 0) {
@@ -873,12 +920,13 @@ static int gmac_init(Gmac *gmac, u32_t gmac_ncfgr_val)
 
 	/* Disable all interrupts */
 	gmac->GMAC_IDR = UINT32_MAX;
-	gmac->GMAC_IDRPQ[GMAC_QUE_1 - 1] = UINT32_MAX;
-	gmac->GMAC_IDRPQ[GMAC_QUE_2 - 1] = UINT32_MAX;
 	/* Clear all interrupts */
 	(void)gmac->GMAC_ISR;
-	(void)gmac->GMAC_ISRPQ[GMAC_QUE_1 - 1];
-	(void)gmac->GMAC_ISRPQ[GMAC_QUE_2 - 1];
+
+	for (idx = GMAC_QUE_0; idx < GMAC_PRIORITY_QUEUE_NUM; idx++) {
+		gmac->GMAC_IDRPQ[idx] = UINT32_MAX;
+		(void)gmac->GMAC_ISRPQ[idx];
+	}
 	/* Setup Hash Registers - enable reception of all multicast frames when
 	 * GMAC_NCFGR_MTIHEN is set.
 	 */
@@ -904,10 +952,9 @@ static int gmac_init(Gmac *gmac, u32_t gmac_ncfgr_val)
 	/* Enable Qav if priority queues are used, and setup the default delta
 	 * bandwidth according to IEEE802.1Qav (34.3.1)
 	 */
-#if GMAC_PRIORITY_QUEUE_NO == 1
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM == 1
 	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 1, 75);
-	eth_sam_gmac_setup_qav(gmac, 1, true);
-#elif GMAC_PRIORITY_QUEUE_NO == 2
+#elif GMAC_ACTIVE_PRIORITY_QUEUE_NUM == 2
 	/* For multiple priority queues, 802.1Qav suggests using 75% for the
 	 * highest priority queue, and 0% for the lower priority queues.
 	 * This is because the lower priority queues are supposed to be using
@@ -920,9 +967,26 @@ static int gmac_init(Gmac *gmac, u32_t gmac_ncfgr_val)
 	 */
 	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 1, 25);
 	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 2, 50);
-	eth_sam_gmac_setup_qav(gmac, 1, true);
-	eth_sam_gmac_setup_qav(gmac, 2, true);
+#elif GMAC_ACTIVE_PRIORITY_QUEUE_NUM == 3
+	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 1, 25);
+	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 2, 25);
+	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 3, 25);
+#elif GMAC_ACTIVE_PRIORITY_QUEUE_NUM == 4
+	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 1, 21);
+	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 2, 18);
+	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 3, 18);
+	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 4, 18);
+#elif GMAC_ACTIVE_PRIORITY_QUEUE_NUM == 5
+	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 1, 15);
+	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 2, 15);
+	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 3, 15);
+	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 4, 15);
+	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 5, 15);
 #endif
+
+	for (idx = GMAC_QUE_1; idx <= GMAC_ACTIVE_PRIORITY_QUEUE_NUM; idx++) {
+		eth_sam_gmac_setup_qav(gmac, idx, true);
+	}
 
 	return 0;
 }
@@ -1092,9 +1156,9 @@ static int priority_queue_init_as_idle(Gmac *gmac, struct gmac_queue *queue)
 
 static int queue_init(Gmac *gmac, struct gmac_queue *queue)
 {
-	if (queue->que_idx == 0) {
+	if (queue->que_idx == GMAC_QUE_0) {
 		return nonpriority_queue_init(gmac, queue);
-	} else if (queue->que_idx <= GMAC_PRIORITY_QUEUE_NO) {
+	} else if (queue->que_idx <= GMAC_ACTIVE_PRIORITY_QUEUE_NUM) {
 		return priority_queue_init(gmac, queue);
 	} else {
 		return priority_queue_init_as_idle(gmac, queue);
@@ -1286,19 +1350,28 @@ static void eth_rx(struct gmac_queue *queue)
 }
 
 #if !defined(CONFIG_ETH_SAM_GMAC_FORCE_QUEUE) && \
-	((CONFIG_ETH_SAM_GMAC_QUEUES != NET_TC_TX_COUNT) || \
+	((GMAC_ACTIVE_QUEUE_NUM != NET_TC_TX_COUNT) || \
 	((NET_TC_TX_COUNT != NET_TC_RX_COUNT) && defined(CONFIG_NET_VLAN)))
 static int priority2queue(enum net_priority priority)
 {
 	static const u8_t queue_priority_map[] = {
-#if CONFIG_ETH_SAM_GMAC_QUEUES == 1
+#if GMAC_ACTIVE_QUEUE_NUM == 1
 		0, 0, 0, 0, 0, 0, 0, 0
 #endif
-#if CONFIG_ETH_SAM_GMAC_QUEUES == 2
+#if GMAC_ACTIVE_QUEUE_NUM == 2
 		0, 0, 0, 0, 1, 1, 1, 1
 #endif
-#if CONFIG_ETH_SAM_GMAC_QUEUES == 3
+#if GMAC_ACTIVE_QUEUE_NUM == 3
 		0, 0, 0, 0, 1, 1, 2, 2
+#endif
+#if GMAC_ACTIVE_QUEUE_NUM == 4
+		0, 0, 0, 0, 1, 1, 2, 3
+#endif
+#if GMAC_ACTIVE_QUEUE_NUM == 5
+		0, 0, 0, 0, 1, 2, 3, 4
+#endif
+#if GMAC_ACTIVE_QUEUE_NUM == 6
+		0, 0, 0, 1, 2, 3, 4, 5
 #endif
 	};
 
@@ -1344,7 +1417,7 @@ static int eth_tx(struct device *dev, struct net_pkt *pkt)
 #if defined(CONFIG_ETH_SAM_GMAC_FORCE_QUEUE)
 	/* Route eveything to the forced queue */
 	queue = &dev_data->queue_list[CONFIG_ETH_SAM_GMAC_FORCED_QUEUE];
-#elif CONFIG_ETH_SAM_GMAC_QUEUES == CONFIG_NET_TC_TX_COUNT
+#elif GMAC_ACTIVE_QUEUE_NUM == CONFIG_NET_TC_TX_COUNT
 	/* Prefer to chose queue based on its traffic class */
 	queue = &dev_data->queue_list[net_tx_priority2tc(pkt_prio)];
 #else
@@ -1537,7 +1610,7 @@ static void queue0_isr(void *arg)
 	}
 }
 
-#if GMAC_PRIORITY_QUEUE_NO >= 1
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1
 static inline void priority_queue_isr(void *arg, unsigned int queue_idx)
 {
 	struct device *const dev = (struct device *const)arg;
@@ -1588,17 +1661,38 @@ static inline void priority_queue_isr(void *arg, unsigned int queue_idx)
 }
 #endif
 
-#if GMAC_PRIORITY_QUEUE_NO >= 1
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1
 static void queue1_isr(void *arg)
 {
 	priority_queue_isr(arg, 1);
 }
 #endif
 
-#if GMAC_PRIORITY_QUEUE_NO == 2
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 2
 static void queue2_isr(void *arg)
 {
 	priority_queue_isr(arg, 2);
+}
+#endif
+
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 3
+static void queue3_isr(void *arg)
+{
+	priority_queue_isr(arg, 3);
+}
+#endif
+
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 4
+static void queue4_isr(void *arg)
+{
+	priority_queue_isr(arg, 4);
+}
+#endif
+
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 5
+static void queue5_isr(void *arg)
+{
+	priority_queue_isr(arg, 5);
 }
 #endif
 
@@ -1718,7 +1812,7 @@ static void eth0_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 
 	/* Initialize GMAC queues */
-	for (i = 0; i < GMAC_QUEUE_NUM; i++) {
+	for (i = GMAC_QUE_0; i < GMAC_QUEUE_NUM; i++) {
 		result = queue_init(cfg->regs, &dev_data->queue_list[i]);
 		if (result < 0) {
 			LOG_ERR("Unable to initialize ETH queue%d", i);
@@ -1726,14 +1820,14 @@ static void eth0_iface_init(struct net_if *iface)
 		}
 	}
 
-#if GMAC_PRIORITY_QUEUE_NO >= 1
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1
 #if defined(CONFIG_ETH_SAM_GMAC_FORCE_QUEUE)
 	for (i = 0; i < CONFIG_NET_TC_RX_COUNT; ++i) {
 		cfg->regs->GMAC_ST1RPQ[i] =
 			GMAC_ST1RPQ_DSTCM(i) |
 			GMAC_ST1RPQ_QNB(CONFIG_ETH_SAM_GMAC_FORCED_QUEUE);
 	}
-#elif CONFIG_ETH_SAM_GMAC_QUEUES == NET_TC_RX_COUNT
+#elif GMAC_ACTIVE_QUEUE_NUM == NET_TC_RX_COUNT
 	/* If TC configuration is compatible with HW configuration, setup the
 	 * screening registers based on the DS/TC values.
 	 * Map them 1:1 - TC 0 -> Queue 0, TC 1 -> Queue 1 etc.
@@ -1795,13 +1889,13 @@ static enum ethernet_hw_caps eth_sam_gmac_get_capabilities(struct device *dev)
 		ETHERNET_PTP |
 #endif
 		ETHERNET_PRIORITY_QUEUES |
-#if GMAC_PRIORITY_QUEUE_NO >= 1
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1
 		ETHERNET_QAV |
 #endif
 		ETHERNET_LINK_100BASE_T;
 }
 
-#if GMAC_PRIORITY_QUEUE_NO >= 1
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1
 static int eth_sam_gmac_set_qav_param(struct device *dev,
 				      enum ethernet_config_type type,
 				      const struct ethernet_config *config)
@@ -1849,7 +1943,7 @@ static int eth_sam_gmac_set_config(struct device *dev,
 				   const struct ethernet_config *config)
 {
 	switch (type) {
-#if GMAC_PRIORITY_QUEUE_NO >= 1
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1
 	case ETHERNET_CONFIG_TYPE_QAV_PARAM:
 		return eth_sam_gmac_set_qav_param(dev, type, config);
 #endif
@@ -1860,7 +1954,7 @@ static int eth_sam_gmac_set_config(struct device *dev,
 	return -ENOTSUP;
 }
 
-#if GMAC_PRIORITY_QUEUE_NO >= 1
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1
 static int eth_sam_gmac_get_qav_param(struct device *dev,
 				      enum ethernet_config_type type,
 				      struct ethernet_config *config)
@@ -1895,7 +1989,7 @@ static int eth_sam_gmac_get_qav_param(struct device *dev,
 		return eth_sam_gmac_get_qav_delta_bandwidth(gmac, queue_id,
 							    delta_bandwidth);
 	case ETHERNET_QAV_PARAM_TYPE_TRAFFIC_CLASS:
-#if CONFIG_ETH_SAM_GMAC_QUEUES == NET_TC_TX_COUNT
+#if GMAC_ACTIVE_QUEUE_NUM == NET_TC_TX_COUNT
 		config->qav_param.traffic_class = queue_id;
 		return 0;
 #else
@@ -1916,9 +2010,9 @@ static int eth_sam_gmac_get_config(struct device *dev,
 {
 	switch (type) {
 	case ETHERNET_CONFIG_TYPE_PRIORITY_QUEUES_NUM:
-		config->priority_queues_num = GMAC_PRIORITY_QUEUE_NO;
+		config->priority_queues_num = GMAC_ACTIVE_PRIORITY_QUEUE_NUM;
 		return 0;
-#if GMAC_PRIORITY_QUEUE_NO >= 1
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1
 	case ETHERNET_CONFIG_TYPE_QAV_PARAM:
 		return eth_sam_gmac_get_qav_param(dev, type, config);
 #endif
@@ -1959,16 +2053,34 @@ static void eth0_irq_config(void)
 		    DEVICE_GET(eth0_sam_gmac), 0);
 	irq_enable(GMAC_IRQn);
 
-#if GMAC_PRIORITY_QUEUE_NO >= 1
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1
 	IRQ_CONNECT(GMAC_Q1_IRQn, CONFIG_ETH_SAM_GMAC_IRQ_PRI, queue1_isr,
 		    DEVICE_GET(eth0_sam_gmac), 0);
 	irq_enable(GMAC_Q1_IRQn);
 #endif
 
-#if GMAC_PRIORITY_QUEUE_NO == 2
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 2
 	IRQ_CONNECT(GMAC_Q2_IRQn, CONFIG_ETH_SAM_GMAC_IRQ_PRI, queue2_isr,
 		    DEVICE_GET(eth0_sam_gmac), 0);
 	irq_enable(GMAC_Q2_IRQn);
+#endif
+
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 3
+	IRQ_CONNECT(GMAC_Q3_IRQn, CONFIG_ETH_SAM_GMAC_IRQ_PRI, queue3_isr,
+		    DEVICE_GET(eth0_sam_gmac), 0);
+	irq_enable(GMAC_Q3_IRQn);
+#endif
+
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 4
+	IRQ_CONNECT(GMAC_Q4_IRQn, CONFIG_ETH_SAM_GMAC_IRQ_PRI, queue4_isr,
+		    DEVICE_GET(eth0_sam_gmac), 0);
+	irq_enable(GMAC_Q4_IRQn);
+#endif
+
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 5
+	IRQ_CONNECT(GMAC_Q5_IRQn, CONFIG_ETH_SAM_GMAC_IRQ_PRI, queue5_isr,
+		    DEVICE_GET(eth0_sam_gmac), 0);
+	irq_enable(GMAC_Q5_IRQn);
 #endif
 }
 
@@ -1994,7 +2106,8 @@ static struct eth_sam_dev_data eth0_data = {
 		CONFIG_ETH_SAM_GMAC_MAC5,
 	},
 #endif
-	.queue_list = {{
+	.queue_list = {
+		{
 			.que_idx = GMAC_QUE_0,
 			.rx_desc_list = {
 				.buf = rx_desc_que0,
@@ -2017,6 +2130,7 @@ static struct eth_sam_dev_data eth0_data = {
 			},
 #endif
 #endif
+#if GMAC_PRIORITY_QUEUE_NUM >= 1
 		}, {
 			.que_idx = GMAC_QUE_1,
 			.rx_desc_list = {
@@ -2027,7 +2141,7 @@ static struct eth_sam_dev_data eth0_data = {
 				.buf = tx_desc_que1,
 				.len = ARRAY_SIZE(tx_desc_que1),
 			},
-#if GMAC_PRIORITY_QUEUE_NO >= 1
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1
 			.rx_frag_list = rx_frag_list_que1,
 #if GMAC_MULTIPLE_TX_PACKETS == 1
 			.tx_frag_list = {
@@ -2042,6 +2156,8 @@ static struct eth_sam_dev_data eth0_data = {
 #endif
 #endif
 #endif
+#endif
+#if GMAC_PRIORITY_QUEUE_NUM >= 2
 		}, {
 			.que_idx = GMAC_QUE_2,
 			.rx_desc_list = {
@@ -2052,7 +2168,7 @@ static struct eth_sam_dev_data eth0_data = {
 				.buf = tx_desc_que2,
 				.len = ARRAY_SIZE(tx_desc_que2),
 			},
-#if GMAC_PRIORITY_QUEUE_NO == 2
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 2
 			.rx_frag_list = rx_frag_list_que2,
 #if GMAC_MULTIPLE_TX_PACKETS == 1
 			.tx_frag_list = {
@@ -2067,7 +2183,8 @@ static struct eth_sam_dev_data eth0_data = {
 #endif
 #endif
 #endif
-#if GMAC_QUEUE_NUM > 3
+#endif
+#if GMAC_PRIORITY_QUEUE_NUM >= 3
 		}, {
 			.que_idx = GMAC_QUE_3,
 			.rx_desc_list = {
@@ -2078,6 +2195,23 @@ static struct eth_sam_dev_data eth0_data = {
 				.buf = tx_desc_que3,
 				.len = ARRAY_SIZE(tx_desc_que3),
 			},
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 3
+			.rx_frag_list = rx_frag_list_que3,
+#if GMAC_MULTIPLE_TX_PACKETS == 1
+			.tx_frag_list = {
+				.buf = (u32_t *)tx_frag_list_que3,
+				.len = ARRAY_SIZE(tx_frag_list_que3),
+			},
+#if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
+			.tx_frames = {
+				.buf = (u32_t *)tx_frame_list_que3,
+				.len = ARRAY_SIZE(tx_frame_list_que3),
+			}
+#endif
+#endif
+#endif
+#endif
+#if GMAC_PRIORITY_QUEUE_NUM >= 4
 		}, {
 			.que_idx = GMAC_QUE_4,
 			.rx_desc_list = {
@@ -2088,6 +2222,23 @@ static struct eth_sam_dev_data eth0_data = {
 				.buf = tx_desc_que4,
 				.len = ARRAY_SIZE(tx_desc_que4),
 			},
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 4
+			.rx_frag_list = rx_frag_list_que4,
+#if GMAC_MULTIPLE_TX_PACKETS == 1
+			.tx_frag_list = {
+				.buf = (u32_t *)tx_frag_list_que4,
+				.len = ARRAY_SIZE(tx_frag_list_que4),
+			},
+#if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
+			.tx_frames = {
+				.buf = (u32_t *)tx_frame_list_que4,
+				.len = ARRAY_SIZE(tx_frame_list_que4),
+			}
+#endif
+#endif
+#endif
+#endif
+#if GMAC_PRIORITY_QUEUE_NUM >= 5
 		}, {
 			.que_idx = GMAC_QUE_5,
 			.rx_desc_list = {
@@ -2098,6 +2249,21 @@ static struct eth_sam_dev_data eth0_data = {
 				.buf = tx_desc_que5,
 				.len = ARRAY_SIZE(tx_desc_que5),
 			},
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 5
+			.rx_frag_list = rx_frag_list_que5,
+#if GMAC_MULTIPLE_TX_PACKETS == 1
+			.tx_frag_list = {
+				.buf = (u32_t *)tx_frag_list_que5,
+				.len = ARRAY_SIZE(tx_frag_list_que5),
+			},
+#if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
+			.tx_frames = {
+				.buf = (u32_t *)tx_frame_list_que5,
+				.len = ARRAY_SIZE(tx_frame_list_que5),
+			}
+#endif
+#endif
+#endif
 #endif
 		}
 	},

--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -27,51 +27,71 @@
 #define GMAC_FRAME_SIZE_MAX (GMAC_MTU + 18)
 
 /** Cache alignment */
-#define GMAC_DCACHE_ALIGNMENT             32
+#define GMAC_DCACHE_ALIGNMENT           32
 /** Memory alignment of the RX/TX Buffer Descriptor List */
-#define GMAC_DESC_ALIGNMENT               4
+#define GMAC_DESC_ALIGNMENT             4
 /** Total number of queues supported by GMAC hardware module */
-#ifdef CONFIG_SOC_ATMEL_SAME70_REVB
-#define GMAC_QUEUE_NUM                    6
+#if defined(CONFIG_SOC_ATMEL_SAME70_REVB) || \
+	defined(CONFIG_SOC_ATMEL_SAMV71_REVB)
+#define GMAC_QUEUE_NUM                  6
+#elif !defined(CONFIG_SOC_SERIES_SAM4E)
+#define GMAC_QUEUE_NUM                  3
 #else
-#define GMAC_QUEUE_NUM                    3
+#define GMAC_QUEUE_NUM                  1
 #endif
+#define GMAC_PRIORITY_QUEUE_NUM         (GMAC_QUEUE_NUM - 1)
+#if (GMAC_PRIORITY_QUEUE_NUM >= 1)
 BUILD_ASSERT_MSG(ARRAY_SIZE(GMAC->GMAC_TBQBAPQ) + 1 == GMAC_QUEUE_NUM,
 		 "GMAC_QUEUE_NUM doesn't match soc header");
+#endif
 /** Number of priority queues used */
-#define GMAC_PRIORITY_QUEUE_NO            (CONFIG_ETH_SAM_GMAC_QUEUES - 1)
+#define GMAC_ACTIVE_QUEUE_NUM           (CONFIG_ETH_SAM_GMAC_QUEUES)
+#define GMAC_ACTIVE_PRIORITY_QUEUE_NUM  (GMAC_ACTIVE_QUEUE_NUM - 1)
 
 /** RX descriptors count for main queue */
-#define MAIN_QUEUE_RX_DESC_COUNT CONFIG_ETH_SAM_GMAC_BUF_RX_COUNT
+#define MAIN_QUEUE_RX_DESC_COUNT        CONFIG_ETH_SAM_GMAC_BUF_RX_COUNT
 /** TX descriptors count for main queue */
-#define MAIN_QUEUE_TX_DESC_COUNT (CONFIG_NET_BUF_TX_COUNT + 1)
+#define MAIN_QUEUE_TX_DESC_COUNT        (CONFIG_NET_BUF_TX_COUNT + 1)
 
 /** RX/TX descriptors count for priority queues */
-#if GMAC_PRIORITY_QUEUE_NO == 2
-#define PRIORITY_QUEUE2_RX_DESC_COUNT         MAIN_QUEUE_RX_DESC_COUNT
-#define PRIORITY_QUEUE2_TX_DESC_COUNT         MAIN_QUEUE_TX_DESC_COUNT
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1
+#define PRIORITY_QUEUE1_RX_DESC_COUNT   MAIN_QUEUE_RX_DESC_COUNT
+#define PRIORITY_QUEUE1_TX_DESC_COUNT   MAIN_QUEUE_TX_DESC_COUNT
 #else
-#define PRIORITY_QUEUE2_RX_DESC_COUNT         1
-#define PRIORITY_QUEUE2_TX_DESC_COUNT         1
+#define PRIORITY_QUEUE1_RX_DESC_COUNT   1
+#define PRIORITY_QUEUE1_TX_DESC_COUNT   1
 #endif
 
-#if GMAC_PRIORITY_QUEUE_NO >= 1
-#define PRIORITY_QUEUE1_RX_DESC_COUNT         MAIN_QUEUE_RX_DESC_COUNT
-#define PRIORITY_QUEUE1_TX_DESC_COUNT         MAIN_QUEUE_TX_DESC_COUNT
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 2
+#define PRIORITY_QUEUE2_RX_DESC_COUNT   MAIN_QUEUE_RX_DESC_COUNT
+#define PRIORITY_QUEUE2_TX_DESC_COUNT   MAIN_QUEUE_TX_DESC_COUNT
 #else
-#define PRIORITY_QUEUE1_RX_DESC_COUNT         1
-#define PRIORITY_QUEUE1_TX_DESC_COUNT         1
+#define PRIORITY_QUEUE2_RX_DESC_COUNT   1
+#define PRIORITY_QUEUE2_TX_DESC_COUNT   1
 #endif
 
-#if GMAC_QUEUE_NUM > 3
-#define PRIORITY_QUEUE3_RX_DESC_COUNT         1
-#define PRIORITY_QUEUE3_TX_DESC_COUNT         1
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 3
+#define PRIORITY_QUEUE3_RX_DESC_COUNT   MAIN_QUEUE_RX_DESC_COUNT
+#define PRIORITY_QUEUE3_TX_DESC_COUNT   MAIN_QUEUE_TX_DESC_COUNT
+#else
+#define PRIORITY_QUEUE3_RX_DESC_COUNT   1
+#define PRIORITY_QUEUE3_TX_DESC_COUNT   1
+#endif
 
-#define PRIORITY_QUEUE4_RX_DESC_COUNT         1
-#define PRIORITY_QUEUE4_TX_DESC_COUNT         1
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 4
+#define PRIORITY_QUEUE4_RX_DESC_COUNT   MAIN_QUEUE_RX_DESC_COUNT
+#define PRIORITY_QUEUE4_TX_DESC_COUNT   MAIN_QUEUE_TX_DESC_COUNT
+#else
+#define PRIORITY_QUEUE4_RX_DESC_COUNT   1
+#define PRIORITY_QUEUE4_TX_DESC_COUNT   1
+#endif
 
-#define PRIORITY_QUEUE5_RX_DESC_COUNT         1
-#define PRIORITY_QUEUE5_TX_DESC_COUNT         1
+#if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 5
+#define PRIORITY_QUEUE5_RX_DESC_COUNT   MAIN_QUEUE_RX_DESC_COUNT
+#define PRIORITY_QUEUE5_TX_DESC_COUNT   MAIN_QUEUE_TX_DESC_COUNT
+#else
+#define PRIORITY_QUEUE5_RX_DESC_COUNT   1
+#define PRIORITY_QUEUE5_TX_DESC_COUNT   1
 #endif
 
 /*
@@ -164,11 +184,9 @@ enum queue_idx {
 	GMAC_QUE_0,  /** Main queue */
 	GMAC_QUE_1,  /** Priority queue 1 */
 	GMAC_QUE_2,  /** Priority queue 2 */
-#if GMAC_QUEUE_NUM > 3
 	GMAC_QUE_3,  /** Priority queue 3 */
 	GMAC_QUE_4,  /** Priority queue 4 */
 	GMAC_QUE_5,  /** Priority queue 5 */
-#endif
 };
 
 /** Minimal ring buffer implementation */

--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -31,7 +31,13 @@
 /** Memory alignment of the RX/TX Buffer Descriptor List */
 #define GMAC_DESC_ALIGNMENT               4
 /** Total number of queues supported by GMAC hardware module */
-#define GMAC_QUEUE_NO                     3
+#ifdef CONFIG_SOC_ATMEL_SAME70_REVB
+#define GMAC_QUEUE_NUM                    6
+#else
+#define GMAC_QUEUE_NUM                    3
+#endif
+BUILD_ASSERT_MSG(ARRAY_SIZE(GMAC->GMAC_TBQBAPQ) + 1 == GMAC_QUEUE_NUM,
+		 "GMAC_QUEUE_NUM doesn't match soc header");
 /** Number of priority queues used */
 #define GMAC_PRIORITY_QUEUE_NO            (CONFIG_ETH_SAM_GMAC_QUEUES - 1)
 
@@ -55,6 +61,17 @@
 #else
 #define PRIORITY_QUEUE1_RX_DESC_COUNT         1
 #define PRIORITY_QUEUE1_TX_DESC_COUNT         1
+#endif
+
+#if GMAC_QUEUE_NUM > 3
+#define PRIORITY_QUEUE3_RX_DESC_COUNT         1
+#define PRIORITY_QUEUE3_TX_DESC_COUNT         1
+
+#define PRIORITY_QUEUE4_RX_DESC_COUNT         1
+#define PRIORITY_QUEUE4_TX_DESC_COUNT         1
+
+#define PRIORITY_QUEUE5_RX_DESC_COUNT         1
+#define PRIORITY_QUEUE5_TX_DESC_COUNT         1
 #endif
 
 /*
@@ -147,6 +164,11 @@ enum queue_idx {
 	GMAC_QUE_0,  /** Main queue */
 	GMAC_QUE_1,  /** Priority queue 1 */
 	GMAC_QUE_2,  /** Priority queue 2 */
+#if GMAC_QUEUE_NUM > 3
+	GMAC_QUE_3,  /** Priority queue 3 */
+	GMAC_QUE_4,  /** Priority queue 4 */
+	GMAC_QUE_5,  /** Priority queue 5 */
+#endif
 };
 
 /** Minimal ring buffer implementation */
@@ -217,7 +239,7 @@ struct eth_sam_dev_data {
 	struct device *ptp_clock;
 #endif
 	u8_t mac_addr[6];
-	struct gmac_queue queue_list[GMAC_QUEUE_NO];
+	struct gmac_queue queue_list[GMAC_QUEUE_NUM];
 };
 
 #define DEV_CFG(dev) \


### PR DESCRIPTION
The Atmel SAM SoC with ethernet port uses same GMAC driver. However, there are differences between SoC GMAC implementation. Some SoCs have priority queue and system can configure 0 up to 5, depending of SoC version. This update current GMAC driver adding missing definitions.

I already tested with SAM_V71_XULT using 6 queues [5 pri queues] with samples/net/telnet with DHCP. Ping is working OK using telnet terminal. It needs people to test SAME70[B]. I already tested SAM_V71_XULT as SAMV71**A** variation and seems to works well.

I added Kconfig rules to make sure user can only select proper queue size.

NOTE for SAM4E: Not yet supported.
NOTE for SAME70[B]: https://github.com/zephyrproject-rtos/hal_atmel/pull/7

This work is based on slack discussion this week and the start point was https://github.com/zephyrproject-rtos/zephyr/pull/12711.

This PR supersedes #12711 (closes #12711).