### PR TITLE
drivers: opt3001:  Add boot delay and config

### DIFF
--- a/drivers/sensor/opt3001/opt3001.h
+++ b/drivers/sensor/opt3001/opt3001.h
@@ -17,15 +17,32 @@
 #define OPT3001_MANUFACTURER_ID_VALUE 0x5449
 #define OPT3001_DEVICE_ID_VALUE 0x3001
 
-#define OPT3001_CONVERSION_MODE_MASK (BIT(10) | BIT(9))
-#define OPT3001_CONVERSION_MODE_CONTINUOUS (BIT(10) | BIT(9))
+#define OPT3001_CONVERSION_TIME             BIT(11)
+#define OPT3001_CONVERSION_MODE_MASK        (BIT(10) | BIT(9))
+#define OPT3001_CONVERSION_MODE_CONTINUOUS  (BIT(10) | BIT(9))
+#define OPT3001_OVERFLOW                    BIT(8)
+#define OPT3001_CONVERSION_READY            BIT(7)
+#define OPT3001_FLAG_HIGH                   BIT(6)
+#define OPT3001_FLAG_LOW                    BIT(5)
+#define OPT3001_LATCH                       BIT(4)
+#define OPT3001_POLARITY                    BIT(3)
+#define OPT3001_MASK_EXPONENT               BIT(2)
+#define OPT3001_FAULT_COUNT                 (BIT(1) | BIT(0))
+
 
 #define OPT3001_SAMPLE_EXPONENT_SHIFT 12
 #define OPT3001_MANTISSA_MASK 0xfff
 
+#define OPT3001_STARTUP_TIME_USEC     1000
+
 struct opt3001_data {
 	struct device *i2c;
 	u16_t sample;
+};
+
+enum opt3001_sensor_attributes {
+	SENSOR_ATTR_FAULT_COUNT = SENSOR_ATTR_PRIV_START,
+	SENSOR_ATTR_LATCH,
 };
 
 #endif /* _SENSOR_OPT3001_ */


### PR DESCRIPTION
After power on, the device specifies a start up time.
This change adds a start up time consistent with the
device datasheet.  Fixes #21707

There are several additional bit fields defined for the
CONFIG register.  The bit fields have been added and
an attr_set() function has been added to enable
setting the sample frequency.

