### PR TITLE
Bluetooth: Mesh: Group resends in proxy nodes

### DIFF
--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -773,7 +773,8 @@ int bt_mesh_net_resend(struct bt_mesh_subnet *sub, struct net_buf *buf,
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY) &&
-	    bt_mesh_proxy_relay(&buf->b, dst)) {
+	    bt_mesh_proxy_relay(&buf->b, dst) &&
+	    BT_MESH_ADDR_IS_UNICAST(dst)) {
 		send_cb_finalize(cb, cb_data);
 	} else {
 		bt_mesh_adv_send(buf, cb, cb_data);


### PR DESCRIPTION
Resend transport segments for groups on the advertiser interface, even
if a connected proxy node holds the group.

Fixes #23121

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>