### PR TITLE
usb: filter out synchronization type for isochronous endpoints

### DIFF
--- a/include/drivers/usb/usb_dc.h
+++ b/include/drivers/usb/usb_dc.h
@@ -22,10 +22,14 @@
 /**
  * USB endpoint direction and number.
  */
-
 #define USB_EP_DIR_MASK		0x80
 #define USB_EP_DIR_IN		0x80
 #define USB_EP_DIR_OUT		0x00
+
+/**
+ * USB endpoint Transfer Type mask.
+ */
+#define USB_EP_TRANSFER_TYPE_MASK 0x3
 
 /**
  * @brief USB Device Controller API

--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -241,7 +241,8 @@ static int usb_validate_ep_cfg_data(struct usb_ep_descriptor * const ep_descr,
 		for (u8_t idx = 1; idx < 16; idx++) {
 			struct usb_dc_ep_cfg_data ep_cfg;
 
-			ep_cfg.ep_type = ep_descr->bmAttributes;
+			ep_cfg.ep_type = (ep_descr->bmAttributes &
+					  USB_EP_TRANSFER_TYPE_MASK);
 			ep_cfg.ep_mps = ep_descr->wMaxPacketSize;
 			ep_cfg.ep_addr = ep_descr->bEndpointAddress;
 			if (ep_cfg.ep_addr & USB_EP_DIR_IN) {

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -471,12 +471,7 @@ static bool set_endpoint(const struct usb_ep_descriptor *ep_desc)
 
 	ep_cfg.ep_addr = ep_desc->bEndpointAddress;
 	ep_cfg.ep_mps = sys_le16_to_cpu(ep_desc->wMaxPacketSize);
-
-	if (ep_desc->bmAttributes > USB_DC_EP_INTERRUPT) {
-		return false;
-	}
-
-	ep_cfg.ep_type = ep_desc->bmAttributes;
+	ep_cfg.ep_type = ep_desc->bmAttributes & USB_EP_TRANSFER_TYPE_MASK;
 
 	LOG_DBG("Set endpoint 0x%x type %u MPS %u",
 		ep_cfg.ep_addr, ep_cfg.ep_type, ep_cfg.ep_mps);
@@ -518,11 +513,7 @@ static bool reset_endpoint(const struct usb_ep_descriptor *ep_desc)
 	int ret;
 
 	ep_cfg.ep_addr = ep_desc->bEndpointAddress;
-	ep_cfg.ep_type = ep_desc->bmAttributes;
-
-	if (ep_desc->bmAttributes > USB_DC_EP_INTERRUPT) {
-		return false;
-	}
+	ep_cfg.ep_type = ep_desc->bmAttributes & USB_EP_TRANSFER_TYPE_MASK;
 
 	LOG_DBG("Reset endpoint 0x%02x type %u",
 		ep_cfg.ep_addr, ep_cfg.ep_type);


### PR DESCRIPTION
This commit fixes so that different isochronous synchronization modes can be used.
It filters out the synchronization mode before sending the endpoint type to drivers.