### PR TITLE
Application-level event for MQTT ping response message

### DIFF
--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -75,7 +75,10 @@ enum mqtt_evt_type {
 	MQTT_EVT_SUBACK,
 
 	/** Acknowledgment to a unsubscribe request. */
-	MQTT_EVT_UNSUBACK
+	MQTT_EVT_UNSUBACK,
+
+	/** Ping Response from server. */
+	MQTT_EVT_PINGRESP,
 };
 
 /** @brief MQTT version protocol level. */

--- a/samples/net/mqtt_publisher/src/main.c
+++ b/samples/net/mqtt_publisher/src/main.c
@@ -192,6 +192,10 @@ void mqtt_evt_handler(struct mqtt_client *const client,
 
 		break;
 
+	case MQTT_EVT_PINGRESP:
+		LOG_INF("PINGRESP packet");
+		break;
+
 	default:
 		break;
 	}

--- a/subsys/net/lib/mqtt/mqtt_rx.c
+++ b/subsys/net/lib/mqtt/mqtt_rx.c
@@ -127,8 +127,7 @@ static int mqtt_handle_packet(struct mqtt_client *client,
 			client->unacked_ping--;
 		}
 
-		/* No notification of Ping response to application. */
-		notify_event = false;
+		evt.type = MQTT_EVT_PINGRESP;
 		break;
 
 	default:


### PR DESCRIPTION
Added event for MQTT ping response and showed it in application.

While TCP packets may be dropped because of the TCP timeout on NAT firewall (which is ubiquitous in IoT), the TCP link may be invalidated without any disconnection. The introduced event can help application to learn whether the TCP link is still valid.