### PR TITLE
eSPI: Userspace and API fixes

### DIFF
--- a/drivers/espi/CMakeLists.txt
+++ b/drivers/espi/CMakeLists.txt
@@ -3,4 +3,4 @@
 zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_ESPI_XEC		espi_mchp_xec.c)
-
+zephyr_library_sources_ifdef(CONFIG_USERSPACE           espi_handlers.c)

--- a/drivers/espi/espi_handlers.c
+++ b/drivers/espi/espi_handlers.c
@@ -83,3 +83,129 @@ static inline int z_vrfy_espi_receive_vwire(struct device *dev,
 	return ret;
 }
 #include <syscalls/espi_receive_vwire_mrsh.c>
+
+static inline int z_vrfy_espi_read_request(struct device *dev,
+					   struct espi_request_packet *req)
+{
+	int ret;
+	struct  espi_request_packet req_copy;
+
+	Z_OOPS(Z_SYSCALL_DRIVER_ESPI(dev, read_request));
+	Z_OOPS(z_user_from_copy(&req_copy, req,
+				sizeof(struct espi_request_packet)));
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(req_copy.data, req_copy.len));
+
+	ret = z_impl_espi_read_request(dev, &req_copy);
+
+	Z_OOPS(z_user_to_copy(req, &req_copy,
+			      sizeof(struct espi_request_packet)));
+
+	return ret;
+}
+#include <syscalls/espi_read_request_mrsh.c>
+
+static inline int z_vrfy_espi_write_request(struct device *dev,
+					    struct espi_request_packet *req)
+{
+	int ret;
+	struct  espi_request_packet req_copy;
+
+	Z_OOPS(Z_SYSCALL_DRIVER_ESPI(dev, write_request));
+	Z_OOPS(Z_SYSCALL_MEMORY_READ(req->data, req->len));
+	Z_OOPS(z_user_from_copy(&req_copy, req,
+				sizeof(struct espi_request_packet)));
+
+	ret = z_impl_espi_write_request(dev, &req_copy);
+
+	return ret;
+}
+#include <syscalls/espi_write_request_mrsh.c>
+
+static inline int z_vrfy_espi_send_oob(struct device *dev,
+				       struct espi_oob_packet *pckt)
+{
+	int ret;
+	struct  espi_oob_packet pckt_copy;
+
+	Z_OOPS(Z_SYSCALL_DRIVER_ESPI(dev, send_oob));
+	Z_OOPS(Z_SYSCALL_MEMORY_READ(pckt->buf, pckt->len));
+	Z_OOPS(z_user_from_copy(&pckt_copy, pckt,
+				sizeof(struct espi_oob_packet)));
+
+	ret = z_impl_espi_send_oob(dev, &pckt_copy);
+
+	return ret;
+}
+#include <syscalls/espi_send_oob_mrsh.c>
+
+static inline int z_vrfy_espi_receive_oob(struct device *dev,
+					  struct espi_oob_packet *pckt)
+{
+	int ret;
+	struct  espi_oob_packet pckt_copy;
+
+	Z_OOPS(Z_SYSCALL_DRIVER_ESPI(dev, receive_oob));
+	Z_OOPS(z_user_from_copy(&pckt_copy, pckt,
+				sizeof(struct espi_oob_packet)));
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(pckt->buf, pckt->len));
+
+	ret = z_impl_espi_receive_oob(dev, &pckt_copy);
+	Z_OOPS(z_user_to_copy(pckt, &pckt_copy,
+			      sizeof(struct espi_oob_packet)));
+
+	return ret;
+}
+#include <syscalls/espi_receive_oob_mrsh.c>
+
+static inline int z_vrfy_espi_read_flash(struct device *dev,
+					 struct espi_flash_packet *pckt)
+{
+	int ret;
+	struct  espi_flash_packet pckt_copy;
+
+	Z_OOPS(Z_SYSCALL_DRIVER_ESPI(dev, read_flash));
+	Z_OOPS(z_user_from_copy(&pckt_copy, pckt,
+				sizeof(struct espi_flash_packet)));
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(pckt->buf, pckt->len));
+
+	ret = z_impl_espi_read_flash(dev, pckt);
+	Z_OOPS(z_user_to_copy(pckt, &pckt_copy,
+			      sizeof(struct espi_flash_packet)));
+
+	return ret;
+}
+#include <syscalls/espi_read_flash_mrsh.c>
+
+static inline int z_vrfy_espi_write_flash(struct device *dev,
+					  struct espi_flash_packet *pckt)
+{
+	int ret;
+	struct  espi_flash_packet pckt_copy;
+
+	Z_OOPS(Z_SYSCALL_DRIVER_ESPI(dev, write_flash));
+	Z_OOPS(z_user_from_copy(&pckt_copy, pckt,
+				sizeof(struct espi_flash_packet)));
+	Z_OOPS(Z_SYSCALL_MEMORY_READ(pckt->buf, pckt->len));
+
+	ret = z_impl_espi_write_flash(dev, &pckt_copy);
+
+	return ret;
+}
+#include <syscalls/espi_write_flash_mrsh.c>
+
+static inline int z_vrfy_espi_flash_erase(struct device *dev,
+					  struct espi_flash_packet *pckt)
+{
+	int ret;
+	struct  espi_flash_packet pckt_copy;
+
+	Z_OOPS(Z_SYSCALL_DRIVER_ESPI(dev, write_flash));
+	Z_OOPS(z_user_from_copy(&pckt_copy, pckt,
+				sizeof(struct espi_flash_packet)));
+	Z_OOPS(Z_SYSCALL_MEMORY_READ(pckt->buf, pckt->len));
+
+	ret = z_impl_espi_flash_erase(dev, &pckt_copy);
+
+	return ret;
+}
+#include <syscalls/espi_flash_erase_mrsh.c>

