### PR TITLE
devicetree: fix DT_NUM_INST() when the answer is 0

### DIFF
--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -851,7 +851,9 @@
  * @param compat lowercase-and-underscores version of a compatible
  * @return Number of enabled instances
  */
-#define DT_NUM_INST(compat) UTIL_CAT(DT_N_INST, DT_DASH(compat, NUM))
+#define DT_NUM_INST(compat)					\
+	UTIL_AND(DT_HAS_COMPAT(compat),				\
+		 UTIL_CAT(DT_N_INST, DT_DASH(compat, NUM)))
 
 /**
  * @brief Test if the devicetree has a /chosen node

--- a/tests/lib/devicetree/src/main.c
+++ b/tests/lib/devicetree/src/main.c
@@ -151,11 +151,14 @@ static void test_has_alias(void)
 	zassert_equal(DT_HAS_NODE(DT_ALIAS(test_undef)), 0, "test-undef");
 }
 
-static void test_has_inst(void)
+static void test_inst_checks(void)
 {
 	zassert_equal(DT_HAS_NODE(DT_INST(0, vnd_gpio)), 1, "vnd,gpio #0");
 	zassert_equal(DT_HAS_NODE(DT_INST(1, vnd_gpio)), 1, "vnd,gpio #1");
 	zassert_equal(DT_HAS_NODE(DT_INST(2, vnd_gpio)), 0, "vnd,gpio #2");
+
+	zassert_equal(DT_NUM_INST(vnd_gpio), 2, "num. vnd,gpio");
+	zassert_equal(DT_NUM_INST(xxxx), 0, "num. xxxx");
 }
 
 static void test_has_nodelabel(void)
@@ -1122,7 +1125,7 @@ void test_main(void)
 			 ztest_unit_test(test_inst_props),
 			 ztest_unit_test(test_has_path),
 			 ztest_unit_test(test_has_alias),
-			 ztest_unit_test(test_has_inst),
+			 ztest_unit_test(test_inst_checks),
 			 ztest_unit_test(test_has_nodelabel),
 			 ztest_unit_test(test_has_compat),
 			 ztest_unit_test(test_bus),


### PR DESCRIPTION
Use UTIL_AND() so it works even when there are no instances.
