### PR TITLE
drivers: modem: wncm14a2a: fix RX socket src/dst port assignment

### DIFF
--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -478,6 +478,8 @@ static int pkt_setup_ip_data(struct net_pkt *pkt,
 			    &((struct sockaddr_in6 *)&sock->src)->sin6_addr)) {
 			return -1;
 		}
+		src_port = ntohs(net_sin6(&sock->src)->sin6_port);
+		dst_port = ntohs(net_sin6(&sock->dst)->sin6_port);
 
 		hdr_len = sizeof(struct net_ipv6_hdr);
 	} else
@@ -490,6 +492,8 @@ static int pkt_setup_ip_data(struct net_pkt *pkt,
 			    &((struct sockaddr_in *)&sock->src)->sin_addr)) {
 			return -1;
 		}
+		src_port = ntohs(net_sin(&sock->src)->sin_port);
+		dst_port = ntohs(net_sin(&sock->dst)->sin_port);
 
 		hdr_len = sizeof(struct net_ipv4_hdr);
 	} else
@@ -500,7 +504,7 @@ static int pkt_setup_ip_data(struct net_pkt *pkt,
 
 #if defined(CONFIG_NET_UDP)
 	if (sock->ip_proto == IPPROTO_UDP) {
-		if (net_udp_create(pkt, src_port, dst_port)) {
+		if (net_udp_create(pkt, dst_port, src_port)) {
 			return -1;
 		}
 
@@ -520,8 +524,8 @@ static int pkt_setup_ip_data(struct net_pkt *pkt,
 		(void)memset(tcp, 0, NET_TCPH_LEN);
 
 		/* Setup TCP header */
-		tcp->src_port = src_port;
-		tcp->dst_port = dst_port;
+		tcp->src_port = dst_port;
+		tcp->dst_port = src_port;
 
 		if (net_pkt_set_data(pkt, &tcp_access)) {
 			return -1;


### PR DESCRIPTION
Source and destination ports should be set properly when assembling the receive socket data.
