### PR TITLE
doc: board_porting: Provide guideline on MPU activation

### DIFF
--- a/doc/guides/porting/board_porting.rst
+++ b/doc/guides/porting/board_porting.rst
@@ -372,6 +372,10 @@ while porting.
 
 - If available, enable pinmux and interrupt controller drivers.
 
+- It is recommended to enable the MPU by default, if there is support for it
+  in hardware. For boards with limited memory resources it is acceptable to
+  disable it.
+
 .. _flash-and-debug-support:
 
 Flash and debug support


### PR DESCRIPTION
Provide a rule to settle on MPU activation by default.
Request is to activate it by default if board resources allow.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>