### PR TITLE
Bluetooth: controller: legacy: Correct DLE time calculations

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -66,10 +66,11 @@
 #define RADIO_PKT_TIME(octets, phy) \
 	(((phy) & BIT(2)) ? \
 	 (80 + 256 + 16 + 24 + ((((2 + (octets) + 4) * 8) + 24 + 3) * 8)) : \
-	 (((octets) + 14) * 8 / BIT(((phy) & 0x03) >> 1)))
+	 (((octets) + 13 + PREAMBLE_SIZE(phy)) * 8 / BIT(((phy) & 0x03) >> 1)))
 #else /* !CONFIG_BT_CTLR_PHY_CODED */
 #define RADIO_PKT_TIME(octets, phy) \
-	(((octets) + 14) * 8 / BIT(((phy) & 0x03) >> 1))
+	(((octets) + 13 + PREAMBLE_SIZE(phy)) * 8 / \
+	BIT(((phy) & 0x03) >> 1))
 #endif /* !CONFIG_BT_CTLR_PHY_CODED */
 
 /* Inter Frame Space */
@@ -641,7 +642,8 @@ static void common_init(void)
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	/* Initialize the DLE defaults */
 	_radio.default_tx_octets = PDU_DC_PAYLOAD_SIZE_MIN;
-	_radio.default_tx_time = RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, 0);
+	_radio.default_tx_time = RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN,
+						BIT(0));
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
 #if defined(CONFIG_BT_CTLR_PHY)
@@ -2257,8 +2259,8 @@ isr_rx_conn_pkt_ctrl_rej_dle(struct radio_pdu_node_rx *node_rx,
 		lr->max_rx_octets = conn->max_rx_octets;
 		lr->max_tx_octets = conn->max_tx_octets;
 #if !defined(CONFIG_BT_CTLR_PHY)
-		lr->max_rx_time = RADIO_PKT_TIME(conn->max_rx_octets, 0);
-		lr->max_tx_time = RADIO_PKT_TIME(conn->max_tx_octets, 0);
+		lr->max_rx_time = RADIO_PKT_TIME(conn->max_rx_octets, BIT(0));
+		lr->max_tx_time = RADIO_PKT_TIME(conn->max_tx_octets, BIT(0));
 #else /* CONFIG_BT_CTLR_PHY */
 		lr->max_rx_time = conn->max_rx_time;
 		lr->max_tx_time = conn->max_tx_time;
@@ -2414,14 +2416,15 @@ static void dle_max_time_get(struct connection *conn, u16_t *max_rx_time,
 	    1
 #endif /* !CONFIG_BT_CTLR_PHY */
 	   ) {
-		*max_rx_time = RADIO_PKT_TIME(LL_LENGTH_OCTETS_RX_MAX, 0);
+	  *max_rx_time = RADIO_PKT_TIME(LL_LENGTH_OCTETS_RX_MAX, BIT(0));
 #if defined(CONFIG_BT_CTLR_PHY)
 		*max_tx_time = MAX(MIN(RADIO_PKT_TIME(LL_LENGTH_OCTETS_RX_MAX,
-						      0),
+						      BIT(0)),
 				       conn->default_tx_time),
-				   RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, 0));
+				   RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN,
+						  BIT(0)));
 #else /* !CONFIG_BT_CTLR_PHY */
-		*max_tx_time = RADIO_PKT_TIME(conn->default_tx_octets, 0);
+		*max_tx_time = RADIO_PKT_TIME(conn->default_tx_octets, BIT(0));
 #endif /* !CONFIG_BT_CTLR_PHY */
 
 #if defined(CONFIG_BT_CTLR_PHY)
@@ -2430,11 +2433,13 @@ static void dle_max_time_get(struct connection *conn, u16_t *max_rx_time,
 		   BIT(BT_LE_FEAT_BIT_PHY_CODED)) {
 		*max_rx_time = MAX(RADIO_PKT_TIME(LL_LENGTH_OCTETS_RX_MAX,
 						  BIT(2)),
-				   RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, 0));
+				   RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN,
+						  BIT(0)));
 		*max_tx_time = MAX(MIN(RADIO_PKT_TIME(LL_LENGTH_OCTETS_RX_MAX,
 						      BIT(2)),
 				       conn->default_tx_time),
-				   RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, 0));
+				   RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN,
+						  BIT(0)));
 #endif /* CONFIG_BT_CTLR_PHY_CODED */
 
 #if defined(CONFIG_BT_CTLR_PHY_2M)
