### PR TITLE
tests: wdt_basic_api: make mec15xxevb_assy6853 build only

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -3,9 +3,14 @@ tests:
     depends_on: watchdog
     tags: drivers watchdog
     filter: not CONFIG_WDT_SAM
-    platform_exclude: nucleo_l496zg nucleo_f401re
+    platform_exclude: nucleo_l496zg nucleo_f401re mec15xxevb_assy6853
   drivers.watchdog.nucleo_l496zg:
     depends_on: watchdog
     tags: drivers watchdog
     extra_args: CONF_FILE="prj.conf;nucleo_l496zg.conf"
     platform_whitelist: nucleo_l496zg
+  drivers.watchdog.mec15xxevb_assy6853:
+    depends_on: watchdog
+    tags: drivers watchdog
+    build_only: true
+    platform_whitelist: mec15xxevb_assy6853


### PR DESCRIPTION
The bootloader on mec15xxevb_assy6853 clears the memory on reboot,
which would fail the wdt_basic_api test. Instead of simply exclude
the platform, add a build only test for this board so the watchdog
is being built to avoid build breakage.

Fixes #20301

Signed-off-by: Daniel Leung <daniel.leung@intel.com>