### PR TITLE
Bluetooth: host: Add kconfig dependency for incompatible features

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -289,6 +289,7 @@ config BT_REMOTE_VERSION
 
 config BT_SMP
 	bool "Security Manager Protocol support"
+	depends on !BT_MESH
 	select TINYCRYPT
 	select TINYCRYPT_AES
 	select TINYCRYPT_AES_CMAC


### PR DESCRIPTION
Bluetooth SMP protocol and Bluetooth Mesh provisioner both use the
bt_pub_key_gen API. Since this uses the HCI DHkey commands which does
not support having more than one private key this API cannot be used
by both protocols at the same time.

Add kconfig dependency to prevent the incompatible features to be
both selected.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>