### PR TITLE
kernel: fix oops policy for k_thread_abort()

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1472,7 +1472,7 @@ static bool thread_obj_validate(struct k_thread *thread)
 	CODE_UNREACHABLE;
 }
 
-int z_vrfy_k_thread_join(struct k_thread *thread, s32_t timeout)
+static inline int z_vrfy_k_thread_join(struct k_thread *thread, s32_t timeout)
 {
 	if (thread_obj_validate(thread)) {
 		return 0;
@@ -1481,4 +1481,17 @@ int z_vrfy_k_thread_join(struct k_thread *thread, s32_t timeout)
 	return z_impl_k_thread_join(thread, timeout);
 }
 #include <syscalls/k_thread_join_mrsh.c>
+
+static inline void z_vrfy_k_thread_abort(k_tid_t thread)
+{
+	if (thread_obj_validate(thread)) {
+		return;
+	}
+
+	Z_OOPS(Z_SYSCALL_VERIFY_MSG(!(thread->base.user_options & K_ESSENTIAL),
+				    "aborting essential thread %p", thread));
+
+	z_impl_k_thread_abort((struct k_thread *)thread);
+}
+#include <syscalls/k_thread_abort_mrsh.c>
 #endif /* CONFIG_USERSPACE */

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -843,17 +843,6 @@ static inline int z_vrfy_k_float_disable(struct k_thread *thread)
 	return z_impl_k_float_disable(thread);
 }
 #include <syscalls/k_float_disable_mrsh.c>
-
-static inline void z_vrfy_k_thread_abort(k_tid_t thread)
-{
-	Z_OOPS(Z_SYSCALL_OBJ(thread, K_OBJ_THREAD));
-	Z_OOPS(Z_SYSCALL_VERIFY_MSG(!(thread->base.user_options & K_ESSENTIAL),
-				    "aborting essential thread %p", thread));
-
-	z_impl_k_thread_abort((struct k_thread *)thread);
-}
-#include <syscalls/k_thread_abort_mrsh.c>
-
 #endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_IRQ_OFFLOAD


### PR DESCRIPTION
Don't generate a Z_OOPS() if k_thread_abort() is called on a
thread that isn't running. Just return to the caller instead,
much like how k_thread_join() functions.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>