### PR TITLE
kernel: remove problematic pend() assertion

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -537,9 +537,6 @@ static void pend(struct k_thread *thread, _wait_q_t *wait_q, s32_t timeout)
 	if (timeout != K_FOREVER) {
 		s32_t ticks;
 
-		__ASSERT(timeout >= 0,
-			"Only non-negative values are accepted.");
-
 		if (timeout < 0) {
 			timeout = 0;
 		}


### PR DESCRIPTION
This assertion, if built in, allows users threads to crash
the kernel in a critical section by passing a negative timeout
value, creating a DoS attack vector.

Remove this assertion, immediately below it there's a check
which just resets it to 0 anyway.

Fixes: #22999

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>