### PR TITLE
NXP: Kinetis: Only enable temperature sensor driver by default if corresponding ADC is enabled

### DIFF
--- a/boards/arm/frdm_k64f/Kconfig.defconfig
+++ b/boards/arm/frdm_k64f/Kconfig.defconfig
@@ -77,7 +77,7 @@ config ADC_1
 	depends on ADC
 
 config TEMP_KINETIS
-	default y
+	default y if ADC_1
 	depends on SENSOR
 
 config PWM_3

--- a/boards/arm/twr_ke18f/Kconfig.defconfig
+++ b/boards/arm/twr_ke18f/Kconfig.defconfig
@@ -79,7 +79,7 @@ config ADC_0
 	depends on ADC
 
 config TEMP_KINETIS
-	default y
+	default y if ADC_0
 	depends on SENSOR
 
 if PWM


### PR DESCRIPTION
Only enable the NXP Kinetis temperature sensor driver by default if corresponding ADC is enabled. Fixes #23694.