### PR TITLE
kernel: mark time conversion functions as constexpr in C++14.

### DIFF
--- a/include/sys/time_units.h
+++ b/include/sys/time_units.h
@@ -24,7 +24,17 @@ static inline int z_impl_z_clock_hw_cycles_per_sec_runtime_get(void)
 }
 #endif /* CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME */
 
-static inline int sys_clock_hw_cycles_per_sec(void)
+#if defined(__cplusplus) && __cplusplus >= 201402L
+  #if defined(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME)
+    #define TIME_CONSTEXPR
+  #else
+    #define TIME_CONSTEXPR constexpr
+  #endif
+#else
+  #define TIME_CONSTEXPR
+#endif
+
+static TIME_CONSTEXPR inline int sys_clock_hw_cycles_per_sec(void)
 {
 #if defined(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME)
 	return z_clock_hw_cycles_per_sec_runtime_get();
@@ -52,9 +62,10 @@ static inline int sys_clock_hw_cycles_per_sec(void)
  *    round_off - Return the nearest value to the resulting fraction
  *                (pass both round_up/off as false to get "round_down")
  */
-static ALWAYS_INLINE u64_t z_tmcvt(u64_t t, u32_t from_hz, u32_t to_hz,
-				   bool const_hz, bool result32,
-				   bool round_up, bool round_off)
+static TIME_CONSTEXPR ALWAYS_INLINE u64_t z_tmcvt(u64_t t, u32_t from_hz,
+						  u32_t to_hz, bool const_hz,
+						  bool result32, bool round_up,
+						  bool round_off)
 {
 	bool mul_ratio = const_hz &&
 		(to_hz > from_hz) && ((to_hz % from_hz) == 0);
@@ -158,7 +169,7 @@ static ALWAYS_INLINE u64_t z_tmcvt(u64_t t, u32_t from_hz, u32_t to_hz,
  *                 print " * \@return The converted time value\n";
  *                 print " *", "/\n";
  *
- *                 print "static inline $type $sym($type t)\n{\n\t";
+ *                 print "static TIME_CONSTEXPR inline $type $sym($type t)\n{\n\t";
  *                 print "/", "* Generated.  Do not edit.  See above. *", "/\n\t";
  *                 print "return z_tmcvt(t, Z_HZ_$from_unit, Z_HZ_$to_unit,";
  *                 print " $const_hz, $ret32, $rup, $roff);\n";
@@ -187,7 +198,7 @@ static ALWAYS_INLINE u64_t z_tmcvt(u64_t t, u32_t from_hz, u32_t to_hz,
  *
  * @return The converted time value
  */
-static inline u32_t k_ms_to_cyc_floor32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ms_to_cyc_floor32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ms, Z_HZ_cyc, Z_CCYC, true, false, false);
@@ -201,7 +212,7 @@ static inline u32_t k_ms_to_cyc_floor32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ms_to_cyc_floor64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ms_to_cyc_floor64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ms, Z_HZ_cyc, Z_CCYC, false, false, false);
@@ -215,7 +226,7 @@ static inline u64_t k_ms_to_cyc_floor64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ms_to_cyc_near32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ms_to_cyc_near32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ms, Z_HZ_cyc, Z_CCYC, true, false, true);
@@ -229,7 +240,7 @@ static inline u32_t k_ms_to_cyc_near32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ms_to_cyc_near64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ms_to_cyc_near64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ms, Z_HZ_cyc, Z_CCYC, false, false, true);
@@ -243,7 +254,7 @@ static inline u64_t k_ms_to_cyc_near64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ms_to_cyc_ceil32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ms_to_cyc_ceil32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ms, Z_HZ_cyc, Z_CCYC, true, true, false);
@@ -257,7 +268,7 @@ static inline u32_t k_ms_to_cyc_ceil32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ms_to_cyc_ceil64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ms_to_cyc_ceil64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ms, Z_HZ_cyc, Z_CCYC, false, true, false);
@@ -271,7 +282,7 @@ static inline u64_t k_ms_to_cyc_ceil64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ms_to_ticks_floor32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ms_to_ticks_floor32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ms, Z_HZ_ticks, true, true, false, false);
@@ -285,7 +296,7 @@ static inline u32_t k_ms_to_ticks_floor32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ms_to_ticks_floor64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ms_to_ticks_floor64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ms, Z_HZ_ticks, true, false, false, false);
@@ -299,7 +310,7 @@ static inline u64_t k_ms_to_ticks_floor64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ms_to_ticks_near32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ms_to_ticks_near32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ms, Z_HZ_ticks, true, true, false, true);
@@ -313,7 +324,7 @@ static inline u32_t k_ms_to_ticks_near32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ms_to_ticks_near64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ms_to_ticks_near64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ms, Z_HZ_ticks, true, false, false, true);
@@ -327,7 +338,7 @@ static inline u64_t k_ms_to_ticks_near64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ms_to_ticks_ceil32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ms_to_ticks_ceil32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ms, Z_HZ_ticks, true, true, true, false);
@@ -341,7 +352,7 @@ static inline u32_t k_ms_to_ticks_ceil32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ms_to_ticks_ceil64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ms_to_ticks_ceil64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ms, Z_HZ_ticks, true, false, true, false);
@@ -355,7 +366,7 @@ static inline u64_t k_ms_to_ticks_ceil64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_us_to_cyc_floor32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_us_to_cyc_floor32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_us, Z_HZ_cyc, Z_CCYC, true, false, false);
@@ -369,7 +380,7 @@ static inline u32_t k_us_to_cyc_floor32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_us_to_cyc_floor64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_us_to_cyc_floor64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_us, Z_HZ_cyc, Z_CCYC, false, false, false);
@@ -383,7 +394,7 @@ static inline u64_t k_us_to_cyc_floor64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_us_to_cyc_near32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_us_to_cyc_near32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_us, Z_HZ_cyc, Z_CCYC, true, false, true);
@@ -397,7 +408,7 @@ static inline u32_t k_us_to_cyc_near32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_us_to_cyc_near64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_us_to_cyc_near64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_us, Z_HZ_cyc, Z_CCYC, false, false, true);
@@ -411,7 +422,7 @@ static inline u64_t k_us_to_cyc_near64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_us_to_cyc_ceil32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_us_to_cyc_ceil32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_us, Z_HZ_cyc, Z_CCYC, true, true, false);
@@ -425,7 +436,7 @@ static inline u32_t k_us_to_cyc_ceil32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_us_to_cyc_ceil64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_us_to_cyc_ceil64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_us, Z_HZ_cyc, Z_CCYC, false, true, false);
@@ -439,7 +450,7 @@ static inline u64_t k_us_to_cyc_ceil64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_us_to_ticks_floor32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_us_to_ticks_floor32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_us, Z_HZ_ticks, true, true, false, false);
@@ -453,7 +464,7 @@ static inline u32_t k_us_to_ticks_floor32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_us_to_ticks_floor64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_us_to_ticks_floor64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_us, Z_HZ_ticks, true, false, false, false);
@@ -467,7 +478,7 @@ static inline u64_t k_us_to_ticks_floor64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_us_to_ticks_near32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_us_to_ticks_near32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_us, Z_HZ_ticks, true, true, false, true);
@@ -481,7 +492,7 @@ static inline u32_t k_us_to_ticks_near32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_us_to_ticks_near64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_us_to_ticks_near64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_us, Z_HZ_ticks, true, false, false, true);
@@ -495,7 +506,7 @@ static inline u64_t k_us_to_ticks_near64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_us_to_ticks_ceil32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_us_to_ticks_ceil32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_us, Z_HZ_ticks, true, true, true, false);
@@ -509,7 +520,7 @@ static inline u32_t k_us_to_ticks_ceil32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_us_to_ticks_ceil64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_us_to_ticks_ceil64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_us, Z_HZ_ticks, true, false, true, false);
@@ -523,7 +534,7 @@ static inline u64_t k_us_to_ticks_ceil64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ns_to_cyc_floor32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ns_to_cyc_floor32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ns, Z_HZ_cyc, Z_CCYC, true, false, false);
@@ -537,7 +548,7 @@ static inline u32_t k_ns_to_cyc_floor32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ns_to_cyc_floor64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ns_to_cyc_floor64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ns, Z_HZ_cyc, Z_CCYC, false, false, false);
@@ -551,7 +562,7 @@ static inline u64_t k_ns_to_cyc_floor64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ns_to_cyc_near32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ns_to_cyc_near32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ns, Z_HZ_cyc, Z_CCYC, true, false, true);
@@ -565,7 +576,7 @@ static inline u32_t k_ns_to_cyc_near32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ns_to_cyc_near64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ns_to_cyc_near64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ns, Z_HZ_cyc, Z_CCYC, false, false, true);
@@ -579,7 +590,7 @@ static inline u64_t k_ns_to_cyc_near64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ns_to_cyc_ceil32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ns_to_cyc_ceil32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ns, Z_HZ_cyc, Z_CCYC, true, true, false);
@@ -593,7 +604,7 @@ static inline u32_t k_ns_to_cyc_ceil32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ns_to_cyc_ceil64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ns_to_cyc_ceil64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ns, Z_HZ_cyc, Z_CCYC, false, true, false);
@@ -607,7 +618,7 @@ static inline u64_t k_ns_to_cyc_ceil64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ns_to_ticks_floor32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ns_to_ticks_floor32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ns, Z_HZ_ticks, true, true, false, false);
@@ -621,7 +632,7 @@ static inline u32_t k_ns_to_ticks_floor32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ns_to_ticks_floor64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ns_to_ticks_floor64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ns, Z_HZ_ticks, true, false, false, false);
@@ -635,7 +646,7 @@ static inline u64_t k_ns_to_ticks_floor64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ns_to_ticks_near32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ns_to_ticks_near32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ns, Z_HZ_ticks, true, true, false, true);
@@ -649,7 +660,7 @@ static inline u32_t k_ns_to_ticks_near32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ns_to_ticks_near64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ns_to_ticks_near64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ns, Z_HZ_ticks, true, false, false, true);
@@ -663,7 +674,7 @@ static inline u64_t k_ns_to_ticks_near64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ns_to_ticks_ceil32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ns_to_ticks_ceil32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ns, Z_HZ_ticks, true, true, true, false);
@@ -677,7 +688,7 @@ static inline u32_t k_ns_to_ticks_ceil32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ns_to_ticks_ceil64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ns_to_ticks_ceil64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ns, Z_HZ_ticks, true, false, true, false);
@@ -691,7 +702,7 @@ static inline u64_t k_ns_to_ticks_ceil64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_cyc_to_ms_floor32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_cyc_to_ms_floor32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_ms, Z_CCYC, true, false, false);
@@ -705,7 +716,7 @@ static inline u32_t k_cyc_to_ms_floor32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_cyc_to_ms_floor64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_cyc_to_ms_floor64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_ms, Z_CCYC, false, false, false);
@@ -719,7 +730,7 @@ static inline u64_t k_cyc_to_ms_floor64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_cyc_to_ms_near32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_cyc_to_ms_near32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_ms, Z_CCYC, true, false, true);
@@ -733,7 +744,7 @@ static inline u32_t k_cyc_to_ms_near32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_cyc_to_ms_near64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_cyc_to_ms_near64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_ms, Z_CCYC, false, false, true);
@@ -747,7 +758,7 @@ static inline u64_t k_cyc_to_ms_near64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_cyc_to_ms_ceil32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_cyc_to_ms_ceil32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_ms, Z_CCYC, true, true, false);
@@ -761,7 +772,7 @@ static inline u32_t k_cyc_to_ms_ceil32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_cyc_to_ms_ceil64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_cyc_to_ms_ceil64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_ms, Z_CCYC, false, true, false);
@@ -775,7 +786,7 @@ static inline u64_t k_cyc_to_ms_ceil64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_cyc_to_us_floor32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_cyc_to_us_floor32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_us, Z_CCYC, true, false, false);
@@ -789,7 +800,7 @@ static inline u32_t k_cyc_to_us_floor32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_cyc_to_us_floor64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_cyc_to_us_floor64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_us, Z_CCYC, false, false, false);
@@ -803,7 +814,7 @@ static inline u64_t k_cyc_to_us_floor64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_cyc_to_us_near32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_cyc_to_us_near32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_us, Z_CCYC, true, false, true);
@@ -817,7 +828,7 @@ static inline u32_t k_cyc_to_us_near32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_cyc_to_us_near64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_cyc_to_us_near64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_us, Z_CCYC, false, false, true);
@@ -831,7 +842,7 @@ static inline u64_t k_cyc_to_us_near64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_cyc_to_us_ceil32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_cyc_to_us_ceil32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_us, Z_CCYC, true, true, false);
@@ -845,7 +856,7 @@ static inline u32_t k_cyc_to_us_ceil32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_cyc_to_us_ceil64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_cyc_to_us_ceil64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_us, Z_CCYC, false, true, false);
@@ -859,7 +870,7 @@ static inline u64_t k_cyc_to_us_ceil64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_cyc_to_ns_floor32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_cyc_to_ns_floor32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_ns, Z_CCYC, true, false, false);
@@ -873,7 +884,7 @@ static inline u32_t k_cyc_to_ns_floor32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_cyc_to_ns_floor64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_cyc_to_ns_floor64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_ns, Z_CCYC, false, false, false);
@@ -887,7 +898,7 @@ static inline u64_t k_cyc_to_ns_floor64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_cyc_to_ns_near32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_cyc_to_ns_near32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_ns, Z_CCYC, true, false, true);
@@ -901,7 +912,7 @@ static inline u32_t k_cyc_to_ns_near32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_cyc_to_ns_near64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_cyc_to_ns_near64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_ns, Z_CCYC, false, false, true);
@@ -915,7 +926,7 @@ static inline u64_t k_cyc_to_ns_near64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_cyc_to_ns_ceil32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_cyc_to_ns_ceil32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_ns, Z_CCYC, true, true, false);
@@ -929,7 +940,7 @@ static inline u32_t k_cyc_to_ns_ceil32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_cyc_to_ns_ceil64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_cyc_to_ns_ceil64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_ns, Z_CCYC, false, true, false);
@@ -943,7 +954,7 @@ static inline u64_t k_cyc_to_ns_ceil64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_cyc_to_ticks_floor32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_cyc_to_ticks_floor32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_ticks, Z_CCYC, true, false, false);
@@ -957,7 +968,7 @@ static inline u32_t k_cyc_to_ticks_floor32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_cyc_to_ticks_floor64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_cyc_to_ticks_floor64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_ticks, Z_CCYC, false, false, false);
@@ -971,7 +982,7 @@ static inline u64_t k_cyc_to_ticks_floor64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_cyc_to_ticks_near32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_cyc_to_ticks_near32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_ticks, Z_CCYC, true, false, true);
@@ -985,7 +996,7 @@ static inline u32_t k_cyc_to_ticks_near32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_cyc_to_ticks_near64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_cyc_to_ticks_near64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_ticks, Z_CCYC, false, false, true);
@@ -999,7 +1010,7 @@ static inline u64_t k_cyc_to_ticks_near64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_cyc_to_ticks_ceil32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_cyc_to_ticks_ceil32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_ticks, Z_CCYC, true, true, false);
@@ -1013,7 +1024,7 @@ static inline u32_t k_cyc_to_ticks_ceil32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_cyc_to_ticks_ceil64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_cyc_to_ticks_ceil64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_cyc, Z_HZ_ticks, Z_CCYC, false, true, false);
@@ -1027,7 +1038,7 @@ static inline u64_t k_cyc_to_ticks_ceil64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ticks_to_ms_floor32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ticks_to_ms_floor32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_ms, true, true, false, false);
@@ -1041,7 +1052,7 @@ static inline u32_t k_ticks_to_ms_floor32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ticks_to_ms_floor64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ticks_to_ms_floor64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_ms, true, false, false, false);
@@ -1055,7 +1066,7 @@ static inline u64_t k_ticks_to_ms_floor64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ticks_to_ms_near32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ticks_to_ms_near32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_ms, true, true, false, true);
@@ -1069,7 +1080,7 @@ static inline u32_t k_ticks_to_ms_near32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ticks_to_ms_near64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ticks_to_ms_near64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_ms, true, false, false, true);
@@ -1083,7 +1094,7 @@ static inline u64_t k_ticks_to_ms_near64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ticks_to_ms_ceil32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ticks_to_ms_ceil32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_ms, true, true, true, false);
@@ -1097,7 +1108,7 @@ static inline u32_t k_ticks_to_ms_ceil32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ticks_to_ms_ceil64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ticks_to_ms_ceil64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_ms, true, false, true, false);
@@ -1111,7 +1122,7 @@ static inline u64_t k_ticks_to_ms_ceil64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ticks_to_us_floor32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ticks_to_us_floor32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_us, true, true, false, false);
@@ -1125,7 +1136,7 @@ static inline u32_t k_ticks_to_us_floor32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ticks_to_us_floor64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ticks_to_us_floor64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_us, true, false, false, false);
@@ -1139,7 +1150,7 @@ static inline u64_t k_ticks_to_us_floor64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ticks_to_us_near32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ticks_to_us_near32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_us, true, true, false, true);
@@ -1153,7 +1164,7 @@ static inline u32_t k_ticks_to_us_near32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ticks_to_us_near64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ticks_to_us_near64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_us, true, false, false, true);
@@ -1167,7 +1178,7 @@ static inline u64_t k_ticks_to_us_near64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ticks_to_us_ceil32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ticks_to_us_ceil32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_us, true, true, true, false);
@@ -1181,7 +1192,7 @@ static inline u32_t k_ticks_to_us_ceil32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ticks_to_us_ceil64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ticks_to_us_ceil64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_us, true, false, true, false);
@@ -1195,7 +1206,7 @@ static inline u64_t k_ticks_to_us_ceil64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ticks_to_ns_floor32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ticks_to_ns_floor32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_ns, true, true, false, false);
@@ -1209,7 +1220,7 @@ static inline u32_t k_ticks_to_ns_floor32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ticks_to_ns_floor64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ticks_to_ns_floor64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_ns, true, false, false, false);
@@ -1223,7 +1234,7 @@ static inline u64_t k_ticks_to_ns_floor64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ticks_to_ns_near32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ticks_to_ns_near32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_ns, true, true, false, true);
@@ -1237,7 +1248,7 @@ static inline u32_t k_ticks_to_ns_near32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ticks_to_ns_near64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ticks_to_ns_near64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_ns, true, false, false, true);
@@ -1251,7 +1262,7 @@ static inline u64_t k_ticks_to_ns_near64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ticks_to_ns_ceil32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ticks_to_ns_ceil32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_ns, true, true, true, false);
@@ -1265,7 +1276,7 @@ static inline u32_t k_ticks_to_ns_ceil32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ticks_to_ns_ceil64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ticks_to_ns_ceil64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_ns, true, false, true, false);
@@ -1279,7 +1290,7 @@ static inline u64_t k_ticks_to_ns_ceil64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ticks_to_cyc_floor32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ticks_to_cyc_floor32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_cyc, Z_CCYC, true, false, false);
@@ -1293,7 +1304,7 @@ static inline u32_t k_ticks_to_cyc_floor32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ticks_to_cyc_floor64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ticks_to_cyc_floor64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_cyc, Z_CCYC, false, false, false);
@@ -1307,7 +1318,7 @@ static inline u64_t k_ticks_to_cyc_floor64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ticks_to_cyc_near32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ticks_to_cyc_near32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_cyc, Z_CCYC, true, false, true);
@@ -1321,7 +1332,7 @@ static inline u32_t k_ticks_to_cyc_near32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ticks_to_cyc_near64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ticks_to_cyc_near64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_cyc, Z_CCYC, false, false, true);
@@ -1335,7 +1346,7 @@ static inline u64_t k_ticks_to_cyc_near64(u64_t t)
  *
  * @return The converted time value
  */
-static inline u32_t k_ticks_to_cyc_ceil32(u32_t t)
+static TIME_CONSTEXPR inline u32_t k_ticks_to_cyc_ceil32(u32_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_cyc, Z_CCYC, true, true, false);
@@ -1349,7 +1360,7 @@ static inline u32_t k_ticks_to_cyc_ceil32(u32_t t)
  *
  * @return The converted time value
  */
-static inline u64_t k_ticks_to_cyc_ceil64(u64_t t)
+static TIME_CONSTEXPR inline u64_t k_ticks_to_cyc_ceil64(u64_t t)
 {
 	/* Generated.  Do not edit.  See above. */
 	return z_tmcvt(t, Z_HZ_ticks, Z_HZ_cyc, Z_CCYC, false, true, false);
@@ -1358,6 +1369,8 @@ static inline u64_t k_ticks_to_cyc_ceil64(u64_t t)
 #if defined(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME)
 #include <syscalls/time_units.h>
 #endif
+
+#undef TIME_CONSTEXPR
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
Allow C++ code to evaluate time base conversion routines at compile time
by marking them as constexpr where possible.