### PR TITLE
usb: mass_storage: check LBA range

### DIFF
--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -433,6 +433,13 @@ static bool infoTransfer(void)
 				 (cbw.CB[5] <<  0);
 
 	LOG_DBG("LBA (block) : 0x%x ", n);
+	if ((n * BLOCK_SIZE) >= memory_size) {
+		LOG_ERR("LBA out of range");
+		csw.Status = CSW_FAILED;
+		sendCSW();
+		return false;
+	}
+
 	addr = n * BLOCK_SIZE;
 
 	/* Number of Blocks to transfer */


### PR DESCRIPTION
Check if LBA is in range of the memory size.

Signed-off-by: Johann Fischer <j.fischer@phytec.de>
Signed-off-by: David Brown <david.brown@linaro.org>

backport #23240