### PR TITLE
west.yml: update hal stm32xx modules

### DIFF
--- a/modules/Kconfig.stm32
+++ b/modules/Kconfig.stm32
@@ -342,6 +342,12 @@ config USE_STM32_HAL_PCD_EX
 	  Enable STM32Cube Extended USB Peripheral Controller (PCD) HAL module
 	  driver
 
+config USE_STM32_HAL_PSSI
+	bool
+	help
+	  Enable STM32Cube Parallel Synchronous Slave Interface (PSSI)
+	  HAL module driver
+
 config USE_STM32_HAL_PWR
 	bool
 	help

--- a/modules/Kconfig.stm32
+++ b/modules/Kconfig.stm32
@@ -127,6 +127,11 @@ config USE_STM32_HAL_ETH
 	help
 	  Enable STM32Cube Ethernet (ETH) HAL module driver
 
+config USE_STM32_HAL_ETH_EX
+	bool
+	help
+	  Enable STM32Cube Extended Ethernet (ETH) HAL module driver
+
 config USE_STM32_HAL_EXTI
 	bool
 	help

--- a/west.yml
+++ b/west.yml
@@ -68,7 +68,7 @@ manifest:
       revision: fa481784b3c49780f18d50bafe00390ccb62b2ec
       path: modules/hal/st
     - name: hal_stm32
-      revision: dee4413253623ec575bb8b58abd56f91afe903bb
+      revision: 37dcc0e120bb2bb99d3ee3b99dbbcf2bffe50258
       path: modules/hal/stm32
     - name: hal_ti
       revision: b25d4b83b16e52f501f8cd360f4efb8c31ffb578


### PR DESCRIPTION
This updates the stm32cube/stm32xx

Requires https://github.com/zephyrproject-rtos/hal_stm32/pull/47

Signed-off-by: Francois Ramu <francois.ramu@st.com>