### PR TITLE
drivers: flash: stm32: fix warnings about format specifiers

### DIFF
--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -180,8 +180,8 @@ static int flash_stm32_read(struct device *dev, off_t offset, void *data,
 			    size_t len)
 {
 	if (!flash_stm32_valid_range(dev, offset, len, false)) {
-		LOG_ERR("Read range invalid. Offset: %d, len: %zu",
-			offset, len);
+		LOG_ERR("Read range invalid. Offset: %ld, len: %zu",
+			(long int) offset, len);
 		return -EINVAL;
 	}
 
@@ -189,7 +189,7 @@ static int flash_stm32_read(struct device *dev, off_t offset, void *data,
 		return 0;
 	}
 
-	LOG_DBG("Read offset: %d, len: %zu", offset, len);
+	LOG_DBG("Read offset: %ld, len: %zu", (long int) offset, len);
 
 	memcpy(data, (u8_t *) CONFIG_FLASH_BASE_ADDRESS + offset, len);
 
@@ -201,8 +201,8 @@ static int flash_stm32_erase(struct device *dev, off_t offset, size_t len)
 	int rc;
 
 	if (!flash_stm32_valid_range(dev, offset, len, true)) {
-		LOG_ERR("Erase range invalid. Offset: %d, len: %zu",
-			offset, len);
+		LOG_ERR("Erase range invalid. Offset: %ld, len: %zu",
+			(long int) offset, len);
 		return -EINVAL;
 	}
 
@@ -212,7 +212,7 @@ static int flash_stm32_erase(struct device *dev, off_t offset, size_t len)
 
 	flash_stm32_sem_take(dev);
 
-	LOG_DBG("Erase offset: %d, len: %zu", offset, len);
+	LOG_DBG("Erase offset: %ld, len: %zu", (long int) offset, len);
 
 	rc = flash_stm32_block_erase_loop(dev, offset, len);
 
@@ -229,8 +229,8 @@ static int flash_stm32_write(struct device *dev, off_t offset,
 	int rc;
 
 	if (!flash_stm32_valid_range(dev, offset, len, true)) {
-		LOG_ERR("Write range invalid. Offset: %d, len: %zu",
-			offset, len);
+		LOG_ERR("Write range invalid. Offset: %ld, len: %zu",
+			(long int) offset, len);
 		return -EINVAL;
 	}
 
@@ -240,7 +240,7 @@ static int flash_stm32_write(struct device *dev, off_t offset,
 
 	flash_stm32_sem_take(dev);
 
-	LOG_DBG("Write offset: %d, len: %zu", offset, len);
+	LOG_DBG("Write offset: %ld, len: %zu", (long int) offset, len);
 
 	rc = flash_stm32_write_range(dev, offset, data, len);
 


### PR DESCRIPTION
Warnings are generated with newlibc about incorrect format specifier (%d for long int) because newlibc defines off_t as long int. Change %d format specifier to %ld for logging of offsets and cast offset to long int to support both newlibc and the minimal c library which defines off_t as int.

Signed-off-by: Thomas Schmid <tom@lfence.de>