### PR TITLE
samples: pi: fix sample.yaml

### DIFF
--- a/samples/smp/pi/sample.yaml
+++ b/samples/smp/pi/sample.yaml
@@ -15,4 +15,4 @@ common:
 tests:
   sample.smp.pi:
     tags: introduction
-    platform_whitelist: nsim_hs_smp qemu_x86_64
+    filter: (CONFIG_MP_NUM_CPUS > 1)


### PR DESCRIPTION
Whitelists are bad; configuration filters scale much better.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>