### PR TITLE
samples: drivers: spi_flash: use printf argument consistent with format

### DIFF
--- a/samples/drivers/spi_flash/src/main.c
+++ b/samples/drivers/spi_flash/src/main.c
@@ -89,7 +89,7 @@ void main(void)
 		printf("Data read does not match data written!!\n");
 		while (rp < rpe) {
 			printf("%08x wrote %02x read %02x %s\n",
-			       FLASH_TEST_REGION_OFFSET + (rp - buf),
+			       (u32_t)(FLASH_TEST_REGION_OFFSET + (rp - buf)),
 			       *wp, *rp, (*rp == *wp) ? "match" : "MISMATCH");
 			++rp;
 			++wp;


### PR DESCRIPTION
Coverity thinks this is a long because FLASH_TEST_REGION_OFFSET is a
signed value.  Zephyr doesn't use standard types so make it a u32_t.

Fixes #22441