### PR TITLE
[RFC][DNM]DTS service nodes

### DIFF
--- a/dts/bindings/services/service.yaml
+++ b/dts/bindings/services/service.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for all services
+
+properties:
+    compatible:
+        type: string-array
+        required: true
+        description: compatible strings
+
+    status:
+        type: string
+        required: true
+        description: indicates the operational status of a service
+        enum:
+           - "okay"
+           - "disabled"
+
+    reg:
+        type: array
+        description: register space
+        required: false

--- a/dts/bindings/services/zephyr,uart-console.yaml
+++ b/dts/bindings/services/zephyr,uart-console.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2020 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Zephyr generic UART console service
+
+include: [service.yaml]
+
+compatible: "zephyr,uart-console"
+
+properties:
+    uart:
+        type: phandle
+        required: true
+        description: phandle to uart node

--- a/dts/x86/ia32.dtsi
+++ b/dts/x86/ia32.dtsi
@@ -71,4 +71,17 @@
 			status = "disabled";
 		};
 	};
+
+	services {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		console@0 {
+			compatible = "zephyr,uart-console";
+			uart = <&uart0>;
+			reg = <0>;
+
+			status = "okay";
+		 };
+	};
 };


### PR DESCRIPTION
This is an attempt to expose "software services" as DTS nodes.

Software services are mostly all these code being initialized through SYS_INIT() (it currently creates a struct device, but most of them are just not devices per-se)

Exposing them is a primary requirement for fixing #22545 
(Or then we will have a problem with all these hardcoded leve/prio used on SYS_INIT())

So I took a quick example with the UART console for qemu_x86, so you'll get an idea.

I put it into a services {} .dtsi root node, it has nothing to do in soc {}, as it is _not_ a hardware device being exposed.