### PR TITLE
drivers/ethernet/eth_gecko: auto-negotiate after link up

### DIFF
--- a/drivers/ethernet/phy_gecko.c
+++ b/drivers/ethernet/phy_gecko.c
@@ -255,7 +255,7 @@ int phy_gecko_auto_negotiate(const struct phy_gecko_dev *phy,
 		*status = 0;
 	}
 
-	LOG_INF("common abilities: speed %s Mb, %s duplex",
+	LOG_DBG("common abilities: speed %s Mb, %s duplex",
 		*status & ETH_NETWORKCFG_SPEED ? "100" : "10",
 		*status & ETH_NETWORKCFG_FULLDUPLEX ? "full" : "half");
 


### PR DESCRIPTION
Move auto-negotiate sequence from driver initialization to link up event
Previously when booting without ethernet cable connected the
initialization would fail and never recover.
Now we can connect the ethernet cable any time and multiple times.

This also drastically reduces boot time to main.

Logging Link up and Link down events.
Logging speed and duplex from eth_gecko logger instead of eth_gecko_phy.

Signed-off-by: Luuk Bosma <l.bosma@interay.com>