### PR TITLE
fix some incorrect syscall handlers

### DIFF
--- a/drivers/gpio/gpio_handlers.c
+++ b/drivers/gpio/gpio_handlers.c
@@ -71,6 +71,8 @@ static inline int z_vrfy_gpio_pin_interrupt_configure(struct device *port,
 static inline int z_vrfy_gpio_enable_callback(struct device *port,
 					     gpio_pin_t pin)
 {
+	Z_OOPS(Z_SYSCALL_DRIVER_GPIO(port, enable_callback));
+
 	return z_impl_gpio_enable_callback((struct device *)port, pin);
 }
 #include <syscalls/gpio_enable_callback_mrsh.c>
@@ -78,12 +80,16 @@ static inline int z_vrfy_gpio_enable_callback(struct device *port,
 static inline int z_vrfy_gpio_disable_callback(struct device *port,
 					      gpio_pin_t pin)
 {
+	Z_OOPS(Z_SYSCALL_DRIVER_GPIO(port, disable_callback));
+
 	return z_impl_gpio_disable_callback((struct device *)port, pin);
 }
 #include <syscalls/gpio_disable_callback_mrsh.c>
 
 static inline int z_vrfy_gpio_get_pending_int(struct device *dev)
 {
+	Z_OOPS(Z_SYSCALL_DRIVER_GPIO(dev, get_pending_int));
+
 	return z_impl_gpio_get_pending_int((struct device *)dev);
 }
 #include <syscalls/gpio_get_pending_int_mrsh.c>

--- a/drivers/kscan/kscan_handlers.c
+++ b/drivers/kscan/kscan_handlers.c
@@ -19,12 +19,16 @@ static inline int z_vrfy_kscan_config(struct device *dev,
 
 static inline int z_vrfy_kscan_disable_callback(struct device *dev);
 {
+	Z_OOPS(Z_SYSCALL_DRIVER_KSCAN(dev, disable_callback));
+
 	return z_impl_kscan_disable_callback((struct device *)dev);
 }
 #include <syscalls/kscan_disable_callback_mrsh.c>
 
 static int z_vrfy_kscan_enable_callback(struct device *dev);
 {
+	Z_OOPS(Z_SYSCALL_DRIVER_KSCAN(dev, enable_callback));
+
 	return z_impl_kscan_enable_callback((struct device *)dev);
 }
 #include <syscalls/kscan_enable_callback_mrsh.c>


### PR DESCRIPTION
GPIO and kscan had problems in their syscall handlers where driver objects were not being validated.