### PR TITLE
drivers: wifi: eswifi: Convert to new DT_INST macros

### DIFF
--- a/drivers/wifi/eswifi/eswifi_bus_spi.c
+++ b/drivers/wifi/eswifi/eswifi_bus_spi.c
@@ -3,6 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#define DT_DRV_COMPAT inventek_eswifi
 #define LOG_LEVEL CONFIG_WIFI_LOG_LEVEL
 #include <logging/log.h>
 LOG_MODULE_REGISTER(wifi_eswifi_bus_spi);
@@ -226,7 +228,7 @@ int eswifi_spi_init(struct eswifi_dev *eswifi)
 	struct eswifi_spi_data *spi = &eswifi_spi0; /* Static instance */
 
 	/* SPI DEV */
-	spi->spi_dev = device_get_binding(DT_INST_0_INVENTEK_ESWIFI_BUS_NAME);
+	spi->spi_dev = device_get_binding(DT_INST_BUS_LABEL(0));
 	if (!spi->spi_dev) {
 		LOG_ERR("Failed to initialize SPI driver");
 		return -ENODEV;
@@ -234,26 +236,26 @@ int eswifi_spi_init(struct eswifi_dev *eswifi)
 
 	/* SPI DATA READY PIN */
 	spi->dr.dev = device_get_binding(
-			DT_INST_0_INVENTEK_ESWIFI_DATA_GPIOS_CONTROLLER);
+			DT_INST_GPIO_LABEL(0, data_gpios));
 	if (!spi->dr.dev) {
 		LOG_ERR("Failed to initialize GPIO driver: %s",
-			    DT_INST_0_INVENTEK_ESWIFI_DATA_GPIOS_CONTROLLER);
+			    DT_INST_GPIO_LABEL(0, data_gpios));
 		return -ENODEV;
 	}
-	spi->dr.pin = DT_INST_0_INVENTEK_ESWIFI_DATA_GPIOS_PIN;
+	spi->dr.pin = DT_INST_GPIO_PIN(0, data_gpios);
 	gpio_pin_configure(spi->dr.dev, spi->dr.pin,
-			   DT_INST_0_INVENTEK_ESWIFI_DATA_GPIOS_FLAGS |
+			   DT_INST_GPIO_FLAGS(0, data_gpios) |
 			   GPIO_INPUT);
 
 	/* SPI CONFIG/CS */
-	spi->spi_cfg.frequency = DT_INST_0_INVENTEK_ESWIFI_SPI_MAX_FREQUENCY;
+	spi->spi_cfg.frequency = DT_INST_PROP(0, spi_max_frequency);
 	spi->spi_cfg.operation = (SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB |
 				  SPI_WORD_SET(16) | SPI_LINES_SINGLE |
 				  SPI_HOLD_ON_CS | SPI_LOCK_ON);
-	spi->spi_cfg.slave = DT_INST_0_INVENTEK_ESWIFI_BASE_ADDRESS;
+	spi->spi_cfg.slave = DT_INST_REG_ADDR(0);
 	spi->spi_cs.gpio_dev =
-		device_get_binding(DT_INST_0_INVENTEK_ESWIFI_CS_GPIOS_CONTROLLER);
-	spi->spi_cs.gpio_pin = DT_INST_0_INVENTEK_ESWIFI_CS_GPIOS_PIN;
+		device_get_binding(DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
+	spi->spi_cs.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
 	spi->spi_cs.delay = 1000U;
 	spi->spi_cfg.cs = &spi->spi_cs;
 

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -3,6 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#define DT_DRV_COMPAT inventek_eswifi
 #define LOG_LEVEL CONFIG_WIFI_LOG_LEVEL
 #include <logging/log.h>
 LOG_MODULE_REGISTER(wifi_eswifi_core);
@@ -638,27 +640,27 @@ static int eswifi_init(struct device *dev)
 	eswifi->bus->init(eswifi);
 
 	eswifi->resetn.dev = device_get_binding(
-			DT_INST_0_INVENTEK_ESWIFI_RESETN_GPIOS_CONTROLLER);
+			DT_INST_GPIO_LABEL(0, resetn_gpios));
 	if (!eswifi->resetn.dev) {
 		LOG_ERR("Failed to initialize GPIO driver: %s",
-			    DT_INST_0_INVENTEK_ESWIFI_RESETN_GPIOS_CONTROLLER);
+			    DT_INST_GPIO_LABEL(0, resetn_gpios));
 		return -ENODEV;
 	}
-	eswifi->resetn.pin = DT_INST_0_INVENTEK_ESWIFI_RESETN_GPIOS_PIN;
+	eswifi->resetn.pin = DT_INST_GPIO_PIN(0, resetn_gpios);
 	gpio_pin_configure(eswifi->resetn.dev, eswifi->resetn.pin,
-			   DT_INST_0_INVENTEK_ESWIFI_RESETN_GPIOS_FLAGS |
+			   DT_INST_GPIO_FLAGS(0, resetn_gpios) |
 			   GPIO_OUTPUT_INACTIVE);
 
 	eswifi->wakeup.dev = device_get_binding(
-			DT_INST_0_INVENTEK_ESWIFI_WAKEUP_GPIOS_CONTROLLER);
+			DT_INST_GPIO_LABEL(0, wakeup_gpios));
 	if (!eswifi->wakeup.dev) {
 		LOG_ERR("Failed to initialize GPIO driver: %s",
-			    DT_INST_0_INVENTEK_ESWIFI_WAKEUP_GPIOS_CONTROLLER);
+			    DT_INST_GPIO_LABEL(0, wakeup_gpios));
 		return -ENODEV;
 	}
-	eswifi->wakeup.pin = DT_INST_0_INVENTEK_ESWIFI_WAKEUP_GPIOS_PIN;
+	eswifi->wakeup.pin = DT_INST_GPIO_PIN(0, wakeup_gpios);
 	gpio_pin_configure(eswifi->wakeup.dev, eswifi->wakeup.pin,
-			   DT_INST_0_INVENTEK_ESWIFI_WAKEUP_GPIOS_FLAGS |
+			   DT_INST_GPIO_FLAGS(0, wakeup_gpios) |
 			   GPIO_OUTPUT_ACTIVE);
 
 	k_work_q_start(&eswifi->work_q, eswifi_work_q_stack,


### PR DESCRIPTION
Convert older DT_INST_ macro use the new include/devicetree.h
DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>