### PR TITLE
sanitycheck: delete the '\r' char in front of serial output

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -651,7 +651,7 @@ class DeviceHandler(Handler):
             # Just because ser_fileno has data doesn't mean an entire line
             # is available yet.
             if serial_line:
-                sl = serial_line.decode('utf-8', 'ignore')
+                sl = serial_line.decode('utf-8', 'ignore').lstrip()
                 logger.debug("DEVICE: {0}".format(sl.rstrip()))
 
                 log_out_fp.write(sl)


### PR DESCRIPTION
Add lstrip() function to delete the '\r' char in front of the
serial output from serail readline, because this '\r'
will influence the result match function in harness.py.

Fixes #23309 

Signed-off-by: peng1 chen <peng1.chen@intel.com>