### PR TITLE
Bluetooth: Kconfig: Fix BT_ECC defaults

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -558,7 +558,7 @@ endif # BT_HCI_HOST
 
 config BT_ECC
 	bool "Enable ECDH key generation support"
-	default y if !BT_SMP_OOB_LEGACY_PAIR_ONLY
+	default y if BT_MESH_PROV || (BT_SMP && !BT_SMP_OOB_LEGACY_PAIR_ONLY)
 	help
 	  This option adds support for ECDH HCI commands.
 

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -20,7 +20,6 @@ if BT_MESH
 # Virtual option enabled whenever Generic Provisioning layer is needed
 config BT_MESH_PROV
 	bool
-	select BT_ECC
 
 config BT_MESH_PB_ADV
 	bool "Provisioning support using the advertising bearer (PB-ADV)"
@@ -32,7 +31,6 @@ config BT_MESH_PB_ADV
 
 config BT_MESH_PROVISIONER
 	bool "Provisioner support"
-	select BT_ECC
 	select BT_MESH_PROV
 	help
 	  Enable this option to have support for provisioning remote devices.


### PR DESCRIPTION
The commit e85dd8af5d39b38 changed the way the BT_ECC Kconfig option
is enabled, however it got the dependency wrong. The dependency should
only look at BT_SMP_OOB_LEGACY_PAIR_ONLY if BT_SMP was also enable.

This broke e.g. the build of the mesh_demo app for the BBC
micro:bit since the memory consumption jumped up by roughly 2k.

This patch fixes the issue, and in the same go makes the Mesh handling
consistent by also using a conditional default rather than select.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>