### PR TITLE
kernel: centralize init of irq stacks

### DIFF
--- a/arch/arc/core/reset.S
+++ b/arch/arc/core/reset.S
@@ -152,22 +152,6 @@ _slave_core_wait:
 _master_core_startup:
 #endif
 
-#ifdef CONFIG_INIT_STACKS
-	/*
-	 * use the main stack to call memset on the interrupt stack and the
-	 * FIRQ stack when CONFIG_INIT_STACKS is enabled before switching to
-	 * one of them for the rest of the early boot
-	 */
-	mov_s sp, z_main_stack
-	add sp, sp, CONFIG_MAIN_STACK_SIZE
-
-	mov_s r0, z_interrupt_stacks
-	mov_s r1, 0xaa
-	mov_s r2, CONFIG_ISR_STACK_SIZE
-	jl memset
-
-#endif /* CONFIG_INIT_STACKS */
-
 	mov_s sp, INIT_STACK
 	add sp, sp, INIT_STACK_SIZE
 

--- a/arch/arm/core/aarch32/cortex_m/reset.S
+++ b/arch/arm/core/aarch32/cortex_m/reset.S
@@ -77,13 +77,6 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
     bl z_arm_watchdog_init
 #endif
 
-#ifdef CONFIG_INIT_STACKS
-    ldr r0, =z_interrupt_stacks
-    ldr r1, =0xaa
-    ldr r2, =CONFIG_ISR_STACK_SIZE
-    bl memset
-#endif
-
     /*
      * Set PSP and use it to boot without using MSP, so that it
      * gets set to z_interrupt_stacks during initialization.

--- a/arch/arm/core/aarch32/cortex_r/stacks.c
+++ b/arch/arm/core/aarch32/cortex_r/stacks.c
@@ -22,7 +22,5 @@ void z_arm_init_stacks(void)
 	memset(z_arm_svc_stack, 0xAA, CONFIG_ARMV7_SVC_STACK_SIZE);
 	memset(z_arm_abort_stack, 0xAA, CONFIG_ARMV7_EXCEPTION_STACK_SIZE);
 	memset(z_arm_undef_stack, 0xAA, CONFIG_ARMV7_EXCEPTION_STACK_SIZE);
-	memset(Z_THREAD_STACK_BUFFER(z_interrupt_stacks[0]), 0xAA,
-	       CONFIG_ISR_STACK_SIZE);
 }
 #endif

--- a/arch/nios2/core/crt0.S
+++ b/arch/nios2/core/crt0.S
@@ -99,26 +99,6 @@ SECTION_FUNC(TEXT, __start)
 	bgt r2, zero, 0b
 #endif /* ALT_CPU_DCACHE_SIZE && defined(CONFIG_INCLUDE_RESET_VECTOR) */
 
-#ifdef CONFIG_INIT_STACKS
-	/* Pre-populate all bytes in z_interrupt_stacks with 0xAA
-	 * init.c enforces that the z_interrupt_stacks pointer
-	 * and CONFIG_ISR_STACK_SIZE are a multiple of STACK_ALIGN (4) */
-	movhi r1, %hi(z_interrupt_stacks)
-	ori r1, r1, %lo(z_interrupt_stacks)
-	movhi r2, %hi(CONFIG_ISR_STACK_SIZE)
-	ori r2, r2, %lo(CONFIG_ISR_STACK_SIZE)
-	/* Put constant 0xaaaaaaaa in r3 */
-	movhi r3, 0xaaaa
-	ori r3, r3, 0xaaaa
-1:
-	/* Loop through the z_interrupt_stacks treating it as an array of
-	 * u32_t, setting each element to r3 */
-	stw r3, (r1)
-	subi r2, r2, 4
-	addi r1, r1, 4
-	blt r0, r2, 1b
-#endif
-
 	/* Set up the initial stack pointer to the interrupt stack, safe
 	 * to use this as the CPU boots up with interrupts disabled and we
 	 * don't turn them on until much later, when the kernel is on

--- a/arch/riscv/core/reset.S
+++ b/arch/riscv/core/reset.S
@@ -46,20 +46,6 @@ loop_slave_core:
 
 boot_master_core:
 
-#ifdef CONFIG_INIT_STACKS
-	/* Pre-populate all bytes in z_interrupt_stacks with 0xAA */
-	la t0, z_interrupt_stacks
-	li t1, CONFIG_ISR_STACK_SIZE
-	add t1, t1, t0
-
-	/* Populate z_interrupt_stacks with 0xaaaaaaaa */
-	li t2, 0xaaaaaaaa
-aa_loop:
-	sw t2, 0x00(t0)
-	addi t0, t0, 4
-	blt t0, t1, aa_loop
-#endif
-
 	/*
 	 * Initially, setup stack pointer to
 	 * z_interrupt_stacks + CONFIG_ISR_STACK_SIZE

--- a/arch/x86/core/ia32/crt0.S
+++ b/arch/x86/core/ia32/crt0.S
@@ -148,17 +148,6 @@ __csSet:
 	 * If it is a cold boot then _sys_resume_from_deep_sleep() should
 	 * not do anything and must return immediately.
 	 */
