### PR TITLE
arch: arm: cortex-m: minor fix in ISR stack limit address during boot

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/reset.S
+++ b/arch/arm/core/aarch32/cortex_m/reset.S
@@ -80,7 +80,7 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 #ifdef CONFIG_INIT_STACKS
     ldr r0, =_interrupt_stack
     ldr r1, =0xaa
-    ldr r2, =CONFIG_ISR_STACK_SIZE
+    ldr r2, =ARCH_THREAD_STACK_LEN(CONFIG_ISR_STACK_SIZE)
     bl memset
 #endif
 
@@ -89,7 +89,7 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
      * gets set to _interrupt_stack during initialization.
      */
     ldr r0, =_interrupt_stack
-    ldr r1, =CONFIG_ISR_STACK_SIZE
+    ldr r1, =ARCH_THREAD_STACK_LEN(CONFIG_ISR_STACK_SIZE)
     adds r0, r0, r1
     msr PSP, r0
     mrs r0, CONTROL


### PR DESCRIPTION
In two cases where we use the interrupt stack
in cortex-m reset.S, namely
- when we initialize the interrupt stack, and
- when we set PSP to the beginning of it
we should be considering the actual size of the stack, i.e.
including the MPU Stack Guard when applicable. By fixing
that in this commit we are able to use a bit of more
space during Zephyr boot (in normal kernel operation
the whole interrupt stack is used anyways).

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

That's a _very_ minor enhancement only.