### PR TITLE
Bluetooth: controller: ticker stop at absolute tick

### DIFF
--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -295,6 +295,7 @@ static void time_slot_callback_work(u32_t ticks_at_expire, u32_t remainder,
 		result = ticker_stop(instance_index,
 				     0,
 				     ticker_id,
+				     0,
 				     NULL,
 				     NULL);
 
@@ -343,7 +344,7 @@ static void time_slot_callback_helper(u32_t ticks_at_expire, u32_t remainder,
 		((struct flash_op_desc *)context)->result = -ECANCELED;
 
 		/* abort flash timeslots */
-		err = ticker_stop(instance_index, 0, ticker_id, NULL, NULL);
+		err = ticker_stop(instance_index, 0, ticker_id, 0, NULL, NULL);
 		if (err != TICKER_STATUS_SUCCESS &&
 		    err != TICKER_STATUS_BUSY) {
 			__ASSERT(0, "Failed to stop ticker.\n");

--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -295,7 +295,7 @@ static void time_slot_callback_work(u32_t ticks_at_expire, u32_t remainder,
 		result = ticker_stop(instance_index,
 				     0,
 				     ticker_id,
-				     0,
+				     0, 0,
 				     NULL,
 				     NULL);
 
@@ -344,7 +344,8 @@ static void time_slot_callback_helper(u32_t ticks_at_expire, u32_t remainder,
 		((struct flash_op_desc *)context)->result = -ECANCELED;
 
 		/* abort flash timeslots */
-		err = ticker_stop(instance_index, 0, ticker_id, 0, NULL, NULL);
+		err = ticker_stop(instance_index, 0, ticker_id, 0, 0,
+				  NULL, NULL);
 		if (err != TICKER_STATUS_SUCCESS &&
 		    err != TICKER_STATUS_BUSY) {
 			__ASSERT(0, "Failed to stop ticker.\n");

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -1238,7 +1238,9 @@ static inline u32_t isr_rx_adv(u8_t devmatch_ok, u8_t devmatch_id,
 			ticks_slot_offset;
 		ticker_status = ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
 					    RADIO_TICKER_USER_ID_WORKER,
-					    RADIO_TICKER_ID_ADV, ticks_at_stop,
+					    RADIO_TICKER_ID_ADV,
+					    TICKER_STOP_FLAG_ABSOLUTE,
+					    ticks_at_stop,
 					    ticker_stop_adv_assert,
 					    (void *)__LINE__);
 		ticker_stop_adv_assert(ticker_status, (void *)__LINE__);
@@ -1251,7 +1253,7 @@ static inline u32_t isr_rx_adv(u8_t devmatch_ok, u8_t devmatch_id,
 			 */
 			ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
 				    RADIO_TICKER_USER_ID_WORKER,
-				    RADIO_TICKER_ID_ADV_STOP, 0, NULL, NULL);
+				    RADIO_TICKER_ID_ADV_STOP, 0, 0, NULL, NULL);
 		}
 
 		/* Start Slave */
@@ -1735,7 +1737,9 @@ static inline u32_t isr_rx_scan(u8_t devmatch_ok, u8_t devmatch_id,
 			ticks_slot_offset;
 		ticker_status = ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
 					    RADIO_TICKER_USER_ID_WORKER,
-					    RADIO_TICKER_ID_SCAN, ticks_at_stop,
+					    RADIO_TICKER_ID_SCAN,
+					    TICKER_STOP_FLAG_ABSOLUTE,
+					    ticks_at_stop,
 					    ticker_stop_scan_assert,
 					    (void *)__LINE__);
 		ticker_stop_scan_assert(ticker_status, (void *)__LINE__);
@@ -1746,7 +1750,7 @@ static inline u32_t isr_rx_scan(u8_t devmatch_ok, u8_t devmatch_id,
 		 */
 		ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
 			    RADIO_TICKER_USER_ID_WORKER,
-			    RADIO_TICKER_ID_SCAN_STOP, 0, NULL, NULL);
+			    RADIO_TICKER_ID_SCAN_STOP, 0, 0, NULL, NULL);
 
 		/* Start master */
 		ticker_status =
@@ -4314,7 +4318,7 @@ static inline u32_t isr_close_adv_mesh(void)
 	if (!_radio.advertiser.retry) {
 		ticker_status =	ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
 					    RADIO_TICKER_USER_ID_WORKER,
-					    RADIO_TICKER_ID_ADV, 0,
+					    RADIO_TICKER_ID_ADV, 0, 0,
 					    ticker_stop_adv_stop,
 					    (void *)__LINE__);
 		LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
@@ -4528,7 +4532,8 @@ static inline u32_t isr_close_scan(void)
 			 */
 			ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
 				    RADIO_TICKER_USER_ID_WORKER,
-				    RADIO_TICKER_ID_SCAN_STOP, 0, NULL, NULL);
+				    RADIO_TICKER_ID_SCAN_STOP, 0, 0,
+				    NULL, NULL);
 		}
 	}
 
