### PR TITLE
drivers: sensor: BME280: add forced sampling mode

### DIFF
--- a/drivers/sensor/bme280/Kconfig
+++ b/drivers/sensor/bme280/Kconfig
@@ -13,6 +13,18 @@ menuconfig BME280
 if BME280
 
 choice
+	prompt "BME280 sampling mode"
+	default BME280_MODE_NORMAL
+	help
+	  Select sampling mode. In normal mode continuous measurements are
+	  performed, whereas in forced mode only single measurement is performed.
+config BME280_MODE_NORMAL
+	bool "normal"
+config BME280_MODE_FORCED
+	bool "forced"
+endchoice
+
+choice
 	prompt "BME280 temperature oversampling"
 	default BME280_TEMP_OVER_2X
 	help

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -169,6 +169,21 @@ static int bme280_sample_fetch(struct device *dev, enum sensor_channel chan)
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 
+#ifdef CONFIG_BME280_MODE_FORCED
+	ret = bm280_reg_write(data, BME280_REG_CTRL_MEAS, BME280_CTRL_MEAS_VAL);
+	if (ret < 0) {
+		return ret;
+	}
+
+	do {
+		k_sleep(K_MSEC(3));
+		ret = bm280_reg_read(data, BME280_REG_STATUS, buf, 1);
+		if (ret < 0) {
+			return ret;
+		}
+	} while (buf[0] & 0x08);
+#endif
+
 	if (data->chip_id == BME280_CHIP_ID) {
 		size = 8;
 	}

--- a/drivers/sensor/bme280/bme280.h
+++ b/drivers/sensor/bme280/bme280.h
@@ -19,13 +19,21 @@
 #define BME280_REG_CONFIG               0xF5
 #define BME280_REG_CTRL_MEAS            0xF4
 #define BME280_REG_CTRL_HUM             0xF2
+#define BME280_REG_STATUS               0xF3
 
 #define BMP280_CHIP_ID_SAMPLE_1         0x56
 #define BMP280_CHIP_ID_SAMPLE_2         0x57
 #define BMP280_CHIP_ID_MP               0x58
 #define BME280_CHIP_ID                  0x60
+#define BME280_MODE_FORCED              0x01
 #define BME280_MODE_NORMAL              0x03
 #define BME280_SPI_3W_DISABLE           0x00
+
+#if defined CONFIG_BME280_MODE_NORMAL
+#define BME280_MODE BME280_MODE_NORMAL
+#elif defined CONFIG_BME280_MODE_FORCED
+#define BME280_MODE BME280_MODE_FORCED
+#endif
 
 #if defined CONFIG_BME280_TEMP_OVER_1X
 #define BME280_TEMP_OVER                (1 << 5)
@@ -95,7 +103,7 @@
 
 #define BME280_CTRL_MEAS_VAL            (BME280_PRESS_OVER | \
 					 BME280_TEMP_OVER |  \
-					 BME280_MODE_NORMAL)
+					 BME280_MODE)
 #define BME280_CONFIG_VAL               (BME280_STANDBY | \
 					 BME280_FILTER |  \
 					 BME280_SPI_3W_DISABLE)


### PR DESCRIPTION
add the forced sampling mode, to take just a single
measurement when fatching a sample

Signed-off-by: Christian Hirsch <christian.hirsch@tuwien.ac.at>