### PR TITLE
drivers: ieee802154_nrf5: Fix build failure

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -184,6 +184,7 @@ static int nrf5_set_channel(struct device *dev, u16_t channel)
 	return 0;
 }
 
+#ifdef CONFIG_NET_L2_OPENTHREAD
 static int nrf5_energy_scan_start(struct device *dev,
 				  u16_t duration,
 				  energy_scan_done_cb_t done_cb)
@@ -205,6 +206,7 @@ static int nrf5_energy_scan_start(struct device *dev,
 
 	return err;
 }
+#endif /* CONFIG_NET_L2_OPENTHREAD */
 
 static int nrf5_set_pan_id(struct device *dev, u16_t pan_id)
 {


### PR DESCRIPTION
Fix build failure when CONFIG_NET_L2_OPENTHREAD is not enabled. The
failure looks as follows:

drivers/ieee802154/ieee802154_nrf5.c:187:12:
	warning: 'nrf5_energy_scan_start' defined but not used
	[-Wunused-function]
 static int nrf5_energy_scan_start(struct device *dev,
            ^~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>