### PR TITLE
Bluetooth: controller: legacy: Fix slave latency during conn update

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -4894,9 +4894,10 @@ static inline void isr_close_conn(void)
 #endif /* CONFIG_BT_CTLR_CONN_RSSI */
 
 	/* break latency based on ctrl procedure pending */
-	if ((_radio.conn_curr->llcp_ack != _radio.conn_curr->llcp_req) &&
-	    ((_radio.conn_curr->llcp_type == LLCP_CONN_UPD) ||
-	     (_radio.conn_curr->llcp_type == LLCP_CHAN_MAP))) {
+	if (((_radio.conn_curr->llcp_ack != _radio.conn_curr->llcp_req) &&
+	     ((_radio.conn_curr->llcp_type == LLCP_CONN_UPD) ||
+	      (_radio.conn_curr->llcp_type == LLCP_CHAN_MAP))) ||
+	    (_radio.conn_curr->llcp_cu.req != _radio.conn_curr->llcp_cu.ack)) {
 		_radio.conn_curr->latency_event = 0U;
 	}
 


### PR DESCRIPTION
Fix regression in cancelling slave latency during Connection
Update Procedure.

Slave latency should not be applied between the ack of a
Connection Update Indication PDU and until the instant.
When caching was introduced, implementation missed this
consideration.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>