### PR TITLE
shell: Fix device service module

### DIFF
--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -17,11 +17,18 @@ extern struct device __device_POST_KERNEL_start[];
 extern struct device __device_APPLICATION_start[];
 extern struct device __device_init_end[];
 
+#ifdef CONFIG_SMP
+extern struct device __device_SMP_start[];
+#endif
+
 static struct device *config_levels[] = {
 	__device_PRE_KERNEL_1_start,
 	__device_PRE_KERNEL_2_start,
 	__device_POST_KERNEL_start,
 	__device_APPLICATION_start,
+#ifdef CONFIG_SMP
+	__device_SMP_start,
+#endif
 	/* End marker */
 	__device_init_end,
 };


### PR DESCRIPTION
There is a new init level SMP that was just added, and this module needs
to take it into account.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>