@@ -2442,11 +2447,13 @@ static void dle_max_time_get(struct connection *conn, u16_t *max_rx_time,
 		   BIT(BT_LE_FEAT_BIT_PHY_2M)) {
 		*max_rx_time = MAX(RADIO_PKT_TIME(LL_LENGTH_OCTETS_RX_MAX,
 						  BIT(1)),
-				   RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, 0));
+				   RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN,
+						  BIT(0)));
 		*max_tx_time = MAX(MIN(RADIO_PKT_TIME(LL_LENGTH_OCTETS_RX_MAX,
 						      BIT(1)),
 				       conn->default_tx_time),
-				   RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, 0));
+				   RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN,
+						  BIT(0)));
 #endif /* CONFIG_BT_CTLR_PHY_2M */
 #endif /* CONFIG_BT_CTLR_PHY */
 	}
@@ -2538,7 +2545,7 @@ static inline u8_t isr_rx_conn_pkt_ctrl_dle(struct pdu_data *pdu_data_rx,
 		 * peer max_rx_time
 		 */
 		if (lr->max_rx_time >=
-		    RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, 0)) {
+		    RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, BIT(0))) {
 			eff_tx_time = MIN(lr->max_rx_time, max_tx_time);
 
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
@@ -2553,7 +2560,7 @@ static inline u8_t isr_rx_conn_pkt_ctrl_dle(struct pdu_data *pdu_data_rx,
 		 * peer max_tx_time
 		 */
 		if (lr->max_tx_time >=
-		    RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, 0)) {
+		    RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, BIT(0))) {
 			eff_rx_time = MIN(lr->max_tx_time, max_rx_time);
 
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
@@ -2681,8 +2688,8 @@ static inline u8_t isr_rx_conn_pkt_ctrl_dle(struct pdu_data *pdu_data_rx,
 			lr->max_tx_octets = eff_tx_octets;
 
 #if !defined(CONFIG_BT_CTLR_PHY)
-			lr->max_rx_time = RADIO_PKT_TIME(eff_rx_octets, 0);
-			lr->max_tx_time = RADIO_PKT_TIME(eff_tx_octets, 0);
+			lr->max_rx_time = RADIO_PKT_TIME(eff_rx_octets, BIT(0));
+			lr->max_tx_time = RADIO_PKT_TIME(eff_tx_octets, BIT(0));
 #else /* CONFIG_BT_CTLR_PHY */
 			lr->max_rx_time = eff_rx_time;
 			lr->max_tx_time = eff_tx_time;
@@ -4930,10 +4937,10 @@ static inline void isr_close_conn(void)
 			rx_time = conn->max_rx_time;
 		}
 #else /* !CONFIG_BT_CTLR_DATA_LENGTH */
-		tx_time = MAX(RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, 0),
+		tx_time = MAX(RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, BIT(0)),
 			      RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN,
 					     conn->phy_tx));
-		rx_time = MAX(RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, 0),
+		rx_time = MAX(RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, BIT(0)),
 			      RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN,
 					     conn->phy_rx));
 #endif /* !CONFIG_BT_CTLR_DATA_LENGTH */
@@ -4941,12 +4948,12 @@ static inline void isr_close_conn(void)
 		ready_delay = (conn->role) ?
 			      radio_rx_ready_delay_get(0, 0) :
 			      radio_tx_ready_delay_get(0, 0);
-		tx_time = RADIO_PKT_TIME(conn->max_tx_octets, 0);
+		tx_time = RADIO_PKT_TIME(conn->max_tx_octets, BIT(0));
 		if (conn->evt_len_adv) {
 			rx_time = RADIO_PKT_TIME(conn->llcp_length.rx_octets,
-						 0);
+						 BIT(0));
 		} else {
-			rx_time = RADIO_PKT_TIME(conn->max_rx_octets, 0);
+			rx_time = RADIO_PKT_TIME(conn->max_rx_octets, BIT(0));
 		}
 #endif /* !CONFIG_BT_CTLR_PHY */
 
