### PR TITLE
arch: arm: aarch32: Fix arch_cpu_idle interrupt masking and add memory barriers

### DIFF
--- a/arch/arm/core/aarch32/cpu_idle.S
+++ b/arch/arm/core/aarch32/cpu_idle.S
@@ -128,15 +128,17 @@ SECTION_FUNC(TEXT, arch_cpu_atomic_idle)
 	cpsid	i
 
 	/*
-	 * No need to set SEVONPEND, it's set once in z_CpuIdleInit() and never
-	 * touched again.
+	 * No need to set SEVONPEND, it's set once in z_arm_cpu_idle_init()
+	 * and never touched again.
 	 */
 
 	/* r0: interrupt mask from caller */
 
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) \
 	|| defined(CONFIG_ARMV7_R)
-	/* No BASEPRI, call wfe directly (SEVONPEND set in z_CpuIdleInit()) */
+	/* No BASEPRI, call wfe directly
+	 * (SEVONPEND is set in z_arm_cpu_idle_init())
+	 */
 	wfe
 
 	cmp	r0, #0

--- a/arch/arm/core/aarch32/cpu_idle.S
+++ b/arch/arm/core/aarch32/cpu_idle.S
@@ -74,9 +74,13 @@ SECTION_FUNC(TEXT, arch_cpu_idle)
 	 */
 	cpsid	i
 
-	/* Set wake-up interrupt priority to the lowest */
+	/*
+	 * Set wake-up interrupt priority to the lowest and synchronise to
+	 * ensure that this is visible to the WFI instruction.
+	 */
 	eors.n	r0, r0
 	msr	BASEPRI, r0
+	isb
 #else
 	/*
 	 * For all the other ARM architectures that do not implement BASEPRI,
@@ -87,10 +91,21 @@ SECTION_FUNC(TEXT, arch_cpu_idle)
 	 */
 #endif /* CONFIG_ARMV7_M_ARMV8_M_MAINLINE */
 
+	/*
+	 * Wait for all memory transactions to complete before entering low
+	 * power state.
+	 */
+	dsb
+
+	/* Enter low power state */
 	wfi
 
-	/* Clear PRIMASK to service any pending interrupt */
+	/*
+	 * Clear PRIMASK and flush instruction buffer to immediately service
+	 * the wake-up interrupt.
+	 */
 	cpsie	i
+	isb
 
 	bx	lr
 

--- a/arch/arm/core/aarch32/cpu_idle.S
+++ b/arch/arm/core/aarch32/cpu_idle.S
@@ -20,12 +20,12 @@ GTEXT(arch_cpu_idle)
 GTEXT(arch_cpu_atomic_idle)
 
 #if defined(CONFIG_CPU_CORTEX_M)
-#define _SCB_SCR 0xE000ED10
+#define _SCB_SCR		0xE000ED10
 
-#define _SCB_SCR_SEVONPEND (1 << 4)
-#define _SCB_SCR_SLEEPDEEP (1 << 2)
-#define _SCB_SCR_SLEEPONEXIT (1 << 1)
-#define _SCR_INIT_BITS _SCB_SCR_SEVONPEND
+#define _SCB_SCR_SEVONPEND	(1 << 4)
+#define _SCB_SCR_SLEEPDEEP	(1 << 2)
+#define _SCB_SCR_SLEEPONEXIT	(1 << 1)
+#define _SCR_INIT_BITS		_SCB_SCR_SEVONPEND
 #endif
 
 /**
@@ -44,48 +44,48 @@ GTEXT(arch_cpu_atomic_idle)
 
 SECTION_FUNC(TEXT, z_arm_cpu_idle_init)
 #if defined(CONFIG_CPU_CORTEX_M)
-	ldr r1, =_SCB_SCR
-	movs.n r2, #_SCR_INIT_BITS
-	str r2, [r1]
+	ldr	r1, =_SCB_SCR
+	movs.n	r2, #_SCR_INIT_BITS
+	str	r2, [r1]
 #endif
-	bx lr
+	bx	lr
 
 SECTION_FUNC(TEXT, arch_cpu_idle)
 #ifdef CONFIG_TRACING
-	push {r0, lr}
-	bl    sys_trace_idle
+	push	{r0, lr}
+	bl	sys_trace_idle
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-	pop {r0, r1}
-        mov lr, r1
+	pop	{r0, r1}
+	mov	lr, r1
 #else
-	pop {r0, lr}
+	pop	{r0, lr}
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 #endif /* CONFIG_TRACING */
 
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) \
 	|| defined(CONFIG_ARMV7_R)
-	cpsie i
+	cpsie	i
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 	/* clear BASEPRI so wfi is awakened by incoming interrupts */
-	eors.n r0, r0
-	msr BASEPRI, r0
+	eors.n	r0, r0
+	msr	BASEPRI, r0
 #else
 #error Unknown ARM architecture
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 
 	wfi
 
-	bx lr
+	bx	lr
 
 SECTION_FUNC(TEXT, arch_cpu_atomic_idle)
 #ifdef CONFIG_TRACING
-	push {r0, lr}
-	bl    sys_trace_idle
+	push	{r0, lr}
+	bl	sys_trace_idle
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-        pop {r0, r1}
-        mov lr, r1
+	pop	{r0, r1}
+	mov	lr, r1
 #else
-	pop {r0, lr}
+	pop	{r0, lr}
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 #endif /* CONFIG_TRACING */
 
@@ -93,7 +93,7 @@ SECTION_FUNC(TEXT, arch_cpu_atomic_idle)
 	 * Lock PRIMASK while sleeping: wfe will still get interrupted by
 	 * incoming interrupts but the CPU will not service them right away.
 	 */
