### PR TITLE
Devicetree: Macro to initialize driver for every device instance

### DIFF
--- a/doc/guides/dts/howtos.rst
+++ b/doc/guides/dts/howtos.rst
@@ -389,19 +389,12 @@ enabled instance. Currently, this looks like this:
 			    MY_DEV_INIT_LEVEL, MY_DEV_INIT_PRIORITY,    \
 			    &my_api_funcs)
 
-   #if DT_HAS_NODE(DT_DRV_INST(0))
-   CREATE_MY_DEVICE(0);
-   #endif
+   /* Call the device creation macro for every compatible node: */
+   DT_INST_FOREACH(CREATE_MY_DEVICE);
 
-   #if DT_HAS_NODE(DT_DRV_INST(1))
-   CREATE_MY_DEVICE(1);
-   #endif
-
-   /* And so on, for all "possible" instance numbers you need to support. */
-
-Notice the use of :c:func:`DT_INST_PROP` and :c:func:`DT_DRV_INST`. These are
-helpers which rely on ``DT_DRV_COMPAT`` to choose devicetree nodes of a chosen
-compatible at a given index.
+Notice the use of :c:func:`DT_INST_PROP` and :c:func:`DT_INST_FOREACH`.
+These are helpers which rely on ``DT_DRV_COMPAT`` to choose devicetree nodes
+of a chosen compatible at a given index.
 
 As shown above, the driver uses additional information from
 :file:`devicetree.h` to create :ref:`struct device <device_struct>` instances

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -1317,6 +1317,22 @@
 	(UTIL_LISTIFY(DT_NUM_INST(DT_DRV_COMPAT), DT_INST_ON_BUS_OR, bus) 0)
 
 /**
+ * @def DT_INST_FOREACH
+ *
+ * @brief Call specified macro for all nodes with compatible DT_DRV_COMPAT
+ *
+ * @details This macro will scan for all DT_INST_ device nodes for that driver.
+ * The macro then calls the supplied macro with the instance number.
+ * This macro can be used for example to call the init macro of a driver
+ * for each device specified in the device tree.
+ *
+ * @param inst_expr Macro or function that is called for each device node.
+ * Has to accept instance_number as only parameter.
+ */
+#define DT_INST_FOREACH(inst_expr) \
+	UTIL_LISTIFY(DT_NUM_INST(DT_DRV_COMPAT), DT_CALL_WITH_ARG, inst_expr)
+
+/**
  * @brief Does a DT_DRV_COMPAT instance have a property?
  * Equivalent to DT_NODE_HAS_PROP(DT_DRV_INST(inst), prop)
  * @param inst instance number
@@ -1391,5 +1407,7 @@
 #define DT_DASH_PREFIX(name) _##name
 /** @internal DT_ANY_INST_ON_BUS helper */
 #define DT_INST_ON_BUS_OR(inst, bus) DT_ON_BUS(DT_DRV_INST(inst), bus) ||
+/** @internal DT_INST_FOREACH helper */
+#define DT_CALL_WITH_ARG(arg, expr) expr(arg);
 
 #endif /* DEVICETREE_H */

--- a/tests/lib/devicetree/src/main.c
+++ b/tests/lib/devicetree/src/main.c
@@ -961,6 +961,8 @@ static int test_gpio_init(struct device *dev)
 }
 
 #define INST(num) DT_INST(num, vnd_gpio)
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_gpio
 
 static const struct gpio_driver_api test_api;
 
@@ -982,12 +984,7 @@ static const struct gpio_driver_api test_api;
 			    CONFIG_APPLICATION_INIT_PRIORITY,	\
 			    &test_api)
 
-#if DT_HAS_NODE(INST(0))
-TEST_GPIO_INIT(0);
-#endif
-#if DT_HAS_NODE(INST(1))
-TEST_GPIO_INIT(1);
-#endif
+DT_INST_FOREACH(TEST_GPIO_INIT);
 
 static inline struct test_gpio_data *to_data(struct device *dev)
 {


### PR DESCRIPTION
This pull request introduces the macro: DT_INST_FOREACH(inst_expr).

This makes it possible to do this:
`DT_INST_FOREACH(I2C_NRFX_TWIM_DEVICE);`

Instead of:
```
#ifdef DT_INST_N_0_nordic_nrf_twim
I2C_NRFX_TWIM_DEVICE(0);
#endif

#ifdef DT_INST_N_1_nordic_nrf_twim
I2C_NRFX_TWIM_DEVICE(1);
#endif

#ifdef DT_INST_N_2_nordic_nrf_twim
I2C_NRFX_TWIM_DEVICE(2);
#endif

#ifdef DT_INST_N_3_nordic_nrf_twim
I2C_NRFX_TWIM_DEVICE(3);
#endif
```


The macro calls the passed inst_expr for every compatible (and enabled) device in the device tree.
By using this approach the drivers don't have to make assumption about the maximum count of device instances anymore.
The expr argument can be either a macro or a function that take the instance number as argument.