@@ -6887,7 +6892,7 @@ static inline void ticker_stop_adv_stop_active(void)
 
 	/* Step 2: Is caller before Event? Stop Event */
 	ret = ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
-			  RADIO_TICKER_USER_ID_JOB, RADIO_TICKER_ID_EVENT, 0,
+			  RADIO_TICKER_USER_ID_JOB, RADIO_TICKER_ID_EVENT, 0, 0,
 			  ticker_if_done, (void *)&ret_cb_evt);
 
 	if (ret == TICKER_STATUS_BUSY) {
@@ -6918,7 +6923,7 @@ static inline void ticker_stop_adv_stop_active(void)
 		 */
 		ret = ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
 				  RADIO_TICKER_USER_ID_JOB,
-				  RADIO_TICKER_ID_MARKER_0, 0,
+				  RADIO_TICKER_ID_MARKER_0, 0, 0,
 				  ticker_if_done, (void *)&ret_cb_m0);
 
 		if (ret == TICKER_STATUS_BUSY) {
@@ -7095,7 +7100,7 @@ void event_adv_stop(u32_t ticks_at_expire, u32_t remainder, u16_t lazy,
 	/* Stop Direct Adv */
 	ticker_status =
 	    ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
-			RADIO_TICKER_USER_ID_WORKER, RADIO_TICKER_ID_ADV, 0,
+			RADIO_TICKER_USER_ID_WORKER, RADIO_TICKER_ID_ADV, 0, 0,
 			ticker_stop_adv_stop, NULL);
 	LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
 		  (ticker_status == TICKER_STATUS_BUSY));
@@ -7602,8 +7607,8 @@ static inline u32_t event_conn_upd_prep(struct connection *conn,
 		ticker_id = RADIO_TICKER_ID_FIRST_CONNECTION + conn->handle;
 		ticker_status =
 			ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
-				    RADIO_TICKER_USER_ID_WORKER, ticker_id, 0,
-				    ticker_stop_conn_assert,
+				    RADIO_TICKER_USER_ID_WORKER, ticker_id,
+				    0, 0, ticker_stop_conn_assert,
 				    (void *)(u32_t)ticker_id);
 		LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
 			  (ticker_status == TICKER_STATUS_BUSY));
@@ -10329,7 +10334,7 @@ static void connection_release(struct connection *conn)
 		ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
 			    RADIO_TICKER_USER_ID_WORKER,
 			    (RADIO_TICKER_ID_FIRST_CONNECTION + conn->handle),
-			    0, ticker_success_assert, (void *)__LINE__);
+			    0, 0, ticker_success_assert, (void *)__LINE__);
 	LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
 		  (ticker_status == TICKER_STATUS_BUSY));
 
@@ -10345,14 +10350,14 @@ static void connection_release(struct connection *conn)
 		ticker_status =
 			ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
 				    RADIO_TICKER_USER_ID_WORKER,
-				    RADIO_TICKER_ID_MARKER_0, 0,
+				    RADIO_TICKER_ID_MARKER_0, 0, 0,
 				    ticker_success_assert, (void *)__LINE__);
 		LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
 			  (ticker_status == TICKER_STATUS_BUSY));
 		ticker_status =
 		    ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
 				RADIO_TICKER_USER_ID_WORKER,
