### PR TITLE
drivers: openisa: Convert openisa drivers to new DT_INST macros

### DIFF
--- a/drivers/clock_control/clock_control_rv32m1_pcc.c
+++ b/drivers/clock_control/clock_control_rv32m1_pcc.c
@@ -3,6 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#define DT_DRV_COMPAT openisa_rv32m1_pcc
 #include <errno.h>
 #include <soc.h>
 #include <drivers/clock_control.h>
@@ -58,24 +60,24 @@ static const struct clock_control_driver_api rv32m1_pcc_api = {
 	.get_rate = rv32m1_pcc_get_rate,
 };
 
-#if defined(DT_INST_0_OPENISA_RV32M1_PCC)
+#if DT_HAS_DRV_INST(0)
 static struct rv32m1_pcc_config rv32m1_pcc0_config = {
-	.base_address = DT_INST_0_OPENISA_RV32M1_PCC_BASE_ADDRESS
+	.base_address = DT_INST_REG_ADDR(0)
 };
 
-DEVICE_AND_API_INIT(rv32m1_pcc0, DT_INST_0_OPENISA_RV32M1_PCC_LABEL,
+DEVICE_AND_API_INIT(rv32m1_pcc0, DT_INST_LABEL(0),
 		    &rv32m1_pcc_init,
 		    NULL, &rv32m1_pcc0_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,
 		    &rv32m1_pcc_api);
 #endif
 
-#if defined(DT_INST_1_OPENISA_RV32M1_PCC)
+#if DT_HAS_DRV_INST(1)
 static struct rv32m1_pcc_config rv32m1_pcc1_config = {
-	.base_address = DT_INST_1_OPENISA_RV32M1_PCC_BASE_ADDRESS
+	.base_address = DT_INST_REG_ADDR(1)
 };
 
-DEVICE_AND_API_INIT(rv32m1_pcc1, DT_INST_1_OPENISA_RV32M1_PCC_LABEL,
+DEVICE_AND_API_INIT(rv32m1_pcc1, DT_INST_LABEL(1),
 		    &rv32m1_pcc_init,
 		    NULL, &rv32m1_pcc1_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,

--- a/drivers/flash/soc_flash_rv32m1.c
+++ b/drivers/flash/soc_flash_rv32m1.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT soc_nv_flash
+
 #include <kernel.h>
 #include <device.h>
 #include <string.h>
@@ -116,8 +118,8 @@ static int flash_mcux_write_protection(struct device *dev, bool enable)
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 static const struct flash_pages_layout dev_layout = {
 	.pages_count = KB(CONFIG_FLASH_SIZE) /
-					DT_INST_0_SOC_NV_FLASH_ERASE_BLOCK_SIZE,
-	.pages_size = DT_INST_0_SOC_NV_FLASH_ERASE_BLOCK_SIZE,
+					DT_INST_PROP(0, erase_block_size),
+	.pages_size = DT_INST_PROP(0, erase_block_size),
 };
 
 static void flash_mcux_pages_layout(

--- a/drivers/gpio/gpio_rv32m1.c
+++ b/drivers/gpio/gpio_rv32m1.c
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT openisa_rv32m1_gpio
+
 #include <errno.h>
 #include <device.h>
 #include <drivers/gpio.h>
@@ -321,7 +323,7 @@ static int gpio_rv32m1_porta_init(struct device *dev);
 
 static const struct gpio_rv32m1_config gpio_rv32m1_porta_config = {
 	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_0_OPENISA_RV32M1_GPIO_NGPIOS),
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(0, ngpios)),
 	},
 	.gpio_base = (GPIO_Type *) DT_OPENISA_RV32M1_GPIO_GPIO_A_BASE_ADDRESS,
 	.port_base = PORTA,
@@ -369,7 +371,7 @@ static int gpio_rv32m1_portb_init(struct device *dev);
 
 static const struct gpio_rv32m1_config gpio_rv32m1_portb_config = {
 	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_1_OPENISA_RV32M1_GPIO_NGPIOS),
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(1, ngpios)),
 	},
 	.gpio_base = (GPIO_Type *) DT_OPENISA_RV32M1_GPIO_GPIO_B_BASE_ADDRESS,
 	.port_base = PORTB,
@@ -417,7 +419,7 @@ static int gpio_rv32m1_portc_init(struct device *dev);
 
 static const struct gpio_rv32m1_config gpio_rv32m1_portc_config = {
 	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_2_OPENISA_RV32M1_GPIO_NGPIOS),
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(2, ngpios)),
 	},
 	.gpio_base = (GPIO_Type *) DT_OPENISA_RV32M1_GPIO_GPIO_C_BASE_ADDRESS,
 	.port_base = PORTC,
