### PR TITLE
doc: release notes: Content for POSIX arch

### DIFF
--- a/doc/releases/release-notes-2.2.rst
+++ b/doc/releases/release-notes-2.2.rst
@@ -157,7 +157,7 @@ Architectures
 
 * POSIX:
 
-  * <TBD>
+  * N/A
 
 * RISC-V:
 


### PR DESCRIPTION
Nothing significant has happened in the POSIX arch,
so just leave that section with an N/A

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>