### PR TITLE
ztest: syscalls: Add empty device.h file

### DIFF
--- a/subsys/testsuite/ztest/include/syscalls/device.h
+++ b/subsys/testsuite/ztest/include/syscalls/device.h
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2020, Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO)
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */


### PR DESCRIPTION
zephyr/include/device.h unconditionally includes syscalls/device.h
Adding syscalls/device.h to the ztest include path allows unit testing of code that includes device.h, but does not rely on the generated syscalls.

The example use case is a subsystem that relies on an underlying device, but that device is mocked for testing purposes.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>