### PR TITLE
Bluetooth: controller: Fix ticker catch up on ISR latency

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -117,7 +117,6 @@ config BT_LLL_VENDOR_NORDIC
 	select BT_HAS_HCI_VS
 	select ENTROPY_NRF5_RNG
 	select ENTROPY_NRF5_BIAS_CORRECTION
-
 	select BT_CTLR_LE_ENC_SUPPORT if !BT_CTLR_DATA_LENGTH_CLEAR && \
 					 !BT_CTLR_PHY_2M_NRF
 	select BT_CTLR_CONN_PARAM_REQ_SUPPORT
@@ -137,11 +136,6 @@ config BT_LLL_VENDOR_NORDIC
 	select BT_CTLR_XTAL_ADVANCED_SUPPORT
 	select BT_CTLR_SCHED_ADVANCED_SUPPORT
 	select BT_CTLR_TIFS_HW_SUPPORT
-
-	# Until ticker resolve collision is fixed for skipped ticker catch-up
-	# issue, use the old compatibility mode
-	select BT_TICKER_COMPATIBILITY_MODE
-
 	default y
 	help
 	  Use Nordic Lower Link Layer implementation.

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -1433,6 +1433,12 @@ static inline void ticker_job_worker_bh(struct ticker_instance *instance,
 				 * restarted
 				 */
 				ticker->ticks_to_expire = ticks_elapsed;
+
+				/* Reset ticker state, so that its put
+				 * back in requested state later down
+				 * in the code.
+				 */
+				ticker->req = ticker->ack;
 			} else {
 				u16_t lazy_periodic;
 				u32_t count;
@@ -1443,6 +1449,12 @@ static inline void ticker_job_worker_bh(struct ticker_instance *instance,
 					lazy_periodic = ticker->lazy_periodic;
 				} else {
 					lazy_periodic = 0U;
+
+					/* Reset ticker state, so that its put
+					 * back in requested state later down
+					 * in the code.
+					 */
+					ticker->req = ticker->ack;
 				}
 
 				/* Reload ticks_to_expire with atleast one


### PR DESCRIPTION
Fix ticker to avoid catch up of periodic timeouts in case of
large ISR latencies like in case of flash erase scenarios.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>