### PR TITLE
[DNM] include: posix: time: Make possible to include with CONFIG_ARCH_POSIX

### DIFF
--- a/include/posix/posix_types.h
+++ b/include/posix/posix_types.h
@@ -17,13 +17,19 @@
 extern "C" {
 #endif
 
+#ifndef __useconds_t_defined
 typedef unsigned long useconds_t;
+#endif
 
 /* time related attributes */
 #ifndef CONFIG_NEWLIB_LIBC
+#ifndef __clockid_t_defined
 typedef u32_t clockid_t;
+#endif
 #endif /*CONFIG_NEWLIB_LIBC */
+#ifndef __timer_t_defined
 typedef unsigned long timer_t;
+#endif
 
 #ifdef CONFIG_PTHREAD_IPC
 /* Thread attributes */

--- a/include/posix/time.h
+++ b/include/posix/time.h
@@ -43,7 +43,12 @@ struct itimerspec {
 
 #else /* CONFIG_NEWLIB_LIBC */
 /* Not Newlib */
-#include <sys/timespec.h>
+# ifdef CONFIG_ARCH_POSIX
+#  include <bits/types/struct_timespec.h>
+#  include <bits/types/struct_itimerspec.h>
+# else
+#  include <sys/timespec.h>
+# endif
 #endif /* CONFIG_NEWLIB_LIBC */
 
 #include <kernel.h>


### PR DESCRIPTION
While CONFIG_ARCH_POSIX in general isn't compatible with Zephyr POSIX
subsys (because CONFIG_ARCH_POSIX itself is implemented on top of
POSIX, so there're obvious conflicts), apply workaround to allow to
at least use clock_gettime() and clock_settime() functions.

This change is grounded in upcoming support for date manipulation
commands for Zephyr shell, which are implemented using functions
above. There's no guarantee that CONFIG_ARCH_POSIX and Zephyr POSIX
subsys will coexist for any other usecase. (But the change is
relatively clean and is definitely in the right direction of
prototyping ways of such a coexistance.)

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>