-				RADIO_TICKER_ID_EVENT, 0,
+				RADIO_TICKER_ID_EVENT, 0, 0,
 				ticker_success_assert, (void *)__LINE__);
 		LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
 			  (ticker_status == TICKER_STATUS_BUSY));
@@ -11114,7 +11119,7 @@ static inline void role_active_disable(u8_t ticker_id_stop,
 
 	/* Step 2: Is caller before Event? Stop Event */
 	ret = ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
-			  RADIO_TICKER_USER_ID_APP, RADIO_TICKER_ID_EVENT, 0,
+			  RADIO_TICKER_USER_ID_APP, RADIO_TICKER_ID_EVENT, 0, 0,
 			  ticker_if_done, (void *)&ret_cb_evt);
 
 	if (ret == TICKER_STATUS_BUSY) {
@@ -11142,7 +11147,7 @@ static inline void role_active_disable(u8_t ticker_id_stop,
 		 */
 		ret = ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
 				  RADIO_TICKER_USER_ID_APP,
-				  RADIO_TICKER_ID_MARKER_0, 0,
+				  RADIO_TICKER_ID_MARKER_0, 0, 0,
 				  ticker_if_done, (void *)&ret_cb_m0);
 
 		if (ret == TICKER_STATUS_BUSY) {
@@ -11239,7 +11244,7 @@ static inline void role_active_disable(u8_t ticker_id_stop,
 
 			ret = ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
 					  RADIO_TICKER_USER_ID_APP,
-					  ticker_id_stop, 0, ticker_if_done,
+					  ticker_id_stop, 0, 0, ticker_if_done,
 					  (void *)&ret_cb_stop);
 
 			if (ret == TICKER_STATUS_BUSY) {
@@ -11314,8 +11319,8 @@ static u8_t role_disable(u8_t ticker_id_primary, u8_t ticker_id_stop)
 		 * hence stop may fail if ticker not used.
 		 */
 		ret = ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
-				  RADIO_TICKER_USER_ID_APP, ticker_id_stop, 0,
-				  ticker_if_done, (void *)&ret_cb);
+				  RADIO_TICKER_USER_ID_APP, ticker_id_stop,
+				  0, 0, ticker_if_done, (void *)&ret_cb);
 		if (ret == TICKER_STATUS_BUSY) {
 			/* wait for ticker to be stopped */
 			while (ret_cb == TICKER_STATUS_BUSY) {
@@ -11361,7 +11366,7 @@ static u8_t role_disable(u8_t ticker_id_primary, u8_t ticker_id_stop)
 	/* Step 1: Is Primary started? Stop the Primary ticker */
 	ret_cb = TICKER_STATUS_BUSY;
 	ret = ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
-			  RADIO_TICKER_USER_ID_APP, ticker_id_primary, 0,
+			  RADIO_TICKER_USER_ID_APP, ticker_id_primary, 0, 0,
 			  ticker_if_done, (void *)&ret_cb);
 
 	if (ret == TICKER_STATUS_BUSY) {

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -1239,8 +1239,8 @@ static inline u32_t isr_rx_adv(u8_t devmatch_ok, u8_t devmatch_id,
 		ticker_status = ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
 					    RADIO_TICKER_USER_ID_WORKER,
 					    RADIO_TICKER_ID_ADV,
-					    TICKER_STOP_FLAG_ABSOLUTE,
 					    ticks_at_stop,
+					    TICKER_STOP_FLAG_ABSOLUTE,
 					    ticker_stop_adv_assert,
 					    (void *)__LINE__);
 		ticker_stop_adv_assert(ticker_status, (void *)__LINE__);
@@ -1738,8 +1738,8 @@ static inline u32_t isr_rx_scan(u8_t devmatch_ok, u8_t devmatch_id,
 		ticker_status = ticker_stop(RADIO_TICKER_INSTANCE_ID_RADIO,
 					    RADIO_TICKER_USER_ID_WORKER,
 					    RADIO_TICKER_ID_SCAN,
-					    TICKER_STOP_FLAG_ABSOLUTE,
 					    ticks_at_stop,
+					    TICKER_STOP_FLAG_ABSOLUTE,
 					    ticker_stop_scan_assert,
 					    (void *)__LINE__);
 		ticker_stop_scan_assert(ticker_status, (void *)__LINE__);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -555,7 +555,7 @@ static int prepare(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 
 	/* Stop running pre-empt timer, if any */
 	ret = ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_LLL,
-			  TICKER_ID_LLL_PREEMPT, 0, NULL, NULL);
+			  TICKER_ID_LLL_PREEMPT, 0, 0, NULL, NULL);
 	LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
 		  (ret == TICKER_STATUS_FAILURE) ||
 		  (ret == TICKER_STATUS_BUSY));

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -555,7 +555,7 @@ static int prepare(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 
 	/* Stop running pre-empt timer, if any */
 	ret = ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_LLL,
-			  TICKER_ID_LLL_PREEMPT, NULL, NULL);
+			  TICKER_ID_LLL_PREEMPT, 0, NULL, NULL);
 	LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
 		  (ret == TICKER_STATUS_FAILURE) ||
 		  (ret == TICKER_STATUS_BUSY));

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -589,7 +589,7 @@ static void isr_abort(void *param)
 	 * expired, hence ignore failure.
 	 */
 	ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_LLL,