-#ifdef CONFIG_INIT_STACKS
-	movl $0xAAAAAAAA, %eax
-	leal z_interrupt_stacks, %edi
-#ifdef CONFIG_X86_STACK_PROTECTION
-	addl $4096, %edi
-#endif
-	stack_size_dwords = (CONFIG_ISR_STACK_SIZE / 4)
-	movl $stack_size_dwords, %ecx
-	rep  stosl
-#endif
-
 	movl	$z_interrupt_stacks, %esp
 #ifdef CONFIG_X86_STACK_PROTECTION
 	/* In this configuration, all stacks, including IRQ stack, are declared

--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -154,14 +154,6 @@ go64:	movl %cr4, %eax			/* enable PAE and SSE */
 	/* finally, complete environment for the C runtime and go. */
 	cld	/* GCC presumes a clear direction flag */
 
-#ifdef CONFIG_INIT_STACKS
-	movq $0xAAAAAAAAAAAAAAAA, %rax
-	movq %rsp, %rdi
-	subq $CONFIG_ISR_STACK_SIZE, %rdi
-	movq $(CONFIG_ISR_STACK_SIZE >> 3), %rcx
-	rep stosq
-#endif
-
 	/* Enter C domain now that we have a stack set up, never to return */
 	movq %rbp, %rdi
 	call z_x86_cpu_init

--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -46,11 +46,6 @@ static ALWAYS_INLINE void arch_kernel_init(void)
 	 * already is a big win.
 	 */
 	WSR(CONFIG_XTENSA_KERNEL_CPU_PTR_SR, cpu0);
-
-#ifdef CONFIG_INIT_STACKS
-	memset(Z_THREAD_STACK_BUFFER(z_interrupt_stacks[0]), 0xAA,
-	       CONFIG_ISR_STACK_SIZE);
-#endif
 }
 
 void xtensa_switch(void *switch_to, void **switched_from);

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -212,6 +212,19 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 	static const unsigned int boot_delay;
 #endif
 
+#ifdef CONFIG_INIT_STACKS
+	/* Disable local interrupts on this CPU. Other CPUs haven't been
+	 * started yet.
+	 */
+	int key = arch_irq_lock();
+
+	for (int i = 0; i < CONFIG_MP_NUM_CPUS; i++) {
+		memset(Z_THREAD_STACK_BUFFER(z_interrupt_stacks[i]), 0xAA,
+		       K_THREAD_STACK_SIZEOF(z_interrupt_stacks[i]));
+	}
+	arch_irq_unlock(key);
+#endif
+
 	z_sys_post_kernel = true;
 
 	z_sys_device_do_config_level(_SYS_INIT_LEVEL_POST_KERNEL);


### PR DESCRIPTION
This is now done as soon as we swap into the main thread
entry, since we are no longer on the IRQ stack.

This simplifies arch code, with the caveat that there is
a brief window where interrupts are delivered before
the stack is initialized, and the stack usage of these
interrupts will not be measured.

Fixes: #7598 

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>