### PR TITLE
arm: aarch64: Reintroduce _ASM_FILE_PROLOGUE

### DIFF
--- a/arch/arm/core/aarch64/cpu_idle.S
+++ b/arch/arm/core/aarch64/cpu_idle.S
@@ -13,6 +13,8 @@
 #include <linker/sections.h>
 #include <arch/cpu.h>
 
+_ASM_FILE_PROLOGUE
+
 GTEXT(arch_cpu_idle)
 SECTION_FUNC(TEXT, arch_cpu_idle)
 #ifdef CONFIG_TRACING

--- a/arch/arm/core/aarch64/isr_wrapper.S
+++ b/arch/arm/core/aarch64/isr_wrapper.S
@@ -15,6 +15,8 @@
 #include <arch/cpu.h>
 #include <sw_isr_table.h>
 
+_ASM_FILE_PROLOGUE
+
 GDATA(_sw_isr_table)
 
 /**

--- a/arch/arm/core/aarch64/reset.S
+++ b/arch/arm/core/aarch64/reset.S
@@ -17,6 +17,8 @@
 #include "vector_table.h"
 #include "macro.h"
 
+_ASM_FILE_PROLOGUE
+
 /**
  *
  * @brief Reset vector

--- a/arch/arm/core/aarch64/swap_helper.S
+++ b/arch/arm/core/aarch64/swap_helper.S
@@ -19,6 +19,8 @@
 #include <syscall.h>
 #include "macro.h"
 
+_ASM_FILE_PROLOGUE
+
 GDATA(_kernel)
 GDATA(_k_neg_eagain)
 

--- a/arch/arm/core/aarch64/vector_table.S
+++ b/arch/arm/core/aarch64/vector_table.S
@@ -13,6 +13,8 @@
 #include <linker/sections.h>
 #include "vector_table.h"
 
+_ASM_FILE_PROLOGUE
+
 /*
  * Four types of exceptions:
  * - synchronous: aborts from MMU, SP/CP alignment checking, unallocated

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -363,7 +363,9 @@ do {                                                                    \
 #else
 #define _ASM_FILE_PROLOGUE .text; .code 32
 #endif /* CONFIG_ASSEMBLER_ISA_THUMB2 */
-#endif /* CONFIG_ARM && !CONFIG_ARM64 */
+#elif defined(CONFIG_ARM64)
+#define _ASM_FILE_PROLOGUE .text
+#endif /* CONFIG_ARM64 || (CONFIG_ARM && !CONFIG_ARM64)*/
 #endif /* _ASMLANGUAGE */
 
 /*


### PR DESCRIPTION
This is currently missing from the AArch64 assembly files.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>