### PR TITLE
net: openthread: Implement energy scan 

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -145,7 +145,8 @@ drop:
 static enum ieee802154_hw_caps nrf5_get_capabilities(struct device *dev)
 {
 	return IEEE802154_HW_FCS | IEEE802154_HW_2_4_GHZ |
-	       IEEE802154_HW_TX_RX_ACK | IEEE802154_HW_FILTER;
+	       IEEE802154_HW_TX_RX_ACK | IEEE802154_HW_FILTER |
+	       IEEE802154_HW_ENERGY_SCAN;
 }
 
 
@@ -181,6 +182,28 @@ static int nrf5_set_channel(struct device *dev, u16_t channel)
 	nrf_802154_channel_set(channel);
 
 	return 0;
+}
+
+static int nrf5_energy_scan_start(struct device *dev,
+				  u16_t duration,
+				  energy_scan_done_cb_t done_cb)
+{
+	int err = 0;
+
+	ARG_UNUSED(dev);
+
+	if (nrf5_data.energy_scan_done == NULL) {
+		nrf5_data.energy_scan_done = done_cb;
+
+		if (nrf_802154_energy_detection(duration * 1000) == false) {
+			nrf5_data.energy_scan_done = NULL;
+			err = -EPERM;
+		}
+	} else {
+		err = -EALREADY;
+	}
+
+	return err;
 }
 
 static int nrf5_set_pan_id(struct device *dev, u16_t pan_id)
@@ -541,6 +564,28 @@ void nrf_802154_cca_failed(nrf_802154_cca_error_t error)
 	k_sem_give(&nrf5_data.cca_wait);
 }
 
+void nrf_802154_energy_detected(uint8_t result)
+{
+	if (nrf5_data.energy_scan_done != NULL) {
+		s16_t dbm;
+		energy_scan_done_cb_t callback = nrf5_data.energy_scan_done;
+
+		nrf5_data.energy_scan_done = NULL;
+		dbm = nrf_802154_dbm_from_energy_level_calculate(result);
+		callback(net_if_get_device(nrf5_data.iface), dbm);
+	}
+}
+
+void nrf_802154_energy_detection_failed(nrf_802154_ed_error_t error)
+{
+	if (nrf5_data.energy_scan_done != NULL) {
+		energy_scan_done_cb_t callback = nrf5_data.energy_scan_done;
+
+		nrf5_data.energy_scan_done = NULL;
+		callback(net_if_get_device(nrf5_data.iface), SHRT_MAX);
+	}
+}
+
 static const struct nrf5_802154_config nrf5_radio_cfg = {
 	.irq_config_func = nrf5_irq_config,
 };
@@ -556,6 +601,9 @@ static struct ieee802154_radio_api nrf5_radio_api = {
 	.start = nrf5_start,
 	.stop = nrf5_stop,
 	.tx = nrf5_tx,
+#ifdef CONFIG_NET_L2_OPENTHREAD
+	.ed_scan = nrf5_energy_scan_start,
+#endif /* CONFIG_NET_L2_OPENTHREAD */
 	.configure = nrf5_configure,
 };
 

--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -65,6 +65,11 @@ struct nrf5_802154_data {
 	 * ACK was requested/received.
 	 */
 	struct nrf5_802154_rx_frame ack_frame;
+
+	/* Callback handler of the currently ongoing energy scan.
+	 * It shall be NULL if energy scan is not in progress.
+	 */
+	energy_scan_done_cb_t energy_scan_done;
 };
 
 #endif /* ZEPHYR_DRIVERS_IEEE802154_IEEE802154_NRF5_H_ */

