### PR TITLE
Adds support for FMC external SDRAM preinitialisation for stm32.

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -565,3 +565,10 @@ config BOARD
 	  The Board is the first location where we search for a linker.ld file,
 	  if not found we look for the linker file in
 	  soc/<arch>/<family>/<series>
+
+config EARLY_INIT
+	bool "Support for early init code"
+	help
+	  Some boards require the initialization of some peripherals such as
+	  external flash or sdram. Enable this and create the vector table and
+	  early_init_handler to run code at the very start of the boot_rom.

--- a/arch/common/text_section_offset.ld
+++ b/arch/common/text_section_offset.ld
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
+#ifndef CONFIG_EARLY_INIT
 . = CONFIG_TEXT_SECTION_OFFSET;
+#endif
 . = ALIGN(4);

--- a/boards/arm/stm32f746g_disco/CMakeLists.txt
+++ b/boards/arm/stm32f746g_disco/CMakeLists.txt
@@ -5,3 +5,5 @@ zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()
+
+zephyr_sources_ifdef(CONFIG_EARLY_INIT early_init.c)

--- a/boards/arm/stm32f746g_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f746g_disco/Kconfig.defconfig
@@ -8,6 +8,13 @@ if BOARD_STM32F746G_DISCO
 config BOARD
 	default "stm32f746g_disco"
 
+config EARLY_INIT
+	default y
+
+choice DATA_LOCATION
+	default DATA_FMC
+endchoice
+
 config UART_1
 	default y
 	depends on UART_CONSOLE

