### PR TITLE
Fixes 10-bit ADC resolution on MEC1501

### DIFF
--- a/drivers/adc/adc_mchp_xec.c
+++ b/drivers/adc/adc_mchp_xec.c
@@ -168,12 +168,14 @@ static int adc_xec_start_read(struct device *dev,
 
 	/* Setup ADC resolution */
 	reg = adc_regs->sar_control_reg;
-	reg &= ~MCHP_ADC_SAR_CTRL_RES_MASK;
+	reg &= ~(MCHP_ADC_SAR_CTRL_RES_MASK |
+		 (1 << MCHP_ADC_SAR_CTRL_SHIFTD_POS));
 
 	if (sequence->resolution == 12) {
 		reg |= MCHP_ADC_SAR_CTRL_RES_12_BITS;
 	} else if (sequence->resolution == 10) {
 		reg |= MCHP_ADC_SAR_CTRL_RES_10_BITS;
+		reg |= MCHP_ADC_SAR_CTRL_SHIFTD_EN;
 	} else {
 		return -EINVAL;
 	}

--- a/west.yml
+++ b/west.yml
@@ -53,7 +53,7 @@ manifest:
       revision: 3b54187649cc9b37161d49918f1ad28ff7c7f830
       path: modules/hal/openisa
     - name: hal_microchip
-      revision: 85302959c0c659311cf90ac51d133e5ce19c9288
+      revision: 03c8819ac3105cc2aee295a8d330de0e665b705f
       path: modules/hal/microchip
     - name: hal_silabs
       revision: 9a3fe1af3a14bf88c86b9cda3bf2a0921d5a97a1


### PR DESCRIPTION
This points to an updated HAL which fixes the incorrect bits for 10-bit resolution. Also enable the hardware feature to right justify the ADC output data for 10-bit resolution.

Fixes #23202

Needs https://github.com/zephyrproject-rtos/hal_microchip/pull/8