### PR TITLE
Support Ethernet on SAM E5x

### DIFF
--- a/boards/arm/atsame54_xpro/Kconfig.defconfig
+++ b/boards/arm/atsame54_xpro/Kconfig.defconfig
@@ -3,6 +3,23 @@
 # Copyright (c) 2019 Benjamin Valentin
 # SPDX-License-Identifier: Apache-2.0
 
+if BOARD_ATSAME54_XPRO
+
 config BOARD
 	default "atsame54_xpro"
-	depends on BOARD_ATSAME54_XPRO
+
+if NETWORKING
+
+config NET_L2_ETHERNET
+	default y
+
+config ETH_SAM_GMAC
+	default y if NET_L2_ETHERNET
+
+choice ETH_SAM_GMAC_MAC_SELECT
+	default ETH_SAM_GMAC_RANDOM_MAC
+endchoice
+
+endif # NETWORKING
+
+endif # BOARD_ATSAME54_XPRO

--- a/boards/arm/atsame54_xpro/atsame54_xpro.dts
+++ b/boards/arm/atsame54_xpro/atsame54_xpro.dts
@@ -81,3 +81,7 @@
 &usb0 {
 	status = "okay";
 };
+
+&gmac {
+	status = "okay";
+};

--- a/boards/arm/atsame54_xpro/atsame54_xpro.yaml
+++ b/boards/arm/atsame54_xpro/atsame54_xpro.yaml
@@ -15,3 +15,4 @@ supported:
   - spi
   - i2c
   - usb_device
+  - netif:eth

--- a/boards/arm/atsame54_xpro/pinmux.c
+++ b/boards/arm/atsame54_xpro/pinmux.c
@@ -106,6 +106,20 @@ static int board_pinmux_init(struct device *dev)
 	pinmux_pin_set(muxa, 25, PINMUX_FUNC_H);
 	pinmux_pin_set(muxa, 24, PINMUX_FUNC_H);
 #endif
+
+#if DT_HAS_NODE(DT_NODELABEL(gmac))
+	pinmux_pin_set(muxa, 14, PINMUX_FUNC_L);	/* PA14 = GTXCK */
+	pinmux_pin_set(muxa, 17, PINMUX_FUNC_L);	/* PA17 = GTXEN */
+	pinmux_pin_set(muxa, 18, PINMUX_FUNC_L);	/* PA18 = GTX0 */
+	pinmux_pin_set(muxa, 19, PINMUX_FUNC_L);	/* PA19 = GTX1 */
+	pinmux_pin_set(muxc, 20, PINMUX_FUNC_L);	/* PC20 = GRXDV */
+	pinmux_pin_set(muxa, 13, PINMUX_FUNC_L);	/* PA13 = GRX0 */
+	pinmux_pin_set(muxa, 12, PINMUX_FUNC_L);	/* PA12 = GRX1 */
+	pinmux_pin_set(muxa, 15, PINMUX_FUNC_L);	/* PA15 = GRXER */
+	pinmux_pin_set(muxc, 11, PINMUX_FUNC_L);	/* PC11 = GMDC */
+	pinmux_pin_set(muxc, 12, PINMUX_FUNC_L);	/* PC12 = GMDIO */
+#endif
+
 	return 0;
 }
 

--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -18,6 +18,7 @@ config ETH_SAM_GMAC_QUEUES
 	range 1 $(dt_node_int_prop_int,/soc/ethernet@40050088,num-queues) if SOC_SERIES_SAME70 || \
 									     SOC_SERIES_SAMV71
 	range 1 $(dt_node_int_prop_int,/soc/ethernet@40034000,num-queues) if SOC_SERIES_SAM4E
+	range 1 $(dt_node_int_prop_int,/soc/ethernet@42000800,num-queues) if SOC_SERIES_SAME54
 	help
 	  Select the number of hardware queues used by the driver. Packets will be
 	  routed to appropriate queues based on their priority.

