### PR TITLE
doc: release notes: Add information for Xtensa SoCs and boards

### DIFF
--- a/doc/releases/release-notes-2.2.rst
+++ b/doc/releases/release-notes-2.2.rst
@@ -191,7 +191,13 @@ Boards & SoC Support
    * ST STM32L152RET6
    * ST STM32L452XC
    * ST STM32G031
+   * Intel Apollolake Audio DSP
 
+* Added support for these Xtensa boards:
+
+  .. rst-class:: rst-columns
+
+   * Up Squared board Audio DSP
 
 * Added support for these ARM boards:
 


### PR DESCRIPTION
Mention the Intel Apollolake Audio DSP SoC and board that were added
for Zephyr 2.2.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>