### PR TITLE
kernel: deprecate k_uptime_delta_32

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1957,17 +1957,16 @@ static inline s64_t k_uptime_delta(s64_t *reftime)
  * This routine computes the elapsed time between the current system uptime
  * and an earlier reference time, in milliseconds.
  *
- * This routine can be more efficient than k_uptime_delta(), as it reduces the
- * need for interrupt locking and 64-bit math. However, the 32-bit result
- * cannot hold an elapsed time larger than approximately 50 days, so the
- * caller must handle possible rollovers.
+ * This is a wrapper around k_uptime_delta().
  *
  * @param reftime Pointer to a reference time, which is updated to the current
  *                uptime upon return.
  *
  * @return Elapsed time.
+ *
+ * @deprecated in 2.3 release, replace with k_uptime_delta()
  */
-static inline u32_t k_uptime_delta_32(s64_t *reftime)
+__deprecated static inline u32_t k_uptime_delta_32(s64_t *reftime)
 {
 	return (u32_t)k_uptime_delta(reftime);
 }

--- a/samples/subsys/canbus/canopen/src/main.c
+++ b/samples/subsys/canbus/canopen/src/main.c
@@ -273,7 +273,7 @@ void main(void)
 				 * exact time elapsed.
 				 */
 				k_sleep(K_MSEC(timeout));
-				elapsed = k_uptime_delta_32(&timestamp);
+				elapsed = (u32_t)k_uptime_delta(&timestamp);
 			} else {
 				/*
 				 * Do not sleep, more processing to be

--- a/tests/kernel/common/src/clock.c
+++ b/tests/kernel/common/src/clock.c
@@ -31,7 +31,6 @@
  * @brief Test clock uptime APIs functionality
  *
  * @see k_uptime_get(), k_uptime_get_32(), k_uptime_delta()
- * k_uptime_delta_32()
  */
 void test_clock_uptime(void)
 {
@@ -66,19 +65,6 @@ void test_clock_uptime(void)
 		k_busy_wait(50);
 #endif
 	}
-
-	/**TESTPOINT: uptime delta lower 32-bit*/
-	k_uptime_delta_32(&d64);
-	while (k_uptime_delta_32(&d64) == 0) {
-#if defined(CONFIG_ARCH_POSIX)
-		k_busy_wait(50);
-#endif
-	}
-
-	/**TESTPOINT: uptime delta straddled ms boundary*/
-	k_uptime_delta_32(&d64);
-	ALIGN_MS_BOUNDARY;
-	zassert_true(k_uptime_delta_32(&d64) > 0, NULL);
 }
 
 /**


### PR DESCRIPTION
The documentation motivates this function by saying it is more efficient than the core 64-bit version. 
 This was untrue when originally added, and is untrue now.  Mark the function deprecated and replace its sole in-tree use with the trivial equivalent.
