### PR TITLE
interrupt_controller: gic: Fix GICD_ICFGR field definition names

### DIFF
--- a/drivers/interrupt_controller/intc_gic.c
+++ b/drivers/interrupt_controller/intc_gic.c
@@ -66,9 +66,9 @@ void arm_gic_irq_set_priority(
 	int_off = (irq % 16) * 2;
 
 	val = sys_read8(GICD_ICFGRn + int_grp);
-	val &= ~(GICC_ICFGR_MASK << int_off);
+	val &= ~(GICD_ICFGR_MASK << int_off);
 	if (flags & IRQ_TYPE_EDGE) {
-		val |= (GICC_ICFGR_TYPE << int_off);
+		val |= (GICD_ICFGR_TYPE << int_off);
 	}
 
 	sys_write8(val, GICD_ICFGRn + int_grp);

--- a/include/drivers/interrupt_controller/gic.h
+++ b/include/drivers/interrupt_controller/gic.h
@@ -200,9 +200,9 @@
 /* GICC_IAR */
 #define	GICC_IAR_SPURIOUS	1023
 
-/* GICC_ICFGR */
-#define GICC_ICFGR_MASK		BIT_MASK(2)
-#define GICC_ICFGR_TYPE		BIT(1)
+/* GICD_ICFGR */
+#define GICD_ICFGR_MASK		BIT_MASK(2)
+#define GICD_ICFGR_TYPE		BIT(1)
 
 #endif /* CONFIG_GIC_VER <= 2 */
 


### PR DESCRIPTION
This commit fixes the field definition names for `GICD_ICFGR`, which
were incorrectly prefixed with `GICC_`.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>