### PR TITLE
Use compiler attribute to warning wrong NULL parameter

### DIFF
--- a/cmake/compiler/gcc/target_warnings.cmake
+++ b/cmake/compiler/gcc/target_warnings.cmake
@@ -10,6 +10,7 @@ macro(toolchain_cc_warning_base)
     -Wformat-security
     -Wno-format-zero-length
     -Wno-main
+    -Wno-nonnull-compare
   )
 
 if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "9.1.0")

--- a/include/toolchain.h
+++ b/include/toolchain.h
@@ -58,4 +58,13 @@
 #endif
 #endif /* !_LINKER */
 
+/** @brief Macro to specify function parameters that must not be NULL
+ *
+ * When -Wnonnull option is enabled, the compiler will raise a warning
+ * when a NULL pointer is given to an argument slot marked with it.
+ */
+#ifndef Z_NON_NULL
+#define Z_NON_NULL(...)
+#endif
+
 #endif /* ZEPHYR_INCLUDE_TOOLCHAIN_H_ */

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -461,5 +461,9 @@ do {                                                                    \
 		_value_a_ < _value_b_ ? _value_a_ : _value_b_; \
 	})
 
+#if __GNUC__ > 4
+#define Z_NON_NULL(...) __attribute__((nonnull(__VA_ARGS__)))
+#endif
+
 #endif /* !_LINKER */
 #endif /* ZEPHYR_INCLUDE_TOOLCHAIN_GCC_H_ */


### PR DESCRIPTION
Add a new macro that uses gcc nonnull attribute to generate warnings when a NULL parameter is given to a function that declares that that parameter should not be NULL.

This macro is set to all include/kernel.h functions. One caveat on using this macro is that was needed to turn off the flag "Wnonnull-compare" otherwise the compiler will warn when finds a comparison with NULL for a parameter set with that macro. That's is a small convenience that in the worst case just ignore a useless check but the benefit is that if someone wrongly pass a explicit NULL pointer a warn will be raised and we avoid further problems. 

For example, `k_pipe_get(struct k_pipe *pipe, void *data, size_t min_xref, s32_t timeout)` crashes if pipe or data are NULL. With this patch, a warning will be generate in compile time with `k_pipe_get(NULL, &data, min_xref, timeout)`.

Note that this does not change anything in runtime and if the warning is ignored it will crash as well.

