### PR TITLE
Restore net_pkt cursor after cloning

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1724,6 +1724,7 @@ struct net_pkt *net_pkt_clone(struct net_pkt *pkt, s32_t timeout)
 {
 	size_t cursor_offset = net_pkt_get_current_offset(pkt);
 	struct net_pkt *clone_pkt;
+	struct net_pkt_cursor backup;
 
 	clone_pkt = net_pkt_alloc_with_buffer(net_pkt_iface(pkt),
 					      net_pkt_get_len(pkt),
@@ -1732,10 +1733,12 @@ struct net_pkt *net_pkt_clone(struct net_pkt *pkt, s32_t timeout)
 		return NULL;
 	}
 
+	net_pkt_cursor_backup(pkt, &backup);
 	net_pkt_cursor_init(pkt);
 
 	if (net_pkt_copy(clone_pkt, pkt, net_pkt_get_len(pkt))) {
 		net_pkt_unref(clone_pkt);
+		net_pkt_cursor_restore(pkt, &backup);
 		return NULL;
 	}
 
@@ -1758,6 +1761,8 @@ struct net_pkt *net_pkt_clone(struct net_pkt *pkt, s32_t timeout)
 		net_pkt_set_overwrite(clone_pkt, true);
 		net_pkt_skip(clone_pkt, cursor_offset);
 	}
+
+	net_pkt_cursor_restore(pkt, &backup);
 
 	NET_DBG("Cloned %p to %p", pkt, clone_pkt);
 

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -672,6 +672,45 @@ void test_net_pkt_pull(void)
 	net_pkt_unref(dummy_pkt);
 }
 
+void test_net_pkt_clone(void)
+{
+	u8_t buf[26] = {"abcdefghijklmnopqrstuvwxyz"};
+	struct net_pkt *pkt;
+	struct net_pkt *cloned_pkt;
+	int ret;
+
+	pkt = net_pkt_alloc_with_buffer(eth_if, 64,
+					AF_UNSPEC, 0, K_NO_WAIT);
+	zassert_true(pkt != NULL, "Pkt not allocated");
+
+	ret = net_pkt_write(pkt, buf, sizeof(buf));
+	zassert_true(ret == 0, "Pkt write failed");
+
+	zassert_true(net_pkt_get_len(pkt) == sizeof(buf),
+		     "Pkt length mismatch");
+
+	net_pkt_cursor_init(pkt);
+	net_pkt_set_overwrite(pkt, true);
+	net_pkt_skip(pkt, 6);
+	zassert_true(sizeof(buf) - 6 == net_pkt_remaining_data(pkt),
+		     "Pkt remaining data mismatch");
+
+	cloned_pkt = net_pkt_clone(pkt, K_NO_WAIT);
+	zassert_true(cloned_pkt != NULL, "Pkt not cloned");
+
+	zassert_true(net_pkt_get_len(cloned_pkt) == sizeof(buf),
+		     "Cloned pkt length mismatch");
+
+	zassert_true(sizeof(buf) - 6 == net_pkt_remaining_data(pkt),
+		     "Pkt remaining data mismatch");
+
+	zassert_true(sizeof(buf) - 6 == net_pkt_remaining_data(cloned_pkt),
+		     "Cloned pkt remaining data mismatch");
+
+	net_pkt_unref(pkt);
+	net_pkt_unref(cloned_pkt);
+}
+
 void test_main(void)
 {
 	eth_if = net_if_get_default();
@@ -683,7 +722,8 @@ void test_main(void)
 			 ztest_unit_test(test_net_pkt_advanced_basics),
 			 ztest_unit_test(test_net_pkt_easier_rw_usage),
 			 ztest_unit_test(test_net_pkt_copy),
-			 ztest_unit_test(test_net_pkt_pull)
+			 ztest_unit_test(test_net_pkt_pull),
+			 ztest_unit_test(test_net_pkt_clone)
 		);
 
 	ztest_run_test_suite(net_pkt_tests);


### PR DESCRIPTION
net_pkt_clone() initializes the original packet cursor and clone the packet. But it doesn't restore the cursor back to original position.
Issue noticed when mDNS resolving fails when mdns responder is also enabled.
 net_conn_input(), in case of multicast packet, connection handler clone the packet and deliver to matching handler.

 Example case: dns_resolver and mdns_responder both register handlers for 5353 port. After first clone original packet cursor moved back to starting position. But first cloned packet cursor is set properly. Second time cloning makes cursor position to set to zero. Which makes second packet
handler header unpacking goes wrong.

Fixes #21970.
