### PR TITLE
Bluetooth: HCI: Re-organize vendor read static address handling

### DIFF
--- a/include/bluetooth/addr.h
+++ b/include/bluetooth/addr.h
@@ -10,6 +10,7 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_ADDR_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_ADDR_H_
 
+#include <string.h>
 #include <zephyr/types.h>
 
 #ifdef __cplusplus

--- a/include/drivers/bluetooth/hci_driver.h
+++ b/include/drivers/bluetooth/hci_driver.h
@@ -20,6 +20,7 @@
 #include <stdbool.h>
 #include <net/buf.h>
 #include <bluetooth/buf.h>
+#include <bluetooth/hci_vs.h>
 #include <device.h>
 
 #ifdef __cplusplus
@@ -94,6 +95,15 @@ int bt_recv(struct net_buf *buf);
  * @return 0 on success or negative error number on failure.
  */
 int bt_recv_prio(struct net_buf *buf);
+
+/** @brief Read static addresses from the controller.
+ *
+ *  @param addrs  Random static address and Identity Root (IR) array.
+ *  @param size   Size of array.
+ *
+ *  @return Number of addresses read.
+ */
+u8_t bt_read_static_addr(struct bt_hci_vs_static_addr addrs[], u8_t size);
 
 /** Possible values for the 'bus' member of the bt_hci_driver struct */
 enum bt_hci_driver_bus {

--- a/subsys/bluetooth/controller/hci/hci_internal.h
+++ b/subsys/bluetooth/controller/hci/hci_internal.h
@@ -49,6 +49,9 @@ void hci_num_cmplt_encode(struct net_buf *buf, u16_t handle, u8_t num);
 #endif
 int hci_vendor_cmd_handle(u16_t ocf, struct net_buf *cmd,
 			  struct net_buf **evt);
+u8_t hci_vendor_read_static_addr(struct bt_hci_vs_static_addr addrs[],
+				 u8_t size);
+void hci_vendor_read_key_hierarchy_roots(u8_t ir[16], u8_t er[16]);
 int hci_vendor_cmd_handle_common(u16_t ocf, struct net_buf *cmd,
 			     struct net_buf **evt);
 void *hci_cmd_complete(struct net_buf **buf, u8_t plen);

--- a/subsys/bluetooth/controller/hci/nordic/hci_vendor.c
+++ b/subsys/bluetooth/controller/hci/nordic/hci_vendor.c
@@ -1,0 +1,76 @@
+/* Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/types.h>
+#include <sys/byteorder.h>
+
+#include <bluetooth/addr.h>
+#include <bluetooth/hci_vs.h>
+
+#include <nrf.h>
+
+u8_t hci_vendor_read_static_addr(struct bt_hci_vs_static_addr addrs[],
+				 u8_t size)
+{
+	/* only one supported */
+	ARG_UNUSED(size);
+
+	if (((NRF_FICR->DEVICEADDR[0] != UINT32_MAX) ||
+	    ((NRF_FICR->DEVICEADDR[1] & UINT16_MAX) != UINT16_MAX)) &&
+	     (NRF_FICR->DEVICEADDRTYPE & 0x01)) {
+		sys_put_le32(NRF_FICR->DEVICEADDR[0], &addrs[0].bdaddr.val[0]);
+		sys_put_le16(NRF_FICR->DEVICEADDR[1], &addrs[0].bdaddr.val[4]);
+
+		/* The FICR value is a just a random number, with no knowledge
+		 * of the Bluetooth Specification requirements for random
+		 * static addresses.
+		 */
+		BT_ADDR_SET_STATIC(&addrs[0].bdaddr);
+
+		/* If no public address is provided and a static address is
+		 * available, then it is recommended to return an identity root
+		 * key (if available) from this command.
+		 */
+		if ((NRF_FICR->IR[0] != UINT32_MAX) &&
+		    (NRF_FICR->IR[1] != UINT32_MAX) &&
+		    (NRF_FICR->IR[2] != UINT32_MAX) &&
+		    (NRF_FICR->IR[3] != UINT32_MAX)) {
+			sys_put_le32(NRF_FICR->IR[0], &addrs[0].ir[0]);
+			sys_put_le32(NRF_FICR->IR[1], &addrs[0].ir[4]);
+			sys_put_le32(NRF_FICR->IR[2], &addrs[0].ir[8]);
+			sys_put_le32(NRF_FICR->IR[3], &addrs[0].ir[12]);
+		} else {
+			/* Mark IR as invalid */
+			(void)memset(addrs[0].ir, 0x00, sizeof(addrs[0].ir));
+		}
+
+		return 1;
+	}
+
+	return 0;
+}
+
+void hci_vendor_read_key_hierarchy_roots(u8_t ir[16], u8_t er[16])
+{
+	/* Mark IR as invalid.
+	 * No public address is available, and static address IR should be read
+	 * using Read Static Addresses command.
+	 */
+	(void)memset(ir, 0x00, 16);
+
+	/* Fill in ER if present */
+	if ((NRF_FICR->ER[0] != UINT32_MAX) &&
+	    (NRF_FICR->ER[1] != UINT32_MAX) &&
+	    (NRF_FICR->ER[2] != UINT32_MAX) &&
+	    (NRF_FICR->ER[3] != UINT32_MAX)) {
+		sys_put_le32(NRF_FICR->ER[0], &er[0]);
+		sys_put_le32(NRF_FICR->ER[1], &er[4]);
+		sys_put_le32(NRF_FICR->ER[2], &er[8]);
+		sys_put_le32(NRF_FICR->ER[3], &er[12]);
+	} else {
+		/* Mark ER as invalid */
+		(void)memset(er, 0x00, 16);
+	}
+}

