### PR TITLE
Tests kernel context cpu idle

### DIFF
--- a/tests/kernel/context/README.txt
+++ b/tests/kernel/context/README.txt
@@ -30,7 +30,9 @@ k_is_in_isr
   - Called from a thread
 
 k_cpu_idle
-  - CPU to be woken up by tick timer.  Thus, after each call, the tick count
+  - Tickless Kernel: CPU to be woken up by a kernel timer (k_timer)
+  - Non-tickless kernel:
+    CPU to be woken up by tick timer.  Thus, after each call, the tick count
     should have advanced by one tick.
 
 irq_lock

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -267,8 +267,8 @@ static void _test_kernel_cpu_idle(int atomic)
 #else /* CONFIG_TICKLESS_KERNEL */
 static void _test_kernel_cpu_idle(int atomic)
 {
-	int tms, tms2;;         /* current time in millisecond */
-	int i;                  /* loop variable */
+	int tms, tms2;
+	int i;
 
 	/* Align to a "ms boundary". */
 	tms = k_uptime_get_32();
@@ -279,7 +279,7 @@ static void _test_kernel_cpu_idle(int atomic)
 	}
 
 	tms = k_uptime_get_32();
-	for (i = 0; i < 5; i++) {       /* Repeat the test five times */
+	for (i = 0; i < 5; i++) { /* Repeat the test five times */
 		if (atomic) {
 			unsigned int key = irq_lock();
 


### PR DESCRIPTION
`k_cpu_idle()` kernel API was not tested for tickless kernel. We wrote a simple test-case that covers the test.

Fixes #23617 