### PR TITLE
drivers: eeprom_slave: Convert to new DT_INST macros

### DIFF
--- a/drivers/i2c/slave/eeprom_slave.c
+++ b/drivers/i2c/slave/eeprom_slave.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT atmel_at24
+
 #include <sys/util.h>
 #include <kernel.h>
 #include <errno.h>
@@ -203,44 +205,44 @@ static int i2c_eeprom_slave_init(struct device *dev)
 	return 0;
 }
 
-#ifdef DT_INST_0_ATMEL_AT24
+#if DT_HAS_DRV_INST(0)
 
 static struct i2c_eeprom_slave_data i2c_eeprom_slave_0_dev_data;
 
-static u8_t i2c_eeprom_slave_0_buffer[(DT_INST_0_ATMEL_AT24_SIZE)];
+static u8_t i2c_eeprom_slave_0_buffer[(DT_INST_PROP(0, size))];
 
 static const struct i2c_eeprom_slave_config i2c_eeprom_slave_0_cfg = {
-	.controller_dev_name = DT_INST_0_ATMEL_AT24_BUS_NAME,
-	.address = DT_INST_0_ATMEL_AT24_BASE_ADDRESS,
-	.buffer_size = DT_INST_0_ATMEL_AT24_SIZE,
+	.controller_dev_name = DT_INST_BUS_LABEL(0),
+	.address = DT_INST_REG_ADDR(0),
+	.buffer_size = DT_INST_PROP(0, size),
 	.buffer = i2c_eeprom_slave_0_buffer
 };
 
-DEVICE_AND_API_INIT(i2c_eeprom_slave_0, DT_INST_0_ATMEL_AT24_LABEL,
+DEVICE_AND_API_INIT(i2c_eeprom_slave_0, DT_INST_LABEL(0),
 		    &i2c_eeprom_slave_init,
 		    &i2c_eeprom_slave_0_dev_data, &i2c_eeprom_slave_0_cfg,
 		    POST_KERNEL, CONFIG_I2C_SLAVE_INIT_PRIORITY,
 		    &api_funcs);
 
-#endif /* DT_INST_0_ATMEL_AT24 */
+#endif /* DT_HAS_DRV_INST(0) */
 
-#ifdef DT_INST_1_ATMEL_AT24
+#if DT_HAS_DRV_INST(1)
 
 static struct i2c_eeprom_slave_data i2c_eeprom_slave_1_dev_data;
 
-static u8_t i2c_eeprom_slave_1_buffer[(DT_INST_1_ATMEL_AT24_SIZE)];
+static u8_t i2c_eeprom_slave_1_buffer[(DT_INST_PROP(1, size))];
 
 static const struct i2c_eeprom_slave_config i2c_eeprom_slave_1_cfg = {
-	.controller_dev_name = DT_INST_1_ATMEL_AT24_BUS_NAME,
-	.address = DT_INST_1_ATMEL_AT24_BASE_ADDRESS,
-	.buffer_size = DT_INST_1_ATMEL_AT24_SIZE,
+	.controller_dev_name = DT_INST_BUS_LABEL(1),
+	.address = DT_INST_REG_ADDR(1),
+	.buffer_size = DT_INST_PROP(1, size),
 	.buffer = i2c_eeprom_slave_1_buffer
 };
 
-DEVICE_AND_API_INIT(i2c_eeprom_slave_1, DT_INST_1_ATMEL_AT24_LABEL,
+DEVICE_AND_API_INIT(i2c_eeprom_slave_1, DT_INST_LABEL(1),
 		    &i2c_eeprom_slave_init,
 		    &i2c_eeprom_slave_1_dev_data, &i2c_eeprom_slave_1_cfg,
 		    POST_KERNEL, CONFIG_I2C_SLAVE_INIT_PRIORITY,
 		    &api_funcs);
 
-#endif /* DT_INST_1_ATMEL_AT24 */
+#endif /* DT_HAS_DRV_INST(1) */


### PR DESCRIPTION
Convert older DT_INST_ macro use the new include/devicetree.h
DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>