### PR TITLE
drivers: led: Convert to new DT_INST macros

### DIFF
--- a/drivers/led/lp3943.c
+++ b/drivers/led/lp3943.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT ti_lp3943
+
 /**
  * @file
  * @brief LP3943 LED driver
@@ -107,7 +109,7 @@ static int lp3943_set_dim_states(struct lp3943_data *data, u32_t led, u8_t mode)
 	}
 
 	/* Set DIMx states for the LEDs */
-	if (i2c_reg_update_byte(data->i2c, DT_INST_0_TI_LP3943_BASE_ADDRESS,
+	if (i2c_reg_update_byte(data->i2c, DT_INST_REG_ADDR(0),
 				reg,
 				LP3943_MASK << (led << 1),
 				mode << (led << 1))) {
@@ -147,7 +149,7 @@ static int lp3943_led_blink(struct device *dev, u32_t led,
 	}
 
 	val = (period * 255U) / dev_data->max_period;
-	if (i2c_reg_write_byte(data->i2c, DT_INST_0_TI_LP3943_BASE_ADDRESS,
+	if (i2c_reg_write_byte(data->i2c, DT_INST_REG_ADDR(0),
 			       reg, val)) {
 		LOG_ERR("LED write failed");
 		return -EIO;
@@ -188,7 +190,7 @@ static int lp3943_led_set_brightness(struct device *dev, u32_t led,
 	}
 
 	val = (value * 255U) / dev_data->max_brightness;
-	if (i2c_reg_write_byte(data->i2c, DT_INST_0_TI_LP3943_BASE_ADDRESS,
+	if (i2c_reg_write_byte(data->i2c, DT_INST_REG_ADDR(0),
 			       reg, val)) {
 		LOG_ERR("LED write failed");
 		return -EIO;
@@ -215,7 +217,7 @@ static inline int lp3943_led_on(struct device *dev, u32_t led)
 
 	/* Set LED state to ON */
 	mode = LP3943_ON;
-	if (i2c_reg_update_byte(data->i2c, DT_INST_0_TI_LP3943_BASE_ADDRESS,
+	if (i2c_reg_update_byte(data->i2c, DT_INST_REG_ADDR(0),
 				reg,
 				LP3943_MASK << (led << 1),
 				mode << (led << 1))) {
@@ -238,7 +240,7 @@ static inline int lp3943_led_off(struct device *dev, u32_t led)
 	}
 
 	/* Set LED state to OFF */
-	if (i2c_reg_update_byte(data->i2c, DT_INST_0_TI_LP3943_BASE_ADDRESS,
+	if (i2c_reg_update_byte(data->i2c, DT_INST_REG_ADDR(0),
 				reg,
 				LP3943_MASK << (led << 1), 0)) {
 		LOG_ERR("LED reg update failed");
@@ -253,7 +255,7 @@ static int lp3943_led_init(struct device *dev)
 	struct lp3943_data *data = dev->driver_data;
 	struct led_data *dev_data = &data->dev_data;
 
-	data->i2c = device_get_binding(DT_INST_0_TI_LP3943_BUS_NAME);
+	data->i2c = device_get_binding(DT_INST_BUS_LABEL(0));
 	if (data->i2c == NULL) {
 		LOG_DBG("Failed to get I2C device");
 		return -EINVAL;
@@ -277,7 +279,7 @@ static const struct led_driver_api lp3943_led_api = {
 	.off = lp3943_led_off,
 };
 
-DEVICE_AND_API_INIT(lp3943_led, DT_INST_0_TI_LP3943_LABEL,
+DEVICE_AND_API_INIT(lp3943_led, DT_INST_LABEL(0),
 		    &lp3943_led_init, &lp3943_led_data,
 		    NULL, POST_KERNEL, CONFIG_LED_INIT_PRIORITY,
 		    &lp3943_led_api);

--- a/drivers/led/lp5562.c
+++ b/drivers/led/lp5562.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT ti_lp5562
+
 /**
  * @file
  * @brief LP5562 LED driver
@@ -307,7 +309,7 @@ static int lp5562_set_led_source(struct device *dev,
 {
 	struct lp5562_data *data = dev->driver_data;
 
-	if (i2c_reg_update_byte(data->i2c, DT_INST_0_TI_LP5562_BASE_ADDRESS,
+	if (i2c_reg_update_byte(data->i2c, DT_INST_REG_ADDR(0),
 				LP5562_LED_MAP,
 				LP5562_CHANNEL_MASK(channel),
 				source << (channel << 1))) {
@@ -335,7 +337,7 @@ static int lp5562_get_led_source(struct device *dev,
 	struct lp5562_data *data = dev->driver_data;
 	u8_t led_map;
 
-	if (i2c_reg_read_byte(data->i2c, DT_INST_0_TI_LP5562_BASE_ADDRESS,
+	if (i2c_reg_read_byte(data->i2c, DT_INST_REG_ADDR(0),
 			      LP5562_LED_MAP, &led_map)) {
 		return -EIO;
 	}
@@ -368,7 +370,7 @@ static bool lp5562_is_engine_executing(struct device *dev,
 		return false;
 	}
 
-	if (i2c_reg_read_byte(data->i2c, DT_INST_0_TI_LP5562_BASE_ADDRESS,
+	if (i2c_reg_read_byte(data->i2c, DT_INST_REG_ADDR(0),
 				LP5562_ENABLE, &enabled)) {
 		LOG_ERR("Failed to read ENABLE register.");
 		return false;
@@ -434,7 +436,7 @@ static int lp5562_set_engine_reg(struct device *dev,
 		return ret;
 	}
 
-	if (i2c_reg_update_byte(data->i2c, DT_INST_0_TI_LP5562_BASE_ADDRESS,
+	if (i2c_reg_update_byte(data->i2c, DT_INST_REG_ADDR(0),
 				   reg,
 				   LP5562_MASK << shift,
 				   val << shift)) {
@@ -562,14 +564,14 @@ static int lp5562_program_command(struct device *dev,
 		return ret;
 	}
 
-	if (i2c_reg_write_byte(data->i2c, DT_INST_0_TI_LP5562_BASE_ADDRESS,
+	if (i2c_reg_write_byte(data->i2c, DT_INST_REG_ADDR(0),
 			       prog_base_addr + (command_index << 1),
 			       command_msb)) {
 		LOG_ERR("Failed to update LED.");
 		return -EIO;
 	}
 
-	if (i2c_reg_write_byte(data->i2c, DT_INST_0_TI_LP5562_BASE_ADDRESS,
+	if (i2c_reg_write_byte(data->i2c, DT_INST_REG_ADDR(0),
 			       prog_base_addr + (command_index << 1) + 1,
 			       command_lsb)) {
 		LOG_ERR("Failed to update LED.");
@@ -854,7 +856,7 @@ static int lp5562_led_set_brightness(struct device *dev, u32_t led, u8_t value)
 		return ret;
 	}
 
-	if (i2c_reg_write_byte(data->i2c, DT_INST_0_TI_LP5562_BASE_ADDRESS,
+	if (i2c_reg_write_byte(data->i2c, DT_INST_REG_ADDR(0),
 			       reg, val)) {
 		LOG_ERR("LED write failed");
 		return -EIO;
@@ -899,7 +901,7 @@ static int lp5562_led_init(struct device *dev)
 	struct lp5562_data *data = dev->driver_data;
 	struct led_data *dev_data = &data->dev_data;
 
-	data->i2c = device_get_binding(DT_INST_0_TI_LP5562_BUS_NAME);
+	data->i2c = device_get_binding(DT_INST_BUS_LABEL(0));
 	if (data->i2c == NULL) {
 		LOG_ERR("Failed to get I2C device");
 		return -EINVAL;
@@ -911,14 +913,14 @@ static int lp5562_led_init(struct device *dev)
 	dev_data->min_brightness = LP5562_MIN_BRIGHTNESS;
 	dev_data->max_brightness = LP5562_MAX_BRIGHTNESS;
 
-	if (i2c_reg_write_byte(data->i2c, DT_INST_0_TI_LP5562_BASE_ADDRESS,
+	if (i2c_reg_write_byte(data->i2c, DT_INST_REG_ADDR(0),
 				LP5562_ENABLE,
 				LP5562_ENABLE_CHIP_EN)) {
 		LOG_ERR("Enabling LP5562 LED chip failed.");
 		return -EIO;
 	}
 
-	if (i2c_reg_write_byte(data->i2c, DT_INST_0_TI_LP5562_BASE_ADDRESS,
+	if (i2c_reg_write_byte(data->i2c, DT_INST_REG_ADDR(0),
 				LP5562_CONFIG,
 				(LP5562_CONFIG_INTERNAL_CLOCK |
 				 LP5562_CONFIG_PWRSAVE_EN))) {
@@ -926,13 +928,13 @@ static int lp5562_led_init(struct device *dev)
 		return -EIO;
 	}
 
-	if (i2c_reg_write_byte(data->i2c, DT_INST_0_TI_LP5562_BASE_ADDRESS,
+	if (i2c_reg_write_byte(data->i2c, DT_INST_REG_ADDR(0),
 				LP5562_OP_MODE, 0x00)) {
 		LOG_ERR("Disabling all engines failed.");
 		return -EIO;
 	}
 
-	if (i2c_reg_write_byte(data->i2c, DT_INST_0_TI_LP5562_BASE_ADDRESS,
+	if (i2c_reg_write_byte(data->i2c, DT_INST_REG_ADDR(0),
 				LP5562_LED_MAP, 0x00)) {
 		LOG_ERR("Setting all LEDs to manual control failed.");
 		return -EIO;
@@ -950,7 +952,7 @@ static const struct led_driver_api lp5562_led_api = {
 	.off = lp5562_led_off,
 };
 
-DEVICE_AND_API_INIT(lp5562_led, DT_INST_0_TI_LP5562_LABEL,
+DEVICE_AND_API_INIT(lp5562_led, DT_INST_LABEL(0),
 		&lp5562_led_init, &lp5562_led_data,
 		NULL, POST_KERNEL, CONFIG_LED_INIT_PRIORITY,
 		&lp5562_led_api);

--- a/drivers/led/pca9633.c
+++ b/drivers/led/pca9633.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT nxp_pca9633
+
 /**
  * @file
  * @brief LED driver for the PCA9633 I2C LED driver (7-bit slave address 0x62)
@@ -65,7 +67,7 @@ static int pca9633_led_blink(struct device *dev, u32_t led,
 	 *		GDC = ((time_on * 256) / period)
 	 */
 	gdc = delay_on * 256U / period;
-	if (i2c_reg_write_byte(data->i2c, DT_INST_0_NXP_PCA9633_BASE_ADDRESS,
+	if (i2c_reg_write_byte(data->i2c, DT_INST_REG_ADDR(0),
 			       PCA9633_GRPPWM,
 			       gdc)) {
 		LOG_ERR("LED reg write failed");
@@ -79,7 +81,7 @@ static int pca9633_led_blink(struct device *dev, u32_t led,
 	 *		GFRQ = ((period * 24 / 1000) - 1)
 	 */
 	gfrq = (period * 24U / 1000) - 1;
-	if (i2c_reg_write_byte(data->i2c, DT_INST_0_NXP_PCA9633_BASE_ADDRESS,
+	if (i2c_reg_write_byte(data->i2c, DT_INST_REG_ADDR(0),
 			       PCA9633_GRPFREQ,
 			       gfrq)) {
 		LOG_ERR("LED reg write failed");
@@ -87,7 +89,7 @@ static int pca9633_led_blink(struct device *dev, u32_t led,
 	}
 
 	/* Enable blinking mode */
-	if (i2c_reg_update_byte(data->i2c, DT_INST_0_NXP_PCA9633_BASE_ADDRESS,
+	if (i2c_reg_update_byte(data->i2c, DT_INST_REG_ADDR(0),
 				PCA9633_MODE2,
 				PCA9633_MODE2_DMBLNK,
 				PCA9633_MODE2_DMBLNK)) {
@@ -96,7 +98,7 @@ static int pca9633_led_blink(struct device *dev, u32_t led,
 	}
 
 	/* Select the GRPPWM source to drive the LED outpout */
-	if (i2c_reg_update_byte(data->i2c, DT_INST_0_NXP_PCA9633_BASE_ADDRESS,
+	if (i2c_reg_update_byte(data->i2c, DT_INST_REG_ADDR(0),
 				PCA9633_LEDOUT,
 				PCA9633_MASK << (led << 1),
 				PCA9633_LED_GRP_PWM << (led << 1))) {
@@ -121,7 +123,7 @@ static int pca9633_led_set_brightness(struct device *dev, u32_t led,
 
 	/* Set the LED brightness value */
 	val = (value * 255U) / dev_data->max_brightness;
-	if (i2c_reg_write_byte(data->i2c, DT_INST_0_NXP_PCA9633_BASE_ADDRESS,
+	if (i2c_reg_write_byte(data->i2c, DT_INST_REG_ADDR(0),
 			       PCA9633_PWM_BASE + led,
 			       val)) {
 		LOG_ERR("LED reg write failed");
@@ -129,7 +131,7 @@ static int pca9633_led_set_brightness(struct device *dev, u32_t led,
 	}
 
 	/* Set the LED driver to be controlled through its PWMx register. */
-	if (i2c_reg_update_byte(data->i2c, DT_INST_0_NXP_PCA9633_BASE_ADDRESS,
+	if (i2c_reg_update_byte(data->i2c, DT_INST_REG_ADDR(0),
 				PCA9633_LEDOUT,
 				PCA9633_MASK << (led << 1),
 				PCA9633_LED_PWM << (led << 1))) {
@@ -145,7 +147,7 @@ static inline int pca9633_led_on(struct device *dev, u32_t led)
 	struct pca9633_data *data = dev->driver_data;
 
 	/* Set LED state to ON */
-	if (i2c_reg_update_byte(data->i2c, DT_INST_0_NXP_PCA9633_BASE_ADDRESS,
+	if (i2c_reg_update_byte(data->i2c, DT_INST_REG_ADDR(0),
 				PCA9633_LEDOUT,
 				PCA9633_MASK << (led << 1),
 				PCA9633_LED_ON << (led << 1))) {
@@ -161,7 +163,7 @@ static inline int pca9633_led_off(struct device *dev, u32_t led)
 	struct pca9633_data *data = dev->driver_data;
 
 	/* Set LED state to OFF */
-	if (i2c_reg_update_byte(data->i2c, DT_INST_0_NXP_PCA9633_BASE_ADDRESS,
+	if (i2c_reg_update_byte(data->i2c, DT_INST_REG_ADDR(0),
 				PCA9633_LEDOUT,
 				PCA9633_MASK << (led << 1),
 				PCA9633_LED_OFF)) {
@@ -177,7 +179,7 @@ static int pca9633_led_init(struct device *dev)
 	struct pca9633_data *data = dev->driver_data;
 	struct led_data *dev_data = &data->dev_data;
 
-	data->i2c = device_get_binding(DT_INST_0_NXP_PCA9633_BUS_NAME);
+	data->i2c = device_get_binding(DT_INST_BUS_LABEL(0));
 	if (data->i2c == NULL) {
 		LOG_DBG("Failed to get I2C device");
 		return -EINVAL;
@@ -201,7 +203,7 @@ static const struct led_driver_api pca9633_led_api = {
 	.off = pca9633_led_off,
 };
 
-DEVICE_AND_API_INIT(pca9633_led, DT_INST_0_NXP_PCA9633_LABEL,
+DEVICE_AND_API_INIT(pca9633_led, DT_INST_LABEL(0),
 		    &pca9633_led_init, &pca9633_led_data,
 		    NULL, POST_KERNEL, CONFIG_LED_INIT_PRIORITY,
 		    &pca9633_led_api);


### PR DESCRIPTION
Convert older DT_INST_ macro use the new include/devicetree.h
DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>