### PR TITLE
Bluetooth: Mesh: Fix possible NULL dereference in BT_DBG statement.

### DIFF
--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -3416,7 +3416,8 @@ u8_t bt_mesh_relay_get(void)
 
 u8_t bt_mesh_friend_get(void)
 {
-	BT_DBG("conf %p conf->frnd 0x%02x", conf, conf->frnd);
+	BT_DBG("conf %p conf->frnd 0x%02x", conf,
+	       conf ? conf->frnd : BT_MESH_FRIEND_NOT_SUPPORTED);
 
 	if (conf) {
 		return conf->frnd;


### PR DESCRIPTION
Fix possible NULL dereference in BT_DBG statement when
bt_mesh_friend_get is called before a successful cfg_srv init

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>