### PR TITLE
doc: gsg: Update SDK version

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -306,15 +306,15 @@ including: compiler, assembler, linker, and their dependencies.
          .. code-block:: bash
 
             cd ~
-            wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.11.1/zephyr-sdk-0.11.1-setup.run
+            wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.11.2/zephyr-sdk-0.11.2-setup.run
 
       #. Run the installation binary, installing the SDK in your home
-         folder :file:`~/zephyr-sdk-0.11.1`:
+         folder :file:`~/zephyr-sdk-0.11.2`:
 
          .. code-block:: bash
 
-            chmod +x zephyr-sdk-0.11.1-setup.run
-            ./zephyr-sdk-0.11.1-setup.run -- -d ~/zephyr-sdk-0.11.1
+            chmod +x zephyr-sdk-0.11.2-setup.run
+            ./zephyr-sdk-0.11.2-setup.run -- -d ~/zephyr-sdk-0.11.2
 
       #. Set environment variables to let the build system know where to
          find the toolchain programs:
@@ -322,7 +322,7 @@ including: compiler, assembler, linker, and their dependencies.
          .. code-block:: bash
 
             export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-            export ZEPHYR_SDK_INSTALL_DIR=~/zephyr-sdk-0.11.1
+            export ZEPHYR_SDK_INSTALL_DIR=~/zephyr-sdk-0.11.2
 
       The SDK contains a udev rules file that provides information
       needed to identify boards and grant hardware access permission to flash

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -237,19 +237,19 @@ Follow these steps to install the Zephyr SDK:
 
    .. code-block:: console
 
-      wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.11.1/zephyr-sdk-0.11.1-setup.run
+      wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.11.2/zephyr-sdk-0.11.2-setup.run
 
-   (You can change *0.11.1* to another version if needed; the `Zephyr
+   (You can change *0.11.2* to another version if needed; the `Zephyr
    Downloads`_ page contains all available SDK releases.)
 
 #. Run the installation binary, installing the SDK at
-   :file:`~/zephyr-sdk-0.11.1`:
+   :file:`~/zephyr-sdk-0.11.2`:
 
    .. code-block:: console
 
       cd <sdk download directory>
-      chmod +x zephyr-sdk-0.11.1-setup.run
-      ./zephyr-sdk-0.11.1-setup.run -- -d ~/zephyr-sdk-0.11.1
+      chmod +x zephyr-sdk-0.11.2-setup.run
+      ./zephyr-sdk-0.11.2-setup.run -- -d ~/zephyr-sdk-0.11.2
 
    You can pick another directory if you want. If this fails, make sure
    Zephyr's dependencies were installed as described in `Install Requirements
@@ -258,7 +258,7 @@ Follow these steps to install the Zephyr SDK:
 #. Set these :ref:`environment variables <env_vars>`:
 
    - set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``zephyr``
-   - set :envvar:`ZEPHYR_SDK_INSTALL_DIR` to :file:`$HOME/zephyr-sdk-0.11.1`
+   - set :envvar:`ZEPHYR_SDK_INSTALL_DIR` to :file:`$HOME/zephyr-sdk-0.11.2`
      (or wherever you chose to install the SDK)
 
 If you ever want to uninstall the SDK, just remove the directory where you


### PR DESCRIPTION
Several users have noticed that the SDK version in the GSG is outdated.
Update it to the latest, 0.11.2.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>