### PR TITLE
ci: support license check with topic branch with v3

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -11,7 +11,7 @@ jobs:
       uses: actions/checkout@v1
     - name: Scan the code
       id: scancode
-      uses: zephyrproject-rtos/action_scancode@v2
+      uses: zephyrproject-rtos/action_scancode@v3
       with:
         directory-to-scan: 'scan/'
     - name: Artifact Upload


### PR DESCRIPTION
When determining added files, support branches other than master.