### PR TITLE
boards: up_squared_adsp: Use local xtensa HAL instead of SDK HAL

### DIFF
--- a/boards/xtensa/up_squared_adsp/bootloader/CMakeLists.txt
+++ b/boards/xtensa/up_squared_adsp/bootloader/CMakeLists.txt
@@ -39,9 +39,9 @@ set_source_files_properties(${ARCH_DIR}/${ARCH}/core/startup/reset-vector.S PROP
 target_compile_options(bootloader PUBLIC -fno-inline-functions -mlongcalls -mtext-section-literals -imacros${CMAKE_BINARY_DIR}/zephyr/include/generated/autoconf.h)
 
 target_link_libraries(bootloader PUBLIC -Wl,--no-check-sections -ucall_user_start -Wl,-static -nostdlib)
-target_link_libraries(bootloader PRIVATE -lhal -L${zephyr_sdk}/xtensa/intel_apl_adsp/xtensa-zephyr-elf/lib)
 target_link_libraries(bootloader PRIVATE -T${BOARD_DIR}/bootloader/boot_ldr.x)
 
 if(CONFIG_XTENSA_HAL)
   target_link_libraries(bootloader PRIVATE XTENSA_HAL)
+  target_link_libraries(bootloader PRIVATE modules_xtensa_hal)
 endif()


### PR DESCRIPTION
SDK HAL is deprecated for Intel ADSP SoCs so fix and use local HAL
module.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>
Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>

Depends on https://github.com/zephyrproject-rtos/sdk-ng/pull/193 and https://github.com/zephyrproject-rtos/hal_xtensa/pull/10