### PR TITLE
cmake: llvm: Fix the installed path setting of non-host clang

### DIFF
--- a/cmake/toolchain/llvm/generic.cmake
+++ b/cmake/toolchain/llvm/generic.cmake
@@ -8,8 +8,8 @@ if((NOT "${USER_CACHE_DIR}" STREQUAL "") AND (EXISTS "${USER_CACHE_DIR}"))
     ${CMAKE_COMMAND} -E remove_directory "${USER_CACHE_DIR}")
 endif()
 
-if(DEFINED $ENV{CLANG_ROOT_DIR})
-  set(TOOLCHAIN_HOME ${CLANG_ROOT}/bin/)
+if(DEFINED ENV{CLANG_ROOT_DIR})
+  set(TOOLCHAIN_HOME $ENV{CLANG_ROOT_DIR}/bin/)
 endif()
 
 set(COMPILER clang)


### PR DESCRIPTION
commit 129ae378c0 breaks the installed path setting by CLANG_ROOT_DIR
because CLANG_ROOT is not set. Remove CLANG_ROOT and just use
CLANG_ROOT_DIR to fix this bug.

Signed-off-by: Jim Shu <cwshu@andestech.com>