### PR TITLE
tests: kernel: context: allow tests_cpu_idle/atomic_idle run for ARM

### DIFF
--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -283,17 +283,10 @@ static void _test_kernel_cpu_idle(int atomic)
  *
  * @see k_cpu_idle()
  */
-#ifndef CONFIG_ARM
 static void test_kernel_cpu_idle_atomic(void)
 {
 	_test_kernel_cpu_idle(1);
 }
-#else
-static void test_kernel_cpu_idle_atomic(void)
-{
-	ztest_test_skip();
-}
-#endif
 
 static void test_kernel_cpu_idle(void)
 {


### PR DESCRIPTION
We do not need to skip running the test_cpu_idle
and test_cpu_atomic_idle tests for ARM, when testing
the non-tickless mode.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>