### PR TITLE
doc: fix some errors

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -225,12 +225,6 @@ ALIASES                = "rst=\verbatim embed:rst:leading-asterisk" \
 
 ALIASES 	       += "req=\xrefitem req \"Requirement\" \"Requirements\" "
 
-# This tag can be used to specify a number of word-keyword mappings (TCL only).
-# A mapping has the form "name=value". For example adding "class=itcl::class"
-# will allow you to use the command class in the itcl::class meaning.
-
-TCL_SUBST              = YES
-
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
 # instance, some of the names that are used will be different. The list of all

--- a/tests/kernel/mem_protect/futex/src/main.c
+++ b/tests/kernel/mem_protect/futex/src/main.c
@@ -458,3 +458,7 @@ void test_main(void)
 			 ztest_unit_test(test_futex_wait_nowait));
 	ztest_run_test_suite(test_futex);
 }
+
+/**
+ * @}
+ */


### PR DESCRIPTION
I've been seeing these cause errors on the more recent versions of
Doxygen which come with Arch Linux for a while now. Fix these:

error: Illegal format for option TCL_SUBST, no equal sign ('=') specified for item 'YES'
$ZEPHYR_BASE/tests/kernel/mem_protect/futex/src/main.c:461: warning: end of file with unbalanced grouping commands

Just trying to get them out of my local output and as preparation for
whenever they start showing up for Ubuntu.
