### PR TITLE
usb: mass_storage: cleanup, fixes to pass USBCV MSC Test

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1526,6 +1526,7 @@ int usb_dc_ep_clear_stall(const u8_t ep)
 		return -EINVAL;
 	}
 
+	nrfx_usbd_ep_dtoggle_clear(ep_addr_to_nrfx(ep));
 	nrfx_usbd_ep_stall_clear(ep_addr_to_nrfx(ep));
 	LOG_DBG("Unstall on EP 0x%02x", ep);
 

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1573,6 +1573,7 @@ int usb_dc_ep_enable(const u8_t ep)
 		return -EINVAL;
 	}
 
+	nrfx_usbd_ep_dtoggle_clear(ep_addr_to_nrfx(ep));
 	if (ep_ctx->cfg.en) {
 		return -EALREADY;
 	}

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -491,6 +491,11 @@ static bool infoTransfer(void)
 
 static void fail(void)
 {
+	if (cbw.DataLength) {
+		/* Stall data stage */
+		usb_ep_set_stall(mass_ep_data[MSD_IN_EP_IDX].ep_addr);
+	}
+
 	csw.Status = CSW_FAILED;
 	sendCSW();
 }

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -355,17 +355,10 @@ static bool readFormatCapacity(void)
 
 static bool readCapacity(void)
 {
-	u8_t capacity[] = {
-		(u8_t)(((block_count - 1) >> 24) & 0xff),
-		(u8_t)(((block_count - 1) >> 16) & 0xff),
-		(u8_t)(((block_count - 1) >> 8) & 0xff),
-		(u8_t)(((block_count - 1) >> 0) & 0xff),
+	u8_t capacity[8];
 
-		(u8_t)((BLOCK_SIZE >> 24) & 0xff),
-		(u8_t)((BLOCK_SIZE >> 16) & 0xff),
-		(u8_t)((BLOCK_SIZE >> 8) & 0xff),
-		(u8_t)((BLOCK_SIZE >> 0) & 0xff),
-	};
+	sys_put_be32(block_count - 1, &capacity[0]);
+	sys_put_be32(BLOCK_SIZE, &capacity[4]);
 
 	return write(capacity, sizeof(capacity));
 }
@@ -434,8 +427,7 @@ static bool infoTransfer(void)
 	u32_t n;
 
 	/* Logical Block Address of First Block */
-	n = (cbw.CB[2] << 24) | (cbw.CB[3] << 16) | (cbw.CB[4] <<  8) |
-				 (cbw.CB[5] <<  0);
+	n = sys_get_be32(&cbw.CB[2]);
 
 	LOG_DBG("LBA (block) : 0x%x ", n);
 	if ((n * BLOCK_SIZE) >= memory_size) {
@@ -452,13 +444,12 @@ static bool infoTransfer(void)
 	case READ10:
 	case WRITE10:
 	case VERIFY10:
-		n = (cbw.CB[7] <<  8) | (cbw.CB[8] <<  0);
+		n = sys_get_be16(&cbw.CB[7]);
 		break;
 
 	case READ12:
 	case WRITE12:
-		n = (cbw.CB[6] << 24) | (cbw.CB[7] << 16) |
-			(cbw.CB[8] <<  8) | (cbw.CB[9] <<  0);
+		n = sys_get_be32(&cbw.CB[6]);
 		break;
 	}
 


### PR DESCRIPTION
 usb: mass_storage: cleanup, fixes to pass USBCV MSC Test

drivers: usb_dc_nrfx: always reset data toggle in usb_dc_ep_enable 
  Data toggle should be reset after SetConfiguration or SetInterface request.
  Always reset data toggle in usb_dc_ep_enable.
  (fixes Case x from #14302 issue)

usb: mass_storage:
  Use sys_get_be32, sys_put_be32 where possible.
  Check dCBWDataTransferLength for every read command.
   (fixes Command Set Test #14302 issue)

cherry-picked from #23188 and #23191 and tested on nRF52840
resolves #14302 for nRF driver

There is more to do but I wanted to have it passes MSC Tests first.
