### PR TITLE
lib: os: onoff: Add cancellation before started feature

### DIFF
--- a/include/sys/onoff.h
+++ b/include/sys/onoff.h
@@ -123,6 +123,16 @@ struct onoff_service {
 	/* Function to invoke to transition the service to off. */
 	onoff_service_transition_fn stop;
 
+	/* Function to invoke to transition the service to on at any point
+	 * (stopped or stopping).
+	 */
+	onoff_service_transition_fn uncond_start;
+
+	/* Function to invoke to transition the service to off at any point
+	 * (started or starting).
+	 */
+	onoff_service_transition_fn uncond_stop;
+
 	/* Function to force the service state to reset, where
 	 * supported.
 	 */
@@ -142,11 +152,14 @@ struct onoff_service {
 };
 
 /** @internal */
-#define ONOFF_SERVICE_INITIALIZER(_start, _stop, _reset, _flags) { \
-		.start = _start,				   \
-		.stop = _stop,					   \
-		.reset = _reset,				   \
-		.flags = _flags,				   \
+#define ONOFF_SERVICE_INITIALIZER(_start, _stop, _reset,		   \
+				  _uncond_start, _uncond_stop, _flags){	   \
+		.start = _start,					   \
+		.stop = _stop,						   \
+		.reset = _reset,					   \
+		.uncond_start = _uncond_start,				   \
+		.uncond_stop = _uncond_stop,				   \
+		.flags = _flags,					   \
 }
 
 /**
@@ -174,6 +187,14 @@ struct onoff_service {
  * with an error notification should support the reset operation.)
  * Include @ref ONOFF_SERVICE_RESET_SLEEPS as appropriate in flags.
  *
+ * @param uncond_start the function used to unconditionally start the service
+ * (also capable of interrupting transition to off state). Pass null if the
+ * service does not support cancellation in progress.
+ *
+ * @param uncond_stop the function used to unconditionally stop the service
+ * (also capable of interrupting transition to off state). Pass null if the
+ * service does not support start cancellation in progress.
+ *
  * @param flags any or all of the flags mentioned above,
  * e.g. @ref ONOFF_SERVICE_START_SLEEPS.  Use of other flags produces an
  * error.
@@ -185,6 +206,8 @@ int onoff_service_init(struct onoff_service *srv,
 		       onoff_service_transition_fn start,
 		       onoff_service_transition_fn stop,
 		       onoff_service_transition_fn reset,
+		       onoff_service_transition_fn uncond_start,
+		       onoff_service_transition_fn uncond_stop,
 		       u32_t flags);
 
 /** @internal

--- a/tests/lib/onoff/src/main.c
+++ b/tests/lib/onoff/src/main.c
@@ -170,23 +170,23 @@ static void test_service_init_validation(void)
 
 	clear_transit();
 
-	rc = onoff_service_init(NULL, NULL, NULL, NULL, 0);
+	rc = onoff_service_init(NULL, NULL, NULL, NULL, NULL, NULL, 0);
 	zassert_equal(rc, -EINVAL,
 		      "init null srv %d", rc);
 
-	rc = onoff_service_init(&srv, NULL, NULL, NULL, 0);
+	rc = onoff_service_init(&srv, NULL, NULL, NULL, NULL, NULL, 0);
 	zassert_equal(rc, -EINVAL,
 		      "init null transit %d", rc);
 
-	rc = onoff_service_init(&srv, start, NULL, NULL, 0);
+	rc = onoff_service_init(&srv, start, NULL, NULL, NULL, NULL, 0);
 	zassert_equal(rc, -EINVAL,
 		      "init null stop %d", rc);
 
-	rc = onoff_service_init(&srv, NULL, stop, NULL, 0);
+	rc = onoff_service_init(&srv, NULL, stop, NULL, NULL, NULL, 0);
 	zassert_equal(rc, -EINVAL,
 		      "init null start %d", rc);
 
-	rc = onoff_service_init(&srv, start, stop, NULL,
+	rc = onoff_service_init(&srv, start, stop, NULL, NULL, NULL,
 				ONOFF_SERVICE_INTERNAL_BASE);
 	zassert_equal(rc, -EINVAL,
 		      "init bad flags %d", rc);
@@ -197,7 +197,7 @@ static void test_service_init_validation(void)
 	zassert_false(sys_slist_is_empty(&srv.clients),
 		      "slist empty");
 
-	rc = onoff_service_init(&srv, start, stop, reset, flags);
+	rc = onoff_service_init(&srv, start, stop, reset, NULL, NULL, flags);
 	zassert_equal(rc, 0,
 		      "init good %d", rc);
 	zassert_equal(srv.start, start,
@@ -263,7 +263,7 @@ static void test_validate_args(void)
 	 * release, and reset; test it through the request API.
 	 */
 
-	rc = onoff_service_init(&srv, start, stop, NULL, 0);
+	rc = onoff_service_init(&srv, start, stop, NULL, NULL, NULL, 0);
 	zassert_equal(rc, 0,
 		      "service init");
 
