### PR TITLE
tests: drivers: uart: config api fix dependency #23459

### DIFF
--- a/tests/drivers/uart/uart_basic_api/src/test_uart_config.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_config.c
@@ -26,11 +26,7 @@
 
 #include "test_uart.h"
 struct uart_config uart_cfg_check;
-
-/* test UART configure (set configuration) */
-static int test_configure(void)
-{
-	const struct uart_config uart_cfg = {
+const struct uart_config uart_cfg = {
 		.baudrate = 115200,
 		.parity = UART_CFG_PARITY_NONE,
 		.stop_bits = UART_CFG_STOP_BITS_1,
@@ -38,6 +34,8 @@ static int test_configure(void)
 		.flow_ctrl = UART_CFG_FLOW_CTRL_NONE
 	};
 
+static int test_configure(void)
+{
 	struct device *uart_dev = device_get_binding(UART_DEVICE_NAME);
 
 	if (!uart_dev) {
@@ -45,27 +43,18 @@ static int test_configure(void)
 		return TC_FAIL;
 	}
 
-	TC_PRINT("This is a configure test.\n");
-
 	/* Verify configure() - set device configuration using data in cfg */
-	/* 0 if successful, - error code otherwise */
 	int ret = uart_configure(uart_dev, &uart_cfg);
 
-	/* Confirm the values provided are the values set*/
-	/* so get the configurations from the device and check */
-	uart_config_get(uart_dev, &uart_cfg_check);
-	if (memcmp(&uart_cfg, &uart_cfg_check, sizeof(uart_cfg)) != 0) {
-		return TC_FAIL;
-	}
-
+	/* 0 if successful, - error code otherwise */
 	return (ret == 0) ? TC_PASS : TC_FAIL;
+
 }
 
 /* test UART configure get (retrieve configuration) */
 static int test_config_get(void)
 {
 	struct device *uart_dev = device_get_binding(UART_DEVICE_NAME);
-	struct uart_config uart_cfg;
 
 	if (!uart_dev) {
 		TC_PRINT("Cannot get UART device\n");
@@ -74,16 +63,24 @@ static int test_config_get(void)
 
 	TC_PRINT("This is a configure_get test.\n");
 
-	/* Verify uart_config_get() - get device configuration, put in cfg */
+	/* Verify configure() - set device configuration using data in cfg */
 	/* 0 if successful, - error code otherwise */
-	int ret = uart_config_get(uart_dev, &uart_cfg);
+	int ret = uart_configure(uart_dev, &uart_cfg);
+
+	zassert_true(ret == 0, "set config error");
+
+	/* Verify config_get() - get device configuration, put in cfg */
+	/* 0 if successful, - error code otherwise */
+	/* so get the configurations from the device and check */
+	ret = uart_config_get(uart_dev, &uart_cfg_check);
+	zassert_true(ret == 0, "get config error");
 
 	/* Confirm the values from device are the values put in cfg*/
 	if (memcmp(&uart_cfg, &uart_cfg_check, sizeof(uart_cfg)) != 0) {
 		return TC_FAIL;
+	} else {
+		return TC_PASS;
 	}
-	return (ret == 0) ? TC_PASS : TC_FAIL;
-
 }
 
 void test_uart_configure(void)


### PR DESCRIPTION
Tests were added for the UART configure API in #22849. The existing test
implementation works, but suggested to reduce dependency between test cases.
This commit allows each test to run independently of each other by removing
the function call of uart_config_get() in the uart_configure() test case, and
uses the uart_config_get() test case to confirm the value set and gotten/read.

Fixes #23459

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>