### PR TITLE
usb: mass_storage: fix API usage by using memmove

### DIFF
--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -756,7 +756,7 @@ static void thread_memory_write_done(void)
 	size_t overflowed_len = (addr + size) % CONFIG_MASS_STORAGE_BULK_EP_MPS;
 
 	if (overflowed_len) {
-		memcpy(page, &page[BLOCK_SIZE], overflowed_len);
+		memmove(page, &page[BLOCK_SIZE], overflowed_len);
 	}
 
 	addr += size;


### PR DESCRIPTION
Fix API usage error introduced by the commit c88155fd2d41
("usb: mass_storage: fix possible page buffer overflow")'

Fixes: #23295
CID: 208676