### PR TITLE
Bluetooth: controller: Fix ticker ticks_current value

### DIFF
--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -2083,6 +2083,7 @@ static inline void ticker_job_compare_update(struct ticker_instance *instance,
 	if (instance->ticker_id_head == TICKER_NULL) {
 		if (cntr_stop() == 0) {
 			instance->ticks_slot_previous = 0U;
+			instance->ticks_current = cntr_cnt_get();
 		}
 		return;
 	}


### PR DESCRIPTION
Update the ticks_current value on last stopped ticker
instance, so that when a new ticker instance is started
the anchor ticks calculation uses the correct current tick
with respect to supplied anchor ticks.

Fixes #23805.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>