### PR TITLE
soc: mec1501: wait for UART FIFO clear before deep sleep

### DIFF
--- a/soc/arm/microchip_mec/mec1501/device_power.c
+++ b/soc/arm/microchip_mec/mec1501/device_power.c
@@ -146,10 +146,22 @@ static u8_t uart_activate[3];
 static void deep_sleep_save_uarts(void)
 {
 	uart_activate[0] = UART0_REGS->ACTV;
+	if (uart_activate[0]) {
+		while ((UART0_REGS->LSR & MCHP_UART_LSR_TEMT) == 0) {
+		};
+	}
 	UART0_REGS->ACTV = 0;
 	uart_activate[1] = UART1_REGS->ACTV;
+	if (uart_activate[1]) {
+		while ((UART1_REGS->LSR & MCHP_UART_LSR_TEMT) == 0) {
+		};
+	}
 	UART1_REGS->ACTV = 0;
 	uart_activate[2] = UART2_REGS->ACTV;
+	if (uart_activate[2]) {
+		while ((UART2_REGS->LSR & MCHP_UART_LSR_TEMT) == 0) {
+		};
+	}
 	UART2_REGS->ACTV = 0;
 }
 


### PR DESCRIPTION
It is observed that after each test, weird characters appear on
console. This problem goes away if deep sleep is disabled.
The theory is that the CPU runs to deep sleep (_sys_suspend())
faster than UART can shift all the bits out. If we spin wait
for UART FIFO to clear, this is no longer an issue. This is
circumstantial evidence to the theory. So for now, put in
a workaround to spin wait for UART FIFO to clear before
going into deep sleep.

Relates to #22885

Signed-off-by: Daniel Leung <daniel.leung@intel.com>