### PR TITLE
boards: arm: mec1501modular: Disable I2C2 bus from board

### DIFF
--- a/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
+++ b/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
@@ -24,7 +24,6 @@
 
 		i2c0 = &i2c_smb_0;
 		i2c1 = &i2c_smb_1;
-		i2c7 = &i2c_smb_2;
 	};
 };
 
@@ -47,12 +46,6 @@
 	status = "okay";
 	label = "I2C1";
 	port_sel = <1>;
-};
-
-&i2c_smb_2 {
-	status = "okay";
-	label = "I2C7";
-	port_sel = <7>;
 };
 
 &espi0 {


### PR DESCRIPTION
MEC1501modular doesn't expose same I2C instances via headers than MEC15xxevb.
Additionally exposing I2C2 causes undesired reconfiguration of pin GPIO012 which
has a different function when card is mated with a platform that complies
with MECC specification.

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>