### PR TITLE
net: ppp: Implement missing ppp mgmt functions

### DIFF
--- a/subsys/net/l2/ppp/CMakeLists.txt
+++ b/subsys/net/l2/ppp/CMakeLists.txt
@@ -20,6 +20,8 @@ zephyr_library_sources_ifdef(CONFIG_NET_L2_PPP
 
 zephyr_library_sources_ifdef(CONFIG_NET_STATISTICS_PPP ppp_stats.c)
 
+zephyr_library_sources_ifdef(CONFIG_NET_L2_PPP_MGMT ppp_mgmt.c)
+
 if(CONFIG_NET_IPV4)
   zephyr_library_sources_ifdef(CONFIG_NET_L2_PPP ipcp.c)
 endif()

--- a/subsys/net/l2/ppp/ppp_mgmt.c
+++ b/subsys/net/l2/ppp/ppp_mgmt.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2020 Lemonbeat GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <net/ppp.h>
+
+void ppp_mgmt_raise_carrier_on_event(struct net_if *iface)
+{
+	net_mgmt_event_notify(NET_EVENT_PPP_CARRIER_ON, iface);
+}
+
+void ppp_mgmt_raise_carrier_off_event(struct net_if *iface)
+{
+	net_mgmt_event_notify(NET_EVENT_PPP_CARRIER_OFF, iface);
+}


### PR DESCRIPTION
The functions ppp_mgmt_raise_carrier_on/off_event() were not
implemented, but already documeted in the header net/ppp.h

Fixes #23420

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>