@@ -337,14 +337,14 @@ static void test_reset(void)
 
 	clear_transit();
 
-	rc = onoff_service_init(&srv, start, stop, NULL, 0);
+	rc = onoff_service_init(&srv, start, stop, NULL, NULL, NULL, 0);
 	zassert_equal(rc, 0,
 		      "service init");
 	rc = onoff_service_reset(&srv, &cli);
 	zassert_equal(rc, -ENOTSUP,
 		      "reset: %d", rc);
 
-	rc = onoff_service_init(&srv, start, stop, reset, 0);
+	rc = onoff_service_init(&srv, start, stop, reset, NULL, NULL, 0);
 	zassert_equal(rc, 0,
 		      "service init");
 
@@ -423,7 +423,7 @@ static void test_reset(void)
 	zassert_false(onoff_service_has_error(&srv),
 		      "has error");
 
-	rc = onoff_service_init(&srv, start, stop, reset,
+	rc = onoff_service_init(&srv, start, stop, reset, NULL, NULL,
 				ONOFF_SERVICE_RESET_SLEEPS);
 	zassert_equal(rc, 0,
 		      "service init");
@@ -463,7 +463,7 @@ static void test_request(void)
 
 	clear_transit();
 
-	rc = onoff_service_init(&srv, start, stop, reset, 0);
+	rc = onoff_service_init(&srv, start, stop, reset, NULL, NULL, 0);
 	zassert_equal(rc, 0,
 		      "service init");
 
@@ -546,7 +546,7 @@ static void test_request(void)
 		      "has error");
 
 	/* Diagnose a no-wait delayed start */
-	rc = onoff_service_init(&srv, start, stop, reset,
+	rc = onoff_service_init(&srv, start, stop, reset, NULL, NULL,
 				ONOFF_SERVICE_START_SLEEPS);
 	zassert_equal(rc, 0,
 		      "service init");
@@ -581,7 +581,7 @@ static void test_sync(void)
 
 	clear_transit();
 
-	rc = onoff_service_init(&srv, start, stop, reset, 0);
+	rc = onoff_service_init(&srv, start, stop, reset, NULL, NULL,0);
 	zassert_equal(rc, 0,
 		      "service init");
 
@@ -635,7 +635,7 @@ static void test_async(void)
 	stop_state.async = true;
 	stop_state.retval = 17;
 
-	rc = onoff_service_init(&srv, start, stop, reset,
+	rc = onoff_service_init(&srv, start, stop, reset, NULL, NULL,
 				ONOFF_SERVICE_START_SLEEPS
 				| ONOFF_SERVICE_STOP_SLEEPS);
 	zassert_equal(rc, 0,
@@ -826,7 +826,7 @@ static void test_half_sync(void)
 	stop_state.async = true;
 	stop_state.retval = 17;
 
-	rc = onoff_service_init(&srv, start, stop, NULL,
+	rc = onoff_service_init(&srv, start, stop, NULL, NULL, NULL,
 				ONOFF_SERVICE_STOP_SLEEPS);
 	zassert_equal(rc, 0,
 		      "service init");
@@ -883,7 +883,7 @@ static void test_cancel_request_waits(void)
 	stop_state.async = true;
 	stop_state.retval = 31;
 
-	rc = onoff_service_init(&srv, start, stop, NULL,
+	rc = onoff_service_init(&srv, start, stop, NULL, NULL, NULL,
 				ONOFF_SERVICE_START_SLEEPS
 				| ONOFF_SERVICE_STOP_SLEEPS);
 	zassert_equal(rc, 0,
@@ -978,7 +978,7 @@ static void test_cancel_request_ok(void)
 	start_state.retval = 14;
 	stop_state.retval = 31;
 
-	rc = onoff_service_init(&srv, start, stop, NULL,
+	rc = onoff_service_init(&srv, start, stop, NULL, NULL, NULL,
 				ONOFF_SERVICE_START_SLEEPS);
 	zassert_equal(rc, 0,
 		      "service init");
@@ -1034,7 +1034,7 @@ static void test_blocked_restart(void)
 	stop_state.async = true;
 	stop_state.retval = 31;
 
-	rc = onoff_service_init(&srv, start, stop, NULL,
+	rc = onoff_service_init(&srv, start, stop, NULL, NULL, NULL,
 				ONOFF_SERVICE_START_SLEEPS
 				| ONOFF_SERVICE_STOP_SLEEPS);
 	zassert_equal(rc, 0,
@@ -1109,7 +1109,7 @@ static void test_cancel_release(void)
 	stop_state.async = true;
 	stop_state.retval = 94;
 
-	rc = onoff_service_init(&srv, start, stop, NULL,
+	rc = onoff_service_init(&srv, start, stop, NULL, NULL, NULL,
 				ONOFF_SERVICE_STOP_SLEEPS);
 	zassert_equal(rc, 0,
 		      "service init");


### PR DESCRIPTION
Extended onoff service to be capable of stopping service during starting.

Fixes #22974.