### PR TITLE
drivers: ipm: fix build issue from DT macro conversion

### DIFF
--- a/drivers/ipm/ipm_cavs_idc_priv.h
+++ b/drivers/ipm/ipm_cavs_idc_priv.h
@@ -7,9 +7,9 @@
 #ifndef ZEPHYR_DRIVERS_IPM_IPM_CAVS_IDC_PRIV_H_
 #define ZEPHYR_DRIVERS_IPM_IPM_CAVS_IDC_PRIV_H_
 
-#define IDC_REG_SIZE		DT_INST_REG_SIZE(0)
+#define IDC_REG_SIZE		DT_REG_SIZE(DT_INST(0, intel_cavs_idc))
 #define IDC_REG_BASE(x)		\
-	(DT_INST_REG_ADDR(0) + x * IDC_REG_SIZE)
+	(DT_REG_ADDR(DT_INST(0, intel_cavs_idc)) + x * IDC_REG_SIZE)
 
 #define IDC_CPU_OFFSET		0x10
 


### PR DESCRIPTION
Since idc_read/idc_write are used outside of the driver we can't use the
DT_INST_... form (that utilize DT_DRV_COMPAT) of the macro's in
ipm_cavs_idc_priv.h.  Use DT_INST(0, intel_cavs_idc) explicitly in the
header to fix the build issue.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>