### PR TITLE
drivers: led_strip: Convert to new DT_INST macros

### DIFF
--- a/drivers/led_strip/apa102.c
+++ b/drivers/led_strip/apa102.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT apa_apa102
+
 #include <errno.h>
 #include <drivers/led_strip.h>
 #include <drivers/spi.h>
@@ -81,13 +83,13 @@ static int apa102_init(struct device *dev)
 {
 	struct apa102_data *data = dev->driver_data;
 
-	data->spi = device_get_binding(DT_INST_0_APA_APA102_BUS_NAME);
+	data->spi = device_get_binding(DT_INST_BUS_LABEL(0));
 	if (!data->spi) {
 		return -ENODEV;
 	}
 
-	data->cfg.slave = DT_INST_0_APA_APA102_BASE_ADDRESS;
-	data->cfg.frequency = DT_INST_0_APA_APA102_SPI_MAX_FREQUENCY;
+	data->cfg.slave = DT_INST_REG_ADDR(0);
+	data->cfg.frequency = DT_INST_PROP(0, spi_max_frequency);
 	data->cfg.operation =
 		SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8);
 
@@ -101,6 +103,6 @@ static const struct led_strip_driver_api apa102_api = {
 	.update_channels = apa102_update_channels,
 };
 
-DEVICE_AND_API_INIT(apa102_0, DT_INST_0_APA_APA102_LABEL, apa102_init,
+DEVICE_AND_API_INIT(apa102_0, DT_INST_LABEL(0), apa102_init,
 		    &apa102_data_0, NULL, POST_KERNEL,
 		    CONFIG_LED_STRIP_INIT_PRIORITY, &apa102_api);

--- a/drivers/led_strip/lpd880x.c
+++ b/drivers/led_strip/lpd880x.c
@@ -9,18 +9,10 @@
 #include <errno.h>
 #include <string.h>
 
-#ifdef DT_INST_0_COLORWAY_LPD8806
-#define DT_INST_0_COLORWAY_LPD880X DT_INST_0_COLORWAY_LPD8806
-#define DT_INST_0_COLORWAY_LPD880X_BASE_ADDRESS DT_INST_0_COLORWAY_LPD8806_BASE_ADDRESS
-#define DT_INST_0_COLORWAY_LPD880X_BUS_NAME DT_INST_0_COLORWAY_LPD8806_BUS_NAME
-#define DT_INST_0_COLORWAY_LPD880X_LABEL DT_INST_0_COLORWAY_LPD8806_LABEL
-#define DT_INST_0_COLORWAY_LPD880X_SPI_MAX_FREQUENCY DT_INST_0_COLORWAY_LPD8806_SPI_MAX_FREQUENCY
+#if DT_HAS_NODE(DT_INST(0, colorway_lpd8806))
+#define DT_DRV_COMPAT colorway_lpd8806
 #else
-#define DT_INST_0_COLORWAY_LPD880X DT_INST_0_COLORWAY_LPD8803
-#define DT_INST_0_COLORWAY_LPD880X_BASE_ADDRESS DT_INST_0_COLORWAY_LPD8803_BASE_ADDRESS
-#define DT_INST_0_COLORWAY_LPD880X_BUS_NAME DT_INST_0_COLORWAY_LPD8803_BUS_NAME
-#define DT_INST_0_COLORWAY_LPD880X_LABEL DT_INST_0_COLORWAY_LPD8803_LABEL
-#define DT_INST_0_COLORWAY_LPD880X_SPI_MAX_FREQUENCY DT_INST_0_COLORWAY_LPD8803_SPI_MAX_FREQUENCY
+#define DT_DRV_COMPAT colorway_lpd8803
 #endif
 
 #define LOG_LEVEL CONFIG_LED_STRIP_LOG_LEVEL
@@ -139,16 +131,16 @@ static int lpd880x_strip_init(struct device *dev)
 	struct lpd880x_data *data = dev->driver_data;
 	struct spi_config *config = &data->config;
 
-	data->spi = device_get_binding(DT_INST_0_COLORWAY_LPD880X_BUS_NAME);
+	data->spi = device_get_binding(DT_INST_BUS_LABEL(0));
 	if (!data->spi) {
 		LOG_ERR("SPI device %s not found",
-			    DT_INST_0_COLORWAY_LPD880X_BUS_NAME);
+			    DT_INST_BUS_LABEL(0));
 		return -ENODEV;
 	}
 
-	config->frequency = DT_INST_0_COLORWAY_LPD880X_SPI_MAX_FREQUENCY;
+	config->frequency = DT_INST_PROP(0, spi_max_frequency);
 	config->operation = LPD880X_SPI_OPERATION;
-	config->slave = DT_INST_0_COLORWAY_LPD880X_BASE_ADDRESS; /* MOSI/CLK only; CS is not supported. */
+	config->slave = DT_INST_REG_ADDR(0); /* MOSI/CLK only; CS is not supported. */
 	config->cs = NULL;
 
 	return 0;
@@ -161,7 +153,7 @@ static const struct led_strip_driver_api lpd880x_strip_api = {
 	.update_channels = lpd880x_strip_update_channels,
 };
 