--- a/boards/arm/stm32f746g_disco/early_init.c
+++ b/boards/arm/stm32f746g_disco/early_init.c
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2020 Mark Olsson <mark@markolsson.se>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "stm32f7xx.h"
+#include "kernel.h"
+
+// Size of early_init_vector_table at the bottom of this file
+#define VECTOR_TABLE_OFFSET 0x80;
+extern void __start(void);
+
+void configure_gpio_fmc(char port, uint8_t pin)
+{
+	/*
+	 * Alternate function: 12
+	 * Alternate function mode
+	 * Speed: 50 MHz
+	 * Output type: push-pull
+	 * No pull-up, pull-down
+	 */
+	volatile GPIO_TypeDef *GPIOx_base =
+		(void *)(GPIOA_BASE + (port - 'A') * 0x400);
+
+	if (pin >= 8) {
+		GPIOx_base->AFR[1] |= 0xC << ((pin - 8) * 4);
+	} else {
+		GPIOx_base->AFR[0] |= 0xC << (pin * 4);
+	}
+	GPIOx_base->MODER |= 0x2 << (pin * 2);
+	GPIOx_base->OSPEEDR |= 0x2 << (pin * 2);
+	GPIOx_base->OTYPER |= 0x0 << (pin * 2);
+	GPIOx_base->PUPDR |= 0x1 << (pin * 2);
+}
+
+void early_init_handler(void)
+{
+	register u32_t temp_register = 0, timeout = 0xFFFF;
+	register __IO u32_t index;
+
+	/* Reset the RCC clock configuration */
+	RCC->CR = (u32_t)0x00000083;
+	RCC->CFGR = (u32_t)0x00000000;
+	RCC->PLLCFGR = (u32_t)0x24003010;
+	RCC->CIR = (u32_t)0x00000000;
+
+	/* Enable GPIO clocks for FMC pins */
+	RCC->AHB1ENR |= (
+		RCC_AHB1ENR_GPIOCEN |
+		RCC_AHB1ENR_GPIODEN |
+		RCC_AHB1ENR_GPIOEEN |
+		RCC_AHB1ENR_GPIOFEN |
+		RCC_AHB1ENR_GPIOGEN |
+		RCC_AHB1ENR_GPIOHEN
+	);
+
+	/* Cofigure the GPIO Pins for FMC */
+	configure_gpio_fmc('C', 3);
+	configure_gpio_fmc('D', 0);
+	configure_gpio_fmc('D', 1);
+	configure_gpio_fmc('D', 8);
+	configure_gpio_fmc('D', 9);
+	configure_gpio_fmc('D', 10);
+	configure_gpio_fmc('D', 14);
+	configure_gpio_fmc('D', 15);
+	configure_gpio_fmc('E', 0);
+	configure_gpio_fmc('E', 1);
+	configure_gpio_fmc('E', 7);
+	configure_gpio_fmc('E', 8);
+	configure_gpio_fmc('E', 9);
+	configure_gpio_fmc('E', 10);
+	configure_gpio_fmc('E', 11);
+	configure_gpio_fmc('E', 12);
+	configure_gpio_fmc('E', 13);
+	configure_gpio_fmc('E', 14);
+	configure_gpio_fmc('E', 15);
+	configure_gpio_fmc('F', 0);
+	configure_gpio_fmc('F', 1);
+	configure_gpio_fmc('F', 2);
+	configure_gpio_fmc('F', 3);
+	configure_gpio_fmc('F', 4);
+	configure_gpio_fmc('F', 5);
+	configure_gpio_fmc('F', 11);
+	configure_gpio_fmc('F', 12);
+	configure_gpio_fmc('F', 13);
+	configure_gpio_fmc('F', 14);
+	configure_gpio_fmc('F', 15);
+	configure_gpio_fmc('G', 0);
+	configure_gpio_fmc('G', 1);
+	configure_gpio_fmc('G', 4);
+	configure_gpio_fmc('G', 5);
+	configure_gpio_fmc('G', 8);
+	configure_gpio_fmc('G', 15);
+	configure_gpio_fmc('H', 3);
+	configure_gpio_fmc('H', 5);
+
+	/* Enable the FMC interface clock */
+	RCC->AHB3ENR |= RCC_AHB3ENR_FMCEN;
+
+	/* Configure and enable SDRAM bank1 */
+	FMC_Bank5_6->SDCR[0] = 0x00001954;
+	FMC_Bank5_6->SDTR[0] = 0x01115351;
+
+	/* SDRAM initialization sequence */
+	/* Clock enable command */
+	FMC_Bank5_6->SDCMR = 0x00000011;
+	temp_register = FMC_Bank5_6->SDSR & 0x00000020;
+	while ((temp_register != 0) && (timeout-- > 0)) {
+		temp_register = FMC_Bank5_6->SDSR & 0x00000020;
+	}
+
+	/* Delay */
+	for (index = 0; index < 1000; index++) {
+	}
+
+	/* PALL command */
+	FMC_Bank5_6->SDCMR = 0x00000012;
+	timeout = 0xFFFF;
+	while ((temp_register != 0) && (timeout-- > 0)) {
+		temp_register = FMC_Bank5_6->SDSR & 0x00000020;
+	}
+
+	/* Auto refresh command */
+	FMC_Bank5_6->SDCMR = 0x000000F3;
+	timeout = 0xFFFF;
+	while ((temp_register != 0) && (timeout-- > 0)) {
+		temp_register = FMC_Bank5_6->SDSR & 0x00000020;
+	}
+
+	/* MRD register program */
+	FMC_Bank5_6->SDCMR = 0x00044014;
+	timeout = 0xFFFF;
+	while ((temp_register != 0) && (timeout-- > 0)) {
+		temp_register = FMC_Bank5_6->SDSR & 0x00000020;
+	}
+
+	/* Set refresh count */
+	temp_register = FMC_Bank5_6->SDRTR;
+	FMC_Bank5_6->SDRTR = (temp_register | (0x0000050C << 1));
+
+	/* Disable write protection */
+	temp_register = FMC_Bank5_6->SDCR[0];
+	FMC_Bank5_6->SDCR[0] = (temp_register & 0xFFFFFDFF);
+
+	/* Set vector table to the Zephyr one */
+	SCB->VTOR = FLASHAXI_BASE | VECTOR_TABLE_OFFSET;
+
+	/* Jump to Zephyr __start */
+	__start();
+}
+
+/* Vector table for early_init */
+unsigned long *early_init_vector_table[0x80] __attribute__((section(".early_init"))) = {
+	(unsigned long *)0x20000400,
+	(unsigned long *)early_init_handler,
+};

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -35,6 +35,12 @@
 		};
 	};
 
+	sdram0: memory@c0000000 {
+		device_type = "memory";
+		compatible = "mmio-sram";
+		reg = < 0xc0000000 DT_SIZE_K(8192) >;
+	};
+
 	aliases {
 		led0 = &green_led_1;
 		sw0 = &user_button;

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.yaml
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 256
+ram: 8192
 flash: 1024
 supported:
   - arduino_i2c

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -639,6 +639,13 @@
 			status = "disabled";
 			label = "DMA_2";
 		};
