### PR TITLE
doc: rename reference/stability to reference/overview

### DIFF
--- a/doc/development_process/api_lifecycle.rst
+++ b/doc/development_process/api_lifecycle.rst
@@ -18,7 +18,7 @@ no longer optimal or supported by the underlying platforms.
     API Life Cycle
 
 An up-to-date table of all APIs and their maturity level can be found in the
-:ref:`api_stability` page.
+:ref:`api_overview` page.
 
 Experimental
 *************
@@ -87,7 +87,7 @@ An API can be declared ``stable`` after fulfilling the following requirements:
 In order to declare an API ``stable``, the following steps need to be followed:
 
 #. A Pull Request must be opened that changes the corresponding entry in the
-   :ref:`api_stability` table
+   :ref:`api_overview` table
 #. An email must be sent to the ``devel`` mailing list announcing the API
    upgrade request
 #. The Pull Request must be submitted for discussion in the next

--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -6,7 +6,7 @@ API Reference
 .. toctree::
    :maxdepth: 1
 
-   stability.rst
+   overview.rst
    terminology.rst
    audio/index.rst
    bluetooth/index.rst

--- a/doc/reference/overview.rst
+++ b/doc/reference/overview.rst
@@ -1,10 +1,10 @@
-.. _api_stability:
+.. _api_overview:
 
-API Stability
-#############
+API Overview
+############
 
-The table below lists the available documented APIs in Zephyr, their
-:ref:`current status <api_lifecycle>` and the release that introduced them.
+The table lists Zephyr's APIs and information about them, including their
+current :ref:`stability level <api_lifecycle>`.
 
 .. list-table::
    :header-rows: 1


### PR DESCRIPTION
This page has a lot more information about APIs than just stability,
and I believe it's currently our only exhaustive list of APIs.

Rename it to API Overview.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>