### PR TITLE
west.yml: update hal nordic to fix _S/_NS peripheral translation

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -47,7 +47,7 @@ manifest:
       revision: a12d92816a53a521d79cefcf5c38b9dc8a4fed6e
       path: modules/hal/cypress
     - name: hal_nordic
-      revision: 12d7647870888e4cb0e421f2b26884c2e76915ac
+      revision: 948cdb855771bec67d9ee5a327b9128e87fd6b2e
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 3b54187649cc9b37161d49918f1ad28ff7c7f830


### PR DESCRIPTION
Update hal_nordic, to pick a fix in _S/_NS
peripheral base address translation.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>