### PR TITLE
[RFC] interrupts: Do not assert on IRQ enable status when installing ISR

### DIFF
--- a/arch/common/sw_isr_common.c
+++ b/arch/common/sw_isr_common.c
@@ -16,8 +16,6 @@ void z_isr_install(unsigned int irq, void (*routine)(void *), void *param)
 {
 	unsigned int table_idx = irq - CONFIG_GEN_IRQ_START_VECTOR;
 
-	__ASSERT(!irq_is_enabled(irq), "IRQ %d is enabled", irq);
-
 	/* If dynamic IRQs are enabled, then the _sw_isr_table is in RAM and
 	 * can be modified
 	 */


### PR DESCRIPTION
The current `z_isr_install` implementation asserts that the IRQ to
which the ISR will be installed must be disabled.

This commit removes that assertion because there is no good reason as
to why that must always be the case, and the assertion fails for the
IRQs that can never be disabled as per the architecture specifications
(e.g. the SGI-type IRQs on the ARM GIC cannot be disabled and therefore
`irq_is_enabled` returns true for all SGI-type IRQs).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>