### PR TITLE
power: device: fix name for Nordic clock driver

### DIFF
--- a/subsys/power/device.c
+++ b/subsys/power/device.c
@@ -24,10 +24,8 @@ LOG_MODULE_DECLARE(power);
  */
 #if defined(CONFIG_SOC_FAMILY_NRF)
 #define MAX_PM_DEVICES	15
-#define MAX_DEV_NAME_LEN	16
-static const char core_devices[][MAX_DEV_NAME_LEN] = {
-	"CLOCK_32K",
-	"CLOCK_16M",
+static const char *const core_devices[] = {
+	"CLOCK",
 	"sys_clock",
 	"UART_0",
 };
@@ -136,7 +134,7 @@ void sys_pm_create_device_list(void)
 		     j < ARRAY_SIZE(core_devices);
 		     j++) {
 			if (!strcmp(pm_device_list[i].config->name,
-						&core_devices[j][0])) {
+						core_devices[j])) {
 				is_core_dev = true;
 				break;
 			}


### PR DESCRIPTION
The device power management infrastructure maintains a hard-coded list
of critical devices to ensure suspend and resume are performed in the
proper order.  PR #21298 combined the 32 KiHz and 16 MHz clock devices
into a single driver, changing the name so the clock driver is not
handled at the correct time, but rather at whatever point it appears
in the general device list.

Update the list to the current clock driver name.  Also store the
device names as standard strings rather than padding them to a fixed
length.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>