### PR TITLE
kernel: work_q: add k_delayed_work_submit_ticks.

### DIFF
--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -81,8 +81,15 @@ static int work_cancel(struct k_delayed_work *work)
 }
 
 int k_delayed_work_submit_to_queue(struct k_work_q *work_q,
+				   struct k_delayed_work *work, s32_t delay)
+{
+	return k_delayed_work_submit_to_queue_ticks(
+		work_q, work, k_ms_to_ticks_ceil32(delay));
+}
+
+int k_delayed_work_submit_to_queue_ticks(struct k_work_q *work_q,
 				   struct k_delayed_work *work,
-				   s32_t delay)
+				   u32_t ticks)
 {
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	int err = 0;
@@ -112,15 +119,14 @@ int k_delayed_work_submit_to_queue(struct k_work_q *work_q,
 	/* Submit work directly if no delay.  Note that this is a
 	 * blocking operation, so release the lock first.
 	 */
-	if (delay == 0) {
+	if (ticks == 0) {
 		k_spin_unlock(&lock, key);
 		k_work_submit_to_queue(work_q, &work->work);
 		return 0;
 	}
 
 	/* Add timeout */
-	z_add_timeout(&work->timeout, work_timeout,
-		     _TICK_ALIGN + k_ms_to_ticks_ceil32(delay));
+	z_add_timeout(&work->timeout, work_timeout, _TICK_ALIGN + ticks);
 
 done:
 	k_spin_unlock(&lock, key);


### PR DESCRIPTION
Add variants of k_delayed_work_submit and k_delayed_work_submit_to_queue
that take a delay in ticks, which is the actual base time unit used for
delays.