### PR TITLE
Bluetooth: Make macro definition compatible with 7-2018-q2-update g++

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -322,6 +322,7 @@ struct bt_le_adv_param {
   */
 #define BT_LE_ADV_PARAM(_options, _int_min, _int_max) \
 		((struct bt_le_adv_param[]) { { \
+			.id = BT_ID_DEFAULT, \
 			.options = (_options), \
 			.interval_min = (_int_min), \
 			.interval_max = (_int_max), \

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -817,10 +817,11 @@ ssize_t bt_gatt_attr_read_cpf(struct bt_conn *conn,
 #define BT_GATT_ATTRIBUTE(_uuid, _perm, _read, _write, _value)		\
 {									\
 	.uuid = _uuid,							\
-	.perm = _perm,							\
 	.read = _read,							\
 	.write = _write,						\
 	.user_data = _value,						\
+	.handle = 0,							\
+	.perm = _perm,							\
 }
 
 /** @brief Notification complete result callback.


### PR DESCRIPTION
In C++ designated initializers require that
1) All members are initialized
2) Designators used in the expression must appear in the same order as the
data members.

Signed-off-by: Alexey Eremin <a.eremin.msu@gmail.com>