### PR TITLE
drivers: ethernet: Convert to new DT_INST macros

### DIFF
--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT intel_e1000
+
 #define LOG_MODULE_NAME eth_e1000
 #define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
 #include <logging/log.h>
@@ -225,12 +227,12 @@ static void e1000_init(struct net_if *iface)
 	net_if_set_link_addr(iface, dev->mac, sizeof(dev->mac),
 				NET_LINK_ETHERNET);
 
-	IRQ_CONNECT(DT_INST_0_INTEL_E1000_IRQ_0,
-			DT_INST_0_INTEL_E1000_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(0),
+			DT_INST_IRQ(0, priority),
 			e1000_isr, DEVICE_GET(eth_e1000),
-			DT_INST_0_INTEL_E1000_IRQ_0_SENSE);
+			DT_INST_IRQ(0, sense));
 
-	irq_enable(DT_INST_0_INTEL_E1000_IRQ_0);
+	irq_enable(DT_INST_IRQN(0));
 
 	iow32(dev, CTRL, CTRL_SLU); /* Set link up */
 

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT microchip_enc28j60
+
 #define LOG_MODULE_NAME eth_enc28j60
 #define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
 
@@ -807,7 +809,7 @@ static int eth_enc28j60_init(struct device *dev)
 #ifdef CONFIG_ETH_ENC28J60_0
 
 static struct eth_enc28j60_runtime eth_enc28j60_0_runtime = {
-	.mac_address = DT_INST_0_MICROCHIP_ENC28J60_LOCAL_MAC_ADDRESS,
+	.mac_address = DT_INST_PROP(0, local_mac_address),
 	.tx_rx_sem = Z_SEM_INITIALIZER(eth_enc28j60_0_runtime.tx_rx_sem,
 					1,  UINT_MAX),
 	.int_sem  = Z_SEM_INITIALIZER(eth_enc28j60_0_runtime.int_sem,
@@ -815,21 +817,21 @@ static struct eth_enc28j60_runtime eth_enc28j60_0_runtime = {
 };
 
 static const struct eth_enc28j60_config eth_enc28j60_0_config = {
-	.gpio_port = DT_INST_0_MICROCHIP_ENC28J60_INT_GPIOS_CONTROLLER,
-	.gpio_pin = DT_INST_0_MICROCHIP_ENC28J60_INT_GPIOS_PIN,
-	.gpio_flags = DT_INST_0_MICROCHIP_ENC28J60_INT_GPIOS_FLAGS,
-	.spi_port = DT_INST_0_MICROCHIP_ENC28J60_BUS_NAME,
-	.spi_freq  = DT_INST_0_MICROCHIP_ENC28J60_SPI_MAX_FREQUENCY,
-	.spi_slave = DT_INST_0_MICROCHIP_ENC28J60_BASE_ADDRESS,
+	.gpio_port = DT_INST_GPIO_LABEL(0, int_gpios),
+	.gpio_pin = DT_INST_GPIO_PIN(0, int_gpios),
+	.gpio_flags = DT_INST_GPIO_FLAGS(0, int_gpios),
+	.spi_port = DT_INST_BUS_LABEL(0),
+	.spi_freq  = DT_INST_PROP(0, spi_max_frequency),
+	.spi_slave = DT_INST_REG_ADDR(0),
 #ifdef CONFIG_ETH_ENC28J60_0_GPIO_SPI_CS
-	.spi_cs_port = DT_INST_0_MICROCHIP_ENC28J60_CS_GPIOS_CONTROLLER,
-	.spi_cs_pin = DT_INST_0_MICROCHIP_ENC28J60_CS_GPIOS_PIN,
+	.spi_cs_port = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
+	.spi_cs_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
 #endif /* CONFIG_ETH_ENC28J60_0_GPIO_SPI_CS */
 	.full_duplex = IS_ENABLED(CONFIG_ETH_ENC28J60_0_FULL_DUPLEX),
 	.timeout = CONFIG_ETH_ENC28J60_TIMEOUT,
 };
 
-ETH_NET_DEVICE_INIT(enc28j60_0, DT_INST_0_MICROCHIP_ENC28J60_LABEL,
+ETH_NET_DEVICE_INIT(enc28j60_0, DT_INST_LABEL(0),
 		    eth_enc28j60_init, device_pm_control_nop,
 		    &eth_enc28j60_0_runtime, &eth_enc28j60_0_config,
 		    CONFIG_ETH_INIT_PRIORITY, &api_funcs, NET_ETH_MTU);

--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT microchip_enc424j600
+
 #include <zephyr.h>
 #include <device.h>
 #include <string.h>
@@ -752,20 +754,20 @@ static struct enc424j600_runtime enc424j600_0_runtime = {
 };
 
 static const struct enc424j600_config enc424j600_0_config = {
-	.gpio_port = DT_INST_0_MICROCHIP_ENC424J600_INT_GPIOS_CONTROLLER,
-	.gpio_pin = DT_INST_0_MICROCHIP_ENC424J600_INT_GPIOS_PIN,
-	.gpio_flags = DT_INST_0_MICROCHIP_ENC424J600_INT_GPIOS_FLAGS,
-	.spi_port = DT_INST_0_MICROCHIP_ENC424J600_BUS_NAME,
-	.spi_freq  = DT_INST_0_MICROCHIP_ENC424J600_SPI_MAX_FREQUENCY,
-	.spi_slave = DT_INST_0_MICROCHIP_ENC424J600_BASE_ADDRESS,
+	.gpio_port = DT_INST_GPIO_LABEL(0, int_gpios),
+	.gpio_pin = DT_INST_GPIO_PIN(0, int_gpios),
+	.gpio_flags = DT_INST_GPIO_FLAGS(0, int_gpios),
+	.spi_port = DT_INST_BUS_LABEL(0),
+	.spi_freq  = DT_INST_PROP(0, spi_max_frequency),
+	.spi_slave = DT_INST_REG_ADDR(0),
 #ifdef CONFIG_ETH_ENC424J600_0_GPIO_SPI_CS
-	.spi_cs_port = DT_INST_0_MICROCHIP_ENC424J600_CS_GPIOS_CONTROLLER,
-	.spi_cs_pin = DT_INST_0_MICROCHIP_ENC424J600_CS_GPIOS_PIN,
+	.spi_cs_port = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
+	.spi_cs_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
 #endif /* CONFIG_ETH_ENC424J600_0_GPIO_SPI_CS */
 	.timeout = CONFIG_ETH_ENC424J600_TIMEOUT,
 };
 
-ETH_NET_DEVICE_INIT(enc424j600_0, DT_INST_0_MICROCHIP_ENC424J600_LABEL,
+ETH_NET_DEVICE_INIT(enc424j600_0, DT_INST_LABEL(0),
 		    enc424j600_init, device_pm_control_nop,
 		    &enc424j600_0_runtime, &enc424j600_0_config,
 		    CONFIG_ETH_INIT_PRIORITY, &api_funcs, NET_ETH_MTU);

--- a/drivers/ethernet/eth_liteeth.c
+++ b/drivers/ethernet/eth_liteeth.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT litex_eth0
+
 #define LOG_MODULE_NAME eth_liteeth
 #define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
 
@@ -25,21 +27,21 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define LITEETH_EV_RX		0x1
 
 /* slots */
-#define LITEETH_SLOT_BASE	DT_INST_0_LITEX_ETH0_BUFFERS_BASE_ADDRESS
+#define LITEETH_SLOT_BASE	DT_INST_REG_ADDR_BY_NAME(0, buffers)
 #define LITEETH_SLOT_RX0	((LITEETH_SLOT_BASE) + 0x0000)
 #define LITEETH_SLOT_RX1	((LITEETH_SLOT_BASE) + 0x0800)
 #define LITEETH_SLOT_TX0	((LITEETH_SLOT_BASE) + 0x1000)
 #define LITEETH_SLOT_TX1	((LITEETH_SLOT_BASE) + 0x1800)
 
 /* sram - rx */
-#define LITEETH_RX_BASE		DT_INST_0_LITEX_ETH0_CONTROL_BASE_ADDRESS
+#define LITEETH_RX_BASE		DT_INST_REG_ADDR_BY_NAME(0, control)
 #define LITEETH_RX_SLOT		((LITEETH_RX_BASE) + 0x00)
 #define LITEETH_RX_LENGTH	((LITEETH_RX_BASE) + 0x04)
 #define LITEETH_RX_EV_PENDING	((LITEETH_RX_BASE) + 0x28)
 #define LITEETH_RX_EV_ENABLE	((LITEETH_RX_BASE) + 0x2c)
 
 /* sram - tx */
-#define LITEETH_TX_BASE		((DT_INST_0_LITEX_ETH0_CONTROL_BASE_ADDRESS) + 0x30)
+#define LITEETH_TX_BASE		((DT_INST_REG_ADDR_BY_NAME(0, control)) + 0x30)
 #define LITEETH_TX_START	((LITEETH_TX_BASE) + 0x00)
 #define LITEETH_TX_READY	((LITEETH_TX_BASE) + 0x04)
 #define LITEETH_TX_SLOT		((LITEETH_TX_BASE) + 0x0c)
@@ -47,11 +49,11 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define LITEETH_TX_EV_PENDING	((LITEETH_TX_BASE) + 0x1c)
 
 /* irq */
-#define LITEETH_IRQ		DT_INST_0_LITEX_ETH0_IRQ_0
+#define LITEETH_IRQ		DT_INST_IRQN(0)
 #define LITEETH_IRQ_PRIORITY	CONFIG_ETH_LITEETH_0_IRQ_PRI
 
 /* label */
-#define LITEETH_LABEL		DT_INST_0_LITEX_ETH0_LABEL
+#define LITEETH_LABEL		DT_INST_LABEL(0)
 
 struct eth_liteeth_dev_data {
 	struct net_if *iface;
@@ -190,7 +192,7 @@ static void generate_mac(u8_t *mac_addr)
 #ifdef CONFIG_ETH_LITEETH_0
 
 static struct eth_liteeth_dev_data eth_data = {
-	.mac_addr =  DT_INST_0_LITEX_ETH0_LOCAL_MAC_ADDRESS
+	.mac_addr =  DT_INST_PROP(0, local_mac_address)
 };
 
 static void eth_irq_config(void);

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -7,6 +7,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT nxp_kinetis_ethernet
+
 /* Driver Limitations:
  *
  * There is no statistics collection for either normal operation or
@@ -1198,7 +1200,7 @@ static void eth_0_config_func(void);
 static struct eth_context eth_0_context = {
 	.base = ENET,
 #if defined(CONFIG_NET_POWER_MANAGEMENT)
-	.clock_name = DT_INST_0_NXP_KINETIS_ETHERNET_CLOCK_CONTROLLER,
+	.clock_name = DT_INST_CLOCKS_LABEL(0),
 	.clock = kCLOCK_Enet0,
 #endif
 	.config_func = eth_0_config_func,
@@ -1260,7 +1262,7 @@ static void eth_1_config_func(void);
 static struct eth_context eth_1_context = {
 	.base = ENET2,
 #if defined(CONFIG_NET_POWER_MANAGEMENT)
-	.clock_name = DT_INST_1_NXP_KINETIS_ETHERNET_CLOCK_CONTROLLER,
+	.clock_name = DT_INST_CLOCKS_LABEL(1),
 	.clock = kCLOCK_Enet2,
 #endif
 	.config_func = eth_1_config_func,

--- a/drivers/ethernet/eth_smsc911x.c
+++ b/drivers/ethernet/eth_smsc911x.c
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT smsc_lan9220
+
 /* SMSC911x/SMSC9220 driver. Partly based on mbedOS driver. */
 
 #define LOG_MODULE_NAME eth_smsc911x
@@ -659,8 +661,8 @@ static struct device DEVICE_NAME_GET(eth_smsc911x_0);
 
 int eth_init(struct device *dev)
 {
-	IRQ_CONNECT(DT_INST_0_SMSC_LAN9220_IRQ_0,
-		    DT_INST_0_SMSC_LAN9220_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		    DT_INST_IRQ(0, priority),
 		    eth_smsc911x_isr, DEVICE_GET(eth_smsc911x_0), 0);
 
 	int ret = smsc_init();
@@ -670,7 +672,7 @@ int eth_init(struct device *dev)
 		return -ENODEV;
 	}
 
-	irq_enable(DT_INST_0_SMSC_LAN9220_IRQ_0);
+	irq_enable(DT_INST_IRQN(0));
 
 	return ret;
 }

--- a/drivers/ethernet/eth_smsc911x_priv.h
+++ b/drivers/ethernet/eth_smsc911x_priv.h
@@ -176,7 +176,7 @@ __IO	uint32_t  E2P_DATA;
 #define SMSC9220_PHY_CS         31
 
 #ifndef SMSC9220_BASE
-#define SMSC9220_BASE           DT_INST_0_SMSC_LAN9220_BASE_ADDRESS
+#define SMSC9220_BASE           DT_INST_REG_ADDR(0)
 #endif
 
 #define SMSC9220                ((volatile SMSC9220_TypeDef *)SMSC9220_BASE)


### PR DESCRIPTION
Convert older DT_INST_ macro use the new include/devicetree.h
DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>