### PR TITLE
usb: add {get,set}_{vendor,product}_id

### DIFF
--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -437,6 +437,26 @@ bool usb_transfer_is_busy(u8_t ep);
 int usb_wakeup_request(void);
 
 /**
+ * @brief Get the USB vendor id.
+ */
+u16_t usb_get_vendor_id(void);
+
+/**
+ * @brief Set the USB vendor id.
+ */
+void usb_set_vendor_id(u16_t vid);
+
+/**
+ * @brief Get the USB product id.
+ */
+u16_t usb_get_product_id(void);
+
+/**
+ * @brief Set the USB product id.
+ */
+void usb_set_product_id(u16_t pid);
+
+/**
  * @}
  */
 

--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -537,3 +537,23 @@ struct usb_dev_data *usb_get_dev_data_by_ep(sys_slist_t *list, u8_t ep)
 
 	return NULL;
 }
+
+u16_t usb_get_vendor_id(void)
+{
+	return sys_le16_to_cpu(common_desc.device_descriptor.idVendor);
+}
+
+void usb_set_vendor_id(u16_t vid)
+{
+	common_desc.device_descriptor.idVendor = sys_cpu_to_le16(vid);
+}
+
+u16_t usb_get_product_id(void)
+{
+	return sys_le16_to_cpu(common_desc.device_descriptor.idProduct);
+}
+
+void usb_set_product_id(u16_t pid)
+{
+	common_desc.device_descriptor.idProduct = sys_cpu_to_le16(pid);
+}


### PR DESCRIPTION
Add runtime getters/setters for the vendor and product ids that were
previously only configurable at build time via USB_DEVICE_{VID,PID}.