### PR TITLE
lib: posix: Fix undefined reference

### DIFF
--- a/lib/posix/pthread_common.c
+++ b/lib/posix/pthread_common.c
@@ -9,6 +9,7 @@
 #include <wait_q.h>
 #include <posix/time.h>
 
+#ifdef CONFIG_POSIX_CLOCK
 s64_t timespec_to_timeoutms(const struct timespec *abstime)
 {
 	s64_t milli_secs, secs, nsecs;
@@ -30,3 +31,4 @@ s64_t timespec_to_timeoutms(const struct timespec *abstime)
 
 	return milli_secs;
 }
+#endif	/* CONFIG_POSIX_CLOCK */


### PR DESCRIPTION
timespec_to_timeoutms calls clock_gettime that requires
CONFIG_POSIX_CLOCK. ifdef this function to avoid undefined reference.

Fixes #20137

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>