### PR TITLE
Bluetooth: Mesh: Segmented TX to groups

### DIFF
--- a/subsys/bluetooth/mesh/adv.h
+++ b/subsys/bluetooth/mesh/adv.h
@@ -31,10 +31,6 @@ struct bt_mesh_adv {
 	u8_t      type:2,
 		  busy:1;
 	u8_t      xmit;
-	/* For transport layer segment sending */
-	struct {
-		u8_t attempts;
-	} seg;
 };
 
 typedef struct bt_mesh_adv *(*bt_mesh_adv_alloc_t)(int id);


### PR DESCRIPTION
Implements several changes to the transport layer segmented tx to
improve group message performance:
- Moves retransmit counter to tx context instead of per packet. As every
  unacked packet is sent every retransmit, the retransmit counters would
  be the same in each segment. This makes it easier to control progress.
- Delays the scheduling of the retransmit until the completion of the
  last segment by adding a seg_pending counter. This is essentially the
  same as the old behavior, except that the old behavior might retrigger
  the sending before all segments are finished if the advertising is
  slow.
- Allows the group transmits to stop as soon as all retransmits have
  been exhausted, instead of timing out waiting for acks that won't
  come. This allows group tx to finish without error.
- Fixes a bug where a failed TX would block IV update.
- Cancels any pending transmissions of acked segments.
- Reduces log level for several common group tx scenarios that aren't
  erronous.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>