### PR TITLE
boards: arm: bl65x_dvk: fix reset not working

### DIFF
--- a/boards/arm/bl652_dvk/board.cmake
+++ b/boards/arm/bl652_dvk/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52")
+board_runner_args(nrfjprog "--nrf-family=NRF52" "--softreset")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/bl654_dvk/board.cmake
+++ b/boards/arm/bl654_dvk/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52")
+board_runner_args(nrfjprog "--nrf-family=NRF52" "--softreset")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Switch from using pin reset to normal reset.

Fixes #23346

Signed-off-by: Jamie McCrae <jamie.mccrae@lairdconnect.com>