### PR TITLE
kconfig: Fix typo in ARM_MPU help

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/mpu/Kconfig
+++ b/arch/arm/core/aarch32/cortex_m/mpu/Kconfig
@@ -16,7 +16,7 @@ config ARM_MPU
 	  MCU implements Memory Protection Unit.
 
 	  Notes:
-	  The ARMv6-M and ARMv8-M MPU architecture requires a power-of-two
+	  The ARMv6-M and ARMv7-M MPU architecture requires a power-of-two
 	  alignment of MPU region base address and size.
 
 	  The NXP MPU as well as the ARMv8-M MPU do not require MPU regions


### PR DESCRIPTION
The ARMv7-M MPU requires power-of-two alignment, not the ARMv8-M MPU, as
noted a few lines later.

Signed-off-by: Anders Montonen <Anders.Montonen@iki.fi>