### PR TITLE
doc: keep IDs when redirecting URLs

### DIFF
--- a/doc/extensions/zephyr/html_redirects.py
+++ b/doc/extensions/zephyr/html_redirects.py
@@ -24,12 +24,19 @@ import os.path
 
 from sphinx.builders.html import StandaloneHTMLBuilder
 
-REDIRECT_TEMPLATE = """
+REDIRECT_TEMPLATE = r"""
 <html>
   <head>
     <meta http-equiv="refresh" content="0; url=$NEWURL" />
     <script>
-      window.location.href = "$NEWURL"
+     var id=window.location.href.split("#")[1];
+
+     if (id && (/^[a-zA-Z\:\/0-9\_\-\.]+$/.test(id))) {
+        window.location.href = "$NEWURL"+"#"+id;
+        }
+     else {
+        window.location.href = "$NEWURL";
+     };
     </script>
   </head>
   <body>


### PR DESCRIPTION
When redirecting from old-topic.html#some-id to new-topic.html,
the ID is ignored.
Not sure if it is possible to keep the ID in the meta redirect,
but at least in the JavaScript version we should keep it and
redirect from old-topic.html#some-id to new-topic.html#some-id.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>