### PR TITLE
devicetree: add DT_COMPAT_ON_BUS()

### DIFF
--- a/doc/guides/dts/macros.bnf
+++ b/doc/guides/dts/macros.bnf
@@ -127,6 +127,12 @@ other-macro =  %s"DT_N_" alternate-id
 other-macro =/ %s"DT_N_INST_" dt-name %s"_NUM"
 ; E.g.: #define DT_CHOSEN_zephyr_flash
 other-macro =/ %s"DT_CHOSEN_" dt-name
+; Declares that a compatible has at least one node on a bus.
+;
+; Example:
+;
+;   #define DT_COMPAT_vnd_dev_BUS_spi 1
+other-macro =/ %s"DT_COMPAT_" dt-name %s"_BUS_" dt-name
 
 ; --------------------------------------------------------------------
 ; alternate-id: another way to specify a node besides a path-id

--- a/dts/bindings/test/vnd,gpio-expander-i2c.yaml
+++ b/dts/bindings/test/vnd,gpio-expander-i2c.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: GPIO expander via I2C
+
+compatible: "vnd,gpio-expander"
+
+include: i2c-device.yaml

--- a/dts/bindings/test/vnd,gpio-expander-spi.yaml
+++ b/dts/bindings/test/vnd,gpio-expander-spi.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: GPIO expander via SPI
+
+compatible: "vnd,gpio-expander"
+
+include: spi-device.yaml

--- a/tests/lib/devicetree/app.overlay
+++ b/tests/lib/devicetree/app.overlay
@@ -121,6 +121,12 @@
 				label = "TEST_I2C_DEV_10";
 				reg = < 0x10 >;
 			};
+
+			gpio@11 {
+				compatible = "vnd,gpio-expander";
+				reg = <0x11>;
+				label = "TEST_EXPANDER_I2C";
+			};
 		};
 
 		test_spi: spi@33334444 {
@@ -134,7 +140,8 @@
 			clock-frequency = < 2000000 >;
 
 			cs-gpios = <&test_gpio_1 0x10 0x20>,
-					<&test_gpio_2 0x30 0x40>;
+					<&test_gpio_2 0x30 0x40>,
+					<&test_gpio_2 0x50 0x60>;
 
 			/* all vnd,spi-device instances should have CS */
 
@@ -150,6 +157,13 @@
 				label = "TEST_SPI_DEV_1";
 				reg = <1>;
 				spi-max-frequency = < 2000000 >;
+			};
+
+			gpio@2 {
+				compatible = "vnd,gpio-expander";
+				reg = <2>;
+				label = "TEST_EXPANDER_SPI";
+				spi-max-frequency = <(1 * 1000 * 1000)>;
 			};
 		};
 

--- a/tests/lib/devicetree/src/main.c
+++ b/tests/lib/devicetree/src/main.c
@@ -292,6 +292,20 @@ static void test_bus(void)
 		     "inst 0 i2c dev label");
 	zassert_true(!strncmp(i2c_bus, DT_INST_BUS_LABEL(0), strlen(i2c_bus)),
 		     "inst 0 i2c bus label");
+
+#undef DT_DRV_COMPAT
+	/*
+	 * Make sure the underlying DT_COMPAT_ON_BUS used by
+	 * DT_ANY_INST_ON_BUS works without DT_DRV_COMPAT defined.
+	 */
+	zassert_equal(DT_COMPAT_ON_BUS(vnd_spi_device, spi), 1, NULL);
+	zassert_equal(DT_COMPAT_ON_BUS(vnd_spi_device, i2c), 0, NULL);
+
+	zassert_equal(DT_COMPAT_ON_BUS(vnd_i2c_device, i2c), 1, NULL);
+	zassert_equal(DT_COMPAT_ON_BUS(vnd_i2c_device, spi), 0, NULL);
+
+	zassert_equal(DT_COMPAT_ON_BUS(vnd_gpio_expander, i2c), 1, NULL);
+	zassert_equal(DT_COMPAT_ON_BUS(vnd_gpio_expander, spi), 1, NULL);
 }
 
 #undef DT_DRV_COMPAT
@@ -1032,7 +1046,7 @@ static void test_cs_gpios(void)
 	zassert_equal(DT_SPI_NUM_CS_GPIOS(TEST_SPI_NO_CS), 0, "wrong no. of cs");
 
 	zassert_equal(DT_SPI_HAS_CS_GPIOS(TEST_SPI), 1, "missing cs");
-	zassert_equal(DT_SPI_NUM_CS_GPIOS(TEST_SPI), 2, "wrong no. of cs");
+	zassert_equal(DT_SPI_NUM_CS_GPIOS(TEST_SPI), 3, "wrong no. of cs");
 
 	zassert_true(!strcmp(DT_SPI_DEV_CS_GPIOS_LABEL(TEST_SPI_DEV_0),
 			     "TEST_GPIO_1"),


### PR DESCRIPTION
And implement DT_ANY_INST_ON_BUS() in terms of it.

This makes some error messages quite a bit shorter by avoiding
UTIL_LISTIFY(), which has a nasty temper and tends to explode if not
treated gently.