@@ -8671,8 +8678,8 @@ static inline int event_len_prep(struct connection *conn)
 		lr->max_rx_octets = conn->max_rx_octets;
 		lr->max_tx_octets = tx_octets;
 #if !defined(CONFIG_BT_CTLR_PHY)
-		lr->max_rx_time = RADIO_PKT_TIME(conn->max_rx_octets, 0);
-		lr->max_tx_time = RADIO_PKT_TIME(tx_octets, 0);
+		lr->max_rx_time = RADIO_PKT_TIME(conn->max_rx_octets, BIT(0));
+		lr->max_tx_time = RADIO_PKT_TIME(tx_octets, BIT(0));
 #else /* CONFIG_BT_CTLR_PHY */
 		lr->max_rx_time = conn->max_rx_time;
 		lr->max_tx_time = tx_time;
@@ -8899,7 +8906,8 @@ static inline void event_phy_upd_ind_prep(struct connection *conn,
 			eff_tx_time =
 				MAX(RADIO_PKT_TIME(conn->max_tx_octets,
 						   conn->phy_tx),
-				    RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, 0));
+				    RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN,
+						   BIT(0)));
 			eff_tx_time = MIN(eff_tx_time, max_tx_time);
 
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
@@ -8917,7 +8925,8 @@ static inline void event_phy_upd_ind_prep(struct connection *conn,
 			eff_rx_time =
 				MAX(RADIO_PKT_TIME(conn->max_rx_octets,
 						   conn->phy_rx),
-				    RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, 0));
+				    RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN,
+						   BIT(0)));
 			eff_rx_time = MIN(eff_rx_time, max_rx_time);
 
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
@@ -11071,9 +11080,9 @@ static void length_resp_send(struct connection *conn,
 
 #if !defined(CONFIG_BT_CTLR_PHY)
 	pdu_ctrl_tx->llctrl.length_rsp.max_rx_time =
-		RADIO_PKT_TIME(eff_rx_octets, 0);
+	  RADIO_PKT_TIME(eff_rx_octets, BIT(0));
 	pdu_ctrl_tx->llctrl.length_rsp.max_tx_time =
-		RADIO_PKT_TIME(eff_tx_octets, 0);
+	  RADIO_PKT_TIME(eff_tx_octets, BIT(0));
 #else /* CONFIG_BT_CTLR_PHY */
 	pdu_ctrl_tx->llctrl.length_rsp.max_rx_time = eff_rx_time;
 	pdu_ctrl_tx->llctrl.length_rsp.max_tx_time = eff_tx_time;
@@ -11564,9 +11573,9 @@ u32_t radio_adv_enable(u16_t interval, u8_t chan_map, u8_t filter_policy,
 #if defined(CONFIG_BT_CTLR_PHY)
 		conn->default_tx_time = _radio.default_tx_time;
 		conn->max_tx_time =
-			RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, 0);
+		  RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, BIT(0));
 		conn->max_rx_time =
-			RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, 0);
+		  RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, BIT(0));
 #endif /* CONFIG_BT_CTLR_PHY */
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
@@ -12103,8 +12112,8 @@ u32_t radio_connect_enable(u8_t adv_addr_type, u8_t *adv_addr, u16_t interval,
 
 #if defined(CONFIG_BT_CTLR_PHY)
 	conn->default_tx_time = _radio.default_tx_time;
-	conn->max_tx_time = RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, 0);
-	conn->max_rx_time = RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, 0);
+	conn->max_tx_time = RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, BIT(0));
+	conn->max_rx_time = RADIO_PKT_TIME(PDU_DC_PAYLOAD_SIZE_MIN, BIT(0));
 #endif /* CONFIG_BT_CTLR_PHY */
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 


### PR DESCRIPTION
This PR fixes #23482. The preamble size for a 2M phy was incorrect.

There is a bug in calculation of time for the DLE procedure:
the preamble size is incorrect for the 2M phy

This is for the legacy code, see PR #23557 for the split controller
Fixes #23482

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>