### PR TITLE
drivers: arm_cmsdk/arm: Convert drivers to new DT_INST macros

### DIFF
--- a/drivers/clock_control/beetle_clock_control.c
+++ b/drivers/clock_control/beetle_clock_control.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT arm_cortex_m3
+
 /**
  * @file
  * @brief Driver for Clock Control of Beetle MCUs.
@@ -233,7 +235,7 @@ static int beetle_clock_control_init(struct device *dev)
 
 static const struct beetle_clock_control_cfg_t beetle_cc_cfg = {
 	.clock_control_id = 0,
-	.freq = DT_INST_0_ARM_CORTEX_M3_CLOCK_FREQUENCY,
+	.freq = DT_INST_PROP(0, clock_frequency),
 };
 
 /**

--- a/drivers/counter/timer_dtmr_cmsdk_apb.c
+++ b/drivers/counter/timer_dtmr_cmsdk_apb.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT arm_cmsdk_dtimer
+
 #include <drivers/counter.h>
 #include <device.h>
 #include <errno.h>
@@ -166,7 +168,7 @@ static int dtmr_cmsdk_apb_init(struct device *dev)
 }
 
 /* TIMER 0 */
-#ifdef DT_INST_0_ARM_CMSDK_DTIMER
+#if DT_HAS_DRV_INST(0)
 static void dtimer_cmsdk_apb_config_0(struct device *dev);
 
 static const struct dtmr_cmsdk_apb_cfg dtmr_cmsdk_apb_cfg_0 = {
@@ -176,14 +178,14 @@ static const struct dtmr_cmsdk_apb_cfg dtmr_cmsdk_apb_cfg_0 = {
 			.flags = 0,
 			.channels = 0U,
 	},
-	.dtimer = ((volatile struct dualtimer_cmsdk_apb *)DT_INST_0_ARM_CMSDK_DTIMER_BASE_ADDRESS),
+	.dtimer = ((volatile struct dualtimer_cmsdk_apb *)DT_INST_REG_ADDR(0)),
 	.dtimer_config_func = dtimer_cmsdk_apb_config_0,
 	.dtimer_cc_as = {.bus = CMSDK_APB, .state = SOC_ACTIVE,
-			 .device = DT_INST_0_ARM_CMSDK_DTIMER_BASE_ADDRESS,},
+			 .device = DT_INST_REG_ADDR(0),},
 	.dtimer_cc_ss = {.bus = CMSDK_APB, .state = SOC_SLEEP,
-			 .device = DT_INST_0_ARM_CMSDK_DTIMER_BASE_ADDRESS,},
+			 .device = DT_INST_REG_ADDR(0),},
 	.dtimer_cc_dss = {.bus = CMSDK_APB, .state = SOC_DEEPSLEEP,
-			  .device = DT_INST_0_ARM_CMSDK_DTIMER_BASE_ADDRESS,},
+			  .device = DT_INST_REG_ADDR(0),},
 };
 
 static struct dtmr_cmsdk_apb_dev_data dtmr_cmsdk_apb_dev_data_0 = {
@@ -191,7 +193,7 @@ static struct dtmr_cmsdk_apb_dev_data dtmr_cmsdk_apb_dev_data_0 = {
 };
 
 DEVICE_AND_API_INIT(dtmr_cmsdk_apb_0,
-		    DT_INST_0_ARM_CMSDK_DTIMER_LABEL,
+		    DT_INST_LABEL(0),
 		    dtmr_cmsdk_apb_init,
 		    &dtmr_cmsdk_apb_dev_data_0,
 		    &dtmr_cmsdk_apb_cfg_0, POST_KERNEL,
@@ -200,10 +202,10 @@ DEVICE_AND_API_INIT(dtmr_cmsdk_apb_0,
 
 static void dtimer_cmsdk_apb_config_0(struct device *dev)
 {
-	IRQ_CONNECT(DT_INST_0_ARM_CMSDK_DTIMER_IRQ_0,
-		    DT_INST_0_ARM_CMSDK_DTIMER_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		    DT_INST_IRQ(0, priority),
 		    dtmr_cmsdk_apb_isr,
 		    DEVICE_GET(dtmr_cmsdk_apb_0), 0);
-	irq_enable(DT_INST_0_ARM_CMSDK_DTIMER_IRQ_0);
+	irq_enable(DT_INST_IRQN(0));
 }
-#endif /* DT_INST_0_ARM_CMSDK_DTIMER */
+#endif /* DT_HAS_DRV_INST(0) */

--- a/drivers/counter/timer_tmr_cmsdk_apb.c
+++ b/drivers/counter/timer_tmr_cmsdk_apb.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT arm_cmsdk_timer
+
 #include <drivers/counter.h>
 #include <device.h>
 #include <errno.h>
@@ -161,7 +163,7 @@ static int tmr_cmsdk_apb_init(struct device *dev)
 }
 
 /* TIMER 0 */
-#ifdef DT_INST_0_ARM_CMSDK_TIMER
+#if DT_HAS_DRV_INST(0)
 static void timer_cmsdk_apb_config_0(struct device *dev);
 
 static const struct tmr_cmsdk_apb_cfg tmr_cmsdk_apb_cfg_0 = {
@@ -171,14 +173,14 @@ static const struct tmr_cmsdk_apb_cfg tmr_cmsdk_apb_cfg_0 = {
 			.flags = 0,
 			.channels = 0U,
 	},
-	.timer = ((volatile struct timer_cmsdk_apb *)DT_INST_0_ARM_CMSDK_TIMER_BASE_ADDRESS),
+	.timer = ((volatile struct timer_cmsdk_apb *)DT_INST_REG_ADDR(0)),
 	.timer_config_func = timer_cmsdk_apb_config_0,
 	.timer_cc_as = {.bus = CMSDK_APB, .state = SOC_ACTIVE,
-			.device = DT_INST_0_ARM_CMSDK_TIMER_BASE_ADDRESS,},
+			.device = DT_INST_REG_ADDR(0),},
 	.timer_cc_ss = {.bus = CMSDK_APB, .state = SOC_SLEEP,
-			.device = DT_INST_0_ARM_CMSDK_TIMER_BASE_ADDRESS,},
+			.device = DT_INST_REG_ADDR(0),},
 	.timer_cc_dss = {.bus = CMSDK_APB, .state = SOC_DEEPSLEEP,
-			 .device = DT_INST_0_ARM_CMSDK_TIMER_BASE_ADDRESS,},
+			 .device = DT_INST_REG_ADDR(0),},
 };
 
 static struct tmr_cmsdk_apb_dev_data tmr_cmsdk_apb_dev_data_0 = {
@@ -186,7 +188,7 @@ static struct tmr_cmsdk_apb_dev_data tmr_cmsdk_apb_dev_data_0 = {
 };
 
 DEVICE_AND_API_INIT(tmr_cmsdk_apb_0,
-		    DT_INST_0_ARM_CMSDK_TIMER_LABEL,
+		    DT_INST_LABEL(0),
 		    tmr_cmsdk_apb_init, &tmr_cmsdk_apb_dev_data_0,
 		    &tmr_cmsdk_apb_cfg_0, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -194,15 +196,15 @@ DEVICE_AND_API_INIT(tmr_cmsdk_apb_0,
 
 static void timer_cmsdk_apb_config_0(struct device *dev)
 {
-	IRQ_CONNECT(DT_INST_0_ARM_CMSDK_TIMER_IRQ_0, DT_INST_0_ARM_CMSDK_TIMER_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
 		    tmr_cmsdk_apb_isr,
 		    DEVICE_GET(tmr_cmsdk_apb_0), 0);
-	irq_enable(DT_INST_0_ARM_CMSDK_TIMER_IRQ_0);
+	irq_enable(DT_INST_IRQN(0));
 }
-#endif /* DT_INST_0_ARM_CMSDK_TIMER */
+#endif /* DT_HAS_DRV_INST(0) */
 
 /* TIMER 1 */
-#ifdef DT_INST_1_ARM_CMSDK_TIMER
+#if DT_HAS_DRV_INST(1)
 static void timer_cmsdk_apb_config_1(struct device *dev);
 
 static const struct tmr_cmsdk_apb_cfg tmr_cmsdk_apb_cfg_1 = {
@@ -212,14 +214,14 @@ static const struct tmr_cmsdk_apb_cfg tmr_cmsdk_apb_cfg_1 = {
 			.flags = 0,
 			.channels = 0U,
 	},
-	.timer = ((volatile struct timer_cmsdk_apb *)DT_INST_1_ARM_CMSDK_TIMER_BASE_ADDRESS),
+	.timer = ((volatile struct timer_cmsdk_apb *)DT_INST_REG_ADDR(1)),
 	.timer_config_func = timer_cmsdk_apb_config_1,
 	.timer_cc_as = {.bus = CMSDK_APB, .state = SOC_ACTIVE,
-			.device = DT_INST_1_ARM_CMSDK_TIMER_BASE_ADDRESS,},
+			.device = DT_INST_REG_ADDR(1),},
 	.timer_cc_ss = {.bus = CMSDK_APB, .state = SOC_SLEEP,
-			.device = DT_INST_1_ARM_CMSDK_TIMER_BASE_ADDRESS,},
+			.device = DT_INST_REG_ADDR(1),},
 	.timer_cc_dss = {.bus = CMSDK_APB, .state = SOC_DEEPSLEEP,
-			 .device = DT_INST_1_ARM_CMSDK_TIMER_BASE_ADDRESS,},
+			 .device = DT_INST_REG_ADDR(1),},
 };
 
 static struct tmr_cmsdk_apb_dev_data tmr_cmsdk_apb_dev_data_1 = {
@@ -227,7 +229,7 @@ static struct tmr_cmsdk_apb_dev_data tmr_cmsdk_apb_dev_data_1 = {
 };
 
 DEVICE_AND_API_INIT(tmr_cmsdk_apb_1,
-		    DT_INST_1_ARM_CMSDK_TIMER_LABEL,
+		    DT_INST_LABEL(1),
 		    tmr_cmsdk_apb_init, &tmr_cmsdk_apb_dev_data_1,
 		    &tmr_cmsdk_apb_cfg_1, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -235,9 +237,9 @@ DEVICE_AND_API_INIT(tmr_cmsdk_apb_1,
 
 static void timer_cmsdk_apb_config_1(struct device *dev)
 {
-	IRQ_CONNECT(DT_INST_1_ARM_CMSDK_TIMER_IRQ_0, DT_INST_1_ARM_CMSDK_TIMER_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(1), DT_INST_IRQ(1, priority),
 		    tmr_cmsdk_apb_isr,
 		    DEVICE_GET(tmr_cmsdk_apb_1), 0);
-	irq_enable(DT_INST_1_ARM_CMSDK_TIMER_IRQ_0);
+	irq_enable(DT_INST_IRQN(1));
 }
-#endif /* DT_INST_1_ARM_CMSDK_TIMER */
+#endif /* DT_HAS_DRV_INST(1) */

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT arm_cmsdk_gpio
+
 #include <kernel.h>
 
 #include <device.h>
@@ -273,7 +275,7 @@ static void gpio_cmsdk_ahb_config_0(struct device *dev);
 
 static const struct gpio_cmsdk_ahb_cfg gpio_cmsdk_ahb_0_cfg = {
 	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_0_ARM_CMSDK_GPIO_NGPIOS),
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(0, ngpios)),
 	},
 	.port = ((volatile struct gpio_cmsdk_ahb *)DT_CMSDK_AHB_GPIO0),
 	.gpio_config_func = gpio_cmsdk_ahb_config_0,
@@ -309,7 +311,7 @@ static void gpio_cmsdk_ahb_config_1(struct device *dev);
 
 static const struct gpio_cmsdk_ahb_cfg gpio_cmsdk_ahb_1_cfg = {
 	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_1_ARM_CMSDK_GPIO_NGPIOS),
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(1, ngpios)),
 	},
 	.port = ((volatile struct gpio_cmsdk_ahb *)DT_CMSDK_AHB_GPIO1),
 	.gpio_config_func = gpio_cmsdk_ahb_config_1,
