### PR TITLE
west.yml: update Xtensa HAL revision

### DIFF
--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -86,7 +86,6 @@ if(SYSROOT_DIR)
     )
 
   set(LIBC_LIBRARY_DIR "\"${SYSROOT_DIR}\"/lib/${NEWLIB_DIR}")
-  set(LIBC_INCLUDE_DIR ${SYSROOT_DIR}/include)
 endif()
 
 # For CMake to be able to test if a compiler flag is supported by the

--- a/west.yml
+++ b/west.yml
@@ -122,7 +122,7 @@ manifest:
       path: modules/bsim_hw_models/nrf_hw_models
       revision: fec69703cb1ca06fcdab6d5fde01274f0fc5c759
     - name: hal_xtensa
-      revision: 382b309b481adc85dd517d50b8a458bcb86f15d4
+      revision: e7a57d0c252f9c5f3cab9d5ceadda8753cacee5b
       path: modules/hal/xtensa
     - name: edtt
       path: tools/edtt


### PR DESCRIPTION
This updates the Xtensa HAL revision to latest master,
which includes updating the HAL to version 12.08, and
making it a named module.

The CMake change is to allow headers from HAL to override those from the toolchain.