### PR TITLE
drivers: audio: tlv320dac310x: Convert to new DT_INST macros

### DIFF
--- a/drivers/audio/tlv320dac310x.c
+++ b/drivers/audio/tlv320dac310x.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT ti_tlv320dac
+
 #include <errno.h>
 
 #include <sys/util.h>
@@ -38,12 +40,12 @@ struct codec_driver_data {
 
 static struct codec_driver_config codec_device_config = {
 	.i2c_device	= NULL,
-	.i2c_dev_name	= DT_INST_0_TI_TLV320DAC_BUS_NAME,
-	.i2c_address	= DT_INST_0_TI_TLV320DAC_BASE_ADDRESS,
+	.i2c_dev_name	= DT_INST_BUS_LABEL(0),
+	.i2c_address	= DT_INST_REG_ADDR(0),
 	.gpio_device	= NULL,
-	.gpio_dev_name	= DT_INST_0_TI_TLV320DAC_RESET_GPIOS_CONTROLLER,
-	.gpio_pin	= DT_INST_0_TI_TLV320DAC_RESET_GPIOS_PIN,
-	.gpio_flags	= DT_INST_0_TI_TLV320DAC_RESET_GPIOS_FLAGS,
+	.gpio_dev_name	= DT_INST_GPIO_LABEL(0, reset_gpios),
+	.gpio_pin	= DT_INST_GPIO_PIN(0, reset_gpios),
+	.gpio_flags	= DT_INST_GPIO_FLAGS(0, reset_gpios),
 };
 
 static struct codec_driver_data codec_device_data;
@@ -534,6 +536,6 @@ static const struct audio_codec_api codec_driver_api = {
 	.apply_properties	= codec_apply_properties,
 };
 
-DEVICE_AND_API_INIT(tlv320dac310x, DT_INST_0_TI_TLV320DAC_LABEL, codec_initialize,
+DEVICE_AND_API_INIT(tlv320dac310x, DT_INST_LABEL(0), codec_initialize,
 		&codec_device_data, &codec_device_config, POST_KERNEL,
 		CONFIG_AUDIO_CODEC_INIT_PRIORITY, &codec_driver_api);


### PR DESCRIPTION
Convert older DT_INST_ macro use the new include/devicetree.h
DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>