### PR TITLE
Bluetooth: controller: ticker minor code optimization

### DIFF
--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -417,7 +417,7 @@ static u8_t ticker_enqueue(struct ticker_instance *instance, u8_t id)
 		 */
 		if (ticks_to_expire == 0 && (ticker_new->lazy_current >
 					     ticker_current->lazy_current)) {
-			ticks_to_expire = ticker_current->ticks_to_expire;
+			ticks_to_expire = ticks_to_expire_current;
 			break;
 		}
 


### PR DESCRIPTION
Minor optimization to use a local variable instead of a
deferencing of a struct member.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>