### PR TITLE
scripts: Dynamically add driver subsystems to subsystems list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,6 +494,7 @@ endif()
 
 set(syscall_list_h ${CMAKE_CURRENT_BINARY_DIR}/include/generated/syscall_list.h)
 set(syscalls_json  ${CMAKE_CURRENT_BINARY_DIR}/misc/generated/syscalls.json)
+set(subsys_json    ${CMAKE_CURRENT_BINARY_DIR}/misc/generated/subsystems.json)
 
 # The syscalls subdirs txt file is constructed by python containing a list of folders to use for
 # dependency handling, including empty folders.
@@ -585,12 +586,14 @@ endforeach()
 add_custom_command(
   OUTPUT
   ${syscalls_json}
+  ${subsys_json}
   COMMAND
   ${PYTHON_EXECUTABLE}
   ${ZEPHYR_BASE}/scripts/parse_syscalls.py
    --include          ${ZEPHYR_BASE}/include        # Read files from this dir
   ${parse_syscalls_include_args}                    # Read files from these dirs also
-  --json-file        ${syscalls_json}              # Write this file
+  --json-file        ${syscalls_json}               # Write this file
+  --subsystem-file   ${subsys_json}                 # Write subsystem list to this file
   DEPENDS ${syscalls_subdirs_trigger} ${PARSE_SYSCALLS_HEADER_DEPENDS}
   )
 
@@ -617,6 +620,9 @@ add_custom_command(OUTPUT include/generated/syscall_dispatch.c ${syscall_list_h}
   DEPENDS ${syscalls_json}
   )
 
