### PR TITLE
net: Remove leftovers for obsolete net stacks shell command

### DIFF
--- a/include/linker/common-ram.ld
+++ b/include/linker/common-ram.ld
@@ -150,16 +150,6 @@
 		__net_if_dev_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-#if defined(CONFIG_NET_SHELL)
-	SECTION_DATA_PROLOGUE(net_stack,,SUBALIGN(4))
-	{
-		__net_stack_start = .;
-		*(".net_stack.*")
-		KEEP(*(SORT_BY_NAME(".net_stack*")))
-		__net_stack_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-#endif /* CONFIG_NET_SHELL */
-
 	SECTION_DATA_PROLOGUE(net_l2_data,,SUBALIGN(4))
 	{
 		__net_l2_data_start = .;

--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -884,7 +884,6 @@ class SizeCalculator:
         "_k_pipe_area",
         "net_if",
         "net_if_dev",
-        "net_stack",
         "net_l2_data",
         "_k_queue_area",
         "_net_buf_pool_area",


### PR DESCRIPTION
The "net stacks" shell command support was just removed, but
the net_stacks linker section was left around.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>