### PR TITLE
doc: API stability: Change HWINFO from unstable to stable

### DIFF
--- a/doc/reference/overview.rst
+++ b/doc/reference/overview.rst
@@ -125,7 +125,7 @@ current :ref:`stability level <api_lifecycle>`.
      - 2.2
 
    * - :ref:`hwinfo_api`
-     - Unstable
+     - Stable
      - 1.14
      - 1.14
 


### PR DESCRIPTION
Change the API status of the HWINFO API from unstable to stable.