### PR TITLE
arch: arm: Initialize floating point registers for every CPU with a FPU

### DIFF
--- a/arch/arm/core/aarch32/prep_c.c
+++ b/arch/arm/core/aarch32/prep_c.c
@@ -76,11 +76,18 @@ void __weak relocate_vector_table(void)
 
 #endif /* CONFIG_CPU_CORTEX_M_HAS_VTOR */
 
-#ifdef CONFIG_FLOAT
-static inline void enable_floating_point(void)
+#if defined(CONFIG_CPU_HAS_FPU)
+static inline void z_arm_floating_point_init(void)
 {
 	/*
-	 * Upon reset, the Co-Processor Access Control Register is 0x00000000.
+	 * Upon reset, the Co-Processor Access Control Register is, normally,
+	 * 0x00000000. However, it might be left un-cleared by firmware running
+	 * before Zephyr boot.
+	 */
+	SCB->CPACR &= (~(CPACR_CP10_Msk | CPACR_CP11_Msk));
+
+#if defined(CONFIG_FLOAT)
+	/*
 	 * Enable CP10 and CP11 Co-Processors to enable access to floating
 	 * point registers.
 	 */
@@ -135,12 +142,10 @@ static inline void enable_floating_point(void)
 	 * will be activated (FPCA bit on the CONTROL register) in the presence
 	 * of floating point instructions.
 	 */
+
+#endif /* CONFIG_FLOAT */
 }
-#else
-static inline void enable_floating_point(void)
-{
-}
-#endif
+#endif /* CONFIG_CPU_HAS_FPU */
 
 extern FUNC_NORETURN void z_cstart(void);
 /**
@@ -154,7 +159,9 @@ extern FUNC_NORETURN void z_cstart(void);
 void z_arm_prep_c(void)
 {
 	relocate_vector_table();
-	enable_floating_point();
+#if defined(CONFIG_CPU_HAS_FPU)
+	z_arm_floating_point_init();
+#endif
 	z_bss_zero();
 	z_data_copy();
 #if defined(CONFIG_ARMV7_R) && defined(CONFIG_INIT_STACKS)

--- a/arch/arm/core/aarch32/prep_c.c
+++ b/arch/arm/core/aarch32/prep_c.c
@@ -144,6 +144,19 @@ static inline void z_arm_floating_point_init(void)
 	 */
 
 #endif /* CONFIG_FLOAT */
+
+	/*
+	 * Upon reset, the CONTROL.FPCA bit is, normally, cleared. However,
+	 * it might be left un-cleared by firmware running before Zephyr boot.
+	 * We must clear this bit to prevent errors in exception unstacking.
+	 *
+	 * Note:
+	 * In Sharing FP Registers mode CONTROL.FPCA is cleared before switching
+	 * to main, so it may be skipped here (saving few boot cycles).
+	 */
+#if !defined(CONFIG_FLOAT) || !defined(CONFIG_FP_SHARING)
+	__set_CONTROL(__get_CONTROL() & (~(CONTROL_FPCA_Msk)));
+#endif
 }
 #endif /* CONFIG_CPU_HAS_FPU */
 


### PR DESCRIPTION
This restores the registers back to reset value, even if CONFIG_FLOAT
is not set.
These registers my be changed earlier for example by a bootloader. This
caused stack offset when booting from a build-in EFM32GG bootloader.

Clearing CPACR unconditionally supports switching between Full access
and Privileged access only.

Initialize the Floating Point Status and Control Register before the
Instruction Synchronization Barrier for symmetry with
arch_switch_to_main_thread.

Should support all combinations of CONFIG_FLOAT and CONFIG_FP_SHARING

Fixes #22977

Signed-off-by: Luuk Bosma <l.bosma@interay.com>