### PR TITLE
Backport: arch: arm: aarch32: userspace: fix syscall ID validation

### DIFF
--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -514,7 +514,10 @@ _do_syscall:
     ldr ip, =K_SYSCALL_LIMIT
     cmp r6, ip
 #endif
-    blt valid_syscall_id
+    /* The supplied syscall_id must be lower than the limit
+     * (Requires unsigned integer comparison)
+     */
+    blo valid_syscall_id
 
     /* bad syscall id.  Set arg1 to bad id and set call_id to SYSCALL_BAD */
     str r6, [r0]

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -1083,6 +1083,10 @@ void test_bad_syscall(void)
 
 	arch_syscall_invoke0(INT_MAX);
 
+	expect_fault = true;
+	expected_reason = K_ERR_KERNEL_OOPS;
+
+	arch_syscall_invoke0(UINT_MAX);
 }
 
 static struct k_sem recycle_sem;


### PR DESCRIPTION
Backport pr23323 to v2.1.