### PR TITLE
arch: arc: fix the bug of blt in syscall

### DIFF
--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -206,7 +206,7 @@ SECTION_SUBSEC_FUNC(TEXT,__fault,__ev_trap)
 	/* do sys_call */
 	mov_s ilink, K_SYSCALL_LIMIT
 	cmp r6, ilink
-	blt valid_syscall_id
+	blo valid_syscall_id
 
 	mov_s r0, r6
 	mov_s r6, K_SYSCALL_BAD


### PR DESCRIPTION
blt is signed comparsion, if r6 is a negative number created by
malicious code, it will pass the check, bring a secure risk.

use blo (unsinged comparison) to do the check.

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>