+
+		fmc: stm32-fmc@a0000000 {
+			compatible = "st,stm32-fmc";
+			reg = < 0xa0000000 0x400>;
+			status = "okay";
+			label = "FMC";
+		};
 	};
 
 	otghs_fs_phy: otghs_fs_phy {

--- a/dts/bindings/memory-controllers/st,stm32-fmc.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-fmc.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2020, Mark Olsson <mark@markolsson.se>
+# SPDX-License-Identifier: Apache-2.0
+
+description: STM32 Flexible Memory Controller (FMC)
+
+compatible: "st,stm32-fmc"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true
+
+    label:
+      required: true

--- a/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -137,6 +137,10 @@ SECTIONS
 
     SECTION_PROLOGUE(rom_start,,)
 	{
+#ifdef CONFIG_EARLY_INIT
+	. = 0x0;
+	KEEP(*(.early_init))
+#endif
 
 /* Located in generated directory. This file is populated by calling
  * zephyr_linker_sources(ROM_START ...). This typically contains the vector

--- a/include/linker/section_tags.h
+++ b/include/linker/section_tags.h
@@ -36,6 +36,10 @@
 #define __nocache __in_section_unique(_NOCACHE_SECTION_NAME)
 #endif /* CONFIG_NOCACHE_MEMORY */
 
+#if defined(CONFIG_EARLY_INIT)
+#define __early_init_section	Z_GENERIC_SECTION(EARLY_INIT)
+#endif /* CONFIG_EARLY_INIT */
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* ZEPHYR_INCLUDE_LINKER_SECTION_TAGS_H_ */

--- a/include/linker/sections.h
+++ b/include/linker/sections.h
@@ -71,6 +71,10 @@
 #define _NOCACHE_SECTION_NAME nocache
 #endif
 
+#ifdef CONFIG_EARLY_INIT
+#define EARLY_INIT	.early_init
+#endif
+
 #include <linker/section_tags.h>
 
 #endif /* ZEPHYR_INCLUDE_LINKER_SECTIONS_H_ */

--- a/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.series
@@ -12,6 +12,26 @@ source "soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f7*"
 config SOC_SERIES
 	default "stm32f7"
 
+if DATA_FMC
+
+config SRAM_SIZE
+	default $(dt_node_reg_size_int,/memory@c0000000,0,K)
+
+config SRAM_BASE_ADDRESS
+	default $(dt_node_reg_addr_hex,/memory@c0000000)
+
+endif # DATA_FMC
+
+if DATA_OCRAM
+
+config SRAM_SIZE
+	default $(dt_node_reg_size_int,/memory@20010000,0,K)
+
+config SRAM_BASE_ADDRESS
+	default $(dt_node_reg_addr_hex,/memory@20010000)
+
+endif # DATA_OCRAM
+
 if GPIO_STM32
 
 # GPIO ports A, B and C are set in ../common/Kconfig.defconfig.series

--- a/soc/arm/st_stm32/stm32f7/Kconfig.soc
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.soc
@@ -25,3 +25,15 @@ config SOC_STM32F769XX
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 
 endchoice
+
+choice DATA_LOCATION
+	prompt "Data location selection"
+	default DATA_OCRAM
+
+config DATA_FMC
+	bool "Link data into external FMC-controlled memory"
+
+config DATA_OCRAM
+	bool "Link data into On-Chip RAM memory"
+
+endchoice

--- a/soc/arm/st_stm32/stm32f7/linker.ld
+++ b/soc/arm/st_stm32/stm32f7/linker.ld
@@ -6,4 +6,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+ #include <autoconf.h>
+ #include <devicetree.h>
+
+MEMORY
+     {
+#if (DT_MMIO_SRAM_20010000_SIZE > 0) && !defined(CONFIG_DATA_OCRAM)
+        OCRAM  (wx) : ORIGIN = DT_MMIO_SRAM_20010000_BASE_ADDRESS, LENGTH = DT_MMIO_SRAM_20010000_SIZE
+#endif
+#if (DT_MMIO_SRAM_C0000000_SIZE > 0) && !defined(CONFIG_DATA_FMC)
+        SDRAM  (wx) : ORIGIN = DT_MMIO_SRAM_C0000000_BASE_ADDRESS, LENGTH = DT_MMIO_SRAM_C0000000_SIZE
+#endif
+     }
+
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>


### PR DESCRIPTION
As a prerequisite for enabling LTDC on STM32, this pull request enables using the external SDRAM on the STM32f746g_discovery board as the main memory. It does this by configuring it at boot and then jumping to the zephyr code.

Closes #15944

Signed-off-by: Mark Olsson <mark@markolsson.se>