--- a/drivers/espi/espi_handlers.c
+++ b/drivers/espi/espi_handlers.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <drivers/espi.h>
+#include <syscall_handler.h>
+
+
+static inline int z_vrfy_espi_config(struct device *dev, struct espi_cfg *cfg)
+{
+	struct  espi_cfg cfg_copy;
+
+	Z_OOPS(Z_SYSCALL_DRIVER_ESPI(dev, config));
+	Z_OOPS(z_user_from_copy(&cfg_copy, cfg,
+				sizeof(struct espi_cfg)));
+
+	return z_impl_espi_config(dev, &cfg_copy);
+}
+#include <syscalls/espi_config_mrsh.c>
+
+static inline bool z_vrfy_espi_get_channel_status(struct device *dev,
+						  enum espi_channel ch)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_ESPI(dev, get_channel_status));
+
+	return z_impl_espi_get_channel_status(dev, ch);
+}
+#include <syscalls/espi_get_channel_status_mrsh.c>
+
+static inline int z_vrfy_espi_read_lpc_request(struct device *dev,
+					       enum lpc_peripheral_opcode op,
+					       u32_t *data)
+{
+	int ret;
+	u32_t data_copy;
+
+	Z_OOPS(Z_SYSCALL_DRIVER_ESPI(dev, read_lpc_request));
+
+	ret = z_impl_espi_read_lpc_request(dev, op, &data_copy);
+	Z_OOPS(z_user_to_copy(data, &data_copy, sizeof(u8_t)));
+
+	return ret;
+}
+#include <syscalls/espi_read_lpc_request_mrsh.c>
+
+static inline int z_vrfy_espi_write_lpc_request(struct device *dev,
+						enum lpc_peripheral_opcode op,
+						u32_t *data)
+{
+	u32_t data_copy;
+
+	Z_OOPS(Z_SYSCALL_DRIVER_ESPI(dev, write_lpc_request));
+	Z_OOPS(z_user_from_copy(&data_copy, data, sizeof(*data)));
+
+	return z_impl_espi_write_lpc_request(dev, op, data_copy);
+}
+#include <syscalls/espi_write_lpc_request_mrsh.c>
+
+static inline int z_vrfy_espi_send_vwire(struct device *dev,
+					 enum espi_vwire_signal signal,
+					 u8_t level)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_ESPI(dev, send_vwire));
+
+	return z_impl_espi_send_vwire(dev, signal, level);
+}
+#include <syscalls/espi_send_vwire_mrsh.c>
+
+static inline int z_vrfy_espi_receive_vwire(struct device *dev,
+					    enum espi_vwire_signal signal,
+					    u8_t *level)
+{
+	int ret;
+	u8_t level_copy;
+
+	Z_OOPS(Z_SYSCALL_DRIVER_ESPI(dev, receive_vwire));
+
+	ret = z_impl_espi_receive_vwire(dev, signal, &level_copy);
+	Z_OOPS(z_user_to_copy(level, &level_copy, sizeof(u8_t)));
+
+	return ret;
+}
+#include <syscalls/espi_receive_vwire_mrsh.c>

