### PR TITLE
west.yml: Use SAME70 DFP version 2.4.166

### DIFF
--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -2098,21 +2098,16 @@ static int ptp_clock_sam_gmac_adjust(struct device *dev, int increment)
 	struct ptp_context *ptp_context = dev->driver_data;
 	const struct eth_sam_dev_cfg *const cfg = DEV_CFG(ptp_context->eth_dev);
 	Gmac *gmac = cfg->regs;
-	GMAC_TA_Type gmac_ta;
 
 	if ((increment <= -NSEC_PER_SEC) || (increment >= NSEC_PER_SEC)) {
 		return -EINVAL;
 	}
 
 	if (increment < 0) {
-		gmac_ta.bit.ADJ = 1;
-		gmac_ta.bit.ITDT = -increment;
+		gmac->GMAC_TA = GMAC_TA_ADJ | GMAC_TA_ITDT(-increment);
 	} else {
-		gmac_ta.bit.ADJ = 0;
-		gmac_ta.bit.ITDT = increment;
+		gmac->GMAC_TA = GMAC_TA_ITDT(increment);
 	}
-
-	gmac->GMAC_TA = gmac_ta.reg;
 
 	return 0;
 }

--- a/west.yml
+++ b/west.yml
@@ -26,7 +26,7 @@ manifest:
   # Please add items below based on alphabetical order
   projects:
     - name: hal_atmel
-      revision: 5a44c9d54dffd685fb6664a646922cfe41c5cf8e
+      revision: 917bfefa5188a473ff49087f1fa207cbb42bf592
       path: modules/hal/atmel
     - name: canopennode
       path: modules/lib/canopennode


### PR DESCRIPTION
This commit updates the hal_atmel entry in the west.yml to pull in the
SAME70 DFP version 2.4.166.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

NOTE: Do not merge until zephyrproject-rtos/hal_atmel#8 is merged and the module commit SHA in this PR is updated.