### PR TITLE
include/drivers/flash: document on the unrestricted alignment of reads

### DIFF
--- a/include/drivers/flash.h
+++ b/include/drivers/flash.h
@@ -95,9 +95,8 @@ __subsystem struct flash_driver_api {
 /**
  *  @brief  Read data from flash
  *
- *  Most of flash drivers support unaligned flash access, but some have
- *  restrictions on the read offset or/and the read size. Please refer to
- *  the driver implementation to get details on the read alignment requirement.
+ *  All flash drivers support reads without alignment restrictions on
+ *  the read offset, the read size, or the destination address.
  *
  *  @param  dev             : flash dev
  *  @param  offset          : Offset (byte aligned) to read

--- a/include/drivers/flash.h
+++ b/include/drivers/flash.h
@@ -120,6 +120,10 @@ static inline int z_impl_flash_read(struct device *dev, off_t offset, void *data
 /**
  *  @brief  Write buffer into flash memory.
  *
+ *  All flash drivers support a source buffer located either in RAM or
+ *  SoC flash, without alignment restrictions on the source address, or
+ *  write size or offset.
+ *
  *  Prior to the invocation of this API, the flash_write_protection_set needs
  *  to be called first to disable the write protection.
  *


### PR DESCRIPTION
Unaligned read-out capability become fact among all drivers.
Let's cut this in stone as API requirement.

fixes #16439

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>