@@ -345,7 +347,7 @@ static void gpio_cmsdk_ahb_config_2(struct device *dev);
 
 static const struct gpio_cmsdk_ahb_cfg gpio_cmsdk_ahb_2_cfg = {
 	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_2_ARM_CMSDK_GPIO_NGPIOS),
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(2, ngpios)),
 	},
 	.port = ((volatile struct gpio_cmsdk_ahb *)DT_CMSDK_AHB_GPIO2),
 	.gpio_config_func = gpio_cmsdk_ahb_config_2,
@@ -381,7 +383,7 @@ static void gpio_cmsdk_ahb_config_3(struct device *dev);
 
 static const struct gpio_cmsdk_ahb_cfg gpio_cmsdk_ahb_3_cfg = {
 	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_3_ARM_CMSDK_GPIO_NGPIOS),
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(3, ngpios)),
 	},
 	.port = ((volatile struct gpio_cmsdk_ahb *)DT_CMSDK_AHB_GPIO3),
 	.gpio_config_func = gpio_cmsdk_ahb_config_3,

--- a/drivers/i2c/i2c_sbcon.c
+++ b/drivers/i2c/i2c_sbcon.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT arm_versatile_i2c
+
 /**
  * @file
  * @brief Driver for ARM's SBCon 2-wire serial bus interface
@@ -111,27 +113,27 @@ static int i2c_sbcon_init(struct device *dev)
 static struct i2c_sbcon_context i2c_sbcon_dev_data_##_num;		\
 									\
 static const struct i2c_sbcon_config i2c_sbcon_dev_cfg_##_num = {	\
-	.sbcon		= (void *)DT_INST_##_num##_ARM_VERSATILE_I2C_BASE_ADDRESS, \
+	.sbcon		= (void *)DT_INST_REG_ADDR(_num), \
 };									\
 									\
-DEVICE_AND_API_INIT(i2c_sbcon_##_num, DT_INST_##_num##_ARM_VERSATILE_I2C_LABEL, \
+DEVICE_AND_API_INIT(i2c_sbcon_##_num, DT_INST_LABEL(_num), \
 	    i2c_sbcon_init,						\
 	    &i2c_sbcon_dev_data_##_num,					\
 	    &i2c_sbcon_dev_cfg_##_num,					\
 	    PRE_KERNEL_2, CONFIG_I2C_INIT_PRIORITY, &api)
 
-#ifdef DT_INST_0_ARM_VERSATILE_I2C
+#if DT_HAS_DRV_INST(0)
 DEFINE_I2C_SBCON(0);
 #endif
 
-#ifdef DT_INST_1_ARM_VERSATILE_I2C
+#if DT_HAS_DRV_INST(1)
 DEFINE_I2C_SBCON(1);
 #endif
 
-#ifdef DT_INST_2_ARM_VERSATILE_I2C
+#if DT_HAS_DRV_INST(2)
 DEFINE_I2C_SBCON(2);
 #endif
 
-#ifdef DT_INST_3_ARM_VERSATILE_I2C
+#if DT_HAS_DRV_INST(3)
 DEFINE_I2C_SBCON(3);
 #endif

--- a/drivers/ipm/ipm_mhu.c
+++ b/drivers/ipm/ipm_mhu.c
@@ -198,7 +198,7 @@ static void ipm_mhu_irq_config_func_0(struct device *d)
 {
 	ARG_UNUSED(d);
 	IRQ_CONNECT(DT_INST_IRQN(0),
-			DT_INST_IRQN(0),
+			DT_INST_IRQ(0, priority),
 			ipm_mhu_isr,
 			DEVICE_GET(mhu_0),
 			0);

--- a/drivers/ipm/ipm_mhu.c
+++ b/drivers/ipm/ipm_mhu.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT arm_mhu
+
 #include <errno.h>
 #include <device.h>
 #include <soc.h>
@@ -175,7 +177,7 @@ static const struct ipm_driver_api ipm_mhu_driver_api = {
 static void ipm_mhu_irq_config_func_0(struct device *d);
 
 static const struct ipm_mhu_device_config ipm_mhu_cfg_0 = {
-	.base = (u8_t *)DT_INST_0_ARM_MHU_BASE_ADDRESS,
+	.base = (u8_t *)DT_INST_REG_ADDR(0),
 	.irq_config_func = ipm_mhu_irq_config_func_0,
 };
 
@@ -185,7 +187,7 @@ static struct ipm_mhu_data ipm_mhu_data_0 = {
 };
 
 DEVICE_AND_API_INIT(mhu_0,
-			DT_INST_0_ARM_MHU_LABEL,
+			DT_INST_LABEL(0),
 			&ipm_mhu_init,
 			&ipm_mhu_data_0,
 			&ipm_mhu_cfg_0, PRE_KERNEL_1,
@@ -195,18 +197,18 @@ DEVICE_AND_API_INIT(mhu_0,
 static void ipm_mhu_irq_config_func_0(struct device *d)
 {
 	ARG_UNUSED(d);
-	IRQ_CONNECT(DT_INST_0_ARM_MHU_IRQ_0,
-			DT_INST_0_ARM_MHU_IRQ_0,
+	IRQ_CONNECT(DT_INST_IRQN(0),
+			DT_INST_IRQN(0),
 			ipm_mhu_isr,
 			DEVICE_GET(mhu_0),
 			0);
-	irq_enable(DT_INST_0_ARM_MHU_IRQ_0);
+	irq_enable(DT_INST_IRQN(0));
 }
 
 static void ipm_mhu_irq_config_func_1(struct device *d);
 
 static const struct ipm_mhu_device_config ipm_mhu_cfg_1 = {
-	.base = (u8_t *)DT_INST_1_ARM_MHU_BASE_ADDRESS,
+	.base = (u8_t *)DT_INST_REG_ADDR(1),
 	.irq_config_func = ipm_mhu_irq_config_func_1,
 };
 
@@ -216,7 +218,7 @@ static struct ipm_mhu_data ipm_mhu_data_1 = {
 };
 
 DEVICE_AND_API_INIT(mhu_1,
-			DT_INST_1_ARM_MHU_LABEL,
+			DT_INST_LABEL(1),
 			&ipm_mhu_init,
 			&ipm_mhu_data_1,
 			&ipm_mhu_cfg_1, PRE_KERNEL_1,
@@ -226,10 +228,10 @@ DEVICE_AND_API_INIT(mhu_1,
 static void ipm_mhu_irq_config_func_1(struct device *d)
 {
 	ARG_UNUSED(d);
-	IRQ_CONNECT(DT_INST_1_ARM_MHU_IRQ_0,
-			DT_INST_1_ARM_MHU_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(1),
+			DT_INST_IRQ(1, priority),
 			ipm_mhu_isr,
 			DEVICE_GET(mhu_1),
 			0);
-	irq_enable(DT_INST_1_ARM_MHU_IRQ_0);
+	irq_enable(DT_INST_IRQN(1));
 }

--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT arm_cmsdk_uart
+
 /**
  * @brief Driver for UART on ARM CMSDK APB UART.
  *
@@ -456,32 +458,32 @@ static const struct uart_driver_api uart_cmsdk_apb_driver_api = {
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 
-#ifdef DT_INST_0_ARM_CMSDK_UART
+#if DT_HAS_DRV_INST(0)
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void uart_cmsdk_apb_irq_config_func_0(struct device *dev);
 #endif
 
 static const struct uart_device_config uart_cmsdk_apb_dev_cfg_0 = {
-	.base = (u8_t *)DT_INST_0_ARM_CMSDK_UART_BASE_ADDRESS,
-	.sys_clk_freq = DT_INST_0_ARM_CMSDK_UART_CLOCKS_CLOCK_FREQUENCY,
+	.base = (u8_t *)DT_INST_REG_ADDR(0),
+	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(0, clocks, clock_frequency),
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = uart_cmsdk_apb_irq_config_func_0,
 #endif
 };
 
 static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_0 = {
-	.baud_rate = DT_INST_0_ARM_CMSDK_UART_CURRENT_SPEED,
+	.baud_rate = DT_INST_PROP(0, current_speed),
 	.uart_cc_as = {.bus = CMSDK_APB, .state = SOC_ACTIVE,
-		       .device = DT_INST_0_ARM_CMSDK_UART_BASE_ADDRESS,},
+		       .device = DT_INST_REG_ADDR(0),},
 	.uart_cc_ss = {.bus = CMSDK_APB, .state = SOC_SLEEP,
-		       .device = DT_INST_0_ARM_CMSDK_UART_BASE_ADDRESS,},
+		       .device = DT_INST_REG_ADDR(0),},
 	.uart_cc_dss = {.bus = CMSDK_APB, .state = SOC_DEEPSLEEP,
-			.device = DT_INST_0_ARM_CMSDK_UART_BASE_ADDRESS,},
+			.device = DT_INST_REG_ADDR(0),},
 };
 
 DEVICE_AND_API_INIT(uart_cmsdk_apb_0,
-		    DT_INST_0_ARM_CMSDK_UART_LABEL,
+		    DT_INST_LABEL(0),
 		    &uart_cmsdk_apb_init,
 		    &uart_cmsdk_apb_dev_data_0,
 		    &uart_cmsdk_apb_dev_cfg_0, PRE_KERNEL_1,
@@ -489,64 +491,64 @@ DEVICE_AND_API_INIT(uart_cmsdk_apb_0,
 		    &uart_cmsdk_apb_driver_api);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-#ifdef DT_INST_0_ARM_CMSDK_UART_IRQ_0
+#if DT_INST_IRQ_HAS_CELL(0, irq)
 static void uart_cmsdk_apb_irq_config_func_0(struct device *dev)
 {
-	IRQ_CONNECT(DT_INST_0_ARM_CMSDK_UART_IRQ_0,
-		    DT_INST_0_ARM_CMSDK_UART_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		    DT_INST_IRQ(0, priority),
 		    uart_cmsdk_apb_isr,
 		    DEVICE_GET(uart_cmsdk_apb_0),
 		    0);
-	irq_enable(DT_INST_0_ARM_CMSDK_UART_IRQ_0);
+	irq_enable(DT_INST_IRQN(0));
 }
 #else
 static void uart_cmsdk_apb_irq_config_func_0(struct device *dev)
 {
-	IRQ_CONNECT(DT_INST_0_ARM_CMSDK_UART_IRQ_TX,
-		    DT_INST_0_ARM_CMSDK_UART_IRQ_TX_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, tx, irq),
+		    DT_INST_IRQ_BY_NAME(0, tx, priority),
 		    uart_cmsdk_apb_isr,
 		    DEVICE_GET(uart_cmsdk_apb_0),
 		    0);
-	irq_enable(DT_INST_0_ARM_CMSDK_UART_IRQ_TX);
+	irq_enable(DT_INST_IRQ_BY_NAME(0, tx, irq));
 
-	IRQ_CONNECT(DT_INST_0_ARM_CMSDK_UART_IRQ_RX,
-		    DT_INST_0_ARM_CMSDK_UART_IRQ_RX_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, rx, irq),
+		    DT_INST_IRQ_BY_NAME(0, rx, priority),
 		    uart_cmsdk_apb_isr,
 		    DEVICE_GET(uart_cmsdk_apb_0),
 		    0);
-	irq_enable(DT_INST_0_ARM_CMSDK_UART_IRQ_RX);
+	irq_enable(DT_INST_IRQ_BY_NAME(0, rx, irq));
 }
 #endif
 #endif
 
-#endif /* DT_INST_0_ARM_CMSDK_UART */
+#endif /* DT_HAS_DRV_INST(0) */
 