--- a/drivers/ethernet/eth_sam0_gmac.h
+++ b/drivers/ethernet/eth_sam0_gmac.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2020 Stephanos Ioannidis <root@stephanos.io>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_ETHERNET_ETH_SAM0_GMAC_H_
+#define ZEPHYR_DRIVERS_ETHERNET_ETH_SAM0_GMAC_H_
+
+/*
+ * Map the SAM-family DFP GMAC register names to the SAM0-family DFP GMAC
+ * register names.
+ */
+#define GMAC_NCR        NCR.reg
+#define GMAC_NCFGR      NCFGR.reg
+#define GMAC_NSR        NSR.reg
+#define GMAC_UR         UR.reg
+#define GMAC_DCFGR      DCFGR.reg
+#define GMAC_TSR        TSR.reg
+#define GMAC_RBQB       RBQB.reg
+#define GMAC_TBQB       TBQB.reg
+#define GMAC_RSR        RSR.reg
+#define GMAC_ISR        ISR.reg
+#define GMAC_IER        IER.reg
+#define GMAC_IDR        IDR.reg
+#define GMAC_IMR        IMR.reg
+#define GMAC_MAN        MAN.reg
+#define GMAC_RPQ        RPQ.reg
+#define GMAC_TPQ        TPQ.reg
+#define GMAC_TPSF       TPSF.reg
+#define GMAC_RPSF       RPSF.reg
+#define GMAC_RJFML      RJFML.reg
+#define GMAC_HRB        HRB.reg
+#define GMAC_HRT        HRT.reg
+#define GMAC_SA         Sa
+#define GMAC_WOL        WOL.reg
+#define GMAC_IPGS       IPGS.reg
+#define GMAC_SVLAN      SVLAN.reg
+#define GMAC_TPFCP      TPFCP.reg
+#define GMAC_SAMB1      SAMB1.reg
+#define GMAC_SAMT1      SAMT1.reg
+#define GMAC_NSC        NSC.reg
+#define GMAC_SCL        SCL.reg
+#define GMAC_SCH        SCH.reg
+#define GMAC_EFTSH      EFTSH.reg
+#define GMAC_EFRSH      EFRSH.reg
+#define GMAC_PEFTSH     PEFTSH.reg
+#define GMAC_PEFRSH     PEFRSH.reg
+#define GMAC_OTLO       OTLO.reg
+#define GMAC_OTHI       OTHI.reg
+#define GMAC_FT         FT.reg
+#define GMAC_BCFT       BCFT.reg
+#define GMAC_MFT        MFT.reg
+#define GMAC_PFT        PFT.reg
+#define GMAC_BFT64      BFT64.reg
+#define GMAC_TBFT127    TBFT127.reg
+#define GMAC_TBFT255    TBFT255.reg
+#define GMAC_TBFT511    TBFT511.reg
+#define GMAC_TBFT1023   TBFT1023.reg
+#define GMAC_TBFT1518   TBFT1518.reg
+#define GMAC_GTBFT1518  GTBFT1518.reg
+#define GMAC_TUR        TUR.reg
+#define GMAC_SCF        SCF.reg
+#define GMAC_MCF        MCF.reg
+#define GMAC_EC         EC.reg
+#define GMAC_LC         LC.reg
+#define GMAC_DTF        DTF.reg
+#define GMAC_CSE        CSE.reg
+#define GMAC_ORLO       ORLO.reg
+#define GMAC_ORHI       ORHI.reg
+#define GMAC_FR         FR.reg
+#define GMAC_BCFR       BCFR.reg
+#define GMAC_MFR        MFR.reg
+#define GMAC_PFR        PFR.reg
+#define GMAC_BFR64      BFR64.reg
+#define GMAC_TBFR127    TBFR127.reg
+#define GMAC_TBFR255    TBFR255.reg
+#define GMAC_TBFR511    TBFR511.reg
+#define GMAC_TBFR1023   TBFR1023.reg
+#define GMAC_TBFR1518   TBFR1518.reg
+#define GMAC_TMXBFR     TMXBFR.reg
+#define GMAC_UFR        UFR.reg
+#define GMAC_OFR        OFR.reg
+#define GMAC_JR         JR.reg
+#define GMAC_FCSE       FCSE.reg
+#define GMAC_LFFE       LFFE.reg
+#define GMAC_RSE        RSE.reg
+#define GMAC_AE         AE.reg
+#define GMAC_RRE        RRE.reg
+#define GMAC_ROE        ROE.reg
+#define GMAC_IHCE       IHCE.reg
+#define GMAC_TCE        TCE.reg
+#define GMAC_UCE        UCE.reg
+#define GMAC_TISUBN     TISUBN.reg
+#define GMAC_TSH        TSH.reg
+#define GMAC_TSSSL      TSSSL.reg
+#define GMAC_TSSN       TSSN.reg
+#define GMAC_TSL        TSL.reg
+#define GMAC_TN         TN.reg
+#define GMAC_TA         TA.reg
+#define GMAC_TI         TI.reg
+#define GMAC_EFTSL      EFTSL.reg
+#define GMAC_EFTN       EFTN.reg
+#define GMAC_EFRSL      EFRSL.reg
+#define GMAC_EFRN       EFRN.reg
+#define GMAC_PEFTSL     PEFTSL.reg
+#define GMAC_PEFTN      PEFTN.reg
+#define GMAC_PEFRSL     PEFRSL.reg
+#define GMAC_PEFRN      PEFRN.reg
+#define GMAC_RLPITR     RLPITR.reg
+#define GMAC_RLPITI     RLPITI.reg
+#define GMAC_TLPITR     TLPITR.reg
+#define GMAC_TLPITI     TLPITI.reg
+
+#define GMAC_SAB        SAB.reg
+#define GMAC_SAT        SAT.reg
+
+/*
+ * Define the register field value symbols that are missing in the SAM0-family
+ * DFP GMAC headers.
+ */
+#define GMAC_NCFGR_CLK_MCK_8    GMAC_NCFGR_CLK(0)
+#define GMAC_NCFGR_CLK_MCK_16   GMAC_NCFGR_CLK(1)
+#define GMAC_NCFGR_CLK_MCK_32   GMAC_NCFGR_CLK(2)
+#define GMAC_NCFGR_CLK_MCK_48   GMAC_NCFGR_CLK(3)
+#define GMAC_NCFGR_CLK_MCK_64   GMAC_NCFGR_CLK(4)
+#define GMAC_NCFGR_CLK_MCK_96   GMAC_NCFGR_CLK(5)
+
+#define GMAC_DCFGR_FBLDO_SINGLE GMAC_DCFGR_FBLDO(1)
+#define GMAC_DCFGR_FBLDO_INCR4  GMAC_DCFGR_FBLDO(2)
+#define GMAC_DCFGR_FBLDO_INCR8  GMAC_DCFGR_FBLDO(3)
+#define GMAC_DCFGR_FBLDO_INCR16 GMAC_DCFGR_FBLDO(4)
+
+#endif /* ZEPHYR_DRIVERS_ETHERNET_ETH_SAM0_GMAC_H_ */