--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -26,14 +26,17 @@ extern "C" {
  * @{
  */
 
+typedef void (*energy_scan_done_cb_t)(struct device *dev, s16_t max_ed);
+
 enum ieee802154_hw_caps {
-	IEEE802154_HW_FCS	= BIT(0), /* Frame Check-Sum supported */
-	IEEE802154_HW_PROMISC	= BIT(1), /* Promiscuous mode supported */
-	IEEE802154_HW_FILTER	= BIT(2), /* Filters PAN ID, long/short addr */
-	IEEE802154_HW_CSMA	= BIT(3), /* CSMA-CA supported */
-	IEEE802154_HW_2_4_GHZ	= BIT(4), /* 2.4Ghz radio supported */
-	IEEE802154_HW_TX_RX_ACK = BIT(5), /* Handles ACK request on TX */
-	IEEE802154_HW_SUB_GHZ	= BIT(6), /* Sub-GHz radio supported */
+	IEEE802154_HW_FCS	  = BIT(0), /* Frame Check-Sum supported */
+	IEEE802154_HW_PROMISC	  = BIT(1), /* Promiscuous mode supported */
+	IEEE802154_HW_FILTER	  = BIT(2), /* Filter PAN ID, long/short addr */
+	IEEE802154_HW_CSMA	  = BIT(3), /* CSMA-CA supported */
+	IEEE802154_HW_2_4_GHZ	  = BIT(4), /* 2.4Ghz radio supported */
+	IEEE802154_HW_TX_RX_ACK	  = BIT(5), /* Handles ACK request on TX */
+	IEEE802154_HW_SUB_GHZ	  = BIT(6), /* Sub-GHz radio supported */
+	IEEE802154_HW_ENERGY_SCAN = BIT(7)  /* Energy scan supported */
 };
 
 enum ieee802154_filter_type {
@@ -149,8 +152,7 @@ struct ieee802154_radio_api {
 	 */
 	int (*ed_scan)(struct device *dev,
 		       u16_t duration,
-		       void (*done_cb)(struct device *dev,
-				       s16_t max_ed));
+		       energy_scan_done_cb_t done_cb);
 #endif /* CONFIG_NET_L2_OPENTHREAD */
 };
 

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -11,11 +11,10 @@
  *
  */
 
-#define LOG_LEVEL CONFIG_OPENTHREAD_LOG_LEVEL
 #define LOG_MODULE_NAME net_otPlat_radio
 
 #include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_OPENTHREAD_L2_LOG_LEVEL);
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -43,6 +42,15 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define FRAME_TYPE_MASK 0x07
 #define FRAME_TYPE_ACK 0x02
 
+
+enum pending_events {
+	PENDING_EVENT_DETECT_ENERGY, /* Requested to start Energy Detection
+				      * procedure.
+				      */
+	PENDING_EVENT_DETECT_ENERGY_DONE, /* Energy Detection finished. */
+	PENDING_EVENT_COUNT /* keep last */
+};
+
 static otRadioState sState = OT_RADIO_STATE_DISABLED;
 
 static otRadioFrame sTransmitFrame;
@@ -57,6 +65,42 @@ static struct ieee802154_radio_api *radio_api;
 
 static s8_t tx_power;
 static u16_t channel;
+
+static u16_t energy_detection_time;
+static u8_t  energy_detection_channel;
+static s16_t energy_detected_value;
+
+ATOMIC_DEFINE(pending_events, PENDING_EVENT_COUNT);
+
+
+static inline bool is_pending_event_set(enum pending_events event)
+{
+	return atomic_test_bit(pending_events, event);
+}
+
+static void set_pending_event(enum pending_events event)
+{
+	atomic_set_bit(pending_events, event);
+	otSysEventSignalPending();
+}
+
+static void reset_pending_event(enum pending_events event)
+{
+	atomic_clear_bit(pending_events, event);
+}
+
+static inline void clear_pending_events(void)
+{
+	atomic_clear(pending_events);
+}
+
+void energy_detected(struct device *dev, s16_t max_ed)
+{
+	if (dev == radio_dev) {
+		energy_detected_value = max_ed;
+		set_pending_event(PENDING_EVENT_DETECT_ENERGY_DONE);
+	}
+}
 
 enum net_verdict ieee802154_radio_handle_ack(struct net_if *iface,
 					     struct net_pkt *pkt)
@@ -123,6 +167,7 @@ void platformRadioInit(void)
 
 void platformRadioProcess(otInstance *aInstance)
 {
+	bool event_pending = false;
 	if (sState == OT_RADIO_STATE_TRANSMIT) {
 		otError result = OT_ERROR_NONE;
 
@@ -183,6 +228,27 @@ void platformRadioProcess(otInstance *aInstance)
 						  NULL, result);
 			}
 		}
+	}
+
+	if (is_pending_event_set(PENDING_EVENT_DETECT_ENERGY)) {
+		radio_api->set_channel(radio_dev, energy_detection_channel);
+
+		if (!radio_api->ed_scan(radio_dev, energy_detection_time,
+					energy_detected)) {
+			reset_pending_event(PENDING_EVENT_DETECT_ENERGY);
+		} else {
+			event_pending = true;
+		}
+	}
+
+	if (is_pending_event_set(PENDING_EVENT_DETECT_ENERGY_DONE)) {
+		otPlatRadioEnergyScanDone(aInstance,
+					  (s8_t)energy_detected_value);
+		reset_pending_event(PENDING_EVENT_DETECT_ENERGY_DONE);
+	}
+
+	if (event_pending) {
+		otSysEventSignalPending();
 	}
 }
 
