### PR TITLE
[v2.1-branch] usb: dfu: check requested length (wLength) during DFU_UPLOAD

### DIFF
--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -509,6 +509,15 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 				len = pSetup->wLength;
 			}
 
+			if (len > USB_DFU_MAX_XFER_SIZE) {
+				/*
+				 * The host could requests more data as stated
+				 * in wTransferSize. Limit upload length to the
+				 * size of the request-buffer.
+				 */
+				len = USB_DFU_MAX_XFER_SIZE;
+			}
+
 			if (len) {
 				const struct flash_area *fa;
 


### PR DESCRIPTION
During DFU_UPLOAD, the host could requests more data
as stated in wTransferSize. Limit upload length to the
size of the request buffer (USB_REQUEST_BUFFER_SIZE).

Signed-off-by: Johann Fischer <j.fischer@phytec.de>
Signed-off-by: David Brown <david.brown@linaro.org>

Backport #23190