### PR TITLE
cmake: flash: three runners.yaml fixes

### DIFF
--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -27,7 +27,7 @@ flash-runner: ${BOARD_FLASH_RUNNER}
     string(APPEND yaml_contents "\
 
 # Default debug runner if --runner is not given.
-debug-runner: ${BOARD_FLASH_RUNNER}
+debug-runner: ${BOARD_DEBUG_RUNNER}
 ")
   endif()
 
@@ -69,14 +69,21 @@ args:
   foreach(runner ${runners})
     string(MAKE_C_IDENTIFIER ${runner} runner_id)
     string(APPEND yaml_contents "\
-  ${runner_id}:
-")
+  ${runner}:")
     get_property(args GLOBAL PROPERTY "BOARD_RUNNER_ARGS_${runner_id}")
-    foreach(arg ${args})
-      string(APPEND yaml_contents "\
-  - ${arg}
+    if(args)
+      # Usually, the runner has arguments. Append them to runners.yaml,
+      # one per line.
+      string(APPEND yaml_contents "\n")
+      foreach(arg ${args})
+        string(APPEND yaml_contents "\
+    - ${arg}
 ")
-    endforeach()
+      endforeach()
+    else()
+      # If the runner doesn't need any arguments, just use an empty list.
+      string(APPEND yaml_contents " []\n")
+    endif()
   endforeach()
 
   # Write the final contents and set its location in the cache.


### PR DESCRIPTION
There are three problems with the way runners.yaml is being created:

1. The dictionary which contains the arguments for each runner is
   using the runner's name converted to a C identifier instead of the
   runner's name itself. That causes west flash to fail when the two
   are different, e.g. for 'misc-flasher' (runner name), which is
   different than 'misc_flasher' (runner name as C identifier)

2. We need to make sure that the dictionary key maps to an empty list
   if there are no arguments, which normally doesn't happen since the
   runner usually at least takes the path of the file to flash or debug.
   It does happen in the case of misc-flasher, though, since the whole
   point of that runner is that it's an escape hatch for people with
   out of tree scripts that nevertheless want 'west flash' integration
   for things like sanitycheck device testing.

3. A copy/paste error is setting the debug runner to the flash runner.

Fix them all.

Fixes: #23004
