### PR TITLE
usb:msc: Stall data stage before sending error status

### DIFF
--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -479,6 +479,11 @@ static bool infoTransfer(void)
 
 static void fail(void)
 {
+	if (cbw.DataLength) {
+		/* Stall data stage */
+		usb_ep_set_stall(mass_ep_data[MSD_IN_EP_IDX].ep_addr);
+	}
+
 	csw.Status = CSW_FAILED;
 	sendCSW();
 }


### PR DESCRIPTION
When an unsupported SCSI command is received, an error status reply
is sent even if the Host expects data prior to the status.

This fix stalls the data reply before sending the error status.

Signed-off-by: Audun Korneliussen <audun.korneliussen@nordicsemi.no>