### PR TITLE
Bluetooth: host: Fix unneeded warning about failure to remove IRK.

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1700,14 +1700,14 @@ static void slave_update_conn_param(struct bt_conn *conn)
 #if defined(CONFIG_BT_SMP)
 static void pending_id_update(struct bt_keys *keys, void *data)
 {
-	if (keys->flags & BT_KEYS_ID_PENDING_ADD) {
-		keys->flags &= ~BT_KEYS_ID_PENDING_ADD;
+	if (keys->state & BT_KEYS_ID_PENDING_ADD) {
+		keys->state &= ~BT_KEYS_ID_PENDING_ADD;
 		bt_id_add(keys);
 		return;
 	}
 
-	if (keys->flags & BT_KEYS_ID_PENDING_DEL) {
-		keys->flags &= ~BT_KEYS_ID_PENDING_DEL;
+	if (keys->state & BT_KEYS_ID_PENDING_DEL) {
+		keys->state &= ~BT_KEYS_ID_PENDING_DEL;
 		bt_id_del(keys);
 		return;
 	}
@@ -1716,7 +1716,7 @@ static void pending_id_update(struct bt_keys *keys, void *data)
 static void pending_id_keys_update_set(struct bt_keys *keys, u8_t flag)
 {
 	atomic_set_bit(bt_dev.flags, BT_DEV_ID_PENDING);
-	keys->flags |= flag;
+	keys->state |= flag;
 }
 
 static void pending_id_keys_update(void)

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -236,8 +236,7 @@ void bt_keys_clear(struct bt_keys *keys)
 {
 	BT_DBG("%s (keys 0x%04x)", bt_addr_le_str(&keys->addr), keys->keys);
 
-	if ((IS_ENABLED(CONFIG_BT_CENTRAL) && IS_ENABLED(CONFIG_BT_PRIVACY)) ||
-	    keys->keys & BT_KEYS_IRK) {
+	if (keys->state & BT_KEYS_ID_ADDED) {
 		bt_id_del(keys);
 	}
 

--- a/subsys/bluetooth/host/keys.h
+++ b/subsys/bluetooth/host/keys.h
@@ -33,40 +33,40 @@ enum {
 };
 
 struct bt_ltk {
-	u8_t			rand[8];
-	u8_t			ediv[2];
-	u8_t			val[16];
+	u8_t                    rand[8];
+	u8_t                    ediv[2];
+	u8_t                    val[16];
 };
 
 struct bt_irk {
-	u8_t			val[16];
-	bt_addr_t		rpa;
+	u8_t                    val[16];
+	bt_addr_t               rpa;
 };
 
 struct bt_csrk {
-	u8_t			val[16];
-	u32_t			cnt;
+	u8_t                    val[16];
+	u32_t                   cnt;
 };
 
 struct bt_keys {
 	u8_t                    id;
-	bt_addr_le_t		addr;
+	bt_addr_le_t            addr;
 	u8_t                    state;
 	u8_t                    storage_start[0] __aligned(sizeof(void *));
-	u8_t			enc_size;
+	u8_t                    enc_size;
 	u8_t                    flags;
-	u16_t			keys;
-	struct bt_ltk		ltk;
-	struct bt_irk		irk;
+	u16_t                   keys;
+	struct bt_ltk           ltk;
+	struct bt_irk           irk;
 #if defined(CONFIG_BT_SIGNING)
-	struct bt_csrk		local_csrk;
-	struct bt_csrk		remote_csrk;
+	struct bt_csrk          local_csrk;
+	struct bt_csrk          remote_csrk;
 #endif /* BT_SIGNING */
 #if !defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
-	struct bt_ltk		slave_ltk;
+	struct bt_ltk           slave_ltk;
 #endif /* CONFIG_BT_SMP_SC_PAIR_ONLY */
 #if (defined(CONFIG_BT_KEYS_OVERWRITE_OLDEST))
-	u32_t			aging_counter;
+	u32_t                   aging_counter;
 #endif /* CONFIG_BT_KEYS_OVERWRITE_OLDEST */
 };
 
@@ -101,9 +101,9 @@ enum {
 };
 
 struct bt_keys_link_key {
-	bt_addr_t		addr;
+	bt_addr_t               addr;
 	u8_t                    flags;
-	u8_t			val[16];
+	u8_t                    val[16];
 };
 
 struct bt_keys_link_key *bt_keys_get_link_key(const bt_addr_t *addr);

--- a/subsys/bluetooth/host/keys.h
+++ b/subsys/bluetooth/host/keys.h
@@ -20,10 +20,14 @@ enum {
 };
 
 enum {
+	BT_KEYS_ID_PENDING_ADD  = BIT(0),
+	BT_KEYS_ID_PENDING_DEL  = BIT(1),
+};
+
+enum {
 	BT_KEYS_AUTHENTICATED   = BIT(0),
 	BT_KEYS_DEBUG           = BIT(1),
-	BT_KEYS_ID_PENDING_ADD  = BIT(2),
-	BT_KEYS_ID_PENDING_DEL  = BIT(3),
+	/* Bit 2 and 3 might accidentally exist in old stored keys */
 	BT_KEYS_SC              = BIT(4),
 };
 
@@ -46,7 +50,8 @@ struct bt_csrk {
 struct bt_keys {
 	u8_t                    id;
 	bt_addr_le_t		addr;
-	u8_t                    storage_start[0];
+	u8_t                    state;
+	u8_t                    storage_start[0] __aligned(sizeof(void *));
 	u8_t			enc_size;
 	u8_t                    flags;
 	u16_t			keys;

--- a/subsys/bluetooth/host/keys.h
+++ b/subsys/bluetooth/host/keys.h
@@ -22,6 +22,7 @@ enum {
 enum {
 	BT_KEYS_ID_PENDING_ADD  = BIT(0),
 	BT_KEYS_ID_PENDING_DEL  = BIT(1),
+	BT_KEYS_ID_ADDED        = BIT(2),
 };
 
 enum {


### PR DESCRIPTION
Fix warning "Failed to add IRK to controller" during pairing procedure.

Move runtime keys flag out of the key storage area.