### PR TITLE
drivers: nrf: Convert nrf drivers to new DT_INST macros

### DIFF
--- a/drivers/clock_control/nrf_power_clock.c
+++ b/drivers/clock_control/nrf_power_clock.c
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT nordic_nrf_clock
+
 #include <soc.h>
 #include <drivers/clock_control.h>
 #include <drivers/clock_control/nrf_clock_control.h>
@@ -300,11 +302,11 @@ void nrf_power_clock_isr(void *arg);
 
 static int clk_init(struct device *dev)
 {
-	IRQ_CONNECT(DT_INST_0_NORDIC_NRF_CLOCK_IRQ_0,
-		    DT_INST_0_NORDIC_NRF_CLOCK_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		    DT_INST_IRQ(0, priority),
 		    nrf_power_clock_isr, 0, 0);
 
-	irq_enable(DT_INST_0_NORDIC_NRF_CLOCK_IRQ_0);
+	irq_enable(DT_INST_IRQN(0));
 
 	nrf_clock_lf_src_set(NRF_CLOCK, CLOCK_CONTROL_NRF_K32SRC);
 
@@ -348,7 +350,7 @@ static const struct nrf_clock_control_config config = {
 };
 
 DEVICE_AND_API_INIT(clock_nrf,
-		    DT_INST_0_NORDIC_NRF_CLOCK_LABEL,
+		    DT_INST_LABEL(0),
 		    clk_init, &data, &config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &clock_control_api);
@@ -449,7 +451,7 @@ void nrf5_power_usb_power_int_enable(bool enable)
 
 	if (enable) {
 		nrf_power_int_enable(NRF_POWER, mask);
-		irq_enable(DT_INST_0_NORDIC_NRF_CLOCK_IRQ_0);
+		irq_enable(DT_INST_IRQN(0));
 	} else {
 		nrf_power_int_disable(NRF_POWER, mask);
 	}

--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 #include <drivers/counter.h>
 #include <drivers/clock_control.h>
 #include <drivers/clock_control/nrf_clock_control.h>
@@ -532,7 +533,7 @@ static int init_rtc(struct device *dev, u32_t prescaler)
 	NRF_RTC_Type *rtc = nrfx_config->rtc;
 	int err;
 
-	clock = device_get_binding(DT_INST_0_NORDIC_NRF_CLOCK_LABEL);
+	clock = device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_clock)));
 	if (!clock) {
 		return -ENODEV;
 	}

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT nordic_qspi_nor
+
 #include <errno.h>
 #include <drivers/flash.h>
 #include <init.h>
@@ -22,7 +24,7 @@
 #define QSPI_BLOCK_SIZE SPI_NOR_BLOCK_SIZE
 
 /* instance 0 flash size in bytes */
-#define INST_0_BYTES (DT_INST_0_NORDIC_QSPI_NOR_SIZE / 8)
+#define INST_0_BYTES (DT_INST_PROP(0, size) / 8)
 
 LOG_MODULE_REGISTER(qspi_nor, CONFIG_FLASH_LOG_LEVEL);
 
@@ -369,30 +371,30 @@ static inline void qspi_fill_init_struct(nrfx_qspi_config_t *initstruct)
 	initstruct->pins.io3_pin = DT_NORDIC_NRF_QSPI_QSPI_0_IO_PINS_3;
 
 	/* Configure Protocol interface */
-#ifdef DT_INST_0_NORDIC_QSPI_NOR_READOC_ENUM
+#if DT_INST_NODE_HAS_PROP(0, readoc_enum)
 	initstruct->prot_if.readoc =
-		(nrf_qspi_writeoc_t)qspi_get_lines_read(DT_INST_0_NORDIC_QSPI_NOR_READOC_ENUM);
+		(nrf_qspi_writeoc_t)qspi_get_lines_read(DT_INST_PROP(0, readoc_enum));
 #else
 	initstruct->prot_if.readoc = NRF_QSPI_READOC_FASTREAD;
 #endif
 
-#ifdef DT_INST_0_NORDIC_QSPI_NOR_WRITEOC_ENUM
+#if DT_INST_NODE_HAS_PROP(0, writeoc_enum)
 	initstruct->prot_if.writeoc =
-		(nrf_qspi_writeoc_t)qspi_get_lines_write(DT_INST_0_NORDIC_QSPI_NOR_WRITEOC_ENUM);
+		(nrf_qspi_writeoc_t)qspi_get_lines_write(DT_INST_PROP(0, writeoc_enum));
 #else
 	initstruct->prot_if.writeoc = NRF_QSPI_WRITEOC_PP;
 #endif
 	initstruct->prot_if.addrmode =
