### PR TITLE
lib: cmsis_rtos: Fix Periodic timer

### DIFF
--- a/lib/cmsis_rtos_v1/cmsis_timer.c
+++ b/lib/cmsis_rtos_v1/cmsis_timer.c
@@ -82,7 +82,7 @@ osStatus osTimerStart(osTimerId timer_id, uint32_t millisec)
 	if (timer->type == osTimerOnce) {
 		k_timer_start(&timer->ztimer, millisec, K_NO_WAIT);
 	} else if (timer->type == osTimerPeriodic) {
-		k_timer_start(&timer->ztimer, K_NO_WAIT, millisec);
+		k_timer_start(&timer->ztimer, millisec, millisec);
 	}
 
 	timer->status = ACTIVE;

--- a/lib/cmsis_rtos_v2/timer.c
+++ b/lib/cmsis_rtos_v2/timer.c
@@ -93,7 +93,7 @@ osStatus_t osTimerStart(osTimerId_t timer_id, uint32_t ticks)
 	if (timer->type == osTimerOnce) {
 		k_timer_start(&timer->z_timer, millisec, K_NO_WAIT);
 	} else if (timer->type == osTimerPeriodic) {
-		k_timer_start(&timer->z_timer, K_NO_WAIT, millisec);
+		k_timer_start(&timer->z_timer, millisec, millisec);
 	}
 
 	timer->status = ACTIVE;

--- a/tests/portability/cmsis_rtos_v1/src/timer.c
+++ b/tests/portability/cmsis_rtos_v1/src/timer.c
@@ -89,10 +89,7 @@ void test_timer(void)
 	 */
 	osDelay(timerDelay*NUM_PERIODS + 100);
 
-	/* The first firing of the timer should be ignored.
-	 * Hence checking for NUM_PERIODS + 1.
-	 */
-	zassert_true(num_periods_executed == NUM_PERIODS + 1,
+	zassert_true(num_periods_executed == NUM_PERIODS,
 			"error setting up periodic timer");
 
 	/* Delete the timer before stop */

--- a/tests/portability/cmsis_rtos_v2/src/timer.c
+++ b/tests/portability/cmsis_rtos_v2/src/timer.c
@@ -100,10 +100,7 @@ void test_timer(void)
 	 */
 	osDelay(timerDelay * NUM_PERIODS + 10);
 
-	/* The first firing of the timer should be ignored.
-	 * Hence checking for NUM_PERIODS + 1.
-	 */
-	zassert_true(num_periods_executed == NUM_PERIODS + 1,
+	zassert_true(num_periods_executed == NUM_PERIODS,
 		     "error setting up periodic timer");
 
 	/* Delete the timer before stop */


### PR DESCRIPTION
This commit changes the behaviour of the CMSIS-RTOS periodic timers to
have an initial timeout equal to the periodic timeout instead of
executing the callback function directly when calling the
osTimerStart(...); function.

This behavioural change is according to the CMSIS-RTOS specification.

Signed-off-by: Måns Ansgariusson <Mans.Ansgariusson@AssaAbloy.com>