-#ifdef DT_INST_1_ARM_CMSDK_UART
+#if DT_HAS_DRV_INST(1)
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void uart_cmsdk_apb_irq_config_func_1(struct device *dev);
 #endif
 
 static const struct uart_device_config uart_cmsdk_apb_dev_cfg_1 = {
-	.base = (u8_t *)DT_INST_1_ARM_CMSDK_UART_BASE_ADDRESS,
-	.sys_clk_freq = DT_INST_1_ARM_CMSDK_UART_CLOCKS_CLOCK_FREQUENCY,
+	.base = (u8_t *)DT_INST_REG_ADDR(1),
+	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(1, clocks, clock_frequency),
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = uart_cmsdk_apb_irq_config_func_1,
 #endif
 };
 
 static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_1 = {
-	.baud_rate = DT_INST_1_ARM_CMSDK_UART_CURRENT_SPEED,
+	.baud_rate = DT_INST_PROP(1, current_speed),
 	.uart_cc_as = {.bus = CMSDK_APB, .state = SOC_ACTIVE,
-		       .device = DT_INST_1_ARM_CMSDK_UART_BASE_ADDRESS,},
+		       .device = DT_INST_REG_ADDR(1),},
 	.uart_cc_ss = {.bus = CMSDK_APB, .state = SOC_SLEEP,
-		       .device = DT_INST_1_ARM_CMSDK_UART_BASE_ADDRESS,},
+		       .device = DT_INST_REG_ADDR(1),},
 	.uart_cc_dss = {.bus = CMSDK_APB, .state = SOC_DEEPSLEEP,
-			.device = DT_INST_1_ARM_CMSDK_UART_BASE_ADDRESS,},
+			.device = DT_INST_REG_ADDR(1),},
 };
 
 DEVICE_AND_API_INIT(uart_cmsdk_apb_1,
-		    DT_INST_1_ARM_CMSDK_UART_LABEL,
+		    DT_INST_LABEL(1),
 		    &uart_cmsdk_apb_init,
 		    &uart_cmsdk_apb_dev_data_1,
 		    &uart_cmsdk_apb_dev_cfg_1, PRE_KERNEL_1,
@@ -554,64 +556,64 @@ DEVICE_AND_API_INIT(uart_cmsdk_apb_1,
 		    &uart_cmsdk_apb_driver_api);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-#ifdef DT_INST_1_ARM_CMSDK_UART_IRQ_0
+#if DT_INST_IRQ_HAS_CELL(1, irq)
 static void uart_cmsdk_apb_irq_config_func_1(struct device *dev)
 {
-	IRQ_CONNECT(DT_INST_1_ARM_CMSDK_UART_IRQ_0,
-		    DT_INST_1_ARM_CMSDK_UART_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(1),
+		    DT_INST_IRQ(1, priority),
 		    uart_cmsdk_apb_isr,
 		    DEVICE_GET(uart_cmsdk_apb_1),
 		    0);
-	irq_enable(DT_INST_1_ARM_CMSDK_UART_IRQ_0);
+	irq_enable(DT_INST_IRQN(1));
 }
 #else
 static void uart_cmsdk_apb_irq_config_func_1(struct device *dev)
 {
-	IRQ_CONNECT(DT_INST_1_ARM_CMSDK_UART_IRQ_TX,
-		    DT_INST_1_ARM_CMSDK_UART_IRQ_TX_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(1, tx, irq),
+		    DT_INST_IRQ_BY_NAME(1, tx, priority),
 		    uart_cmsdk_apb_isr,
 		    DEVICE_GET(uart_cmsdk_apb_1),
 		    0);
-	irq_enable(DT_INST_1_ARM_CMSDK_UART_IRQ_TX);
+	irq_enable(DT_INST_IRQ_BY_NAME(1, tx, irq));
 
-	IRQ_CONNECT(DT_INST_1_ARM_CMSDK_UART_IRQ_RX,
-		    DT_INST_1_ARM_CMSDK_UART_IRQ_RX_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(1, rx, irq),
+		    DT_INST_IRQ_BY_NAME(1, rx, priority),
 		    uart_cmsdk_apb_isr,
 		    DEVICE_GET(uart_cmsdk_apb_1),
 		    0);
-	irq_enable(DT_INST_1_ARM_CMSDK_UART_IRQ_RX);
+	irq_enable(DT_INST_IRQ_BY_NAME(1, rx, irq));
 }
 #endif
 #endif
 
-#endif /* DT_INST_1_ARM_CMSDK_UART */
+#endif /* DT_HAS_DRV_INST(1) */
 
-#ifdef DT_INST_2_ARM_CMSDK_UART
+#if DT_HAS_DRV_INST(2)
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void uart_cmsdk_apb_irq_config_func_2(struct device *dev);
 #endif
 
 static const struct uart_device_config uart_cmsdk_apb_dev_cfg_2 = {
-	.base = (u8_t *)DT_INST_2_ARM_CMSDK_UART_BASE_ADDRESS,
-	.sys_clk_freq = DT_INST_2_ARM_CMSDK_UART_CLOCKS_CLOCK_FREQUENCY,
+	.base = (u8_t *)DT_INST_REG_ADDR(2),
+	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(2, clocks, clock_frequency),
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = uart_cmsdk_apb_irq_config_func_2,
 #endif
 };
 
 static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_2 = {
-	.baud_rate = DT_INST_2_ARM_CMSDK_UART_CURRENT_SPEED,
+	.baud_rate = DT_INST_PROP(2, current_speed),
 	.uart_cc_as = {.bus = CMSDK_APB, .state = SOC_ACTIVE,
-		       .device = DT_INST_2_ARM_CMSDK_UART_BASE_ADDRESS,},
+		       .device = DT_INST_REG_ADDR(2),},
 	.uart_cc_ss = {.bus = CMSDK_APB, .state = SOC_SLEEP,
-		       .device = DT_INST_2_ARM_CMSDK_UART_BASE_ADDRESS,},
+		       .device = DT_INST_REG_ADDR(2),},
 	.uart_cc_dss = {.bus = CMSDK_APB, .state = SOC_DEEPSLEEP,
-			.device = DT_INST_2_ARM_CMSDK_UART_BASE_ADDRESS,},
+			.device = DT_INST_REG_ADDR(2),},
 };
 
 DEVICE_AND_API_INIT(uart_cmsdk_apb_2,
-		    DT_INST_2_ARM_CMSDK_UART_LABEL,
+		    DT_INST_LABEL(2),
 		    &uart_cmsdk_apb_init,
 		    &uart_cmsdk_apb_dev_data_2,
 		    &uart_cmsdk_apb_dev_cfg_2, PRE_KERNEL_1,
@@ -623,7 +625,7 @@ DEVICE_AND_API_INIT(uart_cmsdk_apb_2,
 static void uart_cmsdk_apb_irq_config_func_2(struct device *dev)
 {
 	IRQ_CONNECT(CMSDK_APB_UART_2_IRQ,
-		    DT_INST_2_ARM_CMSDK_UART_IRQ_PRIORITY,
+		    DT_INST_IRQ_BY_NAME(2, priority, irq),
 		    uart_cmsdk_apb_isr,
 		    DEVICE_GET(uart_cmsdk_apb_2),
 		    0);
@@ -632,51 +634,51 @@ static void uart_cmsdk_apb_irq_config_func_2(struct device *dev)
 #else
 static void uart_cmsdk_apb_irq_config_func_2(struct device *dev)
 {
-	IRQ_CONNECT(DT_INST_2_ARM_CMSDK_UART_IRQ_TX,
-		    DT_INST_2_ARM_CMSDK_UART_IRQ_TX_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(2, tx, irq),
+		    DT_INST_IRQ_BY_NAME(2, tx, priority),
 		    uart_cmsdk_apb_isr,
 		    DEVICE_GET(uart_cmsdk_apb_2),
 		    0);
-	irq_enable(DT_INST_2_ARM_CMSDK_UART_IRQ_TX);
+	irq_enable(DT_INST_IRQ_BY_NAME(2, tx, irq));
 
-	IRQ_CONNECT(DT_INST_2_ARM_CMSDK_UART_IRQ_RX,
-		    DT_INST_2_ARM_CMSDK_UART_IRQ_RX_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(2, rx, irq),
+		    DT_INST_IRQ_BY_NAME(2, rx, priority),
 		    uart_cmsdk_apb_isr,
 		    DEVICE_GET(uart_cmsdk_apb_2),
 		    0);
-	irq_enable(DT_INST_2_ARM_CMSDK_UART_IRQ_RX);
+	irq_enable(DT_INST_IRQ_BY_NAME(2, rx, irq));
 }
 #endif
 #endif
 
-#endif /* DT_INST_2_ARM_CMSDK_UART */
+#endif /* DT_HAS_DRV_INST(2) */
 
-#ifdef DT_INST_3_ARM_CMSDK_UART
+#if DT_HAS_DRV_INST(3)
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void uart_cmsdk_apb_irq_config_func_3(struct device *dev);
 #endif
 
 static const struct uart_device_config uart_cmsdk_apb_dev_cfg_3 = {
-	.base = (u8_t *)DT_INST_3_ARM_CMSDK_UART_BASE_ADDRESS,
-	.sys_clk_freq = DT_INST_3_ARM_CMSDK_UART_CLOCKS_CLOCK_FREQUENCY,
+	.base = (u8_t *)DT_INST_REG_ADDR(3),
+	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(3, clocks, clock_frequency),
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = uart_cmsdk_apb_irq_config_func_3,
 #endif
 };
 
 static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_3 = {
-	.baud_rate = DT_INST_3_ARM_CMSDK_UART_CURRENT_SPEED,
+	.baud_rate = DT_INST_PROP(3, current_speed),
 	.uart_cc_as = {.bus = CMSDK_APB, .state = SOC_ACTIVE,
-		       .device = DT_INST_3_ARM_CMSDK_UART_BASE_ADDRESS,},
+		       .device = DT_INST_REG_ADDR(3),},
 	.uart_cc_ss = {.bus = CMSDK_APB, .state = SOC_SLEEP,
-		       .device = DT_INST_3_ARM_CMSDK_UART_BASE_ADDRESS,},
+		       .device = DT_INST_REG_ADDR(3),},
 	.uart_cc_dss = {.bus = CMSDK_APB, .state = SOC_DEEPSLEEP,
-			.device = DT_INST_3_ARM_CMSDK_UART_BASE_ADDRESS,},
+			.device = DT_INST_REG_ADDR(3),},
 };
 
 DEVICE_AND_API_INIT(uart_cmsdk_apb_3,
-		    DT_INST_3_ARM_CMSDK_UART_LABEL,
+		    DT_INST_LABEL(3),
 		    &uart_cmsdk_apb_init,
 		    &uart_cmsdk_apb_dev_data_3,
 		    &uart_cmsdk_apb_dev_cfg_3, PRE_KERNEL_1,
@@ -688,7 +690,7 @@ DEVICE_AND_API_INIT(uart_cmsdk_apb_3,
 static void uart_cmsdk_apb_irq_config_func_3(struct device *dev)
 {
 	IRQ_CONNECT(CMSDK_APB_UART_3_IRQ,
-		    DT_INST_3_ARM_CMSDK_UART_IRQ_PRIORITY,
+		    DT_INST_IRQ_BY_NAME(3, priority, irq),
 		    uart_cmsdk_apb_isr,
 		    DEVICE_GET(uart_cmsdk_apb_3),
 		    0);
@@ -697,51 +699,51 @@ static void uart_cmsdk_apb_irq_config_func_3(struct device *dev)
 #else
 static void uart_cmsdk_apb_irq_config_func_3(struct device *dev)
 {
-	IRQ_CONNECT(DT_INST_3_ARM_CMSDK_UART_IRQ_TX,
-		    DT_INST_3_ARM_CMSDK_UART_IRQ_TX_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(3, tx, irq),
+		    DT_INST_IRQ_BY_NAME(3, tx, priority),
 		    uart_cmsdk_apb_isr,
 		    DEVICE_GET(uart_cmsdk_apb_3),
 		    0);
-	irq_enable(DT_INST_3_ARM_CMSDK_UART_IRQ_TX);
+	irq_enable(DT_INST_IRQ_BY_NAME(3, tx, irq));
 
-	IRQ_CONNECT(DT_INST_3_ARM_CMSDK_UART_IRQ_RX,
-		    DT_INST_3_ARM_CMSDK_UART_IRQ_RX_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(3, rx, irq),
+		    DT_INST_IRQ_BY_NAME(3, rx, priority),
 		    uart_cmsdk_apb_isr,
 		    DEVICE_GET(uart_cmsdk_apb_3),
 		    0);
-	irq_enable(DT_INST_3_ARM_CMSDK_UART_IRQ_RX);
+	irq_enable(DT_INST_IRQ_BY_NAME(3, rx, irq));
 }
 #endif
 #endif
 
-#endif /* DT_INST_3_ARM_CMSDK_UART */
+#endif /* DT_HAS_DRV_INST(3) */
 
-#ifdef DT_INST_4_ARM_CMSDK_UART
+#if DT_HAS_DRV_INST(4)
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void uart_cmsdk_apb_irq_config_func_4(struct device *dev);
 #endif
 
 static const struct uart_device_config uart_cmsdk_apb_dev_cfg_4 = {
-	.base = (u8_t *)DT_INST_4_ARM_CMSDK_UART_BASE_ADDRESS,
-	.sys_clk_freq = DT_INST_4_ARM_CMSDK_UART_CLOCKS_CLOCK_FREQUENCY,
+	.base = (u8_t *)DT_INST_REG_ADDR(4),
+	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(4, clocks, clock_frequency),
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = uart_cmsdk_apb_irq_config_func_4,
 #endif
 };
 
 static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_4 = {
-	.baud_rate = DT_INST_4_ARM_CMSDK_UART_CURRENT_SPEED,
+	.baud_rate = DT_INST_PROP(4, current_speed),
 	.uart_cc_as = {.bus = CMSDK_APB, .state = SOC_ACTIVE,
-		       .device = DT_INST_4_ARM_CMSDK_UART_BASE_ADDRESS,},
+		       .device = DT_INST_REG_ADDR(4),},
 	.uart_cc_ss = {.bus = CMSDK_APB, .state = SOC_SLEEP,
-		       .device = DT_INST_4_ARM_CMSDK_UART_BASE_ADDRESS,},
+		       .device = DT_INST_REG_ADDR(4),},
 	.uart_cc_dss = {.bus = CMSDK_APB, .state = SOC_DEEPSLEEP,
-			.device = DT_INST_4_ARM_CMSDK_UART_BASE_ADDRESS,},
+			.device = DT_INST_REG_ADDR(4),},
 };
 
 DEVICE_AND_API_INIT(uart_cmsdk_apb_4,
-		    DT_INST_4_ARM_CMSDK_UART_LABEL,
+		    DT_INST_LABEL(4),
 		    &uart_cmsdk_apb_init,
 		    &uart_cmsdk_apb_dev_data_4,
 		    &uart_cmsdk_apb_dev_cfg_4, PRE_KERNEL_1,
@@ -753,7 +755,7 @@ DEVICE_AND_API_INIT(uart_cmsdk_apb_4,
 static void uart_cmsdk_apb_irq_config_func_4(struct device *dev)
 {
 	IRQ_CONNECT(CMSDK_APB_UART_4_IRQ,
-		    DT_INST_4_ARM_CMSDK_UART_IRQ_PRIORITY,
+		    DT_INST_IRQ_BY_NAME(4, priority, irq),
 		    uart_cmsdk_apb_isr,
 		    DEVICE_GET(uart_cmsdk_apb_4),
 		    0);
@@ -762,21 +764,21 @@ static void uart_cmsdk_apb_irq_config_func_4(struct device *dev)
 #else
 static void uart_cmsdk_apb_irq_config_func_4(struct device *dev)
 {
-	IRQ_CONNECT(DT_INST_4_ARM_CMSDK_UART_IRQ_TX,
-		    DT_INST_4_ARM_CMSDK_UART_IRQ_TX_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(4, tx, irq),
+		    DT_INST_IRQ_BY_NAME(4, tx, priority),
 		    uart_cmsdk_apb_isr,
 		    DEVICE_GET(uart_cmsdk_apb_4),
 		    0);
-	irq_enable(DT_INST_4_ARM_CMSDK_UART_IRQ_TX);
+	irq_enable(DT_INST_IRQ_BY_NAME(4, tx, irq));
 
-	IRQ_CONNECT(DT_INST_4_ARM_CMSDK_UART_IRQ_RX,
-		    DT_INST_4_ARM_CMSDK_UART_IRQ_RX_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(4, rx, irq),
+		    DT_INST_IRQ_BY_NAME(4, rx, priority),
 		    uart_cmsdk_apb_isr,
 		    DEVICE_GET(uart_cmsdk_apb_4),
 		    0);
-	irq_enable(DT_INST_4_ARM_CMSDK_UART_IRQ_RX);
+	irq_enable(DT_INST_IRQ_BY_NAME(4, rx, irq));
 }
 #endif
 #endif
 
-#endif /* DT_INST_4_ARM_CMSDK_UART */
+#endif /* DT_HAS_DRV_INST(4) */

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT arm_pl011
+
 #include <kernel.h>
 #include <arch/cpu.h>
 #include <init.h>
@@ -413,19 +415,19 @@ static void pl011_irq_config_func_0(struct device *dev);
 #endif
 
 static struct uart_device_config pl011_cfg_port_0 = {
-	.base = (u8_t *)DT_INST_0_ARM_PL011_BASE_ADDRESS,
-	.sys_clk_freq = DT_INST_0_ARM_PL011_CLOCKS_CLOCK_FREQUENCY,
+	.base = (u8_t *)DT_INST_REG_ADDR(0),
+	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(0, clocks, clock_frequency),
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = pl011_irq_config_func_0,
 #endif
 };
 
 static struct pl011_data pl011_data_port_0 = {
-	.baud_rate = DT_INST_0_ARM_PL011_CURRENT_SPEED,
+	.baud_rate = DT_INST_PROP(0, current_speed),
 };
 
 DEVICE_AND_API_INIT(pl011_port_0,
-		    DT_INST_0_ARM_PL011_LABEL,
+		    DT_INST_LABEL(0),
 		    &pl011_init,
 		    &pl011_data_port_0,
 		    &pl011_cfg_port_0, PRE_KERNEL_1,
@@ -436,33 +438,33 @@ DEVICE_AND_API_INIT(pl011_port_0,
 static void pl011_irq_config_func_0(struct device *dev)
 {
 #if DT_NUM_IRQS(DT_INST(0, arm_pl011)) == 1
-	IRQ_CONNECT(DT_INST_0_ARM_PL011_IRQ_0,
-		    DT_INST_0_ARM_PL011_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		    DT_INST_IRQ(0, priority),
 		    pl011_isr,
 		    DEVICE_GET(pl011_port_0),
 		    0);
-	irq_enable(DT_INST_0_ARM_PL011_IRQ_0);
+	irq_enable(DT_INST_IRQN(0));
 #else
-	IRQ_CONNECT(DT_INST_0_ARM_PL011_IRQ_TX,
-		    DT_INST_0_ARM_PL011_IRQ_TX_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, tx, irq),
+		    DT_INST_IRQ_BY_NAME(0, tx, priority),
 		    pl011_isr,
 		    DEVICE_GET(pl011_port_0),
 		    0);
-	irq_enable(DT_INST_0_ARM_PL011_IRQ_TX);
+	irq_enable(DT_INST_IRQ_BY_NAME(0, tx, irq));
 
-	IRQ_CONNECT(DT_INST_0_ARM_PL011_IRQ_RX,
-		    DT_INST_0_ARM_PL011_IRQ_RX_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, rx, irq),
+		    DT_INST_IRQ_BY_NAME(0, rx, priority),
 		    pl011_isr,
 		    DEVICE_GET(pl011_port_0),
 		    0);
-	irq_enable(DT_INST_0_ARM_PL011_IRQ_RX);
+	irq_enable(DT_INST_IRQ_BY_NAME(0, rx, irq));
 
-	IRQ_CONNECT(DT_INST_0_ARM_PL011_IRQ_RXTIM,
-		    DT_INST_0_ARM_PL011_IRQ_RXTIM_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, rxtim, irq),
+		    DT_INST_IRQ_BY_NAME(0, rxtim, priority),
 		    pl011_isr,
 		    DEVICE_GET(pl011_port_0),
 		    0);
-	irq_enable(DT_INST_0_ARM_PL011_IRQ_RXTIM);
+	irq_enable(DT_INST_IRQ_BY_NAME(0, rxtim, irq));
 #endif
 }
 #endif
@@ -476,19 +478,19 @@ static void pl011_irq_config_func_1(struct device *dev);
 #endif
 
 static struct uart_device_config pl011_cfg_port_1 = {
-	.base = (u8_t *)DT_INST_1_ARM_PL011_BASE_ADDRESS,
-	.sys_clk_freq = DT_INST_1_ARM_PL011_CLOCKS_CLOCK_FREQUENCY,
+	.base = (u8_t *)DT_INST_REG_ADDR(1),
+	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(1, clocks, clock_frequency),
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = pl011_irq_config_func_1,
 #endif
 };
 
 static struct pl011_data pl011_data_port_1 = {
-	.baud_rate = DT_INST_1_ARM_PL011_CURRENT_SPEED,
+	.baud_rate = DT_INST_PROP(1, current_speed),
 };
 
 DEVICE_AND_API_INIT(pl011_port_1,
-		    DT_INST_1_ARM_PL011_LABEL,
+		    DT_INST_LABEL(1),
 		    &pl011_init,
 		    &pl011_data_port_1,
 		    &pl011_cfg_port_1, PRE_KERNEL_1,
@@ -499,33 +501,33 @@ DEVICE_AND_API_INIT(pl011_port_1,
 static void pl011_irq_config_func_1(struct device *dev)
 {
 #if DT_NUM_IRQS(DT_INST(1, arm_pl011)) == 1
-	IRQ_CONNECT(DT_INST_1_ARM_PL011_IRQ_0,
-		    DT_INST_1_ARM_PL011_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(1),
+		    DT_INST_IRQ(1, priority),
 		    pl011_isr,
 		    DEVICE_GET(pl011_port_1),
 		    0);
-	irq_enable(DT_INST_1_ARM_PL011_IRQ_0);
+	irq_enable(DT_INST_IRQN(1));
 #else
-	IRQ_CONNECT(DT_INST_1_ARM_PL011_IRQ_TX,
-		    DT_INST_1_ARM_PL011_IRQ_TX_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(1, tx, irq),
+		    DT_INST_IRQ_BY_NAME(1, tx, priority),
 		    pl011_isr,
 		    DEVICE_GET(pl011_port_1),
 		    0);
-	irq_enable(DT_INST_1_ARM_PL011_IRQ_TX);
+	irq_enable(DT_INST_IRQ_BY_NAME(1, tx, irq));
 
-	IRQ_CONNECT(DT_INST_1_ARM_PL011_IRQ_RX,
-		    DT_INST_1_ARM_PL011_IRQ_RX_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(1, rx, irq),
+		    DT_INST_IRQ_BY_NAME(1, rx, priority),
 		    pl011_isr,
 		    DEVICE_GET(pl011_port_1),
 		    0);
-	irq_enable(DT_INST_1_ARM_PL011_IRQ_RX);
+	irq_enable(DT_INST_IRQ_BY_NAME(1, rx, irq));
 
-	IRQ_CONNECT(DT_INST_1_ARM_PL011_IRQ_RXTIM,
-		    DT_INST_1_ARM_PL011_IRQ_RXTIM_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(1, rxtim, irq),
+		    DT_INST_IRQ_BY_NAME(1, rxtim, priority),
 		    pl011_isr,
 		    DEVICE_GET(pl011_port_1),
 		    0);
-	irq_enable(DT_INST_1_ARM_PL011_IRQ_RXTIM);
+	irq_enable(DT_INST_IRQ_BY_NAME(1, rxtim, irq));
 #endif
 }
 #endif

--- a/drivers/watchdog/wdt_cmsdk_apb.c
+++ b/drivers/watchdog/wdt_cmsdk_apb.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT arm_cmsdk_watchdog
+
 /**
  * @brief Driver for CMSDK APB Watchdog.
  */
@@ -57,7 +59,7 @@ struct wdog_cmsdk_apb {
 #define CMSDK_APB_WDOG_LOCK_VALUE (0x2BDDF662)
 
 #define WDOG_STRUCT \
-	((volatile struct wdog_cmsdk_apb *)(DT_INST_0_ARM_CMSDK_WATCHDOG_BASE_ADDRESS))
+	((volatile struct wdog_cmsdk_apb *)(DT_INST_REG_ADDR(0)))
 
 /* Keep reference of the device to pass it to the callback */
 struct device *wdog_r;
@@ -111,7 +113,7 @@ static int wdog_cmsdk_apb_install_timeout(struct device *dev,
 
 	/* Reload value */
 	reload_s = config->window.max *
-			   DT_INST_0_ARM_CMSDK_WATCHDOG_CLOCKS_CLOCK_FREQUENCY;
+			   DT_INST_PROP_BY_PHANDLE(0, clocks, clock_frequency);
 	flags = config->flags;
 
 	wdog->load = reload_s;
@@ -197,7 +199,7 @@ static int wdog_cmsdk_apb_init(struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(wdog_cmsdk_apb, DT_INST_0_ARM_CMSDK_WATCHDOG_LABEL,
+DEVICE_AND_API_INIT(wdog_cmsdk_apb, DT_INST_LABEL(0),
 		    wdog_cmsdk_apb_init,
 		    NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,

--- a/include/drivers/interrupt_controller/gic.h
+++ b/include/drivers/interrupt_controller/gic.h
@@ -23,8 +23,8 @@
  * GIC Register Interface Base Addresses
  */
 
-#define GIC_DIST_BASE	DT_INST_0_ARM_GIC_BASE_ADDRESS_0
-#define GIC_CPU_BASE	DT_INST_0_ARM_GIC_BASE_ADDRESS_1
+#define GIC_DIST_BASE	DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 0)
+#define GIC_CPU_BASE	DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 1)
 
 /*
  * GIC Distributor Interface

--- a/soc/arm/qemu_cortex_a53/mmu_regions.c
+++ b/soc/arm/qemu_cortex_a53/mmu_regions.c
@@ -12,13 +12,13 @@
 static const struct arm_mmu_region mmu_regions[] = {
 
 	MMU_REGION_FLAT_ENTRY("GIC",
-			      DT_INST_0_ARM_GIC_BASE_ADDRESS_0,
-			      DT_INST_0_ARM_GIC_SIZE_0 * 2,
+			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 0),
+			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 0) * 2,
 			      MT_DEVICE_nGnRnE | MT_RW | MT_SECURE),
 
 	MMU_REGION_FLAT_ENTRY("UART",
-			      DT_INST_0_ARM_PL011_BASE_ADDRESS,
-			      DT_INST_0_ARM_PL011_SIZE,
+			      DT_REG_ADDR(DT_INST(0, arm_pl011)),
+			      DT_REG_SIZE(DT_INST(0, arm_pl011)),
 			      MT_DEVICE_nGnRnE | MT_RW | MT_SECURE),
 
 	MMU_REGION_FLAT_ENTRY("SRAM",


### PR DESCRIPTION
Convert older DT_INST_ macro use in arm_cmsdk/arm drivers to the new
include/devicetree.h DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>