### PR TITLE
Enable LOG_PRINTK Kconfig and abort thread when finish testing

### DIFF
--- a/samples/boards/mec15xxevb_assy6853/power_management/prj.conf
+++ b/samples/boards/mec15xxevb_assy6853/power_management/prj.conf
@@ -1,5 +1,6 @@
 # Enable config log
 CONFIG_LOG=y
+CONFIG_LOG_PRINTK=y
 
 # Logging thread frequency higher than CONFIG_SYS_PM_MIN_RESIDENCY_DEEP_SLEEP_1
 CONFIG_LOG_PROCESS_THREAD_SLEEP_MS=2100

--- a/samples/boards/mec15xxevb_assy6853/power_management/src/power_mgmt.c
+++ b/samples/boards/mec15xxevb_assy6853/power_management/src/power_mgmt.c
@@ -193,6 +193,9 @@ int test_pwr_mgmt_multithread(bool use_logging, u8_t cycles)
 
 	pm_reset_counters();
 
+	k_thread_abort(&threadA_id);
+	k_thread_abort(&threadB_id);
+
 	return 0;
 }
 


### PR DESCRIPTION
1. With CONFIG_KERNEL_DEBUG enabled, kernel debug message will be output
    by printk. However this sample has logging enabled also, so enable
    LOG_PRINTK to have logging system processing printk.
2. Abort thread when finish testing to keep next testing clean.

Fixes: #23274