### PR TITLE
drivers: interrupt_controller: shared: handle flags differences in dr…

### DIFF
--- a/drivers/interrupt_controller/intc_shared_irq.c
+++ b/drivers/interrupt_controller/intc_shared_irq.c
@@ -139,10 +139,15 @@ DEVICE_AND_API_INIT(shared_irq_0, DT_INST_0_SHARED_IRQ_LABEL,
 
 void shared_irq_config_0_irq(void)
 {
+#ifdef DT_INST_0_SHARED_IRQ_IRQ_0_SENSE
+#define IRQ_0_FLAGS DT_INST_0_SHARED_IRQ_IRQ_0_SENSE
+#else
+#define IRQ_0_FLAGS DT_INST_0_SHARED_IRQ_IRQ_0_FLAGS
+#endif
 	IRQ_CONNECT(DT_INST_0_SHARED_IRQ_IRQ_0,
 		    DT_INST_0_SHARED_IRQ_IRQ_0_PRIORITY,
 		    shared_irq_isr, DEVICE_GET(shared_irq_0),
-		    DT_INST_0_SHARED_IRQ_IRQ_0_SENSE);
+		    IRQ_0_FLAGS);
 }
 
 #endif /* CONFIG_SHARED_IRQ_0 */
@@ -165,10 +170,15 @@ DEVICE_AND_API_INIT(shared_irq_1, DT_INST_1_SHARED_IRQ_LABEL,
 
 void shared_irq_config_1_irq(void)
 {
+#ifdef DT_INST_1_SHARED_IRQ_IRQ_0_SENSE
+#define IRQ_1_FLAGS DT_INST_1_SHARED_IRQ_IRQ_0_SENSE
+#else
+#define IRQ_1_FLAGS DT_INST_1_SHARED_IRQ_IRQ_0_FLAGS
+#endif
 	IRQ_CONNECT(DT_INST_1_SHARED_IRQ_IRQ_0,
 		    DT_INST_1_SHARED_IRQ_IRQ_0_PRIORITY,
 		    shared_irq_isr, DEVICE_GET(shared_irq_1),
-		    DT_INST_1_SHARED_IRQ_IRQ_0_SENSE);
+		    IRQ_1_FLAGS);
 }
 
 #endif /* CONFIG_SHARED_IRQ_1 */

--- a/soc/arm/qemu_cortex_a53/dts_fixup.h
+++ b/soc/arm/qemu_cortex_a53/dts_fixup.h
@@ -1,7 +1,0 @@
-/*
- * Copyright (c) 2019 Carlo Caione <ccaione@baylibre.com>
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-#define DT_INST_0_SHARED_IRQ_IRQ_0_SENSE	DT_INST_0_SHARED_IRQ_IRQ_0_FLAGS

--- a/soc/arm/qemu_cortex_a53/mmu_regions.c
+++ b/soc/arm/qemu_cortex_a53/mmu_regions.c
@@ -6,7 +6,6 @@
  */
 #include <soc.h>
 #include <arch/arm/aarch64/arm_mmu.h>
-#include <dts_fixup.h>
 
 #define SZ_1K	1024
 


### PR DESCRIPTION
…iver

Towards cleaning up (and hopefully removing dts_fixup.h in the near
future).  We need to move the handling of different names for the irq
flag propety into the shared interrupt_controller driver and out of
dts_fixup.h.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>