### PR TITLE
DNM: west.yml: Update revision of TinyCBOR

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -102,7 +102,7 @@ manifest:
       path: modules/debug/segger
     - name: tinycbor
       path: modules/lib/tinycbor
-      revision: 0fc68fceacd1efc1ce809c5880c380f3d98b7b6e
+      revision: pull/13/head
     - name: littlefs
       path: modules/fs/littlefs
       revision: fe9572dd5a9fcf93a249daa4233012692bd2881d


### PR DESCRIPTION
Update provides fix for TinyCBOR include paths not being added into
compilation, unless MCUMGR has also been selected.

Fixes: #23324

TinyCBOR changes reviewed here:
https://github.com/zephyrproject-rtos/tinycbor/pull/13

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>