### PR TITLE
Bluetooth: controller: split: nRF: Use ticker compat mode as default

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -138,6 +138,10 @@ config BT_LLL_VENDOR_NORDIC
 	select BT_CTLR_SCHED_ADVANCED_SUPPORT
 	select BT_CTLR_TIFS_HW_SUPPORT
 
+	# Until ticker resolve collision is fixed for skipped ticker catch-up
+	# issue, use the old compatibility mode
+	select BT_TICKER_COMPATIBILITY_MODE
+
 	default y
 	help
 	  Use Nordic Lower Link Layer implementation.


### PR DESCRIPTION
Use the old ticker compatibility mode implementation as
default for nRF5x Series SoCs.

Fixes #22926.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>