@@ -309,9 +375,20 @@ int8_t otPlatRadioGetRssi(otInstance *aInstance)
 
 otRadioCaps otPlatRadioGetCaps(otInstance *aInstance)
 {
-	ARG_UNUSED(aInstance);
+	otRadioCaps caps = OT_RADIO_CAPS_NONE;
 
-	return OT_RADIO_CAPS_NONE;
+	enum ieee802154_hw_caps radio_caps;
+	ARG_UNUSED(aInstance);
+	__ASSERT(radio_api,
+	    "platformRadioInit needs to be called prior to otPlatRadioGetCaps");
+
+	radio_caps = radio_api->get_capabilities(radio_dev);
+
+	if (radio_caps & IEEE802154_HW_ENERGY_SCAN) {
+		caps |= OT_RADIO_CAPS_ENERGY_SCAN;
+	}
+
+	return caps;
 }
 
 bool otPlatRadioGetPromiscuous(otInstance *aInstance)
@@ -337,11 +414,26 @@ void otPlatRadioSetPromiscuous(otInstance *aInstance, bool aEnable)
 otError otPlatRadioEnergyScan(otInstance *aInstance, u8_t aScanChannel,
 			      u16_t aScanDuration)
 {
-	ARG_UNUSED(aInstance);
-	ARG_UNUSED(aScanChannel);
-	ARG_UNUSED(aScanDuration);
+	energy_detection_time    = aScanDuration;
+	energy_detection_channel = aScanChannel;
 
-	return OT_ERROR_NOT_IMPLEMENTED;
+	clear_pending_events();
+
+	radio_api->set_channel(radio_dev, aScanChannel);
+
+	if (radio_api->ed_scan(radio_dev, energy_detection_time,
+				    energy_detected) != 0) {
+		/*
+		 * OpenThread API does not accept failure of this function,
+		 * it can return 'No Error' or 'Not Implemented' error only.
+		 * If ed_scan start failed event is set to schedule the scan at
+		 * later time.
+		 */
+		LOG_ERR("Failed do start energy scan, scheduling for later");
+		set_pending_event(PENDING_EVENT_DETECT_ENERGY);
+	}
+
+	return OT_ERROR_NONE;
 }
 
 void otPlatRadioEnableSrcMatch(otInstance *aInstance, bool aEnable)


### PR DESCRIPTION
- Extended radio API to include "energy scan" capability
- Extended nrf5 radio shim to support energy scan feature
- Extended open thread shim to make use of energy scan feature.

tested on nRF52840
