### PR TITLE
Rework Xilinx TTC driver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -210,7 +210,7 @@
 /drivers/timer/altera_avalon_timer_hal.c  @wentongwu
 /drivers/timer/riscv_machine_timer.c      @nategraff-sifive @kgugala @pgielda
 /drivers/timer/litex_timer.c              @mateusz-holenko @kgugala @pgielda
-/drivers/timer/xlnx_psttc_timer.c         @wjliang
+/drivers/timer/xlnx_psttc_timer*          @wjliang @stephanosio
 /drivers/timer/cc13x2_cc26x2_rtc_timer.c  @vanti
 /drivers/usb/                             @jfischer-phytec-iot @finikorg
 /drivers/usb/device/usb_dc_stm32.c        @ydamigos @loicpoulain

--- a/boards/arm/qemu_cortex_r5/board.cmake
+++ b/boards/arm/qemu_cortex_r5/board.cmake
@@ -9,6 +9,7 @@ set(QEMU_CPU_TYPE_${ARCH} cortex-r5)
 set(QEMU_FLAGS_${ARCH}
   -nographic
   -machine arm-generic-fdt
+  -icount shift=3,align=off,sleep=off -rtc clock=vm
   -dtb ${ZEPHYR_BASE}/boards/${ARCH}/${BOARD}/fdt-single_arch-zcu102-arm.dtb
   )
 

--- a/boards/arm/qemu_cortex_r5/qemu_cortex_r5.dts
+++ b/boards/arm/qemu_cortex_r5/qemu_cortex_r5.dts
@@ -28,5 +28,5 @@
 
 &ttc0 {
 	status = "okay";
-	clock-frequency = <100000000>;
+	clock-frequency = <12000000>;
 };

--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -239,6 +239,7 @@ config XLNX_PSTTC_TIMER
 	bool "Xilinx PS ttc timer support"
 	default y
 	depends on SOC_XILINX_ZYNQMP
+	select TICKLESS_CAPABLE
 	help
 	  This module implements a kernel device driver for the Xilinx ZynqMP
 	  platform provides the standard "system clock driver" interfaces.

--- a/drivers/timer/xlnx_psttc_timer.c
+++ b/drivers/timer/xlnx_psttc_timer.c
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <kernel.h>
 #include <drivers/timer/system_timer.h>
-#include <sys_clock.h>
-#include "irq.h"
-#include "legacy_api.h"
+
+#ifdef CONFIG_TICKLESS_KERNEL
+#warning "Tickless mode is not supported"
+#endif
 
 #define TIMER_FREQ          CONFIG_SYS_CLOCK_TICKS_PER_SEC
 
@@ -115,14 +117,6 @@ void _timer_int_handler(void *unused)
 	z_clock_announce(_sys_idle_elapsed_ticks);
 }
 
-/**
- * @brief Initialize and enable the system clock
- *
- * This routine is used to program the systick to deliver interrupts at the
- * rate specified via the 'sys_clock_us_per_tick' global variable.
- *
- * @return 0
- */
 int z_clock_driver_init(struct device *device)
 {
 	int ret;
@@ -151,6 +145,7 @@ int z_clock_driver_init(struct device *device)
 	sys_write32(0, TIMER_BASEADDR + XTTCPS_MATCH_2_OFFSET);
 	sys_write32(0, TIMER_BASEADDR + XTTCPS_IER_OFFSET);
 	sys_write32(XTTCPS_IXR_ALL_MASK, TIMER_BASEADDR + XTTCPS_ISR_OFFSET);
+
 	/* Reset counter value */
 	regval = sys_read32(TIMER_BASEADDR + XTTCPS_CNT_CNTRL_OFFSET);
 	regval |= XTTCPS_CNT_CNTRL_RST_MASK;
@@ -181,15 +176,11 @@ int z_clock_driver_init(struct device *device)
 	return 0;
 }
 
+u32_t z_clock_elapsed(void)
+{
+	return 0;
+}
 
