### PR TITLE
editorconfig: Add assembly code file spec

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,11 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 max_line_length = 80
 
+# Assembly
+[*.S]
+indent_style = tab
+indent_size = 8
+
 # C
 [*.{c,h}]
 indent_style = tab


### PR DESCRIPTION
This commit adds the editorconfig spec for assembly code files (*.S).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>