### PR TITLE
logging: ot: Fix extern logsystem itf

### DIFF
--- a/samples/subsys/logging/logger/src/ext_log_system_adapter.c
+++ b/samples/subsys/logging/logger/src/ext_log_system_adapter.c
@@ -33,7 +33,7 @@ static void log_handler(enum ext_log_level level, const char *fmt, ...)
 	va_list ap;
 
 	va_start(ap, fmt);
-	log_generic(src_level, fmt, ap);
+	log_generic(src_level, fmt, ap, LOG_STRDUP_CHECK_EXEC);
 	va_end(ap);
 }
 

--- a/soc/xtensa/intel_s1000/xcc/log_minimal_fixes.c
+++ b/soc/xtensa/intel_s1000/xcc/log_minimal_fixes.c
@@ -61,7 +61,8 @@ void log_hexdump_sync(struct log_msg_ids src_level, const char *metadata,
 {
 }
 
-void log_generic(struct log_msg_ids src_level, const char *fmt, va_list ap)
+void log_generic(struct log_msg_ids src_level, const char *fmt, va_list ap,
+		 enum log_strdup_action strdup_action)
 {
 }
 

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -335,7 +335,8 @@ void log_printk(const char *fmt, va_list ap)
 
 			z_log_string_from_user(src_level_union.value, str);
 		} else if (IS_ENABLED(CONFIG_LOG_IMMEDIATE)) {
-			log_generic(src_level_union.structure, fmt, ap);
+			log_generic(src_level_union.structure, fmt, ap,
+							LOG_STRDUP_SKIP);
 		} else {
 			uint8_t str[CONFIG_LOG_PRINTK_MAX_STRING_LENGTH + 1];
 			struct log_msg *msg;
@@ -358,7 +359,7 @@ void log_printk(const char *fmt, va_list ap)
  *
  * Function counts number of '%' not followed by '%'.
  */
-static uint32_t count_args(const char *fmt)
+uint32_t log_count_args(const char *fmt)
 {
 	uint32_t args = 0U;
 	bool prev = false; /* if previous char was a modificator. */
@@ -376,11 +377,12 @@ static uint32_t count_args(const char *fmt)
 	return args;
 }
 
-void log_generic(struct log_msg_ids src_level, const char *fmt, va_list ap)
+void log_generic(struct log_msg_ids src_level, const char *fmt, va_list ap,
+		 enum log_strdup_action strdup_action)
 {
 	if (_is_user_context()) {
 		log_generic_from_user(src_level, fmt, ap);
-	} else  if (IS_ENABLED(CONFIG_LOG_IMMEDIATE) &&
+	} else if (IS_ENABLED(CONFIG_LOG_IMMEDIATE) &&
 	    (!IS_ENABLED(CONFIG_LOG_FRONTEND))) {
 		struct log_backend const *backend;
 		uint32_t timestamp = timestamp_func();
@@ -395,13 +397,32 @@ void log_generic(struct log_msg_ids src_level, const char *fmt, va_list ap)
 		}
 	} else {
 		log_arg_t args[LOG_MAX_NARGS];
-		uint32_t nargs = count_args(fmt);
+		uint32_t nargs = log_count_args(fmt);
 
 		__ASSERT_NO_MSG(nargs < LOG_MAX_NARGS);
 		for (int i = 0; i < nargs; i++) {
 			args[i] = va_arg(ap, log_arg_t);
 		}
 
+		if (strdup_action != LOG_STRDUP_SKIP) {
+			uint32_t mask = z_log_get_s_mask(fmt, nargs);
+
+			while (mask) {
+				uint32_t idx = 31 - __builtin_clz(mask);
+				const char *str = (const char *)args[idx];
+
+				/* is_rodata(str) is not checked,
+				 * because log_strdup does it.
+				 * Hence, we will do only optional check
+				 * if already not duplicated.
+				 */
+				if (strdup_action == LOG_STRDUP_EXEC
+				   || !log_is_strdup(str)) {
+					args[idx] = (log_arg_t)log_strdup(str);
+				}
+				mask &= ~BIT(idx);
+			}
+		}
 		log_n(fmt, args, nargs, src_level);
 	}
 }
@@ -412,7 +433,7 @@ void log_string_sync(struct log_msg_ids src_level, const char *fmt, ...)
 
 	va_start(ap, fmt);
 
-	log_generic(src_level, fmt, ap);
+	log_generic(src_level, fmt, ap, LOG_STRDUP_SKIP);
 
 	va_end(ap);
 }

--- a/subsys/net/lib/openthread/platform/logging.c
+++ b/subsys/net/lib/openthread/platform/logging.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,6 +9,7 @@
 #include <stdio.h>
 
 #include <openthread/platform/logging.h>
