### PR TITLE
Bluetooth: host: Allow to initiate pairing without OOB present

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -2622,12 +2622,10 @@ static bool sec_level_reachable(struct bt_conn *conn)
 		return true;
 	case BT_SECURITY_L3:
 		return get_io_capa() != BT_SMP_IO_NO_INPUT_OUTPUT ||
-		       (bt_auth && bt_auth->oob_data_request && oobd_present);
+		       (bt_auth && bt_auth->oob_data_request);
 	case BT_SECURITY_L4:
 		return (get_io_capa() != BT_SMP_IO_NO_INPUT_OUTPUT ||
-			(bt_auth && bt_auth->oob_data_request &&
-			 oobd_present)) &&
-		       sc_supported;
+			(bt_auth && bt_auth->oob_data_request)) && sc_supported;
 	default:
 		return false;
 	}


### PR DESCRIPTION
When OOB callbacks are present it is possible to achieve authenticated
pairing without having the remote OOB data present. Using OOB with
LE Secure Connection only one side of the pairing procedure is required
to have the OOB data present. If we have given the remote our OOB data
then pairing can proceed.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>