### PR TITLE
Bluetooth: controller: Add Kconfig for Optimize for Speed

### DIFF
--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -85,7 +85,7 @@ zephyr_library_include_directories(
   )
 
 zephyr_library_compile_options_ifdef(
-  CONFIG_BT_CTLR_FAST_ENC
+  CONFIG_BT_CTLR_OPTIMIZE_FOR_SPEED
   ${OPTIMIZE_FOR_SPEED_FLAG}
   )
 

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -576,6 +576,12 @@ config BT_CTLR_ZLI
 	  shall not use Zero Latency IRQ themselves when this option is selected,
 	  else will impact controller stability.
 
+config BT_CTLR_OPTIMIZE_FOR_SPEED
+	bool "Optimize for Speed"
+	default y if BT_CTLR_LE_ENC
+	help
+	  Optimize compilation of controller for execution speed.
+
 if BT_LL_SW_LEGACY
 
 config BT_CTLR_WORKER_PRIO


### PR DESCRIPTION
Add Kconfig option to support building the controller
optimized for speed.

Fixes #21601.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>