### PR TITLE
backport-v1.14: arch: arc: fix the bug of blt in syscall

### DIFF
--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -156,7 +156,7 @@ SECTION_SUBSEC_FUNC(TEXT,__fault,__ev_trap)
 	/* do sys_call */
 	mov ilink, K_SYSCALL_LIMIT
 	cmp r6, ilink
-	blt valid_syscall_id
+	blo valid_syscall_id
 
 	mov r0, r6
 	mov r6, K_SYSCALL_BAD


### PR DESCRIPTION
blt is signed comparsion, if r6 is a negative number created by
malicious code, it will pass the check, bring a secure risk.

use blo (unsinged comparison) to do the check.

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>
Signed-off-by: David Brown <david.brown@linaro.org>

Backport of #23328