-		    TICKER_ID_SCAN_STOP, 0, NULL, NULL);
+		    TICKER_ID_SCAN_STOP, 0, 0, NULL, NULL);
 
 	/* Under race conditions, radio could get started while entering ISR */
 	radio_disable();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -589,7 +589,7 @@ static void isr_abort(void *param)
 	 * expired, hence ignore failure.
 	 */
 	ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_LLL,
-		    TICKER_ID_SCAN_STOP, NULL, NULL);
+		    TICKER_ID_SCAN_STOP, 0, NULL, NULL);
 
 	/* Under race conditions, radio could get started while entering ISR */
 	radio_disable();

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1136,7 +1136,7 @@ static void ticker_stop_cb(u32_t ticks_at_expire, u32_t remainder, u16_t lazy,
 	LL_ASSERT(handle < BT_CTLR_ADV_MAX);
 
 	ret = ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_ULL_HIGH,
-			  TICKER_ID_ADV_BASE + handle, 0,
+			  TICKER_ID_ADV_BASE + handle, 0, 0,
 			  ticker_op_stop_cb, adv);
 	LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
 		  (ret == TICKER_STATUS_BUSY));
@@ -1255,7 +1255,8 @@ static inline u8_t disable(u16_t handle)
 	if (adv->lll.is_hdcd) {
 		ret = ticker_stop(TICKER_INSTANCE_ID_CTLR,
 				  TICKER_USER_ID_THREAD, TICKER_ID_ADV_STOP,
-				  0, ull_ticker_status_give, (void *)&ret_cb);
+				  0, 0, ull_ticker_status_give,
+				  (void *)&ret_cb);
 		ret = ull_ticker_status_take(ret, &ret_cb);
 		if (ret) {
 			mark = ull_disable_mark(adv);
@@ -1268,7 +1269,7 @@ static inline u8_t disable(u16_t handle)
 #endif
 
 	ret = ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_THREAD,
-			  TICKER_ID_ADV_BASE + handle, 0,
+			  TICKER_ID_ADV_BASE + handle, 0, 0,
 			  ull_ticker_status_give, (void *)&ret_cb);
 
 	ret = ull_ticker_status_take(ret, &ret_cb);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1136,7 +1136,7 @@ static void ticker_stop_cb(u32_t ticks_at_expire, u32_t remainder, u16_t lazy,
 	LL_ASSERT(handle < BT_CTLR_ADV_MAX);
 
 	ret = ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_ULL_HIGH,
-			  TICKER_ID_ADV_BASE + handle,
+			  TICKER_ID_ADV_BASE + handle, 0,
 			  ticker_op_stop_cb, adv);
 	LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
 		  (ret == TICKER_STATUS_BUSY));