--- a/drivers/espi/espi_mchp_xec.c
+++ b/drivers/espi/espi_mchp_xec.c
@@ -406,7 +406,7 @@ static int espi_xec_receive_vwire(struct device *dev,
 	return 0;
 }
 
-static int espi_xec_send_oob(struct device *dev, struct espi_oob_packet pckt)
+static int espi_xec_send_oob(struct device *dev, struct espi_oob_packet *pckt)
 {
 	int ret;
 	struct espi_xec_data *data = (struct espi_xec_data *)(dev->driver_data);
@@ -426,14 +426,14 @@ static int espi_xec_send_oob(struct device *dev, struct espi_oob_packet pckt)
 		return -EBUSY;
 	}
 
-	if (pckt.len > MAX_OOB_BUFFER_SIZE) {
+	if (pckt->len > MAX_OOB_BUFFER_SIZE) {
 		LOG_ERR("insufficient space");
 		return -EINVAL;
 	}
 
-	memcpy(slave_tx_mem, pckt.buf, pckt.len);
+	memcpy(slave_tx_mem, pckt->buf, pckt->len);
 
-	ESPI_OOB_REGS->TX_LEN = pckt.len;
+	ESPI_OOB_REGS->TX_LEN = pckt->len;
 	ESPI_OOB_REGS->TX_CTRL = MCHP_ESPI_OOB_TX_CTRL_START;
 	LOG_DBG("%s %d", __func__, ESPI_OOB_REGS->TX_LEN);
 
@@ -451,7 +451,7 @@ static int espi_xec_send_oob(struct device *dev, struct espi_oob_packet pckt)
 }
 
 static int espi_xec_receive_oob(struct device *dev,
-				struct espi_oob_packet pckt)
+				struct espi_oob_packet *pckt)
 {
 	int ret;
 	u8_t err_mask = MCHP_ESPI_OOB_RX_STS_IBERR |
@@ -471,13 +471,13 @@ static int espi_xec_receive_oob(struct device *dev,
 	/* Check if buffer passed to driver can fit the received buffer */
 	u32_t rcvd_len = ESPI_OOB_REGS->RX_LEN & ESPI_XEC_OOB_RX_LEN_MASK;
 
-	if (rcvd_len > pckt.len) {
-		LOG_ERR("space rcvd %d vs %d", rcvd_len, pckt.len);
+	if (rcvd_len > pckt->len) {
+		LOG_ERR("space rcvd %d vs %d", rcvd_len, pckt->len);
 		return -EIO;
 	}
 
-	pckt.len = rcvd_len;
-	memcpy(pckt.buf, slave_rx_mem, pckt.len);
+	pckt->len = rcvd_len;
+	memcpy(pckt->buf, slave_rx_mem, pckt->len);
 
 	return 0;
 }

--- a/include/drivers/espi.h
+++ b/include/drivers/espi.h
@@ -705,7 +705,7 @@ static inline int z_impl_espi_receive_oob(struct device *dev,
 __syscall int espi_read_flash(struct device *dev,
 			      struct espi_flash_packet pckt);
 
-static inline int z_impl_espi_flash_read(struct device *dev,
+static inline int z_impl_espi_read_flash(struct device *dev,
 					 struct espi_flash_packet pckt)
 {
 	const struct espi_driver_api *api =
@@ -734,7 +734,7 @@ static inline int z_impl_espi_flash_read(struct device *dev,
 __syscall int espi_write_flash(struct device *dev,
 			       struct espi_flash_packet pckt);
 
-static inline int z_impl_espi_flash_write(struct device *dev,
+static inline int z_impl_espi_write_flash(struct device *dev,
 					  struct espi_flash_packet pckt)
 {
 	const struct espi_driver_api *api =

--- a/include/drivers/espi.h
+++ b/include/drivers/espi.h
@@ -326,9 +326,9 @@ typedef bool (*espi_api_get_channel_status)(struct device *dev,
 					    enum espi_channel ch);
 /* Logical Channel 0 APIs */
 typedef int (*espi_api_read_request)(struct device *dev,
-				     struct espi_request_packet);
+				     struct espi_request_packet *req);
 typedef int (*espi_api_write_request)(struct device *dev,
-				      struct espi_request_packet);
+				      struct espi_request_packet *req);
 typedef int (*espi_api_lpc_read_request)(struct device *dev,
 				enum lpc_peripheral_opcode op, u32_t *data);
 typedef int (*espi_api_lpc_write_request)(struct device *dev,
@@ -342,16 +342,16 @@ typedef int (*espi_api_receive_vwire)(struct device *dev,
 				      u8_t *level);
 /* Logical Channel 2 APIs */
 typedef int (*espi_api_send_oob)(struct device *dev,
-				 struct espi_oob_packet);
+				 struct espi_oob_packet *pckt);
 typedef int (*espi_api_receive_oob)(struct device *dev,
-				    struct espi_oob_packet);
+				    struct espi_oob_packet *pckt);
 /* Logical Channel 3 APIs */
 typedef int (*espi_api_flash_read)(struct device *dev,
-				   struct espi_flash_packet);
+				   struct espi_flash_packet *pckt);
 typedef int (*espi_api_flash_write)(struct device *dev,
-				    struct espi_flash_packet);
+				    struct espi_flash_packet *pckt);
 typedef int (*espi_api_flash_erase)(struct device *dev,
-				    struct espi_flash_packet);
+				    struct espi_flash_packet *pckt);
 /* Callbacks and traffic intercept */
 typedef int (*espi_api_manage_callback)(struct device *dev,
 					struct espi_callback *callback,
@@ -465,7 +465,8 @@ static inline bool z_impl_espi_get_channel_status(struct device *dev,
  * This routines provides a generic interface to send a read request packet.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param req Structure representing a memory, I/O or message read request.
+ * @param req Address of structure representing a memory,
+ *            I/O or message read request.
  *
  * @retval 0 If successful.
  * @retval -ENOTSUP if eSPI controller doesn't support raw packets and instead
@@ -473,10 +474,10 @@ static inline bool z_impl_espi_get_channel_status(struct device *dev,
  * @retval -EIO General input / output error, failed to send over the bus.
  */
 __syscall int espi_read_request(struct device *dev,
-				struct espi_request_packet req);
+				struct espi_request_packet *req);
 
 static inline int z_impl_espi_read_request(struct device *dev,
-					   struct espi_request_packet req)
+					   struct espi_request_packet *req)
 {
 	const struct espi_driver_api *api =
 		(const struct espi_driver_api *)dev->driver_api;
@@ -494,7 +495,8 @@ static inline int z_impl_espi_read_request(struct device *dev,
  * This routines provides a generic interface to send a write request packet.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param req Structure representing a memory, I/O or message write request.
+ * @param req Address of structure representing a memory, I/O or
+ *            message write request.
  *
  * @retval 0 If successful.
  * @retval -ENOTSUP if eSPI controller doesn't support raw packets and instead
@@ -502,10 +504,10 @@ static inline int z_impl_espi_read_request(struct device *dev,
  * @retval -EINVAL General input / output error, failed to send over the bus.
  */
 __syscall int espi_write_request(struct device *dev,
-				 struct espi_request_packet req);
+				 struct espi_request_packet *req);
 
 static inline int z_impl_espi_write_request(struct device *dev,
-					    struct espi_request_packet req)
+					    struct espi_request_packet *req)
 {
 	const struct espi_driver_api *api =
 		(const struct espi_driver_api *)dev->driver_api;
@@ -643,14 +645,14 @@ static inline int z_impl_espi_receive_vwire(struct device *dev,
  * and send into packet over eSPI bus
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param pckt the packet representation of SMBus transaction.
+ * @param pckt Address of the packet representation of SMBus transaction.
  *
  * @retval -EIO General input / output error, failed request to master.
  */
-__syscall int espi_send_oob(struct device *dev, struct espi_oob_packet pckt);
+__syscall int espi_send_oob(struct device *dev, struct espi_oob_packet *pckt);
 
 static inline int z_impl_espi_send_oob(struct device *dev,
-				       struct espi_oob_packet pckt)
+				       struct espi_oob_packet *pckt)
 {
 	const struct espi_driver_api *api =
 		(const struct espi_driver_api *)dev->driver_api;
@@ -669,15 +671,15 @@ static inline int z_impl_espi_send_oob(struct device *dev,
  * transaction from eSPI bus
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param pckt the packet representation of SMBus transaction.
+ * @param pckt Address of the packet representation of SMBus transaction.
  *
  * @retval -EIO General input / output error, failed request to master.
  */
 __syscall int espi_receive_oob(struct device *dev,
-			       struct espi_oob_packet pckt);
+			       struct espi_oob_packet *pckt);
 
 static inline int z_impl_espi_receive_oob(struct device *dev,
-					  struct espi_oob_packet pckt)
+					  struct espi_oob_packet *pckt)
 {
 	const struct espi_driver_api *api =
 		(const struct espi_driver_api *)dev->driver_api;
@@ -696,17 +698,17 @@ static inline int z_impl_espi_receive_oob(struct device *dev,
  * component shared between the eSPI master and eSPI slaves.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param pckt the representation of read flash transaction.
+ * @param pckt Adddress of the representation of read flash transaction.
  *
  * @retval -ENOTSUP eSPI flash logical channel transactions not supported.
  * @retval -EBUSY eSPI flash channel is not ready or disabled by master.
  * @retval -EIO General input / output error, failed request to master.
  */
 __syscall int espi_read_flash(struct device *dev,
-			      struct espi_flash_packet pckt);
+			      struct espi_flash_packet *pckt);
 
 static inline int z_impl_espi_read_flash(struct device *dev,
-					 struct espi_flash_packet pckt)
+					 struct espi_flash_packet *pckt)
 {
 	const struct espi_driver_api *api =
 		(const struct espi_driver_api *)dev->driver_api;
@@ -725,17 +727,17 @@ static inline int z_impl_espi_read_flash(struct device *dev,
  * components shared between the eSPI master and eSPI slaves.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param pckt the representation of write flash transaction.
+ * @param pckt Address of the representation of write flash transaction.
  *
  * @retval -ENOTSUP eSPI flash logical channel transactions not supported.
  * @retval -EBUSY eSPI flash channel is not ready or disabled by master.
  * @retval -EIO General input / output error, failed request to master.
  */
 __syscall int espi_write_flash(struct device *dev,
-			       struct espi_flash_packet pckt);
+			       struct espi_flash_packet *pckt);
 
 static inline int z_impl_espi_write_flash(struct device *dev,
-					  struct espi_flash_packet pckt)
+					  struct espi_flash_packet *pckt)
 {
 	const struct espi_driver_api *api =
 		(const struct espi_driver_api *)dev->driver_api;
@@ -754,17 +756,17 @@ static inline int z_impl_espi_write_flash(struct device *dev,
  * components shared between the eSPI master and eSPI slaves.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param pckt the representation of write flash transaction.
+ * @param pckt Address of the representation of write flash transaction.
  *
  * @retval -ENOTSUP eSPI flash logical channel transactions not supported.
  * @retval -EBUSY eSPI flash channel is not ready or disabled by master.
  * @retval -EIO General input / output error, failed request to master.
  */
 __syscall int espi_flash_erase(struct device *dev,
-			       struct espi_flash_packet pckt);
+			       struct espi_flash_packet *pckt);
 
 static inline int z_impl_espi_flash_erase(struct device *dev,
-					  struct espi_flash_packet pckt)
+					  struct espi_flash_packet *pckt)
 {
 	const struct espi_driver_api *api =
 		(const struct espi_driver_api *)dev->driver_api;

--- a/samples/drivers/espi/src/main.c
+++ b/samples/drivers/espi/src/main.c
@@ -332,13 +332,13 @@ int get_pch_temp(struct device *dev)
 	resp_pckt.buf = (u8_t *)&rsp;
 	resp_pckt.len = MAX_RESP_SIZE;
 
-	ret = espi_send_oob(dev, req_pckt);
+	ret = espi_send_oob(dev, &req_pckt);
 	if (ret) {
 		LOG_ERR("OOB Tx failed %d", ret);
 		return ret;
 	}
 
-	ret = espi_receive_oob(dev, resp_pckt);
+	ret = espi_receive_oob(dev, &resp_pckt);
 	if (ret) {
 		LOG_ERR("OOB Rx failed %d", ret);
 		return ret;


### PR DESCRIPTION
* Implement missing verification handler
* Fix two implementation handler names
* Pass struct by reference in syscall APIs

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/23750