### PR TITLE
stm32: nucleo_g474re: reflash board successively with pyocd

### DIFF
--- a/boards/arm/nucleo_g474re/board.cmake
+++ b/boards/arm/nucleo_g474re/board.cmake
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-board_runner_args(pyocd "--target=stm32g474retx")
+
+# use target=stm32g474rbtx instead of stm32g474retx
+# to allow board re-flashing (see PR #23230)
+board_runner_args(pyocd "--target=stm32g474rbtx")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nucleo_g474re/nucleo_g474re.yaml
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.yaml
@@ -6,8 +6,8 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 32
-flash: 128
+ram: 128
+flash: 512
 supported:
   - arduino_gpio
   - arduino_i2c

--- a/soc/arm/st_stm32/stm32g4/Kconfig.defconfig.stm32g474re
+++ b/soc/arm/st_stm32/stm32g4/Kconfig.defconfig.stm32g474re
@@ -6,11 +6,9 @@
 if SOC_STM32G474XX
 
 config SOC
-	string
 	default "stm32g474xx"
 
 config NUM_IRQS
-	int
 	default 102
 
 endif # SOC_STM32G474XX


### PR DESCRIPTION
It happens that the nucleo_g474re board  cannot be flashed a second time and reboot with pyocd.
(copy binary to the target board is still functional)
This patch changes the board_runner_args(pyocd "--target=stm32g474rbtx") in the board.cmake 
Use west flash to program the target board /zephyr/boards/arm/nucleo_g474re

Signed-off-by: Francois Ramu francois.ramu@st.com

Fixes #23351