@@ -1255,7 +1255,7 @@ static inline u8_t disable(u16_t handle)
 	if (adv->lll.is_hdcd) {
 		ret = ticker_stop(TICKER_INSTANCE_ID_CTLR,
 				  TICKER_USER_ID_THREAD, TICKER_ID_ADV_STOP,
-				  ull_ticker_status_give, (void *)&ret_cb);
+				  0, ull_ticker_status_give, (void *)&ret_cb);
 		ret = ull_ticker_status_take(ret, &ret_cb);
 		if (ret) {
 			mark = ull_disable_mark(adv);
@@ -1268,7 +1268,7 @@ static inline u8_t disable(u16_t handle)
 #endif
 
 	ret = ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_THREAD,
-			  TICKER_ID_ADV_BASE + handle,
+			  TICKER_ID_ADV_BASE + handle, 0,
 			  ull_ticker_status_give, (void *)&ret_cb);
 
 	ret = ull_ticker_status_take(ret, &ret_cb);

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -830,8 +830,27 @@ int ull_conn_llcp(struct ll_conn *conn, u32_t ticks_at_expire, u16_t lazy)
 		}
 	}
 
-	/* check if procedure is requested */
+	/* Check if procedures with instant or encryption setup is requested or
+	 * active.
+	 */
 	if (((conn->llcp_req - conn->llcp_ack) & 0x03) == 0x02) {
+		/* Process parallel procedures that are active */
+		if (0) {
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
+		/* Check if DLE in progress */
+		} else if (conn->llcp_length.ack != conn->llcp_length.req) {
+			if ((conn->llcp_length.state ==
+			     LLCP_LENGTH_STATE_RESIZE) ||
+			    (conn->llcp_length.state ==
+			     LLCP_LENGTH_STATE_RESIZE_RSP)) {
+				/* handle DLU state machine */
+				event_len_prep(conn);
+			}
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
+		}
+
+		/* Process procedures with instants or encryption setup */
+		/* FIXME: Make LE Ping cacheable */
 		switch (conn->llcp_type) {
 		case LLCP_CONN_UPD:
 		{

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1656,7 +1656,7 @@ static inline void disable(u16_t handle)
 	LL_ASSERT(mark == conn);
 
 	ret = ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_THREAD,
-			  TICKER_ID_CONN_BASE + handle,
+			  TICKER_ID_CONN_BASE + handle, 0,
 			  ull_ticker_status_give, (void *)&ret_cb);
 
 	ret = ull_ticker_status_take(ret, &ret_cb);
@@ -1710,7 +1710,7 @@ static void conn_cleanup(struct ll_conn *conn, u8_t reason)
 	/* Stop Master or Slave role ticker */
 	ticker_status = ticker_stop(TICKER_INSTANCE_ID_CTLR,
 				    TICKER_USER_ID_ULL_HIGH,
-				    TICKER_ID_CONN_BASE + lll->handle,
+				    TICKER_ID_CONN_BASE + lll->handle, 0,
 				    ticker_op_stop_cb, (void *)lll);
 	LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
 		  (ticker_status == TICKER_STATUS_BUSY));
@@ -2369,7 +2369,7 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, u16_t lazy,
 		ticker_id_conn = TICKER_ID_CONN_BASE + ll_conn_handle_get(conn);
 		ticker_status =	ticker_stop(TICKER_INSTANCE_ID_CTLR,
 					    TICKER_USER_ID_ULL_HIGH,
-					    ticker_id_conn,
+					    ticker_id_conn, 0,
 					    ticker_stop_conn_op_cb,
 					    (void *)conn);
 		LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1656,7 +1656,7 @@ static inline void disable(u16_t handle)
 	LL_ASSERT(mark == conn);
 
 	ret = ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_THREAD,
-			  TICKER_ID_CONN_BASE + handle, 0,
+			  TICKER_ID_CONN_BASE + handle, 0, 0,
 			  ull_ticker_status_give, (void *)&ret_cb);
 
 	ret = ull_ticker_status_take(ret, &ret_cb);
