### PR TITLE
drivers: atmel sam: Convert atmel sam drivers to new DT_INST macros

### DIFF
--- a/drivers/entropy/entropy_sam.c
+++ b/drivers/entropy/entropy_sam.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT atmel_sam_trng
+
 #include <device.h>
 #include <drivers/entropy.h>
 #include <errno.h>
@@ -162,7 +164,7 @@ static int entropy_sam_init(struct device *dev)
 	trng->CTRLA.bit.ENABLE = 1;
 #else
 	/* Enable the user interface clock */
-	soc_pmc_peripheral_enable(DT_INST_0_ATMEL_SAM_TRNG_PERIPHERAL_ID);
+	soc_pmc_peripheral_enable(DT_INST_PROP(0, peripheral_id));
 
 	/* Enable the TRNG */
 	trng->TRNG_CR = TRNG_CR_KEY_PASSWD | TRNG_CR_ENABLE;
@@ -176,7 +178,7 @@ static const struct entropy_driver_api entropy_sam_api = {
 };
 
 static const struct trng_sam_dev_cfg trng_sam_cfg = {
-	.regs = (Trng *)DT_INST_0_ATMEL_SAM_TRNG_BASE_ADDRESS,
+	.regs = (Trng *)DT_INST_REG_ADDR(0),
 };
 
 DEVICE_AND_API_INIT(entropy_sam, CONFIG_ENTROPY_NAME,

--- a/drivers/flash/flash_sam.c
+++ b/drivers/flash/flash_sam.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT soc_nv_flash
+
 #include <device.h>
 #include <drivers/flash.h>
 #include <init.h>
@@ -166,10 +168,10 @@ static int flash_sam_write(struct device *dev, off_t offset,
 	 * Check that the offset and length are multiples of the write
 	 * block size.
 	 */
-	if ((offset % DT_INST_0_SOC_NV_FLASH_WRITE_BLOCK_SIZE) != 0) {
+	if ((offset % DT_INST_PROP(0, write_block_size)) != 0) {
 		return -EINVAL;
 	}
-	if ((len % DT_INST_0_SOC_NV_FLASH_WRITE_BLOCK_SIZE) != 0) {
+	if ((len % DT_INST_PROP(0, write_block_size)) != 0) {
 		return -EINVAL;
 	}
 
@@ -253,17 +255,17 @@ static int flash_sam_erase(struct device *dev, off_t offset, size_t len)
 	 * Check that the offset and length are multiples of the write
 	 * erase block size.
 	 */
-	if ((offset % DT_INST_0_SOC_NV_FLASH_ERASE_BLOCK_SIZE) != 0) {
+	if ((offset % DT_INST_PROP(0, erase_block_size)) != 0) {
 		return -EINVAL;
 	}
-	if ((len % DT_INST_0_SOC_NV_FLASH_ERASE_BLOCK_SIZE) != 0) {
+	if ((len % DT_INST_PROP(0, erase_block_size)) != 0) {
 		return -EINVAL;
 	}
 
 	flash_sam_sem_take(dev);
 
 	/* Loop through the pages to erase */
-	for (i = offset; i < offset + len; i += DT_INST_0_SOC_NV_FLASH_ERASE_BLOCK_SIZE) {
+	for (i = offset; i < offset + len; i += DT_INST_PROP(0, erase_block_size)) {
 		rc = flash_sam_erase_block(dev, i);
 		if (rc < 0) {
 			goto done;
@@ -311,8 +313,8 @@ done:
  * Here a page refers to the granularity at which the flash can be erased.
  */
 static const struct flash_pages_layout flash_sam_pages_layout = {
-	.pages_count = (CONFIG_FLASH_SIZE * 1024) / DT_INST_0_SOC_NV_FLASH_ERASE_BLOCK_SIZE,
-	.pages_size = DT_INST_0_SOC_NV_FLASH_ERASE_BLOCK_SIZE,
+	.pages_count = (CONFIG_FLASH_SIZE * 1024) / DT_INST_PROP(0, erase_block_size),
+	.pages_size = DT_INST_PROP(0, erase_block_size),
 };
 
 void flash_sam_page_layout(struct device *dev,
@@ -341,7 +343,7 @@ static const struct flash_driver_api flash_sam_api = {
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
 	.page_layout = flash_sam_page_layout,
 #endif
-	.write_block_size = DT_INST_0_SOC_NV_FLASH_WRITE_BLOCK_SIZE,
+	.write_block_size = DT_INST_PROP(0, write_block_size),
 };
 
 static const struct flash_sam_dev_cfg flash_sam_cfg = {

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT atmel_sam_gpio
+
 #include <errno.h>
 #include <kernel.h>
 #include <device.h>
@@ -333,7 +335,7 @@ static void port_a_sam_config_func(struct device *dev);
 
 static const struct gpio_sam_config port_a_sam_config = {
 	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_0_ATMEL_SAM_GPIO_NGPIOS),
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(0, ngpios)),
 	},
 	.regs = (Pio *)DT_GPIO_SAM_PORTA_BASE_ADDRESS,
 	.periph_id = DT_GPIO_SAM_PORTA_PERIPHERAL_ID,
@@ -361,7 +363,7 @@ static void port_b_sam_config_func(struct device *dev);
 
 static const struct gpio_sam_config port_b_sam_config = {
 	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_1_ATMEL_SAM_GPIO_NGPIOS),
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(1, ngpios)),
 	},
 	.regs = (Pio *)DT_GPIO_SAM_PORTB_BASE_ADDRESS,
 	.periph_id = DT_GPIO_SAM_PORTB_PERIPHERAL_ID,
@@ -389,7 +391,7 @@ static void port_c_sam_config_func(struct device *dev);
 
 static const struct gpio_sam_config port_c_sam_config = {
 	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_2_ATMEL_SAM_GPIO_NGPIOS),
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(2, ngpios)),
 	},
 	.regs = (Pio *)DT_GPIO_SAM_PORTC_BASE_ADDRESS,
 	.periph_id = DT_GPIO_SAM_PORTC_PERIPHERAL_ID,
@@ -417,7 +419,7 @@ static void port_d_sam_config_func(struct device *dev);
 
 static const struct gpio_sam_config port_d_sam_config = {
 	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_3_ATMEL_SAM_GPIO_NGPIOS),
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(3, ngpios)),
 	},
 	.regs = (Pio *)DT_GPIO_SAM_PORTD_BASE_ADDRESS,
 	.periph_id = DT_GPIO_SAM_PORTD_PERIPHERAL_ID,
@@ -445,7 +447,7 @@ static void port_e_sam_config_func(struct device *dev);
 
 static const struct gpio_sam_config port_e_sam_config = {
 	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_4_ATMEL_SAM_GPIO_NGPIOS),
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(4, ngpios)),
 	},
 	.regs = (Pio *)DT_GPIO_SAM_PORTE_BASE_ADDRESS,
 	.periph_id = DT_GPIO_SAM_PORTE_PERIPHERAL_ID,

--- a/drivers/pwm/pwm_sam.c
+++ b/drivers/pwm/pwm_sam.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT atmel_sam_pwm
+
 #include <device.h>
 #include <errno.h>
 #include <drivers/pwm.h>
@@ -96,30 +98,30 @@ static const struct pwm_driver_api sam_pwm_driver_api = {
 	.get_cycles_per_sec = sam_pwm_get_cycles_per_sec,
 };
 
-#ifdef DT_INST_0_ATMEL_SAM_PWM
+#if DT_HAS_DRV_INST(0)
 static const struct sam_pwm_config sam_pwm_config_0 = {
-	.regs = (Pwm *)DT_INST_0_ATMEL_SAM_PWM_BASE_ADDRESS,
-	.id = DT_INST_0_ATMEL_SAM_PWM_PERIPHERAL_ID,
-	.prescaler = DT_INST_0_ATMEL_SAM_PWM_PRESCALER,
-	.divider = DT_INST_0_ATMEL_SAM_PWM_DIVIDER,
+	.regs = (Pwm *)DT_INST_REG_ADDR(0),
+	.id = DT_INST_PROP(0, peripheral_id),
+	.prescaler = DT_INST_PROP(0, prescaler),
+	.divider = DT_INST_PROP(0, divider),
 };
 
-DEVICE_AND_API_INIT(sam_pwm_0, DT_INST_0_ATMEL_SAM_PWM_LABEL, &sam_pwm_init,
+DEVICE_AND_API_INIT(sam_pwm_0, DT_INST_LABEL(0), &sam_pwm_init,
 		    NULL, &sam_pwm_config_0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &sam_pwm_driver_api);
-#endif /* DT_INST_0_ATMEL_SAM_PWM */
+#endif /* DT_HAS_DRV_INST(0) */
 
-#ifdef DT_INST_1_ATMEL_SAM_PWM
+#if DT_HAS_DRV_INST(1)
 static const struct sam_pwm_config sam_pwm_config_1 = {
-	.regs = (Pwm *)DT_INST_1_ATMEL_SAM_PWM_BASE_ADDRESS,
-	.id = DT_INST_1_ATMEL_SAM_PWM_PERIPHERAL_ID,
-	.prescaler = DT_INST_1_ATMEL_SAM_PWM_PRESCALER,
-	.divider = DT_INST_1_ATMEL_SAM_PWM_DIVIDER,
+	.regs = (Pwm *)DT_INST_REG_ADDR(1),
+	.id = DT_INST_PROP(1, peripheral_id),
+	.prescaler = DT_INST_PROP(1, prescaler),
+	.divider = DT_INST_PROP(1, divider),
 };
 
-DEVICE_AND_API_INIT(sam_pwm_1, DT_INST_1_ATMEL_SAM_PWM_LABEL, &sam_pwm_init,
+DEVICE_AND_API_INIT(sam_pwm_1, DT_INST_LABEL(1), &sam_pwm_init,
 		    NULL, &sam_pwm_config_1,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &sam_pwm_driver_api);
-#endif /* DT_INST_1_ATMEL_SAM_PWM */
+#endif /* DT_HAS_DRV_INST(1) */

--- a/drivers/watchdog/wdt_sam.c
+++ b/drivers/watchdog/wdt_sam.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT atmel_sam_watchdog
+
 /**
  * @brief Watchdog (WDT) Driver for Atmel SAM MCUs
  *
@@ -228,15 +230,15 @@ static const struct wdt_driver_api wdt_sam_api = {
 };
 
 static const struct wdt_sam_dev_cfg wdt_sam_cfg = {
-	.regs = (Wdt *)DT_INST_0_ATMEL_SAM_WATCHDOG_BASE_ADDRESS,
+	.regs = (Wdt *)DT_INST_REG_ADDR(0),
 };
 
 static void wdt_sam_irq_config(void)
 {
-	IRQ_CONNECT(DT_INST_0_ATMEL_SAM_WATCHDOG_IRQ_0,
-		    DT_INST_0_ATMEL_SAM_WATCHDOG_IRQ_0_PRIORITY, wdt_sam_isr,
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		    DT_INST_IRQ(0, priority), wdt_sam_isr,
 		    DEVICE_GET(wdt_sam), 0);
-	irq_enable(DT_INST_0_ATMEL_SAM_WATCHDOG_IRQ_0);
+	irq_enable(DT_INST_IRQN(0));
 }
 
 static int wdt_sam_init(struct device *dev)
@@ -249,6 +251,6 @@ static int wdt_sam_init(struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(wdt_sam, DT_INST_0_ATMEL_SAM_WATCHDOG_LABEL, wdt_sam_init,
+DEVICE_AND_API_INIT(wdt_sam, DT_INST_LABEL(0), wdt_sam_init,
 		    &wdt_sam_data, &wdt_sam_cfg, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &wdt_sam_api);


### PR DESCRIPTION
Convert older DT_INST_ macro use in atmel sam drivers to the new
include/devicetree.h DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>