### PR TITLE
subsys: bluetooth: Convert to new DT_INST macros

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -5378,7 +5378,7 @@ static void k32src_wait(void)
 	done = true;
 
 	struct device *clock = device_get_binding(
-		DT_INST_0_NORDIC_NRF_CLOCK_LABEL);
+		DT_LABEL(DT_INST(0, nordic_nrf_clock)));
 
 	LL_ASSERT(clock);
 

--- a/subsys/bluetooth/controller/ll_sw/ll.c
+++ b/subsys/bluetooth/controller/ll_sw/ll.c
@@ -125,7 +125,7 @@ int ll_init(struct k_sem *sem_rx)
 
 	sem_recv = sem_rx;
 
-	clk = device_get_binding(DT_INST_0_NORDIC_NRF_CLOCK_LABEL);
+	clk = device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_clock)));
 	if (!clk) {
 		return -ENODEV;
 	}

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
@@ -28,7 +28,7 @@ int lll_clock_init(void)
 {
 	int err;
 
-	dev = device_get_binding(DT_INST_0_NORDIC_NRF_CLOCK_LABEL);
+	dev = device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_clock)));
 	if (!dev) {
 		return -ENODEV;
 	}


### PR DESCRIPTION
Convert older DT_INST_ macro use the new include/devicetree.h
DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>