@@ -1710,7 +1710,7 @@ static void conn_cleanup(struct ll_conn *conn, u8_t reason)
 	/* Stop Master or Slave role ticker */
 	ticker_status = ticker_stop(TICKER_INSTANCE_ID_CTLR,
 				    TICKER_USER_ID_ULL_HIGH,
-				    TICKER_ID_CONN_BASE + lll->handle, 0,
+				    TICKER_ID_CONN_BASE + lll->handle, 0, 0,
 				    ticker_op_stop_cb, (void *)lll);
 	LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
 		  (ticker_status == TICKER_STATUS_BUSY));
@@ -2369,7 +2369,7 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, u16_t lazy,
 		ticker_id_conn = TICKER_ID_CONN_BASE + ll_conn_handle_get(conn);
 		ticker_status =	ticker_stop(TICKER_INSTANCE_ID_CTLR,
 					    TICKER_USER_ID_ULL_HIGH,
-					    ticker_id_conn, 0,
+					    ticker_id_conn, 0, 0,
 					    ticker_stop_conn_op_cb,
 					    (void *)conn);
 		LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -576,7 +576,8 @@ void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	ticker_id_scan = TICKER_ID_SCAN_BASE + ull_scan_handle_get(scan);
 	ticker_status = ticker_stop(TICKER_INSTANCE_ID_CTLR,
 				    TICKER_USER_ID_ULL_HIGH,
-				    ticker_id_scan, ticker_op_stop_scan_cb,
+				    ticker_id_scan, 0,
+				    ticker_op_stop_scan_cb,
 				    (void *)(u32_t)ticker_id_scan);
 	ticker_op_stop_scan_cb(ticker_status, (void *)(u32_t)ticker_id_scan);
 
@@ -585,7 +586,7 @@ void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	 * expired, hence ignore failure.
 	 */
 	ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_ULL_HIGH,
-		    TICKER_ID_SCAN_STOP, NULL, NULL);
+		    TICKER_ID_SCAN_STOP, 0, NULL, NULL);
 
 	/* Start master */
 	ticker_id_conn = TICKER_ID_CONN_BASE + ll_conn_handle_get(conn);

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -576,7 +576,7 @@ void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	ticker_id_scan = TICKER_ID_SCAN_BASE + ull_scan_handle_get(scan);
 	ticker_status = ticker_stop(TICKER_INSTANCE_ID_CTLR,
 				    TICKER_USER_ID_ULL_HIGH,
-				    ticker_id_scan, 0,
+				    ticker_id_scan, 0, 0,
 				    ticker_op_stop_scan_cb,
 				    (void *)(u32_t)ticker_id_scan);
 	ticker_op_stop_scan_cb(ticker_status, (void *)(u32_t)ticker_id_scan);
@@ -586,7 +586,7 @@ void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	 * expired, hence ignore failure.
 	 */
 	ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_ULL_HIGH,
-		    TICKER_ID_SCAN_STOP, 0, NULL, NULL);
+		    TICKER_ID_SCAN_STOP, 0, 0, NULL, NULL);
 
 	/* Start master */
 	ticker_id_conn = TICKER_ID_CONN_BASE + ll_conn_handle_get(conn);

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -275,7 +275,7 @@ u8_t ull_scan_disable(u16_t handle, struct ll_scan_set *scan)
 	LL_ASSERT(mark == scan);
 
 	ret = ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_THREAD,
-			  TICKER_ID_SCAN_BASE + handle,
+			  TICKER_ID_SCAN_BASE + handle, 0,
 			  ull_ticker_status_give, (void *)&ret_cb);
 
 	ret = ull_ticker_status_take(ret, &ret_cb);

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -275,7 +275,7 @@ u8_t ull_scan_disable(u16_t handle, struct ll_scan_set *scan)
 	LL_ASSERT(mark == scan);
 
 	ret = ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_THREAD,
