### PR TITLE
usb: Set cdc_acm initialization level to POST_KERNEL

### DIFF
--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -1048,7 +1048,7 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 			    CONFIG_USB_CDC_ACM_DEVICE_NAME "_" #x,	\
 			    &cdc_acm_init, &cdc_acm_dev_data_##x,	\
 			    &cdc_acm_config_##x,			\
-			    APPLICATION,				\
+			    POST_KERNEL,				\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &cdc_acm_driver_api);
 


### PR DESCRIPTION
OpenThread Network-Coprocessor (https://github.com/zephyrproject-rtos/zephyr/pull/23249) uses ACM. OpenThread is started at an earlier init stage. Start ACM earlier to be ready in time for OpenThread.