### PR TITLE
drivers: stellaris: Convert stellaris drivers to new DT_INST macros

### DIFF
--- a/drivers/ethernet/eth_stellaris.c
+++ b/drivers/ethernet/eth_stellaris.c
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT ti_stellaris_ethernet
+
 #define LOG_MODULE_NAME eth_stellaris
 #define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
 #include <logging/log.h>
@@ -20,7 +22,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 static void eth_stellaris_assign_mac(struct device *dev)
 {
-	u8_t mac_addr[6] = DT_INST_0_TI_STELLARIS_ETHERNET_LOCAL_MAC_ADDRESS;
+	u8_t mac_addr[6] = DT_INST_PROP(0, local_mac_address);
 	u32_t value = 0x0;
 
 	value |= mac_addr[0];
@@ -323,19 +325,19 @@ static struct device DEVICE_NAME_GET(eth_stellaris);
 static void eth_stellaris_irq_config(struct device *dev)
 {
 	/* Enable Interrupt. */
-	IRQ_CONNECT(DT_INST_0_TI_STELLARIS_ETHERNET_IRQ_0,
-		    DT_INST_0_TI_STELLARIS_ETHERNET_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		    DT_INST_IRQ(0, priority),
 		    eth_stellaris_isr, DEVICE_GET(eth_stellaris), 0);
-	irq_enable(DT_INST_0_TI_STELLARIS_ETHERNET_IRQ_0);
+	irq_enable(DT_INST_IRQN(0));
 }
 
 struct eth_stellaris_config eth_cfg = {
-	.mac_base = DT_INST_0_TI_STELLARIS_ETHERNET_BASE_ADDRESS,
+	.mac_base = DT_INST_REG_ADDR(0),
 	.config_func = eth_stellaris_irq_config,
 };
 
 struct eth_stellaris_runtime eth_data = {
-	.mac_addr = DT_INST_0_TI_STELLARIS_ETHERNET_LOCAL_MAC_ADDRESS,
+	.mac_addr = DT_INST_PROP(0, local_mac_address),
 	.tx_err = false,
 	.tx_word = 0,
 	.tx_pos = 0,
@@ -349,7 +351,7 @@ static const struct ethernet_api eth_stellaris_apis = {
 #endif
 };
 
-NET_DEVICE_INIT(eth_stellaris, DT_INST_0_TI_STELLARIS_ETHERNET_LABEL,
+NET_DEVICE_INIT(eth_stellaris, DT_INST_LABEL(0),
 		eth_stellaris_dev_init, &eth_data, &eth_cfg,
 		CONFIG_ETH_INIT_PRIORITY,
 		&eth_stellaris_apis, ETHERNET_L2,

--- a/drivers/gpio/gpio_stellaris.c
+++ b/drivers/gpio/gpio_stellaris.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT ti_stellaris_gpio
+
 #include <errno.h>
 #include <device.h>
 #include <drivers/gpio.h>
@@ -254,7 +256,7 @@ static const struct gpio_driver_api gpio_stellaris_driver_api = {
 };
 
 #define PORT_PIN_MASK(n) \
-	GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_## n ##_TI_STELLARIS_GPIO_NGPIOS)
+	GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(n, ngpios))
 
 #define STELLARIS_GPIO_DEVICE(n)							\
 	static void port_## n ##_stellaris_config_func(struct device *dev);		\
@@ -265,8 +267,8 @@ static const struct gpio_driver_api gpio_stellaris_driver_api = {
 		.common = {								\
 			.port_pin_mask = PORT_PIN_MASK(n),				\
 		},									\
-		.base = DT_INST_## n ##_TI_STELLARIS_GPIO_BASE_ADDRESS,			\
-		.port_map = BIT_MASK(DT_INST_## n ##_TI_STELLARIS_GPIO_NGPIOS),		\
+		.base = DT_INST_REG_ADDR(n),			\
+		.port_map = BIT_MASK(DT_INST_PROP(n, ngpios)),		\
 		.config_func = port_## n ##_stellaris_config_func,			\
 	};										\
 											\
@@ -280,38 +282,38 @@ static const struct gpio_driver_api gpio_stellaris_driver_api = {
 											\
 	static void port_## n ##_stellaris_config_func(struct device *dev)		\
 	{										\
-		IRQ_CONNECT(DT_INST_## n ##_TI_STELLARIS_GPIO_IRQ_0,			\
-			    DT_INST_## n ##_TI_STELLARIS_GPIO_IRQ_0_PRIORITY,		\
+		IRQ_CONNECT(DT_INST_IRQN(n),			\
+			    DT_INST_IRQ(n, priority),		\
 			    gpio_stellaris_isr,						\
 			    DEVICE_GET(gpio_stellaris_port_## n), 0);			\
 											\
-		irq_enable(DT_INST_## n ##_TI_STELLARIS_GPIO_IRQ_0);			\
+		irq_enable(DT_INST_IRQN(n));			\
 	}
 
-#ifdef DT_INST_0_TI_STELLARIS_GPIO
+#if DT_HAS_DRV_INST(0)
 STELLARIS_GPIO_DEVICE(0)
 #endif
 
-#ifdef DT_INST_1_TI_STELLARIS_GPIO
+#if DT_HAS_DRV_INST(1)
 STELLARIS_GPIO_DEVICE(1)
 #endif
 
-#ifdef DT_INST_2_TI_STELLARIS_GPIO
+#if DT_HAS_DRV_INST(2)
 STELLARIS_GPIO_DEVICE(2)
 #endif
 
-#ifdef DT_INST_3_TI_STELLARIS_GPIO
+#if DT_HAS_DRV_INST(3)
 STELLARIS_GPIO_DEVICE(3)
 #endif
 
-#ifdef DT_INST_4_TI_STELLARIS_GPIO
+#if DT_HAS_DRV_INST(4)
 STELLARIS_GPIO_DEVICE(4)
 #endif
 
-#ifdef DT_INST_5_TI_STELLARIS_GPIO
+#if DT_HAS_DRV_INST(5)
 STELLARIS_GPIO_DEVICE(5)
 #endif
 
-#ifdef DT_INST_6_TI_STELLARIS_GPIO
+#if DT_HAS_DRV_INST(6)
 STELLARIS_GPIO_DEVICE(6)
 #endif

--- a/drivers/serial/uart_stellaris.c
+++ b/drivers/serial/uart_stellaris.c
@@ -1,5 +1,7 @@
 /* stellarisUartDrv.c - Stellaris UART driver */
 
+#define DT_DRV_COMPAT ti_stellaris_uart
+
 /*
  * Copyright (c) 2013-2015 Wind River Systems, Inc.
  *
@@ -633,8 +635,8 @@ static void irq_config_func_0(struct device *port);
 #endif
 
 static const struct uart_device_config uart_stellaris_dev_cfg_0 = {
-	.base = (u8_t *)DT_INST_0_TI_STELLARIS_UART_BASE_ADDRESS,
-	.sys_clk_freq = DT_INST_0_TI_STELLARIS_UART_CLOCKS_CLOCK_FREQUENCY,
+	.base = (u8_t *)DT_INST_REG_ADDR(0),
+	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(0, clocks, clock_frequency),
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = irq_config_func_0,
@@ -642,10 +644,10 @@ static const struct uart_device_config uart_stellaris_dev_cfg_0 = {
 };
 
 static struct uart_stellaris_dev_data_t uart_stellaris_dev_data_0 = {
-	.baud_rate = DT_INST_0_TI_STELLARIS_UART_CURRENT_SPEED,
+	.baud_rate = DT_INST_PROP(0, current_speed),
 };
 
-DEVICE_AND_API_INIT(uart_stellaris0, DT_INST_0_TI_STELLARIS_UART_LABEL,
+DEVICE_AND_API_INIT(uart_stellaris0, DT_INST_LABEL(0),
 		    &uart_stellaris_init,
 		    &uart_stellaris_dev_data_0, &uart_stellaris_dev_cfg_0,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -654,11 +656,11 @@ DEVICE_AND_API_INIT(uart_stellaris0, DT_INST_0_TI_STELLARIS_UART_LABEL,
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void irq_config_func_0(struct device *dev)
 {
-	IRQ_CONNECT(DT_INST_0_TI_STELLARIS_UART_IRQ_0,
-		    DT_INST_0_TI_STELLARIS_UART_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		    DT_INST_IRQ(0, priority),
 		    uart_stellaris_isr, DEVICE_GET(uart_stellaris0),
 		    0);
-	irq_enable(DT_INST_0_TI_STELLARIS_UART_IRQ_0);
+	irq_enable(DT_INST_IRQN(0));
 }
 #endif
 
@@ -671,8 +673,8 @@ static void irq_config_func_1(struct device *port);
 #endif
 
 static struct uart_device_config uart_stellaris_dev_cfg_1 = {
-	.base = (u8_t *)DT_INST_1_TI_STELLARIS_UART_BASE_ADDRESS,
-	.sys_clk_freq = DT_INST_1_TI_STELLARIS_UART_CLOCKS_CLOCK_FREQUENCY,
+	.base = (u8_t *)DT_INST_REG_ADDR(1),
+	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(1, clocks, clock_frequency),
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = irq_config_func_1,
@@ -680,10 +682,10 @@ static struct uart_device_config uart_stellaris_dev_cfg_1 = {
 };
 
 static struct uart_stellaris_dev_data_t uart_stellaris_dev_data_1 = {
-	.baud_rate = DT_INST_1_TI_STELLARIS_UART_CURRENT_SPEED,
+	.baud_rate = DT_INST_PROP(1, current_speed),
 };
 
-DEVICE_AND_API_INIT(uart_stellaris1, DT_INST_1_TI_STELLARIS_UART_LABEL,
+DEVICE_AND_API_INIT(uart_stellaris1, DT_INST_LABEL(1),
 		    &uart_stellaris_init,
 		    &uart_stellaris_dev_data_1, &uart_stellaris_dev_cfg_1,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -692,11 +694,11 @@ DEVICE_AND_API_INIT(uart_stellaris1, DT_INST_1_TI_STELLARIS_UART_LABEL,
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void irq_config_func_1(struct device *dev)
 {
-	IRQ_CONNECT(DT_INST_1_TI_STELLARIS_UART_IRQ_0,
-		    DT_INST_1_TI_STELLARIS_UART_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(1),
+		    DT_INST_IRQ(1, priority),
 		    uart_stellaris_isr, DEVICE_GET(uart_stellaris1),
 		    0);
-	irq_enable(DT_INST_1_TI_STELLARIS_UART_IRQ_0);
+	irq_enable(DT_INST_IRQN(1));
 }
 #endif
 
@@ -709,8 +711,8 @@ static void irq_config_func_2(struct device *port);
 #endif
 
 static const struct uart_device_config uart_stellaris_dev_cfg_2 = {
-	.base = (u8_t *)DT_INST_2_TI_STELLARIS_UART_BASE_ADDRESS,
-	.sys_clk_freq = DT_INST_2_TI_STELLARIS_UART_CLOCKS_CLOCK_FREQUENCY,
+	.base = (u8_t *)DT_INST_REG_ADDR(2),
+	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(2, clocks, clock_frequency),
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = irq_config_func_2,
@@ -718,10 +720,10 @@ static const struct uart_device_config uart_stellaris_dev_cfg_2 = {
 };
 
 static struct uart_stellaris_dev_data_t uart_stellaris_dev_data_2 = {
-	.baud_rate = DT_INST_2_TI_STELLARIS_UART_CURRENT_SPEED,
+	.baud_rate = DT_INST_PROP(2, current_speed),
 };
 
-DEVICE_AND_API_INIT(uart_stellaris2, DT_INST_2_TI_STELLARIS_UART_LABEL,
+DEVICE_AND_API_INIT(uart_stellaris2, DT_INST_LABEL(2),
 		    &uart_stellaris_init,
 		    &uart_stellaris_dev_data_2, &uart_stellaris_dev_cfg_2,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -730,11 +732,11 @@ DEVICE_AND_API_INIT(uart_stellaris2, DT_INST_2_TI_STELLARIS_UART_LABEL,
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void irq_config_func_2(struct device *dev)
 {
-	IRQ_CONNECT(DT_INST_2_TI_STELLARIS_UART_IRQ_0,
-		    DT_INST_2_TI_STELLARIS_UART_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(2),
+		    DT_INST_IRQ(2, priority),
 		    uart_stellaris_isr, DEVICE_GET(uart_stellaris2),
 		    0);
-	irq_enable(DT_INST_2_TI_STELLARIS_UART_IRQ_0);
+	irq_enable(DT_INST_IRQN(2));
 }
 #endif
 


### PR DESCRIPTION
Convert older DT_INST_ macro use in stellaris drivers to the new
include/devicetree.h DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>