### PR TITLE
gitignore: exclude tests/drivers/build_all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *~
 build*/
 !doc/guides/build
+!tests/drivers/build_all
 cscope.*
 .dir
 


### PR DESCRIPTION
Exclude tests/drivers/build_all from the build*/ wildcard.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>