### PR TITLE
Fix SAM UART driver irq_update implementation

### DIFF
--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -315,9 +315,9 @@ static int uart_sam_irq_is_pending(struct device *dev)
 
 static int uart_sam_irq_update(struct device *dev)
 {
-	volatile Uart * const uart = DEV_CFG(dev)->regs;
+	ARG_UNUSED(dev);
 
-	return (uart->UART_SR & UART_SR_TXEMPTY);
+	return 1;
 }
 
 static void uart_sam_irq_callback_set(struct device *dev,

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -300,9 +300,9 @@ static int usart_sam_irq_is_pending(struct device *dev)
 
 static int usart_sam_irq_update(struct device *dev)
 {
-	volatile Usart * const usart = DEV_CFG(dev)->regs;
+	ARG_UNUSED(dev);
 
-	return (usart->US_CSR & US_CSR_TXEMPTY);
+	return 1;
 }
 
 static void usart_sam_irq_callback_set(struct device *dev,


### PR DESCRIPTION
The current `irq_update` UART API function implementation for the Atmel SAM family U(S)ART driver is not in compliance with the API documentation, which specifies that the function must always return `1`.

This patch fixes the API implementation to unconditionally return `1`.

Fixes #23278.