### PR TITLE
samples: subsys: nvs: unchecked return values CID#203537

### DIFF
--- a/samples/subsys/nvs/src/main.c
+++ b/samples/subsys/nvs/src/main.c
@@ -98,7 +98,7 @@ void main(void)
 		strcpy(buf, "192.168.1.1");
 		printk("No address found, adding %s at id %d\n", buf,
 		       ADDRESS_ID);
-		nvs_write(&fs, ADDRESS_ID, &buf, strlen(buf)+1);
+		(void)nvs_write(&fs, ADDRESS_ID, &buf, strlen(buf)+1);
 	}
 	/* KEY_ID is used to store a key, lets see if we can read it from flash
 	 */
@@ -119,7 +119,7 @@ void main(void)
 		key[5] = 0xFA;
 		key[6] = 0xF9;
 		key[7] = 0xF8;
-		nvs_write(&fs, KEY_ID, &key, sizeof(key));
+		(void)nvs_write(&fs, KEY_ID, &key, sizeof(key));
 	}
 	/* RBT_CNT_ID is used to store the reboot counter, lets see
 	 * if we can read it from flash
@@ -131,7 +131,7 @@ void main(void)
 	} else   {/* item was not found, add it */
 		printk("No Reboot counter found, adding it at id %d\n",
 		       RBT_CNT_ID);
-		nvs_write(&fs, RBT_CNT_ID, &reboot_counter,
+		(void)nvs_write(&fs, RBT_CNT_ID, &reboot_counter,
 			  sizeof(reboot_counter));
 	}
 	/* STRING_ID is used to store data that will be deleted,lets see
@@ -145,7 +145,7 @@ void main(void)
 			STRING_ID, buf);
 		/* remove the item if reboot_counter = 10 */
 		if (reboot_counter == 10U) {
-			nvs_delete(&fs, STRING_ID);
+			(void)nvs_delete(&fs, STRING_ID);
 		}
 	} else   {
 		/* entry was not found, add it if reboot_counter = 0*/
@@ -153,7 +153,7 @@ void main(void)
 			printk("Id: %d not found, adding it\n",
 			STRING_ID);
 			strcpy(buf, "DATA");
-			nvs_write(&fs, STRING_ID, &buf, strlen(buf) + 1);
+			(void)nvs_write(&fs, STRING_ID, &buf, strlen(buf) + 1);
 		}
 	}
 
@@ -176,7 +176,8 @@ void main(void)
 			for (int n = 0; n < sizeof(longarray); n++) {
 				longarray[n] = n;
 			}
-			nvs_write(&fs, LONG_ID, &longarray, sizeof(longarray));
+			(void)nvs_write(
+				&fs, LONG_ID, &longarray, sizeof(longarray));
 		}
 	}
 
@@ -215,7 +216,7 @@ void main(void)
 			if (cnt == 0) {
 				printk("\n");
 				reboot_counter++;
-				nvs_write(
+				(void)nvs_write(
 					&fs, RBT_CNT_ID, &reboot_counter,
 					sizeof(reboot_counter));
 				if (reboot_counter == MAX_REBOOT) {
@@ -227,7 +228,7 @@ void main(void)
 			printk("Reboot counter reached max value.\n");
 			printk("Reset to 0 and exit test.\n");
 			reboot_counter = 0U;
-			nvs_write(&fs, RBT_CNT_ID, &reboot_counter,
+			(void)nvs_write(&fs, RBT_CNT_ID, &reboot_counter,
 			  sizeof(reboot_counter));
 			break;
 		}


### PR DESCRIPTION
The sample contained calls that were not using the return
value, which was detected by Coverity Scan as an issue. This
commit fixes it by changing to (void).

Fixes #18378
CID#203537

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>