### PR TITLE
subsys/mgmt: Fix incorrect buffer space check

### DIFF
--- a/subsys/mgmt/smp.c
+++ b/subsys/mgmt/smp.c
@@ -148,7 +148,7 @@ zephyr_smp_write_at(struct cbor_encoder_writer *writer, size_t offset,
 		return MGMT_ERR_EINVAL;
 	}
 
-	if (len > net_buf_tailroom(nb)) {
+	if ((offset + len) > (nb->size - net_buf_headroom(nb))) {
 		return MGMT_ERR_EINVAL;
 	}
 


### PR DESCRIPTION
zephyr_smp_write_at is supposed to write len bytes of data at
the offset of a given net_buf, overwriting existing data and extending
beyond current buffer length, if needed. Unfortunately condition
checking if written data would fit within the buffer size has been
incorrectly implemented, making write impossible, when there has been
less bytes of space left within buffer tailroom than required to write
len bytes of data, even if len bytes written starting at given offset
would not cross the buffer boundary.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>