### PR TITLE
drivers: flash: spi_nor: make page size and erase sizes configurable

### DIFF
--- a/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.dts
+++ b/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.dts
@@ -52,7 +52,6 @@
 		reg = <0>;
 		spi-max-frequency = <80000000>;
 		size = <0x200000>;
-		has-be32k;
 		has-dpd;
 		t-enter-dpd = <20000>;
 		t-exit-dpd = <100000>;

--- a/boards/arm/black_f407ve/black_f407ve.dts
+++ b/boards/arm/black_f407ve/black_f407ve.dts
@@ -104,7 +104,6 @@
 		t-enter-dpd = <4000>;
 		t-exit-dpd = <25000>;
 		jedec-id = [ef 40 15];
-		has-be32k;
 	};
 };
 

--- a/boards/arm/efr32_radio/efr32_radio.dtsi
+++ b/boards/arm/efr32_radio/efr32_radio.dtsi
@@ -77,7 +77,6 @@
 		reg = <0>;
 		spi-max-frequency = <33000000>;
 		size = <0x800000>;
-		has-be32k;
 		jedec-id = [c2 28 14];
 	};
 };

--- a/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
+++ b/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
@@ -86,7 +86,6 @@
 		reg = <0>;
 		spi-max-frequency = <80000000>;
 		size = <0x800000>;
-		has-be32k;
 		jedec-id = [c2 28 14];
 	};
 };

--- a/boards/arm/frdm_k82f/frdm_k82f.dts
+++ b/boards/arm/frdm_k82f/frdm_k82f.dts
@@ -196,7 +196,6 @@
 		wp-gpios = <&gpioe 3 0>;
 		reset-gpios = <&gpioe 0 0>;
 		size = <0x2000000>;
-		has-be32k;
 		jedec-id = [c2 25 36];
 	};
 };

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -216,7 +216,6 @@ arduino_i2c: &i2c0 {
 		label = "MX25R64";
 		jedec-id = [c2 28 17];
 		size = <67108864>;
-		has-be32k;
 		has-dpd;
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <35000>;

--- a/boards/arm/particle_argon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather.dtsi
@@ -202,7 +202,6 @@ feather_i2c: &i2c0 { };
 		wp-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 		hold-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
 		size = <0x2000000>;
-		has-be32k;
 		has-dpd;
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <100000>;

--- a/boards/arm/particle_boron/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather.dtsi
@@ -202,7 +202,6 @@ feather_i2c: &i2c0 { };
 		wp-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 		hold-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
 		size = <0x2000000>;
-		has-be32k;
 		has-dpd;
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <100000>;

--- a/boards/arm/particle_xenon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather.dtsi
@@ -202,7 +202,6 @@ feather_i2c: &i2c0 { };
 		wp-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 		hold-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
 		size = <0x2000000>;
-		has-be32k;
 		has-dpd;
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <100000>;

--- a/boards/riscv/rv32m1_vega/rv32m1_vega.dtsi
+++ b/boards/riscv/rv32m1_vega/rv32m1_vega.dtsi
@@ -145,7 +145,6 @@ arduino_spi: &lpspi0 {
 		label = "MX25R32";
 		jedec-id = [c2 28 16];
 		size = <33554432>;
-		has-be32k;
 	};
 };
 

--- a/drivers/flash/spi_nor.h
+++ b/drivers/flash/spi_nor.h
@@ -15,11 +15,20 @@ struct spi_nor_config {
 	/* JEDEC id from devicetree */
 	uint8_t id[SPI_NOR_MAX_ID_LEN];
 
-	/* Indicates support for BE32K */
-	bool has_be32k;
-
 	/* Size from devicetree, in bytes */
 	uint32_t size;
+
+	/* Page size, in bytes */
+	uint16_t page_size;
+
+	/* Indicates if device has chip erase capability */
+	bool has_chip_erase;
+
+	/* Erase size exponent and instruction as in JESD216, Basic Flash
+	 * Parameter Table Dword 8 and 9
+	 */
+	const uint8_t erase_size_exp[4];
+	const uint8_t erase_cmd[4];
 };
 
 /* Status register bits */
