### PR TITLE
drivers: ieee802154: Rem trx_state variable

### DIFF
--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
@@ -81,7 +81,7 @@
 		compatible = "atmel,rf2xx";
 		reg = <0x0>;
 		label = "RF2XX_0";
-		spi-max-frequency = <8000000>;
+		spi-max-frequency = <6000000>;
 		irq-gpios = <&portb 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		reset-gpios = <&portb 15 GPIO_ACTIVE_LOW>;
 		slptr-gpios = <&porta 20 GPIO_ACTIVE_HIGH>;

--- a/drivers/ieee802154/ieee802154_rf2xx.h
+++ b/drivers/ieee802154/ieee802154_rf2xx.h
@@ -1,7 +1,7 @@
 /* ieee802154_rf2xx.h - IEEE 802.15.4 Driver definition for ATMEL RF2XX */
 
 /*
- * Copyright (c) 2019 Gerson Fernando Budke
+ * Copyright (c) 2019-2020 Gerson Fernando Budke
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -139,6 +139,7 @@ struct rf2xx_context {
 	u8_t pkt_ed;
 	s8_t trx_rssi_base;
 	u8_t trx_version;
+	u8_t rx_phr;
 };
 
 #endif /* ZEPHYR_DRIVERS_IEEE802154_IEEE802154_RF2XX_H_ */

--- a/drivers/ieee802154/ieee802154_rf2xx.h
+++ b/drivers/ieee802154/ieee802154_rf2xx.h
@@ -65,14 +65,6 @@ enum rf2xx_trx_state_trac_t {
 	RF2XX_TRX_PHY_STATE_TRAC_INVALID                = 0x07,
 };
 
-enum rf2xx_trx_state_t {
-	RF2XX_TRX_PHY_STATE_INITIAL,
-	RF2XX_TRX_PHY_STATE_IDLE,
-	RF2XX_TRX_PHY_STATE_SLEEP,
-	RF2XX_TRX_PHY_BUSY_RX,
-	RF2XX_TRX_PHY_BUSY_TX,
-};
-
 enum rf2xx_trx_model_t {
 	RF2XX_TRX_MODEL_INV     = 0x00,
 	RF2XX_TRX_MODEL_230     = 0x02,
@@ -127,11 +119,8 @@ struct rf2xx_context {
 			      CONFIG_IEEE802154_RF2XX_RX_STACK_SIZE);
 	struct k_sem trx_isr_lock;
 	struct k_sem trx_tx_sync;
-	struct k_timer trx_isr_timeout;
-	struct k_mutex phy_mutex;
 
 	enum rf2xx_trx_model_t trx_model;
-	enum rf2xx_trx_state_t trx_state;
 	enum rf2xx_trx_state_trac_t trx_trac;
 
 	u8_t mac_addr[8];

--- a/drivers/ieee802154/ieee802154_rf2xx_iface.h
+++ b/drivers/ieee802154/ieee802154_rf2xx_iface.h
@@ -1,7 +1,7 @@
 /* ieee802154_rf2xx_iface.h - ATMEL RF2XX transceiver interface */
 
 /*
- * Copyright (c) 2019 Gerson Fernando Budke
+ * Copyright (c) 2019-2020 Gerson Fernando Budke
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -106,5 +106,20 @@ void rf2xx_iface_frame_read(struct device *dev,
 void rf2xx_iface_frame_write(struct device *dev,
 			     u8_t *data,
 			     u8_t length);
+
+/**
+ * @brief Reads sram data from the transceiver
+ *
+ * This function reads the sram data of the transceiver.
+ *
+ * @param[in]   dev     Transceiver device instance
+ * @param[in]   address Start address to be read
+ * @param[out]  data    Pointer to the location to store data
+ * @param[in]   length  Number of bytes to be read from the sram space
+ */
+void rf2xx_iface_sram_read(struct device *dev,
+			    u8_t address,
+			    u8_t *data,
+			    u8_t length);
 
 #endif /* ZEPHYR_DRIVERS_IEEE802154_IEEE802154_RF2XX_IFACE_H_ */


### PR DESCRIPTION
The rx timeout timer callback need update **trx_state** variable and this variable is protected by a **mutex**. Because of that, when compiling the system with **CONFIG_ASSERT=y** the system reports _ASSERTION FAIL [!arch_is_in_isr()] @ ZEPHYR_BASE/kernel/include/ksched.h:262_.

This refactor the driver remove **trx_state** variable dependency and consequently removes **phy_mutex** and **rx timeout timer** to be compliant with kernel rules.

Fixes: #23198

This PR includes #22511