### PR TITLE
tests: arch: arm: arm_interrupt: remove side effect in assertion

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -437,7 +437,7 @@
 /subsys/usb/                              @jfischer-phytec-iot @finikorg
 /tests/                                   @nashif
 /tests/application_development/libcxx/    @pabigot
-/tests/arch/arm/                          @ioannisg
+/tests/arch/arm/                          @ioannisg @stephanosio
 /tests/boards/native_posix/               @aescolar @daor-oti
 /tests/boards/intel_s1000_crb/            @dcpleung @sathishkuttan
 /tests/bluetooth/                         @joerchan @jhedberg @Vudentz

--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -54,7 +54,7 @@ void test_arm_interrupt(void)
 {
 	/* Determine an NVIC IRQ line that is not currently in use. */
 	int i;
-	int init_flag, post_flag;
+	int init_flag, post_flag, reason;
 
 	init_flag = test_flag;
 
@@ -101,8 +101,9 @@ void test_arm_interrupt(void)
 	/* Verify that the spurious ISR has led to the fault and the
 	 * expected reason variable is reset.
 	 */
-	zassert_true(expected_reason == -1,
-		"expected_reason has not been reset\n");
+	reason = expected_reason;
+	zassert_equal(reason, -1,
+		"expected_reason has not been reset (%d)\n", reason);
 	NVIC_DisableIRQ(i);
 
 	arch_irq_connect_dynamic(i, 0 /* highest priority */,


### PR DESCRIPTION
Remove a side effect in an assertion check of the
expected reason after spurious interrupt handling.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Fixes #23582