### PR TITLE
Arch arm cortex m spurious fix

### DIFF
--- a/arch/arm/core/aarch32/irq_manage.c
+++ b/arch/arm/core/aarch32/irq_manage.c
@@ -146,7 +146,7 @@ void z_arm_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags)
  *
  * @brief Spurious interrupt handler
  *
- * Installed in all dynamic interrupt slots at boot time. Throws an error if
+ * Installed in all _sw_isr_table slots at boot time. Throws an error if
  * called.
  *
  * See z_arm_reserved().

--- a/arch/arm/core/aarch32/irq_manage.c
+++ b/arch/arm/core/aarch32/irq_manage.c
@@ -142,6 +142,8 @@ void z_arm_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags)
 
 #endif
 
+void z_arm_fatal_error(unsigned int reason, const z_arch_esf_t *esf);
+
 /**
  *
  * @brief Spurious interrupt handler
@@ -149,14 +151,13 @@ void z_arm_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags)
  * Installed in all _sw_isr_table slots at boot time. Throws an error if
  * called.
  *
- * See z_arm_reserved().
- *
  * @return N/A
  */
 void z_irq_spurious(void *unused)
 {
 	ARG_UNUSED(unused);
-	z_arm_reserved();
+
+	z_arm_fatal_error(K_ERR_SPURIOUS_IRQ, NULL);
 }
 
 #ifdef CONFIG_SYS_POWER_MANAGEMENT

--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -163,6 +163,14 @@ void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 				arch_irq_unlock(key);
 				return;
 #endif /* CONFIG_STACK_SENTINEL */
+			} else {
+				/* Abort the thread only if the fault is not due to
+				 * a spurious ISR handler triggered.
+				 */
+				if (reason == K_ERR_SPURIOUS_IRQ) {
+					arch_irq_unlock(key);
+					return;
+				}
 			}
 #endif /*CONFIG_ARCH_HAS_NESTED_EXCEPTION_DETECTION */
 	}

--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -112,7 +112,7 @@ void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 	 * See #17656
 	 */
 #if defined(CONFIG_ARCH_HAS_NESTED_EXCEPTION_DETECTION)
-	if (arch_is_in_nested_exception(esf)) {
+	if ((esf != NULL) && arch_is_in_nested_exception(esf)) {
 		LOG_ERR("Fault during interrupt handling\n");
 	}
 #endif
@@ -140,7 +140,7 @@ void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 			 "Attempted to recover from a kernel panic condition");
 		/* FIXME: #17656 */
 #if defined(CONFIG_ARCH_HAS_NESTED_EXCEPTION_DETECTION)
-		if (arch_is_in_nested_exception(esf)) {
+		if ((esf != NULL) && arch_is_in_nested_exception(esf)) {
 #if defined(CONFIG_STACK_SENTINEL)
 			if (reason != K_ERR_STACK_CHK_FAIL) {
 				__ASSERT(0,
@@ -152,7 +152,7 @@ void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 	} else {
 		/* Test mode */
 #if defined(CONFIG_ARCH_HAS_NESTED_EXCEPTION_DETECTION)
-			if (arch_is_in_nested_exception(esf)) {
+			if ((esf != NULL) && arch_is_in_nested_exception(esf)) {
 				/* Abort the thread only on STACK Sentinel check fail. */
 #if defined(CONFIG_STACK_SENTINEL)
 				if (reason != K_ERR_STACK_CHK_FAIL) {

--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -152,26 +152,26 @@ void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 	} else {
 		/* Test mode */
 #if defined(CONFIG_ARCH_HAS_NESTED_EXCEPTION_DETECTION)
-			if ((esf != NULL) && arch_is_in_nested_exception(esf)) {
-				/* Abort the thread only on STACK Sentinel check fail. */
+		if ((esf != NULL) && arch_is_in_nested_exception(esf)) {
+			/* Abort the thread only on STACK Sentinel check fail. */
 #if defined(CONFIG_STACK_SENTINEL)
-				if (reason != K_ERR_STACK_CHK_FAIL) {
-					arch_irq_unlock(key);
-					return;
-				}
-#else
+			if (reason != K_ERR_STACK_CHK_FAIL) {
 				arch_irq_unlock(key);
 				return;
-#endif /* CONFIG_STACK_SENTINEL */
-			} else {
-				/* Abort the thread only if the fault is not due to
-				 * a spurious ISR handler triggered.
-				 */
-				if (reason == K_ERR_SPURIOUS_IRQ) {
-					arch_irq_unlock(key);
-					return;
-				}
 			}
+#else
+			arch_irq_unlock(key);
+			return;
+#endif /* CONFIG_STACK_SENTINEL */
+		} else {
+			/* Abort the thread only if the fault is not due to
+			 * a spurious ISR handler triggered.
+			 */
+			if (reason == K_ERR_SPURIOUS_IRQ) {
+				arch_irq_unlock(key);
+				return;
+			}
+		}
 #endif /*CONFIG_ARCH_HAS_NESTED_EXCEPTION_DETECTION */
 	}
 

--- a/tests/arch/arm/arm_interrupt/README.txt
+++ b/tests/arch/arm/arm_interrupt/README.txt
@@ -6,7 +6,8 @@ Description:
 
 The first test verifies that we can handle system fault conditions
 while running in handler mode (i.e. in an ISR). Only for ARM
-Cortex-M targets.
+Cortex-M targets. The test also verifies the behavior of the
+spurious interrupt handler.
 
 The second test verifies that threads in user mode, despite being able to call
 the irq_lock() and irq_unlock() functions without triggering a CPU fault,


### PR DESCRIPTION
- We fix the behavior of the spurious interrupt handler for ARM Cortex-M:
The behavior is now _identical_ to all other architectures (maybe except for ARC; FYI @vonhust ):
tjhe spurious ISR handler calls the z_arm_fatal_error(K_ERR_SPURIOUS_ISR, NULL).

The fix is done for Cortex-M but it affects shared code with Cortex-R (@stephanosio FYI)
- We fix the documentation of z_irq_spurious() for ARM, stressing that it is installed in _sw_isr_table (that can  have dynamic IRQs or not).

- We fix the *kernel*  z_fatal_error() implementation specifics for ARM so it checks the ESF pointer before de-referencing. Note: this currently applies to Cortex-M as it is the only ARCH with support for detecting nested exception.

- We add a test-case to verfiy the behavior of the spurious interrupt handler.

This closes #23360 
Fixes #23372 as well.