### PR TITLE
net: if: Add functions to check any pending TX or RX packets

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -469,6 +469,14 @@ struct net_if {
 
 	/** Network interface instance configuration */
 	struct net_if_config config;
+
+#if defined(CONFIG_NET_POWER_MANAGEMENT)
+	/** Keep track of packets pending in traffic queues. This is
+	 * needed to avoid putting network device driver to sleep if
+	 * there are packets waiting to be sent.
+	 */
+	int tx_pending;
+#endif
 } __net_if_align;
 
 /**
@@ -2100,6 +2108,27 @@ void net_if_unset_promisc(struct net_if *iface);
  *         False if interface is not in in promiscuous mode.
  */
 bool net_if_is_promisc(struct net_if *iface);
+
+/**
+ * @brief Check if there are any pending TX network data for a given network
+ *        interface.
+ *
+ * @param iface Pointer to network interface
+ *
+ * @return True if there are no any pending TX network packets for this network
+ *         interface.
+ *         False if there are network packets pending.
+ */
+static inline bool net_if_are_pending_tx_packets(struct net_if *iface)
+{
+#if defined(CONFIG_NET_POWER_MANAGEMENT)
+	return !!iface->tx_pending;
+#else
+	ARG_UNUSED(iface);
+
+	return false;
+#endif
+}
 
 /** @cond INTERNAL_HIDDEN */
 struct net_if_api {

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -76,7 +76,7 @@ static inline enum net_verdict net_ipv6_input(struct net_pkt *pkt,
 	return NET_CONTINUE;
 }
 #endif
-extern void net_tc_submit_to_tx_queue(u8_t tc, struct net_pkt *pkt);
+extern bool net_tc_submit_to_tx_queue(u8_t tc, struct net_pkt *pkt);
 extern void net_tc_submit_to_rx_queue(u8_t tc, struct net_pkt *pkt);
 extern enum net_verdict net_promisc_mode_input(struct net_pkt *pkt);
 

--- a/subsys/net/ip/net_tc.c
+++ b/subsys/net/ip/net_tc.c
@@ -29,9 +29,11 @@ K_THREAD_STACK_ARRAY_DEFINE(rx_stack, NET_TC_RX_COUNT,
 static struct net_traffic_class tx_classes[NET_TC_TX_COUNT];
 static struct net_traffic_class rx_classes[NET_TC_RX_COUNT];
 
-void net_tc_submit_to_tx_queue(u8_t tc, struct net_pkt *pkt)
+bool net_tc_submit_to_tx_queue(u8_t tc, struct net_pkt *pkt)
 {
 	k_work_submit_to_queue(&tx_classes[tc].work_q, net_pkt_work(pkt));
+
+	return k_work_pending(net_pkt_work(pkt));
 }
 
 void net_tc_submit_to_rx_queue(u8_t tc, struct net_pkt *pkt)


### PR DESCRIPTION
These functions can be used for example by network power management
to check if the network interface can be suspended or not.
If there are network packets in transmit queue, then the network
interface cannot be suspended yet.
The corresponding RX functions have limited use but were created
for symmetry.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>