### PR TITLE
scripts: dts: gen_defines: Fix issue if there are no compats

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -505,7 +505,7 @@ def write_chosen(edt):
     for name, node in edt.chosen_nodes.items():
         chosen[f"DT_CHOSEN_{str2ident(name)}"] = f"DT_{node.z_path_id}"
         chosen[f"DT_CHOSEN_{str2ident(name)}_EXISTS"] = 1
-    max_len = max(map(len, chosen))
+    max_len = max(map(len, chosen), default=0)
     for macro, value in chosen.items():
         out_define(macro, value, width=max_len)
 


### PR DESCRIPTION
We get the following error:

  ValueError: max() arg is an empty sequence

if the compatiable section of the device tree is empty or doesn't exist.
Fix this by havingin max_len get a default value of 0.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>