### PR TITLE
Backport v1.14: drivers: gpio: fix syscall handlers

### DIFF
--- a/drivers/gpio/gpio_handlers.c
+++ b/drivers/gpio/gpio_handlers.c
@@ -29,17 +29,20 @@ Z_SYSCALL_HANDLER(gpio_read, port, access_op, pin, value)
 
 Z_SYSCALL_HANDLER(gpio_enable_callback, port, access_op, pin)
 {
+	Z_OOPS(Z_SYSCALL_DRIVER_GPIO(port, enable_callback));
 	return z_impl_gpio_enable_callback((struct device *)port, access_op,
 					  pin);
 }
 
 Z_SYSCALL_HANDLER(gpio_disable_callback, port, access_op, pin)
 {
+	Z_OOPS(Z_SYSCALL_DRIVER_GPIO(port, disable_callback));
 	return z_impl_gpio_disable_callback((struct device *)port, access_op,
 					   pin);
 }
 
 Z_SYSCALL_HANDLER(gpio_get_pending_int, port)
 {
+	Z_OOPS(Z_SYSCALL_DRIVER_GPIO(port, get_pending_int));
 	return z_impl_gpio_get_pending_int((struct device *)port);
 }


### PR DESCRIPTION
No driver object checks were being performed for 3 APIs.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>
Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>