### PR TITLE
lib/timeutil: add missing header required for s64_t

### DIFF
--- a/include/sys/timeutil.h
+++ b/include/sys/timeutil.h
@@ -23,6 +23,8 @@
 
 #include <time.h>
 
+#include <zephyr/types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
`sys/timeutil.h` could not be used without including first `<zephyr/types.h>` because `s64_t` type definition was missing.