### PR TITLE
Bluetooth: Mesh: Fix handling of app index and local device key

### DIFF
--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1717,7 +1717,9 @@ int bt_mesh_app_key_get(const struct bt_mesh_subnet *subnet, u16_t app_idx,
 {
 	struct bt_mesh_app_key *app_key;
 
-	if (app_idx == BT_MESH_KEY_DEV_LOCAL) {
+	if (app_idx == BT_MESH_KEY_DEV_LOCAL ||
+	    (app_idx == BT_MESH_KEY_DEV_REMOTE &&
+	     bt_mesh_elem_find(addr) != NULL)) {
 		*aid = 0;
 		*key = bt_mesh.dev_key;
 		return 0;


### PR DESCRIPTION
Fix problem of not checking if the remote device key is actually our
own. This bug was intruduced in
46a95f12adc9f40b974b9d9bf9870b6772b8c87b and causes failure of models
that use app_idx BT_MESH_KEY_DEV_REMOTE. Since this is used by cfg_cli,
it was not possible to do self-configuration.

Signed-off-by: Tobias Svehagen <tobias.svehagen@gmail.com>