@@ -466,7 +468,7 @@ static int gpio_rv32m1_portd_init(struct device *dev);
 
 static const struct gpio_rv32m1_config gpio_rv32m1_portd_config = {
 	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_3_OPENISA_RV32M1_GPIO_NGPIOS),
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(3, ngpios)),
 	},
 	.gpio_base = (GPIO_Type *) DT_OPENISA_RV32M1_GPIO_GPIO_D_BASE_ADDRESS,
 	.port_base = PORTD,
@@ -514,7 +516,7 @@ static int gpio_rv32m1_porte_init(struct device *dev);
 
 static const struct gpio_rv32m1_config gpio_rv32m1_porte_config = {
 	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_4_OPENISA_RV32M1_GPIO_NGPIOS),
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(4, ngpios)),
 	},
 	.gpio_base = (GPIO_Type *) DT_OPENISA_RV32M1_GPIO_GPIO_E_BASE_ADDRESS,
 	.port_base = PORTE,

--- a/drivers/pwm/pwm_rv32m1_tpm.c
+++ b/drivers/pwm/pwm_rv32m1_tpm.c
@@ -7,6 +7,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT openisa_rv32m1_tpm
+
 #include <drivers/clock_control.h>
 #include <errno.h>
 #include <drivers/pwm.h>
@@ -179,37 +181,37 @@ static const struct pwm_driver_api rv32m1_tpm_driver_api = {
 #define TPM_DEVICE(n) \
 	static const struct rv32m1_tpm_config rv32m1_tpm_config_##n = { \
 		.base =	(TPM_Type *) \
-			DT_INST_##n##_OPENISA_RV32M1_TPM_BASE_ADDRESS, \
+			DT_INST_REG_ADDR(n), \
 		.clock_name = \
-			DT_INST_##n##_OPENISA_RV32M1_TPM_CLOCK_CONTROLLER, \
+			DT_INST_CLOCKS_LABEL(n), \
 		.clock_subsys = (clock_control_subsys_t) \
-			DT_INST_##n##_OPENISA_RV32M1_TPM_CLOCK_NAME, \
+			DT_INST_CLOCKS_CELL(n, name), \
 		.tpm_clock_source = kTPM_SystemClock, \
 		.prescale = kTPM_Prescale_Divide_16, \
 		.channel_count = FSL_FEATURE_TPM_CHANNEL_COUNTn((TPM_Type *) \
-			DT_INST_##n##_OPENISA_RV32M1_TPM_BASE_ADDRESS), \
+			DT_INST_REG_ADDR(n)), \
 		.mode = kTPM_EdgeAlignedPwm, \
 	}; \
 	static struct rv32m1_tpm_data rv32m1_tpm_data_##n; \
 	DEVICE_AND_API_INIT(rv32m1_tpm_##n, \
-			    DT_INST_##n##_OPENISA_RV32M1_TPM_LABEL, \
+			    DT_INST_LABEL(n), \
 			    &rv32m1_tpm_init, &rv32m1_tpm_data_##n, \
 			    &rv32m1_tpm_config_##n, \
 			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
 			    &rv32m1_tpm_driver_api)
 
-#if DT_INST_0_OPENISA_RV32M1_TPM
+#if DT_HAS_DRV_INST(0)
 TPM_DEVICE(0);
-#endif /* DT_INST_0_OPENISA_RV32M1_TPM */
+#endif /* DT_HAS_DRV_INST(0) */
 
-#if DT_INST_1_OPENISA_RV32M1_TPM
+#if DT_HAS_DRV_INST(1)
 TPM_DEVICE(1);
-#endif /* DT_INST_1_OPENISA_RV32M1_TPM */
+#endif /* DT_HAS_DRV_INST(1) */
 
-#if DT_INST_2_OPENISA_RV32M1_TPM
+#if DT_HAS_DRV_INST(2)
 TPM_DEVICE(2);
-#endif /* DT_INST_2_OPENISA_RV32M1_TPM */
+#endif /* DT_HAS_DRV_INST(2) */
 
-#if DT_INST_3_OPENISA_RV32M1_TPM
+#if DT_HAS_DRV_INST(3)
 TPM_DEVICE(3);
-#endif /* DT_INST_3_OPENISA_RV32M1_TPM */
+#endif /* DT_HAS_DRV_INST(3) */


### PR DESCRIPTION
Convert older DT_INST_ macro use in openisa drivers to the new
include/devicetree.h DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>