### PR TITLE
drivers: ethernet: eth_sam_gmac: Detect and report link status

### DIFF
--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -77,6 +77,14 @@ config ETH_SAM_GMAC_IRQ_PRI
 	help
 	  IRQ priority of Ethernet device
 
+config ETH_SAM_GMAC_MONITOR_PERIOD
+	int "Monitor task execution period"
+	default 1000
+	help
+	  Monitor task execution period in milliseconds. The monitor task is
+	  periodically executed to detect and report any changes in the PHY
+	  link status to the operating system.
+
 choice ETH_SAM_GMAC_MAC_SELECT
 	prompt "MAC address"
 	help

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1150,7 +1150,6 @@ static void link_configure(Gmac *gmac, u32_t flags)
 
 	gmac->GMAC_NCFGR = val;
 
-	gmac->GMAC_UR = 0;  /* Select RMII mode */
 	gmac->GMAC_NCR |= (GMAC_NCR_RXEN | GMAC_NCR_TXEN);
 }
 

--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -257,6 +257,8 @@ struct eth_sam_dev_data {
 	struct device *ptp_clock;
 #endif
 	u8_t mac_addr[6];
+	struct k_delayed_work monitor_work;
+	bool link_up;
 	struct gmac_queue queue_list[GMAC_QUEUE_NUM];
 };
 

--- a/drivers/ethernet/phy_sam_gmac.c
+++ b/drivers/ethernet/phy_sam_gmac.c
@@ -187,6 +187,22 @@ u32_t phy_sam_gmac_id_get(const struct phy_sam_gmac_dev *phy)
 	return phy_id;
 }
 
+bool phy_sam_gmac_link_status_get(const struct phy_sam_gmac_dev *phy)
+{
+	Gmac * const gmac = phy->regs;
+	u32_t bmsr;
+
+	mdio_bus_enable(gmac);
+
+	if (phy_read(phy, MII_BMSR, &bmsr) < 0) {
+		return false;
+	}
+
+	mdio_bus_disable(gmac);
+
+	return (bmsr & MII_BMSR_LINK_STATUS) != 0;
+}
+
 int phy_sam_gmac_auto_negotiate(const struct phy_sam_gmac_dev *phy,
 				u32_t *status)
 {

--- a/drivers/ethernet/phy_sam_gmac.h
+++ b/drivers/ethernet/phy_sam_gmac.h
@@ -53,6 +53,14 @@ int phy_sam_gmac_auto_negotiate(const struct phy_sam_gmac_dev *phy,
  */
 u32_t phy_sam_gmac_id_get(const struct phy_sam_gmac_dev *phy);
 
+/**
+ * @brief Get PHY link status.
+ *
+ * @param phy PHY instance
+ * @return link status
+ */
+bool phy_sam_gmac_link_status_get(const struct phy_sam_gmac_dev *phy);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This commit adds the "monitor task" to detect and report any changes
in the PHY link status to the operating system.

The monitor task is perodically executed to poll the link status from
the PHY and call `net_eth_carrier_{off,on}` based on the detected
link status change.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Closes #16096 and #23386 (duplicate)

https://gist.github.com/stephanosio/1bdbca520fc068ac5ad3b99834fc4582