### PR TITLE
doc: release notes: list of ARM SoCs added during v2.2 release cycle

### DIFF
--- a/doc/releases/release-notes-2.2.rst
+++ b/doc/releases/release-notes-2.2.rst
@@ -205,6 +205,7 @@ Boards & SoC Support
    * Google Kukui EC
    * NXP i.MX RT1010 Evaluation Kit
    * Silicon Labs EFM32 Giant Gecko GG11
+   * Silicon Labs EFM32 Jade Gecko
    * ST Nucleo F767ZI
    * ST Nucleo G474RE
    * ST Nucleo L152RE

--- a/doc/releases/release-notes-2.2.rst
+++ b/doc/releases/release-notes-2.2.rst
@@ -179,7 +179,19 @@ Boards & SoC Support
 
 .. rst-class:: rst-columns
 
-   * <TBD>
+   * Atmel SAM4E
+   * Atmel SAMV71
+   * Broadcom BCM58400
+   * NXP i.MX RT1011
+   * Silicon Labs EFM32GG11B
+   * Silicon Labs EFM32JG12B
+   * ST STM32F098xx
+   * ST STM32F100XX
+   * ST STM32F767ZI
+   * ST STM32L152RET6
+   * ST STM32L452XC
+   * ST STM32G031
+
 
 * Added support for these ARM boards:
 

--- a/soc/arm/silabs_exx32/efm32gg11b/Kconfig.series
+++ b/soc/arm/silabs_exx32/efm32gg11b/Kconfig.series
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_EFM32GG11B
-	bool "EFM32PG11B Series MCU"
+	bool "EFM32GG11B Series MCU"
 	select ARM
 	select HAS_SILABS_GECKO
 	select HAS_SWO


### PR DESCRIPTION
This commit adds the list of ARM SoCs whose support was
added during the Zephyr v2.2 release cycle.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>