### PR TITLE
Replace IWDG_STM32_START_AT_BOOT by WDT_DISABLE_AT_BOOT

### DIFF
--- a/drivers/watchdog/Kconfig.stm32
+++ b/drivers/watchdog/Kconfig.stm32
@@ -11,15 +11,6 @@ menuconfig IWDG_STM32
 	help
 	  Enable IWDG driver for STM32 line of MCUs
 
-config IWDG_STM32_START_AT_BOOT
-	bool "Start IWDG during boot"
-	depends on IWDG_STM32
-	help
-	  Enable this setting to allow IWDG to be automatically started
-	  during device initialization. Note that once IWDG is started
-	  it must be reloaded before the counter reaches 0, otherwise
-	  the MCU will be reset.
-
 config IWDG_STM32_TIMEOUT
 	int "Value for IWDG timeout in [us]"
 	depends on IWDG_STM32

--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -151,7 +151,7 @@ static const struct wdt_driver_api iwdg_stm32_api = {
 
 static int iwdg_stm32_init(struct device *dev)
 {
-#ifdef CONFIG_IWDG_STM32_START_AT_BOOT
+#ifndef CONFIG_WDT_DISABLE_AT_BOOT
 	IWDG_TypeDef *iwdg = IWDG_STM32_STRUCT(dev);
 	struct wdt_timeout_cfg config = {
 		.window.max = CONFIG_IWDG_STM32_TIMEOUT / USEC_PER_MSEC,


### PR DESCRIPTION
With this patch, the flag specific flag IWDG_STM32_START_AT_BOOT
is replaced by the zephyr generic WDT_DISABLE_AT_BOOT.

Fix https://github.com/zephyrproject-rtos/zephyr/issues/21200

Signed-off-by: Francois Ramu <francois.ramu@st.com>