### PR TITLE
west.yml: Update revision of TinyCBOR

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -83,10 +83,10 @@ manifest:
       revision: cf7020eb4c7ef93319f2d6d2403a21e12a879bf6
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: fab12e052437a68487b647fcfba7069801657c1b
+      revision: 1084100cf4d3c17c4e212f167e3fc0199aa898de
       path: bootloader/mcuboot
     - name: mcumgr
-      revision: dd3b98f28842ecafaa9ae9c9a3ab365cdc8ea6d5
+      revision: dcf32c7f340a10e6e6482feb311cb4fa71953fd3
       path: modules/lib/mcumgr
     - name: net-tools
       revision: 1080094bc246357c6c35e80e8b2d5d0ce7e0d963
@@ -108,7 +108,7 @@ manifest:
       path: modules/debug/segger
     - name: tinycbor
       path: modules/lib/tinycbor
-      revision: 3cb8555348358d437893d3ab8e8de4e3b916afae
+      revision: 40daca97b478989884bffb5226e9ab73ca54b8c4
     - name: tinycrypt
       path: modules/crypto/tinycrypt
       revision: 3e9a49d2672ec01435ffbf0d788db6d95ef28de0


### PR DESCRIPTION
DEPENDS ON:
~~https://github.com/zephyrproject-rtos/tinycbor/pull/13~~
~~https://github.com/apache/mynewt-mcumgr/pull/74~~
~~https://github.com/zephyrproject-rtos/mcumgr/pull/18~~
~~https://github.com/JuulLabs-OSS/mcuboot/pull/688~~


Update provides fix for TinyCBOR include paths not being added into
compilation, unless MCUMGR has also been selected.

Fixes: #23324

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

NOTE: This PR replaces https://github.com/zephyrproject-rtos/zephyr/pull/23342, from branch incorrectly pushed to zephyrproject.