### PR TITLE
Bluetooth: controller: legacy: Validate chan map and hop value

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -1069,7 +1069,13 @@ static inline u32_t isr_rx_adv(u8_t devmatch_ok, u8_t devmatch_id,
 		conn->data_chan_count =
 			util_ones_count_get(&conn->data_chan_map[0],
 					    sizeof(conn->data_chan_map));
+		if (conn->data_chan_count < 2) {
+			return 1;
+		}
 		conn->data_chan_hop = pdu_adv->connect_ind.hop;
+		if ((conn->data_chan_hop < 5) || (conn->data_chan_hop > 16)) {
+			return 1;
+		}
 		conn->conn_interval =
 			pdu_adv->connect_ind.interval;
 		conn_interval_us =


### PR DESCRIPTION
Add validation of channel map and hop increment value
received in CONNECT_IND PDU.

Zero bit count leads to controller assert or divide-by-zero
fault.

Hop increment shall be between 5 and 16 by BT Specification.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>