### PR TITLE
lib: posix: clock: Turn clock_gettime into system call

### DIFF
--- a/include/posix/time.h
+++ b/include/posix/time.h
@@ -79,7 +79,11 @@ static inline s32_t _ts_to_ms(const struct timespec *to)
 	return (to->tv_sec * MSEC_PER_SEC) + (to->tv_nsec / NSEC_PER_MSEC);
 }
 
+#ifdef CONFIG_ARCH_POSIX
 int clock_gettime(clockid_t clock_id, struct timespec *ts);
+#else
+__syscall int clock_gettime(clockid_t clock_id, struct timespec *ts);
+#endif /* CONFIG_ARCH_POSIX */
 int clock_settime(clockid_t clock_id, const struct timespec *ts);
 /* Timer APIs */
 int timer_create(clockid_t clockId, struct sigevent *evp, timer_t *timerid);
@@ -91,5 +95,9 @@ int timer_settime(timer_t timerid, int flags, const struct itimerspec *value,
 #ifdef __cplusplus
 }
 #endif
+
+#ifndef CONFIG_ARCH_POSIX
+#include <syscalls/time.h>
+#endif /* CONFIG_ARCH_POSIX */
 
 #endif /* ZEPHYR_INCLUDE_POSIX_TIME_H_ */

--- a/lib/posix/clock.c
+++ b/lib/posix/clock.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <posix/time.h>
 #include <posix/sys/time.h>
+#include <syscall_handler.h>
 
 /*
  * `k_uptime_get` returns a timestamp based on an always increasing
@@ -22,7 +23,7 @@ static struct timespec rt_clock_base;
  *
  * See IEEE 1003.1
  */
-int clock_gettime(clockid_t clock_id, struct timespec *ts)
+int z_impl_clock_gettime(clockid_t clock_id, struct timespec *ts)
 {
 	u64_t elapsed_msecs;
 	struct timespec base;
@@ -56,6 +57,15 @@ int clock_gettime(clockid_t clock_id, struct timespec *ts)
 
 	return 0;
 }
+
+#ifdef CONFIG_USERSPACE
+int z_vrfy_clock_gettime(clockid_t clock_id, struct timespec *ts)
+{
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(ts, sizeof(*ts)));
+	return z_impl_clock_gettime(clock_id, ts);
+}
+#include <syscalls/clock_gettime_mrsh.c>
+#endif
 
 /**
  * @brief Set the time of the specified clock.


### PR DESCRIPTION
Fix thread fault, on user mode, when reading variable rt_clock_base.
For the moment, clock_settime is left without system call:
we don't want to expose clock_settime without figuring out access
control

Signed-off-by: Julien D'Ascenzio <julien.dascenzio@paratronic.fr>