### PR TITLE
net: ieee802154: Extend TX API with TX mode

### DIFF
--- a/drivers/ieee802154/ieee802154_cc1200.c
+++ b/drivers/ieee802154/ieee802154_cc1200.c
@@ -592,6 +592,7 @@ static int cc1200_set_txpower(struct device *dev, s16_t dbm)
 }
 
 static int cc1200_tx(struct device *dev,
+		     enum ieee802154_tx_mode mode,
 		     struct net_pkt *pkt,
 		     struct net_buf *frag)
 {
@@ -599,6 +600,11 @@ static int cc1200_tx(struct device *dev,
 	u8_t *frame = frag->data;
 	u8_t len = frag->len;
 	bool status = false;
+
+	if (mode != IEEE802154_TX_MODE_DIRECT) {
+		NET_ERR("TX mode %d not supported", mode);
+		return -ENOTSUP;
+	}
 
 	LOG_DBG("%p (%u)", frag, len);
 

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
@@ -188,13 +188,20 @@ static int ieee802154_cc13xx_cc26xx_set_txpower(struct device *dev, s16_t dbm)
 }
 
 /* See IEEE 802.15.4 section 6.2.5.1 and TRM section 25.5.4.3 */
-static int ieee802154_cc13xx_cc26xx_tx(struct device *dev, struct net_pkt *pkt,
+static int ieee802154_cc13xx_cc26xx_tx(struct device *dev,
+				       enum ieee802154_tx_mode mode,
+				       struct net_pkt *pkt,
 				       struct net_buf *frag)
 {
 	struct ieee802154_cc13xx_cc26xx_data *drv_data = get_dev_data(dev);
 	bool ack = ieee802154_is_ar_flag_set(frag);
 	int retry = CONFIG_NET_L2_IEEE802154_RADIO_TX_RETRIES;
 	u32_t status;
+
+	if (mode != IEEE802154_TX_MODE_CSMA_CA) {
+		NET_ERR("TX mode %d not supported", mode);
+		return -ENOTSUP;
+	}
 
 	drv_data->cmd_ieee_csma.status = IDLE;
 	drv_data->cmd_ieee_csma.randomState = sys_rand32_get();

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -793,6 +793,7 @@ error:
 }
 
 static int cc2520_tx(struct device *dev,
+		     enum ieee802154_tx_mode mode,
 		     struct net_pkt *pkt,
 		     struct net_buf *frag)
 {
@@ -801,6 +802,11 @@ static int cc2520_tx(struct device *dev,
 	struct cc2520_context *cc2520 = dev->driver_data;
 	u8_t retry = 2U;
 	bool status;
+
+	if (mode != IEEE802154_TX_MODE_DIRECT) {
+		NET_ERR("TX mode %d not supported", mode);
+		return -ENOTSUP;
+	}
 
 	LOG_DBG("%p (%u)", frag, len);
 

--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -612,14 +612,19 @@ out:
 	net_pkt_unref(ack_pkt);
 }
 
-static int kw41z_tx(struct device *dev, struct net_pkt *pkt,
-		    struct net_buf *frag)
+static int kw41z_tx(struct device *dev, enum ieee802154_tx_mode mode,
+		    struct net_pkt *pkt, struct net_buf *frag)
 {
 	struct kw41z_context *kw41z = dev->driver_data;
 	u8_t payload_len = frag->len;
 	u32_t tx_timeout;
 	u8_t xcvseq;
 	int key;
+
+	if (mode != IEEE802154_TX_MODE_DIRECT) {
+		NET_ERR("TX mode %d not supported", mode);
+		return -ENOTSUP;
+	}
 
 	/*
 	 * The transmit requests are preceded by the CCA request. On

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -1082,6 +1082,7 @@ static inline bool write_txfifo_content(struct mcr20a_context *dev,
 }
 
 static int mcr20a_tx(struct device *dev,
+		     enum ieee802154_tx_mode mode,
 		     struct net_pkt *pkt,
 		     struct net_buf *frag)
 {
@@ -1089,6 +1090,11 @@ static int mcr20a_tx(struct device *dev,
 	u8_t seq = ieee802154_is_ar_flag_set(frag) ? MCR20A_XCVSEQ_TX_RX :
 						     MCR20A_XCVSEQ_TX;
 	int retval;
+
+	if (mode != IEEE802154_TX_MODE_DIRECT) {
+		NET_ERR("TX mode %d not supported", mode);
+		return -ENOTSUP;
+	}
 
 	k_mutex_lock(&mcr20a->phy_mutex, K_FOREVER);
 

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -48,7 +48,12 @@ struct nrf5_802154_config {
 
 static struct nrf5_802154_data nrf5_data;
 
-#define ACK_TIMEOUT K_MSEC(10)
+/* Increase ACK timeout to cover the maximum CSMA CA time in default
+ * configuration. 40ms is enough time to cover worst-case CSMA/CA scenario in
+ * default configuration (CSMA/CA + transmit + ACK delay).
+ * TODO Switch to ACK timeout at driver level.
+ */
+#define ACK_TIMEOUT K_MSEC(40)
 
 /* Convenience defines for RADIO */
 #define NRF5_802154_DATA(dev) \
@@ -143,11 +148,10 @@ drop:
 
 static enum ieee802154_hw_caps nrf5_get_capabilities(struct device *dev)
 {
-	return IEEE802154_HW_FCS | IEEE802154_HW_2_4_GHZ |
-	       IEEE802154_HW_TX_RX_ACK | IEEE802154_HW_FILTER |
-	       IEEE802154_HW_ENERGY_SCAN;
+	return IEEE802154_HW_FCS | IEEE802154_HW_FILTER |
+	       IEEE802154_HW_CSMA | IEEE802154_HW_2_4_GHZ |
+	       IEEE802154_HW_TX_RX_ACK | IEEE802154_HW_ENERGY_SCAN;
 }
-
 
 static int nrf5_cca(struct device *dev)
 {
@@ -331,11 +335,7 @@ static int nrf5_tx(struct device *dev,
 	struct nrf5_802154_data *nrf5_radio = NRF5_802154_DATA(dev);
 	u8_t payload_len = frag->len;
 	u8_t *payload = frag->data;
-
-	if (mode != IEEE802154_TX_MODE_DIRECT) {
-		NET_ERR("TX mode %d not supported", mode);
-		return -ENOTSUP;
-	}
+	bool ret = true;
 
 	LOG_DBG("%p (%u)", payload, payload_len);
 
@@ -345,7 +345,24 @@ static int nrf5_tx(struct device *dev,
 	/* Reset semaphore in case ACK was received after timeout */
 	k_sem_reset(&nrf5_radio->tx_wait);
 
-	if (!nrf_802154_transmit_raw(nrf5_radio->tx_psdu, false)) {
+	switch (mode) {
+	case IEEE802154_TX_MODE_DIRECT:
+		ret = nrf_802154_transmit_raw(nrf5_radio->tx_psdu, false);
+		break;
+	case IEEE802154_TX_MODE_CCA:
+		ret = nrf_802154_transmit_raw(nrf5_radio->tx_psdu, true);
+		break;
+	case IEEE802154_TX_MODE_CSMA_CA:
+		nrf_802154_transmit_csma_ca_raw(nrf5_radio->tx_psdu);
+		break;
+	case IEEE802154_TX_MODE_TXTIME:
+	case IEEE802154_TX_MODE_TXTIME_CCA:
+	default:
+		NET_ERR("TX mode %d not supported", mode);
+		return -ENOTSUP;
+	}
+
+	if (!ret) {
 		LOG_ERR("Cannot send frame");
 		return -EIO;
 	}

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -324,12 +324,18 @@ free_nrf_ack:
 }
 
 static int nrf5_tx(struct device *dev,
+		   enum ieee802154_tx_mode mode,
 		   struct net_pkt *pkt,
 		   struct net_buf *frag)
 {
 	struct nrf5_802154_data *nrf5_radio = NRF5_802154_DATA(dev);
 	u8_t payload_len = frag->len;
 	u8_t *payload = frag->data;
+
+	if (mode != IEEE802154_TX_MODE_DIRECT) {
+		NET_ERR("TX mode %d not supported", mode);
+		return -ENOTSUP;
+	}
 
 	LOG_DBG("%p (%u)", payload, payload_len);
 

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -473,6 +473,7 @@ static void rf2xx_handle_ack(struct rf2xx_context *ctx, struct net_buf *frag)
 #endif
 
 static int rf2xx_tx(struct device *dev,
+		    enum ieee802154_tx_mode mode,
 		    struct net_pkt *pkt,
 		    struct net_buf *frag)
 {
@@ -480,6 +481,11 @@ static int rf2xx_tx(struct device *dev,
 
 	struct rf2xx_context *ctx = dev->driver_data;
 	int response = 0;
+
+	if (mode != IEEE802154_TX_MODE_CSMA_CA) {
+		NET_ERR("TX mode %d not supported", mode);
+		return -ENOTSUP;
+	}
 
 	rf2xx_trx_set_tx_state(dev);
 	rf2xx_iface_reg_read(dev, RF2XX_IRQ_STATUS_REG);

--- a/drivers/ieee802154/ieee802154_uart_pipe.c
+++ b/drivers/ieee802154/ieee802154_uart_pipe.c
@@ -266,6 +266,7 @@ static int upipe_set_txpower(struct device *dev, s16_t dbm)
 }
 
 static int upipe_tx(struct device *dev,
+		    enum ieee802154_tx_mode mode,
 		    struct net_pkt *pkt,
 		    struct net_buf *frag)
 {
@@ -273,6 +274,11 @@ static int upipe_tx(struct device *dev,
 	u8_t *pkt_buf = frag->data;
 	u8_t len = frag->len;
 	u8_t i, data;
+
+	if (mode != IEEE802154_TX_MODE_DIRECT) {
+		NET_ERR("TX mode %d not supported", mode);
+		return -ENOTSUP;
+	}
 
 	LOG_DBG("%p (%u)", frag, len);
 

--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -36,7 +36,8 @@ enum ieee802154_hw_caps {
 	IEEE802154_HW_2_4_GHZ	  = BIT(4), /* 2.4Ghz radio supported */
 	IEEE802154_HW_TX_RX_ACK	  = BIT(5), /* Handles ACK request on TX */
 	IEEE802154_HW_SUB_GHZ	  = BIT(6), /* Sub-GHz radio supported */
-	IEEE802154_HW_ENERGY_SCAN = BIT(7)  /* Energy scan supported */
+	IEEE802154_HW_ENERGY_SCAN = BIT(7), /* Energy scan supported */
+	IEEE802154_HW_TXTIME	  = BIT(8), /* TX at specified time supported */
 };
 
 enum ieee802154_filter_type {
@@ -55,6 +56,24 @@ struct ieee802154_filter {
 		u16_t pan_id;
 	};
 /* @endcond */
+};
+
+/** IEEE802.15.4 Transmission mode. */
+enum ieee802154_tx_mode {
+	/** Transmit packet immediately, no CCA. */
+	IEEE802154_TX_MODE_DIRECT,
+
+	/** Perform CCA before packet transmission. */
+	IEEE802154_TX_MODE_CCA,
+
+	/** Perform full CSMA CA procedure before packet transmission. */
+	IEEE802154_TX_MODE_CSMA_CA,
+
+	/** Transmit packet in the future, at specified time, no CCA. */
+	IEEE802154_TX_MODE_TXTIME,
+
+	/** Transmit packet in the future, perform CCA before transmission. */
+	IEEE802154_TX_MODE_TXTIME_CCA,
 };
 
 /** IEEE802.15.4 driver configuration types. */
@@ -137,9 +156,8 @@ struct ieee802154_radio_api {
 	int (*set_txpower)(struct device *dev, s16_t dbm);
 
 	/** Transmit a packet fragment */
-	int (*tx)(struct device *dev,
-		  struct net_pkt *pkt,
-		  struct net_buf *frag);
+	int (*tx)(struct device *dev, enum ieee802154_tx_mode mode,
+		  struct net_pkt *pkt, struct net_buf *frag);
 
 	/** Start the device */
 	int (*start)(struct device *dev);

--- a/modules/Kconfig.nordic
+++ b/modules/Kconfig.nordic
@@ -11,6 +11,12 @@ menu "Nordic drivers"
 menuconfig NRF_802154_RADIO_DRIVER
 	bool "Enable nRF IEEE 802.15.4 radio driver"
 	depends on HAS_HW_NRF_RADIO_IEEE802154
+	help
+	  This option enables nRF IEEE 802.15.4 radio driver in Zephyr. Note,
+	  that beside the radio peripheral itself, this drivers occupies several
+	  other peripherals. A complete list can be found in the hal_nordic
+	  repository, within drivers/nrf_radio_802154/nrf_802154_peripherals.h
+	  file.
 
 if NRF_802154_RADIO_DRIVER
 

--- a/samples/net/wpan_serial/src/main.c
+++ b/samples/net/wpan_serial/src/main.c
@@ -248,7 +248,8 @@ static void process_data(struct net_pkt *pkt)
 	}
 
 	/* Transmit data through radio */
-	ret = radio_api->tx(ieee802154_dev, pkt, buf);
+	ret = radio_api->tx(ieee802154_dev, IEEE802154_TX_MODE_DIRECT,
+			    pkt, buf);
 	if (ret) {
 		LOG_ERR("Error transmit data");
 	}

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -260,7 +260,8 @@ static int tx(struct net_pkt *pkt)
 	LOG_DBG("len %d seq %u", buf->len, seq);
 
 	do {
-		ret = radio_api->tx(ieee802154_dev, pkt, buf);
+		ret = radio_api->tx(ieee802154_dev, IEEE802154_TX_MODE_DIRECT,
+				    pkt, buf);
 	} while (ret && retries--);
 
 	if (ret) {

--- a/subsys/net/l2/ieee802154/ieee802154.c
+++ b/subsys/net/l2/ieee802154/ieee802154.c
@@ -81,7 +81,8 @@ static inline void ieee802154_acknowledge(struct net_if *iface,
 	}
 
 	if (ieee802154_create_ack_frame(iface, pkt, mpdu->mhr.fs->sequence)) {
-		ieee802154_tx(iface, pkt, pkt->buffer);
+		ieee802154_tx(iface, IEEE802154_TX_MODE_DIRECT,
+			      pkt, pkt->buffer);
 	}
 
 	net_pkt_unref(pkt);
@@ -276,7 +277,8 @@ static int ieee802154_send(struct net_if *iface, struct net_pkt *pkt)
 		if (IS_ENABLED(CONFIG_NET_L2_IEEE802154_RADIO_CSMA_CA) &&
 		    ieee802154_get_hw_capabilities(iface) &
 		    IEEE802154_HW_CSMA) {
-			ret = ieee802154_tx(iface, pkt, &frame_buf);
+			ret = ieee802154_tx(iface, IEEE802154_TX_MODE_CSMA_CA,
+					    pkt, &frame_buf);
 		} else {
 			ret = ieee802154_radio_send(iface, pkt, &frame_buf);
 		}

--- a/subsys/net/l2/ieee802154/ieee802154_radio_aloha.c
+++ b/subsys/net/l2/ieee802154/ieee802154_radio_aloha.c
@@ -30,7 +30,8 @@ static inline int aloha_radio_send(struct net_if *iface,
 	while (retries) {
 		retries--;
 
-		ret = ieee802154_tx(iface, pkt, frag);
+		ret = ieee802154_tx(iface, IEEE802154_TX_MODE_DIRECT,
+				    pkt, frag);
 		if (ret) {
 			continue;
 		}

--- a/subsys/net/l2/ieee802154/ieee802154_radio_aloha.c
+++ b/subsys/net/l2/ieee802154/ieee802154_radio_aloha.c
@@ -50,6 +50,11 @@ static enum net_verdict aloha_radio_handle_ack(struct net_if *iface,
 {
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
 
+	if (IS_ENABLED(CONFIG_NET_L2_IEEE802154_RADIO_CSMA_CA) &&
+	    ieee802154_get_hw_capabilities(iface) & IEEE802154_HW_CSMA) {
+		return NET_OK;
+	}
+
 	return handle_ack(ctx, pkt);
 }
 

--- a/subsys/net/l2/ieee802154/ieee802154_radio_csma_ca.c
+++ b/subsys/net/l2/ieee802154/ieee802154_radio_csma_ca.c
@@ -77,6 +77,11 @@ static enum net_verdict csma_ca_radio_handle_ack(struct net_if *iface,
 {
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
 
+	if (IS_ENABLED(CONFIG_NET_L2_IEEE802154_RADIO_CSMA_CA) &&
+	    ieee802154_get_hw_capabilities(iface) & IEEE802154_HW_CSMA) {
+		return NET_OK;
+	}
+
 	return handle_ack(ctx, pkt);
 }
 

--- a/subsys/net/l2/ieee802154/ieee802154_radio_csma_ca.c
+++ b/subsys/net/l2/ieee802154/ieee802154_radio_csma_ca.c
@@ -57,7 +57,8 @@ loop:
 			}
 		}
 
-		ret = ieee802154_tx(iface, pkt, frag);
+		ret = ieee802154_tx(iface, IEEE802154_TX_MODE_DIRECT,
+				    pkt, frag);
 		if (ret) {
 			continue;
 		}

--- a/subsys/net/l2/ieee802154/ieee802154_utils.h
+++ b/subsys/net/l2/ieee802154/ieee802154_utils.h
@@ -64,7 +64,9 @@ static inline int ieee802154_set_tx_power(struct net_if *iface, s16_t dbm)
 }
 
 static inline int ieee802154_tx(struct net_if *iface,
-				struct net_pkt *pkt, struct net_buf *buf)
+				enum ieee802154_tx_mode mode,
+				struct net_pkt *pkt,
+				struct net_buf *buf)
 {
 	const struct ieee802154_radio_api *radio =
 		net_if_get_device(iface)->driver_api;
@@ -73,7 +75,7 @@ static inline int ieee802154_tx(struct net_if *iface,
 		return -ENOENT;
 	}
 
-	return radio->tx(net_if_get_device(iface), pkt, buf);
+	return radio->tx(net_if_get_device(iface), mode, pkt, buf);
 }
 
 static inline int ieee802154_start(struct net_if *iface)

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -187,9 +187,18 @@ void platformRadioProcess(otInstance *aInstance)
 		radio_api->set_txpower(radio_dev, tx_power);
 
 		if (sTransmitFrame.mInfo.mTxInfo.mCsmaCaEnabled) {
-			if (radio_api->cca(radio_dev) ||
-			    radio_api->tx(radio_dev, IEEE802154_TX_MODE_DIRECT,
-					  tx_pkt, tx_payload)) {
+			if (radio_api->get_capabilities(radio_dev) &
+			    IEEE802154_HW_CSMA) {
+				if (radio_api->tx(radio_dev,
+						  IEEE802154_TX_MODE_CSMA_CA,
+						  tx_pkt, tx_payload) != 0) {
+					result =
+					    OT_ERROR_CHANNEL_ACCESS_FAILURE;
+				}
+			} else if (radio_api->cca(radio_dev) != 0 ||
+				   radio_api->tx(radio_dev,
+						 IEEE802154_TX_MODE_DIRECT,
+						 tx_pkt, tx_payload) != 0) {
 				result = OT_ERROR_CHANNEL_ACCESS_FAILURE;
 			}
 		} else {
@@ -385,6 +394,11 @@ otRadioCaps otPlatRadioGetCaps(otInstance *aInstance)
 
 	if (radio_caps & IEEE802154_HW_ENERGY_SCAN) {
 		caps |= OT_RADIO_CAPS_ENERGY_SCAN;
+	}
+
+	if (radio_caps & IEEE802154_HW_CSMA) {
+		caps |= OT_RADIO_CAPS_CSMA_BACKOFF |
+			OT_RADIO_CAPS_TRANSMIT_RETRIES;
 	}
 
 	return caps;

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -188,11 +188,13 @@ void platformRadioProcess(otInstance *aInstance)
 
 		if (sTransmitFrame.mInfo.mTxInfo.mCsmaCaEnabled) {
 			if (radio_api->cca(radio_dev) ||
-			    radio_api->tx(radio_dev, tx_pkt, tx_payload)) {
+			    radio_api->tx(radio_dev, IEEE802154_TX_MODE_DIRECT,
+					  tx_pkt, tx_payload)) {
 				result = OT_ERROR_CHANNEL_ACCESS_FAILURE;
 			}
 		} else {
-			if (radio_api->tx(radio_dev, tx_pkt, tx_payload)) {
+			if (radio_api->tx(radio_dev, IEEE802154_TX_MODE_DIRECT,
+					  tx_pkt, tx_payload)) {
 				result = OT_ERROR_CHANNEL_ACCESS_FAILURE;
 			}
 		}

--- a/tests/net/ieee802154/l2/src/ieee802154_fake_driver.c
+++ b/tests/net/ieee802154/l2/src/ieee802154_fake_driver.c
@@ -60,6 +60,7 @@ static inline void insert_frag(struct net_pkt *pkt, struct net_buf *frag)
 }
 
 static int fake_tx(struct device *dev,
+		   enum ieee802154_tx_mode mode,
 		   struct net_pkt *pkt,
 		   struct net_buf *frag)
 {

--- a/west.yml
+++ b/west.yml
@@ -53,7 +53,7 @@ manifest:
       revision: a12d92816a53a521d79cefcf5c38b9dc8a4fed6e
       path: modules/hal/cypress
     - name: hal_nordic
-      revision: 59d33bc1dd59df14feb26f0010d527c1ea7a89e8
+      revision: 0774efffa3d095025a55611719020fa23278eeda
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 3b54187649cc9b37161d49918f1ad28ff7c7f830


### PR DESCRIPTION
Introduce TX mode parameter in the `tx` API:
* Existing drivers will use `IEEE802154_TX_MODE_DIRECT` if they did not report CSMA/CA capability or `IEEE802154_TX_MODE_CSMA_CA` if they did.
* Add CSMA/CA support to `ieee802154_nrf5`.
* Use the new feature in OpenThread.