### PR TITLE
net: openthread: Unify IS_ENABLED macro usage

### DIFF
--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -153,14 +153,10 @@ void platformRadioProcess(otInstance *aInstance)
 
 		sState = OT_RADIO_STATE_RECEIVE;
 
-#if OPENTHREAD_ENABLE_DIAG
-
-		if (otPlatDiagModeGet()) {
+		if (IS_ENABLED(OPENTHREAD_ENABLE_DIAG) && otPlatDiagModeGet()) {
 			otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame,
 						    result);
-		} else
-#endif
-		{
+		} else {
 			if (sTransmitFrame.mPsdu[0] & IEEE802154_AR_FLAG_SET) {
 				if (ack_frame.mLength == 0) {
 					LOG_DBG("No ACK received.");


### PR DESCRIPTION
Older OT code used preprocessor #if conditionals, while newer code
used IS_ENABLED macro. Unify the approach by switching to the latter
option.

Additinally, fix inclusion issue that came out after switching to
IS_ENABLED.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>