### PR TITLE
doc: update Getting Started Guide for macOS

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -137,7 +137,12 @@ We'll also install Zephyr's multi-purpose west tool.
 
          .. code-block:: bash
 
-            brew install cmake ninja gperf ccache dfu-util qemu dtc python3
+            brew install cmake ninja gperf ccache dfu-util qemu dtc python3 libgit2
+
+         .. note::
+            Depending on previously installed Python versions, the ``python``
+            command might point to a Python 2 installation instead of the newly
+            installed Python 3. See :ref:`python-pip` for more information.
 
       #. Install west:
 

--- a/doc/guides/beyond-GSG.rst
+++ b/doc/guides/beyond-GSG.rst
@@ -18,6 +18,11 @@ to install and run scripts required to compile and run Zephyr
 applications, set up and maintain the Zephyr development environment,
 and build project documentation.
 
+You must use Python 3 with Zephyr; Python 2 versions will not work.
+Enter ``python --version`` to confirm your Python version. If the displayed
+version is not Python 3, ensure that Python 3 is added to the path before
+any Python 2 version, and create an alias for python=python3 if necessary.
+
 Depending on your operating system, you may need to provide the
 ``--user`` flag to the ``pip3`` command when installing new packages. This is
 documented throughout the instructions.


### PR DESCRIPTION
Added libgit2 to required tools, and added a note to clarify
how to ensure that Python 3 is used.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>