### PR TITLE
boards: stm32: update board definition for new GPIO API

### DIFF
--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -72,6 +72,6 @@
 		label = "DISPLAY";
 		spi-max-frequency = <15151515>;
 		reg = <0>;
-		cmd-data-gpios = <&gpiod 13 0>;
+		cmd-data-gpios = <&gpiod 13 GPIO_ACTIVE_LOW>;
 	};
 };


### PR DESCRIPTION
Update cmd-data-gpios for SPI5 to new GPIO value
to get ili9430 display working

Signed-off-by: Wim Van Loocke <denv8029@gmail.com>