### PR TITLE
Bluetooth: host: Fix scanner unable to resolve directed advertiser

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3051,7 +3051,7 @@ static int addr_res_enable(u8_t enable)
 				    buf, NULL);
 }
 
-static int hci_id_add(const bt_addr_le_t *addr, u8_t val[16])
+static int hci_id_add(u8_t id, const bt_addr_le_t *addr, u8_t peer_irk[16])
 {
 	struct bt_hci_cp_le_add_dev_to_rl *cp;
 	struct net_buf *buf;
@@ -3065,10 +3065,10 @@ static int hci_id_add(const bt_addr_le_t *addr, u8_t val[16])
 
 	cp = net_buf_add(buf, sizeof(*cp));
 	bt_addr_le_copy(&cp->peer_id_addr, addr);
-	memcpy(cp->peer_irk, val, 16);
+	memcpy(cp->peer_irk, peer_irk, 16);
 
 #if defined(CONFIG_BT_PRIVACY)
-	memcpy(cp->local_irk, bt_dev.irk, 16);
+	memcpy(cp->local_irk, bt_dev.irk[id], 16);
 #else
 	(void)memset(cp->local_irk, 0, 16);
 #endif
@@ -3136,7 +3136,7 @@ void bt_id_add(struct bt_keys *keys)
 		goto done;
 	}
 
-	err = hci_id_add(&keys->addr, keys->irk.val);
+	err = hci_id_add(keys->id, &keys->addr, keys->irk.val);
 	if (err) {
 		BT_ERR("Failed to add IRK to controller");
 		goto done;
@@ -3178,7 +3178,7 @@ done:
 
 static void keys_add_id(struct bt_keys *keys, void *data)
 {
-	hci_id_add(&keys->addr, keys->irk.val);
+	hci_id_add(keys->id, &keys->addr, keys->irk.val);
 }
 
 void bt_id_del(struct bt_keys *keys)

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -236,7 +236,8 @@ void bt_keys_clear(struct bt_keys *keys)
 {
 	BT_DBG("%s (keys 0x%04x)", bt_addr_le_str(&keys->addr), keys->keys);
 
-	if (keys->keys & BT_KEYS_IRK) {
+	if ((IS_ENABLED(CONFIG_BT_CENTRAL) && IS_ENABLED(CONFIG_BT_PRIVACY)) ||
+	    keys->keys & BT_KEYS_IRK) {
 		bt_id_del(keys);
 	}
 
@@ -393,7 +394,11 @@ static int keys_commit(void)
 	 * called multiple times for the same address, especially if
 	 * the keys were already removed.
 	 */
-	bt_keys_foreach(BT_KEYS_IRK, id_add, NULL);
+	if (IS_ENABLED(CONFIG_BT_CENTRAL) && IS_ENABLED(CONFIG_BT_PRIVACY)) {
+		bt_keys_foreach(BT_KEYS_ALL, id_add, NULL);
+	} else {
+		bt_keys_foreach(BT_KEYS_IRK, id_add, NULL);
+	}
 
 	return 0;
 }

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -4405,6 +4405,16 @@ static void bt_smp_encrypt_change(struct bt_l2cap_chan *chan,
 		atomic_set_bit(&smp->allowed_cmds, BT_SMP_CMD_SIGNING_INFO);
 	}
 
+	if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
+	    IS_ENABLED(CONFIG_BT_PRIVACY) &&
+	    !(smp->remote_dist & BT_SMP_DIST_ID_KEY)) {
+		/* To resolve directed advertising we need our local IRK
+		 * in the controllers resolving list, add it now since the
+		 * peer has no identity key.
+		 */
+		bt_id_add(conn->le.keys);
+	}
+
 	atomic_set_bit(smp->flags, SMP_FLAG_KEYS_DISTR);
 
 	/* Slave distributes it's keys first */


### PR DESCRIPTION
Fix two issues related to directed advertiser not able to connect.

Fix directed advertiser using the wrong local IRK when doing directed
advertising when the identity of the advertiser is not the default
identity.
This is only an issue for the directed advertiser because it is only
for the directed advertiser that we use the controllers local IRK
to generate the Advertisers RPA.

Fix directed advertising from privacy disabled peer. In this case we
need to have the local IRK in the controllers resolving list in order to
have the controller resolve the initiator address of the directed
advertising pdu (ADV_DIR_IND).
