### PR TITLE
drivers: crypto: mbedtls: Remove dead code

### DIFF
--- a/drivers/crypto/crypto_mtls_shim.c
+++ b/drivers/crypto/crypto_mtls_shim.c
@@ -364,8 +364,6 @@ static int mtls_session_setup(struct device *dev, struct cipher_ctx *ctx,
 			return -EINVAL;
 		}
 		break;
-	case CRYPTO_CIPHER_MODE_CTR:
-		break;
 	case CRYPTO_CIPHER_MODE_CBC:
 		aes_ctx = &mtls_sessions[ctx_idx].mtls_aes;
 		mbedtls_aes_init(aes_ctx);


### PR DESCRIPTION
mtls_session_setup checks early if the given mode is valid and return
an error if not. CRYPTO_CIPHER_MODE_CTR is not a valid one so there is
no needed to have it in the switch.

CID: 20600

Fixes #21701

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>