-DEVICE_AND_API_INIT(lpd880x_strip, DT_INST_0_COLORWAY_LPD880X_LABEL,
+DEVICE_AND_API_INIT(lpd880x_strip, DT_INST_LABEL(0),
 		    lpd880x_strip_init, &lpd880x_strip_data,
 		    NULL, POST_KERNEL, CONFIG_LED_STRIP_INIT_PRIORITY,
 		    &lpd880x_strip_api);

--- a/drivers/led_strip/ws2812_gpio.c
+++ b/drivers/led_strip/ws2812_gpio.c
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT worldsemi_ws2812_gpio
+
 #include <drivers/led_strip.h>
 
 #include <string.h>
@@ -181,15 +183,15 @@ static const struct led_strip_driver_api ws2812_gpio_api = {
 };
 
 #define WS2812_GPIO_LABEL(idx) \
-	(DT_INST_##idx##_WORLDSEMI_WS2812_GPIO_LABEL)
+	(DT_INST_LABEL(idx))
 #define WS2812_GPIO_HAS_WHITE(idx) \
-	(DT_INST_##idx##_WORLDSEMI_WS2812_GPIO_HAS_WHITE_CHANNEL == 1)
+	(DT_INST_PROP(idx, has_white_channel) == 1)
 #define WS2812_GPIO_DEV(idx) \
-	(DT_INST_##idx##_WORLDSEMI_WS2812_GPIO_IN_GPIOS_CONTROLLER)
+	(DT_INST_GPIO_LABEL(idx, in_gpios))
 #define WS2812_GPIO_PIN(idx) \
-	(DT_INST_##idx##_WORLDSEMI_WS2812_GPIO_IN_GPIOS_PIN)
+	(DT_INST_GPIO_PIN(idx, in_gpios))
 #define WS2812_GPIO_FLAGS(idx) \
-	(DT_INST_##idx##_WORLDSEMI_WS2812_GPIO_IN_GPIOS_FLAGS)
+	(DT_INST_GPIO_FLAGS(idx, in_gpios))
 /*
  * The inline assembly above is designed to work on nRF51 devices with
  * the 16 MHz clock enabled.
@@ -238,10 +240,10 @@ static const struct led_strip_driver_api ws2812_gpio_api = {
 			    CONFIG_LED_STRIP_INIT_PRIORITY,		\
 			    &ws2812_gpio_api)
 
-#ifdef DT_INST_0_WORLDSEMI_WS2812_GPIO_LABEL
+#if DT_INST_NODE_HAS_PROP(0, label)
 WS2812_GPIO_DEVICE(0);
 #endif
 
-#ifdef DT_INST_1_WORLDSEMI_WS2812_GPIO_LABEL
+#if DT_INST_NODE_HAS_PROP(1, label)
 WS2812_GPIO_DEVICE(1);
 #endif

--- a/drivers/led_strip/ws2812_spi.c
+++ b/drivers/led_strip/ws2812_spi.c
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT worldsemi_ws2812_spi
+
 #include <drivers/led_strip.h>
 
 #include <string.h>
@@ -167,21 +169,21 @@ static const struct led_strip_driver_api ws2812_spi_api = {
 };
 
 #define WS2812_SPI_LABEL(idx) \
-	(DT_INST_##idx##_WORLDSEMI_WS2812_SPI_LABEL)
+	(DT_INST_LABEL(idx))
 #define WS2812_SPI_NUM_PIXELS(idx) \
-	(DT_INST_##idx##_WORLDSEMI_WS2812_SPI_CHAIN_LENGTH)
+	(DT_INST_PROP(idx, chain_length))
 #define WS2812_SPI_HAS_WHITE(idx) \
-	(DT_INST_##idx##_WORLDSEMI_WS2812_SPI_HAS_WHITE_CHANNEL == 1)
+	(DT_INST_PROP(idx, has_white_channel) == 1)
 #define WS2812_SPI_BUS(idx) \
-	(DT_INST_##idx##_WORLDSEMI_WS2812_SPI_BUS_NAME)
+	(DT_INST_BUS_LABEL(idx))
 #define WS2812_SPI_SLAVE(idx) \
-	(DT_INST_##idx##_WORLDSEMI_WS2812_SPI_BASE_ADDRESS)
+	(DT_INST_REG_ADDR(idx))
 #define WS2812_SPI_FREQ(idx) \
-	(DT_INST_##idx##_WORLDSEMI_WS2812_SPI_SPI_MAX_FREQUENCY)
+	(DT_INST_PROP(idx, spi_max_frequency))
 #define WS2812_SPI_ONE_FRAME(idx) \
-	(DT_INST_##idx##_WORLDSEMI_WS2812_SPI_SPI_ONE_FRAME)
+	(DT_INST_PROP(idx, spi_one_frame))
 #define WS2812_SPI_ZERO_FRAME(idx)\
-	(DT_INST_##idx##_WORLDSEMI_WS2812_SPI_SPI_ZERO_FRAME)
+	(DT_INST_PROP(idx, spi_zero_frame))
 #define WS2812_SPI_BUFSZ(idx) \
 	(BYTES_PER_PX(WS2812_SPI_HAS_WHITE(idx)) * WS2812_SPI_NUM_PIXELS(idx))
 
@@ -228,10 +230,10 @@ static const struct led_strip_driver_api ws2812_spi_api = {
 			    CONFIG_LED_STRIP_INIT_PRIORITY,		\
 			    &ws2812_spi_api);
 
-#ifdef DT_INST_0_WORLDSEMI_WS2812_SPI_LABEL
+#if DT_INST_NODE_HAS_PROP(0, label)
 WS2812_SPI_DEVICE(0);
 #endif
 
-#ifdef DT_INST_1_WORLDSEMI_WS2812_SPI_LABEL
+#if DT_INST_NODE_HAS_PROP(1, label)
 WS2812_SPI_DEVICE(1);
 #endif


### PR DESCRIPTION
Convert older DT_INST_ macro use the new include/devicetree.h
DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>