### PR TITLE
boards: nrf52840_mdk: fix pyocd integration

### DIFF
--- a/boards/arm/adafruit_feather_nrf52840/board.cmake
+++ b/boards/arm/adafruit_feather_nrf52840/board.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
-board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
+board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 board_runner_args(blackmagicprobe "--gdb-serial=/dev/ttyBmpGdb")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nrf52840_mdk/board.cmake
+++ b/boards/arm/nrf52840_mdk/board.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(pyocd "--target=nrf52")
+board_runner_args(pyocd "--target=nrf52840")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
Fix the --target value.

Fixes: #23865

