### PR TITLE
doc/reference/runtime_conf/settings: reference missing API group

### DIFF
--- a/doc/reference/runtime_conf/settings/settings.rst
+++ b/doc/reference/runtime_conf/settings/settings.rst
@@ -279,5 +279,22 @@ API Reference
 
 The Settings subsystem APIs are provided by ``settings.h``:
 
+API for general settings usage
+==============================
 .. doxygengroup:: settings
+   :project: Zephyr
+
+API for key-name processing
+===========================
+.. doxygengroup:: settings_name_proc
+   :project: Zephyr
+
+API for runtime settings manipulation
+=====================================
+.. doxygengroup:: settings_rt
+   :project: Zephyr
+
+API of backend interface
+========================
+..  doxygengroup:: settings_backend
    :project: Zephyr


### PR DESCRIPTION
Added references to missing settings API groups so them
will be generated in documentation build.

Missing API are doxygen subgroup of already referenced doxygen group,
but subgroups aren't automatically extracted to the documentation
output.

Although I [included entire API into doxygen](https://github.com/zephyrproject-rtos/zephyr/pull/22835), I didn't now that subgroup are not automatically extracted if parent group was referenced.

I generated documentation locally for ensure that now it looks like I want:
![image](https://user-images.githubusercontent.com/17042885/75358112-a1c9c780-58b2-11ea-95af-477a321607b2.png)
(...)

![image](https://user-images.githubusercontent.com/17042885/75359021-0b96a100-58b4-11ea-84a4-17f44c0f8151.png)


Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>