### PR TITLE
doc: release notes: Add information about GSM modem

### DIFF
--- a/doc/releases/release-notes-2.2.rst
+++ b/doc/releases/release-notes-2.2.rst
@@ -331,7 +331,7 @@ Drivers and Sensors
 
 * Modem
 
-  * <TBD>
+  * Add support for generic GSM modem
 
 * Pinmux
 


### PR DESCRIPTION
The Modem chapter was missing mention about generic GSM modem
support.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>