### PR TITLE
Bluetooth: controller: split: correct timing calculation in PKT_US

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -600,8 +600,8 @@ u8_t ll_adv_enable(u8_t enable)
 		/* Use the default 1M packet max time. Value of 0 is
 		 * equivalent to using BIT(0).
 		 */
-		conn_lll->max_tx_time = PKT_US(PDU_DC_PAYLOAD_SIZE_MIN, 0);
-		conn_lll->max_rx_time = PKT_US(PDU_DC_PAYLOAD_SIZE_MIN, 0);
+		conn_lll->max_tx_time = PKT_US(PDU_DC_PAYLOAD_SIZE_MIN, PHY_1M);
+		conn_lll->max_rx_time = PKT_US(PDU_DC_PAYLOAD_SIZE_MIN, PHY_1M);
 #endif /* CONFIG_BT_CTLR_PHY */
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
@@ -17,6 +17,9 @@
  */
 #define PAYLOAD_OVERHEAD_SIZE (2 + 4)
 
+#define PHY_1M BIT(0)
+#define PHY_2M BIT(1)
+#define PHY_CODED BIT(2)
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
 #define CODED_PHY_PREAMBLE_TIME_US (80)
 #define CODED_PHY_ACCESS_ADDRESS_TIME_US (256)
@@ -33,23 +36,23 @@
 				     CODED_PHY_CRC_SIZE + \
 				     CODED_PHY_TERM2_SIZE) * 8)
 
-#define PKT_US(octets, phy) (((phy) & BIT(2)) ?		   \
+#define PKT_US(octets, phy) (((phy) & PHY_CODED) ?		   \
 			     (CODED_PHY_PREAMBLE_TIME_US + \
 			      FEC_BLOCK1_TIME_US + \
 			      FEC_BLOCK2_TIME_US(octets)) : \
-			     (((PREAMBLE_SIZE(1) + \
+			     (((PREAMBLE_SIZE(phy) + \
 				ACCESS_ADDR_SIZE + \
 				PAYLOAD_OVERHEAD_SIZE + \
 				(octets) + \
 				CRC_SIZE) * 8) / \
 			      BIT(((phy) & 0x03) >> 1)))
 #else /* !CONFIG_BT_CTLR_PHY_CODED */
-#define PKT_US(octets, phy) (((PREAMBLE_SIZE(1) + \
+#define PKT_US(octets, phy) ((((PREAMBLE_SIZE(phy)) +	\
 			       ACCESS_ADDR_SIZE + \
 			       PAYLOAD_OVERHEAD_SIZE + \
 			       (octets) + \
 			       CRC_SIZE) * 8) / \
-			     BIT(((phy) & 0x03) >> 1))
+			      BIT(((phy) & 0x03) >> 1))
 #endif /* !CONFIG_BT_CTLR_PHY_CODED */
 
 struct ll_conn *ll_conn_acquire(void);

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -127,8 +127,8 @@ u8_t ll_create_connection(u16_t scan_interval, u16_t scan_window,
 	conn_lll->max_rx_octets = PDU_DC_PAYLOAD_SIZE_MIN;
 
 #if defined(CONFIG_BT_CTLR_PHY)
-	conn_lll->max_tx_time = PKT_US(PDU_DC_PAYLOAD_SIZE_MIN, 0);
-	conn_lll->max_rx_time = PKT_US(PDU_DC_PAYLOAD_SIZE_MIN, 0);
+	conn_lll->max_tx_time = PKT_US(PDU_DC_PAYLOAD_SIZE_MIN, PHY_1M);
+	conn_lll->max_rx_time = PKT_US(PDU_DC_PAYLOAD_SIZE_MIN, PHY_1M);
 #endif /* CONFIG_BT_CTLR_PHY */
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 


### PR DESCRIPTION
A bug in the PKT_US resulted in wrong calculations for the 2M phy.
Fixes the bug, verified on EBQ.
Also adds some defines for improved readability.

Fixes #23482

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>