### PR TITLE
Bluetooth: controller: nRF51x: Force optimize for speed

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -577,7 +577,8 @@ config BT_CTLR_ZLI
 	  else will impact controller stability.
 
 config BT_CTLR_OPTIMIZE_FOR_SPEED
-	bool "Optimize for Speed"
+	prompt "Optimize for Speed" if !(SOC_SERIES_NRF51X && BT_CTLR_LE_ENC)
+	bool
 	default y if BT_CTLR_LE_ENC
 	help
 	  Optimize compilation of controller for execution speed.


### PR DESCRIPTION
Make BT_CTLR_OPTIMIZE_FOR_SPEED option so that it is not
user selectable for nRF51x series SoC with encrypted
connections support.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>