### PR TITLE
uart: sifive: fix interrupt-driven transmission

### DIFF
--- a/drivers/serial/Kconfig.sifive
+++ b/drivers/serial/Kconfig.sifive
@@ -36,7 +36,7 @@ config UART_SIFIVE_PORT_0_RXCNT_IRQ
 
 config UART_SIFIVE_PORT_0_TXCNT_IRQ
 	int "Port 0 TX Interrupt Threshold Count"
-	default 0
+	default 1
 	depends on UART_SIFIVE_PORT_0
 	help
 	  Port 0 TX Threshold at which the TX FIFO interrupt triggers.


### PR DESCRIPTION
A txcnt of zero prevents transmission, as transmit requires the number
of entries in the transmit fifo to be strictly less than the txcnt
value.  Set the default to 1.

Fixes #23395