### PR TITLE
DFU: add init function with area id as paramater

### DIFF
--- a/include/dfu/flash_img.h
+++ b/include/dfu/flash_img.h
@@ -27,6 +27,16 @@ struct flash_img_context {
 /**
  * @brief Initialize context needed for writing the image to the flash.
  *
+ * @param ctx     context to be initialized
+ * @param area_id flash area id of partition where the image should be written
+ *
+ * @return  0 on success, negative errno code on fail
+ */
+int flash_img_init_id(struct flash_img_context *ctx, u8_t area_id);
+
+/**
+ * @brief Initialize context needed for writing the image to the flash.
+ *
  * @param ctx context to be initialized
  *
  * @return  0 on success, negative errno code on fail

--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -227,13 +227,27 @@ size_t flash_img_bytes_written(struct flash_img_context *ctx)
 	return ctx->bytes_written;
 }
 
-int flash_img_init(struct flash_img_context *ctx)
+static void init_ctx(struct flash_img_context *ctx)
 {
 	ctx->bytes_written = 0;
 	ctx->buf_bytes = 0U;
 #ifdef CONFIG_IMG_ERASE_PROGRESSIVELY
 	ctx->off_last = -1;
 #endif
+}
+
+int flash_img_init_id(struct flash_img_context *ctx, u8_t area_id)
+{
+	init_ctx(ctx);
+
+	return flash_area_open(area_id,
+			       (const struct flash_area **)&(ctx->flash_area));
+}
+
+int flash_img_init(struct flash_img_context *ctx)
+{
+	init_ctx(ctx);
+
 	return flash_area_open(FLASH_AREA_IMAGE_SECONDARY,
 			       (const struct flash_area **)&(ctx->flash_area));
 }

--- a/tests/subsys/dfu/img_util/src/main.c
+++ b/tests/subsys/dfu/img_util/src/main.c
@@ -8,6 +8,30 @@
 #include <storage/flash_map.h>
 #include <dfu/flash_img.h>
 
+void test_init_id(void)
+{
+	struct flash_img_context ctx_no_id;
+	struct flash_img_context ctx_id;
+	int ret;
+
+	ret = flash_img_init(&ctx_no_id);
+	zassert_true(ret == 0, "Flash img init");
+
+	ret = flash_img_init_id(&ctx_id, DT_FLASH_AREA_IMAGE_1_ID);
+	zassert_true(ret == 0, "Flash img init id");
+
+	/* Verify that the default partition ID is IMAGE_1 */
+	zassert_equal(ctx_id.flash_area, ctx_no_id.flash_area,
+		      "Default partition ID is incorrect");
+
+	/* Note: IMAGE_0, not IMAGE_1 as above */
+	ret = flash_img_init_id(&ctx_id, DT_FLASH_AREA_IMAGE_0_ID);
+	zassert_true(ret == 0, "Flash img init id");
+
+	zassert_equal(ctx_id.flash_area->fa_id, DT_FLASH_AREA_IMAGE_0_ID,
+		      "Partition ID is not set correctly");
+}
+
 void test_collecting(void)
 {
 	const struct flash_area *fa;
@@ -86,6 +110,8 @@ void test_collecting(void)
 void test_main(void)
 {
 	ztest_test_suite(test_util,
-			ztest_unit_test(test_collecting));
+			ztest_unit_test(test_collecting),
+			ztest_unit_test(test_init_id)
+			);
 	ztest_run_test_suite(test_util);
 }


### PR DESCRIPTION
This allows flash_img.c to be used outside of mcuboot scope.
Add new call to not break existing code.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>