### PR TITLE
soc: stm32l4: Factorize includes declarations for GPIO driver

### DIFF
--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -33,11 +33,6 @@
 #include <stm32l4xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_GPIO_STM32
-/* Required to enable VDDio2 for port G */
-#include <stm32l4xx_ll_pwr.h>
-#endif
-
 #ifdef CONFIG_SERIAL_HAS_DRIVER
 #include <stm32l4xx_ll_usart.h>
 #include <stm32l4xx_ll_lpuart.h>
@@ -84,6 +79,8 @@
 
 #ifdef CONFIG_GPIO_STM32
 #include <stm32l4xx_ll_gpio.h>
+/* Required to enable VDDio2 for port G */
+#include <stm32l4xx_ll_pwr.h>
 #endif
 
 #ifdef CONFIG_ADC_STM32


### PR DESCRIPTION
Group #include declarations for CONFIG_GPIO_STM32


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>