### PR TITLE
sys/util.h: allow UTIL_LISTIFY to pass args to repeat macro

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -738,10 +738,10 @@ u8_t u8_to_dec(char *buf, u8_t buflen, u8_t value);
  * @arg LEN: The length of the sequence. Must be defined and less than
  * 20.
  *
- * @arg F(i, F_ARG): A macro function that accepts two arguments.
- *  F is called repeatedly, the first argument
- *  is the index in the sequence, and the second argument is the third
- *  argument given to UTIL_LISTIFY.
+ * @arg F(i, ...): A macro function that accepts at least two arguments.
+ *  F is called repeatedly, the first argument is the index in the sequence,
+ *  the variable list of arguments passed to UTIL_LISTIFY are passed through
+ *  to F.
  *
  * Example:
  *
@@ -753,7 +753,7 @@ u8_t u8_to_dec(char *buf, u8_t buflen, u8_t value);
  * @note Calling UTIL_LISTIFY with undefined arguments has undefined
  * behavior.
  */
-#define UTIL_LISTIFY(LEN, F, F_ARG) UTIL_EVAL(UTIL_REPEAT(LEN, F, F_ARG))
+#define UTIL_LISTIFY(LEN, F, ...) UTIL_EVAL(UTIL_REPEAT(LEN, F, __VA_ARGS__))
 
 /**@brief Implementation details for NUM_VAR_ARGS */
 #define NUM_VA_ARGS_LESS_1_IMPL(				\

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -138,15 +138,19 @@ void test_UTIL_LISTIFY(void)
 		i += x;		\
 	} while (0);
 
-#define DEFINE(x, _) int a##x;
+#define DEFINE(x, y) int a##x = x * y;
 #define MARK_UNUSED(x, _) ARG_UNUSED(a##x);
 
-	UTIL_LISTIFY(4, DEFINE, _)
+	UTIL_LISTIFY(4, DEFINE, 2)
 	UTIL_LISTIFY(4, MARK_UNUSED, _)
 
 	UTIL_LISTIFY(4, INC, _)
 
 	zassert_equal(i, 0 + 1 + 2 + 3, NULL);
+	zassert_equal(a0, 0, NULL);
+	zassert_equal(a1, 2, NULL);
+	zassert_equal(a2, 4, NULL);
+	zassert_equal(a3, 6, NULL);
 }
 
 static int inc_func(void)


### PR DESCRIPTION
Change UTIL_LISTIFY to support passing arguments to the F macro.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>