### PR TITLE
arch: arm: aarch32: rename z_arm_lib_init() function

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/irq_init.c
+++ b/arch/arm/core/aarch32/cortex_m/irq_init.c
@@ -24,7 +24,7 @@
  * @return N/A
  */
 
-void z_arm_int_lib_init(void)
+void z_arm_interrupt_init(void)
 {
 	int irq = 0;
 

--- a/arch/arm/core/aarch32/prep_c.c
+++ b/arch/arm/core/aarch32/prep_c.c
@@ -180,7 +180,7 @@ void z_arm_prep_c(void)
 #if defined(CONFIG_ARMV7_R) && defined(CONFIG_INIT_STACKS)
 	z_arm_init_stacks();
 #endif
-	z_arm_int_lib_init();
+	z_arm_interrupt_init();
 	z_cstart();
 	CODE_UNREACHABLE;
 }

--- a/include/arch/arm/aarch32/irq.h
+++ b/include/arch/arm/aarch32/irq.h
@@ -36,11 +36,11 @@ extern int arch_irq_is_enabled(unsigned int irq);
 extern void z_arm_int_exit(void);
 
 #if defined(CONFIG_ARMV7_R)
-static ALWAYS_INLINE void z_arm_int_lib_init(void)
+static ALWAYS_INLINE void z_arm_interrupt_init(void)
 {
 }
 #else
-extern void z_arm_int_lib_init(void);
+extern void z_arm_interrupt_init(void);
 #endif
 
 /* macros convert value of it's argument to a string */


### PR DESCRIPTION
We rename the z_arm_lib_init() function to
z_arm_interrupt_init(), aligning to how other
ARCHes name their IRQ initialization function.
There is nothing about 'library' in this
functionality, so we remove the 'lib' in-fix.

The commit does not introduce any behavior changes.

Helper for  #22718

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>