--- a/drivers/ethernet/phy_sam_gmac.c
+++ b/drivers/ethernet/phy_sam_gmac.c
@@ -12,6 +12,10 @@
 #include <net/mii.h>
 #include "phy_sam_gmac.h"
 
+#ifdef CONFIG_SOC_FAMILY_SAM0
+#include "eth_sam0_gmac.h"
+#endif
+
 #define LOG_MODULE_NAME eth_sam_phy
 #define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
 

--- a/dts/arm/atmel/same5x.dtsi
+++ b/dts/arm/atmel/same5x.dtsi
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2020 Stephanos Ioannidis <root@stephanos.io>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <atmel/samd5x.dtsi>
+
+/ {
+	soc {
+		gmac: ethernet@42000800 {
+			compatible = "atmel,sam-gmac";
+			reg = <0x42000800 0x400>;
+			interrupts = <84 0>;
+			interrupt-names = "gmac";
+			num-queues = <1>;
+			local-mac-address = [00 00 00 00 00 00];
+			label = "GMAC";
+			status = "disabled";
+		};
+	};
+};

--- a/dts/arm/atmel/same5xx18.dtsi
+++ b/dts/arm/atmel/same5xx18.dtsi
@@ -4,4 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <atmel/samd5xx18.dtsi>
+#include <mem.h>
+#include <atmel/same5x.dtsi>
+
+/ {
+	soc {
+		nvmctrl@41004000 {
+			flash0: flash@0 {
+				reg = <0x0 DT_SIZE_K(256)>;
+			};
+		};
+
+		sram0: memory@20000000 {
+			reg = <0x20000000 DT_SIZE_K(128)>;
+		};
+	};
+};

