### PR TITLE
west.yml: Update open-amp/libmetal to v2020.01.0 release

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -74,7 +74,7 @@ manifest:
       revision: b25d4b83b16e52f501f8cd360f4efb8c31ffb578
       path: modules/hal/ti
     - name: libmetal
-      revision: 45e630d6152824f807d3f919958605c4626cbdff
+      revision: 11a4d140f58b3c220f90fc3591c3d6e05840cca6
       path: modules/hal/libmetal
     - name: lvgl
       revision: 74fc2e753a997bd71cefa34dd9c56dcb954b42e2
@@ -95,7 +95,7 @@ manifest:
       revision: 2f896f74a5fc7220546cc23b50351506cd72ea96
       path: modules/hal/nxp
     - name: open-amp
-      revision: 9b591b289e1f37339bd038b5a1f0e6c8ad39c63a
+      revision: 68c18eae2e619ab161a217b1ce86e7ff37391a15
       path: modules/lib/open-amp
     - name: loramac-node
       revision: 29e516ec585b1a909af2b5f1c60d83e7d4d563e3


### PR DESCRIPTION
Update libmetal and open-amp to v2020.01.0 release.  We do these as
a matched pair.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>