### PR TITLE
bluetooth: host: bt_conn_create dynamic initiation timeout

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -485,6 +485,7 @@ struct bt_conn_cb {
 	 *  - @ref BT_HCI_ERR_UNKNOWN_CONN_ID Creating the connection started by
 	 *    @ref bt_conn_create_le was canceled either by the user through
 	 *    @ref bt_conn_disconnect or by the timeout in the host through
+	 *    @ref bt_conn_initiation_timeout, which defaults to
 	 *    :option:`CONFIG_BT_CREATE_CONN_TIMEOUT`.
 	 *  - @p BT_HCI_ERR_ADV_TIMEOUT Directed advertiser started by @ref
 	 *    bt_conn_create_slave_le with high duty cycle timed out after 1.28
@@ -587,6 +588,15 @@ struct bt_conn_cb {
 
 	struct bt_conn_cb *_next;
 };
+
+/** @brief Update the initiation timeout for future connections
+ *
+ *  By default, the timeout is equal to
+ *  K_SECONDS(CONFIG_BT_CREATE_CONN_TIMEOUT)
+ *
+ *  @param timeout Updated initiation timeout
+ */
+void bt_conn_initiation_timeout(s32_t timeout);
 
 /** @brief Register connection callbacks.
  *

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1158,6 +1158,11 @@ bt_security_t bt_conn_get_security(struct bt_conn *conn)
 }
 #endif /* CONFIG_BT_SMP */
 
+void bt_conn_initiation_timeout(s32_t timeout)
+{
+	conn_initiation_timeout = timeout;
+}
+
 void bt_conn_cb_register(struct bt_conn_cb *cb)
 {
 	cb->_next = callback_list;
@@ -1713,7 +1718,7 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 			/* this indicate LE Create Connection with peer address
 			 * has been stopped. This could either be triggered by
 			 * the application through bt_conn_disconnect or by
-			 * timeout set by CONFIG_BT_CREATE_CONN_TIMEOUT.
+			 * timeout contained in conn_initiation_timeout.
 			 */
 			if (conn->err) {
 				notify_connected(conn);

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -65,7 +65,7 @@ NET_BUF_POOL_FIXED_DEFINE(frag_pool, CONFIG_BT_L2CAP_TX_FRAG_COUNT, FRAG_SIZE,
 #endif /* CONFIG_BT_L2CAP_TX_FRAG_COUNT > 0 */
 
 /* How long until we cancel HCI_LE_Create_Connection */
-#define CONN_TIMEOUT	K_SECONDS(CONFIG_BT_CREATE_CONN_TIMEOUT)
+s32_t conn_initiation_timeout = K_SECONDS(CONFIG_BT_CREATE_CONN_TIMEOUT);
 
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_BREDR)
 const struct bt_conn_auth_cb *bt_auth;
@@ -1765,7 +1765,8 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 		 */
 		if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
 		    conn->type == BT_CONN_TYPE_LE) {
-			k_delayed_work_submit(&conn->update_work, CONN_TIMEOUT);
+			k_delayed_work_submit(&conn->update_work,
+					conn_initiation_timeout);
 		}
 
 		break;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -889,7 +889,7 @@ static inline bool rpa_timeout_valid_check(void)
 }
 
 #if defined(CONFIG_BT_CENTRAL)
-int bt_le_create_conn(const struct bt_conn *conn)
+int bt_le_create_conn(struct bt_conn *conn)
 {
 	struct bt_hci_cp_le_create_conn *cp;
 	struct cmd_state_set state;

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -188,7 +188,7 @@ bool bt_le_conn_params_valid(const struct bt_le_conn_param *param);
 
 int bt_le_scan_update(bool fast_scan);
 
-int bt_le_create_conn(const struct bt_conn *conn);
+int bt_le_create_conn(struct bt_conn *conn);
 int bt_le_create_conn_cancel(void);
 
 bool bt_addr_le_is_bonded(u8_t id, const bt_addr_le_t *addr);


### PR DESCRIPTION
Allows users to change the timeout for connection initiation at run-time, while retaining current interfaces and behavior.

Removing the const qualifier from bt_le_create_conn is not ideal, but issue #22834 needs to be solved before it can be reverted.

Tested against out-of-tree repo.

Fixes #23468