### PR TITLE
Backport v1.14: syscalls: arm: Fix possible overflow in is_in_region function

### DIFF
--- a/arch/arm/core/cortex_m/mpu/arm_mpu_v7_internal.h
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu_v7_internal.h
@@ -200,6 +200,7 @@ static inline int is_in_region(u32_t r_index, u32_t start, u32_t size)
 	u32_t r_addr_start;
 	u32_t r_size_lshift;
 	u32_t r_addr_end;
+	u32_t end;
 
 	/* Lock IRQs to ensure RNR value is correct when reading RBAR, RASR. */
 	unsigned int key;
@@ -216,7 +217,12 @@ static inline int is_in_region(u32_t r_index, u32_t start, u32_t size)
 			MPU_RASR_SIZE_Pos) + 1;
 	r_addr_end = r_addr_start + (1UL << r_size_lshift) - 1;
 
-	if (start >= r_addr_start && (start + size - 1) <= r_addr_end) {
+	size = size == 0 ? 0 : size - 1;
+	if (__builtin_add_overflow(start, size, &end)) {
+		return 0;
+	}
+
+	if ((start >= r_addr_start) && (end <= r_addr_end)) {
 		return 1;
 	}
 

--- a/arch/arm/core/cortex_m/mpu/nxp_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/nxp_mpu.c
@@ -429,11 +429,17 @@ static inline int is_in_region(u32_t r_index, u32_t start, u32_t size)
 {
 	u32_t r_addr_start;
 	u32_t r_addr_end;
+	u32_t end;
 
 	r_addr_start = SYSMPU->WORD[r_index][0];
 	r_addr_end = SYSMPU->WORD[r_index][1];
 
-	if (start >= r_addr_start && (start + size - 1) <= r_addr_end) {
+	size = size == 0 ? 0 : size - 1;
+	if (__builtin_add_overflow(start, size, &end)) {
+		return 0;
+	}
+
+	if ((start >= r_addr_start) && (end <= r_addr_end)) {
 		return 1;
 	}
 

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -137,6 +137,8 @@ extern void z_arch_mem_domain_destroy(struct k_mem_domain *domain);
  * if the supplied memory buffer spans multiple enabled memory management
  * regions (even if all such regions permit user access).
  *
+ * @warning 0 size buffer has undefined behavior.
+ *
  * @param addr start address of the buffer
  * @param size the size of the buffer
  * @param write If nonzero, additionally check if the area is writable.


### PR DESCRIPTION
Manually backporting issue: #23239 to v1.14 branch