### PR TITLE
drivers: sifive: Convert sifive drivers to new DT_INST macros

### DIFF
--- a/drivers/gpio/gpio_sifive.c
+++ b/drivers/gpio/gpio_sifive.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT sifive_gpio0
+
 /**
  * @file GPIO driver for the SiFive Freedom Processor
  */
@@ -401,16 +403,16 @@ static void gpio_sifive_cfg_0(void);
 
 static const struct gpio_sifive_config gpio_sifive_config0 = {
 	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_0_SIFIVE_GPIO0_NGPIOS),
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(0, ngpios)),
 	},
-	.gpio_base_addr = DT_INST_0_SIFIVE_GPIO0_BASE_ADDRESS,
-	.gpio_irq_base  = DT_INST_0_SIFIVE_GPIO0_IRQ_0,
+	.gpio_base_addr = DT_INST_REG_ADDR(0),
+	.gpio_irq_base  = DT_INST_IRQN(0),
 	.gpio_cfg_func  = gpio_sifive_cfg_0,
 };
 
 static struct gpio_sifive_data gpio_sifive_data0;
 
-DEVICE_AND_API_INIT(gpio_sifive_0, DT_INST_0_SIFIVE_GPIO0_LABEL,
+DEVICE_AND_API_INIT(gpio_sifive_0, DT_INST_LABEL(0),
 		    gpio_sifive_init,
 		    &gpio_sifive_data0, &gpio_sifive_config0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -425,100 +427,100 @@ IRQ_CONNECT(DT_INST_0_SIFIVE_GPIO0_IRQ_##n,	\
 
 static void gpio_sifive_cfg_0(void)
 {
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_0
+#if DT_INST_IRQ_HAS_CELL(0, irq)
 	IRQ_INIT(0);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_1
+#if DT_INST_IRQ_HAS_IDX(0, 1)
 	IRQ_INIT(1);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_2
+#if DT_INST_IRQ_HAS_IDX(0, 2)
 	IRQ_INIT(2);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_3
+#if DT_INST_IRQ_HAS_IDX(0, 3)
 	IRQ_INIT(3);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_4
+#if DT_INST_IRQ_HAS_IDX(0, 4)
 	IRQ_INIT(4);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_5
+#if DT_INST_IRQ_HAS_IDX(0, 5)
 	IRQ_INIT(5);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_6
+#if DT_INST_IRQ_HAS_IDX(0, 6)
 	IRQ_INIT(6);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_7
+#if DT_INST_IRQ_HAS_IDX(0, 7)
 	IRQ_INIT(7);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_8
+#if DT_INST_IRQ_HAS_IDX(0, 8)
 	IRQ_INIT(8);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_9
+#if DT_INST_IRQ_HAS_IDX(0, 9)
 	IRQ_INIT(9);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_10
+#if DT_INST_IRQ_HAS_IDX(0, 10)
 	IRQ_INIT(10);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_11
+#if DT_INST_IRQ_HAS_IDX(0, 11)
 	IRQ_INIT(11);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_12
+#if DT_INST_IRQ_HAS_IDX(0, 12)
 	IRQ_INIT(12);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_13
+#if DT_INST_IRQ_HAS_IDX(0, 13)
 	IRQ_INIT(13);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_14
+#if DT_INST_IRQ_HAS_IDX(0, 14)
 	IRQ_INIT(14);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_15
+#if DT_INST_IRQ_HAS_IDX(0, 15)
 	IRQ_INIT(15);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_16
+#if DT_INST_IRQ_HAS_IDX(0, 16)
 	IRQ_INIT(16);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_17
+#if DT_INST_IRQ_HAS_IDX(0, 17)
 	IRQ_INIT(17);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_18
+#if DT_INST_IRQ_HAS_IDX(0, 18)
 	IRQ_INIT(18);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_19
+#if DT_INST_IRQ_HAS_IDX(0, 19)
 	IRQ_INIT(19);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_20
+#if DT_INST_IRQ_HAS_IDX(0, 20)
 	IRQ_INIT(20);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_21
+#if DT_INST_IRQ_HAS_IDX(0, 21)
 	IRQ_INIT(21);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_22
+#if DT_INST_IRQ_HAS_IDX(0, 22)
 	IRQ_INIT(22);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_23
+#if DT_INST_IRQ_HAS_IDX(0, 23)
 	IRQ_INIT(23);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_24
+#if DT_INST_IRQ_HAS_IDX(0, 24)
 	IRQ_INIT(24);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_25
+#if DT_INST_IRQ_HAS_IDX(0, 25)
 	IRQ_INIT(25);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_26
+#if DT_INST_IRQ_HAS_IDX(0, 26)
 	IRQ_INIT(26);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_27
+#if DT_INST_IRQ_HAS_IDX(0, 27)
 	IRQ_INIT(27);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_28
+#if DT_INST_IRQ_HAS_IDX(0, 28)
 	IRQ_INIT(28);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_29
+#if DT_INST_IRQ_HAS_IDX(0, 29)
 	IRQ_INIT(29);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_30
+#if DT_INST_IRQ_HAS_IDX(0, 30)
 	IRQ_INIT(30);
 #endif
-#ifdef DT_INST_0_SIFIVE_GPIO0_IRQ_31
+#if DT_INST_IRQ_HAS_IDX(0, 31)
 	IRQ_INIT(31);
 #endif
 }

--- a/drivers/i2c/i2c_sifive.c
+++ b/drivers/i2c/i2c_sifive.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT sifive_i2c0
+
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>
 LOG_MODULE_REGISTER(i2c_sifive);
@@ -332,12 +334,12 @@ static struct i2c_driver_api i2c_sifive_api = {
 
 #define I2C_SIFIVE_INIT(n) \
 	static struct i2c_sifive_cfg i2c_sifive_cfg_##n = { \
-		.base = DT_INST_##n##_SIFIVE_I2C0_BASE_ADDRESS, \
-		.f_sys = DT_INST_##n##_SIFIVE_I2C0_INPUT_FREQUENCY, \
-		.f_bus = DT_INST_##n##_SIFIVE_I2C0_CLOCK_FREQUENCY, \
+		.base = DT_INST_REG_ADDR(n), \
+		.f_sys = DT_INST_PROP(n, input_frequency), \
+		.f_bus = DT_INST_PROP(n, clock_frequency), \
 	}; \
 	DEVICE_AND_API_INIT(i2c_##n, \
-			    DT_INST_##n##_SIFIVE_I2C0_LABEL, \
+			    DT_INST_LABEL(n), \
 			    i2c_sifive_init, \
 			    NULL, \
 			    &i2c_sifive_cfg_##n, \
@@ -345,6 +347,6 @@ static struct i2c_driver_api i2c_sifive_api = {
 			    CONFIG_I2C_INIT_PRIORITY, \
 			    &i2c_sifive_api)
 
-#ifdef DT_INST_0_SIFIVE_I2C0
+#if DT_HAS_DRV_INST(0)
 I2C_SIFIVE_INIT(0);
 #endif

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT sifive_plic_1_0_0
+
 /**
  * @brief Platform Level Interrupt Controller (PLIC) driver
  *        for RISC-V processors
@@ -17,10 +19,10 @@
 
 #include <sw_isr_table.h>
 
-#define PLIC_MAX_PRIO	DT_INST_0_SIFIVE_PLIC_1_0_0_RISCV_MAX_PRIORITY
-#define PLIC_PRIO	DT_INST_0_SIFIVE_PLIC_1_0_0_PRIO_BASE_ADDRESS
-#define PLIC_IRQ_EN	DT_INST_0_SIFIVE_PLIC_1_0_0_IRQ_EN_BASE_ADDRESS
-#define PLIC_REG	DT_INST_0_SIFIVE_PLIC_1_0_0_REG_BASE_ADDRESS
+#define PLIC_MAX_PRIO	DT_INST_PROP(0, riscv_max_priority)
+#define PLIC_PRIO	DT_INST_REG_ADDR_BY_NAME(0, prio)
+#define PLIC_IRQ_EN	DT_INST_REG_ADDR_BY_NAME(0, irq_en)
+#define PLIC_REG	DT_INST_REG_ADDR_BY_NAME(0, reg)
 
 #define PLIC_IRQS        (CONFIG_NUM_IRQS - CONFIG_2ND_LVL_ISR_TBL_OFFSET)
 #define PLIC_EN_SIZE     ((PLIC_IRQS >> 5) + 1)

--- a/drivers/pwm/pwm_sifive.c
+++ b/drivers/pwm/pwm_sifive.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT sifive_pwm0
+
 #include <logging/log.h>
 
 LOG_MODULE_REGISTER(pwm_sifive, CONFIG_PWM_LOG_LEVEL);
@@ -231,12 +233,12 @@ static const struct pwm_driver_api pwm_sifive_api = {
 #define PWM_SIFIVE_INIT(n)	\
 	static struct pwm_sifive_data pwm_sifive_data_##n;	\
 	static const struct pwm_sifive_cfg pwm_sifive_cfg_##n = {	\
-			.base = DT_INST_##n##_SIFIVE_PWM0_BASE_ADDRESS,	\
-			.f_sys = DT_INST_##n##_SIFIVE_PWM0_CLOCK_FREQUENCY,  \
-			.cmpwidth = DT_INST_##n##_SIFIVE_PWM0_SIFIVE_COMPARE_WIDTH, \
+			.base = DT_INST_REG_ADDR(n),	\
+			.f_sys = DT_INST_PROP(n, clock_frequency),  \
+			.cmpwidth = DT_INST_PROP(n, sifive_compare_width), \
 		};	\
 	DEVICE_AND_API_INIT(pwm_##n,	\
-			    DT_INST_##n##_SIFIVE_PWM0_LABEL,	\
+			    DT_INST_LABEL(n),	\
 			    pwm_sifive_init,	\
 			    &pwm_sifive_data_##n,	\
 			    &pwm_sifive_cfg_##n,	\
@@ -244,14 +246,14 @@ static const struct pwm_driver_api pwm_sifive_api = {
 			    CONFIG_PWM_SIFIVE_INIT_PRIORITY,	\
 			    &pwm_sifive_api)
 
-#ifdef DT_INST_0_SIFIVE_PWM0_LABEL
+#if DT_INST_NODE_HAS_PROP(0, label)
 PWM_SIFIVE_INIT(0);
-#endif /* DT_INST_0_SIFIVE_PWM0_LABEL */
+#endif /* DT_INST_NODE_HAS_PROP(0, label) */
 
-#ifdef DT_INST_1_SIFIVE_PWM0_LABEL
+#if DT_INST_NODE_HAS_PROP(1, label)
 PWM_SIFIVE_INIT(1);
-#endif /* DT_INST_1_SIFIVE_PWM0_LABEL */
+#endif /* DT_INST_NODE_HAS_PROP(1, label) */
 
-#ifdef DT_INST_2_SIFIVE_PWM0_LABEL
+#if DT_INST_NODE_HAS_PROP(2, label)
 PWM_SIFIVE_INIT(2);
-#endif /* DT_INST_2_SIFIVE_PWM0_LABEL */
+#endif /* DT_INST_NODE_HAS_PROP(2, label) */

--- a/drivers/spi/spi_sifive.c
+++ b/drivers/spi/spi_sifive.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT sifive_spi0
+
 #define LOG_LEVEL CONFIG_SPI_LOG_LEVEL
 #include <logging/log.h>
 LOG_MODULE_REGISTER(spi_sifive);
@@ -241,11 +243,11 @@ static struct spi_driver_api spi_sifive_api = {
 		SPI_CONTEXT_INIT_SYNC(spi_sifive_data_##n, ctx), \
 	}; \
 	static struct spi_sifive_cfg spi_sifive_cfg_##n = { \
-		.base = DT_INST_##n##_SIFIVE_SPI0_CONTROL_BASE_ADDRESS, \
-		.f_sys = DT_INST_##n##_SIFIVE_SPI0_CLOCK_FREQUENCY, \
+		.base = DT_INST_REG_ADDR_BY_NAME(n, control), \
+		.f_sys = DT_INST_PROP(n, clock_frequency), \
 	}; \
 	DEVICE_AND_API_INIT(spi_##n, \
-			DT_INST_##n##_SIFIVE_SPI0_LABEL, \
+			DT_INST_LABEL(n), \
 			spi_sifive_init, \
 			&spi_sifive_data_##n, \
 			&spi_sifive_cfg_##n, \
@@ -254,21 +256,21 @@ static struct spi_driver_api spi_sifive_api = {
 			&spi_sifive_api)
 
 #ifndef CONFIG_SIFIVE_SPI_0_ROM
-#ifdef DT_INST_0_SIFIVE_SPI0_LABEL
+#if DT_INST_NODE_HAS_PROP(0, label)
 
 SPI_INIT(0);
 
-#endif /* DT_INST_0_SIFIVE_SPI0_LABEL */
+#endif /* DT_INST_NODE_HAS_PROP(0, label) */
 #endif /* !CONFIG_SIFIVE_SPI_0_ROM */
 
-#ifdef DT_INST_1_SIFIVE_SPI0_LABEL
+#if DT_INST_NODE_HAS_PROP(1, label)
 
 SPI_INIT(1);
 
-#endif /* DT_INST_1_SIFIVE_SPI0_LABEL */
+#endif /* DT_INST_NODE_HAS_PROP(1, label) */
 
-#ifdef DT_INST_2_SIFIVE_SPI0_LABEL
+#if DT_INST_NODE_HAS_PROP(2, label)
 
 SPI_INIT(2);
 
-#endif /* DT_INST_2_SIFIVE_SPI0_LABEL */
+#endif /* DT_INST_NODE_HAS_PROP(2, label) */

--- a/soc/riscv/riscv-privilege/sifive-freedom/soc.h
+++ b/soc/riscv/riscv-privilege/sifive-freedom/soc.h
@@ -15,7 +15,7 @@
 #include <devicetree.h>
 
 /* PINMUX Configuration */
-#define SIFIVE_PINMUX_0_BASE_ADDR     (DT_INST_0_SIFIVE_GPIO0_BASE_ADDRESS + 0x38)
+#define SIFIVE_PINMUX_0_BASE_ADDR     (DT_REG_ADDR(DT_INST(0, sifive_gpio0)) + 0x38)
 
 /* PINMUX IO Hardware Functions */
 #define SIFIVE_PINMUX_IOF0            0x00


### PR DESCRIPTION
Convert older DT_INST_ macro use in sifive drivers to the new
include/devicetree.h DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>