### PR TITLE
codeowners: add subsys/dfu codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -399,6 +399,7 @@
 /subsys/canbus/                           @alexanderwachter
 /subsys/cpp/                              @pabigot @vanwinkeljan
 /subsys/debug/                            @nashif
+/subsys/dfu/                              @nvlsianpu
 /subsys/tracing/                          @nashif @wentongwu
 /subsys/debug/asan_hacks.c                @vanwinkeljan @aescolar
 /subsys/disk/disk_access_spi_sdhc.c       @JunYangNXP


### PR DESCRIPTION
Added dfu support subsystem codeowner
Before this subystem was orphaned.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>