### PR TITLE
sifive: fix and re-enable gpio interrupts

### DIFF
--- a/dts/riscv/riscv32-fe310.dtsi
+++ b/dts/riscv/riscv32-fe310.dtsi
@@ -94,9 +94,9 @@
 			compatible = "sifive,plic-1.0.0";
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
-			reg = <0xc000000 0x2000
-			       0xc002000 0x1fe000
-			       0xc200000 0x2000000>;
+			reg = <0x0c000000 0x00002000
+			       0x0c002000 0x001fe000
+			       0x0c200000 0x03e00000>;
 			reg-names = "prio", "irq_en", "reg";
 			riscv,max-priority = <7>;
 			riscv,ndev = <52>;


### PR DESCRIPTION
The primary problem was that the callback was being invoked twice, which broke the tests.
    
A secondary issue is that when two level tests occur consecutively the second will fail.  Instrumentation confirms that the registers are being configured correctly, and ip indicates that the condition was detected, but the interrupt does not occur.  Tests pass as long as no level test precedes the failing test.
    
It's not clear whether this is an issue with the PLIC, or the GPIO implementation (hardware or software).  As "normal" GPIO applications appear to work we'll run with it and keep #20337 open to track it.