### PR TITLE
drivers: sensor: ENS210: add single shot mode

### DIFF
--- a/drivers/sensor/ens210/Kconfig
+++ b/drivers/sensor/ens210/Kconfig
@@ -10,6 +10,32 @@ menuconfig ENS210
 	  Enable driver for ENS210 Digital Temperature and Humidity sensor.
 if ENS210
 
+choice
+	prompt "Temperature measurement mode"
+	default ENS210_TEMPERATURE_CONTINUOUS
+	help
+	  Enable/disable temperature measurements and set measurement mode.
+config ENS210_TEMPERATURE_OFF
+	bool "Disable temperature measurements"
+config ENS210_TEMPERATURE_SINGLE
+	bool "Enable temperature measurements in single shot mode"
+config ENS210_TEMPERATURE_CONTINUOUS
+	bool "Enable temperature measurements in continuous mode"
+endchoice
+
+choice
+	prompt "Humidity measurement mode"
+	default ENS210_HUMIDITY_CONTINUOUS
+	help
+	  Enable/disable relative humidity measurements and set measurement mode.
+config ENS210_HUMIDITY_OFF
+	bool "Disable relative humidity measurements"
+config ENS210_HUMIDITY_SINGLE
+	bool "Enable relative humidity measurements in single shot mode"
+config ENS210_HUMIDITY_CONTINUOUS
+	bool "Enable relative humidity measurements in continuous mode"
+endchoice
+
 config ENS210_CRC_CHECK
 	bool "Enable CRC Check"
 	default y

--- a/drivers/sensor/ens210/ens210.h
+++ b/drivers/sensor/ens210/ens210.h
@@ -25,6 +25,28 @@
 
 #define ENS210_PART_ID 0x0210
 
+#if defined CONFIG_ENS210_TEMPERATURE_OFF
+#define ENS210_T_RUN   0
+#define ENS210_T_START 0
+#elif defined CONFIG_ENS210_TEMPERATURE_SINGLE
+#define ENS210_T_RUN   0
+#define ENS210_T_START 1
+#elif defined CONFIG_ENS210_TEMPERATURE_CONTINUOUS
+#define ENS210_T_RUN   1
+#define ENS210_T_START 1
+#endif
+
+#if defined CONFIG_ENS210_HUMIDITY_OFF
+#define ENS210_H_RUN   0
+#define ENS210_H_START 0
+#elif defined CONFIG_ENS210_HUMIDITY_SINGLE
+#define ENS210_H_RUN   0
+#define ENS210_H_START 1
+#elif defined CONFIG_ENS210_HUMIDITY_CONTINUOUS
+#define ENS210_H_RUN   1
+#define ENS210_H_START 1
+#endif
+
 /*
  * Polynomial
  * 0b 1000 1001 ~ x^7+x^3+x^0


### PR DESCRIPTION
Add possibility to change the measurement modes
of the temperature and humidity measurements to
continuous or single-shot mode or switch them off.

Signed-off-by: Christian Hirsch <christian.hirsch@tuwien.ac.at>