### PR TITLE
tests: Bluetooth: shell: Fix conditional compile error

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1633,6 +1633,7 @@ static int cmd_wl_clear(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 }
 
+#if defined(CONFIG_BT_CENTRAL)
 static int cmd_wl_connect(const struct shell *shell, size_t argc, char *argv[])
 {
 	int err;
@@ -1656,6 +1657,7 @@ static int cmd_wl_connect(const struct shell *shell, size_t argc, char *argv[])
 
 	return 0;
 }
+#endif /* CONFIG_BT_CENTRAL */
 #endif /* defined(CONFIG_BT_WHITELIST) */
 
 #if defined(CONFIG_BT_FIXED_PASSKEY)
@@ -1782,7 +1784,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 	SHELL_CMD_ARG(wl-add, NULL, HELP_ADDR_LE, cmd_wl_add, 3, 0),
 	SHELL_CMD_ARG(wl-rem, NULL, HELP_ADDR_LE, cmd_wl_rem, 3, 0),
 	SHELL_CMD_ARG(wl-clear, NULL, HELP_NONE, cmd_wl_clear, 1, 0),
+#if defined(CONFIG_BT_CENTRAL)
 	SHELL_CMD_ARG(wl-connect, NULL, "<on, off>", cmd_wl_connect, 2, 0),
+#endif /* CONFIG_BT_CENTRAL */
 #endif /* defined(CONFIG_BT_WHITELIST) */
 #if defined(CONFIG_BT_FIXED_PASSKEY)
 	SHELL_CMD_ARG(fixed-passkey, NULL, "[passkey]", cmd_fixed_passkey,


### PR DESCRIPTION
When building the tests/bluetooth/shell application without
the BT_CENTRAL feature, compilation fails:

subsys/bluetooth/shell/bt.c:1642: undefined reference to
`bt_conn_create_auto_le'

Signed-off-by: Vinayak Kariappa Chettimada <vinayak.kariappa@gmail.com>