### PR TITLE
cmake: Allow change of the QEMU Ethernet interface name

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -513,7 +513,7 @@ if(CONFIG_QEMU_TARGET)
   if(CONFIG_NET_QEMU_ETHERNET)
     if(CONFIG_ETH_NIC_MODEL)
       list(APPEND QEMU_FLAGS_${ARCH}
-        -nic tap,model=${CONFIG_ETH_NIC_MODEL},script=no,downscript=no,ifname=zeth
+        -nic tap,model=${CONFIG_ETH_NIC_MODEL},script=no,downscript=no,ifname=${CONFIG_ETH_QEMU_IFACE_NAME}
       )
     else()
       message(FATAL_ERROR "

--- a/drivers/ethernet/Kconfig
+++ b/drivers/ethernet/Kconfig
@@ -21,6 +21,17 @@ config ETH_INIT_PRIORITY
 	  Note that the priority needs to be lower than the net stack
 	  so that it can start before the networking sub-system.
 
+config ETH_QEMU_IFACE_NAME
+	string "Network interface name for QEMU"
+	default "zeth"
+	depends on NET_QEMU_ETHERNET
+	help
+	  The network interface name for QEMU. This value is given as
+	  a parameter to -nic qemu command line option. The network
+	  interface must be created before starting QEMU. The net-setup.sh
+	  script from net-tools project can be used to create the network
+	  interface.
+
 source "drivers/ethernet/Kconfig.enc28j60"
 source "drivers/ethernet/Kconfig.enc424j600"
 source "drivers/ethernet/Kconfig.mcux"


### PR DESCRIPTION
Instead of hardcoding the "zeth" network interface name, use the
name defined in Kconfig so that user can change it if needed.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>