### PR TITLE
drivers: ieee802154: Convert to new DT_INST macros

### DIFF
--- a/drivers/ieee802154/ieee802154_cc1200.c
+++ b/drivers/ieee802154/ieee802154_cc1200.c
@@ -1,5 +1,7 @@
 /* ieee802154_cc1200.c - TI CC1200 driver */
 
+#define DT_DRV_COMPAT ti_cc1200
+
 /*
  * Copyright (c) 2017 Intel Corporation.
  *
@@ -729,15 +731,15 @@ static int power_on_and_setup(struct device *dev)
 static struct cc1200_gpio_configuration *configure_gpios(struct device *dev)
 {
 	struct cc1200_context *cc1200 = dev->driver_data;
-	struct device *gpio = device_get_binding(DT_INST_0_TI_CC1200_INT_GPIOS_CONTROLLER);
+	struct device *gpio = device_get_binding(DT_INST_GPIO_LABEL(0, int_gpios));
 
 	if (!gpio) {
 		return NULL;
 	}
 
-	cc1200->gpios[CC1200_GPIO_IDX_GPIO0].pin = DT_INST_0_TI_CC1200_INT_GPIOS_PIN;
+	cc1200->gpios[CC1200_GPIO_IDX_GPIO0].pin = DT_INST_GPIO_PIN(0, int_gpios);
 	gpio_pin_configure(gpio, cc1200->gpios[CC1200_GPIO_IDX_GPIO0].pin,
-			   GPIO_INPUT | DT_INST_0_TI_CC1200_INT_GPIOS_FLAGS);
+			   GPIO_INPUT | DT_INST_GPIO_FLAGS(0, int_gpios));
 	cc1200->gpios[CC1200_GPIO_IDX_GPIO0].dev = gpio;
 
 	return cc1200->gpios;
@@ -747,7 +749,7 @@ static int configure_spi(struct device *dev)
 {
 	struct cc1200_context *cc1200 = dev->driver_data;
 
-	cc1200->spi = device_get_binding(DT_INST_0_TI_CC1200_BUS_NAME);
+	cc1200->spi = device_get_binding(DT_INST_BUS_LABEL(0));
 	if (!cc1200->spi) {
 		LOG_ERR("Unable to get SPI device");
 		return -ENODEV;
@@ -755,25 +757,25 @@ static int configure_spi(struct device *dev)
 
 #if defined(CONFIG_IEEE802154_CC1200_GPIO_SPI_CS)
 	cs_ctrl.gpio_dev = device_get_binding(
-		DT_INST_0_TI_CC1200_CS_GPIOS_CONTROLLER);
+		DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
 	if (!cs_ctrl.gpio_dev) {
 		LOG_ERR("Unable to get GPIO SPI CS device");
 		return -ENODEV;
 	}
 
-	cs_ctrl.gpio_pin = DT_INST_0_TI_CC1200_CS_GPIOS_PIN;
+	cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
 	cs_ctrl.delay = 0U;
 
 	cc1200->spi_cfg.cs = &cs_ctrl;
 
 	LOG_DBG("SPI GPIO CS configured on %s:%u",
-		DT_INST_0_TI_CC1200_CS_GPIOS_CONTROLLER,
-		DT_INST_0_TI_CC1200_CS_GPIOS_PIN);
+		DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
+		DT_INST_SPI_DEV_CS_GPIOS_PIN(0));
 #endif /* CONFIG_IEEE802154_CC1200_GPIO_SPI_CS */
 
 	cc1200->spi_cfg.operation = SPI_WORD_SET(8);
-	cc1200->spi_cfg.frequency = DT_INST_0_TI_CC1200_SPI_MAX_FREQUENCY;
-	cc1200->spi_cfg.slave = DT_INST_0_TI_CC1200_BASE_ADDRESS;
+	cc1200->spi_cfg.frequency = DT_INST_PROP(0, spi_max_frequency);
+	cc1200->spi_cfg.slave = DT_INST_REG_ADDR(0);
 
 	return 0;
 }

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -1,5 +1,7 @@
 /* ieee802154_cc2520.c - TI CC2520 driver */
 
+#define DT_DRV_COMPAT ti_cc2520
+
 /*
  * Copyright (c) 2016 Intel Corporation.
  *
@@ -968,69 +970,69 @@ static struct cc2520_gpio_configuration *configure_gpios(struct device *dev)
 	struct device *gpio;
 
 	/* VREG_EN */
