### PR TITLE
kernel: Stack pointer random depends on MULTITHREADING

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -648,6 +648,7 @@ config EXECUTE_XOR_WRITE
 config STACK_POINTER_RANDOM
 	int "Initial stack pointer randomization bounds"
 	depends on !STACK_GROWS_UP
+	depends on MULTITHREADING
 	depends on TEST_RANDOM_GENERATOR || ENTROPY_HAS_DRIVER
 	default 0
 	help


### PR DESCRIPTION
Don't pretend we have stack randomization without multithreading.
When multithreading is disabled the "main" thread never starts. Zephyr
will run on the stack used for the z_cstart(), which on most
architectures is the interrupt stack.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>