### PR TITLE
tests: context: busy-wait with interrupts locked

### DIFF
--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -697,6 +697,16 @@ static void busy_wait_thread(void *mseconds, void *arg2, void *arg3)
 	k_busy_wait(usecs);
 	TC_PRINT("Thread busy waiting completed\n");
 
+	/* FIXME: Broken on Nios II, see #22956 */
+#ifndef CONFIG_NIOS2
+	int key = arch_irq_lock();
+
+	TC_PRINT("Thread busy waiting for %d usecs (irqs locked)\n", usecs);
+	k_busy_wait(usecs);
+	TC_PRINT("Thread busy waiting completed (irqs locked)\n");
+	arch_irq_unlock(key);
+#endif
+
 	/*
 	 * Ideally the test should verify that the correct number of ticks
 	 * have elapsed. However, when running under QEMU, the tick interrupt


### PR DESCRIPTION
This is expected to work on all platforms.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>