-	gpio = device_get_binding(DT_INST_0_TI_CC2520_VREG_EN_GPIOS_CONTROLLER);
+	gpio = device_get_binding(DT_INST_GPIO_LABEL(0, vreg_en_gpios));
 	if (!gpio) {
 		return NULL;
 	}
 
-	cc2520->gpios[CC2520_GPIO_IDX_VREG_EN].pin = DT_INST_0_TI_CC2520_VREG_EN_GPIOS_PIN;
+	cc2520->gpios[CC2520_GPIO_IDX_VREG_EN].pin = DT_INST_GPIO_PIN(0, vreg_en_gpios);
 	gpio_pin_configure(gpio, cc2520->gpios[CC2520_GPIO_IDX_VREG_EN].pin,
-			   GPIO_OUTPUT_LOW | DT_INST_0_TI_CC2520_VREG_EN_GPIOS_FLAGS);
+			   GPIO_OUTPUT_LOW | DT_INST_GPIO_FLAGS(0, vreg_en_gpios));
 	cc2520->gpios[CC2520_GPIO_IDX_VREG_EN].dev = gpio;
 
 	/* RESET */
-	gpio = device_get_binding(DT_INST_0_TI_CC2520_RESET_GPIOS_CONTROLLER);
+	gpio = device_get_binding(DT_INST_GPIO_LABEL(0, reset_gpios));
 	if (!gpio) {
 		return NULL;
 	}
 
-	cc2520->gpios[CC2520_GPIO_IDX_RESET].pin = DT_INST_0_TI_CC2520_RESET_GPIOS_PIN;
+	cc2520->gpios[CC2520_GPIO_IDX_RESET].pin = DT_INST_GPIO_PIN(0, reset_gpios);
 	gpio_pin_configure(gpio, cc2520->gpios[CC2520_GPIO_IDX_RESET].pin,
-			   GPIO_OUTPUT_LOW | DT_INST_0_TI_CC2520_RESET_GPIOS_FLAGS);
+			   GPIO_OUTPUT_LOW | DT_INST_GPIO_FLAGS(0, reset_gpios));
 	cc2520->gpios[CC2520_GPIO_IDX_RESET].dev = gpio;
 
 	/*FIFO */
-	gpio = device_get_binding(DT_INST_0_TI_CC2520_FIFO_GPIOS_CONTROLLER);
+	gpio = device_get_binding(DT_INST_GPIO_LABEL(0, fifo_gpios));
 	if (!gpio) {
 		return NULL;
 	}
 
-	cc2520->gpios[CC2520_GPIO_IDX_FIFO].pin = DT_INST_0_TI_CC2520_FIFO_GPIOS_PIN;
+	cc2520->gpios[CC2520_GPIO_IDX_FIFO].pin = DT_INST_GPIO_PIN(0, fifo_gpios);
 	gpio_pin_configure(gpio, cc2520->gpios[CC2520_GPIO_IDX_FIFO].pin,
-			   GPIO_INPUT | DT_INST_0_TI_CC2520_FIFO_GPIOS_FLAGS);
+			   GPIO_INPUT | DT_INST_GPIO_FLAGS(0, fifo_gpios));
 	cc2520->gpios[CC2520_GPIO_IDX_FIFO].dev = gpio;
 
 	/* CCA */
-	gpio = device_get_binding(DT_INST_0_TI_CC2520_CCA_GPIOS_CONTROLLER);
+	gpio = device_get_binding(DT_INST_GPIO_LABEL(0, cca_gpios));
 	if (!gpio) {
 		return NULL;
 	}
 
-	cc2520->gpios[CC2520_GPIO_IDX_CCA].pin = DT_INST_0_TI_CC2520_CCA_GPIOS_PIN;
+	cc2520->gpios[CC2520_GPIO_IDX_CCA].pin = DT_INST_GPIO_PIN(0, cca_gpios);
 	gpio_pin_configure(gpio, cc2520->gpios[CC2520_GPIO_IDX_CCA].pin,
-			   GPIO_INPUT | DT_INST_0_TI_CC2520_CCA_GPIOS_FLAGS);
+			   GPIO_INPUT | DT_INST_GPIO_FLAGS(0, cca_gpios));
 	cc2520->gpios[CC2520_GPIO_IDX_CCA].dev = gpio;
 
 	/* SFD */
