### PR TITLE
Bluetooth: GATT: Fix not clearing CF_OUT_OF_SYNC

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -713,6 +713,7 @@ static void remove_cf_cfg(struct bt_conn *conn)
 	} else {
 		/* Update address in case it has changed */
 		bt_addr_le_copy(&cfg->peer, &conn->le.dst);
+		atomic_clear_bit(cfg->flags, CF_OUT_OF_SYNC);
 	}
 }
 #endif /* CONFIG_BT_GATT_CACHING */


### PR DESCRIPTION
If the client is change-unware and disconnects the spec requires that
the stack still sends the error out of sync for the next request:

'The ATT_ERROR_RSP PDU is sent only once after the client becomes
change-unaware, unless the client _disconnects_ or the database changes
again before the client becomes change-aware in which case the
ATT_ERROR_RSP PDU shall be sent again'

Fixes #23110

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>