### PR TITLE
riscv machine timer: Fix for long running platform w/ software reset

### DIFF
--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -83,7 +83,8 @@ static void timer_isr(void *arg)
 int z_clock_driver_init(struct device *device)
 {
 	IRQ_CONNECT(RISCV_MACHINE_TIMER_IRQ, 0, timer_isr, NULL, 0);
-	set_mtimecmp(mtime() + CYC_PER_TICK);
+	last_count = mtime();
+	set_mtimecmp(last_count + CYC_PER_TICK);
 	irq_enable(RISCV_MACHINE_TIMER_IRQ);
 	return 0;
 }


### PR DESCRIPTION
When on a long-running platform, the MCU may get a soft reset, without resetting the CLINT registers. In this scenario, the riscv machine timer will continuously interrupt the system when the mtime register exceeds 32 bits in value. This is because the last_count value is used to update the mtimecmp register, and its value is initialized to zero. Its first update is with a 32-bit value, which loses information when the mtime register exceeds 32 bits.

The proposed solution is to set the last_count value to the current value in the mtime register when the MCU is initialized. Since the timer is fired at intervals that are less than 32 bits in value, the next update of last_count will remain valid, and the system will function as expected.

Signed-off-by: Jaron Kelleher <jkelleher@fb.com>