### PR TITLE
dts: stm32: Introduce linux like pinctrl DT bindings

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -7,7 +7,7 @@
 /dts-v1/;
 #include <st/l4/stm32l475Xg.dtsi>
 #include "arduino_r3_connector.dtsi"
-
+#include <dt-bindings/pinctrl/stm32l4-pins.h>
 
 / {
 	model = "STMicroelectronics B-L475E-IOT01Ax board";
@@ -49,13 +49,74 @@
 	};
 };
 
+&pinctrl {
+	usart1_pins_default: pinmux_usart1_pins {
+		pinmux = <STM32_PINMUX('A', 9, AF7)>, <STM32_PINMUX('A', 10, AF7)>;
+		bias-disable;
+	};
+
+	usart2_pins_default: pinmux_usart2_pins {
+		pinmux = <STM32_PINMUX('A', 2, AF7)>, <STM32_PINMUX('A', 3, AF7)>;
+		bias-disable;
+	};
+};
+
+&pinctrl {
+	usart1_pins_default: pinmux_usart1_pins {
+		rx {
+			pinmux = <STM32_PINMUX('A', 10, AF7)>;
+			bias-disable;
+		};
+		tx {
+			pinmux = <STM32_PINMUX('A', 9, AF7)>;
+			bias-pull-up;
+		};
+	};
+
+	usart2_pins_default: pinmux_usart2_pins {
+		rx {
+			pinmux = <STM32_PINMUX('A', 3, AF7)>;
+			bias-disable;
+		};
+		tx {
+			pinmux = <STM32_PINMUX('A', 2, AF7)>;
+			bias-pull-up;
+		};
+	};
+};
+
+&pinctrl {
+	usart1_rx_pins_default: pinmux_usart1_rx_pins {
+		pinmux = <STM32_PINMUX('A', 10, AF7)>;
+		bias-disable;
+	};
+
+	usart1_tx_pins_default: pinmux_usart1_tx_pins {
+		pinmux = <STM32_PINMUX('A', 9, AF7)>;
+		bias-pull-up;
+	};
+
+	usart2_rx_pins_default: pinmux_usart2_rx_pins {
+		pinmux = <PIN_PA3_UART2_RX>;
+		bias-disable;
+	};
+
+	usart2_tx_pins_default: pinmux_usart2_tx_pins {
+		pinmux = <PIN_PA2_UART2_TX STM32_PUSHPULL_PULLUP>;
+	};
+};
+
 &usart1 {
 	current-speed = <115200>;
+	pinctrl-0 = <&usart1_pins_default>;
+	pinctrl-names = "default";
 	status = "okay";
 };
 
 &usart2 {
 	current-speed = <115200>;
+	pinctrl-0 = <&usart2_rx_pins_default &usart2_tx_pins_default>;
+	pinctrl-names = "default";
 	status = "okay";
 };
 

--- a/dts/bindings/pinctrl/st,stm32-pinmux.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinmux.yaml
@@ -11,6 +11,50 @@ properties:
     reg:
       required: true
 
-pinmux-cells:
-  - pin
-  - function
+child-binding:
+    title: STM32 PIN configurations
+
+    description: |
+        This binding gives a base representation of the STM32 pins configration
+
+    properties:
+        pinmux:
+          required: false
+          type: int
+
+        bias-disable:
+          required: false
+          type: boolean
+
+        bias-pull-down:
+          required: false
+          type: boolean
+
+        bias-pull-up:
+          required: false
+          type: boolean
+
+        drive-push-pull:
+          required: false
+          type: boolean
+
+        drive-open-drain:
+          required: false
+          type: boolean
+
+        output-low:
+          required: false
+          type: boolean
+
+        output-high:
+          required: false
+          type: boolean
+
+        slew-rate:
+          type: int
+          default: 2
+          enum:
+          - 0
+          - 1
+          - 2
+          - 3

--- a/include/dt-bindings/pinctrl/stm32-pinctrl-common.h
+++ b/include/dt-bindings/pinctrl/stm32-pinctrl-common.h
@@ -7,6 +7,31 @@
 #ifndef ZEPHYR_STM32_PINCTRL_COMMON_H_
 #define ZEPHYR_STM32_PINCTRL_COMMON_H_
 
+/* Extracted from Linux: include/dt-bindings/pinctrl/stm32-pinfunc.h */
+/*  define PIN modes */
+#define GPIO	0x0
+#define AF0	0x1
+#define AF1	0x2
+#define AF2	0x3
+#define AF3	0x4
+#define AF4	0x5
+#define AF5	0x6
+#define AF6	0x7
+#define AF7	0x8
+#define AF8	0x9
+#define AF9	0xa
+#define AF10	0xb
+#define AF11	0xc
+#define AF12	0xd
+#define AF13	0xe
+#define AF14	0xf
+#define AF15	0x10
+#define ANALOG	0x11
+
+/* define Pins number*/
+#define PIN_NO(port, line)	(((port) - 'A') * 0x10 + (line))
+
+#define STM32_PINMUX(port, line, mode) (((PIN_NO(port, line)) << 8) | (mode))
 
 /**
  * @brief numerical IDs for IO ports

--- a/include/dt-bindings/pinctrl/stm32l4-pins.h
+++ b/include/dt-bindings/pinctrl/stm32l4-pins.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2017 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef INCLUDE_DT_BINDINGS_PINCTRL_STM32L4_PINCTRL_H_
+#define INCLUDE_DT_BINDINGS_PINCTRL_STM32L4_PINCTRL_H_
+
+#include "stm32-pinctrl.h"
+
+#define PIN_PA3_UART2_RX            STM32_PINMUX('A', 3, AF7)
+#define PIN_PA2_UART2_TX            STM32_PINMUX('A', 2, AF7)
+
+
+#endif /* INCLUDE_DT_BINDINGS_PINCTRL_STM32L4_PINCTRL_H_ */


### PR DESCRIPTION
This PR is based on #20386 and tries to showcase pinctrl implementation that is closer to the way pinctrl subsystem is implemented on Linux.

In this proposal the pinmux database is kept away from the SoC level DTS. Configuration is done fully within the board dts.

Three different examples of how pin configuration data could be encoded in `pinctrl` node are presented.