### PR TITLE
doc: dts/macros.rst: "clocks" macro fixes

### DIFF
--- a/doc/guides/dts/macros.rst
+++ b/doc/guides/dts/macros.rst
@@ -587,9 +587,9 @@ example ``DT_<node>_CLOCK_CONTROLLER_0`` instead of
 
    This inconsistency might be fixed in the future.
 
-In addition, if the clock controller node has a ``fixed-clock`` property, it is
-expected to also have a ``clock-frequency`` property giving the frequency, and
-an additional macro is generated:
+If a ``clocks`` controller node has a ``"fixed-clock"`` compatible, it
+must also have a ``clock-frequency`` property giving its frequency in Hertz.
+In this case, an additional macro is generated:
 
 .. code-block:: none
 


### PR DESCRIPTION
The "fixed-clock" value referenced in the documentation is actually a
compatible value, not a property name. Fix that.

Harden the "expected to have a clock-frequency property" language to
use "must" instead of "expected". The scripts error out if a node with
fixed-clock compatible is missing a clock-frequency property; it's not
a soft expectation.

Be explicit about clock-frequency units.