-			  TICKER_ID_SCAN_BASE + handle, 0,
+			  TICKER_ID_SCAN_BASE + handle, 0, 0,
 			  ull_ticker_status_give, (void *)&ret_cb);
 
 	ret = ull_ticker_status_take(ret, &ret_cb);

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -252,7 +252,8 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	ticker_id_adv = TICKER_ID_ADV_BASE + ull_adv_handle_get(adv);
 	ticker_status = ticker_stop(TICKER_INSTANCE_ID_CTLR,
 				    TICKER_USER_ID_ULL_HIGH,
-				    ticker_id_adv, ticker_op_stop_adv_cb, adv);
+				    ticker_id_adv, 0,
+				    ticker_op_stop_adv_cb, adv);
 	ticker_op_stop_adv_cb(ticker_status, adv);
 
 	/* Stop Direct Adv Stop */
@@ -262,7 +263,7 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 		 * expired, hence ignore failure.
 		 */
 		ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_ULL_HIGH,
-			    TICKER_ID_ADV_STOP, NULL, NULL);
+			    TICKER_ID_ADV_STOP, 0, NULL, NULL);
 	}
 
 	/* Start Slave */

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -252,7 +252,7 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	ticker_id_adv = TICKER_ID_ADV_BASE + ull_adv_handle_get(adv);
 	ticker_status = ticker_stop(TICKER_INSTANCE_ID_CTLR,
 				    TICKER_USER_ID_ULL_HIGH,
-				    ticker_id_adv, 0,
+				    ticker_id_adv, 0, 0,
 				    ticker_op_stop_adv_cb, adv);
 	ticker_op_stop_adv_cb(ticker_status, adv);
 
@@ -263,7 +263,7 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 		 * expired, hence ignore failure.
 		 */
 		ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_ULL_HIGH,
-			    TICKER_ID_ADV_STOP, 0, NULL, NULL);
+			    TICKER_ID_ADV_STOP, 0, 0, NULL, NULL);
 	}
 
 	/* Start Slave */

--- a/subsys/bluetooth/controller/ticker/ticker.h
+++ b/subsys/bluetooth/controller/ticker/ticker.h
@@ -133,7 +133,8 @@ u32_t ticker_update(u8_t instance_index, u8_t user_id, u8_t ticker_id,
 		    u32_t ticks_slot_plus, u32_t ticks_slot_minus, u16_t lazy,
 		    u8_t force, ticker_op_func fp_op_func, void *op_context);
 u32_t ticker_stop(u8_t instance_index, u8_t user_id, u8_t ticker_id,
-		  ticker_op_func fp_op_func, void *op_context);
+		  u32_t ticks_at_stop, ticker_op_func fp_op_func,
+		  void *op_context);
 u32_t ticker_next_slot_get(u8_t instance_index, u8_t user_id,
 			   u8_t *ticker_id_head, u32_t *ticks_current,
 			   u32_t *ticks_to_expire,

--- a/subsys/bluetooth/controller/ticker/ticker.h
+++ b/subsys/bluetooth/controller/ticker/ticker.h
@@ -34,6 +34,16 @@
  * @}
  */
 
+/** \defgroup Timer Stop API flags parameter values.
+ *
+ * @{
+ */
+#define TICKER_STOP_FLAG_CURRENT         0
+#define TICKER_STOP_FLAG_ABSOLUTE        BIT(0)
+/**
+ * @}
+ */
+
 /** \brief Timer node type size.
  */
 #if defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
@@ -133,7 +143,7 @@ u32_t ticker_update(u8_t instance_index, u8_t user_id, u8_t ticker_id,
 		    u32_t ticks_slot_plus, u32_t ticks_slot_minus, u16_t lazy,
 		    u8_t force, ticker_op_func fp_op_func, void *op_context);
 u32_t ticker_stop(u8_t instance_index, u8_t user_id, u8_t ticker_id,
-		  u32_t ticks_at_stop, ticker_op_func fp_op_func,
+		  u32_t ticks_at_stop, u8_t flags, ticker_op_func fp_op_func,
 		  void *op_context);
 u32_t ticker_next_slot_get(u8_t instance_index, u8_t user_id,
 			   u8_t *ticker_id_head, u32_t *ticks_current,


### PR DESCRIPTION
Update ticker_stop interface to take absolute tick, so as
to correctly calculate the end of previous ticks_slot.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>