### PR TITLE
DT: designware: Convert to new DT_INST macros

### DIFF
--- a/drivers/dma/dma_dw.c
+++ b/drivers/dma/dma_dw.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT snps_designware_dma
+
 #include <errno.h>
 
 #include <stdio.h>
@@ -357,17 +359,17 @@ static const struct dma_driver_api dw_dma_driver_api = {
 	.stop = dw_dma_transfer_stop,
 };
 
-#if defined(DT_INST_0_SNPS_DESIGNWARE_DMA)
+#if DT_HAS_DRV_INST(0)
 
 static struct device DEVICE_NAME_GET(dw_dma0);
 
 static void dw_dma0_irq_config(void)
 {
-	IRQ_CONNECT(DT_INST_0_SNPS_DESIGNWARE_DMA_IRQ_0,
-		    DT_INST_0_SNPS_DESIGNWARE_DMA_IRQ_0_PRIORITY, dw_dma_isr,
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		    DT_INST_IRQ(0, priority), dw_dma_isr,
 		    DEVICE_GET(dw_dma0),
-		    DT_INST_0_SNPS_DESIGNWARE_DMA_IRQ_0_SENSE);
-	irq_enable(DT_INST_0_SNPS_DESIGNWARE_DMA_IRQ_0);
+		    DT_INST_IRQ(0, sense));
+	irq_enable(DT_INST_IRQN(0));
 }
 
 static struct dw_drv_plat_data dmac0 = {
@@ -406,7 +408,7 @@ static struct dw_drv_plat_data dmac0 = {
 };
 
 static const struct dw_dma_dev_cfg dw_dma0_config = {
-	.base = DT_INST_0_SNPS_DESIGNWARE_DMA_BASE_ADDRESS,
+	.base = DT_INST_REG_ADDR(0),
 	.irq_config = dw_dma0_irq_config
 };
 
@@ -414,23 +416,23 @@ static struct dw_dma_dev_data dw_dma0_data = {
 	.channel_data = &dmac0,
 };
 
-DEVICE_AND_API_INIT(dw_dma0, DT_INST_0_SNPS_DESIGNWARE_DMA_LABEL, &dw_dma_init,
+DEVICE_AND_API_INIT(dw_dma0, DT_INST_LABEL(0), &dw_dma_init,
 		    &dw_dma0_data, &dw_dma0_config, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &dw_dma_driver_api);
-#endif /* DT_INST_0_SNPS_DESIGNWARE_DMA */
+#endif /* DT_HAS_DRV_INST(0) */
 
 
-#if defined(DT_INST_1_SNPS_DESIGNWARE_DMA)
+#if DT_HAS_DRV_INST(1)
 
 static struct device DEVICE_NAME_GET(dw_dma2);
 
 static void dw_dma1_irq_config(void)
 {
-	IRQ_CONNECT(DT_INST_1_SNPS_DESIGNWARE_DMA_IRQ_0,
-		    DT_INST_1_SNPS_DESIGNWARE_DMA_IRQ_0_PRIORITY, dw_dma_isr,
+	IRQ_CONNECT(DT_INST_IRQN(1),
+		    DT_INST_IRQ(1, priority), dw_dma_isr,
 		    DEVICE_GET(dw_dma0),
-		    DT_INST_1_SNPS_DESIGNWARE_DMA_IRQ_0_SENSE);
-	irq_enable(DT_INST_1_SNPS_DESIGNWARE_DMA_IRQ_0);
+		    DT_INST_IRQ(1, sense));
+	irq_enable(DT_INST_IRQN(1));
 }
 
 static struct dw_drv_plat_data dmac1 = {
@@ -469,7 +471,7 @@ static struct dw_drv_plat_data dmac1 = {
 };
 
 static const struct dw_dma_dev_cfg dw_dma1_config = {
-	.base = DT_INST_1_SNPS_DESIGNWARE_DMA_BASE_ADDRESS,
+	.base = DT_INST_REG_ADDR(1),
 	.irq_config = dw_dma1_irq_config
 };
 
@@ -477,22 +479,22 @@ static struct dw_dma_dev_data dw_dma1_data = {
 	.channel_data = &dmac1,
 };
 
-DEVICE_AND_API_INIT(dw_dma1, DT_INST_1_SNPS_DESIGNWARE_DMA_LABEL, &dw_dma_init,
+DEVICE_AND_API_INIT(dw_dma1, DT_INST_LABEL(1), &dw_dma_init,
 		    &dw_dma1_data, &dw_dma1_config, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &dw_dma_driver_api);
-#endif /* DT_INST_1_SNPS_DESIGNWARE_DMA */
+#endif /* DT_HAS_DRV_INST(1) */
 
-#if defined(DT_INST_2_SNPS_DESIGNWARE_DMA)
+#if DT_HAS_DRV_INST(2)
 
 static struct device DEVICE_NAME_GET(dw_dma2);
 
 static void dw_dma2_irq_config(void)
 {
-	IRQ_CONNECT(DT_INST_2_SNPS_DESIGNWARE_DMA_IRQ_0,
-		    DT_INST_2_SNPS_DESIGNWARE_DMA_IRQ_0_PRIORITY, dw_dma_isr,
+	IRQ_CONNECT(DT_INST_IRQN(2),
+		    DT_INST_IRQ(2, priority), dw_dma_isr,
 		    DEVICE_GET(dw_dma0),
-		    DT_INST_2_SNPS_DESIGNWARE_DMA_IRQ_0_SENSE);
-	irq_enable(DT_INST_2_SNPS_DESIGNWARE_DMA_IRQ_0);
+		    DT_INST_IRQ(2, sense));
+	irq_enable(DT_INST_IRQN(2));
 }
 
 static struct dw_drv_plat_data dmac2 = {
@@ -531,7 +533,7 @@ static struct dw_drv_plat_data dmac2 = {
 };
 
 static const struct dw_dma_dev_cfg dw_dma2_config = {
-	.base = DT_INST_2_SNPS_DESIGNWARE_DMA_BASE_ADDRESS,
+	.base = DT_INST_REG_ADDR(2),
 	.irq_config = dw_dma2_irq_config
 };
 
@@ -539,7 +541,7 @@ static struct dw_dma_dev_data dw_dma2_data = {
 	.channel_data = &dmac2,
 };
 
-DEVICE_AND_API_INIT(dw_dma2, DT_INST_2_SNPS_DESIGNWARE_DMA_LABEL, &dw_dma_init,
+DEVICE_AND_API_INIT(dw_dma2, DT_INST_LABEL(2), &dw_dma_init,
 		    &dw_dma2_data, &dw_dma2_config, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &dw_dma_driver_api);
-#endif /* DT_INST_2_SNPS_DESIGNWARE_DMA */
+#endif /* DT_HAS_DRV_INST(2) */

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT snps_designware_gpio
+
 #include <errno.h>
 
 #include <kernel.h>
@@ -584,15 +586,15 @@ static void gpio_config_0_irq(struct device *port);
 
 static const struct gpio_dw_config gpio_config_0 = {
 	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_0_SNPS_DESIGNWARE_GPIO_NGPIOS),
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(0, ngpios)),
 	},
 #ifdef CONFIG_GPIO_DW_0_IRQ_DIRECT
-	.irq_num = DT_INST_0_SNPS_DESIGNWARE_GPIO_IRQ_0,
+	.irq_num = DT_INST_IRQN(0),
 #endif
-	.bits = DT_INST_0_SNPS_DESIGNWARE_GPIO_BITS,
+	.bits = DT_INST_PROP(0, bits),
 	.config_func = gpio_config_0_irq,
 #ifdef CONFIG_GPIO_DW_0_IRQ_SHARED
-	.shared_irq_dev_name = DT_INST_0_SNPS_DESIGNWARE_GPIO_IRQ_SHARED_NAME,
+	.shared_irq_dev_name = DT_INST_IRQ_BY_NAME(0, shared_name, irq),
 #endif
 #ifdef CONFIG_GPIO_DW_CLOCK_GATE
 	.clock_data = UINT_TO_POINTER(CONFIG_GPIO_DW_0_CLOCK_GATE_SUBSYS),
@@ -600,35 +602,35 @@ static const struct gpio_dw_config gpio_config_0 = {
 };
 
 static struct gpio_dw_runtime gpio_0_runtime = {
-	.base_addr = DT_INST_0_SNPS_DESIGNWARE_GPIO_BASE_ADDRESS,
+	.base_addr = DT_INST_REG_ADDR(0),
 };
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 
-DEVICE_DEFINE(gpio_dw_0, DT_INST_0_SNPS_DESIGNWARE_GPIO_LABEL,
+DEVICE_DEFINE(gpio_dw_0, DT_INST_LABEL(0),
 	      gpio_dw_initialize, gpio_dw_device_ctrl, &gpio_0_runtime,
 	      &gpio_config_0, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
 #else
-DEVICE_AND_API_INIT(gpio_dw_0, DT_INST_0_SNPS_DESIGNWARE_GPIO_LABEL,
+DEVICE_AND_API_INIT(gpio_dw_0, DT_INST_LABEL(0),
 		    gpio_dw_initialize, &gpio_0_runtime, &gpio_config_0,
 		    POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 		    &api_funcs);
 #endif
 
-#if defined(DT_INST_0_SNPS_DESIGNWARE_GPIO_IRQ_0_FLAGS)
-#define INST_0_IRQ_FLAGS DT_INST_0_SNPS_DESIGNWARE_GPIO_IRQ_0_FLAGS
+#if DT_INST_IRQ_HAS_CELL(0, flags)
+#define INST_0_IRQ_FLAGS DT_INST_IRQ(0, flags)
 #else
 #define INST_0_IRQ_FLAGS 0
 #endif
 static void gpio_config_0_irq(struct device *port)
 {
-#if (DT_INST_0_SNPS_DESIGNWARE_GPIO_IRQ_0 > 0)
+#if (DT_INST_IRQN(0) > 0)
 	const struct gpio_dw_config *config = port->config->config_info;
 
 #ifdef CONFIG_GPIO_DW_0_IRQ_DIRECT
-	IRQ_CONNECT(DT_INST_0_SNPS_DESIGNWARE_GPIO_IRQ_0,
-		    DT_INST_0_SNPS_DESIGNWARE_GPIO_IRQ_0_PRIORITY, gpio_dw_isr,
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		    DT_INST_IRQ(0, priority), gpio_dw_isr,
 		    DEVICE_GET(gpio_dw_0),
 		    INST_0_IRQ_FLAGS);
 	irq_enable(config->irq_num);
@@ -653,16 +655,16 @@ static void gpio_config_1_irq(struct device *port);
 
 static const struct gpio_dw_config gpio_dw_config_1 = {
 	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_1_SNPS_DESIGNWARE_GPIO_NGPIOS),
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(1, ngpios)),
 	},
 #ifdef CONFIG_GPIO_DW_1_IRQ_DIRECT
-	.irq_num = DT_INST_1_SNPS_DESIGNWARE_GPIO_IRQ_0,
+	.irq_num = DT_INST_IRQN(1),
 #endif
-	.bits = DT_INST_1_SNPS_DESIGNWARE_GPIO_BITS,
+	.bits = DT_INST_PROP(1, bits),
 	.config_func = gpio_config_1_irq,
 
 #ifdef CONFIG_GPIO_DW_1_IRQ_SHARED
-	.shared_irq_dev_name = DT_INST_1_SNPS_DESIGNWARE_GPIO_IRQ_SHARED_NAME,
+	.shared_irq_dev_name = DT_INST_IRQ_BY_NAME(1, shared_name, irq),
 #endif
 #ifdef CONFIG_GPIO_DW_CLOCK_GATE
 	.clock_data = UINT_TO_POINTER(CONFIG_GPIO_DW_1_CLOCK_GATE_SUBSYS),
@@ -670,35 +672,35 @@ static const struct gpio_dw_config gpio_dw_config_1 = {
 };
 
 static struct gpio_dw_runtime gpio_1_runtime = {
-	.base_addr = DT_INST_1_SNPS_DESIGNWARE_GPIO_BASE_ADDRESS,
+	.base_addr = DT_INST_REG_ADDR(1),
 };
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-DEVICE_DEFINE(gpio_dw_1, DT_INST_1_SNPS_DESIGNWARE_GPIO_LABEL,
+DEVICE_DEFINE(gpio_dw_1, DT_INST_LABEL(1),
 	      gpio_dw_initialize, gpio_dw_device_ctrl, &gpio_1_runtime,
 	      &gpio_dw_config_1, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
 #else
-DEVICE_AND_API_INIT(gpio_dw_1, DT_INST_1_SNPS_DESIGNWARE_GPIO_LABEL,
+DEVICE_AND_API_INIT(gpio_dw_1, DT_INST_LABEL(1),
 		    gpio_dw_initialize, &gpio_1_runtime, &gpio_dw_config_1,
 		    POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 		    &api_funcs);
 #endif
 
 
-#if defined(DT_INST_1_SNPS_DESIGNWARE_GPIO_IRQ_0_FLAGS)
-#define INST_1_IRQ_FLAGS DT_INST_1_SNPS_DESIGNWARE_GPIO_IRQ_0_FLAGS
+#if DT_INST_IRQ_HAS_CELL(1, flags)
+#define INST_1_IRQ_FLAGS DT_INST_IRQ(1, flags)
 #else
 #define INST_1_IRQ_FLAGS 0
 #endif
 static void gpio_config_1_irq(struct device *port)
 {
-#if (DT_INST_1_SNPS_DESIGNWARE_GPIO_IRQ_0 > 0)
+#if (DT_INST_IRQN(1) > 0)
 	const struct gpio_dw_config *config = port->config->config_info;
 
 #ifdef CONFIG_GPIO_DW_1_IRQ_DIRECT
-	IRQ_CONNECT(DT_INST_1_SNPS_DESIGNWARE_GPIO_IRQ_0,
-		    DT_INST_1_SNPS_DESIGNWARE_GPIO_IRQ_0_PRIORITY, gpio_dw_isr,
+	IRQ_CONNECT(DT_INST_IRQN(1),
+		    DT_INST_IRQ(1, priority), gpio_dw_isr,
 		    DEVICE_GET(gpio_dw_1),
 		    INST_1_IRQ_FLAGS);
 	irq_enable(config->irq_num);
@@ -722,16 +724,16 @@ static void gpio_config_2_irq(struct device *port);
 
 static const struct gpio_dw_config gpio_dw_config_2 = {
 	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_2_SNPS_DESIGNWARE_GPIO_NGPIOS),
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(2, ngpios)),
 	},
 #ifdef CONFIG_GPIO_DW_2_IRQ_DIRECT
-	.irq_num = DT_INST_2_SNPS_DESIGNWARE_GPIO_IRQ_0,
+	.irq_num = DT_INST_IRQN(2),
 #endif
-	.bits = DT_INST_2_SNPS_DESIGNWARE_GPIO_BITS,
+	.bits = DT_INST_PROP(2, bits),
 	.config_func = gpio_config_2_irq,
 
 #ifdef CONFIG_GPIO_DW_2_IRQ_SHARED
-	.shared_irq_dev_name = DT_INST_2_SNPS_DESIGNWARE_GPIO_IRQ_SHARED_NAME,
+	.shared_irq_dev_name = DT_INST_IRQ_BY_NAME(2, shared_name, irq),
 #endif
 #ifdef CONFIG_GPIO_DW_CLOCK_GATE
 	.clock_data = UINT_TO_POINTER(CONFIG_GPIO_DW_2_CLOCK_GATE_SUBSYS),
@@ -739,34 +741,34 @@ static const struct gpio_dw_config gpio_dw_config_2 = {
 };
 
 static struct gpio_dw_runtime gpio_2_runtime = {
-	.base_addr = DT_INST_2_SNPS_DESIGNWARE_GPIO_BASE_ADDRESS,
+	.base_addr = DT_INST_REG_ADDR(2),
 };
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-DEVICE_DEFINE(gpio_dw_2, DT_INST_2_SNPS_DESIGNWARE_GPIO_LABEL,
+DEVICE_DEFINE(gpio_dw_2, DT_INST_LABEL(2),
 	      gpio_dw_initialize, gpio_dw_device_ctrl, &gpio_2_runtime,
 	      &gpio_dw_config_2, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
 #else
-DEVICE_AND_API_INIT(gpio_dw_2, DT_INST_2_SNPS_DESIGNWARE_GPIO_LABEL,
+DEVICE_AND_API_INIT(gpio_dw_2, DT_INST_LABEL(2),
 		    gpio_dw_initialize, &gpio_2_runtime, &gpio_dw_config_2,
 		    POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 		    &api_funcs);
 #endif
 
-#if defined(DT_INST_2_SNPS_DESIGNWARE_GPIO_IRQ_0_FLAGS)
-#define INST_2_IRQ_FLAGS DT_INST_2_SNPS_DESIGNWARE_GPIO_IRQ_0_FLAGS
+#if DT_INST_IRQ_HAS_CELL(2, flags)
+#define INST_2_IRQ_FLAGS DT_INST_IRQ(2, flags)
 #else
 #define INST_2_IRQ_FLAGS 0
 #endif
 static void gpio_config_2_irq(struct device *port)
 {
-#if (DT_INST_2_SNPS_DESIGNWARE_GPIO_IRQ_0 > 0)
+#if (DT_INST_IRQN(2) > 0)
 	const struct gpio_dw_config *config = port->config->config_info;
 
 #ifdef CONFIG_GPIO_DW_2_IRQ_DIRECT
-	IRQ_CONNECT(DT_INST_2_SNPS_DESIGNWARE_GPIO_IRQ_0,
-		    DT_INST_2_SNPS_DESIGNWARE_GPIO_IRQ_0_PRIORITY, gpio_dw_isr,
+	IRQ_CONNECT(DT_INST_IRQN(2),
+		    DT_INST_IRQ(2, priority), gpio_dw_isr,
 		    DEVICE_GET(gpio_dw_2),
 		    INST_2_IRQ_FLAGS);
 	irq_enable(config->irq_num);
@@ -790,16 +792,16 @@ static void gpio_config_3_irq(struct device *port);
 
 static const struct gpio_dw_config gpio_dw_config_3 = {
 	.common = {
-		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_3_SNPS_DESIGNWARE_GPIO_NGPIOS),
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(3, ngpios)),
 	},
 #ifdef CONFIG_GPIO_DW_3_IRQ_DIRECT
-	.irq_num = DT_INST_3_SNPS_DESIGNWARE_GPIO_IRQ_0,
+	.irq_num = DT_INST_IRQN(3),
 #endif
-	.bits = DT_INST_3_SNPS_DESIGNWARE_GPIO_BITS,
+	.bits = DT_INST_PROP(3, bits),
 	.config_func = gpio_config_3_irq,
 
 #ifdef CONFIG_GPIO_DW_3_IRQ_SHARED
-	.shared_irq_dev_name = DT_INST_3_SNPS_DESIGNWARE_GPIO_IRQ_SHARED_NAME,
+	.shared_irq_dev_name = DT_INST_IRQ_BY_NAME(3, shared_name, irq),
 #endif
 #ifdef CONFIG_GPIO_DW_CLOCK_GATE
 	.clock_data = UINT_TO_POINTER(CONFIG_GPIO_DW_3_CLOCK_GATE_SUBSYS),
@@ -807,34 +809,34 @@ static const struct gpio_dw_config gpio_dw_config_3 = {
 };
 
 static struct gpio_dw_runtime gpio_3_runtime = {
-	.base_addr = DT_INST_3_SNPS_DESIGNWARE_GPIO_BASE_ADDRESS,
+	.base_addr = DT_INST_REG_ADDR(3),
 };
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-DEVICE_DEFINE(gpio_dw_3, DT_INST_3_SNPS_DESIGNWARE_GPIO_LABEL,
+DEVICE_DEFINE(gpio_dw_3, DT_INST_LABEL(3),
 	      gpio_dw_initialize, gpio_dw_device_ctrl, &gpio_3_runtime,
 	      &gpio_dw_config_3, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
 #else
-DEVICE_AND_API_INIT(gpio_dw_3, DT_INST_3_SNPS_DESIGNWARE_GPIO_LABEL,
+DEVICE_AND_API_INIT(gpio_dw_3, DT_INST_LABEL(3),
 		    gpio_dw_initialize, &gpio_3_runtime, &gpio_dw_config_3,
 		    POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 		    &api_funcs);
 #endif
 
-#if defined(DT_INST_3_SNPS_DESIGNWARE_GPIO_IRQ_0_FLAGS)
-#define INST_3_IRQ_FLAGS DT_INST_3_SNPS_DESIGNWARE_GPIO_IRQ_0_FLAGS
+#if DT_INST_IRQ_HAS_CELL(3, flags)
+#define INST_3_IRQ_FLAGS DT_INST_IRQ(3, flags)
 #else
 #define INST_3_IRQ_FLAGS 0
 #endif
 static void gpio_config_3_irq(struct device *port)
 {
-#if (DT_INST_3_SNPS_DESIGNWARE_GPIO_IRQ_0 > 0)
+#if (DT_INST_IRQN(3) > 0)
 	const struct gpio_dw_config *config = port->config->config_info;
 
 #ifdef CONFIG_GPIO_DW_3_IRQ_DIRECT
-	IRQ_CONNECT(DT_INST_3_SNPS_DESIGNWARE_GPIO_IRQ_0,
-		    DT_INST_3_SNPS_DESIGNWARE_GPIO_IRQ_0_PRIORITY, gpio_dw_isr,
+	IRQ_CONNECT(DT_INST_IRQN(3),
+		    DT_INST_IRQ(3, priority), gpio_dw_isr,
 		    DEVICE_GET(gpio_dw_3),
 		    INST_3_IRQ_FLAGS);
 	irq_enable(config->irq_num);

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -11,14 +11,16 @@
 #include <drivers/i2c.h>
 #include <stdbool.h>
 
-#if DT_INST_0_SNPS_DESIGNWARE_I2C_PCIE || \
-	DT_INST_1_SNPS_DESIGNWARE_I2C_PCIE || \
-	DT_INST_2_SNPS_DESIGNWARE_I2C_PCIE || \
-	DT_INST_3_SNPS_DESIGNWARE_I2C_PCIE || \
-	DT_INST_4_SNPS_DESIGNWARE_I2C_PCIE || \
-	DT_INST_5_SNPS_DESIGNWARE_I2C_PCIE || \
-	DT_INST_6_SNPS_DESIGNWARE_I2C_PCIE || \
-	DT_INST_7_SNPS_DESIGNWARE_I2C_PCIE
+#define DT_DRV_COMPAT snps_designware_i2c
+
+#if DT_INST_PROP(0, pcie) || \
+	DT_INST_PROP(1, pcie) || \
+	DT_INST_PROP(2, pcie) || \
+	DT_INST_PROP(3, pcie) || \
+	DT_INST_PROP(4, pcie) || \
+	DT_INST_PROP(5, pcie) || \
+	DT_INST_PROP(6, pcie) || \
+	DT_INST_PROP(7, pcie)
 BUILD_ASSERT_MSG(IS_ENABLED(CONFIG_PCIE), "DW I2C in DT needs CONFIG_PCIE");
 #define I2C_DW_PCIE_ENABLED
 #include <drivers/pcie/pcie.h>

--- a/drivers/i2c/i2c_dw_port_x.h
+++ b/drivers/i2c/i2c_dw_port_x.h
@@ -10,35 +10,37 @@ static void i2c_config_@NUM@(struct device *port);
 
 static const struct i2c_dw_rom_config i2c_config_dw_@NUM@ = {
 	.config_func = i2c_config_@NUM@,
-	.bitrate = DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_CLOCK_FREQUENCY,
+	.bitrate = DT_INST_PROP(@NUM@, clock_frequency),
 
-#if DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_PCIE
+#if DT_INST_PROP(@NUM@, pcie)
 	.pcie = true,
-	.pcie_bdf = DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_BASE_ADDRESS,
-	.pcie_id = DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_SIZE,
+	.pcie_bdf = DT_INST_REG_ADDR(@NUM@),
+	.pcie_id = DT_INST_REG_SIZE(@NUM@),
 #endif
 };
 
 static struct i2c_dw_dev_config i2c_@NUM@_runtime = {
 	.regs = (struct i2c_dw_registers *)
-		DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_BASE_ADDRESS
+		DT_INST_REG_ADDR(@NUM@)
 };
 
-DEVICE_AND_API_INIT(i2c_@NUM@, DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_LABEL,
+DEVICE_AND_API_INIT(i2c_@NUM@, DT_INST_LABEL(@NUM@),
 		    &i2c_dw_initialize,
 		    &i2c_@NUM@_runtime, &i2c_config_dw_@NUM@,
 		    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,
 		    &funcs);
 
-#ifndef DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_IRQ_0_SENSE
-#define DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_IRQ_0_SENSE 0
+#if DT_INST_IRQ_HAS_CELL(@NUM@, sense)
+#define INST_@NUM@_IRQ_FLAGS  DT_INST_IRQ(@NUM@, sense)
+#else
+#define INST_@NUM@_IRQ_FLAGS  0
 #endif
 static void i2c_config_@NUM@(struct device *port)
 {
 	ARG_UNUSED(port);
 
-#if DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_PCIE
-#if DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_IRQ_0 == PCIE_IRQ_DETECT
+#if DT_INST_PROP(@NUM@, pcie)
+#if DT_INST_IRQN(@NUM@) == PCIE_IRQ_DETECT
 
 	/* PCI(e) with auto IRQ detection */
 
@@ -47,39 +49,39 @@ static void i2c_config_@NUM@(struct device *port)
 
 	unsigned int irq;
 
-	irq = pcie_wired_irq(DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_BASE_ADDRESS);
+	irq = pcie_wired_irq(DT_INST_REG_ADDR(@NUM@));
 
 	if (irq == PCIE_CONF_INTR_IRQ_NONE) {
 		return;
 	}
 
 	irq_connect_dynamic(irq,
-			    DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_IRQ_0_PRIORITY,
+			    DT_INST_IRQ(@NUM@, priority),
 			    i2c_dw_isr, DEVICE_GET(i2c_@NUM@),
-			    DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_IRQ_0_SENSE);
-	pcie_irq_enable(DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_BASE_ADDRESS, irq);
+			    INST_@NUM@_IRQ_FLAGS);
+	pcie_irq_enable(DT_INST_REG_ADDR(@NUM@), irq);
 
 #else
 
 	/* PCI(e) with fixed or MSI IRQ */
 
-	IRQ_CONNECT(DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_IRQ_0,
-		    DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(@NUM@),
+		    DT_INST_IRQ(@NUM@, priority),
 		    i2c_dw_isr, DEVICE_GET(i2c_@NUM@),
-		    DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_IRQ_0_SENSE);
-	pcie_irq_enable(DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_BASE_ADDRESS,
-			DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_IRQ_0);
+		    INST_@NUM@_IRQ_FLAGS);
+	pcie_irq_enable(DT_INST_REG_ADDR(@NUM@),
+			DT_INST_IRQN(@NUM@));
 
 #endif
 #else
 
 	/* not PCI(e) */
 
-	IRQ_CONNECT(DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_IRQ_0,
-		    DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(@NUM@),
+		    DT_INST_IRQ(@NUM@, priority),
 		    i2c_dw_isr, DEVICE_GET(i2c_@NUM@),
-		    DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_IRQ_0_SENSE);
-	irq_enable(DT_INST_@NUM@_SNPS_DESIGNWARE_I2C_IRQ_0);
+		    INST_@NUM@_IRQ_FLAGS);
+	irq_enable(DT_INST_IRQN(@NUM@));
 
 #endif
 }

--- a/drivers/interrupt_controller/intc_dw.c
+++ b/drivers/interrupt_controller/intc_dw.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT snps_designware_intc
+
 /* This implementation supports only the regular irqs
  * No support for priority filtering
  * No support for vectored interrupts
@@ -126,8 +128,8 @@ static int dw_ictl_intr_get_line_state(struct device *dev, unsigned int irq)
 static void dw_ictl_config_irq(struct device *dev);
 
 static const struct dw_ictl_config dw_config = {
-	.base_addr = DT_INST_0_SNPS_DESIGNWARE_INTC_BASE_ADDRESS,
-	.numirqs = DT_INST_0_SNPS_DESIGNWARE_INTC_NUM_IRQS,
+	.base_addr = DT_INST_REG_ADDR(0),
+	.numirqs = DT_INST_PROP(0, num_irqs),
 	.isr_table_offset = CONFIG_DW_ISR_TBL_OFFSET,
 	.config_func = dw_ictl_config_irq,
 };
@@ -139,15 +141,15 @@ static const struct irq_next_level_api dw_ictl_apis = {
 	.intr_get_line_state = dw_ictl_intr_get_line_state,
 };
 
-DEVICE_AND_API_INIT(dw_ictl, DT_INST_0_SNPS_DESIGNWARE_INTC_LABEL,
+DEVICE_AND_API_INIT(dw_ictl, DT_INST_LABEL(0),
 		    dw_ictl_initialize, NULL, &dw_config,
 		    PRE_KERNEL_1, CONFIG_DW_ICTL_INIT_PRIORITY, &dw_ictl_apis);
 
 static void dw_ictl_config_irq(struct device *port)
 {
-	IRQ_CONNECT(DT_INST_0_SNPS_DESIGNWARE_INTC_IRQ_0,
-		    DT_INST_0_SNPS_DESIGNWARE_INTC_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		    DT_INST_IRQ(0, priority),
 		    dw_ictl_isr,
 		    DEVICE_GET(dw_ictl),
-		    DT_INST_0_SNPS_DESIGNWARE_INTC_IRQ_0_SENSE);
+		    DT_INST_IRQ(0, sense));
 }

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT snps_designware_spi
+
 /* spi_dw.c - Designware SPI driver implementation */
 
 #define LOG_LEVEL CONFIG_SPI_LOG_LEVEL
@@ -543,16 +545,16 @@ struct spi_dw_data spi_dw_data_port_0 = {
 	SPI_CONTEXT_INIT_SYNC(spi_dw_data_port_0, ctx),
 };
 
-#ifdef DT_INST_0_SNPS_DESIGNWARE_SPI_CLOCKS_CLOCK_FREQUENCY
+#if DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, clocks), clock_frequency)
 #define INST_0_SNPS_DESIGNWARE_SPI_CLOCK_FREQ \
-	DT_INST_0_SNPS_DESIGNWARE_SPI_CLOCKS_CLOCK_FREQUENCY
+	DT_INST_PROP_BY_PHANDLE(0, clocks, clock_frequency)
 #else
 #define INST_0_SNPS_DESIGNWARE_SPI_CLOCK_FREQ \
-	DT_INST_0_SNPS_DESIGNWARE_SPI_CLOCK_FREQUENCY
+	DT_INST_PROP(0, clock_frequency)
 #endif
 
 const struct spi_dw_config spi_dw_config_0 = {
-	.regs = DT_INST_0_SNPS_DESIGNWARE_SPI_BASE_ADDRESS,
+	.regs = DT_INST_REG_ADDR(0),
 	.clock_frequency = INST_0_SNPS_DESIGNWARE_SPI_CLOCK_FREQ,
 #ifdef CONFIG_SPI_DW_PORT_0_CLOCK_GATE
 	.clock_name = CONFIG_SPI_DW_PORT_1_CLOCK_GATE_DRV_NAME,
@@ -562,7 +564,7 @@ const struct spi_dw_config spi_dw_config_0 = {
 	.op_modes = CONFIG_SPI_0_OP_MODES
 };
 
-DEVICE_AND_API_INIT(spi_dw_port_0, DT_INST_0_SNPS_DESIGNWARE_SPI_LABEL,
+DEVICE_AND_API_INIT(spi_dw_port_0, DT_INST_LABEL(0),
 		    spi_dw_init, &spi_dw_data_port_0, &spi_dw_config_0,
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
 		    &dw_spi_api);
@@ -570,33 +572,33 @@ DEVICE_AND_API_INIT(spi_dw_port_0, DT_INST_0_SNPS_DESIGNWARE_SPI_LABEL,
 void spi_config_0_irq(void)
 {
 #ifdef CONFIG_SPI_DW_PORT_0_INTERRUPT_SINGLE_LINE
-#if defined(DT_INST_0_SNPS_DESIGNWARE_SPI_IRQ_FLAGS)
-#define INST_0_IRQ_FLAGS DT_INST_0_SNPS_DESIGNWARE_SPI_IRQ_FLAGS
+#if DT_INST_IRQ_HAS_NAME(0, flags)
+#define INST_0_IRQ_FLAGS DT_INST_IRQ_BY_NAME(0, flags, irq)
 #else
 #define INST_0_IRQ_FLAGS 0
 #endif
-	IRQ_CONNECT(DT_INST_0_SNPS_DESIGNWARE_SPI_IRQ_0,
-		    DT_INST_0_SNPS_DESIGNWARE_SPI_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		    DT_INST_IRQ(0, priority),
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_0),
 		    INST_0_IRQ_FLAGS);
-	irq_enable(DT_INST_0_SNPS_DESIGNWARE_SPI_IRQ_0);
+	irq_enable(DT_INST_IRQN(0));
 #else
-	IRQ_CONNECT(DT_INST_0_SNPS_DESIGNWARE_SPI_IRQ_RX_AVAIL,
-		    DT_INST_0_SNPS_DESIGNWARE_SPI_IRQ_RX_AVAIL_PRI,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, rx_avail, irq),
+		    DT_INST_IRQ_BY_NAME(0, rx_avail_pri, irq),
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_0),
-		    DT_INST_0_SNPS_DESIGNWARE_SPI_IRQ_RX_AVAIL_FLAGS);
-	IRQ_CONNECT(DT_INST_0_SNPS_DESIGNWARE_SPI_IRQ_TX_REQ,
-		    DT_INST_0_SNPS_DESIGNWARE_SPI_IRQ_TX_REQ_PRI,
+		    DT_INST_IRQ_BY_NAME(0, rx_avail, flags));
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, tx_req, irq),
+		    DT_INST_IRQ_BY_NAME(0, tx_req_pri, irq),
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_0),
-		    DT_INST_0_SNPS_DESIGNWARE_SPI_IRQ_TX_REQ_FLAGS);
-	IRQ_CONNECT(DT_INST_0_SNPS_DESIGNWARE_SPI_IRQ_ERR_INT,
-		    DT_INST_0_SNPS_DESIGNWARE_SPI_IRQ_ERR_INT_PRI,
+		    DT_INST_IRQ_BY_NAME(0, tx_req, flags));
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, err_int, irq),
+		    DT_INST_IRQ_BY_NAME(0, err_int_pri, irq),
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_0),
-		    DT_INST_0_SNPS_DESIGNWARE_SPI_IRQ_ERR_INT_FLAGS);
+		    DT_INST_IRQ_BY_NAME(0, err_int, flags));
 
-	irq_enable(DT_INST_0_SNPS_DESIGNWARE_SPI_IRQ_RX_AVAIL);
-	irq_enable(DT_INST_0_SNPS_DESIGNWARE_SPI_IRQ_TX_REQ);
-	irq_enable(DT_INST_0_SNPS_DESIGNWARE_SPI_IRQ_ERR_INT);
+	irq_enable(DT_INST_IRQ_BY_NAME(0, rx_avail, irq));
+	irq_enable(DT_INST_IRQ_BY_NAME(0, tx_req, irq));
+	irq_enable(DT_INST_IRQ_BY_NAME(0, err_int, irq));
 
 #endif
 }
@@ -609,16 +611,16 @@ struct spi_dw_data spi_dw_data_port_1 = {
 	SPI_CONTEXT_INIT_SYNC(spi_dw_data_port_1, ctx),
 };
 
-#ifdef DT_INST_1_SNPS_DESIGNWARE_SPI_CLOCKS_CLOCK_FREQUENCY
+#if DT_NODE_HAS_PROP(DT_INST_PHANDLE(1, clocks), clock_frequency)
 #define INST_1_SNPS_DESIGNWARE_SPI_CLOCK_FREQ \
-	DT_INST_1_SNPS_DESIGNWARE_SPI_CLOCKS_CLOCK_FREQUENCY
+	DT_INST_PROP_BY_PHANDLE(1, clocks, clock_frequency)
 #else
 #define INST_1_SNPS_DESIGNWARE_SPI_CLOCK_FREQ \
-	DT_INST_1_SNPS_DESIGNWARE_SPI_CLOCK_FREQUENCY
+	DT_INST_PROP(1, clock_frequency)
 #endif
 
 static const struct spi_dw_config spi_dw_config_1 = {
-	.regs = DT_INST_1_SNPS_DESIGNWARE_SPI_BASE_ADDRESS,
+	.regs = DT_INST_REG_ADDR(1),
 	.clock_frequency = INST_1_SNPS_DESIGNWARE_SPI_CLOCK_FREQ,
 #ifdef CONFIG_SPI_DW_PORT_1_CLOCK_GATE
 	.clock_name = CONFIG_SPI_DW_PORT_1_CLOCK_GATE_DRV_NAME,
@@ -628,7 +630,7 @@ static const struct spi_dw_config spi_dw_config_1 = {
 	.op_modes = CONFIG_SPI_1_OP_MODES
 };
 
-DEVICE_AND_API_INIT(spi_dw_port_1, DT_INST_1_SNPS_DESIGNWARE_SPI_LABEL,
+DEVICE_AND_API_INIT(spi_dw_port_1, DT_INST_LABEL(1),
 		    spi_dw_init, &spi_dw_data_port_1, &spi_dw_config_1,
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
 		    &dw_spi_api);
@@ -636,33 +638,33 @@ DEVICE_AND_API_INIT(spi_dw_port_1, DT_INST_1_SNPS_DESIGNWARE_SPI_LABEL,
 void spi_config_1_irq(void)
 {
 #ifdef CONFIG_SPI_DW_PORT_1_INTERRUPT_SINGLE_LINE
-#if defined(DT_INST_1_SNPS_DESIGNWARE_SPI_IRQ_FLAGS)
-#define INST_1_IRQ_FLAGS DT_INST_1_SNPS_DESIGNWARE_SPI_IRQ_FLAGS
+#if DT_INST_IRQ_HAS_NAME(1, flags)
+#define INST_1_IRQ_FLAGS DT_INST_IRQ_BY_NAME(1, flags, irq)
 #else
 #define INST_1_IRQ_FLAGS 0
 #endif
-	IRQ_CONNECT(DT_INST_1_SNPS_DESIGNWARE_SPI_IRQ_0,
-		    DT_INST_1_SNPS_DESIGNWARE_SPI_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(1),
+		    DT_INST_IRQ(1, priority),
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_1),
 		    INST_1_IRQ_FLAGS);
-	irq_enable(DT_INST_1_SNPS_DESIGNWARE_SPI_IRQ_0);
+	irq_enable(DT_INST_IRQN(1));
 #else
-	IRQ_CONNECT(DT_INST_1_SNPS_DESIGNWARE_SPI_IRQ_RX_AVAIL,
-		    DT_INST_1_SNPS_DESIGNWARE_SPI_IRQ_RX_AVAIL_PRI,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(1, rx_avail, irq),
+		    DT_INST_IRQ_BY_NAME(1, rx_avail_pri, irq),
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_1),
-		    DT_INST_1_SNPS_DESIGNWARE_SPI_IRQ_RX_AVAIL_FLAGS);
-	IRQ_CONNECT(DT_INST_1_SNPS_DESIGNWARE_SPI_IRQ_TX_REQ,
-		    DT_INST_1_SNPS_DESIGNWARE_SPI_IRQ_TX_REQ_PRI,
+		    DT_INST_IRQ_BY_NAME(1, rx_avail, flags));
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(1, tx_req, irq),
+		    DT_INST_IRQ_BY_NAME(1, tx_req_pri, irq),
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_1),
-		    DT_INST_1_SNPS_DESIGNWARE_SPI_IRQ_TX_REQ_FLAGS);
-	IRQ_CONNECT(DT_INST_1_SNPS_DESIGNWARE_SPI_IRQ_ERR_INT,
-		    DT_INST_1_SNPS_DESIGNWARE_SPI_IRQ_ERR_INT_PRI,
+		    DT_INST_IRQ_BY_NAME(1, tx_req, flags));
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(1, err_int, irq),
+		    DT_INST_IRQ_BY_NAME(1, err_int_pri, irq),
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_1),
-		    DT_INST_1_SNPS_DESIGNWARE_SPI_IRQ_ERR_INT_FLAGS);
+		    DT_INST_IRQ_BY_NAME(1, err_int, flags));
 
-	irq_enable(DT_INST_1_SNPS_DESIGNWARE_SPI_IRQ_RX_AVAIL);
-	irq_enable(DT_INST_1_SNPS_DESIGNWARE_SPI_IRQ_TX_REQ);
-	irq_enable(DT_INST_1_SNPS_DESIGNWARE_SPI_IRQ_ERR_INT);
+	irq_enable(DT_INST_IRQ_BY_NAME(1, rx_avail, irq));
+	irq_enable(DT_INST_IRQ_BY_NAME(1, tx_req, irq));
+	irq_enable(DT_INST_IRQ_BY_NAME(1, err_int, irq));
 
 #endif
 }
@@ -675,16 +677,16 @@ struct spi_dw_data spi_dw_data_port_2 = {
 	SPI_CONTEXT_INIT_SYNC(spi_dw_data_port_2, ctx),
 };
 
-#ifdef DT_INST_2_SNPS_DESIGNWARE_SPI_CLOCKS_CLOCK_FREQUENCY
+#if DT_NODE_HAS_PROP(DT_INST_PHANDLE(2, clocks), clock_frequency)
 #define INST_2_SNPS_DESIGNWARE_SPI_CLOCK_FREQ \
-	DT_INST_2_SNPS_DESIGNWARE_SPI_CLOCKS_CLOCK_FREQUENCY
+	DT_INST_PROP_BY_PHANDLE(2, clocks, clock_frequency)
 #else
 #define INST_2_SNPS_DESIGNWARE_SPI_CLOCK_FREQ \
-	DT_INST_2_SNPS_DESIGNWARE_SPI_CLOCK_FREQUENCY
+	DT_INST_PROP(2, clock_frequency)
 #endif
 
 static const struct spi_dw_config spi_dw_config_2 = {
-	.regs = DT_INST_2_SNPS_DESIGNWARE_SPI_BASE_ADDRESS,
+	.regs = DT_INST_REG_ADDR(2),
 	.clock_frequency = INST_2_SNPS_DESIGNWARE_SPI_CLOCK_FREQ,
 #ifdef CONFIG_SPI_DW_PORT_2_CLOCK_GATE
 	.clock_name = CONFIG_SPI_DW_PORT_2_CLOCK_GATE_DRV_NAME,
@@ -694,7 +696,7 @@ static const struct spi_dw_config spi_dw_config_2 = {
 	.op_modes = CONFIG_SPI_2_OP_MODES
 };
 
-DEVICE_AND_API_INIT(spi_dw_port_2, DT_INST_2_SNPS_DESIGNWARE_SPI_LABEL,
+DEVICE_AND_API_INIT(spi_dw_port_2, DT_INST_LABEL(2),
 		    spi_dw_init, &spi_dw_data_port_2, &spi_dw_config_2,
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
 		    &dw_spi_api);
@@ -702,33 +704,33 @@ DEVICE_AND_API_INIT(spi_dw_port_2, DT_INST_2_SNPS_DESIGNWARE_SPI_LABEL,
 void spi_config_2_irq(void)
 {
 #ifdef CONFIG_SPI_DW_PORT_2_INTERRUPT_SINGLE_LINE
-#if defined(DT_INST_2_SNPS_DESIGNWARE_SPI_IRQ_FLAGS)
-#define INST_2_IRQ_FLAGS DT_INST_2_SNPS_DESIGNWARE_SPI_IRQ_FLAGS
+#if DT_INST_IRQ_HAS_NAME(2, flags)
+#define INST_2_IRQ_FLAGS DT_INST_IRQ_BY_NAME(2, flags, irq)
 #else
 #define INST_2_IRQ_FLAGS 0
 #endif
-	IRQ_CONNECT(DT_INST_2_SNPS_DESIGNWARE_SPI_IRQ_0,
-		    DT_INST_2_SNPS_DESIGNWARE_SPI_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(2),
+		    DT_INST_IRQ(2, priority),
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_2),
 		    INST_2_IRQ_FLAGS);
-	irq_enable(DT_INST_2_SNPS_DESIGNWARE_SPI_IRQ_0);
+	irq_enable(DT_INST_IRQN(2));
 #else
-	IRQ_CONNECT(DT_INST_2_SNPS_DESIGNWARE_SPI_IRQ_RX_AVAIL,
-		    DT_INST_2_SNPS_DESIGNWARE_SPI_IRQ_RX_AVAIL_PRI,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(2, rx_avail, irq),
+		    DT_INST_IRQ_BY_NAME(2, rx_avail_pri, irq),
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_2),
-		    DT_INST_2_SNPS_DESIGNWARE_SPI_IRQ_RX_AVAIL_FLAGS);
-	IRQ_CONNECT(DT_INST_2_SNPS_DESIGNWARE_SPI_IRQ_TX_REQ,
-		    DT_INST_2_SNPS_DESIGNWARE_SPI_IRQ_TX_REQ_PRI,
+		    DT_INST_IRQ_BY_NAME(2, rx_avail, flags));
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(2, tx_req, irq),
+		    DT_INST_IRQ_BY_NAME(2, tx_req_pri, irq),
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_2),
-		    DT_INST_2_SNPS_DESIGNWARE_SPI_IRQ_TX_REQ_FLAGS);
-	IRQ_CONNECT(DT_INST_2_SNPS_DESIGNWARE_SPI_IRQ_ERR_INT,
-		    DT_INST_2_SNPS_DESIGNWARE_SPI_IRQ_ERR_INT_PRI,
+		    DT_INST_IRQ_BY_NAME(2, tx_req, flags));
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(2, err_int, irq),
+		    DT_INST_IRQ_BY_NAME(2, err_int_pri, irq),
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_2),
-		    DT_INST_2_SNPS_DESIGNWARE_SPI_IRQ_ERR_INT_FLAGS);
+		    DT_INST_IRQ_BY_NAME(2, err_int, flags));
 
-	irq_enable(DT_INST_2_SNPS_DESIGNWARE_SPI_IRQ_RX_AVAIL);
-	irq_enable(DT_INST_2_SNPS_DESIGNWARE_SPI_IRQ_TX_REQ);
-	irq_enable(DT_INST_2_SNPS_DESIGNWARE_SPI_IRQ_ERR_INT);
+	irq_enable(DT_INST_IRQ_BY_NAME(2, rx_avail, irq));
+	irq_enable(DT_INST_IRQ_BY_NAME(2, tx_req, irq));
+	irq_enable(DT_INST_IRQ_BY_NAME(2, err_int, irq));
 
 #endif
 }
@@ -741,16 +743,16 @@ struct spi_dw_data spi_dw_data_port_3 = {
 	SPI_CONTEXT_INIT_SYNC(spi_dw_data_port_3, ctx),
 };
 
-#ifdef DT_INST_3_SNPS_DESIGNWARE_SPI_CLOCKS_CLOCK_FREQUENCY
+#if DT_NODE_HAS_PROP(DT_INST_PHANDLE(3, clocks), clock_frequency)
 #define INST_3_SNPS_DESIGNWARE_SPI_CLOCK_FREQ \
-	DT_INST_3_SNPS_DESIGNWARE_SPI_CLOCKS_CLOCK_FREQUENCY
+	DT_INST_PROP_BY_PHANDLE(3, clocks, clock_frequency)
 #else
 #define INST_3_SNPS_DESIGNWARE_SPI_CLOCK_FREQ \
-	DT_INST_3_SNPS_DESIGNWARE_SPI_CLOCK_FREQUENCY
+	DT_INST_PROP(3, clock_frequency)
 #endif
 
 static const struct spi_dw_config spi_dw_config_3 = {
-	.regs = DT_INST_3_SNPS_DESIGNWARE_SPI_BASE_ADDRESS,
+	.regs = DT_INST_REG_ADDR(3),
 	.clock_frequency = INST_3_SNPS_DESIGNWARE_SPI_CLOCK_FREQ,
 #ifdef CONFIG_SPI_DW_PORT_3_CLOCK_GATE
 	.clock_name = CONFIG_SPI_DW_PORT_3_CLOCK_GATE_DRV_NAME,
@@ -760,7 +762,7 @@ static const struct spi_dw_config spi_dw_config_3 = {
 	.op_modes = CONFIG_SPI_3_OP_MODES
 };
 
-DEVICE_AND_API_INIT(spi_dw_port_3, DT_INST_3_SNPS_DESIGNWARE_SPI_LABEL,
+DEVICE_AND_API_INIT(spi_dw_port_3, DT_INST_LABEL(3),
 		    spi_dw_init, &spi_dw_data_port_3, &spi_dw_config_3,
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
 		    &dw_spi_api);
@@ -768,33 +770,33 @@ DEVICE_AND_API_INIT(spi_dw_port_3, DT_INST_3_SNPS_DESIGNWARE_SPI_LABEL,
 void spi_config_3_irq(void)
 {
 #ifdef CONFIG_SPI_DW_PORT_3_INTERRUPT_SINGLE_LINE
-#if defined(DT_INST_3_SNPS_DESIGNWARE_SPI_IRQ_FLAGS)
-#define INST_3_IRQ_FLAGS DT_INST_3_SNPS_DESIGNWARE_SPI_IRQ_FLAGS
+#if DT_INST_IRQ_HAS_NAME(3, flags)
+#define INST_3_IRQ_FLAGS DT_INST_IRQ_BY_NAME(3, flags, irq)
 #else
 #define INST_3_IRQ_FLAGS 0
 #endif
-	IRQ_CONNECT(DT_INST_3_SNPS_DESIGNWARE_SPI_IRQ_0,
-		    DT_INST_3_SNPS_DESIGNWARE_SPI_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(3),
+		    DT_INST_IRQ(3, priority),
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_3),
 		    INST_3_IRQ_FLAGS);
-	irq_enable(DT_INST_3_SNPS_DESIGNWARE_SPI_IRQ_0);
+	irq_enable(DT_INST_IRQN(3));
 #else
-	IRQ_CONNECT(DT_INST_3_SNPS_DESIGNWARE_SPI_IRQ_RX_AVAIL,
-		    DT_INST_3_SNPS_DESIGNWARE_SPI_IRQ_RX_AVAIL_PRI,
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(3, rx_avail, irq),
+		    DT_INST_IRQ_BY_NAME(3, rx_avail_pri, irq),
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_3),
-		    DT_INST_3_SNPS_DESIGNWARE_SPI_IRQ_RX_AVAIL_FLAGS);
-	IRQ_CONNECT(DT_INST_3_SNPS_DESIGNWARE_SPI_IRQ_TX_REQ,
-		    DT_INST_3_SNPS_DESIGNWARE_SPI_IRQ_TX_REQ_PRI,
+		    DT_INST_IRQ_BY_NAME(3, rx_avail, flags));
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(3, tx_req, irq),
+		    DT_INST_IRQ_BY_NAME(3, tx_req_pri, irq),
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_3),
-		    DT_INST_3_SNPS_DESIGNWARE_SPI_IRQ_TX_REQ_FLAGS);
-	IRQ_CONNECT(DT_INST_3_SNPS_DESIGNWARE_SPI_IRQ_ERR_INT,
-		    DT_INST_3_SNPS_DESIGNWARE_SPI_IRQ_ERR_INT_PRI,
+		    DT_INST_IRQ_BY_NAME(3, tx_req, flags));
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(3, err_int, irq),
+		    DT_INST_IRQ_BY_NAME(3, err_int_pri, irq),
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_3),
-		    DT_INST_3_SNPS_DESIGNWARE_SPI_IRQ_ERR_INT_FLAGS);
+		    DT_INST_IRQ_BY_NAME(3, err_int, flags));
 
