### PR TITLE
[backport v2.2] Bluetooth: controller: split: Fix regression in handling invalid pkt seq

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -688,6 +688,7 @@ static int isr_rx_pdu(struct lll_conn *lll, struct pdu_data *pdu_data_rx,
 		if (link) {
 			struct pdu_data *pdu_data_tx;
 			u8_t pdu_data_tx_len;
+			u8_t offset;
 
 			pdu_data_tx = (void *)(tx->pdu +
 					       lll->packet_tx_head_offset);
@@ -702,9 +703,10 @@ static int isr_rx_pdu(struct lll_conn *lll, struct pdu_data *pdu_data_rx,
 			}
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
-			lll->packet_tx_head_offset += pdu_data_tx_len;
-			if (lll->packet_tx_head_offset ==
-			    lll->packet_tx_head_len) {
+			offset = lll->packet_tx_head_offset + pdu_data_tx_len;
+			if (offset < lll->packet_tx_head_len) {
+				lll->packet_tx_head_offset = offset;
+			} else if (offset == lll->packet_tx_head_len) {
 				lll->packet_tx_head_len = 0;
 				lll->packet_tx_head_offset = 0;
 


### PR DESCRIPTION
Fix regression in handling invalid packet sequence in the
first packet in a connection.

This relates to commit 62c1e1a52bcf ("Bluetooth: controller:
split: Fix assert on invalid packet sequence")

Fixes #22967.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>

--------------

Backport of #23516