### PR TITLE
drivers: kscan: add support for the interrupt on the ft5336

### DIFF
--- a/drivers/kscan/Kconfig.ft5336
+++ b/drivers/kscan/Kconfig.ft5336
@@ -11,3 +11,7 @@ config KSCAN_FT5336_PERIOD
 	int "Sample period (ms)"
 	default 10
 	depends on KSCAN_FT5336
+
+config KSCAN_FT5336_INTERRUPT
+	bool "Enable interrupt"
+	depends on KSCAN_FT5336


### PR DESCRIPTION
The ft5336 has an interrupt that can be used instead of polling
this commit adds support for using it but as an option to maintain
compatibility. Tested on the stm32f746g_disco board.

Signed-off-by: Mark Olsson <mark@markolsson.se>