### PR TITLE
test wdt_basic_api failed on nucleo_f746zg

### DIFF
--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -114,17 +114,20 @@ static int iwdg_stm32_install_timeout(struct device *dev,
 
 	tickstart = k_uptime_get_32();
 
-	while (LL_IWDG_IsReady(iwdg) == 0) {
-		/* Wait until WVU, RVU, PVU are reset before updating  */
+	LL_IWDG_EnableWriteAccess(iwdg);
+
+	LL_IWDG_SetPrescaler(iwdg, prescaler);
+	LL_IWDG_SetReloadCounter(iwdg, reload);
+
+	/* Wait for the update operation completed */
+	while (LL_IWDG_IsReady(iwdg) != 0) {
 		if ((k_uptime_get_32() - tickstart) > IWDG_DEFAULT_TIMEOUT) {
 			return -ENODEV;
 		}
 	}
 
-	LL_IWDG_EnableWriteAccess(iwdg);
-
-	LL_IWDG_SetPrescaler(iwdg, prescaler);
-	LL_IWDG_SetReloadCounter(iwdg, reload);
+	/* Reload counter just before leaving */
+	LL_IWDG_ReloadCounter(iwdg);
 
 	return 0;
 }


### PR DESCRIPTION
This patches add a delay after setting the watchdog to wait for the register (Prescaler and Counter registers) to be updated and reload before leaving.
It modifies  the `iwdg_stm32_install_timeout` function of the `wdt_iwdg_stm32.c` 

Fixes  #22257

Signed-off-by: Francois Ramu <francois.ramu@st.com>