-	gpio = device_get_binding(DT_INST_0_TI_CC2520_SFD_GPIOS_CONTROLLER);
+	gpio = device_get_binding(DT_INST_GPIO_LABEL(0, sfd_gpios));
 	if (!gpio) {
 		return NULL;
 	}
 
-	cc2520->gpios[CC2520_GPIO_IDX_SFD].pin = DT_INST_0_TI_CC2520_SFD_GPIOS_PIN;
+	cc2520->gpios[CC2520_GPIO_IDX_SFD].pin = DT_INST_GPIO_PIN(0, sfd_gpios);
 	gpio_pin_configure(gpio, cc2520->gpios[CC2520_GPIO_IDX_SFD].pin,
-			   GPIO_INPUT | DT_INST_0_TI_CC2520_SFD_GPIOS_FLAGS);
+			   GPIO_INPUT | DT_INST_GPIO_FLAGS(0, sfd_gpios));
 	cc2520->gpios[CC2520_GPIO_IDX_SFD].dev = gpio;
 
 	/* FIFOP */
-	gpio = device_get_binding(DT_INST_0_TI_CC2520_FIFOP_GPIOS_CONTROLLER);
+	gpio = device_get_binding(DT_INST_GPIO_LABEL(0, fifop_gpios));
 	if (!gpio) {
 		return NULL;
 	}
 
-	cc2520->gpios[CC2520_GPIO_IDX_FIFOP].pin = DT_INST_0_TI_CC2520_FIFOP_GPIOS_PIN;
+	cc2520->gpios[CC2520_GPIO_IDX_FIFOP].pin = DT_INST_GPIO_PIN(0, fifop_gpios);
 	gpio_pin_configure(gpio, cc2520->gpios[CC2520_GPIO_IDX_FIFOP].pin,
-			   GPIO_INPUT | DT_INST_0_TI_CC2520_SFD_GPIOS_FLAGS);
+			   GPIO_INPUT | DT_INST_GPIO_FLAGS(0, sfd_gpios));
 	cc2520->gpios[CC2520_GPIO_IDX_FIFOP].dev = gpio;
 
 	return cc2520->gpios;
@@ -1041,7 +1043,7 @@ static inline int configure_spi(struct device *dev)
 {
 	struct cc2520_context *cc2520 = dev->driver_data;
 
-	cc2520->spi = device_get_binding(DT_INST_0_TI_CC2520_BUS_NAME);
+	cc2520->spi = device_get_binding(DT_INST_BUS_LABEL(0));
 	if (!cc2520->spi) {
 		LOG_ERR("Unable to get SPI device");
 		return -ENODEV;
@@ -1049,25 +1051,25 @@ static inline int configure_spi(struct device *dev)
 
 #if defined(CONFIG_IEEE802154_CC2520_GPIO_SPI_CS)
 	cs_ctrl.gpio_dev = device_get_binding(
-		DT_INST_0_TI_CC2520_CS_GPIOS_CONTROLLER);
+		DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
 	if (!cs_ctrl.gpio_dev) {
 		LOG_ERR("Unable to get GPIO SPI CS device");
 		return -ENODEV;
 	}
 
-	cs_ctrl.gpio_pin = DT_INST_0_TI_CC2520_CS_GPIOS_PIN;
+	cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
 	cs_ctrl.delay = 0U;
 
 	cc2520->spi_cfg.cs = &cs_ctrl;
 
 	LOG_DBG("SPI GPIO CS configured on %s:%u",
-		    DT_INST_0_TI_CC2520_CS_GPIOS_CONTROLLER,
-		    DT_INST_0_TI_CC2520_CS_GPIOS_PIN);
+		    DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
+		    DT_INST_SPI_DEV_CS_GPIOS_PIN(0));
 #endif /* CONFIG_IEEE802154_CC2520_GPIO_SPI_CS */
 
-	cc2520->spi_cfg.frequency = DT_INST_0_TI_CC2520_SPI_MAX_FREQUENCY;
+	cc2520->spi_cfg.frequency = DT_INST_PROP(0, spi_max_frequency);
 	cc2520->spi_cfg.operation = SPI_WORD_SET(8);
-	cc2520->spi_cfg.slave = DT_INST_0_TI_CC2520_BASE_ADDRESS;
+	cc2520->spi_cfg.slave = DT_INST_REG_ADDR(0);
 
 	return 0;
 }

