### PR TITLE
Bluetooth: host: Fix local RPA not valid in connection complete

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1440,7 +1440,8 @@ static void enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 	    conn->role == BT_HCI_ROLE_SLAVE) {
 		bt_addr_le_copy(&conn->le.init_addr, &peer_addr);
 
-		if (IS_ENABLED(CONFIG_BT_PRIVACY)) {
+		if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
+		    bt_addr_cmp(&evt->local_rpa, BT_ADDR_ANY) != 0) {
 			bt_addr_copy(&conn->le.resp_addr.a, &evt->local_rpa);
 			conn->le.resp_addr.type = BT_ADDR_LE_RANDOM;
 		} else {
@@ -1463,7 +1464,8 @@ static void enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 	    conn->role == BT_HCI_ROLE_MASTER) {
 		bt_addr_le_copy(&conn->le.resp_addr, &peer_addr);
 
-		if (IS_ENABLED(CONFIG_BT_PRIVACY)) {
+		if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
+		    bt_addr_cmp(&evt->local_rpa, BT_ADDR_ANY) != 0) {
 			bt_addr_copy(&conn->le.init_addr.a, &evt->local_rpa);
 			conn->le.init_addr.type = BT_ADDR_LE_RANDOM;
 		} else {


### PR DESCRIPTION
Fix connection complete event handling when the local RPA is not valid.
This can happen when the controller was not instructed to use an RPA
address, or the local IRK was set to an all zero IRK.

Fixes: #23222