### PR TITLE
doc: security: Create a vulnerabilities report

### DIFF
--- a/doc/security/index.rst
+++ b/doc/security/index.rst
@@ -14,3 +14,4 @@ for ensuring security is addressed within the Zephyr project.
    secure-coding.rst
    sensor-threat.rst
    hardening-tool.rst
+   vulnerabilities.rst

--- a/doc/security/vulnerabilities.rst
+++ b/doc/security/vulnerabilities.rst
@@ -1,0 +1,25 @@
+.. _vulnerabilities:
+
+Vulnerabilities
+###############
+
+This page collects all of the vulnerabilities that are discovered and
+fixed in each release.  It will also often have more details than is
+available in the releases.  Some vulnerabilities are deemed to be
+sensitive, and will not be publically discussed until there is
+sufficient time to fix them.  Because the release notes are locked to
+a version, the information here can be updated after the embargo is
+lifted.
+
+Release 1.14.0 and 2.0.0
+------------------------
+
+The following security vulnerability (CVE) was addressed in this
+release:
+
+* Fixes CVE-2019-9506: The Bluetooth BR/EDR specification up to and
+  including version 5.1 permits sufficiently low encryption key length
+  and does not prevent an attacker from influencing the key length
+  negotiation. This allows practical brute-force attacks (aka "KNOB")
+  that can decrypt traffic and inject arbitrary ciphertext without the
+  victim noticing.


### PR DESCRIPTION
In addition to having security vulnerability fixes reported within each
release note page, consolidate all of them in a new vulnerabilities
document.

This gives us two advantages: 1. The vulnerabilities can easily be
referenced in a single place, which is useful for someone trying to
cross reference against CVE lists, and 2. It allows a release to be made
with just CVE numbers when issues are under embargo, and the details can
be added to this vulnerabilities page.  The release notes will be locked
to a tag, and updates will not be visible.

Signed-off-by: David Brown <david.brown@linaro.org>