### PR TITLE
subsys/mgmt: Fix mcumgr file download

### DIFF
--- a/subsys/mgmt/Kconfig.mcumgr
+++ b/subsys/mgmt/Kconfig.mcumgr
@@ -28,11 +28,14 @@ config FS_MGMT_UL_CHUNK_SIZE
 
 config FS_MGMT_DL_CHUNK_SIZE
 	int "Maximum chunk size for file downloads"
-	default 512
+	default MCUMGR_BUF_SIZE
 	help
 	  Limits the maximum chunk size for file downloads, in bytes.  A buffer of
 	  this size gets allocated on the stack during handling of a file download
 	  command.
+	  NOTE: THere is no sense to set this parameter to value greater
+	  than MCUMGR_BUF_SIZE, as at this point MCUMGR is not able to
+	  fragment buffer to fit it to MCUMGR_BUF_SIZE.
 
 config FS_MGMT_PATH_SIZE
 	int "Maximum file path length"

--- a/subsys/mgmt/smp.c
+++ b/subsys/mgmt/smp.c
@@ -148,7 +148,7 @@ zephyr_smp_write_at(struct cbor_encoder_writer *writer, size_t offset,
 		return MGMT_ERR_EINVAL;
 	}
 
-	if (len > net_buf_tailroom(nb)) {
+	if ((offset + len) > (nb->size - net_buf_headroom(nb))) {
 		return MGMT_ERR_EINVAL;
 	}
 

--- a/west.yml
+++ b/west.yml
@@ -80,7 +80,7 @@ manifest:
       revision: v1.5.0
       path: bootloader/mcuboot
     - name: mcumgr
-      revision: d4e97cd4fc80ff949415062b1c83fd42929e8fe4
+      revision: pull/14/head
       path: modules/lib/mcumgr
     - name: net-tools
       revision: 4bff01084d225996e4aae84b98be5969e2f9f33d


### PR DESCRIPTION
The commit reduces default MCUMGR buffer size and introduces changes to
tinycbor and mcumgr that fix problem with mcumgr not being able to download
file off the Zephyr running device.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

Fixes issue #8364
