### PR TITLE
doc: Kconfig: Document how whitespace is used in Kconfig sources

### DIFF
--- a/doc/guides/kconfig/tips.rst
+++ b/doc/guides/kconfig/tips.rst
@@ -807,6 +807,10 @@ A few formatting nits, to help keep things consistent:
 
 - Put a blank line before/after each top-level ``if`` and ``endif``
 
+- Use a single tab for each indentation
+
+- Indent help text with two extra spaces
+
 
 Lesser-known/used Kconfig features
 **********************************


### PR DESCRIPTION
Document how whitespace is used in Kconfig sources. This serves as an
authoritative reference in code review.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>