--- a/drivers/ieee802154/ieee802154_mcr20a.h
+++ b/drivers/ieee802154/ieee802154_mcr20a.h
@@ -25,7 +25,7 @@ struct mcr20a_context {
 	struct gpio_callback irqb_cb;
 	struct device *spi;
 	struct spi_config spi_cfg;
-#if defined(DT_INST_0_NXP_MCR20A_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	struct spi_cs_control cs_ctrl;
 #endif
 	u8_t mac_addr[8];

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -1,5 +1,7 @@
 /* ieee802154_rf2xx.c - ATMEL RF2XX IEEE 802.15.4 Driver */
 
+#define DT_DRV_COMPAT atmel_rf2xx
+
 /*
  * Copyright (c) 2019-2020 Gerson Fernando Budke
  *
@@ -811,69 +813,57 @@ static struct ieee802154_radio_api rf2xx_radio_api = {
 #endif /* CONFIG_IEEE802154_RAW_MODE */
 
 /*
- * Optional features place holders
+ * Optional features place holders, get a 0 if the "gpio" doesn't exist
  */
-#ifndef DT_INST_0_ATMEL_RF2XX_DIG2_GPIOS_CONTROLLER
-#define DT_INST_0_ATMEL_RF2XX_DIG2_GPIOS_CONTROLLER 0
-#define DT_INST_0_ATMEL_RF2XX_DIG2_GPIOS_PIN        0
-#define DT_INST_0_ATMEL_RF2XX_DIG2_GPIOS_FLAGS      0
-#endif
-#ifndef DT_INST_1_ATMEL_RF2XX_DIG2_GPIOS_CONTROLLER
-#define DT_INST_1_ATMEL_RF2XX_DIG2_GPIOS_CONTROLLER 0
-#define DT_INST_1_ATMEL_RF2XX_DIG2_GPIOS_PIN        0
-#define DT_INST_1_ATMEL_RF2XX_DIG2_GPIOS_FLAGS      0
-#endif
-#ifndef DT_INST_0_ATMEL_RF2XX_CLKM_GPIOS_CONTROLLER
-#define DT_INST_0_ATMEL_RF2XX_CLKM_GPIOS_CONTROLLER 0
-#define DT_INST_0_ATMEL_RF2XX_CLKM_GPIOS_PIN        0
-#define DT_INST_0_ATMEL_RF2XX_CLKM_GPIOS_FLAGS      0
-#endif
-#ifndef DT_INST_1_ATMEL_RF2XX_CLKM_GPIOS_CONTROLLER
-#define DT_INST_1_ATMEL_RF2XX_CLKM_GPIOS_CONTROLLER 0
-#define DT_INST_1_ATMEL_RF2XX_CLKM_GPIOS_PIN        0
-#define DT_INST_1_ATMEL_RF2XX_CLKM_GPIOS_FLAGS      0
-#endif
-#ifndef DT_INST_0_ATMEL_RF2XX_CS_GPIOS_CONTROLLER
-#define DT_INST_0_ATMEL_RF2XX_CS_GPIOS_CONTROLLER   0
-#define DT_INST_0_ATMEL_RF2XX_CS_GPIOS_PIN          0
-#define DT_INST_0_ATMEL_RF2XX_CS_GPIOS_FLAGS        0
-#endif
-#ifndef DT_INST_1_ATMEL_RF2XX_CS_GPIOS_CONTROLLER
-#define DT_INST_1_ATMEL_RF2XX_CS_GPIOS_CONTROLLER   0
-#define DT_INST_1_ATMEL_RF2XX_CS_GPIOS_PIN          0
-#define DT_INST_1_ATMEL_RF2XX_CS_GPIOS_FLAGS        0
-#endif
+#define DRV_INST_GPIO_LABEL(n, gpio_pha)	     \
+	UTIL_AND(DT_INST_NODE_HAS_PROP(n, gpio_pha), \
+		 DT_INST_GPIO_LABEL(n, gpio_pha))
+#define DRV_INST_GPIO_PIN(n, gpio_pha)	             \
+	UTIL_AND(DT_INST_NODE_HAS_PROP(n, gpio_pha), \
+		 DT_INST_GPIO_PIN(n, gpio_pha))
+#define DRV_INST_GPIO_FLAGS(n, gpio_pha)	     \
+	UTIL_AND(DT_INST_NODE_HAS_PROP(n, gpio_pha), \
+		 DT_INST_GPIO_FLAGS(n, gpio_pha))
+#define DRV_INST_SPI_DEV_CS_GPIOS_LABEL(n)           \
+	UTIL_AND(DT_INST_SPI_DEV_HAS_CS_GPIOS(n),    \
+		 DT_INST_SPI_DEV_CS_GPIOS_LABEL(n))
+#define DRV_INST_SPI_DEV_CS_GPIOS_PIN(n)             \
+	UTIL_AND(DT_INST_SPI_DEV_HAS_CS_GPIOS(n),    \
+		 DT_INST_SPI_DEV_CS_GPIOS_PIN(n))
+#define DRV_INST_SPI_DEV_CS_GPIOS_FLAGS(n)           \
+	UTIL_AND(DT_INST_SPI_DEV_HAS_CS_GPIOS(n),    \
+		 DT_INST_SPI_DEV_CS_GPIOS_FLAGS(n))
 
 #define IEEE802154_RF2XX_DEVICE_CONFIG(n)					   \
 	static const struct rf2xx_config rf2xx_ctx_config_##n = {		   \
 		.inst = n,							   \
 										   \
-		.irq.devname = DT_INST_##n##_ATMEL_RF2XX_IRQ_GPIOS_CONTROLLER,	   \
-		.irq.pin = DT_INST_##n##_ATMEL_RF2XX_IRQ_GPIOS_PIN,		   \
-		.irq.flags = DT_INST_##n##_ATMEL_RF2XX_IRQ_GPIOS_FLAGS,		   \
+		.irq.devname = DRV_INST_GPIO_LABEL(n, irq_gpios),		   \
+		.irq.pin = DRV_INST_GPIO_PIN(n, irq_gpios),			   \
+		.irq.flags = DRV_INST_GPIO_FLAGS(n, irq_gpios),			   \
 										   \
-		.reset.devname = DT_INST_##n##_ATMEL_RF2XX_RESET_GPIOS_CONTROLLER, \
-		.reset.pin = DT_INST_##n##_ATMEL_RF2XX_RESET_GPIOS_PIN,		   \
-		.reset.flags = DT_INST_##n##_ATMEL_RF2XX_RESET_GPIOS_FLAGS,	   \
+		.reset.devname = DRV_INST_GPIO_LABEL(n, reset_gpios),		   \
+		.reset.pin = DRV_INST_GPIO_PIN(n, reset_gpios),			   \
+		.reset.flags = DRV_INST_GPIO_FLAGS(n, reset_gpios),		   \
 										   \
-		.slptr.devname = DT_INST_##n##_ATMEL_RF2XX_SLPTR_GPIOS_CONTROLLER, \
-		.slptr.pin = DT_INST_##n##_ATMEL_RF2XX_SLPTR_GPIOS_PIN,		   \
-		.slptr.flags = DT_INST_##n##_ATMEL_RF2XX_SLPTR_GPIOS_FLAGS,	   \
+		.slptr.devname = DRV_INST_GPIO_LABEL(n, slptr_gpios),		   \
+		.slptr.pin = DRV_INST_GPIO_PIN(n, slptr_gpios),			   \
+		.slptr.flags = DRV_INST_GPIO_FLAGS(n, slptr_gpios),		   \
 										   \
-		.dig2.devname = DT_INST_##n##_ATMEL_RF2XX_DIG2_GPIOS_CONTROLLER,   \
-		.dig2.pin = DT_INST_##n##_ATMEL_RF2XX_DIG2_GPIOS_PIN,		   \
-		.dig2.flags = DT_INST_##n##_ATMEL_RF2XX_DIG2_GPIOS_FLAGS,	   \
+		.dig2.devname = DRV_INST_GPIO_LABEL(n, dig2_gpios),		   \
+		.dig2.pin = DRV_INST_GPIO_PIN(n, dig2_gpios),			   \
+		.dig2.flags = DRV_INST_GPIO_FLAGS(n, dig2_gpios),		   \
 										   \
-		.clkm.devname = DT_INST_##n##_ATMEL_RF2XX_CLKM_GPIOS_CONTROLLER,   \
-		.clkm.pin = DT_INST_##n##_ATMEL_RF2XX_CLKM_GPIOS_PIN,		   \
-		.clkm.flags = DT_INST_##n##_ATMEL_RF2XX_CLKM_GPIOS_FLAGS,	   \
+		.clkm.devname = DRV_INST_GPIO_LABEL(n, clkm_gpios),		   \
+		.clkm.pin = DRV_INST_GPIO_PIN(n, clkm_gpios),			   \
+		.clkm.flags = DRV_INST_GPIO_FLAGS(n, clkm_gpios),		   \
 										   \
-		.spi.devname = DT_INST_##n##_ATMEL_RF2XX_BUS_NAME,		   \
-		.spi.addr = DT_INST_##n##_ATMEL_RF2XX_BASE_ADDRESS,		   \
-		.spi.freq = DT_INST_##n##_ATMEL_RF2XX_SPI_MAX_FREQUENCY,	   \
-		.spi.cs.devname = DT_INST_##n##_ATMEL_RF2XX_CS_GPIOS_CONTROLLER,   \
-		.spi.cs.pin = DT_INST_##n##_ATMEL_RF2XX_CS_GPIOS_PIN,		   \
-		.spi.cs.flags = DT_INST_##n##_ATMEL_RF2XX_CS_GPIOS_FLAGS,	   \
+		.spi.devname = DT_INST_BUS_LABEL(n),				   \
+		.spi.addr = DT_INST_REG_ADDR(n),				   \
+		.spi.freq = DT_INST_PROP(n, spi_max_frequency),			   \
+		.spi.cs.devname = DRV_INST_SPI_DEV_CS_GPIOS_LABEL(n),		   \
+		.spi.cs.pin = DRV_INST_SPI_DEV_CS_GPIOS_PIN(n),			   \
+		.spi.cs.flags = DRV_INST_SPI_DEV_CS_GPIOS_FLAGS(n),		   \
 	};
 
 #define IEEE802154_RF2XX_DEVICE_DATA(n)			   \
