### PR TITLE
samples: openamp: Fix cmake warning

### DIFF
--- a/samples/subsys/ipc/openamp/CMakeLists.txt
+++ b/samples/subsys/ipc/openamp/CMakeLists.txt
@@ -35,8 +35,8 @@ ExternalProject_Add(
   openamp_remote
   SOURCE_DIR ${APPLICATION_SOURCE_DIR}/remote
   INSTALL_COMMAND ""      # This particular build system has no install command
-  CMAKE_CACHE_ARGS -DBOARD:string=${BOARD_REMOTE}
-  CMAKE_CACHE_ARGS -DDTC_OVERLAY_FILE:string=${DTC_OVERLAY_FILE}
+  CMAKE_CACHE_ARGS -DBOARD:STRING=${BOARD_REMOTE}
+  CMAKE_CACHE_ARGS -DDTC_OVERLAY_FILE:STRING=${DTC_OVERLAY_FILE}
   BUILD_BYPRODUCTS "${REMOTE_ZEPHYR_DIR}/zephyr.bin"
   # NB: Do we need to pass on more CMake variables?
   BUILD_ALWAYS True


### PR DESCRIPTION
Fix the following CMake Warning:
  implicitly converting 'string' to 'STRING' type.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>