### PR TITLE
Refactor device structures

### DIFF
--- a/boards/arm/thingy52_nrf52832/board.c
+++ b/boards/arm/thingy52_nrf52832/board.c
@@ -18,7 +18,7 @@ struct pwr_ctrl_cfg {
 
 static int pwr_ctrl_init(struct device *dev)
 {
-	const struct pwr_ctrl_cfg *cfg = dev->config->config_info;
+	const struct pwr_ctrl_cfg *cfg = dev->config_info;
 	struct device *gpio;
 
 	gpio = device_get_binding(cfg->port);

--- a/doc/guides/dts/howtos.rst
+++ b/doc/guides/dts/howtos.rst
@@ -399,7 +399,7 @@ As shown above, the driver uses additional information from
 :file:`devicetree.h` to create :ref:`struct device <device_struct>` instances
 than just the node label. Devicetree property values used to configure the
 device at boot time are stored in ROM in the value pointed to by a
-``device->config->config_info`` field. This allows users to configure your
+``device->config_info`` field. This allows users to configure your
 driver using overlays.
 
 The Zephyr convention is to name each ``struct device`` using its devicetree

--- a/doc/reference/drivers/index.rst
+++ b/doc/reference/drivers/index.rst
@@ -261,7 +261,7 @@ In the implementation of the common init function:
 
   int my_driver_init(struct device *device)
   {
-        const struct my_driver_config *config = device->config->config_info;
+        const struct my_driver_config *config = device->config_info;
 
         /* Do other initialization stuff */
         ...

--- a/doc/reference/usermode/syscalls.rst
+++ b/doc/reference/usermode/syscalls.rst
@@ -295,10 +295,10 @@ Several macros exist to validate arguments:
 * :c:macro:`Z_SYSCALL_SPECIFIC_DRIVER()` is a runtime check to verify that
   a provided pointer is a valid instance of a specific device driver, that
   the calling thread has permissions on it, and that the driver has been
-  initialized. It does this by checking the init function pointer that
+  initialized. It does this by checking the API structure pointer that
   is stored within the driver instance and ensuring that it matches the
   provided value, which should be the address of the specific driver's
-  init function.
+  API structure.
 
 If any check fails, the macros will return a nonzero value. The macro
 :c:macro:`Z_OOPS()` can be used to induce a kernel oops which will kill the

--- a/drivers/adc/adc_lmp90xxx.c
+++ b/drivers/adc/adc_lmp90xxx.c
@@ -175,7 +175,7 @@ static inline u8_t lmp90xxx_inst2_sz(size_t len)
 static int lmp90xxx_read_reg(struct device *dev, u8_t addr, u8_t *dptr,
 			     size_t len)
 {
-	const struct lmp90xxx_config *config = dev->config->config_info;
+	const struct lmp90xxx_config *config = dev->config_info;
 	struct lmp90xxx_data *data = dev->driver_data;
 	u8_t ura = LMP90XXX_URA(addr);
 	u8_t inst1_uab[2] = { LMP90XXX_INST1_WAB, ura };
@@ -249,7 +249,7 @@ static int lmp90xxx_read_reg8(struct device *dev, u8_t addr, u8_t *val)
 static int lmp90xxx_write_reg(struct device *dev, u8_t addr, u8_t *dptr,
 			      size_t len)
 {
-	const struct lmp90xxx_config *config = dev->config->config_info;
+	const struct lmp90xxx_config *config = dev->config_info;
 	struct lmp90xxx_data *data = dev->driver_data;
 	u8_t ura = LMP90XXX_URA(addr);
 	u8_t inst1_uab[2] = { LMP90XXX_INST1_WAB, ura };
@@ -327,7 +327,7 @@ static int lmp90xxx_soft_reset(struct device *dev)
 
 static inline bool lmp90xxx_has_channel(struct device *dev, u8_t channel)
 {
-	const struct lmp90xxx_config *config = dev->config->config_info;
+	const struct lmp90xxx_config *config = dev->config_info;
 
 	if (channel >= config->channels) {
 		return false;
@@ -338,7 +338,7 @@ static inline bool lmp90xxx_has_channel(struct device *dev, u8_t channel)
 
 static inline bool lmp90xxx_has_input(struct device *dev, u8_t input)
 {
-	const struct lmp90xxx_config *config = dev->config->config_info;
+	const struct lmp90xxx_config *config = dev->config_info;
 
 	if (input >= LMP90XXX_MAX_INPUTS) {
 		return false;
@@ -496,7 +496,7 @@ static int lmp90xxx_validate_buffer_size(const struct adc_sequence *sequence)
 static int lmp90xxx_adc_start_read(struct device *dev,
 				   const struct adc_sequence *sequence)
 {
-	const struct lmp90xxx_config *config = dev->config->config_info;
+	const struct lmp90xxx_config *config = dev->config_info;
 	struct lmp90xxx_data *data = dev->driver_data;
 	int err;
 
@@ -569,7 +569,7 @@ static void adc_context_update_buffer_pointer(struct adc_context *ctx,
 static int lmp90xxx_adc_read_channel(struct device *dev, u8_t channel,
 				     s32_t *result)
 {
-	const struct lmp90xxx_config *config = dev->config->config_info;
+	const struct lmp90xxx_config *config = dev->config_info;
 	struct lmp90xxx_data *data = dev->driver_data;
 	u8_t adc_done;
 	u8_t ch_scan;
@@ -913,7 +913,7 @@ int lmp90xxx_gpio_port_toggle_bits(struct device *dev, gpio_port_pins_t pins)
 
 static int lmp90xxx_init(struct device *dev)
 {
-	const struct lmp90xxx_config *config = dev->config->config_info;
+	const struct lmp90xxx_config *config = dev->config_info;
 	struct lmp90xxx_data *data = dev->driver_data;
 	struct device *drdyb_dev;
 	int err;

--- a/drivers/adc/adc_mcp320x.c
+++ b/drivers/adc/adc_mcp320x.c
@@ -51,7 +51,7 @@ struct mcp320x_data {
 static int mcp320x_channel_setup(struct device *dev,
 				 const struct adc_channel_cfg *channel_cfg)
 {
-	const struct mcp320x_config *config = dev->config->config_info;
+	const struct mcp320x_config *config = dev->config_info;
 	struct mcp320x_data *data = dev->driver_data;
 
 	if (channel_cfg->gain != ADC_GAIN_1) {
@@ -85,7 +85,7 @@ static int mcp320x_channel_setup(struct device *dev,
 static int mcp320x_validate_buffer_size(struct device *dev,
 					const struct adc_sequence *sequence)
 {
-	const struct mcp320x_config *config = dev->config->config_info;
+	const struct mcp320x_config *config = dev->config_info;
 	u8_t channels = 0;
 	size_t needed;
 	u32_t mask;
@@ -111,7 +111,7 @@ static int mcp320x_validate_buffer_size(struct device *dev,
 static int mcp320x_start_read(struct device *dev,
 			      const struct adc_sequence *sequence)
 {
-	const struct mcp320x_config *config = dev->config->config_info;
+	const struct mcp320x_config *config = dev->config_info;
 	struct mcp320x_data *data = dev->driver_data;
 	int err;
 
@@ -180,7 +180,7 @@ static void adc_context_update_buffer_pointer(struct adc_context *ctx,
 
 static int mcp320x_read_channel(struct device *dev, u8_t channel, u16_t *result)
 {
-	const struct mcp320x_config *config = dev->config->config_info;
+	const struct mcp320x_config *config = dev->config_info;
 	struct mcp320x_data *data = dev->driver_data;
 	u8_t tx_bytes[2];
 	u8_t rx_bytes[2];
@@ -272,7 +272,7 @@ static void mcp320x_acquisition_thread(struct device *dev)
 
 static int mcp320x_init(struct device *dev)
 {
-	const struct mcp320x_config *config = dev->config->config_info;
+	const struct mcp320x_config *config = dev->config_info;
 	struct mcp320x_data *data = dev->driver_data;
 
 	k_sem_init(&data->sem, 0, 1);

--- a/drivers/adc/adc_mcux_adc12.c
+++ b/drivers/adc/adc_mcux_adc12.c
@@ -73,7 +73,7 @@ static int mcux_adc12_channel_setup(struct device *dev,
 static int mcux_adc12_start_read(struct device *dev,
 				 const struct adc_sequence *sequence)
 {
-	const struct mcux_adc12_config *config = dev->config->config_info;
+	const struct mcux_adc12_config *config = dev->config_info;
 	struct mcux_adc12_data *data = dev->driver_data;
 	adc12_hardware_average_mode_t mode;
 	adc12_resolution_t resolution;
@@ -152,7 +152,7 @@ static int mcux_adc12_read(struct device *dev,
 
 static void mcux_adc12_start_channel(struct device *dev)
 {
-	const struct mcux_adc12_config *config = dev->config->config_info;
+	const struct mcux_adc12_config *config = dev->config_info;
 	struct mcux_adc12_data *data = dev->driver_data;
 
 	adc12_channel_config_t channel_config;
@@ -191,7 +191,7 @@ static void adc_context_update_buffer_pointer(struct adc_context *ctx,
 static void mcux_adc12_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct mcux_adc12_config *config = dev->config->config_info;
+	const struct mcux_adc12_config *config = dev->config_info;
 	struct mcux_adc12_data *data = dev->driver_data;
 	ADC_Type *base = config->base;
 	u32_t channel_group = 0U;
@@ -213,7 +213,7 @@ static void mcux_adc12_isr(void *arg)
 
 static int mcux_adc12_init(struct device *dev)
 {
-	const struct mcux_adc12_config *config = dev->config->config_info;
+	const struct mcux_adc12_config *config = dev->config_info;
 	struct mcux_adc12_data *data = dev->driver_data;
 	ADC_Type *base = config->base;
 	adc12_config_t adc_config;

--- a/drivers/adc/adc_mcux_adc16.c
+++ b/drivers/adc/adc_mcux_adc16.c
@@ -66,7 +66,7 @@ static int mcux_adc16_channel_setup(struct device *dev,
 
 static int start_read(struct device *dev, const struct adc_sequence *sequence)
 {
-	const struct mcux_adc16_config *config = dev->config->config_info;
+	const struct mcux_adc16_config *config = dev->config_info;
 	struct mcux_adc16_data *data = dev->driver_data;
 	adc16_hardware_average_mode_t mode;
 	adc16_resolution_t resolution;
@@ -162,7 +162,7 @@ static int mcux_adc16_read_async(struct device *dev,
 
 static void mcux_adc16_start_channel(struct device *dev)
 {
-	const struct mcux_adc16_config *config = dev->config->config_info;
+	const struct mcux_adc16_config *config = dev->config_info;
 	struct mcux_adc16_data *data = dev->driver_data;
 
 	adc16_channel_config_t channel_config;
@@ -205,7 +205,7 @@ static void adc_context_update_buffer_pointer(struct adc_context *ctx,
 static void mcux_adc16_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct mcux_adc16_config *config = dev->config->config_info;
+	const struct mcux_adc16_config *config = dev->config_info;
 	struct mcux_adc16_data *data = dev->driver_data;
 	ADC_Type *base = config->base;
 	u32_t channel_group = 0U;
@@ -227,7 +227,7 @@ static void mcux_adc16_isr(void *arg)
 
 static int mcux_adc16_init(struct device *dev)
 {
-	const struct mcux_adc16_config *config = dev->config->config_info;
+	const struct mcux_adc16_config *config = dev->config_info;
 	struct mcux_adc16_data *data = dev->driver_data;
 	ADC_Type *base = config->base;
 	adc16_config_t adc_config;

--- a/drivers/adc/adc_nrfx_adc.c
+++ b/drivers/adc/adc_nrfx_adc.c
@@ -257,7 +257,7 @@ static int init_adc(struct device *dev)
 
 	if (result != NRFX_SUCCESS) {
 		LOG_ERR("Failed to initialize device: %s",
-			    dev->config->name);
+			    dev->name);
 		return -EBUSY;
 	}
 

--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -59,7 +59,7 @@ struct adc_sam0_cfg {
 };
 
 #define DEV_CFG(dev) \
-	((const struct adc_sam0_cfg *const)(dev)->config->config_info)
+	((const struct adc_sam0_cfg *const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct adc_sam0_data *)(dev)->driver_data)
 

--- a/drivers/adc/adc_sam_afec.c
+++ b/drivers/adc/adc_sam_afec.c
@@ -63,7 +63,7 @@ struct adc_sam_cfg {
 };
 
 #define DEV_CFG(dev) \
-	((const struct adc_sam_cfg *const)(dev)->config->config_info)
+	((const struct adc_sam_cfg *const)(dev)->config_info)
 
 #define DEV_DATA(dev) \
 	((struct adc_sam_data *)(dev)->driver_data)

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -245,7 +245,7 @@ static int check_buffer_size(const struct adc_sequence *sequence,
 
 static void adc_stm32_start_conversion(struct device *dev)
 {
-	const struct adc_stm32_cfg *config = dev->config->config_info;
+	const struct adc_stm32_cfg *config = dev->config_info;
 	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
 
 	LOG_DBG("Starting conversion");
@@ -265,7 +265,7 @@ static void adc_stm32_start_conversion(struct device *dev)
 
 static int start_read(struct device *dev, const struct adc_sequence *sequence)
 {
-	const struct adc_stm32_cfg *config = dev->config->config_info;
+	const struct adc_stm32_cfg *config = dev->config_info;
 	struct adc_stm32_data *data = dev->driver_data;
 	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
 	u8_t resolution;
@@ -390,7 +390,7 @@ static void adc_stm32_isr(void *arg)
 	struct device *dev = (struct device *)arg;
 	struct adc_stm32_data *data = (struct adc_stm32_data *)dev->driver_data;
 	struct adc_stm32_cfg *config =
-		(struct adc_stm32_cfg *)dev->config->config_info;
+		(struct adc_stm32_cfg *)dev->config_info;
 	ADC_TypeDef *adc = config->base;
 
 	*data->buffer++ = LL_ADC_REG_ReadConversionData32(adc);
@@ -450,7 +450,7 @@ static void adc_stm32_setup_speed(struct device *dev, u8_t id,
 				  u8_t acq_time_index)
 {
 	struct adc_stm32_cfg *config =
-		(struct adc_stm32_cfg *)dev->config->config_info;
+		(struct adc_stm32_cfg *)dev->config_info;
 	ADC_TypeDef *adc = config->base;
 
 #if defined(CONFIG_SOC_SERIES_STM32F0X) || defined(CONFIG_SOC_SERIES_STM32L0X)
@@ -523,7 +523,7 @@ static int adc_stm32_channel_setup(struct device *dev,
 static void adc_stm32_calib(struct device *dev)
 {
 	struct adc_stm32_cfg *config =
-		(struct adc_stm32_cfg *)dev->config->config_info;
+		(struct adc_stm32_cfg *)dev->config_info;
 	ADC_TypeDef *adc = config->base;
 
 #if defined(CONFIG_SOC_SERIES_STM32F3X) || \
@@ -545,7 +545,7 @@ static void adc_stm32_calib(struct device *dev)
 static int adc_stm32_init(struct device *dev)
 {
 	struct adc_stm32_data *data = dev->driver_data;
-	const struct adc_stm32_cfg *config = dev->config->config_info;
+	const struct adc_stm32_cfg *config = dev->config_info;
 	struct device *clk =
 		device_get_binding(STM32_CLOCK_CONTROL_NAME);
 	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;

--- a/drivers/audio/intel_dmic.c
+++ b/drivers/audio/intel_dmic.c
@@ -1310,7 +1310,7 @@ static int dmic_initialize_device(struct device *dev)
 	/* Set state, note there is no playback direction support */
 	dmic_private.state = DMIC_STATE_INITIALIZED;
 
-	LOG_DBG("Device %s Initialized", dev->config->name);
+	LOG_DBG("Device %s Initialized", dev->name);
 
 	return 0;
 }

--- a/drivers/audio/mpxxdtyy.h
+++ b/drivers/audio/mpxxdtyy.h
@@ -20,7 +20,7 @@ extern "C" {
 #define MPXXDTYY_MAX_PDM_FREQ		3250000 /* 3.25MHz */
 
 #define DEV_CFG(dev) \
-	((struct mpxxdtyy_config *const)(dev)->config->config_info)
+	((struct mpxxdtyy_config *const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct mpxxdtyy_data *const)(dev)->driver_data)
 

--- a/drivers/audio/tlv320dac310x.c
+++ b/drivers/audio/tlv320dac310x.c
@@ -51,7 +51,7 @@ static struct codec_driver_config codec_device_config = {
 static struct codec_driver_data codec_device_data;
 
 #define DEV_CFG(dev) \
-	((struct codec_driver_config *const)(dev)->config->config_info)
+	((struct codec_driver_config *const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct codec_driver_data *const)(dev)->driver_data)
 

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -98,7 +98,7 @@ int can_loopback_send(struct device *dev, const struct zcan_frame *frame,
 	struct k_sem tx_sem;
 
 	LOG_DBG("Sending %d bytes on %s. Id: 0x%x, ID type: %s %s",
-		frame->dlc, dev->config->name,
+		frame->dlc, dev->name,
 		frame->id_type == CAN_STANDARD_IDENTIFIER ?
 				  frame->std_id : frame->ext_id,
 		frame->id_type == CAN_STANDARD_IDENTIFIER ?
@@ -267,7 +267,8 @@ static int can_loopback_init(struct device *dev)
 		return -1;
 	}
 
-	LOG_INF("Init of %s done", dev->config->name);
+	LOG_INF("Init of %s done", dev->name);
+
 	return 0;
 }
 
@@ -290,7 +291,7 @@ static int socket_can_init_1(struct device *dev)
 	struct socket_can_context *socket_context = dev->driver_data;
 
 	LOG_DBG("Init socket CAN device %p (%s) for dev %p (%s)",
-		dev, dev->config->name, can_dev, can_dev->config->name);
+		dev, dev->name, can_dev, can_dev->name);
 
 	socket_context->can_dev = can_dev;
 	socket_context->msgq = &socket_can_msgq;

--- a/drivers/can/can_loopback.h
+++ b/drivers/can/can_loopback.h
@@ -12,7 +12,7 @@
 
 #define DEV_DATA(dev) ((struct can_loopback_data *const)(dev)->driver_data)
 #define DEV_CFG(dev) \
-	((const struct can_loopback_config *const)(dev)->config->config_info)
+	((const struct can_loopback_config *const)(dev)->config_info)
 
 struct can_loopback_filter {
 	can_rx_callback_t rx_cb;

--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -15,7 +15,7 @@
 #define MCP2515_FRAME_LEN               13
 
 #define DEV_CFG(dev) \
-	((const struct mcp2515_config *const)(dev)->config->config_info)
+	((const struct mcp2515_config *const)(dev)->config_info)
 #define DEV_DATA(dev) ((struct mcp2515_data *const)(dev)->driver_data)
 
 struct mcp2515_tx_cb {

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -95,7 +95,7 @@ struct mcux_flexcan_data {
 static int mcux_flexcan_configure(struct device *dev, enum can_mode mode,
 				  u32_t bitrate)
 {
-	const struct mcux_flexcan_config *config = dev->config->config_info;
+	const struct mcux_flexcan_config *config = dev->config_info;
 	flexcan_config_t flexcan_config;
 	struct device *clock_dev;
 	u32_t clock_freq;
@@ -249,7 +249,7 @@ static int mcux_flexcan_send(struct device *dev, const struct zcan_frame *msg,
 			     k_timeout_t timeout,
 			     can_tx_callback_t callback_isr, void *callback_arg)
 {
-	const struct mcux_flexcan_config *config = dev->config->config_info;
+	const struct mcux_flexcan_config *config = dev->config_info;
 	struct mcux_flexcan_data *data = dev->driver_data;
 	flexcan_mb_transfer_t xfer;
 	status_t status;
@@ -299,7 +299,7 @@ static int mcux_flexcan_attach_isr(struct device *dev, can_rx_callback_t isr,
 				   void *callback_arg,
 				   const struct zcan_filter *filter)
 {
-	const struct mcux_flexcan_config *config = dev->config->config_info;
+	const struct mcux_flexcan_config *config = dev->config_info;
 	struct mcux_flexcan_data *data = dev->driver_data;
 	flexcan_mb_transfer_t xfer;
 	status_t status;
@@ -361,7 +361,7 @@ static void mcux_flexcan_register_state_change_isr(struct device *dev,
 static enum can_state mcux_flexcan_get_state(struct device *dev,
 					     struct can_bus_err_cnt *err_cnt)
 {
-	const struct mcux_flexcan_config *config = dev->config->config_info;
+	const struct mcux_flexcan_config *config = dev->config_info;
 	u32_t status_flags;
 
 	if (err_cnt) {
@@ -386,7 +386,7 @@ static enum can_state mcux_flexcan_get_state(struct device *dev,
 #ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 int mcux_flexcan_recover(struct device *dev, k_timeout_t timeout)
 {
-	const struct mcux_flexcan_config *config = dev->config->config_info;
+	const struct mcux_flexcan_config *config = dev->config_info;
 	int ret = 0;
 	u64_t start_time;
 
@@ -414,7 +414,7 @@ int mcux_flexcan_recover(struct device *dev, k_timeout_t timeout)
 
 static void mcux_flexcan_detach(struct device *dev, int filter_id)
 {
-	const struct mcux_flexcan_config *config = dev->config->config_info;
+	const struct mcux_flexcan_config *config = dev->config_info;
 	struct mcux_flexcan_data *data = dev->driver_data;
 
 	if (filter_id >= MCUX_FLEXCAN_MAX_RX) {
@@ -443,7 +443,7 @@ static void mcux_flexcan_detach(struct device *dev, int filter_id)
 static inline void mcux_flexcan_transfer_error_status(struct device *dev,
 						      u32_t error)
 {
-	const struct mcux_flexcan_config *config = dev->config->config_info;
+	const struct mcux_flexcan_config *config = dev->config_info;
 	struct mcux_flexcan_data *data = dev->driver_data;
 	can_tx_callback_t function;
 	int status = CAN_TX_OK;
@@ -545,7 +545,7 @@ static inline void mcux_flexcan_transfer_tx_idle(struct device *dev,
 static inline void mcux_flexcan_transfer_rx_idle(struct device *dev,
 						 u32_t mb)
 {
-	const struct mcux_flexcan_config *config = dev->config->config_info;
+	const struct mcux_flexcan_config *config = dev->config_info;
 	struct mcux_flexcan_data *data = dev->driver_data;
 	can_rx_callback_t function;
 	flexcan_mb_transfer_t xfer;
@@ -606,7 +606,7 @@ static void mcux_flexcan_transfer_callback(CAN_Type *base,
 static void mcux_flexcan_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct mcux_flexcan_config *config = dev->config->config_info;
+	const struct mcux_flexcan_config *config = dev->config_info;
 	struct mcux_flexcan_data *data = dev->driver_data;
 
 	FLEXCAN_TransferHandleIRQ(config->base, &data->handle);
@@ -614,7 +614,7 @@ static void mcux_flexcan_isr(void *arg)
 
 static int mcux_flexcan_init(struct device *dev)
 {
-	const struct mcux_flexcan_config *config = dev->config->config_info;
+	const struct mcux_flexcan_config *config = dev->config_info;
 	struct mcux_flexcan_data *data = dev->driver_data;
 	int err;
 	int i;
@@ -733,7 +733,7 @@ static int socket_can_init_0(struct device *dev)
 	struct socket_can_context *socket_context = dev->driver_data;
 
 	LOG_DBG("Init socket CAN device %p (%s) for dev %p (%s)",
-		dev, dev->config->name, can_dev, can_dev->config->name);
+		dev, dev->name, can_dev, can_dev->name);
 
 	socket_context->can_dev = can_dev;
 	socket_context->msgq = &socket_can_msgq;

--- a/drivers/can/can_net.c
+++ b/drivers/can/can_net.c
@@ -390,7 +390,7 @@ static int net_can_init(struct device *dev)
 	}
 
 	NET_DBG("Init net CAN device %p (%s) for dev %p (%s)",
-		dev, dev->config->name, can_dev, can_dev->config->name);
+		dev, dev->name, can_dev, can_dev->name);
 
 	ctx->can_dev = can_dev;
 

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -378,7 +378,7 @@ int can_stm32_runtime_configure(struct device *dev, enum can_mode mode,
 		goto done;
 	}
 
-	LOG_DBG("Runtime configure of %s done", dev->config->name);
+	LOG_DBG("Runtime configure of %s done", dev->name);
 	ret = 0;
 done:
 	k_mutex_unlock(&data->inst_mutex);
@@ -456,7 +456,7 @@ static int can_stm32_init(struct device *dev)
 
 	cfg->config_irq(can);
 	can->IER |= CAN_IER_TMEIE;
-	LOG_INF("Init of %s done", dev->config->name);
+	LOG_INF("Init of %s done", dev->name);
 	return 0;
 }
 
@@ -558,7 +558,7 @@ int can_stm32_send(struct device *dev, const struct zcan_frame *msg,
 		    "Id: 0x%x, "
 		    "ID type: %s, "
 		    "Remote Frame: %s"
-		    , msg->dlc, dev->config->name
+		    , msg->dlc, dev->name
 		    , msg->id_type == CAN_STANDARD_IDENTIFIER ?
 				      msg->std_id :  msg->ext_id
 		    , msg->id_type == CAN_STANDARD_IDENTIFIER ?
@@ -1112,7 +1112,7 @@ static int socket_can_init_1(struct device *dev)
 	struct socket_can_context *socket_context = dev->driver_data;
 
 	LOG_DBG("Init socket CAN device %p (%s) for dev %p (%s)",
-		dev, dev->config->name, can_dev, can_dev->config->name);
+		dev, dev->name, can_dev, can_dev->name);
 
 	socket_context->can_dev = can_dev;
 	socket_context->msgq = &socket_can_msgq;
@@ -1196,7 +1196,7 @@ static int socket_can_init_2(struct device *dev)
 	struct socket_can_context *socket_context = dev->driver_data;
 
 	LOG_DBG("Init socket CAN device %p (%s) for dev %p (%s)",
-		dev, dev->config->name, can_dev, can_dev->config->name);
+		dev, dev->name, can_dev, can_dev->name);
 
 	socket_context->can_dev = can_dev;
 	socket_context->msgq = &socket_can_msgq;

--- a/drivers/can/can_stm32.h
+++ b/drivers/can/can_stm32.h
@@ -12,7 +12,7 @@
 
 #define DEV_DATA(dev) ((struct can_stm32_data *const)(dev)->driver_data)
 #define DEV_CFG(dev) \
-	((const struct can_stm32_config *const)(dev)->config->config_info)
+	((const struct can_stm32_config *const)(dev)->config_info)
 
 #define BIT_SEG_LENGTH(cfg) ((cfg)->prop_ts1 + (cfg)->ts2 + 1)
 

--- a/drivers/clock_control/beetle_clock_control.c
+++ b/drivers/clock_control/beetle_clock_control.c
@@ -133,7 +133,7 @@ static int beetle_clock_control_get_subsys_rate(struct device *clock,
 {
 #ifdef CONFIG_CLOCK_CONTROL_BEETLE_ENABLE_PLL
 	const struct beetle_clock_control_cfg_t * const cfg =
-						clock->config->config_info;
+						clock->config_info;
 	u32_t nc_mainclk = beetle_round_freq(cfg->freq);
 
 	*rate = nc_mainclk;
@@ -219,7 +219,7 @@ static int beetle_clock_control_init(struct device *dev)
 {
 #ifdef CONFIG_CLOCK_CONTROL_BEETLE_ENABLE_PLL
 	const struct beetle_clock_control_cfg_t * const cfg =
-						dev->config->config_info;
+						dev->config_info;
 
 	/*
 	 * Enable PLL if Beetle is configured to run at a different

--- a/drivers/clock_control/clock_control_mcux_pcc.c
+++ b/drivers/clock_control/clock_control_mcux_pcc.c
@@ -22,7 +22,7 @@ struct mcux_pcc_config {
 	u32_t base_address;
 };
 
-#define DEV_CFG(dev)  ((struct mcux_pcc_config *)(dev->config->config_info))
+#define DEV_CFG(dev)  ((struct mcux_pcc_config *)(dev->config_info))
 #define DEV_BASE(dev) (DEV_CFG(dev)->base_address)
 #ifndef MAKE_PCC_REGADDR
 #define MAKE_PCC_REGADDR(base, offset) ((base) + (offset))

--- a/drivers/clock_control/clock_control_rv32m1_pcc.c
+++ b/drivers/clock_control/clock_control_rv32m1_pcc.c
@@ -18,7 +18,7 @@ struct rv32m1_pcc_config {
 	u32_t base_address;
 };
 
-#define DEV_CFG(dev)  ((struct rv32m1_pcc_config *)(dev->config->config_info))
+#define DEV_CFG(dev)  ((struct rv32m1_pcc_config *)(dev->config_info))
 #define DEV_BASE(dev) (DEV_CFG(dev)->base_address)
 
 static inline clock_ip_name_t clock_ip(struct device *dev,

--- a/drivers/clock_control/nrf_power_clock.c
+++ b/drivers/clock_control/nrf_power_clock.c
@@ -113,7 +113,7 @@ static const struct nrf_clock_control_sub_config *get_sub_config(
 					enum clock_control_nrf_type type)
 {
 	const struct nrf_clock_control_config *config =
-						dev->config->config_info;
+						dev->config_info;
 
 	return &config->subsys[type];
 }

--- a/drivers/console/ipm_console_receiver.c
+++ b/drivers/console/ipm_console_receiver.c
@@ -28,7 +28,7 @@ static void ipm_console_thread(void *arg1, void *arg2, void *arg3)
 
 	d = (struct device *)arg1;
 	driver_data = d->driver_data;
-	config_info = d->config->config_info;
+	config_info = d->config_info;
 	ARG_UNUSED(arg2);
 	size32 = 0U;
 	pos = 0;
@@ -54,11 +54,11 @@ static void ipm_console_thread(void *arg1, void *arg2, void *arg3)
 				config_info->line_buf[pos + 1] = '\0';
 			}
 			if (config_info->flags & IPM_CONSOLE_PRINTK) {
-				printk("%s: '%s'\n", d->config->name,
+				printk("%s: '%s'\n", d->name,
 				       config_info->line_buf);
 			}
 			if (config_info->flags & IPM_CONSOLE_STDOUT) {
-				printf("%s: '%s'\n", d->config->name,
+				printf("%s: '%s'\n", d->name,
 				       config_info->line_buf);
 			}
 			pos = 0;
@@ -118,7 +118,7 @@ static void ipm_console_receive_callback(void *context, u32_t id,
 int ipm_console_receiver_init(struct device *d)
 {
 	const struct ipm_console_receiver_config_info *config_info =
-		d->config->config_info;
+		d->config_info;
 	struct ipm_console_receiver_runtime_data *driver_data = d->driver_data;
 	struct device *ipm;
 

--- a/drivers/console/ipm_console_sender.c
+++ b/drivers/console/ipm_console_sender.c
@@ -37,7 +37,7 @@ int ipm_console_sender_init(struct device *d)
 {
 	const struct ipm_console_sender_config_info *config_info;
 
-	config_info = d->config->config_info;
+	config_info = d->config_info;
 	ipm_console_device = device_get_binding(config_info->bind_to);
 
 	if (!ipm_console_device) {

--- a/drivers/console/uart_mux.c
+++ b/drivers/console/uart_mux.c
@@ -175,7 +175,7 @@ static void uart_mux_rx_work(struct k_work *work)
 		char tmp[sizeof("RECV muxed ") + 10];
 
 		snprintk(tmp, sizeof(tmp), "RECV muxed %s",
-			 uart_mux->uart->config->name);
+			 uart_mux->uart->name);
 		LOG_HEXDUMP_DBG(data, len, log_strdup(tmp));
 	}
 
@@ -209,7 +209,7 @@ static void uart_mux_tx_work(struct k_work *work)
 			 sizeof(CONFIG_UART_MUX_DEVICE_NAME)];
 
 		snprintk(tmp, sizeof(tmp), "SEND %s",
-			 dev_data->dev->config->name);
+			 dev_data->dev->name);
 		LOG_HEXDUMP_DBG(data, len, log_strdup(tmp));
 	}
 
@@ -234,7 +234,7 @@ static int uart_mux_init(struct device *dev)
 	k_work_init(&dev_data->cb_work, uart_mux_cb_work);
 
 	LOG_DBG("Device %s dev %p dev_data %p cfg %p created",
-		dev->config->name, dev, dev_data, dev->config->config_info);
+		dev->name, dev, dev_data, dev->config_info);
 
 	return 0;
 }
@@ -289,7 +289,7 @@ static void dlci_created_cb(struct gsm_dlci *dlci, bool connected,
 		dev_data->status = UART_MUX_DISCONNECTED;
 	}
 
-	LOG_DBG("%s %s", dev_data->dev->config->name,
+	LOG_DBG("%s %s", dev_data->dev->name,
 		dev_data->status == UART_MUX_CONNECTED ? "connected" :
 							 "disconnected");
 
@@ -335,7 +335,7 @@ static int init_real_uart(struct device *mux, struct device *uart,
 		real_uart->mux = gsm_mux_create(mux);
 
 		LOG_DBG("Initializing UART %s and GSM mux %p",
-			real_uart->uart->config->name, real_uart->mux);
+			real_uart->uart->name, real_uart->mux);
 
 		if (!real_uart->mux) {
 			real_uart->uart = NULL;
@@ -375,7 +375,7 @@ static int attach(struct device *mux_uart, struct device *uart,
 	}
 
 	LOG_DBG("Attach DLCI %d (%s) to %s", dlci_address,
-		mux_uart->config->name, uart->config->name);
+		mux_uart->name, uart->name);
 
 	SYS_SLIST_FOR_EACH_NODE_SAFE(&uart_mux_data_devlist, sn, sns) {
 		struct uart_mux_dev_data *dev_data =
@@ -509,7 +509,7 @@ static int uart_mux_fifo_read(struct device *dev, u8_t *rx_data, const int size)
 	}
 
 	LOG_DBG("%s size %d rx_ringbuf space %u",
-		dev->config->name, size,
+		dev->name, size,
 		ring_buf_space_get(dev_data->rx_ringbuf));
 
 	len = ring_buf_get(dev_data->rx_ringbuf, rx_data, size);
@@ -744,7 +744,7 @@ int uart_mux_send(struct device *uart, const u8_t *buf, size_t size)
 		char tmp[sizeof("SEND muxed ") + 10];
 
 		snprintk(tmp, sizeof(tmp), "SEND muxed %s",
-			 dev_data->real_uart->uart->config->name);
+			 dev_data->real_uart->uart->name);
 		LOG_HEXDUMP_DBG(buf, size, log_strdup(tmp));
 	}
 
@@ -765,7 +765,7 @@ int uart_mux_recv(struct device *mux, struct gsm_dlci *dlci, u8_t *data,
 	struct uart_mux_dev_data *dev_data = DEV_DATA(mux);
 	size_t wrote = 0;
 
-	LOG_DBG("%s: dlci %p data %p len %zd", mux->config->name, dlci,
+	LOG_DBG("%s: dlci %p data %p len %zd", mux->name, dlci,
 		data, len);
 
 	if (IS_ENABLED(CONFIG_UART_MUX_VERBOSE_DEBUG)) {
@@ -773,7 +773,7 @@ int uart_mux_recv(struct device *mux, struct gsm_dlci *dlci, u8_t *data,
 			 sizeof(CONFIG_UART_MUX_DEVICE_NAME)];
 
 		snprintk(tmp, sizeof(tmp), "RECV %s",
-			 dev_data->dev->config->name);
+			 dev_data->dev->name);
 		LOG_HEXDUMP_DBG(data, len, log_strdup(tmp));
 	}
 

--- a/drivers/counter/counter_gecko_rtcc.c
+++ b/drivers/counter/counter_gecko_rtcc.c
@@ -39,9 +39,9 @@ struct counter_gecko_data {
 	void *top_user_data;
 };
 
-#define DEV_NAME(dev) ((dev)->config->name)
+#define DEV_NAME(dev) ((dev)->name)
 #define DEV_CFG(dev) \
-	((struct counter_gecko_config * const)(dev)->config->config_info)
+	((struct counter_gecko_config * const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct counter_gecko_data *const)(dev)->driver_data)
 

--- a/drivers/counter/counter_imx_epit.c
+++ b/drivers/counter/counter_imx_epit.c
@@ -25,7 +25,7 @@ struct imx_epit_data {
 
 static inline const struct imx_epit_config *get_epit_config(struct device *dev)
 {
-	return CONTAINER_OF(dev->config->config_info, struct imx_epit_config,
+	return CONTAINER_OF(dev->config_info, struct imx_epit_config,
 			    info);
 }
 

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -54,7 +54,7 @@ struct rtc_stm32_data {
 
 #define DEV_DATA(dev) ((struct rtc_stm32_data *)(dev)->driver_data)
 #define DEV_CFG(dev)	\
-((const struct rtc_stm32_config * const)(dev)->config->config_info)
+((const struct rtc_stm32_config * const)(dev)->config_info)
 
 
 static void rtc_stm32_irq_config(struct device *dev);
@@ -202,7 +202,7 @@ static u32_t rtc_stm32_get_pending_int(struct device *dev)
 
 static u32_t rtc_stm32_get_top_value(struct device *dev)
 {
-	const struct counter_config_info *info = dev->config->config_info;
+	const struct counter_config_info *info = dev->config_info;
 
 	return info->max_top_value;
 }
@@ -211,7 +211,7 @@ static u32_t rtc_stm32_get_top_value(struct device *dev)
 static int rtc_stm32_set_top_value(struct device *dev,
 				   const struct counter_top_cfg *cfg)
 {
-	const struct counter_config_info *info = dev->config->config_info;
+	const struct counter_config_info *info = dev->config_info;
 
 	if ((cfg->ticks != info->max_top_value) ||
 		!(cfg->flags & COUNTER_TOP_CFG_DONT_RESET)) {
@@ -226,7 +226,7 @@ static int rtc_stm32_set_top_value(struct device *dev,
 
 static u32_t rtc_stm32_get_max_relative_alarm(struct device *dev)
 {
-	const struct counter_config_info *info = dev->config->config_info;
+	const struct counter_config_info *info = dev->config_info;
 
 	return info->max_top_value;
 }

--- a/drivers/counter/counter_mchp_xec.c
+++ b/drivers/counter/counter_mchp_xec.c
@@ -48,11 +48,11 @@ struct counter_xec_data {
 #define COUNTER_XEC_REG_BASE(_dev)			\
 	((BTMR_Type *)					\
 	 ((const struct counter_xec_config * const)	\
-	  _dev->config->config_info)->base_address)
+	  _dev->config_info)->base_address)
 
 #define COUNTER_XEC_CONFIG(_dev)			\
 	(((const struct counter_xec_config * const)	\
-	  _dev->config->config_info))
+	  _dev->config_info))
 
 #define COUNTER_XEC_DATA(_dev)				\
 	((struct counter_xec_data *)dev->driver_data)

--- a/drivers/counter/counter_mcux_gpt.c
+++ b/drivers/counter/counter_mcux_gpt.c
@@ -28,7 +28,7 @@ struct mcux_gpt_data {
 
 static int mcux_gpt_start(struct device *dev)
 {
-	const struct mcux_gpt_config *config = dev->config->config_info;
+	const struct mcux_gpt_config *config = dev->config_info;
 
 	GPT_StartTimer(config->base);
 
@@ -37,7 +37,7 @@ static int mcux_gpt_start(struct device *dev)
 
 static int mcux_gpt_stop(struct device *dev)
 {
-	const struct mcux_gpt_config *config = dev->config->config_info;
+	const struct mcux_gpt_config *config = dev->config_info;
 
 	GPT_StopTimer(config->base);
 
@@ -46,7 +46,7 @@ static int mcux_gpt_stop(struct device *dev)
 
 static int mcux_gpt_get_value(struct device *dev, u32_t *ticks)
 {
-	const struct mcux_gpt_config *config = dev->config->config_info;
+	const struct mcux_gpt_config *config = dev->config_info;
 
 	*ticks = GPT_GetCurrentTimerCount(config->base);
 	return 0;
@@ -55,7 +55,7 @@ static int mcux_gpt_get_value(struct device *dev, u32_t *ticks)
 static int mcux_gpt_set_alarm(struct device *dev, u8_t chan_id,
 			      const struct counter_alarm_cfg *alarm_cfg)
 {
-	const struct mcux_gpt_config *config = dev->config->config_info;
+	const struct mcux_gpt_config *config = dev->config_info;
 	struct mcux_gpt_data *data = dev->driver_data;
 
 	u32_t current = GPT_GetCurrentTimerCount(config->base);
@@ -86,7 +86,7 @@ static int mcux_gpt_set_alarm(struct device *dev, u8_t chan_id,
 
 static int mcux_gpt_cancel_alarm(struct device *dev, u8_t chan_id)
 {
-	const struct mcux_gpt_config *config = dev->config->config_info;
+	const struct mcux_gpt_config *config = dev->config_info;
 	struct mcux_gpt_data *data = dev->driver_data;
 
 	if (chan_id != 0) {
@@ -103,7 +103,7 @@ static int mcux_gpt_cancel_alarm(struct device *dev, u8_t chan_id)
 void mcux_gpt_isr(void *p)
 {
 	struct device *dev = p;
-	const struct mcux_gpt_config *config = dev->config->config_info;
+	const struct mcux_gpt_config *config = dev->config_info;
 	struct mcux_gpt_data *data = dev->driver_data;
 	u32_t current = GPT_GetCurrentTimerCount(config->base);
 	u32_t status;
@@ -128,7 +128,7 @@ void mcux_gpt_isr(void *p)
 
 static u32_t mcux_gpt_get_pending_int(struct device *dev)
 {
-	const struct mcux_gpt_config *config = dev->config->config_info;
+	const struct mcux_gpt_config *config = dev->config_info;
 
 	return GPT_GetStatusFlags(config->base, kGPT_OutputCompare1Flag);
 }
@@ -136,7 +136,7 @@ static u32_t mcux_gpt_get_pending_int(struct device *dev)
 static int mcux_gpt_set_top_value(struct device *dev,
 				  const struct counter_top_cfg *cfg)
 {
-	const struct mcux_gpt_config *config = dev->config->config_info;
+	const struct mcux_gpt_config *config = dev->config_info;
 	struct mcux_gpt_data *data = dev->driver_data;
 
 	if (cfg->ticks != config->info.max_top_value) {
@@ -155,21 +155,21 @@ static int mcux_gpt_set_top_value(struct device *dev,
 
 static u32_t mcux_gpt_get_top_value(struct device *dev)
 {
-	const struct mcux_gpt_config *config = dev->config->config_info;
+	const struct mcux_gpt_config *config = dev->config_info;
 
 	return config->info.max_top_value;
 }
 
 static u32_t mcux_gpt_get_max_relative_alarm(struct device *dev)
 {
-	const struct mcux_gpt_config *config = dev->config->config_info;
+	const struct mcux_gpt_config *config = dev->config_info;
 
 	return config->info.max_top_value;
 }
 
 static int mcux_gpt_init(struct device *dev)
 {
-	const struct mcux_gpt_config *config = dev->config->config_info;
+	const struct mcux_gpt_config *config = dev->config_info;
 	gpt_config_t gptConfig;
 	u32_t clock_freq;
 

--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -28,7 +28,7 @@ struct mcux_lptmr_data {
 
 static int mcux_lptmr_start(struct device *dev)
 {
-	const struct mcux_lptmr_config *config = dev->config->config_info;
+	const struct mcux_lptmr_config *config = dev->config_info;
 
 	LPTMR_EnableInterrupts(config->base,
 			       kLPTMR_TimerInterruptEnable);
@@ -39,7 +39,7 @@ static int mcux_lptmr_start(struct device *dev)
 
 static int mcux_lptmr_stop(struct device *dev)
 {
-	const struct mcux_lptmr_config *config = dev->config->config_info;
+	const struct mcux_lptmr_config *config = dev->config_info;
 
 	LPTMR_DisableInterrupts(config->base,
 				kLPTMR_TimerInterruptEnable);
@@ -50,7 +50,7 @@ static int mcux_lptmr_stop(struct device *dev)
 
 static int mcux_lptmr_get_value(struct device *dev, u32_t *ticks)
 {
-	const struct mcux_lptmr_config *config = dev->config->config_info;
+	const struct mcux_lptmr_config *config = dev->config_info;
 
 	*ticks = LPTMR_GetCurrentTimerCount(config->base);
 
@@ -60,7 +60,7 @@ static int mcux_lptmr_get_value(struct device *dev, u32_t *ticks)
 static int mcux_lptmr_set_top_value(struct device *dev,
 				  const struct counter_top_cfg *cfg)
 {
-	const struct mcux_lptmr_config *config = dev->config->config_info;
+	const struct mcux_lptmr_config *config = dev->config_info;
 	struct mcux_lptmr_data *data = dev->driver_data;
 
 	if (cfg->ticks == 0) {
@@ -87,7 +87,7 @@ static int mcux_lptmr_set_top_value(struct device *dev,
 
 static u32_t mcux_lptmr_get_pending_int(struct device *dev)
 {
-	const struct mcux_lptmr_config *config = dev->config->config_info;
+	const struct mcux_lptmr_config *config = dev->config_info;
 	u32_t mask = LPTMR_CSR_TCF_MASK | LPTMR_CSR_TIE_MASK;
 	u32_t flags;
 
@@ -98,7 +98,7 @@ static u32_t mcux_lptmr_get_pending_int(struct device *dev)
 
 static u32_t mcux_lptmr_get_top_value(struct device *dev)
 {
-	const struct mcux_lptmr_config *config = dev->config->config_info;
+	const struct mcux_lptmr_config *config = dev->config_info;
 
 	return (config->base->CMR & LPTMR_CMR_COMPARE_MASK) + 1U;
 }
@@ -114,7 +114,7 @@ static u32_t mcux_lptmr_get_max_relative_alarm(struct device *dev)
 static void mcux_lptmr_isr(void *arg)
 {
 	struct device *dev = arg;
-	const struct mcux_lptmr_config *config = dev->config->config_info;
+	const struct mcux_lptmr_config *config = dev->config_info;
 	struct mcux_lptmr_data *data = dev->driver_data;
 	u32_t flags;
 
@@ -128,7 +128,7 @@ static void mcux_lptmr_isr(void *arg)
 
 static int mcux_lptmr_init(struct device *dev)
 {
-	const struct mcux_lptmr_config *config = dev->config->config_info;
+	const struct mcux_lptmr_config *config = dev->config_info;
 	lptmr_config_t lptmr_config;
 
 	LPTMR_GetDefaultConfig(&lptmr_config);

--- a/drivers/counter/counter_mcux_rtc.c
+++ b/drivers/counter/counter_mcux_rtc.c
@@ -28,7 +28,7 @@ struct mcux_rtc_config {
 
 static int mcux_rtc_start(struct device *dev)
 {
-	const struct counter_config_info *info = dev->config->config_info;
+	const struct counter_config_info *info = dev->config_info;
 	const struct mcux_rtc_config *config =
 		CONTAINER_OF(info, struct mcux_rtc_config, info);
 
@@ -43,7 +43,7 @@ static int mcux_rtc_start(struct device *dev)
 
 static int mcux_rtc_stop(struct device *dev)
 {
-	const struct counter_config_info *info = dev->config->config_info;
+	const struct counter_config_info *info = dev->config_info;
 	const struct mcux_rtc_config *config =
 		CONTAINER_OF(info, struct mcux_rtc_config, info);
 
@@ -61,7 +61,7 @@ static int mcux_rtc_stop(struct device *dev)
 
 static u32_t mcux_rtc_read(struct device *dev)
 {
-	const struct counter_config_info *info = dev->config->config_info;
+	const struct counter_config_info *info = dev->config_info;
 	const struct mcux_rtc_config *config =
 		CONTAINER_OF(info, struct mcux_rtc_config, info);
 
@@ -90,7 +90,7 @@ static int mcux_rtc_get_value(struct device *dev, u32_t *ticks)
 static int mcux_rtc_set_alarm(struct device *dev, u8_t chan_id,
 			      const struct counter_alarm_cfg *alarm_cfg)
 {
-	const struct counter_config_info *info = dev->config->config_info;
+	const struct counter_config_info *info = dev->config_info;
 	const struct mcux_rtc_config *config =
 		CONTAINER_OF(info, struct mcux_rtc_config, info);
 	struct mcux_rtc_data *data = dev->driver_data;
@@ -144,7 +144,7 @@ static int mcux_rtc_cancel_alarm(struct device *dev, u8_t chan_id)
 static int mcux_rtc_set_top_value(struct device *dev,
 				  const struct counter_top_cfg *cfg)
 {
-	const struct counter_config_info *info = dev->config->config_info;
+	const struct counter_config_info *info = dev->config_info;
 	const struct mcux_rtc_config *config =
 			CONTAINER_OF(info, struct mcux_rtc_config, info);
 	struct mcux_rtc_data *data = dev->driver_data;
@@ -168,7 +168,7 @@ static int mcux_rtc_set_top_value(struct device *dev,
 
 static u32_t mcux_rtc_get_pending_int(struct device *dev)
 {
-	const struct counter_config_info *info = dev->config->config_info;
+	const struct counter_config_info *info = dev->config_info;
 	const struct mcux_rtc_config *config =
 		CONTAINER_OF(info, struct mcux_rtc_config, info);
 
@@ -177,14 +177,14 @@ static u32_t mcux_rtc_get_pending_int(struct device *dev)
 
 static u32_t mcux_rtc_get_top_value(struct device *dev)
 {
-	const struct counter_config_info *info = dev->config->config_info;
+	const struct counter_config_info *info = dev->config_info;
 
 	return info->max_top_value;
 }
 
 static u32_t mcux_rtc_get_max_relative_alarm(struct device *dev)
 {
-	const struct counter_config_info *info = dev->config->config_info;
+	const struct counter_config_info *info = dev->config_info;
 
 	return info->max_top_value;
 }
@@ -192,7 +192,7 @@ static u32_t mcux_rtc_get_max_relative_alarm(struct device *dev)
 static void mcux_rtc_isr(void *arg)
 {
 	struct device *dev = arg;
-	const struct counter_config_info *info = dev->config->config_info;
+	const struct counter_config_info *info = dev->config_info;
 	const struct mcux_rtc_config *config =
 		CONTAINER_OF(info, struct mcux_rtc_config, info);
 	struct mcux_rtc_data *data = dev->driver_data;
@@ -233,7 +233,7 @@ static void mcux_rtc_isr(void *arg)
 
 static int mcux_rtc_init(struct device *dev)
 {
-	const struct counter_config_info *info = dev->config->config_info;
+	const struct counter_config_info *info = dev->config_info;
 	const struct mcux_rtc_config *config =
 		CONTAINER_OF(info, struct mcux_rtc_config, info);
 	rtc_config_t rtc_config;

--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -74,7 +74,7 @@ static inline struct counter_nrfx_data *get_dev_data(struct device *dev)
 static inline const struct counter_nrfx_config *get_nrfx_config(
 							struct device *dev)
 {
-	return CONTAINER_OF(dev->config->config_info,
+	return CONTAINER_OF(dev->config_info,
 				struct counter_nrfx_config, info);
 }
 

--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -58,7 +58,7 @@ static inline struct counter_nrfx_data *get_dev_data(struct device *dev)
 static inline const struct counter_nrfx_config *get_nrfx_config(
 							struct device *dev)
 {
-	return CONTAINER_OF(dev->config->config_info,
+	return CONTAINER_OF(dev->config_info,
 				struct counter_nrfx_config, info);
 }
 

--- a/drivers/counter/counter_sam0_tc32.c
+++ b/drivers/counter/counter_sam0_tc32.c
@@ -42,7 +42,7 @@ struct counter_sam0_tc32_config {
 };
 
 #define DEV_CFG(dev) ((const struct counter_sam0_tc32_config *const) \
-		      (dev)->config->config_info)
+		      (dev)->config_info)
 #define DEV_DATA(dev) ((struct counter_sam0_tc32_data *const) \
 		       (dev)->driver_data)
 

--- a/drivers/counter/maxim_ds3231.c
+++ b/drivers/counter/maxim_ds3231.c
@@ -1339,7 +1339,7 @@ int z_vrfy_maxim_ds3231_get_syncpoint(struct device *dev,
 	struct maxim_ds3231_syncpoint value;
 	int rv;
 
-	Z_OOPS(Z_SYSCALL_SPECIFIC_DRIVER(dev, K_OBJ_DRIVER_COUNTER, ds3231_init));
+	Z_OOPS(Z_SYSCALL_SPECIFIC_DRIVER(dev, K_OBJ_DRIVER_COUNTER, &ds3231_api));
 	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(syncpoint, sizeof(*syncpoint)));
 
 	rv = z_impl_maxim_ds3231_get_syncpoint(dev, &value);
@@ -1356,7 +1356,7 @@ int z_vrfy_maxim_ds3231_get_syncpoint(struct device *dev,
 int z_vrfy_maxim_ds3231_req_syncpoint(struct device *dev,
 				      struct k_poll_signal *sig)
 {
-	Z_OOPS(Z_SYSCALL_SPECIFIC_DRIVER(dev, K_OBJ_DRIVER_COUNTER, ds3231_init));
+	Z_OOPS(Z_SYSCALL_SPECIFIC_DRIVER(dev, K_OBJ_DRIVER_COUNTER, &ds3231_api));
 	if (sig != NULL) {
 		Z_OOPS(Z_SYSCALL_OBJ(sig, K_OBJ_POLL_SIGNAL));
 	}

--- a/drivers/counter/maxim_ds3231.c
+++ b/drivers/counter/maxim_ds3231.c
@@ -149,7 +149,7 @@ static int sc_ctrl(struct device *dev,
 		   u8_t clear)
 {
 	struct ds3231_data *data = dev->driver_data;
-	const struct ds3231_config *cfg = dev->config->config_info;
+	const struct ds3231_config *cfg = dev->config_info;
 	struct register_map *rp = &data->registers;
 	u8_t ctrl = (rp->ctrl & ~clear) | set;
 	int rc = ctrl;
@@ -201,7 +201,7 @@ static inline int rsc_stat(struct device *dev,
 	u8_t const ign = MAXIM_DS3231_REG_STAT_OSF | MAXIM_DS3231_ALARM1
 			 | MAXIM_DS3231_ALARM2;
 	struct ds3231_data *data = dev->driver_data;
-	const struct ds3231_config *cfg = dev->config->config_info;
+	const struct ds3231_config *cfg = dev->config_info;
 	struct register_map *rp = &data->registers;
 	u8_t addr = offsetof(struct register_map, ctrl_stat);
 	int rc;
@@ -248,7 +248,7 @@ int maxim_ds3231_stat_update(struct device *dev,
 static void validate_isw_monitoring(struct device *dev)
 {
 	struct ds3231_data *data = dev->driver_data;
-	const struct ds3231_config *cfg = dev->config->config_info;
+	const struct ds3231_config *cfg = dev->config_info;
 	const struct register_map *rp = &data->registers;
 	u8_t isw_mon_req = 0;
 
@@ -449,7 +449,7 @@ static u32_t decode_rtc(struct ds3231_data *data)
 static int update_registers(struct device *dev)
 {
 	struct ds3231_data *data = dev->driver_data;
-	const struct ds3231_config *cfg = dev->config->config_info;
+	const struct ds3231_config *cfg = dev->config_info;
 	u32_t syncclock;
 	int rc;
 	u8_t addr = 0;
@@ -472,7 +472,7 @@ int maxim_ds3231_get_alarm(struct device *dev,
 			   struct maxim_ds3231_alarm *cp)
 {
 	struct ds3231_data *data = dev->driver_data;
-	const struct ds3231_config *cfg = dev->config->config_info;
+	const struct ds3231_config *cfg = dev->config_info;
 	int rv = 0;
 	u8_t addr;
 	u8_t len;
@@ -529,7 +529,7 @@ static int ds3231_counter_cancel_alarm(struct device *dev,
 				       u8_t id)
 {
 	struct ds3231_data *data = dev->driver_data;
-	const struct ds3231_config *cfg = dev->config->config_info;
+	const struct ds3231_config *cfg = dev->config_info;
 	int rv = 0;
 
 	if (id >= cfg->generic.channels) {
@@ -557,7 +557,7 @@ static int set_alarm(struct device *dev,
 		     const struct maxim_ds3231_alarm *cp)
 {
 	struct ds3231_data *data = dev->driver_data;
-	const struct ds3231_config *cfg = dev->config->config_info;
+	const struct ds3231_config *cfg = dev->config_info;
 	u8_t addr;
 	u8_t len;
 
@@ -672,7 +672,7 @@ static void alarm_worker(struct k_work *work)
 	struct ds3231_data *data = CONTAINER_OF(work, struct ds3231_data,
 						alarm_work);
 	struct device *ds3231 = data->ds3231;
-	const struct ds3231_config *cfg = ds3231->config->config_info;
+	const struct ds3231_config *cfg = ds3231->config_info;
 
 	k_sem_take(&data->lock, K_FOREVER);
 
@@ -751,7 +751,7 @@ static int read_time(struct device *dev,
 		     time_t *time)
 {
 	struct ds3231_data *data = dev->driver_data;
-	const struct ds3231_config *cfg = dev->config->config_info;
+	const struct ds3231_config *cfg = dev->config_info;
 	u8_t addr = 0;
 
 	int rc = i2c_write_read(data->i2c, cfg->addr,
@@ -886,7 +886,7 @@ static void sync_prep_write(struct device *dev)
 static void sync_finish_write(struct device *dev)
 {
 	struct ds3231_data *data = dev->driver_data;
-	const struct ds3231_config *cfg = dev->config->config_info;
+	const struct ds3231_config *cfg = dev->config_info;
 	time_t when = data->new_sp.rtc.tv_sec;
 	struct tm tm;
 	u8_t buf[8];
@@ -1118,7 +1118,7 @@ out:
 static int ds3231_init(struct device *dev)
 {
 	struct ds3231_data *data = dev->driver_data;
-	const struct ds3231_config *cfg = dev->config->config_info;
+	const struct ds3231_config *cfg = dev->config_info;
 	struct device *i2c = device_get_binding(cfg->bus_name);
 	int rc;
 
@@ -1215,7 +1215,7 @@ int ds3231_counter_set_alarm(struct device *dev,
 {
 	struct ds3231_data *data = dev->driver_data;
 	const struct register_map *rp = &data->registers;
-	const struct ds3231_config *cfg = dev->config->config_info;
+	const struct ds3231_config *cfg = dev->config_info;
 	time_t when;
 	int rc = 0;
 

--- a/drivers/counter/timer_dtmr_cmsdk_apb.c
+++ b/drivers/counter/timer_dtmr_cmsdk_apb.c
@@ -38,7 +38,7 @@ struct dtmr_cmsdk_apb_dev_data {
 static int dtmr_cmsdk_apb_start(struct device *dev)
 {
 	const struct dtmr_cmsdk_apb_cfg * const cfg =
-						dev->config->config_info;
+						dev->config_info;
 	struct dtmr_cmsdk_apb_dev_data *data = dev->driver_data;
 
 	/* Set the timer reload to count */
@@ -53,7 +53,7 @@ static int dtmr_cmsdk_apb_start(struct device *dev)
 static int dtmr_cmsdk_apb_stop(struct device *dev)
 {
 	const struct dtmr_cmsdk_apb_cfg * const cfg =
-						dev->config->config_info;
+						dev->config_info;
 
 	/* Disable the dualtimer */
 	cfg->dtimer->timer1ctrl = 0x0;
@@ -64,7 +64,7 @@ static int dtmr_cmsdk_apb_stop(struct device *dev)
 static int dtmr_cmsdk_apb_get_value(struct device *dev, u32_t *ticks)
 {
 	const struct dtmr_cmsdk_apb_cfg * const cfg =
-						dev->config->config_info;
+						dev->config_info;
 	struct dtmr_cmsdk_apb_dev_data *data = dev->driver_data;
 
 	*ticks = data->load - cfg->dtimer->timer1value;
@@ -75,7 +75,7 @@ static int dtmr_cmsdk_apb_set_top_value(struct device *dev,
 					const struct counter_top_cfg *top_cfg)
 {
 	const struct dtmr_cmsdk_apb_cfg * const cfg =
-						dev->config->config_info;
+						dev->config_info;
 	struct dtmr_cmsdk_apb_dev_data *data = dev->driver_data;
 
 	data->top_callback = top_cfg->callback;
@@ -118,7 +118,7 @@ static u32_t dtmr_cmsdk_apb_get_top_value(struct device *dev)
 static u32_t dtmr_cmsdk_apb_get_pending_int(struct device *dev)
 {
 	const struct dtmr_cmsdk_apb_cfg * const cfg =
-						dev->config->config_info;
+						dev->config_info;
 
 	return cfg->dtimer->timer1ris;
 }
@@ -137,7 +137,7 @@ static void dtmr_cmsdk_apb_isr(void *arg)
 	struct device *dev = (struct device *)arg;
 	struct dtmr_cmsdk_apb_dev_data *data = dev->driver_data;
 	const struct dtmr_cmsdk_apb_cfg * const cfg =
-						dev->config->config_info;
+						dev->config_info;
 
 	cfg->dtimer->timer1intclr = DUALTIMER_INTCLR;
 	if (data->top_callback) {
@@ -148,7 +148,7 @@ static void dtmr_cmsdk_apb_isr(void *arg)
 static int dtmr_cmsdk_apb_init(struct device *dev)
 {
 	const struct dtmr_cmsdk_apb_cfg * const cfg =
-						dev->config->config_info;
+						dev->config_info;
 
 #ifdef CONFIG_CLOCK_CONTROL
 	/* Enable clock for subsystem */

--- a/drivers/counter/timer_tmr_cmsdk_apb.c
+++ b/drivers/counter/timer_tmr_cmsdk_apb.c
@@ -39,7 +39,7 @@ struct tmr_cmsdk_apb_dev_data {
 static int tmr_cmsdk_apb_start(struct device *dev)
 {
 	const struct tmr_cmsdk_apb_cfg * const cfg =
-						dev->config->config_info;
+						dev->config_info;
 	struct tmr_cmsdk_apb_dev_data *data = dev->driver_data;
 
 	/* Set the timer reload to count */
@@ -53,7 +53,7 @@ static int tmr_cmsdk_apb_start(struct device *dev)
 static int tmr_cmsdk_apb_stop(struct device *dev)
 {
 	const struct tmr_cmsdk_apb_cfg * const cfg =
-						dev->config->config_info;
+						dev->config_info;
 	/* Disable the timer */
 	cfg->timer->ctrl = 0x0;
 
@@ -63,7 +63,7 @@ static int tmr_cmsdk_apb_stop(struct device *dev)
 static int tmr_cmsdk_apb_get_value(struct device *dev, u32_t *ticks)
 {
 	const struct tmr_cmsdk_apb_cfg * const cfg =
-						dev->config->config_info;
+						dev->config_info;
 	struct tmr_cmsdk_apb_dev_data *data = dev->driver_data;
 
 	/* Get Counter Value */
@@ -75,7 +75,7 @@ static int tmr_cmsdk_apb_set_top_value(struct device *dev,
 				       const struct counter_top_cfg *top_cfg)
 {
 	const struct tmr_cmsdk_apb_cfg * const cfg =
-						dev->config->config_info;
+						dev->config_info;
 	struct tmr_cmsdk_apb_dev_data *data = dev->driver_data;
 
 	/* Counter is always reset when top value is updated. */
@@ -113,7 +113,7 @@ static u32_t tmr_cmsdk_apb_get_top_value(struct device *dev)
 static u32_t tmr_cmsdk_apb_get_pending_int(struct device *dev)
 {
 	const struct tmr_cmsdk_apb_cfg * const cfg =
-						dev->config->config_info;
+						dev->config_info;
 
 	return cfg->timer->intstatus;
 }
@@ -132,7 +132,7 @@ static void tmr_cmsdk_apb_isr(void *arg)
 	struct device *dev = (struct device *)arg;
 	struct tmr_cmsdk_apb_dev_data *data = dev->driver_data;
 	const struct tmr_cmsdk_apb_cfg * const cfg =
-						dev->config->config_info;
+						dev->config_info;
 
 	cfg->timer->intclear = TIMER_CTRL_INT_CLEAR;
 	if (data->top_callback) {
@@ -143,7 +143,7 @@ static void tmr_cmsdk_apb_isr(void *arg)
 static int tmr_cmsdk_apb_init(struct device *dev)
 {
 	const struct tmr_cmsdk_apb_cfg * const cfg =
-						dev->config->config_info;
+						dev->config_info;
 
 #ifdef CONFIG_CLOCK_CONTROL
 	/* Enable clock for subsystem */

--- a/drivers/crypto/crypto_ataes132a.c
+++ b/drivers/crypto/crypto_ataes132a.c
@@ -44,7 +44,7 @@ static int ataes132a_send_command(struct device *dev, u8_t opcode,
 {
 	int retry_count = 0;
 	struct ataes132a_device_data *data = dev->driver_data;
-	const struct ataes132a_device_config *cfg = dev->config->config_info;
+	const struct ataes132a_device_config *cfg = dev->config_info;
 	u8_t count;
 	u8_t status;
 	u8_t crc[2];
@@ -167,7 +167,7 @@ static int ataes132a_send_command(struct device *dev, u8_t opcode,
 int ataes132a_init(struct device *dev)
 {
 	struct ataes132a_device_data *ataes132a = dev->driver_data;
-	const struct ataes132a_device_config *cfg = dev->config->config_info;
+	const struct ataes132a_device_config *cfg = dev->config_info;
 	u32_t i2c_cfg;
 
 	LOG_DBG("ATAES132A INIT");
@@ -798,7 +798,7 @@ static int ataes132a_session_setup(struct device *dev, struct cipher_ctx *ctx,
 {
 	u8_t key_id = *((u8_t *)ctx->key.handle);
 	struct ataes132a_device_data *data = dev->driver_data;
-	const struct ataes132a_device_config *cfg = dev->config->config_info;
+	const struct ataes132a_device_config *cfg = dev->config_info;
 	u8_t config;
 
 	if (ataes132a_state[key_id].in_use) {

--- a/drivers/crypto/crypto_stm32_priv.h
+++ b/drivers/crypto/crypto_stm32_priv.h
@@ -28,7 +28,7 @@ struct crypto_stm32_session {
 };
 
 #define CRYPTO_STM32_CFG(dev) \
-	((const struct crypto_stm32_config *const)(dev)->config->config_info)
+	((const struct crypto_stm32_config *const)(dev)->config_info)
 
 #define CRYPTO_STM32_DATA(dev) \
 	((struct crypto_stm32_data *const)(dev)->driver_data)

--- a/drivers/dac/dac_mcux_dac.c
+++ b/drivers/dac/dac_mcux_dac.c
@@ -27,7 +27,7 @@ struct mcux_dac_data {
 static int mcux_dac_channel_setup(struct device *dev,
 				    const struct dac_channel_cfg *channel_cfg)
 {
-	const struct mcux_dac_config *config = dev->config->config_info;
+	const struct mcux_dac_config *config = dev->config_info;
 	struct mcux_dac_data *data = dev->driver_data;
 	dac_config_t dac_config;
 
@@ -54,7 +54,7 @@ static int mcux_dac_channel_setup(struct device *dev,
 
 static int mcux_dac_write_value(struct device *dev, u8_t channel, u32_t value)
 {
-	const struct mcux_dac_config *config = dev->config->config_info;
+	const struct mcux_dac_config *config = dev->config_info;
 	struct mcux_dac_data *data = dev->driver_data;
 
 	if (!data->configured) {

--- a/drivers/dac/dac_mcux_dac32.c
+++ b/drivers/dac/dac_mcux_dac32.c
@@ -28,7 +28,7 @@ struct mcux_dac32_data {
 static int mcux_dac32_channel_setup(struct device *dev,
 				    const struct dac_channel_cfg *channel_cfg)
 {
-	const struct mcux_dac32_config *config = dev->config->config_info;
+	const struct mcux_dac32_config *config = dev->config_info;
 	struct mcux_dac32_data *data = dev->driver_data;
 	dac32_config_t dac32_config;
 
@@ -56,7 +56,7 @@ static int mcux_dac32_channel_setup(struct device *dev,
 
 static int mcux_dac32_write_value(struct device *dev, u8_t channel, u32_t value)
 {
-	const struct mcux_dac32_config *config = dev->config->config_info;
+	const struct mcux_dac32_config *config = dev->config_info;
 	struct mcux_dac32_data *data = dev->driver_data;
 
 	if (!data->configured) {

--- a/drivers/dac/dac_stm32.c
+++ b/drivers/dac/dac_stm32.c
@@ -54,7 +54,7 @@ static int dac_stm32_write_value(struct device *dev,
 					u8_t channel, u32_t value)
 {
 	struct dac_stm32_data *data = dev->driver_data;
-	const struct dac_stm32_cfg *cfg = dev->config->config_info;
+	const struct dac_stm32_cfg *cfg = dev->config_info;
 
 	if (channel - STM32_FIRST_CHANNEL >= data->channel_count ||
 					channel < STM32_FIRST_CHANNEL) {
@@ -77,7 +77,7 @@ static int dac_stm32_channel_setup(struct device *dev,
 				   const struct dac_channel_cfg *channel_cfg)
 {
 	struct dac_stm32_data *data = dev->driver_data;
-	const struct dac_stm32_cfg *cfg = dev->config->config_info;
+	const struct dac_stm32_cfg *cfg = dev->config_info;
 
 	if ((channel_cfg->channel_id - STM32_FIRST_CHANNEL >=
 			data->channel_count) ||
@@ -109,7 +109,7 @@ static int dac_stm32_channel_setup(struct device *dev,
 
 static int dac_stm32_init(struct device *dev)
 {
-	const struct dac_stm32_cfg *cfg = dev->config->config_info;
+	const struct dac_stm32_cfg *cfg = dev->config_info;
 
 	/* enable clock for subsystem */
 	struct device *clk =

--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -44,7 +44,7 @@ static int mcux_elcdif_write(const struct device *dev, const u16_t x,
 			     const struct display_buffer_descriptor *desc,
 			     const void *buf)
 {
-	const struct mcux_elcdif_config *config = dev->config->config_info;
+	const struct mcux_elcdif_config *config = dev->config_info;
 	struct mcux_elcdif_data *data = dev->driver_data;
 
 	u8_t write_idx = data->write_idx;
@@ -132,7 +132,7 @@ static int mcux_elcdif_set_pixel_format(const struct device *dev,
 					const enum display_pixel_format
 					pixel_format)
 {
-	const struct mcux_elcdif_config *config = dev->config->config_info;
+	const struct mcux_elcdif_config *config = dev->config_info;
 
 	if (pixel_format == config->pixel_format) {
 		return 0;
@@ -154,7 +154,7 @@ static int mcux_elcdif_set_orientation(const struct device *dev,
 static void mcux_elcdif_get_capabilities(const struct device *dev,
 		struct display_capabilities *capabilities)
 {
-	const struct mcux_elcdif_config *config = dev->config->config_info;
+	const struct mcux_elcdif_config *config = dev->config_info;
 
 	memset(capabilities, 0, sizeof(struct display_capabilities));
 	capabilities->x_resolution = config->rgb_mode.panelWidth;
@@ -167,7 +167,7 @@ static void mcux_elcdif_get_capabilities(const struct device *dev,
 static void mcux_elcdif_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct mcux_elcdif_config *config = dev->config->config_info;
+	const struct mcux_elcdif_config *config = dev->config_info;
 	struct mcux_elcdif_data *data = dev->driver_data;
 	u32_t status;
 
@@ -179,7 +179,7 @@ static void mcux_elcdif_isr(void *arg)
 
 static int mcux_elcdif_init(struct device *dev)
 {
-	const struct mcux_elcdif_config *config = dev->config->config_info;
+	const struct mcux_elcdif_config *config = dev->config_info;
 	struct mcux_elcdif_data *data = dev->driver_data;
 	int i;
 

--- a/drivers/display/grove_lcd_rgb.c
+++ b/drivers/display/grove_lcd_rgb.c
@@ -105,7 +105,7 @@ static inline void sleep(u32_t sleep_in_ms)
 void glcd_print(struct device *port, char *data, u32_t size)
 {
 	const struct glcd_driver * const rom = (struct glcd_driver *)
-						port->config->config_info;
+						port->config_info;
 	struct glcd_data *dev = port->driver_data;
 	u8_t buf[] = { GLCD_CMD_SET_CGRAM_ADDR, 0 };
 	int i;
@@ -120,7 +120,7 @@ void glcd_print(struct device *port, char *data, u32_t size)
 void glcd_cursor_pos_set(struct device *port, u8_t col, u8_t row)
 {
 	const struct glcd_driver * const rom = (struct glcd_driver *)
-						port->config->config_info;
+						port->config_info;
 	struct glcd_data *dev = port->driver_data;
 
 	unsigned char data[2];
@@ -141,7 +141,7 @@ void glcd_cursor_pos_set(struct device *port, u8_t col, u8_t row)
 void glcd_clear(struct device *port)
 {
 	const struct glcd_driver * const rom = (struct glcd_driver *)
-						port->config->config_info;
+						port->config_info;
 	struct glcd_data *dev = port->driver_data;
 	u8_t clear[] = { 0, GLCD_CMD_SCREEN_CLEAR };
 
@@ -154,7 +154,7 @@ void glcd_clear(struct device *port)
 void glcd_display_state_set(struct device *port, u8_t opt)
 {
 	const struct glcd_driver * const rom = (struct glcd_driver *)
-						port->config->config_info;
+						port->config_info;
 	struct glcd_data *dev = port->driver_data;
 	u8_t data[] = { 0, 0 };
 
@@ -178,7 +178,7 @@ u8_t glcd_display_state_get(struct device *port)
 
 void glcd_input_state_set(struct device *port, u8_t opt)
 {
-	const struct glcd_driver * const rom = port->config->config_info;
+	const struct glcd_driver * const rom = port->config_info;
 	struct glcd_data *dev = port->driver_data;
 	u8_t data[] = { 0, 0 };
 
@@ -223,7 +223,7 @@ void glcd_color_set(struct device *port, u8_t r, u8_t g, u8_t b)
 
 void glcd_function_set(struct device *port, u8_t opt)
 {
-	const struct glcd_driver * const rom = port->config->config_info;
+	const struct glcd_driver * const rom = port->config_info;
 	struct glcd_data *dev = port->driver_data;
 	u8_t data[] = { 0, 0 };
 

--- a/drivers/dma/dma_dw.c
+++ b/drivers/dma/dma_dw.c
@@ -34,10 +34,10 @@ LOG_MODULE_REGISTER(dma_dw);
 /* default initial setup register values */
 #define DW_CFG_LOW_DEF			0x0
 
-#define DEV_NAME(dev) ((dev)->config->name)
+#define DEV_NAME(dev) ((dev)->name)
 #define DEV_DATA(dev) ((struct dw_dma_dev_data *const)(dev)->driver_data)
 #define DEV_CFG(dev) \
-	((const struct dw_dma_dev_cfg *const)(dev)->config->config_info)
+	((const struct dw_dma_dev_cfg *const)(dev)->config_info)
 
 /* number of tries to wait for reset */
 #define DW_DMA_CFG_TRIES	10000

--- a/drivers/dma/dma_nios2_msgdma.c
+++ b/drivers/dma/dma_nios2_msgdma.c
@@ -30,9 +30,9 @@ struct nios2_msgdma_dev_cfg {
 			     int error_code);
 };
 
-#define DEV_NAME(dev) ((dev)->config->name)
+#define DEV_NAME(dev) ((dev)->name)
 #define DEV_CFG(dev) \
-	((struct nios2_msgdma_dev_cfg *)(dev)->config->config_info)
+	((struct nios2_msgdma_dev_cfg *)(dev)->config_info)
 
 static void nios2_msgdma_isr(void *arg)
 {

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -45,9 +45,9 @@ struct sam_xdmac_dev_data {
 	struct sam_xdmac_channel_cfg dma_channels[DMA_CHANNELS_NO];
 };
 
-#define DEV_NAME(dev) ((dev)->config->name)
+#define DEV_NAME(dev) ((dev)->name)
 #define DEV_CFG(dev) \
-	((const struct sam_xdmac_dev_cfg *const)(dev)->config->config_info)
+	((const struct sam_xdmac_dev_cfg *const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct sam_xdmac_dev_data *const)(dev)->driver_data)
 

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -38,7 +38,7 @@ static u32_t table_p_size[] = {
 
 static void dma_stm32_dump_stream_irq(struct device *dev, u32_t id)
 {
-	const struct dma_stm32_config *config = dev->config->config_info;
+	const struct dma_stm32_config *config = dev->config_info;
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
 
 	stm32_dma_dump_stream_irq(dma, id);
@@ -46,7 +46,7 @@ static void dma_stm32_dump_stream_irq(struct device *dev, u32_t id)
 
 static void dma_stm32_clear_stream_irq(struct device *dev, u32_t id)
 {
-	const struct dma_stm32_config *config = dev->config->config_info;
+	const struct dma_stm32_config *config = dev->config_info;
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
 
 	func_ll_clear_tc[id](dma);
@@ -58,7 +58,7 @@ static void dma_stm32_irq_handler(void *arg)
 {
 	struct device *dev = arg;
 	struct dma_stm32_data *data = dev->driver_data;
-	const struct dma_stm32_config *config = dev->config->config_info;
+	const struct dma_stm32_config *config = dev->config_info;
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
 	struct dma_stm32_stream *stream;
 	int id;
@@ -243,7 +243,7 @@ static int dma_stm32_configure(struct device *dev, u32_t id,
 	struct dma_stm32_data *data = dev->driver_data;
 	struct dma_stm32_stream *stream = &data->streams[id - STREAM_OFFSET];
 	const struct dma_stm32_config *dev_config =
-					dev->config->config_info;
+					dev->config_info;
 	DMA_TypeDef *dma = (DMA_TypeDef *)dev_config->base;
 	LL_DMA_InitTypeDef DMA_InitStruct;
 	u32_t msize;
@@ -275,7 +275,7 @@ static int dma_stm32_configure(struct device *dev, u32_t id,
 	if ((config->channel_direction == MEMORY_TO_MEMORY) &&
 		(!dev_config->support_m2m)) {
 		LOG_ERR("Memcopy not supported for device %s",
-			dev->config->name);
+			dev->name);
 		return -ENOTSUP;
 	}
 #endif /* CONFIG_DMA_STM32_V1 */
@@ -477,7 +477,7 @@ static int dma_stm32_reload(struct device *dev, u32_t id,
 			    u32_t src, u32_t dst, size_t size)
 #endif /* CONFIG_DMAMUX_STM32 */
 {
-	const struct dma_stm32_config *config = dev->config->config_info;
+	const struct dma_stm32_config *config = dev->config_info;
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
 	struct dma_stm32_data *data = dev->driver_data;
 	struct dma_stm32_stream *stream = &data->streams[id - STREAM_OFFSET];
@@ -524,7 +524,7 @@ int dma_stm32_start(struct device *dev, u32_t id)
 static int dma_stm32_start(struct device *dev, u32_t id)
 #endif /* CONFIG_DMAMUX_STM32 */
 {
-	const struct dma_stm32_config *config = dev->config->config_info;
+	const struct dma_stm32_config *config = dev->config_info;
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
 	struct dma_stm32_data *data = dev->driver_data;
 
@@ -552,7 +552,7 @@ static int dma_stm32_stop(struct device *dev, u32_t id)
 	struct dma_stm32_data *data = dev->driver_data;
 	struct dma_stm32_stream *stream = &data->streams[id - STREAM_OFFSET];
 	const struct dma_stm32_config *config =
-				dev->config->config_info;
+				dev->config_info;
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
 
 	/* give channel from index 0 */
@@ -583,7 +583,7 @@ struct k_mem_block block;
 static int dma_stm32_init(struct device *dev)
 {
 	struct dma_stm32_data *data = dev->driver_data;
-	const struct dma_stm32_config *config = dev->config->config_info;
+	const struct dma_stm32_config *config = dev->config_info;
 	struct device *clk =
 		device_get_binding(STM32_CLOCK_CONTROL_NAME);
 

--- a/drivers/dma/dmamux_stm32.c
+++ b/drivers/dma/dmamux_stm32.c
@@ -31,7 +31,7 @@ int dmamux_stm32_configure(struct device *dev, u32_t id,
 	/* device is the dmamux, id is the dmamux channel from 0 */
 	struct dmamux_stm32_data *data = dev->driver_data;
 	const struct dmamux_stm32_config *dev_config =
-					dev->config->config_info;
+					dev->config_info;
 
 	/*
 	 * request line ID for this mux channel is stored
@@ -79,7 +79,7 @@ int dmamux_stm32_configure(struct device *dev, u32_t id,
 int dmamux_stm32_start(struct device *dev, u32_t id)
 {
 	const struct dmamux_stm32_config *dev_config =
-				dev->config->config_info;
+				dev->config_info;
 	struct dmamux_stm32_data *data = dev->driver_data;
 
 	/* check if this channel is valid */
@@ -100,7 +100,7 @@ int dmamux_stm32_start(struct device *dev, u32_t id)
 int dmamux_stm32_stop(struct device *dev, u32_t id)
 {
 	const struct dmamux_stm32_config *dev_config =
-				dev->config->config_info;
+				dev->config_info;
 	struct dmamux_stm32_data *data = dev->driver_data;
 
 	/* check if this channel is valid */
@@ -122,7 +122,7 @@ int dmamux_stm32_reload(struct device *dev, u32_t id,
 			    u32_t src, u32_t dst, size_t size)
 {
 	const struct dmamux_stm32_config *dev_config =
-				dev->config->config_info;
+				dev->config_info;
 	struct dmamux_stm32_data *data = dev->driver_data;
 
 	/* check if this channel is valid */
@@ -145,7 +145,7 @@ static int dmamux_stm32_init(struct device *dev)
 {
 	struct dmamux_stm32_data *data = dev->driver_data;
 	const struct dmamux_stm32_config *config =
-				dev->config->config_info;
+				dev->config_info;
 	struct device *clk =
 		device_get_binding(STM32_CLOCK_CONTROL_NAME);
 

--- a/drivers/eeprom/eeprom_at2x.c
+++ b/drivers/eeprom/eeprom_at2x.c
@@ -64,7 +64,7 @@ struct eeprom_at2x_data {
 
 static inline int eeprom_at2x_write_protect(struct device *dev)
 {
-	const struct eeprom_at2x_config *config = dev->config->config_info;
+	const struct eeprom_at2x_config *config = dev->config_info;
 	struct eeprom_at2x_data *data = dev->driver_data;
 
 	if (!data->wp_gpio_dev) {
@@ -76,7 +76,7 @@ static inline int eeprom_at2x_write_protect(struct device *dev)
 
 static inline int eeprom_at2x_write_enable(struct device *dev)
 {
-	const struct eeprom_at2x_config *config = dev->config->config_info;
+	const struct eeprom_at2x_config *config = dev->config_info;
 	struct eeprom_at2x_data *data = dev->driver_data;
 
 	if (!data->wp_gpio_dev) {
@@ -89,7 +89,7 @@ static inline int eeprom_at2x_write_enable(struct device *dev)
 static int eeprom_at2x_read(struct device *dev, off_t offset, void *buf,
 			    size_t len)
 {
-	const struct eeprom_at2x_config *config = dev->config->config_info;
+	const struct eeprom_at2x_config *config = dev->config_info;
 	struct eeprom_at2x_data *data = dev->driver_data;
 	int err;
 
@@ -117,7 +117,7 @@ static int eeprom_at2x_read(struct device *dev, off_t offset, void *buf,
 static size_t eeprom_at2x_limit_write_count(struct device *dev, off_t offset,
 					    size_t len)
 {
-	const struct eeprom_at2x_config *config = dev->config->config_info;
+	const struct eeprom_at2x_config *config = dev->config_info;
 	size_t count = len;
 	off_t page_boundary;
 
@@ -138,7 +138,7 @@ static size_t eeprom_at2x_limit_write_count(struct device *dev, off_t offset,
 static int eeprom_at2x_write(struct device *dev, off_t offset, const void *buf,
 			     size_t len)
 {
-	const struct eeprom_at2x_config *config = dev->config->config_info;
+	const struct eeprom_at2x_config *config = dev->config_info;
 	struct eeprom_at2x_data *data = dev->driver_data;
 	const u8_t *pbuf = buf;
 	int ret;
@@ -192,7 +192,7 @@ static int eeprom_at2x_write(struct device *dev, off_t offset, const void *buf,
 
 static size_t eeprom_at2x_size(struct device *dev)
 {
-	const struct eeprom_at2x_config *config = dev->config->config_info;
+	const struct eeprom_at2x_config *config = dev->config_info;
 
 	return config->size;
 }
@@ -201,7 +201,7 @@ static size_t eeprom_at2x_size(struct device *dev)
 static int eeprom_at24_read(struct device *dev, off_t offset, void *buf,
 			    size_t len)
 {
-	const struct eeprom_at2x_config *config = dev->config->config_info;
+	const struct eeprom_at2x_config *config = dev->config_info;
 	struct eeprom_at2x_data *data = dev->driver_data;
 	s64_t timeout;
 	u8_t addr[2];
@@ -234,7 +234,7 @@ static int eeprom_at24_read(struct device *dev, off_t offset, void *buf,
 static int eeprom_at24_write(struct device *dev, off_t offset,
 			     const void *buf, size_t len)
 {
-	const struct eeprom_at2x_config *config = dev->config->config_info;
+	const struct eeprom_at2x_config *config = dev->config_info;
 	struct eeprom_at2x_data *data = dev->driver_data;
 	int count = eeprom_at2x_limit_write_count(dev, offset, len);
 	u8_t block[config->addr_width / 8 + count];
@@ -311,7 +311,7 @@ static int eeprom_at25_rdsr(struct device *dev, u8_t *status)
 
 static int eeprom_at25_wait_for_idle(struct device *dev)
 {
-	const struct eeprom_at2x_config *config = dev->config->config_info;
+	const struct eeprom_at2x_config *config = dev->config_info;
 	s64_t timeout;
 	u8_t status;
 	int err;
@@ -336,7 +336,7 @@ static int eeprom_at25_wait_for_idle(struct device *dev)
 static int eeprom_at25_read(struct device *dev, off_t offset, void *buf,
 			    size_t len)
 {
-	const struct eeprom_at2x_config *config = dev->config->config_info;
+	const struct eeprom_at2x_config *config = dev->config_info;
 	struct eeprom_at2x_data *data = dev->driver_data;
 	size_t cmd_len = 1 + config->addr_width / 8;
 	u8_t cmd[4] = { EEPROM_AT25_READ, 0, 0, 0 };
@@ -418,7 +418,7 @@ static int eeprom_at25_wren(struct device *dev)
 static int eeprom_at25_write(struct device *dev, off_t offset,
 			     const void *buf, size_t len)
 {
-	const struct eeprom_at2x_config *config = dev->config->config_info;
+	const struct eeprom_at2x_config *config = dev->config_info;
 	struct eeprom_at2x_data *data = dev->driver_data;
 	int count = eeprom_at2x_limit_write_count(dev, offset, len);
 	u8_t cmd[4] = { EEPROM_AT25_WRITE, 0, 0, 0 };
@@ -478,7 +478,7 @@ static int eeprom_at25_write(struct device *dev, off_t offset,
 
 static int eeprom_at2x_init(struct device *dev)
 {
-	const struct eeprom_at2x_config *config = dev->config->config_info;
+	const struct eeprom_at2x_config *config = dev->config_info;
 	struct eeprom_at2x_data *data = dev->driver_data;
 	int err;
 

--- a/drivers/eeprom/eeprom_simulator.c
+++ b/drivers/eeprom/eeprom_simulator.c
@@ -35,8 +35,8 @@ struct eeprom_sim_config {
 	bool readonly;
 };
 
-#define DEV_NAME(dev) ((dev)->config->name)
-#define DEV_CONFIG(dev) ((dev)->config->config_info)
+#define DEV_NAME(dev) ((dev)->name)
+#define DEV_CONFIG(dev) ((dev)->config_info)
 
 #define EEPROM(addr) (mock_eeprom + (addr))
 

--- a/drivers/eeprom/eeprom_stm32.c
+++ b/drivers/eeprom/eeprom_stm32.c
@@ -23,7 +23,7 @@ struct eeprom_stm32_config {
 static int eeprom_stm32_read(struct device *dev, off_t offset, void *buf,
 				size_t len)
 {
-	const struct eeprom_stm32_config *config = dev->config->config_info;
+	const struct eeprom_stm32_config *config = dev->config_info;
 	u8_t *pbuf = buf;
 
 	if (!len) {
@@ -53,7 +53,7 @@ static int eeprom_stm32_read(struct device *dev, off_t offset, void *buf,
 static int eeprom_stm32_write(struct device *dev, off_t offset,
 				const void *buf, size_t len)
 {
-	const struct eeprom_stm32_config *config = dev->config->config_info;
+	const struct eeprom_stm32_config *config = dev->config_info;
 	const u8_t *pbuf = buf;
 	HAL_StatusTypeDef ret = HAL_OK;
 
@@ -100,7 +100,7 @@ static int eeprom_stm32_write(struct device *dev, off_t offset,
 
 static size_t eeprom_stm32_size(struct device *dev)
 {
-	const struct eeprom_stm32_config *config = dev->config->config_info;
+	const struct eeprom_stm32_config *config = dev->config_info;
 
 	return config->size;
 }

--- a/drivers/entropy/entropy_mcux_rng.c
+++ b/drivers/entropy/entropy_mcux_rng.c
@@ -20,7 +20,7 @@ struct mcux_entropy_config {
 static int entropy_mcux_rng_get_entropy(struct device *dev, u8_t *buffer,
 					 u16_t length)
 {
-	const struct mcux_entropy_config *config = dev->config->config_info;
+	const struct mcux_entropy_config *config = dev->config_info;
 	status_t status;
 
 	ARG_UNUSED(dev);

--- a/drivers/entropy/entropy_mcux_trng.c
+++ b/drivers/entropy/entropy_mcux_trng.c
@@ -20,7 +20,7 @@ struct mcux_entropy_config {
 static int entropy_mcux_trng_get_entropy(struct device *dev, u8_t *buffer,
 					 u16_t length)
 {
-	const struct mcux_entropy_config *config = dev->config->config_info;
+	const struct mcux_entropy_config *config = dev->config_info;
 	status_t status;
 
 	ARG_UNUSED(dev);
@@ -48,7 +48,7 @@ DEVICE_AND_API_INIT(entropy_mcux_trng, DT_INST_LABEL(0),
 
 static int entropy_mcux_trng_init(struct device *dev)
 {
-	const struct mcux_entropy_config *config = dev->config->config_info;
+	const struct mcux_entropy_config *config = dev->config_info;
 	trng_config_t conf;
 	status_t status;
 

--- a/drivers/entropy/entropy_rv32m1_trng.c
+++ b/drivers/entropy/entropy_rv32m1_trng.c
@@ -20,7 +20,7 @@ struct rv32m1_entropy_config {
 static int entropy_rv32m1_trng_get_entropy(struct device *dev, u8_t *buffer,
 					 u16_t length)
 {
-	const struct rv32m1_entropy_config *config = dev->config->config_info;
+	const struct rv32m1_entropy_config *config = dev->config_info;
 	status_t status;
 
 	ARG_UNUSED(dev);
@@ -48,7 +48,7 @@ DEVICE_AND_API_INIT(entropy_rv32m1_trng, DT_INST_LABEL(0),
 
 static int entropy_rv32m1_trng_init(struct device *dev)
 {
-	const struct rv32m1_entropy_config *config = dev->config->config_info;
+	const struct rv32m1_entropy_config *config = dev->config_info;
 	trng_config_t conf;
 	status_t status;
 

--- a/drivers/entropy/entropy_sam.c
+++ b/drivers/entropy/entropy_sam.c
@@ -18,7 +18,7 @@ struct trng_sam_dev_cfg {
 };
 
 #define DEV_CFG(dev) \
-	((const struct trng_sam_dev_cfg *const)(dev)->config->config_info)
+	((const struct trng_sam_dev_cfg *const)(dev)->config_info)
 
 static inline bool _ready(Trng * const trng)
 {

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -32,7 +32,7 @@ struct entropy_stm32_rng_dev_data {
 	((struct entropy_stm32_rng_dev_data *)(dev)->driver_data)
 
 #define DEV_CFG(dev) \
-	((struct entropy_stm32_rng_dev_cfg *)(dev)->config->config_info)
+	((struct entropy_stm32_rng_dev_cfg *)(dev)->config_info)
 
 static void entropy_stm32_rng_reset(RNG_TypeDef *rng)
 {

--- a/drivers/espi/espi_mchp_xec.c
+++ b/drivers/espi/espi_mchp_xec.c
@@ -350,7 +350,7 @@ static int espi_xec_write_lpc_request(struct device *dev,
 				      u32_t *data)
 {
 	struct espi_xec_config *config =
-		(struct espi_xec_config *) (dev->config->config_info);
+		(struct espi_xec_config *) (dev->config_info);
 
 	volatile u32_t __attribute__((unused)) dummy;
 
@@ -652,7 +652,7 @@ static void send_slave_bootdone(struct device *dev)
 static void espi_init_oob(struct device *dev)
 {
 	struct espi_xec_config *config =
-		(struct espi_xec_config *) (dev->config->config_info);
+		(struct espi_xec_config *) (dev->config_info);
 
 	/* Enable OOB Tx/Rx interrupts */
 	MCHP_GIRQ_ENSET(config->bus_girq_id) = (MCHP_ESPI_OOB_UP_GIRQ_VAL |
@@ -676,7 +676,7 @@ static void espi_init_oob(struct device *dev)
 static void espi_init_flash(struct device *dev)
 {
 	struct espi_xec_config *config =
-	    (struct espi_xec_config *)(dev->config->config_info);
+	    (struct espi_xec_config *)(dev->config_info);
 
 	LOG_DBG("%s", __func__);
 
@@ -692,7 +692,7 @@ static void espi_init_flash(struct device *dev)
 
 static void espi_bus_init(struct device *dev)
 {
-	const struct espi_xec_config *config = dev->config->config_info;
+	const struct espi_xec_config *config = dev->config_info;
 
 	/* Enable bus interrupts */
 	MCHP_GIRQ_ENSET(config->bus_girq_id) = MCHP_ESPI_ESPI_RST_GIRQ_VAL |
@@ -819,7 +819,7 @@ static void espi_pc_isr(struct device *dev)
 static void espi_vwire_chanel_isr(struct device *dev)
 {
 	struct espi_xec_data *data = (struct espi_xec_data *)(dev->driver_data);
-	const struct espi_xec_config *config = dev->config->config_info;
+	const struct espi_xec_config *config = dev->config_info;
 	struct espi_event evt = { .evt_type = ESPI_BUS_EVENT_CHANNEL_READY,
 				  .evt_details = 0,
 				  .evt_data = 0 };
@@ -1133,7 +1133,7 @@ static u8_t periph_isr_cnt = sizeof(peripherals_isr) / sizeof(struct espi_isr);
 static void espi_xec_bus_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct espi_xec_config *config = dev->config->config_info;
+	const struct espi_xec_config *config = dev->config_info;
 	u32_t girq_result;
 
 	girq_result = MCHP_GIRQ_RESULT(config->bus_girq_id);
@@ -1154,7 +1154,7 @@ static void espi_xec_bus_isr(void *arg)
 static void espi_xec_vw_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct espi_xec_config *config = dev->config->config_info;
+	const struct espi_xec_config *config = dev->config_info;
 	u32_t girq_result;
 
 	girq_result = MCHP_GIRQ_RESULT(config->vw_girq_id);
@@ -1175,7 +1175,7 @@ static void espi_xec_vw_isr(void *arg)
 static void espi_xec_periph_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct espi_xec_config *config = dev->config->config_info;
+	const struct espi_xec_config *config = dev->config_info;
 	u32_t girq_result;
 
 	girq_result = MCHP_GIRQ_RESULT(config->pc_girq_id);
@@ -1225,7 +1225,7 @@ DEVICE_AND_API_INIT(espi_xec_0, DT_INST_LABEL(0),
 
 static int espi_xec_init(struct device *dev)
 {
-	const struct espi_xec_config *config = dev->config->config_info;
+	const struct espi_xec_config *config = dev->config_info;
 	struct espi_xec_data *data = (struct espi_xec_data *)(dev->driver_data);
 
 	data->plt_rst_asserted = 0;

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -349,7 +349,7 @@ static void eth_enc28j60_init_buffers(struct device *dev)
 
 static void eth_enc28j60_init_mac(struct device *dev)
 {
-	const struct eth_enc28j60_config *config = dev->config->config_info;
+	const struct eth_enc28j60_config *config = dev->config_info;
 	struct eth_enc28j60_runtime *context = dev->driver_data;
 	u8_t data_macon;
 
@@ -399,7 +399,7 @@ static void eth_enc28j60_init_mac(struct device *dev)
 
 static void eth_enc28j60_init_phy(struct device *dev)
 {
-	const struct eth_enc28j60_config *config = dev->config->config_info;
+	const struct eth_enc28j60_config *config = dev->config_info;
 
 	if (config->full_duplex) {
 		eth_enc28j60_write_phy(dev, ENC28J60_PHY_PHCON1,
@@ -506,7 +506,7 @@ static int eth_enc28j60_tx(struct device *dev, struct net_pkt *pkt)
 
 static int eth_enc28j60_rx(struct device *dev, u16_t *vlan_tag)
 {
-	const struct eth_enc28j60_config *config = dev->config->config_info;
+	const struct eth_enc28j60_config *config = dev->config_info;
 	struct eth_enc28j60_runtime *context = dev->driver_data;
 	u16_t lengthfr;
 	u8_t counter;
@@ -717,7 +717,7 @@ static const struct ethernet_api api_funcs = {
 
 static int eth_enc28j60_init(struct device *dev)
 {
-	const struct eth_enc28j60_config *config = dev->config->config_info;
+	const struct eth_enc28j60_config *config = dev->config_info;
 	struct eth_enc28j60_runtime *context = dev->driver_data;
 
 	/* SPI config */

--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -344,7 +344,7 @@ static int enc424j600_tx(struct device *dev, struct net_pkt *pkt)
 static int enc424j600_rx(struct device *dev)
 {
 	struct enc424j600_runtime *context = dev->driver_data;
-	const struct enc424j600_config *config = dev->config->config_info;
+	const struct enc424j600_config *config = dev->config_info;
 	u8_t info[ENC424J600_RSV_SIZE + ENC424J600_PTR_NXP_PKT_SIZE];
 	struct net_buf *pkt_buf = NULL;
 	struct net_pkt *pkt;
@@ -596,7 +596,7 @@ static const struct ethernet_api api_funcs = {
 
 static int enc424j600_init(struct device *dev)
 {
-	const struct enc424j600_config *config = dev->config->config_info;
+	const struct enc424j600_config *config = dev->config_info;
 	struct enc424j600_runtime *context = dev->driver_data;
 	u8_t retries = ENC424J600_DEFAULT_NUMOF_RETRIES;
 	u16_t tmp;

--- a/drivers/ethernet/eth_gecko_priv.h
+++ b/drivers/ethernet/eth_gecko_priv.h
@@ -94,9 +94,9 @@ struct eth_gecko_dev_data {
 	bool link_up;
 };
 
-#define DEV_NAME(dev) ((dev)->config->name)
+#define DEV_NAME(dev) ((dev)->name)
 #define DEV_CFG(dev) \
-	((struct eth_gecko_dev_cfg *)(dev)->config->config_info)
+	((struct eth_gecko_dev_cfg *)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct eth_gecko_dev_data *)(dev)->driver_data)
 

--- a/drivers/ethernet/eth_liteeth.c
+++ b/drivers/ethernet/eth_liteeth.c
@@ -72,7 +72,7 @@ struct eth_liteeth_config {
 
 static int eth_initialize(struct device *dev)
 {
-	const struct eth_liteeth_config *config = dev->config->config_info;
+	const struct eth_liteeth_config *config = dev->config_info;
 
 	config->config_func();
 

--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -281,7 +281,7 @@ struct eth_sam_dev_data {
 };
 
 #define DEV_CFG(dev) \
-	((const struct eth_sam_dev_cfg *const)(dev)->config->config_info)
+	((const struct eth_sam_dev_cfg *const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct eth_sam_dev_data *const)(dev)->driver_data)
 

--- a/drivers/ethernet/eth_stellaris_priv.h
+++ b/drivers/ethernet/eth_stellaris_priv.h
@@ -11,7 +11,7 @@
 #define DEV_DATA(dev) \
 	((struct eth_stellaris_runtime *)(dev)->driver_data)
 #define DEV_CFG(dev) \
-	((struct eth_stellaris_config *const)(dev)->config->config_info)
+	((struct eth_stellaris_config *const)(dev)->config_info)
 /*
  *  Register mapping
  */

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -45,7 +45,7 @@ struct eth_stm32_hal_dev_data {
 };
 
 #define DEV_CFG(dev) \
-	((struct eth_stm32_hal_dev_cfg *)(dev)->config->config_info)
+	((struct eth_stm32_hal_dev_cfg *)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct eth_stm32_hal_dev_data *)(dev)->driver_data)
 

--- a/drivers/flash/flash_gecko.c
+++ b/drivers/flash/flash_gecko.c
@@ -24,7 +24,7 @@ struct flash_gecko_data {
 	struct k_sem mutex;
 };
 
-#define DEV_NAME(dev) ((dev)->config->name)
+#define DEV_NAME(dev) ((dev)->name)
 #define DEV_DATA(dev) \
 	((struct flash_gecko_data *const)(dev)->driver_data)
 

--- a/drivers/flash/flash_sam.c
+++ b/drivers/flash/flash_sam.c
@@ -47,7 +47,7 @@ struct flash_sam_dev_data {
 };
 
 #define DEV_CFG(dev) \
-	((const struct flash_sam_dev_cfg *const)(dev)->config->config_info)
+	((const struct flash_sam_dev_cfg *const)(dev)->config_info)
 
 #define DEV_DATA(dev) \
 	((struct flash_sam_dev_data *const)(dev)->driver_data)

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -17,8 +17,8 @@
 #define BUF_ARRAY_CNT 16
 #define TEST_ARR_SIZE 0x1000
 
-extern struct device __device_init_start[];
-extern struct device __device_init_end[];
+extern struct device __device_start[];
+extern struct device __device_end[];
 
 static u8_t test_arr[TEST_ARR_SIZE];
 
@@ -229,7 +229,7 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 	entry->help  = NULL;
 	entry->subcmd = &dsub_device_name;
 
-	for (dev = __device_init_start; dev != __device_init_end; dev++) {
+	for (dev = __device_start; dev != __device_end; dev++) {
 		if ((dev->driver_api != NULL) &&
 		strcmp(dev->config->name, "") && (dev->config->name != NULL)) {
 			if (idx == device_idx) {

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -231,9 +231,9 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 
 	for (dev = __device_start; dev != __device_end; dev++) {
 		if ((dev->driver_api != NULL) &&
-		strcmp(dev->config->name, "") && (dev->config->name != NULL)) {
+		strcmp(dev->name, "") && (dev->name != NULL)) {
 			if (idx == device_idx) {
-				entry->syntax = dev->config->name;
+				entry->syntax = dev->name;
 				break;
 			}
 			device_idx++;

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -320,7 +320,7 @@ static int qspi_erase(struct device *dev, u32_t addr, u32_t size)
 	}
 
 	int rv = -EIO;
-	const struct qspi_nor_config *params = dev->config->config_info;
+	const struct qspi_nor_config *params = dev->config_info;
 
 	while (size) {
 		nrfx_err_t res = !NRFX_SUCCESS;
@@ -504,7 +504,7 @@ static int qspi_nor_read(struct device *dev, off_t addr, void *dest,
 		return -EINVAL;
 	}
 
-	const struct qspi_nor_config *params = dev->config->config_info;
+	const struct qspi_nor_config *params = dev->config_info;
 
 	/* should be between 0 and flash size */
 	if (addr >= params->size ||
@@ -543,7 +543,7 @@ static int qspi_nor_write(struct device *dev, off_t addr, const void *src,
 	}
 
 	struct qspi_nor_data *const driver_data = dev->driver_data;
-	const struct qspi_nor_config *params = dev->config->config_info;
+	const struct qspi_nor_config *params = dev->config_info;
 
 	if (driver_data->write_protection) {
 		return -EACCES;
@@ -572,7 +572,7 @@ static int qspi_nor_write(struct device *dev, off_t addr, const void *src,
 static int qspi_nor_erase(struct device *dev, off_t addr, size_t size)
 {
 	struct qspi_nor_data *const driver_data = dev->driver_data;
-	const struct qspi_nor_config *params = dev->config->config_info;
+	const struct qspi_nor_config *params = dev->config_info;
 
 	if (driver_data->write_protection) {
 		return -EACCES;
@@ -622,7 +622,7 @@ static int qspi_nor_write_protection_set(struct device *dev,
  */
 static int qspi_nor_configure(struct device *dev)
 {
-	const struct qspi_nor_config *params = dev->config->config_info;
+	const struct qspi_nor_config *params = dev->config_info;
 
 	int ret = qspi_nrfx_configure(dev);
 

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -83,7 +83,7 @@ static struct spi_flash_at45_data *get_dev_data(struct device *dev)
 
 static const struct spi_flash_at45_config *get_dev_config(struct device *dev)
 {
-	return dev->config->config_info;
+	return dev->config_info;
 }
 
 static void acquire(struct device *dev)

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -316,7 +316,7 @@ static int spi_nor_wait_until_ready(struct device *dev)
 static int spi_nor_read(struct device *dev, off_t addr, void *dest,
 			size_t size)
 {
-	const struct spi_nor_config *params = dev->config->config_info;
+	const struct spi_nor_config *params = dev->config_info;
 	int ret;
 
 	/* should be between 0 and flash size */
@@ -337,7 +337,7 @@ static int spi_nor_read(struct device *dev, off_t addr, void *dest,
 static int spi_nor_write(struct device *dev, off_t addr, const void *src,
 			 size_t size)
 {
-	const struct spi_nor_config *params = dev->config->config_info;
+	const struct spi_nor_config *params = dev->config_info;
 	int ret = 0;
 
 	/* should be between 0 and flash size */
@@ -382,7 +382,7 @@ out:
 
 static int spi_nor_erase(struct device *dev, off_t addr, size_t size)
 {
-	const struct spi_nor_config *params = dev->config->config_info;
+	const struct spi_nor_config *params = dev->config_info;
 	int ret = 0;
 
 	/* should be between 0 and flash size */
@@ -471,7 +471,7 @@ static int spi_nor_write_protection_set(struct device *dev, bool write_protect)
 static int spi_nor_configure(struct device *dev)
 {
 	struct spi_nor_data *data = dev->driver_data;
-	const struct spi_nor_config *params = dev->config->config_info;
+	const struct spi_nor_config *params = dev->config_info;
 
 	data->spi = device_get_binding(DT_INST_BUS_LABEL(0));
 	if (!data->spi) {

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -62,7 +62,7 @@ struct gpio_cc32xx_data {
 };
 
 #define DEV_CFG(dev) \
-	((const struct gpio_cc32xx_config *)(dev)->config->config_info)
+	((const struct gpio_cc32xx_config *)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct gpio_cc32xx_data *)(dev)->driver_data)
 

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -46,7 +46,7 @@ struct gpio_cmsdk_ahb_dev_data {
 
 static int gpio_cmsdk_ahb_port_get_raw(struct device *dev, u32_t *value)
 {
-	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config->config_info;
+	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config_info;
 
 	*value = cfg->port->data;
 
@@ -56,7 +56,7 @@ static int gpio_cmsdk_ahb_port_get_raw(struct device *dev, u32_t *value)
 static int gpio_cmsdk_ahb_port_set_masked_raw(struct device *dev, u32_t mask,
 					 u32_t value)
 {
-	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config->config_info;
+	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config_info;
 
 	cfg->port->dataout = (cfg->port->dataout & ~mask) | (mask & value);
 
@@ -65,7 +65,7 @@ static int gpio_cmsdk_ahb_port_set_masked_raw(struct device *dev, u32_t mask,
 
 static int gpio_cmsdk_ahb_port_set_bits_raw(struct device *dev, u32_t mask)
 {
-	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config->config_info;
+	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config_info;
 
 	cfg->port->dataout |= mask;
 
@@ -74,7 +74,7 @@ static int gpio_cmsdk_ahb_port_set_bits_raw(struct device *dev, u32_t mask)
 
 static int gpio_cmsdk_ahb_port_clear_bits_raw(struct device *dev, u32_t mask)
 {
-	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config->config_info;
+	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config_info;
 
 	cfg->port->dataout &= ~mask;
 
@@ -83,7 +83,7 @@ static int gpio_cmsdk_ahb_port_clear_bits_raw(struct device *dev, u32_t mask)
 
 static int gpio_cmsdk_ahb_port_toggle_bits(struct device *dev, u32_t mask)
 {
-	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config->config_info;
+	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config_info;
 
 	cfg->port->dataout ^= mask;
 
@@ -92,7 +92,7 @@ static int gpio_cmsdk_ahb_port_toggle_bits(struct device *dev, u32_t mask)
 
 static int cmsdk_ahb_gpio_config(struct device *dev, u32_t mask, gpio_flags_t flags)
 {
-	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config->config_info;
+	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config_info;
 
 	if (((flags & GPIO_INPUT) == 0) && ((flags & GPIO_OUTPUT) == 0)) {
 		return -ENOTSUP;
@@ -148,7 +148,7 @@ static int gpio_cmsdk_ahb_pin_interrupt_configure(struct device *dev,
 		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
-	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config->config_info;
+	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config_info;
 
 	if (trig == GPIO_INT_TRIG_BOTH) {
 		return -ENOTSUP;
@@ -187,7 +187,7 @@ static int gpio_cmsdk_ahb_pin_interrupt_configure(struct device *dev,
 static void gpio_cmsdk_ahb_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config->config_info;
+	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config_info;
 	struct gpio_cmsdk_ahb_dev_data *data = dev->driver_data;
 	u32_t int_stat;
 
@@ -212,7 +212,7 @@ static int gpio_cmsdk_ahb_manage_callback(struct device *dev,
 static int gpio_cmsdk_ahb_enable_callback(struct device *dev,
 					  gpio_pin_t pin)
 {
-	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config->config_info;
+	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config_info;
 
 	cfg->port->intenset |= BIT(pin);
 
@@ -222,7 +222,7 @@ static int gpio_cmsdk_ahb_enable_callback(struct device *dev,
 static int gpio_cmsdk_ahb_disable_callback(struct device *dev,
 					   gpio_pin_t pin)
 {
-	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config->config_info;
+	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config_info;
 
 	cfg->port->intenclr |= BIT(pin);
 
@@ -250,7 +250,7 @@ static const struct gpio_driver_api gpio_cmsdk_ahb_drv_api_funcs = {
  */
 static int gpio_cmsdk_ahb_init(struct device *dev)
 {
-	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config->config_info;
+	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config_info;
 
 #ifdef CONFIG_CLOCK_CONTROL
 	/* Enable clock for subsystem */

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -99,7 +99,7 @@ static inline void gpio_dw_clock_config(struct device *port)
 
 static inline void gpio_dw_clock_on(struct device *port)
 {
-	const struct gpio_dw_config *config = port->config->config_info;
+	const struct gpio_dw_config *config = port->config_info;
 	struct gpio_dw_runtime *context = port->driver_data;
 
 	clock_control_on(context->clock, config->clock_data);
@@ -107,7 +107,7 @@ static inline void gpio_dw_clock_on(struct device *port)
 
 static inline void gpio_dw_clock_off(struct device *port)
 {
-	const struct gpio_dw_config *config = port->config->config_info;
+	const struct gpio_dw_config *config = port->config_info;
 	struct gpio_dw_runtime *context = port->driver_data;
 
 	clock_control_off(context->clock, config->clock_data);
@@ -211,7 +211,7 @@ static int gpio_dw_pin_interrupt_configure(struct device *port,
 		enum gpio_int_trig trig)
 {
 	struct gpio_dw_runtime *context = port->driver_data;
-	const struct gpio_dw_config *config = port->config->config_info;
+	const struct gpio_dw_config *config = port->config_info;
 	u32_t base_addr = dw_base_to_block_base(context->base_addr);
 	u32_t port_base_addr = context->base_addr;
 	u32_t dir_port = dw_get_dir_port(port_base_addr);
@@ -275,7 +275,7 @@ static inline void dw_pin_config(struct device *port,
 				 u32_t pin, int flags)
 {
 	struct gpio_dw_runtime *context = port->driver_data;
-	const struct gpio_dw_config *config = port->config->config_info;
+	const struct gpio_dw_config *config = port->config_info;
 	u32_t base_addr = dw_base_to_block_base(context->base_addr);
 	u32_t port_base_addr = context->base_addr;
 	u32_t dir_port = dw_get_dir_port(port_base_addr);
@@ -307,7 +307,7 @@ static inline int gpio_dw_config(struct device *port,
 				 gpio_pin_t pin,
 				 gpio_flags_t flags)
 {
-	const struct gpio_dw_config *config = port->config->config_info;
+	const struct gpio_dw_config *config = port->config_info;
 	u32_t io_flags;
 
 	/* Check for invalid pin number */
@@ -555,7 +555,7 @@ static const struct gpio_driver_api api_funcs = {
 static int gpio_dw_initialize(struct device *port)
 {
 	struct gpio_dw_runtime *context = port->driver_data;
-	const struct gpio_dw_config *config = port->config->config_info;
+	const struct gpio_dw_config *config = port->config_info;
 	u32_t base_addr;
 
 	if (dw_interrupt_support(config)) {
@@ -626,7 +626,7 @@ DEVICE_AND_API_INIT(gpio_dw_0, DT_INST_LABEL(0),
 static void gpio_config_0_irq(struct device *port)
 {
 #if (DT_INST_IRQN(0) > 0)
-	const struct gpio_dw_config *config = port->config->config_info;
+	const struct gpio_dw_config *config = port->config_info;
 
 #ifdef CONFIG_GPIO_DW_0_IRQ_DIRECT
 	IRQ_CONNECT(DT_INST_IRQN(0),
@@ -696,7 +696,7 @@ DEVICE_AND_API_INIT(gpio_dw_1, DT_INST_LABEL(1),
 static void gpio_config_1_irq(struct device *port)
 {
 #if (DT_INST_IRQN(1) > 0)
-	const struct gpio_dw_config *config = port->config->config_info;
+	const struct gpio_dw_config *config = port->config_info;
 
 #ifdef CONFIG_GPIO_DW_1_IRQ_DIRECT
 	IRQ_CONNECT(DT_INST_IRQN(1),
@@ -764,7 +764,7 @@ DEVICE_AND_API_INIT(gpio_dw_2, DT_INST_LABEL(2),
 static void gpio_config_2_irq(struct device *port)
 {
 #if (DT_INST_IRQN(2) > 0)
-	const struct gpio_dw_config *config = port->config->config_info;
+	const struct gpio_dw_config *config = port->config_info;
 
 #ifdef CONFIG_GPIO_DW_2_IRQ_DIRECT
 	IRQ_CONNECT(DT_INST_IRQN(2),
@@ -832,7 +832,7 @@ DEVICE_AND_API_INIT(gpio_dw_3, DT_INST_LABEL(3),
 static void gpio_config_3_irq(struct device *port)
 {
 #if (DT_INST_IRQN(3) > 0)
-	const struct gpio_dw_config *config = port->config->config_info;
+	const struct gpio_dw_config *config = port->config_info;
 
 #ifdef CONFIG_GPIO_DW_3_IRQ_DIRECT
 	IRQ_CONNECT(DT_INST_IRQN(3),

--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -76,7 +76,7 @@ static int gpio_gecko_configure(struct device *dev,
 				gpio_pin_t pin,
 				gpio_flags_t flags)
 {
-	const struct gpio_gecko_config *config = dev->config->config_info;
+	const struct gpio_gecko_config *config = dev->config_info;
 	GPIO_Port_TypeDef gpio_index = config->gpio_index;
 	GPIO_Mode_TypeDef mode;
 	unsigned int out = 0U;
@@ -127,7 +127,7 @@ static int gpio_gecko_configure(struct device *dev,
 
 static int gpio_gecko_port_get_raw(struct device *dev, u32_t *value)
 {
-	const struct gpio_gecko_config *config = dev->config->config_info;
+	const struct gpio_gecko_config *config = dev->config_info;
 	GPIO_P_TypeDef *gpio_base = config->gpio_base;
 
 	*value = gpio_base->DIN;
@@ -138,7 +138,7 @@ static int gpio_gecko_port_get_raw(struct device *dev, u32_t *value)
 static int gpio_gecko_port_set_masked_raw(struct device *dev, u32_t mask,
 					  u32_t value)
 {
-	const struct gpio_gecko_config *config = dev->config->config_info;
+	const struct gpio_gecko_config *config = dev->config_info;
 	GPIO_P_TypeDef *gpio_base = config->gpio_base;
 
 	gpio_base->DOUT = (gpio_base->DOUT & ~mask) | (mask & value);
@@ -148,7 +148,7 @@ static int gpio_gecko_port_set_masked_raw(struct device *dev, u32_t mask,
 
 static int gpio_gecko_port_set_bits_raw(struct device *dev, u32_t mask)
 {
-	const struct gpio_gecko_config *config = dev->config->config_info;
+	const struct gpio_gecko_config *config = dev->config_info;
 	GPIO_P_TypeDef *gpio_base = config->gpio_base;
 
 #if defined(_GPIO_P_DOUTSET_MASK)
@@ -162,7 +162,7 @@ static int gpio_gecko_port_set_bits_raw(struct device *dev, u32_t mask)
 
 static int gpio_gecko_port_clear_bits_raw(struct device *dev, u32_t mask)
 {
-	const struct gpio_gecko_config *config = dev->config->config_info;
+	const struct gpio_gecko_config *config = dev->config_info;
 	GPIO_P_TypeDef *gpio_base = config->gpio_base;
 
 #if defined(_GPIO_P_DOUTCLR_MASK)
@@ -176,7 +176,7 @@ static int gpio_gecko_port_clear_bits_raw(struct device *dev, u32_t mask)
 
 static int gpio_gecko_port_toggle_bits(struct device *dev, u32_t mask)
 {
-	const struct gpio_gecko_config *config = dev->config->config_info;
+	const struct gpio_gecko_config *config = dev->config_info;
 	GPIO_P_TypeDef *gpio_base = config->gpio_base;
 
 	gpio_base->DOUTTGL = mask;
@@ -188,7 +188,7 @@ static int gpio_gecko_pin_interrupt_configure(struct device *dev,
 		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
-	const struct gpio_gecko_config *config = dev->config->config_info;
+	const struct gpio_gecko_config *config = dev->config_info;
 	struct gpio_gecko_data *data = dev->driver_data;
 
 	/* Interrupt on static level is not supported by the hardware */

--- a/drivers/gpio/gpio_ht16k33.c
+++ b/drivers/gpio/gpio_ht16k33.c
@@ -161,7 +161,7 @@ static u32_t gpio_ht16k33_get_pending_int(struct device *dev)
 
 static int gpio_ht16k33_init(struct device *dev)
 {
-	const struct gpio_ht16k33_cfg *config = dev->config->config_info;
+	const struct gpio_ht16k33_cfg *config = dev->config_info;
 	struct gpio_ht16k33_data *data = dev->driver_data;
 
 	if (config->keyscan_idx >= HT16K33_KEYSCAN_ROWS) {

--- a/drivers/gpio/gpio_imx.c
+++ b/drivers/gpio/gpio_imx.c
@@ -33,7 +33,7 @@ struct imx_gpio_data {
 static int imx_gpio_configure(struct device *port, gpio_pin_t pin,
 			      gpio_flags_t flags)
 {
-	const struct imx_gpio_config *config = port->config->config_info;
+	const struct imx_gpio_config *config = port->config_info;
 	GPIO_Type *base = config->base;
 
 	if (((flags & GPIO_INPUT) != 0U) && ((flags & GPIO_OUTPUT) != 0U)) {
@@ -70,7 +70,7 @@ static int imx_gpio_configure(struct device *port, gpio_pin_t pin,
 
 static int imx_gpio_port_get_raw(struct device *port, u32_t *value)
 {
-	const struct imx_gpio_config *config = port->config->config_info;
+	const struct imx_gpio_config *config = port->config_info;
 	GPIO_Type *base = config->base;
 
 	*value = GPIO_ReadPortInput(base);
@@ -82,7 +82,7 @@ static int imx_gpio_port_set_masked_raw(struct device *port,
 					gpio_port_pins_t mask,
 					gpio_port_value_t value)
 {
-	const struct imx_gpio_config *config = port->config->config_info;
+	const struct imx_gpio_config *config = port->config_info;
 	GPIO_Type *base = config->base;
 
 	GPIO_WritePortOutput(base,
@@ -94,7 +94,7 @@ static int imx_gpio_port_set_masked_raw(struct device *port,
 static int imx_gpio_port_set_bits_raw(struct device *port,
 				      gpio_port_pins_t pins)
 {
-	const struct imx_gpio_config *config = port->config->config_info;
+	const struct imx_gpio_config *config = port->config_info;
 	GPIO_Type *base = config->base;
 
 	GPIO_WritePortOutput(base, GPIO_ReadPortInput(base) | pins);
@@ -105,7 +105,7 @@ static int imx_gpio_port_set_bits_raw(struct device *port,
 static int imx_gpio_port_clear_bits_raw(struct device *port,
 					gpio_port_pins_t pins)
 {
-	const struct imx_gpio_config *config = port->config->config_info;
+	const struct imx_gpio_config *config = port->config_info;
 	GPIO_Type *base = config->base;
 
 	GPIO_WritePortOutput(base, GPIO_ReadPortInput(base) & ~pins);
@@ -115,7 +115,7 @@ static int imx_gpio_port_clear_bits_raw(struct device *port,
 
 static int imx_gpio_port_toggle_bits(struct device *port, gpio_port_pins_t pins)
 {
-	const struct imx_gpio_config *config = port->config->config_info;
+	const struct imx_gpio_config *config = port->config_info;
 	GPIO_Type *base = config->base;
 
 	GPIO_WritePortOutput(base, GPIO_ReadPortInput(base) ^ pins);
@@ -128,7 +128,7 @@ static int imx_gpio_pin_interrupt_configure(struct device *port,
 					    enum gpio_int_mode mode,
 					    enum gpio_int_trig trig)
 {
-	const struct imx_gpio_config *config = port->config->config_info;
+	const struct imx_gpio_config *config = port->config_info;
 	struct imx_gpio_data *data = port->driver_data;
 	GPIO_Type *base = config->base;
 	volatile u32_t *icr_reg;
@@ -190,7 +190,7 @@ static int imx_gpio_manage_callback(struct device *port,
 static int imx_gpio_enable_callback(struct device *port,
 				    gpio_pin_t pin)
 {
-	const struct imx_gpio_config *config = port->config->config_info;
+	const struct imx_gpio_config *config = port->config_info;
 	struct imx_gpio_data *data = port->driver_data;
 
 	data->pin_callback_enables |= BIT(pin);
@@ -202,7 +202,7 @@ static int imx_gpio_enable_callback(struct device *port,
 static int imx_gpio_disable_callback(struct device *port,
 				     gpio_pin_t pin)
 {
-	const struct imx_gpio_config *config = port->config->config_info;
+	const struct imx_gpio_config *config = port->config_info;
 	struct imx_gpio_data *data = port->driver_data;
 
 	GPIO_SetPinIntMode(config->base, pin, false);
@@ -214,7 +214,7 @@ static int imx_gpio_disable_callback(struct device *port,
 static void imx_gpio_port_isr(void *arg)
 {
 	struct device *port = (struct device *)arg;
-	const struct imx_gpio_config *config = port->config->config_info;
+	const struct imx_gpio_config *config = port->config_info;
 	struct imx_gpio_data *data = port->driver_data;
 	u32_t enabled_int;
 

--- a/drivers/gpio/gpio_intel_apl.c
+++ b/drivers/gpio/gpio_intel_apl.c
@@ -132,7 +132,7 @@ struct gpio_intel_apl_data {
  */
 static bool check_perm(struct device *dev, u32_t raw_pin)
 {
-	const struct gpio_intel_apl_config *cfg = dev->config->config_info;
+	const struct gpio_intel_apl_config *cfg = dev->config_info;
 	struct gpio_intel_apl_data *data = dev->driver_data;
 	u32_t offset, val;
 
@@ -183,7 +183,7 @@ static int gpio_intel_apl_isr(struct device *dev)
 
 	for (isr_dev = 0; isr_dev < nr_isr_devs; ++isr_dev) {
 		dev = isr_devs[isr_dev];
-		cfg = dev->config->config_info;
+		cfg = dev->config_info;
 		data = dev->driver_data;
 
 		reg = cfg->reg_base + REG_GPI_INT_STS_BASE
@@ -210,7 +210,7 @@ static int gpio_intel_apl_isr(struct device *dev)
 static int gpio_intel_apl_config(struct device *dev,
 				 gpio_pin_t pin, gpio_flags_t flags)
 {
-	const struct gpio_intel_apl_config *cfg = dev->config->config_info;
+	const struct gpio_intel_apl_config *cfg = dev->config_info;
 	struct gpio_intel_apl_data *data = dev->driver_data;
 	u32_t raw_pin, reg, cfg0, cfg1;
 
@@ -285,7 +285,7 @@ static int gpio_intel_apl_pin_interrupt_configure(struct device *dev,
 		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
-	const struct gpio_intel_apl_config *cfg = dev->config->config_info;
+	const struct gpio_intel_apl_config *cfg = dev->config_info;
 	struct gpio_intel_apl_data *data = dev->driver_data;
 	u32_t raw_pin, cfg0, cfg1;
 	u32_t reg, reg_en, reg_sts;
@@ -373,7 +373,7 @@ static int gpio_intel_apl_manage_callback(struct device *dev,
 static int gpio_intel_apl_enable_callback(struct device *dev,
 					  gpio_pin_t pin)
 {
-	const struct gpio_intel_apl_config *cfg = dev->config->config_info;
+	const struct gpio_intel_apl_config *cfg = dev->config_info;
 	u32_t raw_pin, reg;
 
 	pin = k_array_index_sanitize(pin, cfg->num_pins + 1);
@@ -398,7 +398,7 @@ static int gpio_intel_apl_enable_callback(struct device *dev,
 static int gpio_intel_apl_disable_callback(struct device *dev,
 					   gpio_pin_t pin)
 {
-	const struct gpio_intel_apl_config *cfg = dev->config->config_info;
+	const struct gpio_intel_apl_config *cfg = dev->config_info;
 	u32_t raw_pin, reg;
 
 	pin = k_array_index_sanitize(pin, cfg->num_pins + 1);
@@ -419,7 +419,7 @@ static int gpio_intel_apl_disable_callback(struct device *dev,
 static int port_get_raw(struct device *dev, u32_t mask, u32_t *value,
 			bool read_tx)
 {
-	const struct gpio_intel_apl_config *cfg = dev->config->config_info;
+	const struct gpio_intel_apl_config *cfg = dev->config_info;
 	struct gpio_intel_apl_data *data = dev->driver_data;
 	u32_t pin, raw_pin, reg_addr, reg_val, cmp;
 
@@ -458,7 +458,7 @@ static int port_get_raw(struct device *dev, u32_t mask, u32_t *value,
 
 static int port_set_raw(struct device *dev, u32_t mask, u32_t value)
 {
-	const struct gpio_intel_apl_config *cfg = dev->config->config_info;
+	const struct gpio_intel_apl_config *cfg = dev->config_info;
 	struct gpio_intel_apl_data *data = dev->driver_data;
 	u32_t pin, raw_pin, reg_addr, reg_val;
 
@@ -549,7 +549,7 @@ static const struct gpio_driver_api gpio_intel_apl_api = {
 
 int gpio_intel_apl_init(struct device *dev)
 {
-	const struct gpio_intel_apl_config *cfg = dev->config->config_info;
+	const struct gpio_intel_apl_config *cfg = dev->config_info;
 	struct gpio_intel_apl_data *data = dev->driver_data;
 
 	data->pad_base = sys_read32(cfg->reg_base + REG_PAD_BASE_ADDR);

--- a/drivers/gpio/gpio_litex.c
+++ b/drivers/gpio/gpio_litex.c
@@ -43,7 +43,7 @@ struct gpio_litex_data {
 /* Helper macros for GPIO */
 
 #define DEV_GPIO_CFG(dev)						\
-	((const struct gpio_litex_cfg *)(dev)->config->config_info)
+	((const struct gpio_litex_cfg *)(dev)->config_info)
 
 /* Helper functions for bit / port access */
 

--- a/drivers/gpio/gpio_lmp90xxx.c
+++ b/drivers/gpio/gpio_lmp90xxx.c
@@ -138,7 +138,7 @@ static int gpio_lmp90xxx_pin_interrupt_configure(struct device *dev,
 
 static int gpio_lmp90xxx_init(struct device *dev)
 {
-	const struct gpio_lmp90xxx_config *config = dev->config->config_info;
+	const struct gpio_lmp90xxx_config *config = dev->config_info;
 	struct gpio_lmp90xxx_data *data = dev->driver_data;
 
 	data->parent = device_get_binding(config->parent_dev_name);

--- a/drivers/gpio/gpio_mchp_xec.c
+++ b/drivers/gpio/gpio_mchp_xec.c
@@ -49,7 +49,7 @@ struct gpio_xec_config {
 static int gpio_xec_configure(struct device *dev,
 			      gpio_pin_t pin, gpio_flags_t flags)
 {
-	const struct gpio_xec_config *config = dev->config->config_info;
+	const struct gpio_xec_config *config = dev->config_info;
 	__IO u32_t *current_pcr1;
 	u32_t pcr1 = 0U;
 	u32_t mask = 0U;
@@ -132,7 +132,7 @@ static int gpio_xec_pin_interrupt_configure(struct device *dev,
 		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
-	const struct gpio_xec_config *config = dev->config->config_info;
+	const struct gpio_xec_config *config = dev->config_info;
 	struct gpio_xec_data *drv_data = dev->driver_data;
 	__IO u32_t *current_pcr1;
 	u32_t pcr1 = 0U;
@@ -213,7 +213,7 @@ static int gpio_xec_pin_interrupt_configure(struct device *dev,
 static int gpio_xec_port_set_masked_raw(struct device *dev, u32_t mask,
 					u32_t value)
 {
-	const struct gpio_xec_config *config = dev->config->config_info;
+	const struct gpio_xec_config *config = dev->config_info;
 
 	/* GPIO output registers are used for writing */
 	__IO u32_t *gpio_base = GPIO_OUT_BASE(config);
@@ -225,7 +225,7 @@ static int gpio_xec_port_set_masked_raw(struct device *dev, u32_t mask,
 
 static int gpio_xec_port_set_bits_raw(struct device *dev, u32_t mask)
 {
-	const struct gpio_xec_config *config = dev->config->config_info;
+	const struct gpio_xec_config *config = dev->config_info;
 
 	/* GPIO output registers are used for writing */
 	__IO u32_t *gpio_base = GPIO_OUT_BASE(config);
@@ -237,7 +237,7 @@ static int gpio_xec_port_set_bits_raw(struct device *dev, u32_t mask)
 
 static int gpio_xec_port_clear_bits_raw(struct device *dev, u32_t mask)
 {
-	const struct gpio_xec_config *config = dev->config->config_info;
+	const struct gpio_xec_config *config = dev->config_info;
 
 	/* GPIO output registers are used for writing */
 	__IO u32_t *gpio_base = GPIO_OUT_BASE(config);
@@ -249,7 +249,7 @@ static int gpio_xec_port_clear_bits_raw(struct device *dev, u32_t mask)
 
 static int gpio_xec_port_toggle_bits(struct device *dev, u32_t mask)
 {
-	const struct gpio_xec_config *config = dev->config->config_info;
+	const struct gpio_xec_config *config = dev->config_info;
 
 	/* GPIO output registers are used for writing */
 	__IO u32_t *gpio_base = GPIO_OUT_BASE(config);
@@ -261,7 +261,7 @@ static int gpio_xec_port_toggle_bits(struct device *dev, u32_t mask)
 
 static int gpio_xec_port_get_raw(struct device *dev, u32_t *value)
 {
-	const struct gpio_xec_config *config = dev->config->config_info;
+	const struct gpio_xec_config *config = dev->config_info;
 
 	/* GPIO input registers are used for reading */
 	__IO u32_t *gpio_base = GPIO_IN_BASE(config);
@@ -304,7 +304,7 @@ static int gpio_xec_disable_callback(struct device *dev,
 static void gpio_gpio_xec_port_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct gpio_xec_config *config = dev->config->config_info;
+	const struct gpio_xec_config *config = dev->config_info;
 	struct gpio_xec_data *data = dev->driver_data;
 	u32_t girq_result;
 	u32_t enabled_int;
@@ -364,7 +364,7 @@ DEVICE_AND_API_INIT(gpio_xec_port000_036,
 static int gpio_xec_port000_036_init(struct device *dev)
 {
 #if DT_IRQ_HAS_CELL(DT_NODELABEL(gpio_000_036), irq)
-	const struct gpio_xec_config *config = dev->config->config_info;
+	const struct gpio_xec_config *config = dev->config_info;
 
 	/* Turn on the block enable in the EC aggregator */
 	MCHP_GIRQ_BLK_SETEN(config->girq_id);
@@ -409,7 +409,7 @@ DEVICE_AND_API_INIT(gpio_xec_port040_076,
 static int gpio_xec_port040_076_init(struct device *dev)
 {
 #if DT_IRQ_HAS_CELL(DT_NODELABEL(gpio_040_076), irq)
-	const struct gpio_xec_config *config = dev->config->config_info;
+	const struct gpio_xec_config *config = dev->config_info;
 
 	/* Turn on the block enable in the EC aggregator */
 	MCHP_GIRQ_BLK_SETEN(config->girq_id);
@@ -454,7 +454,7 @@ DEVICE_AND_API_INIT(gpio_xec_port100_136,
 static int gpio_xec_port100_136_init(struct device *dev)
 {
 #if DT_IRQ_HAS_CELL(DT_NODELABEL(gpio_100_136), irq)
-	const struct gpio_xec_config *config = dev->config->config_info;
+	const struct gpio_xec_config *config = dev->config_info;
 
 	/* Turn on the block enable in the EC aggregator */
 	MCHP_GIRQ_BLK_SETEN(config->girq_id);
@@ -499,7 +499,7 @@ DEVICE_AND_API_INIT(gpio_xec_port140_176,
 static int gpio_xec_port140_176_init(struct device *dev)
 {
 #if DT_IRQ_HAS_CELL(DT_NODELABEL(gpio_140_176), irq)
-	const struct gpio_xec_config *config = dev->config->config_info;
+	const struct gpio_xec_config *config = dev->config_info;
 
 	/* Turn on the block enable in the EC aggregator */
 	MCHP_GIRQ_BLK_SETEN(config->girq_id);
@@ -544,7 +544,7 @@ DEVICE_AND_API_INIT(gpio_xec_port200_236,
 static int gpio_xec_port200_236_init(struct device *dev)
 {
 #if DT_IRQ_HAS_CELL(DT_NODELABEL(gpio_200_236), irq)
-	const struct gpio_xec_config *config = dev->config->config_info;
+	const struct gpio_xec_config *config = dev->config_info;
 
 	/* Turn on the block enable in the EC aggregator */
 	MCHP_GIRQ_BLK_SETEN(config->girq_id);
@@ -589,7 +589,7 @@ DEVICE_AND_API_INIT(gpio_xec_port240_276,
 static int gpio_xec_port240_276_init(struct device *dev)
 {
 #if DT_IRQ_HAS_CELL(DT_NODELABEL(gpio_240_276), irq)
-	const struct gpio_xec_config *config = dev->config->config_info;
+	const struct gpio_xec_config *config = dev->config_info;
 
 	/* Turn on the block enable in the EC aggregator */
 	MCHP_GIRQ_BLK_SETEN(config->girq_id);

--- a/drivers/gpio/gpio_mcp23s17.c
+++ b/drivers/gpio/gpio_mcp23s17.c
@@ -360,7 +360,7 @@ static const struct gpio_driver_api api_table = {
 static int mcp23s17_init(struct device *dev)
 {
 	const struct mcp23s17_config *const config =
-		dev->config->config_info;
+		dev->config_info;
 	struct mcp23s17_drv_data *const drv_data =
 		(struct mcp23s17_drv_data *const)dev->driver_data;
 

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -36,7 +36,7 @@ struct gpio_mcux_data {
 static int gpio_mcux_configure(struct device *dev,
 			       gpio_pin_t pin, gpio_flags_t flags)
 {
-	const struct gpio_mcux_config *config = dev->config->config_info;
+	const struct gpio_mcux_config *config = dev->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 	PORT_Type *port_base = config->port_base;
 	u32_t mask = 0U;
@@ -102,7 +102,7 @@ static int gpio_mcux_configure(struct device *dev,
 
 static int gpio_mcux_port_get_raw(struct device *dev, u32_t *value)
 {
-	const struct gpio_mcux_config *config = dev->config->config_info;
+	const struct gpio_mcux_config *config = dev->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 
 	*value = gpio_base->PDIR;
@@ -113,7 +113,7 @@ static int gpio_mcux_port_get_raw(struct device *dev, u32_t *value)
 static int gpio_mcux_port_set_masked_raw(struct device *dev, u32_t mask,
 					 u32_t value)
 {
-	const struct gpio_mcux_config *config = dev->config->config_info;
+	const struct gpio_mcux_config *config = dev->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 
 	gpio_base->PDOR = (gpio_base->PDOR & ~mask) | (mask & value);
@@ -123,7 +123,7 @@ static int gpio_mcux_port_set_masked_raw(struct device *dev, u32_t mask,
 
 static int gpio_mcux_port_set_bits_raw(struct device *dev, u32_t mask)
 {
-	const struct gpio_mcux_config *config = dev->config->config_info;
+	const struct gpio_mcux_config *config = dev->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 
 	gpio_base->PSOR = mask;
@@ -133,7 +133,7 @@ static int gpio_mcux_port_set_bits_raw(struct device *dev, u32_t mask)
 
 static int gpio_mcux_port_clear_bits_raw(struct device *dev, u32_t mask)
 {
-	const struct gpio_mcux_config *config = dev->config->config_info;
+	const struct gpio_mcux_config *config = dev->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 
 	gpio_base->PCOR = mask;
@@ -143,7 +143,7 @@ static int gpio_mcux_port_clear_bits_raw(struct device *dev, u32_t mask)
 
 static int gpio_mcux_port_toggle_bits(struct device *dev, u32_t mask)
 {
-	const struct gpio_mcux_config *config = dev->config->config_info;
+	const struct gpio_mcux_config *config = dev->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 
 	gpio_base->PTOR = mask;
@@ -188,7 +188,7 @@ static int gpio_mcux_pin_interrupt_configure(struct device *dev,
 					     gpio_pin_t pin, enum gpio_int_mode mode,
 					     enum gpio_int_trig trig)
 {
-	const struct gpio_mcux_config *config = dev->config->config_info;
+	const struct gpio_mcux_config *config = dev->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 	PORT_Type *port_base = config->port_base;
 	struct gpio_mcux_data *data = dev->driver_data;
@@ -250,7 +250,7 @@ static int gpio_mcux_disable_callback(struct device *dev,
 static void gpio_mcux_port_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct gpio_mcux_config *config = dev->config->config_info;
+	const struct gpio_mcux_config *config = dev->config_info;
 	struct gpio_mcux_data *data = dev->driver_data;
 	u32_t enabled_int, int_status;
 

--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -33,7 +33,7 @@ struct mcux_igpio_data {
 static int mcux_igpio_configure(struct device *dev,
 				gpio_pin_t pin, gpio_flags_t flags)
 {
-	const struct mcux_igpio_config *config = dev->config->config_info;
+	const struct mcux_igpio_config *config = dev->config_info;
 	GPIO_Type *base = config->base;
 
 	if (((flags & GPIO_INPUT) != 0) && ((flags & GPIO_OUTPUT) != 0)) {
@@ -63,7 +63,7 @@ static int mcux_igpio_configure(struct device *dev,
 
 static int mcux_igpio_port_get_raw(struct device *dev, u32_t *value)
 {
-	const struct mcux_igpio_config *config = dev->config->config_info;
+	const struct mcux_igpio_config *config = dev->config_info;
 	GPIO_Type *base = config->base;
 
 	*value = base->DR;
@@ -74,7 +74,7 @@ static int mcux_igpio_port_get_raw(struct device *dev, u32_t *value)
 static int mcux_igpio_port_set_masked_raw(struct device *dev, u32_t mask,
 		u32_t value)
 {
-	const struct mcux_igpio_config *config = dev->config->config_info;
+	const struct mcux_igpio_config *config = dev->config_info;
 	GPIO_Type *base = config->base;
 
 	base->DR = (base->DR & ~mask) | (mask & value);
@@ -84,7 +84,7 @@ static int mcux_igpio_port_set_masked_raw(struct device *dev, u32_t mask,
 
 static int mcux_igpio_port_set_bits_raw(struct device *dev, u32_t mask)
 {
-	const struct mcux_igpio_config *config = dev->config->config_info;
+	const struct mcux_igpio_config *config = dev->config_info;
 	GPIO_Type *base = config->base;
 
 	base->DR_SET = mask;
@@ -94,7 +94,7 @@ static int mcux_igpio_port_set_bits_raw(struct device *dev, u32_t mask)
 
 static int mcux_igpio_port_clear_bits_raw(struct device *dev, u32_t mask)
 {
-	const struct mcux_igpio_config *config = dev->config->config_info;
+	const struct mcux_igpio_config *config = dev->config_info;
 	GPIO_Type *base = config->base;
 
 	base->DR_CLEAR = mask;
@@ -104,7 +104,7 @@ static int mcux_igpio_port_clear_bits_raw(struct device *dev, u32_t mask)
 
 static int mcux_igpio_port_toggle_bits(struct device *dev, u32_t mask)
 {
-	const struct mcux_igpio_config *config = dev->config->config_info;
+	const struct mcux_igpio_config *config = dev->config_info;
 	GPIO_Type *base = config->base;
 
 	base->DR_TOGGLE = mask;
@@ -116,7 +116,7 @@ static int mcux_igpio_pin_interrupt_configure(struct device *dev,
 		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
-	const struct mcux_igpio_config *config = dev->config->config_info;
+	const struct mcux_igpio_config *config = dev->config_info;
 	struct mcux_igpio_data *data = dev->driver_data;
 	GPIO_Type *base = config->base;
 	unsigned int key;
@@ -199,7 +199,7 @@ static int mcux_igpio_disable_callback(struct device *dev,
 static void mcux_igpio_port_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct mcux_igpio_config *config = dev->config->config_info;
+	const struct mcux_igpio_config *config = dev->config_info;
 	struct mcux_igpio_data *data = dev->driver_data;
 	GPIO_Type *base = config->base;
 	u32_t enabled_int, int_flags;

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -61,7 +61,7 @@ struct gpio_mcux_lpc_data {
 static int gpio_mcux_lpc_configure(struct device *dev, gpio_pin_t pin,
 				   gpio_flags_t flags)
 {
-	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
+	const struct gpio_mcux_lpc_config *config = dev->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 	u32_t port = config->port_no;
 
@@ -102,7 +102,7 @@ static int gpio_mcux_lpc_configure(struct device *dev, gpio_pin_t pin,
 
 static int gpio_mcux_lpc_port_get_raw(struct device *dev, u32_t *value)
 {
-	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
+	const struct gpio_mcux_lpc_config *config = dev->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 
 	*value = gpio_base->PIN[config->port_no];
@@ -113,7 +113,7 @@ static int gpio_mcux_lpc_port_get_raw(struct device *dev, u32_t *value)
 static int gpio_mcux_lpc_port_set_masked_raw(struct device *dev, u32_t mask,
 					     u32_t value)
 {
-	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
+	const struct gpio_mcux_lpc_config *config = dev->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 	u32_t port = config->port_no;
 
@@ -128,7 +128,7 @@ static int gpio_mcux_lpc_port_set_masked_raw(struct device *dev, u32_t mask,
 
 static int gpio_mcux_lpc_port_set_bits_raw(struct device *dev, u32_t mask)
 {
-	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
+	const struct gpio_mcux_lpc_config *config = dev->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 
 	gpio_base->SET[config->port_no] = mask;
@@ -138,7 +138,7 @@ static int gpio_mcux_lpc_port_set_bits_raw(struct device *dev, u32_t mask)
 
 static int gpio_mcux_lpc_port_clear_bits_raw(struct device *dev, u32_t mask)
 {
-	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
+	const struct gpio_mcux_lpc_config *config = dev->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 
 	gpio_base->CLR[config->port_no] = mask;
@@ -148,7 +148,7 @@ static int gpio_mcux_lpc_port_clear_bits_raw(struct device *dev, u32_t mask)
 
 static int gpio_mcux_lpc_port_toggle_bits(struct device *dev, u32_t mask)
 {
-	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
+	const struct gpio_mcux_lpc_config *config = dev->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 
 	gpio_base->NOT[config->port_no] = mask;
@@ -159,7 +159,7 @@ static int gpio_mcux_lpc_port_toggle_bits(struct device *dev, u32_t mask)
 static void gpio_mcux_lpc_port_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
+	const struct gpio_mcux_lpc_config *config = dev->config_info;
 	struct gpio_mcux_lpc_data *data = dev->driver_data;
 	u32_t enabled_int;
 	u32_t int_flags;
@@ -232,7 +232,7 @@ static int gpio_mcux_lpc_pin_interrupt_configure(struct device *dev,
 		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
-	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
+	const struct gpio_mcux_lpc_config *config = dev->config_info;
 	struct gpio_mcux_lpc_data *data = dev->driver_data;
 	pint_pin_enable_t interruptMode = kPINT_PinIntEnableNone;
 	GPIO_Type *gpio_base = config->gpio_base;
@@ -322,7 +322,7 @@ static int gpio_mcux_lpc_disable_cb(struct device *port,
 
 static int gpio_mcux_lpc_init(struct device *dev)
 {
-	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
+	const struct gpio_mcux_lpc_config *config = dev->config_info;
 	struct gpio_mcux_lpc_data *data = dev->driver_data;
 	int i;
 

--- a/drivers/gpio/gpio_mmio32.c
+++ b/drivers/gpio/gpio_mmio32.c
@@ -166,7 +166,7 @@ static const struct gpio_driver_api gpio_mmio32_api = {
 int gpio_mmio32_init(struct device *dev)
 {
 	struct gpio_mmio32_context *context = dev->driver_data;
-	const struct gpio_mmio32_config *config = dev->config->config_info;
+	const struct gpio_mmio32_config *config = dev->config_info;
 
 	context->config = config;
 	dev->driver_api = &gpio_mmio32_api;

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -44,7 +44,7 @@ static inline struct gpio_nrfx_data *get_port_data(struct device *port)
 
 static inline const struct gpio_nrfx_cfg *get_port_cfg(struct device *port)
 {
-	return port->config->config_info;
+	return port->config_info;
 }
 
 static int gpiote_channel_alloc(u32_t abs_pin, nrf_gpiote_polarity_t polarity)

--- a/drivers/gpio/gpio_pca95xx.c
+++ b/drivers/gpio/gpio_pca95xx.c
@@ -100,7 +100,7 @@ struct gpio_pca95xx_drv_data {
 static int read_port_regs(struct device *dev, u8_t reg, u16_t *buf)
 {
 	const struct gpio_pca95xx_config * const config =
-		dev->config->config_info;
+		dev->config_info;
 	struct gpio_pca95xx_drv_data * const drv_data =
 		(struct gpio_pca95xx_drv_data * const)dev->driver_data;
 	struct device * const i2c_master = drv_data->i2c_master;
@@ -140,7 +140,7 @@ static int write_port_regs(struct device *dev, u8_t reg,
 			   u16_t *cache, u16_t value)
 {
 	const struct gpio_pca95xx_config * const config =
-		dev->config->config_info;
+		dev->config_info;
 	struct gpio_pca95xx_drv_data * const drv_data =
 		(struct gpio_pca95xx_drv_data * const)dev->driver_data;
 	struct device * const i2c_master = drv_data->i2c_master;
@@ -253,7 +253,7 @@ static int setup_pin_dir(struct device *dev, u32_t pin, int flags)
 static int setup_pin_pullupdown(struct device *dev, u32_t pin, int flags)
 {
 	const struct gpio_pca95xx_config * const config =
-		dev->config->config_info;
+		dev->config_info;
 	struct gpio_pca95xx_drv_data * const drv_data =
 		(struct gpio_pca95xx_drv_data * const)dev->driver_data;
 	u16_t reg_pud;
@@ -317,7 +317,7 @@ static int gpio_pca95xx_config(struct device *dev,
 
 #if (CONFIG_GPIO_LOG_LEVEL >= LOG_LEVEL_DEBUG)
 	const struct gpio_pca95xx_config * const config =
-		dev->config->config_info;
+		dev->config_info;
 	u16_t i2c_addr = config->i2c_slave_addr;
 #endif
 
@@ -471,7 +471,7 @@ static const struct gpio_driver_api gpio_pca95xx_drv_api_funcs = {
 static int gpio_pca95xx_init(struct device *dev)
 {
 	const struct gpio_pca95xx_config * const config =
-		dev->config->config_info;
+		dev->config_info;
 	struct gpio_pca95xx_drv_data * const drv_data =
 		(struct gpio_pca95xx_drv_data * const)dev->driver_data;
 	struct device *i2c_master;

--- a/drivers/gpio/gpio_rv32m1.c
+++ b/drivers/gpio/gpio_rv32m1.c
@@ -74,7 +74,7 @@ static u32_t get_port_pcr_irqc_value_from_flags(struct device *dev,
 static int gpio_rv32m1_configure(struct device *dev,
 				 gpio_pin_t pin, gpio_flags_t flags)
 {
-	const struct gpio_rv32m1_config *config = dev->config->config_info;
+	const struct gpio_rv32m1_config *config = dev->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 	PORT_Type *port_base = config->port_base;
 	struct gpio_rv32m1_data *data = dev->driver_data;
@@ -158,7 +158,7 @@ static int gpio_rv32m1_configure(struct device *dev,
 }
 static int gpio_rv32m1_port_get_raw(struct device *dev, u32_t *value)
 {
-	const struct gpio_rv32m1_config *config = dev->config->config_info;
+	const struct gpio_rv32m1_config *config = dev->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 
 	*value = gpio_base->PDIR;
@@ -169,7 +169,7 @@ static int gpio_rv32m1_port_get_raw(struct device *dev, u32_t *value)
 static int gpio_rv32m1_port_set_masked_raw(struct device *dev, u32_t mask,
 		u32_t value)
 {
-	const struct gpio_rv32m1_config *config = dev->config->config_info;
+	const struct gpio_rv32m1_config *config = dev->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 
 	gpio_base->PDOR = (gpio_base->PDOR & ~mask) | (mask & value);
@@ -179,7 +179,7 @@ static int gpio_rv32m1_port_set_masked_raw(struct device *dev, u32_t mask,
 
 static int gpio_rv32m1_port_set_bits_raw(struct device *dev, u32_t mask)
 {
-	const struct gpio_rv32m1_config *config = dev->config->config_info;
+	const struct gpio_rv32m1_config *config = dev->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 
 	gpio_base->PSOR = mask;
@@ -189,7 +189,7 @@ static int gpio_rv32m1_port_set_bits_raw(struct device *dev, u32_t mask)
 
 static int gpio_rv32m1_port_clear_bits_raw(struct device *dev, u32_t mask)
 {
-	const struct gpio_rv32m1_config *config = dev->config->config_info;
+	const struct gpio_rv32m1_config *config = dev->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 
 	gpio_base->PCOR = mask;
@@ -199,7 +199,7 @@ static int gpio_rv32m1_port_clear_bits_raw(struct device *dev, u32_t mask)
 
 static int gpio_rv32m1_port_toggle_bits(struct device *dev, u32_t mask)
 {
-	const struct gpio_rv32m1_config *config = dev->config->config_info;
+	const struct gpio_rv32m1_config *config = dev->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 
 	gpio_base->PTOR = mask;
@@ -211,7 +211,7 @@ static int gpio_rv32m1_pin_interrupt_configure(struct device *dev,
 		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
-	const struct gpio_rv32m1_config *config = dev->config->config_info;
+	const struct gpio_rv32m1_config *config = dev->config_info;
 	PORT_Type *port_base = config->port_base;
 	struct gpio_rv32m1_data *data = dev->driver_data;
 
@@ -269,7 +269,7 @@ static int gpio_rv32m1_disable_callback(struct device *dev,
 static void gpio_rv32m1_port_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct gpio_rv32m1_config *config = dev->config->config_info;
+	const struct gpio_rv32m1_config *config = dev->config_info;
 	struct gpio_rv32m1_data *data = dev->driver_data;
 	u32_t enabled_int, int_status;
 
@@ -285,7 +285,7 @@ static void gpio_rv32m1_port_isr(void *arg)
 
 static int gpio_rv32m1_init(struct device *dev)
 {
-	const struct gpio_rv32m1_config *config = dev->config->config_info;
+	const struct gpio_rv32m1_config *config = dev->config_info;
 	struct device *clk;
 	int ret;
 

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -32,7 +32,7 @@ struct gpio_sam_runtime {
 };
 
 #define DEV_CFG(dev) \
-	((const struct gpio_sam_config * const)(dev)->config->config_info)
+	((const struct gpio_sam_config * const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct gpio_sam_runtime * const)(dev)->driver_data)
 

--- a/drivers/gpio/gpio_sam0.c
+++ b/drivers/gpio/gpio_sam0.c
@@ -38,7 +38,7 @@ struct gpio_sam0_data {
 };
 
 #define DEV_CFG(dev) \
-	((const struct gpio_sam0_config *const)(dev)->config->config_info)
+	((const struct gpio_sam0_config *const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct gpio_sam0_data *const)(dev)->driver_data)
 

--- a/drivers/gpio/gpio_sifive.c
+++ b/drivers/gpio/gpio_sifive.c
@@ -60,7 +60,7 @@ struct gpio_sifive_data {
 
 /* Helper Macros for GPIO */
 #define DEV_GPIO_CFG(dev)						\
-	((const struct gpio_sifive_config * const)(dev)->config->config_info)
+	((const struct gpio_sifive_config * const)(dev)->config_info)
 #define DEV_GPIO(dev)							\
 	((volatile struct gpio_sifive_t *)(DEV_GPIO_CFG(dev))->gpio_base_addr)
 #define DEV_GPIO_DATA(dev)				\

--- a/drivers/gpio/gpio_stellaris.c
+++ b/drivers/gpio/gpio_stellaris.c
@@ -31,7 +31,7 @@ struct gpio_stellaris_runtime {
 
 #define DEV_CFG(dev)                                     \
 	((const struct gpio_stellaris_config *const)     \
-	(dev)->config->config_info)
+	(dev)->config_info)
 
 #define DEV_DATA(dev)					 \
 	((struct gpio_stellaris_runtime *const)          \

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -311,7 +311,7 @@ static int gpio_stm32_enable_int(int port, int pin)
 
 static int gpio_stm32_port_get_raw(struct device *dev, u32_t *value)
 {
-	const struct gpio_stm32_config *cfg = dev->config->config_info;
+	const struct gpio_stm32_config *cfg = dev->config_info;
 	GPIO_TypeDef *gpio = (GPIO_TypeDef *)cfg->base;
 
 	*value = LL_GPIO_ReadInputPort(gpio);
@@ -323,7 +323,7 @@ static int gpio_stm32_port_set_masked_raw(struct device *dev,
 					  gpio_port_pins_t mask,
 					  gpio_port_value_t value)
 {
-	const struct gpio_stm32_config *cfg = dev->config->config_info;
+	const struct gpio_stm32_config *cfg = dev->config_info;
 	GPIO_TypeDef *gpio = (GPIO_TypeDef *)cfg->base;
 	u32_t port_value;
 
@@ -336,7 +336,7 @@ static int gpio_stm32_port_set_masked_raw(struct device *dev,
 static int gpio_stm32_port_set_bits_raw(struct device *dev,
 					gpio_port_pins_t pins)
 {
-	const struct gpio_stm32_config *cfg = dev->config->config_info;
+	const struct gpio_stm32_config *cfg = dev->config_info;
 	GPIO_TypeDef *gpio = (GPIO_TypeDef *)cfg->base;
 
 	/*
@@ -351,7 +351,7 @@ static int gpio_stm32_port_set_bits_raw(struct device *dev,
 static int gpio_stm32_port_clear_bits_raw(struct device *dev,
 					  gpio_port_pins_t pins)
 {
-	const struct gpio_stm32_config *cfg = dev->config->config_info;
+	const struct gpio_stm32_config *cfg = dev->config_info;
 	GPIO_TypeDef *gpio = (GPIO_TypeDef *)cfg->base;
 
 #ifdef CONFIG_SOC_SERIES_STM32F1X
@@ -371,7 +371,7 @@ static int gpio_stm32_port_clear_bits_raw(struct device *dev,
 static int gpio_stm32_port_toggle_bits(struct device *dev,
 				       gpio_port_pins_t pins)
 {
-	const struct gpio_stm32_config *cfg = dev->config->config_info;
+	const struct gpio_stm32_config *cfg = dev->config_info;
 	GPIO_TypeDef *gpio = (GPIO_TypeDef *)cfg->base;
 
 	/*
@@ -389,7 +389,7 @@ static int gpio_stm32_port_toggle_bits(struct device *dev,
 static int gpio_stm32_config(struct device *dev,
 			     gpio_pin_t pin, gpio_flags_t flags)
 {
-	const struct gpio_stm32_config *cfg = dev->config->config_info;
+	const struct gpio_stm32_config *cfg = dev->config_info;
 	int err = 0;
 	int pincfg;
 
@@ -428,7 +428,7 @@ static int gpio_stm32_pin_interrupt_configure(struct device *dev,
 		gpio_pin_t pin, enum gpio_int_mode mode,
 		enum gpio_int_trig trig)
 {
-	const struct gpio_stm32_config *cfg = dev->config->config_info;
+	const struct gpio_stm32_config *cfg = dev->config_info;
 	struct gpio_stm32_data *data = dev->driver_data;
 	int edge = 0;
 	int err = 0;
@@ -543,7 +543,7 @@ static const struct gpio_driver_api gpio_stm32_driver = {
  */
 static int gpio_stm32_init(struct device *device)
 {
-	const struct gpio_stm32_config *cfg = device->config->config_info;
+	const struct gpio_stm32_config *cfg = device->config_info;
 
 	/* enable clock for subsystem */
 	struct device *clk =

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -179,7 +179,7 @@ static inline int i2c_reg_write_byte_be(struct device *dev, u16_t dev_addr,
 static int sx1509b_handle_interrupt(void *arg)
 {
 	struct device *dev = (struct device *) arg;
-	const struct sx1509b_config *cfg = dev->config->config_info;
+	const struct sx1509b_config *cfg = dev->config_info;
 	struct sx1509b_drv_data *drv_data = dev->driver_data;
 	int ret = 0;
 	u16_t int_source;
@@ -235,7 +235,7 @@ static int sx1509b_config(struct device *dev,
 			  gpio_pin_t pin,
 			  gpio_flags_t flags)
 {
-	const struct sx1509b_config *cfg = dev->config->config_info;
+	const struct sx1509b_config *cfg = dev->config_info;
 	struct sx1509b_drv_data *drv_data = dev->driver_data;
 	struct sx1509b_pin_state *pins = &drv_data->pin_state;
 	struct {
@@ -373,7 +373,7 @@ out:
 static int port_get(struct device *dev,
 		    gpio_port_value_t *value)
 {
-	const struct sx1509b_config *cfg = dev->config->config_info;
+	const struct sx1509b_config *cfg = dev->config_info;
 	struct sx1509b_drv_data *drv_data = dev->driver_data;
 	u16_t pin_data;
 	int rc = 0;
@@ -412,7 +412,7 @@ static int port_write(struct device *dev,
 		return -EWOULDBLOCK;
 	}
 
-	const struct sx1509b_config *cfg = dev->config->config_info;
+	const struct sx1509b_config *cfg = dev->config_info;
 	struct sx1509b_drv_data *drv_data = dev->driver_data;
 	u16_t *outp = &drv_data->pin_state.data;
 
@@ -476,7 +476,7 @@ static int pin_interrupt_configure(struct device *dev,
 		return -ENOTSUP;
 	}
 
-	const struct sx1509b_config *cfg = dev->config->config_info;
+	const struct sx1509b_config *cfg = dev->config_info;
 	struct sx1509b_drv_data *drv_data = dev->driver_data;
 	struct sx1509b_irq_state *irq = &drv_data->irq_state;
 	struct {
@@ -537,13 +537,13 @@ static int pin_interrupt_configure(struct device *dev,
  */
 static int sx1509b_init(struct device *dev)
 {
-	const struct sx1509b_config *cfg = dev->config->config_info;
+	const struct sx1509b_config *cfg = dev->config_info;
 	struct sx1509b_drv_data *drv_data = dev->driver_data;
 	int rc;
 
 	drv_data->i2c_master = device_get_binding(cfg->i2c_master_dev_name);
 	if (!drv_data->i2c_master) {
-		LOG_ERR("%s: no bus %s", dev->config->name,
+		LOG_ERR("%s: no bus %s", dev->name,
 			cfg->i2c_master_dev_name);
 		rc = -EINVAL;
 		goto out;
@@ -577,7 +577,7 @@ static int sx1509b_init(struct device *dev)
 	rc = i2c_reg_write_byte(drv_data->i2c_master, cfg->i2c_slave_addr,
 				SX1509B_REG_RESET, SX1509B_REG_RESET_MAGIC0);
 	if (rc != 0) {
-		LOG_ERR("%s: reset m0 failed: %d\n", dev->config->name, rc);
+		LOG_ERR("%s: reset m0 failed: %d\n", dev->name, rc);
 		goto out;
 	}
 	rc = i2c_reg_write_byte(drv_data->i2c_master, cfg->i2c_slave_addr,
@@ -621,9 +621,9 @@ static int sx1509b_init(struct device *dev)
 
 out:
 	if (rc != 0) {
-		LOG_ERR("%s init failed: %d", dev->config->name, rc);
+		LOG_ERR("%s init failed: %d", dev->name, rc);
 	} else {
-		LOG_INF("%s init ok", dev->config->name);
+		LOG_INF("%s init ok", dev->name);
 	}
 	k_sem_give(&drv_data->lock);
 	return rc;

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -52,7 +52,7 @@ static inline struct i2c_cc13xx_cc26xx_data *get_dev_data(struct device *dev)
 static inline const struct i2c_cc13xx_cc26xx_config *
 get_dev_config(struct device *dev)
 {
-	return dev->config->config_info;
+	return dev->config_info;
 }
 
 static int i2c_cc13xx_cc26xx_transmit(struct device *dev, const u8_t *buf,

--- a/drivers/i2c/i2c_cc32xx.c
+++ b/drivers/i2c/i2c_cc32xx.c
@@ -39,7 +39,7 @@ LOG_MODULE_REGISTER(i2c_cc32xx);
 #define IS_I2C_MSG_WRITE(flags) ((flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE)
 
 #define DEV_CFG(dev) \
-	((const struct i2c_cc32xx_config *const)(dev)->config->config_info)
+	((const struct i2c_cc32xx_config *const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct i2c_cc32xx_data *const)(dev)->driver_data)
 #define DEV_BASE(dev) \

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -600,7 +600,7 @@ static const struct i2c_driver_api funcs = {
 
 static int i2c_dw_initialize(struct device *dev)
 {
-	const struct i2c_dw_rom_config * const rom = dev->config->config_info;
+	const struct i2c_dw_rom_config * const rom = dev->config_info;
 	struct i2c_dw_dev_config * const dw = dev->driver_data;
 	volatile struct i2c_dw_registers *regs;
 

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -172,7 +172,7 @@ static int i2c_esp32_configure_speed(const struct i2c_esp32_config *config,
 
 static int i2c_esp32_configure(struct device *dev, u32_t dev_config)
 {
-	const struct i2c_esp32_config *config = dev->config->config_info;
+	const struct i2c_esp32_config *config = dev->config_info;
 	struct i2c_esp32_data *data = dev->driver_data;
 	unsigned int key = irq_lock();
 	u32_t v = 0U;
@@ -280,7 +280,7 @@ static int i2c_esp32_spin_yield(int *counter)
 
 static int i2c_esp32_transmit(struct device *dev)
 {
-	const struct i2c_esp32_config *config = dev->config->config_info;
+	const struct i2c_esp32_config *config = dev->config_info;
 	struct i2c_esp32_data *data = dev->driver_data;
 	u32_t status;
 
@@ -304,7 +304,7 @@ static int i2c_esp32_transmit(struct device *dev)
 static int i2c_esp32_wait(struct device *dev,
 			  volatile struct i2c_esp32_cmd *wait_cmd)
 {
-	const struct i2c_esp32_config *config = dev->config->config_info;
+	const struct i2c_esp32_config *config = dev->config_info;
 	int counter = 0;
 	int ret;
 
@@ -347,7 +347,7 @@ i2c_esp32_write_addr(struct device *dev,
 		     struct i2c_msg *msg,
 		     u16_t addr)
 {
-	const struct i2c_esp32_config *config = dev->config->config_info;
+	const struct i2c_esp32_config *config = dev->config_info;
 	struct i2c_esp32_data *data = dev->driver_data;
 	u32_t addr_len = 1U;
 
@@ -376,7 +376,7 @@ i2c_esp32_write_addr(struct device *dev,
 static int i2c_esp32_read_msg(struct device *dev, u16_t addr,
 			      struct i2c_msg msg)
 {
-	const struct i2c_esp32_config *config = dev->config->config_info;
+	const struct i2c_esp32_config *config = dev->config_info;
 	volatile struct i2c_esp32_cmd *cmd =
 		(void *)I2C_COMD0_REG(config->index);
 	u32_t i;
@@ -458,7 +458,7 @@ static int i2c_esp32_read_msg(struct device *dev, u16_t addr,
 static int i2c_esp32_write_msg(struct device *dev, u16_t addr,
 			       struct i2c_msg msg)
 {
-	const struct i2c_esp32_config *config = dev->config->config_info;
+	const struct i2c_esp32_config *config = dev->config_info;
 	volatile struct i2c_esp32_cmd *cmd =
 		(void *)I2C_COMD0_REG(config->index);
 
@@ -543,7 +543,7 @@ static void i2c_esp32_isr(void *arg)
 				   I2C_TRANS_COMPLETE_INT_ST |
 				   I2C_ARBITRATION_LOST_INT_ST;
 	struct device *device = arg;
-	const struct i2c_esp32_config *config = device->config->config_info;
+	const struct i2c_esp32_config *config = device->config_info;
 
 	if (sys_read32(I2C_INT_STATUS_REG(config->index)) & fifo_give_mask) {
 		struct i2c_esp32_data *data = device->driver_data;
@@ -664,7 +664,7 @@ DEVICE_AND_API_INIT(i2c_esp32_1, DT_INST_LABEL(1), &i2c_esp32_init,
 
 static int i2c_esp32_init(struct device *dev)
 {
-	const struct i2c_esp32_config *config = dev->config->config_info;
+	const struct i2c_esp32_config *config = dev->config_info;
 	struct i2c_esp32_data *data = dev->driver_data;
 	u32_t bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);
 	unsigned int key = irq_lock();

--- a/drivers/i2c/i2c_gecko.c
+++ b/drivers/i2c/i2c_gecko.c
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(i2c_gecko);
 #include "i2c-priv.h"
 
 #define DEV_CFG(dev) \
-	((struct i2c_gecko_config * const)(dev)->config->config_info)
+	((struct i2c_gecko_config * const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct i2c_gecko_data * const)(dev)->driver_data)
 #define DEV_BASE(dev) \

--- a/drivers/i2c/i2c_gpio.c
+++ b/drivers/i2c/i2c_gpio.c
@@ -110,7 +110,7 @@ static struct i2c_driver_api api = {
 static int i2c_gpio_init(struct device *dev)
 {
 	struct i2c_gpio_context *context = dev->driver_data;
-	const struct i2c_gpio_config *config = dev->config->config_info;
+	const struct i2c_gpio_config *config = dev->config_info;
 	u32_t bitrate_cfg;
 	int err;
 

--- a/drivers/i2c/i2c_imx.c
+++ b/drivers/i2c/i2c_imx.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(i2c_imx);
 #include "i2c-priv.h"
 
 #define DEV_CFG(dev) \
-	((const struct i2c_imx_config * const)(dev)->config->config_info)
+	((const struct i2c_imx_config * const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct i2c_imx_data * const)(dev)->driver_data)
 #define DEV_BASE(dev) \

--- a/drivers/i2c/i2c_litex.c
+++ b/drivers/i2c/i2c_litex.c
@@ -26,7 +26,7 @@ struct i2c_litex_cfg {
 };
 
 #define GET_I2C_CFG(dev)						     \
-	((const struct i2c_litex_cfg *) dev->config->config_info)
+	((const struct i2c_litex_cfg *) dev->config_info)
 
 #define GET_I2C_BITBANG(dev)						     \
 	((struct i2c_bitbang *) dev->driver_data)

--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -71,6 +71,6 @@ int i2c_stm32_slave_unregister(struct device *dev,
 
 #define DEV_DATA(dev) ((struct i2c_stm32_data * const)(dev)->driver_data)
 #define DEV_CFG(dev)	\
-((const struct i2c_stm32_config * const)(dev)->config->config_info)
+((const struct i2c_stm32_config * const)(dev)->config_info)
 
 #endif	/* ZEPHYR_DRIVERS_I2C_I2C_LL_STM32_H_ */

--- a/drivers/i2c/i2c_mchp_xec.c
+++ b/drivers/i2c/i2c_mchp_xec.c
@@ -149,7 +149,7 @@ static bool check_lines(u32_t ba)
 static int i2c_xec_configure(struct device *dev, u32_t dev_config_raw)
 {
 	const struct i2c_xec_config *config =
-		(const struct i2c_xec_config *const) (dev->config->config_info);
+		(const struct i2c_xec_config *const) (dev->config_info);
 	u32_t ba = config->base_addr;
 	u8_t port_sel = config->port_sel;
 	u32_t speed_id;
@@ -229,7 +229,7 @@ static int i2c_xec_poll_write(struct device *dev, struct i2c_msg msg,
 			      u16_t addr)
 {
 	const struct i2c_xec_config *config =
-		(const struct i2c_xec_config *const) (dev->config->config_info);
+		(const struct i2c_xec_config *const) (dev->config_info);
 	struct i2c_xec_data *data =
 		(struct i2c_xec_data *const) (dev->driver_data);
 	u32_t ba = config->base_addr;
@@ -292,7 +292,7 @@ static int i2c_xec_poll_read(struct device *dev, struct i2c_msg msg,
 			     u16_t addr)
 {
 	const struct i2c_xec_config *config =
-		(const struct i2c_xec_config *const) (dev->config->config_info);
+		(const struct i2c_xec_config *const) (dev->config_info);
 	struct i2c_xec_data *data =
 		(struct i2c_xec_data *const) (dev->driver_data);
 	u32_t ba = config->base_addr;

--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(i2c_mcux);
 #include "i2c-priv.h"
 
 #define DEV_CFG(dev) \
-	((const struct i2c_mcux_config * const)(dev)->config->config_info)
+	((const struct i2c_mcux_config * const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct i2c_mcux_data * const)(dev)->driver_data)
 #define DEV_BASE(dev) \

--- a/drivers/i2c/i2c_mcux_flexcomm.c
+++ b/drivers/i2c/i2c_mcux_flexcomm.c
@@ -31,7 +31,7 @@ struct mcux_flexcomm_data {
 
 static int mcux_flexcomm_configure(struct device *dev, u32_t dev_config_raw)
 {
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 	I2C_Type *base = config->base;
 	u32_t clock_freq;
 	u32_t baudrate;
@@ -96,7 +96,7 @@ static u32_t mcux_flexcomm_convert_flags(int msg_flags)
 static int mcux_flexcomm_transfer(struct device *dev, struct i2c_msg *msgs,
 		u8_t num_msgs, u16_t addr)
 {
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 	struct mcux_flexcomm_data *data = dev->driver_data;
 	I2C_Type *base = config->base;
 	i2c_master_transfer_t transfer;
@@ -157,7 +157,7 @@ static int mcux_flexcomm_transfer(struct device *dev, struct i2c_msg *msgs,
 static void mcux_flexcomm_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 	struct mcux_flexcomm_data *data = dev->driver_data;
 	I2C_Type *base = config->base;
 
@@ -166,7 +166,7 @@ static void mcux_flexcomm_isr(void *arg)
 
 static int mcux_flexcomm_init(struct device *dev)
 {
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 	struct mcux_flexcomm_data *data = dev->driver_data;
 	I2C_Type *base = config->base;
 	u32_t clock_freq, bitrate_cfg;

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -34,7 +34,7 @@ struct mcux_lpi2c_data {
 
 static int mcux_lpi2c_configure(struct device *dev, u32_t dev_config_raw)
 {
-	const struct mcux_lpi2c_config *config = dev->config->config_info;
+	const struct mcux_lpi2c_config *config = dev->config_info;
 	LPI2C_Type *base = config->base;
 	struct device *clock_dev;
 	u32_t clock_freq;
@@ -108,7 +108,7 @@ static u32_t mcux_lpi2c_convert_flags(int msg_flags)
 static int mcux_lpi2c_transfer(struct device *dev, struct i2c_msg *msgs,
 		u8_t num_msgs, u16_t addr)
 {
-	const struct mcux_lpi2c_config *config = dev->config->config_info;
+	const struct mcux_lpi2c_config *config = dev->config_info;
 	struct mcux_lpi2c_data *data = dev->driver_data;
 	LPI2C_Type *base = config->base;
 	lpi2c_master_transfer_t transfer;
@@ -169,7 +169,7 @@ static int mcux_lpi2c_transfer(struct device *dev, struct i2c_msg *msgs,
 static void mcux_lpi2c_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct mcux_lpi2c_config *config = dev->config->config_info;
+	const struct mcux_lpi2c_config *config = dev->config_info;
 	struct mcux_lpi2c_data *data = dev->driver_data;
 	LPI2C_Type *base = config->base;
 
@@ -178,7 +178,7 @@ static void mcux_lpi2c_isr(void *arg)
 
 static int mcux_lpi2c_init(struct device *dev)
 {
-	const struct mcux_lpi2c_config *config = dev->config->config_info;
+	const struct mcux_lpi2c_config *config = dev->config_info;
 	struct mcux_lpi2c_data *data = dev->driver_data;
 	LPI2C_Type *base = config->base;
 	struct device *clock_dev;

--- a/drivers/i2c/i2c_nios2.c
+++ b/drivers/i2c/i2c_nios2.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(i2c_nios2);
 #define NIOS2_I2C_TIMEOUT_USEC		1000
 
 #define DEV_CFG(dev) \
-	((struct i2c_nios2_config *)(dev)->config->config_info)
+	((struct i2c_nios2_config *)(dev)->config_info)
 
 struct i2c_nios2_config {
 	ALT_AVALON_I2C_DEV_t	i2c_dev;

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -35,7 +35,7 @@ static inline struct i2c_nrfx_twi_data *get_dev_data(struct device *dev)
 static inline
 const struct i2c_nrfx_twi_config *get_dev_config(struct device *dev)
 {
-	return dev->config->config_info;
+	return dev->config_info;
 }
 
 static int i2c_nrfx_twi_transfer(struct device *dev, struct i2c_msg *msgs,
@@ -177,7 +177,7 @@ static int init_twi(struct device *dev)
 					  event_handler, dev);
 	if (result != NRFX_SUCCESS) {
 		LOG_ERR("Failed to initialize device: %s",
-			    dev->config->name);
+			    dev->name);
 		return -EBUSY;
 	}
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -35,7 +35,7 @@ static inline struct i2c_nrfx_twim_data *get_dev_data(struct device *dev)
 static inline
 const struct i2c_nrfx_twim_config *get_dev_config(struct device *dev)
 {
-	return dev->config->config_info;
+	return dev->config_info;
 }
 
 static int i2c_nrfx_twim_transfer(struct device *dev, struct i2c_msg *msgs,
@@ -149,7 +149,7 @@ static int init_twim(struct device *dev)
 					   dev);
 	if (result != NRFX_SUCCESS) {
 		LOG_ERR("Failed to initialize device: %s",
-			dev->config->name);
+			dev->name);
 		return -EBUSY;
 	}
 

--- a/drivers/i2c/i2c_rv32m1_lpi2c.c
+++ b/drivers/i2c/i2c_rv32m1_lpi2c.c
@@ -37,7 +37,7 @@ struct rv32m1_lpi2c_data {
 
 static int rv32m1_lpi2c_configure(struct device *dev, u32_t dev_config)
 {
-	const struct rv32m1_lpi2c_config *config = dev->config->config_info;
+	const struct rv32m1_lpi2c_config *config = dev->config_info;
 	struct device *clk;
 	u32_t baudrate;
 	u32_t clk_freq;
@@ -129,7 +129,7 @@ static u32_t rv32m1_lpi2c_convert_flags(int msg_flags)
 static int rv32m1_lpi2c_transfer(struct device *dev, struct i2c_msg *msgs,
 				 u8_t num_msgs, u16_t addr)
 {
-	const struct rv32m1_lpi2c_config *config = dev->config->config_info;
+	const struct rv32m1_lpi2c_config *config = dev->config_info;
 	struct rv32m1_lpi2c_data *data = dev->driver_data;
 	lpi2c_master_transfer_t transfer;
 	status_t status;
@@ -202,7 +202,7 @@ out:
 static void rv32m1_lpi2c_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct rv32m1_lpi2c_config *config = dev->config->config_info;
+	const struct rv32m1_lpi2c_config *config = dev->config_info;
 	struct rv32m1_lpi2c_data *data = dev->driver_data;
 
 	LPI2C_MasterTransferHandleIRQ(config->base, &data->handle);
@@ -210,7 +210,7 @@ static void rv32m1_lpi2c_isr(void *arg)
 
 static int rv32m1_lpi2c_init(struct device *dev)
 {
-	const struct rv32m1_lpi2c_config *config = dev->config->config_info;
+	const struct rv32m1_lpi2c_config *config = dev->config_info;
 	struct rv32m1_lpi2c_data *data = dev->driver_data;
 	lpi2c_master_config_t master_config;
 	struct device *clk;

--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -58,9 +58,9 @@ struct i2c_sam0_dev_data {
 #endif
 };
 
-#define DEV_NAME(dev) ((dev)->config->name)
+#define DEV_NAME(dev) ((dev)->name)
 #define DEV_CFG(dev) \
-	((const struct i2c_sam0_dev_config *const)(dev)->config->config_info)
+	((const struct i2c_sam0_dev_config *const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct i2c_sam0_dev_data *const)(dev)->driver_data)
 

--- a/drivers/i2c/i2c_sam_twi.c
+++ b/drivers/i2c/i2c_sam_twi.c
@@ -66,9 +66,9 @@ struct i2c_sam_twi_dev_data {
 	struct twi_msg msg;
 };
 
-#define DEV_NAME(dev) ((dev)->config->name)
+#define DEV_NAME(dev) ((dev)->name)
 #define DEV_CFG(dev) \
-	((const struct i2c_sam_twi_dev_cfg *const)(dev)->config->config_info)
+	((const struct i2c_sam_twi_dev_cfg *const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct i2c_sam_twi_dev_data *const)(dev)->driver_data)
 

--- a/drivers/i2c/i2c_sam_twihs.c
+++ b/drivers/i2c/i2c_sam_twihs.c
@@ -66,9 +66,9 @@ struct i2c_sam_twihs_dev_data {
 	struct twihs_msg msg;
 };
 
-#define DEV_NAME(dev) ((dev)->config->name)
+#define DEV_NAME(dev) ((dev)->name)
 #define DEV_CFG(dev) \
-	((const struct i2c_sam_twihs_dev_cfg *const)(dev)->config->config_info)
+	((const struct i2c_sam_twihs_dev_cfg *const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct i2c_sam_twihs_dev_data *const)(dev)->driver_data)
 

--- a/drivers/i2c/i2c_sbcon.c
+++ b/drivers/i2c/i2c_sbcon.c
@@ -101,7 +101,7 @@ static struct i2c_driver_api api = {
 static int i2c_sbcon_init(struct device *dev)
 {
 	struct i2c_sbcon_context *context = dev->driver_data;
-	const struct i2c_sbcon_config *config = dev->config->config_info;
+	const struct i2c_sbcon_config *config = dev->config_info;
 
 	i2c_bitbang_init(&context->bitbang, &io_fns, config->sbcon);
 

--- a/drivers/i2c/i2c_shell.c
+++ b/drivers/i2c/i2c_shell.c
@@ -15,8 +15,8 @@ LOG_MODULE_REGISTER(i2c_shell, CONFIG_LOG_DEFAULT_LEVEL);
 
 #define I2C_DEVICE_PREFIX "I2C_"
 
-extern struct device __device_init_start[];
-extern struct device __device_init_end[];
+extern struct device __device_start[];
+extern struct device __device_end[];
 
 static int cmd_i2c_scan(const struct shell *shell,
 			size_t argc, char **argv)
@@ -80,7 +80,7 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 	entry->help  = NULL;
 	entry->subcmd = &dsub_device_name;
 
-	for (dev = __device_init_start; dev != __device_init_end; dev++) {
+	for (dev = __device_start; dev != __device_end; dev++) {
 		if ((dev->driver_api != NULL) &&
 		strstr(dev->config->name, I2C_DEVICE_PREFIX) != NULL &&
 		strcmp(dev->config->name, "") && (dev->config->name != NULL)) {

--- a/drivers/i2c/i2c_shell.c
+++ b/drivers/i2c/i2c_shell.c
@@ -82,10 +82,10 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 
 	for (dev = __device_start; dev != __device_end; dev++) {
 		if ((dev->driver_api != NULL) &&
-		strstr(dev->config->name, I2C_DEVICE_PREFIX) != NULL &&
-		strcmp(dev->config->name, "") && (dev->config->name != NULL)) {
+		strstr(dev->name, I2C_DEVICE_PREFIX) != NULL &&
+		strcmp(dev->name, "") && (dev->name != NULL)) {
 			if (idx == device_idx) {
-				entry->syntax = dev->config->name;
+				entry->syntax = dev->name;
 				break;
 			}
 			device_idx++;

--- a/drivers/i2c/i2c_sifive.c
+++ b/drivers/i2c/i2c_sifive.c
@@ -69,7 +69,7 @@ struct i2c_sifive_cfg {
 
 static inline bool i2c_sifive_busy(struct device *dev)
 {
-	const struct i2c_sifive_cfg *config = dev->config->config_info;
+	const struct i2c_sifive_cfg *config = dev->config_info;
 
 	return IS_SET(config, REG_STATUS, SF_STATUS_TIP);
 }
@@ -78,7 +78,7 @@ static int i2c_sifive_send_addr(struct device *dev,
 				u16_t addr,
 				u16_t rw_flag)
 {
-	const struct i2c_sifive_cfg *config = dev->config->config_info;
+	const struct i2c_sifive_cfg *config = dev->config_info;
 	u8_t command = 0U;
 
 	/* Wait for a previous transfer to complete */
@@ -109,7 +109,7 @@ static int i2c_sifive_write_msg(struct device *dev,
 				struct i2c_msg *msg,
 				u16_t addr)
 {
-	const struct i2c_sifive_cfg *config = dev->config->config_info;
+	const struct i2c_sifive_cfg *config = dev->config_info;
 	int rc = 0;
 	u8_t command = 0U;
 
@@ -158,7 +158,7 @@ static int i2c_sifive_read_msg(struct device *dev,
 			       struct i2c_msg *msg,
 			       u16_t addr)
 {
-	const struct i2c_sifive_cfg *config = dev->config->config_info;
+	const struct i2c_sifive_cfg *config = dev->config_info;
 	u8_t command = 0U;
 
 	i2c_sifive_send_addr(dev, addr, SF_TX_READ);
@@ -208,12 +208,7 @@ static int i2c_sifive_configure(struct device *dev, u32_t dev_config)
 		LOG_ERR("Device handle is NULL");
 		return -EINVAL;
 	}
-	if (dev->config == NULL) {
-		LOG_ERR("Device handle config is NULL");
-		return -EINVAL;
-	}
-
-	config = dev->config->config_info;
+	config = dev->config_info;
 	if (config == NULL) {
 		LOG_ERR("Device config is NULL");
 		return -EINVAL;
@@ -279,11 +274,7 @@ static int i2c_sifive_transfer(struct device *dev,
 		LOG_ERR("Device handle is NULL");
 		return -EINVAL;
 	}
-	if (dev->config == NULL) {
-		LOG_ERR("Device handle config is NULL");
-		return -EINVAL;
-	}
-	if (dev->config->config_info == NULL) {
+	if (dev->config_info == NULL) {
 		LOG_ERR("Device config is NULL");
 		return -EINVAL;
 	}
@@ -309,7 +300,7 @@ static int i2c_sifive_transfer(struct device *dev,
 
 static int i2c_sifive_init(struct device *dev)
 {
-	const struct i2c_sifive_cfg *config = dev->config->config_info;
+	const struct i2c_sifive_cfg *config = dev->config_info;
 	u32_t dev_config = 0U;
 	int rc = 0;
 

--- a/drivers/i2c/slave/eeprom_slave.c
+++ b/drivers/i2c/slave/eeprom_slave.c
@@ -36,7 +36,7 @@ struct i2c_eeprom_slave_config {
 /* convenience defines */
 #define DEV_CFG(dev)							\
 	((const struct i2c_eeprom_slave_config * const)			\
-		(dev)->config->config_info)
+		(dev)->config_info)
 #define DEV_DATA(dev)							\
 	((struct i2c_eeprom_slave_data * const)(dev)->driver_data)
 

--- a/drivers/i2s/i2s_cavs.c
+++ b/drivers/i2s/i2s_cavs.c
@@ -156,9 +156,9 @@ struct i2s_cavs_dev_data {
 	struct stream rx;
 };
 
-#define DEV_NAME(dev) ((dev)->config->name)
+#define DEV_NAME(dev) ((dev)->name)
 #define DEV_CFG(dev) \
-	((const struct i2s_cavs_config *const)(dev)->config->config_info)
+	((const struct i2s_cavs_config *const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct i2s_cavs_dev_data *const)(dev)->driver_data)
 

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -681,7 +681,7 @@ static int i2s_stm32_initialize(struct device *dev)
 		return -ENODEV;
 	}
 
-	LOG_INF("%s inited", dev->config->name);
+	LOG_INF("%s inited", dev->name);
 
 	return 0;
 }

--- a/drivers/i2s/i2s_ll_stm32.h
+++ b/drivers/i2s/i2s_ll_stm32.h
@@ -50,7 +50,7 @@
 #endif /* CONFIG_I2S_STM32_USE_PLLI2S_ENABLE */
 
 #define DEV_CFG(dev) \
-	(const struct i2s_stm32_cfg * const)((dev)->config->config_info)
+	(const struct i2s_stm32_cfg * const)((dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct i2s_stm32_data *const)(dev)->driver_data)
 

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -95,9 +95,9 @@ struct i2s_sam_dev_data {
 	struct stream tx;
 };
 
-#define DEV_NAME(dev) ((dev)->config->name)
+#define DEV_NAME(dev) ((dev)->name)
 #define DEV_CFG(dev) \
-	((const struct i2s_sam_dev_cfg *const)(dev)->config->config_info)
+	((const struct i2s_sam_dev_cfg *const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct i2s_sam_dev_data *const)(dev)->driver_data)
 

--- a/drivers/ieee802154/ieee802154_dw1000.c
+++ b/drivers/ieee802154/ieee802154_dw1000.c
@@ -954,7 +954,7 @@ static int dwt_configure(struct device *dev, enum ieee802154_config_type type,
 static int dwt_hw_reset(struct device *dev)
 {
 	struct dwt_context *ctx = dev->driver_data;
-	const struct dwt_hi_cfg *hi_cfg = dev->config->config_info;
+	const struct dwt_hi_cfg *hi_cfg = dev->config_info;
 
 	if (gpio_pin_configure(ctx->rst_gpio, hi_cfg->rst_pin,
 			       GPIO_OUTPUT_ACTIVE | hi_cfg->rst_flags)) {
@@ -1488,7 +1488,7 @@ static int dwt_configure_rf_phy(struct dwt_context *ctx)
 static int dw1000_init(struct device *dev)
 {
 	struct dwt_context *ctx = dev->driver_data;
-	const struct dwt_hi_cfg *hi_cfg = dev->config->config_info;
+	const struct dwt_hi_cfg *hi_cfg = dev->config_info;
 
 	LOG_INF("Initialize DW1000 Transceiver");
 	k_sem_init(&ctx->phy_sem, 0, 1);

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -58,7 +58,7 @@ static struct nrf5_802154_data nrf5_data;
 	((struct nrf5_802154_data * const)(dev)->driver_data)
 
 #define NRF5_802154_CFG(dev) \
-	((struct nrf5_802154_config * const)(dev)->config->config_info)
+	((struct nrf5_802154_config * const)(dev)->config_info)
 
 static void nrf5_get_eui64(u8_t *mac)
 {

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -307,7 +307,7 @@ static void rf2xx_thread_main(void *arg)
 
 static inline u8_t *get_mac(struct device *dev)
 {
-	const struct rf2xx_config *conf = dev->config->config_info;
+	const struct rf2xx_config *conf = dev->config_info;
 	struct rf2xx_context *ctx = dev->driver_data;
 	u32_t *ptr = (u32_t *)(ctx->mac_addr);
 
@@ -534,7 +534,7 @@ static int rf2xx_tx(struct device *dev,
 
 static int rf2xx_start(struct device *dev)
 {
-	const struct rf2xx_config *conf = dev->config->config_info;
+	const struct rf2xx_config *conf = dev->config_info;
 	struct rf2xx_context *ctx = dev->driver_data;
 
 	rf2xx_trx_set_state(dev, RF2XX_TRX_PHY_STATE_CMD_TRX_OFF);
@@ -548,7 +548,7 @@ static int rf2xx_start(struct device *dev)
 
 static int rf2xx_stop(struct device *dev)
 {
-	const struct rf2xx_config *conf = dev->config->config_info;
+	const struct rf2xx_config *conf = dev->config_info;
 	struct rf2xx_context *ctx = dev->driver_data;
 
 	gpio_pin_interrupt_configure(ctx->irq_gpio, conf->irq.pin,
@@ -571,7 +571,7 @@ int rf2xx_configure(struct device *dev, enum ieee802154_config_type type,
 
 static int power_on_and_setup(struct device *dev)
 {
-	const struct rf2xx_config *conf = dev->config->config_info;
+	const struct rf2xx_config *conf = dev->config_info;
 	struct rf2xx_context *ctx = dev->driver_data;
 	u8_t config;
 
@@ -641,7 +641,7 @@ static int power_on_and_setup(struct device *dev)
 
 static inline int configure_gpios(struct device *dev)
 {
-	const struct rf2xx_config *conf = dev->config->config_info;
+	const struct rf2xx_config *conf = dev->config_info;
 	struct rf2xx_context *ctx = dev->driver_data;
 
 	/* Chip IRQ line */
@@ -702,7 +702,7 @@ static inline int configure_gpios(struct device *dev)
 static inline int configure_spi(struct device *dev)
 {
 	struct rf2xx_context *ctx = dev->driver_data;
-	const struct rf2xx_config *conf = dev->config->config_info;
+	const struct rf2xx_config *conf = dev->config_info;
 
 	/* Get SPI Driver Instance*/
 	ctx->spi = device_get_binding(conf->spi.devname);
@@ -744,7 +744,7 @@ static inline int configure_spi(struct device *dev)
 static int rf2xx_init(struct device *dev)
 {
 	struct rf2xx_context *ctx = dev->driver_data;
-	const struct rf2xx_config *conf = dev->config->config_info;
+	const struct rf2xx_config *conf = dev->config_info;
 	char thread_name[20];
 
 	LOG_DBG("\nInitialize RF2XX Transceiver\n");

--- a/drivers/ieee802154/ieee802154_rf2xx_iface.c
+++ b/drivers/ieee802154/ieee802154_rf2xx_iface.c
@@ -25,7 +25,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 void rf2xx_iface_phy_rst(struct device *dev)
 {
-	const struct rf2xx_config *conf = dev->config->config_info;
+	const struct rf2xx_config *conf = dev->config_info;
 	const struct rf2xx_context *ctx = dev->driver_data;
 
 	/* Ensure control lines have correct levels. */
@@ -41,7 +41,7 @@ void rf2xx_iface_phy_rst(struct device *dev)
 }
 void rf2xx_iface_phy_tx_start(struct device *dev)
 {
-	const struct rf2xx_config *conf = dev->config->config_info;
+	const struct rf2xx_config *conf = dev->config_info;
 	const struct rf2xx_context *ctx = dev->driver_data;
 
 	/* Start TX transmission at rise edge */

--- a/drivers/interrupt_controller/intc_cavs.c
+++ b/drivers/interrupt_controller/intc_cavs.c
@@ -53,7 +53,7 @@ static void cavs_ictl_isr(void *arg)
 	struct device *port = (struct device *)arg;
 	struct cavs_ictl_runtime *context = port->driver_data;
 
-	const struct cavs_ictl_config *config = port->config->config_info;
+	const struct cavs_ictl_config *config = port->config_info;
 
 	volatile struct cavs_registers * const regs =
 					get_base_address(context);

--- a/drivers/interrupt_controller/intc_dw.c
+++ b/drivers/interrupt_controller/intc_dw.c
@@ -35,7 +35,7 @@ static ALWAYS_INLINE void dw_ictl_dispatch_child_isrs(u32_t intr_status,
 
 static int dw_ictl_initialize(struct device *dev)
 {
-	const struct dw_ictl_config *config = dev->config->config_info;
+	const struct dw_ictl_config *config = dev->config_info;
 	volatile struct dw_ictl_registers * const regs =
 			(struct dw_ictl_registers *)config->base_addr;
 
@@ -49,7 +49,7 @@ static int dw_ictl_initialize(struct device *dev)
 static void dw_ictl_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct dw_ictl_config *config = dev->config->config_info;
+	const struct dw_ictl_config *config = dev->config_info;
 	volatile struct dw_ictl_registers * const regs =
 			(struct dw_ictl_registers *)config->base_addr;
 
@@ -64,7 +64,7 @@ static void dw_ictl_isr(void *arg)
 
 static inline void dw_ictl_intr_enable(struct device *dev, unsigned int irq)
 {
-	const struct dw_ictl_config *config = dev->config->config_info;
+	const struct dw_ictl_config *config = dev->config_info;
 	volatile struct dw_ictl_registers * const regs =
 		(struct dw_ictl_registers *)config->base_addr;
 
@@ -77,7 +77,7 @@ static inline void dw_ictl_intr_enable(struct device *dev, unsigned int irq)
 
 static inline void dw_ictl_intr_disable(struct device *dev, unsigned int irq)
 {
-	const struct dw_ictl_config *config = dev->config->config_info;
+	const struct dw_ictl_config *config = dev->config_info;
 	volatile struct dw_ictl_registers * const regs =
 		(struct dw_ictl_registers *)config->base_addr;
 
@@ -90,7 +90,7 @@ static inline void dw_ictl_intr_disable(struct device *dev, unsigned int irq)
 
 static inline unsigned int dw_ictl_intr_get_state(struct device *dev)
 {
-	const struct dw_ictl_config *config = dev->config->config_info;
+	const struct dw_ictl_config *config = dev->config_info;
 	volatile struct dw_ictl_registers * const regs =
 		(struct dw_ictl_registers *)config->base_addr;
 
@@ -108,7 +108,7 @@ static inline unsigned int dw_ictl_intr_get_state(struct device *dev)
 
 static int dw_ictl_intr_get_line_state(struct device *dev, unsigned int irq)
 {
-	const struct dw_ictl_config *config = dev->config->config_info;
+	const struct dw_ictl_config *config = dev->config_info;
 	volatile struct dw_ictl_registers * const regs =
 		(struct dw_ictl_registers *)config->base_addr;
 

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -57,7 +57,7 @@
 
 #include <toolchain.h>
 #include <linker/sections.h>
-#include <init.h>
+#include <device.h>
 #include <string.h>
 
 #include <drivers/interrupt_controller/ioapic.h> /* public API declarations */

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -100,7 +100,7 @@ static void IoApicRedUpdateLo(unsigned int irq, u32_t value,
  *
  * @return N/A
  */
-int _ioapic_init(struct device *unused)
+int ioapic_init(struct device *unused)
 {
 	ARG_UNUSED(unused);
 #ifdef CONFIG_IOAPIC_MASK_RTE
@@ -439,8 +439,8 @@ static void IoApicRedUpdateLo(unsigned int irq,
 
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-SYS_DEVICE_DEFINE("ioapic", _ioapic_init, ioapic_device_ctrl, PRE_KERNEL_1,
+SYS_DEVICE_DEFINE("ioapic", ioapic_init, ioapic_device_ctrl, PRE_KERNEL_1,
 		  CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #else
-SYS_INIT(_ioapic_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(ioapic_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #endif

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -18,7 +18,7 @@
 #include <toolchain.h>
 #include <linker/sections.h>
 #include <drivers/interrupt_controller/loapic.h> /* public API declarations */
-#include <init.h>
+#include <device.h>
 #include <drivers/interrupt_controller/sysapic.h>
 
 /* Local APIC Version Register Bits */

--- a/drivers/interrupt_controller/intc_rv32m1_intmux.c
+++ b/drivers/interrupt_controller/intc_rv32m1_intmux.c
@@ -46,7 +46,7 @@ struct rv32m1_intmux_config {
 };
 
 #define DEV_CFG(dev) \
-	((struct rv32m1_intmux_config *)(dev->config->config_info))
+	((struct rv32m1_intmux_config *)(dev->config_info))
 
 #define DEV_REGS(dev) (DEV_CFG(dev)->regs)
 

--- a/drivers/interrupt_controller/intc_shared_irq.c
+++ b/drivers/interrupt_controller/intc_shared_irq.c
@@ -28,7 +28,7 @@ static int isr_register(struct device *dev, isr_t isr_func,
 				 struct device *isr_dev)
 {
 	struct shared_irq_runtime *clients = dev->driver_data;
-	const struct shared_irq_config *config = dev->config->config_info;
+	const struct shared_irq_config *config = dev->config_info;
 	u32_t i;
 
 	for (i = 0U; i < config->client_count; i++) {
@@ -49,7 +49,7 @@ static int isr_register(struct device *dev, isr_t isr_func,
 static inline int enable(struct device *dev, struct device *isr_dev)
 {
 	struct shared_irq_runtime *clients = dev->driver_data;
-	const struct shared_irq_config *config = dev->config->config_info;
+	const struct shared_irq_config *config = dev->config_info;
 	u32_t i;
 
 	for (i = 0U; i < config->client_count; i++) {
@@ -81,7 +81,7 @@ static int last_enabled_isr(struct shared_irq_runtime *clients, int count)
 static inline int disable(struct device *dev, struct device *isr_dev)
 {
 	struct shared_irq_runtime *clients = dev->driver_data;
-	const struct shared_irq_config *config = dev->config->config_info;
+	const struct shared_irq_config *config = dev->config_info;
 	u32_t i;
 
 	for (i = 0U; i < config->client_count; i++) {
@@ -99,7 +99,7 @@ static inline int disable(struct device *dev, struct device *isr_dev)
 void shared_irq_isr(struct device *dev)
 {
 	struct shared_irq_runtime *clients = dev->driver_data;
-	const struct shared_irq_config *config = dev->config->config_info;
+	const struct shared_irq_config *config = dev->config_info;
 	u32_t i;
 
 	for (i = 0U; i < config->client_count; i++) {
@@ -118,7 +118,7 @@ static const struct shared_irq_driver_api api_funcs = {
 
 int shared_irq_initialize(struct device *dev)
 {
-	const struct shared_irq_config *config = dev->config->config_info;
+	const struct shared_irq_config *config = dev->config_info;
 	config->config();
 	return 0;
 }

--- a/drivers/ipm/ipm_imx.c
+++ b/drivers/ipm/ipm_imx.c
@@ -34,7 +34,7 @@ struct imx_mu_data {
 static void imx_mu_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct imx_mu_config *config = dev->config->config_info;
+	const struct imx_mu_config *config = dev->config_info;
 	MU_Type *base = MU(config);
 	struct imx_mu_data *data = dev->driver_data;
 	u32_t data32[IMX_IPM_DATA_REGS];
@@ -90,7 +90,7 @@ static void imx_mu_isr(void *arg)
 static int imx_mu_ipm_send(struct device *dev, int wait, u32_t id,
 			   const void *data, int size)
 {
-	const struct imx_mu_config *config = dev->config->config_info;
+	const struct imx_mu_config *config = dev->config_info;
 	MU_Type *base = MU(config);
 	u32_t data32[IMX_IPM_DATA_REGS];
 	mu_status_t status;
@@ -150,7 +150,7 @@ static void imx_mu_ipm_register_callback(struct device *dev,
 
 static int imx_mu_ipm_set_enabled(struct device *dev, int enable)
 {
-	const struct imx_mu_config *config = dev->config->config_info;
+	const struct imx_mu_config *config = dev->config_info;
 	MU_Type *base = MU(config);
 
 #if CONFIG_IPM_IMX_MAX_DATA_SIZE_4
@@ -188,7 +188,7 @@ static int imx_mu_ipm_set_enabled(struct device *dev, int enable)
 
 static int imx_mu_init(struct device *dev)
 {
-	const struct imx_mu_config *config = dev->config->config_info;
+	const struct imx_mu_config *config = dev->config_info;
 
 	MU_Init(MU(config));
 	config->irq_config_func(dev);

--- a/drivers/ipm/ipm_mcux.c
+++ b/drivers/ipm/ipm_mcux.c
@@ -38,7 +38,7 @@ static void mcux_mailbox_isr(void *arg)
 {
 	struct device *dev = arg;
 	struct mcux_mailbox_data *data = dev->driver_data;
-	const struct mcux_mailbox_config *config = dev->config->config_info;
+	const struct mcux_mailbox_config *config = dev->config_info;
 	mailbox_cpu_id_t cpu_id;
 
 	cpu_id = MAILBOX_ID_THIS_CPU;
@@ -67,7 +67,7 @@ static void mcux_mailbox_isr(void *arg)
 static int mcux_mailbox_ipm_send(struct device *d, int wait, u32_t id,
 			const void *data, int size)
 {
-	const struct mcux_mailbox_config *config = d->config->config_info;
+	const struct mcux_mailbox_config *config = d->config_info;
 	MAILBOX_Type *base = config->base;
 	u32_t data32[MCUX_IPM_DATA_REGS]; /* Until we change API
 					   * to u32_t array
@@ -135,7 +135,7 @@ static int mcux_mailbox_ipm_set_enabled(struct device *d, int enable)
 
 static int mcux_mailbox_init(struct device *dev)
 {
-	const struct mcux_mailbox_config *config = dev->config->config_info;
+	const struct mcux_mailbox_config *config = dev->config_info;
 
 	MAILBOX_Init(config->base);
 	config->irq_config_func(dev);

--- a/drivers/ipm/ipm_mhu.c
+++ b/drivers/ipm/ipm_mhu.c
@@ -12,7 +12,7 @@
 #include "ipm_mhu.h"
 
 #define DEV_CFG(dev) \
-	((const struct ipm_mhu_device_config * const)(dev)->config->config_info)
+	((const struct ipm_mhu_device_config * const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct ipm_mhu_data *)(dev)->driver_data)
 #define IPM_MHU_REGS(dev) \

--- a/drivers/ipm/ipm_stm32_ipcc.c
+++ b/drivers/ipm/ipm_stm32_ipcc.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(ipm_stm32_ipcc, CONFIG_IPM_LOG_LEVEL);
 
 /* convenience defines */
 #define DEV_CFG(dev)							\
-	((const struct stm32_ipcc_mailbox_config * const)(dev)->config->config_info)
+	((const struct stm32_ipcc_mailbox_config * const)(dev)->config_info)
 #define DEV_DATA(dev)							\
 	((struct stm32_ipcc_mbx_data * const)(dev)->driver_data)
 #define MBX_STRUCT(dev)					\

--- a/drivers/kscan/kscan_ft5336.c
+++ b/drivers/kscan/kscan_ft5336.c
@@ -49,7 +49,7 @@ struct ft5336_data {
 
 static int ft5336_read(struct device *dev)
 {
-	const struct ft5336_config *config = dev->config->config_info;
+	const struct ft5336_config *config = dev->config_info;
 	struct ft5336_data *data = dev->driver_data;
 	u8_t buffer[FT5406_DATA_SIZE];
 	u8_t event;
@@ -102,7 +102,7 @@ static void ft5336_work_handler(struct k_work *work)
 static void ft5336_isr_handler(struct device *dev, struct gpio_callback *cb,
 		    u32_t pins)
 {
-	const struct ft5336_config *config = dev->config->config_info;
+	const struct ft5336_config *config = dev->config_info;
 	struct ft5336_data *drv_data =
 		CONTAINER_OF(cb, struct ft5336_data, int_gpio_cb);
 
@@ -155,7 +155,7 @@ static int ft5336_disable_callback(struct device *dev)
 
 static int ft5336_init(struct device *dev)
 {
-	const struct ft5336_config *config = dev->config->config_info;
+	const struct ft5336_config *config = dev->config_info;
 	struct ft5336_data *data = dev->driver_data;
 
 	data->i2c = device_get_binding(config->i2c_name);

--- a/drivers/kscan/kscan_sdl.c
+++ b/drivers/kscan/kscan_sdl.c
@@ -60,7 +60,7 @@ static int sdl_configure(struct device *dev, kscan_callback_t callback)
 		LOG_ERR("Callback is null");
 		return -EINVAL;
 	}
-	LOG_DBG("%s: set callback", dev->config->name);
+	LOG_DBG("%s: set callback", dev->name);
 
 	data->callback = callback;
 
@@ -71,7 +71,7 @@ static int sdl_enable_callback(struct device *dev)
 {
 	struct sdl_data *data = dev->driver_data;
 
-	LOG_DBG("%s: enable cb", dev->config->name);
+	LOG_DBG("%s: enable cb", dev->name);
 	data->enabled = true;
 	return 0;
 }
@@ -80,14 +80,14 @@ static int sdl_disable_callback(struct device *dev)
 {
 	struct sdl_data *data = dev->driver_data;
 
-	LOG_DBG("%s: disable cb", dev->config->name);
+	LOG_DBG("%s: disable cb", dev->name);
 	data->enabled = false;
 	return 0;
 }
 
 static int sdl_init(struct device *dev)
 {
-	LOG_INF("Init '%s' device", dev->config->name);
+	LOG_INF("Init '%s' device", dev->name);
 	SDL_AddEventWatch(sdl_filter, dev);
 
 	return 0;

--- a/drivers/led/ht16k33.c
+++ b/drivers/led/ht16k33.c
@@ -100,7 +100,7 @@ static int ht16k33_led_blink(struct device *dev, u32_t led,
 	/* The HT16K33 blinks all LEDs at the same frequency */
 	ARG_UNUSED(led);
 
-	const struct ht16k33_cfg *config = dev->config->config_info;
+	const struct ht16k33_cfg *config = dev->config_info;
 	struct ht16k33_data *data = dev->driver_data;
 	struct led_data *dev_data = &data->dev_data;
 	u32_t period;
@@ -135,7 +135,7 @@ static int ht16k33_led_set_brightness(struct device *dev, u32_t led,
 {
 	ARG_UNUSED(led);
 
-	const struct ht16k33_cfg *config = dev->config->config_info;
+	const struct ht16k33_cfg *config = dev->config_info;
 	struct ht16k33_data *data = dev->driver_data;
 	struct led_data *dev_data = &data->dev_data;
 	u8_t dim;
@@ -159,7 +159,7 @@ static int ht16k33_led_set_brightness(struct device *dev, u32_t led,
 
 static int ht16k33_led_set_state(struct device *dev, u32_t led, bool on)
 {
-	const struct ht16k33_cfg *config = dev->config->config_info;
+	const struct ht16k33_cfg *config = dev->config_info;
 	struct ht16k33_data *data = dev->driver_data;
 	u8_t cmd[2];
 	u8_t addr;
@@ -206,7 +206,7 @@ static int ht16k33_led_off(struct device *dev, u32_t led)
 #ifdef CONFIG_HT16K33_KEYSCAN
 u32_t ht16k33_get_pending_int(struct device *dev)
 {
-	const struct ht16k33_cfg *config = dev->config->config_info;
+	const struct ht16k33_cfg *config = dev->config_info;
 	struct ht16k33_data *data = dev->driver_data;
 	u8_t cmd;
 	u8_t flag;
@@ -225,7 +225,7 @@ u32_t ht16k33_get_pending_int(struct device *dev)
 
 static bool ht16k33_process_keyscan_data(struct device *dev)
 {
-	const struct ht16k33_cfg *config = dev->config->config_info;
+	const struct ht16k33_cfg *config = dev->config_info;
 	struct ht16k33_data *data = dev->driver_data;
 	u8_t keys[HT16K33_KEYSCAN_DATA_SIZE];
 	bool pressed = false;
@@ -321,7 +321,7 @@ int ht16k33_register_keyscan_device(struct device *parent,
 
 static int ht16k33_init(struct device *dev)
 {
-	const struct ht16k33_cfg *config = dev->config->config_info;
+	const struct ht16k33_cfg *config = dev->config_info;
 	struct ht16k33_data *data = dev->driver_data;
 	struct led_data *dev_data = &data->dev_data;
 	u8_t cmd[1 + HT16K33_DISP_DATA_SIZE]; /* 1 byte command + data */

--- a/drivers/led_strip/ws2812_gpio.c
+++ b/drivers/led_strip/ws2812_gpio.c
@@ -39,7 +39,7 @@ static struct ws2812_gpio_data *dev_data(struct device *dev)
 
 static const struct ws2812_gpio_cfg *dev_cfg(struct device *dev)
 {
-	return dev->config->config_info;
+	return dev->config_info;
 }
 
 /*
@@ -148,7 +148,7 @@ static int send_buf(struct device *dev, u8_t *buf, size_t len)
 static int ws2812_gpio_update_rgb(struct device *dev, struct led_rgb *pixels,
 				  size_t num_pixels)
 {
-	const struct ws2812_gpio_cfg *config = dev->config->config_info;
+	const struct ws2812_gpio_cfg *config = dev->config_info;
 	const bool has_white = config->has_white;
 	u8_t *ptr = (u8_t *)pixels;
 	size_t i;

--- a/drivers/led_strip/ws2812_spi.c
+++ b/drivers/led_strip/ws2812_spi.c
@@ -64,7 +64,7 @@ static struct ws2812_spi_data *dev_data(struct device *dev)
 
 static const struct ws2812_spi_cfg *dev_cfg(struct device *dev)
 {
-	return dev->config->config_info;
+	return dev->config_info;
 }
 
 /*

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -321,7 +321,7 @@ static void gsm_finalize_connection(struct gsm_modem *gsm)
 	if (IS_ENABLED(CONFIG_GSM_MUX) && gsm->mux_enabled) {
 		/* Re-use the original iface for AT channel */
 		ret = modem_iface_uart_init_dev(&gsm->context.iface,
-						gsm->at_dev->config->name);
+						gsm->at_dev->name);
 		if (ret < 0) {
 			LOG_DBG("iface %suart error %d", "AT ", ret);
 		} else {
@@ -337,7 +337,7 @@ static void gsm_finalize_connection(struct gsm_modem *gsm)
 					ret, "AT cmds failed");
 			} else {
 				LOG_INF("AT channel %d connected to %s",
-					DLCI_AT, gsm->at_dev->config->name);
+					DLCI_AT, gsm->at_dev->name);
 			}
 		}
 	}
@@ -395,7 +395,7 @@ static void mux_setup_next(struct gsm_modem *gsm)
 static void mux_attach_cb(struct device *mux, int dlci_address,
 			  bool connected, void *user_data)
 {
-	LOG_DBG("DLCI %d to %s %s", dlci_address, mux->config->name,
+	LOG_DBG("DLCI %d to %s %s", dlci_address, mux->name,
 		connected ? "connected" : "disconnected");
 
 	if (connected) {
@@ -413,7 +413,7 @@ static int mux_attach(struct device *mux, struct device *uart,
 				  user_data);
 	if (ret < 0) {
 		LOG_ERR("Cannot attach DLCI %d (%s) to %s (%d)", dlci_address,
-			mux->config->name, uart->config->name, ret);
+			mux->name, uart->name, ret);
 		return ret;
 	}
 
@@ -486,7 +486,7 @@ static void mux_setup(struct k_work *work)
 		 * to the modem.
 		 */
 		ret = modem_iface_uart_init_dev(&gsm->context.iface,
-						gsm->ppp_dev->config->name);
+						gsm->ppp_dev->name);
 		if (ret < 0) {
 			LOG_DBG("iface %suart error %d", "PPP ", ret);
 			gsm->mux_enabled = false;
@@ -494,7 +494,7 @@ static void mux_setup(struct k_work *work)
 		}
 
 		LOG_INF("PPP channel %d connected to %s",
-			DLCI_PPP, gsm->ppp_dev->config->name);
+			DLCI_PPP, gsm->ppp_dev->name);
 
 		gsm_finalize_connection(gsm);
 		break;

--- a/drivers/modem/modem_shell.c
+++ b/drivers/modem/modem_shell.c
@@ -33,14 +33,14 @@ struct modem_shell_user_data {
 #define ms_send(ctx_, buf_, size_) \
 			(ctx_->iface.write(&ctx_->iface, buf_, size_))
 #define ms_context_from_id	modem_context_from_id
-#define UART_DEV_NAME(ctx)	(ctx->iface.dev->config->name)
+#define UART_DEV_NAME(ctx)	(ctx->iface.dev->name)
 #elif defined(CONFIG_MODEM_RECEIVER)
 #include "modem_receiver.h"
 #define ms_context		mdm_receiver_context
 #define ms_max_context		CONFIG_MODEM_RECEIVER_MAX_CONTEXTS
 #define ms_send			mdm_receiver_send
 #define ms_context_from_id	mdm_receiver_context_from_id
-#define UART_DEV_NAME(ctx_)	(ctx_->uart_dev->config->name)
+#define UART_DEV_NAME(ctx_)	(ctx_->uart_dev->name)
 #else
 #error "MODEM_CONTEXT or MODEM_RECEIVER need to be enabled"
 #endif
@@ -159,7 +159,7 @@ static void uart_mux_cb(struct device *uart, struct device *dev,
 
 	shell_fprintf(shell, SHELL_NORMAL,
 		      "%s\t\t%s\t\t%d (%s)\n",
-		      uart->config->name, dev->config->name, dlci_address, ch);
+		      uart->name, dev->name, dlci_address, ch);
 }
 #endif
 

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -649,7 +649,7 @@ static void ppp_isr_cb_work(struct k_work *work)
 
 	/* This will print too much data, enable only if really needed */
 	if (0) {
-		LOG_HEXDUMP_DBG(data, len, ppp->dev->config->name);
+		LOG_HEXDUMP_DBG(data, len, ppp->dev->name);
 	}
 
 	tmp = len;
@@ -826,7 +826,7 @@ static int ppp_start(struct device *dev)
 			return -ENOENT;
 		}
 
-		dev_name = mux->config->name;
+		dev_name = mux->name;
 #elif IS_ENABLED(CONFIG_MODEM_GSM_PPP)
 		dev_name = CONFIG_MODEM_GSM_UART_NAME;
 #else

--- a/drivers/neural_net/intel_gna.c
+++ b/drivers/neural_net/intel_gna.c
@@ -24,9 +24,9 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(neural_net);
 
-#define DEV_NAME(dev) ((dev)->config->name)
+#define DEV_NAME(dev) ((dev)->name)
 #define DEV_CFG(dev) \
-	((struct intel_gna_config *const)(dev)->config->config_info)
+	((struct intel_gna_config *const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct intel_gna_data *const)(dev)->driver_data)
 

--- a/drivers/pinmux/pinmux_mchp_xec.c
+++ b/drivers/pinmux/pinmux_mchp_xec.c
@@ -25,7 +25,7 @@ struct pinmux_xec_config {
 
 static int pinmux_xec_set(struct device *dev, u32_t pin, u32_t func)
 {
-	const struct pinmux_xec_config *config = dev->config->config_info;
+	const struct pinmux_xec_config *config = dev->config_info;
 	__IO u32_t *current_pcr1;
 	u32_t pcr1 = 0;
 	u32_t mask = 0;
@@ -78,7 +78,7 @@ static int pinmux_xec_set(struct device *dev, u32_t pin, u32_t func)
 
 static int pinmux_xec_get(struct device *dev, u32_t pin, u32_t *func)
 {
-	const struct pinmux_xec_config *config = dev->config->config_info;
+	const struct pinmux_xec_config *config = dev->config_info;
 	__IO u32_t *current_pcr1;
 
 	/* Validate pin number in terms of current port */

--- a/drivers/pinmux/pinmux_mcux.c
+++ b/drivers/pinmux/pinmux_mcux.c
@@ -17,7 +17,7 @@ struct pinmux_mcux_config {
 
 static int pinmux_mcux_set(struct device *dev, u32_t pin, u32_t func)
 {
-	const struct pinmux_mcux_config *config = dev->config->config_info;
+	const struct pinmux_mcux_config *config = dev->config_info;
 	PORT_Type *base = config->base;
 
 	base->PCR[pin] = func;
@@ -27,7 +27,7 @@ static int pinmux_mcux_set(struct device *dev, u32_t pin, u32_t func)
 
 static int pinmux_mcux_get(struct device *dev, u32_t pin, u32_t *func)
 {
-	const struct pinmux_mcux_config *config = dev->config->config_info;
+	const struct pinmux_mcux_config *config = dev->config_info;
 	PORT_Type *base = config->base;
 
 	*func = base->PCR[pin];
@@ -47,7 +47,7 @@ static int pinmux_mcux_input(struct device *dev, u32_t pin, u8_t func)
 
 static int pinmux_mcux_init(struct device *dev)
 {
-	const struct pinmux_mcux_config *config = dev->config->config_info;
+	const struct pinmux_mcux_config *config = dev->config_info;
 
 	CLOCK_EnableClock(config->clock_ip_name);
 

--- a/drivers/pinmux/pinmux_mcux_lpc.c
+++ b/drivers/pinmux/pinmux_mcux_lpc.c
@@ -24,7 +24,7 @@ struct pinmux_mcux_lpc_config {
 
 static int pinmux_mcux_lpc_set(struct device *dev, u32_t pin, u32_t func)
 {
-	const struct pinmux_mcux_lpc_config *config = dev->config->config_info;
+	const struct pinmux_mcux_lpc_config *config = dev->config_info;
 	IOCON_Type *base = config->base;
 	u32_t port = config->port_no;
 
@@ -35,7 +35,7 @@ static int pinmux_mcux_lpc_set(struct device *dev, u32_t pin, u32_t func)
 
 static int pinmux_mcux_lpc_get(struct device *dev, u32_t pin, u32_t *func)
 {
-	const struct pinmux_mcux_lpc_config *config = dev->config->config_info;
+	const struct pinmux_mcux_lpc_config *config = dev->config_info;
 	IOCON_Type *base = config->base;
 	u32_t port = config->port_no;
 
@@ -56,7 +56,7 @@ static int pinmux_mcux_lpc_input(struct device *dev, u32_t pin, u8_t func)
 
 static int pinmux_mcux_lpc_init(struct device *dev)
 {
-	const struct pinmux_mcux_lpc_config *config = dev->config->config_info;
+	const struct pinmux_mcux_lpc_config *config = dev->config_info;
 
 	CLOCK_EnableClock(config->clock_ip_name);
 

--- a/drivers/pinmux/pinmux_rv32m1.c
+++ b/drivers/pinmux/pinmux_rv32m1.c
@@ -21,7 +21,7 @@ struct pinmux_rv32m1_config {
 
 static int pinmux_rv32m1_set(struct device *dev, u32_t pin, u32_t func)
 {
-	const struct pinmux_rv32m1_config *config = dev->config->config_info;
+	const struct pinmux_rv32m1_config *config = dev->config_info;
 	PORT_Type *base = config->base;
 
 	base->PCR[pin] = (base->PCR[pin] & ~PORT_PCR_MUX_MASK) | func;
@@ -31,7 +31,7 @@ static int pinmux_rv32m1_set(struct device *dev, u32_t pin, u32_t func)
 
 static int pinmux_rv32m1_get(struct device *dev, u32_t pin, u32_t *func)
 {
-	const struct pinmux_rv32m1_config *config = dev->config->config_info;
+	const struct pinmux_rv32m1_config *config = dev->config_info;
 	PORT_Type *base = config->base;
 
 	*func = base->PCR[pin] & ~PORT_PCR_MUX_MASK;
@@ -51,7 +51,7 @@ static int pinmux_rv32m1_input(struct device *dev, u32_t pin, u8_t func)
 
 static int pinmux_rv32m1_init(struct device *dev)
 {
-	const struct pinmux_rv32m1_config *config = dev->config->config_info;
+	const struct pinmux_rv32m1_config *config = dev->config_info;
 
 	CLOCK_EnableClock(config->clock_ip_name);
 

--- a/drivers/pinmux/pinmux_sam0.c
+++ b/drivers/pinmux/pinmux_sam0.c
@@ -13,7 +13,7 @@ struct pinmux_sam0_config {
 
 static int pinmux_sam0_set(struct device *dev, u32_t pin, u32_t func)
 {
-	const struct pinmux_sam0_config *cfg = dev->config->config_info;
+	const struct pinmux_sam0_config *cfg = dev->config_info;
 	bool odd_pin = pin & 1;
 	int idx = pin / 2U;
 
@@ -33,7 +33,7 @@ static int pinmux_sam0_set(struct device *dev, u32_t pin, u32_t func)
 
 static int pinmux_sam0_get(struct device *dev, u32_t pin, u32_t *func)
 {
-	const struct pinmux_sam0_config *cfg = dev->config->config_info;
+	const struct pinmux_sam0_config *cfg = dev->config_info;
 	bool odd_pin = pin & 1;
 	int idx = pin / 2U;
 

--- a/drivers/pinmux/pinmux_sifive.c
+++ b/drivers/pinmux/pinmux_sifive.c
@@ -24,7 +24,7 @@ struct pinmux_sifive_regs_t {
 
 #define DEV_CFG(dev)					\
 	((const struct pinmux_sifive_config * const)	\
-	 (dev)->config->config_info)
+	 (dev)->config_info)
 
 #define DEV_PINMUX(dev)						\
 	((struct pinmux_sifive_regs_t *)(DEV_CFG(dev))->base)

--- a/drivers/ps2/ps2_mchp_xec.c
+++ b/drivers/ps2/ps2_mchp_xec.c
@@ -32,7 +32,7 @@ struct ps2_xec_data {
 
 static int ps2_xec_configure(struct device *dev, ps2_callback_t callback_isr)
 {
-	const struct ps2_xec_config *config = dev->config->config_info;
+	const struct ps2_xec_config *config = dev->config_info;
 	struct ps2_xec_data *data = dev->driver_data;
 	PS2_Type *base = config->base;
 
@@ -69,7 +69,7 @@ static int ps2_xec_configure(struct device *dev, ps2_callback_t callback_isr)
 
 static int ps2_xec_write(struct device *dev, u8_t value)
 {
-	const struct ps2_xec_config *config = dev->config->config_info;
+	const struct ps2_xec_config *config = dev->config_info;
 	struct ps2_xec_data *data = dev->driver_data;
 	PS2_Type *base = config->base;
 	int i = 0;
@@ -118,7 +118,7 @@ static int ps2_xec_write(struct device *dev, u8_t value)
 
 static int ps2_xec_inhibit_interface(struct device *dev)
 {
-	const struct ps2_xec_config *config = dev->config->config_info;
+	const struct ps2_xec_config *config = dev->config_info;
 	struct ps2_xec_data *data = dev->driver_data;
 	PS2_Type *base = config->base;
 
@@ -137,7 +137,7 @@ static int ps2_xec_inhibit_interface(struct device *dev)
 
 static int ps2_xec_enable_interface(struct device *dev)
 {
-	const struct ps2_xec_config *config = dev->config->config_info;
+	const struct ps2_xec_config *config = dev->config_info;
 	struct ps2_xec_data *data = dev->driver_data;
 	PS2_Type *base = config->base;
 
@@ -151,7 +151,7 @@ static int ps2_xec_enable_interface(struct device *dev)
 static void ps2_xec_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct ps2_xec_config *config = dev->config->config_info;
+	const struct ps2_xec_config *config = dev->config_info;
 	struct ps2_xec_data *data = dev->driver_data;
 	PS2_Type *base = config->base;
 	u32_t status;

--- a/drivers/pwm/pwm_dw.c
+++ b/drivers/pwm/pwm_dw.c
@@ -73,7 +73,7 @@ struct pwm_dw_config {
 static inline int pwm_dw_timer_base_addr(struct device *dev, u32_t timer)
 {
 	const struct pwm_dw_config * const cfg =
-	    (struct pwm_dw_config *)dev->config->config_info;
+	    (struct pwm_dw_config *)dev->config_info;
 
 	return (cfg->addr + (timer * REG_OFFSET));
 }
@@ -89,7 +89,7 @@ static inline int pwm_dw_timer_base_addr(struct device *dev, u32_t timer)
 static inline int pwm_dw_timer_ldcnt2_addr(struct device *dev, u32_t timer)
 {
 	const struct pwm_dw_config * const cfg =
-	    (struct pwm_dw_config *)dev->config->config_info;
+	    (struct pwm_dw_config *)dev->config_info;
 
 	return (cfg->addr + REG_TMR_LOAD_CNT2 + (timer * REG_OFFSET_LOAD_CNT2));
 }
@@ -144,7 +144,7 @@ static int pwm_dw_pin_set_cycles(struct device *dev,
 				 u32_t pulse_cycles, pwm_flags_t flags)
 {
 	const struct pwm_dw_config * const cfg =
-	    (struct pwm_dw_config *)dev->config->config_info;
+	    (struct pwm_dw_config *)dev->config_info;
 	int i;
 	u32_t on, off;
 

--- a/drivers/pwm/pwm_imx.c
+++ b/drivers/pwm/pwm_imx.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(pwm_imx);
 				<<PWM_PWMCR_SWR_SHIFT))&PWM_PWMCR_SWR_MASK)
 
 #define DEV_CFG(dev) \
-	((const struct imx_pwm_config * const)(dev)->config->config_info)
+	((const struct imx_pwm_config * const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct imx_pwm_data * const)(dev)->driver_data)
 #define DEV_BASE(dev) \
@@ -128,7 +128,7 @@ static int imx_pwm_pin_set(struct device *dev, u32_t pwm,
 	if (data->period_cycles != period_cycles) {
 		LOG_WRN("Changing period cycles from %d to %d in %s",
 			    data->period_cycles, period_cycles,
-			    dev->config->name);
+			    dev->name);
 
 		data->period_cycles = period_cycles;
 		PWM_PWMPR_REG(base) = period_cycles;

--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -320,7 +320,7 @@ static int pwm_led_esp32_pin_set_cycles(struct device *dev,
 	int timer;
 	int ret;
 	const struct pwm_led_esp32_config * const config =
-		(struct pwm_led_esp32_config *) dev->config->config_info;
+		(struct pwm_led_esp32_config *) dev->config_info;
 
 	ARG_UNUSED(period_cycles);
 
@@ -373,7 +373,7 @@ static int pwm_led_esp32_get_cycles_per_sec(struct device *dev, u32_t pwm,
 	int timer;
 	int speed_mode;
 
-	config = (struct pwm_led_esp32_config *) dev->config->config_info;
+	config = (struct pwm_led_esp32_config *) dev->config_info;
 
 	channel = pwm_led_esp32_get_gpio_config(pwm, config->ch_cfg);
 	if (channel < 0) {

--- a/drivers/pwm/pwm_litex.c
+++ b/drivers/pwm/pwm_litex.c
@@ -26,7 +26,7 @@ struct pwm_litex_cfg {
 };
 
 #define GET_PWM_CFG(dev)				       \
-	((const struct pwm_litex_cfg *) dev->config->config_info)
+	((const struct pwm_litex_cfg *) dev->config_info)
 
 static void litex_set_reg(volatile u32_t *reg, u32_t reg_size, u32_t val)
 {

--- a/drivers/pwm/pwm_mchp_xec.c
+++ b/drivers/pwm/pwm_mchp_xec.c
@@ -49,11 +49,11 @@ struct pwm_xec_config {
 #define PWM_XEC_REG_BASE(_dev)				\
 	((PWM_Type *)			\
 	 ((const struct pwm_xec_config * const)		\
-	  _dev->config->config_info)->base_address)
+	  _dev->config_info)->base_address)
 
 #define PWM_XEC_CONFIG(_dev)				\
 	(((const struct pwm_xec_config * const)		\
-	  _dev->config->config_info))
+	  _dev->config_info))
 
 struct xec_params {
 	u32_t on;

--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -35,7 +35,7 @@ static int mcux_pwm_pin_set(struct device *dev, u32_t pwm,
 			    u32_t period_cycles, u32_t pulse_cycles,
 			    pwm_flags_t flags)
 {
-	const struct pwm_mcux_config *config = dev->config->config_info;
+	const struct pwm_mcux_config *config = dev->config_info;
 	struct pwm_mcux_data *data = dev->driver_data;
 	u8_t duty_cycle;
 
@@ -111,7 +111,7 @@ static int mcux_pwm_pin_set(struct device *dev, u32_t pwm,
 static int mcux_pwm_get_cycles_per_sec(struct device *dev, u32_t pwm,
 				       u64_t *cycles)
 {
-	const struct pwm_mcux_config *config = dev->config->config_info;
+	const struct pwm_mcux_config *config = dev->config_info;
 
 	*cycles = CLOCK_GetFreq(config->clock_source) >> config->prescale;
 
@@ -120,7 +120,7 @@ static int mcux_pwm_get_cycles_per_sec(struct device *dev, u32_t pwm,
 
 static int pwm_mcux_init(struct device *dev)
 {
-	const struct pwm_mcux_config *config = dev->config->config_info;
+	const struct pwm_mcux_config *config = dev->config_info;
 	struct pwm_mcux_data *data = dev->driver_data;
 	pwm_config_t pwm_config;
 	status_t status;

--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -39,7 +39,7 @@ static int mcux_ftm_pin_set(struct device *dev, u32_t pwm,
 			    u32_t period_cycles, u32_t pulse_cycles,
 			    pwm_flags_t flags)
 {
-	const struct mcux_ftm_config *config = dev->config->config_info;
+	const struct mcux_ftm_config *config = dev->config_info;
 	struct mcux_ftm_data *data = dev->driver_data;
 	status_t status;
 
@@ -71,7 +71,7 @@ static int mcux_ftm_pin_set(struct device *dev, u32_t pwm,
 			LOG_WRN("Changing period cycles from %d to %d"
 				" affects all %d channels in %s",
 				data->period_cycles, period_cycles,
-				config->channel_count, dev->config->name);
+				config->channel_count, dev->name);
 		}
 
 		data->period_cycles = period_cycles;
@@ -98,7 +98,7 @@ static int mcux_ftm_pin_set(struct device *dev, u32_t pwm,
 static int mcux_ftm_get_cycles_per_sec(struct device *dev, u32_t pwm,
 				       u64_t *cycles)
 {
-	const struct mcux_ftm_config *config = dev->config->config_info;
+	const struct mcux_ftm_config *config = dev->config_info;
 	struct mcux_ftm_data *data = dev->driver_data;
 
 	*cycles = data->clock_freq >> config->prescale;
@@ -108,7 +108,7 @@ static int mcux_ftm_get_cycles_per_sec(struct device *dev, u32_t pwm,
 
 static int mcux_ftm_init(struct device *dev)
 {
-	const struct mcux_ftm_config *config = dev->config->config_info;
+	const struct mcux_ftm_config *config = dev->config_info;
 	struct mcux_ftm_data *data = dev->driver_data;
 	ftm_chnl_pwm_config_param_t *channel = data->channel;
 	struct device *clock_dev;

--- a/drivers/pwm/pwm_mcux_tpm.c
+++ b/drivers/pwm/pwm_mcux_tpm.c
@@ -43,7 +43,7 @@ static int mcux_tpm_pin_set(struct device *dev, u32_t pwm,
 			      u32_t period_cycles, u32_t pulse_cycles,
 			      pwm_flags_t flags)
 {
-	const struct mcux_tpm_config *config = dev->config->config_info;
+	const struct mcux_tpm_config *config = dev->config_info;
 	struct mcux_tpm_data *data = dev->driver_data;
 	u8_t duty_cycle;
 
@@ -79,7 +79,7 @@ static int mcux_tpm_pin_set(struct device *dev, u32_t pwm,
 			LOG_WRN("Changing period cycles from %d to %d"
 				" affects all %d channels in %s",
 				data->period_cycles, period_cycles,
-				config->channel_count, dev->config->name);
+				config->channel_count, dev->name);
 		}
 
 		data->period_cycles = period_cycles;
@@ -119,7 +119,7 @@ static int mcux_tpm_pin_set(struct device *dev, u32_t pwm,
 static int mcux_tpm_get_cycles_per_sec(struct device *dev, u32_t pwm,
 					 u64_t *cycles)
 {
-	const struct mcux_tpm_config *config = dev->config->config_info;
+	const struct mcux_tpm_config *config = dev->config_info;
 	struct mcux_tpm_data *data = dev->driver_data;
 
 	*cycles = data->clock_freq >> config->prescale;
@@ -129,7 +129,7 @@ static int mcux_tpm_get_cycles_per_sec(struct device *dev, u32_t pwm,
 
 static int mcux_tpm_init(struct device *dev)
 {
-	const struct mcux_tpm_config *config = dev->config->config_info;
+	const struct mcux_tpm_config *config = dev->config_info;
 	struct mcux_tpm_data *data = dev->driver_data;
 	tpm_chnl_pwm_signal_param_t *channel = data->channel;
 	struct device *clock_dev;

--- a/drivers/pwm/pwm_nrf5_sw.c
+++ b/drivers/pwm/pwm_nrf5_sw.c
@@ -100,7 +100,7 @@ static int pwm_nrf5_sw_pin_set(struct device *dev, u32_t pwm,
 	u16_t div;
 	u32_t ret;
 
-	config = (struct pwm_config *)dev->config->config_info;
+	config = (struct pwm_config *)dev->config_info;
 	timer = config->timer;
 	data = dev->driver_data;
 
@@ -218,7 +218,7 @@ static int pwm_nrf5_sw_get_cycles_per_sec(struct device *dev, u32_t pwm,
 {
 	struct pwm_config *config;
 
-	config = (struct pwm_config *)dev->config->config_info;
+	config = (struct pwm_config *)dev->config_info;
 
 	/* HF timer frequency is derived from 16MHz source with a prescaler */
 	*cycles = 16000000UL / BIT(config->prescaler);
@@ -236,7 +236,7 @@ static int pwm_nrf5_sw_init(struct device *dev)
 	struct pwm_config *config;
 	NRF_TIMER_Type *timer;
 
-	config = (struct pwm_config *)dev->config->config_info;
+	config = (struct pwm_config *)dev->config_info;
 	timer = config->timer;
 
 	/* setup HF timer */

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -131,7 +131,7 @@ static int pwm_nrfx_pin_set(struct device *dev, u32_t pwm,
 	 * be removed, see ISSUE #6958.
 	 * TODO: Remove this comment when issue has been resolved.
 	 */
-	const struct pwm_nrfx_config *config = dev->config->config_info;
+	const struct pwm_nrfx_config *config = dev->config_info;
 	struct pwm_nrfx_data *data = dev->driver_data;
 	u8_t channel;
 	bool was_stopped;
@@ -267,14 +267,14 @@ static const struct pwm_driver_api pwm_nrfx_drv_api_funcs = {
 
 static int pwm_nrfx_init(struct device *dev)
 {
-	const struct pwm_nrfx_config *config = dev->config->config_info;
+	const struct pwm_nrfx_config *config = dev->config_info;
 
 	nrfx_err_t result = nrfx_pwm_init(&config->pwm,
 					  &config->initial_config,
 					  NULL,
 					  NULL);
 	if (result != NRFX_SUCCESS) {
-		LOG_ERR("Failed to initialize device: %s", dev->config->name);
+		LOG_ERR("Failed to initialize device: %s", dev->name);
 		return -EBUSY;
 	}
 
@@ -285,7 +285,7 @@ static int pwm_nrfx_init(struct device *dev)
 
 static void pwm_nrfx_uninit(struct device *dev)
 {
-	const struct pwm_nrfx_config *config = dev->config->config_info;
+	const struct pwm_nrfx_config *config = dev->config_info;
 
 	nrfx_pwm_uninit(&config->pwm);
 }

--- a/drivers/pwm/pwm_pca9685.c
+++ b/drivers/pwm/pwm_pca9685.c
@@ -65,7 +65,7 @@ static int pwm_pca9685_pin_set_cycles(struct device *dev, u32_t pwm,
 				      pwm_flags_t flags)
 {
 	const struct pwm_pca9685_config * const config =
-		dev->config->config_info;
+		dev->config_info;
 	struct pwm_pca9685_drv_data * const drv_data =
 		(struct pwm_pca9685_drv_data * const)dev->driver_data;
 	struct device * const i2c_master = drv_data->i2c_master;
@@ -128,7 +128,7 @@ static const struct pwm_driver_api pwm_pca9685_drv_api_funcs = {
 int pwm_pca9685_init(struct device *dev)
 {
 	const struct pwm_pca9685_config * const config =
-		dev->config->config_info;
+		dev->config_info;
 	struct pwm_pca9685_drv_data * const drv_data =
 		(struct pwm_pca9685_drv_data * const)dev->driver_data;
 	struct device *i2c_master;

--- a/drivers/pwm/pwm_rv32m1_tpm.c
+++ b/drivers/pwm/pwm_rv32m1_tpm.c
@@ -42,7 +42,7 @@ static int rv32m1_tpm_pin_set(struct device *dev, u32_t pwm,
 			      u32_t period_cycles, u32_t pulse_cycles,
 			      pwm_flags_t flags)
 {
-	const struct rv32m1_tpm_config *config = dev->config->config_info;
+	const struct rv32m1_tpm_config *config = dev->config_info;
 	struct rv32m1_tpm_data *data = dev->driver_data;
 	u8_t duty_cycle;
 
@@ -78,7 +78,7 @@ static int rv32m1_tpm_pin_set(struct device *dev, u32_t pwm,
 			LOG_WRN("Changing period cycles from %d to %d"
 				" affects all %d channels in %s",
 				data->period_cycles, period_cycles,
-				config->channel_count, dev->config->name);
+				config->channel_count, dev->name);
 		}
 
 		data->period_cycles = period_cycles;
@@ -118,7 +118,7 @@ static int rv32m1_tpm_pin_set(struct device *dev, u32_t pwm,
 static int rv32m1_tpm_get_cycles_per_sec(struct device *dev, u32_t pwm,
 					 u64_t *cycles)
 {
-	const struct rv32m1_tpm_config *config = dev->config->config_info;
+	const struct rv32m1_tpm_config *config = dev->config_info;
 	struct rv32m1_tpm_data *data = dev->driver_data;
 
 	*cycles = data->clock_freq >> config->prescale;
@@ -128,7 +128,7 @@ static int rv32m1_tpm_get_cycles_per_sec(struct device *dev, u32_t pwm,
 
 static int rv32m1_tpm_init(struct device *dev)
 {
-	const struct rv32m1_tpm_config *config = dev->config->config_info;
+	const struct rv32m1_tpm_config *config = dev->config_info;
 	struct rv32m1_tpm_data *data = dev->driver_data;
 	tpm_chnl_pwm_signal_param_t *channel = data->channel;
 	struct device *clock_dev;

--- a/drivers/pwm/pwm_sam.c
+++ b/drivers/pwm/pwm_sam.c
@@ -23,7 +23,7 @@ struct sam_pwm_config {
 };
 
 #define DEV_CFG(dev) \
-	((const struct sam_pwm_config * const)(dev)->config->config_info)
+	((const struct sam_pwm_config * const)(dev)->config_info)
 
 static int sam_pwm_get_cycles_per_sec(struct device *dev, u32_t pwm,
 				      u64_t *cycles)

--- a/drivers/pwm/pwm_sifive.c
+++ b/drivers/pwm/pwm_sifive.c
@@ -70,7 +70,7 @@ static inline void sys_set_mask(mem_addr_t addr, u32_t mask, u32_t value)
 
 static int pwm_sifive_init(struct device *dev)
 {
-	const struct pwm_sifive_cfg *config = dev->config->config_info;
+	const struct pwm_sifive_cfg *config = dev->config_info;
 
 	/* When pwms == pwmcmp0, reset the counter */
 	sys_set_bit(PWM_REG(config, REG_PWMCFG), SF_PWMZEROCMP);
@@ -110,17 +110,13 @@ static int pwm_sifive_pin_set(struct device *dev,
 		LOG_ERR("The device instance pointer was NULL\n");
 		return -EFAULT;
 	}
-	if (dev->config == NULL) {
-		LOG_ERR("The device config pointer was NULL\n");
-		return -EFAULT;
-	}
 
 	if (flags) {
 		/* PWM polarity not supported (yet?) */
 		return -ENOTSUP;
 	}
 
-	config = dev->config->config_info;
+	config = dev->config_info;
 	if (config == NULL) {
 		LOG_ERR("The device configuration is NULL\n");
 		return -EFAULT;
@@ -202,12 +198,8 @@ static int pwm_sifive_get_cycles_per_sec(struct device *dev,
 		LOG_ERR("The device instance pointer was NULL\n");
 		return -EFAULT;
 	}
-	if (dev->config == NULL) {
-		LOG_ERR("The device config pointer was NULL\n");
-		return -EFAULT;
-	}
 
-	config = dev->config->config_info;
+	config = dev->config_info;
 	if (config == NULL) {
 		LOG_ERR("The device configuration is NULL\n");
 		return -EFAULT;

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -23,7 +23,7 @@ LOG_MODULE_REGISTER(pwm_stm32);
 
 /* convenience defines */
 #define DEV_CFG(dev)							\
-	((const struct pwm_stm32_config * const)(dev)->config->config_info)
+	((const struct pwm_stm32_config * const)(dev)->config_info)
 #define DEV_DATA(dev)							\
 	((struct pwm_stm32_data * const)(dev)->driver_data)
 #define PWM_STRUCT(dev)					\

--- a/drivers/sensor/adt7420/adt7420.c
+++ b/drivers/sensor/adt7420/adt7420.c
@@ -22,7 +22,7 @@ LOG_MODULE_REGISTER(ADT7420, CONFIG_SENSOR_LOG_LEVEL);
 static int adt7420_temp_reg_read(struct device *dev, u8_t reg, s16_t *val)
 {
 	struct adt7420_data *drv_data = dev->driver_data;
-	const struct adt7420_dev_config *cfg = dev->config->config_info;
+	const struct adt7420_dev_config *cfg = dev->config_info;
 
 	if (i2c_burst_read(drv_data->i2c, cfg->i2c_addr,
 			   reg, (u8_t *) val, 2) < 0) {
@@ -37,7 +37,7 @@ static int adt7420_temp_reg_read(struct device *dev, u8_t reg, s16_t *val)
 static int adt7420_temp_reg_write(struct device *dev, u8_t reg, s16_t val)
 {
 	struct adt7420_data *drv_data = dev->driver_data;
-	const struct adt7420_dev_config *cfg = dev->config->config_info;
+	const struct adt7420_dev_config *cfg = dev->config_info;
 	u8_t buf[3] = {reg, val >> 8, val & 0xFF};
 
 	return i2c_write(drv_data->i2c, buf, sizeof(buf), cfg->i2c_addr);
@@ -49,7 +49,7 @@ static int adt7420_attr_set(struct device *dev,
 			   const struct sensor_value *val)
 {
 	struct adt7420_data *drv_data = dev->driver_data;
-	const struct adt7420_dev_config *cfg = dev->config->config_info;
+	const struct adt7420_dev_config *cfg = dev->config_info;
 	u8_t val8, reg = 0U;
 	u16_t rate;
 	s64_t value;
@@ -157,7 +157,7 @@ static const struct sensor_driver_api adt7420_driver_api = {
 static int adt7420_probe(struct device *dev)
 {
 	struct adt7420_data *drv_data = dev->driver_data;
-	const struct adt7420_dev_config *cfg = dev->config->config_info;
+	const struct adt7420_dev_config *cfg = dev->config_info;
 	u8_t value;
 	int ret;
 
@@ -203,7 +203,7 @@ static int adt7420_probe(struct device *dev)
 static int adt7420_init(struct device *dev)
 {
 	struct adt7420_data *drv_data = dev->driver_data;
-	const struct adt7420_dev_config *cfg = dev->config->config_info;
+	const struct adt7420_dev_config *cfg = dev->config_info;
 
 	drv_data->i2c = device_get_binding(cfg->i2c_port);
 	if (drv_data->i2c == NULL) {

--- a/drivers/sensor/adt7420/adt7420_trigger.c
+++ b/drivers/sensor/adt7420/adt7420_trigger.c
@@ -20,7 +20,7 @@ static void setup_int(struct device *dev,
 		      bool enable)
 {
 	struct adt7420_data *drv_data = dev->driver_data;
-	const struct adt7420_dev_config *cfg = dev->config->config_info;
+	const struct adt7420_dev_config *cfg = dev->config_info;
 	gpio_flags_t flags = enable
 		? GPIO_INT_EDGE_TO_ACTIVE
 		: GPIO_INT_DISABLE;
@@ -44,7 +44,7 @@ static void handle_int(struct device *dev)
 static void process_int(struct device *dev)
 {
 	struct adt7420_data *drv_data = dev->driver_data;
-	const struct adt7420_dev_config *cfg = dev->config->config_info;
+	const struct adt7420_dev_config *cfg = dev->config_info;
 	u8_t status;
 
 	/* Clear the status */
@@ -105,7 +105,7 @@ int adt7420_trigger_set(struct device *dev,
 			sensor_trigger_handler_t handler)
 {
 	struct adt7420_data *drv_data = dev->driver_data;
-	const struct adt7420_dev_config *cfg = dev->config->config_info;
+	const struct adt7420_dev_config *cfg = dev->config_info;
 
 	setup_int(dev, false);
 
@@ -134,7 +134,7 @@ int adt7420_trigger_set(struct device *dev,
 int adt7420_init_interrupt(struct device *dev)
 {
 	struct adt7420_data *drv_data = dev->driver_data;
-	const struct adt7420_dev_config *cfg = dev->config->config_info;
+	const struct adt7420_dev_config *cfg = dev->config_info;
 
 	drv_data->gpio = device_get_binding(cfg->int_name);
 	if (drv_data->gpio == NULL) {

--- a/drivers/sensor/adxl345/adxl345.c
+++ b/drivers/sensor/adxl345/adxl345.c
@@ -132,7 +132,7 @@ static int adxl345_init(struct device *dev)
 {
 	int rc;
 	struct adxl345_dev_data *data = dev->driver_data;
-	const struct adxl345_dev_config *cfg = dev->config->config_info;
+	const struct adxl345_dev_config *cfg = dev->config_info;
 	u8_t dev_id;
 
 	data->sample_number = 0;

--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -721,7 +721,7 @@ static int adxl362_chip_init(struct device *dev)
  */
 static int adxl362_init(struct device *dev)
 {
-	const struct adxl362_config *config = dev->config->config_info;
+	const struct adxl362_config *config = dev->config_info;
 	struct adxl362_data *data = dev->driver_data;
 	u8_t value;
 	int err;

--- a/drivers/sensor/adxl362/adxl362_trigger.c
+++ b/drivers/sensor/adxl362/adxl362_trigger.c
@@ -123,7 +123,7 @@ int adxl362_trigger_set(struct device *dev,
 int adxl362_init_interrupt(struct device *dev)
 {
 	struct adxl362_data *drv_data = dev->driver_data;
-	const struct adxl362_config *cfg = dev->config->config_info;
+	const struct adxl362_config *cfg = dev->config_info;
 	int ret;
 
 	k_mutex_init(&drv_data->trigger_mutex);

--- a/drivers/sensor/adxl372/adxl372.c
+++ b/drivers/sensor/adxl372/adxl372.c
@@ -58,7 +58,7 @@ static int adxl372_bus_access(struct device *dev, u8_t reg,
 
 	return spi_write(adxl372_data->bus, &adxl372_data->spi_cfg, &tx);
 #elif CONFIG_ADXL372_I2C
-	const struct adxl372_dev_config *cfg = dev->config->config_info;
+	const struct adxl372_dev_config *cfg = dev->config_info;
 
 	if (reg & ADXL372_READ) {
 		return i2c_burst_read(adxl372_data->bus, cfg->i2c_addr,
@@ -637,7 +637,7 @@ static int adxl372_attr_set_thresh(struct device *dev, enum sensor_channel chan,
 			    enum sensor_attribute attr,
 			    const struct sensor_value *val)
 {
-	const struct adxl372_dev_config *cfg = dev->config->config_info;
+	const struct adxl372_dev_config *cfg = dev->config_info;
 	struct adxl372_activity_threshold threshold;
 	s32_t value;
 	s64_t micro_ms2 = val->val1 * 1000000LL + val->val2;
@@ -692,7 +692,7 @@ static int adxl372_attr_set(struct device *dev, enum sensor_channel chan,
 static int adxl372_sample_fetch(struct device *dev, enum sensor_channel chan)
 {
 	struct adxl372_data *data = dev->driver_data;
-	const struct adxl372_dev_config *cfg = dev->config->config_info;
+	const struct adxl372_dev_config *cfg = dev->config_info;
 
 	return adxl372_get_accel_data(dev, cfg->max_peak_detect_mode,
 				      &data->sample);
@@ -750,7 +750,7 @@ static const struct sensor_driver_api adxl372_api_funcs = {
 
 static int adxl372_probe(struct device *dev)
 {
-	const struct adxl372_dev_config *cfg = dev->config->config_info;
+	const struct adxl372_dev_config *cfg = dev->config_info;
 	u8_t dev_id, part_id;
 	int ret;
 
@@ -878,7 +878,7 @@ static int adxl372_probe(struct device *dev)
 static int adxl372_init(struct device *dev)
 {
 	struct adxl372_data *data = dev->driver_data;
-	const struct adxl372_dev_config *cfg = dev->config->config_info;
+	const struct adxl372_dev_config *cfg = dev->config_info;
 
 #ifdef CONFIG_ADXL372_I2C
 	data->bus  = device_get_binding(cfg->i2c_port);

--- a/drivers/sensor/adxl372/adxl372_trigger.c
+++ b/drivers/sensor/adxl372/adxl372_trigger.c
@@ -20,7 +20,7 @@ static void adxl372_thread_cb(void *arg)
 {
 	struct device *dev = arg;
 	struct adxl372_data *drv_data = dev->driver_data;
-	const struct adxl372_dev_config *cfg = dev->config->config_info;
+	const struct adxl372_dev_config *cfg = dev->config_info;
 	u8_t status1, status2;
 
 	/* Clear the status */
@@ -56,7 +56,7 @@ static void adxl372_gpio_callback(struct device *dev,
 {
 	struct adxl372_data *drv_data =
 		CONTAINER_OF(cb, struct adxl372_data, gpio_cb);
-	const struct adxl372_dev_config *cfg = dev->config->config_info;
+	const struct adxl372_dev_config *cfg = dev->config_info;
 
 	gpio_pin_interrupt_configure(drv_data->gpio, cfg->int_gpio,
 				     GPIO_INT_DISABLE);
@@ -97,7 +97,7 @@ int adxl372_trigger_set(struct device *dev,
 			sensor_trigger_handler_t handler)
 {
 	struct adxl372_data *drv_data = dev->driver_data;
-	const struct adxl372_dev_config *cfg = dev->config->config_info;
+	const struct adxl372_dev_config *cfg = dev->config_info;
 	u8_t int_mask, int_en, status1, status2;
 	int ret;
 
@@ -141,7 +141,7 @@ out:
 int adxl372_init_interrupt(struct device *dev)
 {
 	struct adxl372_data *drv_data = dev->driver_data;
-	const struct adxl372_dev_config *cfg = dev->config->config_info;
+	const struct adxl372_dev_config *cfg = dev->config_info;
 
 	drv_data->gpio = device_get_binding(cfg->gpio_port);
 	if (drv_data->gpio == NULL) {

--- a/drivers/sensor/amg88xx/amg88xx.c
+++ b/drivers/sensor/amg88xx/amg88xx.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(AMG88XX, CONFIG_SENSOR_LOG_LEVEL);
 static int amg88xx_sample_fetch(struct device *dev, enum sensor_channel chan)
 {
 	struct amg88xx_data *drv_data = dev->driver_data;
-	const struct amg88xx_config *config = dev->config->config_info;
+	const struct amg88xx_config *config = dev->config_info;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_AMBIENT_TEMP);
 
@@ -66,7 +66,7 @@ static int amg88xx_channel_get(struct device *dev,
 static int amg88xx_init_device(struct device *dev)
 {
 	struct amg88xx_data *drv_data = dev->driver_data;
-	const struct amg88xx_config *config = dev->config->config_info;
+	const struct amg88xx_config *config = dev->config_info;
 	u8_t tmp;
 
 	if (i2c_reg_read_byte(drv_data->i2c, config->i2c_address,
@@ -106,7 +106,7 @@ static int amg88xx_init_device(struct device *dev)
 int amg88xx_init(struct device *dev)
 {
 	struct amg88xx_data *drv_data = dev->driver_data;
-	const struct amg88xx_config *config = dev->config->config_info;
+	const struct amg88xx_config *config = dev->config_info;
 
 	drv_data->i2c = device_get_binding(config->i2c_name);
 	if (drv_data->i2c == NULL) {

--- a/drivers/sensor/amg88xx/amg88xx_trigger.c
+++ b/drivers/sensor/amg88xx/amg88xx_trigger.c
@@ -36,7 +36,7 @@ int amg88xx_attr_set(struct device *dev,
 		     const struct sensor_value *val)
 {
 	struct amg88xx_data *drv_data = dev->driver_data;
-	const struct amg88xx_config *config = dev->config->config_info;
+	const struct amg88xx_config *config = dev->config_info;
 	s16_t int_level = (val->val1 * 1000000 + val->val2) /
 			  AMG88XX_TREG_LSB_SCALING;
 	u8_t intl_reg;
@@ -92,7 +92,7 @@ static void amg88xx_thread_cb(void *arg)
 {
 	struct device *dev = arg;
 	struct amg88xx_data *drv_data = dev->driver_data;
-	const struct amg88xx_config *config = dev->config->config_info;
+	const struct amg88xx_config *config = dev->config_info;
 	u8_t status;
 
 	if (i2c_reg_read_byte(drv_data->i2c, config->i2c_address,
@@ -140,7 +140,7 @@ int amg88xx_trigger_set(struct device *dev,
 			sensor_trigger_handler_t handler)
 {
 	struct amg88xx_data *drv_data = dev->driver_data;
-	const struct amg88xx_config *config = dev->config->config_info;
+	const struct amg88xx_config *config = dev->config_info;
 
 	if (i2c_reg_write_byte(drv_data->i2c, config->i2c_address,
 			       AMG88XX_INTC, AMG88XX_INTC_DISABLED)) {
@@ -170,7 +170,7 @@ int amg88xx_trigger_set(struct device *dev,
 int amg88xx_init_interrupt(struct device *dev)
 {
 	struct amg88xx_data *drv_data = dev->driver_data;
-	const struct amg88xx_config *config = dev->config->config_info;
+	const struct amg88xx_config *config = dev->config_info;
 
 	/* setup gpio interrupt */
 	drv_data->gpio = device_get_binding(config->gpio_name);

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -47,7 +47,7 @@ static void apds9960_gpio_callback(struct device *dev,
 
 static int apds9960_sample_fetch(struct device *dev, enum sensor_channel chan)
 {
-	const struct apds9960_config *config = dev->config->config_info;
+	const struct apds9960_config *config = dev->config_info;
 	struct apds9960_data *data = dev->driver_data;
 	u8_t tmp;
 
@@ -151,7 +151,7 @@ static int apds9960_channel_get(struct device *dev,
 
 static int apds9960_proxy_setup(struct device *dev)
 {
-	const struct apds9960_config *config = dev->config->config_info;
+	const struct apds9960_config *config = dev->config_info;
 	struct apds9960_data *data = dev->driver_data;
 
 	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
@@ -223,7 +223,7 @@ static int apds9960_proxy_setup(struct device *dev)
 #ifdef CONFIG_APDS9960_ENABLE_ALS
 static int apds9960_ambient_setup(struct device *dev)
 {
-	const struct apds9960_config *config = dev->config->config_info;
+	const struct apds9960_config *config = dev->config_info;
 	struct apds9960_data *data = dev->driver_data;
 	u16_t th;
 
@@ -273,7 +273,7 @@ static int apds9960_ambient_setup(struct device *dev)
 
 static int apds9960_sensor_setup(struct device *dev)
 {
-	const struct apds9960_config *config = dev->config->config_info;
+	const struct apds9960_config *config = dev->config_info;
 	struct apds9960_data *data = dev->driver_data;
 	u8_t chip_id;
 
@@ -358,7 +358,7 @@ static int apds9960_sensor_setup(struct device *dev)
 
 static int apds9960_init_interrupt(struct device *dev)
 {
-	const struct apds9960_config *config = dev->config->config_info;
+	const struct apds9960_config *config = dev->config_info;
 	struct apds9960_data *drv_data = dev->driver_data;
 
 	/* setup gpio interrupt */
@@ -410,7 +410,7 @@ static int apds9960_init_interrupt(struct device *dev)
 static int apds9960_device_ctrl(struct device *dev, u32_t ctrl_command,
 				void *context, device_pm_cb cb, void *arg)
 {
-	const struct apds9960_config *config = dev->config->config_info;
+	const struct apds9960_config *config = dev->config_info;
 	struct apds9960_data *data = dev->driver_data;
 	int ret = 0;
 
@@ -453,7 +453,7 @@ static int apds9960_device_ctrl(struct device *dev, u32_t ctrl_command,
 
 static int apds9960_init(struct device *dev)
 {
-	const struct apds9960_config *config = dev->config->config_info;
+	const struct apds9960_config *config = dev->config_info;
 	struct apds9960_data *data = dev->driver_data;
 
 	/* Initialize time 5.7ms */

--- a/drivers/sensor/apds9960/apds9960_trigger.c
+++ b/drivers/sensor/apds9960/apds9960_trigger.c
@@ -36,7 +36,7 @@ int apds9960_attr_set(struct device *dev,
 		      enum sensor_attribute attr,
 		      const struct sensor_value *val)
 {
-	const struct apds9960_config *config = dev->config->config_info;
+	const struct apds9960_config *config = dev->config_info;
 	struct apds9960_data *data = dev->driver_data;
 
 	if (chan == SENSOR_CHAN_PROX) {
@@ -69,7 +69,7 @@ int apds9960_trigger_set(struct device *dev,
 			const struct sensor_trigger *trig,
 			sensor_trigger_handler_t handler)
 {
-	const struct apds9960_config *config = dev->config->config_info;
+	const struct apds9960_config *config = dev->config_info;
 	struct apds9960_data *data = dev->driver_data;
 
 	apds9960_setup_int(data, false);

--- a/drivers/sensor/bmc150_magn/bmc150_magn.c
+++ b/drivers/sensor/bmc150_magn/bmc150_magn.c
@@ -53,7 +53,7 @@ static int bmc150_magn_set_power_mode(struct device *dev,
 				      int state)
 {
 	struct bmc150_magn_data *data = dev->driver_data;
-	const struct bmc150_magn_config *config = dev->config->config_info;
+	const struct bmc150_magn_config *config = dev->config_info;
 
 	switch (mode) {
 	case BMC150_MAGN_POWER_MODE_SUSPEND:
@@ -91,7 +91,7 @@ static int bmc150_magn_set_power_mode(struct device *dev,
 static int bmc150_magn_set_odr(struct device *dev, u8_t val)
 {
 	struct bmc150_magn_data *data = dev->driver_data;
-	const struct bmc150_magn_config *config = dev->config->config_info;
+	const struct bmc150_magn_config *config = dev->config_info;
 	u8_t i;
 
 	for (i = 0U; i < ARRAY_SIZE(bmc150_magn_samp_freq_table); ++i) {
@@ -113,7 +113,7 @@ static int bmc150_magn_set_odr(struct device *dev, u8_t val)
 static int bmc150_magn_read_rep_xy(struct device *dev)
 {
 	struct bmc150_magn_data *data = dev->driver_data;
-	const struct bmc150_magn_config *config = dev->config->config_info;
+	const struct bmc150_magn_config *config = dev->config_info;
 	u8_t reg_val;
 
 	if (i2c_reg_read_byte(data->i2c_master, config->i2c_slave_addr,
@@ -129,7 +129,7 @@ static int bmc150_magn_read_rep_xy(struct device *dev)
 static int bmc150_magn_read_rep_z(struct device *dev)
 {
 	struct bmc150_magn_data *data = dev->driver_data;
-	const struct bmc150_magn_config *config = dev->config->config_info;
+	const struct bmc150_magn_config *config = dev->config_info;
 	u8_t reg_val;
 
 	if (i2c_reg_read_byte(data->i2c_master, config->i2c_slave_addr,
@@ -175,7 +175,7 @@ static int bmc150_magn_compute_max_odr(struct device *dev, int rep_xy,
 static int bmc150_magn_read_odr(struct device *dev)
 {
 	struct bmc150_magn_data *data = dev->driver_data;
-	const struct bmc150_magn_config *config = dev->config->config_info;
+	const struct bmc150_magn_config *config = dev->config_info;
 	u8_t i, odr_val, reg_val;
 
 	if (i2c_reg_read_byte(data->i2c_master, config->i2c_slave_addr,
@@ -200,7 +200,7 @@ static int bmc150_magn_read_odr(struct device *dev)
 static int bmc150_magn_write_rep_xy(struct device *dev, int val)
 {
 	struct bmc150_magn_data *data = dev->driver_data;
-	const struct bmc150_magn_config *config = dev->config->config_info;
+	const struct bmc150_magn_config *config = dev->config_info;
 
 	if (i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
 				BMC150_MAGN_REG_REP_XY,
@@ -219,7 +219,7 @@ static int bmc150_magn_write_rep_xy(struct device *dev, int val)
 static int bmc150_magn_write_rep_z(struct device *dev, int val)
 {
 	struct bmc150_magn_data *data = dev->driver_data;
-	const struct bmc150_magn_config *config = dev->config->config_info;
+	const struct bmc150_magn_config *config = dev->config_info;
 
 	if (i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
 				BMC150_MAGN_REG_REP_Z,
@@ -292,7 +292,7 @@ static int bmc150_magn_sample_fetch(struct device *dev,
 				    enum sensor_channel chan)
 {
 	struct bmc150_magn_data *data = dev->driver_data;
-	const struct bmc150_magn_config *config = dev->config->config_info;
+	const struct bmc150_magn_config *config = dev->config_info;
 	u16_t values[BMC150_MAGN_AXIS_XYZR_MAX];
 	s16_t raw_x, raw_y, raw_z;
 	u16_t rhall;
@@ -485,7 +485,7 @@ static const struct sensor_driver_api bmc150_magn_api_funcs = {
 static int bmc150_magn_init_chip(struct device *dev)
 {
 	struct bmc150_magn_data *data = dev->driver_data;
-	const struct bmc150_magn_config *config = dev->config->config_info;
+	const struct bmc150_magn_config *config = dev->config_info;
 	u8_t chip_id;
 	struct bmc150_magn_preset preset;
 
@@ -571,7 +571,7 @@ err_poweroff:
 static int bmc150_magn_init(struct device *dev)
 {
 	const struct bmc150_magn_config * const config =
-					  dev->config->config_info;
+					  dev->config_info;
 	struct bmc150_magn_data *data = dev->driver_data;
 
 	data->i2c_master = device_get_binding(config->i2c_master_dev_name);

--- a/drivers/sensor/bmc150_magn/bmc150_magn_trigger.c
+++ b/drivers/sensor/bmc150_magn/bmc150_magn_trigger.c
@@ -20,7 +20,7 @@ static inline void setup_drdy(struct device *dev,
 {
 	struct bmc150_magn_data *data = dev->driver_data;
 	const struct bmc150_magn_config *const cfg =
-		dev->config->config_info;
+		dev->config_info;
 
 	gpio_pin_interrupt_configure(data->gpio_drdy,
 				     cfg->gpio_drdy_int_pin,
@@ -36,7 +36,7 @@ int bmc150_magn_trigger_set(struct device *dev,
 {
 	struct bmc150_magn_data *data = dev->driver_data;
 	const struct bmc150_magn_config * const config =
-					dev->config->config_info;
+					dev->config_info;
 	u8_t state;
 
 #if defined(CONFIG_BMC150_MAGN_TRIGGER_DRDY)
@@ -86,7 +86,7 @@ static void bmc150_magn_thread_main(void *arg1, void *arg2, void *arg3)
 {
 	struct device *dev = (struct device *) arg1;
 	struct bmc150_magn_data *data = dev->driver_data;
-	const struct bmc150_magn_config *config = dev->config->config_info;
+	const struct bmc150_magn_config *config = dev->config_info;
 	u8_t reg_val;
 
 	while (1) {
@@ -110,7 +110,7 @@ static void bmc150_magn_thread_main(void *arg1, void *arg2, void *arg3)
 static int bmc150_magn_set_drdy_polarity(struct device *dev, int state)
 {
 	struct bmc150_magn_data *data = dev->driver_data;
-	const struct bmc150_magn_config *config = dev->config->config_info;
+	const struct bmc150_magn_config *config = dev->config_info;
 
 	if (state) {
 		state = 1;
@@ -125,7 +125,7 @@ static int bmc150_magn_set_drdy_polarity(struct device *dev, int state)
 int bmc150_magn_init_interrupt(struct device *dev)
 {
 	const struct bmc150_magn_config * const config =
-						dev->config->config_info;
+						dev->config_info;
 	struct bmc150_magn_data *data = dev->driver_data;
 
 

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -117,7 +117,7 @@ static inline struct bme280_data *to_data(struct device *dev)
 
 static inline const struct bme280_config *to_config(struct device *dev)
 {
-	return dev->config->config_info;
+	return dev->config_info;
 }
 
 static inline struct device *to_bus(struct device *dev)
@@ -543,7 +543,7 @@ static inline int bme280_spi_init(struct device *dev)
 
 int bme280_init(struct device *dev)
 {
-	const char *name = dev->config->name;
+	const char *name = dev->name;
 	struct bme280_data *data = to_data(dev);
 	const struct bme280_config *config = to_config(dev);
 	int rc;

--- a/drivers/sensor/bmg160/bmg160.c
+++ b/drivers/sensor/bmg160/bmg160.c
@@ -24,7 +24,7 @@ struct bmg160_device_data bmg160_data;
 
 static inline int bmg160_bus_config(struct device *dev)
 {
-	const struct bmg160_device_config *dev_cfg = dev->config->config_info;
+	const struct bmg160_device_config *dev_cfg = dev->config_info;
 	struct bmg160_device_data *bmg160 = dev->driver_data;
 	u32_t i2c_cfg;
 
@@ -36,7 +36,7 @@ static inline int bmg160_bus_config(struct device *dev)
 int bmg160_read(struct device *dev, u8_t reg_addr, u8_t *data,
 		u8_t len)
 {
-	const struct bmg160_device_config *dev_cfg = dev->config->config_info;
+	const struct bmg160_device_config *dev_cfg = dev->config_info;
 	struct bmg160_device_data *bmg160 = dev->driver_data;
 	int ret = 0;
 
@@ -62,7 +62,7 @@ int bmg160_read_byte(struct device *dev, u8_t reg_addr, u8_t *byte)
 static int bmg160_write(struct device *dev, u8_t reg_addr, u8_t *data,
 			u8_t len)
 {
-	const struct bmg160_device_config *dev_cfg = dev->config->config_info;
+	const struct bmg160_device_config *dev_cfg = dev->config_info;
 	struct bmg160_device_data *bmg160 = dev->driver_data;
 	int ret = 0;
 
@@ -88,7 +88,7 @@ int bmg160_write_byte(struct device *dev, u8_t reg_addr, u8_t byte)
 int bmg160_update_byte(struct device *dev, u8_t reg_addr, u8_t mask,
 		       u8_t value)
 {
-	const struct bmg160_device_config *dev_cfg = dev->config->config_info;
+	const struct bmg160_device_config *dev_cfg = dev->config_info;
 	struct bmg160_device_data *bmg160 = dev->driver_data;
 	int ret = 0;
 
@@ -273,7 +273,7 @@ static const struct sensor_driver_api bmg160_api = {
 
 int bmg160_init(struct device *dev)
 {
-	const struct bmg160_device_config *cfg = dev->config->config_info;
+	const struct bmg160_device_config *cfg = dev->config_info;
 	struct bmg160_device_data *bmg160 = dev->driver_data;
 	u8_t chip_id = 0U;
 	u16_t range_dps;

--- a/drivers/sensor/bmg160/bmg160_trigger.c
+++ b/drivers/sensor/bmg160/bmg160_trigger.c
@@ -23,7 +23,7 @@ static inline void setup_int(struct device *dev,
 {
 	struct bmg160_device_data *data = dev->driver_data;
 	const struct bmg160_device_config *const cfg =
-		dev->config->config_info;
+		dev->config_info;
 
 	gpio_pin_interrupt_configure(data->gpio,
 				     cfg->int_pin,
@@ -208,7 +208,7 @@ static void bmg160_work_cb(struct k_work *work)
 
 int bmg160_trigger_init(struct device *dev)
 {
-	const struct bmg160_device_config *cfg = dev->config->config_info;
+	const struct bmg160_device_config *cfg = dev->config_info;
 	struct bmg160_device_data *bmg160 = dev->driver_data;
 
 	/* set INT1 pin to: push-pull, active low */

--- a/drivers/sensor/bmi160/bmi160_trigger.c
+++ b/drivers/sensor/bmi160/bmi160_trigger.c
@@ -274,7 +274,7 @@ int bmi160_trigger_mode_init(struct device *dev)
 {
 	struct bmi160_device_data *bmi160 = dev->driver_data;
 
-	const struct bmi160_device_config *cfg = dev->config->config_info;
+	const struct bmi160_device_config *cfg = dev->config_info;
 
 	bmi160->gpio = device_get_binding((char *)cfg->gpio_port);
 	if (!bmi160->gpio) {

--- a/drivers/sensor/bmm150/bmm150.c
+++ b/drivers/sensor/bmm150/bmm150.c
@@ -41,7 +41,7 @@ static int bmm150_set_power_mode(struct device *dev,
 				 int state)
 {
 	struct bmm150_data *data = dev->driver_data;
-	const struct bmm150_config *config = dev->config->config_info;
+	const struct bmm150_config *config = dev->config_info;
 
 	switch (mode) {
 	case BMM150_POWER_MODE_SUSPEND:
@@ -80,7 +80,7 @@ static int bmm150_set_power_mode(struct device *dev,
 static int bmm150_set_odr(struct device *dev, u8_t val)
 {
 	struct bmm150_data *data = dev->driver_data;
-	const struct bmm150_config *config = dev->config->config_info;
+	const struct bmm150_config *config = dev->config_info;
 	u8_t i;
 
 	for (i = 0U; i < ARRAY_SIZE(bmm150_samp_freq_table); ++i) {
@@ -101,7 +101,7 @@ static int bmm150_set_odr(struct device *dev, u8_t val)
 static int bmm150_read_rep_xy(struct device *dev)
 {
 	struct bmm150_data *data = dev->driver->data;
-	const struct bmm150_config *config = dev->config->config_info;
+	const struct bmm150_config *config = dev->config_info;
 	u8_t reg_val;
 
 	if (i2c_reg_read_byte(data->i2c, config->i2c_slave_addr,
@@ -117,7 +117,7 @@ static int bmm150_read_rep_xy(struct device *dev)
 static int bmm150_read_rep_z(struct device *dev)
 {
 	struct bmm150_data *data = dev->driver_data;
-	const struct bmm150_config *config = dev->config->config_info;
+	const struct bmm150_config *config = dev->config_info;
 	u8_t reg_val;
 
 	if (i2c_reg_read_byte(data->i2c, config->i2c_slave_addr,
@@ -164,7 +164,7 @@ static int bmm150_compute_max_odr(struct device *dev, int rep_xy,
 static int bmm150_read_odr(struct device *dev)
 {
 	struct bmm150_data *data = dev->driver_data;
-	const struct bmm150_config *config = dev->config->config_info;
+	const struct bmm150_config *config = dev->config_info;
 	u8_t i, odr_val, reg_val;
 
 	if (i2c_reg_read_byte(data->i2c, config->i2c_slave_addr,
@@ -189,7 +189,7 @@ static int bmm150_read_odr(struct device *dev)
 static int bmm150_write_rep_xy(struct device *dev, int val)
 {
 	struct bmm150_data *data = dev->driver_data;
-	const struct bmm150_config *config = dev->config->config_info;
+	const struct bmm150_config *config = dev->config_info;
 
 	if (i2c_reg_update_byte(data->i2c, config->i2c_slave_addr,
 				BMM150_REG_REP_XY,
@@ -208,7 +208,7 @@ static int bmm150_write_rep_xy(struct device *dev, int val)
 static int bmm150_write_rep_z(struct device *dev, int val)
 {
 	struct bmm150_data *data = dev->driver_data;
-	const struct bmm150_config *config = dev->config->config_info;
+	const struct bmm150_config *config = dev->config_info;
 
 	if (i2c_reg_update_byte(data->i2c, config->i2c_slave_addr,
 				BMM150_REG_REP_Z,
@@ -292,7 +292,7 @@ static int bmm150_sample_fetch(struct device *dev, enum sensor_channel chan)
 {
 
 	struct bmm150_data *drv_data = dev->driver_data;
-	const struct bmm150_config *config = dev->config->config_info;
+	const struct bmm150_config *config = dev->config_info;
 	u16_t values[BMM150_AXIS_XYZR_MAX];
 	s16_t raw_x, raw_y, raw_z;
 	u16_t rhall;
@@ -489,7 +489,7 @@ static const struct sensor_driver_api bmm150_api_funcs = {
 static int bmm150_init_chip(struct device *dev)
 {
 	struct bmm150_data *data = dev->driver_data;
-	const struct bmm150_config *config = dev->config->config_info;
+	const struct bmm150_config *config = dev->config_info;
 	u8_t chip_id;
 	struct bmm150_preset preset;
 
@@ -581,7 +581,7 @@ err_poweroff:
 static int bmm150_init(struct device *dev)
 {
 	const struct bmm150_config *const config =
-		dev->config->config_info;
+		dev->config_info;
 	struct bmm150_data *data = dev->driver_data;
 
 	data->i2c = device_get_binding(config->i2c_master_dev_name);

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -351,7 +351,7 @@ static int bq274xx_sample_fetch(struct device *dev, enum sensor_channel chan)
 static int bq274xx_gauge_init(struct device *dev)
 {
 	struct bq274xx_data *bq274xx = dev->driver_data;
-	const struct bq274xx_config *const config = dev->config->config_info;
+	const struct bq274xx_config *const config = dev->config_info;
 	int status = 0;
 	u8_t tmp_checksum = 0, checksum_old = 0, checksum_new = 0;
 	u16_t flags = 0, designenergy_mwh = 0, taperrate = 0, id;

--- a/drivers/sensor/dht/dht.c
+++ b/drivers/sensor/dht/dht.c
@@ -32,7 +32,7 @@ static s8_t dht_measure_signal_duration(struct device *dev,
 					bool active)
 {
 	struct dht_data *drv_data = dev->driver_data;
-	const struct dht_config *cfg = dev->config->config_info;
+	const struct dht_config *cfg = dev->config_info;
 	u32_t elapsed_cycles;
 	u32_t max_wait_cycles = (u32_t)(
 		(u64_t)DHT_SIGNAL_MAX_WAIT_DURATION *
@@ -60,7 +60,7 @@ static s8_t dht_measure_signal_duration(struct device *dev,
 static int dht_sample_fetch(struct device *dev, enum sensor_channel chan)
 {
 	struct dht_data *drv_data = dev->driver_data;
-	const struct dht_config *cfg = dev->config->config_info;
+	const struct dht_config *cfg = dev->config_info;
 	int ret = 0;
 	s8_t signal_duration[DHT_DATA_BITS_NUM];
 	s8_t max_duration, min_duration, avg_duration;
@@ -225,7 +225,7 @@ static int dht_init(struct device *dev)
 {
 	int rc = 0;
 	struct dht_data *drv_data = dev->driver_data;
-	const struct dht_config *cfg = dev->config->config_info;
+	const struct dht_config *cfg = dev->config_info;
 
 	drv_data->gpio = device_get_binding(cfg->ctrl);
 	if (drv_data->gpio == NULL) {

--- a/drivers/sensor/fxas21002/fxas21002.c
+++ b/drivers/sensor/fxas21002/fxas21002.c
@@ -20,7 +20,7 @@ static const u32_t sample_period[] = {
 
 static int fxas21002_sample_fetch(struct device *dev, enum sensor_channel chan)
 {
-	const struct fxas21002_config *config = dev->config->config_info;
+	const struct fxas21002_config *config = dev->config_info;
 	struct fxas21002_data *data = dev->driver_data;
 	u8_t buffer[FXAS21002_MAX_NUM_BYTES];
 	s16_t *raw;
@@ -73,7 +73,7 @@ static void fxas21002_convert(struct sensor_value *val, s16_t raw,
 static int fxas21002_channel_get(struct device *dev, enum sensor_channel chan,
 				 struct sensor_value *val)
 {
-	const struct fxas21002_config *config = dev->config->config_info;
+	const struct fxas21002_config *config = dev->config_info;
 	struct fxas21002_data *data = dev->driver_data;
 	int start_channel;
 	int num_channels;
@@ -132,7 +132,7 @@ static int fxas21002_channel_get(struct device *dev, enum sensor_channel chan,
 
 int fxas21002_get_power(struct device *dev, enum fxas21002_power *power)
 {
-	const struct fxas21002_config *config = dev->config->config_info;
+	const struct fxas21002_config *config = dev->config_info;
 	struct fxas21002_data *data = dev->driver_data;
 	u8_t val = *power;
 
@@ -150,7 +150,7 @@ int fxas21002_get_power(struct device *dev, enum fxas21002_power *power)
 
 int fxas21002_set_power(struct device *dev, enum fxas21002_power power)
 {
-	const struct fxas21002_config *config = dev->config->config_info;
+	const struct fxas21002_config *config = dev->config_info;
 	struct fxas21002_data *data = dev->driver_data;
 
 	return i2c_reg_update_byte(data->i2c, config->i2c_address,
@@ -186,7 +186,7 @@ u32_t fxas21002_get_transition_time(enum fxas21002_power start,
 
 static int fxas21002_init(struct device *dev)
 {
-	const struct fxas21002_config *config = dev->config->config_info;
+	const struct fxas21002_config *config = dev->config_info;
 	struct fxas21002_data *data = dev->driver_data;
 	u32_t transition_time;
 	u8_t whoami;

--- a/drivers/sensor/fxas21002/fxas21002_trigger.c
+++ b/drivers/sensor/fxas21002/fxas21002_trigger.c
@@ -50,7 +50,7 @@ static int fxas21002_handle_drdy_int(struct device *dev)
 static void fxas21002_handle_int(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct fxas21002_config *config = dev->config->config_info;
+	const struct fxas21002_config *config = dev->config_info;
 	struct fxas21002_data *data = dev->driver_data;
 	u8_t int_source;
 
@@ -103,7 +103,7 @@ int fxas21002_trigger_set(struct device *dev,
 			 const struct sensor_trigger *trig,
 			 sensor_trigger_handler_t handler)
 {
-	const struct fxas21002_config *config = dev->config->config_info;
+	const struct fxas21002_config *config = dev->config_info;
 	struct fxas21002_data *data = dev->driver_data;
 	enum fxas21002_power power = FXAS21002_POWER_STANDBY;
 	u32_t transition_time;
@@ -171,7 +171,7 @@ exit:
 
 int fxas21002_trigger_init(struct device *dev)
 {
-	const struct fxas21002_config *config = dev->config->config_info;
+	const struct fxas21002_config *config = dev->config_info;
 	struct fxas21002_data *data = dev->driver_data;
 	u8_t ctrl_reg2;
 

--- a/drivers/sensor/fxos8700/fxos8700.c
+++ b/drivers/sensor/fxos8700/fxos8700.c
@@ -17,7 +17,7 @@ LOG_MODULE_REGISTER(FXOS8700, CONFIG_SENSOR_LOG_LEVEL);
 
 int fxos8700_set_odr(struct device *dev, const struct sensor_value *val)
 {
-	const struct fxos8700_config *config = dev->config->config_info;
+	const struct fxos8700_config *config = dev->config_info;
 	struct fxos8700_data *data = dev->driver_data;
 	s32_t dr = val->val1;
 
@@ -75,7 +75,7 @@ static int fxos8700_set_mt_ths(struct device *dev,
 			       const struct sensor_value *val)
 {
 #ifdef CONFIG_FXOS8700_MOTION
-	const struct fxos8700_config *config = dev->config->config_info;
+	const struct fxos8700_config *config = dev->config_info;
 	struct fxos8700_data *data = dev->driver_data;
 	u64_t micro_ms2 = abs(val->val1 * 1000000LL + val->val2);
 	u64_t ths = micro_ms2 / FXOS8700_FF_MT_THS_SCALE;
@@ -117,7 +117,7 @@ static int fxos8700_attr_set(struct device *dev,
 
 static int fxos8700_sample_fetch(struct device *dev, enum sensor_channel chan)
 {
-	const struct fxos8700_config *config = dev->config->config_info;
+	const struct fxos8700_config *config = dev->config_info;
 	struct fxos8700_data *data = dev->driver_data;
 	u8_t buffer[FXOS8700_MAX_NUM_BYTES];
 	u8_t num_bytes;
@@ -234,7 +234,7 @@ static void fxos8700_temp_convert(struct sensor_value *val, s8_t raw)
 static int fxos8700_channel_get(struct device *dev, enum sensor_channel chan,
 				struct sensor_value *val)
 {
-	const struct fxos8700_config *config = dev->config->config_info;
+	const struct fxos8700_config *config = dev->config_info;
 	struct fxos8700_data *data = dev->driver_data;
 	int start_channel;
 	int num_channels;
@@ -341,7 +341,7 @@ static int fxos8700_channel_get(struct device *dev, enum sensor_channel chan,
 
 int fxos8700_get_power(struct device *dev, enum fxos8700_power *power)
 {
-	const struct fxos8700_config *config = dev->config->config_info;
+	const struct fxos8700_config *config = dev->config_info;
 	struct fxos8700_data *data = dev->driver_data;
 	u8_t val = *power;
 
@@ -359,7 +359,7 @@ int fxos8700_get_power(struct device *dev, enum fxos8700_power *power)
 
 int fxos8700_set_power(struct device *dev, enum fxos8700_power power)
 {
-	const struct fxos8700_config *config = dev->config->config_info;
+	const struct fxos8700_config *config = dev->config_info;
 	struct fxos8700_data *data = dev->driver_data;
 
 	return i2c_reg_update_byte(data->i2c, config->i2c_address,
@@ -370,7 +370,7 @@ int fxos8700_set_power(struct device *dev, enum fxos8700_power power)
 
 static int fxos8700_init(struct device *dev)
 {
-	const struct fxos8700_config *config = dev->config->config_info;
+	const struct fxos8700_config *config = dev->config_info;
 	struct fxos8700_data *data = dev->driver_data;
 	struct sensor_value odr = {.val1 = 6, .val2 = 250000};
 	struct device *rst;

--- a/drivers/sensor/fxos8700/fxos8700_trigger.c
+++ b/drivers/sensor/fxos8700/fxos8700_trigger.c
@@ -50,7 +50,7 @@ static int fxos8700_handle_drdy_int(struct device *dev)
 #ifdef CONFIG_FXOS8700_PULSE
 static int fxos8700_handle_pulse_int(struct device *dev)
 {
-	const struct fxos8700_config *config = dev->config->config_info;
+	const struct fxos8700_config *config = dev->config_info;
 	struct fxos8700_data *data = dev->driver_data;
 	sensor_trigger_handler_t handler = NULL;
 	u8_t pulse_source;
@@ -88,7 +88,7 @@ static int fxos8700_handle_pulse_int(struct device *dev)
 #ifdef CONFIG_FXOS8700_MOTION
 static int fxos8700_handle_motion_int(struct device *dev)
 {
-	const struct fxos8700_config *config = dev->config->config_info;
+	const struct fxos8700_config *config = dev->config_info;
 	struct fxos8700_data *data = dev->driver_data;
 	sensor_trigger_handler_t handler = data->motion_handler;
 	u8_t motion_source;
@@ -119,7 +119,7 @@ static int fxos8700_handle_motion_int(struct device *dev)
 static void fxos8700_handle_int(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct fxos8700_config *config = dev->config->config_info;
+	const struct fxos8700_config *config = dev->config_info;
 	struct fxos8700_data *data = dev->driver_data;
 	u8_t int_source;
 
@@ -182,7 +182,7 @@ int fxos8700_trigger_set(struct device *dev,
 			 const struct sensor_trigger *trig,
 			 sensor_trigger_handler_t handler)
 {
-	const struct fxos8700_config *config = dev->config->config_info;
+	const struct fxos8700_config *config = dev->config_info;
 	struct fxos8700_data *data = dev->driver_data;
 	enum fxos8700_power power = FXOS8700_POWER_STANDBY;
 	u8_t mask;
@@ -260,7 +260,7 @@ exit:
 #ifdef CONFIG_FXOS8700_PULSE
 static int fxos8700_pulse_init(struct device *dev)
 {
-	const struct fxos8700_config *config = dev->config->config_info;
+	const struct fxos8700_config *config = dev->config_info;
 	struct fxos8700_data *data = dev->driver_data;
 
 	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
@@ -305,7 +305,7 @@ static int fxos8700_pulse_init(struct device *dev)
 #ifdef CONFIG_FXOS8700_MOTION
 static int fxos8700_motion_init(struct device *dev)
 {
-	const struct fxos8700_config *config = dev->config->config_info;
+	const struct fxos8700_config *config = dev->config_info;
 	struct fxos8700_data *data = dev->driver_data;
 
 	/* Set Mode 4, Motion detection with ELE = 1, OAE = 1 */
@@ -333,7 +333,7 @@ static int fxos8700_motion_init(struct device *dev)
 
 int fxos8700_trigger_init(struct device *dev)
 {
-	const struct fxos8700_config *config = dev->config->config_info;
+	const struct fxos8700_config *config = dev->config_info;
 	struct fxos8700_data *data = dev->driver_data;
 	u8_t ctrl_reg5;
 

--- a/drivers/sensor/grove/light_sensor.c
+++ b/drivers/sensor/grove/light_sensor.c
@@ -84,7 +84,7 @@ static const struct sensor_driver_api gls_api = {
 static int gls_init(struct device *dev)
 {
 	struct gls_data *drv_data = dev->driver_data;
-	const struct gls_config *cfg = dev->config->config_info;
+	const struct gls_config *cfg = dev->config_info;
 
 	drv_data->adc = device_get_binding(cfg->adc_label);
 

--- a/drivers/sensor/grove/temperature_sensor.c
+++ b/drivers/sensor/grove/temperature_sensor.c
@@ -59,7 +59,7 @@ static int gts_channel_get(struct device *dev,
 			   struct sensor_value *val)
 {
 	struct gts_data *drv_data = dev->driver_data;
-	const struct gts_config *cfg = dev->config->config_info;
+	const struct gts_config *cfg = dev->config_info;
 	double dval;
 
 	/*
@@ -87,7 +87,7 @@ static const struct sensor_driver_api gts_api = {
 static int gts_init(struct device *dev)
 {
 	struct gts_data *drv_data = dev->driver_data;
-	const struct gts_config *cfg = dev->config->config_info;
+	const struct gts_config *cfg = dev->config_info;
 
 	drv_data->adc = device_get_binding(cfg->adc_label);
 	if (drv_data->adc == NULL) {

--- a/drivers/sensor/hts221/hts221.c
+++ b/drivers/sensor/hts221/hts221.c
@@ -61,7 +61,7 @@ static int hts221_channel_get(struct device *dev,
 static int hts221_sample_fetch(struct device *dev, enum sensor_channel chan)
 {
 	struct hts221_data *data = dev->driver_data;
-	const struct hts221_config *cfg = dev->config->config_info;
+	const struct hts221_config *cfg = dev->config_info;
 	u8_t buf[4];
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
@@ -82,7 +82,7 @@ static int hts221_sample_fetch(struct device *dev, enum sensor_channel chan)
 static int hts221_read_conversion_data(struct device *dev)
 {
 	struct hts221_data *data = dev->driver_data;
-	const struct hts221_config *cfg = dev->config->config_info;
+	const struct hts221_config *cfg = dev->config_info;
 	u8_t buf[16];
 
 	if (i2c_burst_read(data->i2c, cfg->i2c_addr,
@@ -114,7 +114,7 @@ static const struct sensor_driver_api hts221_driver_api = {
 
 int hts221_init(struct device *dev)
 {
-	const struct hts221_config *cfg = dev->config->config_info;
+	const struct hts221_config *cfg = dev->config_info;
 	struct hts221_data *data = dev->driver_data;
 	u8_t id, idx;
 

--- a/drivers/sensor/hts221/hts221_trigger.c
+++ b/drivers/sensor/hts221/hts221_trigger.c
@@ -19,7 +19,7 @@ static inline void setup_drdy(struct device *dev,
 			      bool enable)
 {
 	struct hts221_data *data = dev->driver_data;
-	const struct hts221_config *cfg = dev->config->config_info;
+	const struct hts221_config *cfg = dev->config_info;
 	unsigned int flags = enable
 		? GPIO_INT_EDGE_TO_ACTIVE
 		: GPIO_INT_DISABLE;
@@ -58,7 +58,7 @@ int hts221_trigger_set(struct device *dev,
 		       sensor_trigger_handler_t handler)
 {
 	struct hts221_data *data = dev->driver_data;
-	const struct hts221_config *cfg = dev->config->config_info;
+	const struct hts221_config *cfg = dev->config_info;
 
 	__ASSERT_NO_MSG(trig->type == SENSOR_TRIG_DATA_READY);
 
@@ -122,7 +122,7 @@ static void hts221_work_cb(struct k_work *work)
 int hts221_init_interrupt(struct device *dev)
 {
 	struct hts221_data *data = dev->driver_data;
-	const struct hts221_config *cfg = dev->config->config_info;
+	const struct hts221_config *cfg = dev->config_info;
 
 	data->dev = dev;
 

--- a/drivers/sensor/iis2dlpc/iis2dlpc.c
+++ b/drivers/sensor/iis2dlpc/iis2dlpc.c
@@ -35,7 +35,7 @@ static int iis2dlpc_set_range(struct device *dev, u16_t range)
 {
 	int err;
 	struct iis2dlpc_data *iis2dlpc = dev->driver_data;
-	const struct iis2dlpc_device_config *cfg = dev->config->config_info;
+	const struct iis2dlpc_device_config *cfg = dev->config_info;
 	u8_t shift_gain = 0U;
 	u8_t fs = IIS2DLPC_FS_TO_REG(range);
 
@@ -178,7 +178,7 @@ static int iis2dlpc_attr_set(struct device *dev, enum sensor_channel chan,
 static int iis2dlpc_sample_fetch(struct device *dev, enum sensor_channel chan)
 {
 	struct iis2dlpc_data *iis2dlpc = dev->driver_data;
-	const struct iis2dlpc_device_config *cfg = dev->config->config_info;
+	const struct iis2dlpc_device_config *cfg = dev->config_info;
 	u8_t shift;
 	union axis3bit16_t buf;
 
@@ -214,7 +214,7 @@ static const struct sensor_driver_api iis2dlpc_driver_api = {
 static int iis2dlpc_init_interface(struct device *dev)
 {
 	struct iis2dlpc_data *iis2dlpc = dev->driver_data;
-	const struct iis2dlpc_device_config *cfg = dev->config->config_info;
+	const struct iis2dlpc_device_config *cfg = dev->config_info;
 
 	iis2dlpc->bus = device_get_binding(cfg->bus_name);
 	if (!iis2dlpc->bus) {
@@ -256,7 +256,7 @@ static int iis2dlpc_set_power_mode(struct iis2dlpc_data *iis2dlpc,
 static int iis2dlpc_init(struct device *dev)
 {
 	struct iis2dlpc_data *iis2dlpc = dev->driver_data;
-	const struct iis2dlpc_device_config *cfg = dev->config->config_info;
+	const struct iis2dlpc_device_config *cfg = dev->config_info;
 	u8_t wai;
 
 	if (iis2dlpc_init_interface(dev)) {

--- a/drivers/sensor/iis2dlpc/iis2dlpc_trigger.c
+++ b/drivers/sensor/iis2dlpc/iis2dlpc_trigger.c
@@ -25,7 +25,7 @@ LOG_MODULE_DECLARE(IIS2DLPC, CONFIG_SENSOR_LOG_LEVEL);
 static int iis2dlpc_enable_int(struct device *dev,
 			       enum sensor_trigger_type type, int enable)
 {
-	const struct iis2dlpc_device_config *cfg = dev->config->config_info;
+	const struct iis2dlpc_device_config *cfg = dev->config_info;
 	struct iis2dlpc_data *iis2dlpc = dev->driver_data;
 	iis2dlpc_reg_t int_route;
 
@@ -165,7 +165,7 @@ static void iis2dlpc_handle_interrupt(void *arg)
 {
 	struct device *dev = (struct device *)arg;
 	struct iis2dlpc_data *iis2dlpc = dev->driver_data;
-	const struct iis2dlpc_device_config *cfg = dev->config->config_info;
+	const struct iis2dlpc_device_config *cfg = dev->config_info;
 	iis2dlpc_all_sources_t sources;
 
 	iis2dlpc_all_sources_get(iis2dlpc->ctx, &sources);
@@ -234,7 +234,7 @@ static void iis2dlpc_work_cb(struct k_work *work)
 int iis2dlpc_init_interrupt(struct device *dev)
 {
 	struct iis2dlpc_data *iis2dlpc = dev->driver_data;
-	const struct iis2dlpc_device_config *cfg = dev->config->config_info;
+	const struct iis2dlpc_device_config *cfg = dev->config_info;
 	int ret;
 
 	/* setup data ready gpio interrupt (INT1 or INT2) */

--- a/drivers/sensor/iis2mdc/iis2mdc.c
+++ b/drivers/sensor/iis2mdc/iis2mdc.c
@@ -243,7 +243,7 @@ static const struct sensor_driver_api iis2mdc_driver_api = {
 static int iis2mdc_init_interface(struct device *dev)
 {
 	const struct iis2mdc_config *const config =
-						dev->config->config_info;
+						dev->config_info;
 	struct iis2mdc_data *iis2mdc = dev->driver_data;
 
 	iis2mdc->bus = device_get_binding(config->master_dev_name);

--- a/drivers/sensor/iis2mdc/iis2mdc_i2c.c
+++ b/drivers/sensor/iis2mdc/iis2mdc_i2c.c
@@ -25,7 +25,7 @@ static int iis2mdc_i2c_read(struct device *dev, u8_t reg_addr,
 				 u8_t *value, u16_t len)
 {
 	struct iis2mdc_data *data = dev->driver_data;
-	const struct iis2mdc_config *cfg = dev->config->config_info;
+	const struct iis2mdc_config *cfg = dev->config_info;
 
 	return i2c_burst_read(data->bus, cfg->i2c_slv_addr,
 			      reg_addr, value, len);
@@ -35,7 +35,7 @@ static int iis2mdc_i2c_write(struct device *dev, u8_t reg_addr,
 				  u8_t *value, u16_t len)
 {
 	struct iis2mdc_data *data = dev->driver_data;
-	const struct iis2mdc_config *cfg = dev->config->config_info;
+	const struct iis2mdc_config *cfg = dev->config_info;
 
 	return i2c_burst_write(data->bus, cfg->i2c_slv_addr,
 			       reg_addr, value, len);

--- a/drivers/sensor/iis2mdc/iis2mdc_spi.c
+++ b/drivers/sensor/iis2mdc/iis2mdc_spi.c
@@ -25,7 +25,7 @@ static int iis2mdc_spi_read(struct device *dev, u8_t reg_addr,
 			    u8_t *value, u8_t len)
 {
 	struct iis2mdc_data *data = dev->driver_data;
-	const struct iis2mdc_config *cfg = dev->config->config_info;
+	const struct iis2mdc_config *cfg = dev->config_info;
 	const struct spi_config *spi_cfg = &cfg->spi_conf;
 	u8_t buffer_tx[2] = { reg_addr | IIS2MDC_SPI_READ, 0 };
 	const struct spi_buf tx_buf = {
@@ -67,7 +67,7 @@ static int iis2mdc_spi_write(struct device *dev, u8_t reg_addr,
 			     u8_t *value, u8_t len)
 {
 	struct iis2mdc_data *data = dev->driver_data;
-	const struct iis2mdc_config *cfg = dev->config->config_info;
+	const struct iis2mdc_config *cfg = dev->config_info;
 	const struct spi_config *spi_cfg = &cfg->spi_conf;
 	u8_t buffer_tx[1] = { reg_addr & ~IIS2MDC_SPI_READ };
 	const struct spi_buf tx_buf[2] = {
@@ -108,7 +108,7 @@ int iis2mdc_spi_init(struct device *dev)
 	data->ctx->handle = dev;
 
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	const struct iis2mdc_config *cfg = dev->config->config_info;
+	const struct iis2mdc_config *cfg = dev->config_info;
 
 	/* handle SPI CS thru GPIO if it is the case */
 	data->cs_ctrl.gpio_dev = device_get_binding(cfg->gpio_cs_port);

--- a/drivers/sensor/iis2mdc/iis2mdc_trigger.c
+++ b/drivers/sensor/iis2mdc/iis2mdc_trigger.c
@@ -55,7 +55,7 @@ static void iis2mdc_handle_interrupt(void *arg)
 	struct device *dev = arg;
 	struct iis2mdc_data *iis2mdc = dev->driver_data;
 	const struct iis2mdc_config *const config =
-						dev->config->config_info;
+						dev->config_info;
 	struct sensor_trigger drdy_trigger = {
 		.type = SENSOR_TRIG_DATA_READY,
 	};
@@ -73,7 +73,7 @@ static void iis2mdc_gpio_callback(struct device *dev,
 {
 	struct iis2mdc_data *iis2mdc =
 		CONTAINER_OF(cb, struct iis2mdc_data, gpio_cb);
-	const struct iis2mdc_config *const config = dev->config->config_info;
+	const struct iis2mdc_config *const config = dev->config_info;
 
 	ARG_UNUSED(pins);
 
@@ -114,7 +114,7 @@ static void iis2mdc_work_cb(struct k_work *work)
 int iis2mdc_init_interrupt(struct device *dev)
 {
 	struct iis2mdc_data *iis2mdc = dev->driver_data;
-	const struct iis2mdc_config *const config = dev->config->config_info;
+	const struct iis2mdc_config *const config = dev->config_info;
 
 	/* setup data ready gpio interrupt */
 	iis2mdc->gpio = device_get_binding(config->drdy_port);

--- a/drivers/sensor/iis3dhhc/iis3dhhc.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc.c
@@ -191,7 +191,7 @@ static int iis3dhhc_init_chip(struct device *dev)
 
 static int iis3dhhc_init(struct device *dev)
 {
-	const struct iis3dhhc_config * const config = dev->config->config_info;
+	const struct iis3dhhc_config * const config = dev->config_info;
 	struct iis3dhhc_data *data = dev->driver_data;
 
 	data->bus = device_get_binding(config->master_dev_name);

--- a/drivers/sensor/iis3dhhc/iis3dhhc_trigger.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc_trigger.c
@@ -69,7 +69,7 @@ static void iis3dhhc_handle_interrupt(void *arg)
 	struct sensor_trigger drdy_trigger = {
 		.type = SENSOR_TRIG_DATA_READY,
 	};
-	const struct iis3dhhc_config *cfg = dev->config->config_info;
+	const struct iis3dhhc_config *cfg = dev->config_info;
 
 	if (iis3dhhc->handler_drdy != NULL) {
 		iis3dhhc->handler_drdy(dev, &drdy_trigger);
@@ -84,7 +84,7 @@ static void iis3dhhc_gpio_callback(struct device *dev,
 {
 	struct iis3dhhc_data *iis3dhhc =
 		CONTAINER_OF(cb, struct iis3dhhc_data, gpio_cb);
-	const struct iis3dhhc_config *cfg = dev->config->config_info;
+	const struct iis3dhhc_config *cfg = dev->config_info;
 
 	ARG_UNUSED(pins);
 
@@ -126,7 +126,7 @@ static void iis3dhhc_work_cb(struct k_work *work)
 int iis3dhhc_init_interrupt(struct device *dev)
 {
 	struct iis3dhhc_data *iis3dhhc = dev->driver_data;
-	const struct iis3dhhc_config *cfg = dev->config->config_info;
+	const struct iis3dhhc_config *cfg = dev->config_info;
 	int ret;
 
 	/* setup data ready gpio interrupt (INT1 or INT2) */

--- a/drivers/sensor/ism330dhcx/ism330dhcx.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx.c
@@ -804,7 +804,7 @@ static const struct ism330dhcx_config ism330dhcx_config = {
 
 static int ism330dhcx_init(struct device *dev)
 {
-	const struct ism330dhcx_config * const config = dev->config->config_info;
+	const struct ism330dhcx_config * const config = dev->config_info;
 	struct ism330dhcx_data *data = dev->driver_data;
 
 	data->bus = device_get_binding(config->bus_name);

--- a/drivers/sensor/ism330dhcx/ism330dhcx_i2c.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx_i2c.c
@@ -24,7 +24,7 @@ static int ism330dhcx_i2c_read(struct device *dev, u8_t reg_addr,
 			    u8_t *value, u8_t len)
 {
 	struct ism330dhcx_data *data = dev->driver_data;
-	const struct ism330dhcx_config *cfg = dev->config->config_info;
+	const struct ism330dhcx_config *cfg = dev->config_info;
 
 	return i2c_burst_read(data->bus, cfg->i2c_slv_addr,
 			      reg_addr, value, len);
@@ -34,7 +34,7 @@ static int ism330dhcx_i2c_write(struct device *dev, u8_t reg_addr,
 			     u8_t *value, u8_t len)
 {
 	struct ism330dhcx_data *data = dev->driver_data;
-	const struct ism330dhcx_config *cfg = dev->config->config_info;
+	const struct ism330dhcx_config *cfg = dev->config_info;
 
 	return i2c_burst_write(data->bus, cfg->i2c_slv_addr,
 			       reg_addr, value, len);

--- a/drivers/sensor/ism330dhcx/ism330dhcx_spi.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx_spi.c
@@ -24,7 +24,7 @@ static int ism330dhcx_spi_read(struct device *dev, u8_t reg_addr,
 			    u8_t *value, u8_t len)
 {
 	struct ism330dhcx_data *data = dev->driver_data;
-	const struct ism330dhcx_config *cfg = dev->config->config_info;
+	const struct ism330dhcx_config *cfg = dev->config_info;
 	const struct spi_config *spi_cfg = &cfg->spi_conf;
 	u8_t buffer_tx[2] = { reg_addr | ISM330DHCX_SPI_READ, 0 };
 	const struct spi_buf tx_buf = {
@@ -66,7 +66,7 @@ static int ism330dhcx_spi_write(struct device *dev, u8_t reg_addr,
 			     u8_t *value, u8_t len)
 {
 	struct ism330dhcx_data *data = dev->driver_data;
-	const struct ism330dhcx_config *cfg = dev->config->config_info;
+	const struct ism330dhcx_config *cfg = dev->config_info;
 	const struct spi_config *spi_cfg = &cfg->spi_conf;
 	u8_t buffer_tx[1] = { reg_addr & ~ISM330DHCX_SPI_READ };
 	const struct spi_buf tx_buf[2] = {
@@ -107,7 +107,7 @@ int ism330dhcx_spi_init(struct device *dev)
 	data->ctx->handle = dev;
 
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	const struct ism330dhcx_config *cfg = dev->config->config_info;
+	const struct ism330dhcx_config *cfg = dev->config_info;
 
 	/* handle SPI CS thru GPIO if it is the case */
 	data->cs_ctrl.gpio_dev = device_get_binding(cfg->gpio_cs_port);

--- a/drivers/sensor/ism330dhcx/ism330dhcx_trigger.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx_trigger.c
@@ -25,7 +25,7 @@ LOG_MODULE_DECLARE(ISM330DHCX, CONFIG_SENSOR_LOG_LEVEL);
  */
 static int ism330dhcx_enable_t_int(struct device *dev, int enable)
 {
-	const struct ism330dhcx_config *cfg = dev->config->config_info;
+	const struct ism330dhcx_config *cfg = dev->config_info;
 	struct ism330dhcx_data *ism330dhcx = dev->driver_data;
 	ism330dhcx_pin_int2_route_t int2_route;
 
@@ -53,7 +53,7 @@ static int ism330dhcx_enable_t_int(struct device *dev, int enable)
  */
 static int ism330dhcx_enable_xl_int(struct device *dev, int enable)
 {
-	const struct ism330dhcx_config *cfg = dev->config->config_info;
+	const struct ism330dhcx_config *cfg = dev->config_info;
 	struct ism330dhcx_data *ism330dhcx = dev->driver_data;
 
 	if (enable) {
@@ -89,7 +89,7 @@ static int ism330dhcx_enable_xl_int(struct device *dev, int enable)
  */
 static int ism330dhcx_enable_g_int(struct device *dev, int enable)
 {
-	const struct ism330dhcx_config *cfg = dev->config->config_info;
+	const struct ism330dhcx_config *cfg = dev->config_info;
 	struct ism330dhcx_data *ism330dhcx = dev->driver_data;
 
 	if (enable) {
@@ -168,7 +168,7 @@ static void ism330dhcx_handle_interrupt(void *arg)
 	struct sensor_trigger drdy_trigger = {
 		.type = SENSOR_TRIG_DATA_READY,
 	};
-	const struct ism330dhcx_config *cfg = dev->config->config_info;
+	const struct ism330dhcx_config *cfg = dev->config_info;
 	ism330dhcx_status_reg_t status;
 
 	while (1) {
@@ -209,7 +209,7 @@ static void ism330dhcx_gpio_callback(struct device *dev,
 {
 	struct ism330dhcx_data *ism330dhcx =
 		CONTAINER_OF(cb, struct ism330dhcx_data, gpio_cb);
-	const struct ism330dhcx_config *cfg = dev->config->config_info;
+	const struct ism330dhcx_config *cfg = dev->config_info;
 
 	ARG_UNUSED(pins);
 
@@ -251,7 +251,7 @@ static void ism330dhcx_work_cb(struct k_work *work)
 int ism330dhcx_init_interrupt(struct device *dev)
 {
 	struct ism330dhcx_data *ism330dhcx = dev->driver_data;
-	const struct ism330dhcx_config *cfg = dev->config->config_info;
+	const struct ism330dhcx_config *cfg = dev->config_info;
 	int ret;
 
 	/* setup data ready gpio interrupt (INT1 or INT2) */

--- a/drivers/sensor/lis2dh/lis2dh.c
+++ b/drivers/sensor/lis2dh/lis2dh.c
@@ -269,7 +269,7 @@ static const struct sensor_driver_api lis2dh_driver_api = {
 int lis2dh_init(struct device *dev)
 {
 	struct lis2dh_data *lis2dh = dev->driver_data;
-	const struct lis2dh_config *cfg = dev->config->config_info;
+	const struct lis2dh_config *cfg = dev->config_info;
 	int status;
 	u8_t id;
 	u8_t raw[6];

--- a/drivers/sensor/lis2dh/lis2dh_i2c.c
+++ b/drivers/sensor/lis2dh/lis2dh_i2c.c
@@ -24,7 +24,7 @@ static int lis2dh_i2c_read_data(struct device *dev, u8_t reg_addr,
 				 u8_t *value, u8_t len)
 {
 	struct lis2dh_data *data = dev->driver_data;
-	const struct lis2dh_config *cfg = dev->config->config_info;
+	const struct lis2dh_config *cfg = dev->config_info;
 
 	return i2c_burst_read(data->bus, cfg->i2c_slv_addr,
 			      reg_addr | LIS2DH_AUTOINCREMENT_ADDR,
@@ -35,7 +35,7 @@ static int lis2dh_i2c_write_data(struct device *dev, u8_t reg_addr,
 				  u8_t *value, u8_t len)
 {
 	struct lis2dh_data *data = dev->driver_data;
-	const struct lis2dh_config *cfg = dev->config->config_info;
+	const struct lis2dh_config *cfg = dev->config_info;
 
 	return i2c_burst_write(data->bus, cfg->i2c_slv_addr,
 			       reg_addr | LIS2DH_AUTOINCREMENT_ADDR,
@@ -46,7 +46,7 @@ static int lis2dh_i2c_read_reg(struct device *dev, u8_t reg_addr,
 				u8_t *value)
 {
 	struct lis2dh_data *data = dev->driver_data;
-	const struct lis2dh_config *cfg = dev->config->config_info;
+	const struct lis2dh_config *cfg = dev->config_info;
 
 	return i2c_reg_read_byte(data->bus,
 				 cfg->i2c_slv_addr,
@@ -57,7 +57,7 @@ static int lis2dh_i2c_write_reg(struct device *dev, u8_t reg_addr,
 				u8_t value)
 {
 	struct lis2dh_data *data = dev->driver_data;
-	const struct lis2dh_config *cfg = dev->config->config_info;
+	const struct lis2dh_config *cfg = dev->config_info;
 
 	return i2c_reg_write_byte(data->bus,
 				  cfg->i2c_slv_addr,
@@ -68,7 +68,7 @@ static int lis2dh_i2c_update_reg(struct device *dev, u8_t reg_addr,
 				  u8_t mask, u8_t value)
 {
 	struct lis2dh_data *data = dev->driver_data;
-	const struct lis2dh_config *cfg = dev->config->config_info;
+	const struct lis2dh_config *cfg = dev->config_info;
 
 	return i2c_reg_update_byte(data->bus,
 				   cfg->i2c_slv_addr,

--- a/drivers/sensor/lis2dh/lis2dh_spi.c
+++ b/drivers/sensor/lis2dh/lis2dh_spi.c
@@ -22,7 +22,7 @@ static int lis2dh_raw_read(struct device *dev, u8_t reg_addr,
 			    u8_t *value, u8_t len)
 {
 	struct lis2dh_data *data = dev->driver_data;
-	const struct lis2dh_config *cfg = dev->config->config_info;
+	const struct lis2dh_config *cfg = dev->config_info;
 	const struct spi_config *spi_cfg = &cfg->spi_conf;
 	u8_t buffer_tx[2] = { reg_addr | LIS2DH_SPI_READ_BIT, 0 };
 	const struct spi_buf tx_buf = {
@@ -68,7 +68,7 @@ static int lis2dh_raw_write(struct device *dev, u8_t reg_addr,
 			     u8_t *value, u8_t len)
 {
 	struct lis2dh_data *data = dev->driver_data;
-	const struct lis2dh_config *cfg = dev->config->config_info;
+	const struct lis2dh_config *cfg = dev->config_info;
 	const struct spi_config *spi_cfg = &cfg->spi_conf;
 	u8_t buffer_tx[1] = { reg_addr & ~LIS2DH_SPI_READ_BIT };
 	const struct spi_buf tx_buf[2] = {
@@ -154,7 +154,7 @@ int lis2dh_spi_init(struct device *dev)
 	data->hw_tf = &lis2dh_spi_transfer_fn;
 
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	const struct lis2dh_config *cfg = dev->config->config_info;
+	const struct lis2dh_config *cfg = dev->config_info;
 
 	/* handle SPI CS thru GPIO if it is the case */
 	data->cs_ctrl.gpio_dev = device_get_binding(cfg->gpio_cs_port);

--- a/drivers/sensor/lis2ds12/lis2ds12.c
+++ b/drivers/sensor/lis2ds12/lis2ds12.c
@@ -256,7 +256,7 @@ static const struct sensor_driver_api lis2ds12_api_funcs = {
 
 static int lis2ds12_init(struct device *dev)
 {
-	const struct lis2ds12_config * const config = dev->config->config_info;
+	const struct lis2ds12_config * const config = dev->config_info;
 	struct lis2ds12_data *data = dev->driver_data;
 	u8_t chip_id;
 

--- a/drivers/sensor/lis2ds12/lis2ds12_trigger.c
+++ b/drivers/sensor/lis2ds12/lis2ds12_trigger.c
@@ -24,7 +24,7 @@ static void lis2ds12_gpio_callback(struct device *dev,
 {
 	struct lis2ds12_data *data =
 		CONTAINER_OF(cb, struct lis2ds12_data, gpio_cb);
-	const struct lis2ds12_config *cfg = dev->config->config_info;
+	const struct lis2ds12_config *cfg = dev->config_info;
 
 	ARG_UNUSED(pins);
 
@@ -51,7 +51,7 @@ static void lis2ds12_handle_int(void *arg)
 {
 	struct device *dev = arg;
 	struct lis2ds12_data *data = dev->driver_data;
-	const struct lis2ds12_config *cfg = dev->config->config_info;
+	const struct lis2ds12_config *cfg = dev->config_info;
 	u8_t status;
 
 	if (data->hw_tf->read_reg(data, LIS2DS12_REG_STATUS, &status) < 0) {
@@ -120,7 +120,7 @@ static int lis2ds12_init_interrupt(struct device *dev)
 int lis2ds12_trigger_init(struct device *dev)
 {
 	struct lis2ds12_data *data = dev->driver_data;
-	const struct lis2ds12_config *cfg = dev->config->config_info;
+	const struct lis2ds12_config *cfg = dev->config_info;
 
 	/* setup data ready gpio interrupt */
 	data->gpio = device_get_binding(cfg->irq_port);
@@ -165,7 +165,7 @@ int lis2ds12_trigger_set(struct device *dev,
 			sensor_trigger_handler_t handler)
 {
 	struct lis2ds12_data *data = dev->driver_data;
-	const struct lis2ds12_config *cfg = dev->config->config_info;
+	const struct lis2ds12_config *cfg = dev->config_info;
 	u8_t buf[6];
 
 	__ASSERT_NO_MSG(trig->type == SENSOR_TRIG_DATA_READY);

--- a/drivers/sensor/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/lis2dw12/lis2dw12.c
@@ -35,7 +35,7 @@ static int lis2dw12_set_range(struct device *dev, u16_t range)
 {
 	int err;
 	struct lis2dw12_data *lis2dw12 = dev->driver_data;
-	const struct lis2dw12_device_config *cfg = dev->config->config_info;
+	const struct lis2dw12_device_config *cfg = dev->config_info;
 	u8_t shift_gain = 0U;
 	u8_t fs = LIS2DW12_FS_TO_REG(range);
 
@@ -178,7 +178,7 @@ static int lis2dw12_attr_set(struct device *dev, enum sensor_channel chan,
 static int lis2dw12_sample_fetch(struct device *dev, enum sensor_channel chan)
 {
 	struct lis2dw12_data *lis2dw12 = dev->driver_data;
-	const struct lis2dw12_device_config *cfg = dev->config->config_info;
+	const struct lis2dw12_device_config *cfg = dev->config_info;
 	u8_t shift;
 	union axis3bit16_t buf;
 
@@ -214,7 +214,7 @@ static const struct sensor_driver_api lis2dw12_driver_api = {
 static int lis2dw12_init_interface(struct device *dev)
 {
 	struct lis2dw12_data *lis2dw12 = dev->driver_data;
-	const struct lis2dw12_device_config *cfg = dev->config->config_info;
+	const struct lis2dw12_device_config *cfg = dev->config_info;
 
 	lis2dw12->bus = device_get_binding(cfg->bus_name);
 	if (!lis2dw12->bus) {
@@ -256,7 +256,7 @@ static int lis2dw12_set_power_mode(struct lis2dw12_data *lis2dw12,
 static int lis2dw12_init(struct device *dev)
 {
 	struct lis2dw12_data *lis2dw12 = dev->driver_data;
-	const struct lis2dw12_device_config *cfg = dev->config->config_info;
+	const struct lis2dw12_device_config *cfg = dev->config_info;
 	u8_t wai;
 
 	if (lis2dw12_init_interface(dev)) {

--- a/drivers/sensor/lis2dw12/lis2dw12_trigger.c
+++ b/drivers/sensor/lis2dw12/lis2dw12_trigger.c
@@ -25,7 +25,7 @@ LOG_MODULE_DECLARE(LIS2DW12, CONFIG_SENSOR_LOG_LEVEL);
 static int lis2dw12_enable_int(struct device *dev,
 			       enum sensor_trigger_type type, int enable)
 {
-	const struct lis2dw12_device_config *cfg = dev->config->config_info;
+	const struct lis2dw12_device_config *cfg = dev->config_info;
 	struct lis2dw12_data *lis2dw12 = dev->driver_data;
 	lis2dw12_reg_t int_route;
 
@@ -168,7 +168,7 @@ static void lis2dw12_handle_interrupt(void *arg)
 {
 	struct device *dev = (struct device *)arg;
 	struct lis2dw12_data *lis2dw12 = dev->driver_data;
-	const struct lis2dw12_device_config *cfg = dev->config->config_info;
+	const struct lis2dw12_device_config *cfg = dev->config_info;
 	lis2dw12_all_sources_t sources;
 
 	lis2dw12_all_sources_get(lis2dw12->ctx, &sources);
@@ -237,7 +237,7 @@ static void lis2dw12_work_cb(struct k_work *work)
 int lis2dw12_init_interrupt(struct device *dev)
 {
 	struct lis2dw12_data *lis2dw12 = dev->driver_data;
-	const struct lis2dw12_device_config *cfg = dev->config->config_info;
+	const struct lis2dw12_device_config *cfg = dev->config_info;
 	int ret;
 
 	/* setup data ready gpio interrupt (INT1 or INT2) */

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -243,7 +243,7 @@ static const struct sensor_driver_api lis2mdl_driver_api = {
 static int lis2mdl_init_interface(struct device *dev)
 {
 	const struct lis2mdl_config *const config =
-						dev->config->config_info;
+						dev->config_info;
 	struct lis2mdl_data *lis2mdl = dev->driver_data;
 
 	lis2mdl->bus = device_get_binding(config->master_dev_name);

--- a/drivers/sensor/lis2mdl/lis2mdl_i2c.c
+++ b/drivers/sensor/lis2mdl/lis2mdl_i2c.c
@@ -25,7 +25,7 @@ static int lis2mdl_i2c_read(struct device *dev, u8_t reg_addr,
 				 u8_t *value, u16_t len)
 {
 	struct lis2mdl_data *data = dev->driver_data;
-	const struct lis2mdl_config *cfg = dev->config->config_info;
+	const struct lis2mdl_config *cfg = dev->config_info;
 
 	return i2c_burst_read(data->bus, cfg->i2c_slv_addr,
 			      reg_addr, value, len);
@@ -35,7 +35,7 @@ static int lis2mdl_i2c_write(struct device *dev, u8_t reg_addr,
 				  u8_t *value, u16_t len)
 {
 	struct lis2mdl_data *data = dev->driver_data;
-	const struct lis2mdl_config *cfg = dev->config->config_info;
+	const struct lis2mdl_config *cfg = dev->config_info;
 
 	return i2c_burst_write(data->bus, cfg->i2c_slv_addr,
 			       reg_addr, value, len);

--- a/drivers/sensor/lis2mdl/lis2mdl_spi.c
+++ b/drivers/sensor/lis2mdl/lis2mdl_spi.c
@@ -25,7 +25,7 @@ static int lis2mdl_spi_read(struct device *dev, u8_t reg_addr,
 			    u8_t *value, u8_t len)
 {
 	struct lis2mdl_data *data = dev->driver_data;
-	const struct lis2mdl_config *cfg = dev->config->config_info;
+	const struct lis2mdl_config *cfg = dev->config_info;
 	const struct spi_config *spi_cfg = &cfg->spi_conf;
 	u8_t buffer_tx[2] = { reg_addr | LIS2MDL_SPI_READ, 0 };
 	const struct spi_buf tx_buf = {
@@ -67,7 +67,7 @@ static int lis2mdl_spi_write(struct device *dev, u8_t reg_addr,
 			     u8_t *value, u8_t len)
 {
 	struct lis2mdl_data *data = dev->driver_data;
-	const struct lis2mdl_config *cfg = dev->config->config_info;
+	const struct lis2mdl_config *cfg = dev->config_info;
 	const struct spi_config *spi_cfg = &cfg->spi_conf;
 	u8_t buffer_tx[1] = { reg_addr & ~LIS2MDL_SPI_READ };
 	const struct spi_buf tx_buf[2] = {
@@ -108,7 +108,7 @@ int lis2mdl_spi_init(struct device *dev)
 	data->ctx->handle = dev;
 
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	const struct lis2mdl_config *cfg = dev->config->config_info;
+	const struct lis2mdl_config *cfg = dev->config_info;
 
 	/* handle SPI CS thru GPIO if it is the case */
 	data->cs_ctrl.gpio_dev = device_get_binding(cfg->gpio_cs_port);

--- a/drivers/sensor/lis2mdl/lis2mdl_trigger.c
+++ b/drivers/sensor/lis2mdl/lis2mdl_trigger.c
@@ -55,7 +55,7 @@ static void lis2mdl_handle_interrupt(void *arg)
 	struct device *dev = arg;
 	struct lis2mdl_data *lis2mdl = dev->driver_data;
 	const struct lis2mdl_config *const config =
-						dev->config->config_info;
+						dev->config_info;
 	struct sensor_trigger drdy_trigger = {
 		.type = SENSOR_TRIG_DATA_READY,
 	};
@@ -73,7 +73,7 @@ static void lis2mdl_gpio_callback(struct device *dev,
 {
 	struct lis2mdl_data *lis2mdl =
 		CONTAINER_OF(cb, struct lis2mdl_data, gpio_cb);
-	const struct lis2mdl_config *const config = dev->config->config_info;
+	const struct lis2mdl_config *const config = dev->config_info;
 
 	ARG_UNUSED(pins);
 
@@ -114,7 +114,7 @@ static void lis2mdl_work_cb(struct k_work *work)
 int lis2mdl_init_interrupt(struct device *dev)
 {
 	struct lis2mdl_data *lis2mdl = dev->driver_data;
-	const struct lis2mdl_config *const config = dev->config->config_info;
+	const struct lis2mdl_config *const config = dev->config_info;
 
 	/* setup data ready gpio interrupt */
 	lis2mdl->gpio = device_get_binding(config->gpio_name);

--- a/drivers/sensor/lps22hb/lps22hb.c
+++ b/drivers/sensor/lps22hb/lps22hb.c
@@ -23,7 +23,7 @@ LOG_MODULE_REGISTER(LPS22HB, CONFIG_SENSOR_LOG_LEVEL);
 static inline int lps22hb_set_odr_raw(struct device *dev, u8_t odr)
 {
 	struct lps22hb_data *data = dev->driver_data;
-	const struct lps22hb_config *config = dev->config->config_info;
+	const struct lps22hb_config *config = dev->config_info;
 
 	return i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
 				   LPS22HB_REG_CTRL_REG1,
@@ -35,7 +35,7 @@ static int lps22hb_sample_fetch(struct device *dev,
 				enum sensor_channel chan)
 {
 	struct lps22hb_data *data = dev->driver_data;
-	const struct lps22hb_config *config = dev->config->config_info;
+	const struct lps22hb_config *config = dev->config_info;
 	u8_t out[5];
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
@@ -98,7 +98,7 @@ static const struct sensor_driver_api lps22hb_api_funcs = {
 static int lps22hb_init_chip(struct device *dev)
 {
 	struct lps22hb_data *data = dev->driver_data;
-	const struct lps22hb_config *config = dev->config->config_info;
+	const struct lps22hb_config *config = dev->config_info;
 	u8_t chip_id;
 
 	if (i2c_reg_read_byte(data->i2c_master, config->i2c_slave_addr,
@@ -133,7 +133,7 @@ err_poweroff:
 
 static int lps22hb_init(struct device *dev)
 {
-	const struct lps22hb_config * const config = dev->config->config_info;
+	const struct lps22hb_config * const config = dev->config_info;
 	struct lps22hb_data *data = dev->driver_data;
 
 	data->i2c_master = device_get_binding(config->i2c_master_dev_name);

--- a/drivers/sensor/lps22hh/lps22hh.c
+++ b/drivers/sensor/lps22hh/lps22hh.c
@@ -172,7 +172,7 @@ static int lps22hh_init_chip(struct device *dev)
 
 static int lps22hh_init(struct device *dev)
 {
-	const struct lps22hh_config * const config = dev->config->config_info;
+	const struct lps22hh_config * const config = dev->config_info;
 	struct lps22hh_data *data = dev->driver_data;
 
 	data->bus = device_get_binding(config->master_dev_name);

--- a/drivers/sensor/lps22hh/lps22hh_i2c.c
+++ b/drivers/sensor/lps22hh/lps22hh_i2c.c
@@ -24,7 +24,7 @@ static int lps22hh_i2c_read(struct device *dev, u8_t reg_addr,
 				 u8_t *value, u16_t len)
 {
 	struct lps22hh_data *data = dev->driver_data;
-	const struct lps22hh_config *cfg = dev->config->config_info;
+	const struct lps22hh_config *cfg = dev->config_info;
 
 	return i2c_burst_read(data->bus, cfg->i2c_slv_addr,
 			      reg_addr, value, len);
@@ -34,7 +34,7 @@ static int lps22hh_i2c_write(struct device *dev, u8_t reg_addr,
 				  u8_t *value, u16_t len)
 {
 	struct lps22hh_data *data = dev->driver_data;
-	const struct lps22hh_config *cfg = dev->config->config_info;
+	const struct lps22hh_config *cfg = dev->config_info;
 
 	return i2c_burst_write(data->bus, cfg->i2c_slv_addr,
 			       reg_addr, value, len);

--- a/drivers/sensor/lps22hh/lps22hh_spi.c
+++ b/drivers/sensor/lps22hh/lps22hh_spi.c
@@ -25,7 +25,7 @@ static int lps22hh_spi_read(struct device *dev, u8_t reg_addr,
 			    u8_t *value, u8_t len)
 {
 	struct lps22hh_data *data = dev->driver_data;
-	const struct lps22hh_config *cfg = dev->config->config_info;
+	const struct lps22hh_config *cfg = dev->config_info;
 	const struct spi_config *spi_cfg = &cfg->spi_conf;
 	u8_t buffer_tx[2] = { reg_addr | LPS22HH_SPI_READ, 0 };
 	const struct spi_buf tx_buf = {
@@ -67,7 +67,7 @@ static int lps22hh_spi_write(struct device *dev, u8_t reg_addr,
 			     u8_t *value, u8_t len)
 {
 	struct lps22hh_data *data = dev->driver_data;
-	const struct lps22hh_config *cfg = dev->config->config_info;
+	const struct lps22hh_config *cfg = dev->config_info;
 	const struct spi_config *spi_cfg = &cfg->spi_conf;
 	u8_t buffer_tx[1] = { reg_addr & ~LPS22HH_SPI_READ };
 	const struct spi_buf tx_buf[2] = {
@@ -108,7 +108,7 @@ int lps22hh_spi_init(struct device *dev)
 	data->ctx->handle = dev;
 
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	const struct lps22hh_config *cfg = dev->config->config_info;
+	const struct lps22hh_config *cfg = dev->config_info;
 
 	/* handle SPI CS thru GPIO if it is the case */
 	data->cs_ctrl.gpio_dev = device_get_binding(cfg->gpio_cs_port);

--- a/drivers/sensor/lps22hh/lps22hh_trigger.c
+++ b/drivers/sensor/lps22hh/lps22hh_trigger.c
@@ -71,7 +71,7 @@ static void lps22hh_handle_interrupt(void *arg)
 {
 	struct device *dev = arg;
 	struct lps22hh_data *lps22hh = dev->driver_data;
-	const struct lps22hh_config *cfg = dev->config->config_info;
+	const struct lps22hh_config *cfg = dev->config_info;
 	struct sensor_trigger drdy_trigger = {
 		.type = SENSOR_TRIG_DATA_READY,
 	};
@@ -87,7 +87,7 @@ static void lps22hh_handle_interrupt(void *arg)
 static void lps22hh_gpio_callback(struct device *dev,
 				  struct gpio_callback *cb, u32_t pins)
 {
-	const struct lps22hh_config *cfg = dev->config->config_info;
+	const struct lps22hh_config *cfg = dev->config_info;
 	struct lps22hh_data *lps22hh =
 		CONTAINER_OF(cb, struct lps22hh_data, gpio_cb);
 
@@ -131,7 +131,7 @@ static void lps22hh_work_cb(struct k_work *work)
 int lps22hh_init_interrupt(struct device *dev)
 {
 	struct lps22hh_data *lps22hh = dev->driver_data;
-	const struct lps22hh_config *cfg = dev->config->config_info;
+	const struct lps22hh_config *cfg = dev->config_info;
 	int ret;
 
 	/* setup data ready gpio interrupt */

--- a/drivers/sensor/lps25hb/lps25hb.c
+++ b/drivers/sensor/lps25hb/lps25hb.c
@@ -23,7 +23,7 @@ LOG_MODULE_REGISTER(LPS25HB, CONFIG_SENSOR_LOG_LEVEL);
 static inline int lps25hb_power_ctrl(struct device *dev, u8_t value)
 {
 	struct lps25hb_data *data = dev->driver_data;
-	const struct lps25hb_config *config = dev->config->config_info;
+	const struct lps25hb_config *config = dev->config_info;
 
 	return i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
 				   LPS25HB_REG_CTRL_REG1,
@@ -34,7 +34,7 @@ static inline int lps25hb_power_ctrl(struct device *dev, u8_t value)
 static inline int lps25hb_set_odr_raw(struct device *dev, u8_t odr)
 {
 	struct lps25hb_data *data = dev->driver_data;
-	const struct lps25hb_config *config = dev->config->config_info;
+	const struct lps25hb_config *config = dev->config_info;
 
 	return i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
 				   LPS25HB_REG_CTRL_REG1,
@@ -46,7 +46,7 @@ static int lps25hb_sample_fetch(struct device *dev,
 				enum sensor_channel chan)
 {
 	struct lps25hb_data *data = dev->driver_data;
-	const struct lps25hb_config *config = dev->config->config_info;
+	const struct lps25hb_config *config = dev->config_info;
 	u8_t out[5];
 	int offset;
 
@@ -114,7 +114,7 @@ static const struct sensor_driver_api lps25hb_api_funcs = {
 static int lps25hb_init_chip(struct device *dev)
 {
 	struct lps25hb_data *data = dev->driver_data;
-	const struct lps25hb_config *config = dev->config->config_info;
+	const struct lps25hb_config *config = dev->config_info;
 	u8_t chip_id;
 
 	lps25hb_power_ctrl(dev, 0);
@@ -162,7 +162,7 @@ err_poweroff:
 
 static int lps25hb_init(struct device *dev)
 {
-	const struct lps25hb_config * const config = dev->config->config_info;
+	const struct lps25hb_config * const config = dev->config_info;
 	struct lps25hb_data *data = dev->driver_data;
 
 	data->i2c_master = device_get_binding(config->i2c_master_dev_name);

--- a/drivers/sensor/lsm303dlhc_magn/lsm303dlhc_magn.c
+++ b/drivers/sensor/lsm303dlhc_magn/lsm303dlhc_magn.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(lsm303dlhc_magn, CONFIG_SENSOR_LOG_LEVEL);
 static int lsm303dlhc_sample_fetch(struct device *dev,
 				   enum sensor_channel chan)
 {
-	const struct lsm303dlhc_magn_config *config = dev->config->config_info;
+	const struct lsm303dlhc_magn_config *config = dev->config_info;
 	struct lsm303dlhc_magn_data *drv_data = dev->driver_data;
 	u8_t magn_buf[6];
 	u8_t status;
@@ -93,7 +93,7 @@ static const struct sensor_driver_api lsm303dlhc_magn_driver_api = {
 
 static int lsm303dlhc_magn_init(struct device *dev)
 {
-	const struct lsm303dlhc_magn_config *config = dev->config->config_info;
+	const struct lsm303dlhc_magn_config *config = dev->config_info;
 	struct lsm303dlhc_magn_data *drv_data = dev->driver_data;
 
 	drv_data->i2c = device_get_binding(config->i2c_name);

--- a/drivers/sensor/lsm6ds0/lsm6ds0.c
+++ b/drivers/sensor/lsm6ds0/lsm6ds0.c
@@ -25,7 +25,7 @@ LOG_MODULE_REGISTER(LSM6DS0, CONFIG_SENSOR_LOG_LEVEL);
 static inline int lsm6ds0_reboot(struct device *dev)
 {
 	struct lsm6ds0_data *data = dev->driver_data;
-	const struct lsm6ds0_config *config = dev->config->config_info;
+	const struct lsm6ds0_config *config = dev->config_info;
 
 	if (i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
 				LSM6DS0_REG_CTRL_REG8,
@@ -43,7 +43,7 @@ static inline int lsm6ds0_accel_axis_ctrl(struct device *dev, int x_en,
 					  int y_en, int z_en)
 {
 	struct lsm6ds0_data *data = dev->driver_data;
-	const struct lsm6ds0_config *config = dev->config->config_info;
+	const struct lsm6ds0_config *config = dev->config_info;
 	u8_t state = (x_en << LSM6DS0_SHIFT_CTRL_REG5_XL_XEN_XL) |
 			(y_en << LSM6DS0_SHIFT_CTRL_REG5_XL_YEN_XL) |
 			(z_en << LSM6DS0_SHIFT_CTRL_REG5_XL_ZEN_XL);
@@ -59,7 +59,7 @@ static inline int lsm6ds0_accel_axis_ctrl(struct device *dev, int x_en,
 static int lsm6ds0_accel_set_fs_raw(struct device *dev, u8_t fs)
 {
 	struct lsm6ds0_data *data = dev->driver_data;
-	const struct lsm6ds0_config *config = dev->config->config_info;
+	const struct lsm6ds0_config *config = dev->config_info;
 
 	if (i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
 				LSM6DS0_REG_CTRL_REG6_XL,
@@ -74,7 +74,7 @@ static int lsm6ds0_accel_set_fs_raw(struct device *dev, u8_t fs)
 static int lsm6ds0_accel_set_odr_raw(struct device *dev, u8_t odr)
 {
 	struct lsm6ds0_data *data = dev->driver_data;
-	const struct lsm6ds0_config *config = dev->config->config_info;
+	const struct lsm6ds0_config *config = dev->config_info;
 
 	if (i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
 				LSM6DS0_REG_CTRL_REG6_XL,
@@ -90,7 +90,7 @@ static inline int lsm6ds0_gyro_axis_ctrl(struct device *dev, int x_en, int y_en,
 					 int z_en)
 {
 	struct lsm6ds0_data *data = dev->driver_data;
-	const struct lsm6ds0_config *config = dev->config->config_info;
+	const struct lsm6ds0_config *config = dev->config_info;
 	u8_t state = (x_en << LSM6DS0_SHIFT_CTRL_REG4_XEN_G) |
 			(y_en << LSM6DS0_SHIFT_CTRL_REG4_YEN_G) |
 			(z_en << LSM6DS0_SHIFT_CTRL_REG4_ZEN_G);
@@ -106,7 +106,7 @@ static inline int lsm6ds0_gyro_axis_ctrl(struct device *dev, int x_en, int y_en,
 static int lsm6ds0_gyro_set_fs_raw(struct device *dev, u8_t fs)
 {
 	struct lsm6ds0_data *data = dev->driver_data;
-	const struct lsm6ds0_config *config = dev->config->config_info;
+	const struct lsm6ds0_config *config = dev->config_info;
 
 	if (i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
 				LSM6DS0_REG_CTRL_REG1_G,
@@ -121,7 +121,7 @@ static int lsm6ds0_gyro_set_fs_raw(struct device *dev, u8_t fs)
 static int lsm6ds0_gyro_set_odr_raw(struct device *dev, u8_t odr)
 {
 	struct lsm6ds0_data *data = dev->driver_data;
-	const struct lsm6ds0_config *config = dev->config->config_info;
+	const struct lsm6ds0_config *config = dev->config_info;
 
 	if (i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
 				LSM6DS0_REG_CTRL_REG1_G,
@@ -136,7 +136,7 @@ static int lsm6ds0_gyro_set_odr_raw(struct device *dev, u8_t odr)
 static int lsm6ds0_sample_fetch_accel(struct device *dev)
 {
 	struct lsm6ds0_data *data = dev->driver_data;
-	const struct lsm6ds0_config *config = dev->config->config_info;
+	const struct lsm6ds0_config *config = dev->config_info;
 	u8_t buf[6];
 
 	if (i2c_burst_read(data->i2c_master, config->i2c_slave_addr,
@@ -164,7 +164,7 @@ static int lsm6ds0_sample_fetch_accel(struct device *dev)
 static int lsm6ds0_sample_fetch_gyro(struct device *dev)
 {
 	struct lsm6ds0_data *data = dev->driver_data;
-	const struct lsm6ds0_config *config = dev->config->config_info;
+	const struct lsm6ds0_config *config = dev->config_info;
 	u8_t buf[6];
 
 	if (i2c_burst_read(data->i2c_master, config->i2c_slave_addr,
@@ -193,7 +193,7 @@ static int lsm6ds0_sample_fetch_gyro(struct device *dev)
 static int lsm6ds0_sample_fetch_temp(struct device *dev)
 {
 	struct lsm6ds0_data *data = dev->driver_data;
-	const struct lsm6ds0_config *config = dev->config->config_info;
+	const struct lsm6ds0_config *config = dev->config_info;
 	u8_t buf[2];
 
 	if (i2c_burst_read(data->i2c_master, config->i2c_slave_addr,
@@ -407,7 +407,7 @@ static const struct sensor_driver_api lsm6ds0_api_funcs = {
 static int lsm6ds0_init_chip(struct device *dev)
 {
 	struct lsm6ds0_data *data = dev->driver_data;
-	const struct lsm6ds0_config *config = dev->config->config_info;
+	const struct lsm6ds0_config *config = dev->config_info;
 	u8_t chip_id;
 
 	if (lsm6ds0_reboot(dev) < 0) {
@@ -482,7 +482,7 @@ static int lsm6ds0_init_chip(struct device *dev)
 
 static int lsm6ds0_init(struct device *dev)
 {
-	const struct lsm6ds0_config * const config = dev->config->config_info;
+	const struct lsm6ds0_config * const config = dev->config_info;
 	struct lsm6ds0_data *data = dev->driver_data;
 
 	data->i2c_master = device_get_binding(config->i2c_master_dev_name);

--- a/drivers/sensor/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.c
@@ -779,7 +779,7 @@ static struct lsm6dsl_config lsm6dsl_config = {
 
 static int lsm6dsl_init(struct device *dev)
 {
-	const struct lsm6dsl_config * const config = dev->config->config_info;
+	const struct lsm6dsl_config * const config = dev->config_info;
 	struct lsm6dsl_data *data = dev->driver_data;
 
 	data->comm_master = device_get_binding(config->comm_master_dev_name);

--- a/drivers/sensor/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/lsm6dso/lsm6dso.c
@@ -788,7 +788,7 @@ static const struct lsm6dso_config lsm6dso_config = {
 
 static int lsm6dso_init(struct device *dev)
 {
-	const struct lsm6dso_config * const config = dev->config->config_info;
+	const struct lsm6dso_config * const config = dev->config_info;
 	struct lsm6dso_data *data = dev->driver_data;
 
 	data->bus = device_get_binding(config->bus_name);

--- a/drivers/sensor/lsm6dso/lsm6dso_i2c.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_i2c.c
@@ -24,7 +24,7 @@ static int lsm6dso_i2c_read(struct device *dev, u8_t reg_addr,
 			    u8_t *value, u8_t len)
 {
 	struct lsm6dso_data *data = dev->driver_data;
-	const struct lsm6dso_config *cfg = dev->config->config_info;
+	const struct lsm6dso_config *cfg = dev->config_info;
 
 	return i2c_burst_read(data->bus, cfg->i2c_slv_addr,
 			      reg_addr, value, len);
@@ -34,7 +34,7 @@ static int lsm6dso_i2c_write(struct device *dev, u8_t reg_addr,
 			     u8_t *value, u8_t len)
 {
 	struct lsm6dso_data *data = dev->driver_data;
-	const struct lsm6dso_config *cfg = dev->config->config_info;
+	const struct lsm6dso_config *cfg = dev->config_info;
 
 	return i2c_burst_write(data->bus, cfg->i2c_slv_addr,
 			       reg_addr, value, len);

--- a/drivers/sensor/lsm6dso/lsm6dso_spi.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_spi.c
@@ -24,7 +24,7 @@ static int lsm6dso_spi_read(struct device *dev, u8_t reg_addr,
 			    u8_t *value, u8_t len)
 {
 	struct lsm6dso_data *data = dev->driver_data;
-	const struct lsm6dso_config *cfg = dev->config->config_info;
+	const struct lsm6dso_config *cfg = dev->config_info;
 	const struct spi_config *spi_cfg = &cfg->spi_conf;
 	u8_t buffer_tx[2] = { reg_addr | LSM6DSO_SPI_READ, 0 };
 	const struct spi_buf tx_buf = {
@@ -66,7 +66,7 @@ static int lsm6dso_spi_write(struct device *dev, u8_t reg_addr,
 			     u8_t *value, u8_t len)
 {
 	struct lsm6dso_data *data = dev->driver_data;
-	const struct lsm6dso_config *cfg = dev->config->config_info;
+	const struct lsm6dso_config *cfg = dev->config_info;
 	const struct spi_config *spi_cfg = &cfg->spi_conf;
 	u8_t buffer_tx[1] = { reg_addr & ~LSM6DSO_SPI_READ };
 	const struct spi_buf tx_buf[2] = {
@@ -107,7 +107,7 @@ int lsm6dso_spi_init(struct device *dev)
 	data->ctx->handle = dev;
 
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	const struct lsm6dso_config *cfg = dev->config->config_info;
+	const struct lsm6dso_config *cfg = dev->config_info;
 
 	/* handle SPI CS thru GPIO if it is the case */
 	data->cs_ctrl.gpio_dev = device_get_binding(cfg->gpio_cs_port);

--- a/drivers/sensor/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_trigger.c
@@ -25,7 +25,7 @@ LOG_MODULE_DECLARE(LSM6DSO, CONFIG_SENSOR_LOG_LEVEL);
  */
 static int lsm6dso_enable_t_int(struct device *dev, int enable)
 {
-	const struct lsm6dso_config *cfg = dev->config->config_info;
+	const struct lsm6dso_config *cfg = dev->config_info;
 	struct lsm6dso_data *lsm6dso = dev->driver_data;
 	lsm6dso_pin_int2_route_t int2_route;
 
@@ -53,7 +53,7 @@ static int lsm6dso_enable_t_int(struct device *dev, int enable)
  */
 static int lsm6dso_enable_xl_int(struct device *dev, int enable)
 {
-	const struct lsm6dso_config *cfg = dev->config->config_info;
+	const struct lsm6dso_config *cfg = dev->config_info;
 	struct lsm6dso_data *lsm6dso = dev->driver_data;
 
 	if (enable) {
@@ -89,7 +89,7 @@ static int lsm6dso_enable_xl_int(struct device *dev, int enable)
  */
 static int lsm6dso_enable_g_int(struct device *dev, int enable)
 {
-	const struct lsm6dso_config *cfg = dev->config->config_info;
+	const struct lsm6dso_config *cfg = dev->config_info;
 	struct lsm6dso_data *lsm6dso = dev->driver_data;
 
 	if (enable) {
@@ -168,7 +168,7 @@ static void lsm6dso_handle_interrupt(void *arg)
 	struct sensor_trigger drdy_trigger = {
 		.type = SENSOR_TRIG_DATA_READY,
 	};
-	const struct lsm6dso_config *cfg = dev->config->config_info;
+	const struct lsm6dso_config *cfg = dev->config_info;
 	lsm6dso_status_reg_t status;
 
 	while (1) {
@@ -209,7 +209,7 @@ static void lsm6dso_gpio_callback(struct device *dev,
 {
 	struct lsm6dso_data *lsm6dso =
 		CONTAINER_OF(cb, struct lsm6dso_data, gpio_cb);
-	const struct lsm6dso_config *cfg = dev->config->config_info;
+	const struct lsm6dso_config *cfg = dev->config_info;
 
 	ARG_UNUSED(pins);
 
@@ -251,7 +251,7 @@ static void lsm6dso_work_cb(struct k_work *work)
 int lsm6dso_init_interrupt(struct device *dev)
 {
 	struct lsm6dso_data *lsm6dso = dev->driver_data;
-	const struct lsm6dso_config *cfg = dev->config->config_info;
+	const struct lsm6dso_config *cfg = dev->config_info;
 	int ret;
 
 	/* setup data ready gpio interrupt (INT1 or INT2) */

--- a/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro.c
+++ b/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro.c
@@ -26,7 +26,7 @@ static inline int lsm9ds0_gyro_power_ctrl(struct device *dev, int power,
 					  int x_en, int y_en, int z_en)
 {
 	struct lsm9ds0_gyro_data *data = dev->driver_data;
-	const struct lsm9ds0_gyro_config *config = dev->config->config_info;
+	const struct lsm9ds0_gyro_config *config = dev->config_info;
 	u8_t state = (power << LSM9DS0_GYRO_SHIFT_CTRL_REG1_G_PD) |
 			(x_en << LSM9DS0_GYRO_SHIFT_CTRL_REG1_G_XEN) |
 			(y_en << LSM9DS0_GYRO_SHIFT_CTRL_REG1_G_YEN) |
@@ -44,7 +44,7 @@ static inline int lsm9ds0_gyro_power_ctrl(struct device *dev, int power,
 static int lsm9ds0_gyro_set_fs_raw(struct device *dev, u8_t fs)
 {
 	struct lsm9ds0_gyro_data *data = dev->driver_data;
-	const struct lsm9ds0_gyro_config *config = dev->config->config_info;
+	const struct lsm9ds0_gyro_config *config = dev->config_info;
 
 	if (i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
 				LSM9DS0_GYRO_REG_CTRL_REG4_G,
@@ -85,7 +85,7 @@ static int lsm9ds0_gyro_set_fs(struct device *dev, int fs)
 static inline int lsm9ds0_gyro_set_odr_raw(struct device *dev, u8_t odr)
 {
 	struct lsm9ds0_gyro_data *data = dev->driver_data;
-	const struct lsm9ds0_gyro_config *config = dev->config->config_info;
+	const struct lsm9ds0_gyro_config *config = dev->config_info;
 
 	return i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
 				   LSM9DS0_GYRO_REG_CTRL_REG1_G,
@@ -122,7 +122,7 @@ static int lsm9ds0_gyro_sample_fetch(struct device *dev,
 				     enum sensor_channel chan)
 {
 	struct lsm9ds0_gyro_data *data = dev->driver_data;
-	const struct lsm9ds0_gyro_config *config = dev->config->config_info;
+	const struct lsm9ds0_gyro_config *config = dev->config_info;
 	u8_t x_l, x_h, y_l, y_h, z_l, z_h;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL ||
@@ -262,7 +262,7 @@ static const struct sensor_driver_api lsm9ds0_gyro_api_funcs = {
 static int lsm9ds0_gyro_init_chip(struct device *dev)
 {
 	struct lsm9ds0_gyro_data *data = dev->driver_data;
-	const struct lsm9ds0_gyro_config *config = dev->config->config_info;
+	const struct lsm9ds0_gyro_config *config = dev->config_info;
 	u8_t chip_id;
 
 	if (lsm9ds0_gyro_power_ctrl(dev, 0, 0, 0, 0) < 0) {
@@ -318,7 +318,7 @@ err_poweroff:
 static int lsm9ds0_gyro_init(struct device *dev)
 {
 	const struct lsm9ds0_gyro_config * const config =
-					   dev->config->config_info;
+					   dev->config_info;
 	struct lsm9ds0_gyro_data *data = dev->driver_data;
 
 	data->i2c_master = device_get_binding(config->i2c_master_dev_name);

--- a/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro_trigger.c
+++ b/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro_trigger.c
@@ -24,7 +24,7 @@ static inline void setup_drdy(struct device *dev,
 			      bool enable)
 {
 	struct lsm9ds0_gyro_data *data = dev->driver_data;
-	const struct lsm9ds0_gyro_config *cfg = dev->config->config_info;
+	const struct lsm9ds0_gyro_config *cfg = dev->config_info;
 
 	gpio_pin_interrupt_configure(data->gpio_drdy,
 				     cfg->gpio_drdy_int_pin,
@@ -39,7 +39,7 @@ int lsm9ds0_gyro_trigger_set(struct device *dev,
 {
 	struct lsm9ds0_gyro_data *data = dev->driver_data;
 	const struct lsm9ds0_gyro_config * const config =
-					 dev->config->config_info;
+					 dev->config_info;
 	u8_t state;
 
 	if (trig->type == SENSOR_TRIG_DATA_READY) {
@@ -100,7 +100,7 @@ static void lsm9ds0_gyro_thread_main(void *arg1, void *arg2, void *arg3)
 int lsm9ds0_gyro_init_interrupt(struct device *dev)
 {
 	const struct lsm9ds0_gyro_config * const config =
-					   dev->config->config_info;
+					   dev->config_info;
 	struct lsm9ds0_gyro_data *data = dev->driver_data;
 
 	k_sem_init(&data->sem, 0, UINT_MAX);

--- a/drivers/sensor/lsm9ds0_mfd/lsm9ds0_mfd.c
+++ b/drivers/sensor/lsm9ds0_mfd/lsm9ds0_mfd.c
@@ -26,7 +26,7 @@ LOG_MODULE_REGISTER(LSM9DS0_MFD, CONFIG_SENSOR_LOG_LEVEL);
 static inline int lsm9ds0_mfd_reboot_memory(struct device *dev)
 {
 	struct lsm9ds0_mfd_data *data = dev->driver_data;
-	const struct lsm9ds0_mfd_config *config = dev->config->config_info;
+	const struct lsm9ds0_mfd_config *config = dev->config_info;
 
 	if (i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
 				LSM9DS0_MFD_REG_CTRL_REG0_XM,
@@ -45,7 +45,7 @@ static inline int lsm9ds0_mfd_reboot_memory(struct device *dev)
 static inline int lsm9ds0_mfd_accel_set_odr_raw(struct device *dev, u8_t odr)
 {
 	struct lsm9ds0_mfd_data *data = dev->driver_data;
-	const struct lsm9ds0_mfd_config *config = dev->config->config_info;
+	const struct lsm9ds0_mfd_config *config = dev->config_info;
 
 	return i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
 				   LSM9DS0_MFD_REG_CTRL_REG1_XM,
@@ -89,7 +89,7 @@ static int lsm9ds0_mfd_accel_set_odr(struct device *dev,
 static inline int lsm9ds0_mfd_accel_set_fs_raw(struct device *dev, u8_t fs)
 {
 	struct lsm9ds0_mfd_data *data = dev->driver_data;
-	const struct lsm9ds0_mfd_config *config = dev->config->config_info;
+	const struct lsm9ds0_mfd_config *config = dev->config_info;
 
 	if (i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
 				LSM9DS0_MFD_REG_CTRL_REG2_XM,
@@ -134,7 +134,7 @@ static int lsm9ds0_mfd_accel_set_fs(struct device *dev, int val)
 static inline int lsm9ds0_mfd_magn_set_odr_raw(struct device *dev, u8_t odr)
 {
 	struct lsm9ds0_mfd_data *data = dev->driver_data;
-	const struct lsm9ds0_mfd_config *config = dev->config->config_info;
+	const struct lsm9ds0_mfd_config *config = dev->config_info;
 
 	return i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
 				   LSM9DS0_MFD_REG_CTRL_REG5_XM,
@@ -174,7 +174,7 @@ static int lsm9ds0_mfd_magn_set_odr(struct device *dev,
 static inline int lsm9ds0_mfd_magn_set_fs_raw(struct device *dev, u8_t fs)
 {
 	struct lsm9ds0_mfd_data *data = dev->driver_data;
-	const struct lsm9ds0_mfd_config *config = dev->config->config_info;
+	const struct lsm9ds0_mfd_config *config = dev->config_info;
 
 	if (i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
 				LSM9DS0_MFD_REG_CTRL_REG6_XM,
@@ -219,7 +219,7 @@ static int lsm9ds0_mfd_magn_set_fs(struct device *dev,
 static inline int lsm9ds0_mfd_sample_fetch_accel(struct device *dev)
 {
 	struct lsm9ds0_mfd_data *data = dev->driver_data;
-	const struct lsm9ds0_mfd_config *config = dev->config->config_info;
+	const struct lsm9ds0_mfd_config *config = dev->config_info;
 	u8_t out_l, out_h;
 
 #if defined(CONFIG_LSM9DS0_MFD_ACCEL_ENABLE_X)
@@ -273,7 +273,7 @@ static inline int lsm9ds0_mfd_sample_fetch_accel(struct device *dev)
 static inline int lsm9ds0_mfd_sample_fetch_magn(struct device *dev)
 {
 	struct lsm9ds0_mfd_data *data = dev->driver_data;
-	const struct lsm9ds0_mfd_config *config = dev->config->config_info;
+	const struct lsm9ds0_mfd_config *config = dev->config_info;
 	u8_t out_l, out_h;
 
 	if (i2c_reg_read_byte(data->i2c_master, config->i2c_slave_addr,
@@ -321,7 +321,7 @@ static inline int lsm9ds0_mfd_sample_fetch_magn(struct device *dev)
 static inline int lsm9ds0_mfd_sample_fetch_temp(struct device *dev)
 {
 	struct lsm9ds0_mfd_data *data = dev->driver_data;
-	const struct lsm9ds0_mfd_config *config = dev->config->config_info;
+	const struct lsm9ds0_mfd_config *config = dev->config_info;
 	u8_t out_l, out_h;
 
 	if (i2c_reg_read_byte(data->i2c_master, config->i2c_slave_addr,
@@ -668,7 +668,7 @@ static const struct sensor_driver_api lsm9ds0_mfd_api_funcs = {
 static int lsm9ds0_mfd_init_chip(struct device *dev)
 {
 	struct lsm9ds0_mfd_data *data = dev->driver_data;
-	const struct lsm9ds0_mfd_config *config = dev->config->config_info;
+	const struct lsm9ds0_mfd_config *config = dev->config_info;
 	u8_t chip_id;
 
 	if (lsm9ds0_mfd_reboot_memory(dev) < 0) {
@@ -770,7 +770,7 @@ static int lsm9ds0_mfd_init_chip(struct device *dev)
 int lsm9ds0_mfd_init(struct device *dev)
 {
 	const struct lsm9ds0_mfd_config * const config =
-				dev->config->config_info;
+				dev->config_info;
 	struct lsm9ds0_mfd_data *data = dev->driver_data;
 
 	data->i2c_master = device_get_binding(config->i2c_master_dev_name);

--- a/drivers/sensor/max30101/max30101.c
+++ b/drivers/sensor/max30101/max30101.c
@@ -15,7 +15,7 @@ LOG_MODULE_REGISTER(MAX30101, CONFIG_SENSOR_LOG_LEVEL);
 static int max30101_sample_fetch(struct device *dev, enum sensor_channel chan)
 {
 	struct max30101_data *data = dev->driver_data;
-	const struct max30101_config *config = dev->config->config_info;
+	const struct max30101_config *config = dev->config_info;
 	u8_t buffer[MAX30101_MAX_BYTES_PER_SAMPLE];
 	u32_t fifo_data;
 	int fifo_chan;
@@ -93,7 +93,7 @@ static const struct sensor_driver_api max30101_driver_api = {
 
 static int max30101_init(struct device *dev)
 {
-	const struct max30101_config *config = dev->config->config_info;
+	const struct max30101_config *config = dev->config_info;
 	struct max30101_data *data = dev->driver_data;
 	u8_t part_id;
 	u8_t mode_cfg;

--- a/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
+++ b/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
@@ -32,11 +32,11 @@ struct tach_xec_data {
 #define TACH_XEC_REG_BASE(_dev)				\
 	((TACH_Type *)					\
 	 ((const struct tach_xec_config * const)	\
-	  _dev->config->config_info)->base_address)
+	  _dev->config_info)->base_address)
 
 #define TACH_XEC_CONFIG(_dev)				\
 	(((const struct counter_xec_config * const)	\
-	  _dev->config->config_info))
+	  _dev->config_info))
 
 #define TACH_XEC_DATA(_dev)				\
 	((struct tach_xec_data *)dev->driver_data)

--- a/drivers/sensor/mcp9808/mcp9808.c
+++ b/drivers/sensor/mcp9808/mcp9808.c
@@ -23,7 +23,7 @@ LOG_MODULE_REGISTER(MCP9808, CONFIG_SENSOR_LOG_LEVEL);
 int mcp9808_reg_read(struct device *dev, u8_t reg, u16_t *val)
 {
 	const struct mcp9808_data *data = dev->driver_data;
-	const struct mcp9808_config *cfg = dev->config->config_info;
+	const struct mcp9808_config *cfg = dev->config_info;
 	int rc = i2c_write_read(data->i2c_master, cfg->i2c_addr,
 				&reg, sizeof(reg),
 				val, sizeof(*val));
@@ -72,7 +72,7 @@ static const struct sensor_driver_api mcp9808_api_funcs = {
 int mcp9808_init(struct device *dev)
 {
 	struct mcp9808_data *data = dev->driver_data;
-	const struct mcp9808_config *cfg = dev->config->config_info;
+	const struct mcp9808_config *cfg = dev->config_info;
 	int rc = 0;
 
 	data->i2c_master = device_get_binding(cfg->i2c_bus);

--- a/drivers/sensor/mcp9808/mcp9808_trigger.c
+++ b/drivers/sensor/mcp9808/mcp9808_trigger.c
@@ -17,7 +17,7 @@ LOG_MODULE_DECLARE(MCP9808, CONFIG_SENSOR_LOG_LEVEL);
 static int mcp9808_reg_write(struct device *dev, u8_t reg, u16_t val)
 {
 	const struct mcp9808_data *data = dev->driver_data;
-	const struct mcp9808_config *cfg = dev->config->config_info;
+	const struct mcp9808_config *cfg = dev->config_info;
 	u8_t buf[3] = {
 		reg,
 		val >> 8,	/* big-endian register storage */
@@ -61,7 +61,7 @@ static inline void setup_int(struct device *dev,
 			     bool enable)
 {
 	const struct mcp9808_data *data = dev->driver_data;
-	const struct mcp9808_config *cfg = dev->config->config_info;
+	const struct mcp9808_config *cfg = dev->config_info;
 	unsigned int flags = enable
 		? GPIO_INT_EDGE_TO_ACTIVE
 		: GPIO_INT_DISABLE;
@@ -100,7 +100,7 @@ int mcp9808_trigger_set(struct device *dev,
 			sensor_trigger_handler_t handler)
 {
 	struct mcp9808_data *data = dev->driver_data;
-	const struct mcp9808_config *cfg = dev->config->config_info;
+	const struct mcp9808_config *cfg = dev->config_info;
 	int rv = 0;
 
 	setup_int(dev, false);
@@ -163,7 +163,7 @@ static void mcp9808_gpio_thread_cb(struct k_work *work)
 int mcp9808_setup_interrupt(struct device *dev)
 {
 	struct mcp9808_data *data = dev->driver_data;
-	const struct mcp9808_config *cfg = dev->config->config_info;
+	const struct mcp9808_config *cfg = dev->config_info;
 	struct device *gpio;
 	int rc = mcp9808_reg_write(dev, MCP9808_REG_CRITICAL,
 				   MCP9808_TEMP_ABS_MASK);

--- a/drivers/sensor/mpr/mpr.c
+++ b/drivers/sensor/mpr/mpr.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(MPR, CONFIG_SENSOR_LOG_LEVEL);
 static int mpr_init(struct device *dev)
 {
 	struct mpr_data *data = dev->driver_data;
-	const struct mpr_config *cfg = dev->config->config_info;
+	const struct mpr_config *cfg = dev->config_info;
 
 	data->i2c_master = device_get_binding(cfg->i2c_bus);
 	if (!data->i2c_master) {
@@ -37,7 +37,7 @@ static int mpr_init(struct device *dev)
 static int mpr_read_reg(struct device *dev)
 {
 	struct mpr_data *data = dev->driver_data;
-	const struct mpr_config *cfg = dev->config->config_info;
+	const struct mpr_config *cfg = dev->config_info;
 
 	u8_t write_buf[] = { MPR_OUTPUT_MEASUREMENT_COMMAND, 0x00, 0x00 };
 	u8_t read_buf[4] = { 0x0 };

--- a/drivers/sensor/mpu6050/mpu6050.c
+++ b/drivers/sensor/mpu6050/mpu6050.c
@@ -112,7 +112,7 @@ static int mpu6050_channel_get(struct device *dev,
 static int mpu6050_sample_fetch(struct device *dev, enum sensor_channel chan)
 {
 	struct mpu6050_data *drv_data = dev->driver_data;
-	const struct mpu6050_config *cfg = dev->config->config_info;
+	const struct mpu6050_config *cfg = dev->config_info;
 	s16_t buf[7];
 
 	if (i2c_burst_read(drv_data->i2c, cfg->i2c_addr,
@@ -143,7 +143,7 @@ static const struct sensor_driver_api mpu6050_driver_api = {
 int mpu6050_init(struct device *dev)
 {
 	struct mpu6050_data *drv_data = dev->driver_data;
-	const struct mpu6050_config *cfg = dev->config->config_info;
+	const struct mpu6050_config *cfg = dev->config_info;
 	u8_t id, i;
 
 	drv_data->i2c = device_get_binding(cfg->i2c_label);

--- a/drivers/sensor/mpu6050/mpu6050_trigger.c
+++ b/drivers/sensor/mpu6050/mpu6050_trigger.c
@@ -19,7 +19,7 @@ int mpu6050_trigger_set(struct device *dev,
 			sensor_trigger_handler_t handler)
 {
 	struct mpu6050_data *drv_data = dev->driver_data;
-	const struct mpu6050_config *cfg = dev->config->config_info;
+	const struct mpu6050_config *cfg = dev->config_info;
 
 	if (trig->type != SENSOR_TRIG_DATA_READY) {
 		return -ENOTSUP;
@@ -46,7 +46,7 @@ static void mpu6050_gpio_callback(struct device *dev,
 {
 	struct mpu6050_data *drv_data =
 		CONTAINER_OF(cb, struct mpu6050_data, gpio_cb);
-	const struct mpu6050_config *cfg = drv_data->dev->config->config_info;
+	const struct mpu6050_config *cfg = drv_data->dev->config_info;
 
 	ARG_UNUSED(pins);
 
@@ -64,7 +64,7 @@ static void mpu6050_thread_cb(void *arg)
 {
 	struct device *dev = arg;
 	struct mpu6050_data *drv_data = dev->driver_data;
-	const struct mpu6050_config *cfg = dev->config->config_info;
+	const struct mpu6050_config *cfg = dev->config_info;
 
 	if (drv_data->data_ready_handler != NULL) {
 		drv_data->data_ready_handler(dev,
@@ -104,7 +104,7 @@ static void mpu6050_work_cb(struct k_work *work)
 int mpu6050_init_interrupt(struct device *dev)
 {
 	struct mpu6050_data *drv_data = dev->driver_data;
-	const struct mpu6050_config *cfg = dev->config->config_info;
+	const struct mpu6050_config *cfg = dev->config_info;
 
 	/* setup data ready gpio interrupt */
 	drv_data->gpio = device_get_binding(cfg->int_label);

--- a/drivers/sensor/ms5607/ms5607.c
+++ b/drivers/sensor/ms5607/ms5607.c
@@ -228,7 +228,7 @@ static const struct ms5607_config ms5607_config = {
 
 static int ms5607_init(struct device *dev)
 {
-	const struct ms5607_config *const config = dev->config->config_info;
+	const struct ms5607_config *const config = dev->config_info;
 	struct ms5607_data *data = dev->driver_data;
 	struct sensor_value val;
 	int err;

--- a/drivers/sensor/ms5837/ms5837.c
+++ b/drivers/sensor/ms5837/ms5837.c
@@ -100,7 +100,7 @@ static void ms5837_compensate(struct ms5837_data *data,
 static int ms5837_sample_fetch(struct device *dev, enum sensor_channel channel)
 {
 	struct ms5837_data *data = dev->driver_data;
-	const struct ms5837_config *cfg = dev->config->config_info;
+	const struct ms5837_config *cfg = dev->config_info;
 	int err;
 	u32_t adc_pressure;
 	u32_t adc_temperature;
@@ -246,7 +246,7 @@ static int ms5837_read_prom(struct device *i2c_master, const u8_t i2c_address,
 static int ms5837_init(struct device *dev)
 {
 	struct ms5837_data *data = dev->driver_data;
-	const struct ms5837_config *cfg = dev->config->config_info;
+	const struct ms5837_config *cfg = dev->config_info;
 	int err;
 	u8_t cmd;
 

--- a/drivers/sensor/nxp_kinetis_temp/temp_kinetis.c
+++ b/drivers/sensor/nxp_kinetis_temp/temp_kinetis.c
@@ -43,7 +43,7 @@ struct temp_kinetis_data {
 static int temp_kinetis_sample_fetch(struct device *dev,
 				     enum sensor_channel chan)
 {
-	const struct temp_kinetis_config *config = dev->config->config_info;
+	const struct temp_kinetis_config *config = dev->config_info;
 	struct temp_kinetis_data *data = dev->driver_data;
 #ifdef CONFIG_TEMP_KINETIS_FILTER
 	u16_t previous[TEMP_KINETIS_ADC_SAMPLES];
@@ -88,7 +88,7 @@ static int temp_kinetis_channel_get(struct device *dev,
 				    enum sensor_channel chan,
 				    struct sensor_value *val)
 {
-	const struct temp_kinetis_config *config = dev->config->config_info;
+	const struct temp_kinetis_config *config = dev->config_info;
 	struct temp_kinetis_data *data = dev->driver_data;
 	u16_t adcr_vdd = BIT_MASK(config->adc_seq.resolution);
 	u16_t adcr_temp25;
@@ -139,7 +139,7 @@ static const struct sensor_driver_api temp_kinetis_driver_api = {
 
 static int temp_kinetis_init(struct device *dev)
 {
-	const struct temp_kinetis_config *config = dev->config->config_info;
+	const struct temp_kinetis_config *config = dev->config_info;
 	struct temp_kinetis_data *data = dev->driver_data;
 	int err;
 	int i;

--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -172,9 +172,9 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 
 	for (dev = __device_start; dev != __device_end; dev++) {
 		if ((dev->driver_api != NULL) &&
-		strcmp(dev->config->name, "") && (dev->config->name != NULL)) {
+		strcmp(dev->name, "") && (dev->name != NULL)) {
 			if (idx == device_idx) {
-				entry->syntax = dev->config->name;
+				entry->syntax = dev->name;
 				break;
 			}
 			device_idx++;

--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -16,8 +16,8 @@
 	"when no channels are provided. Syntax:\n" \
 	"<device_name> <channel name 0> .. <channel name N>"
 
-extern struct device __device_init_start[];
-extern struct device __device_init_end[];
+extern struct device __device_start[];
+extern struct device __device_end[];
 
 const char *sensor_channel_name[SENSOR_CHAN_ALL] = {
 	[SENSOR_CHAN_ACCEL_X] =		"accel_x",
@@ -170,7 +170,7 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 	entry->help  = NULL;
 	entry->subcmd = &dsub_channel_name;
 
-	for (dev = __device_init_start; dev != __device_init_end; dev++) {
+	for (dev = __device_start; dev != __device_end; dev++) {
 		if ((dev->driver_api != NULL) &&
 		strcmp(dev->config->name, "") && (dev->config->name != NULL)) {
 			if (idx == device_idx) {

--- a/drivers/sensor/sht3xd/sht3xd.c
+++ b/drivers/sensor/sht3xd/sht3xd.c
@@ -180,7 +180,7 @@ static const struct sensor_driver_api sht3xd_driver_api = {
 static int sht3xd_init(struct device *dev)
 {
 	struct sht3xd_data *data = dev->driver_data;
-	const struct sht3xd_config *cfg = dev->config->config_info;
+	const struct sht3xd_config *cfg = dev->config_info;
 	struct device *i2c = device_get_binding(cfg->bus_name);
 
 	if (i2c == NULL) {

--- a/drivers/sensor/sht3xd/sht3xd.h
+++ b/drivers/sensor/sht3xd/sht3xd.h
@@ -88,7 +88,7 @@ struct sht3xd_data {
 
 static inline u8_t sht3xd_i2c_address(struct device *dev)
 {
-	const struct sht3xd_config *dcp = dev->config->config_info;
+	const struct sht3xd_config *dcp = dev->config_info;
 
 	return dcp->base_address;
 }

--- a/drivers/sensor/sht3xd/sht3xd_trigger.c
+++ b/drivers/sensor/sht3xd/sht3xd_trigger.c
@@ -86,7 +86,7 @@ static inline void setup_alert(struct device *dev,
 {
 	struct sht3xd_data *data = (struct sht3xd_data *)dev->driver_data;
 	const struct sht3xd_config *cfg =
-		(const struct sht3xd_config *)dev->config->config_info;
+		(const struct sht3xd_config *)dev->config_info;
 	unsigned int flags = enable
 		? GPIO_INT_EDGE_TO_ACTIVE
 		: GPIO_INT_DISABLE;
@@ -115,7 +115,7 @@ int sht3xd_trigger_set(struct device *dev,
 {
 	struct sht3xd_data *data = (struct sht3xd_data *)dev->driver_data;
 	const struct sht3xd_config *cfg =
-		(const struct sht3xd_config *)dev->config->config_info;
+		(const struct sht3xd_config *)dev->config_info;
 
 	setup_alert(dev, false);
 
@@ -191,7 +191,7 @@ static void sht3xd_work_cb(struct k_work *work)
 int sht3xd_init_interrupt(struct device *dev)
 {
 	struct sht3xd_data *data = dev->driver_data;
-	const struct sht3xd_config *cfg = dev->config->config_info;
+	const struct sht3xd_config *cfg = dev->config_info;
 	struct device *gpio = device_get_binding(cfg->alert_gpio_name);
 	int rc;
 

--- a/drivers/sensor/stts751/stts751.c
+++ b/drivers/sensor/stts751/stts751.c
@@ -169,7 +169,7 @@ static int stts751_init_chip(struct device *dev)
 
 static int stts751_init(struct device *dev)
 {
-	const struct stts751_config * const config = dev->config->config_info;
+	const struct stts751_config * const config = dev->config_info;
 	struct stts751_data *data = dev->driver_data;
 
 	data->bus = device_get_binding(config->master_dev_name);

--- a/drivers/sensor/stts751/stts751_i2c.c
+++ b/drivers/sensor/stts751/stts751_i2c.c
@@ -24,7 +24,7 @@ static int stts751_i2c_read(struct device *dev, u8_t reg_addr,
 				 u8_t *value, u16_t len)
 {
 	struct stts751_data *data = dev->driver_data;
-	const struct stts751_config *cfg = dev->config->config_info;
+	const struct stts751_config *cfg = dev->config_info;
 
 	return i2c_burst_read(data->bus, cfg->i2c_slv_addr,
 			      reg_addr, value, len);
@@ -34,7 +34,7 @@ static int stts751_i2c_write(struct device *dev, u8_t reg_addr,
 				  u8_t *value, u16_t len)
 {
 	struct stts751_data *data = dev->driver_data;
-	const struct stts751_config *cfg = dev->config->config_info;
+	const struct stts751_config *cfg = dev->config_info;
 
 	return i2c_burst_write(data->bus, cfg->i2c_slv_addr,
 			       reg_addr, value, len);

--- a/drivers/sensor/stts751/stts751_trigger.c
+++ b/drivers/sensor/stts751/stts751_trigger.c
@@ -59,7 +59,7 @@ static void stts751_handle_interrupt(void *arg)
 {
 	struct device *dev = arg;
 	struct stts751_data *stts751 = dev->driver_data;
-	const struct stts751_config *cfg = dev->config->config_info;
+	const struct stts751_config *cfg = dev->config_info;
 	struct sensor_trigger thsld_trigger = {
 		.type = SENSOR_TRIG_THRESHOLD,
 	};
@@ -79,7 +79,7 @@ static void stts751_handle_interrupt(void *arg)
 static void stts751_gpio_callback(struct device *dev,
 				  struct gpio_callback *cb, u32_t pins)
 {
-	const struct stts751_config *cfg = dev->config->config_info;
+	const struct stts751_config *cfg = dev->config_info;
 	struct stts751_data *stts751 =
 		CONTAINER_OF(cb, struct stts751_data, gpio_cb);
 
@@ -122,7 +122,7 @@ static void stts751_work_cb(struct k_work *work)
 int stts751_init_interrupt(struct device *dev)
 {
 	struct stts751_data *stts751 = dev->driver_data;
-	const struct stts751_config *cfg = dev->config->config_info;
+	const struct stts751_config *cfg = dev->config_info;
 	int ret;
 
 	/* setup data ready gpio interrupt */

--- a/drivers/sensor/tmp116/tmp116.c
+++ b/drivers/sensor/tmp116/tmp116.c
@@ -23,7 +23,7 @@ LOG_MODULE_REGISTER(TMP116);
 static int tmp116_reg_read(struct device *dev, u8_t reg, u16_t *val)
 {
 	struct tmp116_data *drv_data = dev->driver_data;
-	const struct tmp116_dev_config *cfg = dev->config->config_info;
+	const struct tmp116_dev_config *cfg = dev->config_info;
 
 	if (i2c_burst_read(drv_data->i2c, cfg->i2c_addr, reg, (u8_t *)val, 2)
 	    < 0) {

--- a/drivers/serial/leuart_gecko.c
+++ b/drivers/serial/leuart_gecko.c
@@ -19,7 +19,7 @@
 #define CLOCK_LEUART(id) CLOCK_ID_PRFX(LEUART_PREFIX, id)
 
 #define DEV_CFG(dev) \
-	((const struct leuart_gecko_config * const)(dev)->config->config_info)
+	((const struct leuart_gecko_config * const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct leuart_gecko_data * const)(dev)->driver_data)
 #define DEV_BASE(dev) \

--- a/drivers/serial/uart_altera_jtag_hal.c
+++ b/drivers/serial/uart_altera_jtag_hal.c
@@ -17,7 +17,7 @@
 #define UART_ALTERA_JTAG_CONTROL_REG               1
 
 #define DEV_CFG(dev) \
-	((const struct uart_device_config * const)(dev)->config->config_info)
+	((const struct uart_device_config * const)(dev)->config_info)
 
 extern int altera_avalon_jtag_uart_read(altera_avalon_jtag_uart_state *sp,
 		char *buffer, int space, int flags);

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -47,7 +47,7 @@ static inline struct uart_cc13xx_cc26xx_data *get_dev_data(struct device *dev)
 
 static inline const struct uart_device_config *get_dev_conf(struct device *dev)
 {
-	return dev->config->config_info;
+	return dev->config_info;
 }
 
 static int uart_cc13xx_cc26xx_poll_in(struct device *dev, unsigned char *c)

--- a/drivers/serial/uart_cc32xx.c
+++ b/drivers/serial/uart_cc32xx.c
@@ -25,7 +25,7 @@ struct uart_cc32xx_dev_data_t {
 };
 
 #define DEV_CFG(dev) \
-	((const struct uart_device_config * const)(dev)->config->config_info)
+	((const struct uart_device_config * const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct uart_cc32xx_dev_data_t * const)(dev)->driver_data)
 

--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -77,7 +77,7 @@ struct uart_cmsdk_apb_dev_data {
 
 /* convenience defines */
 #define DEV_CFG(dev) \
-	((const struct uart_device_config * const)(dev)->config->config_info)
+	((const struct uart_device_config * const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct uart_cmsdk_apb_dev_data * const)(dev)->driver_data)
 #define UART_STRUCT(dev) \

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -95,7 +95,7 @@ struct uart_esp32_data {
 };
 
 #define DEV_CFG(dev) \
-	((const struct uart_esp32_config *const)(dev)->config->config_info)
+	((const struct uart_esp32_config *const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct uart_esp32_data *)(dev)->driver_data)
 #define DEV_BASE(dev) \

--- a/drivers/serial/uart_gecko.c
+++ b/drivers/serial/uart_gecko.c
@@ -44,7 +44,7 @@ struct uart_gecko_data {
 
 static int uart_gecko_poll_in(struct device *dev, unsigned char *c)
 {
-	const struct uart_gecko_config *config = dev->config->config_info;
+	const struct uart_gecko_config *config = dev->config_info;
 	u32_t flags = USART_StatusGet(config->base);
 
 	if (flags & USART_STATUS_RXDATAV) {
@@ -57,14 +57,14 @@ static int uart_gecko_poll_in(struct device *dev, unsigned char *c)
 
 static void uart_gecko_poll_out(struct device *dev, unsigned char c)
 {
-	const struct uart_gecko_config *config = dev->config->config_info;
+	const struct uart_gecko_config *config = dev->config_info;
 
 	USART_Tx(config->base, c);
 }
 
 static int uart_gecko_err_check(struct device *dev)
 {
-	const struct uart_gecko_config *config = dev->config->config_info;
+	const struct uart_gecko_config *config = dev->config_info;
 	u32_t flags = USART_IntGet(config->base);
 	int err = 0;
 
@@ -91,7 +91,7 @@ static int uart_gecko_err_check(struct device *dev)
 static int uart_gecko_fifo_fill(struct device *dev, const u8_t *tx_data,
 			       int len)
 {
-	const struct uart_gecko_config *config = dev->config->config_info;
+	const struct uart_gecko_config *config = dev->config_info;
 	u8_t num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
@@ -106,7 +106,7 @@ static int uart_gecko_fifo_fill(struct device *dev, const u8_t *tx_data,
 static int uart_gecko_fifo_read(struct device *dev, u8_t *rx_data,
 			       const int len)
 {
-	const struct uart_gecko_config *config = dev->config->config_info;
+	const struct uart_gecko_config *config = dev->config_info;
 	u8_t num_rx = 0U;
 
 	while ((len - num_rx > 0) &&
@@ -120,7 +120,7 @@ static int uart_gecko_fifo_read(struct device *dev, u8_t *rx_data,
 
 static void uart_gecko_irq_tx_enable(struct device *dev)
 {
-	const struct uart_gecko_config *config = dev->config->config_info;
+	const struct uart_gecko_config *config = dev->config_info;
 	u32_t mask = USART_IEN_TXBL | USART_IEN_TXC;
 
 	USART_IntEnable(config->base, mask);
@@ -128,7 +128,7 @@ static void uart_gecko_irq_tx_enable(struct device *dev)
 
 static void uart_gecko_irq_tx_disable(struct device *dev)
 {
-	const struct uart_gecko_config *config = dev->config->config_info;
+	const struct uart_gecko_config *config = dev->config_info;
 	u32_t mask = USART_IEN_TXBL | USART_IEN_TXC;
 
 	USART_IntDisable(config->base, mask);
@@ -136,7 +136,7 @@ static void uart_gecko_irq_tx_disable(struct device *dev)
 
 static int uart_gecko_irq_tx_complete(struct device *dev)
 {
-	const struct uart_gecko_config *config = dev->config->config_info;
+	const struct uart_gecko_config *config = dev->config_info;
 	u32_t flags = USART_IntGet(config->base);
 
 	USART_IntClear(config->base, USART_IF_TXC);
@@ -146,7 +146,7 @@ static int uart_gecko_irq_tx_complete(struct device *dev)
 
 static int uart_gecko_irq_tx_ready(struct device *dev)
 {
-	const struct uart_gecko_config *config = dev->config->config_info;
+	const struct uart_gecko_config *config = dev->config_info;
 	u32_t flags = USART_IntGet(config->base);
 
 	return (flags & USART_IF_TXBL) != 0U;
@@ -154,7 +154,7 @@ static int uart_gecko_irq_tx_ready(struct device *dev)
 
 static void uart_gecko_irq_rx_enable(struct device *dev)
 {
-	const struct uart_gecko_config *config = dev->config->config_info;
+	const struct uart_gecko_config *config = dev->config_info;
 	u32_t mask = USART_IEN_RXDATAV;
 
 	USART_IntEnable(config->base, mask);
@@ -162,7 +162,7 @@ static void uart_gecko_irq_rx_enable(struct device *dev)
 
 static void uart_gecko_irq_rx_disable(struct device *dev)
 {
-	const struct uart_gecko_config *config = dev->config->config_info;
+	const struct uart_gecko_config *config = dev->config_info;
 	u32_t mask = USART_IEN_RXDATAV;
 
 	USART_IntDisable(config->base, mask);
@@ -170,7 +170,7 @@ static void uart_gecko_irq_rx_disable(struct device *dev)
 
 static int uart_gecko_irq_rx_full(struct device *dev)
 {
-	const struct uart_gecko_config *config = dev->config->config_info;
+	const struct uart_gecko_config *config = dev->config_info;
 	u32_t flags = USART_IntGet(config->base);
 
 	return (flags & USART_IF_RXDATAV) != 0U;
@@ -178,7 +178,7 @@ static int uart_gecko_irq_rx_full(struct device *dev)
 
 static int uart_gecko_irq_rx_ready(struct device *dev)
 {
-	const struct uart_gecko_config *config = dev->config->config_info;
+	const struct uart_gecko_config *config = dev->config_info;
 	u32_t mask = USART_IEN_RXDATAV;
 
 	return (config->base->IEN & mask)
@@ -187,7 +187,7 @@ static int uart_gecko_irq_rx_ready(struct device *dev)
 
 static void uart_gecko_irq_err_enable(struct device *dev)
 {
-	const struct uart_gecko_config *config = dev->config->config_info;
+	const struct uart_gecko_config *config = dev->config_info;
 
 	USART_IntEnable(config->base, USART_IF_RXOF |
 			 USART_IF_PERR |
@@ -196,7 +196,7 @@ static void uart_gecko_irq_err_enable(struct device *dev)
 
 static void uart_gecko_irq_err_disable(struct device *dev)
 {
-	const struct uart_gecko_config *config = dev->config->config_info;
+	const struct uart_gecko_config *config = dev->config_info;
 
 	USART_IntDisable(config->base, USART_IF_RXOF |
 			 USART_IF_PERR |
@@ -236,7 +236,7 @@ static void uart_gecko_isr(void *arg)
 
 static void uart_gecko_init_pins(struct device *dev)
 {
-	const struct uart_gecko_config *config = dev->config->config_info;
+	const struct uart_gecko_config *config = dev->config_info;
 
 	soc_gpio_configure(&config->pin_rx);
 	soc_gpio_configure(&config->pin_tx);
@@ -254,7 +254,7 @@ static void uart_gecko_init_pins(struct device *dev)
 
 static int uart_gecko_init(struct device *dev)
 {
-	const struct uart_gecko_config *config = dev->config->config_info;
+	const struct uart_gecko_config *config = dev->config_info;
 	USART_InitAsync_TypeDef usartInit = USART_INITASYNC_DEFAULT;
 
 	/* The peripheral and gpio clock are already enabled from soc and gpio

--- a/drivers/serial/uart_imx.c
+++ b/drivers/serial/uart_imx.c
@@ -22,7 +22,7 @@
 #include <uart_imx.h>
 
 #define DEV_CFG(dev) \
-	((const struct imx_uart_config *const)(dev)->config->config_info)
+	((const struct imx_uart_config *const)(dev)->config_info)
 #define UART_STRUCT(dev) \
 	((UART_Type *)(DEV_CFG(dev))->base)
 
@@ -55,7 +55,7 @@ struct imx_uart_data {
 static int uart_imx_init(struct device *dev)
 {
 	UART_Type *uart = UART_STRUCT(dev);
-	const struct imx_uart_config *config = dev->config->config_info;
+	const struct imx_uart_config *config = dev->config_info;
 	unsigned int old_level;
 
 	/* disable interrupts */

--- a/drivers/serial/uart_mcux.c
+++ b/drivers/serial/uart_mcux.c
@@ -33,7 +33,7 @@ struct uart_mcux_data {
 
 static int uart_mcux_poll_in(struct device *dev, unsigned char *c)
 {
-	const struct uart_mcux_config *config = dev->config->config_info;
+	const struct uart_mcux_config *config = dev->config_info;
 	u32_t flags = UART_GetStatusFlags(config->base);
 	int ret = -1;
 
@@ -47,7 +47,7 @@ static int uart_mcux_poll_in(struct device *dev, unsigned char *c)
 
 static void uart_mcux_poll_out(struct device *dev, unsigned char c)
 {
-	const struct uart_mcux_config *config = dev->config->config_info;
+	const struct uart_mcux_config *config = dev->config_info;
 
 	while (!(UART_GetStatusFlags(config->base) & kUART_TxDataRegEmptyFlag)) {
 	}
@@ -57,7 +57,7 @@ static void uart_mcux_poll_out(struct device *dev, unsigned char c)
 
 static int uart_mcux_err_check(struct device *dev)
 {
-	const struct uart_mcux_config *config = dev->config->config_info;
+	const struct uart_mcux_config *config = dev->config_info;
 	u32_t flags = UART_GetStatusFlags(config->base);
 	int err = 0;
 
@@ -84,7 +84,7 @@ static int uart_mcux_err_check(struct device *dev)
 static int uart_mcux_fifo_fill(struct device *dev, const u8_t *tx_data,
 			       int len)
 {
-	const struct uart_mcux_config *config = dev->config->config_info;
+	const struct uart_mcux_config *config = dev->config_info;
 	u8_t num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
@@ -99,7 +99,7 @@ static int uart_mcux_fifo_fill(struct device *dev, const u8_t *tx_data,
 static int uart_mcux_fifo_read(struct device *dev, u8_t *rx_data,
 			       const int len)
 {
-	const struct uart_mcux_config *config = dev->config->config_info;
+	const struct uart_mcux_config *config = dev->config_info;
 	u8_t num_rx = 0U;
 
 	while ((len - num_rx > 0) &&
@@ -113,7 +113,7 @@ static int uart_mcux_fifo_read(struct device *dev, u8_t *rx_data,
 
 static void uart_mcux_irq_tx_enable(struct device *dev)
 {
-	const struct uart_mcux_config *config = dev->config->config_info;
+	const struct uart_mcux_config *config = dev->config_info;
 	u32_t mask = kUART_TxDataRegEmptyInterruptEnable;
 
 	UART_EnableInterrupts(config->base, mask);
@@ -121,7 +121,7 @@ static void uart_mcux_irq_tx_enable(struct device *dev)
 
 static void uart_mcux_irq_tx_disable(struct device *dev)
 {
-	const struct uart_mcux_config *config = dev->config->config_info;
+	const struct uart_mcux_config *config = dev->config_info;
 	u32_t mask = kUART_TxDataRegEmptyInterruptEnable;
 
 	UART_DisableInterrupts(config->base, mask);
@@ -129,7 +129,7 @@ static void uart_mcux_irq_tx_disable(struct device *dev)
 
 static int uart_mcux_irq_tx_complete(struct device *dev)
 {
-	const struct uart_mcux_config *config = dev->config->config_info;
+	const struct uart_mcux_config *config = dev->config_info;
 	u32_t flags = UART_GetStatusFlags(config->base);
 
 	return (flags & kUART_TxDataRegEmptyFlag) != 0U;
@@ -137,7 +137,7 @@ static int uart_mcux_irq_tx_complete(struct device *dev)
 
 static int uart_mcux_irq_tx_ready(struct device *dev)
 {
-	const struct uart_mcux_config *config = dev->config->config_info;
+	const struct uart_mcux_config *config = dev->config_info;
 	u32_t mask = kUART_TxDataRegEmptyInterruptEnable;
 
 	return (UART_GetEnabledInterrupts(config->base) & mask)
@@ -146,7 +146,7 @@ static int uart_mcux_irq_tx_ready(struct device *dev)
 
 static void uart_mcux_irq_rx_enable(struct device *dev)
 {
-	const struct uart_mcux_config *config = dev->config->config_info;
+	const struct uart_mcux_config *config = dev->config_info;
 	u32_t mask = kUART_RxDataRegFullInterruptEnable;
 
 	UART_EnableInterrupts(config->base, mask);
@@ -154,7 +154,7 @@ static void uart_mcux_irq_rx_enable(struct device *dev)
 
 static void uart_mcux_irq_rx_disable(struct device *dev)
 {
-	const struct uart_mcux_config *config = dev->config->config_info;
+	const struct uart_mcux_config *config = dev->config_info;
 	u32_t mask = kUART_RxDataRegFullInterruptEnable;
 
 	UART_DisableInterrupts(config->base, mask);
@@ -162,7 +162,7 @@ static void uart_mcux_irq_rx_disable(struct device *dev)
 
 static int uart_mcux_irq_rx_full(struct device *dev)
 {
-	const struct uart_mcux_config *config = dev->config->config_info;
+	const struct uart_mcux_config *config = dev->config_info;
 	u32_t flags = UART_GetStatusFlags(config->base);
 
 	return (flags & kUART_RxDataRegFullFlag) != 0U;
@@ -170,7 +170,7 @@ static int uart_mcux_irq_rx_full(struct device *dev)
 
 static int uart_mcux_irq_rx_ready(struct device *dev)
 {
-	const struct uart_mcux_config *config = dev->config->config_info;
+	const struct uart_mcux_config *config = dev->config_info;
 	u32_t mask = kUART_RxDataRegFullInterruptEnable;
 
 	return (UART_GetEnabledInterrupts(config->base) & mask)
@@ -179,7 +179,7 @@ static int uart_mcux_irq_rx_ready(struct device *dev)
 
 static void uart_mcux_irq_err_enable(struct device *dev)
 {
-	const struct uart_mcux_config *config = dev->config->config_info;
+	const struct uart_mcux_config *config = dev->config_info;
 	u32_t mask = kUART_NoiseErrorInterruptEnable |
 			kUART_FramingErrorInterruptEnable |
 			kUART_ParityErrorInterruptEnable;
@@ -189,7 +189,7 @@ static void uart_mcux_irq_err_enable(struct device *dev)
 
 static void uart_mcux_irq_err_disable(struct device *dev)
 {
-	const struct uart_mcux_config *config = dev->config->config_info;
+	const struct uart_mcux_config *config = dev->config_info;
 	u32_t mask = kUART_NoiseErrorInterruptEnable |
 			kUART_FramingErrorInterruptEnable |
 			kUART_ParityErrorInterruptEnable;
@@ -230,7 +230,7 @@ static void uart_mcux_isr(void *arg)
 
 static int uart_mcux_init(struct device *dev)
 {
-	const struct uart_mcux_config *config = dev->config->config_info;
+	const struct uart_mcux_config *config = dev->config_info;
 	uart_config_t uart_config;
 	struct device *clock_dev;
 	u32_t clock_freq;

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -40,7 +40,7 @@ struct mcux_flexcomm_data {
 
 static int mcux_flexcomm_poll_in(struct device *dev, unsigned char *c)
 {
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 	u32_t flags = USART_GetStatusFlags(config->base);
 	int ret = -1;
 
@@ -55,7 +55,7 @@ static int mcux_flexcomm_poll_in(struct device *dev, unsigned char *c)
 static void mcux_flexcomm_poll_out(struct device *dev,
 					     unsigned char c)
 {
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 
 	/* Wait until space is available in TX FIFO */
 	while (!(USART_GetStatusFlags(config->base) & kUSART_TxFifoEmptyFlag)) {
@@ -66,7 +66,7 @@ static void mcux_flexcomm_poll_out(struct device *dev,
 
 static int mcux_flexcomm_err_check(struct device *dev)
 {
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 	u32_t flags = USART_GetStatusFlags(config->base);
 	int err = 0;
 
@@ -94,7 +94,7 @@ static int mcux_flexcomm_err_check(struct device *dev)
 static int mcux_flexcomm_fifo_fill(struct device *dev, const u8_t *tx_data,
 			       int len)
 {
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 	u8_t num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
@@ -110,7 +110,7 @@ static int mcux_flexcomm_fifo_fill(struct device *dev, const u8_t *tx_data,
 static int mcux_flexcomm_fifo_read(struct device *dev, u8_t *rx_data,
 			       const int len)
 {
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 	u8_t num_rx = 0U;
 
 	while ((len - num_rx > 0) &&
@@ -125,7 +125,7 @@ static int mcux_flexcomm_fifo_read(struct device *dev, u8_t *rx_data,
 
 static void mcux_flexcomm_irq_tx_enable(struct device *dev)
 {
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 	u32_t mask = kUSART_TxLevelInterruptEnable;
 
 	USART_EnableInterrupts(config->base, mask);
@@ -133,7 +133,7 @@ static void mcux_flexcomm_irq_tx_enable(struct device *dev)
 
 static void mcux_flexcomm_irq_tx_disable(struct device *dev)
 {
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 	u32_t mask = kUSART_TxLevelInterruptEnable;
 
 	USART_DisableInterrupts(config->base, mask);
@@ -141,7 +141,7 @@ static void mcux_flexcomm_irq_tx_disable(struct device *dev)
 
 static int mcux_flexcomm_irq_tx_complete(struct device *dev)
 {
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 	u32_t flags = USART_GetStatusFlags(config->base);
 
 	return (flags & kUSART_TxFifoEmptyFlag) != 0U;
@@ -149,7 +149,7 @@ static int mcux_flexcomm_irq_tx_complete(struct device *dev)
 
 static int mcux_flexcomm_irq_tx_ready(struct device *dev)
 {
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 	u32_t mask = kUSART_TxLevelInterruptEnable;
 
 	return (USART_GetEnabledInterrupts(config->base) & mask)
@@ -158,7 +158,7 @@ static int mcux_flexcomm_irq_tx_ready(struct device *dev)
 
 static void mcux_flexcomm_irq_rx_enable(struct device *dev)
 {
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 	u32_t mask = kUSART_RxLevelInterruptEnable;
 
 	USART_EnableInterrupts(config->base, mask);
@@ -166,7 +166,7 @@ static void mcux_flexcomm_irq_rx_enable(struct device *dev)
 
 static void mcux_flexcomm_irq_rx_disable(struct device *dev)
 {
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 	u32_t mask = kUSART_RxLevelInterruptEnable;
 
 	USART_DisableInterrupts(config->base, mask);
@@ -174,7 +174,7 @@ static void mcux_flexcomm_irq_rx_disable(struct device *dev)
 
 static int mcux_flexcomm_irq_rx_full(struct device *dev)
 {
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 	u32_t flags = USART_GetStatusFlags(config->base);
 
 	return (flags & kUSART_RxFifoNotEmptyFlag) != 0U;
@@ -182,7 +182,7 @@ static int mcux_flexcomm_irq_rx_full(struct device *dev)
 
 static int mcux_flexcomm_irq_rx_ready(struct device *dev)
 {
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 	u32_t mask = kUSART_RxLevelInterruptEnable;
 
 	return (USART_GetEnabledInterrupts(config->base) & mask)
@@ -191,7 +191,7 @@ static int mcux_flexcomm_irq_rx_ready(struct device *dev)
 
 static void mcux_flexcomm_irq_err_enable(struct device *dev)
 {
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 	u32_t mask = kStatus_USART_NoiseError |
 			kStatus_USART_FramingError |
 			kStatus_USART_ParityError;
@@ -201,7 +201,7 @@ static void mcux_flexcomm_irq_err_enable(struct device *dev)
 
 static void mcux_flexcomm_irq_err_disable(struct device *dev)
 {
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 	u32_t mask = kStatus_USART_NoiseError |
 			kStatus_USART_FramingError |
 			kStatus_USART_ParityError;
@@ -244,7 +244,7 @@ static void mcux_flexcomm_isr(void *arg)
 
 static int mcux_flexcomm_init(struct device *dev)
 {
-	const struct mcux_flexcomm_config *config = dev->config->config_info;
+	const struct mcux_flexcomm_config *config = dev->config_info;
 	usart_config_t usart_config;
 	u32_t clock_freq;
 

--- a/drivers/serial/uart_mcux_lpsci.c
+++ b/drivers/serial/uart_mcux_lpsci.c
@@ -32,7 +32,7 @@ struct mcux_lpsci_data {
 
 static int mcux_lpsci_poll_in(struct device *dev, unsigned char *c)
 {
-	const struct mcux_lpsci_config *config = dev->config->config_info;
+	const struct mcux_lpsci_config *config = dev->config_info;
 	u32_t flags = LPSCI_GetStatusFlags(config->base);
 	int ret = -1;
 
@@ -46,7 +46,7 @@ static int mcux_lpsci_poll_in(struct device *dev, unsigned char *c)
 
 static void mcux_lpsci_poll_out(struct device *dev, unsigned char c)
 {
-	const struct mcux_lpsci_config *config = dev->config->config_info;
+	const struct mcux_lpsci_config *config = dev->config_info;
 
 	while (!(LPSCI_GetStatusFlags(config->base)
 		& kLPSCI_TxDataRegEmptyFlag)) {
@@ -57,7 +57,7 @@ static void mcux_lpsci_poll_out(struct device *dev, unsigned char c)
 
 static int mcux_lpsci_err_check(struct device *dev)
 {
-	const struct mcux_lpsci_config *config = dev->config->config_info;
+	const struct mcux_lpsci_config *config = dev->config_info;
 	u32_t flags = LPSCI_GetStatusFlags(config->base);
 	int err = 0;
 
@@ -84,7 +84,7 @@ static int mcux_lpsci_err_check(struct device *dev)
 static int mcux_lpsci_fifo_fill(struct device *dev, const u8_t *tx_data,
 				int len)
 {
-	const struct mcux_lpsci_config *config = dev->config->config_info;
+	const struct mcux_lpsci_config *config = dev->config_info;
 	u8_t num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
@@ -100,7 +100,7 @@ static int mcux_lpsci_fifo_fill(struct device *dev, const u8_t *tx_data,
 static int mcux_lpsci_fifo_read(struct device *dev, u8_t *rx_data,
 				const int len)
 {
-	const struct mcux_lpsci_config *config = dev->config->config_info;
+	const struct mcux_lpsci_config *config = dev->config_info;
 	u8_t num_rx = 0U;
 
 	while ((len - num_rx > 0) &&
@@ -115,7 +115,7 @@ static int mcux_lpsci_fifo_read(struct device *dev, u8_t *rx_data,
 
 static void mcux_lpsci_irq_tx_enable(struct device *dev)
 {
-	const struct mcux_lpsci_config *config = dev->config->config_info;
+	const struct mcux_lpsci_config *config = dev->config_info;
 	u32_t mask = kLPSCI_TxDataRegEmptyInterruptEnable;
 
 	LPSCI_EnableInterrupts(config->base, mask);
@@ -123,7 +123,7 @@ static void mcux_lpsci_irq_tx_enable(struct device *dev)
 
 static void mcux_lpsci_irq_tx_disable(struct device *dev)
 {
-	const struct mcux_lpsci_config *config = dev->config->config_info;
+	const struct mcux_lpsci_config *config = dev->config_info;
 	u32_t mask = kLPSCI_TxDataRegEmptyInterruptEnable;
 
 	LPSCI_DisableInterrupts(config->base, mask);
@@ -131,7 +131,7 @@ static void mcux_lpsci_irq_tx_disable(struct device *dev)
 
 static int mcux_lpsci_irq_tx_complete(struct device *dev)
 {
-	const struct mcux_lpsci_config *config = dev->config->config_info;
+	const struct mcux_lpsci_config *config = dev->config_info;
 	u32_t flags = LPSCI_GetStatusFlags(config->base);
 
 	return (flags & kLPSCI_TxDataRegEmptyFlag) != 0U;
@@ -139,7 +139,7 @@ static int mcux_lpsci_irq_tx_complete(struct device *dev)
 
 static int mcux_lpsci_irq_tx_ready(struct device *dev)
 {
-	const struct mcux_lpsci_config *config = dev->config->config_info;
+	const struct mcux_lpsci_config *config = dev->config_info;
 	u32_t mask = kLPSCI_TxDataRegEmptyInterruptEnable;
 
 	return (LPSCI_GetEnabledInterrupts(config->base) & mask)
@@ -148,7 +148,7 @@ static int mcux_lpsci_irq_tx_ready(struct device *dev)
 
 static void mcux_lpsci_irq_rx_enable(struct device *dev)
 {
-	const struct mcux_lpsci_config *config = dev->config->config_info;
+	const struct mcux_lpsci_config *config = dev->config_info;
 	u32_t mask = kLPSCI_RxDataRegFullInterruptEnable;
 
 	LPSCI_EnableInterrupts(config->base, mask);
@@ -156,7 +156,7 @@ static void mcux_lpsci_irq_rx_enable(struct device *dev)
 
 static void mcux_lpsci_irq_rx_disable(struct device *dev)
 {
-	const struct mcux_lpsci_config *config = dev->config->config_info;
+	const struct mcux_lpsci_config *config = dev->config_info;
 	u32_t mask = kLPSCI_RxDataRegFullInterruptEnable;
 
 	LPSCI_DisableInterrupts(config->base, mask);
@@ -164,7 +164,7 @@ static void mcux_lpsci_irq_rx_disable(struct device *dev)
 
 static int mcux_lpsci_irq_rx_full(struct device *dev)
 {
-	const struct mcux_lpsci_config *config = dev->config->config_info;
+	const struct mcux_lpsci_config *config = dev->config_info;
 	u32_t flags = LPSCI_GetStatusFlags(config->base);
 
 	return (flags & kLPSCI_RxDataRegFullFlag) != 0U;
@@ -172,7 +172,7 @@ static int mcux_lpsci_irq_rx_full(struct device *dev)
 
 static int mcux_lpsci_irq_rx_ready(struct device *dev)
 {
-	const struct mcux_lpsci_config *config = dev->config->config_info;
+	const struct mcux_lpsci_config *config = dev->config_info;
 	u32_t mask = kLPSCI_RxDataRegFullInterruptEnable;
 
 	return (LPSCI_GetEnabledInterrupts(config->base) & mask)
@@ -181,7 +181,7 @@ static int mcux_lpsci_irq_rx_ready(struct device *dev)
 
 static void mcux_lpsci_irq_err_enable(struct device *dev)
 {
-	const struct mcux_lpsci_config *config = dev->config->config_info;
+	const struct mcux_lpsci_config *config = dev->config_info;
 	u32_t mask = kLPSCI_NoiseErrorInterruptEnable |
 			kLPSCI_FramingErrorInterruptEnable |
 			kLPSCI_ParityErrorInterruptEnable;
@@ -191,7 +191,7 @@ static void mcux_lpsci_irq_err_enable(struct device *dev)
 
 static void mcux_lpsci_irq_err_disable(struct device *dev)
 {
-	const struct mcux_lpsci_config *config = dev->config->config_info;
+	const struct mcux_lpsci_config *config = dev->config_info;
 	u32_t mask = kLPSCI_NoiseErrorInterruptEnable |
 			kLPSCI_FramingErrorInterruptEnable |
 			kLPSCI_ParityErrorInterruptEnable;
@@ -233,7 +233,7 @@ static void mcux_lpsci_isr(void *arg)
 
 static int mcux_lpsci_init(struct device *dev)
 {
-	const struct mcux_lpsci_config *config = dev->config->config_info;
+	const struct mcux_lpsci_config *config = dev->config_info;
 	lpsci_config_t uart_config;
 	struct device *clock_dev;
 	u32_t clock_freq;

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -32,7 +32,7 @@ struct mcux_lpuart_data {
 
 static int mcux_lpuart_poll_in(struct device *dev, unsigned char *c)
 {
-	const struct mcux_lpuart_config *config = dev->config->config_info;
+	const struct mcux_lpuart_config *config = dev->config_info;
 	u32_t flags = LPUART_GetStatusFlags(config->base);
 	int ret = -1;
 
@@ -46,7 +46,7 @@ static int mcux_lpuart_poll_in(struct device *dev, unsigned char *c)
 
 static void mcux_lpuart_poll_out(struct device *dev, unsigned char c)
 {
-	const struct mcux_lpuart_config *config = dev->config->config_info;
+	const struct mcux_lpuart_config *config = dev->config_info;
 
 	while (!(LPUART_GetStatusFlags(config->base)
 		& kLPUART_TxDataRegEmptyFlag)) {
@@ -57,7 +57,7 @@ static void mcux_lpuart_poll_out(struct device *dev, unsigned char c)
 
 static int mcux_lpuart_err_check(struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config->config_info;
+	const struct mcux_lpuart_config *config = dev->config_info;
 	u32_t flags = LPUART_GetStatusFlags(config->base);
 	int err = 0;
 
@@ -84,7 +84,7 @@ static int mcux_lpuart_err_check(struct device *dev)
 static int mcux_lpuart_fifo_fill(struct device *dev, const u8_t *tx_data,
 			       int len)
 {
-	const struct mcux_lpuart_config *config = dev->config->config_info;
+	const struct mcux_lpuart_config *config = dev->config_info;
 	u8_t num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
@@ -100,7 +100,7 @@ static int mcux_lpuart_fifo_fill(struct device *dev, const u8_t *tx_data,
 static int mcux_lpuart_fifo_read(struct device *dev, u8_t *rx_data,
 			       const int len)
 {
-	const struct mcux_lpuart_config *config = dev->config->config_info;
+	const struct mcux_lpuart_config *config = dev->config_info;
 	u8_t num_rx = 0U;
 
 	while ((len - num_rx > 0) &&
@@ -115,7 +115,7 @@ static int mcux_lpuart_fifo_read(struct device *dev, u8_t *rx_data,
 
 static void mcux_lpuart_irq_tx_enable(struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config->config_info;
+	const struct mcux_lpuart_config *config = dev->config_info;
 	u32_t mask = kLPUART_TxDataRegEmptyInterruptEnable;
 
 	LPUART_EnableInterrupts(config->base, mask);
@@ -123,7 +123,7 @@ static void mcux_lpuart_irq_tx_enable(struct device *dev)
 
 static void mcux_lpuart_irq_tx_disable(struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config->config_info;
+	const struct mcux_lpuart_config *config = dev->config_info;
 	u32_t mask = kLPUART_TxDataRegEmptyInterruptEnable;
 
 	LPUART_DisableInterrupts(config->base, mask);
@@ -131,7 +131,7 @@ static void mcux_lpuart_irq_tx_disable(struct device *dev)
 
 static int mcux_lpuart_irq_tx_complete(struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config->config_info;
+	const struct mcux_lpuart_config *config = dev->config_info;
 	u32_t flags = LPUART_GetStatusFlags(config->base);
 
 	return (flags & kLPUART_TxDataRegEmptyFlag) != 0U;
@@ -139,7 +139,7 @@ static int mcux_lpuart_irq_tx_complete(struct device *dev)
 
 static int mcux_lpuart_irq_tx_ready(struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config->config_info;
+	const struct mcux_lpuart_config *config = dev->config_info;
 	u32_t mask = kLPUART_TxDataRegEmptyInterruptEnable;
 
 	return (LPUART_GetEnabledInterrupts(config->base) & mask)
@@ -148,7 +148,7 @@ static int mcux_lpuart_irq_tx_ready(struct device *dev)
 
 static void mcux_lpuart_irq_rx_enable(struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config->config_info;
+	const struct mcux_lpuart_config *config = dev->config_info;
 	u32_t mask = kLPUART_RxDataRegFullInterruptEnable;
 
 	LPUART_EnableInterrupts(config->base, mask);
@@ -156,7 +156,7 @@ static void mcux_lpuart_irq_rx_enable(struct device *dev)
 
 static void mcux_lpuart_irq_rx_disable(struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config->config_info;
+	const struct mcux_lpuart_config *config = dev->config_info;
 	u32_t mask = kLPUART_RxDataRegFullInterruptEnable;
 
 	LPUART_DisableInterrupts(config->base, mask);
@@ -164,7 +164,7 @@ static void mcux_lpuart_irq_rx_disable(struct device *dev)
 
 static int mcux_lpuart_irq_rx_full(struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config->config_info;
+	const struct mcux_lpuart_config *config = dev->config_info;
 	u32_t flags = LPUART_GetStatusFlags(config->base);
 
 	return (flags & kLPUART_RxDataRegFullFlag) != 0U;
@@ -172,7 +172,7 @@ static int mcux_lpuart_irq_rx_full(struct device *dev)
 
 static int mcux_lpuart_irq_rx_ready(struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config->config_info;
+	const struct mcux_lpuart_config *config = dev->config_info;
 	u32_t mask = kLPUART_RxDataRegFullInterruptEnable;
 
 	return (LPUART_GetEnabledInterrupts(config->base) & mask)
@@ -181,7 +181,7 @@ static int mcux_lpuart_irq_rx_ready(struct device *dev)
 
 static void mcux_lpuart_irq_err_enable(struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config->config_info;
+	const struct mcux_lpuart_config *config = dev->config_info;
 	u32_t mask = kLPUART_NoiseErrorInterruptEnable |
 			kLPUART_FramingErrorInterruptEnable |
 			kLPUART_ParityErrorInterruptEnable;
@@ -191,7 +191,7 @@ static void mcux_lpuart_irq_err_enable(struct device *dev)
 
 static void mcux_lpuart_irq_err_disable(struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config->config_info;
+	const struct mcux_lpuart_config *config = dev->config_info;
 	u32_t mask = kLPUART_NoiseErrorInterruptEnable |
 			kLPUART_FramingErrorInterruptEnable |
 			kLPUART_ParityErrorInterruptEnable;
@@ -233,7 +233,7 @@ static void mcux_lpuart_isr(void *arg)
 
 static int mcux_lpuart_init(struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config->config_info;
+	const struct mcux_lpuart_config *config = dev->config_info;
 	lpuart_config_t uart_config;
 	struct device *clock_dev;
 	u32_t clock_freq;

--- a/drivers/serial/uart_miv.c
+++ b/drivers/serial/uart_miv.c
@@ -146,7 +146,7 @@ struct uart_miv_data {
 
 #define DEV_CFG(dev)						\
 	((const struct uart_miv_device_config * const)		\
-	 (dev)->config->config_info)
+	 (dev)->config_info)
 #define DEV_UART(dev)						\
 	((struct uart_miv_regs_t *)(DEV_CFG(dev))->uart_addr)
 #define DEV_DATA(dev)						\

--- a/drivers/serial/uart_msp432p4xx.c
+++ b/drivers/serial/uart_msp432p4xx.c
@@ -29,7 +29,7 @@ struct uart_msp432p4xx_dev_data_t {
 };
 
 #define DEV_CFG(dev) \
-	((const struct uart_device_config * const)(dev)->config->config_info)
+	((const struct uart_device_config * const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct uart_msp432p4xx_dev_data_t * const)(dev)->driver_data)
 

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -63,7 +63,7 @@ static inline struct uart_nrfx_data *get_dev_data(struct device *dev)
 
 static inline const struct uart_nrfx_config *get_dev_config(struct device *dev)
 {
-	return dev->config->config_info;
+	return dev->config_info;
 }
 
 #ifdef CONFIG_UART_0_ASYNC

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -140,7 +140,7 @@ static inline struct uarte_nrfx_data *get_dev_data(struct device *dev)
 
 static inline const struct uarte_nrfx_config *get_dev_config(struct device *dev)
 {
-	return dev->config->config_info;
+	return dev->config_info;
 }
 
 static inline NRF_UARTE_Type *get_uarte_instance(struct device *dev)

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -202,7 +202,7 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_PCIE), "NS16550(s) in DT need CONFIG_PCIE");
 
 #define DEV_CFG(dev) \
 	((struct uart_ns16550_device_config * const) \
-	 (dev)->config->config_info)
+	 (dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct uart_ns16550_dev_data_t *)(dev)->driver_data)
 

--- a/drivers/serial/uart_nsim.c
+++ b/drivers/serial/uart_nsim.c
@@ -49,7 +49,7 @@
 
 
 #define DEV_CFG(dev) \
-	((const struct uart_device_config * const)(dev)->config->config_info)
+	((const struct uart_device_config * const)(dev)->config_info)
 
 
 #define UART_REG_SET(u, r, v) ((*(u8_t *)(u + r)) = v)

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -141,7 +141,7 @@ struct pl011_data {
 		PL011_IMSC_RTIM)
 
 #define DEV_CFG(dev) \
-	((const struct uart_device_config * const)(dev)->config->config_info)
+	((const struct uart_device_config * const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct pl011_data *)(dev)->driver_data)
 #define PL011_REGS(dev) \

--- a/drivers/serial/uart_psoc6.c
+++ b/drivers/serial/uart_psoc6.c
@@ -94,7 +94,7 @@ static const cy_stc_scb_uart_config_t uartConfig = {
  */
 static int uart_psoc6_init(struct device *dev)
 {
-	const struct cypress_psoc6_config *config = dev->config->config_info;
+	const struct cypress_psoc6_config *config = dev->config_info;
 
 	/* Connect SCB5 UART function to pins */
 	Cy_GPIO_SetHSIOM(config->port, config->rx_num, config->rx_val);
@@ -125,7 +125,7 @@ static int uart_psoc6_init(struct device *dev)
 
 static int uart_psoc6_poll_in(struct device *dev, unsigned char *c)
 {
-	const struct cypress_psoc6_config *config = dev->config->config_info;
+	const struct cypress_psoc6_config *config = dev->config_info;
 	u32_t rec;
 
 	rec = Cy_SCB_UART_Get(config->base);
@@ -136,7 +136,7 @@ static int uart_psoc6_poll_in(struct device *dev, unsigned char *c)
 
 static void uart_psoc6_poll_out(struct device *dev, unsigned char c)
 {
-	const struct cypress_psoc6_config *config = dev->config->config_info;
+	const struct cypress_psoc6_config *config = dev->config_info;
 
 	while (Cy_SCB_UART_Put(config->base, (uint32_t)c) != 1UL) {
 	}

--- a/drivers/serial/uart_rtt.c
+++ b/drivers/serial/uart_rtt.c
@@ -17,7 +17,7 @@ struct uart_rtt_config {
 
 static inline const struct uart_rtt_config *get_dev_config(struct device *dev)
 {
-	return dev->config->config_info;
+	return dev->config_info;
 }
 
 static int uart_rtt_init(struct device *dev)
@@ -30,10 +30,10 @@ static int uart_rtt_init(struct device *dev)
 	if (get_dev_config(dev)) {
 		const struct uart_rtt_config *cfg = get_dev_config(dev);
 
-		SEGGER_RTT_ConfigUpBuffer(cfg->channel, dev->config->name,
+		SEGGER_RTT_ConfigUpBuffer(cfg->channel, dev->name,
 					  cfg->up_buffer, cfg->up_size,
 					  SEGGER_RTT_MODE_NO_BLOCK_SKIP);
-		SEGGER_RTT_ConfigDownBuffer(cfg->channel, dev->config->name,
+		SEGGER_RTT_ConfigDownBuffer(cfg->channel, dev->name,
 					    cfg->down_buffer, cfg->down_size,
 					    SEGGER_RTT_MODE_NO_BLOCK_SKIP);
 	}

--- a/drivers/serial/uart_rv32m1_lpuart.c
+++ b/drivers/serial/uart_rv32m1_lpuart.c
@@ -36,7 +36,7 @@ struct rv32m1_lpuart_data {
 
 static int rv32m1_lpuart_poll_in(struct device *dev, unsigned char *c)
 {
-	const struct rv32m1_lpuart_config *config = dev->config->config_info;
+	const struct rv32m1_lpuart_config *config = dev->config_info;
 	u32_t flags = LPUART_GetStatusFlags(config->base);
 	int ret = -1;
 
@@ -50,7 +50,7 @@ static int rv32m1_lpuart_poll_in(struct device *dev, unsigned char *c)
 
 static void rv32m1_lpuart_poll_out(struct device *dev, unsigned char c)
 {
-	const struct rv32m1_lpuart_config *config = dev->config->config_info;
+	const struct rv32m1_lpuart_config *config = dev->config_info;
 
 	while (!(LPUART_GetStatusFlags(config->base)
 		& kLPUART_TxDataRegEmptyFlag)) {
@@ -61,7 +61,7 @@ static void rv32m1_lpuart_poll_out(struct device *dev, unsigned char c)
 
 static int rv32m1_lpuart_err_check(struct device *dev)
 {
-	const struct rv32m1_lpuart_config *config = dev->config->config_info;
+	const struct rv32m1_lpuart_config *config = dev->config_info;
 	u32_t flags = LPUART_GetStatusFlags(config->base);
 	int err = 0;
 
@@ -88,7 +88,7 @@ static int rv32m1_lpuart_err_check(struct device *dev)
 static int rv32m1_lpuart_fifo_fill(struct device *dev, const u8_t *tx_data,
 			       int len)
 {
-	const struct rv32m1_lpuart_config *config = dev->config->config_info;
+	const struct rv32m1_lpuart_config *config = dev->config_info;
 	u8_t num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
@@ -104,7 +104,7 @@ static int rv32m1_lpuart_fifo_fill(struct device *dev, const u8_t *tx_data,
 static int rv32m1_lpuart_fifo_read(struct device *dev, u8_t *rx_data,
 			       const int len)
 {
-	const struct rv32m1_lpuart_config *config = dev->config->config_info;
+	const struct rv32m1_lpuart_config *config = dev->config_info;
 	u8_t num_rx = 0U;
 
 	while ((len - num_rx > 0) &&
@@ -119,7 +119,7 @@ static int rv32m1_lpuart_fifo_read(struct device *dev, u8_t *rx_data,
 
 static void rv32m1_lpuart_irq_tx_enable(struct device *dev)
 {
-	const struct rv32m1_lpuart_config *config = dev->config->config_info;
+	const struct rv32m1_lpuart_config *config = dev->config_info;
 	u32_t mask = kLPUART_TxDataRegEmptyInterruptEnable;
 
 	LPUART_EnableInterrupts(config->base, mask);
@@ -127,7 +127,7 @@ static void rv32m1_lpuart_irq_tx_enable(struct device *dev)
 
 static void rv32m1_lpuart_irq_tx_disable(struct device *dev)
 {
-	const struct rv32m1_lpuart_config *config = dev->config->config_info;
+	const struct rv32m1_lpuart_config *config = dev->config_info;
 	u32_t mask = kLPUART_TxDataRegEmptyInterruptEnable;
 
 	LPUART_DisableInterrupts(config->base, mask);
@@ -135,7 +135,7 @@ static void rv32m1_lpuart_irq_tx_disable(struct device *dev)
 
 static int rv32m1_lpuart_irq_tx_complete(struct device *dev)
 {
-	const struct rv32m1_lpuart_config *config = dev->config->config_info;
+	const struct rv32m1_lpuart_config *config = dev->config_info;
 	u32_t flags = LPUART_GetStatusFlags(config->base);
 
 	return (flags & kLPUART_TxDataRegEmptyFlag) != 0U;
@@ -143,7 +143,7 @@ static int rv32m1_lpuart_irq_tx_complete(struct device *dev)
 
 static int rv32m1_lpuart_irq_tx_ready(struct device *dev)
 {
-	const struct rv32m1_lpuart_config *config = dev->config->config_info;
+	const struct rv32m1_lpuart_config *config = dev->config_info;
 	u32_t mask = kLPUART_TxDataRegEmptyInterruptEnable;
 
 	return (LPUART_GetEnabledInterrupts(config->base) & mask)
@@ -152,7 +152,7 @@ static int rv32m1_lpuart_irq_tx_ready(struct device *dev)
 
 static void rv32m1_lpuart_irq_rx_enable(struct device *dev)
 {
-	const struct rv32m1_lpuart_config *config = dev->config->config_info;
+	const struct rv32m1_lpuart_config *config = dev->config_info;
 	u32_t mask = kLPUART_RxDataRegFullInterruptEnable;
 
 	LPUART_EnableInterrupts(config->base, mask);
@@ -160,7 +160,7 @@ static void rv32m1_lpuart_irq_rx_enable(struct device *dev)
 
 static void rv32m1_lpuart_irq_rx_disable(struct device *dev)
 {
-	const struct rv32m1_lpuart_config *config = dev->config->config_info;
+	const struct rv32m1_lpuart_config *config = dev->config_info;
 	u32_t mask = kLPUART_RxDataRegFullInterruptEnable;
 
 	LPUART_DisableInterrupts(config->base, mask);
@@ -168,7 +168,7 @@ static void rv32m1_lpuart_irq_rx_disable(struct device *dev)
 
 static int rv32m1_lpuart_irq_rx_full(struct device *dev)
 {
-	const struct rv32m1_lpuart_config *config = dev->config->config_info;
+	const struct rv32m1_lpuart_config *config = dev->config_info;
 	u32_t flags = LPUART_GetStatusFlags(config->base);
 
 	return (flags & kLPUART_RxDataRegFullFlag) != 0U;
@@ -176,7 +176,7 @@ static int rv32m1_lpuart_irq_rx_full(struct device *dev)
 
 static int rv32m1_lpuart_irq_rx_ready(struct device *dev)
 {
-	const struct rv32m1_lpuart_config *config = dev->config->config_info;
+	const struct rv32m1_lpuart_config *config = dev->config_info;
 	u32_t mask = kLPUART_RxDataRegFullInterruptEnable;
 
 	return (LPUART_GetEnabledInterrupts(config->base) & mask)
@@ -185,7 +185,7 @@ static int rv32m1_lpuart_irq_rx_ready(struct device *dev)
 
 static void rv32m1_lpuart_irq_err_enable(struct device *dev)
 {
-	const struct rv32m1_lpuart_config *config = dev->config->config_info;
+	const struct rv32m1_lpuart_config *config = dev->config_info;
 	u32_t mask = kLPUART_NoiseErrorInterruptEnable |
 			kLPUART_FramingErrorInterruptEnable |
 			kLPUART_ParityErrorInterruptEnable;
@@ -195,7 +195,7 @@ static void rv32m1_lpuart_irq_err_enable(struct device *dev)
 
 static void rv32m1_lpuart_irq_err_disable(struct device *dev)
 {
-	const struct rv32m1_lpuart_config *config = dev->config->config_info;
+	const struct rv32m1_lpuart_config *config = dev->config_info;
 	u32_t mask = kLPUART_NoiseErrorInterruptEnable |
 			kLPUART_FramingErrorInterruptEnable |
 			kLPUART_ParityErrorInterruptEnable;
@@ -237,7 +237,7 @@ static void rv32m1_lpuart_isr(void *arg)
 
 static int rv32m1_lpuart_init(struct device *dev)
 {
-	const struct rv32m1_lpuart_config *config = dev->config->config_info;
+	const struct rv32m1_lpuart_config *config = dev->config_info;
 	lpuart_config_t uart_config;
 	struct device *clock_dev;
 	u32_t clock_freq;

--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -44,7 +44,7 @@ struct uart_sam_dev_data {
 };
 
 #define DEV_CFG(dev) \
-	((const struct uart_sam_dev_cfg *const)(dev)->config->config_info)
+	((const struct uart_sam_dev_cfg *const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct uart_sam_dev_data *const)(dev)->driver_data)
 

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -77,7 +77,7 @@ struct uart_sam0_dev_data {
 };
 
 #define DEV_CFG(dev) \
-	((const struct uart_sam0_dev_cfg *const)(dev)->config->config_info)
+	((const struct uart_sam0_dev_cfg *const)(dev)->config_info)
 #define DEV_DATA(dev) ((struct uart_sam0_dev_data * const)(dev)->driver_data)
 
 static void wait_synchronization(SercomUsart *const usart)

--- a/drivers/serial/uart_sifive.c
+++ b/drivers/serial/uart_sifive.c
@@ -66,7 +66,7 @@ struct uart_sifive_data {
 
 #define DEV_CFG(dev)						\
 	((const struct uart_sifive_device_config * const)	\
-	 (dev)->config->config_info)
+	 (dev)->config_info)
 #define DEV_UART(dev)						\
 	((struct uart_sifive_regs_t *)(DEV_CFG(dev))->port)
 #define DEV_DATA(dev)						\

--- a/drivers/serial/uart_stellaris.c
+++ b/drivers/serial/uart_stellaris.c
@@ -80,7 +80,7 @@ struct uart_stellaris_dev_data_t {
 /* convenience defines */
 
 #define DEV_CFG(dev) \
-	((const struct uart_device_config * const)(dev)->config->config_info)
+	((const struct uart_device_config * const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct uart_stellaris_dev_data_t * const)(dev)->driver_data)
 #define UART_STRUCT(dev) \

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -35,7 +35,7 @@ LOG_MODULE_REGISTER(uart_stm32);
 
 /* convenience defines */
 #define DEV_CFG(dev)							\
-	((const struct uart_stm32_config * const)(dev)->config->config_info)
+	((const struct uart_stm32_config * const)(dev)->config_info)
 #define DEV_DATA(dev)							\
 	((struct uart_stm32_data * const)(dev)->driver_data)
 #define UART_STRUCT(dev)					\

--- a/drivers/serial/uart_xlnx_ps.c
+++ b/drivers/serial/uart_xlnx_ps.c
@@ -152,7 +152,7 @@ struct uart_xlnx_ps_dev_data_t {
 
 #define DEV_CFG(dev) \
 	((const struct uart_xlnx_ps_dev_config * const) \
-	 (dev)->config->config_info)
+	 (dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct uart_xlnx_ps_dev_data_t *)(dev)->driver_data)
 

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -44,7 +44,7 @@ struct usart_sam_dev_data {
 };
 
 #define DEV_CFG(dev) \
-	((const struct usart_sam_dev_cfg *const)(dev)->config->config_info)
+	((const struct usart_sam_dev_cfg *const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct usart_sam_dev_data *const)(dev)->driver_data)
 

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -47,7 +47,7 @@ static inline struct spi_cc13xx_cc26xx_data *get_dev_data(struct device *dev)
 static inline const struct spi_cc13xx_cc26xx_config *
 get_dev_config(struct device *dev)
 {
-	return dev->config->config_info;
+	return dev->config_info;
 }
 
 static int spi_cc13xx_cc26xx_configure(struct device *dev,

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -55,7 +55,7 @@ static inline bool spi_dw_is_slave(struct spi_dw_data *spi)
 
 static void completed(struct device *dev, int error)
 {
-	const struct spi_dw_config *info = dev->config->config_info;
+	const struct spi_dw_config *info = dev->config_info;
 	struct spi_dw_data *spi = dev->driver_data;
 
 	if (error) {
@@ -87,7 +87,7 @@ out:
 
 static void push_data(struct device *dev)
 {
-	const struct spi_dw_config *info = dev->config->config_info;
+	const struct spi_dw_config *info = dev->config_info;
 	struct spi_dw_data *spi = dev->driver_data;
 	u32_t data = 0U;
 	u32_t f_tx;
@@ -156,7 +156,7 @@ static void push_data(struct device *dev)
 
 static void pull_data(struct device *dev)
 {
-	const struct spi_dw_config *info = dev->config->config_info;
+	const struct spi_dw_config *info = dev->config_info;
 	struct spi_dw_data *spi = dev->driver_data;
 
 	DBG_COUNTER_INIT();
@@ -336,7 +336,7 @@ static int transceive(struct device *dev,
 		      bool asynchronous,
 		      struct k_poll_signal *signal)
 {
-	const struct spi_dw_config *info = dev->config->config_info;
+	const struct spi_dw_config *info = dev->config_info;
 	struct spi_dw_data *spi = dev->driver_data;
 	u32_t tmod = DW_SPI_CTRLR0_TMOD_TX_RX;
 	u32_t reg_data;
@@ -478,7 +478,7 @@ static int spi_dw_release(struct device *dev, const struct spi_config *config)
 
 void spi_dw_isr(struct device *dev)
 {
-	const struct spi_dw_config *info = dev->config->config_info;
+	const struct spi_dw_config *info = dev->config_info;
 	u32_t int_status;
 	int error;
 
@@ -517,7 +517,7 @@ static const struct spi_driver_api dw_spi_api = {
 
 int spi_dw_init(struct device *dev)
 {
-	const struct spi_dw_config *info = dev->config->config_info;
+	const struct spi_dw_config *info = dev->config_info;
 	struct spi_dw_data *spi = dev->driver_data;
 
 	clock_config(dev);

--- a/drivers/spi/spi_dw.h
+++ b/drivers/spi/spi_dw.h
@@ -231,7 +231,7 @@ DEFINE_TEST_BIT_OP(sr_busy, DW_SPI_REG_SR, DW_SPI_SR_BUSY_BIT)
 
 static inline int clock_config(struct device *dev)
 {
-	const struct spi_dw_config *info = dev->config->config_info;
+	const struct spi_dw_config *info = dev->config_info;
 	struct spi_dw_data *spi = dev->driver_data;
 
 	if (!info->clock_name || strlen(info->clock_name) == 0) {
@@ -252,7 +252,7 @@ static inline void clock_on(struct device *dev)
 	struct spi_dw_data *spi = dev->driver_data;
 
 	if (spi->clock) {
-		const struct spi_dw_config *info = dev->config->config_info;
+		const struct spi_dw_config *info = dev->config_info;
 
 		clock_control_on(spi->clock, info->clock_data);
 	}
@@ -265,7 +265,7 @@ static inline void clock_off(struct device *dev)
 	struct spi_dw_data *spi = dev->driver_data;
 
 	if (spi->clock) {
-		const struct spi_dw_config *info = dev->config->config_info;
+		const struct spi_dw_config *info = dev->config_info;
 
 		clock_control_off(spi->clock, info->clock_data);
 	}

--- a/drivers/spi/spi_gecko.c
+++ b/drivers/spi/spi_gecko.c
@@ -53,7 +53,7 @@ struct spi_gecko_config {
 static int spi_config(struct device *dev, const struct spi_config *config,
 		      u16_t *control)
 {
-	const struct spi_gecko_config *gecko_config = dev->config->config_info;
+	const struct spi_gecko_config *gecko_config = dev->config_info;
 	struct spi_gecko_data *data = DEV_DATA(dev);
 
 	if (SPI_WORD_SIZE_GET(config->operation) != SPI_WORD_SIZE) {
@@ -168,7 +168,7 @@ static void spi_gecko_xfer(struct device *dev,
 {
 	int ret;
 	struct spi_context *ctx = &DEV_DATA(dev)->ctx;
-	const struct spi_gecko_config *gecko_config = dev->config->config_info;
+	const struct spi_gecko_config *gecko_config = dev->config_info;
 	struct spi_gecko_data *data = DEV_DATA(dev);
 
 	spi_context_cs_control(ctx, true);
@@ -183,7 +183,7 @@ static void spi_gecko_xfer(struct device *dev,
 
 static void spi_gecko_init_pins(struct device *dev)
 {
-	const struct spi_gecko_config *config = dev->config->config_info;
+	const struct spi_gecko_config *config = dev->config_info;
 
 	soc_gpio_configure(&config->pin_rx);
 	soc_gpio_configure(&config->pin_tx);
@@ -208,7 +208,7 @@ static void spi_gecko_init_pins(struct device *dev)
 
 static int spi_gecko_init(struct device *dev)
 {
-	const struct spi_gecko_config *config = dev->config->config_info;
+	const struct spi_gecko_config *config = dev->config_info;
 	USART_InitSync_TypeDef usartInit = USART_INITSYNC_DEFAULT;
 
 	/* The peripheral and gpio clock are already enabled from soc and gpio
@@ -269,7 +269,7 @@ static int spi_gecko_transceive_async(struct device *dev,
 static int spi_gecko_release(struct device *dev,
 			     const struct spi_config *config)
 {
-	const struct spi_gecko_config *gecko_config = dev->config->config_info;
+	const struct spi_gecko_config *gecko_config = dev->config_info;
 
 	if (!(gecko_config->base->STATUS & USART_STATUS_TXIDLE)) {
 		return -EBUSY;

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -26,7 +26,7 @@ LOG_MODULE_REGISTER(spi_ll_stm32);
 #include "spi_ll_stm32.h"
 
 #define DEV_CFG(dev)						\
-(const struct spi_stm32_config * const)(dev->config->config_info)
+(const struct spi_stm32_config * const)(dev->config_info)
 
 #define DEV_DATA(dev)					\
 (struct spi_stm32_data * const)(dev->driver_data)
@@ -451,7 +451,7 @@ static void spi_stm32_complete(struct spi_stm32_data *data, SPI_TypeDef *spi,
 static void spi_stm32_isr(void *arg)
 {
 	struct device * const dev = (struct device *) arg;
-	const struct spi_stm32_config *cfg = dev->config->config_info;
+	const struct spi_stm32_config *cfg = dev->config_info;
 	struct spi_stm32_data *data = dev->driver_data;
 	SPI_TypeDef *spi = cfg->spi;
 	int err;
@@ -778,7 +778,7 @@ static const struct spi_driver_api api_funcs = {
 static int spi_stm32_init(struct device *dev)
 {
 	struct spi_stm32_data *data __attribute__((unused)) = dev->driver_data;
-	const struct spi_stm32_config *cfg = dev->config->config_info;
+	const struct spi_stm32_config *cfg = dev->config_info;
 
 	__ASSERT_NO_MSG(device_get_binding(STM32_CLOCK_CONTROL_NAME));
 

--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -33,7 +33,7 @@ struct spi_mcux_data {
 
 static int spi_mcux_transfer_next_packet(struct device *dev)
 {
-	const struct spi_mcux_config *config = dev->config->config_info;
+	const struct spi_mcux_config *config = dev->config_info;
 	struct spi_mcux_data *data = dev->driver_data;
 	SPI_Type *base = config->base;
 	struct spi_context *ctx = &data->ctx;
@@ -103,7 +103,7 @@ static int spi_mcux_transfer_next_packet(struct device *dev)
 static void spi_mcux_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct spi_mcux_config *config = dev->config->config_info;
+	const struct spi_mcux_config *config = dev->config_info;
 	struct spi_mcux_data *data = dev->driver_data;
 	SPI_Type *base = config->base;
 
@@ -125,7 +125,7 @@ static void spi_mcux_master_transfer_callback(SPI_Type *base,
 static int spi_mcux_configure(struct device *dev,
 			      const struct spi_config *spi_cfg)
 {
-	const struct spi_mcux_config *config = dev->config->config_info;
+	const struct spi_mcux_config *config = dev->config_info;
 	struct spi_mcux_data *data = dev->driver_data;
 	SPI_Type *base = config->base;
 	dspi_master_config_t master_config;
@@ -259,7 +259,7 @@ static int spi_mcux_release(struct device *dev,
 
 static int spi_mcux_init(struct device *dev)
 {
-	const struct spi_mcux_config *config = dev->config->config_info;
+	const struct spi_mcux_config *config = dev->config_info;
 	struct spi_mcux_data *data = dev->driver_data;
 
 	config->irq_config_func(dev);

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -32,7 +32,7 @@ struct spi_mcux_data {
 
 static void spi_mcux_transfer_next_packet(struct device *dev)
 {
-	const struct spi_mcux_config *config = dev->config->config_info;
+	const struct spi_mcux_config *config = dev->config_info;
 	struct spi_mcux_data *data = dev->driver_data;
 	SPI_Type *base = config->base;
 	struct spi_context *ctx = &data->ctx;
@@ -99,7 +99,7 @@ static void spi_mcux_transfer_next_packet(struct device *dev)
 static void spi_mcux_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct spi_mcux_config *config = dev->config->config_info;
+	const struct spi_mcux_config *config = dev->config_info;
 	struct spi_mcux_data *data = dev->driver_data;
 	SPI_Type *base = config->base;
 
@@ -121,7 +121,7 @@ static void spi_mcux_master_transfer_callback(SPI_Type *base,
 static int spi_mcux_configure(struct device *dev,
 			      const struct spi_config *spi_cfg)
 {
-	const struct spi_mcux_config *config = dev->config->config_info;
+	const struct spi_mcux_config *config = dev->config_info;
 	struct spi_mcux_data *data = dev->driver_data;
 	SPI_Type *base = config->base;
 	spi_master_config_t master_config;
@@ -249,7 +249,7 @@ static int spi_mcux_release(struct device *dev,
 
 static int spi_mcux_init(struct device *dev)
 {
-	const struct spi_mcux_config *config = dev->config->config_info;
+	const struct spi_mcux_config *config = dev->config_info;
 	struct spi_mcux_data *data = dev->driver_data;
 
 	config->irq_config_func(dev);

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -35,7 +35,7 @@ struct spi_mcux_data {
 
 static void spi_mcux_transfer_next_packet(struct device *dev)
 {
-	const struct spi_mcux_config *config = dev->config->config_info;
+	const struct spi_mcux_config *config = dev->config_info;
 	struct spi_mcux_data *data = dev->driver_data;
 	LPSPI_Type *base = config->base;
 	struct spi_context *ctx = &data->ctx;
@@ -103,7 +103,7 @@ static void spi_mcux_transfer_next_packet(struct device *dev)
 static void spi_mcux_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct spi_mcux_config *config = dev->config->config_info;
+	const struct spi_mcux_config *config = dev->config_info;
 	struct spi_mcux_data *data = dev->driver_data;
 	LPSPI_Type *base = config->base;
 
@@ -125,7 +125,7 @@ static void spi_mcux_master_transfer_callback(LPSPI_Type *base,
 static int spi_mcux_configure(struct device *dev,
 			      const struct spi_config *spi_cfg)
 {
-	const struct spi_mcux_config *config = dev->config->config_info;
+	const struct spi_mcux_config *config = dev->config_info;
 	struct spi_mcux_data *data = dev->driver_data;
 	LPSPI_Type *base = config->base;
 	lpspi_master_config_t master_config;
@@ -257,7 +257,7 @@ static int spi_mcux_release(struct device *dev,
 
 static int spi_mcux_init(struct device *dev)
 {
-	const struct spi_mcux_config *config = dev->config->config_info;
+	const struct spi_mcux_config *config = dev->config_info;
 	struct spi_mcux_data *data = dev->driver_data;
 
 	config->irq_config_func(dev);

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -35,7 +35,7 @@ static inline struct spi_nrfx_data *get_dev_data(struct device *dev)
 
 static inline const struct spi_nrfx_config *get_dev_config(struct device *dev)
 {
-	return dev->config->config_info;
+	return dev->config_info;
 }
 
 static inline nrf_spi_frequency_t get_nrf_spi_frequency(u32_t frequency)
@@ -98,7 +98,7 @@ static int configure(struct device *dev,
 
 	if (SPI_OP_MODE_GET(spi_cfg->operation) != SPI_OP_MODE_MASTER) {
 		LOG_ERR("Slave mode is not supported on %s",
-			    dev->config->name);
+			    dev->name);
 		return -EINVAL;
 	}
 
@@ -268,7 +268,7 @@ static int init_spi(struct device *dev)
 					  dev);
 	if (result != NRFX_SUCCESS) {
 		LOG_ERR("Failed to initialize device: %s",
-			    dev->config->name);
+			    dev->name);
 		return -EBUSY;
 	}
 

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -40,7 +40,7 @@ static inline struct spi_nrfx_data *get_dev_data(struct device *dev)
 
 static inline const struct spi_nrfx_config *get_dev_config(struct device *dev)
 {
-	return dev->config->config_info;
+	return dev->config_info;
 }
 
 static inline nrf_spim_frequency_t get_nrf_spim_frequency(u32_t frequency)
@@ -112,7 +112,7 @@ static int configure(struct device *dev,
 
 	if (SPI_OP_MODE_GET(spi_cfg->operation) != SPI_OP_MODE_MASTER) {
 		LOG_ERR("Slave mode is not supported on %s",
-			    dev->config->name);
+			    dev->name);
 		return -EINVAL;
 	}
 
@@ -307,7 +307,7 @@ static int init_spim(struct device *dev)
 					   dev);
 	if (result != NRFX_SUCCESS) {
 		LOG_ERR("Failed to initialize device: %s",
-			    dev->config->name);
+			    dev->name);
 		return -EBUSY;
 	}
 

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -30,7 +30,7 @@ static inline struct spi_nrfx_data *get_dev_data(struct device *dev)
 
 static inline const struct spi_nrfx_config *get_dev_config(struct device *dev)
 {
-	return dev->config->config_info;
+	return dev->config_info;
 }
 
 static inline nrf_spis_mode_t get_nrf_spis_mode(u16_t operation)
@@ -71,7 +71,7 @@ static int configure(struct device *dev,
 
 	if (SPI_OP_MODE_GET(spi_cfg->operation) == SPI_OP_MODE_MASTER) {
 		LOG_ERR("Master mode is not supported on %s",
-			    dev->config->name);
+			    dev->name);
 		return -EINVAL;
 	}
 
@@ -240,7 +240,7 @@ static int init_spis(struct device *dev, const nrfx_spis_config_t *config)
 					   dev);
 	if (result != NRFX_SUCCESS) {
 		LOG_ERR("Failed to initialize device: %s",
-			    dev->config->name);
+			    dev->name);
 		return -EBUSY;
 	}
 

--- a/drivers/spi/spi_oc_simple.c
+++ b/drivers/spi/spi_oc_simple.c
@@ -90,7 +90,7 @@ int spi_oc_simple_transceive(struct device *dev,
 			  const struct spi_buf_set *tx_bufs,
 			  const struct spi_buf_set *rx_bufs)
 {
-	const struct spi_oc_simple_cfg *info = dev->config->config_info;
+	const struct spi_oc_simple_cfg *info = dev->config_info;
 	struct spi_oc_simple_data *spi = SPI_OC_SIMPLE_DATA(dev);
 	struct spi_context *ctx = &spi->ctx;
 
@@ -184,7 +184,7 @@ static struct spi_driver_api spi_oc_simple_api = {
 
 int spi_oc_simple_init(struct device *dev)
 {
-	const struct spi_oc_simple_cfg *info = dev->config->config_info;
+	const struct spi_oc_simple_cfg *info = dev->config_info;
 
 	/* Clear chip selects */
 	sys_write8(0, SPI_OC_SIMPLE_SPSS(info));

--- a/drivers/spi/spi_rv32m1_lpspi.c
+++ b/drivers/spi/spi_rv32m1_lpspi.c
@@ -39,7 +39,7 @@ struct spi_mcux_data {
 
 static void spi_mcux_transfer_next_packet(struct device *dev)
 {
-	const struct spi_mcux_config *config = dev->config->config_info;
+	const struct spi_mcux_config *config = dev->config_info;
 	struct spi_mcux_data *data = dev->driver_data;
 	LPSPI_Type *base = config->base;
 	struct spi_context *ctx = &data->ctx;
@@ -106,7 +106,7 @@ static void spi_mcux_transfer_next_packet(struct device *dev)
 static void spi_mcux_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct spi_mcux_config *config = dev->config->config_info;
+	const struct spi_mcux_config *config = dev->config_info;
 	struct spi_mcux_data *data = dev->driver_data;
 	LPSPI_Type *base = config->base;
 
@@ -128,7 +128,7 @@ static void spi_mcux_master_transfer_callback(LPSPI_Type *base,
 static int spi_mcux_configure(struct device *dev,
 			      const struct spi_config *spi_cfg)
 {
-	const struct spi_mcux_config *config = dev->config->config_info;
+	const struct spi_mcux_config *config = dev->config_info;
 	struct spi_mcux_data *data = dev->driver_data;
 	LPSPI_Type *base = config->base;
 	lpspi_master_config_t master_config;
@@ -258,7 +258,7 @@ static int spi_mcux_release(struct device *dev,
 
 static int spi_mcux_init(struct device *dev)
 {
-	const struct spi_mcux_config *config = dev->config->config_info;
+	const struct spi_mcux_config *config = dev->config_info;
 	struct spi_mcux_data *data = dev->driver_data;
 
 	CLOCK_SetIpSrc(config->clock_ip_name, config->clock_ip_src);

--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -51,7 +51,7 @@ static int spi_slave_to_mr_pcs(int slave)
 static int spi_sam_configure(struct device *dev,
 			     const struct spi_config *config)
 {
-	const struct spi_sam_config *cfg = dev->config->config_info;
+	const struct spi_sam_config *cfg = dev->config_info;
 	struct spi_sam_data *data = dev->driver_data;
 	Spi *regs = cfg->regs;
 	u32_t spi_mr = 0U, spi_csr = 0U;
@@ -272,7 +272,7 @@ static void spi_sam_fast_transceive(struct device *dev,
 				    const struct spi_buf_set *tx_bufs,
 				    const struct spi_buf_set *rx_bufs)
 {
-	const struct spi_sam_config *cfg = dev->config->config_info;
+	const struct spi_sam_config *cfg = dev->config_info;
 	size_t tx_count = 0;
 	size_t rx_count = 0;
 	Spi *regs = cfg->regs;
@@ -361,7 +361,7 @@ static int spi_sam_transceive(struct device *dev,
 			      const struct spi_buf_set *tx_bufs,
 			      const struct spi_buf_set *rx_bufs)
 {
-	const struct spi_sam_config *cfg = dev->config->config_info;
+	const struct spi_sam_config *cfg = dev->config_info;
 	struct spi_sam_data *data = dev->driver_data;
 	Spi *regs = cfg->regs;
 	int err;
@@ -429,7 +429,7 @@ static int spi_sam_release(struct device *dev,
 
 static int spi_sam_init(struct device *dev)
 {
-	const struct spi_sam_config *cfg = dev->config->config_info;
+	const struct spi_sam_config *cfg = dev->config_info;
 	struct spi_sam_data *data = dev->driver_data;
 
 	soc_pmc_peripheral_enable(cfg->periph_id);

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -68,7 +68,7 @@ static void wait_synchronization(SercomSpi *regs)
 static int spi_sam0_configure(struct device *dev,
 			      const struct spi_config *config)
 {
-	const struct spi_sam0_config *cfg = dev->config->config_info;
+	const struct spi_sam0_config *cfg = dev->config_info;
 	struct spi_sam0_data *data = dev->driver_data;
 	SercomSpi *regs = cfg->regs;
 	SERCOM_SPI_CTRLA_Type ctrla = {.reg = 0};
@@ -296,7 +296,7 @@ static void spi_sam0_fast_transceive(struct device *dev,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs)
 {
-	const struct spi_sam0_config *cfg = dev->config->config_info;
+	const struct spi_sam0_config *cfg = dev->config_info;
 	size_t tx_count = 0;
 	size_t rx_count = 0;
 	SercomSpi *regs = cfg->regs;
@@ -387,7 +387,7 @@ static int spi_sam0_transceive(struct device *dev,
 			       const struct spi_buf_set *tx_bufs,
 			       const struct spi_buf_set *rx_bufs)
 {
-	const struct spi_sam0_config *cfg = dev->config->config_info;
+	const struct spi_sam0_config *cfg = dev->config_info;
 	struct spi_sam0_data *data = dev->driver_data;
 	SercomSpi *regs = cfg->regs;
 	int err;
@@ -438,7 +438,7 @@ static void spi_sam0_dma_rx_done(void *arg, u32_t id, int error_code);
 static int spi_sam0_dma_rx_load(struct device *dev, u8_t *buf,
 				size_t len)
 {
-	const struct spi_sam0_config *cfg = dev->config->config_info;
+	const struct spi_sam0_config *cfg = dev->config_info;
 	struct spi_sam0_data *data = dev->driver_data;
 	SercomSpi *regs = cfg->regs;
 	struct dma_config dma_cfg = { 0 };
@@ -480,7 +480,7 @@ static int spi_sam0_dma_rx_load(struct device *dev, u8_t *buf,
 static int spi_sam0_dma_tx_load(struct device *dev, const u8_t *buf,
 				size_t len)
 {
-	const struct spi_sam0_config *cfg = dev->config->config_info;
+	const struct spi_sam0_config *cfg = dev->config_info;
 	struct spi_sam0_data *data = dev->driver_data;
 	SercomSpi *regs = cfg->regs;
 	struct dma_config dma_cfg = { 0 };
@@ -582,7 +582,7 @@ static int spi_sam0_dma_advance_buffers(struct device *dev)
 static void spi_sam0_dma_rx_done(void *arg, u32_t id, int error_code)
 {
 	struct device *dev = arg;
-	const struct spi_sam0_config *cfg = dev->config->config_info;
+	const struct spi_sam0_config *cfg = dev->config_info;
 	struct spi_sam0_data *data = dev->driver_data;
 	int retval;
 
@@ -616,7 +616,7 @@ static int spi_sam0_transceive_async(struct device *dev,
 				     const struct spi_buf_set *rx_bufs,
 				     struct k_poll_signal *async)
 {
-	const struct spi_sam0_config *cfg = dev->config->config_info;
+	const struct spi_sam0_config *cfg = dev->config_info;
 	struct spi_sam0_data *data = dev->driver_data;
 	int retval;
 
@@ -675,7 +675,7 @@ static int spi_sam0_release(struct device *dev,
 
 static int spi_sam0_init(struct device *dev)
 {
-	const struct spi_sam0_config *cfg = dev->config->config_info;
+	const struct spi_sam0_config *cfg = dev->config_info;
 	struct spi_sam0_data *data = dev->driver_data;
 	SercomSpi *regs = cfg->regs;
 

--- a/drivers/spi/spi_sifive.h
+++ b/drivers/spi/spi_sifive.h
@@ -13,7 +13,7 @@
 #include <device.h>
 #include <drivers/spi.h>
 
-#define SPI_CFG(dev) ((struct spi_sifive_cfg *) ((dev)->config->config_info))
+#define SPI_CFG(dev) ((struct spi_sifive_cfg *) ((dev)->config_info))
 #define SPI_DATA(dev) ((struct spi_sifive_data *) ((dev)->driver_data))
 
 #define SPI_REG(dev, offset) ((mem_addr_t) (SPI_CFG(dev)->base + (offset)))

--- a/drivers/spi/spi_xec_qmspi.c
+++ b/drivers/spi/spi_xec_qmspi.c
@@ -168,7 +168,7 @@ static u32_t qmspi_config_get_lines(const struct spi_config *config)
 static int qmspi_configure(struct device *dev,
 			   const struct spi_config *config)
 {
-	const struct spi_qmspi_config *cfg = dev->config->config_info;
+	const struct spi_qmspi_config *cfg = dev->config_info;
 	struct spi_qmspi_data *data = dev->driver_data;
 	QMSPI_Type *regs = cfg->regs;
 	u32_t smode;
@@ -508,7 +508,7 @@ static int qmspi_transceive(struct device *dev,
 			    const struct spi_buf_set *tx_bufs,
 			    const struct spi_buf_set *rx_bufs)
 {
-	const struct spi_qmspi_config *cfg = dev->config->config_info;
+	const struct spi_qmspi_config *cfg = dev->config_info;
 	struct spi_qmspi_data *data = dev->driver_data;
 	QMSPI_Type *regs = cfg->regs;
 	const struct spi_buf *ptx;
@@ -593,7 +593,7 @@ static int qmspi_release(struct device *dev,
 			 const struct spi_config *config)
 {
 	struct spi_qmspi_data *data = dev->driver_data;
-	const struct spi_qmspi_config *cfg = dev->config->config_info;
+	const struct spi_qmspi_config *cfg = dev->config_info;
 	QMSPI_Type *regs = cfg->regs;
 
 	/* Force CS# to de-assert on next unit boundary */
@@ -616,7 +616,7 @@ static int qmspi_release(struct device *dev,
  */
 static int qmspi_init(struct device *dev)
 {
-	const struct spi_qmspi_config *cfg = dev->config->config_info;
+	const struct spi_qmspi_config *cfg = dev->config_info;
 	struct spi_qmspi_data *data = dev->driver_data;
 	QMSPI_Type *regs = cfg->regs;
 

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -50,7 +50,7 @@ static void __frame_done_cb(CSI_Type *base, csi_handle_t *handle,
 			    status_t status, void *user_data)
 {
 	struct device *dev = user_data;
-	const struct video_mcux_csi_config *config = dev->config->config_info;
+	const struct video_mcux_csi_config *config = dev->config_info;
 	struct video_mcux_csi_data *data = dev->driver_data;
 	enum video_signal_result result = VIDEO_BUF_DONE;
 	struct video_buffer *vbuf, *vbuf_first = NULL;
@@ -115,7 +115,7 @@ done:
 static int video_mcux_csi_set_fmt(struct device *dev, enum video_endpoint_id ep,
 				  struct video_format *fmt)
 {
-	const struct video_mcux_csi_config *config = dev->config->config_info;
+	const struct video_mcux_csi_config *config = dev->config_info;
 	struct video_mcux_csi_data *data = dev->driver_data;
 	unsigned int bpp = video_pix_fmt_bpp(fmt->pixelformat);
 	status_t ret;
@@ -176,7 +176,7 @@ static int video_mcux_csi_get_fmt(struct device *dev, enum video_endpoint_id ep,
 
 static int video_mcux_csi_stream_start(struct device *dev)
 {
-	const struct video_mcux_csi_config *config = dev->config->config_info;
+	const struct video_mcux_csi_config *config = dev->config_info;
 	struct video_mcux_csi_data *data = dev->driver_data;
 	status_t ret;
 
@@ -194,7 +194,7 @@ static int video_mcux_csi_stream_start(struct device *dev)
 
 static int video_mcux_csi_stream_stop(struct device *dev)
 {
-	const struct video_mcux_csi_config *config = dev->config->config_info;
+	const struct video_mcux_csi_config *config = dev->config_info;
 	struct video_mcux_csi_data *data = dev->driver_data;
 	status_t ret;
 
@@ -214,7 +214,7 @@ static int video_mcux_csi_stream_stop(struct device *dev)
 static int video_mcux_csi_flush(struct device *dev, enum video_endpoint_id ep,
 				bool cancel)
 {
-	const struct video_mcux_csi_config *config = dev->config->config_info;
+	const struct video_mcux_csi_config *config = dev->config_info;
 	struct video_mcux_csi_data *data = dev->driver_data;
 	struct video_buf *vbuf;
 	u32_t buffer_addr;
@@ -248,7 +248,7 @@ static int video_mcux_csi_flush(struct device *dev, enum video_endpoint_id ep,
 static int video_mcux_csi_enqueue(struct device *dev, enum video_endpoint_id ep,
 				  struct video_buffer *vbuf)
 {
-	const struct video_mcux_csi_config *config = dev->config->config_info;
+	const struct video_mcux_csi_config *config = dev->config_info;
 	struct video_mcux_csi_data *data = dev->driver_data;
 	unsigned int to_read;
 	status_t ret;
@@ -349,7 +349,7 @@ static void video_mcux_csi_isr(void *p)
 
 static int video_mcux_csi_init(struct device *dev)
 {
-	const struct video_mcux_csi_config *config = dev->config->config_info;
+	const struct video_mcux_csi_config *config = dev->config_info;
 	struct video_mcux_csi_data *data = dev->driver_data;
 
 	k_fifo_init(&data->fifo_in);

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -58,7 +58,7 @@ struct wdt_esp32_config {
 };
 
 #define DEV_CFG(dev) \
-	((const struct wdt_esp32_config *const)(dev)->config->config_info)
+	((const struct wdt_esp32_config *const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct wdt_esp32_data *)(dev)->driver_data)
 #define DEV_BASE(dev) \

--- a/drivers/watchdog/wdt_gecko.c
+++ b/drivers/watchdog/wdt_gecko.c
@@ -32,11 +32,11 @@ struct wdt_gecko_data {
 	bool timeout_installed;
 };
 
-#define DEV_NAME(dev) ((dev)->config->name)
+#define DEV_NAME(dev) ((dev)->name)
 #define DEV_DATA(dev) \
 	((struct wdt_gecko_data *)(dev)->driver_data)
 #define DEV_CFG(dev) \
-	((struct wdt_gecko_cfg *)(dev)->config->config_info)
+	((struct wdt_gecko_cfg *)(dev)->config_info)
 
 static u32_t wdt_gecko_get_timeout_from_persel(int perSel)
 {

--- a/drivers/watchdog/wdt_mcux_wdog.c
+++ b/drivers/watchdog/wdt_mcux_wdog.c
@@ -32,7 +32,7 @@ struct mcux_wdog_data {
 
 static int mcux_wdog_setup(struct device *dev, u8_t options)
 {
-	const struct mcux_wdog_config *config = dev->config->config_info;
+	const struct mcux_wdog_config *config = dev->config_info;
 	struct mcux_wdog_data *data = dev->driver_data;
 	WDOG_Type *base = config->base;
 
@@ -55,7 +55,7 @@ static int mcux_wdog_setup(struct device *dev, u8_t options)
 
 static int mcux_wdog_disable(struct device *dev)
 {
-	const struct mcux_wdog_config *config = dev->config->config_info;
+	const struct mcux_wdog_config *config = dev->config_info;
 	struct mcux_wdog_data *data = dev->driver_data;
 	WDOG_Type *base = config->base;
 
@@ -69,7 +69,7 @@ static int mcux_wdog_disable(struct device *dev)
 static int mcux_wdog_install_timeout(struct device *dev,
 				     const struct wdt_timeout_cfg *cfg)
 {
-	const struct mcux_wdog_config *config = dev->config->config_info;
+	const struct mcux_wdog_config *config = dev->config_info;
 	struct mcux_wdog_data *data = dev->driver_data;
 	struct device *clock_dev;
 	u32_t clock_freq;
@@ -118,7 +118,7 @@ static int mcux_wdog_install_timeout(struct device *dev,
 
 static int mcux_wdog_feed(struct device *dev, int channel_id)
 {
-	const struct mcux_wdog_config *config = dev->config->config_info;
+	const struct mcux_wdog_config *config = dev->config_info;
 	WDOG_Type *base = config->base;
 
 	if (channel_id != 0) {
@@ -135,7 +135,7 @@ static int mcux_wdog_feed(struct device *dev, int channel_id)
 static void mcux_wdog_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct mcux_wdog_config *config = dev->config->config_info;
+	const struct mcux_wdog_config *config = dev->config_info;
 	struct mcux_wdog_data *data = dev->driver_data;
 	WDOG_Type *base = config->base;
 	u32_t flags;
@@ -150,7 +150,7 @@ static void mcux_wdog_isr(void *arg)
 
 static int mcux_wdog_init(struct device *dev)
 {
-	const struct mcux_wdog_config *config = dev->config->config_info;
+	const struct mcux_wdog_config *config = dev->config_info;
 
 	config->irq_config_func(dev);
 

--- a/drivers/watchdog/wdt_mcux_wdog32.c
+++ b/drivers/watchdog/wdt_mcux_wdog32.c
@@ -40,7 +40,7 @@ struct mcux_wdog32_data {
 
 static int mcux_wdog32_setup(struct device *dev, u8_t options)
 {
-	const struct mcux_wdog32_config *config = dev->config->config_info;
+	const struct mcux_wdog32_config *config = dev->config_info;
 	struct mcux_wdog32_data *data = dev->driver_data;
 	WDOG_Type *base = config->base;
 
@@ -63,7 +63,7 @@ static int mcux_wdog32_setup(struct device *dev, u8_t options)
 
 static int mcux_wdog32_disable(struct device *dev)
 {
-	const struct mcux_wdog32_config *config = dev->config->config_info;
+	const struct mcux_wdog32_config *config = dev->config_info;
 	struct mcux_wdog32_data *data = dev->driver_data;
 	WDOG_Type *base = config->base;
 
@@ -80,7 +80,7 @@ static int mcux_wdog32_disable(struct device *dev)
 static int mcux_wdog32_install_timeout(struct device *dev,
 				       const struct wdt_timeout_cfg *cfg)
 {
-	const struct mcux_wdog32_config *config = dev->config->config_info;
+	const struct mcux_wdog32_config *config = dev->config_info;
 	struct mcux_wdog32_data *data = dev->driver_data;
 	u32_t clock_freq;
 	int div;
@@ -139,7 +139,7 @@ static int mcux_wdog32_install_timeout(struct device *dev,
 
 static int mcux_wdog32_feed(struct device *dev, int channel_id)
 {
-	const struct mcux_wdog32_config *config = dev->config->config_info;
+	const struct mcux_wdog32_config *config = dev->config_info;
 	WDOG_Type *base = config->base;
 
 	if (channel_id != 0) {
@@ -156,7 +156,7 @@ static int mcux_wdog32_feed(struct device *dev, int channel_id)
 static void mcux_wdog32_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
-	const struct mcux_wdog32_config *config = dev->config->config_info;
+	const struct mcux_wdog32_config *config = dev->config_info;
 	struct mcux_wdog32_data *data = dev->driver_data;
 	WDOG_Type *base = config->base;
 	u32_t flags;
@@ -171,7 +171,7 @@ static void mcux_wdog32_isr(void *arg)
 
 static int mcux_wdog32_init(struct device *dev)
 {
-	const struct mcux_wdog32_config *config = dev->config->config_info;
+	const struct mcux_wdog32_config *config = dev->config_info;
 
 	config->irq_config_func(dev);
 

--- a/drivers/watchdog/wdt_nrfx.c
+++ b/drivers/watchdog/wdt_nrfx.c
@@ -29,7 +29,7 @@ static inline struct wdt_nrfx_data *get_dev_data(struct device *dev)
 
 static inline const struct wdt_nrfx_config *get_dev_config(struct device *dev)
 {
-	return dev->config->config_info;
+	return dev->config_info;
 }
 
 

--- a/drivers/watchdog/wdt_sam.c
+++ b/drivers/watchdog/wdt_sam.c
@@ -46,7 +46,7 @@ struct wdt_sam_dev_data {
 static struct wdt_sam_dev_data wdt_sam_data = { 0 };
 
 #define DEV_CFG(dev) \
-	((const struct wdt_sam_dev_cfg *const)(dev)->config->config_info)
+	((const struct wdt_sam_dev_cfg *const)(dev)->config_info)
 
 static void wdt_sam_isr(struct device *dev)
 {

--- a/drivers/watchdog/wdt_wwdg_stm32.h
+++ b/drivers/watchdog/wdt_wwdg_stm32.h
@@ -37,7 +37,7 @@ struct wwdg_stm32_data {
 };
 
 #define WWDG_STM32_CFG(dev) \
-	((const struct wwdg_stm32_config *const)(dev)->config->config_info)
+	((const struct wwdg_stm32_config *const)(dev)->config_info)
 
 #define WWDG_STM32_DATA(dev) \
 	((struct wwdg_stm32_data *const)(dev)->driver_data)

--- a/include/device.h
+++ b/include/device.h
@@ -7,8 +7,6 @@
 #ifndef ZEPHYR_INCLUDE_DEVICE_H_
 #define ZEPHYR_INCLUDE_DEVICE_H_
 
-#include <kernel.h>
-
 /**
  * @brief Device Driver APIs
  * @defgroup io_interfaces Device Driver APIs
@@ -21,13 +19,34 @@
  * @{
  */
 
-#include <zephyr/types.h>
+#include <init.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #define Z_DEVICE_MAX_NAME_LEN	48
+
+
+/**
+ * @def SYS_DEVICE_DEFINE
+ *
+ * @brief Run an initialization function at boot at specified priority,
+ * and define device PM control function.
+ *
+ * @details This macro lets you run a function at system boot.
+ *
+ * @param drv_name Name of this system device
+ * @param init_fn Pointer to the boot function to run
+ * @param pm_control_fn Pointer to device_pm_control function.
+ * Can be empty function (device_pm_control_nop) if not implemented.
+ * @param level The initialization level, See Z_INIT_ENTRY_DEFINE for details.
+ * @param prio Priority within the selected initialization level. See
+ * Z_INIT_ENTRY_DEFINE for details.
+ */
+#define SYS_DEVICE_DEFINE(drv_name, init_fn, pm_control_fn, level, prio) \
+	DEVICE_DEFINE(Z_SYS_NAME(init_fn), drv_name, init_fn, pm_control_fn, \
+		      NULL, NULL, level, prio, NULL)
 
 /**
  * @def DEVICE_INIT
@@ -53,36 +72,10 @@ extern "C" {
  * @param cfg_info The address to the structure containing the
  * configuration information for this instance of the driver.
  *
- * @param level The initialization level at which configuration occurs.
- * Must be one of the following symbols, which are listed in the order
- * they are performed by the kernel:
- * \n
- * \li PRE_KERNEL_1: Used for devices that have no dependencies, such as those
- * that rely solely on hardware present in the processor/SOC. These devices
- * cannot use any kernel services during configuration, since they are not
- * yet available.
- * \n
- * \li PRE_KERNEL_2: Used for devices that rely on the initialization of devices
- * initialized as part of the PRE_KERNEL_1 level. These devices cannot use any
- * kernel services during configuration, since they are not yet available.
- * \n
- * \li POST_KERNEL: Used for devices that require kernel services during
- * configuration.
- * \n
- * \li POST_KERNEL_SMP: Used for devices that require kernel services during
- * configuration after SMP initialization.
- * \n
- * \li APPLICATION: Used for application components (i.e. non-kernel components)
- * that need automatic configuration. These devices can use all services
- * provided by the kernel during configuration.
+ * @param level The initialization level, See Z_INIT_ENTRY_DEFINE for details.
  *
- * @param prio The initialization priority of the device, relative to
- * other devices of the same initialization level. Specified as an integer
- * value in the range 0 to 99; lower values indicate earlier initialization.
- * Must be a decimal integer literal without leading zeroes or sign (e.g. 32),
- * or an equivalent symbolic name (e.g. \#define MY_INIT_PRIO 32); symbolic
- * expressions are *not* permitted
- * (e.g. CONFIG_KERNEL_INIT_PRIORITY_DEFAULT + 5).
+ * @param prio Priority within the selected initialization level. See
+ * Z_INIT_ENTRY_DEFINE for details.
  */
 #define DEVICE_INIT(dev_name, drv_name, init_fn, data, cfg_info, level, prio) \
 	DEVICE_AND_API_INIT(dev_name, drv_name, init_fn,		\
@@ -102,19 +95,18 @@ extern "C" {
  * during initialization.
  */
 #ifndef CONFIG_DEVICE_POWER_MANAGEMENT
-#define DEVICE_AND_API_INIT(dev_name, drv_name, init_fn, data, cfg_info,  \
-			    level, prio, api)				  \
-	static const struct device_config _CONCAT(__config_, dev_name) __used \
-	__attribute__((__section__(".devconfig.init"))) = {		  \
-		.name = drv_name, .init = (init_fn),			  \
-		.config_info = (cfg_info)				  \
-	};								  \
-	static Z_DECL_ALIGN(struct device) _CONCAT(__device_, dev_name) __used \
-	__attribute__((__section__(".init_" #level STRINGIFY(prio)))) = { \
-		.config = &_CONCAT(__config_, dev_name),		  \
-		.driver_api = api,					  \
-		.driver_data = data					  \
-	}
+#define DEVICE_AND_API_INIT(dev_name, drv_name, init_fn, data, cfg_info, \
+			    level, prio, api)				\
+	static Z_DECL_ALIGN(struct device)				\
+		_CONCAT(__device_, dev_name) __used			\
+	__attribute__((__section__(".device_" #level STRINGIFY(prio)))) = { \
+		.name = drv_name,					\
+		.config_info = (cfg_info),				\
+		.driver_api = (api),					\
+		.driver_data = (data),					\
+	};								\
+	Z_INIT_ENTRY_DEFINE(_CONCAT(__device_, dev_name), init_fn,	\
+			    (&_CONCAT(__device_, dev_name)), level, prio)
 #else
 /*
  * Use the default device_pm_control for devices that do not call the
@@ -146,32 +138,32 @@ extern "C" {
 	DEVICE_AND_API_INIT(dev_name, drv_name, init_fn, data, cfg_info, \
 			    level, prio, api)
 #else
-#define DEVICE_DEFINE(dev_name, drv_name, init_fn, pm_control_fn,	  \
-		      data, cfg_info, level, prio, api)			  \
-	static struct device_pm _CONCAT(__pm_, dev_name) __used           \
-							= {               \
-		.usage = ATOMIC_INIT(0),                                  \
-		.lock = Z_SEM_INITIALIZER(                               \
-				_CONCAT(__pm_, dev_name).lock, 1, 1),     \
-		.signal = K_POLL_SIGNAL_INITIALIZER(                      \
-				_CONCAT(__pm_, dev_name).signal),         \
-		.event = K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL,     \
-				K_POLL_MODE_NOTIFY_ONLY,                  \
-				&_CONCAT(__pm_, dev_name).signal),        \
-	};								  \
-	static struct device_config _CONCAT(__config_, dev_name) __used	  \
-	__attribute__((__section__(".devconfig.init"))) = {		  \
-		.name = drv_name, .init = (init_fn),			  \
-		.device_pm_control = (pm_control_fn),			  \
-		.pm  = &_CONCAT(__pm_, dev_name),                         \
-		.config_info = (cfg_info)				  \
-	};								  \
-	static Z_DECL_ALIGN(struct device) _CONCAT(__device_, dev_name) __used \
-	__attribute__((__section__(".init_" #level STRINGIFY(prio)))) = { \
-		.config = &_CONCAT(__config_, dev_name),		  \
-		.driver_api = api,					  \
-		.driver_data = data,					  \
-	}
+#define DEVICE_DEFINE(dev_name, drv_name, init_fn, pm_control_fn,	\
+		      data, cfg_info, level, prio, api)			\
+	static struct device_pm _CONCAT(__pm_, dev_name) __used  = {	\
+		.usage = ATOMIC_INIT(0),				\
+		.lock = Z_SEM_INITIALIZER(				\
+			_CONCAT(__pm_, dev_name).lock, 1, 1),		\
+		.signal = K_POLL_SIGNAL_INITIALIZER(			\
+			_CONCAT(__pm_, dev_name).signal),		\
+		.event = K_POLL_EVENT_INITIALIZER(			\
+			K_POLL_TYPE_SIGNAL,				\
+			K_POLL_MODE_NOTIFY_ONLY,			\
+			&_CONCAT(__pm_, dev_name).signal),		\
+	};								\
+	static Z_DECL_ALIGN(struct device)				\
+		_CONCAT(__device_, dev_name) __used			\
+	__attribute__((__section__(".device_" #level STRINGIFY(prio)))) = { \
+		.name = drv_name,					\
+		.config_info = (cfg_info),				\
+		.driver_api = (api),					\
+		.driver_data = (data),					\
+		.device_pm_control = (pm_control_fn),			\
+		.pm  = &_CONCAT(__pm_, dev_name),			\
+	};								\
+	Z_INIT_ENTRY_DEFINE(_CONCAT(__device_, dev_name), init_fn,	\
+			    (&_CONCAT(__device_, dev_name)), level, prio)
+
 #endif
 
 /**
@@ -222,8 +214,6 @@ extern "C" {
  */
 #define DEVICE_DECLARE(name) static struct device DEVICE_NAME_GET(name)
 
-struct device;
-
 typedef void (*device_pm_cb)(struct device *dev,
 			     int status, void *context, void *arg);
 
@@ -250,37 +240,27 @@ struct device_pm {
 };
 
 /**
- * @brief Static device information (In ROM) Per driver instance
+ * @brief Runtime device structure (in memory) per driver instance
  *
  * @param name name of the device
  * @param init init function for the driver
  * @param config_info address of driver instance config information
- */
-struct device_config {
-	const char *name;
-	int (*init)(struct device *device);
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-	int (*device_pm_control)(struct device *device, u32_t command,
-				 void *context, device_pm_cb cb, void *arg);
-	struct device_pm *pm;
-#endif
-	const void *config_info;
-};
-
-/**
- * @brief Runtime device structure (In memory) Per driver instance
  * @param device_config Build time config information
  * @param driver_api pointer to structure containing the API functions for
- * the device type. This pointer is filled in by the driver at init time.
+ * the device type.
  * @param driver_data driver instance data. For driver use only
  */
 struct device {
-	const struct device_config *config;
+	const char *name;
+	const void *config_info;
 	const void *driver_api;
-	void *driver_data;
+	void * const driver_data;
+#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+	int (*device_pm_control)(struct device *device, u32_t command,
+				 void *context, device_pm_cb cb, void *arg);
+	struct device_pm * const pm;
+#endif
 };
-
-void z_sys_device_do_config_level(s32_t level);
 
 /**
  * @brief Retrieve the device structure for a driver by name
@@ -432,9 +412,9 @@ static inline int device_set_power_state(struct device *device,
 					 u32_t device_power_state,
 					 device_pm_cb cb, void *arg)
 {
-	return device->config->device_pm_control(device,
-						 DEVICE_PM_SET_POWER_STATE,
-						 &device_power_state, cb, arg);
+	return device->device_pm_control(device,
+					 DEVICE_PM_SET_POWER_STATE,
+					 &device_power_state, cb, arg);
 }
 
 /**
@@ -453,10 +433,10 @@ static inline int device_set_power_state(struct device *device,
 static inline int device_get_power_state(struct device *device,
 					 u32_t *device_power_state)
 {
-	return device->config->device_pm_control(device,
-						 DEVICE_PM_GET_POWER_STATE,
-						 device_power_state,
-						 NULL, NULL);
+	return device->device_pm_control(device,
+					 DEVICE_PM_GET_POWER_STATE,
+					 device_power_state,
+					 NULL, NULL);
 }
 
 /**

--- a/include/device.h
+++ b/include/device.h
@@ -85,8 +85,8 @@ extern "C" {
  * (e.g. CONFIG_KERNEL_INIT_PRIORITY_DEFAULT + 5).
  */
 #define DEVICE_INIT(dev_name, drv_name, init_fn, data, cfg_info, level, prio) \
-	DEVICE_AND_API_INIT(dev_name, drv_name, init_fn,\
-	data, cfg_info, level, prio, NULL)
+	DEVICE_AND_API_INIT(dev_name, drv_name, init_fn,		\
+			    data, cfg_info, level, prio, NULL)
 
 
 /**

--- a/include/drivers/clock_control.h
+++ b/include/drivers/clock_control.h
@@ -232,7 +232,7 @@ static inline int clock_control_get_rate(struct device *dev,
 		(const struct clock_control_driver_api *)dev->driver_api;
 
 	__ASSERT(api->get_rate != NULL, "%s not implemented for device %s",
-		__func__, dev->config->name);
+		__func__, dev->name);
 
 	return api->get_rate(dev, sys, rate);
 }

--- a/include/drivers/counter.h
+++ b/include/drivers/counter.h
@@ -211,7 +211,7 @@ __syscall bool counter_is_counting_up(const struct device *dev);
 static inline bool z_impl_counter_is_counting_up(const struct device *dev)
 {
 	const struct counter_config_info *config =
-			(struct counter_config_info *)dev->config->config_info;
+			(struct counter_config_info *)dev->config_info;
 
 	return config->flags & COUNTER_CONFIG_INFO_COUNT_UP;
 }
@@ -228,7 +228,7 @@ __syscall u8_t counter_get_num_of_channels(const struct device *dev);
 static inline u8_t z_impl_counter_get_num_of_channels(const struct device *dev)
 {
 	const struct counter_config_info *config =
-			(struct counter_config_info *)dev->config->config_info;
+			(struct counter_config_info *)dev->config_info;
 
 	return config->channels;
 }
@@ -246,7 +246,7 @@ __syscall u32_t counter_get_frequency(const struct device *dev);
 static inline u32_t z_impl_counter_get_frequency(const struct device *dev)
 {
 	const struct counter_config_info *config =
-			(struct counter_config_info *)dev->config->config_info;
+			(struct counter_config_info *)dev->config_info;
 
 	return config->freq;
 }
@@ -265,7 +265,7 @@ static inline u32_t z_impl_counter_us_to_ticks(const struct device *dev,
 					       u64_t us)
 {
 	const struct counter_config_info *config =
-			(struct counter_config_info *)dev->config->config_info;
+			(struct counter_config_info *)dev->config_info;
 	u64_t ticks = (us * config->freq) / USEC_PER_SEC;
 
 	return (ticks > (u64_t)UINT32_MAX) ? UINT32_MAX : ticks;
@@ -285,7 +285,7 @@ static inline u64_t z_impl_counter_ticks_to_us(const struct device *dev,
 					       u32_t ticks)
 {
 	const struct counter_config_info *config =
-			(struct counter_config_info *)dev->config->config_info;
+			(struct counter_config_info *)dev->config_info;
 
 	return ((u64_t)ticks * USEC_PER_SEC) / config->freq;
 }
@@ -302,7 +302,7 @@ __syscall u32_t counter_get_max_top_value(const struct device *dev);
 static inline u32_t z_impl_counter_get_max_top_value(const struct device *dev)
 {
 	const struct counter_config_info *config =
-			(struct counter_config_info *)dev->config->config_info;
+			(struct counter_config_info *)dev->config_info;
 
 	return config->max_top_value;
 }

--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -582,7 +582,7 @@ static inline int z_impl_gpio_enable_callback(struct device *port,
 	const struct gpio_driver_api *api =
 		(const struct gpio_driver_api *)port->driver_api;
 	const struct gpio_driver_config *const cfg =
-		(const struct gpio_driver_config *)port->config->config_info;
+		(const struct gpio_driver_config *)port->config_info;
 
 	(void)cfg;
 	__ASSERT((cfg->port_pin_mask & (gpio_port_pins_t)BIT(pin)) != 0U,
@@ -603,7 +603,7 @@ static inline int z_impl_gpio_disable_callback(struct device *port,
 	const struct gpio_driver_api *api =
 		(const struct gpio_driver_api *)port->driver_api;
 	const struct gpio_driver_config *const cfg =
-		(const struct gpio_driver_config *)port->config->config_info;
+		(const struct gpio_driver_config *)port->config_info;
 
 	(void)cfg;
 	__ASSERT((cfg->port_pin_mask & (gpio_port_pins_t)BIT(pin)) != 0U,
@@ -650,7 +650,7 @@ static inline int z_impl_gpio_pin_interrupt_configure(struct device *port,
 	const struct gpio_driver_api *api =
 		(const struct gpio_driver_api *)port->driver_api;
 	const struct gpio_driver_config *const cfg =
-		(const struct gpio_driver_config *)port->config->config_info;
+		(const struct gpio_driver_config *)port->config_info;
 	const struct gpio_driver_data *const data =
 		(const struct gpio_driver_data *)port->driver_data;
 	enum gpio_int_trig trig;
@@ -715,7 +715,7 @@ static inline int gpio_pin_configure(struct device *port, gpio_pin_t pin,
 	const struct gpio_driver_api *api =
 		(const struct gpio_driver_api *)port->driver_api;
 	const struct gpio_driver_config *const cfg =
-		(const struct gpio_driver_config *)port->config->config_info;
+		(const struct gpio_driver_config *)port->config_info;
 	struct gpio_driver_data *data =
 		(struct gpio_driver_data *)port->driver_data;
 	int ret;
@@ -1041,7 +1041,7 @@ static inline int gpio_port_set_clr_bits(struct device *port,
 static inline int gpio_pin_get_raw(struct device *port, gpio_pin_t pin)
 {
 	const struct gpio_driver_config *const cfg =
-		(const struct gpio_driver_config *)port->config->config_info;
+		(const struct gpio_driver_config *)port->config_info;
 	gpio_port_value_t value;
 	int ret;
 
@@ -1079,7 +1079,7 @@ static inline int gpio_pin_get_raw(struct device *port, gpio_pin_t pin)
 static inline int gpio_pin_get(struct device *port, gpio_pin_t pin)
 {
 	const struct gpio_driver_config *const cfg =
-		(const struct gpio_driver_config *)port->config->config_info;
+		(const struct gpio_driver_config *)port->config_info;
 	gpio_port_value_t value;
 	int ret;
 
@@ -1114,7 +1114,7 @@ static inline int gpio_pin_set_raw(struct device *port, gpio_pin_t pin,
 				   int value)
 {
 	const struct gpio_driver_config *const cfg =
-		(const struct gpio_driver_config *)port->config->config_info;
+		(const struct gpio_driver_config *)port->config_info;
 	int ret;
 
 	(void)cfg;
@@ -1154,7 +1154,7 @@ static inline int gpio_pin_set_raw(struct device *port, gpio_pin_t pin,
 static inline int gpio_pin_set(struct device *port, gpio_pin_t pin, int value)
 {
 	const struct gpio_driver_config *const cfg =
-		(const struct gpio_driver_config *)port->config->config_info;
+		(const struct gpio_driver_config *)port->config_info;
 	const struct gpio_driver_data *const data =
 			(const struct gpio_driver_data *)port->driver_data;
 
@@ -1182,7 +1182,7 @@ static inline int gpio_pin_set(struct device *port, gpio_pin_t pin, int value)
 static inline int gpio_pin_toggle(struct device *port, gpio_pin_t pin)
 {
 	const struct gpio_driver_config *const cfg =
-		(const struct gpio_driver_config *)port->config->config_info;
+		(const struct gpio_driver_config *)port->config_info;
 
 	(void)cfg;
 	__ASSERT((cfg->port_pin_mask & (gpio_port_pins_t)BIT(pin)) != 0U,

--- a/include/init.h
+++ b/include/init.h
@@ -7,8 +7,9 @@
 #ifndef ZEPHYR_INCLUDE_INIT_H_
 #define ZEPHYR_INCLUDE_INIT_H_
 
-#include <device.h>
 #include <toolchain.h>
+#include <kernel.h>
+#include <zephyr/types.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -29,10 +30,84 @@ extern "C" {
 #define _SYS_INIT_LEVEL_SMP		4
 #endif
 
+struct device;
+
+/**
+ * @brief Static init entry structure for each device driver or services
+ *
+ * @param init init function for the init entry which will take the dev
+ * attribute as parameter. See below.
+ * @param dev pointer to a device driver instance structure. Can be NULL
+ * if the init entry is not used for a device driver but a service.
+ */
+struct init_entry {
+	int (*init)(struct device *dev);
+	struct device *dev;
+};
+
+void z_sys_init_run_level(s32_t level);
+
 /* A counter is used to avoid issues when two or more system devices
  * are declared in the same C file with the same init function.
  */
 #define Z_SYS_NAME(init_fn) _CONCAT(_CONCAT(sys_init_, init_fn), __COUNTER__)
+
+/**
+ * @def Z_INIT_ENTRY_DEFINE
+ *
+ * @brief Create an init entry object and set it up for boot time initialization
+ *
+ * @details This macro defines an init entry object that will be automatically
+ * configured by the kernel during system initialization. Note that
+ * init entries will not be accessible from user mode. Also this macro should
+ * not be used directly, use relevant macro such as SYS_INIT() or
+ * DEVICE_AND_API_INIT() instead.
+ *
+ * @param entry_name Init entry name. It is the name this instance exposes to
+ * the system.
+ *
+ * @param init_fn Address to the init function of the entry.
+ *
+ * @param device A device driver instance pointer or NULL
+ *
+ * @param level The initialization level at which configuration occurs.
+ * Must be one of the following symbols, which are listed in the order
+ * they are performed by the kernel:
+ * \n
+ * \li PRE_KERNEL_1: Used for initialization objects that have no dependencies,
+ * such as those that rely solely on hardware present in the processor/SOC.
+ * These objects cannot use any kernel services during configuration, since
+ * they are not yet available.
+ * \n
+ * \li PRE_KERNEL_2: Used for initialization objects that rely on objects
+ * initialized as part of the PRE_KERNEL_1 level. These objects cannot use any
+ * kernel services during configuration, since they are not yet available.
+ * \n
+ * \li POST_KERNEL: Used for initialization objects that require kernel services
+ * during configuration.
+ * \n
+ * \li POST_KERNEL_SMP: Used for initialization objects that require kernel
+ * services during configuration after SMP initialization.
+ * \n
+ * \li APPLICATION: Used for application components (i.e. non-kernel components)
+ * that need automatic configuration. These objects can use all services
+ * provided by the kernel during configuration.
+ *
+ * @param prio The initialization priority of the object, relative to
+ * other objects of the same initialization level. Specified as an integer
+ * value in the range 0 to 99; lower values indicate earlier initialization.
+ * Must be a decimal integer literal without leading zeroes or sign (e.g. 32),
+ * or an equivalent symbolic name (e.g. \#define MY_INIT_PRIO 32); symbolic
+ * expressions are *not* permitted
+ * (e.g. CONFIG_KERNEL_INIT_PRIORITY_DEFAULT + 5).
+ */
+#define Z_INIT_ENTRY_DEFINE(entry_name, init_fn, device, level, prio)	\
+	static const Z_DECL_ALIGN(struct init_entry)			\
+		_CONCAT(__init_, entry_name) __used			\
+	__attribute__((__section__(".init_" #level STRINGIFY(prio)))) = { \
+		.init = (init_fn),					\
+		.dev = (device),					\
+	}
 
 /**
  * @def SYS_INIT
@@ -43,35 +118,13 @@ extern "C" {
  *
  * @param init_fn Pointer to the boot function to run
  *
- * @param level The initialization level, See DEVICE_AND_API_INIT for details.
+ * @param level The initialization level, See Z_INIT_ENTRY_DEFINE for details.
  *
  * @param prio Priority within the selected initialization level. See
- * DEVICE_AND_API_INIT for details.
+ * Z_INIT_ENTRY_DEFINE for details.
  */
 #define SYS_INIT(init_fn, level, prio)					\
-	DEVICE_AND_API_INIT(Z_SYS_NAME(init_fn), "", init_fn,		\
-			    NULL, NULL, level, prio, NULL)
-
-/**
- * @def SYS_DEVICE_DEFINE
- *
- * @brief Run an initialization function at boot at specified priority,
- * and define device PM control function.
- *
- * @details This macro lets you run a function at system boot.
- *
- * @param drv_name Name of this system device
- * @param init_fn Pointer to the boot function to run
- * @param pm_control_fn Pointer to device_pm_control function.
- *                      Can be empty function (device_pm_control_nop) if not
- *                      implemented.
- * @param level The initialization level, See DEVICE_INIT for details.
- * @param prio Priority within the selected initialization level. See
- * 	       DEVICE_INIT for details.
- */
-#define SYS_DEVICE_DEFINE(drv_name, init_fn, pm_control_fn, level, prio) \
-	DEVICE_DEFINE(Z_SYS_NAME(init_fn), drv_name, init_fn, pm_control_fn, \
-		      NULL, NULL, level, prio, NULL)
+	Z_INIT_ENTRY_DEFINE(Z_SYS_NAME(init_fn), init_fn, NULL, level, prio)
 
 #ifdef __cplusplus
 }

--- a/include/init.h
+++ b/include/init.h
@@ -48,9 +48,9 @@ extern "C" {
  * @param prio Priority within the selected initialization level. See
  * DEVICE_AND_API_INIT for details.
  */
-#define SYS_INIT(init_fn, level, prio) \
-	DEVICE_AND_API_INIT(Z_SYS_NAME(init_fn), "", init_fn, NULL, NULL, level,\
-	prio, NULL)
+#define SYS_INIT(init_fn, level, prio)					\
+	DEVICE_AND_API_INIT(Z_SYS_NAME(init_fn), "", init_fn,		\
+			    NULL, NULL, level, prio, NULL)
 
 /**
  * @def SYS_DEVICE_DEFINE

--- a/include/linker/common-ram.ld
+++ b/include/linker/common-ram.ld
@@ -1,10 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-	SECTION_DATA_PROLOGUE(initlevel,,)
-	{
-		DEVICE_INIT_SECTIONS()
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
 #if defined(CONFIG_GEN_SW_ISR_TABLE) && defined(CONFIG_DYNAMIC_INTERRUPTS)
 	SECTION_DATA_PROLOGUE(sw_isr_table,,)
 	{
@@ -18,12 +13,10 @@
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif
 
-	/* verify we don't have rogue .init_<something> initlevel sections */
-	SECTION_DATA_PROLOGUE(initlevel_error,,)
+	SECTION_DATA_PROLOGUE(devices,,)
 	{
-		DEVICE_INIT_UNDEFINED_SECTION()
-	}
-	ASSERT(SIZEOF(initlevel_error) == 0, "Undefined initialization levels used.")
+		DEVICE_SECTIONS()
+	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 	SECTION_DATA_PROLOGUE(initshell,,)
 	{

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -1,5 +1,10 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+	SECTION_PROLOGUE(initlevel,,)
+	{
+		INIT_SECTIONS()
+	} GROUP_LINK_IN(ROMABLE_REGION)
+
 #if defined(CONFIG_GEN_SW_ISR_TABLE) && !defined(CONFIG_DYNAMIC_INTERRUPTS)
 	SECTION_PROLOGUE(sw_isr_table,,)
 	{
@@ -12,6 +17,14 @@
 		*(_SW_ISR_TABLE_SECTION_NAME)
 	} GROUP_LINK_IN(ROMABLE_REGION)
 #endif
+
+	/* verify we don't have rogue .init_<something> initlevel sections */
+	SECTION_PROLOGUE(initlevel_error,,)
+	{
+		INIT_UNDEFINED_SECTION()
+	}
+	ASSERT(SIZEOF(initlevel_error) == 0, "Undefined initialization levels used.")
+
 #ifdef CONFIG_CPLUSPLUS
 	SECTION_PROLOGUE(_CTOR_SECTION_NAME,,)
 	{
@@ -64,14 +77,6 @@
 		__app_shmem_regions_start = .;
 		KEEP(*(SORT(".app_regions.*")));
 		__app_shmem_regions_end = .;
-	} GROUP_LINK_IN(ROMABLE_REGION)
-
-	SECTION_PROLOGUE (devconfig,,)
-	{
-		__devconfig_start = .;
-		*(".devconfig.*")
-		KEEP(*(SORT_BY_NAME(".devconfig*")))
-		__devconfig_end = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
 	SECTION_PROLOGUE(net_l2,,)

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -45,7 +45,7 @@
  */
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 #define DEVICE_COUNT \
-	((__device_init_end - __device_init_start) / _DEVICE_STRUCT_SIZEOF)
+	((__device_end - __device_start) / _DEVICE_STRUCT_SIZEOF)
 #define DEV_BUSY_SZ	(((DEVICE_COUNT + 31) / 32) * 4)
 #define DEVICE_BUSY_BITFIELD()			\
 		FILL(0x00) ;			\
@@ -57,36 +57,52 @@
 #endif
 
 /*
- * generate a symbol to mark the start of the device initialization objects for
- * the specified level, then link all of those objects (sorted by priority);
- * ensure the objects aren't discarded if there is no direct reference to them
+ * generate a symbol to mark the start of the objects array for
+ * the specified object and level, then link all of those objects
+ * (sorted by priority). Ensure the objects aren't discarded if there is
+ * no direct reference to them
  */
-
-#define DEVICE_INIT_LEVEL(level)				\
-		__device_##level##_start = .;			\
-		KEEP(*(SORT(.init_##level[0-9])));		\
-		KEEP(*(SORT(.init_##level[1-9][0-9])));	\
+#define CREATE_OBJ_LEVEL(object, level)				\
+		__##object##_##level##_start = .;		\
+		KEEP(*(SORT(.##object##_##level[0-9])));	\
+		KEEP(*(SORT(.##object##_##level[1-9][0-9])));	\
 
 /*
- * link in device initialization objects for all devices that are automatically
+ * link in initialization objects for all objects that are automatically
  * initialized by the kernel; the objects are sorted in the order they will be
  * initialized (i.e. ordered by level, sorted by priority within a level)
  */
 
-#define	DEVICE_INIT_SECTIONS()			\
-		__device_init_start = .;	\
-		DEVICE_INIT_LEVEL(PRE_KERNEL_1)	\
-		DEVICE_INIT_LEVEL(PRE_KERNEL_2)	\
-		DEVICE_INIT_LEVEL(POST_KERNEL)	\
-		DEVICE_INIT_LEVEL(APPLICATION)	\
-		DEVICE_INIT_LEVEL(SMP)		\
-		__device_init_end = .;		\
-		DEVICE_BUSY_BITFIELD()		\
+#define	INIT_SECTIONS()					\
+		__init_start = .;			\
+		CREATE_OBJ_LEVEL(init, PRE_KERNEL_1)	\
+		CREATE_OBJ_LEVEL(init, PRE_KERNEL_2)	\
+		CREATE_OBJ_LEVEL(init, POST_KERNEL)	\
+		CREATE_OBJ_LEVEL(init, APPLICATION)	\
+		CREATE_OBJ_LEVEL(init, SMP)		\
+		__init_end = .;				\
 
 
 /* define a section for undefined device initialization levels */
-#define DEVICE_INIT_UNDEFINED_SECTION()		\
+#define INIT_UNDEFINED_SECTION()		\
 		KEEP(*(SORT(.init_[_A-Z0-9]*)))	\
+
+
+/*
+ * link in devices objects, which are tied to the init ones;
+ * the objects are thus sorted the same way as their init object parent
+ * see include/device.h
+ */
+#define	DEVICE_SECTIONS()				\
+		__device_start = .;			\
+		CREATE_OBJ_LEVEL(device, PRE_KERNEL_1)	\
+		CREATE_OBJ_LEVEL(device, PRE_KERNEL_2)	\
+		CREATE_OBJ_LEVEL(device, POST_KERNEL)	\
+		CREATE_OBJ_LEVEL(device, APPLICATION)	\
+		CREATE_OBJ_LEVEL(device, SMP)		\
+		__device_end = .;			\
+		DEVICE_BUSY_BITFIELD()			\
+
 
 /*
  * link in shell initialization objects for all modules that use shell and

--- a/include/syscall_handler.h
+++ b/include/syscall_handler.h
@@ -442,9 +442,8 @@ static inline int z_obj_validation_check(struct z_object *ko,
  *
  * Checks that the driver object passed in is initialized, the caller has
  * correct permissions, and that it belongs to the specified driver
- * subsystems. Additionally, all devices store a function pointer to the
- * driver's init function. If this doesn't match the value provided, the
- * check will fail.
+ * subsystems. Additionally, all devices store a structure pointer of the
+ * driver's API. If this doesn't match the value provided, the check will fail.
  *
  * This provides an easy way to determine if a device object not only
  * belongs to a particular subsystem, but is of a specific device driver
@@ -453,15 +452,15 @@ static inline int z_obj_validation_check(struct z_object *ko,
  *
  * @param _device Untrusted device pointer
  * @param _dtype Expected kernel object type for the provided device pointer
- * @param _init_fn Expected init function memory address
+ * @param _api Expected driver API structure memory address
  * @return 0 on success, nonzero on failure
  */
-#define Z_SYSCALL_SPECIFIC_DRIVER(_device, _dtype, _init_fn) \
+#define Z_SYSCALL_SPECIFIC_DRIVER(_device, _dtype, _api) \
 	({ \
 		struct device *_dev = (struct device *)_device; \
 		Z_SYSCALL_OBJ(_dev, _dtype) || \
-			Z_SYSCALL_VERIFY_MSG(_dev->init == _init_fn, \
-					     "init function mismatch"); \
+			Z_SYSCALL_VERIFY_MSG(_dev->driver_api == _api, \
+					     "API structure mismatch"); \
 	})
 
 /**

--- a/include/syscall_handler.h
+++ b/include/syscall_handler.h
@@ -460,7 +460,7 @@ static inline int z_obj_validation_check(struct z_object *ko,
 	({ \
 		struct device *_dev = (struct device *)_device; \
 		Z_SYSCALL_OBJ(_dev, _dtype) || \
-			Z_SYSCALL_VERIFY_MSG(_dev->config->init == _init_fn, \
+			Z_SYSCALL_VERIFY_MSG(_dev->init == _init_fn, \
 					     "init function mismatch"); \
 	})
 

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -213,7 +213,7 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 
 	z_sys_post_kernel = true;
 
-	z_sys_device_do_config_level(_SYS_INIT_LEVEL_POST_KERNEL);
+	z_sys_init_run_level(_SYS_INIT_LEVEL_POST_KERNEL);
 #if CONFIG_STACK_POINTER_RANDOM
 	z_stack_adjust_initialized = 1;
 #endif
@@ -234,7 +234,7 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 #endif
 
 	/* Final init level before app starts */
-	z_sys_device_do_config_level(_SYS_INIT_LEVEL_APPLICATION);
+	z_sys_init_run_level(_SYS_INIT_LEVEL_APPLICATION);
 
 #ifdef CONFIG_CPLUSPLUS
 	/* Process the .ctors and .init_array sections */
@@ -248,7 +248,7 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 
 #ifdef CONFIG_SMP
 	z_smp_init();
-	z_sys_device_do_config_level(_SYS_INIT_LEVEL_SMP);
+	z_sys_init_run_level(_SYS_INIT_LEVEL_SMP);
 #endif
 
 #ifdef CONFIG_BOOT_TIME_MEASUREMENT
@@ -488,8 +488,8 @@ FUNC_NORETURN void z_cstart(void)
 #endif
 
 	/* perform basic hardware initialization */
-	z_sys_device_do_config_level(_SYS_INIT_LEVEL_PRE_KERNEL_1);
-	z_sys_device_do_config_level(_SYS_INIT_LEVEL_PRE_KERNEL_2);
+	z_sys_init_run_level(_SYS_INIT_LEVEL_PRE_KERNEL_1);
+	z_sys_init_run_level(_SYS_INIT_LEVEL_PRE_KERNEL_2);
 
 #ifdef CONFIG_STACK_CANARIES
 	z_early_boot_rand_get((u8_t *)&stack_guard, sizeof(stack_guard));

--- a/samples/application_development/out_of_tree_driver/src/main.c
+++ b/samples/application_development/out_of_tree_driver/src/main.c
@@ -16,7 +16,7 @@ void main(void)
 
 	__ASSERT(dev, "Failed to get device binding");
 
-	printk("device is %p, name is %s\n", dev, dev->config->name);
+	printk("device is %p, name is %s\n", dev, dev->name);
 
 	hello_world_print(dev);
 }

--- a/samples/bluetooth/peripheral_ht/src/hts.c
+++ b/samples/bluetooth/peripheral_ht/src/hts.c
@@ -64,7 +64,7 @@ void hts_init(void)
 	}
 
 	printk("temp device is %p, name is %s\n", temp_dev,
-	       temp_dev->config->name);
+	       temp_dev->name);
 }
 
 void hts_indicate(void)

--- a/samples/drivers/entropy/src/main.c
+++ b/samples/drivers/entropy/src/main.c
@@ -21,7 +21,7 @@ void main(void)
 	}
 
 	printf("entropy device is %p, name is %s\n",
-	       dev, dev->config->name);
+	       dev, dev->name);
 
 	while (1) {
 #define BUFFER_LENGTH 10

--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -570,7 +570,7 @@ static int cmd_set_dev(const struct shell *shell, size_t argc, char **argv)
 	}
 	if (flash_device) {
 		PR_SHELL(shell, "Leaving behind device %s\n",
-			 flash_device->config->name);
+			 flash_device->name);
 	}
 	flash_device = dev;
 

--- a/samples/drivers/ht16k33/src/main.c
+++ b/samples/drivers/ht16k33/src/main.c
@@ -27,7 +27,7 @@ static struct gpio_callback ks_cb[KEYSCAN_DEVICES];
 static void keyscan_callback(struct device *gpiob,
 			     struct gpio_callback *cb, u32_t pins)
 {
-	LOG_INF("%s: 0x%08x", gpiob->config->name, pins);
+	LOG_INF("%s: 0x%08x", gpiob->name, pins);
 }
 
 void main(void)

--- a/samples/sensor/adt7420/src/main.c
+++ b/samples/sensor/adt7420/src/main.c
@@ -176,7 +176,7 @@ void main(void)
 		return;
 	}
 
-	printf("device is %p, name is %s\n", dev, dev->config->name);
+	printf("device is %p, name is %s\n", dev, dev->name);
 
 	process(dev);
 }

--- a/samples/sensor/amg88xx/src/main.c
+++ b/samples/sensor/amg88xx/src/main.c
@@ -58,7 +58,7 @@ void main(void)
 		return;
 	}
 
-	printk("device: %p, name: %s\n", dev, dev->config->name);
+	printk("device: %p, name: %s\n", dev, dev->name);
 
 #ifdef CONFIG_AMG88XX_TRIGGER
 	struct sensor_value attr = {

--- a/samples/sensor/ams_iAQcore/src/main.c
+++ b/samples/sensor/ams_iAQcore/src/main.c
@@ -20,7 +20,7 @@ void main(void)
 		return;
 	}
 
-	printk("device is %p, name is %s\n", dev, dev->config->name);
+	printk("device is %p, name is %s\n", dev, dev->name);
 
 	while (1) {
 		sensor_sample_fetch(dev);

--- a/samples/sensor/bme680/src/main.c
+++ b/samples/sensor/bme680/src/main.c
@@ -14,7 +14,7 @@ void main(void)
 	struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, bosch_bme680)));
 	struct sensor_value temp, press, humidity, gas_res;
 
-	printf("Device %p name is %s\n", dev, dev->config->name);
+	printf("Device %p name is %s\n", dev, dev->name);
 
 	while (1) {
 		k_sleep(K_MSEC(3000));

--- a/samples/sensor/bmm150/src/main.c
+++ b/samples/sensor/bmm150/src/main.c
@@ -63,7 +63,7 @@ void main(void)
 	dev = sensor_search();
 	if (dev) {
 		printk("Found device is %p, name is %s\n",
-				dev, dev->config->name);
+				dev, dev->name);
 		do_main(dev);
 	} else {
 		printk("There is no available Geomagnetic device.\n");

--- a/samples/sensor/bq274xx/src/main.c
+++ b/samples/sensor/bq274xx/src/main.c
@@ -138,7 +138,7 @@ void main(void)
 		return;
 	}
 
-	printk("device is %p, name is %s\n", dev, dev->config->name);
+	printk("device is %p, name is %s\n", dev, dev->name);
 
 	do_main(dev);
 }

--- a/samples/sensor/ccs811/src/main.c
+++ b/samples/sensor/ccs811/src/main.c
@@ -121,7 +121,7 @@ void main(void)
 		return;
 	}
 
-	printk("device is %p, name is %s\n", dev, dev->config->name);
+	printk("device is %p, name is %s\n", dev, dev->name);
 
 	rc = ccs811_configver_fetch(dev, &cfgver);
 	if (rc == 0) {

--- a/samples/sensor/ens210/src/main.c
+++ b/samples/sensor/ens210/src/main.c
@@ -20,7 +20,7 @@ void main(void)
 		return;
 	}
 
-	printk("device is %p, name is %s\n", dev, dev->config->name);
+	printk("device is %p, name is %s\n", dev, dev->name);
 
 	while (1) {
 		sensor_sample_fetch(dev);

--- a/samples/sensor/hmc5883l/src/main.c
+++ b/samples/sensor/hmc5883l/src/main.c
@@ -49,7 +49,7 @@ void main(void)
 		return;
 	}
 
-	printk("device is %p, name is %s\n", dev, dev->config->name);
+	printk("device is %p, name is %s\n", dev, dev->name);
 
 	while (1) {
 		read_sensor(dev);

--- a/samples/sensor/magn_polling/src/main.c
+++ b/samples/sensor/magn_polling/src/main.c
@@ -58,7 +58,7 @@ void main(void)
 
 	dev = sensor_search_for_magnetometer();
 	if (dev) {
-		printk("Found device is %p, name is %s\n", dev, dev->config->name);
+		printk("Found device is %p, name is %s\n", dev, dev->name);
 		do_main(dev);
 	} else {
 		printk("There is no available magnetometer device.\n");

--- a/samples/sensor/sx9500/src/main.c
+++ b/samples/sensor/sx9500/src/main.c
@@ -82,7 +82,7 @@ void main(void)
 		return;
 	}
 
-	printk("device is %p, name is %s\n", dev, dev->config->name);
+	printk("device is %p, name is %s\n", dev, dev->name);
 
 	do_main(dev);
 }

--- a/samples/sensor/thermometer/src/main.c
+++ b/samples/sensor/thermometer/src/main.c
@@ -21,7 +21,7 @@ void main(void)
 	}
 
 	printf("temp device is %p, name is %s\n",
-	       temp_dev, temp_dev->config->name);
+	       temp_dev, temp_dev->name);
 
 	while (1) {
 		int r;

--- a/samples/sensor/ti_hdc/src/main.c
+++ b/samples/sensor/ti_hdc/src/main.c
@@ -19,7 +19,7 @@ void main(void)
 
 	__ASSERT(dev != NULL, "Failed to get device binding");
 
-	printk("Dev %p name %s is ready!\n", dev, dev->config->name);
+	printk("Dev %p name %s is ready!\n", dev, dev->name);
 
 	struct sensor_value temp, humidity;
 

--- a/samples/sensor/tmp112/src/main.c
+++ b/samples/sensor/tmp112/src/main.c
@@ -60,7 +60,7 @@ void main(void)
 
 	dev = device_get_binding("TMP112");
 	__ASSERT(dev != NULL, "Failed to get device binding");
-	printk("device is %p, name is %s\n", dev, dev->config->name);
+	printk("device is %p, name is %s\n", dev, dev->name);
 
 	do_main(dev);
 }

--- a/samples/sensor/tmp116/src/main.c
+++ b/samples/sensor/tmp116/src/main.c
@@ -19,7 +19,7 @@ void main(void)
 	dev = device_get_binding(DT_LABEL(DT_INST(0, ti_tmp116)));
 	__ASSERT(dev != NULL, "Failed to get TMP116 device binding");
 
-	printk("Device %s - %p is ready\n", dev->config->name, dev);
+	printk("Device %s - %p is ready\n", dev->name, dev);
 
 	while (1) {
 		ret = sensor_sample_fetch(dev);

--- a/samples/subsys/power/device_pm/src/dummy_driver.c
+++ b/samples/subsys/power/device_pm/src/dummy_driver.c
@@ -34,12 +34,12 @@ static int dummy_open(struct device *dev)
 
 	do {
 		(void)k_poll(&async_evt, 1, K_FOREVER);
-		k_poll_signal_check(&dev->config->pm->signal,
+		k_poll_signal_check(&dev->pm->signal,
 						&signaled, &result);
 	} while (!signaled);
 
 	async_evt.state = K_POLL_STATE_NOT_READY;
-	k_poll_signal_reset(&dev->config->pm->signal);
+	k_poll_signal_reset(&dev->pm->signal);
 
 	if (result == DEVICE_PM_ACTIVE_STATE) {
 		printk("Dummy device resumed\n");
@@ -158,7 +158,7 @@ int dummy_init(struct device *dev)
 	device_power_state = DEVICE_PM_ACTIVE_STATE;
 
 	k_poll_event_init(&async_evt, K_POLL_TYPE_SIGNAL,
-			K_POLL_MODE_NOTIFY_ONLY, &dev->config->pm->signal);
+			K_POLL_MODE_NOTIFY_ONLY, &dev->pm->signal);
 	return 0;
 }
 

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -491,8 +491,8 @@ def addr_deref(elf, addr):
 
 
 def device_get_api_addr(elf, addr):
-    # Read device->driver API
-    offset = 4 if elf.elfclass == 32 else 8
+    # See include/device.h for a description of struct device
+    offset = 8 if elf.elfclass == 32 else 16
     return addr_deref(elf, addr + offset)
 
 
@@ -543,7 +543,7 @@ def find_kobjects(elf, syms):
         if not name:
             continue
 
-        if name.startswith("__device_sys_init"):
+        if name.startswith("__init_sys_init"):
             # Boot-time initialization function; not an actual device
             continue
 

--- a/subsys/disk/disk_access_usdhc.c
+++ b/subsys/disk/disk_access_usdhc.c
@@ -2706,7 +2706,7 @@ static int usdhc_access_init(const struct device *dev)
 
 	memset((char *)priv, 0, sizeof(struct usdhc_priv));
 #if DT_HAS_NODE_STATUS_OKAY(DT_INST(0, nxp_imx_usdhc))
-	if (!strcmp(dev->config->name, DT_LABEL(DT_INST(0, nxp_imx_usdhc)))) {
+	if (!strcmp(dev->name, DT_LABEL(DT_INST(0, nxp_imx_usdhc)))) {
 		priv->host_config.base =
 			(USDHC_Type *)DT_REG_ADDR(DT_INST(0, nxp_imx_usdhc));
 		priv->nusdhc = 0;
@@ -2722,7 +2722,7 @@ static int usdhc_access_init(const struct device *dev)
 #endif
 
 #if DT_HAS_NODE_STATUS_OKAY(DT_INST(1, nxp_imx_usdhc))
-	if (!strcmp(dev->config->name, DT_LABEL(DT_INST(1, nxp_imx_usdhc)))) {
+	if (!strcmp(dev->name, DT_LABEL(DT_INST(1, nxp_imx_usdhc)))) {
 		priv->host_config.base =
 			(USDHC_Type *)DT_REG_ADDR(DT_INST(1, nxp_imx_usdhc));
 		priv->nusdhc = 1;

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -628,7 +628,7 @@ static int littlefs_mount(struct fs_mount_t *mountp)
 	lfs_size_t block_count = fs->area->fa_size / block_size;
 
 	LOG_INF("FS at %s:0x%x is %u 0x%x-byte blocks with %u cycle",
-		dev->config->name, (u32_t)fs->area->fa_off,
+		dev->name, (u32_t)fs->area->fa_off,
 		block_count, block_size, block_cycles);
 	LOG_INF("sizes: rd %u ; pr %u ; ca %u ; la %u",
 		read_size, prog_size, cache_size, lookahead_size);

--- a/subsys/power/device.c
+++ b/subsys/power/device.c
@@ -95,11 +95,9 @@ static int _sys_pm_devices(u32_t state)
 		 * and set the device states accordingly.
 		 */
 		rc = device_set_power_state(dev, state, NULL, NULL);
-
 		if (rc != 0) {
 			LOG_DBG("%s did not enter %s state: %d",
-				dev->config->name,
-				device_pm_state_str(state), rc);
+				dev->name, device_pm_state_str(state), rc);
 			return rc;
 		}
 
@@ -161,7 +159,7 @@ void sys_pm_create_device_list(void)
 		const struct device *dev = &all_devices[pmi];
 
 		/* Ignore "device"s that don't support PM */
-		if (dev->config->device_pm_control == device_pm_control_nop) {
+		if (dev->device_pm_control == device_pm_control_nop) {
 			continue;
 		}
 
@@ -169,7 +167,7 @@ void sys_pm_create_device_list(void)
 		 * reserved slot.
 		 */
 		while (cdi < ARRAY_SIZE(core_devices)) {
-			if (strcmp(dev->config->name, core_devices[cdi]) == 0) {
+			if (strcmp(dev->name, core_devices[cdi]) == 0) {
 				pm_devices[cdi] = pmi;
 				break;
 			}

--- a/subsys/power/device_pm.c
+++ b/subsys/power/device_pm.c
@@ -24,14 +24,14 @@ static void device_pm_callback(struct device *dev,
 
 	/* Set the fsm_state */
 	if (*((u32_t *)context) == DEVICE_PM_ACTIVE_STATE) {
-		atomic_set(&dev->config->pm->fsm_state,
-				DEVICE_PM_FSM_STATE_ACTIVE);
+		atomic_set(&dev->pm->fsm_state,
+			   DEVICE_PM_FSM_STATE_ACTIVE);
 	} else {
-		atomic_set(&dev->config->pm->fsm_state,
-				DEVICE_PM_FSM_STATE_SUSPENDED);
+		atomic_set(&dev->pm->fsm_state,
+			   DEVICE_PM_FSM_STATE_SUSPENDED);
 	}
 
-	k_work_submit(&dev->config->pm->work);
+	k_work_submit(&dev->pm->work);
 }
 
 static void pm_work_handler(struct k_work *work)
@@ -42,12 +42,12 @@ static void pm_work_handler(struct k_work *work)
 	int ret = 0;
 	u8_t pm_state;
 
-	switch (atomic_get(&dev->config->pm->fsm_state)) {
+	switch (atomic_get(&dev->pm->fsm_state)) {
 	case DEVICE_PM_FSM_STATE_ACTIVE:
-		if ((atomic_get(&dev->config->pm->usage) == 0) &&
-					dev->config->pm->enable) {
-			atomic_set(&dev->config->pm->fsm_state,
-					DEVICE_PM_FSM_STATE_SUSPENDING);
+		if ((atomic_get(&dev->pm->usage) == 0) &&
+					dev->pm->enable) {
+			atomic_set(&dev->pm->fsm_state,
+				   DEVICE_PM_FSM_STATE_SUSPENDING);
 			ret = device_set_power_state(dev,
 						DEVICE_PM_SUSPEND_STATE,
 						device_pm_callback, NULL);
@@ -57,10 +57,10 @@ static void pm_work_handler(struct k_work *work)
 		}
 		break;
 	case DEVICE_PM_FSM_STATE_SUSPENDED:
-		if ((atomic_get(&dev->config->pm->usage) > 0) ||
-					!dev->config->pm->enable) {
-			atomic_set(&dev->config->pm->fsm_state,
-					DEVICE_PM_FSM_STATE_RESUMING);
+		if ((atomic_get(&dev->pm->usage) > 0) ||
+					!dev->pm->enable) {
+			atomic_set(&dev->pm->fsm_state,
+				   DEVICE_PM_FSM_STATE_RESUMING);
 			ret = device_set_power_state(dev,
 						DEVICE_PM_ACTIVE_STATE,
 						device_pm_callback, NULL);
@@ -82,7 +82,7 @@ static void pm_work_handler(struct k_work *work)
 	return;
 
 fsm_out:
-	k_poll_signal_raise(&dev->config->pm->signal, pm_state);
+	k_poll_signal_raise(&dev->pm->signal, pm_state);
 }
 
 static int device_pm_request(struct device *dev,
@@ -95,16 +95,16 @@ static int device_pm_request(struct device *dev,
 			"Invalid device PM state requested");
 
 	if (target_state == DEVICE_PM_ACTIVE_STATE) {
-		if (atomic_inc(&dev->config->pm->usage) < 0) {
+		if (atomic_inc(&dev->pm->usage) < 0) {
 			return 0;
 		}
 	} else {
-		if (atomic_dec(&dev->config->pm->usage) > 1) {
+		if (atomic_dec(&dev->pm->usage) > 1) {
 			return 0;
 		}
 	}
 
-	k_work_submit(&dev->config->pm->work);
+	k_work_submit(&dev->pm->work);
 
 	/* Return in case of Async request */
 	if (pm_flags & DEVICE_PM_ASYNC) {
@@ -113,13 +113,13 @@ static int device_pm_request(struct device *dev,
 
 	/* Incase of Sync request wait for completion event */
 	do {
-		(void)k_poll(&dev->config->pm->event, 1, K_FOREVER);
-		k_poll_signal_check(&dev->config->pm->signal,
+		(void)k_poll(&dev->pm->event, 1, K_FOREVER);
+		k_poll_signal_check(&dev->pm->signal,
 						&signaled, &result);
 	} while (!signaled);
 
-	dev->config->pm->event.state = K_POLL_STATE_NOT_READY;
-	k_poll_signal_reset(&dev->config->pm->signal);
+	dev->pm->event.state = K_POLL_STATE_NOT_READY;
+	k_poll_signal_reset(&dev->pm->signal);
 
 
 	return result == target_state ? 0 : -EIO;
@@ -149,29 +149,29 @@ int device_pm_put_sync(struct device *dev)
 
 void device_pm_enable(struct device *dev)
 {
-	k_sem_take(&dev->config->pm->lock, K_FOREVER);
-	dev->config->pm->enable = true;
+	k_sem_take(&dev->pm->lock, K_FOREVER);
+	dev->pm->enable = true;
 
 	/* During the driver init, device can set the
 	 * PM state accordingly. For later cases we need
 	 * to check the usage and set the device PM state.
 	 */
-	if (!dev->config->pm->dev) {
-		dev->config->pm->dev = dev;
-		atomic_set(&dev->config->pm->fsm_state,
-					DEVICE_PM_FSM_STATE_SUSPENDED);
-		k_work_init(&dev->config->pm->work, pm_work_handler);
+	if (!dev->pm->dev) {
+		dev->pm->dev = dev;
+		atomic_set(&dev->pm->fsm_state,
+			   DEVICE_PM_FSM_STATE_SUSPENDED);
+		k_work_init(&dev->pm->work, pm_work_handler);
 	} else {
-		k_work_submit(&dev->config->pm->work);
+		k_work_submit(&dev->pm->work);
 	}
-	k_sem_give(&dev->config->pm->lock);
+	k_sem_give(&dev->pm->lock);
 }
 
 void device_pm_disable(struct device *dev)
 {
-	k_sem_take(&dev->config->pm->lock, K_FOREVER);
-	dev->config->pm->enable = false;
+	k_sem_take(&dev->pm->lock, K_FOREVER);
+	dev->pm->enable = false;
 	/* Bring up the device before disabling the Idle PM */
-	k_work_submit(&dev->config->pm->work);
-	k_sem_give(&dev->config->pm->lock);
+	k_work_submit(&dev->pm->work);
+	k_sem_give(&dev->pm->lock);
 }

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -42,8 +42,7 @@ static bool device_get_config_level(const struct shell *shell, int level)
 		if (dev->driver_api != NULL) {
 			devices = true;
 
-			shell_fprintf(shell, SHELL_NORMAL, "- %s\n",
-				      dev->config->name);
+			shell_fprintf(shell, SHELL_NORMAL, "- %s\n", dev->name);
 		}
 	}
 	return devices;
@@ -97,7 +96,7 @@ static int cmd_device_list(const struct shell *shell,
 			continue;
 		}
 
-		shell_fprintf(shell, SHELL_NORMAL, "- %s", dev->config->name);
+		shell_fprintf(shell, SHELL_NORMAL, "- %s", dev->name);
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 		u32_t state = DEVICE_PM_ACTIVE_STATE;

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -10,18 +10,18 @@
 #include <string.h>
 #include <device.h>
 
-extern struct device __device_init_start[];
+extern struct device __device_start[];
 extern struct device __device_PRE_KERNEL_1_start[];
 extern struct device __device_PRE_KERNEL_2_start[];
 extern struct device __device_POST_KERNEL_start[];
 extern struct device __device_APPLICATION_start[];
-extern struct device __device_init_end[];
+extern struct device __device_end[];
 
 #ifdef CONFIG_SMP
 extern struct device __device_SMP_start[];
 #endif
 
-static struct device *config_levels[] = {
+static struct device *levels[] = {
 	__device_PRE_KERNEL_1_start,
 	__device_PRE_KERNEL_2_start,
 	__device_POST_KERNEL_start,
@@ -30,20 +30,20 @@ static struct device *config_levels[] = {
 	__device_SMP_start,
 #endif
 	/* End marker */
-	__device_init_end,
+	__device_end,
 };
 
 static bool device_get_config_level(const struct shell *shell, int level)
 {
-	struct device *info;
+	struct device *dev;
 	bool devices = false;
 
-	for (info = config_levels[level]; info < config_levels[level+1];
-								info++) {
-		if (info->driver_api != NULL) {
+	for (dev = levels[level]; dev < levels[level+1]; dev++) {
+		if (dev->driver_api != NULL) {
 			devices = true;
+
 			shell_fprintf(shell, SHELL_NORMAL, "- %s\n",
-					info->config->name);
+				      dev->config->name);
 		}
 	}
 	return devices;
@@ -86,27 +86,30 @@ static int cmd_device_levels(const struct shell *shell,
 static int cmd_device_list(const struct shell *shell,
 			      size_t argc, char **argv)
 {
-	struct device *info;
+	struct device *dev;
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 	shell_fprintf(shell, SHELL_NORMAL, "devices:\n");
-	for (info = __device_init_start; info != __device_init_end; info++) {
-		if (info->driver_api != NULL) {
-			shell_fprintf(shell, SHELL_NORMAL, "- %s",
-					info->config->name);
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-			u32_t state = DEVICE_PM_ACTIVE_STATE;
-			int err;
 
-			err = device_get_power_state(info, &state);
-			if (!err) {
-				shell_fprintf(shell, SHELL_NORMAL, " (%s)",
-					      device_pm_state_str(state));
-			}
-#endif /* CONFIG_DEVICE_POWER_MANAGEMENT */
-			shell_fprintf(shell, SHELL_NORMAL, "\n");
+	for (dev = __device_start; dev != __device_end; dev++) {
+		if (dev->driver_api == NULL) {
+			continue;
 		}
+
+		shell_fprintf(shell, SHELL_NORMAL, "- %s", dev->config->name);
+
+#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+		u32_t state = DEVICE_PM_ACTIVE_STATE;
+		int err;
+
+		err = device_get_power_state(dev, &state);
+		if (!err) {
+			shell_fprintf(shell, SHELL_NORMAL, " (%s)",
+				      device_pm_state_str(state));
+		}
+#endif /* CONFIG_DEVICE_POWER_MANAGEMENT */
+		shell_fprintf(shell, SHELL_NORMAL, "\n");
 	}
 
 	return 0;

--- a/subsys/usb/class/audio/audio.c
+++ b/subsys/usb/class/audio/audio.c
@@ -777,7 +777,7 @@ static int audio_class_handle_req(struct usb_setup_packet *pSetup,
 
 static int usb_audio_device_init(struct device *dev)
 {
-	LOG_DBG("Init Audio Device: dev %p (%s)", dev, dev->config->name);
+	LOG_DBG("Init Audio Device: dev %p (%s)", dev, dev->name);
 
 	return 0;
 }
@@ -811,7 +811,7 @@ int usb_audio_send(const struct device *dev, struct net_buf *buffer,
 		   size_t len)
 {
 	struct usb_audio_dev_data *audio_dev_data = dev->driver_data;
-	struct usb_cfg_data *cfg = (void *)dev->config->config_info;
+	struct usb_cfg_data *cfg = (void *)dev->config_info;
 	/* EP ISO IN is always placed first in the endpoint table */
 	u8_t ep = cfg->endpoint[0].ep_addr;
 
@@ -901,7 +901,7 @@ void usb_audio_register(struct device *dev,
 			const struct usb_audio_ops *ops)
 {
 	struct usb_audio_dev_data *audio_dev_data = dev->driver_data;
-	const struct usb_cfg_data *cfg = dev->config->config_info;
+	const struct usb_cfg_data *cfg = dev->config_info;
 	const struct std_if_descriptor *iface_descr =
 		cfg->interface_descriptor;
 	const struct cs_ac_if_descriptor *header =
@@ -917,7 +917,7 @@ void usb_audio_register(struct device *dev,
 	sys_slist_append(&usb_audio_data_devlist, &audio_dev_data->common.node);
 
 	LOG_DBG("Device dev %p dev_data %p cfg %p added to devlist %p",
-		dev, audio_dev_data, dev->config->config_info,
+		dev, audio_dev_data, dev->config_info,
 		&usb_audio_data_devlist);
 }
 

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -288,7 +288,7 @@ static void tx_work_handler(struct k_work *work)
 	struct cdc_acm_dev_data_t *dev_data =
 		CONTAINER_OF(work, struct cdc_acm_dev_data_t, tx_work);
 	struct device *dev = dev_data->common.dev;
-	struct usb_cfg_data *cfg = (void *)dev->config->config_info;
+	struct usb_cfg_data *cfg = (void *)dev->config_info;
 	u8_t ep = cfg->endpoint[ACM_IN_EP_IDX].ep_addr;
 	u8_t *data;
 	size_t len;
@@ -400,7 +400,7 @@ static void cdc_acm_do_cb(struct cdc_acm_dev_data_t *dev_data,
 			  const u8_t *param)
 {
 	struct device *dev = dev_data->common.dev;
-	struct usb_cfg_data *cfg = (void *)dev->config->config_info;
+	struct usb_cfg_data *cfg = (void *)dev->config_info;
 
 	/* Store the new status */
 	if (!(status == USB_DC_SOF || status == USB_DC_INTERFACE)) {
@@ -522,7 +522,7 @@ static int cdc_acm_init(struct device *dev)
 	sys_slist_append(&cdc_acm_data_devlist, &dev_data->common.node);
 
 	LOG_DBG("Device dev %p dev_data %p cfg %p added to devlist %p",
-		dev, dev_data, dev->config->config_info, &cdc_acm_data_devlist);
+		dev, dev_data, dev->config_info, &cdc_acm_data_devlist);
 
 	k_sem_init(&poll_wait_sem, 0, UINT_MAX);
 	k_work_init(&dev_data->cb_work, cdc_acm_irq_callback_work_handler);
@@ -778,7 +778,7 @@ static void cdc_acm_baudrate_set(struct device *dev, u32_t baudrate)
 static int cdc_acm_send_notification(struct device *dev, u16_t serial_state)
 {
 	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
-	struct usb_cfg_data * const cfg = (void *)dev->config->config_info;
+	struct usb_cfg_data * const cfg = (void *)dev->config_info;
 	struct cdc_acm_notification notification;
 	u32_t cnt = 0U;
 

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -516,7 +516,7 @@ static int hid_custom_handle_req(struct usb_setup_packet *setup,
 
 		switch (value) {
 		case HID_CLASS_DESCRIPTOR_HID:
-			cfg = common->dev->config->config_info;
+			cfg = common->dev->config_info;
 			hid_desc = cfg->interface_descriptor;
 
 			LOG_DBG("Return HID Descriptor");
@@ -644,7 +644,7 @@ static void hid_interface_config(struct usb_desc_header *head,
 
 int usb_hid_init(const struct device *dev)
 {
-	struct usb_cfg_data *cfg = (void *)dev->config->config_info;
+	struct usb_cfg_data *cfg = (void *)dev->config_info;
 	struct hid_device_info *dev_data = dev->driver_data;
 
 	LOG_DBG("Initializing HID Device: dev %p", dev);
@@ -677,7 +677,7 @@ void usb_hid_register_device(struct device *dev, const u8_t *desc,
 int hid_int_ep_write(const struct device *dev, const u8_t *data, u32_t data_len,
 		     u32_t *bytes_ret)
 {
-	const struct usb_cfg_data *cfg = dev->config->config_info;
+	const struct usb_cfg_data *cfg = dev->config_info;
 
 	return usb_write(cfg->endpoint[HID_INT_IN_EP_IDX].ep_addr, data,
 			 data_len, bytes_ret);
@@ -687,7 +687,7 @@ int hid_int_ep_read(const struct device *dev, u8_t *data, u32_t max_data_len,
 		    u32_t *ret_bytes)
 {
 #ifdef CONFIG_ENABLE_HID_INT_OUT_EP
-	const struct usb_cfg_data *cfg = dev->config->config_info;
+	const struct usb_cfg_data *cfg = dev->config_info;
 
 	return usb_read(cfg->endpoint[HID_INT_OUT_EP_IDX].ep_addr,
 			data, max_data_len, ret_bytes);
@@ -702,7 +702,7 @@ static const struct usb_hid_device_api {
 
 static int usb_hid_device_init(struct device *dev)
 {
-	LOG_DBG("Init HID Device: dev %p (%s)", dev, dev->config->name);
+	LOG_DBG("Init HID Device: dev %p (%s)", dev, dev->name);
 
 	return 0;
 }

--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -485,7 +485,7 @@ struct usb_dev_data *usb_get_dev_data_by_cfg(sys_slist_t *list,
 
 	SYS_SLIST_FOR_EACH_CONTAINER(list, dev_data, node) {
 		struct device *dev = dev_data->dev;
-		const struct usb_cfg_data *cfg_cur = dev->config->config_info;
+		const struct usb_cfg_data *cfg_cur = dev->config_info;
 
 		if (cfg_cur == cfg) {
 			return dev_data;
@@ -504,7 +504,7 @@ struct usb_dev_data *usb_get_dev_data_by_iface(sys_slist_t *list,
 
 	SYS_SLIST_FOR_EACH_CONTAINER(list, dev_data, node) {
 		struct device *dev = dev_data->dev;
-		const struct usb_cfg_data *cfg = dev->config->config_info;
+		const struct usb_cfg_data *cfg = dev->config_info;
 		const struct usb_if_descriptor *if_desc =
 						cfg->interface_descriptor;
 
@@ -524,7 +524,7 @@ struct usb_dev_data *usb_get_dev_data_by_ep(sys_slist_t *list, u8_t ep)
 
 	SYS_SLIST_FOR_EACH_CONTAINER(list, dev_data, node) {
 		struct device *dev = dev_data->dev;
-		const struct usb_cfg_data *cfg = dev->config->config_info;
+		const struct usb_cfg_data *cfg = dev->config_info;
 		const struct usb_ep_cfg_data *ep_data = cfg->endpoint;
 
 		for (u8_t i = 0; i < cfg->num_endpoints; i++) {

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -152,7 +152,7 @@ static bool set_top_value_capable(const char *dev_name)
 static void top_handler(struct device *dev, void *user_data)
 {
 	zassert_true(user_data == exp_user_data,
-			"%s: Unexpected callback", dev->config->name);
+			"%s: Unexpected callback", dev->name);
 	k_sem_give(&top_cnt_sem);
 }
 
@@ -265,7 +265,7 @@ static void alarm_handler(struct device *dev, u8_t chan_id, u32_t counter,
 
 	err = counter_get_value(dev, &now);
 	zassert_true(err == 0, "%s: Counter read failed (err: %d)",
-		     dev->config->name, err);
+		     dev->name, err);
 
 	top = counter_get_top_value(dev);
 	if (counter_is_counting_up(dev)) {
@@ -284,11 +284,11 @@ static void alarm_handler(struct device *dev, u8_t chan_id, u32_t counter,
 
 	if (user_data) {
 		zassert_true(&alarm_cfg == user_data,
-			"%s: Unexpected callback", dev->config->name);
+			"%s: Unexpected callback", dev->name);
 	}
 
 	zassert_true(k_is_in_isr(), "%s: Expected interrupt context",
-			dev->config->name);
+			dev->name);
 	k_sem_give(&alarm_cnt_sem);
 }
 

--- a/tests/drivers/counter/maxim_ds3231_api/src/test_counter.c
+++ b/tests/drivers/counter/maxim_ds3231_api/src/test_counter.c
@@ -109,7 +109,7 @@ static bool set_top_value_capable(const char *dev_name)
 static void top_handler(struct device *dev, void *user_data)
 {
 	zassert_true(user_data == exp_user_data,
-		     "%s: Unexpected callback", dev->config->name);
+		     "%s: Unexpected callback", dev->name);
 	k_sem_give(&top_cnt_sem);
 }
 
@@ -216,26 +216,26 @@ static void alarm_handler(struct device *dev, u8_t chan_id, u32_t counter,
 
 	err = counter_get_value(dev, &now);
 	zassert_true(err == 0, "%s: Counter read failed (err: %d)",
-		     dev->config->name, err);
+		     dev->name, err);
 
 	if (counter_is_counting_up(dev)) {
 		zassert_true(now >= counter,
 			     "%s: Alarm (%d) too early now: %d (counting up).",
-			     dev->config->name, counter, now);
+			     dev->name, counter, now);
 	} else {
 		zassert_true(now <= counter,
 			     "%s: Alarm (%d) too early now: %d (counting down).",
-			     dev->config->name, counter, now);
+			     dev->name, counter, now);
 	}
 
 	if (user_data) {
 		zassert_true(&alarm_cfg == user_data,
-			     "%s: Unexpected callback", dev->config->name);
+			     "%s: Unexpected callback", dev->name);
 	}
 
 	/* DS3231 does not invoke callbacks from interrupt context. */
 	zassert_false(k_is_in_isr(), "%s: Unexpected interrupt context",
-		      dev->config->name);
+		      dev->name);
 	k_sem_give(&alarm_cnt_sem);
 }
 

--- a/tests/drivers/entropy/api/src/main.c
+++ b/tests/drivers/entropy/api/src/main.c
@@ -78,7 +78,7 @@ static int get_entropy(void)
 	}
 
 	TC_PRINT("random device is %p, name is %s\n",
-		 dev, dev->config->name);
+		 dev, dev->name);
 
 	ret = random_entropy(dev, buffer, 0);
 

--- a/tests/drivers/i2c/i2c_slave_api/src/main.c
+++ b/tests/drivers/i2c/i2c_slave_api/src/main.c
@@ -48,7 +48,7 @@ static void run_full_read(struct device *i2c, u8_t addr, u8_t *comp_buffer)
 	int ret;
 
 	LOG_INF("Start full read. Master: %s, address: 0x%x",
-		    i2c->config->name, addr);
+		    i2c->name, addr);
 
 	/* Read EEPROM from I2C Master requests, then compare */
 	ret = i2c_burst_read(i2c, addr,
@@ -75,7 +75,7 @@ static void run_partial_read(struct device *i2c, u8_t addr, u8_t *comp_buffer,
 	int ret;
 
 	LOG_INF("Start partial read. Master: %s, address: 0x%x, off=%d",
-		    i2c->config->name, addr, offset);
+		    i2c->name, addr, offset);
 
 	ret = i2c_burst_read(i2c, addr,
 			     offset, i2c_buffer, TEST_DATA_SIZE-offset);
@@ -100,7 +100,7 @@ static void run_program_read(struct device *i2c, u8_t addr, unsigned int offset)
 	int ret, i;
 
 	LOG_INF("Start program. Master: %s, address: 0x%x, off=%d",
-		    i2c->config->name, addr, offset);
+		    i2c->name, addr, offset);
 
 	for (i = 0 ; i < TEST_DATA_SIZE-offset ; ++i) {
 		i2c_buffer[i] = i;

--- a/tests/lib/devicetree/src/main.c
+++ b/tests/lib/devicetree/src/main.c
@@ -1190,7 +1190,7 @@ static inline struct test_gpio_data *to_data(struct device *dev)
 
 static inline const struct test_gpio_info *to_info(struct device *dev)
 {
-	return (struct test_gpio_info *)dev->config->config_info;
+	return (struct test_gpio_info *)dev->config_info;
 }
 
 static void test_devices(void)


### PR DESCRIPTION
Part of #22941

Original struct device was only meant for actual devices. But its infrastructure has been then used also for non-hardware based boot-time critical piece of software. Though this was a simple solution, it brought the device concept to non-device systems. 

So refactoring all of this in order to get rid of struct device from these systems, as well as clarifying the struct device as well. 

This leads to some bytes saved from both ROM and RAM.