### PR TITLE
drivers: serial: uart_sam0: Fix interrupt connection

### DIFF
--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -940,7 +940,7 @@ static const struct uart_driver_api uart_sam0_driver_api = {
 #define UART_SAM0_IRQ_HANDLER_FUNC(n)					\
 	.irq_config_func = uart_sam0_irq_config_##n,
 
-#ifdef DT_ATMEL_SAM0_UART_0_IRQ_3
+#ifdef DT_INST_0_ATMEL_SAM0_UART_IRQ_3
 #define UART_SAM0_IRQ_HANDLER(n)					\
 static void uart_sam0_irq_config_##n(struct device *dev)		\
 {									\


### PR DESCRIPTION
This commit fixes the multiple SERCOM interrupt handling for the SAM
D5x and E5x devices by replacing the obsolete device tree symbol with
the new `DT_INST` symbol.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #23281

p.s. This could potentially be handled in a more elegant way in the future; but as far as this PR goes, it only fixes the reference to the now obsolete device tree symbol.