### PR TITLE
drivers: eeprom: eeprom_simulator: Convert to new DT_INST macros

### DIFF
--- a/drivers/eeprom/eeprom_simulator.c
+++ b/drivers/eeprom/eeprom_simulator.c
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT zephyr_sim_eeprom
+
 #include <device.h>
 #include <drivers/eeprom.h>
 
@@ -88,7 +90,7 @@ static int eeprom_fd = -1;
 static const char *eeprom_file_path;
 static const char default_eeprom_file_path[] = "eeprom.bin";
 #else
-static u8_t mock_eeprom[DT_INST_0_ZEPHYR_SIM_EEPROM_SIZE];
+static u8_t mock_eeprom[DT_INST_PROP(0, size)];
 #endif /* CONFIG_ARCH_POSIX */
 
 static int eeprom_range_is_valid(struct device *dev, off_t offset, size_t len)
@@ -204,8 +206,8 @@ static const struct eeprom_driver_api eeprom_sim_api = {
 };
 
 static const struct eeprom_sim_config eeprom_sim_config_0 = {
-	.size = DT_INST_0_ZEPHYR_SIM_EEPROM_SIZE,
-	.readonly = DT_INST_0_ZEPHYR_SIM_EEPROM_READ_ONLY,
+	.size = DT_INST_PROP(0, size),
+	.readonly = DT_INST_PROP(0, read_only),
 };
 
 #ifdef CONFIG_ARCH_POSIX
@@ -224,14 +226,14 @@ static int eeprom_mock_init(struct device *dev)
 		return -EIO;
 	}
 
-	if (ftruncate(eeprom_fd, DT_INST_0_ZEPHYR_SIM_EEPROM_SIZE) == -1) {
+	if (ftruncate(eeprom_fd, DT_INST_PROP(0, size)) == -1) {
 		posix_print_warning("Failed to resize eeprom device file ",
 				    "%s: %s\n",
 				    eeprom_file_path, strerror(errno));
 		return -EIO;
 	}
 
-	mock_eeprom = mmap(NULL, DT_INST_0_ZEPHYR_SIM_EEPROM_SIZE,
+	mock_eeprom = mmap(NULL, DT_INST_PROP(0, size),
 			  PROT_WRITE | PROT_READ, MAP_SHARED, eeprom_fd, 0);
 	if (mock_eeprom == MAP_FAILED) {
 		posix_print_warning("Failed to mmap eeprom device file "
@@ -263,7 +265,7 @@ static int eeprom_sim_init(struct device *dev)
 	return eeprom_mock_init(dev);
 }
 
-DEVICE_AND_API_INIT(eeprom_sim_0, DT_INST_0_ZEPHYR_SIM_EEPROM_LABEL,
+DEVICE_AND_API_INIT(eeprom_sim_0, DT_INST_LABEL(0),
 		    &eeprom_sim_init, NULL, &eeprom_sim_config_0, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &eeprom_sim_api);
 
@@ -272,7 +274,7 @@ DEVICE_AND_API_INIT(eeprom_sim_0, DT_INST_0_ZEPHYR_SIM_EEPROM_LABEL,
 static void eeprom_native_posix_cleanup(void)
 {
 	if ((mock_eeprom != MAP_FAILED) && (mock_eeprom != NULL)) {
-		munmap(mock_eeprom, DT_INST_0_ZEPHYR_SIM_EEPROM_SIZE);
+		munmap(mock_eeprom, DT_INST_PROP(0, size));
 	}
 
 	if (eeprom_fd != -1) {


### PR DESCRIPTION
Convert older DT_INST_ macro use the new include/devicetree.h
DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>