### PR TITLE
cmake: Get unit tests passing CI again

### DIFF
--- a/tests/unit/base64/CMakeLists.txt
+++ b/tests/unit/base64/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 project(base64)
 set(SOURCES main.c)
-find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)

--- a/tests/unit/crc/CMakeLists.txt
+++ b/tests/unit/crc/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 project(crc)
 set(SOURCES main.c)
-find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)

--- a/tests/unit/intmath/CMakeLists.txt
+++ b/tests/unit/intmath/CMakeLists.txt
@@ -4,4 +4,4 @@ project(base64)
 set(SOURCES
   main.c
   )
-find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)

--- a/tests/unit/list/CMakeLists.txt
+++ b/tests/unit/list/CMakeLists.txt
@@ -7,4 +7,4 @@ set(SOURCES
   dlist.c
   sflist.c
   )
-find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)

--- a/tests/unit/math_extras/CMakeLists.txt
+++ b/tests/unit/math_extras/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 project(math_extras)
 set(SOURCES main.c portable.c)
-find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)

--- a/tests/unit/rbtree/CMakeLists.txt
+++ b/tests/unit/rbtree/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 project(rbtree)
 set(SOURCES main.c)
-find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)

--- a/tests/unit/timeutil/CMakeLists.txt
+++ b/tests/unit/timeutil/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 project(timeutil)
 set(SOURCES main.c test_gmtime.c  test_s32.c test_s64.c)
-find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 project(util)
 set(SOURCES main.c ../../../lib/os/dec.c)
-find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)

--- a/tests/ztest/base/CMakeLists.txt
+++ b/tests/ztest/base/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.13.1)
 if(BOARD STREQUAL unit_testing)
   list(APPEND SOURCES src/main.c)
 
-  find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+  include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)
   project(base)
 else()
   find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})

--- a/tests/ztest/mock/CMakeLists.txt
+++ b/tests/ztest/mock/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.13.1)
 if(BOARD STREQUAL unit_testing)
   list(APPEND SOURCES src/main.c)
 
-  find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+  include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)
   project(mock)
 else()
   find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})


### PR DESCRIPTION
The following commit:

commit 407b49b35c111042ce474785bb88760322b26f32 (refs/bisect/bad)
Author: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>
Date:   Wed Feb 12 15:00:46 2020 +0100

    cmake: use find_package to locate Zephyr

breaks as we don't find the ZephyrUnittest package.  For now revert to
the old means until a proper fix can be made.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>