### PR TITLE
net: wifi: fix log message printing ssid and psk

### DIFF
--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -26,10 +26,9 @@ static int wifi_connect(u32_t mgmt_request, struct net_if *iface,
 		return -ENOTSUP;
 	}
 
-	NET_DBG("%s %u %u %u %s %u",
-		params->ssid, params->ssid_length,
-		params->channel, params->security,
-		params->psk, params->psk_length);
+	LOG_HEXDUMP_DBG(params->ssid, params->ssid_length, "ssid");
+	LOG_HEXDUMP_DBG(params->psk, params->psk_length, "psk");
+	NET_DBG("ch %u sec %u", params->channel, params->security);
 
 	if ((params->security > WIFI_SECURITY_TYPE_PSK) ||
 	    (params->ssid_length > WIFI_SSID_MAX_LEN) ||


### PR DESCRIPTION
The following logs show up when trying to connect:

  uart:~$ wifi connect xxxxxx xxxxxxxxxx
  Connection requested
  [00:00:13.654,968] <dbg> net_wifi_mgmt.wifi_connect: (0x20000500): xxxxxx 6 255 1 xxxxxxxxxx 10
  [00:00:14.655,029] <err> log: argument 6 in source net_wifi_mgmt log message "%s: (%p): %s %u %u %u %s %u" missinglog_strdup().
  [00:00:14.655,029] <err> log: argument 2 in source net_wifi_mgmt log message "%s: (%p): %s %u %u %u %s %u" missinglog_strdup().
  Connected
  uart:~$

Fix that by using LOG_HEXDUMP_DBG() to print SSID and PSK.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>