### PR TITLE
updatehub: Fix possible memory overflow

### DIFF
--- a/lib/updatehub/updatehub.c
+++ b/lib/updatehub/updatehub.c
@@ -687,6 +687,12 @@ enum updatehub_response updatehub_probe(void)
 			goto cleanup;
 		}
 
+		if (metadata_any_boards.objects[1].objects.sha256sum >
+		    TC_SHA256_BLOCK_SIZE) {
+			ctx.code_status = UPDATEHUB_METADATA_ERROR;
+			goto cleanup;
+		}
+
 		memcpy(update_info.sha256sum_image,
 		       metadata_any_boards.objects[1].objects.sha256sum,
 		       strlen(metadata_any_boards.objects[1].objects.sha256sum));
@@ -698,6 +704,13 @@ enum updatehub_response updatehub_probe(void)
 				UPDATEHUB_INCOMPATIBLE_HARDWARE;
 			goto cleanup;
 		}
+
+		if (metadata_some_boards.objects[1].objects.sha256sum >
+		    TC_SHA256_BLOCK_SIZE) {
+			ctx.code_status = UPDATEHUB_METADATA_ERROR;
+			goto cleanup;
+		}
+
 		memcpy(update_info.sha256sum_image,
 		       metadata_some_boards.objects[1].objects.sha256sum,
 		       strlen(metadata_some_boards.objects[1]


### PR DESCRIPTION
updatehub_probe copies a variable-size hash string into a fixed-size
array what can cause an oveflow. Adding a simple size check.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>