+#include "openthread-core-zephyr-config.h"
 
 #define LOG_MODULE_NAME net_openthread
 #define LOG_LEVEL LOG_LEVEL_DBG
@@ -17,41 +18,63 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include "platform-zephyr.h"
 
-#define LOG_PARSE_BUFFER_SIZE  128
 
 void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion,
 	       const char *aFormat, ...)
 {
+	/*
+	 * The following speed optimization have been used:
+	 * - arguments are counted at compile time
+	 * - for none arguments aFormat is not checked for %s
+	 * - for up to three arguments program uses fast path
+	 * - time consuming string formatting is posponed to idle time
+	 * TODO : add support for ll (problem for 32 bit processors)
+	 */
+
+
+#ifdef OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION__COUNT_ARGS
+	/* The arguments number has been counted by macro at compile time,
+	 * and the value has been passed in unused (now) aLogRegion.
+	 * If LogRegion value from OT is needed, rewrite macro
+	 * OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION__COUNT_ARGS and use higher bits.
+	 * to pass args_num.
+	 */
+	uint32_t args_num = (uint32_t) aLogRegion;
+#else
 	ARG_UNUSED(aLogRegion);
 
-	char logString[LOG_PARSE_BUFFER_SIZE + 1];
-	uint16_t length = 0U;
+	uint32_t args_num = log_count_args(aFormat);
+#endif
 
-	/* Parse user string. */
-	va_list paramList;
+	va_list param_list;
 
-	va_start(paramList, aFormat);
-	length += vsnprintf(&logString[length],
-			    (LOG_PARSE_BUFFER_SIZE - length),
-			    aFormat, paramList);
-	va_end(paramList);
+	va_start(param_list, aFormat);
 
-
+	/* We assume, that OT has no access to strdup utility,
+	 * and we are not obliged to check, if string has already
+	 * been duplicated. So, to save time, in Z_LOG_VA macro calls
+	 * we will use LOG_STRDUP_EXEC option.
+	 */
 	switch (aLogLevel) {
 	case OT_LOG_LEVEL_CRIT:
-		LOG_ERR("%s", log_strdup(logString));
+		Z_LOG_VA(LOG_LEVEL_ERR, aFormat, param_list, args_num,
+			LOG_STRDUP_EXEC);
 		break;
 	case OT_LOG_LEVEL_WARN:
-		LOG_WRN("%s", log_strdup(logString));
+		Z_LOG_VA(LOG_LEVEL_WRN, aFormat, param_list, args_num,
+			LOG_STRDUP_EXEC);
 		break;
 	case OT_LOG_LEVEL_NOTE:
 	case OT_LOG_LEVEL_INFO:
-		LOG_INF("%s", log_strdup(logString));
+		Z_LOG_VA(LOG_LEVEL_INF, aFormat, param_list, args_num,
+			LOG_STRDUP_EXEC);
 		break;
 	case OT_LOG_LEVEL_DEBG:
-		LOG_DBG("%s", log_strdup(logString));
+		Z_LOG_VA(LOG_LEVEL_DBG, aFormat, param_list, args_num,
+			LOG_STRDUP_EXEC);
 		break;
 	default:
 		break;
 	}
+	va_end(param_list);
 }

--- a/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
+++ b/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
@@ -151,4 +151,32 @@
  */
 #define OPENTHREAD_CONFIG_NCP_BUFFER_SIZE 2048
 
+/**
+ * @def OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION
+ *
+ * The platform logging function for openthread.
+ *
+ */
+#define _OT_CONF_PLAT_LOG_FUN_NARGS__IMPL(		\
+		_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10,\
+		_11, _12, _13, _14, N, ...) N
+
+#define _OT_CONF_PLAT_LOG_FUN_NARGS__GET(...) \
+		_OT_CONF_PLAT_LOG_FUN_NARGS__IMPL(__VA_ARGS__,\
+		15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, ~)
+
+#define OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION__COUNT_ARGS(aLogLevel, unused, \
+							aFormat, ...) \
+	otPlatLog(aLogLevel, \
+		  (otLogRegion)_OT_CONF_PLAT_LOG_FUN_NARGS__GET(__VA_ARGS__),\
+		  aFormat, ##__VA_ARGS__)
+
+#ifdef OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION
+#error OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION \
+	"OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION mustn't be defined before"
+#endif
+
+#define OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION \
+	OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION__COUNT_ARGS
+
 #endif  /* OPENTHREAD_CORE_NRF52840_CONFIG_H_ */


### PR DESCRIPTION
The pull request consist of two commits: 
- first, adding support for full zephyr's log functionality in the interface function of external subsystem
- second, which uses new methods to enhance OpenThread logs.

Note, that zephyr's utils file could not be used in openthread-core-zephyr-config.h.

Tested using logs with all possible parameters combination.