### PR TITLE
doc: enforce minimum python version

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -23,7 +23,7 @@ else()
   message(STATUS "West: not found")
 endif()
 
-find_package(PythonInterp 3.4)
+find_package(PythonInterp 3.6 REQUIRED)
 set(DOXYGEN_SKIP_DOT True)
 find_package(Doxygen REQUIRED)
 find_package(LATEX)


### PR DESCRIPTION
This was still set to 3.4, and does not include REQUIRED to fail the
build in case of an old version.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>