-		qspi_get_address_size(DT_INST_0_NORDIC_QSPI_NOR_ADDRESS_SIZE_32);
+		qspi_get_address_size(DT_INST_PROP(0, address_size_32));
 
 	initstruct->prot_if.dpmconfig = false;
 
 	/* Configure physical interface */
 	initstruct->phy_if.sck_freq =
-		get_nrf_qspi_prescaler(DT_INST_0_NORDIC_QSPI_NOR_SCK_FREQUENCY);
-	initstruct->phy_if.sck_delay = DT_INST_0_NORDIC_QSPI_NOR_SCK_DELAY;
-	initstruct->phy_if.spi_mode = qspi_get_mode(DT_INST_0_NORDIC_QSPI_NOR_CPOL,
-						    DT_INST_0_NORDIC_QSPI_NOR_CPHA);
+		get_nrf_qspi_prescaler(DT_INST_PROP(0, sck_frequency));
+	initstruct->phy_if.sck_delay = DT_INST_PROP(0, sck_delay);
+	initstruct->phy_if.spi_mode = qspi_get_mode(DT_INST_PROP(0, cpol),
+						    DT_INST_PROP(0, cpha));
 
 	initstruct->phy_if.dpmen = false;
 }
@@ -671,11 +673,11 @@ static const struct flash_driver_api qspi_nor_api = {
 
 
 static const struct qspi_nor_config flash_id = {
-	.id = DT_INST_0_NORDIC_QSPI_NOR_JEDEC_ID,
+	.id = DT_INST_PROP(0, jedec_id),
 	.size = INST_0_BYTES,
 };
 
-DEVICE_AND_API_INIT(qspi_flash_memory, DT_INST_0_NORDIC_QSPI_NOR_LABEL,
+DEVICE_AND_API_INIT(qspi_flash_memory, DT_INST_LABEL(0),
 		    &qspi_nor_init, &qspi_nor_memory_data,
 		    &flash_id, POST_KERNEL, CONFIG_NORDIC_QSPI_NOR_INIT_PRIORITY,
 		    &qspi_nor_api);

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT nordic_nrf_gpio
+
 #include <drivers/gpio.h>
 #include <hal/nrf_gpio.h>
 #include <hal/nrf_gpiote.h>
@@ -513,7 +515,9 @@ static int gpio_nrfx_init(struct device *port)
 #define GPIO_NRF_DEVICE(id)						\
 	static const struct gpio_nrfx_cfg gpio_nrfx_p##id##_cfg = {	\
 		.common = {						\
-			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_##id##_NORDIC_NRF_GPIO_NGPIOS), \
+			.port_pin_mask =				\
+				GPIO_PORT_PIN_MASK_FROM_NGPIOS(		\
+					DT_INST_PROP(id, ngpios)),	\
 		},							\
 		.port = NRF_P##id,					\
 		.port_num = id						\

--- a/drivers/ipm/ipm_nrfx_ipc.c
+++ b/drivers/ipm/ipm_nrfx_ipc.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT nordic_nrf_ipc
+
 #include <string.h>
 #include <drivers/ipm.h>
 #include <nrfx_ipc.h>
@@ -82,10 +84,10 @@ static int ipm_nrf_set_enabled(struct device *dev, int enable)
 {
 	/* Enable configured channels */
 	if (enable) {
-		irq_enable(DT_INST_0_NORDIC_NRF_IPC_IRQ_0);
+		irq_enable(DT_INST_IRQN(0));
 		nrfx_ipc_receive_event_group_enable((uint32_t)IPC_EVENT_BITS);
 	} else {
-		irq_disable(DT_INST_0_NORDIC_NRF_IPC_IRQ_0);
+		irq_disable(DT_INST_IRQN(0));
 		nrfx_ipc_receive_event_group_disable((uint32_t)IPC_EVENT_BITS);
 	}
 	return 0;
@@ -105,7 +107,7 @@ static const struct ipm_driver_api ipm_nrf_driver_api = {
 	.set_enabled = ipm_nrf_set_enabled
 };
 
-DEVICE_AND_API_INIT(ipm_nrf, DT_INST_0_NORDIC_NRF_IPC_LABEL,
+DEVICE_AND_API_INIT(ipm_nrf, DT_INST_LABEL(0),
 		    ipm_nrf_init, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &ipm_nrf_driver_api);
@@ -205,7 +207,7 @@ static int vipm_nrf_##_idx##_set_enabled(struct device *dev, int enable)\
 		LOG_ERR("IPM_" #_idx " is TX message channel");		\
 		return -EINVAL;						\
 	} else if (enable) {						\
-		irq_enable(DT_INST_0_NORDIC_NRF_IPC_IRQ_0);		\
+		irq_enable(DT_INST_IRQN(0));		\
 		nrfx_ipc_receive_event_enable(_idx);			\
 	} else if (!enable) {						\
 		nrfx_ipc_receive_event_disable(_idx);			\
@@ -241,8 +243,8 @@ static void gipm_init(void)
 #else
 	nrfx_ipc_init(0, vipm_dispatcher, (void *)&nrfx_ipm_data);
 #endif
-	IRQ_CONNECT(DT_INST_0_NORDIC_NRF_IPC_IRQ_0,
-		    DT_INST_0_NORDIC_NRF_IPC_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		    DT_INST_IRQ(0, priority),
 		    nrfx_isr, nrfx_ipc_irq_handler, 0);
 
 	/* Set up signals and channels */

--- a/drivers/pwm/pwm_nrf5_sw.c
+++ b/drivers/pwm/pwm_nrf5_sw.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT nordic_nrf_sw_pwm
+
 #include <soc.h>
 
 #include <drivers/pwm.h>
@@ -14,13 +16,13 @@
 LOG_MODULE_REGISTER(pwm_nrf5_sw);
 
 /* One compare channel is needed to set the PWM period, hence +1. */
-#if ((DT_INST_0_NORDIC_NRF_SW_PWM_CHANNEL_COUNT + 1) > \
+#if ((DT_INST_PROP(0, channel_count) + 1) > \
 	(_CONCAT( \
-		_CONCAT(TIMER, DT_INST_0_NORDIC_NRF_SW_PWM_TIMER_INSTANCE), \
+		_CONCAT(TIMER, DT_INST_PROP(0, timer_instance)), \
 		_CC_NUM)))
 #error "Invalid number of PWM channels configured."
 #endif
-#define PWM_0_MAP_SIZE DT_INST_0_NORDIC_NRF_SW_PWM_CHANNEL_COUNT
+#define PWM_0_MAP_SIZE DT_INST_PROP(0, channel_count)
 
 struct pwm_config {
 	NRF_TIMER_Type *timer;
@@ -251,17 +253,17 @@ static int pwm_nrf5_sw_init(struct device *dev)
 }
 
 static const struct pwm_config pwm_nrf5_sw_0_config = {
-	.timer = _CONCAT(NRF_TIMER, DT_INST_0_NORDIC_NRF_SW_PWM_TIMER_INSTANCE),
-	.ppi_base = DT_INST_0_NORDIC_NRF_SW_PWM_PPI_BASE,
-	.gpiote_base = DT_INST_0_NORDIC_NRF_SW_PWM_GPIOTE_BASE,
+	.timer = _CONCAT(NRF_TIMER, DT_INST_PROP(0, timer_instance)),
+	.ppi_base = DT_INST_PROP(0, ppi_base),
+	.gpiote_base = DT_INST_PROP(0, gpiote_base),
 	.map_size = PWM_0_MAP_SIZE,
-	.prescaler = DT_INST_0_NORDIC_NRF_SW_PWM_CLOCK_PRESCALER,
+	.prescaler = DT_INST_PROP(0, clock_prescaler),
 };
 
 static struct pwm_data pwm_nrf5_sw_0_data;
 
 DEVICE_AND_API_INIT(pwm_nrf5_sw_0,
-		    DT_INST_0_NORDIC_NRF_SW_PWM_LABEL,
+		    DT_INST_LABEL(0),
 		    pwm_nrf5_sw_init,
 		    &pwm_nrf5_sw_0_data,
 		    &pwm_nrf5_sw_0_config,

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -83,7 +83,7 @@ int z_clock_driver_init(struct device *device)
 
 	ARG_UNUSED(device);
 
-	clock = device_get_binding(DT_INST_0_NORDIC_NRF_CLOCK_LABEL);
+	clock = device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_clock)));
 	if (!clock) {
 		return -1;
 	}

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -536,7 +536,7 @@ static int hf_clock_enable(bool on, bool blocking)
 	struct device *clock;
 	static bool clock_requested;
 
-	clock = device_get_binding(DT_INST_0_NORDIC_NRF_CLOCK_LABEL);
+	clock = device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_clock)));
 	if (!clock) {
 		LOG_ERR("NRF HF Clock device not found!");
 		return ret;


### PR DESCRIPTION
Convert older DT_INST_ macro use in nrf drivers to the new
include/devicetree.h DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>