### PR TITLE
dts: arm: nordic: Add regions and region size to SPU

### DIFF
--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -97,6 +97,8 @@
 			compatible = "nordic,nrf-spu";
 			reg = <0x50003000 0x1000>;
 			interrupts = <3 1>;
+			ram-regions = <64 8>;
+			flash-regions = <64 16>;
 			status = "okay";
 		};
 

--- a/dts/arm/nordic/nrf9160.dtsi
+++ b/dts/arm/nordic/nrf9160.dtsi
@@ -109,6 +109,8 @@
 			compatible = "nordic,nrf-spu";
 			reg = <0x50003000 0x1000>;
 			interrupts = <3 1>;
+			ram-regions = <32 8>;
+			flash-regions = <32 32>;
 			status = "okay";
 		};
 

--- a/dts/bindings/arm/nordic,nrf-spu.yaml
+++ b/dts/bindings/arm/nordic,nrf-spu.yaml
@@ -10,3 +10,13 @@ properties:
 
     interrupts:
       required: true
+
+    ram-regions:
+      type: array
+      description: number of lockable RAM regions and region size in KiB
+      required: true
+
+    flash-regions:
+      type: array
+      description: number of lockable flash regions and region size in KiB
+      required: true


### PR DESCRIPTION
This adds information about the SPU hardware  with the number of
lockable regions and granularity to the SPU node in the device tree.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>