### PR TITLE
bluetooth: Add decoding for BLE 5.2 version string

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4878,7 +4878,7 @@ static const char *ver_str(u8_t ver)
 {
 	const char * const str[] = {
 		"1.0b", "1.1", "1.2", "2.0", "2.1", "3.0", "4.0", "4.1", "4.2",
-		"5.0", "5.1",
+		"5.0", "5.1", "5.2"
 	};
 
 	if (ver < ARRAY_SIZE(str)) {


### PR DESCRIPTION
The BLE 5.2 specification has been assigned the version number 0x0b.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>