### PR TITLE
timer: mchp_xec_rtos: convert to use DT_INST_ defines

### DIFF
--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -43,6 +43,8 @@
 			reg = <0x40007400 0x10>;
 			interrupts = <111 0>;
 			label = "RTIMER";
+			girq = <23>;
+			girq-bit = <10>;
 		};
 		wdog: watchdog@40000400 {
 			compatible = "microchip,xec-watchdog";

--- a/dts/bindings/timer/microchip,xec-rtos-timer.yaml
+++ b/dts/bindings/timer/microchip,xec-rtos-timer.yaml
@@ -16,3 +16,13 @@ properties:
 
     label:
       required: true
+
+    girq:
+      type: int
+      required: true
+      description: GIRQ for this device
+
+    girq-bit:
+      type: int
+      required: true
+      description: Bit position in GIRQ for this device


### PR DESCRIPTION
Use DT_INST_* instead of the hard-coded macro from the HAL,
as DT_INST_* are preferred.
    
Fixes #17775
    
Signed-off-by: Daniel Leung <daniel.leung@intel.com>