### PR TITLE
drivers: serial: uart_pl011: Unify uart clock from DT

### DIFF
--- a/boards/arm/qemu_cortex_a53/qemu_cortex_a53.dts
+++ b/boards/arm/qemu_cortex_a53/qemu_cortex_a53.dts
@@ -22,5 +22,4 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	clock-frequency = <24000000>;
 };

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -419,14 +419,9 @@ void pl011_isr(void *arg)
 static void pl011_irq_config_func_0(struct device *dev);
 #endif
 
-#ifndef DT_INST_0_ARM_PL011_CLOCK_FREQUENCY
-#define DT_INST_0_ARM_PL011_CLOCK_FREQUENCY \
-	DT_INST_0_ARM_PL011_CLOCKS_CLOCK_FREQUENCY
-#endif
-
 static struct uart_device_config pl011_cfg_port_0 = {
 	.base = (u8_t *)DT_INST_0_ARM_PL011_BASE_ADDRESS,
-	.sys_clk_freq = DT_INST_0_ARM_PL011_CLOCK_FREQUENCY,
+	.sys_clk_freq = DT_INST_0_ARM_PL011_CLOCKS_CLOCK_FREQUENCY,
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = pl011_irq_config_func_0,
 #endif
@@ -490,14 +485,9 @@ static void pl011_irq_config_func_0(struct device *dev)
 static void pl011_irq_config_func_1(struct device *dev);
 #endif
 
-#ifndef DT_INST_1_ARM_PL011_CLOCK_FREQUENCY
-#define DT_INST_1_ARM_PL011_CLOCK_FREQUENCY \
-	DT_INST_1_ARM_PL011_CLOCKS_CLOCK_FREQUENCY
-#endif
-
 static struct uart_device_config pl011_cfg_port_1 = {
 	.base = (u8_t *)DT_INST_1_ARM_PL011_BASE_ADDRESS,
-	.sys_clk_freq = DT_INST_1_ARM_PL011_CLOCK_FREQUENCY,
+	.sys_clk_freq = DT_INST_1_ARM_PL011_CLOCKS_CLOCK_FREQUENCY,
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = pl011_irq_config_func_1,
 #endif

--- a/dts/arm/qemu-virt/qemu-virt-a53.dtsi
+++ b/dts/arm/qemu-virt/qemu-virt-a53.dtsi
@@ -29,6 +29,12 @@
 		};
 	};
 
+	uartclk: apb-pclk {
+		compatible = "fixed-clock";
+		clock-frequency = <24000000>;
+		#clock-cells = <0>;
+	};
+
 	soc {
 		interrupt-parent = <&gic>;
 
@@ -48,6 +54,7 @@
 			status = "disabled";
 			interrupts = <GIC_SPI 1 0 IRQ_TYPE_LEVEL>;
 			interrupt-names = "irq_0";
+			clocks = <&uartclk>;
 			label = "UART_0";
 		};
 


### PR DESCRIPTION
Add a fixed clock to the qemu-virt-a53.dtsi to match how the musca dts
files work so we get the clock DT info in the same way in the driver.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>