### PR TITLE
arch: arm: userspace: fix syscall ID validation

### DIFF
--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -411,7 +411,10 @@ _do_syscall:
     /* validate syscall limit */
     ldr ip, =K_SYSCALL_LIMIT
     cmp r6, ip
-    blt valid_syscall_id
+    /* The supplied syscall_id must be lower than the limit
+     * (Requires unsigned integer comparison)
+     */
+    blo valid_syscall_id
 
     /* bad syscall id.  Set arg1 to bad id and set call_id to SYSCALL_BAD */
     str r6, [r0, #0]


### PR DESCRIPTION
We need an unsigned comparison when evaluating whether
the supplied syscall ID is lower than the syscall ID limit.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Manually backporting #23323 to 1.14 branch.