### PR TITLE
Bluetooth: tester: Fix GATT service registration

### DIFF
--- a/tests/bluetooth/tester/src/gatt.c
+++ b/tests/bluetooth/tester/src/gatt.c
@@ -214,11 +214,19 @@ static void supported_commands(u8_t *data, u16_t len)
 
 static int register_service(void)
 {
+	int err;
+
 	server_svcs[svc_count].attrs = server_db +
 				       (attr_count - svc_attr_count);
 	server_svcs[svc_count].attr_count = svc_attr_count;
 
-	return bt_gatt_service_register(&server_svcs[svc_count]);
+	err = bt_gatt_service_register(&server_svcs[svc_count]);
+	if (!err) {
+		/* Service registered, reset the counter */
+		svc_attr_count = 0U;
+	}
+
+	return err;
 }
 
 static void add_service(u8_t *data, u16_t len)
@@ -237,14 +245,13 @@ static void add_service(u8_t *data, u16_t len)
 							sizeof(uuid.u128);
 
 	/* Register last defined service */
-	if (svc_count) {
+	if (svc_attr_count) {
 		if (register_service()) {
 			goto fail;
 		}
 	}
 
 	svc_count++;
-	svc_attr_count = 0U;
 
 	switch (cmd->type) {
 	case GATT_SERVICE_PRIMARY:
@@ -809,7 +816,7 @@ static void start_server(u8_t *data, u16_t len)
 	struct gatt_start_server_rp rp;
 
 	/* Register last defined service */
-	if (svc_count) {
+	if (svc_attr_count) {
 		if (register_service()) {
 			tester_rsp(BTP_SERVICE_ID_GATT, GATT_START_SERVER,
 				   CONTROLLER_INDEX, BTP_STATUS_FAILED);


### PR DESCRIPTION
The service registration logic was using the wrong variable to check for
a pending service to be registered, which led to the same service being
registered twice in some cases. Fix the logic so that a pending service
is only registered once.

---

Relates to #22982.
