### PR TITLE
devicetree: Rename spi cs gpio macros

### DIFF
--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -761,7 +761,7 @@ static int mcp2515_init(struct device *dev)
 		return -EINVAL;
 	}
 
-#if DT_INST_SPI_DEV_HAS_CS(0)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	dev_data->spi_cs_ctrl.gpio_dev =
 		device_get_binding(dev_cfg->spi_cs_port);
 	if (!dev_data->spi_cs_ctrl.gpio_dev) {
@@ -775,7 +775,7 @@ static int mcp2515_init(struct device *dev)
 	dev_data->spi_cfg.cs = &dev_data->spi_cs_ctrl;
 #else
 	dev_data->spi_cfg.cs = NULL;
-#endif  /* DT_INST_SPI_DEV_HAS_CS(0) */
+#endif  /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
 
 	/* Reset MCP2515 */
 	if (mcp2515_cmd_soft_reset(dev)) {
@@ -846,10 +846,10 @@ static const struct mcp2515_config mcp2515_config_1 = {
 	.int_port = DT_INST_GPIO_LABEL(0, int_gpios),
 	.int_thread_stack_size = CONFIG_CAN_MCP2515_INT_THREAD_STACK_SIZE,
 	.int_thread_priority = CONFIG_CAN_MCP2515_INT_THREAD_PRIO,
-#if DT_INST_SPI_DEV_HAS_CS(0)
-	.spi_cs_pin = DT_INST_SPI_DEV_CS_GPIO_PIN(0),
-	.spi_cs_port = DT_INST_SPI_DEV_CS_GPIO_LABEL(0),
-#endif  /* DT_INST_SPI_DEV_HAS_CS(0) */
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
+	.spi_cs_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
+	.spi_cs_port = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
+#endif  /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
 	.tq_sjw = DT_INST_PROP(0, sjw),
 	.tq_prop = DT_INST_PROP(0, prop_seg),
 	.tq_bs1 = DT_INST_PROP(0, phase_seg1),

--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -28,9 +28,9 @@ struct mcp2515_data {
 	/* spi device data */
 	struct device *spi;
 	struct spi_config spi_cfg;
-#if DT_INST_SPI_DEV_HAS_CS(0)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	struct spi_cs_control spi_cs_ctrl;
-#endif /* DT_INST_SPI_DEV_HAS_CS(0) */
+#endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
 
 	/* interrupt data */
 	struct device *int_gpio;

--- a/include/devicetree/spi.h
+++ b/include/devicetree/spi.h
@@ -27,15 +27,15 @@ extern "C" {
  * @param spi node identifier for a SPI bus controller
  * @return 1 if it has a cs-gpios property, 0 otherwise
  */
-#define DT_SPI_HAS_CS(spi) DT_NODE_HAS_PROP(spi, cs_gpios)
+#define DT_SPI_HAS_CS_GPIOS(spi) DT_NODE_HAS_PROP(spi, cs_gpios)
 
 /**
  * @brief The number of chip select GPIOs in a SPI controller
  * @param spi node identifier for a SPI bus controller
  * @return The length of its cs-gpios, or 0 if it doesn't have one
  */
-#define DT_SPI_NUM_CS(spi) \
-	COND_CODE_1(DT_SPI_HAS_CS(spi), \
+#define DT_SPI_NUM_CS_GPIOS(spi) \
+	COND_CODE_1(DT_SPI_HAS_CS_GPIOS(spi), \
 		    (DT_PROP_LEN(spi, cs_gpios)), (0))
 
 /**
@@ -44,15 +44,15 @@ extern "C" {
  * @return 1 if the SPI device's bus DT_BUS(spi_dev) has a CS
  *         pin at index DT_REG_ADDR(spi_dev), 0 otherwise
  */
-#define DT_SPI_DEV_HAS_CS(spi_dev) DT_SPI_HAS_CS(DT_BUS(spi_dev))
+#define DT_SPI_DEV_HAS_CS_GPIOS(spi_dev) DT_SPI_HAS_CS_GPIOS(DT_BUS(spi_dev))
 
 /**
  * @brief Get GPIO controller name for a SPI device's chip select
- * DT_SPI_DEV_HAS_CS(spi_dev) must expand to 1.
+ * DT_SPI_DEV_HAS_CS_GPIOS(spi_dev) must expand to 1.
  * @brief spi_dev a SPI device node identifier
  * @return label property of spi_dev's chip select GPIO controller
  */
-#define DT_SPI_DEV_CS_GPIO_LABEL(spi_dev) \
+#define DT_SPI_DEV_CS_GPIOS_LABEL(spi_dev) \
 	DT_GPIO_LABEL_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR(spi_dev))
 
 /**
@@ -62,7 +62,7 @@ extern "C" {
  * @brief spi_dev a SPI device node identifier
  * @return pin number of spi_dev's chip select GPIO
  */
-#define DT_SPI_DEV_CS_GPIO_PIN(spi_dev) \
+#define DT_SPI_DEV_CS_GPIOS_PIN(spi_dev) \
 	DT_GPIO_PIN_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR(spi_dev))
 
 /**
@@ -72,43 +72,44 @@ extern "C" {
  * @brief spi_dev a SPI device node identifier
  * @return flags value of spi_dev's chip select GPIO specifier
  */
-#define DT_SPI_DEV_CS_GPIO_FLAGS(spi_dev) \
+#define DT_SPI_DEV_CS_GPIOS_FLAGS(spi_dev) \
 	DT_GPIO_FLAGS_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR(spi_dev))
 
 /**
- * @brief Equivalent to DT_SPI_DEV_HAS_CS(DT_DRV_INST(inst))
+ * @brief Equivalent to DT_SPI_DEV_HAS_CS_GPIOS(DT_DRV_INST(inst))
  * @param inst instance number
  * @return 1 if the instance's bus has a CS pin at index
  *         DT_INST_REG_ADDR(inst), 0 otherwise
  */
-#define DT_INST_SPI_DEV_HAS_CS(inst) DT_SPI_DEV_HAS_CS(DT_DRV_INST(inst))
+#define DT_INST_SPI_DEV_HAS_CS_GPIOS(inst) \
+	DT_SPI_DEV_HAS_CS_GPIOS(DT_DRV_INST(inst))
 
 /**
  * @brief Get GPIO controller name for a SPI device instance
- * This is equivalent to DT_SPI_DEV_CS_GPIO_LABEL(DT_DRV_INST(inst)).
+ * This is equivalent to DT_SPI_DEV_CS_GPIOS_LABEL(DT_DRV_INST(inst)).
  * @brief inst instance number
  * @return label property of the instance's chip select GPIO controller
  */
-#define DT_INST_SPI_DEV_CS_GPIO_LABEL(inst) \
-	DT_SPI_DEV_CS_GPIO_LABEL(DT_DRV_INST(inst))
+#define DT_INST_SPI_DEV_CS_GPIOS_LABEL(inst) \
+	DT_SPI_DEV_CS_GPIOS_LABEL(DT_DRV_INST(inst))
 
 /**
  * @brief Get GPIO specifier "pin" value for a SPI device instance
- * This is equivalent to DT_SPI_DEV_CS_GPIO_PIN(DT_DRV_INST(inst)).
+ * This is equivalent to DT_SPI_DEV_CS_GPIOS_PIN(DT_DRV_INST(inst)).
  * @brief inst a SPI device instance number
  * @return pin number of the instance's chip select GPIO
  */
-#define DT_INST_SPI_DEV_CS_GPIO_PIN(inst) \
-	DT_SPI_DEV_CS_GPIO_PIN(DT_DRV_INST(inst))
+#define DT_INST_SPI_DEV_CS_GPIOS_PIN(inst) \
+	DT_SPI_DEV_CS_GPIOS_PIN(DT_DRV_INST(inst))
 
 /**
  * @brief Get GPIO specifier "flags" value for a SPI device instance
- * This is equivalent to DT_SPI_DEV_CS_GPIO_FLAGS(DT_DRV_INST(inst)).
+ * This is equivalent to DT_SPI_DEV_CS_GPIOS_FLAGS(DT_DRV_INST(inst)).
  * @brief inst a SPI device instance number
  * @return flags value of the instance's chip select GPIO specifier
  */
-#define DT_INST_SPI_DEV_CS_GPIO_FLAGS(inst) \
-	DT_SPI_DEV_CS_GPIO_FLAGS(DT_DRV_INST(inst))
+#define DT_INST_SPI_DEV_CS_GPIOS_FLAGS(inst) \
+	DT_SPI_DEV_CS_GPIOS_FLAGS(DT_DRV_INST(inst))
 
 /**
  * @}

--- a/tests/lib/devicetree/src/main.c
+++ b/tests/lib/devicetree/src/main.c
@@ -223,13 +223,13 @@ static void test_bus(void)
 	zassert_true(!strcmp(DT_LABEL(TEST_SPI_BUS_1), "TEST_SPI_CTLR"),
 		     "spi 1");
 
-	zassert_equal(DT_SPI_DEV_HAS_CS(TEST_SPI_DEV_0), 1, "no cs");
-	zassert_equal(DT_SPI_DEV_HAS_CS(TEST_SPI_DEV_NO_CS), 0, "has cs");
+	zassert_equal(DT_SPI_DEV_HAS_CS_GPIOS(TEST_SPI_DEV_0), 1, "no cs");
+	zassert_equal(DT_SPI_DEV_HAS_CS_GPIOS(TEST_SPI_DEV_NO_CS), 0, "has cs");
 
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT vnd_spi_device_2
 	/* there is only one instance, and it has no CS */
-	zassert_equal(DT_INST_SPI_DEV_HAS_CS(0), 0,
+	zassert_equal(DT_INST_SPI_DEV_HAS_CS_GPIOS(0), 0,
 		      "inst of vnd,spi-device-2 with cs");
 
 #undef DT_DRV_COMPAT
@@ -238,17 +238,17 @@ static void test_bus(void)
 	 * DT_INST_SPI_DEV: use with care here. We could be matching
 	 * either vnd,spi-device.
 	 */
-	zassert_equal(DT_INST_SPI_DEV_HAS_CS(0), 1,
+	zassert_equal(DT_INST_SPI_DEV_HAS_CS_GPIOS(0), 1,
 		      "inst of vnd,spi-device without cs");
 
-	zassert_true(!strncmp(gpio, DT_INST_SPI_DEV_CS_GPIO_LABEL(0),
+	zassert_true(!strncmp(gpio, DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
 			      strlen(gpio)),
 		     "inst 0 cs label");
 
-	pin = DT_INST_SPI_DEV_CS_GPIO_PIN(0);
+	pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
 	zassert_true((pin == 0x10) || (pin == 0x30), "inst 0 cs pin");
 
-	flags = DT_INST_SPI_DEV_CS_GPIO_FLAGS(0);
+	flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
 	zassert_true((flags == 0x20) || (flags == 0x40), "inst 0 cs flags");
 
 	zassert_equal(DT_ON_BUS(TEST_SPI_DEV_0, spi), 1, "spidev not on spi");
@@ -1031,18 +1031,18 @@ static void test_devices(void)
 
 static void test_cs_gpios(void)
 {
-	zassert_equal(DT_SPI_HAS_CS(TEST_SPI_NO_CS), 0, "unexpected cs");
-	zassert_equal(DT_SPI_NUM_CS(TEST_SPI_NO_CS), 0, "wrong no. of cs");
+	zassert_equal(DT_SPI_HAS_CS_GPIOS(TEST_SPI_NO_CS), 0, "unexpected cs");
+	zassert_equal(DT_SPI_NUM_CS_GPIOS(TEST_SPI_NO_CS), 0, "wrong no. of cs");
 
-	zassert_equal(DT_SPI_HAS_CS(TEST_SPI), 1, "missing cs");
-	zassert_equal(DT_SPI_NUM_CS(TEST_SPI), 2, "wrong no. of cs");
+	zassert_equal(DT_SPI_HAS_CS_GPIOS(TEST_SPI), 1, "missing cs");
+	zassert_equal(DT_SPI_NUM_CS_GPIOS(TEST_SPI), 2, "wrong no. of cs");
 
-	zassert_true(!strcmp(DT_SPI_DEV_CS_GPIO_LABEL(TEST_SPI_DEV_0),
+	zassert_true(!strcmp(DT_SPI_DEV_CS_GPIOS_LABEL(TEST_SPI_DEV_0),
 			     "TEST_GPIO_1"),
 		     "dev 0 cs gpio name");
-	zassert_equal(DT_SPI_DEV_CS_GPIO_PIN(TEST_SPI_DEV_0), 0x10,
+	zassert_equal(DT_SPI_DEV_CS_GPIOS_PIN(TEST_SPI_DEV_0), 0x10,
 		      "dev 0 cs gpio pin");
-	zassert_equal(DT_SPI_DEV_CS_GPIO_FLAGS(TEST_SPI_DEV_0), 0x20,
+	zassert_equal(DT_SPI_DEV_CS_GPIOS_FLAGS(TEST_SPI_DEV_0), 0x20,
 		      "dev 0 cs gpio flags");
 }
 


### PR DESCRIPTION
Rename the DT_*_CS macro's to DT_*_CS_GPIO to be more clear.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>