### PR TITLE
ztest: rename zassert_ APIs

### DIFF
--- a/doc/guides/test/mocking.c
+++ b/doc/guides/test/mocking.c
@@ -21,7 +21,7 @@ static int returns_int(void)
 static void return_value_tests(void)
 {
 	ztest_returns_value(returns_int, 5);
-	zassert_equal(returns_int(), 5, NULL);
+	ztest_equal(returns_int(), 5, NULL);
 }
 
 void test_main(void)

--- a/doc/guides/test/ztest.rst
+++ b/doc/guides/test/ztest.rst
@@ -77,11 +77,11 @@ An example can be seen below::
     /**
      * @brief Test Asserts
      *
-     * This test verifies the zassert_true macro.
+     * This test verifies the ztest_true macro.
      */
     static void test_assert(void)
     {
-            zassert_true(1, "1 was false");
+            ztest_true(1, "1 was false");
     }
 
 
@@ -119,7 +119,7 @@ it needs to report either a pass or fail.  For example::
 	#ifdef CONFIG_TEST1
 	void test_test1(void)
 	{
-		zassert_true(1, "true");
+		ztest_true(1, "true");
 	}
         #else
 	void test_test1(void)
@@ -312,7 +312,7 @@ option:`CONFIG_ZTEST_ASSERT_VERBOSE` is 0, the assertions will only print the
 file and line numbers, reducing the binary size of the test.
 
 Example output for a failed macro from
-``zassert_equal(buf->ref, 2, "Invalid refcount")``:
+``ztest_equal(buf->ref, 2, "Invalid refcount")``:
 
 .. code-block:: none
 

--- a/samples/testing/integration/src/main.c
+++ b/samples/testing/integration/src/main.c
@@ -14,12 +14,12 @@
  */
 static void test_assert(void)
 {
-	zassert_true(1, "1 was false");
-	zassert_false(0, "0 was true");
-	zassert_is_null(NULL, "NULL was not NULL");
-	zassert_not_null("foo", "\"foo\" was NULL");
-	zassert_equal(1, 1, "1 was not equal to 1");
-	zassert_equal_ptr(NULL, NULL, "NULL was not equal to NULL");
+	ztest_true(1, "1 was false");
+	ztest_false(0, "0 was true");
+	ztest_is_null(NULL, "NULL was not NULL");
+	ztest_not_null("foo", "\"foo\" was NULL");
+	ztest_equal(1, 1, "1 was not equal to 1");
+	ztest_equal_ptr(NULL, NULL, "NULL was not equal to NULL");
 }
 
 void test_main(void)

--- a/subsys/testsuite/ztest/include/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/ztest_assert.h
@@ -26,7 +26,7 @@ extern "C" {
 void ztest_test_fail(void);
 #if CONFIG_ZTEST_ASSERT_VERBOSE == 0
 
-static inline void z_zassert_(bool cond, const char *file, int line)
+static inline void z_ztest_(bool cond, const char *file, int line)
 {
 	if (cond == false) {
 		PRINT("\n    Assertion failed at %s:%d\n",
@@ -35,12 +35,12 @@ static inline void z_zassert_(bool cond, const char *file, int line)
 	}
 }
 
-#define z_zassert(cond, default_msg, file, line, func, msg, ...)	\
-	z_zassert_(cond, file, line)
+#define z_ztest(cond, default_msg, file, line, func, msg, ...)	\
+	z_ztest_(cond, file, line)
 
 #else /* CONFIG_ZTEST_ASSERT_VERBOSE != 0 */
 
-static inline void z_zassert(bool cond,
+static inline void z_ztest(bool cond,
 			    const char *default_msg,
 			    const char *file,
 			    int line, const char *func,
@@ -81,22 +81,22 @@ static inline void z_zassert(bool cond,
  * @brief Fail the test, if @a cond is false
  *
  * You probably don't need to call this macro directly. You should
- * instead use zassert_{condition} macros below.
+ * instead use ztest_{condition} macros below.
  *
  * @param cond Condition to check
  * @param msg Optional, can be NULL. Message to print if @a cond is false.
  * @param default_msg Message to print if @a cond is false
  */
 
-#define zassert(cond, default_msg, msg, ...)			    \
-	z_zassert(cond, msg ? ("(" default_msg ")") : (default_msg), \
+#define ztest(cond, default_msg, msg, ...)			    \
+	z_ztest(cond, msg ? ("(" default_msg ")") : (default_msg), \
 		 __FILE__, __LINE__, __func__, msg ? msg : "", ##__VA_ARGS__)
 
 /**
  * @brief Assert that this function call won't be reached
  * @param msg Optional message to print if the assertion fails
  */
-#define zassert_unreachable(msg, ...) zassert(0, "Reached unreachable code", \
+#define ztest_unreachable(msg, ...) ztest(0, "Reached unreachable code", \
 					      msg, ##__VA_ARGS__)
 
 /**
@@ -104,7 +104,7 @@ static inline void z_zassert(bool cond,
  * @param cond Condition to check
  * @param msg Optional message to print if the assertion fails
  */
-#define zassert_true(cond, msg, ...) zassert(cond, #cond " is false", \
+#define ztest_true(cond, msg, ...) ztest(cond, #cond " is false", \
 					     msg, ##__VA_ARGS__)
 
 /**
@@ -112,7 +112,7 @@ static inline void z_zassert(bool cond,
  * @param cond Condition to check
  * @param msg Optional message to print if the assertion fails
  */
-#define zassert_false(cond, msg, ...) zassert(!(cond), #cond " is true", \
+#define ztest_false(cond, msg, ...) ztest(!(cond), #cond " is true", \
 					      msg, ##__VA_ARGS__)
 
 /**
@@ -120,7 +120,7 @@ static inline void z_zassert(bool cond,
  * @param ptr Pointer to compare
  * @param msg Optional message to print if the assertion fails
  */
-#define zassert_is_null(ptr, msg, ...) zassert((ptr) == NULL,	    \
+#define ztest_is_null(ptr, msg, ...) ztest((ptr) == NULL,	    \
 					       #ptr " is not NULL", \
 					       msg, ##__VA_ARGS__)
 
@@ -129,7 +129,7 @@ static inline void z_zassert(bool cond,
  * @param ptr Pointer to compare
  * @param msg Optional message to print if the assertion fails
  */
-#define zassert_not_null(ptr, msg, ...) zassert((ptr) != NULL,	      \
+#define ztest_not_null(ptr, msg, ...) ztest((ptr) != NULL,	      \
 						#ptr " is NULL", msg, \
 						##__VA_ARGS__)
 
@@ -142,7 +142,7 @@ static inline void z_zassert(bool cond,
  * @param b Value to compare
  * @param msg Optional message to print if the assertion fails
  */
-#define zassert_equal(a, b, msg, ...) zassert((a) == (b),	      \
+#define ztest_equal(a, b, msg, ...) ztest((a) == (b),	      \
 					      #a " not equal to " #b, \
 					      msg, ##__VA_ARGS__)
 
@@ -155,7 +155,7 @@ static inline void z_zassert(bool cond,
  * @param b Value to compare
  * @param msg Optional message to print if the assertion fails
  */
-#define zassert_not_equal(a, b, msg, ...) zassert((a) != (b),	      \
+#define ztest_not_equal(a, b, msg, ...) ztest((a) != (b),	      \
 						  #a " equal to " #b, \
 						  msg, ##__VA_ARGS__)
 
@@ -168,8 +168,8 @@ static inline void z_zassert(bool cond,
  * @param b Value to compare
  * @param msg Optional message to print if the assertion fails
  */
-#define zassert_equal_ptr(a, b, msg, ...)			    \
-	zassert((void *)(a) == (void *)(b), #a " not equal to " #b, \
+#define ztest_equal_ptr(a, b, msg, ...)			    \
+	ztest((void *)(a) == (void *)(b), #a " not equal to " #b, \
 		msg, ##__VA_ARGS__)
 
 /**
@@ -180,8 +180,8 @@ static inline void z_zassert(bool cond,
  * @param d Delta
  * @param msg Optional message to print if the assertion fails
  */
-#define zassert_within(a, b, d, msg, ...)			     \
-	zassert(((a) > ((b) - (d))) && ((a) < ((b) + (d))),	     \
+#define ztest_within(a, b, d, msg, ...)			     \
+	ztest(((a) > ((b) - (d))) && ((a) < ((b) + (d))),	     \
 		#a " not within " #b " +/- " #d,		     \
 		msg, ##__VA_ARGS__)
 
@@ -193,30 +193,46 @@ static inline void z_zassert(bool cond,
  * would expand to more than one values (ANSI-C99 defines that all the macro
  * arguments have to be expanded before macro call).
  *
- * @param ... Arguments, see @ref zassert_mem_equal__
+ * @param ... Arguments, see @ref ztest_mem_equal__
  *            for real arguments accepted.
  */
-#define zassert_mem_equal(...) \
-	zassert_mem_equal__(__VA_ARGS__)
+#define ztest_mem_equal(...) \
+	ztest_mem_equal__(__VA_ARGS__)
 
 /**
  * @brief Internal assert that 2 memory buffers have the same contents
  *
  * @note This is internal macro, to be used as a second expansion.
- *       See @ref zassert_mem_equal.
+ *       See @ref ztest_mem_equal.
  *
  * @param buf Buffer to compare
  * @param exp Buffer with expected contents
  * @param size Size of buffers
  * @param msg Optional message to print if the assertion fails
  */
-#define zassert_mem_equal__(buf, exp, size, msg, ...)                    \
-	zassert(memcmp(buf, exp, size) == 0, #buf " not equal to " #exp, \
+#define ztest_mem_equal__(buf, exp, size, msg, ...)                    \
+	ztest(memcmp(buf, exp, size) == 0, #buf " not equal to " #exp, \
 	msg, ##__VA_ARGS__)
 
 /**
  * @}
  */
+
+/*
+ * Legacy macros, do not use, remove for 2.4
+ */
+
+#define zassert_mem_equal	ztest_mem_equal		DEPRECATED_MACRO
+#define zassert_within		ztest_within		DEPRECATED_MACRO
+#define zassert_equal_ptr	ztest_equal_ptr		DEPRECATED_MACRO
+#define zassert_not_equal	ztest_not_equal		DEPRECATED_MACRO
+#define zassert_equal		ztest_equal		DEPRECATED_MACRO
+#define zassert_not_null	ztest_not_null		DEPRECATED_MACRO
+#define zassert_is_null		ztest_is_null		DEPRECATED_MACRO
+#define zassert_false		ztest_false		DEPRECATED_MACRO
+#define zassert_true		ztest_true		DEPRECATED_MACRO
+#define zassert_unreachable	ztest_unreachable	DEPRECATED_MACRO
+#define zassert			ztest			DEPRECATED_MACRO
 
 #ifdef __cplusplus
 }

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -93,7 +93,7 @@ static void cpu_hold(void *arg1, void *arg2, void *arg3)
 	 * logic views it as one "job") and cause other test failures.
 	 */
 	dt = k_uptime_get_32() - start_ms;
-	zassert_true(dt < 3000,
+	ztest_true(dt < 3000,
 		     "1cpu test took too long (%d ms)", dt);
 	arch_irq_unlock(key);
 }

--- a/tests/application_development/cpp/src/main.cpp
+++ b/tests/application_development/cpp/src/main.cpp
@@ -61,7 +61,7 @@ SYS_INIT(test_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
 static void test_new_delete(void)
 {
 	foo_class *test_foo = new foo_class(10);
-	zassert_equal(test_foo->get_foo(), 10, NULL);
+	ztest_equal(test_foo->get_foo(), 10, NULL);
 	delete test_foo;
 }
 

--- a/tests/application_development/gen_inc_file/src/main.c
+++ b/tests/application_development/gen_inc_file/src/main.c
@@ -78,10 +78,10 @@ static void test_gen_inc_file(void)
 {
 	int i;
 
-	zassert_equal(sizeof(inc_file), 256, "Invalid size file");
+	ztest_equal(sizeof(inc_file), 256, "Invalid size file");
 
 	for (i = 0; i < sizeof(inc_file); i++) {
-		zassert_equal(inc_file[i], i, "Invalid value in inc file");
+		ztest_equal(inc_file[i], i, "Invalid value in inc file");
 	}
 }
 
@@ -97,21 +97,21 @@ static void do_test_gen_gz_inc_file(const unsigned char gz_inc_file[],
 			 * the gzip header.
 			 */
 			if (mtime != NULL) { /* NULL arg = random "now" */
-				zassert_equal(gz_inc_file[i], mtime[i-4],
+				ztest_equal(gz_inc_file[i], mtime[i-4],
 					      "Invalid mtime in inc file");
 			}
 
 			continue;
 		}
 
-		zassert_equal(gz_inc_file[i], compressed_inc_file[i],
+		ztest_equal(gz_inc_file[i], compressed_inc_file[i],
 			      "Invalid value in inc file");
 	}
 }
 
 static void test_gen_gz_inc_file_no_mtime(void)
 {
-	zassert_equal(sizeof(no_mtime_gz_inc_file), sizeof(compressed_inc_file),
+	ztest_equal(sizeof(no_mtime_gz_inc_file), sizeof(compressed_inc_file),
 		      "Invalid compressed file size");
 
 	do_test_gen_gz_inc_file(no_mtime_gz_inc_file, mtime_zero);
@@ -119,7 +119,7 @@ static void test_gen_gz_inc_file_no_mtime(void)
 
 static void test_gen_gz_inc_file_mtime_arg(void)
 {
-	zassert_equal(sizeof(mtime_gz_inc_file), sizeof(compressed_inc_file),
+	ztest_equal(sizeof(mtime_gz_inc_file), sizeof(compressed_inc_file),
 		      "Invalid compressed file size");
 
 	do_test_gen_gz_inc_file(mtime_gz_inc_file, mtime_test_val);

--- a/tests/application_development/libcxx/src/main.cpp
+++ b/tests/application_development/libcxx/src/main.cpp
@@ -17,23 +17,23 @@ std::vector<int> vector;
 
 static void test_array(void)
 {
-	zassert_equal(array.size(), 4, "unexpected size");
-	zassert_equal(array[0], 1, "array[0] wrong");
-	zassert_equal(array[3], 4, "array[3] wrong");
+	ztest_equal(array.size(), 4, "unexpected size");
+	ztest_equal(array[0], 1, "array[0] wrong");
+	ztest_equal(array[3], 4, "array[3] wrong");
 
 	std::array<u8_t, 2> local = {1, 2};
-	zassert_equal(local.size(), 2, "unexpected size");
-	zassert_equal(local[0], 1, "local[0] wrong");
-	zassert_equal(local[1], 2, "local[1] wrong");
+	ztest_equal(local.size(), 2, "unexpected size");
+	ztest_equal(local[0], 1, "local[0] wrong");
+	ztest_equal(local[1], 2, "local[1] wrong");
 }
 
 static void test_vector(void)
 {
-	zassert_equal(vector.size(), 0, "vector init nonzero");
+	ztest_equal(vector.size(), 0, "vector init nonzero");
 	for (auto v : array) {
 		vector.push_back(v);
 	}
-	zassert_equal(vector.size(), array.size(), "vector store failed");
+	ztest_equal(vector.size(), array.size(), "vector store failed");
 }
 
 struct make_unique_data {
@@ -55,16 +55,16 @@ int make_unique_data::dtors;
 
 static void test_make_unique(void)
 {
-	zassert_equal(make_unique_data::ctors, 0, "ctor count not initialized");
-	zassert_equal(make_unique_data::dtors, 0, "dtor count not initialized");
+	ztest_equal(make_unique_data::ctors, 0, "ctor count not initialized");
+	ztest_equal(make_unique_data::dtors, 0, "dtor count not initialized");
 	auto d = std::make_unique<make_unique_data>();
-	zassert_true(static_cast<bool>(d), "allocation failed");
-	zassert_equal(make_unique_data::ctors, 1, "ctr update failed");
-	zassert_equal(d->inst, 1, "instance init failed");
-	zassert_equal(make_unique_data::dtors, 0, "dtor count not zero");
+	ztest_true(static_cast<bool>(d), "allocation failed");
+	ztest_equal(make_unique_data::ctors, 1, "ctr update failed");
+	ztest_equal(d->inst, 1, "instance init failed");
+	ztest_equal(make_unique_data::dtors, 0, "dtor count not zero");
 	d.reset();
-	zassert_false(d, "release failed");
-	zassert_equal(make_unique_data::dtors, 1, "dtor count not incremented");
+	ztest_false(d, "release failed");
+	ztest_equal(make_unique_data::dtors, 1, "dtor count not incremented");
 }
 
 void test_main(void)

--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -58,7 +58,7 @@ void test_arm_interrupt(void)
 
 	init_flag = test_flag;
 
-	zassert_false(init_flag, "Test flag not initialized to zero\n");
+	ztest_false(init_flag, "Test flag not initialized to zero\n");
 
 	for (i = CONFIG_NUM_IRQS - 1; i >= 0; i--) {
 		if (NVIC_GetEnableIRQ(i) == 0) {
@@ -82,7 +82,7 @@ void test_arm_interrupt(void)
 		}
 	}
 
-	zassert_true(i >= 0,
+	ztest_true(i >= 0,
 		"No available IRQ line to use in the test\n");
 
 	TC_PRINT("Available IRQ line: %u\n", i);
@@ -101,7 +101,7 @@ void test_arm_interrupt(void)
 	/* Verify that the spurious ISR has led to the fault and the
 	 * expected reason variable is reset.
 	 */
-	zassert_true(expected_reason == -1,
+	ztest_true(expected_reason == -1,
 		"expected_reason has not been reset\n");
 	NVIC_DisableIRQ(i);
 
@@ -129,7 +129,7 @@ void test_arm_interrupt(void)
 
 		/* Confirm test flag is set by the ISR handler. */
 		post_flag = test_flag;
-		zassert_true(post_flag == j, "Test flag not set by ISR\n");
+		ztest_true(post_flag == j, "Test flag not set by ISR\n");
 	}
 }
 
@@ -141,7 +141,7 @@ void z_impl_test_arm_user_interrupt_syscall(void)
 {
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
 	/* Confirm IRQs are not locked */
-	zassert_false(__get_PRIMASK(), "PRIMASK is set\n");
+	ztest_false(__get_PRIMASK(), "PRIMASK is set\n");
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 
 	static bool first_call = 1;
@@ -155,11 +155,11 @@ void z_impl_test_arm_user_interrupt_syscall(void)
 		int key = irq_lock();
 
 		/* Verify that IRQs were not already locked */
-		zassert_false(key, "IRQs locked in system call\n");
+		ztest_false(key, "IRQs locked in system call\n");
 	}
 
 	/* Confirm IRQs are still locked */
-	zassert_true(__get_BASEPRI(), "BASEPRI not set\n");
+	ztest_true(__get_BASEPRI(), "BASEPRI not set\n");
 #endif
 }
 
@@ -172,7 +172,7 @@ static inline void z_vrfy_test_arm_user_interrupt_syscall(void)
 void test_arm_user_interrupt(void)
 {
 	/* Test thread executing in user mode */
-	zassert_true(arch_is_user_context(),
+	ztest_true(arch_is_user_context(),
 		"Test thread not running in user mode\n");
 
 	/* Attempt to lock IRQs in user mode */
@@ -182,7 +182,7 @@ void test_arm_user_interrupt(void)
 	 */
 	int lock = irq_lock();
 
-	zassert_false(lock, "IRQs shown locked in user mode\n");
+	ztest_false(lock, "IRQs shown locked in user mode\n");
 
 	/* Generate a system call to manage the IRQ locking */
 	test_arm_user_interrupt_syscall();
@@ -201,7 +201,7 @@ void test_arm_user_interrupt(void)
 	test_arm_user_interrupt_syscall();
 
 	/* Verify that thread is not able to infer that IRQs are locked. */
-	zassert_false(irq_lock(), "IRQs are shown to be locked\n");
+	ztest_false(irq_lock(), "IRQs are shown to be locked\n");
 #endif
 }
 #else

--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_dynamic_direct_interrupts.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_dynamic_direct_interrupts.c
@@ -58,7 +58,7 @@ void test_arm_dynamic_direct_interrupts(void)
 
 	/* Confirm test flag is set by the dynamic direct ISR handler. */
 	post_flag = test_flag;
-	zassert_true(post_flag == 1, "Test flag not set by ISR0\n");
+	ztest_true(post_flag == 1, "Test flag not set by ISR0\n");
 
 	post_flag = 0;
 	irq_disable(DIRECT_ISR_OFFSET);
@@ -82,7 +82,7 @@ void test_arm_dynamic_direct_interrupts(void)
 
 	/* Confirm test flag is set by the dynamic direct ISR handler. */
 	post_flag = test_flag;
-	zassert_true(post_flag == 2, "Test flag not set by ISR1\n");
+	ztest_true(post_flag == 2, "Test flag not set by ISR1\n");
 }
 /**
  * @}

--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_zero_latency_irqs.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_zero_latency_irqs.c
@@ -27,7 +27,7 @@ void test_arm_zero_latency_irqs(void)
 
 	init_flag = test_flag;
 
-	zassert_false(init_flag, "Test flag not initialized to zero\n");
+	ztest_false(init_flag, "Test flag not initialized to zero\n");
 
 	for (i = CONFIG_NUM_IRQS - 1; i >= 0; i--) {
 		if (NVIC_GetEnableIRQ(i) == 0) {
@@ -51,7 +51,7 @@ void test_arm_zero_latency_irqs(void)
 		}
 	}
 
-	zassert_true(i >= 0,
+	ztest_true(i >= 0,
 		"No available IRQ line to configure as zero-latency\n");
 
 	TC_PRINT("Available IRQ line: %u\n", i);
@@ -81,7 +81,7 @@ void test_arm_zero_latency_irqs(void)
 
 	/* Confirm test flag is set by the zero-latency ISR handler. */
 	post_flag = test_flag;
-	zassert_true(post_flag == 1, "Test flag not set by ISR\n");
+	ztest_true(post_flag == 1, "Test flag not set by ISR\n");
 
 	irq_unlock(key);
 }

--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -150,7 +150,7 @@ void test_arm_irq_vector_table(void)
 		k_sem_init(&sem[ii], 0, UINT_MAX);
 	}
 
-	zassert_true((k_sem_take(&sem[0], K_NO_WAIT) ||
+	ztest_true((k_sem_take(&sem[0], K_NO_WAIT) ||
 		      k_sem_take(&sem[1], K_NO_WAIT) ||
 		      k_sem_take(&sem[2], K_NO_WAIT)), NULL);
 
@@ -166,7 +166,7 @@ void test_arm_irq_vector_table(void)
 #endif
 	}
 
-	zassert_false((k_sem_take(&sem[0], K_NO_WAIT) ||
+	ztest_false((k_sem_take(&sem[0], K_NO_WAIT) ||
 		       k_sem_take(&sem[1], K_NO_WAIT) ||
 		       k_sem_take(&sem[2], K_NO_WAIT)), NULL);
 

--- a/tests/arch/arm/arm_ramfunc/src/arm_ramfunc.c
+++ b/tests/arch/arm/arm_ramfunc/src/arm_ramfunc.c
@@ -20,18 +20,18 @@ void test_arm_ramfunc(void)
 	int init_flag, post_flag;
 
 	init_flag = test_flag;
-	zassert_true(init_flag == 0, "Test flag not initialized to zero");
+	ztest_true(init_flag == 0, "Test flag not initialized to zero");
 
 	/* Verify that the .ramfunc section is not empty, it is located
 	 * inside SRAM, and that arm_ram_function(.) is located inside
 	 * the .ramfunc section.
 	 */
-	zassert_true((u32_t)&_ramfunc_ram_size != 0,
+	ztest_true((u32_t)&_ramfunc_ram_size != 0,
 		".ramfunc linker section is empty");
-	zassert_true(((u32_t)&_ramfunc_ram_start >= (u32_t)&_image_ram_start)
+	ztest_true(((u32_t)&_ramfunc_ram_start >= (u32_t)&_image_ram_start)
 			&& ((u32_t)&_ramfunc_ram_end < (u32_t)&_image_ram_end),
 			".ramfunc linker section not in RAM");
-	zassert_true(
+	ztest_true(
 		(((u32_t)&_ramfunc_ram_start) <= (u32_t)arm_ram_function) &&
 		(((u32_t)&_ramfunc_ram_end) > (u32_t)arm_ram_function),
 		"arm_ram_function not loaded into .ramfunc");
@@ -40,7 +40,7 @@ void test_arm_ramfunc(void)
 	 * arm_ram_function(.) is user (read) accessible.
 	 */
 #if defined(CONFIG_USERSPACE)
-	zassert_true(arch_buffer_validate((void *)&_ramfunc_ram_start,
+	ztest_true(arch_buffer_validate((void *)&_ramfunc_ram_start,
 			(size_t)&_ramfunc_ram_size, 0) == 0 /* Success */,
 		".ramfunc section not user accessible");
 #endif /* CONFIG_USERSPACE */
@@ -50,7 +50,7 @@ void test_arm_ramfunc(void)
 
 	/* Verify that the function is executed successfully. */
 	post_flag = test_flag;
-	zassert_true(post_flag == 1,
+	ztest_true(post_flag == 1,
 		"arm_ram_function() execution failed.");
 }
 /**

--- a/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
@@ -40,22 +40,22 @@ void z_impl_test_arm_user_syscall(void)
 	 * - PSPLIM register guards the privileged stack
 	 * - MSPLIM register still guards the interrupt stack
 	 */
-	zassert_true((_current->arch.mode & CONTROL_nPRIV_Msk) == 0,
+	ztest_true((_current->arch.mode & CONTROL_nPRIV_Msk) == 0,
 	"mode variable not set to PRIV mode in system call\n");
 
-	zassert_false(arch_is_user_context(),
+	ztest_false(arch_is_user_context(),
 	"arch_is_user_context() indicates nPRIV\n");
 
-	zassert_true(
+	ztest_true(
 		((__get_PSP() >= _current->arch.priv_stack_start) &&
 		(__get_PSP() < (_current->arch.priv_stack_start +
 			CONFIG_PRIVILEGED_STACK_SIZE))),
 	"Process SP outside thread privileged stack limits\n");
 
 #if defined(CONFIG_BUILTIN_STACK_GUARD)
-	zassert_true(__get_PSPLIM() == _current->arch.priv_stack_start,
+	ztest_true(__get_PSPLIM() == _current->arch.priv_stack_start,
 	"PSPLIM not guarding the thread's privileged stack\n");
-	zassert_true(__get_MSPLIM() == (u32_t)z_interrupt_stacks,
+	ztest_true(__get_MSPLIM() == (u32_t)z_interrupt_stacks,
 	"MSPLIM not guarding the interrupt stack\n");
 #endif
 }
@@ -78,13 +78,13 @@ void arm_isr_handler(void *args)
 	 * - MSPLIM register still guards the interrupt stack
 	 */
 
-	zassert_true((_current->arch.mode & CONTROL_nPRIV_Msk) != 0,
+	ztest_true((_current->arch.mode & CONTROL_nPRIV_Msk) != 0,
 	"mode variable not set to nPRIV mode for user thread\n");
 
-	zassert_false(arch_is_user_context(),
+	ztest_false(arch_is_user_context(),
 	"arch_is_user_context() indicates nPRIV in ISR\n");
 
-	zassert_true(
+	ztest_true(
 		((__get_PSP() >= _current->stack_info.start) &&
 		(__get_PSP() < (_current->stack_info.start +
 			_current->stack_info.size))),
@@ -106,9 +106,9 @@ void arm_isr_handler(void *args)
 		/* Second ISR run occurs after thread context-switch.
 		 * We expect PSPLIM to be clear at this point.
 		 */
-		zassert_true(__get_PSPLIM() == 0,
+		ztest_true(__get_PSPLIM() == 0,
 		"PSPLIM not clear\n");
-		zassert_true(__get_MSPLIM() == (u32_t)z_interrupt_stacks,
+		ztest_true(__get_MSPLIM() == (u32_t)z_interrupt_stacks,
 		"MSPLIM not guarding the interrupt stack\n");
 #endif
 	}
@@ -161,22 +161,22 @@ void test_arm_syscalls(void)
 	 * - MSPLIM register guards the interrupt stack
 	 */
 
-	zassert_true((_current->arch.mode & CONTROL_nPRIV_Msk) == 0,
+	ztest_true((_current->arch.mode & CONTROL_nPRIV_Msk) == 0,
 	"mode variable not set to PRIV mode for supervisor thread\n");
 
-	zassert_false(arch_is_user_context(),
+	ztest_false(arch_is_user_context(),
 	"arch_is_user_context() indicates nPRIV\n");
 
-	zassert_true(
+	ztest_true(
 		((__get_PSP() >= _current->stack_info.start) &&
 		(__get_PSP() < (_current->stack_info.start +
 			_current->stack_info.size))),
 	"Process SP outside thread stack limits\n");
 
 #if defined(CONFIG_BUILTIN_STACK_GUARD)
-	zassert_true(__get_PSPLIM() == _current->stack_info.start,
+	ztest_true(__get_PSPLIM() == _current->stack_info.start,
 	"PSPLIM not guarding the default stack\n");
-	zassert_true(__get_MSPLIM() == (u32_t)z_interrupt_stacks,
+	ztest_true(__get_MSPLIM() == (u32_t)z_interrupt_stacks,
 	"MSPLIM not guarding the interrupt stack\n");
 #endif
 
@@ -203,7 +203,7 @@ void test_arm_syscalls(void)
 		}
 	}
 
-	zassert_true(i >= 0,
+	ztest_true(i >= 0,
 		 "No available IRQ line to use in the test\n");
 
 	TC_PRINT("Available IRQ line: %u\n", i);

--- a/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
@@ -81,7 +81,7 @@ static void verify_callee_saved(const _callee_saved_t *src,
 		const _callee_saved_t *dst)
 {
 	/* Verify callee-saved registers are as expected */
-	zassert_true((src->v1 == dst->v1)
+	ztest_true((src->v1 == dst->v1)
 			&& (src->v2 == dst->v2)
 			&& (src->v3 == dst->v3)
 			&& (src->v4 == dst->v4)
@@ -139,7 +139,7 @@ static void verify_fp_callee_saved(const struct _preempt_float *src,
 		const struct _preempt_float *dst)
 {
 	/* Verify FP callee-saved registers are as expected */
-	zassert_true((src->s16 == dst->s16)
+	ztest_true((src->s16 == dst->s16)
 			&& (src->s17 == dst->s17)
 			&& (src->s18 == dst->s18)
 			&& (src->s19 == dst->s19)
@@ -205,24 +205,24 @@ static void alt_thread_entry(void)
 	(void)irq_lock();
 
 	init_flag = switch_flag;
-	zassert_true(init_flag == false,
+	ztest_true(init_flag == false,
 		"Alternative thread: switch flag not false on thread entry\n");
 
 	/* Set switch flag */
 	switch_flag = true;
 
 #if defined(CONFIG_NO_OPTIMIZATIONS)
-	zassert_true(p_ztest_thread->arch.basepri == 0,
+	ztest_true(p_ztest_thread->arch.basepri == 0,
 		"ztest thread basepri not preserved in swap-out\n");
 #else
 	/* Verify that the main test thread has the correct value
 	 * for state variable thread.arch.basepri (set before swap).
 	 */
-	zassert_true(p_ztest_thread->arch.basepri == BASEPRI_MODIFIED_1,
+	ztest_true(p_ztest_thread->arch.basepri == BASEPRI_MODIFIED_1,
 		"ztest thread basepri not preserved in swap-out\n");
 
 	/* Verify original swap return value (set by arch_swap() */
-	zassert_true(p_ztest_thread->arch.swap_return_value == -EAGAIN,
+	ztest_true(p_ztest_thread->arch.swap_return_value == -EAGAIN,
 		"ztest thread swap-return-value not preserved in swap-out\n");
 #endif
 
@@ -242,15 +242,15 @@ static void alt_thread_entry(void)
 #if defined(CONFIG_FLOAT) && defined(CONFIG_FP_SHARING)
 
 	/*  Verify that the _current_ (alt) thread is initialized with FPCA cleared. */
-	zassert_true((__get_CONTROL() & CONTROL_FPCA_Msk) == 0,
+	ztest_true((__get_CONTROL() & CONTROL_FPCA_Msk) == 0,
 		"CONTROL.FPCA is not cleared at initialization: 0x%x\n",
 		__get_CONTROL());
 
 	/* Verify that the _current_ (alt) thread is initialized with FPSCR cleared. */
-	zassert_true(__get_FPSCR() == 0,
+	ztest_true(__get_FPSCR() == 0,
 		"(Alt thread) FPSCR is not cleared at initialization: 0x%x\n", __get_FPSCR());
 
-	zassert_true((p_ztest_thread->arch.mode & CONTROL_FPCA_Msk) != 0,
+	ztest_true((p_ztest_thread->arch.mode & CONTROL_FPCA_Msk) != 0,
 		"ztest thread mode FPCA flag not updated at swap-out: 0x%0x\n",
 		p_ztest_thread->arch.mode);
 
@@ -328,7 +328,7 @@ static void alt_thread_entry(void)
 	 * it when it is swapped-back in.
 	 */
 	post_flag = switch_flag;
-	zassert_true(post_flag == false,
+	ztest_true(post_flag == false,
 		"Alternative thread: switch flag not false on thread exit\n");
 }
 
@@ -362,45 +362,45 @@ void test_arm_thread_swap(void)
 
 	/* Confirm initial conditions before starting the test. */
 	test_flag = switch_flag;
-	zassert_true(test_flag == false,
+	ztest_true(test_flag == false,
 		"Switch flag not initialized properly\n");
-	zassert_true(_current->arch.basepri == 0,
+	ztest_true(_current->arch.basepri == 0,
 		"Thread BASEPRI flag not clear at thread start\n");
 	/* Verify, also, that the interrupts are unlocked. */
 #if defined(CONFIG_CPU_CORTEX_M_HAS_BASEPRI)
-	zassert_true(__get_BASEPRI() == 0,
+	ztest_true(__get_BASEPRI() == 0,
 		"initial BASEPRI not zero\n");
 #else
 	/* For Cortex-M Baseline architecture, we verify that
 	 * the interrupt lock is disabled.
 	 */
-	 zassert_true(__get_PRIMASK() == 0,
+	 ztest_true(__get_PRIMASK() == 0,
 	 "initial PRIMASK not zero\n");
 #endif /* CONFIG_CPU_CORTEX_M_HAS_BASEPRI */
 
 #if defined(CONFIG_USERSPACE)
 	/* The main test thread is set to run in privilege mode */
-	zassert_false((arch_is_user_context()),
+	ztest_false((arch_is_user_context()),
 		"Main test thread does not start in privilege mode\n");
 
 	/* Assert that the mode status variable indicates privilege mode */
-	zassert_true((_current->arch.mode & CONTROL_nPRIV_Msk) == 0,
+	ztest_true((_current->arch.mode & CONTROL_nPRIV_Msk) == 0,
 		"Thread nPRIV flag not clear for supervisor thread: 0x%0x\n",
 		_current->arch.mode);
 #endif /* CONFIG_USERSPACE */
 
 #if defined(CONFIG_FLOAT) && defined(CONFIG_FP_SHARING)
 	/* The main test thread is not (yet) actively using the FP registers */
-	zassert_true((_current->arch.mode & CONTROL_FPCA_Msk) == 0,
+	ztest_true((_current->arch.mode & CONTROL_FPCA_Msk) == 0,
 		"Thread FPCA flag not clear at initialization 0x%0x\n",
 		_current->arch.mode);
 
 	/* Verify that the main test thread is initialized with FPCA cleared. */
-	zassert_true((__get_CONTROL() & CONTROL_FPCA_Msk) == 0,
+	ztest_true((__get_CONTROL() & CONTROL_FPCA_Msk) == 0,
 		"CONTROL.FPCA is not cleared at initialization: 0x%x\n",
 		__get_CONTROL());
 	/* Verify that the main test thread is initialized with FPSCR cleared. */
-	zassert_true(__get_FPSCR() == 0,
+	ztest_true(__get_FPSCR() == 0,
 		"FPSCR is not cleared at initialization: 0x%x\n", __get_FPSCR());
 
 	/* Clear the thread's floating-point callee-saved registers' container.
@@ -413,14 +413,14 @@ void test_arm_thread_swap(void)
 	load_fp_callee_saved_regs(&ztest_thread_fp_callee_saved_regs);
 
 	/* Modify bit-0 of the FPSCR - will be checked again upon swap-in. */
-	zassert_true((__get_FPSCR() & 0x1) == 0,
+	ztest_true((__get_FPSCR() & 0x1) == 0,
 		"FPSCR bit-0 has been set before testing it\n");
 	__set_FPSCR(__get_FPSCR() | 0x1);
 
 	/* The main test thread is using the FP registers, but the .mode
 	 * flag is not updated until the next context switch.
 	 */
-	zassert_true((_current->arch.mode & CONTROL_FPCA_Msk) == 0,
+	ztest_true((_current->arch.mode & CONTROL_FPCA_Msk) == 0,
 		"Thread FPCA flag not clear at initialization\n");
 #endif /* CONFIG_FLOAT && CONFIG_FP_SHARING */
 
@@ -435,7 +435,7 @@ void test_arm_thread_swap(void)
 
 	/* Verify context-switch has not occurred. */
 	test_flag = switch_flag;
-	zassert_true(test_flag == false,
+	ztest_true(test_flag == false,
 		"Switch flag incremented when it should not have\n");
 
 	/* Prepare to force a context switch to the alternative thread,
@@ -456,7 +456,7 @@ void test_arm_thread_swap(void)
 
 	/* Verify context-switch has not occurred yet. */
 	test_flag = switch_flag;
-	zassert_true(test_flag == false,
+	ztest_true(test_flag == false,
 		"Switch flag incremented by unexpected context-switch.\n");
 
 	/* Store the callee-saved registers to some global memory
@@ -570,7 +570,7 @@ void test_arm_thread_swap(void)
 
 	/* Verify context-switch did occur. */
 	test_flag = switch_flag;
-	zassert_true(test_flag == true,
+	ztest_true(test_flag == true,
 		"Switch flag not incremented as expected %u\n",
 		switch_flag);
 	/* Clear the switch flag to signal that the main test thread
@@ -582,31 +582,31 @@ void test_arm_thread_swap(void)
 	 * the alternative thread modified it, since the thread
 	 * is now switched back in.
 	 */
-	zassert_true(_current->arch.basepri == 0,
+	ztest_true(_current->arch.basepri == 0,
 		"arch.basepri value not in accordance with the update\n");
 
 #if defined(CONFIG_CPU_CORTEX_M_HAS_BASEPRI)
 	/* Verify that the BASEPRI register is updated during the last
 	 * swap-in of the thread.
 	 */
-	zassert_true(__get_BASEPRI() == BASEPRI_MODIFIED_2,
+	ztest_true(__get_BASEPRI() == BASEPRI_MODIFIED_2,
 		"BASEPRI not in accordance with the update: 0x%0x\n",
 		__get_BASEPRI());
 #else
 	/* For Cortex-M Baseline architecture, we verify that
 	 * the interrupt lock is enabled.
 	 */
-	 zassert_true(__get_PRIMASK() != 0,
+	 ztest_true(__get_PRIMASK() != 0,
 	 "PRIMASK not in accordance with the update: 0x%0x\n",
 	 __get_PRIMASK());
 #endif /* CONFIG_CPU_CORTEX_M_HAS_BASEPRI */
 
 #if !defined(CONFIG_NO_OPTIMIZATIONS)
 	/* The thread is now swapped-back in. */
-	zassert_equal(_current->arch.swap_return_value, SWAP_RETVAL,
+	ztest_equal(_current->arch.swap_return_value, SWAP_RETVAL,
 		"Swap value not set as expected: 0x%x (0x%x)\n",
 		_current->arch.swap_return_value, SWAP_RETVAL);
-	zassert_equal(_current->arch.swap_return_value, ztest_swap_return_val,
+	ztest_equal(_current->arch.swap_return_value, ztest_swap_return_val,
 		"Swap value not returned as expected 0x%x (0x%x)\n",
 		_current->arch.swap_return_value, ztest_swap_return_val);
 #endif
@@ -629,7 +629,7 @@ void test_arm_thread_swap(void)
 		&_current->arch.preempt_float);
 
 	/* Verify that the main test thread restored the FPSCR bit-0. */
-	zassert_true((__get_FPSCR() & 0x1) == 0x1,
+	ztest_true((__get_FPSCR() & 0x1) == 0x1,
 		"FPSCR bit-0 not restored at swap: 0x%x\n", __get_FPSCR());
 
 #endif /* CONFIG_FLOAT && CONFIG_FP_SHARING */

--- a/tests/arch/x86/boot_page_table/src/boot_page_table.c
+++ b/tests/arch/x86/boot_page_table/src/boot_page_table.c
@@ -42,7 +42,7 @@ static void starting_addr_range(u32_t start_addr_range)
 	     addr_range += 0x1000) {
 		value = *z_x86_get_pte(&z_x86_kernel_ptables, addr_range);
 		status &= check_param(value, REGION_PERM);
-		zassert_false((status == 0U), "error at %d permissions %d\n",
+		ztest_false((status == 0U), "error at %d permissions %d\n",
 			      addr_range, REGION_PERM);
 	}
 }
@@ -58,7 +58,7 @@ static void before_start_addr_range(u32_t start_addr_range)
 		value = *z_x86_get_pte(&z_x86_kernel_ptables, addr_range);
 		status &= check_param_nonset_region(value, REGION_PERM);
 
-		zassert_false((status == 0U), "error at %d permissions %d\n",
+		ztest_false((status == 0U), "error at %d permissions %d\n",
 			      addr_range, REGION_PERM);
 	}
 }
@@ -73,7 +73,7 @@ static void ending_start_addr_range(u32_t start_addr_range)
 	     addr_range += 0x1000) {
 		value = *z_x86_get_pte(&z_x86_kernel_ptables, addr_range);
 		status &= check_param_nonset_region(value, REGION_PERM);
-		zassert_false((status == 0U), "error at %d permissions %d\n",
+		ztest_false((status == 0U), "error at %d permissions %d\n",
 			      addr_range, REGION_PERM);
 	}
 }

--- a/tests/arch/x86/static_idt/src/main.c
+++ b/tests/arch/x86/static_idt/src/main.c
@@ -119,7 +119,7 @@ void test_idt_stub(void)
 	p_idt_entry = (struct segment_descriptor *)
 		      (_idt_base_address + (TEST_SOFT_INT << 3));
 	offset = (u32_t)(&int_stub);
-	zassert_equal(DTE_OFFSET(p_idt_entry), offset,
+	ztest_equal(DTE_OFFSET(p_idt_entry), offset,
 		      "Failed to find offset of int_stub (0x%x)"
 		      " at vector %d\n", offset, TEST_SOFT_INT);
 
@@ -127,7 +127,7 @@ void test_idt_stub(void)
 	p_idt_entry = (struct segment_descriptor *)
 		      (_idt_base_address + (IV_DIVIDE_ERROR << 3));
 	offset = (u32_t)(&_EXCEPTION_STUB_NAME(exc_divide_error_handler, 0));
-	zassert_equal(DTE_OFFSET(p_idt_entry), offset,
+	ztest_equal(DTE_OFFSET(p_idt_entry), offset,
 		      "Failed to find offset of exc stub (0x%x)"
 		      " at vector %d\n", offset, IV_DIVIDE_ERROR);
 
@@ -164,9 +164,9 @@ void test_static_idt(void)
 	TC_PRINT("Testing to see interrupt handler executes properly\n");
 	_trigger_isr_handler();
 
-	zassert_not_equal(int_handler_executed, 0,
+	ztest_not_equal(int_handler_executed, 0,
 			  "Interrupt handler did not execute");
-	zassert_equal(int_handler_executed, 1,
+	ztest_equal(int_handler_executed, 1,
 		      "Interrupt handler executed more than once! (%d)\n",
 		      int_handler_executed);
 
@@ -179,9 +179,9 @@ void test_static_idt(void)
 	error = 32;     /* avoid static checker uninitialized warnings */
 	error = error / exc_handler_executed;
 
-	zassert_not_equal(exc_handler_executed, 0,
+	ztest_not_equal(exc_handler_executed, 0,
 			  "Exception handler did not execute");
-	zassert_equal(exc_handler_executed, 1,
+	ztest_equal(exc_handler_executed, 1,
 		      "Exception handler executed more than once! (%d)\n",
 		      exc_handler_executed);
 	/*
@@ -196,7 +196,7 @@ void test_static_idt(void)
 	 * The thread should not run past where the spurious interrupt is
 	 * generated. Therefore spur_handler_aborted_thread should remain at 1.
 	 */
-	zassert_not_equal(spur_handler_aborted_thread, 0,
+	ztest_not_equal(spur_handler_aborted_thread, 0,
 			  "Spurious handler did not execute as expected");
 }
 

--- a/tests/arch/x86/x86_mmu_api/src/userbuffer_validate.c
+++ b/tests/arch/x86/x86_mmu_api/src/userbuffer_validate.c
@@ -443,7 +443,7 @@ void reset_multi_pde_flag(void)
  */
 void test_multi_pde_buffer_readable_write(void)
 {
-	zassert_true(multi_pde_buffer_readable_write() == TC_PASS, NULL);
+	ztest_true(multi_pde_buffer_readable_write() == TC_PASS, NULL);
 }
 
 /**
@@ -455,7 +455,7 @@ void test_multi_pde_buffer_readable_write(void)
  */
 void test_multi_pde_buffer_readable_read(void)
 {
-	zassert_true(multi_pde_buffer_readable_read() == TC_PASS, NULL);
+	ztest_true(multi_pde_buffer_readable_read() == TC_PASS, NULL);
 }
 
 /**
@@ -467,7 +467,7 @@ void test_multi_pde_buffer_readable_read(void)
  */
 void test_multi_pde_buffer_writeable_write(void)
 {
-	zassert_true(multi_pde_buffer_writeable_write() == TC_PASS, NULL);
+	ztest_true(multi_pde_buffer_writeable_write() == TC_PASS, NULL);
 }
 
 /**
@@ -479,7 +479,7 @@ void test_multi_pde_buffer_writeable_write(void)
  */
 void test_multi_pde_buffer_rw(void)
 {
-	zassert_true(multi_pde_buffer_rw() == TC_PASS, NULL);
+	ztest_true(multi_pde_buffer_rw() == TC_PASS, NULL);
 }
 
 /**
@@ -491,7 +491,7 @@ void test_multi_pde_buffer_rw(void)
  */
 void test_buffer_rw_read(void)
 {
-	zassert_true(buffer_rw_read() == TC_PASS, NULL);
+	ztest_true(buffer_rw_read() == TC_PASS, NULL);
 }
 
 /**
@@ -503,7 +503,7 @@ void test_buffer_rw_read(void)
  */
 void test_buffer_writeable_write(void)
 {
-	zassert_true(buffer_writeable_write() == TC_PASS, NULL);
+	ztest_true(buffer_writeable_write() == TC_PASS, NULL);
 }
 
 /**
@@ -515,7 +515,7 @@ void test_buffer_writeable_write(void)
  */
 void test_buffer_readable_read(void)
 {
-	zassert_true(buffer_readable_read() == TC_PASS, NULL);
+	ztest_true(buffer_readable_read() == TC_PASS, NULL);
 }
 
 /**
@@ -527,7 +527,7 @@ void test_buffer_readable_read(void)
  */
 void test_buffer_readable_write(void)
 {
-	zassert_true(buffer_readable_write() == TC_PASS, NULL);
+	ztest_true(buffer_readable_write() == TC_PASS, NULL);
 }
 
 /**
@@ -539,7 +539,7 @@ void test_buffer_readable_write(void)
  */
 void test_buffer_supervisor_rw(void)
 {
-	zassert_true(buffer_supervisor_rw() == TC_PASS, NULL);
+	ztest_true(buffer_supervisor_rw() == TC_PASS, NULL);
 }
 
 /**
@@ -551,7 +551,7 @@ void test_buffer_supervisor_rw(void)
  */
 void test_buffer_supervisor_w(void)
 {
-	zassert_true(buffer_supervisor_w() == TC_PASS, NULL);
+	ztest_true(buffer_supervisor_w() == TC_PASS, NULL);
 }
 
 /**
@@ -563,7 +563,7 @@ void test_buffer_supervisor_w(void)
  */
 void test_buffer_user_rw_user(void)
 {
-	zassert_true(buffer_user_rw_user() == TC_PASS, NULL);
+	ztest_true(buffer_user_rw_user() == TC_PASS, NULL);
 }
 
 /**
@@ -575,7 +575,7 @@ void test_buffer_user_rw_user(void)
  */
 void test_buffer_user_rw_supervisor(void)
 {
-	zassert_true(buffer_user_rw_supervisor() == TC_PASS, NULL);
+	ztest_true(buffer_user_rw_supervisor() == TC_PASS, NULL);
 }
 
 /**
@@ -587,7 +587,7 @@ void test_buffer_user_rw_supervisor(void)
  */
 void test_multi_page_buffer_user(void)
 {
-	zassert_true(multi_page_buffer_user() == TC_PASS, NULL);
+	ztest_true(multi_page_buffer_user() == TC_PASS, NULL);
 }
 
 /**
@@ -599,7 +599,7 @@ void test_multi_page_buffer_user(void)
  */
 void test_multi_page_buffer_write_user(void)
 {
-	zassert_true(multi_page_buffer_write_user() == TC_PASS, NULL);
+	ztest_true(multi_page_buffer_write_user() == TC_PASS, NULL);
 }
 
 /**
@@ -611,7 +611,7 @@ void test_multi_page_buffer_write_user(void)
  */
 void test_multi_page_buffer_read_user(void)
 {
-	zassert_true(multi_page_buffer_read_user() == TC_PASS, NULL);
+	ztest_true(multi_page_buffer_read_user() == TC_PASS, NULL);
 }
 
 /**
@@ -623,5 +623,5 @@ void test_multi_page_buffer_read_user(void)
  */
 void test_multi_page_buffer_read(void)
 {
-	zassert_true(multi_page_buffer_read() == TC_PASS, NULL);
+	ztest_true(multi_page_buffer_read() == TC_PASS, NULL);
 }

--- a/tests/bluetooth/at/src/main.c
+++ b/tests/bluetooth/at/src/main.c
@@ -25,9 +25,9 @@ int at_handle(struct at_client *hf_at)
 {
 	u32_t val;
 
-	zassert_equal(at_get_number(hf_at, &val), 0, "Error getting value");
+	ztest_equal(at_get_number(hf_at, &val), 0, "Error getting value");
 
-	zassert_equal(val, 999, "Invalid value parsed");
+	ztest_equal(val, 999, "Invalid value parsed");
 
 	return 0;
 }
@@ -38,7 +38,7 @@ int at_resp(struct at_client *hf_at, struct net_buf *buf)
 
 	err = at_parse_cmd_input(hf_at, buf, "ABCD", at_handle,
 				 AT_CMD_TYPE_NORMAL);
-	zassert_equal(err, 0, "Error parsing CMD input");
+	ztest_equal(err, 0, "Error parsing CMD input");
 
 	return 0;
 }
@@ -53,17 +53,17 @@ static void at_test1(void)
 	at.buf = buffer;
 
 	buf = net_buf_alloc(&at_pool, K_FOREVER);
-	zassert_not_null(buf, "Failed to get buffer");
+	ztest_not_null(buf, "Failed to get buffer");
 
 	at_register(&at, at_resp, NULL);
 	len = strlen(example_data);
 
-	zassert_true(net_buf_tailroom(buf) >= len,
+	ztest_true(net_buf_tailroom(buf) >= len,
 		    "Allocated buffer is too small");
 	strncpy((char *)buf->data, example_data, len);
 	net_buf_add(buf, len);
 
-	zassert_equal(at_parse_input(&at, buf), 0, "Parsing failed");
+	ztest_equal(at_parse_input(&at, buf), 0, "Parsing failed");
 }
 
 void test_main(void)

--- a/tests/bluetooth/bluetooth/src/bluetooth.c
+++ b/tests/bluetooth/bluetooth/src/bluetooth.c
@@ -46,7 +46,7 @@ void test_bluetooth_entry(void)
 {
 	driver_init();
 
-	zassert_true((bt_enable(NULL) == EXPECTED_ERROR),
+	ztest_true((bt_enable(NULL) == EXPECTED_ERROR),
 			"bt_enable failed");
 }
 

--- a/tests/bluetooth/ctrl_sw_privacy/src/main.c
+++ b/tests/bluetooth/ctrl_sw_privacy/src/main.c
@@ -15,7 +15,7 @@
 
 void test_ctrl_sw_privacy(void)
 {
-	zassert_false(bt_enable(NULL), "%s failed", __func__);
+	ztest_false(bt_enable(NULL), "%s failed", __func__);
 }
 
 /* test case main entry */

--- a/tests/bluetooth/ctrl_sw_privacy_unit/src/main.c
+++ b/tests/bluetooth/ctrl_sw_privacy_unit/src/main.c
@@ -29,9 +29,9 @@
 
 void helper_privacy_clear(void)
 {
-	zassert_equal(newest_prpa, 0, "");
+	ztest_equal(newest_prpa, 0, "");
 	for (u8_t i = 0; i < CONFIG_BT_CTLR_RPA_CACHE_SIZE; i++) {
-		zassert_equal(prpa_cache[i].taken, 0U, "");
+		ztest_equal(prpa_cache[i].taken, 0U, "");
 	}
 }
 
@@ -49,33 +49,33 @@ void helper_privacy_add(int skew)
 	prpa_cache_add(&a1);
 	pos = prpa_cache_find(&a1);
 	ex_pos = (1 + skew) % CONFIG_BT_CTLR_RPA_CACHE_SIZE;
-	zassert_equal(pos, ex_pos, "");
+	ztest_equal(pos, ex_pos, "");
 
 	prpa_cache_add(&a2);
 	pos = prpa_cache_find(&a2);
 	ex_pos = (2 + skew) % CONFIG_BT_CTLR_RPA_CACHE_SIZE;
-	zassert_equal(pos, ex_pos, "");
+	ztest_equal(pos, ex_pos, "");
 
 	prpa_cache_add(&a3);
 	pos = prpa_cache_find(&a3);
 	ex_pos = (3 + skew) % CONFIG_BT_CTLR_RPA_CACHE_SIZE;
-	zassert_equal(pos, ex_pos, "");
+	ztest_equal(pos, ex_pos, "");
 
 	/* Adding this should cause wrap around */
 	prpa_cache_add(&a4);
 	pos = prpa_cache_find(&a4);
 	ex_pos = (4 + skew) % CONFIG_BT_CTLR_RPA_CACHE_SIZE;
-	zassert_equal(pos, ex_pos, "");
+	ztest_equal(pos, ex_pos, "");
 
 	/* adding this should cause a1 to be dropped */
 	prpa_cache_add(&a5);
 	pos = prpa_cache_find(&a5);
 	ex_pos = (1 + skew) % CONFIG_BT_CTLR_RPA_CACHE_SIZE;
-	zassert_equal(pos, ex_pos, "");
+	ztest_equal(pos, ex_pos, "");
 
 	/* check that a1 can no loger be found */
 	pos = prpa_cache_find(&a1);
-	zassert_equal(pos, FILTER_IDX_NONE, "");
+	ztest_equal(pos, FILTER_IDX_NONE, "");
 }
 
 void test_privacy_clear(void)

--- a/tests/bluetooth/ctrl_user_ext/src/main.c
+++ b/tests/bluetooth/ctrl_user_ext/src/main.c
@@ -15,7 +15,7 @@
 
 void test_ctrl_user_ext(void)
 {
-	zassert_false(bt_enable(NULL), "Bluetooth ctrl_user_ext failed");
+	ztest_false(bt_enable(NULL), "Bluetooth ctrl_user_ext failed");
 }
 
 /*test case main entry*/

--- a/tests/bluetooth/gatt/src/main.c
+++ b/tests/bluetooth/gatt/src/main.c
@@ -92,47 +92,47 @@ static struct bt_gatt_service test1_svc = BT_GATT_SERVICE(test1_attrs);
 void test_gatt_register(void)
 {
 	/* Attempt to register services */
-	zassert_false(bt_gatt_service_register(&test_svc),
+	ztest_false(bt_gatt_service_register(&test_svc),
 		     "Test service registration failed");
-	zassert_false(bt_gatt_service_register(&test1_svc),
+	ztest_false(bt_gatt_service_register(&test1_svc),
 		     "Test service1 registration failed");
 
 	/* Attempt to register already registered services */
-	zassert_true(bt_gatt_service_register(&test_svc),
+	ztest_true(bt_gatt_service_register(&test_svc),
 		     "Test service duplicate succeeded");
-	zassert_true(bt_gatt_service_register(&test1_svc),
+	ztest_true(bt_gatt_service_register(&test1_svc),
 		     "Test service1 duplicate succeeded");
 }
 
 void test_gatt_unregister(void)
 {
 	/* Attempt to unregister last */
-	zassert_false(bt_gatt_service_unregister(&test1_svc),
+	ztest_false(bt_gatt_service_unregister(&test1_svc),
 		     "Test service1 unregister failed");
-	zassert_false(bt_gatt_service_register(&test1_svc),
+	ztest_false(bt_gatt_service_register(&test1_svc),
 		     "Test service1 re-registration failed");
 
 	/* Attempt to unregister first/middle */
-	zassert_false(bt_gatt_service_unregister(&test_svc),
+	ztest_false(bt_gatt_service_unregister(&test_svc),
 		     "Test service unregister failed");
-	zassert_false(bt_gatt_service_register(&test_svc),
+	ztest_false(bt_gatt_service_register(&test_svc),
 		     "Test service re-registration failed");
 
 	/* Attempt to unregister all reverse order */
-	zassert_false(bt_gatt_service_unregister(&test1_svc),
+	ztest_false(bt_gatt_service_unregister(&test1_svc),
 		     "Test service1 unregister failed");
-	zassert_false(bt_gatt_service_unregister(&test_svc),
+	ztest_false(bt_gatt_service_unregister(&test_svc),
 		     "Test service unregister failed");
 
-	zassert_false(bt_gatt_service_register(&test_svc),
+	ztest_false(bt_gatt_service_register(&test_svc),
 		     "Test service registration failed");
-	zassert_false(bt_gatt_service_register(&test1_svc),
+	ztest_false(bt_gatt_service_register(&test1_svc),
 		     "Test service1 registration failed");
 
 	/* Attempt to unregister all same order */
-	zassert_false(bt_gatt_service_unregister(&test_svc),
+	ztest_false(bt_gatt_service_unregister(&test_svc),
 		     "Test service1 unregister failed");
-	zassert_false(bt_gatt_service_unregister(&test1_svc),
+	ztest_false(bt_gatt_service_unregister(&test1_svc),
 		     "Test service unregister failed");
 }
 
@@ -160,29 +160,29 @@ void test_gatt_foreach(void)
 	u16_t num = 0;
 
 	/* Attempt to register services */
-	zassert_false(bt_gatt_service_register(&test_svc),
+	ztest_false(bt_gatt_service_register(&test_svc),
 		     "Test service registration failed");
-	zassert_false(bt_gatt_service_register(&test1_svc),
+	ztest_false(bt_gatt_service_register(&test1_svc),
 		     "Test service1 registration failed");
 
 	/* Iterate attributes */
 	bt_gatt_foreach_attr(test_attrs[0].handle, 0xffff, count_attr, &num);
-	zassert_equal(num, 7, "Number of attributes don't match");
+	ztest_equal(num, 7, "Number of attributes don't match");
 
 	/* Iterate 1 attribute */
 	num = 0;
 	bt_gatt_foreach_attr_type(test_attrs[0].handle, 0xffff, NULL, NULL, 1,
 				  count_attr, &num);
-	zassert_equal(num, 1, "Number of attributes don't match");
+	ztest_equal(num, 1, "Number of attributes don't match");
 
 	/* Find attribute by UUID */
 	attr = NULL;
 	bt_gatt_foreach_attr_type(test_attrs[0].handle, 0xffff,
 				  &test_chrc_uuid.uuid, NULL, 0, find_attr,
 				  &attr);
-	zassert_not_null(attr, "Attribute don't match");
+	ztest_not_null(attr, "Attribute don't match");
 	if (attr) {
-		zassert_equal(attr->uuid, &test_chrc_uuid.uuid,
+		ztest_equal(attr->uuid, &test_chrc_uuid.uuid,
 			      "Attribute UUID don't match");
 	}
 
@@ -190,9 +190,9 @@ void test_gatt_foreach(void)
 	attr = NULL;
 	bt_gatt_foreach_attr_type(test_attrs[0].handle, 0xffff, NULL,
 				  test_value, 0, find_attr, &attr);
-	zassert_not_null(attr, "Attribute don't match");
+	ztest_not_null(attr, "Attribute don't match");
 	if (attr) {
-		zassert_equal(attr->user_data, test_value,
+		ztest_equal(attr->user_data, test_value,
 			      "Attribute value don't match");
 	}
 
@@ -200,24 +200,24 @@ void test_gatt_foreach(void)
 	num = 0;
 	bt_gatt_foreach_attr_type(test_attrs[0].handle, 0xffff,
 				  BT_UUID_GATT_CHRC, NULL, 0, count_attr, &num);
-	zassert_equal(num, 2, "Number of attributes don't match");
+	ztest_equal(num, 2, "Number of attributes don't match");
 
 	/* Find 1 characteristic */
 	attr = NULL;
 	bt_gatt_foreach_attr_type(test_attrs[0].handle, 0xffff,
 				  BT_UUID_GATT_CHRC, NULL, 1, find_attr, &attr);
-	zassert_not_null(attr, "Attribute don't match");
+	ztest_not_null(attr, "Attribute don't match");
 
 	/* Find attribute by UUID and DATA */
 	attr = NULL;
 	bt_gatt_foreach_attr_type(test_attrs[0].handle, 0xffff,
 				  &test1_nfy_uuid.uuid, &nfy_enabled, 1,
 				  find_attr, &attr);
-	zassert_not_null(attr, "Attribute don't match");
+	ztest_not_null(attr, "Attribute don't match");
 	if (attr) {
-		zassert_equal(attr->uuid, &test1_nfy_uuid.uuid,
+		ztest_equal(attr->uuid, &test1_nfy_uuid.uuid,
 			      "Attribute UUID don't match");
-		zassert_equal(attr->user_data, &nfy_enabled,
+		ztest_equal(attr->user_data, &nfy_enabled,
 			      "Attribute value don't match");
 	}
 }
@@ -233,14 +233,14 @@ void test_gatt_read(void)
 	bt_gatt_foreach_attr_type(test_attrs[0].handle, 0xffff,
 				  &test_chrc_uuid.uuid, NULL, 0, find_attr,
 				  &attr);
-	zassert_not_null(attr, "Attribute don't match");
-	zassert_equal(attr->uuid, &test_chrc_uuid.uuid,
+	ztest_not_null(attr, "Attribute don't match");
+	ztest_equal(attr->uuid, &test_chrc_uuid.uuid,
 			      "Attribute UUID don't match");
 
 	ret = attr->read(NULL, attr, (void *)buf, sizeof(buf), 0);
-	zassert_equal(ret, strlen(test_value),
+	ztest_equal(ret, strlen(test_value),
 		      "Attribute read unexpected return");
-	zassert_mem_equal(buf, test_value, ret,
+	ztest_mem_equal(buf, test_value, ret,
 			  "Attribute read value don't match");
 }
 
@@ -255,11 +255,11 @@ void test_gatt_write(void)
 	bt_gatt_foreach_attr_type(test_attrs[0].handle, 0xffff,
 				  &test_chrc_uuid.uuid, NULL, 0, find_attr,
 				  &attr);
-	zassert_not_null(attr, "Attribute don't match");
+	ztest_not_null(attr, "Attribute don't match");
 
 	ret = attr->write(NULL, attr, (void *)value, strlen(value), 0, 0);
-	zassert_equal(ret, strlen(value), "Attribute write unexpected return");
-	zassert_mem_equal(value, test_value, ret,
+	ztest_equal(ret, strlen(value), "Attribute write unexpected return");
+	ztest_mem_equal(value, test_value, ret,
 			  "Attribute write value don't match");
 }
 

--- a/tests/bluetooth/hci_prop_evt/src/main.c
+++ b/tests/bluetooth/hci_prop_evt/src/main.c
@@ -212,7 +212,7 @@ static int driver_open(void)
 /*  HCI driver send.  */
 static int driver_send(struct net_buf *buf)
 {
-	zassert_true(cmd_handle(buf, cmds, ARRAY_SIZE(cmds)) == 0,
+	ztest_true(cmd_handle(buf, cmds, ARRAY_SIZE(cmds)) == 0,
 		     "Unknown HCI command");
 
 	net_buf_unref(buf);
@@ -300,7 +300,7 @@ static bool prop_cb(struct net_buf_simple *buf)
 
 		/* Allocate memory for storing the data */
 		prop_cb_data = k_malloc(data_len);
-		zassert_not_null(prop_cb_data, "Cannot allocate memory");
+		ztest_not_null(prop_cb_data, "Cannot allocate memory");
 
 		/* Copy data so it can be verified later */
 		memcpy(prop_cb_data, data, data_len);
@@ -350,7 +350,7 @@ static void test_hci_prop_evt_entry(void)
 	bt_hci_driver_register(&drv);
 
 	/* Go! Wait until Bluetooth initialization is done  */
-	zassert_true((bt_enable(NULL) == 0),
+	ztest_true((bt_enable(NULL) == 0),
 		     "bt_enable failed");
 
 	/* Register the prop callback */
@@ -364,15 +364,15 @@ static void test_hci_prop_evt_entry(void)
 	send_prop_report(&data[0], data_len);
 
 	/* Wait for the prop callback to be called */
-	zassert_true(k_sem_take(&prop_cb_sem, K_MSEC(100)) == 0,
+	ztest_true(k_sem_take(&prop_cb_sem, K_MSEC(100)) == 0,
 		     "prop_cb was not called within timeout");
 
 	/* Verify the data length */
-	zassert_true(prop_cb_data_len == data_len,
+	ztest_true(prop_cb_data_len == data_len,
 		     "prop_cb_data_len invalid");
 
 	/* Verify the data itself */
-	zassert_true(memcmp(prop_cb_data, data, data_len) == 0,
+	ztest_true(memcmp(prop_cb_data, data, data_len) == 0,
 		     "prop_cb_data invalid");
 
 	/* Free the data memory */

--- a/tests/bluetooth/init/src/main.c
+++ b/tests/bluetooth/init/src/main.c
@@ -15,7 +15,7 @@
 
 void test_init(void)
 {
-	zassert_false(bt_enable(NULL), "Bluetooth init failed");
+	ztest_false(bt_enable(NULL), "Bluetooth init failed");
 }
 
 /*test case main entry*/

--- a/tests/bluetooth/l2cap/src/main.c
+++ b/tests/bluetooth/l2cap/src/main.c
@@ -41,31 +41,31 @@ static struct bt_l2cap_server test_inv_server = {
 void test_l2cap_register(void)
 {
 	/* Attempt to register server with PSM auto allocation */
-	zassert_false(bt_l2cap_server_register(&test_server),
+	ztest_false(bt_l2cap_server_register(&test_server),
 		     "Test server registration failed");
 
 	/* Attempt to register server with fixed PSM */
-	zassert_false(bt_l2cap_server_register(&test_fixed_server),
+	ztest_false(bt_l2cap_server_register(&test_fixed_server),
 		     "Test fixed PSM server registration failed");
 
 	/* Attempt to register server with dynamic PSM */
-	zassert_false(bt_l2cap_server_register(&test_dyn_server),
+	ztest_false(bt_l2cap_server_register(&test_dyn_server),
 		     "Test dynamic PSM server registration failed");
 
 	/* Attempt to register server with invalid PSM */
-	zassert_true(bt_l2cap_server_register(&test_inv_server),
+	ztest_true(bt_l2cap_server_register(&test_inv_server),
 		     "Test invalid PSM server registration succeeded");
 
 	/* Attempt to re-register server with PSM auto allocation */
-	zassert_true(bt_l2cap_server_register(&test_server),
+	ztest_true(bt_l2cap_server_register(&test_server),
 		     "Test server duplicate succeeded");
 
 	/* Attempt to re-register server with fixed PSM */
-	zassert_true(bt_l2cap_server_register(&test_fixed_server),
+	ztest_true(bt_l2cap_server_register(&test_fixed_server),
 		     "Test fixed PSM server duplicate succeeded");
 
 	/* Attempt to re-register server with dynamic PSM */
-	zassert_true(bt_l2cap_server_register(&test_dyn_server),
+	ztest_true(bt_l2cap_server_register(&test_dyn_server),
 		     "Test dynamic PSM server duplicate succeeded");
 }
 

--- a/tests/bluetooth/ll_settings/src/main.c
+++ b/tests/bluetooth/ll_settings/src/main.c
@@ -21,14 +21,14 @@ void test_company_id(void)
 
 	cid = 0x1234;
 	err = settings_runtime_set("bt/ctlr/company", &cid, sizeof(cid));
-	zassert_equal(err, 0, "Setting Company Id failed");
-	zassert_equal(ll_settings_company_id(), cid,
+	ztest_equal(err, 0, "Setting Company Id failed");
+	ztest_equal(ll_settings_company_id(), cid,
 		      "Company Id does not match");
 
 	cid = 0x5678;
 	err = settings_runtime_set("bt/ctlr/company", &cid, sizeof(cid));
-	zassert_equal(err, 0, "Changing Company Id failed");
-	zassert_equal(ll_settings_company_id(), cid,
+	ztest_equal(err, 0, "Changing Company Id failed");
+	ztest_equal(ll_settings_company_id(), cid,
 		      "Company ID does not match");
 }
 
@@ -38,12 +38,12 @@ void test_subversion_number(void)
 
 	svn = 0x1234;
 	settings_runtime_set("bt/ctlr/subver", &svn, sizeof(svn));
-	zassert_equal(ll_settings_subversion_number(), svn,
+	ztest_equal(ll_settings_subversion_number(), svn,
 		      "Subversion number does not match");
 
 	svn = 0x5678;
 	settings_runtime_set("bt/ctlr/subver", &svn, sizeof(svn));
-	zassert_equal(ll_settings_subversion_number(), svn,
+	ztest_equal(ll_settings_subversion_number(), svn,
 		      "Subversion number does not match");
 }
 

--- a/tests/bluetooth/uuid/src/main.c
+++ b/tests/bluetooth/uuid/src/main.c
@@ -25,23 +25,23 @@ static struct bt_uuid_128 le_128 = BT_UUID_INIT_128(
 static void test_uuid_cmp(void)
 {
 	/* Compare UUID 16 bits */
-	zassert_false(bt_uuid_cmp(&uuid_16.uuid, BT_UUID_DECLARE_16(0xffff)),
+	ztest_false(bt_uuid_cmp(&uuid_16.uuid, BT_UUID_DECLARE_16(0xffff)),
 		     "Test UUIDs don't match");
 
 	/* Compare UUID 128 bits */
-	zassert_false(bt_uuid_cmp(&uuid_128.uuid, BT_UUID_DECLARE_16(0xffff)),
+	ztest_false(bt_uuid_cmp(&uuid_128.uuid, BT_UUID_DECLARE_16(0xffff)),
 		     "Test UUIDs don't match");
 
 	/* Compare UUID 16 bits with UUID 128 bits */
-	zassert_false(bt_uuid_cmp(&uuid_16.uuid, &uuid_128.uuid),
+	ztest_false(bt_uuid_cmp(&uuid_16.uuid, &uuid_128.uuid),
 		     "Test UUIDs don't match");
 
 	/* Compare different UUID 16 bits */
-	zassert_true(bt_uuid_cmp(&uuid_16.uuid, BT_UUID_DECLARE_16(0x0000)),
+	ztest_true(bt_uuid_cmp(&uuid_16.uuid, BT_UUID_DECLARE_16(0x0000)),
 		     "Test UUIDs match");
 
 	/* Compare different UUID 128 bits */
-	zassert_true(bt_uuid_cmp(&uuid_128.uuid, BT_UUID_DECLARE_16(0x000)),
+	ztest_true(bt_uuid_cmp(&uuid_128.uuid, BT_UUID_DECLARE_16(0x000)),
 		     "Test UUIDs match");
 }
 
@@ -56,35 +56,35 @@ static void test_uuid_create(void)
 	} u;
 
 	/* Create UUID from LE 16 bit byte array */
-	zassert_true(bt_uuid_create(&u.uuid, le16, sizeof(le16)),
+	ztest_true(bt_uuid_create(&u.uuid, le16, sizeof(le16)),
 		     "Unable create UUID");
 
 	/* Compare UUID 16 bits */
-	zassert_true(bt_uuid_cmp(&u.uuid, BT_UUID_DECLARE_16(0x0001)) == 0,
+	ztest_true(bt_uuid_cmp(&u.uuid, BT_UUID_DECLARE_16(0x0001)) == 0,
 		     "Test UUIDs don't match");
 
 	/* Compare UUID 128 bits */
-	zassert_true(bt_uuid_cmp(&u.uuid, &le_128.uuid) == 0,
+	ztest_true(bt_uuid_cmp(&u.uuid, &le_128.uuid) == 0,
 		     "Test UUIDs don't match");
 
 	/* Compare swapped UUID 16 bits */
-	zassert_false(bt_uuid_cmp(&u.uuid, BT_UUID_DECLARE_16(0x0100)) == 0,
+	ztest_false(bt_uuid_cmp(&u.uuid, BT_UUID_DECLARE_16(0x0100)) == 0,
 		     "Test UUIDs match");
 
 	/* Create UUID from BE 16 bit byte array */
-	zassert_true(bt_uuid_create(&u.uuid, be16, sizeof(be16)),
+	ztest_true(bt_uuid_create(&u.uuid, be16, sizeof(be16)),
 		     "Unable create UUID");
 
 	/* Compare UUID 16 bits */
-	zassert_false(bt_uuid_cmp(&u.uuid, BT_UUID_DECLARE_16(0x0001)) == 0,
+	ztest_false(bt_uuid_cmp(&u.uuid, BT_UUID_DECLARE_16(0x0001)) == 0,
 		     "Test UUIDs match");
 
 	/* Compare UUID 128 bits */
-	zassert_false(bt_uuid_cmp(&u.uuid, &le_128.uuid) == 0,
+	ztest_false(bt_uuid_cmp(&u.uuid, &le_128.uuid) == 0,
 		     "Test UUIDs match");
 
 	/* Compare swapped UUID 16 bits */
-	zassert_true(bt_uuid_cmp(&u.uuid, BT_UUID_DECLARE_16(0x0100)) == 0,
+	ztest_true(bt_uuid_cmp(&u.uuid, BT_UUID_DECLARE_16(0x0100)) == 0,
 		     "Test UUIDs don't match");
 }
 

--- a/tests/boards/altera_max10/i2c_master/src/i2c_master.c
+++ b/tests/boards/altera_max10/i2c_master/src/i2c_master.c
@@ -81,7 +81,7 @@ static int test_i2c_adv7513(void)
 	}
 
 	/* Power up ADV7513 */
-	zassert_true(powerup_adv7513(i2c_dev) == TC_PASS,
+	ztest_true(powerup_adv7513(i2c_dev) == TC_PASS,
 					"ADV7513 power up failed");
 
 	TC_PRINT("*** Running i2c read/write tests ***\n");
@@ -123,7 +123,7 @@ static int test_i2c_adv7513(void)
 
 void test_i2c_master(void)
 {
-	zassert_true(test_i2c_adv7513() == TC_PASS, NULL);
+	ztest_true(test_i2c_adv7513() == TC_PASS, NULL);
 }
 
 void test_main(void)

--- a/tests/boards/altera_max10/msgdma/src/dma.c
+++ b/tests/boards/altera_max10/msgdma/src/dma.c
@@ -44,7 +44,7 @@ void test_msgdma(void)
 	int i;
 
 	dma = device_get_binding(CONFIG_DMA_0_NAME);
-	zassert_true(dma != NULL, "DMA_0 device not found!!");
+	ztest_true(dma != NULL, "DMA_0 device not found!!");
 
 	/* Init tx buffer */
 	for (i = 0; i < DMA_BUFF_SIZE; i++) {
@@ -73,14 +73,14 @@ void test_msgdma(void)
 	dma_block_cfg.dest_address = (u32_t)rx_data;
 
 	/* Configure DMA */
-	zassert_true(dma_config(dma, chan_id, &dma_cfg) == 0,
+	ztest_true(dma_config(dma, chan_id, &dma_cfg) == 0,
 						"DMA config error");
 
 	/* Make sure all the data is written out to memory */
 	z_nios2_dcache_flush_all();
 
 	/* Start DMA operation */
-	zassert_true(dma_start(dma, chan_id) == 0, "DMA start error");
+	ztest_true(dma_start(dma, chan_id) == 0, "DMA start error");
 
 	while (dma_stat == DMA_OP_STAT_NONE) {
 		k_busy_wait(10);
@@ -89,10 +89,10 @@ void test_msgdma(void)
 	/* Invalidate the data cache */
 	z_nios2_dcache_flush_no_writeback(rx_data, DMA_BUFF_SIZE);
 
-	zassert_true(dma_stat == DMA_OP_STAT_SUCCESS,
+	ztest_true(dma_stat == DMA_OP_STAT_SUCCESS,
 			"Nios-II DMA operation failed!!");
 
-	zassert_true(!memcmp(&tx_data, &rx_data, DMA_BUFF_SIZE),
+	ztest_true(!memcmp(&tx_data, &rx_data, DMA_BUFF_SIZE),
 					"Nios-II DMA Test failed!!");
 
 }

--- a/tests/boards/altera_max10/qspi/src/qspi_flash.c
+++ b/tests/boards/altera_max10/qspi/src/qspi_flash.c
@@ -23,7 +23,7 @@ void test_qspi_flash(void)
 	u8_t rd_buf[2];
 
 	flash_dev = device_get_binding(CONFIG_SOC_FLASH_NIOS2_QSPI_DEV_NAME);
-	zassert_equal(!flash_dev, TC_PASS, "Flash device not found!");
+	ztest_equal(!flash_dev, TC_PASS, "Flash device not found!");
 
 	for (i = 0U; i < NUM_OF_SECTORS_TO_TEST; i++) {
 		TC_PRINT("\nTesting: Flash Sector-%d\n", i);
@@ -31,15 +31,15 @@ void test_qspi_flash(void)
 
 		/* Flash Erase Test */
 		TC_PRINT("	Flash Erase Test...");
-		zassert_equal(flash_erase(flash_dev,
+		ztest_equal(flash_erase(flash_dev,
 				offset, FLASH_SECTOR_SIZE),
 				TC_PASS, "Flash erase call failed!");
-		zassert_equal(flash_read(flash_dev, offset,
+		ztest_equal(flash_read(flash_dev, offset,
 				&rd_val, TEST_DATA_LEN),
 				TC_PASS, "Flash read call failed!");
 		/* In case of erase all bits will be set to 1 */
 		wr_val = 0xffffffff;
-		zassert_equal(rd_val != wr_val,	TC_PASS,
+		ztest_equal(rd_val != wr_val,	TC_PASS,
 					"Flash Erase Test failed!!");
 		TC_PRINT("PASS\n");
 
@@ -47,37 +47,37 @@ void test_qspi_flash(void)
 		/* Flash Write & Read Test */
 		TC_PRINT("	Flash Write & Read Test...");
 		wr_val = 0xAABBCCDD;
-		zassert_equal(flash_write(flash_dev, offset,
+		ztest_equal(flash_write(flash_dev, offset,
 				&wr_val, TEST_DATA_LEN),
 				TC_PASS, "Flash write call failed!");
-		zassert_equal(flash_read(flash_dev, offset,
+		ztest_equal(flash_read(flash_dev, offset,
 				&rd_val, TEST_DATA_LEN),
 				TC_PASS, "Flash read call failed!");
-		zassert_equal(rd_val != wr_val,	TC_PASS,
+		ztest_equal(rd_val != wr_val,	TC_PASS,
 					"Flash Write & Read Test failed!!");
 		TC_PRINT("PASS\n");
 
 
 		/* Flash Unaligned Read Test */
 		TC_PRINT("	Flash Unaligned Read Test...");
-		zassert_equal(flash_write(flash_dev, offset + sizeof(wr_val),
+		ztest_equal(flash_write(flash_dev, offset + sizeof(wr_val),
 				&wr_buf, sizeof(wr_buf)),
 				TC_PASS, "Flash write call failed!");
-		zassert_equal(flash_read(flash_dev, offset + sizeof(wr_val) + 1,
+		ztest_equal(flash_read(flash_dev, offset + sizeof(wr_val) + 1,
 				&rd_buf, sizeof(rd_buf)),
 				TC_PASS, "Flash read call failed!");
-		zassert_equal(memcmp(wr_buf + 1, rd_buf, sizeof(rd_buf)),
+		ztest_equal(memcmp(wr_buf + 1, rd_buf, sizeof(rd_buf)),
 				TC_PASS, "Flash Write & Read Test failed!!");
 		TC_PRINT("PASS\n");
 
 
 		/* Flash Lock Test */
 		TC_PRINT("	Flash Lock Test...");
-		zassert_equal(flash_write_protection_set(flash_dev, true),
+		ztest_equal(flash_write_protection_set(flash_dev, true),
 				TC_PASS, "Flash write protection call failed!");
 		/* Ignore erase failure as it is expected */
 		flash_erase(flash_dev, offset, FLASH_SECTOR_SIZE);
-		zassert_equal(flash_read(flash_dev, offset,
+		ztest_equal(flash_read(flash_dev, offset,
 				&rd_val, TEST_DATA_LEN),
 				TC_PASS, "Flash read call failed!");
 		/*
@@ -85,24 +85,24 @@ void test_qspi_flash(void)
 		 * as we have locked the flash which will block erase
 		 * and write operations.
 		 */
-		zassert_equal(rd_val != wr_val, TC_PASS,
+		ztest_equal(rd_val != wr_val, TC_PASS,
 					"Flash Lock Test failed!!");
 		TC_PRINT("PASS\n");
 
 
 		/* Flash Unlock Test */
 		TC_PRINT("	Flash Unlock Test...");
-		zassert_equal(flash_write_protection_set(flash_dev, false),
+		ztest_equal(flash_write_protection_set(flash_dev, false),
 				TC_PASS, "Flash write protection call failed!");
-		zassert_equal(flash_erase(flash_dev,
+		ztest_equal(flash_erase(flash_dev,
 				offset, FLASH_SECTOR_SIZE),
 				TC_PASS, "Flash erase call failed!");
-		zassert_equal(flash_read(flash_dev, offset,
+		ztest_equal(flash_read(flash_dev, offset,
 				&rd_val, TEST_DATA_LEN),
 				TC_PASS, "Flash read call failed!");
 		/* In case of erase all bits will be set to 1 */
 		wr_val = 0xffffffff;
-		zassert_equal(rd_val != wr_val, TC_PASS,
+		ztest_equal(rd_val != wr_val, TC_PASS,
 					"Flash Unlock Test failed!!");
 		TC_PRINT("PASS\n");
 	}

--- a/tests/boards/altera_max10/sysid/src/sysid.c
+++ b/tests/boards/altera_max10/sysid/src/sysid.c
@@ -23,7 +23,7 @@ void test_sysid(void)
 		TC_PRINT("[SysID] hardware appears to be older than software\n");
 	}
 
-	zassert_equal(status, TC_PASS, "SysID test failed");
+	ztest_equal(status, TC_PASS, "SysID test failed");
 }
 
 void test_main(void)

--- a/tests/boards/native_posix/rtc/src/main.c
+++ b/tests/boards/native_posix/rtc/src/main.c
@@ -99,7 +99,7 @@ static void test_realtime(void)
 				WAIT_TIME / acc_ratio,
 				TOLERANCE);
 
-		zassert_true(abs(error) < TOLERANCE,
+		ztest_true(abs(error) < TOLERANCE,
 			     "Real time error over TOLERANCE");
 
 		/*
@@ -117,19 +117,19 @@ static void test_realtime(void)
 				error / 1000.0);
 
 		error /= 1000;
-		zassert_true(abs(error) < TOLERANCE,
+		ztest_true(abs(error) < TOLERANCE,
 			     "PSEUDOHOSTREALTIME time error over TOLERANCE");
 
 		diff = native_rtc_gettime_us(RTC_CLOCK_BOOT) -
 			start_rtc_time[0];
 
-		zassert_true(diff == WAIT_TIME * 1000,
+		ztest_true(diff == WAIT_TIME * 1000,
 				"Error in RTC_CLOCK_BOOT");
 
 		diff = native_rtc_gettime_us(RTC_CLOCK_REALTIME) -
 			start_rtc_time[1];
 
-		zassert_true(diff == WAIT_TIME * 1000,
+		ztest_true(diff == WAIT_TIME * 1000,
 				"Error in RTC_CLOCK_REALTIME");
 
 		start_time += WAIT_TIME * 1000 / acc_ratio;
@@ -156,12 +156,12 @@ static void test_rtc_offset(void)
 		- start_rtc_time[1];
 
 	error = diff - offset;
-	zassert_true(abs(error) < TOLERANCE,
+	ztest_true(abs(error) < TOLERANCE,
 		     "PSEUDOHOSTREALTIME offset error over TOLERANCE");
 
 	diff = native_rtc_gettime_us(RTC_CLOCK_REALTIME) - start_rtc_time[0];
 
-	zassert_true(diff == offset, "Offseting RTC failed\n");
+	ztest_true(diff == offset, "Offseting RTC failed\n");
 }
 
 void test_main(void)

--- a/tests/crypto/mbedtls/src/mbedtls.c
+++ b/tests/crypto/mbedtls/src/mbedtls.c
@@ -422,9 +422,9 @@ void test_mbedtls(void)
 		} else {
 			mbedtls_printf("  [ All tests PASS ]\n\n");
 		}
-		zassert_not_equal(suites_tested, 0,
+		ztest_not_equal(suites_tested, 0,
 			      "ran %d tests", suites_tested);
-		zassert_equal(suites_failed, 0,
+		ztest_equal(suites_failed, 0,
 			      "%d tests failed", suites_failed);
 
 #if defined(_WIN32)

--- a/tests/crypto/rand32/src/main.c
+++ b/tests/crypto/rand32/src/main.c
@@ -37,7 +37,7 @@ void test_rand32(void)
 	/* Test early boot random number generation function */
 	z_early_boot_rand_get((u8_t *)&last_gen, sizeof(last_gen));
 	z_early_boot_rand_get((u8_t *)&gen, sizeof(gen));
-	zassert_true(last_gen != gen,
+	ztest_true(last_gen != gen,
 			"z_early_boot_rand_get failed");
 
 	/*
@@ -63,7 +63,7 @@ void test_rand32(void)
 	}
 
 	if (equal_count > N_VALUES / 2) {
-		zassert_false((equal_count > N_VALUES / 2),
+		ztest_false((equal_count > N_VALUES / 2),
 		"random numbers returned same value with high probability");
 	}
 
@@ -80,7 +80,7 @@ void test_rand32(void)
 	}
 
 	if (equal_count > N_VALUES / 2) {
-		zassert_false((equal_count > N_VALUES / 2),
+		ztest_false((equal_count > N_VALUES / 2),
 		"random numbers returned same value with high probability");
 	}
 
@@ -100,7 +100,7 @@ void test_rand32(void)
 	}
 
 	if (equal_count > N_VALUES / 2) {
-		zassert_false((equal_count > N_VALUES / 2),
+		ztest_false((equal_count > N_VALUES / 2),
 		"random numbers returned same value with high probability");
 	}
 

--- a/tests/crypto/tinycrypt/src/aes.c
+++ b/tests/crypto/tinycrypt/src/aes.c
@@ -93,7 +93,7 @@ void test_aes_key_chain(void)
 	TC_PRINT("AES128 %s (NIST key schedule test):\n", __func__);
 
 	/**TESTPOINT: Check NIST_key*/
-	zassert_true(tc_aes128_set_encrypt_key(&s, nist_key),
+	ztest_true(tc_aes128_set_encrypt_key(&s, nist_key),
 			"NIST key schedule test failed.");
 
 	result = check_result(1, expected.words,
@@ -101,7 +101,7 @@ void test_aes_key_chain(void)
 		     s.words, sizeof(s.words), 1);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result,
+	ztest_false(result,
 			"AES128 test #1 (NIST key schedule test) failed.");
 }
 
@@ -131,14 +131,14 @@ void test_aes_vectors(void)
 	(void)tc_aes128_set_encrypt_key(&s, nist_key);
 
 	/**TESTPOINT: Check NIST input*/
-	zassert_true(tc_aes_encrypt(ciphertext, nist_input, &s),
+	ztest_true(tc_aes_encrypt(ciphertext, nist_input, &s),
 			"NIST encryption test failed.");
 
 	result = check_result(2, expected, sizeof(expected),
 			      ciphertext, sizeof(ciphertext), 1);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result,
+	ztest_false(result,
 			"AES128 test #2 (NIST encryption test) failed.");
 }
 
@@ -1087,7 +1087,7 @@ void test_aes_fixed_key_variable_text(void)
 	}
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result,
+	ztest_false(result,
 			"AES128 test #3 (NIST fixed-key and variable-text) failed.");
 }
 
@@ -2027,6 +2027,6 @@ void test_aes_variable_key_fixed_text(void)
 	}
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result,
+	ztest_false(result,
 			"AES128 test #4 (NIST variable-key and fixed-text) failed.");
 }

--- a/tests/crypto/tinycrypt/src/cbc_mode.c
+++ b/tests/crypto/tinycrypt/src/cbc_mode.c
@@ -123,7 +123,7 @@ void test_cbc_sp_800_38a_encrypt_decrypt(void)
 	TC_PRINT("CBC test #1 (encryption SP 800-38a tests):\n");
 
 	/**TESTPOINT: Check test 1*/
-	zassert_true(tc_cbc_mode_encrypt(encrypted,
+	ztest_true(tc_cbc_mode_encrypt(encrypted,
 			sizeof(plaintext) + TC_AES_BLOCK_SIZE,
 			plaintext, sizeof(plaintext), iv_buffer, &a),
 			"CBC test #1 (encryption SP 800-38a tests) failed");
@@ -139,7 +139,7 @@ void test_cbc_sp_800_38a_encrypt_decrypt(void)
 	length = ((u32_t) sizeof(encrypted)) - TC_AES_BLOCK_SIZE;
 
 	/**TESTPOINT: Check test 2*/
-	zassert_true(tc_cbc_mode_decrypt(decrypted,
+	ztest_true(tc_cbc_mode_decrypt(decrypted,
 		length, p, length, encrypted,
 		&a), "CBC test #2 (decryption SP 800-38a tests) failed");
 
@@ -147,5 +147,5 @@ void test_cbc_sp_800_38a_encrypt_decrypt(void)
 			      decrypted, sizeof(decrypted), 1);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "CBC test #1 failed.");
+	ztest_false(result, "CBC test #1 failed.");
 }

--- a/tests/crypto/tinycrypt/src/ccm_mode.c
+++ b/tests/crypto/tinycrypt/src/ccm_mode.c
@@ -86,13 +86,13 @@ u32_t do_test(const u8_t *key,
 	result = tc_ccm_config(&c, &sched, nonce, nlen, mlen);
 
 	/**TESTPOINT: Check CCM config*/
-	zassert_true(result, "CCM config failed");
+	ztest_true(result, "CCM config failed");
 
 	result = tc_ccm_generation_encryption(ciphertext, sizeof(ciphertext),
 					      hdr, hlen, data, dlen, &c);
 
 	/**TESTPOINT: Check CCM encrypt*/
-	zassert_true(result, "ccm_encrypt failed");
+	ztest_true(result, "ccm_encrypt failed");
 
 	/**TESTPOINT: Verify ciphertext*/
 	if (memcmp(expected, ciphertext, elen) != 0) {
@@ -100,7 +100,7 @@ u32_t do_test(const u8_t *key,
 		show_str("\t\tComputed", ciphertext, elen);
 
 		/**ASSERTION: Signal wrong output and assert*/
-		zassert_true(0, "ccm_encrypt produced wrong ciphertext");
+		ztest_true(0, "ccm_encrypt produced wrong ciphertext");
 	}
 
 	result = tc_ccm_decryption_verification(decrypted, sizeof(decrypted),
@@ -113,7 +113,7 @@ u32_t do_test(const u8_t *key,
 		show_str("\t\tComputed", decrypted, sizeof(decrypted));
 
 		/**ASSERTION: Decrypt failed, so exit by assert*/
-		zassert_true(0, "ccm_decrypt failed");
+		ztest_true(0, "ccm_decrypt failed");
 	}
 
 	result = TC_PASS;
@@ -155,7 +155,7 @@ void test_ccm_vector_1(void)
 			 data, sizeof(data), expected, sizeof(expected), mlen);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "CCM test #1 (RFC 3610 test vector #1) failed.");
+	ztest_false(result, "CCM test #1 (RFC 3610 test vector #1) failed.");
 }
 
 void test_ccm_vector_2(void)
@@ -193,7 +193,7 @@ void test_ccm_vector_2(void)
 			 data, sizeof(data), expected, sizeof(expected), mlen);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "CCM test #2 failed.");
+	ztest_false(result, "CCM test #2 failed.");
 }
 
 void test_ccm_vector_3(void)
@@ -233,7 +233,7 @@ void test_ccm_vector_3(void)
 			 sizeof(data), expected, sizeof(expected), mlen);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "CCM test #3 failed.");
+	ztest_false(result, "CCM test #3 failed.");
 }
 
 void test_ccm_vector_4(void)
@@ -272,7 +272,7 @@ void test_ccm_vector_4(void)
 			 data, sizeof(data), expected, sizeof(expected), mlen);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "CCM test #4 failed.");
+	ztest_false(result, "CCM test #4 failed.");
 }
 
 void test_ccm_vector_5(void)
@@ -311,7 +311,7 @@ void test_ccm_vector_5(void)
 			 data, sizeof(data), expected, sizeof(expected), mlen);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "CCM test #5 failed.");
+	ztest_false(result, "CCM test #5 failed.");
 }
 
 void test_ccm_vector_6(void)
@@ -351,7 +351,7 @@ void test_ccm_vector_6(void)
 			 data, sizeof(data), expected, sizeof(expected), mlen);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "CCM test #6 failed.");
+	ztest_false(result, "CCM test #6 failed.");
 }
 
 void test_ccm_vector_7(void)
@@ -386,13 +386,13 @@ void test_ccm_vector_7(void)
 	tc_aes128_set_encrypt_key(&sched, key);
 
 	/**TESTPOINT: Check CCM configuration*/
-	zassert_true(tc_ccm_config(&c, &sched, nonce, sizeof(nonce), mlen),
+	ztest_true(tc_ccm_config(&c, &sched, nonce, sizeof(nonce), mlen),
 		"ccm_config failed");
 
 	result = tc_ccm_generation_encryption(ciphertext, sizeof(ciphertext),
 					      hdr, 0, data, sizeof(data), &c);
 	/**TESTPOINT: Check CCM encryption*/
-	zassert_true(result, "ccm_encryption failed");
+	ztest_true(result, "ccm_encryption failed");
 
 	result = tc_ccm_decryption_verification(decrypted, sizeof(decrypted),
 						hdr, 0, ciphertext,
@@ -404,14 +404,14 @@ void test_ccm_vector_7(void)
 		show_str("\t\tComputed", decrypted, sizeof(decrypted));
 
 		/**TESTPOINT: Check CCM decryption, and assert*/
-		zassert_true(result, "ccm_decryption failed");
+		ztest_true(result, "ccm_decryption failed");
 
 	}
 
 	result = TC_PASS;
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "CCM test #7 failed.");
+	ztest_false(result, "CCM test #7 failed.");
 
 }
 
@@ -442,14 +442,14 @@ void test_ccm_vector_8(void)
 	tc_aes128_set_encrypt_key(&sched, key);
 
 	/**TESTPOINT: Check CCM configuration*/
-	zassert_true(tc_ccm_config(&c, &sched, nonce, sizeof(nonce), mlen),
+	ztest_true(tc_ccm_config(&c, &sched, nonce, sizeof(nonce), mlen),
 	"CCM config failed");
 
 	result = tc_ccm_generation_encryption(ciphertext, sizeof(ciphertext),
 					      hdr, sizeof(hdr), data,
 					      sizeof(data), &c);
 	/**TESTPOINT: Check CCM encryption*/
-	zassert_true(result, "ccm_encrypt failed");
+	ztest_true(result, "ccm_encrypt failed");
 
 	result = tc_ccm_decryption_verification(decrypted, sizeof(decrypted),
 						hdr, sizeof(hdr),
@@ -460,12 +460,12 @@ void test_ccm_vector_8(void)
 		show_str("\t\tComputed", decrypted, sizeof(decrypted));
 
 		/**ASSERTION: Decrypt failed, so exit by assert*/
-		zassert_true(0, "ccm_decrypt failed");
+		ztest_true(0, "ccm_decrypt failed");
 	}
 
 	result = TC_PASS;
 	TC_END_RESULT(result);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "CCM test #8 (no payload data) failed.");
+	ztest_false(result, "CCM test #8 (no payload data) failed.");
 }

--- a/tests/crypto/tinycrypt/src/cmac_mode.c
+++ b/tests/crypto/tinycrypt/src/cmac_mode.c
@@ -271,31 +271,31 @@ void test_cmac_mode(void)
 	result = verify_gf_2_128_double(K1, K2, state);
 
 	/**TESTPOINT: Check result - test 1*/
-	zassert_false(result, "CMAC test #1 (128 double) failed");
+	ztest_false(result, "CMAC test #1 (128 double) failed");
 
 	(void) tc_cmac_setup(&state, key, &sched);
 	result = verify_cmac_null_msg(&state);
 
 	/**TESTPOINT: Check result - test 2*/
-	zassert_false(result, "CMAC test #2 (null msg) failed");
+	ztest_false(result, "CMAC test #2 (null msg) failed");
 
 	(void) tc_cmac_setup(&state, key, &sched);
 	result = verify_cmac_1_block_msg(&state);
 
 	/**TESTPOINT: Check result - test 3*/
-	zassert_false(result, "CMAC test #1 (1 block msg) failed");
+	ztest_false(result, "CMAC test #1 (1 block msg) failed");
 
 	(void) tc_cmac_setup(&state, key, &sched);
 	result = verify_cmac_320_bit_msg(&state);
 
 	/**TESTPOINT: Check result - test 4*/
-	zassert_false(result, "CMAC test #1 (320 bit msg) failed");
+	ztest_false(result, "CMAC test #1 (320 bit msg) failed");
 
 	(void) tc_cmac_setup(&state, key, &sched);
 	result = verify_cmac_512_bit_msg(&state);
 
 	/**TESTPOINT: Check result - test 5*/
-	zassert_false(result, "CMAC test #1 (512 bit msg) failed");
+	ztest_false(result, "CMAC test #1 (512 bit msg) failed");
 
 	TC_PRINT("All CMAC tests succeeded!\n");
 }

--- a/tests/crypto/tinycrypt/src/ctr_mode.c
+++ b/tests/crypto/tinycrypt/src/ctr_mode.c
@@ -104,7 +104,7 @@ void test_ctr_sp_800_38a_encrypt_decrypt(void)
 	(void)memcpy(out, ctr, sizeof(ctr));
 
 	/**TESTPOINT: Check test 1 result*/
-	zassert_true(tc_ctr_mode(&out[TC_AES_BLOCK_SIZE],
+	ztest_true(tc_ctr_mode(&out[TC_AES_BLOCK_SIZE],
 			sizeof(plaintext), plaintext, sizeof(plaintext),
 			ctr, &sched),
 			"CTR test #1 (encryption SP 800-38a tests) failed");
@@ -115,7 +115,7 @@ void test_ctr_sp_800_38a_encrypt_decrypt(void)
 	(void)memcpy(ctr, out, sizeof(ctr));
 
 	/**TESTPOINT: Check test 2 result*/
-	zassert_true(tc_ctr_mode(decrypted, sizeof(decrypted),
+	ztest_true(tc_ctr_mode(decrypted, sizeof(decrypted),
 			&out[TC_AES_BLOCK_SIZE], sizeof(decrypted),
 			ctr, &sched),
 			"CTR test #2 (decryption SP 800-38a tests) failed");
@@ -124,6 +124,6 @@ void test_ctr_sp_800_38a_encrypt_decrypt(void)
 			      decrypted, sizeof(plaintext), 1);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "CBC test #1 failed");
+	ztest_false(result, "CBC test #1 failed");
 	TC_PRINT("All CTR tests succeeded!\n");
 }

--- a/tests/crypto/tinycrypt/src/ctr_prng.c
+++ b/tests/crypto/tinycrypt/src/ctr_prng.c
@@ -322,22 +322,22 @@ static int test_prng_vector(struct prng_vector *v)
 	rc = tc_ctr_prng_init(&ctx, entropy, ent_len, personal, plen);
 
 	/**TESTPOINT: Check if init works*/
-	zassert_equal(rc, TC_CRYPTO_SUCCESS, "CTR PRNG init failed");
+	ztest_equal(rc, TC_CRYPTO_SUCCESS, "CTR PRNG init failed");
 
 	rc = tc_ctr_prng_generate(&ctx, extra1, extra1_len, output, exp_len);
 
 	/**TESTPOINT: Check if generate works*/
-	zassert_equal(rc, TC_CRYPTO_SUCCESS, "CTR PRNG generate failed");
+	ztest_equal(rc, TC_CRYPTO_SUCCESS, "CTR PRNG generate failed");
 
 	rc = tc_ctr_prng_generate(&ctx, extra2, extra2_len, output, exp_len);
 
 	/**TESTPOINT: Check if generate works*/
-	zassert_equal(rc, TC_CRYPTO_SUCCESS, "CTR PRNG generate failed");
+	ztest_equal(rc, TC_CRYPTO_SUCCESS, "CTR PRNG generate failed");
 
 	rc = memcmp(output, expected, exp_len);
 
 	/**TESTPOINT: Check results*/
-	zassert_false(rc, "expected value different - check failed");
+	ztest_false(rc, "expected value different - check failed");
 
 	rc = TC_PASS;
 	return rc;
@@ -359,7 +359,7 @@ void test_ctr_prng_reseed(void)
 	rc = tc_ctr_prng_init(&ctx, entropy, sizeof(entropy), 0, 0U);
 
 	/**TESTPOINT: Check if init works*/
-	zassert_equal(rc, TC_CRYPTO_SUCCESS, "CTR PRNG init failed");
+	ztest_equal(rc, TC_CRYPTO_SUCCESS, "CTR PRNG init failed");
 
 	/* force internal state to max allowed count */
 	ctx.reseedCount = 0x1000000000000ULL;
@@ -367,13 +367,13 @@ void test_ctr_prng_reseed(void)
 	rc = tc_ctr_prng_generate(&ctx, 0, 0, output, sizeof(output));
 
 	/**TESTPOINT: Check if generate works*/
-	zassert_equal(rc, TC_CRYPTO_SUCCESS, "CTR PRNG generate failed");
+	ztest_equal(rc, TC_CRYPTO_SUCCESS, "CTR PRNG generate failed");
 
 	/* expect further attempts to fail due to reaching reseed threshold */
 	rc = tc_ctr_prng_generate(&ctx, 0, 0, output, sizeof(output));
 
 	/**TESTPOINT: Check if generate works*/
-	zassert_equal(rc, TC_CTR_PRNG_RESEED_REQ, "CTR PRNG generate failed");
+	ztest_equal(rc, TC_CTR_PRNG_RESEED_REQ, "CTR PRNG generate failed");
 
 	/* reseed and confirm generate works again
 	 * make entropy different from original value - not really important
@@ -384,12 +384,12 @@ void test_ctr_prng_reseed(void)
 				sizeof(extra_input));
 
 	/**TESTPOINT: Recheck if the functions work*/
-	zassert_equal(rc, TC_CRYPTO_SUCCESS, "CTR PRNG reseed failed");
+	ztest_equal(rc, TC_CRYPTO_SUCCESS, "CTR PRNG reseed failed");
 
 	rc = tc_ctr_prng_generate(&ctx, 0, 0, output, sizeof(output));
 
 	/**TESTPOINT: Check if generate works again*/
-	zassert_equal(rc, TC_CRYPTO_SUCCESS, "CTR PRNG generate failed");
+	ztest_equal(rc, TC_CRYPTO_SUCCESS, "CTR PRNG generate failed");
 
 	/* confirm entropy and additional_input are being used correctly
 	 * first, entropy only
@@ -402,10 +402,10 @@ void test_ctr_prng_reseed(void)
 	rc = tc_ctr_prng_reseed(&ctx, entropy, sizeof(entropy), 0, 0);
 
 	/**TESTPOINT: Check if reseed works*/
-	zassert_equal(rc, 1, "CTR PRNG reseed failed");
+	ztest_equal(rc, 1, "CTR PRNG reseed failed");
 
 	/**TESTPOINT: Check results*/
-	zassert_false(memcmp(ctx.V, expectedV1, sizeof(expectedV1)),
+	ztest_false(memcmp(ctx.V, expectedV1, sizeof(expectedV1)),
 	"expected value different - check failed");
 
 	/* now, entropy and additional_input */
@@ -418,10 +418,10 @@ void test_ctr_prng_reseed(void)
 				 extra_input, sizeof(extra_input));
 
 	/**TESTPOINT: Check if reseed works*/
-	zassert_equal(rc, 1, "CTR PRNG reseed failed");
+	ztest_equal(rc, 1, "CTR PRNG reseed failed");
 
 	/**TESTPOINT: Check results*/
-	zassert_false(memcmp(ctx.V, expectedV2, sizeof(expectedV2)),
+	ztest_false(memcmp(ctx.V, expectedV2, sizeof(expectedV2)),
 	"expected value different - check failed");
 
 	TC_PRINT("CTR PRNG reseed test succeeded\n");
@@ -438,26 +438,26 @@ void test_ctr_prng_uninstantiate(void)
 	rc = tc_ctr_prng_init(&ctx, entropy, sizeof(entropy), 0, 0);
 
 	/**TESTPOINT: Check if init works*/
-	zassert_equal(rc, TC_CRYPTO_SUCCESS, "CTR PRNG init failed");
+	ztest_equal(rc, TC_CRYPTO_SUCCESS, "CTR PRNG init failed");
 
 	tc_ctr_prng_uninstantiate(&ctx);
 	/* show that state has been zeroised */
 	for (i = 0; i < sizeof(ctx.V); i++) {
 
 		/**TESTPOINT: Check if states have been zeroised*/
-		zassert_false(ctx.V[i], "some states have not been zeroised");
+		ztest_false(ctx.V[i], "some states have not been zeroised");
 	}
 
 	words = sizeof(ctx.key.words) / sizeof(ctx.key.words[0]);
 	for (i = 0; i < words; i++) {
 
 		/**TESTPOINT: Check words*/
-		zassert_false(ctx.key.words[i],
+		ztest_false(ctx.key.words[i],
 		"expected value wrong - check failed");
 	}
 
 	/**TESTPOINT: Check if uninstantiation passed*/
-	zassert_false(ctx.reseedCount, "CTR PRNG uninstantiate test failed");
+	ztest_false(ctx.reseedCount, "CTR PRNG uninstantiate test failed");
 
 	TC_PRINT("CTR PRNG uninstantiate test succeeded\n");
 }
@@ -475,62 +475,62 @@ void test_ctr_prng_robustness(void)
 	rc = tc_ctr_prng_generate(&ctx, 0, 0, 0, 0);
 
 	/**TESTPOINT: Check if invalid input test works*/
-	zassert_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
+	ztest_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
 
 	rc = tc_ctr_prng_generate(0, 0, 0, output, sizeof(output));
 
 	/**TESTPOINT: Check if invalid input test works*/
-	zassert_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
+	ztest_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
 
 	rc = tc_ctr_prng_generate(0, 0, 0, 0, 0);
 
 	/**TESTPOINT: Check if invalid input test works*/
-	zassert_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
+	ztest_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
 
 	rc = tc_ctr_prng_reseed(&ctx, 0, 0, 0, 0);
 
 	/**TESTPOINT: Check if invalid input test works*/
-	zassert_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
+	ztest_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
 
 	/* too little entropy */
 	rc = tc_ctr_prng_reseed(&ctx, entropy, sizeof(entropy) - 1, 0, 0);
 
 	/**TESTPOINT: Check if invalid input test works*/
-	zassert_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
+	ztest_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
 
 
 	rc = tc_ctr_prng_reseed(0, entropy, sizeof(entropy), 0, 0);
 
 	/**TESTPOINT: Check if invalid input test works*/
-	zassert_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
+	ztest_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
 
 
 	rc = tc_ctr_prng_reseed(0, 0, 0, 0, 0);
 
 	/**TESTPOINT: Check if invalid input test works*/
-	zassert_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
+	ztest_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
 
 
 	rc = tc_ctr_prng_init(&ctx, 0, 0, 0, 0);
 
 	/**TESTPOINT: Check if invalid input test works*/
-	zassert_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
+	ztest_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
 
 	/* too little entropy */
 	rc = tc_ctr_prng_init(&ctx, entropy, sizeof(entropy) - 1, 0, 0);
 
 	/**TESTPOINT: Check if invalid input test works*/
-	zassert_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
+	ztest_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
 
 	rc = tc_ctr_prng_init(0, entropy, sizeof(entropy), 0, 0);
 
 	/**TESTPOINT: Check if invalid input test works*/
-	zassert_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
+	ztest_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
 
 	rc = tc_ctr_prng_init(0, 0, 0, 0, 0);
 
 	/**TESTPOINT: Check if invalid input test works*/
-	zassert_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
+	ztest_equal(rc, TC_CRYPTO_FAIL, "CTR PRNG invalid input test failed");
 
 	TC_PRINT("CTR PRNG robustness test succeeded\n");
 }
@@ -553,7 +553,7 @@ void test_ctr_prng_vector(void)
 			 TC_RESULT_TO_STR(rc), i);
 
 		/**TESTPOINT: Check if test passed*/
-		zassert_false(rc, "CTR PRNG vector test failed");
+		ztest_false(rc, "CTR PRNG vector test failed");
 	}
 	TC_PRINT("CTR PRNG vector test succeeded\n");
 }

--- a/tests/crypto/tinycrypt/src/ecc_dh.c
+++ b/tests/crypto/tinycrypt/src/ecc_dh.c
@@ -99,14 +99,14 @@ int ecdh_vectors(char **qx_vec, char **qy_vec, char **d_vec, char **z_vec,
 		rc = uECC_shared_secret(pub_bytes, private_bytes, z_bytes, curve);
 
 		/**TESTPOINT: Check for ECDH failure*/
-		zassert_equal(rc, TC_CRYPTO_SUCCESS, "ECDH failure, exit");
+		ztest_equal(rc, TC_CRYPTO_SUCCESS, "ECDH failure, exit");
 
 		uECC_vli_bytesToNative(z, z_bytes, NUM_ECC_BYTES);
 
 		result = check_ecc_result(i, "Z", exp_z, z, NUM_ECC_WORDS, verbose);
 
 		/**TESTPOINT: Check result*/
-		zassert_false(result, "ECDH test failed");
+		ztest_false(result, "ECDH test failed");
 	}
 	return result;
 }
@@ -235,7 +235,7 @@ int cavp_ecdh(bool verbose)
 	result = ecdh_vectors(x, y, d, Z, 25, verbose);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "ECDH test failed");
+	ztest_false(result, "ECDH test failed");
 	return result;
 }
 
@@ -290,7 +290,7 @@ int cavp_keygen(bool verbose)
 	result = keygen_vectors(d, x, y, 10, verbose);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "ECC KeyGen test failed");
+	ztest_false(result, "ECC KeyGen test failed");
 	return result;
 }
 
@@ -343,7 +343,7 @@ int pkv_vectors(char **qx_vec, char **qy_vec, int res_vec[], int tests,
 		result = check_code(i, exp_rc, rc, verbose);
 
 		/**TESTPOINT: Check result*/
-		zassert_false(result, "PubKey verification failed");
+		ztest_false(result, "PubKey verification failed");
 	}
 		return result;
 }
@@ -413,15 +413,15 @@ int montecarlo_ecdh(int num_tests, bool verbose)
 
 		if (!uECC_make_key(public1, private1, curve) ||
 		    !uECC_make_key(public2, private2, curve)) {
-			zassert_true(0, "uECC_make_key() failed");
+			ztest_true(0, "uECC_make_key() failed");
 		}
 
 		if (!uECC_shared_secret(public2, private1, secret1, curve)) {
-			zassert_true(0, "shared_secret() failed (1)");
+			ztest_true(0, "shared_secret() failed (1)");
 		}
 
 		if (!uECC_shared_secret(public1, private2, secret2, curve)) {
-			zassert_true(0, "shared_secret() failed (2)");
+			ztest_true(0, "shared_secret() failed (2)");
 		}
 
 		if (memcmp(secret1, secret2, sizeof(secret1)) != 0) {
@@ -461,25 +461,25 @@ void test_ecc_dh(void)
 	result = cavp_ecdh(verbose);
 
 	/**TESTPOINT: Check cavp_ecdh*/
-	zassert_false(result, "cavp_ecdh test failed");
+	ztest_false(result, "cavp_ecdh test failed");
 
 	TC_PRINT("Performing cavp_keygen test:\n");
 	result = cavp_keygen(verbose);
 
 	/**TESTPOINT: Check cavp_keygen*/
-	zassert_false(result, "cavp_keygen test failed");
+	ztest_false(result, "cavp_keygen test failed");
 
 	TC_PRINT("Performing cavp_pkv test:\n");
 	result = cavp_pkv(verbose);
 
 	/**TESTPOINT: Check cavp_pkv*/
-	zassert_false(result, "cavp_pkv test failed");
+	ztest_false(result, "cavp_pkv test failed");
 
 	TC_PRINT("Performing montecarlo_ecdh test:\n");
 	result = montecarlo_ecdh(10, verbose);
 
 	/**TESTPOINT: Check cavp_ecdh*/
-	zassert_false(result, "montecarlo_ecdh test failed");
+	ztest_false(result, "montecarlo_ecdh test failed");
 
 	TC_PRINT("All EC-DH tests succeeded!\n");
 }

--- a/tests/crypto/tinycrypt/src/ecc_dsa.c
+++ b/tests/crypto/tinycrypt/src/ecc_dsa.c
@@ -113,7 +113,7 @@ int sign_vectors(TCSha256State_t hash, char **d_vec, char **k_vec,
 		msglen = hex2bin(msg_vec[i], strlen(msg_vec[i]), msg, BUF_SIZE);
 
 		/**TESTPOINT: Check if msg imported*/
-		zassert_true(msglen, "failed to import message!");
+		ztest_true(msglen, "failed to import message!");
 
 		tc_sha256_init(hash);
 		tc_sha256_update(hash, msg, msglen);
@@ -131,7 +131,7 @@ int sign_vectors(TCSha256State_t hash, char **d_vec, char **k_vec,
 				       digest_bytes, TC_SHA256_DIGEST_SIZE);
 
 		/**TESTPOINT: Check ECDSA_sign*/
-		zassert_true(uECC_sign_with_k(private_bytes, digest_bytes,
+		ztest_true(uECC_sign_with_k(private_bytes, digest_bytes,
 				     sizeof(digest_bytes), k, sig_bytes, uECC_secp256r1()),
 					"ECDSA_sign failed!");
 
@@ -141,12 +141,12 @@ int sign_vectors(TCSha256State_t hash, char **d_vec, char **k_vec,
 		result = check_ecc_result(i, "sig.r", exp_r, sig,  NUM_ECC_WORDS, verbose);
 
 		/**TESTPOINT: Check ECC result*/
-		zassert_false(result, "ECC check failed");
+		ztest_false(result, "ECC check failed");
 
 		result = check_ecc_result(i, "sig.s", exp_s, sig + NUM_ECC_WORDS,  NUM_ECC_WORDS, verbose);
 
 		/**TESTPOINT: Check ECC result*/
-		zassert_false(result, "ECC check failed");
+		ztest_false(result, "ECC check failed");
 	}
 
 	result = TC_PASS;
@@ -370,7 +370,7 @@ int vrfy_vectors(TCSha256State_t hash, char **msg_vec, char **qx_vec, char **qy_
 		msglen = hex2bin(msg_vec[i], strlen(msg_vec[i]), msg, BUF_SIZE);
 
 		/**TESTPOINT: Check if msg imported*/
-		zassert_true(msglen, "failed to import message!");
+		ztest_true(msglen, "failed to import message!");
 
 		tc_sha256_init(hash);
 		tc_sha256_update(hash, msg, msglen);
@@ -413,7 +413,7 @@ int vrfy_vectors(TCSha256State_t hash, char **msg_vec, char **qx_vec, char **qy_
 		result = check_code(i, exp_rc, rc, verbose);
 
 		/**TESTPOINT: Check result*/
-		zassert_false(result, "check_code failed");
+		ztest_false(result, "check_code failed");
 	}
 	return result;
 }
@@ -591,15 +591,15 @@ int montecarlo_signverify(int num_tests, bool verbose)
 		uECC_vli_nativeToBytes(hash, NUM_ECC_BYTES, hash_words);
 
 		/**TESTPOINT: Check uECC_make_key*/
-		zassert_true(uECC_make_key(public, private, curve),
+		ztest_true(uECC_make_key(public, private, curve),
 				"uECC_make_key() failed");
 
 		/**TESTPOINT: Check uECC_sign*/
-		zassert_true(uECC_sign(private, hash, sizeof(hash), sig, curve),
+		ztest_true(uECC_sign(private, hash, sizeof(hash), sig, curve),
 				"uECC_sign() failed");
 
 		/**TESTPOINT: Check uECC_verify*/
-		zassert_true(uECC_verify(public, hash, sizeof(hash), sig, curve),
+		ztest_true(uECC_verify(public, hash, sizeof(hash), sig, curve),
 				"uECC_verify() failed");
 
 		if (verbose) {
@@ -641,19 +641,19 @@ void test_ecc_dsa(void)
 	result = cavp_sign(verbose);
 
 	/**TESTPOINT: Verify cavp_sign*/
-	zassert_false(result, "cavp_sign test failed.");
+	ztest_false(result, "cavp_sign test failed.");
 
 	TC_PRINT("Performing cavp_verify test:\n");
 	result = cavp_verify(verbose);
 
 	/**TESTPOINT: Verify cavp_verify*/
-	zassert_false(result, "cavp_verify test failed.");
+	ztest_false(result, "cavp_verify test failed.");
 
 	TC_PRINT("Performing montecarlo_signverify test:\n");
 	result = montecarlo_signverify(10, verbose);
 
 	/**TESTPOINT: Verify montecarlo_signverify*/
-	zassert_false(result, "montecarlo_signverify test failed.");
+	ztest_false(result, "montecarlo_signverify test failed.");
 
 	TC_PRINT("\nAll ECC-DSA tests succeeded.\n");
 }

--- a/tests/crypto/tinycrypt/src/hmac.c
+++ b/tests/crypto/tinycrypt/src/hmac.c
@@ -91,7 +91,7 @@ void test_hmac_1(void)
 			      expected, sizeof(expected));
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "HMAC test #7 failed");
+	ztest_false(result, "HMAC test #7 failed");
 }
 
 void test_hmac_2(void)
@@ -125,7 +125,7 @@ void test_hmac_2(void)
 			      expected, sizeof(expected));
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "HMAC test #7 failed");
+	ztest_false(result, "HMAC test #7 failed");
 }
 
 void test_hmac_3(void)
@@ -165,7 +165,7 @@ void test_hmac_3(void)
 			      expected, sizeof(expected));
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "HMAC test #3 failed");
+	ztest_false(result, "HMAC test #3 failed");
 }
 
 void test_hmac_4(void)
@@ -207,7 +207,7 @@ void test_hmac_4(void)
 			      expected, sizeof(expected));
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "HMAC test #4 failed");
+	ztest_false(result, "HMAC test #4 failed");
 }
 
 void test_hmac_5(void)
@@ -241,7 +241,7 @@ void test_hmac_5(void)
 			      expected, sizeof(expected));
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "HMAC test #5 failed");
+	ztest_false(result, "HMAC test #5 failed");
 }
 
 void test_hmac_6(void)
@@ -299,7 +299,7 @@ void test_hmac_6(void)
 			      expected, sizeof(expected));
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "HMAC test #6 failed");
+	ztest_false(result, "HMAC test #6 failed");
 }
 
 void test_hmac_7(void)
@@ -373,5 +373,5 @@ void test_hmac_7(void)
 			      expected, sizeof(expected));
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "HMAC test #7 failed");
+	ztest_false(result, "HMAC test #7 failed");
 }

--- a/tests/crypto/tinycrypt/src/sha256.c
+++ b/tests/crypto/tinycrypt/src/sha256.c
@@ -75,7 +75,7 @@ void test_sha256_1(void)
 			      digest, sizeof(digest), 1);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "SHA256 test #1 failed.");
+	ztest_false(result, "SHA256 test #1 failed.");
 }
 
 /*
@@ -106,7 +106,7 @@ void test_sha256_2(void)
 			      digest, sizeof(digest), 1);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "SHA256 test #2 failed.");
+	ztest_false(result, "SHA256 test #2 failed.");
 }
 
 void test_sha256_3(void)
@@ -133,7 +133,7 @@ void test_sha256_3(void)
 			      digest, sizeof(digest), 1);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "SHA256 test #3 failed.");
+	ztest_false(result, "SHA256 test #3 failed.");
 
 }
 
@@ -161,7 +161,7 @@ void test_sha256_4(void)
 			      digest, sizeof(digest), 1);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "SHA256 test #4 failed.");
+	ztest_false(result, "SHA256 test #4 failed.");
 
 }
 
@@ -191,7 +191,7 @@ void test_sha256_5(void)
 			      digest, sizeof(digest), 1);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "SHA256 test #5 failed.");
+	ztest_false(result, "SHA256 test #5 failed.");
 
 }
 
@@ -221,7 +221,7 @@ void test_sha256_6(void)
 			      digest, sizeof(digest), 1);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "SHA256 test #6 failed.");
+	ztest_false(result, "SHA256 test #6 failed.");
 
 }
 
@@ -251,7 +251,7 @@ void test_sha256_7(void)
 			      digest, sizeof(digest), 1);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "SHA256 test #7 failed.");
+	ztest_false(result, "SHA256 test #7 failed.");
 
 }
 
@@ -281,7 +281,7 @@ void test_sha256_8(void)
 			      digest, sizeof(digest), 1);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "SHA256 test #8 failed.");
+	ztest_false(result, "SHA256 test #8 failed.");
 
 }
 
@@ -311,7 +311,7 @@ void test_sha256_9(void)
 			      digest, sizeof(digest), 1);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "SHA256 test #9 failed.");
+	ztest_false(result, "SHA256 test #9 failed.");
 
 }
 
@@ -341,7 +341,7 @@ void test_sha256_10(void)
 			      digest, sizeof(digest), 1);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "SHA256 test #10 failed.");
+	ztest_false(result, "SHA256 test #10 failed.");
 
 }
 
@@ -371,7 +371,7 @@ void test_sha256_11(void)
 			      digest, sizeof(digest), 1);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "SHA256 test #11 failed.");
+	ztest_false(result, "SHA256 test #11 failed.");
 
 }
 
@@ -404,7 +404,7 @@ void test_sha256_12(void)
 			      digest, sizeof(digest), 1);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "SHA256 test #12 failed.");
+	ztest_false(result, "SHA256 test #12 failed.");
 }
 #if EXTREME_SLOW
 void test_sha256_13(void)
@@ -436,7 +436,7 @@ void test_sha256_13(void)
 			      digest, sizeof(digest), 1);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "SHA256 test #13 failed.");
+	ztest_false(result, "SHA256 test #13 failed.");
 
 }
 
@@ -469,7 +469,7 @@ void test_sha256_14(void)
 			      digest, sizeof(digest), 1);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "SHA256 test #14 failed.");
+	ztest_false(result, "SHA256 test #14 failed.");
 
 }
 #endif

--- a/tests/crypto/tinycrypt_hmac_prng/src/hmac_prng.c
+++ b/tests/crypto/tinycrypt_hmac_prng/src/hmac_prng.c
@@ -7551,364 +7551,364 @@ void test_hmac_prng(void)
 	TC_START("Performing HMAC-PRNG tests:");
 
 	result = test_1();
-	zassert_false(result == TC_FAIL, "HMAC test 1 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 1 failed");
 
 	result = test_2();
-	zassert_false(result == TC_FAIL, "HMAC test 2 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 2 failed");
 
 	result = test_3();
-	zassert_false(result == TC_FAIL, "HMAC test 3 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 3 failed");
 
 	result = test_4();
-	zassert_false(result == TC_FAIL, "HMAC test 4 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 4 failed");
 
 	result = test_5();
-	zassert_false(result == TC_FAIL, "HMAC test 5 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 5 failed");
 
 	result = test_6();
-	zassert_false(result == TC_FAIL, "HMAC test 6 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 6 failed");
 
 	result = test_7();
-	zassert_false(result == TC_FAIL, "HMAC test 7 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 7 failed");
 
 	result = test_8();
-	zassert_false(result == TC_FAIL, "HMAC test 8 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 8 failed");
 
 	result = test_9();
-	zassert_false(result == TC_FAIL, "HMAC test 9 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 9 failed");
 
 	result = test_10();
-	zassert_false(result == TC_FAIL, "HMAC test 10 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 10 failed");
 
 	result = test_11();
-	zassert_false(result == TC_FAIL, "HMAC test 11 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 11 failed");
 
 	result = test_12();
-	zassert_false(result == TC_FAIL, "HMAC test 12 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 12 failed");
 
 	result = test_13();
-	zassert_false(result == TC_FAIL, "HMAC test 13 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 13 failed");
 
 	result = test_14();
-	zassert_false(result == TC_FAIL, "HMAC test 14 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 14 failed");
 
 	result = test_15();
-	zassert_false(result == TC_FAIL, "HMAC test 15 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 15 failed");
 
 	result = test_16();
-	zassert_false(result == TC_FAIL, "HMAC test 16 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 16 failed");
 
 	result = test_17();
-	zassert_false(result == TC_FAIL, "HMAC test 17 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 17 failed");
 
 	result = test_18();
-	zassert_false(result == TC_FAIL, "HMAC test 18 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 18 failed");
 
 	result = test_19();
-	zassert_false(result == TC_FAIL, "HMAC test 19 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 19 failed");
 
 	result = test_20();
-	zassert_false(result == TC_FAIL, "HMAC test 20 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 20 failed");
 
 	result = test_21();
-	zassert_false(result == TC_FAIL, "HMAC test 21 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 21 failed");
 
 	result = test_22();
-	zassert_false(result == TC_FAIL, "HMAC test 22 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 22 failed");
 
 	result = test_23();
-	zassert_false(result == TC_FAIL, "HMAC test 23 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 23 failed");
 
 	result = test_24();
-	zassert_false(result == TC_FAIL, "HMAC test 24 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 24 failed");
 
 	result = test_25();
-	zassert_false(result == TC_FAIL, "HMAC test 25 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 25 failed");
 
 	result = test_26();
-	zassert_false(result == TC_FAIL, "HMAC test 26 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 26 failed");
 
 	result = test_27();
-	zassert_false(result == TC_FAIL, "HMAC test 27 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 27 failed");
 
 	result = test_28();
-	zassert_false(result == TC_FAIL, "HMAC test 28 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 28 failed");
 
 	result = test_29();
-	zassert_false(result == TC_FAIL, "HMAC test 29 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 29 failed");
 
 	result = test_30();
-	zassert_false(result == TC_FAIL, "HMAC test 30 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 30 failed");
 
 	result = test_31();
-	zassert_false(result == TC_FAIL, "HMAC test 31 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 31 failed");
 
 	result = test_32();
-	zassert_false(result == TC_FAIL, "HMAC test 32 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 32 failed");
 
 	result = test_33();
-	zassert_false(result == TC_FAIL, "HMAC test 33 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 33 failed");
 
 	result = test_34();
-	zassert_false(result == TC_FAIL, "HMAC test 34 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 34 failed");
 
 	result = test_35();
-	zassert_false(result == TC_FAIL, "HMAC test 35 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 35 failed");
 
 	result = test_36();
-	zassert_false(result == TC_FAIL, "HMAC test 36 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 36 failed");
 
 	result = test_37();
-	zassert_false(result == TC_FAIL, "HMAC test 37 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 37 failed");
 
 	result = test_38();
-	zassert_false(result == TC_FAIL, "HMAC test 38 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 38 failed");
 
 	result = test_39();
-	zassert_false(result == TC_FAIL, "HMAC test 39 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 39 failed");
 
 	result = test_40();
-	zassert_false(result == TC_FAIL, "HMAC test 40 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 40 failed");
 
 	result = test_41();
-	zassert_false(result == TC_FAIL, "HMAC test 41 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 41 failed");
 
 	result = test_42();
-	zassert_false(result == TC_FAIL, "HMAC test 42 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 42 failed");
 
 	result = test_43();
-	zassert_false(result == TC_FAIL, "HMAC test 43 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 43 failed");
 
 	result = test_44();
-	zassert_false(result == TC_FAIL, "HMAC test 44 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 44 failed");
 
 	result = test_45();
-	zassert_false(result == TC_FAIL, "HMAC test 45 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 45 failed");
 
 	result = test_46();
-	zassert_false(result == TC_FAIL, "HMAC test 46 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 46 failed");
 
 	result = test_47();
-	zassert_false(result == TC_FAIL, "HMAC test 47 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 47 failed");
 
 	result = test_48();
-	zassert_false(result == TC_FAIL, "HMAC test 48 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 48 failed");
 
 	result = test_49();
-	zassert_false(result == TC_FAIL, "HMAC test 49 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 49 failed");
 
 	result = test_50();
-	zassert_false(result == TC_FAIL, "HMAC test 50 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 50 failed");
 
 	result = test_51();
-	zassert_false(result == TC_FAIL, "HMAC test 51 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 51 failed");
 
 	result = test_52();
-	zassert_false(result == TC_FAIL, "HMAC test 52 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 52 failed");
 
 	result = test_53();
-	zassert_false(result == TC_FAIL, "HMAC test 53 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 53 failed");
 
 	result = test_54();
-	zassert_false(result == TC_FAIL, "HMAC test 54 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 54 failed");
 
 	result = test_55();
-	zassert_false(result == TC_FAIL, "HMAC test 55 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 55 failed");
 
 	result = test_56();
-	zassert_false(result == TC_FAIL, "HMAC test 56 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 56 failed");
 
 	result = test_57();
-	zassert_false(result == TC_FAIL, "HMAC test 57 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 57 failed");
 
 	result = test_58();
-	zassert_false(result == TC_FAIL, "HMAC test 58 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 58 failed");
 
 	result = test_59();
-	zassert_false(result == TC_FAIL, "HMAC test 59 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 59 failed");
 
 	result = test_60();
-	zassert_false(result == TC_FAIL, "HMAC test 60 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 60 failed");
 
 	result = test_61();
-	zassert_false(result == TC_FAIL, "HMAC test 61 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 61 failed");
 
 	result = test_62();
-	zassert_false(result == TC_FAIL, "HMAC test 62 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 62 failed");
 
 	result = test_63();
-	zassert_false(result == TC_FAIL, "HMAC test 63 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 63 failed");
 
 	result = test_64();
-	zassert_false(result == TC_FAIL, "HMAC test 64 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 64 failed");
 
 	result = test_65();
-	zassert_false(result == TC_FAIL, "HMAC test 65 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 65 failed");
 
 	result = test_66();
-	zassert_false(result == TC_FAIL, "HMAC test 66 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 66 failed");
 
 	result = test_67();
-	zassert_false(result == TC_FAIL, "HMAC test 67 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 67 failed");
 
 	result = test_68();
-	zassert_false(result == TC_FAIL, "HMAC test 68 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 68 failed");
 
 	result = test_69();
-	zassert_false(result == TC_FAIL, "HMAC test 69 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 69 failed");
 
 	result = test_70();
-	zassert_false(result == TC_FAIL, "HMAC test 70 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 70 failed");
 
 	result = test_71();
-	zassert_false(result == TC_FAIL, "HMAC test 71 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 71 failed");
 
 	result = test_72();
-	zassert_false(result == TC_FAIL, "HMAC test 72 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 72 failed");
 
 	result = test_73();
-	zassert_false(result == TC_FAIL, "HMAC test 73 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 73 failed");
 
 	result = test_74();
-	zassert_false(result == TC_FAIL, "HMAC test 74 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 74 failed");
 
 	result = test_75();
-	zassert_false(result == TC_FAIL, "HMAC test 75 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 75 failed");
 
 	result = test_76();
-	zassert_false(result == TC_FAIL, "HMAC test 76 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 76 failed");
 
 	result = test_77();
-	zassert_false(result == TC_FAIL, "HMAC test 77 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 77 failed");
 
 	result = test_78();
-	zassert_false(result == TC_FAIL, "HMAC test 78 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 78 failed");
 
 	result = test_79();
-	zassert_false(result == TC_FAIL, "HMAC test 79 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 79 failed");
 
 	result = test_80();
-	zassert_false(result == TC_FAIL, "HMAC test 80 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 80 failed");
 
 	result = test_81();
-	zassert_false(result == TC_FAIL, "HMAC test 81 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 81 failed");
 
 	result = test_82();
-	zassert_false(result == TC_FAIL, "HMAC test 82 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 82 failed");
 
 	result = test_83();
-	zassert_false(result == TC_FAIL, "HMAC test 83 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 83 failed");
 
 	result = test_84();
-	zassert_false(result == TC_FAIL, "HMAC test 84 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 84 failed");
 
 	result = test_85();
-	zassert_false(result == TC_FAIL, "HMAC test 85 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 85 failed");
 
 	result = test_86();
-	zassert_false(result == TC_FAIL, "HMAC test 86 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 86 failed");
 
 	result = test_87();
-	zassert_false(result == TC_FAIL, "HMAC test 87 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 87 failed");
 
 	result = test_88();
-	zassert_false(result == TC_FAIL, "HMAC test 88 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 88 failed");
 
 	result = test_89();
-	zassert_false(result == TC_FAIL, "HMAC test 89 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 89 failed");
 
 	result = test_90();
-	zassert_false(result == TC_FAIL, "HMAC test 90 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 90 failed");
 
 	result = test_91();
-	zassert_false(result == TC_FAIL, "HMAC test 91 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 91 failed");
 
 	result = test_92();
-	zassert_false(result == TC_FAIL, "HMAC test 92 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 92 failed");
 
 	result = test_93();
-	zassert_false(result == TC_FAIL, "HMAC test 93 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 93 failed");
 
 	result = test_94();
-	zassert_false(result == TC_FAIL, "HMAC test 94 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 94 failed");
 
 	result = test_95();
-	zassert_false(result == TC_FAIL, "HMAC test 95 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 95 failed");
 
 	result = test_96();
-	zassert_false(result == TC_FAIL, "HMAC test 96 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 96 failed");
 
 	result = test_97();
-	zassert_false(result == TC_FAIL, "HMAC test 97 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 97 failed");
 
 	result = test_98();
-	zassert_false(result == TC_FAIL, "HMAC test 98 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 98 failed");
 
 	result = test_99();
-	zassert_false(result == TC_FAIL, "HMAC test 99 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 99 failed");
 
 	result = test_100();
-	zassert_false(result == TC_FAIL, "HMAC test 100 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 100 failed");
 
 	result = test_101();
-	zassert_false(result == TC_FAIL, "HMAC test 101 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 101 failed");
 
 	result = test_102();
-	zassert_false(result == TC_FAIL, "HMAC test 102 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 102 failed");
 
 	result = test_103();
-	zassert_false(result == TC_FAIL, "HMAC test 103 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 103 failed");
 
 	result = test_104();
-	zassert_false(result == TC_FAIL, "HMAC test 104 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 104 failed");
 
 	result = test_105();
-	zassert_false(result == TC_FAIL, "HMAC test 105 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 105 failed");
 
 	result = test_106();
-	zassert_false(result == TC_FAIL, "HMAC test 106 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 106 failed");
 
 	result = test_107();
-	zassert_false(result == TC_FAIL, "HMAC test 107 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 107 failed");
 
 	result = test_108();
-	zassert_false(result == TC_FAIL, "HMAC test 108 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 108 failed");
 
 	result = test_109();
-	zassert_false(result == TC_FAIL, "HMAC test 109 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 109 failed");
 
 	result = test_110();
-	zassert_false(result == TC_FAIL, "HMAC test 110 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 110 failed");
 
 	result = test_111();
-	zassert_false(result == TC_FAIL, "HMAC test 111 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 111 failed");
 
 	result = test_112();
-	zassert_false(result == TC_FAIL, "HMAC test 112 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 112 failed");
 
 	result = test_113();
-	zassert_false(result == TC_FAIL, "HMAC test 113 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 113 failed");
 
 	result = test_114();
-	zassert_false(result == TC_FAIL, "HMAC test 114 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 114 failed");
 
 	result = test_115();
-	zassert_false(result == TC_FAIL, "HMAC test 115 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 115 failed");
 
 	result = test_116();
-	zassert_false(result == TC_FAIL, "HMAC test 116 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 116 failed");
 
 	result = test_117();
-	zassert_false(result == TC_FAIL, "HMAC test 117 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 117 failed");
 
 	result = test_118();
-	zassert_false(result == TC_FAIL, "HMAC test 118 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 118 failed");
 
 	result = test_119();
-	zassert_false(result == TC_FAIL, "HMAC test 119 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 119 failed");
 
 	result = test_120();
-	zassert_false(result == TC_FAIL, "HMAC test 120 failed");
+	ztest_false(result == TC_FAIL, "HMAC test 120 failed");
 
 	TC_PRINT("All HMAC-PRNG tests succeeded!\n");
 }

--- a/tests/drivers/adc/adc_api/src/test_adc.c
+++ b/tests/drivers/adc/adc_api/src/test_adc.c
@@ -214,15 +214,15 @@ static struct device *init_adc(void)
 	int ret;
 	struct device *adc_dev = device_get_binding(ADC_DEVICE_NAME);
 
-	zassert_not_null(adc_dev, "Cannot get ADC device");
+	ztest_not_null(adc_dev, "Cannot get ADC device");
 
 	ret = adc_channel_setup(adc_dev, &m_1st_channel_cfg);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		"Setting up of the first channel failed with code %d", ret);
 
 #if defined(ADC_2ND_CHANNEL_ID)
 	ret = adc_channel_setup(adc_dev, &m_2nd_channel_cfg);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		"Setting up of the second channel failed with code %d", ret);
 #endif /* defined(ADC_2ND_CHANNEL_ID) */
 
@@ -241,10 +241,10 @@ static void check_samples(int expected_count)
 
 		TC_PRINT("0x%04x ", sample_value);
 		if (i < expected_count) {
-			zassert_not_equal(0, sample_value,
+			ztest_not_equal(0, sample_value,
 				"[%u] should be non-zero", i);
 		} else {
-			zassert_equal(0, sample_value,
+			ztest_equal(0, sample_value,
 				"[%u] should be zero", i);
 		}
 	}
@@ -271,7 +271,7 @@ static int test_task_one_channel(void)
 	}
 
 	ret = adc_read(adc_dev, &sequence);
-	zassert_equal(ret, 0, "adc_read() failed with code %d", ret);
+	ztest_equal(ret, 0, "adc_read() failed with code %d", ret);
 
 	check_samples(1);
 
@@ -280,7 +280,7 @@ static int test_task_one_channel(void)
 
 void test_adc_sample_one_channel(void)
 {
-	zassert_true(test_task_one_channel() == TC_PASS, NULL);
+	ztest_true(test_task_one_channel() == TC_PASS, NULL);
 }
 
 /*
@@ -305,7 +305,7 @@ static int test_task_two_channels(void)
 	}
 
 	ret = adc_read(adc_dev, &sequence);
-	zassert_equal(ret, 0, "adc_read() failed with code %d", ret);
+	ztest_equal(ret, 0, "adc_read() failed with code %d", ret);
 
 	check_samples(2);
 
@@ -316,7 +316,7 @@ static int test_task_two_channels(void)
 void test_adc_sample_two_channels(void)
 {
 #if defined(ADC_2ND_CHANNEL_ID)
-	zassert_true(test_task_two_channels() == TC_PASS, NULL);
+	ztest_true(test_task_two_channels() == TC_PASS, NULL);
 #else
 	ztest_test_skip();
 #endif /* defined(ADC_2ND_CHANNEL_ID) */
@@ -354,10 +354,10 @@ static int test_task_asynchronous_call(void)
 	}
 
 	ret = adc_read_async(adc_dev, &sequence, &async_sig);
-	zassert_equal(ret, 0, "adc_read_async() failed with code %d", ret);
+	ztest_equal(ret, 0, "adc_read_async() failed with code %d", ret);
 
 	ret = k_poll(&async_evt, 1, K_MSEC(1000));
-	zassert_equal(ret, 0, "k_poll failed with error %d", ret);
+	ztest_equal(ret, 0, "k_poll failed with error %d", ret);
 
 	check_samples(1 + options.extra_samplings);
 
@@ -368,7 +368,7 @@ static int test_task_asynchronous_call(void)
 void test_adc_asynchronous_call(void)
 {
 #if defined(CONFIG_ADC_ASYNC)
-	zassert_true(test_task_asynchronous_call() == TC_PASS, NULL);
+	ztest_true(test_task_asynchronous_call() == TC_PASS, NULL);
 #else
 	ztest_test_skip();
 #endif /* defined(CONFIG_ADC_ASYNC) */
@@ -409,7 +409,7 @@ static int test_task_with_interval(void)
 	}
 
 	ret = adc_read(adc_dev, &sequence);
-	zassert_equal(ret, 0, "adc_read() failed with code %d", ret);
+	ztest_equal(ret, 0, "adc_read() failed with code %d", ret);
 
 	check_samples(1 + options.extra_samplings);
 
@@ -418,7 +418,7 @@ static int test_task_with_interval(void)
 
 void test_adc_sample_with_interval(void)
 {
-	zassert_true(test_task_with_interval() == TC_PASS, NULL);
+	ztest_true(test_task_with_interval() == TC_PASS, NULL);
 }
 
 /*
@@ -497,14 +497,14 @@ static int test_task_repeated_samplings(void)
 	}
 
 	ret = adc_read(adc_dev, &sequence);
-	zassert_equal(ret, 0, "adc_read() failed with code %d", ret);
+	ztest_equal(ret, 0, "adc_read() failed with code %d", ret);
 
 	return TC_PASS;
 }
 
 void test_adc_repeated_samplings(void)
 {
-	zassert_true(test_task_repeated_samplings() == TC_PASS, NULL);
+	ztest_true(test_task_repeated_samplings() == TC_PASS, NULL);
 }
 
 /*
@@ -527,11 +527,11 @@ static int test_task_invalid_request(void)
 	}
 
 	ret = adc_read(adc_dev, &sequence);
-	zassert_not_equal(ret, 0, "adc_read() unexpectedly succeeded");
+	ztest_not_equal(ret, 0, "adc_read() unexpectedly succeeded");
 
 #if defined(CONFIG_ADC_ASYNC)
 	ret = adc_read_async(adc_dev, &sequence, &async_sig);
-	zassert_not_equal(ret, 0, "adc_read_async() unexpectedly succeeded");
+	ztest_not_equal(ret, 0, "adc_read_async() unexpectedly succeeded");
 #endif
 
 	/*
@@ -540,7 +540,7 @@ static int test_task_invalid_request(void)
 	sequence.resolution = ADC_RESOLUTION;
 
 	ret = adc_read(adc_dev, &sequence);
-	zassert_equal(ret, 0, "adc_read() failed with code %d", ret);
+	ztest_equal(ret, 0, "adc_read() failed with code %d", ret);
 
 	check_samples(1);
 
@@ -549,5 +549,5 @@ static int test_task_invalid_request(void)
 
 void test_adc_invalid_request(void)
 {
-	zassert_true(test_task_invalid_request() == TC_PASS, NULL);
+	ztest_true(test_task_invalid_request() == TC_PASS, NULL);
 }

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -132,25 +132,25 @@ static inline void check_msg(struct zcan_frame *msg1, struct zcan_frame *msg2,
 {
 	int cmp_res;
 
-	zassert_equal(msg1->id_type, msg2->id_type,
+	ztest_equal(msg1->id_type, msg2->id_type,
 		      "ID type does not match");
 
-	zassert_equal(msg1->rtr, msg2->rtr,
+	ztest_equal(msg1->rtr, msg2->rtr,
 		      "RTR bit does not match");
 
 	if (msg2->id_type == CAN_STANDARD_IDENTIFIER) {
-		zassert_equal(msg1->std_id | mask, msg2->std_id | mask,
+		ztest_equal(msg1->std_id | mask, msg2->std_id | mask,
 			      "ID does not match");
 	} else {
-		zassert_equal(msg1->ext_id | mask, msg2->ext_id | mask,
+		ztest_equal(msg1->ext_id | mask, msg2->ext_id | mask,
 			      "ID does not match");
 	}
 
-	zassert_equal(msg1->dlc, msg2->dlc,
+	ztest_equal(msg1->dlc, msg2->dlc,
 		      "DLC does not match");
 
 	cmp_res = memcmp(msg1->data, msg2->data, msg1->dlc);
-	zassert_equal(cmp_res, 0, "Received data differ");
+	ztest_equal(cmp_res, 0, "Received data differ");
 }
 
 static void tx_std_isr(u32_t error_flags, void *arg)
@@ -159,7 +159,7 @@ static void tx_std_isr(u32_t error_flags, void *arg)
 
 	k_sem_give(&tx_cb_sem);
 
-	zassert_equal(msg->std_id, TEST_CAN_STD_ID, "Arg does not match");
+	ztest_equal(msg->std_id, TEST_CAN_STD_ID, "Arg does not match");
 }
 
 static void tx_std_masked_isr(u32_t error_flags, void *arg)
@@ -168,7 +168,7 @@ static void tx_std_masked_isr(u32_t error_flags, void *arg)
 
 	k_sem_give(&tx_cb_sem);
 
-	zassert_equal(msg->std_id, TEST_CAN_STD_MASK_ID, "Arg does not match");
+	ztest_equal(msg->std_id, TEST_CAN_STD_MASK_ID, "Arg does not match");
 }
 
 static void tx_ext_isr(u32_t error_flags, void *arg)
@@ -177,7 +177,7 @@ static void tx_ext_isr(u32_t error_flags, void *arg)
 
 	k_sem_give(&tx_cb_sem);
 
-	zassert_equal(msg->ext_id, TEST_CAN_EXT_ID, "Arg does not match");
+	ztest_equal(msg->ext_id, TEST_CAN_EXT_ID, "Arg does not match");
 }
 
 static void tx_ext_masked_isr(u32_t error_flags, void *arg)
@@ -186,62 +186,62 @@ static void tx_ext_masked_isr(u32_t error_flags, void *arg)
 
 	k_sem_give(&tx_cb_sem);
 
-	zassert_equal(msg->ext_id, TEST_CAN_EXT_MASK_ID, "Arg does not match");
+	ztest_equal(msg->ext_id, TEST_CAN_EXT_MASK_ID, "Arg does not match");
 }
 
 static void rx_std_isr(struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_std_msg, 0);
-	zassert_equal_ptr(arg, &test_std_filter, "arg does not match");
+	ztest_equal_ptr(arg, &test_std_filter, "arg does not match");
 	k_sem_give(&rx_isr_sem);
 }
 
 static void rx_std_mask_isr(struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_std_msg, 0x0F);
-	zassert_equal_ptr(arg, &test_std_masked_filter, "arg does not match");
+	ztest_equal_ptr(arg, &test_std_masked_filter, "arg does not match");
 	k_sem_give(&rx_isr_sem);
 }
 
 static void rx_ext_isr(struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_ext_msg, 0);
-	zassert_equal_ptr(arg, &test_ext_filter, "arg does not match");
+	ztest_equal_ptr(arg, &test_ext_filter, "arg does not match");
 	k_sem_give(&rx_isr_sem);
 }
 
 static void rx_ext_mask_isr(struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_ext_msg, 0x0F);
-	zassert_equal_ptr(arg, &test_ext_masked_filter, "arg does not match");
+	ztest_equal_ptr(arg, &test_ext_masked_filter, "arg does not match");
 	k_sem_give(&rx_isr_sem);
 }
 
 static void rx_std_cb(struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_std_msg, 0);
-	zassert_equal_ptr(arg, &test_std_filter, "arg does not match");
+	ztest_equal_ptr(arg, &test_std_filter, "arg does not match");
 	k_sem_give(&rx_cb_sem);
 }
 
 static void rx_std_mask_cb(struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_std_msg, 0x0F);
-	zassert_equal_ptr(arg, &test_std_masked_filter, "arg does not match");
+	ztest_equal_ptr(arg, &test_std_masked_filter, "arg does not match");
 	k_sem_give(&rx_cb_sem);
 }
 
 static void rx_ext_cb(struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_ext_msg, 0);
-	zassert_equal_ptr(arg, &test_ext_filter, "arg does not match");
+	ztest_equal_ptr(arg, &test_ext_filter, "arg does not match");
 	k_sem_give(&rx_cb_sem);
 }
 
 static void rx_ext_mask_cb(struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_ext_msg, 0x0F);
-	zassert_equal_ptr(arg, &test_ext_masked_filter, "arg does not match");
+	ztest_equal_ptr(arg, &test_ext_masked_filter, "arg does not match");
 	k_sem_give(&rx_cb_sem);
 }
 
@@ -250,9 +250,9 @@ static void send_test_msg(struct device *can_dev, struct zcan_frame *msg)
 	int ret;
 
 	ret = can_send(can_dev, msg, TEST_SEND_TIMEOUT, NULL, NULL);
-	zassert_not_equal(ret, CAN_TX_ARB_LOST,
+	ztest_not_equal(ret, CAN_TX_ARB_LOST,
 			  "Arbitration though in loopback mode");
-	zassert_equal(ret, CAN_TX_OK, "Can't send a message. Err: %d", ret);
+	ztest_equal(ret, CAN_TX_OK, "Can't send a message. Err: %d", ret);
 }
 
 static void send_test_msg_nowait(struct device *can_dev, struct zcan_frame *msg)
@@ -277,9 +277,9 @@ static void send_test_msg_nowait(struct device *can_dev, struct zcan_frame *msg)
 		}
 	}
 
-	zassert_not_equal(ret, CAN_TX_ARB_LOST,
+	ztest_not_equal(ret, CAN_TX_ARB_LOST,
 			  "Arbitration though in loopback mode");
-	zassert_equal(ret, CAN_TX_OK, "Can't send a message. Err: %d", ret);
+	ztest_equal(ret, CAN_TX_OK, "Can't send a message. Err: %d", ret);
 }
 
 static inline int attach_msgq(struct device *can_dev,
@@ -288,9 +288,9 @@ static inline int attach_msgq(struct device *can_dev,
 	int filter_id;
 
 	filter_id = can_attach_msgq(can_dev, &can_msgq, filter);
-	zassert_not_equal(filter_id, CAN_NO_FREE_FILTER,
+	ztest_not_equal(filter_id, CAN_NO_FREE_FILTER,
 			  "Filter full even for a single one");
-	zassert_true((filter_id >= 0), "Negative filter number");
+	ztest_true((filter_id >= 0), "Negative filter number");
 
 	return filter_id;
 }
@@ -322,9 +322,9 @@ static inline int attach_workq(struct device *can_dev,
 		}
 	}
 
-	zassert_not_equal(filter_id, CAN_NO_FREE_FILTER,
+	ztest_not_equal(filter_id, CAN_NO_FREE_FILTER,
 			  "Filter full even for a single one");
-	zassert_true((filter_id >= 0), "Negative filter number");
+	ztest_true((filter_id >= 0), "Negative filter number");
 
 	return filter_id;
 }
@@ -354,9 +354,9 @@ static inline int attach_isr(struct device *can_dev,
 		}
 	}
 
-	zassert_not_equal(filter_id, CAN_NO_FREE_FILTER,
+	ztest_not_equal(filter_id, CAN_NO_FREE_FILTER,
 			  "Filter full even for a single one");
-	zassert_true((filter_id >= 0), "Negative filter number");
+	ztest_true((filter_id >= 0), "Negative filter number");
 
 	return filter_id;
 }
@@ -367,12 +367,12 @@ static void send_receive(const struct zcan_filter *filter, struct zcan_frame *ms
 	struct zcan_frame msg_buffer;
 	u32_t mask = 0U;
 
-	zassert_not_null(can_dev, "Device not not found");
+	ztest_not_null(can_dev, "Device not not found");
 
 	filter_id = attach_msgq(can_dev, filter);
 	send_test_msg(can_dev, msg);
 	ret = k_msgq_get(&can_msgq, &msg_buffer, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(ret, 0, "Receiving timeout");
+	ztest_equal(ret, 0, "Receiving timeout");
 
 	if (filter->id_type == CAN_STANDARD_IDENTIFIER) {
 		if (filter->std_id_mask != CAN_STD_ID_MASK) {
@@ -391,15 +391,15 @@ static void send_receive(const struct zcan_filter *filter, struct zcan_frame *ms
 	filter_id = attach_isr(can_dev, filter);
 	send_test_msg_nowait(can_dev, msg);
 	ret = k_sem_take(&rx_isr_sem, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(ret, 0, "Receiving timeout");
+	ztest_equal(ret, 0, "Receiving timeout");
 	ret = k_sem_take(&tx_cb_sem, TEST_SEND_TIMEOUT);
-	zassert_equal(ret, 0, "Missing TX callback");
+	ztest_equal(ret, 0, "Missing TX callback");
 	can_detach(can_dev, filter_id);
 
 	filter_id = attach_workq(can_dev, filter);
 	send_test_msg(can_dev, msg);
 	ret = k_sem_take(&rx_cb_sem, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(ret, 0, "Receiving timeout");
+	ztest_equal(ret, 0, "Receiving timeout");
 	can_detach(can_dev, filter_id);
 }
 
@@ -413,7 +413,7 @@ static void test_set_loopback(void)
 	int ret;
 
 	ret = can_configure(can_dev, CAN_LOOPBACK_MODE, 0);
-	zassert_equal(ret, 0, "Can't set loopback-mode. Err: %d", ret);
+	ztest_equal(ret, 0, "Can't set loopback-mode. Err: %d", ret);
 }
 
 /*
@@ -422,7 +422,7 @@ static void test_set_loopback(void)
  */
 static void test_send_and_forget(void)
 {
-	zassert_not_null(can_dev, "Device not not found");
+	ztest_not_null(can_dev, "Device not not found");
 
 	send_test_msg(can_dev, &test_std_msg);
 }
@@ -471,7 +471,7 @@ static void test_receive_timeout(void)
 	filter_id = attach_msgq(can_dev, &test_std_filter);
 
 	ret = k_msgq_get(&can_msgq, &msg, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(ret, -EAGAIN, "Got a message without sending it");
+	ztest_equal(ret, -EAGAIN, "Got a message without sending it");
 
 	can_detach(can_dev, filter_id);
 }
@@ -488,7 +488,7 @@ static void test_send_callback(void)
 	send_test_msg_nowait(can_dev, &test_std_msg);
 
 	ret = k_sem_take(&tx_cb_sem, TEST_SEND_TIMEOUT);
-	zassert_equal(ret, 0, "Missing TX callback");
+	ztest_equal(ret, 0, "Missing TX callback");
 }
 
 /*
@@ -553,7 +553,7 @@ void test_send_receive_buffer(void)
 
 	for (i = 0; i < CONFIG_CAN_WORKQ_FRAMES_BUF_CNT; i++) {
 		ret = k_sem_take(&rx_cb_sem, TEST_RECEIVE_TIMEOUT);
-		zassert_equal(ret, 0, "Receiving timeout");
+		ztest_equal(ret, 0, "Receiving timeout");
 	}
 
 	for (i = 0; i < CONFIG_CAN_WORKQ_FRAMES_BUF_CNT; i++) {
@@ -562,7 +562,7 @@ void test_send_receive_buffer(void)
 
 	for (i = 0; i < CONFIG_CAN_WORKQ_FRAMES_BUF_CNT; i++) {
 		ret = k_sem_take(&rx_cb_sem, TEST_RECEIVE_TIMEOUT);
-		zassert_equal(ret, 0, "Receiving timeout");
+		ztest_equal(ret, 0, "Receiving timeout");
 	}
 
 	can_detach(can_dev, filter_id);
@@ -583,7 +583,7 @@ static void test_send_receive_wrong_id(void)
 	send_test_msg(can_dev, &test_std_mask_msg);
 
 	ret = k_msgq_get(&can_msgq, &msg_buffer, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(ret, -EAGAIN,
+	ztest_equal(ret, -EAGAIN,
 		      "Got a message that should not pass the filter");
 
 	can_detach(can_dev, filter_id);
@@ -600,7 +600,7 @@ static void test_send_invalid_dlc(void)
 	frame.dlc = CAN_MAX_DLC + 1;
 
 	ret = can_send(can_dev, &frame, TEST_SEND_TIMEOUT, tx_std_isr, NULL);
-	zassert_equal(ret, CAN_TX_EINVAL,
+	ztest_equal(ret, CAN_TX_EINVAL,
 		      "ret [%d] not equal to %d", ret, CAN_TX_EINVAL);
 }
 
@@ -610,7 +610,7 @@ void test_main(void)
 	k_sem_init(&rx_cb_sem, 0, INT_MAX);
 	k_sem_init(&tx_cb_sem, 0, 1);
 	can_dev = device_get_binding(CAN_DEVICE_NAME);
-	zassert_not_null(can_dev, "Device not found");
+	ztest_not_null(can_dev, "Device not found");
 
 	ztest_test_suite(can_driver,
 			 ztest_unit_test(test_set_loopback),

--- a/tests/drivers/can/stm32/src/main.c
+++ b/tests/drivers/can/stm32/src/main.c
@@ -88,25 +88,25 @@ static inline void check_msg(struct zcan_frame *msg1, struct zcan_frame *msg2)
 {
 	int cmp_res;
 
-	zassert_equal(msg1->id_type, msg2->id_type,
+	ztest_equal(msg1->id_type, msg2->id_type,
 		      "ID type does not match");
 
-	zassert_equal(msg1->rtr, msg2->rtr,
+	ztest_equal(msg1->rtr, msg2->rtr,
 		      "RTR bit does not match");
 
 	if (msg2->id_type == CAN_STANDARD_IDENTIFIER) {
-		zassert_equal(msg1->std_id, msg2->std_id,
+		ztest_equal(msg1->std_id, msg2->std_id,
 			      "ID does not match");
 	} else {
-		zassert_equal(msg1->ext_id, msg2->ext_id,
+		ztest_equal(msg1->ext_id, msg2->ext_id,
 			      "ID does not match");
 	}
 
-	zassert_equal(msg1->dlc, msg2->dlc,
+	ztest_equal(msg1->dlc, msg2->dlc,
 		      "DLC does not match");
 
 	cmp_res = memcmp(msg1->data, msg2->data, msg1->dlc);
-	zassert_equal(cmp_res, 0, "Received data differ");
+	ztest_equal(cmp_res, 0, "Received data differ");
 }
 
 static void send_test_msg(struct device *can_dev, struct zcan_frame *msg)
@@ -114,9 +114,9 @@ static void send_test_msg(struct device *can_dev, struct zcan_frame *msg)
 	int ret;
 
 	ret = can_send(can_dev, msg, TEST_SEND_TIMEOUT, NULL, NULL);
-	zassert_not_equal(ret, CAN_TX_ARB_LOST,
+	ztest_not_equal(ret, CAN_TX_ARB_LOST,
 			  "Arbitration though in loopback mode");
-	zassert_equal(ret, CAN_TX_OK, "Can't send a message. Err: %d", ret);
+	ztest_equal(ret, CAN_TX_OK, "Can't send a message. Err: %d", ret);
 }
 
 /*
@@ -135,40 +135,40 @@ static void test_filter_handling(void)
 	ret = can_configure(can_dev, CAN_LOOPBACK_MODE, 0);
 
 	filter_id_1 = can_attach_msgq(can_dev, &can_msgq, &test_ext_masked_filter);
-	zassert_not_equal(filter_id_1, CAN_NO_FREE_FILTER,
+	ztest_not_equal(filter_id_1, CAN_NO_FREE_FILTER,
 			  "Filter full even for a single one");
-	zassert_true((filter_id_1 >= 0), "Negative filter number");
+	ztest_true((filter_id_1 >= 0), "Negative filter number");
 
 	filter_id_2 = can_attach_msgq(can_dev, &can_msgq, &test_std_filter);
-	zassert_not_equal(filter_id_2, CAN_NO_FREE_FILTER,
+	ztest_not_equal(filter_id_2, CAN_NO_FREE_FILTER,
 			  "Filter full when attaching the second one");
-	zassert_true((filter_id_2 >= 0), "Negative filter number");
+	ztest_true((filter_id_2 >= 0), "Negative filter number");
 
 	can_detach(can_dev, filter_id_1);
 	filter_id_1 = can_attach_msgq(can_dev, &can_msgq, &test_std_some_filter);
-	zassert_not_equal(filter_id_1, CAN_NO_FREE_FILTER,
+	ztest_not_equal(filter_id_1, CAN_NO_FREE_FILTER,
 			  "Filter full when overriding the first one");
-	zassert_true((filter_id_1 >= 0), "Negative filter number");
+	ztest_true((filter_id_1 >= 0), "Negative filter number");
 
 	send_test_msg(can_dev, &test_std_msg);
 
 	ret = k_msgq_get(&can_msgq, &msg_buffer, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(ret, 0, "Receiving timeout");
+	ztest_equal(ret, 0, "Receiving timeout");
 	check_msg(&test_std_msg, &msg_buffer);
 
 	ret = k_msgq_get(&can_msgq, &msg_buffer, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(ret, -EAGAIN, "There is more than one msg in the queue");
+	ztest_equal(ret, -EAGAIN, "There is more than one msg in the queue");
 
 	can_detach(can_dev, filter_id_1);
 	filter_id_1 = can_attach_msgq(can_dev, &can_msgq, &test_ext_filter);
-	zassert_not_equal(filter_id_1, CAN_NO_FREE_FILTER,
+	ztest_not_equal(filter_id_1, CAN_NO_FREE_FILTER,
 			  "Filter full when overriding the first one");
-	zassert_true((filter_id_1 >= 0), "Negative filter number");
+	ztest_true((filter_id_1 >= 0), "Negative filter number");
 
 	send_test_msg(can_dev, &test_std_msg);
 
 	ret = k_msgq_get(&can_msgq, &msg_buffer, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(ret, 0, "Receiving timeout");
+	ztest_equal(ret, 0, "Receiving timeout");
 	check_msg(&test_std_msg, &msg_buffer);
 
 	can_detach(can_dev, filter_id_1);

--- a/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
+++ b/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
@@ -111,32 +111,32 @@ static void test_on_off_status_instance(const char *dev_name,
 	enum clock_control_status status;
 	int err;
 
-	zassert_true(dev != NULL, "%s: Unknown device", dev_name);
+	ztest_true(dev != NULL, "%s: Unknown device", dev_name);
 
 	status = clock_control_get_status(dev, subsys);
-	zassert_equal(CLOCK_CONTROL_STATUS_OFF, status,
+	ztest_equal(CLOCK_CONTROL_STATUS_OFF, status,
 			"%s: Unexpected status (%d)", dev_name, status);
 
 
 	err = clock_control_on(dev, subsys);
-	zassert_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
+	ztest_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
 
 	status = clock_control_get_status(dev, subsys);
-	zassert_true((status == CLOCK_CONTROL_STATUS_STARTING) ||
+	ztest_true((status == CLOCK_CONTROL_STATUS_STARTING) ||
 			(status == CLOCK_CONTROL_STATUS_ON),
 			"%s: Unexpected status (%d)", dev_name, status);
 
 	k_busy_wait(startup_us);
 
 	status = clock_control_get_status(dev, subsys);
-	zassert_equal(CLOCK_CONTROL_STATUS_ON, status,
+	ztest_equal(CLOCK_CONTROL_STATUS_ON, status,
 			"%s: Unexpected status (%d)", dev_name, status);
 
 	err = clock_control_off(dev, subsys);
-	zassert_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
+	ztest_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
 
 	status = clock_control_get_status(dev, subsys);
-	zassert_equal(CLOCK_CONTROL_STATUS_OFF, status,
+	ztest_equal(CLOCK_CONTROL_STATUS_OFF, status,
 			"%s: Unexpected status (%d)", dev_name, status);
 }
 
@@ -159,30 +159,30 @@ static void test_multiple_users_instance(const char *dev_name,
 	int err;
 
 	status = clock_control_get_status(dev, subsys);
-	zassert_equal(CLOCK_CONTROL_STATUS_OFF, status,
+	ztest_equal(CLOCK_CONTROL_STATUS_OFF, status,
 			"%s: Unexpected status (%d)", dev_name, status);
 
 	for (int i = 0; i < users; i++) {
 		err = clock_control_on(dev, subsys);
-		zassert_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
+		ztest_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
 	}
 
 	status = clock_control_get_status(dev, subsys);
-	zassert_true((status == CLOCK_CONTROL_STATUS_STARTING) ||
+	ztest_true((status == CLOCK_CONTROL_STATUS_STARTING) ||
 			(status == CLOCK_CONTROL_STATUS_ON),
 			"%s: Unexpected status (%d)", dev_name, status);
 
 	for (int i = 0; i < users; i++) {
 		err = clock_control_off(dev, subsys);
-		zassert_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
+		ztest_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
 	}
 
 	status = clock_control_get_status(dev, subsys);
-	zassert_true(status == CLOCK_CONTROL_STATUS_OFF,
+	ztest_true(status == CLOCK_CONTROL_STATUS_OFF,
 			"%s: Unexpected status (%d)", dev_name, status);
 
 	err = clock_control_off(dev, subsys);
-	zassert_equal(-EALREADY, err, "%s: Unexpected err (%d)", dev_name, err);
+	ztest_equal(-EALREADY, err, "%s: Unexpected err (%d)", dev_name, err);
 }
 
 static void test_multiple_users(void)
@@ -234,20 +234,20 @@ static void test_async_on_instance(const char *dev_name,
 	};
 
 	status = clock_control_get_status(dev, subsys);
-	zassert_equal(CLOCK_CONTROL_STATUS_OFF, status,
+	ztest_equal(CLOCK_CONTROL_STATUS_OFF, status,
 			"%s: Unexpected status (%d)", dev_name, status);
 
 	err = clock_control_async_on(dev, subsys, &data1);
-	zassert_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
+	ztest_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
 
 	err = clock_control_async_on(dev, subsys, &data2);
-	zassert_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
+	ztest_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
 
 	/* wait for clock started. */
 	k_busy_wait(startup_us);
 
-	zassert_true(executed1, "%s: Expected flag to be true", dev_name);
-	zassert_true(executed2, "%s: Expected flag to be true", dev_name);
+	ztest_true(executed1, "%s: Expected flag to be true", dev_name);
+	ztest_true(executed2, "%s: Expected flag to be true", dev_name);
 }
 
 static void test_async_on(void)
@@ -274,22 +274,22 @@ static void test_async_on_stopped_on_instance(const char *dev_name,
 	};
 
 	status = clock_control_get_status(dev, subsys);
-	zassert_equal(CLOCK_CONTROL_STATUS_OFF, status,
+	ztest_equal(CLOCK_CONTROL_STATUS_OFF, status,
 			"%s: Unexpected status (%d)", dev_name, status);
 
 	/* lock to prevent clock interrupt for fast starting clocks.*/
 	key = irq_lock();
 	err = clock_control_async_on(dev, subsys, &data1);
-	zassert_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
+	ztest_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
 
 	err = clock_control_off(dev, subsys);
-	zassert_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
+	ztest_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
 
 	irq_unlock(key);
 
 	k_busy_wait(10000);
 
-	zassert_false(executed1, "%s: Expected flag to be false", dev_name);
+	ztest_false(executed1, "%s: Expected flag to be false", dev_name);
 }
 
 static void test_async_on_stopped(void)
@@ -315,23 +315,23 @@ static void test_immediate_cb_when_clock_on_on_instance(const char *dev_name,
 	};
 
 	status = clock_control_get_status(dev, subsys);
-	zassert_equal(CLOCK_CONTROL_STATUS_OFF, status,
+	ztest_equal(CLOCK_CONTROL_STATUS_OFF, status,
 			"%s: Unexpected status (%d)", dev_name, status);
 
 	err = clock_control_on(dev, subsys);
-	zassert_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
+	ztest_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
 
 	/* wait for clock started. */
 	k_busy_wait(startup_us);
 
 	status = clock_control_get_status(dev, subsys);
-	zassert_equal(CLOCK_CONTROL_STATUS_ON, status,
+	ztest_equal(CLOCK_CONTROL_STATUS_ON, status,
 			"%s: Unexpected status (%d)", dev_name, status);
 
 	err = clock_control_async_on(dev, subsys, &data1);
-	zassert_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
+	ztest_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
 
-	zassert_true(executed1, "%s: Expected flag to be false", dev_name);
+	ztest_true(executed1, "%s: Expected flag to be false", dev_name);
 }
 
 static void test_immediate_cb_when_clock_on(void)

--- a/tests/drivers/clock_control/nrf_clock_calibration/src/test_nrf_clock_calibration.c
+++ b/tests/drivers/clock_control/nrf_clock_calibration/src/test_nrf_clock_calibration.c
@@ -57,10 +57,10 @@ static void test_calibration(u32_t exp_cal, u32_t exp_skip,
 	cal_cnt = z_nrf_clock_calibration_count() - cal_cnt;
 	skip_cnt = z_nrf_clock_calibration_skips_count() - skip_cnt;
 
-	zassert_equal(cal_cnt, exp_cal,
+	ztest_equal(cal_cnt, exp_cal,
 			"%d: Unexpected number of calibrations (%d, exp:%d)",
 			line, cal_cnt, exp_cal);
-	zassert_equal(skip_cnt, exp_skip,
+	ztest_equal(skip_cnt, exp_skip,
 			"%d: Unexpected number of skips (%d, exp:%d)",
 			line, skip_cnt, exp_skip);
 }

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -101,11 +101,11 @@ static void counter_tear_down_instance(const char *dev_name)
 		err = counter_set_top_value(dev, &top_cfg);
 
 	}
-	zassert_true((err == 0) || (err == -ENOTSUP),
+	ztest_true((err == 0) || (err == -ENOTSUP),
 			"%s: Setting top value to default failed", dev_name);
 
 	err = counter_stop(dev);
-	zassert_equal(0, err, "%s: Counter failed to stop", dev_name);
+	ztest_equal(0, err, "%s: Counter failed to stop", dev_name);
 
 }
 
@@ -151,7 +151,7 @@ static bool set_top_value_capable(const char *dev_name)
 
 static void top_handler(struct device *dev, void *user_data)
 {
-	zassert_true(user_data == exp_user_data,
+	ztest_true(user_data == exp_user_data,
 			"%s: Unexpected callback", dev->config->name);
 	k_sem_give(&top_cnt_sem);
 }
@@ -173,12 +173,12 @@ void test_set_top_value_with_alarm_instance(const char *dev_name)
 	dev = device_get_binding(dev_name);
 	top_cfg.ticks = counter_us_to_ticks(dev, COUNTER_PERIOD_US);
 	err = counter_start(dev);
-	zassert_equal(0, err, "%s: Counter failed to start", dev_name);
+	ztest_equal(0, err, "%s: Counter failed to start", dev_name);
 
 	k_busy_wait(5000);
 
 	err = counter_get_value(dev, &cnt);
-	zassert_true(err == 0, "%s: Counter read failed (err: %d)", dev_name,
+	ztest_true(err == 0, "%s: Counter read failed (err: %d)", dev_name,
 		     err);
 	if (counter_is_counting_up(dev)) {
 		err = (cnt > 0) ? 0 : 1;
@@ -186,16 +186,16 @@ void test_set_top_value_with_alarm_instance(const char *dev_name)
 		top_cnt = counter_get_top_value(dev);
 		err = (cnt < top_cnt) ? 0 : 1;
 	}
-	zassert_true(err == 0, "%s: Counter should progress", dev_name);
+	ztest_true(err == 0, "%s: Counter should progress", dev_name);
 
 	err = counter_set_top_value(dev, &top_cfg);
-	zassert_equal(0, err, "%s: Counter failed to set top value (err: %d)",
+	ztest_equal(0, err, "%s: Counter failed to set top value (err: %d)",
 			dev_name, err);
 
 	k_busy_wait(5.2*COUNTER_PERIOD_US);
 
 	top_cnt = k_sem_count_get(&top_cnt_sem);
-	zassert_true(top_cnt == 5U,
+	ztest_true(top_cnt == 5U,
 			"%s: Unexpected number of turnarounds (%d).",
 			dev_name, top_cnt);
 }
@@ -221,12 +221,12 @@ void test_set_top_value_without_alarm_instance(const char *dev_name)
 	dev = device_get_binding(dev_name);
 	top_cfg.ticks = counter_us_to_ticks(dev, COUNTER_PERIOD_US);
 	err = counter_start(dev);
-	zassert_equal(0, err, "%s: Counter failed to start", dev_name);
+	ztest_equal(0, err, "%s: Counter failed to start", dev_name);
 
 	k_busy_wait(5000);
 
 	err = counter_get_value(dev, &cnt);
-	zassert_true(err == 0, "%s: Counter read failed (err: %d)", dev_name,
+	ztest_true(err == 0, "%s: Counter read failed (err: %d)", dev_name,
 		     err);
 	if (counter_is_counting_up(dev)) {
 		err = (cnt > 0) ? 0 : 1;
@@ -234,13 +234,13 @@ void test_set_top_value_without_alarm_instance(const char *dev_name)
 		top_cnt = counter_get_top_value(dev);
 		err = (cnt < top_cnt) ? 0 : 1;
 	}
-	zassert_true(err == 0, "%s: Counter should progress", dev_name);
+	ztest_true(err == 0, "%s: Counter should progress", dev_name);
 
 	err = counter_set_top_value(dev, &top_cfg);
-	zassert_equal(0, err, "%s: Counter failed to set top value (err: %d)",
+	ztest_equal(0, err, "%s: Counter failed to set top value (err: %d)",
 			dev_name, err);
 
-	zassert_true(counter_get_top_value(dev) == top_cfg.ticks,
+	ztest_true(counter_get_top_value(dev) == top_cfg.ticks,
 			"%s: new top value not in use.",
 			dev_name);
 }
@@ -258,25 +258,25 @@ static void alarm_handler(struct device *dev, u8_t chan_id, u32_t counter,
 	int err;
 
 	err = counter_get_value(dev, &now);
-	zassert_true(err == 0, "%s: Counter read failed (err: %d)",
+	ztest_true(err == 0, "%s: Counter read failed (err: %d)",
 		     dev->config->name, err);
 
 	if (counter_is_counting_up(dev)) {
-		zassert_true(now >= counter,
+		ztest_true(now >= counter,
 			"%s: Alarm (%d) too early now: %d (counting up).",
 			dev->config->name, counter, now);
 	} else {
-		zassert_true(now <= counter,
+		ztest_true(now <= counter,
 			"%s: Alarm (%d) too early now: %d (counting down).",
 			dev->config->name, counter, now);
 	}
 
 	if (user_data) {
-		zassert_true(&alarm_cfg == user_data,
+		ztest_true(&alarm_cfg == user_data,
 			"%s: Unexpected callback", dev->config->name);
 	}
 
-	zassert_true(k_is_in_isr(), "%s: Expected interrupt context",
+	ztest_true(k_is_in_isr(), "%s: Expected interrupt context",
 			dev->config->name);
 	k_sem_give(&alarm_cnt_sem);
 }
@@ -309,17 +309,17 @@ void test_single_shot_alarm_instance(const char *dev_name, bool set_top)
 	}
 
 	err = counter_start(dev);
-	zassert_equal(0, err, "%s: Counter failed to start", dev_name);
+	ztest_equal(0, err, "%s: Counter failed to start", dev_name);
 
 	if (set_top) {
 		err = counter_set_top_value(dev, &top_cfg);
 
-		zassert_equal(0, err,
+		ztest_equal(0, err,
 			     "%s: Counter failed to set top value", dev_name);
 
 		alarm_cfg.ticks = ticks + 1;
 		err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
-		zassert_equal(-EINVAL, err,
+		ztest_equal(-EINVAL, err,
 			      "%s: Counter should return error because ticks"
 			      " exceeded the limit set alarm", dev_name);
 		alarm_cfg.ticks = ticks - 1;
@@ -327,22 +327,22 @@ void test_single_shot_alarm_instance(const char *dev_name, bool set_top)
 
 	alarm_cfg.ticks = ticks;
 	err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
-	zassert_equal(0, err, "%s: Counter set alarm failed (err: %d)",
+	ztest_equal(0, err, "%s: Counter set alarm failed (err: %d)",
 			dev_name, err);
 
 	k_busy_wait(2*(u32_t)counter_ticks_to_us(dev, ticks));
 
 	alarm_cnt = k_sem_count_get(&alarm_cnt_sem);
-	zassert_equal(1, alarm_cnt,
+	ztest_equal(1, alarm_cnt,
 			"%s: Expecting alarm callback", dev_name);
 
 	k_busy_wait(1.5*counter_ticks_to_us(dev, ticks));
 	alarm_cnt = k_sem_count_get(&alarm_cnt_sem);
-	zassert_equal(1, alarm_cnt,
+	ztest_equal(1, alarm_cnt,
 			"%s: Expecting alarm callback", dev_name);
 
 	err = counter_cancel_channel_alarm(dev, 0);
-	zassert_equal(0, err, "%s: Counter disabling alarm failed", dev_name);
+	ztest_equal(0, err, "%s: Counter disabling alarm failed", dev_name);
 
 	top_cfg.ticks = counter_get_max_top_value(dev);
 	top_cfg.callback = NULL;
@@ -354,11 +354,11 @@ void test_single_shot_alarm_instance(const char *dev_name, bool set_top)
 		err = counter_set_top_value(dev, &top_cfg);
 
 	}
-	zassert_true((err == 0) || (err == -ENOTSUP),
+	ztest_true((err == 0) || (err == -ENOTSUP),
 			"%s: Setting top value to default failed", dev_name);
 
 	err = counter_stop(dev);
-	zassert_equal(0, err, "%s: Counter failed to stop", dev_name);
+	ztest_equal(0, err, "%s: Counter failed to stop", dev_name);
 }
 
 void test_single_shot_alarm_notop_instance(const char *dev_name)
@@ -445,39 +445,39 @@ void test_multiple_alarms_instance(const char *dev_name)
 	}
 
 	err = counter_start(dev);
-	zassert_equal(0, err, "%s: Counter failed to start", dev_name);
+	ztest_equal(0, err, "%s: Counter failed to start", dev_name);
 
 	err = counter_set_top_value(dev, &top_cfg);
-	zassert_equal(0, err,
+	ztest_equal(0, err,
 			"%s: Counter failed to set top value", dev_name);
 
 	k_busy_wait(3*(u32_t)counter_ticks_to_us(dev, alarm_cfg.ticks));
 
 	err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
-	zassert_equal(0, err, "%s: Counter set alarm failed", dev_name);
+	ztest_equal(0, err, "%s: Counter set alarm failed", dev_name);
 
 	err = counter_set_channel_alarm(dev, 1, &alarm_cfg2);
-	zassert_equal(0, err, "%s: Counter set alarm failed", dev_name);
+	ztest_equal(0, err, "%s: Counter set alarm failed", dev_name);
 
 	k_busy_wait(1.2*counter_ticks_to_us(dev, ticks * 2U));
 	alarm_cnt = k_sem_count_get(&alarm_cnt_sem);
-	zassert_equal(2, alarm_cnt,
+	ztest_equal(2, alarm_cnt,
 			"%s: Invalid number of callbacks %d (expected: %d)",
 			dev_name, alarm_cnt, 2);
 
-	zassert_equal(&alarm_cfg2, clbk_data[0],
+	ztest_equal(&alarm_cfg2, clbk_data[0],
 			"%s: Expected different order or callbacks",
 			dev_name);
-	zassert_equal(&alarm_cfg, clbk_data[1],
+	ztest_equal(&alarm_cfg, clbk_data[1],
 			"%s: Expected different order or callbacks",
 			dev_name);
 
 	/* tear down */
 	err = counter_cancel_channel_alarm(dev, 0);
-	zassert_equal(0, err, "%s: Counter disabling alarm failed", dev_name);
+	ztest_equal(0, err, "%s: Counter disabling alarm failed", dev_name);
 
 	err = counter_cancel_channel_alarm(dev, 1);
-	zassert_equal(0, err, "%s: Counter disabling alarm failed", dev_name);
+	ztest_equal(0, err, "%s: Counter disabling alarm failed", dev_name);
 }
 
 static bool multiple_channel_alarm_capable(const char *dev_name)
@@ -513,7 +513,7 @@ void test_all_channels_instance(const char *dev_name)
 	alarm_cfgs.user_data = NULL;
 
 	err = counter_start(dev);
-	zassert_equal(0, err, "%s: Counter failed to start", dev_name);
+	ztest_equal(0, err, "%s: Counter failed to start", dev_name);
 
 	for (int i = 0; i < n; i++) {
 		err = counter_set_channel_alarm(dev, i, &alarm_cfgs);
@@ -522,25 +522,25 @@ void test_all_channels_instance(const char *dev_name)
 		} else if (err == -ENOTSUP) {
 			limit_reached = true;
 		} else {
-			zassert_equal(0, 1,
+			ztest_equal(0, 1,
 			   "%s: Unexpected error on setting alarm", dev_name);
 		}
 	}
 
 	k_busy_wait(1.5*counter_ticks_to_us(dev, ticks));
 	alarm_cnt = k_sem_count_get(&alarm_cnt_sem);
-	zassert_equal(nchan, alarm_cnt,
+	ztest_equal(nchan, alarm_cnt,
 			"%s: Expecting alarm callback", dev_name);
 
 	for (int i = 0; i < nchan; i++) {
 		err = counter_cancel_channel_alarm(dev, i);
-		zassert_equal(0, err,
+		ztest_equal(0, err,
 			"%s: Unexpected error on disabling alarm", dev_name);
 	}
 
 	for (int i = nchan; i < n; i++) {
 		err = counter_cancel_channel_alarm(dev, i);
-		zassert_equal(-ENOTSUP, err,
+		ztest_equal(-ENOTSUP, err,
 			"%s: Unexpected error on disabling alarm", dev_name);
 	}
 }
@@ -571,38 +571,38 @@ void test_late_alarm_instance(const char *dev_name)
 
 	err = counter_set_guard_period(dev, guard,
 					COUNTER_GUARD_PERIOD_LATE_TO_SET);
-	zassert_equal(0, err, "%s: Unexcepted error", dev_name);
+	ztest_equal(0, err, "%s: Unexcepted error", dev_name);
 
 	err = counter_start(dev);
-	zassert_equal(0, err, "%s: Unexcepted error", dev_name);
+	ztest_equal(0, err, "%s: Unexcepted error", dev_name);
 
 	k_busy_wait(2*tick_us);
 
 	alarm_cfg.ticks = 0;
 	err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
-	zassert_equal(-ETIME, err, "%s: Unexpected error (%d)", dev_name, err);
+	ztest_equal(-ETIME, err, "%s: Unexpected error (%d)", dev_name, err);
 
 	/* wait couple of ticks */
 	k_busy_wait(5*tick_us);
 
 	alarm_cnt = k_sem_count_get(&alarm_cnt_sem);
-	zassert_equal(1, alarm_cnt,
+	ztest_equal(1, alarm_cnt,
 			"%s: Expected %d callbacks, got %d\n",
 			dev_name, 1, alarm_cnt);
 
 	err = counter_get_value(dev, &(alarm_cfg.ticks));
-	zassert_true(err == 0, "%s: Counter read failed (err: %d)", dev_name,
+	ztest_true(err == 0, "%s: Counter read failed (err: %d)", dev_name,
 		     err);
 
 	err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
-	zassert_equal(-ETIME, err, "%s: Failed to set an alarm (err: %d)",
+	ztest_equal(-ETIME, err, "%s: Failed to set an alarm (err: %d)",
 			dev_name, err);
 
 	/* wait to ensure that tick+1 timeout will expire. */
 	k_busy_wait(3*tick_us);
 
 	alarm_cnt = k_sem_count_get(&alarm_cnt_sem);
-	zassert_equal(2, alarm_cnt,
+	ztest_equal(2, alarm_cnt,
 			"%s: Expected %d callbacks, got %d\n",
 			dev_name, 2, alarm_cnt);
 }
@@ -621,25 +621,25 @@ void test_late_alarm_error_instance(const char *dev_name)
 
 	err = counter_set_guard_period(dev, guard,
 					COUNTER_GUARD_PERIOD_LATE_TO_SET);
-	zassert_equal(0, err, "%s: Unexcepted error", dev_name);
+	ztest_equal(0, err, "%s: Unexcepted error", dev_name);
 
 	err = counter_start(dev);
-	zassert_equal(0, err, "%s: Unexcepted error", dev_name);
+	ztest_equal(0, err, "%s: Unexcepted error", dev_name);
 
 	k_busy_wait(2*tick_us);
 
 	alarm_cfg.ticks = 0;
 	err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
-	zassert_equal(-ETIME, err,
+	ztest_equal(-ETIME, err,
 			"%s: Failed to detect late setting (err: %d)",
 			dev_name, err);
 
 	err = counter_get_value(dev, &(alarm_cfg.ticks));
-	zassert_true(err == 0, "%s: Counter read failed (err: %d)", dev_name,
+	ztest_true(err == 0, "%s: Counter read failed (err: %d)", dev_name,
 		     err);
 
 	err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
-	zassert_equal(-ETIME, err,
+	ztest_equal(-ETIME, err,
 			"%s: Counter failed to detect late setting (err: %d)",
 			dev_name, err);
 }
@@ -683,13 +683,13 @@ static void test_short_relative_alarm_instance(const char *dev_name)
 	};
 
 	err = counter_start(dev);
-	zassert_equal(0, err, "%s: Unexcepted error", dev_name);
+	ztest_equal(0, err, "%s: Unexcepted error", dev_name);
 
 	alarm_cfg.ticks = 1;
 
 	for (int i = 0; i < 100; ++i) {
 		err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
-		zassert_equal(0, err,
+		ztest_equal(0, err,
 				"%s: Failed to set an alarm (err: %d)",
 				dev_name, err);
 
@@ -697,7 +697,7 @@ static void test_short_relative_alarm_instance(const char *dev_name)
 		k_busy_wait(3*tick_us);
 
 		alarm_cnt = k_sem_count_get(&alarm_cnt_sem);
-		zassert_equal(i + 1, alarm_cnt,
+		ztest_equal(i + 1, alarm_cnt,
 				"%s: Expected %d callbacks, got %d\n",
 				dev_name, i + 1, alarm_cnt);
 	}
@@ -778,39 +778,39 @@ static void test_cancelled_alarm_does_not_expire_instance(const char *dev_name)
 	};
 
 	err = counter_start(dev);
-	zassert_equal(0, err, "%s: Unexcepted error", dev_name);
+	ztest_equal(0, err, "%s: Unexcepted error", dev_name);
 
 
 	for (int i = 0; i < us/2; ++i) {
 		err = counter_get_value(dev, &(alarm_cfg.ticks));
-		zassert_true(err == 0, "%s: Counter read failed (err: %d)",
+		ztest_true(err == 0, "%s: Counter read failed (err: %d)",
 			     dev_name, err);
 
 		alarm_cfg.ticks	+= ticks;
 		err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
-		zassert_equal(0, err, "%s: Failed to set an alarm (err: %d)",
+		ztest_equal(0, err, "%s: Failed to set an alarm (err: %d)",
 				dev_name, err);
 
 		err = counter_cancel_channel_alarm(dev, 0);
-		zassert_equal(0, err, "%s: Failed to cancel an alarm (err: %d)",
+		ztest_equal(0, err, "%s: Failed to cancel an alarm (err: %d)",
 				dev_name, err);
 
 		k_busy_wait(us/2 + i);
 
 		alarm_cfg.ticks = alarm_cfg.ticks + 2*alarm_cfg.ticks;
 		err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
-		zassert_equal(0, err, "%s: Failed to set an alarm (err: %d)",
+		ztest_equal(0, err, "%s: Failed to set an alarm (err: %d)",
 				dev_name, err);
 
 		/* wait to ensure that tick+1 timeout will expire. */
 		k_busy_wait(us);
 
 		err = counter_cancel_channel_alarm(dev, 0);
-		zassert_equal(0, err, "%s: Failed to cancel an alarm (err: %d)",
+		ztest_equal(0, err, "%s: Failed to cancel an alarm (err: %d)",
 					dev_name, err);
 
 		alarm_cnt = k_sem_count_get(&alarm_cnt_sem);
-		zassert_equal(0, alarm_cnt,
+		ztest_equal(0, alarm_cnt,
 				"%s: Expected %d callbacks, got %d\n",
 				dev_name, 0, alarm_cnt);
 	}
@@ -890,7 +890,7 @@ void test_main(void)
 
 	for (i = 0; i < ARRAY_SIZE(devices); i++) {
 		dev = device_get_binding(devices[i]);
-		zassert_not_null(dev, "Unable to get counter device %s",
+		ztest_not_null(dev, "Unable to get counter device %s",
 				 devices[i]);
 		k_object_access_grant(dev, k_current_get());
 	}

--- a/tests/drivers/counter/counter_cmos/src/main.c
+++ b/tests/drivers/counter/counter_cmos/src/main.c
@@ -22,19 +22,19 @@ void test_cmos_rate(void)
 	int err;
 
 	cmos = device_get_binding("CMOS");
-	zassert_true(cmos != NULL, "can't find CMOS counter device");
+	ztest_true(cmos != NULL, "can't find CMOS counter device");
 
 	err = counter_get_value(cmos, &start);
-	zassert_true(err == 0, "failed to read CMOS counter device");
+	ztest_true(err == 0, "failed to read CMOS counter device");
 
 	k_sleep(DELAY_MS);
 
 	err = counter_get_value(cmos, &elapsed);
-	zassert_true(err == 0, "failed to read CMOS counter device");
+	ztest_true(err == 0, "failed to read CMOS counter device");
 	elapsed -= start;
 
-	zassert_true(elapsed >= MIN_BOUND, "busted minimum bound");
-	zassert_true(elapsed <= MAX_BOUND, "busted maximum bound");
+	ztest_true(elapsed >= MIN_BOUND, "busted minimum bound");
+	ztest_true(elapsed <= MAX_BOUND, "busted maximum bound");
 }
 
 void test_main(void)

--- a/tests/drivers/counter/counter_nrf_rtc/fixed_top/src/test_counter_fixed_top.c
+++ b/tests/drivers/counter/counter_nrf_rtc/fixed_top/src/test_counter_fixed_top.c
@@ -40,7 +40,7 @@ static void counter_tear_down_instance(const char *dev_name)
 	dev = device_get_binding(dev_name);
 
 	err = counter_stop(dev);
-	zassert_equal(0, err, "%s: Counter failed to stop", dev_name);
+	ztest_equal(0, err, "%s: Counter failed to stop", dev_name);
 
 }
 
@@ -68,7 +68,7 @@ void test_set_custom_top_value_fails_on_instance(const char *dev_name)
 	top_cfg.ticks = counter_get_max_top_value(dev) - 1;
 
 	err = counter_set_top_value(dev, &top_cfg);
-	zassert_true(err != 0, "%s: Expected error code", dev_name);
+	ztest_true(err != 0, "%s: Expected error code", dev_name);
 }
 
 void test_set_custom_top_value_fails(void)
@@ -95,7 +95,7 @@ void test_top_handler_on_instance(const char *dev_name)
 	top_cfg.ticks = counter_get_max_top_value(dev);
 
 	err = counter_set_top_value(dev, &top_cfg);
-	zassert_equal(0, err, "%s: Unexpected error code (%d)", dev_name, err);
+	ztest_equal(0, err, "%s: Unexpected error code (%d)", dev_name, err);
 
 #ifdef CONFIG_COUNTER_RTC0
 	nrf_rtc_task_trigger(NRF_RTC0, NRF_RTC_TASK_TRIGGER_OVERFLOW);
@@ -108,7 +108,7 @@ void test_top_handler_on_instance(const char *dev_name)
 	k_busy_wait(10000);
 
 	tmp_top_cnt = top_cnt;
-	zassert_equal(tmp_top_cnt, 1, "%s: Expected top handler", dev_name);
+	ztest_equal(tmp_top_cnt, 1, "%s: Expected top handler", dev_name);
 }
 
 void test_top_handler(void)

--- a/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
@@ -88,20 +88,20 @@ static int test_task(u32_t chan_id, u32_t blen)
 /* export test cases */
 void test_dma_m2m_chan0_burst8(void)
 {
-	zassert_true((test_task(0, 8) == TC_PASS), NULL);
+	ztest_true((test_task(0, 8) == TC_PASS), NULL);
 }
 
 void test_dma_m2m_chan1_burst8(void)
 {
-	zassert_true((test_task(1, 8) == TC_PASS), NULL);
+	ztest_true((test_task(1, 8) == TC_PASS), NULL);
 }
 
 void test_dma_m2m_chan0_burst16(void)
 {
-	zassert_true((test_task(0, 16) == TC_PASS), NULL);
+	ztest_true((test_task(0, 16) == TC_PASS), NULL);
 }
 
 void test_dma_m2m_chan1_burst16(void)
 {
-	zassert_true((test_task(1, 16) == TC_PASS), NULL);
+	ztest_true((test_task(1, 16) == TC_PASS), NULL);
 }

--- a/tests/drivers/eeprom/src/main.c
+++ b/tests/drivers/eeprom/src/main.c
@@ -16,7 +16,7 @@ static void test_size(void)
 	eeprom = device_get_binding(DT_ALIAS_EEPROM_0_LABEL);
 
 	size = eeprom_get_size(eeprom);
-	zassert_not_equal(0, size, "Unexpected size of zero bytes");
+	ztest_not_equal(0, size, "Unexpected size of zero bytes");
 }
 
 static void test_out_of_bounds(void)
@@ -30,7 +30,7 @@ static void test_out_of_bounds(void)
 	size = eeprom_get_size(eeprom);
 
 	rc = eeprom_write(eeprom, size - 1, data, sizeof(data));
-	zassert_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
 }
 
 static void test_write_and_verify(void)
@@ -44,22 +44,22 @@ static void test_write_and_verify(void)
 	eeprom = device_get_binding(DT_ALIAS_EEPROM_0_LABEL);
 
 	rc = eeprom_write(eeprom, 0, wr_buf1, sizeof(wr_buf1));
-	zassert_equal(0, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(0, rc, "Unexpected error code (%d)", rc);
 
 	rc = eeprom_read(eeprom, 0, rd_buf, sizeof(rd_buf));
-	zassert_equal(0, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(0, rc, "Unexpected error code (%d)", rc);
 
 	rc = memcmp(wr_buf1, rd_buf, sizeof(wr_buf1));
-	zassert_equal(0, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(0, rc, "Unexpected error code (%d)", rc);
 
 	rc = eeprom_write(eeprom, 0, wr_buf2, sizeof(wr_buf2));
-	zassert_equal(0, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(0, rc, "Unexpected error code (%d)", rc);
 
 	rc = eeprom_read(eeprom, 0, rd_buf, sizeof(rd_buf));
-	zassert_equal(0, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(0, rc, "Unexpected error code (%d)", rc);
 
 	rc = memcmp(wr_buf2, rd_buf, sizeof(wr_buf2));
-	zassert_equal(0, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(0, rc, "Unexpected error code (%d)", rc);
 }
 
 static void test_zero_length_write(void)
@@ -73,22 +73,22 @@ static void test_zero_length_write(void)
 	eeprom = device_get_binding(DT_ALIAS_EEPROM_0_LABEL);
 
 	rc = eeprom_write(eeprom, 0, wr_buf1, sizeof(wr_buf1));
-	zassert_equal(0, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(0, rc, "Unexpected error code (%d)", rc);
 
 	rc = eeprom_read(eeprom, 0, rd_buf, sizeof(rd_buf));
-	zassert_equal(0, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(0, rc, "Unexpected error code (%d)", rc);
 
 	rc = memcmp(wr_buf1, rd_buf, sizeof(wr_buf1));
-	zassert_equal(0, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(0, rc, "Unexpected error code (%d)", rc);
 
 	rc = eeprom_write(eeprom, 0, wr_buf2, 0);
-	zassert_equal(0, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(0, rc, "Unexpected error code (%d)", rc);
 
 	rc = eeprom_read(eeprom, 0, rd_buf, sizeof(rd_buf));
-	zassert_equal(0, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(0, rc, "Unexpected error code (%d)", rc);
 
 	rc = memcmp(wr_buf1, rd_buf, sizeof(wr_buf1));
-	zassert_equal(0, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(0, rc, "Unexpected error code (%d)", rc);
 }
 
 void test_main(void)
@@ -96,7 +96,7 @@ void test_main(void)
 	static struct device *eeprom;
 
 	eeprom = device_get_binding(DT_ALIAS_EEPROM_0_LABEL);
-	zassert_not_null(eeprom, "Unable to get EEPROM device");
+	ztest_not_null(eeprom, "Unable to get EEPROM device");
 
 	k_object_access_grant(eeprom, k_current_get());
 

--- a/tests/drivers/entropy/api/src/main.c
+++ b/tests/drivers/entropy/api/src/main.c
@@ -100,7 +100,7 @@ static int get_entropy(void)
 
 static void test_entropy_get_entropy(void)
 {
-	zassert_true(get_entropy() == TC_PASS, NULL);
+	ztest_true(get_entropy() == TC_PASS, NULL);
 }
 
 void test_main(void)

--- a/tests/drivers/flash_simulator/src/main.c
+++ b/tests/drivers/flash_simulator/src/main.c
@@ -50,9 +50,9 @@ static void test_check_pattern32(off_t start, u32_t (*pattern_gen)(void),
 	for (off = 0; off < size; off += 4) {
 		rc = flash_read(flash_dev, start + off, &r_val32,
 				sizeof(r_val32));
-		zassert_equal(0, rc, "flash_write should succedd");
+		ztest_equal(0, rc, "flash_write should succedd");
 		val32 = pattern_gen();
-		zassert_equal(val32, r_val32,
+		ztest_equal(val32, r_val32,
 			     "flash word at offset 0x%x has value 0x%0x02",
 			     start + off, r_val32);
 	}
@@ -65,15 +65,15 @@ static void test_int(void)
 
 	flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
 
-	zassert_true(flash_dev != NULL,
+	ztest_true(flash_dev != NULL,
 		     "Simulated flash driver was not found!");
 
 	rc = flash_read(flash_dev, FLASH_SIMULATOR_BASE_OFFSET,
 			test_read_buf, sizeof(test_read_buf));
-	zassert_equal(0, rc, "flash_read should succedd");
+	ztest_equal(0, rc, "flash_read should succedd");
 
 	for (i = 0; i < sizeof(test_read_buf); i++) {
-		zassert_equal(0xff, test_read_buf[i],
+		ztest_equal(0xff, test_read_buf[i],
 			     "sim flash byte at offset 0x%x has value 0x%0x02",
 			     i, test_read_buf[i]);
 	}
@@ -87,11 +87,11 @@ static void test_write_read(void)
 
 	for (off = 0; off < TEST_SIM_FLASH_SIZE; off += 4) {
 		rc = flash_write_protection_set(flash_dev, false);
-		zassert_equal(0, rc, NULL);
+		ztest_equal(0, rc, NULL);
 		rc = flash_write(flash_dev, FLASH_SIMULATOR_BASE_OFFSET +
 					    off,
 				 &val32, sizeof(val32));
-		zassert_equal(0, rc,
+		ztest_equal(0, rc,
 			      "flash_write (%d) should succedd at off 0x%x", rc,
 			       FLASH_SIMULATOR_BASE_OFFSET + off);
 		val32++;
@@ -103,8 +103,8 @@ static void test_write_read(void)
 		rc = flash_read(flash_dev, FLASH_SIMULATOR_BASE_OFFSET +
 					   off,
 				&r_val32, sizeof(r_val32));
-		zassert_equal(0, rc, "flash_write should succedd");
-		zassert_equal(val32, r_val32,
+		ztest_equal(0, rc, "flash_write should succedd");
+		ztest_equal(val32, r_val32,
 			     "flash byte at offset 0x%x has value 0x%0x02",
 			     off, r_val32);
 		val32++;
@@ -118,7 +118,7 @@ static void test_erase(void)
 	rc = flash_erase(flash_dev, FLASH_SIMULATOR_BASE_OFFSET +
 			 FLASH_SIMULATOR_ERASE_UNIT,
 			 FLASH_SIMULATOR_ERASE_UNIT);
-	zassert_equal(0, rc, "flash_erase should succedd");
+	ztest_equal(0, rc, "flash_erase should succedd");
 
 	TC_PRINT("Incremental pattern expected\n");
 	pattern32_ini(0);
@@ -145,15 +145,15 @@ static void test_access(void)
 	int rc;
 
 	rc = flash_write_protection_set(flash_dev, true);
-	zassert_equal(0, rc, NULL);
+	ztest_equal(0, rc, NULL);
 
 	rc = flash_write(flash_dev, FLASH_SIMULATOR_BASE_OFFSET,
 				 data, 4);
-	zassert_equal(-EACCES, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EACCES, rc, "Unexpected error code (%d)", rc);
 
 	rc = flash_erase(flash_dev, FLASH_SIMULATOR_BASE_OFFSET,
 			 FLASH_SIMULATOR_ERASE_UNIT);
-	zassert_equal(-EACCES, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EACCES, rc, "Unexpected error code (%d)", rc);
 }
 
 static void test_out_of_bounds(void)
@@ -165,53 +165,53 @@ static void test_out_of_bounds(void)
 
 	rc = flash_write(flash_dev, FLASH_SIMULATOR_BASE_OFFSET - 4,
 				 data, 4);
-	zassert_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
 
 	rc = flash_write(flash_dev, FLASH_SIMULATOR_BASE_OFFSET - 4,
 				 data, 8);
-	zassert_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
 
 	rc = flash_write(flash_dev, TEST_SIM_FLASH_END,
 				 data, 4);
-	zassert_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
 
 	rc = flash_write(flash_dev, TEST_SIM_FLASH_END - 4,
 				 data, 8);
-	zassert_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
 
 	rc = flash_erase(flash_dev, FLASH_SIMULATOR_BASE_OFFSET -
 			 FLASH_SIMULATOR_ERASE_UNIT,
 			 FLASH_SIMULATOR_ERASE_UNIT);
-	zassert_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
 
 	rc = flash_erase(flash_dev, TEST_SIM_FLASH_END,
 			 FLASH_SIMULATOR_ERASE_UNIT);
-	zassert_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
 
 	rc = flash_erase(flash_dev, FLASH_SIMULATOR_BASE_OFFSET -
 			 FLASH_SIMULATOR_ERASE_UNIT*2,
 			 FLASH_SIMULATOR_ERASE_UNIT*2);
-	zassert_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
 
 	rc = flash_erase(flash_dev, TEST_SIM_FLASH_END -
 			 FLASH_SIMULATOR_ERASE_UNIT,
 			 FLASH_SIMULATOR_ERASE_UNIT*2);
-	zassert_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
 
 	rc = flash_read(flash_dev, FLASH_SIMULATOR_BASE_OFFSET - 4,
 				 data, 4);
-	zassert_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
 
 	rc = flash_read(flash_dev, FLASH_SIMULATOR_BASE_OFFSET - 4,
 				 data, 8);
-	zassert_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
 
 	rc = flash_read(flash_dev, TEST_SIM_FLASH_END,
 				 data, 4);
-	zassert_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
 
 	rc = flash_read(flash_dev, TEST_SIM_FLASH_END - 4, data, 8);
-	zassert_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
 }
 
 static void test_align(void)
@@ -221,25 +221,25 @@ static void test_align(void)
 
 	rc = flash_read(flash_dev, FLASH_SIMULATOR_BASE_OFFSET + 1,
 				 data, 4);
-	zassert_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
 
 	rc = flash_write(flash_dev, FLASH_SIMULATOR_BASE_OFFSET + 1,
 				 data, 4);
-	zassert_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
 
 	rc = flash_write(flash_dev, FLASH_SIMULATOR_BASE_OFFSET,
 				 data, 3);
-	zassert_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
 
 	rc = flash_erase(flash_dev, FLASH_SIMULATOR_BASE_OFFSET + 1,
 			 FLASH_SIMULATOR_ERASE_UNIT);
 
-	zassert_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
 
 	rc = flash_erase(flash_dev, FLASH_SIMULATOR_BASE_OFFSET,
 			 FLASH_SIMULATOR_ERASE_UNIT + 1);
 
-	zassert_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EINVAL, rc, "Unexpected error code (%d)", rc);
 }
 
 static void test_double_write(void)
@@ -249,15 +249,15 @@ static void test_double_write(void)
 
 	rc = flash_erase(flash_dev, FLASH_SIMULATOR_BASE_OFFSET,
 			 FLASH_SIMULATOR_ERASE_UNIT);
-	zassert_equal(0, rc, "flash_erase should succedd");
+	ztest_equal(0, rc, "flash_erase should succedd");
 
 	rc = flash_write(flash_dev, FLASH_SIMULATOR_BASE_OFFSET,
 				 data, 4);
-	zassert_equal(0, rc, "flash_write should succedd");
+	ztest_equal(0, rc, "flash_write should succedd");
 
 	rc = flash_write(flash_dev, FLASH_SIMULATOR_BASE_OFFSET,
 				 data, 4);
-	zassert_equal(-EIO, rc, "Unexpected error code (%d)", rc);
+	ztest_equal(-EIO, rc, "Unexpected error code (%d)", rc);
 }
 
 void test_main(void)

--- a/tests/drivers/gpio/gpio_api_1pin/src/test_config.c
+++ b/tests/drivers/gpio/gpio_api_1pin/src/test_config.c
@@ -26,16 +26,16 @@ static void pin_get_raw_and_verify(struct device *port, unsigned int pin,
 	int val_actual;
 
 	val_actual = gpio_pin_get_raw(port, pin);
-	zassert_true(val_actual >= 0,
+	ztest_true(val_actual >= 0,
 		     "Test point %d: failed to get pin value", idx);
-	zassert_equal(val_expected, val_actual,
+	ztest_equal(val_expected, val_actual,
 		      "Test point %d: invalid pin get value", idx);
 }
 
 static void pin_set_raw_and_verify(struct device *port, unsigned int pin,
 				   int val, int idx)
 {
-	zassert_equal(gpio_pin_set_raw(port, pin, val), 0,
+	ztest_equal(gpio_pin_set_raw(port, pin, val), 0,
 		      "Test point %d: failed to set pin value", idx);
 	k_busy_wait(TEST_GPIO_MAX_RISE_FALL_TIME_US);
 }
@@ -57,12 +57,12 @@ void test_gpio_pin_configure_push_pull(void)
 	int ret;
 
 	port = device_get_binding(TEST_DEV);
-	zassert_not_null(port, "device " TEST_DEV " not found");
+	ztest_not_null(port, "device " TEST_DEV " not found");
 
 	TC_PRINT("Running test on port=%s, pin=%d\n", TEST_DEV, TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT);
-	zassert_equal(ret, 0, "Failed to configure the pin as an output");
+	ztest_equal(ret, 0, "Failed to configure the pin as an output");
 
 	pin_set_raw_and_verify(port, TEST_PIN, 1, TEST_POINT(1));
 	pin_set_raw_and_verify(port, TEST_PIN, 0, TEST_POINT(1));
@@ -76,7 +76,7 @@ void test_gpio_pin_configure_push_pull(void)
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure the pin in in/out mode");
+	ztest_equal(ret, 0, "Failed to configure the pin in in/out mode");
 
 	pin_set_raw_and_verify(port, TEST_PIN, 0, TEST_POINT(2));
 	pin_get_raw_and_verify(port, TEST_PIN, 0, TEST_POINT(2));
@@ -89,7 +89,7 @@ void test_gpio_pin_configure_push_pull(void)
 
 	/* Verify that GPIO_OUTPUT_HIGH flag is initializing the pin to high. */
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT_HIGH | GPIO_INPUT);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Failed to configure the pin in in/out mode and "
 		      "initialize it to high");
 
@@ -99,13 +99,13 @@ void test_gpio_pin_configure_push_pull(void)
 	 * to high or low does not change pin state.
 	 */
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT | GPIO_INPUT);
-	zassert_equal(ret, 0, "Failed to configure the pin in in/out mode");
+	ztest_equal(ret, 0, "Failed to configure the pin in in/out mode");
 
 	pin_get_raw_and_verify(port, TEST_PIN, 1, TEST_POINT(6));
 
 	/* Verify that GPIO_OUTPUT_LOW flag is initializing the pin to low. */
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT_LOW | GPIO_INPUT);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Failed to configure the pin in in/out mode and "
 		      "initialize it to low");
 
@@ -115,7 +115,7 @@ void test_gpio_pin_configure_push_pull(void)
 	 * to high or low does not change pin state.
 	 */
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT | GPIO_INPUT);
-	zassert_equal(ret, 0, "Failed to configure the pin in in/out mode");
+	ztest_equal(ret, 0, "Failed to configure the pin in in/out mode");
 
 	pin_get_raw_and_verify(port, TEST_PIN, 0, TEST_POINT(8));
 
@@ -123,12 +123,12 @@ void test_gpio_pin_configure_push_pull(void)
 	 * gpio_pin_set_raw function if pin is configured as an input.
 	 */
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_INPUT);
-	zassert_equal(ret, 0, "Failed to configure the pin as an input");
+	ztest_equal(ret, 0, "Failed to configure the pin as an input");
 
 	int pin_in_val;
 
 	pin_in_val = gpio_pin_get_raw(port, TEST_PIN);
-	zassert_true(pin_in_val >= 0,
+	ztest_true(pin_in_val >= 0,
 		     "Test point %d: failed to get pin value", TEST_POINT(9));
 
 	pin_set_raw_and_verify(port, TEST_PIN, 0, TEST_POINT(10));
@@ -173,7 +173,7 @@ void test_gpio_pin_configure_single_ended(void)
 	int ret;
 
 	port = device_get_binding(TEST_DEV);
-	zassert_not_null(port, "device " TEST_DEV " not found");
+	ztest_not_null(port, "device " TEST_DEV " not found");
 
 	TC_PRINT("Running test on port=%s, pin=%d\n", TEST_DEV, TEST_PIN);
 
@@ -199,12 +199,12 @@ void test_gpio_pin_configure_single_ended(void)
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure pin as an input");
+	ztest_equal(ret, 0, "Failed to configure pin as an input");
 
 	k_sleep(K_MSEC(TEST_GPIO_MAX_SINGLE_ENDED_RISE_FALL_TIME_MS));
 
 	pin_in_val = gpio_pin_get_raw(port, TEST_PIN);
-	zassert_true(pin_in_val >= 0, "Failed to get pin value");
+	ztest_true(pin_in_val >= 0, "Failed to get pin value");
 
 	if (pin_val != pin_in_val) {
 		TC_PRINT("Board configuration does not allow to run the test\n");
@@ -227,7 +227,7 @@ void test_gpio_pin_configure_single_ended(void)
 			ztest_test_skip();
 			return;
 		}
-		zassert_equal(ret, 0,
+		ztest_equal(ret, 0,
 			      "Failed to configure the pin in Open Drain mode");
 
 		pin_get_raw_and_verify(port, TEST_PIN, 1, TEST_POINT(1));
@@ -250,7 +250,7 @@ void test_gpio_pin_configure_single_ended(void)
 				 "bias is not supported\n");
 			return;
 		}
-		zassert_equal(ret, 0,
+		ztest_equal(ret, 0,
 			      "Failed to configure the pin in Open Source mode");
 
 		k_sleep(K_MSEC(TEST_GPIO_MAX_SINGLE_ENDED_RISE_FALL_TIME_MS));
@@ -274,7 +274,7 @@ void test_gpio_pin_configure_single_ended(void)
 			ztest_test_skip();
 			return;
 		}
-		zassert_equal(ret, 0,
+		ztest_equal(ret, 0,
 			      "Failed to configure the pin in Open Source mode");
 
 		pin_get_raw_and_verify(port, TEST_PIN, 0, TEST_POINT(5));
@@ -297,7 +297,7 @@ void test_gpio_pin_configure_single_ended(void)
 				 "bias is not supported\n");
 			return;
 		}
-		zassert_equal(ret, 0,
+		ztest_equal(ret, 0,
 			      "Failed to configure the pin in Open Drain mode");
 
 		k_sleep(K_MSEC(TEST_GPIO_MAX_SINGLE_ENDED_RISE_FALL_TIME_MS));

--- a/tests/drivers/gpio/gpio_api_1pin/src/test_pin.c
+++ b/tests/drivers/gpio/gpio_api_1pin/src/test_pin.c
@@ -23,9 +23,9 @@ static void pin_get_raw_and_verify(struct device *port, unsigned int pin,
 	int val_actual;
 
 	val_actual = gpio_pin_get_raw(port, pin);
-	zassert_true(val_actual >= 0,
+	ztest_true(val_actual >= 0,
 		     "Test point %d: failed to get physical pin value", idx);
-	zassert_equal(val_expected, val_actual,
+	ztest_equal(val_expected, val_actual,
 		      "Test point %d: invalid physical pin get value", idx);
 }
 
@@ -35,16 +35,16 @@ static void pin_get_and_verify(struct device *port, unsigned int pin,
 	int val_actual;
 
 	val_actual = gpio_pin_get(port, pin);
-	zassert_true(val_actual >= 0,
+	ztest_true(val_actual >= 0,
 		     "Test point %d: failed to get logical pin value", idx);
-	zassert_equal(val_expected, val_actual,
+	ztest_equal(val_expected, val_actual,
 		      "Test point %d: invalid logical pin get value", idx);
 }
 
 static void pin_set_raw_and_verify(struct device *port, unsigned int pin,
 				   int val, int idx)
 {
-	zassert_equal(gpio_pin_set_raw(port, pin, val), 0,
+	ztest_equal(gpio_pin_set_raw(port, pin, val), 0,
 		      "Test point %d: failed to set physical pin value", idx);
 	k_busy_wait(TEST_GPIO_MAX_RISE_FALL_TIME_US);
 }
@@ -52,7 +52,7 @@ static void pin_set_raw_and_verify(struct device *port, unsigned int pin,
 static void pin_set_and_verify(struct device *port, unsigned int pin, int val,
 			       int idx)
 {
-	zassert_equal(gpio_pin_set(port, pin, val), 0,
+	ztest_equal(gpio_pin_set(port, pin, val), 0,
 		      "Test point %d: failed to set logical pin value", idx);
 	k_busy_wait(TEST_GPIO_MAX_RISE_FALL_TIME_US);
 }
@@ -69,7 +69,7 @@ void test_gpio_pin_toggle(void)
 	int ret;
 
 	port = device_get_binding(TEST_DEV);
-	zassert_not_null(port, "device " TEST_DEV " not found");
+	ztest_not_null(port, "device " TEST_DEV " not found");
 
 	TC_PRINT("Running test on port=%s, pin=%d\n", TEST_DEV, TEST_PIN);
 
@@ -79,13 +79,13 @@ void test_gpio_pin_toggle(void)
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure the pin");
+	ztest_equal(ret, 0, "Failed to configure the pin");
 
 	pin_set_raw_and_verify(port, TEST_PIN, 1, 0);
 
 	for (int i = 0; i < 5; i++) {
 		ret = gpio_pin_toggle(port, TEST_PIN);
-		zassert_equal(ret, 0, "Failed to toggle pin value");
+		ztest_equal(ret, 0, "Failed to toggle pin value");
 		k_busy_wait(TEST_GPIO_MAX_RISE_FALL_TIME_US);
 
 		val_expected = i % 2;
@@ -111,13 +111,13 @@ void test_gpio_pin_toggle_visual(void)
 	int ret;
 
 	port = device_get_binding(TEST_DEV);
-	zassert_not_null(port, "device " TEST_DEV " not found");
+	ztest_not_null(port, "device " TEST_DEV " not found");
 
 	TC_PRINT("Running test on port=%s, pin=%d\n", TEST_DEV, TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT |
 				 TEST_PIN_DTS_FLAGS);
-	zassert_equal(ret, 0, "Failed to configure the pin");
+	ztest_equal(ret, 0, "Failed to configure the pin");
 
 	pin_set_and_verify(port, TEST_PIN, 1, 0);
 	TC_PRINT("LED ON\n");
@@ -126,7 +126,7 @@ void test_gpio_pin_toggle_visual(void)
 		k_sleep(K_SECONDS(2));
 
 		ret = gpio_pin_toggle(port, TEST_PIN);
-		zassert_equal(ret, 0, "Failed to toggle pin value");
+		ztest_equal(ret, 0, "Failed to toggle pin value");
 		k_busy_wait(TEST_GPIO_MAX_RISE_FALL_TIME_US);
 
 		val_expected = i % 2;
@@ -150,7 +150,7 @@ void test_gpio_pin_set_get_raw(void)
 	};
 
 	port = device_get_binding(TEST_DEV);
-	zassert_not_null(port, "device " TEST_DEV " not found");
+	ztest_not_null(port, "device " TEST_DEV " not found");
 
 	TC_PRINT("Running test on port=%s, pin=%d\n", TEST_DEV, TEST_PIN);
 
@@ -160,7 +160,7 @@ void test_gpio_pin_set_get_raw(void)
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure the pin");
+	ztest_equal(ret, 0, "Failed to configure the pin");
 
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
 		pin_set_raw_and_verify(port, TEST_PIN, test_vector[i], i);
@@ -187,7 +187,7 @@ void test_gpio_pin_set_get(void)
 	};
 
 	port = device_get_binding(TEST_DEV);
-	zassert_not_null(port, "device " TEST_DEV " not found");
+	ztest_not_null(port, "device " TEST_DEV " not found");
 
 	TC_PRINT("Running test on port=%s, pin=%d\n", TEST_DEV, TEST_PIN);
 
@@ -197,7 +197,7 @@ void test_gpio_pin_set_get(void)
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure the pin");
+	ztest_equal(ret, 0, "Failed to configure the pin");
 
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
 		pin_set_and_verify(port, TEST_PIN, test_vector[i], i);
@@ -224,7 +224,7 @@ void test_gpio_pin_set_get_active_high(void)
 	const int test_vector[] = {0, 2, 0, 9, -1, 0, 0, 1, INT_MAX, INT_MIN};
 
 	port = device_get_binding(TEST_DEV);
-	zassert_not_null(port, "device " TEST_DEV " not found");
+	ztest_not_null(port, "device " TEST_DEV " not found");
 
 	TC_PRINT("Running test on port=%s, pin=%d\n", TEST_DEV, TEST_PIN);
 
@@ -235,7 +235,7 @@ void test_gpio_pin_set_get_active_high(void)
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure the pin");
+	ztest_equal(ret, 0, "Failed to configure the pin");
 
 	TC_PRINT("Step 1: Set logical, get logical and physical pin value\n");
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
@@ -274,7 +274,7 @@ void test_gpio_pin_set_get_active_low(void)
 	const int test_vector[] = {0, 4, 0, 0, 1, 8, -3, -12, 0};
 
 	port = device_get_binding(TEST_DEV);
-	zassert_not_null(port, "device " TEST_DEV " not found");
+	ztest_not_null(port, "device " TEST_DEV " not found");
 
 	TC_PRINT("Running test on port=%s, pin=%d\n", TEST_DEV, TEST_PIN);
 
@@ -285,7 +285,7 @@ void test_gpio_pin_set_get_active_low(void)
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure the pin");
+	ztest_equal(ret, 0, "Failed to configure the pin");
 
 	TC_PRINT("Step 1: Set logical, get logical and physical pin value\n");
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {

--- a/tests/drivers/gpio/gpio_api_1pin/src/test_pin_interrupt.c
+++ b/tests/drivers/gpio/gpio_api_1pin/src/test_pin_interrupt.c
@@ -23,7 +23,7 @@ static int cb_count;
 static void callback_edge(struct device *port, struct gpio_callback *cb,
 			  gpio_port_pins_t pins)
 {
-	zassert_equal(pins, BIT(TEST_PIN),
+	ztest_equal(pins, BIT(TEST_PIN),
 		     "Detected interrupt on an invalid pin");
 	cb_count++;
 }
@@ -33,11 +33,11 @@ static void callback_level(struct device *port, struct gpio_callback *cb,
 {
 	int ret;
 
-	zassert_equal(pins, BIT(TEST_PIN),
+	ztest_equal(pins, BIT(TEST_PIN),
 		     "Detected interrupt on an invalid pin");
 
 	ret = gpio_pin_interrupt_configure(port, TEST_PIN, GPIO_INT_DISABLE);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Failed to disable pin interrupt in the callback");
 
 	cb_count++;
@@ -46,7 +46,7 @@ static void callback_level(struct device *port, struct gpio_callback *cb,
 static void pin_set_and_verify(struct device *port, unsigned int pin, int val,
 			       int idx)
 {
-	zassert_equal(gpio_pin_set(port, pin, val), 0,
+	ztest_equal(gpio_pin_set(port, pin, val), 0,
 		      "Test point %d: failed to set logical pin value", idx);
 	k_busy_wait(TEST_GPIO_MAX_RISE_FALL_TIME_US);
 }
@@ -60,7 +60,7 @@ void test_gpio_pin_interrupt_edge(unsigned int cfg_flags,
 	int ret;
 
 	port = device_get_binding(TEST_DEV);
-	zassert_not_null(port, "device " TEST_DEV " not found");
+	ztest_not_null(port, "device " TEST_DEV " not found");
 
 	TC_PRINT("Running test on port=%s, pin=%d\n", TEST_DEV, TEST_PIN);
 
@@ -70,7 +70,7 @@ void test_gpio_pin_interrupt_edge(unsigned int cfg_flags,
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure the pin");
+	ztest_equal(ret, 0, "Failed to configure the pin");
 
 	if ((cfg_flags & GPIO_ACTIVE_LOW) != 0) {
 		cfg_out_flag = GPIO_OUTPUT_HIGH;
@@ -79,7 +79,7 @@ void test_gpio_pin_interrupt_edge(unsigned int cfg_flags,
 	}
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_INPUT | cfg_out_flag |
 				 cfg_flags);
-	zassert_equal(ret, 0, "Failed to configure the pin");
+	ztest_equal(ret, 0, "Failed to configure the pin");
 
 	cb_count = 0;
 	cb_count_expected = 0;
@@ -93,14 +93,14 @@ void test_gpio_pin_interrupt_edge(unsigned int cfg_flags,
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure pin interrupt");
+	ztest_equal(ret, 0, "Failed to configure pin interrupt");
 
 	for (int i = 0; i < 6; i++) {
 		pin_set_and_verify(port, TEST_PIN, 1, i);
 		if (int_flags & GPIO_INT_HIGH_1) {
 			cb_count_expected++;
 		}
-		zassert_equal(cb_count, cb_count_expected,
+		ztest_equal(cb_count, cb_count_expected,
 			      "Test point %d: Pin interrupt triggered invalid "
 			      "number of times on rising/to active edge", i);
 
@@ -108,18 +108,18 @@ void test_gpio_pin_interrupt_edge(unsigned int cfg_flags,
 		if (int_flags & GPIO_INT_LOW_0) {
 			cb_count_expected++;
 		}
-		zassert_equal(cb_count, cb_count_expected,
+		ztest_equal(cb_count, cb_count_expected,
 			      "Test point %d: Pin interrupt triggered invalid "
 			      "number of times on falling/to inactive edge", i);
 	}
 
 	ret = gpio_pin_interrupt_configure(port, TEST_PIN, GPIO_INT_DISABLE);
-	zassert_equal(ret, 0, "Failed to disable pin interrupt");
+	ztest_equal(ret, 0, "Failed to disable pin interrupt");
 
 	for (int i = 0; i < 6; i++) {
 		pin_set_and_verify(port, TEST_PIN, 1, i);
 		pin_set_and_verify(port, TEST_PIN, 0, i);
-		zassert_equal(cb_count, cb_count_expected,
+		ztest_equal(cb_count, cb_count_expected,
 			      "Pin interrupt triggered when disabled");
 	}
 }
@@ -134,7 +134,7 @@ void test_gpio_pin_interrupt_level(unsigned int cfg_flags,
 	int ret;
 
 	port = device_get_binding(TEST_DEV);
-	zassert_not_null(port, "device " TEST_DEV " not found");
+	ztest_not_null(port, "device " TEST_DEV " not found");
 
 	TC_PRINT("Running test on port=%s, pin=%d\n", TEST_DEV, TEST_PIN);
 
@@ -144,7 +144,7 @@ void test_gpio_pin_interrupt_level(unsigned int cfg_flags,
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure the pin");
+	ztest_equal(ret, 0, "Failed to configure the pin");
 
 	pin_out_val = ((int_flags & GPIO_INT_HIGH_1) != 0) ? 0 : 1;
 
@@ -158,7 +158,7 @@ void test_gpio_pin_interrupt_level(unsigned int cfg_flags,
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_INPUT | cfg_out_flag |
 				 cfg_flags);
-	zassert_equal(ret, 0, "Failed to configure the pin");
+	ztest_equal(ret, 0, "Failed to configure the pin");
 
 	cb_count = 0;
 	cb_count_expected = 0;
@@ -172,38 +172,38 @@ void test_gpio_pin_interrupt_level(unsigned int cfg_flags,
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure pin interrupt");
+	ztest_equal(ret, 0, "Failed to configure pin interrupt");
 
-	zassert_equal(cb_count, cb_count_expected,
+	ztest_equal(cb_count, cb_count_expected,
 		      "Pin interrupt triggered on level %d", pin_out_val);
 
 	for (int i = 0; i < 6; i++) {
 		pin_out_val = (pin_out_val != 0) ? 0 : 1;
 		pin_set_and_verify(port, TEST_PIN, pin_out_val, i);
 		cb_count_expected++;
-		zassert_equal(cb_count, cb_count_expected,
+		ztest_equal(cb_count, cb_count_expected,
 			      "Test point %d: Pin interrupt triggered invalid "
 			      "number of times on level %d", i, pin_out_val);
 
 		pin_out_val = (pin_out_val != 0) ? 0 : 1;
 		pin_set_and_verify(port, TEST_PIN, pin_out_val, i);
-		zassert_equal(cb_count, cb_count_expected,
+		ztest_equal(cb_count, cb_count_expected,
 			      "Test point %d: Pin interrupt triggered invalid "
 			      "number of times on level %d", i, pin_out_val);
 
 		/* Re-enable pin level interrupt */
 		ret = gpio_pin_interrupt_configure(port, TEST_PIN, int_flags);
-		zassert_equal(ret, 0,
+		ztest_equal(ret, 0,
 			      "Failed to re-enable pin level interrupt");
 	}
 
 	ret = gpio_pin_interrupt_configure(port, TEST_PIN, GPIO_INT_DISABLE);
-	zassert_equal(ret, 0, "Failed to disable pin interrupt");
+	ztest_equal(ret, 0, "Failed to disable pin interrupt");
 
 	for (int i = 0; i < 6; i++) {
 		pin_set_and_verify(port, TEST_PIN, 1, i);
 		pin_set_and_verify(port, TEST_PIN, 0, i);
-		zassert_equal(cb_count, cb_count_expected,
+		ztest_equal(cb_count, cb_count_expected,
 			      "Pin interrupt triggered when disabled");
 	}
 }

--- a/tests/drivers/gpio/gpio_api_1pin/src/test_port.c
+++ b/tests/drivers/gpio/gpio_api_1pin/src/test_port.c
@@ -24,9 +24,9 @@ static void port_get_raw_and_verify(struct device *port, gpio_port_pins_t mask,
 {
 	gpio_port_value_t val_actual;
 
-	zassert_equal(gpio_port_get_raw(port, &val_actual), 0,
+	ztest_equal(gpio_port_get_raw(port, &val_actual), 0,
 		     "Test point %d: failed to get physical port value", idx);
-	zassert_equal(val_expected & mask, val_actual & mask,
+	ztest_equal(val_expected & mask, val_actual & mask,
 		      "Test point %d: invalid physical port get value", idx);
 }
 
@@ -35,16 +35,16 @@ static void port_get_and_verify(struct device *port, gpio_port_pins_t mask,
 {
 	gpio_port_value_t val_actual;
 
-	zassert_equal(gpio_port_get(port, &val_actual), 0,
+	ztest_equal(gpio_port_get(port, &val_actual), 0,
 		     "Test point %d: failed to get logical port value", idx);
-	zassert_equal(val_expected & mask, val_actual & mask,
+	ztest_equal(val_expected & mask, val_actual & mask,
 		      "Test point %d: invalid logical port get value", idx);
 }
 
 static void port_set_masked_raw_and_verify(struct device *port,
 		gpio_port_pins_t mask, gpio_port_value_t value, int idx)
 {
-	zassert_equal(gpio_port_set_masked_raw(port, mask, value), 0,
+	ztest_equal(gpio_port_set_masked_raw(port, mask, value), 0,
 		      "Test point %d: failed to set physical port value", idx);
 	k_busy_wait(TEST_GPIO_MAX_RISE_FALL_TIME_US);
 }
@@ -52,7 +52,7 @@ static void port_set_masked_raw_and_verify(struct device *port,
 static void port_set_masked_and_verify(struct device *port,
 		gpio_port_pins_t mask, gpio_port_value_t value, int idx)
 {
-	zassert_equal(gpio_port_set_masked(port, mask, value), 0,
+	ztest_equal(gpio_port_set_masked(port, mask, value), 0,
 		      "Test point %d: failed to set logical port value", idx);
 	k_busy_wait(TEST_GPIO_MAX_RISE_FALL_TIME_US);
 }
@@ -60,7 +60,7 @@ static void port_set_masked_and_verify(struct device *port,
 static void port_set_bits_raw_and_verify(struct device *port,
 		gpio_port_pins_t pins, int idx)
 {
-	zassert_equal(gpio_port_set_bits_raw(port, pins), 0,
+	ztest_equal(gpio_port_set_bits_raw(port, pins), 0,
 		      "Test point %d: failed to set physical port value", idx);
 	k_busy_wait(TEST_GPIO_MAX_RISE_FALL_TIME_US);
 }
@@ -68,7 +68,7 @@ static void port_set_bits_raw_and_verify(struct device *port,
 static void port_set_bits_and_verify(struct device *port,
 		gpio_port_pins_t pins, int idx)
 {
-	zassert_equal(gpio_port_set_bits(port, pins), 0,
+	ztest_equal(gpio_port_set_bits(port, pins), 0,
 		      "Test point %d: failed to set logical port value", idx);
 	k_busy_wait(TEST_GPIO_MAX_RISE_FALL_TIME_US);
 }
@@ -76,7 +76,7 @@ static void port_set_bits_and_verify(struct device *port,
 static void port_clear_bits_raw_and_verify(struct device *port,
 		gpio_port_pins_t pins, int idx)
 {
-	zassert_equal(gpio_port_clear_bits_raw(port, pins), 0,
+	ztest_equal(gpio_port_clear_bits_raw(port, pins), 0,
 		      "Test point %d: failed to set physical port value", idx);
 	k_busy_wait(TEST_GPIO_MAX_RISE_FALL_TIME_US);
 }
@@ -84,7 +84,7 @@ static void port_clear_bits_raw_and_verify(struct device *port,
 static void port_clear_bits_and_verify(struct device *port,
 		gpio_port_pins_t pins, int idx)
 {
-	zassert_equal(gpio_port_clear_bits(port, pins), 0,
+	ztest_equal(gpio_port_clear_bits(port, pins), 0,
 		      "Test point %d: failed to set logical port value", idx);
 	k_busy_wait(TEST_GPIO_MAX_RISE_FALL_TIME_US);
 }
@@ -92,7 +92,7 @@ static void port_clear_bits_and_verify(struct device *port,
 static void port_set_clr_bits_raw(struct device *port,
 		gpio_port_pins_t set_pins, gpio_port_pins_t clear_pins, int idx)
 {
-	zassert_equal(gpio_port_set_clr_bits_raw(port, set_pins, clear_pins), 0,
+	ztest_equal(gpio_port_set_clr_bits_raw(port, set_pins, clear_pins), 0,
 		      "Test point %d: failed to set physical port value", idx);
 	k_busy_wait(TEST_GPIO_MAX_RISE_FALL_TIME_US);
 }
@@ -100,7 +100,7 @@ static void port_set_clr_bits_raw(struct device *port,
 static void port_set_clr_bits(struct device *port,
 		gpio_port_pins_t set_pins, gpio_port_pins_t clear_pins, int idx)
 {
-	zassert_equal(gpio_port_set_clr_bits(port, set_pins, clear_pins), 0,
+	ztest_equal(gpio_port_set_clr_bits(port, set_pins, clear_pins), 0,
 		      "Test point %d: failed to set logical port value", idx);
 	k_busy_wait(TEST_GPIO_MAX_RISE_FALL_TIME_US);
 }
@@ -117,7 +117,7 @@ void test_gpio_port_toggle(void)
 	int ret;
 
 	port = device_get_binding(TEST_DEV);
-	zassert_not_null(port, "device " TEST_DEV " not found");
+	ztest_not_null(port, "device " TEST_DEV " not found");
 
 	TC_PRINT("Running test on port=%s, pin=%d\n", TEST_DEV, TEST_PIN);
 
@@ -127,7 +127,7 @@ void test_gpio_port_toggle(void)
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure the pin");
+	ztest_equal(ret, 0, "Failed to configure the pin");
 
 	port_set_bits_raw_and_verify(port, BIT(TEST_PIN), 0);
 
@@ -135,7 +135,7 @@ void test_gpio_port_toggle(void)
 
 	for (int i = 0; i < 5; i++) {
 		ret = gpio_port_toggle_bits(port, BIT(TEST_PIN));
-		zassert_equal(ret, 0, "Failed to toggle pin value");
+		ztest_equal(ret, 0, "Failed to toggle pin value");
 		k_busy_wait(TEST_GPIO_MAX_RISE_FALL_TIME_US);
 
 		val_expected ^= BIT(TEST_PIN);
@@ -166,7 +166,7 @@ void test_gpio_port_set_masked_get_raw(void)
 	};
 
 	port = device_get_binding(TEST_DEV);
-	zassert_not_null(port, "device " TEST_DEV " not found");
+	ztest_not_null(port, "device " TEST_DEV " not found");
 
 	TC_PRINT("Running test on port=%s, pin=%d\n", TEST_DEV, TEST_PIN);
 
@@ -176,7 +176,7 @@ void test_gpio_port_set_masked_get_raw(void)
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure the pin");
+	ztest_equal(ret, 0, "Failed to configure the pin");
 
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
 		port_set_masked_raw_and_verify(port, BIT(TEST_PIN), test_vector[i], i);
@@ -206,7 +206,7 @@ void test_gpio_port_set_masked_get(void)
 	};
 
 	port = device_get_binding(TEST_DEV);
-	zassert_not_null(port, "device " TEST_DEV " not found");
+	ztest_not_null(port, "device " TEST_DEV " not found");
 
 	TC_PRINT("Running test on port=%s, pin=%d\n", TEST_DEV, TEST_PIN);
 
@@ -216,7 +216,7 @@ void test_gpio_port_set_masked_get(void)
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure the pin");
+	ztest_equal(ret, 0, "Failed to configure the pin");
 
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
 		port_set_masked_and_verify(port, BIT(TEST_PIN), test_vector[i], i);
@@ -247,7 +247,7 @@ void test_gpio_port_set_masked_get_active_high(void)
 	};
 
 	port = device_get_binding(TEST_DEV);
-	zassert_not_null(port, "device " TEST_DEV " not found");
+	ztest_not_null(port, "device " TEST_DEV " not found");
 
 	TC_PRINT("Running test on port=%s, pin=%d\n", TEST_DEV, TEST_PIN);
 
@@ -258,7 +258,7 @@ void test_gpio_port_set_masked_get_active_high(void)
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure the pin");
+	ztest_equal(ret, 0, "Failed to configure the pin");
 
 	TC_PRINT("Step 1: Set logical, get logical and physical port value\n");
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
@@ -298,7 +298,7 @@ void test_gpio_port_set_masked_get_active_low(void)
 	};
 
 	port = device_get_binding(TEST_DEV);
-	zassert_not_null(port, "device " TEST_DEV " not found");
+	ztest_not_null(port, "device " TEST_DEV " not found");
 
 	TC_PRINT("Running test on port=%s, pin=%d\n", TEST_DEV, TEST_PIN);
 
@@ -309,7 +309,7 @@ void test_gpio_port_set_masked_get_active_low(void)
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure the pin");
+	ztest_equal(ret, 0, "Failed to configure the pin");
 
 	TC_PRINT("Step 1: Set logical, get logical and physical port value\n");
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
@@ -342,7 +342,7 @@ void test_gpio_port_set_bits_clear_bits_raw(void)
 	};
 
 	port = device_get_binding(TEST_DEV);
-	zassert_not_null(port, "device " TEST_DEV " not found");
+	ztest_not_null(port, "device " TEST_DEV " not found");
 
 	TC_PRINT("Running test on port=%s, pin=%d\n", TEST_DEV, TEST_PIN);
 
@@ -352,7 +352,7 @@ void test_gpio_port_set_bits_clear_bits_raw(void)
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure the pin");
+	ztest_equal(ret, 0, "Failed to configure the pin");
 
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
 		port_set_bits_raw_and_verify(port, test_vector[i][0], i);
@@ -381,7 +381,7 @@ void test_gpio_port_set_bits_clear_bits(void)
 	};
 
 	port = device_get_binding(TEST_DEV);
-	zassert_not_null(port, "device " TEST_DEV " not found");
+	ztest_not_null(port, "device " TEST_DEV " not found");
 
 	TC_PRINT("Running test on port=%s, pin=%d\n", TEST_DEV, TEST_PIN);
 
@@ -391,7 +391,7 @@ void test_gpio_port_set_bits_clear_bits(void)
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure the pin");
+	ztest_equal(ret, 0, "Failed to configure the pin");
 
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
 		port_set_bits_and_verify(port, test_vector[i][0], i);
@@ -422,7 +422,7 @@ void test_gpio_port_set_clr_bits_raw(void)
 	};
 
 	port = device_get_binding(TEST_DEV);
-	zassert_not_null(port, "device " TEST_DEV " not found");
+	ztest_not_null(port, "device " TEST_DEV " not found");
 
 	TC_PRINT("Running test on port=%s, pin=%d\n", TEST_DEV, TEST_PIN);
 
@@ -432,7 +432,7 @@ void test_gpio_port_set_clr_bits_raw(void)
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure the pin");
+	ztest_equal(ret, 0, "Failed to configure the pin");
 
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
 		port_set_clr_bits_raw(port, test_vector[i][0], test_vector[i][1], i);
@@ -459,7 +459,7 @@ void test_gpio_port_set_clr_bits(void)
 	};
 
 	port = device_get_binding(TEST_DEV);
-	zassert_not_null(port, "device " TEST_DEV " not found");
+	ztest_not_null(port, "device " TEST_DEV " not found");
 
 	TC_PRINT("Running test on port=%s, pin=%d\n", TEST_DEV, TEST_PIN);
 
@@ -469,7 +469,7 @@ void test_gpio_port_set_clr_bits(void)
 		ztest_test_skip();
 		return;
 	}
-	zassert_equal(ret, 0, "Failed to configure the pin");
+	ztest_equal(ret, 0, "Failed to configure the pin");
 
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
 		port_set_clr_bits(port, test_vector[i][0], test_vector[i][1], i);

--- a/tests/drivers/gpio/gpio_basic_api/src/test_callback_manage.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_callback_manage.c
@@ -100,7 +100,7 @@ static int test_callback_add_remove(void)
 		TC_PRINT("%s not supported\n", __func__);
 		return TC_PASS;
 	}
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "init_callback failed");
 
 	/* 3. enable callback, trigger PIN_IN interrupt by operate PIN_OUT */
@@ -149,7 +149,7 @@ static int test_callback_self_remove(void)
 		TC_PRINT("%s not supported\n", __func__);
 		return TC_PASS;
 	}
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "init_callback failed");
 
 	gpio_pin_set(dev, PIN_OUT, 0);
@@ -201,7 +201,7 @@ static int test_callback_enable_disable(void)
 		TC_PRINT("%s not supported\n", __func__);
 		return TC_PASS;
 	}
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "init_callback failed");
 
 	/* 3. enable callback, trigger PIN_IN interrupt by operate PIN_OUT */
@@ -239,18 +239,18 @@ err_exit:
 
 void test_gpio_callback_add_remove(void)
 {
-	zassert_equal(test_callback_add_remove(), TC_PASS,
+	ztest_equal(test_callback_add_remove(), TC_PASS,
 		     NULL);
 }
 
 void test_gpio_callback_self_remove(void)
 {
-	zassert_equal(test_callback_self_remove(), TC_PASS,
+	ztest_equal(test_callback_self_remove(), TC_PASS,
 		     NULL);
 }
 
 void test_gpio_callback_enable_disable(void)
 {
-	zassert_equal(test_callback_enable_disable(), TC_PASS,
+	ztest_equal(test_callback_enable_disable(), TC_PASS,
 		     NULL);
 }

--- a/tests/drivers/gpio/gpio_basic_api/src/test_callback_trigger.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_callback_trigger.c
@@ -25,7 +25,7 @@ static void callback(struct device *dev,
 						 struct drv_data, gpio_cb);
 
 	/*= checkpoint: pins should be marked with correct pin number bit =*/
-	zassert_equal(pins, BIT(PIN_IN),
+	ztest_equal(pins, BIT(PIN_IN),
 		      "unexpected pins %x", pins);
 	++cb_cnt;
 	TC_PRINT("callback triggered: %d\n", cb_cnt);
@@ -128,22 +128,22 @@ err_exit:
 /* export test cases */
 void test_gpio_callback_variants(void)
 {
-	zassert_equal(test_callback(GPIO_INT_EDGE_FALLING), TC_PASS,
+	ztest_equal(test_callback(GPIO_INT_EDGE_FALLING), TC_PASS,
 		      "falling edge failed");
-	zassert_equal(test_callback(GPIO_INT_EDGE_RISING), TC_PASS,
+	ztest_equal(test_callback(GPIO_INT_EDGE_RISING), TC_PASS,
 		      "rising edge failed");
-	zassert_equal(test_callback(GPIO_INT_EDGE_TO_ACTIVE), TC_PASS,
+	ztest_equal(test_callback(GPIO_INT_EDGE_TO_ACTIVE), TC_PASS,
 		      "edge active failed");
-	zassert_equal(test_callback(GPIO_INT_EDGE_TO_INACTIVE), TC_PASS,
+	ztest_equal(test_callback(GPIO_INT_EDGE_TO_INACTIVE), TC_PASS,
 		      "edge inactive failed");
-	zassert_equal(test_callback(GPIO_INT_LEVEL_HIGH), TC_PASS,
+	ztest_equal(test_callback(GPIO_INT_LEVEL_HIGH), TC_PASS,
 		      "level high failed");
-	zassert_equal(test_callback(GPIO_INT_LEVEL_LOW), TC_PASS,
+	ztest_equal(test_callback(GPIO_INT_LEVEL_LOW), TC_PASS,
 		      "level low failed");
-	zassert_equal(test_callback(GPIO_INT_LEVEL_ACTIVE), TC_PASS,
+	ztest_equal(test_callback(GPIO_INT_LEVEL_ACTIVE), TC_PASS,
 		      "level active failed");
-	zassert_equal(test_callback(GPIO_INT_LEVEL_INACTIVE), TC_PASS,
+	ztest_equal(test_callback(GPIO_INT_LEVEL_INACTIVE), TC_PASS,
 		      "level inactive failed");
-	zassert_equal(test_callback(GPIO_INT_EDGE_BOTH), TC_PASS,
+	ztest_equal(test_callback(GPIO_INT_EDGE_BOTH), TC_PASS,
 		      "edge both failed");
 }

--- a/tests/drivers/gpio/gpio_basic_api/src/test_deprecated.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_deprecated.c
@@ -26,7 +26,7 @@ static void callback(struct device *dev,
 						 struct drv_data, gpio_cb);
 
 	/*= checkpoint: pins should be marked with correct pin number bit =*/
-	zassert_equal(pins, BIT(PIN_IN),
+	ztest_equal(pins, BIT(PIN_IN),
 		      "unexpected pins %x", pins);
 	++cb_cnt;
 	TC_PRINT("callback triggered: %d\n", cb_cnt);
@@ -46,7 +46,7 @@ static void callback(struct device *dev,
 		 */
 		rc = gpio_pin_configure(dev, PIN_IN, GPIO_DIR_IN
 					| GPIO_INT_DISABLE);
-		zassert_equal(rc, 0,
+		ztest_equal(rc, 0,
 			      "disable interrupts failed: %d", rc);
 	}
 }
@@ -152,16 +152,16 @@ static int test_callback_enable_disable(void)
 /* export test cases */
 void test_gpio_deprecated(void)
 {
-	zassert_equal(test_callback_enable_disable(),
+	ztest_equal(test_callback_enable_disable(),
 		      TC_PASS, "callback enable/disable failed");
-	zassert_equal(test_callback(GPIO_INT_EDGE | GPIO_INT_ACTIVE_HIGH),
+	ztest_equal(test_callback(GPIO_INT_EDGE | GPIO_INT_ACTIVE_HIGH),
 		      TC_PASS, "rising edge failed");
-	zassert_equal(test_callback(GPIO_INT_EDGE | GPIO_INT_ACTIVE_LOW),
+	ztest_equal(test_callback(GPIO_INT_EDGE | GPIO_INT_ACTIVE_LOW),
 		      TC_PASS, "falling edge failed");
-	zassert_equal(test_callback(GPIO_INT_EDGE_BOTH),
+	ztest_equal(test_callback(GPIO_INT_EDGE_BOTH),
 		      TC_PASS, "double edge failed");
-	zassert_equal(test_callback(GPIO_INT_LEVEL | GPIO_INT_ACTIVE_HIGH),
+	ztest_equal(test_callback(GPIO_INT_LEVEL | GPIO_INT_ACTIVE_HIGH),
 		      TC_PASS, "level high failed");
-	zassert_equal(test_callback(GPIO_INT_LEVEL | GPIO_INT_ACTIVE_LOW),
+	ztest_equal(test_callback(GPIO_INT_LEVEL | GPIO_INT_ACTIVE_LOW),
 		      TC_PASS, "level low failed");
 }

--- a/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
@@ -24,7 +24,7 @@ static bool raw_in(void)
 	gpio_port_value_t v;
 	int rc = gpio_port_get_raw(dev, &v);
 
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "raw_in failed");
 	return (v & BIT(PIN_IN)) ? true : false;
 }
@@ -35,7 +35,7 @@ static bool logic_in(void)
 	gpio_port_value_t v;
 	int rc = gpio_port_get(dev, &v);
 
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "logic_in failed");
 	return (v & BIT(PIN_IN)) ? true : false;
 }
@@ -50,7 +50,7 @@ static void raw_out(bool set)
 	} else {
 		rc = gpio_port_clear_bits_raw(dev, BIT(PIN_OUT));
 	}
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "raw_out failed");
 }
 
@@ -64,7 +64,7 @@ static void logic_out(bool set)
 	} else {
 		rc = gpio_port_clear_bits(dev, BIT(PIN_OUT));
 	}
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "raw_out failed");
 }
 
@@ -78,21 +78,21 @@ static int setup(void)
 
 	TC_PRINT("Validate device %s\n", DEV_NAME);
 	dev = device_get_binding(DEV_NAME);
-	zassert_not_equal(dev, NULL,
+	ztest_not_equal(dev, NULL,
 			  "Device not found");
 
 	TC_PRINT("Check %s output %d connected to input %d\n", DEV_NAME,
 		 PIN_OUT, PIN_IN);
 	rc = gpio_pin_configure(dev, PIN_OUT, GPIO_OUTPUT_LOW);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "pin config output low failed");
 
 	rc = gpio_pin_configure(dev, PIN_IN, GPIO_INPUT);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "pin config input failed");
 
 	rc = gpio_port_get_raw(dev, &v1);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "get raw low failed");
 	if (raw_in() != false) {
 		TC_PRINT("FATAL output pin not wired to input pin? (out low => in high)\n");
@@ -101,15 +101,15 @@ static int setup(void)
 		}
 	}
 
-	zassert_equal(v1 & BIT(PIN_IN), 0,
+	ztest_equal(v1 & BIT(PIN_IN), 0,
 		      "out low does not read low");
 
 	rc = gpio_pin_configure(dev, PIN_OUT, GPIO_OUTPUT_HIGH);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "pin config output high failed");
 
 	rc = gpio_port_get_raw(dev, &v1);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "get raw high failed");
 	if (raw_in() != true) {
 		TC_PRINT("FATAL output pin not wired to input pin? (out high => in low)\n");
@@ -117,7 +117,7 @@ static int setup(void)
 			k_sleep(K_FOREVER);
 		}
 	}
-	zassert_not_equal(v1 & BIT(PIN_IN), 0,
+	ztest_not_equal(v1 & BIT(PIN_IN), 0,
 			  "out high does not read low");
 
 	TC_PRINT("OUT %d to IN %d linkage works\n", PIN_OUT, PIN_IN);
@@ -137,57 +137,57 @@ static int bits_physical(void)
 
 	/* port_set_bits_raw */
 	rc = gpio_port_set_bits_raw(dev, BIT(PIN_OUT));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "port set raw out failed");
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "raw set mismatch");
 
 	/* port_clear_bits_raw */
 	rc = gpio_port_clear_bits_raw(dev, BIT(PIN_OUT));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "port clear raw out failed");
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "raw clear mismatch");
 
 	/* set after clear changes */
 	rc = gpio_port_set_bits_raw(dev, BIT(PIN_OUT));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "port set raw out failed");
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "raw set mismatch");
 
 	/* raw_out() after set works */
 	raw_out(false);
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "raw_out() false mismatch");
 
 	/* raw_out() set after raw_out() clear works */
 	raw_out(true);
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "raw_out() true mismatch");
 
 	rc = gpio_port_set_masked_raw(dev, BIT(PIN_OUT), 0);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "set_masked_raw low failed");
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "set_masked_raw low mismatch");
 
 	rc = gpio_port_set_masked_raw(dev, BIT(PIN_OUT), ALL_BITS);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "set_masked_raw high failed");
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "set_masked_raw high mismatch");
 
 	rc = gpio_port_set_clr_bits_raw(dev, BIT(PIN_IN), BIT(PIN_OUT));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "set in clear out failed");
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "set in clear out mismatch");
 
 	rc = gpio_port_set_clr_bits_raw(dev, BIT(PIN_OUT), BIT(PIN_IN));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "set out clear in failed");
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "set out clear in mismatch");
 
 	/* Conditionally verify that behavior with __ASSERT disabled
@@ -196,30 +196,30 @@ static int bits_physical(void)
 	if (false) {
 		/* preserve set */
 		rc = gpio_port_set_clr_bits_raw(dev, BIT(PIN_OUT), BIT(PIN_OUT));
-		zassert_equal(rc, 0,
+		ztest_equal(rc, 0,
 			      "s/c dup set failed");
-		zassert_equal(raw_in(), true,
+		ztest_equal(raw_in(), true,
 			      "s/c dup set mismatch");
 
 		/* do set */
 		raw_out(false);
 		rc = gpio_port_set_clr_bits_raw(dev, BIT(PIN_OUT), BIT(PIN_OUT));
-		zassert_equal(rc, 0,
+		ztest_equal(rc, 0,
 			      "s/c dup2 set failed");
-		zassert_equal(raw_in(), true,
+		ztest_equal(raw_in(), true,
 			      "s/c dup2 set mismatch");
 	}
 
 	rc = gpio_port_toggle_bits(dev, BIT(PIN_OUT));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "toggle_bits high-to-low failed");
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "toggle_bits high-to-low mismatch");
 
 	rc = gpio_port_toggle_bits(dev, BIT(PIN_OUT));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "toggle_bits low-to-high failed");
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "toggle_bits low-to-high mismatch");
 
 	return TC_PASS;
@@ -235,35 +235,35 @@ static int pin_physical(void)
 	TC_PRINT("- %s\n", __func__);
 
 	raw_out(true);
-	zassert_equal(gpio_pin_get_raw(dev, PIN_IN), raw_in(),
+	ztest_equal(gpio_pin_get_raw(dev, PIN_IN), raw_in(),
 		      "pin_get_raw high failed");
 
 	raw_out(false);
-	zassert_equal(gpio_pin_get_raw(dev, PIN_IN), raw_in(),
+	ztest_equal(gpio_pin_get_raw(dev, PIN_IN), raw_in(),
 		      "pin_get_raw low failed");
 
 	rc = gpio_pin_set_raw(dev, PIN_OUT, 32);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "pin_set_raw high failed");
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "pin_set_raw high failed");
 
 	rc = gpio_pin_set_raw(dev, PIN_OUT, 0);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "pin_set_raw low failed");
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "pin_set_raw low failed");
 
 	rc = gpio_pin_toggle(dev, PIN_OUT);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "pin_toggle low-to-high failed");
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "pin_toggle low-to-high mismatch");
 
 	rc = gpio_pin_toggle(dev, PIN_OUT);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "pin_toggle high-to-low failed");
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "pin_toggle high-to-low mismatch");
 
 	return TC_PASS;
@@ -280,42 +280,42 @@ static int check_raw_output_levels(void)
 
 	rc = gpio_pin_configure(dev, PIN_OUT,
 				GPIO_ACTIVE_HIGH | GPIO_OUTPUT_LOW);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "active high output low failed");
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "active high output low raw mismatch");
 	raw_out(true);
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "set high mismatch");
 
 	rc = gpio_pin_configure(dev, PIN_OUT,
 				GPIO_ACTIVE_HIGH | GPIO_OUTPUT_HIGH);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "active high output high failed");
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "active high output high raw mismatch");
 	raw_out(false);
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "set low mismatch");
 
 	rc = gpio_pin_configure(dev, PIN_OUT,
 				GPIO_ACTIVE_LOW | GPIO_OUTPUT_LOW);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "active low output low failed");
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "active low output low raw mismatch");
 	raw_out(true);
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "set high mismatch");
 
 	rc = gpio_pin_configure(dev, PIN_OUT,
 				GPIO_ACTIVE_LOW | GPIO_OUTPUT_HIGH);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "active low output high failed");
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "active low output high raw mismatch");
 	raw_out(false);
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "set low mismatch");
 
 	return TC_PASS;
@@ -332,43 +332,43 @@ static int check_logic_output_levels(void)
 
 	rc = gpio_pin_configure(dev, PIN_OUT,
 				GPIO_ACTIVE_HIGH | GPIO_OUTPUT_INACTIVE);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "active true output false failed: %d", rc);
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "active true output false logic mismatch");
 	logic_out(true);
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "set true mismatch");
 
 	rc = gpio_pin_configure(dev, PIN_OUT,
 				GPIO_ACTIVE_HIGH | GPIO_OUTPUT_ACTIVE);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "active true output true failed");
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "active true output true logic mismatch");
 	logic_out(false);
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "set false mismatch");
 
 	rc = gpio_pin_configure(dev, PIN_OUT,
 				GPIO_ACTIVE_LOW | GPIO_OUTPUT_ACTIVE);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "active low output true failed");
 
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "active low output true raw mismatch");
 	logic_out(false);
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "set false mismatch");
 
 	rc = gpio_pin_configure(dev, PIN_OUT,
 				GPIO_ACTIVE_LOW | GPIO_OUTPUT_INACTIVE);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "active low output false failed");
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "active low output false logic mismatch");
 	logic_out(true);
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "set true mismatch");
 
 	return TC_PASS;
@@ -384,38 +384,38 @@ static int check_input_levels(void)
 	TC_PRINT("- %s\n", __func__);
 
 	rc = gpio_pin_configure(dev, PIN_OUT, GPIO_OUTPUT);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "output configure failed");
 
 	rc = gpio_pin_configure(dev, PIN_IN, GPIO_INPUT);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "active high failed");
 	raw_out(true);
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "raw high mismatch");
-	zassert_equal(logic_in(), true,
+	ztest_equal(logic_in(), true,
 		      "logic high mismatch");
 
 	raw_out(false);
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "raw low mismatch");
-	zassert_equal(logic_in(), false,
+	ztest_equal(logic_in(), false,
 		      "logic low mismatch");
 
 	rc = gpio_pin_configure(dev, PIN_IN, GPIO_INPUT | GPIO_ACTIVE_LOW);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "active low failed");
 
 	raw_out(true);
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "raw high mismatch");
-	zassert_equal(logic_in(), false,
+	ztest_equal(logic_in(), false,
 		      "logic inactive mismatch");
 
 	raw_out(false);
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "raw low mismatch");
-	zassert_equal(logic_in(), true,
+	ztest_equal(logic_in(), true,
 		      "logic active mismatch");
 
 	return TC_PASS;
@@ -439,7 +439,7 @@ static int check_pulls(void)
 		TC_PRINT("NOTE: cannot configure pin as disconnected; trying as input\n");
 		rc = gpio_pin_configure(dev, PIN_OUT, GPIO_INPUT);
 	}
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "output disconnect failed");
 
 	rc = gpio_pin_configure(dev, PIN_IN, GPIO_INPUT | GPIO_PULL_UP);
@@ -451,7 +451,7 @@ static int check_pulls(void)
 		TC_ERROR("input pull-up fail: %d\n", rc);
 		return TC_FAIL;
 	}
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "physical pull-up does not read high");
 
 	rc = gpio_pin_configure(dev, PIN_IN, GPIO_INPUT | GPIO_PULL_DOWN);
@@ -463,7 +463,7 @@ static int check_pulls(void)
 		TC_ERROR("input pull-down fail: %d\n", rc);
 		return TC_FAIL;
 	}
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "physical pull-down does not read low");
 
 	/* Test that pull is not affected by active level */
@@ -476,9 +476,9 @@ static int check_pulls(void)
 		TC_ERROR("input pull-up fail: %d\n", rc);
 		return TC_FAIL;
 	}
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "logical pull-up does not read high");
-	zassert_equal(logic_in(), false,
+	ztest_equal(logic_in(), false,
 		      "logical pull-up reads true");
 
 	rc = gpio_pin_configure(dev, PIN_IN, GPIO_INPUT | GPIO_ACTIVE_LOW | GPIO_PULL_DOWN);
@@ -490,9 +490,9 @@ static int check_pulls(void)
 		TC_ERROR("input pull-up fail: %d\n", rc);
 		return TC_FAIL;
 	}
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "logical pull-down does not read low");
-	zassert_equal(logic_in(), true,
+	ztest_equal(logic_in(), true,
 		      "logical pull-down reads false");
 
 	return TC_PASS;
@@ -511,72 +511,72 @@ static int bits_logical(void)
 
 	rc = gpio_pin_configure(dev, PIN_OUT,
 				GPIO_OUTPUT_HIGH | GPIO_ACTIVE_LOW);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "output configure failed");
-	zassert_equal(raw_in(), true,
+	ztest_equal(raw_in(), true,
 		      "raw out high mismatch");
-	zassert_equal(logic_in(), !raw_in(),
+	ztest_equal(logic_in(), !raw_in(),
 		      "logic in active mismatch");
 
 	/* port_set_bits */
 	rc = gpio_port_set_bits(dev, BIT(PIN_OUT));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "port set raw out failed");
-	zassert_equal(raw_in(), false,
+	ztest_equal(raw_in(), false,
 		      "raw low set mismatch");
-	zassert_equal(logic_in(), !raw_in(),
+	ztest_equal(logic_in(), !raw_in(),
 		      "logic in inactive mismatch");
 
 	/* port_clear_bits */
 	rc = gpio_port_clear_bits(dev, BIT(PIN_OUT));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "port clear raw out failed");
-	zassert_equal(logic_in(), false,
+	ztest_equal(logic_in(), false,
 		      "low clear mismatch");
 
 	/* set after clear changes */
 	rc = gpio_port_set_bits_raw(dev, BIT(PIN_OUT));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "port set raw out failed");
-	zassert_equal(logic_in(), false,
+	ztest_equal(logic_in(), false,
 		      "raw set mismatch");
 
 	/* pin_set false */
 	rc = gpio_pin_set(dev, PIN_OUT, 0);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "pin clear failed");
-	zassert_equal(logic_in(), false,
+	ztest_equal(logic_in(), false,
 		      "pin clear mismatch");
 
 	/* pin_set true */
 	rc = gpio_pin_set(dev, PIN_OUT, 32);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "pin set failed");
-	zassert_equal(logic_in(), true,
+	ztest_equal(logic_in(), true,
 		      "pin set mismatch");
 
 	rc = gpio_port_set_masked(dev, BIT(PIN_OUT), 0);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "set_masked low failed");
-	zassert_equal(logic_in(), false,
+	ztest_equal(logic_in(), false,
 		      "set_masked low mismatch");
 
 	rc = gpio_port_set_masked(dev, BIT(PIN_OUT), ALL_BITS);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "set_masked high failed");
-	zassert_equal(logic_in(), true,
+	ztest_equal(logic_in(), true,
 		      "set_masked high mismatch");
 
 	rc = gpio_port_set_clr_bits(dev, BIT(PIN_IN), BIT(PIN_OUT));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "set in clear out failed");
-	zassert_equal(logic_in(), false,
+	ztest_equal(logic_in(), false,
 		      "set in clear out mismatch");
 
 	rc = gpio_port_set_clr_bits(dev, BIT(PIN_OUT), BIT(PIN_IN));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "set out clear in failed");
-	zassert_equal(logic_in(), true,
+	ztest_equal(logic_in(), true,
 		      "set out clear in mismatch");
 
 	/* Conditionally verify that behavior with __ASSERT disabled
@@ -585,36 +585,36 @@ static int bits_logical(void)
 	if (false) {
 		/* preserve set */
 		rc = gpio_port_set_clr_bits(dev, BIT(PIN_OUT), BIT(PIN_OUT));
-		zassert_equal(rc, 0,
+		ztest_equal(rc, 0,
 			      "s/c set toggle failed");
-		zassert_equal(logic_in(), false,
+		ztest_equal(logic_in(), false,
 			      "s/c set toggle mismatch");
 
 		/* force set */
 		raw_out(true);
 		rc = gpio_port_set_clr_bits(dev, BIT(PIN_OUT), BIT(PIN_OUT));
-		zassert_equal(rc, 0,
+		ztest_equal(rc, 0,
 			      "s/c dup set failed");
-		zassert_equal(logic_in(), false,
+		ztest_equal(logic_in(), false,
 			      "s/c dup set mismatch");
 	}
 
 	rc = gpio_port_toggle_bits(dev, BIT(PIN_OUT));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "toggle_bits active-to-inactive failed");
-	zassert_equal(logic_in(), false,
+	ztest_equal(logic_in(), false,
 		      "toggle_bits active-to-inactive mismatch");
 
 	rc = gpio_port_toggle_bits(dev, BIT(PIN_OUT));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "toggle_bits inactive-to-active failed");
-	zassert_equal(logic_in(), true,
+	ztest_equal(logic_in(), true,
 		      "toggle_bits inactive-to-active mismatch");
 
 	rc = gpio_pin_toggle(dev, PIN_OUT);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "pin_toggle low-to-high failed");
-	zassert_equal(logic_in(), false,
+	ztest_equal(logic_in(), false,
 		      "pin_toggle low-to-high mismatch");
 
 	return TC_PASS;
@@ -622,20 +622,20 @@ static int bits_logical(void)
 
 void test_gpio_port(void)
 {
-	zassert_equal(setup(), TC_PASS,
+	ztest_equal(setup(), TC_PASS,
 		      "device setup failed");
-	zassert_equal(bits_physical(), TC_PASS,
+	ztest_equal(bits_physical(), TC_PASS,
 		      "bits_physical failed");
-	zassert_equal(pin_physical(), TC_PASS,
+	ztest_equal(pin_physical(), TC_PASS,
 		      "pin_physical failed");
-	zassert_equal(check_raw_output_levels(), TC_PASS,
+	ztest_equal(check_raw_output_levels(), TC_PASS,
 		      "check_raw_output_levels failed");
-	zassert_equal(check_logic_output_levels(), TC_PASS,
+	ztest_equal(check_logic_output_levels(), TC_PASS,
 		      "check_logic_output_levels failed");
-	zassert_equal(check_input_levels(), TC_PASS,
+	ztest_equal(check_input_levels(), TC_PASS,
 		      "check_input_levels failed");
-	zassert_equal(bits_logical(), TC_PASS,
+	ztest_equal(bits_logical(), TC_PASS,
 		      "bits_logical failed");
-	zassert_equal(check_pulls(), TC_PASS,
+	ztest_equal(check_pulls(), TC_PASS,
 		      "check_pulls failed");
 }

--- a/tests/drivers/hwinfo/api/src/main.c
+++ b/tests/drivers/hwinfo/api/src/main.c
@@ -35,16 +35,16 @@ static void test_device_id_get(void)
 	int i;
 
 	length_read_1 = hwinfo_get_device_id(buffer_1, 1);
-	zassert_not_equal(length_read_1, -ENOTSUP, "Not supported by hardware");
-	zassert_false((length_read_1 < 0),
+	ztest_not_equal(length_read_1, -ENOTSUP, "Not supported by hardware");
+	ztest_false((length_read_1 < 0),
 		      "Unexpected negative return value: %d", length_read_1);
-	zassert_not_equal(length_read_1, 0, "Zero bytes read");
-	zassert_equal(length_read_1, 1, "Length not adhered");
+	ztest_not_equal(length_read_1, 0, "Zero bytes read");
+	ztest_equal(length_read_1, 1, "Length not adhered");
 
 	memset(buffer_1, BUFFER_CANARY, sizeof(buffer_1));
 
 	length_read_1 = hwinfo_get_device_id(buffer_1, BUFFER_LENGTH - 1);
-	zassert_equal(buffer_1[length_read_1], BUFFER_CANARY,
+	ztest_equal(buffer_1[length_read_1], BUFFER_CANARY,
 		      "Too many bytes are written");
 
 	memcpy(buffer_2, buffer_1, length_read_1);
@@ -54,13 +54,13 @@ static void test_device_id_get(void)
 	}
 
 	length_read_2 = hwinfo_get_device_id(buffer_1, BUFFER_LENGTH - 1);
-	zassert_equal(length_read_1, length_read_2, "Length varied");
+	ztest_equal(length_read_1, length_read_2, "Length varied");
 
-	zassert_equal(buffer_1[length_read_1], (BUFFER_CANARY ^ 0xA5),
+	ztest_equal(buffer_1[length_read_1], (BUFFER_CANARY ^ 0xA5),
 		      "Too many bytes are written");
 
 	for (i = 0; i < length_read_1; i++) {
-		zassert_equal(buffer_1[i], buffer_2[i],
+		ztest_equal(buffer_1[i], buffer_2[i],
 			      "Two consecutively readings don't match");
 	}
 }
@@ -78,7 +78,7 @@ static void test_device_id_enotsup(void)
 	/* There is no hwinfo driver for this platform, hence the return value
 	 * should be -ENOTSUP
 	 */
-	zassert_equal(ret, -ENOTSUP,
+	ztest_equal(ret, -ENOTSUP,
 		      "hwinfo_get_device_id returned % instead of %d",
 		      ret, -ENOTSUP);
 }

--- a/tests/drivers/i2c/i2c_api/src/test_i2c.c
+++ b/tests/drivers/i2c/i2c_api/src/test_i2c.c
@@ -129,10 +129,10 @@ static int test_burst_gy271(void)
 
 void test_i2c_gy271(void)
 {
-	zassert_true(test_gy271() == TC_PASS, NULL);
+	ztest_true(test_gy271() == TC_PASS, NULL);
 }
 
 void test_i2c_burst_gy271(void)
 {
-	zassert_true(test_burst_gy271() == TC_PASS, NULL);
+	ztest_true(test_burst_gy271() == TC_PASS, NULL);
 }

--- a/tests/drivers/i2c/i2c_slave_api/src/main.c
+++ b/tests/drivers/i2c/i2c_slave_api/src/main.c
@@ -53,7 +53,7 @@ static void run_full_read(struct device *i2c, u8_t addr, u8_t *comp_buffer)
 	/* Read EEPROM from I2C Master requests, then compare */
 	ret = i2c_burst_read(i2c, addr,
 			     0, i2c_buffer, TEST_DATA_SIZE);
-	zassert_equal(ret, 0, "Failed to read EEPROM");
+	ztest_equal(ret, 0, "Failed to read EEPROM");
 
 	if (memcmp(i2c_buffer, comp_buffer, TEST_DATA_SIZE)) {
 		to_display_format(i2c_buffer, TEST_DATA_SIZE,
@@ -79,7 +79,7 @@ static void run_partial_read(struct device *i2c, u8_t addr, u8_t *comp_buffer,
 
 	ret = i2c_burst_read(i2c, addr,
 			     offset, i2c_buffer, TEST_DATA_SIZE-offset);
-	zassert_equal(ret, 0, "Failed to read EEPROM");
+	ztest_equal(ret, 0, "Failed to read EEPROM");
 
 	if (memcmp(i2c_buffer, &comp_buffer[offset], TEST_DATA_SIZE-offset)) {
 		to_display_format(i2c_buffer, TEST_DATA_SIZE-offset,
@@ -108,14 +108,14 @@ static void run_program_read(struct device *i2c, u8_t addr, unsigned int offset)
 
 	ret = i2c_burst_write(i2c, addr,
 			      offset, i2c_buffer, TEST_DATA_SIZE-offset);
-	zassert_equal(ret, 0, "Failed to write EEPROM");
+	ztest_equal(ret, 0, "Failed to write EEPROM");
 
 	(void)memset(i2c_buffer, 0xFF, TEST_DATA_SIZE);
 
 	/* Read back EEPROM from I2C Master requests, then compare */
 	ret = i2c_burst_read(i2c, addr,
 			     offset, i2c_buffer, TEST_DATA_SIZE-offset);
-	zassert_equal(ret, 0, "Failed to read EEPROM");
+	ztest_equal(ret, 0, "Failed to read EEPROM");
 
 	for (i = 0 ; i < TEST_DATA_SIZE-offset ; ++i) {
 		if (i2c_buffer[i] != i) {
@@ -140,7 +140,7 @@ void test_eeprom_slave(void)
 
 	i2c_0 = device_get_binding(
 			DT_INST_0_ATMEL_AT24_BUS_NAME);
-	zassert_not_null(i2c_0, "I2C device %s not found",
+	ztest_not_null(i2c_0, "I2C device %s not found",
 			 DT_INST_0_ATMEL_AT24_BUS_NAME);
 
 	LOG_INF("Found I2C Master device %s",
@@ -148,7 +148,7 @@ void test_eeprom_slave(void)
 
 	i2c_1 = device_get_binding(
 			DT_INST_1_ATMEL_AT24_BUS_NAME);
-	zassert_not_null(i2c_1, "I2C device %s not found",
+	ztest_not_null(i2c_1, "I2C device %s not found",
 			 DT_INST_1_ATMEL_AT24_BUS_NAME);
 
 	LOG_INF("Found I2C Master device %s",
@@ -172,35 +172,35 @@ void test_eeprom_slave(void)
 	 */
 
 	eeprom_0 = device_get_binding(DT_INST_0_ATMEL_AT24_LABEL);
-	zassert_not_null(eeprom_0, "EEPROM device %s not found",
+	ztest_not_null(eeprom_0, "EEPROM device %s not found",
 			 DT_INST_0_ATMEL_AT24_LABEL);
 
 	LOG_INF("Found EEPROM device %s", DT_INST_0_ATMEL_AT24_LABEL);
 
 	eeprom_1 = device_get_binding(DT_INST_1_ATMEL_AT24_LABEL);
-	zassert_not_null(eeprom_1, "EEPROM device %s not found",
+	ztest_not_null(eeprom_1, "EEPROM device %s not found",
 			 DT_INST_1_ATMEL_AT24_LABEL);
 
 	LOG_INF("Found EEPROM device %s", DT_INST_1_ATMEL_AT24_LABEL);
 
 	/* Program dummy bytes */
 	ret = eeprom_slave_program(eeprom_0, eeprom_0_data, TEST_DATA_SIZE);
-	zassert_equal(ret, 0, "Failed to program EEPROM %s",
+	ztest_equal(ret, 0, "Failed to program EEPROM %s",
 		      DT_INST_0_ATMEL_AT24_LABEL);
 
 	ret = eeprom_slave_program(eeprom_1, eeprom_1_data, TEST_DATA_SIZE);
-	zassert_equal(ret, 0, "Failed to program EEPROM %s",
+	ztest_equal(ret, 0, "Failed to program EEPROM %s",
 		      DT_INST_1_ATMEL_AT24_LABEL);
 
 	/* Attach EEPROM */
 	ret = i2c_slave_driver_register(eeprom_0);
-	zassert_equal(ret, 0, "Failed to register EEPROM %s",
+	ztest_equal(ret, 0, "Failed to register EEPROM %s",
 		      DT_INST_0_ATMEL_AT24_LABEL);
 
 	LOG_INF("EEPROM %s Attached !", DT_INST_0_ATMEL_AT24_LABEL);
 
 	ret = i2c_slave_driver_register(eeprom_1);
-	zassert_equal(ret, 0, "Failed to register EEPROM %s",
+	ztest_equal(ret, 0, "Failed to register EEPROM %s",
 		      DT_INST_1_ATMEL_AT24_LABEL);
 
 	LOG_INF("EEPROM %s Attached !", DT_INST_1_ATMEL_AT24_LABEL);
@@ -233,14 +233,14 @@ void test_eeprom_slave(void)
 
 	/* Detach EEPROM */
 	ret = i2c_slave_driver_unregister(eeprom_0);
-	zassert_equal(ret, 0, "Failed to unregister EEPROM %s",
+	ztest_equal(ret, 0, "Failed to unregister EEPROM %s",
 		      DT_INST_0_ATMEL_AT24_LABEL);
 
 	LOG_INF("EEPROM %s Detached !",
 		    DT_INST_0_ATMEL_AT24_LABEL);
 
 	ret = i2c_slave_driver_unregister(eeprom_1);
-	zassert_equal(ret, 0, "Failed to unregister EEPROM %s",
+	ztest_equal(ret, 0, "Failed to unregister EEPROM %s",
 		      DT_INST_1_ATMEL_AT24_LABEL);
 
 	LOG_INF("EEPROM %s Detached !",

--- a/tests/drivers/i2s/i2s_api/src/test_i2s_loopback.c
+++ b/tests/drivers/i2s/i2s_api/src/test_i2s_loopback.c
@@ -39,7 +39,7 @@ void test_i2s_tx_transfer_configure_0(void)
 	int ret;
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	/* Configure */
 
@@ -54,7 +54,7 @@ void test_i2s_tx_transfer_configure_0(void)
 	i2s_cfg.options = I2S_OPT_LOOPBACK;
 
 	ret = i2s_configure(dev_i2s, I2S_DIR_TX, &i2s_cfg);
-	zassert_equal(ret, 0, "Failed to configure I2S TX stream");
+	ztest_equal(ret, 0, "Failed to configure I2S TX stream");
 }
 
 /** Configure I2S RX transfer. */
@@ -65,7 +65,7 @@ void test_i2s_rx_transfer_configure_0(void)
 	int ret;
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	/* Configure */
 
@@ -80,7 +80,7 @@ void test_i2s_rx_transfer_configure_0(void)
 	i2s_cfg.options = I2S_OPT_LOOPBACK;
 
 	ret = i2s_configure(dev_i2s, I2S_DIR_RX, &i2s_cfg);
-	zassert_equal(ret, 0, "Failed to configure I2S RX stream");
+	ztest_equal(ret, 0, "Failed to configure I2S RX stream");
 }
 
 /** @brief Short I2S transfer.
@@ -97,47 +97,47 @@ void test_i2s_transfer_short(void)
 	int ret;
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 	TC_PRINT("%d->OK\n", 1);
 
 	ret = tx_block_write(dev_i2s, 1, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 	TC_PRINT("%d->OK\n", 2);
 
 	/* Start reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "RX START trigger failed");
+	ztest_equal(ret, 0, "RX START trigger failed");
 
 	/* Start transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "TX START trigger failed");
+	ztest_equal(ret, 0, "TX START trigger failed");
 
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 	TC_PRINT("%d<-OK\n", 1);
 
 	ret = tx_block_write(dev_i2s, 2, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 	TC_PRINT("%d->OK\n", 3);
 
 	/* All data written, drain TX queue and stop the transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, 0, "TX DRAIN trigger failed");
+	ztest_equal(ret, 0, "TX DRAIN trigger failed");
 
 	ret = rx_block_read(dev_i2s, 1);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 	TC_PRINT("%d<-OK\n", 2);
 
 	/* All but one data block read, stop reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, 0, "RX STOP trigger failed");
+	ztest_equal(ret, 0, "RX STOP trigger failed");
 
 	ret = rx_block_read(dev_i2s, 2);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 	TC_PRINT("%d<-OK\n", 3);
 
 	/* TODO: Verify the interface is in READY state when i2s_state_get
@@ -161,38 +161,38 @@ void test_i2s_transfer_long(void)
 	int ret;
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 
 	/* Start reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "RX START trigger failed");
+	ztest_equal(ret, 0, "RX START trigger failed");
 
 	/* Start transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "TX START trigger failed");
+	ztest_equal(ret, 0, "TX START trigger failed");
 
 	for (int i = 0; i < TEST_I2S_TRANSFER_LONG_REPEAT_COUNT; i++) {
 		ret = tx_block_write(dev_i2s, 0, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		ztest_equal(ret, TC_PASS, NULL);
 
 		ret = rx_block_read(dev_i2s, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		ztest_equal(ret, TC_PASS, NULL);
 	}
 
 	/* All data written, flush TX queue and stop the transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, 0, "TX DRAIN trigger failed");
+	ztest_equal(ret, 0, "TX DRAIN trigger failed");
 
 	/* All but one data block read, stop reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, 0, "RX STOP trigger failed");
+	ztest_equal(ret, 0, "RX STOP trigger failed");
 
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 
 	/* TODO: Verify the interface is in READY state when i2s_state_get
 	 * function is available.
@@ -215,38 +215,38 @@ void test_i2s_rx_sync_start(void)
 	char buf[BLOCK_SIZE];
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	/* Prefill TX queue */
 	for (int n = 0; n < NUM_TX_BLOCKS; n++) {
 		fill_buf_const((u16_t *)buf, 1, 2);
 		ret = i2s_buf_write(dev_i2s, buf, BLOCK_SIZE);
-		zassert_equal(ret, TC_PASS, NULL);
+		ztest_equal(ret, TC_PASS, NULL);
 		TC_PRINT("%d->OK\n", n);
 	}
 
 	/* Start transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "TX START trigger failed");
+	ztest_equal(ret, 0, "TX START trigger failed");
 
 	k_busy_wait(75);
 
 	/* Start reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "RX START trigger failed");
+	ztest_equal(ret, 0, "RX START trigger failed");
 	ret = i2s_buf_read(dev_i2s, buf, &rx_size);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 	ret = verify_buf_const((u16_t *)buf, 1, 2);
 
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 	TC_PRINT("%d<-OK\n", 1);
 
 	/* All data written, drop TX, RX queue and stop the transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_DROP);
-	zassert_equal(ret, 0, "TX DROP trigger failed");
+	ztest_equal(ret, 0, "TX DROP trigger failed");
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_DROP);
-	zassert_equal(ret, 0, "RX DROP trigger failed");
+	ztest_equal(ret, 0, "RX DROP trigger failed");
 
 	/* TODO: Verify the interface is in READY state when i2s_state_get
 	 * function is available.
@@ -265,10 +265,10 @@ void test_i2s_rx_empty_timeout(void)
 	char buf[BLOCK_SIZE];
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	ret = i2s_buf_read(dev_i2s, buf, &rx_size);
-	zassert_equal(ret, -EAGAIN, "i2s_read did not timed out");
+	ztest_equal(ret, -EAGAIN, "i2s_read did not timed out");
 }
 
 #define TEST_I2S_TRANSFER_RESTART_PAUSE_LENGTH_US  1000
@@ -285,35 +285,35 @@ void test_i2s_transfer_restart(void)
 	int ret;
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 	TC_PRINT("%d->OK\n", 1);
 
 	ret = tx_block_write(dev_i2s, 1, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 	TC_PRINT("%d->OK\n", 2);
 
 	/* Start reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "RX START trigger failed");
+	ztest_equal(ret, 0, "RX START trigger failed");
 
 	/* Start transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "TX START trigger failed");
+	ztest_equal(ret, 0, "TX START trigger failed");
 
 	/* Stop transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, 0, "TX STOP trigger failed");
+	ztest_equal(ret, 0, "TX STOP trigger failed");
 
 	/* Stop reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, 0, "RX STOP trigger failed");
+	ztest_equal(ret, 0, "RX STOP trigger failed");
 
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 	TC_PRINT("%d<-OK\n", 1);
 
 	TC_PRINT("Stop transmission\n");
@@ -325,31 +325,31 @@ void test_i2s_transfer_restart(void)
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s, 2, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 	TC_PRINT("%d->OK\n", 3);
 
 	/* Start reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "RX START trigger failed");
+	ztest_equal(ret, 0, "RX START trigger failed");
 
 	/* Start transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "TX START trigger failed");
+	ztest_equal(ret, 0, "TX START trigger failed");
 
 	/* All data written, drain TX queue and stop the transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, 0, "TX DRAIN trigger failed");
+	ztest_equal(ret, 0, "TX DRAIN trigger failed");
 
 	ret = rx_block_read(dev_i2s, 1);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 	TC_PRINT("%d<-OK\n", 2);
 
 	/* All but one data block read, stop reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, 0, "RX STOP trigger failed");
+	ztest_equal(ret, 0, "RX STOP trigger failed");
 
 	ret = rx_block_read(dev_i2s, 2);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 	TC_PRINT("%d<-OK\n", 3);
 }
 
@@ -372,28 +372,28 @@ void test_i2s_transfer_rx_overrun(void)
 	char rx_buf[BLOCK_SIZE];
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 
 	/* Start reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "RX START trigger failed");
+	ztest_equal(ret, 0, "RX START trigger failed");
 
 	/* Start transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "TX START trigger failed");
+	ztest_equal(ret, 0, "TX START trigger failed");
 
 	for (int i = 0; i < NUM_RX_BLOCKS; i++) {
 		ret = tx_block_write(dev_i2s, 0, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		ztest_equal(ret, TC_PASS, NULL);
 	}
 
 	/* All data written, flush TX queue and stop the transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, 0, "TX DRAIN trigger failed");
+	ztest_equal(ret, 0, "TX DRAIN trigger failed");
 
 	/* Wait for transmission to finish */
 	k_sleep(TEST_I2S_TRANSFER_RX_OVERRUN_PAUSE_LENGTH_US);
@@ -401,30 +401,30 @@ void test_i2s_transfer_rx_overrun(void)
 	/* Read all available data blocks in RX queue */
 	for (int i = 0; i < NUM_RX_BLOCKS; i++) {
 		ret = rx_block_read(dev_i2s, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		ztest_equal(ret, TC_PASS, NULL);
 	}
 
 	/* Attempt to read one more data block, expect an error */
 	ret = i2s_buf_read(dev_i2s, rx_buf, &rx_size);
 
-	zassert_equal(ret, -EIO, "RX overrun error not detected");
+	ztest_equal(ret, -EIO, "RX overrun error not detected");
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_PREPARE);
-	zassert_equal(ret, 0, "RX PREPARE trigger failed");
+	ztest_equal(ret, 0, "RX PREPARE trigger failed");
 
 	/* Transmit and receive one more data block */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "RX START trigger failed");
+	ztest_equal(ret, 0, "RX START trigger failed");
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "TX START trigger failed");
+	ztest_equal(ret, 0, "TX START trigger failed");
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, 0, "TX DRAIN trigger failed");
+	ztest_equal(ret, 0, "TX DRAIN trigger failed");
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, 0, "RX STOP trigger failed");
+	ztest_equal(ret, 0, "RX STOP trigger failed");
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 
 	k_sleep(K_MSEC(200));
 }
@@ -442,55 +442,55 @@ void test_i2s_transfer_tx_underrun(void)
 	int ret;
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 
 	/* Start reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "RX START trigger failed");
+	ztest_equal(ret, 0, "RX START trigger failed");
 
 	/* Start transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "TX START trigger failed");
+	ztest_equal(ret, 0, "TX START trigger failed");
 
 	/* Stop reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, 0, "RX STOP trigger failed");
+	ztest_equal(ret, 0, "RX STOP trigger failed");
 
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 
 	k_sleep(K_MSEC(200));
 
 	/* Write one more TX data block, expect an error */
 	ret = tx_block_write(dev_i2s, 2, -EIO);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_PREPARE);
-	zassert_equal(ret, 0, "TX PREPARE trigger failed");
+	ztest_equal(ret, 0, "TX PREPARE trigger failed");
 
 	k_sleep(K_MSEC(200));
 
 	/* Transmit and receive two more data blocks */
 	ret = tx_block_write(dev_i2s, 1, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 	ret = tx_block_write(dev_i2s, 1, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "RX START trigger failed");
+	ztest_equal(ret, 0, "RX START trigger failed");
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "TX START trigger failed");
+	ztest_equal(ret, 0, "TX START trigger failed");
 	ret = rx_block_read(dev_i2s, 1);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, 0, "TX DRAIN trigger failed");
+	ztest_equal(ret, 0, "TX DRAIN trigger failed");
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, 0, "RX STOP trigger failed");
+	ztest_equal(ret, 0, "RX STOP trigger failed");
 	ret = rx_block_read(dev_i2s, 1);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 
 	k_sleep(K_MSEC(200));
 }

--- a/tests/drivers/i2s/i2s_api/src/test_i2s_states.c
+++ b/tests/drivers/i2s/i2s_api/src/test_i2s_states.c
@@ -41,7 +41,7 @@ void test_i2s_tx_transfer_configure_1(void)
 	int ret;
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	/* Configure */
 
@@ -56,7 +56,7 @@ void test_i2s_tx_transfer_configure_1(void)
 	i2s_cfg.options = I2S_OPT_LOOPBACK;
 
 	ret = i2s_configure(dev_i2s, I2S_DIR_TX, &i2s_cfg);
-	zassert_equal(ret, 0, "Failed to configure I2S TX stream");
+	ztest_equal(ret, 0, "Failed to configure I2S TX stream");
 }
 
 /** Configure I2S RX transfer. */
@@ -67,7 +67,7 @@ void test_i2s_rx_transfer_configure_1(void)
 	int ret;
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	/* Configure */
 
@@ -82,7 +82,7 @@ void test_i2s_rx_transfer_configure_1(void)
 	i2s_cfg.options = I2S_OPT_LOOPBACK;
 
 	ret = i2s_configure(dev_i2s, I2S_DIR_RX, &i2s_cfg);
-	zassert_equal(ret, 0, "Failed to configure I2S RX stream");
+	ztest_equal(ret, 0, "Failed to configure I2S RX stream");
 }
 
 /** @brief Verify all failure cases in NOT_READY state.
@@ -101,55 +101,55 @@ void test_i2s_state_not_ready_neg(void)
 	char rx_buf[BLOCK_SIZE];
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	i2s_cfg.frame_clk_freq = 0U;
 	i2s_cfg.mem_slab = &rx_1_mem_slab;
 
 	ret = i2s_configure(dev_i2s, I2S_DIR_RX, &i2s_cfg);
-	zassert_equal(ret, 0, "Failed to configure I2S RX stream");
+	ztest_equal(ret, 0, "Failed to configure I2S RX stream");
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_DROP);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_PREPARE);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	ret = i2s_buf_read(dev_i2s, rx_buf, &rx_size);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	i2s_cfg.frame_clk_freq = 0U;
 	i2s_cfg.mem_slab = &tx_1_mem_slab;
 
 	ret = i2s_configure(dev_i2s, I2S_DIR_TX, &i2s_cfg);
-	zassert_equal(ret, 0, "Failed to configure I2S TX stream");
+	ztest_equal(ret, 0, "Failed to configure I2S TX stream");
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_DROP);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_PREPARE);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	ret = tx_block_write(dev_i2s, 2, -EIO);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 }
 
 /** @brief Verify all failure cases in READY state.
@@ -163,7 +163,7 @@ void test_i2s_state_ready_neg(void)
 	int ret;
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	/* Configure RX stream changing its state to READY */
 
@@ -177,18 +177,18 @@ void test_i2s_state_ready_neg(void)
 	i2s_cfg.timeout = TIMEOUT;
 
 	ret = i2s_configure(dev_i2s, I2S_DIR_RX, &i2s_cfg);
-	zassert_equal(ret, 0, "Failed to configure I2S RX stream");
+	ztest_equal(ret, 0, "Failed to configure I2S RX stream");
 
 	/* Send RX stream triggers */
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_PREPARE);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	/* Configure TX stream changing its state to READY */
 
@@ -196,18 +196,18 @@ void test_i2s_state_ready_neg(void)
 	i2s_cfg.mem_slab = &tx_1_mem_slab;
 
 	ret = i2s_configure(dev_i2s, I2S_DIR_TX, &i2s_cfg);
-	zassert_equal(ret, 0, "Failed to configure I2S RX stream");
+	ztest_equal(ret, 0, "Failed to configure I2S RX stream");
 
 	/* Send TX stream triggers */
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_PREPARE);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 }
 
 #define TEST_I2S_STATE_RUNNING_NEG_REPEAT_COUNT  5
@@ -222,48 +222,48 @@ void test_i2s_state_running_neg(void)
 	int ret;
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 
 	/* Start reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "RX START trigger failed");
+	ztest_equal(ret, 0, "RX START trigger failed");
 
 	/* Start transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "TX START trigger failed");
+	ztest_equal(ret, 0, "TX START trigger failed");
 
 	for (int i = 0; i < TEST_I2S_STATE_RUNNING_NEG_REPEAT_COUNT; i++) {
 		ret = tx_block_write(dev_i2s, 0, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		ztest_equal(ret, TC_PASS, NULL);
 
 		ret = rx_block_read(dev_i2s, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		ztest_equal(ret, TC_PASS, NULL);
 
 		/* Send invalid triggers, expect failure */
 		ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-		zassert_equal(ret, -EIO, NULL);
+		ztest_equal(ret, -EIO, NULL);
 		ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_PREPARE);
-		zassert_equal(ret, -EIO, NULL);
+		ztest_equal(ret, -EIO, NULL);
 		ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
-		zassert_equal(ret, -EIO, NULL);
+		ztest_equal(ret, -EIO, NULL);
 		ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_PREPARE);
-		zassert_equal(ret, -EIO, NULL);
+		ztest_equal(ret, -EIO, NULL);
 	}
 
 	/* All data written, flush TX queue and stop the transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, 0, "TX DRAIN trigger failed");
+	ztest_equal(ret, 0, "TX DRAIN trigger failed");
 
 	/* All but one data block read, stop reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, 0, "RX STOP trigger failed");
+	ztest_equal(ret, 0, "RX STOP trigger failed");
 
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 }
 
 /** @brief Verify all failure cases in STOPPING state.
@@ -277,56 +277,56 @@ void test_i2s_state_stopping_neg(void)
 	int ret;
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 
 	/* Start reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "RX START trigger failed");
+	ztest_equal(ret, 0, "RX START trigger failed");
 
 	/* Start transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "TX START trigger failed");
+	ztest_equal(ret, 0, "TX START trigger failed");
 
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 
 	/* All data written, flush TX queue and stop the transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, 0, "TX DRAIN trigger failed");
+	ztest_equal(ret, 0, "TX DRAIN trigger failed");
 
 	/* Send invalid triggers, expect failure */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_PREPARE);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	/* All but one data block read, stop reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, 0, "RX STOP trigger failed");
+	ztest_equal(ret, 0, "RX STOP trigger failed");
 
 	/* Send invalid triggers, expect failure */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_PREPARE);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 }
 
 #define TEST_I2S_STATE_ERROR_NEG_PAUSE_LENGTH_US  200
@@ -343,23 +343,23 @@ void test_i2s_state_error_neg(void)
 	char rx_buf[BLOCK_SIZE];
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 
 	/* Start reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "RX START trigger failed");
+	ztest_equal(ret, 0, "RX START trigger failed");
 
 	/* Start transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "TX START trigger failed");
+	ztest_equal(ret, 0, "TX START trigger failed");
 
 	for (int i = 0; i < NUM_RX_BLOCKS; i++) {
 		ret = tx_block_write(dev_i2s, 0, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		ztest_equal(ret, TC_PASS, NULL);
 	}
 
 	/* Wait for transmission to finish */
@@ -368,54 +368,54 @@ void test_i2s_state_error_neg(void)
 	/* Read all available data blocks in RX queue */
 	for (int i = 0; i < NUM_RX_BLOCKS; i++) {
 		ret = rx_block_read(dev_i2s, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		ztest_equal(ret, TC_PASS, NULL);
 	}
 
 	/* Attempt to read one more data block, expect an error */
 	ret = i2s_buf_read(dev_i2s, rx_buf, &rx_size);
-	zassert_equal(ret, -EIO, "RX overrun error not detected");
+	ztest_equal(ret, -EIO, "RX overrun error not detected");
 
 	/* Send invalid triggers, expect failure */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	/* Recover from ERROR state */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_PREPARE);
-	zassert_equal(ret, 0, "RX PREPARE trigger failed");
+	ztest_equal(ret, 0, "RX PREPARE trigger failed");
 
 	/* Write one more TX data block, expect an error */
 	ret = tx_block_write(dev_i2s, 2, -EIO);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 
 	/* Send invalid triggers, expect failure */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, -EIO, NULL);
+	ztest_equal(ret, -EIO, NULL);
 
 	/* Recover from ERROR state */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_PREPARE);
-	zassert_equal(ret, 0, "TX PREPARE trigger failed");
+	ztest_equal(ret, 0, "TX PREPARE trigger failed");
 
 	/* Transmit and receive one more data block */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "RX START trigger failed");
+	ztest_equal(ret, 0, "RX START trigger failed");
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "TX START trigger failed");
+	ztest_equal(ret, 0, "TX START trigger failed");
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, 0, "TX DRAIN trigger failed");
+	ztest_equal(ret, 0, "TX DRAIN trigger failed");
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, 0, "RX STOP trigger failed");
+	ztest_equal(ret, 0, "RX STOP trigger failed");
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	ztest_equal(ret, TC_PASS, NULL);
 
 	k_sleep(K_MSEC(200));
 }

--- a/tests/drivers/i2s/i2s_speed/src/test_i2s_speed.c
+++ b/tests/drivers/i2s/i2s_speed/src/test_i2s_speed.c
@@ -88,7 +88,7 @@ void test_i2s_tx_transfer_configure(void)
 	int ret;
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	/* Configure */
 
@@ -103,7 +103,7 @@ void test_i2s_tx_transfer_configure(void)
 	i2s_cfg.options = I2S_OPT_LOOPBACK;
 
 	ret = i2s_configure(dev_i2s, I2S_DIR_TX, &i2s_cfg);
-	zassert_equal(ret, 0, "Failed to configure I2S TX stream");
+	ztest_equal(ret, 0, "Failed to configure I2S TX stream");
 }
 
 /** Configure I2S RX transfer. */
@@ -114,7 +114,7 @@ void test_i2s_rx_transfer_configure(void)
 	int ret;
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	/* Configure */
 
@@ -129,7 +129,7 @@ void test_i2s_rx_transfer_configure(void)
 	i2s_cfg.options = I2S_OPT_LOOPBACK;
 
 	ret = i2s_configure(dev_i2s, I2S_DIR_RX, &i2s_cfg);
-	zassert_equal(ret, 0, "Failed to configure I2S RX stream");
+	ztest_equal(ret, 0, "Failed to configure I2S RX stream");
 }
 
 /** @brief Short I2S transfer.
@@ -149,61 +149,61 @@ void test_i2s_transfer_short(void)
 	int ret;
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	/* Prefill TX queue */
 	for (int i = 0; i < 3; i++) {
 		ret = k_mem_slab_alloc(&tx_0_mem_slab, &tx_block, K_FOREVER);
-		zassert_equal(ret, 0, NULL);
+		ztest_equal(ret, 0, NULL);
 		fill_buf((u16_t *)tx_block, i);
 
 		ret = i2s_write(dev_i2s, tx_block, BLOCK_SIZE);
-		zassert_equal(ret, 0, NULL);
+		ztest_equal(ret, 0, NULL);
 
 		TC_PRINT("%d->OK\n", i);
 	}
 
 	/* Start reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "RX START trigger failed");
+	ztest_equal(ret, 0, "RX START trigger failed");
 
 	/* Start transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "TX START trigger failed");
+	ztest_equal(ret, 0, "TX START trigger failed");
 
 	/* All data written, drain TX queue and stop the transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, 0, "TX DRAIN trigger failed");
+	ztest_equal(ret, 0, "TX DRAIN trigger failed");
 
 	ret = i2s_read(dev_i2s, &rx_block[0], &rx_size);
-	zassert_equal(ret, 0, NULL);
-	zassert_equal(rx_size, BLOCK_SIZE, NULL);
+	ztest_equal(ret, 0, NULL);
+	ztest_equal(rx_size, BLOCK_SIZE, NULL);
 
 	ret = i2s_read(dev_i2s, &rx_block[1], &rx_size);
-	zassert_equal(ret, 0, NULL);
-	zassert_equal(rx_size, BLOCK_SIZE, NULL);
+	ztest_equal(ret, 0, NULL);
+	ztest_equal(rx_size, BLOCK_SIZE, NULL);
 
 	/* All but one data block read, stop reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, 0, "RX STOP trigger failed");
+	ztest_equal(ret, 0, "RX STOP trigger failed");
 
 	ret = i2s_read(dev_i2s, &rx_block[2], &rx_size);
-	zassert_equal(ret, 0, NULL);
-	zassert_equal(rx_size, BLOCK_SIZE, NULL);
+	ztest_equal(ret, 0, NULL);
+	ztest_equal(rx_size, BLOCK_SIZE, NULL);
 
 	/* Verify received data */
 	ret = verify_buf((u16_t *)rx_block[0], 0);
-	zassert_equal(ret, 0, NULL);
+	ztest_equal(ret, 0, NULL);
 	k_mem_slab_free(&rx_0_mem_slab, &rx_block[0]);
 	TC_PRINT("%d<-OK\n", 1);
 
 	ret = verify_buf((u16_t *)rx_block[1], 1);
-	zassert_equal(ret, 0, NULL);
+	ztest_equal(ret, 0, NULL);
 	k_mem_slab_free(&rx_0_mem_slab, &rx_block[1]);
 	TC_PRINT("%d<-OK\n", 2);
 
 	ret = verify_buf((u16_t *)rx_block[2], 2);
-	zassert_equal(ret, 0, NULL);
+	ztest_equal(ret, 0, NULL);
 	k_mem_slab_free(&rx_0_mem_slab, &rx_block[2]);
 	TC_PRINT("%d<-OK\n", 3);
 }
@@ -228,13 +228,13 @@ void test_i2s_transfer_long(void)
 	int ret;
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
+	ztest_not_null(dev_i2s, "device " I2S_DEV_NAME " not found");
 
 	/* Prepare TX data blocks */
 	for (tx_idx = 0; tx_idx < NUM_BLOCKS; tx_idx++) {
 		ret = k_mem_slab_alloc(&tx_0_mem_slab, &tx_block[tx_idx],
 				       K_FOREVER);
-		zassert_equal(ret, 0, NULL);
+		ztest_equal(ret, 0, NULL);
 		fill_buf((u16_t *)tx_block[tx_idx], tx_idx % 3);
 	}
 
@@ -242,43 +242,43 @@ void test_i2s_transfer_long(void)
 
 	/* Prefill TX queue */
 	ret = i2s_write(dev_i2s, tx_block[tx_idx++], BLOCK_SIZE);
-	zassert_equal(ret, 0, NULL);
+	ztest_equal(ret, 0, NULL);
 
 	ret = i2s_write(dev_i2s, tx_block[tx_idx++], BLOCK_SIZE);
-	zassert_equal(ret, 0, NULL);
+	ztest_equal(ret, 0, NULL);
 
 	/* Start reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "RX START trigger failed");
+	ztest_equal(ret, 0, "RX START trigger failed");
 
 	/* Start transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, 0, "TX START trigger failed");
+	ztest_equal(ret, 0, "TX START trigger failed");
 
 	for (; tx_idx < NUM_BLOCKS; ) {
 		ret = i2s_write(dev_i2s, tx_block[tx_idx++], BLOCK_SIZE);
-		zassert_equal(ret, 0, NULL);
+		ztest_equal(ret, 0, NULL);
 
 		ret = i2s_read(dev_i2s, &rx_block[rx_idx++], &rx_size);
-		zassert_equal(ret, 0, NULL);
-		zassert_equal(rx_size, BLOCK_SIZE, NULL);
+		ztest_equal(ret, 0, NULL);
+		ztest_equal(rx_size, BLOCK_SIZE, NULL);
 	}
 
 	/* All data written, flush TX queue and stop the transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, 0, "TX DRAIN trigger failed");
+	ztest_equal(ret, 0, "TX DRAIN trigger failed");
 
 	ret = i2s_read(dev_i2s, &rx_block[rx_idx++], &rx_size);
-	zassert_equal(ret, 0, NULL);
-	zassert_equal(rx_size, BLOCK_SIZE, NULL);
+	ztest_equal(ret, 0, NULL);
+	ztest_equal(rx_size, BLOCK_SIZE, NULL);
 
 	/* All but one data block read, stop reception */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, 0, "RX STOP trigger failed");
+	ztest_equal(ret, 0, "RX STOP trigger failed");
 
 	ret = i2s_read(dev_i2s, &rx_block[rx_idx++], &rx_size);
-	zassert_equal(ret, 0, NULL);
-	zassert_equal(rx_size, BLOCK_SIZE, NULL);
+	ztest_equal(ret, 0, NULL);
+	ztest_equal(rx_size, BLOCK_SIZE, NULL);
 
 	TC_PRINT("%d TX blocks sent\n", tx_idx);
 	TC_PRINT("%d RX blocks received\n", rx_idx);
@@ -294,5 +294,5 @@ void test_i2s_transfer_long(void)
 		}
 		k_mem_slab_free(&rx_0_mem_slab, &rx_block[rx_idx]);
 	}
-	zassert_equal(num_verified, NUM_BLOCKS, "Invalid RX blocks received");
+	ztest_equal(num_verified, NUM_BLOCKS, "Invalid RX blocks received");
 }

--- a/tests/drivers/kscan/kscan_api/src/test_kscan.c
+++ b/tests/drivers/kscan/kscan_api/src/test_kscan.c
@@ -86,16 +86,16 @@ static int test_disable_enable_callback(void)
 void test_init_callback(void)
 {
 	/* Configure kscan matrix with an appropriate callback */
-	zassert_true(test_kb_callback() == TC_PASS, NULL);
+	ztest_true(test_kb_callback() == TC_PASS, NULL);
 	k_sleep(K_MSEC(1000));
 
 	/* Configure kscan with a null callback */
-	zassert_true(test_null_callback() == TC_PASS, NULL);
+	ztest_true(test_null_callback() == TC_PASS, NULL);
 }
 
 void test_control_callback(void)
 {
 	/* Disable/enable notifications to user */
-	zassert_true(test_disable_enable_callback() == TC_PASS, NULL);
+	ztest_true(test_disable_enable_callback() == TC_PASS, NULL);
 	k_sleep(K_MSEC(1000));
 }

--- a/tests/drivers/pwm/pwm_api/src/test_pwm.c
+++ b/tests/drivers/pwm/pwm_api/src/test_pwm.c
@@ -110,17 +110,17 @@ static int test_task(u32_t port, u32_t period, u32_t pulse, u8_t unit)
 void test_pwm_usec(void)
 {
 	/* Period : Pulse (2000 : 1000), unit (usec). Voltage : 1.65V */
-	zassert_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_USEC,
+	ztest_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_USEC,
 				DEFAULT_PULSE_USEC, UNIT_USECS) == TC_PASS, NULL);
 	k_sleep(K_MSEC(1000));
 
 	/* Period : Pulse (2000 : 2000), unit (usec). Voltage : 3.3V */
-	zassert_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_USEC,
+	ztest_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_USEC,
 				DEFAULT_PERIOD_USEC, UNIT_USECS) == TC_PASS, NULL);
 	k_sleep(K_MSEC(1000));
 
 	/* Period : Pulse (2000 : 0), unit (usec). Voltage : 0V */
-	zassert_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_USEC,
+	ztest_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_USEC,
 				0, UNIT_USECS) == TC_PASS, NULL);
 	k_sleep(K_MSEC(1000));
 }
@@ -128,17 +128,17 @@ void test_pwm_usec(void)
 void test_pwm_nsec(void)
 {
 	/* Period : Pulse (2000000 : 1000000), unit (nsec). Voltage : 1.65V */
-	zassert_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_NSEC,
+	ztest_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_NSEC,
 				DEFAULT_PULSE_NSEC, UNIT_NSECS) == TC_PASS, NULL);
 	k_sleep(K_MSEC(1000));
 
 	/* Period : Pulse (2000000 : 2000000), unit (nsec). Voltage : 3.3V */
-	zassert_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_NSEC,
+	ztest_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_NSEC,
 				DEFAULT_PERIOD_NSEC, UNIT_NSECS) == TC_PASS, NULL);
 	k_sleep(K_MSEC(1000));
 
 	/* Period : Pulse (2000000 : 0), unit (nsec). Voltage : 0V */
-	zassert_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_NSEC,
+	ztest_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_NSEC,
 				0, UNIT_NSECS) == TC_PASS, NULL);
 	k_sleep(K_MSEC(1000));
 }
@@ -146,16 +146,16 @@ void test_pwm_nsec(void)
 void test_pwm_cycle(void)
 {
 	/* Period : Pulse (64000 : 32000), unit (cycle). Voltage : 1.65V */
-	zassert_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_CYCLE,
+	ztest_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_CYCLE,
 				DEFAULT_PULSE_CYCLE, UNIT_CYCLES) == TC_PASS, NULL);
 	k_sleep(K_MSEC(1000));
 
 	/* Period : Pulse (64000 : 64000), unit (cycle). Voltage : 3.3V */
-	zassert_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_CYCLE,
+	ztest_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_CYCLE,
 				DEFAULT_PERIOD_CYCLE, UNIT_CYCLES) == TC_PASS, NULL);
 	k_sleep(K_MSEC(1000));
 
 	/* Period : Pulse (64000 : 0), unit (cycle). Voltage : 0V */
-	zassert_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_CYCLE,
+	ztest_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_CYCLE,
 				0, UNIT_CYCLES) == TC_PASS, NULL);
 }

--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -84,7 +84,7 @@ static int cs_ctrl_gpio_config(void)
 	spi_cs.gpio_dev = device_get_binding(CS_CTRL_GPIO_DRV_NAME);
 	if (!spi_cs.gpio_dev) {
 		LOG_ERR("Cannot find %s!", CS_CTRL_GPIO_DRV_NAME);
-		zassert_not_null(spi_cs.gpio_dev, "Invalid gpio device");
+		ztest_not_null(spi_cs.gpio_dev, "Invalid gpio device");
 		return -1;
 	}
 
@@ -122,7 +122,7 @@ static int spi_complete_loop(struct device *dev, struct spi_config *spi_conf)
 	ret = spi_transceive(dev, spi_conf, &tx, &rx);
 	if (ret) {
 		LOG_ERR("Code %d", ret);
-		zassert_false(ret, "SPI transceive failed");
+		ztest_false(ret, "SPI transceive failed");
 		return ret;
 	}
 
@@ -133,7 +133,7 @@ static int spi_complete_loop(struct device *dev, struct spi_config *spi_conf)
 			    buffer_print_tx);
 		LOG_ERR("                           vs: %s",
 			    buffer_print_rx);
-		zassert_false(1, "Buffer contents are different");
+		ztest_false(1, "Buffer contents are different");
 		return -1;
 	}
 
@@ -180,7 +180,7 @@ static int spi_null_tx_buf(struct device *dev, struct spi_config *spi_conf)
 	ret = spi_transceive(dev, spi_conf, &tx, &rx);
 	if (ret) {
 		LOG_ERR("Code %d", ret);
-		zassert_false(ret, "SPI transceive failed");
+		ztest_false(ret, "SPI transceive failed");
 		return ret;
 	}
 
@@ -189,7 +189,7 @@ static int spi_null_tx_buf(struct device *dev, struct spi_config *spi_conf)
 		to_display_format(buffer_rx, BUF_SIZE, buffer_print_rx);
 		LOG_ERR("Rx Buffer should contain NOP frames but got: %s",
 			buffer_print_rx);
-		zassert_false(1, "Buffer not as expected");
+		ztest_false(1, "Buffer not as expected");
 		return -1;
 	}
 
@@ -229,7 +229,7 @@ static int spi_rx_half_start(struct device *dev, struct spi_config *spi_conf)
 	ret = spi_transceive(dev, spi_conf, &tx, &rx);
 	if (ret) {
 		LOG_ERR("Code %d", ret);
-		zassert_false(ret, "SPI transceive failed");
+		ztest_false(ret, "SPI transceive failed");
 		return -1;
 	}
 
@@ -240,7 +240,7 @@ static int spi_rx_half_start(struct device *dev, struct spi_config *spi_conf)
 			    buffer_print_tx);
 		LOG_ERR("                           vs: %s",
 			    buffer_print_rx);
-		zassert_false(1, "Buffer contents are different");
+		ztest_false(1, "Buffer contents are different");
 		return -1;
 	}
 
@@ -284,7 +284,7 @@ static int spi_rx_half_end(struct device *dev, struct spi_config *spi_conf)
 	ret = spi_transceive(dev, spi_conf, &tx, &rx);
 	if (ret) {
 		LOG_ERR("Code %d", ret);
-		zassert_false(ret, "SPI transceive failed");
+		ztest_false(ret, "SPI transceive failed");
 		return -1;
 	}
 
@@ -295,7 +295,7 @@ static int spi_rx_half_end(struct device *dev, struct spi_config *spi_conf)
 			    buffer_print_tx);
 		LOG_ERR("                           vs: %s",
 			    buffer_print_rx);
-		zassert_false(1, "Buffer contents are different");
+		ztest_false(1, "Buffer contents are different");
 		return -1;
 	}
 
@@ -347,7 +347,7 @@ static int spi_rx_every_4(struct device *dev, struct spi_config *spi_conf)
 	ret = spi_transceive(dev, spi_conf, &tx, &rx);
 	if (ret) {
 		LOG_ERR("Code %d", ret);
-		zassert_false(ret, "SPI transceive failed");
+		ztest_false(ret, "SPI transceive failed");
 		return -1;
 	}
 
@@ -358,7 +358,7 @@ static int spi_rx_every_4(struct device *dev, struct spi_config *spi_conf)
 			    buffer_print_tx);
 		LOG_ERR("                           vs: %s",
 			    buffer_print_rx);
-		zassert_false(1, "Buffer contents are different");
+		ztest_false(1, "Buffer contents are different");
 		return -1;
 	} else if (memcmp(buffer_tx + 12, buffer_rx + 4, 4)) {
 		to_display_format(buffer_tx + 12, 4, buffer_print_tx);
@@ -367,7 +367,7 @@ static int spi_rx_every_4(struct device *dev, struct spi_config *spi_conf)
 			    buffer_print_tx);
 		LOG_ERR("                           vs: %s",
 			    buffer_print_rx);
-		zassert_false(1, "Buffer contents are different");
+		ztest_false(1, "Buffer contents are different");
 		return -1;
 	}
 
@@ -396,7 +396,7 @@ static void spi_async_call_cb(struct k_poll_event *async_evt,
 
 	while (1) {
 		ret = k_poll(async_evt, 1, K_MSEC(200));
-		zassert_false(ret, "one or more events are not ready");
+		ztest_false(ret, "one or more events are not ready");
 
 		result = async_evt->signal->result;
 		k_sem_give(caller_sem);
@@ -441,7 +441,7 @@ static int spi_async_call(struct device *dev, struct spi_config *spi_conf)
 
 	if (ret) {
 		LOG_ERR("Code %d", ret);
-		zassert_false(ret, "SPI transceive failed");
+		ztest_false(ret, "SPI transceive failed");
 		return -1;
 	}
 
@@ -449,7 +449,7 @@ static int spi_async_call(struct device *dev, struct spi_config *spi_conf)
 
 	if (result)  {
 		LOG_ERR("Call code %d", ret);
-		zassert_false(result, "SPI transceive failed");
+		ztest_false(result, "SPI transceive failed");
 		return -1;
 	}
 
@@ -472,7 +472,7 @@ static int spi_resource_lock_test(struct device *lock_dev,
 
 	if (spi_release(lock_dev, spi_conf_lock)) {
 		LOG_ERR("Deadlock now?");
-		zassert_false(1, "SPI release failed");
+		ztest_false(1, "SPI release failed");
 		return -1;
 	}
 
@@ -503,7 +503,7 @@ void test_spi_loopback(void)
 	spi_slow = device_get_binding(SPI_DRV_NAME);
 	if (!spi_slow) {
 		LOG_ERR("Cannot find %s!\n", SPI_DRV_NAME);
-		zassert_not_null(spi_slow, "Invalid SPI device");
+		ztest_not_null(spi_slow, "Invalid SPI device");
 		return;
 	}
 

--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -66,27 +66,27 @@ void test_single_read(void)
 	u8_t rx_buf[10] = {0};
 	u8_t tx_buf[5] = "test";
 
-	zassert_not_equal(memcmp(tx_buf, rx_buf, 5), 0,
+	ztest_not_equal(memcmp(tx_buf, rx_buf, 5), 0,
 			  "Initial buffer check failed");
 
 	uart_rx_enable(uart_dev, rx_buf, 10, 50);
 	uart_tx(uart_dev, tx_buf, sizeof(tx_buf), 100);
-	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
-	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
+	ztest_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
+	ztest_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
 
-	zassert_equal(memcmp(tx_buf, rx_buf, 5), 0, "Buffers not equal");
-	zassert_not_equal(memcmp(tx_buf, rx_buf+5, 5), 0, "Buffers not equal");
+	ztest_equal(memcmp(tx_buf, rx_buf, 5), 0, "Buffers not equal");
+	ztest_not_equal(memcmp(tx_buf, rx_buf+5, 5), 0, "Buffers not equal");
 
 	uart_tx(uart_dev, tx_buf, sizeof(tx_buf), 100);
-	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
-	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
-	zassert_equal(k_sem_take(&rx_buf_released, K_MSEC(100)),
+	ztest_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
+	ztest_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
+	ztest_equal(k_sem_take(&rx_buf_released, K_MSEC(100)),
 		      0,
 		      "RX_BUF_RELEASED timeout");
-	zassert_equal(k_sem_take(&rx_disabled, K_MSEC(1000)), 0,
+	ztest_equal(k_sem_take(&rx_disabled, K_MSEC(1000)), 0,
 		      "RX_DISABLED timeout");
-	zassert_equal(memcmp(tx_buf, rx_buf+5, 5), 0, "Buffers not equal");
-	zassert_equal(tx_aborted_count, 0, "TX aborted triggered");
+	ztest_equal(memcmp(tx_buf, rx_buf+5, 5), 0, "Buffers not equal");
+	ztest_equal(tx_aborted_count, 0, "TX aborted triggered");
 }
 
 ZTEST_BMEM u8_t chained_read_buf0[10];
@@ -146,24 +146,24 @@ void test_chained_read(void)
 	uart_rx_enable(uart_dev, chained_read_buf0, 10, 50);
 
 	for (int i = 0; i < 6; i++) {
-		zassert_not_equal(k_sem_take(&rx_disabled, K_MSEC(10)),
+		ztest_not_equal(k_sem_take(&rx_disabled, K_MSEC(10)),
 				  0,
 				  "RX_DISABLED occurred");
 		snprintf(tx_buf, sizeof(tx_buf), "Message %d", i);
 		uart_tx(uart_dev, tx_buf, sizeof(tx_buf), 100);
-		zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0,
+		ztest_equal(k_sem_take(&tx_done, K_MSEC(100)), 0,
 			      "TX_DONE timeout");
-		zassert_equal(k_sem_take(&rx_rdy, K_MSEC(1000)), 0,
+		ztest_equal(k_sem_take(&rx_rdy, K_MSEC(1000)), 0,
 			      "RX_RDY timeout");
 		size_t read_len_temp = read_len;
 
-		zassert_equal(read_len_temp, sizeof(tx_buf),
+		ztest_equal(read_len_temp, sizeof(tx_buf),
 			      "Incorrect read length");
-		zassert_equal(memcmp(tx_buf, read_ptr, sizeof(tx_buf)),
+		ztest_equal(memcmp(tx_buf, read_ptr, sizeof(tx_buf)),
 			      0,
 			      "Buffers not equal");
 	}
-	zassert_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
+	ztest_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
 		      "RX_DISABLED timeout");
 }
 
@@ -210,7 +210,7 @@ void test_double_buffer(void)
 	struct device *uart_dev = device_get_binding(UART_DEVICE_NAME);
 	u8_t tx_buf[4];
 
-	zassert_equal(uart_rx_enable(uart_dev,
+	ztest_equal(uart_rx_enable(uart_dev,
 				     double_buffer[0],
 				     sizeof(double_buffer[0]),
 				     50),
@@ -220,16 +220,16 @@ void test_double_buffer(void)
 	for (int i = 0; i < 100; i++) {
 		snprintf(tx_buf, sizeof(tx_buf), "%03d", i);
 		uart_tx(uart_dev, tx_buf, sizeof(tx_buf), 100);
-		zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0,
+		ztest_equal(k_sem_take(&tx_done, K_MSEC(100)), 0,
 			      "TX_DONE timeout");
-		zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0,
+		ztest_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0,
 			      "RX_RDY timeout");
-		zassert_equal(memcmp(tx_buf, read_ptr, sizeof(tx_buf)),
+		ztest_equal(memcmp(tx_buf, read_ptr, sizeof(tx_buf)),
 			      0,
 			      "Buffers not equal");
 	}
 	uart_rx_disable(uart_dev);
-	zassert_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
+	ztest_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
 		      "RX_DISABLED timeout");
 }
 
@@ -273,22 +273,22 @@ void test_read_abort(void)
 	uart_rx_enable(uart_dev, rx_buf, sizeof(rx_buf), 50);
 
 	uart_tx(uart_dev, tx_buf, 5, 100);
-	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
-	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
-	zassert_equal(memcmp(tx_buf, rx_buf, 5), 0, "Buffers not equal");
+	ztest_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
+	ztest_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
+	ztest_equal(memcmp(tx_buf, rx_buf, 5), 0, "Buffers not equal");
 
 
 	uart_tx(uart_dev, tx_buf, 95, 100);
 	uart_rx_disable(uart_dev);
-	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
-	zassert_equal(k_sem_take(&rx_buf_released, K_MSEC(100)),
+	ztest_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
+	ztest_equal(k_sem_take(&rx_buf_released, K_MSEC(100)),
 		      0,
 		      "RX_BUF_RELEASED timeout");
-	zassert_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
+	ztest_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
 		      "RX_DISABLED timeout");
-	zassert_not_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0,
+	ztest_not_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0,
 			  "RX_RDY occurred");
-	zassert_not_equal(memcmp(tx_buf, rx_buf, 100), 0, "Buffers equal");
+	ztest_not_equal(memcmp(tx_buf, rx_buf, 100), 0, "Buffers equal");
 }
 
 ZTEST_BMEM volatile size_t sent;
@@ -339,24 +339,24 @@ void test_write_abort(void)
 	uart_rx_enable(uart_dev, rx_buf, sizeof(rx_buf), 50);
 
 	uart_tx(uart_dev, tx_buf, 5, 100);
-	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
-	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
-	zassert_equal(memcmp(tx_buf, rx_buf, 5), 0, "Buffers not equal");
+	ztest_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
+	ztest_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
+	ztest_equal(memcmp(tx_buf, rx_buf, 5), 0, "Buffers not equal");
 
 	uart_tx(uart_dev, tx_buf, 95, 100);
 	uart_tx_abort(uart_dev);
-	zassert_equal(k_sem_take(&tx_aborted, K_MSEC(100)), 0,
+	ztest_equal(k_sem_take(&tx_aborted, K_MSEC(100)), 0,
 		      "TX_ABORTED timeout");
 	if (sent != 0) {
-		zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0,
+		ztest_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0,
 			      "RX_RDY timeout");
-		zassert_equal(sent, received, "Sent is not equal to received.");
+		ztest_equal(sent, received, "Sent is not equal to received.");
 	}
 	uart_rx_disable(uart_dev);
-	zassert_equal(k_sem_take(&rx_buf_released, K_MSEC(100)),
+	ztest_equal(k_sem_take(&rx_buf_released, K_MSEC(100)),
 		      0,
 		      "RX_BUF_RELEASED timeout");
-	zassert_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
+	ztest_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
 		      "RX_DISABLED timeout");
 }
 
@@ -406,27 +406,27 @@ void test_forever_timeout(void)
 	uart_rx_enable(uart_dev, rx_buf, sizeof(rx_buf), K_FOREVER);
 
 	uart_tx(uart_dev, tx_buf, 5, K_FOREVER);
-	zassert_not_equal(k_sem_take(&tx_aborted, K_MSEC(1000)), 0,
+	ztest_not_equal(k_sem_take(&tx_aborted, K_MSEC(1000)), 0,
 			  "TX_ABORTED timeout");
-	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
-	zassert_not_equal(k_sem_take(&rx_rdy, K_MSEC(1000)), 0,
+	ztest_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
+	ztest_not_equal(k_sem_take(&rx_rdy, K_MSEC(1000)), 0,
 			  "RX_RDY timeout");
 
 	uart_tx(uart_dev, tx_buf, 95, K_FOREVER);
 
-	zassert_not_equal(k_sem_take(&tx_aborted, K_MSEC(1000)), 0,
+	ztest_not_equal(k_sem_take(&tx_aborted, K_MSEC(1000)), 0,
 			  "TX_ABORTED timeout");
-	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
-	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
+	ztest_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
+	ztest_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
 
 
-	zassert_equal(memcmp(tx_buf, rx_buf, 100), 0, "Buffers not equal");
+	ztest_equal(memcmp(tx_buf, rx_buf, 100), 0, "Buffers not equal");
 
 	uart_rx_disable(uart_dev);
-	zassert_equal(k_sem_take(&rx_buf_released, K_MSEC(100)),
+	ztest_equal(k_sem_take(&rx_buf_released, K_MSEC(100)),
 		      0,
 		      "RX_BUF_RELEASED timeout");
-	zassert_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
+	ztest_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
 		      "RX_DISABLED timeout");
 }
 
@@ -485,22 +485,22 @@ void test_chained_write(void)
 	uart_rx_enable(uart_dev, rx_buf, sizeof(rx_buf), 50);
 
 	uart_tx(uart_dev, chained_write_tx_bufs[0], 10, 100);
-	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
-	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
-	zassert_equal(chained_write_next_buf, false, "Sent no message");
-	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
-	zassert_equal(memcmp(chained_write_tx_bufs[0], rx_buf, 10),
+	ztest_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
+	ztest_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
+	ztest_equal(chained_write_next_buf, false, "Sent no message");
+	ztest_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
+	ztest_equal(memcmp(chained_write_tx_bufs[0], rx_buf, 10),
 		      0,
 		      "Buffers not equal");
-	zassert_equal(memcmp(chained_write_tx_bufs[1], rx_buf + 10, 10),
+	ztest_equal(memcmp(chained_write_tx_bufs[1], rx_buf + 10, 10),
 		      0,
 		      "Buffers not equal");
 
 	uart_rx_disable(uart_dev);
-	zassert_equal(k_sem_take(&rx_buf_released, K_MSEC(100)),
+	ztest_equal(k_sem_take(&rx_buf_released, K_MSEC(100)),
 		      0,
 		      "RX_BUF_RELEASED timeout");
-	zassert_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
+	ztest_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
 		      "RX_DISABLED timeout");
 }
 
@@ -563,31 +563,31 @@ void test_long_buffers(void)
 	uart_rx_enable(uart_dev, long_rx_buf, sizeof(long_rx_buf), 10);
 
 	uart_tx(uart_dev, long_tx_buf, 500, 200);
-	zassert_equal(k_sem_take(&tx_done, K_MSEC(200)), 0, "TX_DONE timeout");
-	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(200)), 0, "RX_RDY timeout");
-	zassert_equal(long_received[0], 500, "Wrong number of bytes received.");
-	zassert_equal(memcmp(long_tx_buf, long_rx_buf, 500),
+	ztest_equal(k_sem_take(&tx_done, K_MSEC(200)), 0, "TX_DONE timeout");
+	ztest_equal(k_sem_take(&rx_rdy, K_MSEC(200)), 0, "RX_RDY timeout");
+	ztest_equal(long_received[0], 500, "Wrong number of bytes received.");
+	ztest_equal(memcmp(long_tx_buf, long_rx_buf, 500),
 		      0,
 		      "Buffers not equal");
 
 	evt_num = 0;
 	uart_tx(uart_dev, long_tx_buf, 1000, 200);
-	zassert_equal(k_sem_take(&tx_done, K_MSEC(200)), 0, "TX_DONE timeout");
-	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(200)), 0, "RX_RDY timeout");
-	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(200)), 0, "RX_RDY timeout");
-	zassert_equal(long_received[0], 524, "Wrong number of bytes received.");
-	zassert_equal(long_received[1], 476, "Wrong number of bytes received.");
-	zassert_equal(memcmp(long_tx_buf, long_rx_buf + 500, long_received[0]),
+	ztest_equal(k_sem_take(&tx_done, K_MSEC(200)), 0, "TX_DONE timeout");
+	ztest_equal(k_sem_take(&rx_rdy, K_MSEC(200)), 0, "RX_RDY timeout");
+	ztest_equal(k_sem_take(&rx_rdy, K_MSEC(200)), 0, "RX_RDY timeout");
+	ztest_equal(long_received[0], 524, "Wrong number of bytes received.");
+	ztest_equal(long_received[1], 476, "Wrong number of bytes received.");
+	ztest_equal(memcmp(long_tx_buf, long_rx_buf + 500, long_received[0]),
 		      0,
 		      "Buffers not equal");
-	zassert_equal(memcmp(long_tx_buf, long_rx_buf2, long_received[1]),
+	ztest_equal(memcmp(long_tx_buf, long_rx_buf2, long_received[1]),
 		      0,
 		      "Buffers not equal");
 
 	uart_rx_disable(uart_dev);
-	zassert_equal(k_sem_take(&rx_buf_released, K_MSEC(100)),
+	ztest_equal(k_sem_take(&rx_buf_released, K_MSEC(100)),
 		      0,
 		      "RX_BUF_RELEASED timeout");
-	zassert_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
+	ztest_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
 		      "RX_DISABLED timeout");
 }

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_config.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_config.c
@@ -88,10 +88,10 @@ static int test_config_get(void)
 
 void test_uart_configure(void)
 {
-	zassert_true(test_configure() == TC_PASS, NULL);
+	ztest_true(test_configure() == TC_PASS, NULL);
 }
 
 void test_uart_config_get(void)
 {
-	zassert_true(test_config_get() == TC_PASS, NULL);
+	ztest_true(test_config_get() == TC_PASS, NULL);
 }

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_fifo.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_fifo.c
@@ -143,10 +143,10 @@ static int test_fifo_fill(void)
 
 void test_uart_fifo_fill(void)
 {
-	zassert_true(test_fifo_fill() == TC_PASS, NULL);
+	ztest_true(test_fifo_fill() == TC_PASS, NULL);
 }
 
 void test_uart_fifo_read(void)
 {
-	zassert_true(test_fifo_read() == TC_PASS, NULL);
+	ztest_true(test_fifo_read() == TC_PASS, NULL);
 }

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_poll.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_poll.c
@@ -55,10 +55,10 @@ static int test_poll_out(void)
 
 void test_uart_poll_out(void)
 {
-	zassert_true(test_poll_out() == TC_PASS, NULL);
+	ztest_true(test_poll_out() == TC_PASS, NULL);
 }
 
 void test_uart_poll_in(void)
 {
-	zassert_true(test_poll_in() == TC_PASS, NULL);
+	ztest_true(test_poll_in() == TC_PASS, NULL);
 }

--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -305,24 +305,24 @@ static int test_wdt_bad_window_max(void)
 void test_wdt(void)
 {
 	if ((m_testcase_index != 1U) && (m_testcase_index != 2U)) {
-		zassert_true(test_wdt_no_callback() == TC_PASS, NULL);
+		ztest_true(test_wdt_no_callback() == TC_PASS, NULL);
 	}
 	if (m_testcase_index == 1U) {
 #if TEST_WDT_CALLBACK_1
-		zassert_true(test_wdt_callback_1() == TC_PASS, NULL);
+		ztest_true(test_wdt_callback_1() == TC_PASS, NULL);
 #else
 		m_testcase_index++;
 #endif
 	}
 	if (m_testcase_index == 2U) {
 #if TEST_WDT_CALLBACK_2
-		zassert_true(test_wdt_callback_2() == TC_PASS, NULL);
+		ztest_true(test_wdt_callback_2() == TC_PASS, NULL);
 #else
 		m_testcase_index++;
 #endif
 	}
 	if (m_testcase_index == 3U) {
-		zassert_true(test_wdt_bad_window_max() == TC_PASS, NULL);
+		ztest_true(test_wdt_bad_window_max() == TC_PASS, NULL);
 		m_testcase_index++;
 	}
 	if (m_testcase_index > 3) {

--- a/tests/kernel/common/src/atomic.c
+++ b/tests/kernel/common/src/atomic.c
@@ -36,106 +36,106 @@ void test_atomic(void)
 	oldvalue = 6;
 
 	/* atomic_cas() */
-	zassert_false(atomic_cas(&target, oldvalue, value), "atomic_cas");
+	ztest_false(atomic_cas(&target, oldvalue, value), "atomic_cas");
 	target = 6;
-	zassert_true(atomic_cas(&target, oldvalue, value), "atomic_cas");
-	zassert_true((target == value), "atomic_cas");
+	ztest_true(atomic_cas(&target, oldvalue, value), "atomic_cas");
+	ztest_true((target == value), "atomic_cas");
 
 	/* atomic_ptr_cas() */
 	ptr_target = (atomic_ptr_t)4;
 	ptr_value = (void *)5;
 	old_ptr_value = (void *)6;
-	zassert_false(atomic_ptr_cas(&ptr_target, old_ptr_value, ptr_value),
+	ztest_false(atomic_ptr_cas(&ptr_target, old_ptr_value, ptr_value),
 		      "atomic_ptr_cas");
 	ptr_target = (void *)6;
-	zassert_true(atomic_ptr_cas(&ptr_target, old_ptr_value, ptr_value),
+	ztest_true(atomic_ptr_cas(&ptr_target, old_ptr_value, ptr_value),
 		     "atomic_ptr_cas");
-	zassert_true((ptr_target == ptr_value), "atomic_ptr_cas");
+	ztest_true((ptr_target == ptr_value), "atomic_ptr_cas");
 
 	/* atomic_add() */
 	target = 1;
 	value = 2;
-	zassert_true((atomic_add(&target, value) == 1), "atomic_add");
-	zassert_true((target == 3), "atomic_add");
+	ztest_true((atomic_add(&target, value) == 1), "atomic_add");
+	ztest_true((target == 3), "atomic_add");
 
 	/* atomic_sub() */
 	target = 10;
 	value = 2;
-	zassert_true((atomic_sub(&target, value) == 10), "atomic_sub");
-	zassert_true((target == 8), "atomic_sub");
+	ztest_true((atomic_sub(&target, value) == 10), "atomic_sub");
+	ztest_true((target == 8), "atomic_sub");
 
 	/* atomic_inc() */
 	target = 5;
-	zassert_true((atomic_inc(&target) == 5), "atomic_inc");
-	zassert_true((target == 6), "atomic_inc");
+	ztest_true((atomic_inc(&target) == 5), "atomic_inc");
+	ztest_true((target == 6), "atomic_inc");
 
 	/* atomic_dec() */
 	target = 2;
-	zassert_true((atomic_dec(&target) == 2), "atomic_dec");
-	zassert_true((target == 1), "atomic_dec");
+	ztest_true((atomic_dec(&target) == 2), "atomic_dec");
+	ztest_true((target == 1), "atomic_dec");
 
 	/* atomic_get() */
 	target = 50;
-	zassert_true((atomic_get(&target) == 50), "atomic_get");
+	ztest_true((atomic_get(&target) == 50), "atomic_get");
 
 	/* atomic_ptr_get() */
 	ptr_target = (atomic_ptr_t)50;
-	zassert_true((atomic_ptr_get(&ptr_target) == (void *)50),
+	ztest_true((atomic_ptr_get(&ptr_target) == (void *)50),
 		     "atomic_ptr_get");
 
 	/* atomic_set() */
 	target = 42;
 	value = 77;
-	zassert_true((atomic_set(&target, value) == 42), "atomic_set");
-	zassert_true((target == value), "atomic_set");
+	ztest_true((atomic_set(&target, value) == 42), "atomic_set");
+	ztest_true((target == value), "atomic_set");
 
 	/* atomic_ptr_set() */
 	ptr_target = (atomic_ptr_t)42;
 	ptr_value = (void *)77;
-	zassert_true((atomic_ptr_set(&ptr_target, ptr_value) == (void *)42),
+	ztest_true((atomic_ptr_set(&ptr_target, ptr_value) == (void *)42),
 		     "atomic_ptr_set");
-	zassert_true((ptr_target == ptr_value), "atomic_ptr_set");
+	ztest_true((ptr_target == ptr_value), "atomic_ptr_set");
 
 	/* atomic_clear() */
 	target = 100;
-	zassert_true((atomic_clear(&target) == 100), "atomic_clear");
-	zassert_true((target == 0), "atomic_clear");
+	ztest_true((atomic_clear(&target) == 100), "atomic_clear");
+	ztest_true((target == 0), "atomic_clear");
 
 	/* atomic_ptr_clear() */
 	ptr_target = (atomic_ptr_t)100;
-	zassert_true((atomic_ptr_clear(&ptr_target) == (void *)100),
+	ztest_true((atomic_ptr_clear(&ptr_target) == (void *)100),
 		     "atomic_ptr_clear");
-	zassert_true((ptr_target == NULL), "atomic_ptr_clear");
+	ztest_true((ptr_target == NULL), "atomic_ptr_clear");
 
 	/* atomic_or() */
 	target = 0xFF00;
 	value  = 0x0F0F;
-	zassert_true((atomic_or(&target, value) == 0xFF00), "atomic_or");
-	zassert_true((target == 0xFF0F), "atomic_or");
+	ztest_true((atomic_or(&target, value) == 0xFF00), "atomic_or");
+	ztest_true((target == 0xFF0F), "atomic_or");
 
 	/* atomic_xor() */
 	target = 0xFF00;
 	value  = 0x0F0F;
-	zassert_true((atomic_xor(&target, value) == 0xFF00), "atomic_xor");
-	zassert_true((target == 0xF00F), "atomic_xor");
+	ztest_true((atomic_xor(&target, value) == 0xFF00), "atomic_xor");
+	ztest_true((target == 0xF00F), "atomic_xor");
 
 	/* atomic_and() */
 	target = 0xFF00;
 	value  = 0x0F0F;
-	zassert_true((atomic_and(&target, value) == 0xFF00), "atomic_and");
-	zassert_true((target == 0x0F00), "atomic_and");
+	ztest_true((atomic_and(&target, value) == 0xFF00), "atomic_and");
+	ztest_true((target == 0x0F00), "atomic_and");
 
 
 	/* atomic_nand() */
 	target = 0xFF00;
 	value  = 0x0F0F;
-	zassert_true((atomic_nand(&target, value) == 0xFF00), "atomic_nand");
-	zassert_true((target == 0xFFFFF0FF), "atomic_nand");
+	ztest_true((atomic_nand(&target, value) == 0xFF00), "atomic_nand");
+	ztest_true((target == 0xFFFFF0FF), "atomic_nand");
 
 	/* atomic_test_bit() */
 	for (i = 0; i < 32; i++) {
 		target = 0x0F0F0F0F;
-		zassert_true(!!(atomic_test_bit(&target, i) == !!(target & (1 << i))),
+		ztest_true(!!(atomic_test_bit(&target, i) == !!(target & (1 << i))),
 			     "atomic_test_bit");
 	}
 
@@ -143,18 +143,18 @@ void test_atomic(void)
 	for (i = 0; i < 32; i++) {
 		orig = 0x0F0F0F0F;
 		target = orig;
-		zassert_true(!!(atomic_test_and_clear_bit(&target, i)) == !!(orig & (1 << i)),
+		ztest_true(!!(atomic_test_and_clear_bit(&target, i)) == !!(orig & (1 << i)),
 			     "atomic_test_and_clear_bit");
-		zassert_true(target == (orig & ~(1 << i)), "atomic_test_and_clear_bit");
+		ztest_true(target == (orig & ~(1 << i)), "atomic_test_and_clear_bit");
 	}
 
 	/* atomic_test_and_set_bit() */
 	for (i = 0; i < 32; i++) {
 		orig = 0x0F0F0F0F;
 		target = orig;
-		zassert_true(!!(atomic_test_and_set_bit(&target, i)) == !!(orig & (1 << i)),
+		ztest_true(!!(atomic_test_and_set_bit(&target, i)) == !!(orig & (1 << i)),
 			     "atomic_test_and_set_bit");
-		zassert_true(target == (orig | (1 << i)), "atomic_test_and_set_bit");
+		ztest_true(target == (orig | (1 << i)), "atomic_test_and_set_bit");
 	}
 
 	/* atomic_clear_bit() */
@@ -162,7 +162,7 @@ void test_atomic(void)
 		orig = 0x0F0F0F0F;
 		target = orig;
 		atomic_clear_bit(&target, i);
-		zassert_true(target == (orig & ~(1 << i)), "atomic_clear_bit");
+		ztest_true(target == (orig & ~(1 << i)), "atomic_clear_bit");
 	}
 
 	/* atomic_set_bit() */
@@ -170,7 +170,7 @@ void test_atomic(void)
 		orig = 0x0F0F0F0F;
 		target = orig;
 		atomic_set_bit(&target, i);
-		zassert_true(target == (orig | (1 << i)), "atomic_set_bit");
+		ztest_true(target == (orig | (1 << i)), "atomic_set_bit");
 	}
 
 	/* atomic_set_bit_to(&target, i, false) */
@@ -178,7 +178,7 @@ void test_atomic(void)
 		orig = 0x0F0F0F0F;
 		target = orig;
 		atomic_set_bit_to(&target, i, false);
-		zassert_true(target == (orig & ~(1 << i)), "atomic_set_bit_to");
+		ztest_true(target == (orig & ~(1 << i)), "atomic_set_bit_to");
 	}
 
 	/* atomic_set_bit_to(&target, i, true) */
@@ -186,7 +186,7 @@ void test_atomic(void)
 		orig = 0x0F0F0F0F;
 		target = orig;
 		atomic_set_bit_to(&target, i, true);
-		zassert_true(target == (orig | (1 << i)), "atomic_set_bit_to");
+		ztest_true(target == (orig | (1 << i)), "atomic_set_bit_to");
 	}
 }
 /**

--- a/tests/kernel/common/src/bitfield.c
+++ b/tests/kernel/common/src/bitfield.c
@@ -39,84 +39,84 @@ void test_bitfield(void)
 	for (bit = 0U; bit < 32; ++bit) {
 		sys_set_bit((mem_addr_t)&b1, bit);
 
-		zassert_equal(b1, (1 << bit),
+		ztest_equal(b1, (1 << bit),
 			      "sys_set_bit failed on bit %d\n", bit);
 
-		zassert_true(sys_test_bit((mem_addr_t)&b1, bit),
+		ztest_true(sys_test_bit((mem_addr_t)&b1, bit),
 			     "sys_test_bit did not detect bit %d\n", bit);
 
 		sys_clear_bit((mem_addr_t)&b1, bit);
-		zassert_equal(b1, 0, "sys_clear_bit failed for bit %d\n", bit);
+		ztest_equal(b1, 0, "sys_clear_bit failed for bit %d\n", bit);
 
-		zassert_false(sys_test_bit((mem_addr_t)&b1, bit),
+		ztest_false(sys_test_bit((mem_addr_t)&b1, bit),
 			      "sys_test_bit erroneously detected bit %d\n",
 			      bit);
 
-		zassert_false(sys_test_and_set_bit((mem_addr_t)&b1, bit),
+		ztest_false(sys_test_and_set_bit((mem_addr_t)&b1, bit),
 			      "sys_test_and_set_bit erroneously"
 			      " detected bit %d\n", bit);
-		zassert_equal(b1, (1 << bit),
+		ztest_equal(b1, (1 << bit),
 			      "sys_test_and_set_bit did not set bit %d\n",
 			      bit);
-		zassert_true(sys_test_and_set_bit((mem_addr_t)&b1, bit),
+		ztest_true(sys_test_and_set_bit((mem_addr_t)&b1, bit),
 			     "sys_test_and_set_bit did not detect bit %d\n",
 			     bit);
-		zassert_equal(b1, (1 << bit),
+		ztest_equal(b1, (1 << bit),
 			      "sys_test_and_set_bit cleared bit %d\n", bit);
 
-		zassert_true(sys_test_and_clear_bit((mem_addr_t)&b1, bit),
+		ztest_true(sys_test_and_clear_bit((mem_addr_t)&b1, bit),
 			     "sys_test_and_clear_bit did not detect bit %d\n",
 			     bit);
-		zassert_equal(b1, 0, "sys_test_and_clear_bit did not clear"
+		ztest_equal(b1, 0, "sys_test_and_clear_bit did not clear"
 			      " bit %d\n", bit);
-		zassert_false(sys_test_and_clear_bit((mem_addr_t)&b1, bit),
+		ztest_false(sys_test_and_clear_bit((mem_addr_t)&b1, bit),
 			      "sys_test_and_clear_bit erroneously detected"
 			      " bit %d\n", bit);
-		zassert_equal(b1, 0, "sys_test_and_clear_bit set bit %d\n",
+		ztest_equal(b1, 0, "sys_test_and_clear_bit set bit %d\n",
 			      bit);
 	}
 
 	for (bit = 0U; bit < BITFIELD_SIZE; ++bit) {
 		sys_bitfield_set_bit((mem_addr_t)b2, bit);
-		zassert_equal(b2[BIT_INDEX(bit)], BIT_VAL(bit),
+		ztest_equal(b2[BIT_INDEX(bit)], BIT_VAL(bit),
 			      "sys_bitfield_set_bit failed for bit %d\n",
 			      bit);
-		zassert_true(sys_bitfield_test_bit((mem_addr_t)b2, bit),
+		ztest_true(sys_bitfield_test_bit((mem_addr_t)b2, bit),
 			     "sys_bitfield_test_bit did not detect bit %d\n",
 			     bit);
 
 		sys_bitfield_clear_bit((mem_addr_t)b2, bit);
-		zassert_equal(b2[BIT_INDEX(bit)], 0,
+		ztest_equal(b2[BIT_INDEX(bit)], 0,
 			      "sys_bitfield_clear_bit failed for bit %d\n",
 			      bit);
-		zassert_false(sys_bitfield_test_bit((mem_addr_t)b2, bit),
+		ztest_false(sys_bitfield_test_bit((mem_addr_t)b2, bit),
 			      "sys_bitfield_test_bit erroneously detected"
 			      " bit %d\n", bit);
 
 		ret = sys_bitfield_test_and_set_bit((mem_addr_t)b2, bit);
-		zassert_false(ret, "sys_bitfield_test_and_set_bit erroneously"
+		ztest_false(ret, "sys_bitfield_test_and_set_bit erroneously"
 			      " detected bit %d\n", bit);
 
-		zassert_equal(b2[BIT_INDEX(bit)], BIT_VAL(bit),
+		ztest_equal(b2[BIT_INDEX(bit)], BIT_VAL(bit),
 			      "sys_bitfield_test_and_set_bit did not set"
 			      " bit %d\n", bit);
-		zassert_true(sys_bitfield_test_and_set_bit((mem_addr_t)b2, bit),
+		ztest_true(sys_bitfield_test_and_set_bit((mem_addr_t)b2, bit),
 			     "sys_bitfield_test_and_set_bit did not detect bit"
 			     " %d\n", bit);
-		zassert_equal(b2[BIT_INDEX(bit)], BIT_VAL(bit),
+		ztest_equal(b2[BIT_INDEX(bit)], BIT_VAL(bit),
 			      "sys_bitfield_test_and_set_bit cleared bit %d\n",
 			      bit);
 
-		zassert_true(sys_bitfield_test_and_clear_bit((mem_addr_t)b2,
+		ztest_true(sys_bitfield_test_and_clear_bit((mem_addr_t)b2,
 							     bit), "sys_bitfield_test_and_clear_bit did not"
 			     " detect bit %d\n", bit);
-		zassert_equal(b2[BIT_INDEX(bit)], 0,
+		ztest_equal(b2[BIT_INDEX(bit)], 0,
 			      "sys_bitfield_test_and_clear_bit did not"
 			      " clear bit %d\n", bit);
-		zassert_false(sys_bitfield_test_and_clear_bit((mem_addr_t)b2,
+		ztest_false(sys_bitfield_test_and_clear_bit((mem_addr_t)b2,
 							      bit), "sys_bitfield_test_and_clear_bit"
 			      " erroneously detected bit %d\n", bit);
-		zassert_equal(b2[BIT_INDEX(bit)], 0,
+		ztest_equal(b2[BIT_INDEX(bit)], 0,
 			      "sys_bitfield_test_and_clear_bit set bit %d\n",
 			      bit);
 	}

--- a/tests/kernel/common/src/boot_delay.c
+++ b/tests/kernel/common/src/boot_delay.c
@@ -22,7 +22,7 @@ void test_verify_bootdelay(void)
 	u32_t current_cycles = k_cycle_get_32();
 
 	/* compare this with the boot delay specified */
-	zassert_true(k_cyc_to_ns_floor64(current_cycles) >=
+	ztest_true(k_cyc_to_ns_floor64(current_cycles) >=
 			(NSEC_PER_MSEC * CONFIG_BOOT_DELAY),
 			"boot delay not executed");
 }

--- a/tests/kernel/common/src/byteorder.c
+++ b/tests/kernel/common/src/byteorder.c
@@ -30,11 +30,11 @@ void test_byteorder_memcpy_swap(void)
 	u8_t buf_dst[8] = { 0 };
 
 	sys_memcpy_swap(buf_dst, buf_orig, 8);
-	zassert_true((memcmp(buf_dst, buf_chk, 8) == 0),
+	ztest_true((memcmp(buf_dst, buf_chk, 8) == 0),
 		     "Swap memcpy failed");
 
 	sys_memcpy_swap(buf_dst, buf_chk, 8);
-	zassert_true((memcmp(buf_dst, buf_orig, 8) == 0),
+	ztest_true((memcmp(buf_dst, buf_orig, 8) == 0),
 		     "Swap memcpy failed");
 }
 
@@ -59,11 +59,11 @@ void test_byteorder_mem_swap(void)
 			       0x02, 0x01, 0x00 };
 
 	sys_mem_swap(buf_orig_1, 8);
-	zassert_true((memcmp(buf_orig_1, buf_chk_1, 8) == 0),
+	ztest_true((memcmp(buf_orig_1, buf_chk_1, 8) == 0),
 		     "Swapping buffer failed");
 
 	sys_mem_swap(buf_orig_2, 11);
-	zassert_true((memcmp(buf_orig_2, buf_chk_2, 11) == 0),
+	ztest_true((memcmp(buf_orig_2, buf_chk_2, 11) == 0),
 		     "Swapping buffer failed");
 }
 
@@ -83,7 +83,7 @@ void test_sys_get_be64(void)
 
 	tmp = sys_get_be64(buf);
 
-	zassert_equal(tmp, val, "sys_get_be64() failed");
+	ztest_equal(tmp, val, "sys_get_be64() failed");
 }
 
 /**
@@ -103,7 +103,7 @@ void test_sys_put_be64(void)
 
 	sys_put_be64(val, tmp);
 
-	zassert_mem_equal(tmp, buf, sizeof(u64_t), "sys_put_be64() failed");
+	ztest_mem_equal(tmp, buf, sizeof(u64_t), "sys_put_be64() failed");
 }
 
 /**
@@ -122,7 +122,7 @@ void test_sys_get_be32(void)
 
 	tmp = sys_get_be32(buf);
 
-	zassert_equal(tmp, val, "sys_get_be32() failed");
+	ztest_equal(tmp, val, "sys_get_be32() failed");
 }
 
 /**
@@ -142,7 +142,7 @@ void test_sys_put_be32(void)
 
 	sys_put_be32(val, tmp);
 
-	zassert_mem_equal(tmp, buf, sizeof(u32_t), "sys_put_be32() failed");
+	ztest_mem_equal(tmp, buf, sizeof(u32_t), "sys_put_be32() failed");
 }
 
 /**
@@ -161,7 +161,7 @@ void test_sys_get_be16(void)
 
 	tmp = sys_get_be16(buf);
 
-	zassert_equal(tmp, val, "sys_get_be16() failed");
+	ztest_equal(tmp, val, "sys_get_be16() failed");
 }
 
 /**
@@ -181,7 +181,7 @@ void test_sys_put_be16(void)
 
 	sys_put_be16(val, tmp);
 
-	zassert_mem_equal(tmp, buf, sizeof(u16_t), "sys_put_be16() failed");
+	ztest_mem_equal(tmp, buf, sizeof(u16_t), "sys_put_be16() failed");
 }
 
 /**
@@ -200,7 +200,7 @@ void test_sys_get_le16(void)
 
 	tmp = sys_get_le16(buf);
 
-	zassert_equal(tmp, val, "sys_get_le16() failed");
+	ztest_equal(tmp, val, "sys_get_le16() failed");
 }
 
 /**
@@ -220,7 +220,7 @@ void test_sys_put_le16(void)
 
 	sys_put_le16(val, tmp);
 
-	zassert_mem_equal(tmp, buf, sizeof(u16_t), "sys_put_le16() failed");
+	ztest_mem_equal(tmp, buf, sizeof(u16_t), "sys_put_le16() failed");
 }
 
 /**
@@ -239,7 +239,7 @@ void test_sys_get_le32(void)
 
 	tmp = sys_get_le32(buf);
 
-	zassert_equal(tmp, val, "sys_get_le32() failed");
+	ztest_equal(tmp, val, "sys_get_le32() failed");
 }
 
 /**
@@ -259,7 +259,7 @@ void test_sys_put_le32(void)
 
 	sys_put_le32(val, tmp);
 
-	zassert_mem_equal(tmp, buf, sizeof(u32_t), "sys_put_le32() failed");
+	ztest_mem_equal(tmp, buf, sizeof(u32_t), "sys_put_le32() failed");
 }
 
 /**
@@ -278,7 +278,7 @@ void test_sys_get_le64(void)
 
 	tmp = sys_get_le64(buf);
 
-	zassert_equal(tmp, val, "sys_get_le64() failed");
+	ztest_equal(tmp, val, "sys_get_le64() failed");
 }
 
 /**
@@ -298,7 +298,7 @@ void test_sys_put_le64(void)
 
 	sys_put_le64(val, tmp);
 
-	zassert_mem_equal(tmp, buf, sizeof(u64_t), "sys_put_le64() failed");
+	ztest_mem_equal(tmp, buf, sizeof(u64_t), "sys_put_le64() failed");
 }
 
 /**

--- a/tests/kernel/common/src/clock.c
+++ b/tests/kernel/common/src/clock.c
@@ -57,7 +57,7 @@ void test_clock_uptime(void)
 	/**TESTPOINT: uptime straddled ms boundary*/
 	t32 = k_uptime_get_32();
 	ALIGN_MS_BOUNDARY;
-	zassert_true(k_uptime_get_32() > t32, NULL);
+	ztest_true(k_uptime_get_32() > t32, NULL);
 
 	/**TESTPOINT: uptime delta*/
 	d64 = k_uptime_delta(&d64);
@@ -78,7 +78,7 @@ void test_clock_uptime(void)
 	/**TESTPOINT: uptime delta straddled ms boundary*/
 	k_uptime_delta_32(&d64);
 	ALIGN_MS_BOUNDARY;
-	zassert_true(k_uptime_delta_32(&d64) > 0, NULL);
+	ztest_true(k_uptime_delta_32(&d64) > 0, NULL);
 }
 
 /**
@@ -115,11 +115,11 @@ void test_clock_cycle(void)
 	/*avoid cycle counter wrap around*/
 	if (c1 > c0) {
 		/* delta cycle should be greater than 1 milli-second*/
-		zassert_true((c1 - c0) >
+		ztest_true((c1 - c0) >
 			     (sys_clock_hw_cycles_per_sec() / MSEC_PER_SEC),
 			     NULL);
 		/* delta NS should be greater than 1 milli-second */
-		zassert_true((u32_t)k_cyc_to_ns_floor64(c1 - c0) >
+		ztest_true((u32_t)k_cyc_to_ns_floor64(c1 - c0) >
 			     (NSEC_PER_SEC / MSEC_PER_SEC), NULL);
 	}
 }

--- a/tests/kernel/common/src/errno.c
+++ b/tests/kernel/common/src/errno.c
@@ -51,7 +51,7 @@ static void errno_thread(void *_n, void *_my_errno, void *_unused)
 		result[n].pass = 1;
 	}
 
-	zassert_equal(errno, my_errno, NULL);
+	ztest_equal(errno, my_errno, NULL);
 
 	k_fifo_put(&fifo, &result[n]);
 }
@@ -93,7 +93,7 @@ void test_thread_context(void)
 		}
 	}
 
-	zassert_equal(errno, test_errno, NULL);
+	ztest_equal(errno, test_errno, NULL);
 
 	if (errno != errno_values[N_THREADS]) {
 		rv = TC_FAIL;

--- a/tests/kernel/common/src/irq_offload.c
+++ b/tests/kernel/common/src/irq_offload.c
@@ -25,7 +25,7 @@ static void offload_function(void *param)
 	u32_t x = POINTER_TO_INT(param);
 
 	/* Make sure we're in IRQ context */
-	zassert_true(k_is_in_isr(), "Not in IRQ context!");
+	ztest_true(k_is_in_isr(), "Not in IRQ context!");
 
 	sentinel = x;
 }
@@ -44,11 +44,11 @@ void test_irq_offload(void)
 	unsigned int key1, key2;
 
 	key1 = arch_irq_lock();
-	zassert_true(arch_irq_unlocked(key1),
+	ztest_true(arch_irq_unlocked(key1),
 		     "IRQs should have been unlocked, but key is 0x%x\n",
 		     key1);
 	key2 = arch_irq_lock();
-	zassert_false(arch_irq_unlocked(key2),
+	ztest_false(arch_irq_unlocked(key2),
 		      "IRQs should have been locked, but key is 0x%x\n",
 		      key2);
 	arch_irq_unlock(key2);
@@ -57,6 +57,6 @@ void test_irq_offload(void)
 	/**TESTPOINT: Offload to IRQ context*/
 	irq_offload(offload_function, (void *)SENTINEL_VALUE);
 
-	zassert_equal(sentinel, SENTINEL_VALUE,
+	ztest_equal(sentinel, SENTINEL_VALUE,
 		"irq_offload() didn't work properly");
 }

--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -69,11 +69,11 @@ static void test_version(void)
 {
 	u32_t version = sys_kernel_version_get();
 
-	zassert_true(SYS_KERNEL_VER_MAJOR(version) == KERNEL_VERSION_MAJOR,
+	ztest_true(SYS_KERNEL_VER_MAJOR(version) == KERNEL_VERSION_MAJOR,
 		     "major version mismatch");
-	zassert_true(SYS_KERNEL_VER_MINOR(version) == KERNEL_VERSION_MINOR,
+	ztest_true(SYS_KERNEL_VER_MINOR(version) == KERNEL_VERSION_MINOR,
 		     "minor version mismatch");
-	zassert_true(SYS_KERNEL_VER_PATCHLEVEL(version) == KERNEL_PATCHLEVEL,
+	ztest_true(SYS_KERNEL_VER_PATCHLEVEL(version) == KERNEL_PATCHLEVEL,
 		     "patchlevel version match");
 
 }
@@ -88,11 +88,11 @@ static void test_bounds_check_mitigation(void)
 	int index = 17;
 
 	index = k_array_index_sanitize(index, 24);
-	zassert_equal(index, 17, "bad index");
+	ztest_equal(index, 17, "bad index");
 
 #ifdef CONFIG_USERSPACE
 	index = k_array_index_sanitize(index, 5);
-	zassert_equal(index, 0, "bad index");
+	ztest_equal(index, 0, "bad index");
 #endif
 }
 

--- a/tests/kernel/common/src/multilib.c
+++ b/tests/kernel/common/src/multilib.c
@@ -23,7 +23,7 @@ void test_multilib(void)
 	volatile long long b = 3;
 	volatile long long c = a / b;
 
-	zassert_equal(c, 33, "smoke-test failed: wrong multilib selected");
+	ztest_equal(c, 33, "smoke-test failed: wrong multilib selected");
 }
 
 /**

--- a/tests/kernel/common/src/printk.c
+++ b/tests/kernel/common/src/printk.c
@@ -105,7 +105,7 @@ void test_printk(void)
 	printk("%lld %lld %llu %llx\n", 0xFFFFFFFFFULL, -1LL, -1ULL, -1ULL);
 
 	pk_console[pos] = '\0';
-	zassert_true((strcmp(pk_console, expected) == 0), "printk failed");
+	ztest_true((strcmp(pk_console, expected) == 0), "printk failed");
 
 	(void)memset(pk_console, 0, sizeof(pk_console));
 	count = 0;
@@ -136,7 +136,7 @@ void test_printk(void)
 			  "%lld %lld %llu %llx\n",
 			  0xFFFFFFFFFULL, -1LL, -1ULL, -1ULL);
 	pk_console[count] = '\0';
-	zassert_true((strcmp(pk_console, expected) == 0), "snprintk failed");
+	ztest_true((strcmp(pk_console, expected) == 0), "snprintk failed");
 }
 /**
  * @}

--- a/tests/kernel/common/src/timeout_order.c
+++ b/tests/kernel/common/src/timeout_order.c
@@ -86,16 +86,16 @@ void test_timeout_order(void)
 	/* drop prio to get all poll events together */
 	k_thread_priority_set(k_current_get(), prio + 1);
 
-	zassert_equal(k_poll(poll_events, NUM_TIMEOUTS, K_MSEC(2000)), 0, "");
+	ztest_equal(k_poll(poll_events, NUM_TIMEOUTS, K_MSEC(2000)), 0, "");
 
 	k_thread_priority_set(k_current_get(), prio - 1);
 
 	for (ii = 0; ii < NUM_TIMEOUTS; ii++) {
-		zassert_equal(poll_events[ii].state,
+		ztest_equal(poll_events[ii].state,
 			      K_POLL_STATE_SEM_AVAILABLE, "");
 	}
 	for (ii = 0; ii < NUM_TIMEOUTS; ii++) {
-		zassert_equal(results[ii], ii, "");
+		ztest_equal(results[ii], ii, "");
 	}
 }
 

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -264,7 +264,7 @@ static void _test_kernel_cpu_idle(int atomic)
 		/* calculating milliseconds per tick*/
 		tms += k_ticks_to_ms_floor64(1);
 		tms2 = k_uptime_get_32();
-		zassert_false(tms2 < tms, "Bad ms per tick value computed,"
+		ztest_false(tms2 < tms, "Bad ms per tick value computed,"
 			      "got %d which is less than %d\n",
 			      tms2, tms);
 	}
@@ -366,7 +366,7 @@ static void _test_kernel_interrupts(disable_int_func disable_int,
 	 * counter and ticks DO advance with interrupts locked!
 	 */
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		zassert_equal(tick2, tick,
+		ztest_equal(tick2, tick,
 			      "tick advanced with interrupts locked");
 	}
 
@@ -379,7 +379,7 @@ static void _test_kernel_interrupts(disable_int_func disable_int,
 	}
 
 	tick2 = z_tick_get_32();
-	zassert_not_equal(tick, tick2,
+	ztest_not_equal(tick, tick2,
 			  "tick didn't advance as expected");
 }
 
@@ -452,9 +452,9 @@ static void test_kernel_ctx_thread(void)
 	/* isr_info is modified by the isr_handler routine */
 	isr_handler_trigger();
 
-	zassert_false(isr_info.error, "ISR detected an error");
+	ztest_false(isr_info.error, "ISR detected an error");
 
-	zassert_equal(isr_info.data, (void *)self_thread_id,
+	ztest_equal(isr_info.data, (void *)self_thread_id,
 		      "ISR context ID mismatch");
 
 	TC_PRINT("Testing k_is_in_isr() from an ISR\n");
@@ -462,15 +462,15 @@ static void test_kernel_ctx_thread(void)
 	isr_info.error = 0;
 	isr_handler_trigger();
 
-	zassert_false(isr_info.error, "ISR detected an error");
+	ztest_false(isr_info.error, "ISR detected an error");
 
-	zassert_equal(isr_info.value, K_ISR,
+	ztest_equal(isr_info.value, K_ISR,
 		      "isr_info.value was not K_ISR");
 
 	TC_PRINT("Testing k_is_in_isr() from a preemptible thread\n");
-	zassert_false(k_is_in_isr(), "Should not be in ISR context");
+	ztest_false(k_is_in_isr(), "Should not be in ISR context");
 
-	zassert_false(_current->base.prio < 0,
+	ztest_false(_current->base.prio < 0,
 		      "Current thread should have preemptible priority: %d",
 		      _current->base.prio);
 
@@ -490,7 +490,7 @@ static void _test_kernel_thread(k_tid_t _thread_id)
 	k_tid_t self_thread_id;
 
 	self_thread_id = k_current_get();
-	zassert_true((self_thread_id != _thread_id), "thread id matches parent thread");
+	ztest_true((self_thread_id != _thread_id), "thread id matches parent thread");
 
 	isr_info.command = THREAD_SELF_CMD;
 	isr_info.error = 0;
@@ -499,18 +499,18 @@ static void _test_kernel_thread(k_tid_t _thread_id)
 	 * Either the ISR detected an error, or the ISR context ID
 	 * does not match the interrupted thread's ID.
 	 */
-	zassert_false((isr_info.error || (isr_info.data != (void *)self_thread_id)),
+	ztest_false((isr_info.error || (isr_info.data != (void *)self_thread_id)),
 		      "Thread ID taken during ISR != calling thread");
 
 	isr_info.command = EXEC_CTX_TYPE_CMD;
 	isr_info.error = 0;
 	isr_handler_trigger();
-	zassert_false((isr_info.error || (isr_info.value != K_ISR)),
+	ztest_false((isr_info.error || (isr_info.value != K_ISR)),
 		      "k_is_in_isr() when called from an ISR is false");
 
-	zassert_false(k_is_in_isr(), "k_is_in_isr() when called from a thread is true");
+	ztest_false(k_is_in_isr(), "k_is_in_isr() when called from a thread is true");
 
-	zassert_false((_current->base.prio >= 0),
+	ztest_false((_current->base.prio >= 0),
 		      "thread is not a cooperative thread");
 }
 
@@ -583,7 +583,7 @@ static void k_yield_entry(void *arg0, void *arg1, void *arg2)
 			thread_helper, NULL, NULL, NULL,
 			K_PRIO_COOP(THREAD_PRIORITY - 1), 0, K_NO_WAIT);
 
-	zassert_equal(thread_evidence, 0,
+	ztest_equal(thread_evidence, 0,
 		      "Helper created at higher priority ran prematurely.");
 
 	/*
@@ -592,11 +592,11 @@ static void k_yield_entry(void *arg0, void *arg1, void *arg2)
 	 */
 	k_yield();
 
-	zassert_not_equal(thread_evidence, 0,
+	ztest_not_equal(thread_evidence, 0,
 			  "k_yield() did not yield to a higher priority thread: %d",
 			  thread_evidence);
 
-	zassert_false((thread_evidence > 1),
+	ztest_false((thread_evidence > 1),
 		      "k_yield() did not yield to an equal priority thread: %d",
 		      thread_evidence);
 
@@ -607,7 +607,7 @@ static void k_yield_entry(void *arg0, void *arg1, void *arg2)
 	k_thread_priority_set(self_thread_id, self_thread_id->base.prio - 1);
 	k_yield();
 
-	zassert_equal(thread_evidence, 1,
+	ztest_equal(thread_evidence, 1,
 		      "k_yield() yielded to a lower priority thread");
 
 	/*
@@ -746,7 +746,7 @@ static void test_busy_wait(void)
 
 	rv = k_sem_take(&reply_timeout, timeout * 2);
 
-	zassert_false(rv, " *** thread timed out waiting for " "k_busy_wait()");
+	ztest_false(rv, " *** thread timed out waiting for " "k_busy_wait()");
 }
 
 /**
@@ -772,7 +772,7 @@ static void test_k_sleep(void)
 			NULL, K_PRIO_COOP(THREAD_PRIORITY), 0, K_NO_WAIT);
 
 	rv = k_sem_take(&reply_timeout, timeout * 2);
-	zassert_equal(rv, 0, " *** thread timed out waiting for thread on "
+	ztest_equal(rv, 0, " *** thread timed out waiting for thread on "
 		      "k_sleep().");
 
 	/* test k_thread_create() without cancellation */
@@ -787,10 +787,10 @@ static void test_k_sleep(void)
 	}
 	for (i = 0; i < NUM_TIMEOUT_THREADS; i++) {
 		data = k_fifo_get(&timeout_order_fifo, 750);
-		zassert_not_null(data, " *** timeout while waiting for"
+		ztest_not_null(data, " *** timeout while waiting for"
 				 " delayed thread");
 
-		zassert_equal(data->timeout_order, i,
+		ztest_equal(data->timeout_order, i,
 			      " *** wrong delayed thread ran (got %d, "
 			      "expected %d)\n", data->timeout_order, i);
 
@@ -801,7 +801,7 @@ static void test_k_sleep(void)
 	/* ensure no more thread fire */
 	data = k_fifo_get(&timeout_order_fifo, 750);
 
-	zassert_false(data, " *** got something unexpected in the fifo");
+	ztest_false(data, " *** got something unexpected in the fifo");
 
 	/* test k_thread_create() with cancellation */
 	TC_PRINT("Testing k_thread_create() with cancellations\n");
@@ -846,10 +846,10 @@ static void test_k_sleep(void)
 
 		data = k_fifo_get(&timeout_order_fifo, 2750);
 
-		zassert_not_null(data, " *** timeout while waiting for"
+		ztest_not_null(data, " *** timeout while waiting for"
 				 " delayed thread");
 
-		zassert_equal(data->timeout_order, i,
+		ztest_equal(data->timeout_order, i,
 			      " *** wrong delayed thread ran (got %d, "
 			      "expected %d)\n", data->timeout_order, i);
 
@@ -858,13 +858,13 @@ static void test_k_sleep(void)
 			 data->timeout_order);
 	}
 
-	zassert_equal(num_cancellations, next_cancellation,
+	ztest_equal(num_cancellations, next_cancellation,
 		      " *** wrong number of cancellations (expected %d, "
 		      "got %d\n", num_cancellations, next_cancellation);
 
 	/* ensure no more thread fire */
 	data = k_fifo_get(&timeout_order_fifo, 750);
-	zassert_false(data, " *** got something unexpected in the fifo");
+	ztest_false(data, " *** got something unexpected in the fifo");
 
 }
 
@@ -892,7 +892,7 @@ void test_k_yield(void)
 			k_yield_entry, NULL, NULL,
 			NULL, K_PRIO_COOP(THREAD_PRIORITY), 0, K_NO_WAIT);
 
-	zassert_equal(thread_evidence, 1,
+	ztest_equal(thread_evidence, 1,
 		      "Thread did not execute as expected!: %d", thread_evidence);
 
 	k_sem_give(&sem_thread);

--- a/tests/kernel/critical/src/main.c
+++ b/tests/kernel/critical/src/main.c
@@ -172,10 +172,10 @@ void regression_thread(void *arg1, void *arg2, void *arg3)
 	ncalls = critical_loop("reg1", ncalls);
 
 	/* Wait for alternate_thread() to complete */
-	zassert_true(k_sem_take(&REGRESS_SEM, TEST_TIMEOUT) == 0,
+	ztest_true(k_sem_take(&REGRESS_SEM, TEST_TIMEOUT) == 0,
 		     "Timed out waiting for REGRESS_SEM");
 
-	zassert_equal(critical_var, ncalls + alt_thread_iterations,
+	ztest_equal(critical_var, ncalls + alt_thread_iterations,
 		      "Unexpected value for <critical_var>");
 
 	TC_PRINT("Enable timeslicing at %u\n", k_uptime_get_32());
@@ -186,10 +186,10 @@ void regression_thread(void *arg1, void *arg2, void *arg3)
 	ncalls = critical_loop("reg2", ncalls);
 
 	/* Wait for alternate_thread() to finish */
-	zassert_true(k_sem_take(&REGRESS_SEM, TEST_TIMEOUT) == 0,
+	ztest_true(k_sem_take(&REGRESS_SEM, TEST_TIMEOUT) == 0,
 		     "Timed out waiting for REGRESS_SEM");
 
-	zassert_equal(critical_var, ncalls + alt_thread_iterations,
+	ztest_equal(critical_var, ncalls + alt_thread_iterations,
 		      "Unexpected value for <critical_var>");
 
 	k_sem_give(&TEST_SEM);
@@ -230,7 +230,7 @@ void test_critical(void)
 	init_objects();
 	start_threads();
 
-	zassert_true(k_sem_take(&TEST_SEM, TEST_TIMEOUT * 2) == 0,
+	ztest_true(k_sem_take(&TEST_SEM, TEST_TIMEOUT * 2) == 0,
 		     "Timed out waiting for TEST_SEM");
 }
 

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -42,9 +42,9 @@ void test_dummy_device(void)
 	struct device *dev;
 
 	dev = device_get_binding(DUMMY_PORT_1);
-	zassert_equal(dev, NULL, NULL);
+	ztest_equal(dev, NULL, NULL);
 	dev = device_get_binding(DUMMY_PORT_2);
-	zassert_false((dev == NULL), NULL);
+	ztest_false((dev == NULL), NULL);
 
 	device_busy_set(dev);
 	device_busy_clear(dev);
@@ -53,7 +53,7 @@ void test_dummy_device(void)
 	 * with failed init.
 	 */
 	dev = device_get_binding(BAD_DRIVER);
-	zassert_true((dev == NULL), NULL);
+	ztest_true((dev == NULL), NULL);
 }
 
 /**
@@ -70,7 +70,7 @@ static void test_dynamic_name(void)
 
 	snprintk(name, sizeof(name), "%s", DUMMY_PORT_2);
 	mux = device_get_binding(name);
-	zassert_true(mux != NULL, NULL);
+	ztest_true(mux != NULL, NULL);
 }
 
 /**
@@ -88,7 +88,7 @@ static void test_bogus_dynamic_name(void)
 
 	snprintk(name, sizeof(name), "ANOTHER_BOGUS_NAME");
 	mux = device_get_binding(name);
-	zassert_true(mux == NULL, NULL);
+	ztest_true(mux == NULL, NULL);
 }
 
 static struct init_record {
@@ -144,23 +144,23 @@ void test_pre_kernel_detection(void)
 {
 	struct init_record *rpe = rp;
 
-	zassert_equal(rp - init_records, 4U,
+	ztest_equal(rp - init_records, 4U,
 		      "bad record count");
 	rp = init_records;
 	while ((rp < rpe) && rp->pre_kernel) {
-		zassert_equal(rp->is_in_isr, false,
+		ztest_equal(rp->is_in_isr, false,
 			      "rec %zu isr", rp - init_records);
-		zassert_equal(rp->is_pre_kernel, true,
+		ztest_equal(rp->is_pre_kernel, true,
 			      "rec %zu pre-kernel", rp - init_records);
 		++rp;
 	}
-	zassert_equal(rp - init_records, 2U,
+	ztest_equal(rp - init_records, 2U,
 		      "bad pre-kernel count");
 
 	while (rp < rpe) {
-		zassert_equal(rp->is_in_isr, false,
+		ztest_equal(rp->is_in_isr, false,
 			      "rec %zu isr", rp - init_records);
-		zassert_equal(rp->is_pre_kernel, false,
+		ztest_equal(rp->is_pre_kernel, false,
 			      "rec %zu post-kernel", rp - init_records);
 		++rp;
 	}
@@ -181,7 +181,7 @@ static void build_suspend_device_list(void)
 	struct device *devices;
 
 	device_list_get(&devices, &devcount);
-	zassert_false((devcount == 0), NULL);
+	ztest_false((devcount == 0), NULL);
 }
 
 /**
@@ -201,32 +201,32 @@ void test_dummy_device_pm(void)
 	int busy, ret;
 
 	dev = device_get_binding(DUMMY_PORT_2);
-	zassert_false((dev == NULL), NULL);
+	ztest_false((dev == NULL), NULL);
 
 	busy = device_any_busy_check();
-	zassert_true((busy == 0), NULL);
+	ztest_true((busy == 0), NULL);
 
 	/* Set device state to DEVICE_PM_ACTIVE_STATE */
 	ret = device_set_power_state(dev, DEVICE_PM_ACTIVE_STATE, NULL, NULL);
-	zassert_true((ret == 0), "Unable to set active state to device");
+	ztest_true((ret == 0), "Unable to set active state to device");
 
 	device_busy_set(dev);
 
 	busy = device_any_busy_check();
-	zassert_false((busy == 0), NULL);
+	ztest_false((busy == 0), NULL);
 
 	busy = device_busy_check(dev);
-	zassert_false((busy == 0), NULL);
+	ztest_false((busy == 0), NULL);
 
 	device_busy_clear(dev);
 
 	busy = device_busy_check(dev);
-	zassert_true((busy == 0), NULL);
+	ztest_true((busy == 0), NULL);
 
 	/* Set device state to DEVICE_PM_FORCE_SUSPEND_STATE */
 	ret = device_set_power_state(dev,
 			DEVICE_PM_FORCE_SUSPEND_STATE, NULL, NULL);
-	zassert_true((ret == 0), "Unable to force suspend device");
+	ztest_true((ret == 0), "Unable to force suspend device");
 
 	build_suspend_device_list();
 }

--- a/tests/kernel/early_sleep/src/main.c
+++ b/tests/kernel/early_sleep/src/main.c
@@ -116,21 +116,21 @@ static void test_early_sleep(void)
 
 	TC_PRINT("k_sleep() ticks at POST_KERNEL level: %d\n",
 					actual_post_kernel_sleep_ticks);
-	zassert_true((actual_post_kernel_sleep_ticks + 1) >
+	ztest_true((actual_post_kernel_sleep_ticks + 1) >
 					TEST_TICKS_TO_SLEEP, NULL);
 
 	TC_PRINT("k_sleep() ticks at APPLICATION level: %d\n",
 					actual_app_sleep_ticks);
-	zassert_true((actual_app_sleep_ticks + 1) >
+	ztest_true((actual_app_sleep_ticks + 1) >
 					TEST_TICKS_TO_SLEEP, NULL);
 
 	actual_sleep_ticks = ticks_to_sleep(TEST_TICKS_TO_SLEEP);
 	TC_PRINT("k_sleep() ticks on running system: %d\n",
 					actual_sleep_ticks);
-	zassert_true((actual_sleep_ticks + 1) >
+	ztest_true((actual_sleep_ticks + 1) >
 					TEST_TICKS_TO_SLEEP, NULL);
 
-	zassert_false(test_failure, "Lower priority thread not ran!!");
+	ztest_false(test_failure, "Lower priority thread not ran!!");
 }
 
 /*test case main entry*/

--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -243,7 +243,7 @@ void check_stack_overflow(void *handler, u32_t flags)
 			NULL, NULL, NULL, K_PRIO_PREEMPT(PRIORITY), flags,
 			K_NO_WAIT);
 
-	zassert_not_equal(rv, TC_FAIL, "thread was not aborted");
+	ztest_not_equal(rv, TC_FAIL, "thread was not aborted");
 }
 #endif /* !CONFIG_ARCH_POSIX */
 
@@ -274,7 +274,7 @@ void test_fatal(void)
 			(k_thread_entry_t)alt_thread1,
 			NULL, NULL, NULL, K_PRIO_COOP(PRIORITY), 0,
 			K_NO_WAIT);
-	zassert_not_equal(rv, TC_FAIL, "thread was not aborted");
+	ztest_not_equal(rv, TC_FAIL, "thread was not aborted");
 #else
 	/*
 	 * We want the native OS to handle segfaults so we can debug it
@@ -290,7 +290,7 @@ void test_fatal(void)
 			NULL, NULL, NULL, K_PRIO_COOP(PRIORITY), 0,
 			K_NO_WAIT);
 	k_thread_abort(&alt_thread);
-	zassert_not_equal(rv, TC_FAIL, "thread was not aborted");
+	ztest_not_equal(rv, TC_FAIL, "thread was not aborted");
 
 	TC_PRINT("test alt thread 3: initiate kernel panic\n");
 	k_thread_create(&alt_thread, alt_stack,
@@ -299,7 +299,7 @@ void test_fatal(void)
 			NULL, NULL, NULL, K_PRIO_COOP(PRIORITY), 0,
 			K_NO_WAIT);
 	k_thread_abort(&alt_thread);
-	zassert_not_equal(rv, TC_FAIL, "thread was not aborted");
+	ztest_not_equal(rv, TC_FAIL, "thread was not aborted");
 
 	TC_PRINT("test alt thread 4: fail assertion\n");
 	k_thread_create(&alt_thread, alt_stack,
@@ -308,7 +308,7 @@ void test_fatal(void)
 			NULL, NULL, NULL, K_PRIO_COOP(PRIORITY), 0,
 			K_NO_WAIT);
 	k_thread_abort(&alt_thread);
-	zassert_not_equal(rv, TC_FAIL, "thread was not aborted");
+	ztest_not_equal(rv, TC_FAIL, "thread was not aborted");
 
 	TC_PRINT("test alt thread 5: initiate arbitrary SW exception\n");
 	k_thread_create(&alt_thread, alt_stack,
@@ -317,7 +317,7 @@ void test_fatal(void)
 			NULL, NULL, NULL, K_PRIO_COOP(PRIORITY), 0,
 			K_NO_WAIT);
 	k_thread_abort(&alt_thread);
-	zassert_not_equal(rv, TC_FAIL, "thread was not aborted");
+	ztest_not_equal(rv, TC_FAIL, "thread was not aborted");
 
 #ifndef CONFIG_ARCH_POSIX
 

--- a/tests/kernel/fifo/fifo_api/src/test_fifo_cancel.c
+++ b/tests/kernel/fifo/fifo_api/src/test_fifo_cancel.c
@@ -39,14 +39,14 @@ static void tfifo_thread_thread(struct k_fifo *pfifo)
 	 * from the call, leading to crash.
 	 */
 	k_thread_abort(tid);
-	zassert_is_null(ret,
+	ztest_is_null(ret,
 			"k_fifo_get didn't get 'timeout expired' status");
 	/* 80 includes generous fuzz factor as k_sleep() will add an extra
 	 * tick for non-tickless systems, and we may cross another tick
 	 * boundary while doing this. We just want to ensure we didn't
 	 * hit the timeout anyway.
 	 */
-	zassert_true(dur < 80,
+	ztest_true(dur < 80,
 		     "k_fifo_get didn't get cancelled in expected timeframe");
 }
 

--- a/tests/kernel/fifo/fifo_api/src/test_fifo_contexts.c
+++ b/tests/kernel/fifo/fifo_api/src/test_fifo_contexts.c
@@ -51,17 +51,17 @@ static void tfifo_get(struct k_fifo *pfifo)
 	for (int i = 0; i < LIST_LEN; i++) {
 		/**TESTPOINT: fifo get*/
 		rx_data = k_fifo_get(pfifo, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data[i], NULL);
+		ztest_equal(rx_data, (void *)&data[i], NULL);
 	}
 	/*get fifo data from "fifo_put_list"*/
 	for (int i = 0; i < LIST_LEN; i++) {
 		rx_data = k_fifo_get(pfifo, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data_l[i], NULL);
+		ztest_equal(rx_data, (void *)&data_l[i], NULL);
 	}
 	/*get fifo data from "fifo_put_slist"*/
 	for (int i = 0; i < LIST_LEN; i++) {
 		rx_data = k_fifo_get(pfifo, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data_sl[i], NULL);
+		ztest_equal(rx_data, (void *)&data_sl[i], NULL);
 	}
 }
 
@@ -69,13 +69,13 @@ static void tfifo_get(struct k_fifo *pfifo)
 static void tIsr_entry_put(void *p)
 {
 	tfifo_put((struct k_fifo *)p);
-	zassert_false(k_fifo_is_empty((struct k_fifo *)p), NULL);
+	ztest_false(k_fifo_is_empty((struct k_fifo *)p), NULL);
 }
 
 static void tIsr_entry_get(void *p)
 {
 	tfifo_get((struct k_fifo *)p);
-	zassert_true(k_fifo_is_empty((struct k_fifo *)p), NULL);
+	ztest_true(k_fifo_is_empty((struct k_fifo *)p), NULL);
 }
 
 static void tThread_entry(void *p1, void *p2, void *p3)
@@ -118,11 +118,11 @@ static void tfifo_is_empty(void *p)
 
 	tfifo_put(&fifo);
 	/**TESTPOINT: return false when data available*/
-	zassert_false(k_fifo_is_empty(pfifo), NULL);
+	ztest_false(k_fifo_is_empty(pfifo), NULL);
 
 	tfifo_get(&fifo);
 	/**TESTPOINT: return true with data unavailable*/
-	zassert_true(k_fifo_is_empty(pfifo), NULL);
+	ztest_true(k_fifo_is_empty(pfifo), NULL);
 }
 
 /**
@@ -180,7 +180,7 @@ void test_fifo_is_empty_thread(void)
 {
 	k_fifo_init(&fifo);
 	/**TESTPOINT: k_fifo_is_empty after init*/
-	zassert_true(k_fifo_is_empty(&fifo), NULL);
+	ztest_true(k_fifo_is_empty(&fifo), NULL);
 
 	/**TESTPONT: check fifo is empty from thread*/
 	tfifo_is_empty(&fifo);

--- a/tests/kernel/fifo/fifo_api/src/test_fifo_fail.c
+++ b/tests/kernel/fifo/fifo_api/src/test_fifo_fail.c
@@ -25,8 +25,8 @@ void test_fifo_get_fail(void *p1, void *p2, void *p3)
 
 	k_fifo_init(&fifo);
 	/**TESTPOINT: fifo get returns NULL*/
-	zassert_is_null(k_fifo_get(&fifo, K_NO_WAIT), NULL);
-	zassert_is_null(k_fifo_get(&fifo, TIMEOUT), NULL);
+	ztest_is_null(k_fifo_get(&fifo, K_NO_WAIT), NULL);
+	ztest_is_null(k_fifo_get(&fifo, TIMEOUT), NULL);
 }
 /**
  * @}

--- a/tests/kernel/fifo/fifo_api/src/test_fifo_loop.c
+++ b/tests/kernel/fifo/fifo_api/src/test_fifo_loop.c
@@ -32,7 +32,7 @@ static void tfifo_get(struct k_fifo *pfifo)
 	for (int i = 0; i < LIST_LEN; i++) {
 		/**TESTPOINT: fifo get*/
 		rx_data = k_fifo_get(pfifo, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data[i], NULL);
+		ztest_equal(rx_data, (void *)&data[i], NULL);
 	}
 }
 

--- a/tests/kernel/fifo/fifo_timeout/src/main.c
+++ b/tests/kernel/fifo/fifo_timeout/src/main.c
@@ -87,7 +87,7 @@ static void *get_scratch_packet(void)
 {
 	void *packet = k_fifo_get(&scratch_fifo_packets_fifo, K_NO_WAIT);
 
-	zassert_true(packet != NULL, NULL);
+	ztest_true(packet != NULL, NULL);
 	return packet;
 }
 
@@ -127,8 +127,8 @@ static void test_thread_pend_and_timeout(void *p1, void *p2, void *p3)
 
 	start_time = k_cycle_get_32();
 	packet = k_fifo_get(d->fifo, d->timeout);
-	zassert_true(packet == NULL, NULL);
-	zassert_true(is_timeout_in_range(start_time, d->timeout), NULL);
+	ztest_true(packet == NULL, NULL);
+	ztest_true(is_timeout_in_range(start_time, d->timeout), NULL);
 
 	k_fifo_put(&timeout_order_fifo, d);
 }
@@ -158,7 +158,7 @@ static int test_multiple_threads_pending(struct timeout_order_data *test_data,
 		struct timeout_order_data *data =
 			k_fifo_get(&timeout_order_fifo, K_FOREVER);
 
-		zassert_not_null(data, NULL);
+		ztest_not_null(data, NULL);
 		if (data->timeout_order == ii) {
 			TC_PRINT(" thread (q order: %d, t/o: %d, fifo %p)\n",
 				data->q_order, data->timeout, data->fifo);
@@ -201,7 +201,7 @@ static void test_thread_pend_and_get_data(void *p1, void *p2, void *p3)
 	void *packet;
 
 	packet = k_fifo_get(d->fifo, d->timeout);
-	zassert_true(packet != NULL, NULL);
+	ztest_true(packet != NULL, NULL);
 
 	put_scratch_packet(packet);
 	k_fifo_put(&timeout_order_fifo, d);
@@ -306,12 +306,12 @@ static void test_timeout_empty_fifo(void)
 	timeout = 10U;
 	start_time = k_cycle_get_32();
 	packet = k_fifo_get(&fifo_timeout[0], timeout);
-	zassert_true(packet == NULL, NULL);
-	zassert_true(is_timeout_in_range(start_time, timeout), NULL);
+	ztest_true(packet == NULL, NULL);
+	ztest_true(is_timeout_in_range(start_time, timeout), NULL);
 
 	/* Test empty fifo with timeout of K_NO_WAIT */
 	packet = k_fifo_get(&fifo_timeout[0], K_NO_WAIT);
-	zassert_true(packet == NULL, NULL);
+	ztest_true(packet == NULL, NULL);
 }
 
 /**
@@ -326,14 +326,14 @@ static void test_timeout_non_empty_fifo(void)
 	scratch_packet = get_scratch_packet();
 	k_fifo_put(&fifo_timeout[0], scratch_packet);
 	packet = k_fifo_get(&fifo_timeout[0], K_NO_WAIT);
-	zassert_true(packet != NULL, NULL);
+	ztest_true(packet != NULL, NULL);
 	put_scratch_packet(scratch_packet);
 
 	 /* Test k_fifo_get with K_FOREVER */
 	scratch_packet = get_scratch_packet();
 	k_fifo_put(&fifo_timeout[0], scratch_packet);
 	packet = k_fifo_get(&fifo_timeout[0], K_FOREVER);
-	zassert_true(packet != NULL, NULL);
+	ztest_true(packet != NULL, NULL);
 	put_scratch_packet(scratch_packet);
 }
 
@@ -368,8 +368,8 @@ static void test_timeout_fifo_thread(void)
 				FIFO_THREAD_PRIO, K_INHERIT_PERMS, K_NO_WAIT);
 
 	packet = k_fifo_get(&fifo_timeout[0], timeout + 10);
-	zassert_true(packet != NULL, NULL);
-	zassert_true(is_timeout_in_range(start_time, timeout), NULL);
+	ztest_true(packet != NULL, NULL);
+	ztest_true(is_timeout_in_range(start_time, timeout), NULL);
 	put_scratch_packet(packet);
 
 	/*
@@ -385,8 +385,8 @@ static void test_timeout_fifo_thread(void)
 
 	k_yield();
 	packet = k_fifo_get(&timeout_order_fifo, K_NO_WAIT);
-	zassert_true(packet != NULL, NULL);
-	zassert_false(reply_packet.reply, NULL);
+	ztest_true(packet != NULL, NULL);
+	ztest_false(reply_packet.reply, NULL);
 
 	/*
 	 * Test k_fifo_get with timeout of K_NO_WAIT and the fifo
@@ -404,8 +404,8 @@ static void test_timeout_fifo_thread(void)
 
 	k_yield();
 	packet = k_fifo_get(&timeout_order_fifo, K_NO_WAIT);
-	zassert_true(packet != NULL, NULL);
-	zassert_true(reply_packet.reply, NULL);
+	ztest_true(packet != NULL, NULL);
+	ztest_true(reply_packet.reply, NULL);
 	put_scratch_packet(scratch_packet);
 
 	/*
@@ -423,8 +423,8 @@ static void test_timeout_fifo_thread(void)
 				FIFO_THREAD_PRIO, K_INHERIT_PERMS, K_NO_WAIT);
 
 	packet = k_fifo_get(&timeout_order_fifo, K_FOREVER);
-	zassert_true(packet != NULL, NULL);
-	zassert_true(reply_packet.reply, NULL);
+	ztest_true(packet != NULL, NULL);
+	ztest_true(reply_packet.reply, NULL);
 	put_scratch_packet(scratch_packet);
 }
 
@@ -444,7 +444,7 @@ static void test_timeout_threads_pend_on_fifo(void)
 	 */
 	test_data_size = ARRAY_SIZE(timeout_order_data);
 	rv = test_multiple_threads_pending(timeout_order_data, test_data_size);
-	zassert_equal(rv, TC_PASS, NULL);
+	ztest_equal(rv, TC_PASS, NULL);
 }
 
 /**
@@ -464,7 +464,7 @@ static void test_timeout_threads_pend_on_dual_fifos(void)
 	test_data_size = ARRAY_SIZE(timeout_order_data_mult_fifo);
 	rv = test_multiple_threads_pending(timeout_order_data_mult_fifo,
 							test_data_size);
-	zassert_equal(rv, TC_PASS, NULL);
+	ztest_equal(rv, TC_PASS, NULL);
 
 }
 
@@ -485,7 +485,7 @@ static void test_timeout_threads_pend_fail_on_fifo(void)
 	 */
 	test_data_size = ARRAY_SIZE(timeout_order_data);
 	rv = test_multiple_threads_get_data(timeout_order_data, test_data_size);
-	zassert_equal(rv, TC_PASS, NULL);
+	ztest_equal(rv, TC_PASS, NULL);
 }
 
 /**

--- a/tests/kernel/fifo/fifo_usage/src/main.c
+++ b/tests/kernel/fifo/fifo_usage/src/main.c
@@ -64,7 +64,7 @@ static void tIsr_entry_put(void *p)
 	for (i = 0U; i < LIST_LEN; i++) {
 		k_fifo_put((struct k_fifo *)p, (void *)&data_isr[i]);
 	}
-	zassert_false(k_fifo_is_empty((struct k_fifo *)p), NULL);
+	ztest_false(k_fifo_is_empty((struct k_fifo *)p), NULL);
 }
 
 static void tIsr_entry_get(void *p)
@@ -75,9 +75,9 @@ static void tIsr_entry_get(void *p)
 	/* Get items from fifo */
 	for (i = 0U; i < LIST_LEN; i++) {
 		rx_data = k_fifo_get((struct k_fifo *)p, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data_isr[i], NULL);
+		ztest_equal(rx_data, (void *)&data_isr[i], NULL);
 	}
-	zassert_true(k_fifo_is_empty((struct k_fifo *)p), NULL);
+	ztest_true(k_fifo_is_empty((struct k_fifo *)p), NULL);
 }
 
 static void thread_entry_fn_single(void *p1, void *p2, void *p3)
@@ -88,7 +88,7 @@ static void thread_entry_fn_single(void *p1, void *p2, void *p3)
 	/* Get items from fifo */
 	for (i = 0U; i < LIST_LEN; i++) {
 		rx_data = k_fifo_get((struct k_fifo *)p1, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data1[i], NULL);
+		ztest_equal(rx_data, (void *)&data1[i], NULL);
 	}
 
 	/* Put items into fifo */
@@ -108,7 +108,7 @@ static void thread_entry_fn_dual(void *p1, void *p2, void *p3)
 	for (i = 0U; i < LIST_LEN; i++) {
 		/* Get items from fifo2 */
 		rx_data = k_fifo_get((struct k_fifo *)p2, K_FOREVER);
-		zassert_equal(rx_data, (void *)&data2[i], NULL);
+		ztest_equal(rx_data, (void *)&data2[i], NULL);
 
 		/* Put items into fifo1 */
 		k_fifo_put((struct k_fifo *)p1, (void *)&data1[i]);
@@ -164,7 +164,7 @@ static void test_single_fifo_play(void)
 	/* Get items from fifo */
 	for (i = 0U; i < LIST_LEN; i++) {
 		rx_data = k_fifo_get(&fifo1, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data2[i], NULL);
+		ztest_equal(rx_data, (void *)&data2[i], NULL);
 	}
 
 	/* Clear the spawn thread to avoid side effect */
@@ -195,7 +195,7 @@ static void test_dual_fifo_play(void)
 
 		/* Get item from fifo */
 		rx_data = k_fifo_get(&fifo1, K_FOREVER);
-		zassert_equal(rx_data, (void *)&data1[i], NULL);
+		ztest_equal(rx_data, (void *)&data1[i], NULL);
 	}
 
 	/* Clear the spawn thread to avoid side effect */

--- a/tests/kernel/fp_sharing/float_disable/src/k_float_disable.c
+++ b/tests/kernel/fp_sharing/float_disable/src/k_float_disable.c
@@ -73,32 +73,32 @@ void test_k_float_disable_common(void)
 	k_yield();
 
 	/* Verify K_FP_OPTS are set properly */
-	zassert_true(
+	ztest_true(
 		(usr_fp_thread.base.user_options & K_FP_OPTS) != 0,
 		"usr_fp_thread FP options not set (0x%0x)",
 		usr_fp_thread.base.user_options);
 
 #if defined(CONFIG_ARM)
 	/* Verify FP mode can only be disabled for current thread */
-	zassert_true((k_float_disable(&usr_fp_thread) == -EINVAL),
+	ztest_true((k_float_disable(&usr_fp_thread) == -EINVAL),
 		"k_float_disable() successful on thread other than current!");
 
 	/* Verify K_FP_OPTS are still set */
-	zassert_true(
+	ztest_true(
 		(usr_fp_thread.base.user_options & K_FP_OPTS) != 0,
 		"usr_fp_thread FP options cleared");
 #elif defined(CONFIG_X86) && defined(CONFIG_LAZY_FP_SHARING)
-	zassert_true((k_float_disable(&usr_fp_thread) == 0),
+	ztest_true((k_float_disable(&usr_fp_thread) == 0),
 		"k_float_disable() failure");
 
 	/* Verify K_FP_OPTS are now cleared */
-	zassert_true(
+	ztest_true(
 		(usr_fp_thread.base.user_options & K_FP_OPTS) == 0,
 		"usr_fp_thread FP options not clear (0x%0x)",
 		usr_fp_thread.base.user_options);
 #elif defined(CONFIG_X86) && !defined(CONFIG_LAZY_FP_SHARING)
 	/* Verify k_float_disable() is not supported */
-	zassert_true((k_float_disable(&usr_fp_thread) == -ENOSYS),
+	ztest_true((k_float_disable(&usr_fp_thread) == -ENOSYS),
 		"k_float_disable() successful when not supported");
 #endif
 }
@@ -122,7 +122,7 @@ void test_k_float_disable_syscall(void)
 	k_yield();
 
 	/* Verify K_FP_OPTS are set properly */
-	zassert_true(
+	ztest_true(
 		(usr_fp_thread.base.user_options & K_FP_OPTS) != 0,
 		"usr_fp_thread FP options not set (0x%0x)",
 		usr_fp_thread.base.user_options);
@@ -134,7 +134,7 @@ void test_k_float_disable_syscall(void)
 	(defined(CONFIG_X86) && defined(CONFIG_LAZY_FP_SHARING))
 
 	/* Verify K_FP_OPTS are now cleared by the user thread itself */
-	zassert_true(
+	ztest_true(
 		(usr_fp_thread.base.user_options & K_FP_OPTS) == 0,
 		"usr_fp_thread FP options not clear (0x%0x)",
 		usr_fp_thread.base.user_options);
@@ -142,7 +142,7 @@ void test_k_float_disable_syscall(void)
 	/* ret is volatile, static analysis says we can't use in assert */
 	bool ok = ret == TC_PASS;
 
-	zassert_true(ok, "");
+	ztest_true(ok, "");
 #else
 	/* Check skipped for x86 without support for Lazy FP Sharing */
 #endif
@@ -192,7 +192,7 @@ static void sup_fp_thread_entry(void)
 		}
 	}
 
-	zassert_true(i >= 0,
+	ztest_true(i >= 0,
 		"No available IRQ line to use in the test\n");
 
 	TC_PRINT("Available IRQ line: %u\n", i);
@@ -243,7 +243,7 @@ void test_k_float_disable_irq(void)
 	/* ret is volatile, static analysis says we can't use in assert */
 	bool ok = ret == TC_PASS;
 
-	zassert_true(ok, "");
+	ztest_true(ok, "");
 }
 #else
 void test_k_float_disable_irq(void)

--- a/tests/kernel/interrupt/src/interrupt.h
+++ b/tests/kernel/interrupt/src/interrupt.h
@@ -39,7 +39,7 @@ static u32_t get_available_nvic_line(u32_t initial_offset)
 		}
 	}
 
-	zassert_true(i >= 0, "No available IRQ line\n");
+	ztest_true(i >= 0, "No available IRQ line\n");
 
 	return i;
 }

--- a/tests/kernel/interrupt/src/main.c
+++ b/tests/kernel/interrupt/src/main.c
@@ -38,14 +38,14 @@ static void do_isr_dynamic(void)
 		}
 	}
 
-	zassert_true(_sw_isr_table[i].isr == z_irq_spurious,
+	ztest_true(_sw_isr_table[i].isr == z_irq_spurious,
 		     "could not find slot for dynamic isr");
 
 	argval = &i;
 	arch_irq_connect_dynamic(i + CONFIG_GEN_IRQ_START_VECTOR, 0, dyn_isr,
 				   argval, 0);
 
-	zassert_true(_sw_isr_table[i].isr == dyn_isr &&
+	ztest_true(_sw_isr_table[i].isr == dyn_isr &&
 		     _sw_isr_table[i].arg == argval,
 		     "dynamic isr did not install successfully");
 }

--- a/tests/kernel/interrupt/src/nested_irq.c
+++ b/tests/kernel/interrupt/src/nested_irq.c
@@ -89,7 +89,7 @@ void isr0(void *param)
 	k_busy_wait(MS_TO_US(10));
 #endif
 	printk("%s execution completed !!\n", __func__);
-	zassert_equal(new_val, old_val, "Nested interrupt is not working\n");
+	ztest_equal(new_val, old_val, "Nested interrupt is not working\n");
 }
 
 /**
@@ -155,7 +155,7 @@ void test_prevent_interruption(void)
 	 */
 	k_timer_start(&irqlock_timer, DURATION, K_NO_WAIT);
 	k_busy_wait(MS_TO_US(1000));
-	zassert_not_equal(check_lock_new, check_lock_old,
+	ztest_not_equal(check_lock_new, check_lock_old,
 		"Interrupt locking didn't work properly");
 
 	printk("unlocking interrupts\n");
@@ -163,7 +163,7 @@ void test_prevent_interruption(void)
 
 	k_busy_wait(MS_TO_US(1000));
 
-	zassert_equal(check_lock_new, check_lock_old,
+	ztest_equal(check_lock_new, check_lock_old,
 		"timer should have fired");
 
 	k_timer_stop(&irqlock_timer);

--- a/tests/kernel/lifo/lifo_api/src/test_lifo_contexts.c
+++ b/tests/kernel/lifo/lifo_api/src/test_lifo_contexts.c
@@ -34,7 +34,7 @@ static void tlifo_get(struct k_lifo *plifo)
 	for (int i = LIST_LEN-1; i >= 0; i--) {
 		/**TESTPOINT: lifo get*/
 		rx_data = k_lifo_get(plifo, K_FOREVER);
-		zassert_equal(rx_data, (void *)&data[i], NULL);
+		ztest_equal(rx_data, (void *)&data[i], NULL);
 	}
 }
 

--- a/tests/kernel/lifo/lifo_api/src/test_lifo_fail.c
+++ b/tests/kernel/lifo/lifo_api/src/test_lifo_fail.c
@@ -26,8 +26,8 @@ void test_lifo_get_fail(void *p1, void *p2, void *p3)
 
 	k_lifo_init(&lifo);
 	/**TESTPOINT: lifo get returns NULL*/
-	zassert_is_null(k_lifo_get(&lifo, K_NO_WAIT), NULL);
-	zassert_is_null(k_lifo_get(&lifo, TIMEOUT), NULL);
+	ztest_is_null(k_lifo_get(&lifo, K_NO_WAIT), NULL);
+	ztest_is_null(k_lifo_get(&lifo, TIMEOUT), NULL);
 }
 
 /**

--- a/tests/kernel/lifo/lifo_api/src/test_lifo_loop.c
+++ b/tests/kernel/lifo/lifo_api/src/test_lifo_loop.c
@@ -32,7 +32,7 @@ static void tlifo_get(struct k_lifo *plifo)
 	for (int i = LIST_LEN-1; i >= 0; i--) {
 		/**TESTPOINT: lifo get*/
 		rx_data = k_lifo_get(plifo, K_FOREVER);
-		zassert_equal(rx_data, (void *)&data[i], NULL);
+		ztest_equal(rx_data, (void *)&data[i], NULL);
 	}
 }
 

--- a/tests/kernel/lifo/lifo_usage/src/main.c
+++ b/tests/kernel/lifo/lifo_usage/src/main.c
@@ -80,7 +80,7 @@ static void *get_scratch_packet(void)
 {
 	void *packet = k_lifo_get(&scratch_lifo_packets_lifo, K_NO_WAIT);
 
-	zassert_true(packet != NULL, NULL);
+	ztest_true(packet != NULL, NULL);
 	return packet;
 }
 
@@ -96,11 +96,11 @@ static void thread_entry_nowait(void *p1, void *p2, void *p3)
 	ret = k_lifo_get((struct k_lifo *)p1, K_FOREVER);
 
 	/* data pushed at last should be read first */
-	zassert_equal(ret, (void *)&data[1], NULL);
+	ztest_equal(ret, (void *)&data[1], NULL);
 
 	ret = k_lifo_get((struct k_lifo *)p1, K_FOREVER);
 
-	zassert_equal(ret, (void *)&data[0], NULL);
+	ztest_equal(ret, (void *)&data[0], NULL);
 
 	k_sem_give(&start_sema);
 }
@@ -136,7 +136,7 @@ static int test_multiple_threads_pending(struct timeout_order_data *test_data,
 			TC_PRINT(" thread (q order: %d, t/o: %d, lifo %p)\n",
 				data->q_order, data->timeout, data->klifo);
 		} else {
-			zassert_equal(data->timeout_order, ii, " *** thread %d "
+			ztest_equal(data->timeout_order, ii, " *** thread %d "
 				      "woke up, expected %d\n",
 				      data->timeout_order, ii);
 			return TC_FAIL;
@@ -244,13 +244,13 @@ static void test_lifo_wait(void)
 
 	ret = k_lifo_get(&plifo, K_FOREVER);
 
-	zassert_equal(ret, (void *)&data[0], NULL);
+	ztest_equal(ret, (void *)&data[0], NULL);
 
 	k_sem_take(&wait_sema, K_FOREVER);
 
 	ret = k_lifo_get(&plifo, K_FOREVER);
 
-	zassert_equal(ret, (void *)&data[1], NULL);
+	ztest_equal(ret, (void *)&data[1], NULL);
 
 	k_thread_abort(tid);
 }
@@ -271,13 +271,13 @@ static void test_timeout_empty_lifo(void)
 
 	packet = k_lifo_get(&lifo_timeout[0], timeout);
 
-	zassert_equal(packet, NULL, NULL);
+	ztest_equal(packet, NULL, NULL);
 
-	zassert_true(is_timeout_in_range(start_time, timeout), NULL);
+	ztest_true(is_timeout_in_range(start_time, timeout), NULL);
 
 	/* Test empty lifo with timeout of K_NO_WAIT */
 	packet = k_lifo_get(&lifo_timeout[0], K_NO_WAIT);
-	zassert_equal(packet, NULL, NULL);
+	ztest_equal(packet, NULL, NULL);
 }
 
 /**
@@ -292,14 +292,14 @@ static void test_timeout_non_empty_lifo(void)
 	scratch_packet = get_scratch_packet();
 	k_lifo_put(&lifo_timeout[0], scratch_packet);
 	packet = k_lifo_get(&lifo_timeout[0], K_NO_WAIT);
-	zassert_true(packet != NULL, NULL);
+	ztest_true(packet != NULL, NULL);
 	put_scratch_packet(scratch_packet);
 
 	 /* Test k_lifo_get with K_FOREVER */
 	scratch_packet = get_scratch_packet();
 	k_lifo_put(&lifo_timeout[0], scratch_packet);
 	packet = k_lifo_get(&lifo_timeout[0], K_FOREVER);
-	zassert_true(packet != NULL, NULL);
+	ztest_true(packet != NULL, NULL);
 }
 
 /**
@@ -325,8 +325,8 @@ static void test_timeout_lifo_thread(void)
 				LIFO_THREAD_PRIO, K_INHERIT_PERMS, K_NO_WAIT);
 
 	packet = k_lifo_get(&lifo_timeout[0], timeout + 10);
-	zassert_true(packet != NULL, NULL);
-	zassert_true(is_timeout_in_range(start_time, timeout), NULL);
+	ztest_true(packet != NULL, NULL);
+	ztest_true(is_timeout_in_range(start_time, timeout), NULL);
 	put_scratch_packet(packet);
 
 	/*
@@ -342,8 +342,8 @@ static void test_timeout_lifo_thread(void)
 
 	k_yield();
 	packet = k_lifo_get(&timeout_order_lifo, K_NO_WAIT);
-	zassert_true(packet != NULL, NULL);
-	zassert_false(reply_packet.reply, NULL);
+	ztest_true(packet != NULL, NULL);
+	ztest_false(reply_packet.reply, NULL);
 
 	/*
 	 * Test k_lifo_get with timeout of K_NO_WAIT and the lifo
@@ -361,8 +361,8 @@ static void test_timeout_lifo_thread(void)
 
 	k_yield();
 	packet = k_lifo_get(&timeout_order_lifo, K_NO_WAIT);
-	zassert_true(packet != NULL, NULL);
-	zassert_true(reply_packet.reply, NULL);
+	ztest_true(packet != NULL, NULL);
+	ztest_true(reply_packet.reply, NULL);
 	put_scratch_packet(scratch_packet);
 
 	/*
@@ -380,8 +380,8 @@ static void test_timeout_lifo_thread(void)
 				LIFO_THREAD_PRIO, K_INHERIT_PERMS, K_NO_WAIT);
 
 	packet = k_lifo_get(&timeout_order_lifo, K_FOREVER);
-	zassert_true(packet != NULL, NULL);
-	zassert_true(reply_packet.reply, NULL);
+	ztest_true(packet != NULL, NULL);
+	ztest_true(reply_packet.reply, NULL);
 	put_scratch_packet(scratch_packet);
 }
 
@@ -397,8 +397,8 @@ void test_thread_pend_and_timeout(void *p1, void *p2, void *p3)
 
 	start_time = k_cycle_get_32();
 	packet = k_lifo_get(d->klifo, d->timeout);
-	zassert_true(packet == NULL, NULL);
-	zassert_true(is_timeout_in_range(start_time, d->timeout), NULL);
+	ztest_true(packet == NULL, NULL);
+	ztest_true(is_timeout_in_range(start_time, d->timeout), NULL);
 
 	k_lifo_put(&timeout_order_lifo, d);
 }
@@ -420,7 +420,7 @@ static void test_timeout_threads_pend_on_lifo(void)
 	 */
 	test_data_size = ARRAY_SIZE(timeout_order_data);
 	rv = test_multiple_threads_pending(timeout_order_data, test_data_size);
-	zassert_equal(rv, TC_PASS, NULL);
+	ztest_equal(rv, TC_PASS, NULL);
 }
 
 /**

--- a/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
+++ b/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
@@ -100,7 +100,7 @@ static void mbox_get_waiting_thread(void *p1, void *p2, void *p3)
 	}
 
 	mmsg.size = 0;
-	zassert_true(k_mbox_get(pmbox, &mmsg, NULL, K_FOREVER) == 0,
+	ztest_true(k_mbox_get(pmbox, &mmsg, NULL, K_FOREVER) == 0,
 		     "Failure at thread number %d", thread_number);
 
 }
@@ -149,7 +149,7 @@ static void tmbox_put(struct k_mbox *pmbox)
 		mmsg.info = ASYNC_PUT_GET_BLOCK;
 		mmsg.size = MAIL_LEN;
 		mmsg.tx_data = NULL;
-		zassert_equal(k_mem_pool_alloc(&mpooltx, &mmsg.tx_block,
+		ztest_equal(k_mem_pool_alloc(&mpooltx, &mmsg.tx_block,
 					       MAIL_LEN, K_NO_WAIT), 0, NULL);
 		memcpy(mmsg.tx_block.data, data[info_type], MAIL_LEN);
 		if (info_type == TARGET_SOURCE_THREAD_BLOCK) {
@@ -163,7 +163,7 @@ static void tmbox_put(struct k_mbox *pmbox)
 		break;
 	case INCORRECT_TRANSMIT_TID:
 		mmsg.tx_target_thread = random_tid;
-		zassert_true(k_mbox_put(pmbox,
+		ztest_true(k_mbox_put(pmbox,
 					&mmsg,
 					K_NO_WAIT) == -ENOMSG, NULL);
 		break;
@@ -192,7 +192,7 @@ static void tmbox_put(struct k_mbox *pmbox)
 		mmsg.tx_data = data[1];
 		mmsg.tx_block.data = NULL;
 		mmsg.tx_target_thread = K_ANY;
-		zassert_true(k_mbox_put(pmbox, &mmsg, K_FOREVER) == 0, NULL);
+		ztest_true(k_mbox_put(pmbox, &mmsg, K_FOREVER) == 0, NULL);
 		break;
 	case BLOCK_GET_BUFF_TO_SMALLER_POOL:
 		/* copy the tx buffer data onto a pool block via data_block_get
@@ -203,7 +203,7 @@ static void tmbox_put(struct k_mbox *pmbox)
 		mmsg.tx_data = data[1];
 		mmsg.tx_block.data = NULL;
 		mmsg.tx_target_thread = K_ANY;
-		zassert_true(k_mbox_put(pmbox, &mmsg, TIMEOUT) == 0, NULL);
+		ztest_true(k_mbox_put(pmbox, &mmsg, TIMEOUT) == 0, NULL);
 		break;
 
 	case DISPOSE_SIZE_0_MSG:
@@ -212,18 +212,18 @@ static void tmbox_put(struct k_mbox *pmbox)
 		mmsg.tx_data = data[1];
 		mmsg.tx_block.data = NULL;
 		mmsg.tx_target_thread = K_ANY;
-		zassert_true(k_mbox_put(pmbox, &mmsg, K_FOREVER) == 0, NULL);
+		ztest_true(k_mbox_put(pmbox, &mmsg, K_FOREVER) == 0, NULL);
 		break;
 
 	case CLEAN_UP_TX_POOL:
 		/* Dispose of tx mem pool once we receive it */
 		mmsg.size = MAIL_LEN;
 		mmsg.tx_data = NULL;
-		zassert_equal(k_mem_pool_alloc(&mpooltx, &mmsg.tx_block,
+		ztest_equal(k_mem_pool_alloc(&mpooltx, &mmsg.tx_block,
 					       MAIL_LEN, K_NO_WAIT), 0, NULL);
 		memcpy(mmsg.tx_block.data, data[0], MAIL_LEN);
 		mmsg.tx_target_thread = K_ANY;
-		zassert_true(k_mbox_put(pmbox, &mmsg, K_FOREVER) == 0, NULL);
+		ztest_true(k_mbox_put(pmbox, &mmsg, K_FOREVER) == 0, NULL);
 		break;
 	case ASYNC_PUT_TO_WAITING_GET:
 		k_sem_take(&sync_sema, K_FOREVER);
@@ -306,12 +306,12 @@ static void tmbox_get(struct k_mbox *pmbox)
 		mmsg.size = sizeof(rxdata);
 		mmsg.rx_source_thread = K_ANY;
 		/*verify return value*/
-		zassert_true(k_mbox_get(pmbox, &mmsg, rxdata, K_FOREVER) == 0,
+		ztest_true(k_mbox_get(pmbox, &mmsg, rxdata, K_FOREVER) == 0,
 			     NULL);
 		/*verify .info*/
-		zassert_equal(mmsg.info, PUT_GET_NULL, NULL);
+		ztest_equal(mmsg.info, PUT_GET_NULL, NULL);
 		/*verify .size*/
-		zassert_equal(mmsg.size, 0, NULL);
+		ztest_equal(mmsg.size, 0, NULL);
 		break;
 	case PUT_GET_BUFFER:
 	/*fall through*/
@@ -323,24 +323,24 @@ static void tmbox_get(struct k_mbox *pmbox)
 		} else {
 			mmsg.rx_source_thread = K_ANY;
 		}
-		zassert_true(k_mbox_get(pmbox, &mmsg, rxdata, K_FOREVER) == 0,
+		ztest_true(k_mbox_get(pmbox, &mmsg, rxdata, K_FOREVER) == 0,
 			     NULL);
-		zassert_equal(mmsg.info, PUT_GET_BUFFER, NULL);
-		zassert_equal(mmsg.size, sizeof(data[info_type]), NULL);
+		ztest_equal(mmsg.info, PUT_GET_BUFFER, NULL);
+		ztest_equal(mmsg.size, sizeof(data[info_type]), NULL);
 		/*verify rxdata*/
-		zassert_true(memcmp(rxdata, data[info_type], MAIL_LEN) == 0,
+		ztest_true(memcmp(rxdata, data[info_type], MAIL_LEN) == 0,
 			     NULL);
 		break;
 	case ASYNC_PUT_GET_BUFFER:
 		/**TESTPOINT: mbox async get buffer*/
 		mmsg.size = sizeof(rxdata);
 		mmsg.rx_source_thread = K_ANY;
-		zassert_true(k_mbox_get(pmbox, &mmsg, NULL, K_FOREVER) == 0,
+		ztest_true(k_mbox_get(pmbox, &mmsg, NULL, K_FOREVER) == 0,
 			     NULL);
-		zassert_equal(mmsg.info, ASYNC_PUT_GET_BUFFER, NULL);
-		zassert_equal(mmsg.size, sizeof(data[info_type]), NULL);
+		ztest_equal(mmsg.info, ASYNC_PUT_GET_BUFFER, NULL);
+		ztest_equal(mmsg.size, sizeof(data[info_type]), NULL);
 		k_mbox_data_get(&mmsg, rxdata);
-		zassert_true(memcmp(rxdata, data[info_type], MAIL_LEN) == 0,
+		ztest_true(memcmp(rxdata, data[info_type], MAIL_LEN) == 0,
 			     NULL);
 		break;
 	case ASYNC_PUT_GET_BLOCK:
@@ -353,41 +353,41 @@ static void tmbox_get(struct k_mbox *pmbox)
 		} else {
 			mmsg.rx_source_thread = K_ANY;
 		}
-		zassert_true(k_mbox_get(pmbox, &mmsg, NULL, K_FOREVER) == 0,
+		ztest_true(k_mbox_get(pmbox, &mmsg, NULL, K_FOREVER) == 0,
 			     NULL);
-		zassert_true(k_mbox_data_block_get
+		ztest_true(k_mbox_data_block_get
 				     (&mmsg, &mpoolrx, &rxblock, K_FOREVER) == 0
 			     , NULL);
-		zassert_equal(mmsg.info, ASYNC_PUT_GET_BLOCK, NULL);
-		zassert_equal(mmsg.size, MAIL_LEN, NULL);
+		ztest_equal(mmsg.info, ASYNC_PUT_GET_BLOCK, NULL);
+		ztest_equal(mmsg.size, MAIL_LEN, NULL);
 		/*verify rxblock*/
-		zassert_true(memcmp(rxblock.data, data[info_type], MAIL_LEN)
+		ztest_true(memcmp(rxblock.data, data[info_type], MAIL_LEN)
 			     == 0, NULL);
 		k_mem_pool_free(&rxblock);
 		break;
 	case INCORRECT_RECEIVER_TID:
 		mmsg.rx_source_thread = random_tid;
-		zassert_true(k_mbox_get
+		ztest_true(k_mbox_get
 			     (pmbox, &mmsg, NULL, K_NO_WAIT) == -ENOMSG,
 			     NULL);
 		break;
 	case TIMED_OUT_MBOX_GET:
 		mmsg.rx_source_thread = random_tid;
-		zassert_true(k_mbox_get(pmbox, &mmsg, NULL, TIMEOUT) == -EAGAIN,
+		ztest_true(k_mbox_get(pmbox, &mmsg, NULL, TIMEOUT) == -EAGAIN,
 			     NULL);
 		break;
 	case BLOCK_GET_INVALID_POOL:
 		/* To dispose of the rx msg using block get */
 		mmsg.rx_source_thread = K_ANY;
-		zassert_true(k_mbox_get(pmbox, &mmsg, NULL, K_FOREVER) == 0,
+		ztest_true(k_mbox_get(pmbox, &mmsg, NULL, K_FOREVER) == 0,
 			     NULL);
-		zassert_true(k_mbox_data_block_get
+		ztest_true(k_mbox_data_block_get
 			     (&mmsg, NULL, NULL, K_FOREVER) == 0,
 			     NULL);
 		break;
 	case MSG_TID_MISMATCH:
 		mmsg.rx_source_thread = random_tid;
-		zassert_true(k_mbox_get
+		ztest_true(k_mbox_get
 			     (pmbox, &mmsg, NULL, K_NO_WAIT) == -ENOMSG, NULL);
 		break;
 
@@ -397,13 +397,13 @@ static void tmbox_get(struct k_mbox *pmbox)
 		 */
 		mmsg.rx_source_thread = K_ANY;
 		mmsg.size = MAIL_LEN;
-		zassert_true(k_mbox_get(pmbox, &mmsg, NULL, K_FOREVER) == 0,
+		ztest_true(k_mbox_get(pmbox, &mmsg, NULL, K_FOREVER) == 0,
 			     NULL);
-		zassert_true(k_mbox_data_block_get
+		ztest_true(k_mbox_data_block_get
 			     (&mmsg, &mpoolrx, &rxblock, K_FOREVER) == 0, NULL);
 
 		/* verfiy */
-		zassert_true(memcmp(rxblock.data, data[1], MAIL_LEN)
+		ztest_true(memcmp(rxblock.data, data[1], MAIL_LEN)
 			     == 0, NULL);
 		/* free the block */
 		k_mem_pool_free(&rxblock);
@@ -415,10 +415,10 @@ static void tmbox_get(struct k_mbox *pmbox)
 		 */
 		mmsg.rx_source_thread = K_ANY;
 		mmsg.size = MAIL_LEN * 2;
-		zassert_true(k_mbox_get(pmbox, &mmsg, NULL, K_FOREVER) == 0,
+		ztest_true(k_mbox_get(pmbox, &mmsg, NULL, K_FOREVER) == 0,
 			     NULL);
 
-		zassert_true(k_mbox_data_block_get
+		ztest_true(k_mbox_data_block_get
 			     (&mmsg, &mpoolrx, &rxblock, K_MSEC(1)) == -EAGAIN,
 			     NULL);
 
@@ -429,7 +429,7 @@ static void tmbox_get(struct k_mbox *pmbox)
 	case DISPOSE_SIZE_0_MSG:
 		mmsg.rx_source_thread = K_ANY;
 		mmsg.size = 0;
-		zassert_true(k_mbox_get(pmbox, &mmsg, &rxdata, K_FOREVER) == 0,
+		ztest_true(k_mbox_get(pmbox, &mmsg, &rxdata, K_FOREVER) == 0,
 			     NULL);
 		break;
 
@@ -437,7 +437,7 @@ static void tmbox_get(struct k_mbox *pmbox)
 
 		mmsg.rx_source_thread = K_ANY;
 		mmsg.size = 0;
-		zassert_true(k_mbox_get(pmbox, &mmsg, NULL, K_FOREVER) == 0,
+		ztest_true(k_mbox_get(pmbox, &mmsg, NULL, K_FOREVER) == 0,
 			     NULL);
 		break;
 	case ASYNC_PUT_TO_WAITING_GET:
@@ -453,7 +453,7 @@ static void tmbox_get(struct k_mbox *pmbox)
 		/* Here get is blocked until the thread we created releases
 		 *  the semaphore and the async put completes it operation.
 		 */
-		zassert_true(k_mbox_get(pmbox, &mmsg, NULL, K_FOREVER) == 0,
+		ztest_true(k_mbox_get(pmbox, &mmsg, NULL, K_FOREVER) == 0,
 			     NULL);
 		break;
 	case GET_WAITING_PUT_INCORRECT_TID:
@@ -469,11 +469,11 @@ static void tmbox_get(struct k_mbox *pmbox)
 		 * but the TIDs of the msgs doesn't match and hence
 		 * causing a timeout.
 		 */
-		zassert_true(k_mbox_get(pmbox, &mmsg, NULL, TIMEOUT) == -EAGAIN,
+		ztest_true(k_mbox_get(pmbox, &mmsg, NULL, TIMEOUT) == -EAGAIN,
 			     NULL);
 		/* clean up  */
 		mmsg.rx_source_thread = K_ANY;
-		zassert_true(k_mbox_get(pmbox, &mmsg, NULL, TIMEOUT) == 0,
+		ztest_true(k_mbox_get(pmbox, &mmsg, NULL, TIMEOUT) == 0,
 			     NULL);
 		break;
 
@@ -484,16 +484,16 @@ static void tmbox_get(struct k_mbox *pmbox)
 		mmsg.rx_source_thread = K_ANY;
 		mmsg.size = 0;
 		/* get K_any msg */
-		zassert_true(k_mbox_get(pmbox, &mmsg, NULL, TIMEOUT) == 0,
+		ztest_true(k_mbox_get(pmbox, &mmsg, NULL, TIMEOUT) == 0,
 			     NULL);
 		/* get the msg specific to receiver_tid */
 		mmsg.rx_source_thread = sender_tid;
-		zassert_true(k_mbox_get
+		ztest_true(k_mbox_get
 			     (pmbox, &mmsg, NULL, TIMEOUT) == 0, NULL);
 
 		/* get msg from async or random tid */
 		mmsg.rx_source_thread = K_ANY;
-		zassert_true(k_mbox_get
+		ztest_true(k_mbox_get
 			     (pmbox, &mmsg, NULL, TIMEOUT) == 0, NULL);
 		break;
 	case MULTIPLE_WAITING_GET:

--- a/tests/kernel/mbox/mbox_usage/src/main.c
+++ b/tests/kernel/mbox/mbox_usage/src/main.c
@@ -63,13 +63,13 @@ static void msg_receiver(struct k_mbox *pmbox, k_tid_t thd_id, s32_t timeout)
 		mmsg.size = sizeof(rxdata);
 		mmsg.rx_source_thread = thd_id;
 		if (timeout == K_FOREVER) {
-			zassert_true(k_mbox_get(pmbox, &mmsg,
+			ztest_true(k_mbox_get(pmbox, &mmsg,
 				     rxdata, K_FOREVER) == 0, NULL);
 		} else if (timeout == K_NO_WAIT) {
-			zassert_false(k_mbox_get(pmbox, &mmsg,
+			ztest_false(k_mbox_get(pmbox, &mmsg,
 				      rxdata, K_NO_WAIT) == 0, NULL);
 		} else {
-			zassert_true(k_mbox_get(pmbox, &mmsg,
+			ztest_true(k_mbox_get(pmbox, &mmsg,
 				     rxdata, timeout) == 0, NULL);
 		}
 		break;

--- a/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_api.c
+++ b/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_api.c
@@ -33,12 +33,12 @@ void test_mheap_malloc_free(void)
 		 */
 		block[i] = k_malloc(i);
 		/** TESTPOINT: Address of the allocated memory if successful;*/
-		zassert_not_null(block[i], NULL);
+		ztest_not_null(block[i], NULL);
 	}
 
 	block_fail = k_malloc(BLK_SIZE_MIN);
 	/** TESTPOINT: Return NULL if fail.*/
-	zassert_is_null(block_fail, NULL);
+	ztest_is_null(block_fail, NULL);
 
 	for (int i = 0; i < BLK_NUM_MAX; i++) {
 		/**
@@ -75,11 +75,11 @@ void test_mheap_calloc(void)
 
 	mem = k_calloc(NMEMB, SIZE);
 
-	zassert_not_null(mem, "calloc operation failed");
+	ztest_not_null(mem, "calloc operation failed");
 
 	/* Memory should be zeroed and not crash us if we read/write to it */
 	for (int i = 0; i < BOUNDS; i++) {
-		zassert_equal(mem[i], 0, NULL);
+		ztest_equal(mem[i], 0, NULL);
 		mem[i] = 1;
 	}
 

--- a/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_concept.c
+++ b/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_concept.c
@@ -35,8 +35,8 @@ void test_mheap_malloc_align4(void)
 	 */
 	for (int i = 0; i < BLK_NUM_MAX; i++) {
 		block[i] = k_malloc(i);
-		zassert_not_null(block[i], NULL);
-		zassert_false((uintptr_t)block[i] % sizeof(void *), NULL);
+		ztest_not_null(block[i], NULL);
+		ztest_false((uintptr_t)block[i] % sizeof(void *), NULL);
 	}
 
 	/* test case tear down*/
@@ -75,11 +75,11 @@ void test_mheap_min_block_size(void)
 	 */
 	for (int i = 0; i < BLK_NUM_MAX; i++) {
 		block[i] = k_malloc(TEST_SIZE_0);
-		zassert_not_null(block[i], NULL);
+		ztest_not_null(block[i], NULL);
 	}
 	/* verify no more free blocks available*/
 	block_fail = k_malloc(BLK_SIZE_MIN);
-	zassert_is_null(block_fail, NULL);
+	ztest_is_null(block_fail, NULL);
 
 	/* test case tear down*/
 	for (int i = 0; i < BLK_NUM_MAX; i++) {
@@ -113,11 +113,11 @@ void test_mheap_block_desc(void)
 	 */
 	for (int i = 0; i < BLK_NUM_MAX; i++) {
 		block[i] = k_malloc(BLK_SIZE_EXCLUDE_DESC);
-		zassert_not_null(block[i], NULL);
+		ztest_not_null(block[i], NULL);
 	}
 	/* verify no more free blocks available*/
 	block_fail = k_malloc(BLK_SIZE_MIN);
-	zassert_is_null(block_fail, NULL);
+	ztest_is_null(block_fail, NULL);
 
 	/* test case tear down*/
 	for (int i = 0; i < BLK_NUM_MAX; i++) {

--- a/tests/kernel/mem_pool/mem_pool_api/src/test_mpool_api.c
+++ b/tests/kernel/mem_pool/mem_pool_api/src/test_mpool_api.c
@@ -27,9 +27,9 @@ void tmpool_alloc_free(void *data)
 		 * the block descriptor is set to the starting address of the
 		 * memory block.
 		 */
-		zassert_true(k_mem_pool_alloc(&kmpool, &block[i], BLK_SIZE_MIN,
+		ztest_true(k_mem_pool_alloc(&kmpool, &block[i], BLK_SIZE_MIN,
 					      K_NO_WAIT) == 0, NULL);
-		zassert_not_null(block[i].data, NULL);
+		ztest_not_null(block[i].data, NULL);
 	}
 
 	for (int i = 0; i < BLK_NUM_MIN; i++) {
@@ -46,9 +46,9 @@ void tmpool_alloc_free(void *data)
 	 * @a max_size bytes long.
 	 */
 	for (int i = 0; i < BLK_NUM_MAX; i++) {
-		zassert_true(k_mem_pool_alloc(&kmpool, &block[i], BLK_SIZE_MAX,
+		ztest_true(k_mem_pool_alloc(&kmpool, &block[i], BLK_SIZE_MAX,
 					      K_NO_WAIT) == 0, NULL);
-		zassert_not_null(block[i].data, NULL);
+		ztest_not_null(block[i].data, NULL);
 	}
 
 	for (int i = 0; i < BLK_NUM_MAX; i++) {
@@ -106,10 +106,10 @@ void test_mpool_alloc_size(void)
 	 * into quarters, down to blocks of @a min_size bytes long.
 	 */
 	while (size >= BLK_SIZE_MIN) {
-		zassert_true(k_mem_pool_alloc(&kmpool, &block[i], size,
+		ztest_true(k_mem_pool_alloc(&kmpool, &block[i], size,
 					      K_NO_WAIT) == 0, NULL);
-		zassert_not_null(block[i].data, NULL);
-		zassert_true((uintptr_t)(block[i].data) % BLK_ALIGN == 0, NULL);
+		ztest_not_null(block[i].data, NULL);
+		ztest_true((uintptr_t)(block[i].data) % BLK_ALIGN == 0, NULL);
 		i++;
 		size = size >> 2;
 	}
@@ -124,10 +124,10 @@ void test_mpool_alloc_size(void)
 	 * aligned to this boundary, min_size must also be a multiple of align.
 	 */
 	while (size <= BLK_SIZE_MAX) {
-		zassert_true(k_mem_pool_alloc(&kmpool, &block[i], size,
+		ztest_true(k_mem_pool_alloc(&kmpool, &block[i], size,
 					      K_NO_WAIT) == 0, NULL);
-		zassert_not_null(block[i].data, NULL);
-		zassert_true((uintptr_t)(block[i].data) % BLK_ALIGN == 0, NULL);
+		ztest_not_null(block[i].data, NULL);
+		ztest_true((uintptr_t)(block[i].data) % BLK_ALIGN == 0, NULL);
 		i++;
 		size = size << 2;
 	}
@@ -148,23 +148,23 @@ void test_mpool_alloc_timeout(void)
 	s64_t tms;
 
 	for (int i = 0; i < BLK_NUM_MIN; i++) {
-		zassert_equal(k_mem_pool_alloc(&kmpool, &block[i], BLK_SIZE_MIN,
+		ztest_equal(k_mem_pool_alloc(&kmpool, &block[i], BLK_SIZE_MIN,
 					       K_NO_WAIT), 0, NULL);
 	}
 
 	/** TESTPOINT: Use K_NO_WAIT to return without waiting*/
 	/** TESTPOINT: @retval -ENOMEM Returned without waiting*/
-	zassert_equal(k_mem_pool_alloc(&kmpool, &fblock, BLK_SIZE_MIN,
+	ztest_equal(k_mem_pool_alloc(&kmpool, &fblock, BLK_SIZE_MIN,
 				       K_NO_WAIT), -ENOMEM, NULL);
 	/** TESTPOINT: @retval -EAGAIN Waiting period timed out*/
 	tms = k_uptime_get();
-	zassert_equal(k_mem_pool_alloc(&kmpool, &fblock, BLK_SIZE_MIN, TIMEOUT),
+	ztest_equal(k_mem_pool_alloc(&kmpool, &fblock, BLK_SIZE_MIN, TIMEOUT),
 		      -EAGAIN, NULL);
 	/**
 	 * TESTPOINT: Maximum time to wait for operation to complete (in
 	 * milliseconds)
 	 */
-	zassert_true(k_uptime_delta(&tms) >= TIMEOUT, NULL);
+	ztest_true(k_uptime_delta(&tms) >= TIMEOUT, NULL);
 
 	for (int i = 0; i < BLK_NUM_MIN; i++) {
 		k_mem_pool_free(&block[i]);
@@ -183,9 +183,9 @@ void test_sys_heap_mem_pool_assign(void)
 
 	k_thread_system_pool_assign(k_current_get());
 	ptr = (char *)z_thread_malloc(BLK_SIZE_MIN/2);
-	zassert_not_null(ptr, "bytes allocation failed from system pool");
+	ztest_not_null(ptr, "bytes allocation failed from system pool");
 	k_free(ptr);
 
-	zassert_is_null((char *)z_thread_malloc(BLK_SIZE_MAX * 2),
+	ztest_is_null((char *)z_thread_malloc(BLK_SIZE_MAX * 2),
 						"overflow check failed");
 }

--- a/tests/kernel/mem_pool/mem_pool_concept/src/test_mpool_alloc_size.c
+++ b/tests/kernel/mem_pool/mem_pool_concept/src/test_mpool_alloc_size.c
@@ -32,11 +32,11 @@ void test_mpool_alloc_size_roundup(void)
 	 */
 	for (int i = 0; i < BLK_NUM_MAX; i++) {
 		/*request a size for the mpool to round up to "BLK_SIZE_MAX"*/
-		zassert_true(k_mem_pool_alloc(&mpool1, &block[i], TEST_SIZE,
+		ztest_true(k_mem_pool_alloc(&mpool1, &block[i], TEST_SIZE,
 					      K_NO_WAIT) == 0, NULL);
 	}
 	/*verify consequently no more blocks available*/
-	zassert_true(k_mem_pool_alloc(&mpool1, &block_fail, BLK_SIZE_MIN,
+	ztest_true(k_mem_pool_alloc(&mpool1, &block_fail, BLK_SIZE_MIN,
 				      K_NO_WAIT) == -ENOMEM, NULL);
 
 	/*test case tear down*/

--- a/tests/kernel/mem_pool/mem_pool_concept/src/test_mpool_alloc_wait.c
+++ b/tests/kernel/mem_pool/mem_pool_concept/src/test_mpool_alloc_wait.c
@@ -20,14 +20,14 @@ void tmpool_alloc_wait_timeout(void *p1, void *p2, void *p3)
 {
 	struct k_mem_block block;
 
-	zassert_true(k_mem_pool_alloc(&mpool1, &block, BLK_SIZE_MIN,
+	ztest_true(k_mem_pool_alloc(&mpool1, &block, BLK_SIZE_MIN,
 				      TIMEOUT) == -EAGAIN, NULL);
 	k_sem_give(&sync_sema);
 }
 
 void tmpool_alloc_wait_ok(void *p1, void *p2, void *p3)
 {
-	zassert_true(k_mem_pool_alloc(&mpool1, &block_ok, BLK_SIZE_MIN,
+	ztest_true(k_mem_pool_alloc(&mpool1, &block_ok, BLK_SIZE_MIN,
 				      TIMEOUT) == 0, NULL);
 	k_sem_give(&sync_sema);
 }
@@ -55,7 +55,7 @@ void test_mpool_alloc_wait_prio(void)
 	k_sem_init(&sync_sema, 0, THREAD_NUM);
 	/*allocated up all blocks*/
 	for (int i = 0; i < BLK_NUM_MIN; i++) {
-		zassert_true(k_mem_pool_alloc(&mpool1, &block[i], BLK_SIZE_MIN,
+		ztest_true(k_mem_pool_alloc(&mpool1, &block[i], BLK_SIZE_MIN,
 					      K_NO_WAIT) == 0, NULL);
 	}
 

--- a/tests/kernel/mem_pool/mem_pool_concept/src/test_mpool_merge_fail_diff_parent.c
+++ b/tests/kernel/mem_pool/mem_pool_concept/src/test_mpool_merge_fail_diff_parent.c
@@ -29,7 +29,7 @@ void test_mpool_alloc_merge_failed_diff_parent(void)
 
 	for (int i = 0; i < BLK_NUM_MIN; i++) {
 		/* 1. allocated up all blocks*/
-		zassert_true(k_mem_pool_alloc(&mpool1, &block[i], BLK_SIZE_MIN,
+		ztest_true(k_mem_pool_alloc(&mpool1, &block[i], BLK_SIZE_MIN,
 					      K_NO_WAIT) == 0, NULL);
 	}
 	/* 2. free adjacent blocks belong to different parent quad-blocks*/
@@ -37,7 +37,7 @@ void test_mpool_alloc_merge_failed_diff_parent(void)
 		k_mem_pool_free(&block[i]);
 	}
 	/* 3. request a big block, expected failed to merge*/
-	zassert_true(k_mem_pool_alloc(&mpool1, &block_fail, BLK_SIZE_MAX,
+	ztest_true(k_mem_pool_alloc(&mpool1, &block_fail, BLK_SIZE_MAX,
 				      TIMEOUT) == -EAGAIN, NULL);
 
 	/* 4. test case tear down*/

--- a/tests/kernel/mem_pool/mem_pool_concept/src/test_mpool_merge_fail_diff_size.c
+++ b/tests/kernel/mem_pool/mem_pool_concept/src/test_mpool_merge_fail_diff_size.c
@@ -42,7 +42,7 @@ void test_mpool_alloc_merge_failed_diff_size(void)
 
 	for (int i = 0; i < block_count; i++) {
 		/* 1. allocate blocks in different sizes*/
-		zassert_true(k_mem_pool_alloc(&mpool3, &block[i], block_size[i],
+		ztest_true(k_mem_pool_alloc(&mpool3, &block[i], block_size[i],
 					      K_NO_WAIT) == 0, NULL);
 	}
 	/* 2. free block [2~8], in different sizes*/
@@ -50,7 +50,7 @@ void test_mpool_alloc_merge_failed_diff_size(void)
 		k_mem_pool_free(&block[i]);
 	}
 	/* 3. request a big block, expected failed to merge*/
-	zassert_true(k_mem_pool_alloc(&mpool3, &block_fail, BLK_SIZE_MAX,
+	ztest_true(k_mem_pool_alloc(&mpool3, &block_fail, BLK_SIZE_MAX,
 				      TIMEOUT) == -EAGAIN, NULL);
 
 	/* 4. test case tear down*/

--- a/tests/kernel/mem_pool/sys_mem_pool/src/main.c
+++ b/tests/kernel/mem_pool/sys_mem_pool/src/main.c
@@ -39,12 +39,12 @@ void test_sys_mem_pool_alloc_free(void)
 		 */
 		block[i] = sys_mem_pool_alloc(&pool, BLK_SIZE_MAX - DESC_SIZE);
 		/** TESTPOINT: Address of the allocated memory if successful;*/
-		zassert_not_null(block[i], NULL);
+		ztest_not_null(block[i], NULL);
 	}
 
 	block_fail = sys_mem_pool_alloc(&pool, BLK_SIZE_MIN);
 	/** TESTPOINT: Return NULL if fail.*/
-	zassert_is_null(block_fail, NULL);
+	ztest_is_null(block_fail, NULL);
 
 	for (int i = 0; i < BLK_NUM_MAX; i++) {
 		/**
@@ -75,8 +75,8 @@ void test_sys_mem_pool_alloc_align4(void)
 	 */
 	for (int i = 0; i < BLK_NUM_MAX; i++) {
 		block[i] = sys_mem_pool_alloc(&pool, i);
-		zassert_not_null(block[i], NULL);
-		zassert_false((uintptr_t)block[i] % sizeof(void *), NULL);
+		ztest_not_null(block[i], NULL);
+		ztest_false((uintptr_t)block[i] % sizeof(void *), NULL);
 	}
 
 	/* test case tear down*/
@@ -109,11 +109,11 @@ void test_sys_mem_pool_min_block_size(void)
 	 */
 	for (int i = 0; i < TOTAL_MIN_BLKS; i++) {
 		block[i] = sys_mem_pool_alloc(&pool, 0);
-		zassert_not_null(block[i], NULL);
+		ztest_not_null(block[i], NULL);
 	}
 	/* verify no more free blocks available*/
 	block_fail = sys_mem_pool_alloc(&pool, BLK_SIZE_MIN);
-	zassert_is_null(block_fail, NULL);
+	ztest_is_null(block_fail, NULL);
 
 	/* test case tear down*/
 	for (int i = 0; i < BLK_NUM_MAX; i++) {

--- a/tests/kernel/mem_protect/futex/src/main.c
+++ b/tests/kernel/mem_protect/futex/src/main.c
@@ -64,25 +64,25 @@ void futex_wait_task(void *p1, void *p2, void *p3)
 	s32_t ret_value;
 	int time_val = *(int *)p1;
 
-	zassert_true(time_val >= K_FOREVER, "invalid timeout parameter");
+	ztest_true(time_val >= K_FOREVER, "invalid timeout parameter");
 
 	ret_value = k_futex_wait(&simple_futex,
 			atomic_get(&simple_futex.val), time_val);
 
 	switch (time_val) {
 	case K_FOREVER:
-		zassert_true(ret_value == 0,
+		ztest_true(ret_value == 0,
 		     "k_futex_wait failed when it shouldn't have");
-		zassert_false(ret_value == 0,
+		ztest_false(ret_value == 0,
 		     "futex wait task wakeup when it shouldn't have");
 		break;
 	case K_NO_WAIT:
-		zassert_true(ret_value == -ETIMEDOUT,
+		ztest_true(ret_value == -ETIMEDOUT,
 		     "k_futex_wait failed when it shouldn't have");
 		atomic_sub(&simple_futex.val, 1);
 		break;
 	default:
-		zassert_true(ret_value == -ETIMEDOUT,
+		ztest_true(ret_value == -ETIMEDOUT,
 		     "k_futex_wait failed when it shouldn't have");
 		atomic_sub(&simple_futex.val, 1);
 		break;
@@ -96,7 +96,7 @@ void futex_wake_task(void *p1, void *p2, void *p3)
 
 	ret_value = k_futex_wake(&simple_futex,
 				woken_num == 1 ? false : true);
-	zassert_true(ret_value == woken_num,
+	ztest_true(ret_value == woken_num,
 		"k_futex_wake failed when it shouldn't have");
 }
 
@@ -105,22 +105,22 @@ void futex_wait_wake_task(void *p1, void *p2, void *p3)
 	s32_t ret_value;
 	int time_val = *(int *)p1;
 
-	zassert_true(time_val >= K_FOREVER, "invalid timeout parameter");
+	ztest_true(time_val >= K_FOREVER, "invalid timeout parameter");
 
 	ret_value = k_futex_wait(&simple_futex,
 			atomic_get(&simple_futex.val), time_val);
 
 	switch (time_val) {
 	case K_FOREVER:
-		zassert_true(ret_value == 0,
+		ztest_true(ret_value == 0,
 		     "k_futex_wait failed when it shouldn't have");
 		break;
 	case K_NO_WAIT:
-		zassert_true(ret_value == -ETIMEDOUT,
+		ztest_true(ret_value == -ETIMEDOUT,
 		     "k_futex_wait failed when it shouldn't have");
 		break;
 	default:
-		zassert_true(ret_value == 0,
+		ztest_true(ret_value == 0,
 		     "k_futex_wait failed when it shouldn't have");
 		break;
 	}
@@ -134,11 +134,11 @@ void futex_multiple_wake_task(void *p1, void *p2, void *p3)
 	int woken_num = *(int *)p1;
 	int idx = *(int *)p2;
 
-	zassert_true(woken_num > 0, "invalid woken number");
+	ztest_true(woken_num > 0, "invalid woken number");
 
 	ret_value = k_futex_wake(&multiple_futex[idx],
 			woken_num == 1 ? false : true);
-	zassert_true(ret_value == woken_num,
+	ztest_true(ret_value == woken_num,
 		"k_futex_wake failed when it shouldn't have");
 }
 
@@ -148,11 +148,11 @@ void futex_multiple_wait_wake_task(void *p1, void *p2, void *p3)
 	int time_val = *(int *)p1;
 	int idx = *(int *)p2;
 
-	zassert_true(time_val == K_FOREVER, "invalid timeout parameter");
+	ztest_true(time_val == K_FOREVER, "invalid timeout parameter");
 
 	ret_value = k_futex_wait(&multiple_futex[idx],
 		atomic_get(&(multiple_futex[idx].val)), time_val);
-	zassert_true(ret_value == 0,
+	ztest_true(ret_value == 0,
 	     "k_futex_wait failed when it shouldn't have");
 
 	atomic_sub(&(multiple_futex[idx].val), 1);
@@ -180,7 +180,7 @@ void test_futex_wait_forever(void)
 	/* giving time for the futex_wait_task to execute */
 	k_yield();
 
-	zassert_false(atomic_get(&simple_futex.val) == 0,
+	ztest_false(atomic_get(&simple_futex.val) == 0,
 			"wait forever shouldn't wake");
 
 	k_thread_abort(&futex_tid);
@@ -200,7 +200,7 @@ void test_futex_wait_timeout(void)
 	/* giving time for the futex_wait_task to execute */
 	k_sleep(K_MSEC(100));
 
-	zassert_true(atomic_get(&simple_futex.val) == 0,
+	ztest_true(atomic_get(&simple_futex.val) == 0,
 			"wait timeout doesn't timeout");
 
 	k_thread_abort(&futex_tid);
@@ -220,7 +220,7 @@ void test_futex_wait_nowait(void)
 	/* giving time for the futex_wait_task to execute */
 	k_sleep(K_MSEC(100));
 
-	zassert_true(atomic_get(&simple_futex.val) == 0, "wait nowait fail");
+	ztest_true(atomic_get(&simple_futex.val) == 0, "wait nowait fail");
 
 	k_thread_abort(&futex_tid);
 }
@@ -254,7 +254,7 @@ void test_futex_wait_forever_wake(void)
 	 */
 	k_yield();
 
-	zassert_true(atomic_get(&simple_futex.val) == 0,
+	ztest_true(atomic_get(&simple_futex.val) == 0,
 			"wait forever doesn't wake");
 
 	k_thread_abort(&futex_wake_tid);
@@ -287,7 +287,7 @@ void test_futex_wait_timeout_wake(void)
 	 */
 	k_yield();
 
-	zassert_true(atomic_get(&simple_futex.val) == 0,
+	ztest_true(atomic_get(&simple_futex.val) == 0,
 			"wait timeout doesn't wake");
 
 	k_thread_abort(&futex_wake_tid);
@@ -340,7 +340,7 @@ void test_futex_wait_forever_wake_from_isr(void)
 	/* giving time for the futex_wait_wake_task to execute */
 	k_yield();
 
-	zassert_true(atomic_get(&simple_futex.val) == 0,
+	ztest_true(atomic_get(&simple_futex.val) == 0,
 			"wait forever wake from isr doesn't wake");
 
 	k_thread_abort(&futex_tid);
@@ -372,7 +372,7 @@ void test_futex_multiple_threads_wait_wake(void)
 	/* giving time for the other threads to execute */
 	k_yield();
 
-	zassert_true(atomic_get(&simple_futex.val) == 0,
+	ztest_true(atomic_get(&simple_futex.val) == 0,
 			"wait forever wake doesn't wake all threads");
 
 	k_thread_abort(&futex_wake_tid);
@@ -409,7 +409,7 @@ void test_multiple_futex_wait_wake(void)
 	k_yield();
 
 	for (int i = 0; i < TOTAL_THREADS_WAITING; i++) {
-		zassert_true(atomic_get(&multiple_futex[i].val) == 0,
+		ztest_true(atomic_get(&multiple_futex[i].val) == 0,
 			"wait forever wake doesn't wake %d thread", i);
 	}
 
@@ -425,30 +425,30 @@ void test_user_futex_bad(void)
 
 	/* Is a futex, but no access to its memory */
 	ret = k_futex_wait(&no_access_futex, 0, K_NO_WAIT);
-	zassert_equal(ret, -EACCES, "shouldn't have been able to access");
+	ztest_equal(ret, -EACCES, "shouldn't have been able to access");
 	ret = k_futex_wake(&no_access_futex, false);
-	zassert_equal(ret, -EACCES, "shouldn't have been able to access");
+	ztest_equal(ret, -EACCES, "shouldn't have been able to access");
 
 	/* Access to memory, but not a kernel object */
 	ret = k_futex_wait((struct k_futex *)&not_a_futex, 0, K_NO_WAIT);
-	zassert_equal(ret, -EINVAL, "waited on non-futex");
+	ztest_equal(ret, -EINVAL, "waited on non-futex");
 	ret = k_futex_wake((struct k_futex *)&not_a_futex, false);
-	zassert_equal(ret, -EINVAL, "woke non-futex");
+	ztest_equal(ret, -EINVAL, "woke non-futex");
 
 	/* Access to memory, but wrong object type */
 	ret = k_futex_wait((struct k_futex *)&also_not_a_futex, 0, K_NO_WAIT);
-	zassert_equal(ret, -EINVAL, "waited on non-futex");
+	ztest_equal(ret, -EINVAL, "waited on non-futex");
 	ret = k_futex_wake((struct k_futex *)&also_not_a_futex, false);
-	zassert_equal(ret, -EINVAL, "woke non-futex");
+	ztest_equal(ret, -EINVAL, "woke non-futex");
 
 	/* Wait with unexpected value */
 	atomic_set(&simple_futex.val, 100);
 	ret = k_futex_wait(&simple_futex, 0, K_NO_WAIT);
-	zassert_equal(ret, -EAGAIN, "waited when values did not match");
+	ztest_equal(ret, -EAGAIN, "waited when values did not match");
 
 	/* Timeout case */
 	ret = k_futex_wait(&simple_futex, 100, K_NO_WAIT);
-	zassert_equal(ret, -ETIMEDOUT, "didn't time out");
+	ztest_equal(ret, -ETIMEDOUT, "didn't time out");
 }
 
 /* ztest main entry*/

--- a/tests/kernel/mem_protect/mem_protect/src/kobject.c
+++ b/tests/kernel/mem_protect/mem_protect/src/kobject.c
@@ -240,7 +240,7 @@ void kobject_user_test6(void *p1, void *p2, void *p3)
 	USERSPACE_BARRIER;
 
 	k_object_access_grant(&kobject_sem, &kobject_test_reuse_2_tid);
-	zassert_unreachable("k_object validation  failure");
+	ztest_unreachable("k_object validation  failure");
 }
 
 /**
@@ -377,7 +377,7 @@ void kobject_user_2_test9(void *p1, void *p2, void *p3)
 	USERSPACE_BARRIER;
 
 	k_sem_take(&kobject_sem, K_FOREVER);
-	zassert_unreachable("Failed to clear permission on a deleted thread");
+	ztest_unreachable("Failed to clear permission on a deleted thread");
 }
 
 /**
@@ -439,7 +439,7 @@ void test_kobject_access_grant_to_invalid_thread(void *p1, void *p2, void *p3)
 	    != 0) {
 		ztest_test_pass();
 	} else {
-		zassert_unreachable(ERROR_STR_TEST_10);
+		ztest_unreachable(ERROR_STR_TEST_10);
 	}
 }
 /****************************************************************************/
@@ -456,7 +456,7 @@ void test_kobject_access_invalid_kobject(void *p1, void *p2, void *p3)
 	USERSPACE_BARRIER;
 
 	k_sem_take(&kobject_sem_not_hash_table, K_SECONDS(1));
-	zassert_unreachable("k_object validation  failure.");
+	ztest_unreachable("k_object validation  failure.");
 
 }
 
@@ -476,7 +476,7 @@ void test_access_kobject_without_init_access(void *p1,
 	USERSPACE_BARRIER;
 
 	k_sem_take(&kobject_sem_no_init_no_access, K_SECONDS(1));
-	zassert_unreachable("k_object validation  failure");
+	ztest_unreachable("k_object validation  failure");
 
 }
 /****************************************************************************/
@@ -487,7 +487,7 @@ void kobject_test_user_13(void *p1, void *p2, void *p3)
 	USERSPACE_BARRIER;
 
 	k_sem_take(&kobject_sem_no_init_access, K_SECONDS(1));
-	zassert_unreachable("_SYSCALL_OBJ implementation failure.");
+	ztest_unreachable("_SYSCALL_OBJ implementation failure.");
 }
 
 /**
@@ -519,7 +519,7 @@ void test_access_kobject_without_init_with_access(void *p1,
 /* object validation checks */
 void kobject_test_user_2_14(void *p1, void *p2, void *p3)
 {
-	zassert_unreachable("_SYSCALL_OBJ implementation failure.");
+	ztest_unreachable("_SYSCALL_OBJ implementation failure.");
 }
 
 void kobject_test_user_1_14(void *p1, void *p2, void *p3)
@@ -534,7 +534,7 @@ void kobject_test_user_1_14(void *p1, void *p2, void *p3)
 			NULL, NULL, NULL,
 			0, K_USER, K_NO_WAIT);
 
-	zassert_unreachable("_SYSCALL_OBJ implementation failure.");
+	ztest_unreachable("_SYSCALL_OBJ implementation failure.");
 
 }
 /**
@@ -605,7 +605,7 @@ void test_create_new_thread_from_user(void *p1, void *p2, void *p3)
 /* object validation checks */
 void kobject_test_user_2_16(void *p1, void *p2, void *p3)
 {
-	zassert_unreachable("k_object validation failure in k thread create");
+	ztest_unreachable("k_object validation failure in k thread create");
 }
 
 void kobject_test_user_1_16(void *p1, void *p2, void *p3)
@@ -654,7 +654,7 @@ void test_create_new_thread_from_user_no_access_stack(void *p1,
 /* object validation checks */
 void kobject_test_user_2_17(void *p1, void *p2, void *p3)
 {
-	zassert_unreachable("k_object validation failure in k thread create");
+	ztest_unreachable("k_object validation failure in k thread create");
 }
 
 void kobject_test_user_1_17(void *p1, void *p2, void *p3)
@@ -670,7 +670,7 @@ void kobject_test_user_1_17(void *p1, void *p2, void *p3)
 			NULL, NULL, NULL,
 			0, K_USER, K_NO_WAIT);
 
-	zassert_unreachable("k_object validation failure in k thread create");
+	ztest_unreachable("k_object validation failure in k thread create");
 }
 /**
  * @brief Test to validate user thread spawning with stack overflow
@@ -711,7 +711,7 @@ void test_create_new_thread_from_user_invalid_stacksize(void *p1,
 /* object validation checks */
 void kobject_test_user_2_18(void *p1, void *p2, void *p3)
 {
-	zassert_unreachable("k_object validation failure in k thread create");
+	ztest_unreachable("k_object validation failure in k thread create");
 }
 
 void kobject_test_user_1_18(void *p1, void *p2, void *p3)
@@ -728,7 +728,7 @@ void kobject_test_user_1_18(void *p1, void *p2, void *p3)
 			NULL, NULL, NULL,
 			0, K_USER, K_NO_WAIT);
 
-	zassert_unreachable("k_object validation failure in k thread create");
+	ztest_unreachable("k_object validation failure in k thread create");
 }
 /**
  * @brief Test to check stack overflow from user thread
@@ -772,7 +772,7 @@ void test_create_new_thread_from_user_huge_stacksize(void *p1,
 
 void kobject_test_user_2_19(void *p1, void *p2, void *p3)
 {
-	zassert_unreachable("k_object validation failure in k thread create");
+	ztest_unreachable("k_object validation failure in k thread create");
 }
 
 void kobject_test_user_1_19(void *p1, void *p2, void *p3)
@@ -788,7 +788,7 @@ void kobject_test_user_1_19(void *p1, void *p2, void *p3)
 			NULL, NULL, NULL,
 			0, 0, K_NO_WAIT);
 
-	zassert_unreachable("k_object validation failure in k thread create");
+	ztest_unreachable("k_object validation failure in k thread create");
 }
 /**
  * @brief Test to create a new supervisor thread from user.
@@ -818,7 +818,7 @@ void test_create_new_supervisor_thread_from_user(void *p1, void *p2, void *p3)
 
 void kobject_test_user_2_20(void *p1, void *p2, void *p3)
 {
-	zassert_unreachable("k_object validation failure in k thread create");
+	ztest_unreachable("k_object validation failure in k thread create");
 }
 
 void kobject_test_user_1_20(void *p1, void *p2, void *p3)
@@ -834,7 +834,7 @@ void kobject_test_user_1_20(void *p1, void *p2, void *p3)
 			NULL, NULL, NULL,
 			0, K_USER | K_ESSENTIAL, K_NO_WAIT);
 
-	zassert_unreachable("k_object validation failure in k thread create");
+	ztest_unreachable("k_object validation failure in k thread create");
 }
 /**
  * @brief Create a new essential thread from user.
@@ -864,7 +864,7 @@ void test_create_new_essential_thread_from_user(void *p1, void *p2, void *p3)
 
 void kobject_test_user_2_21(void *p1, void *p2, void *p3)
 {
-	zassert_unreachable("k_object validation failure in k thread create");
+	ztest_unreachable("k_object validation failure in k thread create");
 }
 
 void kobject_test_user_1_21(void *p1, void *p2, void *p3)
@@ -880,7 +880,7 @@ void kobject_test_user_1_21(void *p1, void *p2, void *p3)
 			NULL, NULL, NULL,
 			-1, K_USER, K_NO_WAIT);
 
-	zassert_unreachable("k_object validation failure in k thread create");
+	ztest_unreachable("k_object validation failure in k thread create");
 }
 /**
  * @brief Thread creation with prority is higher than current thread
@@ -913,7 +913,7 @@ void test_create_new_higher_prio_thread_from_user(void *p1, void *p2, void *p3)
 
 void kobject_test_user_2_22(void *p1, void *p2, void *p3)
 {
-	zassert_unreachable("k_object validation failure in k thread create");
+	ztest_unreachable("k_object validation failure in k thread create");
 }
 
 void kobject_test_user_1_22(void *p1, void *p2, void *p3)
@@ -929,7 +929,7 @@ void kobject_test_user_1_22(void *p1, void *p2, void *p3)
 			NULL, NULL, NULL,
 			6000, K_USER, K_NO_WAIT);
 
-	zassert_unreachable("k_object validation failure in k thread create");
+	ztest_unreachable("k_object validation failure in k thread create");
 }
 /**
  * @brief Create a new thread whose prority is invalid.

--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -217,7 +217,7 @@ static void user_thread_entry_ro(void *p1, void *p2, void *p3)
 	 */
 	mem_domain_buf1[0] = 10U;
 
-	zassert_unreachable("The user thread is allowed to access a read only"
+	ztest_unreachable("The user thread is allowed to access a read only"
 			    " partition of a memory domain");
 }
 /**
@@ -338,7 +338,7 @@ void mem_domain_for_user_tc3(void *max_partitions, void *p2, void *p3)
 			10U;
 	}
 
-	zassert_unreachable(ERROR_STR);
+	ztest_unreachable(ERROR_STR);
 	ztest_test_fail();
 }
 
@@ -456,7 +456,7 @@ void mem_domain_for_user_tc5(void *p1, void *p2, void *p3)
 
 	/* will generate a fault */
 	mem_domain_tc3_part1[0] = 10U;
-	zassert_unreachable(ERROR_STR);
+	ztest_unreachable(ERROR_STR);
 }
 /**
  * @brief Test the removal of the partition
@@ -497,7 +497,7 @@ void mem_domain_test_6_2(void *p1, void *p2, void *p3)
 	USERSPACE_BARRIER;
 
 	mem_domain_tc3_part2[0] = 10U;
-	zassert_unreachable(ERROR_STR);
+	ztest_unreachable(ERROR_STR);
 }
 
 /**
@@ -550,7 +550,7 @@ void mem_domain_for_user_tc7(void *p1, void *p2, void *p3)
 
 	/* will generate a fault */
 	mem_domain_tc3_part4[0] = 10U;
-	zassert_unreachable(ERROR_STR);
+	ztest_unreachable(ERROR_STR);
 }
 
 /**
@@ -600,10 +600,10 @@ void test_mem_domain_destroy(void)
 	if (tid->mem_domain_info.mem_domain == &mem_domain1) {
 		k_mem_domain_destroy(&mem_domain1);
 
-		zassert_true(tid->mem_domain_info.mem_domain !=
+		ztest_true(tid->mem_domain_info.mem_domain !=
 			     &mem_domain1, "The thread has reference to"
 			     " memory domain which is already destroyed");
 	} else {
-		zassert_unreachable("k_mem_domain_add_thread() failed");
+		ztest_unreachable("k_mem_domain_add_thread() failed");
 	}
 }

--- a/tests/kernel/mem_protect/obj_validation/src/main.c
+++ b/tests/kernel/mem_protect/obj_validation/src/main.c
@@ -49,20 +49,20 @@ static int test_object(struct k_sem *sem, int retval)
 void object_permission_checks(struct k_sem *sem, bool skip_init)
 {
 	/* Should fail because we don't have perms on this object */
-	zassert_false(test_object(sem, -EPERM),
+	ztest_false(test_object(sem, -EPERM),
 		      "object should not have had permission granted");
 
 	k_object_access_grant(sem, k_current_get());
 
 	if (!skip_init) {
 		/* Should fail, not initialized and we have no permissions */
-		zassert_false(test_object(sem, -EINVAL),
+		ztest_false(test_object(sem, -EINVAL),
 			      "object should not have been initialized");
 		k_sem_init(sem, 0, 1);
 	}
 
 	/* This should succeed now */
-	zassert_false(test_object(sem, 0),
+	ztest_false(test_object(sem, 0),
 		      "object should have had sufficient permissions");
 }
 
@@ -78,9 +78,9 @@ void test_generic_object(void)
 	struct k_sem stack_sem;
 
 	/* None of these should be even in the table */
-	zassert_false(test_object(&stack_sem, -EBADF), NULL);
-	zassert_false(test_object((struct k_sem *)&bad_sem, -EBADF), NULL);
-	zassert_false(test_object((struct k_sem *)0xFFFFFFFF, -EBADF), NULL);
+	ztest_false(test_object(&stack_sem, -EBADF), NULL);
+	ztest_false(test_object((struct k_sem *)&bad_sem, -EBADF), NULL);
+	ztest_false(test_object((struct k_sem *)0xFFFFFFFF, -EBADF), NULL);
 	object_permission_checks(&sem3, false);
 	object_permission_checks(&sem1, true);
 	object_permission_checks(&sem2, false);
@@ -88,7 +88,7 @@ void test_generic_object(void)
 	for (int i = 0; i < SEM_ARRAY_SIZE; i++) {
 		object_permission_checks(&semarray[i], false);
 		dyn_sem[i] = k_object_alloc(K_OBJ_SEM);
-		zassert_not_null(dyn_sem[i], "couldn't allocate semaphore");
+		ztest_not_null(dyn_sem[i], "couldn't allocate semaphore");
 		/* Give an extra reference to another thread so the object
 		 * doesn't disappear if we revoke our own
 		 */
@@ -98,11 +98,11 @@ void test_generic_object(void)
 	/* dynamic object table well-populated with semaphores at this point */
 	for (int i = 0; i < SEM_ARRAY_SIZE; i++) {
 		/* Should have permission granted but be uninitialized */
-		zassert_false(test_object(dyn_sem[i], -EINVAL), NULL);
+		ztest_false(test_object(dyn_sem[i], -EINVAL), NULL);
 		k_object_access_revoke(dyn_sem[i], k_current_get());
 		object_permission_checks(dyn_sem[i], false);
 		k_object_free(dyn_sem[i]);
-		zassert_false(test_object(dyn_sem[i], -EBADF), NULL);
+		ztest_false(test_object(dyn_sem[i], -EBADF), NULL);
 	}
 }
 

--- a/tests/kernel/mem_protect/protection/src/main.c
+++ b/tests/kernel/mem_protect/protection/src/main.c
@@ -95,7 +95,7 @@ static void write_ro(void)
 		INFO("something went wrong!\n");
 	}
 
-	zassert_unreachable("Write to rodata did not fault");
+	ztest_unreachable("Write to rodata did not fault");
 }
 
 /**
@@ -126,7 +126,7 @@ static void write_text(void)
 		INFO("Did not get expected return value!\n");
 	}
 
-	zassert_unreachable("Write to text did not fault");
+	ztest_unreachable("Write to text did not fault");
 }
 
 /**
@@ -137,7 +137,7 @@ static void write_text(void)
 static void exec_data(void)
 {
 	execute_from_buffer(data_buf);
-	zassert_unreachable("Execute from data did not fault");
+	ztest_unreachable("Execute from data did not fault");
 }
 
 /**
@@ -150,7 +150,7 @@ static void exec_stack(void)
 	u8_t stack_buf[BUF_SIZE] __aligned(sizeof(int));
 
 	execute_from_buffer(stack_buf);
-	zassert_unreachable("Execute from stack did not fault");
+	ztest_unreachable("Execute from stack did not fault");
 }
 
 /**
@@ -165,7 +165,7 @@ static void exec_heap(void)
 
 	execute_from_buffer(heap_buf);
 	k_free(heap_buf);
-	zassert_unreachable("Execute from heap did not fault");
+	ztest_unreachable("Execute from heap did not fault");
 }
 #else
 static void exec_heap(void)

--- a/tests/kernel/mem_protect/stack_random/src/main.c
+++ b/tests/kernel/mem_protect/stack_random/src/main.c
@@ -65,7 +65,7 @@ void test_stack_pt_randomization(void)
 	       changed, THREAD_COUNT);
 
 	sp_changed = changed;
-	zassert_not_equal(sp_changed, 0, "Stack pointer is not randomized");
+	ztest_not_equal(sp_changed, 0, "Stack pointer is not randomized");
 
 	/* Restore priority */
 	k_thread_priority_set(k_current_get(), old_prio);

--- a/tests/kernel/mem_protect/stackprot/src/main.c
+++ b/tests/kernel/mem_protect/stackprot/src/main.c
@@ -116,7 +116,7 @@ static struct k_thread alt_thread_data;
 
 void test_stackprot(void)
 {
-	zassert_true(ret == TC_PASS, NULL);
+	ztest_true(ret == TC_PASS, NULL);
 	print_loop(__func__);
 }
 

--- a/tests/kernel/mem_protect/sys_sem/src/main.c
+++ b/tests/kernel/mem_protect/sys_sem/src/main.c
@@ -74,10 +74,10 @@ void sem_take_multiple_low_prio_helper(void *p1, void *p2, void *p3)
 	s32_t ret_value;
 
 	ret_value = sys_sem_take(&low_prio_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "sys_sem_take failed");
+	ztest_true(ret_value == 0, "sys_sem_take failed");
 
 	ret_value = sys_sem_take(&multiple_thread_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "sys_sem_take failed");
+	ztest_true(ret_value == 0, "sys_sem_take failed");
 
 	sys_sem_give(&low_prio_sem);
 }
@@ -87,10 +87,10 @@ void sem_take_multiple_mid_prio_helper(void *p1, void *p2, void *p3)
 	s32_t ret_value;
 
 	ret_value = sys_sem_take(&mid_prio_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "sys_sem_take failed");
+	ztest_true(ret_value == 0, "sys_sem_take failed");
 
 	ret_value = sys_sem_take(&multiple_thread_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "sys_sem_take failed");
+	ztest_true(ret_value == 0, "sys_sem_take failed");
 
 	sys_sem_give(&mid_prio_sem);
 }
@@ -100,10 +100,10 @@ void sem_take_multiple_high_prio_helper(void *p1, void *p2, void *p3)
 	s32_t ret_value;
 
 	ret_value = sys_sem_take(&high_prio_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "sys_sem_take failed");
+	ztest_true(ret_value == 0, "sys_sem_take failed");
 
 	ret_value = sys_sem_take(&multiple_thread_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "sys_sem_take failed");
+	ztest_true(ret_value == 0, "sys_sem_take failed");
 
 	sys_sem_give(&high_prio_sem);
 }
@@ -114,7 +114,7 @@ void sem_multiple_threads_wait_helper(void *p1, void *p2, void *p3)
 
 	/* get blocked until the test thread gives the semaphore */
 	ret_value = sys_sem_take(&multiple_thread_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "sys_sem_take failed");
+	ztest_true(ret_value == 0, "sys_sem_take failed");
 
 	/* Inform the test thread that this thread has got multiple_thread_sem*/
 	sys_sem_give(&simple_sem);
@@ -131,19 +131,19 @@ void test_basic_sem_test(void)
 	s32_t ret_value;
 
 	ret_value = sys_sem_init(NULL, SEM_INIT_VAL, SEM_MAX_VAL);
-	zassert_true(ret_value == -EINVAL,
+	ztest_true(ret_value == -EINVAL,
 		     "sys_sem_init returned not equal -EINVAL");
 
 	ret_value = sys_sem_init(&simple_sem, SEM_INIT_VAL, SEM_INIT_VAL);
-	zassert_true(ret_value == -EINVAL,
+	ztest_true(ret_value == -EINVAL,
 		     "sys_sem_init returned not equal -EINVAL");
 
 	ret_value = sys_sem_init(&simple_sem, UINT_MAX, SEM_MAX_VAL);
-	zassert_true(ret_value == -EINVAL,
+	ztest_true(ret_value == -EINVAL,
 		     "sys_sem_init returned not equal -EINVAL");
 
 	ret_value = sys_sem_init(&simple_sem, SEM_MAX_VAL, UINT_MAX);
-	zassert_true(ret_value == -EINVAL,
+	ztest_true(ret_value == -EINVAL,
 		     "sys_sem_init returned not equal -EINVAL");
 
 	sys_sem_init(&simple_sem, SEM_INIT_VAL, SEM_MAX_VAL);
@@ -165,7 +165,7 @@ void test_simple_sem_from_isr(void)
 		sem_give_from_isr(&simple_sem);
 
 		signal_count = sys_sem_count_get(&simple_sem);
-		zassert_true(signal_count == (i + 1),
+		ztest_true(signal_count == (i + 1),
 			     "signal count missmatch Expected %d, got %d",
 			     (i + 1), signal_count);
 	}
@@ -185,7 +185,7 @@ void test_simple_sem_from_task(void)
 		sys_sem_give(&simple_sem);
 
 		signal_count = sys_sem_count_get(&simple_sem);
-		zassert_true(signal_count == (i + 1),
+		ztest_true(signal_count == (i + 1),
 			     "signal count missmatch Expected %d, got %d",
 			     (i + 1), signal_count);
 	}
@@ -202,12 +202,12 @@ void test_sem_take_no_wait(void)
 
 	for (int i = 4; i >= 0; i--) {
 		ret_value = sys_sem_take(&simple_sem, K_NO_WAIT);
-		zassert_true(ret_value == 0,
+		ztest_true(ret_value == 0,
 			     "unable to do sys_sem_take which returned %d",
 			     ret_value);
 
 		signal_count = sys_sem_count_get(&simple_sem);
-		zassert_true(signal_count == i,
+		ztest_true(signal_count == i,
 			     "signal count missmatch Expected %d, got %d",
 			     i, signal_count);
 	}
@@ -226,11 +226,11 @@ void test_sem_take_no_wait_fails(void)
 
 	for (int i = 4; i >= 0; i--) {
 		ret_value = sys_sem_take(&simple_sem, K_NO_WAIT);
-		zassert_true(ret_value == -ETIMEDOUT,
+		ztest_true(ret_value == -ETIMEDOUT,
 			     "sys_sem_take returned when not possible");
 
 		signal_count = sys_sem_count_get(&simple_sem);
-		zassert_true(signal_count == 0U,
+		ztest_true(signal_count == 0U,
 			     "signal count missmatch Expected 0, got %d",
 			     signal_count);
 	}
@@ -248,7 +248,7 @@ void test_sem_take_timeout_fails(void)
 
 	for (int i = 4; i >= 0; i--) {
 		ret_value = sys_sem_take(&simple_sem, SEM_TIMEOUT);
-		zassert_true(ret_value == -ETIMEDOUT,
+		ztest_true(ret_value == -ETIMEDOUT,
 			     "sys_sem_take succeeded when its not possible");
 	}
 
@@ -274,7 +274,7 @@ void test_sem_take_timeout(void)
 			K_NO_WAIT);
 
 	ret_value = sys_sem_take(&simple_sem, SEM_TIMEOUT);
-	zassert_true(ret_value == 0,
+	ztest_true(ret_value == 0,
 		     "sys_sem_take failed when its shouldn't have");
 }
 
@@ -298,7 +298,7 @@ void test_sem_take_timeout_forever(void)
 			K_NO_WAIT);
 
 	ret_value = sys_sem_take(&simple_sem, K_FOREVER);
-	zassert_true(ret_value == 0,
+	ztest_true(ret_value == 0,
 		     "sys_sem_take failed when its shouldn't have");
 }
 
@@ -316,7 +316,7 @@ void test_sem_take_timeout_isr(void)
 			K_PRIO_PREEMPT(0), 0, K_NO_WAIT);
 
 	ret_value = sys_sem_take(&simple_sem, SEM_TIMEOUT);
-	zassert_true(ret_value == 0,
+	ztest_true(ret_value == 0,
 		     "sys_sem_take failed when its shouldn't have");
 }
 
@@ -373,15 +373,15 @@ void test_sem_take_multiple(void)
 
 	/* check which threads completed. */
 	signal_count = sys_sem_count_get(&high_prio_sem);
-	zassert_true(signal_count == 1U,
+	ztest_true(signal_count == 1U,
 		     "Higher priority threads didn't execute");
 
 	signal_count = sys_sem_count_get(&mid_prio_sem);
-	zassert_true(signal_count == 0U,
+	ztest_true(signal_count == 0U,
 		     "Medium priority threads shouldn't have executed");
 
 	signal_count = sys_sem_count_get(&low_prio_sem);
-	zassert_true(signal_count == 0U,
+	ztest_true(signal_count == 0U,
 		     "low priority threads shouldn't have executed");
 
 	/* enable the Medium priority thread to run. */
@@ -390,15 +390,15 @@ void test_sem_take_multiple(void)
 
 	/* check which threads completed. */
 	signal_count = sys_sem_count_get(&high_prio_sem);
-	zassert_true(signal_count == 1U,
+	ztest_true(signal_count == 1U,
 		     "Higher priority thread executed again");
 
 	signal_count = sys_sem_count_get(&mid_prio_sem);
-	zassert_true(signal_count == 1U,
+	ztest_true(signal_count == 1U,
 		     "Medium priority thread didn't get executed");
 
 	signal_count = sys_sem_count_get(&low_prio_sem);
-	zassert_true(signal_count == 0U,
+	ztest_true(signal_count == 0U,
 		     "low priority thread shouldn't have executed");
 
 	/* enable the low priority thread to run. */
@@ -407,15 +407,15 @@ void test_sem_take_multiple(void)
 
 	/* check which threads completed. */
 	signal_count = sys_sem_count_get(&high_prio_sem);
-	zassert_true(signal_count == 1U,
+	ztest_true(signal_count == 1U,
 		     "Higher priority thread executed again");
 
 	signal_count = sys_sem_count_get(&mid_prio_sem);
-	zassert_true(signal_count == 1U,
+	ztest_true(signal_count == 1U,
 		     "Medium priority thread executed again");
 
 	signal_count = sys_sem_count_get(&low_prio_sem);
-	zassert_true(signal_count == 1U,
+	ztest_true(signal_count == 1U,
 		     "low priority thread didn't get executed");
 
 }
@@ -434,7 +434,7 @@ void test_sem_give_take_from_isr(void)
 		sem_give_from_isr(&simple_sem);
 
 		signal_count = sys_sem_count_get(&simple_sem);
-		zassert_true(signal_count == i + 1,
+		ztest_true(signal_count == i + 1,
 			     "signal count missmatch Expected %d, got %d",
 			     i + 1, signal_count);
 	}
@@ -444,7 +444,7 @@ void test_sem_give_take_from_isr(void)
 		sem_take_from_isr(&simple_sem);
 
 		signal_count = sys_sem_count_get(&simple_sem);
-		zassert_true(signal_count == (i - 1),
+		ztest_true(signal_count == (i - 1),
 			     "signal count missmatch Expected %d, got %d",
 			     (i - 1), signal_count);
 	}
@@ -463,11 +463,11 @@ void test_sem_give_limit(void)
 	/* Give semaphore and do a check for the count */
 	for (int i = 0; i < SEM_MAX_VAL; i++) {
 		ret_value = sys_sem_give(&simple_sem);
-		zassert_true(ret_value == 0,
+		ztest_true(ret_value == 0,
 			     "sys_sem_give failed when its shouldn't have");
 
 		signal_count = sys_sem_count_get(&simple_sem);
-		zassert_true(signal_count == i + 1,
+		ztest_true(signal_count == i + 1,
 			     "signal count missmatch Expected %d, got %d",
 			     i + 1, signal_count);
 	}
@@ -476,14 +476,14 @@ void test_sem_give_limit(void)
 		ret_value = sys_sem_give(&simple_sem);
 		if (ret_value == -EAGAIN) {
 			signal_count = sys_sem_count_get(&simple_sem);
-			zassert_true(signal_count == SEM_MAX_VAL,
+			ztest_true(signal_count == SEM_MAX_VAL,
 				"signal count missmatch Expected %d, got %d",
 				SEM_MAX_VAL, signal_count);
 
 			sys_sem_take(&simple_sem, K_FOREVER);
 		} else if (ret_value == 0) {
 			signal_count = sys_sem_count_get(&simple_sem);
-			zassert_true(signal_count == SEM_MAX_VAL,
+			ztest_true(signal_count == SEM_MAX_VAL,
 				"signal count missmatch Expected %d, got %d",
 				SEM_MAX_VAL, signal_count);
 		}
@@ -530,18 +530,18 @@ void test_sem_multiple_threads_wait(void)
 		/* check if all the threads are done. */
 		for (int i = 0; i < TOTAL_THREADS_WAITING; i++) {
 			ret_value = sys_sem_take(&simple_sem, K_FOREVER);
-			zassert_true(ret_value == 0,
+			ztest_true(ret_value == 0,
 				     "Some of the threads didn't get multiple_thread_sem"
 				     );
 		}
 
 		signal_count = sys_sem_count_get(&simple_sem);
-		zassert_true(signal_count == 0U,
+		ztest_true(signal_count == 0U,
 			     "signal count missmatch Expected 0, got %d",
 			     signal_count);
 
 		signal_count = sys_sem_count_get(&multiple_thread_sem);
-		zassert_true(signal_count == 0U,
+		ztest_true(signal_count == 0U,
 			     "signal count missmatch Expected 0, got %d",
 			     signal_count);
 

--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -156,18 +156,18 @@ void test_string_nlen(void)
 
 	ret = string_nlen(kernel_string, BUF_SIZE, &err);
 	if (arch_is_user_context()) {
-		zassert_equal(err, -1,
+		ztest_equal(err, -1,
 			      "kernel string did not fault on user access");
 	} else {
-		zassert_equal(err, 0, "kernel string faulted in kernel mode");
-		zassert_equal(ret, strlen(kernel_string),
+		ztest_equal(err, 0, "kernel string faulted in kernel mode");
+		ztest_equal(ret, strlen(kernel_string),
 			      "incorrect length returned");
 	}
 
 	/* Valid usage */
 	ret = string_nlen(user_string, BUF_SIZE, &err);
-	zassert_equal(err, 0, "user string faulted");
-	zassert_equal(ret, strlen(user_string), "incorrect length returned");
+	ztest_equal(err, 0, "user string faulted");
+	ztest_equal(ret, strlen(user_string), "incorrect length returned");
 
 	/* Skip this scenario for nsim_sem emulated board, unfortunately
 	 * the emulator doesn't set up memory as specified in DTS and poking
@@ -176,7 +176,7 @@ void test_string_nlen(void)
 #if !(defined(CONFIG_BOARD_NSIM) && defined(CONFIG_SOC_NSIM_SEM))
 	/* Try to blow up the kernel */
 	ret = string_nlen((char *)0xFFFFFFF0, BUF_SIZE, &err);
-	zassert_equal(err, -1, "nonsense string address did not fault");
+	ztest_equal(err, -1, "nonsense string address did not fault");
 #endif
 }
 
@@ -192,17 +192,17 @@ void test_user_string_alloc_copy(void)
 	int ret;
 
 	ret = string_alloc_copy("asdkajshdazskjdh");
-	zassert_equal(ret, -2, "got %d", ret);
+	ztest_equal(ret, -2, "got %d", ret);
 
 	ret = string_alloc_copy(
 	    "asdkajshdazskjdhikfsdjhfskdjfhsdkfjhskdfjhdskfjhs");
-	zassert_equal(ret, -1, "got %d", ret);
+	ztest_equal(ret, -1, "got %d", ret);
 
 	ret = string_alloc_copy(kernel_string);
-	zassert_equal(ret, -1, "got %d", ret);
+	ztest_equal(ret, -1, "got %d", ret);
 
 	ret = string_alloc_copy("this is a kernel string");
-	zassert_equal(ret, 0, "string should have matched");
+	ztest_equal(ret, 0, "string should have matched");
 }
 
 /**
@@ -217,16 +217,16 @@ void test_user_string_copy(void)
 	int ret;
 
 	ret = string_copy("asdkajshdazskjdh");
-	zassert_equal(ret, ESRCH, "got %d", ret);
+	ztest_equal(ret, ESRCH, "got %d", ret);
 
 	ret = string_copy("asdkajshdazskjdhikfsdjhfskdjfhsdkfjhskdfjhdskfjhs");
-	zassert_equal(ret, EINVAL, "got %d", ret);
+	ztest_equal(ret, EINVAL, "got %d", ret);
 
 	ret = string_copy(kernel_string);
-	zassert_equal(ret, EFAULT, "got %d", ret);
+	ztest_equal(ret, EFAULT, "got %d", ret);
 
 	ret = string_copy("this is a kernel string");
-	zassert_equal(ret, 0, "string should have matched");
+	ztest_equal(ret, 0, "string should have matched");
 }
 
 /**
@@ -242,21 +242,21 @@ void test_to_copy(void)
 	int ret;
 
 	ret = to_copy(kernel_buf);
-	zassert_equal(ret, EFAULT, "should have faulted");
+	ztest_equal(ret, EFAULT, "should have faulted");
 
 	ret = to_copy(buf);
-	zassert_equal(ret, 0, "copy should have been a success");
+	ztest_equal(ret, 0, "copy should have been a success");
 	ret = strcmp(buf, user_string);
-	zassert_equal(ret, 0, "string should have matched");
+	ztest_equal(ret, 0, "string should have matched");
 }
 
 void test_arg64(void)
 {
-	zassert_equal(syscall_arg64(54321),
+	ztest_equal(syscall_arg64(54321),
 		      z_impl_syscall_arg64(54321),
 		      "syscall didn't match impl");
 
-	zassert_equal(syscall_arg64_big(1, 2, 3, 4, 5, 6),
+	ztest_equal(syscall_arg64_big(1, 2, 3, 4, 5, 6),
 		      z_impl_syscall_arg64_big(1, 2, 3, 4, 5, 6),
 		      "syscall didn't match impl");
 }
@@ -280,20 +280,20 @@ void syscall_torture(void *arg1, void *arg2, void *arg3)
 		 * for concurrency problems.
 		 */
 		ret = string_nlen(user_string, BUF_SIZE, &err);
-		zassert_equal(err, 0, "user string faulted");
-		zassert_equal(ret, strlen(user_string),
+		ztest_equal(err, 0, "user string faulted");
+		ztest_equal(ret, strlen(user_string),
 			      "incorrect length returned");
 
 		ret = string_alloc_copy("this is a kernel string");
-		zassert_equal(ret, 0, "string should have matched");
+		ztest_equal(ret, 0, "string should have matched");
 
 		ret = string_copy("this is a kernel string");
-		zassert_equal(ret, 0, "string should have matched");
+		ztest_equal(ret, 0, "string should have matched");
 
 		ret = to_copy(buf);
-		zassert_equal(ret, 0, "copy should have been a success");
+		ztest_equal(ret, 0, "copy should have been a success");
 		ret = strcmp(buf, user_string);
-		zassert_equal(ret, 0, "string should have matched");
+		ztest_equal(ret, 0, "string should have matched");
 
 		test_arg64();
 

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -99,7 +99,7 @@ static void is_usermode(void)
 	/* Confirm that we are in fact running in user mode. */
 	expect_fault = false;
 	BARRIER();
-	zassert_true(_is_user_context(), "thread left in kernel mode");
+	ztest_true(_is_user_context(), "thread left in kernel mode");
 }
 
 /**
@@ -126,7 +126,7 @@ static void write_control(void)
 		"mov %eax, %cr0;\n\t"
 		);
 #endif
-	zassert_unreachable("Write to control register did not fault");
+	ztest_unreachable("Write to control register did not fault");
 #elif defined(CONFIG_ARM)
 	unsigned int msr_value;
 
@@ -138,7 +138,7 @@ static void write_control(void)
 	__DSB();
 	__ISB();
 	msr_value = __get_CONTROL();
-	zassert_true((msr_value & (CONTROL_nPRIV_Msk)),
+	ztest_true((msr_value & (CONTROL_nPRIV_Msk)),
 		     "Write to control register was successful");
 #elif defined(CONFIG_ARC)
 	unsigned int er_status;
@@ -153,7 +153,7 @@ static void write_control(void)
 	);
 #else
 #error "Not implemented for this architecture"
-	zassert_unreachable("Write to control register did not fault");
+	ztest_unreachable("Write to control register did not fault");
 #endif
 }
 
@@ -195,7 +195,7 @@ static void disable_mmu_mpu(void)
 #else
 #error "Not implemented for this architecture"
 #endif
-	zassert_unreachable("Disable MMU/MPU did not fault");
+	ztest_unreachable("Disable MMU/MPU did not fault");
 }
 
 /**
@@ -213,7 +213,7 @@ static void read_kernram(void)
 	BARRIER();
 	p = _current->init_data;
 	printk("%p\n", p);
-	zassert_unreachable("Read from kernel RAM did not fault");
+	ztest_unreachable("Read from kernel RAM did not fault");
 }
 
 /**
@@ -228,7 +228,7 @@ static void write_kernram(void)
 	expected_reason = K_ERR_CPU_EXCEPTION;
 	BARRIER();
 	_current->init_data = NULL;
-	zassert_unreachable("Write to kernel RAM did not fault");
+	ztest_unreachable("Write to kernel RAM did not fault");
 }
 
 extern int _k_neg_eagain;
@@ -245,14 +245,14 @@ static void write_kernro(void)
 	/* Try to write to kernel RO. */
 	const char *const ptr = (const char *const)&_k_neg_eagain;
 
-	zassert_true(ptr < _image_rodata_end &&
+	ztest_true(ptr < _image_rodata_end &&
 		     ptr >= _image_rodata_start,
 		     "_k_neg_eagain is not in rodata");
 	expect_fault = true;
 	expected_reason = K_ERR_CPU_EXCEPTION;
 	BARRIER();
 	_k_neg_eagain = -EINVAL;
-	zassert_unreachable("Write to kernel RO did not fault");
+	ztest_unreachable("Write to kernel RO did not fault");
 }
 
 /**
@@ -267,7 +267,7 @@ static void write_kerntext(void)
 	expected_reason = K_ERR_CPU_EXCEPTION;
 	BARRIER();
 	memset(&z_is_thread_essential, 0, 4);
-	zassert_unreachable("Write to kernel text did not fault");
+	ztest_unreachable("Write to kernel text did not fault");
 }
 
 static int kernel_data;
@@ -287,7 +287,7 @@ static void read_kernel_data(void)
 	BARRIER();
 	value = kernel_data;
 	printk("%d\n", value);
-	zassert_unreachable("Read from data did not fault");
+	ztest_unreachable("Read from data did not fault");
 }
 
 /**
@@ -301,7 +301,7 @@ static void write_kernel_data(void)
 	expected_reason = K_ERR_CPU_EXCEPTION;
 	BARRIER();
 	kernel_data = 1;
-	zassert_unreachable("Write to  data did not fault");
+	ztest_unreachable("Write to  data did not fault");
 }
 
 /*
@@ -335,7 +335,7 @@ static void read_priv_stack(void)
 	expected_reason = K_ERR_CPU_EXCEPTION;
 	BARRIER();
 	printk("%c\n", *priv_stack_ptr);
-	zassert_unreachable("Read from privileged stack did not fault");
+	ztest_unreachable("Read from privileged stack did not fault");
 }
 
 /**
@@ -360,7 +360,7 @@ static void write_priv_stack(void)
 	expected_reason = K_ERR_CPU_EXCEPTION;
 	BARRIER();
 	*priv_stack_ptr = 42;
-	zassert_unreachable("Write to privileged stack did not fault");
+	ztest_unreachable("Write to privileged stack did not fault");
 }
 
 
@@ -378,7 +378,7 @@ static void pass_user_object(void)
 	expected_reason = K_ERR_KERNEL_OOPS;
 	BARRIER();
 	k_sem_init(&sem, 0, 1);
-	zassert_unreachable("Pass a user object to a syscall did not fault");
+	ztest_unreachable("Pass a user object to a syscall did not fault");
 }
 
 static struct k_sem ksem;
@@ -395,7 +395,7 @@ static void pass_noperms_object(void)
 	expected_reason = K_ERR_KERNEL_OOPS;
 	BARRIER();
 	k_sem_init(&ksem, 0, 1);
-	zassert_unreachable("Pass an unauthorized object to a "
+	ztest_unreachable("Pass an unauthorized object to a "
 			    "syscall did not fault");
 }
 
@@ -422,7 +422,7 @@ static void start_kernel_thread(void)
 			(k_thread_entry_t)thread_body, NULL, NULL, NULL,
 			K_PRIO_PREEMPT(1), K_INHERIT_PERMS,
 			K_NO_WAIT);
-	zassert_unreachable("Create a kernel thread did not fault");
+	ztest_unreachable("Create a kernel thread did not fault");
 }
 
 struct k_thread uthread_thread;
@@ -468,7 +468,7 @@ static void read_other_stack(void)
 		give_uthread_end_sem = false;
 		k_sem_give(&uthread_end_sem);
 	}
-	zassert_unreachable("Read from other thread stack did not fault");
+	ztest_unreachable("Read from other thread stack did not fault");
 }
 
 /**
@@ -501,7 +501,7 @@ static void write_other_stack(void)
 		give_uthread_end_sem = false;
 		k_sem_give(&uthread_end_sem);
 	}
-	zassert_unreachable("Write to other thread stack did not fault");
+	ztest_unreachable("Write to other thread stack did not fault");
 }
 
 /**
@@ -517,7 +517,7 @@ static void revoke_noperms_object(void)
 	BARRIER();
 	k_object_release(&ksem);
 
-	zassert_unreachable("Revoke access to unauthorized object "
+	ztest_unreachable("Revoke access to unauthorized object "
 			    "did not fault");
 }
 
@@ -536,7 +536,7 @@ static void access_after_revoke(void)
 	BARRIER();
 	k_sem_take(&test_revoke_sem, K_NO_WAIT);
 
-	zassert_unreachable("Using revoked object did not fault");
+	ztest_unreachable("Using revoked object did not fault");
 }
 
 static void umode_enter_func(void)
@@ -550,7 +550,7 @@ static void umode_enter_func(void)
 		 */
 		ztest_test_pass();
 	} else {
-		zassert_unreachable("Thread did not enter user mode");
+		ztest_unreachable("Thread did not enter user mode");
 	}
 }
 
@@ -588,7 +588,7 @@ static void write_kobject_user_pipe(void)
 	k_pipe_get(&kpipe, &uthread_start_sem, BYTES_TO_READ_WRITE,
 		   &bytes_written_read, 1, K_NO_WAIT);
 
-	zassert_unreachable("System call memory write validation "
+	ztest_unreachable("System call memory write validation "
 			    "did not fault");
 }
 
@@ -609,7 +609,7 @@ static void read_kobject_user_pipe(void)
 	k_pipe_put(&kpipe, &uthread_start_sem, BYTES_TO_READ_WRITE,
 		   &bytes_written_read, 1, K_NO_WAIT);
 
-	zassert_unreachable("System call memory read validation "
+	ztest_unreachable("System call memory read validation "
 			    "did not fault");
 }
 
@@ -626,7 +626,7 @@ static void shared_mem_thread(void)
 	expected_reason = K_ERR_CPU_EXCEPTION;
 	BARRIER();
 	thread_bool = false;
-	zassert_unreachable("Thread accessed global in other "
+	ztest_unreachable("Thread accessed global in other "
 			    "memory domain\n");
 }
 
@@ -951,15 +951,15 @@ void stack_buffer_scenarios(k_thread_stack_t *stack_obj, size_t obj_size)
 	/* Assert that the created stack object, with the reserved data
 	 * removed, can hold a thread buffer of STEST_STACKSIZE
 	 */
-	zassert_true(STEST_STACKSIZE <= (obj_size - K_THREAD_STACK_RESERVED),
+	ztest_true(STEST_STACKSIZE <= (obj_size - K_THREAD_STACK_RESERVED),
 		      "bad stack size in object");
 
 	/* Check that the stack info in the thread marks a region
 	 * completely contained within the stack object
 	 */
-	zassert_true(stack_end <= obj_end,
+	ztest_true(stack_end <= obj_end,
 		     "stack size in thread struct out of bounds (overflow)");
-	zassert_true(stack_start >= obj_start,
+	ztest_true(stack_start >= obj_start,
 		     "stack size in thread struct out of bounds (underflow)");
 
 	/* Check that the entire stack buffer is read/writable */
@@ -986,7 +986,7 @@ void stack_buffer_scenarios(k_thread_stack_t *stack_obj, size_t obj_size)
 		 * to ensure that the thread has permissions on it.
 		 */
 		for (pos = stack_start; pos < stack_end; pos++) {
-			zassert_false(check_perms((void *)pos, 1, 1),
+			ztest_false(check_perms((void *)pos, 1, 1),
 				      "bad MPU/MMU permission on stack buffer at address %p",
 				      pos);
 		}
@@ -996,10 +996,10 @@ void stack_buffer_scenarios(k_thread_stack_t *stack_obj, size_t obj_size)
 		 * alignment constraints, we test the end of the stack object
 		 * and not the buffer.
 		 */
-		zassert_true(check_perms(obj_start - 1, 1, 0),
+		ztest_true(check_perms(obj_start - 1, 1, 0),
 			     "user mode access to memory %p before start of stack object",
 			     obj_start - 1);
-		zassert_true(check_perms(obj_end, 1, 0),
+		ztest_true(check_perms(obj_end, 1, 0),
 			     "user mode access to memory %p past end of stack object",
 			     obj_end);
 	}
@@ -1012,7 +1012,7 @@ void stack_buffer_scenarios(k_thread_stack_t *stack_obj, size_t obj_size)
 	}
 
 	if (arch_is_user_context()) {
-		zassert_true(stack_size <= obj_size - K_THREAD_STACK_RESERVED,
+		ztest_true(stack_size <= obj_size - K_THREAD_STACK_RESERVED,
 			      "bad stack size %zu in thread struct",
 			      stack_size);
 	}
@@ -1025,7 +1025,7 @@ void stack_buffer_scenarios(k_thread_stack_t *stack_obj, size_t obj_size)
 		expected = 0;
 	}
 
-	zassert_equal(ret, expected, "unexpected return value %d", ret);
+	ztest_equal(ret, expected, "unexpected return value %d", ret);
 	if (ret == 0) {
 		printk("self-reported unused stack space: %zu\n", unused);
 	}
@@ -1058,7 +1058,7 @@ void stest_thread_launch(void *stack_obj, size_t obj_size, u32_t flags,
 	k_sem_take(&uthread_end_sem, K_FOREVER);
 
 	ret = k_thread_stack_space_get(&uthread_thread, &unused);
-	zassert_equal(ret, 0, "failed to calculate unused stack space\n");
+	ztest_equal(ret, 0, "failed to calculate unused stack space\n");
 	printk("target thread unused stack space: %zu\n", unused);
 }
 
@@ -1130,15 +1130,15 @@ void test_object_recycle(void)
 	(void)memset(ko->perms, 0xFF, sizeof(ko->perms));
 
 	z_object_recycle(&recycle_sem);
-	zassert_true(ko != NULL, "kernel object not found");
-	zassert_true(ko->flags & K_OBJ_FLAG_INITIALIZED,
+	ztest_true(ko != NULL, "kernel object not found");
+	ztest_true(ko->flags & K_OBJ_FLAG_INITIALIZED,
 		     "object wasn't marked as initialized");
 
 	for (int i = 0; i < CONFIG_MAX_THREAD_BYTES; i++) {
 		perms_count += popcount(ko->perms[i]);
 	}
 
-	zassert_true(perms_count == 1, "invalid number of thread permissions");
+	ztest_true(perms_count == 1, "invalid number of thread permissions");
 }
 
 #define test_oops(provided, expected) do { \
@@ -1181,10 +1181,10 @@ void z_impl_check_syscall_context(void)
 	/* Make sure that interrupts aren't locked when handling system calls;
 	 * key has the previous locking state before the above irq_lock() call.
 	 */
-	zassert_true(arch_irq_unlocked(key), "irqs locked during syscall");
+	ztest_true(arch_irq_unlocked(key), "irqs locked during syscall");
 
 	/* The kernel should not think we are in ISR context either */
-	zassert_false(k_is_in_isr(), "kernel reports irq context");
+	ztest_false(k_is_in_isr(), "kernel reports irq context");
 }
 
 static inline void z_vrfy_check_syscall_context(void)

--- a/tests/kernel/mem_slab/mslab/src/main.c
+++ b/tests/kernel/mem_slab/mslab/src/main.c
@@ -131,11 +131,11 @@ void test_slab_get_all_blocks(void **p)
 
 	for (int i = 0; i < NUMBLOCKS; i++) {
 		/* Verify number of used blocks in the map */
-		zassert_equal(k_mem_slab_num_used_get(&map_lgblks), i,
+		ztest_equal(k_mem_slab_num_used_get(&map_lgblks), i,
 			      "Failed k_mem_slab_num_used_get");
 
 		/* Get memory block */
-		zassert_equal(k_mem_slab_alloc(&map_lgblks, &p[i], K_NO_WAIT), 0,
+		ztest_equal(k_mem_slab_alloc(&map_lgblks, &p[i], K_NO_WAIT), 0,
 			      "Failed k_mem_slab_alloc");
 	} /* for */
 
@@ -143,11 +143,11 @@ void test_slab_get_all_blocks(void **p)
 	 * Verify number of used blocks in the map - expect all blocks are
 	 * used
 	 */
-	zassert_equal(k_mem_slab_num_used_get(&map_lgblks), NUMBLOCKS,
+	ztest_equal(k_mem_slab_num_used_get(&map_lgblks), NUMBLOCKS,
 		      "Failed k_mem_slab_num_used_get");
 
 	/* Try to get one more block and it should fail */
-	zassert_equal(k_mem_slab_alloc(&map_lgblks, &errptr, K_NO_WAIT), -ENOMEM,
+	ztest_equal(k_mem_slab_alloc(&map_lgblks, &errptr, K_NO_WAIT), -ENOMEM,
 		      "Failed k_mem_slab_alloc");
 
 }  /* test_slab_get_all_blocks */
@@ -172,7 +172,7 @@ void test_slab_free_all_blocks(void **p)
 {
 	for (int i = 0; i < NUMBLOCKS; i++) {
 		/* Verify number of used blocks in the map */
-		zassert_equal(k_mem_slab_num_used_get(&map_lgblks), NUMBLOCKS - i,
+		ztest_equal(k_mem_slab_num_used_get(&map_lgblks), NUMBLOCKS - i,
 			      "Failed k_mem_slab_num_used_get");
 
 		TC_PRINT("  block ptr to free p[%d] = %p\n", i, p[i]);
@@ -188,7 +188,7 @@ void test_slab_free_all_blocks(void **p)
 	 *  - should be 0 as no blocks are used
 	 */
 
-	zassert_equal(k_mem_slab_num_used_get(&map_lgblks), 0,
+	ztest_equal(k_mem_slab_num_used_get(&map_lgblks), 0,
 		      "Failed k_mem_slab_num_used_get");
 
 }   /* test_slab_free_all_blocks */
@@ -244,13 +244,13 @@ void test_mslab(void)
 		 "in <%s>\n", __func__);
 
 	ret_value = k_mem_slab_alloc(&map_lgblks, &b, K_MSEC(20));
-	zassert_equal(-EAGAIN, ret_value,
+	ztest_equal(-EAGAIN, ret_value,
 		      "Failed k_mem_slab_alloc, retValue %d\n", ret_value);
 
 	TC_PRINT("%s: start to wait for block\n", __func__);
 	k_sem_give(&SEM_REGRESSDONE);    /* Allow helper thread to run part 4 */
 	ret_value = k_mem_slab_alloc(&map_lgblks, &b, K_MSEC(50));
-	zassert_equal(0, ret_value,
+	ztest_equal(0, ret_value,
 		      "Failed k_mem_slab_alloc, ret_value %d\n", ret_value);
 
 	/* Wait for helper thread to complete */
@@ -259,7 +259,7 @@ void test_mslab(void)
 	TC_PRINT("%s: start to wait for block\n", __func__);
 	k_sem_give(&SEM_REGRESSDONE);    /* Allow helper thread to run part 5 */
 	ret_value = k_mem_slab_alloc(&map_lgblks, &b, K_FOREVER);
-	zassert_equal(0, ret_value,
+	ztest_equal(0, ret_value,
 		      "Failed k_mem_slab_alloc, ret_value %d\n", ret_value);
 
 	/* Wait for helper thread to complete */

--- a/tests/kernel/mem_slab/mslab_api/src/test_mslab_api.c
+++ b/tests/kernel/mem_slab/mslab_api/src/test_mslab_api.c
@@ -25,13 +25,13 @@ void tmslab_alloc_free(void *data)
 	for (int i = 0; i < BLK_NUM; i++) {
 		/** TESTPOINT: Allocate memory from a memory slab.*/
 		/** TESTPOINT: @retval 0 Memory allocated.*/
-		zassert_true(k_mem_slab_alloc(pslab, &block[i], K_NO_WAIT) == 0,
+		ztest_true(k_mem_slab_alloc(pslab, &block[i], K_NO_WAIT) == 0,
 			     NULL);
 		/**
 		 * TESTPOINT: The block address area pointed at by @a mem is set
 		 * to the starting address of the memory block.
 		 */
-		zassert_not_null(block[i], NULL);
+		ztest_not_null(block[i], NULL);
 	}
 	for (int i = 0; i < BLK_NUM; i++) {
 		/** TESTPOINT: Free memory allocated from a memory slab.*/
@@ -45,13 +45,13 @@ static void tmslab_alloc_align(void *data)
 	void *block[BLK_NUM];
 
 	for (int i = 0; i < BLK_NUM; i++) {
-		zassert_true(k_mem_slab_alloc(pslab, &block[i], K_NO_WAIT) == 0,
+		ztest_true(k_mem_slab_alloc(pslab, &block[i], K_NO_WAIT) == 0,
 			     NULL);
 		/**
 		 * TESTPOINT: To ensure that each memory block is similarly
 		 * aligned to this boundary
 		 */
-		zassert_true((uintptr_t)block[i] % BLK_ALIGN == 0U, NULL);
+		ztest_true((uintptr_t)block[i] % BLK_ALIGN == 0U, NULL);
 	}
 	for (int i = 0; i < BLK_NUM; i++) {
 		k_mem_slab_free(pslab, &block[i]);
@@ -65,23 +65,23 @@ static void tmslab_alloc_timeout(void *data)
 	s64_t tms;
 
 	for (int i = 0; i < BLK_NUM; i++) {
-		zassert_true(k_mem_slab_alloc(pslab, &block[i], K_NO_WAIT) == 0,
+		ztest_true(k_mem_slab_alloc(pslab, &block[i], K_NO_WAIT) == 0,
 			     NULL);
 	}
 
 	/** TESTPOINT: Use K_NO_WAIT to return without waiting*/
 	/** TESTPOINT: -ENOMEM Returned without waiting.*/
-	zassert_equal(k_mem_slab_alloc(pslab, &block_fail, K_NO_WAIT), -ENOMEM,
+	ztest_equal(k_mem_slab_alloc(pslab, &block_fail, K_NO_WAIT), -ENOMEM,
 		      NULL);
 	/** TESTPOINT: -EAGAIN Waiting period timed out*/
 	tms = k_uptime_get();
-	zassert_equal(k_mem_slab_alloc(pslab, &block_fail, TIMEOUT), -EAGAIN,
+	ztest_equal(k_mem_slab_alloc(pslab, &block_fail, TIMEOUT), -EAGAIN,
 		      NULL);
 	/**
 	 * TESTPOINT: timeout Maximum time to wait for operation to
 	 * complete (in milliseconds)
 	 */
-	zassert_true(k_uptime_delta(&tms) >= TIMEOUT, NULL);
+	ztest_true(k_uptime_delta(&tms) >= TIMEOUT, NULL);
 
 	for (int i = 0; i < BLK_NUM; i++) {
 		k_mem_slab_free(pslab, &block[i]);
@@ -94,32 +94,32 @@ static void tmslab_used_get(void *data)
 	void *block[BLK_NUM], *block_fail;
 
 	for (int i = 0; i < BLK_NUM; i++) {
-		zassert_true(k_mem_slab_alloc(pslab, &block[i], K_NO_WAIT) == 0,
+		ztest_true(k_mem_slab_alloc(pslab, &block[i], K_NO_WAIT) == 0,
 			     NULL);
 		/** TESTPOINT: Get the number of used blocks in a memory slab.*/
-		zassert_equal(k_mem_slab_num_used_get(pslab), i + 1, NULL);
+		ztest_equal(k_mem_slab_num_used_get(pslab), i + 1, NULL);
 		/**
 		 * TESTPOINT: Get the number of unused blocks in a memory slab.
 		 */
-		zassert_equal(k_mem_slab_num_free_get(pslab), BLK_NUM - 1 - i, NULL);
+		ztest_equal(k_mem_slab_num_free_get(pslab), BLK_NUM - 1 - i, NULL);
 	}
 
-	zassert_equal(k_mem_slab_alloc(pslab, &block_fail, K_NO_WAIT), -ENOMEM,
+	ztest_equal(k_mem_slab_alloc(pslab, &block_fail, K_NO_WAIT), -ENOMEM,
 		      NULL);
 	/* free get on allocation failure*/
-	zassert_equal(k_mem_slab_num_free_get(pslab), 0, NULL);
+	ztest_equal(k_mem_slab_num_free_get(pslab), 0, NULL);
 	/* used get on allocation failure*/
-	zassert_equal(k_mem_slab_num_used_get(pslab), BLK_NUM, NULL);
+	ztest_equal(k_mem_slab_num_used_get(pslab), BLK_NUM, NULL);
 
-	zassert_equal(k_mem_slab_alloc(pslab, &block_fail, TIMEOUT), -EAGAIN,
+	ztest_equal(k_mem_slab_alloc(pslab, &block_fail, TIMEOUT), -EAGAIN,
 		      NULL);
-	zassert_equal(k_mem_slab_num_free_get(pslab), 0, NULL);
-	zassert_equal(k_mem_slab_num_used_get(pslab), BLK_NUM, NULL);
+	ztest_equal(k_mem_slab_num_free_get(pslab), 0, NULL);
+	ztest_equal(k_mem_slab_num_used_get(pslab), BLK_NUM, NULL);
 
 	for (int i = 0; i < BLK_NUM; i++) {
 		k_mem_slab_free(pslab, &block[i]);
-		zassert_equal(k_mem_slab_num_free_get(pslab), i + 1, NULL);
-		zassert_equal(k_mem_slab_num_used_get(pslab), BLK_NUM - 1 - i, NULL);
+		ztest_equal(k_mem_slab_num_free_get(pslab), i + 1, NULL);
+		ztest_equal(k_mem_slab_num_used_get(pslab), BLK_NUM - 1 - i, NULL);
 	}
 }
 
@@ -137,8 +137,8 @@ static void tmslab_used_get(void *data)
 void test_mslab_kinit(void)
 {
 	k_mem_slab_init(&mslab, tslab, BLK_SIZE, BLK_NUM);
-	zassert_equal(k_mem_slab_num_used_get(&mslab), 0, NULL);
-	zassert_equal(k_mem_slab_num_free_get(&mslab), BLK_NUM, NULL);
+	ztest_equal(k_mem_slab_num_used_get(&mslab), 0, NULL);
+	ztest_equal(k_mem_slab_num_free_get(&mslab), BLK_NUM, NULL);
 }
 
 /**
@@ -152,8 +152,8 @@ void test_mslab_kinit(void)
  */
 void test_mslab_kdefine(void)
 {
-	zassert_equal(k_mem_slab_num_used_get(&kmslab), 0, NULL);
-	zassert_equal(k_mem_slab_num_free_get(&kmslab), BLK_NUM, NULL);
+	ztest_equal(k_mem_slab_num_used_get(&kmslab), 0, NULL);
+	ztest_equal(k_mem_slab_num_free_get(&kmslab), BLK_NUM, NULL);
 }
 
 /**

--- a/tests/kernel/mem_slab/mslab_concept/src/test_mslab_alloc_wait.c
+++ b/tests/kernel/mem_slab/mslab_concept/src/test_mslab_alloc_wait.c
@@ -22,14 +22,14 @@ void tmslab_alloc_wait_timeout(void *p1, void *p2, void *p3)
 {
 	void *block;
 
-	zassert_true(k_mem_slab_alloc(&mslab1, &block, TIMEOUT) == -EAGAIN,
+	ztest_true(k_mem_slab_alloc(&mslab1, &block, TIMEOUT) == -EAGAIN,
 		     NULL);
 	k_sem_give(&sync_sema);
 }
 
 void tmslab_alloc_wait_ok(void *p1, void *p2, void *p3)
 {
-	zassert_true(k_mem_slab_alloc(&mslab1, &block_ok, TIMEOUT) == 0, NULL);
+	ztest_true(k_mem_slab_alloc(&mslab1, &block_ok, TIMEOUT) == 0, NULL);
 	k_sem_give(&sync_sema);
 }
 
@@ -56,7 +56,7 @@ void test_mslab_alloc_wait_prio(void)
 	k_sem_init(&sync_sema, 0, THREAD_NUM);
 	/*allocated up all blocks*/
 	for (int i = 0; i < BLK_NUM; i++) {
-		zassert_equal(k_mem_slab_alloc(&mslab1, &block[i], K_NO_WAIT),
+		ztest_equal(k_mem_slab_alloc(&mslab1, &block[i], K_NO_WAIT),
 			      0, NULL);
 	}
 

--- a/tests/kernel/mem_slab/mslab_threadsafe/src/test_mslab_threadsafe.c
+++ b/tests/kernel/mem_slab/mslab_threadsafe/src/test_mslab_threadsafe.c
@@ -47,7 +47,7 @@ static void tmslab_api(void *p1, void *p2, void *p3)
 
 		for (int i = 0; i < BLK_NUM; i++) {
 			ret = k_mem_slab_alloc(slab, &block[i], TIMEOUT);
-			zassert_false(ret, "memory is not allocated");
+			ztest_false(ret, "memory is not allocated");
 		}
 		for (int i = 0; i < BLK_NUM; i++) {
 			if (block[i]) {

--- a/tests/kernel/mp/src/main.c
+++ b/tests/kernel/mp/src/main.c
@@ -35,7 +35,7 @@ volatile int cpu_running;
  */
 FUNC_NORETURN void cpu1_fn(void *arg)
 {
-	zassert_true(arg == &cpu_arg && *(int *)arg == 12345, "wrong arg");
+	ztest_true(arg == &cpu_arg && *(int *)arg == 12345, "wrong arg");
 
 	cpu_running = 1;
 
@@ -59,7 +59,7 @@ void test_mp_start(void)
 	while (!cpu_running) {
 	}
 
-	zassert_true(cpu_running, "cpu1 didn't start");
+	ztest_true(cpu_running, "cpu1 didn't start");
 }
 
 void test_main(void)

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_attrs.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_attrs.c
@@ -16,24 +16,24 @@ static void attrs_get(struct k_msgq *q)
 	struct k_msgq_attrs attrs;
 
 	k_msgq_get_attrs(q, &attrs);
-	zassert_equal(attrs.used_msgs, 0, NULL);
+	ztest_equal(attrs.used_msgs, 0, NULL);
 
 	/*fill the queue to full*/
 	for (int i = 0; i < MSGQ_LEN; i++) {
 		ret = k_msgq_put(q, (void *)&send_buf[i], K_NO_WAIT);
-		zassert_equal(ret, 0, NULL);
+		ztest_equal(ret, 0, NULL);
 	}
 
 	k_msgq_get_attrs(q, &attrs);
-	zassert_equal(attrs.used_msgs, MSGQ_LEN, NULL);
+	ztest_equal(attrs.used_msgs, MSGQ_LEN, NULL);
 
 	for (int i = 0; i < MSGQ_LEN; i++) {
 		ret = k_msgq_get(q, (void *)&rec_buf[i], K_NO_WAIT);
-		zassert_equal(ret, 0, NULL);
+		ztest_equal(ret, 0, NULL);
 	}
 
 	k_msgq_get_attrs(q, &attrs);
-	zassert_equal(attrs.used_msgs, 0, NULL);
+	ztest_equal(attrs.used_msgs, 0, NULL);
 }
 
 /**
@@ -64,8 +64,8 @@ void test_msgq_user_attrs_get(void)
 	struct k_msgq *q;
 
 	q = k_object_alloc(K_OBJ_MSGQ);
-	zassert_not_null(q, "couldn't alloc message queue");
-	zassert_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN), NULL);
+	ztest_not_null(q, "couldn't alloc message queue");
+	ztest_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN), NULL);
 	attrs_get(q);
 }
 #endif

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
@@ -29,21 +29,21 @@ static void put_msgq(struct k_msgq *pmsgq)
 
 	for (int i = 0; i < MSGQ_LEN; i++) {
 		ret = k_msgq_put(pmsgq, (void *)&data[i], K_NO_WAIT);
-		zassert_equal(ret, 0, NULL);
+		ztest_equal(ret, 0, NULL);
 
 		/**TESTPOINT: Check if k_msgq_peek reads msgq
 		 * in FIFO manner.
 		 * Everytime msg is enqueued, msg read should
 		 * always be the first message
 		 */
-		zassert_equal(k_msgq_peek(pmsgq, &read_data), 0, NULL);
-		zassert_equal(read_data, data[0], NULL);
+		ztest_equal(k_msgq_peek(pmsgq, &read_data), 0, NULL);
+		ztest_equal(read_data, data[0], NULL);
 
 		/**TESTPOINT: msgq free get*/
-		zassert_equal(k_msgq_num_free_get(pmsgq),
+		ztest_equal(k_msgq_num_free_get(pmsgq),
 				MSGQ_LEN - 1 - i, NULL);
 		/**TESTPOINT: msgq used get*/
-		zassert_equal(k_msgq_num_used_get(pmsgq), i + 1, NULL);
+		ztest_equal(k_msgq_num_used_get(pmsgq), i + 1, NULL);
 	}
 }
 
@@ -53,18 +53,18 @@ static void get_msgq(struct k_msgq *pmsgq)
 	int ret;
 
 	for (int i = 0; i < MSGQ_LEN; i++) {
-		zassert_equal(k_msgq_peek(pmsgq, &read_data), 0, NULL);
+		ztest_equal(k_msgq_peek(pmsgq, &read_data), 0, NULL);
 
 		ret = k_msgq_get(pmsgq, &rx_data, K_FOREVER);
-		zassert_equal(ret, 0, NULL);
-		zassert_equal(rx_data, data[i], NULL);
+		ztest_equal(ret, 0, NULL);
+		ztest_equal(rx_data, data[i], NULL);
 
 		/**TESTPOINT: Check if msg read is the msg deleted*/
-		zassert_equal(read_data, rx_data, NULL);
+		ztest_equal(read_data, rx_data, NULL);
 		/**TESTPOINT: msgq free get*/
-		zassert_equal(k_msgq_num_free_get(pmsgq), i + 1, NULL);
+		ztest_equal(k_msgq_num_free_get(pmsgq), i + 1, NULL);
 		/**TESTPOINT: msgq used get*/
-		zassert_equal(k_msgq_num_used_get(pmsgq),
+		ztest_equal(k_msgq_num_used_get(pmsgq),
 				MSGQ_LEN - 1 - i, NULL);
 	}
 }
@@ -74,9 +74,9 @@ static void purge_msgq(struct k_msgq *pmsgq)
 	u32_t read_data;
 
 	k_msgq_purge(pmsgq);
-	zassert_equal(k_msgq_num_free_get(pmsgq), MSGQ_LEN, NULL);
-	zassert_equal(k_msgq_num_used_get(pmsgq), 0, NULL);
-	zassert_equal(k_msgq_peek(pmsgq, &read_data), -ENOMSG, NULL);
+	ztest_equal(k_msgq_num_free_get(pmsgq), MSGQ_LEN, NULL);
+	ztest_equal(k_msgq_num_used_get(pmsgq), 0, NULL);
+	ztest_equal(k_msgq_peek(pmsgq, &read_data), -ENOMSG, NULL);
 }
 
 static void tisr_entry(void *p)
@@ -113,11 +113,11 @@ static void thread_entry_overflow(void *p1, void *p2, void *p3)
 
 	ret = k_msgq_get(p1, &rx_buf[0], K_FOREVER);
 
-	zassert_equal(ret, 0, NULL);
+	ztest_equal(ret, 0, NULL);
 
 	ret = k_msgq_get(p1, &rx_buf[1], K_FOREVER);
 
-	zassert_equal(ret, 0, NULL);
+	ztest_equal(ret, 0, NULL);
 
 	k_sem_give(&end_sema);
 }
@@ -128,7 +128,7 @@ static void msgq_thread_overflow(struct k_msgq *pmsgq)
 
 	ret = k_msgq_put(pmsgq, (void *)&data[0], K_FOREVER);
 
-	zassert_equal(ret, 0, NULL);
+	ztest_equal(ret, 0, NULL);
 
 	/**TESTPOINT: thread-thread data passing via message queue*/
 	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
@@ -138,7 +138,7 @@ static void msgq_thread_overflow(struct k_msgq *pmsgq)
 
 	ret = k_msgq_put(pmsgq, (void *)&data[1], K_FOREVER);
 
-	zassert_equal(ret, 0, NULL);
+	ztest_equal(ret, 0, NULL);
 
 	k_sem_take(&end_sema, K_FOREVER);
 	k_thread_abort(tid);
@@ -174,7 +174,7 @@ static void pend_thread_entry(void *p1, void *p2, void *p3)
 	int ret;
 
 	ret = k_msgq_put(p1, &data[1], TIMEOUT);
-	zassert_equal(ret, 0, NULL);
+	ztest_equal(ret, 0, NULL);
 }
 
 static void msgq_thread_data_passing(struct k_msgq *pmsgq)
@@ -241,8 +241,8 @@ void test_msgq_user_thread(void)
 	struct k_msgq *q;
 
 	q = k_object_alloc(K_OBJ_MSGQ);
-	zassert_not_null(q, "couldn't alloc message queue");
-	zassert_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN), NULL);
+	ztest_not_null(q, "couldn't alloc message queue");
+	ztest_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN), NULL);
 	k_sem_init(&end_sema, 0, 1);
 
 	msgq_thread(q);
@@ -257,8 +257,8 @@ void test_msgq_user_thread_overflow(void)
 	struct k_msgq *q;
 
 	q = k_object_alloc(K_OBJ_MSGQ);
-	zassert_not_null(q, "couldn't alloc message queue");
-	zassert_false(k_msgq_alloc_init(q, MSG_SIZE, 1), NULL);
+	ztest_not_null(q, "couldn't alloc message queue");
+	ztest_false(k_msgq_alloc_init(q, MSG_SIZE, 1), NULL);
 	k_sem_init(&end_sema, 0, 1);
 
 	msgq_thread_overflow(q);
@@ -308,12 +308,12 @@ void test_msgq_alloc(void)
 
 	/** Requesting buffer allocation from the test pool.*/
 	ret = k_msgq_alloc_init(&kmsgq_test_alloc, MSG_SIZE * 64, MSGQ_LEN);
-	zassert_true(ret == -ENOMEM,
+	ztest_true(ret == -ENOMEM,
 		"resource pool is smaller then requested buffer");
 
 	/* Requesting a huge size of MSG to validate overflow*/
 	ret = k_msgq_alloc_init(&kmsgq_test_alloc, OVERFLOW_SIZE_MSG, MSGQ_LEN);
-	zassert_true(ret == -EINVAL, "Invalid request");
+	ztest_true(ret == -EINVAL, "Invalid request");
 }
 
 /**

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_fail.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_fail.c
@@ -13,15 +13,15 @@ static void put_fail(struct k_msgq *q)
 {
 	int ret = k_msgq_put(q, (void *)&data[0], K_NO_WAIT);
 
-	zassert_false(ret, NULL);
+	ztest_false(ret, NULL);
 	ret = k_msgq_put(q, (void *)&data[0], K_NO_WAIT);
-	zassert_false(ret, NULL);
+	ztest_false(ret, NULL);
 	/**TESTPOINT: msgq put returns -ENOMSG*/
 	ret = k_msgq_put(q, (void *)&data[1], K_NO_WAIT);
-	zassert_equal(ret, -ENOMSG, NULL);
+	ztest_equal(ret, -ENOMSG, NULL);
 	/**TESTPOINT: msgq put returns -EAGAIN*/
 	ret = k_msgq_put(q, (void *)&data[0], TIMEOUT);
-	zassert_equal(ret, -EAGAIN, NULL);
+	ztest_equal(ret, -EAGAIN, NULL);
 
 	k_msgq_purge(q);
 }
@@ -33,10 +33,10 @@ static void get_fail(struct k_msgq *q)
 	/**TESTPOINT: msgq get returns -ENOMSG*/
 	int ret = k_msgq_get(q, &rx_data, K_NO_WAIT);
 
-	zassert_equal(ret, -ENOMSG, NULL);
+	ztest_equal(ret, -ENOMSG, NULL);
 	/**TESTPOINT: msgq get returns -EAGAIN*/
 	ret = k_msgq_get(q, &rx_data, TIMEOUT);
-	zassert_equal(ret, -EAGAIN, NULL);
+	ztest_equal(ret, -EAGAIN, NULL);
 }
 
 /**
@@ -64,8 +64,8 @@ void test_msgq_user_put_fail(void)
 	struct k_msgq *q;
 
 	q = k_object_alloc(K_OBJ_MSGQ);
-	zassert_not_null(q, "couldn't alloc message queue");
-	zassert_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN), NULL);
+	ztest_not_null(q, "couldn't alloc message queue");
+	ztest_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN), NULL);
 	put_fail(q);
 }
 #endif /* CONFIG_USERSPACE */
@@ -90,8 +90,8 @@ void test_msgq_user_get_fail(void)
 	struct k_msgq *q;
 
 	q = k_object_alloc(K_OBJ_MSGQ);
-	zassert_not_null(q, "couldn't alloc message queue");
-	zassert_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN), NULL);
+	ztest_not_null(q, "couldn't alloc message queue");
+	ztest_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN), NULL);
 	get_fail(q);
 }
 #endif /* CONFIG_USERSPACE */

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_purge.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_purge.c
@@ -16,7 +16,7 @@ static void tThread_entry(void *p1, void *p2, void *p3)
 {
 	int ret = k_msgq_put((struct k_msgq *)p1, (void *)&data[0], TIMEOUT);
 
-	zassert_equal(ret, -ENOMSG, NULL);
+	ztest_equal(ret, -ENOMSG, NULL);
 }
 
 static void purge_when_put(struct k_msgq *q)
@@ -26,7 +26,7 @@ static void purge_when_put(struct k_msgq *q)
 	/*fill the queue to full*/
 	for (int i = 0; i < MSGQ_LEN; i++) {
 		ret = k_msgq_put(q, (void *)&data[i], K_NO_WAIT);
-		zassert_equal(ret, 0, NULL);
+		ztest_equal(ret, 0, NULL);
 	}
 	/*create another thread waiting to put msg*/
 	k_thread_create(&tdata, tstack, STACK_SIZE,
@@ -40,7 +40,7 @@ static void purge_when_put(struct k_msgq *q)
 	/*verify msg put after purge*/
 	for (int i = 0; i < MSGQ_LEN; i++) {
 		ret = k_msgq_put(q, (void *)&data[i], K_NO_WAIT);
-		zassert_equal(ret, 0, NULL);
+		ztest_equal(ret, 0, NULL);
 	}
 
 	k_thread_abort(&tdata);
@@ -72,8 +72,8 @@ void test_msgq_user_purge_when_put(void)
 	struct k_msgq *q;
 
 	q = k_object_alloc(K_OBJ_MSGQ);
-	zassert_not_null(q, "couldn't alloc message queue");
-	zassert_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN), NULL);
+	ztest_not_null(q, "couldn't alloc message queue");
+	ztest_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN), NULL);
 
 	purge_when_put(q);
 }

--- a/tests/kernel/mutex/mutex_api/src/test_mutex_apis.c
+++ b/tests/kernel/mutex/mutex_api/src/test_mutex_apis.c
@@ -17,26 +17,26 @@ static struct k_thread tdata;
 
 static void tThread_entry_lock_forever(void *p1, void *p2, void *p3)
 {
-	zassert_false(k_mutex_lock((struct k_mutex *)p1, K_FOREVER) == 0,
+	ztest_false(k_mutex_lock((struct k_mutex *)p1, K_FOREVER) == 0,
 		      "access locked resource from spawn thread");
 	/* should not hit here */
 }
 
 static void tThread_entry_lock_no_wait(void *p1, void *p2, void *p3)
 {
-	zassert_true(k_mutex_lock((struct k_mutex *)p1, K_NO_WAIT) != 0, NULL);
+	ztest_true(k_mutex_lock((struct k_mutex *)p1, K_NO_WAIT) != 0, NULL);
 	TC_PRINT("bypass locked resource from spawn thread\n");
 }
 
 static void tThread_entry_lock_timeout_fail(void *p1, void *p2, void *p3)
 {
-	zassert_true(k_mutex_lock((struct k_mutex *)p1, TIMEOUT - 100) != 0, NULL);
+	ztest_true(k_mutex_lock((struct k_mutex *)p1, TIMEOUT - 100) != 0, NULL);
 	TC_PRINT("bypass locked resource from spawn thread\n");
 }
 
 static void tThread_entry_lock_timeout_pass(void *p1, void *p2, void *p3)
 {
-	zassert_true(k_mutex_lock((struct k_mutex *)p1, TIMEOUT + 100) == 0, NULL);
+	ztest_true(k_mutex_lock((struct k_mutex *)p1, TIMEOUT + 100) == 0, NULL);
 	TC_PRINT("access resource from spawn thread\n");
 	k_mutex_unlock((struct k_mutex *)p1);
 }
@@ -78,13 +78,13 @@ static void tmutex_test_lock_timeout(struct k_mutex *pmutex,
 static void tmutex_test_lock_unlock(struct k_mutex *pmutex)
 {
 	k_mutex_init(pmutex);
-	zassert_true(k_mutex_lock(pmutex, K_FOREVER) == 0,
+	ztest_true(k_mutex_lock(pmutex, K_FOREVER) == 0,
 		     "fail to lock K_FOREVER");
 	k_mutex_unlock(pmutex);
-	zassert_true(k_mutex_lock(pmutex, K_NO_WAIT) == 0,
+	ztest_true(k_mutex_lock(pmutex, K_NO_WAIT) == 0,
 		     "fail to lock K_NO_WAIT");
 	k_mutex_unlock(pmutex);
-	zassert_true(k_mutex_lock(pmutex, TIMEOUT) == 0,
+	ztest_true(k_mutex_lock(pmutex, TIMEOUT) == 0,
 		     "fail to lock TIMEOUT");
 	k_mutex_unlock(pmutex);
 }

--- a/tests/kernel/mutex/sys_mutex/src/main.c
+++ b/tests/kernel/mutex/sys_mutex/src/main.c
@@ -281,15 +281,15 @@ void test_mutex(void)
 
 	for (i = 0; i < 4; i++) {
 		rv = sys_mutex_lock(mutexes[i], K_NO_WAIT);
-		zassert_equal(rv, 0, "Failed to lock mutex %p\n", mutexes[i]);
+		ztest_equal(rv, 0, "Failed to lock mutex %p\n", mutexes[i]);
 		k_sleep(K_SECONDS(1));
 
 		rv = k_thread_priority_get(k_current_get());
-		zassert_equal(rv, priority[i], "expected priority %d, not %d\n",
+		ztest_equal(rv, priority[i], "expected priority %d, not %d\n",
 			      priority[i], rv);
 
 		/* Catch any errors from other threads */
-		zassert_equal(tc_rc, TC_PASS, NULL);
+		ztest_equal(tc_rc, TC_PASS, NULL);
 	}
 
 	/* ~ 4 seconds have passed */
@@ -302,14 +302,14 @@ void test_mutex(void)
 	/* ~ 5 seconds have passed */
 
 	rv = k_thread_priority_get(k_current_get());
-	zassert_equal(rv, 6, "%s timed out and out priority should drop.\n",
+	ztest_equal(rv, 6, "%s timed out and out priority should drop.\n",
 		      "thread_05");
-	zassert_equal(rv, 6, "Expected priority %d, not %d\n", 6, rv);
+	ztest_equal(rv, 6, "Expected priority %d, not %d\n", 6, rv);
 
 	sys_mutex_unlock(&mutex_4);
 	rv = k_thread_priority_get(k_current_get());
-	zassert_equal(rv, 7, "Gave %s and priority should drop.\n", "mutex_4");
-	zassert_equal(rv, 7, "Expected priority %d, not %d\n", 7, rv);
+	ztest_equal(rv, 7, "Gave %s and priority should drop.\n", "mutex_4");
+	ztest_equal(rv, 7, "Expected priority %d, not %d\n", 7, rv);
 
 	k_sleep(K_SECONDS(1));       /* thread_07 should time out */
 
@@ -317,29 +317,29 @@ void test_mutex(void)
 
 	for (i = 0; i < 3; i++) {
 		rv = k_thread_priority_get(k_current_get());
-		zassert_equal(rv, droppri[i], "Expected priority %d, not %d\n",
+		ztest_equal(rv, droppri[i], "Expected priority %d, not %d\n",
 			      droppri[i], rv);
 		sys_mutex_unlock(givemutex[i]);
 
-		zassert_equal(tc_rc, TC_PASS, NULL);
+		ztest_equal(tc_rc, TC_PASS, NULL);
 	}
 
 	rv = k_thread_priority_get(k_current_get());
-	zassert_equal(rv, 10, "Expected priority %d, not %d\n", 10, rv);
+	ztest_equal(rv, 10, "Expected priority %d, not %d\n", 10, rv);
 
 	k_sleep(K_SECONDS(1));     /* Give thread_11 time to run */
 
-	zassert_equal(tc_rc, TC_PASS, NULL);
+	ztest_equal(tc_rc, TC_PASS, NULL);
 
 	/* test recursive locking using a private mutex */
 
 	TC_PRINT("Testing recursive locking\n");
 
 	rv = sys_mutex_lock(&private_mutex, K_NO_WAIT);
-	zassert_equal(rv, 0, "Failed to lock private mutex");
+	ztest_equal(rv, 0, "Failed to lock private mutex");
 
 	rv = sys_mutex_lock(&private_mutex, K_NO_WAIT);
-	zassert_equal(rv, 0, "Failed to recursively lock private mutex");
+	ztest_equal(rv, 0, "Failed to recursively lock private mutex");
 
 	/* Start thread */
 	k_thread_create(&thread_12_thread_data, thread_12_stack_area, STACKSIZE,
@@ -351,10 +351,10 @@ void test_mutex(void)
 	sys_mutex_unlock(&private_mutex); /* thread_12 should now have lock */
 
 	rv = sys_mutex_lock(&private_mutex, K_NO_WAIT);
-	zassert_equal(rv, -EBUSY, "Unexpectedly got lock on private mutex");
+	ztest_equal(rv, -EBUSY, "Unexpectedly got lock on private mutex");
 
 	rv = sys_mutex_lock(&private_mutex, K_SECONDS(1));
-	zassert_equal(rv, 0, "Failed to re-obtain lock on private mutex");
+	ztest_equal(rv, 0, "Failed to re-obtain lock on private mutex");
 
 	sys_mutex_unlock(&private_mutex);
 
@@ -368,19 +368,19 @@ void test_supervisor_access(void)
 #ifdef CONFIG_USERSPACE
 	/* coverage for get_k_mutex checks */
 	rv = sys_mutex_lock((struct sys_mutex *)NULL, K_NO_WAIT);
-	zassert_true(rv == -EINVAL, "accepted bad mutex pointer");
+	ztest_true(rv == -EINVAL, "accepted bad mutex pointer");
 	rv = sys_mutex_lock((struct sys_mutex *)k_current_get(), K_NO_WAIT);
-	zassert_true(rv == -EINVAL, "accepted object that was not a mutex");
+	ztest_true(rv == -EINVAL, "accepted object that was not a mutex");
 	rv = sys_mutex_unlock((struct sys_mutex *)NULL);
-	zassert_true(rv == -EINVAL, "accepted bad mutex pointer");
+	ztest_true(rv == -EINVAL, "accepted bad mutex pointer");
 	rv = sys_mutex_unlock((struct sys_mutex *)k_current_get());
-	zassert_true(rv == -EINVAL, "accepted object that was not a mutex");
+	ztest_true(rv == -EINVAL, "accepted object that was not a mutex");
 #endif /* CONFIG_USERSPACE */
 
 	rv = sys_mutex_unlock(&not_my_mutex);
-	zassert_true(rv == -EPERM, "unlocked a mutex that wasn't owner");
+	ztest_true(rv == -EPERM, "unlocked a mutex that wasn't owner");
 	rv = sys_mutex_unlock(&bad_count_mutex);
-	zassert_true(rv == -EINVAL, "mutex wasn't locked");
+	ztest_true(rv == -EINVAL, "mutex wasn't locked");
 }
 
 void test_user_access(void)
@@ -389,9 +389,9 @@ void test_user_access(void)
 	int rv;
 
 	rv = sys_mutex_lock(&no_access_mutex, K_NO_WAIT);
-	zassert_true(rv == -EACCES, "accessed mutex not in memory domain");
+	ztest_true(rv == -EACCES, "accessed mutex not in memory domain");
 	rv = sys_mutex_unlock(&no_access_mutex);
-	zassert_true(rv == -EACCES, "accessed mutex not in memory domain");
+	ztest_true(rv == -EACCES, "accessed mutex not in memory domain");
 #else
 	ztest_test_skip();
 #endif /* CONFIG_USERSPACE */

--- a/tests/kernel/obj_tracing/src/main.c
+++ b/tests/kernel/obj_tracing/src/main.c
@@ -109,7 +109,7 @@ static void object_monitor(void)
 
 	thread_counter += thread_monitor();
 
-	zassert_true(((thread_counter == (TOTAL_THREADS + initial_count)) &&
+	ztest_true(((thread_counter == (TOTAL_THREADS + initial_count)) &&
 		      (obj_counter == TOTAL_OBJECTS)), "test failed");
 }
 

--- a/tests/kernel/obj_tracing/src/trace_obj.c
+++ b/tests/kernel/obj_tracing/src/trace_obj.c
@@ -77,7 +77,7 @@ static void get_obj_count(int obj_type)
 			obj_list = SYS_TRACING_NEXT(struct k_timer, k_timer,
 						    obj_list);
 		}
-		zassert_equal(obj_found, 2,  "Didn't find timer objects");
+		ztest_equal(obj_found, 2,  "Didn't find timer objects");
 		break;
 	case MEM_SLAB:
 		k_mem_slab_init(&mslab, slab, BLOCK_SIZE, NUM_BLOCKS);
@@ -90,7 +90,7 @@ static void get_obj_count(int obj_type)
 			obj_list = SYS_TRACING_NEXT(struct k_mem_slab,
 						    k_mem_slab, obj_list);
 		}
-		zassert_equal(obj_found, 2, "Didn't find mem_slab objects");
+		ztest_equal(obj_found, 2, "Didn't find mem_slab objects");
 		break;
 	case SEM:
 		k_sem_init(&sema, 0, 1);
@@ -103,7 +103,7 @@ static void get_obj_count(int obj_type)
 			obj_list = SYS_TRACING_NEXT(struct k_sem, k_sem,
 						    obj_list);
 		}
-		zassert_equal(obj_found, 2, "Didn't find semaphore objects");
+		ztest_equal(obj_found, 2, "Didn't find semaphore objects");
 		break;
 	case MUTEX:
 		k_mutex_init(&mutex);
@@ -116,7 +116,7 @@ static void get_obj_count(int obj_type)
 			obj_list = SYS_TRACING_NEXT(struct k_mutex, k_mutex,
 						    obj_list);
 		}
-		zassert_equal(obj_found, 2, "Didn't find mutex objects");
+		ztest_equal(obj_found, 2, "Didn't find mutex objects");
 		break;
 	case STACK:
 		k_stack_init(&stack, sdata, NUM_BLOCKS);
@@ -129,7 +129,7 @@ static void get_obj_count(int obj_type)
 			obj_list = SYS_TRACING_NEXT(struct k_stack, k_stack,
 						    obj_list);
 		}
-		zassert_equal(obj_found, 2, "Didn't find stack objects");
+		ztest_equal(obj_found, 2, "Didn't find stack objects");
 		break;
 	case MSGQ:
 		k_msgq_init(&msgq, buffer, BLOCK_SIZE, NUM_BLOCKS);
@@ -142,7 +142,7 @@ static void get_obj_count(int obj_type)
 			obj_list = SYS_TRACING_NEXT(struct k_msgq, k_msgq,
 						    obj_list);
 		}
-		zassert_equal(obj_found, 2, "Didn't find msgq objects");
+		ztest_equal(obj_found, 2, "Didn't find msgq objects");
 		break;
 	case MBOX:
 		k_mbox_init(&mbox);
@@ -155,7 +155,7 @@ static void get_obj_count(int obj_type)
 			obj_list = SYS_TRACING_NEXT(struct k_mbox, k_mbox,
 						    obj_list);
 		}
-		zassert_equal(obj_found, 2, "Didn't find mbox objects");
+		ztest_equal(obj_found, 2, "Didn't find mbox objects");
 		break;
 	case PIPE:
 		k_pipe_init(&pipe, data, 8);
@@ -168,7 +168,7 @@ static void get_obj_count(int obj_type)
 			obj_list = SYS_TRACING_NEXT(struct k_pipe, k_pipe,
 						    obj_list);
 		}
-		zassert_equal(obj_found, 2, "Didn't find pipe objects");
+		ztest_equal(obj_found, 2, "Didn't find pipe objects");
 		break;
 	case QUEUE:
 		k_queue_init(&queue);
@@ -181,10 +181,10 @@ static void get_obj_count(int obj_type)
 			obj_list = SYS_TRACING_NEXT(struct k_queue, k_queue,
 						    obj_list);
 		}
-		zassert_equal(obj_found, 2, "Didn't find queue objects\n");
+		ztest_equal(obj_found, 2, "Didn't find queue objects\n");
 		break;
 	default:
-		zassert_unreachable("Undefined kernel object");
+		ztest_unreachable("Undefined kernel object");
 	}
 }
 

--- a/tests/kernel/pending/src/main.c
+++ b/tests/kernel/pending/src/main.c
@@ -308,7 +308,7 @@ void test_pending_fifo(void)
 	 */
 
 	TC_PRINT("Testing preemptible threads block on fifos ...\n");
-	zassert_false((coop_high_state != FIFO_TEST_START) ||
+	ztest_false((coop_high_state != FIFO_TEST_START) ||
 		      (coop_low_state != FIFO_TEST_START) ||
 		      (task_high_state != FIFO_TEST_START) ||
 		      (task_low_state != FIFO_TEST_START), NULL);
@@ -322,7 +322,7 @@ void test_pending_fifo(void)
 	 */
 
 	TC_PRINT("Testing fifos time-out in correct order ...\n");
-	zassert_false((task_low_state != FIFO_TEST_START + 1) ||
+	ztest_false((task_low_state != FIFO_TEST_START + 1) ||
 		      (task_high_state != FIFO_TEST_START + 2) ||
 		      (coop_low_state != FIFO_TEST_START + 3) ||
 		      (coop_high_state != FIFO_TEST_START + 4),
@@ -346,7 +346,7 @@ void test_pending_fifo(void)
 	k_fifo_put(&fifo, &fifo_test_data[2]);
 	k_fifo_put(&fifo, &fifo_test_data[3]);
 
-	zassert_false((coop_high_state != FIFO_TEST_END + 1) ||
+	ztest_false((coop_high_state != FIFO_TEST_END + 1) ||
 		      (coop_low_state != FIFO_TEST_END + 2) ||
 		      (task_high_state != FIFO_TEST_END + 3) ||
 		      (task_low_state != FIFO_TEST_END + 4),
@@ -380,7 +380,7 @@ void test_pending_lifo(void)
 	 */
 
 	TC_PRINT("Testing preemptible threads block on lifos ...\n");
-	zassert_false((coop_high_state != LIFO_TEST_START) ||
+	ztest_false((coop_high_state != LIFO_TEST_START) ||
 		      (coop_low_state != LIFO_TEST_START) ||
 		      (task_high_state != LIFO_TEST_START) ||
 		      (task_low_state != LIFO_TEST_START), NULL);
@@ -389,7 +389,7 @@ void test_pending_lifo(void)
 	k_sleep(NUM_SECONDS(2));
 
 	TC_PRINT("Testing lifos time-out in correct order ...\n");
-	zassert_false((task_low_state != LIFO_TEST_START + 1) ||
+	ztest_false((task_low_state != LIFO_TEST_START + 1) ||
 		      (task_high_state != LIFO_TEST_START + 2) ||
 		      (coop_low_state != LIFO_TEST_START + 3) ||
 		      (coop_high_state != LIFO_TEST_START + 4),
@@ -413,7 +413,7 @@ void test_pending_lifo(void)
 	k_lifo_put(&lifo, &lifo_test_data[3]);
 
 	TC_PRINT("Testing lifos delivered data correctly ...\n");
-	zassert_false((coop_high_state != LIFO_TEST_END + 1) ||
+	ztest_false((coop_high_state != LIFO_TEST_END + 1) ||
 		      (coop_low_state != LIFO_TEST_END + 2) ||
 		      (task_high_state != LIFO_TEST_END + 3) ||
 		      (task_low_state != LIFO_TEST_END + 4),
@@ -446,15 +446,15 @@ void test_pending_timer(void)
 	 */
 
 	TC_PRINT("Testing preemptible thread waiting on timer ...\n");
-	zassert_equal(timer_end_tick, 0, "Task did not pend on timer");
+	ztest_equal(timer_end_tick, 0, "Task did not pend on timer");
 
 	/* Let the timer expire */
 	k_sleep(NUM_SECONDS(2));
 
-	zassert_false((timer_end_tick < timer_start_tick + NUM_SECONDS(1)),
+	ztest_false((timer_end_tick < timer_start_tick + NUM_SECONDS(1)),
 			"Task waiting on timer error");
 
-	zassert_equal(timer_data, NON_NULL_PTR,
+	ztest_equal(timer_data, NON_NULL_PTR,
 				"Incorrect data from timer");
 
 	k_sem_give(&end_test_sem);

--- a/tests/kernel/pipe/pipe/src/test_pipe.c
+++ b/tests/kernel/pipe/pipe/src/test_pipe.c
@@ -153,13 +153,13 @@ void pipe_put_single(void)
 					  single_elements[index].size, &written,
 					  min_xfer, K_NO_WAIT);
 
-		zassert_true((return_value ==
+		ztest_true((return_value ==
 			      single_elements[index].return_value),
 			     " Return value of k_pipe_put missmatch at index = %d expected =%d received = %d\n",
 			     index,
 			     single_elements[index].return_value, return_value);
 
-		zassert_true((written == single_elements[index].sent_bytes),
+		ztest_true((written == single_elements[index].sent_bytes),
 			     "Bytes written missmatch written is %d but expected is %d index = %d\n",
 			     written,
 			     single_elements[index].sent_bytes, index);
@@ -191,17 +191,17 @@ void pipe_get_single(void *p1, void *p2, void *p3)
 					  min_xfer, K_NO_WAIT);
 
 
-		zassert_true((return_value ==
+		ztest_true((return_value ==
 			      single_elements[index].return_value),
 			     "Return value of k_pipe_get missmatch at index = %d expected =%d received = %d\n",
 			     index, single_elements[index].return_value,
 			     return_value);
 
-		zassert_true((read == single_elements[index].sent_bytes),
+		ztest_true((read == single_elements[index].sent_bytes),
 			     "Bytes read missmatch read is %d but expected is %d index = %d\n",
 			     read, single_elements[index].sent_bytes, index);
 
-		zassert_true(rx_buffer_check(rx_buffer, read) == read,
+		ztest_true(rx_buffer_check(rx_buffer, read) == read,
 			     "Bytes read are not matching at index= %d\n expected =%d but received= %d",
 			     index, read, rx_buffer_check(rx_buffer, read));
 		k_sem_give(&put_sem);
@@ -228,14 +228,14 @@ void pipe_put_multiple(void)
 					  &written,
 					  min_xfer, K_NO_WAIT);
 
-		zassert_true((return_value ==
+		ztest_true((return_value ==
 			      multiple_elements[index].return_value),
 			     "Return value of k_pipe_put missmatch at index = %d expected =%d received = %d\n",
 			     index,
 			     multiple_elements[index].return_value,
 			     return_value);
 
-		zassert_true((written == multiple_elements[index].sent_bytes),
+		ztest_true((written == multiple_elements[index].sent_bytes),
 			     "Bytes written missmatch written is %d but expected is %d index = %d\n",
 			     written,
 			     multiple_elements[index].sent_bytes, index);
@@ -269,17 +269,17 @@ void pipe_get_multiple(void *p1, void *p2, void *p3)
 					  min_xfer, K_NO_WAIT);
 
 
-		zassert_true((return_value ==
+		ztest_true((return_value ==
 			      multiple_elements[index].return_value),
 			     "Return value of k_pipe_get missmatch at index = %d expected =%d received = %d\n",
 			     index, multiple_elements[index].return_value,
 			     return_value);
 
-		zassert_true((read == multiple_elements[index].sent_bytes),
+		ztest_true((read == multiple_elements[index].sent_bytes),
 			     "Bytes read missmatch read is %d but expected is %d index = %d\n",
 			     read, multiple_elements[index].sent_bytes, index);
 
-		zassert_true(rx_buffer_check(rx_buffer, read) == read,
+		ztest_true(rx_buffer_check(rx_buffer, read) == read,
 			     "Bytes read are not matching at index= %d\n expected =%d but received= %d",
 			     index, read, rx_buffer_check(rx_buffer, read));
 
@@ -303,11 +303,11 @@ void pipe_put_forever_wait(void)
 				  PIPE_SIZE, &written,
 				  PIPE_SIZE, K_FOREVER);
 
-	zassert_true(return_value == RETURN_SUCCESS,
+	ztest_true(return_value == RETURN_SUCCESS,
 		     "k_pipe_put failed expected = 0 received = %d\n",
 		     return_value);
 
-	zassert_true(written == PIPE_SIZE,
+	ztest_true(written == PIPE_SIZE,
 		     "k_pipe_put written failed expected = %d received = %d\n",
 		     PIPE_SIZE, written);
 
@@ -319,11 +319,11 @@ void pipe_put_forever_wait(void)
 				  PIPE_SIZE, &written,
 				  PIPE_SIZE, K_FOREVER);
 
-	zassert_true(return_value == RETURN_SUCCESS,
+	ztest_true(return_value == RETURN_SUCCESS,
 		     "k_pipe_put failed expected = 0 received = %d\n",
 		     return_value);
 
-	zassert_true(written == PIPE_SIZE,
+	ztest_true(written == PIPE_SIZE,
 		     "k_pipe_put written failed expected = %d received = %d\n",
 		     PIPE_SIZE, written);
 
@@ -332,11 +332,11 @@ void pipe_put_forever_wait(void)
 				  PIPE_SIZE, &written,
 				  ATLEAST_1, K_FOREVER);
 
-	zassert_true(return_value == RETURN_SUCCESS,
+	ztest_true(return_value == RETURN_SUCCESS,
 		     "k_pipe_put failed expected = 0 received = %d\n",
 		     return_value);
 
-	zassert_true(written == PIPE_SIZE,
+	ztest_true(written == PIPE_SIZE,
 		     "k_pipe_put written failed expected = %d received = %d\n",
 		     PIPE_SIZE, written);
 
@@ -356,11 +356,11 @@ void pipe_get_forever_wait(void *pi, void *p2, void *p3)
 				  PIPE_SIZE, &read,
 				  PIPE_SIZE, K_FOREVER);
 
-	zassert_true(return_value == RETURN_SUCCESS,
+	ztest_true(return_value == RETURN_SUCCESS,
 		     "k_pipe_get failed expected = 0 received = %d\n",
 		     return_value);
 
-	zassert_true(read == PIPE_SIZE,
+	ztest_true(read == PIPE_SIZE,
 		     "k_pipe_put written failed expected = %d received = %d\n",
 		     PIPE_SIZE, read);
 
@@ -369,11 +369,11 @@ void pipe_get_forever_wait(void *pi, void *p2, void *p3)
 				  PIPE_SIZE, &read,
 				  ATLEAST_1, K_FOREVER);
 
-	zassert_true(return_value == RETURN_SUCCESS,
+	ztest_true(return_value == RETURN_SUCCESS,
 		     "k_pipe_get failed expected = 0 received = %d\n",
 		     return_value);
 
-	zassert_true(read == PIPE_SIZE,
+	ztest_true(read == PIPE_SIZE,
 		     "k_pipe_put written failed expected = %d received = %d\n",
 		     PIPE_SIZE, read);
 
@@ -382,11 +382,11 @@ void pipe_get_forever_wait(void *pi, void *p2, void *p3)
 				  PIPE_SIZE, &read,
 				  ATLEAST_1, K_FOREVER);
 
-	zassert_true(return_value == RETURN_SUCCESS,
+	ztest_true(return_value == RETURN_SUCCESS,
 		     "k_pipe_get failed expected = 0 received = %d\n",
 		     return_value);
 
-	zassert_true(read == PIPE_SIZE,
+	ztest_true(read == PIPE_SIZE,
 		     "k_pipe_put written failed expected = %d received = %d\n",
 		     PIPE_SIZE, read);
 
@@ -407,11 +407,11 @@ void pipe_put_timeout(void)
 				  PIPE_SIZE, &written,
 				  PIPE_SIZE, TIMEOUT_VAL);
 
-	zassert_true(return_value == RETURN_SUCCESS,
+	ztest_true(return_value == RETURN_SUCCESS,
 		     "k_pipe_put failed expected = 0 received = %d\n",
 		     return_value);
 
-	zassert_true(written == PIPE_SIZE,
+	ztest_true(written == PIPE_SIZE,
 		     "k_pipe_put written failed expected = %d received = %d\n",
 		     PIPE_SIZE, written);
 
@@ -421,11 +421,11 @@ void pipe_put_timeout(void)
 				  PIPE_SIZE, &written,
 				  PIPE_SIZE, TIMEOUT_VAL);
 
-	zassert_true(return_value == -EAGAIN,
+	ztest_true(return_value == -EAGAIN,
 		     "k_pipe_put failed expected = -EAGAIN received = %d\n",
 		     return_value);
 
-	zassert_true(written == 0,
+	ztest_true(written == 0,
 		     "k_pipe_put written failed expected = %d received = %d\n",
 		     PIPE_SIZE, written);
 
@@ -436,11 +436,11 @@ void pipe_put_timeout(void)
 				  PIPE_SIZE, &written,
 				  ATLEAST_1, TIMEOUT_VAL);
 
-	zassert_true(return_value == -EAGAIN,
+	ztest_true(return_value == -EAGAIN,
 		     "k_pipe_put failed expected = -EAGAIN received = %d\n",
 		     return_value);
 
-	zassert_true(written == 0,
+	ztest_true(written == 0,
 		     "k_pipe_put written failed expected = %d received = %d\n",
 		     PIPE_SIZE, written);
 
@@ -451,11 +451,11 @@ void pipe_put_timeout(void)
 				  PIPE_SIZE, &written,
 				  PIPE_SIZE, TIMEOUT_VAL);
 
-	zassert_true(return_value == RETURN_SUCCESS,
+	ztest_true(return_value == RETURN_SUCCESS,
 		     "k_pipe_put failed expected = 0 received = %d\n",
 		     return_value);
 
-	zassert_true(written == PIPE_SIZE,
+	ztest_true(written == PIPE_SIZE,
 		     "k_pipe_put written failed expected = %d received = %d\n",
 		     PIPE_SIZE, written);
 
@@ -464,11 +464,11 @@ void pipe_put_timeout(void)
 				  PIPE_SIZE, &written,
 				  ATLEAST_1, TIMEOUT_VAL);
 
-	zassert_true(return_value == RETURN_SUCCESS,
+	ztest_true(return_value == RETURN_SUCCESS,
 		     "k_pipe_put failed expected = 0 received = %d\n",
 		     return_value);
 
-	zassert_true(written == PIPE_SIZE,
+	ztest_true(written == PIPE_SIZE,
 		     "k_pipe_put written failed expected = %d received = %d\n",
 		     PIPE_SIZE, written);
 }
@@ -487,11 +487,11 @@ void pipe_get_timeout(void *pi, void *p2, void *p3)
 				  PIPE_SIZE, &read,
 				  PIPE_SIZE, TIMEOUT_VAL);
 
-	zassert_true(return_value == RETURN_SUCCESS,
+	ztest_true(return_value == RETURN_SUCCESS,
 		     "k_pipe_get failed expected = 0 received = %d\n",
 		     return_value);
 
-	zassert_true(read == PIPE_SIZE,
+	ztest_true(read == PIPE_SIZE,
 		     "k_pipe_put written failed expected = %d received = %d\n",
 		     PIPE_SIZE, read);
 
@@ -500,11 +500,11 @@ void pipe_get_timeout(void *pi, void *p2, void *p3)
 				  PIPE_SIZE, &read,
 				  ATLEAST_1, TIMEOUT_VAL);
 
-	zassert_true(return_value == RETURN_SUCCESS,
+	ztest_true(return_value == RETURN_SUCCESS,
 		     "k_pipe_get failed expected = 0 received = %d\n",
 		     return_value);
 
-	zassert_true(read == PIPE_SIZE,
+	ztest_true(read == PIPE_SIZE,
 		     "k_pipe_put written failed expected = %d received = %d\n",
 		     PIPE_SIZE, read);
 
@@ -513,11 +513,11 @@ void pipe_get_timeout(void *pi, void *p2, void *p3)
 				  PIPE_SIZE, &read,
 				  ATLEAST_1, TIMEOUT_VAL);
 
-	zassert_true(return_value == RETURN_SUCCESS,
+	ztest_true(return_value == RETURN_SUCCESS,
 		     "k_pipe_get failed expected = 0 received = %d\n",
 		     return_value);
 
-	zassert_true(read == PIPE_SIZE,
+	ztest_true(read == PIPE_SIZE,
 		     "k_pipe_put written failed expected = %d received = %d\n",
 		     PIPE_SIZE, read);
 
@@ -539,7 +539,7 @@ void pipe_get_on_empty_pipe(void)
 					  read_size, &read,
 					  read_size, K_NO_WAIT);
 
-		zassert_true(return_value == -EIO,
+		ztest_true(return_value == -EIO,
 			     "k_pipe_get failed expected = -EIO received = %d\n",
 			     return_value);
 
@@ -547,7 +547,7 @@ void pipe_get_on_empty_pipe(void)
 					  read_size, &read,
 					  ATLEAST_1, K_NO_WAIT);
 
-		zassert_true(return_value == -EIO,
+		ztest_true(return_value == -EIO,
 			     "k_pipe_get failed expected = -EIO received = %d\n",
 			     return_value);
 
@@ -555,11 +555,11 @@ void pipe_get_on_empty_pipe(void)
 					  read_size, &read,
 					  NO_CONSTRAINT, K_NO_WAIT);
 
-		zassert_true(return_value == RETURN_SUCCESS,
+		ztest_true(return_value == RETURN_SUCCESS,
 			     "k_pipe_get failed expected = 0 received = %d\n",
 			     return_value);
 
-		zassert_true(read == 0,
+		ztest_true(read == 0,
 			     "k_pipe_put written failed expected = %d received = %d\n",
 			     PIPE_SIZE, read);
 	}
@@ -588,13 +588,13 @@ void pipe_put_forever_timeout(void)
 					  wait_elements[index].size, &written,
 					  min_xfer, K_FOREVER);
 
-		zassert_true((return_value ==
+		ztest_true((return_value ==
 			      wait_elements[index].return_value),
 			     "Return value of k_pipe_put missmatch at index = %d expected =%d received = %d\n",
 			     index, wait_elements[index].return_value,
 			     return_value);
 
-		zassert_true((written == wait_elements[index].sent_bytes),
+		ztest_true((written == wait_elements[index].sent_bytes),
 			     "Bytes written missmatch written is %d but expected is %d index = %d\n",
 			     written, wait_elements[index].sent_bytes, index);
 
@@ -622,13 +622,13 @@ void pipe_get_forever_timeout(void *p1, void *p2, void *p3)
 					  min_xfer, K_FOREVER);
 
 
-		zassert_true((return_value ==
+		ztest_true((return_value ==
 			      wait_elements[index].return_value),
 			     "Return value of k_pipe_get missmatch at index = %d expected =%d received = %d\n",
 			     index, wait_elements[index].return_value,
 			     return_value);
 
-		zassert_true((read == wait_elements[index].sent_bytes),
+		ztest_true((read == wait_elements[index].sent_bytes),
 			     "Bytes read missmatch read is %d but expected is %d index = %d\n",
 			     read, wait_elements[index].sent_bytes, index);
 
@@ -658,13 +658,13 @@ void pipe_put_get_timeout(void)
 					  min_xfer, TIMEOUT_200MSEC);
 
 
-		zassert_true((return_value ==
+		ztest_true((return_value ==
 			      timeout_elements[index].return_value),
 			     "Return value of k_pipe_get missmatch at index = %d expected =%d received = %d\n",
 			     index, timeout_elements[index].return_value,
 			     return_value);
 
-		zassert_true((read == timeout_elements[index].sent_bytes),
+		ztest_true((read == timeout_elements[index].sent_bytes),
 			     "Bytes read missmatch read is %d but expected is %d index = %d\n",
 			     read, timeout_elements[index].sent_bytes, index);
 
@@ -823,6 +823,6 @@ void test_pipe_get_invalid_size(void)
 		   0, &read,
 		   1, TIMEOUT_200MSEC);
 
-	zassert_equal(ret, -EINVAL,
+	ztest_equal(ret, -EINVAL,
 		      "fault didn't occur for min_xfer <= bytes_to_read");
 }

--- a/tests/kernel/pipe/pipe_api/src/test_pipe_contexts.c
+++ b/tests/kernel/pipe/pipe_api/src/test_pipe_contexts.c
@@ -50,9 +50,9 @@ static void tpipe_put(struct k_pipe *ppipe, int timeout)
 		/**TESTPOINT: pipe put*/
 		to_wt = (PIPE_LEN - i) >= BYTES_TO_WRITE ?
 			BYTES_TO_WRITE : (PIPE_LEN - i);
-		zassert_false(k_pipe_put(ppipe, &data[i], to_wt,
+		ztest_false(k_pipe_put(ppipe, &data[i], to_wt,
 					 &wt_byte, 1, timeout), NULL);
-		zassert_true(wt_byte == to_wt || wt_byte == 1, NULL);
+		ztest_true(wt_byte == to_wt || wt_byte == 1, NULL);
 	}
 }
 
@@ -63,7 +63,7 @@ static void tpipe_block_put(struct k_pipe *ppipe, struct k_sem *sema,
 
 	for (int i = 0; i < PIPE_LEN; i += BYTES_TO_WRITE) {
 		/**TESTPOINT: pipe block put*/
-		zassert_equal(k_mem_pool_alloc(&mpool, &block, BYTES_TO_WRITE,
+		ztest_equal(k_mem_pool_alloc(&mpool, &block, BYTES_TO_WRITE,
 					       timeout), 0, NULL);
 		memcpy(block.data, &data[i], BYTES_TO_WRITE);
 		k_pipe_block_put(ppipe, &block, BYTES_TO_WRITE, sema);
@@ -83,12 +83,12 @@ static void tpipe_get(struct k_pipe *ppipe, int timeout)
 		/**TESTPOINT: pipe get*/
 		to_rd = (PIPE_LEN - i) >= BYTES_TO_READ ?
 			BYTES_TO_READ : (PIPE_LEN - i);
-		zassert_false(k_pipe_get(ppipe, &rx_data[i], to_rd,
+		ztest_false(k_pipe_get(ppipe, &rx_data[i], to_rd,
 					 &rd_byte, 1, timeout), NULL);
-		zassert_true(rd_byte == to_rd || rd_byte == 1, NULL);
+		ztest_true(rd_byte == to_rd || rd_byte == 1, NULL);
 	}
 	for (int i = 0; i < PIPE_LEN; i++) {
-		zassert_equal(rx_data[i], data[i], NULL);
+		ztest_equal(rx_data[i], data[i], NULL);
 	}
 }
 
@@ -150,9 +150,9 @@ static void tpipe_put_no_wait(struct k_pipe *ppipe)
 	/**TESTPOINT: pipe put*/
 		to_wt = (PIPE_LEN - i) >= BYTES_TO_WRITE ?
 			BYTES_TO_WRITE : (PIPE_LEN - i);
-		zassert_false(k_pipe_put(ppipe, &data[i], to_wt,
+		ztest_false(k_pipe_put(ppipe, &data[i], to_wt,
 					&wt_byte, 1, K_NO_WAIT), NULL);
-		zassert_true(wt_byte == to_wt || wt_byte == 1, NULL);
+		ztest_true(wt_byte == to_wt || wt_byte == 1, NULL);
 	}
 }
 
@@ -198,8 +198,8 @@ void test_pipe_user_thread2thread(void)
 
 	struct k_pipe *p = k_object_alloc(K_OBJ_PIPE);
 
-	zassert_true(p != NULL, NULL);
-	zassert_false(k_pipe_alloc_init(p, PIPE_LEN), NULL);
+	ztest_true(p != NULL, NULL);
+	ztest_false(k_pipe_alloc_init(p, PIPE_LEN), NULL);
 	tpipe_thread_thread(&pipe);
 
 	/**TESTPOINT: test K_PIPE_DEFINE pipe*/
@@ -273,8 +273,8 @@ void test_resource_pool_auto_free(void)
 	/* Pool has 2 blocks, both should succeed if kernel object and pipe
 	 * buffer are auto-freed when the allocating threads exit
 	 */
-	zassert_true(k_mem_pool_malloc(&test_pool, 64) != NULL, NULL);
-	zassert_true(k_mem_pool_malloc(&test_pool, 64) != NULL, NULL);
+	ztest_true(k_mem_pool_malloc(&test_pool, 64) != NULL, NULL);
+	ztest_true(k_mem_pool_malloc(&test_pool, 64) != NULL, NULL);
 }
 #endif
 
@@ -326,7 +326,7 @@ void test_half_pipe_saturating_block_put(void)
 	r[0] = k_mem_pool_alloc(&mpool, &blocks[0], BYTES_TO_WRITE, K_NO_WAIT);
 	r[1] = k_mem_pool_alloc(&mpool, &blocks[1], BYTES_TO_WRITE, K_NO_WAIT);
 	r[2] = k_mem_pool_alloc(&mpool, &blocks[2], BYTES_TO_WRITE, K_NO_WAIT);
-	zassert_true(r[0] == 0 && r[1] == 0 && r[2] == -ENOMEM, NULL);
+	ztest_true(r[0] == 0 && r[1] == 0 && r[2] == -ENOMEM, NULL);
 	k_mem_pool_free(&blocks[0]);
 	k_mem_pool_free(&blocks[1]);
 
@@ -367,16 +367,16 @@ void test_pipe_alloc(void)
 {
 	int ret;
 
-	zassert_false(k_pipe_alloc_init(&pipe_test_alloc, PIPE_LEN), NULL);
+	ztest_false(k_pipe_alloc_init(&pipe_test_alloc, PIPE_LEN), NULL);
 
 	tpipe_kthread_to_kthread(&pipe_test_alloc);
 	k_pipe_cleanup(&pipe_test_alloc);
 
-	zassert_false(k_pipe_alloc_init(&pipe_test_alloc, 0), NULL);
+	ztest_false(k_pipe_alloc_init(&pipe_test_alloc, 0), NULL);
 	k_pipe_cleanup(&pipe_test_alloc);
 
 	ret = k_pipe_alloc_init(&pipe_test_alloc, 1024);
-	zassert_true(ret == -ENOMEM,
+	ztest_true(ret == -ENOMEM,
 		"resource pool max block size is not smaller then requested buffer");
 }
 

--- a/tests/kernel/pipe/pipe_api/src/test_pipe_fail.c
+++ b/tests/kernel/pipe/pipe_api/src/test_pipe_fail.c
@@ -19,16 +19,16 @@ static void put_fail(struct k_pipe *p)
 {
 	size_t wt_byte = 0;
 
-	zassert_false(k_pipe_put(p, data, PIPE_LEN, &wt_byte,
+	ztest_false(k_pipe_put(p, data, PIPE_LEN, &wt_byte,
 				 1, K_FOREVER), NULL);
 	/**TESTPOINT: pipe put returns -EIO*/
-	zassert_equal(k_pipe_put(p, data, PIPE_LEN, &wt_byte,
+	ztest_equal(k_pipe_put(p, data, PIPE_LEN, &wt_byte,
 				 1, K_NO_WAIT), -EIO, NULL);
-	zassert_false(wt_byte, NULL);
+	ztest_false(wt_byte, NULL);
 	/**TESTPOINT: pipe put returns -EAGAIN*/
-	zassert_equal(k_pipe_put(p, data, PIPE_LEN, &wt_byte,
+	ztest_equal(k_pipe_put(p, data, PIPE_LEN, &wt_byte,
 				 1, TIMEOUT), -EAGAIN, NULL);
-	zassert_true(wt_byte < 1, NULL);
+	ztest_true(wt_byte < 1, NULL);
 }
 
 /**
@@ -52,8 +52,8 @@ void test_pipe_user_put_fail(void)
 {
 	struct k_pipe *p = k_object_alloc(K_OBJ_PIPE);
 
-	zassert_true(p != NULL, NULL);
-	zassert_false(k_pipe_alloc_init(p, PIPE_LEN), NULL);
+	ztest_true(p != NULL, NULL);
+	ztest_false(k_pipe_alloc_init(p, PIPE_LEN), NULL);
 
 	put_fail(p);
 }
@@ -65,13 +65,13 @@ static void get_fail(struct k_pipe *p)
 	size_t rd_byte = 0;
 
 	/**TESTPOINT: pipe put returns -EIO*/
-	zassert_equal(k_pipe_get(p, rx_data, PIPE_LEN, &rd_byte, 1,
+	ztest_equal(k_pipe_get(p, rx_data, PIPE_LEN, &rd_byte, 1,
 				 K_NO_WAIT), -EIO, NULL);
-	zassert_false(rd_byte, NULL);
+	ztest_false(rd_byte, NULL);
 	/**TESTPOINT: pipe put returns -EAGAIN*/
-	zassert_equal(k_pipe_get(p, rx_data, PIPE_LEN, &rd_byte, 1,
+	ztest_equal(k_pipe_get(p, rx_data, PIPE_LEN, &rd_byte, 1,
 				 TIMEOUT), -EAGAIN, NULL);
-	zassert_true(rd_byte < 1, NULL);
+	ztest_true(rd_byte < 1, NULL);
 }
 
 /**
@@ -96,8 +96,8 @@ void test_pipe_user_get_fail(void)
 {
 	struct k_pipe *p = k_object_alloc(K_OBJ_PIPE);
 
-	zassert_true(p != NULL, NULL);
-	zassert_false(k_pipe_alloc_init(p, PIPE_LEN), NULL);
+	ztest_true(p != NULL, NULL);
+	ztest_false(k_pipe_alloc_init(p, PIPE_LEN), NULL);
 
 	get_fail(p);
 }

--- a/tests/kernel/poll/src/test_poll.c
+++ b/tests/kernel/poll/src/test_poll.c
@@ -79,18 +79,18 @@ void test_poll_no_wait(void)
 	 * implementation
 	 */
 
-	zassert_equal(k_poll(events, INT_MAX, K_NO_WAIT), -EINVAL, NULL);
-	zassert_equal(k_poll(events, 4096, K_NO_WAIT), -ENOMEM, NULL);
+	ztest_equal(k_poll(events, INT_MAX, K_NO_WAIT), -EINVAL, NULL);
+	ztest_equal(k_poll(events, 4096, K_NO_WAIT), -ENOMEM, NULL);
 
 	/* Allow zero events */
-	zassert_equal(k_poll(events, 0, K_NO_WAIT), -EAGAIN, NULL);
+	ztest_equal(k_poll(events, 0, K_NO_WAIT), -EAGAIN, NULL);
 
 	struct k_poll_event bad_events[] = {
 		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SEM_AVAILABLE,
 					 K_POLL_NUM_MODES,
 					 &no_wait_sem),
 	};
-	zassert_equal(k_poll(bad_events, ARRAY_SIZE(bad_events), K_NO_WAIT),
+	ztest_equal(k_poll(bad_events, ARRAY_SIZE(bad_events), K_NO_WAIT),
 		      -EINVAL,
 		      NULL);
 
@@ -99,32 +99,32 @@ void test_poll_no_wait(void)
 					 K_POLL_MODE_NOTIFY_ONLY,
 					 &no_wait_sem),
 	};
-	zassert_equal(k_poll(bad_events2, ARRAY_SIZE(bad_events), K_NO_WAIT),
+	ztest_equal(k_poll(bad_events2, ARRAY_SIZE(bad_events), K_NO_WAIT),
 		      -EINVAL,
 		      NULL);
 #endif /* CONFIG_USERSPACE */
 
 	/* test polling events that are already ready */
-	zassert_false(k_fifo_alloc_put(&no_wait_fifo, &msg), NULL);
+	ztest_false(k_fifo_alloc_put(&no_wait_fifo, &msg), NULL);
 	k_poll_signal_raise(&no_wait_signal, SIGNAL_RESULT);
 
-	zassert_equal(k_poll(events, ARRAY_SIZE(events), K_NO_WAIT), 0, "");
+	ztest_equal(k_poll(events, ARRAY_SIZE(events), K_NO_WAIT), 0, "");
 
-	zassert_equal(events[0].state, K_POLL_STATE_SEM_AVAILABLE, "");
-	zassert_equal(k_sem_take(&no_wait_sem, K_NO_WAIT), 0, "");
+	ztest_equal(events[0].state, K_POLL_STATE_SEM_AVAILABLE, "");
+	ztest_equal(k_sem_take(&no_wait_sem, K_NO_WAIT), 0, "");
 
-	zassert_equal(events[1].state, K_POLL_STATE_FIFO_DATA_AVAILABLE, "");
+	ztest_equal(events[1].state, K_POLL_STATE_FIFO_DATA_AVAILABLE, "");
 	msg_ptr = k_fifo_get(&no_wait_fifo, 0);
-	zassert_not_null(msg_ptr, "");
-	zassert_equal(msg_ptr, &msg, "");
-	zassert_equal(msg_ptr->msg, FIFO_MSG_VALUE, "");
+	ztest_not_null(msg_ptr, "");
+	ztest_equal(msg_ptr, &msg, "");
+	ztest_equal(msg_ptr->msg, FIFO_MSG_VALUE, "");
 
-	zassert_equal(events[2].state, K_POLL_STATE_SIGNALED, "");
+	ztest_equal(events[2].state, K_POLL_STATE_SIGNALED, "");
 	k_poll_signal_check(&no_wait_signal, &signaled, &result);
-	zassert_not_equal(signaled, 0, "");
-	zassert_equal(result, SIGNAL_RESULT, "");
+	ztest_not_equal(signaled, 0, "");
+	ztest_equal(result, SIGNAL_RESULT, "");
 
-	zassert_equal(events[3].state, K_POLL_STATE_NOT_READY, "");
+	ztest_equal(events[3].state, K_POLL_STATE_NOT_READY, "");
 
 	/* verify events are not ready anymore (user has to clear them first) */
 	events[0].state = K_POLL_STATE_NOT_READY;
@@ -133,15 +133,15 @@ void test_poll_no_wait(void)
 	events[3].state = K_POLL_STATE_NOT_READY;
 	k_poll_signal_reset(&no_wait_signal);
 
-	zassert_equal(k_poll(events, ARRAY_SIZE(events), K_NO_WAIT), -EAGAIN,
+	ztest_equal(k_poll(events, ARRAY_SIZE(events), K_NO_WAIT), -EAGAIN,
 		      "");
-	zassert_equal(events[0].state, K_POLL_STATE_NOT_READY, "");
-	zassert_equal(events[1].state, K_POLL_STATE_NOT_READY, "");
-	zassert_equal(events[2].state, K_POLL_STATE_NOT_READY, "");
-	zassert_equal(events[3].state, K_POLL_STATE_NOT_READY, "");
+	ztest_equal(events[0].state, K_POLL_STATE_NOT_READY, "");
+	ztest_equal(events[1].state, K_POLL_STATE_NOT_READY, "");
+	ztest_equal(events[2].state, K_POLL_STATE_NOT_READY, "");
+	ztest_equal(events[3].state, K_POLL_STATE_NOT_READY, "");
 
-	zassert_not_equal(k_sem_take(&no_wait_sem, K_NO_WAIT), 0, "");
-	zassert_is_null(k_fifo_get(&no_wait_fifo, 0), "");
+	ztest_not_equal(k_sem_take(&no_wait_sem, K_NO_WAIT), 0, "");
+	ztest_is_null(k_fifo_get(&no_wait_fifo, 0), "");
 }
 
 /* verify k_poll() that has to wait */
@@ -220,26 +220,26 @@ void test_poll_wait(void)
 
 	k_thread_priority_set(k_current_get(), old_prio);
 
-	zassert_equal(rc, 0, "");
+	ztest_equal(rc, 0, "");
 
-	zassert_equal(wait_events[0].state, K_POLL_STATE_SEM_AVAILABLE, "");
-	zassert_equal(k_sem_take(&wait_sem, K_NO_WAIT), 0, "");
-	zassert_equal(wait_events[0].tag, TAG_0, "");
+	ztest_equal(wait_events[0].state, K_POLL_STATE_SEM_AVAILABLE, "");
+	ztest_equal(k_sem_take(&wait_sem, K_NO_WAIT), 0, "");
+	ztest_equal(wait_events[0].tag, TAG_0, "");
 
-	zassert_equal(wait_events[1].state,
+	ztest_equal(wait_events[1].state,
 		      K_POLL_STATE_FIFO_DATA_AVAILABLE, "");
 	msg_ptr = k_fifo_get(&wait_fifo, 0);
-	zassert_not_null(msg_ptr, "");
-	zassert_equal(msg_ptr, &wait_msg, "");
-	zassert_equal(msg_ptr->msg, FIFO_MSG_VALUE, "");
-	zassert_equal(wait_events[1].tag, TAG_1, "");
+	ztest_not_null(msg_ptr, "");
+	ztest_equal(msg_ptr, &wait_msg, "");
+	ztest_equal(msg_ptr->msg, FIFO_MSG_VALUE, "");
+	ztest_equal(wait_events[1].tag, TAG_1, "");
 
-	zassert_equal(wait_events[2].state, K_POLL_STATE_SIGNALED, "");
-	zassert_equal(wait_signal.signaled, 1, "");
-	zassert_equal(wait_signal.result, SIGNAL_RESULT, "");
-	zassert_equal(wait_events[2].tag, TAG_2, "");
+	ztest_equal(wait_events[2].state, K_POLL_STATE_SIGNALED, "");
+	ztest_equal(wait_signal.signaled, 1, "");
+	ztest_equal(wait_signal.result, SIGNAL_RESULT, "");
+	ztest_equal(wait_events[2].tag, TAG_2, "");
 
-	zassert_equal(wait_events[3].state, K_POLL_STATE_NOT_READY, "");
+	ztest_equal(wait_events[3].state, K_POLL_STATE_NOT_READY, "");
 
 	/* verify events are not ready anymore */
 	wait_events[0].state = K_POLL_STATE_NOT_READY;
@@ -248,18 +248,18 @@ void test_poll_wait(void)
 	wait_events[3].state = K_POLL_STATE_NOT_READY;
 	wait_signal.signaled = 0U;
 
-	zassert_equal(k_poll(wait_events, ARRAY_SIZE(wait_events),
+	ztest_equal(k_poll(wait_events, ARRAY_SIZE(wait_events),
 			     K_SECONDS(1)), -EAGAIN, "");
 
-	zassert_equal(wait_events[0].state, K_POLL_STATE_NOT_READY, "");
-	zassert_equal(wait_events[1].state, K_POLL_STATE_NOT_READY, "");
-	zassert_equal(wait_events[2].state, K_POLL_STATE_NOT_READY, "");
-	zassert_equal(wait_events[3].state, K_POLL_STATE_NOT_READY, "");
+	ztest_equal(wait_events[0].state, K_POLL_STATE_NOT_READY, "");
+	ztest_equal(wait_events[1].state, K_POLL_STATE_NOT_READY, "");
+	ztest_equal(wait_events[2].state, K_POLL_STATE_NOT_READY, "");
+	ztest_equal(wait_events[3].state, K_POLL_STATE_NOT_READY, "");
 
 	/* tags should not have been touched */
-	zassert_equal(wait_events[0].tag, TAG_0, "");
-	zassert_equal(wait_events[1].tag, TAG_1, "");
-	zassert_equal(wait_events[2].tag, TAG_2, "");
+	ztest_equal(wait_events[0].tag, TAG_0, "");
+	ztest_equal(wait_events[1].tag, TAG_1, "");
+	ztest_equal(wait_events[2].tag, TAG_2, "");
 
 	/*
 	 * Wait for 2 out of 3 non-ready events to become ready from a higher
@@ -276,21 +276,21 @@ void test_poll_wait(void)
 
 	k_thread_priority_set(k_current_get(), old_prio);
 
-	zassert_equal(rc, 0, "");
+	ztest_equal(rc, 0, "");
 
-	zassert_equal(wait_events[0].state, K_POLL_STATE_SEM_AVAILABLE, "");
-	zassert_equal(k_sem_take(&wait_sem, K_NO_WAIT), 0, "");
-	zassert_equal(wait_events[0].tag, TAG_0, "");
+	ztest_equal(wait_events[0].state, K_POLL_STATE_SEM_AVAILABLE, "");
+	ztest_equal(k_sem_take(&wait_sem, K_NO_WAIT), 0, "");
+	ztest_equal(wait_events[0].tag, TAG_0, "");
 
-	zassert_equal(wait_events[1].state, K_POLL_STATE_NOT_READY, "");
+	ztest_equal(wait_events[1].state, K_POLL_STATE_NOT_READY, "");
 	msg_ptr = k_fifo_get(&wait_fifo, K_NO_WAIT);
-	zassert_is_null(msg_ptr, "");
-	zassert_equal(wait_events[1].tag, TAG_1, "");
+	ztest_is_null(msg_ptr, "");
+	ztest_equal(wait_events[1].tag, TAG_1, "");
 
-	zassert_equal(wait_events[2].state, K_POLL_STATE_SIGNALED, "");
-	zassert_equal(wait_signal.signaled, 1, "");
-	zassert_equal(wait_signal.result, SIGNAL_RESULT, "");
-	zassert_equal(wait_events[2].tag, TAG_2, "");
+	ztest_equal(wait_events[2].state, K_POLL_STATE_SIGNALED, "");
+	ztest_equal(wait_signal.signaled, 1, "");
+	ztest_equal(wait_signal.result, SIGNAL_RESULT, "");
+	ztest_equal(wait_events[2].tag, TAG_2, "");
 
 	/*
 	 * Wait for each event to be ready from a lower priority thread, one at
@@ -311,60 +311,60 @@ void test_poll_wait(void)
 	/* semaphore */
 	rc = k_poll(wait_events, ARRAY_SIZE(wait_events), K_SECONDS(1));
 
-	zassert_equal(rc, 0, "");
+	ztest_equal(rc, 0, "");
 
-	zassert_equal(wait_events[0].state, K_POLL_STATE_SEM_AVAILABLE, "");
-	zassert_equal(k_sem_take(&wait_sem, K_NO_WAIT), 0, "");
-	zassert_equal(wait_events[0].tag, TAG_0, "");
+	ztest_equal(wait_events[0].state, K_POLL_STATE_SEM_AVAILABLE, "");
+	ztest_equal(k_sem_take(&wait_sem, K_NO_WAIT), 0, "");
+	ztest_equal(wait_events[0].tag, TAG_0, "");
 
-	zassert_equal(wait_events[1].state, K_POLL_STATE_NOT_READY, "");
+	ztest_equal(wait_events[1].state, K_POLL_STATE_NOT_READY, "");
 	msg_ptr = k_fifo_get(&wait_fifo, K_NO_WAIT);
-	zassert_is_null(msg_ptr, "");
-	zassert_equal(wait_events[1].tag, TAG_1, "");
+	ztest_is_null(msg_ptr, "");
+	ztest_equal(wait_events[1].tag, TAG_1, "");
 
-	zassert_equal(wait_events[2].state, K_POLL_STATE_NOT_READY, "");
-	zassert_equal(wait_events[2].tag, TAG_2, "");
+	ztest_equal(wait_events[2].state, K_POLL_STATE_NOT_READY, "");
+	ztest_equal(wait_events[2].tag, TAG_2, "");
 
 	wait_events[0].state = K_POLL_STATE_NOT_READY;
 
 	/* fifo */
 	rc = k_poll(wait_events, ARRAY_SIZE(wait_events), K_SECONDS(1));
 
-	zassert_equal(rc, 0, "");
+	ztest_equal(rc, 0, "");
 
-	zassert_equal(wait_events[0].state, K_POLL_STATE_NOT_READY, "");
-	zassert_equal(k_sem_take(&wait_sem, K_NO_WAIT), -EBUSY, "");
-	zassert_equal(wait_events[0].tag, TAG_0, "");
+	ztest_equal(wait_events[0].state, K_POLL_STATE_NOT_READY, "");
+	ztest_equal(k_sem_take(&wait_sem, K_NO_WAIT), -EBUSY, "");
+	ztest_equal(wait_events[0].tag, TAG_0, "");
 
-	zassert_equal(wait_events[1].state,
+	ztest_equal(wait_events[1].state,
 		      K_POLL_STATE_FIFO_DATA_AVAILABLE, "");
 	msg_ptr = k_fifo_get(&wait_fifo, K_NO_WAIT);
-	zassert_not_null(msg_ptr, "");
-	zassert_equal(wait_events[1].tag, TAG_1, "");
+	ztest_not_null(msg_ptr, "");
+	ztest_equal(wait_events[1].tag, TAG_1, "");
 
-	zassert_equal(wait_events[2].state, K_POLL_STATE_NOT_READY, "");
-	zassert_equal(wait_events[2].tag, TAG_2, "");
+	ztest_equal(wait_events[2].state, K_POLL_STATE_NOT_READY, "");
+	ztest_equal(wait_events[2].tag, TAG_2, "");
 
 	wait_events[1].state = K_POLL_STATE_NOT_READY;
 
 	/* poll signal */
 	rc = k_poll(wait_events, ARRAY_SIZE(wait_events), K_SECONDS(1));
 
-	zassert_equal(rc, 0, "");
+	ztest_equal(rc, 0, "");
 
-	zassert_equal(wait_events[0].state, K_POLL_STATE_NOT_READY, "");
-	zassert_equal(k_sem_take(&wait_sem, K_NO_WAIT), -EBUSY, "");
-	zassert_equal(wait_events[0].tag, TAG_0, "");
+	ztest_equal(wait_events[0].state, K_POLL_STATE_NOT_READY, "");
+	ztest_equal(k_sem_take(&wait_sem, K_NO_WAIT), -EBUSY, "");
+	ztest_equal(wait_events[0].tag, TAG_0, "");
 
-	zassert_equal(wait_events[1].state, K_POLL_STATE_NOT_READY, "");
+	ztest_equal(wait_events[1].state, K_POLL_STATE_NOT_READY, "");
 	msg_ptr = k_fifo_get(&wait_fifo, K_NO_WAIT);
-	zassert_is_null(msg_ptr, "");
-	zassert_equal(wait_events[1].tag, TAG_1, "");
+	ztest_is_null(msg_ptr, "");
+	ztest_equal(wait_events[1].tag, TAG_1, "");
 
-	zassert_equal(wait_events[2].state, K_POLL_STATE_SIGNALED, "");
-	zassert_equal(wait_signal.signaled, 1, "");
-	zassert_equal(wait_signal.result, SIGNAL_RESULT, "");
-	zassert_equal(wait_events[2].tag, TAG_2, "");
+	ztest_equal(wait_events[2].state, K_POLL_STATE_SIGNALED, "");
+	ztest_equal(wait_signal.signaled, 1, "");
+	ztest_equal(wait_signal.result, SIGNAL_RESULT, "");
+	ztest_equal(wait_events[2].tag, TAG_2, "");
 
 	wait_events[2].state = K_POLL_STATE_NOT_READY;
 	wait_signal.signaled = 0U;
@@ -430,9 +430,9 @@ void test_poll_cancel(bool is_main_low_prio)
 
 	k_thread_priority_set(k_current_get(), old_prio);
 
-	zassert_equal(rc, -EINTR, "");
+	ztest_equal(rc, -EINTR, "");
 
-	zassert_equal(cancel_events[0].state,
+	ztest_equal(cancel_events[0].state,
 		      K_POLL_STATE_CANCELLED, "");
 
 	if (is_main_low_prio) {
@@ -440,13 +440,13 @@ void test_poll_cancel(bool is_main_low_prio)
 		 * generate poll events, it may get multiple poll events
 		 * at once.
 		 */
-		zassert_equal(cancel_events[1].state,
+		ztest_equal(cancel_events[1].state,
 			      K_POLL_STATE_FIFO_DATA_AVAILABLE, "");
 	} else {
 		/* Otherwise, poller thread will be woken up on first
 		 * event triggered.
 		 */
-		zassert_equal(cancel_events[1].state,
+		ztest_equal(cancel_events[1].state,
 			      K_POLL_STATE_NOT_READY, "");
 	}
 }
@@ -476,7 +476,7 @@ static void multi_lowprio(void *p1, void *p2, void *p3)
 
 	(void)k_poll(&event, 1, K_FOREVER);
 	rc = k_sem_take(&multi_sem, K_FOREVER);
-	zassert_equal(rc, 0, "");
+	ztest_equal(rc, 0, "");
 }
 
 static K_SEM_DEFINE(multi_reply, 0, 1);
@@ -539,16 +539,16 @@ void test_poll_multi(void)
 	k_sleep(K_MSEC(250));
 	rc = k_poll(events, ARRAY_SIZE(events), K_SECONDS(1));
 
-	zassert_equal(rc, 0, "");
-	zassert_equal(events[0].state, K_POLL_STATE_NOT_READY, "");
-	zassert_equal(events[1].state, K_POLL_STATE_SEM_AVAILABLE, "");
+	ztest_equal(rc, 0, "");
+	ztest_equal(events[0].state, K_POLL_STATE_NOT_READY, "");
+	ztest_equal(events[1].state, K_POLL_STATE_SEM_AVAILABLE, "");
 
 	/* free polling threads, ensuring it awoken from k_poll() and got the sem */
 	k_sem_give(&multi_sem);
 	k_sem_give(&multi_sem);
 	rc = k_sem_take(&multi_reply, K_SECONDS(1));
 
-	zassert_equal(rc, 0, "");
+	ztest_equal(rc, 0, "");
 
 	/* wait for polling threads to complete execution */
 	k_thread_priority_set(k_current_get(), old_prio);
@@ -605,11 +605,11 @@ void test_poll_threadstate(void)
 			K_NO_WAIT);
 
 	/* wait for spawn thread to take action */
-	zassert_equal(k_poll(&event, 1, K_SECONDS(1)), 0, "");
-	zassert_equal(event.state, K_POLL_STATE_SIGNALED, "");
+	ztest_equal(k_poll(&event, 1, K_SECONDS(1)), 0, "");
+	ztest_equal(event.state, K_POLL_STATE_SIGNALED, "");
 	k_poll_signal_check(&signal, &signaled, &result);
-	zassert_not_equal(signaled, 0, "");
-	zassert_equal(result, SIGNAL_RESULT, "");
+	ztest_not_equal(signaled, 0, "");
+	ztest_equal(result, SIGNAL_RESULT, "");
 
 	event.state = K_POLL_STATE_NOT_READY;
 	k_poll_signal_reset(&signal);
@@ -635,5 +635,5 @@ void test_poll_zero_events(void)
 	k_poll_event_init(&event, K_POLL_TYPE_SEM_AVAILABLE,
 			  K_POLL_MODE_NOTIFY_ONLY, &zero_events_sem);
 
-	zassert_equal(k_poll(&event, 0, K_MSEC(50)), -EAGAIN, NULL);
+	ztest_equal(k_poll(&event, 0, K_MSEC(50)), -EAGAIN, NULL);
 }

--- a/tests/kernel/queue/src/test_queue_contexts.c
+++ b/tests/kernel/queue/src/test_queue_contexts.c
@@ -68,23 +68,23 @@ static void tqueue_get(struct k_queue *pqueue)
 	for (int i = 0; i < LIST_LEN; i++) {
 		/**TESTPOINT: queue get*/
 		rx_data = k_queue_get(pqueue, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data_p[i], NULL);
+		ztest_equal(rx_data, (void *)&data_p[i], NULL);
 	}
 	/*get queue data from "queue_append"*/
 	for (int i = 0; i < LIST_LEN; i++) {
 		/**TESTPOINT: queue get*/
 		rx_data = k_queue_get(pqueue, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data[i], NULL);
+		ztest_equal(rx_data, (void *)&data[i], NULL);
 	}
 	/*get queue data from "queue_append_list"*/
 	for (int i = 0; i < LIST_LEN; i++) {
 		rx_data = k_queue_get(pqueue, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data_l[i], NULL);
+		ztest_equal(rx_data, (void *)&data_l[i], NULL);
 	}
 	/*get queue data from "queue_merge_slist"*/
 	for (int i = 0; i < LIST_LEN; i++) {
 		rx_data = k_queue_get(pqueue, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data_sl[i], NULL);
+		ztest_equal(rx_data, (void *)&data_sl[i], NULL);
 	}
 }
 
@@ -182,7 +182,7 @@ void test_queue_isr2thread(void)
 
 static void tThread_get(void *p1, void *p2, void *p3)
 {
-	zassert_true(k_queue_get((struct k_queue *)p1, K_FOREVER) != NULL,
+	ztest_true(k_queue_get((struct k_queue *)p1, K_FOREVER) != NULL,
 		     NULL);
 	k_sem_give(&end_sema);
 }
@@ -233,7 +233,7 @@ static void tqueue_alloc(struct k_queue *pqueue)
 	k_queue_alloc_append(pqueue, (void *)&data_append);
 
 	/* Insertion fails and alloc returns NOMEM */
-	zassert_false(k_queue_remove(pqueue, &data_append), NULL);
+	ztest_false(k_queue_remove(pqueue, &data_append), NULL);
 
 	/* Assign resource pool of lower size */
 	k_thread_resource_pool_assign(k_current_get(), &mem_pool_fail);
@@ -243,24 +243,24 @@ static void tqueue_alloc(struct k_queue *pqueue)
 	 */
 	k_queue_alloc_prepend(pqueue, (void *)&data_prepend);
 
-	zassert_false(k_queue_remove(pqueue, &data_prepend), NULL);
+	ztest_false(k_queue_remove(pqueue, &data_prepend), NULL);
 
 	/* No element must be present in the queue, as all
 	 * operations failed
 	 */
-	zassert_true(k_queue_is_empty(pqueue), NULL);
+	ztest_true(k_queue_is_empty(pqueue), NULL);
 
 	/* Assign resource pool of sufficient size */
 	k_thread_resource_pool_assign(k_current_get(),
 				      &mem_pool_pass);
 
-	zassert_false(k_queue_alloc_prepend(pqueue, (void *)&data_prepend),
+	ztest_false(k_queue_alloc_prepend(pqueue, (void *)&data_prepend),
 		      NULL);
 
 	/* Now queue shouldn't be empty */
-	zassert_false(k_queue_is_empty(pqueue), NULL);
+	ztest_false(k_queue_is_empty(pqueue), NULL);
 
-	zassert_true(k_queue_get(pqueue, K_FOREVER) != NULL,
+	ztest_true(k_queue_get(pqueue, K_FOREVER) != NULL,
 		     NULL);
 }
 

--- a/tests/kernel/queue/src/test_queue_fail.c
+++ b/tests/kernel/queue/src/test_queue_fail.c
@@ -20,6 +20,6 @@ void test_queue_get_fail(void)
 
 	k_queue_init(&queue);
 	/**TESTPOINT: queue get returns NULL*/
-	zassert_is_null(k_queue_get(&queue, K_NO_WAIT), NULL);
-	zassert_is_null(k_queue_get(&queue, TIMEOUT), NULL);
+	ztest_is_null(k_queue_get(&queue, K_NO_WAIT), NULL);
+	ztest_is_null(k_queue_get(&queue, TIMEOUT), NULL);
 }

--- a/tests/kernel/queue/src/test_queue_loop.c
+++ b/tests/kernel/queue/src/test_queue_loop.c
@@ -44,14 +44,14 @@ static void tqueue_get(struct k_queue *pqueue)
 	for (int i = 0; i < LIST_LEN; i++) {
 		/**TESTPOINT: queue get*/
 		rx_data = k_queue_get(pqueue, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data_p[i], NULL);
+		ztest_equal(rx_data, (void *)&data_p[i], NULL);
 	}
 
 	/*get queue data from "queue_append"*/
 	for (int i = 0; i < LIST_LEN; i++) {
 		/**TESTPOINT: queue get*/
 		rx_data = k_queue_get(pqueue, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data[i], NULL);
+		ztest_equal(rx_data, (void *)&data[i], NULL);
 	}
 }
 
@@ -60,7 +60,7 @@ static void tqueue_find_and_remove(struct k_queue *pqueue)
 	/*remove queue data from "queue_find_and_remove"*/
 	for (int i = 0; i < LIST_LEN; i++) {
 		/**TESTPOINT: queue find and remove*/
-		zassert_true(k_queue_remove(pqueue, &data_r[i]), NULL);
+		ztest_true(k_queue_remove(pqueue, &data_r[i]), NULL);
 	}
 }
 

--- a/tests/kernel/queue/src/test_queue_user.c
+++ b/tests/kernel/queue/src/test_queue_user.c
@@ -30,29 +30,29 @@ void child_thread_get(void *p1, void *p2, void *p3)
 	struct k_queue *q = p1;
 	struct k_sem *sem = p2;
 
-	zassert_false(k_queue_is_empty(q), NULL);
+	ztest_false(k_queue_is_empty(q), NULL);
 	qd = k_queue_peek_head(q);
-	zassert_equal(qd->data, 0, NULL);
+	ztest_equal(qd->data, 0, NULL);
 	qd = k_queue_peek_tail(q);
-	zassert_equal(qd->data, (LIST_LEN * 2) - 1,
+	ztest_equal(qd->data, (LIST_LEN * 2) - 1,
 		      "got %d expected %d", qd->data, (LIST_LEN * 2) - 1);
 
 	for (int i = 0; i < (LIST_LEN * 2); i++) {
 		qd = k_queue_get(q, K_FOREVER);
 
-		zassert_equal(qd->data, i, NULL);
+		ztest_equal(qd->data, i, NULL);
 		if (qd->allocated) {
 			/* snode should never have been touched */
-			zassert_is_null(qd->snode.next, NULL);
+			ztest_is_null(qd->snode.next, NULL);
 		}
 	}
 
 
-	zassert_true(k_queue_is_empty(q), NULL);
+	ztest_true(k_queue_is_empty(q), NULL);
 
 	/* This one gets canceled */
 	qd = k_queue_get(q, K_FOREVER);
-	zassert_is_null(qd, NULL);
+	ztest_is_null(qd, NULL);
 
 	k_sem_give(sem);
 }
@@ -75,11 +75,11 @@ void test_queue_supv_to_user(void)
 	struct k_sem *sem;
 
 	q = k_object_alloc(K_OBJ_QUEUE);
-	zassert_not_null(q, "no memory for allocated queue object");
+	ztest_not_null(q, "no memory for allocated queue object");
 	k_queue_init(q);
 
 	sem = k_object_alloc(K_OBJ_SEM);
-	zassert_not_null(sem, "no memory for semaphore object");
+	ztest_not_null(sem, "no memory for semaphore object");
 	k_sem_init(sem, 0, 1);
 
 	for (int i = 0; i < (LIST_LEN * 2); i = i + 2) {
@@ -95,7 +95,7 @@ void test_queue_supv_to_user(void)
 		qdata[i + 1].data = i + 1;
 		qdata[i + 1].allocated = true;
 		qdata[i + 1].snode.next = NULL;
-		zassert_false(k_queue_alloc_append(q, &qdata[i + 1]), NULL);
+		ztest_false(k_queue_alloc_append(q, &qdata[i + 1]), NULL);
 	}
 
 	k_thread_create(&child_thread, child_stack, STACK_SIZE,
@@ -114,20 +114,20 @@ void test_queue_alloc_prepend_user(void)
 	struct k_queue *q;
 
 	q = k_object_alloc(K_OBJ_QUEUE);
-	zassert_not_null(q, "no memory for allocated queue object");
+	ztest_not_null(q, "no memory for allocated queue object");
 	k_queue_init(q);
 
 	for (int i = 0; i < LIST_LEN * 2; i++) {
 		qdata[i].data = i;
-		zassert_false(k_queue_alloc_prepend(q, &qdata[i]), NULL);
+		ztest_false(k_queue_alloc_prepend(q, &qdata[i]), NULL);
 	}
 
 	for (int i = (LIST_LEN * 2) - 1; i >= 0; i--) {
 		struct qdata *qd;
 
 		qd = k_queue_get(q, K_NO_WAIT);
-		zassert_true(qd != NULL, NULL);
-		zassert_equal(qd->data, i, NULL);
+		ztest_true(qd != NULL, NULL);
+		ztest_equal(qd->data, i, NULL);
 	}
 }
 
@@ -136,20 +136,20 @@ void test_queue_alloc_append_user(void)
 	struct k_queue *q;
 
 	q = k_object_alloc(K_OBJ_QUEUE);
-	zassert_not_null(q, "no memory for allocated queue object");
+	ztest_not_null(q, "no memory for allocated queue object");
 	k_queue_init(q);
 
 	for (int i = 0; i < LIST_LEN * 2; i++) {
 		qdata[i].data = i;
-		zassert_false(k_queue_alloc_append(q, &qdata[i]), NULL);
+		ztest_false(k_queue_alloc_append(q, &qdata[i]), NULL);
 	}
 
 	for (int i = 0; i < LIST_LEN * 2; i++) {
 		struct qdata *qd;
 
 		qd = k_queue_get(q, K_NO_WAIT);
-		zassert_true(qd != NULL, NULL);
-		zassert_equal(qd->data, i, NULL);
+		ztest_true(qd != NULL, NULL);
+		ztest_equal(qd->data, i, NULL);
 	}
 }
 
@@ -171,7 +171,7 @@ void test_auto_free(void)
 	int i;
 
 	for (i = 0; i < 4; i++) {
-		zassert_false(k_mem_pool_alloc(&test_pool, &b[i], 64,
+		ztest_false(k_mem_pool_alloc(&test_pool, &b[i], 64,
 					       K_FOREVER),
 			      "memory not auto released!");
 	}

--- a/tests/kernel/sched/deadline/src/main.c
+++ b/tests/kernel/sched/deadline/src/main.c
@@ -28,8 +28,8 @@ void worker(void *p1, void *p2, void *p3)
 	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
 
-	zassert_true(tidx >= 0 && tidx < NUM_THREADS, "");
-	zassert_true(n_exec >= 0 && n_exec < NUM_THREADS, "");
+	ztest_true(tidx >= 0 && tidx < NUM_THREADS, "");
+	ztest_true(n_exec >= 0 && n_exec < NUM_THREADS, "");
 
 	exec_order[n_exec++] = tidx;
 
@@ -67,7 +67,7 @@ void test_deadline(void)
 		thread_deadlines[i] = sys_rand32_get() & 0x7fffff00;
 	}
 
-	zassert_true(n_exec == 0, "threads ran too soon");
+	ztest_true(n_exec == 0, "threads ran too soon");
 
 	/* Similarly do the deadline setting in one quick pass to
 	 * minimize aliasing with "now"
@@ -76,17 +76,17 @@ void test_deadline(void)
 		k_thread_deadline_set(&worker_threads[i], thread_deadlines[i]);
 	}
 
-	zassert_true(n_exec == 0, "threads ran too soon");
+	ztest_true(n_exec == 0, "threads ran too soon");
 
 	k_sleep(K_MSEC(100));
 
-	zassert_true(n_exec == NUM_THREADS, "not enough threads ran");
+	ztest_true(n_exec == NUM_THREADS, "not enough threads ran");
 
 	for (i = 1; i < NUM_THREADS; i++) {
 		int d0 = thread_deadlines[exec_order[i-1]];
 		int d1 = thread_deadlines[exec_order[i]];
 
-		zassert_true(d0 <= d1, "threads ran in wrong order");
+		ztest_true(d0 <= d1, "threads ran in wrong order");
 	}
 }
 

--- a/tests/kernel/sched/metairq/src/main.c
+++ b/tests/kernel/sched/metairq/src/main.c
@@ -73,18 +73,18 @@ void coop_thread1(void)
 
 	/* Expect that low-priority thread has run to completion */
 	cnt1 = coop_cnt1;
-	zassert_equal(cnt1, 0, "Unexpected cnt1 at start: %d", cnt1);
+	ztest_equal(cnt1, 0, "Unexpected cnt1 at start: %d", cnt1);
 	cnt2 = coop_cnt2;
-	zassert_equal(cnt2, LOOP_CNT, "Unexpected cnt2 at start: %d", cnt2);
+	ztest_equal(cnt2, LOOP_CNT, "Unexpected cnt2 at start: %d", cnt2);
 
 	printk("thread1\n");
 	coop_cnt1++;
 
 	/* Expect that both threads have run to completion */
 	cnt1 = coop_cnt1;
-	zassert_equal(cnt1, 1, "Unexpected cnt1 at end: %d", cnt1);
+	ztest_equal(cnt1, 1, "Unexpected cnt1 at end: %d", cnt1);
 	cnt2 = coop_cnt2;
-	zassert_equal(cnt2, LOOP_CNT, "Unexpected cnt2 at end: %d", cnt2);
+	ztest_equal(cnt2, LOOP_CNT, "Unexpected cnt2 at end: %d", cnt2);
 
 	k_sem_give(&coop_sem1);
 }
@@ -98,9 +98,9 @@ void coop_thread2(void)
 
 	/* Expect that this is run first */
 	cnt1 = coop_cnt1;
-	zassert_equal(cnt1, 0, "Unexpected cnt1 at start: %d", cnt1);
+	ztest_equal(cnt1, 0, "Unexpected cnt1 at start: %d", cnt1);
 	cnt2 = coop_cnt2;
-	zassert_equal(cnt2, 0, "Unexpected cnt2 at start: %d", cnt2);
+	ztest_equal(cnt2, 0, "Unexpected cnt2 at start: %d", cnt2);
 
 	for (int i = 0; i < LOOP_CNT; i++) {
 		printk("thread2\n");
@@ -112,9 +112,9 @@ void coop_thread2(void)
 	 * thread is started
 	 */
 	cnt1 = coop_cnt1;
-	zassert_equal(cnt1, 0, "Unexpected cnt1 at end: %d", cnt1);
+	ztest_equal(cnt1, 0, "Unexpected cnt1 at end: %d", cnt1);
 	cnt2 = coop_cnt2;
-	zassert_equal(cnt2, LOOP_CNT, "Unexpected cnt2 at end: %d", cnt2);
+	ztest_equal(cnt2, LOOP_CNT, "Unexpected cnt2 at end: %d", cnt2);
 
 	k_sem_give(&coop_sem2);
 }

--- a/tests/kernel/sched/preempt/src/main.c
+++ b/tests/kernel/sched/preempt/src/main.c
@@ -83,7 +83,7 @@ K_SEM_DEFINE(main_sem, 0, 1);
 
 void wakeup_src_thread(int id)
 {
-	zassert_true(k_current_get() == &manager_thread, "");
+	ztest_true(k_current_get() == &manager_thread, "");
 
 	/* irq_offload() on ARM appears not to do what we want.  It
 	 * doesn't appear to go through the normal exception return
@@ -102,7 +102,7 @@ void wakeup_src_thread(int id)
 	for (int i = 0; i < NUM_THREADS; i++) {
 		k_tid_t th = &worker_threads[i];
 
-		zassert_equal(strcmp(k_thread_state_str(th), "pending"),
+		ztest_equal(strcmp(k_thread_state_str(th), "pending"),
 				0, "worker thread %d not pending?", i);
 	}
 
@@ -128,7 +128,7 @@ void wakeup_src_thread(int id)
 	}
 
 	/* We are lowest priority, SOMEONE must have run */
-	zassert_true(!!last_thread, "");
+	ztest_true(!!last_thread, "");
 }
 
 void manager(void *p1, void *p2, void *p3)
@@ -177,17 +177,17 @@ void validate_wakeup(int src, int target, k_tid_t last_thread)
 	int tie = PRI(src) == PRI(target);
 
 	if (do_sleep) {
-		zassert_true(preempted, "sleeping must let any worker run");
+		ztest_true(preempted, "sleeping must let any worker run");
 		return;
 	}
 
 	if (do_yield) {
 		if (preempted) {
-			zassert_false(src_wins,
+			ztest_false(src_wins,
 				      "src (pri %d) should not have yielded to tgt (%d)",
 				      PRI(src), PRI(target));
 		} else {
-			zassert_true(src_wins,
+			ztest_true(src_wins,
 				      "src (pri %d) should have yielded to tgt (%d)",
 				      PRI(src), PRI(target));
 		}
@@ -196,21 +196,21 @@ void validate_wakeup(int src, int target, k_tid_t last_thread)
 	}
 
 	if (preempted) {
-		zassert_true(target_wins, "preemption must raise priority");
+		ztest_true(target_wins, "preemption must raise priority");
 	}
 
 	if (PRI(target) == METAIRQ) {
-		zassert_true(preempted,
+		ztest_true(preempted,
 			     "metairq threads must always preempt");
 	} else {
-		zassert_false(do_lock && preempted,
+		ztest_false(do_lock && preempted,
 			      "threads holding scheduler lock must not be preempted");
 
-		zassert_false(preempted && src_wins,
+		ztest_false(preempted && src_wins,
 			      "lower priority threads must never preempt");
 
 		if (!do_lock) {
-			zassert_false(!preempted && target_wins,
+			ztest_false(!preempted && target_wins,
 				      "higher priority thread should have preempted");
 
 			/* The scheudler implements a 'first added to
@@ -228,7 +228,7 @@ void validate_wakeup(int src, int target, k_tid_t last_thread)
 			 * to revisit this particular check and maybe
 			 * make the poilicy configurable.
 			 */
-			zassert_false(preempted && tie,
+			ztest_false(preempted && tie,
 				      "tied priority should not preempt");
 		}
 	}
@@ -242,8 +242,8 @@ void worker(void *p1, void *p2, void *p3)
 	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
 
-	zassert_true(id >= 0 && id < NUM_THREADS, "");
-	zassert_true(curr == k_current_get(), "");
+	ztest_true(id >= 0 && id < NUM_THREADS, "");
+	ztest_true(curr == k_current_get(), "");
 
 	while (1) {
 		/* Wait for the manager or another test thread to wake
@@ -293,7 +293,7 @@ void worker(void *p1, void *p2, void *p3)
 
 			k_sleep(K_MSEC(1));
 
-			zassert_true(k_uptime_get() - start > 0,
+			ztest_true(k_uptime_get() - start > 0,
 				     "didn't sleep");
 			prev = last_thread;
 		}
@@ -320,11 +320,11 @@ void test_preempt(void)
 			priority = K_HIGHEST_THREAD_PRIO
 				+ CONFIG_NUM_METAIRQ_PRIORITIES;
 
-			zassert_true(priority < K_PRIO_PREEMPT(0), "");
+			ztest_true(priority < K_PRIO_PREEMPT(0), "");
 		} else {
 			priority = K_LOWEST_APPLICATION_THREAD_PRIO - 1;
 
-			zassert_true(priority >= K_PRIO_PREEMPT(0), "");
+			ztest_true(priority >= K_PRIO_PREEMPT(0), "");
 		}
 
 		k_thread_create(&worker_threads[i],

--- a/tests/kernel/sched/schedule_api/src/test_priority_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_priority_scheduling.c
@@ -43,7 +43,7 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 		/* Prining alphabet corresponding to thread*/
 		TC_PRINT("%c", thread_parameter);
 		/* Testing if threads are execueted as per priority*/
-		zassert_true((idx == thread_idx), NULL);
+		ztest_true((idx == thread_idx), NULL);
 		thread_idx = (thread_idx + 1) % (NUM_THREAD);
 
 		/* Realease CPU and give chance to Ztest thread to run*/

--- a/tests/kernel/sched/schedule_api/src/test_sched_is_preempt_thread.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_is_preempt_thread.c
@@ -15,38 +15,38 @@ static struct k_sem end_sema;
 static void tIsr(void *data)
 {
 	/** TESTPOINT: The code is running at ISR.*/
-	zassert_false(k_is_preempt_thread(), NULL);
+	ztest_false(k_is_preempt_thread(), NULL);
 }
 
 static void tpreempt_ctx(void *p1, void *p2, void *p3)
 {
 	/** TESTPOINT: The thread's priority is in the preemptible range.*/
-	zassert_true(k_is_preempt_thread(), NULL);
+	ztest_true(k_is_preempt_thread(), NULL);
 	k_sched_lock();
 	/** TESTPOINT: The thread has locked the scheduler.*/
-	zassert_false(k_is_preempt_thread(), NULL);
+	ztest_false(k_is_preempt_thread(), NULL);
 	k_sched_unlock();
 	/** TESTPOINT: The thread has not locked the scheduler.*/
-	zassert_true(k_is_preempt_thread(), NULL);
+	ztest_true(k_is_preempt_thread(), NULL);
 	k_thread_priority_set(k_current_get(), K_PRIO_COOP(1));
 	/** TESTPOINT: The thread's priority is in the cooperative range.*/
-	zassert_false(k_is_preempt_thread(), NULL);
+	ztest_false(k_is_preempt_thread(), NULL);
 	k_sem_give(&end_sema);
 }
 
 static void tcoop_ctx(void *p1, void *p2, void *p3)
 {
 	/** TESTPOINT: The thread's priority is in the cooperative range.*/
-	zassert_false(k_is_preempt_thread(), NULL);
+	ztest_false(k_is_preempt_thread(), NULL);
 	k_thread_priority_set(k_current_get(), K_PRIO_PREEMPT(1));
 	/** TESTPOINT: The thread's priority is in the preemptible range.*/
-	zassert_true(k_is_preempt_thread(), NULL);
+	ztest_true(k_is_preempt_thread(), NULL);
 	k_sched_lock();
 	/** TESTPOINT: The thread has locked the scheduler.*/
-	zassert_false(k_is_preempt_thread(), NULL);
+	ztest_false(k_is_preempt_thread(), NULL);
 	k_sched_unlock();
 	/** TESTPOINT: The thread has not locked the scheduler.*/
-	zassert_true(k_is_preempt_thread(), NULL);
+	ztest_true(k_is_preempt_thread(), NULL);
 	k_sem_give(&end_sema);
 }
 

--- a/tests/kernel/sched/schedule_api/src/test_sched_priority.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_priority.c
@@ -43,10 +43,10 @@ void test_priority_cooperative(void)
 				      thread_entry, NULL, NULL, NULL,
 				      spawn_prio, 0, K_NO_WAIT);
 	/* checkpoint: current thread shouldn't preempted by higher thread */
-	zassert_true(last_prio == k_thread_priority_get(k_current_get()), NULL);
+	ztest_true(last_prio == k_thread_priority_get(k_current_get()), NULL);
 	k_sleep(K_MSEC(100));
 	/* checkpoint: spawned thread get executed */
-	zassert_true(last_prio == spawn_prio, NULL);
+	ztest_true(last_prio == spawn_prio, NULL);
 	k_thread_abort(tid);
 
 	/* restore environment */
@@ -78,7 +78,7 @@ void test_priority_preemptible(void)
 				      thread_entry, NULL, NULL, NULL,
 				      spawn_prio, 0, K_NO_WAIT);
 	/* checkpoint: thread is preempted by higher thread */
-	zassert_true(last_prio == spawn_prio, NULL);
+	ztest_true(last_prio == spawn_prio, NULL);
 
 	k_sleep(K_MSEC(100));
 	k_thread_abort(tid);
@@ -88,7 +88,7 @@ void test_priority_preemptible(void)
 			      thread_entry, NULL, NULL, NULL,
 			      spawn_prio, 0, K_NO_WAIT);
 	/* checkpoint: thread is not preempted by lower thread */
-	zassert_false(last_prio == spawn_prio, NULL);
+	ztest_false(last_prio == spawn_prio, NULL);
 	k_thread_abort(tid);
 
 	/* restore environment */
@@ -122,11 +122,11 @@ void test_bad_priorities(void)
 	};
 
 	for (int i = 0; i < ARRAY_SIZE(testcases); i++) {
-		zassert_equal(_is_valid_prio(testcases[i].prio,
+		ztest_equal(_is_valid_prio(testcases[i].prio,
 					     testcases[i].entry),
 			      testcases[i].result, "failed check %d", i);
 		/* XXX why are these even separate APIs? */
-		zassert_equal(Z_VALID_PRIO(testcases[i].prio,
+		ztest_equal(Z_VALID_PRIO(testcases[i].prio,
 					   testcases[i].entry),
 			      testcases[i].result, "failed check %d", i);
 	}

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
@@ -106,10 +106,10 @@ void test_yield_cooperative(void)
 	spawn_threads(0);
 	/* checkpoint: only higher priority thread get executed when yield */
 	k_yield();
-	zassert_true(tdata[0].executed == 1, NULL);
-	zassert_true(tdata[1].executed == 1, NULL);
+	ztest_true(tdata[0].executed == 1, NULL);
+	ztest_true(tdata[1].executed == 1, NULL);
 	for (int i = 2; i < THREADS_NUM; i++) {
-		zassert_true(tdata[i].executed == 0, NULL);
+		ztest_true(tdata[i].executed == 0, NULL);
 	}
 	/* restore environment */
 	teardown_threads();
@@ -133,7 +133,7 @@ void test_sleep_cooperative(void)
 	/* checkpoint: all ready threads get executed when k_sleep */
 	k_sleep(K_MSEC(100));
 	for (int i = 0; i < THREADS_NUM; i++) {
-		zassert_true(tdata[i].executed == 1, NULL);
+		ztest_true(tdata[i].executed == 1, NULL);
 	}
 
 	/* restore environment */
@@ -150,7 +150,7 @@ void test_busy_wait_cooperative(void)
 	k_busy_wait(100000); /* 100 ms */
 	/* checkpoint: No other threads get executed */
 	for (int i = 0; i < THREADS_NUM; i++) {
-		zassert_true(tdata[i].executed == 0, NULL);
+		ztest_true(tdata[i].executed == 0, NULL);
 	}
 	/* restore environment */
 	teardown_threads();
@@ -178,10 +178,10 @@ void test_sleep_wakeup_preemptible(void)
 	spawn_threads(10 * 1000); /* 10 second */
 	/* checkpoint: lower threads not executed, high threads are in sleep */
 	for (int i = 0; i < THREADS_NUM; i++) {
-		zassert_true(tdata[i].executed == 0, NULL);
+		ztest_true(tdata[i].executed == 0, NULL);
 	}
 	k_wakeup(tdata[0].tid);
-	zassert_true(tdata[0].executed == 1, NULL);
+	ztest_true(tdata[0].executed == 1, NULL);
 	/* restore environment */
 	teardown_threads();
 }
@@ -215,7 +215,7 @@ void test_pending_thread_wakeup(void)
 				      NULL, NULL, NULL,
 				      K_PRIO_COOP(1), 0, K_NO_WAIT);
 
-	zassert_false(executed == 1, "The thread didn't wait"
+	ztest_false(executed == 1, "The thread didn't wait"
 		      " for semaphore acquisition");
 
 	/* Call wakeup on pending thread */
@@ -224,7 +224,7 @@ void test_pending_thread_wakeup(void)
 	/* TESTPOINT: k_wakeup() shouldn't resume
 	 * execution of pending thread
 	 */
-	zassert_true(executed != 1, "k_wakeup woke up a"
+	ztest_true(executed != 1, "k_wakeup woke up a"
 		     " pending thread!");
 
 	k_thread_abort(tid);
@@ -249,12 +249,12 @@ void test_time_slicing_preemptible(void)
 	k_sched_time_slice_set(200, 0); /* 200 ms */
 	spawn_threads(0);
 	/* checkpoint: higher priority threads get executed immediately */
-	zassert_true(tdata[0].executed == 1, NULL);
+	ztest_true(tdata[0].executed == 1, NULL);
 	k_busy_wait(500000); /* 500 ms */
 	/* checkpoint: equal priority threads get executed every time slice */
-	zassert_true(tdata[1].executed == 1, NULL);
+	ztest_true(tdata[1].executed == 1, NULL);
 	for (int i = 2; i < THREADS_NUM; i++) {
-		zassert_true(tdata[i].executed == 0, NULL);
+		ztest_true(tdata[i].executed == 0, NULL);
 	}
 
 	/* restore environment */
@@ -287,12 +287,12 @@ void test_time_slicing_disable_preemptible(void)
 
 	spawn_threads(0);
 	/* checkpoint: higher priority threads get executed immediately */
-	zassert_true(tdata[0].executed == 1, NULL);
+	ztest_true(tdata[0].executed == 1, NULL);
 	k_busy_wait(500000); /* 500 ms */
 	/* checkpoint: equal priority threads get executed every time slice */
-	zassert_true(tdata[1].executed == 0, NULL);
+	ztest_true(tdata[1].executed == 0, NULL);
 	for (int i = 2; i < THREADS_NUM; i++) {
-		zassert_true(tdata[i].executed == 0, NULL);
+		ztest_true(tdata[i].executed == 0, NULL);
 	}
 	/* restore environment */
 	teardown_threads();
@@ -322,13 +322,13 @@ void test_lock_preemptible(void)
 	k_busy_wait(100000);
 	/* checkpoint: all other threads not been executed */
 	for (int i = 0; i < THREADS_NUM; i++) {
-		zassert_true(tdata[i].executed == 0, NULL);
+		ztest_true(tdata[i].executed == 0, NULL);
 	}
 	/* make current thread unready */
 	k_sleep(K_MSEC(100));
 	/* checkpoint: all other threads get executed */
 	for (int i = 0; i < THREADS_NUM; i++) {
-		zassert_true(tdata[i].executed == 1, NULL);
+		ztest_true(tdata[i].executed == 1, NULL);
 	}
 	/* restore environment */
 	teardown_threads();
@@ -362,9 +362,9 @@ void test_unlock_preemptible(void)
 	k_yield();
 
 	/* checkpoint: higher and equal threads get executed */
-	zassert_true(tdata[0].executed == 1, NULL);
-	zassert_true(tdata[1].executed == 1, NULL);
-	zassert_true(tdata[2].executed == 0, NULL);
+	ztest_true(tdata[0].executed == 1, NULL);
+	ztest_true(tdata[1].executed == 1, NULL);
+	ztest_true(tdata[2].executed == 0, NULL);
 
 	/* restore environment */
 	teardown_threads();
@@ -403,7 +403,7 @@ void test_unlock_nested_sched_lock(void)
 
 	/* checkpoint: no threads get executed */
 	for (int i = 0; i < THREADS_NUM; i++) {
-		zassert_true(tdata[i].executed == 0, NULL);
+		ztest_true(tdata[i].executed == 0, NULL);
 	}
 
 	/* unlock another; this let the higher thread to run */
@@ -413,9 +413,9 @@ void test_unlock_nested_sched_lock(void)
 	k_yield();
 
 	/* checkpoint: higher threads NOT get executed */
-	zassert_true(tdata[0].executed == 1, NULL);
-	zassert_true(tdata[1].executed == 1, NULL);
-	zassert_true(tdata[2].executed == 0, NULL);
+	ztest_true(tdata[0].executed == 1, NULL);
+	ztest_true(tdata[1].executed == 1, NULL);
+	ztest_true(tdata[2].executed == 0, NULL);
 
 	/* restore environment */
 	teardown_threads();

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -85,10 +85,10 @@ static void thread_time_slice(void *p1, void *p2, void *p3)
 
 	/** TESTPOINT: timeslice should be reset for each preemptive thread*/
 #ifndef CONFIG_COVERAGE
-	zassert_true(t >= expected_slice_min,
+	ztest_true(t >= expected_slice_min,
 		     "timeslice too small, expected %u got %u",
 		     expected_slice_min, t);
-	zassert_true(t <= expected_slice_max,
+	ztest_true(t <= expected_slice_max,
 		     "timeslice too big, expected %u got %u",
 		     expected_slice_max, t);
 #else

--- a/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
@@ -58,7 +58,7 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 		/* Test Fails if thread exceed allocated time slice or
 		 * Any thread is scheduled out of order.
 		 */
-		zassert_true(((tdelta >= expected_slice_min) &&
+		ztest_true(((tdelta >= expected_slice_min) &&
 			      (tdelta <= expected_slice_max) &&
 			      (idx == thread_idx)), NULL);
 		thread_idx = (thread_idx + 1) % (NUM_THREAD);

--- a/tests/kernel/sched/schedule_api/src/user_api.c
+++ b/tests/kernel/sched/schedule_api/src/user_api.c
@@ -48,7 +48,7 @@ static void preempt_test_thread(void *p1, void *p2, void *p3)
 void test_user_k_is_preempt(void)
 {
 	/* thread_was_preempt is volatile, and static analysis doesn't
-	 * like to see it being tested inside zassert_true, because
+	 * like to see it being tested inside ztest_true, because
 	 * the read is treated as a "side effect" of an assertion
 	 * (e.g. a read is significant for things like volatile MMIO
 	 * addresses, and assertions may or may not be compiled, even
@@ -67,7 +67,7 @@ void test_user_k_is_preempt(void)
 	k_sem_take(&user_sem, K_FOREVER);
 
 	twp = thread_was_preempt;
-	zassert_false(twp, "unexpected return value");
+	ztest_false(twp, "unexpected return value");
 
 	k_thread_create(&user_thread, ustack, STACK_SIZE, preempt_test_thread,
 			NULL, NULL, NULL,
@@ -77,5 +77,5 @@ void test_user_k_is_preempt(void)
 	k_sem_take(&user_sem, K_FOREVER);
 
 	twp = thread_was_preempt;
-	zassert_true(twp, "unexpected return value");
+	ztest_true(twp, "unexpected return value");
 }

--- a/tests/kernel/semaphore/semaphore/src/main.c
+++ b/tests/kernel/semaphore/semaphore/src/main.c
@@ -67,7 +67,7 @@ static void tsema_thread_thread(struct k_sem *psem)
 				      K_PRIO_PREEMPT(0),
 				      K_USER | K_INHERIT_PERMS, K_NO_WAIT);
 
-	zassert_false(k_sem_take(psem, K_FOREVER), NULL);
+	ztest_false(k_sem_take(psem, K_FOREVER), NULL);
 
 	/*clean the spawn thread avoid side effect in next TC*/
 	k_thread_abort(tid);
@@ -77,7 +77,7 @@ static void tsema_thread_isr(struct k_sem *psem)
 {
 	/**TESTPOINT: thread-isr sync via sema*/
 	irq_offload(isr_sem_give, psem);
-	zassert_false(k_sem_take(psem, K_FOREVER), NULL);
+	ztest_false(k_sem_take(psem, K_FOREVER), NULL);
 }
 
 
@@ -104,10 +104,10 @@ void sem_take_multiple_low_prio_helper(void *p1, void *p2, void *p3)
 	s32_t ret_value;
 
 	ret_value = k_sem_take(&low_prio_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "k_sem_take failed");
+	ztest_true(ret_value == 0, "k_sem_take failed");
 
 	ret_value = k_sem_take(&multiple_thread_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "k_sem_take failed");
+	ztest_true(ret_value == 0, "k_sem_take failed");
 
 	k_sem_give(&low_prio_sem);
 }
@@ -117,10 +117,10 @@ void sem_take_multiple_mid_prio_helper(void *p1, void *p2, void *p3)
 	s32_t ret_value;
 
 	ret_value = k_sem_take(&mid_prio_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "k_sem_take failed");
+	ztest_true(ret_value == 0, "k_sem_take failed");
 
 	ret_value = k_sem_take(&multiple_thread_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "k_sem_take failed");
+	ztest_true(ret_value == 0, "k_sem_take failed");
 
 	k_sem_give(&mid_prio_sem);
 }
@@ -130,10 +130,10 @@ void sem_take_multiple_high_prio_helper(void *p1, void *p2, void *p3)
 	s32_t ret_value;
 
 	ret_value = k_sem_take(&high_prio_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "k_sem_take failed");
+	ztest_true(ret_value == 0, "k_sem_take failed");
 
 	ret_value = k_sem_take(&multiple_thread_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "k_sem_take failed");
+	ztest_true(ret_value == 0, "k_sem_take failed");
 
 	k_sem_give(&high_prio_sem);
 }
@@ -155,7 +155,7 @@ void test_sema_thread2thread(void)
 	/**TESTPOINT: test k_sem_init sema*/
 	ret = k_sem_init(&sema, SEM_INIT_VAL, SEM_MAX_VAL);
 
-	zassert_equal(ret, 0, NULL);
+	ztest_equal(ret, 0, NULL);
 
 	tsema_thread_thread(&sema);
 
@@ -173,7 +173,7 @@ void test_sema_thread2isr(void)
 	/**TESTPOINT: test k_sem_init sema*/
 	ret = k_sem_init(&sema, SEM_INIT_VAL, SEM_MAX_VAL);
 
-	zassert_equal(ret, 0, NULL);
+	ztest_equal(ret, 0, NULL);
 	tsema_thread_isr(&sema);
 
 	/**TESTPOINT: test K_SEM_DEFINE sema*/
@@ -189,15 +189,15 @@ void test_k_sema_init(void)
 	int ret;
 
 	ret = k_sem_init(&sema, SEM_INIT_VAL, SEM_MAX_VAL);
-	zassert_equal(ret, 0, NULL);
+	ztest_equal(ret, 0, NULL);
 
 	k_sem_reset(&sema);
 
 	ret = k_sem_init(&sema, SEM_INIT_VAL, 0);
-	zassert_equal(ret, -EINVAL, NULL);
+	ztest_equal(ret, -EINVAL, NULL);
 
 	ret = k_sem_init(&sema, SEM_MAX_VAL + 1, SEM_MAX_VAL);
-	zassert_equal(ret, -EINVAL, NULL);
+	ztest_equal(ret, -EINVAL, NULL);
 
 }
 
@@ -211,17 +211,17 @@ void test_sema_reset(void)
 	int ret;
 
 	ret = k_sem_init(&sema, SEM_INIT_VAL, SEM_MAX_VAL);
-	zassert_equal(ret, 0, NULL);
+	ztest_equal(ret, 0, NULL);
 
 	k_sem_give(&sema);
 	k_sem_reset(&sema);
-	zassert_false(k_sem_count_get(&sema), NULL);
+	ztest_false(k_sem_count_get(&sema), NULL);
 	/**TESTPOINT: sem take return -EBUSY*/
-	zassert_equal(k_sem_take(&sema, K_NO_WAIT), -EBUSY, NULL);
+	ztest_equal(k_sem_take(&sema, K_NO_WAIT), -EBUSY, NULL);
 	/**TESTPOINT: sem take return -EAGAIN*/
-	zassert_equal(k_sem_take(&sema, SEM_TIMEOUT), -EAGAIN, NULL);
+	ztest_equal(k_sem_take(&sema, SEM_TIMEOUT), -EAGAIN, NULL);
 	k_sem_give(&sema);
-	zassert_false(k_sem_take(&sema, K_FOREVER), NULL);
+	ztest_false(k_sem_take(&sema, K_FOREVER), NULL);
 }
 
 /**
@@ -233,22 +233,22 @@ void test_sema_count_get(void)
 	int ret;
 
 	ret = k_sem_init(&sema, SEM_INIT_VAL, SEM_MAX_VAL);
-	zassert_equal(ret, 0, NULL);
+	ztest_equal(ret, 0, NULL);
 
 	/**TESTPOINT: sem count get upon init*/
-	zassert_equal(k_sem_count_get(&sema), SEM_INIT_VAL, NULL);
+	ztest_equal(k_sem_count_get(&sema), SEM_INIT_VAL, NULL);
 	k_sem_give(&sema);
 	/**TESTPOINT: sem count get after give*/
-	zassert_equal(k_sem_count_get(&sema), SEM_INIT_VAL + 1, NULL);
+	ztest_equal(k_sem_count_get(&sema), SEM_INIT_VAL + 1, NULL);
 	k_sem_take(&sema, K_FOREVER);
 	/**TESTPOINT: sem count get after take*/
 	for (int i = 0; i < SEM_MAX_VAL; i++) {
-		zassert_equal(k_sem_count_get(&sema), SEM_INIT_VAL + i, NULL);
+		ztest_equal(k_sem_count_get(&sema), SEM_INIT_VAL + i, NULL);
 		k_sem_give(&sema);
 	}
 	/**TESTPOINT: sem give above limit*/
 	k_sem_give(&sema);
-	zassert_equal(k_sem_count_get(&sema), SEM_MAX_VAL, NULL);
+	ztest_equal(k_sem_count_get(&sema), SEM_MAX_VAL, NULL);
 }
 
 
@@ -269,7 +269,7 @@ void test_simple_sem_from_isr(void)
 		sem_give_from_isr(&simple_sem);
 
 		signal_count = k_sem_count_get(&simple_sem);
-		zassert_true(signal_count == (i + 1),
+		ztest_true(signal_count == (i + 1),
 			     "signal count missmatch Expected %d, got %d",
 			     (i + 1), signal_count);
 	}
@@ -295,7 +295,7 @@ void test_simple_sem_from_task(void)
 		k_sem_give(&simple_sem);
 
 		signal_count = k_sem_count_get(&simple_sem);
-		zassert_true(signal_count == (i + 1),
+		ztest_true(signal_count == (i + 1),
 			     "signal count missmatch Expected %d, got %d",
 			     (i + 1), signal_count);
 	}
@@ -323,12 +323,12 @@ void test_sem_take_no_wait(void)
 
 	for (int i = 4; i >= 0; i--) {
 		ret_value = k_sem_take(&simple_sem, K_NO_WAIT);
-		zassert_true(ret_value == 0,
+		ztest_true(ret_value == 0,
 			     "unable to do k_sem_take which returned %d",
 			     ret_value);
 
 		signal_count = k_sem_count_get(&simple_sem);
-		zassert_true(signal_count == i,
+		ztest_true(signal_count == i,
 			     "signal count missmatch Expected %d, got %d",
 			     i, signal_count);
 	}
@@ -353,11 +353,11 @@ void test_sem_take_no_wait_fails(void)
 
 	for (int i = 4; i >= 0; i--) {
 		ret_value = k_sem_take(&simple_sem, K_NO_WAIT);
-		zassert_true(ret_value == -EBUSY,
+		ztest_true(ret_value == -EBUSY,
 			     "k_sem_take returned when not possible");
 
 		signal_count = k_sem_count_get(&simple_sem);
-		zassert_true(signal_count == 0U,
+		ztest_true(signal_count == 0U,
 			     "signal count missmatch Expected 0, got %d",
 			     signal_count);
 	}
@@ -380,7 +380,7 @@ void test_sem_take_timeout_fails(void)
 
 	for (int i = 4; i >= 0; i--) {
 		ret_value = k_sem_take(&simple_sem, SEM_TIMEOUT);
-		zassert_true(ret_value == -EAGAIN,
+		ztest_true(ret_value == -EAGAIN,
 			     "k_sem_take succeeded when its not possible");
 	}
 
@@ -407,7 +407,7 @@ void test_sem_take_timeout(void)
 	k_sem_reset(&simple_sem);
 
 	ret_value = k_sem_take(&simple_sem, SEM_TIMEOUT);
-	zassert_true(ret_value == 0, "k_sem_take failed");
+	ztest_true(ret_value == 0, "k_sem_take failed");
 	k_thread_abort(&sem_tid);
 
 }
@@ -433,7 +433,7 @@ void test_sem_take_timeout_forever(void)
 	k_sem_reset(&simple_sem);
 
 	ret_value = k_sem_take(&simple_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "k_sem_take failed");
+	ztest_true(ret_value == 0, "k_sem_take failed");
 	k_thread_abort(&sem_tid);
 
 }
@@ -459,7 +459,7 @@ void test_sem_take_timeout_isr(void)
 
 	ret_value = k_sem_take(&simple_sem, SEM_TIMEOUT);
 
-	zassert_true(ret_value == 0, "k_sem_take failed");
+	ztest_true(ret_value == 0, "k_sem_take failed");
 }
 
 /**
@@ -510,15 +510,15 @@ void test_sem_take_multiple(void)
 
 	/* check which threads completed. */
 	signal_count = k_sem_count_get(&high_prio_sem);
-	zassert_true(signal_count == 1U,
+	ztest_true(signal_count == 1U,
 		     "Higher priority threads didn't execute");
 
 	signal_count = k_sem_count_get(&mid_prio_sem);
-	zassert_true(signal_count == 0U,
+	ztest_true(signal_count == 0U,
 		     "Medium priority threads shouldn't have executed");
 
 	signal_count = k_sem_count_get(&low_prio_sem);
-	zassert_true(signal_count == 0U,
+	ztest_true(signal_count == 0U,
 		     "low priority threads shouldn't have executed");
 
 	/* enable the Medium priority thread to run. */
@@ -526,15 +526,15 @@ void test_sem_take_multiple(void)
 	k_sleep(K_MSEC(200));
 	/* check which threads completed. */
 	signal_count = k_sem_count_get(&high_prio_sem);
-	zassert_true(signal_count == 1U,
+	ztest_true(signal_count == 1U,
 		     "Higher priority thread executed again");
 
 	signal_count = k_sem_count_get(&mid_prio_sem);
-	zassert_true(signal_count == 1U,
+	ztest_true(signal_count == 1U,
 		     "Medium priority thread didn't get executed");
 
 	signal_count = k_sem_count_get(&low_prio_sem);
-	zassert_true(signal_count == 0U,
+	ztest_true(signal_count == 0U,
 		     "low priority thread shouldn't have executed");
 
 	/* enable the low priority thread to run. */
@@ -542,15 +542,15 @@ void test_sem_take_multiple(void)
 	k_sleep(K_MSEC(200));
 	/* check which threads completed. */
 	signal_count = k_sem_count_get(&high_prio_sem);
-	zassert_true(signal_count == 1U,
+	ztest_true(signal_count == 1U,
 		     "Higher priority thread executed again");
 
 	signal_count = k_sem_count_get(&mid_prio_sem);
-	zassert_true(signal_count == 1U,
+	ztest_true(signal_count == 1U,
 		     "Medium priority thread executed again");
 
 	signal_count = k_sem_count_get(&low_prio_sem);
-	zassert_true(signal_count == 1U,
+	ztest_true(signal_count == 1U,
 		     "low priority thread didn't get executed");
 
 }
@@ -570,7 +570,7 @@ void test_sem_give_take_from_isr(void)
 		sem_give_from_isr(&simple_sem);
 
 		signal_count = k_sem_count_get(&simple_sem);
-		zassert_true(signal_count == i + 1,
+		ztest_true(signal_count == i + 1,
 			     "signal count missmatch Expected %d, got %d",
 			     i + 1, signal_count);
 	}
@@ -580,7 +580,7 @@ void test_sem_give_take_from_isr(void)
 		sem_take_from_isr(&simple_sem);
 
 		signal_count = k_sem_count_get(&simple_sem);
-		zassert_true(signal_count == (i - 1),
+		ztest_true(signal_count == (i - 1),
 			     "signal count missmatch Expected %d, got %d",
 			     (i - 1), signal_count);
 	}
@@ -639,18 +639,18 @@ void test_sem_multiple_threads_wait(void)
 		/* check if all the threads are done. */
 		for (int i = 0; i < TOTAL_THREADS_WAITING; i++) {
 			ret_value = k_sem_take(&simple_sem, K_FOREVER);
-			zassert_true(ret_value == 0,
+			ztest_true(ret_value == 0,
 				     "Some of the threads didn't get multiple_thread_sem"
 				     );
 		}
 
 		signal_count = k_sem_count_get(&simple_sem);
-		zassert_true(signal_count == 0U,
+		ztest_true(signal_count == 0U,
 			     "signal count missmatch Expected 0, got %d",
 			     signal_count);
 
 		signal_count = k_sem_count_get(&multiple_thread_sem);
-		zassert_true(signal_count == 0U,
+		ztest_true(signal_count == 0U,
 			     "signal count missmatch Expected 0, got %d",
 			     signal_count);
 
@@ -680,9 +680,9 @@ void test_sem_measure_timeouts(void)
 
 	end_ticks = k_uptime_get();
 
-	zassert_true(ret_value == -EAGAIN, "k_sem_take failed");
+	ztest_true(ret_value == -EAGAIN, "k_sem_take failed");
 
-	zassert_true((end_ticks - start_ticks >= K_SECONDS(1)),
+	ztest_true((end_ticks - start_ticks >= K_SECONDS(1)),
 		     "time missmatch expected %d, got %d",
 		     K_SECONDS(1), end_ticks - start_ticks);
 
@@ -693,9 +693,9 @@ void test_sem_measure_timeouts(void)
 
 	end_ticks = k_uptime_get();
 
-	zassert_true(ret_value == -EBUSY, "k_sem_take failed");
+	ztest_true(ret_value == -EBUSY, "k_sem_take failed");
 
-	zassert_true((end_ticks - start_ticks < 1),
+	ztest_true((end_ticks - start_ticks < 1),
 		     "time missmatch expected %d, got %d",
 		     1, end_ticks - start_ticks);
 
@@ -742,9 +742,9 @@ void test_sem_measure_timeout_from_thread(void)
 
 	end_ticks = k_uptime_get();
 
-	zassert_true(ret_value == 0, "k_sem_take failed");
+	ztest_true(ret_value == 0, "k_sem_take failed");
 
-	zassert_true((end_ticks - start_ticks <= K_SECONDS(1)),
+	ztest_true((end_ticks - start_ticks <= K_SECONDS(1)),
 		     "time missmatch. expected less than%d ,got %d",
 		     K_SECONDS(1), end_ticks - start_ticks);
 
@@ -762,7 +762,7 @@ void sem_multiple_take_and_timeouts_helper(void *p1, void *p2, void *p3)
 
 	end_ticks = k_uptime_get();
 
-	zassert_true((end_ticks - start_ticks >= timeout),
+	ztest_true((end_ticks - start_ticks >= timeout),
 		     "time missmatch. expected less than %d ,got %d",
 		     timeout, end_ticks - start_ticks);
 
@@ -798,7 +798,7 @@ void test_sem_multiple_take_and_timeouts(void)
 	for (int i = 0; i < TOTAL_THREADS_WAITING; i++) {
 		k_pipe_get(&timeout_info_pipe, &timeout, sizeof(int),
 			   &bytes_read, sizeof(int), K_FOREVER);
-		zassert_true(timeout == K_SECONDS(i + 1),
+		ztest_true(timeout == K_SECONDS(i + 1),
 			     "timeout didn't occur properly");
 	}
 
@@ -827,7 +827,7 @@ void sem_multi_take_timeout_diff_sem_helper(void *p1, void *p2, void *p3)
 
 	end_ticks = k_uptime_get();
 
-	zassert_true((end_ticks - start_ticks >= timeout),
+	ztest_true((end_ticks - start_ticks >= timeout),
 		     "time missmatch. expected less than %d, got %d",
 		     timeout, end_ticks - start_ticks);
 
@@ -880,7 +880,7 @@ void test_sem_multi_take_timeout_diff_sem(void)
 			   K_FOREVER);
 
 
-		zassert_true(retrieved_info.timeout == K_SECONDS(i + 1),
+		ztest_true(retrieved_info.timeout == K_SECONDS(i + 1),
 			     "timeout didn't occur properly");
 	}
 

--- a/tests/kernel/sleep/src/main.c
+++ b/tests/kernel/sleep/src/main.c
@@ -230,14 +230,14 @@ void test_sleep(void)
 	/* Wake the test thread */
 	k_wakeup(test_thread_id);
 
-	zassert_false(test_failure, "test failure");
+	ztest_false(test_failure, "test failure");
 
 	TC_PRINT("Testing kernel k_sleep()\n");
 	align_to_tick_boundary();
 	start_tick = k_uptime_get_32();
 	k_sleep(ONE_SECOND);
 	end_tick = k_uptime_get_32();
-	zassert_true(sleep_time_valid(start_tick, end_tick, ONE_SECOND_ALIGNED),
+	ztest_true(sleep_time_valid(start_tick, end_tick, ONE_SECOND_ALIGNED),
 		     "k_sleep() slept for %d ticks, not %d\n",
 		     end_tick - start_tick, ONE_SECOND_ALIGNED);
 
@@ -251,7 +251,7 @@ static void forever_thread_entry(void *p1, void *p2, void *p3)
 	s32_t ret;
 
 	ret = k_sleep(K_FOREVER);
-	zassert_equal(ret, K_FOREVER, "unexpected return value");
+	ztest_equal(ret, K_FOREVER, "unexpected return value");
 	k_sem_give(&test_thread_sem);
 }
 

--- a/tests/kernel/sleep/src/usleep.c
+++ b/tests/kernel/sleep/src/usleep.c
@@ -88,6 +88,6 @@ void test_usleep(void)
 	}
 
 	printk("elapsed_ms = %lld\n", elapsed_ms);
-	zassert_true(elapsed_ms >= LOWER_BOUND_MS, "short sleep");
-	zassert_true(elapsed_ms <= UPPER_BOUND_MS, "overslept");
+	ztest_true(elapsed_ms >= LOWER_BOUND_MS, "short sleep");
+	ztest_true(elapsed_ms <= UPPER_BOUND_MS, "overslept");
 }

--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -121,7 +121,7 @@ void test_smp_coop_threads(void)
 	}
 
 	k_thread_abort(tid);
-	zassert_true(ok, "SMP test failed");
+	ztest_true(ok, "SMP test failed");
 }
 
 static void child_fn(void *p1, void *p2, void *p3)
@@ -130,7 +130,7 @@ static void child_fn(void *p1, void *p2, void *p3)
 	ARG_UNUSED(p3);
 	int parent_cpu_id = POINTER_TO_INT(p1);
 
-	zassert_true(parent_cpu_id != curr_cpu(),
+	ztest_true(parent_cpu_id != curr_cpu(),
 		     "Parent isn't on other core");
 
 	sync_count++;
@@ -261,10 +261,10 @@ void test_coop_resched_threads(void)
 	 * other cores except the last one
 	 */
 	for (int i = 0; i < THREADS_NUM - 1; i++) {
-		zassert_true(tinfo[i].executed == 1,
+		ztest_true(tinfo[i].executed == 1,
 			     "cooperative thread %d didn't run", i);
 	}
-	zassert_true(tinfo[THREADS_NUM - 1].executed == 0,
+	ztest_true(tinfo[THREADS_NUM - 1].executed == 0,
 		     "cooperative thread is preempted");
 
 	/* Abort threads created */
@@ -293,7 +293,7 @@ void test_preempt_resched_threads(void)
 	spin_for_threads_exit();
 
 	for (int i = 0; i < THREADS_NUM; i++) {
-		zassert_true(tinfo[i].executed == 1,
+		ztest_true(tinfo[i].executed == 1,
 			     "preemptive thread %d didn't run", i);
 	}
 
@@ -325,7 +325,7 @@ void test_yield_threads(void)
 	k_busy_wait(DELAY_US);
 
 	for (int i = 0; i < THREADS_NUM; i++) {
-		zassert_true(tinfo[i].executed == 1,
+		ztest_true(tinfo[i].executed == 1,
 			     "thread %d did not execute", i);
 
 	}
@@ -351,7 +351,7 @@ void test_sleep_threads(void)
 	k_sleep(TIMEOUT);
 
 	for (int i = 0; i < THREADS_NUM; i++) {
-		zassert_true(tinfo[i].executed == 1,
+		ztest_true(tinfo[i].executed == 1,
 			     "thread %d did not execute", i);
 	}
 
@@ -392,7 +392,7 @@ static void wakeup_on_start_thread(int tnum)
 			k_wakeup(tinfo[i].tid);
 		}
 	}
-	zassert_equal(threads_started, tnum,
+	ztest_equal(threads_started, tnum,
 		      "All threads haven't started");
 }
 
@@ -410,7 +410,7 @@ static void check_wokeup_threads(int tnum)
 			threads_woke_up++;
 		}
 	}
-	zassert_equal(threads_woke_up, tnum, "Threads did not wakeup");
+	ztest_equal(threads_woke_up, tnum, "Threads did not wakeup");
 }
 
 /**

--- a/tests/kernel/spinlock/src/main.c
+++ b/tests/kernel/spinlock/src/main.c
@@ -43,15 +43,15 @@ void test_spinlock_basic(void)
 	k_spinlock_key_t key;
 	static struct k_spinlock l;
 
-	zassert_true(!l.locked, "Spinlock initialized to locked");
+	ztest_true(!l.locked, "Spinlock initialized to locked");
 
 	key = k_spin_lock(&l);
 
-	zassert_true(l.locked, "Spinlock failed to lock");
+	ztest_true(l.locked, "Spinlock failed to lock");
 
 	k_spin_unlock(&l, key);
 
-	zassert_true(!l.locked, "Spinlock failed to unlock");
+	ztest_true(!l.locked, "Spinlock failed to unlock");
 }
 
 void bounce_once(int id)
@@ -79,7 +79,7 @@ void bounce_once(int id)
 		return;
 	}
 
-	zassert_true(locked, "Other cpu did not get lock in 10000 tries");
+	ztest_true(locked, "Other cpu did not get lock in 10000 tries");
 
 	/* Mark us as the owner, spin for a while validating that we
 	 * never see another owner write to the protected data.
@@ -87,7 +87,7 @@ void bounce_once(int id)
 	bounce_owner = id;
 
 	for (i = 0; i < 100; i++) {
-		zassert_true(bounce_owner == id, "Locked data changed");
+		ztest_true(bounce_owner == id, "Locked data changed");
 	}
 
 	/* Release the lock */

--- a/tests/kernel/stack/stack/src/main.c
+++ b/tests/kernel/stack/stack/src/main.c
@@ -124,7 +124,7 @@ static void thread_entry_fn_single(void *p1, void *p2, void *p3)
 	for (i = STACK_LEN; i; i--) {
 		k_stack_pop((struct k_stack *)p1, &tmp[i - 1], K_NO_WAIT);
 	}
-	zassert_false(memcmp(tmp, data1, STACK_LEN),
+	ztest_false(memcmp(tmp, data1, STACK_LEN),
 		      "Push & Pop items does not match");
 
 	/* Push items from stack */
@@ -149,7 +149,7 @@ static void thread_entry_fn_dual(void *p1, void *p2, void *p3)
 		k_stack_push(p1, data1[i]);
 
 	}
-	zassert_false(memcmp(tmp, data2, STACK_LEN),
+	ztest_false(memcmp(tmp, data2, STACK_LEN),
 		      "Push & Pop items does not match");
 }
 
@@ -157,7 +157,7 @@ static void thread_entry_fn_isr(void *p1, void *p2, void *p3)
 {
 	/* Pop items from stack2 */
 	irq_offload(tIsr_entry_pop, p2);
-	zassert_false(memcmp(data_isr, data2, STACK_LEN),
+	ztest_false(memcmp(data_isr, data2, STACK_LEN),
 		      "Push & Pop items does not match");
 
 	/* Push items to stack1 */
@@ -202,7 +202,7 @@ static void test_single_stack_play(void)
 		k_stack_pop(&stack1, &tmp[i - 1], K_NO_WAIT);
 	}
 
-	zassert_false(memcmp(tmp, data2, STACK_LEN),
+	ztest_false(memcmp(tmp, data2, STACK_LEN),
 		      "Push & Pop items does not match");
 
 	/* Clear the spawn thread to avoid side effect */
@@ -231,7 +231,7 @@ static void test_dual_stack_play(void)
 		k_stack_pop(&stack1, &tmp[i], K_FOREVER);
 	}
 
-	zassert_false(memcmp(tmp, data1, STACK_LEN),
+	ztest_false(memcmp(tmp, data1, STACK_LEN),
 		      "Push & Pop items does not match");
 
 	/* Clear the spawn thread to avoid side effect */
@@ -262,7 +262,7 @@ static void test_isr_stack_play(void)
 	/* Pop items from stack1 */
 	irq_offload(tIsr_entry_pop, &stack1);
 
-	zassert_false(memcmp(data_isr, data1, STACK_LEN),
+	ztest_false(memcmp(data_isr, data1, STACK_LEN),
 		      "Push & Pop items does not match");
 
 	/* Clear the spawn thread to avoid side effect */

--- a/tests/kernel/stack/stack/src/test_stack_contexts.c
+++ b/tests/kernel/stack/stack/src/test_stack_contexts.c
@@ -33,8 +33,8 @@ static void tstack_pop(struct k_stack *pstack)
 
 	for (int i = STACK_LEN - 1; i >= 0; i--) {
 		/**TESTPOINT: stack pop*/
-		zassert_false(k_stack_pop(pstack, &rx_data, K_NO_WAIT), NULL);
-		zassert_equal(rx_data, data[i], NULL);
+		ztest_false(k_stack_pop(pstack, &rx_data, K_NO_WAIT), NULL);
+		ztest_equal(rx_data, data[i], NULL);
 	}
 }
 
@@ -114,8 +114,8 @@ void test_stack_user_thread2thread(void)
 {
 	struct k_stack *stack = k_object_alloc(K_OBJ_STACK);
 
-	zassert_not_null(stack, "couldn't allocate stack object");
-	zassert_false(k_stack_alloc_init(stack, STACK_LEN),
+	ztest_not_null(stack, "couldn't allocate stack object");
+	ztest_false(k_stack_alloc_init(stack, STACK_LEN),
 		      "stack init failed");
 
 	tstack_thread_thread(stack);
@@ -164,7 +164,7 @@ void test_stack_alloc_thread2thread(void)
 
 	/** Requested buffer allocation from the test pool.*/
 	ret = k_stack_alloc_init(&kstack_test_alloc, (STACK_SIZE/2)+1);
-	zassert_true(ret == -ENOMEM,
+	ztest_true(ret == -ENOMEM,
 			"resource pool is smaller then requested buffer");
 }
 

--- a/tests/kernel/stack/stack/src/test_stack_fail.c
+++ b/tests/kernel/stack/stack/src/test_stack_fail.c
@@ -18,9 +18,9 @@ static void stack_pop_fail(struct k_stack *stack)
 	stack_data_t rx_data;
 
 	/**TESTPOINT: stack pop returns -EBUSY*/
-	zassert_equal(k_stack_pop(stack, &rx_data, K_NO_WAIT), -EBUSY, NULL);
+	ztest_equal(k_stack_pop(stack, &rx_data, K_NO_WAIT), -EBUSY, NULL);
 	/**TESTPOINT: stack pop returns -EAGAIN*/
-	zassert_equal(k_stack_pop(stack, &rx_data, TIMEOUT), -EAGAIN, NULL);
+	ztest_equal(k_stack_pop(stack, &rx_data, TIMEOUT), -EAGAIN, NULL);
 }
 
 /**
@@ -48,8 +48,8 @@ void test_stack_user_pop_fail(void)
 {
 	struct k_stack *alloc_stack = k_object_alloc(K_OBJ_STACK);
 
-	zassert_not_null(alloc_stack, "couldn't allocate stack object");
-	zassert_false(k_stack_alloc_init(alloc_stack, STACK_LEN),
+	ztest_not_null(alloc_stack, "couldn't allocate stack object");
+	ztest_false(k_stack_alloc_init(alloc_stack, STACK_LEN),
 		      "stack init failed");
 
 	stack_pop_fail(alloc_stack);

--- a/tests/kernel/threads/dynamic_thread/src/main.c
+++ b/tests/kernel/threads/dynamic_thread/src/main.c
@@ -46,7 +46,7 @@ static void create_dynamic_thread(void)
 
 	dyn_thread = k_object_alloc(K_OBJ_THREAD);
 
-	zassert_not_null(dyn_thread, "Cannot allocate thread k_object!");
+	ztest_not_null(dyn_thread, "Cannot allocate thread k_object!");
 
 	tid = k_thread_create(dyn_thread, dyn_thread_stack, STACKSIZE,
 			      dyn_thread_entry, NULL, NULL, NULL,
@@ -57,7 +57,7 @@ static void create_dynamic_thread(void)
 
 	k_sem_give(&start_sem);
 
-	zassert_true(k_sem_take(&end_sem, K_SECONDS(1)) == 0,
+	ztest_true(k_sem_take(&end_sem, K_SECONDS(1)) == 0,
 		     "k_sem_take(end_sem) failed");
 
 	k_thread_abort(tid);
@@ -72,7 +72,7 @@ static void permission_test(void)
 
 	dyn_thread = k_object_alloc(K_OBJ_THREAD);
 
-	zassert_not_null(dyn_thread, "Cannot allocate thread k_object!");
+	ztest_not_null(dyn_thread, "Cannot allocate thread k_object!");
 
 	tid = k_thread_create(dyn_thread, dyn_thread_stack, STACKSIZE,
 			      dyn_thread_entry, NULL, NULL, NULL,
@@ -91,7 +91,7 @@ static void permission_test(void)
 	 * If dyn_thread has permission to access end_sem,
 	 * k_sem_take() would be able to take the semaphore.
 	 */
-	zassert_true(k_sem_take(&end_sem, K_SECONDS(1)) != 0,
+	ztest_true(k_sem_take(&end_sem, K_SECONDS(1)) != 0,
 		     "Semaphore end_sem has incorrect permission");
 
 	k_thread_abort(tid);
@@ -134,7 +134,7 @@ static void test_thread_index_management(void)
 		ctr++;
 	}
 
-	zassert_true(ctr != 0, "unable to create any thread objects");
+	ztest_true(ctr != 0, "unable to create any thread objects");
 
 	TC_PRINT("created %d thread objects\n", ctr);
 
@@ -142,7 +142,7 @@ static void test_thread_index_management(void)
 	 * heap space/
 	 */
 	void *blob = k_malloc(256);
-	zassert_true(blob != NULL, "out of heap memory");
+	ztest_true(blob != NULL, "out of heap memory");
 
 	/* Free one of the threads... */
 	k_object_free(dynamic_threads[0]);
@@ -151,7 +151,7 @@ static void test_thread_index_management(void)
 	 * index should have been garbage collected.
 	 */
 	dynamic_threads[0] = k_object_alloc(K_OBJ_THREAD);
-	zassert_true(dynamic_threads[0] != NULL,
+	ztest_true(dynamic_threads[0] != NULL,
 		     "couldn't create thread object\n");
 
 	/* TODO: Implement a test that shows that thread IDs are properly

--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -57,7 +57,7 @@ static int main_prio;
  */
 void test_systhreads_main(void)
 {
-	zassert_true(main_prio == CONFIG_MAIN_THREAD_PRIORITY, NULL);
+	ztest_true(main_prio == CONFIG_MAIN_THREAD_PRIORITY, NULL);
 }
 
 /**
@@ -68,7 +68,7 @@ void test_systhreads_idle(void)
 {
 	k_sleep(K_MSEC(100));
 	/** TESTPOINT: check working thread priority should */
-	zassert_true(k_thread_priority_get(k_current_get()) <
+	ztest_true(k_thread_priority_get(k_current_get()) <
 		     K_IDLE_PRIO, NULL);
 }
 
@@ -76,13 +76,13 @@ static void customdata_entry(void *p1, void *p2, void *p3)
 {
 	long data = 1U;
 
-	zassert_is_null(k_thread_custom_data_get(), NULL);
+	ztest_is_null(k_thread_custom_data_get(), NULL);
 	while (1) {
 		k_thread_custom_data_set((void *)data);
 		/* relinguish cpu for a while */
 		k_sleep(K_MSEC(50));
 		/** TESTPOINT: custom data comparison */
-		zassert_equal(data, (long)k_thread_custom_data_get(), NULL);
+		ztest_equal(data, (long)k_thread_custom_data_get(), NULL);
 		data++;
 	}
 }
@@ -123,11 +123,11 @@ void test_thread_name_get_set(void)
 
 	/* Set and get current thread's name */
 	ret = k_thread_name_set(NULL, "parent_thread");
-	zassert_equal(ret, 0, "k_thread_name_set() failed");
+	ztest_equal(ret, 0, "k_thread_name_set() failed");
 	thread_name = k_thread_name_get(k_current_get());
-	zassert_true(thread_name != NULL, "thread name was null");
+	ztest_true(thread_name != NULL, "thread name was null");
 	ret = strcmp(thread_name, "parent_thread");
-	zassert_equal(ret, 0, "parent thread name does not match");
+	ztest_equal(ret, 0, "parent thread name does not match");
 
 	/* Set and get child thread's name */
 	k_tid_t tid = k_thread_create(&tdata_name, tstack_name, STACK_SIZE,
@@ -135,11 +135,11 @@ void test_thread_name_get_set(void)
 				      K_PRIO_PREEMPT(1), 0, K_NO_WAIT);
 
 	ret = k_thread_name_set(tid, "customdata");
-	zassert_equal(ret, 0, "k_thread_name_set() failed");
+	ztest_equal(ret, 0, "k_thread_name_set() failed");
 	ret = k_thread_name_copy(tid, thread_buf, sizeof(thread_buf));
-	zassert_equal(ret, 0, "couldn't get copied thread name");
+	ztest_equal(ret, 0, "couldn't get copied thread name");
 	ret = strcmp(thread_buf, "customdata");
-	zassert_equal(ret, 0, "child thread name does not match");
+	ztest_equal(ret, 0, "child thread name does not match");
 
 	/* cleanup environment */
 	k_thread_abort(tid);
@@ -165,36 +165,36 @@ void test_thread_name_user_get_set(void)
 
 	/* Some memory-related error cases for k_thread_name_set() */
 	ret = k_thread_name_set(NULL, (const char *)0xFFFFFFF0);
-	zassert_equal(ret, -EFAULT, "accepted nonsense string (%d)", ret);
+	ztest_equal(ret, -EFAULT, "accepted nonsense string (%d)", ret);
 	ret = k_thread_name_set(NULL, unreadable_string);
-	zassert_equal(ret, -EFAULT, "accepted unreadable string");
+	ztest_equal(ret, -EFAULT, "accepted unreadable string");
 	ret = k_thread_name_set((struct k_thread *)&sem, "some name");
-	zassert_equal(ret, -EINVAL, "accepted non-thread object");
+	ztest_equal(ret, -EINVAL, "accepted non-thread object");
 	ret = k_thread_name_set(&z_main_thread, "some name");
-	zassert_equal(ret, -EINVAL, "no permission on thread object");
+	ztest_equal(ret, -EINVAL, "no permission on thread object");
 
 	/* Set and get current thread's name */
 	ret = k_thread_name_set(NULL, "parent_thread");
-	zassert_equal(ret, 0, "k_thread_name_set() failed");
+	ztest_equal(ret, 0, "k_thread_name_set() failed");
 	ret = k_thread_name_copy(k_current_get(), thread_name,
 				     sizeof(thread_name));
-	zassert_equal(ret, 0, "k_thread_name_copy() failed");
+	ztest_equal(ret, 0, "k_thread_name_copy() failed");
 	ret = strcmp(thread_name, "parent_thread");
-	zassert_equal(ret, 0, "parent thread name does not match");
+	ztest_equal(ret, 0, "parent thread name does not match");
 
 	/* memory-related cases for k_thread_name_get() */
 	ret = k_thread_name_copy(k_current_get(), too_small,
 				     sizeof(too_small));
-	zassert_equal(ret, -ENOSPC, "wrote to too-small buffer");
+	ztest_equal(ret, -ENOSPC, "wrote to too-small buffer");
 	ret = k_thread_name_copy(k_current_get(), not_my_buffer,
 				     sizeof(not_my_buffer));
-	zassert_equal(ret, -EFAULT, "wrote to buffer without permission");
+	ztest_equal(ret, -EFAULT, "wrote to buffer without permission");
 	ret = k_thread_name_copy((struct k_thread *)&sem, thread_name,
 				     sizeof(thread_name));
-	zassert_equal(ret, -EINVAL, "not a thread object");
+	ztest_equal(ret, -EINVAL, "not a thread object");
 	ret = k_thread_name_copy(&z_main_thread, thread_name,
 				     sizeof(thread_name));
-	zassert_equal(ret, 0, "couldn't get main thread name");
+	ztest_equal(ret, 0, "couldn't get main thread name");
 	printk("Main thread name is '%s'\n", thread_name);
 
 	/* Set and get child thread's name */
@@ -202,11 +202,11 @@ void test_thread_name_user_get_set(void)
 				      thread_name_entry, NULL, NULL, NULL,
 				      K_PRIO_PREEMPT(1), K_USER, K_NO_WAIT);
 	ret = k_thread_name_set(tid, "customdata");
-	zassert_equal(ret, 0, "k_thread_name_set() failed");
+	ztest_equal(ret, 0, "k_thread_name_set() failed");
 	ret = k_thread_name_copy(tid, thread_name, sizeof(thread_name));
-	zassert_equal(ret, 0, "couldn't get copied thread name");
+	ztest_equal(ret, 0, "couldn't get copied thread name");
 	ret = strcmp(thread_name, "customdata");
-	zassert_equal(ret, 0, "child thread name does not match");
+	ztest_equal(ret, 0, "child thread name does not match");
 
 	/* cleanup environment */
 	k_thread_abort(tid);
@@ -243,7 +243,7 @@ static void umode_entry(void *thread_id, void *p2, void *p3)
 	    (k_current_get() == (k_tid_t)thread_id)) {
 		ztest_test_pass();
 	} else {
-		zassert_unreachable("User thread is essential or thread"
+		ztest_unreachable("User thread is essential or thread"
 				    " structure is corrupted\n");
 	}
 }
@@ -258,7 +258,7 @@ void test_user_mode(void)
 {
 	z_thread_essential_set();
 
-	zassert_true(z_is_thread_essential(), "Thread isn't set"
+	ztest_true(z_is_thread_essential(), "Thread isn't set"
 		     " as essential\n");
 
 	k_thread_user_mode_enter((k_thread_entry_t)umode_entry,
@@ -374,22 +374,22 @@ void test_thread_join(void)
 {
 #ifdef CONFIG_USERSPACE
 	/* scenario: thread never started */
-	zassert_equal(k_thread_join(&join_thread, K_FOREVER), 0,
+	ztest_equal(k_thread_join(&join_thread, K_FOREVER), 0,
 		      "failed case thread never started");
 #endif
-	zassert_equal(join_scenario(TIMEOUT), -EAGAIN, "failed timeout case");
-	zassert_equal(join_scenario(NO_WAIT), -EBUSY, "failed no-wait case");
-	zassert_equal(join_scenario(SELF_ABORT), 0, "failed self-abort case");
-	zassert_equal(join_scenario(OTHER_ABORT), 0, "failed other-abort case");
-	zassert_equal(join_scenario(ALREADY_EXIT), 0,
+	ztest_equal(join_scenario(TIMEOUT), -EAGAIN, "failed timeout case");
+	ztest_equal(join_scenario(NO_WAIT), -EBUSY, "failed no-wait case");
+	ztest_equal(join_scenario(SELF_ABORT), 0, "failed self-abort case");
+	ztest_equal(join_scenario(OTHER_ABORT), 0, "failed other-abort case");
+	ztest_equal(join_scenario(ALREADY_EXIT), 0,
 		      "failed already exit case");
 
 }
 
 void test_thread_join_isr(void)
 {
-	zassert_equal(join_scenario(ISR_RUNNING), -EBUSY, "failed isr running");
-	zassert_equal(join_scenario(ISR_ALREADY_EXIT), 0, "failed isr exited");
+	ztest_equal(join_scenario(ISR_RUNNING), -EBUSY, "failed isr running");
+	ztest_equal(join_scenario(ISR_ALREADY_EXIT), 0, "failed isr exited");
 }
 
 struct k_thread deadlock1_thread;
@@ -405,7 +405,7 @@ void deadlock1_entry(void *p1, void *p2, void *p3)
 	k_sleep(500);
 
 	ret = k_thread_join(&deadlock2_thread, K_FOREVER);
-	zassert_equal(ret, -EDEADLK, "failed mutual join case");
+	ztest_equal(ret, -EDEADLK, "failed mutual join case");
 }
 
 void deadlock2_entry(void *p1, void *p2, void *p3)
@@ -415,13 +415,13 @@ void deadlock2_entry(void *p1, void *p2, void *p3)
 	/* deadlock1_thread is active but currently sleeping */
 	ret = k_thread_join(&deadlock1_thread, K_FOREVER);
 
-	zassert_equal(ret, 0, "couldn't join deadlock2_thread");
+	ztest_equal(ret, 0, "couldn't join deadlock2_thread");
 }
 
 void test_thread_join_deadlock(void)
 {
 	/* Deadlock scenarios */
-	zassert_equal(k_thread_join(k_current_get(), K_FOREVER), -EDEADLK,
+	ztest_equal(k_thread_join(k_current_get(), K_FOREVER), -EDEADLK,
 				    "failed self-deadlock case");
 
 	k_thread_create(&deadlock1_thread, deadlock1_stack, STACK_SIZE,
@@ -431,9 +431,9 @@ void test_thread_join_deadlock(void)
 			deadlock2_entry, NULL, NULL, NULL,
 			K_PRIO_PREEMPT(1), K_USER | K_INHERIT_PERMS, K_NO_WAIT);
 
-	zassert_equal(k_thread_join(&deadlock1_thread, K_FOREVER), 0,
+	ztest_equal(k_thread_join(&deadlock1_thread, K_FOREVER), 0,
 		      "couldn't join deadlock1_thread");
-	zassert_equal(k_thread_join(&deadlock2_thread, K_FOREVER), 0,
+	ztest_equal(k_thread_join(&deadlock2_thread, K_FOREVER), 0,
 		      "couldn't join deadlock2_thread");
 }
 

--- a/tests/kernel/threads/thread_apis/src/test_essential_thread.c
+++ b/tests/kernel/threads/thread_apis/src/test_essential_thread.c
@@ -21,11 +21,11 @@ static void thread_entry(void *p1, void *p2, void *p3)
 	if (z_is_thread_essential()) {
 		k_busy_wait(100);
 	} else {
-		zassert_unreachable("The thread is not set as essential");
+		ztest_unreachable("The thread is not set as essential");
 	}
 
 	z_thread_essential_clear();
-	zassert_false(z_is_thread_essential(),
+	ztest_false(z_is_thread_essential(),
 		      "Essential flag of the thread is not cleared");
 
 	k_sem_give(&sync_sem);

--- a/tests/kernel/threads/thread_apis/src/test_kthread_for_each.c
+++ b/tests/kernel/threads/thread_apis/src/test_kthread_for_each.c
@@ -54,7 +54,7 @@ void test_k_thread_foreach(void)
 	/* Check thread_count non-zero, thread_flag
 	 * and stack_flag are not set.
 	 */
-	zassert_true(tcount && !thread_flag,
+	ztest_true(tcount && !thread_flag,
 				"thread_callback() not getting called");
 	/* Save the initial thread count */
 	count = tcount;
@@ -73,7 +73,7 @@ void test_k_thread_foreach(void)
 	k_thread_foreach(thread_callback, TEST_STRING);
 
 	/* Check thread_count > temp, thread_flag and stack_flag are set */
-	zassert_true((tcount > count) && thread_flag,
+	ztest_true((tcount > count) && thread_flag,
 					"thread_callback() not getting called");
 	k_thread_abort(tid);
 }

--- a/tests/kernel/threads/thread_apis/src/test_threads_cancel_abort.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_cancel_abort.c
@@ -27,7 +27,7 @@ static void thread_entry_abort(void *p1, void *p2, void *p3)
 	k_thread_abort(k_current_get());
 	/*unreachable*/
 	execute_flag = 2;
-	zassert_true(1 == 0, NULL);
+	ztest_true(1 == 0, NULL);
 }
 /**
  * @ingroup kernel_thread_tests
@@ -46,7 +46,7 @@ void test_threads_abort_self(void)
 			NULL, NULL, NULL, 0, K_USER, K_NO_WAIT);
 	k_sleep(K_MSEC(100));
 	/**TESTPOINT: spawned thread executed but abort itself*/
-	zassert_true(execute_flag == 1, NULL);
+	ztest_true(execute_flag == 1, NULL);
 }
 
 /**
@@ -69,7 +69,7 @@ void test_threads_abort_others(void)
 	k_thread_abort(tid);
 	k_sleep(K_MSEC(100));
 	/**TESTPOINT: check not-started thread is aborted*/
-	zassert_true(execute_flag == 0, NULL);
+	ztest_true(execute_flag == 0, NULL);
 
 	tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 			      thread_entry, NULL, NULL, NULL,
@@ -77,9 +77,9 @@ void test_threads_abort_others(void)
 	k_sleep(K_MSEC(50));
 	k_thread_abort(tid);
 	/**TESTPOINT: check running thread is aborted*/
-	zassert_true(execute_flag == 1, NULL);
+	ztest_true(execute_flag == 1, NULL);
 	k_sleep(K_MSEC(1000));
-	zassert_true(execute_flag == 1, NULL);
+	ztest_true(execute_flag == 1, NULL);
 }
 
 /**
@@ -117,7 +117,7 @@ static void abort_function(void)
 static void uthread_entry(void)
 {
 	block = k_malloc(BLOCK_SIZE);
-	zassert_true(block != NULL, NULL);
+	ztest_true(block != NULL, NULL);
 	printk("Child thread is running\n");
 	k_sleep(K_MSEC(2));
 }
@@ -144,7 +144,7 @@ void test_abort_handler(void)
 	printk("Calling abort of child from parent\n");
 	k_thread_abort(tid);
 
-	zassert_true(abort_called == true, "Abort handler"
+	ztest_true(abort_called == true, "Abort handler"
 		     " is not called");
 }
 
@@ -152,7 +152,7 @@ static void delayed_thread_entry(void *p1, void *p2, void *p3)
 {
 	execute_flag = 1;
 
-	zassert_unreachable("Delayed thread shouldn't be executed");
+	ztest_unreachable("Delayed thread shouldn't be executed");
 }
 
 /**
@@ -180,13 +180,13 @@ void test_delayed_thread_abort(void)
 	k_sleep(K_MSEC(50));
 
 	/* Test point: check if thread delayed for 100ms has not started*/
-	zassert_true(execute_flag == 0, "Delayed thread created is not"
+	ztest_true(execute_flag == 0, "Delayed thread created is not"
 		     " put to wait queue");
 
 	k_thread_abort(tid);
 
 	/* Test point: Test abort of thread before its execution*/
-	zassert_false(execute_flag == 1, "Delayed thread is has executed"
+	ztest_false(execute_flag == 1, "Delayed thread is has executed"
 		      " before cancellation");
 
 	/* Restore the priority */

--- a/tests/kernel/threads/thread_apis/src/test_threads_cpu_mask.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_cpu_mask.c
@@ -30,16 +30,16 @@ void test_threads_cpu_mask(void)
 
 	/* Shouldn't be able to operate on a running thread */
 	ret = k_thread_cpu_mask_clear(k_current_get());
-	zassert_true(ret == -EINVAL, "");
+	ztest_true(ret == -EINVAL, "");
 
 	ret = k_thread_cpu_mask_enable_all(k_current_get());
-	zassert_true(ret == -EINVAL, "");
+	ztest_true(ret == -EINVAL, "");
 
 	ret = k_thread_cpu_mask_enable(k_current_get(), 0);
-	zassert_true(ret == -EINVAL, "");
+	ztest_true(ret == -EINVAL, "");
 
 	ret = k_thread_cpu_mask_disable(k_current_get(), 0);
-	zassert_true(ret == -EINVAL, "");
+	ztest_true(ret == -EINVAL, "");
 
 	for (pass = 0; pass < 4; pass++) {
 		child_has_run = false;
@@ -48,7 +48,7 @@ void test_threads_cpu_mask(void)
 		 * it yet.
 		 */
 		prio = k_thread_priority_get(k_current_get());
-		zassert_true(prio > K_HIGHEST_APPLICATION_THREAD_PRIO, "");
+		ztest_true(prio > K_HIGHEST_APPLICATION_THREAD_PRIO, "");
 		thread = k_thread_create(&child_thread,
 					 tstack, tstack_size,
 					 child_fn, NULL, NULL, NULL,
@@ -58,29 +58,29 @@ void test_threads_cpu_mask(void)
 		/* Set up the CPU mask */
 		if (pass == 0) {
 			ret = k_thread_cpu_mask_clear(thread);
-			zassert_true(ret == 0, "");
+			ztest_true(ret == 0, "");
 		} else if (pass == 1) {
 			ret = k_thread_cpu_mask_enable_all(thread);
-			zassert_true(ret == 0, "");
+			ztest_true(ret == 0, "");
 		} else if (pass == 2) {
 			ret = k_thread_cpu_mask_disable(thread, 0);
-			zassert_true(ret == 0, "");
+			ztest_true(ret == 0, "");
 		} else {
 			ret = k_thread_cpu_mask_enable(thread, 0);
-			zassert_true(ret == 0, "");
+			ztest_true(ret == 0, "");
 		}
 
 		/* Start it.  If it is runnable, it will do so
 		 * immediately when we yield.  Check to see if it ran.
 		 */
-		zassert_false(child_has_run, "");
+		ztest_false(child_has_run, "");
 		k_thread_start(thread);
 		k_yield();
 
 		if (pass == 1 || pass == 3) {
-			zassert_true(child_has_run, "");
+			ztest_true(child_has_run, "");
 		} else {
-			zassert_false(child_has_run, "");
+			ztest_false(child_has_run, "");
 		}
 
 		k_thread_abort(thread);

--- a/tests/kernel/threads/thread_apis/src/test_threads_set_priority.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_set_priority.c
@@ -50,21 +50,21 @@ void test_threads_priority_set(void)
 	/* Lower the priority of the current thread (thread1) */
 	k_thread_priority_set(k_current_get(), prio + 2);
 	rv = k_thread_priority_get(k_current_get());
-	zassert_equal(rv, prio + 2,
+	ztest_equal(rv, prio + 2,
 		      "Expected priority to be changed to %d, not %d\n",
 		      prio + 2, rv);
 
 	/* Raise the priority of the current thread (thread1) */
 	k_thread_priority_set(k_current_get(), prio - 2);
 	rv = k_thread_priority_get(k_current_get());
-	zassert_equal(rv, prio - 2,
+	ztest_equal(rv, prio - 2,
 		      "Expected priority to be changed to %d, not %d\n",
 		      prio - 2, rv);
 
 	/* Restore the priority of the current thread (thread1) */
 	k_thread_priority_set(k_current_get(), prio);
 	rv = k_thread_priority_get(k_current_get());
-	zassert_equal(rv, prio,
+	ztest_equal(rv, prio,
 		      "Expected priority to be changed to %d, not %d\n",
 		      prio, rv);
 
@@ -80,7 +80,7 @@ void test_threads_priority_set(void)
 	k_thread_priority_set(thread2_id, thread2_prio + 2);
 	k_sem_give(&sem_thread2);
 	k_sem_take(&sem_thread1, K_FOREVER);
-	zassert_equal(thread2_data, thread2_prio + 2,
+	ztest_equal(thread2_data, thread2_prio + 2,
 		      "Expected priority to be changed to %d, not %d\n",
 		      thread2_prio + 2, thread2_data);
 
@@ -88,7 +88,7 @@ void test_threads_priority_set(void)
 	k_thread_priority_set(thread2_id, thread2_prio - 2);
 	k_sem_give(&sem_thread2);
 	k_sem_take(&sem_thread1, K_FOREVER);
-	zassert_equal(thread2_data, thread2_prio - 2,
+	ztest_equal(thread2_data, thread2_prio - 2,
 		      "Expected priority to be changed to %d, not %d\n",
 		      thread2_prio - 2, thread2_data);
 
@@ -96,7 +96,7 @@ void test_threads_priority_set(void)
 	k_thread_priority_set(thread2_id, thread2_prio);
 	k_sem_give(&sem_thread2);
 	k_sem_take(&sem_thread1, K_FOREVER);
-	zassert_equal(thread2_data, thread2_prio,
+	ztest_equal(thread2_data, thread2_prio,
 		      "Expected priority to be changed to %d, not %d\n",
 		      thread2_prio, thread2_data);
 }

--- a/tests/kernel/threads/thread_apis/src/test_threads_spawn.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_spawn.c
@@ -17,15 +17,15 @@ static ZTEST_BMEM int spawn_prio;
 static void thread_entry_params(void *p1, void *p2, void *p3)
 {
 	/* checkpoint: check parameter 1, 2, 3 */
-	zassert_equal(p1, tp1, NULL);
-	zassert_equal(POINTER_TO_INT(p2), tp2, NULL);
-	zassert_equal(p3, tp3, NULL);
+	ztest_equal(p1, tp1, NULL);
+	ztest_equal(POINTER_TO_INT(p2), tp2, NULL);
+	ztest_equal(p3, tp3, NULL);
 }
 
 static void thread_entry_priority(void *p1, void *p2, void *p3)
 {
 	/* checkpoint: check priority */
-	zassert_equal(k_thread_priority_get(k_current_get()), spawn_prio, NULL);
+	ztest_equal(k_thread_priority_get(k_current_get()), spawn_prio, NULL);
 }
 
 static void thread_entry_delay(void *p1, void *p2, void *p3)
@@ -89,10 +89,10 @@ void test_threads_spawn_delay(void)
 	/* 100 < 120 ensure spawn thread not start */
 	k_sleep(K_MSEC(100));
 	/* checkpoint: check spawn thread not execute */
-	zassert_true(tp2 == 10, NULL);
+	ztest_true(tp2 == 10, NULL);
 	/* checkpoint: check spawn thread executed */
 	k_sleep(K_MSEC(100));
-	zassert_true(tp2 == 100, NULL);
+	ztest_true(tp2 == 100, NULL);
 }
 
 /**
@@ -119,11 +119,11 @@ void test_threads_spawn_forever(void)
 				      K_USER, K_FOREVER);
 	k_yield();
 	/* checkpoint: check spawn thread not execute */
-	zassert_true(tp2 == 10, NULL);
+	ztest_true(tp2 == 10, NULL);
 	/* checkpoint: check spawn thread executed */
 	k_thread_start(tid);
 	k_yield();
-	zassert_true(tp2 == 100, NULL);
+	ztest_true(tp2 == 100, NULL);
 	k_thread_abort(tid);
 }
 
@@ -146,7 +146,7 @@ void test_thread_start(void)
 
 	k_thread_start(tid);
 	k_yield();
-	zassert_true(tp2 == 100, NULL);
+	ztest_true(tp2 == 100, NULL);
 
 	/* checkpoint: k_thread_start() should not start the
 	 * terminated thread
@@ -155,5 +155,5 @@ void test_thread_start(void)
 	tp2 = 50;
 	k_thread_start(tid);
 	k_yield();
-	zassert_false(tp2 == 100, NULL);
+	ztest_false(tp2 == 100, NULL);
 }

--- a/tests/kernel/threads/thread_apis/src/test_threads_suspend_resume.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_suspend_resume.c
@@ -31,11 +31,11 @@ static void threads_suspend_resume(int prio)
 	k_thread_suspend(tid);
 	k_sleep(K_MSEC(100));
 	/* checkpoint: created thread shouldn't be executed after suspend */
-	zassert_false(last_prio == create_prio, NULL);
+	ztest_false(last_prio == create_prio, NULL);
 	k_thread_resume(tid);
 	k_sleep(K_MSEC(100));
 	/* checkpoint: created thread should be executed after resume */
-	zassert_true(last_prio == create_prio, NULL);
+	ztest_true(last_prio == create_prio, NULL);
 }
 
 /*test cases*/
@@ -101,7 +101,7 @@ void test_threads_suspend(void)
 	 * stopped executing after suspending itself.
 	 */
 	k_sleep(K_MSEC(100));
-	zassert_false(after_suspend, "thread woke up unexpectedly");
+	ztest_false(after_suspend, "thread woke up unexpectedly");
 
 	k_thread_abort(tid);
 }
@@ -142,7 +142,7 @@ void test_threads_suspend_timeout(void)
 	 * has been suspended)
 	 */
 	k_sleep(K_MSEC(200));
-	zassert_false(after_suspend, "thread woke up unexpectedly");
+	ztest_false(after_suspend, "thread woke up unexpectedly");
 
 	k_thread_abort(tid);
 }

--- a/tests/kernel/threads/thread_init/src/main.c
+++ b/tests/kernel/threads/thread_init/src/main.c
@@ -59,7 +59,7 @@ static void thread_entry(void *p1, void *p2, void *p3)
 	if (t_create) {
 		u64_t t_delay = k_uptime_get() - t_create;
 		/**TESTPOINT: check delay start*/
-		zassert_true(t_delay >= expected.init_delay,
+		ztest_true(t_delay >= expected.init_delay,
 			     "k_thread_create delay start failed");
 	}
 
@@ -67,10 +67,10 @@ static void thread_entry(void *p1, void *p2, void *p3)
 
 	k_tid_t tid = k_current_get();
 	/**TESTPOINT: check priority and params*/
-	zassert_equal(k_thread_priority_get(tid), expected.init_prio, NULL);
-	zassert_equal(p1, expected.init_p1, NULL);
-	zassert_equal(p2, expected.init_p2, NULL);
-	zassert_equal(p3, expected.init_p3, NULL);
+	ztest_equal(k_thread_priority_get(tid), expected.init_prio, NULL);
+	ztest_equal(p1, expected.init_p1, NULL);
+	ztest_equal(p2, expected.init_p2, NULL);
+	ztest_equal(p3, expected.init_p3, NULL);
 	/*option, stack size, not checked, no public API to get these values*/
 
 	k_sem_give(&end_sema);
@@ -148,7 +148,7 @@ void test_kinit_preempt_thread(void)
 
 	/*record time stamp of thread creation*/
 	t_create = k_uptime_get();
-	zassert_not_null(pthread, "thread creation failed");
+	ztest_not_null(pthread, "thread creation failed");
 
 	expected.init_p1 = INIT_PREEMPT_P1;
 	expected.init_p2 = INIT_PREEMPT_P2;
@@ -181,7 +181,7 @@ void test_kinit_coop_thread(void)
 
 	/*record time stamp of thread creation*/
 	t_create = k_uptime_get();
-	zassert_not_null(pthread, "thread spawn failed");
+	ztest_not_null(pthread, "thread spawn failed");
 
 	expected.init_p1 = INIT_COOP_P1;
 	expected.init_p2 = INIT_COOP_P2;

--- a/tests/kernel/tickless/tickless/src/main.c
+++ b/tests/kernel/tickless/tickless/src/main.c
@@ -203,7 +203,7 @@ void ticklessTestThread(void)
 
 	printk("variance in time stamp diff: %d percent\n", (s32_t)diff_per);
 
-	zassert_equal(diff_ticks, SLEEP_TICKS,
+	ztest_equal(diff_ticks, SLEEP_TICKS,
 		      "* TEST FAILED. TICK COUNT INCORRECT *");
 
 	/* release the timer, if necessary */

--- a/tests/kernel/tickless/tickless_concept/src/main.c
+++ b/tests/kernel/tickless/tickless_concept/src/main.c
@@ -54,9 +54,9 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 		t, SLICE_SIZE, SLICE_SIZE_LIMIT);
 
 	/**TESTPOINT: verify slicing scheduler behaves as expected*/
-	zassert_true(t >= SLICE_SIZE, NULL);
+	ztest_true(t >= SLICE_SIZE, NULL);
 	/*less than one tick delay*/
-	zassert_true(t <= SLICE_SIZE_LIMIT, NULL);
+	ztest_true(t <= SLICE_SIZE_LIMIT, NULL);
 
 	/*keep the current thread busy for more than one slice*/
 	k_busy_wait(1000 * SLEEP_TICKLESS);
@@ -83,7 +83,7 @@ void test_tickless_sysclock(void)
 	t1 = k_uptime_get_32();
 	TC_PRINT("time %d, %d\n", t0, t1);
 	/**TESTPOINT: verify system clock recovery after exiting tickless idle*/
-	zassert_true((t1 - t0) >= SLEEP_TICKLESS, NULL);
+	ztest_true((t1 - t0) >= SLEEP_TICKLESS, NULL);
 
 	ALIGN_MS_BOUNDARY();
 	t0 = k_uptime_get_32();
@@ -91,7 +91,7 @@ void test_tickless_sysclock(void)
 	t1 = k_uptime_get_32();
 	TC_PRINT("time %d, %d\n", t0, t1);
 	/**TESTPOINT: verify system clock recovery after exiting tickful idle*/
-	zassert_true((t1 - t0) >= SLEEP_TICKFUL, NULL);
+	ztest_true((t1 - t0) >= SLEEP_TICKFUL, NULL);
 }
 
 /**

--- a/tests/kernel/timer/starve/src/main.c
+++ b/tests/kernel/timer/starve/src/main.c
@@ -65,7 +65,7 @@ static void test_starve(void)
 
 		s32_t now_diff = now - last_now;
 
-		zassert_true(now_diff > 0,
+		ztest_true(now_diff > 0,
 			     "%sTime went backwards by %d: was %u.%03u\n",
 			     tag(), -now_diff, last_now / MSEC_PER_SEC,
 			     last_now % MSEC_PER_SEC);
@@ -75,14 +75,14 @@ static void test_starve(void)
 		u64_t ticks = z_tick_get();
 		s64_t ticks_diff = ticks - last_ticks;
 
-		zassert_true(ticks_diff > 0,
+		ztest_true(ticks_diff > 0,
 			     "%sTicks went backwards by %d\n",
 			     tag(), -(s32_t)ticks_diff);
 		last_ticks = ticks;
 
 		u32_t na_capture = na;
 
-		zassert_equal(na_capture, 0,
+		ztest_equal(na_capture, 0,
 			      "%sTimer alarm fired: %u\n",
 			      na_capture);
 

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -43,7 +43,7 @@ extern void test_time_conversions(void);
 	do {					 \
 		if (!(exp)) {			 \
 			k_timer_stop(tmr);	 \
-			zassert_true(exp, NULL); \
+			ztest_true(exp, NULL); \
 		}				 \
 	} while (0)
 
@@ -483,7 +483,7 @@ void test_timer_user_data(void)
 				      (void *)user_data[ii]);
 		check = (intptr_t)k_timer_user_data_get(user_data_timer[ii]);
 
-		zassert_true(check == user_data[ii], NULL);
+		ztest_true(check == user_data[ii], NULL);
 	}
 
 	for (ii = 0; ii < 5; ii++) {
@@ -497,7 +497,7 @@ void test_timer_user_data(void)
 	}
 
 	for (ii = 0; ii < 5; ii++) {
-		zassert_true(user_data_correct[ii], NULL);
+		ztest_true(user_data_correct[ii], NULL);
 	}
 }
 
@@ -532,7 +532,7 @@ void test_timer_remaining_get(void)
 	 * the value obtained through k_timer_remaining_get() could be larger
 	 * than actual remaining time with maximum error equal to one tick.
 	 */
-	zassert_true(remaining <= (DURATION / 2) + k_ticks_to_ms_floor64(1), NULL);
+	ztest_true(remaining <= (DURATION / 2) + k_ticks_to_ms_floor64(1), NULL);
 }
 
 static void timer_init(struct k_timer *timer, k_timer_expiry_t expiry_fn,

--- a/tests/kernel/timer/timer_api/src/timer_convert.c
+++ b/tests/kernel/timer/timer_api/src/timer_convert.c
@@ -154,7 +154,7 @@ void test_conversion(struct test_rec *t, u64_t val)
 		mindiff = -(s64_t)(from_hz/2);
 	}
 
-	zassert_true(diff <= maxdiff && diff >= mindiff,
+	ztest_true(diff <= maxdiff && diff >= mindiff,
 		     "Convert %lld from %lldhz to %lldhz (= %lld) failed. "
 		     "diff %lld should be in [%lld:%lld]",
 		     val, from_hz, to_hz, result, diff, mindiff, maxdiff);

--- a/tests/kernel/timer/timer_monotonic/src/main.c
+++ b/tests/kernel/timer/timer_monotonic/src/main.c
@@ -75,9 +75,9 @@ void test_timer(void)
 		t_last = t_now;
 	}
 
-	zassert_false(errors, "errors = %d\n", errors);
+	ztest_false(errors, "errors = %d\n", errors);
 
-	zassert_false(test_frequency(), "test frequency failed");
+	ztest_false(test_frequency(), "test frequency failed");
 }
 
 void test_main(void)

--- a/tests/kernel/workq/work_queue/src/main.c
+++ b/tests/kernel/workq/work_queue/src/main.c
@@ -130,12 +130,12 @@ static void check_results(int num_tests)
 {
 	int i;
 
-	zassert_equal(num_results, num_tests,
+	ztest_equal(num_results, num_tests,
 		      "*** work items finished: %d (expected: %d)\n",
 		      num_results, num_tests);
 
 	for (i = 0; i < num_tests; i++) {
-		zassert_equal(results[i], i + 1,
+		ztest_equal(results[i], i + 1,
 			      "*** got result %d in position %d"
 			      " (expected %d)\n",
 			      results[i], i, i + 1);
@@ -271,7 +271,7 @@ static void test_delayed_submit(void)
 	for (i = 0; i < NUM_TEST_ITEMS; i += 2) {
 		TC_PRINT(" - Submitting delayed work %d from"
 			 " preempt thread\n", i + 1);
-		zassert_true(k_delayed_work_submit(&delayed_tests[i].work,
+		ztest_true(k_delayed_work_submit(&delayed_tests[i].work,
 						   (i + 1) * WORK_ITEM_WAIT) == 0, NULL);
 	}
 
@@ -443,7 +443,7 @@ static void triggered_work_handler(struct k_work *work)
 
 	TC_PRINT(" - Running triggered test item %d\n", ti->key);
 
-	zassert_equal(ti->work.poll_result, expected_poll_result,
+	ztest_equal(ti->work.poll_result, expected_poll_result,
 		     "res %d expect %d", ti->work.poll_result, expected_poll_result);
 
 	results[num_results++] = ti->key;
@@ -486,7 +486,7 @@ static void test_triggered_submit(s32_t timeout)
 
 	for (i = 0; i < NUM_TEST_ITEMS; i++) {
 		TC_PRINT(" - Submitting triggered work %d\n", i + 1);
-		zassert_true(k_work_poll_submit(&triggered_tests[i].work,
+		ztest_true(k_work_poll_submit(&triggered_tests[i].work,
 						&triggered_tests[i].event,
 						1, timeout) == 0, NULL);
 	}
@@ -503,7 +503,7 @@ static void test_triggered_trigger(void)
 
 	for (i = 0; i < NUM_TEST_ITEMS; i++) {
 		TC_PRINT(" - Triggering work %d\n", i + 1);
-		zassert_true(k_poll_signal_raise(&triggered_tests[i].signal,
+		ztest_true(k_poll_signal_raise(&triggered_tests[i].signal,
 						 1) == 0, NULL);
 	}
 }
@@ -582,7 +582,7 @@ static void triggered_resubmit_work_handler(struct k_work *work)
 		TC_PRINT(" - Resubmitting triggered work\n");
 
 		k_poll_signal_reset(&triggered_tests[0].signal);
-		zassert_true(k_work_poll_submit(&triggered_tests[0].work,
+		ztest_true(k_work_poll_submit(&triggered_tests[0].work,
 						&triggered_tests[0].event,
 						1, K_FOREVER) == 0, NULL);
 	}
@@ -615,14 +615,14 @@ static void test_triggered_resubmit(void)
 			  &triggered_tests[0].signal);
 
 	TC_PRINT(" - Submitting triggered work\n");
-	zassert_true(k_work_poll_submit(&triggered_tests[0].work,
+	ztest_true(k_work_poll_submit(&triggered_tests[0].work,
 					&triggered_tests[0].event,
 					1, K_FOREVER) == 0, NULL);
 
 	for (i = 0; i < NUM_TEST_ITEMS; i++) {
 		TC_PRINT(" - Triggering test item execution (iteration: %d)\n",
 									i + 1);
-		zassert_true(k_poll_signal_raise(&triggered_tests[0].signal,
+		ztest_true(k_poll_signal_raise(&triggered_tests[0].signal,
 						 1) == 0, NULL);
 		k_sleep(WORK_ITEM_WAIT);
 	}

--- a/tests/kernel/workq/work_queue_api/src/main.c
+++ b/tests/kernel/workq/work_queue_api/src/main.c
@@ -61,11 +61,11 @@ static void twork_submit_1(struct k_work_q *work_q, struct k_work *w,
 	/**TESTPOINT: init via k_work_init*/
 	k_work_init(w, handler);
 	/**TESTPOINT: check pending after work init*/
-	zassert_false(k_work_pending(w), NULL);
+	ztest_false(k_work_pending(w), NULL);
 
 	if (work_q) {
 		/**TESTPOINT: work submit to queue*/
-		zassert_false(k_work_submit_to_user_queue(work_q, w),
+		ztest_false(k_work_submit_to_user_queue(work_q, w),
 			      "failed to submit to queue");
 	} else {
 		/**TESTPOINT: work submit to system queue*/
@@ -91,7 +91,7 @@ static void twork_submit_multipleq(void *data)
 
 	k_delayed_work_submit_to_queue(work_q, &new_work, TIMEOUT);
 
-	zassert_equal(k_delayed_work_submit(&new_work, TIMEOUT),
+	ztest_equal(k_delayed_work_submit(&new_work, TIMEOUT),
 		      -EADDRINUSE, NULL);
 
 	k_sem_give(&sync_sema);
@@ -113,7 +113,7 @@ static void twork_resubmit(void *data)
 	 */
 	k_queue_remove(&(new_work.work_q->queue), &(new_work.work));
 
-	zassert_equal(k_delayed_work_submit_to_queue(work_q, &new_work, K_NO_WAIT),
+	ztest_equal(k_delayed_work_submit_to_queue(work_q, &new_work, K_NO_WAIT),
 		      -EINVAL, NULL);
 
 	k_sem_give(&sync_sema);
@@ -132,33 +132,33 @@ static void tdelayed_work_submit_1(struct k_work_q *work_q,
 	/**TESTPOINT: init via k_delayed_work_init*/
 	k_delayed_work_init(w, handler);
 	/**TESTPOINT: check pending after delayed work init*/
-	zassert_false(k_work_pending((struct k_work *)w), NULL);
+	ztest_false(k_work_pending((struct k_work *)w), NULL);
 	/**TESTPOINT: check remaining timeout before submit*/
-	zassert_equal(k_delayed_work_remaining_get(w), 0, NULL);
+	ztest_equal(k_delayed_work_remaining_get(w), 0, NULL);
 
 	if (work_q) {
 		/**TESTPOINT: delayed work submit to queue*/
-		zassert_true(k_delayed_work_submit_to_queue(work_q, w, TIMEOUT)
+		ztest_true(k_delayed_work_submit_to_queue(work_q, w, TIMEOUT)
 			     == 0, NULL);
 	} else {
 		/**TESTPOINT: delayed work submit to system queue*/
-		zassert_true(k_delayed_work_submit(w, TIMEOUT) == 0, NULL);
+		ztest_true(k_delayed_work_submit(w, TIMEOUT) == 0, NULL);
 	}
 
 	time_remaining = k_delayed_work_remaining_get(w);
 	timeout_ticks = z_ms_to_ticks(TIMEOUT);
 
 	/**TESTPOINT: check remaining timeout after submit */
-	zassert_true(time_remaining <= k_ticks_to_ms_floor64(timeout_ticks +
+	ztest_true(time_remaining <= k_ticks_to_ms_floor64(timeout_ticks +
 		     _TICK_ALIGN), NULL);
 
 	timeout_ticks -= z_ms_to_ticks(15);
 
-	zassert_true(time_remaining >= k_ticks_to_ms_floor64(timeout_ticks),
+	ztest_true(time_remaining >= k_ticks_to_ms_floor64(timeout_ticks),
 		     NULL);
 
 	/**TESTPOINT: check pending after delayed work submit*/
-	zassert_true(k_work_pending((struct k_work *)w) == 0, NULL);
+	ztest_true(k_work_pending((struct k_work *)w) == 0, NULL);
 }
 
 static void tdelayed_work_submit(void *data)
@@ -201,30 +201,30 @@ static void tdelayed_work_cancel(void *data)
 	 *                delayed_work[1] completed
 	 *                cancel delayed_work_sleepy, expected 0
 	 */
-	zassert_true(ret == 0, NULL);
+	ztest_true(ret == 0, NULL);
 	/**TESTPOINT: delayed work cancel when countdown*/
 	ret = k_delayed_work_cancel(&delayed_work[0]);
-	zassert_true(ret == 0, NULL);
+	ztest_true(ret == 0, NULL);
 	/**TESTPOINT: check pending after delayed work cancel*/
-	zassert_false(k_work_pending((struct k_work *)&delayed_work[0]), NULL);
+	ztest_false(k_work_pending((struct k_work *)&delayed_work[0]), NULL);
 	if (!k_is_in_isr()) {
 		/*wait for handling work_sleepy*/
 		k_sleep(TIMEOUT);
 		/**TESTPOINT: check pending when work pending*/
-		zassert_true(k_work_pending((struct k_work *)&delayed_work[1]),
+		ztest_true(k_work_pending((struct k_work *)&delayed_work[1]),
 			     NULL);
 		/**TESTPOINT: delayed work cancel when pending*/
 		ret = k_delayed_work_cancel(&delayed_work[1]);
-		zassert_equal(ret, 0, NULL);
+		ztest_equal(ret, 0, NULL);
 		k_sem_give(&sync_sema);
 		/*wait for completed work_sleepy and delayed_work[1]*/
 		k_sleep(TIMEOUT);
 		/**TESTPOINT: check pending when work completed*/
-		zassert_false(k_work_pending(
+		ztest_false(k_work_pending(
 				      (struct k_work *)&delayed_work_sleepy), NULL);
 		/**TESTPOINT: delayed work cancel when completed*/
 		ret = k_delayed_work_cancel(&delayed_work_sleepy);
-		zassert_not_equal(ret, 0, NULL);
+		ztest_not_equal(ret, 0, NULL);
 	}
 	/*work items not cancelled: delayed_work[1], delayed_work_sleepy*/
 }
@@ -243,33 +243,33 @@ static void ttriggered_work_submit(void *data)
 		/**TESTPOINT: init via k_work_poll_init*/
 		k_work_poll_init(&triggered_work[i], work_handler);
 		/**TESTPOINT: check pending after triggered work init*/
-		zassert_false(k_work_pending(
+		ztest_false(k_work_pending(
 			     (struct k_work *)&triggered_work[i]), NULL);
 		if (work_q) {
 			/**TESTPOINT: triggered work submit to queue*/
-			zassert_true(k_work_poll_submit_to_queue(work_q,
+			ztest_true(k_work_poll_submit_to_queue(work_q,
 				    &triggered_work[i],
 				    &triggered_work_event[i], 1,
 				    K_FOREVER) == 0, NULL);
 		} else {
 			/**TESTPOINT: triggered work submit to system queue*/
-			zassert_true(k_work_poll_submit(
+			ztest_true(k_work_poll_submit(
 				    &triggered_work[i],
 				    &triggered_work_event[i], 1,
 				    K_FOREVER) == 0, NULL);
 		}
 
 		/**TESTPOINT: check pending after triggered work submit*/
-		zassert_true(k_work_pending(
+		ztest_true(k_work_pending(
 			    (struct k_work *)&triggered_work[i]) == 0, NULL);
 	}
 
 	for (int i = 0; i < NUM_OF_WORK; i++) {
 		/**TESTPOINT: trigger work execution*/
-		zassert_true(k_poll_signal_raise(&triggered_work_signal[i], 1)
+		ztest_true(k_poll_signal_raise(&triggered_work_signal[i], 1)
 								   == 0, NULL);
 		/**TESTPOINT: check pending after sending signal */
-		zassert_true(k_work_pending(
+		ztest_true(k_work_pending(
 			    (struct k_work *)&triggered_work[i]) != 0, NULL);
 	}
 }
@@ -316,31 +316,31 @@ static void ttriggered_work_cancel(void *data)
 				&triggered_work_event[1], 1, K_FOREVER);
 	}
 	/* Check if all submission succeeded */
-	zassert_true(ret == 0, NULL);
+	ztest_true(ret == 0, NULL);
 
 	/**TESTPOINT: triggered work cancel when waiting for event*/
 	ret = k_work_poll_cancel(&triggered_work[0]);
-	zassert_true(ret == 0, NULL);
+	ztest_true(ret == 0, NULL);
 
 	/**TESTPOINT: check pending after triggerd work cancel*/
 	ret = k_work_pending((struct k_work *)&triggered_work[0]);
-	zassert_true(ret == 0, NULL);
+	ztest_true(ret == 0, NULL);
 
 	/* Trigger work #1 */
 	ret = k_poll_signal_raise(&triggered_work_signal[1], 1);
-	zassert_true(ret == 0, NULL);
+	ztest_true(ret == 0, NULL);
 
 	/**TESTPOINT: check pending after sending signal */
 	ret = k_work_pending((struct k_work *)&triggered_work[1]);
-	zassert_true(ret != 0, NULL);
+	ztest_true(ret != 0, NULL);
 
 	/**TESTPOINT: triggered work cancel when pending for event*/
 	ret = k_work_poll_cancel(&triggered_work[1]);
-	zassert_true(ret == -EINVAL, NULL);
+	ztest_true(ret == -EINVAL, NULL);
 
 	/* Trigger sleepy work */
 	ret = k_poll_signal_raise(&triggered_work_sleepy_signal, 1);
-	zassert_true(ret == 0, NULL);
+	ztest_true(ret == 0, NULL);
 
 	if (!k_is_in_isr()) {
 		/*wait for completed work_sleepy and triggered_work[1]*/
@@ -348,11 +348,11 @@ static void ttriggered_work_cancel(void *data)
 
 		/**TESTPOINT: check pending when work completed*/
 		ret = k_work_pending((struct k_work *)&triggered_work_sleepy);
-		zassert_true(ret == 0, NULL);
+		ztest_true(ret == 0, NULL);
 
 		/**TESTPOINT: delayed work cancel when completed*/
 		ret = k_work_poll_cancel(&triggered_work_sleepy);
-		zassert_true(ret == -EINVAL, NULL);
+		ztest_true(ret == -EINVAL, NULL);
 
 	}
 
@@ -631,7 +631,7 @@ static void delayed_work_handler_resubmit(struct k_work *w)
 
 	if (k_sem_count_get(&sync_sema) < NUM_OF_WORK) {
 		/**TESTPOINT: check if work can be resubmit from handler */
-		zassert_false(k_delayed_work_submit(delayed_w, TIMEOUT), NULL);
+		ztest_false(k_delayed_work_submit(delayed_w, TIMEOUT), NULL);
 	}
 }
 

--- a/tests/kernel/xip/src/main.c
+++ b/tests/kernel/xip/src/main.c
@@ -52,7 +52,7 @@ void test_globals(void)
 	for (i = 0; i < XIP_TEST_ARRAY_SZ; i++) {
 
 		/**TESTPOINT: Check if the array value is correct*/
-		zassert_equal(xip_array[i], (i+1), "Array value is incorrect");
+		ztest_equal(xip_array[i], (i+1), "Array value is incorrect");
 	}
 }
 

--- a/tests/lib/c_lib/src/main.c
+++ b/tests/lib/c_lib/src/main.c
@@ -53,7 +53,7 @@ volatile long long_one = 1L;
 void test_limits(void)
 {
 
-	zassert_true((long_max + long_one == LONG_MIN), NULL);
+	ztest_true((long_max + long_one == LONG_MIN), NULL);
 }
 
 static ssize_t foobar(void)
@@ -63,7 +63,7 @@ static ssize_t foobar(void)
 
 void test_ssize_t(void)
 {
-	zassert_true(foobar() < 0, NULL);
+	ztest_true(foobar() < 0, NULL);
 }
 
 /**
@@ -75,8 +75,8 @@ void test_ssize_t(void)
 void test_stdbool(void)
 {
 
-	zassert_true((true == 1), "true value");
-	zassert_true((false == 0), "false value");
+	ztest_true((true == 1), "true value");
+	ztest_true((false == 0), "false value");
 }
 
 /*
@@ -96,9 +96,9 @@ volatile size_t size_of_long_variable = sizeof(long_variable);
 void test_stddef(void)
 {
 #ifdef CONFIG_64BIT
-	zassert_true((size_of_long_variable == 8), "sizeof");
+	ztest_true((size_of_long_variable == 8), "sizeof");
 #else
-	zassert_true((size_of_long_variable == 4), "sizeof");
+	ztest_true((size_of_long_variable == 4), "sizeof");
 #endif
 }
 
@@ -118,7 +118,7 @@ volatile u32_t unsigned_int = 0xffffff00;
 
 void test_stdint(void)
 {
-	zassert_true((unsigned_int + unsigned_byte + 1u == 0U), NULL);
+	ztest_true((unsigned_int + unsigned_byte + 1u == 0U), NULL);
 
 }
 
@@ -139,8 +139,8 @@ char buffer[BUFSIZE];
 void test_memset(void)
 {
 	(void)memset(buffer, 'a', BUFSIZE);
-	zassert_true((buffer[0] == 'a'), "memset");
-	zassert_true((buffer[BUFSIZE - 1] == 'a'), "memset");
+	ztest_true((buffer[0] == 'a'), "memset");
+	ztest_true((buffer[BUFSIZE - 1] == 'a'), "memset");
 }
 
 /**
@@ -153,7 +153,7 @@ void test_strlen(void)
 {
 	(void)memset(buffer, '\0', BUFSIZE);
 	(void)memset(buffer, 'b', 5); /* 5 is BUFSIZE / 2 */
-	zassert_equal(strlen(buffer), 5, "strlen");
+	ztest_equal(strlen(buffer), 5, "strlen");
 }
 
 /**
@@ -166,9 +166,9 @@ void test_strcmp(void)
 {
 	strcpy(buffer, "eeeee");
 
-	zassert_true((strcmp(buffer, "fffff") < 0), "strcmp less ...");
-	zassert_true((strcmp(buffer, "eeeee") == 0), "strcmp equal ...");
-	zassert_true((strcmp(buffer, "ddddd") > 0), "strcmp greater ...");
+	ztest_true((strcmp(buffer, "fffff") < 0), "strcmp less ...");
+	ztest_true((strcmp(buffer, "eeeee") == 0), "strcmp equal ...");
+	ztest_true((strcmp(buffer, "ddddd") > 0), "strcmp greater ...");
 }
 
 /**
@@ -185,9 +185,9 @@ void test_strncmp(void)
 	__ASSERT_NO_MSG(sizeof(pattern) - 1 > BUFSIZE);
 	memcpy(buffer, pattern, BUFSIZE);
 
-	zassert_true((strncmp(buffer, "fffff", 0) == 0), "strncmp 0");
-	zassert_true((strncmp(buffer, "eeeff", 3) == 0), "strncmp 3");
-	zassert_true((strncmp(buffer, "eeeeeeeeeeeff", BUFSIZE) == 0),
+	ztest_true((strncmp(buffer, "fffff", 0) == 0), "strncmp 0");
+	ztest_true((strncmp(buffer, "eeeff", 3) == 0), "strncmp 3");
+	ztest_true((strncmp(buffer, "eeeeeeeeeeeff", BUFSIZE) == 0),
 		     "strncmp 10");
 }
 
@@ -203,7 +203,7 @@ void test_strcpy(void)
 	(void)memset(buffer, '\0', BUFSIZE);
 	strcpy(buffer, "10 chars!\0");
 
-	zassert_true((strcmp(buffer, "10 chars!\0") == 0), "strcpy");
+	ztest_true((strcmp(buffer, "10 chars!\0") == 0), "strcpy");
 }
 
 /**
@@ -221,7 +221,7 @@ void test_strncpy(void)
 
 	/* Purposely different values */
 	ret = strncmp(buffer, "This is over 20 characters", BUFSIZE);
-	zassert_true((ret == 0), "strncpy");
+	ztest_true((ret == 0), "strncpy");
 
 }
 
@@ -241,11 +241,11 @@ void test_strchr(void)
 
 	rs = strchr(buffer, '1');
 
-	zassert_not_null(rs, "strchr");
+	ztest_not_null(rs, "strchr");
 
 
 	ret = strncmp(rs, "10", 2);
-	zassert_true((ret == 0), "strchr");
+	ztest_true((ret == 0), "strchr");
 
 }
 
@@ -260,17 +260,17 @@ void test_strxspn(void)
 	const char *empty = "";
 	const char *cset = "abc";
 
-	zassert_true(strspn("", empty) == 0U, "strspn empty empty");
-	zassert_true(strcspn("", empty) == 0U, "strcspn empty empty");
+	ztest_true(strspn("", empty) == 0U, "strspn empty empty");
+	ztest_true(strcspn("", empty) == 0U, "strcspn empty empty");
 
-	zassert_true(strspn("abde", cset) == 2U, "strspn match");
-	zassert_true(strcspn("abde", cset) == 0U, "strcspn nomatch");
+	ztest_true(strspn("abde", cset) == 2U, "strspn match");
+	ztest_true(strcspn("abde", cset) == 0U, "strcspn nomatch");
 
-	zassert_true(strspn("da", cset) == 0U, "strspn nomatch");
-	zassert_true(strcspn("da", cset) == 1U, "strcspn match");
+	ztest_true(strspn("da", cset) == 0U, "strspn nomatch");
+	ztest_true(strcspn("da", cset) == 1U, "strcspn match");
 
-	zassert_true(strspn("abac", cset) == 4U, "strspn all");
-	zassert_true(strcspn("defg", cset) == 4U, "strcspn all");
+	ztest_true(strspn("abac", cset) == 4U, "strspn all");
+	ztest_true(strcspn("defg", cset) == 4U, "strcspn all");
 }
 
 /**
@@ -287,10 +287,10 @@ void test_memcmp(void)
 
 
 	ret = memcmp(m1, m2, 4);
-	zassert_true((ret == 0), "memcmp 4");
+	ztest_true((ret == 0), "memcmp 4");
 
 	ret = memcmp(m1, m2, 5);
-	zassert_true((ret != 0), "memcmp 5");
+	ztest_true((ret != 0), "memcmp 5");
 }
 
 /**
@@ -312,11 +312,11 @@ void test_bsearch(void)
 	int key = 30;
 
 	result = (int *)bsearch(&key, arr, size, sizeof(int), cmp_func);
-	zassert_is_null(result, "bsearch -key not found");
+	ztest_is_null(result, "bsearch -key not found");
 
 	key = 60;
 	result = (int *)bsearch(&key, arr, size, sizeof(int), cmp_func);
-	zassert_not_null(result, "bsearch -key found");
+	ztest_not_null(result, "bsearch -key found");
 }
 
 void test_main(void)

--- a/tests/lib/fdtable/src/main.c
+++ b/tests/lib/fdtable/src/main.c
@@ -13,7 +13,7 @@ void test_z_reserve_fd(void)
 {
 	int fd = z_reserve_fd(); /* function being tested */
 
-	zassert_true(fd >= 0, "fd < 0");
+	ztest_true(fd >= 0, "fd < 0");
 
 	z_free_fd(fd);
 }
@@ -23,12 +23,12 @@ void test_z_get_fd_obj_and_vtable(void)
 	const struct fd_op_vtable *vtable;
 
 	int fd = z_reserve_fd();
-	zassert_true(fd >= 0, "fd < 0");
+	ztest_true(fd >= 0, "fd < 0");
 
 	int *obj;
 	obj = z_get_fd_obj_and_vtable(fd, &vtable); /* function being tested */
 
-	zassert_equal(obj != NULL, true, "obj is NULL");
+	ztest_equal(obj != NULL, true, "obj is NULL");
 
 	z_free_fd(fd);
 }
@@ -36,7 +36,7 @@ void test_z_get_fd_obj_and_vtable(void)
 void test_z_get_fd_obj(void)
 {
 	int fd = z_reserve_fd();
-	zassert_true(fd >= 0, "fd < 0");
+	ztest_true(fd >= 0, "fd < 0");
 
 	int err = -1;
 	const struct fd_op_vtable *vtable = 0;
@@ -44,20 +44,20 @@ void test_z_get_fd_obj(void)
 
 	int *obj = z_get_fd_obj(fd, vtable, err); /* function being tested */
 
-	zassert_equal(obj != NULL, true, "obj is NULL");
-	zassert_equal(errno != EBADF && errno != ENFILE, true, "errno not set");
+	ztest_equal(obj != NULL, true, "obj is NULL");
+	ztest_equal(errno != EBADF && errno != ENFILE, true, "errno not set");
 
 	/* take branch -- if (_check_fd(fd) < 0) */
 	obj = z_get_fd_obj(-1, vtable, err); /* function being tested */
 
-	zassert_equal_ptr(obj, NULL, "obj is not NULL when fd < 0");
-	zassert_equal(errno, EBADF, "fd: out of bounds error");
+	ztest_equal_ptr(obj, NULL, "obj is not NULL when fd < 0");
+	ztest_equal(errno, EBADF, "fd: out of bounds error");
 
 	/* take branch -- if (vtable != NULL && fd_entry->vtable != vtable) */
 	obj = z_get_fd_obj(fd, vtable2, err); /* function being tested */
 
-	zassert_equal_ptr(obj, NULL, "obj is not NULL - vtable doesn't match");
-	zassert_equal(errno, err, "vtable matches");
+	ztest_equal_ptr(obj, NULL, "obj is not NULL - vtable doesn't match");
+	ztest_equal(errno, err, "vtable matches");
 
 	z_free_fd(fd);
 }
@@ -67,7 +67,7 @@ void test_z_finalize_fd(void)
 	const struct fd_op_vtable *vtable;
 
 	int fd = z_reserve_fd();
-	zassert_true(fd >= 0, NULL);
+	ztest_true(fd >= 0, NULL);
 
 	int *obj = z_get_fd_obj_and_vtable(fd, &vtable);
 
@@ -78,8 +78,8 @@ void test_z_finalize_fd(void)
 
 	obj = z_get_fd_obj_and_vtable(fd, &vtable);
 
-	zassert_equal_ptr(obj, original_obj, "obj is different after finalizing");
-	zassert_equal_ptr(vtable, original_vtable, "vtable is different after finalizing");
+	ztest_equal_ptr(obj, original_obj, "obj is different after finalizing");
+	ztest_equal_ptr(vtable, original_vtable, "vtable is different after finalizing");
 
 	z_free_fd(fd);
 }
@@ -90,12 +90,12 @@ void test_z_alloc_fd(void)
 	int *obj = NULL;
 
 	int fd = z_alloc_fd(obj, vtable); /* function being tested */
-	zassert_true(fd >= 0, NULL);
+	ztest_true(fd >= 0, NULL);
 
 	obj = z_get_fd_obj_and_vtable(fd, &vtable);
 
-	zassert_equal_ptr(obj, NULL, "obj is different after allocating");
-	zassert_equal_ptr(vtable, NULL, "vtable is different after allocating");
+	ztest_equal_ptr(obj, NULL, "obj is different after allocating");
+	ztest_equal_ptr(vtable, NULL, "vtable is different after allocating");
 
 	z_free_fd(fd);
 }
@@ -105,13 +105,13 @@ void test_z_free_fd(void)
 	const struct fd_op_vtable *vtable = NULL;
 
 	int fd = z_reserve_fd();
-	zassert_true(fd >= 0, NULL);
+	ztest_true(fd >= 0, NULL);
 
 	z_free_fd(fd); /* function being tested */
 
 	int *obj = z_get_fd_obj_and_vtable(fd, &vtable);
 
-	zassert_equal_ptr(obj, NULL, "obj is not NULL after freeing");
+	ztest_equal_ptr(obj, NULL, "obj is not NULL after freeing");
 }
 
 void test_main(void)

--- a/tests/lib/gui/lvgl/src/main.c
+++ b/tests/lib/gui/lvgl/src/main.c
@@ -27,18 +27,18 @@ static struct fs_mount_t mnt = {
 
 void test_get_default_screen(void)
 {
-	zassert_not_null(lv_scr_act(), "No default screen");
+	ztest_not_null(lv_scr_act(), "No default screen");
 }
 
 void test_add_delete_screen(void)
 {
 	lv_obj_t *default_screen = lv_scr_act();
 
-	zassert_not_null(default_screen, "No default screen");
+	ztest_not_null(default_screen, "No default screen");
 
 	lv_obj_t *new_screen = lv_obj_create(NULL, NULL);
 
-	zassert_not_null(new_screen, "Failed to create new screen");
+	ztest_not_null(new_screen, "Failed to create new screen");
 
 	lv_scr_load(new_screen);
 
@@ -46,7 +46,7 @@ void test_add_delete_screen(void)
 
 	lv_obj_t *act_screen = lv_scr_act();
 
-	zassert_equal_ptr(act_screen, new_screen, "New screen not active");
+	ztest_equal_ptr(act_screen, new_screen, "New screen not active");
 
 	lv_obj_del(new_screen);
 
@@ -55,7 +55,7 @@ void test_add_delete_screen(void)
 	lv_task_handler();
 
 	act_screen = lv_scr_act();
-	zassert_equal_ptr(act_screen, default_screen,
+	ztest_equal_ptr(act_screen, default_screen,
 			"Default screen not active");
 
 }
@@ -63,7 +63,7 @@ void test_add_img(void)
 {
 	lv_obj_t *img = lv_img_create(lv_scr_act(), NULL);
 
-	zassert_not_null(img, "Failed to create image");
+	ztest_not_null(img, "Failed to create image");
 
 	lv_img_set_src(img, IMG_FILE_PATH);
 	lv_obj_align(img, NULL, LV_ALIGN_CENTER, 0, 0);

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -143,14 +143,14 @@ static void test_json_encoding(void)
 	ssize_t len;
 
 	len = json_calc_encoded_len(test_descr, ARRAY_SIZE(test_descr), &ts);
-	zassert_equal(len, strlen(encoded), "encoded size mismatch");
+	ztest_equal(len, strlen(encoded), "encoded size mismatch");
 
 	ret = json_obj_encode_buf(test_descr, ARRAY_SIZE(test_descr),
 				  &ts, buffer, sizeof(buffer));
-	zassert_equal(ret, 0, "Encoding function returned no errors");
+	ztest_equal(ret, 0, "Encoding function returned no errors");
 
 	ret = strncmp(buffer, encoded, sizeof(encoded) - 1);
-	zassert_equal(ret, 0, "Encoded contents consistent");
+	ztest_equal(ret, 0, "Encoded contents consistent");
 }
 
 static void test_json_decoding(void)
@@ -180,38 +180,38 @@ static void test_json_decoding(void)
 	ret = json_obj_parse(encoded, sizeof(encoded) - 1, test_descr,
 			     ARRAY_SIZE(test_descr), &ts);
 
-	zassert_equal(ret, (1 << ARRAY_SIZE(test_descr)) - 1,
+	ztest_equal(ret, (1 << ARRAY_SIZE(test_descr)) - 1,
 		     "All fields decoded correctly");
 
-	zassert_true(!strcmp(ts.some_string, "zephyr 123\\uABCD456"),
+	ztest_true(!strcmp(ts.some_string, "zephyr 123\\uABCD456"),
 		    "String decoded correctly");
-	zassert_equal(ts.some_int, 42, "Positive integer decoded correctly");
-	zassert_equal(ts.some_bool, true, "Boolean decoded correctly");
-	zassert_equal(ts.some_nested_struct.nested_int, -1234,
+	ztest_equal(ts.some_int, 42, "Positive integer decoded correctly");
+	ztest_equal(ts.some_bool, true, "Boolean decoded correctly");
+	ztest_equal(ts.some_nested_struct.nested_int, -1234,
 		     "Nested negative integer decoded correctly");
-	zassert_equal(ts.some_nested_struct.nested_bool, false,
+	ztest_equal(ts.some_nested_struct.nested_bool, false,
 		     "Nested boolean value decoded correctly");
-	zassert_true(!strcmp(ts.some_nested_struct.nested_string,
+	ztest_true(!strcmp(ts.some_nested_struct.nested_string,
 			    "this should be escaped: \\t"),
 		    "Nested string decoded correctly");
-	zassert_equal(ts.some_array_len, 5, "Array has correct number of items");
-	zassert_true(!memcmp(ts.some_array, expected_array,
+	ztest_equal(ts.some_array_len, 5, "Array has correct number of items");
+	ztest_true(!memcmp(ts.some_array, expected_array,
 		    sizeof(expected_array)),
 		    "Array decoded with expected values");
-	zassert_true(ts.another_bxxl,
+	ztest_true(ts.another_bxxl,
 		     "Named boolean (special chars) decoded correctly");
-	zassert_false(ts.if_,
+	ztest_false(ts.if_,
 		      "Named boolean (reserved word) decoded correctly");
-	zassert_equal(ts.another_array_len, 4,
+	ztest_equal(ts.another_array_len, 4,
 		      "Named array has correct number of items");
-	zassert_true(!memcmp(ts.another_array, expected_other_array,
+	ztest_true(!memcmp(ts.another_array, expected_other_array,
 			     sizeof(expected_other_array)),
 		     "Decoded named array with expected values");
-	zassert_equal(ts.xnother_nexx.nested_int, 1234,
+	ztest_equal(ts.xnother_nexx.nested_int, 1234,
 		      "Named nested integer decoded correctly");
-	zassert_equal(ts.xnother_nexx.nested_bool, true,
+	ztest_equal(ts.xnother_nexx.nested_bool, true,
 		      "Named nested boolean decoded correctly");
-	zassert_true(!strcmp(ts.xnother_nexx.nested_string,
+	ztest_true(!strcmp(ts.xnother_nexx.nested_string,
 			     "no escape necessary"),
 		     "Named nested string decoded correctly");
 }
@@ -231,10 +231,10 @@ static void test_json_decoding_array_array(void)
 			     ARRAY_SIZE(array_array_descr),
 			     &obj_array_array_ts);
 
-	zassert_equal(ret, 1, "Encoding array of object returned no errors");
-	zassert_true(!strcmp(obj_array_array_ts.objects_array[1].objects.name,
+	ztest_equal(ret, 1, "Encoding array of object returned no errors");
+	ztest_true(!strcmp(obj_array_array_ts.objects_array[1].objects.name,
 			 "Pelé"), "String decoded correctly");
-	zassert_equal(obj_array_array_ts.objects_array[2].objects.height, 195,
+	ztest_equal(obj_array_array_ts.objects_array[2].objects.height, 195,
 		      "Usain Bolt height decoded correctly");
 }
 
@@ -272,8 +272,8 @@ static void test_json_obj_arr_encoding(void)
 
 	ret = json_obj_encode_buf(obj_array_descr, ARRAY_SIZE(obj_array_descr),
 				  &oa, buffer, sizeof(buffer));
-	zassert_equal(ret, 0, "Encoding array of object returned no errors");
-	zassert_true(!strcmp(buffer, encoded),
+	ztest_equal(ret, 0, "Encoding array of object returned no errors");
+	ztest_true(!strcmp(buffer, encoded),
 		     "Encoded array of objects is consistent");
 }
 
@@ -312,16 +312,16 @@ static void test_json_obj_arr_decoding(void)
 	ret = json_obj_parse(encoded, sizeof(encoded) - 1, obj_array_descr,
 			     ARRAY_SIZE(obj_array_descr), &oa);
 
-	zassert_equal(ret, (1 << ARRAY_SIZE(obj_array_descr)) - 1,
+	ztest_equal(ret, (1 << ARRAY_SIZE(obj_array_descr)) - 1,
 		      "Array of object fields decoded correctly");
-	zassert_equal(oa.num_elements, 10,
+	ztest_equal(oa.num_elements, 10,
 		      "Number of object fields decoded correctly");
 
 	for (int i = 0; i < expected.num_elements; i++) {
-		zassert_true(!strcmp(oa.elements[i].name,
+		ztest_true(!strcmp(oa.elements[i].name,
 				     expected.elements[i].name),
 			     "Element %d name decoded correctly", i);
-		zassert_equal(oa.elements[i].height,
+		ztest_equal(oa.elements[i].height,
 			      expected.elements[i].height,
 			      "Element %d height decoded correctly", i);
 	}
@@ -340,7 +340,7 @@ static void parse_harness(struct encoding_test encoded[], size_t size)
 	for (int i = 0; i < size; i++) {
 		ret = json_obj_parse(encoded[i].str, strlen(encoded[i].str),
 				     test_descr, ARRAY_SIZE(test_descr), &ts);
-		zassert_equal(ret, encoded[i].result,
+		ztest_equal(ret, encoded[i].result,
 			      "Decoding '%s' result %d, expected %d",
 			      encoded[i].str, ret, encoded[i].result);
 	}
@@ -398,7 +398,7 @@ static void test_json_missing_quote(void)
 
 	ret = json_obj_parse(encoded, sizeof(encoded) - 1, test_descr,
 			     ARRAY_SIZE(test_descr), &ts);
-	zassert_equal(ret, -EINVAL, "Decoding has to fail");
+	ztest_equal(ret, -EINVAL, "Decoding has to fail");
 }
 
 static void test_json_wrong_token(void)
@@ -409,7 +409,7 @@ static void test_json_wrong_token(void)
 
 	ret = json_obj_parse(encoded, sizeof(encoded) - 1, test_descr,
 			     ARRAY_SIZE(test_descr), &ts);
-	zassert_equal(ret, -EINVAL, "Decoding has to fail");
+	ztest_equal(ret, -EINVAL, "Decoding has to fail");
 }
 
 static void test_json_item_wrong_type(void)
@@ -420,7 +420,7 @@ static void test_json_item_wrong_type(void)
 
 	ret = json_obj_parse(encoded, sizeof(encoded) - 1, test_descr,
 			     ARRAY_SIZE(test_descr), &ts);
-	zassert_equal(ret, -EINVAL, "Decoding has to fail");
+	ztest_equal(ret, -EINVAL, "Decoding has to fail");
 }
 
 static void test_json_key_not_in_descr(void)
@@ -431,7 +431,7 @@ static void test_json_key_not_in_descr(void)
 
 	ret = json_obj_parse(encoded, sizeof(encoded) - 1, test_descr,
 			     ARRAY_SIZE(test_descr), &ts);
-	zassert_equal(ret, 0, "No items should be decoded");
+	ztest_equal(ret, 0, "No items should be decoded");
 }
 
 static void test_json_escape(void)
@@ -458,10 +458,10 @@ static void test_json_escape(void)
 	len = strlen(buf);
 
 	ret = json_escape(buf, &len, sizeof(buf));
-	zassert_equal(ret, 0, "Escape succeeded");
-	zassert_equal(len, sizeof(buf) - 1,
+	ztest_equal(ret, 0, "Escape succeeded");
+	ztest_equal(len, sizeof(buf) - 1,
 		      "Escaped length computed correctly");
-	zassert_true(!strcmp(buf, expected),
+	ztest_true(!strcmp(buf, expected),
 		     "Escaped value is correct");
 }
 
@@ -474,11 +474,11 @@ static void test_json_escape_one(void)
 	ssize_t ret;
 
 	ret = json_escape(buf, &len, sizeof(buf));
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Escaping one character succeeded");
-	zassert_equal(len, sizeof(buf) - 1,
+	ztest_equal(len, sizeof(buf) - 1,
 		      "Escaping one character length is correct");
-	zassert_true(!strcmp(buf, expected),
+	ztest_true(!strcmp(buf, expected),
 		     "Escaped value is correct");
 }
 
@@ -489,9 +489,9 @@ static void test_json_escape_empty(void)
 	ssize_t ret;
 
 	ret = json_escape(empty, &len, sizeof(empty));
-	zassert_equal(ret, 0, "Escaped empty string");
-	zassert_equal(len, 0, "Length of empty escaped string is zero");
-	zassert_equal(empty[0], '\0', "Empty string remains empty");
+	ztest_equal(ret, 0, "Escaped empty string");
+	ztest_equal(len, 0, "Length of empty escaped string is zero");
+	ztest_equal(empty[0], '\0', "Empty string remains empty");
 }
 
 static void test_json_escape_no_op(void)
@@ -502,10 +502,10 @@ static void test_json_escape_no_op(void)
 	ssize_t ret;
 
 	ret = json_escape(nothing_to_escape, &len, sizeof(nothing_to_escape));
-	zassert_equal(ret, 0, "Nothing to escape handled correctly");
-	zassert_equal(len, sizeof(nothing_to_escape) - 1,
+	ztest_equal(ret, 0, "Nothing to escape handled correctly");
+	ztest_equal(len, sizeof(nothing_to_escape) - 1,
 		      "Didn't change length of already escaped string");
-	zassert_true(!strcmp(nothing_to_escape, expected),
+	ztest_true(!strcmp(nothing_to_escape, expected),
 		     "Didn't alter string with nothing to escape");
 }
 
@@ -516,7 +516,7 @@ static void test_json_escape_bounds_check(void)
 	ssize_t ret;
 
 	ret = json_escape(not_enough_memory, &len, sizeof(not_enough_memory));
-	zassert_equal(ret, -ENOMEM, "Bounds check OK");
+	ztest_equal(ret, -ENOMEM, "Bounds check OK");
 }
 
 void test_main(void)

--- a/tests/lib/mem_alloc/src/main.c
+++ b/tests/lib/mem_alloc/src/main.c
@@ -34,7 +34,7 @@ void test_malloc(void)
 	int *iptr = NULL;
 
 	iptr = malloc(BUF_LEN * sizeof(int));
-	zassert_not_null((iptr), "malloc failed, errno: %d", errno);
+	ztest_not_null((iptr), "malloc failed, errno: %d", errno);
 	memset(iptr, 'p', BUF_LEN * sizeof(int));
 	free(iptr);
 	iptr = NULL;
@@ -67,8 +67,8 @@ void test_calloc(void)
 	char *cptr = NULL;
 
 	cptr =  calloc(CALLOC_BUFLEN, sizeof(char));
-	zassert_not_null((cptr), "calloc failed, errno: %d", errno);
-	zassert_true(((memcmp(cptr, zerobuf, CALLOC_BUFLEN)) == 0),
+	ztest_not_null((cptr), "calloc failed, errno: %d", errno);
+	ztest_true(((memcmp(cptr, zerobuf, CALLOC_BUFLEN)) == 0),
 			"calloc failed to set zero value, errno: %d", errno);
 	memset(cptr, 'p', CALLOC_BUFLEN);
 	free(cptr);
@@ -91,17 +91,17 @@ void test_realloc(void)
 
 	ptr = malloc(orig_size);
 
-	zassert_not_null((ptr), "malloc failed, errno: %d", errno);
+	ztest_not_null((ptr), "malloc failed, errno: %d", errno);
 	(void)memset(ptr, 'p', orig_size);
 
 	reloc_ptr = realloc(ptr, new_size);
 
-	zassert_not_null(reloc_ptr, "realloc failed, errno: %d", errno);
-	zassert_not_null((ptr), "malloc/realloc failed, errno: %d", errno);
+	ztest_not_null(reloc_ptr, "realloc failed, errno: %d", errno);
+	ztest_not_null((ptr), "malloc/realloc failed, errno: %d", errno);
 	ptr = reloc_ptr;
 
 	(void)memset(filled_buf, 'p', BUF_LEN);
-	zassert_true(((memcmp(ptr, filled_buf, BUF_LEN)) == 0),
+	ztest_true(((memcmp(ptr, filled_buf, BUF_LEN)) == 0),
 			"realloc failed to copy malloc data, errno: %d", errno);
 
 	free(ptr);
@@ -127,17 +127,17 @@ void test_reallocarray(void)
 
 	ptr = malloc(orig_size);
 
-	zassert_not_null((ptr), "malloc failed, errno: %d", errno);
+	ztest_not_null((ptr), "malloc failed, errno: %d", errno);
 	(void)memset(ptr, 'p', orig_size);
 
 	char *reloc_ptr = reallocarray(ptr, 2, orig_size);
 
-	zassert_not_null(reloc_ptr, "reallocarray failed");
-	zassert_not_null((ptr), "malloc/reallocarray failed, errno: %d", errno);
+	ztest_not_null(reloc_ptr, "reallocarray failed");
+	ztest_not_null((ptr), "malloc/reallocarray failed, errno: %d", errno);
 	ptr = reloc_ptr;
 
 	(void)memset(filled_buf, 'p', BUF_LEN);
-	zassert_true(((memcmp(ptr, filled_buf, BUF_LEN)) == 0),
+	ztest_true(((memcmp(ptr, filled_buf, BUF_LEN)) == 0),
 			"realloc failed to copy malloc data, errno: %d", errno);
 
 	free(ptr);
@@ -162,14 +162,14 @@ void test_memalloc_all(void)
 	int new_size = MAX_LEN;
 
 	mlc_ptr = malloc(orig_size);
-	zassert_not_null((mlc_ptr), "malloc failed, errno: %d", errno);
+	ztest_not_null((mlc_ptr), "malloc failed, errno: %d", errno);
 
 	clc_ptr = calloc(100, sizeof(char));
-	zassert_not_null((clc_ptr), "calloc failed, errno: %d", errno);
+	ztest_not_null((clc_ptr), "calloc failed, errno: %d", errno);
 
 	reloc_ptr = realloc(mlc_ptr, new_size);
-	zassert_not_null(reloc_ptr, "realloc failed, errno: %d", errno);
-	zassert_not_null((mlc_ptr), "malloc/realloc failed, errno: %d", errno);
+	ztest_not_null(reloc_ptr, "realloc failed, errno: %d", errno);
+	ztest_not_null((mlc_ptr), "malloc/realloc failed, errno: %d", errno);
 	mlc_ptr = reloc_ptr;
 
 	free(mlc_ptr);
@@ -191,7 +191,7 @@ void test_memalloc_max(void)
 	char *ptr = NULL;
 
 	ptr = malloc(0x7fffffff);
-	zassert_is_null(ptr, "malloc passed unexpectedly");
+	ztest_is_null(ptr, "malloc passed unexpectedly");
 	free(ptr);
 	ptr = NULL;
 }

--- a/tests/lib/onoff/src/main.c
+++ b/tests/lib/onoff/src/main.c
@@ -171,46 +171,46 @@ static void test_service_init_validation(void)
 	clear_transit();
 
 	rc = onoff_service_init(NULL, NULL, NULL, NULL, 0);
-	zassert_equal(rc, -EINVAL,
+	ztest_equal(rc, -EINVAL,
 		      "init null srv %d", rc);
 
 	rc = onoff_service_init(&srv, NULL, NULL, NULL, 0);
-	zassert_equal(rc, -EINVAL,
+	ztest_equal(rc, -EINVAL,
 		      "init null transit %d", rc);
 
 	rc = onoff_service_init(&srv, start, NULL, NULL, 0);
-	zassert_equal(rc, -EINVAL,
+	ztest_equal(rc, -EINVAL,
 		      "init null stop %d", rc);
 
 	rc = onoff_service_init(&srv, NULL, stop, NULL, 0);
-	zassert_equal(rc, -EINVAL,
+	ztest_equal(rc, -EINVAL,
 		      "init null start %d", rc);
 
 	rc = onoff_service_init(&srv, start, stop, NULL,
 				ONOFF_SERVICE_INTERNAL_BASE);
-	zassert_equal(rc, -EINVAL,
+	ztest_equal(rc, -EINVAL,
 		      "init bad flags %d", rc);
 
 	u32_t flags = ONOFF_SERVICE_START_SLEEPS;
 
 	memset(&srv, 0xA5, sizeof(srv));
-	zassert_false(sys_slist_is_empty(&srv.clients),
+	ztest_false(sys_slist_is_empty(&srv.clients),
 		      "slist empty");
 
 	rc = onoff_service_init(&srv, start, stop, reset, flags);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "init good %d", rc);
-	zassert_equal(srv.start, start,
+	ztest_equal(srv.start, start,
 		      "init start mismatch");
-	zassert_equal(srv.stop, stop,
+	ztest_equal(srv.stop, stop,
 		      "init stop mismatch");
-	zassert_equal(srv.reset, reset,
+	ztest_equal(srv.reset, reset,
 		      "init reset mismatch");
-	zassert_equal(srv.flags, ONOFF_SERVICE_START_SLEEPS,
+	ztest_equal(srv.flags, ONOFF_SERVICE_START_SLEEPS,
 		      "init flags mismatch");
-	zassert_equal(srv.refs, 0,
+	ztest_equal(srv.refs, 0,
 		      "init refs mismatch");
-	zassert_true(sys_slist_is_empty(&srv.clients),
+	ztest_true(sys_slist_is_empty(&srv.clients),
 		     "init slist empty");
 }
 
@@ -222,31 +222,31 @@ static void test_client_init_validation(void)
 
 	memset(&cli, 0xA5, sizeof(cli));
 	onoff_client_init_spinwait(&cli);
-	zassert_equal(z_snode_next_peek(&cli.node), NULL,
+	ztest_equal(z_snode_next_peek(&cli.node), NULL,
 		      "cli node mismatch");
-	zassert_equal(cli.flags, ONOFF_CLIENT_NOTIFY_SPINWAIT,
+	ztest_equal(cli.flags, ONOFF_CLIENT_NOTIFY_SPINWAIT,
 		      "cli spinwait flags");
 
 	struct k_poll_signal sig;
 
 	memset(&cli, 0xA5, sizeof(cli));
 	onoff_client_init_signal(&cli, &sig);
-	zassert_equal(z_snode_next_peek(&cli.node), NULL,
+	ztest_equal(z_snode_next_peek(&cli.node), NULL,
 		      "cli signal node");
-	zassert_equal(cli.flags, ONOFF_CLIENT_NOTIFY_SIGNAL,
+	ztest_equal(cli.flags, ONOFF_CLIENT_NOTIFY_SIGNAL,
 		      "cli signal flags");
-	zassert_equal(cli.async.signal, &sig,
+	ztest_equal(cli.async.signal, &sig,
 		      "cli signal async");
 
 	memset(&cli, 0xA5, sizeof(cli));
 	onoff_client_init_callback(&cli, callback, &sig);
-	zassert_equal(z_snode_next_peek(&cli.node), NULL,
+	ztest_equal(z_snode_next_peek(&cli.node), NULL,
 		      "cli callback node");
-	zassert_equal(cli.flags, ONOFF_CLIENT_NOTIFY_CALLBACK,
+	ztest_equal(cli.flags, ONOFF_CLIENT_NOTIFY_CALLBACK,
 		      "cli callback flags");
-	zassert_equal(cli.async.callback.handler, callback,
+	ztest_equal(cli.async.callback.handler, callback,
 		      "cli callback handler");
-	zassert_equal(cli.async.callback.user_data, &sig,
+	ztest_equal(cli.async.callback.user_data, &sig,
 		      "cli callback user_data");
 }
 
@@ -264,65 +264,65 @@ static void test_validate_args(void)
 	 */
 
 	rc = onoff_service_init(&srv, start, stop, NULL, 0);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "service init");
 
 	rc = onoff_request(NULL, NULL);
-	zassert_equal(rc, -EINVAL,
+	ztest_equal(rc, -EINVAL,
 		      "validate req null srv");
 
 	rc = onoff_release(NULL, NULL);
-	zassert_equal(rc, -EINVAL,
+	ztest_equal(rc, -EINVAL,
 		      "validate rel null srv");
 
 	rc = onoff_release(&srv, NULL);
-	zassert_equal(rc, -EINVAL,
+	ztest_equal(rc, -EINVAL,
 		      "validate rel null cli");
 
 	rc = onoff_request(&srv, NULL);
-	zassert_equal(rc, -EINVAL,
+	ztest_equal(rc, -EINVAL,
 		      "validate req null cli");
 
 	init_spinwait(&spinwait_cli);
 	rc = onoff_request(&srv, &spinwait_cli);
-	zassert_true(rc > 0,
+	ztest_true(rc > 0,
 		     "trigger to on");
 
 	memset(&cli, 0xA3, sizeof(cli));
 	rc = onoff_request(&srv, &cli);
-	zassert_equal(rc, -EINVAL,
+	ztest_equal(rc, -EINVAL,
 		      "validate req cli flags");
 
 	init_spinwait(&cli);
 	cli.flags = ONOFF_CLIENT_NOTIFY_INVALID;
 	rc = onoff_request(&srv, &cli);
-	zassert_equal(rc, -EINVAL,
+	ztest_equal(rc, -EINVAL,
 		      "validate req cli mode");
 
 	init_notify_sig(&cli, &sig);
 	rc = onoff_request(&srv, &cli);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "validate req cli signal: %d", rc);
 	init_notify_sig(&cli, &sig);
 	cli.async.signal = NULL;
 	rc = onoff_request(&srv, &cli);
-	zassert_equal(rc, -EINVAL,
+	ztest_equal(rc, -EINVAL,
 		      "validate req cli signal null");
 
 	init_notify_cb(&cli);
 	rc = onoff_request(&srv, &cli);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "validate req cli callback");
 
 	init_notify_cb(&cli);
 	cli.async.callback.handler = NULL;
 	rc = onoff_request(&srv, &cli);
-	zassert_equal(rc, -EINVAL,
+	ztest_equal(rc, -EINVAL,
 		      "validate req cli callback null");
 
 	memset(&cli, 0x3C, sizeof(cli)); /* makes flags invalid */
 	rc = onoff_request(&srv, &cli);
-	zassert_equal(rc, -EINVAL,
+	ztest_equal(rc, -EINVAL,
 		      "validate req cli notify mode");
 }
 
@@ -338,101 +338,101 @@ static void test_reset(void)
 	clear_transit();
 
 	rc = onoff_service_init(&srv, start, stop, NULL, 0);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "service init");
 	rc = onoff_service_reset(&srv, &cli);
-	zassert_equal(rc, -ENOTSUP,
+	ztest_equal(rc, -ENOTSUP,
 		      "reset: %d", rc);
 
 	rc = onoff_service_init(&srv, start, stop, reset, 0);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "service init");
 
 	rc = onoff_service_reset(&srv, NULL);
-	zassert_equal(rc, -EINVAL,
+	ztest_equal(rc, -EINVAL,
 		      "rst no cli");
 
 	init_spinwait(&spinwait_cli);
 	rc = onoff_request(&srv, &spinwait_cli);
-	zassert_true(rc > 0,
+	ztest_true(rc > 0,
 		     "req ok");
-	zassert_equal(srv.refs, 1U,
+	ztest_equal(srv.refs, 1U,
 		      "reset req refs: %u", srv.refs);
 
 
-	zassert_false(onoff_service_has_error(&srv),
+	ztest_false(onoff_service_has_error(&srv),
 		      "has error");
 	reset_state.retval = 57;
 	init_notify_sig(&cli, &sig);
 	rc = onoff_service_reset(&srv, &cli);
-	zassert_equal(rc, -EALREADY,
+	ztest_equal(rc, -EALREADY,
 		      "reset: %d", rc);
 
 	stop_state.retval = -23;
 	init_notify_sig(&cli, &sig);
 	rc = onoff_release(&srv, &cli);
-	zassert_equal(rc, 2,
+	ztest_equal(rc, 2,
 		      "rel trigger: %d", rc);
-	zassert_equal(srv.refs, 0U,
+	ztest_equal(srv.refs, 0U,
 		      "reset req refs: %u", srv.refs);
-	zassert_true(onoff_service_has_error(&srv),
+	ztest_true(onoff_service_has_error(&srv),
 		     "has error");
-	zassert_equal(cli_result(&cli), stop_state.retval,
+	ztest_equal(cli_result(&cli), stop_state.retval,
 		      "cli result");
 	signalled = 0;
 	result = -1;
 	k_poll_signal_check(&sig, &signalled, &result);
-	zassert_true(signalled != 0,
+	ztest_true(signalled != 0,
 		     "signalled");
-	zassert_equal(result, stop_state.retval,
+	ztest_equal(result, stop_state.retval,
 		      "result");
 	k_poll_signal_reset(&sig);
 
 	reset_state.retval = -59;
 	init_notify_sig(&cli, &sig);
 	rc = onoff_service_reset(&srv, &cli);
-	zassert_equal(rc, 0U,
+	ztest_equal(rc, 0U,
 		      "reset: %d", rc);
-	zassert_equal(cli_result(&cli), reset_state.retval,
+	ztest_equal(cli_result(&cli), reset_state.retval,
 		      "reset result");
-	zassert_equal(srv.refs, 0U,
+	ztest_equal(srv.refs, 0U,
 		      "reset req refs: %u", srv.refs);
-	zassert_true(onoff_service_has_error(&srv),
+	ztest_true(onoff_service_has_error(&srv),
 		     "has error");
 
 	reset_state.retval = 62;
 	init_notify_sig(&cli, &sig);
 	rc = onoff_service_reset(&srv, &cli);
-	zassert_equal(rc, 0U,
+	ztest_equal(rc, 0U,
 		      "reset: %d", rc);
-	zassert_equal(cli_result(&cli), reset_state.retval,
+	ztest_equal(cli_result(&cli), reset_state.retval,
 		      "reset result");
-	zassert_false(onoff_service_has_error(&srv),
+	ztest_false(onoff_service_has_error(&srv),
 		      "has error");
 
 	signalled = 0;
 	result = -1;
 	k_poll_signal_check(&sig, &signalled, &result);
-	zassert_true(signalled != 0,
+	ztest_true(signalled != 0,
 		     "signalled");
-	zassert_equal(result, reset_state.retval,
+	ztest_equal(result, reset_state.retval,
 		      "result");
 
-	zassert_equal(srv.refs, 0U,
+	ztest_equal(srv.refs, 0U,
 		      "reset req refs: %u", srv.refs);
-	zassert_false(onoff_service_has_error(&srv),
+	ztest_false(onoff_service_has_error(&srv),
 		      "has error");
 
 	rc = onoff_service_init(&srv, start, stop, reset,
 				ONOFF_SERVICE_RESET_SLEEPS);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "service init");
 	start_state.retval = -23;
-	zassert_false(onoff_service_has_error(&srv),
+	ztest_false(onoff_service_has_error(&srv),
 		      "has error");
 	init_spinwait(&spinwait_cli);
 	rc = onoff_request(&srv, &spinwait_cli);
-	zassert_true(onoff_service_has_error(&srv),
+	ztest_true(onoff_service_has_error(&srv),
 		     "has error");
 
 	struct isr_call_state isr_state = {
@@ -447,12 +447,12 @@ static void test_reset(void)
 
 	k_timer_start(&timer, K_MSEC(1), K_NO_WAIT);
 	rc = k_sem_take(&isr_sync, K_MSEC(10));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "isr sync");
 
-	zassert_equal(isr_state.result, -EWOULDBLOCK,
+	ztest_equal(isr_state.result, -EWOULDBLOCK,
 		      "isr reset");
-	zassert_equal(cli_result(&spinwait_cli), -EAGAIN,
+	ztest_equal(cli_result(&spinwait_cli), -EAGAIN,
 		      "is reset result");
 }
 
@@ -464,22 +464,22 @@ static void test_request(void)
 	clear_transit();
 
 	rc = onoff_service_init(&srv, start, stop, reset, 0);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "service init");
 
 	init_spinwait(&spinwait_cli);
 	rc = onoff_request(&srv, &spinwait_cli);
-	zassert_true(rc >= 0,
+	ztest_true(rc >= 0,
 		     "reset req: %d", rc);
-	zassert_equal(srv.refs, 1U,
+	ztest_equal(srv.refs, 1U,
 		      "reset req refs: %u", srv.refs);
-	zassert_equal(cli_result(&spinwait_cli), 0,
+	ztest_equal(cli_result(&spinwait_cli), 0,
 		      "reset req result: %d", cli_result(&spinwait_cli));
 
 	/* Can't reset when no error present. */
 	init_spinwait(&spinwait_cli);
 	rc = onoff_service_reset(&srv, &spinwait_cli);
-	zassert_equal(rc, -EALREADY,
+	ztest_equal(rc, -EALREADY,
 		      "reset spin client");
 
 	/* Reference overflow produces -EAGAIN */
@@ -488,7 +488,7 @@ static void test_request(void)
 	srv.refs = UINT16_MAX;
 	init_spinwait(&spinwait_cli);
 	rc = onoff_request(&srv, &spinwait_cli);
-	zassert_equal(rc, -EAGAIN,
+	ztest_equal(rc, -EAGAIN,
 		      "reset req overflow: %d", rc);
 	srv.refs = refs;
 
@@ -496,23 +496,23 @@ static void test_request(void)
 	stop_state.retval = -32;
 	init_spinwait(&spinwait_cli);
 	rc = onoff_release(&srv, &spinwait_cli);
-	zassert_equal(rc, 2,
+	ztest_equal(rc, 2,
 		      "error release");
-	zassert_equal(cli_result(&spinwait_cli), stop_state.retval,
+	ztest_equal(cli_result(&spinwait_cli), stop_state.retval,
 		      "error retval");
-	zassert_true(onoff_service_has_error(&srv),
+	ztest_true(onoff_service_has_error(&srv),
 		     "has error");
 
 	/* Can't request when error present. */
 	init_spinwait(&spinwait_cli);
 	rc = onoff_request(&srv, &spinwait_cli);
-	zassert_equal(rc, -EIO,
+	ztest_equal(rc, -EIO,
 		      "req with error");
 
 	/* Can't release when error present. */
 	init_spinwait(&spinwait_cli);
 	rc = onoff_release(&srv, &spinwait_cli);
-	zassert_equal(rc, -EIO,
+	ztest_equal(rc, -EIO,
 		      "rel with error");
 
 	struct k_poll_signal sig;
@@ -521,34 +521,34 @@ static void test_request(void)
 	/* Clear the error */
 	init_notify_sig(&cli, &sig);
 	rc = onoff_service_reset(&srv, &cli);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "reset");
-	zassert_false(onoff_service_has_error(&srv),
+	ztest_false(onoff_service_has_error(&srv),
 		      "has error");
 
 	/* Error on start */
 	start_state.retval = -12;
 	init_spinwait(&spinwait_cli);
 	rc = onoff_request(&srv, &spinwait_cli);
-	zassert_equal(rc, 2,
+	ztest_equal(rc, 2,
 		      "req with error");
-	zassert_equal(cli_result(&spinwait_cli), start_state.retval,
+	ztest_equal(cli_result(&spinwait_cli), start_state.retval,
 		      "req with error");
-	zassert_true(onoff_service_has_error(&srv),
+	ztest_true(onoff_service_has_error(&srv),
 		     "has error");
 
 	/* Clear the error */
 	init_spinwait(&spinwait_cli);
 	rc = onoff_service_reset(&srv, &spinwait_cli);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "reset");
-	zassert_false(onoff_service_has_error(&srv),
+	ztest_false(onoff_service_has_error(&srv),
 		      "has error");
 
 	/* Diagnose a no-wait delayed start */
 	rc = onoff_service_init(&srv, start, stop, reset,
 				ONOFF_SERVICE_START_SLEEPS);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "service init");
 	start_state.async = true;
 	start_state.retval = 12;
@@ -565,12 +565,12 @@ static void test_request(void)
 
 	k_timer_start(&timer, K_MSEC(1), K_NO_WAIT);
 	rc = k_sem_take(&isr_sync, K_MSEC(10));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "isr sync");
 
-	zassert_equal(isr_state.result, -EWOULDBLOCK,
+	ztest_equal(isr_state.result, -EWOULDBLOCK,
 		      "isr request");
-	zassert_equal(cli_result(&spinwait_cli), -EAGAIN,
+	ztest_equal(cli_result(&spinwait_cli), -EAGAIN,
 		      "isr request result");
 }
 
@@ -582,41 +582,41 @@ static void test_sync(void)
 	clear_transit();
 
 	rc = onoff_service_init(&srv, start, stop, reset, 0);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "service init");
 
 	/* WHITEBOX: request that triggers on returns positive */
 	init_spinwait(&spinwait_cli);
 	rc = onoff_request(&srv, &spinwait_cli);
-	zassert_equal(rc, 2,    /* WHITEBOX starting request */
+	ztest_equal(rc, 2,    /* WHITEBOX starting request */
 		      "req ok");
-	zassert_equal(srv.refs, 1U,
+	ztest_equal(srv.refs, 1U,
 		      "reset req refs: %u", srv.refs);
 
 	init_spinwait(&spinwait_cli);
 	rc = onoff_request(&srv, &spinwait_cli);
-	zassert_equal(rc, 0,    /* WHITEBOX on request */
+	ztest_equal(rc, 0,    /* WHITEBOX on request */
 		      "req ok");
-	zassert_equal(srv.refs, 2U,
+	ztest_equal(srv.refs, 2U,
 		      "reset req refs: %u", srv.refs);
 
 	init_spinwait(&spinwait_cli);
 	rc = onoff_release(&srv, &spinwait_cli);
-	zassert_equal(rc, 1,    /* WHITEBOX non-stopping release */
+	ztest_equal(rc, 1,    /* WHITEBOX non-stopping release */
 		      "rel ok");
-	zassert_equal(srv.refs, 1U,
+	ztest_equal(srv.refs, 1U,
 		      "reset rel refs: %u", srv.refs);
 
 	init_spinwait(&spinwait_cli);
 	rc = onoff_release(&srv, &spinwait_cli);
-	zassert_equal(rc, 2,    /* WHITEBOX stopping release*/
+	ztest_equal(rc, 2,    /* WHITEBOX stopping release*/
 		      "rel ok: %d", rc);
-	zassert_equal(srv.refs, 0U,
+	ztest_equal(srv.refs, 0U,
 		      "reset rel refs: %u", srv.refs);
 
 	init_spinwait(&spinwait_cli);
 	rc = onoff_release(&srv, &spinwait_cli);
-	zassert_equal(rc, -EALREADY,
+	ztest_equal(rc, -EALREADY,
 		      "rel noent");
 }
 
@@ -638,18 +638,18 @@ static void test_async(void)
 	rc = onoff_service_init(&srv, start, stop, reset,
 				ONOFF_SERVICE_START_SLEEPS
 				| ONOFF_SERVICE_STOP_SLEEPS);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "service init");
 
 	/* WHITEBOX: request that triggers on returns positive */
 	init_notify_sig(&cli[0], &sig[0]);
 	rc = onoff_request(&srv, &cli[0]);
-	zassert_equal(rc, 2,    /* WHITEBOX starting request */
+	ztest_equal(rc, 2,    /* WHITEBOX starting request */
 		      "req ok");
 	k_poll_signal_check(&sig[0], &signalled, &result);
-	zassert_equal((bool)signalled, false,
+	ztest_equal((bool)signalled, false,
 		      "cli signalled");
-	zassert_equal(srv.refs, 0U,
+	ztest_equal(srv.refs, 0U,
 		      "reset req refs: %u", srv.refs);
 
 
@@ -667,62 +667,62 @@ static void test_async(void)
 
 	k_timer_start(&timer, K_MSEC(1), K_NO_WAIT);
 	rc = k_sem_take(&isr_sync, K_MSEC(10));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "isr sync");
 
-	zassert_equal(isr_state.result, 1, /* WHITEBOX pending request */
+	ztest_equal(isr_state.result, 1, /* WHITEBOX pending request */
 		      "isr request: %d", isr_state.result);
-	zassert_equal(cli_result(&isrcli), -EAGAIN,
+	ztest_equal(cli_result(&isrcli), -EAGAIN,
 		      "isr request result");
 
 	/* Off while on pending is not supported */
 	init_notify_sig(&cli[1], &sig[1]);
 	rc = onoff_release(&srv, &cli[1]);
-	zassert_equal(rc, -EBUSY,
+	ztest_equal(rc, -EBUSY,
 		      "rel in to-on");
 
 	/* Second request is delayed for first. */
 	init_notify_sig(&cli[1], &sig[1]);
 	rc = onoff_request(&srv, &cli[1]);
-	zassert_equal(rc, 1,    /* WHITEBOX pending request */
+	ztest_equal(rc, 1,    /* WHITEBOX pending request */
 		      "req ok");
 	k_poll_signal_check(&sig[1], &signalled, &result);
-	zassert_equal((bool)signalled, false,
+	ztest_equal((bool)signalled, false,
 		      "cli signalled");
-	zassert_equal(srv.refs, 0U,
+	ztest_equal(srv.refs, 0U,
 		      "reset req refs: %u", srv.refs);
 
 	/* Complete the transition. */
 	notify(&start_state);
 	k_poll_signal_check(&sig[0], &signalled, &result);
 	k_poll_signal_reset(&sig[0]);
-	zassert_equal((bool)signalled, true,
+	ztest_equal((bool)signalled, true,
 		      "cli signalled");
-	zassert_equal(result, start_state.retval,
+	ztest_equal(result, start_state.retval,
 		      "cli result");
-	zassert_equal(cli_result(&isrcli), start_state.retval,
+	ztest_equal(cli_result(&isrcli), start_state.retval,
 		      "isrcli result");
 	k_poll_signal_check(&sig[1], &signalled, &result);
 	k_poll_signal_reset(&sig[1]);
-	zassert_equal((bool)signalled, true,
+	ztest_equal((bool)signalled, true,
 		      "cli2 signalled");
-	zassert_equal(result, start_state.retval,
+	ztest_equal(result, start_state.retval,
 		      "cli2 result");
-	zassert_equal(srv.refs, 3U,
+	ztest_equal(srv.refs, 3U,
 		      "reset req refs: %u", srv.refs);
 
 	/* Non-final release decrements refs and completes. */
 	init_notify_sig(&cli[0], &sig[0]);
 	rc = onoff_release(&srv, &cli[0]);
-	zassert_equal(rc, 1,    /* WHITEBOX non-stopping release */
+	ztest_equal(rc, 1,    /* WHITEBOX non-stopping release */
 		      "rel ok");
-	zassert_equal(srv.refs, 2U,
+	ztest_equal(srv.refs, 2U,
 		      "reset rel refs: %u", srv.refs);
 	k_poll_signal_check(&sig[0], &signalled, &result);
 	k_poll_signal_reset(&sig[0]);
-	zassert_equal((bool)signalled, true,
+	ztest_equal((bool)signalled, true,
 		      "cli signalled");
-	zassert_equal(result, 0,
+	ztest_equal(result, 0,
 		      "cli result");
 
 	/* Non-final release from ISR is OK */
@@ -732,14 +732,14 @@ static void test_async(void)
 
 	k_timer_start(&timer, K_MSEC(1), K_NO_WAIT);
 	rc = k_sem_take(&isr_sync, K_MSEC(10));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "isr sync");
 
-	zassert_equal(isr_state.result, 1, /* WHITEBOX pending request */
+	ztest_equal(isr_state.result, 1, /* WHITEBOX pending request */
 		      "isr release: %d", isr_state.result);
-	zassert_equal(cli_result(&isrcli), 0,
+	ztest_equal(cli_result(&isrcli), 0,
 		      "isr release result");
-	zassert_equal(srv.refs, 1U,
+	ztest_equal(srv.refs, 1U,
 		      "reset rel refs: %u", srv.refs);
 
 	/* Final release cannot be from ISR */
@@ -747,70 +747,70 @@ static void test_async(void)
 	init_spinwait(&isrcli);
 	k_timer_start(&timer, K_MSEC(1), K_NO_WAIT);
 	rc = k_sem_take(&isr_sync, K_MSEC(10));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "isr sync");
 
-	zassert_equal(isr_state.result, -EWOULDBLOCK,
+	ztest_equal(isr_state.result, -EWOULDBLOCK,
 		      "isr release");
-	zassert_equal(cli_result(&isrcli), -EAGAIN,
+	ztest_equal(cli_result(&isrcli), -EAGAIN,
 		      "is release result");
 
 	/* Final async release holds until notify */
 	init_notify_sig(&cli[1], &sig[1]);
 	rc = onoff_release(&srv, &cli[1]);
-	zassert_equal(rc, 2,    /* WHITEBOX stopping release */
+	ztest_equal(rc, 2,    /* WHITEBOX stopping release */
 		      "rel ok: %d", rc);
-	zassert_equal(srv.refs, 1U,
+	ztest_equal(srv.refs, 1U,
 		      "reset rel refs: %u", srv.refs);
 
 	/* Redundant release in to-off */
 	init_notify_sig(&cli[0], &sig[0]);
 	rc = onoff_release(&srv, &cli[0]);
-	zassert_equal(rc, -EALREADY,
+	ztest_equal(rc, -EALREADY,
 		      "rel to-off: %d", rc);
-	zassert_equal(srv.refs, 1U,
+	ztest_equal(srv.refs, 1U,
 		      "reset rel refs: %u", srv.refs);
 	k_poll_signal_check(&sig[0], &signalled, &result);
-	zassert_equal((bool)signalled, false,
+	ztest_equal((bool)signalled, false,
 		      "cli signalled");
 
 	/* Request when turning off is queued */
 	init_notify_sig(&cli[0], &sig[0]);
 	rc = onoff_request(&srv, &cli[0]);
-	zassert_equal(rc, 3,    /* WHITEBOX stopping request */
+	ztest_equal(rc, 3,    /* WHITEBOX stopping request */
 		      "req in to-off");
 
 	/* Finalize release, queues start */
-	zassert_true(start_state.notify == NULL,
+	ztest_true(start_state.notify == NULL,
 		     "start not invoked");
 	notify(&stop_state);
-	zassert_false(start_state.notify == NULL,
+	ztest_false(start_state.notify == NULL,
 		      "start invoked");
-	zassert_equal(srv.refs, 0U,
+	ztest_equal(srv.refs, 0U,
 		      "reset rel refs: %u", srv.refs);
 	k_poll_signal_check(&sig[1], &signalled, &result);
 	k_poll_signal_reset(&sig[1]);
-	zassert_equal((bool)signalled, true,
+	ztest_equal((bool)signalled, true,
 		      "cli signalled");
-	zassert_equal(result, stop_state.retval,
+	ztest_equal(result, stop_state.retval,
 		      "cli result");
 
 	/* Release when starting is an error */
 	init_notify_sig(&cli[0], &sig[0]);
 	rc = onoff_release(&srv, &cli[0]);
-	zassert_equal(rc, -EBUSY,
+	ztest_equal(rc, -EBUSY,
 		      "rel to-off: %d", rc);
 
 	/* Finalize queued start, gets us to on */
 	cli[0].result = 1 + start_state.retval;
-	zassert_equal(cli_result(&cli[0]), -EAGAIN,
+	ztest_equal(cli_result(&cli[0]), -EAGAIN,
 		      "fetch failed");
-	zassert_false(start_state.notify == NULL,
+	ztest_false(start_state.notify == NULL,
 		      "start invoked");
 	notify(&start_state);
-	zassert_equal(cli_result(&cli[0]), start_state.retval,
+	ztest_equal(cli_result(&cli[0]), start_state.retval,
 		      "start notified");
-	zassert_equal(srv.refs, 1U,
+	ztest_equal(srv.refs, 1U,
 		      "reset rel refs: %u", srv.refs);
 }
 
@@ -828,7 +828,7 @@ static void test_half_sync(void)
 
 	rc = onoff_service_init(&srv, start, stop, NULL,
 				ONOFF_SERVICE_STOP_SLEEPS);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "service init");
 
 	/* Test that a synchronous start delayed by a pending
@@ -836,37 +836,37 @@ static void test_half_sync(void)
 	 */
 	init_spinwait(&spinwait_cli);
 	rc = onoff_request(&srv, &spinwait_cli);
-	zassert_equal(rc, 2,
+	ztest_equal(rc, 2,
 		      "req0");
-	zassert_equal(srv.refs, 1U,
+	ztest_equal(srv.refs, 1U,
 		      "active");
-	zassert_equal(cli_result(&spinwait_cli), start_state.retval,
+	ztest_equal(cli_result(&spinwait_cli), start_state.retval,
 		      "request");
 
-	zassert_true(stop_state.notify == NULL,
+	ztest_true(stop_state.notify == NULL,
 		     "not stopping");
 	init_notify_sig(&cli, &sig);
 	rc = onoff_release(&srv, &cli);
-	zassert_equal(rc, 2,
+	ztest_equal(rc, 2,
 		      "rel0");
-	zassert_equal(srv.refs, 1U,
+	ztest_equal(srv.refs, 1U,
 		      "active");
-	zassert_false(stop_state.notify == NULL,
+	ztest_false(stop_state.notify == NULL,
 		      "stop pending");
 
 	init_spinwait(&spinwait_cli);
 	rc = onoff_request(&srv, &spinwait_cli);
-	zassert_equal(rc, 3,    /* WHITEBOX start delayed for stop */
+	ztest_equal(rc, 3,    /* WHITEBOX start delayed for stop */
 		      "restart");
 
-	zassert_equal(cli_result(&cli), -EAGAIN,
+	ztest_equal(cli_result(&cli), -EAGAIN,
 		      "stop incomplete");
-	zassert_equal(cli_result(&spinwait_cli), -EAGAIN,
+	ztest_equal(cli_result(&spinwait_cli), -EAGAIN,
 		      "restart incomplete");
 	notify(&stop_state);
-	zassert_equal(cli_result(&cli), stop_state.retval,
+	ztest_equal(cli_result(&cli), stop_state.retval,
 		      "stop complete");
-	zassert_equal(cli_result(&spinwait_cli), start_state.retval,
+	ztest_equal(cli_result(&spinwait_cli), start_state.retval,
 		      "restart complete");
 }
 
@@ -886,50 +886,50 @@ static void test_cancel_request_waits(void)
 	rc = onoff_service_init(&srv, start, stop, NULL,
 				ONOFF_SERVICE_START_SLEEPS
 				| ONOFF_SERVICE_STOP_SLEEPS);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "service init");
 
 	init_notify_sig(&cli, &sig);
 	rc = onoff_request(&srv, &cli);
-	zassert_true(rc > 0,
+	ztest_true(rc > 0,
 		     "request pending");
-	zassert_false(start_state.notify == NULL,
+	ztest_false(start_state.notify == NULL,
 		      "start pending");
-	zassert_equal(cli_result(&cli), -EAGAIN,
+	ztest_equal(cli_result(&cli), -EAGAIN,
 		      "start pending");
 
 	init_spinwait(&spinwait_cli);
 	rc = onoff_request(&srv, &spinwait_cli);
-	zassert_equal(rc, 1, /* WHITEBOX secondary request */
+	ztest_equal(rc, 1, /* WHITEBOX secondary request */
 		      "start2 pending");
-	zassert_equal(cli_result(&spinwait_cli), -EAGAIN,
+	ztest_equal(cli_result(&spinwait_cli), -EAGAIN,
 		      "start2 pending");
 
 	/* Allowed to cancel in-progress start if doing so leaves
 	 * something to receive the start completion.
 	 */
 	rc = onoff_cancel(&srv, &cli);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "cancel failed: %d", rc);
-	zassert_equal(cli_result(&cli), -ECANCELED,
+	ztest_equal(cli_result(&cli), -ECANCELED,
 		      "cancel notified");
-	zassert_false(onoff_service_has_error(&srv),
+	ztest_false(onoff_service_has_error(&srv),
 		      "has error");
 
 	/* Not allowed to cancel the last pending start.
 	 */
 	rc = onoff_cancel(&srv, &spinwait_cli);
-	zassert_equal(rc, -EWOULDBLOCK,
+	ztest_equal(rc, -EWOULDBLOCK,
 		      "last cancel", rc);
-	zassert_false(onoff_service_has_error(&srv),
+	ztest_false(onoff_service_has_error(&srv),
 		      "has error");
-	zassert_equal(cli_result(&spinwait_cli), -EAGAIN,
+	ztest_equal(cli_result(&spinwait_cli), -EAGAIN,
 		      "last request");
 
 	notify(&start_state);
-	zassert_equal(cli_result(&spinwait_cli), start_state.retval,
+	ztest_equal(cli_result(&spinwait_cli), start_state.retval,
 		      "last request");
-	zassert_false(onoff_service_has_error(&srv),
+	ztest_false(onoff_service_has_error(&srv),
 		      "has error");
 
 
@@ -938,31 +938,31 @@ static void test_cancel_request_waits(void)
 	 */
 	init_spinwait(&cli);
 	rc = onoff_release(&srv, &cli);
-	zassert_equal(rc, 2, /* WHITEBOX stop pending */
+	ztest_equal(rc, 2, /* WHITEBOX stop pending */
 		      "stop pending, %d", rc);
-	zassert_equal(cli_result(&cli), -EAGAIN,
+	ztest_equal(cli_result(&cli), -EAGAIN,
 		      "stop pending");
 
 	init_spinwait(&spinwait_cli);
 	rc = onoff_request(&srv, &spinwait_cli);
-	zassert_equal(rc, 3, /* WHITEBOX restart pending */
+	ztest_equal(rc, 3, /* WHITEBOX restart pending */
 		      "restart pending");
 
 	rc = onoff_cancel(&srv, &spinwait_cli);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "restart cancel");
-	zassert_equal(cli_result(&spinwait_cli), -ECANCELED,
+	ztest_equal(cli_result(&spinwait_cli), -ECANCELED,
 		      "restart cancel");
-	zassert_false(onoff_service_has_error(&srv),
+	ztest_false(onoff_service_has_error(&srv),
 		      "has error");
 
-	zassert_equal(cli_result(&cli), -EAGAIN,
+	ztest_equal(cli_result(&cli), -EAGAIN,
 		      "stop pending");
 
 	notify(&stop_state);
-	zassert_equal(cli_result(&cli), stop_state.retval,
+	ztest_equal(cli_result(&cli), stop_state.retval,
 		      "released");
-	zassert_false(onoff_service_has_error(&srv),
+	ztest_false(onoff_service_has_error(&srv),
 		      "has error");
 }
 
@@ -980,42 +980,42 @@ static void test_cancel_request_ok(void)
 
 	rc = onoff_service_init(&srv, start, stop, NULL,
 				ONOFF_SERVICE_START_SLEEPS);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "service init");
 
 	init_notify_sig(&cli, &sig);
 	rc = onoff_request(&srv, &cli);
-	zassert_true(rc > 0,
+	ztest_true(rc > 0,
 		     "request pending");
-	zassert_false(start_state.notify == NULL,
+	ztest_false(start_state.notify == NULL,
 		      "start pending");
 
 	/* You can't cancel the last start request */
 	rc = onoff_cancel(&srv, &cli);
-	zassert_equal(rc, -EWOULDBLOCK,
+	ztest_equal(rc, -EWOULDBLOCK,
 		      "cancel");
-	zassert_equal(srv.refs, 0,
+	ztest_equal(srv.refs, 0,
 		      "refs empty");
 
 	notify(&start_state);
-	zassert_equal(srv.refs, 1,
+	ztest_equal(srv.refs, 1,
 		      "refs");
-	zassert_false(onoff_service_has_error(&srv),
+	ztest_false(onoff_service_has_error(&srv),
 		      "has error");
-	zassert_equal(cli_result(&cli), start_state.retval,
+	ztest_equal(cli_result(&cli), start_state.retval,
 		      "cancel notified");
-	zassert_false(onoff_service_has_error(&srv),
+	ztest_false(onoff_service_has_error(&srv),
 		      "has error");
 
 	/* You can "cancel" an request that isn't active */
 	init_spinwait(&cli);
 	rc = onoff_cancel(&srv, &cli);
-	zassert_equal(rc, -EALREADY,
+	ztest_equal(rc, -EALREADY,
 		      "unregistered");
 
 	/* Error if cancel params invalid */
 	rc = onoff_cancel(&srv, NULL);
-	zassert_equal(rc, -EINVAL,
+	ztest_equal(rc, -EINVAL,
 		      "invalid");
 }
 
@@ -1037,65 +1037,65 @@ static void test_blocked_restart(void)
 	rc = onoff_service_init(&srv, start, stop, NULL,
 				ONOFF_SERVICE_START_SLEEPS
 				| ONOFF_SERVICE_STOP_SLEEPS);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "service init");
 
 	init_notify_sig(&cli[0], &sig[0]);
 	rc = onoff_request(&srv, &cli[0]);
-	zassert_true(rc > 0,
+	ztest_true(rc > 0,
 		     "started");
-	zassert_false(start_state.notify == NULL,
+	ztest_false(start_state.notify == NULL,
 		      "start pending");
 	notify(&start_state);
 
 	result = -start_state.retval;
 	k_poll_signal_check(&sig[0], &signalled, &result);
-	zassert_true(signalled != 0,
+	ztest_true(signalled != 0,
 		     "signalled");
-	zassert_equal(result, start_state.retval,
+	ztest_equal(result, start_state.retval,
 		      "result");
 	k_poll_signal_reset(&sig[0]);
 
 	start_state.async = true;
 	init_notify_sig(&cli[0], &sig[0]);
 	rc = onoff_release(&srv, &cli[0]);
-	zassert_true(rc > 0,
+	ztest_true(rc > 0,
 		     "stop initiated");
-	zassert_false(stop_state.notify == NULL,
+	ztest_false(stop_state.notify == NULL,
 		      "stop pending");
 	init_notify_sig(&cli[1], &sig[1]);
 	rc = onoff_request(&srv, &cli[1]);
-	zassert_true(rc > 0,
+	ztest_true(rc > 0,
 		     "start pending");
 
 	result = start_state.retval + stop_state.retval;
 	k_poll_signal_check(&sig[0], &signalled, &result);
-	zassert_true(signalled == 0,
+	ztest_true(signalled == 0,
 		     "stop signalled");
 	k_poll_signal_check(&sig[1], &signalled, &result);
-	zassert_true(signalled == 0,
+	ztest_true(signalled == 0,
 		     "restart signalled");
 
 	k_timer_user_data_set(&isr_timer, &stop_state);
 	k_timer_start(&isr_timer, K_MSEC(1), K_NO_WAIT);
 	rc = k_sem_take(&isr_sync, K_MSEC(10));
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "isr sync");
 
 	/* Fail-to-restart is not an error */
-	zassert_false(onoff_service_has_error(&srv),
+	ztest_false(onoff_service_has_error(&srv),
 		      "has error");
 
 	k_poll_signal_check(&sig[0], &signalled, &result);
-	zassert_false(signalled == 0,
+	ztest_false(signalled == 0,
 		      "stop pending");
-	zassert_equal(result, stop_state.retval,
+	ztest_equal(result, stop_state.retval,
 		      "stop succeeded");
 
 	k_poll_signal_check(&sig[1], &signalled, &result);
-	zassert_false(signalled == 0,
+	ztest_false(signalled == 0,
 		      "restart pending");
-	zassert_equal(result, -EWOULDBLOCK,
+	ztest_equal(result, -EWOULDBLOCK,
 		      "restart failed");
 }
 
@@ -1111,36 +1111,36 @@ static void test_cancel_release(void)
 
 	rc = onoff_service_init(&srv, start, stop, NULL,
 				ONOFF_SERVICE_STOP_SLEEPS);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "service init");
 
 	init_spinwait(&spinwait_cli);
 	rc = onoff_request(&srv, &spinwait_cli);
-	zassert_true(rc > 0,
+	ztest_true(rc > 0,
 		     "request done");
-	zassert_equal(cli_result(&spinwait_cli), start_state.retval,
+	ztest_equal(cli_result(&spinwait_cli), start_state.retval,
 		      "started");
 
 	init_spinwait(&spinwait_cli);
 	rc = onoff_release(&srv, &spinwait_cli);
-	zassert_true(rc > 0,
+	ztest_true(rc > 0,
 		     "release pending");
-	zassert_false(stop_state.notify == NULL,
+	ztest_false(stop_state.notify == NULL,
 		      "release pending");
-	zassert_equal(cli_result(&spinwait_cli), -EAGAIN,
+	ztest_equal(cli_result(&spinwait_cli), -EAGAIN,
 		      "release pending");
 
 	/* You can't cancel a stop request. */
 	rc = onoff_cancel(&srv, &spinwait_cli);
-	zassert_equal(rc, -EWOULDBLOCK,
+	ztest_equal(rc, -EWOULDBLOCK,
 		      "cancel succeeded");
-	zassert_false(onoff_service_has_error(&srv),
+	ztest_false(onoff_service_has_error(&srv),
 		      "has error");
 
 	notify(&stop_state);
-	zassert_equal(cli_result(&spinwait_cli), stop_state.retval,
+	ztest_equal(cli_result(&spinwait_cli), stop_state.retval,
 		      "release pending");
-	zassert_false(onoff_service_has_error(&srv),
+	ztest_false(onoff_service_has_error(&srv),
 		      "has error");
 }
 

--- a/tests/lib/ringbuffer/src/main.c
+++ b/tests/lib/ringbuffer/src/main.c
@@ -78,7 +78,7 @@ void test_ring_buffer_main(void)
 	if (ret != -EMSGSIZE) {
 		LOG_DBG("Allowed retreival with insufficient "
 			"destination buffer space");
-		zassert_true((getsize == INITIAL_SIZE),
+		ztest_true((getsize == INITIAL_SIZE),
 			     "Correct size wasn't reported back to the caller");
 	}
 
@@ -86,21 +86,21 @@ void test_ring_buffer_main(void)
 		getsize = SIZE32_OF(getdata);
 		ret = ring_buf_item_get(&ring_buf1, &gettype, &getval, getdata,
 				       &getsize);
-		zassert_true((ret == 0), "Couldn't retrieve a stored value");
+		ztest_true((ret == 0), "Couldn't retrieve a stored value");
 		LOG_DBG("got %u chunks of type %u and val %u, %u remaining",
 			    getsize, gettype, getval,
 			    ring_buf_space_get(&ring_buf1));
 
-		zassert_true((memcmp((char *)getdata, rb_data, getsize * sizeof(u32_t)) == 0),
+		ztest_true((memcmp((char *)getdata, rb_data, getsize * sizeof(u32_t)) == 0),
 			     "data corrupted");
-		zassert_true((gettype == TYPE), "type information corrupted");
-		zassert_true((getval == VALUE), "value information corrupted");
+		ztest_true((gettype == TYPE), "type information corrupted");
+		ztest_true((getval == VALUE), "value information corrupted");
 	}
 
 	getsize = SIZE32_OF(getdata);
 	ret = ring_buf_item_get(&ring_buf1, &gettype, &getval, getdata,
 			       &getsize);
-	zassert_true((ret == -EAGAIN), "Got data out of an empty buffer");
+	ztest_true((ret == -EAGAIN), "Got data out of an empty buffer");
 }
 
 /**TESTPOINT: init via RING_BUF_ITEM_DECLARE_POW2*/
@@ -134,7 +134,7 @@ static void tringbuf_put(void *p)
 	int ret = ring_buf_item_put(pbuf, data[index].type, data[index].value,
 				   data[index].buffer, data[index].length);
 
-	zassert_equal(ret, 0, NULL);
+	ztest_equal(ret, 0, NULL);
 }
 
 static void tringbuf_get(void *p)
@@ -146,11 +146,11 @@ static void tringbuf_get(void *p)
 
 	/**TESTPOINT: ring buffer get*/
 	ret = ring_buf_item_get(pbuf, &type, &value, rx_data, &size32);
-	zassert_equal(ret, 0, NULL);
-	zassert_equal(type, data[index].type, NULL);
-	zassert_equal(value, data[index].value, NULL);
-	zassert_equal(size32, data[index].length, NULL);
-	zassert_equal(memcmp(rx_data, data[index].buffer, size32), 0, NULL);
+	ztest_equal(ret, 0, NULL);
+	ztest_equal(type, data[index].type, NULL);
+	ztest_equal(value, data[index].value, NULL);
+	ztest_equal(size32, data[index].length, NULL);
+	ztest_equal(memcmp(rx_data, data[index].buffer, size32), 0, NULL);
 }
 
 /*test cases*/
@@ -158,20 +158,20 @@ void test_ringbuffer_init(void)
 {
 	/**TESTPOINT: init via ring_buf_init*/
 	ring_buf_init(&ringbuf, RINGBUFFER_SIZE, buffer);
-	zassert_true(ring_buf_is_empty(&ringbuf), NULL);
-	zassert_equal(ring_buf_space_get(&ringbuf), RINGBUFFER_SIZE - 1, NULL);
+	ztest_true(ring_buf_is_empty(&ringbuf), NULL);
+	ztest_equal(ring_buf_space_get(&ringbuf), RINGBUFFER_SIZE - 1, NULL);
 }
 
 void test_ringbuffer_declare_pow2(void)
 {
-	zassert_true(ring_buf_is_empty(&ringbuf_pow2), NULL);
-	zassert_equal(ring_buf_space_get(&ringbuf_pow2), (1 << POW) - 1, NULL);
+	ztest_true(ring_buf_is_empty(&ringbuf_pow2), NULL);
+	ztest_equal(ring_buf_space_get(&ringbuf_pow2), (1 << POW) - 1, NULL);
 }
 
 void test_ringbuffer_declare_size(void)
 {
-	zassert_true(ring_buf_is_empty(&ringbuf_size), NULL);
-	zassert_equal(ring_buf_space_get(&ringbuf_size), RINGBUFFER_SIZE - 1,
+	ztest_true(ring_buf_is_empty(&ringbuf_size), NULL);
+	ztest_equal(ring_buf_space_get(&ringbuf_size), RINGBUFFER_SIZE - 1,
 		      NULL);
 }
 
@@ -183,9 +183,9 @@ void test_ringbuffer_put_get_thread(void)
 	tringbuf_get((void *)0);
 	tringbuf_get((void *)1);
 	tringbuf_put((void *)2);
-	zassert_false(ring_buf_is_empty(pbuf), NULL);
+	ztest_false(ring_buf_is_empty(pbuf), NULL);
 	tringbuf_get((void *)2);
-	zassert_true(ring_buf_is_empty(pbuf), NULL);
+	ztest_true(ring_buf_is_empty(pbuf), NULL);
 }
 
 void test_ringbuffer_put_get_isr(void)
@@ -196,9 +196,9 @@ void test_ringbuffer_put_get_isr(void)
 	irq_offload(tringbuf_get, (void *)0);
 	irq_offload(tringbuf_get, (void *)1);
 	irq_offload(tringbuf_put, (void *)2);
-	zassert_false(ring_buf_is_empty(pbuf), NULL);
+	ztest_false(ring_buf_is_empty(pbuf), NULL);
 	irq_offload(tringbuf_get, (void *)2);
-	zassert_true(ring_buf_is_empty(pbuf), NULL);
+	ztest_true(ring_buf_is_empty(pbuf), NULL);
 }
 
 void test_ringbuffer_put_get_thread_isr(void)
@@ -254,28 +254,28 @@ void test_ringbuffer_raw(void)
 		out_size = ring_buf_get(&ringbuf_raw, outbuf,
 						RINGBUFFER_SIZE - 2);
 
-		zassert_true(in_size == RINGBUFFER_SIZE - 2, NULL);
-		zassert_true(in_size == out_size, NULL);
-		zassert_true(memcmp(inbuf, outbuf, RINGBUFFER_SIZE - 2) == 0,
+		ztest_true(in_size == RINGBUFFER_SIZE - 2, NULL);
+		ztest_true(in_size == out_size, NULL);
+		ztest_true(memcmp(inbuf, outbuf, RINGBUFFER_SIZE - 2) == 0,
 			     NULL);
 	}
 
 	in_size = ring_buf_put(&ringbuf_raw, inbuf,
 				       RINGBUFFER_SIZE);
-	zassert_equal(in_size, RINGBUFFER_SIZE - 1, NULL);
+	ztest_equal(in_size, RINGBUFFER_SIZE - 1, NULL);
 
 	in_size = ring_buf_put(&ringbuf_raw, inbuf,
 				       1);
-	zassert_equal(in_size, 0, NULL);
+	ztest_equal(in_size, 0, NULL);
 
 	out_size = ring_buf_get(&ringbuf_raw, outbuf,
 					RINGBUFFER_SIZE);
 
-	zassert_true(out_size == RINGBUFFER_SIZE - 1, NULL);
+	ztest_true(out_size == RINGBUFFER_SIZE - 1, NULL);
 
 	out_size = ring_buf_get(&ringbuf_raw, outbuf,
 					RINGBUFFER_SIZE + 1);
-	zassert_true(out_size == 0, NULL);
+	ztest_true(out_size == 0, NULL);
 
 
 }
@@ -294,27 +294,27 @@ void test_ringbuffer_alloc_put(void)
 
 	allocated = ring_buf_put_claim(&ringbuf_raw, &data, 1);
 	sum_allocated = allocated;
-	zassert_true(allocated == 1U, NULL);
+	ztest_true(allocated == 1U, NULL);
 
 
 	allocated = ring_buf_put_claim(&ringbuf_raw, &data,
 					   RINGBUFFER_SIZE - 1);
 	sum_allocated += allocated;
-	zassert_true(allocated == RINGBUFFER_SIZE - 2, NULL);
+	ztest_true(allocated == RINGBUFFER_SIZE - 2, NULL);
 
 	/* Putting too much returns error */
 	err = ring_buf_put_finish(&ringbuf_raw, RINGBUFFER_SIZE);
-	zassert_true(err != 0, NULL);
+	ztest_true(err != 0, NULL);
 
 	err = ring_buf_put_finish(&ringbuf_raw, 1);
-	zassert_true(err == 0, NULL);
+	ztest_true(err == 0, NULL);
 
 	err = ring_buf_put_finish(&ringbuf_raw, RINGBUFFER_SIZE - 2);
-	zassert_true(err == 0, NULL);
+	ztest_true(err == 0, NULL);
 
 	read_size = ring_buf_get(&ringbuf_raw, outputbuf,
 					     RINGBUFFER_SIZE - 1);
-	zassert_true(read_size == (RINGBUFFER_SIZE - 1), NULL);
+	ztest_true(read_size == (RINGBUFFER_SIZE - 1), NULL);
 
 	for (int i = 0; i < 10; i++) {
 		allocated = ring_buf_put_claim(&ringbuf_raw, &data, 2);
@@ -338,13 +338,13 @@ void test_ringbuffer_alloc_put(void)
 		}
 
 		err = ring_buf_put_finish(&ringbuf_raw, 4);
-		zassert_true(err == 0, NULL);
+		ztest_true(err == 0, NULL);
 
 		read_size = ring_buf_get(&ringbuf_raw,
 						     outputbuf, 4);
-		zassert_true(read_size == 4U, NULL);
+		ztest_true(read_size == 4U, NULL);
 
-		zassert_true(memcmp(outputbuf, inputbuf, 4) == 0, NULL);
+		ztest_true(memcmp(outputbuf, inputbuf, 4) == 0, NULL);
 	}
 }
 
@@ -359,7 +359,7 @@ void test_byte_put_free(void)
 
 	/* Ring buffer is empty */
 	granted = ring_buf_get_claim(&ringbuf_raw, &data, RINGBUFFER_SIZE);
-	zassert_true(granted == 0U, NULL);
+	ztest_true(granted == 0U, NULL);
 
 	for (int i = 0; i < 10; i++) {
 		ring_buf_put(&ringbuf_raw, indata,
@@ -369,29 +369,29 @@ void test_byte_put_free(void)
 					       RINGBUFFER_SIZE);
 
 		if (granted == (RINGBUFFER_SIZE-2)) {
-			zassert_true(memcmp(indata, data, granted) == 0, NULL);
+			ztest_true(memcmp(indata, data, granted) == 0, NULL);
 		} else if (granted < (RINGBUFFER_SIZE-2)) {
 			/* When buffer wraps, operation is split. */
 			u32_t granted_1 = granted;
 
-			zassert_true(memcmp(indata, data, granted) == 0, NULL);
+			ztest_true(memcmp(indata, data, granted) == 0, NULL);
 			granted = ring_buf_get_claim(&ringbuf_raw, &data,
 						       RINGBUFFER_SIZE);
 
-			zassert_true((granted + granted_1) ==
+			ztest_true((granted + granted_1) ==
 					RINGBUFFER_SIZE - 2, NULL);
-			zassert_true(memcmp(&indata[granted_1], data, granted)
+			ztest_true(memcmp(&indata[granted_1], data, granted)
 					== 0, NULL);
 		} else {
-			zassert_true(false, NULL);
+			ztest_true(false, NULL);
 		}
 
 		/* Freeing more than possible case. */
 		err = ring_buf_get_finish(&ringbuf_raw, RINGBUFFER_SIZE-1);
-		zassert_true(err != 0, NULL);
+		ztest_true(err != 0, NULL);
 
 		err = ring_buf_get_finish(&ringbuf_raw, RINGBUFFER_SIZE-2);
-		zassert_true(err == 0, NULL);
+		ztest_true(err == 0, NULL);
 	}
 }
 
@@ -405,7 +405,7 @@ void test_capacity(void)
 	 * 1 byte is used for distinguishing between full and empty state.
 	 */
 	capacity = ring_buf_capacity_get(&ringbuf_raw);
-	zassert_equal(RINGBUFFER_SIZE - 1, capacity,
+	ztest_equal(RINGBUFFER_SIZE - 1, capacity,
 			"Unexpected capacity");
 }
 
@@ -423,24 +423,24 @@ void test_reset(void)
 
 	len = 3;
 	out_len = ring_buf_put(&ringbuf_raw, indata, len);
-	zassert_equal(out_len, len, NULL);
+	ztest_equal(out_len, len, NULL);
 
 	out_len = ring_buf_get(&ringbuf_raw, outdata, len);
-	zassert_equal(out_len, len, NULL);
+	ztest_equal(out_len, len, NULL);
 
 	space = ring_buf_space_get(&ringbuf_raw);
-	zassert_equal(space, RINGBUFFER_SIZE - 1, NULL);
+	ztest_equal(space, RINGBUFFER_SIZE - 1, NULL);
 
 	/* Even though ringbuffer is empty, full buffer cannot be allocated
 	 * because internal pointers are not at the beginning.
 	 */
 	granted = ring_buf_put_claim(&ringbuf_raw, &outbuf, RINGBUFFER_SIZE);
-	zassert_false(granted == RINGBUFFER_SIZE - 1, NULL);
+	ztest_false(granted == RINGBUFFER_SIZE - 1, NULL);
 
 	/* After reset full buffer can be allocated. */
 	ring_buf_reset(&ringbuf_raw);
 	granted = ring_buf_put_claim(&ringbuf_raw, &outbuf, RINGBUFFER_SIZE);
-	zassert_true(granted == RINGBUFFER_SIZE - 1, NULL);
+	ztest_true(granted == RINGBUFFER_SIZE - 1, NULL);
 }
 
 /*test case main entry*/

--- a/tests/lib/sprintf/src/main.c
+++ b/tests/lib/sprintf/src/main.c
@@ -72,156 +72,156 @@ void test_sprintf_double(void)
 	var.u1 = 0x00000000;
 	var.u2 = 0x7ff00000;    /* Bit pattern for +INF (double) */
 	sprintf(buffer, "%e", var.d);
-	zassert_true((strcmp(buffer, "inf") == 0),
+	ztest_true((strcmp(buffer, "inf") == 0),
 		     "sprintf(inf) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%E", var.d);
-	zassert_true((strcmp(buffer, "INF") == 0),
+	ztest_true((strcmp(buffer, "INF") == 0),
 		     "sprintf(INF) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%f", var.d);
-	zassert_true((strcmp(buffer, "inf") == 0),
+	ztest_true((strcmp(buffer, "inf") == 0),
 		     "sprintf(inf) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%F", var.d);
-	zassert_true((strcmp(buffer, "INF") == 0),
+	ztest_true((strcmp(buffer, "INF") == 0),
 		     "sprintf(INF) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%g", var.d);
-	zassert_true((strcmp(buffer, "inf") == 0),
+	ztest_true((strcmp(buffer, "inf") == 0),
 		     "sprintf(inf) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%G", var.d);
-	zassert_true((strcmp(buffer, "INF") == 0),
+	ztest_true((strcmp(buffer, "INF") == 0),
 		     "sprintf(INF) - incorrect output '%s'\n", buffer);
 
 	var.u1 = 0x00000000;
 	var.u2 = 0xfff00000;    /* Bit pattern for -INF (double) */
 	sprintf(buffer, "%e", var.d);
-	zassert_true((strcmp(buffer, "-inf") == 0),
+	ztest_true((strcmp(buffer, "-inf") == 0),
 		     "sprintf(-INF) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%E", var.d);
-	zassert_true((strcmp(buffer, "-INF") == 0),
+	ztest_true((strcmp(buffer, "-INF") == 0),
 		     "sprintf(-INF) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%f", var.d);
-	zassert_true((strcmp(buffer, "-inf") == 0),
+	ztest_true((strcmp(buffer, "-inf") == 0),
 		     "sprintf(-INF) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%F", var.d);
-	zassert_true((strcmp(buffer, "-INF") == 0),
+	ztest_true((strcmp(buffer, "-INF") == 0),
 		     "sprintf(-INF) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%g", var.d);
-	zassert_true((strcmp(buffer, "-inf") == 0),
+	ztest_true((strcmp(buffer, "-inf") == 0),
 		     "sprintf(-INF) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%G", var.d);
-	zassert_true((strcmp(buffer, "-INF") == 0),
+	ztest_true((strcmp(buffer, "-INF") == 0),
 		     "sprintf(-INF) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%010f", var.d);
-	zassert_true((strcmp(buffer, "      -inf") == 0),
+	ztest_true((strcmp(buffer, "      -inf") == 0),
 		     "sprintf(      +inf) - incorrect output '%s'\n", buffer);
 
 	var.u1 = 0x00000000;
 	var.u2 = 0x7ff80000;    /* Bit pattern for NaN (double) */
 	sprintf(buffer, "%e", var.d);
-	zassert_true((strcmp(buffer, "nan") == 0),
+	ztest_true((strcmp(buffer, "nan") == 0),
 		     "sprintf(nan) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%E", var.d);
-	zassert_true((strcmp(buffer, "NAN") == 0),
+	ztest_true((strcmp(buffer, "NAN") == 0),
 		     "sprintf(NAN) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%f", var.d);
-	zassert_true((strcmp(buffer, "nan") == 0),
+	ztest_true((strcmp(buffer, "nan") == 0),
 		     "sprintf(nan) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%F", var.d);
-	zassert_true((strcmp(buffer, "NAN") == 0),
+	ztest_true((strcmp(buffer, "NAN") == 0),
 		     "sprintf(NAN) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%g", var.d);
-	zassert_true((strcmp(buffer, "nan") == 0),
+	ztest_true((strcmp(buffer, "nan") == 0),
 		     "sprintf(nan) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%G", var.d);
-	zassert_true((strcmp(buffer, "NAN") == 0),
+	ztest_true((strcmp(buffer, "NAN") == 0),
 		     "sprintf(NAN) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%+8.5e", var.d);
-	zassert_true((strcmp(buffer, "    +nan") == 0),
+	ztest_true((strcmp(buffer, "    +nan") == 0),
 		     "sprintf(    +nan) - incorrect output '%s'\n", buffer);
 
 	var.u1 = 0x00000000;
 	var.u2 = 0xfff80000;    /* Bit pattern for -NaN (double) */
 	sprintf(buffer, "%e", var.d);
-	zassert_true((strcmp(buffer, "-nan") == 0),
+	ztest_true((strcmp(buffer, "-nan") == 0),
 		     "sprintf(-nan) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%E", var.d);
-	zassert_true((strcmp(buffer, "-NAN") == 0),
+	ztest_true((strcmp(buffer, "-NAN") == 0),
 		     "sprintf(-NAN) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%f", var.d);
-	zassert_true((strcmp(buffer, "-nan") == 0),
+	ztest_true((strcmp(buffer, "-nan") == 0),
 		     "sprintf(-nan) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%F", var.d);
-	zassert_true((strcmp(buffer, "-NAN") == 0),
+	ztest_true((strcmp(buffer, "-NAN") == 0),
 		     "sprintf(-NAN) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%g", var.d);
-	zassert_true((strcmp(buffer, "-nan") == 0),
+	ztest_true((strcmp(buffer, "-nan") == 0),
 		     "sprintf(-nan) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%G", var.d);
-	zassert_true((strcmp(buffer, "-NAN") == 0),
+	ztest_true((strcmp(buffer, "-NAN") == 0),
 		     "sprintf(-NAN) - incorrect output '%s'\n", buffer);
 
 	var.d = 1.0;
 	sprintf(buffer, "%f", var.d);
-	zassert_true((strcmp(buffer, "1.000000") == 0),
+	ztest_true((strcmp(buffer, "1.000000") == 0),
 		     "sprintf(1.0) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%+f", var.d);
-	zassert_true((strcmp(buffer, "+1.000000") == 0),
+	ztest_true((strcmp(buffer, "+1.000000") == 0),
 		     "sprintf(+1.0) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%.2f", var.d);
-	zassert_true((strcmp(buffer, "1.00") == 0),
+	ztest_true((strcmp(buffer, "1.00") == 0),
 		     "sprintf(1.00) - incorrect output '%s'\n", buffer);
 
 	sprintf(buffer, "%.*f", 11, var.d);
-	zassert_true((strcmp(buffer, "1.00000000000") == 0),
+	ztest_true((strcmp(buffer, "1.00000000000") == 0),
 		     "sprintf(1.00000000000) - incorrect "
 		     "output '%s'\n", buffer);
 
 	sprintf(buffer, "%12f", var.d);
-	zassert_true((strcmp(buffer, "    1.000000") == 0),
+	ztest_true((strcmp(buffer, "    1.000000") == 0),
 		     "sprintf(    1.000000) - incorrect "
 		     "output '%s'\n", buffer);
 
 	sprintf(buffer, "%-12f", var.d);
-	zassert_true((strcmp(buffer, "1.000000    ") == 0),
+	ztest_true((strcmp(buffer, "1.000000    ") == 0),
 		     "sprintf(1.000000    ) - incorrect "
 		     "output '%s'\n", buffer);
 
 	sprintf(buffer, "%012f", var.d);
-	zassert_true((strcmp(buffer, "00001.000000") == 0),
+	ztest_true((strcmp(buffer, "00001.000000") == 0),
 		     "sprintf(00001.000000) - incorrect "
 		     "output '%s'\n", buffer);
 
 	var.d = -1.0;
 	sprintf(buffer, "%f", var.d);
-	zassert_true((strcmp(buffer, "-1.000000") == 0),
+	ztest_true((strcmp(buffer, "-1.000000") == 0),
 		     "sprintf(-1.0) - incorrect output '%s'\n", buffer);
 
 	var.d = 1234.56789;
 	sprintf(buffer, "%f", var.d);
-	zassert_true((strcmp(buffer, "1234.567890") == 0),
+	ztest_true((strcmp(buffer, "1234.567890") == 0),
 		     "sprintf(-1.0) - incorrect output '%s'\n", buffer);
 
 	/*
@@ -232,101 +232,101 @@ void test_sprintf_double(void)
 	 */
 	var.d = 0x1p800;
 	sprintf(buffer, "%.140f", var.d);
-	zassert_true((strlen(buffer) == 382),
+	ztest_true((strlen(buffer) == 382),
 		     "sprintf(<large output>) - incorrect length %d\n",
 		     strlen(buffer));
 	buffer[10] = 0;  /* log facility doesn't support %.10s */
-	zassert_true((strcmp(buffer, "6668014432") == 0),
+	ztest_true((strcmp(buffer, "6668014432") == 0),
 		     "sprintf(<large output>) - starts with \"%s\" "
 		     "expected \"6668014432\"\n", buffer);
-	zassert_true((buffer[241] == '.'),
+	ztest_true((buffer[241] == '.'),
 		      "sprintf(<large output>) - expected '.' got '%c'\n",
 		      buffer[241]);
 
 	var.d = 0x1p-400;
 	sprintf(buffer, "% .380f", var.d);
-	zassert_true((strlen(buffer) == 383),
+	ztest_true((strlen(buffer) == 383),
 		     "sprintf(<large output>) - incorrect length %d\n",
 		     strlen(buffer));
 	buffer[10] = 0;  /* log facility doesn't support %.10s */
-	zassert_true((strcmp(buffer, " 0.0000000") == 0),
+	ztest_true((strcmp(buffer, " 0.0000000") == 0),
 		     "sprintf(<large output>) - starts with \"%s\" "
 		     "expected \" 0.0000000\"\n", buffer);
 	buffer[119 + 10] = 0;  /* log facility doesn't support %.10s */
-	zassert_true((strcmp(buffer + 119, "0000387259") == 0),
+	ztest_true((strcmp(buffer + 119, "0000387259") == 0),
 		      "sprintf(<large output>) - got \"%s\" "
 		      "while expecting \"0000387259\"\n", buffer + 119);
 
 	/*******************/
 	var.d = 1234.0;
 	sprintf(buffer, "%e", var.d);
-	zassert_true((strcmp(buffer, "1.234000e+03") == 0),
+	ztest_true((strcmp(buffer, "1.234000e+03") == 0),
 		     "sprintf(1.234000e+03) - incorrect "
 		     "output '%s'\n", buffer);
 
 	sprintf(buffer, "%E", var.d);
-	zassert_true((strcmp(buffer, "1.234000E+03") == 0),
+	ztest_true((strcmp(buffer, "1.234000E+03") == 0),
 		     "sprintf(1.234000E+03) - incorrect "
 		     "output '%s'\n", buffer);
 
 	/*******************/
 	var.d = 0.1234;
 	sprintf(buffer, "%e", var.d);
-	zassert_true((strcmp(buffer, "1.234000e-01") == 0),
+	ztest_true((strcmp(buffer, "1.234000e-01") == 0),
 		     "sprintf(1.234000e-01) - incorrect "
 		     "output '%s'\n", buffer);
 
 	sprintf(buffer, "%E", var.d);
-	zassert_true((strcmp(buffer, "1.234000E-01") == 0),
+	ztest_true((strcmp(buffer, "1.234000E-01") == 0),
 		     "sprintf(1.234000E-01) - incorrect "
 		     "output '%s'\n", buffer);
 
 	/*******************/
 	var.d = 1234000000.0;
 	sprintf(buffer, "%g", var.d);
-	zassert_true((strcmp(buffer, "1.234e+09") == 0),
+	ztest_true((strcmp(buffer, "1.234e+09") == 0),
 		     "sprintf(1.234e+09) - incorrect "
 		     "output '%s'\n", buffer);
 
 	sprintf(buffer, "%G", var.d);
-	zassert_true((strcmp(buffer, "1.234E+09") == 0),
+	ztest_true((strcmp(buffer, "1.234E+09") == 0),
 		     "sprintf(1.234E+09) - incorrect "
 		     "output '%s'\n", buffer);
 
 	var.d = 150.0;
 	sprintf(buffer, "%#.3g", var.d);
-	zassert_true((strcmp(buffer, "150.") == 0),
+	ztest_true((strcmp(buffer, "150.") == 0),
 		     "sprintf(150.) - incorrect "
 		     "output '%s'\n", buffer);
 
 	var.d = 150.1;
 	sprintf(buffer, "%.2g", var.d);
-	zassert_true((strcmp(buffer, "1.5e+02") == 0),
+	ztest_true((strcmp(buffer, "1.5e+02") == 0),
 		     "sprintf(1.5e+02) - incorrect "
 		     "output '%s'\n", buffer);
 
 	var.d = 150.567;
 	sprintf(buffer, "%.3g", var.d);
-	zassert_true((strcmp(buffer, "151") == 0),
+	ztest_true((strcmp(buffer, "151") == 0),
 		     "sprintf(151) - incorrect "
 		     "output '%s'\n", buffer);
 
 	var.d = 15e-5;
 	sprintf(buffer, "%#.3g", var.d);
-	zassert_true((strcmp(buffer, "0.000150") == 0),
+	ztest_true((strcmp(buffer, "0.000150") == 0),
 		     "sprintf(0.000150) - incorrect "
 		     "output '%s'\n", buffer);
 
 	var.d = 1505e-7;
 	sprintf(buffer, "%.4g", var.d);
-	zassert_true((strcmp(buffer, "0.0001505") == 0),
+	ztest_true((strcmp(buffer, "0.0001505") == 0),
 		     "sprintf(0.0001505) - incorrect "
 		     "output '%s'\n", buffer);
 
 	var.u1 = 0x00000001;
 	var.u2 = 0x00000000;    /* smallest denormal value */
 	sprintf(buffer, "%g", var.d);
-	zassert_true((strcmp(buffer, "4.94066e-324") == 0),
+	ztest_true((strcmp(buffer, "4.94066e-324") == 0),
 		     "sprintf(4.94066e-324) - incorrect "
 		     "output '%s'\n", buffer);
 }
@@ -365,21 +365,21 @@ void test_vsnprintf(void)
 	/*******************/
 	buffer[0] = '\0';
 	len = tvsnprintf(buffer, 0, "%x", DEADBEEF);
-	zassert_true((len == strlen(DEADBEEF_LHEX_STR)),
+	ztest_true((len == strlen(DEADBEEF_LHEX_STR)),
 		     "vsnprintf(%%x).  Expected return value %zu, not %d\n",
 		     strlen(DEADBEEF_LHEX_STR), len);
 
-	zassert_true((strcmp(buffer, "") == 0),
+	ztest_true((strcmp(buffer, "") == 0),
 		     "vsnprintf(%%x).  Expected '%s', got '%s'\n",
 		     "", buffer);
 
 	/*******************/
 	len = tvsnprintf(buffer, 4, "%x", DEADBEEF);
-	zassert_true((len == strlen(DEADBEEF_LHEX_STR)),
+	ztest_true((len == strlen(DEADBEEF_LHEX_STR)),
 		     "vsnprintf(%%x).  Expected return value %zu, not %d\n",
 		     strlen(DEADBEEF_LHEX_STR), len);
 
-	zassert_true((strcmp(buffer, "dea") == 0),
+	ztest_true((strcmp(buffer, "dea") == 0),
 		     "vsnprintf(%%x).  Expected '%s', got '%s'\n",
 		     "dea", buffer);
 
@@ -419,11 +419,11 @@ void test_vsprintf(void)
 
 	/*******************/
 	len = tvsprintf(buffer, "%x", DEADBEEF);
-	zassert_true((len == strlen(DEADBEEF_LHEX_STR)),
+	ztest_true((len == strlen(DEADBEEF_LHEX_STR)),
 		     "sprintf(%%x).  Expected %zu bytes written, not %d\n",
 		     strlen(DEADBEEF_LHEX_STR), len);
 
-	zassert_true((strcmp(buffer, DEADBEEF_LHEX_STR) == 0),
+	ztest_true((strcmp(buffer, DEADBEEF_LHEX_STR) == 0),
 		     "sprintf(%%x).  Expected '%s', got '%s'\n",
 		     DEADBEEF_LHEX_STR, buffer);
 }
@@ -459,20 +459,20 @@ void test_snprintf(void)
 	/*******************/
 	buffer[0] = '\0';
 	len = snprintf(buffer, 0, "%x", DEADBEEF);
-	zassert_true((len == strlen(DEADBEEF_LHEX_STR)),
+	ztest_true((len == strlen(DEADBEEF_LHEX_STR)),
 		     "snprintf(%%x).  Expected return value %zu, not %d\n",
 		     strlen(DEADBEEF_LHEX_STR), len);
 
-	zassert_true((strcmp(buffer, "") == 0),
+	ztest_true((strcmp(buffer, "") == 0),
 		     "snprintf(%%x).  Expected '%s', got '%s'\n",
 		     "", buffer);
 	/*******************/
 	len = snprintf(buffer, 4, "%x", DEADBEEF);
-	zassert_true((len == strlen(DEADBEEF_LHEX_STR)),
+	ztest_true((len == strlen(DEADBEEF_LHEX_STR)),
 		     "snprintf(%%x).  Expected return value %zu, not %d\n",
 		     strlen(DEADBEEF_LHEX_STR), len);
 
-	zassert_true((strcmp(buffer, "dea") == 0),
+	ztest_true((strcmp(buffer, "dea") == 0),
 		     "snprintf(%%x).  Expected '%s', got '%s'\n",
 		     "dea", buffer);
 
@@ -494,43 +494,43 @@ void test_sprintf_misc(void)
 
 	/*******************/
 	sprintf(buffer, "%p", (void *) DEADBEEF);
-	zassert_false((strcmp(buffer, DEADBEEF_PTR_STR) != 0),
+	ztest_false((strcmp(buffer, DEADBEEF_PTR_STR) != 0),
 		      "sprintf(%%p).  Expected '%s', got '%s'", DEADBEEF_PTR_STR, buffer);
 	/*******************/
 	sprintf(buffer, "test data %n test data", &count);
-	zassert_false((count != 10), "sprintf(%%n).  Expected count to be %d, not %d",
+	ztest_false((count != 10), "sprintf(%%n).  Expected count to be %d, not %d",
 		      10, count);
 
-	zassert_false((strcmp(buffer, "test data  test data") != 0),
+	ztest_false((strcmp(buffer, "test data  test data") != 0),
 		      "sprintf(%%p).  Expected '%s', got '%s'",
 		      "test data  test data", buffer);
 
 	/*******************/
 	sprintf(buffer, "%*d", 10, 1234);
-	zassert_true((strcmp(buffer, "      1234") == 0),
+	ztest_true((strcmp(buffer, "      1234") == 0),
 		     "sprintf(%%p).  Expected '%s', got '%s'",
 		     "      1234", buffer);
 
 	/*******************/
 	sprintf(buffer, "%*d", -10, 1234);
-	zassert_true((strcmp(buffer, "1234      ") == 0),
+	ztest_true((strcmp(buffer, "1234      ") == 0),
 		     "sprintf(%%p).  Expected '%s', got '%s'",
 		     "1234      ", buffer);
 
 	/*******************/
 	sprintf(buffer, "% d", 1234);
-	zassert_true((strcmp(buffer, " 1234") == 0),
+	ztest_true((strcmp(buffer, " 1234") == 0),
 		     "sprintf(%% d). Expected '%s', got '%s'",
 		     " 1234", buffer);
 
 	/*******************/
 	sprintf(buffer, "%hx", (unsigned short)1234);
-	zassert_true((strcmp("4d2", buffer) == 0),
+	ztest_true((strcmp("4d2", buffer) == 0),
 		     "sprintf(%%hx).  Expected '4d2', got '%s'", buffer);
 
 	/*******************/
 	sprintf(buffer, "%lx", 1234ul);
-	zassert_true((strcmp("4d2", buffer) == 0),
+	ztest_true((strcmp("4d2", buffer) == 0),
 		     "sprintf(%%lx).  Expected '4d2', got '%s'", buffer);
 
 }
@@ -549,101 +549,101 @@ void test_sprintf_integer(void)
 
 	/* Note: prints hex numbers in 8 characters */
 	len = sprintf(buffer, "%x", 0x11);
-	zassert_true((len == 2),
+	ztest_true((len == 2),
 		     "sprintf(%%x). "
 		     "Expected 2 bytes written, not %d", len);
 
-	zassert_true((strcmp(buffer, "11") == 0),
+	ztest_true((strcmp(buffer, "11") == 0),
 		     "sprintf(%%x). "
 		     "Expected '%s', got '%s'", "11", buffer);
 
 	/*******************/
 	len = sprintf(buffer, "%x", DEADBEEF);
-	zassert_true((len == strlen(DEADBEEF_LHEX_STR)),
+	ztest_true((len == strlen(DEADBEEF_LHEX_STR)),
 		     "sprintf(%%x).  Expected %zu bytes written, not %d\n",
 		     strlen(DEADBEEF_LHEX_STR), len);
 	/*******************/
-	zassert_true((strcmp(buffer, DEADBEEF_LHEX_STR) == 0),
+	ztest_true((strcmp(buffer, DEADBEEF_LHEX_STR) == 0),
 		     "sprintf(%%x).  Expected '%s', got '%s'\n",
 		     DEADBEEF_LHEX_STR, buffer);
 	/*******************/
 	len = sprintf(buffer, "%X", DEADBEEF);
-	zassert_true((len == strlen(DEADBEEF_UHEX_STR)),
+	ztest_true((len == strlen(DEADBEEF_UHEX_STR)),
 		     "sprintf(%%X).  Expected %zu bytes written, not %d\n",
 		     strlen(DEADBEEF_UHEX_STR), len);
 
-	zassert_true((strcmp(buffer, DEADBEEF_UHEX_STR) == 0),
+	ztest_true((strcmp(buffer, DEADBEEF_UHEX_STR) == 0),
 		     "sprintf(%%X).  Expected '%s', got '%s'\n",
 		     DEADBEEF_UHEX_STR, buffer);
 
 	/*******************/
 	len = sprintf(buffer, "%u", DEADBEEF);
-	zassert_true((len == strlen(DEADBEEF_UNSIGNED_STR)),
+	ztest_true((len == strlen(DEADBEEF_UNSIGNED_STR)),
 		     "sprintf(%%u).  Expected %zu bytes written, not %d\n",
 		     strlen(DEADBEEF_UNSIGNED_STR), len);
 
-	zassert_true((strcmp(buffer, DEADBEEF_UNSIGNED_STR) == 0),
+	ztest_true((strcmp(buffer, DEADBEEF_UNSIGNED_STR) == 0),
 		     "sprintf(%%u).  Expected '%s', got '%s'\n",
 		     DEADBEEF_UNSIGNED_STR, buffer);
 
 	/*******************/
 	len = sprintf(buffer, "%d", (int) DEADBEEF);
-	zassert_true((len == strlen(DEADBEEF_SIGNED_STR)),
+	ztest_true((len == strlen(DEADBEEF_SIGNED_STR)),
 		     "sprintf(%%d).  Expected %zu bytes written, not %d\n",
 		     strlen(DEADBEEF_SIGNED_STR), len);
 
-	zassert_true((strcmp(buffer, DEADBEEF_SIGNED_STR) == 0),
+	ztest_true((strcmp(buffer, DEADBEEF_SIGNED_STR) == 0),
 		     "sprintf(%%d).  Expected '%s', got '%s'\n",
 		     DEADBEEF_SIGNED_STR, buffer);
 
 	/*******************/
 	len = sprintf(buffer, "%o", DEADBEEF);
-	zassert_true((len == strlen(DEADBEEF_OCTAL_STR)),
+	ztest_true((len == strlen(DEADBEEF_OCTAL_STR)),
 		     "sprintf(%%o).  Expected %zu bytes written, not %d\n",
 		     strlen(DEADBEEF_OCTAL_STR), len);
 
-	zassert_true((strcmp(buffer, DEADBEEF_OCTAL_STR) == 0),
+	ztest_true((strcmp(buffer, DEADBEEF_OCTAL_STR) == 0),
 		     "sprintf(%%o).  Expected '%s', got '%s'\n",
 		     DEADBEEF_OCTAL_STR, buffer);
 
 	/*******************/
 	len = sprintf(buffer, "%#o", DEADBEEF);
-	zassert_true((len == strlen(DEADBEEF_OCTAL_ALT_STR)),
+	ztest_true((len == strlen(DEADBEEF_OCTAL_ALT_STR)),
 		     "sprintf(%%#o).  Expected %zu bytes written, not %d\n",
 		     strlen(DEADBEEF_OCTAL_ALT_STR), len);
 
-	zassert_true((strcmp(buffer, DEADBEEF_OCTAL_ALT_STR) == 0),
+	ztest_true((strcmp(buffer, DEADBEEF_OCTAL_ALT_STR) == 0),
 		     "sprintf(%%#o).  Expected '%s', got '%s'\n",
 		     DEADBEEF_OCTAL_ALT_STR, buffer);
 
 	/*******************/
 	len = sprintf(buffer, "%#x", DEADBEEF);
-	zassert_true((len == strlen(DEADBEEF_LHEX_ALT_STR)),
+	ztest_true((len == strlen(DEADBEEF_LHEX_ALT_STR)),
 		     "sprintf(%%#x).  Expected %zu bytes written, not %d\n",
 		     strlen(DEADBEEF_LHEX_ALT_STR), len);
 
-	zassert_true((strcmp(buffer, DEADBEEF_LHEX_ALT_STR) == 0),
+	ztest_true((strcmp(buffer, DEADBEEF_LHEX_ALT_STR) == 0),
 		     "sprintf(%%#x).  Expected '%s', got '%s'\n",
 		     DEADBEEF_LHEX_ALT_STR, buffer);
 
 	/*******************/
 	len = sprintf(buffer, "%#X", DEADBEEF);
-	zassert_true((len == strlen(DEADBEEF_UHEX_ALT_STR)),
+	ztest_true((len == strlen(DEADBEEF_UHEX_ALT_STR)),
 		     "sprintf(%%#X).  Expected %zu bytes written, not %d\n",
 		     strlen(DEADBEEF_UHEX_ALT_STR), len);
 
-	zassert_true((strcmp(buffer, DEADBEEF_UHEX_ALT_STR) == 0),
+	ztest_true((strcmp(buffer, DEADBEEF_UHEX_ALT_STR) == 0),
 		     "sprintf(%%#X).  Expected '%s', got '%s'\n",
 		     DEADBEEF_UHEX_ALT_STR, buffer);
 
 	/*******************/
 
 	len = sprintf(buffer, "%+d", 1);
-	zassert_true((len == 2),
+	ztest_true((len == 2),
 		     "sprintf(%%+d).  Expected %d bytes written, not %d\n",
 		     2, len);
 
-	zassert_true((strcmp(buffer, "+1") == 0),
+	ztest_true((strcmp(buffer, "+1") == 0),
 		     "sprintf(%%+d). Expected '+1', got '%s'\n", buffer);
 
 }
@@ -659,20 +659,20 @@ void test_sprintf_string(void)
 	char buffer[400];
 
 	sprintf(buffer, "%%");
-	zassert_true((strcmp(buffer, "%") == 0),
+	ztest_true((strcmp(buffer, "%") == 0),
 		     "sprintf(%%).  Expected '%%', got '%s'\n", buffer);
 
 	sprintf(buffer, "%c", 't');
-	zassert_true((strcmp(buffer, "t") == 0),
+	ztest_true((strcmp(buffer, "t") == 0),
 		     "sprintf(%%c).  Expected 't', got '%s'\n", buffer);
 
 	sprintf(buffer, "%s", "short string");
-	zassert_true((strcmp(buffer, "short string") == 0),
+	ztest_true((strcmp(buffer, "short string") == 0),
 		     "sprintf(%%s). "
 		     "Expected 'short string', got '%s'\n", buffer);
 
 	sprintf(buffer, "%s", REALLY_LONG_STRING);
-	zassert_true((strcmp(buffer, REALLY_LONG_STRING) == 0),
+	ztest_true((strcmp(buffer, REALLY_LONG_STRING) == 0),
 		     "sprintf(%%s) of REALLY_LONG_STRING doesn't match!\n");
 }
 

--- a/tests/net/6lo/src/main.c
+++ b/tests/net/6lo/src/main.c
@@ -1070,7 +1070,7 @@ static void test_6lo(struct net_6lo_data *data)
 	int diff;
 
 	pkt = create_pkt(data);
-	zassert_not_null(pkt, "failed to create buffer");
+	ztest_not_null(pkt, "failed to create buffer");
 #if DEBUG > 0
 	TC_PRINT("length before compression %zu\n",
 		 net_pkt_get_len(pkt));
@@ -1079,7 +1079,7 @@ static void test_6lo(struct net_6lo_data *data)
 
 	net_pkt_cursor_init(pkt);
 
-	zassert_true((net_6lo_compress(pkt, data->iphc) >= 0),
+	ztest_true((net_6lo_compress(pkt, data->iphc) >= 0),
 		     "compression failed");
 
 #if DEBUG > 0
@@ -1089,9 +1089,9 @@ static void test_6lo(struct net_6lo_data *data)
 #endif
 
 	diff = net_6lo_uncompress_hdr_diff(pkt);
-	zassert_true(diff == data->hdr_diff, "unexpected HDR diff");
+	ztest_true(diff == data->hdr_diff, "unexpected HDR diff");
 
-	zassert_true(net_6lo_uncompress(pkt),
+	ztest_true(net_6lo_uncompress(pkt),
 		     "uncompression failed");
 #if DEBUG > 0
 	TC_PRINT("length after uncompression %zu\n",
@@ -1099,7 +1099,7 @@ static void test_6lo(struct net_6lo_data *data)
 	net_pkt_hexdump(pkt, "after-uncompression");
 #endif
 
-	zassert_true(compare_pkt(pkt, data), NULL);
+	ztest_true(compare_pkt(pkt, data), NULL);
 
 	net_pkt_unref(pkt);
 }

--- a/tests/net/all/src/main.c
+++ b/tests/net/all/src/main.c
@@ -37,7 +37,7 @@ NET_DEVICE_OFFLOAD_INIT(net_offload, "net_offload",
 
 static void ok(void)
 {
-	zassert_true(true, "This test should never fail");
+	ztest_true(true, "This test should never fail");
 }
 
 void test_main(void)

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -179,7 +179,7 @@ static inline struct net_pkt *prepare_arp_reply(struct net_if *iface,
 					sizeof(struct net_eth_hdr) +
 					sizeof(struct net_arp_hdr),
 					AF_UNSPEC, 0, K_SECONDS(1));
-	zassert_not_null(pkt, "out of mem reply");
+	ztest_not_null(pkt, "out of mem reply");
 
 	eth = NET_ETH_HDR(pkt);
 
@@ -229,7 +229,7 @@ static inline struct net_pkt *prepare_arp_request(struct net_if *iface,
 	pkt = net_pkt_alloc_with_buffer(iface, sizeof(struct net_eth_hdr) +
 					sizeof(struct net_arp_hdr),
 					AF_UNSPEC, 0, K_SECONDS(1));
-	zassert_not_null(pkt, "out of mem request");
+	ztest_not_null(pkt, "out of mem request");
 
 	eth_req = NET_ETH_HDR(req);
 	eth = NET_ETH_HDR(pkt);
@@ -347,7 +347,7 @@ void test_arp(void)
 				      &src,
 				      NET_ADDR_MANUAL,
 				      0);
-	zassert_not_null(ifaddr, "Cannot add address");
+	ztest_not_null(ifaddr, "Cannot add address");
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
 
 	len = strlen(app_data);
@@ -355,7 +355,7 @@ void test_arp(void)
 	/* Application data for testing */
 	pkt = net_pkt_alloc_with_buffer(iface, sizeof(struct net_ipv4_hdr) +
 		len, AF_INET, 0, K_SECONDS(1));
-	zassert_not_null(pkt, "out of mem");
+	ztest_not_null(pkt, "out of mem");
 
 	net_pkt_lladdr_src(pkt)->addr = (u8_t *)net_if_get_link_addr(iface);
 	net_pkt_lladdr_src(pkt)->len = sizeof(struct net_eth_addr);
@@ -374,18 +374,18 @@ void test_arp(void)
 	 */
 
 	/**TESTPOINTS: Check packets*/
-	zassert_not_equal((void *)(pkt2), (void *)(pkt),
+	ztest_not_equal((void *)(pkt2), (void *)(pkt),
 		/* The packets cannot be the same as the ARP cache has
 		 * still room for the pkt.
 		 */
 		"ARP cache should still have free space");
 
-	zassert_not_null(pkt2, "ARP pkt is empty");
+	ztest_not_null(pkt2, "ARP pkt is empty");
 
 	/* The ARP cache should now have a link to pending net_pkt
 	 * that is to be sent after we have got an ARP reply.
 	 */
-	zassert_not_null(pkt->buffer,
+	ztest_not_null(pkt->buffer,
 		"Pending pkt buffer is NULL");
 
 	pending_pkt = pkt;
@@ -396,31 +396,31 @@ void test_arp(void)
 	if (arp_hdr->hwtype != htons(NET_ARP_HTYPE_ETH)) {
 		printk("ARP hwtype 0x%x, should be 0x%x\n",
 		       arp_hdr->hwtype, htons(NET_ARP_HTYPE_ETH));
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	if (arp_hdr->protocol != htons(NET_ETH_PTYPE_IP)) {
 		printk("ARP protocol 0x%x, should be 0x%x\n",
 		       arp_hdr->protocol, htons(NET_ETH_PTYPE_IP));
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	if (arp_hdr->hwlen != sizeof(struct net_eth_addr)) {
 		printk("ARP hwlen 0x%x, should be 0x%zx\n",
 		       arp_hdr->hwlen, sizeof(struct net_eth_addr));
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	if (arp_hdr->protolen != sizeof(struct in_addr)) {
 		printk("ARP IP addr len 0x%x, should be 0x%zx\n",
 		       arp_hdr->protolen, sizeof(struct in_addr));
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	if (arp_hdr->opcode != htons(NET_ARP_REQUEST)) {
 		printk("ARP opcode 0x%x, should be 0x%x\n",
 		       arp_hdr->opcode, htons(NET_ARP_REQUEST));
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	if (!net_ipv4_addr_cmp(&arp_hdr->dst_ipaddr,
@@ -428,7 +428,7 @@ void test_arp(void)
 		printk("ARP IP dest invalid %s, should be %s",
 			net_sprint_ipv4_addr(&arp_hdr->dst_ipaddr),
 			net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->dst));
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	if (!net_ipv4_addr_cmp(&arp_hdr->src_ipaddr,
@@ -436,7 +436,7 @@ void test_arp(void)
 		printk("ARP IP src invalid %s, should be %s",
 			net_sprint_ipv4_addr(&arp_hdr->src_ipaddr),
 			net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src));
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	/* We could have send the new ARP request but for this test we
@@ -444,7 +444,7 @@ void test_arp(void)
 	 */
 	net_pkt_unref(pkt2);
 
-	zassert_equal(atomic_get(&pkt->atomic_ref), 2,
+	ztest_equal(atomic_get(&pkt->atomic_ref), 2,
 		"ARP cache should own the original packet");
 
 	/* Then a case where target is not in the same subnet */
@@ -452,11 +452,11 @@ void test_arp(void)
 
 	pkt2 = net_arp_prepare(pkt, &NET_IPV4_HDR(pkt)->dst, NULL);
 
-	zassert_not_equal((void *)(pkt2), (void *)(pkt),
+	ztest_not_equal((void *)(pkt2), (void *)(pkt),
 		"ARP cache should not find anything");
 
 	/**TESTPOINTS: Check if packets not empty*/
-	zassert_not_null(pkt2,
+	ztest_not_null(pkt2,
 		"ARP pkt2 is empty");
 
 	arp_hdr = NET_ARP_HDR(pkt2);
@@ -466,7 +466,7 @@ void test_arp(void)
 		printk("ARP IP dst invalid %s, should be %s\n",
 			net_sprint_ipv4_addr(&arp_hdr->dst_ipaddr),
 			net_sprint_ipv4_addr(&iface->config.ip.ipv4->gw));
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	net_pkt_unref(pkt2);
@@ -483,7 +483,7 @@ void test_arp(void)
 
 	pkt2 = net_arp_prepare(pkt, &NET_IPV4_HDR(pkt)->dst, NULL);
 
-	zassert_not_null(pkt2,
+	ztest_not_null(pkt2,
 		"ARP cache is not sending the request again");
 
 	net_pkt_unref(pkt2);
@@ -500,7 +500,7 @@ void test_arp(void)
 
 	pkt2 = net_arp_prepare(pkt, &NET_IPV4_HDR(pkt)->dst, NULL);
 
-	zassert_not_null(pkt2,
+	ztest_not_null(pkt2,
 		"ARP cache did not send a req");
 
 	/* Restore the original address so that following test case can
@@ -514,7 +514,7 @@ void test_arp(void)
 	pkt = net_pkt_alloc_with_buffer(iface, sizeof(struct net_eth_hdr) +
 					sizeof(struct net_arp_hdr),
 					AF_UNSPEC, 0, K_SECONDS(1));
-	zassert_not_null(pkt, "out of mem reply");
+	ztest_not_null(pkt, "out of mem reply");
 
 	arp_hdr = NET_ARP_HDR(pkt);
 	net_buf_add(pkt->buffer, sizeof(struct net_arp_hdr));
@@ -524,7 +524,7 @@ void test_arp(void)
 
 	pkt2 = prepare_arp_reply(iface, pkt, &hwaddr, &eth_hdr);
 
-	zassert_not_null(pkt2, "ARP reply generation failed.");
+	ztest_not_null(pkt2, "ARP reply generation failed.");
 
 	/* The pending packet should now be sent */
 	switch (net_arp_input(pkt2, eth_hdr)) {
@@ -539,9 +539,9 @@ void test_arp(void)
 	k_yield();
 
 	/**TESTPOINTS: Check ARP reply*/
-	zassert_false(send_status < 0, "ARP reply was not sent");
+	ztest_false(send_status < 0, "ARP reply was not sent");
 
-	zassert_equal(atomic_get(&pkt->atomic_ref), 1,
+	ztest_equal(atomic_get(&pkt->atomic_ref), 1,
 		      "ARP cache should no longer own the original packet");
 
 	net_pkt_unref(pkt);
@@ -550,7 +550,7 @@ void test_arp(void)
 	pkt = net_pkt_alloc_with_buffer(iface, sizeof(struct net_eth_hdr) +
 					sizeof(struct net_arp_hdr),
 					AF_UNSPEC, 0, K_SECONDS(1));
-	zassert_not_null(pkt, "out of mem reply");
+	ztest_not_null(pkt, "out of mem reply");
 
 	send_status = -EINVAL;
 
@@ -566,7 +566,7 @@ void test_arp(void)
 	pkt2 = prepare_arp_request(iface, pkt, &hwaddr, &eth_hdr);
 
 	/**TESTPOINT: Check if ARP request generation failed*/
-	zassert_not_null(pkt2, "ARP request generation failed.");
+	ztest_not_null(pkt2, "ARP request generation failed.");
 
 	req_test = true;
 
@@ -582,7 +582,7 @@ void test_arp(void)
 	k_yield();
 
 	/**TESTPOINT: Check if ARP request sent*/
-	zassert_false(send_status < 0, "ARP req was not sent");
+	ztest_false(send_status < 0, "ARP req was not sent");
 
 	net_pkt_unref(pkt);
 
@@ -597,13 +597,13 @@ void test_arp(void)
 		entry_found = false;
 		expected_hwaddr = &hwaddr;
 		net_arp_foreach(arp_cb, &dst);
-		zassert_true(entry_found, "Entry not found");
+		ztest_true(entry_found, "Entry not found");
 
 		pkt = net_pkt_alloc_with_buffer(iface,
 						sizeof(struct net_eth_hdr) +
 						sizeof(struct net_arp_hdr),
 						AF_UNSPEC, 0, K_SECONDS(1));
-		zassert_not_null(pkt, "out of mem request");
+		ztest_not_null(pkt, "out of mem request");
 
 		setup_eth_header(iface, pkt, net_eth_broadcast_addr(),
 				 NET_ETH_PTYPE_ARP);
@@ -626,7 +626,7 @@ void test_arp(void)
 		net_buf_add(pkt->buffer, sizeof(struct net_arp_hdr));
 
 		verdict = net_arp_input(pkt, eth_hdr);
-		zassert_not_equal(verdict, NET_DROP, "Gratuitous ARP failed");
+		ztest_not_equal(verdict, NET_DROP, "Gratuitous ARP failed");
 
 		/* Then check that the HW address is changed for an existing
 		 * entry.
@@ -634,7 +634,7 @@ void test_arp(void)
 		entry_found = false;
 		expected_hwaddr = &new_hwaddr;
 		net_arp_foreach(arp_cb, &dst);
-		zassert_true(entry_found, "Changed entry not found");
+		ztest_true(entry_found, "Changed entry not found");
 
 		net_pkt_unref(pkt);
 	}

--- a/tests/net/buf/src/main.c
+++ b/tests/net/buf/src/main.c
@@ -72,7 +72,7 @@ static void buf_destroy(struct net_buf *buf)
 	struct net_buf_pool *pool = net_buf_pool_get(buf->pool_id);
 
 	destroy_called++;
-	zassert_equal(pool, &bufs_pool, "Invalid free pointer in buffer");
+	ztest_equal(pool, &bufs_pool, "Invalid free pointer in buffer");
 	net_buf_destroy(buf);
 }
 
@@ -81,7 +81,7 @@ static void fixed_destroy(struct net_buf *buf)
 	struct net_buf_pool *pool = net_buf_pool_get(buf->pool_id);
 
 	destroy_called++;
-	zassert_equal(pool, &fixed_pool, "Invalid free pointer in buffer");
+	ztest_equal(pool, &fixed_pool, "Invalid free pointer in buffer");
 	net_buf_destroy(buf);
 }
 
@@ -90,7 +90,7 @@ static void var_destroy(struct net_buf *buf)
 	struct net_buf_pool *pool = net_buf_pool_get(buf->pool_id);
 
 	destroy_called++;
-	zassert_equal(pool, &var_pool, "Invalid free pointer in buffer");
+	ztest_equal(pool, &var_pool, "Invalid free pointer in buffer");
 	net_buf_destroy(buf);
 }
 
@@ -106,7 +106,7 @@ static void net_buf_test_1(void)
 
 	for (i = 0; i < bufs_pool.buf_count; i++) {
 		buf = net_buf_alloc_len(&bufs_pool, 74, K_NO_WAIT);
-		zassert_not_null(buf, "Failed to get buffer");
+		ztest_not_null(buf, "Failed to get buffer");
 		bufs[i] = buf;
 	}
 
@@ -114,7 +114,7 @@ static void net_buf_test_1(void)
 		net_buf_unref(bufs[i]);
 	}
 
-	zassert_equal(destroy_called, ARRAY_SIZE(bufs),
+	ztest_equal(destroy_called, ARRAY_SIZE(bufs),
 		     "Incorrect destroy callback count");
 }
 
@@ -125,12 +125,12 @@ static void net_buf_test_2(void)
 	int i;
 
 	head = net_buf_alloc_len(&bufs_pool, 74, K_NO_WAIT);
-	zassert_not_null(head, "Failed to get fragment list head");
+	ztest_not_null(head, "Failed to get fragment list head");
 
 	frag = head;
 	for (i = 0; i < bufs_pool.buf_count - 1; i++) {
 		frag->frags = net_buf_alloc_len(&bufs_pool, 74, K_NO_WAIT);
-		zassert_not_null(frag->frags, "Failed to get fragment");
+		ztest_not_null(frag->frags, "Failed to get fragment");
 		frag = frag->frags;
 	}
 
@@ -140,7 +140,7 @@ static void net_buf_test_2(void)
 
 	destroy_called = 0;
 	net_buf_unref(head);
-	zassert_equal(destroy_called, bufs_pool.buf_count,
+	ztest_equal(destroy_called, bufs_pool.buf_count,
 		     "Incorrect fragment destroy callback count");
 }
 
@@ -153,11 +153,11 @@ static void test_3_thread(void *arg1, void *arg2, void *arg3)
 	k_sem_give(sema);
 
 	buf = net_buf_get(fifo, TEST_TIMEOUT);
-	zassert_not_null(buf, "Unable to get buffer");
+	ztest_not_null(buf, "Unable to get buffer");
 
 	destroy_called = 0;
 	net_buf_unref(buf);
-	zassert_equal(destroy_called, bufs_pool.buf_count,
+	ztest_equal(destroy_called, bufs_pool.buf_count,
 		     "Incorrect destroy callback count");
 
 	k_sem_give(sema);
@@ -174,12 +174,12 @@ static void net_buf_test_3(void)
 	int i;
 
 	head = net_buf_alloc_len(&bufs_pool, 74, K_NO_WAIT);
-	zassert_not_null(head, "Failed to get fragment list head");
+	ztest_not_null(head, "Failed to get fragment list head");
 
 	frag = head;
 	for (i = 0; i < bufs_pool.buf_count - 1; i++) {
 		frag->frags = net_buf_alloc_len(&bufs_pool, 74, K_NO_WAIT);
-		zassert_not_null(frag->frags, "Failed to get fragment");
+		ztest_not_null(frag->frags, "Failed to get fragment");
 		frag = frag->frags;
 	}
 
@@ -191,12 +191,12 @@ static void net_buf_test_3(void)
 			(k_thread_entry_t) test_3_thread, &fifo, &sema, NULL,
 			K_PRIO_COOP(7), 0, K_NO_WAIT);
 
-	zassert_true(k_sem_take(&sema, TEST_TIMEOUT) == 0,
+	ztest_true(k_sem_take(&sema, TEST_TIMEOUT) == 0,
 		    "Timeout while waiting for semaphore");
 
 	net_buf_put(&fifo, head);
 
-	zassert_true(k_sem_take(&sema, TEST_TIMEOUT) == 0,
+	ztest_true(k_sem_take(&sema, TEST_TIMEOUT) == 0,
 		    "Timeout while waiting for semaphore");
 }
 
@@ -213,7 +213,7 @@ static void net_buf_test_4(void)
 	 */
 	buf = net_buf_alloc_len(&bufs_pool, 0, K_FOREVER);
 
-	zassert_equal(buf->size, 0, "Invalid buffer size");
+	ztest_equal(buf->size, 0, "Invalid buffer size");
 
 	/* Test the fragments by appending after last fragment */
 	for (i = 0; i < bufs_pool.buf_count - 2; i++) {
@@ -235,7 +235,7 @@ static void net_buf_test_4(void)
 		i++;
 	}
 
-	zassert_equal(i, bufs_pool.buf_count - 1, "Incorrect fragment count");
+	ztest_equal(i, bufs_pool.buf_count - 1, "Incorrect fragment count");
 
 	/* Remove about half of the fragments and verify count */
 	i = removed = 0;
@@ -260,7 +260,7 @@ static void net_buf_test_4(void)
 		i++;
 	}
 
-	zassert_equal(1 + i + removed, bufs_pool.buf_count,
+	ztest_equal(1 + i + removed, bufs_pool.buf_count,
 		     "Incorrect removed fragment count");
 
 	removed = 0;
@@ -273,8 +273,8 @@ static void net_buf_test_4(void)
 		removed++;
 	}
 
-	zassert_equal(removed, i, "Incorrect removed fragment count");
-	zassert_equal(destroy_called, bufs_pool.buf_count - 1,
+	ztest_equal(removed, i, "Incorrect removed fragment count");
+	ztest_equal(destroy_called, bufs_pool.buf_count - 1,
 		     "Incorrect frag destroy callback count");
 
 	/* Add the fragments back and verify that they are properly unref
@@ -300,13 +300,13 @@ static void net_buf_test_4(void)
 		i++;
 	}
 
-	zassert_equal(i, bufs_pool.buf_count - 1, "Incorrect fragment count");
+	ztest_equal(i, bufs_pool.buf_count - 1, "Incorrect fragment count");
 
 	destroy_called = 0;
 
 	net_buf_unref(buf);
 
-	zassert_equal(destroy_called, bufs_pool.buf_count,
+	ztest_equal(destroy_called, bufs_pool.buf_count,
 		     "Incorrect frag destroy callback count");
 }
 
@@ -334,7 +334,7 @@ static void net_buf_test_big_buf(void)
 	/* First add some application data */
 	len = strlen(example_data);
 	for (i = 0; i < 2; i++) {
-		zassert_true(net_buf_tailroom(frag) >= len,
+		ztest_true(net_buf_tailroom(frag) >= len,
 			    "Allocated buffer is too small");
 		memcpy(net_buf_add(frag, len), example_data, len);
 	}
@@ -345,7 +345,7 @@ static void net_buf_test_big_buf(void)
 	net_buf_frag_add(buf, frag);
 	net_buf_unref(buf);
 
-	zassert_equal(destroy_called, 2, "Incorrect destroy callback count");
+	ztest_equal(destroy_called, 2, "Incorrect destroy callback count");
 }
 
 static void net_buf_test_multi_frags(void)
@@ -386,7 +386,7 @@ static void net_buf_test_multi_frags(void)
 	/* First add some application data */
 	len = strlen(example_data);
 	for (i = 0; i < bufs_pool.buf_count - 2; i++) {
-		zassert_true(net_buf_tailroom(frags[i]) >= len,
+		ztest_true(net_buf_tailroom(frags[i]) >= len,
 			    "Allocated buffer is too small");
 		memcpy(net_buf_add(frags[i], len), example_data, len);
 		occupied += frags[i]->len;
@@ -397,7 +397,7 @@ static void net_buf_test_multi_frags(void)
 
 	net_buf_unref(buf);
 
-	zassert_equal(destroy_called, bufs_pool.buf_count,
+	ztest_equal(destroy_called, bufs_pool.buf_count,
 		     "Incorrect frag destroy callback count");
 }
 
@@ -408,16 +408,16 @@ static void net_buf_test_clone(void)
 	destroy_called = 0;
 
 	buf = net_buf_alloc_len(&bufs_pool, 74, K_NO_WAIT);
-	zassert_not_null(buf, "Failed to get buffer");
+	ztest_not_null(buf, "Failed to get buffer");
 
 	clone = net_buf_clone(buf, K_NO_WAIT);
-	zassert_not_null(clone, "Failed to get clone buffer");
-	zassert_equal(buf->data, clone->data, "Incorrect clone data pointer");
+	ztest_not_null(clone, "Failed to get clone buffer");
+	ztest_equal(buf->data, clone->data, "Incorrect clone data pointer");
 
 	net_buf_unref(buf);
 	net_buf_unref(clone);
 
-	zassert_equal(destroy_called, 2, "Incorrect destroy callback count");
+	ztest_equal(destroy_called, 2, "Incorrect destroy callback count");
 }
 
 static void net_buf_test_fixed_pool(void)
@@ -427,11 +427,11 @@ static void net_buf_test_fixed_pool(void)
 	destroy_called = 0;
 
 	buf = net_buf_alloc_len(&fixed_pool, 20, K_NO_WAIT);
-	zassert_not_null(buf, "Failed to get buffer");
+	ztest_not_null(buf, "Failed to get buffer");
 
 	net_buf_unref(buf);
 
-	zassert_equal(destroy_called, 1, "Incorrect destroy callback count");
+	ztest_equal(destroy_called, 1, "Incorrect destroy callback count");
 }
 
 static void net_buf_test_var_pool(void)
@@ -441,20 +441,20 @@ static void net_buf_test_var_pool(void)
 	destroy_called = 0;
 
 	buf1 = net_buf_alloc_len(&var_pool, 20, K_NO_WAIT);
-	zassert_not_null(buf1, "Failed to get buffer");
+	ztest_not_null(buf1, "Failed to get buffer");
 
 	buf2 = net_buf_alloc_len(&var_pool, 200, K_NO_WAIT);
-	zassert_not_null(buf2, "Failed to get buffer");
+	ztest_not_null(buf2, "Failed to get buffer");
 
 	buf3 = net_buf_clone(buf2, K_NO_WAIT);
-	zassert_not_null(buf3, "Failed to clone buffer");
-	zassert_equal(buf3->data, buf2->data, "Cloned data doesn't match");
+	ztest_not_null(buf3, "Failed to clone buffer");
+	ztest_equal(buf3->data, buf2->data, "Cloned data doesn't match");
 
 	net_buf_unref(buf1);
 	net_buf_unref(buf2);
 	net_buf_unref(buf3);
 
-	zassert_equal(destroy_called, 3, "Incorrect destroy callback count");
+	ztest_equal(destroy_called, 3, "Incorrect destroy callback count");
 }
 
 static void net_buf_test_byte_order(void)
@@ -475,13 +475,13 @@ static void net_buf_test_byte_order(void)
 	u64_t u64;
 
 	buf = net_buf_alloc_len(&fixed_pool, 16, K_FOREVER);
-	zassert_not_null(buf, "Failed to get buffer");
+	ztest_not_null(buf, "Failed to get buffer");
 
 	net_buf_add_mem(buf, &le16, sizeof(le16));
 	net_buf_add_mem(buf, &be16, sizeof(be16));
 
 	u16 = net_buf_pull_le16(buf);
-	zassert_equal(u16, net_buf_pull_be16(buf),
+	ztest_equal(u16, net_buf_pull_be16(buf),
 		      "Invalid 16 bits byte order");
 
 	net_buf_reset(buf);
@@ -489,9 +489,9 @@ static void net_buf_test_byte_order(void)
 	net_buf_add_le16(buf, u16);
 	net_buf_add_be16(buf, u16);
 
-	zassert_mem_equal(le16, net_buf_pull_mem(buf, sizeof(le16)),
+	ztest_mem_equal(le16, net_buf_pull_mem(buf, sizeof(le16)),
 			  sizeof(le16), "Invalid 16 bits byte order");
-	zassert_mem_equal(be16, net_buf_pull_mem(buf, sizeof(be16)),
+	ztest_mem_equal(be16, net_buf_pull_mem(buf, sizeof(be16)),
 			  sizeof(be16), "Invalid 16 bits byte order");
 
 	net_buf_reset(buf);
@@ -500,7 +500,7 @@ static void net_buf_test_byte_order(void)
 	net_buf_add_mem(buf, &be24, sizeof(be24));
 
 	u32 = net_buf_pull_le24(buf);
-	zassert_equal(u32, net_buf_pull_be24(buf),
+	ztest_equal(u32, net_buf_pull_be24(buf),
 		      "Invalid 24 bits byte order");
 
 	net_buf_reset(buf);
@@ -508,9 +508,9 @@ static void net_buf_test_byte_order(void)
 	net_buf_add_le24(buf, u32);
 	net_buf_add_be24(buf, u32);
 
-	zassert_mem_equal(le24, net_buf_pull_mem(buf, sizeof(le24)),
+	ztest_mem_equal(le24, net_buf_pull_mem(buf, sizeof(le24)),
 			  sizeof(le24), "Invalid 24 bits byte order");
-	zassert_mem_equal(be24, net_buf_pull_mem(buf, sizeof(be24)),
+	ztest_mem_equal(be24, net_buf_pull_mem(buf, sizeof(be24)),
 			  sizeof(be24), "Invalid 24 bits byte order");
 
 	net_buf_reset(buf);
@@ -519,7 +519,7 @@ static void net_buf_test_byte_order(void)
 	net_buf_add_mem(buf, &be32, sizeof(be32));
 
 	u32 = net_buf_pull_le32(buf);
-	zassert_equal(u32, net_buf_pull_be32(buf),
+	ztest_equal(u32, net_buf_pull_be32(buf),
 		      "Invalid 32 bits byte order");
 
 	net_buf_reset(buf);
@@ -527,9 +527,9 @@ static void net_buf_test_byte_order(void)
 	net_buf_add_le32(buf, u32);
 	net_buf_add_be32(buf, u32);
 
-	zassert_mem_equal(le32, net_buf_pull_mem(buf, sizeof(le32)),
+	ztest_mem_equal(le32, net_buf_pull_mem(buf, sizeof(le32)),
 			  sizeof(le32), "Invalid 32 bits byte order");
-	zassert_mem_equal(be32, net_buf_pull_mem(buf, sizeof(be32)),
+	ztest_mem_equal(be32, net_buf_pull_mem(buf, sizeof(be32)),
 			  sizeof(be32), "Invalid 32 bits byte order");
 
 	net_buf_reset(buf);
@@ -538,7 +538,7 @@ static void net_buf_test_byte_order(void)
 	net_buf_add_mem(buf, &be48, sizeof(be48));
 
 	u64 = net_buf_pull_le48(buf);
-	zassert_equal(u64, net_buf_pull_be48(buf),
+	ztest_equal(u64, net_buf_pull_be48(buf),
 		      "Invalid 48 bits byte order");
 
 	net_buf_reset(buf);
@@ -546,9 +546,9 @@ static void net_buf_test_byte_order(void)
 	net_buf_add_le48(buf, u64);
 	net_buf_add_be48(buf, u64);
 
-	zassert_mem_equal(le48, net_buf_pull_mem(buf, sizeof(le48)),
+	ztest_mem_equal(le48, net_buf_pull_mem(buf, sizeof(le48)),
 			  sizeof(le48), "Invalid 48 bits byte order");
-	zassert_mem_equal(be48, net_buf_pull_mem(buf, sizeof(be48)),
+	ztest_mem_equal(be48, net_buf_pull_mem(buf, sizeof(be48)),
 			  sizeof(be48), "Invalid 48 bits byte order");
 
 	net_buf_reset(buf);
@@ -557,7 +557,7 @@ static void net_buf_test_byte_order(void)
 	net_buf_add_mem(buf, &be64, sizeof(be64));
 
 	u64 = net_buf_pull_le64(buf);
-	zassert_equal(u64, net_buf_pull_be64(buf),
+	ztest_equal(u64, net_buf_pull_be64(buf),
 		      "Invalid 64 bits byte order");
 
 	net_buf_reset(buf);
@@ -565,9 +565,9 @@ static void net_buf_test_byte_order(void)
 	net_buf_add_le64(buf, u64);
 	net_buf_add_be64(buf, u64);
 
-	zassert_mem_equal(le64, net_buf_pull_mem(buf, sizeof(le64)),
+	ztest_mem_equal(le64, net_buf_pull_mem(buf, sizeof(le64)),
 			  sizeof(le64), "Invalid 64 bits byte order");
-	zassert_mem_equal(be64, net_buf_pull_mem(buf, sizeof(be64)),
+	ztest_mem_equal(be64, net_buf_pull_mem(buf, sizeof(be64)),
 			  sizeof(be48), "Invalid 64 bits byte order");
 
 	net_buf_unref(buf);

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -139,7 +139,7 @@ static int eth_tx_offloading_disabled(struct device *dev, struct net_pkt *pkt)
 {
 	struct eth_context *context = dev->driver_data;
 
-	zassert_equal_ptr(&eth_context_offloading_disabled, context,
+	ztest_equal_ptr(&eth_context_offloading_disabled, context,
 			  "Context pointers do not match (%p vs %p)",
 			  eth_context_offloading_disabled, context);
 
@@ -175,7 +175,7 @@ static int eth_tx_offloading_disabled(struct device *dev, struct net_pkt *pkt)
 		}
 
 		udp_hdr = net_udp_get_hdr(pkt, &hdr);
-		zassert_not_null(udp_hdr, "UDP header missing");
+		ztest_not_null(udp_hdr, "UDP header missing");
 
 		port = udp_hdr->src_port;
 		udp_hdr->src_port = udp_hdr->dst_port;
@@ -193,7 +193,7 @@ static int eth_tx_offloading_disabled(struct device *dev, struct net_pkt *pkt)
 		if (net_recv_data(net_pkt_iface(pkt),
 				  net_pkt_clone(pkt, K_NO_WAIT)) < 0) {
 			test_failed = true;
-			zassert_true(false, "Packet %p receive failed\n", pkt);
+			ztest_true(false, "Packet %p receive failed\n", pkt);
 		}
 
 		return 0;
@@ -206,7 +206,7 @@ static int eth_tx_offloading_disabled(struct device *dev, struct net_pkt *pkt)
 
 		DBG("Chksum 0x%x offloading disabled\n", chksum);
 
-		zassert_not_equal(chksum, 0, "Checksum calculated");
+		ztest_not_equal(chksum, 0, "Checksum calculated");
 
 		k_sem_give(&wait_data);
 	}
@@ -218,7 +218,7 @@ static int eth_tx_offloading_enabled(struct device *dev, struct net_pkt *pkt)
 {
 	struct eth_context *context = dev->driver_data;
 
-	zassert_equal_ptr(&eth_context_offloading_enabled, context,
+	ztest_equal_ptr(&eth_context_offloading_enabled, context,
 			  "Context pointers do not match (%p vs %p)",
 			  eth_context_offloading_enabled, context);
 
@@ -234,7 +234,7 @@ static int eth_tx_offloading_enabled(struct device *dev, struct net_pkt *pkt)
 
 		DBG("Chksum 0x%x offloading enabled\n", chksum);
 
-		zassert_equal(chksum, 0, "Checksum calculated");
+		ztest_equal(chksum, 0, "Checksum calculated");
 
 		k_sem_give(&wait_data);
 	}
@@ -362,7 +362,7 @@ static void eth_setup(void)
 	/* Make sure we have enough virtual interfaces */
 	net_if_foreach(iface_cb, &ud);
 
-	zassert_equal(ud.eth_if_count, sizeof(eth_interfaces) / sizeof(void *),
+	ztest_equal(ud.eth_if_count, sizeof(eth_interfaces) / sizeof(void *),
 		      "Invalid number of interfaces (%d vs %d)\n",
 		      ud.eth_if_count,
 		      sizeof(eth_interfaces) / sizeof(void *));
@@ -376,15 +376,15 @@ static void address_setup(void)
 	iface1 = eth_interfaces[0];
 	iface2 = eth_interfaces[1];
 
-	zassert_not_null(iface1, "Interface 1");
-	zassert_not_null(iface2, "Interface 2");
+	ztest_not_null(iface1, "Interface 1");
+	ztest_not_null(iface2, "Interface 2");
 
 	ifaddr = net_if_ipv6_addr_add(iface1, &my_addr1,
 				      NET_ADDR_MANUAL, 0);
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr1));
-		zassert_not_null(ifaddr, "addr1");
+		ztest_not_null(ifaddr, "addr1");
 	}
 
 	/* For testing purposes we need to set the adddresses preferred */
@@ -395,28 +395,28 @@ static void address_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&ll_addr));
-		zassert_not_null(ifaddr, "ll_addr");
+		ztest_not_null(ifaddr, "ll_addr");
 	}
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
 
 	ifaddr = net_if_ipv4_addr_add(iface1, &in4addr_my,
 				      NET_ADDR_MANUAL, 0);
-	zassert_not_null(ifaddr, "Cannot add IPv4 address");
+	ztest_not_null(ifaddr, "Cannot add IPv4 address");
 
 	ifaddr = net_if_ipv6_addr_add(iface2, &my_addr2,
 				      NET_ADDR_MANUAL, 0);
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr2));
-		zassert_not_null(ifaddr, "addr2");
+		ztest_not_null(ifaddr, "addr2");
 	}
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
 
 	ifaddr = net_if_ipv4_addr_add(iface2, &in4addr_my2,
 				      NET_ADDR_MANUAL, 0);
-	zassert_not_null(ifaddr, "Cannot add IPv4 address");
+	ztest_not_null(ifaddr, "Cannot add IPv4 address");
 
 	net_if_up(iface1);
 	net_if_up(iface2);
@@ -472,24 +472,24 @@ static void tx_chksum_offload_disabled_test_v6(void)
 
 	ret = net_context_get(AF_INET6, SOCK_DGRAM, IPPROTO_UDP,
 			      &udp_v6_ctx_1);
-	zassert_equal(ret, 0, "Create IPv6 UDP context failed");
+	ztest_equal(ret, 0, "Create IPv6 UDP context failed");
 
 	memcpy(&src_addr6.sin6_addr, &my_addr1, sizeof(struct in6_addr));
 	memcpy(&dst_addr6.sin6_addr, &dst_addr, sizeof(struct in6_addr));
 
 	ret = net_context_bind(udp_v6_ctx_1, (struct sockaddr *)&src_addr6,
 			       sizeof(struct sockaddr_in6));
-	zassert_equal(ret, 0, "Context bind failure test failed");
+	ztest_equal(ret, 0, "Context bind failure test failed");
 
 	iface = eth_interfaces[0];
 	ctx = net_if_get_device(iface)->driver_data;
-	zassert_equal_ptr(&eth_context_offloading_disabled, ctx,
+	ztest_equal_ptr(&eth_context_offloading_disabled, ctx,
 			  "eth context mismatch");
 
 	test_started = true;
 
 	ret = add_neighbor(iface, &dst_addr);
-	zassert_true(ret, "Cannot add neighbor");
+	ztest_true(ret, "Cannot add neighbor");
 
 	len = strlen(test_data);
 
@@ -497,11 +497,11 @@ static void tx_chksum_offload_disabled_test_v6(void)
 				 (struct sockaddr *)&dst_addr6,
 				 sizeof(struct sockaddr_in6),
 				 NULL, K_FOREVER, NULL);
-	zassert_equal(ret, len, "Send UDP pkt failed (%d)\n", ret);
+	ztest_equal(ret, len, "Send UDP pkt failed (%d)\n", ret);
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		DBG("Timeout while waiting interface data\n");
-		zassert_false(true, "Timeout");
+		ztest_false(true, "Timeout");
 	}
 
 	net_context_unref(udp_v6_ctx_1);
@@ -523,18 +523,18 @@ static void tx_chksum_offload_disabled_test_v4(void)
 
 	ret = net_context_get(AF_INET, SOCK_DGRAM, IPPROTO_UDP,
 			      &udp_v4_ctx_1);
-	zassert_equal(ret, 0, "Create IPv4 UDP context failed");
+	ztest_equal(ret, 0, "Create IPv4 UDP context failed");
 
 	memcpy(&src_addr4.sin_addr, &in4addr_my, sizeof(struct in_addr));
 	memcpy(&dst_addr4.sin_addr, &in4addr_dst, sizeof(struct in_addr));
 
 	ret = net_context_bind(udp_v4_ctx_1, (struct sockaddr *)&src_addr4,
 			       sizeof(struct sockaddr_in));
-	zassert_equal(ret, 0, "Context bind failure test failed");
+	ztest_equal(ret, 0, "Context bind failure test failed");
 
 	iface = eth_interfaces[0];
 	ctx = net_if_get_device(iface)->driver_data;
-	zassert_equal_ptr(&eth_context_offloading_disabled, ctx,
+	ztest_equal_ptr(&eth_context_offloading_disabled, ctx,
 			  "eth context mismatch");
 
 	len = strlen(test_data);
@@ -542,17 +542,17 @@ static void tx_chksum_offload_disabled_test_v4(void)
 	test_started = true;
 
 	ret = add_neighbor(iface, &dst_addr);
-	zassert_true(ret, "Cannot add neighbor");
+	ztest_true(ret, "Cannot add neighbor");
 
 	ret = net_context_sendto(udp_v4_ctx_1, test_data, len,
 				 (struct sockaddr *)&dst_addr4,
 				 sizeof(struct sockaddr_in),
 				 NULL, K_FOREVER, NULL);
-	zassert_equal(ret, len, "Send UDP pkt failed (%d)\n", ret);
+	ztest_equal(ret, len, "Send UDP pkt failed (%d)\n", ret);
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		DBG("Timeout while waiting interface data\n");
-		zassert_false(true, "Timeout");
+		ztest_false(true, "Timeout");
 	}
 
 	net_context_unref(udp_v4_ctx_1);
@@ -574,18 +574,18 @@ static void tx_chksum_offload_enabled_test_v6(void)
 
 	ret = net_context_get(AF_INET6, SOCK_DGRAM, IPPROTO_UDP,
 			      &udp_v6_ctx_2);
-	zassert_equal(ret, 0, "Create IPv6 UDP context failed");
+	ztest_equal(ret, 0, "Create IPv6 UDP context failed");
 
 	memcpy(&src_addr6.sin6_addr, &my_addr2, sizeof(struct in6_addr));
 	memcpy(&dst_addr6.sin6_addr, &dst_addr, sizeof(struct in6_addr));
 
 	ret = net_context_bind(udp_v6_ctx_2, (struct sockaddr *)&src_addr6,
 			       sizeof(struct sockaddr_in6));
-	zassert_equal(ret, 0, "Context bind failure test failed");
+	ztest_equal(ret, 0, "Context bind failure test failed");
 
 	iface = eth_interfaces[1];
 	ctx = net_if_get_device(iface)->driver_data;
-	zassert_equal_ptr(&eth_context_offloading_enabled, ctx,
+	ztest_equal_ptr(&eth_context_offloading_enabled, ctx,
 			  "eth context mismatch");
 
 	len = strlen(test_data);
@@ -593,17 +593,17 @@ static void tx_chksum_offload_enabled_test_v6(void)
 	test_started = true;
 
 	ret = add_neighbor(iface, &dst_addr);
-	zassert_true(ret, "Cannot add neighbor");
+	ztest_true(ret, "Cannot add neighbor");
 
 	ret = net_context_sendto(udp_v6_ctx_2, test_data, len,
 				 (struct sockaddr *)&dst_addr6,
 				 sizeof(struct sockaddr_in6),
 				 NULL, K_FOREVER, NULL);
-	zassert_equal(ret, len, "Send UDP pkt failed (%d)\n", ret);
+	ztest_equal(ret, len, "Send UDP pkt failed (%d)\n", ret);
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		DBG("Timeout while waiting interface data\n");
-		zassert_false(true, "Timeout");
+		ztest_false(true, "Timeout");
 	}
 
 	net_context_unref(udp_v6_ctx_2);
@@ -625,18 +625,18 @@ static void tx_chksum_offload_enabled_test_v4(void)
 
 	ret = net_context_get(AF_INET, SOCK_DGRAM, IPPROTO_UDP,
 			      &udp_v4_ctx_2);
-	zassert_equal(ret, 0, "Create IPv4 UDP context failed");
+	ztest_equal(ret, 0, "Create IPv4 UDP context failed");
 
 	memcpy(&src_addr4.sin_addr, &in4addr_my2, sizeof(struct in_addr));
 	memcpy(&dst_addr4.sin_addr, &in4addr_dst, sizeof(struct in_addr));
 
 	ret = net_context_bind(udp_v4_ctx_2, (struct sockaddr *)&src_addr4,
 			       sizeof(struct sockaddr_in));
-	zassert_equal(ret, 0, "Context bind failure test failed");
+	ztest_equal(ret, 0, "Context bind failure test failed");
 
 	iface = eth_interfaces[1];
 	ctx = net_if_get_device(iface)->driver_data;
-	zassert_equal_ptr(&eth_context_offloading_enabled, ctx,
+	ztest_equal_ptr(&eth_context_offloading_enabled, ctx,
 			  "eth context mismatch");
 
 	len = strlen(test_data);
@@ -644,17 +644,17 @@ static void tx_chksum_offload_enabled_test_v4(void)
 	test_started = true;
 
 	ret = add_neighbor(iface, &dst_addr);
-	zassert_true(ret, "Cannot add neighbor");
+	ztest_true(ret, "Cannot add neighbor");
 
 	ret = net_context_sendto(udp_v4_ctx_2, test_data, len,
 				 (struct sockaddr *)&dst_addr4,
 				 sizeof(struct sockaddr_in),
 				 NULL, K_FOREVER, NULL);
-	zassert_equal(ret, len, "Send UDP pkt failed (%d)\n", ret);
+	ztest_equal(ret, len, "Send UDP pkt failed (%d)\n", ret);
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		DBG("Timeout while waiting interface data\n");
-		zassert_false(true, "Timeout");
+		ztest_false(true, "Timeout");
 	}
 
 	net_context_unref(udp_v4_ctx_2);
@@ -667,13 +667,13 @@ static void recv_cb_offload_disabled(struct net_context *context,
 				     int status,
 				     void *user_data)
 {
-	zassert_not_null(proto_hdr->udp, "UDP header missing");
-	zassert_not_equal(proto_hdr->udp->chksum, 0, "Checksum is not set");
+	ztest_not_null(proto_hdr->udp, "UDP header missing");
+	ztest_not_equal(proto_hdr->udp->chksum, 0, "Checksum is not set");
 
 	if (net_pkt_family(pkt) == AF_INET) {
 		struct net_ipv4_hdr *ipv4 = NET_IPV4_HDR(pkt);
 
-		zassert_not_equal(ipv4->chksum, 0,
+		ztest_not_equal(ipv4->chksum, 0,
 				  "IPv4 checksum is not set");
 	}
 
@@ -689,13 +689,13 @@ static void recv_cb_offload_enabled(struct net_context *context,
 				    int status,
 				    void *user_data)
 {
-	zassert_not_null(proto_hdr->udp, "UDP header missing");
-	zassert_equal(proto_hdr->udp->chksum, 0, "Checksum is set");
+	ztest_not_null(proto_hdr->udp, "UDP header missing");
+	ztest_equal(proto_hdr->udp->chksum, 0, "Checksum is set");
 
 	if (net_pkt_family(pkt) == AF_INET) {
 		struct net_ipv4_hdr *ipv4 = NET_IPV4_HDR(pkt);
 
-		zassert_equal(ipv4->chksum, 0, "IPv4 checksum is set");
+		ztest_equal(ipv4->chksum, 0, "IPv4 checksum is set");
 	}
 
 	k_sem_give(&wait_data);
@@ -719,18 +719,18 @@ static void rx_chksum_offload_disabled_test_v6(void)
 
 	ret = net_context_get(AF_INET6, SOCK_DGRAM, IPPROTO_UDP,
 			      &udp_v6_ctx_1);
-	zassert_equal(ret, 0, "Create IPv6 UDP context failed");
+	ztest_equal(ret, 0, "Create IPv6 UDP context failed");
 
 	memcpy(&src_addr6.sin6_addr, &my_addr1, sizeof(struct in6_addr));
 	memcpy(&dst_addr6.sin6_addr, &dst_addr, sizeof(struct in6_addr));
 
 	ret = net_context_bind(udp_v6_ctx_1, (struct sockaddr *)&src_addr6,
 			       sizeof(struct sockaddr_in6));
-	zassert_equal(ret, 0, "Context bind failure test failed");
+	ztest_equal(ret, 0, "Context bind failure test failed");
 
 	iface = eth_interfaces[0];
 	ctx = net_if_get_device(iface)->driver_data;
-	zassert_equal_ptr(&eth_context_offloading_disabled, ctx,
+	ztest_equal_ptr(&eth_context_offloading_disabled, ctx,
 			  "eth context mismatch");
 
 	len = strlen(test_data);
@@ -740,7 +740,7 @@ static void rx_chksum_offload_disabled_test_v6(void)
 
 	ret = net_context_recv(udp_v6_ctx_1, recv_cb_offload_disabled, 0,
 			       NULL);
-	zassert_equal(ret, 0, "Recv UDP failed (%d)\n", ret);
+	ztest_equal(ret, 0, "Recv UDP failed (%d)\n", ret);
 
 	start_receiving = false;
 
@@ -748,11 +748,11 @@ static void rx_chksum_offload_disabled_test_v6(void)
 				 (struct sockaddr *)&dst_addr6,
 				 sizeof(struct sockaddr_in6),
 				 NULL, K_FOREVER, NULL);
-	zassert_equal(ret, len, "Send UDP pkt failed (%d)\n", ret);
+	ztest_equal(ret, len, "Send UDP pkt failed (%d)\n", ret);
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		DBG("Timeout while waiting interface data\n");
-		zassert_false(true, "Timeout");
+		ztest_false(true, "Timeout");
 	}
 
 	/* Let the receiver to receive the packets */
@@ -775,18 +775,18 @@ static void rx_chksum_offload_disabled_test_v4(void)
 
 	ret = net_context_get(AF_INET, SOCK_DGRAM, IPPROTO_UDP,
 			      &udp_v4_ctx_1);
-	zassert_equal(ret, 0, "Create IPv4 UDP context failed");
+	ztest_equal(ret, 0, "Create IPv4 UDP context failed");
 
 	memcpy(&src_addr4.sin_addr, &in4addr_my, sizeof(struct in_addr));
 	memcpy(&dst_addr4.sin_addr, &in4addr_dst, sizeof(struct in_addr));
 
 	ret = net_context_bind(udp_v4_ctx_1, (struct sockaddr *)&src_addr4,
 			       sizeof(struct sockaddr_in));
-	zassert_equal(ret, 0, "Context bind failure test failed");
+	ztest_equal(ret, 0, "Context bind failure test failed");
 
 	iface = eth_interfaces[0];
 	ctx = net_if_get_device(iface)->driver_data;
-	zassert_equal_ptr(&eth_context_offloading_disabled, ctx,
+	ztest_equal_ptr(&eth_context_offloading_disabled, ctx,
 			  "eth context mismatch");
 
 	len = strlen(test_data);
@@ -796,7 +796,7 @@ static void rx_chksum_offload_disabled_test_v4(void)
 
 	ret = net_context_recv(udp_v4_ctx_1, recv_cb_offload_disabled, 0,
 			       NULL);
-	zassert_equal(ret, 0, "Recv UDP failed (%d)\n", ret);
+	ztest_equal(ret, 0, "Recv UDP failed (%d)\n", ret);
 
 	start_receiving = false;
 
@@ -804,11 +804,11 @@ static void rx_chksum_offload_disabled_test_v4(void)
 				 (struct sockaddr *)&dst_addr4,
 				 sizeof(struct sockaddr_in),
 				 NULL, K_FOREVER, NULL);
-	zassert_equal(ret, len, "Send UDP pkt failed (%d)\n", ret);
+	ztest_equal(ret, len, "Send UDP pkt failed (%d)\n", ret);
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		DBG("Timeout while waiting interface data\n");
-		zassert_false(true, "Timeout");
+		ztest_false(true, "Timeout");
 	}
 
 	/* Let the receiver to receive the packets */
@@ -831,18 +831,18 @@ static void rx_chksum_offload_enabled_test_v6(void)
 
 	ret = net_context_get(AF_INET6, SOCK_DGRAM, IPPROTO_UDP,
 			      &udp_v6_ctx_2);
-	zassert_equal(ret, 0, "Create IPv6 UDP context failed");
+	ztest_equal(ret, 0, "Create IPv6 UDP context failed");
 
 	memcpy(&src_addr6.sin6_addr, &my_addr2, sizeof(struct in6_addr));
 	memcpy(&dst_addr6.sin6_addr, &dst_addr, sizeof(struct in6_addr));
 
 	ret = net_context_bind(udp_v6_ctx_2, (struct sockaddr *)&src_addr6,
 			       sizeof(struct sockaddr_in6));
-	zassert_equal(ret, 0, "Context bind failure test failed");
+	ztest_equal(ret, 0, "Context bind failure test failed");
 
 	iface = eth_interfaces[1];
 	ctx = net_if_get_device(iface)->driver_data;
-	zassert_equal_ptr(&eth_context_offloading_enabled, ctx,
+	ztest_equal_ptr(&eth_context_offloading_enabled, ctx,
 			  "eth context mismatch");
 
 	len = strlen(test_data);
@@ -852,17 +852,17 @@ static void rx_chksum_offload_enabled_test_v6(void)
 
 	ret = net_context_recv(udp_v6_ctx_2, recv_cb_offload_enabled, 0,
 			       NULL);
-	zassert_equal(ret, 0, "Recv UDP failed (%d)\n", ret);
+	ztest_equal(ret, 0, "Recv UDP failed (%d)\n", ret);
 
 	ret = net_context_sendto(udp_v6_ctx_2, test_data, len,
 				 (struct sockaddr *)&dst_addr6,
 				 sizeof(struct sockaddr_in6),
 				 NULL, K_FOREVER, NULL);
-	zassert_equal(ret, len, "Send UDP pkt failed (%d)\n", ret);
+	ztest_equal(ret, len, "Send UDP pkt failed (%d)\n", ret);
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		DBG("Timeout while waiting interface data\n");
-		zassert_false(true, "Timeout");
+		ztest_false(true, "Timeout");
 	}
 
 	/* Let the receiver to receive the packets */
@@ -885,18 +885,18 @@ static void rx_chksum_offload_enabled_test_v4(void)
 
 	ret = net_context_get(AF_INET, SOCK_DGRAM, IPPROTO_UDP,
 			      &udp_v4_ctx_2);
-	zassert_equal(ret, 0, "Create IPv4 UDP context failed");
+	ztest_equal(ret, 0, "Create IPv4 UDP context failed");
 
 	memcpy(&src_addr4.sin_addr, &in4addr_my2, sizeof(struct in_addr));
 	memcpy(&dst_addr4.sin_addr, &in4addr_dst, sizeof(struct in_addr));
 
 	ret = net_context_bind(udp_v4_ctx_2, (struct sockaddr *)&src_addr4,
 			       sizeof(struct sockaddr_in));
-	zassert_equal(ret, 0, "Context bind failure test failed");
+	ztest_equal(ret, 0, "Context bind failure test failed");
 
 	iface = eth_interfaces[1];
 	ctx = net_if_get_device(iface)->driver_data;
-	zassert_equal_ptr(&eth_context_offloading_enabled, ctx,
+	ztest_equal_ptr(&eth_context_offloading_enabled, ctx,
 			  "eth context mismatch");
 
 	len = strlen(test_data);
@@ -906,17 +906,17 @@ static void rx_chksum_offload_enabled_test_v4(void)
 
 	ret = net_context_recv(udp_v4_ctx_2, recv_cb_offload_enabled, 0,
 			       NULL);
-	zassert_equal(ret, 0, "Recv UDP failed (%d)\n", ret);
+	ztest_equal(ret, 0, "Recv UDP failed (%d)\n", ret);
 
 	ret = net_context_sendto(udp_v4_ctx_2, test_data, len,
 				 (struct sockaddr *)&dst_addr4,
 				 sizeof(struct sockaddr_in),
 				 NULL, K_FOREVER, NULL);
-	zassert_equal(ret, len, "Send UDP pkt failed (%d)\n", ret);
+	ztest_equal(ret, len, "Send UDP pkt failed (%d)\n", ret);
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		DBG("Timeout while waiting interface data\n");
-		zassert_false(true, "Timeout");
+		ztest_false(true, "Timeout");
 	}
 
 	/* Let the receiver to receive the packets */

--- a/tests/net/context/src/main.c
+++ b/tests/net/context/src/main.c
@@ -77,31 +77,31 @@ static void net_ctx_get_fail(void)
 	int ret;
 
 	ret = net_context_get(AF_UNSPEC, SOCK_DGRAM, IPPROTO_UDP, &context);
-	zassert_equal(ret, -EAFNOSUPPORT,
+	ztest_equal(ret, -EAFNOSUPPORT,
 		      "Invalid family test failed");
 
 	ret = net_context_get(AF_INET6, 10, IPPROTO_UDP, &context);
-	zassert_equal(ret, -EPROTOTYPE,
+	ztest_equal(ret, -EPROTOTYPE,
 		      "Invalid context type test failed ");
 
 	ret = net_context_get(AF_INET6, SOCK_DGRAM, IPPROTO_ICMPV6, &context);
-	zassert_equal(ret, -EPROTONOSUPPORT,
+	ztest_equal(ret, -EPROTONOSUPPORT,
 		      "Invalid context protocol test failed");
 
 	ret = net_context_get(99, SOCK_DGRAM, IPPROTO_UDP, &context);
-	zassert_equal(ret, -EAFNOSUPPORT,
+	ztest_equal(ret, -EAFNOSUPPORT,
 		      "Invalid context family test failed");
 
 	ret = net_context_get(AF_INET6, SOCK_STREAM, IPPROTO_TCP, &context);
-	zassert_equal(ret, -EPROTOTYPE,
+	ztest_equal(ret, -EPROTOTYPE,
 		      "Invalid context proto type test failed");
 
 	ret = net_context_get(AF_INET6, SOCK_DGRAM, IPPROTO_TCP, &context);
-	zassert_equal(ret, -EPROTONOSUPPORT,
+	ztest_equal(ret, -EPROTONOSUPPORT,
 		      "Invalid context proto value test failed");
 
 	ret = net_context_get(AF_INET6, SOCK_DGRAM, IPPROTO_UDP, NULL);
-	zassert_equal(ret, -EINVAL,
+	ztest_equal(ret, -EINVAL,
 		      "Invalid context value test failed ");
 }
 
@@ -111,15 +111,15 @@ static void net_ctx_get_success(void)
 	int ret;
 
 	ret = net_context_get(AF_INET6, SOCK_DGRAM, IPPROTO_UDP, &context);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Context get test failed");
-	zassert_not_null(context, "Got NULL context");
+	ztest_not_null(context, "Got NULL context");
 
 	ret = net_context_put(context);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Context put test failed");
 
-	zassert_false(net_context_is_used(context),
+	ztest_false(net_context_is_used(context),
 		      "Context put check test failed");
 }
 
@@ -132,17 +132,17 @@ static void net_ctx_get_all(void)
 	for (i = 0; i < ARRAY_SIZE(contexts); i++) {
 		ret = net_context_get(AF_INET6, SOCK_DGRAM,
 				      IPPROTO_UDP, &contexts[i]);
-		zassert_equal(ret, 0,
+		ztest_equal(ret, 0,
 			      "context get test failed");
 	}
 
 	ret = net_context_get(AF_INET6, SOCK_DGRAM, IPPROTO_UDP, &context);
-	zassert_equal(ret, -ENOENT,
+	ztest_equal(ret, -ENOENT,
 		      "Context get extra test failed");
 
 	for (i = 0; i < ARRAY_SIZE(contexts); i++) {
 		ret = net_context_put(contexts[i]);
-		zassert_equal(ret, 0,
+		ztest_equal(ret, 0,
 			      "Context put test failed");
 	}
 }
@@ -153,28 +153,28 @@ static void net_ctx_create(void)
 
 	ret = net_context_get(AF_INET6, SOCK_DGRAM, IPPROTO_UDP,
 			      &udp_v6_ctx);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Context create IPv6 UDP test failed");
 
 	ret = net_context_get(AF_INET6, SOCK_DGRAM, IPPROTO_UDP,
 			      &mcast_v6_ctx);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Context create IPv6 mcast test failed ");
 
 	ret = net_context_get(AF_INET, SOCK_DGRAM, IPPROTO_UDP,
 			      &udp_v4_ctx);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Context create IPv4 UDP test failed");
 
 #if defined(CONFIG_NET_TCP)
 	ret = net_context_get(AF_INET6, SOCK_STREAM, IPPROTO_TCP,
 			      &tcp_v6_ctx);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Context create IPv6 TCP test failed");
 
 	ret = net_context_get(AF_INET, SOCK_STREAM, IPPROTO_TCP,
 			      &tcp_v4_ctx);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Context create IPv4 TCP test failed");
 #endif /* CONFIG_NET_TCP */
 }
@@ -191,7 +191,7 @@ static void net_ctx_bind_fail(void)
 
 	ret = net_context_bind(udp_v6_ctx, (struct sockaddr *)&addr,
 			       sizeof(struct sockaddr_in6));
-	zassert_equal(ret, -ENOENT,
+	ztest_equal(ret, -ENOENT,
 		      "Context bind failure test failed");
 }
 
@@ -207,7 +207,7 @@ static void net_ctx_bind_uni_success_v6(void)
 
 	ret = net_context_bind(udp_v6_ctx, (struct sockaddr *)&addr,
 			       sizeof(struct sockaddr_in6));
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Context bind IPv6 test failed");
 }
 
@@ -222,7 +222,7 @@ static void net_ctx_bind_uni_success_v4(void)
 
 	ret = net_context_bind(udp_v4_ctx, (struct sockaddr *)&addr,
 			       sizeof(struct sockaddr_in));
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Context bind IPv4 test failed");
 }
 
@@ -239,28 +239,28 @@ static void net_ctx_bind_mcast_success(void)
 
 	ret = net_context_bind(mcast_v6_ctx, (struct sockaddr *)&addr,
 			       sizeof(struct sockaddr_in6));
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Context bind test failed ");
 }
 
 static void net_ctx_listen_v6(void)
 {
-	zassert_true(net_context_listen(udp_v6_ctx, 0),
+	ztest_true(net_context_listen(udp_v6_ctx, 0),
 		     "Context listen IPv6 UDP test failed");
 
 #if defined(CONFIG_NET_TCP)
-	zassert_true(net_context_listen(tcp_v6_ctx, 0),
+	ztest_true(net_context_listen(tcp_v6_ctx, 0),
 		     "Context listen IPv6 TCP test failed");
 #endif /* CONFIG_NET_TCP */
 }
 
 static void net_ctx_listen_v4(void)
 {
-	zassert_true(net_context_listen(udp_v4_ctx, 0),
+	ztest_true(net_context_listen(udp_v4_ctx, 0),
 		     "Context listen IPv4 UDP test failed ");
 
 #if defined(CONFIG_NET_TCP)
-	zassert_true(net_context_listen(tcp_v4_ctx, 0),
+	ztest_true(net_context_listen(tcp_v4_ctx, 0),
 		     "Context listen IPv4 TCP test failed");
 #endif /* CONFIG_NET_TCP */
 }
@@ -293,14 +293,14 @@ static void net_ctx_connect_v6(void)
 	ret = net_context_connect(udp_v6_ctx, (struct sockaddr *)&addr,
 				  sizeof(struct sockaddr_in6), connect_cb,
 				  K_NO_WAIT, INT_TO_POINTER(AF_INET6));
-	zassert_false((ret || cb_failure),
+	ztest_false((ret || cb_failure),
 		      "Context connect IPv6 UDP test failed");
 
 #if defined(CONFIG_NET_TCP)
 	ret = net_context_connect(tcp_v6_ctx, (struct sockaddr *)&addr,
 				  sizeof(struct sockaddr_in6), connect_cb,
 				  K_NO_WAIT, INT_TO_POINTER(AF_INET6));
-	zassert_false((ret || cb_failure),
+	ztest_false((ret || cb_failure),
 		      "Context connect IPv6 TCP test failed");
 
 #endif /* CONFIG_NET_TCP */
@@ -318,14 +318,14 @@ static void net_ctx_connect_v4(void)
 	ret = net_context_connect(udp_v4_ctx, (struct sockaddr *)&addr,
 				  sizeof(struct sockaddr_in), connect_cb,
 				  K_NO_WAIT, INT_TO_POINTER(AF_INET));
-	zassert_false((ret || cb_failure),
+	ztest_false((ret || cb_failure),
 		      "Context connect IPv6 UDP test failed");
 
 #if defined(CONFIG_NET_TCP)
 	ret = net_context_connect(tcp_v4_ctx, (struct sockaddr *)&addr,
 				  sizeof(struct sockaddr_in6), connect_cb,
 				  K_NO_WAIT, INT_TO_POINTER(AF_INET));
-	zassert_false((ret || cb_failure),
+	ztest_false((ret || cb_failure),
 		      "Context connect IPv6 TCP test failed");
 #endif /* CONFIG_NET_TCP */
 }
@@ -354,7 +354,7 @@ static void net_ctx_accept_v6(void)
 
 	ret = net_context_accept(udp_v6_ctx, accept_cb, K_NO_WAIT,
 				 INT_TO_POINTER(AF_INET6));
-	zassert_false((ret != -EINVAL || cb_failure),
+	ztest_false((ret != -EINVAL || cb_failure),
 		      "Context accept IPv6 UDP test failed");
 }
 
@@ -364,7 +364,7 @@ static void net_ctx_accept_v4(void)
 
 	ret = net_context_accept(udp_v4_ctx, accept_cb, K_NO_WAIT,
 				 INT_TO_POINTER(AF_INET));
-	zassert_false((ret != -EINVAL || cb_failure),
+	ztest_false((ret != -EINVAL || cb_failure),
 		      "Context accept IPv4 UDP test failed");
 }
 
@@ -392,7 +392,7 @@ static void net_ctx_send_v6(void)
 			       send_cb, K_FOREVER, INT_TO_POINTER(AF_INET6));
 	k_yield();
 
-	zassert_false(((ret < 0) || cb_failure),
+	ztest_false(((ret < 0) || cb_failure),
 		     "Context send IPv6 UDP test failed");
 }
 
@@ -406,7 +406,7 @@ static void net_ctx_send_v4(void)
 			       send_cb, K_FOREVER, INT_TO_POINTER(AF_INET));
 	k_yield();
 
-	zassert_false(((ret < 0) || cb_failure),
+	ztest_false(((ret < 0) || cb_failure),
 		      "Context send IPv4 UDP test failed");
 }
 
@@ -426,7 +426,7 @@ static void net_ctx_sendto_v6(void)
 				 (struct sockaddr *)&addr,
 				 sizeof(struct sockaddr_in6), send_cb,
 				 K_NO_WAIT, INT_TO_POINTER(AF_INET6));
-	zassert_false(((ret < 0) || cb_failure),
+	ztest_false(((ret < 0) || cb_failure),
 		      "Context send IPv6 UDP test failed");
 }
 
@@ -445,7 +445,7 @@ static void net_ctx_sendto_v4(void)
 				 (struct sockaddr *)&addr,
 				 sizeof(struct sockaddr_in), send_cb,
 				 K_NO_WAIT, INT_TO_POINTER(AF_INET));
-	zassert_false(((ret < 0) || cb_failure),
+	ztest_false(((ret < 0) || cb_failure),
 		      "Context send IPv4 UDP test failed");
 }
 
@@ -468,14 +468,14 @@ static void net_ctx_recv_v6(void)
 
 	ret = net_context_recv(udp_v6_ctx, recv_cb, K_NO_WAIT,
 			       INT_TO_POINTER(AF_INET6));
-	zassert_false((ret || cb_failure),
+	ztest_false((ret || cb_failure),
 		      "Context recv IPv6 UDP test failed");
 
 	net_ctx_sendto_v6();
 
 	k_sem_take(&wait_data, WAIT_TIME);
 
-	zassert_true(recv_cb_called, "No data received on time, "
+	ztest_true(recv_cb_called, "No data received on time, "
 				"IPv6 recv test failed");
 	recv_cb_called = false;
 }
@@ -486,14 +486,14 @@ static void net_ctx_recv_v4(void)
 
 	ret = net_context_recv(udp_v4_ctx, recv_cb, K_NO_WAIT,
 			       INT_TO_POINTER(AF_INET));
-	zassert_false((ret || cb_failure),
+	ztest_false((ret || cb_failure),
 		      "Context recv IPv4 UDP test failed");
 
 	net_ctx_sendto_v4();
 
 	k_sem_take(&wait_data, WAIT_TIME);
 
-	zassert_true(recv_cb_called, "No data received on time, "
+	ztest_true(recv_cb_called, "No data received on time, "
 				"IPv4 recv test failed");
 
 	recv_cb_called = false;
@@ -528,10 +528,10 @@ static void net_ctx_recv_v6_fail(void)
 {
 	net_ctx_sendto_v6_wrong_src();
 
-	zassert_true(k_sem_take(&wait_data, WAIT_TIME),
+	ztest_true(k_sem_take(&wait_data, WAIT_TIME),
 		     "Semaphore triggered but should not");
 
-	zassert_false(recv_cb_called, "Data received but should not have, "
+	ztest_false(recv_cb_called, "Data received but should not have, "
 			     "IPv6 recv test failed");
 
 	recv_cb_called = false;
@@ -564,10 +564,10 @@ static void net_ctx_recv_v4_fail(void)
 {
 	net_ctx_sendto_v4_wrong_src();
 
-	zassert_true(k_sem_take(&wait_data, WAIT_TIME),
+	ztest_true(k_sem_take(&wait_data, WAIT_TIME),
 		     "Semaphore triggered but should not");
 
-	zassert_false(recv_cb_called, "Data received but should not have, "
+	ztest_false(recv_cb_called, "Data received but should not have, "
 		      "IPv4 recv test failed");
 
 	recv_cb_called = false;
@@ -579,7 +579,7 @@ static void net_ctx_recv_v6_again(void)
 
 	k_sem_take(&wait_data, WAIT_TIME);
 
-	zassert_true(recv_cb_called, "No data received on time 2nd time, "
+	ztest_true(recv_cb_called, "No data received on time 2nd time, "
 		     "IPv6 recv test failed");
 
 	recv_cb_called = false;
@@ -591,7 +591,7 @@ static void net_ctx_recv_v4_again(void)
 
 	k_sem_take(&wait_data, WAIT_TIME);
 
-	zassert_true(recv_cb_called,
+	ztest_true(recv_cb_called,
 		     "No data received on time 2nd time, "
 		     "IPv4 recv test failed");
 
@@ -617,14 +617,14 @@ static void net_ctx_recv_v6_reconfig(void)
 
 	ret = net_context_recv(udp_v6_ctx, recv_cb_another, K_NO_WAIT,
 			       INT_TO_POINTER(AF_INET6));
-	zassert_false((ret || cb_failure),
+	ztest_false((ret || cb_failure),
 		      "Context recv reconfig IPv6 UDP test failed");
 
 	net_ctx_sendto_v6();
 
 	k_sem_take(&wait_data, WAIT_TIME);
 
-	zassert_true(recv_cb_reconfig_called,
+	ztest_true(recv_cb_reconfig_called,
 		     "No data received on time, "
 		     "IPv6 recv reconfig test failed");
 
@@ -637,7 +637,7 @@ static void net_ctx_recv_v4_reconfig(void)
 
 	ret = net_context_recv(udp_v4_ctx, recv_cb_another, K_NO_WAIT,
 			       INT_TO_POINTER(AF_INET));
-	zassert_false((ret || cb_failure),
+	ztest_false((ret || cb_failure),
 		      "Context recv reconfig IPv4 UDP test failed");
 
 
@@ -645,7 +645,7 @@ static void net_ctx_recv_v4_reconfig(void)
 
 	k_sem_take(&wait_data, WAIT_TIME);
 
-	zassert_true(recv_cb_reconfig_called, "No data received on time, "
+	ztest_true(recv_cb_reconfig_called, "No data received on time, "
 		     "IPv4 recv reconfig test failed");
 
 	recv_cb_reconfig_called = false;
@@ -681,7 +681,7 @@ void timeout_thread(struct net_context *ctx, void *param2, void *param3)
 	ret = net_context_recv(ctx, recv_cb_timeout, timeout,
 			       INT_TO_POINTER(family));
 	if (ret != -ETIMEDOUT && expecting_cb_failure) {
-		zassert_true(expecting_cb_failure,
+		ztest_true(expecting_cb_failure,
 			     "Context recv UDP timeout test failed");
 		cb_failure = true;
 		return;
@@ -741,7 +741,7 @@ static void net_ctx_recv_v6_timeout(void)
 	expecting_cb_failure = false;
 	recv_cb_timeout_called = false;
 
-	zassert_true(!cb_failure, NULL);
+	ztest_true(!cb_failure, NULL);
 }
 
 static void net_ctx_recv_v4_timeout(void)
@@ -769,7 +769,7 @@ static void net_ctx_recv_v4_timeout(void)
 	expecting_cb_failure = false;
 	recv_cb_timeout_called = false;
 
-	zassert_true(!cb_failure, NULL);
+	ztest_true(!cb_failure, NULL);
 }
 
 static void net_ctx_recv_v6_timeout_forever(void)
@@ -829,24 +829,24 @@ static void net_ctx_put(void)
 	int ret;
 
 	ret = net_context_put(udp_v6_ctx);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Context put IPv6 UDP test failed.");
 
 	ret = net_context_put(mcast_v6_ctx);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Context put IPv6 mcast test failed");
 
 	ret = net_context_put(udp_v4_ctx);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Context put IPv4 UDP test failed");
 
 #if defined(CONFIG_NET_TCP)
 	ret = net_context_put(tcp_v4_ctx);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Context put IPv4 TCP test failed");
 
 	ret = net_context_put(tcp_v6_ctx);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Context put IPv6 TCP test failed");
 #endif
 }
@@ -978,20 +978,20 @@ static void test_init(void)
 	struct net_if_mcast_addr *maddr;
 	struct net_if *iface = net_if_get_default();
 
-	zassert_not_null(iface, "Interface is NULL");
+	ztest_not_null(iface, "Interface is NULL");
 
 	ifaddr = net_if_ipv6_addr_add(iface, &in6addr_my,
 				      NET_ADDR_MANUAL, 0);
-	zassert_not_null(ifaddr, "Cannot add IPv6 address ");
+	ztest_not_null(ifaddr, "Cannot add IPv6 address ");
 
 	ifaddr = net_if_ipv4_addr_add(iface, &in4addr_my,
 				      NET_ADDR_MANUAL, 0);
-	zassert_not_null(ifaddr, "Cannot add IPv4 address");
+	ztest_not_null(ifaddr, "Cannot add IPv4 address");
 
 	net_ipv6_addr_create(&in6addr_mcast, 0xff02, 0, 0, 0, 0, 0, 0, 0x0001);
 
 	maddr = net_if_ipv6_maddr_add(iface, &in6addr_mcast);
-	zassert_not_null(maddr, "Cannot add multicast IPv6 address");
+	ztest_not_null(maddr, "Cannot add multicast IPv6 address");
 
 	/* The semaphore is there to wait the data to be received. */
 	k_sem_init(&wait_data, 0, UINT_MAX);

--- a/tests/net/dhcpv4/src/main.c
+++ b/tests/net/dhcpv4/src/main.c
@@ -423,14 +423,14 @@ void test_dhcp(void)
 
 	iface = net_if_get_default();
 	if (!iface) {
-		zassert_true(false, "Interface not available");
+		ztest_true(false, "Interface not available");
 	}
 
 	net_dhcpv4_start(iface);
 
 	while (event_count < 3) {
 		if (k_sem_take(&test_lock, WAIT_TIME)) {
-			zassert_true(false, "Timeout while waiting");
+			ztest_true(false, "Timeout while waiting");
 		}
 	}
 }

--- a/tests/net/ethernet_mgmt/src/main.c
+++ b/tests/net/ethernet_mgmt/src/main.c
@@ -316,7 +316,7 @@ static void test_change_mac_when_up(void)
 	ret = net_mgmt(NET_REQUEST_ETHERNET_SET_MAC_ADDRESS, iface,
 		       &params, sizeof(struct ethernet_req_params));
 
-	zassert_not_equal(ret, 0,
+	ztest_not_equal(ret, 0,
 			  "mac address change should not be possible");
 }
 
@@ -333,12 +333,12 @@ static void test_change_mac_when_down(void)
 	ret = net_mgmt(NET_REQUEST_ETHERNET_SET_MAC_ADDRESS, iface,
 		       &params, sizeof(struct ethernet_req_params));
 
-	zassert_equal(ret, 0, "unable to change mac address");
+	ztest_equal(ret, 0, "unable to change mac address");
 
 	ret = memcmp(net_if_get_link_addr(iface)->addr, mac_addr_change,
 		     sizeof(mac_addr_change));
 
-	zassert_equal(ret, 0, "invalid mac address change");
+	ztest_equal(ret, 0, "invalid mac address change");
 
 	net_if_up(iface);
 }
@@ -354,7 +354,7 @@ static void test_change_auto_neg(void)
 	ret = net_mgmt(NET_REQUEST_ETHERNET_SET_AUTO_NEGOTIATION, iface,
 		       &params, sizeof(struct ethernet_req_params));
 
-	zassert_equal(ret, 0, "invalid auto negotiation change");
+	ztest_equal(ret, 0, "invalid auto negotiation change");
 }
 
 static void test_change_to_same_auto_neg(void)
@@ -368,7 +368,7 @@ static void test_change_to_same_auto_neg(void)
 	ret = net_mgmt(NET_REQUEST_ETHERNET_SET_AUTO_NEGOTIATION, iface,
 		       &params, sizeof(struct ethernet_req_params));
 
-	zassert_not_equal(ret, 0,
+	ztest_not_equal(ret, 0,
 			  "invalid change to already auto negotiation");
 }
 
@@ -383,7 +383,7 @@ static void test_change_link(void)
 	ret = net_mgmt(NET_REQUEST_ETHERNET_SET_LINK, iface,
 		       &params, sizeof(struct ethernet_req_params));
 
-	zassert_equal(ret, 0, "invalid link change");
+	ztest_equal(ret, 0, "invalid link change");
 }
 
 static void test_change_same_link(void)
@@ -397,7 +397,7 @@ static void test_change_same_link(void)
 	ret = net_mgmt(NET_REQUEST_ETHERNET_SET_LINK, iface,
 		       &params, sizeof(struct ethernet_req_params));
 
-	zassert_not_equal(ret, 0, "invalid same link change");
+	ztest_not_equal(ret, 0, "invalid same link change");
 }
 
 static void test_change_unsupported_link(void)
@@ -411,7 +411,7 @@ static void test_change_unsupported_link(void)
 	ret = net_mgmt(NET_REQUEST_ETHERNET_SET_LINK, iface,
 		       &params, sizeof(struct ethernet_req_params));
 
-	zassert_not_equal(ret, 0, "invalid change to unsupported link");
+	ztest_not_equal(ret, 0, "invalid change to unsupported link");
 }
 
 static void test_change_duplex(void)
@@ -425,7 +425,7 @@ static void test_change_duplex(void)
 	ret = net_mgmt(NET_REQUEST_ETHERNET_SET_DUPLEX, iface,
 		       &params, sizeof(struct ethernet_req_params));
 
-	zassert_equal(ret, 0, "invalid duplex change");
+	ztest_equal(ret, 0, "invalid duplex change");
 }
 
 static void test_change_same_duplex(void)
@@ -439,7 +439,7 @@ static void test_change_same_duplex(void)
 	ret = net_mgmt(NET_REQUEST_ETHERNET_SET_DUPLEX, iface,
 		       &params, sizeof(struct ethernet_req_params));
 
-	zassert_not_equal(ret, 0, "invalid change to already set duplex");
+	ztest_not_equal(ret, 0, "invalid change to already set duplex");
 }
 
 static void test_change_qav_params(void)
@@ -457,13 +457,13 @@ static void test_change_qav_params(void)
 		       iface,
 		       &params, sizeof(struct ethernet_req_params));
 
-	zassert_equal(ret, 0, "could not get the number of priority queues");
+	ztest_equal(ret, 0, "could not get the number of priority queues");
 
 	available_priority_queues = params.priority_queues_num;
 
-	zassert_not_equal(available_priority_queues, 0,
+	ztest_not_equal(available_priority_queues, 0,
 			  "returned no priority queues");
-	zassert_equal(available_priority_queues,
+	ztest_equal(available_priority_queues,
 		      ARRAY_SIZE(ctx->priority_queues),
 		      "an invalid number of priority queues returned");
 
@@ -478,7 +478,7 @@ static void test_change_qav_params(void)
 			       iface,
 			       &params, sizeof(struct ethernet_req_params));
 
-		zassert_equal(ret, 0, "could not disable qav");
+		ztest_equal(ret, 0, "could not disable qav");
 
 		/* Invert it to make sure the read-back value is proper */
 		params.qav_param.enabled = true;
@@ -487,9 +487,9 @@ static void test_change_qav_params(void)
 			       iface,
 			       &params, sizeof(struct ethernet_req_params));
 
-		zassert_equal(ret, 0, "could not read qav status");
+		ztest_equal(ret, 0, "could not read qav status");
 
-		zassert_equal(false, params.qav_param.enabled,
+		ztest_equal(false, params.qav_param.enabled,
 			      "qav should be disabled");
 
 		/* Re-enable Qav for queue */
@@ -498,7 +498,7 @@ static void test_change_qav_params(void)
 			       iface,
 			       &params, sizeof(struct ethernet_req_params));
 
-		zassert_equal(ret, 0, "could not enable qav");
+		ztest_equal(ret, 0, "could not enable qav");
 
 		/* Invert it to make sure the read-back value is proper */
 		params.qav_param.enabled = false;
@@ -507,9 +507,9 @@ static void test_change_qav_params(void)
 			       iface,
 			       &params, sizeof(struct ethernet_req_params));
 
-		zassert_equal(ret, 0, "could not read qav status");
+		ztest_equal(ret, 0, "could not read qav status");
 
-		zassert_equal(true, params.qav_param.enabled,
+		ztest_equal(true, params.qav_param.enabled,
 			      "qav should be enabled");
 
 		/* Starting with delta bandwidth */
@@ -520,7 +520,7 @@ static void test_change_qav_params(void)
 			       iface,
 			       &params, sizeof(struct ethernet_req_params));
 
-		zassert_equal(ret, 0, "could not set delta bandwidth");
+		ztest_equal(ret, 0, "could not set delta bandwidth");
 
 		/* Reset local value - read-back and verify it */
 		params.qav_param.delta_bandwidth = 0U;
@@ -528,8 +528,8 @@ static void test_change_qav_params(void)
 			       iface,
 			       &params, sizeof(struct ethernet_req_params));
 
-		zassert_equal(ret, 0, "could not read delta bandwidth");
-		zassert_equal(params.qav_param.delta_bandwidth, 10,
+		ztest_equal(ret, 0, "could not read delta bandwidth");
+		ztest_equal(params.qav_param.delta_bandwidth, 10,
 			      "delta bandwidth did not change");
 
 		/* And them the idle slope */
@@ -539,7 +539,7 @@ static void test_change_qav_params(void)
 			       iface,
 			       &params, sizeof(struct ethernet_req_params));
 
-		zassert_equal(ret, 0, "could not set idle slope");
+		ztest_equal(ret, 0, "could not set idle slope");
 
 		/* Reset local value - read-back and verify it */
 		params.qav_param.idle_slope = 0U;
@@ -547,8 +547,8 @@ static void test_change_qav_params(void)
 			       iface,
 			       &params, sizeof(struct ethernet_req_params));
 
-		zassert_equal(ret, 0, "could not read idle slope");
-		zassert_equal(params.qav_param.idle_slope, 10,
+		ztest_equal(ret, 0, "could not read idle slope");
+		ztest_equal(params.qav_param.idle_slope, 10,
 			      "idle slope did not change");
 
 		/* Oper idle slope should also be the same */
@@ -558,8 +558,8 @@ static void test_change_qav_params(void)
 			       iface,
 			       &params, sizeof(struct ethernet_req_params));
 
-		zassert_equal(ret, 0, "could not read oper idle slope");
-		zassert_equal(params.qav_param.oper_idle_slope, 10,
+		ztest_equal(ret, 0, "could not read oper idle slope");
+		ztest_equal(params.qav_param.oper_idle_slope, 10,
 			      "oper idle slope should equal admin idle slope");
 
 		/* Now try to set incorrect params to a correct queue */
@@ -570,7 +570,7 @@ static void test_change_qav_params(void)
 			       iface,
 			       &params, sizeof(struct ethernet_req_params));
 
-		zassert_not_equal(ret, 0,
+		ztest_not_equal(ret, 0,
 				  "allowed to set invalid delta bandwidth");
 
 		params.qav_param.delta_bandwidth = 101U;
@@ -578,7 +578,7 @@ static void test_change_qav_params(void)
 			       iface,
 			       &params, sizeof(struct ethernet_req_params));
 
-		zassert_not_equal(ret, 0,
+		ztest_not_equal(ret, 0,
 				  "allowed to set invalid delta bandwidth");
 	}
 
@@ -589,7 +589,7 @@ static void test_change_qav_params(void)
 		       iface,
 		       &params, sizeof(struct ethernet_req_params));
 
-	zassert_not_equal(ret, 0, "should not be able to set oper idle slope");
+	ztest_not_equal(ret, 0, "should not be able to set oper idle slope");
 
 	params.qav_param.queue_id = 0;
 	params.qav_param.type = ETHERNET_QAV_PARAM_TYPE_TRAFFIC_CLASS;
@@ -597,7 +597,7 @@ static void test_change_qav_params(void)
 		       iface,
 		       &params, sizeof(struct ethernet_req_params));
 
-	zassert_not_equal(ret, 0, "should not be able to set traffic class");
+	ztest_not_equal(ret, 0, "should not be able to set traffic class");
 
 	/* Now try to set valid parameters to an invalid queue id */
 	params.qav_param.type = ETHERNET_QAV_PARAM_TYPE_DELTA_BANDWIDTH;
@@ -607,7 +607,7 @@ static void test_change_qav_params(void)
 		       iface,
 		       &params, sizeof(struct ethernet_req_params));
 
-	zassert_not_equal(ret, 0, "should not be able to set delta bandwidth");
+	ztest_not_equal(ret, 0, "should not be able to set delta bandwidth");
 
 	params.qav_param.type = ETHERNET_QAV_PARAM_TYPE_IDLE_SLOPE;
 	params.qav_param.idle_slope = 10U;
@@ -615,7 +615,7 @@ static void test_change_qav_params(void)
 		       iface,
 		       &params, sizeof(struct ethernet_req_params));
 
-	zassert_not_equal(ret, 0, "should not be able to set idle slope");
+	ztest_not_equal(ret, 0, "should not be able to set idle slope");
 }
 
 static void test_change_promisc_mode(bool mode)
@@ -629,7 +629,7 @@ static void test_change_promisc_mode(bool mode)
 	ret = net_mgmt(NET_REQUEST_ETHERNET_SET_PROMISC_MODE, iface,
 		       &params, sizeof(struct ethernet_req_params));
 
-	zassert_equal(ret, 0, "invalid promisc mode change");
+	ztest_equal(ret, 0, "invalid promisc mode change");
 }
 
 static void test_change_promisc_mode_on(void)
@@ -653,7 +653,7 @@ static void test_change_to_same_promisc_mode(void)
 	ret = net_mgmt(NET_REQUEST_ETHERNET_SET_PROMISC_MODE, iface,
 		       &params, sizeof(struct ethernet_req_params));
 
-	zassert_equal(ret, -EALREADY,
+	ztest_equal(ret, -EALREADY,
 		      "invalid change to already set promisc mode");
 }
 

--- a/tests/net/hostname/src/main.c
+++ b/tests/net/hostname/src/main.c
@@ -232,14 +232,14 @@ static void iface_setup(void)
 	DBG("Interfaces: [%d] iface1 %p\n",
 	    net_if_get_by_iface(iface1), iface1);
 
-	zassert_not_null(iface1, "Interface 1");
+	ztest_not_null(iface1, "Interface 1");
 
 	ifaddr = net_if_ipv6_addr_add(iface1, &my_addr1,
 				      NET_ADDR_MANUAL, 0);
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr1));
-		zassert_not_null(ifaddr, "addr1");
+		ztest_not_null(ifaddr, "addr1");
 	}
 
 	ifaddr = net_if_ipv4_addr_add(iface1, &my_ipv4_addr1,
@@ -247,7 +247,7 @@ static void iface_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv4 address %s\n",
 		       net_sprint_ipv4_addr(&my_ipv4_addr1));
-		zassert_not_null(ifaddr, "ipv4 addr1");
+		ztest_not_null(ifaddr, "ipv4 addr1");
 	}
 
 	/* For testing purposes we need to set the adddresses preferred */
@@ -258,7 +258,7 @@ static void iface_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&ll_addr));
-		zassert_not_null(ifaddr, "ll_addr");
+		ztest_not_null(ifaddr, "ll_addr");
 	}
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
@@ -269,7 +269,7 @@ static void iface_setup(void)
 	if (!maddr) {
 		DBG("Cannot add multicast IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&in6addr_mcast));
-		zassert_not_null(maddr, "mcast");
+		ztest_not_null(maddr, "mcast");
 	}
 
 	net_if_up(iface1);
@@ -318,7 +318,7 @@ static void hostname_get(void)
 
 	hostname = net_hostname_get();
 
-	zassert_mem_equal(hostname, config_hostname,
+	ztest_mem_equal(hostname, config_hostname,
 			  sizeof(CONFIG_NET_HOSTNAME) - 1, "");
 
 	if (IS_ENABLED(CONFIG_NET_HOSTNAME_UNIQUE)) {
@@ -327,9 +327,9 @@ static void hostname_get(void)
 
 		ret = bytes_from_hostname_unique(mac, sizeof(mac),
 				 hostname + sizeof(CONFIG_NET_HOSTNAME) - 1);
-		zassert_equal(ret, 0, "");
+		ztest_equal(ret, 0, "");
 
-		zassert_mem_equal(mac, net_if_get_link_addr(iface1)->addr,
+		ztest_mem_equal(mac, net_if_get_link_addr(iface1)->addr,
 				  net_if_get_link_addr(iface1)->len, "");
 	}
 }
@@ -340,7 +340,7 @@ static void hostname_set(void)
 		int ret;
 
 		ret = net_hostname_set_postfix("foobar", sizeof("foobar") - 1);
-		zassert_equal(ret, -EALREADY,
+		ztest_equal(ret, -EALREADY,
 			      "Could set hostname postfix (%d)", ret);
 	}
 }

--- a/tests/net/icmpv4/src/main.c
+++ b/tests/net/icmpv4/src/main.c
@@ -182,40 +182,40 @@ static int verify_echo_reply(struct net_pkt *pkt)
 
 	ret = net_pkt_skip(pkt, NET_IPV4H_LEN);
 	if (ret != 0) {
-		zassert_true(false, "echo_reply skip failed");
+		ztest_true(false, "echo_reply skip failed");
 	}
 
 	/* EchoReply Code and Type is 0 */
 	ret = net_pkt_read(pkt, &icmp_hdr, sizeof(struct net_icmp_hdr));
 	if (ret != 0) {
-		zassert_true(false, "echo_reply read failed");
+		ztest_true(false, "echo_reply read failed");
 	}
 
 	if (icmp_hdr.code != 0 || icmp_hdr.type != 0) {
-		zassert_true(false, "echo_reply invalid type or code");
+		ztest_true(false, "echo_reply invalid type or code");
 	}
 
 	/* Calculate payload length */
 	payload_len = sizeof(icmpv4_echo_req) -
 		      NET_IPV4H_LEN - NET_ICMPH_LEN;
 	if (payload_len != net_pkt_remaining_data(pkt)) {
-		zassert_true(false, "echo_reply invalid payload len");
+		ztest_true(false, "echo_reply invalid payload len");
 	}
 
 	ret = net_pkt_read(pkt, buf, payload_len);
 	if (ret != 0) {
-		zassert_true(false, "echo_reply read payload failed");
+		ztest_true(false, "echo_reply read payload failed");
 	}
 
 	/* Compare the payload */
 	if (memcmp(buf, icmpv4_echo_req + NET_IPV4H_LEN + NET_ICMPH_LEN,
 		   payload_len)) {
-		zassert_true(false, "echo_reply invalid payload");
+		ztest_true(false, "echo_reply invalid payload");
 	}
 
 	/* Options length should be zero */
 	if (net_pkt_ipv4_opts_len(pkt)) {
-		zassert_true(false, "echo_reply invalid opts len");
+		ztest_true(false, "echo_reply invalid opts len");
 	}
 
 	return 0;
@@ -235,52 +235,52 @@ static int verify_echo_reply_with_opts(struct net_pkt *pkt)
 
 	ret = net_pkt_read_u8(pkt, &vhl);
 	if (ret != 0) {
-		zassert_true(false, "echo_reply_opts read failed");
+		ztest_true(false, "echo_reply_opts read failed");
 	}
 
 	vhl = (vhl & NET_IPV4_IHL_MASK) * 4U;
 	opts_len = vhl - sizeof(struct net_ipv4_hdr);
 	if (opts_len == 0) {
-		zassert_true(false, "echo_reply_opts wrong opts len");
+		ztest_true(false, "echo_reply_opts wrong opts len");
 	}
 
 	ret = net_pkt_skip(pkt, NET_IPV4H_LEN - 1U + opts_len);
 	if (ret != 0) {
-		zassert_true(false, "echo_reply_opts skip failed");
+		ztest_true(false, "echo_reply_opts skip failed");
 	}
 
 	/* EchoReply Code and Type is 0 */
 	ret = net_pkt_read(pkt, &icmp_hdr, sizeof(struct net_icmp_hdr));
 	if (ret != 0) {
-		zassert_true(false, "echo_reply_opts read failed");
+		ztest_true(false, "echo_reply_opts read failed");
 	}
 
 	if (icmp_hdr.code != 0 || icmp_hdr.type != 0) {
-		zassert_true(false, "echo_reply_opts wrong code and type");
+		ztest_true(false, "echo_reply_opts wrong code and type");
 	}
 
 	/* Calculate payload length */
 	payload_len = sizeof(icmpv4_echo_req_opt) -
 		      NET_IPV4H_LEN - NET_ICMPH_LEN - opts_len;
 	if (payload_len != net_pkt_remaining_data(pkt)) {
-		zassert_true(false, "echo_reply_opts invalid paylaod len");
+		ztest_true(false, "echo_reply_opts invalid paylaod len");
 	}
 
 	ret = net_pkt_read(pkt, buf, payload_len);
 	if (ret != 0) {
-		zassert_true(false, "echo_reply_opts read payload failed");
+		ztest_true(false, "echo_reply_opts read payload failed");
 	}
 
 	/* Compare the payload */
 	if (memcmp(buf, icmpv4_echo_req_opt +
 		   NET_IPV4H_LEN + NET_ICMPH_LEN + opts_len,
 		   payload_len)) {
-		zassert_true(false, "echo_reply_opts invalid payload");
+		ztest_true(false, "echo_reply_opts invalid payload");
 	}
 
 	/* Options length should not be zero */
 	if (net_pkt_ipv4_opts_len(pkt) != opts_len) {
-		zassert_true(false, "echo_reply_opts wrong opts len");
+		ztest_true(false, "echo_reply_opts wrong opts len");
 	}
 
 	return 0;
@@ -419,12 +419,12 @@ static void test_icmpv4(void)
 
 	iface = net_if_get_default();
 	if (!iface) {
-		zassert_true(false, "Interface not available");
+		ztest_true(false, "Interface not available");
 	}
 
 	ifaddr = net_if_ipv4_addr_add(iface, &my_addr, NET_ADDR_MANUAL, 0);
 	if (!ifaddr) {
-		zassert_true(false, "Failed to add address");
+		ztest_true(false, "Failed to add address");
 	}
 }
 
@@ -436,12 +436,12 @@ static void test_icmpv4_send_echo_req(void)
 
 	pkt = prepare_echo_request(iface);
 	if (!pkt) {
-		zassert_true(false, "EchoRequest packet prep failed");
+		ztest_true(false, "EchoRequest packet prep failed");
 	}
 
 	if (net_ipv4_input(pkt)) {
 		net_pkt_unref(pkt);
-		zassert_true(false, "Failed to send");
+		ztest_true(false, "Failed to send");
 	}
 }
 
@@ -453,12 +453,12 @@ static void test_icmpv4_send_echo_rep(void)
 
 	pkt = prepare_echo_reply(iface);
 	if (!pkt) {
-		zassert_true(false, "EchoReply packet prep failed");
+		ztest_true(false, "EchoReply packet prep failed");
 	}
 
 	if (net_ipv4_input(pkt)) {
 		net_pkt_unref(pkt);
-		zassert_true(false, "Failed to send");
+		ztest_true(false, "Failed to send");
 	}
 
 	net_icmpv4_unregister_handler(&echo_rep_handler);
@@ -472,12 +472,12 @@ static void test_icmpv4_send_echo_req_opt(void)
 
 	pkt = prepare_echo_request_with_options(iface);
 	if (!pkt) {
-		zassert_true(false, "EchoRequest with opts packet prep failed");
+		ztest_true(false, "EchoRequest with opts packet prep failed");
 	}
 
 	if (net_ipv4_input(pkt)) {
 		net_pkt_unref(pkt);
-		zassert_true(false, "Failed to send");
+		ztest_true(false, "Failed to send");
 	}
 }
 
@@ -487,13 +487,13 @@ static void test_icmpv4_send_echo_req_bad_opt(void)
 
 	pkt = prepare_echo_request_with_bad_options(iface);
 	if (!pkt) {
-		zassert_true(false,
+		ztest_true(false,
 			     "EchoRequest with bad opts packet prep failed");
 	}
 
 	if (!net_ipv4_input(pkt)) {
 		net_pkt_unref(pkt);
-		zassert_true(false, "Failed to send");
+		ztest_true(false, "Failed to send");
 	}
 }
 

--- a/tests/net/icmpv6/src/main.c
+++ b/tests/net/icmpv6/src/main.c
@@ -102,7 +102,7 @@ void test_icmpv6(void)
 
 	pkt = net_pkt_alloc_with_buffer(NULL, ICMPV6_MSG_SIZE,
 					AF_UNSPEC, 0, K_SECONDS(1));
-	zassert_not_null(pkt, "Allocation failed");
+	ztest_not_null(pkt, "Allocation failed");
 
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv6_hdr));
 
@@ -116,7 +116,7 @@ void test_icmpv6(void)
 	ret = net_icmpv6_input(pkt, hdr);
 
 	/**TESTPOINT: Check input*/
-	zassert_true(ret == NET_DROP, "Callback not called properly");
+	ztest_true(ret == NET_DROP, "Callback not called properly");
 
 	handler_status = -1;
 
@@ -134,7 +134,7 @@ void test_icmpv6(void)
 	ret = net_icmpv6_input(pkt, hdr);
 
 	/**TESTPOINT: Check input*/
-	zassert_true(!(ret == NET_DROP || handler_status != 0),
+	ztest_true(!(ret == NET_DROP || handler_status != 0),
 		     "Callback not called properly");
 
 	handler_status = -1;
@@ -153,11 +153,11 @@ void test_icmpv6(void)
 	ret = net_icmpv6_input(pkt, hdr);
 
 	/**TESTPOINT: Check input*/
-	zassert_true(!(ret == NET_DROP || handler_status != 0),
+	ztest_true(!(ret == NET_DROP || handler_status != 0),
 			"Callback not called properly");
 
 	/**TESTPOINT: Check input*/
-	zassert_true(!(handler_called != 2), "Callbacks not called properly");
+	ztest_true(!(handler_called != 2), "Callbacks not called properly");
 }
 
 /**test case main entry*/

--- a/tests/net/ieee802154/fragment/src/main.c
+++ b/tests/net/ieee802154/fragment/src/main.c
@@ -578,56 +578,56 @@ static void test_fragment_sam00_dam00(void)
 {
 	bool ret = test_fragment(&test_data_1);
 
-	zassert_true(ret, NULL);
+	ztest_true(ret, NULL);
 }
 
 static void test_fragment_sam01_dam01(void)
 {
 	bool ret = test_fragment(&test_data_2);
 
-	zassert_true(ret, NULL);
+	ztest_true(ret, NULL);
 }
 
 static void test_fragment_sam10_dam10(void)
 {
 	bool ret = test_fragment(&test_data_3);
 
-	zassert_true(ret, NULL);
+	ztest_true(ret, NULL);
 }
 
 static void test_fragment_sam00_m1_dam00(void)
 {
 	bool ret = test_fragment(&test_data_4);
 
-	zassert_true(ret, NULL);
+	ztest_true(ret, NULL);
 }
 
 static void test_fragment_sam01_m1_dam01(void)
 {
 	bool ret = test_fragment(&test_data_5);
 
-	zassert_true(ret, NULL);
+	ztest_true(ret, NULL);
 }
 
 static void test_fragment_sam10_m1_dam10(void)
 {
 	bool ret = test_fragment(&test_data_6);
 
-	zassert_true(ret, NULL);
+	ztest_true(ret, NULL);
 }
 
 static void test_fragment_ipv6_dispatch_small(void)
 {
 	bool ret = test_fragment(&test_data_7);
 
-	zassert_true(ret, NULL);
+	ztest_true(ret, NULL);
 }
 
 static void test_fragment_ipv6_dispatch_big(void)
 {
 	bool ret = test_fragment(&test_data_8);
 
-	zassert_true(ret, NULL);
+	ztest_true(ret, NULL);
 }
 
 

--- a/tests/net/ieee802154/l2/src/ieee802154_test.c
+++ b/tests/net/ieee802154/l2/src/ieee802154_test.c
@@ -298,7 +298,7 @@ static void test_init(void)
 
 	ret = initialize_test_environment();
 
-	zassert_true(ret, "Test initialization");
+	ztest_true(ret, "Test initialization");
 }
 
 
@@ -308,7 +308,7 @@ static void test_parsing_ns_pkt(void)
 
 	ret = test_packet_parsing(&test_ns_pkt);
 
-	zassert_true(ret, "NS parsed");
+	ztest_true(ret, "NS parsed");
 }
 
 static void test_sending_ns_pkt(void)
@@ -317,7 +317,7 @@ static void test_sending_ns_pkt(void)
 
 	ret = test_ns_sending(&test_ns_pkt);
 
-	zassert_true(ret, "NS sent");
+	ztest_true(ret, "NS sent");
 }
 
 static void test_parsing_ack_pkt(void)
@@ -326,7 +326,7 @@ static void test_parsing_ack_pkt(void)
 
 	ret = test_packet_parsing(&test_ack_pkt);
 
-	zassert_true(ret, "ACK parsed");
+	ztest_true(ret, "ACK parsed");
 }
 
 static void test_replying_ack_pkt(void)
@@ -335,7 +335,7 @@ static void test_replying_ack_pkt(void)
 
 	ret = test_ack_reply(&test_ack_pkt);
 
-	zassert_true(ret, "ACK replied");
+	ztest_true(ret, "ACK replied");
 }
 
 static void test_parsing_beacon_pkt(void)
@@ -344,7 +344,7 @@ static void test_parsing_beacon_pkt(void)
 
 	ret = test_packet_parsing(&test_beacon_pkt);
 
-	zassert_true(ret, "Beacon parsed");
+	ztest_true(ret, "Beacon parsed");
 }
 
 static void test_parsing_sec_data_pkt(void)
@@ -353,7 +353,7 @@ static void test_parsing_sec_data_pkt(void)
 
 	ret = test_packet_parsing(&test_sec_data_pkt);
 
-	zassert_true(ret, "Secured data frame parsed");
+	ztest_true(ret, "Secured data frame parsed");
 }
 
 void test_main(void)

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -339,16 +339,16 @@ static void iface_setup(void)
 	    net_if_get_by_iface(iface2), iface2,
 	    net_if_get_by_iface(iface3), iface3);
 
-	zassert_not_null(iface1, "Interface 1");
-	zassert_not_null(iface2, "Interface 2");
-	zassert_not_null(iface3, "Interface 3");
+	ztest_not_null(iface1, "Interface 1");
+	ztest_not_null(iface2, "Interface 2");
+	ztest_not_null(iface3, "Interface 3");
 
 	ifaddr = net_if_ipv6_addr_add(iface1, &my_addr1,
 				      NET_ADDR_MANUAL, 0);
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr1));
-		zassert_not_null(ifaddr, "addr1");
+		ztest_not_null(ifaddr, "addr1");
 	}
 
 	ifaddr = net_if_ipv4_addr_add(iface1, &my_ipv4_addr1,
@@ -356,7 +356,7 @@ static void iface_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv4 address %s\n",
 		       net_sprint_ipv4_addr(&my_ipv4_addr1));
-		zassert_not_null(ifaddr, "ipv4 addr1");
+		ztest_not_null(ifaddr, "ipv4 addr1");
 	}
 
 	/* For testing purposes we need to set the adddresses preferred */
@@ -367,7 +367,7 @@ static void iface_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&ll_addr));
-		zassert_not_null(ifaddr, "ll_addr");
+		ztest_not_null(ifaddr, "ll_addr");
 	}
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
@@ -377,7 +377,7 @@ static void iface_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr2));
-		zassert_not_null(ifaddr, "addr2");
+		ztest_not_null(ifaddr, "addr2");
 	}
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
@@ -387,7 +387,7 @@ static void iface_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr3));
-		zassert_not_null(ifaddr, "addr3");
+		ztest_not_null(ifaddr, "addr3");
 	}
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
@@ -398,7 +398,7 @@ static void iface_setup(void)
 	if (!maddr) {
 		DBG("Cannot add multicast IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&in6addr_mcast));
-		zassert_not_null(maddr, "mcast");
+		ztest_not_null(maddr, "mcast");
 	}
 
 	net_if_up(iface1);
@@ -453,7 +453,7 @@ static void send_iface1(void)
 
 	ret = send_iface(iface1, 1, false);
 
-	zassert_true(ret, "iface 1");
+	ztest_true(ret, "iface 1");
 }
 
 static void send_iface2(void)
@@ -464,7 +464,7 @@ static void send_iface2(void)
 
 	ret = send_iface(iface2, 2, false);
 
-	zassert_true(ret, "iface 2");
+	ztest_true(ret, "iface 2");
 }
 
 static void send_iface3(void)
@@ -475,7 +475,7 @@ static void send_iface3(void)
 
 	ret = send_iface(iface3, 3, false);
 
-	zassert_true(ret, "iface 3");
+	ztest_true(ret, "iface 3");
 }
 
 static void send_iface1_down(void)
@@ -488,7 +488,7 @@ static void send_iface1_down(void)
 
 	ret = send_iface(iface1, 1, true);
 
-	zassert_true(ret, "iface 1 down");
+	ztest_true(ret, "iface 1 down");
 }
 
 static void send_iface1_up(void)
@@ -501,7 +501,7 @@ static void send_iface1_up(void)
 
 	ret = send_iface(iface1, 1, false);
 
-	zassert_true(ret, "iface 1 up again");
+	ztest_true(ret, "iface 1 up again");
 }
 
 static void select_src_iface(void)
@@ -522,31 +522,31 @@ static void select_src_iface(void)
 	struct sockaddr_in6 ipv6;
 
 	iface = net_if_ipv6_select_src_iface(&dst_addr1);
-	zassert_equal_ptr(iface, iface1, "Invalid interface %p vs %p selected",
+	ztest_equal_ptr(iface, iface1, "Invalid interface %p vs %p selected",
 			  iface, iface1);
 
 	iface = net_if_ipv6_select_src_iface(&ll_addr1);
-	zassert_equal_ptr(iface, iface1, "Invalid interface %p vs %p selected",
+	ztest_equal_ptr(iface, iface1, "Invalid interface %p vs %p selected",
 			  iface, iface1);
 
 	net_ipv6_addr_create(&in6addr_mcast1, 0xff02, 0, 0, 0, 0, 0, 0, 0x0002);
 
 	iface = net_if_ipv6_select_src_iface(&in6addr_mcast1);
-	zassert_equal_ptr(iface, iface1, "Invalid interface %p vs %p selected",
+	ztest_equal_ptr(iface, iface1, "Invalid interface %p vs %p selected",
 			  iface, iface1);
 
 	iface = net_if_ipv6_select_src_iface(&dst_addr3);
-	zassert_equal_ptr(iface, iface2, "Invalid interface %p vs %p selected",
+	ztest_equal_ptr(iface, iface2, "Invalid interface %p vs %p selected",
 			  iface, iface2);
 
 	ifaddr = net_if_ipv6_addr_lookup(&ll_addr, NULL);
-	zassert_not_null(ifaddr, "No such ll_addr found");
+	ztest_not_null(ifaddr, "No such ll_addr found");
 
 	ifaddr->addr_state = NET_ADDR_TENTATIVE;
 
 	/* We should now get default interface */
 	iface = net_if_ipv6_select_src_iface(&ll_addr1);
-	zassert_equal_ptr(iface, net_if_get_default(),
+	ztest_equal_ptr(iface, net_if_get_default(),
 			  "Invalid interface %p vs %p selected",
 			  iface, net_if_get_default());
 
@@ -555,7 +555,7 @@ static void select_src_iface(void)
 	ipv4.sin_port = 0U;
 
 	iface = net_if_select_src_iface((struct sockaddr *)&ipv4);
-	zassert_equal_ptr(iface, iface1, "Invalid interface %p vs %p selected",
+	ztest_equal_ptr(iface, iface1, "Invalid interface %p vs %p selected",
 			  iface, iface1);
 
 	net_ipaddr_copy(&ipv6.sin6_addr, &dst_addr1);
@@ -563,7 +563,7 @@ static void select_src_iface(void)
 	ipv6.sin6_port = 0U;
 
 	iface = net_if_select_src_iface((struct sockaddr *)&ipv6);
-	zassert_equal_ptr(iface, iface1, "Invalid interface %p vs %p selected",
+	ztest_equal_ptr(iface, iface1, "Invalid interface %p vs %p selected",
 			  iface, iface1);
 }
 
@@ -575,7 +575,7 @@ static void check_promisc_mode_off(void)
 
 	ret = net_if_is_promisc(iface4);
 
-	zassert_false(ret, "iface 1 promiscuous mode ON");
+	ztest_false(ret, "iface 1 promiscuous mode ON");
 }
 
 static void check_promisc_mode_on(void)
@@ -586,7 +586,7 @@ static void check_promisc_mode_on(void)
 
 	ret = net_if_is_promisc(iface4);
 
-	zassert_true(ret, "iface 1 promiscuous mode OFF");
+	ztest_true(ret, "iface 1 promiscuous mode OFF");
 }
 
 static void set_promisc_mode_on_again(void)
@@ -597,7 +597,7 @@ static void set_promisc_mode_on_again(void)
 
 	ret = net_if_set_promisc(iface4);
 
-	zassert_equal(ret, -EALREADY, "iface 1 promiscuous mode OFF");
+	ztest_equal(ret, -EALREADY, "iface 1 promiscuous mode OFF");
 }
 
 static void set_promisc_mode_on(void)
@@ -608,7 +608,7 @@ static void set_promisc_mode_on(void)
 
 	ret = net_if_set_promisc(iface4);
 
-	zassert_equal(ret, 0, "iface 1 promiscuous mode set failed");
+	ztest_equal(ret, 0, "iface 1 promiscuous mode set failed");
 }
 
 static void set_promisc_mode_off(void)
@@ -627,7 +627,7 @@ static void v4_addr_add(void)
 
 	ret = net_if_ipv4_addr_add_by_index(1, &my_ipv4_addr_test,
 					    NET_ADDR_MANUAL, 0);
-	zassert_true(ret, "Cannot add IPv4 address");
+	ztest_true(ret, "Cannot add IPv4 address");
 }
 
 static void v4_addr_lookup(void)
@@ -635,10 +635,10 @@ static void v4_addr_lookup(void)
 	int ret;
 
 	ret = net_if_ipv4_addr_lookup_by_index(&my_ipv4_addr_test);
-	zassert_equal(ret, 1, "IPv4 address not found");
+	ztest_equal(ret, 1, "IPv4 address not found");
 
 	ret = net_if_ipv4_addr_lookup_by_index(&my_ipv4_addr_not_found);
-	zassert_not_equal(ret, 1, "IPv4 address found");
+	ztest_not_equal(ret, 1, "IPv4 address found");
 }
 
 static void v4_addr_rm(void)
@@ -646,7 +646,7 @@ static void v4_addr_rm(void)
 	bool ret;
 
 	ret = net_if_ipv4_addr_rm_by_index(1, &my_ipv4_addr_test);
-	zassert_true(ret, "Cannot remove IPv4 address");
+	ztest_true(ret, "Cannot remove IPv4 address");
 }
 
 #define MY_ADDR_V4_USER      { { { 10, 0, 0, 2 } } }
@@ -659,11 +659,11 @@ static void v4_addr_add_user(void)
 
 	ret = net_if_ipv4_addr_add_by_index(1, &my_addr, NET_ADDR_MANUAL, 0);
 	if (IS_ENABLED(CONFIG_NET_IF_USERSPACE_ACCESS)) {
-		zassert_true(ret, "Cannot add IPv4 address");
+		ztest_true(ret, "Cannot add IPv4 address");
 	} else if (IS_ENABLED(CONFIG_USERSPACE)) {
-		zassert_false(ret, "Could add IPv4 address");
+		ztest_false(ret, "Could add IPv4 address");
 	} else {
-		zassert_true(ret, "Cannot add IPv4 address");
+		ztest_true(ret, "Cannot add IPv4 address");
 	}
 }
 
@@ -675,11 +675,11 @@ static void v4_addr_lookup_user(void)
 
 	if (IS_ENABLED(CONFIG_NET_IF_USERSPACE_ACCESS)) {
 		ret = net_if_ipv4_addr_lookup_by_index(&my_addr);
-		zassert_equal(ret, 1, "IPv4 address not found (%d)", ret);
+		ztest_equal(ret, 1, "IPv4 address not found (%d)", ret);
 	}
 
 	ret = net_if_ipv4_addr_lookup_by_index(&unknown_addr);
-	zassert_equal(ret, 0, "IPv4 address found");
+	ztest_equal(ret, 0, "IPv4 address found");
 }
 
 static void v4_addr_rm_user(void)
@@ -689,7 +689,7 @@ static void v4_addr_rm_user(void)
 
 	if (IS_ENABLED(CONFIG_NET_IF_USERSPACE_ACCESS)) {
 		ret = net_if_ipv4_addr_rm_by_index(1, &my_addr);
-		zassert_true(ret, "Cannot remove IPv4 address");
+		ztest_true(ret, "Cannot remove IPv4 address");
 	}
 }
 
@@ -707,7 +707,7 @@ static void v6_addr_add(void)
 
 	ret = net_if_ipv6_addr_add_by_index(1, &my_ipv6_addr_test,
 					    NET_ADDR_MANUAL, 0);
-	zassert_true(ret, "Cannot add IPv6 address");
+	ztest_true(ret, "Cannot add IPv6 address");
 }
 
 static void v6_addr_lookup(void)
@@ -715,10 +715,10 @@ static void v6_addr_lookup(void)
 	int ret;
 
 	ret = net_if_ipv6_addr_lookup_by_index(&my_ipv6_addr_test);
-	zassert_equal(ret, 1, "IPv6 address not found");
+	ztest_equal(ret, 1, "IPv6 address not found");
 
 	ret = net_if_ipv6_addr_lookup_by_index(&my_ipv6_addr_not_found);
-	zassert_not_equal(ret, 1, "IPv6 address found");
+	ztest_not_equal(ret, 1, "IPv6 address found");
 }
 
 static void v6_addr_rm(void)
@@ -726,7 +726,7 @@ static void v6_addr_rm(void)
 	bool ret;
 
 	ret = net_if_ipv6_addr_rm_by_index(1, &my_ipv6_addr_test);
-	zassert_true(ret, "Cannot remove IPv6 address");
+	ztest_true(ret, "Cannot remove IPv6 address");
 }
 
 #define MY_ADDR_V6_USER { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, \
@@ -742,11 +742,11 @@ static void v6_addr_add_user(void)
 
 	ret = net_if_ipv6_addr_add_by_index(1, &my_addr, NET_ADDR_MANUAL, 0);
 	if (IS_ENABLED(CONFIG_NET_IF_USERSPACE_ACCESS)) {
-		zassert_true(ret, "Cannot add IPv6 address");
+		ztest_true(ret, "Cannot add IPv6 address");
 	} else if (IS_ENABLED(CONFIG_USERSPACE)) {
-		zassert_false(ret, "Could add IPv6 address");
+		ztest_false(ret, "Could add IPv6 address");
 	} else {
-		zassert_true(ret, "Cannot add IPv6 address");
+		ztest_true(ret, "Cannot add IPv6 address");
 	}
 }
 
@@ -758,10 +758,10 @@ static void v6_addr_lookup_user(void)
 
 	if (IS_ENABLED(CONFIG_NET_IF_USERSPACE_ACCESS)) {
 		ret = net_if_ipv6_addr_lookup_by_index(&my_addr);
-		zassert_equal(ret, 1, "IPv6 address not found (%d)", ret);
+		ztest_equal(ret, 1, "IPv6 address not found (%d)", ret);
 
 		ret = net_if_ipv6_addr_lookup_by_index(&unknown_addr);
-		zassert_equal(ret, 0, "IPv6 address found");
+		ztest_equal(ret, 0, "IPv6 address found");
 	}
 }
 
@@ -775,7 +775,7 @@ static void v6_addr_rm_user(void)
 	 */
 	if (IS_ENABLED(CONFIG_NET_IF_USERSPACE_ACCESS)) {
 		ret = net_if_ipv6_addr_rm_by_index(1, &my_addr);
-		zassert_true(ret, "Cannot remove IPv6 address");
+		ztest_true(ret, "Cannot remove IPv6 address");
 	}
 }
 
@@ -786,7 +786,7 @@ static void netmask_addr_add(void)
 
 	if (IS_ENABLED(CONFIG_NET_IF_USERSPACE_ACCESS)) {
 		ret = net_if_ipv4_set_netmask_by_index(1, &my_netmask);
-		zassert_true(ret, "Cannot add IPv4 netmask");
+		ztest_true(ret, "Cannot add IPv4 netmask");
 	}
 }
 
@@ -797,7 +797,7 @@ static void gw_addr_add(void)
 
 	if (IS_ENABLED(CONFIG_NET_IF_USERSPACE_ACCESS)) {
 		ret = net_if_ipv4_set_gw_by_index(1, &my_gw);
-		zassert_true(ret, "Cannot add IPv4 gateway");
+		ztest_true(ret, "Cannot add IPv4 gateway");
 	}
 }
 

--- a/tests/net/ip-addr/src/main.c
+++ b/tests/net/ip-addr/src/main.c
@@ -37,7 +37,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 	do {							 \
 		char out[3];					 \
 		net_byte_to_hex(out, value, 'A', true);		 \
-		zassert_false(strcmp(out, expected),		 \
+		ztest_false(strcmp(out, expected),		 \
 			      "Test 0x%s failed.\n", expected);	 \
 	} while (0)
 
@@ -45,14 +45,14 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 	do {							 \
 		char out[3];					 \
 		net_byte_to_hex(out, value, 'a', true);		 \
-		zassert_false(strcmp(out, expected),		 \
+		ztest_false(strcmp(out, expected),		 \
 			      "Test 0x%s failed.\n", expected);	 \
 	} while (0)
 
 #define TEST_LL_6(a, b, c, d, e, f, expected)				\
 	do {								\
 		u8_t ll[] = { a, b, c, d, e, f };			\
-		zassert_false(strcmp(net_sprint_ll_addr(ll, sizeof(ll)),\
+		ztest_false(strcmp(net_sprint_ll_addr(ll, sizeof(ll)),\
 				     expected),				\
 			      "Test %s failed.\n", expected);		\
 	} while (0)
@@ -60,7 +60,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 #define TEST_LL_8(a, b, c, d, e, f, g, h, expected)			\
 	do {								\
 		u8_t ll[] = { a, b, c, d, e, f, g, h };			\
-		zassert_false(strcmp(net_sprint_ll_addr(ll, sizeof(ll)), \
+		ztest_false(strcmp(net_sprint_ll_addr(ll, sizeof(ll)), \
 				     expected),				\
 			      "Test %s failed.\n", expected);		\
 	} while (0)
@@ -75,7 +75,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 		snprintk(out + sizeof("xx:xx:xx:xx:xx:xx"),		\
 			 sizeof(out), "%s",				\
 			 net_sprint_ll_addr(ll2, sizeof(ll2)));		\
-		zassert_false(strcmp(out, expected),			\
+		ztest_false(strcmp(out, expected),			\
 			      "Test %s failed, got %s\n", expected,	\
 			      out);					\
 	} while (0)
@@ -85,7 +85,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 		struct in6_addr addr = { { { a, b, c, d, e, f, g, h,	     \
 					       i, j, k, l, m, n, o, p } } }; \
 		char *ptr = net_sprint_ipv6_addr(&addr);		     \
-		zassert_false(strcmp(ptr, expected),			     \
+		ztest_false(strcmp(ptr, expected),			     \
 			      "Test %s failed, got %s\n", expected,	     \
 			      ptr);					     \
 	} while (0)
@@ -94,7 +94,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 	do {								\
 		struct in_addr addr = { { { a, b, c, d } } };		\
 		char *ptr = net_sprint_ipv4_addr(&addr);		\
-		zassert_false(strcmp(ptr, expected),			\
+		ztest_false(strcmp(ptr, expected),			\
 			      "Test %s failed, got %s\n", expected,	\
 			      ptr);					\
 	} while (0)
@@ -224,11 +224,11 @@ static void test_ipv6_addresses(void)
 	int i;
 
 	/**TESTPOINT: Check if the IPv6 address is a loopback address*/
-	zassert_true(net_ipv6_is_addr_loopback(&loopback),
+	ztest_true(net_ipv6_is_addr_loopback(&loopback),
 		     "IPv6 loopback address check failed.");
 
 	/**TESTPOINT: Check if the IPv6 address is a multicast address*/
-	zassert_true(net_ipv6_is_addr_mcast(&mcast),
+	ztest_true(net_ipv6_is_addr_mcast(&mcast),
 		     "IPv6 multicast address check failed.");
 
 	ifaddr1 = net_if_ipv6_addr_add(net_if_get_default(),
@@ -236,76 +236,76 @@ static void test_ipv6_addresses(void)
 				      NET_ADDR_MANUAL,
 				      0);
 	/**TESTPOINT: Check if IPv6 interface address is added*/
-	zassert_not_null(ifaddr1, "IPv6 interface address add failed");
+	ztest_not_null(ifaddr1, "IPv6 interface address add failed");
 
 	ifaddr2 = net_if_ipv6_addr_lookup(&addr6, NULL);
 
 	/**TESTPOINT: Check if addresses match*/
-	zassert_equal_ptr(ifaddr1, ifaddr2,
+	ztest_equal_ptr(ifaddr1, ifaddr2,
 			  "IPv6 interface address mismatch");
 
 	/**TESTPOINT: Check if the IPv6 address is a loopback address*/
-	zassert_false(net_ipv6_is_my_addr(&loopback),
+	ztest_false(net_ipv6_is_my_addr(&loopback),
 		      "My IPv6 loopback address check failed");
 
 	/**TESTPOINT: Check IPv6 address*/
-	zassert_true(net_ipv6_is_my_addr(&addr6),
+	ztest_true(net_ipv6_is_my_addr(&addr6),
 		     "My IPv6 address check failed");
 
 	/**TESTPOINTS: Check IPv6 prefix*/
-	zassert_true(net_ipv6_is_prefix((u8_t *)&addr6_pref1,
+	ztest_true(net_ipv6_is_prefix((u8_t *)&addr6_pref1,
 					(u8_t *)&addr6_pref2, 64),
 		     "Same IPv6 prefix test failed");
 
-	zassert_false(net_ipv6_is_prefix((u8_t *)&addr6_pref1,
+	ztest_false(net_ipv6_is_prefix((u8_t *)&addr6_pref1,
 					 (u8_t *)&addr6_pref3, 64),
 		      "Different IPv6 prefix test failed");
 
-	zassert_false(net_ipv6_is_prefix((u8_t *)&addr6_pref1,
+	ztest_false(net_ipv6_is_prefix((u8_t *)&addr6_pref1,
 					 (u8_t *)&addr6_pref2, 128),
 		      "Different full IPv6 prefix test failed");
 
-	zassert_false(net_ipv6_is_prefix((u8_t *)&addr6_pref1,
+	ztest_false(net_ipv6_is_prefix((u8_t *)&addr6_pref1,
 					 (u8_t *)&addr6_pref3, 255),
 		      "Too long prefix test failed");
 
 	ifmaddr1 = net_if_ipv6_maddr_add(net_if_get_default(), &mcast);
 
 	/**TESTPOINTS: Check IPv6 addresses*/
-	zassert_not_null(ifmaddr1, "IPv6 multicast address add failed");
+	ztest_not_null(ifmaddr1, "IPv6 multicast address add failed");
 
 	ifmaddr1 = net_if_ipv6_maddr_add(net_if_get_default(), &addr6);
 
-	zassert_is_null(ifmaddr1,
+	ztest_is_null(ifmaddr1,
 			"IPv6 multicast address could be added failed");
 
-	zassert_false(memcmp(net_ipv6_unspecified_address(), &any, sizeof(any)),
+	ztest_false(memcmp(net_ipv6_unspecified_address(), &any, sizeof(any)),
 		      "My IPv6 unspecified address check failed");
 
 	ifaddr2 = net_if_ipv6_addr_add(net_if_get_default(),
 				       &addr6,
 				       NET_ADDR_AUTOCONF,
 				       0);
-	zassert_not_null(ifaddr2, "IPv6 ll address autoconf add failed");
+	ztest_not_null(ifaddr2, "IPv6 ll address autoconf add failed");
 
 	ifaddr2->addr_state = NET_ADDR_PREFERRED;
 
 	tmp = net_if_ipv6_get_ll(net_if_get_default(), NET_ADDR_PREFERRED);
-	zassert_false(tmp && memcmp(tmp, &addr6.s6_addr,
+	ztest_false(tmp && memcmp(tmp, &addr6.s6_addr,
 				    sizeof(struct in6_addr)),
 		      "IPv6 ll address fetch failed");
 
 	ifaddr2->addr_state = NET_ADDR_DEPRECATED;
 
 	tmp = net_if_ipv6_get_ll(net_if_get_default(), NET_ADDR_PREFERRED);
-	zassert_false(tmp && !memcmp(tmp, &any, sizeof(struct in6_addr)),
+	ztest_false(tmp && !memcmp(tmp, &any, sizeof(struct in6_addr)),
 		      "IPv6 preferred ll address fetch failed");
 
 	ifaddr1 = net_if_ipv6_addr_add(net_if_get_default(),
 				       &addr6_pref2,
 				       NET_ADDR_AUTOCONF,
 				       0);
-	zassert_not_null(ifaddr1, "IPv6 global address autoconf add failed");
+	ztest_not_null(ifaddr1, "IPv6 global address autoconf add failed");
 
 	ifaddr1->addr_state = NET_ADDR_PREFERRED;
 
@@ -316,27 +316,27 @@ static void test_ipv6_addresses(void)
 		ifaddr2->addr_state = NET_ADDR_DEPRECATED;
 
 		out = net_if_ipv6_select_src_addr(iface, &addr6_pref1);
-		zassert_not_null(out,
+		ztest_not_null(out,
 				 "IPv6 src addr selection failed, iface %p\n",
 				 iface);
 
 		DBG("Selected IPv6 address %s, iface %p\n",
 		       net_sprint_ipv6_addr(out), iface);
 
-		zassert_false(memcmp(out->s6_addr, &addr6_pref2.s6_addr,
+		ztest_false(memcmp(out->s6_addr, &addr6_pref2.s6_addr,
 				     sizeof(struct in6_addr)),
 			      "IPv6 wrong src address selected, iface %p\n",
 			      iface);
 
 		/* Now we should get :: address */
 		out = net_if_ipv6_select_src_addr(iface, &addr6);
-		zassert_not_null(out, "IPv6 src any addr selection failed, "
+		ztest_not_null(out, "IPv6 src any addr selection failed, "
 				 "iface %p\n", iface);
 
 		DBG("Selected IPv6 address %s, iface %p\n",
 		       net_sprint_ipv6_addr(out), iface);
 
-		zassert_false(memcmp(out->s6_addr, &any.s6_addr,
+		ztest_false(memcmp(out->s6_addr, &any.s6_addr,
 				     sizeof(struct in6_addr)),
 			      "IPv6 wrong src any address selected, iface %p\n",
 			      iface);
@@ -345,13 +345,13 @@ static void test_ipv6_addresses(void)
 
 		/* Now we should get ll address */
 		out = net_if_ipv6_select_src_addr(iface, &addr6);
-		zassert_not_null(out,  "IPv6 src ll addr selection failed, "
+		ztest_not_null(out,  "IPv6 src ll addr selection failed, "
 				 "iface %p\n", iface);
 
 		DBG("Selected IPv6 address %s, iface %p\n",
 		       net_sprint_ipv6_addr(out), iface);
 
-		zassert_false(memcmp(out->s6_addr, &addr6.s6_addr,
+		ztest_false(memcmp(out->s6_addr, &addr6.s6_addr,
 				     sizeof(struct in6_addr)),
 			      "IPv6 wrong src ll address selected, iface %p\n",
 			      iface);
@@ -387,21 +387,21 @@ static void test_ipv4_addresses(void)
 				       &addr4,
 				       NET_ADDR_MANUAL,
 				       0);
-	zassert_not_null(ifaddr1, "IPv4 interface address add failed");
+	ztest_not_null(ifaddr1, "IPv4 interface address add failed");
 
-	zassert_true(net_ipv4_is_my_addr(&addr4),
+	ztest_true(net_ipv4_is_my_addr(&addr4),
 		     "My IPv4 address check failed");
 
 	ifaddr1 = net_if_ipv4_addr_add(net_if_get_default(),
 				       &lladdr4,
 				       NET_ADDR_MANUAL,
 				       0);
-	zassert_not_null(ifaddr1, "IPv4 interface address add failed");
+	ztest_not_null(ifaddr1, "IPv4 interface address add failed");
 
-	zassert_true(net_ipv4_is_my_addr(&lladdr4),
+	ztest_true(net_ipv4_is_my_addr(&lladdr4),
 		     "My IPv4 address check failed");
 
-	zassert_false(net_ipv4_is_my_addr(&loopback4),
+	ztest_false(net_ipv4_is_my_addr(&loopback4),
 		      "My IPv4 loopback address check failed");
 
 	/* Two tests for IPv4, first with interface given, then when
@@ -409,49 +409,49 @@ static void test_ipv4_addresses(void)
 	 */
 	for (i = 0, iface = net_if_get_default(); i < 2; i++, iface = NULL) {
 		out = net_if_ipv4_select_src_addr(iface, &addr4);
-		zassert_not_null(out,  "IPv4 src addr selection failed, "
+		ztest_not_null(out,  "IPv4 src addr selection failed, "
 				 "iface %p\n", iface);
 
 		DBG("Selected IPv4 address %s, iface %p\n",
 		       net_sprint_ipv4_addr(out), iface);
 
-		zassert_equal(out->s_addr, addr4.s_addr,
+		ztest_equal(out->s_addr, addr4.s_addr,
 			      "IPv4 wrong src address selected, iface %p\n",
 			      iface);
 
 		/* Now we should get ll address */
 		out = net_if_ipv4_select_src_addr(iface, &lladdr4);
-		zassert_not_null(out, "IPv4 src ll addr selection failed, "
+		ztest_not_null(out, "IPv4 src ll addr selection failed, "
 				 "iface %p\n", iface);
 
 		DBG("Selected IPv4 address %s, iface %p\n",
 		       net_sprint_ipv4_addr(out), iface);
 
-		zassert_equal(out->s_addr, lladdr4.s_addr,
+		ztest_equal(out->s_addr, lladdr4.s_addr,
 			      "IPv4 wrong src ll address selected, iface %p\n",
 			      iface);
 
 		/* Now we should get 192.168.0.1 address */
 		out = net_if_ipv4_select_src_addr(iface, &addr4b);
-		zassert_not_null(out, "IPv4 src any addr selection failed, "
+		ztest_not_null(out, "IPv4 src any addr selection failed, "
 				 "iface %p\n", iface);
 
 		DBG("Selected IPv4 address %s, iface %p\n",
 		       net_sprint_ipv4_addr(out), iface);
 
-		zassert_equal(out->s_addr, addr4.s_addr,
+		ztest_equal(out->s_addr, addr4.s_addr,
 			      "IPv4 wrong src address selected, iface %p\n",
 			      iface);
 
 		/* Now we should get 192.168.0.1 address */
 		out = net_if_ipv4_select_src_addr(iface, &addr4_not_found);
-		zassert_not_null(out, "IPv4 src any addr selection failed, "
+		ztest_not_null(out, "IPv4 src any addr selection failed, "
 				 "iface %p\n", iface);
 
 		DBG("Selected IPv4 address %s, iface %p\n",
 		       net_sprint_ipv4_addr(out), iface);
 
-		zassert_equal(out->s_addr, addr4.s_addr,
+		ztest_equal(out->s_addr, addr4.s_addr,
 			      "IPv4 wrong src address selected, iface %p\n",
 			      iface);
 	}
@@ -461,25 +461,25 @@ static void test_ipv4_addresses(void)
 	net_if_ipv4_set_gw(iface, &gw);
 	net_if_ipv4_set_netmask(iface, &netmask);
 
-	zassert_false(net_ipv4_addr_mask_cmp(iface, &fail_addr),
+	ztest_false(net_ipv4_addr_mask_cmp(iface, &fail_addr),
 		"IPv4 wrong match failed");
 
-	zassert_true(net_ipv4_addr_mask_cmp(iface, &match_addr),
+	ztest_true(net_ipv4_addr_mask_cmp(iface, &match_addr),
 		     "IPv4 match failed");
 
-	zassert_true(net_ipv4_is_addr_mcast(&maddr4a),
+	ztest_true(net_ipv4_is_addr_mcast(&maddr4a),
 		     "IPv4 multicast address");
 
-	zassert_true(net_ipv4_is_addr_mcast(&maddr4b),
+	ztest_true(net_ipv4_is_addr_mcast(&maddr4b),
 		     "IPv4 multicast address");
 
-	zassert_false(net_ipv4_is_addr_mcast(&addr4), "IPv4 address");
+	ztest_false(net_ipv4_is_addr_mcast(&addr4), "IPv4 address");
 
 	ifmaddr1 = net_if_ipv4_maddr_add(net_if_get_default(), &maddr4a);
-	zassert_not_null(ifmaddr1, "IPv4 multicast address add failed");
+	ztest_not_null(ifmaddr1, "IPv4 multicast address add failed");
 
 	ifmaddr1 = net_if_ipv4_maddr_add(net_if_get_default(), &maddr4b);
-	zassert_not_null(ifmaddr1, "IPv4 multicast address add failed");
+	ztest_not_null(ifmaddr1, "IPv4 multicast address add failed");
 
 	iface = NULL;
 
@@ -487,53 +487,53 @@ static void test_ipv4_addresses(void)
 	iface2 = net_if_get_by_index(2);
 
 	ifmaddr1 = net_if_ipv4_maddr_lookup(&maddr4a, &iface);
-	zassert_not_null(ifmaddr1, "IPv4 multicast address lookup failed");
-	zassert_equal(iface, iface1, "Interface not found");
+	ztest_not_null(ifmaddr1, "IPv4 multicast address lookup failed");
+	ztest_equal(iface, iface1, "Interface not found");
 
 	ifmaddr1 = net_if_ipv4_maddr_lookup(&maddr4b, &iface);
-	zassert_not_null(ifmaddr1, "IPv4 multicast address lookup failed");
-	zassert_equal(iface, iface1, "Interface not found");
+	ztest_not_null(ifmaddr1, "IPv4 multicast address lookup failed");
+	ztest_equal(iface, iface1, "Interface not found");
 
 	ifmaddr1 = net_if_ipv4_maddr_lookup(&maddr4a, &iface2);
-	zassert_is_null(ifmaddr1, "IPv4 multicast address lookup succeed");
+	ztest_is_null(ifmaddr1, "IPv4 multicast address lookup succeed");
 
 	ret = net_if_ipv4_maddr_rm(iface2, &maddr4a);
-	zassert_false(ret, "IPv4 rm succeed");
+	ztest_false(ret, "IPv4 rm succeed");
 
 	ret = net_if_ipv4_maddr_rm(iface1, &maddr4a);
-	zassert_true(ret, "IPv4 rm failed");
+	ztest_true(ret, "IPv4 rm failed");
 
 	ifmaddr1 = net_if_ipv4_maddr_lookup(&maddr4a, &iface1);
-	zassert_is_null(ifmaddr1, "IPv4 multicast address lookup succeed");
+	ztest_is_null(ifmaddr1, "IPv4 multicast address lookup succeed");
 
 	ret = net_if_ipv4_maddr_rm(iface1, &maddr4b);
-	zassert_true(ret, "IPv4 rm failed");
+	ztest_true(ret, "IPv4 rm failed");
 
 	ifmaddr1 = net_if_ipv4_maddr_lookup(&maddr4b, &iface1);
-	zassert_is_null(ifmaddr1, "IPv4 multicast address lookup succeed");
+	ztest_is_null(ifmaddr1, "IPv4 multicast address lookup succeed");
 
 	ret = net_ipv4_is_addr_bcast(iface, &bcast_addr1);
-	zassert_true(ret, "IPv4 address 1 is not broadcast address");
+	ztest_true(ret, "IPv4 address 1 is not broadcast address");
 
 	ret = net_ipv4_is_addr_bcast(iface, &bcast_addr2);
-	zassert_false(ret, "IPv4 address 2 is broadcast address");
+	ztest_false(ret, "IPv4 address 2 is broadcast address");
 
 	ret = net_ipv4_is_addr_bcast(iface, &bcast_addr4);
-	zassert_false(ret, "IPv4 address 4 is broadcast address");
+	ztest_false(ret, "IPv4 address 4 is broadcast address");
 
 	ret = net_ipv4_is_addr_bcast(iface, &maddr4b);
-	zassert_false(ret, "IPv4 address is broadcast address");
+	ztest_false(ret, "IPv4 address is broadcast address");
 
 	ret = net_ipv4_is_addr_bcast(iface, &bcast_addr5);
-	zassert_true(ret, "IPv4 address 5 is not broadcast address");
+	ztest_true(ret, "IPv4 address 5 is not broadcast address");
 
 	net_if_ipv4_set_netmask(iface, &netmask2);
 
 	ret = net_ipv4_is_addr_bcast(iface, &bcast_addr2);
-	zassert_false(ret, "IPv4 address 2 is broadcast address");
+	ztest_false(ret, "IPv4 address 2 is broadcast address");
 
 	ret = net_ipv4_is_addr_bcast(iface, &bcast_addr3);
-	zassert_true(ret, "IPv4 address 3 is not broadcast address");
+	ztest_true(ret, "IPv4 address 3 is not broadcast address");
 }
 
 void test_main(void)

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -301,7 +301,7 @@ static void test_init(void)
 	struct net_if_ipv6 *ipv6;
 	int i;
 
-	zassert_not_null(iface, "Interface is NULL");
+	ztest_not_null(iface, "Interface is NULL");
 
 	/* We cannot use net_if_ipv6_addr_add() to add the address to
 	 * network interface in this case as that would trigger DAD which
@@ -309,7 +309,7 @@ static void test_init(void)
 	 * manually in this special case so that subsequent tests can
 	 * pass.
 	 */
-	zassert_false(net_if_config_ipv6_get(iface, &ipv6) < 0,
+	ztest_false(net_if_config_ipv6_get(iface, &ipv6) < 0,
 			"IPv6 config is not valid");
 
 	for (i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
@@ -328,12 +328,12 @@ static void test_init(void)
 	}
 
 	ifaddr2 = net_if_ipv6_addr_lookup(&my_addr, &iface2);
-	zassert_true(ifaddr2 == ifaddr, "Invalid ifaddr (%p vs %p)\n", ifaddr, ifaddr2);
+	ztest_true(ifaddr2 == ifaddr, "Invalid ifaddr (%p vs %p)\n", ifaddr, ifaddr2);
 
 	net_ipv6_addr_create(&mcast_addr, 0xff02, 0, 0, 0, 0, 0, 0, 0x0001);
 
 	maddr = net_if_ipv6_maddr_add(iface, &mcast_addr);
-	zassert_not_null(maddr, "Cannot add multicast IPv6 address %s\n",
+	ztest_not_null(maddr, "Cannot add multicast IPv6 address %s\n",
 			 net_sprint_ipv6_addr(&mcast_addr));
 
 	/* The semaphore is there to wait the data to be received. */
@@ -355,36 +355,36 @@ static void test_cmp_prefix(void)
 					0, 0, 0, 0, 0, 0, 0, 0x2 } } };
 
 	st = net_ipv6_is_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 64);
-	zassert_true(st, "Prefix /64  compare failed");
+	ztest_true(st, "Prefix /64  compare failed");
 
 	st = net_ipv6_is_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 65);
-	zassert_true(st, "Prefix /65 compare failed");
+	ztest_true(st, "Prefix /65 compare failed");
 
 	/* Set one extra bit in the other prefix for testing /65 */
 	prefix1.s6_addr[8] = 0x80;
 
 	st = net_ipv6_is_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 65);
-	zassert_false(st, "Prefix /65 compare should have failed");
+	ztest_false(st, "Prefix /65 compare should have failed");
 
 	/* Set two bits in prefix2, it is now /66 */
 	prefix2.s6_addr[8] = 0xc0;
 
 	st = net_ipv6_is_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 65);
-	zassert_true(st, "Prefix /65 compare failed");
+	ztest_true(st, "Prefix /65 compare failed");
 
 	/* Set all remaining bits in prefix2, it is now /128 */
 	(void)memset(&prefix2.s6_addr[8], 0xff, 8);
 
 	st = net_ipv6_is_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 65);
-	zassert_true(st, "Prefix /65 compare failed");
+	ztest_true(st, "Prefix /65 compare failed");
 
 	/* Comparing /64 should be still ok */
 	st = net_ipv6_is_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 64);
-	zassert_true(st, "Prefix /64 compare failed");
+	ztest_true(st, "Prefix /64 compare failed");
 
 	/* But comparing /66 should should fail */
 	st = net_ipv6_is_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 66);
-	zassert_false(st, "Prefix /66 compare should have failed");
+	ztest_false(st, "Prefix /66 compare should have failed");
 
 }
 
@@ -410,7 +410,7 @@ static void test_add_neighbor(void)
 
 	nbr = net_ipv6_nbr_add(net_if_get_default(), &peer_addr, &lladdr,
 			       false, NET_IPV6_NBR_STATE_REACHABLE);
-	zassert_not_null(nbr, "Cannot add peer %s to neighbor cache\n",
+	ztest_not_null(nbr, "Cannot add peer %s to neighbor cache\n",
 			 net_sprint_ipv6_addr(&peer_addr));
 }
 
@@ -443,7 +443,7 @@ static void test_add_max_neighbors(void)
 		nbr = net_ipv6_nbr_add(net_if_get_default(), &dst_addr,
 				       &lladdr, false,
 				       NET_IPV6_NBR_STATE_STALE);
-		zassert_not_null(nbr, "Cannot add peer %s to neighbor cache\n",
+		ztest_not_null(nbr, "Cannot add peer %s to neighbor cache\n",
 				 net_sprint_ipv6_addr(&dst_addr));
 	}
 }
@@ -457,7 +457,7 @@ static void test_nbr_lookup_fail(void)
 
 	nbr = net_ipv6_nbr_lookup(net_if_get_default(),
 				  &peer_addr);
-	zassert_is_null(nbr, "Neighbor %s found in cache\n",
+	ztest_is_null(nbr, "Neighbor %s found in cache\n",
 			net_sprint_ipv6_addr(&peer_addr));
 
 }
@@ -471,7 +471,7 @@ static void test_nbr_lookup_ok(void)
 
 	nbr = net_ipv6_nbr_lookup(net_if_get_default(),
 				  &peer_addr);
-	zassert_not_null(nbr, "Neighbor %s not found in cache\n",
+	ztest_not_null(nbr, "Neighbor %s not found in cache\n",
 			 net_sprint_ipv6_addr(&peer_addr));
 }
 
@@ -493,7 +493,7 @@ static void test_send_ns_extra_options(void)
 	net_pkt_write(pkt, icmpv6_ns_invalid, sizeof(icmpv6_ns_invalid));
 	net_pkt_lladdr_clear(pkt);
 
-	zassert_false((net_recv_data(iface, pkt) < 0),
+	ztest_false((net_recv_data(iface, pkt) < 0),
 		      "Data receive for invalid NS failed.");
 
 }
@@ -516,7 +516,7 @@ static void test_send_ns_no_options(void)
 	net_pkt_write(pkt, icmpv6_ns_no_sllao, sizeof(icmpv6_ns_no_sllao));
 	net_pkt_lladdr_clear(pkt);
 
-	zassert_false((net_recv_data(iface, pkt) < 0),
+	ztest_false((net_recv_data(iface, pkt) < 0),
 		      "Data receive for invalid NS failed.");
 }
 
@@ -533,7 +533,7 @@ static void test_prefix_timeout(void)
 
 	prefix = net_if_ipv6_prefix_add(net_if_get_default(),
 					&addr, len, lifetime);
-	zassert_not_null(prefix, "Cannot get prefix");
+	ztest_not_null(prefix, "Cannot get prefix");
 
 	net_if_ipv6_prefix_set_lf(prefix, false);
 	net_if_ipv6_prefix_set_timer(prefix, lifetime);
@@ -542,7 +542,7 @@ static void test_prefix_timeout(void)
 
 	prefix = net_if_ipv6_prefix_lookup(net_if_get_default(),
 					   &addr, len);
-	zassert_is_null(prefix, "Prefix %s/%d should have expired",
+	ztest_is_null(prefix, "Prefix %s/%d should have expired",
 			net_sprint_ipv6_addr(&addr), len);
 }
 
@@ -562,18 +562,18 @@ static void test_prefix_timeout_long(void)
 	net_if_ipv6_prefix_set_lf(ifprefix, false);
 	net_if_ipv6_prefix_set_timer(ifprefix, lifetime);
 
-	zassert_equal(ifprefix->lifetime.wrap_counter, 2000,
+	ztest_equal(ifprefix->lifetime.wrap_counter, 2000,
 		      "Wrap counter wrong (%d)",
 		      ifprefix->lifetime.wrap_counter);
 	remaining = K_SECONDS((u64_t)lifetime) -
 		NET_TIMEOUT_MAX_VALUE * (u64_t)ifprefix->lifetime.wrap_counter;
 
-	zassert_equal(remaining, ifprefix->lifetime.timer_timeout,
+	ztest_equal(remaining, ifprefix->lifetime.timer_timeout,
 		     "Remaining time wrong (%llu vs %d)", remaining,
 		      ifprefix->lifetime.timer_timeout);
 
 	ret = net_if_ipv6_prefix_rm(net_if_get_default(), &prefix, len);
-	zassert_equal(ret, true, "Prefix %s/%d should have been removed",
+	ztest_equal(ret, true, "Prefix %s/%d should have been removed",
 		      net_sprint_ipv6_addr(&prefix), len);
 }
 
@@ -588,7 +588,7 @@ static void test_rs_message(void)
 
 	ret = net_ipv6_send_rs(iface);
 
-	zassert_equal(ret, 0, "RS sending failed (%d)", ret);
+	ztest_equal(ret, 0, "RS sending failed (%d)", ret);
 }
 
 static void test_ra_message(void)
@@ -604,12 +604,12 @@ static void test_ra_message(void)
 
 	expecting_ra = false;
 
-	zassert_false(!net_if_ipv6_prefix_lookup(net_if_get_default(),
+	ztest_false(!net_if_ipv6_prefix_lookup(net_if_get_default(),
 						 &prefix, 32),
 		      "Prefix %s should be here\n",
 		      net_sprint_ipv6_addr(&prefix));
 
-	zassert_false(!net_if_ipv6_router_lookup(net_if_get_default(), &addr),
+	ztest_false(!net_if_ipv6_router_lookup(net_if_get_default(), &addr),
 		      "Router %s should be here\n",
 		      net_sprint_ipv6_addr(&addr));
 }
@@ -632,7 +632,7 @@ static void test_hbho_message(void)
 	net_pkt_write(pkt, ipv6_hbho, sizeof(ipv6_hbho));
 	net_pkt_lladdr_clear(pkt);
 
-	zassert_false(net_recv_data(iface, pkt) < 0,
+	ztest_false(net_recv_data(iface, pkt) < 0,
 		      "Data receive for HBHO failed.");
 }
 
@@ -684,11 +684,11 @@ static void test_hbho_message_1(void)
 
 	net_pkt_lladdr_clear(pkt);
 
-	zassert_false(net_recv_data(iface, pkt) < 0,
+	ztest_false(net_recv_data(iface, pkt) < 0,
 		      "Data receive for HBHO failed.");
 
 	/* Verify IPv6 Ext hdr length */
-	zassert_false(net_pkt_ipv6_ext_len(pkt) == 72U,
+	ztest_false(net_pkt_ipv6_ext_len(pkt) == 72U,
 		      "IPv6 mismatch ext hdr length");
 }
 
@@ -744,11 +744,11 @@ static void test_hbho_message_2(void)
 	net_pkt_write(pkt, ipv6_hbho_2, sizeof(ipv6_hbho_2));
 	net_pkt_lladdr_clear(pkt);
 
-	zassert_false(net_recv_data(iface, pkt) < 0,
+	ztest_false(net_recv_data(iface, pkt) < 0,
 		      "Data receive for HBHO failed.");
 
 	/* Verify IPv6 Ext hdr length */
-	zassert_false(net_pkt_ipv6_ext_len(pkt) == 104U,
+	ztest_false(net_pkt_ipv6_ext_len(pkt) == 104U,
 		      "IPv6 mismatch ext hdr length");
 }
 
@@ -906,11 +906,11 @@ static void test_hbho_message_3(void)
 	net_pkt_write(pkt, ipv6_hbho_3, sizeof(ipv6_hbho_3));
 	net_pkt_lladdr_clear(pkt);
 
-	zassert_false(net_recv_data(iface, pkt) < 0,
+	ztest_false(net_recv_data(iface, pkt) < 0,
 		      "Data receive for HBHO failed.");
 
 	/* Verify IPv6 Ext hdr length */
-	zassert_false(net_pkt_ipv6_ext_len(pkt) == 920U,
+	ztest_false(net_pkt_ipv6_ext_len(pkt) == 920U,
 		      "IPv6 mismatch ext hdr length");
 }
 
@@ -932,7 +932,7 @@ static void test_address_lifetime(void)
 
 	ifaddr = net_if_ipv6_addr_add(iface, &addr, NET_ADDR_AUTOCONF,
 				      vlifetime);
-	zassert_not_null(ifaddr, "Address with lifetime cannot be added");
+	ztest_not_null(ifaddr, "Address with lifetime cannot be added");
 
 	/* Make sure DAD gets some time to run */
 	k_sleep(K_MSEC(200));
@@ -940,10 +940,10 @@ static void test_address_lifetime(void)
 	/* Then check that the timeout values in net_if_addr are set correctly.
 	 * Start first with smaller timeout values.
 	 */
-	zassert_equal(ifaddr->lifetime.timer_timeout, timeout,
+	ztest_equal(ifaddr->lifetime.timer_timeout, timeout,
 		      "Timer timeout set wrong (%d vs %llu)",
 		      ifaddr->lifetime.timer_timeout, timeout);
-	zassert_equal(ifaddr->lifetime.wrap_counter, 0,
+	ztest_equal(ifaddr->lifetime.wrap_counter, 0,
 		      "Wrap counter wrong (%d)", ifaddr->lifetime.wrap_counter);
 
 	/* Then update the lifetime and check that timeout values are correct
@@ -951,19 +951,19 @@ static void test_address_lifetime(void)
 	vlifetime = FIFTY_DAYS;
 	net_if_ipv6_addr_update_lifetime(ifaddr, vlifetime);
 
-	zassert_equal(ifaddr->lifetime.wrap_counter, 2,
+	ztest_equal(ifaddr->lifetime.wrap_counter, 2,
 		      "Wrap counter wrong (%d)", ifaddr->lifetime.wrap_counter);
 	remaining = K_SECONDS((u64_t)vlifetime) -
 		NET_TIMEOUT_MAX_VALUE * (u64_t)ifaddr->lifetime.wrap_counter;
 
-	zassert_equal(remaining, ifaddr->lifetime.timer_timeout,
+	ztest_equal(remaining, ifaddr->lifetime.timer_timeout,
 		     "Remaining time wrong (%llu vs %d)", remaining,
 		      ifaddr->lifetime.timer_timeout);
 
 	/* The address should not expire */
 	net_address_lifetime_timeout();
 
-	zassert_equal(ifaddr->lifetime.wrap_counter, 2,
+	ztest_equal(ifaddr->lifetime.wrap_counter, 2,
 		      "Wrap counter wrong (%d)", ifaddr->lifetime.wrap_counter);
 
 	ifaddr->lifetime.timer_timeout = K_MSEC(10);
@@ -973,14 +973,14 @@ static void test_address_lifetime(void)
 	net_address_lifetime_timeout();
 
 	/* The address should be expired now */
-	zassert_equal(ifaddr->lifetime.timer_timeout, 0,
+	ztest_equal(ifaddr->lifetime.timer_timeout, 0,
 		      "Timer timeout set wrong (%llu vs %llu)",
 		      ifaddr->lifetime.timer_timeout, 0);
-	zassert_equal(ifaddr->lifetime.wrap_counter, 0,
+	ztest_equal(ifaddr->lifetime.wrap_counter, 0,
 		      "Wrap counter wrong (%d)", ifaddr->lifetime.wrap_counter);
 
 	ret = net_if_ipv6_addr_rm(iface, &addr);
-	zassert_true(ret, "Address with lifetime cannot be removed");
+	ztest_true(ret, "Address with lifetime cannot be removed");
 }
 
 /**
@@ -1006,14 +1006,14 @@ static void test_change_ll_addr(void)
 
 	ret = net_ipv6_send_na(iface, &peer_addr, &dst,
 			       &peer_addr, flags);
-	zassert_false(ret < 0, "Cannot send NA 1");
+	ztest_false(ret < 0, "Cannot send NA 1");
 
 	nbr = net_ipv6_nbr_lookup(iface, &peer_addr);
 	ll = net_nbr_get_lladdr(nbr->idx);
 
 	ll_iface = net_if_get_link_addr(iface);
 
-	zassert_true(memcmp(ll->addr, ll_iface->addr, ll->len) != 0,
+	ztest_true(memcmp(ll->addr, ll_iface->addr, ll->len) != 0,
 		     "Wrong link address 1");
 
 	/* As the net_ipv6_send_na() uses interface link address to
@@ -1023,12 +1023,12 @@ static void test_change_ll_addr(void)
 
 	ret = net_ipv6_send_na(iface, &peer_addr, &dst,
 			       &peer_addr, flags);
-	zassert_false(ret < 0, "Cannot send NA 2");
+	ztest_false(ret < 0, "Cannot send NA 2");
 
 	nbr = net_ipv6_nbr_lookup(iface, &peer_addr);
 	ll = net_nbr_get_lladdr(nbr->idx);
 
-	zassert_true(memcmp(ll->addr, ll_iface->addr, ll->len) != 0,
+	ztest_true(memcmp(ll->addr, ll_iface->addr, ll->len) != 0,
 		     "Wrong link address 2");
 }
 
@@ -1048,26 +1048,26 @@ static void test_dad_timeout(void)
 	dad_time[0] = dad_time[1] = dad_time[2] = 0U;
 
 	ifaddr = net_if_ipv6_addr_add(iface, &addr1, NET_ADDR_AUTOCONF, 0xffff);
-	zassert_not_null(ifaddr, "Address 1 cannot be added");
+	ztest_not_null(ifaddr, "Address 1 cannot be added");
 
 	k_sleep(K_MSEC(10));
 
 	ifaddr = net_if_ipv6_addr_add(iface, &addr2, NET_ADDR_AUTOCONF, 0xffff);
-	zassert_not_null(ifaddr, "Address 2 cannot be added");
+	ztest_not_null(ifaddr, "Address 2 cannot be added");
 
 	k_sleep(K_MSEC(10));
 
 	ifaddr = net_if_ipv6_addr_add(iface, &addr3, NET_ADDR_AUTOCONF, 0xffff);
-	zassert_not_null(ifaddr, "Address 3 cannot be added");
+	ztest_not_null(ifaddr, "Address 3 cannot be added");
 
 	k_sleep(K_MSEC(200));
 
 	/* We should have received three DAD queries, make sure they are in
 	 * proper order.
 	 */
-	zassert_true(dad_time[0] < dad_time[1], "DAD timer 1+2 failure");
-	zassert_true(dad_time[1] < dad_time[2], "DAD timer 2+3 failure");
-	zassert_true((dad_time[2] - dad_time[0]) < 100,
+	ztest_true(dad_time[0] < dad_time[1], "DAD timer 1+2 failure");
+	ztest_true(dad_time[1] < dad_time[2], "DAD timer 2+3 failure");
+	ztest_true((dad_time[2] - dad_time[0]) < 100,
 		     "DAD timers took too long time [%u] [%u] [%u]",
 		     dad_time[0], dad_time[1], dad_time[2]);
 #endif
@@ -1092,17 +1092,17 @@ static struct net_pkt *setup_ipv6_udp(struct net_if *iface,
 
 	if (net_ipv6_create(pkt, local_addr, remote_addr)) {
 		printk("Cannot create IPv6  pkt %p", pkt);
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	if (net_udp_create(pkt, htons(local_port), htons(remote_port))) {
 		printk("Cannot create IPv6  pkt %p", pkt);
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	if (net_pkt_write(pkt, (u8_t *)payload, strlen(payload))) {
 		printk("Cannot write IPv6 ext header pkt %p", pkt);
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	net_pkt_cursor_init(pkt);
@@ -1148,7 +1148,7 @@ static void test_src_localaddr_recv(void)
 	enum net_verdict verdict;
 
 	verdict = recv_msg(&localaddr, &addr);
-	zassert_equal(verdict, NET_DROP,
+	ztest_equal(verdict, NET_DROP,
 		      "Local address packet was not dropped");
 }
 
@@ -1161,7 +1161,7 @@ static void test_dst_localaddr_recv(void)
 	enum net_verdict verdict;
 
 	verdict = recv_msg(&addr, &localaddr);
-	zassert_equal(verdict, NET_DROP,
+	ztest_equal(verdict, NET_DROP,
 		      "Local address packet was not dropped");
 }
 
@@ -1174,7 +1174,7 @@ static void test_dst_iface_scope_mcast_recv(void)
 	enum net_verdict verdict;
 
 	verdict = recv_msg(&addr, &mcast_iface);
-	zassert_equal(verdict, NET_DROP,
+	ztest_equal(verdict, NET_DROP,
 		      "Interface scope multicast packet was not dropped");
 }
 
@@ -1187,7 +1187,7 @@ static void test_dst_zero_scope_mcast_recv(void)
 	enum net_verdict verdict;
 
 	verdict = recv_msg(&addr, &mcast_zero);
-	zassert_equal(verdict, NET_DROP,
+	ztest_equal(verdict, NET_DROP,
 		      "Zero scope multicast packet was not dropped");
 }
 
@@ -1200,7 +1200,7 @@ static void test_dst_site_scope_mcast_recv_drop(void)
 	enum net_verdict verdict;
 
 	verdict = recv_msg(&addr, &mcast_site);
-	zassert_equal(verdict, NET_DROP,
+	ztest_equal(verdict, NET_DROP,
 		      "Site scope multicast packet was not dropped");
 }
 
@@ -1209,7 +1209,7 @@ static void net_ctx_create(struct net_context **ctx)
 	int ret;
 
 	ret = net_context_get(AF_INET6, SOCK_DGRAM, IPPROTO_UDP, ctx);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Context create IPv6 UDP test failed");
 }
 
@@ -1226,12 +1226,12 @@ static void net_ctx_bind_mcast(struct net_context *ctx, struct in6_addr *maddr)
 
 	ret = net_context_bind(ctx, (struct sockaddr *)&addr,
 			       sizeof(struct sockaddr_in6));
-	zassert_equal(ret, 0, "Context bind test failed (%d)", ret);
+	ztest_equal(ret, 0, "Context bind test failed (%d)", ret);
 }
 
 static void net_ctx_listen(struct net_context *ctx)
 {
-	zassert_true(net_context_listen(ctx, 0),
+	ztest_true(net_context_listen(ctx, 0),
 		     "Context listen IPv6 UDP test failed");
 }
 
@@ -1259,7 +1259,7 @@ static void net_ctx_recv(struct net_context *ctx)
 	int ret;
 
 	ret = net_context_recv(ctx, recv_cb, 0, NULL);
-	zassert_equal(ret, 0, "Context recv IPv6 UDP failed");
+	ztest_equal(ret, 0, "Context recv IPv6 UDP failed");
 }
 
 static void join_group(struct in6_addr *mcast_addr)
@@ -1267,7 +1267,7 @@ static void join_group(struct in6_addr *mcast_addr)
 	int ret;
 
 	ret = net_ipv6_mld_join(net_if_get_default(), mcast_addr);
-	zassert_equal(ret, 0, "Cannot join IPv6 multicast group");
+	ztest_equal(ret, 0, "Cannot join IPv6 multicast group");
 }
 
 static void test_dst_site_scope_mcast_recv_ok(void)
@@ -1290,7 +1290,7 @@ static void test_dst_site_scope_mcast_recv_ok(void)
 	net_ctx_recv(ctx);
 
 	verdict = recv_msg(&addr, &mcast_all_dhcp);
-	zassert_equal(verdict, NET_OK,
+	ztest_equal(verdict, NET_OK,
 		      "All DHCP site scope multicast packet was dropped (%d)",
 		      verdict);
 
@@ -1306,7 +1306,7 @@ static void test_dst_org_scope_mcast_recv(void)
 	enum net_verdict verdict;
 
 	verdict = recv_msg(&addr, &mcast_org);
-	zassert_equal(verdict, NET_DROP,
+	ztest_equal(verdict, NET_DROP,
 		      "Organisation scope multicast packet was not dropped");
 }
 
@@ -1326,7 +1326,7 @@ static void test_dst_iface_scope_mcast_send(void)
 	 * the network interface.
 	 */
 	maddr = net_if_ipv6_maddr_add(net_if_get_default(), &mcast_iface);
-	zassert_not_null(maddr, "Cannot add multicast address to interface");
+	ztest_not_null(maddr, "Cannot add multicast address to interface");
 
 	net_ctx_create(&ctx);
 	net_ctx_bind_mcast(ctx, &mcast_iface);
@@ -1334,13 +1334,13 @@ static void test_dst_iface_scope_mcast_send(void)
 	net_ctx_recv(ctx);
 
 	ret = send_msg(&addr, &mcast_iface);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Interface local scope multicast packet was dropped (%d)",
 		      ret);
 
 	k_sem_take(&wait_data, WAIT_TIME);
 
-	zassert_true(recv_cb_called, "No data received on time, "
+	ztest_true(recv_cb_called, "No data received on time, "
 		     "IPv6 recv test failed");
 	recv_cb_called = false;
 

--- a/tests/net/ipv6_fragment/src/main.c
+++ b/tests/net/ipv6_fragment/src/main.c
@@ -1345,7 +1345,7 @@ static int sender_iface(struct device *dev, struct net_pkt *pkt)
 	}
 
 	net_pkt_unref(pkt);
-	zassert_false(test_failed, "Fragment verify failed");
+	ztest_false(test_failed, "Fragment verify failed");
 
 	return 0;
 }
@@ -1393,7 +1393,7 @@ static void add_nbr(struct net_if *iface,
 
 	nbr = net_ipv6_nbr_add(iface, addr, lladdr, false,
 			       NET_IPV6_NBR_STATE_REACHABLE);
-	zassert_not_null(nbr, "Cannot add neighbor");
+	ztest_not_null(nbr, "Cannot add neighbor");
 }
 
 static enum net_verdict udp_data_received(struct net_conn *conn,
@@ -1428,7 +1428,7 @@ static void setup_udp_handler(const struct in6_addr *raddr,
 	ret = net_udp_register(AF_INET6, &remote_addr, &local_addr,
 			       remote_port, local_port, udp_data_received,
 			       NULL, &handle);
-	zassert_equal(ret, 0, "Cannot register UDP handler");
+	ztest_equal(ret, 0, "Cannot register UDP handler");
 }
 
 static void test_setup(void)
@@ -1448,20 +1448,20 @@ static void test_setup(void)
 		net_if_get_by_iface(iface2);
 
 	idx = net_if_get_by_iface(iface1);
-	zassert_equal(idx, 1, "Invalid index iface1");
+	ztest_equal(idx, 1, "Invalid index iface1");
 
 	idx = net_if_get_by_iface(iface2);
-	zassert_equal(idx, 2, "Invalid index iface2");
+	ztest_equal(idx, 2, "Invalid index iface2");
 
-	zassert_not_null(iface1, "Interface 1");
-	zassert_not_null(iface2, "Interface 2");
+	ztest_not_null(iface1, "Interface 1");
+	ztest_not_null(iface2, "Interface 2");
 
 	ifaddr = net_if_ipv6_addr_add(iface1, &my_addr1,
 				      NET_ADDR_MANUAL, 0);
 	if (!ifaddr) {
 		NET_DBG("Cannot add IPv6 address %s",
 			net_sprint_ipv6_addr(&my_addr1));
-		zassert_not_null(ifaddr, "addr1");
+		ztest_not_null(ifaddr, "addr1");
 	}
 
 	ifaddr = net_if_ipv6_addr_add(iface1, &ll_addr,
@@ -1469,7 +1469,7 @@ static void test_setup(void)
 	if (!ifaddr) {
 		NET_DBG("Cannot add IPv6 address %s",
 			net_sprint_ipv6_addr(&ll_addr));
-		zassert_not_null(ifaddr, "ll_addr");
+		ztest_not_null(ifaddr, "ll_addr");
 	} else {
 		/* we need to set the adddresses preferred */
 		ifaddr->addr_state = NET_ADDR_PREFERRED;
@@ -1503,7 +1503,7 @@ static void test_find_last_ipv6_fragment_udp(void)
 
 	pkt = net_pkt_alloc_with_buffer(iface1, sizeof(ipv6_udp), AF_INET6,
 					IPPROTO_UDP, ALLOC_TIMEOUT);
-	zassert_not_null(pkt, "packet");
+	ztest_not_null(pkt, "packet");
 
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv6_hdr));
 	net_pkt_set_ipv6_ext_len(pkt, sizeof(ipv6_udp) -
@@ -1512,17 +1512,17 @@ static void test_find_last_ipv6_fragment_udp(void)
 	/* Add IPv6 header + UDP */
 	ret = net_pkt_write(pkt, ipv6_udp, sizeof(ipv6_udp));
 
-	zassert_true(ret == 0, "IPv6 header append failed");
+	ztest_true(ret == 0, "IPv6 header append failed");
 
 	ret = net_ipv6_find_last_ext_hdr(pkt, &next_hdr_pos, &last_hdr_pos);
-	zassert_equal(ret, 0, "Cannot find last header");
+	ztest_equal(ret, 0, "Cannot find last header");
 
-	zassert_equal(next_hdr_pos, 6, "Next header index wrong");
-	zassert_equal(last_hdr_pos, sizeof(struct net_ipv6_hdr),
+	ztest_equal(next_hdr_pos, 6, "Next header index wrong");
+	ztest_equal(last_hdr_pos, sizeof(struct net_ipv6_hdr),
 		      "Last header position wrong");
 
-	zassert_equal(NET_IPV6_HDR(pkt)->nexthdr, 0x11, "Invalid next header");
-	zassert_equal(pkt->buffer->data[next_hdr_pos], 0x11, "Invalid next "
+	ztest_equal(NET_IPV6_HDR(pkt)->nexthdr, 0x11, "Invalid next header");
+	ztest_equal(pkt->buffer->data[next_hdr_pos], 0x11, "Invalid next "
 		      "header");
 
 	net_pkt_unref(pkt);
@@ -1538,7 +1538,7 @@ static void test_find_last_ipv6_fragment_hbho_udp(void)
 	pkt = net_pkt_alloc_with_buffer(iface1, sizeof(ipv6_hbho) +
 					sizeof(struct net_ipv6_hdr) + 6,
 					AF_UNSPEC, 0, ALLOC_TIMEOUT);
-	zassert_not_null(pkt, "packet");
+	ztest_not_null(pkt, "packet");
 
 	net_pkt_set_family(pkt, AF_INET6);
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv6_hdr));
@@ -1546,18 +1546,18 @@ static void test_find_last_ipv6_fragment_hbho_udp(void)
 				 sizeof(struct net_ipv6_hdr));
 	/* Add IPv6 header + HBH option */
 	ret = net_pkt_write(pkt, ipv6_hbho, sizeof(ipv6_hbho));
-	zassert_true(ret == 0, "IPv6 header append failed");
+	ztest_true(ret == 0, "IPv6 header append failed");
 
 	ret = net_ipv6_find_last_ext_hdr(pkt, &next_hdr_pos, &last_hdr_pos);
-	zassert_equal(ret, 0, "Cannot find last header");
+	ztest_equal(ret, 0, "Cannot find last header");
 
-	zassert_equal(next_hdr_pos, sizeof(struct net_ipv6_hdr),
+	ztest_equal(next_hdr_pos, sizeof(struct net_ipv6_hdr),
 		      "Next header index wrong");
-	zassert_equal(last_hdr_pos, sizeof(struct net_ipv6_hdr) + 8,
+	ztest_equal(last_hdr_pos, sizeof(struct net_ipv6_hdr) + 8,
 		      "Last header position wrong");
 
-	zassert_equal(NET_IPV6_HDR(pkt)->nexthdr, 0, "Invalid next header");
-	zassert_equal(pkt->buffer->data[next_hdr_pos], 0x11, "Invalid next "
+	ztest_equal(NET_IPV6_HDR(pkt)->nexthdr, 0, "Invalid next header");
+	ztest_equal(pkt->buffer->data[next_hdr_pos], 0x11, "Invalid next "
 		      "header");
 
 	net_pkt_unref(pkt);
@@ -1574,34 +1574,34 @@ static void test_find_last_ipv6_fragment_hbho_1(void)
 
 	pkt = net_pkt_alloc_with_buffer(iface1, sizeof(ipv6_hbho_1),
 					AF_UNSPEC, 0, ALLOC_TIMEOUT);
-	zassert_not_null(pkt, "packet");
+	ztest_not_null(pkt, "packet");
 
 	net_pkt_set_family(pkt, AF_INET6);
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv6_hdr));
 
 	/* Add IPv6 header + HBH option + fragment header */
 	ret = net_pkt_write(pkt, ipv6_hbho_1, sizeof(ipv6_hbho_1));
-	zassert_true(ret == 0, "IPv6 header append failed");
+	ztest_true(ret == 0, "IPv6 header append failed");
 
 	net_pkt_set_overwrite(pkt, true);
 
 	ret = net_ipv6_find_last_ext_hdr(pkt, &next_hdr_pos, &last_hdr_pos);
-	zassert_equal(ret, 0, "Cannot find last header");
+	ztest_equal(ret, 0, "Cannot find last header");
 
-	zassert_equal(next_hdr_pos, 40, "Next header position wrong");
-	zassert_equal(last_hdr_pos, 112, "Last header position wrong");
+	ztest_equal(next_hdr_pos, 40, "Next header position wrong");
+	ztest_equal(last_hdr_pos, 112, "Last header position wrong");
 
 	net_pkt_cursor_init(pkt);
 	net_pkt_skip(pkt, next_hdr_pos);
 	net_pkt_read_u8(pkt, &next_hdr);
 
-	zassert_equal(next_hdr, 0x11, "Invalid next header");
+	ztest_equal(next_hdr, 0x11, "Invalid next header");
 
 	net_pkt_cursor_init(pkt);
 	net_pkt_skip(pkt, last_hdr_pos);
 	net_pkt_read_u8(pkt, &last_hdr);
 
-	zassert_equal(last_hdr, 0x4e, "Invalid last header");
+	ztest_equal(last_hdr, 0x4e, "Invalid last header");
 
 	net_pkt_unref(pkt);
 }
@@ -1617,34 +1617,34 @@ static void test_find_last_ipv6_fragment_hbho_2(void)
 
 	pkt = net_pkt_alloc_with_buffer(iface1, sizeof(ipv6_hbho_2),
 					AF_UNSPEC, 0, ALLOC_TIMEOUT);
-	zassert_not_null(pkt, "packet");
+	ztest_not_null(pkt, "packet");
 
 	net_pkt_set_family(pkt, AF_INET6);
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv6_hdr));
 
 	/* Add IPv6 header + HBH option + fragment header */
 	ret = net_pkt_write(pkt, ipv6_hbho_2, sizeof(ipv6_hbho_2));
-	zassert_true(ret == 0, "IPv6 header append failed");
+	ztest_true(ret == 0, "IPv6 header append failed");
 
 	net_pkt_set_overwrite(pkt, true);
 
 	ret = net_ipv6_find_last_ext_hdr(pkt, &next_hdr_pos, &last_hdr_pos);
-	zassert_equal(ret, 0, "Cannot find last header");
+	ztest_equal(ret, 0, "Cannot find last header");
 
-	zassert_equal(next_hdr_pos, 40, "Next header position wrong");
-	zassert_equal(last_hdr_pos, 144, "Last header position wrong");
+	ztest_equal(next_hdr_pos, 40, "Next header position wrong");
+	ztest_equal(last_hdr_pos, 144, "Last header position wrong");
 
 	net_pkt_cursor_init(pkt);
 	net_pkt_skip(pkt, next_hdr_pos);
 	net_pkt_read_u8(pkt, &next_hdr);
 
-	zassert_equal(next_hdr, 0x11, "Invalid next header");
+	ztest_equal(next_hdr, 0x11, "Invalid next header");
 
 	net_pkt_cursor_init(pkt);
 	net_pkt_skip(pkt, last_hdr_pos);
 	net_pkt_read_u8(pkt, &last_hdr);
 
-	zassert_equal(last_hdr, 0x4e, "Invalid last header");
+	ztest_equal(last_hdr, 0x4e, "Invalid last header");
 
 	net_pkt_unref(pkt);
 }
@@ -1660,34 +1660,34 @@ static void test_find_last_ipv6_fragment_hbho_3(void)
 
 	pkt = net_pkt_alloc_with_buffer(iface1, sizeof(ipv6_hbho_3),
 					AF_UNSPEC, 0, ALLOC_TIMEOUT);
-	zassert_not_null(pkt, "packet");
+	ztest_not_null(pkt, "packet");
 
 	net_pkt_set_family(pkt, AF_INET6);
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv6_hdr));
 
 	/* Add IPv6 header + HBH option + fragment header */
 	ret = net_pkt_write(pkt, ipv6_hbho_3, sizeof(ipv6_hbho_3));
-	zassert_true(ret == 0, "IPv6 header append failed");
+	ztest_true(ret == 0, "IPv6 header append failed");
 
 	net_pkt_set_overwrite(pkt, true);
 
 	ret = net_ipv6_find_last_ext_hdr(pkt, &next_hdr_pos, &last_hdr_pos);
-	zassert_equal(ret, 0, "Cannot find last header");
+	ztest_equal(ret, 0, "Cannot find last header");
 
-	zassert_equal(next_hdr_pos, 40, "Next header position wrong");
-	zassert_equal(last_hdr_pos, 960, "Last header position wrong");
+	ztest_equal(next_hdr_pos, 40, "Next header position wrong");
+	ztest_equal(last_hdr_pos, 960, "Last header position wrong");
 
 	net_pkt_cursor_init(pkt);
 	net_pkt_skip(pkt, next_hdr_pos);
 	net_pkt_read_u8(pkt, &next_hdr);
 
-	zassert_equal(next_hdr, 0x11, "Invalid next header");
+	ztest_equal(next_hdr, 0x11, "Invalid next header");
 
 	net_pkt_cursor_init(pkt);
 	net_pkt_skip(pkt, last_hdr_pos);
 	net_pkt_read_u8(pkt, &last_hdr);
 
-	zassert_equal(last_hdr, 0x4e, "Invalid last header");
+	ztest_equal(last_hdr, 0x4e, "Invalid last header");
 
 	net_pkt_unref(pkt);
 }
@@ -1701,27 +1701,27 @@ static void test_find_last_ipv6_fragment_hbho_frag(void)
 
 	pkt = net_pkt_alloc_with_buffer(iface1, sizeof(ipv6_hbho_frag),
 					AF_UNSPEC, 0, ALLOC_TIMEOUT);
-	zassert_not_null(pkt, "packet");
+	ztest_not_null(pkt, "packet");
 
 	net_pkt_set_family(pkt, AF_INET6);
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv6_hdr));
 
 	/* Add IPv6 header + HBH option + fragment header */
 	ret = net_pkt_write(pkt, ipv6_hbho_frag, sizeof(ipv6_hbho_frag));
-	zassert_true(ret == 0, "IPv6 header append failed");
+	ztest_true(ret == 0, "IPv6 header append failed");
 
 	net_pkt_set_overwrite(pkt, true);
 
 	ret = net_ipv6_find_last_ext_hdr(pkt, &next_hdr_pos, &last_hdr_pos);
-	zassert_equal(ret, 0, "Cannot find last header");
+	ztest_equal(ret, 0, "Cannot find last header");
 
-	zassert_equal(next_hdr_pos, sizeof(struct net_ipv6_hdr) + 8,
+	ztest_equal(next_hdr_pos, sizeof(struct net_ipv6_hdr) + 8,
 		      "Next header position wrong");
-	zassert_equal(last_hdr_pos, sizeof(struct net_ipv6_hdr) + 8 + 8,
+	ztest_equal(last_hdr_pos, sizeof(struct net_ipv6_hdr) + 8 + 8,
 		      "Last header position wrong");
 
-	zassert_equal(NET_IPV6_HDR(pkt)->nexthdr, 0, "Invalid next header");
-	zassert_equal(pkt->buffer->data[next_hdr_pos], 0x11,
+	ztest_equal(NET_IPV6_HDR(pkt)->nexthdr, 0, "Invalid next header");
+	ztest_equal(pkt->buffer->data[next_hdr_pos], 0x11,
 		      "Invalid next header");
 
 	net_pkt_unref(pkt);
@@ -1738,7 +1738,7 @@ static void test_find_last_ipv6_fragment_hbho_frag_1(void)
 
 	pkt = net_pkt_alloc_with_buffer(iface1, sizeof(ipv6_hbho_frag_1),
 					AF_UNSPEC, 0, ALLOC_TIMEOUT);
-	zassert_not_null(pkt, "packet");
+	ztest_not_null(pkt, "packet");
 
 	net_pkt_set_family(pkt, AF_INET6);
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv6_hdr));
@@ -1746,27 +1746,27 @@ static void test_find_last_ipv6_fragment_hbho_frag_1(void)
 	/* Add IPv6 header + HBH option + fragment header */
 	ret = net_pkt_write(pkt, ipv6_hbho_frag_1,
 			    sizeof(ipv6_hbho_frag_1));
-	zassert_true(ret == 0, "IPv6 header append failed");
+	ztest_true(ret == 0, "IPv6 header append failed");
 
 	net_pkt_set_overwrite(pkt, true);
 
 	ret = net_ipv6_find_last_ext_hdr(pkt, &next_hdr_pos, &last_hdr_pos);
-	zassert_equal(ret, 0, "Cannot find last header");
+	ztest_equal(ret, 0, "Cannot find last header");
 
-	zassert_equal(next_hdr_pos, 1072, "Next header position wrong");
-	zassert_equal(last_hdr_pos, 1080, "Last header position wrong");
+	ztest_equal(next_hdr_pos, 1072, "Next header position wrong");
+	ztest_equal(last_hdr_pos, 1080, "Last header position wrong");
 
 	net_pkt_cursor_init(pkt);
 	net_pkt_skip(pkt, next_hdr_pos);
 	net_pkt_read_u8(pkt, &next_hdr);
 
-	zassert_equal(next_hdr, 0x3a, "Invalid next header");
+	ztest_equal(next_hdr, 0x3a, "Invalid next header");
 
 	net_pkt_cursor_init(pkt);
 	net_pkt_skip(pkt, last_hdr_pos);
 	net_pkt_read_u8(pkt, &last_hdr);
 
-	zassert_equal(last_hdr, 0x80, "Invalid next header");
+	ztest_equal(last_hdr, 0x80, "Invalid next header");
 
 	net_pkt_unref(pkt);
 }
@@ -1787,7 +1787,7 @@ static void test_send_ipv6_fragment(void)
 	pkt = net_pkt_alloc_with_buffer(iface1,
 					sizeof(ipv6_hbho) + (count * data_len),
 					AF_UNSPEC, 0, ALLOC_TIMEOUT);
-	zassert_not_null(pkt, "packet");
+	ztest_not_null(pkt, "packet");
 
 	net_pkt_set_iface(pkt, iface1);
 	net_pkt_set_family(pkt, AF_INET6);
@@ -1796,25 +1796,25 @@ static void test_send_ipv6_fragment(void)
 
 	/* Add IPv6 header + HBH option */
 	ret = net_pkt_write(pkt, ipv6_hbho, sizeof(ipv6_hbho));
-	zassert_true(ret == 0, "IPv6 header append failed");
+	ztest_true(ret == 0, "IPv6 header append failed");
 
 	/* Then add some data that is over 1280 bytes long */
 	for (i = 0; i < count; i++) {
 		ret = net_pkt_write(pkt, data, data_len);
 
-		zassert_true(ret == 0, "Cannot append data");
+		ztest_true(ret == 0, "Cannot append data");
 
 		pkt_data_len += data_len;
 	}
 
-	zassert_equal(pkt_data_len, count * data_len, "Data size mismatch");
+	ztest_equal(pkt_data_len, count * data_len, "Data size mismatch");
 
 	total_len = net_pkt_get_len(pkt) - sizeof(struct net_ipv6_hdr);
 
 	NET_DBG("Sending %zd bytes of which ext %d and data %d bytes",
 		total_len, net_pkt_ipv6_ext_len(pkt), pkt_data_len);
 
-	zassert_equal(total_len - net_pkt_ipv6_ext_len(pkt) - 8, pkt_data_len,
+	ztest_equal(total_len - net_pkt_ipv6_ext_len(pkt) - 8, pkt_data_len,
 		      "Packet size invalid");
 
 	NET_IPV6_HDR(pkt)->len = htons(total_len);
@@ -1830,12 +1830,12 @@ static void test_send_ipv6_fragment(void)
 	ret = net_send_data(pkt);
 	if (ret < 0) {
 		NET_DBG("Cannot send test packet (%d)", ret);
-		zassert_equal(ret, 0, "Cannot send");
+		ztest_equal(ret, 0, "Cannot send");
 	}
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		NET_DBG("Timeout while waiting interface data");
-		zassert_equal(ret, 0, "Timeout");
+		ztest_equal(ret, 0, "Timeout");
 	}
 }
 
@@ -1851,14 +1851,14 @@ static void test_send_ipv6_fragment_large_hbho(void)
 
 	pkt = net_pkt_alloc_with_buffer(iface1, sizeof(ipv6_large_hbho),
 					AF_UNSPEC, 0, ALLOC_TIMEOUT);
-	zassert_not_null(pkt, "packet");
+	ztest_not_null(pkt, "packet");
 
 	net_pkt_set_family(pkt, AF_INET6);
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv6_hdr));
 	net_pkt_set_ipv6_ext_len(pkt, 1032); /* hbho */
 
 	ret = net_pkt_write(pkt, ipv6_large_hbho, sizeof(ipv6_large_hbho));
-	zassert_true(ret == 0, "IPv6 header append failed");
+	ztest_true(ret == 0, "IPv6 header append failed");
 
 	net_pkt_set_overwrite(pkt, true);
 
@@ -1872,12 +1872,12 @@ static void test_send_ipv6_fragment_large_hbho(void)
 	ret = net_send_data(pkt);
 	if (ret < 0) {
 		NET_DBG("Cannot send test packet (%d)", ret);
-		zassert_equal(ret, 0, "Cannot send");
+		ztest_equal(ret, 0, "Cannot send");
 	}
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		NET_DBG("Timeout while waiting interface data");
-		zassert_equal(ret, 0, "Timeout");
+		ztest_equal(ret, 0, "Timeout");
 	}
 }
 
@@ -1895,7 +1895,7 @@ static void test_send_ipv6_fragment_without_hbho(void)
 
 	pkt = net_pkt_alloc_with_buffer(iface1, sizeof(ipv6_frag_wo_hbho),
 					AF_UNSPEC, 0, ALLOC_TIMEOUT);
-	zassert_not_null(pkt, "packet");
+	ztest_not_null(pkt, "packet");
 
 	net_pkt_set_family(pkt, AF_INET6);
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv6_hdr));
@@ -1903,7 +1903,7 @@ static void test_send_ipv6_fragment_without_hbho(void)
 
 	ret = net_pkt_write(pkt, ipv6_frag_wo_hbho,
 			    sizeof(ipv6_frag_wo_hbho));
-	zassert_true(ret == 0, "IPv6 header append failed");
+	ztest_true(ret == 0, "IPv6 header append failed");
 
 	net_pkt_set_overwrite(pkt, true);
 
@@ -1918,12 +1918,12 @@ static void test_send_ipv6_fragment_without_hbho(void)
 	ret = net_send_data(pkt);
 	if (ret < 0) {
 		NET_DBG("Cannot send test packet (%d)", ret);
-		zassert_equal(ret, 0, "Cannot send");
+		ztest_equal(ret, 0, "Cannot send");
 	}
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		NET_DBG("Timeout while waiting interface data");
-		zassert_equal(ret, 0, "Timeout");
+		ztest_equal(ret, 0, "Timeout");
 	}
 }
 
@@ -1966,7 +1966,7 @@ static void test_recv_ipv6_fragment(void)
 
 	pkt1 = net_pkt_alloc_with_buffer(iface1, NET_IPV6_MTU, AF_UNSPEC,
 					 0, ALLOC_TIMEOUT);
-	zassert_not_null(pkt1, "packet");
+	ztest_not_null(pkt1, "packet");
 
 	net_pkt_set_family(pkt1, AF_INET6);
 	net_pkt_set_ip_hdr_len(pkt1, sizeof(struct net_ipv6_hdr));
@@ -1976,7 +1976,7 @@ static void test_recv_ipv6_fragment(void)
 
 	ret = net_pkt_write(pkt1, ipv6_reass_frag1,
 			    sizeof(struct net_ipv6_hdr) + 1);
-	zassert_true(ret == 0, "IPv6 header append failed");
+	ztest_true(ret == 0, "IPv6 header append failed");
 
 	net_pkt_cursor_backup(pkt1, &backup);
 
@@ -1984,11 +1984,11 @@ static void test_recv_ipv6_fragment(void)
 			    ipv6_reass_frag1 + sizeof(struct net_ipv6_hdr) + 1,
 			    sizeof(ipv6_reass_frag1) -
 			    sizeof(struct net_ipv6_hdr) - 1);
-	zassert_true(ret == 0, "IPv6 fragment header append failed");
+	ztest_true(ret == 0, "IPv6 fragment header append failed");
 
 	while (payload1_len--) {
 		ret = net_pkt_write_u8(pkt1, data++);
-		zassert_true(ret == 0, "IPv6 header append failed");
+		ztest_true(ret == 0, "IPv6 header append failed");
 	}
 
 	net_pkt_set_ipv6_fragment_start(pkt1, sizeof(struct net_ipv6_hdr));
@@ -1998,14 +1998,14 @@ static void test_recv_ipv6_fragment(void)
 
 	ret = net_ipv6_handle_fragment_hdr(pkt1, &ipv6_hdr,
 					   NET_IPV6_NEXTHDR_FRAG);
-	zassert_true(ret == NET_OK, "IPv6 frag1 reassembly failed");
+	ztest_true(ret == NET_OK, "IPv6 frag1 reassembly failed");
 
 	/* Fragment 2 */
 
 	pkt2 = net_pkt_alloc_with_buffer(iface1, payload2_len +
 					 sizeof(ipv6_reass_frag2),
 					 AF_UNSPEC, 0, ALLOC_TIMEOUT);
-	zassert_not_null(pkt2, "packet");
+	ztest_not_null(pkt2, "packet");
 
 	net_pkt_set_family(pkt2, AF_INET6);
 	net_pkt_set_ip_hdr_len(pkt2, sizeof(struct net_ipv6_hdr));
@@ -2015,7 +2015,7 @@ static void test_recv_ipv6_fragment(void)
 
 	ret = net_pkt_write(pkt2, ipv6_reass_frag2,
 			    sizeof(struct net_ipv6_hdr) + 1);
-	zassert_true(ret == 0, "IPv6 header append failed");
+	ztest_true(ret == 0, "IPv6 header append failed");
 
 	net_pkt_cursor_backup(pkt2, &backup);
 
@@ -2023,11 +2023,11 @@ static void test_recv_ipv6_fragment(void)
 			    ipv6_reass_frag2 + sizeof(struct net_ipv6_hdr) + 1,
 			    sizeof(ipv6_reass_frag2) -
 			    sizeof(struct net_ipv6_hdr) - 1);
-	zassert_true(ret == 0, "IPv6 fragment header append failed");
+	ztest_true(ret == 0, "IPv6 fragment header append failed");
 
 	while (payload2_len--) {
 		ret = net_pkt_write_u8(pkt2, data++);
-		zassert_true(ret == 0, "IPv6 header append failed");
+		ztest_true(ret == 0, "IPv6 header append failed");
 	}
 
 	net_pkt_set_ipv6_fragment_start(pkt2, sizeof(struct net_ipv6_hdr));
@@ -2037,7 +2037,7 @@ static void test_recv_ipv6_fragment(void)
 
 	ret = net_ipv6_handle_fragment_hdr(pkt2, &ipv6_hdr,
 					   NET_IPV6_NEXTHDR_FRAG);
-	zassert_true(ret == NET_OK, "IPv6 frag2 reassembly failed");
+	ztest_true(ret == NET_OK, "IPv6 frag2 reassembly failed");
 }
 
 void test_main(void)

--- a/tests/net/lib/dns_addremove/src/main.c
+++ b/tests/net/lib/dns_addremove/src/main.c
@@ -155,7 +155,7 @@ static void test_init(void)
 	struct net_if_addr *ifaddr;
 
 	iface1 = net_if_get_by_index(0);
-	zassert_is_null(iface1, "iface1");
+	ztest_is_null(iface1, "iface1");
 
 	iface1 = net_if_get_by_index(1);
 
@@ -168,7 +168,7 @@ static void test_init(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr1));
-		zassert_not_null(ifaddr, "addr1");
+		ztest_not_null(ifaddr, "addr1");
 
 		return;
 	}
@@ -183,7 +183,7 @@ static void test_init(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv4 address %s\n",
 		       net_sprint_ipv4_addr(&my_addr2));
-		zassert_not_null(ifaddr, "addr2");
+		ztest_not_null(ifaddr, "addr2");
 
 		return;
 	}
@@ -210,7 +210,7 @@ static void dns_do_not_add_add_callback6(void)
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&dns_added, WAIT_TIME)) {
-		zassert_true(true,
+		ztest_true(true,
 			"Received DNS added callback when should not have");
 	}
 #endif
@@ -236,7 +236,7 @@ static void dns_add_callback6(void)
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&dns_added, WAIT_TIME)) {
-		zassert_true(false,
+		ztest_true(false,
 			     "Timeout while waiting for DNS added callback");
 	}
 #endif
@@ -251,12 +251,12 @@ static void dns_remove_callback6(void)
 
 	ret = dns_resolve_close(&resv_ipv6);
 
-	zassert_equal(ret, 0, "Cannot remove DNS server");
+	ztest_equal(ret, 0, "Cannot remove DNS server");
 
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&dns_removed, WAIT_TIME)) {
-		zassert_true(false,
+		ztest_true(false,
 			     "Timeout while waiting for DNS removed callback");
 	}
 #endif
@@ -270,12 +270,12 @@ static void dns_remove_none_callback6(void)
 
 	ret = dns_resolve_close(&resv_ipv6);
 
-	zassert_not_equal(ret, 0, "Cannot remove DNS server");
+	ztest_not_equal(ret, 0, "Cannot remove DNS server");
 
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&dns_removed, WAIT_TIME)) {
-		zassert_true(true,
+		ztest_true(true,
 			"Received DNS removed callback when should not have");
 	}
 #endif
@@ -299,7 +299,7 @@ static void dns_add_remove_two_callback6(void)
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&dns_added, WAIT_TIME)) {
-		zassert_true(false,
+		ztest_true(false,
 			     "Timeout while waiting for DNS added callback");
 	}
 
@@ -316,56 +316,56 @@ static void dns_add_remove_two_callback6(void)
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&dns_added, WAIT_TIME)) {
-		zassert_true(false,
+		ztest_true(false,
 			     "Timeout while waiting for DNS added callback");
 	}
 
 	/* Check both DNS servers are used */
-	zassert_true(resv_ipv6.is_used, "DNS server #1 is missing");
-	zassert_true(resv_ipv6_2.is_used, "DNS server #2 is missing");
+	ztest_true(resv_ipv6.is_used, "DNS server #1 is missing");
+	ztest_true(resv_ipv6_2.is_used, "DNS server #2 is missing");
 
 	/* Remove first DNS server */
 	dnsCtx = &resv_ipv6;
 	ret = dns_resolve_close(dnsCtx);
-	zassert_equal(ret, 0, "Cannot remove DNS server #1");
+	ztest_equal(ret, 0, "Cannot remove DNS server #1");
 
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&dns_removed, WAIT_TIME)) {
-		zassert_true(true,
+		ztest_true(true,
 			"Received DNS removed callback when should not have");
 	}
 
 	/* Check second DNS servers is used */
-	zassert_false(resv_ipv6.is_used, "DNS server #1 is active");
-	zassert_true(resv_ipv6_2.is_used, "DNS server #2 is missing");
+	ztest_false(resv_ipv6.is_used, "DNS server #1 is active");
+	ztest_true(resv_ipv6_2.is_used, "DNS server #2 is missing");
 
 	/* Check first DNS server cannot be removed once removed */
 	ret = dns_resolve_close(dnsCtx);
-	zassert_not_equal(ret, 0,
+	ztest_not_equal(ret, 0,
 			  "Successful result code when attempting to "
 			  "remove DNS server #1 again");
 
 	/* Remove second DNS server */
 	dnsCtx = &resv_ipv6_2;
 	ret = dns_resolve_close(dnsCtx);
-	zassert_equal(ret, 0, "Cannot remove DNS server #2");
+	ztest_equal(ret, 0, "Cannot remove DNS server #2");
 
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&dns_removed, WAIT_TIME)) {
-		zassert_true(true,
+		ztest_true(true,
 			     "Received DNS removed callback when should "
 			     "not have");
 	}
 
 	/* Check neither DNS server is used */
-	zassert_false(resv_ipv6.is_used, "DNS server #1 isa ctive");
-	zassert_false(resv_ipv6_2.is_used, "DNS server #2 is active");
+	ztest_false(resv_ipv6.is_used, "DNS server #1 isa ctive");
+	ztest_false(resv_ipv6_2.is_used, "DNS server #2 is active");
 
 	/* Check first DNS server cannot be removed once removed */
 	ret = dns_resolve_close(dnsCtx);
-	zassert_not_equal(ret, 0,
+	ztest_not_equal(ret, 0,
 			  "Successful result code when attempting "
 			  "to remove DNS server #1 again");
 #endif
@@ -379,7 +379,7 @@ static void dns_do_not_add_add_callback(void)
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&dns_added, WAIT_TIME)) {
-		zassert_true(true,
+		ztest_true(true,
 			"Received DNS added callback when should not have");
 	}
 #endif
@@ -404,7 +404,7 @@ static void dns_add_callback(void)
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&dns_added, WAIT_TIME)) {
-		zassert_true(false,
+		ztest_true(false,
 			     "Timeout while waiting for DNS added callback");
 	}
 #endif
@@ -418,12 +418,12 @@ static void dns_remove_callback(void)
 
 	ret = dns_resolve_close(&resv_ipv4);
 
-	zassert_equal(ret, 0, "Cannot remove DNS server");
+	ztest_equal(ret, 0, "Cannot remove DNS server");
 
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&dns_removed, WAIT_TIME)) {
-		zassert_true(false,
+		ztest_true(false,
 			     "Timeout while waiting for DNS removed callback");
 	}
 #endif
@@ -437,12 +437,12 @@ static void dns_remove_none_callback(void)
 
 	ret = dns_resolve_close(&resv_ipv4);
 
-	zassert_not_equal(ret, 0, "Cannot remove DNS server");
+	ztest_not_equal(ret, 0, "Cannot remove DNS server");
 
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&dns_removed, WAIT_TIME)) {
-		zassert_true(true,
+		ztest_true(true,
 			"Received DNS removed callback when should not have");
 	}
 #endif
@@ -466,7 +466,7 @@ static void dns_add_remove_two_callback(void)
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&dns_added, WAIT_TIME)) {
-		zassert_true(false,
+		ztest_true(false,
 			     "Timeout while waiting for DNS added callback");
 	}
 
@@ -483,56 +483,56 @@ static void dns_add_remove_two_callback(void)
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&dns_added, WAIT_TIME)) {
-		zassert_true(false,
+		ztest_true(false,
 			     "Timeout while waiting for DNS added callback");
 	}
 
 	/* Check both DNS servers are used */
-	zassert_true(resv_ipv4.is_used, "DNS server #1 is missing");
-	zassert_true(resv_ipv4_2.is_used, "DNS server #2 is missing");
+	ztest_true(resv_ipv4.is_used, "DNS server #1 is missing");
+	ztest_true(resv_ipv4_2.is_used, "DNS server #2 is missing");
 
 	/* Remove first DNS server */
 	dnsCtx = &resv_ipv4;
 	ret = dns_resolve_close(dnsCtx);
-	zassert_equal(ret, 0, "Cannot remove DNS server #1");
+	ztest_equal(ret, 0, "Cannot remove DNS server #1");
 
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&dns_removed, WAIT_TIME)) {
-		zassert_true(true,
+		ztest_true(true,
 			"Received DNS removed callback when should not have");
 	}
 
 	/* Check second DNS servers is used */
-	zassert_false(resv_ipv4.is_used, "DNS server #1 is active");
-	zassert_true(resv_ipv4_2.is_used, "DNS server #2 is missing");
+	ztest_false(resv_ipv4.is_used, "DNS server #1 is active");
+	ztest_true(resv_ipv4_2.is_used, "DNS server #2 is missing");
 
 	/* Check first DNS server cannot be removed once removed */
 	ret = dns_resolve_close(dnsCtx);
-	zassert_not_equal(ret, 0,
+	ztest_not_equal(ret, 0,
 			  "Successful result code when attempting to "
 			  "remove DNS server #1 again");
 
 	/* Remove second DNS server */
 	dnsCtx = &resv_ipv4_2;
 	ret = dns_resolve_close(dnsCtx);
-	zassert_equal(ret, 0, "Cannot remove DNS server #2");
+	ztest_equal(ret, 0, "Cannot remove DNS server #2");
 
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&dns_removed, WAIT_TIME)) {
-		zassert_true(true,
+		ztest_true(true,
 			     "Received DNS removed callback when should "
 			     "not have");
 	}
 
 	/* Check neither DNS server is used */
-	zassert_false(resv_ipv4.is_used, "DNS server #1 isa ctive");
-	zassert_false(resv_ipv4_2.is_used, "DNS server #2 is active");
+	ztest_false(resv_ipv4.is_used, "DNS server #1 isa ctive");
+	ztest_false(resv_ipv4_2.is_used, "DNS server #2 is active");
 
 	/* Check first DNS server cannot be removed once removed */
 	ret = dns_resolve_close(dnsCtx);
-	zassert_not_equal(ret, 0,
+	ztest_not_equal(ret, 0,
 			  "Successful result code when attempting to "
 			  "remove DNS server #1 again");
 #endif

--- a/tests/net/lib/dns_packet/src/main.c
+++ b/tests/net/lib/dns_packet/src/main.c
@@ -417,19 +417,19 @@ void test_dns_query(void)
 
 	rc = eval_query(DNAME1, tid1, DNS_RR_TYPE_A,
 			query_ipv4, sizeof(query_ipv4));
-	zassert_equal(rc, 0, "Query test failed for domain: "DNAME1);
+	ztest_equal(rc, 0, "Query test failed for domain: "DNAME1);
 
 	rc = eval_query(NULL, tid1, DNS_RR_TYPE_A,
 			query_ipv4, sizeof(query_ipv4));
-	zassert_not_equal(rc, 0, "Query test with invalid domain name failed");
+	ztest_not_equal(rc, 0, "Query test with invalid domain name failed");
 
 	rc = eval_query(DNAME1, tid1, DNS_RR_TYPE_AAAA,
 			query_ipv4, sizeof(query_ipv4));
-	zassert_not_equal(rc, 0, "Query test for IPv4 with RR type AAAA failed");
+	ztest_not_equal(rc, 0, "Query test for IPv4 with RR type AAAA failed");
 
 	rc = eval_query(DNAME1, tid1 + 1, DNS_RR_TYPE_A,
 			query_ipv4, sizeof(query_ipv4));
-	zassert_not_equal(rc, 0, "Query test with invalid ID failed");
+	ztest_not_equal(rc, 0, "Query test with invalid ID failed");
 }
 
 /* DNS response for www.zephyrproject.org with the following parameters:
@@ -471,14 +471,14 @@ void test_dns_response(void)
 
 	memcpy(&test1, &test, sizeof(test1));
 	rc = eval_response1(&test1, false);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "Response test failed for domain: " DNAME1
 		      " at line %d", -rc);
 
 	/* Test also using dns_unpack_answer() API */
 	memcpy(&test2, &test, sizeof(test2));
 	rc = eval_response1(&test2, true);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "Response test 2 failed for domain: " DNAME1
 		      " at line %d", -rc);
 }
@@ -521,7 +521,7 @@ void test_dns_response2(void)
 
 	/* Test also using dns_unpack_answer() API */
 	rc = eval_response1(&test1, true);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "Response test 2 failed for domain: " DNAME2
 		      " at line %d", -rc);
 }
@@ -532,7 +532,7 @@ void test_mdns_query(void)
 
 	rc = eval_query(ZEPHYR_LOCAL, tid1, DNS_RR_TYPE_A,
 			query_mdns, sizeof(query_mdns));
-	zassert_equal(rc, 0, "Query test failed for domain: " ZEPHYR_LOCAL);
+	ztest_equal(rc, 0, "Query test failed for domain: " ZEPHYR_LOCAL);
 }
 
 /* DNS response for zephyr.local with the following parameters:
@@ -579,7 +579,7 @@ void test_mdns_response(void)
 	int rc;
 
 	rc = eval_response1(&test1, true);
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "Response test failed for domain: " ZEPHYR_LOCAL
 		      " at line %d", -rc);
 }

--- a/tests/net/lib/dns_resolve/src/main.c
+++ b/tests/net/lib/dns_resolve/src/main.c
@@ -203,7 +203,7 @@ static void test_init(void)
 	k_sem_init(&wait_data2, 0, UINT_MAX);
 
 	iface1 = net_if_get_by_index(0);
-	zassert_is_null(iface1, "iface1");
+	ztest_is_null(iface1, "iface1");
 
 	iface1 = net_if_get_by_index(1);
 
@@ -216,7 +216,7 @@ static void test_init(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr1));
-		zassert_not_null(ifaddr, "addr1");
+		ztest_not_null(ifaddr, "addr1");
 
 		return;
 	}
@@ -229,7 +229,7 @@ static void test_init(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&ll_addr));
-		zassert_not_null(ifaddr, "ll_addr");
+		ztest_not_null(ifaddr, "ll_addr");
 
 		return;
 	}
@@ -243,7 +243,7 @@ static void test_init(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv4 address %s\n",
 		       net_sprint_ipv4_addr(&my_addr2));
-		zassert_not_null(ifaddr, "addr2");
+		ztest_not_null(ifaddr, "addr2");
 
 		return;
 	}
@@ -279,7 +279,7 @@ static void dns_query_invalid_timeout(void)
 				dns_result_cb_dummy,
 				NULL,
 				K_NO_WAIT);
-	zassert_equal(ret, -EINVAL, "Wrong return code for timeout");
+	ztest_equal(ret, -EINVAL, "Wrong return code for timeout");
 }
 
 static void dns_query_invalid_context(void)
@@ -293,7 +293,7 @@ static void dns_query_invalid_context(void)
 			       dns_result_cb_dummy,
 			       NULL,
 			       DNS_TIMEOUT);
-	zassert_equal(ret, -EINVAL, "Wrong return code for context");
+	ztest_equal(ret, -EINVAL, "Wrong return code for context");
 }
 
 static void dns_query_invalid_callback(void)
@@ -306,7 +306,7 @@ static void dns_query_invalid_callback(void)
 				NULL,
 				NULL,
 				DNS_TIMEOUT);
-	zassert_equal(ret, -EINVAL, "Wrong return code for callback");
+	ztest_equal(ret, -EINVAL, "Wrong return code for callback");
 }
 
 static void dns_query_invalid_query(void)
@@ -319,7 +319,7 @@ static void dns_query_invalid_query(void)
 				dns_result_cb_dummy,
 				NULL,
 				DNS_TIMEOUT);
-	zassert_equal(ret, -EINVAL, "Wrong return code for query");
+	ztest_equal(ret, -EINVAL, "Wrong return code for query");
 }
 
 void dns_result_cb_timeout(enum dns_resolve_status status,
@@ -332,7 +332,7 @@ void dns_result_cb_timeout(enum dns_resolve_status status,
 		DBG("Result status %d\n", status);
 		DBG("Expected status %d\n", expected_status);
 
-		zassert_equal(expected_status, status, "Invalid status");
+		ztest_equal(expected_status, status, "Invalid status");
 	}
 
 	k_sem_give(&wait_data);
@@ -355,7 +355,7 @@ static void dns_query_server_count(void)
 		count++;
 	}
 
-	zassert_equal(count, CONFIG_DNS_RESOLVER_MAX_SERVERS,
+	ztest_equal(count, CONFIG_DNS_RESOLVER_MAX_SERVERS,
 		     "Invalid number of servers");
 }
 
@@ -385,8 +385,8 @@ static void dns_query_ipv4_server_count(void)
 		}
 	}
 
-	zassert_equal(count, 2, "Invalid number of IPv4 servers");
-	zassert_equal(port, 1, "Invalid number of IPv4 servers with port 53");
+	ztest_equal(count, 2, "Invalid number of IPv4 servers");
+	ztest_equal(port, 1, "Invalid number of IPv4 servers with port 53");
 }
 
 static void dns_query_ipv6_server_count(void)
@@ -416,11 +416,11 @@ static void dns_query_ipv6_server_count(void)
 	}
 
 #if defined(CONFIG_NET_IPV6)
-	zassert_equal(count, 2, "Invalid number of IPv6 servers");
-	zassert_equal(port, 1, "Invalid number of IPv6 servers with port 53");
+	ztest_equal(count, 2, "Invalid number of IPv6 servers");
+	ztest_equal(port, 1, "Invalid number of IPv6 servers with port 53");
 #else
-	zassert_equal(count, 0, "Invalid number of IPv6 servers");
-	zassert_equal(port, 0, "Invalid number of IPv6 servers with port 53");
+	ztest_equal(count, 0, "Invalid number of IPv6 servers");
+	ztest_equal(port, 0, "Invalid number of IPv6 servers with port 53");
 #endif
 }
 
@@ -437,7 +437,7 @@ static void dns_query_too_many(void)
 				dns_result_cb_timeout,
 				INT_TO_POINTER(expected_status),
 				DNS_TIMEOUT);
-	zassert_equal(ret, 0, "Cannot create IPv4 query");
+	ztest_equal(ret, 0, "Cannot create IPv4 query");
 
 	ret = dns_get_addr_info(NAME4,
 				DNS_QUERY_TYPE_A,
@@ -445,10 +445,10 @@ static void dns_query_too_many(void)
 				dns_result_cb_dummy,
 				INT_TO_POINTER(expected_status),
 				DNS_TIMEOUT);
-	zassert_equal(ret, -EAGAIN, "Should have run out of space");
+	ztest_equal(ret, -EAGAIN, "Should have run out of space");
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
-		zassert_true(false, "Timeout while waiting data");
+		ztest_true(false, "Timeout while waiting data");
 	}
 
 	timeout_query = false;
@@ -467,10 +467,10 @@ static void dns_query_ipv4_timeout(void)
 				dns_result_cb_timeout,
 				INT_TO_POINTER(expected_status),
 				DNS_TIMEOUT);
-	zassert_equal(ret, 0, "Cannot create IPv4 query");
+	ztest_equal(ret, 0, "Cannot create IPv4 query");
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
-		zassert_true(false, "Timeout while waiting data");
+		ztest_true(false, "Timeout while waiting data");
 	}
 
 	timeout_query = false;
@@ -489,10 +489,10 @@ static void dns_query_ipv6_timeout(void)
 				dns_result_cb_timeout,
 				INT_TO_POINTER(expected_status),
 				DNS_TIMEOUT);
-	zassert_equal(ret, 0, "Cannot create IPv6 query");
+	ztest_equal(ret, 0, "Cannot create IPv6 query");
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
-		zassert_true(false, "Timeout while waiting data");
+		ztest_true(false, "Timeout while waiting data");
 	}
 
 	timeout_query = false;
@@ -513,8 +513,8 @@ static void verify_cancelled(void)
 		}
 	}
 
-	zassert_equal(count, 0, "Not all pending queries vere cancelled");
-	zassert_equal(timer_not_stopped, 0, "Not all timers vere cancelled");
+	ztest_equal(count, 0, "Not all pending queries vere cancelled");
+	ztest_equal(timer_not_stopped, 0, "Not all timers vere cancelled");
 }
 
 static void dns_query_ipv4_cancel(void)
@@ -531,13 +531,13 @@ static void dns_query_ipv4_cancel(void)
 				dns_result_cb_timeout,
 				INT_TO_POINTER(expected_status),
 				DNS_TIMEOUT);
-	zassert_equal(ret, 0, "Cannot create IPv4 query");
+	ztest_equal(ret, 0, "Cannot create IPv4 query");
 
 	ret = dns_cancel_addr_info(dns_id);
-	zassert_equal(ret, 0, "Cannot cancel IPv4 query");
+	ztest_equal(ret, 0, "Cannot cancel IPv4 query");
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
-		zassert_true(false, "Timeout while waiting data");
+		ztest_true(false, "Timeout while waiting data");
 	}
 
 	verify_cancelled();
@@ -557,13 +557,13 @@ static void dns_query_ipv6_cancel(void)
 				dns_result_cb_timeout,
 				INT_TO_POINTER(expected_status),
 				DNS_TIMEOUT);
-	zassert_equal(ret, 0, "Cannot create IPv6 query");
+	ztest_equal(ret, 0, "Cannot create IPv6 query");
 
 	ret = dns_cancel_addr_info(dns_id);
-	zassert_equal(ret, 0, "Cannot cancel IPv6 query");
+	ztest_equal(ret, 0, "Cannot cancel IPv6 query");
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
-		zassert_true(false, "Timeout while waiting data");
+		ztest_true(false, "Timeout while waiting data");
 	}
 
 	verify_cancelled();
@@ -587,7 +587,7 @@ void dns_result_cb(enum dns_resolve_status status,
 		DBG("Expected status2 %d\n", expected->status2);
 		DBG("Caller %s\n", expected->caller);
 
-		zassert_true(false, "Invalid status");
+		ztest_true(false, "Invalid status");
 	}
 
 	k_sem_give(&wait_data2);
@@ -610,14 +610,14 @@ static void dns_query_ipv4(void)
 				dns_result_cb,
 				&status,
 				DNS_TIMEOUT);
-	zassert_equal(ret, 0, "Cannot create IPv4 query");
+	ztest_equal(ret, 0, "Cannot create IPv4 query");
 
 	DBG("Query id %u\n", current_dns_id);
 
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&wait_data2, WAIT_TIME)) {
-		zassert_true(false, "Timeout while waiting data");
+		ztest_true(false, "Timeout while waiting data");
 	}
 }
 
@@ -639,14 +639,14 @@ static void dns_query_ipv6(void)
 				dns_result_cb,
 				&status,
 				DNS_TIMEOUT);
-	zassert_equal(ret, 0, "Cannot create IPv6 query");
+	ztest_equal(ret, 0, "Cannot create IPv6 query");
 
 	DBG("Query id %u\n", current_dns_id);
 
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&wait_data2, WAIT_TIME)) {
-		zassert_true(false, "Timeout while waiting data");
+		ztest_true(false, "Timeout while waiting data");
 	}
 }
 #endif
@@ -670,13 +670,13 @@ void dns_result_numeric_cb(enum dns_resolve_status status,
 		DBG("Expected status2 %d\n", expected->status2);
 		DBG("Caller %s\n", expected->caller);
 
-		zassert_true(false, "Invalid status");
+		ztest_true(false, "Invalid status");
 	}
 
 	if (info && info->ai_family == AF_INET) {
 		if (net_ipv4_addr_cmp(&net_sin(&info->ai_addr)->sin_addr,
 				      &my_addr2) != true) {
-			zassert_true(false, "IPv4 address does not match");
+			ztest_true(false, "IPv4 address does not match");
 		}
 	}
 
@@ -684,7 +684,7 @@ void dns_result_numeric_cb(enum dns_resolve_status status,
 #if defined(CONFIG_NET_IPV6)
 		if (net_ipv6_addr_cmp(&net_sin6(&info->ai_addr)->sin6_addr,
 				      &my_addr3) != true) {
-			zassert_true(false, "IPv6 address does not match");
+			ztest_true(false, "IPv6 address does not match");
 		}
 #endif
 	}
@@ -709,14 +709,14 @@ static void dns_query_ipv4_numeric(void)
 				dns_result_numeric_cb,
 				&status,
 				DNS_TIMEOUT);
-	zassert_equal(ret, 0, "Cannot create IPv4 numeric query");
+	ztest_equal(ret, 0, "Cannot create IPv4 numeric query");
 
 	DBG("Query id %u\n", current_dns_id);
 
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&wait_data2, WAIT_TIME)) {
-		zassert_true(false, "Timeout while waiting data");
+		ztest_true(false, "Timeout while waiting data");
 	}
 }
 
@@ -738,14 +738,14 @@ static void dns_query_ipv6_numeric(void)
 				dns_result_numeric_cb,
 				&status,
 				DNS_TIMEOUT);
-	zassert_equal(ret, 0, "Cannot create IPv6 query");
+	ztest_equal(ret, 0, "Cannot create IPv6 query");
 
 	DBG("Query id %u\n", current_dns_id);
 
 	k_yield(); /* mandatory so that net_if send func gets to run */
 
 	if (k_sem_take(&wait_data2, WAIT_TIME)) {
-		zassert_true(false, "Timeout while waiting data");
+		ztest_true(false, "Timeout while waiting data");
 	}
 }
 #endif

--- a/tests/net/lib/http_header_fields/src/main.c
+++ b/tests/net/lib/http_header_fields/src/main.c
@@ -581,7 +581,7 @@ void test_preserve_data(void)
 	http_parser_init(&parser, HTTP_REQUEST);
 
 	/**TESTPOINT: Check results*/
-	zassert_equal(parser.data, my_data, "test_preserve_data error");
+	ztest_equal(parser.data, my_data, "test_preserve_data error");
 }
 
 void test_parse_url(void)
@@ -605,13 +605,13 @@ void test_parse_url(void)
 		if (test->rv == 0) {
 
 			/**TESTPOINT: Check test_parse_url functions*/
-			zassert_false(rv, "http_parser_parse_url error");
+			ztest_false(rv, "http_parser_parse_url error");
 
-			zassert_false(memcmp(&u, &test->u, sizeof(u)),
+			ztest_false(memcmp(&u, &test->u, sizeof(u)),
 					"test_parse_url failed");
 		} else {
 			/* test->rv != 0 */
-			zassert_true(rv, "http_parser_parse_url error");
+			ztest_true(rv, "http_parser_parse_url error");
 		}
 	}
 }
@@ -619,9 +619,9 @@ void test_parse_url(void)
 void test_method_str(void)
 {
 	/**TESTPOINT: Check test_method_str function*/
-	zassert_false(strcmp("GET", http_method_str(HTTP_GET)),
+	ztest_false(strcmp("GET", http_method_str(HTTP_GET)),
 			"http_method_str error");
-	zassert_false(strcmp("<unknown>", http_method_str(127)),
+	ztest_false(strcmp("<unknown>", http_method_str(127)),
 			"http_method_str error");
 }
 
@@ -635,9 +635,9 @@ void test_header_nread_value(void)
 	buf = "GET / HTTP/1.1\r\nheader: value\nhdr: value\r\n";
 	parsed = http_parser_execute(&parser, &settings_null, buf, strlen(buf));
 
-	zassert_equal(parsed, strlen(buf),
+	ztest_equal(parsed, strlen(buf),
 			"http_parser error");
-	zassert_equal(parser.nread, strlen(buf),
+	ztest_equal(parser.nread, strlen(buf),
 			"http_parser error");
 }
 
@@ -653,14 +653,14 @@ int test_invalid_header_content(int req, const char *str)
 	parsed = http_parser_execute(&parser, &settings_null, buf, strlen(buf));
 
 	/**TESTPOINTS: Check test_invalid_header_content functions*/
-	zassert_equal(parsed, strlen(buf),
+	ztest_equal(parsed, strlen(buf),
 			"http_parser_execute error");
 
 	buf = str;
 	buflen = strlen(buf);
 	parsed = http_parser_execute(&parser, &settings_null, buf, buflen);
 	if (parsed != buflen) {
-		zassert_equal(HTTP_PARSER_ERRNO(&parser),
+		ztest_equal(HTTP_PARSER_ERRNO(&parser),
 				HPE_INVALID_HEADER_TOKEN,
 				"http_parser_execute error");
 
@@ -677,11 +677,11 @@ int test_invalid_header_field_content_error(int req)
 	rc = test_invalid_header_content(req, "Foo: F\01ailure");
 
 	/**TESTPOINTS: Check test_invalid_header_field_content_error*/
-	zassert_false(rc, "test_invalid_header_content error");
+	ztest_false(rc, "test_invalid_header_content error");
 
 	rc = test_invalid_header_content(req, "Foo: B\02ar");
 
-	zassert_false(rc, "test_invalid_header_content error");
+	ztest_false(rc, "test_invalid_header_content error");
 
 	return TC_PASS;
 }
@@ -698,13 +698,13 @@ int test_invalid_header_field(int req, const char *str)
 	parsed = http_parser_execute(&parser, &settings_null, buf, strlen(buf));
 
 	/**TESTPOINTS: Check http_parser_execute*/
-	zassert_equal(parsed, strlen(buf),
+	ztest_equal(parsed, strlen(buf),
 			"http_parser_execute error");
 	buf = str;
 	buflen = strlen(buf);
 	parsed = http_parser_execute(&parser, &settings_null, buf, buflen);
 	if (parsed != buflen) {
-		zassert_equal(HTTP_PARSER_ERRNO(&parser),
+		ztest_equal(HTTP_PARSER_ERRNO(&parser),
 				HPE_INVALID_HEADER_TOKEN,
 				"http_parser_execute error");
 
@@ -721,10 +721,10 @@ int test_invalid_header_field_token_error(int req)
 	rc = test_invalid_header_field(req, "Fo@: Failure");
 
 	/**TESTPOINTS: Check test_invalid_header_field_token_error*/
-	zassert_false(rc, "test_invalid_header_field error");
+	ztest_false(rc, "test_invalid_header_field error");
 
 	rc = test_invalid_header_field(req, "Foo\01\test: Bar");
-	zassert_false(rc, "test_invalid_header_field error");
+	ztest_false(rc, "test_invalid_header_field error");
 
 	return TC_PASS;
 }
@@ -741,7 +741,7 @@ int test_double_content_length_error(int req)
 	parsed = http_parser_execute(&parser, &settings_null, buf, strlen(buf));
 
 	/**TESTPOINTS: Check http_parser_execute*/
-	zassert_equal(parsed, strlen(buf),
+	ztest_equal(parsed, strlen(buf),
 			"http_parser_execute error");
 
 	buf = "Content-Length: 0\r\nContent-Length: 1\r\n\r\n";
@@ -750,7 +750,7 @@ int test_double_content_length_error(int req)
 	if (parsed != buflen) {
 		int error = HTTP_PARSER_ERRNO(&parser);
 
-		zassert_equal(error, HPE_UNEXPECTED_CONTENT_LENGTH,
+		ztest_equal(error, HPE_UNEXPECTED_CONTENT_LENGTH,
 			"http_parser_execute error");
 
 		return TC_PASS;
@@ -772,7 +772,7 @@ int test_chunked_content_length_error(int req)
 	parsed = http_parser_execute(&parser, &settings_null, buf, strlen(buf));
 
 	/**TESTPOINTS: Check http_parser_execute*/
-	zassert_equal(parsed, strlen(buf),
+	ztest_equal(parsed, strlen(buf),
 			"http_parser_execute error");
 
 	buf = "Transfer-Encoding: chunked\r\nContent-Length: 1\r\n\r\n";
@@ -781,7 +781,7 @@ int test_chunked_content_length_error(int req)
 	if (parsed != buflen) {
 		int error = HTTP_PARSER_ERRNO(&parser);
 
-		zassert_equal(error, HPE_UNEXPECTED_CONTENT_LENGTH,
+		ztest_equal(error, HPE_UNEXPECTED_CONTENT_LENGTH,
 			"http_parser_execute error");
 
 		return TC_PASS;
@@ -802,7 +802,7 @@ int test_header_cr_no_lf_error(int req)
 	parsed = http_parser_execute(&parser, &settings_null, buf, strlen(buf));
 
 	/**TESTPOINTS: Check http_parser_execute*/
-	zassert_equal(parsed, strlen(buf),
+	ztest_equal(parsed, strlen(buf),
 			"http_parser_execute error");
 
 
@@ -812,7 +812,7 @@ int test_header_cr_no_lf_error(int req)
 	if (parsed != buflen) {
 		int error = HTTP_PARSER_ERRNO(&parser);
 
-		zassert_equal(error, HPE_LF_EXPECTED,
+		ztest_equal(error, HPE_LF_EXPECTED,
 			"http_parser_execute error");
 
 		return TC_PASS;
@@ -829,52 +829,52 @@ void test_http_header_fields(void)
 	rc = test_double_content_length_error(HTTP_REQUEST);
 
 	/**TESTPOINT: Check test_double_content_length_error*/
-	zassert_false(rc, "test_double_content_length_error failed");
+	ztest_false(rc, "test_double_content_length_error failed");
 
 	rc = test_chunked_content_length_error(HTTP_REQUEST);
 
 	/**TESTPOINT: Check test_chunked_content_length_error*/
-	zassert_false(rc, "test_chunked_content_length_error failed");
+	ztest_false(rc, "test_chunked_content_length_error failed");
 
 	rc = test_header_cr_no_lf_error(HTTP_REQUEST);
 
 	/**TESTPOINT: Check test_header_cr_no_lf_error*/
-	zassert_false(rc, "test_header_cr_no_lf_error failed");
+	ztest_false(rc, "test_header_cr_no_lf_error failed");
 
 	rc = test_invalid_header_field_token_error(HTTP_REQUEST);
 
 	/**TESTPOINT: Check test_invalid_header_field_token_error*/
-	zassert_false(rc, "test_invalid_header_field_token_error failed");
+	ztest_false(rc, "test_invalid_header_field_token_error failed");
 
 	rc = test_invalid_header_field_content_error(HTTP_REQUEST);
 
 	/**TESTPOINT: Check test_invalid_header_field_content_error*/
-	zassert_false(rc, "test_invalid_header_field_content_error failed");
+	ztest_false(rc, "test_invalid_header_field_content_error failed");
 
 	rc = test_double_content_length_error(HTTP_RESPONSE);
 
 	/**TESTPOINT: Check test_double_content_length_error*/
-	zassert_false(rc, "test_double_content_length_error failed");
+	ztest_false(rc, "test_double_content_length_error failed");
 
 	rc = test_chunked_content_length_error(HTTP_RESPONSE);
 
 	/**TESTPOINT: Check test_chunked_content_length_error*/
-	zassert_false(rc, "test_chunked_content_length_error failed");
+	ztest_false(rc, "test_chunked_content_length_error failed");
 
 	rc = test_header_cr_no_lf_error(HTTP_RESPONSE);
 
 	/**TESTPOINT: Check test_header_cr_no_lf_error*/
-	zassert_false(rc, "test_header_cr_no_lf_error failed");
+	ztest_false(rc, "test_header_cr_no_lf_error failed");
 
 	rc = test_invalid_header_field_token_error(HTTP_RESPONSE);
 
 	/**TESTPOINT: Check test_invalid_header_field_token_error*/
-	zassert_false(rc, "test_invalid_header_field_token_error failed");
+	ztest_false(rc, "test_invalid_header_field_token_error failed");
 
 	rc = test_invalid_header_field_content_error(HTTP_RESPONSE);
 
 	/**TESTPOINT: Check test_invalid_header_field_content_error*/
-	zassert_false(rc, "test_invalid_header_field_content_error failed");
+	ztest_false(rc, "test_invalid_header_field_content_error failed");
 }
 
 void test_main(void)

--- a/tests/net/lib/mqtt_packet/src/mqtt_packet.c
+++ b/tests/net/lib/mqtt_packet/src/mqtt_packet.c
@@ -671,11 +671,11 @@ static int eval_msg_connect(struct mqtt_test *mqtt_test)
 	rc = connect_request_encode(&client, &buf);
 
 	/**TESTPOINTS: Check connect_request_encode functions*/
-	zassert_false(rc, "connect_request_encode failed");
+	ztest_false(rc, "connect_request_encode failed");
 
 	rc = eval_buffers(&buf, mqtt_test->expected, mqtt_test->expected_len);
 
-	zassert_false(rc, "eval_buffers failed");
+	ztest_false(rc, "eval_buffers failed");
 
 	return TC_PASS;
 }
@@ -691,11 +691,11 @@ static int eval_msg_disconnect(struct mqtt_test *mqtt_test)
 	rc = disconnect_encode(&buf);
 
 	/**TESTPOINTS: Check disconnect_encode functions*/
-	zassert_false(rc, "disconnect_encode failed");
+	ztest_false(rc, "disconnect_encode failed");
 
 	rc = eval_buffers(&buf, mqtt_test->expected, mqtt_test->expected_len);
 
-	zassert_false(rc, "eval_buffers failed");
+	ztest_false(rc, "eval_buffers failed");
 
 	return TC_PASS;
 }
@@ -723,38 +723,38 @@ static int eval_msg_publish(struct mqtt_test *mqtt_test)
 	buf.end += param->message.payload.len;
 
 	/**TESTPOINT: Check publish_encode function*/
-	zassert_false(rc, "publish_encode failed");
+	ztest_false(rc, "publish_encode failed");
 
 	rc = eval_buffers(&buf, mqtt_test->expected, mqtt_test->expected_len);
 
-	zassert_false(rc, "eval_buffers failed");
+	ztest_false(rc, "eval_buffers failed");
 
 	rc = fixed_header_decode(&buf, &type_and_flags, &length);
 
-	zassert_false(rc, "fixed_header_decode failed");
+	ztest_false(rc, "fixed_header_decode failed");
 
 	rc = publish_decode(type_and_flags, length, &buf, &dec_param);
 
 	/**TESTPOINT: Check publish_decode function*/
-	zassert_false(rc, "publish_decode failed");
+	ztest_false(rc, "publish_decode failed");
 
-	zassert_equal(dec_param.message_id, param->message_id,
+	ztest_equal(dec_param.message_id, param->message_id,
 		      "message_id error");
-	zassert_equal(dec_param.dup_flag, param->dup_flag,
+	ztest_equal(dec_param.dup_flag, param->dup_flag,
 		      "dup flag error");
-	zassert_equal(dec_param.retain_flag, param->retain_flag,
+	ztest_equal(dec_param.retain_flag, param->retain_flag,
 		      "retain flag error");
-	zassert_equal(dec_param.message.topic.qos, param->message.topic.qos,
+	ztest_equal(dec_param.message.topic.qos, param->message.topic.qos,
 		      "topic qos error");
-	zassert_equal(dec_param.message.topic.topic.size,
+	ztest_equal(dec_param.message.topic.topic.size,
 		      param->message.topic.topic.size,
 		      "topic len error");
 	if (memcmp(dec_param.message.topic.topic.utf8,
 		   param->message.topic.topic.utf8,
 		   dec_param.message.topic.topic.size) != 0) {
-		zassert_unreachable("topic content error");
+		ztest_unreachable("topic content error");
 	}
-	zassert_equal(dec_param.message.payload.len,
+	ztest_equal(dec_param.message.payload.len,
 		      param->message.payload.len,
 		      "payload len error");
 
@@ -774,7 +774,7 @@ static int eval_msg_subscribe(struct mqtt_test *mqtt_test)
 	rc = subscribe_encode(param, &buf);
 
 	/**TESTPOINT: Check subscribe_encode function*/
-	zassert_false(rc, "subscribe_encode failed");
+	ztest_false(rc, "subscribe_encode failed");
 
 	return eval_buffers(&buf, mqtt_test->expected, mqtt_test->expected_len);
 }
@@ -797,21 +797,21 @@ static int eval_msg_suback(struct mqtt_test *mqtt_test)
 
 	rc = fixed_header_decode(&buf, &type_and_flags, &length);
 
-	zassert_false(rc, "fixed_header_decode failed");
+	ztest_false(rc, "fixed_header_decode failed");
 
 	rc = subscribe_ack_decode(&buf, &dec_param);
 
 	/**TESTPOINT: Check subscribe_ack_decode function*/
-	zassert_false(rc, "subscribe_ack_decode failed");
+	ztest_false(rc, "subscribe_ack_decode failed");
 
-	zassert_equal(dec_param.message_id, param->message_id,
+	ztest_equal(dec_param.message_id, param->message_id,
 		      "packet identifier error");
-	zassert_equal(dec_param.return_codes.len,
+	ztest_equal(dec_param.return_codes.len,
 		      param->return_codes.len,
 		      "topic count error");
 	if (memcmp(dec_param.return_codes.data, param->return_codes.data,
 		   dec_param.return_codes.len) != 0) {
-		zassert_unreachable("subscribe result error");
+		ztest_unreachable("subscribe result error");
 	}
 
 	return TC_PASS;
@@ -828,11 +828,11 @@ static int eval_msg_pingreq(struct mqtt_test *mqtt_test)
 	rc = ping_request_encode(&buf);
 
 	/**TESTPOINTS: Check eval_msg_pingreq functions*/
-	zassert_false(rc, "ping_request_encode failed");
+	ztest_false(rc, "ping_request_encode failed");
 
 	rc = eval_buffers(&buf, mqtt_test->expected, mqtt_test->expected_len);
 
-	zassert_false(rc, "eval_buffers failed");
+	ztest_false(rc, "eval_buffers failed");
 
 	return TC_PASS;
 }
@@ -855,21 +855,21 @@ static int eval_msg_puback(struct mqtt_test *mqtt_test)
 	rc = publish_ack_encode(param, &buf);
 
 	/**TESTPOINTS: Check publish_ack_encode functions*/
-	zassert_false(rc, "publish_ack_encode failed");
+	ztest_false(rc, "publish_ack_encode failed");
 
 	rc = eval_buffers(&buf, mqtt_test->expected, mqtt_test->expected_len);
 
-	zassert_false(rc, "eval_buffers failed");
+	ztest_false(rc, "eval_buffers failed");
 
 	rc = fixed_header_decode(&buf, &type_and_flags, &length);
 
-	zassert_false(rc, "fixed_header_decode failed");
+	ztest_false(rc, "fixed_header_decode failed");
 
 	rc = publish_ack_decode(&buf, &dec_param);
 
-	zassert_false(rc, "publish_ack_decode failed");
+	ztest_false(rc, "publish_ack_decode failed");
 
-	zassert_equal(dec_param.message_id, param->message_id,
+	ztest_equal(dec_param.message_id, param->message_id,
 		      "packet identifier error");
 
 	return TC_PASS;
@@ -893,21 +893,21 @@ static int eval_msg_pubcomp(struct mqtt_test *mqtt_test)
 	rc = publish_complete_encode(param, &buf);
 
 	/**TESTPOINTS: Check publish_complete_encode functions*/
-	zassert_false(rc, "publish_complete_encode failed");
+	ztest_false(rc, "publish_complete_encode failed");
 
 	rc = eval_buffers(&buf, mqtt_test->expected, mqtt_test->expected_len);
 
-	zassert_false(rc, "eval_buffers failed");
+	ztest_false(rc, "eval_buffers failed");
 
 	rc = fixed_header_decode(&buf, &type_and_flags, &length);
 
-	zassert_false(rc, "fixed_header_decode failed");
+	ztest_false(rc, "fixed_header_decode failed");
 
 	rc = publish_complete_decode(&buf, &dec_param);
 
-	zassert_false(rc, "publish_complete_decode failed");
+	ztest_false(rc, "publish_complete_decode failed");
 
-	zassert_equal(dec_param.message_id, param->message_id,
+	ztest_equal(dec_param.message_id, param->message_id,
 		      "packet identifier error");
 
 	return TC_PASS;
@@ -931,21 +931,21 @@ static int eval_msg_pubrec(struct mqtt_test *mqtt_test)
 	rc = publish_receive_encode(param, &buf);
 
 	/**TESTPOINTS: Check publish_receive_encode functions*/
-	zassert_false(rc, "publish_receive_encode failed");
+	ztest_false(rc, "publish_receive_encode failed");
 
 	rc = eval_buffers(&buf, mqtt_test->expected, mqtt_test->expected_len);
 
-	zassert_false(rc, "eval_buffers failed");
+	ztest_false(rc, "eval_buffers failed");
 
 	rc = fixed_header_decode(&buf, &type_and_flags, &length);
 
-	zassert_false(rc, "fixed_header_decode failed");
+	ztest_false(rc, "fixed_header_decode failed");
 
 	rc = publish_receive_decode(&buf, &dec_param);
 
-	zassert_false(rc, "publish_receive_decode failed");
+	ztest_false(rc, "publish_receive_decode failed");
 
-	zassert_equal(dec_param.message_id, param->message_id,
+	ztest_equal(dec_param.message_id, param->message_id,
 		      "packet identifier error");
 
 	return TC_PASS;
@@ -969,21 +969,21 @@ static int eval_msg_pubrel(struct mqtt_test *mqtt_test)
 	rc = publish_release_encode(param, &buf);
 
 	/**TESTPOINTS: Check publish_release_encode functions*/
-	zassert_false(rc, "publish_release_encode failed");
+	ztest_false(rc, "publish_release_encode failed");
 
 	rc = eval_buffers(&buf, mqtt_test->expected, mqtt_test->expected_len);
 
-	zassert_false(rc, "eval_buffers failed");
+	ztest_false(rc, "eval_buffers failed");
 
 	rc = fixed_header_decode(&buf, &type_and_flags, &length);
 
-	zassert_false(rc, "fixed_header_decode failed");
+	ztest_false(rc, "fixed_header_decode failed");
 
 	rc = publish_release_decode(&buf, &dec_param);
 
-	zassert_false(rc, "publish_release_decode failed");
+	ztest_false(rc, "publish_release_decode failed");
 
-	zassert_equal(dec_param.message_id, param->message_id,
+	ztest_equal(dec_param.message_id, param->message_id,
 		      "packet identifier error");
 
 	return TC_PASS;
@@ -1006,13 +1006,13 @@ static int eval_msg_unsuback(struct mqtt_test *mqtt_test)
 
 	rc = fixed_header_decode(&buf, &type_and_flags, &length);
 
-	zassert_false(rc, "fixed_header_decode failed");
+	ztest_false(rc, "fixed_header_decode failed");
 
 	rc = unsubscribe_ack_decode(&buf, &dec_param);
 
-	zassert_false(rc, "unsubscribe_ack_decode failed");
+	ztest_false(rc, "unsubscribe_ack_decode failed");
 
-	zassert_equal(dec_param.message_id, param->message_id,
+	ztest_equal(dec_param.message_id, param->message_id,
 		      "packet identifier error");
 
 	return TC_PASS;
@@ -1045,7 +1045,7 @@ void test_mqtt_packet(void)
 			test->test_name);
 
 		/**TESTPOINT: Check eval_fcn*/
-		zassert_false(rc, "mqtt_packet test error");
+		ztest_false(rc, "mqtt_packet test error");
 
 		i++;
 	} while (1);

--- a/tests/net/lib/mqtt_publisher/src/test_mqtt_publish.c
+++ b/tests/net/lib/mqtt_publisher/src/test_mqtt_publish.c
@@ -294,22 +294,22 @@ static int test_disconnect(void)
 
 void test_mqtt_connect(void)
 {
-	zassert_true(test_connect() == TC_PASS, NULL);
+	ztest_true(test_connect() == TC_PASS, NULL);
 }
 
 void test_mqtt_pingreq(void)
 {
-	zassert_true(test_pingreq() == TC_PASS, NULL);
+	ztest_true(test_pingreq() == TC_PASS, NULL);
 }
 
 void test_mqtt_publish(void)
 {
-	zassert_true(test_publish(MQTT_QOS_0_AT_MOST_ONCE) == TC_PASS, NULL);
-	zassert_true(test_publish(MQTT_QOS_1_AT_LEAST_ONCE) == TC_PASS, NULL);
-	zassert_true(test_publish(MQTT_QOS_2_EXACTLY_ONCE) == TC_PASS, NULL);
+	ztest_true(test_publish(MQTT_QOS_0_AT_MOST_ONCE) == TC_PASS, NULL);
+	ztest_true(test_publish(MQTT_QOS_1_AT_LEAST_ONCE) == TC_PASS, NULL);
+	ztest_true(test_publish(MQTT_QOS_2_EXACTLY_ONCE) == TC_PASS, NULL);
 }
 
 void test_mqtt_disconnect(void)
 {
-	zassert_true(test_disconnect() == TC_PASS, NULL);
+	ztest_true(test_disconnect() == TC_PASS, NULL);
 }

--- a/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
+++ b/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
@@ -423,32 +423,32 @@ static int test_disconnect(void)
 
 void test_mqtt_connect(void)
 {
-	zassert_true(test_connect() == TC_PASS, NULL);
+	ztest_true(test_connect() == TC_PASS, NULL);
 }
 
 void test_mqtt_subscribe(void)
 {
-	zassert_true(test_subscribe() == TC_PASS, NULL);
+	ztest_true(test_subscribe() == TC_PASS, NULL);
 }
 
 void test_mqtt_publish_short(void)
 {
 	payload = payload_short;
-	zassert_true(test_publish(MQTT_QOS_0_AT_MOST_ONCE) == TC_PASS, NULL);
+	ztest_true(test_publish(MQTT_QOS_0_AT_MOST_ONCE) == TC_PASS, NULL);
 }
 
 void test_mqtt_publish_long(void)
 {
 	payload = payload_long;
-	zassert_true(test_publish(MQTT_QOS_1_AT_LEAST_ONCE) == TC_PASS, NULL);
+	ztest_true(test_publish(MQTT_QOS_1_AT_LEAST_ONCE) == TC_PASS, NULL);
 }
 
 void test_mqtt_unsubscribe(void)
 {
-	zassert_true(test_unsubscribe() == TC_PASS, NULL);
+	ztest_true(test_unsubscribe() == TC_PASS, NULL);
 }
 
 void test_mqtt_disconnect(void)
 {
-	zassert_true(test_disconnect() == TC_PASS, NULL);
+	ztest_true(test_disconnect() == TC_PASS, NULL);
 }

--- a/tests/net/lib/mqtt_subscriber/src/test_mqtt_subscribe.c
+++ b/tests/net/lib/mqtt_subscriber/src/test_mqtt_subscribe.c
@@ -302,20 +302,20 @@ static int test_disconnect(void)
 
 void test_mqtt_connect(void)
 {
-	zassert_true(test_connect() == TC_PASS, NULL);
+	ztest_true(test_connect() == TC_PASS, NULL);
 }
 
 void test_mqtt_subscribe(void)
 {
-	zassert_true(test_subscribe() == TC_PASS, NULL);
+	ztest_true(test_subscribe() == TC_PASS, NULL);
 }
 
 void test_mqtt_unsubscribe(void)
 {
-	zassert_true(test_unsubscribe() == TC_PASS, NULL);
+	ztest_true(test_unsubscribe() == TC_PASS, NULL);
 }
 
 void test_mqtt_disconnect(void)
 {
-	zassert_true(test_disconnect() == TC_PASS, NULL);
+	ztest_true(test_disconnect() == TC_PASS, NULL);
 }

--- a/tests/net/lib/tls_credentials/src/main.c
+++ b/tests/net/lib/tls_credentials/src/main.c
@@ -28,7 +28,7 @@ static void test_credential_add(void)
 	for (i = 0; i < CONFIG_TLS_MAX_CREDENTIALS_NUMBER - 2; i++) {
 		ret = tls_credential_add(i, TLS_CREDENTIAL_CA_CERTIFICATE,
 					 test_ca_cert, sizeof(test_ca_cert));
-		zassert_equal(ret, 0, "Failed to add credential %d %d", i);
+		ztest_equal(ret, 0, "Failed to add credential %d %d", i);
 	}
 
 	/* Function should allow to add credentials of different types
@@ -36,24 +36,24 @@ static void test_credential_add(void)
 	 */
 	ret = tls_credential_add(common_tag, TLS_CREDENTIAL_SERVER_CERTIFICATE,
 				 test_server_cert, sizeof(test_server_cert));
-	zassert_equal(ret, 0, "Failed to add credential %d %d",
+	ztest_equal(ret, 0, "Failed to add credential %d %d",
 		      common_tag, TLS_CREDENTIAL_SERVER_CERTIFICATE);
 
 	ret = tls_credential_add(common_tag, TLS_CREDENTIAL_PRIVATE_KEY,
 				 test_server_key, sizeof(test_server_key));
-	zassert_equal(ret, 0, "Failed to add credential %d %d",
+	ztest_equal(ret, 0, "Failed to add credential %d %d",
 		      common_tag, TLS_CREDENTIAL_PRIVATE_KEY);
 
 	/* Try to register another credential - should not have memory for that
 	 */
 	ret = tls_credential_add(unused_tag, TLS_CREDENTIAL_CA_CERTIFICATE,
 				 test_ca_cert, sizeof(test_ca_cert));
-	zassert_equal(ret, -ENOMEM, "Should have failed with ENOMEM");
+	ztest_equal(ret, -ENOMEM, "Should have failed with ENOMEM");
 
 	/* Try to re-register with already registered tag and type */
 	ret = tls_credential_add(common_tag, TLS_CREDENTIAL_PRIVATE_KEY,
 				 test_server_key, sizeof(test_server_key));
-	zassert_equal(ret, -EEXIST, "Should have failed with EEXIST");
+	ztest_equal(ret, -EEXIST, "Should have failed with EEXIST");
 }
 
 /**
@@ -72,24 +72,24 @@ static void test_credential_get(void)
 	credlen = sizeof(cred);
 	ret = tls_credential_get(common_tag, TLS_CREDENTIAL_PRIVATE_KEY,
 				 cred, &credlen);
-	zassert_equal(ret, 0, "Failed to read credential %d %d",
+	ztest_equal(ret, 0, "Failed to read credential %d %d",
 		      0, TLS_CREDENTIAL_CA_CERTIFICATE);
 	ret = strcmp(cred, test_server_key);
-	zassert_equal(ret, 0, "Invalid credential content");
-	zassert_equal(credlen, sizeof(test_server_key),
+	ztest_equal(ret, 0, "Invalid credential content");
+	ztest_equal(credlen, sizeof(test_server_key),
 		      "Invalid credential length");
 
 	/* Try to read non-existing credentials */
 	credlen = sizeof(cred);
 	ret = tls_credential_get(invalid_tag, TLS_CREDENTIAL_PSK,
 				 cred, &credlen);
-	zassert_equal(ret, -ENOENT, "Should have failed with ENOENT");
+	ztest_equal(ret, -ENOENT, "Should have failed with ENOENT");
 
 	/* Try to read with too small buffer */
 	credlen = sizeof(test_server_cert) - 1;
 	ret = tls_credential_get(common_tag, TLS_CREDENTIAL_SERVER_CERTIFICATE,
 				 cred, &credlen);
-	zassert_equal(ret, -EFBIG, "Should have failed with EFBIG");
+	ztest_equal(ret, -EFBIG, "Should have failed with EFBIG");
 }
 
 /**
@@ -103,14 +103,14 @@ static void test_credential_internal_iterate(void)
 
 	/* Non-existing credential should return NULL */
 	key = credential_next_get(invalid_tag, NULL);
-	zassert_is_null(key, "Should have return NULL for unknown credential");
+	ztest_is_null(key, "Should have return NULL for unknown credential");
 
 	/* Iterate over credentials with the same tag */
 	cert = credential_next_get(common_tag, NULL);
-	zassert_not_null(cert, "Should have find a credential");
+	ztest_not_null(cert, "Should have find a credential");
 
 	key = credential_next_get(common_tag, cert);
-	zassert_not_null(key, "Should have find a credential");
+	ztest_not_null(key, "Should have find a credential");
 
 	if (cert->type == TLS_CREDENTIAL_PRIVATE_KEY) {
 		/* Function does not guarantee order of reads,
@@ -121,22 +121,22 @@ static void test_credential_internal_iterate(void)
 		cert = temp;
 	}
 
-	zassert_equal(cert->type, TLS_CREDENTIAL_SERVER_CERTIFICATE,
+	ztest_equal(cert->type, TLS_CREDENTIAL_SERVER_CERTIFICATE,
 		      "Invalid type for cert");
-	zassert_equal(cert->tag, common_tag, "Invalid tag for cert");
-	zassert_equal_ptr(cert->buf, test_server_cert, "Invalid cert content");
-	zassert_equal(cert->len, sizeof(test_server_cert),
+	ztest_equal(cert->tag, common_tag, "Invalid tag for cert");
+	ztest_equal_ptr(cert->buf, test_server_cert, "Invalid cert content");
+	ztest_equal(cert->len, sizeof(test_server_cert),
 		      "Invalid cert length");
 
-	zassert_equal(key->type, TLS_CREDENTIAL_PRIVATE_KEY,
+	ztest_equal(key->type, TLS_CREDENTIAL_PRIVATE_KEY,
 		      "Invalid type for key");
-	zassert_equal(key->tag, common_tag, "Invalid tag for key");
-	zassert_equal_ptr(key->buf, test_server_key, "Invalid key content");
-	zassert_equal(key->len, sizeof(test_server_key), "Invalid key length");
+	ztest_equal(key->tag, common_tag, "Invalid tag for key");
+	ztest_equal_ptr(key->buf, test_server_key, "Invalid key content");
+	ztest_equal(key->len, sizeof(test_server_key), "Invalid key length");
 
 	/* Iteration after getting last credential should return NULL */
 	key = credential_next_get(common_tag, key);
-	zassert_is_null(key, "Should have return NULL after last credential");
+	ztest_is_null(key, "Should have return NULL after last credential");
 }
 
 /**
@@ -152,16 +152,16 @@ static void test_credential_delete(void)
 
 	/* Should fail if when trying to remove non-existing credential. */
 	ret = tls_credential_delete(invalid_tag, TLS_CREDENTIAL_CA_CERTIFICATE);
-	zassert_equal(ret, -ENOENT, "Should have failed with ENOENT");
+	ztest_equal(ret, -ENOENT, "Should have failed with ENOENT");
 
 	/* Should remove existing credential. */
 	ret = tls_credential_delete(common_tag, TLS_CREDENTIAL_PRIVATE_KEY);
-	zassert_equal(ret, 0, "Failed to delete credential %d %d",
+	ztest_equal(ret, 0, "Failed to delete credential %d %d",
 		      common_tag, TLS_CREDENTIAL_PRIVATE_KEY);
 
 	ret = tls_credential_get(common_tag, TLS_CREDENTIAL_PRIVATE_KEY,
 				 cred, &credlen);
-	zassert_equal(ret, -ENOENT, "Should have failed with ENOENT");
+	ztest_equal(ret, -ENOENT, "Should have failed with ENOENT");
 }
 
 void test_main(void)

--- a/tests/net/mgmt/src/mgmt.c
+++ b/tests/net/mgmt/src/mgmt.c
@@ -99,7 +99,7 @@ void test_requesting_nm(void)
 
 	TC_PRINT("- Request Net MGMT\n");
 
-	zassert_false(net_mgmt(TEST_MGMT_REQUEST, NULL, &data, sizeof(data)),
+	ztest_false(net_mgmt(TEST_MGMT_REQUEST, NULL, &data, sizeof(data)),
 		      "Requesting Net MGMT failed");
 }
 
@@ -171,8 +171,8 @@ static int sending_event(u32_t times, bool receiver, bool info)
 		TC_PRINT("\tReceived 0x%08X %u times\n",
 			 rx_event, rx_calls);
 
-		zassert_equal(rx_event, event2throw, "rx_event check failed");
-		zassert_equal(rx_calls, times, "rx_calls check failed");
+		ztest_equal(rx_event, event2throw, "rx_event check failed");
+		ztest_equal(rx_calls, times, "rx_calls check failed");
 
 		net_mgmt_del_event_callback(&rx_cb);
 		rx_event = rx_calls = 0U;
@@ -261,12 +261,12 @@ static int test_core_event(u32_t event, bool (*func)(void))
 
 	net_mgmt_add_event_callback(&rx_cb);
 
-	zassert_true(func(), "func() check failed");
+	ztest_true(func(), "func() check failed");
 
 	k_yield();
 
-	zassert_true(rx_calls > 0 && rx_calls != -1, "rx_calls empty");
-	zassert_equal(rx_event, event, "rx_event check failed, "
+	ztest_true(rx_calls > 0 && rx_calls != -1, "rx_calls empty");
+	ztest_equal(rx_event, event, "rx_event check failed, "
 		      "0x%08x vs 0x%08x", rx_event, event);
 
 	net_mgmt_del_event_callback(&rx_cb);
@@ -302,40 +302,40 @@ void test_mgmt(void)
 
 	initialize_event_tests();
 
-	zassert_false(test_sending_event(1, false),
+	ztest_false(test_sending_event(1, false),
 		      "test_sending_event failed");
 
-	zassert_false(test_sending_event(2, false),
+	ztest_false(test_sending_event(2, false),
 		      "test_sending_event failed");
 
-	zassert_false(test_sending_event(1, true),
+	ztest_false(test_sending_event(1, true),
 		      "test_sending_event failed");
 
-	zassert_false(test_sending_event(2, true),
+	ztest_false(test_sending_event(2, true),
 		      "test_sending_event failed");
 
-	zassert_false(test_sending_event_info(1, false),
+	ztest_false(test_sending_event_info(1, false),
 		      "test_sending_event failed");
 
-	zassert_false(test_sending_event_info(2, false),
+	ztest_false(test_sending_event_info(2, false),
 		      "test_sending_event failed");
 
-	zassert_false(test_sending_event_info(1, true),
+	ztest_false(test_sending_event_info(1, true),
 		      "test_sending_event failed");
 
-	zassert_false(test_sending_event_info(2, true),
+	ztest_false(test_sending_event_info(2, true),
 		      "test_sending_event failed");
 
-	zassert_false(test_core_event(NET_EVENT_IPV6_ADDR_ADD, _iface_ip6_add),
+	ztest_false(test_core_event(NET_EVENT_IPV6_ADDR_ADD, _iface_ip6_add),
 		      "test_core_event failed");
 
-	zassert_false(test_core_event(NET_EVENT_IPV6_ADDR_DEL, _iface_ip6_del),
+	ztest_false(test_core_event(NET_EVENT_IPV6_ADDR_DEL, _iface_ip6_del),
 		      "test_core_event failed");
 
-	zassert_false(test_synchronous_event_listener(2, false),
+	ztest_false(test_synchronous_event_listener(2, false),
 		      "test_synchronous_event_listener failed");
 
-	zassert_false(test_synchronous_event_listener(2, true),
+	ztest_false(test_synchronous_event_listener(2, true),
 		      "test_synchronous_event_listener failed");
 }
 

--- a/tests/net/neighbor/src/main.c
+++ b/tests/net/neighbor/src/main.c
@@ -77,7 +77,7 @@ static void test_neighbor(void)
 	struct net_if *iface2 = INT_TO_POINTER(2);
 	int ret, i;
 
-	zassert_true(CONFIG_NET_IPV6_MAX_NEIGHBORS == (ARRAY_SIZE(addrs) - 2),
+	ztest_true(CONFIG_NET_IPV6_MAX_NEIGHBORS == (ARRAY_SIZE(addrs) - 2),
 		     "There should be exactly %d valid entries in addrs array\n",
 		     CONFIG_NET_IPV6_MAX_NEIGHBORS + 1);
 
@@ -85,10 +85,10 @@ static void test_neighbor(void)
 	 * to it. Only the first one should succeed.
 	 */
 	nbr = net_nbr_get(&net_test_neighbor.table);
-	zassert_not_null(nbr, "Cannot get neighbor from table %p\n",
+	ztest_not_null(nbr, "Cannot get neighbor from table %p\n",
 			 &net_test_neighbor.table);
 
-	zassert_false(nbr->ref != 1, "Invalid ref count %d\n", nbr->ref);
+	ztest_false(nbr->ref != 1, "Invalid ref count %d\n", nbr->ref);
 
 	lladdr.len = sizeof(struct net_eth_addr);
 
@@ -100,7 +100,7 @@ static void test_neighbor(void)
 		ret = net_nbr_link(nbr, iface1, &lladdr);
 
 		/* One neighbor can have only one lladdr */
-		zassert_false(i == 0 && ret < 0, "Cannot add %s to nbr cache (%d)\n",
+		ztest_false(i == 0 && ret < 0, "Cannot add %s to nbr cache (%d)\n",
 			      net_sprint_ll_addr(lladdr.addr, lladdr.len),
 			      ret);
 
@@ -113,7 +113,7 @@ static void test_neighbor(void)
 
 	lladdr.addr = addrs[0]->addr;
 	nbr = net_nbr_lookup(&net_test_neighbor.table, iface1, &lladdr);
-	zassert_true(nbr->idx == 0, "Wrong index %d should be %d\n", nbr->idx, 0);
+	ztest_true(nbr->idx == 0, "Wrong index %d should be %d\n", nbr->idx, 0);
 
 	for (i = 0; i < 2; i++) {
 		eth_addr = addrs[i];
@@ -121,7 +121,7 @@ static void test_neighbor(void)
 		lladdr.addr = eth_addr->addr;
 
 		ret = net_nbr_unlink(nbr, &lladdr);
-		zassert_false(i == 0 && ret < 0, "Cannot add %s to nbr cache (%d)\n",
+		ztest_false(i == 0 && ret < 0, "Cannot add %s to nbr cache (%d)\n",
 			      net_sprint_ll_addr(lladdr.addr, lladdr.len),
 			      ret);
 		if (!ret) {
@@ -132,7 +132,7 @@ static void test_neighbor(void)
 	}
 
 	net_nbr_unref(nbr);
-	zassert_false(nbr->ref != 0, "nbr still referenced, ref %d\n",
+	ztest_false(nbr->ref != 0, "nbr still referenced, ref %d\n",
 		      nbr->ref);
 
 	/* Then adding multiple neighbors.
@@ -146,11 +146,11 @@ static void test_neighbor(void)
 				/* Ok, last entry will not fit cache */
 				break;
 			}
-			zassert_true(1, "[%d] Cannot get neighbor from table %p\n",
+			ztest_true(1, "[%d] Cannot get neighbor from table %p\n",
 				     i, &net_test_neighbor.table);
 		}
 
-		zassert_true(nbr->ref == 1, "[%d] Invalid ref count %d\n", i, nbr->ref);
+		ztest_true(nbr->ref == 1, "[%d] Invalid ref count %d\n", i, nbr->ref);
 		nbrs[i] = nbr;
 
 		eth_addr = addrs[i];
@@ -158,7 +158,7 @@ static void test_neighbor(void)
 		lladdr.addr = eth_addr->addr;
 
 		ret = net_nbr_link(nbr, iface1, &lladdr);
-		zassert_false(ret < 0, "Cannot add %s to nbr cache (%d)\n",
+		ztest_false(ret < 0, "Cannot add %s to nbr cache (%d)\n",
 			      net_sprint_ll_addr(lladdr.addr, lladdr.len),
 			      ret);
 		printk("Adding %s\n", net_sprint_ll_addr(eth_addr->addr,
@@ -168,7 +168,7 @@ static void test_neighbor(void)
 	for (i = 0; i < ARRAY_SIZE(addrs) - 2; i++) {
 		lladdr.addr = addrs[i]->addr;
 		nbr = net_nbr_lookup(&net_test_neighbor.table, iface1, &lladdr);
-		zassert_false(nbr->idx != i, "Wrong index %d should be %d\n", nbr->idx, i);
+		ztest_false(nbr->idx != i, "Wrong index %d should be %d\n", nbr->idx, i);
 	}
 
 	for (i = 0; i < ARRAY_SIZE(addrs); i++) {
@@ -181,14 +181,14 @@ static void test_neighbor(void)
 		}
 
 		ret = net_nbr_unlink(nbr, &lladdr);
-		zassert_false(ret < 0, "Cannot del %s from nbr cache (%d)\n",
+		ztest_false(ret < 0, "Cannot del %s from nbr cache (%d)\n",
 			      net_sprint_ll_addr(lladdr.addr, lladdr.len),
 			      ret);
 		printk("Deleting %s\n", net_sprint_ll_addr(eth_addr->addr,
 							   sizeof(struct net_eth_addr)));
 
 		net_nbr_unref(nbr);
-		zassert_false(nbr->ref != 0, "nbr still referenced, ref %d\n",
+		ztest_false(nbr->ref != 0, "nbr still referenced, ref %d\n",
 			      nbr->ref);
 	}
 
@@ -205,11 +205,11 @@ static void test_neighbor(void)
 				/* Ok, last entry will not fit cache */
 				break;
 			}
-			zassert_true(1, "[%d] Cannot get neighbor from table %p\n",
+			ztest_true(1, "[%d] Cannot get neighbor from table %p\n",
 				     i, &net_test_neighbor.table);
 		}
 
-		zassert_false(nbr->ref != 1, "[%d] Invalid ref count %d\n", i, nbr->ref);
+		ztest_false(nbr->ref != 1, "[%d] Invalid ref count %d\n", i, nbr->ref);
 		nbrs[i] = nbr;
 
 		eth_addr = addrs[i];
@@ -221,7 +221,7 @@ static void test_neighbor(void)
 		} else {
 			ret = net_nbr_link(nbr, iface2, &lladdr);
 		}
-		zassert_false(ret < 0, "Cannot add %s to nbr cache (%d)\n",
+		ztest_false(ret < 0, "Cannot add %s to nbr cache (%d)\n",
 			      net_sprint_ll_addr(lladdr.addr, lladdr.len),
 			      ret);
 		printk("Adding %s iface %p\n",
@@ -240,12 +240,12 @@ static void test_neighbor(void)
 			nbr = net_nbr_lookup(&net_test_neighbor.table, iface2,
 					     &lladdr);
 		}
-		zassert_false(nbr->idx != i, "Wrong index %d should be %d\n", nbr->idx, i);
+		ztest_false(nbr->idx != i, "Wrong index %d should be %d\n", nbr->idx, i);
 
 		lladdr_ptr = net_nbr_get_lladdr(i);
 		if (memcmp(lladdr_ptr->addr, addrs[i]->addr,
 			   sizeof(struct net_eth_addr))) {
-			zassert_true(1, "Wrong lladdr %s in index %d\n",
+			ztest_true(1, "Wrong lladdr %s in index %d\n",
 				     net_sprint_ll_addr(lladdr_ptr->addr,
 							lladdr_ptr->len),
 				     i);
@@ -266,7 +266,7 @@ static void test_neighbor(void)
 		iface = nbr->iface;
 
 		ret = net_nbr_unlink(nbr, &lladdr);
-		zassert_false(ret < 0, "Cannot del %s from nbr cache (%d)\n",
+		ztest_false(ret < 0, "Cannot del %s from nbr cache (%d)\n",
 			      net_sprint_ll_addr(lladdr.addr, lladdr.len),
 			      ret);
 
@@ -274,21 +274,21 @@ static void test_neighbor(void)
 								    sizeof(struct net_eth_addr)), iface);
 
 		net_nbr_unref(nbr);
-		zassert_false(nbr->ref != 0, "nbr still referenced, ref %d\n", nbr->ref);
+		ztest_false(nbr->ref != 0, "nbr still referenced, ref %d\n", nbr->ref);
 	}
 
-	zassert_false(add_count != remove_count, "Remove count %d does not match add count %d\n",
+	ztest_false(add_count != remove_count, "Remove count %d does not match add count %d\n",
 		      remove_count, add_count);
 
 	net_nbr_clear_table(&net_test_neighbor.table);
 
-	zassert_true(clear_called, "Table clear check failed");
+	ztest_true(clear_called, "Table clear check failed");
 
 	/* The table should be empty now */
 	lladdr.addr = addrs[0]->addr;
 	nbr = net_nbr_lookup(&net_test_neighbor.table, iface1, &lladdr);
 
-	zassert_is_null(nbr, "Some entries still found in nbr cache");
+	ztest_is_null(nbr, "Some entries still found in nbr cache");
 
 	return;
 }

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -110,21 +110,21 @@ static void test_net_pkt_allocate_wo_buffer(void)
 
 	/* How to allocate a packet, with no buffer */
 	pkt = net_pkt_alloc(K_NO_WAIT);
-	zassert_true(pkt != NULL, "Pkt not allocated");
+	ztest_true(pkt != NULL, "Pkt not allocated");
 
 	/* Freeing the packet */
 	net_pkt_unref(pkt);
-	zassert_true(atomic_get(&pkt->atomic_ref) == 0,
+	ztest_true(atomic_get(&pkt->atomic_ref) == 0,
 		     "Pkt not properly unreferenced");
 
 	/* Note that, if you already know the iface to which the packet
 	 * belongs to, you will be able to use net_pkt_alloc_on_iface().
 	 */
 	pkt = net_pkt_alloc_on_iface(eth_if, K_NO_WAIT);
-	zassert_true(pkt != NULL, "Pkt not allocated");
+	ztest_true(pkt != NULL, "Pkt not allocated");
 
 	net_pkt_unref(pkt);
-	zassert_true(atomic_get(&pkt->atomic_ref) == 0,
+	ztest_true(atomic_get(&pkt->atomic_ref) == 0,
 		     "Pkt not properly unreferenced");
 }
 
@@ -138,14 +138,14 @@ static void test_net_pkt_allocate_with_buffer(void)
 	 */
 	pkt = net_pkt_alloc_with_buffer(eth_if, 512,
 					AF_UNSPEC, 0, K_NO_WAIT);
-	zassert_true(pkt != NULL, "Pkt not allocated");
+	ztest_true(pkt != NULL, "Pkt not allocated");
 
 	/* Did we get the requested size? */
-	zassert_true(pkt_is_of_size(pkt, 512), "Pkt size is not right");
+	ztest_true(pkt_is_of_size(pkt, 512), "Pkt size is not right");
 
 	/* Freeing the packet */
 	net_pkt_unref(pkt);
-	zassert_true(atomic_get(&pkt->atomic_ref) == 0,
+	ztest_true(atomic_get(&pkt->atomic_ref) == 0,
 		     "Pkt not properly unreferenced");
 
 	/*
@@ -154,15 +154,15 @@ static void test_net_pkt_allocate_with_buffer(void)
 	 */
 	pkt = net_pkt_alloc_with_buffer(eth_if, 1800,
 					AF_UNSPEC, 0, K_NO_WAIT);
-	zassert_true(pkt != NULL, "Pkt not allocated");
+	ztest_true(pkt != NULL, "Pkt not allocated");
 
-	zassert_false(pkt_is_of_size(pkt, 1800), "Pkt size is not right");
-	zassert_true(pkt_is_of_size(pkt, net_if_get_mtu(eth_if) + L2_HDR_SIZE),
+	ztest_false(pkt_is_of_size(pkt, 1800), "Pkt size is not right");
+	ztest_true(pkt_is_of_size(pkt, net_if_get_mtu(eth_if) + L2_HDR_SIZE),
 		     "Pkt size is not right");
 
 	/* Freeing the packet */
 	net_pkt_unref(pkt);
-	zassert_true(atomic_get(&pkt->atomic_ref) == 0,
+	ztest_true(atomic_get(&pkt->atomic_ref) == 0,
 		     "Pkt not properly unreferenced");
 
 	/*
@@ -170,15 +170,15 @@ static void test_net_pkt_allocate_with_buffer(void)
 	 */
 	pkt = net_pkt_alloc_with_buffer(eth_if, 512, AF_INET,
 					IPPROTO_UDP, K_NO_WAIT);
-	zassert_true(pkt != NULL, "Pkt not allocated");
+	ztest_true(pkt != NULL, "Pkt not allocated");
 
 	/* Because 512 + NET_IPV4UDPH_LEN fits MTU, total must be that one */
-	zassert_true(pkt_is_of_size(pkt, 512 + NET_IPV4UDPH_LEN),
+	ztest_true(pkt_is_of_size(pkt, 512 + NET_IPV4UDPH_LEN),
 		     "Pkt overall size does not match");
 
 	/* Freeing the packet */
 	net_pkt_unref(pkt);
-	zassert_true(atomic_get(&pkt->atomic_ref) == 0,
+	ztest_true(atomic_get(&pkt->atomic_ref) == 0,
 		     "Pkt not properly unreferenced");
 
 	/*
@@ -186,18 +186,18 @@ static void test_net_pkt_allocate_with_buffer(void)
 	 */
 	pkt = net_pkt_alloc_with_buffer(eth_if, 1800, AF_INET,
 					IPPROTO_UDP, K_NO_WAIT);
-	zassert_true(pkt != NULL, "Pkt not allocated");
+	ztest_true(pkt != NULL, "Pkt not allocated");
 
 	/* Because 1800 + NET_IPV4UDPH_LEN won't fit MTU, payload size
 	 * should be MTU
 	 */
-	zassert_true(net_pkt_available_buffer(pkt) ==
+	ztest_true(net_pkt_available_buffer(pkt) ==
 		     net_if_get_mtu(eth_if),
 		     "Payload buf size does not match for ipv4/udp");
 
 	/* Freeing the packet */
 	net_pkt_unref(pkt);
-	zassert_true(atomic_get(&pkt->atomic_ref) == 0,
+	ztest_true(atomic_get(&pkt->atomic_ref) == 0,
 		     "Pkt not properly unreferenced");
 }
 
@@ -214,12 +214,12 @@ static void test_net_pkt_basics_of_rw(void)
 
 	pkt = net_pkt_alloc_with_buffer(eth_if, 512,
 					AF_UNSPEC, 0, K_NO_WAIT);
-	zassert_true(pkt != NULL, "Pkt not allocated");
+	ztest_true(pkt != NULL, "Pkt not allocated");
 
 	/* Once newly allocated with buffer,
 	 * a packet has no data accounted for in its buffer
 	 */
-	zassert_true(net_pkt_get_len(pkt) == 0,
+	ztest_true(net_pkt_get_len(pkt) == 0,
 		     "Pkt initial length should be 0");
 
 	/* This is done through net_buf which can distinguish
@@ -230,16 +230,16 @@ static void test_net_pkt_basics_of_rw(void)
 	 * We write values made of 0s
 	 */
 	ret = net_pkt_write_u8(pkt, 0);
-	zassert_true(ret == 0, "Pkt write failed");
+	ztest_true(ret == 0, "Pkt write failed");
 
 	/* Length should be 1 now */
-	zassert_true(net_pkt_get_len(pkt) == 1, "Pkt length mismatch");
+	ztest_true(net_pkt_get_len(pkt) == 1, "Pkt length mismatch");
 
 	ret = net_pkt_write_be16(pkt, 0);
-	zassert_true(ret == 0, "Pkt write failed");
+	ztest_true(ret == 0, "Pkt write failed");
 
 	/* Length should be 3 now */
-	zassert_true(net_pkt_get_len(pkt) == 3, "Pkt length mismatch");
+	ztest_true(net_pkt_get_len(pkt) == 3, "Pkt length mismatch");
 
 	/* Verify that the data is properly written to net_buf */
 	net_pkt_cursor_backup(pkt, &backup);
@@ -247,47 +247,47 @@ static void test_net_pkt_basics_of_rw(void)
 	net_pkt_set_overwrite(pkt, true);
 	net_pkt_skip(pkt, 1);
 	net_pkt_read_be16(pkt, &value16);
-	zassert_equal(value16, 0, "Invalid value %d read, expected %d",
+	ztest_equal(value16, 0, "Invalid value %d read, expected %d",
 		      value16, 0);
 
 	/* Then write new value, overwriting the old one */
 	net_pkt_cursor_init(pkt);
 	net_pkt_skip(pkt, 1);
 	ret = net_pkt_write_be16(pkt, 42);
-	zassert_true(ret == 0, "Pkt write failed");
+	ztest_true(ret == 0, "Pkt write failed");
 
 	/* And re-read the value again */
 	net_pkt_cursor_init(pkt);
 	net_pkt_skip(pkt, 1);
 	ret = net_pkt_read_be16(pkt, &value16);
-	zassert_true(ret == 0, "Pkt read failed");
-	zassert_equal(value16, 42, "Invalid value %d read, expected %d",
+	ztest_true(ret == 0, "Pkt read failed");
+	ztest_equal(value16, 42, "Invalid value %d read, expected %d",
 		      value16, 42);
 
 	net_pkt_set_overwrite(pkt, false);
 	net_pkt_cursor_restore(pkt, &backup);
 
 	ret = net_pkt_write_be32(pkt, 0);
-	zassert_true(ret == 0, "Pkt write failed");
+	ztest_true(ret == 0, "Pkt write failed");
 
 	/* Length should be 7 now */
-	zassert_true(net_pkt_get_len(pkt) == 7, "Pkt length mismatch");
+	ztest_true(net_pkt_get_len(pkt) == 7, "Pkt length mismatch");
 
 	/* All these writing functions use net_ptk_write(), which works
 	 * this way:
 	 */
 	ret = net_pkt_write(pkt, small_buffer, 9);
-	zassert_true(ret == 0, "Pkt write failed");
+	ztest_true(ret == 0, "Pkt write failed");
 
 	/* Length should be 16 now */
-	zassert_true(net_pkt_get_len(pkt) == 16, "Pkt length mismatch");
+	ztest_true(net_pkt_get_len(pkt) == 16, "Pkt length mismatch");
 
 	/* Now let's say you want to memset some data */
 	ret = net_pkt_memset(pkt, 0, 4);
-	zassert_true(ret == 0, "Pkt memset failed");
+	ztest_true(ret == 0, "Pkt memset failed");
 
 	/* Length should be 20 now */
-	zassert_true(net_pkt_get_len(pkt) == 20, "Pkt length mismatch");
+	ztest_true(net_pkt_get_len(pkt) == 20, "Pkt length mismatch");
 
 	/* So memset affects the length exactly as write does */
 
@@ -297,10 +297,10 @@ static void test_net_pkt_basics_of_rw(void)
 	 * Note: usually you will not have to use that function a lot yourself.
 	 */
 	ret = net_pkt_skip(pkt, 20);
-	zassert_true(ret == 0, "Pkt skip failed");
+	ztest_true(ret == 0, "Pkt skip failed");
 
 	/* Length should be 40 now */
-	zassert_true(net_pkt_get_len(pkt) == 40, "Pkt length mismatch");
+	ztest_true(net_pkt_get_len(pkt) == 40, "Pkt length mismatch");
 
 	/* Again, skip affected the length also, like a write
 	 * But wait a minute: how to get back then, in order to write at
@@ -332,29 +332,29 @@ static void test_net_pkt_basics_of_rw(void)
 	 */
 	net_pkt_set_overwrite(pkt, true);
 
-	zassert_true(net_pkt_is_being_overwritten(pkt),
+	ztest_true(net_pkt_is_being_overwritten(pkt),
 		     "Pkt is not set to overwrite");
 
 	/* Ok so previous skipped position was at offset 20 */
 	ret = net_pkt_skip(pkt, 20);
-	zassert_true(ret == 0, "Pkt skip failed");
+	ztest_true(ret == 0, "Pkt skip failed");
 
 	/* Length should _still_ be 40 */
-	zassert_true(net_pkt_get_len(pkt) == 40, "Pkt length mismatch");
+	ztest_true(net_pkt_get_len(pkt) == 40, "Pkt length mismatch");
 
 	/* And you can write stuff */
 	ret = net_pkt_write_le32(pkt, 0);
-	zassert_true(ret == 0, "Pkt write failed");
+	ztest_true(ret == 0, "Pkt write failed");
 
 	/* Again, length should _still_ be 40 */
-	zassert_true(net_pkt_get_len(pkt) == 40, "Pkt length mismatch");
+	ztest_true(net_pkt_get_len(pkt) == 40, "Pkt length mismatch");
 
 	/* Let's memset the rest */
 	ret = net_pkt_memset(pkt, 0, 16);
-	zassert_true(ret == 0, "Pkt memset failed");
+	ztest_true(ret == 0, "Pkt memset failed");
 
 	/* Again, length should _still_ be 40 */
-	zassert_true(net_pkt_get_len(pkt) == 40, "Pkt length mismatch");
+	ztest_true(net_pkt_get_len(pkt) == 40, "Pkt length mismatch");
 
 	/* We are now back at the end of the existing data in the buffer
 	 * Since overwrite is still on, we should not be able to r/w
@@ -363,7 +363,7 @@ static void test_net_pkt_basics_of_rw(void)
 	 * on existing data in the buffer:
 	 */
 	ret = net_pkt_write_be32(pkt, 0);
-	zassert_true(ret != 0, "Pkt write succeeded where it shouldn't have");
+	ztest_true(ret != 0, "Pkt write succeeded where it shouldn't have");
 
 	/* Logically, in order to be able to add new data in the buffer,
 	 * overwrite should be disabled:
@@ -372,7 +372,7 @@ static void test_net_pkt_basics_of_rw(void)
 
 	/* But it will fail: */
 	ret = net_pkt_write_le32(pkt, 0);
-	zassert_true(ret != 0, "Pkt write succeeded?");
+	ztest_true(ret != 0, "Pkt write succeeded?");
 
 	/* Why is that?
 	 * This is because in case of r/w error: the iterator is invalidated.
@@ -384,7 +384,7 @@ static void test_net_pkt_basics_of_rw(void)
 
 	/* Freeing the packet */
 	net_pkt_unref(pkt);
-	zassert_true(atomic_get(&pkt->atomic_ref) == 0,
+	ztest_true(atomic_get(&pkt->atomic_ref) == 0,
 		     "Pkt not properly unreferenced");
 }
 
@@ -396,7 +396,7 @@ void test_net_pkt_advanced_basics(void)
 
 	pkt = net_pkt_alloc_with_buffer(eth_if, 512,
 					AF_INET, IPPROTO_UDP, K_NO_WAIT);
-	zassert_true(pkt != NULL, "Pkt not allocated");
+	ztest_true(pkt != NULL, "Pkt not allocated");
 
 	pkt_print_cursor(pkt);
 
@@ -409,7 +409,7 @@ void test_net_pkt_advanced_basics(void)
 	 * You could certainly do:
 	 */
 	ret = net_pkt_write(pkt, small_buffer, 20);
-	zassert_true(ret == 0, "Pkt write failed");
+	ztest_true(ret == 0, "Pkt write failed");
 
 	pkt_print_cursor(pkt);
 
@@ -422,7 +422,7 @@ void test_net_pkt_advanced_basics(void)
 	/* And finally go back with overwrite/skip: */
 	net_pkt_set_overwrite(pkt, true);
 	ret = net_pkt_skip(pkt, 20);
-	zassert_true(ret == 0, "Pkt skip failed");
+	ztest_true(ret == 0, "Pkt skip failed");
 	net_pkt_set_overwrite(pkt, false);
 
 	pkt_print_cursor(pkt);
@@ -451,7 +451,7 @@ void test_net_pkt_advanced_basics(void)
 	 * For this, you'll use:
 	 */
 	ret = (int) net_pkt_is_contiguous(pkt, 4);
-	zassert_true(ret == 1, "Pkt contiguity check failed");
+	ztest_true(ret == 1, "Pkt contiguity check failed");
 
 	/* If that's successful you should be able to get the actual
 	 * position in the buffer and cast it to the type you want.
@@ -470,7 +470,7 @@ void test_net_pkt_advanced_basics(void)
 
 	/* Freeing the packet */
 	net_pkt_unref(pkt);
-	zassert_true(atomic_get(&pkt->atomic_ref) == 0,
+	ztest_true(atomic_get(&pkt->atomic_ref) == 0,
 		     "Pkt not properly unreferenced");
 
 	/* Obviously one will very rarely use these 2 last low level functions
@@ -488,7 +488,7 @@ void test_net_pkt_easier_rw_usage(void)
 
 	pkt = net_pkt_alloc_with_buffer(eth_if, 512,
 					AF_INET, IPPROTO_UDP, K_NO_WAIT);
-	zassert_true(pkt != NULL, "Pkt not allocated");
+	ztest_true(pkt != NULL, "Pkt not allocated");
 
 	/* In net core, all goes down in fine to header manipulation.
 	 * Either it's an IP header, UDP, ICMP, TCP one etc...
@@ -512,14 +512,14 @@ void test_net_pkt_easier_rw_usage(void)
 
 		ip_hdr = (struct net_ipv4_hdr *)
 			net_pkt_get_data(pkt, &ip_access);
-		zassert_not_null(ip_hdr, "Accessor failed");
+		ztest_not_null(ip_hdr, "Accessor failed");
 
 		ip_hdr->tos = 0x00;
 
 		ret = net_pkt_set_data(pkt, &ip_access);
-		zassert_true(ret == 0, "Accessor failed");
+		ztest_true(ret == 0, "Accessor failed");
 
-		zassert_true(net_pkt_get_len(pkt) == NET_IPV4H_LEN,
+		ztest_true(net_pkt_get_len(pkt) == NET_IPV4H_LEN,
 			     "Pkt length mismatch");
 	}
 
@@ -530,7 +530,7 @@ void test_net_pkt_easier_rw_usage(void)
 
 	/* Freeing the packet */
 	net_pkt_unref(pkt);
-	zassert_true(atomic_get(&pkt->atomic_ref) == 0,
+	ztest_true(atomic_get(&pkt->atomic_ref) == 0,
 		     "Pkt not properly unreferenced");
 }
 
@@ -580,7 +580,7 @@ void test_net_pkt_copy(void)
 	struct net_pkt *pkt_dst;
 
 	pkt_src = net_pkt_alloc_on_iface(eth_if, K_NO_WAIT);
-	zassert_true(pkt_src != NULL, "Pkt not allocated");
+	ztest_true(pkt_src != NULL, "Pkt not allocated");
 
 	pkt_print_cursor(pkt_src);
 
@@ -590,12 +590,12 @@ void test_net_pkt_copy(void)
 	net_pkt_set_overwrite(pkt_src, true);
 
 	/* There should be some space left */
-	zassert_true(net_pkt_available_buffer(pkt_src) != 0, "No space left?");
+	ztest_true(net_pkt_available_buffer(pkt_src) != 0, "No space left?");
 	/* Length should be 4 */
-	zassert_true(net_pkt_get_len(pkt_src) == 4, "Wrong length");
+	ztest_true(net_pkt_get_len(pkt_src) == 4, "Wrong length");
 
 	/* Actual space left is 12 (in b1, b2 and b4) */
-	zassert_true(net_pkt_available_buffer(pkt_src) == 12,
+	ztest_true(net_pkt_available_buffer(pkt_src) == 12,
 		     "Wrong space left?");
 
 	pkt_print_cursor(pkt_src);
@@ -604,28 +604,28 @@ void test_net_pkt_copy(void)
 	 * This will test net_pkt_copy_new() as it uses it for the buffers
 	 */
 	pkt_dst = net_pkt_clone(pkt_src, K_NO_WAIT);
-	zassert_true(pkt_dst != NULL, "Pkt not clone");
+	ztest_true(pkt_dst != NULL, "Pkt not clone");
 
 	/* Cloning does not take into account left space,
 	 * but only occupied one
 	 */
-	zassert_true(net_pkt_available_buffer(pkt_dst) == 0, "Space left");
-	zassert_true(net_pkt_get_len(pkt_src) == net_pkt_get_len(pkt_dst),
+	ztest_true(net_pkt_available_buffer(pkt_dst) == 0, "Space left");
+	ztest_true(net_pkt_get_len(pkt_src) == net_pkt_get_len(pkt_dst),
 		     "Not same amount?");
 
 	/* It also did not care to copy the net_buf itself, only the content
 	 * so, knowing that the base buffer size is bigger than necessary,
 	 * pkt_dst has only one net_buf
 	 */
-	zassert_true(pkt_dst->buffer->frags == NULL, "Not only one buffer?");
+	ztest_true(pkt_dst->buffer->frags == NULL, "Not only one buffer?");
 
 	/* Freeing the packet */
 	pkt_src->buffer = NULL;
 	net_pkt_unref(pkt_src);
-	zassert_true(atomic_get(&pkt_src->atomic_ref) == 0,
+	ztest_true(atomic_get(&pkt_src->atomic_ref) == 0,
 		     "Pkt not properly unreferenced");
 	net_pkt_unref(pkt_dst);
-	zassert_true(atomic_get(&pkt_dst->atomic_ref) == 0,
+	ztest_true(atomic_get(&pkt_dst->atomic_ref) == 0,
 		     "Pkt not properly unreferenced");
 }
 
@@ -648,23 +648,23 @@ void test_net_pkt_pull(void)
 					      AF_UNSPEC,
 					      0,
 					      K_NO_WAIT);
-	zassert_true(dummy_pkt != NULL, "Pkt not allocated");
+	ztest_true(dummy_pkt != NULL, "Pkt not allocated");
 
-	zassert_true(net_pkt_write(dummy_pkt,
+	ztest_true(net_pkt_write(dummy_pkt,
 				   pkt_data,
 				   PULL_TEST_PKT_DATA_SIZE) == 0,
 		     "Write packet failed");
 
 	net_pkt_cursor_init(dummy_pkt);
 	net_pkt_pull(dummy_pkt, PULL_AMOUNT);
-	zassert_equal(net_pkt_get_len(dummy_pkt),
+	ztest_equal(net_pkt_get_len(dummy_pkt),
 		      PULL_TEST_PKT_DATA_SIZE - PULL_AMOUNT,
 		      "Pull failed to set new size");
-	zassert_true(net_pkt_read(dummy_pkt,
+	ztest_true(net_pkt_read(dummy_pkt,
 				  pkt_data_readback,
 				  PULL_TEST_PKT_DATA_SIZE - PULL_AMOUNT) == 0,
 		     "Read packet failed");
-	zassert_mem_equal(pkt_data_readback,
+	ztest_mem_equal(pkt_data_readback,
 			  &pkt_data[PULL_AMOUNT],
 			  PULL_TEST_PKT_DATA_SIZE - PULL_AMOUNT,
 			  "Packet data changed");
@@ -681,30 +681,30 @@ void test_net_pkt_clone(void)
 
 	pkt = net_pkt_alloc_with_buffer(eth_if, 64,
 					AF_UNSPEC, 0, K_NO_WAIT);
-	zassert_true(pkt != NULL, "Pkt not allocated");
+	ztest_true(pkt != NULL, "Pkt not allocated");
 
 	ret = net_pkt_write(pkt, buf, sizeof(buf));
-	zassert_true(ret == 0, "Pkt write failed");
+	ztest_true(ret == 0, "Pkt write failed");
 
-	zassert_true(net_pkt_get_len(pkt) == sizeof(buf),
+	ztest_true(net_pkt_get_len(pkt) == sizeof(buf),
 		     "Pkt length mismatch");
 
 	net_pkt_cursor_init(pkt);
 	net_pkt_set_overwrite(pkt, true);
 	net_pkt_skip(pkt, 6);
-	zassert_true(sizeof(buf) - 6 == net_pkt_remaining_data(pkt),
+	ztest_true(sizeof(buf) - 6 == net_pkt_remaining_data(pkt),
 		     "Pkt remaining data mismatch");
 
 	cloned_pkt = net_pkt_clone(pkt, K_NO_WAIT);
-	zassert_true(cloned_pkt != NULL, "Pkt not cloned");
+	ztest_true(cloned_pkt != NULL, "Pkt not cloned");
 
-	zassert_true(net_pkt_get_len(cloned_pkt) == sizeof(buf),
+	ztest_true(net_pkt_get_len(cloned_pkt) == sizeof(buf),
 		     "Cloned pkt length mismatch");
 
-	zassert_true(sizeof(buf) - 6 == net_pkt_remaining_data(pkt),
+	ztest_true(sizeof(buf) - 6 == net_pkt_remaining_data(pkt),
 		     "Pkt remaining data mismatch");
 
-	zassert_true(sizeof(buf) - 6 == net_pkt_remaining_data(cloned_pkt),
+	ztest_true(sizeof(buf) - 6 == net_pkt_remaining_data(cloned_pkt),
 		     "Cloned pkt remaining data mismatch");
 
 	net_pkt_unref(pkt);

--- a/tests/net/ppp/driver/src/main.c
+++ b/tests/net/ppp/driver/src/main.c
@@ -209,7 +209,7 @@ static enum net_verdict ppp_l2_recv(struct net_if *iface, struct net_pkt *pkt)
 static void iface_setup(void)
 {
 	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(PPP));
-	zassert_not_null(iface, "PPP interface not found!");
+	ztest_not_null(iface, "PPP interface not found!");
 
 	/* The semaphore is there to wait the data to be received. */
 	k_sem_init(&wait_data, 0, UINT_MAX);
@@ -236,7 +236,7 @@ static bool send_iface(struct net_if *iface,
 
 	ppp_driver_feed_data(recv, recv_len);
 
-	zassert_false(test_failed, "Test failed");
+	ztest_false(test_failed, "Test failed");
 
 	return true;
 }
@@ -250,7 +250,7 @@ static void send_ppp_pkt_with_escapes(void)
 	ret = send_iface(iface, ppp_recv_data1, sizeof(ppp_recv_data1),
 			 ppp_expect_data1, sizeof(ppp_expect_data1));
 
-	zassert_true(ret, "iface");
+	ztest_true(ret, "iface");
 }
 
 static void send_ppp_pkt_with_full_and_partial(void)
@@ -262,7 +262,7 @@ static void send_ppp_pkt_with_full_and_partial(void)
 	ret = send_iface(iface, ppp_recv_data2, sizeof(ppp_recv_data2),
 			 ppp_expect_data1, sizeof(ppp_expect_data1));
 
-	zassert_true(ret, "iface");
+	ztest_true(ret, "iface");
 }
 
 static bool check_fcs(struct net_pkt *pkt, u16_t *fcs)
@@ -321,7 +321,7 @@ static void ppp_verify_fcs(u8_t *buf, int len)
 	bool ret;
 
 	pkt = net_pkt_alloc_with_buffer(iface, len, AF_UNSPEC, 0, K_NO_WAIT);
-	zassert_not_null(pkt, "Cannot create pkt");
+	ztest_not_null(pkt, "Cannot create pkt");
 
 	ptr = buf;
 	while (ptr < &buf[len]) {
@@ -339,14 +339,14 @@ static void ppp_verify_fcs(u8_t *buf, int len)
 	 * fields so they must always be present.
 	 */
 	if (addr_and_ctrl != (0xff << 8 | 0x03)) {
-		zassert_true(false, "Invalid address / control bytes");
+		ztest_true(false, "Invalid address / control bytes");
 	}
 
 	/* Skip sync byte (1) */
 	net_buf_frag_last(pkt->buffer)->len -= 1;
 
 	ret = check_fcs(pkt, &fcs);
-	zassert_true(ret, "FCS calc failed, expecting 0x%x got 0x%x",
+	ztest_true(ret, "FCS calc failed, expecting 0x%x got 0x%x",
 		     0xf0b8, fcs);
 
 	net_pkt_unref(pkt);
@@ -392,7 +392,7 @@ static void ppp_calc_fcs(u8_t *buf, int len)
 	bool ret;
 
 	pkt = net_pkt_alloc_with_buffer(iface, len, AF_UNSPEC, 0, K_NO_WAIT);
-	zassert_not_null(pkt, "Cannot create pkt");
+	ztest_not_null(pkt, "Cannot create pkt");
 
 	ptr = buf;
 	while (ptr < &buf[len]) {
@@ -410,7 +410,7 @@ static void ppp_calc_fcs(u8_t *buf, int len)
 	 * fields so they must always be present.
 	 */
 	if (addr_and_ctrl != (0xff << 8 | 0x03)) {
-		zassert_true(false, "Invalid address / control bytes");
+		ztest_true(false, "Invalid address / control bytes");
 	}
 
 	len = net_pkt_get_len(pkt);
@@ -423,9 +423,9 @@ static void ppp_calc_fcs(u8_t *buf, int len)
 	net_buf_frag_last(pkt->buffer)->len -= 2 + 1;
 
 	ret = calc_fcs(pkt, &fcs);
-	zassert_true(ret, "FCS calc failed");
+	ztest_true(ret, "FCS calc failed");
 
-	zassert_equal(pkt_fcs, fcs, "FCS calc failed, expecting 0x%x got 0x%x",
+	ztest_equal(pkt_fcs, fcs, "FCS calc failed, expecting 0x%x got 0x%x",
 		     pkt_fcs, fcs);
 
 	net_pkt_unref(pkt);
@@ -450,10 +450,10 @@ static void send_ppp_3(void)
 	ret = send_iface(iface, ppp_recv_data3, sizeof(ppp_recv_data3),
 			 ppp_expect_data3, sizeof(ppp_expect_data3));
 
-	zassert_true(ret, "iface");
+	ztest_true(ret, "iface");
 
 	if (k_sem_take(&wait_data, WAIT_TIME_LONG)) {
-		zassert_true(false, "Timeout, packet not received");
+		ztest_true(false, "Timeout, packet not received");
 	}
 }
 
@@ -466,10 +466,10 @@ static void send_ppp_4(void)
 	ret = send_iface(iface, ppp_recv_data4, sizeof(ppp_recv_data4),
 			 ppp_expect_data4, sizeof(ppp_expect_data4));
 
-	zassert_true(ret, "iface");
+	ztest_true(ret, "iface");
 
 	if (k_sem_take(&wait_data, WAIT_TIME_LONG)) {
-		zassert_true(false, "Timeout, packet not received");
+		ztest_true(false, "Timeout, packet not received");
 	}
 }
 
@@ -482,10 +482,10 @@ static void send_ppp_5(void)
 	ret = send_iface(iface, ppp_recv_data5, sizeof(ppp_recv_data5),
 			 ppp_expect_data5, sizeof(ppp_expect_data5));
 
-	zassert_true(ret, "iface");
+	ztest_true(ret, "iface");
 
 	if (k_sem_take(&wait_data, WAIT_TIME_LONG)) {
-		zassert_true(false, "Timeout, packet not received");
+		ztest_true(false, "Timeout, packet not received");
 	}
 }
 
@@ -498,10 +498,10 @@ static void send_ppp_6(void)
 	ret = send_iface(iface, ppp_recv_data6, sizeof(ppp_recv_data6),
 			 ppp_expect_data6, sizeof(ppp_expect_data6));
 
-	zassert_true(ret, "iface");
+	ztest_true(ret, "iface");
 
 	if (k_sem_take(&wait_data, WAIT_TIME_LONG)) {
-		zassert_true(false, "Timeout, packet not received");
+		ztest_true(false, "Timeout, packet not received");
 	}
 }
 
@@ -514,10 +514,10 @@ static void send_ppp_7(void)
 	ret = send_iface(iface, ppp_recv_data7, sizeof(ppp_recv_data7),
 			 ppp_expect_data7, sizeof(ppp_expect_data7));
 
-	zassert_true(ret, "iface");
+	ztest_true(ret, "iface");
 
 	if (k_sem_take(&wait_data, WAIT_TIME_LONG)) {
-		zassert_true(false, "Timeout, packet not received");
+		ztest_true(false, "Timeout, packet not received");
 	}
 }
 
@@ -530,10 +530,10 @@ static void send_ppp_8(void)
 	ret = send_iface(iface, ppp_recv_data8, sizeof(ppp_recv_data8),
 			 ppp_expect_data8, sizeof(ppp_expect_data8));
 
-	zassert_true(ret, "iface");
+	ztest_true(ret, "iface");
 
 	if (k_sem_take(&wait_data, WAIT_TIME_LONG)) {
-		zassert_true(false, "Timeout, packet not received");
+		ztest_true(false, "Timeout, packet not received");
 	}
 }
 

--- a/tests/net/promiscuous/src/main.c
+++ b/tests/net/promiscuous/src/main.c
@@ -211,8 +211,8 @@ static void iface_setup(void)
 	((struct net_if_test *)
 	 net_if_get_device(iface2)->driver_data)->idx = idx;
 
-	zassert_not_null(iface1, "Interface 1");
-	zassert_not_null(iface2, "Interface 2");
+	ztest_not_null(iface1, "Interface 1");
+	ztest_not_null(iface2, "Interface 2");
 
 	DBG("Interfaces: [%d] iface1 %p, [%d] iface2 %p\n",
 	    net_if_get_by_iface(iface1), iface1,
@@ -223,7 +223,7 @@ static void iface_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr1));
-		zassert_not_null(ifaddr, "addr1");
+		ztest_not_null(ifaddr, "addr1");
 	}
 
 	/* For testing purposes we need to set the adddresses preferred */
@@ -234,7 +234,7 @@ static void iface_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&ll_addr));
-		zassert_not_null(ifaddr, "ll_addr");
+		ztest_not_null(ifaddr, "ll_addr");
 	}
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
@@ -244,7 +244,7 @@ static void iface_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr2));
-		zassert_not_null(ifaddr, "addr2");
+		ztest_not_null(ifaddr, "addr2");
 	}
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
@@ -254,7 +254,7 @@ static void iface_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr3));
-		zassert_not_null(ifaddr, "addr3");
+		ztest_not_null(ifaddr, "addr3");
 	}
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
@@ -265,7 +265,7 @@ static void iface_setup(void)
 	if (!maddr) {
 		DBG("Cannot add multicast IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&in6addr_mcast));
-		zassert_not_null(maddr, "mcast");
+		ztest_not_null(maddr, "mcast");
 	}
 
 	net_if_up(iface1);
@@ -280,7 +280,7 @@ static void _set_promisc_mode_on_again(struct net_if *iface)
 
 	ret = net_promisc_mode_on(iface);
 
-	zassert_equal(ret, -EALREADY, "iface %p promiscuous mode ON", iface);
+	ztest_equal(ret, -EALREADY, "iface %p promiscuous mode ON", iface);
 }
 
 static void _set_promisc_mode_on(struct net_if *iface)
@@ -291,7 +291,7 @@ static void _set_promisc_mode_on(struct net_if *iface)
 
 	ret = net_promisc_mode_on(iface);
 
-	zassert_equal(ret, 0, "iface %p promiscuous mode set ON failed",
+	ztest_equal(ret, 0, "iface %p promiscuous mode set ON failed",
 		      iface);
 }
 
@@ -303,7 +303,7 @@ static void _set_promisc_mode_off_again(struct net_if *iface)
 
 	ret = net_promisc_mode_off(iface);
 
-	zassert_equal(ret, -EALREADY, "iface %p promiscuous mode OFF", iface);
+	ztest_equal(ret, -EALREADY, "iface %p promiscuous mode OFF", iface);
 }
 
 static void _set_promisc_mode_off(struct net_if *iface)
@@ -314,7 +314,7 @@ static void _set_promisc_mode_off(struct net_if *iface)
 
 	ret = net_promisc_mode_off(iface);
 
-	zassert_equal(ret, 0, "iface %p promiscuous mode set OFF failed",
+	ztest_equal(ret, 0, "iface %p promiscuous mode set OFF failed",
 		      iface);
 }
 
@@ -353,7 +353,7 @@ static void _recv_data(struct net_if *iface, struct net_pkt **pkt)
 	net_pkt_write(*pkt, data, sizeof(data));
 
 	ret = net_recv_data(iface, *pkt);
-	zassert_equal(ret, 0, "Data receive failure");
+	ztest_equal(ret, 0, "Data receive failure");
 }
 
 static struct net_pkt *pkt1;
@@ -370,11 +370,11 @@ static void verify_data(void)
 	struct net_pkt *pkt;
 
 	pkt = net_promisc_mode_wait_data(K_SECONDS(1));
-	zassert_equal_ptr(pkt, pkt1, "pkt %p != %p", pkt, pkt1);
+	ztest_equal_ptr(pkt, pkt1, "pkt %p != %p", pkt, pkt1);
 	net_pkt_unref(pkt);
 
 	pkt = net_promisc_mode_wait_data(K_SECONDS(1));
-	zassert_equal_ptr(pkt, pkt2, "pkt %p != %p", pkt, pkt2);
+	ztest_equal_ptr(pkt, pkt2, "pkt %p != %p", pkt, pkt2);
 	net_pkt_unref(pkt);
 }
 

--- a/tests/net/ptp/clock/src/main.c
+++ b/tests/net/ptp/clock/src/main.c
@@ -99,7 +99,7 @@ static int eth_tx(struct device *dev, struct net_pkt *pkt)
 	struct eth_context *context = dev->driver_data;
 
 	if (&eth_context_1 != context && &eth_context_2 != context) {
-		zassert_true(false, "Context pointers do not match\n");
+		ztest_true(false, "Context pointers do not match\n");
 	}
 
 	if (!pkt->frags) {
@@ -186,7 +186,7 @@ static int my_ptp_clock_set(struct device *dev, struct net_ptp_time *tm)
 	struct eth_context *eth_ctx = ptp_ctx->eth_context;
 
 	if (&eth_context_1 != eth_ctx && &eth_context_2 != eth_ctx) {
-		zassert_true(false, "Context pointers do not match\n");
+		ztest_true(false, "Context pointers do not match\n");
 	}
 
 	memcpy(&eth_ctx->time, tm, sizeof(struct net_ptp_time));
@@ -320,11 +320,11 @@ static void check_interfaces(void)
 	/* Make sure we have enough interfaces */
 	net_if_foreach(iface_cb, &ud);
 
-	zassert_equal(ud.eth_if_count, MAX_NUM_INTERFACES,
+	ztest_equal(ud.eth_if_count, MAX_NUM_INTERFACES,
 		      "Invalid numer of ethernet interfaces %d vs %d\n",
 		      ud.eth_if_count, MAX_NUM_INTERFACES);
 
-	zassert_equal(ud.total_if_count, ud.eth_if_count,
+	ztest_equal(ud.total_if_count, ud.eth_if_count,
 		      "Invalid numer of interfaces %d vs %d\n",
 		      ud.total_if_count, ud.eth_if_count);
 }
@@ -342,16 +342,16 @@ static void address_setup(void)
 	iface2 = eth_interfaces[1];
 	iface3 = eth_interfaces[2];
 
-	zassert_not_null(iface1, "Interface 1\n");
-	zassert_not_null(iface2, "Interface 2\n");
-	zassert_not_null(iface3, "Interface 3\n");
+	ztest_not_null(iface1, "Interface 1\n");
+	ztest_not_null(iface2, "Interface 2\n");
+	ztest_not_null(iface3, "Interface 3\n");
 
 	ifaddr = net_if_ipv6_addr_add(iface1, &my_addr1,
 				      NET_ADDR_MANUAL, 0);
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr1));
-		zassert_not_null(ifaddr, "addr1\n");
+		ztest_not_null(ifaddr, "addr1\n");
 	}
 
 	/* For testing purposes we need to set the adddresses preferred */
@@ -362,7 +362,7 @@ static void address_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&ll_addr));
-		zassert_not_null(ifaddr, "ll_addr\n");
+		ztest_not_null(ifaddr, "ll_addr\n");
 	}
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
@@ -372,7 +372,7 @@ static void address_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr2));
-		zassert_not_null(ifaddr, "addr2\n");
+		ztest_not_null(ifaddr, "addr2\n");
 	}
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
@@ -382,7 +382,7 @@ static void address_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr3));
-		zassert_not_null(ifaddr, "addr3\n");
+		ztest_not_null(ifaddr, "addr3\n");
 	}
 
 	net_if_up(iface1);
@@ -400,20 +400,20 @@ static void test_ptp_clock_interfaces(void)
 
 	idx = ptp_interface[0];
 	clk = net_eth_get_ptp_clock(eth_interfaces[idx]);
-	zassert_not_null(clk, "Clock not found for interface %p\n",
+	ztest_not_null(clk, "Clock not found for interface %p\n",
 			 eth_interfaces[idx]);
 
 	idx = ptp_interface[1];
 	clk = net_eth_get_ptp_clock(eth_interfaces[idx]);
-	zassert_not_null(clk, "Clock not found for interface %p\n",
+	ztest_not_null(clk, "Clock not found for interface %p\n",
 			 eth_interfaces[idx]);
 
 	clk = net_eth_get_ptp_clock(eth_interfaces[non_ptp_interface]);
-	zassert_is_null(clk, "Clock found for interface %p\n",
+	ztest_is_null(clk, "Clock found for interface %p\n",
 			eth_interfaces[non_ptp_interface]);
 
 	clk_by_index = net_eth_get_ptp_clock_by_index(ptp_clocks[0]);
-	zassert_not_null(clk_by_index,
+	ztest_not_null(clk_by_index,
 			 "Clock not found for interface index %d\n",
 			 ptp_clocks[0]);
 }
@@ -430,7 +430,7 @@ static void test_ptp_clock_iface(int idx)
 
 	clk = net_eth_get_ptp_clock(eth_interfaces[idx]);
 
-	zassert_not_null(clk, "Clock not found for interface %p\n",
+	ztest_not_null(clk, "Clock not found for interface %p\n",
 			 eth_interfaces[idx]);
 
 	ptp_clock_set(clk, &tm);
@@ -449,7 +449,7 @@ static void test_ptp_clock_iface(int idx)
 	new_value = timestamp_to_nsec(&tm);
 
 	/* The clock value must be the same after incrementing it */
-	zassert_equal(orig + rnd_value, new_value,
+	ztest_equal(orig + rnd_value, new_value,
 		      "Time adjust failure (%llu vs %llu)\n",
 		      orig + rnd_value, new_value);
 }
@@ -475,26 +475,26 @@ static void test_ptp_clock_get_by_index(void)
 	idx = ptp_interface[0];
 
 	clk = net_eth_get_ptp_clock(eth_interfaces[idx]);
-	zassert_not_null(clk, "PTP 0 not found");
+	ztest_not_null(clk, "PTP 0 not found");
 
 	clk0 = clk;
 
 	clk_by_index = net_eth_get_ptp_clock_by_index(ptp_clocks[0]);
-	zassert_not_null(clk_by_index, "PTP 0 not found");
+	ztest_not_null(clk_by_index, "PTP 0 not found");
 
-	zassert_equal(clk, clk_by_index, "Interface index %d invalid", idx);
+	ztest_equal(clk, clk_by_index, "Interface index %d invalid", idx);
 
 	idx = ptp_interface[1];
 
 	clk = net_eth_get_ptp_clock(eth_interfaces[idx]);
-	zassert_not_null(clk, "PTP 1 not found");
+	ztest_not_null(clk, "PTP 1 not found");
 
 	clk1 = clk;
 
 	clk_by_index = net_eth_get_ptp_clock_by_index(ptp_clocks[1]);
-	zassert_not_null(clk_by_index, "PTP 1 not found");
+	ztest_not_null(clk_by_index, "PTP 1 not found");
 
-	zassert_equal(clk, clk_by_index, "Interface index %d invalid", idx);
+	ztest_equal(clk, clk_by_index, "Interface index %d invalid", idx);
 }
 
 static void test_ptp_clock_get_by_index_user(void)
@@ -502,12 +502,12 @@ static void test_ptp_clock_get_by_index_user(void)
 	struct device *clk_by_index;
 
 	clk_by_index = net_eth_get_ptp_clock_by_index(ptp_clocks[0]);
-	zassert_not_null(clk_by_index, "PTP 0 not found");
-	zassert_equal(clk0, clk_by_index, "Invalid PTP clock 0");
+	ztest_not_null(clk_by_index, "PTP 0 not found");
+	ztest_equal(clk0, clk_by_index, "Invalid PTP clock 0");
 
 	clk_by_index = net_eth_get_ptp_clock_by_index(ptp_clocks[1]);
-	zassert_not_null(clk_by_index, "PTP 1 not found");
-	zassert_equal(clk1, clk_by_index, "Invalid PTP clock 1");
+	ztest_not_null(clk_by_index, "PTP 1 not found");
+	ztest_equal(clk1, clk_by_index, "Invalid PTP clock 1");
 }
 
 static ZTEST_BMEM struct net_ptp_time tm;
@@ -519,14 +519,14 @@ static void test_ptp_clock_get_by_xxx(const char *who)
 	int ret;
 
 	clk_by_index = net_eth_get_ptp_clock_by_index(ptp_clocks[0]);
-	zassert_not_null(clk_by_index, "PTP 0 not found (%s)", who);
-	zassert_equal(clk0, clk_by_index, "Invalid PTP clock 0 (%s)", who);
+	ztest_not_null(clk_by_index, "PTP 0 not found (%s)", who);
+	ztest_equal(clk0, clk_by_index, "Invalid PTP clock 0 (%s)", who);
 
 	(void)memset(&tm, 0, sizeof(tm));
 	ptp_clock_get(clk_by_index, &tm);
 
 	ret = memcmp(&tm, &empty, sizeof(tm));
-	zassert_not_equal(ret, 0, "ptp_clock_get() failed in %s mode", who);
+	ztest_not_equal(ret, 0, "ptp_clock_get() failed in %s mode", who);
 }
 
 static void test_ptp_clock_get_kernel(void)

--- a/tests/net/route/src/main.c
+++ b/tests/net/route/src/main.c
@@ -239,15 +239,15 @@ static void test_init(void)
 	    net_if_get_by_iface(my_iface), my_iface,
 	    net_if_get_by_iface(peer_iface), peer_iface);
 
-	zassert_not_null(my_iface,
+	ztest_not_null(my_iface,
 			 "Interface is NULL");
 
-	zassert_not_null(peer_iface,
+	ztest_not_null(peer_iface,
 			 "Interface is NULL");
 
 	ifaddr = net_if_ipv6_addr_add(my_iface, &my_addr,
 				      NET_ADDR_MANUAL, 0);
-	zassert_not_null(ifaddr,
+	ztest_not_null(ifaddr,
 			 "Cannot add IPv6 address");
 
 	/* For testing purposes we need to set the adddresses preferred */
@@ -255,7 +255,7 @@ static void test_init(void)
 
 	ifaddr = net_if_ipv6_addr_add(my_iface, &ll_addr,
 				      NET_ADDR_MANUAL, 0);
-	zassert_not_null(ifaddr,
+	ztest_not_null(ifaddr,
 			 "Cannot add IPv6 address");
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
@@ -263,7 +263,7 @@ static void test_init(void)
 	net_ipv6_addr_create(&in6addr_mcast, 0xff02, 0, 0, 0, 0, 0, 0, 0x0001);
 
 	maddr = net_if_ipv6_maddr_add(my_iface, &in6addr_mcast);
-	zassert_not_null(maddr,
+	ztest_not_null(maddr,
 			 "Cannot add multicast IPv6 address");
 
 	/* The peer and dest interfaces are just simulated, they are not
@@ -286,7 +286,7 @@ static void net_ctx_create(void)
 
 	ret = net_context_get(AF_INET6, SOCK_DGRAM, IPPROTO_UDP,
 			      &udp_ctx);
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Context create IPv6 UDP test failed");
 }
 
@@ -334,24 +334,24 @@ static void populate_nbr_cache(void)
 
 	recipient = my_iface;
 
-	zassert_true(net_test_send_ns(peer_iface, &peer_addr), NULL);
+	ztest_true(net_test_send_ns(peer_iface, &peer_addr), NULL);
 
 	nbr = net_ipv6_nbr_add(net_if_get_default(),
 			       &peer_addr,
 			       &net_route_data_peer.ll_addr,
 			       false,
 			       NET_IPV6_NBR_STATE_REACHABLE);
-	zassert_not_null(nbr, "Cannot add peer to neighbor cache");
+	ztest_not_null(nbr, "Cannot add peer to neighbor cache");
 
 	k_sem_take(&wait_data, WAIT_TIME);
 
 	feed_data = false;
 
-	zassert_false(data_failure, "data failure");
+	ztest_false(data_failure, "data failure");
 
 	data_failure = false;
 
-	zassert_true(net_test_nbr_lookup_ok(my_iface, &peer_addr), NULL);
+	ztest_true(net_test_nbr_lookup_ok(my_iface, &peer_addr), NULL);
 }
 
 static void route_add(void)
@@ -360,7 +360,7 @@ static void route_add(void)
 			      &dest_addr, 128,
 			      &peer_addr);
 
-	zassert_not_null(entry, "Route add failed");
+	ztest_not_null(entry, "Route add failed");
 }
 
 static void route_update(void)
@@ -370,7 +370,7 @@ static void route_update(void)
 	update_entry = net_route_add(my_iface,
 				     &dest_addr, 128,
 				     &peer_addr);
-	zassert_equal_ptr(update_entry, entry,
+	ztest_equal_ptr(update_entry, entry,
 			  "Route add again failed");
 }
 
@@ -380,7 +380,7 @@ static void route_del(void)
 
 	ret = net_route_del(entry);
 	if (ret < 0) {
-		zassert_true(0, "Route del failed");
+		ztest_true(0, "Route del failed");
 	}
 }
 
@@ -390,7 +390,7 @@ static void route_del_again(void)
 
 	ret = net_route_del(entry);
 	if (ret >= 0) {
-		zassert_true(0, "Route del again failed");
+		ztest_true(0, "Route del again failed");
 	}
 }
 
@@ -400,9 +400,9 @@ static void route_get_nexthop(void)
 
 	nexthop = net_route_get_nexthop(entry);
 
-	zassert_not_null(nexthop, "Route get nexthop failed");
+	ztest_not_null(nexthop, "Route get nexthop failed");
 
-	zassert_true(net_ipv6_addr_cmp(nexthop, &peer_addr),
+	ztest_true(net_ipv6_addr_cmp(nexthop, &peer_addr),
 		     "Route nexthop does not match");
 }
 
@@ -411,7 +411,7 @@ static void route_lookup_ok(void)
 	struct net_route_entry *entry;
 
 	entry = net_route_lookup(my_iface, &dest_addr);
-	zassert_not_null(entry,
+	ztest_not_null(entry,
 			 "Route lookup failed");
 }
 
@@ -420,7 +420,7 @@ static void route_lookup_fail(void)
 	struct net_route_entry *entry;
 
 	entry = net_route_lookup(my_iface, &peer_addr);
-	zassert_is_null(entry,
+	ztest_is_null(entry,
 			"Route lookup failed for peer address");
 }
 
@@ -430,7 +430,7 @@ static void route_del_nexthop(void)
 	int ret;
 
 	ret = net_route_del_by_nexthop(my_iface, nexthop);
-	zassert_false((ret <= 0), "Route del nexthop failed");
+	ztest_false((ret <= 0), "Route del nexthop failed");
 }
 
 static void route_del_nexthop_again(void)
@@ -439,7 +439,7 @@ static void route_del_nexthop_again(void)
 	int ret;
 
 	ret = net_route_del_by_nexthop(my_iface, nexthop);
-	zassert_false((ret >= 0), "Route del again nexthop failed");
+	ztest_false((ret >= 0), "Route del again nexthop failed");
 }
 
 static void route_add_many(void)
@@ -452,7 +452,7 @@ static void route_add_many(void)
 		test_routes[i] = net_route_add(my_iface,
 					  &dest_addresses[i], 128,
 					  &peer_addr);
-		zassert_not_null(test_routes[i], "Route add failed");
+		ztest_not_null(test_routes[i], "Route add failed");
 		}
 }
 
@@ -463,7 +463,7 @@ static void route_del_many(void)
 	for (i = 0; i < max_routes; i++) {
 		DBG("Deleting route %d addr %s\n", i + 1,
 		    net_sprint_ipv6_addr(&dest_addresses[i]));
-		zassert_false(net_route_del(test_routes[i]),
+		ztest_false(net_route_del(test_routes[i]),
 			      " Route del failed");
 	}
 }

--- a/tests/net/shell/src/main.c
+++ b/tests/net/shell/src/main.c
@@ -190,14 +190,14 @@ static void test_setup(void)
 	if (!ifaddr) {
 		printk("Cannot add %s to interface %p\n",
 		       net_sprint_ipv6_addr(&in6addr_my), iface);
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	ifaddr = net_if_ipv4_addr_add(iface, &in4addr_my, NET_ADDR_MANUAL, 0);
 	if (!ifaddr) {
 		printk("Cannot add %s to interface %p\n",
 		       net_sprint_ipv4_addr(&in4addr_my), iface);
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 }
 
@@ -207,11 +207,11 @@ static void test_net_shell(void)
 
 	/* Test that command exists */
 	ret = shell_execute_cmd(NULL, "net iface");
-	zassert_equal(ret, 0, "");
+	ztest_equal(ret, 0, "");
 
 	/* There is no foobar command */
 	ret = shell_execute_cmd(NULL, "net foobar");
-	zassert_equal(ret, 1, "");
+	ztest_equal(ret, 1, "");
 }
 
 void test_main(void)

--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -80,7 +80,7 @@ static int setup_socket(struct net_if *iface)
 	int sock;
 
 	sock = socket(AF_PACKET, SOCK_RAW, ETH_P_ALL);
-	zassert_true(sock >= 0, "Cannot create packet socket (%d)", sock);
+	ztest_true(sock >= 0, "Cannot create packet socket (%d)", sock);
 
 	return sock;
 }
@@ -125,20 +125,20 @@ static void test_packet_sockets(void)
 
 	net_if_foreach(iface_cb, &ud);
 
-	zassert_not_null(ud.first, "1st Ethernet interface not found");
-	zassert_not_null(ud.second, "2nd Ethernet interface not found");
+	ztest_not_null(ud.first, "1st Ethernet interface not found");
+	ztest_not_null(ud.second, "2nd Ethernet interface not found");
 
 	sock1 = setup_socket(ud.first);
-	zassert_true(sock1 >= 0, "Cannot create 1st socket (%d)", sock1);
+	ztest_true(sock1 >= 0, "Cannot create 1st socket (%d)", sock1);
 
 	sock2 = setup_socket(ud.second);
-	zassert_true(sock2 >= 0, "Cannot create 2nd socket (%d)", sock2);
+	ztest_true(sock2 >= 0, "Cannot create 2nd socket (%d)", sock2);
 
 	ret = bind_socket(sock1, ud.first);
-	zassert_equal(ret, 0, "Cannot bind 1st socket (%d)", -errno);
+	ztest_equal(ret, 0, "Cannot bind 1st socket (%d)", -errno);
 
 	ret = bind_socket(sock2, ud.second);
-	zassert_equal(ret, 0, "Cannot bind 2nd socket (%d)", -errno);
+	ztest_equal(ret, 0, "Cannot bind 2nd socket (%d)", -errno);
 }
 
 void test_main(void)

--- a/tests/net/socket/getaddrinfo/src/main.c
+++ b/tests/net/socket/getaddrinfo/src/main.c
@@ -176,7 +176,7 @@ void test_getaddrinfo_setup(void)
 	ret = net_ipaddr_parse(CONFIG_DNS_SERVER1,
 			       sizeof(CONFIG_DNS_SERVER1) - 1,
 			       &addr);
-	zassert_true(ret, "Cannot parse IP address %s", CONFIG_DNS_SERVER1);
+	ztest_true(ret, "Cannot parse IP address %s", CONFIG_DNS_SERVER1);
 
 	if (addr.sa_family == AF_INET) {
 		memcpy(&addr_v4, net_sin(&addr), sizeof(struct sockaddr_in));
@@ -187,7 +187,7 @@ void test_getaddrinfo_setup(void)
 	ret = net_ipaddr_parse(CONFIG_DNS_SERVER2,
 			       sizeof(CONFIG_DNS_SERVER2) - 1,
 			       &addr);
-	zassert_true(ret, "Cannot parse IP address %s", CONFIG_DNS_SERVER2);
+	ztest_true(ret, "Cannot parse IP address %s", CONFIG_DNS_SERVER2);
 
 	if (addr.sa_family == AF_INET) {
 		memcpy(&addr_v4, net_sin(&addr), sizeof(struct sockaddr_in));
@@ -199,13 +199,13 @@ void test_getaddrinfo_setup(void)
 	NET_DBG("v4: [%s]:%d", log_strdup(addr_str), ntohs(addr_v4.sin_port));
 
 	sock_v4 = prepare_listen_sock_udp_v4(&addr_v4);
-	zassert_true(sock_v4 >= 0, "Invalid IPv4 socket");
+	ztest_true(sock_v4 >= 0, "Invalid IPv4 socket");
 
 	addr_str = inet_ntop(AF_INET6, &addr_v6.sin6_addr, str, sizeof(str));
 	NET_DBG("v6: [%s]:%d", log_strdup(addr_str), ntohs(addr_v6.sin6_port));
 
 	sock_v6 = prepare_listen_sock_udp_v6(&addr_v6);
-	zassert_true(sock_v6 >= 0, "Invalid IPv6 socket");
+	ztest_true(sock_v6 >= 0, "Invalid IPv6 socket");
 
 	k_thread_start(dns_server_thread_id);
 
@@ -227,10 +227,10 @@ void test_getaddrinfo_ok(void)
 	(void)getaddrinfo(QUERY_HOST, NULL, NULL, &res);
 
 	if (sys_mutex_lock(&wait_data, WAIT_TIME)) {
-		zassert_true(false, "Timeout DNS query not received");
+		ztest_true(false, "Timeout DNS query not received");
 	}
 
-	zassert_equal(queries_received, 2,
+	ztest_equal(queries_received, 2,
 		      "Did not receive both IPv4 and IPv6 query");
 
 	freeaddrinfo(res);
@@ -244,7 +244,7 @@ void test_getaddrinfo_cancelled(void)
 	ret = getaddrinfo(QUERY_HOST, NULL, NULL, &res);
 
 	/* Without a local DNS server this request will be canceled. */
-	zassert_equal(ret, DNS_EAI_CANCELED, "Invalid result");
+	ztest_equal(ret, DNS_EAI_CANCELED, "Invalid result");
 
 	freeaddrinfo(res);
 }
@@ -256,9 +256,9 @@ void test_getaddrinfo_no_host(void)
 
 	ret = getaddrinfo(NULL, NULL, NULL, &res);
 
-	zassert_equal(ret, DNS_EAI_SYSTEM, "Invalid result");
-	zassert_equal(errno, EINVAL, "Invalid errno");
-	zassert_is_null(res, "ai_addr is not NULL");
+	ztest_equal(ret, DNS_EAI_SYSTEM, "Invalid result");
+	ztest_equal(errno, EINVAL, "Invalid errno");
+	ztest_is_null(res, "ai_addr is not NULL");
 
 	freeaddrinfo(res);
 }
@@ -271,21 +271,21 @@ void test_getaddrinfo_num_ipv4(void)
 
 	ret = zsock_getaddrinfo("1.2.3.255", "65534", NULL, &res);
 
-	zassert_equal(ret, 0, "Invalid result");
-	zassert_not_null(res, "");
-	zassert_is_null(res->ai_next, "");
+	ztest_equal(ret, 0, "Invalid result");
+	ztest_not_null(res, "");
+	ztest_is_null(res->ai_next, "");
 
-	zassert_equal(res->ai_family, AF_INET, "");
-	zassert_equal(res->ai_socktype, SOCK_STREAM, "");
-	zassert_equal(res->ai_protocol, IPPROTO_TCP, "");
+	ztest_equal(res->ai_family, AF_INET, "");
+	ztest_equal(res->ai_socktype, SOCK_STREAM, "");
+	ztest_equal(res->ai_protocol, IPPROTO_TCP, "");
 
 	saddr = (struct sockaddr_in *)res->ai_addr;
-	zassert_equal(saddr->sin_family, AF_INET, "");
-	zassert_equal(saddr->sin_port, htons(65534), "");
-	zassert_equal(saddr->sin_addr.s4_addr[0], 1, "");
-	zassert_equal(saddr->sin_addr.s4_addr[1], 2, "");
-	zassert_equal(saddr->sin_addr.s4_addr[2], 3, "");
-	zassert_equal(saddr->sin_addr.s4_addr[3], 255, "");
+	ztest_equal(saddr->sin_family, AF_INET, "");
+	ztest_equal(saddr->sin_port, htons(65534), "");
+	ztest_equal(saddr->sin_addr.s4_addr[0], 1, "");
+	ztest_equal(saddr->sin_addr.s4_addr[1], 2, "");
+	ztest_equal(saddr->sin_addr.s4_addr[2], 3, "");
+	ztest_equal(saddr->sin_addr.s4_addr[3], 255, "");
 
 	zsock_freeaddrinfo(res);
 }
@@ -299,12 +299,12 @@ void test_getaddrinfo_flags_numerichost(void)
 	};
 
 	ret = zsock_getaddrinfo("foo.bar", "65534", &hints, &res);
-	zassert_equal(ret, DNS_EAI_FAIL, "Invalid result");
-	zassert_is_null(res, "");
+	ztest_equal(ret, DNS_EAI_FAIL, "Invalid result");
+	ztest_is_null(res, "");
 
 	ret = zsock_getaddrinfo("1.2.3.4", "65534", &hints, &res);
-	zassert_equal(ret, 0, "Invalid result");
-	zassert_not_null(res, "");
+	ztest_equal(ret, 0, "Invalid result");
+	ztest_not_null(res, "");
 
 	zsock_freeaddrinfo(res);
 }
@@ -318,8 +318,8 @@ static void test_getaddrinfo_ipv4_hints_ipv6(void)
 	int ret;
 
 	ret = zsock_getaddrinfo("192.0.2.1", NULL, &hints, &res);
-	zassert_equal(ret, DNS_EAI_ADDRFAMILY, "Invalid result (%d)", ret);
-	zassert_is_null(res, "");
+	ztest_equal(ret, DNS_EAI_ADDRFAMILY, "Invalid result (%d)", ret);
+	ztest_is_null(res, "");
 }
 
 static void test_getaddrinfo_ipv6_hints_ipv4(void)
@@ -331,8 +331,8 @@ static void test_getaddrinfo_ipv6_hints_ipv4(void)
 	int ret;
 
 	ret = zsock_getaddrinfo("2001:db8::1", NULL, &hints, &res);
-	zassert_equal(ret, DNS_EAI_ADDRFAMILY, "Invalid result (%d)", ret);
-	zassert_is_null(res, "");
+	ztest_equal(ret, DNS_EAI_ADDRFAMILY, "Invalid result (%d)", ret);
+	ztest_is_null(res, "");
 }
 
 void test_main(void)

--- a/tests/net/socket/getnameinfo/src/main.c
+++ b/tests/net/socket/getnameinfo/src/main.c
@@ -24,22 +24,22 @@ void test_getnameinfo_ipv4(void)
 
 	ret = getnameinfo((struct sockaddr *)&saddr, sizeof(saddr),
 			  host, sizeof(host), serv, sizeof(serv), 0);
-	zassert_equal(ret, 0, "");
+	ztest_equal(ret, 0, "");
 
 	printk("%s %s\n", host, serv);
-	zassert_equal(strcmp(host, "0.0.0.0"), 0, "");
-	zassert_equal(strcmp(serv, "0"), 0, "");
+	ztest_equal(strcmp(host, "0.0.0.0"), 0, "");
+	ztest_equal(strcmp(serv, "0"), 0, "");
 
 	saddr.sin_port = htons(1234);
 	saddr.sin_addr.s_addr = htonl(0x7f000001);
 
 	ret = getnameinfo((struct sockaddr *)&saddr, sizeof(saddr),
 			  host, sizeof(host), serv, sizeof(serv), 0);
-	zassert_equal(ret, 0, "");
+	ztest_equal(ret, 0, "");
 
 	printk("%s %s\n", host, serv);
-	zassert_equal(strcmp(host, "127.0.0.1"), 0, "");
-	zassert_equal(strcmp(serv, "1234"), 0, "");
+	ztest_equal(strcmp(host, "127.0.0.1"), 0, "");
+	ztest_equal(strcmp(serv, "1234"), 0, "");
 }
 
 void test_getnameinfo_ipv6(void)
@@ -54,11 +54,11 @@ void test_getnameinfo_ipv6(void)
 
 	ret = getnameinfo((struct sockaddr *)&saddr, sizeof(saddr),
 			  host, sizeof(host), serv, sizeof(serv), 0);
-	zassert_equal(ret, 0, "");
+	ztest_equal(ret, 0, "");
 
 	printk("%s %s\n", host, serv);
-	zassert_equal(strcmp(host, "::"), 0, "");
-	zassert_equal(strcmp(serv, "0"), 0, "");
+	ztest_equal(strcmp(host, "::"), 0, "");
+	ztest_equal(strcmp(serv, "0"), 0, "");
 
 	saddr.sin6_port = htons(4321);
 	saddr.sin6_addr.s6_addr[0] = 0xff;
@@ -67,11 +67,11 @@ void test_getnameinfo_ipv6(void)
 
 	ret = getnameinfo((struct sockaddr *)&saddr, sizeof(saddr),
 			  host, sizeof(host), serv, sizeof(serv), 0);
-	zassert_equal(ret, 0, "");
+	ztest_equal(ret, 0, "");
 
 	printk("%s %s\n", host, serv);
-	zassert_equal(strcmp(host, "ff55::11"), 0, "");
-	zassert_equal(strcmp(serv, "4321"), 0, "");
+	ztest_equal(strcmp(host, "ff55::11"), 0, "");
+	ztest_equal(strcmp(serv, "4321"), 0, "");
 }
 
 void test_main(void)

--- a/tests/net/socket/misc/src/main.c
+++ b/tests/net/socket/misc/src/main.c
@@ -20,9 +20,9 @@ void test_gethostname(void)
 	int res;
 
 	res = gethostname(buf, sizeof(buf));
-	zassert_equal(res, 0, "");
+	ztest_equal(res, 0, "");
 	printk("%s\n", buf);
-	zassert_equal(strcmp(buf, "ztest_hostname"), 0, "");
+	ztest_equal(strcmp(buf, "ztest_hostname"), 0, "");
 }
 
 void test_inet_pton(void)
@@ -31,22 +31,22 @@ void test_inet_pton(void)
 	u8_t buf[32];
 
 	res = inet_pton(AF_INET, "127.0.0.1", buf);
-	zassert_equal(res, 1, "");
+	ztest_equal(res, 1, "");
 
 	res = inet_pton(AF_INET, "127.0.0.1a", buf);
-	zassert_equal(res, 0, "");
+	ztest_equal(res, 0, "");
 
 	res = inet_pton(AF_INET6, "a:b:c:d:0:1:2:3", buf);
-	zassert_equal(res, 1, "");
+	ztest_equal(res, 1, "");
 
 	res = inet_pton(AF_INET6, "::1", buf);
-	zassert_equal(res, 1, "");
+	ztest_equal(res, 1, "");
 
 	res = inet_pton(AF_INET6, "1::", buf);
-	zassert_equal(res, 1, "");
+	ztest_equal(res, 1, "");
 
 	res = inet_pton(AF_INET6, "a:b:c:d:0:1:2:3z", buf);
-	zassert_equal(res, 0, "");
+	ztest_equal(res, 0, "");
 }
 
 void test_main(void)

--- a/tests/net/socket/net_mgmt/src/main.c
+++ b/tests/net/socket/net_mgmt/src/main.c
@@ -348,7 +348,7 @@ static void test_net_mgmt_setup(void)
 	int ret;
 
 	fd = socket(AF_NET_MGMT, SOCK_DGRAM, NET_MGMT_EVENT_PROTO);
-	zassert_false(fd < 0, "Cannot create net_mgmt socket (%d)", errno);
+	ztest_false(fd < 0, "Cannot create net_mgmt socket (%d)", errno);
 
 	memset(&sockaddr, 0, sizeof(sockaddr));
 
@@ -360,7 +360,7 @@ static void test_net_mgmt_setup(void)
 			   NET_EVENT_IPV6_ADDR_DEL;
 
 	ret = bind(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
-	zassert_false(ret < 0, "Cannot bind net_mgmt socket (%d)", errno);
+	ztest_false(ret < 0, "Cannot bind net_mgmt socket (%d)", errno);
 
 	k_thread_start(trigger_events_thread_id);
 }
@@ -400,7 +400,7 @@ static void test_net_mgmt_catch_events(void)
 			    event_addr.nm_ifindex,
 			    get_ip_addr(ipaddr, sizeof(ipaddr),
 					AF_INET6, hdr));
-			zassert_equal(strncmp(ipaddr, "2001:db8::3",
+			ztest_equal(strncmp(ipaddr, "2001:db8::3",
 					      sizeof(ipaddr) - 1), 0,
 				      "Invalid IPv6 address %s added",
 				      ipaddr);
@@ -411,7 +411,7 @@ static void test_net_mgmt_catch_events(void)
 			    event_addr.nm_ifindex,
 			    get_ip_addr(ipaddr, sizeof(ipaddr),
 					AF_INET6, hdr));
-			zassert_equal(strncmp(ipaddr, "2001:db8::3",
+			ztest_equal(strncmp(ipaddr, "2001:db8::3",
 					      sizeof(ipaddr) - 1), 0,
 				      "Invalid IPv6 address %s removed",
 				      ipaddr);
@@ -450,7 +450,7 @@ static void test_ethernet_set_qav(void)
 	ret = setsockopt(fd, SOL_NET_MGMT_RAW,
 			 NET_REQUEST_ETHERNET_SET_QAV_PARAM,
 			 &params, sizeof(params));
-	zassert_equal(ret, 0, "Cannot set Qav parameters");
+	ztest_equal(ret, 0, "Cannot set Qav parameters");
 }
 
 static void test_ethernet_set_qav_kernel(void)
@@ -477,10 +477,10 @@ static void test_ethernet_get_qav(void)
 	ret = getsockopt(fd, SOL_NET_MGMT_RAW,
 			 NET_REQUEST_ETHERNET_GET_QAV_PARAM,
 			 &params, &optlen);
-	zassert_equal(ret, 0, "Cannot get Qav parameters (%d)", ret);
-	zassert_equal(optlen, sizeof(params), "Invalid optlen (%d)", optlen);
+	ztest_equal(ret, 0, "Cannot get Qav parameters (%d)", ret);
+	ztest_equal(optlen, sizeof(params), "Invalid optlen (%d)", optlen);
 
-	zassert_true(params.qav_param.enabled, "Qav not enabled");
+	ztest_true(params.qav_param.enabled, "Qav not enabled");
 }
 
 static void test_ethernet_get_qav_kernel(void)
@@ -504,8 +504,8 @@ static void test_ethernet_get_unknown_option(void)
 	ret = getsockopt(fd, SOL_NET_MGMT_RAW,
 			 NET_REQUEST_ETHERNET_GET_PRIORITY_QUEUES_NUM,
 			 &params, &optlen);
-	zassert_equal(ret, -1, "Could get prio queue parameters (%d)", errno);
-	zassert_equal(errno, EINVAL, "prio queue get parameters");
+	ztest_equal(ret, -1, "Could get prio queue parameters (%d)", errno);
+	ztest_equal(errno, EINVAL, "prio queue get parameters");
 }
 
 static void test_ethernet_get_unknown_opt_kernel(void)
@@ -529,8 +529,8 @@ static void test_ethernet_set_unknown_option(void)
 	ret = setsockopt(fd, SOL_NET_MGMT_RAW,
 			 NET_REQUEST_ETHERNET_SET_MAC_ADDRESS,
 			 &params, optlen);
-	zassert_equal(ret, -1, "Could set promisc_mode parameters (%d)", errno);
-	zassert_equal(errno, EINVAL, "promisc_mode set parameters");
+	ztest_equal(ret, -1, "Could set promisc_mode parameters (%d)", errno);
+	ztest_equal(errno, EINVAL, "promisc_mode set parameters");
 }
 
 static void test_ethernet_set_unknown_opt_kernel(void)

--- a/tests/net/socket/poll/src/main.c
+++ b/tests/net/socket/poll/src/main.c
@@ -52,10 +52,10 @@ void test_poll(void)
 			    &s_sock_tcp, &s_addr);
 
 	res = bind(s_sock, (struct sockaddr *)&s_addr, sizeof(s_addr));
-	zassert_equal(res, 0, "bind failed");
+	ztest_equal(res, 0, "bind failed");
 
 	res = connect(c_sock, (struct sockaddr *)&s_addr, sizeof(s_addr));
-	zassert_equal(res, 0, "connect failed");
+	ztest_equal(res, 0, "connect failed");
 
 	memset(pollfds, 0, sizeof(pollfds));
 	pollfds[0].fd = c_sock;
@@ -66,53 +66,53 @@ void test_poll(void)
 	/* Poll non-ready fd's with timeout of 0 */
 	tstamp = k_uptime_get_32();
 	res = poll(pollfds, ARRAY_SIZE(pollfds), 0);
-	zassert_true(k_uptime_get_32() - tstamp <= FUZZ, "");
-	zassert_equal(res, 0, "");
+	ztest_true(k_uptime_get_32() - tstamp <= FUZZ, "");
+	ztest_equal(res, 0, "");
 
-	zassert_equal(pollfds[0].fd, c_sock, "");
-	zassert_equal(pollfds[0].events, POLLIN, "");
-	zassert_equal(pollfds[0].revents, 0, "");
-	zassert_equal(pollfds[1].fd, s_sock, "");
-	zassert_equal(pollfds[1].events, POLLIN, "");
-	zassert_equal(pollfds[1].revents, 0, "");
+	ztest_equal(pollfds[0].fd, c_sock, "");
+	ztest_equal(pollfds[0].events, POLLIN, "");
+	ztest_equal(pollfds[0].revents, 0, "");
+	ztest_equal(pollfds[1].fd, s_sock, "");
+	ztest_equal(pollfds[1].events, POLLIN, "");
+	ztest_equal(pollfds[1].revents, 0, "");
 
 
 	/* Poll non-ready fd's with timeout of 30 */
 	tstamp = k_uptime_get_32();
 	res = poll(pollfds, ARRAY_SIZE(pollfds), 30);
 	tstamp = k_uptime_get_32() - tstamp;
-	zassert_true(tstamp >= 30U && tstamp <= 30 + FUZZ * 2, "tstamp %d",
+	ztest_true(tstamp >= 30U && tstamp <= 30 + FUZZ * 2, "tstamp %d",
 		     tstamp);
-	zassert_equal(res, 0, "");
+	ztest_equal(res, 0, "");
 
 
 	/* Send pkt for s_sock and poll with timeout of 10 */
 	len = send(c_sock, BUF_AND_SIZE(TEST_STR_SMALL), 0);
-	zassert_equal(len, STRLEN(TEST_STR_SMALL), "invalid send len");
+	ztest_equal(len, STRLEN(TEST_STR_SMALL), "invalid send len");
 
 	tstamp = k_uptime_get_32();
 	res = poll(pollfds, ARRAY_SIZE(pollfds), 30);
 	tstamp = k_uptime_get_32() - tstamp;
-	zassert_true(tstamp <= FUZZ, "");
-	zassert_equal(res, 1, "");
+	ztest_true(tstamp <= FUZZ, "");
+	ztest_equal(res, 1, "");
 
-	zassert_equal(pollfds[0].fd, c_sock, "");
-	zassert_equal(pollfds[0].events, POLLIN, "");
-	zassert_equal(pollfds[0].revents, 0, "");
-	zassert_equal(pollfds[1].fd, s_sock, "");
-	zassert_equal(pollfds[1].events, POLLIN, "");
-	zassert_equal(pollfds[1].revents, POLLIN, "");
+	ztest_equal(pollfds[0].fd, c_sock, "");
+	ztest_equal(pollfds[0].events, POLLIN, "");
+	ztest_equal(pollfds[0].revents, 0, "");
+	ztest_equal(pollfds[1].fd, s_sock, "");
+	ztest_equal(pollfds[1].events, POLLIN, "");
+	ztest_equal(pollfds[1].revents, POLLIN, "");
 
 
 	/* Recv pkt from s_sock and ensure no poll events happen */
 	len = recv(s_sock, BUF_AND_SIZE(buf), 0);
-	zassert_equal(len, STRLEN(TEST_STR_SMALL), "invalid recv len");
+	ztest_equal(len, STRLEN(TEST_STR_SMALL), "invalid recv len");
 
 	tstamp = k_uptime_get_32();
 	res = poll(pollfds, ARRAY_SIZE(pollfds), 0);
-	zassert_true(k_uptime_get_32() - tstamp <= FUZZ, "");
-	zassert_equal(res, 0, "");
-	zassert_equal(pollfds[1].revents, 0, "");
+	ztest_true(k_uptime_get_32() - tstamp <= FUZZ, "");
+	ztest_equal(res, 0, "");
+	ztest_equal(pollfds[1].revents, 0, "");
 
 	/* Make sure that POLLOUT does not wait if not really needed */
 	memset(pollout, 0, sizeof(pollout));
@@ -121,13 +121,13 @@ void test_poll(void)
 
 	res = connect(c_sock, (const struct sockaddr *)&s_addr,
 		      sizeof(s_addr));
-	zassert_equal(res, 0, "");
+	ztest_equal(res, 0, "");
 
 	tstamp = k_uptime_get_32();
 	res = poll(pollout, ARRAY_SIZE(pollout), K_MSEC(200));
-	zassert_true(k_uptime_get_32() - tstamp < K_MSEC(100), "");
-	zassert_equal(res, 1, "");
-	zassert_equal(pollout[0].revents, POLLOUT, "");
+	ztest_true(k_uptime_get_32() - tstamp < K_MSEC(100), "");
+	ztest_equal(res, 1, "");
+	ztest_equal(pollout[0].revents, POLLOUT, "");
 
 	/* First test that TCP POLLOUT will not wait if there is enough
 	 * room in TCP window
@@ -137,40 +137,40 @@ void test_poll(void)
 	pollout[0].events = POLLOUT;
 
 	res = bind(s_sock_tcp, (struct sockaddr *)&s_addr, sizeof(s_addr));
-	zassert_equal(res, 0, "");
+	ztest_equal(res, 0, "");
 	res = listen(s_sock_tcp, 0);
-	zassert_equal(res, 0, "");
+	ztest_equal(res, 0, "");
 
 	res = connect(c_sock_tcp, (const struct sockaddr *)&s_addr,
 		      sizeof(s_addr));
-	zassert_equal(res, 0, "");
+	ztest_equal(res, 0, "");
 
 	tstamp = k_uptime_get_32();
 	res = poll(pollout, ARRAY_SIZE(pollout), K_MSEC(200));
-	zassert_true(k_uptime_get_32() - tstamp < K_MSEC(100), "");
-	zassert_equal(res, 1, "");
-	zassert_equal(pollout[0].revents, POLLOUT, "");
+	ztest_true(k_uptime_get_32() - tstamp < K_MSEC(100), "");
+	ztest_equal(res, 1, "");
+	ztest_equal(pollout[0].revents, POLLOUT, "");
 
 	res = close(c_sock_tcp);
-	zassert_equal(res, 0, "close failed");
+	ztest_equal(res, 0, "close failed");
 
 	res = close(s_sock_tcp);
-	zassert_equal(res, 0, "close failed");
+	ztest_equal(res, 0, "close failed");
 
 	/* Close one socket and ensure POLLNVAL happens */
 	res = close(c_sock);
-	zassert_equal(res, 0, "close failed");
+	ztest_equal(res, 0, "close failed");
 
 	tstamp = k_uptime_get_32();
 	res = poll(pollfds, ARRAY_SIZE(pollfds), 0);
-	zassert_true(k_uptime_get_32() - tstamp <= FUZZ, "");
-	zassert_equal(res, 1, "");
-	zassert_equal(pollfds[0].revents, POLLNVAL, "");
-	zassert_equal(pollfds[1].revents, 0, "");
+	ztest_true(k_uptime_get_32() - tstamp <= FUZZ, "");
+	ztest_equal(res, 1, "");
+	ztest_equal(pollfds[0].revents, POLLNVAL, "");
+	ztest_equal(pollfds[1].revents, 0, "");
 
 
 	res = close(s_sock);
-	zassert_equal(res, 0, "close failed");
+	ztest_equal(res, 0, "close failed");
 }
 
 void test_main(void)

--- a/tests/net/socket/register/src/main.c
+++ b/tests/net/socket/register/src/main.c
@@ -237,12 +237,12 @@ void test_create_sockets(void)
 			continue;
 		}
 
-		zassert_equal(fd, expected_result[i].result,
+		ztest_equal(fd, expected_result[i].result,
 			      "[%d] Invalid result (expecting %d got %d, "
 			      "errno %d)", i, expected_result[i].result, fd,
 			      errno);
 		if (expected_result[i].result < 0) {
-			zassert_equal(errno, expected_result[i].error,
+			ztest_equal(errno, expected_result[i].error,
 				      "[%d] Invalid errno (%d vs %d)", i,
 				      errno, expected_result[i].error);
 		}
@@ -258,7 +258,7 @@ void test_create_sockets(void)
 		}
 	}
 
-	zassert_equal(ok_tests + failed_tests - failed_family, func_called,
+	ztest_equal(ok_tests + failed_tests - failed_family, func_called,
 		      "Invalid num of tests failed (%d vs %d)",
 		      ok_tests + failed_tests - failed_family, func_called);
 }

--- a/tests/net/socket/select/src/main.c
+++ b/tests/net/socket/select/src/main.c
@@ -31,34 +31,34 @@ void test_fd_set(void)
 	fd_set set;
 
 	/* Relies on specific value of CONFIG_POSIX_MAX_FDS in prj.conf */
-	zassert_equal(sizeof(set.bitset), sizeof(u32_t) * 2, "");
+	ztest_equal(sizeof(set.bitset), sizeof(u32_t) * 2, "");
 
 	FD_ZERO(&set);
-	zassert_equal(set.bitset[0], 0, "");
-	zassert_equal(set.bitset[1], 0, "");
-	zassert_false(FD_ISSET(0, &set), "");
+	ztest_equal(set.bitset[0], 0, "");
+	ztest_equal(set.bitset[1], 0, "");
+	ztest_false(FD_ISSET(0, &set), "");
 
 	FD_SET(0, &set);
-	zassert_true(FD_ISSET(0, &set), "");
+	ztest_true(FD_ISSET(0, &set), "");
 
 	FD_CLR(0, &set);
-	zassert_false(FD_ISSET(0, &set), "");
+	ztest_false(FD_ISSET(0, &set), "");
 
 	FD_SET(0, &set);
-	zassert_equal(set.bitset[0], 0x00000001, "");
-	zassert_equal(set.bitset[1], 0, "");
+	ztest_equal(set.bitset[0], 0x00000001, "");
+	ztest_equal(set.bitset[1], 0, "");
 
 	FD_SET(31, &set);
-	zassert_equal(set.bitset[0], 0x80000001, "");
-	zassert_equal(set.bitset[1], 0, "");
+	ztest_equal(set.bitset[0], 0x80000001, "");
+	ztest_equal(set.bitset[1], 0, "");
 
 	FD_SET(33, &set);
-	zassert_equal(set.bitset[0], 0x80000001, "");
-	zassert_equal(set.bitset[1], 0x00000002, "");
+	ztest_equal(set.bitset[0], 0x80000001, "");
+	ztest_equal(set.bitset[1], 0x00000002, "");
 
 	FD_ZERO(&set);
-	zassert_equal(set.bitset[0], 0, "");
-	zassert_equal(set.bitset[1], 0, "");
+	ztest_equal(set.bitset[0], 0, "");
+	ztest_equal(set.bitset[1], 0, "");
 }
 
 void test_select(void)
@@ -80,10 +80,10 @@ void test_select(void)
 			    &s_sock, &s_addr);
 
 	res = bind(s_sock, (struct sockaddr *)&s_addr, sizeof(s_addr));
-	zassert_equal(res, 0, "bind failed");
+	ztest_equal(res, 0, "bind failed");
 
 	res = connect(c_sock, (struct sockaddr *)&s_addr, sizeof(s_addr));
-	zassert_equal(res, 0, "connect failed");
+	ztest_equal(res, 0, "connect failed");
 
 	FD_ZERO(&readfds);
 	FD_SET(c_sock, &readfds);
@@ -98,11 +98,11 @@ void test_select(void)
 	 * preempt the thread. That's why we add FUZZ to the expected
 	 * delay time. Also applies to similar cases below.
 	 */
-	zassert_true(tstamp <= FUZZ, "");
-	zassert_equal(res, 0, "");
+	ztest_true(tstamp <= FUZZ, "");
+	ztest_equal(res, 0, "");
 
-	zassert_false(FD_ISSET(c_sock, &readfds), "");
-	zassert_false(FD_ISSET(s_sock, &readfds), "");
+	ztest_false(FD_ISSET(c_sock, &readfds), "");
+	ztest_false(FD_ISSET(s_sock, &readfds), "");
 
 	/* Poll non-ready fd's with timeout of 10ms */
 	FD_SET(c_sock, &readfds);
@@ -112,13 +112,13 @@ void test_select(void)
 	tstamp = k_uptime_get_32();
 	res = select(s_sock + 1, &readfds, NULL, NULL, &tval);
 	tstamp = k_uptime_get_32() - tstamp;
-	zassert_true(tstamp >= 30U && tstamp <= 30 + FUZZ, "");
-	zassert_equal(res, 0, "");
+	ztest_true(tstamp >= 30U && tstamp <= 30 + FUZZ, "");
+	ztest_equal(res, 0, "");
 
 
 	/* Send pkt for s_sock and poll with timeout of 10ms */
 	len = send(c_sock, BUF_AND_SIZE(TEST_STR_SMALL), 0);
-	zassert_equal(len, STRLEN(TEST_STR_SMALL), "invalid send len");
+	ztest_equal(len, STRLEN(TEST_STR_SMALL), "invalid send len");
 
 	FD_SET(c_sock, &readfds);
 	FD_SET(s_sock, &readfds);
@@ -127,42 +127,42 @@ void test_select(void)
 	tstamp = k_uptime_get_32();
 	res = select(s_sock + 1, &readfds, NULL, NULL, &tval);
 	tstamp = k_uptime_get_32() - tstamp;
-	zassert_true(tstamp <= FUZZ, "");
-	zassert_equal(res, 1, "");
+	ztest_true(tstamp <= FUZZ, "");
+	ztest_equal(res, 1, "");
 
-	zassert_false(FD_ISSET(c_sock, &readfds), "");
-	zassert_true(FD_ISSET(s_sock, &readfds), "");
+	ztest_false(FD_ISSET(c_sock, &readfds), "");
+	ztest_true(FD_ISSET(s_sock, &readfds), "");
 
 
 	/* Recv pkt from s_sock and ensure no poll events happen */
 	len = recv(s_sock, BUF_AND_SIZE(buf), 0);
-	zassert_equal(len, STRLEN(TEST_STR_SMALL), "invalid recv len");
+	ztest_equal(len, STRLEN(TEST_STR_SMALL), "invalid recv len");
 
 	FD_SET(c_sock, &readfds);
 	FD_SET(s_sock, &readfds);
 	tval.tv_sec = tval.tv_usec = 0;
 	tstamp = k_uptime_get_32();
 	res = select(s_sock + 1, &readfds, NULL, NULL, &tval);
-	zassert_true(k_uptime_get_32() - tstamp <= FUZZ, "");
-	zassert_equal(res, 0, "");
-	zassert_false(FD_ISSET(s_sock, &readfds), "");
+	ztest_true(k_uptime_get_32() - tstamp <= FUZZ, "");
+	ztest_equal(res, 0, "");
+	ztest_false(FD_ISSET(s_sock, &readfds), "");
 
 
 	/* Close one socket and ensure POLLNVAL happens */
 	res = close(c_sock);
-	zassert_equal(res, 0, "close failed");
+	ztest_equal(res, 0, "close failed");
 
 	FD_SET(c_sock, &readfds);
 	FD_SET(s_sock, &readfds);
 	tval.tv_sec = tval.tv_usec = 0;
 	tstamp = k_uptime_get_32();
 	res = select(s_sock + 1, &readfds, NULL, NULL, &tval);
-	zassert_true(k_uptime_get_32() - tstamp <= FUZZ, "");
-	zassert_true(res < 0, "");
-	zassert_equal(errno, EBADF, "");
+	ztest_true(k_uptime_get_32() - tstamp <= FUZZ, "");
+	ztest_true(res < 0, "");
+	ztest_equal(errno, EBADF, "");
 
 	res = close(s_sock);
-	zassert_equal(res, 0, "close failed");
+	ztest_equal(res, 0, "close failed");
 }
 
 void test_main(void)

--- a/tests/net/socket/socket_helpers.h
+++ b/tests/net/socket/socket_helpers.h
@@ -14,17 +14,17 @@ static inline int prepare_listen_sock_udp_v4(struct sockaddr_in *addr)
 {
 	int ret, sock;
 
-	zassert_not_null(addr, "null sockaddr");
+	ztest_not_null(addr, "null sockaddr");
 
 	ret = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-	zassert_true(ret >= 0, "socket open failed");
+	ztest_true(ret >= 0, "socket open failed");
 
 	sock = ret;
 
-	zassert_equal(addr->sin_family, AF_INET, "Invalid family");
+	ztest_equal(addr->sin_family, AF_INET, "Invalid family");
 
 	ret = bind(sock, (struct sockaddr *)addr, sizeof(*addr));
-	zassert_equal(ret, 0, "bind failed (%d/%d)", ret, errno);
+	ztest_equal(ret, 0, "bind failed (%d/%d)", ret, errno);
 
 	return sock;
 }
@@ -33,17 +33,17 @@ static inline int prepare_listen_sock_udp_v6(struct sockaddr_in6 *addr)
 {
 	int ret, sock;
 
-	zassert_not_null(addr, "null sockaddr");
+	ztest_not_null(addr, "null sockaddr");
 
 	ret = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
-	zassert_true(ret >= 0, "socket open failed");
+	ztest_true(ret >= 0, "socket open failed");
 
 	sock = ret;
 
-	zassert_equal(addr->sin6_family, AF_INET6, "Invalid family");
+	ztest_equal(addr->sin6_family, AF_INET6, "Invalid family");
 
 	ret = bind(sock, (struct sockaddr *)addr, sizeof(*addr));
-	zassert_equal(ret, 0, "bind failed (%d/%d)", ret, errno);
+	ztest_equal(ret, 0, "bind failed (%d/%d)", ret, errno);
 
 	return sock;
 }
@@ -53,17 +53,17 @@ static inline void prepare_sock_udp_v4(const char *addr, u16_t port,
 {
 	int rv;
 
-	zassert_not_null(addr, "null addr");
-	zassert_not_null(sock, "null sock");
-	zassert_not_null(sockaddr, "null sockaddr");
+	ztest_not_null(addr, "null addr");
+	ztest_not_null(sock, "null sock");
+	ztest_not_null(sockaddr, "null sockaddr");
 
 	*sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-	zassert_true(*sock >= 0, "socket open failed");
+	ztest_true(*sock >= 0, "socket open failed");
 
 	sockaddr->sin_family = AF_INET;
 	sockaddr->sin_port = htons(port);
 	rv = inet_pton(AF_INET, addr, &sockaddr->sin_addr);
-	zassert_equal(rv, 1, "inet_pton failed");
+	ztest_equal(rv, 1, "inet_pton failed");
 }
 
 static inline void prepare_sock_udp_v6(const char *addr, u16_t port,
@@ -71,18 +71,18 @@ static inline void prepare_sock_udp_v6(const char *addr, u16_t port,
 {
 	int rv;
 
-	zassert_not_null(addr, "null addr");
-	zassert_not_null(sock, "null sock");
-	zassert_not_null(sockaddr, "null sockaddr");
+	ztest_not_null(addr, "null addr");
+	ztest_not_null(sock, "null sock");
+	ztest_not_null(sockaddr, "null sockaddr");
 
 	*sock = zsock_socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
-	zassert_true(*sock >= 0, "socket open failed");
+	ztest_true(*sock >= 0, "socket open failed");
 
 	(void)memset(sockaddr, 0, sizeof(*sockaddr));
 	sockaddr->sin6_family = AF_INET6;
 	sockaddr->sin6_port = htons(port);
 	rv = zsock_inet_pton(AF_INET6, addr, &sockaddr->sin6_addr);
-	zassert_equal(rv, 1, "inet_pton failed");
+	ztest_equal(rv, 1, "inet_pton failed");
 }
 
 static inline void prepare_sock_tcp_v4(const char *addr, u16_t port,
@@ -90,17 +90,17 @@ static inline void prepare_sock_tcp_v4(const char *addr, u16_t port,
 {
 	int rv;
 
-	zassert_not_null(addr, "null addr");
-	zassert_not_null(sock, "null sock");
-	zassert_not_null(sockaddr, "null sockaddr");
+	ztest_not_null(addr, "null addr");
+	ztest_not_null(sock, "null sock");
+	ztest_not_null(sockaddr, "null sockaddr");
 
 	*sock = zsock_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-	zassert_true(*sock >= 0, "socket open failed");
+	ztest_true(*sock >= 0, "socket open failed");
 
 	sockaddr->sin_family = AF_INET;
 	sockaddr->sin_port = htons(port);
 	rv = zsock_inet_pton(AF_INET, addr, &sockaddr->sin_addr);
-	zassert_equal(rv, 1, "inet_pton failed");
+	ztest_equal(rv, 1, "inet_pton failed");
 }
 
 static inline void prepare_sock_tcp_v6(const char *addr, u16_t port,
@@ -108,15 +108,15 @@ static inline void prepare_sock_tcp_v6(const char *addr, u16_t port,
 {
 	int rv;
 
-	zassert_not_null(addr, "null addr");
-	zassert_not_null(sock, "null sock");
-	zassert_not_null(sockaddr, "null sockaddr");
+	ztest_not_null(addr, "null addr");
+	ztest_not_null(sock, "null sock");
+	ztest_not_null(sockaddr, "null sockaddr");
 
 	*sock = zsock_socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
-	zassert_true(*sock >= 0, "socket open failed");
+	ztest_true(*sock >= 0, "socket open failed");
 
 	sockaddr->sin6_family = AF_INET6;
 	sockaddr->sin6_port = htons(port);
 	rv = zsock_inet_pton(AF_INET6, addr, &sockaddr->sin6_addr);
-	zassert_equal(rv, 1, "inet_pton failed");
+	ztest_equal(rv, 1, "inet_pton failed");
 }

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -24,28 +24,28 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 static void test_bind(int sock, struct sockaddr *addr, socklen_t addrlen)
 {
-	zassert_equal(bind(sock, addr, addrlen),
+	ztest_equal(bind(sock, addr, addrlen),
 		      0,
 		      "bind failed");
 }
 
 static void test_listen(int sock)
 {
-	zassert_equal(listen(sock, MAX_CONNS),
+	ztest_equal(listen(sock, MAX_CONNS),
 		      0,
 		      "listen failed");
 }
 
 static void test_connect(int sock, struct sockaddr *addr, socklen_t addrlen)
 {
-	zassert_equal(connect(sock, addr, addrlen),
+	ztest_equal(connect(sock, addr, addrlen),
 		      0,
 		      "connect failed");
 }
 
 static void test_send(int sock, const void *buf, size_t len, int flags)
 {
-	zassert_equal(send(sock, buf, len, flags),
+	ztest_equal(send(sock, buf, len, flags),
 		      len,
 		      "send failed");
 }
@@ -53,7 +53,7 @@ static void test_send(int sock, const void *buf, size_t len, int flags)
 static void test_sendto(int sock, const void *buf, size_t len, int flags,
 			const struct sockaddr *addr, socklen_t addrlen)
 {
-	zassert_equal(sendto(sock, buf, len, flags, addr, addrlen),
+	ztest_equal(sendto(sock, buf, len, flags, addr, addrlen),
 		      len,
 		      "send failed");
 }
@@ -61,25 +61,25 @@ static void test_sendto(int sock, const void *buf, size_t len, int flags,
 static void test_accept(int sock, int *new_sock, struct sockaddr *addr,
 			socklen_t *addrlen)
 {
-	zassert_not_null(new_sock, "null newsock");
+	ztest_not_null(new_sock, "null newsock");
 
 	*new_sock = accept(sock, addr, addrlen);
-	zassert_true(*new_sock >= 0, "accept failed");
+	ztest_true(*new_sock >= 0, "accept failed");
 }
 
 static void test_accept_timeout(int sock, int *new_sock, struct sockaddr *addr,
 				socklen_t *addrlen)
 {
-	zassert_not_null(new_sock, "null newsock");
+	ztest_not_null(new_sock, "null newsock");
 
 	*new_sock = accept(sock, addr, addrlen);
-	zassert_equal(*new_sock, -1, "accept succeed");
-	zassert_equal(errno, EAGAIN, "");
+	ztest_equal(*new_sock, -1, "accept succeed");
+	ztest_equal(errno, EAGAIN, "");
 }
 
 static void test_fcntl(int sock, int cmd, int val)
 {
-	zassert_equal(fcntl(sock, cmd, val), 0, "fcntl failed");
+	ztest_equal(fcntl(sock, cmd, val), 0, "fcntl failed");
 }
 
 static void test_recv(int sock, int flags)
@@ -88,10 +88,10 @@ static void test_recv(int sock, int flags)
 	char rx_buf[30] = {0};
 
 	recved = recv(sock, rx_buf, sizeof(rx_buf), flags);
-	zassert_equal(recved,
+	ztest_equal(recved,
 		      strlen(TEST_STR_SMALL),
 		      "unexpected received bytes");
-	zassert_equal(strncmp(rx_buf, TEST_STR_SMALL, strlen(TEST_STR_SMALL)),
+	ztest_equal(strncmp(rx_buf, TEST_STR_SMALL, strlen(TEST_STR_SMALL)),
 		      0,
 		      "unexpected data");
 }
@@ -110,17 +110,17 @@ static void test_recvfrom(int sock,
 			  flags,
 			  addr,
 			  addrlen);
-	zassert_equal(recved,
+	ztest_equal(recved,
 		      strlen(TEST_STR_SMALL),
 		      "unexpected received bytes");
-	zassert_equal(strncmp(rx_buf, TEST_STR_SMALL, strlen(TEST_STR_SMALL)),
+	ztest_equal(strncmp(rx_buf, TEST_STR_SMALL, strlen(TEST_STR_SMALL)),
 		      0,
 		      "unexpected data");
 }
 
 static void test_close(int sock)
 {
-	zassert_equal(close(sock),
+	ztest_equal(close(sock),
 		      0,
 		      "close failed");
 }
@@ -135,16 +135,16 @@ static void test_eof(int sock)
 
 	/* Test that EOF properly detected. */
 	recved = recv(sock, rx_buf, sizeof(rx_buf), 0);
-	zassert_equal(recved, 0, "");
+	ztest_equal(recved, 0, "");
 
 	/* Calling again should be OK. */
 	recved = recv(sock, rx_buf, sizeof(rx_buf), 0);
-	zassert_equal(recved, 0, "");
+	ztest_equal(recved, 0, "");
 
 	/* Calling when TCP connection is fully torn down should be still OK. */
 	k_sleep(TCP_TEARDOWN_TIMEOUT);
 	recved = recv(sock, rx_buf, sizeof(rx_buf), 0);
-	zassert_equal(recved, 0, "");
+	ztest_equal(recved, 0, "");
 }
 
 void test_v4_send_recv(void)
@@ -170,7 +170,7 @@ void test_v4_send_recv(void)
 	test_send(c_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
 
 	test_accept(s_sock, &new_sock, &addr, &addrlen);
-	zassert_equal(addrlen, sizeof(struct sockaddr_in), "wrong addrlen");
+	ztest_equal(addrlen, sizeof(struct sockaddr_in), "wrong addrlen");
 
 	test_recv(new_sock, MSG_PEEK);
 	test_recv(new_sock, 0);
@@ -207,7 +207,7 @@ void test_v6_send_recv(void)
 	test_send(c_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
 
 	test_accept(s_sock, &new_sock, &addr, &addrlen);
-	zassert_equal(addrlen, sizeof(struct sockaddr_in6), "wrong addrlen");
+	ztest_equal(addrlen, sizeof(struct sockaddr_in6), "wrong addrlen");
 
 	test_recv(new_sock, MSG_PEEK);
 	test_recv(new_sock, 0);
@@ -244,13 +244,13 @@ void test_v4_sendto_recvfrom(void)
 		    (struct sockaddr *)&s_saddr, sizeof(s_saddr));
 
 	test_accept(s_sock, &new_sock, &addr, &addrlen);
-	zassert_equal(addrlen, sizeof(struct sockaddr_in), "wrong addrlen");
+	ztest_equal(addrlen, sizeof(struct sockaddr_in), "wrong addrlen");
 
 	test_recvfrom(new_sock, MSG_PEEK, &addr, &addrlen);
-	zassert_equal(addrlen, sizeof(struct sockaddr_in), "wrong addrlen");
+	ztest_equal(addrlen, sizeof(struct sockaddr_in), "wrong addrlen");
 
 	test_recvfrom(new_sock, 0, &addr, &addrlen);
-	zassert_equal(addrlen, sizeof(struct sockaddr_in), "wrong addrlen");
+	ztest_equal(addrlen, sizeof(struct sockaddr_in), "wrong addrlen");
 
 	test_close(new_sock);
 	test_close(s_sock);
@@ -283,13 +283,13 @@ void test_v6_sendto_recvfrom(void)
 		    (struct sockaddr *)&s_saddr, sizeof(s_saddr));
 
 	test_accept(s_sock, &new_sock, &addr, &addrlen);
-	zassert_equal(addrlen, sizeof(struct sockaddr_in6), "wrong addrlen");
+	ztest_equal(addrlen, sizeof(struct sockaddr_in6), "wrong addrlen");
 
 	test_recvfrom(new_sock, MSG_PEEK, &addr, &addrlen);
-	zassert_equal(addrlen, sizeof(struct sockaddr_in6), "wrong addrlen");
+	ztest_equal(addrlen, sizeof(struct sockaddr_in6), "wrong addrlen");
 
 	test_recvfrom(new_sock, 0, &addr, &addrlen);
-	zassert_equal(addrlen, sizeof(struct sockaddr_in6), "wrong addrlen");
+	ztest_equal(addrlen, sizeof(struct sockaddr_in6), "wrong addrlen");
 
 	test_close(new_sock);
 	test_close(s_sock);
@@ -322,7 +322,7 @@ void test_v4_sendto_recvfrom_null_dest(void)
 		    (struct sockaddr *)&s_saddr, sizeof(s_saddr));
 
 	test_accept(s_sock, &new_sock, &addr, &addrlen);
-	zassert_equal(addrlen, sizeof(struct sockaddr_in), "wrong addrlen");
+	ztest_equal(addrlen, sizeof(struct sockaddr_in), "wrong addrlen");
 
 	test_recvfrom(new_sock, 0, NULL, NULL);
 
@@ -357,7 +357,7 @@ void test_v6_sendto_recvfrom_null_dest(void)
 		    (struct sockaddr *)&s_saddr, sizeof(s_saddr));
 
 	test_accept(s_sock, &new_sock, &addr, &addrlen);
-	zassert_equal(addrlen, sizeof(struct sockaddr_in6), "wrong addrlen");
+	ztest_equal(addrlen, sizeof(struct sockaddr_in6), "wrong addrlen");
 
 	test_recvfrom(new_sock, 0, NULL, NULL);
 
@@ -402,7 +402,7 @@ void test_open_close_immediately(void)
 	 */
 	s_saddr.sin_port = htons(SERVER_PORT + 1);
 
-	zassert_not_equal(connect(c_sock, (struct sockaddr *)&s_saddr,
+	ztest_not_equal(connect(c_sock, (struct sockaddr *)&s_saddr,
 				  sizeof(s_saddr)),
 			  0, "connect succeed");
 	test_close(c_sock);
@@ -412,7 +412,7 @@ void test_open_close_immediately(void)
 
 	test_close(s_sock);
 
-	zassert_equal(count_before - 1, count_after,
+	ztest_equal(count_before - 1, count_after,
 		      "net_context still in use (before %d vs after %d)",
 		      count_before - 1, count_after);
 
@@ -439,7 +439,7 @@ void test_v4_accept_timeout(void)
 
 	tstamp = k_uptime_get_32();
 	test_accept_timeout(s_sock, &new_sock, &addr, &addrlen);
-	zassert_true(k_uptime_get_32() - tstamp <= 100, "");
+	ztest_true(k_uptime_get_32() - tstamp <= 100, "");
 
 	test_close(s_sock);
 

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -55,8 +55,8 @@ static void comm_sendto_recvfrom(int client_sock,
 	socklen_t addrlen2;
 	static char rx_buf[400] = {0};
 
-	zassert_not_null(client_addr, "null client addr");
-	zassert_not_null(server_addr, "null server addr");
+	ztest_not_null(client_addr, "null client addr");
+	ztest_not_null(server_addr, "null server addr");
 
 	/*
 	 * Test client -> server sending
@@ -64,33 +64,33 @@ static void comm_sendto_recvfrom(int client_sock,
 
 	sent = sendto(client_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL),
 		      0, server_addr, server_addrlen);
-	zassert_equal(sent, strlen(TEST_STR_SMALL), "sendto failed");
+	ztest_equal(sent, strlen(TEST_STR_SMALL), "sendto failed");
 
 	/* Test recvfrom(MSG_PEEK) */
 	addrlen = sizeof(addr);
 	clear_buf(rx_buf);
 	recved = recvfrom(server_sock, rx_buf, sizeof(rx_buf),
 			  MSG_PEEK, &addr, &addrlen);
-	zassert_true(recved >= 0, "recvfrom fail");
-	zassert_equal(recved, strlen(TEST_STR_SMALL),
+	ztest_true(recved >= 0, "recvfrom fail");
+	ztest_equal(recved, strlen(TEST_STR_SMALL),
 		      "unexpected received bytes");
-	zassert_mem_equal(rx_buf, BUF_AND_SIZE(TEST_STR_SMALL), "wrong data");
-	zassert_equal(addrlen, client_addrlen, "unexpected addrlen");
+	ztest_mem_equal(rx_buf, BUF_AND_SIZE(TEST_STR_SMALL), "wrong data");
+	ztest_equal(addrlen, client_addrlen, "unexpected addrlen");
 
 	/* Test normal recvfrom() */
 	addrlen = sizeof(addr);
 	clear_buf(rx_buf);
 	recved = recvfrom(server_sock, rx_buf, sizeof(rx_buf),
 			  0, &addr, &addrlen);
-	zassert_true(recved >= 0, "recvfrom fail");
-	zassert_equal(recved, strlen(TEST_STR_SMALL),
+	ztest_true(recved >= 0, "recvfrom fail");
+	ztest_equal(recved, strlen(TEST_STR_SMALL),
 		      "unexpected received bytes");
-	zassert_mem_equal(rx_buf, BUF_AND_SIZE(TEST_STR_SMALL), "wrong data");
-	zassert_equal(addrlen, client_addrlen, "unexpected addrlen");
+	ztest_mem_equal(rx_buf, BUF_AND_SIZE(TEST_STR_SMALL), "wrong data");
+	ztest_equal(addrlen, client_addrlen, "unexpected addrlen");
 
 	/* Check the client port */
 	if (net_sin(client_addr)->sin_port != ANY_PORT) {
-		zassert_equal(net_sin(client_addr)->sin_port,
+		ztest_equal(net_sin(client_addr)->sin_port,
 			      net_sin(&addr)->sin_port,
 			      "unexpected client port");
 	}
@@ -101,21 +101,21 @@ static void comm_sendto_recvfrom(int client_sock,
 
 	sent = sendto(server_sock, BUF_AND_SIZE(TEST_STR2),
 		      0, &addr, addrlen);
-	zassert_equal(sent, STRLEN(TEST_STR2), "sendto failed");
+	ztest_equal(sent, STRLEN(TEST_STR2), "sendto failed");
 
 	/* Test normal recvfrom() */
 	addrlen2 = sizeof(addr);
 	clear_buf(rx_buf);
 	recved = recvfrom(client_sock, rx_buf, sizeof(rx_buf),
 			  0, &addr2, &addrlen2);
-	zassert_true(recved >= 0, "recvfrom fail");
-	zassert_equal(recved, STRLEN(TEST_STR2),
+	ztest_true(recved >= 0, "recvfrom fail");
+	ztest_equal(recved, STRLEN(TEST_STR2),
 		      "unexpected received bytes");
-	zassert_mem_equal(rx_buf, BUF_AND_SIZE(TEST_STR2), "wrong data");
-	zassert_equal(addrlen2, server_addrlen, "unexpected addrlen");
+	ztest_mem_equal(rx_buf, BUF_AND_SIZE(TEST_STR2), "wrong data");
+	ztest_equal(addrlen2, server_addrlen, "unexpected addrlen");
 
 	/* Check the server port */
-	zassert_equal(net_sin(server_addr)->sin_port,
+	ztest_equal(net_sin(server_addr)->sin_port,
 		      net_sin(&addr2)->sin_port,
 		      "unexpected server port");
 
@@ -124,24 +124,24 @@ static void comm_sendto_recvfrom(int client_sock,
 	/* Send 2 datagrams */
 	sent = sendto(server_sock, BUF_AND_SIZE(TEST_STR2),
 		      0, &addr, addrlen);
-	zassert_equal(sent, STRLEN(TEST_STR2), "sendto failed");
+	ztest_equal(sent, STRLEN(TEST_STR2), "sendto failed");
 	sent = sendto(server_sock, BUF_AND_SIZE(TEST_STR_SMALL),
 		      0, &addr, addrlen);
-	zassert_equal(sent, STRLEN(TEST_STR_SMALL), "sendto failed");
+	ztest_equal(sent, STRLEN(TEST_STR_SMALL), "sendto failed");
 
 	/* Receive just beginning of 1st datagram */
 	addrlen2 = sizeof(addr);
 	clear_buf(rx_buf);
 	recved = recvfrom(client_sock, rx_buf, 16, 0, &addr2, &addrlen2);
-	zassert_true(recved == 16, "recvfrom fail");
-	zassert_mem_equal(rx_buf, TEST_STR2, 16, "wrong data");
+	ztest_true(recved == 16, "recvfrom fail");
+	ztest_mem_equal(rx_buf, TEST_STR2, 16, "wrong data");
 
 	/* Make sure that now we receive 2nd datagram */
 	addrlen2 = sizeof(addr);
 	clear_buf(rx_buf);
 	recved = recvfrom(client_sock, rx_buf, 16, 0, &addr2, &addrlen2);
-	zassert_true(recved == STRLEN(TEST_STR_SMALL), "recvfrom fail");
-	zassert_mem_equal(rx_buf, BUF_AND_SIZE(TEST_STR_SMALL), "wrong data");
+	ztest_true(recved == STRLEN(TEST_STR_SMALL), "recvfrom fail");
+	ztest_mem_equal(rx_buf, BUF_AND_SIZE(TEST_STR_SMALL), "wrong data");
 }
 
 void test_v4_sendto_recvfrom(void)
@@ -160,7 +160,7 @@ void test_v4_sendto_recvfrom(void)
 	rv = bind(server_sock,
 		  (struct sockaddr *)&server_addr,
 		  sizeof(server_addr));
-	zassert_equal(rv, 0, "bind failed");
+	ztest_equal(rv, 0, "bind failed");
 
 	comm_sendto_recvfrom(client_sock,
 			     (struct sockaddr *)&client_addr,
@@ -170,9 +170,9 @@ void test_v4_sendto_recvfrom(void)
 			     sizeof(server_addr));
 
 	rv = close(client_sock);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 	rv = close(server_sock);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 }
 
 void test_v6_sendto_recvfrom(void)
@@ -190,7 +190,7 @@ void test_v6_sendto_recvfrom(void)
 
 	rv = bind(server_sock,
 		  (struct sockaddr *)&server_addr, sizeof(server_addr));
-	zassert_equal(rv, 0, "bind failed");
+	ztest_equal(rv, 0, "bind failed");
 
 	comm_sendto_recvfrom(client_sock,
 			     (struct sockaddr *)&client_addr,
@@ -200,9 +200,9 @@ void test_v6_sendto_recvfrom(void)
 			     sizeof(server_addr));
 
 	rv = close(client_sock);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 	rv = close(server_sock);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 }
 
 void test_v4_bind_sendto(void)
@@ -220,11 +220,11 @@ void test_v4_bind_sendto(void)
 
 	rv = bind(client_sock,
 		  (struct sockaddr *)&client_addr, sizeof(client_addr));
-	zassert_equal(rv, 0, "bind failed");
+	ztest_equal(rv, 0, "bind failed");
 
 	rv = bind(server_sock,
 		  (struct sockaddr *)&server_addr, sizeof(server_addr));
-	zassert_equal(rv, 0, "bind failed");
+	ztest_equal(rv, 0, "bind failed");
 
 	comm_sendto_recvfrom(client_sock,
 			     (struct sockaddr *)&client_addr,
@@ -234,9 +234,9 @@ void test_v4_bind_sendto(void)
 			     sizeof(server_addr));
 
 	rv = close(client_sock);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 	rv = close(server_sock);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 }
 
 void test_v6_bind_sendto(void)
@@ -254,11 +254,11 @@ void test_v6_bind_sendto(void)
 
 	rv = bind(client_sock,
 		  (struct sockaddr *)&client_addr, sizeof(client_addr));
-	zassert_equal(rv, 0, "bind failed");
+	ztest_equal(rv, 0, "bind failed");
 
 	rv = bind(server_sock,
 		  (struct sockaddr *)&server_addr, sizeof(server_addr));
-	zassert_equal(rv, 0, "bind failed");
+	ztest_equal(rv, 0, "bind failed");
 
 	comm_sendto_recvfrom(client_sock,
 			     (struct sockaddr *)&client_addr,
@@ -268,9 +268,9 @@ void test_v6_bind_sendto(void)
 			     sizeof(server_addr));
 
 	rv = close(client_sock);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 	rv = close(server_sock);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 }
 
 void test_send_recv_2_sock(void)
@@ -286,28 +286,28 @@ void test_send_recv_2_sock(void)
 			    &sock2, &conn_addr);
 
 	rv = bind(sock1, (struct sockaddr *)&bind_addr, sizeof(bind_addr));
-	zassert_equal(rv, 0, "bind failed");
+	ztest_equal(rv, 0, "bind failed");
 
 	rv = connect(sock2, (struct sockaddr *)&conn_addr, sizeof(conn_addr));
-	zassert_equal(rv, 0, "connect failed");
+	ztest_equal(rv, 0, "connect failed");
 
 	len = send(sock2, BUF_AND_SIZE(TEST_STR_SMALL), 0);
-	zassert_equal(len, STRLEN(TEST_STR_SMALL), "invalid send len");
+	ztest_equal(len, STRLEN(TEST_STR_SMALL), "invalid send len");
 
 	clear_buf(buf);
 	len = recv(sock1, buf, sizeof(buf), MSG_PEEK);
-	zassert_equal(len, STRLEN(TEST_STR_SMALL), "Invalid recv len");
-	zassert_mem_equal(buf, BUF_AND_SIZE(TEST_STR_SMALL), "Wrong data");
+	ztest_equal(len, STRLEN(TEST_STR_SMALL), "Invalid recv len");
+	ztest_mem_equal(buf, BUF_AND_SIZE(TEST_STR_SMALL), "Wrong data");
 
 	clear_buf(buf);
 	len = recv(sock1, buf, sizeof(buf), 0);
-	zassert_equal(len, STRLEN(TEST_STR_SMALL), "Invalid recv len");
-	zassert_mem_equal(buf, BUF_AND_SIZE(TEST_STR_SMALL), "Wrong data");
+	ztest_equal(len, STRLEN(TEST_STR_SMALL), "Invalid recv len");
+	ztest_mem_equal(buf, BUF_AND_SIZE(TEST_STR_SMALL), "Wrong data");
 
 	rv = close(sock1);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 	rv = close(sock2);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 }
 
 void test_so_priority(void)
@@ -323,25 +323,25 @@ void test_so_priority(void)
 			    &sock2, &bind_addr6);
 
 	rv = bind(sock1, (struct sockaddr *)&bind_addr4, sizeof(bind_addr4));
-	zassert_equal(rv, 0, "bind failed");
+	ztest_equal(rv, 0, "bind failed");
 
 	rv = bind(sock2, (struct sockaddr *)&bind_addr6, sizeof(bind_addr6));
-	zassert_equal(rv, 0, "bind failed");
+	ztest_equal(rv, 0, "bind failed");
 
 	optval = 2;
 	rv = setsockopt(sock1, SOL_SOCKET, SO_PRIORITY, &optval,
 			sizeof(optval));
-	zassert_equal(rv, 0, "setsockopt failed (%d)", errno);
+	ztest_equal(rv, 0, "setsockopt failed (%d)", errno);
 
 	optval = 8;
 	rv = setsockopt(sock2, SOL_SOCKET, SO_PRIORITY, &optval,
 			sizeof(optval));
-	zassert_equal(rv, 0, "setsockopt failed");
+	ztest_equal(rv, 0, "setsockopt failed");
 
 	rv = close(sock1);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 	rv = close(sock2);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 }
 
 static void comm_sendmsg_recvfrom(int client_sock,
@@ -359,51 +359,51 @@ static void comm_sendmsg_recvfrom(int client_sock,
 	static char rx_buf[400];
 	int len, i;
 
-	zassert_not_null(client_addr, "null client addr");
-	zassert_not_null(server_addr, "null server addr");
+	ztest_not_null(client_addr, "null client addr");
+	ztest_not_null(server_addr, "null server addr");
 
 	/*
 	 * Test client -> server sending
 	 */
 
 	sent = sendmsg(client_sock, client_msg, 0);
-	zassert_true(sent > 0, "sendmsg failed (%d)", -errno);
+	ztest_true(sent > 0, "sendmsg failed (%d)", -errno);
 
 	for (i = 0, len = 0; i < client_msg->msg_iovlen; i++) {
 		len += client_msg->msg_iov[i].iov_len;
 	}
 
-	zassert_equal(sent, len, "iovec len (%d) vs sent (%d)", len, sent);
+	ztest_equal(sent, len, "iovec len (%d) vs sent (%d)", len, sent);
 
 	/* Test recvfrom(MSG_PEEK) */
 	addrlen = sizeof(addr);
 	clear_buf(rx_buf);
 	recved = recvfrom(server_sock, rx_buf, sizeof(rx_buf),
 			  MSG_PEEK, &addr, &addrlen);
-	zassert_true(recved >= 0, "recvfrom fail");
-	zassert_equal(recved, strlen(TEST_STR_SMALL),
+	ztest_true(recved >= 0, "recvfrom fail");
+	ztest_equal(recved, strlen(TEST_STR_SMALL),
 		      "unexpected received bytes");
-	zassert_equal(sent, recved, "sent(%d)/received(%d) mismatch",
+	ztest_equal(sent, recved, "sent(%d)/received(%d) mismatch",
 		      sent, recved);
 
-	zassert_mem_equal(rx_buf, BUF_AND_SIZE(TEST_STR_SMALL),
+	ztest_mem_equal(rx_buf, BUF_AND_SIZE(TEST_STR_SMALL),
 			  "wrong data (%s)", rx_buf);
-	zassert_equal(addrlen, client_addrlen, "unexpected addrlen");
+	ztest_equal(addrlen, client_addrlen, "unexpected addrlen");
 
 	/* Test normal recvfrom() */
 	addrlen = sizeof(addr);
 	clear_buf(rx_buf);
 	recved = recvfrom(server_sock, rx_buf, sizeof(rx_buf),
 			  0, &addr, &addrlen);
-	zassert_true(recved >= 0, "recvfrom fail");
-	zassert_equal(recved, strlen(TEST_STR_SMALL),
+	ztest_true(recved >= 0, "recvfrom fail");
+	ztest_equal(recved, strlen(TEST_STR_SMALL),
 		      "unexpected received bytes");
-	zassert_mem_equal(rx_buf, BUF_AND_SIZE(TEST_STR_SMALL), "wrong data");
-	zassert_equal(addrlen, client_addrlen, "unexpected addrlen");
+	ztest_mem_equal(rx_buf, BUF_AND_SIZE(TEST_STR_SMALL), "wrong data");
+	ztest_equal(addrlen, client_addrlen, "unexpected addrlen");
 
 	/* Check the client port */
 	if (net_sin(client_addr)->sin_port != ANY_PORT) {
-		zassert_equal(net_sin(client_addr)->sin_port,
+		ztest_equal(net_sin(client_addr)->sin_port,
 			      net_sin(&addr)->sin_port,
 			      "unexpected client port");
 	}
@@ -432,12 +432,12 @@ void test_v4_sendmsg_recvfrom(void)
 	rv = bind(server_sock,
 		  (struct sockaddr *)&server_addr,
 		  sizeof(server_addr));
-	zassert_equal(rv, 0, "server bind failed");
+	ztest_equal(rv, 0, "server bind failed");
 
 	rv = bind(client_sock,
 		  (struct sockaddr *)&client_addr,
 		  sizeof(client_addr));
-	zassert_equal(rv, 0, "client bind failed");
+	ztest_equal(rv, 0, "client bind failed");
 
 	io_vector[0].iov_base = TEST_STR_SMALL;
 	io_vector[0].iov_len = strlen(TEST_STR_SMALL);
@@ -465,9 +465,9 @@ void test_v4_sendmsg_recvfrom(void)
 			      sizeof(server_addr));
 
 	rv = close(client_sock);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 	rv = close(server_sock);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 }
 
 void test_v6_sendmsg_recvfrom(void)
@@ -492,12 +492,12 @@ void test_v6_sendmsg_recvfrom(void)
 
 	rv = bind(server_sock,
 		  (struct sockaddr *)&server_addr, sizeof(server_addr));
-	zassert_equal(rv, 0, "server bind failed");
+	ztest_equal(rv, 0, "server bind failed");
 
 	rv = bind(client_sock,
 		  (struct sockaddr *)&client_addr,
 		  sizeof(client_addr));
-	zassert_equal(rv, 0, "client bind failed");
+	ztest_equal(rv, 0, "client bind failed");
 
 	io_vector[0].iov_base = TEST_STR_SMALL;
 	io_vector[0].iov_len = strlen(TEST_STR_SMALL);
@@ -525,9 +525,9 @@ void test_v6_sendmsg_recvfrom(void)
 			      sizeof(server_addr));
 
 	rv = close(client_sock);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 	rv = close(server_sock);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 }
 
 void test_v4_sendmsg_recvfrom_connected(void)
@@ -553,16 +553,16 @@ void test_v4_sendmsg_recvfrom_connected(void)
 	rv = bind(server_sock,
 		  (struct sockaddr *)&server_addr,
 		  sizeof(server_addr));
-	zassert_equal(rv, 0, "server bind failed");
+	ztest_equal(rv, 0, "server bind failed");
 
 	rv = bind(client_sock,
 		  (struct sockaddr *)&client_addr,
 		  sizeof(client_addr));
-	zassert_equal(rv, 0, "client bind failed");
+	ztest_equal(rv, 0, "client bind failed");
 
 	rv = connect(client_sock, (struct sockaddr *)&server_addr,
 		     sizeof(server_addr));
-	zassert_equal(rv, 0, "connect failed");
+	ztest_equal(rv, 0, "connect failed");
 
 	io_vector[0].iov_base = TEST_STR_SMALL;
 	io_vector[0].iov_len = strlen(TEST_STR_SMALL);
@@ -588,9 +588,9 @@ void test_v4_sendmsg_recvfrom_connected(void)
 			      sizeof(server_addr));
 
 	rv = close(client_sock);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 	rv = close(server_sock);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 }
 
 void test_v6_sendmsg_recvfrom_connected(void)
@@ -615,16 +615,16 @@ void test_v6_sendmsg_recvfrom_connected(void)
 
 	rv = bind(server_sock,
 		  (struct sockaddr *)&server_addr, sizeof(server_addr));
-	zassert_equal(rv, 0, "server bind failed");
+	ztest_equal(rv, 0, "server bind failed");
 
 	rv = bind(client_sock,
 		  (struct sockaddr *)&client_addr,
 		  sizeof(client_addr));
-	zassert_equal(rv, 0, "client bind failed");
+	ztest_equal(rv, 0, "client bind failed");
 
 	rv = connect(client_sock, (struct sockaddr *)&server_addr,
 		     sizeof(server_addr));
-	zassert_equal(rv, 0, "connect failed");
+	ztest_equal(rv, 0, "connect failed");
 
 	io_vector[0].iov_base = TEST_STR_SMALL;
 	io_vector[0].iov_len = strlen(TEST_STR_SMALL);
@@ -650,9 +650,9 @@ void test_v6_sendmsg_recvfrom_connected(void)
 			      sizeof(server_addr));
 
 	rv = close(client_sock);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 	rv = close(server_sock);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 }
 
 void test_so_txtime(void)
@@ -669,39 +669,39 @@ void test_so_txtime(void)
 			    &sock2, &bind_addr6);
 
 	rv = bind(sock1, (struct sockaddr *)&bind_addr4, sizeof(bind_addr4));
-	zassert_equal(rv, 0, "bind failed");
+	ztest_equal(rv, 0, "bind failed");
 
 	rv = bind(sock2, (struct sockaddr *)&bind_addr6, sizeof(bind_addr6));
-	zassert_equal(rv, 0, "bind failed");
+	ztest_equal(rv, 0, "bind failed");
 
 	optval = true;
 	rv = setsockopt(sock1, SOL_SOCKET, SO_TXTIME, &optval,
 			sizeof(optval));
-	zassert_equal(rv, 0, "setsockopt failed (%d)", errno);
+	ztest_equal(rv, 0, "setsockopt failed (%d)", errno);
 
 	optval = false;
 	rv = setsockopt(sock2, SOL_SOCKET, SO_TXTIME, &optval,
 			sizeof(optval));
-	zassert_equal(rv, 0, "setsockopt failed");
+	ztest_equal(rv, 0, "setsockopt failed");
 
 	optlen = sizeof(optval);
 	rv = getsockopt(sock1, SOL_SOCKET, SO_TXTIME, &optval, &optlen);
-	zassert_equal(rv, 0, "getsockopt failed (%d)", errno);
-	zassert_equal(optlen, sizeof(optval), "invalid optlen %d vs %d",
+	ztest_equal(rv, 0, "getsockopt failed (%d)", errno);
+	ztest_equal(optlen, sizeof(optval), "invalid optlen %d vs %d",
 		      optlen, sizeof(optval));
-	zassert_equal(optval, true, "getsockopt txtime");
+	ztest_equal(optval, true, "getsockopt txtime");
 
 	optlen = sizeof(optval);
 	rv = getsockopt(sock2, SOL_SOCKET, SO_TXTIME, &optval, &optlen);
-	zassert_equal(rv, 0, "getsockopt failed (%d)", errno);
-	zassert_equal(optlen, sizeof(optval), "invalid optlen %d vs %d",
+	ztest_equal(rv, 0, "getsockopt failed (%d)", errno);
+	ztest_equal(optlen, sizeof(optval), "invalid optlen %d vs %d",
 		      optlen, sizeof(optval));
-	zassert_equal(optval, false, "getsockopt txtime");
+	ztest_equal(optval, false, "getsockopt txtime");
 
 	rv = close(sock1);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 	rv = close(sock2);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 }
 
 static void comm_sendmsg_with_txtime(int client_sock,
@@ -712,20 +712,20 @@ static void comm_sendmsg_with_txtime(int client_sock,
 	ssize_t sent;
 	int len, i;
 
-	zassert_not_null(client_addr, "null client addr");
+	ztest_not_null(client_addr, "null client addr");
 
 	/*
 	 * Test client -> server sending
 	 */
 
 	sent = sendmsg(client_sock, client_msg, 0);
-	zassert_true(sent > 0, "sendmsg failed (%d)", -errno);
+	ztest_true(sent > 0, "sendmsg failed (%d)", -errno);
 
 	for (i = 0, len = 0; i < client_msg->msg_iovlen; i++) {
 		len += client_msg->msg_iov[i].iov_len;
 	}
 
-	zassert_equal(sent, len, "iovec len (%d) vs sent (%d)", len, sent);
+	ztest_equal(sent, len, "iovec len (%d) vs sent (%d)", len, sent);
 }
 
 /* In order to verify that the network device driver is able to receive
@@ -818,14 +818,14 @@ static void setup_eth(void)
 	int ret;
 
 	eth_iface = net_if_get_first_by_type(&NET_L2_GET_NAME(ETHERNET));
-	zassert_not_null(eth_iface, "No ethernet interface found");
+	ztest_not_null(eth_iface, "No ethernet interface found");
 
 	ifaddr = net_if_ipv6_addr_add(eth_iface, &my_addr1,
 				      NET_ADDR_MANUAL, 0);
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr1));
-		zassert_not_null(ifaddr, "addr1");
+		ztest_not_null(ifaddr, "addr1");
 	}
 
 	net_if_up(eth_iface);
@@ -834,7 +834,7 @@ static void setup_eth(void)
 	server_addr.sin6_family = AF_INET6;
 	server_addr.sin6_port = htons(1234);
 	ret = inet_pton(AF_INET6, PEER_IPV6_ADDR, &server_addr.sin6_addr);
-	zassert_equal(ret, 1, "inet_pton failed");
+	ztest_equal(ret, 1, "inet_pton failed");
 
 	/* In order to avoid neighbor discovery, populate neighbor cache */
 	net_ipv6_nbr_add(eth_iface, &server_addr.sin6_addr, &server_link_addr,
@@ -862,7 +862,7 @@ void test_v6_sendmsg_with_txtime(void)
 	rv = bind(client_sock,
 		  (struct sockaddr *)&client_addr,
 		  sizeof(client_addr));
-	zassert_equal(rv, 0, "client bind failed");
+	ztest_equal(rv, 0, "client bind failed");
 
 	io_vector[0].iov_base = TEST_STR_SMALL;
 	io_vector[0].iov_len = strlen(TEST_STR_SMALL);
@@ -895,13 +895,13 @@ void test_v6_sendmsg_with_txtime(void)
 				 &msg);
 
 	rv = close(client_sock);
-	zassert_equal(rv, 0, "close failed");
+	ztest_equal(rv, 0, "close failed");
 
 	if (sys_mutex_lock(&wait_data, WAIT_TIME)) {
-		zassert_true(false, "Timeout DNS query not received");
+		ztest_true(false, "Timeout DNS query not received");
 	}
 
-	zassert_false(test_failed, "Invalid txtime received");
+	ztest_false(test_failed, "Invalid txtime received");
 
 	test_started = false;
 }

--- a/tests/net/socket/websocket/src/main.c
+++ b/tests/net/socket/websocket/src/main.c
@@ -131,7 +131,7 @@ static void test_recv(int count)
 				    recv_buf + total_read,
 				    sizeof(recv_buf) - total_read);
 		if (count < 7 && (i * count) < FRAME1_HDR_SIZE) {
-			zassert_equal(ret, -EAGAIN,
+			ztest_equal(ret, -EAGAIN,
 				      "[%d] Header parse failed (ret %d)",
 				      i * count, ret);
 		} else {
@@ -147,10 +147,10 @@ static void test_recv(int count)
 				    &ctx, &msg_type, &remaining,
 				    recv_buf + total_read,
 				    sizeof(recv_buf) - total_read);
-		zassert_true(ret <= (sizeof(recv_buf) - total_read),
+		ztest_true(ret <= (sizeof(recv_buf) - total_read),
 			     "Invalid number of bytes read (%d)", ret);
 		total_read += ret;
-		zassert_equal(total_read, sizeof(frame1) - FRAME1_HDR_SIZE,
+		ztest_equal(total_read, sizeof(frame1) - FRAME1_HDR_SIZE,
 			      "Invalid amount of data read (%d)", ret);
 
 	} else if (total_read < (sizeof(frame1) - FRAME1_HDR_SIZE)) {
@@ -164,15 +164,15 @@ static void test_recv(int count)
 				    recv_buf + total_read,
 				    sizeof(recv_buf) - total_read);
 		total_read += ret;
-		zassert_equal(total_read, sizeof(frame1) - FRAME1_HDR_SIZE,
+		ztest_equal(total_read, sizeof(frame1) - FRAME1_HDR_SIZE,
 			      "Invalid amount of data read (%d)", ret);
 	}
 
-	zassert_mem_equal(recv_buf, frame1_msg, sizeof(frame1_msg) - 1,
+	ztest_mem_equal(recv_buf, frame1_msg, sizeof(frame1_msg) - 1,
 			  "Invalid message, should be '%s' was '%s'",
 			  frame1_msg, recv_buf);
 
-	zassert_equal(remaining, 0, "Msg not empty");
+	ztest_equal(remaining, 0, "Msg not empty");
 }
 
 static void test_recv_1_byte(void)
@@ -246,11 +246,11 @@ static void test_recv_2(int count)
 	total_read = test_recv_buf(&feed_buf[0], count, &ctx, &msg_type,
 				   &remaining, recv_buf, sizeof(recv_buf));
 
-	zassert_mem_equal(recv_buf, frame1_msg, sizeof(frame1_msg) - 1,
+	ztest_mem_equal(recv_buf, frame1_msg, sizeof(frame1_msg) - 1,
 			  "Invalid message, should be '%s' was '%s'",
 			  frame1_msg, recv_buf);
 
-	zassert_equal(remaining, 0, "Msg not empty");
+	ztest_equal(remaining, 0, "Msg not empty");
 
 	/* Then read again, now we should get EAGAIN as the second message
 	 * header is partially read.
@@ -258,10 +258,10 @@ static void test_recv_2(int count)
 	ret = test_recv_buf(&feed_buf[sizeof(frame1)], count, &ctx, &msg_type,
 			    &remaining, recv_buf, sizeof(recv_buf));
 
-	zassert_equal(ret, sizeof(frame1_msg) - 1,
+	ztest_equal(ret, sizeof(frame1_msg) - 1,
 		      "2nd header parse failed (ret %d)", ret);
 
-	zassert_equal(remaining, 0, "Msg not empty");
+	ztest_equal(remaining, 0, "Msg not empty");
 }
 
 static void test_recv_two_msg(void)
@@ -287,7 +287,7 @@ int verify_sent_and_received_msg(struct msghdr *msg, bool split_msg)
 			    msg->msg_iov[0].iov_len,
 			    &ctx, &msg_type, &remaining,
 			    recv_buf, sizeof(recv_buf));
-	zassert_equal(ret, -EAGAIN, "Msg header not found");
+	ztest_equal(ret, -EAGAIN, "Msg header not found");
 
 	/* Then the first split if it is enabled */
 	if (split_msg) {
@@ -297,7 +297,7 @@ int verify_sent_and_received_msg(struct msghdr *msg, bool split_msg)
 				    split_len,
 				    &ctx, &msg_type, &remaining,
 				    recv_buf, sizeof(recv_buf));
-		zassert_true(ret > 0, "Cannot read data (%d)", ret);
+		ztest_true(ret > 0, "Cannot read data (%d)", ret);
 
 		total_read = ret;
 	}
@@ -309,20 +309,20 @@ int verify_sent_and_received_msg(struct msghdr *msg, bool split_msg)
 				    msg->msg_iov[1].iov_len - total_read,
 				    &ctx, &msg_type, &remaining,
 				    recv_buf, sizeof(recv_buf));
-		zassert_true(ret > 0, "Cannot read data (%d)", ret);
+		ztest_true(ret > 0, "Cannot read data (%d)", ret);
 
 		if (memcmp(recv_buf, lorem_ipsum + total_read, ret) != 0) {
 			LOG_HEXDUMP_ERR(lorem_ipsum + total_read, ret,
 					"Received message should be");
 			LOG_HEXDUMP_ERR(recv_buf, ret, "but it was instead");
-			zassert_true(false, "Invalid received message "
+			ztest_true(false, "Invalid received message "
 				     "after %d bytes", total_read);
 		}
 
 		total_read += ret;
 	}
 
-	zassert_equal(total_read, test_msg_len,
+	ztest_equal(total_read, test_msg_len,
 		      "Msg body not valid, received %d instead of %zd",
 		      total_read, test_msg_len);
 
@@ -348,7 +348,7 @@ static void test_send_and_recv_lorem_ipsum(void)
 				 lorem_ipsum, test_msg_len,
 				 WEBSOCKET_OPCODE_DATA_TEXT, true, true,
 				 K_FOREVER);
-	zassert_equal(ret, test_msg_len,
+	ztest_equal(ret, test_msg_len,
 		      "Should have sent %zd bytes but sent %d instead",
 		      test_msg_len, ret);
 }
@@ -368,7 +368,7 @@ static void test_recv_two_large_split_msg(void)
 	ret = websocket_send_msg(POINTER_TO_INT(&ctx), lorem_ipsum,
 				 test_msg_len, WEBSOCKET_OPCODE_DATA_TEXT,
 				 false, true, K_FOREVER);
-	zassert_equal(ret, test_msg_len,
+	ztest_equal(ret, test_msg_len,
 		      "1st should have sent %zd bytes but sent %d instead",
 		      test_msg_len, ret);
 }

--- a/tests/net/traffic_class/src/main.c
+++ b/tests/net/traffic_class/src/main.c
@@ -177,7 +177,7 @@ static int eth_tx(struct device *dev, struct net_pkt *pkt)
 		net_ipaddr_copy(&NET_IPV6_HDR(pkt)->dst, &addr);
 
 		udp_hdr = net_udp_get_hdr(pkt, &hdr);
-		zassert_not_null(udp_hdr, "UDP header missing");
+		ztest_not_null(udp_hdr, "UDP header missing");
 
 		port = udp_hdr->src_port;
 		udp_hdr->src_port = udp_hdr->dst_port;
@@ -186,7 +186,7 @@ static int eth_tx(struct device *dev, struct net_pkt *pkt)
 		if (net_recv_data(net_pkt_iface(pkt),
 				  net_pkt_clone(pkt, K_NO_WAIT)) < 0) {
 			test_failed = true;
-			zassert_true(false, "Packet %p receive failed\n", pkt);
+			ztest_true(false, "Packet %p receive failed\n", pkt);
 		}
 
 		return 0;
@@ -210,7 +210,7 @@ static int eth_tx(struct device *dev, struct net_pkt *pkt)
 				    pkt, prio, net_tx_priority2tc(prio));
 
 				test_failed = true;
-				zassert_false(test_failed,
+				ztest_false(test_failed,
 					      "Invalid priority sent %d TC %d,"
 					      " expecting %d (pkt %p)\n",
 					      prio,
@@ -277,14 +277,14 @@ static void address_setup(void)
 
 	iface1 = net_if_get_default();
 
-	zassert_not_null(iface1, "Interface 1");
+	ztest_not_null(iface1, "Interface 1");
 
 	ifaddr = net_if_ipv6_addr_add(iface1, &my_addr1,
 				      NET_ADDR_MANUAL, 0);
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr1));
-		zassert_not_null(ifaddr, "addr1");
+		ztest_not_null(ifaddr, "addr1");
 	}
 
 	/* For testing purposes we need to set the adddresses preferred */
@@ -295,7 +295,7 @@ static void address_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&ll_addr));
-		zassert_not_null(ifaddr, "ll_addr");
+		ztest_not_null(ifaddr, "ll_addr");
 	}
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
@@ -305,7 +305,7 @@ static void address_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr2));
-		zassert_not_null(ifaddr, "addr2");
+		ztest_not_null(ifaddr, "addr2");
 	}
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
@@ -315,7 +315,7 @@ static void address_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr3));
-		zassert_not_null(ifaddr, "addr3");
+		ztest_not_null(ifaddr, "addr3");
 	}
 
 	net_if_up(iface1);
@@ -381,18 +381,18 @@ static void setup_net_context(struct net_context **ctx)
 	iface1 = net_if_get_default();
 
 	ret = net_context_get(AF_INET6, SOCK_DGRAM, IPPROTO_UDP, ctx);
-	zassert_equal(ret, 0, "Create IPv6 UDP context %p failed (%d)\n",
+	ztest_equal(ret, 0, "Create IPv6 UDP context %p failed (%d)\n",
 		      *ctx, ret);
 
 	memcpy(&src_addr6.sin6_addr, &my_addr1, sizeof(struct in6_addr));
 	memcpy(&dst_addr6.sin6_addr, &dst_addr, sizeof(struct in6_addr));
 
 	ret = add_neighbor(iface1, &dst_addr);
-	zassert_true(ret, "Cannot add neighbor");
+	ztest_true(ret, "Cannot add neighbor");
 
 	ret = net_context_bind(*ctx, (struct sockaddr *)&src_addr6,
 			       sizeof(struct sockaddr_in6));
-	zassert_equal(ret, 0,
+	ztest_equal(ret, 0,
 		      "Context bind failure test failed (%d)\n", ret);
 }
 
@@ -415,7 +415,7 @@ static void traffic_class_setup(enum net_priority *tc2prio, int count)
 		ret = net_context_set_option(net_ctxs[i].ctx,
 					     NET_OPT_PRIORITY,
 					     &priority, sizeof(priority));
-		zassert_equal(ret, 0,
+		ztest_equal(ret, 0,
 			      "Cannot set priority %d to ctx %p (%d)\n",
 			      priority, net_ctxs[i].ctx, ret);
 	}
@@ -480,7 +480,7 @@ static void traffic_class_send_packets_with_prio(enum net_priority prio,
 				 (struct sockaddr *)&dst_addr6,
 				 sizeof(struct sockaddr_in6),
 				 NULL, K_NO_WAIT, NULL);
-	zassert_true(ret > 0, "Send UDP pkt failed");
+	ztest_true(ret > 0, "Send UDP pkt failed");
 }
 
 static void traffic_class_send_priority(enum net_priority prio,
@@ -500,7 +500,7 @@ static void traffic_class_send_priority(enum net_priority prio,
 	if (wait_for_packets) {
 		if (k_sem_take(&wait_data, WAIT_TIME)) {
 			DBG("Timeout while waiting ok status\n");
-			zassert_false(true, "Timeout");
+			ztest_false(true, "Timeout");
 		}
 
 		/* This sleep is needed here so that the sending side
@@ -573,10 +573,10 @@ static void traffic_class_send_data_mix(void)
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		DBG("Timeout while waiting ok status\n");
-		zassert_false(true, "Timeout");
+		ztest_false(true, "Timeout");
 	}
 
-	zassert_false(test_failed, "Traffic class verification failed.");
+	ztest_false(test_failed, "Traffic class verification failed.");
 }
 
 static void traffic_class_send_data_mix_all_1(void)
@@ -614,10 +614,10 @@ static void traffic_class_send_data_mix_all_1(void)
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		DBG("Timeout while waiting ok status\n");
-		zassert_false(true, "Timeout");
+		ztest_false(true, "Timeout");
 	}
 
-	zassert_false(test_failed, "Traffic class verification failed.");
+	ztest_false(test_failed, "Traffic class verification failed.");
 }
 
 static void traffic_class_send_data_mix_all_2(void)
@@ -664,10 +664,10 @@ static void traffic_class_send_data_mix_all_2(void)
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		DBG("Timeout while waiting ok status\n");
-		zassert_false(true, "Timeout");
+		ztest_false(true, "Timeout");
 	}
 
-	zassert_false(test_failed, "Traffic class verification failed.");
+	ztest_false(test_failed, "Traffic class verification failed.");
 }
 
 static void recv_cb(struct net_context *context,
@@ -696,7 +696,7 @@ static void recv_cb(struct net_context *context,
 			    pkt, prio, net_rx_priority2tc(prio));
 
 			test_failed = true;
-			zassert_false(test_failed,
+			ztest_false(test_failed,
 				      "Invalid priority received %d TC %d,"
 				      " expecting %d (pkt %p)\n",
 				      prio,
@@ -725,7 +725,7 @@ static void traffic_class_setup_recv(void)
 	for (i = 0; i < NET_TC_RX_COUNT; i++) {
 		ret = net_context_recv(net_ctxs[i].ctx, recv_cb,
 				       K_NO_WAIT, NULL);
-		zassert_equal(ret, 0,
+		ztest_equal(ret, 0,
 			      "[%d] Context recv UDP setup failed (%d)\n",
 			      i, ret);
 	}
@@ -759,11 +759,11 @@ static void traffic_class_recv_packets_with_prio(enum net_priority prio,
 	recv_priorities[net_rx_priority2tc(prio)][pkt_count - 1] = prio + 1;
 
 	src_addr = net_if_ipv6_select_src_addr(NULL, &dst_addr);
-	zassert_not_null(src_addr, "Cannot select source address");
+	ztest_not_null(src_addr, "Cannot select source address");
 
 	ifaddr = net_if_ipv6_addr_lookup(src_addr, &iface);
-	zassert_not_null(ifaddr, "Cannot find source address");
-	zassert_not_null(iface, "Interface not found");
+	ztest_not_null(ifaddr, "Cannot find source address");
+	ztest_not_null(iface, "Interface not found");
 
 	/* We cannot use net_recv_data() here as the packet does not have
 	 * UDP header.
@@ -772,7 +772,7 @@ static void traffic_class_recv_packets_with_prio(enum net_priority prio,
 				 (struct sockaddr *)&dst_addr6,
 				 sizeof(struct sockaddr_in6),
 				 NULL, K_NO_WAIT, NULL);
-	zassert_true(ret > 0, "Send UDP pkt failed");
+	ztest_true(ret > 0, "Send UDP pkt failed");
 
 	/* Let the receiver to receive the packets */
 	k_sleep(K_MSEC(1));
@@ -795,7 +795,7 @@ static void traffic_class_recv_priority(enum net_priority prio,
 	if (wait_for_packets) {
 		if (k_sem_take(&wait_data, WAIT_TIME)) {
 			DBG("Timeout while waiting ok status\n");
-			zassert_false(true, "Timeout");
+			ztest_false(true, "Timeout");
 		}
 
 		/* This sleep is needed here so that the receiving side
@@ -812,7 +812,7 @@ static void traffic_class_recv_data_prio_bk(void)
 	 */
 	traffic_class_recv_priority(NET_PRIORITY_BK, MAX_PKT_TO_RECV, true);
 
-	zassert_false(test_failed, "Traffic class verification failed.");
+	ztest_false(test_failed, "Traffic class verification failed.");
 }
 
 static void traffic_class_recv_data_prio_be(void)
@@ -870,10 +870,10 @@ static void traffic_class_recv_data_mix(void)
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		DBG("Timeout while waiting ok status\n");
-		zassert_false(true, "Timeout");
+		ztest_false(true, "Timeout");
 	}
 
-	zassert_false(test_failed, "Traffic class verification failed.");
+	ztest_false(test_failed, "Traffic class verification failed.");
 }
 
 static void traffic_class_recv_data_mix_all_1(void)
@@ -911,10 +911,10 @@ static void traffic_class_recv_data_mix_all_1(void)
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		DBG("Timeout while waiting ok status\n");
-		zassert_false(true, "Timeout");
+		ztest_false(true, "Timeout");
 	}
 
-	zassert_false(test_failed, "Traffic class verification failed.");
+	ztest_false(test_failed, "Traffic class verification failed.");
 }
 
 static void traffic_class_recv_data_mix_all_2(void)
@@ -961,10 +961,10 @@ static void traffic_class_recv_data_mix_all_2(void)
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		DBG("Timeout while waiting ok status\n");
-		zassert_false(true, "Timeout");
+		ztest_false(true, "Timeout");
 	}
 
-	zassert_false(test_failed, "Traffic class verification failed.");
+	ztest_false(test_failed, "Traffic class verification failed.");
 }
 
 void test_main(void)

--- a/tests/net/trickle/src/main.c
+++ b/tests/net/trickle/src/main.c
@@ -87,10 +87,10 @@ static void test_trickle_create(void)
 	int ret;
 
 	ret = net_trickle_create(&t1, T1_IMIN, T1_IMAX, T1_K);
-	zassert_false(ret, "Trickle 1 create failed");
+	ztest_false(ret, "Trickle 1 create failed");
 
 	ret = net_trickle_create(&t2, T2_IMIN, T2_IMAX, T2_K);
-	zassert_false(ret, "Trickle 2 create failed");
+	ztest_false(ret, "Trickle 2 create failed");
 }
 
 static void test_trickle_start(void)
@@ -101,24 +101,24 @@ static void test_trickle_start(void)
 	cb_2_called = false;
 
 	ret = net_trickle_start(&t1, cb_1, &t1);
-	zassert_false(ret, "Trickle 1 start failed");
+	ztest_false(ret, "Trickle 1 start failed");
 
 	ret = net_trickle_start(&t2, cb_2, &t2);
-	zassert_false(ret, "Trickle 2 start failed");
+	ztest_false(ret, "Trickle 2 start failed");
 }
 
 static void test_trickle_stop(void)
 {
-	zassert_false(net_trickle_stop(&t1),
+	ztest_false(net_trickle_stop(&t1),
 			"Trickle 1 stop failed");
 
-	zassert_false(net_trickle_stop(&t2),
+	ztest_false(net_trickle_stop(&t2),
 			"Trickle 2 stop failed");
 }
 
 static void test_trickle_1_status(void)
 {
-	zassert_true(net_trickle_is_running(&t1), "Trickle 1 not running");
+	ztest_true(net_trickle_is_running(&t1), "Trickle 1 not running");
 
 	if (token1 != token2) {
 		net_trickle_inconsistency(&t1);
@@ -129,7 +129,7 @@ static void test_trickle_1_status(void)
 
 static void test_trickle_2_status(void)
 {
-	zassert_true(net_trickle_is_running(&t2), "Trickle 2 not running");
+	ztest_true(net_trickle_is_running(&t2), "Trickle 2 not running");
 
 	if (token1 == token2) {
 		net_trickle_consistency(&t2);
@@ -142,9 +142,9 @@ static void test_trickle_1_wait(void)
 {
 	k_sem_take(&wait, WAIT_TIME);
 
-	zassert_true(cb_1_called, "Trickle 1 no timeout");
+	ztest_true(cb_1_called, "Trickle 1 no timeout");
 
-	zassert_true(net_trickle_is_running(&t1), "Trickle 1 not running");
+	ztest_true(net_trickle_is_running(&t1), "Trickle 1 not running");
 }
 
 #if CHECK_LONG_TIMEOUT > 0
@@ -154,9 +154,9 @@ static void test_trickle_1_wait_long(void)
 
 	k_sem_take(&wait, WAIT_TIME_LONG);
 
-	zassert_false(cb_1_called, "Trickle 1 no timeout");
+	ztest_false(cb_1_called, "Trickle 1 no timeout");
 
-	zassert_true(net_trickle_is_running(&t1), "Trickle 1 not running");
+	ztest_true(net_trickle_is_running(&t1), "Trickle 1 not running");
 }
 #else
 static void test_trickle_1_wait_long(void)
@@ -169,25 +169,25 @@ static void test_trickle_2_wait(void)
 {
 	k_sem_take(&wait2, WAIT_TIME);
 
-	zassert_true(cb_2_called, "Trickle 2 no timeout");
+	ztest_true(cb_2_called, "Trickle 2 no timeout");
 
-	zassert_true(net_trickle_is_running(&t2), "Trickle 2 not running");
+	ztest_true(net_trickle_is_running(&t2), "Trickle 2 not running");
 }
 
 static void test_trickle_1_stopped(void)
 {
-	zassert_false(net_trickle_is_running(&t1), "Trickle 1 running");
+	ztest_false(net_trickle_is_running(&t1), "Trickle 1 running");
 }
 
 static void test_trickle_2_inc(void)
 {
-	zassert_true(net_trickle_is_running(&t2), "Trickle 2 is not running");
+	ztest_true(net_trickle_is_running(&t2), "Trickle 2 is not running");
 	token2++;
 }
 
 static void test_trickle_1_update(void)
 {
-	zassert_true(net_trickle_is_running(&t1), "trickle 1 is not running");
+	ztest_true(net_trickle_is_running(&t1), "trickle 1 is not running");
 
 	token1 = token2;
 }

--- a/tests/net/tx_timestamp/src/main.c
+++ b/tests/net/tx_timestamp/src/main.c
@@ -168,7 +168,7 @@ static void timestamp_callback(struct net_pkt *pkt)
 		/* This is very artificial test but make sure that we
 		 * have advanced the time a bit.
 		 */
-		zassert_true(pkt->timestamp.nanosecond > pkt->timestamp.second,
+		ztest_true(pkt->timestamp.nanosecond > pkt->timestamp.second,
 			     "Timestamp not working ok (%d < %d)\n",
 			     pkt->timestamp.nanosecond, pkt->timestamp.second);
 	}
@@ -199,8 +199,8 @@ static void timestamp_setup(void)
 	/* Make sure that the callback function is called */
 	net_if_call_timestamp_cb(pkt);
 
-	zassert_true(timestamp_cb_called, "Timestamp callback not called\n");
-	zassert_equal(atomic_get(&pkt->atomic_ref), 0, "Pkt %p not released\n");
+	ztest_true(timestamp_cb_called, "Timestamp callback not called\n");
+	ztest_equal(atomic_get(&pkt->atomic_ref), 0, "Pkt %p not released\n");
 }
 
 static void timestamp_callback_2(struct net_pkt *pkt)
@@ -211,12 +211,12 @@ static void timestamp_callback_2(struct net_pkt *pkt)
 		/* This is very artificial test but make sure that we
 		 * have advanced the time a bit.
 		 */
-		zassert_true(pkt->timestamp.nanosecond > pkt->timestamp.second,
+		ztest_true(pkt->timestamp.nanosecond > pkt->timestamp.second,
 			     "Timestamp not working ok (%d < %d)\n",
 			     pkt->timestamp.nanosecond, pkt->timestamp.second);
 	}
 
-	zassert_equal(eth_interfaces[1], net_pkt_iface(pkt),
+	ztest_equal(eth_interfaces[1], net_pkt_iface(pkt),
 		      "Invalid interface");
 
 	/* The pkt was ref'ed in send_some_data()() */
@@ -245,8 +245,8 @@ static void timestamp_setup_2nd_iface(void)
 	/* Make sure that the callback function is called */
 	net_if_call_timestamp_cb(pkt);
 
-	zassert_true(timestamp_cb_called, "Timestamp callback not called\n");
-	zassert_equal(atomic_get(&pkt->atomic_ref), 0, "Pkt %p not released\n");
+	ztest_true(timestamp_cb_called, "Timestamp callback not called\n");
+	ztest_equal(atomic_get(&pkt->atomic_ref), 0, "Pkt %p not released\n");
 }
 
 static void timestamp_setup_all(void)
@@ -270,8 +270,8 @@ static void timestamp_setup_all(void)
 	/* Make sure that the callback function is called */
 	net_if_call_timestamp_cb(pkt);
 
-	zassert_true(timestamp_cb_called, "Timestamp callback not called\n");
-	zassert_equal(atomic_get(&pkt->atomic_ref), 0, "Pkt %p not released\n");
+	ztest_true(timestamp_cb_called, "Timestamp callback not called\n");
+	ztest_equal(atomic_get(&pkt->atomic_ref), 0, "Pkt %p not released\n");
 
 	net_if_unregister_timestamp_cb(&timestamp_cb_3);
 }
@@ -294,8 +294,8 @@ static void timestamp_cleanup(void)
 	 */
 	net_if_call_timestamp_cb(pkt);
 
-	zassert_false(timestamp_cb_called, "Timestamp callback called\n");
-	zassert_false(atomic_get(&pkt->atomic_ref) < 1, "Pkt %p released\n");
+	ztest_false(timestamp_cb_called, "Timestamp callback called\n");
+	ztest_false(atomic_get(&pkt->atomic_ref) < 1, "Pkt %p released\n");
 
 	net_pkt_unref(pkt);
 }
@@ -352,15 +352,15 @@ static void address_setup(void)
 	iface1 = eth_interfaces[0];
 	iface2 = eth_interfaces[1];
 
-	zassert_not_null(iface1, "Interface 1\n");
-	zassert_not_null(iface2, "Interface 2\n");
+	ztest_not_null(iface1, "Interface 1\n");
+	ztest_not_null(iface2, "Interface 2\n");
 
 	ifaddr = net_if_ipv6_addr_add(iface1, &my_addr1,
 				      NET_ADDR_MANUAL, 0);
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr1));
-		zassert_not_null(ifaddr, "addr1\n");
+		ztest_not_null(ifaddr, "addr1\n");
 	}
 
 	/* For testing purposes we need to set the adddresses preferred */
@@ -371,7 +371,7 @@ static void address_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&ll_addr));
-		zassert_not_null(ifaddr, "ll_addr\n");
+		ztest_not_null(ifaddr, "ll_addr\n");
 	}
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
@@ -381,7 +381,7 @@ static void address_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr2));
-		zassert_not_null(ifaddr, "addr2\n");
+		ztest_not_null(ifaddr, "addr2\n");
 	}
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
@@ -439,17 +439,17 @@ static void send_some_data(struct net_if *iface)
 
 	ret = net_context_get(AF_INET6, SOCK_DGRAM, IPPROTO_UDP,
 			      &udp_v6_ctx);
-	zassert_equal(ret, 0, "Create IPv6 UDP context failed\n");
+	ztest_equal(ret, 0, "Create IPv6 UDP context failed\n");
 
 	memcpy(&src_addr6.sin6_addr, &my_addr1, sizeof(struct in6_addr));
 	memcpy(&dst_addr6.sin6_addr, &dst_addr, sizeof(struct in6_addr));
 
 	ret = net_context_bind(udp_v6_ctx, (struct sockaddr *)&src_addr6,
 			       sizeof(struct sockaddr_in6));
-	zassert_equal(ret, 0, "Context bind failure test failed\n");
+	ztest_equal(ret, 0, "Context bind failure test failed\n");
 
 	ret = add_neighbor(iface, &dst_addr);
-	zassert_true(ret, "Cannot add neighbor\n");
+	ztest_true(ret, "Cannot add neighbor\n");
 
 	net_context_set_option(udp_v6_ctx, NET_OPT_TIMESTAMP,
 			       &timestamp, sizeof(timestamp));
@@ -458,7 +458,7 @@ static void send_some_data(struct net_if *iface)
 				 (struct sockaddr *)&dst_addr6,
 				 sizeof(struct sockaddr_in6),
 				 NULL, K_NO_WAIT, NULL);
-	zassert_true(ret > 0, "Send UDP pkt failed\n");
+	ztest_true(ret > 0, "Send UDP pkt failed\n");
 
 	net_context_unref(udp_v6_ctx);
 }
@@ -472,7 +472,7 @@ static void check_timestamp_before_enabling(void)
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		DBG("Timeout while waiting interface data\n");
-		zassert_false(true, "Timeout\n");
+		ztest_false(true, "Timeout\n");
 	}
 }
 
@@ -485,7 +485,7 @@ static void check_timestamp_after_enabling(void)
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		DBG("Timeout while waiting interface data\n");
-		zassert_false(true, "Timeout\n");
+		ztest_false(true, "Timeout\n");
 	}
 }
 

--- a/tests/net/udp/src/main.c
+++ b/tests/net/udp/src/main.c
@@ -239,12 +239,12 @@ static bool send_ipv6_udp_msg(struct net_if *iface,
 
 	pkt = net_pkt_alloc_with_buffer(iface, 0, AF_INET6,
 					IPPROTO_UDP, K_SECONDS(1));
-	zassert_not_null(pkt, "Out of mem");
+	ztest_not_null(pkt, "Out of mem");
 
 	if (net_ipv6_create(pkt, src, dst) ||
 	    net_udp_create(pkt, htons(src_port), htons(dst_port))) {
 		printk("Cannot create IPv6 UDP pkt %p", pkt);
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	net_pkt_cursor_init(pkt);
@@ -253,13 +253,13 @@ static bool send_ipv6_udp_msg(struct net_if *iface,
 	ret = net_recv_data(iface, pkt);
 	if (ret < 0) {
 		printk("Cannot recv pkt %p, ret %d\n", pkt, ret);
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	if (k_sem_take(&recv_lock, TIMEOUT)) {
 
 		/**TESTPOINT: Check for failure*/
-		zassert_true(expect_failure, "Timeout, packet not received");
+		ztest_true(expect_failure, "Timeout, packet not received");
 		return true;
 	}
 
@@ -269,7 +269,7 @@ static bool send_ipv6_udp_msg(struct net_if *iface,
 	if (ud != returned_ud && !expect_failure) {
 		printk("IPv6 wrong user data %p returned, expected %p\n",
 		       returned_ud, ud);
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	return !fail;
@@ -290,17 +290,17 @@ static bool send_ipv6_udp_long_msg(struct net_if *iface,
 					sizeof(ipv6_hop_by_hop_ext_hdr) +
 					sizeof(payload), AF_INET6,
 					IPPROTO_UDP, K_SECONDS(1));
-	zassert_not_null(pkt, "Out of mem");
+	ztest_not_null(pkt, "Out of mem");
 
 	if (net_ipv6_create(pkt, src, dst)) {
 		printk("Cannot create IPv6  pkt %p", pkt);
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	if (net_pkt_write(pkt, (u8_t *)ipv6_hop_by_hop_ext_hdr,
 			      sizeof(ipv6_hop_by_hop_ext_hdr))) {
 		printk("Cannot write IPv6 ext header pkt %p", pkt);
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	net_pkt_set_ipv6_ext_len(pkt, sizeof(ipv6_hop_by_hop_ext_hdr));
@@ -308,12 +308,12 @@ static bool send_ipv6_udp_long_msg(struct net_if *iface,
 
 	if (net_udp_create(pkt, htons(src_port), htons(dst_port))) {
 		printk("Cannot create IPv6  pkt %p", pkt);
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	if (net_pkt_write(pkt, (u8_t *)payload, sizeof(payload))) {
 		printk("Cannot write IPv6 ext header pkt %p", pkt);
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	net_pkt_cursor_init(pkt);
@@ -322,12 +322,12 @@ static bool send_ipv6_udp_long_msg(struct net_if *iface,
 	ret = net_recv_data(iface, pkt);
 	if (ret < 0) {
 		printk("Cannot recv pkt %p, ret %d\n", pkt, ret);
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	if (k_sem_take(&recv_lock, TIMEOUT)) {
 		/**TESTPOINT: Check for failure*/
-		zassert_true(expect_failure, "Timeout, packet not received");
+		ztest_true(expect_failure, "Timeout, packet not received");
 		return true;
 	}
 
@@ -337,7 +337,7 @@ static bool send_ipv6_udp_long_msg(struct net_if *iface,
 	if (ud != returned_ud && !expect_failure) {
 		printk("IPv6 wrong user data %p returned, expected %p\n",
 		       returned_ud, ud);
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	return !fail;
@@ -356,12 +356,12 @@ static bool send_ipv4_udp_msg(struct net_if *iface,
 
 	pkt = net_pkt_alloc_with_buffer(iface, 0, AF_INET,
 					IPPROTO_UDP, K_SECONDS(1));
-	zassert_not_null(pkt, "Out of mem");
+	ztest_not_null(pkt, "Out of mem");
 
 	if (net_ipv4_create(pkt, src, dst) ||
 	    net_udp_create(pkt, htons(src_port), htons(dst_port))) {
 		printk("Cannot create IPv4 UDP pkt %p", pkt);
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	net_pkt_cursor_init(pkt);
@@ -370,13 +370,13 @@ static bool send_ipv4_udp_msg(struct net_if *iface,
 	ret = net_recv_data(iface, pkt);
 	if (ret < 0) {
 		printk("Cannot recv pkt %p, ret %d\n", pkt, ret);
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	if (k_sem_take(&recv_lock, TIMEOUT)) {
 
 		/**TESTPOINT: Check for failure*/
-		zassert_true(expect_failure, "Timeout, packet not received");
+		ztest_true(expect_failure, "Timeout, packet not received");
 		return true;
 	}
 
@@ -386,7 +386,7 @@ static bool send_ipv4_udp_msg(struct net_if *iface,
 	if (ud != returned_ud && !expect_failure) {
 		printk("IPv4 wrong user data %p returned, expected %p\n",
 		       returned_ud, ud);
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	return !fail;
@@ -474,14 +474,14 @@ void test_udp(void)
 	if (!ifaddr) {
 		printk("Cannot add %s to interface %p\n",
 		       net_sprint_ipv6_addr(&in6addr_my), iface);
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 	ifaddr = net_if_ipv4_addr_add(iface, &in4addr_my, NET_ADDR_MANUAL, 0);
 	if (!ifaddr) {
 		printk("Cannot add %s to interface %p\n",
 		       net_sprint_ipv4_addr(&in4addr_my), iface);
-		zassert_true(0, "exiting");
+		ztest_true(0, "exiting");
 	}
 
 #define REGISTER(family, raddr, laddr, rport, lport)			\
@@ -507,7 +507,7 @@ void test_udp(void)
 		if (ret) {						\
 			printk("UDP register %s failed (%d)\n",		\
 			       user_data.test, ret);			\
-			zassert_true(0, "exiting");			\
+			ztest_true(0, "exiting");			\
 		}							\
 		user_data.handle = handlers[i++];			\
 		&user_data;						\
@@ -522,7 +522,7 @@ void test_udp(void)
 	if (!ret) {							\
 		printk("UDP register invalid match %s failed\n",	\
 		       "DST="#raddr"-SRC="#laddr"-RP="#rport"-LP="#lport); \
-		zassert_true(0, "exiting");				\
+		ztest_true(0, "exiting");				\
 	}
 
 #define UNREGISTER(ud)							\
@@ -530,7 +530,7 @@ void test_udp(void)
 	if (ret) {							\
 		printk("UDP unregister %p failed (%d)\n", ud->handle,	\
 		       ret);						\
-		zassert_true(0, "exiting");				\
+		ztest_true(0, "exiting");				\
 	}
 
 #define TEST_IPV6_OK(ud, raddr, laddr, rport, lport)			\
@@ -539,7 +539,7 @@ void test_udp(void)
 	if (!st) {							\
 		printk("%d: UDP test \"%s\" fail\n", __LINE__,		\
 		       ud->test);					\
-		zassert_true(0, "exiting");				\
+		ztest_true(0, "exiting");				\
 	}
 
 #define TEST_IPV6_LONG_OK(ud, raddr, laddr, rport, lport)		\
@@ -548,7 +548,7 @@ void test_udp(void)
 	if (!st) {							\
 		printk("%d: UDP long test \"%s\" fail\n", __LINE__,	\
 		       ud->test);					\
-		zassert_true(0, "exiting");				\
+		ztest_true(0, "exiting");				\
 	}
 
 #define TEST_IPV4_OK(ud, raddr, laddr, rport, lport)			\
@@ -557,7 +557,7 @@ void test_udp(void)
 	if (!st) {							\
 		printk("%d: UDP test \"%s\" fail\n", __LINE__,		\
 		       ud->test);					\
-		zassert_true(0, "exiting");				\
+		ztest_true(0, "exiting");				\
 	}
 
 #define TEST_IPV6_FAIL(ud, raddr, laddr, rport, lport)			\
@@ -566,7 +566,7 @@ void test_udp(void)
 	if (!st) {							\
 		printk("%d: UDP neg test \"%s\" fail\n", __LINE__,	\
 		       ud->test);					\
-		zassert_true(0, "exiting");				\
+		ztest_true(0, "exiting");				\
 	}
 
 #define TEST_IPV4_FAIL(ud, raddr, laddr, rport, lport)			\
@@ -575,7 +575,7 @@ void test_udp(void)
 	if (!st) {							\
 		printk("%d: UDP neg test \"%s\" fail\n", __LINE__,	\
 		       ud->test);					\
-		zassert_true(0, "exiting");				\
+		ztest_true(0, "exiting");				\
 	}
 
 	ud = REGISTER(AF_INET6, &any_addr6, &any_addr6, 1234, 4242);
@@ -644,21 +644,21 @@ void test_udp(void)
 	REGISTER_FAIL(&my_addr4, &my_addr6, 1234, 4242);
 
 	/**TESTPOINT: Check if tests passed*/
-	zassert_false(fail, "Tests failed");
+	ztest_false(fail, "Tests failed");
 
 	i--;
 	while (i) {
 		ret = net_udp_unregister(handlers[i]);
 		if (ret < 0 && ret != -ENOENT) {
 			printk("Cannot unregister udp %d\n", i);
-			zassert_true(0, "exiting");
+			ztest_true(0, "exiting");
 		}
 
 		i--;
 	}
 
-	zassert_true((net_udp_unregister(NULL) < 0), "Unregister udp failed");
-	zassert_false(test_failed, "udp tests failed");
+	ztest_true((net_udp_unregister(NULL) < 0), "Unregister udp failed");
+	ztest_false(test_failed, "udp tests failed");
 }
 
 void test_main(void)

--- a/tests/net/utils/src/main.c
+++ b/tests/net/utils/src/main.c
@@ -401,7 +401,7 @@ void test_net_addr(void)
 		}
 	}
 
-	zassert_equal(pass, ARRAY_SIZE(tests), "check_net_addr error");
+	ztest_equal(pass, ARRAY_SIZE(tests), "check_net_addr error");
 }
 
 void test_addr_parse(void)
@@ -783,19 +783,19 @@ void test_addr_parse(void)
 		if (ret != parse_ipv4_entries[i].verdict) {
 			printk("IPv4 entry [%d] \"%s\" failed\n", i,
 				parse_ipv4_entries[i].address);
-			zassert_true(false, "failure");
+			ztest_true(false, "failure");
 		}
 
 		if (ret == true) {
-			zassert_true(
+			ztest_true(
 				net_ipv4_addr_cmp(
 				      &net_sin(&addr)->sin_addr,
 				      &parse_ipv4_entries[i].result.sin_addr),
 				parse_ipv4_entries[i].address);
-			zassert_true(net_sin(&addr)->sin_port ==
+			ztest_true(net_sin(&addr)->sin_port ==
 				     parse_ipv4_entries[i].result.sin_port,
 				     "IPv4 port");
-			zassert_true(net_sin(&addr)->sin_family ==
+			ztest_true(net_sin(&addr)->sin_family ==
 				     parse_ipv4_entries[i].result.sin_family,
 				     "IPv4 family");
 		}
@@ -812,19 +812,19 @@ void test_addr_parse(void)
 		if (ret != parse_ipv6_entries[i].verdict) {
 			printk("IPv6 entry [%d] \"%s\" failed\n", i,
 			       parse_ipv6_entries[i].address);
-			zassert_true(false, "failure");
+			ztest_true(false, "failure");
 		}
 
 		if (ret == true) {
-			zassert_true(
+			ztest_true(
 				net_ipv6_addr_cmp(
 				      &net_sin6(&addr)->sin6_addr,
 				      &parse_ipv6_entries[i].result.sin6_addr),
 				parse_ipv6_entries[i].address);
-			zassert_true(net_sin6(&addr)->sin6_port ==
+			ztest_true(net_sin6(&addr)->sin6_port ==
 				     parse_ipv6_entries[i].result.sin6_port,
 				     "IPv6 port");
-			zassert_true(net_sin6(&addr)->sin6_family ==
+			ztest_true(net_sin6(&addr)->sin6_family ==
 				     parse_ipv6_entries[i].result.sin6_family,
 				     "IPv6 family");
 		}

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -109,7 +109,7 @@ static int eth_tx(struct device *dev, struct net_pkt *pkt)
 {
 	struct eth_context *context = dev->driver_data;
 
-	zassert_equal_ptr(&eth_vlan_context, context,
+	ztest_equal_ptr(&eth_vlan_context, context,
 			  "Context pointers do not match (%p vs %p)",
 			  eth_vlan_context, context);
 
@@ -122,13 +122,13 @@ static int eth_tx(struct device *dev, struct net_pkt *pkt)
 		struct net_eth_vlan_hdr *hdr =
 			(struct net_eth_vlan_hdr *)NET_ETH_HDR(pkt);
 
-		zassert_equal(context->expecting_tag,
+		ztest_equal(context->expecting_tag,
 			      net_pkt_vlan_tag(pkt),
 			      "Invalid VLAN tag (%d vs %d) in TX pkt\n",
 			      net_pkt_vlan_tag(pkt),
 			      context->expecting_tag);
 
-		zassert_equal(context->expecting_tag,
+		ztest_equal(context->expecting_tag,
 			      net_eth_vlan_get_vid(ntohs(hdr->vlan.tci)),
 			      "Invalid VLAN tag in ethernet header");
 
@@ -317,7 +317,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	if (net_if_l2(iface) == &NET_L2_GET_NAME(DUMMY)) {
 		dummy_interfaces[ud->dummy_if_count++] = iface;
 
-		zassert_true(ud->dummy_if_count <= 2,
+		ztest_true(ud->dummy_if_count <= 2,
 			     "Too many dummy interfaces");
 	}
 
@@ -335,17 +335,17 @@ static void test_vlan_setup(void)
 	net_if_foreach(iface_cb, &ud);
 
 	/* One extra eth interface without vlan support */
-	zassert_equal(ud.eth_if_count, NET_VLAN_MAX_COUNT,
+	ztest_equal(ud.eth_if_count, NET_VLAN_MAX_COUNT,
 		      "Invalid numer of VLANs %d vs %d\n",
 		      ud.eth_if_count, NET_VLAN_MAX_COUNT);
 
-	zassert_equal(ud.total_if_count, NET_VLAN_MAX_COUNT + 1 + 2,
+	ztest_equal(ud.total_if_count, NET_VLAN_MAX_COUNT + 1 + 2,
 		      "Invalid numer of interfaces");
 
 	/* Put the extra non-vlan ethernet interface to last */
 	eth_interfaces[4] = extra_eth;
-	zassert_not_null(extra_eth, "Extra interface missing");
-	zassert_equal_ptr(net_if_l2(extra_eth), &NET_L2_GET_NAME(ETHERNET),
+	ztest_not_null(extra_eth, "Extra interface missing");
+	ztest_equal_ptr(net_if_l2(extra_eth), &NET_L2_GET_NAME(ETHERNET),
 			  "Invalid L2 type %p for iface %p (should be %p)\n",
 			  net_if_l2(extra_eth), extra_eth,
 			  &NET_L2_GET_NAME(ETHERNET));
@@ -360,16 +360,16 @@ static void test_address_setup(void)
 	iface2 = eth_interfaces[0]; /* and this one not */
 	iface3 = eth_interfaces[3]; /* and this one has VLAN enabled */
 
-	zassert_not_null(iface1, "Interface 1");
-	zassert_not_null(iface2, "Interface 2");
-	zassert_not_null(iface3, "Interface 3");
+	ztest_not_null(iface1, "Interface 1");
+	ztest_not_null(iface2, "Interface 2");
+	ztest_not_null(iface3, "Interface 3");
 
 	ifaddr = net_if_ipv6_addr_add(iface1, &my_addr1,
 				      NET_ADDR_MANUAL, 0);
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr1));
-		zassert_not_null(ifaddr, "addr1");
+		ztest_not_null(ifaddr, "addr1");
 	}
 
 	/* For testing purposes we need to set the adddresses preferred */
@@ -380,7 +380,7 @@ static void test_address_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&ll_addr));
-		zassert_not_null(ifaddr, "ll_addr");
+		ztest_not_null(ifaddr, "ll_addr");
 	}
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
@@ -390,7 +390,7 @@ static void test_address_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr2));
-		zassert_not_null(ifaddr, "addr2");
+		ztest_not_null(ifaddr, "addr2");
 	}
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
@@ -400,7 +400,7 @@ static void test_address_setup(void)
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&my_addr3));
-		zassert_not_null(ifaddr, "addr3");
+		ztest_not_null(ifaddr, "addr3");
 	}
 
 	net_if_up(iface1);
@@ -430,71 +430,71 @@ static void test_vlan_tci(void)
 	priority = 0U;
 	net_pkt_set_vlan_priority(pkt, priority);
 
-	zassert_equal(net_pkt_vlan_tag(pkt), NET_VLAN_TAG_UNSPEC,
+	ztest_equal(net_pkt_vlan_tag(pkt), NET_VLAN_TAG_UNSPEC,
 		      "invalid VLAN tag unspec");
-	zassert_equal(net_pkt_vlan_priority(pkt), priority,
+	ztest_equal(net_pkt_vlan_priority(pkt), priority,
 		      "invalid VLAN priority");
 
 	net_pkt_set_vlan_tag(pkt, 0);
-	zassert_equal(net_pkt_vlan_tag(pkt), 0, "invalid VLAN tag");
+	ztest_equal(net_pkt_vlan_tag(pkt), 0, "invalid VLAN tag");
 
 	/* TCI should be zero now */
-	zassert_equal(net_pkt_vlan_tci(pkt), 0, "invalid VLAN TCI");
+	ztest_equal(net_pkt_vlan_tci(pkt), 0, "invalid VLAN TCI");
 
 	priority = 1U;
 	net_pkt_set_vlan_priority(pkt, priority);
 
-	zassert_equal(net_pkt_vlan_priority(pkt), priority,
+	ztest_equal(net_pkt_vlan_priority(pkt), priority,
 		      "invalid VLAN priority");
 
 	net_pkt_set_vlan_tag(pkt, tag);
 
-	zassert_equal(net_pkt_vlan_tag(pkt), NET_VLAN_TAG_UNSPEC,
+	ztest_equal(net_pkt_vlan_tag(pkt), NET_VLAN_TAG_UNSPEC,
 		      "invalid VLAN tag unspec");
 
-	zassert_equal(net_pkt_vlan_priority(pkt), priority,
+	ztest_equal(net_pkt_vlan_priority(pkt), priority,
 		      "invalid VLAN priority");
 
 	net_pkt_set_vlan_tag(pkt, 0);
-	zassert_equal(net_pkt_vlan_priority(pkt), priority,
+	ztest_equal(net_pkt_vlan_priority(pkt), priority,
 		      "invalid VLAN priority");
 
 	dei = true;
 	net_pkt_set_vlan_dei(pkt, dei);
 
-	zassert_equal(net_pkt_vlan_dei(pkt), dei, "invalid VLAN DEI");
-	zassert_equal(net_pkt_vlan_priority(pkt), priority,
+	ztest_equal(net_pkt_vlan_dei(pkt), dei, "invalid VLAN DEI");
+	ztest_equal(net_pkt_vlan_priority(pkt), priority,
 		      "invalid VLAN priority");
-	zassert_equal(net_pkt_vlan_tag(pkt), 0, "invalid VLAN tag");
+	ztest_equal(net_pkt_vlan_tag(pkt), 0, "invalid VLAN tag");
 
 	net_pkt_set_vlan_tag(pkt, tag);
-	zassert_equal(net_pkt_vlan_tag(pkt), tag, "invalid VLAN tag");
-	zassert_equal(net_pkt_vlan_dei(pkt), dei, "invalid VLAN DEI");
-	zassert_equal(net_pkt_vlan_priority(pkt), priority,
+	ztest_equal(net_pkt_vlan_tag(pkt), tag, "invalid VLAN tag");
+	ztest_equal(net_pkt_vlan_dei(pkt), dei, "invalid VLAN DEI");
+	ztest_equal(net_pkt_vlan_priority(pkt), priority,
 		      "invalid VLAN priority");
 
 	dei = false;
 	net_pkt_set_vlan_dei(pkt, dei);
-	zassert_equal(net_pkt_vlan_tag(pkt), tag, "invalid VLAN tag");
-	zassert_equal(net_pkt_vlan_dei(pkt), dei, "invalid VLAN DEI");
-	zassert_equal(net_pkt_vlan_priority(pkt), priority,
+	ztest_equal(net_pkt_vlan_tag(pkt), tag, "invalid VLAN tag");
+	ztest_equal(net_pkt_vlan_dei(pkt), dei, "invalid VLAN DEI");
+	ztest_equal(net_pkt_vlan_priority(pkt), priority,
 		      "invalid VLAN priority");
 
 	tag = 0U;
 	net_pkt_set_vlan_tag(pkt, tag);
-	zassert_equal(net_pkt_vlan_tag(pkt), tag, "invalid VLAN tag");
-	zassert_equal(net_pkt_vlan_dei(pkt), dei, "invalid VLAN DEI");
-	zassert_equal(net_pkt_vlan_priority(pkt), priority,
+	ztest_equal(net_pkt_vlan_tag(pkt), tag, "invalid VLAN tag");
+	ztest_equal(net_pkt_vlan_dei(pkt), dei, "invalid VLAN DEI");
+	ztest_equal(net_pkt_vlan_priority(pkt), priority,
 		      "invalid VLAN priority");
 
 	priority = 0U;
 	net_pkt_set_vlan_priority(pkt, priority);
-	zassert_equal(net_pkt_vlan_tag(pkt), tag, "invalid VLAN tag");
-	zassert_equal(net_pkt_vlan_dei(pkt), dei, "invalid VLAN DEI");
-	zassert_equal(net_pkt_vlan_priority(pkt), priority,
+	ztest_equal(net_pkt_vlan_tag(pkt), tag, "invalid VLAN tag");
+	ztest_equal(net_pkt_vlan_dei(pkt), dei, "invalid VLAN DEI");
+	ztest_equal(net_pkt_vlan_priority(pkt), priority,
 		      "invalid VLAN priority");
 
-	zassert_equal(net_pkt_vlan_tci(pkt), 0, "invalid VLAN TCI");
+	ztest_equal(net_pkt_vlan_tci(pkt), 0, "invalid VLAN TCI");
 
 	tci = 0U;
 	tag = 100U;
@@ -503,8 +503,8 @@ static void test_vlan_tci(void)
 	tci = net_eth_vlan_set_vid(tci, tag);
 	tci = net_eth_vlan_set_pcp(tci, priority);
 
-	zassert_equal(tag, net_eth_vlan_get_vid(tci), "Invalid VLAN tag");
-	zassert_equal(priority, net_eth_vlan_get_pcp(tci),
+	ztest_equal(tag, net_eth_vlan_get_vid(tci), "Invalid VLAN tag");
+	ztest_equal(priority, net_eth_vlan_get_pcp(tci),
 		      "Invalid VLAN priority");
 
 	net_pkt_unref(pkt);
@@ -519,41 +519,41 @@ static void test_vlan_enable(void)
 	int ret;
 
 	ret = net_eth_vlan_enable(eth_interfaces[1], VLAN_TAG_1);
-	zassert_equal(ret, 0, "Cannot enable %d (%d)\n", VLAN_TAG_1, ret);
+	ztest_equal(ret, 0, "Cannot enable %d (%d)\n", VLAN_TAG_1, ret);
 	ret = net_eth_vlan_enable(eth_interfaces[3], VLAN_TAG_2);
-	zassert_equal(ret, 0, "Cannot enable %d (%d)\n", VLAN_TAG_2, ret);
+	ztest_equal(ret, 0, "Cannot enable %d (%d)\n", VLAN_TAG_2, ret);
 
 	eth_ctx = net_if_l2_data(eth_interfaces[0]);
 
 	iface = net_eth_get_vlan_iface(eth_interfaces[0], VLAN_TAG_1);
-	zassert_equal_ptr(iface, eth_interfaces[1],
+	ztest_equal_ptr(iface, eth_interfaces[1],
 			  "Invalid interface for tag %d (%p vs %p)\n",
 			  VLAN_TAG_1, iface, eth_interfaces[1]);
 
 	iface = net_eth_get_vlan_iface(eth_interfaces[0], VLAN_TAG_2);
-	zassert_equal_ptr(iface, eth_interfaces[3],
+	ztest_equal_ptr(iface, eth_interfaces[3],
 			  "Invalid interface for tag %d (%p vs %p)\n",
 			  VLAN_TAG_2, iface, eth_interfaces[3]);
 
 	ret = net_eth_is_vlan_enabled(eth_ctx, eth_interfaces[0]);
-	zassert_equal(ret, false, "VLAN enabled for interface 0");
+	ztest_equal(ret, false, "VLAN enabled for interface 0");
 
 	ret = net_eth_is_vlan_enabled(eth_ctx, eth_interfaces[1]);
-	zassert_equal(ret, true, "VLAN disabled for interface 1");
+	ztest_equal(ret, true, "VLAN disabled for interface 1");
 
 	ret = net_eth_is_vlan_enabled(eth_ctx, eth_interfaces[2]);
-	zassert_equal(ret, false, "VLAN enabled for interface 2");
+	ztest_equal(ret, false, "VLAN enabled for interface 2");
 
 	ret = net_eth_is_vlan_enabled(eth_ctx, eth_interfaces[3]);
-	zassert_equal(ret, true, "VLAN disabled for interface 3");
+	ztest_equal(ret, true, "VLAN disabled for interface 3");
 
 	iface = eth_interfaces[0];
 	ret = net_eth_vlan_enable(iface, NET_VLAN_TAG_UNSPEC);
-	zassert_equal(ret, -EBADF, "Invalid VLAN tag value %d\n", ret);
+	ztest_equal(ret, -EBADF, "Invalid VLAN tag value %d\n", ret);
 
 	iface = eth_interfaces[1];
 	ret = net_eth_vlan_enable(iface, VLAN_TAG_1);
-	zassert_equal(ret, -EALREADY, "VLAN tag %d enabled for iface 1\n",
+	ztest_equal(ret, -EALREADY, "VLAN tag %d enabled for iface 1\n",
 		      VLAN_TAG_1);
 }
 
@@ -564,41 +564,41 @@ static void test_vlan_disable(void)
 	int ret;
 
 	ret = net_eth_vlan_disable(eth_interfaces[1], VLAN_TAG_1);
-	zassert_equal(ret, 0, "Cannot disable %d (%d)\n", VLAN_TAG_1, ret);
+	ztest_equal(ret, 0, "Cannot disable %d (%d)\n", VLAN_TAG_1, ret);
 	ret = net_eth_vlan_disable(eth_interfaces[3], VLAN_TAG_2);
-	zassert_equal(ret, 0, "Cannot disable %d (%d)\n", VLAN_TAG_2, ret);
+	ztest_equal(ret, 0, "Cannot disable %d (%d)\n", VLAN_TAG_2, ret);
 
 	eth_ctx = net_if_l2_data(eth_interfaces[0]);
 
 	iface = net_eth_get_vlan_iface(eth_interfaces[0], VLAN_TAG_1);
-	zassert_equal_ptr(iface, eth_interfaces[0],
+	ztest_equal_ptr(iface, eth_interfaces[0],
 			  "Invalid interface for tag %d (%p vs %p)\n",
 			  VLAN_TAG_1, iface, eth_interfaces[0]);
 
 	iface = net_eth_get_vlan_iface(eth_interfaces[0], VLAN_TAG_2);
-	zassert_equal_ptr(iface, eth_interfaces[0],
+	ztest_equal_ptr(iface, eth_interfaces[0],
 			  "Invalid interface for tag %d (%p vs %p)\n",
 			  VLAN_TAG_2, iface, eth_interfaces[0]);
 
 	ret = net_eth_is_vlan_enabled(eth_ctx, eth_interfaces[0]);
-	zassert_equal(ret, false, "VLAN enabled for interface 0");
+	ztest_equal(ret, false, "VLAN enabled for interface 0");
 
 	ret = net_eth_is_vlan_enabled(eth_ctx, eth_interfaces[1]);
-	zassert_equal(ret, false, "VLAN enabled for interface 1");
+	ztest_equal(ret, false, "VLAN enabled for interface 1");
 
 	ret = net_eth_is_vlan_enabled(eth_ctx, eth_interfaces[2]);
-	zassert_equal(ret, false, "VLAN enabled for interface 2");
+	ztest_equal(ret, false, "VLAN enabled for interface 2");
 
 	ret = net_eth_is_vlan_enabled(eth_ctx, eth_interfaces[3]);
-	zassert_equal(ret, false, "VLAN enabled for interface 3");
+	ztest_equal(ret, false, "VLAN enabled for interface 3");
 
 	iface = eth_interfaces[0];
 	ret = net_eth_vlan_disable(iface, NET_VLAN_TAG_UNSPEC);
-	zassert_equal(ret, -EBADF, "Invalid VLAN tag value %d\n", ret);
+	ztest_equal(ret, -EBADF, "Invalid VLAN tag value %d\n", ret);
 
 	iface = eth_interfaces[1];
 	ret = net_eth_vlan_disable(iface, VLAN_TAG_1);
-	zassert_equal(ret, -ESRCH, "VLAN tag %d disabled for iface 1\n",
+	ztest_equal(ret, -ESRCH, "VLAN tag %d disabled for iface 1\n",
 		      VLAN_TAG_1);
 }
 
@@ -609,36 +609,36 @@ static void test_vlan_enable_all(void)
 	int ret;
 
 	ret = net_eth_vlan_enable(eth_interfaces[0], VLAN_TAG_1);
-	zassert_equal(ret, 0, "Cannot enable %d\n", VLAN_TAG_1);
+	ztest_equal(ret, 0, "Cannot enable %d\n", VLAN_TAG_1);
 	ret = net_eth_vlan_enable(eth_interfaces[1], VLAN_TAG_2);
-	zassert_equal(ret, 0, "Cannot enable %d\n", VLAN_TAG_2);
+	ztest_equal(ret, 0, "Cannot enable %d\n", VLAN_TAG_2);
 	ret = net_eth_vlan_enable(eth_interfaces[2], VLAN_TAG_3);
-	zassert_equal(ret, 0, "Cannot enable %d\n", VLAN_TAG_3);
+	ztest_equal(ret, 0, "Cannot enable %d\n", VLAN_TAG_3);
 	ret = net_eth_vlan_enable(eth_interfaces[3], VLAN_TAG_4);
-	zassert_equal(ret, 0, "Cannot enable %d\n", VLAN_TAG_4);
+	ztest_equal(ret, 0, "Cannot enable %d\n", VLAN_TAG_4);
 
 	eth_ctx = net_if_l2_data(eth_interfaces[0]);
 
 	ret = net_eth_is_vlan_enabled(eth_ctx, eth_interfaces[0]);
-	zassert_equal(ret, true, "VLAN disabled for interface 0");
+	ztest_equal(ret, true, "VLAN disabled for interface 0");
 
 	ret = net_eth_is_vlan_enabled(eth_ctx, eth_interfaces[1]);
-	zassert_equal(ret, true, "VLAN disabled for interface 1");
+	ztest_equal(ret, true, "VLAN disabled for interface 1");
 
 	ret = net_eth_is_vlan_enabled(eth_ctx, eth_interfaces[2]);
-	zassert_equal(ret, true, "VLAN disabled for interface 2");
+	ztest_equal(ret, true, "VLAN disabled for interface 2");
 
 	ret = net_eth_is_vlan_enabled(eth_ctx, eth_interfaces[3]);
-	zassert_equal(ret, true, "VLAN disabled for interface 3");
+	ztest_equal(ret, true, "VLAN disabled for interface 3");
 
 	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
-	zassert_not_null(iface, "No dummy iface found");
+	ztest_not_null(iface, "No dummy iface found");
 
-	zassert_equal(net_if_l2(iface), &NET_L2_GET_NAME(DUMMY),
+	ztest_equal(net_if_l2(iface), &NET_L2_GET_NAME(DUMMY),
 		      "Not a dummy interface");
 
 	ret = net_eth_vlan_enable(iface, VLAN_TAG_5);
-	zassert_equal(ret, -EINVAL, "Wrong iface type (%d)\n", ret);
+	ztest_equal(ret, -EINVAL, "Wrong iface type (%d)\n", ret);
 }
 
 static void test_vlan_disable_all(void)
@@ -648,36 +648,36 @@ static void test_vlan_disable_all(void)
 	int ret;
 
 	ret = net_eth_vlan_disable(eth_interfaces[0], VLAN_TAG_1);
-	zassert_equal(ret, 0, "Cannot disable %d\n", VLAN_TAG_1);
+	ztest_equal(ret, 0, "Cannot disable %d\n", VLAN_TAG_1);
 	ret = net_eth_vlan_disable(eth_interfaces[1], VLAN_TAG_2);
-	zassert_equal(ret, 0, "Cannot disable %d\n", VLAN_TAG_2);
+	ztest_equal(ret, 0, "Cannot disable %d\n", VLAN_TAG_2);
 	ret = net_eth_vlan_disable(eth_interfaces[2], VLAN_TAG_3);
-	zassert_equal(ret, 0, "Cannot disable %d\n", VLAN_TAG_3);
+	ztest_equal(ret, 0, "Cannot disable %d\n", VLAN_TAG_3);
 	ret = net_eth_vlan_disable(eth_interfaces[3], VLAN_TAG_4);
-	zassert_equal(ret, 0, "Cannot disable %d\n", VLAN_TAG_4);
+	ztest_equal(ret, 0, "Cannot disable %d\n", VLAN_TAG_4);
 
 	eth_ctx = net_if_l2_data(eth_interfaces[0]);
 
 	ret = net_eth_is_vlan_enabled(eth_ctx, eth_interfaces[0]);
-	zassert_equal(ret, false, "VLAN enabled for interface 0");
+	ztest_equal(ret, false, "VLAN enabled for interface 0");
 
 	ret = net_eth_is_vlan_enabled(eth_ctx, eth_interfaces[1]);
-	zassert_equal(ret, false, "VLAN enabled for interface 1");
+	ztest_equal(ret, false, "VLAN enabled for interface 1");
 
 	ret = net_eth_is_vlan_enabled(eth_ctx, eth_interfaces[2]);
-	zassert_equal(ret, false, "VLAN enabled for interface 2");
+	ztest_equal(ret, false, "VLAN enabled for interface 2");
 
 	ret = net_eth_is_vlan_enabled(eth_ctx, eth_interfaces[3]);
-	zassert_equal(ret, false, "VLAN enabled for interface 3");
+	ztest_equal(ret, false, "VLAN enabled for interface 3");
 
 	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
-	zassert_not_null(iface, "No dummy iface found");
+	ztest_not_null(iface, "No dummy iface found");
 
-	zassert_equal(net_if_l2(iface), &NET_L2_GET_NAME(DUMMY),
+	ztest_equal(net_if_l2(iface), &NET_L2_GET_NAME(DUMMY),
 		      "Not a dummy interface");
 
 	ret = net_eth_vlan_disable(iface, VLAN_TAG_5);
-	zassert_equal(ret, -EINVAL, "Wrong iface type (%d)\n", ret);
+	ztest_equal(ret, -EINVAL, "Wrong iface type (%d)\n", ret);
 }
 
 static bool add_neighbor(struct net_if *iface, struct in6_addr *addr)
@@ -728,20 +728,20 @@ static void test_vlan_send_data(void)
 
 	ret = net_context_get(AF_INET6, SOCK_DGRAM, IPPROTO_UDP,
 			      &udp_v6_ctx);
-	zassert_equal(ret, 0, "Create IPv6 UDP context failed");
+	ztest_equal(ret, 0, "Create IPv6 UDP context failed");
 
 	memcpy(&src_addr6.sin6_addr, &my_addr1, sizeof(struct in6_addr));
 	memcpy(&dst_addr6.sin6_addr, &dst_addr, sizeof(struct in6_addr));
 
 	ret = net_context_bind(udp_v6_ctx, (struct sockaddr *)&src_addr6,
 			       sizeof(struct sockaddr_in6));
-	zassert_equal(ret, 0, "Context bind failure test failed");
+	ztest_equal(ret, 0, "Context bind failure test failed");
 
 	iface = eth_interfaces[1]; /* This is the VLAN interface */
 	ctx = net_if_get_device(iface)->driver_data;
 	eth_ctx = net_if_l2_data(iface);
 	ret = net_eth_is_vlan_enabled(eth_ctx, iface);
-	zassert_equal(ret, true, "VLAN disabled for interface 1");
+	ztest_equal(ret, true, "VLAN disabled for interface 1");
 
 	ctx->expecting_tag = VLAN_TAG_1;
 
@@ -749,22 +749,22 @@ static void test_vlan_send_data(void)
 	ctx = net_if_get_device(iface)->driver_data;
 	eth_ctx = net_if_l2_data(iface);
 	ret = net_eth_is_vlan_enabled(eth_ctx, iface);
-	zassert_equal(ret, true, "VLAN disabled for interface 1");
+	ztest_equal(ret, true, "VLAN disabled for interface 1");
 
 	test_started = true;
 
 	ret = add_neighbor(iface, &dst_addr);
-	zassert_true(ret, "Cannot add neighbor");
+	ztest_true(ret, "Cannot add neighbor");
 
 	ret = net_context_sendto(udp_v6_ctx, test_data, strlen(test_data),
 				 (struct sockaddr *)&dst_addr6,
 				 sizeof(struct sockaddr_in6),
 				 NULL, K_NO_WAIT, NULL);
-	zassert_true(ret > 0, "Send UDP pkt failed");
+	ztest_true(ret > 0, "Send UDP pkt failed");
 
 	if (k_sem_take(&wait_data, WAIT_TIME)) {
 		DBG("Timeout while waiting interface data\n");
-		zassert_false(true, "Timeout");
+		ztest_false(true, "Timeout");
 	}
 
 	net_context_unref(udp_v6_ctx);

--- a/tests/portability/cmsis_rtos_v1/src/kernel_apis.c
+++ b/tests/portability/cmsis_rtos_v1/src/kernel_apis.c
@@ -22,13 +22,13 @@ void test_kernel_start(void)
 		/* When osFeature_MainThread is 1 the kernel offers to start
 		 * with 'main'. The kernel is in this case already started.
 		 */
-		zassert_true(!osKernelInitialize() && !osKernelStart()
+		ztest_true(!osKernelInitialize() && !osKernelStart()
 			     && osKernelRunning(), NULL);
 	} else {
 		/* When osFeature_MainThread is 0 the kernel requires
 		 * explicit start with osKernelStart.
 		 */
-		zassert_false(osKernelRunning(), NULL);
+		ztest_false(osKernelRunning(), NULL);
 	}
 }
 
@@ -55,7 +55,7 @@ void test_kernel_systick(void)
 	max = WAIT_TIME_US + (WAIT_TIME_US / 100);
 	min = WAIT_TIME_US - (WAIT_TIME_US / 100);
 
-	zassert_true(diff <= max && diff >= min,
+	ztest_true(diff <= max && diff >= min,
 		     "start %d stop %d (diff %d) wait %d\n",
 		     start_time, stop_time, diff, WAIT_TIME_US);
 }

--- a/tests/portability/cmsis_rtos_v1/src/mempool.c
+++ b/tests/portability/cmsis_rtos_v1/src/mempool.c
@@ -32,35 +32,35 @@ void test_mempool(void)
 	static struct mem_block zeroblock;
 
 	mempool_id = osPoolCreate(osPool(MemPool));
-	zassert_true(mempool_id != NULL, "mempool creation failed");
+	ztest_true(mempool_id != NULL, "mempool creation failed");
 
 	for (i = 0; i < MAX_BLOCKS; i++) {
 		addr_list[i] = (struct mem_block *)osPoolAlloc(mempool_id);
-		zassert_true(addr_list[i] != NULL, "mempool allocation failed");
+		ztest_true(addr_list[i] != NULL, "mempool allocation failed");
 	}
 
 	/* All blocks in mempool are allocated, any more allocation
 	 * without free should fail
 	 */
 	addr_list[i] = (struct mem_block *)osPoolAlloc(mempool_id);
-	zassert_true(addr_list[i] == NULL, "allocation happened."
+	ztest_true(addr_list[i] == NULL, "allocation happened."
 			" Something's wrong!");
 
 	for (i = 0; i < MAX_BLOCKS; i++) {
 		status_list[i] = osPoolFree(mempool_id, addr_list[i]);
-		zassert_true(status_list[i] == osOK, "mempool free failed");
+		ztest_true(status_list[i] == osOK, "mempool free failed");
 	}
 
 	for (i = 0; i < MAX_BLOCKS; i++) {
 		addr_list[i] = (struct mem_block *)osPoolCAlloc(mempool_id);
-		zassert_true(addr_list[i] != NULL, "mempool allocation failed");
-		zassert_true(memcmp(addr_list[i], &zeroblock,
+		ztest_true(addr_list[i] != NULL, "mempool allocation failed");
+		ztest_true(memcmp(addr_list[i], &zeroblock,
 					sizeof(struct mem_block)) == 0,
 			     "osPoolCAlloc didn't set mempool to 0");
 	}
 
 	for (i = 0; i < MAX_BLOCKS; i++) {
 		status_list[i] = osPoolFree(mempool_id, addr_list[i]);
-		zassert_true(status_list[i] == osOK, "mempool free failed");
+		ztest_true(status_list[i] == osOK, "mempool free failed");
 	}
 }

--- a/tests/portability/cmsis_rtos_v1/src/msgq.c
+++ b/tests/portability/cmsis_rtos_v1/src/msgq.c
@@ -28,13 +28,13 @@ void send_msg_thread(void const *argument)
 
 	/* Prepare and send the 1st message */
 	status = osMessagePut(message_id, data, osWaitForever);
-	zassert_true(status == osOK, "osMessagePut failure for Message1");
+	ztest_true(status == osOK, "osMessagePut failure for Message1");
 
 	/* Fill the queue with blocks of messages */
 	for (i = 0; i < Q_LEN; i++) {
 		data = i;
 		status = osMessagePut(message_id, data, osWaitForever);
-		zassert_true(status == osOK,
+		ztest_true(status == osOK,
 				"osMessagePut failure for message!");
 	}
 
@@ -43,7 +43,7 @@ void send_msg_thread(void const *argument)
 	 */
 	data = MESSAGE2;
 	status = osMessagePut(message_id, data, 0);
-	zassert_true(status == osErrorResource,
+	ztest_true(status == osErrorResource,
 			"Something's wrong with osMessagePut!");
 
 	/* Try putting message to a full queue within a duration
@@ -51,13 +51,13 @@ void send_msg_thread(void const *argument)
 	 */
 	data = MESSAGE2;
 	status = osMessagePut(message_id, data, TIMEOUT/2);
-	zassert_true(status == osErrorTimeoutResource,
+	ztest_true(status == osErrorTimeoutResource,
 			"Something's wrong with osMessagePut!");
 
 	/* Send another message after the queue is emptied */
 	data = MESSAGE2;
 	status = osMessagePut(message_id, data, TIMEOUT*2);
-	zassert_true(status == osOK,
+	ztest_true(status == osOK,
 			"osMessagePut failure for message!");
 }
 
@@ -69,20 +69,20 @@ void message_recv(void)
 
 	/* Try getting message immediately before the queue is populated */
 	evt = osMessageGet(message_id, 0);
-	zassert_true(evt.status == osOK,
+	ztest_true(evt.status == osOK,
 			"Something's wrong with osMessageGet!");
 
 	/* Try receiving message within a duration of TIMEOUT */
 	evt = osMessageGet(message_id, TIMEOUT);
-	zassert_true(evt.status == osEventTimeout,
+	ztest_true(evt.status == osEventTimeout,
 			"Something's wrong with osMessageGet!");
 
 	/* Receive 1st message */
 	evt = osMessageGet(message_id, osWaitForever);
-	zassert_true(evt.status == osEventMessage, "osMessageGet failure");
+	ztest_true(evt.status == osEventMessage, "osMessageGet failure");
 
 	data = evt.value.v;
-	zassert_equal(data, MESSAGE1, NULL);
+	ztest_equal(data, MESSAGE1, NULL);
 
 	/* Wait for queue to get filled */
 	osDelay(TIMEOUT);
@@ -90,19 +90,19 @@ void message_recv(void)
 	/* Empty the queue */
 	for (i = 0; i < Q_LEN; i++) {
 		evt = osMessageGet(message_id, osWaitForever);
-		zassert_true(evt.status == osEventMessage,
+		ztest_true(evt.status == osEventMessage,
 				"osMessageGet failure");
 
 		data = evt.value.v;
-		zassert_equal(data, i, NULL);
+		ztest_equal(data, i, NULL);
 	}
 
 	/* Receive the next message */
 	evt = osMessageGet(message_id, osWaitForever);
-	zassert_true(evt.status == osEventMessage, "osMessageGet failure");
+	ztest_true(evt.status == osEventMessage, "osMessageGet failure");
 
 	data = evt.value.v;
-	zassert_equal(data, MESSAGE2, NULL);
+	ztest_equal(data, MESSAGE2, NULL);
 }
 
 osThreadDef(send_msg_thread, osPriorityNormal, 1, 0);
@@ -112,10 +112,10 @@ void test_messageq(void)
 	osThreadId tid;
 
 	message_id = osMessageCreate(osMessageQ(message), NULL);
-	zassert_true(message_id != NULL, "Message creation failed");
+	ztest_true(message_id != NULL, "Message creation failed");
 
 	tid = osThreadCreate(osThread(send_msg_thread), NULL);
-	zassert_true(tid != NULL, "Thread creation failed");
+	ztest_true(tid != NULL, "Thread creation failed");
 
 	message_recv();
 }

--- a/tests/portability/cmsis_rtos_v1/src/mutex.c
+++ b/tests/portability/cmsis_rtos_v1/src/mutex.c
@@ -23,7 +23,7 @@ void cleanup_max_mutex(osMutexId *mutex_ids)
 
 	for (mutex_count = 0; mutex_count < max_mtx_cnt; mutex_count++) {
 		status = osMutexDelete(mutex_ids[mutex_count]);
-		zassert_true(status == osOK, "Mutex delete fail");
+		ztest_true(status == osOK, "Mutex delete fail");
 	}
 }
 
@@ -36,11 +36,11 @@ void test_max_mutex(void)
 	for (mtx_cnt = 0; mtx_cnt < max_mtx_cnt + 1; mtx_cnt++) {
 		mutex_ids[mtx_cnt] = osMutexCreate(osMutex(Mutex_multi));
 		if (mtx_cnt == max_mtx_cnt) {
-			zassert_true(mutex_ids[mtx_cnt] == NULL,
+			ztest_true(mutex_ids[mtx_cnt] == NULL,
 			  "Mutex creation pass unexpectedly after max count");
 			cleanup_max_mutex(mutex_ids);
 		} else {
-			zassert_true(mutex_ids[mtx_cnt] != NULL,
+			ztest_true(mutex_ids[mtx_cnt] != NULL,
 			  "Multiple mutex creation failed before max count");
 		}
 	}
@@ -53,36 +53,36 @@ void test_mutex(void)
 
 	/* Try deleting invalid mutex object */
 	status = osMutexDelete(mutex_id);
-	zassert_true(status == osErrorParameter,
+	ztest_true(status == osErrorParameter,
 		     "Invalid Mutex deleted unexpectedly!");
 
 	mutex_id = osMutexCreate(osMutex(Mutex_1));
-	zassert_true(mutex_id != NULL, "Mutex1 creation failed");
+	ztest_true(mutex_id != NULL, "Mutex1 creation failed");
 
 	/* Try to release mutex without obtaining it */
 	status = osMutexRelease(mutex_id);
-	zassert_true(status == osErrorResource, "Mutex released unexpectedly!");
+	ztest_true(status == osErrorResource, "Mutex released unexpectedly!");
 
 	status = osMutexWait(mutex_id, 0);
-	zassert_true(status == osOK, "Mutex wait failure");
+	ztest_true(status == osOK, "Mutex wait failure");
 
 	/* Try to acquire an already acquired mutex */
 	status = osMutexWait(mutex_id, 0);
-	zassert_true(status == osOK, "Mutex wait failure");
+	ztest_true(status == osOK, "Mutex wait failure");
 
 	status = osMutexRelease(mutex_id);
-	zassert_true(status == osOK, "Mutex release failure");
+	ztest_true(status == osOK, "Mutex release failure");
 
 	/* Release mutex again as it was acquired twice */
 	status = osMutexRelease(mutex_id);
-	zassert_true(status == osOK, "Mutex release failure");
+	ztest_true(status == osOK, "Mutex release failure");
 
 	/* Try to release mutex that was already released */
 	status = osMutexRelease(mutex_id);
-	zassert_true(status == osErrorResource, "Mutex released unexpectedly!");
+	ztest_true(status == osErrorResource, "Mutex released unexpectedly!");
 
 	status = osMutexDelete(mutex_id);
-	zassert_true(status == osOK, "Mutex delete failure");
+	ztest_true(status == osOK, "Mutex delete failure");
 
 	/* Try mutex creation for more than maximum allowed count */
 	test_max_mutex();
@@ -96,16 +96,16 @@ void tThread_entry_lock_timeout(void const *arg)
 	 * other thread. Try with and without timeout.
 	 */
 	status = osMutexWait((osMutexId)arg, 0);
-	zassert_true(status == osErrorResource, NULL);
+	ztest_true(status == osErrorResource, NULL);
 
 	status = osMutexWait((osMutexId)arg, TIMEOUT - 100);
-	zassert_true(status == osErrorTimeoutResource, NULL);
+	ztest_true(status == osErrorTimeoutResource, NULL);
 
 	/* At this point, mutex is held by the other thread.
 	 * Trying to release it here should fail.
 	 */
 	status = osMutexRelease((osMutexId)arg);
-	zassert_true(status == osErrorResource, "Mutex unexpectedly released");
+	ztest_true(status == osErrorResource, "Mutex unexpectedly released");
 
 	/* This delay ensures that the mutex gets released by the other
 	 * thread in the meantime
@@ -116,7 +116,7 @@ void tThread_entry_lock_timeout(void const *arg)
 	 * and release it.
 	 */
 	status = osMutexWait((osMutexId)arg, TIMEOUT);
-	zassert_true(status == osOK, NULL);
+	ztest_true(status == osOK, NULL);
 	osMutexRelease((osMutexId)arg);
 }
 
@@ -129,13 +129,13 @@ void test_mutex_lock_timeout(void)
 	osStatus status;
 
 	mutex_id = osMutexCreate(osMutex(Mutex_2));
-	zassert_true(mutex_id != NULL, "Mutex2 creation failed");
+	ztest_true(mutex_id != NULL, "Mutex2 creation failed");
 
 	id = osThreadCreate(osThread(tThread_entry_lock_timeout), mutex_id);
-	zassert_true(id != NULL, "Thread creation failed");
+	ztest_true(id != NULL, "Thread creation failed");
 
 	status = osMutexWait(mutex_id, osWaitForever);
-	zassert_true(status == osOK, "Mutex wait failure");
+	ztest_true(status == osOK, "Mutex wait failure");
 
 	/* wait for spawn thread to take action */
 	osDelay(TIMEOUT);

--- a/tests/portability/cmsis_rtos_v1/src/semaphore.c
+++ b/tests/portability/cmsis_rtos_v1/src/semaphore.c
@@ -18,12 +18,12 @@ void thread_sema(void const *arg)
 
 	/* Try taking semaphore immediately when it is not available */
 	tokens_available = osSemaphoreWait((osSemaphoreId)arg, 0);
-	zassert_true(tokens_available == 0,
+	ztest_true(tokens_available == 0,
 			"Semaphore acquired unexpectedly!");
 
 	/* Try taking semaphore after a TIMEOUT, but before release */
 	tokens_available = osSemaphoreWait((osSemaphoreId)arg, TIMEOUT - 100);
-	zassert_true(tokens_available == 0,
+	ztest_true(tokens_available == 0,
 			"Semaphore acquired unexpectedly!");
 
 	/* This delay ensures that the semaphore gets released by the other
@@ -35,13 +35,13 @@ void thread_sema(void const *arg)
 	 * and release it.
 	 */
 	tokens_available = osSemaphoreWait((osSemaphoreId)arg, 0);
-	zassert_true(tokens_available > 0, NULL);
+	ztest_true(tokens_available > 0, NULL);
 
-	zassert_true(osSemaphoreRelease((osSemaphoreId)arg) == osOK,
+	ztest_true(osSemaphoreRelease((osSemaphoreId)arg) == osOK,
 			"Semaphore release failure");
 
 	/* Try releasing when no semaphore is obtained */
-	zassert_true(osSemaphoreRelease((osSemaphoreId)arg) == osErrorResource,
+	ztest_true(osSemaphoreRelease((osSemaphoreId)arg) == osErrorResource,
 			"Semaphore released unexpectedly!");
 }
 
@@ -54,12 +54,12 @@ void test_semaphore(void)
 	osSemaphoreId semaphore_id;
 
 	semaphore_id = osSemaphoreCreate(osSemaphore(semaphore_1), 1);
-	zassert_true(semaphore_id != NULL, "semaphore creation failed");
+	ztest_true(semaphore_id != NULL, "semaphore creation failed");
 
 	id = osThreadCreate(osThread(thread_sema), semaphore_id);
-	zassert_true(id != NULL, "Thread creation failed");
+	ztest_true(id != NULL, "Thread creation failed");
 
-	zassert_true(osSemaphoreWait(semaphore_id, osWaitForever) > 0,
+	ztest_true(osSemaphoreWait(semaphore_id, osWaitForever) > 0,
 			"Semaphore wait failure");
 
 	/* wait for spawn thread to take action */
@@ -67,10 +67,10 @@ void test_semaphore(void)
 
 	/* Release the semaphore to be used by the other thread */
 	status = osSemaphoreRelease(semaphore_id);
-	zassert_true(status == osOK, "Semaphore release failure");
+	ztest_true(status == osOK, "Semaphore release failure");
 
 	osDelay(TIMEOUT);
 
 	status = osSemaphoreDelete(semaphore_id);
-	zassert_true(status == osOK, "semaphore delete failure");
+	ztest_true(status == osOK, "semaphore delete failure");
 }

--- a/tests/portability/cmsis_rtos_v1/src/thread_apis.c
+++ b/tests/portability/cmsis_rtos_v1/src/thread_apis.c
@@ -23,20 +23,20 @@ void thread1(void const *argument)
 	osStatus status;
 	osThreadId id = osThreadGetId();
 
-	zassert_true(id != NULL, "Failed getting Thread ID");
+	ztest_true(id != NULL, "Failed getting Thread ID");
 
 	/* This thread starts off at a high priority (same as thread2) */
 	thread_yield_check++;
-	zassert_equal(thread_yield_check, 1, NULL);
+	ztest_equal(thread_yield_check, 1, NULL);
 
 	/* Yield to thread2 which is of same priority */
 	status = osThreadYield();
-	zassert_true(status == osOK, "Error doing thread yield");
+	ztest_true(status == osOK, "Error doing thread yield");
 
 	/* thread_yield_check should now be 2 as it was incremented
 	 * in thread2.
 	 */
-	zassert_equal(thread_yield_check, 2, NULL);
+	ztest_equal(thread_yield_check, 2, NULL);
 }
 
 void thread2(void const *argument)
@@ -61,27 +61,27 @@ void thread3(void const *argument)
 	/* Lower the priority of the current thread */
 	osThreadSetPriority(id, osPriorityBelowNormal);
 	rv = osThreadGetPriority(id);
-	zassert_equal(rv, osPriorityBelowNormal,
+	ztest_equal(rv, osPriorityBelowNormal,
 			"Expected priority to be changed to %d, not %d",
 			(int)osPriorityBelowNormal, (int)rv);
 
 	/* Increase the priority of the current thread */
 	osThreadSetPriority(id, osPriorityAboveNormal);
 	rv = osThreadGetPriority(id);
-	zassert_equal(rv, osPriorityAboveNormal,
+	ztest_equal(rv, osPriorityAboveNormal,
 			"Expected priority to be changed to %d, not %d",
 			(int)osPriorityAboveNormal, (int)rv);
 
 	/* Restore the priority of the current thread */
 	osThreadSetPriority(id, prio);
 	rv = osThreadGetPriority(id);
-	zassert_equal(rv, prio,
+	ztest_equal(rv, prio,
 			"Expected priority to be changed to %d, not %d",
 			(int)prio, (int)rv);
 
 	/* Try to set unsupported priority and assert failure */
 	status = osThreadSetPriority(id, osPriorityDeadline);
-	zassert_true(status == osErrorValue,
+	ztest_true(status == osErrorValue,
 			"Something's wrong with osThreadSetPriority!");
 
 	/* Indication that thread3 is done with its processing */
@@ -103,7 +103,7 @@ void test_thread_prio(void)
 	osThreadId id3;
 
 	id3 = osThreadCreate(osThread(thread3), NULL);
-	zassert_true(id3 != NULL, "Failed creating thread3");
+	ztest_true(id3 != NULL, "Failed creating thread3");
 
 	/* Keep delaying 10 milliseconds to ensure thread3 is done with
 	 * its execution. It loops at the end and is terminated here.
@@ -113,16 +113,16 @@ void test_thread_prio(void)
 	} while (thread3_state == 0);
 
 	status = osThreadTerminate(id3);
-	zassert_true(status == osOK, "Error terminating thread3");
+	ztest_true(status == osOK, "Error terminating thread3");
 
 	/* Try to set priority to inactive thread and assert failure */
 	status = osThreadSetPriority(id3, osPriorityNormal);
-	zassert_true(status == osErrorResource,
+	ztest_true(status == osErrorResource,
 			"Something's wrong with osThreadSetPriority!");
 
 	/* Try to terminate inactive thread and assert failure */
 	status = osThreadTerminate(id3);
-	zassert_true(status == osErrorResource,
+	ztest_true(status == osErrorResource,
 			"Something's wrong with osThreadTerminate!");
 
 	thread3_state = 0;
@@ -134,10 +134,10 @@ void test_thread_apis(void)
 	osThreadId id2;
 
 	id1 = osThreadCreate(osThread(thread1), NULL);
-	zassert_true(id1 != NULL, "Failed creating thread1");
+	ztest_true(id1 != NULL, "Failed creating thread1");
 
 	id2 = osThreadCreate(osThread(thread2), NULL);
-	zassert_true(id2 != NULL, "Failed creating thread2");
+	ztest_true(id2 != NULL, "Failed creating thread2");
 
 	do {
 		osDelay(100);

--- a/tests/portability/cmsis_rtos_v1/src/thread_instance.c
+++ b/tests/portability/cmsis_rtos_v1/src/thread_instance.c
@@ -18,7 +18,7 @@ void thread_inst_check(void const *argument)
 {
 	osThreadId id = osThreadGetId();
 
-	zassert_true(id != NULL, "Failed getting ThreadId");
+	ztest_true(id != NULL, "Failed getting ThreadId");
 }
 
 osThreadDef(thread_inst_check, osPriorityNormal, 3, STACKSZ);
@@ -28,14 +28,14 @@ void test_thread_instances(void)
 	osThreadId id1, id2, id3, id4;
 
 	id1 = osThreadCreate(osThread(thread_inst_check), NULL);
-	zassert_true(id1 != NULL, "Failed creating thread_inst_check");
+	ztest_true(id1 != NULL, "Failed creating thread_inst_check");
 
 	id2 = osThreadCreate(osThread(thread_inst_check), NULL);
-	zassert_true(id2 != NULL, "Failed creating thread_inst_check");
+	ztest_true(id2 != NULL, "Failed creating thread_inst_check");
 
 	id3 = osThreadCreate(osThread(thread_inst_check), NULL);
-	zassert_true(id3 != NULL, "Failed creating thread_inst_check");
+	ztest_true(id3 != NULL, "Failed creating thread_inst_check");
 
 	id4 = osThreadCreate(osThread(thread_inst_check), NULL);
-	zassert_true(id4 == NULL, "Something wrong with thread instances");
+	ztest_true(id4 == NULL, "Something wrong with thread instances");
 }

--- a/tests/portability/cmsis_rtos_v1/src/timer.c
+++ b/tests/portability/cmsis_rtos_v1/src/timer.c
@@ -50,38 +50,38 @@ void test_timer(void)
 	/* Create one-shot timer */
 	exec1 = 1U;
 	id1 = osTimerCreate(osTimer(Timer1), osTimerOnce, &exec1);
-	zassert_true(id1 != NULL, "error creating one-shot timer");
+	ztest_true(id1 != NULL, "error creating one-shot timer");
 
 	/* Stop the timer before start */
 	status = osTimerStop(id1);
-	zassert_true(status == osErrorResource, "error while stopping non-active timer");
+	ztest_true(status == osErrorResource, "error while stopping non-active timer");
 
 	timerDelay = ONESHOT_TIME;
 	status = osTimerStart(id1, timerDelay);
-	zassert_true(status == osOK, "error starting one-shot timer");
+	ztest_true(status == osOK, "error starting one-shot timer");
 
 	/* Timer should fire only once if setup in one shot
 	 * mode. Wait for 3 times the one-shot time to see
 	 * if it fires more than once.
 	 */
 	osDelay(timerDelay*3U + 100);
-	zassert_true(num_oneshots_executed == 1U,
+	ztest_true(num_oneshots_executed == 1U,
 			"error setting up one-shot timer");
 
 	status = osTimerStop(id1);
-	zassert_true(status == osOK, "error stopping one-shot timer");
+	ztest_true(status == osOK, "error stopping one-shot timer");
 
 	status = osTimerDelete(id1);
-	zassert_true(status == osOK, "error deleting one-shot timer");
+	ztest_true(status == osOK, "error deleting one-shot timer");
 
 	/* Create periodic timer */
 	exec2 = 2U;
 	id2 = osTimerCreate(osTimer(Timer2), osTimerPeriodic, &exec2);
-	zassert_true(id2 != NULL, "error creating periodic timer");
+	ztest_true(id2 != NULL, "error creating periodic timer");
 
 	timerDelay = PERIOD;
 	status = osTimerStart(id2, timerDelay);
-	zassert_true(status == osOK, "error starting periodic timer");
+	ztest_true(status == osOK, "error starting periodic timer");
 
 	/* Timer should fire periodically if setup in periodic
 	 * mode. Wait for NUM_PERIODS periods to see if it is
@@ -92,10 +92,10 @@ void test_timer(void)
 	/* The first firing of the timer should be ignored.
 	 * Hence checking for NUM_PERIODS + 1.
 	 */
-	zassert_true(num_periods_executed == NUM_PERIODS + 1,
+	ztest_true(num_periods_executed == NUM_PERIODS + 1,
 			"error setting up periodic timer");
 
 	/* Delete the timer before stop */
 	status = osTimerDelete(id2);
-	zassert_true(status == osOK, "error deleting periodic timer");
+	ztest_true(status == osOK, "error deleting periodic timer");
 }

--- a/tests/portability/cmsis_rtos_v2/src/kernel.c
+++ b/tests/portability/cmsis_rtos_v2/src/kernel.c
@@ -42,22 +42,22 @@ void lock_unlock_check(void *arg)
 
 	state_before_lock = osKernelLock();
 	if (k_is_in_isr()) {
-		zassert_true(state_before_lock == osErrorISR, NULL);
+		ztest_true(state_before_lock == osErrorISR, NULL);
 	}
 	tick_freq = osKernelGetTickFreq();
 	sys_timer_freq = osKernelGetTickFreq();
 
 	state_after_lock = osKernelUnlock();
 	if (k_is_in_isr()) {
-		zassert_true(state_after_lock == osErrorISR, NULL);
+		ztest_true(state_after_lock == osErrorISR, NULL);
 	} else {
-		zassert_true(state_before_lock == !state_after_lock, NULL);
+		ztest_true(state_before_lock == !state_after_lock, NULL);
 	}
 	current_state = osKernelRestoreLock(state_before_lock);
 	if (k_is_in_isr()) {
-		zassert_true(current_state == osErrorISR, NULL);
+		ztest_true(current_state == osErrorISR, NULL);
 	} else {
-		zassert_equal(current_state, state_before_lock, NULL);
+		ztest_equal(current_state, state_before_lock, NULL);
 	}
 }
 
@@ -69,9 +69,9 @@ void test_kernel_apis(void)
 	irq_offload(get_version_check, &version_irq);
 
 	/* Check if the version value retrieved in ISR and thread is same */
-	zassert_equal(strcmp(version.info, version_irq.info), 0, NULL);
-	zassert_equal(version.os_info.api, version_irq.os_info.api, NULL);
-	zassert_equal(version.os_info.kernel, version_irq.os_info.kernel, NULL);
+	ztest_equal(strcmp(version.info, version_irq.info), 0, NULL);
+	ztest_equal(version.os_info.api, version_irq.os_info.api, NULL);
+	ztest_equal(version.os_info.kernel, version_irq.os_info.kernel, NULL);
 
 	lock_unlock_check(NULL);
 
@@ -90,9 +90,9 @@ void delay_until(void *param)
 void test_delay(void)
 {
 	delay_until(NULL);
-	zassert_true(tick <= osKernelGetTickCount(), NULL);
-	zassert_equal(status_val, osOK, NULL);
+	ztest_true(tick <= osKernelGetTickCount(), NULL);
+	ztest_equal(status_val, osOK, NULL);
 
 	irq_offload(delay_until, NULL);
-	zassert_equal(status_val, osErrorISR, NULL);
+	ztest_equal(status_val, osErrorISR, NULL);
 }

--- a/tests/portability/cmsis_rtos_v2/src/mempool.c
+++ b/tests/portability/cmsis_rtos_v2/src/mempool.c
@@ -35,42 +35,42 @@ static void mempool_common_tests(osMemoryPoolId_t mp_id,
 	struct mem_block *addr_list[MAX_BLOCKS + 1];
 	osStatus_t status;
 
-	zassert_true(osMemoryPoolGetName(dummy_id) == NULL,
+	ztest_true(osMemoryPoolGetName(dummy_id) == NULL,
 		     "Something's wrong with osMemoryPoolGetName!");
 
 	name = osMemoryPoolGetName(mp_id);
-	zassert_true(strcmp(expected_name, name) == 0,
+	ztest_true(strcmp(expected_name, name) == 0,
 		     "Error getting mempool name");
 
-	zassert_equal(osMemoryPoolGetCapacity(dummy_id), 0,
+	ztest_equal(osMemoryPoolGetCapacity(dummy_id), 0,
 		      "Something's wrong with osMemoryPoolGetCapacity!");
 
-	zassert_equal(osMemoryPoolGetCapacity(mp_id), MAX_BLOCKS,
+	ztest_equal(osMemoryPoolGetCapacity(mp_id), MAX_BLOCKS,
 		      "Something's wrong with osMemoryPoolGetCapacity!");
 
-	zassert_equal(osMemoryPoolGetBlockSize(dummy_id), 0,
+	ztest_equal(osMemoryPoolGetBlockSize(dummy_id), 0,
 		      "Something's wrong with osMemoryPoolGetBlockSize!");
 
-	zassert_equal(osMemoryPoolGetBlockSize(mp_id),
+	ztest_equal(osMemoryPoolGetBlockSize(mp_id),
 		      sizeof(struct mem_block),
 		      "Something's wrong with osMemoryPoolGetBlockSize!");
 
 	/* The memory pool should be completely available at this point */
-	zassert_equal(osMemoryPoolGetCount(mp_id), 0,
+	ztest_equal(osMemoryPoolGetCount(mp_id), 0,
 		      "Something's wrong with osMemoryPoolGetCount!");
-	zassert_equal(osMemoryPoolGetSpace(mp_id), MAX_BLOCKS,
+	ztest_equal(osMemoryPoolGetSpace(mp_id), MAX_BLOCKS,
 		      "Something's wrong with osMemoryPoolGetSpace!");
 
 	for (i = 0; i < MAX_BLOCKS; i++) {
 		addr_list[i] = (struct mem_block *)osMemoryPoolAlloc(mp_id,
 								     osWaitForever);
-		zassert_true(addr_list[i] != NULL, "mempool allocation failed");
+		ztest_true(addr_list[i] != NULL, "mempool allocation failed");
 	}
 
 	/* The memory pool should be completely in use at this point */
-	zassert_equal(osMemoryPoolGetCount(mp_id), MAX_BLOCKS,
+	ztest_equal(osMemoryPoolGetCount(mp_id), MAX_BLOCKS,
 		      "Something's wrong with osMemoryPoolGetCount!");
-	zassert_equal(osMemoryPoolGetSpace(mp_id), 0,
+	ztest_equal(osMemoryPoolGetSpace(mp_id), 0,
 		      "Something's wrong with osMemoryPoolGetSpace!");
 
 	/* All blocks in mempool are allocated, any more allocation
@@ -78,22 +78,22 @@ static void mempool_common_tests(osMemoryPoolId_t mp_id,
 	 */
 	addr_list[i] = (struct mem_block *)osMemoryPoolAlloc(mp_id,
 							     TIMEOUT_TICKS);
-	zassert_true(addr_list[i] == NULL, "allocation happened."
+	ztest_true(addr_list[i] == NULL, "allocation happened."
 		     " Something's wrong!");
 
-	zassert_equal(osMemoryPoolFree(dummy_id, addr_list[0]),
+	ztest_equal(osMemoryPoolFree(dummy_id, addr_list[0]),
 		      osErrorParameter, "mempool free worked unexpectedly!");
 
 	for (i = 0; i < MAX_BLOCKS; i++) {
 		status = osMemoryPoolFree(mp_id, addr_list[i]);
-		zassert_true(status == osOK, "mempool free failed");
+		ztest_true(status == osOK, "mempool free failed");
 	}
 
-	zassert_equal(osMemoryPoolDelete(dummy_id), osErrorParameter,
+	ztest_equal(osMemoryPoolDelete(dummy_id), osErrorParameter,
 		      "mempool delete worked unexpectedly!");
 
 	status = osMemoryPoolDelete(mp_id);
-	zassert_true(status == osOK, "mempool delete failure");
+	ztest_true(status == osOK, "mempool delete failure");
 }
 
 /**
@@ -107,7 +107,7 @@ void test_mempool_dynamic(void)
 
 	mp_id = osMemoryPoolNew(MAX_BLOCKS, sizeof(struct mem_block),
 				NULL);
-	zassert_true(mp_id != NULL, "mempool creation failed");
+	ztest_true(mp_id != NULL, "mempool creation failed");
 
 	mempool_common_tests(mp_id, "ZephyrMemPool");
 }
@@ -124,11 +124,11 @@ void test_mempool(void)
 	/* Create memory pool with invalid block size */
 	mp_id = osMemoryPoolNew(MAX_BLOCKS + 1, sizeof(struct mem_block),
 				&mp_attrs);
-	zassert_true(mp_id == NULL, "osMemoryPoolNew worked unexpectedly!");
+	ztest_true(mp_id == NULL, "osMemoryPoolNew worked unexpectedly!");
 
 	mp_id = osMemoryPoolNew(MAX_BLOCKS, sizeof(struct mem_block),
 				&mp_attrs);
-	zassert_true(mp_id != NULL, "mempool creation failed");
+	ztest_true(mp_id != NULL, "mempool creation failed");
 
 	mempool_common_tests(mp_id, mp_attrs.name);
 }

--- a/tests/portability/cmsis_rtos_v2/src/msgq.c
+++ b/tests/portability/cmsis_rtos_v2/src/msgq.c
@@ -35,12 +35,12 @@ void send_msg_thread(void *argument)
 	/* Prepare and send the 1st message (a simple integer data) */
 	sample.data1 = MESSAGE1;
 	status = osMessageQueuePut(message_id, &sample, 0, osWaitForever);
-	zassert_true(status == osOK, "osMessageQueuePut failure for Message1");
+	ztest_true(status == osOK, "osMessageQueuePut failure for Message1");
 
 	/* The Queue should be empty at this point */
-	zassert_equal(osMessageQueueGetCount(message_id), 0,
+	ztest_equal(osMessageQueueGetCount(message_id), 0,
 		      "Something's wrong with osMessageQueueGetCount!");
-	zassert_equal(osMessageQueueGetSpace(message_id), Q_LEN,
+	ztest_equal(osMessageQueueGetSpace(message_id), Q_LEN,
 		      "Something's wrong with osMessageQueueGetSpace!");
 
 	/* Fill the queue with blocks of messages */
@@ -50,14 +50,14 @@ void send_msg_thread(void *argument)
 		data[i].data3 = i * 3 + 2;
 		status = osMessageQueuePut(message_id, data + i,
 					   0, osWaitForever);
-		zassert_true(status == osOK,
+		ztest_true(status == osOK,
 			     "osMessageQueuePut failure for message!");
 	}
 
 	/* The Queue should be full at this point */
-	zassert_equal(osMessageQueueGetCount(message_id), Q_LEN,
+	ztest_equal(osMessageQueueGetCount(message_id), Q_LEN,
 		      "Something's wrong with osMessageQueueGetCount!");
-	zassert_equal(osMessageQueueGetSpace(message_id), 0,
+	ztest_equal(osMessageQueueGetSpace(message_id), 0,
 		      "Something's wrong with osMessageQueueGetSpace!");
 
 	/* Try putting message to a full queue immediately
@@ -65,7 +65,7 @@ void send_msg_thread(void *argument)
 	 */
 	sample.data1 = MESSAGE2;
 	status = osMessageQueuePut(message_id, &sample, 0, 0);
-	zassert_true(status == osErrorResource,
+	ztest_true(status == osErrorResource,
 		     "Something's wrong with osMessageQueuePut!");
 
 	/* Try putting message to a full queue within a duration
@@ -73,13 +73,13 @@ void send_msg_thread(void *argument)
 	 */
 	sample.data1 = MESSAGE2;
 	status = osMessageQueuePut(message_id, &sample, 0, TIMEOUT_TICKS / 2);
-	zassert_true(status == osErrorTimeout,
+	ztest_true(status == osErrorTimeout,
 		     "Something's wrong with osMessageQueuePut!");
 
 	/* Send another message after the queue is emptied */
 	sample.data1 = MESSAGE2;
 	status = osMessageQueuePut(message_id, &sample, 0, TIMEOUT_TICKS * 2);
-	zassert_true(status == osOK,
+	ztest_true(status == osOK,
 		     "osMessageQueuePut failure for message!");
 }
 
@@ -91,27 +91,27 @@ void message_recv(void)
 
 	/* Try getting message immediately before the queue is populated */
 	status = osMessageQueueGet(message_id, (void *)&recv_data, NULL, 0);
-	zassert_true(status == osErrorResource,
+	ztest_true(status == osErrorResource,
 		     "Something's wrong with osMessageQueueGet!");
 
 	/* Try receiving message within a duration of TIMEOUT */
 	status = osMessageQueueGet(message_id, (void *)&recv_data,
 				   NULL, TIMEOUT_TICKS);
-	zassert_true(status == osErrorTimeout,
+	ztest_true(status == osErrorTimeout,
 		     "Something's wrong with osMessageQueueGet!");
 
-	zassert_equal(osMessageQueueGetCapacity(message_id), Q_LEN,
+	ztest_equal(osMessageQueueGetCapacity(message_id), Q_LEN,
 		      "Something's wrong with osMessageQueueGetCapacity!");
 
-	zassert_equal(osMessageQueueGetMsgSize(message_id),
+	ztest_equal(osMessageQueueGetMsgSize(message_id),
 		      sizeof(struct sample_data),
 		      "Something's wrong with osMessageQueueGetMsgSize!");
 
 	/* Receive 1st message */
 	status = osMessageQueueGet(message_id, (void *)&recv_data,
 				   NULL, osWaitForever);
-	zassert_true(status == osOK, "osMessageQueueGet failure");
-	zassert_equal(recv_data.data1, MESSAGE1, NULL);
+	ztest_true(status == osOK, "osMessageQueueGet failure");
+	ztest_equal(recv_data.data1, MESSAGE1, NULL);
 
 	/* Wait for queue to get filled */
 	osDelay(TIMEOUT_TICKS);
@@ -120,18 +120,18 @@ void message_recv(void)
 	for (i = 0; i < Q_LEN; i++) {
 		status = osMessageQueueGet(message_id, (void *)&recv_data, NULL,
 					   osWaitForever);
-		zassert_true(status == osOK, "osMessageQueueGet failure");
+		ztest_true(status == osOK, "osMessageQueueGet failure");
 
-		zassert_equal(recv_data.data1, i * 3, NULL);
-		zassert_equal(recv_data.data2, i * 3 + 1, NULL);
-		zassert_equal(recv_data.data3, i * 3 + 2, NULL);
+		ztest_equal(recv_data.data1, i * 3, NULL);
+		ztest_equal(recv_data.data2, i * 3 + 1, NULL);
+		ztest_equal(recv_data.data3, i * 3 + 2, NULL);
 	}
 
 	/* Receive the next message */
 	status = osMessageQueueGet(message_id, (void *)&recv_data,
 				   NULL, osWaitForever);
-	zassert_true(status == osOK, "osMessageQueueGet failure");
-	zassert_equal(recv_data.data1, MESSAGE2, NULL);
+	ztest_true(status == osOK, "osMessageQueueGet failure");
+	ztest_equal(recv_data.data1, MESSAGE2, NULL);
 }
 
 static K_THREAD_STACK_DEFINE(test_stack, STACKSZ);
@@ -160,10 +160,10 @@ void test_messageq(void)
 
 	message_id = osMessageQueueNew(Q_LEN, sizeof(struct sample_data),
 				       &init_mem_attrs);
-	zassert_true(message_id != NULL, "Message creation failed");
+	ztest_true(message_id != NULL, "Message creation failed");
 
 	tid = osThreadNew(send_msg_thread, NULL, &thread_attr);
-	zassert_true(tid != NULL, "Thread creation failed");
+	ztest_true(tid != NULL, "Thread creation failed");
 
 	message_recv();
 
@@ -173,23 +173,23 @@ void test_messageq(void)
 	osDelay(TIMEOUT_TICKS / 10);
 
 	/* Make sure msgq is empty */
-	zassert_equal(osMessageQueueGetCount(message_id), 0,
+	ztest_equal(osMessageQueueGetCount(message_id), 0,
 		      "Something's wrong with osMessageQueueGetCount!");
 
 	sample.data1 = MESSAGE1;
 	status = osMessageQueuePut(message_id, &sample, 0, osWaitForever);
-	zassert_true(status == osOK, "osMessageQueuePut failure for Message1");
+	ztest_true(status == osOK, "osMessageQueuePut failure for Message1");
 
-	zassert_equal(osMessageQueueGetCount(message_id), 1,
+	ztest_equal(osMessageQueueGetCount(message_id), 1,
 		      "Something's wrong with osMessageQueueGetCount!");
 
 	status = osMessageQueueReset(message_id);
-	zassert_true(status == osOK, "osMessageQueueReset failure");
+	ztest_true(status == osOK, "osMessageQueueReset failure");
 
 	/* After reset msgq must be empty */
-	zassert_equal(osMessageQueueGetCount(message_id), 0,
+	ztest_equal(osMessageQueueGetCount(message_id), 0,
 		      "Something's wrong with osMessageQueueGetCount!");
 
 	status = osMessageQueueDelete(message_id);
-	zassert_true(status == osOK, "osMessageQueueDelete failure");
+	ztest_true(status == osOK, "osMessageQueueDelete failure");
 }

--- a/tests/portability/cmsis_rtos_v2/src/mutex.c
+++ b/tests/portability/cmsis_rtos_v2/src/mutex.c
@@ -26,7 +26,7 @@ void cleanup_max_mutex(osMutexId_t *mutex_ids)
 
 	for (mutex_count = 0; mutex_count < max_mtx_cnt; mutex_count++) {
 		status = osMutexDelete(mutex_ids[mutex_count]);
-		zassert_true(status == osOK, "Mutex delete fail");
+		ztest_true(status == osOK, "Mutex delete fail");
 	}
 }
 
@@ -39,11 +39,11 @@ void test_max_mutex(void)
 	for (mtx_cnt = 0; mtx_cnt < max_mtx_cnt + 1; mtx_cnt++) {
 		mutex_ids[mtx_cnt] = osMutexNew(&mutex_attr);
 		if (mtx_cnt == max_mtx_cnt) {
-			zassert_true(mutex_ids[mtx_cnt] == NULL,
+			ztest_true(mutex_ids[mtx_cnt] == NULL,
 				     "Mutex creation pass unexpectedly after max count");
 			cleanup_max_mutex(mutex_ids);
 		} else {
-			zassert_true(mutex_ids[mtx_cnt] != NULL,
+			ztest_true(mutex_ids[mtx_cnt] != NULL,
 				     "Multiple mutex creation failed before max count");
 		}
 	}
@@ -58,49 +58,49 @@ void test_mutex(void)
 
 	/* Try deleting invalid mutex object */
 	status = osMutexDelete(mutex_id);
-	zassert_true(status == osErrorParameter,
+	ztest_true(status == osErrorParameter,
 		     "Invalid Mutex deleted unexpectedly!");
 
 	mutex_id = osMutexNew(&mutex_attr);
-	zassert_true(mutex_id != NULL, "Mutex1 creation failed");
+	ztest_true(mutex_id != NULL, "Mutex1 creation failed");
 
 	name = osMutexGetName(mutex_id);
-	zassert_true(strcmp(mutex_attr.name, name) == 0,
+	ztest_true(strcmp(mutex_attr.name, name) == 0,
 		     "Error getting Mutex name");
 
 	/* Try to release mutex without obtaining it */
 	status = osMutexRelease(mutex_id);
-	zassert_true(status == osErrorResource, "Mutex released unexpectedly!");
+	ztest_true(status == osErrorResource, "Mutex released unexpectedly!");
 
 	/* Try figuring out the owner for a Mutex which has not been
 	 * acquired by any thread yet.
 	 */
 	id = osMutexGetOwner(mutex_id);
-	zassert_true(id == NULL, "Something wrong with MutexGetOwner!");
+	ztest_true(id == NULL, "Something wrong with MutexGetOwner!");
 
 	status = osMutexAcquire(mutex_id, 0);
-	zassert_true(status == osOK, "Mutex wait failure");
+	ztest_true(status == osOK, "Mutex wait failure");
 
 	id = osMutexGetOwner(mutex_id);
-	zassert_equal(id, osThreadGetId(), "Current thread is not the owner!");
+	ztest_equal(id, osThreadGetId(), "Current thread is not the owner!");
 
 	/* Try to acquire an already acquired mutex */
 	status = osMutexAcquire(mutex_id, 0);
-	zassert_true(status == osOK, "Mutex wait failure");
+	ztest_true(status == osOK, "Mutex wait failure");
 
 	status = osMutexRelease(mutex_id);
-	zassert_true(status == osOK, "Mutex release failure");
+	ztest_true(status == osOK, "Mutex release failure");
 
 	/* Release mutex again as it was acquired twice */
 	status = osMutexRelease(mutex_id);
-	zassert_true(status == osOK, "Mutex release failure");
+	ztest_true(status == osOK, "Mutex release failure");
 
 	/* Try to release mutex that was already released */
 	status = osMutexRelease(mutex_id);
-	zassert_true(status == osErrorResource, "Mutex released unexpectedly!");
+	ztest_true(status == osErrorResource, "Mutex released unexpectedly!");
 
 	status = osMutexDelete(mutex_id);
-	zassert_true(status == osOK, "Mutex delete failure");
+	ztest_true(status == osOK, "Mutex delete failure");
 
 	/* Try mutex creation for more than maximum allowed count */
 	test_max_mutex();
@@ -115,16 +115,16 @@ void tThread_entry_lock_timeout(void *arg)
 	 * by the other thread. Try with and without timeout.
 	 */
 	status = osMutexAcquire((osMutexId_t)arg, 0);
-	zassert_true(status == osErrorResource, NULL);
+	ztest_true(status == osErrorResource, NULL);
 
 	status = osMutexAcquire((osMutexId_t)arg, TIMEOUT_TICKS - 5);
-	zassert_true(status == osErrorTimeout, NULL);
+	ztest_true(status == osErrorTimeout, NULL);
 
 	status = osMutexRelease((osMutexId_t)arg);
-	zassert_true(status == osErrorResource, "Mutex unexpectedly released");
+	ztest_true(status == osErrorResource, "Mutex unexpectedly released");
 
 	id = osMutexGetOwner((osMutexId_t)arg);
-	zassert_not_equal(id, osThreadGetId(),
+	ztest_not_equal(id, osThreadGetId(),
 			  "Unexpectedly, current thread is the mutex owner!");
 
 	/* This delay ensures that the mutex gets released by the other
@@ -136,7 +136,7 @@ void tThread_entry_lock_timeout(void *arg)
 	 * and release it.
 	 */
 	status = osMutexAcquire((osMutexId_t)arg, TIMEOUT_TICKS);
-	zassert_true(status == osOK, NULL);
+	ztest_true(status == osOK, NULL);
 	osMutexRelease((osMutexId_t)arg);
 }
 
@@ -160,13 +160,13 @@ void test_mutex_lock_timeout(void)
 	osStatus_t status;
 
 	mutex_id = osMutexNew(&mutex_attr);
-	zassert_true(mutex_id != NULL, "Mutex2 creation failed");
+	ztest_true(mutex_id != NULL, "Mutex2 creation failed");
 
 	id = osThreadNew(tThread_entry_lock_timeout, mutex_id, &thread_attr);
-	zassert_true(id != NULL, "Thread creation failed");
+	ztest_true(id != NULL, "Thread creation failed");
 
 	status = osMutexAcquire(mutex_id, osWaitForever);
-	zassert_true(status == osOK, "Mutex wait failure");
+	ztest_true(status == osOK, "Mutex wait failure");
 
 	/* wait for spawn thread to take action */
 	osDelay(TIMEOUT_TICKS);

--- a/tests/portability/cmsis_rtos_v2/src/semaphore.c
+++ b/tests/portability/cmsis_rtos_v2/src/semaphore.c
@@ -17,12 +17,12 @@ void thread_sema(void *arg)
 
 	/* Try taking semaphore immediately when it is not available */
 	status = osSemaphoreAcquire((osSemaphoreId_t)arg, 0);
-	zassert_true(status == osErrorResource,
+	ztest_true(status == osErrorResource,
 		     "Semaphore acquired unexpectedly!");
 
 	/* Try taking semaphore after a TIMEOUT, but before release */
 	status = osSemaphoreAcquire((osSemaphoreId_t)arg, TIMEOUT_TICKS - 5);
-	zassert_true(status == osErrorTimeout,
+	ztest_true(status == osErrorTimeout,
 		     "Semaphore acquired unexpectedly!");
 
 	/* This delay ensures that the semaphore gets released by the other
@@ -34,13 +34,13 @@ void thread_sema(void *arg)
 	 * and release it.
 	 */
 	status = osSemaphoreAcquire((osSemaphoreId_t)arg, 0);
-	zassert_true(status == osOK, "Semaphore could not be acquired");
+	ztest_true(status == osOK, "Semaphore could not be acquired");
 
-	zassert_true(osSemaphoreRelease((osSemaphoreId_t)arg) == osOK,
+	ztest_true(osSemaphoreRelease((osSemaphoreId_t)arg) == osOK,
 		     "Semaphore release failure");
 
 	/* Try releasing when no semaphore is obtained */
-	zassert_true(
+	ztest_true(
 		osSemaphoreRelease((osSemaphoreId_t)arg) == osErrorResource,
 		"Semaphore released unexpectedly!");
 }
@@ -74,43 +74,43 @@ void test_semaphore(void)
 	const char *name;
 
 	semaphore_id = osSemaphoreNew(1, 1, &sema_attr);
-	zassert_true(semaphore_id != NULL, "semaphore creation failed");
+	ztest_true(semaphore_id != NULL, "semaphore creation failed");
 
 	name = osSemaphoreGetName(semaphore_id);
-	zassert_true(strcmp(sema_attr.name, name) == 0,
+	ztest_true(strcmp(sema_attr.name, name) == 0,
 		     "Error getting Semaphore name");
 
 	id = osThreadNew(thread_sema, semaphore_id, &thread_attr);
-	zassert_true(id != NULL, "Thread creation failed");
+	ztest_true(id != NULL, "Thread creation failed");
 
-	zassert_true(osSemaphoreGetCount(semaphore_id) == 1, NULL);
+	ztest_true(osSemaphoreGetCount(semaphore_id) == 1, NULL);
 
 	/* Acquire invalid semaphore */
-	zassert_equal(osSemaphoreAcquire(dummy_sem_id, osWaitForever),
+	ztest_equal(osSemaphoreAcquire(dummy_sem_id, osWaitForever),
 		      osErrorParameter, "Semaphore wait worked unexpectedly");
 
 	status = osSemaphoreAcquire(semaphore_id, osWaitForever);
-	zassert_true(status == osOK, "Semaphore wait failure");
+	ztest_true(status == osOK, "Semaphore wait failure");
 
-	zassert_true(osSemaphoreGetCount(semaphore_id) == 0, NULL);
+	ztest_true(osSemaphoreGetCount(semaphore_id) == 0, NULL);
 
 	/* wait for spawn thread to take action */
 	osDelay(TIMEOUT_TICKS);
 
 	/* Release invalid semaphore */
-	zassert_equal(osSemaphoreRelease(dummy_sem_id), osErrorParameter,
+	ztest_equal(osSemaphoreRelease(dummy_sem_id), osErrorParameter,
 		      "Semaphore release worked unexpectedly");
 
 	/* Release the semaphore to be used by the other thread */
 	status = osSemaphoreRelease(semaphore_id);
-	zassert_true(status == osOK, "Semaphore release failure");
+	ztest_true(status == osOK, "Semaphore release failure");
 
 	osDelay(TIMEOUT_TICKS);
 
 	/* Delete invalid semaphore */
-	zassert_equal(osSemaphoreDelete(dummy_sem_id), osErrorParameter,
+	ztest_equal(osSemaphoreDelete(dummy_sem_id), osErrorParameter,
 		      "Semaphore delete worked unexpectedly");
 
 	status = osSemaphoreDelete(semaphore_id);
-	zassert_true(status == osOK, "semaphore delete failure");
+	ztest_true(status == osOK, "semaphore delete failure");
 }

--- a/tests/portability/cmsis_rtos_v2/src/thread_apis.c
+++ b/tests/portability/cmsis_rtos_v2/src/thread_apis.c
@@ -43,24 +43,24 @@ static void thread1(void *argument)
 	struct thread1_args *args = (struct thread1_args *)argument;
 
 	thread_id = osThreadGetId();
-	zassert_true(thread_id != NULL, "Failed getting Thread ID");
+	ztest_true(thread_id != NULL, "Failed getting Thread ID");
 
 	name = osThreadGetName(thread_id);
-	zassert_true(strcmp(args->name, name) == 0,
+	ztest_true(strcmp(args->name, name) == 0,
 		     "Failed getting Thread name");
 
 	/* This thread starts off at a high priority (same as thread2) */
 	(*args->yield_check)++;
-	zassert_equal(*args->yield_check, 1, NULL);
+	ztest_equal(*args->yield_check, 1, NULL);
 
 	/* Yield to thread2 which is of same priority */
 	status = osThreadYield();
-	zassert_true(status == osOK, "Error doing thread yield");
+	ztest_true(status == osOK, "Error doing thread yield");
 
 	/* thread_yield_check should now be 2 as it was incremented
 	 * in thread2.
 	 */
-	zassert_equal(*args->yield_check, 2, NULL);
+	ztest_equal(*args->yield_check, 2, NULL);
 
 	osThreadExit();
 }
@@ -79,28 +79,28 @@ static void thread2(void *argument)
 
 	thread_array = k_calloc(max_num_threads, sizeof(osThreadId_t));
 	num_threads = osThreadEnumerate(thread_array, max_num_threads);
-	zassert_equal(num_threads, 2,
+	ztest_equal(num_threads, 2,
 		      "Incorrect number of cmsis rtos v2 threads");
 
 	for (i = 0U; i < num_threads; i++) {
 		u32_t size = osThreadGetStackSize(thread_array[i]);
 		u32_t space = osThreadGetStackSpace(thread_array[i]);
 
-		zassert_true(space < size,
+		ztest_true(space < size,
 			     "stack size remaining is not what is expected");
 	}
 
-	zassert_equal(osThreadGetState(thread_array[1]), osThreadReady,
+	ztest_equal(osThreadGetState(thread_array[1]), osThreadReady,
 		      "Thread not in ready state");
-	zassert_equal(osThreadGetState(thread_array[0]), osThreadRunning,
+	ztest_equal(osThreadGetState(thread_array[0]), osThreadRunning,
 		      "Thread not in running state");
 
-	zassert_equal(osThreadSuspend(thread_array[1]), osOK, "");
-	zassert_equal(osThreadGetState(thread_array[1]), osThreadBlocked,
+	ztest_equal(osThreadSuspend(thread_array[1]), osOK, "");
+	ztest_equal(osThreadGetState(thread_array[1]), osThreadBlocked,
 		      "Thread not in blocked state");
 
-	zassert_equal(osThreadResume(thread_array[1]), osOK, "");
-	zassert_equal(osThreadGetState(thread_array[1]), osThreadReady,
+	ztest_equal(osThreadResume(thread_array[1]), osOK, "");
+	ztest_equal(osThreadGetState(thread_array[1]), osThreadReady,
 		      "Thread not in ready state");
 
 	k_free(thread_array);
@@ -123,12 +123,12 @@ static void thread_apis_common(int *yield_check,
 	};
 
 	id1 = osThreadNew(thread1, &args, thread1_attr);
-	zassert_true(id1 != NULL, "Failed creating thread1");
+	ztest_true(id1 != NULL, "Failed creating thread1");
 
 	id2 = osThreadNew(thread2, yield_check, thread2_attr);
-	zassert_true(id2 != NULL, "Failed creating thread2");
+	ztest_true(id2 != NULL, "Failed creating thread2");
 
-	zassert_equal(osThreadGetCount(), 2,
+	ztest_equal(osThreadGetCount(), 2,
 		      "Incorrect number of cmsis rtos v2 threads");
 
 	do {
@@ -173,27 +173,27 @@ static void thread3(void *argument)
 	/* Lower the priority of the current thread */
 	osThreadSetPriority(id, osPriorityBelowNormal);
 	rv = osThreadGetPriority(id);
-	zassert_equal(rv, osPriorityBelowNormal,
+	ztest_equal(rv, osPriorityBelowNormal,
 		      "Expected priority to be changed to %d, not %d",
 		      (int)osPriorityBelowNormal, (int)rv);
 
 	/* Increase the priority of the current thread */
 	osThreadSetPriority(id, osPriorityAboveNormal);
 	rv = osThreadGetPriority(id);
-	zassert_equal(rv, osPriorityAboveNormal,
+	ztest_equal(rv, osPriorityAboveNormal,
 		      "Expected priority to be changed to %d, not %d",
 		      (int)osPriorityAboveNormal, (int)rv);
 
 	/* Restore the priority of the current thread */
 	osThreadSetPriority(id, prio);
 	rv = osThreadGetPriority(id);
-	zassert_equal(rv, prio,
+	ztest_equal(rv, prio,
 		      "Expected priority to be changed to %d, not %d",
 		      (int)prio, (int)rv);
 
 	/* Try to set unsupported priority and assert failure */
 	status = osThreadSetPriority(id, OsPriorityInvalid);
-	zassert_true(status == osErrorParameter,
+	ztest_true(status == osErrorParameter,
 		     "Something's wrong with osThreadSetPriority!");
 
 	/* Indication that thread3 is done with its processing */
@@ -211,7 +211,7 @@ static void thread_prior_common(int *state, osThreadAttr_t *attr)
 	osThreadId_t id3;
 
 	id3 = osThreadNew(thread3, state, attr);
-	zassert_true(id3 != NULL, "Failed creating thread3");
+	ztest_true(id3 != NULL, "Failed creating thread3");
 
 	/* Keep delaying 10 milliseconds to ensure thread3 is done with
 	 * its execution. It loops at the end and is terminated here.
@@ -221,16 +221,16 @@ static void thread_prior_common(int *state, osThreadAttr_t *attr)
 	} while (*state == 0);
 
 	status = osThreadTerminate(id3);
-	zassert_true(status == osOK, "Error terminating thread3");
+	ztest_true(status == osOK, "Error terminating thread3");
 
 	/* Try to set priority to inactive thread and assert failure */
 	status = osThreadSetPriority(id3, osPriorityNormal);
-	zassert_true(status == osErrorResource,
+	ztest_true(status == osErrorResource,
 		     "Something's wrong with osThreadSetPriority!");
 
 	/* Try to terminate inactive thread and assert failure */
 	status = osThreadTerminate(id3);
-	zassert_true(status == osErrorResource,
+	ztest_true(status == osErrorResource,
 		     "Something's wrong with osThreadTerminate!");
 
 	*state = 0;
@@ -263,7 +263,7 @@ static void thread4(void *argument)
 
 	printk(" + Thread A started.\n");
 	status = osThreadJoin(tB);
-	zassert_equal(status, osOK, "osThreadJoin thread B failed!");
+	ztest_equal(status, osOK, "osThreadJoin thread B failed!");
 	printk(" + Thread A joining...\n");
 }
 
@@ -281,28 +281,28 @@ void test_thread_join(void)
 
 	printk(" - Creating thread B...\n");
 	tB = osThreadNew(thread5, NULL, &attr);
-	zassert_not_null(tB, "Failed to create thread B with osThreadNew!");
+	ztest_not_null(tB, "Failed to create thread B with osThreadNew!");
 
 	printk(" - Creating thread A...\n");
 	tA = osThreadNew(thread4, tB, &attr);
-	zassert_not_null(tA, "Failed to create thread A with osThreadNew!");
+	ztest_not_null(tA, "Failed to create thread A with osThreadNew!");
 
 	printk(" - Waiting for thread B to join...\n");
 	status = osThreadJoin(tB);
-	zassert_equal(status, osOK, "osThreadJoin thread B failed!");
+	ztest_equal(status, osOK, "osThreadJoin thread B failed!");
 
 	if (status == osOK) {
 		printk(" - Thread B joined.\n");
 	}
 
 	milliseconds_spent = k_uptime_delta(&time_stamp);
-	zassert_true((milliseconds_spent >= DELAY_MS - DELTA_MS) &&
+	ztest_true((milliseconds_spent >= DELAY_MS - DELTA_MS) &&
 		     (milliseconds_spent <= DELAY_MS + DELTA_MS),
 		     "Join completed but was too fast or too slow.");
 
 	printk(" - Waiting for thread A to join...\n");
 	status = osThreadJoin(tA);
-	zassert_equal(status, osOK, "osThreadJoin thread A failed!");
+	ztest_equal(status, osOK, "osThreadJoin thread A failed!");
 
 	if (status == osOK) {
 		printk(" - Thread A joined.\n");
@@ -315,12 +315,12 @@ void test_thread_detached(void)
 	osStatus_t status;
 
 	thread = osThreadNew(thread5, NULL, NULL); /* osThreadDetached */
-	zassert_not_null(thread, "Failed to create thread with osThreadNew!");
+	ztest_not_null(thread, "Failed to create thread with osThreadNew!");
 
 	osDelay(k_ms_to_ticks_ceil32(DELAY_MS - DELTA_MS));
 
 	status = osThreadJoin(thread);
-	zassert_equal(status, osErrorResource,
+	ztest_equal(status, osErrorResource,
 		      "Incorrect status returned from osThreadJoin!");
 
 	osDelay(k_ms_to_ticks_ceil32(DELTA_MS));
@@ -332,7 +332,7 @@ void thread6(void *argument)
 	osStatus_t status;
 
 	status = osThreadJoin(thread);
-	zassert_equal(status, osErrorResource,
+	ztest_equal(status, osErrorResource,
 		      "Incorrect status returned from osThreadJoin!");
 }
 
@@ -345,15 +345,15 @@ void test_thread_joinable_detach(void)
 	attr.attr_bits = osThreadJoinable;
 
 	tA = osThreadNew(thread5, NULL, &attr);
-	zassert_not_null(tA, "Failed to create thread with osThreadNew!");
+	ztest_not_null(tA, "Failed to create thread with osThreadNew!");
 
 	tB = osThreadNew(thread6, tA, &attr);
-	zassert_not_null(tB, "Failed to create thread with osThreadNew!");
+	ztest_not_null(tB, "Failed to create thread with osThreadNew!");
 
 	osDelay(k_ms_to_ticks_ceil32(DELAY_MS - DELTA_MS));
 
 	status = osThreadDetach(tA);
-	zassert_equal(status, osOK, "osThreadDetach failed.");
+	ztest_equal(status, osOK, "osThreadDetach failed.");
 
 	osDelay(k_ms_to_ticks_ceil32(DELTA_MS));
 }
@@ -367,15 +367,15 @@ void test_thread_joinable_terminate(void)
 	attr.attr_bits = osThreadJoinable;
 
 	tA = osThreadNew(thread5, NULL, &attr);
-	zassert_not_null(tA, "Failed to create thread with osThreadNew!");
+	ztest_not_null(tA, "Failed to create thread with osThreadNew!");
 
 	tB = osThreadNew(thread6, tA, &attr);
-	zassert_not_null(tB, "Failed to create thread with osThreadNew!");
+	ztest_not_null(tB, "Failed to create thread with osThreadNew!");
 
 	osDelay(k_ms_to_ticks_ceil32(DELAY_MS - DELTA_MS));
 
 	status = osThreadTerminate(tA);
-	zassert_equal(status, osOK, "osThreadTerminate failed.");
+	ztest_equal(status, osOK, "osThreadTerminate failed.");
 
 	osDelay(k_ms_to_ticks_ceil32(DELTA_MS));
 }

--- a/tests/portability/cmsis_rtos_v2/src/thread_flags.c
+++ b/tests/portability/cmsis_rtos_v2/src/thread_flags.c
@@ -26,24 +26,24 @@ static void thread1(void *arg)
 	 * already triggered.
 	 */
 	flags = osThreadFlagsWait(FLAG1, osFlagsWaitAny | osFlagsNoClear, 0);
-	zassert_equal(flags & FLAG1, FLAG1, "");
+	ztest_equal(flags & FLAG1, FLAG1, "");
 
 	/* Since the flags are not cleared automatically in the previous step,
 	 * we should be able to get the same flags upon query below.
 	 */
 	flags = osThreadFlagsGet();
-	zassert_equal(flags & FLAG1, FLAG1, "");
+	ztest_equal(flags & FLAG1, FLAG1, "");
 
 	/* Clear the Flag explicitly */
 	flags = osThreadFlagsClear(FLAG1);
-	zassert_not_equal(flags, osFlagsErrorParameter,
+	ztest_not_equal(flags, osFlagsErrorParameter,
 			  "ThreadFlagsClear failed");
 
 	/* wait for FLAG1. It should timeout here as the flag
 	 * though triggered, gets cleared in the previous step.
 	 */
 	flags = osThreadFlagsWait(FLAG1, osFlagsWaitAny, TIMEOUT_TICKS);
-	zassert_equal(flags, osFlagsErrorTimeout, "ThreadFlagsWait failed");
+	ztest_equal(flags, osFlagsErrorTimeout, "ThreadFlagsWait failed");
 }
 
 static void thread2(void *arg)
@@ -51,21 +51,21 @@ static void thread2(void *arg)
 	u32_t flags;
 
 	flags = osThreadFlagsWait(FLAG, osFlagsWaitAll, TIMEOUT_TICKS);
-	zassert_equal(flags & FLAG, FLAG,
+	ztest_equal(flags & FLAG, FLAG,
 		      "osThreadFlagsWait failed unexpectedly");
 
 	/* validate by passing invalid parameters */
-	zassert_equal(osThreadFlagsSet(NULL, 0), osFlagsErrorParameter,
+	ztest_equal(osThreadFlagsSet(NULL, 0), osFlagsErrorParameter,
 		      "Invalid Thread Flags ID is unexpectedly working!");
-	zassert_equal(osThreadFlagsSet(osThreadGetId(), 0x80010000),
+	ztest_equal(osThreadFlagsSet(osThreadGetId(), 0x80010000),
 		      osFlagsErrorParameter,
 		      "Thread with MSB set is set unexpectedly");
 
-	zassert_equal(osThreadFlagsClear(0x80010000), osFlagsErrorParameter,
+	ztest_equal(osThreadFlagsClear(0x80010000), osFlagsErrorParameter,
 		      "Thread with MSB set is cleared unexpectedly");
 
 	/* cannot wait for Flag mask with MSB set */
-	zassert_equal(osThreadFlagsWait(0x80010000, osFlagsWaitAny, 0),
+	ztest_equal(osThreadFlagsWait(0x80010000, osFlagsWaitAny, 0),
 		      osFlagsErrorParameter,
 		      "ThreadFlagsWait passed unexpectedly");
 }
@@ -92,10 +92,10 @@ void test_thread_flags_no_wait_timeout(void)
 	u32_t flags;
 
 	id1 = osThreadNew(thread1, NULL, &thread1_attr);
-	zassert_true(id1 != NULL, "Failed creating thread1");
+	ztest_true(id1 != NULL, "Failed creating thread1");
 
 	flags = osThreadFlagsSet(id1, FLAG1);
-	zassert_equal(flags & FLAG1, FLAG1, "");
+	ztest_equal(flags & FLAG1, FLAG1, "");
 
 	/* Let id1 run to do the tests for Thread Flags */
 	osDelay(TIMEOUT_TICKS);
@@ -107,16 +107,16 @@ void test_thread_flags_signalled(void)
 	u32_t flags;
 
 	id = osThreadNew(thread2, osThreadGetId(), &thread2_attr);
-	zassert_true(id != NULL, "Failed creating thread2");
+	ztest_true(id != NULL, "Failed creating thread2");
 
 	flags = osThreadFlagsSet(id, FLAG1);
-	zassert_equal(flags & FLAG1, FLAG1, "");
+	ztest_equal(flags & FLAG1, FLAG1, "");
 
 	/* Let id run to do the tests for Thread Flags */
 	osDelay(TIMEOUT_TICKS / 2);
 
 	flags = osThreadFlagsSet(id, FLAG2);
-	zassert_equal(flags & FLAG2, FLAG2, "");
+	ztest_equal(flags & FLAG2, FLAG2, "");
 
 	/* z_thread has a higher priority over the other threads.
 	 * Hence, this thread needs to be put to sleep for thread2
@@ -131,10 +131,10 @@ static void offload_function(void *param)
 	int flags;
 
 	/* Make sure we're in IRQ context */
-	zassert_true(k_is_in_isr(), "Not in IRQ context!");
+	ztest_true(k_is_in_isr(), "Not in IRQ context!");
 
 	flags = osThreadFlagsSet((osThreadId_t)param, ISR_FLAG);
-	zassert_equal(flags & ISR_FLAG, ISR_FLAG,
+	ztest_equal(flags & ISR_FLAG, ISR_FLAG,
 		      "ThreadFlagsSet failed in ISR");
 }
 
@@ -146,7 +146,7 @@ void test_thread_flags_from_isr(void *thread_id)
 	irq_offload(offload_function, (void *)osThreadGetId());
 
 	flags = osThreadFlagsWait(ISR_FLAG, osFlagsWaitAll, TIMEOUT_TICKS);
-	zassert_equal((flags & ISR_FLAG),
+	ztest_equal((flags & ISR_FLAG),
 		      ISR_FLAG, "unexpected Thread flags value");
 }
 
@@ -164,7 +164,7 @@ void test_thread_flags_isr(void)
 
 	id = osThreadNew(test_thread_flags_from_isr, osThreadGetId(),
 			 &thread3_attr);
-	zassert_true(id != NULL, "Failed creating thread");
+	ztest_true(id != NULL, "Failed creating thread");
 
 	osDelay(TIMEOUT_TICKS);
 }

--- a/tests/portability/cmsis_rtos_v2/src/timer.c
+++ b/tests/portability/cmsis_rtos_v2/src/timer.c
@@ -52,47 +52,47 @@ void test_timer(void)
 	/* Create one-shot timer */
 	exec1 = 1U;
 	id1 = osTimerNew(Timer1_Callback, osTimerOnce, &exec1, &timer_attr);
-	zassert_true(id1 != NULL, "error creating one-shot timer");
+	ztest_true(id1 != NULL, "error creating one-shot timer");
 
 	name = osTimerGetName(id1);
-	zassert_true(strcmp(timer_attr.name, name) == 0,
+	ztest_true(strcmp(timer_attr.name, name) == 0,
 		     "Error getting Timer name");
 
 	/* Stop the timer before start */
 	status = osTimerStop(id1);
-	zassert_true(status == osErrorResource,
+	ztest_true(status == osErrorResource,
 		     "error while stopping non-active timer");
 
 	timerDelay = ONESHOT_TIME_TICKS;
 	status = osTimerStart(id1, timerDelay);
-	zassert_true(status == osOK, "error starting one-shot timer");
+	ztest_true(status == osOK, "error starting one-shot timer");
 
-	zassert_equal(osTimerIsRunning(id1), 1, "Error: Timer not running");
+	ztest_equal(osTimerIsRunning(id1), 1, "Error: Timer not running");
 
 	/* Timer should fire only once if setup in one shot
 	 * mode. Wait for 3 times the one-shot time to see
 	 * if it fires more than once.
 	 */
 	osDelay(timerDelay * 3U + 10);
-	zassert_true(num_oneshots_executed == 1U,
+	ztest_true(num_oneshots_executed == 1U,
 		     "error setting up one-shot timer");
 
 	status = osTimerStop(id1);
-	zassert_true(status == osOK, "error stopping one-shot timer");
+	ztest_true(status == osOK, "error stopping one-shot timer");
 
 	status = osTimerDelete(id1);
-	zassert_true(status == osOK, "error deleting one-shot timer");
+	ztest_true(status == osOK, "error deleting one-shot timer");
 
 	/* Create periodic timer */
 	exec2 = 2U;
 	id2 = osTimerNew(Timer2_Callback, osTimerPeriodic, &exec2, NULL);
-	zassert_true(id2 != NULL, "error creating periodic timer");
+	ztest_true(id2 != NULL, "error creating periodic timer");
 
-	zassert_equal(osTimerIsRunning(id2), 0, "Error: Timer is running");
+	ztest_equal(osTimerIsRunning(id2), 0, "Error: Timer is running");
 
 	timerDelay = PERIOD_TICKS;
 	status = osTimerStart(id2, timerDelay);
-	zassert_true(status == osOK, "error starting periodic timer");
+	ztest_true(status == osOK, "error starting periodic timer");
 
 	/* Timer should fire periodically if setup in periodic
 	 * mode. Wait for NUM_PERIODS periods to see if it is
@@ -103,10 +103,10 @@ void test_timer(void)
 	/* The first firing of the timer should be ignored.
 	 * Hence checking for NUM_PERIODS + 1.
 	 */
-	zassert_true(num_periods_executed == NUM_PERIODS + 1,
+	ztest_true(num_periods_executed == NUM_PERIODS + 1,
 		     "error setting up periodic timer");
 
 	/* Delete the timer before stop */
 	status = osTimerDelete(id2);
-	zassert_true(status == osOK, "error deleting periodic timer");
+	ztest_true(status == osOK, "error deleting periodic timer");
 }

--- a/tests/posix/common/src/clock.c
+++ b/tests/posix/common/src/clock.c
@@ -19,9 +19,9 @@ void test_posix_clock(void)
 	printk("POSIX clock APIs\n");
 
 	/* TESTPOINT: Pass invalid clock type */
-	zassert_equal(clock_gettime(CLOCK_INVALID, &ts), -1,
+	ztest_equal(clock_gettime(CLOCK_INVALID, &ts), -1,
 			NULL);
-	zassert_equal(errno, EINVAL, NULL);
+	ztest_equal(errno, EINVAL, NULL);
 
 	clock_gettime(CLOCK_MONOTONIC, &ts);
 	/* 2 Sec Delay */
@@ -38,7 +38,7 @@ void test_posix_clock(void)
 	}
 
 	/*TESTPOINT: Check if POSIX clock API test passes*/
-	zassert_equal(secs_elapsed, (2 * SLEEP_SECONDS),
+	ztest_equal(secs_elapsed, (2 * SLEEP_SECONDS),
 			"POSIX clock API test failed");
 
 	printk("POSIX clock APIs test done\n");
@@ -57,13 +57,13 @@ void test_posix_realtime(void)
 
 	printk("POSIX clock set APIs\n");
 	ret = clock_gettime(CLOCK_MONOTONIC, &mts);
-	zassert_equal(ret, 0, "Fail to get monotonic clock");
+	ztest_equal(ret, 0, "Fail to get monotonic clock");
 
 	ret = clock_gettime(CLOCK_REALTIME, &rts);
-	zassert_equal(ret, 0, "Fail to get realtime clock");
+	ztest_equal(ret, 0, "Fail to get realtime clock");
 
-	zassert_equal(rts.tv_sec, mts.tv_sec, "Seconds not equal");
-	zassert_equal(rts.tv_nsec, mts.tv_nsec, "Nanoseconds not equal");
+	ztest_equal(rts.tv_sec, mts.tv_sec, "Seconds not equal");
+	ztest_equal(rts.tv_nsec, mts.tv_nsec, "Nanoseconds not equal");
 
 	/* Set a particular time.  In this case, the output of:
 	 * `date +%s -d 2018-01-01T15:45:01Z`
@@ -73,15 +73,15 @@ void test_posix_realtime(void)
 	nts.tv_nsec = NSEC_PER_SEC / 2U;
 
 	/* TESTPOINT: Pass invalid clock type */
-	zassert_equal(clock_settime(CLOCK_INVALID, &nts), -1,
+	ztest_equal(clock_settime(CLOCK_INVALID, &nts), -1,
 			NULL);
-	zassert_equal(errno, EINVAL, NULL);
+	ztest_equal(errno, EINVAL, NULL);
 
 	ret = clock_settime(CLOCK_MONOTONIC, &nts);
-	zassert_not_equal(ret, 0, "Should not be able to set monotonic time");
+	ztest_not_equal(ret, 0, "Should not be able to set monotonic time");
 
 	ret = clock_settime(CLOCK_REALTIME, &nts);
-	zassert_equal(ret, 0, "Fail to set realtime clock");
+	ztest_equal(ret, 0, "Fail to set realtime clock");
 
 	/*
 	 * Loop 20 times, sleeping a little bit for each, making sure
@@ -93,7 +93,7 @@ void test_posix_realtime(void)
 	for (int i = 1; i <= 20; i++) {
 		usleep(USEC_PER_MSEC * 90U);
 		ret = clock_gettime(CLOCK_REALTIME, &rts);
-		zassert_equal(ret, 0, "Fail to read realitime clock");
+		ztest_equal(ret, 0, "Fail to read realitime clock");
 
 		s64_t delta =
 			((s64_t)rts.tv_sec * NSEC_PER_SEC -
@@ -103,7 +103,7 @@ void test_posix_realtime(void)
 		/* Make the delta milliseconds. */
 		delta /= (NSEC_PER_SEC / 1000U);
 
-		zassert_true(delta > last_delta, "Clock moved backward");
+		ztest_true(delta > last_delta, "Clock moved backward");
 		s64_t error = delta - last_delta;
 
 		/* printk("Delta %d: %lld\n", i, delta); */
@@ -111,26 +111,26 @@ void test_posix_realtime(void)
 		/* Allow for a little drift upward, but not
 		 * downward
 		 */
-		zassert_true(error >= 90, "Clock inaccurate %d", error);
-		zassert_true(error <= 110, "Clock inaccurate %d", error);
+		ztest_true(error >= 90, "Clock inaccurate %d", error);
+		ztest_true(error <= 110, "Clock inaccurate %d", error);
 
 		last_delta = delta;
 	}
 
 	/* Validate gettimeofday API */
 	ret = gettimeofday(&tv, NULL);
-	zassert_equal(ret, 0, NULL);
+	ztest_equal(ret, 0, NULL);
 
 	ret = clock_gettime(CLOCK_REALTIME, &rts);
-	zassert_equal(ret, 0, NULL);
+	ztest_equal(ret, 0, NULL);
 
 	/* TESTPOINT: Check if time obtained from
 	 * gettimeofday is same or more than obtained
 	 * from clock_gettime
 	 */
-	zassert_true(rts.tv_sec >= tv.tv_sec, "gettimeofday didn't"
+	ztest_true(rts.tv_sec >= tv.tv_sec, "gettimeofday didn't"
 			" provide correct result");
-	zassert_true(rts.tv_nsec >= tv.tv_usec * NSEC_PER_USEC,
+	ztest_true(rts.tv_nsec >= tv.tv_usec * NSEC_PER_USEC,
 			"gettimeofday didn't provide correct result");
 
 	printk("POSIX clock set APIs test done\n");

--- a/tests/posix/common/src/mqueue.c
+++ b/tests/posix/common/src/mqueue.c
@@ -32,10 +32,10 @@ void *sender_thread(void *p1)
 	mqd = mq_open(queue, O_WRONLY);
 	clock_gettime(CLOCK_MONOTONIC, &curtime);
 	curtime.tv_sec += 1;
-	zassert_false(mq_timedsend(mqd, send_data, MESSAGE_SIZE, 0, &curtime),
+	ztest_false(mq_timedsend(mqd, send_data, MESSAGE_SIZE, 0, &curtime),
 		      "Not able to send message in timer");
 	usleep(USEC_PER_MSEC);
-	zassert_false(mq_close(mqd),
+	ztest_false(mq_close(mqd),
 		      "unable to close message queue descriptor.");
 	pthread_exit(p1);
 	return NULL;
@@ -52,9 +52,9 @@ void *receiver_thread(void *p1)
 	clock_gettime(CLOCK_MONOTONIC, &curtime);
 	curtime.tv_sec += 1;
 	mq_timedreceive(mqd, rec_data, MESSAGE_SIZE, 0, &curtime);
-	zassert_false(strcmp(rec_data, send_data), "Error in data reception");
+	ztest_false(strcmp(rec_data, send_data), "Error in data reception");
 	usleep(USEC_PER_MSEC);
-	zassert_false(mq_close(mqd),
+	ztest_false(mq_close(mqd),
 		      "unable to close message queue descriptor.");
 	pthread_exit(p1);
 	return NULL;
@@ -77,8 +77,8 @@ void test_posix_mqueue(void)
 	for (i = 0; i < N_THR; i++) {
 		/* Creating threads */
 		if (pthread_attr_init(&attr[i]) != 0) {
-			zassert_equal(pthread_attr_destroy(&attr[i]), 0, NULL);
-			zassert_false(pthread_attr_init(&attr[i]),
+			ztest_equal(pthread_attr_destroy(&attr[i]), 0, NULL);
+			ztest_false(pthread_attr_init(&attr[i]),
 				      "pthread attr init failed");
 		}
 		pthread_attr_setstack(&attr[i], &stacks[i][0], STACKSZ);
@@ -93,8 +93,8 @@ void test_posix_mqueue(void)
 					     INT_TO_POINTER(i));
 		}
 
-		zassert_false(ret, "Not enough space to create new thread");
-		zassert_equal(pthread_attr_destroy(&attr[i]), 0, NULL);
+		ztest_false(ret, "Not enough space to create new thread");
+		ztest_equal(pthread_attr_destroy(&attr[i]), 0, NULL);
 	}
 
 	usleep(USEC_PER_MSEC * 10U);
@@ -103,7 +103,7 @@ void test_posix_mqueue(void)
 		pthread_join(newthread[i], &retval);
 	}
 
-	zassert_false(mq_close(mqd),
+	ztest_false(mq_close(mqd),
 		      "unable to close message queue descriptor.");
-	zassert_false(mq_unlink(queue), "Not able to unlink Queue");
+	ztest_false(mq_unlink(queue), "Not able to unlink Queue");
 }

--- a/tests/posix/common/src/mutex.c
+++ b/tests/posix/common/src/mutex.c
@@ -31,22 +31,22 @@ void *normal_mutex_entry(void *p1)
 		k_sleep(SLEEP_MS);
 	}
 
-	zassert_false(rc, "try lock failed");
+	ztest_false(rc, "try lock failed");
 	TC_PRINT("mutex lock is taken\n");
-	zassert_false(pthread_mutex_unlock(&mutex1),
+	ztest_false(pthread_mutex_unlock(&mutex1),
 		      "mutex unlock is falied");
 	return NULL;
 }
 
 void *recursive_mutex_entry(void *p1)
 {
-	zassert_false(pthread_mutex_lock(&mutex2), "mutex is not taken");
-	zassert_false(pthread_mutex_lock(&mutex2),
+	ztest_false(pthread_mutex_lock(&mutex2), "mutex is not taken");
+	ztest_false(pthread_mutex_lock(&mutex2),
 		      "mutex is not taken 2nd time");
 	TC_PRINT("recrusive mutex lock is taken\n");
-	zassert_false(pthread_mutex_unlock(&mutex2),
+	ztest_false(pthread_mutex_unlock(&mutex2),
 		      "mutex is not unlocked");
-	zassert_false(pthread_mutex_unlock(&mutex2),
+	ztest_false(pthread_mutex_unlock(&mutex2),
 		      "mutex is not unlocked");
 	return NULL;
 }
@@ -70,9 +70,9 @@ void test_posix_normal_mutex(void)
 	schedparam.sched_priority = 2;
 	ret = pthread_attr_init(&attr);
 	if (ret != 0) {
-		zassert_false(pthread_attr_destroy(&attr),
+		ztest_false(pthread_attr_destroy(&attr),
 			      "Unable to destroy pthread object attrib");
-		zassert_false(pthread_attr_init(&attr),
+		ztest_false(pthread_attr_init(&attr),
 			      "Unable to create pthread object attrib");
 	}
 
@@ -81,21 +81,21 @@ void test_posix_normal_mutex(void)
 	pthread_attr_setschedparam(&attr, &schedparam);
 
 	temp = pthread_mutexattr_settype(&mut_attr, PTHREAD_MUTEX_NORMAL);
-	zassert_false(temp, "setting mutex type is failed");
+	ztest_false(temp, "setting mutex type is failed");
 	temp = pthread_mutex_init(&mutex1, &mut_attr);
-	zassert_false(temp, "mutex initialization is failed");
+	ztest_false(temp, "mutex initialization is failed");
 
 	temp = pthread_mutexattr_gettype(&mut_attr, &type);
-	zassert_false(temp, "reading mutex type is failed");
+	ztest_false(temp, "reading mutex type is failed");
 	temp = pthread_mutexattr_getprotocol(&mut_attr, &protocol);
-	zassert_false(temp, "reading mutex protocol is failed");
+	ztest_false(temp, "reading mutex protocol is failed");
 
 	pthread_mutex_lock(&mutex1);
 
-	zassert_equal(type, PTHREAD_MUTEX_NORMAL,
+	ztest_equal(type, PTHREAD_MUTEX_NORMAL,
 		      "mutex type is not normal");
 
-	zassert_equal(protocol, PTHREAD_PRIO_NONE,
+	ztest_equal(protocol, PTHREAD_PRIO_NONE,
 		      "mutex protocol is not prio_none");
 	ret = pthread_create(&thread_1, &attr, &normal_mutex_entry, NULL);
 
@@ -107,7 +107,7 @@ void test_posix_normal_mutex(void)
 
 	pthread_join(thread_1, NULL);
 	temp = pthread_mutex_destroy(&mutex1);
-	zassert_false(temp, "Destroying mutex is failed");
+	ztest_false(temp, "Destroying mutex is failed");
 }
 
 /**
@@ -129,9 +129,9 @@ void test_posix_recursive_mutex(void)
 	schedparam2.sched_priority = 2;
 	ret = pthread_attr_init(&attr2);
 	if (ret != 0) {
-		zassert_false(pthread_attr_destroy(&attr2),
+		ztest_false(pthread_attr_destroy(&attr2),
 			      "Unable to destroy pthread object attrib");
-		zassert_false(pthread_attr_init(&attr2),
+		ztest_false(pthread_attr_init(&attr2),
 			      "Unable to create pthread object attrib");
 	}
 
@@ -140,25 +140,25 @@ void test_posix_recursive_mutex(void)
 	pthread_attr_setschedparam(&attr2, &schedparam2);
 
 	temp = pthread_mutexattr_settype(&mut_attr2, PTHREAD_MUTEX_RECURSIVE);
-	zassert_false(temp, "setting mutex2 type is failed");
+	ztest_false(temp, "setting mutex2 type is failed");
 	temp = pthread_mutex_init(&mutex2, &mut_attr2);
-	zassert_false(temp, "mutex2 initialization is failed");
+	ztest_false(temp, "mutex2 initialization is failed");
 
 	temp = pthread_mutexattr_gettype(&mut_attr2, &type);
-	zassert_false(temp, "reading mutex2 type is failed");
+	ztest_false(temp, "reading mutex2 type is failed");
 	temp = pthread_mutexattr_getprotocol(&mut_attr2, &protocol);
-	zassert_false(temp, "reading mutex2 protocol is failed");
+	ztest_false(temp, "reading mutex2 protocol is failed");
 
-	zassert_equal(type, PTHREAD_MUTEX_RECURSIVE,
+	ztest_equal(type, PTHREAD_MUTEX_RECURSIVE,
 		      "mutex2 type is not recursive");
 
-	zassert_equal(protocol, PTHREAD_PRIO_NONE,
+	ztest_equal(protocol, PTHREAD_PRIO_NONE,
 		      "mutex2 protocol is not prio_none");
 	ret = pthread_create(&thread_2, &attr2, &recursive_mutex_entry, NULL);
 
-	zassert_false(ret, "Thread2 creation failed");
+	ztest_false(ret, "Thread2 creation failed");
 
 	pthread_join(thread_2, NULL);
 	temp = pthread_mutex_destroy(&mutex2);
-	zassert_false(temp, "Destroying mutex2 is failed");
+	ztest_false(temp, "Destroying mutex2 is failed");
 }

--- a/tests/posix/common/src/posix_rwlock.c
+++ b/tests/posix/common/src/posix_rwlock.c
@@ -29,26 +29,26 @@ static void *thread_top(void *p1)
 	ret = pthread_rwlock_tryrdlock(&rwlock);
 	if (ret) {
 		printk("Not able to get RD lock on trying, try again\n");
-		zassert_false(pthread_rwlock_rdlock(&rwlock),
+		ztest_false(pthread_rwlock_rdlock(&rwlock),
 			      "Failed to acquire write lock");
 	}
 
 	printk("Thread %d got RD lock\n", id);
 	usleep(USEC_PER_MSEC);
 	printk("Thread %d releasing RD lock\n", id);
-	zassert_false(pthread_rwlock_unlock(&rwlock), "Failed to unlock");
+	ztest_false(pthread_rwlock_unlock(&rwlock), "Failed to unlock");
 
 	printk("Thread %d acquiring WR lock\n", id);
 	ret = pthread_rwlock_trywrlock(&rwlock);
 	if (ret != 0U) {
-		zassert_false(pthread_rwlock_wrlock(&rwlock),
+		ztest_false(pthread_rwlock_wrlock(&rwlock),
 			      "Failed to acquire WR lock");
 	}
 
 	printk("Thread %d acquired WR lock\n", id);
 	usleep(USEC_PER_MSEC);
 	printk("Thread %d releasing WR lock\n", id);
-	zassert_false(pthread_rwlock_unlock(&rwlock), "Failed to unlock");
+	ztest_false(pthread_rwlock_unlock(&rwlock), "Failed to unlock");
 	pthread_exit(NULL);
 	return NULL;
 }
@@ -65,24 +65,24 @@ void test_posix_rw_lock(void)
 	time.tv_sec = 1;
 	time.tv_nsec = 0;
 
-	zassert_equal(pthread_rwlock_destroy(&rwlock), EINVAL, NULL);
-	zassert_equal(pthread_rwlock_rdlock(&rwlock), EINVAL, NULL);
-	zassert_equal(pthread_rwlock_wrlock(&rwlock), EINVAL, NULL);
-	zassert_equal(pthread_rwlock_trywrlock(&rwlock), EINVAL, NULL);
-	zassert_equal(pthread_rwlock_tryrdlock(&rwlock), EINVAL, NULL);
-	zassert_equal(pthread_rwlock_timedwrlock(&rwlock, &time), EINVAL, NULL);
-	zassert_equal(pthread_rwlock_timedrdlock(&rwlock, &time), EINVAL, NULL);
-	zassert_equal(pthread_rwlock_unlock(&rwlock), EINVAL, NULL);
+	ztest_equal(pthread_rwlock_destroy(&rwlock), EINVAL, NULL);
+	ztest_equal(pthread_rwlock_rdlock(&rwlock), EINVAL, NULL);
+	ztest_equal(pthread_rwlock_wrlock(&rwlock), EINVAL, NULL);
+	ztest_equal(pthread_rwlock_trywrlock(&rwlock), EINVAL, NULL);
+	ztest_equal(pthread_rwlock_tryrdlock(&rwlock), EINVAL, NULL);
+	ztest_equal(pthread_rwlock_timedwrlock(&rwlock, &time), EINVAL, NULL);
+	ztest_equal(pthread_rwlock_timedrdlock(&rwlock, &time), EINVAL, NULL);
+	ztest_equal(pthread_rwlock_unlock(&rwlock), EINVAL, NULL);
 
-	zassert_false(pthread_rwlock_init(&rwlock, NULL),
+	ztest_false(pthread_rwlock_init(&rwlock, NULL),
 		      "Failed to create rwlock");
 	printk("\nmain acquire WR lock and 3 threads acquire RD lock\n");
-	zassert_false(pthread_rwlock_timedwrlock(&rwlock, &time),
+	ztest_false(pthread_rwlock_timedwrlock(&rwlock, &time),
 		      "Failed to acquire write lock");
 
 	/* Creating N premptive threads in increasing order of priority */
 	for (i = 0; i < N_THR; i++) {
-		zassert_equal(pthread_attr_init(&attr[i]), 0,
+		ztest_equal(pthread_attr_init(&attr[i]), 0,
 			      "Unable to create pthread object attrib");
 
 		/* Setting scheduling priority */
@@ -94,14 +94,14 @@ void test_posix_rw_lock(void)
 
 		ret = pthread_create(&newthread[i], &attr[i], thread_top,
 				     INT_TO_POINTER(i));
-		zassert_false(ret, "Low memory to thread new thread");
+		ztest_false(ret, "Low memory to thread new thread");
 
 	}
 
 	/* Delay to give change to child threads to run */
 	usleep(USEC_PER_MSEC);
 	printk("Parent thread releasing WR lock\n");
-	zassert_false(pthread_rwlock_unlock(&rwlock), "Failed to unlock");
+	ztest_false(pthread_rwlock_unlock(&rwlock), "Failed to unlock");
 
 	/* Let child threads acquire RD Lock */
 	usleep(USEC_PER_MSEC);
@@ -112,14 +112,14 @@ void test_posix_rw_lock(void)
 	ret = pthread_rwlock_timedwrlock(&rwlock, &time);
 
 	if (ret) {
-		zassert_false(pthread_rwlock_wrlock(&rwlock),
+		ztest_false(pthread_rwlock_wrlock(&rwlock),
 			      "Failed to acquire write lock");
 	}
 
 	printk("Parent thread acquired WR lock again\n");
 	usleep(USEC_PER_MSEC);
 	printk("Parent thread releasing WR lock again\n");
-	zassert_false(pthread_rwlock_unlock(&rwlock), "Failed to unlock");
+	ztest_false(pthread_rwlock_unlock(&rwlock), "Failed to unlock");
 
 	printk("\n3 threads acquire WR lock\n");
 	printk("Main thread acquiring RD lock\n");
@@ -127,19 +127,19 @@ void test_posix_rw_lock(void)
 	ret = pthread_rwlock_timedrdlock(&rwlock, &time);
 
 	if (ret != 0) {
-		zassert_false(pthread_rwlock_rdlock(&rwlock), "Failed to lock");
+		ztest_false(pthread_rwlock_rdlock(&rwlock), "Failed to lock");
 	}
 
 	printk("Main thread acquired RD lock\n");
 	usleep(USEC_PER_MSEC);
 	printk("Main thread releasing RD lock\n");
-	zassert_false(pthread_rwlock_unlock(&rwlock), "Failed to unlock");
+	ztest_false(pthread_rwlock_unlock(&rwlock), "Failed to unlock");
 
 	for (i = 0; i < N_THR; i++) {
-		zassert_false(pthread_join(newthread[i], &status),
+		ztest_false(pthread_join(newthread[i], &status),
 			      "Failed to join");
 	}
 
-	zassert_false(pthread_rwlock_destroy(&rwlock),
+	ztest_false(pthread_rwlock_destroy(&rwlock),
 		      "Failed to destroy rwlock");
 }

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -198,10 +198,10 @@ void *thread_top_term(void *p1)
 	self = pthread_self();
 
 	/* Change priority of thread */
-	zassert_false(pthread_setschedparam(self, SCHED_RR, &param),
+	ztest_false(pthread_setschedparam(self, SCHED_RR, &param),
 		      "Unable to set thread priority!");
 
-	zassert_false(pthread_getschedparam(self, &policy, &getschedparam),
+	ztest_false(pthread_getschedparam(self, &policy, &getschedparam),
 			"Unable to get thread priority!");
 
 	printk("Thread %d starting with a priority of %d\n",
@@ -210,13 +210,13 @@ void *thread_top_term(void *p1)
 
 	if (id % 2) {
 		ret = pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &oldstate);
-		zassert_false(ret, "Unable to set cancel state!");
+		ztest_false(ret, "Unable to set cancel state!");
 	}
 
 	if (id >= 2) {
 		ret = pthread_detach(self);
 		if (id == 2) {
-			zassert_equal(ret, EINVAL, "re-detached thread!");
+			ztest_equal(ret, EINVAL, "re-detached thread!");
 		}
 	}
 
@@ -252,83 +252,83 @@ void test_posix_pthread_execution(void)
 			schedparam.sched_priority > max_prio);
 
 	/* TESTPOINT: Check if scheduling priority is valid */
-	zassert_false(ret,
+	ztest_false(ret,
 			"Scheduling priority outside valid priority range");
 
 	/* TESTPOINTS: Try setting attributes before init */
 	ret = pthread_attr_setschedparam(&attr[0], &schedparam);
-	zassert_equal(ret, EINVAL, "uninitialized attr set!");
+	ztest_equal(ret, EINVAL, "uninitialized attr set!");
 
 	ret = pthread_attr_setdetachstate(&attr[0], PTHREAD_CREATE_JOINABLE);
-	zassert_equal(ret, EINVAL, "uninitialized attr set!");
+	ztest_equal(ret, EINVAL, "uninitialized attr set!");
 
 	ret = pthread_attr_setschedpolicy(&attr[0], schedpolicy);
-	zassert_equal(ret, EINVAL, "uninitialized attr set!");
+	ztest_equal(ret, EINVAL, "uninitialized attr set!");
 
 	/* TESTPOINT: Try setting attribute with empty stack */
 	ret = pthread_attr_setstack(&attr[0], 0, STACKS);
-	zassert_equal(ret, EACCES, "empty stack set!");
+	ztest_equal(ret, EACCES, "empty stack set!");
 
 	/* TESTPOINTS: Try getting attributes before init */
 	ret = pthread_attr_getschedparam(&attr[0], &getschedparam);
-	zassert_equal(ret, EINVAL, "uninitialized attr retrieved!");
+	ztest_equal(ret, EINVAL, "uninitialized attr retrieved!");
 
 	ret = pthread_attr_getdetachstate(&attr[0], &dstate);
-	zassert_equal(ret, EINVAL, "uninitialized attr retrieved!");
+	ztest_equal(ret, EINVAL, "uninitialized attr retrieved!");
 
 	ret = pthread_attr_getschedpolicy(&attr[0], &policy);
-	zassert_equal(ret, EINVAL, "uninitialized attr retrieved!");
+	ztest_equal(ret, EINVAL, "uninitialized attr retrieved!");
 
 	ret = pthread_attr_getstack(&attr[0], &stackaddr, &stacksize);
-	zassert_equal(ret, EINVAL, "uninitialized attr retrieved!");
+	ztest_equal(ret, EINVAL, "uninitialized attr retrieved!");
 
 	ret = pthread_attr_getstacksize(&attr[0], &stacksize);
-	zassert_equal(ret, EINVAL, "uninitialized attr retrieved!");
+	ztest_equal(ret, EINVAL, "uninitialized attr retrieved!");
 
 	/* TESTPOINT: Try destroying attr before init */
 	ret = pthread_attr_destroy(&attr[0]);
-	zassert_equal(ret, EINVAL, "uninitialized attr destroyed!");
+	ztest_equal(ret, EINVAL, "uninitialized attr destroyed!");
 
 	/* TESTPOINT: Try getting thread name before init */
 	ret = pthread_getname_np(newthread[0], getName, sizeof(getName));
-	zassert_equal(ret, ESRCH, "uninitialized getname!");
+	ztest_equal(ret, ESRCH, "uninitialized getname!");
 
 	/* TESTPOINT: Try setting thread name before init */
 	ret = pthread_setname_np(newthread[0], name);
-	zassert_equal(ret, ESRCH, "uninitialized setname!");
+	ztest_equal(ret, ESRCH, "uninitialized setname!");
 
 	/* TESTPOINT: Try creating thread before attr init */
 	ret = pthread_create(&newthread[0], &attr[0],
 				thread_top_exec, NULL);
-	zassert_equal(ret, EINVAL, "thread created before attr init!");
+	ztest_equal(ret, EINVAL, "thread created before attr init!");
 
 	for (i = 0; i < N_THR_E; i++) {
 		ret = pthread_attr_init(&attr[i]);
 		if (ret != 0) {
-			zassert_false(pthread_attr_destroy(&attr[i]),
+			ztest_false(pthread_attr_destroy(&attr[i]),
 				      "Unable to destroy pthread object attrib");
-			zassert_false(pthread_attr_init(&attr[i]),
+			ztest_false(pthread_attr_init(&attr[i]),
 				      "Unable to create pthread object attrib");
 		}
 
 		/* TESTPOINTS: Retrieve set stack attributes and compare */
 		pthread_attr_setstack(&attr[i], &stack_e[i][0], STACKS);
 		pthread_attr_getstack(&attr[i], &stackaddr, &stacksize);
-		zassert_equal_ptr(attr[i].stack, stackaddr,
+		ztest_equal_ptr(attr[i].stack, stackaddr,
 				"stack attribute addresses do not match!");
-		zassert_equal(STACKS, stacksize, "stack sizes do not match!");
+		ztest_equal(STACKS, stacksize, "stack sizes do not match!");
 
 		pthread_attr_getstacksize(&attr[i], &stacksize);
-		zassert_equal(STACKS, stacksize, "stack sizes do not match!");
+		ztest_equal(STACKS, stacksize, "stack sizes do not match!");
 
 		pthread_attr_setschedpolicy(&attr[i], schedpolicy);
 		pthread_attr_getschedpolicy(&attr[i], &policy);
-		zassert_equal(schedpolicy, policy,
+		ztest_equal(schedpolicy, policy,
 				"scheduling policies do not match!");
 
 		pthread_attr_setschedparam(&attr[i], &schedparam);
 		pthread_attr_getschedparam(&attr[i], &getschedparam);
-		zassert_equal(schedparam.sched_priority,
+		ztest_equal(schedparam.sched_priority,
 			      getschedparam.sched_priority,
 			      "scheduling priorities do not match!");
 
@@ -336,35 +336,35 @@ void test_posix_pthread_execution(void)
 				INT_TO_POINTER(i));
 
 		/* TESTPOINT: Check if thread is created successfully */
-		zassert_false(ret, "Number of threads exceed max limit");
+		ztest_false(ret, "Number of threads exceed max limit");
 	}
 
 	/* TESTPOINT: Try getting thread name with no buffer */
 	ret = pthread_getname_np(newthread[0], NULL, sizeof(getName));
-	zassert_equal(ret, EINVAL, "uninitialized getname!");
+	ztest_equal(ret, EINVAL, "uninitialized getname!");
 
 	/* TESTPOINT: Try setting thread name with no buffer */
 	ret = pthread_setname_np(newthread[0], NULL);
-	zassert_equal(ret, EINVAL, "uninitialized setname!");
+	ztest_equal(ret, EINVAL, "uninitialized setname!");
 
 	/* TESTPOINT: Try setting thread name */
 	ret = pthread_setname_np(newthread[0], name);
-	zassert_false(ret, "Set name failed!");
+	ztest_false(ret, "Set name failed!");
 
 	/* TESTPOINT: Try getting thread name */
 	ret = pthread_getname_np(newthread[0], getName, sizeof(getName));
-	zassert_false(ret, "Get name failed!");
+	ztest_false(ret, "Get name failed!");
 
 	/* TESTPOINT: Thread names match */
 	ret = strncmp(name, getName, min(strlen(name), strlen(getName)));
-	zassert_false(ret, "Thread names don't match!");
+	ztest_false(ret, "Thread names don't match!");
 
 	while (!bounce_test_done()) {
 		sem_wait(&main_sem);
 	}
 
 	/* TESTPOINT: Check if bounce test passes */
-	zassert_false(bounce_failed, "Bounce test failed");
+	ztest_false(bounce_failed, "Bounce test failed");
 
 	printk("Bounce test OK\n");
 
@@ -378,7 +378,7 @@ void test_posix_pthread_execution(void)
 	}
 
 	/* TESTPOINT: Check if barrier test passes */
-	zassert_false(barrier_failed, "Barrier test failed");
+	ztest_false(barrier_failed, "Barrier test failed");
 
 	for (i = 0; i < N_THR_E; i++) {
 		pthread_join(newthread[i], &retval);
@@ -391,7 +391,7 @@ void test_posix_pthread_execution(void)
 	}
 
 	/* TESTPOINT: Check only one PTHREAD_BARRIER_SERIAL_THREAD returned. */
-	zassert_true(serial_threads == 1, "Bungled barrier return value(s)");
+	ztest_true(serial_threads == 1, "Bungled barrier return value(s)");
 
 	printk("Barrier test OK\n");
 }
@@ -409,9 +409,9 @@ void test_posix_pthread_termination(void)
 	for (i = 0; i < N_THR_T; i++) {
 		ret = pthread_attr_init(&attr[i]);
 		if (ret != 0) {
-			zassert_false(pthread_attr_destroy(&attr[i]),
+			ztest_false(pthread_attr_destroy(&attr[i]),
 				      "Unable to destroy pthread object attrib");
-			zassert_false(pthread_attr_init(&attr[i]),
+			ztest_false(pthread_attr_init(&attr[i]),
 				      "Unable to create pthread object attrib");
 		}
 
@@ -426,21 +426,21 @@ void test_posix_pthread_termination(void)
 		ret = pthread_create(&newthread[i], &attr[i], thread_top_term,
 				     INT_TO_POINTER(i));
 
-		zassert_false(ret, "Not enough space to create new thread");
+		ztest_false(ret, "Not enough space to create new thread");
 	}
 
 	/* TESTPOINT: Try setting invalid cancel state to current thread */
 	ret = pthread_setcancelstate(PTHREAD_CANCEL_INVALID, &oldstate);
-	zassert_equal(ret, EINVAL, "invalid cancel state set!");
+	ztest_equal(ret, EINVAL, "invalid cancel state set!");
 
 	/* TESTPOINT: Try setting invalid policy */
 	ret = pthread_setschedparam(newthread[0], SCHED_INVALID, &schedparam);
-	zassert_equal(ret, EINVAL, "invalid policy set!");
+	ztest_equal(ret, EINVAL, "invalid policy set!");
 
 	/* TESTPOINT: Try setting invalid priority */
 	schedparam.sched_priority = PRIO_INVALID;
 	ret = pthread_setschedparam(newthread[0], SCHED_RR, &schedparam);
-	zassert_equal(ret, EINVAL, "invalid priority set!");
+	ztest_equal(ret, EINVAL, "invalid priority set!");
 
 	for (i = 0; i < N_THR_T; i++) {
 		pthread_join(newthread[i], &retval);
@@ -448,13 +448,13 @@ void test_posix_pthread_termination(void)
 
 	/* TESTPOINT: Test for deadlock */
 	ret = pthread_join(pthread_self(), &retval);
-	zassert_equal(ret, EDEADLK, "thread joined with self inexplicably!");
+	ztest_equal(ret, EDEADLK, "thread joined with self inexplicably!");
 
 	/* TESTPOINT: Try canceling a terminated thread */
 	ret = pthread_cancel(newthread[N_THR_T/2]);
-	zassert_equal(ret, ESRCH, "cancelled a terminated thread!");
+	ztest_equal(ret, ESRCH, "cancelled a terminated thread!");
 
 	/* TESTPOINT: Try getting scheduling info from terminated thread */
 	ret = pthread_getschedparam(newthread[N_THR_T/2], &policy, &schedparam);
-	zassert_equal(ret, ESRCH, "got attr from terminated thread!");
+	ztest_equal(ret, ESRCH, "got attr from terminated thread!");
 }

--- a/tests/posix/common/src/pthread_key.c
+++ b/tests/posix/common/src/pthread_key.c
@@ -29,13 +29,13 @@ void *thread_top(void *p1)
 
 	value = k_malloc(sizeof(buffer));
 
-	zassert_true((int) POINTER_TO_INT(value),
+	ztest_true((int) POINTER_TO_INT(value),
 		     "thread could not allocate storage");
 
 	ret = pthread_setspecific(key, value);
 
 	/* TESTPOINT: Check if thread's value is associated with key */
-	zassert_false(ret, "pthread_setspecific failed");
+	ztest_false(ret, "pthread_setspecific failed");
 
 	getval = 0;
 
@@ -44,7 +44,7 @@ void *thread_top(void *p1)
 	/* TESTPOINT: Check if pthread_getspecific returns the same value
 	 * set by pthread_setspecific
 	 */
-	zassert_equal(value, getval,
+	ztest_equal(value, getval,
 			"set and retrieved values are different");
 
 	printk("set value = %d and retrieved value = %d\n",
@@ -63,14 +63,14 @@ void *thread_func(void *p1)
 
 	value = k_malloc(sizeof(buffer));
 
-	zassert_true((int) POINTER_TO_INT(value),
+	ztest_true((int) POINTER_TO_INT(value),
 		     "thread could not allocate storage");
 
 	for (i = 0; i < N_KEY; i++) {
 		ret = pthread_setspecific(keys[i], value);
 
 		/* TESTPOINT: Check if thread's value is associated with keys */
-		zassert_false(ret, "pthread_setspecific failed");
+		ztest_false(ret, "pthread_setspecific failed");
 	}
 
 	for (i = 0; i < N_KEY; i++) {
@@ -80,7 +80,7 @@ void *thread_func(void *p1)
 		/* TESTPOINT: Check if pthread_getspecific returns the same
 		 * value set by pthread_setspecific for each of the keys
 		 */
-		zassert_equal(value, getval,
+		ztest_equal(value, getval,
 				"set and retrieved values are different");
 
 		printk("key %d: set value = %d and retrieved value = %d\n",
@@ -95,7 +95,7 @@ static void make_key(void)
 	int ret = 0;
 
 	ret = pthread_key_create(&key, NULL);
-	zassert_false(ret, "insufficient memory to create key");
+	ztest_false(ret, "insufficient memory to create key");
 }
 
 static void make_keys(void)
@@ -104,7 +104,7 @@ static void make_keys(void)
 
 	for (i = 0; i < N_KEY; i++) {
 		ret = pthread_key_create(&keys[i], NULL);
-		zassert_false(ret, "insufficient memory to create keys");
+		ztest_false(ret, "insufficient memory to create keys");
 	}
 }
 
@@ -133,7 +133,7 @@ void test_posix_multiple_threads_single_key(void)
 	ret = pthread_once(&key_once, make_key);
 
 	/* TESTPOINT: Check if key is created */
-	zassert_false(ret, "attempt to create key failed");
+	ztest_false(ret, "attempt to create key failed");
 
 	printk("\nDifferent threads set different values to same key:\n");
 
@@ -141,9 +141,9 @@ void test_posix_multiple_threads_single_key(void)
 	for (i = 0; i < N_THR; i++) {
 		ret = pthread_attr_init(&attr[i]);
 		if (ret != 0) {
-			zassert_false(pthread_attr_destroy(&attr[i]),
+			ztest_false(pthread_attr_destroy(&attr[i]),
 					"Unable to destroy pthread object attr");
-			zassert_false(pthread_attr_init(&attr[i]),
+			ztest_false(pthread_attr_init(&attr[i]),
 					"Unable to create pthread object attr");
 		}
 
@@ -155,7 +155,7 @@ void test_posix_multiple_threads_single_key(void)
 				INT_TO_POINTER(i));
 
 		/* TESTPOINT: Check if threads are created successfully */
-		zassert_false(ret, "attempt to create threads failed");
+		ztest_false(ret, "attempt to create threads failed");
 	}
 
 	for (i = 0; i < N_THR; i++) {
@@ -166,7 +166,7 @@ void test_posix_multiple_threads_single_key(void)
 	ret = pthread_key_delete(key);
 
 	/* TESTPOINT: Check if key is deleted */
-	zassert_false(ret, "attempt to delete key failed");
+	ztest_false(ret, "attempt to delete key failed");
 	printk("\n");
 }
 
@@ -181,14 +181,14 @@ void test_posix_single_thread_multiple_keys(void)
 	ret = pthread_once(&keys_once, make_keys);
 
 	/* TESTPOINT: Check if keys are created successfully */
-	zassert_false(ret, "attempt to create keys failed");
+	ztest_false(ret, "attempt to create keys failed");
 
 	printk("\nSingle thread associates its value with different keys:\n");
 	ret = pthread_attr_init(&attr);
 	if (ret != 0) {
-		zassert_false(pthread_attr_destroy(&attr),
+		ztest_false(pthread_attr_destroy(&attr),
 				"Unable to destroy pthread object attr");
-		zassert_false(pthread_attr_init(&attr),
+		ztest_false(pthread_attr_init(&attr),
 				"Unable to create pthread object attr");
 	}
 
@@ -200,7 +200,7 @@ void test_posix_single_thread_multiple_keys(void)
 			(void *)0);
 
 	/*TESTPOINT: Check if thread is created successfully */
-	zassert_false(ret, "attempt to create thread failed");
+	ztest_false(ret, "attempt to create thread failed");
 
 	pthread_join(newthread, NULL);
 
@@ -208,7 +208,7 @@ void test_posix_single_thread_multiple_keys(void)
 		ret = pthread_key_delete(keys[i]);
 
 		/* TESTPOINT: Check if keys are deleted */
-		zassert_false(ret, "attempt to delete keys failed");
+		ztest_false(ret, "attempt to delete keys failed");
 	}
 	printk("\n");
 }

--- a/tests/posix/common/src/semaphore.c
+++ b/tests/posix/common/src/semaphore.c
@@ -21,7 +21,7 @@ static K_THREAD_STACK_DEFINE(stack, STACK_SIZE);
 
 static void *child_func(void *p1)
 {
-	zassert_equal(sem_post(&sema), 0, "sem_post failed");
+	ztest_equal(sem_post(&sema), 0, "sem_post failed");
 	return NULL;
 }
 
@@ -33,9 +33,9 @@ void initialize_thread_attr(pthread_attr_t *attr)
 
 	ret = pthread_attr_init(attr);
 	if (ret != 0) {
-		zassert_equal(pthread_attr_destroy(attr), 0,
+		ztest_equal(pthread_attr_destroy(attr), 0,
 			      "Unable to destroy pthread object attrib");
-		zassert_equal(pthread_attr_init(attr), 0,
+		ztest_equal(pthread_attr_init(attr), 0,
 			      "Unable to create pthread object attrib");
 	}
 
@@ -56,31 +56,31 @@ void test_posix_semaphore(void)
 	/* TESTPOINT: Check if sema value is less than
 	 * CONFIG_SEM_VALUE_MAX
 	 */
-	zassert_equal(sem_init(&sema, 0, (CONFIG_SEM_VALUE_MAX + 1)), -1,
+	ztest_equal(sem_init(&sema, 0, (CONFIG_SEM_VALUE_MAX + 1)), -1,
 		      "value larger than %d\n", CONFIG_SEM_VALUE_MAX);
-	zassert_equal(errno, EINVAL, NULL);
+	ztest_equal(errno, EINVAL, NULL);
 
-	zassert_equal(sem_init(&sema, 0, 0), 0, "sem_init failed");
+	ztest_equal(sem_init(&sema, 0, 0), 0, "sem_init failed");
 
 	/* TESTPOINT: Call sem_post with invalid kobject */
-	zassert_equal(sem_post(dummy_sem), -1, "sem_post of"
+	ztest_equal(sem_post(dummy_sem), -1, "sem_post of"
 		      " invalid semaphore object didn't fail");
-	zassert_equal(errno, EINVAL, NULL);
+	ztest_equal(errno, EINVAL, NULL);
 
 	/* TESTPOINT: Check if semaphore value is as set */
-	zassert_equal(sem_getvalue(&sema, &val), 0, NULL);
-	zassert_equal(val, 0, NULL);
+	ztest_equal(sem_getvalue(&sema, &val), 0, NULL);
+	ztest_equal(val, 0, NULL);
 
 	/* TESTPOINT: Check if sema is acquired when it
 	 * is not available
 	 */
-	zassert_equal(sem_trywait(&sema), -1, NULL);
-	zassert_equal(errno, EAGAIN, NULL);
+	ztest_equal(sem_trywait(&sema), -1, NULL);
+	ztest_equal(errno, EAGAIN, NULL);
 
 	ret = pthread_create(&thread1, &attr1, child_func, NULL);
-	zassert_equal(ret, 0, "Thread creation failed");
+	ztest_equal(ret, 0, "Thread creation failed");
 
-	zassert_equal(clock_gettime(CLOCK_REALTIME, &abstime), 0,
+	ztest_equal(clock_gettime(CLOCK_REALTIME, &abstime), 0,
 		      "clock_gettime failed");
 
 	abstime.tv_sec += 5;
@@ -88,41 +88,41 @@ void test_posix_semaphore(void)
 	/* TESPOINT: Wait for 5 seconds and acquire sema given
 	 * by thread1
 	 */
-	zassert_equal(sem_timedwait(&sema, &abstime), 0, NULL);
+	ztest_equal(sem_timedwait(&sema, &abstime), 0, NULL);
 
 	/* TESTPOINT: Semaphore is already acquired, check if
 	 * no semaphore is available
 	 */
-	zassert_equal(sem_timedwait(&sema, &abstime), -1, NULL);
-	zassert_equal(errno, ETIMEDOUT, NULL);
+	ztest_equal(sem_timedwait(&sema, &abstime), -1, NULL);
+	ztest_equal(errno, ETIMEDOUT, NULL);
 
 	/* TESTPOINT: sem_destroy with invalid kobject */
-	zassert_equal(sem_destroy(dummy_sem), -1, "invalid"
+	ztest_equal(sem_destroy(dummy_sem), -1, "invalid"
 		      " semaphore is destroyed");
-	zassert_equal(errno, EINVAL, NULL);
+	ztest_equal(errno, EINVAL, NULL);
 
-	zassert_equal(sem_destroy(&sema), 0, "semaphore is not destroyed");
+	ztest_equal(sem_destroy(&sema), 0, "semaphore is not destroyed");
 
-	zassert_equal(pthread_attr_destroy(&attr1), 0,
+	ztest_equal(pthread_attr_destroy(&attr1), 0,
 		      "Unable to destroy pthread object attrib");
 
 	/* TESTPOINT: Initialize sema with 1 */
-	zassert_equal(sem_init(&sema, 0, 1), 0, "sem_init failed");
-	zassert_equal(sem_getvalue(&sema, &val), 0, NULL);
-	zassert_equal(val, 1, NULL);
+	ztest_equal(sem_init(&sema, 0, 1), 0, "sem_init failed");
+	ztest_equal(sem_getvalue(&sema, &val), 0, NULL);
+	ztest_equal(val, 1, NULL);
 
-	zassert_equal(sem_destroy(&sema), -1, "acquired semaphore"
+	ztest_equal(sem_destroy(&sema), -1, "acquired semaphore"
 		      " is destroyed");
-	zassert_equal(errno, EBUSY, NULL);
+	ztest_equal(errno, EBUSY, NULL);
 
 	/* TESTPOINT: take semaphore which is initialized with 1 */
-	zassert_equal(sem_trywait(&sema), 0, NULL);
+	ztest_equal(sem_trywait(&sema), 0, NULL);
 
 	initialize_thread_attr(&attr2);
 
-	zassert_equal(pthread_create(&thread2, &attr2, child_func, NULL), 0,
+	ztest_equal(pthread_create(&thread2, &attr2, child_func, NULL), 0,
 		      "Thread creation failed");
 
 	/* TESTPOINT: Wait and acquire semaphore till thread2 gives */
-	zassert_equal(sem_wait(&sema), 0, "sem_wait failed");
+	ztest_equal(sem_wait(&sema), 0, "sem_wait failed");
 }

--- a/tests/posix/common/src/timer.c
+++ b/tests/posix/common/src/timer.c
@@ -39,7 +39,7 @@ void test_posix_timer(void)
 	ret = timer_create(CLOCK_MONOTONIC, &sig, &timerid);
 
 	/*TESTPOINT: Check if timer is created successfully*/
-	zassert_false(ret, "POSIX timer create failed");
+	ztest_false(ret, "POSIX timer create failed");
 
 	value.it_value.tv_sec = DURATION_SECS;
 	value.it_value.tv_nsec = DURATION_NSECS;
@@ -48,7 +48,7 @@ void test_posix_timer(void)
 	ret = timer_settime(timerid, 0, &value, &ovalue);
 	usleep(100 * USEC_PER_MSEC);
 	ret = timer_gettime(timerid, &value);
-	zassert_false(ret, "Failed to get time to expire.");
+	ztest_false(ret, "Failed to get time to expire.");
 
 	if (ret == 0) {
 		printk("Timer fires every %d secs and  %d nsecs\n",
@@ -62,7 +62,7 @@ void test_posix_timer(void)
 	clock_gettime(CLOCK_MONOTONIC, &ts);
 
 	/*TESTPOINT: Check if timer has started successfully*/
-	zassert_false(ret, "POSIX timer failed to start");
+	ztest_false(ret, "POSIX timer failed to start");
 
 	sleep(SECS_TO_SLEEP);
 
@@ -83,6 +83,6 @@ void test_posix_timer(void)
 			     value.it_interval.tv_nsec)) / NSEC_PER_SEC;
 
 	/*TESTPOINT: Check if POSIX timer test passed*/
-	zassert_equal(total_secs_timer, secs_elapsed,
+	ztest_equal(total_secs_timer, secs_elapsed,
 		      "POSIX timer test has failed");
 }

--- a/tests/posix/fs/src/test_fat_mount.c
+++ b/tests/posix/fs/src/test_fat_mount.c
@@ -39,5 +39,5 @@ static int test_mount(void)
  */
 void test_fs_mount(void)
 {
-	zassert_true(test_mount() == TC_PASS, NULL);
+	ztest_true(test_mount() == TC_PASS, NULL);
 }

--- a/tests/posix/fs/src/test_fs_dir.c
+++ b/tests/posix/fs/src/test_fs_dir.c
@@ -91,7 +91,7 @@ static int test_lsdir(const char *path)
  */
 void test_fs_mkdir(void)
 {
-	zassert_true(test_mkdir() == TC_PASS, NULL);
+	ztest_true(test_mkdir() == TC_PASS, NULL);
 }
 
 /**
@@ -103,5 +103,5 @@ void test_fs_mkdir(void)
  */
 void test_fs_readdir(void)
 {
-	zassert_true(test_lsdir(TEST_DIR) == TC_PASS, NULL);
+	ztest_true(test_lsdir(TEST_DIR) == TC_PASS, NULL);
 }

--- a/tests/posix/fs/src/test_fs_file.c
+++ b/tests/posix/fs/src/test_fs_file.c
@@ -17,7 +17,7 @@ static int test_file_open(void)
 	int res;
 
 	res = open(TEST_FILE, O_RDWR);
-	zassert_true(res >= 0, "Failed opening file: %d, errno=%d\n", res, errno);
+	ztest_true(res >= 0, "Failed opening file: %d, errno=%d\n", res, errno);
 
 	file = res;
 
@@ -117,7 +117,7 @@ static int test_file_close(void)
 	int res;
 
 	res = close(file);
-	zassert_true(res == 0, "Failed closing file: %d, errno=%d\n", res, errno);
+	ztest_true(res == 0, "Failed closing file: %d, errno=%d\n", res, errno);
 
 	return res;
 }
@@ -142,7 +142,7 @@ static int test_file_delete(void)
  */
 void test_fs_open(void)
 {
-	zassert_true(test_file_open() == TC_PASS, NULL);
+	ztest_true(test_file_open() == TC_PASS, NULL);
 }
 
 /**
@@ -152,7 +152,7 @@ void test_fs_open(void)
  */
 void test_fs_write(void)
 {
-	zassert_true(test_file_write() == TC_PASS, NULL);
+	ztest_true(test_file_write() == TC_PASS, NULL);
 }
 
 /**
@@ -162,7 +162,7 @@ void test_fs_write(void)
  */
 void test_fs_read(void)
 {
-	zassert_true(test_file_read() == TC_PASS, NULL);
+	ztest_true(test_file_read() == TC_PASS, NULL);
 }
 
 /**
@@ -172,7 +172,7 @@ void test_fs_read(void)
  */
 void test_fs_close(void)
 {
-	zassert_true(test_file_close() == TC_PASS, NULL);
+	ztest_true(test_file_close() == TC_PASS, NULL);
 }
 
 /**
@@ -182,7 +182,7 @@ void test_fs_close(void)
  */
 void test_fs_unlink(void)
 {
-	zassert_true(test_file_delete() == TC_PASS, NULL);
+	ztest_true(test_file_delete() == TC_PASS, NULL);
 }
 
 void test_fs_fd_leak(void)

--- a/tests/shell/src/main.c
+++ b/tests/shell/src/main.c
@@ -29,7 +29,7 @@ static void test_shell_execute_cmd(const char *cmd, int result)
 
 	TC_PRINT("shell_execute_cmd(%s): %d\n", cmd, ret);
 
-	zassert_true(ret == result, cmd);
+	ztest_true(ret == result, cmd);
 }
 
 static void test_cmd_help(void)

--- a/tests/subsys/canbus/frame/src/main.c
+++ b/tests/subsys/canbus/frame/src/main.c
@@ -39,10 +39,10 @@ static void test_can_frame_to_zcan_frame(void)
 	LOG_HEXDUMP_DBG((const u8_t *)&msg, sizeof(msg), "msg");
 	LOG_HEXDUMP_DBG((const u8_t *)&expected, sizeof(expected), "expected");
 
-	zassert_equal(msg.rtr, expected.rtr, "RTR bit not set");
-	zassert_equal(msg.id_type, expected.id_type, "Id-type bit not set");
-	zassert_equal(msg.std_id, expected.std_id, "Std CAN id invalid");
-	zassert_equal(msg.dlc, expected.dlc, "Msg length invalid");
+	ztest_equal(msg.rtr, expected.rtr, "RTR bit not set");
+	ztest_equal(msg.id_type, expected.id_type, "Id-type bit not set");
+	ztest_equal(msg.std_id, expected.std_id, "Std CAN id invalid");
+	ztest_equal(msg.dlc, expected.dlc, "Msg length invalid");
 }
 
 static void test_zcan_frame_to_can_frame(void)
@@ -69,11 +69,11 @@ static void test_zcan_frame_to_can_frame(void)
 	LOG_HEXDUMP_DBG((const u8_t *)&msg, sizeof(msg), "msg");
 	LOG_HEXDUMP_DBG((const u8_t *)&expected, sizeof(expected), "expected");
 
-	zassert_mem_equal(&frame.can_id, &expected.can_id, sizeof(frame.can_id),
+	ztest_mem_equal(&frame.can_id, &expected.can_id, sizeof(frame.can_id),
 			  "CAN ID not same");
-	zassert_mem_equal(&frame.data, &expected.data, sizeof(frame.data),
+	ztest_mem_equal(&frame.data, &expected.data, sizeof(frame.data),
 			  "CAN data not same");
-	zassert_equal(frame.can_dlc, expected.can_dlc,
+	ztest_equal(frame.can_dlc, expected.can_dlc,
 		      "CAN msg length not same");
 }
 
@@ -100,11 +100,11 @@ static void test_invalid_zcan_frame_to_can_frame(void)
 	LOG_HEXDUMP_DBG((const u8_t *)&msg, sizeof(msg), "msg");
 	LOG_HEXDUMP_DBG((const u8_t *)&expected, sizeof(expected), "expected");
 
-	zassert_mem_equal(&frame.can_id, &expected.can_id, sizeof(frame.can_id),
+	ztest_mem_equal(&frame.can_id, &expected.can_id, sizeof(frame.can_id),
 			  "CAN ID not same");
-	zassert_mem_equal(&frame.data, &expected.data, sizeof(frame.data),
+	ztest_mem_equal(&frame.data, &expected.data, sizeof(frame.data),
 			  "CAN data not same");
-	zassert_equal(frame.can_dlc, expected.can_dlc,
+	ztest_equal(frame.can_dlc, expected.can_dlc,
 		      "CAN msg length not same");
 }
 
@@ -131,14 +131,14 @@ static void test_can_filter_to_zcan_filter(void)
 	LOG_HEXDUMP_DBG((const u8_t *)&filter, sizeof(filter), "filter");
 	LOG_HEXDUMP_DBG((const u8_t *)&expected, sizeof(expected), "expected");
 
-	zassert_equal(msg_filter.rtr, expected.rtr, "RTR bit not set");
-	zassert_equal(msg_filter.id_type, expected.id_type,
+	ztest_equal(msg_filter.rtr, expected.rtr, "RTR bit not set");
+	ztest_equal(msg_filter.id_type, expected.id_type,
 		      "Id-type bit not set");
-	zassert_equal(msg_filter.std_id, expected.std_id,
+	ztest_equal(msg_filter.std_id, expected.std_id,
 		      "Std CAN id invalid");
-	zassert_equal(msg_filter.rtr_mask, expected.rtr_mask,
+	ztest_equal(msg_filter.rtr_mask, expected.rtr_mask,
 		      "RTR mask bit not set");
-	zassert_equal(msg_filter.std_id_mask, expected.std_id_mask,
+	ztest_equal(msg_filter.std_id_mask, expected.std_id_mask,
 		      "Std id mask not set");
 }
 
@@ -164,9 +164,9 @@ static void test_zcan_filter_to_can_filter(void)
 	LOG_HEXDUMP_DBG((const u8_t *)&filter, sizeof(filter), "filter");
 	LOG_HEXDUMP_DBG((const u8_t *)&expected, sizeof(expected), "expected");
 
-	zassert_mem_equal(&filter.can_id, &expected.can_id,
+	ztest_mem_equal(&filter.can_id, &expected.can_id,
 			  sizeof(filter.can_id), "CAN ID not same");
-	zassert_mem_equal(&filter.can_mask, &expected.can_mask,
+	ztest_mem_equal(&filter.can_mask, &expected.can_mask,
 			  sizeof(filter.can_mask), "CAN mask not same");
 }
 

--- a/tests/subsys/canbus/isotp/implementation/src/main.c
+++ b/tests/subsys/canbus/isotp/implementation/src/main.c
@@ -58,7 +58,7 @@ u8_t data_buf[128];
 
 void send_complette_cb(int error_nr, void *arg)
 {
-	zassert_equal(error_nr, ISOTP_N_OK, "Sending failed (%d)", error_nr);
+	ztest_equal(error_nr, ISOTP_N_OK, "Sending failed (%d)", error_nr);
 }
 
 static void send_sf(struct device *can_dev)
@@ -67,7 +67,7 @@ static void send_sf(struct device *can_dev)
 
 	ret = isotp_send(&send_ctx, can_dev, random_data, DATA_SIZE_SF,
 			 &rx_addr, &tx_addr, send_complette_cb, NULL);
-	zassert_equal(ret, 0, "Send returned %d", ret);
+	ztest_equal(ret, 0, "Send returned %d", ret);
 }
 
 static void get_sf_net(struct isotp_recv_ctx *recv_ctx)
@@ -76,13 +76,13 @@ static void get_sf_net(struct isotp_recv_ctx *recv_ctx)
 	int remaining_len, ret;
 
 	remaining_len = isotp_recv_net(recv_ctx, &buf, K_MSEC(1000));
-	zassert_true(remaining_len >= 0, "recv returned %d", remaining_len);
-	zassert_equal(remaining_len, 0, "SF should fit in one frame");
-	zassert_equal(buf->len, DATA_SIZE_SF, "Data length (%d) should be %d.",
+	ztest_true(remaining_len >= 0, "recv returned %d", remaining_len);
+	ztest_equal(remaining_len, 0, "SF should fit in one frame");
+	ztest_equal(buf->len, DATA_SIZE_SF, "Data length (%d) should be %d.",
 		      buf->len, DATA_SIZE_SF);
 
 	ret = memcmp(random_data, buf->data, buf->len);
-	zassert_equal(ret, 0, "received data differ");
+	ztest_equal(ret, 0, "received data differ");
 	memset(buf->data, 0, buf->len);
 	net_buf_unref(buf);
 }
@@ -94,13 +94,13 @@ static void get_sf(struct isotp_recv_ctx *recv_ctx)
 
 	memset(data_buf, 0, sizeof(data_buf));
 	ret = isotp_recv(recv_ctx, data_buf_ptr++, 1, K_MSEC(1000));
-	zassert_equal(ret, 1, "recv returned %d", ret);
+	ztest_equal(ret, 1, "recv returned %d", ret);
 	ret = isotp_recv(recv_ctx, data_buf_ptr++, sizeof(data_buf) - 1,
 			  K_MSEC(1000));
-	zassert_equal(ret, DATA_SIZE_SF - 1, "recv returned %d", ret);
+	ztest_equal(ret, DATA_SIZE_SF - 1, "recv returned %d", ret);
 
 	ret = memcmp(random_data, data_buf, DATA_SIZE_SF);
-	zassert_equal(ret, 0, "received data differ");
+	ztest_equal(ret, 0, "received data differ");
 }
 
 void print_hex(const u8_t *ptr, size_t len)
@@ -116,7 +116,7 @@ static void send_test_data(struct device *can_dev, const u8_t *data, size_t len)
 
 	ret = isotp_send(&send_ctx, can_dev, data, len, &rx_addr, &tx_addr,
 			  send_complette_cb, NULL);
-	zassert_equal(ret, 0, "Send returned %d", ret);
+	ztest_equal(ret, 0, "Send returned %d", ret);
 }
 
 static const u8_t *check_frag(struct net_buf *frag, const u8_t *data)
@@ -131,7 +131,7 @@ static const u8_t *check_frag(struct net_buf *frag, const u8_t *data)
 		print_hex(frag->data, frag->len);
 		printk("\n");
 	}
-	zassert_equal(ret, 0, "Received data differ");
+	ztest_equal(ret, 0, "Received data differ");
 	return data + frag->len;
 }
 
@@ -145,10 +145,10 @@ static void receive_test_data_net(struct isotp_recv_ctx *recv_ctx,
 
 	do {
 		remaining_len = isotp_recv_net(recv_ctx, &buf, K_MSEC(1000));
-		zassert_true(remaining_len >= 0, "recv error: %d",
+		ztest_true(remaining_len >= 0, "recv error: %d",
 			     remaining_len);
 		received_len += buf->len;
-		zassert_equal(received_len + remaining_len, len,
+		ztest_equal(received_len + remaining_len, len,
 			      "Length missmatch");
 
 		data_ptr = check_frag(buf, data_ptr);
@@ -161,7 +161,7 @@ static void receive_test_data_net(struct isotp_recv_ctx *recv_ctx,
 	} while (remaining_len);
 
 	remaining_len = isotp_recv_net(recv_ctx, &buf, K_MSEC(50));
-	zassert_equal(remaining_len, ISOTP_RECV_TIMEOUT,
+	ztest_equal(remaining_len, ISOTP_RECV_TIMEOUT,
 		      "Expected timeout but got %d", remaining_len);
 }
 
@@ -177,7 +177,7 @@ static void check_data(const u8_t *recv_data, const u8_t *send_data, size_t len)
 		print_hex(recv_data, len);
 		printk("\n");
 	}
-	zassert_equal(ret, 0, "Received data differ");
+	ztest_equal(ret, 0, "Received data differ");
 }
 
 static void receive_test_data(struct isotp_recv_ctx *recv_ctx,
@@ -191,9 +191,9 @@ static void receive_test_data(struct isotp_recv_ctx *recv_ctx,
 		memset(data_buf, 0, sizeof(data_buf));
 		ret = isotp_recv(recv_ctx, data_buf, sizeof(data_buf),
 				 K_MSEC(1000));
-		zassert_true(ret >= 0, "recv error: %d", ret);
+		ztest_true(ret >= 0, "recv error: %d", ret);
 
-		zassert_true(remaining_len >= ret, "More data then expected");
+		ztest_true(remaining_len >= ret, "More data then expected");
 		check_data(data_buf, data_ptr, ret);
 		data_ptr += ret;
 		remaining_len -= ret;
@@ -204,7 +204,7 @@ static void receive_test_data(struct isotp_recv_ctx *recv_ctx,
 	} while (remaining_len);
 
 	ret = isotp_recv(recv_ctx, data_buf, sizeof(data_buf), K_MSEC(50));
-	zassert_equal(ret, ISOTP_RECV_TIMEOUT,
+	ztest_equal(ret, ISOTP_RECV_TIMEOUT,
 		      "Expected timeout but got %d", ret);
 }
 
@@ -214,7 +214,7 @@ static void test_send_receive_net_sf(void)
 
 	ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr, &fc_opts,
 			 K_NO_WAIT);
-	zassert_equal(ret, 0, "Bind returned %d", ret);
+	ztest_equal(ret, 0, "Bind returned %d", ret);
 
 	for (i = 0; i < NUMBER_OF_REPETITIONS; i++) {
 		send_sf(can_dev);
@@ -230,7 +230,7 @@ static void test_send_receive_sf(void)
 
 	ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr, &fc_opts,
 			 K_NO_WAIT);
-	zassert_equal(ret, 0, "Bind returned %d", ret);
+	ztest_equal(ret, 0, "Bind returned %d", ret);
 
 	for (i = 0; i < NUMBER_OF_REPETITIONS; i++) {
 		send_sf(can_dev);
@@ -246,7 +246,7 @@ static void test_send_receive_net_blocks(void)
 
 	ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr, &fc_opts,
 			 K_NO_WAIT);
-	zassert_equal(ret, 0, "Binding failed (%d)", ret);
+	ztest_equal(ret, 0, "Binding failed (%d)", ret);
 
 	for (i = 0; i < NUMBER_OF_REPETITIONS; i++) {
 		send_test_data(can_dev, random_data, random_data_len);
@@ -264,7 +264,7 @@ static void test_send_receive_blocks(void)
 
 	ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr, &fc_opts,
 			 K_NO_WAIT);
-	zassert_equal(ret, 0, "Binding failed (%d)", ret);
+	ztest_equal(ret, 0, "Binding failed (%d)", ret);
 
 	for (i = 0; i < NUMBER_OF_REPETITIONS; i++) {
 		send_test_data(can_dev, random_data, data_size);
@@ -285,16 +285,16 @@ static void test_send_receive_net_single_blocks(void)
 
 	ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr,
 			 &fc_opts_single, K_NO_WAIT);
-	zassert_equal(ret, 0, "Binding failed (%d)", ret);
+	ztest_equal(ret, 0, "Binding failed (%d)", ret);
 
 	for (i = 0; i < NUMBER_OF_REPETITIONS; i++) {
 		send_test_data(can_dev, random_data, send_len);
 		data_ptr = random_data;
 
 		ret = isotp_recv_net(&recv_ctx, &buf, K_MSEC(1000));
-		zassert_equal(ret, 0, "recv returned %d", ret);
+		ztest_equal(ret, 0, "recv returned %d", ret);
 		buf_len = net_buf_frags_len(buf);
-		zassert_equal(buf_len, send_len, "Data length differ");
+		ztest_equal(buf_len, send_len, "Data length differ");
 		frag = buf;
 
 		do {
@@ -316,7 +316,7 @@ static void test_send_receive_single_block(void)
 
 	ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr,
 			 &fc_opts_single, K_NO_WAIT);
-	zassert_equal(ret, 0, "Binding failed (%d)", ret);
+	ztest_equal(ret, 0, "Binding failed (%d)", ret);
 
 	for (i = 0; i < NUMBER_OF_REPETITIONS; i++) {
 		send_test_data(can_dev, random_data, send_len);
@@ -324,10 +324,10 @@ static void test_send_receive_single_block(void)
 		memset(data_buf, 0, sizeof(data_buf));
 		ret = isotp_recv(&recv_ctx, data_buf, sizeof(data_buf),
 				 K_MSEC(1000));
-		zassert_equal(ret, send_len,
+		ztest_equal(ret, send_len,
 			      "data should be received at once (ret: %d)", ret);
 		ret = memcmp(random_data, data_buf, send_len);
-		zassert_equal(ret, 0, "Data differ");
+		ztest_equal(ret, 0, "Data differ");
 	}
 
 	isotp_unbind(&recv_ctx);
@@ -340,14 +340,14 @@ static void test_bind_unbind(void)
 	for (i = 0; i < 100; i++) {
 		ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr,
 				 &fc_opts, K_NO_WAIT);
-		zassert_equal(ret, 0, "Binding failed (%d)", ret);
+		ztest_equal(ret, 0, "Binding failed (%d)", ret);
 		isotp_unbind(&recv_ctx);
 	}
 
 	for (i = 0; i < NUMBER_OF_REPETITIONS; i++) {
 		ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr,
 				 &fc_opts, K_NO_WAIT);
-		zassert_equal(ret, 0, "Binding failed (%d)", ret);
+		ztest_equal(ret, 0, "Binding failed (%d)", ret);
 		send_sf(can_dev);
 		get_sf_net(&recv_ctx);
 		isotp_unbind(&recv_ctx);
@@ -356,7 +356,7 @@ static void test_bind_unbind(void)
 	for (i = 0; i < NUMBER_OF_REPETITIONS; i++) {
 		ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr,
 				 &fc_opts, K_NO_WAIT);
-		zassert_equal(ret, 0, "Binding failed (%d)", ret);
+		ztest_equal(ret, 0, "Binding failed (%d)", ret);
 		send_sf(can_dev);
 		get_sf(&recv_ctx);
 		isotp_unbind(&recv_ctx);
@@ -365,7 +365,7 @@ static void test_bind_unbind(void)
 	for (i = 0; i < 10; i++) {
 		ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr,
 				 &fc_opts, K_NO_WAIT);
-		zassert_equal(ret, 0, "Binding failed (%d)", ret);
+		ztest_equal(ret, 0, "Binding failed (%d)", ret);
 		send_test_data(can_dev, random_data, 60);
 		receive_test_data_net(&recv_ctx, random_data, 60, 0);
 		isotp_unbind(&recv_ctx);
@@ -374,7 +374,7 @@ static void test_bind_unbind(void)
 	for (i = 0; i < NUMBER_OF_REPETITIONS; i++) {
 		ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr,
 				 &fc_opts, K_NO_WAIT);
-		zassert_equal(ret, 0, "Binding failed (%d)", ret);
+		ztest_equal(ret, 0, "Binding failed (%d)", ret);
 		send_test_data(can_dev, random_data, 60);
 		receive_test_data(&recv_ctx, random_data, 60, 0);
 		isotp_unbind(&recv_ctx);
@@ -389,7 +389,7 @@ static void test_buffer_allocation(void)
 
 	ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr, &fc_opts,
 			 K_NO_WAIT);
-	zassert_equal(ret, 0, "Binding failed (%d)", ret);
+	ztest_equal(ret, 0, "Binding failed (%d)", ret);
 
 	send_test_data(can_dev, random_data, send_data_length);
 	k_sleep(K_MSEC(100));
@@ -405,7 +405,7 @@ static void test_buffer_allocation_wait(void)
 
 	ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr, &fc_opts,
 			 K_NO_WAIT);
-	zassert_equal(ret, 0, "Binding failed (%d)", ret);
+	ztest_equal(ret, 0, "Binding failed (%d)", ret);
 
 	send_test_data(can_dev, random_data, send_data_length);
 	k_sleep(K_MSEC(100));
@@ -417,13 +417,13 @@ void test_main(void)
 {
 	int ret;
 
-	zassert_true(sizeof(random_data) >= sizeof(data_buf) * 2 + 10,
+	ztest_true(sizeof(random_data) >= sizeof(data_buf) * 2 + 10,
 		     "Test data size to small");
 
 	can_dev = device_get_binding(CAN_DEVICE_NAME);
-	zassert_not_null(can_dev, "CAN device not not found");
+	ztest_not_null(can_dev, "CAN device not not found");
 	ret = can_configure(can_dev, CAN_LOOPBACK_MODE, 0);
-	zassert_equal(ret, 0, "Configuring loopback mode failed (%d)", ret);
+	ztest_equal(ret, 0, "Configuring loopback mode failed (%d)", ret);
 
 	ztest_test_suite(isotp,
 			 ztest_unit_test(test_bind_unbind),

--- a/tests/subsys/dfu/img_util/src/main.c
+++ b/tests/subsys/dfu/img_util/src/main.c
@@ -15,20 +15,20 @@ void test_init_id(void)
 	int ret;
 
 	ret = flash_img_init(&ctx_no_id);
-	zassert_true(ret == 0, "Flash img init");
+	ztest_true(ret == 0, "Flash img init");
 
 	ret = flash_img_init_id(&ctx_id, DT_FLASH_AREA_IMAGE_1_ID);
-	zassert_true(ret == 0, "Flash img init id");
+	ztest_true(ret == 0, "Flash img init id");
 
 	/* Verify that the default partition ID is IMAGE_1 */
-	zassert_equal(ctx_id.flash_area, ctx_no_id.flash_area,
+	ztest_equal(ctx_id.flash_area, ctx_no_id.flash_area,
 		      "Default partition ID is incorrect");
 
 	/* Note: IMAGE_0, not IMAGE_1 as above */
 	ret = flash_img_init_id(&ctx_id, DT_FLASH_AREA_IMAGE_0_ID);
-	zassert_true(ret == 0, "Flash img init id");
+	ztest_true(ret == 0, "Flash img init id");
 
-	zassert_equal(ctx_id.flash_area->fa_id, DT_FLASH_AREA_IMAGE_0_ID,
+	ztest_equal(ctx_id.flash_area->fa_id, DT_FLASH_AREA_IMAGE_0_ID,
 		      "Partition ID is not set correctly");
 }
 
@@ -41,7 +41,7 @@ void test_collecting(void)
 	int ret;
 
 	ret = flash_img_init(&ctx);
-	zassert_true(ret == 0, "Flash img init");
+	ztest_true(ret == 0, "Flash img init");
 
 #ifdef CONFIG_IMG_ERASE_PROGRESSIVELY
 	u8_t erase_buf[8];
@@ -57,19 +57,19 @@ void test_collecting(void)
 	for (i = 0U; i < 300 * sizeof(data) / sizeof(erase_buf); i++) {
 		ret = flash_area_write(fa, i * sizeof(erase_buf), erase_buf,
 				       sizeof(erase_buf));
-		zassert_true(ret == 0, "Flash write failure (%d)", ret);
+		ztest_true(ret == 0, "Flash write failure (%d)", ret);
 	}
 
 	/* ensure that the last page dirt */
 	ret = flash_area_write(fa, fa->fa_size - sizeof(erase_buf), erase_buf,
 			       sizeof(erase_buf));
-	zassert_true(ret == 0, "Flash write failure (%d)", ret);
+	ztest_true(ret == 0, "Flash write failure (%d)", ret);
 #else
 	ret = flash_area_erase(ctx.flash_area, 0, ctx.flash_area->fa_size);
-	zassert_true(ret == 0, "Flash erase failure (%d)", ret);
+	ztest_true(ret == 0, "Flash erase failure (%d)", ret);
 #endif
 
-	zassert(flash_img_bytes_written(&ctx) == 0, "pass", "fail");
+	ztest(flash_img_bytes_written(&ctx) == 0, "pass", "fail");
 
 	k = 0U;
 	for (i = 0U; i < 300; i++) {
@@ -77,10 +77,10 @@ void test_collecting(void)
 			data[j] = k++;
 		}
 		ret = flash_img_buffered_write(&ctx, data, sizeof(data), false);
-		zassert_true(ret == 0, "image colletion fail: %d\n", ret);
+		ztest_true(ret == 0, "image colletion fail: %d\n", ret);
 	}
 
-	zassert(flash_img_buffered_write(&ctx, data, 0, true) == 0, "pass",
+	ztest(flash_img_buffered_write(&ctx, data, 0, true) == 0, "pass",
 					 "fail");
 
 
@@ -92,8 +92,8 @@ void test_collecting(void)
 
 	k = 0U;
 	for (i = 0U; i < 300 * sizeof(data); i++) {
-		zassert(flash_area_read(fa, i, &temp, 1) == 0, "pass", "fail");
-		zassert(temp == k, "pass", "fail");
+		ztest(flash_area_read(fa, i, &temp, 1) == 0, "pass", "fail");
+		ztest(temp == k, "pass", "fail");
 		k++;
 	}
 
@@ -101,8 +101,8 @@ void test_collecting(void)
 	u8_t buf[sizeof(erase_buf)];
 
 	ret = flash_area_read(fa, fa->fa_size - sizeof(buf), buf, sizeof(buf));
-	zassert_true(ret == 0, "Flash read failure (%d)", ret);
-	zassert_true(memcmp(erase_buf, buf, sizeof(buf)) == 0,
+	ztest_true(ret == 0, "Flash read failure (%d)", ret);
+	ztest_true(memcmp(erase_buf, buf, sizeof(buf)) == 0,
 		     "Image trailer was not cleared");
 #endif
 }

--- a/tests/subsys/dfu/mcuboot/src/main.c
+++ b/tests/subsys/dfu/mcuboot/src/main.c
@@ -31,20 +31,20 @@ void test_bank_erase(void)
 
 	for (offs = 0; offs < fa->fa_size; offs += sizeof(temp)) {
 		ret = flash_area_read(fa, offs, &temp, sizeof(temp));
-		zassert_true(ret == 0, "Reading from flash");
+		ztest_true(ret == 0, "Reading from flash");
 		if (temp == 0xFFFFFFFF) {
 			ret = flash_area_write(fa, offs, &temp2, sizeof(temp));
-			zassert_true(ret == 0, "Writing to flash");
+			ztest_true(ret == 0, "Writing to flash");
 		}
 	}
 
-	zassert(boot_erase_img_bank(DT_FLASH_AREA_IMAGE_1_ID) == 0,
+	ztest(boot_erase_img_bank(DT_FLASH_AREA_IMAGE_1_ID) == 0,
 		"pass", "fail");
 
 	for (offs = 0; offs < fa->fa_size; offs += sizeof(temp)) {
 		ret = flash_area_read(fa, offs, &temp, sizeof(temp));
-		zassert_true(ret == 0, "Reading from flash");
-		zassert(temp == 0xFFFFFFFF, "pass", "fail");
+		ztest_true(ret == 0, "Reading from flash");
+		ztest(temp == 0xFFFFFFFF, "pass", "fail");
 	}
 }
 
@@ -68,27 +68,27 @@ void test_request_upgrade(void)
 		return;
 	}
 
-	zassert(boot_request_upgrade(false) == 0, "pass", "fail");
+	ztest(boot_request_upgrade(false) == 0, "pass", "fail");
 
 	ret = flash_area_read(fa, fa->fa_size - sizeof(expectation),
 			      &readout, sizeof(readout));
-	zassert_true(ret == 0, "Read from flash");
+	ztest_true(ret == 0, "Read from flash");
 
-	zassert(memcmp(expectation, readout, sizeof(expectation)) == 0,
+	ztest(memcmp(expectation, readout, sizeof(expectation)) == 0,
 		"pass", "fail");
 
 	boot_erase_img_bank(DT_FLASH_AREA_IMAGE_1_ID);
 
-	zassert(boot_request_upgrade(true) == 0, "pass", "fail");
+	ztest(boot_request_upgrade(true) == 0, "pass", "fail");
 
 	ret = flash_area_read(fa, fa->fa_size - sizeof(expectation),
 			      &readout, sizeof(readout));
-	zassert_true(ret == 0, "Read from flash");
+	ztest_true(ret == 0, "Read from flash");
 
-	zassert(memcmp(&expectation[2], &readout[2], sizeof(expectation) -
+	ztest(memcmp(&expectation[2], &readout[2], sizeof(expectation) -
 		       2 * sizeof(expectation[0])) == 0, "pass", "fail");
 
-	zassert_equal(1, readout[0] & 0xff, "confirmation error");
+	ztest_equal(1, readout[0] & 0xff, "confirmation error");
 }
 
 void test_write_confirm(void)
@@ -104,26 +104,26 @@ void test_write_confirm(void)
 		return;
 	}
 
-	zassert(boot_erase_img_bank(DT_FLASH_AREA_IMAGE_0_ID) == 0,
+	ztest(boot_erase_img_bank(DT_FLASH_AREA_IMAGE_0_ID) == 0,
 		"pass", "fail");
 
 	ret = flash_area_read(fa, fa->fa_size - sizeof(img_magic),
 			      &readout, sizeof(img_magic));
-	zassert_true(ret == 0, "Read from flash");
+	ztest_true(ret == 0, "Read from flash");
 
 	if (memcmp(img_magic, readout, sizeof(img_magic)) != 0) {
 		ret = flash_area_write(fa, fa->fa_size - 16,
 				       img_magic, 16);
-		zassert_true(ret == 0, "Write to flash");
+		ztest_true(ret == 0, "Write to flash");
 	}
 
-	zassert(boot_write_img_confirmed() == 0, "pass", "fail");
+	ztest(boot_write_img_confirmed() == 0, "pass", "fail");
 
 	ret = flash_area_read(fa, fa->fa_size - 24, readout,
 			      sizeof(readout[0]));
-	zassert_true(ret == 0, "Read from flash");
+	ztest_true(ret == 0, "Read from flash");
 
-	zassert_equal(1, readout[0] & 0xff, "confirmation error");
+	ztest_equal(1, readout[0] & 0xff, "confirmation error");
 }
 
 void test_main(void)

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_dir.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_dir.c
@@ -158,9 +158,9 @@ static int test_rmdir(void)
 
 void test_fat_dir(void)
 {
-	zassert_true(test_mkdir() == TC_PASS, NULL);
-	zassert_true(test_lsdir(FATFS_MNTP) == TC_PASS, NULL);
-	zassert_true(test_lsdir(TEST_DIR) == TC_PASS, NULL);
-	zassert_true(test_rmdir() == TC_PASS, NULL);
-	zassert_true(test_lsdir(FATFS_MNTP) == TC_PASS, NULL);
+	ztest_true(test_mkdir() == TC_PASS, NULL);
+	ztest_true(test_lsdir(FATFS_MNTP) == TC_PASS, NULL);
+	ztest_true(test_lsdir(TEST_DIR) == TC_PASS, NULL);
+	ztest_true(test_rmdir() == TC_PASS, NULL);
+	ztest_true(test_lsdir(FATFS_MNTP) == TC_PASS, NULL);
 }

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_file.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_file.c
@@ -272,11 +272,11 @@ static int test_file_delete(void)
 
 void test_fat_file(void)
 {
-	zassert_true(test_file_open() == TC_PASS, NULL);
-	zassert_true(test_file_write() == TC_PASS, NULL);
-	zassert_true(test_file_sync() == TC_PASS, NULL);
-	zassert_true(test_file_read() == TC_PASS, NULL);
-	zassert_true(test_file_truncate() == TC_PASS, NULL);
-	zassert_true(test_file_close() == TC_PASS, NULL);
-	zassert_true(test_file_delete() == TC_PASS, NULL);
+	ztest_true(test_file_open() == TC_PASS, NULL);
+	ztest_true(test_file_write() == TC_PASS, NULL);
+	ztest_true(test_file_sync() == TC_PASS, NULL);
+	ztest_true(test_file_read() == TC_PASS, NULL);
+	ztest_true(test_file_truncate() == TC_PASS, NULL);
+	ztest_true(test_file_close() == TC_PASS, NULL);
+	ztest_true(test_file_delete() == TC_PASS, NULL);
 }

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_fs.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_fs.c
@@ -35,5 +35,5 @@ static int test_statvfs(void)
 
 void test_fat_fs(void)
 {
-	zassert_true(test_statvfs() == TC_PASS, NULL);
+	ztest_true(test_statvfs() == TC_PASS, NULL);
 }

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_mount.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_mount.c
@@ -38,5 +38,5 @@ static int test_mount(void)
 
 void test_fat_mount(void)
 {
-	zassert_true(test_mount() == TC_PASS, NULL);
+	ztest_true(test_mount() == TC_PASS, NULL);
 }

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_rename.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_rename.c
@@ -163,6 +163,6 @@ cleanup:
 
 void test_fat_rename(void)
 {
-	zassert_true(test_rename_file() == TC_PASS, NULL);
-	zassert_true(test_rename_dir() == TC_PASS, NULL);
+	ztest_true(test_rename_file() == TC_PASS, NULL);
+	ztest_true(test_rename_dir() == TC_PASS, NULL);
 }

--- a/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_dir.c
+++ b/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_dir.c
@@ -159,16 +159,16 @@ static int test_rmdir(const char *dir)
 void test_fat_dir(void)
 {
 	TC_PRINT("\nTesting directory operations on %s\n", FATFS_MNTP);
-	zassert_true(test_mkdir(TEST_DIR, TEST_DIR_FILE) == TC_PASS, NULL);
-	zassert_true(test_lsdir(FATFS_MNTP) == TC_PASS, NULL);
-	zassert_true(test_lsdir(TEST_DIR) == TC_PASS, NULL);
-	zassert_true(test_rmdir(TEST_DIR) == TC_PASS, NULL);
-	zassert_true(test_lsdir(FATFS_MNTP) == TC_PASS, NULL);
+	ztest_true(test_mkdir(TEST_DIR, TEST_DIR_FILE) == TC_PASS, NULL);
+	ztest_true(test_lsdir(FATFS_MNTP) == TC_PASS, NULL);
+	ztest_true(test_lsdir(TEST_DIR) == TC_PASS, NULL);
+	ztest_true(test_rmdir(TEST_DIR) == TC_PASS, NULL);
+	ztest_true(test_lsdir(FATFS_MNTP) == TC_PASS, NULL);
 
 	TC_PRINT("\nTesting directory operations on %s\n", FATFS_MNTP1);
-	zassert_true(test_mkdir(TEST_DIR1, TEST_DIR_FILE1) == TC_PASS, NULL);
-	zassert_true(test_lsdir(FATFS_MNTP1) == TC_PASS, NULL);
-	zassert_true(test_lsdir(TEST_DIR1) == TC_PASS, NULL);
-	zassert_true(test_rmdir(TEST_DIR1) == TC_PASS, NULL);
-	zassert_true(test_lsdir(FATFS_MNTP1) == TC_PASS, NULL);
+	ztest_true(test_mkdir(TEST_DIR1, TEST_DIR_FILE1) == TC_PASS, NULL);
+	ztest_true(test_lsdir(FATFS_MNTP1) == TC_PASS, NULL);
+	ztest_true(test_lsdir(TEST_DIR1) == TC_PASS, NULL);
+	ztest_true(test_rmdir(TEST_DIR1) == TC_PASS, NULL);
+	ztest_true(test_lsdir(FATFS_MNTP1) == TC_PASS, NULL);
 }

--- a/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_file.c
+++ b/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_file.c
@@ -306,20 +306,20 @@ static int test_file_delete(const char *path)
 void test_fat_file(void)
 {
 	TC_PRINT("Testing file operations on %s\n", FATFS_MNTP);
-	zassert_true(test_file_open(TEST_FILE) == TC_PASS, NULL);
-	zassert_true(test_file_write() == TC_PASS, NULL);
-	zassert_true(test_file_sync() == TC_PASS, NULL);
-	zassert_true(test_file_read() == TC_PASS, NULL);
-	zassert_true(test_file_truncate() == TC_PASS, NULL);
-	zassert_true(test_file_close() == TC_PASS, NULL);
-	zassert_true(test_file_delete(TEST_FILE) == TC_PASS, NULL);
+	ztest_true(test_file_open(TEST_FILE) == TC_PASS, NULL);
+	ztest_true(test_file_write() == TC_PASS, NULL);
+	ztest_true(test_file_sync() == TC_PASS, NULL);
+	ztest_true(test_file_read() == TC_PASS, NULL);
+	ztest_true(test_file_truncate() == TC_PASS, NULL);
+	ztest_true(test_file_close() == TC_PASS, NULL);
+	ztest_true(test_file_delete(TEST_FILE) == TC_PASS, NULL);
 
 	TC_PRINT("Testing file operations on %s\n", FATFS_MNTP1);
-	zassert_true(test_file_open(TEST_FILE1) == TC_PASS, NULL);
-	zassert_true(test_file_write() == TC_PASS, NULL);
-	zassert_true(test_file_sync() == TC_PASS, NULL);
-	zassert_true(test_file_read() == TC_PASS, NULL);
-	zassert_true(test_file_truncate() == TC_PASS, NULL);
-	zassert_true(test_file_close() == TC_PASS, NULL);
-	zassert_true(test_file_delete(TEST_FILE1) == TC_PASS, NULL);
+	ztest_true(test_file_open(TEST_FILE1) == TC_PASS, NULL);
+	ztest_true(test_file_write() == TC_PASS, NULL);
+	ztest_true(test_file_sync() == TC_PASS, NULL);
+	ztest_true(test_file_read() == TC_PASS, NULL);
+	ztest_true(test_file_truncate() == TC_PASS, NULL);
+	ztest_true(test_file_close() == TC_PASS, NULL);
+	ztest_true(test_file_delete(TEST_FILE1) == TC_PASS, NULL);
 }

--- a/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_fs.c
+++ b/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_fs.c
@@ -35,8 +35,8 @@ static int test_statvfs(const char *path)
 void test_fat_fs(void)
 {
 	TC_PRINT("\nTesting statvfs operation on %s\n", FATFS_MNTP);
-	zassert_true(test_statvfs(FATFS_MNTP) == TC_PASS, NULL);
+	ztest_true(test_statvfs(FATFS_MNTP) == TC_PASS, NULL);
 
 	TC_PRINT("\nTesting statvfs operation on %s\n", FATFS_MNTP1);
-	zassert_true(test_statvfs(FATFS_MNTP1) == TC_PASS, NULL);
+	ztest_true(test_statvfs(FATFS_MNTP1) == TC_PASS, NULL);
 }

--- a/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_mount.c
+++ b/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_mount.c
@@ -47,8 +47,8 @@ static int test_mount(struct fs_mount_t *mnt)
 void test_fat_mount(void)
 {
 	TC_PRINT("Mounting %s\n", FATFS_MNTP);
-	zassert_true(test_mount(&fatfs_mnt) == TC_PASS, NULL);
+	ztest_true(test_mount(&fatfs_mnt) == TC_PASS, NULL);
 
 	TC_PRINT("Mounting %s\n", FATFS_MNTP1);
-	zassert_true(test_mount(&fatfs_mnt1) == TC_PASS, NULL);
+	ztest_true(test_mount(&fatfs_mnt1) == TC_PASS, NULL);
 }

--- a/tests/subsys/fs/fcb/src/fcb_test_append.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_append.c
@@ -24,17 +24,17 @@ void fcb_test_append(void)
 			test_data[j] = fcb_test_append_data(i, j);
 		}
 		rc = fcb_append(fcb, i, &loc);
-		zassert_true(rc == 0, "fcb_append call failure");
+		ztest_true(rc == 0, "fcb_append call failure");
 		rc = flash_area_write(fcb->fap, FCB_ENTRY_FA_DATA_OFF(loc),
 				      test_data, i);
-		zassert_true(rc == 0, "flash_area_write call failure");
+		ztest_true(rc == 0, "flash_area_write call failure");
 		rc = fcb_append_finish(fcb, &loc);
-		zassert_true(rc == 0, "fcb_append_finish call failure");
+		ztest_true(rc == 0, "fcb_append_finish call failure");
 	}
 
 	var_cnt = 0;
 	rc = fcb_walk(fcb, 0, fcb_test_data_walk_cb, &var_cnt);
-	zassert_true(rc == 0, "fcb_walk call failure");
-	zassert_true(var_cnt == sizeof(test_data),
+	ztest_true(rc == 0, "fcb_walk call failure");
+	ztest_true(var_cnt == sizeof(test_data),
 		     "fetched data size not match to wrote data size");
 }

--- a/tests/subsys/fs/fcb/src/fcb_test_append_fill.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_append_fill.c
@@ -40,39 +40,39 @@ void fcb_test_append_fill(void)
 		} else if (loc.fe_sector == &test_fcb_sector[1]) {
 			elem_cnts[1]++;
 		} else {
-			zassert_true(0,
+			ztest_true(0,
 				     "unexpected flash area of appended loc");
 		}
 
 		rc = flash_area_write(fcb->fap, FCB_ENTRY_FA_DATA_OFF(loc),
 				      test_data, sizeof(test_data));
-		zassert_true(rc == 0, "flash_area_write call failure");
+		ztest_true(rc == 0, "flash_area_write call failure");
 
 		rc = fcb_append_finish(fcb, &loc);
-		zassert_true(rc == 0, "fcb_append_finish call failure");
+		ztest_true(rc == 0, "fcb_append_finish call failure");
 	}
-	zassert_true(elem_cnts[0] > 0,
+	ztest_true(elem_cnts[0] > 0,
 		     "appendend count should be greater than zero");
-	zassert_true(elem_cnts[0] == elem_cnts[1],
+	ztest_true(elem_cnts[0] == elem_cnts[1],
 		     "appendend counts should equal to each other");
 
 	(void)memset(&aa_together_cnts, 0, sizeof(aa_together_cnts));
 	rc = fcb_walk(fcb, NULL, fcb_test_cnt_elems_cb, &aa_together);
-	zassert_true(rc == 0, "fcb_walk call failure");
-	zassert_true(aa_together.elem_cnts[0] == elem_cnts[0],
+	ztest_true(rc == 0, "fcb_walk call failure");
+	ztest_true(aa_together.elem_cnts[0] == elem_cnts[0],
 		     "fcb_walk: elements count read different than expected");
-	zassert_true(aa_together.elem_cnts[1] == elem_cnts[1],
+	ztest_true(aa_together.elem_cnts[1] == elem_cnts[1],
 		     "fcb_walk: elements count read different than expected");
 
 	(void)memset(&aa_separate_cnts, 0, sizeof(aa_separate_cnts));
 	rc = fcb_walk(fcb, &test_fcb_sector[0], fcb_test_cnt_elems_cb,
 	  &aa_separate);
-	zassert_true(rc == 0, "fcb_walk call failure");
+	ztest_true(rc == 0, "fcb_walk call failure");
 	rc = fcb_walk(fcb, &test_fcb_sector[1], fcb_test_cnt_elems_cb,
 	  &aa_separate);
-	zassert_true(rc == 0, "fcb_walk call failure");
-	zassert_true(aa_separate.elem_cnts[0] == elem_cnts[0],
+	ztest_true(rc == 0, "fcb_walk call failure");
+	ztest_true(aa_separate.elem_cnts[0] == elem_cnts[0],
 		     "fcb_walk: elements count read different than expected");
-	zassert_true(aa_separate.elem_cnts[1] == elem_cnts[1],
+	ztest_true(aa_separate.elem_cnts[1] == elem_cnts[1],
 		     "fcb_walk: elements count read different than expected");
 }

--- a/tests/subsys/fs/fcb/src/fcb_test_append_too_big.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_append_too_big.c
@@ -23,29 +23,29 @@ void (fcb_test_append_too_big(void))
 		len = fcb->f_active.fe_sector->fs_size;
 
 		rc = fcb_append(fcb, len, &elem_loc);
-		zassert_true(rc != 0,
+		ztest_true(rc != 0,
 			     "fcb_append call should fail for too big entry");
 
 		len--;
 		rc = fcb_append(fcb, len, &elem_loc);
-		zassert_true(rc != 0,
+		ztest_true(rc != 0,
 			     "fcb_append call should fail for too big entry");
 
 		len -= sizeof(struct fcb_disk_area);
 		rc = fcb_append(fcb, len, &elem_loc);
-		zassert_true(rc != 0,
+		ztest_true(rc != 0,
 			     "fcb_append call should fail for too big entry");
 
 		len = fcb->f_active.fe_sector->fs_size -
 			(sizeof(struct fcb_disk_area) + 1 + 2);
 		rc = fcb_append(fcb, len, &elem_loc);
-		zassert_true(rc == 0, "fcb_append call failure");
+		ztest_true(rc == 0, "fcb_append call failure");
 
 		rc = fcb_append_finish(fcb, &elem_loc);
-		zassert_true(rc == 0, "fcb_append call failure");
+		ztest_true(rc == 0, "fcb_append call failure");
 
 		rc = fcb_elem_info(fcb, &elem_loc);
-		zassert_true(rc == 0, "fcb_elem_info call failure");
-		zassert_true(elem_loc.fe_data_len == len,
+		ztest_true(rc == 0, "fcb_elem_info call failure");
+		ztest_true(elem_loc.fe_data_len == len,
 		"entry length fetched should match length of appended entry");
 }

--- a/tests/subsys/fs/fcb/src/fcb_test_empty_walk.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_empty_walk.c
@@ -15,5 +15,5 @@ void fcb_test_empty_walk(void)
 	fcb = &test_fcb;
 
 	rc = fcb_walk(fcb, 0, fcb_test_empty_walk_cb, NULL);
-	zassert_true(rc == 0, "fcb_walk call failure");
+	ztest_true(rc == 0, "fcb_walk call failure");
 }

--- a/tests/subsys/fs/fcb/src/fcb_test_init.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_init.c
@@ -16,19 +16,19 @@ void fcb_test_init(void)
 	(void)memset(fcb, 0, sizeof(*fcb));
 
 	rc = fcb_init(TEST_FCB_FLASH_AREA_ID, fcb);
-	zassert_true(rc == -EINVAL, "fcb_init call should fail");
+	ztest_true(rc == -EINVAL, "fcb_init call should fail");
 
 	fcb->f_sectors = test_fcb_sector;
 
 	rc = fcb_init(TEST_FCB_FLASH_AREA_ID, fcb);
-	zassert_true(rc == -EINVAL, "fcb_init call should fail");
+	ztest_true(rc == -EINVAL, "fcb_init call should fail");
 
 	fcb->f_sector_cnt = 2U;
 	fcb->f_magic = 0x12345678;
 	rc = fcb_init(TEST_FCB_FLASH_AREA_ID, fcb);
-	zassert_true(rc == -ENOMSG, "fcb_init call should fail");
+	ztest_true(rc == -ENOMSG, "fcb_init call should fail");
 
 	fcb->f_magic = 0U;
 	rc = fcb_init(TEST_FCB_FLASH_AREA_ID, fcb);
-	zassert_true(rc == 0,  "fcb_init call failure");
+	ztest_true(rc == 0,  "fcb_init call failure");
 }

--- a/tests/subsys/fs/fcb/src/fcb_test_last_of_n.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_last_of_n.c
@@ -22,7 +22,7 @@ void fcb_test_last_of_n(void)
 
 	/* No fcbs available */
 	rc = fcb_offset_last_n(fcb, 1, &loc);
-	zassert_true(rc != 0, "No fcbs available");
+	ztest_true(rc != 0, "No fcbs available");
 
 	/*
 	 * Add some fcbs.
@@ -35,42 +35,42 @@ void fcb_test_last_of_n(void)
 
 		rc = flash_area_write(fcb->fap, FCB_ENTRY_FA_DATA_OFF(loc),
 				      test_data, sizeof(test_data));
-		zassert_true(rc == 0, "flash_area_write call failure");
+		ztest_true(rc == 0, "flash_area_write call failure");
 
 		rc = fcb_append_finish(fcb, &loc);
-		zassert_true(rc == 0, "fcb_append_finish call failure");
+		ztest_true(rc == 0, "fcb_append_finish call failure");
 
 		areas[i] = loc;
 	}
 
 	/* last entry */
 	rc = fcb_offset_last_n(fcb, 1, &loc);
-	zassert_true(rc == 0, "fcb_offset_last_n call failure");
-	zassert_true(areas[4].fe_sector == loc.fe_sector &&
+	ztest_true(rc == 0, "fcb_offset_last_n call failure");
+	ztest_true(areas[4].fe_sector == loc.fe_sector &&
 		     areas[4].fe_data_off == loc.fe_data_off &&
 		     areas[4].fe_data_len == loc.fe_data_len,
 		     "fcb_offset_last_n: fetched wrong n-th location");
 
 	/* somewhere in the middle */
 	rc = fcb_offset_last_n(fcb, 3, &loc);
-	zassert_true(rc == 0, "fcb_offset_last_n call failure");
-	zassert_true(areas[2].fe_sector == loc.fe_sector &&
+	ztest_true(rc == 0, "fcb_offset_last_n call failure");
+	ztest_true(areas[2].fe_sector == loc.fe_sector &&
 		     areas[2].fe_data_off == loc.fe_data_off &&
 		     areas[2].fe_data_len == loc.fe_data_len,
 		     "fcb_offset_last_n: fetched wrong n-th location");
 
 	/* first entry */
 	rc = fcb_offset_last_n(fcb, 5, &loc);
-	zassert_true(rc == 0, "fcb_offset_last_n call failure");
-	zassert_true(areas[0].fe_sector == loc.fe_sector &&
+	ztest_true(rc == 0, "fcb_offset_last_n call failure");
+	ztest_true(areas[0].fe_sector == loc.fe_sector &&
 		     areas[0].fe_data_off == loc.fe_data_off &&
 		     areas[0].fe_data_len == loc.fe_data_len,
 		     "fcb_offset_last_n: fetched wrong n-th location");
 
 	/* after last valid entry, returns the first one like for 5 */
 	rc = fcb_offset_last_n(fcb, 6, &loc);
-	zassert_true(rc == 0, "fcb_offset_last_n call failure");
-	zassert_true(areas[0].fe_sector == loc.fe_sector &&
+	ztest_true(rc == 0, "fcb_offset_last_n call failure");
+	ztest_true(areas[0].fe_sector == loc.fe_sector &&
 		     areas[0].fe_data_off == loc.fe_data_off &&
 		     areas[0].fe_data_len == loc.fe_data_len,
 		     "fcb_offset_last_n: fetched wrong n-th location");

--- a/tests/subsys/fs/fcb/src/fcb_test_len.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_len.c
@@ -17,11 +17,11 @@ void fcb_test_len(void)
 
 	for (len = 0U; len < FCB_MAX_LEN; len++) {
 		rc = fcb_put_len(buf, len);
-		zassert_true(rc == 1 || rc == 2, "fcb_pull_len call failure");
+		ztest_true(rc == 1 || rc == 2, "fcb_pull_len call failure");
 
 		rc2 = fcb_get_len(buf, &len2);
-		zassert_true(rc2 == rc, "fcb_get_len call failure");
+		ztest_true(rc2 == rc, "fcb_get_len call failure");
 
-		zassert_true(len == len2, "fcb_get_len call failure");
+		ztest_true(len == len2, "fcb_get_len call failure");
 	}
 }

--- a/tests/subsys/fs/fcb/src/fcb_test_multiple_scratch.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_multiple_scratch.c
@@ -38,23 +38,23 @@ void fcb_test_multi_scratch(void)
 
 		rc = flash_area_write(fcb->fap, FCB_ENTRY_FA_DATA_OFF(loc),
 				      test_data, sizeof(test_data));
-		zassert_true(rc == 0, "flash_area_write call failure");
+		ztest_true(rc == 0, "flash_area_write call failure");
 
 		rc = fcb_append_finish(fcb, &loc);
-		zassert_true(rc == 0, "fcb_append_finish call failure");
+		ztest_true(rc == 0, "fcb_append_finish call failure");
 	}
 
-	zassert_true(elem_cnts[0] > 0, "unexpected entry number was appended");
-	zassert_true(elem_cnts[0] == elem_cnts[1] &&
+	ztest_true(elem_cnts[0] > 0, "unexpected entry number was appended");
+	ztest_true(elem_cnts[0] == elem_cnts[1] &&
 		     elem_cnts[0] == elem_cnts[2],
 		     "unexpected entry number was appended");
-	zassert_true(elem_cnts[3] == 0, "unexpected entry number was appended");
+	ztest_true(elem_cnts[3] == 0, "unexpected entry number was appended");
 
 	/*
 	 * Ask to use scratch block, then fill it up.
 	 */
 	rc = fcb_append_to_scratch(fcb);
-	zassert_true(rc == 0, "fcb_append_to_scratch call failure");
+	ztest_true(rc == 0, "fcb_append_to_scratch call failure");
 
 	while (1) {
 		rc = fcb_append(fcb, sizeof(test_data), &loc);
@@ -66,31 +66,31 @@ void fcb_test_multi_scratch(void)
 
 		rc = flash_area_write(fcb->fap, FCB_ENTRY_FA_DATA_OFF(loc),
 				      test_data, sizeof(test_data));
-		zassert_true(rc == 0, "flash_area_write call failure");
+		ztest_true(rc == 0, "flash_area_write call failure");
 
 		rc = fcb_append_finish(fcb, &loc);
-		zassert_true(rc == 0, "fcb_append_finish call failure");
+		ztest_true(rc == 0, "fcb_append_finish call failure");
 	}
-	zassert_true(elem_cnts[3] == elem_cnts[0],
+	ztest_true(elem_cnts[3] == elem_cnts[0],
 		     "unexpected entry number was appended");
 
 	/*
 	 * Rotate
 	 */
 	rc = fcb_rotate(fcb);
-	zassert_true(rc == 0, "fcb_rotate call failure");
+	ztest_true(rc == 0, "fcb_rotate call failure");
 
 	(void)memset(&cnts, 0, sizeof(cnts));
 	rc = fcb_walk(fcb, NULL, fcb_test_cnt_elems_cb, &aa_arg);
-	zassert_true(rc == 0, "fcb_walk call failure");
+	ztest_true(rc == 0, "fcb_walk call failure");
 
-	zassert_true(cnts[0] == 0, "unexpected entry count");
-	zassert_true(cnts[1] > 0, "unexpected entry count");
-	zassert_true(cnts[1] == cnts[2] && cnts[1] == cnts[3],
+	ztest_true(cnts[0] == 0, "unexpected entry count");
+	ztest_true(cnts[1] > 0, "unexpected entry count");
+	ztest_true(cnts[1] == cnts[2] && cnts[1] == cnts[3],
 		     "unexpected entry count");
 
 	rc = fcb_append_to_scratch(fcb);
-	zassert_true(rc == 0, "fcb_append_to_scratch call failure");
+	ztest_true(rc == 0, "fcb_append_to_scratch call failure");
 	rc = fcb_append_to_scratch(fcb);
-	zassert_true(rc != 0, "fcb_append_to_scratch call should fail");
+	ztest_true(rc != 0, "fcb_append_to_scratch call should fail");
 }

--- a/tests/subsys/fs/fcb/src/fcb_test_reset.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_reset.c
@@ -20,20 +20,20 @@ void fcb_test_reset(void)
 
 	var_cnt = 0;
 	rc = fcb_walk(fcb, 0, fcb_test_data_walk_cb, &var_cnt);
-	zassert_true(rc == 0, "fcb_walk call failure");
-	zassert_true(var_cnt == 0,
+	ztest_true(rc == 0, "fcb_walk call failure");
+	ztest_true(var_cnt == 0,
 		     "fcb_walk: elements count read different than expected");
 
 	rc = fcb_append(fcb, 32, &loc);
-	zassert_true(rc == 0, "fcb_append call failure");
+	ztest_true(rc == 0, "fcb_append call failure");
 
 	/*
 	 * No ready ones yet. CRC should not match.
 	 */
 	var_cnt = 0;
 	rc = fcb_walk(fcb, 0, fcb_test_data_walk_cb, &var_cnt);
-	zassert_true(rc == 0, "fcb_walk call failure");
-	zassert_true(var_cnt == 0,
+	ztest_true(rc == 0, "fcb_walk call failure");
+	ztest_true(var_cnt == 0,
 		     "fcb_walk: elements count read different than expected");
 
 	for (i = 0; i < sizeof(test_data); i++) {
@@ -41,18 +41,18 @@ void fcb_test_reset(void)
 	}
 	rc = flash_area_write(fcb->fap, FCB_ENTRY_FA_DATA_OFF(loc), test_data,
 			      32);
-	zassert_true(rc == 0, "flash_area_write call failure");
+	ztest_true(rc == 0, "flash_area_write call failure");
 
 	rc = fcb_append_finish(fcb, &loc);
-	zassert_true(rc == 0, "fcb_append_finish call failure");
+	ztest_true(rc == 0, "fcb_append_finish call failure");
 
 	/*
 	 * one entry
 	 */
 	var_cnt = 32;
 	rc = fcb_walk(fcb, 0, fcb_test_data_walk_cb, &var_cnt);
-	zassert_true(rc == 0, "fcb_walk call failure");
-	zassert_true(var_cnt == 33,
+	ztest_true(rc == 0, "fcb_walk call failure");
+	ztest_true(var_cnt == 33,
 		     "fcb_walk: elements count read different than expected");
 
 	/*
@@ -63,75 +63,75 @@ void fcb_test_reset(void)
 	fcb->f_sectors = test_fcb_sector;
 
 	rc = fcb_init(TEST_FCB_FLASH_AREA_ID, fcb);
-	zassert_true(rc == 0, "fcb_init call failure");
+	ztest_true(rc == 0, "fcb_init call failure");
 
 	var_cnt = 32;
 	rc = fcb_walk(fcb, 0, fcb_test_data_walk_cb, &var_cnt);
-	zassert_true(rc == 0, "fcb_walk call failure");
-	zassert_true(var_cnt == 33,
+	ztest_true(rc == 0, "fcb_walk call failure");
+	ztest_true(var_cnt == 33,
 		     "fcb_walk: elements count read different than expected");
 
 	rc = fcb_append(fcb, 33, &loc);
-	zassert_true(rc == 0, "fcb_append call failure");
+	ztest_true(rc == 0, "fcb_append call failure");
 
 	for (i = 0; i < sizeof(test_data); i++) {
 		test_data[i] = fcb_test_append_data(33, i);
 	}
 	rc = flash_area_write(fcb->fap, FCB_ENTRY_FA_DATA_OFF(loc), test_data,
 			      33);
-	zassert_true(rc == 0, "flash_area_write call failure");
+	ztest_true(rc == 0, "flash_area_write call failure");
 
 	rc = fcb_append_finish(fcb, &loc);
-	zassert_true(rc == 0, "fcb_append_finish call failure");
+	ztest_true(rc == 0, "fcb_append_finish call failure");
 
 	var_cnt = 32;
 	rc = fcb_walk(fcb, 0, fcb_test_data_walk_cb, &var_cnt);
-	zassert_true(rc == 0, "fcb_walk call failure");
-	zassert_true(var_cnt == 34,
+	ztest_true(rc == 0, "fcb_walk call failure");
+	ztest_true(var_cnt == 34,
 		     "fcb_walk: elements count read different than expected");
 
 	/*
 	 * Add partial one, make sure that we survive reset then.
 	 */
 	rc = fcb_append(fcb, 34, &loc);
-	zassert_true(rc == 0, "fcb_append call failure");
+	ztest_true(rc == 0, "fcb_append call failure");
 
 	(void)memset(fcb, 0, sizeof(*fcb));
 	fcb->f_sector_cnt = 2U;
 	fcb->f_sectors = test_fcb_sector;
 
 	rc = fcb_init(TEST_FCB_FLASH_AREA_ID, fcb);
-	zassert_true(rc == 0, "fcb_init call failure");
+	ztest_true(rc == 0, "fcb_init call failure");
 
 	/*
 	 * Walk should skip that.
 	 */
 	var_cnt = 32;
 	rc = fcb_walk(fcb, 0, fcb_test_data_walk_cb, &var_cnt);
-	zassert_true(rc == 0, "fcb_walk call failure");
-	zassert_true(var_cnt == 34,
+	ztest_true(rc == 0, "fcb_walk call failure");
+	ztest_true(var_cnt == 34,
 		     "fcb_walk: elements count read different than expected");
 
 	/* Add a 3rd one, should go behind corrupt entry */
 	rc = fcb_append(fcb, 34, &loc);
-	zassert_true(rc == 0, "fcb_append call failure");
+	ztest_true(rc == 0, "fcb_append call failure");
 
 	for (i = 0; i < sizeof(test_data); i++) {
 		test_data[i] = fcb_test_append_data(34, i);
 	}
 	rc = flash_area_write(fcb->fap, FCB_ENTRY_FA_DATA_OFF(loc), test_data,
 			      34);
-	zassert_true(rc == 0, "flash_area_write call failure");
+	ztest_true(rc == 0, "flash_area_write call failure");
 
 	rc = fcb_append_finish(fcb, &loc);
-	zassert_true(rc == 0, "fcb_append_finish call failure");
+	ztest_true(rc == 0, "fcb_append_finish call failure");
 
 	/*
 	 * Walk should skip corrupt entry, but report the next one.
 	 */
 	var_cnt = 32;
 	rc = fcb_walk(fcb, 0, fcb_test_data_walk_cb, &var_cnt);
-	zassert_true(rc == 0, "fcb_walk call failure");
-	zassert_true(var_cnt == 35,
+	ztest_true(rc == 0, "fcb_walk call failure");
+	ztest_true(var_cnt == 35,
 		     "fcb_walk: elements count read different than expected");
 }

--- a/tests/subsys/fs/fcb/src/fcb_test_rotate.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_rotate.c
@@ -24,8 +24,8 @@ void fcb_test_rotate(void)
 
 	old_id = fcb->f_active_id;
 	rc = fcb_rotate(fcb);
-	zassert_true(rc == 0, "fcb_rotate call failure");
-	zassert_true(fcb->f_active_id == old_id + 1,
+	ztest_true(rc == 0, "fcb_rotate call failure");
+	ztest_true(fcb->f_active_id == old_id + 1,
 		     "flash location id should increased");
 
 	/*
@@ -41,59 +41,59 @@ void fcb_test_rotate(void)
 		} else if (loc.fe_sector == &test_fcb_sector[1]) {
 			elem_cnts[1]++;
 		} else {
-			zassert_true(0,
+			ztest_true(0,
 				     "unexpected flash area of appended loc");
 		}
 
 		rc = flash_area_write(fcb->fap, FCB_ENTRY_FA_DATA_OFF(loc),
 				      test_data, sizeof(test_data));
-		zassert_true(rc == 0, "flash_area_write call failure");
+		ztest_true(rc == 0, "flash_area_write call failure");
 
 		rc = fcb_append_finish(fcb, &loc);
-		zassert_true(rc == 0, "fcb_append_finish call failure");
+		ztest_true(rc == 0, "fcb_append_finish call failure");
 	}
-	zassert_true(elem_cnts[0] > 0 && elem_cnts[0] == elem_cnts[1],
+	ztest_true(elem_cnts[0] > 0 && elem_cnts[0] == elem_cnts[1],
 		     "unexpected entry number was appended");
 
 	old_id = fcb->f_active_id;
 	rc = fcb_rotate(fcb);
-	zassert_true(rc == 0, "fcb_rotate call failure");
-	zassert_true(fcb->f_active_id == old_id,
+	ztest_true(rc == 0, "fcb_rotate call failure");
+	ztest_true(fcb->f_active_id == old_id,
 		     "flash location should be kept");
 
 	(void)memset(cnts, 0, sizeof(cnts));
 	rc = fcb_walk(fcb, NULL, fcb_test_cnt_elems_cb, &aa_arg);
-	zassert_true(rc == 0, "fcb_walk call failure");
-	zassert_true(aa_arg.elem_cnts[0] == elem_cnts[0] ||
+	ztest_true(rc == 0, "fcb_walk call failure");
+	ztest_true(aa_arg.elem_cnts[0] == elem_cnts[0] ||
 		     aa_arg.elem_cnts[1] == elem_cnts[1],
 		     "fcb_walk: entry count got different than expected");
-	zassert_true(aa_arg.elem_cnts[0] == 0 || aa_arg.elem_cnts[1] == 0,
+	ztest_true(aa_arg.elem_cnts[0] == 0 || aa_arg.elem_cnts[1] == 0,
 		     "fcb_walk: entry count got different than expected");
 
 	/*
 	 * One sector is full. The other one should have one entry in it.
 	 */
 	rc = fcb_append(fcb, sizeof(test_data), &loc);
-	zassert_true(rc == 0, "fcb_append call failure");
+	ztest_true(rc == 0, "fcb_append call failure");
 
 	rc = flash_area_write(fcb->fap, FCB_ENTRY_FA_DATA_OFF(loc), test_data,
 			      sizeof(test_data));
-	zassert_true(rc == 0, "flash_area_write call failure");
+	ztest_true(rc == 0, "flash_area_write call failure");
 
 	rc = fcb_append_finish(fcb, &loc);
-	zassert_true(rc == 0, "fcb_append_finish call failure");
+	ztest_true(rc == 0, "fcb_append_finish call failure");
 
 	old_id = fcb->f_active_id;
 	rc = fcb_rotate(fcb);
-	zassert_true(rc == 0, "fcb_rotate call failure");
-	zassert_true(fcb->f_active_id == old_id,
+	ztest_true(rc == 0, "fcb_rotate call failure");
+	ztest_true(fcb->f_active_id == old_id,
 		     "flash location should be kept");
 
 	(void)memset(cnts, 0, sizeof(cnts));
 	rc = fcb_walk(fcb, NULL, fcb_test_cnt_elems_cb, &aa_arg);
-	zassert_true(rc == 0, "fcb_walk call failure");
-	zassert_true(aa_arg.elem_cnts[0] == 1 || aa_arg.elem_cnts[1] == 1,
+	ztest_true(rc == 0, "fcb_walk call failure");
+	ztest_true(aa_arg.elem_cnts[0] == 1 || aa_arg.elem_cnts[1] == 1,
 		     "fcb_walk: entry count got different than expected");
-	zassert_true(aa_arg.elem_cnts[0] == 0 || aa_arg.elem_cnts[1] == 0,
+	ztest_true(aa_arg.elem_cnts[0] == 0 || aa_arg.elem_cnts[1] == 0,
 		     "fcb_walk: entry count got different than expected");
 }

--- a/tests/subsys/fs/fcb/src/main.c
+++ b/tests/subsys/fs/fcb/src/main.c
@@ -44,18 +44,18 @@ void fcb_test_wipe(void)
 	const struct flash_area *fap;
 
 	rc = flash_area_open(TEST_FCB_FLASH_AREA_ID, &fap);
-	zassert_true(rc == 0, "flash area open call failure");
+	ztest_true(rc == 0, "flash area open call failure");
 
 	for (i = 0; i < ARRAY_SIZE(test_fcb_sector); i++) {
 		rc = flash_area_erase(fap, test_fcb_sector[i].fs_off,
 				      test_fcb_sector[i].fs_size);
-		zassert_true(rc == 0, "erase call failure");
+		ztest_true(rc == 0, "erase call failure");
 	}
 }
 
 int fcb_test_empty_walk_cb(struct fcb_entry_ctx *entry_ctx, void *arg)
 {
-	zassert_unreachable("fcb_test_empty_walk_cb");
+	ztest_unreachable("fcb_test_empty_walk_cb");
 	return 0;
 }
 
@@ -74,15 +74,15 @@ int fcb_test_data_walk_cb(struct fcb_entry_ctx *entry_ctx, void *arg)
 
 	len = entry_ctx->loc.fe_data_len;
 
-	zassert_true(len == *var_cnt, "");
+	ztest_true(len == *var_cnt, "");
 
 	rc = flash_area_read(entry_ctx->fap,
 			     FCB_ENTRY_FA_DATA_OFF(entry_ctx->loc),
 			     test_data, len);
-	zassert_true(rc == 0, "read call failure");
+	ztest_true(rc == 0, "read call failure");
 
 	for (i = 0; i < len; i++) {
-		zassert_true(test_data[i] == fcb_test_append_data(len, i),
+		ztest_true(test_data[i] == fcb_test_append_data(len, i),
 		"fcb_test_append_data redout misrepresentation");
 	}
 	(*var_cnt)++;
@@ -114,7 +114,7 @@ void fcb_tc_pretest(int sectors)
 	rc = fcb_init(TEST_FCB_FLASH_AREA_ID, fcb);
 	if (rc != 0) {
 		printf("%s rc == %xm, %d\n", __func__, rc, rc);
-		zassert_true(rc == 0, "fbc initialization failure");
+		ztest_true(rc == 0, "fbc initialization failure");
 	}
 }
 

--- a/tests/subsys/fs/littlefs/src/test_lfs_basic.c
+++ b/tests/subsys/fs/littlefs/src/test_lfs_basic.c
@@ -31,7 +31,7 @@ static int mount(struct fs_mount_t *mp)
 {
 	TC_PRINT("mounting %s\n", mp->mnt_point);
 
-	zassert_equal(fs_mount(mp), 0,
+	ztest_equal(fs_mount(mp), 0,
 		      "mount failed");
 
 	return TC_PASS;
@@ -41,7 +41,7 @@ static int clear_partition(struct fs_mount_t *mp)
 {
 	TC_PRINT("clearing partition %s\n", mp->mnt_point);
 
-	zassert_equal(testfs_lfs_wipe_partition(mp),
+	ztest_equal(testfs_lfs_wipe_partition(mp),
 		      TC_PASS,
 		      "failed to wipe partition");
 
@@ -54,19 +54,19 @@ static int clean_statvfs(const struct fs_mount_t *mp)
 
 	TC_PRINT("checking clean statvfs of %s\n", mp->mnt_point);
 
-	zassert_equal(fs_statvfs(mp->mnt_point, &stat), 0,
+	ztest_equal(fs_statvfs(mp->mnt_point, &stat), 0,
 		      "statvfs failed");
 
 	TC_PRINT("%s: bsize %lu ; frsize %lu ; blocks %lu ; bfree %lu\n",
 		 mp->mnt_point,
 		 stat.f_bsize, stat.f_frsize, stat.f_blocks, stat.f_bfree);
-	zassert_equal(stat.f_bsize, 16,
+	ztest_equal(stat.f_bsize, 16,
 		      "bsize fail");
-	zassert_equal(stat.f_frsize, 4096,
+	ztest_equal(stat.f_frsize, 4096,
 		      "frsize fail");
-	zassert_equal(stat.f_blocks, 16,
+	ztest_equal(stat.f_blocks, 16,
 		      "blocks fail");
-	zassert_equal(stat.f_bfree, stat.f_blocks - 2U,
+	ztest_equal(stat.f_bfree, stat.f_blocks - 2U,
 		      "bfree fail");
 
 	return TC_PASS;
@@ -79,7 +79,7 @@ static int create_write_hello(const struct fs_mount_t *mp)
 
 	TC_PRINT("creating and writing file\n");
 
-	zassert_equal(fs_open(&file,
+	ztest_equal(fs_open(&file,
 			      testfs_path_init(&path, mp,
 					       HELLO,
 					       TESTFS_PATH_END)),
@@ -88,28 +88,28 @@ static int create_write_hello(const struct fs_mount_t *mp)
 
 	struct fs_dirent stat;
 
-	zassert_equal(fs_stat(path.path, &stat),
+	ztest_equal(fs_stat(path.path, &stat),
 		      0,
 		      "stat new hello failed");
 
-	zassert_equal(stat.type, FS_DIR_ENTRY_FILE,
+	ztest_equal(stat.type, FS_DIR_ENTRY_FILE,
 		      "stat new hello not file");
-	zassert_equal(strcmp(stat.name, HELLO), 0,
+	ztest_equal(strcmp(stat.name, HELLO), 0,
 		      "stat new hello not hello");
-	zassert_equal(stat.size, 0,
+	ztest_equal(stat.size, 0,
 		      "stat new hello not empty");
 
-	zassert_equal(testfs_write_incrementing(&file, 0, TESTFS_BUFFER_SIZE),
+	ztest_equal(testfs_write_incrementing(&file, 0, TESTFS_BUFFER_SIZE),
 		      TESTFS_BUFFER_SIZE,
 		      "write constant failed");
 
-	zassert_equal(fs_stat(path.path, &stat),
+	ztest_equal(fs_stat(path.path, &stat),
 		      0,
 		      "stat written hello failed");
 
-	zassert_equal(stat.type, FS_DIR_ENTRY_FILE,
+	ztest_equal(stat.type, FS_DIR_ENTRY_FILE,
 		      "stat written hello not file");
-	zassert_equal(strcmp(stat.name, HELLO), 0,
+	ztest_equal(strcmp(stat.name, HELLO), 0,
 		      "stat written hello not hello");
 
 	/* Anomalous behavior requiring upstream response */
@@ -117,22 +117,22 @@ static int create_write_hello(const struct fs_mount_t *mp)
 		/* VARIATION POINT: littlefs does not update the file size of
 		 * an open file.  See upstream issue #250.
 		 */
-		zassert_equal(stat.size, 0,
+		ztest_equal(stat.size, 0,
 			      "stat written hello bad size");
 	}
 
-	zassert_equal(fs_close(&file), 0,
+	ztest_equal(fs_close(&file), 0,
 		      "close hello failed");
 
-	zassert_equal(fs_stat(path.path, &stat),
+	ztest_equal(fs_stat(path.path, &stat),
 		      0,
 		      "stat closed hello failed");
 
-	zassert_equal(stat.type, FS_DIR_ENTRY_FILE,
+	ztest_equal(stat.type, FS_DIR_ENTRY_FILE,
 		      "stat closed hello not file");
-	zassert_equal(strcmp(stat.name, HELLO), 0,
+	ztest_equal(strcmp(stat.name, HELLO), 0,
 		      "stat closed hello not hello");
-	zassert_equal(stat.size, TESTFS_BUFFER_SIZE,
+	ztest_equal(stat.size, TESTFS_BUFFER_SIZE,
 		      "stat closed hello badsize");
 
 	return TC_PASS;
@@ -145,24 +145,24 @@ static int verify_hello(const struct fs_mount_t *mp)
 
 	TC_PRINT("opening and verifying file\n");
 
-	zassert_equal(fs_open(&file,
+	ztest_equal(fs_open(&file,
 			      testfs_path_init(&path, mp,
 					       HELLO,
 					       TESTFS_PATH_END)),
 		      0,
 		      "verify hello open failed");
 
-	zassert_equal(fs_tell(&file), 0U,
+	ztest_equal(fs_tell(&file), 0U,
 		      "verify hello open tell failed");
 
-	zassert_equal(testfs_verify_incrementing(&file, 0, TESTFS_BUFFER_SIZE),
+	ztest_equal(testfs_verify_incrementing(&file, 0, TESTFS_BUFFER_SIZE),
 		      TESTFS_BUFFER_SIZE,
 		      "verify hello at start failed");
 
-	zassert_equal(fs_tell(&file), TESTFS_BUFFER_SIZE,
+	ztest_equal(fs_tell(&file), TESTFS_BUFFER_SIZE,
 		      "verify hello read tell failed");
 
-	zassert_equal(fs_close(&file), 0,
+	ztest_equal(fs_close(&file), 0,
 		      "verify close hello failed");
 
 	return TC_PASS;
@@ -175,60 +175,60 @@ static int seek_within_hello(const struct fs_mount_t *mp)
 
 	TC_PRINT("seek and tell in file\n");
 
-	zassert_equal(fs_open(&file,
+	ztest_equal(fs_open(&file,
 			      testfs_path_init(&path, mp,
 					       HELLO,
 					       TESTFS_PATH_END)),
 		      0,
 		      "verify hello open failed");
 
-	zassert_equal(fs_tell(&file), 0U,
+	ztest_equal(fs_tell(&file), 0U,
 		      "verify hello open tell failed");
 
 	struct fs_dirent stat;
 
-	zassert_equal(fs_stat(path.path, &stat),
+	ztest_equal(fs_stat(path.path, &stat),
 		      0,
 		      "stat old hello failed");
-	zassert_equal(stat.size, TESTFS_BUFFER_SIZE,
+	ztest_equal(stat.size, TESTFS_BUFFER_SIZE,
 		      "stat old hello bad size");
 
 	off_t pos = stat.size / 4;
 
-	zassert_equal(fs_seek(&file, pos, FS_SEEK_SET),
+	ztest_equal(fs_seek(&file, pos, FS_SEEK_SET),
 		      0,
 		      "verify hello seek near mid failed");
 
-	zassert_equal(fs_tell(&file), pos,
+	ztest_equal(fs_tell(&file), pos,
 		      "verify hello tell near mid failed");
 
-	zassert_equal(testfs_verify_incrementing(&file, pos, TESTFS_BUFFER_SIZE),
+	ztest_equal(testfs_verify_incrementing(&file, pos, TESTFS_BUFFER_SIZE),
 		      TESTFS_BUFFER_SIZE - pos,
 		      "verify hello at middle failed");
 
-	zassert_equal(fs_tell(&file), stat.size,
+	ztest_equal(fs_tell(&file), stat.size,
 		      "verify hello read middle tell failed");
 
-	zassert_equal(fs_seek(&file, -stat.size, FS_SEEK_CUR),
+	ztest_equal(fs_seek(&file, -stat.size, FS_SEEK_CUR),
 		      0,
 		      "verify hello seek back from cur failed");
 
-	zassert_equal(fs_tell(&file), 0U,
+	ztest_equal(fs_tell(&file), 0U,
 		      "verify hello tell back from cur failed");
 
-	zassert_equal(fs_seek(&file, -pos, FS_SEEK_END),
+	ztest_equal(fs_seek(&file, -pos, FS_SEEK_END),
 		      0,
 		      "verify hello seek from end failed");
 
-	zassert_equal(fs_tell(&file), stat.size - pos,
+	ztest_equal(fs_tell(&file), stat.size - pos,
 		      "verify hello tell from end failed");
 
-	zassert_equal(testfs_verify_incrementing(&file, stat.size - pos,
+	ztest_equal(testfs_verify_incrementing(&file, stat.size - pos,
 						 TESTFS_BUFFER_SIZE),
 		      pos,
 		      "verify hello at post middle failed");
 
-	zassert_equal(fs_close(&file), 0,
+	ztest_equal(fs_close(&file), 0,
 		      "verify close hello failed");
 
 	return TC_PASS;
@@ -241,7 +241,7 @@ static int truncate_hello(const struct fs_mount_t *mp)
 
 	TC_PRINT("truncate in file\n");
 
-	zassert_equal(fs_open(&file,
+	ztest_equal(fs_open(&file,
 			      testfs_path_init(&path, mp,
 					       HELLO,
 					       TESTFS_PATH_END)),
@@ -250,25 +250,25 @@ static int truncate_hello(const struct fs_mount_t *mp)
 
 	struct fs_dirent stat;
 
-	zassert_equal(fs_stat(path.path, &stat),
+	ztest_equal(fs_stat(path.path, &stat),
 		      0,
 		      "stat old hello failed");
-	zassert_equal(stat.size, TESTFS_BUFFER_SIZE,
+	ztest_equal(stat.size, TESTFS_BUFFER_SIZE,
 		      "stat old hello bad size");
 
 	off_t pos = 3 * stat.size / 4;
 
-	zassert_equal(fs_tell(&file), 0U,
+	ztest_equal(fs_tell(&file), 0U,
 		      "truncate initial tell failed");
 
-	zassert_equal(fs_truncate(&file, pos),
+	ztest_equal(fs_truncate(&file, pos),
 		      0,
 		      "truncate 3/4 failed");
 
-	zassert_equal(fs_tell(&file), 0U,
+	ztest_equal(fs_tell(&file), 0U,
 		      "truncate post tell failed");
 
-	zassert_equal(fs_stat(path.path, &stat),
+	ztest_equal(fs_stat(path.path, &stat),
 		      0,
 		      "stat open 3/4 failed");
 
@@ -277,22 +277,22 @@ static int truncate_hello(const struct fs_mount_t *mp)
 		/* VARIATION POINT: littlefs does not update the file size of
 		 * an open file.  See upstream issue #250.
 		 */
-		zassert_equal(stat.size, TESTFS_BUFFER_SIZE,
+		ztest_equal(stat.size, TESTFS_BUFFER_SIZE,
 			      "stat open 3/4 bad size");
 	}
 
-	zassert_equal(testfs_verify_incrementing(&file, 0, 64),
+	ztest_equal(testfs_verify_incrementing(&file, 0, 64),
 		      48,
 		      "post truncate content unexpected");
 
-	zassert_equal(fs_close(&file), 0,
+	ztest_equal(fs_close(&file), 0,
 		      "post truncate close failed");
 
 	/* After close size is correct. */
-	zassert_equal(fs_stat(path.path, &stat),
+	ztest_equal(fs_stat(path.path, &stat),
 		      0,
 		      "stat closed truncated failed");
-	zassert_equal(stat.size, pos,
+	ztest_equal(stat.size, pos,
 		      "stat closed truncated bad size");
 
 	return TC_PASS;
@@ -310,13 +310,13 @@ static int unlink_hello(const struct fs_mount_t *mp)
 
 	struct fs_dirent stat;
 
-	zassert_equal(fs_stat(path.path, &stat),
+	ztest_equal(fs_stat(path.path, &stat),
 		      0,
 		      "stat existing hello failed");
-	zassert_equal(fs_unlink(path.path),
+	ztest_equal(fs_unlink(path.path),
 		      0,
 		      "unlink hello failed");
-	zassert_equal(fs_stat(path.path, &stat),
+	ztest_equal(fs_stat(path.path, &stat),
 		      -ENOENT,
 		      "stat existing hello failed");
 
@@ -330,7 +330,7 @@ static int sync_goodbye(const struct fs_mount_t *mp)
 
 	TC_PRINT("sync goodbye\n");
 
-	zassert_equal(fs_open(&file,
+	ztest_equal(fs_open(&file,
 			      testfs_path_init(&path, mp,
 					       GOODBYE,
 					       TESTFS_PATH_END)),
@@ -339,47 +339,47 @@ static int sync_goodbye(const struct fs_mount_t *mp)
 
 	struct fs_dirent stat;
 
-	zassert_equal(fs_stat(path.path, &stat),
+	ztest_equal(fs_stat(path.path, &stat),
 		      0,
 		      "stat existing hello failed");
-	zassert_equal(stat.size, 0,
+	ztest_equal(stat.size, 0,
 		      "stat new goodbye not empty");
 
-	zassert_equal(testfs_write_incrementing(&file, 0, TESTFS_BUFFER_SIZE),
+	ztest_equal(testfs_write_incrementing(&file, 0, TESTFS_BUFFER_SIZE),
 		      TESTFS_BUFFER_SIZE,
 		      "write goodbye failed");
 
-	zassert_equal(fs_tell(&file), TESTFS_BUFFER_SIZE,
+	ztest_equal(fs_tell(&file), TESTFS_BUFFER_SIZE,
 		      "tell goodbye failed");
 
 	if (true) {
 		/* Upstream issue #250 */
-		zassert_equal(stat.size, 0,
+		ztest_equal(stat.size, 0,
 			      "stat new goodbye not empty");
 	}
 
-	zassert_equal(fs_sync(&file), 0,
+	ztest_equal(fs_sync(&file), 0,
 		      "sync goodbye failed");
 
-	zassert_equal(fs_tell(&file), TESTFS_BUFFER_SIZE,
+	ztest_equal(fs_tell(&file), TESTFS_BUFFER_SIZE,
 		      "tell synced moved");
 
-	zassert_equal(fs_stat(path.path, &stat),
+	ztest_equal(fs_stat(path.path, &stat),
 		      0,
 		      "stat existing hello failed");
 	printk("sync size %u\n", (u32_t)stat.size);
 
-	zassert_equal(stat.size, TESTFS_BUFFER_SIZE,
+	ztest_equal(stat.size, TESTFS_BUFFER_SIZE,
 		      "stat synced goodbye not correct");
 
-	zassert_equal(fs_close(&file), 0,
+	ztest_equal(fs_close(&file), 0,
 		      "post sync close failed");
 
 	/* After close size is correct. */
-	zassert_equal(fs_stat(path.path, &stat),
+	ztest_equal(fs_stat(path.path, &stat),
 		      0,
 		      "stat sync failed");
-	zassert_equal(stat.size, TESTFS_BUFFER_SIZE,
+	ztest_equal(stat.size, TESTFS_BUFFER_SIZE,
 		      "stat sync bad size");
 
 	return TC_PASS;
@@ -392,18 +392,18 @@ static int verify_goodbye(const struct fs_mount_t *mp)
 
 	TC_PRINT("verify goodbye\n");
 
-	zassert_equal(fs_open(&file,
+	ztest_equal(fs_open(&file,
 			      testfs_path_init(&path, mp,
 					       GOODBYE,
 					       TESTFS_PATH_END)),
 		      0,
 		      "verify goodbye failed");
 
-	zassert_equal(testfs_verify_incrementing(&file, 0, TESTFS_BUFFER_SIZE),
+	ztest_equal(testfs_verify_incrementing(&file, 0, TESTFS_BUFFER_SIZE),
 		      TESTFS_BUFFER_SIZE,
 		      "write goodbye failed");
 
-	zassert_equal(fs_close(&file), 0,
+	ztest_equal(fs_close(&file), 0,
 		      "post sync close failed");
 
 	return TC_PASS;
@@ -414,28 +414,28 @@ static int check_medium(void)
 	struct fs_mount_t *mp = &testfs_medium_mnt;
 	struct fs_statvfs stat;
 
-	zassert_equal(clear_partition(mp), TC_PASS,
+	ztest_equal(clear_partition(mp), TC_PASS,
 		      "clear partition failed");
 
-	zassert_equal(fs_mount(mp), 0,
+	ztest_equal(fs_mount(mp), 0,
 		      "medium mount failed");
 
-	zassert_equal(fs_statvfs(mp->mnt_point, &stat), 0,
+	ztest_equal(fs_statvfs(mp->mnt_point, &stat), 0,
 		      "statvfs failed");
 
 	TC_PRINT("%s: bsize %lu ; frsize %lu ; blocks %lu ; bfree %lu\n",
 		 mp->mnt_point,
 		 stat.f_bsize, stat.f_frsize, stat.f_blocks, stat.f_bfree);
-	zassert_equal(stat.f_bsize, MEDIUM_IO_SIZE,
+	ztest_equal(stat.f_bsize, MEDIUM_IO_SIZE,
 		      "bsize fail");
-	zassert_equal(stat.f_frsize, 4096,
+	ztest_equal(stat.f_frsize, 4096,
 		      "frsize fail");
-	zassert_equal(stat.f_blocks, 240,
+	ztest_equal(stat.f_blocks, 240,
 		      "blocks fail");
-	zassert_equal(stat.f_bfree, stat.f_blocks - 2U,
+	ztest_equal(stat.f_bfree, stat.f_blocks - 2U,
 		      "bfree fail");
 
-	zassert_equal(fs_unmount(mp), 0,
+	ztest_equal(fs_unmount(mp), 0,
 		      "medium unmount failed");
 
 	return TC_PASS;
@@ -446,28 +446,28 @@ static int check_large(void)
 	struct fs_mount_t *mp = &testfs_large_mnt;
 	struct fs_statvfs stat;
 
-	zassert_equal(clear_partition(mp), TC_PASS,
+	ztest_equal(clear_partition(mp), TC_PASS,
 		      "clear partition failed");
 
-	zassert_equal(fs_mount(mp), 0,
+	ztest_equal(fs_mount(mp), 0,
 		      "large mount failed");
 
-	zassert_equal(fs_statvfs(mp->mnt_point, &stat), 0,
+	ztest_equal(fs_statvfs(mp->mnt_point, &stat), 0,
 		      "statvfs failed");
 
 	TC_PRINT("%s: bsize %lu ; frsize %lu ; blocks %lu ; bfree %lu\n",
 		 mp->mnt_point,
 		 stat.f_bsize, stat.f_frsize, stat.f_blocks, stat.f_bfree);
-	zassert_equal(stat.f_bsize, LARGE_IO_SIZE,
+	ztest_equal(stat.f_bsize, LARGE_IO_SIZE,
 		      "bsize fail");
-	zassert_equal(stat.f_frsize, 32768,
+	ztest_equal(stat.f_frsize, 32768,
 		      "frsize fail");
-	zassert_equal(stat.f_blocks, 96,
+	ztest_equal(stat.f_blocks, 96,
 		      "blocks fail");
-	zassert_equal(stat.f_bfree, stat.f_blocks - 2U,
+	ztest_equal(stat.f_bfree, stat.f_blocks - 2U,
 		      "bfree fail");
 
-	zassert_equal(fs_unmount(mp), 0,
+	ztest_equal(fs_unmount(mp), 0,
 		      "large unmount failed");
 
 	return TC_PASS;
@@ -477,55 +477,55 @@ void test_lfs_basic(void)
 {
 	struct fs_mount_t *mp = &testfs_small_mnt;
 
-	zassert_equal(clear_partition(mp), TC_PASS,
+	ztest_equal(clear_partition(mp), TC_PASS,
 		      "clear partition failed");
 
-	zassert_equal(mount(mp), TC_PASS,
+	ztest_equal(mount(mp), TC_PASS,
 		      "clean mount failed");
 
-	zassert_equal(clean_statvfs(mp), TC_PASS,
+	ztest_equal(clean_statvfs(mp), TC_PASS,
 		      "clean statvfs failed");
 
-	zassert_equal(create_write_hello(mp), TC_PASS,
+	ztest_equal(create_write_hello(mp), TC_PASS,
 		      "write hello failed");
 
-	zassert_equal(verify_hello(mp), TC_PASS,
+	ztest_equal(verify_hello(mp), TC_PASS,
 		      "verify hello failed");
 
-	zassert_equal(seek_within_hello(mp), TC_PASS,
+	ztest_equal(seek_within_hello(mp), TC_PASS,
 		      "seek within hello failed");
 
-	zassert_equal(truncate_hello(mp), TC_PASS,
+	ztest_equal(truncate_hello(mp), TC_PASS,
 		      "truncate hello failed");
 
-	zassert_equal(unlink_hello(mp), TC_PASS,
+	ztest_equal(unlink_hello(mp), TC_PASS,
 		      "unlink hello failed");
 
-	zassert_equal(sync_goodbye(mp), TC_PASS,
+	ztest_equal(sync_goodbye(mp), TC_PASS,
 		      "sync goodbye failed");
 
 	TC_PRINT("unmounting %s\n", mp->mnt_point);
-	zassert_equal(fs_unmount(mp), 0,
+	ztest_equal(fs_unmount(mp), 0,
 		      "unmount small failed");
 
 	k_sleep(K_MSEC(100));   /* flush log messages */
 	TC_PRINT("checking double unmount diagnoses\n");
-	zassert_equal(fs_unmount(mp), -EINVAL,
+	ztest_equal(fs_unmount(mp), -EINVAL,
 		      "unmount unmounted failed");
 
-	zassert_equal(mount(mp), TC_PASS,
+	ztest_equal(mount(mp), TC_PASS,
 		      "remount failed");
 
-	zassert_equal(verify_goodbye(mp), TC_PASS,
+	ztest_equal(verify_goodbye(mp), TC_PASS,
 		      "verify goodbye failed");
 
-	zassert_equal(fs_unmount(mp), 0,
+	ztest_equal(fs_unmount(mp), 0,
 		      "unmount2 small failed");
 
-	zassert_equal(check_medium(), TC_PASS,
+	ztest_equal(check_medium(), TC_PASS,
 		      "check medium failed");
 
-	zassert_equal(check_large(), TC_PASS,
+	ztest_equal(check_large(), TC_PASS,
 		      "check large failed");
 
 }

--- a/tests/subsys/fs/littlefs/src/test_lfs_dirops.c
+++ b/tests/subsys/fs/littlefs/src/test_lfs_dirops.c
@@ -35,10 +35,10 @@ static int clean_mount(struct fs_mount_t *mp)
 {
 	TC_PRINT("checking clean mount\n");
 
-	zassert_equal(testfs_lfs_wipe_partition(mp),
+	ztest_equal(testfs_lfs_wipe_partition(mp),
 		      TC_PASS,
 		      "failed to wipe partition");
-	zassert_equal(fs_mount(mp), 0,
+	ztest_equal(fs_mount(mp), 0,
 		      "mount small failed");
 
 	return TC_PASS;
@@ -49,43 +49,43 @@ static int check_mkdir(struct fs_mount_t *mp)
 	struct testfs_path dpath;
 
 	TC_PRINT("checking dir create unlink\n");
-	zassert_equal(testfs_path_init(&dpath, mp,
+	ztest_equal(testfs_path_init(&dpath, mp,
 				       "dir",
 				       TESTFS_PATH_END),
 		      dpath.path,
 		      "root init failed");
 
-	zassert_equal(fs_mkdir(dpath.path),
+	ztest_equal(fs_mkdir(dpath.path),
 		      0,
 		      "mkdir failed");
 
 	struct fs_file_t file;
 	struct testfs_path fpath;
 
-	zassert_equal(fs_open(&file,
+	ztest_equal(fs_open(&file,
 			      testfs_path_extend(testfs_path_copy(&fpath,
 								  &dpath),
 						 "file",
 						 TESTFS_PATH_END)),
 		      0,
 		      "creat in dir failed");
-	zassert_equal(fs_close(&file), 0,
+	ztest_equal(fs_close(&file), 0,
 		      "close file failed");
 
 	struct fs_dirent stat;
 
-	zassert_equal(fs_stat(fpath.path, &stat), 0,
+	ztest_equal(fs_stat(fpath.path, &stat), 0,
 		      "stat file failed");
 
-	zassert_equal(fs_unlink(dpath.path),
+	ztest_equal(fs_unlink(dpath.path),
 		      -ENOTEMPTY,
 		      "unlink bad failure");
 
-	zassert_equal(fs_unlink(fpath.path),
+	ztest_equal(fs_unlink(fpath.path),
 		      0,
 		      "unlink file failed");
 
-	zassert_equal(fs_unlink(dpath.path),
+	ztest_equal(fs_unlink(dpath.path),
 		      0,
 		      "unlink dir failed");
 
@@ -100,21 +100,21 @@ static int build_layout(struct fs_mount_t *mp,
 
 	TC_PRINT("building layout on %s\n", mp->mnt_point);
 
-	zassert_equal(fs_statvfs(mp->mnt_point, &stat), 0,
+	ztest_equal(fs_statvfs(mp->mnt_point, &stat), 0,
 		      "statvfs failed");
 
 	TC_PRINT("before: bsize %lu ; frsize %lu ; blocks %lu ; bfree %lu\n",
 		 stat.f_bsize, stat.f_frsize, stat.f_blocks, stat.f_bfree);
 
-	zassert_equal(testfs_path_init(&path, mp, TESTFS_PATH_END),
+	ztest_equal(testfs_path_init(&path, mp, TESTFS_PATH_END),
 		      path.path,
 		      "root init failed");
 
-	zassert_equal(testfs_build(&path, cp),
+	ztest_equal(testfs_build(&path, cp),
 		      0,
 		      "build_layout failed");
 
-	zassert_equal(fs_statvfs(mp->mnt_point, &stat), 0,
+	ztest_equal(fs_statvfs(mp->mnt_point, &stat), 0,
 		      "statvfs failed");
 
 	TC_PRINT("after: bsize %lu ; frsize %lu ; blocks %lu ; bfree %lu\n",
@@ -131,15 +131,15 @@ static int check_layout(struct fs_mount_t *mp,
 
 	TC_PRINT("checking layout\n");
 
-	zassert_equal(testfs_path_init(&path, mp, TESTFS_PATH_END),
+	ztest_equal(testfs_path_init(&path, mp, TESTFS_PATH_END),
 		      path.path,
 		      "root init failed");
 
 	int rc = testfs_bcmd_verify_layout(&path, layout, end_layout);
 
-	zassert_true(rc >= 0, "layout check failed");
+	ztest_true(rc >= 0, "layout check failed");
 
-	zassert_equal(rc, 0,
+	ztest_equal(rc, 0,
 		      "layout found foreign");
 
 	struct testfs_bcmd *cp = layout;
@@ -150,7 +150,7 @@ static int check_layout(struct fs_mount_t *mp,
 				 cp->name,
 				 (cp->type == FS_DIR_ENTRY_DIR) ? "/" : "",
 				 cp->size);
-			zassert_true(cp->matched,
+			ztest_true(cp->matched,
 				     "Unmatched layout entry");
 		}
 		++cp;
@@ -197,20 +197,20 @@ static int check_rename(struct fs_mount_t *mp)
 	};
 	struct testfs_bcmd *to_end_bcmd = testfs_bcmd_end(to_bcmd);
 
-	zassert_equal(testfs_path_init(&root, mp,
+	ztest_equal(testfs_path_init(&root, mp,
 				       "rename",
 				       TESTFS_PATH_END),
 		      root.path,
 		      "root init failed");
 
-	zassert_equal(fs_mkdir(root.path),
+	ztest_equal(fs_mkdir(root.path),
 		      0,
 		      "rename mkdir failed");
-	zassert_equal(testfs_build(&root, from_bcmd),
+	ztest_equal(testfs_build(&root, from_bcmd),
 		      0,
 		      "rename build failed");
 
-	zassert_equal(testfs_bcmd_verify_layout(&root, from_bcmd, from_end_bcmd),
+	ztest_equal(testfs_bcmd_verify_layout(&root, from_bcmd, from_end_bcmd),
 		      0,
 		      "layout check failed");
 
@@ -221,7 +221,7 @@ static int check_rename(struct fs_mount_t *mp)
 			   "f1t",
 			   TESTFS_PATH_END);
 	TC_PRINT("%s => %s -ENOENT\n", from, to);
-	zassert_equal(fs_rename(from, to),
+	ztest_equal(fs_rename(from, to),
 		      -ENOENT,
 		      "rename noent failed");
 
@@ -230,7 +230,7 @@ static int check_rename(struct fs_mount_t *mp)
 			   "f1f",
 			   TESTFS_PATH_END);
 	TC_PRINT("%s => %s ok\n", from, to);
-	zassert_equal(fs_rename(from, to),
+	ztest_equal(fs_rename(from, to),
 		      0,
 		      "rename noent failed");
 
@@ -242,10 +242,10 @@ static int check_rename(struct fs_mount_t *mp)
 			   "f2t",
 			   TESTFS_PATH_END);
 	TC_PRINT("%s => %s clobber ok\n", from, to);
-	zassert_equal(fs_rename(from, to),
+	ztest_equal(fs_rename(from, to),
 		      0,
 		      "rename clobber failed");
-	zassert_equal(fs_stat(from, &stat),
+	ztest_equal(fs_stat(from, &stat),
 		      -ENOENT,
 		      "rename clobber left from");
 
@@ -257,10 +257,10 @@ static int check_rename(struct fs_mount_t *mp)
 			   "d1f", "d1f2t",
 			   TESTFS_PATH_END);
 	TC_PRINT("%s => %s move ok\n", from, to);
-	zassert_equal(fs_rename(from, to),
+	ztest_equal(fs_rename(from, to),
 		      0,
 		      "rename to subdir failed");
-	zassert_equal(fs_stat(from, &stat),
+	ztest_equal(fs_stat(from, &stat),
 		      -ENOENT,
 		      "rename to subdir left from");
 
@@ -272,7 +272,7 @@ static int check_rename(struct fs_mount_t *mp)
 			   "d2t",
 			   TESTFS_PATH_END);
 	TC_PRINT("%s => %s -ENOTEMPTY\n", from, to);
-	zassert_equal(fs_rename(from, to),
+	ztest_equal(fs_rename(from, to),
 		      -ENOTEMPTY,
 		      "rename to existing dir failed");
 
@@ -284,14 +284,14 @@ static int check_rename(struct fs_mount_t *mp)
 			   "d1t",
 			   TESTFS_PATH_END);
 	TC_PRINT("%s => %s ok\n", from, to);
-	zassert_equal(fs_rename(from, to),
+	ztest_equal(fs_rename(from, to),
 		      0,
 		      "rename to new dir failed");
-	zassert_equal(fs_stat(from, &stat),
+	ztest_equal(fs_stat(from, &stat),
 		      -ENOENT,
 		      "rename to new dir left from");
 
-	zassert_equal(testfs_bcmd_verify_layout(&root, to_bcmd, to_end_bcmd),
+	ztest_equal(testfs_bcmd_verify_layout(&root, to_bcmd, to_end_bcmd),
 		      0,
 		      "layout verification failed");
 
@@ -299,7 +299,7 @@ static int check_rename(struct fs_mount_t *mp)
 
 	while (cp != to_end_bcmd) {
 		if (cp->name) {
-			zassert_true(cp->matched, "foriegn file retained");
+			ztest_true(cp->matched, "foriegn file retained");
 		}
 		++cp;
 	}
@@ -311,25 +311,25 @@ void test_lfs_dirops(void)
 {
 	struct fs_mount_t *mp = &testfs_small_mnt;
 
-	zassert_equal(clean_mount(mp), TC_PASS,
+	ztest_equal(clean_mount(mp), TC_PASS,
 		      "clean mount failed");
 
-	zassert_equal(check_mkdir(mp), TC_PASS,
+	ztest_equal(check_mkdir(mp), TC_PASS,
 		      "check mkdir failed");
 
 	k_sleep(K_MSEC(100));   /* flush log messages */
-	zassert_equal(build_layout(mp, test_hierarchy), TC_PASS,
+	ztest_equal(build_layout(mp, test_hierarchy), TC_PASS,
 		      "build test hierarchy failed");
 
 	k_sleep(K_MSEC(100));   /* flush log messages */
-	zassert_equal(check_layout(mp, test_hierarchy), TC_PASS,
+	ztest_equal(check_layout(mp, test_hierarchy), TC_PASS,
 		      "check test hierarchy failed");
 
 	k_sleep(K_MSEC(100));   /* flush log messages */
-	zassert_equal(check_rename(mp), TC_PASS,
+	ztest_equal(check_rename(mp), TC_PASS,
 		      "check rename failed");
 
 	k_sleep(K_MSEC(100));   /* flush log messages */
-	zassert_equal(fs_unmount(mp), 0,
+	ztest_equal(fs_unmount(mp), 0,
 		      "unmount small failed");
 }

--- a/tests/subsys/fs/littlefs/src/test_lfs_perf.c
+++ b/tests/subsys/fs/littlefs/src/test_lfs_perf.c
@@ -225,25 +225,25 @@ static int small_8_1K_cust(void)
 void test_lfs_perf(void)
 {
 	k_sleep(K_MSEC(100));   /* flush log messages */
-	zassert_equal(write_read("small 8x1K dflt",
+	ztest_equal(write_read("small 8x1K dflt",
 				 &testfs_small_mnt,
 				 1024, 8),
 		      TC_PASS,
 		      "failed");
 
 	k_sleep(K_MSEC(100));   /* flush log messages */
-	zassert_equal(small_8_1K_cust(), TC_PASS,
+	ztest_equal(small_8_1K_cust(), TC_PASS,
 		      "failed");
 
 	k_sleep(K_MSEC(100));   /* flush log messages */
-	zassert_equal(write_read("medium 32x2K dflt",
+	ztest_equal(write_read("medium 32x2K dflt",
 				 &testfs_medium_mnt,
 				 2048, 32),
 		      TC_PASS,
 		      "failed");
 
 	k_sleep(K_MSEC(100));   /* flush log messages */
-	zassert_equal(write_read("large 64x4K dflt",
+	ztest_equal(write_read("large 64x4K dflt",
 				 &testfs_large_mnt,
 				 4096, 64),
 		      TC_PASS,

--- a/tests/subsys/fs/littlefs/src/test_util.c
+++ b/tests/subsys/fs/littlefs/src/test_util.c
@@ -28,15 +28,15 @@ static inline struct testfs_path *reset_path()
 
 void test_util_path_init_base(void)
 {
-	zassert_equal(testfs_path_init(&path, NULL, TESTFS_PATH_END),
+	ztest_equal(testfs_path_init(&path, NULL, TESTFS_PATH_END),
 		      path.path,
 		      "bad root init return");
-	zassert_equal(strcmp(path.path, "/"), 0, "bad root init path");
+	ztest_equal(strcmp(path.path, "/"), 0, "bad root init path");
 
-	zassert_equal(testfs_path_init(&path, &mnt, TESTFS_PATH_END),
+	ztest_equal(testfs_path_init(&path, &mnt, TESTFS_PATH_END),
 		      path.path,
 		      "bad mnt init return");
-	zassert_equal(strcmp(path.path, mnt.mnt_point), 0, "bad mnt init path");
+	ztest_equal(strcmp(path.path, mnt.mnt_point), 0, "bad mnt init path");
 
 	if (IS_ENABLED(CONFIG_DEBUG)) {
 		struct fs_mount_t invalid = {
@@ -57,33 +57,33 @@ void test_util_path_init_overrun(void)
 		.mnt_point = overrun,
 	};
 
-	zassert_true(path_max < overrun_max,
+	ztest_true(path_max < overrun_max,
 		     "path length requirements unmet");
 
 	memset(overrun + 1, 'A', overrun_max - 1);
 
-	zassert_equal(testfs_path_init(&path, &overrun_mnt, TESTFS_PATH_END),
+	ztest_equal(testfs_path_init(&path, &overrun_mnt, TESTFS_PATH_END),
 		      path.path,
 		      "bad overrun init return");
-	zassert_true(strcmp(path.path, overrun) < 0,
+	ztest_true(strcmp(path.path, overrun) < 0,
 		     "bad overrun init");
-	zassert_equal(strncmp(path.path, overrun, path_max),
+	ztest_equal(strncmp(path.path, overrun, path_max),
 		      0,
 		      "bad overrun path");
-	zassert_equal(path.path[path_max], '\0',
+	ztest_equal(path.path[path_max], '\0',
 		      "missing overrun EOS");
 }
 
 void test_util_path_init_extended(void)
 {
-	zassert_equal(strcmp(testfs_path_init(&path, &mnt,
+	ztest_equal(strcmp(testfs_path_init(&path, &mnt,
 					      ELT1,
 					      TESTFS_PATH_END),
 			     MNT "/" ELT1),
 		      0,
 		      "bad mnt init elt1");
 
-	zassert_equal(strcmp(testfs_path_init(&path, &mnt,
+	ztest_equal(strcmp(testfs_path_init(&path, &mnt,
 					      ELT1,
 					      ELT2,
 					      TESTFS_PATH_END),
@@ -94,20 +94,20 @@ void test_util_path_init_extended(void)
 
 void test_util_path_extend(void)
 {
-	zassert_equal(strcmp(testfs_path_extend(reset_path(),
+	ztest_equal(strcmp(testfs_path_extend(reset_path(),
 						TESTFS_PATH_END),
 			     MNT),
 		      0,
 		      "empty extend failed");
 
-	zassert_equal(strcmp(testfs_path_extend(reset_path(),
+	ztest_equal(strcmp(testfs_path_extend(reset_path(),
 						ELT2,
 						TESTFS_PATH_END),
 			     MNT "/" ELT2),
 		      0,
 		      "elt extend failed");
 
-	zassert_equal(strcmp(testfs_path_extend(reset_path(),
+	ztest_equal(strcmp(testfs_path_extend(reset_path(),
 						ELT1,
 						ELT2,
 						TESTFS_PATH_END),
@@ -118,7 +118,7 @@ void test_util_path_extend(void)
 
 void test_util_path_extend_up(void)
 {
-	zassert_equal(strcmp(testfs_path_extend(reset_path(),
+	ztest_equal(strcmp(testfs_path_extend(reset_path(),
 						ELT2,
 						"..",
 						ELT1,
@@ -127,14 +127,14 @@ void test_util_path_extend_up(void)
 		      0,
 		      "elt elt2, up, elt1 failed");
 
-	zassert_equal(strcmp(testfs_path_extend(reset_path(),
+	ztest_equal(strcmp(testfs_path_extend(reset_path(),
 						"..",
 						TESTFS_PATH_END),
 			     "/"),
 		      0,
 		      "up strip mnt failed");
 
-	zassert_equal(strcmp(testfs_path_extend(reset_path(),
+	ztest_equal(strcmp(testfs_path_extend(reset_path(),
 						"..",
 						"..",
 						TESTFS_PATH_END),
@@ -150,7 +150,7 @@ void test_util_path_extend_overrun(void)
 	memset(long_elt, 'a', sizeof(long_elt) - 1);
 	long_elt[sizeof(long_elt) - 1] = '\0';
 
-	zassert_equal(strcmp(testfs_path_extend(reset_path(),
+	ztest_equal(strcmp(testfs_path_extend(reset_path(),
 						long_elt,
 						ELT1,
 						TESTFS_PATH_END),

--- a/tests/subsys/fs/littlefs/src/testfs_util.c
+++ b/tests/subsys/fs/littlefs/src/testfs_util.c
@@ -393,7 +393,7 @@ int testfs_bcmd_verify_layout(struct testfs_path *pp,
 			 stat.size);
 
 		if (dotdir) {
-			zassert_true(false,
+			ztest_true(false,
 				     "special directories observed");
 		} else if (cp != NULL) {
 			rc = check_layout_entry(pp, &stat, cp, ecp);

--- a/tests/subsys/fs/multi-fs/src/test_fat_dir.c
+++ b/tests/subsys/fs/multi-fs/src/test_fat_dir.c
@@ -13,15 +13,15 @@
 
 void test_fat_mkdir(void)
 {
-	zassert_true(test_mkdir(TEST_DIR_PATH, TEST_FILE) == TC_PASS, NULL);
+	ztest_true(test_mkdir(TEST_DIR_PATH, TEST_FILE) == TC_PASS, NULL);
 }
 
 void test_fat_readdir(void)
 {
-	zassert_true(test_lsdir(TEST_DIR_PATH) == TC_PASS, NULL);
+	ztest_true(test_lsdir(TEST_DIR_PATH) == TC_PASS, NULL);
 }
 
 void test_fat_rmdir(void)
 {
-	zassert_true(test_rmdir(TEST_DIR_PATH) == TC_PASS, NULL);
+	ztest_true(test_rmdir(TEST_DIR_PATH) == TC_PASS, NULL);
 }

--- a/tests/subsys/fs/multi-fs/src/test_fat_file.c
+++ b/tests/subsys/fs/multi-fs/src/test_fat_file.c
@@ -14,27 +14,27 @@ static const char *test_str = "Hello world FAT";
 
 void test_fat_open(void)
 {
-	zassert_true(test_file_open(&test_file, TEST_FILE_PATH) == TC_PASS,
+	ztest_true(test_file_open(&test_file, TEST_FILE_PATH) == TC_PASS,
 		NULL);
 }
 
 void test_fat_write(void)
 {
 	TC_PRINT("Write to file %s\n", TEST_FILE_PATH);
-	zassert_true(test_file_write(&test_file, test_str) == TC_PASS,
+	ztest_true(test_file_write(&test_file, test_str) == TC_PASS,
 		NULL);
 }
 
 void test_fat_read(void)
 {
-	zassert_true(test_file_read(&test_file, test_str) == TC_PASS, NULL);
+	ztest_true(test_file_read(&test_file, test_str) == TC_PASS, NULL);
 }
 
 void test_fat_close(void)
 {
-	zassert_true(test_file_close(&test_file) == TC_PASS, NULL);
+	ztest_true(test_file_close(&test_file) == TC_PASS, NULL);
 }
 void test_fat_unlink(void)
 {
-	zassert_true(test_file_delete(TEST_FILE_PATH) == TC_PASS, NULL);
+	ztest_true(test_file_delete(TEST_FILE_PATH) == TC_PASS, NULL);
 }

--- a/tests/subsys/fs/multi-fs/src/test_fat_mount.c
+++ b/tests/subsys/fs/multi-fs/src/test_fat_mount.c
@@ -42,6 +42,6 @@ void test_fat_mount(void)
 #ifdef CONFIG_FILE_SYSTEM_SHELL
 	test_fs_fat_mount();
 #else
-	zassert_true(test_mount() == TC_PASS, NULL);
+	ztest_true(test_mount() == TC_PASS, NULL);
 #endif
 }

--- a/tests/subsys/fs/multi-fs/src/test_fs_shell.c
+++ b/tests/subsys/fs/multi-fs/src/test_fs_shell.c
@@ -23,7 +23,7 @@ static void test_shell_exec(const char *line, int result)
 
 	TC_PRINT("shell_execute_cmd(%s): %d\n", line, ret);
 
-	zassert_true(ret == result, line);
+	ztest_true(ret == result, line);
 }
 
 void test_fs_help(void)

--- a/tests/subsys/fs/multi-fs/src/test_littlefs_dir.c
+++ b/tests/subsys/fs/multi-fs/src/test_littlefs_dir.c
@@ -13,15 +13,15 @@
 
 void test_littlefs_mkdir(void)
 {
-	zassert_true(test_mkdir(TEST_DIR_PATH, TEST_FILE) == TC_PASS, NULL);
+	ztest_true(test_mkdir(TEST_DIR_PATH, TEST_FILE) == TC_PASS, NULL);
 }
 
 void test_littlefs_readdir(void)
 {
-	zassert_true(test_lsdir(TEST_DIR_PATH) == TC_PASS, NULL);
+	ztest_true(test_lsdir(TEST_DIR_PATH) == TC_PASS, NULL);
 }
 
 void test_littlefs_rmdir(void)
 {
-	zassert_true(test_rmdir(TEST_DIR_PATH) == TC_PASS, NULL);
+	ztest_true(test_rmdir(TEST_DIR_PATH) == TC_PASS, NULL);
 }

--- a/tests/subsys/fs/multi-fs/src/test_littlefs_file.c
+++ b/tests/subsys/fs/multi-fs/src/test_littlefs_file.c
@@ -14,27 +14,27 @@ static const char *test_str = "Hello world LITTLEFS";
 
 void test_littlefs_open(void)
 {
-	zassert_true(test_file_open(&test_file, TEST_FILE_PATH) == TC_PASS,
+	ztest_true(test_file_open(&test_file, TEST_FILE_PATH) == TC_PASS,
 		NULL);
 }
 
 void test_littlefs_write(void)
 {
 	TC_PRINT("Write to file %s\n", TEST_FILE_PATH);
-	zassert_true(test_file_write(&test_file, test_str) == TC_PASS,
+	ztest_true(test_file_write(&test_file, test_str) == TC_PASS,
 		NULL);
 }
 
 void test_littlefs_read(void)
 {
-	zassert_true(test_file_read(&test_file, test_str) == TC_PASS, NULL);
+	ztest_true(test_file_read(&test_file, test_str) == TC_PASS, NULL);
 }
 
 void test_littlefs_close(void)
 {
-	zassert_true(test_file_close(&test_file) == TC_PASS, NULL);
+	ztest_true(test_file_close(&test_file) == TC_PASS, NULL);
 }
 void test_littlefs_unlink(void)
 {
-	zassert_true(test_file_delete(TEST_FILE_PATH) == TC_PASS, NULL);
+	ztest_true(test_file_delete(TEST_FILE_PATH) == TC_PASS, NULL);
 }

--- a/tests/subsys/fs/multi-fs/src/test_littlefs_mount.c
+++ b/tests/subsys/fs/multi-fs/src/test_littlefs_mount.c
@@ -41,6 +41,6 @@ void test_littlefs_mount(void)
 #ifdef CONFIG_FILE_SYSTEM_SHELL
 	test_fs_littlefs_mount();
 #else
-	zassert_true(test_mount() == TC_PASS, NULL);
+	ztest_true(test_mount() == TC_PASS, NULL);
 #endif
 }

--- a/tests/subsys/fs/multi-fs/src/test_ram_backend.c
+++ b/tests/subsys/fs/multi-fs/src/test_ram_backend.c
@@ -28,8 +28,8 @@ static int test_flash_ram_erase(struct device *dev, off_t offset, size_t len)
 	struct flash_pages_info info;
 	off_t end_offset = offset + len;
 
-	zassert_true(offset >= 0, "invalid offset");
-	zassert_true(offset + len <= DT_FLASH_AREA_STORAGE_SIZE,
+	ztest_true(offset >= 0, "invalid offset");
+	ztest_true(offset + len <= DT_FLASH_AREA_STORAGE_SIZE,
 		     "flash address out of bounds");
 
 	while (offset < end_offset) {
@@ -44,8 +44,8 @@ static int test_flash_ram_erase(struct device *dev, off_t offset, size_t len)
 static int test_flash_ram_write(struct device *dev, off_t offset,
 						const void *data, size_t len)
 {
-	zassert_true(offset >= 0, "invalid offset");
-	zassert_true(offset + len <= DT_FLASH_AREA_STORAGE_SIZE,
+	ztest_true(offset >= 0, "invalid offset");
+	ztest_true(offset + len <= DT_FLASH_AREA_STORAGE_SIZE,
 		     "flash address out of bounds");
 
 	memcpy(rambuf + offset, data, len);
@@ -56,8 +56,8 @@ static int test_flash_ram_write(struct device *dev, off_t offset,
 static int test_flash_ram_read(struct device *dev, off_t offset, void *data,
 								size_t len)
 {
-	zassert_true(offset >= 0, "invalid offset");
-	zassert_true(offset + len <= DT_FLASH_AREA_STORAGE_SIZE,
+	ztest_true(offset >= 0, "invalid offset");
+	ztest_true(offset + len <= DT_FLASH_AREA_STORAGE_SIZE,
 		     "flash address out of bounds");
 
 	memcpy(data, rambuf + offset, len);

--- a/tests/subsys/fs/multi-fs/src/test_utils.c
+++ b/tests/subsys/fs/multi-fs/src/test_utils.c
@@ -26,8 +26,8 @@ void clear_flash(void)
 	const struct flash_area *fap;
 
 	rc = flash_area_open(DT_FLASH_AREA_STORAGE_ID, &fap);
-	zassert_equal(rc, 0, "Opening flash area for erase [%d]\n", rc);
+	ztest_equal(rc, 0, "Opening flash area for erase [%d]\n", rc);
 
 	rc = flash_area_erase(fap, 0, fap->fa_size);
-	zassert_equal(rc, 0, "Erasing flash area [%d]\n", rc);
+	ztest_equal(rc, 0, "Erasing flash area [%d]\n", rc);
 }

--- a/tests/subsys/fs/nvs/src/main.c
+++ b/tests/subsys/fs/nvs/src/main.c
@@ -43,7 +43,7 @@ void setup(void)
 		int err;
 
 		err = nvs_clear(&fs);
-		zassert_true(err == 0,  "nvs_clear call failure: %d", err);
+		ztest_true(err == 0,  "nvs_clear call failure: %d", err);
 	}
 }
 
@@ -64,18 +64,18 @@ void test_nvs_init(void)
 	struct flash_pages_info info;
 
 	err = flash_area_open(DT_FLASH_AREA_STORAGE_ID, &fa);
-	zassert_true(err == 0, "flash_area_open() fail: %d", err);
+	ztest_true(err == 0, "flash_area_open() fail: %d", err);
 
 	fs.offset = TEST_FLASH_AREA_STORAGE_OFFSET;
 	err = flash_get_page_info_by_offs(flash_area_get_device(fa), fs.offset,
 					  &info);
-	zassert_true(err == 0,  "Unable to get page info: %d", err);
+	ztest_true(err == 0,  "Unable to get page info: %d", err);
 
 	fs.sector_size = info.size;
 	fs.sector_count = TEST_SECTOR_COUNT;
 
 	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	ztest_true(err == 0,  "nvs_init call failure: %d", err);
 }
 
 static void execute_long_pattern_write(u16_t id)
@@ -86,7 +86,7 @@ static void execute_long_pattern_write(u16_t id)
 	size_t len;
 
 	len = nvs_read(&fs, id, rd_buf, sizeof(rd_buf));
-	zassert_true(len == -ENOENT,  "nvs_read unexpected failure: %d", len);
+	ztest_true(len == -ENOENT,  "nvs_read unexpected failure: %d", len);
 
 	BUILD_ASSERT((sizeof(wr_buf) % sizeof(pattern)) == 0);
 	for (int i = 0; i < sizeof(wr_buf); i += sizeof(pattern)) {
@@ -94,12 +94,12 @@ static void execute_long_pattern_write(u16_t id)
 	}
 
 	len = nvs_write(&fs, id, wr_buf, sizeof(wr_buf));
-	zassert_true(len == sizeof(wr_buf), "nvs_write failed: %d", len);
+	ztest_true(len == sizeof(wr_buf), "nvs_write failed: %d", len);
 
 	len = nvs_read(&fs, id, rd_buf, sizeof(rd_buf));
-	zassert_true(len == sizeof(rd_buf),  "nvs_read unexpected failure: %d",
+	ztest_true(len == sizeof(rd_buf),  "nvs_read unexpected failure: %d",
 			len);
-	zassert_mem_equal(wr_buf, rd_buf, sizeof(rd_buf),
+	ztest_mem_equal(wr_buf, rd_buf, sizeof(rd_buf),
 			"RD buff should be equal to the WR buff");
 }
 
@@ -108,7 +108,7 @@ void test_nvs_write(void)
 	int err;
 
 	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	ztest_true(err == 0,  "nvs_init call failure: %d", err);
 
 	execute_long_pattern_write(TEST_DATA_ID);
 }
@@ -148,10 +148,10 @@ void test_nvs_corrupted_write(void)
 	u32_t *flash_max_write_calls;
 
 	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	ztest_true(err == 0,  "nvs_init call failure: %d", err);
 
 	err = nvs_read(&fs, TEST_DATA_ID, rd_buf, sizeof(rd_buf));
-	zassert_true(err == -ENOENT,  "nvs_read unexpected failure: %d", err);
+	ztest_true(err == -ENOENT,  "nvs_read unexpected failure: %d", err);
 
 	BUILD_ASSERT((sizeof(wr_buf_1) % sizeof(pattern_1)) == 0);
 	for (int i = 0; i < sizeof(wr_buf_1); i += sizeof(pattern_1)) {
@@ -159,12 +159,12 @@ void test_nvs_corrupted_write(void)
 	}
 
 	len = nvs_write(&fs, TEST_DATA_ID, wr_buf_1, sizeof(wr_buf_1));
-	zassert_true(len == sizeof(wr_buf_1), "nvs_write failed: %d", len);
+	ztest_true(len == sizeof(wr_buf_1), "nvs_write failed: %d", len);
 
 	len = nvs_read(&fs, TEST_DATA_ID, rd_buf, sizeof(rd_buf));
-	zassert_true(len == sizeof(rd_buf),  "nvs_read unexpected failure: %d",
+	ztest_true(len == sizeof(rd_buf),  "nvs_read unexpected failure: %d",
 			len);
-	zassert_mem_equal(wr_buf_1, rd_buf, sizeof(rd_buf),
+	ztest_mem_equal(wr_buf_1, rd_buf, sizeof(rd_buf),
 			"RD buff should be equal to the first WR buff");
 
 	BUILD_ASSERT((sizeof(wr_buf_2) % sizeof(pattern_2)) == 0);
@@ -187,19 +187,19 @@ void test_nvs_corrupted_write(void)
 	 * are corrupted at this point and should be discarded by the NVS.
 	 */
 	len = nvs_write(&fs, TEST_DATA_ID, wr_buf_2, sizeof(wr_buf_2));
-	zassert_true(len == sizeof(wr_buf_2), "nvs_write failed: %d", len);
+	ztest_true(len == sizeof(wr_buf_2), "nvs_write failed: %d", len);
 
 	/* Reinitialize the NVS. */
 	memset(&fs, 0, sizeof(fs));
 	test_nvs_init();
 
 	len = nvs_read(&fs, TEST_DATA_ID, rd_buf, sizeof(rd_buf));
-	zassert_true(len == sizeof(rd_buf),  "nvs_read unexpected failure: %d",
+	ztest_true(len == sizeof(rd_buf),  "nvs_read unexpected failure: %d",
 			len);
-	zassert_true(memcmp(wr_buf_2, rd_buf, sizeof(rd_buf)) != 0,
+	ztest_true(memcmp(wr_buf_2, rd_buf, sizeof(rd_buf)) != 0,
 			"RD buff should not be equal to the second WR buff because of "
 			"corrupted write operation");
-	zassert_mem_equal(wr_buf_1, rd_buf, sizeof(rd_buf),
+	ztest_mem_equal(wr_buf_1, rd_buf, sizeof(rd_buf),
 			"RD buff should be equal to the first WR buff because subsequent "
 			"write operation has failed");
 }
@@ -218,7 +218,7 @@ void test_nvs_gc(void)
 	fs.sector_count = 2;
 
 	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	ztest_true(err == 0,  "nvs_init call failure: %d", err);
 
 	for (u16_t i = 0; i < max_writes; i++) {
 		u8_t id = (i % max_id);
@@ -227,36 +227,36 @@ void test_nvs_gc(void)
 		memset(buf, id_data, sizeof(buf));
 
 		len = nvs_write(&fs, id, buf, sizeof(buf));
-		zassert_true(len == sizeof(buf), "nvs_write failed: %d", len);
+		ztest_true(len == sizeof(buf), "nvs_write failed: %d", len);
 	}
 
 	for (u16_t id = 0; id < max_id; id++) {
 		len = nvs_read(&fs, id, rd_buf, sizeof(buf));
-		zassert_true(len == sizeof(rd_buf),
+		ztest_true(len == sizeof(rd_buf),
 			     "nvs_read unexpected failure: %d", len);
 
 		for (u16_t i = 0; i < sizeof(rd_buf); i++) {
 			rd_buf[i] = rd_buf[i] % max_id;
 			buf[i] = id;
 		}
-		zassert_mem_equal(buf, rd_buf, sizeof(rd_buf),
+		ztest_mem_equal(buf, rd_buf, sizeof(rd_buf),
 				"RD buff should be equal to the WR buff");
 
 	}
 
 	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	ztest_true(err == 0,  "nvs_init call failure: %d", err);
 
 	for (u16_t id = 0; id < max_id; id++) {
 		len = nvs_read(&fs, id, rd_buf, sizeof(buf));
-		zassert_true(len == sizeof(rd_buf),
+		ztest_true(len == sizeof(rd_buf),
 			     "nvs_read unexpected failure: %d", len);
 
 		for (u16_t i = 0; i < sizeof(rd_buf); i++) {
 			rd_buf[i] = rd_buf[i] % max_id;
 			buf[i] = id;
 		}
-		zassert_mem_equal(buf, rd_buf, sizeof(rd_buf),
+		ztest_mem_equal(buf, rd_buf, sizeof(rd_buf),
 				"RD buff should be equal to the WR buff");
 
 	}
@@ -275,7 +275,7 @@ static void write_content(u16_t max_id, u16_t begin, u16_t end,
 		memset(buf, id_data, sizeof(buf));
 
 		len = nvs_write(fs, id, buf, sizeof(buf));
-		zassert_true(len == sizeof(buf), "nvs_write failed: %d", len);
+		ztest_true(len == sizeof(buf), "nvs_write failed: %d", len);
 	}
 }
 
@@ -287,14 +287,14 @@ static void check_content(u16_t max_id, struct nvs_fs *fs)
 
 	for (u16_t id = 0; id < max_id; id++) {
 		len = nvs_read(fs, id, rd_buf, sizeof(buf));
-		zassert_true(len == sizeof(rd_buf),
+		ztest_true(len == sizeof(rd_buf),
 			     "nvs_read unexpected failure: %d", len);
 
 		for (u16_t i = 0; i < ARRAY_SIZE(rd_buf); i++) {
 			rd_buf[i] = rd_buf[i] % max_id;
 			buf[i] = id;
 		}
-		zassert_mem_equal(buf, rd_buf, sizeof(rd_buf),
+		ztest_mem_equal(buf, rd_buf, sizeof(rd_buf),
 				  "RD buff should be equal to the WR buff");
 
 	}
@@ -320,22 +320,22 @@ void test_nvs_gc_3sectors(void)
 	fs.sector_count = 3;
 
 	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
-	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 0,
+	ztest_true(err == 0,  "nvs_init call failure: %d", err);
+	ztest_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 0,
 		     "unexpected write sector");
 
 	/* Trigger 1st GC */
 	write_content(max_id, 0, max_writes, &fs);
 
 	/* sector sequence: empty,closed, write */
-	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 2,
+	ztest_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 2,
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 
 	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	ztest_true(err == 0,  "nvs_init call failure: %d", err);
 
-	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 2,
+	ztest_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 2,
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 
@@ -343,14 +343,14 @@ void test_nvs_gc_3sectors(void)
 	write_content(max_id, max_writes, max_writes_2, &fs);
 
 	/* sector sequence: write, empty, closed */
-	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 0,
+	ztest_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 0,
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 
 	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	ztest_true(err == 0,  "nvs_init call failure: %d", err);
 
-	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 0,
+	ztest_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 0,
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 
@@ -358,14 +358,14 @@ void test_nvs_gc_3sectors(void)
 	write_content(max_id, max_writes_2, max_writes_3, &fs);
 
 	/* sector sequence: closed, write, empty */
-	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 1,
+	ztest_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 1,
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 
 	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	ztest_true(err == 0,  "nvs_init call failure: %d", err);
 
-	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 1,
+	ztest_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 1,
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 
@@ -373,14 +373,14 @@ void test_nvs_gc_3sectors(void)
 	write_content(max_id, max_writes_3, max_writes_4, &fs);
 
 	/* sector sequence: empty,closed, write */
-	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 2,
+	ztest_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 2,
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 
 	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	ztest_true(err == 0,  "nvs_init call failure: %d", err);
 
-	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 2,
+	ztest_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 2,
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 }
@@ -444,7 +444,7 @@ void test_nvs_corrupted_sector_close_operation(void)
 	stats_walk(sim_stats, flash_sim_erase_calls_find, &flash_erase_stat);
 
 	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	ztest_true(err == 0,  "nvs_init call failure: %d", err);
 
 	for (u16_t i = 0; i < max_writes; i++) {
 		u8_t id = (i % max_id);
@@ -467,7 +467,7 @@ void test_nvs_corrupted_sector_close_operation(void)
 		}
 
 		len = nvs_write(&fs, id, buf, sizeof(buf));
-		zassert_true(len == sizeof(buf), "nvs_write failed: %d", len);
+		ztest_true(len == sizeof(buf), "nvs_write failed: %d", len);
 	}
 
 	/* Make the flash simulator functional again. */
@@ -476,7 +476,7 @@ void test_nvs_corrupted_sector_close_operation(void)
 	*flash_max_len = 0;
 
 	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	ztest_true(err == 0,  "nvs_init call failure: %d", err);
 
 	check_content(max_id, &fs);
 
@@ -497,7 +497,7 @@ void test_nvs_full_sector(void)
 	fs.sector_count = 3;
 
 	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	ztest_true(err == 0,  "nvs_init call failure: %d", err);
 
 	while (1) {
 		len = nvs_write(&fs, filling_id, &filling_id,
@@ -505,33 +505,33 @@ void test_nvs_full_sector(void)
 		if (len == -ENOSPC) {
 			break;
 		}
-		zassert_true(len == sizeof(filling_id), "nvs_write failed: %d",
+		ztest_true(len == sizeof(filling_id), "nvs_write failed: %d",
 			     len);
 		filling_id++;
 	}
 
 	/* check whether can delete whatever from full storage */
 	err = nvs_delete(&fs, 1);
-	zassert_true(err == 0,  "nvs_delete call failure: %d", err);
+	ztest_true(err == 0,  "nvs_delete call failure: %d", err);
 
 	/* the last sector is full now, test re-initialization */
 	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	ztest_true(err == 0,  "nvs_init call failure: %d", err);
 
 	len = nvs_write(&fs, filling_id, &filling_id, sizeof(filling_id));
-	zassert_true(len == sizeof(filling_id), "nvs_write failed: %d", len);
+	ztest_true(len == sizeof(filling_id), "nvs_write failed: %d", len);
 
 	/* sanitycheck on NVS content */
 	for (i = 0; i <= filling_id; i++) {
 		len = nvs_read(&fs, i, &data_read, sizeof(data_read));
 		if (i == 1) {
-			zassert_true(len == -ENOENT,
+			ztest_true(len == -ENOENT,
 				     "nvs_read shouldn't found the entry: %d",
 				     len);
 		} else {
-			zassert_true(len == sizeof(data_read),
+			ztest_true(len == sizeof(data_read),
 				     "nvs_read failed: %d", i, len);
-			zassert_equal(data_read, i,
+			ztest_equal(data_read, i,
 				      "read unexpected data: %d instead of %d",
 				      data_read, i);
 		}
@@ -548,13 +548,13 @@ void test_delete(void)
 	fs.sector_count = 3;
 
 	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
-	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	ztest_true(err == 0,  "nvs_init call failure: %d", err);
 
 	for (filling_id = 0; filling_id < 10; filling_id++) {
 		len = nvs_write(&fs, filling_id, &filling_id,
 				sizeof(filling_id));
 
-		zassert_true(len == sizeof(filling_id), "nvs_write failed: %d",
+		ztest_true(len == sizeof(filling_id), "nvs_write failed: %d",
 			     len);
 
 		if (filling_id != 0) {
@@ -563,19 +563,19 @@ void test_delete(void)
 
 		/* delete the first entry while it is the most recent one */
 		err = nvs_delete(&fs, filling_id);
-		zassert_true(err == 0,  "nvs_delete call failure: %d", err);
+		ztest_true(err == 0,  "nvs_delete call failure: %d", err);
 
 		len = nvs_read(&fs, filling_id, &data_read, sizeof(data_read));
-		zassert_true(len == -ENOENT,
+		ztest_true(len == -ENOENT,
 			     "nvs_read shouldn't found the entry: %d", len);
 	}
 
 	/* delete existing entry */
 	err = nvs_delete(&fs, 1);
-	zassert_true(err == 0,  "nvs_delete call failure: %d", err);
+	ztest_true(err == 0,  "nvs_delete call failure: %d", err);
 
 	len = nvs_read(&fs, 1, &data_read, sizeof(data_read));
-	zassert_true(len == -ENOENT, "nvs_read shouldn't found the entry: %d",
+	ztest_true(len == -ENOENT, "nvs_read shouldn't found the entry: %d",
 		     len);
 
 	ate_wra = fs.ate_wra;
@@ -583,15 +583,15 @@ void test_delete(void)
 
 	/* delete already deleted entry */
 	err = nvs_delete(&fs, 1);
-	zassert_true(err == 0,  "nvs_delete call failure: %d", err);
-	zassert_true(ate_wra == fs.ate_wra && data_wra == fs.data_wra,
+	ztest_true(err == 0,  "nvs_delete call failure: %d", err);
+	ztest_true(ate_wra == fs.ate_wra && data_wra == fs.data_wra,
 		     "delete already deleted entry should not make"
 		     " any footprint in the storage");
 
 	/* delete nonexisting entry */
 	err = nvs_delete(&fs, filling_id);
-	zassert_true(err == 0,  "nvs_delete call failure: %d", err);
-	zassert_true(ate_wra == fs.ate_wra && data_wra == fs.data_wra,
+	ztest_true(err == 0,  "nvs_delete call failure: %d", err);
+	ztest_true(ate_wra == fs.ate_wra && data_wra == fs.data_wra,
 		     "delete nonexistent entry should not make"
 		     " any footprint in the storage");
 }

--- a/tests/subsys/jwt/src/main.c
+++ b/tests/subsys/jwt/src/main.c
@@ -42,16 +42,16 @@ void test_jwt(void)
 
 	res = jwt_init_builder(&build, buf, sizeof(buf));
 
-	zassert_equal(res, 0, "Setting up jwt");
+	ztest_equal(res, 0, "Setting up jwt");
 
 	res = jwt_add_payload(&build, 1530312026, 1530308426,
 			      "iot-work-199419");
-	zassert_equal(res, 0, "Adding payload");
+	ztest_equal(res, 0, "Adding payload");
 
 	res = jwt_sign(&build, jwt_test_private_der, jwt_test_private_der_len);
-	zassert_equal(res, 0, "Signing payload");
+	ztest_equal(res, 0, "Signing payload");
 
-	zassert_equal(build.overflowed, false, "Not overflow");
+	ztest_equal(build.overflowed, false, "Not overflow");
 
 	printk("JWT:\n%s\n", buf);
 	printk("len: %zd\n", jwt_payload_len(&build));

--- a/tests/subsys/logging/log_core/src/log_core_test.c
+++ b/tests/subsys/logging/log_core/src/log_core_test.c
@@ -54,7 +54,7 @@ static void put(struct log_backend const *const backend,
 	if (cb->check_id) {
 		u32_t exp_id = cb->exp_id[cb->counter];
 
-		zassert_equal(log_msg_source_id_get(msg),
+		ztest_equal(log_msg_source_id_get(msg),
 			      exp_id,
 			      "Unexpected source_id");
 	}
@@ -62,7 +62,7 @@ static void put(struct log_backend const *const backend,
 	if (cb->check_timestamp) {
 		u32_t exp_timestamp = cb->exp_timestamps[cb->counter];
 
-		zassert_equal(log_msg_timestamp_get(msg),
+		ztest_equal(log_msg_timestamp_get(msg),
 			      exp_timestamp,
 			      "Unexpected message index");
 	}
@@ -72,13 +72,13 @@ static void put(struct log_backend const *const backend,
 		for (int i = 0; i < nargs; i++) {
 			u32_t arg = log_msg_arg_get(msg, i);
 
-			zassert_equal(i+1, arg,
+			ztest_equal(i+1, arg,
 				      "Unexpected argument in the message");
 		}
 	}
 
 	if (cb->check_strdup) {
-		zassert_false(cb->exp_strdup[cb->counter]
+		ztest_false(cb->exp_strdup[cb->counter]
 			      ^ log_is_strdup((void *)log_msg_arg_get(msg, 0)),
 			      NULL);
 	}
@@ -151,11 +151,11 @@ static int log_source_id_get(const char *name)
 static void log_setup(bool backend2_enable)
 {
 	stamp = 0U;
-	zassert_false(in_panic, "Logger in panic state.");
+	ztest_false(in_panic, "Logger in panic state.");
 
 	log_init();
 
-	zassert_equal(0, log_set_timestamp_func(timestamp_get, 0),
+	ztest_equal(0, log_set_timestamp_func(timestamp_get, 0),
 		      "Expects successful timestamp function setting.");
 
 	memset(&backend1_cb, 0, sizeof(backend1_cb));
@@ -208,11 +208,11 @@ static void test_log_backend_runtime_filtering(void)
 	while (log_process(false)) {
 	}
 
-	zassert_equal(3,
+	ztest_equal(3,
 		      backend1_cb.counter,
 		      "Unexpected amount of messages received by the backend.");
 
-	zassert_equal(2,
+	ztest_equal(2,
 		      backend2_cb.counter,
 		      "Unexpected amount of messages received by the backend.");
 }
@@ -231,7 +231,7 @@ static void test_log_overflow(void)
 	u32_t hexdump_len = max_hexdump_len - HEXDUMP_BYTES_CONT_MSG;
 
 
-	zassert_true(IS_ENABLED(CONFIG_LOG_MODE_OVERFLOW),
+	ztest_true(IS_ENABLED(CONFIG_LOG_MODE_OVERFLOW),
 		     "Test requires that overflow mode is enabled");
 
 	log_setup(false);
@@ -260,7 +260,7 @@ static void test_log_overflow(void)
 	while (log_process(false)) {
 	}
 
-	zassert_equal(2,
+	ztest_equal(2,
 		      backend1_cb.counter,
 		      "Unexpected amount of messages received by the backend.");
 }
@@ -298,7 +298,7 @@ static void test_log_arguments(void)
 	while (log_process(false)) {
 	}
 
-	zassert_equal(8,
+	ztest_equal(8,
 		      backend1_cb.counter,
 		      "Unexpected amount of messages received by the backend.");
 }
@@ -322,7 +322,7 @@ static void test_log_from_declared_module(void)
 	while (log_process(false)) {
 	}
 
-	zassert_equal(2, backend1_cb.counter,
+	ztest_equal(2, backend1_cb.counter,
 		      "Unexpected amount of messages received by the backend.");
 }
 
@@ -349,7 +349,7 @@ static void test_log_strdup_gc(void)
 	while (log_process(false)) {
 	}
 
-	zassert_equal(2, backend1_cb.counter,
+	ztest_equal(2, backend1_cb.counter,
 		      "Unexpected amount of messages received by the backend.");
 
 	/* Processing should free strdup buffer. */
@@ -359,7 +359,7 @@ static void test_log_strdup_gc(void)
 	while (log_process(false)) {
 	}
 
-	zassert_equal(3, backend1_cb.counter,
+	ztest_equal(3, backend1_cb.counter,
 		      "Unexpected amount of messages received by the backend.");
 
 }
@@ -373,7 +373,7 @@ static void test_log_strdup_gc(void)
 		while (log_process(false)) { \
 		} \
 		\
-		zassert_equal(exp_cnt, backend1_cb.counter,\
+		ztest_equal(exp_cnt, backend1_cb.counter,\
 		"Unexpected amount of messages received by the backend (%d).", \
 			backend1_cb.counter); \
 	}
@@ -411,7 +411,7 @@ static void strdup_trim_callback(struct log_backend const *const backend,
 	char *str = (char *)log_msg_arg_get(msg, 0);
 	size_t len = strlen(str);
 
-	zassert_equal(len, CONFIG_LOG_STRDUP_MAX_STRING,
+	ztest_equal(len, CONFIG_LOG_STRDUP_MAX_STRING,
 			"Expected trimmed string");
 }
 
@@ -431,7 +431,7 @@ static void test_strdup_trimming(void)
 	while (log_process(false)) {
 	}
 
-	zassert_equal(1, backend1_cb.counter,
+	ztest_equal(1, backend1_cb.counter,
 		      "Unexpected amount of messages received by the backend.");
 }
 
@@ -446,7 +446,7 @@ static void log_n_messages(u32_t n_msg, u32_t exp_dropped)
 	while (log_process(false)) {
 	}
 
-	zassert_equal(backend1_cb.total_drops, exp_dropped,
+	ztest_equal(backend1_cb.total_drops, exp_dropped,
 			"Unexpected log msg dropped %d (expected %d)",
 			backend1_cb.total_drops, exp_dropped);
 
@@ -482,7 +482,7 @@ static void test_single_z_log_get_s_mask(const char *str, u32_t nargs,
 {
 	u32_t mask = z_log_get_s_mask(str, nargs);
 
-	zassert_equal(mask, exp_mask, "Unexpected mask %x (expected %x)",
+	ztest_equal(mask, exp_mask, "Unexpected mask %x (expected %x)",
 								mask, exp_mask);
 }
 
@@ -511,17 +511,17 @@ static void test_log_panic(void)
 	log_panic();
 	in_panic = true;
 
-	zassert_true(backend1_cb.panic,
+	ztest_true(backend1_cb.panic,
 		     "Expecting backend to receive panic notification.");
 
-	zassert_equal(2,
+	ztest_equal(2,
 		      backend1_cb.counter,
 		      "Unexpected amount of messages received by the backend.");
 
 	/* messages processed where called */
 	LOG_INF("test");
 
-	zassert_equal(3,
+	ztest_equal(3,
 		      backend1_cb.counter,
 		      "Unexpected amount of messages received by the backend.");
 }

--- a/tests/subsys/logging/log_immediate/src/log_immediate_test.c
+++ b/tests/subsys/logging/log_immediate/src/log_immediate_test.c
@@ -67,7 +67,7 @@ static void test_log_immediate_preemption(void)
 	for (int i = 0; i < NUM_THREADS; i++) {
 		k_thread_abort(tids[i]);
 	}
-	zassert_true(true, "");
+	ztest_true(true, "");
 }
 
 /*test case main entry*/

--- a/tests/subsys/logging/log_list/src/log_list_test.c
+++ b/tests/subsys/logging/log_list/src/log_list_test.c
@@ -30,12 +30,12 @@ void test_log_list(void)
 	log_list_add_tail(&my_list, &msg1);
 
 	msg = log_list_head_peek(&my_list);
-	zassert_true(&msg1 == msg, "Unexpected head 0x%08X.\n", msg);
+	ztest_true(&msg1 == msg, "Unexpected head 0x%08X.\n", msg);
 
 	msg = log_list_head_get(&my_list);
 
-	zassert_true(&msg1 == msg, "Unexpected head 0x%08X.\n", msg);
-	zassert_true(log_list_head_peek(&my_list) == NULL,
+	ztest_true(&msg1 == msg, "Unexpected head 0x%08X.\n", msg);
+	ztest_true(log_list_head_peek(&my_list) == NULL,
 		     "Expected empty list.\n");
 
 	/* two elements */
@@ -43,24 +43,24 @@ void test_log_list(void)
 	log_list_add_tail(&my_list, &msg2);
 
 	msg = log_list_head_peek(&my_list);
-	zassert_true(&msg1 == msg, "Unexpected head 0x%08X.\n", msg);
+	ztest_true(&msg1 == msg, "Unexpected head 0x%08X.\n", msg);
 
 	msg = log_list_head_get(&my_list);
-	zassert_true(&msg1 == msg, "Unexpected head 0x%08X.\n", msg);
+	ztest_true(&msg1 == msg, "Unexpected head 0x%08X.\n", msg);
 
 	msg = log_list_head_peek(&my_list);
-	zassert_true(&msg2 == msg, "Unexpected head 0x%08X.\n", msg);
+	ztest_true(&msg2 == msg, "Unexpected head 0x%08X.\n", msg);
 
 	log_list_add_tail(&my_list, &msg1);
 
 	msg = log_list_head_get(&my_list);
-	zassert_true(&msg2 == msg, "Unexpected head 0x%08X.\n", msg);
+	ztest_true(&msg2 == msg, "Unexpected head 0x%08X.\n", msg);
 
 	msg = log_list_head_get(&my_list);
-	zassert_true(&msg1 == msg, "Unexpected head 0x%08X.\n", msg);
+	ztest_true(&msg1 == msg, "Unexpected head 0x%08X.\n", msg);
 
 	msg = log_list_head_get(&my_list);
-	zassert_true(msg == NULL, "Expected empty list.\n");
+	ztest_true(msg == NULL, "Expected empty list.\n");
 }
 
 void test_log_list_multiple_items(void)
@@ -77,10 +77,10 @@ void test_log_list_multiple_items(void)
 	}
 
 	for (i = 0; i < 10; i++) {
-		zassert_true(&msg[i] == log_list_head_get(&my_list),
+		ztest_true(&msg[i] == log_list_head_get(&my_list),
 			     "Unexpected head.\n");
 	}
-	zassert_true(log_list_head_get(&my_list) == NULL,
+	ztest_true(log_list_head_get(&my_list) == NULL,
 		     "Expected empty list.\n");
 }
 /*test case main entry*/

--- a/tests/subsys/logging/log_msg/src/log_msg_test.c
+++ b/tests/subsys/logging/log_msg/src/log_msg_test.c
@@ -20,7 +20,7 @@ extern struct k_mem_slab log_msg_pool;
 static const char my_string[] = "test_string";
 void test_log_std_msg(void)
 {
-	zassert_equal(LOG_MSG_NARGS_SINGLE_CHUNK,
+	ztest_equal(LOG_MSG_NARGS_SINGLE_CHUNK,
 		      IS_ENABLED(CONFIG_64BIT) ? 4 : 3,
 		      "test assumes following setting");
 
@@ -49,14 +49,14 @@ void test_log_std_msg(void)
 		}
 
 		used_slabs += (i > LOG_MSG_NARGS_SINGLE_CHUNK) ? 2 : 1;
-		zassert_equal(used_slabs,
+		ztest_equal(used_slabs,
 			      k_mem_slab_num_used_get(&log_msg_pool),
 			      "Expected mem slab allocation.");
 
 		log_msg_put(msg);
 
 		used_slabs -= (i > LOG_MSG_NARGS_SINGLE_CHUNK) ? 2 : 1;
-		zassert_equal(used_slabs,
+		ztest_equal(used_slabs,
 			      k_mem_slab_num_used_get(&log_msg_pool),
 			      "Expected mem slab allocation.");
 	}
@@ -77,14 +77,14 @@ void test_log_hexdump_msg(void)
 	msg = log_msg_hexdump_create("test", data,
 				     LOG_MSG_HEXDUMP_BYTES_SINGLE_CHUNK - 4);
 
-	zassert_equal((used_slabs + 1),
+	ztest_equal((used_slabs + 1),
 		      k_mem_slab_num_used_get(&log_msg_pool),
 		      "Expected mem slab allocation.");
 	used_slabs++;
 
 	log_msg_put(msg);
 
-	zassert_equal((used_slabs - 1),
+	ztest_equal((used_slabs - 1),
 		      k_mem_slab_num_used_get(&log_msg_pool),
 		      "Expected mem slab allocation.");
 	used_slabs--;
@@ -93,14 +93,14 @@ void test_log_hexdump_msg(void)
 	msg = log_msg_hexdump_create("test", data,
 				     LOG_MSG_HEXDUMP_BYTES_SINGLE_CHUNK);
 
-	zassert_equal((used_slabs + 1),
+	ztest_equal((used_slabs + 1),
 		      k_mem_slab_num_used_get(&log_msg_pool),
 		      "Expected mem slab allocation.");
 	used_slabs++;
 
 	log_msg_put(msg);
 
-	zassert_equal((used_slabs - 1),
+	ztest_equal((used_slabs - 1),
 		      k_mem_slab_num_used_get(&log_msg_pool),
 		      "Expected mem slab allocation.");
 	used_slabs--;
@@ -109,14 +109,14 @@ void test_log_hexdump_msg(void)
 	msg = log_msg_hexdump_create("test", data,
 				     LOG_MSG_HEXDUMP_BYTES_SINGLE_CHUNK + 1);
 
-	zassert_equal((used_slabs + 2U),
+	ztest_equal((used_slabs + 2U),
 		      k_mem_slab_num_used_get(&log_msg_pool),
 		      "Expected mem slab allocation.");
 	used_slabs += 2U;
 
 	log_msg_put(msg);
 
-	zassert_equal((used_slabs - 2U),
+	ztest_equal((used_slabs - 2U),
 		      k_mem_slab_num_used_get(&log_msg_pool),
 		      "Expected mem slab allocation.");
 	used_slabs -= 2U;
@@ -126,14 +126,14 @@ void test_log_hexdump_msg(void)
 				     LOG_MSG_HEXDUMP_BYTES_SINGLE_CHUNK +
 				     HEXDUMP_BYTES_CONT_MSG + 1);
 
-	zassert_equal((used_slabs + 3U),
+	ztest_equal((used_slabs + 3U),
 		      k_mem_slab_num_used_get(&log_msg_pool),
 		      "Expected mem slab allocation.");
 	used_slabs += 3U;
 
 	log_msg_put(msg);
 
-	zassert_equal((used_slabs - 3U),
+	ztest_equal((used_slabs - 3U),
 		      k_mem_slab_num_used_get(&log_msg_pool),
 		      "Expected mem slab allocation.");
 	used_slabs -= 3U;
@@ -166,11 +166,11 @@ void test_log_hexdump_data_get_single_chunk(void)
 				 &rd_length,
 				 offset);
 
-	zassert_equal(rd_length,
+	ztest_equal(rd_length,
 		      rd_req_length,
 		      "Expected to read requested amount of data\n");
 
-	zassert_true(memcmp(&data[offset],
+	ztest_true(memcmp(&data[offset],
 		     read_data,
 		     rd_length) == 0,
 			"Expected data.\n");
@@ -184,11 +184,11 @@ void test_log_hexdump_data_get_single_chunk(void)
 				 read_data,
 				 &rd_length,
 				 offset);
-	zassert_equal(rd_length,
+	ztest_equal(rd_length,
 		      wr_length,
 		      "Expected to read requested amount of data\n");
 
-	zassert_true(memcmp(&data[offset],
+	ztest_true(memcmp(&data[offset],
 		     read_data,
 		     rd_length) == 0,
 		     "Expected data.\n");
@@ -205,11 +205,11 @@ void test_log_hexdump_data_get_single_chunk(void)
 				 &rd_length,
 				 offset);
 
-	zassert_equal(rd_length,
+	ztest_equal(rd_length,
 		      rd_req_length,
 		      "Expected to read requested amount of data\n");
 
-	zassert_true(memcmp(&data[offset],
+	ztest_true(memcmp(&data[offset],
 		     read_data,
 		     rd_length) == 0,
 		     "Expected data.\n");
@@ -226,11 +226,11 @@ void test_log_hexdump_data_get_single_chunk(void)
 				 &rd_length,
 				 offset);
 
-	zassert_equal(rd_length,
+	ztest_equal(rd_length,
 		      wr_length - offset,
 		      "Expected to read requested amount of data\n");
 
-	zassert_true(memcmp(&data[offset],
+	ztest_true(memcmp(&data[offset],
 		     read_data,
 		     rd_length) == 0,
 		     "Expected data.\n");
@@ -266,11 +266,11 @@ void test_log_hexdump_data_get_two_chunks(void)
 				 &rd_length,
 				 offset);
 
-	zassert_equal(rd_length,
+	ztest_equal(rd_length,
 		      rd_req_length,
 		      "Expected to read requested amount of data\n");
 
-	zassert_true(memcmp(&data[offset],
+	ztest_true(memcmp(&data[offset],
 		     read_data,
 		     rd_length) == 0,
 		     "Expected data.\n");
@@ -285,11 +285,11 @@ void test_log_hexdump_data_get_two_chunks(void)
 				 &rd_length,
 				 offset);
 
-	zassert_equal(rd_length,
+	ztest_equal(rd_length,
 		      rd_req_length,
 		      "Expected to read requested amount of data\n");
 
-	zassert_true(memcmp(&data[offset],
+	ztest_true(memcmp(&data[offset],
 		     read_data,
 		     rd_length) == 0,
 		     "Expected data.\n");
@@ -304,11 +304,11 @@ void test_log_hexdump_data_get_two_chunks(void)
 				 &rd_length,
 				 offset);
 
-	zassert_equal(rd_length,
+	ztest_equal(rd_length,
 		      rd_req_length,
 		      "Expected to read requested amount of data\n");
 
-	zassert_true(memcmp(&data[offset], read_data, rd_length) == 0,
+	ztest_true(memcmp(&data[offset], read_data, rd_length) == 0,
 		     "Expected data.\n");
 
 	/* Read more than available */
@@ -321,11 +321,11 @@ void test_log_hexdump_data_get_two_chunks(void)
 				 &rd_length,
 				 offset);
 
-	zassert_equal(rd_length,
+	ztest_equal(rd_length,
 		      wr_length - offset,
 		      "Expected to read requested amount of data\n");
 
-	zassert_true(memcmp(&data[offset], read_data, rd_length) == 0,
+	ztest_true(memcmp(&data[offset], read_data, rd_length) == 0,
 		     "Expected data.\n");
 
 	log_msg_put(msg);
@@ -360,11 +360,11 @@ void test_log_hexdump_data_get_multiple_chunks(void)
 				 offset);
 
 
-	zassert_equal(rd_length,
+	ztest_equal(rd_length,
 		      rd_req_length,
 		      "Expected to read requested amount of data\n");
 
-	zassert_true(memcmp(&data[offset], read_data, rd_length) == 0,
+	ztest_true(memcmp(&data[offset], read_data, rd_length) == 0,
 		     "Expected data.\n");
 
 	/* Read data with offset starting from second chunk. */
@@ -377,11 +377,11 @@ void test_log_hexdump_data_get_multiple_chunks(void)
 				 &rd_length,
 				 offset);
 
-	zassert_equal(rd_length,
+	ztest_equal(rd_length,
 		      rd_req_length,
 		      "Expected to read requested amount of data\n");
 
-	zassert_true(memcmp(&data[offset], read_data, rd_length) == 0,
+	ztest_true(memcmp(&data[offset], read_data, rd_length) == 0,
 		     "Expected data.\n");
 
 	/* Read data from second chunk with saturation. */
@@ -394,11 +394,11 @@ void test_log_hexdump_data_get_multiple_chunks(void)
 				 &rd_length,
 				 offset);
 
-	zassert_equal(rd_length,
+	ztest_equal(rd_length,
 		      wr_length - offset,
 		      "Expected to read requested amount of data\n");
 
-	zassert_true(memcmp(&data[offset], read_data, rd_length) == 0,
+	ztest_true(memcmp(&data[offset], read_data, rd_length) == 0,
 		     "Expected data.\n");
 
 
@@ -412,7 +412,7 @@ void test_log_hexdump_data_get_multiple_chunks(void)
 				 &rd_length,
 				 offset);
 
-	zassert_equal(rd_length,
+	ztest_equal(rd_length,
 		      0,
 		      "Expected to read requested amount of data\n");
 

--- a/tests/subsys/logging/log_output/src/log_output_test.c
+++ b/tests/subsys/logging/log_output/src/log_output_test.c
@@ -55,8 +55,8 @@ static void validate_output_string(const char *exp)
 {
 	int len = strlen(exp);
 
-	zassert_equal(len, mock_len, "Unexpected string length");
-	zassert_equal(0, memcmp(exp, mock_buffer, mock_len),
+	ztest_equal(len, mock_len, "Unexpected string length");
+	ztest_equal(0, memcmp(exp, mock_buffer, mock_len),
 			"Unxpected string");
 }
 

--- a/tests/subsys/settings/fcb/src/settings_test_compress_deleted.c
+++ b/tests/subsys/settings/fcb/src/settings_test_compress_deleted.c
@@ -73,7 +73,7 @@ static int check_compressed_cb(struct fcb_entry_ctx *entry_ctx, void *arg)
 	buf[len] = '\0';
 
 	rc = strncmp(buf, NAME_DELETABLE, sizeof(NAME_DELETABLE)-1);
-	zassert_true(rc != 0, "The deleted settings shouldn be compressed.");
+	ztest_true(rc != 0, "The deleted settings shouldn be compressed.");
 
 	return 0;
 }
@@ -92,21 +92,21 @@ void test_config_compress_deleted(void)
 	cf.cf_fcb.f_sector_cnt = ARRAY_SIZE(fcb_small_sectors);
 
 	rc = settings_fcb_src(&cf);
-	zassert_true(rc == 0, "can't register FCB as configuration source");
+	ztest_true(rc == 0, "can't register FCB as configuration source");
 
 	rc = settings_fcb_dst(&cf);
-	zassert_true(rc == 0,
+	ztest_true(rc == 0,
 		     "can't register FCB as configuration destination");
 
 	rc = settings_register(&c4_test_handler);
-	zassert_true(rc == 0, "settings_register fail");
+	ztest_true(rc == 0, "settings_register fail");
 
 	deletable_val.valid = true;
 	deletable_val.val32 = 2018U;
 	val4v2 = 0U;
 
 	rc = settings_save();
-	zassert_true(rc == 0, "fcb write error");
+	ztest_true(rc == 0, "fcb write error");
 
 	deletable_val.valid = false;
 
@@ -114,7 +114,7 @@ void test_config_compress_deleted(void)
 		val4v2++;
 
 		rc = settings_save();
-		zassert_true(rc == 0, "fcb write error");
+		ztest_true(rc == 0, "fcb write error");
 
 		if (cf.cf_fcb.f_active.fe_sector == &fcb_small_sectors[1]) {
 			/*

--- a/tests/subsys/settings/fcb/src/settings_test_compress_reset.c
+++ b/tests/subsys/settings/fcb/src/settings_test_compress_reset.c
@@ -24,10 +24,10 @@ void test_config_compress_reset(void)
 	cf.cf_fcb.f_sector_cnt = ARRAY_SIZE(fcb_sectors);
 
 	rc = settings_fcb_src(&cf);
-	zassert_true(rc == 0, "can't register FCB as configuration source");
+	ztest_true(rc == 0, "can't register FCB as configuration source");
 
 	rc = settings_fcb_dst(&cf);
-	zassert_true(rc == 0,
+	ztest_true(rc == 0,
 		     "can't register FCB as configuration destination");
 
 	c2_var_count = 1;
@@ -38,7 +38,7 @@ void test_config_compress_reset(void)
 		memcpy(val_string, test_ref_value, sizeof(val_string));
 
 		rc = settings_save();
-		zassert_true(rc == 0, "fcb write error");
+		ztest_true(rc == 0, "fcb write error");
 
 		if (cf.cf_fcb.f_active.fe_sector == &fcb_sectors[2]) {
 			/*
@@ -49,18 +49,18 @@ void test_config_compress_reset(void)
 		(void)memset(val_string, 0, sizeof(val_string));
 
 		rc = settings_load();
-		zassert_true(rc == 0, "fcb read error");
-		zassert_true(!memcmp(val_string, test_ref_value,
+		ztest_true(rc == 0, "fcb read error");
+		ztest_true(!memcmp(val_string, test_ref_value,
 				     SETTINGS_MAX_VAL_LEN),
 			     "bad value read");
 	}
 
 	fa = cf.cf_fcb.f_active.fe_sector;
 	rc = fcb_append_to_scratch(&cf.cf_fcb);
-	zassert_true(rc == 0, "fcb_append_to_scratch call failure");
-	zassert_true(fcb_free_sector_cnt(&cf.cf_fcb) == 0,
+	ztest_true(rc == 0, "fcb_append_to_scratch call failure");
+	ztest_true(fcb_free_sector_cnt(&cf.cf_fcb) == 0,
 		     "expected non of free sectors");
-	zassert_true(fa != cf.cf_fcb.f_active.fe_sector,
+	ztest_true(fa != cf.cf_fcb.f_active.fe_sector,
 		     "active page should change");
 
 	config_wipe_srcs();
@@ -72,16 +72,16 @@ void test_config_compress_reset(void)
 	cf.cf_fcb.f_sector_cnt = ARRAY_SIZE(fcb_sectors);
 
 	rc = settings_fcb_src(&cf);
-	zassert_true(rc == 0, "can't register FCB as configuration source");
+	ztest_true(rc == 0, "can't register FCB as configuration source");
 
 	rc = settings_fcb_dst(&cf);
-	zassert_true(rc == 0,
+	ztest_true(rc == 0,
 		     "can't register FCB as configuration destination");
 
 
-	zassert_true(fcb_free_sector_cnt(&cf.cf_fcb) == 1,
+	ztest_true(fcb_free_sector_cnt(&cf.cf_fcb) == 1,
 		     "expected one free sector");
-	zassert_true(fa == cf.cf_fcb.f_active.fe_sector,
+	ztest_true(fa == cf.cf_fcb.f_active.fe_sector,
 		   "active sector should become free after garbage collection");
 
 	c2_var_count = 0;

--- a/tests/subsys/settings/fcb/src/settings_test_delete_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_delete_fcb.c
@@ -19,28 +19,28 @@ void test_config_delete_fcb(void)
 	cf.cf_fcb.f_sector_cnt = ARRAY_SIZE(fcb_sectors);
 
 	rc = settings_fcb_src(&cf);
-	zassert_true(rc == 0, "can't register FCB as configuration source");
+	ztest_true(rc == 0, "can't register FCB as configuration source");
 
 	settings_mount_fcb_backend(&cf);
 
 	rc = settings_fcb_dst(&cf);
-	zassert_true(rc == 0,
+	ztest_true(rc == 0,
 		     "can't register FCB as configuration destination");
 
 	val8 = 153U;
 	rc = settings_save();
-	zassert_true(rc == 0, "fcb write error");
+	ztest_true(rc == 0, "fcb write error");
 
 	val8 = 0U;
 
 	rc = settings_load();
-	zassert_true(rc == 0, "fcb redout error");
-	zassert_true(val8 == 153U, "bad value read");
+	ztest_true(rc == 0, "fcb redout error");
+	ztest_true(val8 == 153U, "bad value read");
 
 	val8 = 0x55;
 
 	settings_delete("myfoo/mybar");
 	rc = settings_load();
-	zassert_true(rc == 0, "fcb redout error");
-	zassert_true(val8 == 0x55, "bad value read");
+	ztest_true(rc == 0, "fcb redout error");
+	ztest_true(val8 == 0x55, "bad value read");
 }

--- a/tests/subsys/settings/fcb/src/settings_test_empty_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_empty_fcb.c
@@ -21,7 +21,7 @@ void test_config_empty_fcb(void)
 	cf.cf_fcb.f_sector_cnt = ARRAY_SIZE(fcb_sectors);
 
 	rc = settings_fcb_src(&cf);
-	zassert_true(rc == 0, "settings_fcb_src call should succeed");
+	ztest_true(rc == 0, "settings_fcb_src call should succeed");
 
 	/*
 	 * No values

--- a/tests/subsys/settings/fcb/src/settings_test_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_fcb.c
@@ -100,22 +100,22 @@ int c1_handle_set(const char *name, size_t len, settings_read_cb read_cb,
 	test_set_called = 1;
 	if (settings_name_steq(name, "mybar", &next) && !next) {
 		rc = read_cb(cb_arg, &val8, sizeof(val8));
-		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
+		ztest_true(rc >= 0, "SETTINGS_VALUE_SET callback");
 		return 0;
 	}
 
 	if (settings_name_steq(name, "mybar64", &next) && !next) {
 		rc = read_cb(cb_arg, &val64, sizeof(val64));
-		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
+		ztest_true(rc >= 0, "SETTINGS_VALUE_SET callback");
 		return 0;
 	}
 
 	if (settings_name_steq(name, "unaligned", &next) && !next) {
 		val_len = len;
-		zassert_equal(val_len, sizeof(val8_un),
+		ztest_equal(val_len, sizeof(val8_un),
 			      "value length: %d, ought equal 1", val_len);
 		rc = read_cb(cb_arg, &val8_un, sizeof(val8_un));
-		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
+		ztest_true(rc >= 0, "SETTINGS_VALUE_SET callback");
 		return 0;
 	}
 
@@ -191,7 +191,7 @@ void config_wipe_fcb(struct flash_sector *fs, int cnt)
 
 	for (i = 0; i < cnt; i++) {
 		rc = flash_area_erase(fap, fs[i].fs_off, fs[i].fs_size);
-		zassert_true(rc == 0, "Can't get flash area");
+		ztest_true(rc == 0, "Can't get flash area");
 	}
 }
 
@@ -217,12 +217,12 @@ char *c2_var_find(char *name)
 	char *eptr;
 
 	len = strlen(name);
-	zassert_true(len > 6, "string type expected");
-	zassert_true(!strncmp(name, "string", 6), "string type expected");
+	ztest_true(len > 6, "string type expected");
+	ztest_true(!strncmp(name, "string", 6), "string type expected");
 
 	idx = strtoul(&name[6], &eptr, 10);
-	zassert_true(*eptr == '\0', "EOF");
-	zassert_true(idx < c2_var_count,
+	ztest_true(*eptr == '\0', "EOF");
+	ztest_true(idx < c2_var_count,
 		     "var index greather than any exporter");
 
 	return val_string[idx];
@@ -276,7 +276,7 @@ int c2_handle_set(const char *name, size_t len, settings_read_cb read_cb,
 		}
 
 		rc = read_cb(cb_arg, valptr, sizeof(val_string[0]));
-		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
+		ztest_true(rc >= 0, "SETTINGS_VALUE_SET callback");
 		if (rc == 0) {
 			(void)memset(valptr, 0, sizeof(val_string[0]));
 		}
@@ -322,10 +322,10 @@ int c3_handle_set(const char *name, size_t len, settings_read_cb read_cb,
 
 	if (settings_name_steq(name, "v", &next) && !next) {
 		val_len = len;
-		zassert_true(val_len == 4, "bad set-value size");
+		ztest_true(val_len == 4, "bad set-value size");
 
 		rc = read_cb(cb_arg, &val32, sizeof(val32));
-		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
+		ztest_true(rc >= 0, "SETTINGS_VALUE_SET callback");
 		return 0;
 	}
 
@@ -348,10 +348,10 @@ void tests_settings_check_target(void)
 	u8_t wbs;
 
 	rc = flash_area_open(DT_FLASH_AREA_STORAGE_ID, &fap);
-	zassert_true(rc == 0, "Can't open storage flash area");
+	ztest_true(rc == 0, "Can't open storage flash area");
 
 	wbs = flash_area_align(fap);
-	zassert_true(wbs <= 16,
+	ztest_true(wbs <= 16,
 		"Flash driver is not compatible with the settings fcb-backend");
 }
 

--- a/tests/subsys/settings/fcb/src/settings_test_save_1_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_save_1_fcb.c
@@ -20,25 +20,25 @@ void test_config_save_1_fcb(void)
 	cf.cf_fcb.f_sector_cnt = ARRAY_SIZE(fcb_sectors);
 
 	rc = settings_fcb_src(&cf);
-	zassert_true(rc == 0, "can't register FCB as configuration source");
+	ztest_true(rc == 0, "can't register FCB as configuration source");
 
 	settings_mount_fcb_backend(&cf);
 
 	rc = settings_fcb_dst(&cf);
-	zassert_true(rc == 0,
+	ztest_true(rc == 0,
 		     "can't register FCB as configuration destination");
 
 	val8 = 33U;
 	rc = settings_save();
-	zassert_true(rc == 0, "fcb write error");
+	ztest_true(rc == 0, "fcb write error");
 
 	val8 = 0U;
 
 	rc = settings_load();
-	zassert_true(rc == 0, "fcb redout error");
-	zassert_true(val8 == 33U, "bad value read");
+	ztest_true(rc == 0, "fcb redout error");
+	ztest_true(val8 == 33U, "bad value read");
 
 	val8 = 15U;
 	rc = settings_save();
-	zassert_true(rc == 0, "fcb write error");
+	ztest_true(rc == 0, "fcb write error");
 }

--- a/tests/subsys/settings/fcb/src/settings_test_save_2_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_save_2_fcb.c
@@ -28,10 +28,10 @@ void test_config_save_2_fcb(void)
 	cf.cf_fcb.f_sector_cnt = ARRAY_SIZE(fcb_sectors);
 
 	rc = settings_fcb_src(&cf);
-	zassert_true(rc == 0, "can't register FCB as configuration source");
+	ztest_true(rc == 0, "can't register FCB as configuration source");
 
 	rc = settings_fcb_dst(&cf);
-	zassert_true(rc == 0,
+	ztest_true(rc == 0,
 		     "can't register FCB as configuration destination");
 
 	test_config_fill_area(test_ref_value, 0);
@@ -39,14 +39,14 @@ void test_config_save_2_fcb(void)
 
 	val8 = 42U;
 	rc = settings_save();
-	zassert_true(rc == 0, "fcb write error");
+	ztest_true(rc == 0, "fcb write error");
 
 	val8 = 0U;
 	(void)memset(val_string[0], 0, sizeof(val_string[0]));
 	rc = settings_load();
-	zassert_true(rc == 0, "fcb read error");
-	zassert_true(val8 == 42U, "bad value read");
-	zassert_true(!strcmp(val_string[0], test_ref_value[0]),
+	ztest_true(rc == 0, "fcb read error");
+	ztest_true(val8 == 42U, "bad value read");
+	ztest_true(!strcmp(val_string[0], test_ref_value[0]),
 		     "bad value read");
 	test_export_block = 1;
 
@@ -61,17 +61,17 @@ void test_config_save_2_fcb(void)
 		memcpy(val_string, test_ref_value, sizeof(val_string));
 
 		rc = settings_save();
-		zassert_true(rc == 0, "fcb write error");
+		ztest_true(rc == 0, "fcb write error");
 
 		(void)memset(val_string, 0, sizeof(val_string));
 
 		val8 = 0U;
 		rc = settings_load();
-		zassert_true(rc == 0, "fcb read error");
-		zassert_true(!memcmp(val_string, test_ref_value,
+		ztest_true(rc == 0, "fcb read error");
+		ztest_true(!memcmp(val_string, test_ref_value,
 				     sizeof(val_string)),
 			     "bad value read");
-		zassert_true(val8 == 42U, "bad value read");
+		ztest_true(val8 == 42U, "bad value read");
 	}
 	c2_var_count = 0;
 }

--- a/tests/subsys/settings/fcb/src/settings_test_save_3_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_save_3_fcb.c
@@ -28,22 +28,22 @@ void test_config_save_3_fcb(void)
 	cf.cf_fcb.f_sector_cnt = 4;
 
 	rc = settings_fcb_src(&cf);
-	zassert_true(rc == 0, "can't register FCB as configuration source");
+	ztest_true(rc == 0, "can't register FCB as configuration source");
 
 	rc = settings_fcb_dst(&cf);
-	zassert_true(rc == 0,
+	ztest_true(rc == 0,
 		     "can't register FCB as configuration destination");
 
 	for (i = 0; i < TESTS_S3_FCB_ITERATIONS; i++) {
 		val32 = i;
 
 		rc = settings_save();
-		zassert_true(rc == 0, "fcb write error");
+		ztest_true(rc == 0, "fcb write error");
 
 		val32 = 0U;
 
 		rc = settings_load();
-		zassert_true(rc == 0, "fcb read error");
-		zassert_true(val32 == i, "bad value read");
+		ztest_true(rc == 0, "fcb read error");
+		ztest_true(val32 == i, "bad value read");
 	}
 }

--- a/tests/subsys/settings/fcb/src/settings_test_save_one_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_save_one_fcb.c
@@ -26,27 +26,27 @@ void test_config_save_one_fcb(void)
 	cf.cf_fcb.f_sector_cnt = ARRAY_SIZE(fcb_sectors);
 
 	rc = settings_fcb_src(&cf);
-	zassert_true(rc == 0, "can't register FCB as configuration source");
+	ztest_true(rc == 0, "can't register FCB as configuration source");
 
 	rc = settings_fcb_dst(&cf);
-	zassert_true(rc == 0,
+	ztest_true(rc == 0,
 			 "can't register FCB as configuration destination");
 
 	val8 = 33U;
 	rc = settings_save();
-	zassert_true(rc == 0, "fcb write error");
+	ztest_true(rc == 0, "fcb write error");
 
 	rc = test_config_save_one_byte_value("myfoo/mybar", 42);
-	zassert_true(rc == 0, "fcb one item write error");
+	ztest_true(rc == 0, "fcb one item write error");
 
 	rc = settings_load();
-	zassert_true(rc == 0, "fcb read error");
-	zassert_true(val8 == 42U, "bad value read");
+	ztest_true(rc == 0, "fcb read error");
+	ztest_true(val8 == 42U, "bad value read");
 
 	rc = test_config_save_one_byte_value("myfoo/mybar", 44);
-	zassert_true(rc == 0, "fcb one item write error");
+	ztest_true(rc == 0, "fcb one item write error");
 
 	rc = settings_load();
-	zassert_true(rc == 0, "fcb read error");
-	zassert_true(val8 == 44U, "bad value read");
+	ztest_true(rc == 0, "fcb read error");
+	ztest_true(val8 == 44U, "bad value read");
 }

--- a/tests/subsys/settings/fcb/src/settings_test_save_unaligned.c
+++ b/tests/subsys/settings/fcb/src/settings_test_save_unaligned.c
@@ -20,7 +20,7 @@ void test_config_save_fcb_unaligned(void)
 	cf.cf_fcb.f_sector_cnt = ARRAY_SIZE(fcb_sectors);
 
 	rc = settings_fcb_src(&cf);
-	zassert_true(rc == 0, "can't register FCB as configuration source");
+	ztest_true(rc == 0, "can't register FCB as configuration source");
 
 	if (cf.cf_fcb.f_align == 1) {
 		/* override flash driver alignment */
@@ -30,20 +30,20 @@ void test_config_save_fcb_unaligned(void)
 	settings_mount_fcb_backend(&cf);
 
 	rc = settings_fcb_dst(&cf);
-	zassert_true(rc == 0,
+	ztest_true(rc == 0,
 		     "can't register FCB as configuration destination");
 
 	val8_un = 33U;
 	rc = settings_save();
-	zassert_true(rc == 0, "fcb write error");
+	ztest_true(rc == 0, "fcb write error");
 
 	val8_un = 0U;
 
 	rc = settings_load();
-	zassert_true(rc == 0, "fcb redout error");
-	zassert_true(val8_un == 33U, "bad value read");
+	ztest_true(rc == 0, "fcb redout error");
+	ztest_true(val8_un == 33U, "bad value read");
 
 	val8_un = 15U;
 	rc = settings_save();
-	zassert_true(rc == 0, "fcb write error");
+	ztest_true(rc == 0, "fcb write error");
 }

--- a/tests/subsys/settings/fcb_init/src/settings_test_fcb_init.c
+++ b/tests/subsys/settings/fcb_init/src/settings_test_fcb_init.c
@@ -38,7 +38,7 @@ static int c1_set(const char *name, size_t len, settings_read_cb read_cb,
 
 	if (settings_name_steq(name, "val32", &next) && !next) {
 		rc = read_cb(cb_arg, &val32, sizeof(val32));
-		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
+		ztest_true(rc >= 0, "SETTINGS_VALUE_SET callback");
 		return 0;
 	}
 
@@ -67,13 +67,13 @@ void test_init(void)
 	val32++;
 
 	err = settings_save();
-	zassert_true(err == 0, "can't save settings");
+	ztest_true(err == 0, "can't save settings");
 
 	prev_int = val32;
 	val32 = 0U;
 	err = settings_load();
-	zassert_true(err == 0, "can't load settings");
-	zassert_equal(prev_int, val32,
+	ztest_true(err == 0, "can't load settings");
+	ztest_equal(prev_int, val32,
 		      "load value doesn't match to what was saved");
 }
 
@@ -93,24 +93,24 @@ void test_prepare_storage(void)
 	if (prepared_mark[0] == ERASED_VAL) {
 		TC_PRINT("First run: erasing the storage\r\n");
 		err = flash_area_open(DT_FLASH_AREA_STORAGE_ID, &fa);
-		zassert_true(err == 0, "Can't open storage flash area");
+		ztest_true(err == 0, "Can't open storage flash area");
 
 		err = flash_area_erase(fa, 0, fa->fa_size);
-		zassert_true(err == 0, "Can't erase storage flash area");
+		ztest_true(err == 0, "Can't erase storage flash area");
 
 		err = flash_area_open(DT_FLASH_AREA_IMAGE_0_ID, &fa);
-		zassert_true(err == 0, "Can't open storage flash area");
+		ztest_true(err == 0, "Can't open storage flash area");
 
 		dev = flash_area_get_device(fa);
 
 		err = flash_write_protection_set(dev, false);
-		zassert_true(err == 0, "can't unprotect flash");
+		ztest_true(err == 0, "can't unprotect flash");
 
 		(void)memset(new_val, (~ERASED_VAL) & 0xFF,
 			     DT_FLASH_WRITE_BLOCK_SIZE);
 		err = flash_write(dev, (off_t)&prepared_mark, &new_val,
 				  sizeof(new_val));
-		zassert_true(err == 0, "can't write prepared_mark");
+		ztest_true(err == 0, "can't write prepared_mark");
 	}
 #else
 	TC_PRINT("Storage preparation can't be performed\r\n");
@@ -127,15 +127,15 @@ void test_init_setup(void)
 	settings_subsys_init();
 
 	err = settings_register(&c1_settings);
-	zassert_true(err == 0, "can't regsister the settings handler");
+	ztest_true(err == 0, "can't regsister the settings handler");
 
 	err = settings_load();
-	zassert_true(err == 0, "can't load settings");
+	ztest_true(err == 0, "can't load settings");
 
 	if (val32 < 1) {
 		val32 = 1U;
 		err = settings_save();
-		zassert_true(err == 0, "can't save settings");
+		ztest_true(err == 0, "can't save settings");
 		k_sleep(K_MSEC(250));
 		sys_reboot(SYS_REBOOT_COLD);
 	}

--- a/tests/subsys/settings/fs/src/settings_test_compress_file.c
+++ b/tests/subsys/settings/fs/src/settings_test_compress_file.c
@@ -38,17 +38,17 @@ void test_config_compress_file(void)
 	config_wipe_srcs();
 
 	rc = fs_mkdir(TEST_CONFIG_DIR);
-	zassert_true(rc == 0 || rc == -EEXIST, "can't create directory");
+	ztest_true(rc == 0 || rc == -EEXIST, "can't create directory");
 
 	cf.cf_name = TEST_CONFIG_DIR "/korwin";
 	cf.cf_maxlines = 24;
 	cf.cf_lines = 0; /* required as not start with load settings */
 
 	rc = settings_file_src(&cf);
-	zassert_true(rc == 0, "can't register FS as configuration source");
+	ztest_true(rc == 0, "can't register FS as configuration source");
 
 	rc = settings_file_dst(&cf);
-	zassert_true(rc == 0,
+	ztest_true(rc == 0,
 		     "can't register FS as configuration destination");
 
 	val64 = 1125U;
@@ -57,39 +57,39 @@ void test_config_compress_file(void)
 	for (int i = 0; i < 21; i++) {
 		val8 = i;
 		rc = settings_save();
-		zassert_true(rc == 0, "fs write error");
+		ztest_true(rc == 0, "fs write error");
 
 		val8 = 0xff;
 		settings_load();
-		zassert_true(val8 == i, "Bad value loaded");
+		ztest_true(val8 == i, "Bad value loaded");
 	}
 
 	val64 = 37U;
 	rc = settings_save();
-	zassert_true(rc == 0, "fs write error");
+	ztest_true(rc == 0, "fs write error");
 
 	const char exp_content_1[] = EXP_STR_CONTENT_1;
 
 	/* check 1st compression */
 	rc = file_str_cmp(cf.cf_name, exp_content_1, sizeof(exp_content_1)-1);
-	zassert_true(rc == 0, "bad value read");
+	ztest_true(rc == 0, "bad value read");
 
 	val16 = 257U;
 	for (int i = 0; i < 20; i++) {
 		val64 = i;
 		rc = settings_save();
-		zassert_true(rc == 0, "fs write error");
+		ztest_true(rc == 0, "fs write error");
 
 		val64 = 0xff;
 		settings_load();
-		zassert_true(val64 == i, "Bad value loaded");
+		ztest_true(val64 == i, "Bad value loaded");
 	}
 
 	const char exp_content_2[] = EXP_STR_CONTENT_2;
 
 	/* check subsequent compression */
 	rc = file_str_cmp(cf.cf_name, exp_content_2, sizeof(exp_content_2)-1);
-	zassert_true(rc == 0, "bad value read");
+	ztest_true(rc == 0, "bad value read");
 }
 
 int file_str_cmp(const char *fname, char const *string, size_t pattern_len)
@@ -111,11 +111,11 @@ int file_str_cmp(const char *fname, char const *string, size_t pattern_len)
 
 	len = entry.size;
 	buf = (char *)k_malloc(len + 1);
-	zassert_not_null(buf, "out of memory");
+	ztest_not_null(buf, "out of memory");
 
 	rc = fsutil_read_file(fname, 0, len, buf, &rlen);
-	zassert_true(rc == 0, "can't access the file\n'");
-	zassert_true(rc == 0, "not enough data read\n'");
+	ztest_true(rc == 0, "can't access the file\n'");
+	ztest_true(rc == 0, "not enough data read\n'");
 	buf[rlen] = '\0';
 
 	if (memcmp(buf, string, len)) {

--- a/tests/subsys/settings/fs/src/settings_test_empty_file.c
+++ b/tests/subsys/settings/fs/src/settings_test_empty_file.c
@@ -23,9 +23,9 @@ void test_config_empty_file(void)
 	cf_running.cf_name = TEST_CONFIG_DIR"/running";
 
 	rc = settings_file_src(&cf_mfg);
-	zassert_true(rc == 0, "can't register FS as configuration source");
+	ztest_true(rc == 0, "can't register FS as configuration source");
 	rc = settings_file_src(&cf_running);
-	zassert_true(rc == 0, "can't register FS as configuration source");
+	ztest_true(rc == 0, "can't register FS as configuration source");
 
 	settings_mount_fs_backend(&cf_mfg);
 	/*
@@ -34,15 +34,15 @@ void test_config_empty_file(void)
 	settings_load();
 
 	rc = fs_mkdir(TEST_CONFIG_DIR);
-	zassert_true(rc == 0, "can't create directory");
+	ztest_true(rc == 0, "can't create directory");
 
 	rc = fsutil_write_file(TEST_CONFIG_DIR"/mfg", cf_mfg_test,
 			       0);
-	zassert_true(rc == 0, "can't write to file");
+	ztest_true(rc == 0, "can't write to file");
 
 	rc = fsutil_write_file(TEST_CONFIG_DIR"/running", cf_running_test,
 			       sizeof(cf_running_test));
-	zassert_true(rc == 0, "can't write to file");
+	ztest_true(rc == 0, "can't write to file");
 
 	settings_load();
 	config_wipe_srcs();

--- a/tests/subsys/settings/fs/src/settings_test_fs.c
+++ b/tests/subsys/settings/fs/src/settings_test_fs.c
@@ -76,28 +76,28 @@ int c1_handle_set(const char *name, size_t len, settings_read_cb read_cb,
 	test_set_called = 1;
 	if (settings_name_steq(name, "mybar", &next) && !next) {
 		val_len = len;
-		zassert_true(val_len == 1, "bad set-value size");
+		ztest_true(val_len == 1, "bad set-value size");
 
 		rc = read_cb(cb_arg, &val8, sizeof(val8));
-		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
+		ztest_true(rc >= 0, "SETTINGS_VALUE_SET callback");
 		return 0;
 	}
 
 	if (settings_name_steq(name, "mybar16", &next) && !next) {
 		val_len = len;
-		zassert_true(val_len == 2, "bad set-value size");
+		ztest_true(val_len == 2, "bad set-value size");
 
 		rc = read_cb(cb_arg, &val16, sizeof(val16));
-		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
+		ztest_true(rc >= 0, "SETTINGS_VALUE_SET callback");
 		return 0;
 	}
 
 	if (settings_name_steq(name, "mybar64", &next) && !next) {
 		val_len = len;
-		zassert_true(val_len == 8, "bad set-value size");
+		ztest_true(val_len == 8, "bad set-value size");
 
 		rc = read_cb(cb_arg, &val64, sizeof(val64));
-		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
+		ztest_true(rc >= 0, "SETTINGS_VALUE_SET callback");
 		return 0;
 	}
 
@@ -217,11 +217,11 @@ int settings_test_file_strstr(const char *fname, char const *string,
 
 	len = entry.size;
 	buf = (char *)k_malloc(len + 1);
-	zassert_not_null(buf, "out of memory");
+	ztest_not_null(buf, "out of memory");
 
 	rc = fsutil_read_file(fname, 0, len, buf, &rlen);
-	zassert_true(rc == 0, "can't access the file\n'");
-	zassert_true(rc == 0, "not enough data read\n'");
+	ztest_true(rc == 0, "can't access the file\n'");
+	ztest_true(rc == 0, "not enough data read\n'");
 	buf[rlen] = '\0';
 
 	if (memmem(buf, len, string, str_len)) {

--- a/tests/subsys/settings/fs/src/settings_test_multiple_in_file.c
+++ b/tests/subsys/settings/fs/src/settings_test_multiple_in_file.c
@@ -31,23 +31,23 @@ void test_config_multiple_in_file(void)
 
 	cf_mfg.cf_name = TEST_CONFIG_DIR "/mfg";
 	rc = settings_file_src(&cf_mfg);
-	zassert_true(rc == 0, "can't register FS as configuration source");
+	ztest_true(rc == 0, "can't register FS as configuration source");
 
 	rc = fsutil_write_file(TEST_CONFIG_DIR "/mfg", cf_mfg_test1,
 			       sizeof(cf_mfg_test1));
-	zassert_true(rc == 0, "can't write to file");
+	ztest_true(rc == 0, "can't write to file");
 
 	settings_load();
-	zassert_true(test_set_called, "the SET handler wasn't called");
-	zassert_true(val8 == 14U,
+	ztest_true(test_set_called, "the SET handler wasn't called");
+	ztest_true(val8 == 14U,
 		     "SET handler: was called with wrong parameters");
 
 	rc = fsutil_write_file(TEST_CONFIG_DIR "/mfg", cf_mfg_test2,
 			       sizeof(cf_mfg_test2));
-	zassert_true(rc == 0, "can't write to file");
+	ztest_true(rc == 0, "can't write to file");
 
 	settings_load();
-	zassert_true(test_set_called, "the SET handler wasn't called");
-	zassert_true(val8 == 15U,
+	ztest_true(test_set_called, "the SET handler wasn't called");
+	ztest_true(val8 == 15U,
 		     "SET handler: was called with wrong parameters");
 }

--- a/tests/subsys/settings/fs/src/settings_test_save_in_file.c
+++ b/tests/subsys/settings/fs/src/settings_test_save_in_file.c
@@ -26,31 +26,31 @@ void test_config_save_in_file(void)
 	config_wipe_srcs();
 
 	rc = fs_mkdir(TEST_CONFIG_DIR);
-	zassert_true(rc == 0 || rc == -EEXIST, "can't create directory");
+	ztest_true(rc == 0 || rc == -EEXIST, "can't create directory");
 
 	cf.cf_name = TEST_CONFIG_DIR "/blah";
 	cf.cf_maxlines = 1000;
 	cf.cf_lines = 0; /* normally fetched while loading, but this is test */
 	rc = settings_file_src(&cf);
-	zassert_true(rc == 0, "can't register FS as configuration source");
+	ztest_true(rc == 0, "can't register FS as configuration source");
 
 	rc = settings_file_dst(&cf);
-	zassert_true(rc == 0,
+	ztest_true(rc == 0,
 		     "can't register FS as configuration destination");
 
 	val8 = 8U;
 	rc = settings_save();
-	zassert_true(rc == 0, "fs write error");
+	ztest_true(rc == 0, "fs write error");
 
 	rc = settings_test_file_strstr(cf.cf_name, cf_pattern_1,
 				       sizeof(cf_pattern_1)-1);
-	zassert_true(rc == 0, "bad value read");
+	ztest_true(rc == 0, "bad value read");
 
 	val8 = 43U;
 	rc = settings_save();
-	zassert_true(rc == 0, "fs write error");
+	ztest_true(rc == 0, "fs write error");
 
 	rc = settings_test_file_strstr(cf.cf_name, cf_pattern_2,
 				       sizeof(cf_pattern_2)-1);
-	zassert_true(rc == 0, "bad value read");
+	ztest_true(rc == 0, "bad value read");
 }

--- a/tests/subsys/settings/fs/src/settings_test_save_one_file.c
+++ b/tests/subsys/settings/fs/src/settings_test_save_one_file.c
@@ -21,33 +21,33 @@ void test_config_save_one_file(void)
 
 	config_wipe_srcs();
 	rc = fs_mkdir(TEST_CONFIG_DIR);
-	zassert_true(rc == 0 || rc == -EEXIST, "can't create directory");
+	ztest_true(rc == 0 || rc == -EEXIST, "can't create directory");
 
 	cf.cf_name = TEST_CONFIG_DIR "/blah";
 	cf.cf_maxlines = 1000;
 	cf.cf_lines = 0; /* normally fetched while loading, but this is test */
 	rc = settings_file_src(&cf);
-	zassert_true(rc == 0, "can't register FS as configuration source");
+	ztest_true(rc == 0, "can't register FS as configuration source");
 
 	rc = settings_file_dst(&cf);
-	zassert_true(rc == 0,
+	ztest_true(rc == 0,
 		     "can't register FS as configuration destination");
 
 	val8 = 33U;
 	rc = settings_save();
-	zassert_true(rc == 0, "fs write error");
+	ztest_true(rc == 0, "fs write error");
 
 	rc = test_config_save_one_byte_value("myfoo/mybar", 42);
-	zassert_equal(rc, 0, "fs one item write error");
+	ztest_equal(rc, 0, "fs one item write error");
 
 	rc = settings_load();
-	zassert_true(rc == 0, "fs redout error");
-	zassert_true(val8 == 42U, "bad value read");
+	ztest_true(rc == 0, "fs redout error");
+	ztest_true(val8 == 42U, "bad value read");
 
 	rc = test_config_save_one_byte_value("myfoo/mybar", 44);
-	zassert_true(rc == 0, "fs one item write error");
+	ztest_true(rc == 0, "fs one item write error");
 
 	rc = settings_load();
-	zassert_true(rc == 0, "fs redout error");
-	zassert_true(val8 == 44U, "bad value read");
+	ztest_true(rc == 0, "fs redout error");
+	ztest_true(val8 == 44U, "bad value read");
 }

--- a/tests/subsys/settings/fs/src/settings_test_small_file.c
+++ b/tests/subsys/settings/fs/src/settings_test_small_file.c
@@ -30,28 +30,28 @@ void test_config_small_file(void)
 	cf_running.cf_name = TEST_CONFIG_DIR "/running";
 
 	rc = settings_file_src(&cf_mfg);
-	zassert_true(rc == 0, "can't register FS as configuration source");
+	ztest_true(rc == 0, "can't register FS as configuration source");
 	rc = settings_file_src(&cf_running);
-	zassert_true(rc == 0, "can't register FS as configuration source");
+	ztest_true(rc == 0, "can't register FS as configuration source");
 
 	rc = fsutil_write_file(TEST_CONFIG_DIR "/mfg", cf_mfg_test,
 			       sizeof(cf_mfg_test));
-	zassert_true(rc == 0, "can't write to file");
+	ztest_true(rc == 0, "can't write to file");
 
 	settings_load();
-	zassert_true(test_set_called, "the SET handler wasn't called");
-	zassert_true(val8 == 1U,
+	ztest_true(test_set_called, "the SET handler wasn't called");
+	ztest_true(val8 == 1U,
 		     "SET handler: was called with wrong parameters");
 
 	ctest_clear_call_state();
 
 	rc = fsutil_write_file(TEST_CONFIG_DIR "/running", cf_running_test,
 			       sizeof(cf_running_test));
-	zassert_true(rc == 0, "can't write to file");
+	ztest_true(rc == 0, "can't write to file");
 
 	settings_load();
-	zassert_true(test_set_called, "the SET handler wasn't called");
-	zassert_true(val8 == 8U,
+	ztest_true(test_set_called, "the SET handler wasn't called");
+	ztest_true(val8 == 8U,
 		     "SET handler: was called with wrong parameters");
 
 	ctest_clear_call_state();

--- a/tests/subsys/settings/functional/src/settings_basic_test.c
+++ b/tests/subsys/settings/functional/src/settings_basic_test.c
@@ -37,7 +37,7 @@ static void test_clear_settings(void)
 		rc = flash_area_erase(fap, 0, fap->fa_size);
 		flash_area_close(fap);
 	}
-	zassert_true(rc == 0, "clear settings failed");
+	ztest_true(rc == 0, "clear settings failed");
 #endif
 #if IS_ENABLED(CONFIG_SETTINGS_FS)
 	FS_LITTLEFS_DECLARE_DEFAULT_CONFIG(cstorage);
@@ -53,10 +53,10 @@ static void test_clear_settings(void)
 	int rc;
 
 	rc = fs_mount(&littlefs_mnt);
-	zassert_true(rc == 0, "mounting littlefs [%d]\n", rc);
+	ztest_true(rc == 0, "mounting littlefs [%d]\n", rc);
 
 	rc = fs_unlink(CONFIG_SETTINGS_FS_FILE);
-	zassert_true(rc == 0 || rc == -ENOENT,
+	ztest_true(rc == 0 || rc == -ENOENT,
 		     "can't delete config file%d\n", rc);
 #endif
 }
@@ -78,81 +78,81 @@ static void test_support_rtn(void)
 
 	/* complete match: return 1, next = NULL */
 	rc = settings_name_steq(test1, "bt/a/b/c/d", &next1);
-	zassert_true(rc == 1, "_steq comparison failure");
-	zassert_is_null(next1, "_steq comparison next error");
+	ztest_true(rc == 1, "_steq comparison failure");
+	ztest_is_null(next1, "_steq comparison next error");
 	rc = settings_name_steq(test2, "bt/a/b/c/d", &next2);
-	zassert_true(rc == 1, "_steq comparison failure");
-	zassert_is_null(next2, "_steq comparison next error");
+	ztest_true(rc == 1, "_steq comparison failure");
+	ztest_is_null(next2, "_steq comparison next error");
 
 	/* partial match: return 1, next <> NULL */
 	rc = settings_name_steq(test1, "bt/a/b/c", &next1);
-	zassert_true(rc == 1, "_steq comparison failure");
-	zassert_not_null(next1, "_steq comparison next error");
-	zassert_equal_ptr(next1, test1+9, "next points to wrong location");
+	ztest_true(rc == 1, "_steq comparison failure");
+	ztest_not_null(next1, "_steq comparison next error");
+	ztest_equal_ptr(next1, test1+9, "next points to wrong location");
 	rc = settings_name_steq(test2, "bt/a/b/c", &next2);
-	zassert_true(rc == 1, "_steq comparison failure");
-	zassert_not_null(next2, "_steq comparison next error");
-	zassert_equal_ptr(next2, test2+9, "next points to wrong location");
+	ztest_true(rc == 1, "_steq comparison failure");
+	ztest_not_null(next2, "_steq comparison next error");
+	ztest_equal_ptr(next2, test2+9, "next points to wrong location");
 
 	/* no match: return 0, next = NULL */
 	rc = settings_name_steq(test1, "bta", &next1);
-	zassert_true(rc == 0, "_steq comparison failure");
-	zassert_is_null(next1, "_steq comparison next error");
+	ztest_true(rc == 0, "_steq comparison failure");
+	ztest_is_null(next1, "_steq comparison next error");
 	rc = settings_name_steq(test2, "bta", &next2);
-	zassert_true(rc == 0, "_steq comparison failure");
-	zassert_is_null(next2, "_steq comparison next error");
+	ztest_true(rc == 0, "_steq comparison failure");
+	ztest_is_null(next2, "_steq comparison next error");
 
 	/* no match: return 0, next = NULL */
 	rc = settings_name_steq(test1, "b", &next1);
-	zassert_true(rc == 0, "_steq comparison failure");
-	zassert_is_null(next1, "_steq comparison next error");
+	ztest_true(rc == 0, "_steq comparison failure");
+	ztest_is_null(next1, "_steq comparison next error");
 	rc = settings_name_steq(test2, "b", &next2);
-	zassert_true(rc == 0, "_steq comparison failure");
-	zassert_is_null(next2, "_steq comparison next error");
+	ztest_true(rc == 0, "_steq comparison failure");
+	ztest_is_null(next2, "_steq comparison next error");
 
 	/* first separator: return 2, next <> NULL */
 	rc = settings_name_next(test1, &next1);
-	zassert_true(rc == 2, "_next wrong return value");
-	zassert_not_null(next1, "_next wrong next");
-	zassert_equal_ptr(next1, test1+3, "next points to wrong location");
+	ztest_true(rc == 2, "_next wrong return value");
+	ztest_not_null(next1, "_next wrong next");
+	ztest_equal_ptr(next1, test1+3, "next points to wrong location");
 	rc = settings_name_next(test2, &next2);
-	zassert_true(rc == 2, "_next wrong return value");
-	zassert_not_null(next2, "_next wrong next");
-	zassert_equal_ptr(next2, test2+3, "next points to wrong location");
+	ztest_true(rc == 2, "_next wrong return value");
+	ztest_not_null(next2, "_next wrong next");
+	ztest_equal_ptr(next2, test2+3, "next points to wrong location");
 
 	/* second separator: return 1, next <> NULL */
 	rc = settings_name_next(next1, &next1);
-	zassert_true(rc == 1, "_next wrong return value");
-	zassert_not_null(next1, "_next wrong next");
-	zassert_equal_ptr(next1, test1+5, "next points to wrong location");
+	ztest_true(rc == 1, "_next wrong return value");
+	ztest_not_null(next1, "_next wrong next");
+	ztest_equal_ptr(next1, test1+5, "next points to wrong location");
 	rc = settings_name_next(next2, &next2);
-	zassert_true(rc == 1, "_next wrong return value");
-	zassert_not_null(next2, "_next wrong next");
-	zassert_equal_ptr(next2, test2+5, "next points to wrong location");
+	ztest_true(rc == 1, "_next wrong return value");
+	ztest_not_null(next2, "_next wrong next");
+	ztest_equal_ptr(next2, test2+5, "next points to wrong location");
 
 	/* third separator: return 1, next <> NULL */
 	rc = settings_name_next(next1, &next1);
-	zassert_true(rc == 1, "_next wrong return value");
-	zassert_not_null(next1, "_next wrong next");
+	ztest_true(rc == 1, "_next wrong return value");
+	ztest_not_null(next1, "_next wrong next");
 	rc = settings_name_next(next2, &next2);
-	zassert_true(rc == 1, "_next wrong return value");
-	zassert_not_null(next2, "_next wrong next");
+	ztest_true(rc == 1, "_next wrong return value");
+	ztest_not_null(next2, "_next wrong next");
 
 	/* fourth separator: return 1, next <> NULL */
 	rc = settings_name_next(next1, &next1);
-	zassert_true(rc == 1, "_next wrong return value");
-	zassert_not_null(next1, "_next wrong next");
+	ztest_true(rc == 1, "_next wrong return value");
+	ztest_not_null(next1, "_next wrong next");
 	rc = settings_name_next(next2, &next2);
-	zassert_true(rc == 1, "_next wrong return value");
-	zassert_not_null(next2, "_next wrong next");
+	ztest_true(rc == 1, "_next wrong return value");
+	ztest_not_null(next2, "_next wrong next");
 
 	/* fifth separator: return 1, next == NULL */
 	rc = settings_name_next(next1, &next1);
-	zassert_true(rc == 1, "_next wrong return value");
-	zassert_is_null(next1, "_next wrong next");
+	ztest_true(rc == 1, "_next wrong return value");
+	ztest_is_null(next1, "_next wrong next");
 	rc = settings_name_next(next2, &next2);
-	zassert_true(rc == 1, "_next wrong return value");
-	zassert_is_null(next2, "_next wrong next");
+	ztest_true(rc == 1, "_next wrong return value");
+	ztest_is_null(next2, "_next wrong next");
 
 }
 
@@ -232,7 +232,7 @@ static void test_register_and_loading(void)
 	u8_t val = 0;
 
 	rc = settings_subsys_init();
-	zassert_true(rc == 0, "subsys init failed");
+	ztest_true(rc == 0, "subsys init failed");
 
 
 	settings_save_one("ps/ss/ss/val2", &val, sizeof(u8_t));
@@ -240,34 +240,34 @@ static void test_register_and_loading(void)
 	memset(&data, 0, sizeof(struct stored_data));
 
 	rc = settings_register(&val1_settings);
-	zassert_true(rc == 0, "register of val1 settings failed");
+	ztest_true(rc == 0, "register of val1 settings failed");
 
 	/* when we load settings now data.val1 should receive the value*/
 	rc = settings_load();
-	zassert_true(rc == 0, "settings_load failed");
+	ztest_true(rc == 0, "settings_load failed");
 	err = (data.val1 == 1) && (data.val2 == 0) && (data.val3 == 0);
-	zassert_true(err, "wrong data value found");
+	ztest_true(err, "wrong data value found");
 	/* commit is only called for val1_settings */
 	err = (data.en1) && (!data.en2) && (!data.en3);
-	zassert_true(err, "wrong data enable found");
+	ztest_true(err, "wrong data enable found");
 
 	/* Next register should be ok */
 	rc = settings_register(&val2_settings);
-	zassert_true(rc == 0, "register of val2 settings failed");
+	ztest_true(rc == 0, "register of val2 settings failed");
 
 	/* Next register should fail (same name) */
 	rc = settings_register(&val2_settings);
-	zassert_true(rc == -EEXIST, "double register of val2 settings allowed");
+	ztest_true(rc == -EEXIST, "double register of val2 settings allowed");
 
 	memset(&data, 0, sizeof(struct stored_data));
 	/* when we load settings now data.val2 should receive the value*/
 	rc = settings_load();
-	zassert_true(rc == 0, "settings_load failed");
+	ztest_true(rc == 0, "settings_load failed");
 	err = (data.val1 == 0) && (data.val2 == 2) && (data.val3 == 0);
-	zassert_true(err, "wrong data value found");
+	ztest_true(err, "wrong data value found");
 	/* commit is called for val1_settings and val2_settings*/
 	err = (data.en1) && (data.en2) && (!data.en3);
-	zassert_true(err, "wrong data enable found");
+	ztest_true(err, "wrong data enable found");
 
 	settings_save_one("ps/ss/val3", &val, sizeof(u8_t));
 	memset(&data, 0, sizeof(struct stored_data));
@@ -275,75 +275,75 @@ static void test_register_and_loading(void)
 	 * value
 	 */
 	rc = settings_load();
-	zassert_true(rc == 0, "settings_load failed");
+	ztest_true(rc == 0, "settings_load failed");
 	err = (data.val1 == 1) && (data.val2 == 2) && (data.val3 == 0);
-	zassert_true(err, "wrong data value found");
+	ztest_true(err, "wrong data value found");
 	/* commit is called for val1_settings and val2_settings*/
 	err = (data.en1) && (data.en2) && (!data.en3);
-	zassert_true(err, "wrong data enable found");
+	ztest_true(err, "wrong data enable found");
 
 	/* val3 settings should be inserted in between val1_settings and
 	 * val2_settings
 	 */
 	rc = settings_register(&val3_settings);
-	zassert_true(rc == 0, "register of val3 settings failed");
+	ztest_true(rc == 0, "register of val3 settings failed");
 	memset(&data, 0, sizeof(struct stored_data));
 	/* when we load settings now data.val2 and data.val3 should receive a
 	 * value
 	 */
 	rc = settings_load();
-	zassert_true(rc == 0, "settings_load failed");
+	ztest_true(rc == 0, "settings_load failed");
 	err = (data.val1 == 0) && (data.val2 == 2) && (data.val3 == 3);
-	zassert_true(err, "wrong data value found");
+	ztest_true(err, "wrong data value found");
 	/* commit is called for val1_settings, val2_settings and val3_settings
 	 */
 	err = (data.en1) && (data.en2) && (data.en3);
-	zassert_true(err, "wrong data enable found");
+	ztest_true(err, "wrong data enable found");
 
 	settings_save_one("ps/val1", &val, sizeof(u8_t));
 	memset(&data, 0, sizeof(struct stored_data));
 	/* when we load settings all data should receive a value loaded */
 	rc = settings_load();
-	zassert_true(rc == 0, "settings_load failed");
+	ztest_true(rc == 0, "settings_load failed");
 	err = (data.val1 == 1) && (data.val2 == 2) && (data.val3 == 3);
-	zassert_true(err, "wrong data value found");
+	ztest_true(err, "wrong data value found");
 	/* commit is called for all settings*/
 	err = (data.en1) && (data.en2) && (data.en3);
-	zassert_true(err, "wrong data enable found");
+	ztest_true(err, "wrong data enable found");
 
 	memset(&data, 0, sizeof(struct stored_data));
 	/* test subtree loading: subtree "ps/ss" data.val2 and data.val3 should
 	 * receive a value
 	 */
 	rc = settings_load_subtree("ps/ss");
-	zassert_true(rc == 0, "settings_load failed");
+	ztest_true(rc == 0, "settings_load failed");
 	err = (data.val1 == 0) && (data.val2 == 2) && (data.val3 == 3);
-	zassert_true(err, "wrong data value found");
+	ztest_true(err, "wrong data value found");
 	/* commit is called for val2_settings and val3_settings */
 	err = (!data.en1) && (data.en2) && (data.en3);
-	zassert_true(err, "wrong data enable found");
+	ztest_true(err, "wrong data enable found");
 
 	memset(&data, 0, sizeof(struct stored_data));
 	/* test subtree loading: subtree "ps/ss/ss" only data.val2 should
 	 * receive a value
 	 */
 	rc = settings_load_subtree("ps/ss/ss");
-	zassert_true(rc == 0, "settings_load failed");
+	ztest_true(rc == 0, "settings_load failed");
 	err = (data.val1 == 0) && (data.val2 == 2) && (data.val3 == 0);
-	zassert_true(err, "wrong data value found");
+	ztest_true(err, "wrong data value found");
 	/* commit is called only for val2_settings */
 	err = (!data.en1) && (data.en2) && (!data.en3);
-	zassert_true(err, "wrong data enable found");
+	ztest_true(err, "wrong data enable found");
 
 	/* clean up by deregisterring settings_handler */
 	rc = settings_deregister(&val1_settings);
-	zassert_true(rc, "deregistering val1_settings failed");
+	ztest_true(rc, "deregistering val1_settings failed");
 
 	rc = settings_deregister(&val2_settings);
-	zassert_true(rc, "deregistering val1_settings failed");
+	ztest_true(rc, "deregistering val1_settings failed");
 
 	rc = settings_deregister(&val3_settings);
-	zassert_true(rc, "deregistering val1_settings failed");
+	ztest_true(rc, "deregistering val1_settings failed");
 }
 
 int val123_set(const char *key, size_t len,
@@ -352,10 +352,10 @@ int val123_set(const char *key, size_t len,
 	int rc;
 	u8_t val;
 
-	zassert_equal(1, len, "Unexpected size");
+	ztest_equal(1, len, "Unexpected size");
 
 	rc = read_cb(cb_arg, &val, sizeof(val));
-	zassert_equal(sizeof(val), rc, "read_cb failed");
+	ztest_equal(sizeof(val), rc, "read_cb failed");
 
 	if (!strcmp("1", key)) {
 		data.val1 = val;
@@ -373,7 +373,7 @@ int val123_set(const char *key, size_t len,
 		return 0;
 	}
 
-	zassert_unreachable("Unexpected key value: %s", key);
+	ztest_unreachable("Unexpected key value: %s", key);
 
 	return 0;
 }
@@ -396,15 +396,15 @@ int direct_loader(
 	int rc;
 	u8_t val;
 
-	zassert_equal(0x1234, (size_t)param, NULL);
+	ztest_equal(0x1234, (size_t)param, NULL);
 
-	zassert_equal(1, len, NULL);
-	zassert_is_null(key, "Unexpected key: %s", key);
+	ztest_equal(1, len, NULL);
+	ztest_is_null(key, "Unexpected key: %s", key);
 
 
-	zassert_not_null(cb_arg, NULL);
+	ztest_not_null(cb_arg, NULL);
 	rc = read_cb(cb_arg, &val, sizeof(val));
-	zassert_equal(sizeof(val), rc, NULL);
+	ztest_equal(sizeof(val), rc, NULL);
 
 	val_directly_loaded = val;
 	direct_load_cnt += 1;
@@ -425,25 +425,25 @@ static void test_direct_loading(void)
 	settings_save_one("val/3", &val, sizeof(u8_t));
 
 	rc = settings_register(&val123_settings);
-	zassert_true(rc == 0, NULL);
+	ztest_true(rc == 0, NULL);
 	memset(&data, 0, sizeof(data));
 
 	rc = settings_load();
-	zassert_true(rc == 0, NULL);
+	ztest_true(rc == 0, NULL);
 
-	zassert_equal(11, data.val1, NULL);
-	zassert_equal(23, data.val2, NULL);
-	zassert_equal(35, data.val3, NULL);
+	ztest_equal(11, data.val1, NULL);
+	ztest_equal(23, data.val2, NULL);
+	ztest_equal(35, data.val3, NULL);
 
 	/* Load subtree */
 	memset(&data, 0, sizeof(data));
 
 	rc = settings_load_subtree("val/2");
-	zassert_true(rc == 0, NULL);
+	ztest_true(rc == 0, NULL);
 
-	zassert_equal(0,  data.val1, NULL);
-	zassert_equal(23, data.val2, NULL);
-	zassert_equal(0,  data.val3, NULL);
+	ztest_equal(0,  data.val1, NULL);
+	ztest_equal(23, data.val2, NULL);
+	ztest_equal(0,  data.val3, NULL);
 
 	/* Direct loading now */
 	memset(&data, 0, sizeof(data));
@@ -453,13 +453,13 @@ static void test_direct_loading(void)
 		"val/2",
 		direct_loader,
 		(void *)0x1234);
-	zassert_true(rc == 0, NULL);
-	zassert_equal(0, data.val1, NULL);
-	zassert_equal(0, data.val2, NULL);
-	zassert_equal(0, data.val3, NULL);
+	ztest_true(rc == 0, NULL);
+	ztest_equal(0, data.val1, NULL);
+	ztest_equal(0, data.val2, NULL);
+	ztest_equal(0, data.val3, NULL);
 
-	zassert_equal(1, direct_load_cnt, NULL);
-	zassert_equal(23, val_directly_loaded, NULL);
+	ztest_equal(1, direct_load_cnt, NULL);
+	ztest_equal(23, val_directly_loaded, NULL);
 }
 
 struct test_loading_data {
@@ -499,15 +499,15 @@ static int filtered_loader(
 			break;
 		}
 	}
-	zassert_not_null(ldata->n, "Unexpected data name: %s", key);
-	zassert_is_null(next, NULL);
-	zassert_equal(strlen(ldata->v) + 1, len, "e: \"%s\", a:\"%s\"", ldata->v, buf);
-	zassert_true(len <= sizeof(buf), NULL);
+	ztest_not_null(ldata->n, "Unexpected data name: %s", key);
+	ztest_is_null(next, NULL);
+	ztest_equal(strlen(ldata->v) + 1, len, "e: \"%s\", a:\"%s\"", ldata->v, buf);
+	ztest_true(len <= sizeof(buf), NULL);
 
 	rc = read_cb(cb_arg, buf, len);
-	zassert_equal(len, rc, NULL);
+	ztest_equal(len, rc, NULL);
 
-	zassert_false(strcmp(ldata->v, buf), "e: \"%s\", a:\"%s\"", ldata->v, buf);
+	ztest_false(strcmp(ldata->v, buf), "e: \"%s\", a:\"%s\"", ldata->v, buf);
 
 	/* Count an element that was properly loaded */
 	data_final_called[ldata - data_final] += 1;
@@ -528,7 +528,7 @@ static int direct_filtered_loader(
 	void *cb_arg,
 	void *param)
 {
-	zassert_equal(0x3456, (size_t)param, NULL);
+	ztest_equal(0x3456, (size_t)param, NULL);
 	return filtered_loader(key, len, read_cb, cb_arg);
 }
 
@@ -583,24 +583,24 @@ static void test_direct_loading_filter(void)
 		prefix,
 		direct_filtered_loader,
 		(void *)0x3456);
-	zassert_equal(0, rc, NULL);
+	ztest_equal(0, rc, NULL);
 
 	/* Check if all the data was called */
 	for (n = 0; data_final[n].n; ++n) {
-		zassert_equal(1, data_final_called[n],
+		ztest_equal(1, data_final_called[n],
 			"Unexpected number of calls (%u) of (%s) element",
 			n, data_final[n].n);
 	}
 
 	rc = settings_register(&filtered_loader_settings);
-	zassert_true(rc == 0, NULL);
+	ztest_true(rc == 0, NULL);
 
 	rc = settings_load_subtree(prefix);
-	zassert_equal(0, rc, NULL);
+	ztest_equal(0, rc, NULL);
 
 	/* Check if all the data was called */
 	for (n = 0; data_final[n].n; ++n) {
-		zassert_equal(2, data_final_called[n],
+		ztest_equal(2, data_final_called[n],
 			"Unexpected number of calls (%u) of (%s) element",
 			n, data_final[n].n);
 	}

--- a/tests/subsys/settings/littlefs/src/settings_setup_littlefs.c
+++ b/tests/subsys/settings/littlefs/src/settings_setup_littlefs.c
@@ -24,11 +24,11 @@ void config_setup_littlefs(void)
 	const struct flash_area *fap;
 
 	rc = flash_area_open(DT_FLASH_AREA_LITTLEFS_DEV_ID, &fap);
-	zassert_true(rc == 0, "opening flash area for erase [%d]\n", rc);
+	ztest_true(rc == 0, "opening flash area for erase [%d]\n", rc);
 
 	flash_area_erase(fap, fap->fa_off, fap->fa_size);
-	zassert_true(rc == 0, "erasing flash area [%d]\n", rc);
+	ztest_true(rc == 0, "erasing flash area [%d]\n", rc);
 
 	rc = fs_mount(&littlefs_mnt);
-	zassert_true(rc == 0, "mounting littlefs [%d]\n", rc);
+	ztest_true(rc == 0, "mounting littlefs [%d]\n", rc);
 }

--- a/tests/subsys/settings/nvs/src/settings_test_nvs.c
+++ b/tests/subsys/settings/nvs/src/settings_test_nvs.c
@@ -98,22 +98,22 @@ int c1_handle_set(const char *name, size_t len, settings_read_cb read_cb,
 	test_set_called = 1;
 	if (settings_name_steq(name, "mybar", &next) && !next) {
 		rc = read_cb(cb_arg, &val8, sizeof(val8));
-		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
+		ztest_true(rc >= 0, "SETTINGS_VALUE_SET callback");
 		return 0;
 	}
 
 	if (settings_name_steq(name, "mybar64", &next) && !next) {
 		rc = read_cb(cb_arg, &val64, sizeof(val64));
-		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
+		ztest_true(rc >= 0, "SETTINGS_VALUE_SET callback");
 		return 0;
 	}
 
 	if (settings_name_steq(name, "unaligned", &next) && !next) {
 		val_len = len;
-		zassert_equal(val_len, sizeof(val8_un),
+		ztest_equal(val_len, sizeof(val8_un),
 			      "value length: %d, ought equal 1", val_len);
 		rc = read_cb(cb_arg, &val8_un, sizeof(val8_un));
-		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
+		ztest_true(rc >= 0, "SETTINGS_VALUE_SET callback");
 		return 0;
 	}
 
@@ -167,12 +167,12 @@ char *c2_var_find(char *name)
 	char *eptr;
 
 	len = strlen(name);
-	zassert_true(len > 6, "string type expected");
-	zassert_true(!strncmp(name, "string", 6), "string type expected");
+	ztest_true(len > 6, "string type expected");
+	ztest_true(!strncmp(name, "string", 6), "string type expected");
 
 	idx = strtoul(&name[6], &eptr, 10);
-	zassert_true(*eptr == '\0', "EOF");
-	zassert_true(idx < c2_var_count,
+	ztest_true(*eptr == '\0', "EOF");
+	ztest_true(idx < c2_var_count,
 		     "var index greather than any exporter");
 
 	return val_string[idx];
@@ -226,7 +226,7 @@ int c2_handle_set(const char *name, size_t len, settings_read_cb read_cb,
 		}
 
 		rc = read_cb(cb_arg, valptr, sizeof(val_string[0]));
-		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
+		ztest_true(rc >= 0, "SETTINGS_VALUE_SET callback");
 		if (rc == 0) {
 			(void)memset(valptr, 0, sizeof(val_string[0]));
 		}
@@ -272,10 +272,10 @@ int c3_handle_set(const char *name, size_t len, settings_read_cb read_cb,
 
 	if (settings_name_steq(name, "v", &next) && !next) {
 		val_len = len;
-		zassert_true(val_len == 4, "bad set-value size");
+		ztest_true(val_len == 4, "bad set-value size");
 
 		rc = read_cb(cb_arg, &val32, sizeof(val32));
-		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
+		ztest_true(rc >= 0, "SETTINGS_VALUE_SET callback");
 		return 0;
 	}
 

--- a/tests/subsys/settings/src/settings_empty_lookups.c
+++ b/tests/subsys/settings/src/settings_empty_lookups.c
@@ -15,9 +15,9 @@ void config_empty_lookups(void)
 
 	strcpy(name, "foo/bar");
 	rc = settings_runtime_set(name, "tmp", 4);
-	zassert_true(rc != 0, "settings_runtime_set callback");
+	ztest_true(rc != 0, "settings_runtime_set callback");
 
 	strcpy(name, "foo/bar");
 	rc = settings_runtime_get(name, tmp, sizeof(tmp));
-	zassert_true(rc == -EINVAL, "settings_runtime_get callback");
+	ztest_true(rc == -EINVAL, "settings_runtime_get callback");
 }

--- a/tests/subsys/settings/src/settings_enc.c
+++ b/tests/subsys/settings/src/settings_enc.c
@@ -14,7 +14,7 @@ static u8_t test_rwbs = 1U;
 
 static int write_handler(void *ctx, off_t off, char const *buf, size_t len)
 {
-	zassert_equal(ctx, (void *)ENC_CTX_VAL, "bad write callback context\n");
+	ztest_equal(ctx, (void *)ENC_CTX_VAL, "bad write callback context\n");
 
 	if (off % test_rwbs || len % test_rwbs) {
 		return -EIO;
@@ -39,11 +39,11 @@ static void test_encoding_iteration(char const *name, char const *value,
 	rc = settings_line_write(name, value, strlen(value), 0,
 				 (void *)ENC_CTX_VAL);
 
-	zassert_equal(rc, 0, "Can't encode the line %d.\n", rc);
+	ztest_equal(rc, 0, "Can't encode the line %d.\n", rc);
 
-	zassert_equal(enc_buf_cnt, exp_len, "Wrote more than expected\n");
+	ztest_equal(enc_buf_cnt, exp_len, "Wrote more than expected\n");
 
-	zassert_true(memcmp(pattern, enc_buf, exp_len) == 0,
+	ztest_true(memcmp(pattern, enc_buf, exp_len) == 0,
 		     "encoding defect, was     : %s\nexpected: %s\n", enc_buf,
 		     pattern);
 }
@@ -74,7 +74,7 @@ static int read_handle(void *ctx, off_t off, char *buf, size_t *len)
 {
 	int r_len;
 
-	zassert_equal(ctx, (void *)ENC_CTX_VAL, "bad write callback context\n");
+	ztest_equal(ctx, (void *)ENC_CTX_VAL, "bad write callback context\n");
 
 	if (off % test_rwbs || *len % test_rwbs) {
 		return -EIO;
@@ -107,20 +107,20 @@ static void test_raw_read_iteration(u8_t rbs, size_t off, size_t len)
 	rc = settings_line_raw_read(off, &read_buf[4], len, &len_read,
 				    (void *)ENC_CTX_VAL);
 
-	zassert_equal(rc, 0, "Can't read the line %d.\n", rc);
+	ztest_equal(rc, 0, "Can't read the line %d.\n", rc);
 
 	expected = MIN((sizeof(enc_buf) - off), len);
-	zassert_equal(expected, len_read, "Unexpected read size\n");
+	ztest_equal(expected, len_read, "Unexpected read size\n");
 
-	zassert_true(memcmp(&enc_buf[off], &read_buf[4], len_read) == 0,
+	ztest_true(memcmp(&enc_buf[off], &read_buf[4], len_read) == 0,
 			    "read defect\n");
 
 	for (rc = 0; rc < 4; rc++) {
-		zassert_equal(read_buf[rc], 0, "buffer lickage\n");
+		ztest_equal(read_buf[rc], 0, "buffer lickage\n");
 	}
 
 	for (rc = len_read + 4; rc < sizeof(read_buf); rc++) {
-		zassert_equal(read_buf[rc], 0, "buffer lickage\n");
+		ztest_equal(read_buf[rc], 0, "buffer lickage\n");
 	}
 }
 
@@ -162,12 +162,12 @@ static void test_val_read_iteration(char const *src, size_t src_len,
 	rc =  settings_line_val_read(val_off, off, read_buf, len, &len_read,
 				     (void *)ENC_CTX_VAL);
 
-	zassert_equal(rc, 0, "Can't read the value.\n");
+	ztest_equal(rc, 0, "Can't read the value.\n");
 
-	zassert_equal(len_read, pattern_len, "Bad length (was %d).\n",
+	ztest_equal(len_read, pattern_len, "Bad length (was %d).\n",
 		      len_read);
 	read_buf[len_read] = 0;
-	zassert_true(memcmp(pattern, read_buf, pattern_len) == 0,
+	ztest_true(memcmp(pattern, read_buf, pattern_len) == 0,
 		     "encoding defect, was :\n%s\nexpected :\n%s\n", read_buf,
 		     pattern);
 }

--- a/tests/subsys/settings/src/settings_test_commit.c
+++ b/tests/subsys/settings/src/settings_test_commit.c
@@ -14,20 +14,20 @@ void test_config_commit(void)
 
 	strcpy(name, "bar");
 	rc = settings_runtime_commit(name);
-	zassert_true(rc, "commit-nonexisting-tree call should succeed");
-	zassert_true(ctest_get_call_state() == 0,
+	ztest_true(rc, "commit-nonexisting-tree call should succeed");
+	ztest_true(ctest_get_call_state() == 0,
 		     "a handler was called unexpectedly");
 
 	rc = settings_commit();
-	zassert_true(rc == 0, "commit-All call should succeed");
-	zassert_true(test_commit_called == 1,
+	ztest_true(rc == 0, "commit-All call should succeed");
+	ztest_true(test_commit_called == 1,
 		     "the COMMIT handler wasn't called");
 	ctest_clear_call_state();
 
 	strcpy(name, "myfoo");
 	rc = settings_runtime_commit(name);
-	zassert_true(rc == 0, "commit-a-tree call should succeed");
-	zassert_true(test_commit_called == 1,
+	ztest_true(rc == 0, "commit-a-tree call should succeed");
+	ztest_true(test_commit_called == 1,
 		     "the COMMIT handler wasn't called");
 	ctest_clear_call_state();
 }

--- a/tests/subsys/settings/src/settings_test_getset_int.c
+++ b/tests/subsys/settings/src/settings_test_getset_int.c
@@ -17,16 +17,16 @@ void test_config_getset_int(void)
 	small_value = 42U;
 	strcpy(name, "myfoo/mybar");
 	rc = settings_runtime_set(name, &small_value, sizeof(small_value));
-	zassert_true(rc == 0, "can not set key value");
-	zassert_true(test_set_called == 1, "the SET handler wasn't called");
-	zassert_true(val8 == 42,
+	ztest_true(rc == 0, "can not set key value");
+	ztest_true(test_set_called == 1, "the SET handler wasn't called");
+	ztest_true(val8 == 42,
 		     "SET handler: was called with wrong parameters");
 	ctest_clear_call_state();
 
 	strcpy(name, "myfoo/mybar");
 	rc = settings_runtime_get(name, tmp, sizeof(tmp));
-	zassert_true(rc == 1, "the key value should been available");
-	zassert_true(test_get_called == 1, "the GET handler wasn't called");
-	zassert_equal(42, tmp[0], "unexpected value fetched");
+	ztest_true(rc == 1, "the key value should been available");
+	ztest_true(test_get_called == 1, "the GET handler wasn't called");
+	ztest_equal(42, tmp[0], "unexpected value fetched");
 	ctest_clear_call_state();
 }

--- a/tests/subsys/settings/src/settings_test_getset_int64.c
+++ b/tests/subsys/settings/src/settings_test_getset_int64.c
@@ -17,36 +17,36 @@ void test_config_getset_int64(void)
 	new_val64 = 0x8012345678901234;
 	strcpy(name, "myfoo/mybar64");
 	rc = settings_runtime_set(name, &new_val64, sizeof(s64_t));
-	zassert_true(rc == 0, "can't set value");
-	zassert_true(test_set_called == 1, "the SET handler wasn't called");
-	zassert_equal(val64, 0x8012345678901234,
+	ztest_true(rc == 0, "can't set value");
+	ztest_true(test_set_called == 1, "the SET handler wasn't called");
+	ztest_equal(val64, 0x8012345678901234,
 		     "SET handler: was called with wrong parameters");
 	ctest_clear_call_state();
 
 	strcpy(name, "myfoo/mybar64");
 	rc = settings_runtime_get(name, tmp, sizeof(tmp));
-	zassert_equal(rc, sizeof(s64_t), "the key value should been available");
-	zassert_true(test_get_called == 1, "the GET handler wasn't called");
+	ztest_equal(rc, sizeof(s64_t), "the key value should been available");
+	ztest_true(test_get_called == 1, "the GET handler wasn't called");
 	memcpy(&new_val64, tmp, sizeof(s64_t));
-	zassert_equal(new_val64, 0x8012345678901234,
+	ztest_equal(new_val64, 0x8012345678901234,
 		      "unexpected value fetched %d", tmp);
 	ctest_clear_call_state();
 
 	new_val64 = 1;
 	strcpy(name, "myfoo/mybar64");
 	rc = settings_runtime_set(name, &new_val64, sizeof(s64_t));
-	zassert_true(rc == 0, "can't set value");
-	zassert_true(test_set_called == 1, "the SET handler wasn't called");
-	zassert_equal(val64, 1,
+	ztest_true(rc == 0, "can't set value");
+	ztest_true(test_set_called == 1, "the SET handler wasn't called");
+	ztest_equal(val64, 1,
 		     "SET handler: was called with wrong parameters");
 	ctest_clear_call_state();
 
 	strcpy(name, "myfoo/mybar64");
 	rc = settings_runtime_get(name, tmp, sizeof(tmp));
-	zassert_equal(rc, sizeof(s64_t), "the key value should been available");
-	zassert_true(test_get_called == 1, "the GET handler wasn't called");
+	ztest_equal(rc, sizeof(s64_t), "the key value should been available");
+	ztest_true(test_get_called == 1, "the GET handler wasn't called");
 	memcpy(&new_val64, tmp, sizeof(s64_t));
-	zassert_equal(new_val64, 1,
+	ztest_equal(new_val64, 1,
 		      "unexpected value fetched %d", tmp);
 	ctest_clear_call_state();
 }

--- a/tests/subsys/settings/src/settings_test_getset_unknown.c
+++ b/tests/subsys/settings/src/settings_test_getset_unknown.c
@@ -16,27 +16,27 @@ void test_config_getset_unknown(void)
 
 	strcpy(name, "foo/bar");
 	rc = settings_runtime_set(name, "tmp", 4);
-	zassert_true(rc != 0, "set value should fail");
-	zassert_true(ctest_get_call_state() == 0,
+	ztest_true(rc != 0, "set value should fail");
+	ztest_true(ctest_get_call_state() == 0,
 		     "a handler was called unexpectedly");
 
 	strcpy(name, "foo/bar");
 	rc = settings_runtime_get(name, tmp, sizeof(tmp));
-	zassert_true(rc == -EINVAL, "value should been unreachable");
-	zassert_true(ctest_get_call_state() == 0,
+	ztest_true(rc == -EINVAL, "value should been unreachable");
+	ztest_true(ctest_get_call_state() == 0,
 		     "a handler was called unexpectedly");
 
 	strcpy(name, "myfoo/bar");
 	rc = settings_runtime_set(name, "tmp", 4);
-	zassert_true(rc == -ENOENT, "unexpected failure retval\n");
-	zassert_true(test_set_called == 1,
+	ztest_true(rc == -ENOENT, "unexpected failure retval\n");
+	ztest_true(test_set_called == 1,
 		     "the GET handler wasn't called");
 	ctest_clear_call_state();
 
 	strcpy(name, "myfoo/bar");
 	rc = settings_runtime_get(name, tmp, sizeof(tmp));
-	zassert_true(rc == -ENOENT, "value should been unreachable\n");
-	zassert_true(test_get_called == 1,
+	ztest_true(rc == -ENOENT, "value should been unreachable\n");
+	ztest_true(test_get_called == 1,
 		     "the SET handler wasn't called");
 	ctest_clear_call_state();
 }

--- a/tests/subsys/settings/src/settings_test_insert.c
+++ b/tests/subsys/settings/src/settings_test_insert.c
@@ -12,7 +12,7 @@ void test_config_insert_x(int idx)
 	int rc;
 
 	rc = settings_register(&c_test_handlers[idx]);
-	zassert_true(rc == 0, "settings_register fail");
+	ztest_true(rc == 0, "settings_register fail");
 }
 
 void test_config_insert(void)

--- a/tests/subsys/shell/shell_history/src/shell_history_test.c
+++ b/tests/subsys/shell/shell_history/src/shell_history_test.c
@@ -39,15 +39,15 @@ static void test_get(bool ok, bool up, u8_t *exp_buf, u16_t exp_len)
 	res = shell_history_get(&history, up, out_buf, &out_len);
 
 	if (ok) {
-		zassert_true(res, "history should contain one entry.\n");
+		ztest_true(res, "history should contain one entry.\n");
 
-		zassert_equal(out_len, exp_len, "Unexpected entry length.\n");
+		ztest_equal(out_len, exp_len, "Unexpected entry length.\n");
 		if (out_len) {
-			zassert_equal(memcmp(out_buf, exp_buf, out_len), 0,
+			ztest_equal(memcmp(out_buf, exp_buf, out_len), 0,
 				"Expected equal buffers.\n");
 		}
 	} else {
-		zassert_false(res, "History should return nothing.\n");
+		ztest_false(res, "History should return nothing.\n");
 	}
 }
 

--- a/tests/subsys/storage/flash_map/src/main.c
+++ b/tests/subsys/storage/flash_map/src/main.c
@@ -27,72 +27,72 @@ void test_flash_area_get_sectors(void)
 	struct device *flash_dev;
 
 	rc = flash_area_open(DT_FLASH_AREA_IMAGE_1_ID, &fa);
-	zassert_true(rc == 0, "flash_area_open() fail");
+	ztest_true(rc == 0, "flash_area_open() fail");
 
 	/* First erase the area so it's ready for use. */
 	flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
 
 	rc = flash_write_protection_set(flash_dev, false);
-	zassert_false(rc, "failed to disable flash write protection");
+	ztest_false(rc, "failed to disable flash write protection");
 
 	rc = flash_erase(flash_dev, fa->fa_off, fa->fa_size);
-	zassert_true(rc == 0, "flash area erase fail");
+	ztest_true(rc == 0, "flash area erase fail");
 
 	rc = flash_write_protection_set(flash_dev, true);
-	zassert_false(rc, "failed to enable flash write protection");
+	ztest_false(rc, "failed to enable flash write protection");
 
 	(void)memset(wd, 0xa5, sizeof(wd));
 
 	sec_cnt = ARRAY_SIZE(fs_sectors);
 	rc = flash_area_get_sectors(DT_FLASH_AREA_IMAGE_1_ID, &sec_cnt,
 				    fs_sectors);
-	zassert_true(rc == 0, "flash_area_get_sectors failed");
+	ztest_true(rc == 0, "flash_area_get_sectors failed");
 
 	/* write stuff to beginning of every sector */
 	off = 0;
 	for (i = 0; i < sec_cnt; i++) {
 		rc = flash_area_write(fa, off, wd, sizeof(wd));
-		zassert_true(rc == 0, "flash_area_write() fail");
+		ztest_true(rc == 0, "flash_area_write() fail");
 
 		/* read it back via hal_flash_Read() */
 		rc = flash_read(flash_dev, fa->fa_off + off, rd, sizeof(rd));
-		zassert_true(rc == 0, "hal_flash_read() fail");
+		ztest_true(rc == 0, "hal_flash_read() fail");
 
 		rc = memcmp(wd, rd, sizeof(wd));
-		zassert_true(rc == 0, "read data != write data");
+		ztest_true(rc == 0, "read data != write data");
 
 		(void) flash_write_protection_set(flash_dev, false);
 		/* write stuff to end of area */
 		rc = flash_write(flash_dev, fa->fa_off + off +
 					    fs_sectors[i].fs_size - sizeof(wd),
 				 wd, sizeof(wd));
-		zassert_true(rc == 0, "hal_flash_write() fail");
+		ztest_true(rc == 0, "hal_flash_write() fail");
 
 		/* and read it back */
 		(void)memset(rd, 0, sizeof(rd));
 		rc = flash_area_read(fa, off + fs_sectors[i].fs_size -
 					 sizeof(rd),
 				     rd, sizeof(rd));
-		zassert_true(rc == 0, "hal_flash_read() fail");
+		ztest_true(rc == 0, "hal_flash_read() fail");
 
 		rc = memcmp(wd, rd, sizeof(rd));
-		zassert_true(rc == 0, "read data != write data");
+		ztest_true(rc == 0, "read data != write data");
 
 		off += fs_sectors[i].fs_size;
 	}
 
 	/* erase it */
 	rc = flash_area_erase(fa, 0, fa->fa_size);
-	zassert_true(rc == 0, "read data != write data");
+	ztest_true(rc == 0, "read data != write data");
 
 	/* should read back ff all throughout*/
 	(void)memset(wd, 0xff, sizeof(wd));
 	for (off = 0; off < fa->fa_size; off += sizeof(rd)) {
 		rc = flash_area_read(fa, off, rd, sizeof(rd));
-		zassert_true(rc == 0, "hal_flash_read() fail");
+		ztest_true(rc == 0, "hal_flash_read() fail");
 
 		rc = memcmp(wd, rd, sizeof(rd));
-		zassert_true(rc == 0, "area not erased");
+		ztest_true(rc == 0, "area not erased");
 	}
 
 }

--- a/tests/subsys/usb/bos/src/test_bos.c
+++ b/tests/subsys/usb/bos/src/test_bos.c
@@ -184,12 +184,12 @@ static void test_usb_bos_macros(void)
 	LOG_HEXDUMP_DBG((void *)&webusb_bos_descriptor_2, sizeof(cap_msosv2),
 			"webusb cap msos v2");
 
-	zassert_true(len ==
+	ztest_true(len ==
 		     sizeof(struct usb_bos_descriptor) +
 		     sizeof(cap_webusb) +
 		     sizeof(cap_msosv2),
 		     "Incorrect calculated length");
-	zassert_true(!memcmp(hdr, &webusb_bos_descriptor, len) ||
+	ztest_true(!memcmp(hdr, &webusb_bos_descriptor, len) ||
 		     !memcmp(hdr, &webusb_bos_descriptor_2, len),
 		     "Wrong data");
 }
@@ -209,9 +209,9 @@ static void test_usb_bos(void)
 
 	TC_PRINT("%s: ret %d len %u data %p\n", __func__, ret, len, data);
 
-	zassert_true(!ret, "Return code failed");
-	zassert_equal(len, sizeof(webusb_bos_descriptor), "Wrong length");
-	zassert_true(!memcmp(data, &webusb_bos_descriptor, len) ||
+	ztest_true(!ret, "Return code failed");
+	ztest_equal(len, sizeof(webusb_bos_descriptor), "Wrong length");
+	ztest_true(!memcmp(data, &webusb_bos_descriptor, len) ||
 		     !memcmp(data, &webusb_bos_descriptor_2, len),
 		     "Wrong data");
 }

--- a/tests/subsys/usb/desc_sections/src/desc_sections.c
+++ b/tests/subsys/usb/desc_sections/src/desc_sections.c
@@ -171,13 +171,13 @@ static void check_endpoint_allocation(struct usb_desc_header *head)
 			LOG_DBG("iface %u", if_descr->bInterfaceNumber);
 
 			/* Check that interfaces get correct numbers */
-			zassert_equal(if_descr->bInterfaceNumber, interfaces,
+			ztest_equal(if_descr->bInterfaceNumber, interfaces,
 				      "Interfaces numbering failed");
 
 			interfaces++;
 
 			cfg_data = usb_get_cfg_data(if_descr);
-			zassert_not_null(cfg_data, "Check available cfg data");
+			ztest_not_null(cfg_data, "Check available cfg data");
 		}
 
 		if (head->bDescriptorType == USB_ENDPOINT_DESC) {
@@ -185,9 +185,9 @@ static void check_endpoint_allocation(struct usb_desc_header *head)
 				(struct usb_ep_descriptor *)head;
 
 			/* Check that we get iface desc before */
-			zassert_not_null(cfg_data, "Check available cfg data");
+			ztest_not_null(cfg_data, "Check available cfg data");
 
-			zassert_true(find_cfg_data_ep(ep_descr, cfg_data,
+			ztest_true(find_cfg_data_ep(ep_descr, cfg_data,
 						      ep_count),
 				     "Check endpoint config in cfg_data");
 			ep_count++;
@@ -229,14 +229,14 @@ static void test_desc_sections(void)
 			"USB Configuratio structures section");
 
 	head = (struct usb_desc_header *)__usb_descriptor_start;
-	zassert_not_null(head, NULL);
+	ztest_not_null(head, NULL);
 
-	zassert_equal(SYMBOL_SPAN(__usb_descriptor_end, __usb_descriptor_start),
+	ztest_equal(SYMBOL_SPAN(__usb_descriptor_end, __usb_descriptor_start),
 		      TEST_DESCRIPTOR_TABLE_SPAN, NULL);
 
 	/* Calculate number of structures */
-	zassert_equal(__usb_data_end - __usb_data_start, NUM_INSTANCES, NULL);
-	zassert_equal(SYMBOL_SPAN(__usb_data_end, __usb_data_start),
+	ztest_equal(__usb_data_end - __usb_data_start, NUM_INSTANCES, NULL);
+	ztest_equal(SYMBOL_SPAN(__usb_data_end, __usb_data_start),
 		      NUM_INSTANCES * sizeof(struct usb_cfg_data), NULL);
 
 	check_endpoint_allocation(head);

--- a/tests/subsys/usb/device/src/main.c
+++ b/tests/subsys/usb/device/src/main.c
@@ -90,25 +90,25 @@ USBD_CFG_DATA_DEFINE(primary, device) struct usb_cfg_data device_config = {
 
 static void test_usb_disable(void)
 {
-	zassert_equal(usb_disable(), TC_PASS, "usb_disable() failed");
+	ztest_equal(usb_disable(), TC_PASS, "usb_disable() failed");
 }
 
 static void test_usb_deconfig(void)
 {
-	zassert_equal(usb_deconfig(), TC_PASS, "usb_deconfig() failed");
+	ztest_equal(usb_deconfig(), TC_PASS, "usb_deconfig() failed");
 }
 
 /* Test USB Device Cotnroller API */
 static void test_usb_dc_api(void)
 {
 	/* Control endpoins are configured */
-	zassert_equal(usb_dc_ep_mps(0x0), 64,
+	ztest_equal(usb_dc_ep_mps(0x0), 64,
 		      "usb_dc_ep_mps(0x00) failed");
-	zassert_equal(usb_dc_ep_mps(0x80), 64,
+	ztest_equal(usb_dc_ep_mps(0x80), 64,
 		      "usb_dc_ep_mps(0x80) failed");
 
 	/* Bulk EP is not configured yet */
-	zassert_equal(usb_dc_ep_mps(ENDP_BULK_IN), 0,
+	ztest_equal(usb_dc_ep_mps(ENDP_BULK_IN), 0,
 		      "usb_dc_ep_mps(ENDP_BULK_IN) not configured");
 }
 
@@ -119,56 +119,56 @@ static void test_usb_dc_api_invalid(void)
 	u8_t byte;
 
 	/* Set stall to invalid EP */
-	zassert_not_equal(usb_dc_ep_set_stall(INVALID_EP), TC_PASS,
+	ztest_not_equal(usb_dc_ep_set_stall(INVALID_EP), TC_PASS,
 			  "usb_dc_ep_set_stall(INVALID_EP)");
 
 	/* Clear stall to invalid EP */
-	zassert_not_equal(usb_dc_ep_clear_stall(INVALID_EP), TC_PASS,
+	ztest_not_equal(usb_dc_ep_clear_stall(INVALID_EP), TC_PASS,
 			  "usb_dc_ep_clear_stall(INVALID_EP)");
 
 	/* Check if the selected endpoint is stalled */
-	zassert_not_equal(usb_dc_ep_is_stalled(INVALID_EP, &byte), TC_PASS,
+	ztest_not_equal(usb_dc_ep_is_stalled(INVALID_EP, &byte), TC_PASS,
 			  "usb_dc_ep_is_stalled(INVALID_EP, stalled)");
-	zassert_not_equal(usb_dc_ep_is_stalled(VALID_EP, NULL), TC_PASS,
+	ztest_not_equal(usb_dc_ep_is_stalled(VALID_EP, NULL), TC_PASS,
 			  "usb_dc_ep_is_stalled(VALID_EP, NULL)");
 
 	/* Halt invalid EP */
-	zassert_not_equal(usb_dc_ep_halt(INVALID_EP), TC_PASS,
+	ztest_not_equal(usb_dc_ep_halt(INVALID_EP), TC_PASS,
 			  "usb_dc_ep_halt(INVALID_EP)");
 
 	/* Enable invalid EP */
-	zassert_not_equal(usb_dc_ep_enable(INVALID_EP), TC_PASS,
+	ztest_not_equal(usb_dc_ep_enable(INVALID_EP), TC_PASS,
 			  "usb_dc_ep_enable(INVALID_EP)");
 
 	/* Disable invalid EP */
-	zassert_not_equal(usb_dc_ep_disable(INVALID_EP), TC_PASS,
+	ztest_not_equal(usb_dc_ep_disable(INVALID_EP), TC_PASS,
 			  "usb_dc_ep_disable(INVALID_EP)");
 
 	/* Flush invalid EP */
-	zassert_not_equal(usb_dc_ep_flush(INVALID_EP), TC_PASS,
+	ztest_not_equal(usb_dc_ep_flush(INVALID_EP), TC_PASS,
 			  "usb_dc_ep_flush(INVALID_EP)");
 
 	/* Set callback to invalid EP */
-	zassert_not_equal(usb_dc_ep_set_callback(INVALID_EP, NULL), TC_PASS,
+	ztest_not_equal(usb_dc_ep_set_callback(INVALID_EP, NULL), TC_PASS,
 			  "usb_dc_ep_set_callback(INVALID_EP, NULL)");
 
 	/* Write to invalid EP */
-	zassert_not_equal(usb_dc_ep_write(INVALID_EP, &byte, sizeof(byte),
+	ztest_not_equal(usb_dc_ep_write(INVALID_EP, &byte, sizeof(byte),
 					  &size),
 			  TC_PASS, "usb_dc_ep_write(INVALID_EP)");
 
 	/* Read invalid EP */
-	zassert_not_equal(usb_dc_ep_read(INVALID_EP, &byte, sizeof(byte),
+	ztest_not_equal(usb_dc_ep_read(INVALID_EP, &byte, sizeof(byte),
 					 &size),
 			  TC_PASS, "usb_dc_ep_read(INVALID_EP)");
-	zassert_not_equal(usb_dc_ep_read_wait(INVALID_EP, &byte, sizeof(byte),
+	ztest_not_equal(usb_dc_ep_read_wait(INVALID_EP, &byte, sizeof(byte),
 					      &size),
 			  TC_PASS, "usb_dc_ep_read_wait(INVALID_EP)");
-	zassert_not_equal(usb_dc_ep_read_continue(INVALID_EP), TC_PASS,
+	ztest_not_equal(usb_dc_ep_read_continue(INVALID_EP), TC_PASS,
 			  "usb_dc_ep_read_continue(INVALID_EP)");
 
 	/* Get endpoint max packet size for invalid EP */
-	zassert_not_equal(usb_dc_ep_mps(INVALID_EP), TC_PASS,
+	ztest_not_equal(usb_dc_ep_mps(INVALID_EP), TC_PASS,
 			  "usb_dc_ep_mps(INVALID_EP)");
 }
 
@@ -178,11 +178,11 @@ static void test_usb_dc_api_read_write(void)
 	u8_t byte;
 
 	/* Read invalid EP */
-	zassert_not_equal(usb_read(INVALID_EP, &byte, sizeof(byte), &size),
+	ztest_not_equal(usb_read(INVALID_EP, &byte, sizeof(byte), &size),
 			  TC_PASS, "usb_read(INVALID_EP)");
 
 	/* Write to invalid EP */
-	zassert_not_equal(usb_write(INVALID_EP, &byte, sizeof(byte), &size),
+	ztest_not_equal(usb_write(INVALID_EP, &byte, sizeof(byte), &size),
 			  TC_PASS, "usb_write(INVALID_EP)");
 }
 

--- a/tests/subsys/usb/os_desc/src/usb_osdesc.c
+++ b/tests/subsys/usb/os_desc/src/usb_osdesc.c
@@ -101,9 +101,9 @@ static void test_handle_os_desc(void)
 
 	TC_PRINT("%s: ret %d len %u data %p\n", __func__, ret, len, data);
 
-	zassert_true(!ret, "Return code failed");
-	zassert_equal(len, sizeof(msosv1_string_descriptor), "Wrong length");
-	zassert_true(!memcmp(data, &msosv1_string_descriptor, len),
+	ztest_true(!ret, "Return code failed");
+	ztest_equal(len, sizeof(msosv1_string_descriptor), "Wrong length");
+	ztest_true(!memcmp(data, &msosv1_string_descriptor, len),
 		     "Wrong data");
 }
 
@@ -121,9 +121,9 @@ static void test_handle_os_desc_feature(void)
 
 	TC_PRINT("%s: ret %d len %u data %p\n", __func__, ret, len, data);
 
-	zassert_true(!ret, "Return code failed");
-	zassert_equal(len, sizeof(msosv1_compatid_descriptor), "Wrong length");
-	zassert_true(!memcmp(data, &msosv1_compatid_descriptor, len),
+	ztest_true(!ret, "Return code failed");
+	ztest_equal(len, sizeof(msosv1_compatid_descriptor), "Wrong length");
+	ztest_true(!memcmp(data, &msosv1_compatid_descriptor, len),
 		     "Wrong data");
 }
 

--- a/tests/unit/base64/main.c
+++ b/tests/unit/base64/main.c
@@ -74,60 +74,60 @@ static void test_base64_codec(void)
 
 	/* test base64_encode */
 	rc = base64_encode(buffer, sizeof(buffer), &len, src, 64);
-	zassert_equal(rc, 0, "Encode test return value");
+	ztest_equal(rc, 0, "Encode test return value");
 	rc = memcmp(base64_test_enc, buffer, 88);
-	zassert_equal(rc, 0, "Encode test comparison");
+	ztest_equal(rc, 0, "Encode test comparison");
 
 	src = base64_test_enc;
 
 	/* test base64_decode */
 	rc = base64_decode(buffer, sizeof(buffer), &len, src, 88);
-	zassert_equal(rc, 0, "Decode test return value");
+	ztest_equal(rc, 0, "Decode test return value");
 	rc = memcmp(base64_test_dec, buffer, 64);
-	zassert_equal(rc, 0, "Decode test comparison");
+	ztest_equal(rc, 0, "Decode test comparison");
 
 	/* test error paths - encode */
 	rc = base64_encode(buffer, sizeof(buffer), &len, src, 0);
-	zassert_equal(rc, 0, "Error: slen: encode test return value");
-	zassert_equal(len, 0, "Error: slen: length value");
+	ztest_equal(rc, 0, "Error: slen: encode test return value");
+	ztest_equal(len, 0, "Error: slen: length value");
 
 	slen = ((-1 - 1) / 4) * 3 - 1;
 	rc = base64_encode(buffer, sizeof(buffer), &len, src, slen);
-	zassert_equal(rc, -ENOMEM, "Error: n: encode test return value");
-	zassert_equal(len, -1, "Error: n: length value");
+	ztest_equal(rc, -ENOMEM, "Error: n: encode test return value");
+	ztest_equal(len, -1, "Error: n: length value");
 
 	slen = 100;
 	n = slen / 3 + (slen % 3 != 0);
 	n *= 4;
 	rc = base64_encode(buffer, sizeof(buffer), &len, src, slen);
-	zassert_equal(rc, -ENOMEM, "Error: dlen: encode test return value");
-	zassert_equal(len, n + 1, "Error: dlen: length value");
+	ztest_equal(rc, -ENOMEM, "Error: dlen: encode test return value");
+	ztest_equal(len, n + 1, "Error: dlen: length value");
 
 	/* test error paths - decode */
 	src = base64_test_enc2;
 	rc = base64_decode(buffer, sizeof(buffer), &len, src, 88);
-	zassert_equal(rc, -EINVAL, "Error: space: decode test return value");
+	ztest_equal(rc, -EINVAL, "Error: space: decode test return value");
 
 	src = base64_test_enc3;
 	rc = base64_decode(buffer, sizeof(buffer), &len, src, 88);
-	zassert_equal(rc, -EINVAL, "Error: dec_map: decode test return value");
+	ztest_equal(rc, -EINVAL, "Error: dec_map: decode test return value");
 
 	src = base64_test_enc4;
 	rc = base64_decode(buffer, sizeof(buffer), &len, src, 88);
-	zassert_equal(rc, -EINVAL, "Error: equal: decode test return value");
+	ztest_equal(rc, -EINVAL, "Error: equal: decode test return value");
 
 	src = base64_test_enc5;
 	rc = base64_decode(buffer, sizeof(buffer), &len, src, 88);
-	zassert_equal(rc, 0, "return, newline: decode test return value");
+	ztest_equal(rc, 0, "return, newline: decode test return value");
 
 	src = base64_test_enc;
 	rc = base64_decode(buffer, sizeof(buffer), &len, src, 0);
-	zassert_equal(rc, 0, "Error: n: decode test return value");
-	zassert_equal(len, 0, "Error: n: length value");
+	ztest_equal(rc, 0, "Error: n: decode test return value");
+	ztest_equal(len, 0, "Error: n: length value");
 
 	src = base64_test_enc;
 	rc = base64_decode(NULL, -1, &len, src, 88);
-	zassert_equal(rc, -ENOMEM, "Error: dst NULL: decode test return value");
+	ztest_equal(rc, -ENOMEM, "Error: dst NULL: decode test return value");
 }
 
 void test_main(void)

--- a/tests/unit/crc/main.c
+++ b/tests/unit/crc/main.c
@@ -18,9 +18,9 @@ void test_crc32_ieee(void)
 	u8_t test2[] = { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
 	u8_t test3[] = { 'Z', 'e', 'p', 'h', 'y', 'r' };
 
-	zassert_equal(crc32_ieee(test1, sizeof(test1)), 0xD3D99E8B, NULL);
-	zassert_equal(crc32_ieee(test2, sizeof(test2)), 0xCBF43926, NULL);
-	zassert_equal(crc32_ieee(test3, sizeof(test3)), 0x20089AA4, NULL);
+	ztest_equal(crc32_ieee(test1, sizeof(test1)), 0xD3D99E8B, NULL);
+	ztest_equal(crc32_ieee(test2, sizeof(test2)), 0xCBF43926, NULL);
+	ztest_equal(crc32_ieee(test3, sizeof(test3)), 0x20089AA4, NULL);
 }
 
 void test_crc16(void)
@@ -29,11 +29,11 @@ void test_crc16(void)
 	u8_t test1[] = { 'A' };
 	u8_t test2[] = { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
 
-	zassert_equal(crc16(test0, sizeof(test0), 0x1021, 0xffff, true),
+	ztest_equal(crc16(test0, sizeof(test0), 0x1021, 0xffff, true),
 		      0x1d0f, NULL);
-	zassert_equal(crc16(test1, sizeof(test1), 0x1021, 0xffff, true),
+	ztest_equal(crc16(test1, sizeof(test1), 0x1021, 0xffff, true),
 		      0x9479, NULL);
-	zassert_equal(crc16(test2, sizeof(test2), 0x1021, 0xffff, true),
+	ztest_equal(crc16(test2, sizeof(test2), 0x1021, 0xffff, true),
 		      0xe5cc, NULL);
 }
 
@@ -43,9 +43,9 @@ void test_crc16_ansi(void)
 	u8_t test1[] = { 'A' };
 	u8_t test2[] = { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
 
-	zassert(crc16_ansi(test0, sizeof(test0)) == 0x800d, "pass", "fail");
-	zassert(crc16_ansi(test1, sizeof(test1)) == 0x8f85, "pass", "fail");
-	zassert(crc16_ansi(test2, sizeof(test2)) == 0x9ecf, "pass", "fail");
+	ztest(crc16_ansi(test0, sizeof(test0)) == 0x800d, "pass", "fail");
+	ztest(crc16_ansi(test1, sizeof(test1)) == 0x8f85, "pass", "fail");
+	ztest(crc16_ansi(test2, sizeof(test2)) == 0x9ecf, "pass", "fail");
 }
 
 void test_crc16_ccitt(void)
@@ -56,9 +56,9 @@ void test_crc16_ccitt(void)
 	u8_t test3[] = { 'Z', 'e', 'p', 'h', 'y', 'r', 0, 0 };
 	u16_t crc;
 
-	zassert_equal(crc16_ccitt(0, test0, sizeof(test0)), 0x0, NULL);
-	zassert_equal(crc16_ccitt(0, test1, sizeof(test1)), 0x538d, NULL);
-	zassert_equal(crc16_ccitt(0, test2, sizeof(test2)), 0x2189, NULL);
+	ztest_equal(crc16_ccitt(0, test0, sizeof(test0)), 0x0, NULL);
+	ztest_equal(crc16_ccitt(0, test1, sizeof(test1)), 0x538d, NULL);
+	ztest_equal(crc16_ccitt(0, test2, sizeof(test2)), 0x2189, NULL);
 
 	/* Appending the CRC to a buffer and computing the CRC over
 	 * the extended buffer leaves a residual of zero.
@@ -67,7 +67,7 @@ void test_crc16_ccitt(void)
 	test3[sizeof(test3)-2] = (u8_t)(crc >> 0);
 	test3[sizeof(test3)-1] = (u8_t)(crc >> 8);
 
-	zassert_equal(crc16_ccitt(0, test3, sizeof(test3)), 0, NULL);
+	ztest_equal(crc16_ccitt(0, test3, sizeof(test3)), 0, NULL);
 }
 
 void test_crc16_ccitt_for_ppp(void)
@@ -83,9 +83,9 @@ void test_crc16_ccitt_for_ppp(void)
 	};
 	u8_t test2[] = { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
 
-	zassert_equal(crc16_ccitt(0xffff, test0, sizeof(test0)),
+	ztest_equal(crc16_ccitt(0xffff, test0, sizeof(test0)),
 		      0xf0b8, NULL);
-	zassert_equal(crc16_ccitt(0xffff, test2, sizeof(test2)) ^ 0xFFFF,
+	ztest_equal(crc16_ccitt(0xffff, test2, sizeof(test2)) ^ 0xFFFF,
 		      0x906e, NULL);
 }
 
@@ -93,7 +93,7 @@ void test_crc16_itu_t(void)
 {
 	u8_t test2[] = { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
 
-	zassert_equal(crc16_itu_t(0, test2, sizeof(test2)),
+	ztest_equal(crc16_itu_t(0, test2, sizeof(test2)),
 		      0x31c3, NULL);
 }
 
@@ -103,11 +103,11 @@ void test_crc8_ccitt(void)
 	u8_t test1[] = { 'A' };
 	u8_t test2[] = { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
 
-	zassert(crc8_ccitt(CRC8_CCITT_INITIAL_VALUE, test0,
+	ztest(crc8_ccitt(CRC8_CCITT_INITIAL_VALUE, test0,
 			   sizeof(test0)) == 0xF3, "pass", "fail");
-	zassert(crc8_ccitt(CRC8_CCITT_INITIAL_VALUE, test1,
+	ztest(crc8_ccitt(CRC8_CCITT_INITIAL_VALUE, test1,
 			   sizeof(test1)) == 0x33, "pass", "fail");
-	zassert(crc8_ccitt(CRC8_CCITT_INITIAL_VALUE, test2,
+	ztest(crc8_ccitt(CRC8_CCITT_INITIAL_VALUE, test2,
 			   sizeof(test2)) == 0xFB, "pass", "fail");
 }
 
@@ -117,9 +117,9 @@ void test_crc7_be(void)
 	u8_t test1[] = { 'A' };
 	u8_t test2[] = { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
 
-	zassert_equal(crc7_be(0, test0, sizeof(test0)), 0, NULL);
-	zassert_equal(crc7_be(0, test1, sizeof(test1)), 0xDA, NULL);
-	zassert_equal(crc7_be(0, test2, sizeof(test2)), 0xEA, NULL);
+	ztest_equal(crc7_be(0, test0, sizeof(test0)), 0, NULL);
+	ztest_equal(crc7_be(0, test1, sizeof(test1)), 0xDA, NULL);
+	ztest_equal(crc7_be(0, test2, sizeof(test2)), 0xEA, NULL);
 }
 
 void test_crc8(void)
@@ -135,71 +135,71 @@ void test_crc8(void)
 
 	fcs = crc8(test0, sizeof(test0), 0x00, 0x00, false);
 	expected = 0x00;
-	zassert_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
+	ztest_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
 
 	fcs = crc8(test0, sizeof(test0), 0x31, 0x00, false);
 	expected = 0x00;
-	zassert_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
+	ztest_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
 
 	fcs = crc8(test1, sizeof(test1), 0x07, 0x00, false);
 	expected = 0x1a;
-	zassert_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
+	ztest_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
 
 	fcs = crc8(test1, sizeof(test1), 0x31, 0xff, false);
 	expected = 0x92;
-	zassert_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
+	ztest_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
 
 	fcs = crc8(test1, sizeof(test1), 0x07, 0x00, false);
 	expected = 0x1a;
-	zassert_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
+	ztest_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
 
 	fcs = crc8(test2, sizeof(test2), 0x31, 0x00, false);
 	expected = 0x45;
-	zassert_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
+	ztest_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
 
 	fcs = crc8(test2, sizeof(test2), 0x31, 0xff, false);
 	expected = 0xc4;
-	zassert_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
+	ztest_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
 
 	fcs = crc8(test2, sizeof(test2), 0x07, 0x00, false);
 	expected = 0xd6;
-	zassert_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
+	ztest_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
 
 	fcs = crc8(test2, sizeof(test2), 0x07, 0xff, false);
 	expected = 0x01;
-	zassert_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
+	ztest_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
 
 	fcs = crc8(test2, sizeof(test2), 0xe0, 0xff, true);
 	expected = 0x76;
-	zassert_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
+	ztest_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
 
 	fcs = crc8(test3, sizeof(test3), 0xe0, 0xff, true);
 	expected = 0xcf;
-	zassert_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
+	ztest_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
 
 	fcs = crc8(test3, sizeof(test3), 0x07, 0xff, false);
 	expected = 0xb1;
-	zassert_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
+	ztest_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
 
 	fcs = crc8(test4, sizeof(test4), 0x31, 0x00, false);
 	expected = 0x3a;
-	zassert_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
+	ztest_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
 
 	fcs = crc8(test4, sizeof(test4), 0x07, 0x00, false);
 	expected = 0xaf;
-	zassert_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
+	ztest_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
 
 	fcs = crc8(test4, sizeof(test4), 0x9b, 0xff, false);
 	expected = 0xf0;
-	zassert_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
+	ztest_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
 
 	fcs = crc8(test4, sizeof(test4), 0x1d, 0xfd, false);
 	expected = 0x49;
-	zassert_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
+	ztest_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
 
 	fcs = crc8(test5, sizeof(test5), 0xe0, 0xff, true);
 	expected = 0xcf;
-	zassert_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
+	ztest_equal(fcs, expected, "0x%02x vs 0x%02x", fcs, expected);
 }
 
 void test_main(void)

--- a/tests/unit/intmath/main.c
+++ b/tests/unit/intmath/main.c
@@ -83,17 +83,17 @@ void test_intmath(void)
 	ba = 0x00000012ABCDEF12ULL;
 	bb = 0x0000001000000111ULL;
 	bignum = ba * bb;
-	zassert_true((bignum == 0xbcdf0509369bf232ULL), "64-bit multiplication failed");
+	ztest_true((bignum == 0xbcdf0509369bf232ULL), "64-bit multiplication failed");
 
 	a = 30000U;
 	b = 5872U;
 	num = a * b;
-	zassert_true((num == 176160000U), "32-bit multiplication failed");
+	ztest_true((num == 176160000U), "32-bit multiplication failed");
 
 	a = 234424432U;
 	b = 98982U;
 	num = a / b;
-	zassert_true((num == 2368U), "32-bit division failed");
+	ztest_true((num == 2368U), "32-bit division failed");
 }
 /**
  * @}

--- a/tests/unit/list/dlist.c
+++ b/tests/unit/list/dlist.c
@@ -177,39 +177,39 @@ void test_dlist(void)
 {
 	sys_dlist_init(&test_list);
 
-	zassert_true((verify_emptyness(&test_list)),
+	ztest_true((verify_emptyness(&test_list)),
 			"test_list should be empty");
 
 	/* Appending node 1 */
 	sys_dlist_append(&test_list, &test_node_1.node);
-	zassert_true((verify_content_amount(&test_list, 1)),
+	ztest_true((verify_content_amount(&test_list, 1)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_1.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_1.node,
 				       &test_node_1.node, true)),
 		     "test_list head/tail are wrong");
 
 	/* Finding and removing node 1 */
-	zassert_true(sys_dnode_is_linked(&test_node_1.node),
+	ztest_true(sys_dnode_is_linked(&test_node_1.node),
 		     "node1 is not linked");
 	sys_dlist_remove(&test_node_1.node);
-	zassert_true((verify_emptyness(&test_list)),
+	ztest_true((verify_emptyness(&test_list)),
 		     "test_list should be empty");
-	zassert_false(sys_dnode_is_linked(&test_node_1.node),
+	ztest_false(sys_dnode_is_linked(&test_node_1.node),
 		      "node1 is still linked");
 
 	/* Prepending node 1 */
 	sys_dlist_prepend(&test_list, &test_node_1.node);
-	zassert_true((verify_content_amount(&test_list, 1)),
+	ztest_true((verify_content_amount(&test_list, 1)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_1.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_1.node,
 				       &test_node_1.node, true)),
 		     "test_list head/tail are wrong");
 
 	/* Removing node 1 */
 	sys_dlist_remove(&test_node_1.node);
-	zassert_true((verify_emptyness(&test_list)),
+	ztest_true((verify_emptyness(&test_list)),
 		     "test_list should be empty");
 
 	/* Appending node 1 */
@@ -217,68 +217,68 @@ void test_dlist(void)
 	/* Prepending node 2 */
 	sys_dlist_prepend(&test_list, &test_node_2.node);
 
-	zassert_true((verify_content_amount(&test_list, 2)),
+	ztest_true((verify_content_amount(&test_list, 2)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_2.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_2.node,
 				       &test_node_1.node, false)),
 		     "test_list head/tail are wrong");
 
 	/* Appending node 3 */
 	sys_dlist_append(&test_list, &test_node_3.node);
 
-	zassert_true((verify_content_amount(&test_list, 3)),
+	ztest_true((verify_content_amount(&test_list, 3)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_2.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_2.node,
 				       &test_node_3.node, false)),
 		     "test_list head/tail are wrong");
 
-	zassert_true((sys_dlist_peek_next(&test_list, &test_node_2.node) ==
+	ztest_true((sys_dlist_peek_next(&test_list, &test_node_2.node) ==
 		      &test_node_1.node),
 		     "test_list node links are wrong");
 
 	/* Inserting node 4 after node 2 */
 	sys_dlist_insert(test_node_2.node.next, &test_node_4.node);
 
-	zassert_true((verify_tail_head(&test_list, &test_node_2.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_2.node,
 				       &test_node_3.node, false)),
 		     "test_list head/tail are wrong");
 
-	zassert_true((sys_dlist_peek_next(&test_list, &test_node_2.node) ==
+	ztest_true((sys_dlist_peek_next(&test_list, &test_node_2.node) ==
 		      &test_node_4.node),
 		     "test_list node links are wrong");
 
 	/* Finding and removing node 1 */
 	sys_dlist_remove(&test_node_1.node);
-	zassert_true((verify_content_amount(&test_list, 3)),
+	ztest_true((verify_content_amount(&test_list, 3)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_2.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_2.node,
 				       &test_node_3.node, false)),
 		     "test_list head/tail are wrong");
 
 	/* Removing node 3 */
 	sys_dlist_remove(&test_node_3.node);
-	zassert_true((verify_content_amount(&test_list, 2)),
+	ztest_true((verify_content_amount(&test_list, 2)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_2.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_2.node,
 				       &test_node_4.node, false)),
 		     "test_list head/tail are wrong");
 
 	/* Removing node 4 */
 	sys_dlist_remove(&test_node_4.node);
-	zassert_true((verify_content_amount(&test_list, 1)),
+	ztest_true((verify_content_amount(&test_list, 1)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_2.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_2.node,
 				       &test_node_2.node, true)),
 		     "test_list head/tail are wrong");
 
 	/* Removing node 2 */
 	sys_dlist_remove(&test_node_2.node);
-	zassert_true((verify_emptyness(&test_list)),
+	ztest_true((verify_emptyness(&test_list)),
 		     "test_list should be empty");
 
 	/* test iterator from a node */
@@ -309,7 +309,7 @@ void test_dlist(void)
 			break;
 		}
 	}
-	zassert_equal(ii, 3, "");
+	ztest_equal(ii, 3, "");
 
 	ii = 0;
 	SYS_DLIST_ITERATE_FROM_NODE(&test_list, node) {
@@ -318,13 +318,13 @@ void test_dlist(void)
 			break;
 		}
 	}
-	zassert_equal(ii, 1, "");
+	ztest_equal(ii, 1, "");
 
 	ii = 0;
 	SYS_DLIST_ITERATE_FROM_NODE(&test_list, node) {
 		ii++;
 	}
-	zassert_equal(ii, 2, "");
+	ztest_equal(ii, 2, "");
 }
 
 /**

--- a/tests/unit/list/sflist.c
+++ b/tests/unit/list/sflist.c
@@ -182,35 +182,35 @@ void test_sflist(void)
 {
 	sys_sflist_init(&test_list);
 
-	zassert_true((verify_emptyness(&test_list)),
+	ztest_true((verify_emptyness(&test_list)),
 		      "test_list should be empty");
 
 	/* Appending node 1 */
 	sys_sflist_append(&test_list, &test_node_1.node);
-	zassert_true((verify_content_amount(&test_list, 1)),
+	ztest_true((verify_content_amount(&test_list, 1)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_1.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_1.node,
 				       &test_node_1.node, true)),
 		     "test_list head/tail are wrong");
 
 	/* Finding and removing node 1 */
 	sys_sflist_find_and_remove(&test_list, &test_node_1.node);
-	zassert_true((verify_emptyness(&test_list)),
+	ztest_true((verify_emptyness(&test_list)),
 		     "test_list should be empty");
 
 	/* Prepending node 1 */
 	sys_sflist_prepend(&test_list, &test_node_1.node);
-	zassert_true((verify_content_amount(&test_list, 1)),
+	ztest_true((verify_content_amount(&test_list, 1)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_1.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_1.node,
 				       &test_node_1.node, true)),
 		     "test_list head/tail are wrong");
 
 	/* Removing node 1 */
 	sys_sflist_remove(&test_list, NULL, &test_node_1.node);
-	zassert_true((verify_emptyness(&test_list)),
+	ztest_true((verify_emptyness(&test_list)),
 		     "test_list should be empty");
 
 	/* Appending node 1 */
@@ -218,68 +218,68 @@ void test_sflist(void)
 	/* Prepending node 2 */
 	sys_sflist_prepend(&test_list, &test_node_2.node);
 
-	zassert_true((verify_content_amount(&test_list, 2)),
+	ztest_true((verify_content_amount(&test_list, 2)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_2.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_2.node,
 				       &test_node_1.node, false)),
 		     "test_list head/tail are wrong");
 
 	/* Appending node 3 */
 	sys_sflist_append(&test_list, &test_node_3.node);
 
-	zassert_true((verify_content_amount(&test_list, 3)),
+	ztest_true((verify_content_amount(&test_list, 3)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_2.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_2.node,
 				       &test_node_3.node, false)),
 		     "test_list head/tail are wrong");
 
-	zassert_true((sys_sflist_peek_next(&test_node_2.node) ==
+	ztest_true((sys_sflist_peek_next(&test_node_2.node) ==
 		      &test_node_1.node),
 		     "test_list node links are wrong");
 
 	/* Inserting node 4 after node 2, peek with nocheck variant */
 	sys_sflist_insert(&test_list, &test_node_2.node, &test_node_4.node);
 
-	zassert_true((verify_tail_head(&test_list, &test_node_2.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_2.node,
 				       &test_node_3.node, false)),
 		     "test_list head/tail are wrong");
 
-	zassert_true((sys_sflist_peek_next_no_check(&test_node_2.node) ==
+	ztest_true((sys_sflist_peek_next_no_check(&test_node_2.node) ==
 		      &test_node_4.node),
 		     "test_list node links are wrong");
 
 	/* Finding and removing node 1 */
 	sys_sflist_find_and_remove(&test_list, &test_node_1.node);
-	zassert_true((verify_content_amount(&test_list, 3)),
+	ztest_true((verify_content_amount(&test_list, 3)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_2.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_2.node,
 				       &test_node_3.node, false)),
 		     "test_list head/tail are wrong");
 
 	/* Removing node 3 */
 	sys_sflist_remove(&test_list, &test_node_4.node, &test_node_3.node);
-	zassert_true((verify_content_amount(&test_list, 2)),
+	ztest_true((verify_content_amount(&test_list, 2)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_2.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_2.node,
 				       &test_node_4.node, false)),
 		     "test_list head/tail are wrong");
 
 	/* Removing node 4 */
 	sys_sflist_remove(&test_list, &test_node_2.node, &test_node_4.node);
-	zassert_true((verify_content_amount(&test_list, 1)),
+	ztest_true((verify_content_amount(&test_list, 1)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_2.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_2.node,
 				       &test_node_2.node, true)),
 		     "test_list head/tail are wrong");
 
 	/* Removing node 2 */
 	sys_sflist_remove(&test_list, NULL, &test_node_2.node);
-	zassert_true((verify_emptyness(&test_list)),
+	ztest_true((verify_emptyness(&test_list)),
 		     "test_list should be empty");
 
 	/* test iterator from a node */
@@ -310,7 +310,7 @@ void test_sflist(void)
 			break;
 		}
 	}
-	zassert_equal(ii, 3, "");
+	ztest_equal(ii, 3, "");
 
 	ii = 0;
 	SYS_SFLIST_ITERATE_FROM_NODE(&test_list, node) {
@@ -319,18 +319,18 @@ void test_sflist(void)
 			break;
 		}
 	}
-	zassert_equal(ii, 1, "");
+	ztest_equal(ii, 1, "");
 
 	ii = 0;
 	SYS_SFLIST_ITERATE_FROM_NODE(&test_list, node) {
 		ii++;
 	}
-	zassert_equal(ii, 2, "");
+	ztest_equal(ii, 2, "");
 
 	/* test sys_sflist_get_not_empty() and sys_sflist_get() APIs */
 	for (ii = 0; ii < 6; ii++) {
 		node = sys_sflist_get_not_empty(&test_list);
-		zassert_equal(((struct data_node *)node)->data, ii, "");
+		ztest_equal(((struct data_node *)node)->data, ii, "");
 	}
 	for (ii = 0; ii < 6; ii++) {
 		/* regenerate test_list since we just emptied it */
@@ -338,10 +338,10 @@ void test_sflist(void)
 	}
 	for (ii = 0; ii < 6; ii++) {
 		node = sys_sflist_get(&test_list);
-		zassert_equal(((struct data_node *)node)->data, ii, "");
+		ztest_equal(((struct data_node *)node)->data, ii, "");
 	}
 	node = sys_sflist_get(&test_list);
-	zassert_equal(node, NULL, "");
+	ztest_equal(node, NULL, "");
 
 	/* test sys_sflist_append_list() */
 	sys_sflist_init(&append_list);
@@ -363,7 +363,7 @@ void test_sflist(void)
 			      &data_node_append[5].node);
 	for (ii = 0; ii < 12; ii++) {
 		node = sys_sflist_get(&test_list);
-		zassert_equal(((struct data_node *)node)->data, ii,
+		ztest_equal(((struct data_node *)node)->data, ii,
 			      "expected %d got %d", ii,
 			      ((struct data_node *)node)->data);
 	}
@@ -379,11 +379,11 @@ void test_sflist(void)
 	sys_sflist_merge_sflist(&test_list, &append_list);
 	for (ii = 0; ii < 12; ii++) {
 		node = sys_sflist_get(&test_list);
-		zassert_equal(((struct data_node *)node)->data, ii,
+		ztest_equal(((struct data_node *)node)->data, ii,
 			      "expected %d got %d", ii,
 			      ((struct data_node *)node)->data);
 	}
-	zassert_true(sys_sflist_is_empty(&append_list),
+	ztest_true(sys_sflist_is_empty(&append_list),
 		     "merged list is not empty");
 
 	/* tests for sys_sfnode_flags_get(), sys_sfnode_flags_set()
@@ -397,7 +397,7 @@ void test_sflist(void)
 	}
 	for (ii = 0; ii < 4; ii++) {
 		node = sys_sflist_get(&test_list);
-		zassert_equal(sys_sfnode_flags_get(node), ii,
+		ztest_equal(sys_sfnode_flags_get(node), ii,
 			      "wrong flags value");
 		/* Place the nodes back on the list with the flags set
 		 * in reverse order for the next test
@@ -407,7 +407,7 @@ void test_sflist(void)
 	}
 	for (ii = 3; ii >= 0; ii--) {
 		node = sys_sflist_get(&test_list);
-		zassert_equal(sys_sfnode_flags_get(node), ii,
+		ztest_equal(sys_sfnode_flags_get(node), ii,
 			      "wrong flags value");
 	}
 }

--- a/tests/unit/list/slist.c
+++ b/tests/unit/list/slist.c
@@ -182,35 +182,35 @@ void test_slist(void)
 {
 	sys_slist_init(&test_list);
 
-	zassert_true((verify_emptyness(&test_list)),
+	ztest_true((verify_emptyness(&test_list)),
 		      "test_list should be empty");
 
 	/* Appending node 1 */
 	sys_slist_append(&test_list, &test_node_1.node);
-	zassert_true((verify_content_amount(&test_list, 1)),
+	ztest_true((verify_content_amount(&test_list, 1)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_1.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_1.node,
 				       &test_node_1.node, true)),
 		     "test_list head/tail are wrong");
 
 	/* Finding and removing node 1 */
 	sys_slist_find_and_remove(&test_list, &test_node_1.node);
-	zassert_true((verify_emptyness(&test_list)),
+	ztest_true((verify_emptyness(&test_list)),
 		     "test_list should be empty");
 
 	/* Prepending node 1 */
 	sys_slist_prepend(&test_list, &test_node_1.node);
-	zassert_true((verify_content_amount(&test_list, 1)),
+	ztest_true((verify_content_amount(&test_list, 1)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_1.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_1.node,
 				       &test_node_1.node, true)),
 		     "test_list head/tail are wrong");
 
 	/* Removing node 1 */
 	sys_slist_remove(&test_list, NULL, &test_node_1.node);
-	zassert_true((verify_emptyness(&test_list)),
+	ztest_true((verify_emptyness(&test_list)),
 		     "test_list should be empty");
 
 	/* Appending node 1 */
@@ -218,68 +218,68 @@ void test_slist(void)
 	/* Prepending node 2 */
 	sys_slist_prepend(&test_list, &test_node_2.node);
 
-	zassert_true((verify_content_amount(&test_list, 2)),
+	ztest_true((verify_content_amount(&test_list, 2)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_2.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_2.node,
 				       &test_node_1.node, false)),
 		     "test_list head/tail are wrong");
 
 	/* Appending node 3 */
 	sys_slist_append(&test_list, &test_node_3.node);
 
-	zassert_true((verify_content_amount(&test_list, 3)),
+	ztest_true((verify_content_amount(&test_list, 3)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_2.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_2.node,
 				       &test_node_3.node, false)),
 		     "test_list head/tail are wrong");
 
-	zassert_true((sys_slist_peek_next(&test_node_2.node) ==
+	ztest_true((sys_slist_peek_next(&test_node_2.node) ==
 		      &test_node_1.node),
 		     "test_list node links are wrong");
 
 	/* Inserting node 4 after node 2, peek with nocheck variant */
 	sys_slist_insert(&test_list, &test_node_2.node, &test_node_4.node);
 
-	zassert_true((verify_tail_head(&test_list, &test_node_2.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_2.node,
 				       &test_node_3.node, false)),
 		     "test_list head/tail are wrong");
 
-	zassert_true((sys_slist_peek_next_no_check(&test_node_2.node) ==
+	ztest_true((sys_slist_peek_next_no_check(&test_node_2.node) ==
 		      &test_node_4.node),
 		     "test_list node links are wrong");
 
 	/* Finding and removing node 1 */
 	sys_slist_find_and_remove(&test_list, &test_node_1.node);
-	zassert_true((verify_content_amount(&test_list, 3)),
+	ztest_true((verify_content_amount(&test_list, 3)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_2.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_2.node,
 				       &test_node_3.node, false)),
 		     "test_list head/tail are wrong");
 
 	/* Removing node 3 */
 	sys_slist_remove(&test_list, &test_node_4.node, &test_node_3.node);
-	zassert_true((verify_content_amount(&test_list, 2)),
+	ztest_true((verify_content_amount(&test_list, 2)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_2.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_2.node,
 				       &test_node_4.node, false)),
 		     "test_list head/tail are wrong");
 
 	/* Removing node 4 */
 	sys_slist_remove(&test_list, &test_node_2.node, &test_node_4.node);
-	zassert_true((verify_content_amount(&test_list, 1)),
+	ztest_true((verify_content_amount(&test_list, 1)),
 		     "test_list has wrong content");
 
-	zassert_true((verify_tail_head(&test_list, &test_node_2.node,
+	ztest_true((verify_tail_head(&test_list, &test_node_2.node,
 				       &test_node_2.node, true)),
 		     "test_list head/tail are wrong");
 
 	/* Removing node 2 */
 	sys_slist_remove(&test_list, NULL, &test_node_2.node);
-	zassert_true((verify_emptyness(&test_list)),
+	ztest_true((verify_emptyness(&test_list)),
 		     "test_list should be empty");
 
 	/* test iterator from a node */
@@ -310,7 +310,7 @@ void test_slist(void)
 			break;
 		}
 	}
-	zassert_equal(ii, 3, "");
+	ztest_equal(ii, 3, "");
 
 	ii = 0;
 	SYS_SLIST_ITERATE_FROM_NODE(&test_list, node) {
@@ -319,18 +319,18 @@ void test_slist(void)
 			break;
 		}
 	}
-	zassert_equal(ii, 1, "");
+	ztest_equal(ii, 1, "");
 
 	ii = 0;
 	SYS_SLIST_ITERATE_FROM_NODE(&test_list, node) {
 		ii++;
 	}
-	zassert_equal(ii, 2, "");
+	ztest_equal(ii, 2, "");
 
 	/* test sys_slist_get_not_empty() and sys_slist_get() APIs */
 	for (ii = 0; ii < 6; ii++) {
 		node = sys_slist_get_not_empty(&test_list);
-		zassert_equal(((struct data_node *)node)->data, ii, "");
+		ztest_equal(((struct data_node *)node)->data, ii, "");
 	}
 	for (ii = 0; ii < 6; ii++) {
 		/* regenerate test_list since we just emptied it */
@@ -338,10 +338,10 @@ void test_slist(void)
 	}
 	for (ii = 0; ii < 6; ii++) {
 		node = sys_slist_get(&test_list);
-		zassert_equal(((struct data_node *)node)->data, ii, "");
+		ztest_equal(((struct data_node *)node)->data, ii, "");
 	}
 	node = sys_slist_get(&test_list);
-	zassert_equal(node, NULL, "");
+	ztest_equal(node, NULL, "");
 
 	/* test sys_slist_append_list() */
 	sys_slist_init(&append_list);
@@ -363,7 +363,7 @@ void test_slist(void)
 			      &data_node_append[5].node);
 	for (ii = 0; ii < 12; ii++) {
 		node = sys_slist_get(&test_list);
-		zassert_equal(((struct data_node *)node)->data, ii,
+		ztest_equal(((struct data_node *)node)->data, ii,
 			      "expected %d got %d", ii,
 			      ((struct data_node *)node)->data);
 	}
@@ -379,11 +379,11 @@ void test_slist(void)
 	sys_slist_merge_slist(&test_list, &append_list);
 	for (ii = 0; ii < 12; ii++) {
 		node = sys_slist_get(&test_list);
-		zassert_equal(((struct data_node *)node)->data, ii,
+		ztest_equal(((struct data_node *)node)->data, ii,
 			      "expected %d got %d", ii,
 			      ((struct data_node *)node)->data);
 	}
-	zassert_true(sys_slist_is_empty(&append_list),
+	ztest_true(sys_slist_is_empty(&append_list),
 		     "merged list is not empty");
 }
 

--- a/tests/unit/math_extras/tests.inc
+++ b/tests/unit/math_extras/tests.inc
@@ -12,170 +12,170 @@ static void VNAME(u32_add)(void)
 {
 	u32_t result = 42;
 
-	zassert_false(u32_add_overflow(2, 3, &result), NULL);
-	zassert_equal(result, 5, NULL);
+	ztest_false(u32_add_overflow(2, 3, &result), NULL);
+	ztest_equal(result, 5, NULL);
 
-	zassert_false(u32_add_overflow(2, 0, &result), NULL);
-	zassert_equal(result, 2, NULL);
+	ztest_false(u32_add_overflow(2, 0, &result), NULL);
+	ztest_equal(result, 2, NULL);
 
-	zassert_false(u32_add_overflow(0, 3, &result), NULL);
-	zassert_equal(result, 3, NULL);
+	ztest_false(u32_add_overflow(0, 3, &result), NULL);
+	ztest_equal(result, 3, NULL);
 
-	zassert_false(u32_add_overflow(0, UINT32_MAX, &result), NULL);
-	zassert_equal(result, UINT32_MAX, NULL);
-	zassert_true(u32_add_overflow(1, UINT32_MAX, &result), NULL);
-	zassert_equal(result, 0, NULL);
+	ztest_false(u32_add_overflow(0, UINT32_MAX, &result), NULL);
+	ztest_equal(result, UINT32_MAX, NULL);
+	ztest_true(u32_add_overflow(1, UINT32_MAX, &result), NULL);
+	ztest_equal(result, 0, NULL);
 
-	zassert_false(u32_add_overflow(UINT32_MAX, 0, &result), NULL);
-	zassert_equal(result, UINT32_MAX, NULL);
-	zassert_true(u32_add_overflow(UINT32_MAX, 2, &result), NULL);
-	zassert_equal(result, 1, NULL);
+	ztest_false(u32_add_overflow(UINT32_MAX, 0, &result), NULL);
+	ztest_equal(result, UINT32_MAX, NULL);
+	ztest_true(u32_add_overflow(UINT32_MAX, 2, &result), NULL);
+	ztest_equal(result, 1, NULL);
 }
 
 static void VNAME(u32_mul)(void)
 {
 	u32_t result = 42;
 
-	zassert_false(u32_mul_overflow(2, 3, &result), NULL);
-	zassert_equal(result, 6, NULL);
+	ztest_false(u32_mul_overflow(2, 3, &result), NULL);
+	ztest_equal(result, 6, NULL);
 
-	zassert_false(u32_mul_overflow(UINT32_MAX, 1, &result), NULL);
-	zassert_equal(result, UINT32_MAX, NULL);
-	zassert_true(u32_mul_overflow(UINT32_MAX, 2, &result), NULL);
-	zassert_equal(result, UINT32_MAX * 2, NULL);
+	ztest_false(u32_mul_overflow(UINT32_MAX, 1, &result), NULL);
+	ztest_equal(result, UINT32_MAX, NULL);
+	ztest_true(u32_mul_overflow(UINT32_MAX, 2, &result), NULL);
+	ztest_equal(result, UINT32_MAX * 2, NULL);
 
-	zassert_false(u32_mul_overflow(1, UINT32_MAX, &result), NULL);
-	zassert_equal(result, UINT32_MAX, NULL);
-	zassert_true(u32_mul_overflow(2, UINT32_MAX, &result), NULL);
-	zassert_equal(result, UINT32_MAX * 2, NULL);
+	ztest_false(u32_mul_overflow(1, UINT32_MAX, &result), NULL);
+	ztest_equal(result, UINT32_MAX, NULL);
+	ztest_true(u32_mul_overflow(2, UINT32_MAX, &result), NULL);
+	ztest_equal(result, UINT32_MAX * 2, NULL);
 }
 
 static void VNAME(u64_add)(void)
 {
 	u64_t result = 42;
 
-	zassert_false(u64_add_overflow(2, 3, &result), NULL);
-	zassert_equal(result, 5, NULL);
+	ztest_false(u64_add_overflow(2, 3, &result), NULL);
+	ztest_equal(result, 5, NULL);
 
-	zassert_false(u64_add_overflow(2, 0, &result), NULL);
-	zassert_equal(result, 2, NULL);
+	ztest_false(u64_add_overflow(2, 0, &result), NULL);
+	ztest_equal(result, 2, NULL);
 
-	zassert_false(u64_add_overflow(0, 3, &result), NULL);
-	zassert_equal(result, 3, NULL);
+	ztest_false(u64_add_overflow(0, 3, &result), NULL);
+	ztest_equal(result, 3, NULL);
 
-	zassert_false(u64_add_overflow(0, UINT64_MAX, &result), NULL);
-	zassert_equal(result, UINT64_MAX, NULL);
-	zassert_true(u64_add_overflow(1, UINT64_MAX, &result), NULL);
-	zassert_equal(result, 0, NULL);
+	ztest_false(u64_add_overflow(0, UINT64_MAX, &result), NULL);
+	ztest_equal(result, UINT64_MAX, NULL);
+	ztest_true(u64_add_overflow(1, UINT64_MAX, &result), NULL);
+	ztest_equal(result, 0, NULL);
 
-	zassert_false(u64_add_overflow(UINT64_MAX, 0, &result), NULL);
-	zassert_equal(result, UINT64_MAX, NULL);
-	zassert_true(u64_add_overflow(UINT64_MAX, 2, &result), NULL);
-	zassert_equal(result, 1, NULL);
+	ztest_false(u64_add_overflow(UINT64_MAX, 0, &result), NULL);
+	ztest_equal(result, UINT64_MAX, NULL);
+	ztest_true(u64_add_overflow(UINT64_MAX, 2, &result), NULL);
+	ztest_equal(result, 1, NULL);
 }
 
 static void VNAME(u64_mul)(void)
 {
 	u64_t result = 42;
 
-	zassert_false(u64_mul_overflow(2, 3, &result), NULL);
-	zassert_equal(result, 6, NULL);
+	ztest_false(u64_mul_overflow(2, 3, &result), NULL);
+	ztest_equal(result, 6, NULL);
 
-	zassert_false(u64_mul_overflow(UINT64_MAX, 1, &result), NULL);
-	zassert_equal(result, UINT64_MAX, NULL);
-	zassert_true(u64_mul_overflow(UINT64_MAX, 2, &result), NULL);
-	zassert_equal(result, UINT64_MAX * 2, NULL);
+	ztest_false(u64_mul_overflow(UINT64_MAX, 1, &result), NULL);
+	ztest_equal(result, UINT64_MAX, NULL);
+	ztest_true(u64_mul_overflow(UINT64_MAX, 2, &result), NULL);
+	ztest_equal(result, UINT64_MAX * 2, NULL);
 
-	zassert_false(u64_mul_overflow(1, UINT64_MAX, &result), NULL);
-	zassert_equal(result, UINT64_MAX, NULL);
-	zassert_true(u64_mul_overflow(2, UINT64_MAX, &result), NULL);
-	zassert_equal(result, UINT64_MAX * 2, NULL);
+	ztest_false(u64_mul_overflow(1, UINT64_MAX, &result), NULL);
+	ztest_equal(result, UINT64_MAX, NULL);
+	ztest_true(u64_mul_overflow(2, UINT64_MAX, &result), NULL);
+	ztest_equal(result, UINT64_MAX * 2, NULL);
 }
 
 static void VNAME(size_add)(void)
 {
 	size_t result = 42;
 
-	zassert_false(size_add_overflow(2, 3, &result), NULL);
-	zassert_equal(result, 5, NULL);
+	ztest_false(size_add_overflow(2, 3, &result), NULL);
+	ztest_equal(result, 5, NULL);
 
-	zassert_false(size_add_overflow(2, 0, &result), NULL);
-	zassert_equal(result, 2, NULL);
+	ztest_false(size_add_overflow(2, 0, &result), NULL);
+	ztest_equal(result, 2, NULL);
 
-	zassert_false(size_add_overflow(0, 3, &result), NULL);
-	zassert_equal(result, 3, NULL);
+	ztest_false(size_add_overflow(0, 3, &result), NULL);
+	ztest_equal(result, 3, NULL);
 
-	zassert_false(size_add_overflow(0, SIZE_MAX, &result), NULL);
-	zassert_equal(result, SIZE_MAX, NULL);
-	zassert_true(size_add_overflow(1, SIZE_MAX, &result), NULL);
-	zassert_equal(result, 0, NULL);
+	ztest_false(size_add_overflow(0, SIZE_MAX, &result), NULL);
+	ztest_equal(result, SIZE_MAX, NULL);
+	ztest_true(size_add_overflow(1, SIZE_MAX, &result), NULL);
+	ztest_equal(result, 0, NULL);
 
-	zassert_false(size_add_overflow(SIZE_MAX, 0, &result), NULL);
-	zassert_equal(result, SIZE_MAX, NULL);
-	zassert_true(size_add_overflow(SIZE_MAX, 2, &result), NULL);
-	zassert_equal(result, 1, NULL);
+	ztest_false(size_add_overflow(SIZE_MAX, 0, &result), NULL);
+	ztest_equal(result, SIZE_MAX, NULL);
+	ztest_true(size_add_overflow(SIZE_MAX, 2, &result), NULL);
+	ztest_equal(result, 1, NULL);
 }
 
 static void VNAME(size_mul)(void)
 {
 	size_t result = 42;
 
-	zassert_false(size_mul_overflow(2, 3, &result), NULL);
-	zassert_equal(result, 6, NULL);
+	ztest_false(size_mul_overflow(2, 3, &result), NULL);
+	ztest_equal(result, 6, NULL);
 
-	zassert_false(size_mul_overflow(SIZE_MAX, 1, &result), NULL);
-	zassert_equal(result, SIZE_MAX, NULL);
-	zassert_true(size_mul_overflow(SIZE_MAX, 2, &result), NULL);
-	zassert_equal(result, SIZE_MAX * 2, NULL);
+	ztest_false(size_mul_overflow(SIZE_MAX, 1, &result), NULL);
+	ztest_equal(result, SIZE_MAX, NULL);
+	ztest_true(size_mul_overflow(SIZE_MAX, 2, &result), NULL);
+	ztest_equal(result, SIZE_MAX * 2, NULL);
 
-	zassert_false(size_mul_overflow(1, SIZE_MAX, &result), NULL);
-	zassert_equal(result, SIZE_MAX, NULL);
-	zassert_true(size_mul_overflow(2, SIZE_MAX, &result), NULL);
-	zassert_equal(result, SIZE_MAX * 2, NULL);
+	ztest_false(size_mul_overflow(1, SIZE_MAX, &result), NULL);
+	ztest_equal(result, SIZE_MAX, NULL);
+	ztest_true(size_mul_overflow(2, SIZE_MAX, &result), NULL);
+	ztest_equal(result, SIZE_MAX * 2, NULL);
 }
 
 static void VNAME(u32_clz)(void)
 {
-	zassert_equal(u32_count_leading_zeros(0), 32, NULL);
-	zassert_equal(u32_count_leading_zeros(1), 31, NULL);
-	zassert_equal(u32_count_leading_zeros(0xf00f), 16, NULL);
-	zassert_equal(u32_count_leading_zeros(0xf00ff00f), 0, NULL);
-	zassert_equal(u32_count_leading_zeros(0xffffffff), 0, NULL);
+	ztest_equal(u32_count_leading_zeros(0), 32, NULL);
+	ztest_equal(u32_count_leading_zeros(1), 31, NULL);
+	ztest_equal(u32_count_leading_zeros(0xf00f), 16, NULL);
+	ztest_equal(u32_count_leading_zeros(0xf00ff00f), 0, NULL);
+	ztest_equal(u32_count_leading_zeros(0xffffffff), 0, NULL);
 }
 
 static void VNAME(u64_clz)(void)
 {
-	zassert_equal(u64_count_leading_zeros(0), 64, NULL);
-	zassert_equal(u64_count_leading_zeros(1), 63, NULL);
-	zassert_equal(u64_count_leading_zeros(0xf00f), 48, NULL);
-	zassert_equal(u64_count_leading_zeros(0xf00ff00f), 32, NULL);
-	zassert_equal(u64_count_leading_zeros(0xffffffff), 32, NULL);
-	zassert_equal(u64_count_leading_zeros(0xf00f00000000ull), 16, NULL);
-	zassert_equal(u64_count_leading_zeros(0xf00ff00f00000000ull), 0, NULL);
-	zassert_equal(u64_count_leading_zeros(0xffffffff00000000ull), 0, NULL);
+	ztest_equal(u64_count_leading_zeros(0), 64, NULL);
+	ztest_equal(u64_count_leading_zeros(1), 63, NULL);
+	ztest_equal(u64_count_leading_zeros(0xf00f), 48, NULL);
+	ztest_equal(u64_count_leading_zeros(0xf00ff00f), 32, NULL);
+	ztest_equal(u64_count_leading_zeros(0xffffffff), 32, NULL);
+	ztest_equal(u64_count_leading_zeros(0xf00f00000000ull), 16, NULL);
+	ztest_equal(u64_count_leading_zeros(0xf00ff00f00000000ull), 0, NULL);
+	ztest_equal(u64_count_leading_zeros(0xffffffff00000000ull), 0, NULL);
 }
 
 static void VNAME(u32_ctz)(void)
 {
-	zassert_equal(u32_count_trailing_zeros(0), 32, NULL);
-	zassert_equal(u32_count_trailing_zeros(1), 0, NULL);
-	zassert_equal(u32_count_trailing_zeros(6), 1, NULL);
-	zassert_equal(u32_count_trailing_zeros(0x00f00f00), 8, NULL);
-	zassert_equal(u32_count_trailing_zeros(0xf00ffc00), 10, NULL);
-	zassert_equal(u32_count_trailing_zeros(0xffffffff), 0, NULL);
-	zassert_equal(u32_count_trailing_zeros(0x80000000), 31, NULL);
+	ztest_equal(u32_count_trailing_zeros(0), 32, NULL);
+	ztest_equal(u32_count_trailing_zeros(1), 0, NULL);
+	ztest_equal(u32_count_trailing_zeros(6), 1, NULL);
+	ztest_equal(u32_count_trailing_zeros(0x00f00f00), 8, NULL);
+	ztest_equal(u32_count_trailing_zeros(0xf00ffc00), 10, NULL);
+	ztest_equal(u32_count_trailing_zeros(0xffffffff), 0, NULL);
+	ztest_equal(u32_count_trailing_zeros(0x80000000), 31, NULL);
 }
 
 static void VNAME(u64_ctz)(void)
 {
-	zassert_equal(u64_count_trailing_zeros(0), 64, NULL);
-	zassert_equal(u64_count_trailing_zeros(1), 0, NULL);
-	zassert_equal(u64_count_trailing_zeros(6), 1, NULL);
-	zassert_equal(u64_count_trailing_zeros(0x00f00f00), 8, NULL);
-	zassert_equal(u64_count_trailing_zeros(0xf00ffc00), 10, NULL);
-	zassert_equal(u64_count_trailing_zeros(0xffffffffffffffffull), 0, NULL);
-	zassert_equal(u64_count_trailing_zeros(0x8000000080000000ull), 31,
+	ztest_equal(u64_count_trailing_zeros(0), 64, NULL);
+	ztest_equal(u64_count_trailing_zeros(1), 0, NULL);
+	ztest_equal(u64_count_trailing_zeros(6), 1, NULL);
+	ztest_equal(u64_count_trailing_zeros(0x00f00f00), 8, NULL);
+	ztest_equal(u64_count_trailing_zeros(0xf00ffc00), 10, NULL);
+	ztest_equal(u64_count_trailing_zeros(0xffffffffffffffffull), 0, NULL);
+	ztest_equal(u64_count_trailing_zeros(0x8000000080000000ull), 31,
 		      NULL);
-	zassert_equal(u64_count_trailing_zeros(0xc000000000000000ull), 62,
+	ztest_equal(u64_count_trailing_zeros(0xc000000000000000ull), 62,
 		      NULL);
 }

--- a/tests/unit/rbtree/main.c
+++ b/tests/unit/rbtree/main.c
@@ -9,7 +9,7 @@
 #include "../../../lib/os/rb.c"
 
 #define _CHECK(n) \
-	zassert_true(!!(n), "Tree check failed: [ " #n " ] @%d", __LINE__)
+	ztest_true(!!(n), "Tree check failed: [ " #n " ] @%d", __LINE__)
 
 #define MAX_NODES 256
 

--- a/tests/unit/timeutil/main.c
+++ b/tests/unit/timeutil/main.c
@@ -17,34 +17,34 @@ void timeutil_check(const struct timeutil_test_data *tp,
 		struct tm tm = *gmtime(&tp->ux);
 		time_t uxtime = timeutil_timegm(&tm);
 
-		zassert_equal(&tm, gmtime_r(&tp->ux, &tm),
+		ztest_equal(&tm, gmtime_r(&tp->ux, &tm),
 			      "gmtime_r failed");
 
-		zassert_equal(tm.tm_year, tp->tm.tm_year,
+		ztest_equal(tm.tm_year, tp->tm.tm_year,
 			      "datetime %s year %d != %d",
 			      tp->civil, tm.tm_year, tp->tm.tm_year);
-		zassert_equal(tm.tm_mon, tp->tm.tm_mon,
+		ztest_equal(tm.tm_mon, tp->tm.tm_mon,
 			      "datetime %s mon %d != %d",
 			      tp->civil, tm.tm_mon, tp->tm.tm_mon);
-		zassert_equal(tm.tm_mday, tp->tm.tm_mday,
+		ztest_equal(tm.tm_mday, tp->tm.tm_mday,
 			      "datetime %s mday %d != %d",
 			      tp->civil, tm.tm_mday, tp->tm.tm_mday);
-		zassert_equal(tm.tm_hour, tp->tm.tm_hour,
+		ztest_equal(tm.tm_hour, tp->tm.tm_hour,
 			      "datetime %s hour %d != %d",
 			      tp->civil, tm.tm_hour, tp->tm.tm_hour);
-		zassert_equal(tm.tm_min, tp->tm.tm_min,
+		ztest_equal(tm.tm_min, tp->tm.tm_min,
 			      "datetime %s min %d != %d",
 			      tp->civil, tm.tm_min, tp->tm.tm_min);
-		zassert_equal(tm.tm_sec, tp->tm.tm_sec,
+		ztest_equal(tm.tm_sec, tp->tm.tm_sec,
 			      "datetime %s sec %d != %d",
 			      tp->civil, tm.tm_sec, tp->tm.tm_sec);
-		zassert_equal(tm.tm_wday, tp->tm.tm_wday,
+		ztest_equal(tm.tm_wday, tp->tm.tm_wday,
 			      "datetime %s wday %d != %d",
 			      tp->civil, tm.tm_wday, tp->tm.tm_wday);
-		zassert_equal(tm.tm_yday, tp->tm.tm_yday,
+		ztest_equal(tm.tm_yday, tp->tm.tm_yday,
 			      "datetime %s yday %d != %d",
 			      tp->civil, tm.tm_yday, tp->tm.tm_yday);
-		zassert_equal(tp->ux, uxtime,
+		ztest_equal(tp->ux, uxtime,
 			      "datetime %s reverse != %ld",
 			      tp->civil, uxtime);
 

--- a/tests/unit/timeutil/test_gmtime.c
+++ b/tests/unit/timeutil/test_gmtime.c
@@ -18,11 +18,11 @@ void test_gmtime(void)
 	};
 	time_t time = 1561994005;
 
-	zassert_equal(&tm, gmtime_r(&time, &tm),
+	ztest_equal(&tm, gmtime_r(&time, &tm),
 		      "gmtime_r return failed");
 
 	struct tm *tp = gmtime(&time);
 
-	zassert_true(memcmp(&tm, tp, sizeof(tm)) == 0,
+	ztest_true(memcmp(&tm, tp, sizeof(tm)) == 0,
 		     "gmtime disagrees with gmtime_r");
 }

--- a/tests/unit/timeutil/test_s64.c
+++ b/tests/unit/timeutil/test_s64.c
@@ -232,9 +232,9 @@ static void test_time32_errno_clear(void)
 
 	time_t ux = timeutil_timegm(&tp->tm);
 
-	zassert_equal(ux, tp->ux,
+	ztest_equal(ux, tp->ux,
 		      "conversion incorrect");
-	zassert_equal(errno, 0,
+	ztest_equal(errno, 0,
 		      "errno was not cleared");
 }
 
@@ -259,9 +259,9 @@ static void test_time32_epochm1(void)
 
 	time_t ux = timeutil_timegm(&tp->tm);
 
-	zassert_equal(ux, tp->ux,
+	ztest_equal(ux, tp->ux,
 		      "conversion incorrect");
-	zassert_equal(errno, 0,
+	ztest_equal(errno, 0,
 		      "final errno state bad");
 }
 
@@ -282,15 +282,15 @@ static void test_time32_underflow(void)
 		},
 	};
 
-	zassert_equal(timeutil_timegm64(&tp->tm), unix64,
+	ztest_equal(timeutil_timegm64(&tp->tm), unix64,
 		      "fullscale failed");
 	errno = 0;
 
 	time_t ux = timeutil_timegm(&tp->tm);
 
-	zassert_equal(ux, -1,
+	ztest_equal(ux, -1,
 		      "underflow undetected");
-	zassert_equal(errno, ERANGE,
+	ztest_equal(errno, ERANGE,
 		      "final errno state bad");
 }
 
@@ -311,15 +311,15 @@ static void test_time32_overflow(void)
 		},
 	};
 
-	zassert_equal(timeutil_timegm64(&tp->tm), unix64,
+	ztest_equal(timeutil_timegm64(&tp->tm), unix64,
 		      "fullscale failed");
 	errno = 0;
 
 	time_t ux = timeutil_timegm(&tp->tm);
 
-	zassert_equal(ux, -1,
+	ztest_equal(ux, -1,
 		      "overflow undetected");
-	zassert_equal(errno, ERANGE,
+	ztest_equal(errno, ERANGE,
 		      "final errno state bad");
 }
 

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -20,54 +20,54 @@ static void test_u8_to_dec(void)
 	u8_t len;
 
 	len = u8_to_dec(text, sizeof(text), 0);
-	zassert_equal(len, 1, "Length of 0 is not 1");
-	zassert_equal(strcmp(text, "0"), 0,
+	ztest_equal(len, 1, "Length of 0 is not 1");
+	ztest_equal(strcmp(text, "0"), 0,
 		      "Value=0 is not converted to \"0\"");
 
 	len = u8_to_dec(text, sizeof(text), 1);
-	zassert_equal(len, 1, "Length of 1 is not 1");
-	zassert_equal(strcmp(text, "1"), 0,
+	ztest_equal(len, 1, "Length of 1 is not 1");
+	ztest_equal(strcmp(text, "1"), 0,
 		      "Value=1 is not converted to \"1\"");
 
 	len = u8_to_dec(text, sizeof(text), 11);
-	zassert_equal(len, 2, "Length of 11 is not 2");
-	zassert_equal(strcmp(text, "11"), 0,
+	ztest_equal(len, 2, "Length of 11 is not 2");
+	ztest_equal(strcmp(text, "11"), 0,
 		      "Value=10 is not converted to \"11\"");
 
 	len = u8_to_dec(text, sizeof(text), 100);
-	zassert_equal(len, 3, "Length of 100 is not 3");
-	zassert_equal(strcmp(text, "100"), 0,
+	ztest_equal(len, 3, "Length of 100 is not 3");
+	ztest_equal(strcmp(text, "100"), 0,
 		      "Value=100 is not converted to \"100\"");
 
 	len = u8_to_dec(text, sizeof(text), 101);
-	zassert_equal(len, 3, "Length of 101 is not 3");
-	zassert_equal(strcmp(text, "101"), 0,
+	ztest_equal(len, 3, "Length of 101 is not 3");
+	ztest_equal(strcmp(text, "101"), 0,
 		      "Value=101 is not converted to \"101\"");
 
 	len = u8_to_dec(text, sizeof(text), 255);
-	zassert_equal(len, 3, "Length of 255 is not 3");
-	zassert_equal(strcmp(text, "255"), 0,
+	ztest_equal(len, 3, "Length of 255 is not 3");
+	ztest_equal(strcmp(text, "255"), 0,
 		      "Value=255 is not converted to \"255\"");
 
 	memset(text, 0, sizeof(text));
 	len = u8_to_dec(text, 2, 123);
-	zassert_equal(len, 2,
+	ztest_equal(len, 2,
 		      "Length of converted value using 2 byte buffer isn't 2");
-	zassert_equal(
+	ztest_equal(
 		strcmp(text, "12"), 0,
 		"Value=123 is not converted to \"12\" using 2-byte buffer");
 
 	memset(text, 0, sizeof(text));
 	len = u8_to_dec(text, 1, 123);
-	zassert_equal(len, 1,
+	ztest_equal(len, 1,
 		      "Length of converted value using 1 byte buffer isn't 1");
-	zassert_equal(
+	ztest_equal(
 		strcmp(text, "1"), 0,
 		"Value=123 is not converted to \"1\" using 1-byte buffer");
 
 	memset(text, 0, sizeof(text));
 	len = u8_to_dec(text, 0, 123);
-	zassert_equal(len, 0,
+	ztest_equal(len, 0,
 		      "Length of converted value using 0 byte buffer isn't 0");
 }
 
@@ -80,16 +80,16 @@ void test_COND_CODE_1(void)
 	 * be seen in compilation (lack of variable or ununsed variable.
 	 */
 	COND_CODE_1(1, (u32_t x0 = 1;), (u32_t y0;))
-	zassert_true((x0 == 1), NULL);
+	ztest_true((x0 == 1), NULL);
 
 	COND_CODE_1(NOT_EXISTING_DEFINE, (u32_t x1 = 1;), (u32_t y1 = 1;))
-	zassert_true((y1 == 1), NULL);
+	ztest_true((y1 == 1), NULL);
 
 	COND_CODE_1(TEST_DEFINE_1, (u32_t x2 = 1;), (u32_t y2 = 1;))
-	zassert_true((x2 == 1), NULL);
+	ztest_true((x2 == 1), NULL);
 
 	COND_CODE_1(2, (u32_t x3 = 1;), (u32_t y3 = 1;))
-	zassert_true((y3 == 1), NULL);
+	ztest_true((y3 == 1), NULL);
 }
 
 void test_COND_CODE_0(void)
@@ -98,16 +98,16 @@ void test_COND_CODE_0(void)
 	 * be seen in compilation (lack of variable or ununsed variable.
 	 */
 	COND_CODE_0(0, (u32_t x0 = 1;), (u32_t y0;))
-	zassert_true((x0 == 1), NULL);
+	ztest_true((x0 == 1), NULL);
 
 	COND_CODE_0(NOT_EXISTING_DEFINE, (u32_t x1 = 1;), (u32_t y1 = 1;))
-	zassert_true((y1 == 1), NULL);
+	ztest_true((y1 == 1), NULL);
 
 	COND_CODE_0(TEST_DEFINE_0, (u32_t x2 = 1;), (u32_t y2 = 1;))
-	zassert_true((x2 == 1), NULL);
+	ztest_true((x2 == 1), NULL);
 
 	COND_CODE_0(2, (u32_t x3 = 1;), (u32_t y3 = 1;))
-	zassert_true((y3 == 1), NULL);
+	ztest_true((y3 == 1), NULL);
 }
 
 void test_IF_ENABLED(void)
@@ -117,13 +117,13 @@ void test_IF_ENABLED(void)
 
 	IF_ENABLED(test_IF_ENABLED_FLAG_A, (goto skipped;))
 	/* location should be skipped if IF_ENABLED macro is correct. */
-	zassert_false(true, "location should be skipped");
+	ztest_false(true, "location should be skipped");
 skipped:
-	IF_ENABLED(test_IF_ENABLED_FLAG_B, (zassert_false(true, "");))
+	IF_ENABLED(test_IF_ENABLED_FLAG_B, (ztest_false(true, "");))
 
-	IF_ENABLED(test_IF_ENABLED_FLAG_C, (zassert_false(true, "");))
+	IF_ENABLED(test_IF_ENABLED_FLAG_C, (ztest_false(true, "");))
 
-	zassert_true(true, "");
+	ztest_true(true, "");
 
 	#undef test_IF_ENABLED_FLAG_A
 	#undef test_IF_ENABLED_FLAG_B
@@ -146,11 +146,11 @@ void test_UTIL_LISTIFY(void)
 
 	UTIL_LISTIFY(4, INC, _)
 
-	zassert_equal(i, 0 + 1 + 2 + 3, NULL);
-	zassert_equal(a0, 0, NULL);
-	zassert_equal(a1, 2, NULL);
-	zassert_equal(a2, 4, NULL);
-	zassert_equal(a3, 6, NULL);
+	ztest_equal(i, 0 + 1 + 2 + 3, NULL);
+	ztest_equal(a0, 0, NULL);
+	ztest_equal(a1, 2, NULL);
+	ztest_equal(a2, 4, NULL);
+	ztest_equal(a3, 6, NULL);
 }
 
 static int inc_func(void)
@@ -165,13 +165,13 @@ static int inc_func(void)
  */
 static void test_z_max_z_min(void)
 {
-	zassert_equal(Z_MAX(inc_func(), 0), 1, "Unexpected macro result");
+	ztest_equal(Z_MAX(inc_func(), 0), 1, "Unexpected macro result");
 	/* Z_MAX should have call inc_func only once */
-	zassert_equal(inc_func(), 2, "Unexpected return value");
+	ztest_equal(inc_func(), 2, "Unexpected return value");
 
-	zassert_equal(Z_MIN(inc_func(), 2), 2, "Unexpected macro result");
+	ztest_equal(Z_MIN(inc_func(), 2), 2, "Unexpected macro result");
 	/* Z_MIN should have call inc_func only once */
-	zassert_equal(inc_func(), 4, "Unexpected return value");
+	ztest_equal(inc_func(), 4, "Unexpected return value");
 }
 
 void test_main(void)

--- a/tests/ztest/base/src/main.c
+++ b/tests/ztest/base/src/main.c
@@ -12,12 +12,12 @@ static void test_empty_test(void)
 
 static void test_assert_tests(void)
 {
-	zassert_true(1, NULL);
-	zassert_false(0, NULL);
-	zassert_is_null(NULL, NULL);
-	zassert_not_null("foo", NULL);
-	zassert_equal(1, 1, NULL);
-	zassert_equal_ptr(NULL, NULL, NULL);
+	ztest_true(1, NULL);
+	ztest_false(0, NULL);
+	ztest_is_null(NULL, NULL);
+	ztest_not_null("foo", NULL);
+	ztest_equal(1, 1, NULL);
+	ztest_equal_ptr(NULL, NULL, NULL);
 }
 
 static void test_assert_mem_equal(void)
@@ -30,7 +30,7 @@ static void test_assert_mem_equal(void)
 	};
 	uint32_t actual[4] = {0};
 	memcpy(actual, expected, sizeof(actual));
-	zassert_mem_equal(actual, expected, sizeof(expected), NULL);
+	ztest_mem_equal(actual, expected, sizeof(expected), NULL);
 }
 
 void test_main(void)

--- a/tests/ztest/mock/src/main.c
+++ b/tests/ztest/mock/src/main.c
@@ -35,7 +35,7 @@ static int returns_int(void)
 static void test_return_value_tests(void)
 {
 	ztest_returns_value(returns_int, 5);
-	zassert_equal(returns_int(), 5, NULL);
+	ztest_equal(returns_int(), 5, NULL);
 }
 
 static void test_multi_value_tests(void)
@@ -48,7 +48,7 @@ static void test_multi_value_tests(void)
 
 	/* Verify mock behavior */
 	expect_one_parameter(1);
-	zassert_equal(returns_int(), 5, NULL);
+	ztest_equal(returns_int(), 5, NULL);
 	expect_two_parameters(2, 3);
 }
 


### PR DESCRIPTION
These flag Coverity failures in some cases ASSERT_SIDE_EFFECT
because Coverity believes that these are conditionally compiled
assertions when they actually aren't.

Fixes Coverity failures of the form:

Argument "expected_reason" of z_zassert() has a side effect
because the variable is volatile.  The containing function might
work differently in a non-debug build.
104         zassert_true(expected_reason == -1,

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>