-	irq_enable(DT_INST_3_SNPS_DESIGNWARE_SPI_IRQ_RX_AVAIL);
-	irq_enable(DT_INST_3_SNPS_DESIGNWARE_SPI_IRQ_TX_REQ);
-	irq_enable(DT_INST_3_SNPS_DESIGNWARE_SPI_IRQ_ERR_INT);
+	irq_enable(DT_INST_IRQ_BY_NAME(3, rx_avail, irq));
+	irq_enable(DT_INST_IRQ_BY_NAME(3, tx_req, irq));
+	irq_enable(DT_INST_IRQ_BY_NAME(3, err_int, irq));
 
 #endif
 }

--- a/drivers/usb/device/usb_dc_dw.c
+++ b/drivers/usb/device/usb_dc_dw.c
@@ -1,5 +1,7 @@
 /* usb_dc_dw.c - USB DesignWare device controller driver */
 
+#define DT_DRV_COMPAT snps_designware_usb
+
 /*
  * Copyright (c) 2016 Intel Corporation.
  *
@@ -723,11 +725,11 @@ int usb_dc_attach(void)
 	}
 
 	/* Connect and enable USB interrupt */
-	IRQ_CONNECT(DT_INST_0_SNPS_DESIGNWARE_USB_IRQ_0,
-		    DT_INST_0_SNPS_DESIGNWARE_USB_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		    DT_INST_IRQ(0, priority),
 		    usb_dw_isr_handler, 0,
-		    DT_INST_0_SNPS_DESIGNWARE_USB_IRQ_0_SENSE);
-	irq_enable(DT_INST_0_SNPS_DESIGNWARE_USB_IRQ_0);
+		    DT_INST_IRQ(0, sense));
+	irq_enable(DT_INST_IRQN(0));
 
 	usb_dw_ctrl.attached = 1U;
 
