### PR TITLE
Bluetooth: test: Delay SMP pairing distribution phase when testing

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -4356,6 +4356,14 @@ static void bt_smp_encrypt_change(struct bt_l2cap_chan *chan,
 		return;
 	}
 
+	if (IS_ENABLED(CONFIG_BT_TESTING)) {
+		/* Avoid the HCI-USB race condition where HCI data and
+		 * HCI events can be re-ordered, and pairing information appears
+		 * to be sent unencrypted.
+		 */
+		k_sleep(K_MSEC(100));
+	}
+
 	if (bt_smp_distribute_keys(smp)) {
 		return;
 	}


### PR DESCRIPTION
Avoid the HCI-USB race condition where HCI data and HCI events can be
re-ordered, and pairing information appears to be sent unencrypted.

Needed for #22928, but does not fix it. Test is still inconclusive.