### PR TITLE
drivers:flash:sam0: fix unaligned memory read

### DIFF
--- a/drivers/flash/flash_sam0.c
+++ b/drivers/flash/flash_sam0.c
@@ -145,7 +145,7 @@ static int flash_sam0_write_page(struct device *dev, off_t offset,
 
 	/* Ensure writes happen 32 bits at a time. */
 	for (; src != end; src++, dst++) {
-		*dst = *src;
+		*dst = UNALIGNED_GET((u32_t *)src);
 	}
 
 #ifdef NVMCTRL_CTRLA_CMD_WP


### PR DESCRIPTION
This PR replaces PR #21347

The PR addresses an issue with the sam0 flash driver. The flash driver writes data to the flash page using 32 bit long words. This will generate a hard fault if the source address for a flash write is not aligned to a 32 bit word boundary. This PR fixes this issue.

This PR uses the UNALIGNED_GET() macro instead of the flash_sam0_read_unaigned_u32() function to ensure word alignment.