### PR TITLE
sensor: pms7003: Convert to DTS

### DIFF
--- a/drivers/sensor/pms7003/Kconfig
+++ b/drivers/sensor/pms7003/Kconfig
@@ -3,20 +3,8 @@
 # Copyright (c) 2017 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig PMS7003
+config PMS7003
 	bool "PMS7003 particulate matter sensor"
 	depends on SERIAL
 	help
 	  Enable driver for pms7003 particulate matter sensor.
-
-if PMS7003
-
-config PMS7003_UART_DEVICE
-	string "UART device"
-	default "UART_3"
-
-config PMS7003_DRIVER_NAME
-	string "Driver name"
-	default "PMS7003"
-
-endif # PMS7003

--- a/drivers/sensor/pms7003/pms7003.c
+++ b/drivers/sensor/pms7003/pms7003.c
@@ -166,11 +166,11 @@ static int pms7003_init(struct device *dev)
 {
 	struct pms7003_data *drv_data = dev->driver_data;
 
-	drv_data->uart_dev = device_get_binding(CONFIG_PMS7003_UART_DEVICE);
+	drv_data->uart_dev = device_get_binding(DT_INST_0_PLANTOWER_PMS7003_BUS_NAME);
 
 	if (!drv_data->uart_dev) {
 		LOG_DBG("uart device is not found: %s",
-			    CONFIG_PMS7003_UART_DEVICE);
+			    DT_INST_0_PLANTOWER_PMS7003_BUS_NAME);
 		return -EINVAL;
 	}
 
@@ -179,6 +179,6 @@ static int pms7003_init(struct device *dev)
 
 static struct pms7003_data pms7003_data;
 
-DEVICE_AND_API_INIT(gts_dev, CONFIG_PMS7003_DRIVER_NAME, &pms7003_init,
+DEVICE_AND_API_INIT(gts_dev, DT_INST_0_PLANTOWER_PMS7003_LABEL, &pms7003_init,
 		    &pms7003_data, NULL, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &pms7003_api);

--- a/dts/bindings/sensor/plantower,pms7003.yaml
+++ b/dts/bindings/sensor/plantower,pms7003.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2020, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Plantower PMS7003 air pollution sensor.
+  Air pollution sensor capable of measuring mass concentration of dust.  See
+  more info at:
+  https://www.espruino.com/datasheets/PMS7003.pdf
+
+compatible: "plantower,pms7003"
+
+include: uart-device.yaml


### PR DESCRIPTION
Convert pms7003 sensor driver to utilize device tree.

DTS would look something like the following for the pms7003:

uart {
	pms7003: pms7003 {
		 status = "okay";
		 compatible = "plantower,pms7003";
		 label = "pms7003";
	};
};

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>