### PR TITLE
soc: arm: stm32: configure LDO supply on H7 init

### DIFF
--- a/soc/arm/st_stm32/stm32h7/soc_m7.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m7.c
@@ -88,6 +88,8 @@ static int stm32h7_init(struct device *arg)
 	/* Power Configuration */
 #ifdef SMPS
 	LL_PWR_ConfigSupply(LL_PWR_DIRECT_SMPS_SUPPLY);
+#else
+	LL_PWR_ConfigSupply(LL_PWR_LDO_SUPPLY);
 #endif
 	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
 	while (LL_PWR_IsActiveFlag_VOS() == 0) {


### PR DESCRIPTION
Configure the LDO supply when initializing H7 (M7) SoC. I have
observed MCU hanging on `LL_PWR_IsActiveFlag_VOS()` wait loop when
doing a cold boot if LDO supply is not explicitely enabled.
According to the datasheet LDO should be enabled by default,
however HAL examples also configure LDO, so there may be a
reason to perform such step.

Signed-off-by: Gerard Marull-Paretas <gerard@teslabs.com>