### PR TITLE
tests: work_q: Add assert if k_delayed_work_submit fails in the handler

### DIFF
--- a/tests/kernel/workq/work_queue_api/src/main.c
+++ b/tests/kernel/workq/work_queue_api/src/main.c
@@ -630,7 +630,8 @@ static void delayed_work_handler_resubmit(struct k_work *w)
 	k_sem_give(&sync_sema);
 
 	if (k_sem_count_get(&sync_sema) < NUM_OF_WORK) {
-		k_delayed_work_submit(delayed_w, TIMEOUT);
+		/**TESTPOINT: check if work can be resubmit from handler */
+		zassert_false(k_delayed_work_submit(delayed_w, TIMEOUT), NULL);
 	}
 }
 


### PR DESCRIPTION
This makes the tests actually assert if k_delayed_work_submit fails to
resubmit to ensure that not only the work is executed but also no errors
are reported in such case.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>