-	cpsid i
+	cpsid	i
 
 	/*
 	 * No need to set SEVONPEND, it's set once in z_CpuIdleInit() and never
@@ -107,23 +107,23 @@ SECTION_FUNC(TEXT, arch_cpu_atomic_idle)
 	/* No BASEPRI, call wfe directly (SEVONPEND set in z_CpuIdleInit()) */
 	wfe
 
-	cmp r0, #0
-	bne _irq_disabled
-	cpsie i
+	cmp	r0, #0
+	bne	_irq_disabled
+	cpsie	i
 _irq_disabled:
 
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 	/* r1: zero, for setting BASEPRI (needs a register) */
-	eors.n r1, r1
+	eors.n	r1, r1
 
 	/* unlock BASEPRI so wfe gets interrupted by incoming interrupts */
-	msr BASEPRI, r1
+	msr	BASEPRI, r1
 
 	wfe
 
-	msr BASEPRI, r0
-	cpsie i
+	msr	BASEPRI, r0
+	cpsie	i
 #else
 #error Unknown ARM architecture
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
-	bx lr
+	bx	lr

--- a/arch/arm/core/aarch32/cpu_idle.S
+++ b/arch/arm/core/aarch32/cpu_idle.S
@@ -62,18 +62,35 @@ SECTION_FUNC(TEXT, arch_cpu_idle)
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 #endif /* CONFIG_TRACING */
 
-#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) \
-	|| defined(CONFIG_ARMV7_R)
-	cpsie	i
-#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-	/* clear BASEPRI so wfi is awakened by incoming interrupts */
+#if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+	/*
+	 * PRIMASK is always cleared on ARMv7-M and ARMv8-M Mainline (not used
+	 * for interrupt locking), and configuring BASEPRI to the lowest
+	 * priority to ensure wake-up will cause interrupts to be serviced
+	 * before entering low power state.
+	 *
+	 * Set PRIMASK before configuring BASEPRI to prevent interruption
+	 * before wake-up.
+	 */
+	cpsid	i
+
+	/* Set wake-up interrupt priority to the lowest */
 	eors.n	r0, r0
 	msr	BASEPRI, r0
 #else
-#error Unknown ARM architecture
-#endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
+	/*
+	 * For all the other ARM architectures that do not implement BASEPRI,
+	 * PRIMASK is used as the interrupt locking mechanism, and it is not
+	 * necessary to set PRIMASK here, as PRIMASK would have already been
+	 * set by the caller as part of interrupt locking if necessary
+	 * (i.e. if the caller sets _kernel.idle).
+	 */
+#endif /* CONFIG_ARMV7_M_ARMV8_M_MAINLINE */
 
 	wfi
+
+	/* Clear PRIMASK to service any pending interrupt */
+	cpsie	i
 
 	bx	lr
 

--- a/doc/reference/kernel/other/cpu_idle.rst
+++ b/doc/reference/kernel/other/cpu_idle.rst
@@ -25,8 +25,9 @@ Making the CPU idle
 ===================
 
 Making the CPU idle is simple: call the k_cpu_idle() API. The CPU will stop
-executing instructions until an event occurs. Make sure interrupts are not
-locked before invoking it. Most likely, it will be called within a loop.
+executing instructions until an event occurs. Most likely, the function will
+be called within a loop. Note that in certain architectures, upon return,
+k_cpu_idle() unconditionally unmasks interrupts.
 
 .. code-block:: c
 

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4999,6 +4999,9 @@ extern void z_handle_obj_poll_events(sys_dlist_t *events, u32_t state);
  * However, in some more constrained systems, such as a single-threaded system,
  * the only thread would be responsible for this if needed.
  *
+ * @note In some architectures, before returning, the function unmasks interrupts
+ * unconditionally.
+ *
  * @return N/A
  * @req K-CPU-IDLE-001
  */

--- a/include/sys/arch_interface.h
+++ b/include/sys/arch_interface.h
@@ -127,6 +127,10 @@ static inline u32_t arch_k_cycle_get_32(void);
  * immediately return, otherwise a power-saving instruction should be
  * issued to wait for an interrupt.
  *
+ * @note The function is expected to return after the interrupt that has
+ * caused the CPU to exit power-saving mode has been serviced, although
+ * this is not a firm requirement.
+ *
  * @see k_cpu_idle()
  */
 void arch_cpu_idle(void);


### PR DESCRIPTION
```
arch: arm: aarch32: Fix arch_cpu_idle interrupt masking

The current AArch32 `arch_cpu_idle` implementation enables interrupt
before executing the WFI instruction, and this has the side effect of
allowing interruption and thereby calling wake-up notification
functions before the CPU enters sleep.

This commit fixes the problem described above by ensuring that
interrupt is disabled when the WFI instruction is executed and
re-enabled only after the processor wakes up.

For ARMv6-M, ARMv8-M Baseline and ARM-R, the PRIMASK (ARM-M)/
CPSR.I (ARM-R) is used to lock interrupts and therefore it is not
necessary to do anything before executing the WFI instruction.

For ARMv7-M and ARMv8-M Mainline, the BASEPRI is used to lock
interrupts and the PRIMASK is always cleared in non-interrupt context;
therefore, it is necessary to set the PRIMASK to mask interrupts,
before clearing the BASEPRI to configure wake-up interrupt priority to
the lowest.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```

```
This commit adds the required memory barriers to the `arch_cpu_idle`
function in order to ensure proper idle operation in all cases.

1. Add ISB after setting BASEPRI to ensure that the new wake-up
  interrupt priority is visible to the WFI instruction.

2. Add DSB before WFI to ensure that all memory transactions are
  completed before going to sleep.

3. Add ISB after CPSIE to ensure that the pending wake-up interrupt
  is serviced immediately.

Co-authored-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>
Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```

Addresses #22078