### PR TITLE
soc: arc: snps_emsk: fix typo bug in DT define

### DIFF
--- a/soc/arc/snps_emsk/soc_config.c
+++ b/soc/arc/snps_emsk/soc_config.c
@@ -18,14 +18,14 @@ static int uart_ns16550_init(struct device *dev)
 	/* On ARC EM Starter kit board,
 	 * send the UART the command to clear the interrupt
 	 */
-#ifdef DT_INST_0_NS16650
+#ifdef DT_INST_0_NS16550
 	sys_write32(0, DT_INST_0_NS16550_BASE_ADDRESS+0x4);
 	sys_write32(0, DT_INST_0_NS16550_BASE_ADDRESS+0x10);
-#endif /* DT_INST_0_NS16650 */
-#ifdef DT_INST_1_NS16650
+#endif /* DT_INST_0_NS16550 */
+#ifdef DT_INST_1_NS16550
 	sys_write32(0, DT_INST_1_NS16550_BASE_ADDRESS+0x4);
 	sys_write32(0, DT_INST_1_NS16550_BASE_ADDRESS+0x10);
-#endif /* DT_INST_1_NS16650 */
+#endif /* DT_INST_1_NS16550 */
 
 	return 0;
 }


### PR DESCRIPTION
DT_INST_{0,1}_NS16650 should be DT_INST_{0,1}_NS16550.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>