### PR TITLE
dts: arm: st: Add support for stm32l433Xb

### DIFF
--- a/drivers/pinmux/stm32/pinmux_stm32l4x.h
+++ b/drivers/pinmux/stm32/pinmux_stm32l4x.h
@@ -72,11 +72,21 @@
 
 #define STM32L4X_PINMUX_FUNC_PA9_USART1_TX                                     \
 	(STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)
+#if defined(CONFIG_SOC_STM32L432XX) || defined(CONFIG_SOC_STM32L433XX) ||      \
+	defined(CONFIG_SOC_STM32L452XX)
+#define STM32L4X_PINMUX_FUNC_PA9_I2C1_SCL                                      \
+	(STM32_PINMUX_ALT_FUNC_4 | STM32_OPENDRAIN_PULLUP)
+#endif
 
 #define STM32L4X_PINMUX_FUNC_PA10_USART1_RX                                    \
 	(STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)
 #define STM32L4X_PINMUX_FUNC_PA10_OTG_FS_ID                                    \
 	(STM32_PINMUX_ALT_FUNC_10 | STM32_PUSHPULL_PULLUP)
+#if defined(CONFIG_SOC_STM32L432XX) || defined(CONFIG_SOC_STM32L433XX) ||      \
+	defined(CONFIG_SOC_STM32L452XX)
+#define STM32L4X_PINMUX_FUNC_PA10_I2C1_SDA                                     \
+	(STM32_PINMUX_ALT_FUNC_4 | STM32_OPENDRAIN_PULLUP)
+#endif
 
 #define STM32L4X_PINMUX_FUNC_PA11_USART1_CTS                                   \
 	(STM32_PINMUX_ALT_FUNC_7 | STM32_OPENDRAIN_PULLUP)
@@ -153,9 +163,17 @@
 
 #define STM32L4X_PINMUX_FUNC_PB8_I2C1_SCL                                      \
 	(STM32_PINMUX_ALT_FUNC_4 | STM32_OPENDRAIN_PULLUP)
+#ifndef CONFIG_SOC_STM32L432XX
+#define STM32L4X_PINMUX_FUNC_PB8_CAN_RX                                        \
+	(STM32_PINMUX_ALT_FUNC_9 | STM32_PUSHPULL_NOPULL)
+#endif
 
 #define STM32L4X_PINMUX_FUNC_PB9_I2C1_SDA                                      \
 	(STM32_PINMUX_ALT_FUNC_4 | STM32_OPENDRAIN_PULLUP)
+#ifndef CONFIG_SOC_STM32L432XX
+#define STM32L4X_PINMUX_FUNC_PB9_CAN_TX                                        \
+	(STM32_PINMUX_ALT_FUNC_9 | STM32_PUSHPULL_NOPULL)
+#endif
 
 #define STM32L4X_PINMUX_FUNC_PB10_SPI2_SCK                                     \
 	(STM32_PINMUX_ALT_FUNC_5 | STM32_PUSHPULL_NOPULL | \
@@ -251,6 +269,16 @@
 	 STM32_OSPEEDR_VERY_HIGH_SPEED)
 
 /* Port D */
+#ifndef CONFIG_SOC_STM32L432XX
+#define STM32L4X_PINMUX_FUNC_PD0_CAN_RX                                        \
+	(STM32_PINMUX_ALT_FUNC_9 | STM32_PUSHPULL_NOPULL)
+#endif
+
+#ifndef CONFIG_SOC_STM32L432XX
+#define STM32L4X_PINMUX_FUNC_PD1_CAN_TX                                        \
+	(STM32_PINMUX_ALT_FUNC_9 | STM32_PUSHPULL_NOPULL)
+#endif
+
 #define STM32L4X_PINMUX_FUNC_PD2_USART3_RTS                                    \
 	(STM32_PINMUX_ALT_FUNC_7 | STM32_OPENDRAIN_PULLUP)
 

--- a/dts/arm/st/l4/stm32l433Xb.dtsi
+++ b/dts/arm/st/l4/stm32l433Xb.dtsi
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2020 Kwon Tae-young <tykwon@m2i.co.kr>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <mem.h>
+#include <st/l4/stm32l433.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(64)>;
+	};
+
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(128)>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Adds support for `stm32l433Xb`.
And add `I2C_1` and `CAN` pin of L4 series.

Signed-off-by: Kwon Tae-young <tykwon@m2i.co.kr>