### PR TITLE
samples: net: cloud: Fix the mqtt_azure sample location

### DIFF
--- a/samples/net/cloud/mqtt_azure/README.rst
+++ b/samples/net/cloud/mqtt_azure/README.rst
@@ -16,7 +16,7 @@ can publish messages to an Azure Cloud IoT hub based on MQTT protocol.
 - DNS supported
 
 The source code of this sample application can be found at:
-:zephyr_file:`samples/net/mqtt_azure`.
+:zephyr_file:`samples/net/cloud/mqtt_azure`.
 
 Requirements
 ************


### PR DESCRIPTION
The path to the mqtt_azure sample was not correct.
Original patch by Benjamin Cabé at #21464 which unfortunately seems to be abandoned.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>