### PR TITLE
Coverity fixes for #22431 and #22643

### DIFF
--- a/drivers/counter/counter_handlers.c
+++ b/drivers/counter/counter_handlers.c
@@ -68,7 +68,7 @@ static inline int z_vrfy_counter_get_value(struct device *dev,
 					   u32_t *ticks)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_COUNTER(dev, get_value));
-	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(ticks, sizeof(ticks)));
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(ticks, sizeof(*ticks)));
 	return z_impl_counter_get_value((struct device *)dev, ticks);
 }
 #include <syscalls/counter_get_value_mrsh.c>

--- a/samples/sensor/fxos8700-hid/src/main.c
+++ b/samples/sensor/fxos8700-hid/src/main.c
@@ -118,6 +118,8 @@ int callbacks_configure(struct device *gpio, u32_t pin, int flags,
 			void (*handler)(struct device*, struct gpio_callback*,
 			u32_t), struct gpio_callback *callback, u32_t *val)
 {
+	int ret;
+
 	if (!gpio) {
 		LOG_ERR("Could not find PORT");
 		return -ENXIO;
@@ -125,10 +127,12 @@ int callbacks_configure(struct device *gpio, u32_t pin, int flags,
 
 	gpio_pin_configure(gpio, pin,
 			   GPIO_INPUT | GPIO_INT_DEBOUNCE | flags);
-	*val = gpio_pin_get(gpio, pin);
-	if (*val < 0) {
-		return *val;
+	ret = gpio_pin_get(gpio, pin);
+	if (ret < 0) {
+		return ret;
 	}
+
+	*val = (u32_t)ret;
 
 	gpio_init_callback(callback, handler, BIT(pin));
 	gpio_add_callback(gpio, callback);


### PR DESCRIPTION
General fixes for problem spotted by Coverity.

Fixes #22431 - z_vrfy_counter_get_value should check the size of memory pointed to
ticks and not the size of the pointer.

Fixes #22643 - gpio_pin_get() returns a negative value in case of error and
callbacks_configure was assigning this value to an unsigned variable.
