### PR TITLE
boards: arm: particle_*: add label for arduino_i2c

### DIFF
--- a/boards/arm/particle_argon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather.dtsi
@@ -118,7 +118,7 @@
 	status = "okay";
 };
 
-&i2c0 { /* feather I2C */
+arduino_i2c: &i2c0 { /* feather I2C */
 	compatible = "nordic,nrf-twi";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;

--- a/boards/arm/particle_boron/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather.dtsi
@@ -118,7 +118,7 @@
 	status = "okay";
 };
 
-&i2c0 { /* feather I2C */
+arduino_i2c: &i2c0 { /* feather I2C */
 	compatible = "nordic,nrf-twi";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;

--- a/boards/arm/particle_xenon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather.dtsi
@@ -118,7 +118,7 @@
 	status = "okay";
 };
 
-&i2c0 { /* feather I2C */
+arduino_i2c: &i2c0 { /* feather I2C */
 	compatible = "nordic,nrf-twi";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;


### PR DESCRIPTION
Zephyr shields are mostly defined using references to the arduino
headers.  There are featherwing shields like the Adafruit SSD1306
128x32 display that could work on feather form-factor devices if the
arduino I2C label was available.  Add that label.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>