### PR TITLE
dts: nios2: Add interrupt controller support in dts

### DIFF
--- a/boards/nios2/altera_max10/altera_max10.dts
+++ b/boards/nios2/altera_max10/altera_max10.dts
@@ -6,7 +6,7 @@
 
 / {
 	model = "altera_max10";
-	compatible = "altera,nios2f";
+	compatible = "altera,nios2-max10";
 
 	aliases {
 		uart-0 = &uart0;

--- a/dts/bindings/cpu/altera,nios2f.yaml
+++ b/dts/bindings/cpu/altera,nios2f.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2018 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Altera NIOS-2F CPU
+
+compatible: "altera,nios2f"
+
+include: [interrupt-controller.yaml, base.yaml]
+
+properties:
+  "#interrupt-cells":
+      const: 1
+
+interrupt-cells:
+  - irq

--- a/dts/bindings/cpu/qemu,nios2-zephyr.yaml
+++ b/dts/bindings/cpu/qemu,nios2-zephyr.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: QEMU NIOS2 Zephyr CPU
+
+compatible: "qemu,nios2-zephyr"
+
+include: [interrupt-controller.yaml, base.yaml]
+
+properties:
+  "#interrupt-cells":
+      const: 1
+
+interrupt-cells:
+  - irq

--- a/dts/nios2/nios2-qemu.dtsi
+++ b/dts/nios2/nios2-qemu.dtsi
@@ -7,12 +7,13 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		cpu@0 {
+		cpu: cpu@0 {
 			device_type = "cpu";
-			compatible = "qemu,nios2";
+			compatible = "qemu,nios2-zephyr";
 			reg = <0>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
 		};
-
 	};
 
 	flash0: flash@420000 {
@@ -29,6 +30,7 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "simple-bus";
+		interrupt-parent = <&cpu>;
 		ranges;
 
 		jtag_uart: uart@201000 {
@@ -42,12 +44,11 @@
 		ns16550_uart: uart@440000 {
 			compatible = "ns16550";
 			reg = <0x440000 0x400>;
-			/* interrupts = <1 0>; */
+			interrupts = <1>;
 			clock-frequency = <50000000>;
 			label = "UART_0";
 
 			status = "disabled";
 		};
-
 	};
 };

--- a/dts/nios2/nios2f.dtsi
+++ b/dts/nios2/nios2f.dtsi
@@ -8,12 +8,13 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		cpu@0 {
+		cpu: cpu@0 {
 			device_type = "cpu";
 			compatible = "altera,nios2f";
 			reg = <0>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
 		};
-
 	};
 
 	flash0: flash@0 {
@@ -30,13 +31,14 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "simple-bus";
+		interrupt-parent = <&cpu>;
 		ranges;
 
 		uart0: uart@f0008000 {
 			compatible = "ns16550";
 			reg = <0xf0008000 0x400>;
 			clock-frequency = <50000000>;
-			/* interrupts = <1 0>; */
+			interrupts = <1 0>;
 			label = "UART_0";
 
 			status = "disabled";

--- a/soc/nios2/nios2-qemu/soc.h
+++ b/soc/nios2/nios2-qemu/soc.h
@@ -10,7 +10,4 @@
 
 #include <system.h>
 
-/* Move to DTS once interrupt controller is defined there */
-#define DT_INST_0_NS16550_IRQ_0		A_16550_UART_0_IRQ
-
 #endif

--- a/soc/nios2/nios2f-zephyr/soc.h
+++ b/soc/nios2/nios2f-zephyr/soc.h
@@ -10,7 +10,4 @@
 
 #include <system.h>
 
-/* Move to DTS once interrupt controller is defined there */
-#define DT_INST_0_NS16550_IRQ_0		A_16550_UART_0_IRQ
-
 #endif


### PR DESCRIPTION
Added properties to support the core interrupt controller on the NIOS2
cpu cores and enable that support for the NS16550 UART.

We rename some compatibles so that the cpu core compatibles is unique.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>