--- a/subsys/bluetooth/controller/ll_sw/nrf.cmake
+++ b/subsys/bluetooth/controller/ll_sw/nrf.cmake
@@ -84,6 +84,11 @@ zephyr_library_sources(
   ll_sw/nordic/hal/nrf5/ticker.c
   )
 
+zephyr_library_sources_ifdef(
+  CONFIG_SOC_FAMILY_NRF
+  hci/nordic/hci_vendor.c
+  )
+
 zephyr_library_include_directories(
   ll_sw/nordic
   hci/nordic

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -5728,7 +5728,7 @@ void bt_setup_public_id_addr(void)
 }
 
 #if defined(CONFIG_BT_HCI_VS_EXT)
-static uint8_t bt_read_static_addr(struct bt_hci_vs_static_addr *addrs)
+u8_t bt_read_static_addr(struct bt_hci_vs_static_addr addrs[], u8_t size)
 {
 	struct bt_hci_rp_vs_read_static_addrs *rp;
 	struct net_buf *rsp;
@@ -5754,7 +5754,7 @@ static uint8_t bt_read_static_addr(struct bt_hci_vs_static_addr *addrs)
 	}
 
 	rp = (void *)rsp->data;
-	cnt = MIN(rp->num_addrs, CONFIG_BT_ID_MAX);
+	cnt = MIN(rp->num_addrs, size);
 
 	if (IS_ENABLED(CONFIG_BT_HCI_VS_EXT_DETECT) &&
 	    rsp->len != (sizeof(struct bt_hci_rp_vs_read_static_addrs) +
@@ -5776,8 +5776,6 @@ static uint8_t bt_read_static_addr(struct bt_hci_vs_static_addr *addrs)
 
 	return cnt;
 }
-#elif defined(CONFIG_BT_CTLR)
-uint8_t bt_read_static_addr(struct bt_hci_vs_static_addr *addrs);
 #endif /* CONFIG_BT_HCI_VS_EXT */
 
 int bt_setup_random_id_addr(void)
@@ -5789,7 +5787,7 @@ int bt_setup_random_id_addr(void)
 	if (!bt_dev.id_count) {
 		struct bt_hci_vs_static_addr addrs[CONFIG_BT_ID_MAX];
 
-		bt_dev.id_count = bt_read_static_addr(addrs);
+		bt_dev.id_count = bt_read_static_addr(addrs, CONFIG_BT_ID_MAX);
 
 		if (bt_dev.id_count) {
 			for (u8_t i = 0; i < bt_dev.id_count; i++) {


### PR DESCRIPTION
Add header definition for bt_read_static_addr function. Declaring it
without a header definition will not give any compilation error when
function definition changes.
Refactor nRF SoC specific code into nRF specific source files and
provide weak definitions when these are not implemented. This will make
it easier to add handlers per vendor.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>