### PR TITLE
Bluetooth: Mesh: Fix cdb key update iteration

### DIFF
--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -2299,7 +2299,7 @@ static struct key_update *cdb_key_update_find(bool app_key, u16_t key_idx,
 	match = NULL;
 	*free_slot = NULL;
 
-	for (i = 0; i < ARRAY_SIZE(key_updates); i++) {
+	for (i = 0; i < ARRAY_SIZE(cdb_key_updates); i++) {
 		struct key_update *update = &cdb_key_updates[i];
 
 		if (!update->valid) {


### PR DESCRIPTION
Fixes copy/paste error taking the size of the the wrong array.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>