### PR TITLE
Bluetooth: tester: Add missing log_strdup

### DIFF
--- a/tests/bluetooth/tester/src/gatt.c
+++ b/tests/bluetooth/tester/src/gatt.c
@@ -1858,7 +1858,7 @@ static void get_attrs(u8_t *data, u16_t len)
 
 		bt_uuid_to_str(&uuid.uuid, uuid_str, sizeof(uuid_str));
 		LOG_DBG("start 0x%04x end 0x%04x, uuid %s", start_handle,
-			end_handle, uuid_str);
+			end_handle, log_strdup(uuid_str));
 
 		foreach.uuid = &uuid.uuid;
 	} else {

--- a/tests/bluetooth/tester/src/mesh.c
+++ b/tests/bluetooth/tester/src/mesh.c
@@ -314,7 +314,7 @@ static int output_string(const char *str)
 	struct mesh_out_string_action_ev *ev;
 	struct net_buf_simple *buf = NET_BUF_SIMPLE(BTP_DATA_MAX_SIZE);
 
-	LOG_DBG("str %s", str);
+	LOG_DBG("str %s", log_strdup(str));
 
 	net_buf_simple_init(buf, 0);
 


### PR DESCRIPTION
Since we enable CONFIG_ASSERT in the tester app, the logging subsystem
will assert if it detects a missing log_strdup. Add the two missing ones
that I could find to properly log transient strings.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>