### PR TITLE
Openocd workaround for cc13x2/cc26x2

### DIFF
--- a/boards/arm/cc1352r1_launchxl/support/openocd.cfg
+++ b/boards/arm/cc1352r1_launchxl/support/openocd.cfg
@@ -1,1 +1,4 @@
 source [find board/ti_cc13x2_launchpad.cfg]
+# Workaround for #21372. This allows OpenOCD to flash correctly
+# with newer 3.x XDS firmware
+adapter_khz 1500

--- a/boards/arm/cc26x2r1_launchxl/support/openocd.cfg
+++ b/boards/arm/cc26x2r1_launchxl/support/openocd.cfg
@@ -1,1 +1,4 @@
 source [find board/ti_cc26x2_launchpad.cfg]
+# Workaround for #21372. This allows OpenOCD to flash correctly
+# with newer 3.x XDS firmware
+adapter_khz 1500


### PR DESCRIPTION
Newer XDS firmware fails to flash correctly with higher adapter clock
speed. Using a slower speed for now to prevent errors.

Fixes #21372