### PR TITLE
drivers: litex: Convert litex drivers to new DT_INST macros

### DIFF
--- a/drivers/entropy/entropy_litex.c
+++ b/drivers/entropy/entropy_litex.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT litex_prbs
+
 #include <device.h>
 #include <drivers/entropy.h>
 #include <errno.h>
@@ -12,8 +14,8 @@
 #include <string.h>
 #include <zephyr.h>
 
-#define PRBS_STATUS     ((volatile uint32_t *)DT_INST_0_LITEX_PRBS_BASE_ADDRESS)
-#define PRBS_WIDTH      DT_INST_0_LITEX_PRBS_SIZE
+#define PRBS_STATUS     ((volatile uint32_t *)DT_INST_REG_ADDR(0))
+#define PRBS_WIDTH      DT_INST_REG_SIZE(0)
 #define SUBREG_SIZE_BIT 8
 
 static inline unsigned int prbs_read(volatile u32_t *reg_status,

--- a/drivers/ethernet/eth_liteeth.c
+++ b/drivers/ethernet/eth_liteeth.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT litex_eth0
+
 #define LOG_MODULE_NAME eth_liteeth
 #define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
 
@@ -25,21 +27,21 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define LITEETH_EV_RX		0x1
 
 /* slots */
-#define LITEETH_SLOT_BASE	DT_INST_0_LITEX_ETH0_BUFFERS_BASE_ADDRESS
+#define LITEETH_SLOT_BASE	DT_INST_REG_ADDR_BY_NAME(0, buffers)
 #define LITEETH_SLOT_RX0	((LITEETH_SLOT_BASE) + 0x0000)
 #define LITEETH_SLOT_RX1	((LITEETH_SLOT_BASE) + 0x0800)
 #define LITEETH_SLOT_TX0	((LITEETH_SLOT_BASE) + 0x1000)
 #define LITEETH_SLOT_TX1	((LITEETH_SLOT_BASE) + 0x1800)
 
 /* sram - rx */
-#define LITEETH_RX_BASE		DT_INST_0_LITEX_ETH0_CONTROL_BASE_ADDRESS
+#define LITEETH_RX_BASE		DT_INST_REG_ADDR_BY_NAME(0, control)
 #define LITEETH_RX_SLOT		((LITEETH_RX_BASE) + 0x00)
 #define LITEETH_RX_LENGTH	((LITEETH_RX_BASE) + 0x04)
 #define LITEETH_RX_EV_PENDING	((LITEETH_RX_BASE) + 0x28)
 #define LITEETH_RX_EV_ENABLE	((LITEETH_RX_BASE) + 0x2c)
 
 /* sram - tx */
-#define LITEETH_TX_BASE		((DT_INST_0_LITEX_ETH0_CONTROL_BASE_ADDRESS) + 0x30)
+#define LITEETH_TX_BASE		((DT_INST_REG_ADDR_BY_NAME(0, control)) + 0x30)
 #define LITEETH_TX_START	((LITEETH_TX_BASE) + 0x00)
 #define LITEETH_TX_READY	((LITEETH_TX_BASE) + 0x04)
 #define LITEETH_TX_SLOT		((LITEETH_TX_BASE) + 0x0c)
@@ -47,11 +49,11 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define LITEETH_TX_EV_PENDING	((LITEETH_TX_BASE) + 0x1c)
 
 /* irq */
-#define LITEETH_IRQ		DT_INST_0_LITEX_ETH0_IRQ_0
+#define LITEETH_IRQ		DT_INST_IRQN(0)
 #define LITEETH_IRQ_PRIORITY	CONFIG_ETH_LITEETH_0_IRQ_PRI
 
 /* label */
-#define LITEETH_LABEL		DT_INST_0_LITEX_ETH0_LABEL
+#define LITEETH_LABEL		DT_INST_LABEL(0)
 
 struct eth_liteeth_dev_data {
 	struct net_if *iface;
@@ -190,7 +192,7 @@ static void generate_mac(u8_t *mac_addr)
 #ifdef CONFIG_ETH_LITEETH_0
 
 static struct eth_liteeth_dev_data eth_data = {
-	.mac_addr =  DT_INST_0_LITEX_ETH0_LOCAL_MAC_ADDRESS
+	.mac_addr =  DT_INST_PROP(0, local_mac_address)
 };
 
 static void eth_irq_config(void);

--- a/drivers/gpio/gpio_litex.c
+++ b/drivers/gpio/gpio_litex.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT litex_gpio
+
 #include <errno.h>
 #include <device.h>
 #include <drivers/gpio.h>
@@ -214,21 +216,21 @@ static const struct gpio_driver_api gpio_litex_driver_api = {
 /* Device Instantiation */
 
 #define GPIO_LITEX_INIT(n) \
-	BUILD_ASSERT_MSG(DT_INST_##n##_LITEX_GPIO_SIZE != 0 \
-			&& DT_INST_##n##_LITEX_GPIO_SIZE % 4 == 0, \
+	BUILD_ASSERT_MSG(DT_INST_REG_SIZE(n) != 0 \
+			&& DT_INST_REG_SIZE(n) % 4 == 0, \
 		"Register size must be a multiple of 4"); \
 \
 	static const struct gpio_litex_cfg gpio_litex_cfg_##n = { \
 		.reg_addr = \
-		(volatile u32_t *) DT_INST_##n##_LITEX_GPIO_BASE_ADDRESS, \
-		.reg_size = DT_INST_##n##_LITEX_GPIO_SIZE, \
-		.nr_gpios = DT_INST_##n##_LITEX_GPIO_NGPIOS, \
-		.port_is_output = DT_INST_##n##_LITEX_GPIO_PORT_IS_OUTPUT, \
+		(volatile u32_t *) DT_INST_REG_ADDR(n), \
+		.reg_size = DT_INST_REG_SIZE(n), \
+		.nr_gpios = DT_INST_PROP(n, ngpios), \
+		.port_is_output = DT_INST_PROP(n, port_is_output), \
 	}; \
 	static struct gpio_litex_data gpio_litex_data_##n; \
 \
 	DEVICE_AND_API_INIT(litex_gpio_##n, \
-			    DT_INST_##n##_LITEX_GPIO_LABEL, \
+			    DT_INST_LABEL(n), \
 			    gpio_litex_init, \
 			    &gpio_litex_data_##n, \
 			    &gpio_litex_cfg_##n, \
@@ -237,38 +239,38 @@ static const struct gpio_driver_api gpio_litex_driver_api = {
 			    &gpio_litex_driver_api \
 			   )
 
-#ifdef DT_INST_0_LITEX_GPIO_LABEL
+#if DT_INST_NODE_HAS_PROP(0, label)
 GPIO_LITEX_INIT(0);
 #endif
 
-#ifdef DT_INST_1_LITEX_GPIO_LABEL
+#if DT_INST_NODE_HAS_PROP(1, label)
 GPIO_LITEX_INIT(1);
 #endif
 
-#ifdef DT_INST_2_LITEX_GPIO_LABEL
+#if DT_INST_NODE_HAS_PROP(2, label)
 GPIO_LITEX_INIT(2);
 #endif
 
-#ifdef DT_INST_3_LITEX_GPIO_LABEL
+#if DT_INST_NODE_HAS_PROP(3, label)
 GPIO_LITEX_INIT(3);
 #endif
 
-#ifdef DT_INST_4_LITEX_GPIO_LABEL
+#if DT_INST_NODE_HAS_PROP(4, label)
 GPIO_LITEX_INIT(4);
 #endif
 
-#ifdef DT_INST_5_LITEX_GPIO_LABEL
+#if DT_INST_NODE_HAS_PROP(5, label)
 GPIO_LITEX_INIT(5);
 #endif
 
-#ifdef DT_INST_6_LITEX_GPIO_LABEL
+#if DT_INST_NODE_HAS_PROP(6, label)
 GPIO_LITEX_INIT(6);
 #endif
 
-#ifdef DT_INST_7_LITEX_GPIO_LABEL
+#if DT_INST_NODE_HAS_PROP(7, label)
 GPIO_LITEX_INIT(7);
 #endif
 
-#ifdef DT_INST_8_LITEX_GPIO_LABEL
+#if DT_INST_NODE_HAS_PROP(8, label)
 GPIO_LITEX_INIT(8);
 #endif

--- a/drivers/hwinfo/hwinfo_litex.c
+++ b/drivers/hwinfo/hwinfo_litex.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT litex_dna0
+
 #include <drivers/hwinfo.h>
 #include <soc.h>
 #include <string.h>
@@ -12,8 +14,8 @@
 
 ssize_t z_impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
 {
-	u32_t volatile *ptr = (u32_t volatile *)(DT_INST_0_LITEX_DNA0_BASE_ADDRESS);
-	ssize_t end = MIN(length, (DT_INST_0_LITEX_DNA0_SIZE / sizeof(u32_t)));
+	u32_t volatile *ptr = (u32_t volatile *)(DT_INST_REG_ADDR(0));
+	ssize_t end = MIN(length, (DT_INST_REG_SIZE(0) / sizeof(u32_t)));
 
 	for (int i = 0; i < end; i++) {
 		/* In LiteX even though registers are 32-bit wide, each one

--- a/drivers/i2c/i2c_litex.c
+++ b/drivers/i2c/i2c_litex.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT litex_i2c
+
 #include <device.h>
 #include <drivers/i2c.h>
 #include "i2c_bitbang.h"
@@ -117,15 +119,15 @@ static const struct i2c_driver_api i2c_litex_driver_api = {
 #define I2C_LITEX_INIT(n)						       \
 	static const struct i2c_litex_cfg i2c_litex_cfg_##n = {		       \
 		.w_reg =						       \
-		 (volatile u32_t *) DT_INST_##n##_LITEX_I2C_WRITE_BASE_ADDRESS,\
+		 (volatile u32_t *) DT_INST_REG_ADDR_BY_NAME(n, write),\
 		.r_reg =						       \
-		 (volatile u32_t *) DT_INST_##n##_LITEX_I2C_READ_BASE_ADDRESS, \
+		 (volatile u32_t *) DT_INST_REG_ADDR_BY_NAME(n, read), \
 	};								       \
 									       \
 	static struct i2c_bitbang i2c_bitbang_##n;			       \
 									       \
 	DEVICE_AND_API_INIT(litex_i2c_##n,				       \
-			   DT_INST_##n##_LITEX_I2C_LABEL,		       \
+			   DT_INST_LABEL(n),		       \
 			   i2c_litex_init,				       \
 			   &i2c_bitbang_##n,	                               \
 			   &i2c_litex_cfg_##n,				       \
@@ -134,38 +136,38 @@ static const struct i2c_driver_api i2c_litex_driver_api = {
 			   &i2c_litex_driver_api			       \
 			   )
 
-#ifdef DT_INST_0_LITEX_I2C_LABEL
+#if DT_INST_NODE_HAS_PROP(0, label)
 I2C_LITEX_INIT(0);
 #endif
 
-#ifdef DT_INST_1_LITEX_I2C_LABEL
+#if DT_INST_NODE_HAS_PROP(1, label)
 I2C_LITEX_INIT(1);
 #endif
 
-#ifdef DT_INST_2_LITEX_I2C_LABEL
+#if DT_INST_NODE_HAS_PROP(2, label)
 I2C_LITEX_INIT(2);
 #endif
 
-#ifdef DT_INST_3_LITEX_I2C_LABEL
+#if DT_INST_NODE_HAS_PROP(3, label)
 I2C_LITEX_INIT(3);
 #endif
 
-#ifdef DT_INST_4_LITEX_I2C_LABEL
+#if DT_INST_NODE_HAS_PROP(4, label)
 I2C_LITEX_INIT(4);
 #endif
 
-#ifdef DT_INST_5_LITEX_I2C_LABEL
+#if DT_INST_NODE_HAS_PROP(5, label)
 I2C_LITEX_INIT(5);
 #endif
 
-#ifdef DT_INST_6_LITEX_I2C_LABEL
+#if DT_INST_NODE_HAS_PROP(6, label)
 I2C_LITEX_INIT(6);
 #endif
 
-#ifdef DT_INST_7_LITEX_I2C_LABEL
+#if DT_INST_NODE_HAS_PROP(7, label)
 I2C_LITEX_INIT(7);
 #endif
 
-#ifdef DT_INST_8_LITEX_I2C_LABEL
+#if DT_INST_NODE_HAS_PROP(8, label)
 I2C_LITEX_INIT(8);
 #endif

--- a/drivers/interrupt_controller/intc_vexriscv_litex.c
+++ b/drivers/interrupt_controller/intc_vexriscv_litex.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT litex_eth0
+
 #include <kernel.h>
 #include <arch/cpu.h>
 #include <init.h>
@@ -12,13 +14,13 @@
 #include <zephyr.h>
 #include <zephyr/types.h>
 
-#define IRQ_MASK		DT_INST_0_VEXRISCV_INTC0_IRQ_MASK_BASE_ADDRESS
-#define IRQ_PENDING		DT_INST_0_VEXRISCV_INTC0_IRQ_PENDING_BASE_ADDRESS
+#define IRQ_MASK		DT_REG_ADDR_BY_NAME(DT_INST(0, vexriscv_intc0), irq_mask)
+#define IRQ_PENDING		DT_REG_ADDR_BY_NAME(DT_INST(0, vexriscv_intc0), irq_pending)
 
-#define TIMER0_IRQ		DT_INST_0_LITEX_TIMER0_IRQ_0
-#define UART0_IRQ		DT_INST_0_LITEX_UART0_IRQ_0
+#define TIMER0_IRQ		DT_IRQN(DT_INST(0, litex_timer0))
+#define UART0_IRQ		DT_IRQN(DT_INST(0, litex_uart0))
 
-#define ETH0_IRQ		DT_INST_0_LITEX_ETH0_IRQ_0
+#define ETH0_IRQ		DT_IRQN(DT_INST(0, litex_eth0))
 
 static inline void vexriscv_litex_irq_setmask(u32_t mask)
 {

--- a/drivers/pwm/pwm_litex.c
+++ b/drivers/pwm/pwm_litex.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT litex_pwm
+
 #include <device.h>
 #include <drivers/pwm.h>
 #include <zephyr/types.h>
@@ -89,20 +91,20 @@ static const struct pwm_driver_api pwm_litex_driver_api = {
 	static const struct pwm_litex_cfg pwm_litex_cfg_##n = {		       \
 		.reg_en =						       \
 		  (volatile u32_t *)                                           \
-			DT_INST_##n##_LITEX_PWM_ENABLE_BASE_ADDRESS,           \
-		.reg_en_size = DT_INST_##n##_LITEX_PWM_ENABLE_SIZE / 4,        \
+			DT_INST_REG_ADDR_BY_NAME(n, enable),           \
+		.reg_en_size = DT_INST_REG_SIZE_BY_NAME(n, enable) / 4,        \
 		.reg_width =						       \
 		  (volatile u32_t *)                                           \
-			DT_INST_##n##_LITEX_PWM_WIDTH_BASE_ADDRESS,            \
-		.reg_width_size = DT_INST_##n##_LITEX_PWM_WIDTH_SIZE / 4,      \
+			DT_INST_REG_ADDR_BY_NAME(n, width),            \
+		.reg_width_size = DT_INST_REG_SIZE_BY_NAME(n, width) / 4,      \
 		.reg_period  =						       \
 		  (volatile u32_t *)                                           \
-			DT_INST_##n##_LITEX_PWM_PERIOD_BASE_ADDRESS,           \
-		.reg_period_size = DT_INST_##n##_LITEX_PWM_PERIOD_SIZE / 4,    \
+			DT_INST_REG_ADDR_BY_NAME(n, period),           \
+		.reg_period_size = DT_INST_REG_SIZE_BY_NAME(n, period) / 4,    \
 	};								       \
 									       \
 	DEVICE_AND_API_INIT(pwm_##n,					       \
-			    DT_INST_##n##_LITEX_PWM_LABEL,		       \
+			    DT_INST_LABEL(n),		       \
 			    pwm_litex_init,				       \
 			    NULL,					       \
 			    &pwm_litex_cfg_##n,				       \
@@ -111,38 +113,38 @@ static const struct pwm_driver_api pwm_litex_driver_api = {
 			    &pwm_litex_driver_api			       \
 			   )
 
-#ifdef DT_INST_0_LITEX_PWM_LABEL
+#if DT_INST_NODE_HAS_PROP(0, label)
 PWM_LITEX_INIT(0);
 #endif
 
-#ifdef DT_INST_1_LITEX_PWM_LABEL
+#if DT_INST_NODE_HAS_PROP(1, label)
 PWM_LITEX_INIT(1);
 #endif
 
-#ifdef DT_INST_2_LITEX_PWM_LABEL
+#if DT_INST_NODE_HAS_PROP(2, label)
 PWM_LITEX_INIT(2);
 #endif
 
-#ifdef DT_INST_3_LITEX_PWM_LABEL
+#if DT_INST_NODE_HAS_PROP(3, label)
 PWM_LITEX_INIT(3);
 #endif
 
-#ifdef DT_INST_4_LITEX_PWM_LABEL
+#if DT_INST_NODE_HAS_PROP(4, label)
 PWM_LITEX_INIT(4);
 #endif
 
-#ifdef DT_INST_5_LITEX_PWM_LABEL
+#if DT_INST_NODE_HAS_PROP(5, label)
 PWM_LITEX_INIT(5);
 #endif
 
-#ifdef DT_INST_6_LITEX_PWM_LABEL
+#if DT_INST_NODE_HAS_PROP(6, label)
 PWM_LITEX_INIT(6);
 #endif
 
-#ifdef DT_INST_7_LITEX_PWM_LABEL
+#if DT_INST_NODE_HAS_PROP(7, label)
 PWM_LITEX_INIT(7);
 #endif
 
-#ifdef DT_INST_8_LITEX_PWM_LABEL
+#if DT_INST_NODE_HAS_PROP(8, label)
 PWM_LITEX_INIT(8);
 #endif

--- a/drivers/serial/uart_liteuart.c
+++ b/drivers/serial/uart_liteuart.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT litex_uart0
+
 #include <kernel.h>
 #include <arch/cpu.h>
 #include <init.h>
@@ -14,14 +16,14 @@
 
 #define UART_EV_TX	(1 << 0)
 #define UART_EV_RX	(1 << 1)
-#define UART_BASE_ADDR	DT_INST_0_LITEX_UART0_BASE_ADDRESS
+#define UART_BASE_ADDR	DT_INST_REG_ADDR(0)
 #define UART_RXTX	((UART_BASE_ADDR) + 0x00)
 #define UART_TXFULL	((UART_BASE_ADDR) + 0x04)
 #define UART_RXEMPTY	((UART_BASE_ADDR) + 0x08)
 #define UART_EV_STATUS	((UART_BASE_ADDR) + 0x0c)
 #define UART_EV_PENDING	((UART_BASE_ADDR) + 0x10)
 #define UART_EV_ENABLE	((UART_BASE_ADDR) + 0x14)
-#define UART_IRQ	DT_INST_0_LITEX_UART0_IRQ_0
+#define UART_IRQ	DT_INST_IRQN(0)
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 typedef void (*irq_cfg_func_t)(void);
@@ -313,10 +315,10 @@ static int uart_liteuart_init(struct device *dev);
 
 static const struct uart_liteuart_device_config uart_liteuart_dev_cfg_0 = {
 	.port		= UART_BASE_ADDR,
-	.baud_rate	= DT_INST_0_LITEX_UART0_CURRENT_SPEED
+	.baud_rate	= DT_INST_PROP(0, current_speed)
 };
 
-DEVICE_AND_API_INIT(uart_liteuart_0, DT_INST_0_LITEX_UART0_LABEL,
+DEVICE_AND_API_INIT(uart_liteuart_0, DT_INST_LABEL(0),
 		uart_liteuart_init,
 		&uart_liteuart_data_0, &uart_liteuart_dev_cfg_0,
 		PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -327,7 +329,7 @@ static int uart_liteuart_init(struct device *dev)
 	sys_write8(UART_EV_TX | UART_EV_RX, UART_EV_PENDING);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	IRQ_CONNECT(UART_IRQ, DT_INST_0_LITEX_UART0_IRQ_0_PRIORITY,
+	IRQ_CONNECT(UART_IRQ, DT_INST_IRQ(0, priority),
 			liteuart_uart_irq_handler, DEVICE_GET(uart_liteuart_0),
 			0);
 	irq_enable(UART_IRQ);

--- a/drivers/spi/spi_litespi.c
+++ b/drivers/spi/spi_litespi.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT litex_spi
+
 #define LOG_LEVEL CONFIG_SPI_LOG_LEVEL
 #include <logging/log.h>
 LOG_MODULE_REGISTER(spi_litespi);
@@ -169,10 +171,10 @@ static struct spi_driver_api spi_litespi_api = {
 		SPI_CONTEXT_INIT_SYNC(spi_litespi_data_##n, ctx), \
 	}; \
 	static struct spi_litespi_cfg spi_litespi_cfg_##n = { \
-		.base = DT_INST_##n##_LITEX_SPI_CONTROL_BASE_ADDRESS, \
+		.base = DT_INST_REG_ADDR_BY_NAME(n, control), \
 	}; \
 	DEVICE_AND_API_INIT(spi_##n, \
-			DT_INST_##n##_LITEX_SPI_LABEL, \
+			DT_INST_LABEL(n), \
 			spi_litespi_init, \
 			&spi_litespi_data_##n, \
 			&spi_litespi_cfg_##n, \
@@ -180,8 +182,8 @@ static struct spi_driver_api spi_litespi_api = {
 			CONFIG_SPI_INIT_PRIORITY, \
 			&spi_litespi_api)
 
-#ifdef DT_INST_0_LITEX_SPI_LABEL
+#if DT_INST_NODE_HAS_PROP(0, label)
 
 SPI_INIT(0);
 
-#endif /* DT_INST_0_LITEX_SPI_LABEL */
+#endif /* DT_INST_NODE_HAS_PROP(0, label) */

--- a/drivers/spi/spi_litespi.h
+++ b/drivers/spi/spi_litespi.h
@@ -13,7 +13,7 @@
 #include <device.h>
 #include <drivers/spi.h>
 
-#define SPI_BASE_ADDR DT_INST_0_LITEX_SPI_BASE_ADDRESS
+#define SPI_BASE_ADDR DT_INST_REG_ADDR(0)
 #define SPI_CONTROL_REG SPI_BASE_ADDR
 #define SPI_STATUS_REG (SPI_BASE_ADDR + 0x08)
 #define SPI_MOSI_DATA_REG (SPI_BASE_ADDR + 0x0c)

--- a/drivers/timer/litex_timer.c
+++ b/drivers/timer/litex_timer.c
@@ -4,13 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT litex_timer0
+
 #include <kernel.h>
 #include <arch/cpu.h>
 #include <device.h>
 #include <irq.h>
 #include <drivers/timer/system_timer.h>
 
-#define TIMER_BASE	        DT_INST_0_LITEX_TIMER0_BASE_ADDRESS
+#define TIMER_BASE	        DT_INST_REG_ADDR(0)
 #define TIMER_LOAD_ADDR		((TIMER_BASE) + 0x00)
 #define TIMER_RELOAD_ADDR	((TIMER_BASE) + 0x10)
 #define TIMER_EN_ADDR		((TIMER_BASE) + 0x20)
@@ -18,7 +20,7 @@
 #define TIMER_EV_ENABLE_ADDR	((TIMER_BASE) + 0x40)
 
 #define TIMER_EV	0x1
-#define TIMER_IRQ	DT_INST_0_LITEX_TIMER0_IRQ_0
+#define TIMER_IRQ	DT_INST_IRQN(0)
 #define TIMER_DISABLE	0x0
 #define TIMER_ENABLE	0x1
 
@@ -50,7 +52,7 @@ u32_t z_clock_elapsed(void)
 int z_clock_driver_init(struct device *device)
 {
 	ARG_UNUSED(device);
-	IRQ_CONNECT(TIMER_IRQ, DT_INST_0_LITEX_TIMER0_IRQ_0_PRIORITY,
+	IRQ_CONNECT(TIMER_IRQ, DT_INST_IRQ(0, priority),
 			litex_timer_irq_handler, NULL, 0);
 	irq_enable(TIMER_IRQ);
 

--- a/soc/riscv/litex-vexriscv/soc.h
+++ b/soc/riscv/litex-vexriscv/soc.h
@@ -11,8 +11,8 @@
 #include <devicetree.h>
 
 /* lib-c hooks required RAM defined variables */
-#define RISCV_RAM_BASE              DT_INST_0_MMIO_SRAM_BASE_ADDRESS
-#define RISCV_RAM_SIZE              DT_INST_0_MMIO_SRAM_SIZE
+#define RISCV_RAM_BASE              DT_REG_ADDR(DT_INST(0, mmio_sram))
+#define RISCV_RAM_SIZE              DT_REG_SIZE(DT_INST(0, mmio_sram))
 
 #ifndef _ASMLANGUAGE
 /* CSR access helpers */


### PR DESCRIPTION
Convert older DT_INST_ macro use in litex drivers to the new
include/devicetree.h DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>