@@ -882,7 +872,7 @@ static struct ieee802154_radio_api rf2xx_radio_api = {
 #define IEEE802154_RF2XX_RAW_DEVICE_INIT(n)	   \
 	DEVICE_AND_API_INIT(			   \
 		rf2xx_##n,			   \
-		DT_INST_##n##_ATMEL_RF2XX_LABEL,   \
+		DT_INST_LABEL(n),		   \
 		&rf2xx_init,			   \
 		&rf2xx_ctx_data_##n,		   \
 		&rf2xx_ctx_config_##n,		   \
@@ -893,7 +883,7 @@ static struct ieee802154_radio_api rf2xx_radio_api = {
 #define IEEE802154_RF2XX_NET_DEVICE_INIT(n)	   \
 	NET_DEVICE_INIT(			   \
 		rf2xx_##n,			   \
-		DT_INST_##n##_ATMEL_RF2XX_LABEL,   \
+		DT_INST_LABEL(n),		   \
 		&rf2xx_init,			   \
 		device_pm_control_nop,		   \
 		&rf2xx_ctx_data_##n,		   \
@@ -904,7 +894,7 @@ static struct ieee802154_radio_api rf2xx_radio_api = {
 		L2_CTX_TYPE,			   \
 		MTU)
 
-#if DT_INST_0_ATMEL_RF2XX
+#if DT_HAS_DRV_INST(0)
 	IEEE802154_RF2XX_DEVICE_CONFIG(0);
 	IEEE802154_RF2XX_DEVICE_DATA(0);
 
@@ -915,7 +905,7 @@ static struct ieee802154_radio_api rf2xx_radio_api = {
 	#endif /* CONFIG_IEEE802154_RAW_MODE */
 #endif
 
-#if DT_INST_1_ATMEL_RF2XX
+#if DT_HAS_DRV_INST(1)
 	IEEE802154_RF2XX_DEVICE_CONFIG(1);
 	IEEE802154_RF2XX_DEVICE_DATA(1);
 


### PR DESCRIPTION
Convert older DT_INST_ macro use the new include/devicetree.h
DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>