### PR TITLE
west.yml: Update OpenThread revision

### DIFF
--- a/subsys/net/lib/openthread/platform/CMakeLists.txt
+++ b/subsys/net/lib/openthread/platform/CMakeLists.txt
@@ -10,7 +10,7 @@ zephyr_library_sources(
   radio.c
   settings.c
   spi.c
-  uart.c
   )
 
+zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_NCP uart.c)
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_SHELL shell.c)

--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
       revision: 29e516ec585b1a909af2b5f1c60d83e7d4d563e3
       path: modules/lib/loramac-node
     - name: openthread
-      revision: bc267a62237dac68d1a7443acadd66d0415d155d
+      revision: 497590aa126c331eb1447f699f1c710e0de714c0
       path: modules/lib/openthread
     - name: segger
       revision: 6fcf61606d6012d2c44129edc033f59331e268bc


### PR DESCRIPTION
Introduce an update in the mbedTLS configuration, which is needed after
the OpenThread update. The default mbedTLS CMake configuration was
changed upstream, which resulted in broken cryptography in Zephyr.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>