### PR TITLE
soc: mec1501: wait for PLL to lock coming out of deep sleep

### DIFF
--- a/soc/arm/microchip_mec/mec1501/power.c
+++ b/soc/arm/microchip_mec/mec1501/power.c
@@ -72,8 +72,11 @@ static void z_power_soc_deep_sleep(void)
 
 	soc_deep_sleep_non_wake_dis();
 
-	soc_deep_sleep_periph_restore();
+	/* Wait for PLL to lock */
+	while ((PCR_REGS->OSC_ID & MCHP_PCR_OSC_ID_PLL_LOCK) == 0) {
+	};
 
+	soc_deep_sleep_periph_restore();
 }
 #endif
 


### PR DESCRIPTION
The 48MHz PLL on MEC1501 is shut off during deep sleep (i.e. heavy
sleep in datasheet). When coming out of deep sleep, this PLL needs
about 3ms to lock. Most peripherals are using this PLL as clock
source and timing would be off before PLL is locked. Example of
this is seen on serial console where garbage characters are sent
as the UART block is not pushing characters out at the configured
baud rate. This likely affects all other peripherals such as I2C
and eSPI. Luckily, there is a register to indicate whether the PLL
is ready. So spin on it when coming out of deep sleep.

Fixes #23207

Signed-off-by: Daniel Leung <daniel.leung@intel.com>