### PR TITLE
enhancements to font generation

### DIFF
--- a/include/display/cfb.h
+++ b/include/display/cfb.h
@@ -44,6 +44,7 @@ enum cfb_display_param {
 enum cfb_font_caps {
 	CFB_FONT_MONO_VPACKED		= BIT(0),
 	CFB_FONT_MONO_HPACKED		= BIT(1),
+	CFB_FONT_MSB_FIRST		= BIT(2),
 };
 
 struct cfb_font {


### PR DESCRIPTION
Per [request](https://github.com/zephyrproject-rtos/zephyr/pull/22087#issuecomment-580879560) this provides two features in font generation, described below.  I can't find the commits that actually used this to support displays that don't have a rotated natural orientation.

##  scripts: gen_cfb_font_header: extend to additional representations
    
The default vertical tiling is designed for displays that are rotated 90 or 270 degrees from normal orientation.  Devices where pixel data advances first horizontally then vertically requires horizontally-tiled data.

Similarly when generating upright text on a row-major-order monochrome display the most significant bit may encode the pixel at the lowest horizontal position.

Add options to control horizontal vs vertical tiling, and msb vs lsb pixel order.

The commit also generates the representation of the glyph in comments at each row.

##  subsys/cfb: move MSB_FIRST down to font capabilities
    
Font capabilities currently indicate whether font data is packed horizontally or vertically, and this is used to control frame buffer updates.  The font bit ordering should likewise be recorded in the font description, and any reversal to match the display applied when text is being set in the frame buffer.

## Example

I haven't included the patch that updates the generated fonts, but it would basically add comments like this alongside the glyph data.  Let me know if you want that.

```
        /* 38 (&) */
        {
                0x00,0x00,   /*                  */
                0x00,0x00,   /*                  */
                0x00,0x0e,   /*          ###     */
                0x70,0x19,   /*     ### #  ##    */
                0x88,0x10,   /*    #   #    #    */
                0xc8,0x13,   /*    #  ####  #    */
                0x70,0x0c,   /*     ###   ##     */
                0x00,0x1f,   /*         #####    */
                0x00,0x10,   /*             #    */
                0x00,0x00,   /*                  */
```