@@ -33,29 +42,30 @@ struct spi_nor_config {
 #define SPI_NOR_CMD_WREN        0x06    /* Write enable */
 #define SPI_NOR_CMD_WRDI        0x04    /* Write disable */
 #define SPI_NOR_CMD_PP          0x02    /* Page program */
-#define SPI_NOR_CMD_SE          0x20    /* Sector erase */
-#define SPI_NOR_CMD_BE_32K      0x52    /* Block erase 32KB */
-#define SPI_NOR_CMD_BE          0xD8    /* Block erase */
 #define SPI_NOR_CMD_CE          0xC7    /* Chip erase */
 #define SPI_NOR_CMD_RDID        0x9F    /* Read JEDEC ID */
 #define SPI_NOR_CMD_ULBPR       0x98    /* Global Block Protection Unlock */
 #define SPI_NOR_CMD_DPD         0xB9    /* Deep Power Down */
 #define SPI_NOR_CMD_RDPD        0xAB    /* Release from Deep Power Down */
 
-/* Page, sector, and block size are standard, not configurable. */
-#define SPI_NOR_PAGE_SIZE    0x0100U
 #define SPI_NOR_SECTOR_SIZE  0x1000U
 #define SPI_NOR_BLOCK_SIZE   0x10000U
 
-/* Some devices support erase operations on 32 KiBy blocks.
- * Support is indicated by the has-be32k property.
- */
-#define SPI_NOR_BLOCK32_SIZE 0x8000
+/* SFDP Basic Flash Parameters. See JESD216 for documentation*/
+#define SFDP_GET_FIELD(reg, h, l) ((reg & GENMASK(h, l)) >> l)
+#define SFDP_B8_ERASE_SIZE_2(dword)	SFDP_GET_FIELD(dword, 23, 16)
+#define SFDP_B8_ERASE_SIZE_1(dword)	SFDP_GET_FIELD(dword,  7,  0)
+#define SFDP_B8_ERASE_CMD_2(dword)	SFDP_GET_FIELD(dword, 31, 24)
+#define SFDP_B8_ERASE_CMD_1(dword)	SFDP_GET_FIELD(dword, 15,  8)
+#define SFDP_B9_ERASE_SIZE_4(dword)	SFDP_GET_FIELD(dword, 23, 16)
+#define SFDP_B9_ERASE_SIZE_3(dword)	SFDP_GET_FIELD(dword,  7,  0)
+#define SFDP_B9_ERASE_CMD_4(dword)	SFDP_GET_FIELD(dword, 31, 24)
+#define SFDP_B9_ERASE_CMD_3(dword)	SFDP_GET_FIELD(dword, 15,  8)
+#define SFDP_B11_PAGE_SIZE(dword)	SFDP_GET_FIELD(dword,  7,  4)
 
 /* Test whether offset is aligned. */
-#define SPI_NOR_IS_PAGE_ALIGNED(_ofs) (((_ofs) & (SPI_NOR_PAGE_SIZE - 1U)) == 0)
+#define SPI_NOR_IS_ALIGNED(_ofs, _size) (((_ofs) & (_size - 1U)) == 0)
 #define SPI_NOR_IS_SECTOR_ALIGNED(_ofs) (((_ofs) & (SPI_NOR_SECTOR_SIZE - 1U)) == 0)
-#define SPI_NOR_IS_BLOCK_ALIGNED(_ofs) (((_ofs) & (SPI_NOR_BLOCK_SIZE - 1U)) == 0)
-#define SPI_NOR_IS_BLOCK32_ALIGNED(_ofs) (((_ofs) & (SPI_NOR_BLOCK32_SIZE - 1U)) == 0)
+
 
 #endif /*__SPI_NOR_H__*/

--- a/dts/bindings/mtd/jedec,spi-nor-common.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor-common.yaml
@@ -11,11 +11,6 @@ properties:
     required: true
     description: JEDEC ID as manufacturer ID, memory type, memory density
 
-  has-be32k:
-    type: boolean
-    required: false
-    description: Indicates the device supports the BE32K (0xD8) command
-
   requires-ulbpr:
     type: boolean
     required: false
@@ -85,3 +80,33 @@ properties:
     type: int
     required: true
     description: flash capacity in bits
+
+  sfdp-basic-8:
+    type: int
+    required: false
+    default: 0xD810200C
+    description: |
+      Corresponds to the 8th DWORD of the JEDEC Basic Flash Parameter Table,
+      providing erase type 1 and 2 size and instruction.
+
+  sfdp-basic-9:
+    type: int
+    required: false
+    default: 0x0000520F
+    description: |
+      Corresponds to the 9th DWORD of the JEDEC Basic Flash Parameter Table,
+      providing erase type 3 and 4 size and instruction.
+
+  sfdp-basic-11:
+    type: int
+    required: false
+    default: 0x00000080
+    description: |
+      Corresponds to the 11th DWORD of the JEDEC Basic Flash Parameter Table,
+      providing page size. Only bits 7:4 are respected, setting the other bits
+      has no effect.
+
+  has-no-chip-erase:
+    type: boolean
+    required: false
+    description: Indicates device does no support chip erase


### PR DESCRIPTION
JEDEC compatible spi nor devices are not required to have a
standard page and sector size as well as supported erase sizes. The
JEDEC SFDP headers supports up to four erase types with configurable
size and op-code.
Make page size and erase types configurable by adding properties for
the corresponding DWORDS from the JEDEC Basic Flash Parameter Table,
documented in JESD216B. The defaults reflect the drivers old behaviour.

Remove has-be32k property because it is never read.

Fixes  #23322
Fixes  #23673

Signed-off-by: Thomas Schmid <tom@lfence.de>