@@ -740,7 +742,7 @@ int usb_dc_detach(void)
 		return 0;
 	}
 
-	irq_disable(DT_INST_0_SNPS_DESIGNWARE_USB_IRQ_0);
+	irq_disable(DT_INST_IRQN(0));
 
 	/* Enable soft disconnect */
 	USB_DW->dctl |= USB_DW_DCTL_SFT_DISCON;

--- a/drivers/usb/device/usb_dw_registers.h
+++ b/drivers/usb/device/usb_dw_registers.h
@@ -198,9 +198,9 @@ struct usb_dw_reg {
 #define USB_DW_PLL_TIMEOUT_US 100
 
 #define USB_DW_EP_FIFO(ep)						\
-	(*(u32_t *)(DT_INST_0_SNPS_DESIGNWARE_USB_BASE_ADDRESS + 0x1000 * (ep + 1)))
+	(*(u32_t *)(DT_INST_REG_ADDR(0) + 0x1000 * (ep + 1)))
 /* USB register block base address */
-#define USB_DW ((struct usb_dw_reg *)DT_INST_0_SNPS_DESIGNWARE_USB_BASE_ADDRESS)
+#define USB_DW ((struct usb_dw_reg *)DT_INST_REG_ADDR(0))
 
 #define DW_USB_IN_EP_NUM		(6)
 #define DW_USB_OUT_EP_NUM		(4)


### PR DESCRIPTION
Convert designware drivers to new DT_INST macros.