### PR TITLE
net: mqtt: add and use MQTT_UTF8_LITERAL() helper macro

### DIFF
--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -154,6 +154,18 @@ struct mqtt_utf8 {
 	u32_t size;             /**< Size of UTF string, in bytes. */
 };
 
+/**
+ * @brief Initialize UTF-8 encoded string from C literal string.
+ *
+ * Use it as follows:
+ *
+ * struct mqtt_utf8 password = MQTT_UTF8_LITERAL("my_pass");
+ *
+ * @param[in] literal Literal string from which to generate mqtt_utf8 object.
+ */
+#define MQTT_UTF8_LITERAL(literal)				\
+	((struct mqtt_utf8) {literal, sizeof(literal) - 1})
+
 /** @brief Abstracts binary strings. */
 struct mqtt_binstr {
 	u8_t *data;             /**< Pointer to binary stream. */

--- a/subsys/net/lib/mqtt/mqtt_encoder.c
+++ b/subsys/net/lib/mqtt/mqtt_encoder.c
@@ -15,25 +15,11 @@ LOG_MODULE_REGISTER(net_mqtt_enc, CONFIG_MQTT_LOG_LEVEL);
 #include "mqtt_internal.h"
 #include "mqtt_os.h"
 
-#define MQTT_3_1_0_PROTO_DESC_LEN 6
-#define MQTT_3_1_1_PROTO_DESC_LEN 4
+static const struct mqtt_utf8 mqtt_3_1_0_proto_desc =
+	MQTT_UTF8_LITERAL("MQIsdp");
 
-static const u8_t mqtt_3_1_0_proto_desc_str[MQTT_3_1_0_PROTO_DESC_LEN] = {
-	'M', 'Q', 'I', 's', 'd', 'p'
-};
-static const u8_t mqtt_3_1_1_proto_desc_str[MQTT_3_1_1_PROTO_DESC_LEN] = {
-	'M', 'Q', 'T', 'T'
-};
-
-static const struct mqtt_utf8 mqtt_3_1_0_proto_desc = {
-	.utf8 = (u8_t *)mqtt_3_1_0_proto_desc_str,
-	.size = MQTT_3_1_0_PROTO_DESC_LEN
-};
-
-static const struct mqtt_utf8 mqtt_3_1_1_proto_desc = {
-	.utf8 = (u8_t *)mqtt_3_1_1_proto_desc_str,
-	.size = MQTT_3_1_1_PROTO_DESC_LEN
-};
+static const struct mqtt_utf8 mqtt_3_1_1_proto_desc =
+	MQTT_UTF8_LITERAL("MQTT");
 
 /** Never changing ping request, needed for Keep Alive. */
 static const u8_t ping_packet[MQTT_FIXED_HEADER_MIN_SIZE] = {

--- a/tests/net/lib/mqtt_packet/src/mqtt_packet.c
+++ b/tests/net/lib/mqtt_packet/src/mqtt_packet.c
@@ -9,18 +9,12 @@
 #include <sys/util.h>	/* for ARRAY_SIZE */
 #include <ztest.h>
 
-#define CLIENTID	"zephyr"
-#define CLIENTID_LEN	6
-#define TOPIC		"sensors"
-#define TOPIC_LEN	7
-#define WILL_TOPIC	"quitting"
-#define WILL_TOPIC_LEN	8
-#define WILL_MSG	"bye"
-#define WILL_MSG_LEN	3
-#define USERNAME	"zephyr1"
-#define USERNAME_LEN	7
-#define PASSWORD	"password"
-#define PASSWORD_LEN	8
+#define CLIENTID	MQTT_UTF8_LITERAL("zephyr")
+#define TOPIC		MQTT_UTF8_LITERAL("sensors")
+#define WILL_TOPIC	MQTT_UTF8_LITERAL("quitting")
+#define WILL_MSG	MQTT_UTF8_LITERAL("bye")
+#define USERNAME	MQTT_UTF8_LITERAL("zephyr1")
+#define PASSWORD	MQTT_UTF8_LITERAL("password")
 
 #define BUFFER_SIZE 128
 
@@ -30,41 +24,27 @@ static ZTEST_DMEM struct mqtt_client client;
 
 static ZTEST_DMEM struct mqtt_topic topic_qos_0 = {
 	.qos = 0,
-	.topic.utf8 = TOPIC,
-	.topic.size = TOPIC_LEN
+	.topic = TOPIC,
 };
 static ZTEST_DMEM struct mqtt_topic topic_qos_1 = {
 	.qos = 1,
-	.topic.utf8 = TOPIC,
-	.topic.size = TOPIC_LEN
+	.topic = TOPIC,
 };
 static ZTEST_DMEM struct mqtt_topic topic_qos_2 = {
 	.qos = 2,
-	.topic.utf8 = TOPIC,
-	.topic.size = TOPIC_LEN
+	.topic = TOPIC,
 };
 static ZTEST_DMEM struct mqtt_topic will_topic_qos_0 = {
 	.qos = 0,
-	.topic.utf8 = WILL_TOPIC,
-	.topic.size = WILL_TOPIC_LEN
+	.topic = WILL_TOPIC,
 };
 static ZTEST_DMEM struct mqtt_topic will_topic_qos_1 = {
 	.qos = 1,
-	.topic.utf8 = WILL_TOPIC,
-	.topic.size = WILL_TOPIC_LEN
+	.topic = WILL_TOPIC,
 };
-static ZTEST_DMEM struct mqtt_utf8 will_msg = {
-	.utf8 = WILL_MSG,
-	.size = WILL_MSG_LEN
-};
-static ZTEST_DMEM struct mqtt_utf8 username = {
-	.utf8 = USERNAME,
-	.size = USERNAME_LEN
-};
-static ZTEST_DMEM struct mqtt_utf8 password = {
-	.utf8 = PASSWORD,
-	.size = PASSWORD_LEN
-};
+static ZTEST_DMEM struct mqtt_utf8 will_msg = WILL_MSG;
+static ZTEST_DMEM struct mqtt_utf8 username = USERNAME;
+static ZTEST_DMEM struct mqtt_utf8 password = PASSWORD;
 
 /**
  * @brief MQTT test structure
@@ -225,8 +205,7 @@ u8_t connect1[] = {0x10, 0x12, 0x00, 0x04, 0x4d, 0x51, 0x54, 0x54,
 		   0x70, 0x68, 0x79, 0x72};
 
 static ZTEST_DMEM struct mqtt_client client_connect1 = {
-	.clean_session = 1, .client_id.utf8 = CLIENTID,
-	.client_id.size = CLIENTID_LEN,
+	.clean_session = 1, .client_id = CLIENTID,
 	.will_retain = 0, .will_topic = NULL,
 	.will_message = NULL, .user_name = NULL,
 	.password = NULL
@@ -250,8 +229,7 @@ u8_t connect2[] = {0x10, 0x21, 0x00, 0x04, 0x4d, 0x51, 0x54, 0x54,
 		   0x62, 0x79, 0x65};
 
 static ZTEST_DMEM struct mqtt_client client_connect2 = {
-	.clean_session = 1, .client_id.utf8 = CLIENTID,
-	.client_id.size = CLIENTID_LEN,
+	.clean_session = 1, .client_id = CLIENTID,
 	.will_retain = 0, .will_topic = &will_topic_qos_0,
 	.will_message = &will_msg, .user_name = NULL,
 	.password = NULL
@@ -273,8 +251,7 @@ u8_t connect3[] = {0x10, 0x21, 0x00, 0x04, 0x4d, 0x51, 0x54, 0x54,
 		   0x62, 0x79, 0x65};
 
 static ZTEST_DMEM struct mqtt_client client_connect3 = {
-	.clean_session = 1, .client_id.utf8 = CLIENTID,
-	.client_id.size = CLIENTID_LEN,
+	.clean_session = 1, .client_id = CLIENTID,
 	.will_retain = 1, .will_topic = &will_topic_qos_0,
 	.will_message = &will_msg, .user_name = NULL,
 	.password = NULL
@@ -296,8 +273,7 @@ u8_t connect4[] = {0x10, 0x21, 0x00, 0x04, 0x4d, 0x51, 0x54, 0x54,
 		   0x62, 0x79, 0x65};
 
 static ZTEST_DMEM struct mqtt_client client_connect4 = {
-	.clean_session = 1, .client_id.utf8 = CLIENTID,
-	.client_id.size = CLIENTID_LEN,
+	.clean_session = 1, .client_id = CLIENTID,
 	.will_retain = 0, .will_topic = &will_topic_qos_1,
 	.will_message = &will_msg, .user_name = NULL,
 	.password = NULL
@@ -319,8 +295,7 @@ u8_t connect5[] = {0x10, 0x21, 0x00, 0x04, 0x4d, 0x51, 0x54, 0x54,
 		   0x62, 0x79, 0x65};
 
 static ZTEST_DMEM struct mqtt_client client_connect5 = {
-	.clean_session = 1, .client_id.utf8 = CLIENTID,
-	.client_id.size = CLIENTID_LEN,
+	.clean_session = 1, .client_id = CLIENTID,
 	.will_retain = 1, .will_topic = &will_topic_qos_1,
 	.will_message = &will_msg, .user_name = NULL,
 	.password = NULL
@@ -344,8 +319,7 @@ u8_t connect6[] = {0x10, 0x34, 0x00, 0x04, 0x4d, 0x51, 0x54, 0x54,
 		  0x73, 0x73, 0x77, 0x6f, 0x72, 0x64};
 
 static ZTEST_DMEM struct mqtt_client client_connect6 = {
-	.clean_session = 1, .client_id.utf8 = CLIENTID,
-	.client_id.size = CLIENTID_LEN,
+	.clean_session = 1, .client_id = CLIENTID,
 	.will_retain = 1, .will_topic = &will_topic_qos_1,
 	.will_message = &will_msg, .user_name = &username,
 	.password = &password
@@ -368,8 +342,7 @@ u8_t publish1[] = {0x30, 0x0b, 0x00, 0x07, 0x73, 0x65, 0x6e, 0x73,
 static ZTEST_DMEM struct mqtt_publish_param msg_publish1 = {
 	.dup_flag = 0, .retain_flag = 0, .message_id = 0,
 	.message.topic.qos = 0,
-	.message.topic.topic.utf8 = TOPIC,
-	.message.topic.topic.size = TOPIC_LEN,
+	.message.topic.topic = TOPIC,
 	.message.payload.data = (u8_t *)"OK",
 	.message.payload.len = 2,
 };
@@ -388,8 +361,7 @@ u8_t publish2[] = {0x31, 0x0b, 0x00, 0x07, 0x73, 0x65, 0x6e, 0x73,
 static ZTEST_DMEM struct mqtt_publish_param msg_publish2 = {
 	.dup_flag = 0, .retain_flag = 1, .message_id = 0,
 	.message.topic.qos = 0,
-	.message.topic.topic.utf8 = TOPIC,
-	.message.topic.topic.size = TOPIC_LEN,
+	.message.topic.topic = TOPIC,
 	.message.payload.data = (u8_t *)"OK",
 	.message.payload.len = 2,
 };
@@ -408,8 +380,7 @@ u8_t publish3[] = {0x33, 0x0d, 0x00, 0x07, 0x73, 0x65, 0x6e, 0x73,
 static ZTEST_DMEM struct mqtt_publish_param msg_publish3 = {
 	.dup_flag = 0, .retain_flag = 1, .message_id = 1,
 	.message.topic.qos = 1,
-	.message.topic.topic.utf8 = TOPIC,
-	.message.topic.topic.size = TOPIC_LEN,
+	.message.topic.topic = TOPIC,
 	.message.payload.data = (u8_t *)"OK",
 	.message.payload.len = 2,
 };
@@ -427,8 +398,7 @@ u8_t publish4[] = {0x34, 0x0d, 0x00, 0x07, 0x73, 0x65, 0x6e, 0x73,
 static ZTEST_DMEM struct mqtt_publish_param msg_publish4 = {
 	.dup_flag = 0, .retain_flag = 0, .message_id = 1,
 	.message.topic.qos = 2,
-	.message.topic.topic.utf8 = TOPIC,
-	.message.topic.topic.size = TOPIC_LEN,
+	.message.topic.topic = TOPIC,
 	.message.payload.data = (u8_t *)"OK",
 	.message.payload.len = 2,
 };


### PR DESCRIPTION
This macro allows to easily initialize utf8 strings (struct mqtt_utf8) from C literals, as it automatically calculates string length.

Use it inside mqtt_encoder to simplify the code and fix NULL-termination (and ability to log) of proto descriptions in:
```
	MQTT_TRC("Encoding Protocol Description. Str:%s Size:%08x.",
		 mqtt_proto_desc->utf8, mqtt_proto_desc->size);
```

Also simplify one of the mqtt tests that initializes mqtt_utf8 structures in many places.