### PR TITLE
boards: arm: Fix broken links in nxp board docs

### DIFF
--- a/boards/arm/lpcxpresso55s69/doc/index.rst
+++ b/boards/arm/lpcxpresso55s69/doc/index.rst
@@ -201,7 +201,7 @@ should see the following message in the terminal:
    https://www.nxp.com/docs/en/data-sheet/LPC55S6x.pdf
 
 .. _LPC55S69 Reference Manual:
-   https://www.nxp.com/docs/en/user-guide/UM11126.pdf
+   https://www.nxp.com/webapp/Download?colCode=UM11126
 
 .. _LPCXPRESSO55S69 Website:
    https://www.nxp.com/products/processors-and-microcontrollers/arm-based-processors-and-mcus/lpc-cortex-m-mcus/lpc5500-cortex-m33/lpcxpresso55s69-development-board:LPC55S69-EVK

--- a/boards/arm/mimxrt1010_evk/doc/index.rst
+++ b/boards/arm/mimxrt1010_evk/doc/index.rst
@@ -49,7 +49,7 @@ these references:
 - `i.MX RT1010 Datasheet`_
 - `i.MX RT1010 Reference Manual`_
 - `MIMXRT1010-EVK Website`_
-- `MIMXRT1010-EVK Quick Reference Guide`_
+- `MIMXRT1010-EVK User Guide`_
 - `MIMXRT1010-EVK Design Files`_
 
 Supported Features
@@ -177,8 +177,8 @@ see the following message in the terminal:
 .. _MIMXRT1010-EVK Website:
    https://www.nxp.com/MIMXRT1010-EVK
 
-.. _MIMXRT1010-EVK Quick Reference Guide:
-   https://www.nxp.com/docs/en/quick-reference-guide/iMX-RT1010-EVK-QSG.pdf
+.. _MIMXRT1010-EVK User Guide:
+   https://www.nxp.com/webapp/Download?colCode=MIMXRT1010EVKHUG
 
 .. _MIMXRT1010-EVK Design Files:
    https://www.nxp.com/downloads/en/printed-circuit-boards/IMXRT1010-EVK-DESIGN-FILES.7z
@@ -190,4 +190,4 @@ see the following message in the terminal:
    https://www.nxp.com/docs/en/data-sheet/IMXRT1010CEC.pdf
 
 .. _i.MX RT1010 Reference Manual:
-   https://www.nxp.com/docs/en/reference-manual/IMXRT1010RM.pdf
+   https://www.nxp.com/webapp/Download?colCode=IMXRT1010RM

--- a/boards/arm/mimxrt1015_evk/doc/index.rst
+++ b/boards/arm/mimxrt1015_evk/doc/index.rst
@@ -183,7 +183,7 @@ see the following message in the terminal:
    https://www.nxp.com/support/developer-resources/run-time-software/i.mx-developer-resources/i.mx-rt1015-evaluation-kit:MIMXRT1015-EVK
 
 .. _MIMXRT1015-EVK Quick Reference Guide:
-   https://www.nxp.com/docs/en/quick-reference-guide/IMXRT1015QSG.pdf
+   https://www.nxp.com/webapp/Download?colCode=IMXRT1015QSG
 
 .. _MIMXRT1015-EVK Design Files:
    https://www.nxp.com/webapp/Download?colCode=MIMXRT1015-EVK-REVB-DS
@@ -195,4 +195,4 @@ see the following message in the terminal:
    https://www.nxp.com/docs/en/data-sheet/IMXRT1015CEC.pdf
 
 .. _i.MX RT1015 Reference Manual:
-   https://www.nxp.com/docs/en/reference-manual/IMXRT1015RM.pdf
+   https://www.nxp.com/webapp/Download?colCode=IMXRT1015RM

--- a/boards/arm/mimxrt1020_evk/doc/index.rst
+++ b/boards/arm/mimxrt1020_evk/doc/index.rst
@@ -250,7 +250,7 @@ should see the following message in the terminal:
    https://www.nxp.com/support/developer-resources/run-time-software/i.mx-developer-resources/i.mx-rt1020-evaluation-kit:MIMXRT1020-EVK
 
 .. _MIMXRT1020-EVK User Guide:
-   https://www.nxp.com/docs/en/user-guide/MIMXRT1020EVKHUG.pdf
+   https://www.nxp.com/webapp/Download?colCode=MIMXRT1020EVKHUG
 
 .. _MIMXRT1020-EVK Design Files:
    https://www.nxp.com/webapp/Download?colCode=MIMXRT1020-EVK-Design-Files

--- a/boards/arm/mimxrt1060_evk/doc/index.rst
+++ b/boards/arm/mimxrt1060_evk/doc/index.rst
@@ -305,7 +305,7 @@ should see the following message in the terminal:
    https://www.nxp.com/support/developer-resources/software-development-tools/mcuxpresso-software-and-tools/mimxrt1060-evk-i.mx-rt1060-evaluation-kit:MIMXRT1060-EVK
 
 .. _MIMXRT1060-EVK User Guide:
-   https://www.nxp.com/webapp/Download?colCode=UM11151
+   https://www.nxp.com/webapp/Download?colCode=UM11151UG
 
 .. _MIMXRT1060-EVK Schematics:
    https://www.nxp.com/webapp/Download?colCode=MIMXRT1060-EVK-DESIGN-FILE-A2

--- a/boards/arm/mimxrt1064_evk/doc/index.rst
+++ b/boards/arm/mimxrt1064_evk/doc/index.rst
@@ -293,7 +293,7 @@ should see the following message in the terminal:
    https://www.nxp.com/support/developer-resources/run-time-software/i.mx-developer-resources/mimxrt1064-evk-i.mx-rt1064-evaluation-kit:MIMXRT1064-EVK
 
 .. _MIMXRT1064-EVK Quick Reference Guide:
-   https://www.nxp.com/docs/en/quick-reference-guide/IMXRT1064QSG.pdf
+   https://www.nxp.com/webapp/Download?colCode=IMXRT1064QSG
 
 .. _MIMXRT1064-EVK Schematics:
    https://www.nxp.com/webapp/Download?colCode=i.MXRT160EVKDS&Parent_nodeId=1537930933174731284155&Parent_pageType=product
@@ -305,4 +305,4 @@ should see the following message in the terminal:
    https://www.nxp.com/docs/en/data-sheet/IMXRT1064CEC.pdf
 
 .. _i.MX RT1064 Reference Manual:
-   https://www.nxp.com/docs/en/reference-manual/IMXRT1064RM.pdf
+   https://www.nxp.com/webapp/Download?colCode=IMXRT1064RM


### PR DESCRIPTION
Fixes broken links in several imx rt and lpc board documentation pages.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>