--- a/dts/arm/atmel/same5xx19.dtsi
+++ b/dts/arm/atmel/same5xx19.dtsi
@@ -4,4 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <atmel/samd5xx19.dtsi>
+#include <mem.h>
+#include <atmel/same5x.dtsi>
+
+/ {
+	soc {
+		nvmctrl@41004000 {
+			flash0: flash@0 {
+				reg = <0x0 DT_SIZE_K(512)>;
+			};
+		};
+
+		sram0: memory@20000000 {
+			reg = <0x20000000 DT_SIZE_K(192)>;
+		};
+	};
+};

--- a/dts/arm/atmel/same5xx20.dtsi
+++ b/dts/arm/atmel/same5xx20.dtsi
@@ -4,4 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <atmel/samd5xx20.dtsi>
+#include <mem.h>
+#include <atmel/same5x.dtsi>
+
+/ {
+	soc {
+		nvmctrl@41004000 {
+			flash0: flash@0 {
+				reg = <0x0 DT_SIZE_K(1024)>;
+			};
+		};
+
+		sram0: memory@20000000 {
+			reg = <0x20000000 DT_SIZE_K(256)>;
+		};
+	};
+};

--- a/include/drivers/pinmux.h
+++ b/include/drivers/pinmux.h
@@ -34,6 +34,14 @@ extern "C" {
 #define PINMUX_FUNC_F		5
 #define PINMUX_FUNC_G		6
 #define PINMUX_FUNC_H		7
+#define PINMUX_FUNC_I		8
+#define PINMUX_FUNC_J		9
+#define PINMUX_FUNC_K		10
+#define PINMUX_FUNC_L		11
+#define PINMUX_FUNC_M		12
+#define PINMUX_FUNC_N		13
+#define PINMUX_FUNC_O		14
+#define PINMUX_FUNC_P		15
 
 #define PINMUX_PULLUP_ENABLE	(0x1)
 #define PINMUX_PULLUP_DISABLE	(0x0)

--- a/soc/arm/atmel_sam0/common/gmac_fixup_samd5x.h
+++ b/soc/arm/atmel_sam0/common/gmac_fixup_samd5x.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020 Stephanos Ioannidis <root@stephanos.io>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * The following GMAC clock configuration fix-up symbols map to the applicable
+ * APB-specific symbols, in order to accommodate different SoC series with the
+ * GMAC core connected to different APBs.
+ */
+#ifdef MCLK_APBAMASK_GMAC
+#define MCLK_GMAC (&MCLK->APBAMASK.reg)
+#define MCLK_GMAC_MASK (MCLK_APBAMASK_GMAC)
+#endif
+#ifdef MCLK_APBBMASK_GMAC
+#define MCLK_GMAC (&MCLK->APBBMASK.reg)
+#define MCLK_GMAC_MASK (MCLK_APBBMASK_GMAC)
+#endif
+#ifdef MCLK_APBCMASK_GMAC
+#define MCLK_GMAC (&MCLK->APBCMASK.reg)
+#define MCLK_GMAC_MASK (MCLK_APBCMASK_GMAC)
+#endif
+#ifdef MCLK_APBDMASK_GMAC
+#define MCLK_GMAC (&MCLK->APBDMASK.reg)
+#define MCLK_GMAC_MASK (MCLK_APBDMASK_GMAC)
+#endif

--- a/soc/arm/atmel_sam0/same53/soc.h
+++ b/soc/arm/atmel_sam0/same53/soc.h
@@ -31,6 +31,7 @@
 
 #include "sercom_fixup_samd5x.h"
 #include "tc_fixup_samd5x.h"
+#include "gmac_fixup_samd5x.h"
 
 #define SOC_ATMEL_SAM0_OSC32K_FREQ_HZ 32768
 

--- a/soc/arm/atmel_sam0/same54/soc.h
+++ b/soc/arm/atmel_sam0/same54/soc.h
@@ -29,6 +29,7 @@
 
 #include "sercom_fixup_samd5x.h"
 #include "tc_fixup_samd5x.h"
+#include "gmac_fixup_samd5x.h"
 
 #define SOC_ATMEL_SAM0_OSC32K_FREQ_HZ 32768
 


### PR DESCRIPTION
This PR includes a series of commits to support the GMAC Ethernet peripheral on the Atmel SAM0 family devices, and enable Ethernet support on the Atmel SAM E53 and E54 SoCs.

Closes #23001.

NOTE: This patch has been tested and verified working on the `atsame54_xpro` board using the `samples/net/dhcpv4_client` sample.