+# This is passed into all calls to the gen_kobject_list.py script.
+set(gen_kobject_list_include_args --include ${subsys_json})
+
 set(DRV_VALIDATION ${PROJECT_BINARY_DIR}/include/generated/driver-validation.h)
 add_custom_command(
   OUTPUT ${DRV_VALIDATION}
@@ -624,8 +630,11 @@ add_custom_command(
   ${PYTHON_EXECUTABLE}
   ${ZEPHYR_BASE}/scripts/gen_kobject_list.py
   --validation-output ${DRV_VALIDATION}
+  ${gen_kobject_list_include_args}
   $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
-  DEPENDS ${ZEPHYR_BASE}/scripts/gen_kobject_list.py
+  DEPENDS
+  ${ZEPHYR_BASE}/scripts/gen_kobject_list.py
+  ${subsys_json}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 add_custom_target(${DRIVER_VALIDATION_H_TARGET} DEPENDS ${DRV_VALIDATION})
@@ -941,8 +950,11 @@ if(CONFIG_USERSPACE)
     ${GEN_KOBJ_LIST}
     --kernel $<TARGET_FILE:${ZEPHYR_PREBUILT_EXECUTABLE}>
     --gperf-output ${OBJ_LIST}
+    ${gen_kobject_list_include_args}
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
-    DEPENDS ${ZEPHYR_PREBUILT_EXECUTABLE}
+    DEPENDS
+    ${ZEPHYR_PREBUILT_EXECUTABLE}
+    ${subsys_json}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
   add_custom_target(obj_list DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${OBJ_LIST})

--- a/cmake/kobj.cmake
+++ b/cmake/kobj.cmake
@@ -21,8 +21,11 @@ function(gen_kobj gen_dir_out)
     --kobj-types-output ${KOBJ_TYPES}
     --kobj-otype-output ${KOBJ_OTYPE}
     --kobj-size-output ${KOBJ_SIZE}
+    ${gen_kobject_list_include_args}
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
-    DEPENDS $ENV{ZEPHYR_BASE}/scripts/gen_kobject_list.py
+    DEPENDS
+    $ENV{ZEPHYR_BASE}/scripts/gen_kobject_list.py
+    ${subsys_json}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
   add_custom_target(${KOBJ_TYPES_H_TARGET} DEPENDS ${KOBJ_TYPES} ${KOBJ_OTYPE})

--- a/include/crypto/cipher.h
+++ b/include/crypto/cipher.h
@@ -24,7 +24,7 @@
 #include "cipher_structs.h"
 
 /* The API a crypto driver should implement */
-struct crypto_driver_api {
+__subsystem struct crypto_driver_api {
 	int (*query_hw_caps)(struct device *dev);
 
 	/* Setup a crypto session */

--- a/include/drivers/adc.h
+++ b/include/drivers/adc.h
@@ -353,7 +353,7 @@ typedef int (*adc_api_read_async)(struct device *dev,
  *
  * This is the mandatory API any ADC driver needs to expose.
  */
-struct adc_driver_api {
+__subsystem struct adc_driver_api {
 	adc_api_channel_setup channel_setup;
 	adc_api_read          read;
 #ifdef CONFIG_ADC_ASYNC

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -312,7 +312,7 @@ struct zcan_work {
 	void *cb_arg;
 };
 
-struct can_driver_api {
+__subsystem struct can_driver_api {
 	can_configure_t configure;
 	can_send_t send;
 	can_attach_isr_t attach_isr;

--- a/include/drivers/counter.h
+++ b/include/drivers/counter.h
@@ -184,7 +184,7 @@ typedef u32_t (*counter_api_get_guard_period)(struct device *dev, u32_t flags);
 typedef int (*counter_api_set_guard_period)(struct device *dev, u32_t ticks,
 						u32_t flags);
 
-struct counter_driver_api {
+__subsystem struct counter_driver_api {
 	counter_api_start start;
 	counter_api_stop stop;
 	counter_api_get_value get_value;

--- a/include/drivers/dma.h
+++ b/include/drivers/dma.h
@@ -189,7 +189,7 @@ typedef int (*dma_api_stop)(struct device *dev, u32_t channel);
 typedef int (*dma_api_get_status)(struct device *dev, u32_t channel,
 				  struct dma_status *status);
 
-struct dma_driver_api {
+__subsystem struct dma_driver_api {
 	dma_api_config config;
 	dma_api_reload reload;
 	dma_api_start start;

--- a/include/drivers/eeprom.h
+++ b/include/drivers/eeprom.h
@@ -38,7 +38,7 @@ typedef int (*eeprom_api_write)(struct device *dev, off_t offset,
 				const void *data, size_t len);
 typedef size_t (*eeprom_api_size)(struct device *dev);
 
-struct eeprom_driver_api {
+__subsystem struct eeprom_driver_api {
 	eeprom_api_read read;
 	eeprom_api_write write;
 	eeprom_api_size size;

--- a/include/drivers/entropy.h
+++ b/include/drivers/entropy.h
@@ -46,7 +46,7 @@ typedef int (*entropy_get_entropy_isr_t)(struct device *dev,
 					 u8_t *buffer,
 					 u16_t length,
 					 u32_t flags);
-struct entropy_driver_api {
+__subsystem struct entropy_driver_api {
 	entropy_get_entropy_t     get_entropy;
 	entropy_get_entropy_isr_t get_entropy_isr;
 };

--- a/include/drivers/espi.h
+++ b/include/drivers/espi.h
@@ -357,7 +357,7 @@ typedef int (*espi_api_manage_callback)(struct device *dev,
 					struct espi_callback *callback,
 					bool set);
 
-struct espi_driver_api {
+__subsystem struct espi_driver_api {
 	espi_api_config config;
 	espi_api_get_channel_status get_channel_status;
 	espi_api_read_request read_request;

--- a/include/drivers/flash.h
+++ b/include/drivers/flash.h
@@ -70,7 +70,7 @@ typedef void (*flash_api_pages_layout)(struct device *dev,
 				       size_t *layout_size);
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
-struct flash_driver_api {
+__subsystem struct flash_driver_api {
 	flash_api_read read;
 	flash_api_write write;
 	flash_api_erase erase;

--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -545,7 +545,7 @@ enum gpio_int_trig {
 	GPIO_INT_TRIG_BOTH = GPIO_INT_LOW_0 | GPIO_INT_HIGH_1,
 };
 
-struct gpio_driver_api {
+__subsystem struct gpio_driver_api {
 	int (*pin_configure)(struct device *port, gpio_pin_t pin, gpio_flags_t flags);
 	int (*port_get_raw)(struct device *port, gpio_port_value_t *value);
 	int (*port_set_masked_raw)(struct device *port, gpio_port_pins_t mask,

--- a/include/drivers/i2c.h
+++ b/include/drivers/i2c.h
@@ -174,7 +174,7 @@ typedef int (*i2c_api_slave_register_t)(struct device *dev,
 typedef int (*i2c_api_slave_unregister_t)(struct device *dev,
 					  struct i2c_slave_config *cfg);
 
-struct i2c_driver_api {
+__subsystem struct i2c_driver_api {
 	i2c_api_configure_t configure;
 	i2c_api_full_io_t transfer;
 	i2c_api_slave_register_t slave_register;

--- a/include/drivers/i2s.h
+++ b/include/drivers/i2s.h
@@ -313,7 +313,7 @@ struct i2s_config {
  *
  * For internal use only, skip these in public documentation.
  */
-struct i2s_driver_api {
+__subsystem struct i2s_driver_api {
 	int (*configure)(struct device *dev, enum i2s_dir dir,
 			 struct i2s_config *cfg);
 	struct i2s_config *(*config_get)(struct device *dev,

--- a/include/drivers/ipm.h
+++ b/include/drivers/ipm.h
@@ -85,7 +85,7 @@ typedef void (*ipm_register_callback_t)(struct device *port, ipm_callback_t cb,
  */
 typedef int (*ipm_set_enabled_t)(struct device *ipmdev, int enable);
 
-struct ipm_driver_api {
+__subsystem struct ipm_driver_api {
 	ipm_send_t send;
 	ipm_register_callback_t register_callback;
 	ipm_max_data_size_get_t max_data_size_get;

--- a/include/drivers/kscan.h
+++ b/include/drivers/kscan.h
@@ -56,7 +56,7 @@ typedef int (*kscan_config_t)(struct device *dev,
 typedef int (*kscan_disable_callback_t)(struct device *dev);
 typedef int (*kscan_enable_callback_t)(struct device *dev);
 
-struct kscan_driver_api {
+__subsystem struct kscan_driver_api {
 	kscan_config_t config;
 	kscan_disable_callback_t disable_callback;
 	kscan_enable_callback_t enable_callback;

--- a/include/drivers/led.h
+++ b/include/drivers/led.h
@@ -53,7 +53,7 @@ typedef int (*led_api_off)(struct device *dev, u32_t led);
  *
  * This is the mandatory API any LED driver needs to expose.
  */
-struct led_driver_api {
+__subsystem struct led_driver_api {
 	led_api_blink blink;
 	led_api_set_brightness set_brightness;
 	led_api_on on;

--- a/include/drivers/pinmux.h
+++ b/include/drivers/pinmux.h
@@ -66,7 +66,7 @@ typedef int (*pmux_pullup)(struct device *dev, u32_t pin, u8_t func);
  */
 typedef int (*pmux_input)(struct device *dev, u32_t pin, u8_t func);
 
-struct pinmux_driver_api {
+__subsystem struct pinmux_driver_api {
 	pmux_set set;
 	pmux_get get;
 	pmux_pullup pullup;

--- a/include/drivers/ps2.h
+++ b/include/drivers/ps2.h
@@ -50,7 +50,7 @@ typedef int (*ps2_write_t)(struct device *dev, u8_t value);
 typedef int (*ps2_disable_callback_t)(struct device *dev);
 typedef int (*ps2_enable_callback_t)(struct device *dev);
 
-struct ps2_driver_api {
+__subsystem struct ps2_driver_api {
 	ps2_config_t config;
 	ps2_read_t read;
 	ps2_write_t write;

--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -52,7 +52,7 @@ typedef int (*pwm_get_cycles_per_sec_t)(struct device *dev, u32_t pwm,
 					u64_t *cycles);
 
 /** @brief PWM driver API definition. */
-struct pwm_driver_api {
+__subsystem struct pwm_driver_api {
 	pwm_pin_set_t pin_set;
 	pwm_get_cycles_per_sec_t get_cycles_per_sec;
 };

--- a/include/drivers/sensor.h
+++ b/include/drivers/sensor.h
@@ -316,7 +316,7 @@ typedef int (*sensor_channel_get_t)(struct device *dev,
 				    enum sensor_channel chan,
 				    struct sensor_value *val);
 
-struct sensor_driver_api {
+__subsystem struct sensor_driver_api {
 	sensor_attr_set_t attr_set;
 	sensor_trigger_set_t trigger_set;
 	sensor_sample_fetch_t sample_fetch;

--- a/include/drivers/spi.h
+++ b/include/drivers/spi.h
@@ -223,7 +223,7 @@ typedef int (*spi_api_release)(struct device *dev,
  * @brief SPI driver API
  * This is the mandatory API any SPI driver needs to expose.
  */
-struct spi_driver_api {
+__subsystem struct spi_driver_api {
 	spi_api_io transceive;
 #ifdef CONFIG_SPI_ASYNC
 	spi_api_io_async transceive_async;

--- a/include/drivers/uart.h
+++ b/include/drivers/uart.h
@@ -342,7 +342,7 @@ struct uart_device_config {
 };
 
 /** @brief Driver API structure. */
-struct uart_driver_api {
+__subsystem struct uart_driver_api {
 
 #ifdef CONFIG_UART_ASYNC_API
 

--- a/include/drivers/watchdog.h
+++ b/include/drivers/watchdog.h
@@ -135,7 +135,7 @@ typedef int (*wdt_api_install_timeout)(struct device *dev,
 typedef int (*wdt_api_feed)(struct device *dev, int channel_id);
 
 /** @cond INTERNAL_HIDDEN */
-struct wdt_driver_api {
+__subsystem struct wdt_driver_api {
 	wdt_api_setup setup;
 	wdt_api_disable disable;
 	wdt_api_install_timeout install_timeout;

--- a/include/ptp_clock.h
+++ b/include/ptp_clock.h
@@ -22,7 +22,7 @@ extern "C" {
 #define PTP_CLOCK_NAME "PTP_CLOCK"
 #endif
 
-struct ptp_clock_driver_api {
+__subsystem struct ptp_clock_driver_api {
 	int (*set)(struct device *dev, struct net_ptp_time *tm);
 	int (*get)(struct device *dev, struct net_ptp_time *tm);
 	int (*adjust)(struct device *dev, int increment);

--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -132,6 +132,11 @@
 #define __syscall
 #endif /* #ifndef ZTEST_UNITTEST */
 
+/* Used as a sentinel by parse_syscalls.py to identify what API structs
+ * define driver subsystems.
+ */
+#define __subsystem
+
 #ifndef BUILD_ASSERT
 /* compile-time assertion that makes the build fail */
 #define BUILD_ASSERT(EXPR) \

--- a/samples/userspace/prod_consumer/src/sample_driver.h
+++ b/samples/userspace/prod_consumer/src/sample_driver.h
@@ -23,7 +23,7 @@ typedef int (*sample_driver_set_callback_t)(struct device *dev,
 
 typedef int (*sample_driver_state_set_t)(struct device *dev, bool active);
 
-struct sample_driver_api {
+__subsystem struct sample_driver_api {
 	sample_driver_write_t write;
 	sample_driver_set_callback_t set_callback;
 	sample_driver_state_set_t state_set;

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -92,30 +92,12 @@ kobjects = OrderedDict([
 ])
 
 subsystems = [
-    "adc_driver_api",
-    "aio_cmp_driver_api",
-    "counter_driver_api",
-    "crypto_driver_api",
-    "dma_driver_api",
-    "flash_driver_api",
-    "gpio_driver_api",
-    "i2c_driver_api",
-    "i2s_driver_api",
-    "ipm_driver_api",
-    "led_driver_api",
-    "pinmux_driver_api",
-    "pwm_driver_api",
-    "entropy_driver_api",
-    "sensor_driver_api",
-    "spi_driver_api",
-    "uart_driver_api",
-    "can_driver_api",
-    "ptp_clock_driver_api",
-    "eeprom_driver_api",
-    "wdt_driver_api",
-
-    # Fake 'sample driver' subsystem, used by tests/samples
-    "sample_driver_api"
+    # Editing the list is deprecated, add the __subsystem sentinal to your driver
+    # api declaration instead. e.x.
+    #
+    # __subsystem struct my_driver_api {
+    #    ....
+    #};
 ]
 
 header = """%compare-lengths


### PR DESCRIPTION
This change extends the parse_syscalls.py script to scan for a
__subsystem sentinal added to driver api declarations. It thens
generates a list that is passed into gen_kobject_list.py to extend
the subsystems list. This allows subsystems to be declared in the
code instead of a separate python list and provides a mechanism for
defining out-of-tree subsystems.

Signed-off-by: Corey Wharton <coreyw7@fb.com>