### PR TITLE
doc: fix broken links in README and board docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Here's a quick summary of resources to help you find your way around:
 * **Source Code**: https://github.com/zephyrproject-rtos/zephyr is the main
   repository; https://elixir.bootlin.com/zephyr/latest/source contains a
   searchable index
-* **Releases**: https://zephyrproject.org/developers/#downloads
+* **Releases**: https://github.com/zephyrproject-rtos/zephyr/releases
 * **Samples and example code**: see `Sample and Demo Code Examples`_
 * **Mailing Lists**: users@lists.zephyrproject.org and
   devel@lists.zephyrproject.org are the main user and developer mailing lists,

--- a/boards/riscv/qemu_riscv64/doc/index.rst
+++ b/boards/riscv/qemu_riscv64/doc/index.rst
@@ -19,7 +19,7 @@ Get the Toolchain and QEMU
 **************************
 
 The minimum version of the `Zephyr SDK tools
-<https://www.zephyrproject.org/developers/#downloads>`_
+<https://github.com/zephyrproject-rtos/sdk-ng/releases>`_
 with toolchain and QEMU support for the RISV64 architecture is v0.10.2.
 Please see the :ref:`installation instructions <install-required-tools>`
 for more details.


### PR DESCRIPTION
Point to zephyr/sdk release pages instead of non-existent downloads page
on project website.

Fixes #21706