### PR TITLE
boards/arm/nucleo_h743zi/nucleo_h743zi.dts:Changes User LD2 led

### DIFF
--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
@@ -26,8 +26,8 @@
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
-		blue_led: led_1 {
-			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
+		yellow_led: led_1 {
+			gpios = <&gpioe 1 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
 		red_led: led_2 {
@@ -46,7 +46,7 @@
 
 	aliases {
 		led0 = &green_led;
-		led1 = &blue_led;
+		led1 = &yellow_led;
 		led2 = &red_led;
 		sw0 = &user_button;
 	};


### PR DESCRIPTION
The "User LD2" led is connected to pin PE1 and its color is yellow on the nucleo_h743zi board.
Connections in the dts file are fixed.

Signed-off-by: jvegam juan.vega25@gmail.com