### PR TITLE
Backport v2.1: shell: utils: Fix buffer overrun in shell_spaces_trim

### DIFF
--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -413,7 +413,7 @@ void shell_spaces_trim(char *str)
 					/* +1 for EOS */
 					memmove(&str[i + 1],
 						&str[j],
-						len - shift + 1);
+						len - j + 1);
 					len -= shift;
 					shift = 0U;
 				}


### PR DESCRIPTION
The third argument in memmove can possible be greater than remaining
buffer size. Just ensuring that memmove will changes bytes only inside
the string buffer and nothing else.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>

Backporting #23304 to 2.1 branch