### PR TITLE
samples: display: doc: Corrected build commands

### DIFF
--- a/samples/drivers/display/README.rst
+++ b/samples/drivers/display/README.rst
@@ -23,7 +23,7 @@ Below is an example on how to build for a :ref:`nrf52840_pca10056` board with a
 :ref:`adafruit_2_8_tft_touch_v2`.
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/drivers/display_shield
+   :zephyr-app: samples/drivers/display
    :board: nrf52840_pca10056
    :goals: build
    :shield: adafruit_2_8_tft_touch_v2
@@ -33,7 +33,7 @@ For testing purpose without the need of any hardware, the :ref:`native_posix`
 board is also supported and can be built as follows;
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/drivers/display_shield
+   :zephyr-app: samples/drivers/display
    :board: native_posix
    :goals: build
    :compact:


### PR DESCRIPTION
Corrected build command paths in the documentation of the display
driver sample