### PR TITLE
tests/subsys/fs/fat: Incorrect mount path has been tested

### DIFF
--- a/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_fs.c
+++ b/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_fs.c
@@ -38,5 +38,5 @@ void test_fat_fs(void)
 	zassert_true(test_statvfs(FATFS_MNTP) == TC_PASS, NULL);
 
 	TC_PRINT("\nTesting statvfs operation on %s\n", FATFS_MNTP1);
-	zassert_true(test_statvfs(FATFS_MNTP) == TC_PASS, NULL);
+	zassert_true(test_statvfs(FATFS_MNTP1) == TC_PASS, NULL);
 }

--- a/tests/subsys/fs/fat_fs_dual_drive/testcase.yaml
+++ b/tests/subsys/fs/fat_fs_dual_drive/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   filesystem.fat.dual_drive:
-    platform_whitelist: qemu_x86
+    platform_whitelist: qemu_x86 native_posix
     tags: filesystem


### PR DESCRIPTION
While testing statvfs operation, same mount path has been tested twice,
instead of two different mount points as intended.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>