-/**
- * @brief Read the platform's timer hardware
- *
- * This routine returns the current time in terms of timer hardware clock
- * cycles.
- *
- * @return up counter of elapsed clock cycles
- */
 u32_t z_timer_cycle_get_32(void)
 {
 	return accumulated_cycles;

--- a/drivers/timer/xlnx_psttc_timer_priv.h
+++ b/drivers/timer/xlnx_psttc_timer_priv.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2019 Stephanos Ioannidis <root@stephanos.io>
+ * Copyright (c) 2018 Xilinx, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_TIMER_XLNX_PSTTC_TIMER_PRIV_H_
+#define ZEPHYR_DRIVERS_TIMER_XLNX_PSTTC_TIMER_PRIV_H_
+
+/*
+ * Refer to the "Zynq UltraScale+ Device Technical Reference Manual" document
+ * from Xilinx for more information on this peripheral.
+ */
+
+/*
+ * Triple-timer Counter (TTC) Register Offsets
+ */
+
+/* Clock Control Register */
+#define XTTCPS_CLK_CNTRL_OFFSET     0x00000000U
+/* Counter Control Register*/
+#define XTTCPS_CNT_CNTRL_OFFSET     0x0000000CU
+/* Current Counter Value */
+#define XTTCPS_COUNT_VALUE_OFFSET   0x00000018U
+/* Interval Count Value */
+#define XTTCPS_INTERVAL_VAL_OFFSET  0x00000024U
+/* Match 1 value */
+#define XTTCPS_MATCH_0_OFFSET       0x00000030U
+/* Match 2 value */
+#define XTTCPS_MATCH_1_OFFSET       0x0000003CU
+/* Match 3 value */
+#define XTTCPS_MATCH_2_OFFSET       0x00000048U
+/* Interrupt Status Register */
+#define XTTCPS_ISR_OFFSET           0x00000054U
+/* Interrupt Enable Register */
+#define XTTCPS_IER_OFFSET           0x00000060U
+
+/*
+ * Clock Control Register Definitions
+ */
+
+/* Prescale enable */
+#define XTTCPS_CLK_CNTRL_PS_EN_MASK     0x00000001U
+/* Prescale value */
+#define XTTCPS_CLK_CNTRL_PS_VAL_MASK    0x0000001EU
+/* Prescale shift */
+#define XTTCPS_CLK_CNTRL_PS_VAL_SHIFT   1U
+/* Prescale disable */
+#define XTTCPS_CLK_CNTRL_PS_DISABLE     16U
+/* Clock source */
+#define XTTCPS_CLK_CNTRL_SRC_MASK       0x00000020U
+/* External Clock edge */
+#define XTTCPS_CLK_CNTRL_EXT_EDGE_MASK  0x00000040U
+
+/*
+ * Counter Control Register Definitions
+ */
+
+/* Disable the counter */
+#define XTTCPS_CNT_CNTRL_DIS_MASK       0x00000001U
+/* Interval mode */
+#define XTTCPS_CNT_CNTRL_INT_MASK       0x00000002U
+/* Decrement mode */
+#define XTTCPS_CNT_CNTRL_DECR_MASK      0x00000004U
+/* Match mode */
+#define XTTCPS_CNT_CNTRL_MATCH_MASK     0x00000008U
+/* Reset counter */
+#define XTTCPS_CNT_CNTRL_RST_MASK       0x00000010U
+/* Enable waveform */
+#define XTTCPS_CNT_CNTRL_EN_WAVE_MASK   0x00000020U
+/* Waveform polarity */
+#define XTTCPS_CNT_CNTRL_POL_WAVE_MASK  0x00000040U
+/* Reset value */
+#define XTTCPS_CNT_CNTRL_RESET_VALUE    0x00000021U
+
+/*
+ * Interrupt Register Definitions
+ */
+
+/* Interval Interrupt */
+#define XTTCPS_IXR_INTERVAL_MASK    0x00000001U
+/* Match 1 Interrupt */
+#define XTTCPS_IXR_MATCH_0_MASK     0x00000002U
+/* Match 2 Interrupt */
+#define XTTCPS_IXR_MATCH_1_MASK     0x00000004U
+/* Match 3 Interrupt */
+#define XTTCPS_IXR_MATCH_2_MASK     0x00000008U
+/* Counter Overflow */
+#define XTTCPS_IXR_CNT_OVR_MASK     0x00000010U
+/* All valid Interrupts */
+#define XTTCPS_IXR_ALL_MASK         0x0000001FU
+
+/*
+ * Constants
+ */
+
+/* Maximum value of interval counter */
+#define XTTC_MAX_INTERVAL_COUNT 0xFFFFFFFFU
+
+#endif /* ZEPHYR_DRIVERS_TIMER_XLNX_PSTTC_TIMER_PRIV_H_ */

--- a/dts/arm/xilinx/zynqmp.dtsi
+++ b/dts/arm/xilinx/zynqmp.dtsi
@@ -31,7 +31,7 @@
 		};
 
 		ttc0: timer@ff110000 {
-			compatible = "cdns,ttc";
+			compatible = "xlnx,ttcps";
 			status = "disabled";
 			interrupts = <GIC_SPI 36 IRQ_TYPE_LEVEL
 					IRQ_DEFAULT_PRIORITY>,
@@ -45,7 +45,7 @@
 		};
 
 		ttc1: timer@ff120000 {
-			compatible = "cdns,ttc";
+			compatible = "xlnx,ttcps";
 			status = "disabled";
 			interrupts = <GIC_SPI 39 IRQ_TYPE_LEVEL
 					IRQ_DEFAULT_PRIORITY>,
@@ -59,7 +59,7 @@
 		};
 
 		ttc2: timer@ff130000 {
-			compatible = "cdns,ttc";
+			compatible = "xlnx,ttcps";
 			status = "disabled";
 			interrupts = <GIC_SPI 42 IRQ_TYPE_LEVEL
 					IRQ_DEFAULT_PRIORITY>,
@@ -73,7 +73,7 @@
 		};
 
 		ttc3: timer@ff140000 {
-			compatible = "cdns,ttc";
+			compatible = "xlnx,ttcps";
 			status = "disabled";
 			interrupts = <GIC_SPI 45 IRQ_TYPE_LEVEL
 					IRQ_DEFAULT_PRIORITY>,

--- a/dts/bindings/timer/xlnx,ttcps.yaml
+++ b/dts/bindings/timer/xlnx,ttcps.yaml
@@ -1,6 +1,6 @@
 description: Xilinx ZynqMP PS TTC timer
 
-compatible: "cdns,ttc"
+compatible: "xlnx,ttcps"
 
 include: base.yaml
 
@@ -13,5 +13,5 @@ properties:
 
     clock-frequency:
       type: int
-      required: false
+      required: true
       description: Clock frequency information for Timer operation

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -70,7 +70,7 @@
 #elif defined(CONFIG_RV32M1_LPTMR_TIMER)
 #define TICK_IRQ DT_OPENISA_RV32M1_LPTMR_SYSTEM_LPTMR_IRQ_0
 #elif defined(CONFIG_XLNX_PSTTC_TIMER)
-#define TICK_IRQ DT_INST_0_CDNS_TTC_IRQ_0
+#define TICK_IRQ DT_INST_0_XLNX_TTCPS_IRQ_0
 #elif defined(CONFIG_CPU_CORTEX_M)
 /*
  * The Cortex-M use the SYSTICK exception for the system timer, which is

--- a/tests/kernel/context/testcase.yaml
+++ b/tests/kernel/context/testcase.yaml
@@ -2,3 +2,6 @@ tests:
   kernel.common:
     tags: kernel
     min_ram: 20
+    # FIXME: Remove `qemu_cortex_r5` exclusion once Zephyr SDK 0.11.3 is
+    #        mainlined (see #22904).
+    platform_exclude: qemu_cortex_r5


### PR DESCRIPTION
Rework Xilinx TTC driver to support tickless mode and fix the `k_busy_wait` hang issue when calling with interrupts locked.

Closes #19869 (tickless support issue)
Fixes #23541