### PR TITLE
Bluetooth: controller: split: handle latency for cancelled conn events

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Nordic Semiconductor ASA
+ * Copyright (c) 2018-2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -63,11 +63,20 @@ int lll_master_reset(void)
 void lll_master_prepare(void *param)
 {
 	struct lll_prepare_param *p = param;
+	struct lll_conn *lll = p->param;
+	u16_t elapsed;
 	int err;
 
 	err = lll_clk_on();
 	LL_ASSERT(!err || err == -EINPROGRESS);
 
+	/* Instants elapsed */
+	elapsed = p->lazy + 1;
+
+	/* Save the (latency + 1) for use in event */
+	lll->latency_prepare += elapsed;
+
+	/* Invoke common pipeline handling of prepare */
 	err = lll_prepare(lll_conn_is_abort_cb, lll_conn_abort_cb, prepare_cb,
 			  0, p);
 	LL_ASSERT(!err || err == -EINPROGRESS);
@@ -88,36 +97,27 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	u32_t remainder_us;
 	u8_t data_chan_use;
 	u32_t remainder;
-	u16_t lazy;
 
 	DEBUG_RADIO_START_M(1);
-
-	/* TODO: Do the below in ULL ?  */
-
-	lazy = prepare_param->lazy;
-
-	/* save the latency for use in event */
-	lll->latency_prepare += lazy;
-
-	/* calc current event counter value */
-	event_counter = lll->event_counter + lll->latency_prepare;
-
-	/* store the next event counter value */
-	lll->event_counter = event_counter + 1;
-
-	/* TODO: Do the above in ULL ?  */
 
 	/* Reset connection event global variables */
 	lll_conn_prepare_reset();
 
-	/* TODO: can we do something in ULL? */
-	lll->latency_event = lll->latency_prepare;
+	/* Deduce the latency */
+	lll->latency_event = lll->latency_prepare - 1;
+
+	/* Calculate the current event counter value */
+	event_counter = lll->event_counter + lll->latency_event;
+
+	/* Update event counter to next value */
+	lll->event_counter = lll->event_counter + lll->latency_prepare;
+
+	/* Reset accumulated latencies */
 	lll->latency_prepare = 0;
 
 	if (lll->data_chan_sel) {
 #if defined(CONFIG_BT_CTLR_CHAN_SEL_2)
-		data_chan_use = lll_chan_sel_2(lll->event_counter - 1,
-					       lll->data_chan_id,
+		data_chan_use = lll_chan_sel_2(event_counter, lll->data_chan_id,
 					       &lll->data_chan_map[0],
 					       lll->data_chan_count);
 #else /* !CONFIG_BT_CTLR_CHAN_SEL_2 */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Nordic Semiconductor ASA
+ * Copyright (c) 2018-2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -63,11 +63,29 @@ int lll_slave_reset(void)
 void lll_slave_prepare(void *param)
 {
 	struct lll_prepare_param *p = param;
+	struct lll_conn *lll = p->param;
+	u16_t elapsed;
 	int err;
 
 	err = lll_clk_on();
 	LL_ASSERT(!err || err == -EINPROGRESS);
 
+	/* Instants elapsed */
+	elapsed = p->lazy + 1;
+
+	/* Save the (latency + 1) for use in event */
+	lll->latency_prepare += elapsed;
+
+	/* Accumulate window widening */
+	lll->slave.window_widening_prepare_us +=
+	    lll->slave.window_widening_periodic_us * elapsed;
+	if (lll->slave.window_widening_prepare_us >
+	    lll->slave.window_widening_max_us) {
+		lll->slave.window_widening_prepare_us =
+			lll->slave.window_widening_max_us;
+	}
+
+	/* Invoke common pipeline handling of prepare */
 	err = lll_prepare(lll_conn_is_abort_cb, lll_conn_abort_cb, prepare_cb,
 			  0, p);
 	LL_ASSERT(!err || err == -EINPROGRESS);
@@ -88,47 +106,27 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	u8_t data_chan_use;
 	u32_t remainder;
 	u32_t hcto;
-	u16_t lazy;
 
 	DEBUG_RADIO_START_S(1);
-
-	/* TODO: Do the below in ULL ?  */
-
-	lazy = prepare_param->lazy;
-
-	/* Calc window widening */
-	if (lll->role) {
-		lll->slave.window_widening_prepare_us +=
-		    lll->slave.window_widening_periodic_us * (lazy + 1);
-		if (lll->slave.window_widening_prepare_us >
-		    lll->slave.window_widening_max_us) {
-			lll->slave.window_widening_prepare_us =
-				lll->slave.window_widening_max_us;
-		}
-	}
-
-	/* save the latency for use in event */
-	lll->latency_prepare += lazy;
-
-	/* calc current event counter value */
-	event_counter = lll->event_counter + lll->latency_prepare;
-
-	/* store the next event counter value */
-	lll->event_counter = event_counter + 1;
-
-	/* TODO: Do the above in ULL ?  */
 
 	/* Reset connection event global variables */
 	lll_conn_prepare_reset();
 
-	/* TODO: can we do something in ULL? */
-	lll->latency_event = lll->latency_prepare;
+	/* Deduce the latency */
+	lll->latency_event = lll->latency_prepare - 1;
+
+	/* Calculate the current event counter value */
+	event_counter = lll->event_counter + lll->latency_event;
+
+	/* Update event counter to next value */
+	lll->event_counter = lll->event_counter + lll->latency_prepare;
+
+	/* Reset accumulated latencies */
 	lll->latency_prepare = 0;
 
 	if (lll->data_chan_sel) {
 #if defined(CONFIG_BT_CTLR_CHAN_SEL_2)
-		data_chan_use = lll_chan_sel_2(lll->event_counter - 1,
-					       lll->data_chan_id,
+		data_chan_use = lll_chan_sel_2(event_counter, lll->data_chan_id,
 					       &lll->data_chan_map[0],
 					       lll->data_chan_count);
 #else /* !CONFIG_BT_CTLR_CHAN_SEL_2 */


### PR DESCRIPTION
Update implementation of master and slave LLL's to correctly
handle event counter values when latencies introduced due to
connection events cancelled by active events operating in
unreserved time space.

When an active radio event extends into unreserved time
space, and a connection event prepare is scheduled but at
the time of pre-emption timeout if the connection event is
cancelled then the event count and latencies needs to be
continiued to get acummulated.

In the current controller usecases the above scenarios does
not get exercised, the changes in this commit is needed for
future roles that can extend into unreserved time space and
would cancel a scheduled connection event.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>