### PR TITLE
Bluetooth: host: Include scan response with name when non-connectable

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -6109,7 +6109,7 @@ int bt_le_adv_start_internal(const struct bt_le_adv_param *param,
 			return err;
 		}
 
-		if (sd) {
+		if (sd || (param->options & BT_LE_ADV_OPT_USE_NAME)) {
 			set_param.type = BT_LE_ADV_SCAN_IND;
 		} else {
 			set_param.type = BT_LE_ADV_NONCONN_IND;


### PR DESCRIPTION
When using BT_LE_ADV_NCONN_NAME then the advertising name will not be
included in the advertising data. This is because the host always puts
the device name in the scan response. But since the scan data was
otherwise empty the advertising type was set to ADV_NONCONN_IND.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>