### PR TITLE
Remove 2 boards from default testing coverage

### DIFF
--- a/boards/arc/em_starterkit/em_starterkit_em7d_normal.yaml
+++ b/boards/arc/em_starterkit/em_starterkit_em7d_normal.yaml
@@ -12,7 +12,6 @@ supported:
 ram: 64
 flash: 128
 testing:
-  default: true
   ignore_tags:
     - net
     - bluetooth

--- a/boards/arm/ip_k66f/ip_k66f.yaml
+++ b/boards/arm/ip_k66f/ip_k66f.yaml
@@ -11,7 +11,5 @@ supported:
   - gpio
   - nvs
   - watchdog
-testing:
-  default: true
 ram: 256
 flash: 2048


### PR DESCRIPTION
This will reduce PR CI time. Focus on runnable platforms.