### PR TITLE
lib: posix: fix ARG_UNUSED check on clock_getrtc

### DIFF
--- a/lib/posix/clock.c
+++ b/lib/posix/clock.c
@@ -98,7 +98,7 @@ int gettimeofday(struct timeval *tv, const void *tz)
 
 	/* As per POSIX, "if tzp is not a null pointer, the behavior
 	 * is unspecified."  "tzp" is the "tz" parameter above. */
-	ARG_UNUSED(tv);
+	ARG_UNUSED(tz);
 
 	res = clock_gettime(CLOCK_REALTIME, &ts);
 	tv->tv_sec = ts.tv_sec;


### PR DESCRIPTION
The ARG_UNUSED should be on tz, not tv