### PR TITLE
boards: intel_s1000_crb: fix xt-gdb cannot find register error

### DIFF
--- a/boards/xtensa/intel_s1000_crb/support/load_elf.txt
+++ b/boards/xtensa/intel_s1000_crb/support/load_elf.txt
@@ -9,6 +9,6 @@ set *(0x71F90) = 0x71
 
 set pagination off
 set confirm off
-load zephyr/zephyr.elf
 file zephyr/zephyr.elf
+load zephyr/zephyr.elf
 c


### PR DESCRIPTION
With the new RI-2018.0 XCC, xt-gdb complains about not being able
to find register f0. Turns out that xt-gdb needs to be told which
file to look at (the file command) before a load command can be
issued. So swap these two commands in the load_elf.txt file.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>