### PR TITLE
drivers: bme280: add delay during boot

### DIFF
--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -290,6 +290,12 @@ static int bme280_chip_init(struct device *dev)
 {
 	struct bme280_data *data = (struct bme280_data *) dev->driver_data;
 	int err;
+	s64_t now;
+
+	now = k_uptime_get() * 1000;
+	if (now < BME280_STARTUP_TIME_USEC) {
+		k_busy_wait(BME280_STARTUP_TIME_USEC - now);
+	}
 
 	err = bm280_reg_read(data, BME280_REG_ID, &data->chip_id, 1);
 	if (err < 0) {

--- a/drivers/sensor/bme280/bme280.h
+++ b/drivers/sensor/bme280/bme280.h
@@ -100,6 +100,8 @@
 					 BME280_FILTER |  \
 					 BME280_SPI_3W_DISABLE)
 
+#define BME280_STARTUP_TIME_USEC        2000
+
 struct bme280_data {
 #ifdef DT_BOSCH_BME280_BUS_I2C
 	struct device *i2c_master;


### PR DESCRIPTION
drivers: bme280: Add delay during boot

After power on, many devices specify a start up time.
This change adds a start up time consistent with the
device datasheet.