### PR TITLE
Bluetooth: shell: Update help text of `bt init` command

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1713,7 +1713,7 @@ static int cmd_auth_passkey(const struct shell *shell,
 #define HELP_ADDR_LE "<address: XX:XX:XX:XX:XX:XX> <type: (public|random)>"
 
 SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
-	SHELL_CMD_ARG(init, NULL, HELP_ADDR_LE, cmd_init, 1, 0),
+	SHELL_CMD_ARG(init, NULL, HELP_NONE, cmd_init, 1, 0),
 #if defined(CONFIG_BT_HCI)
 	SHELL_CMD_ARG(hci-cmd, NULL, "<ogf> <ocf> [data]", cmd_hci_cmd, 3, 1),
 #endif


### PR DESCRIPTION
Update help text of `bt init` command which says address could be
provided. This feature was removed by:
d22b7c9f2d771bf9a2a1b8e0378795d4c507f558

As a replacement the `bt id-create` command can be used instead.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>