### PR TITLE
Zephyr unittest fix

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -405,6 +405,7 @@
 /scripts/zephyr_module.py                 @tejlmand
 /scripts/valgrind.supp                    @aescolar @daor-oti
 /share/zephyr-package/                    @tejlmand
+/share/zephyrunittest-package/            @tejlmand
 /subsys/bluetooth/                        @joerchan @jhedberg @Vudentz
 /subsys/bluetooth/controller/             @carlescufi @cvinayak @thoh-ot
 /subsys/bluetooth/mesh/                   @jhedberg @trond-snekvik @joerchan @Vudentz

--- a/scripts/west_commands/export.py
+++ b/scripts/west_commands/export.py
@@ -47,8 +47,26 @@ class ZephyrExport(WestCommand):
         lines = run_cmake(cmake_args, capture_output=True)
 
         # Let's clean up, as Zephyr has now been exported, and we no longer
-	# need the generated files.
+        # need the generated files.
         cmake_args = ['--build', f'{zephyr_config_package_path}',
+                      '--target', 'pristine']
+        run_cmake(cmake_args, capture_output=True)
+
+        # Let's ignore the normal CMake printing and instead only print
+        # the important information.
+        msg = [line for line in lines if not line.startswith('-- ')]
+        print('\n'.join(msg))
+
+        zephyr_unittest_config_package_path = PurePath(__file__).parents[2] \
+            / 'share' / 'zephyrunittest-package' / 'cmake'
+
+        cmake_args = ['-S', f'{zephyr_unittest_config_package_path}',
+                      '-B', f'{zephyr_unittest_config_package_path}']
+        lines = run_cmake(cmake_args, capture_output=True)
+
+        # Let's clean up, as Zephyr has now been exported, and we no longer
+        # need the generated files.
+        cmake_args = ['--build', f'{zephyr_unittest_config_package_path}',
                       '--target', 'pristine']
         run_cmake(cmake_args, capture_output=True)
 

--- a/share/zephyr-package/cmake/CMakeLists.txt
+++ b/share/zephyr-package/cmake/CMakeLists.txt
@@ -15,14 +15,12 @@ if(NOT (CMAKE_BINARY_DIR STREQUAL CMAKE_CURRENT_LIST_DIR))
   message(WARNING "\$\{CMAKE_BINARY_DIR\} is different from \$\{CMAKE_CURRENT_LIST_DIR\}, Zephyr config package may not work as expected.")
 endif()
 
-message("Zephyr and ZephyrUnitTest (${CMAKE_CURRENT_LIST_DIR})")
+message("Zephyr (${CMAKE_CURRENT_LIST_DIR})")
 message("has been added to the user package registry in:")
 if(WIN32)
-  message("HKEY_CURRENT_USER\\Software\\Kitware\\CMake\\Packages\\Zephyr")
-  message("HKEY_CURRENT_USER\\Software\\Kitware\\CMake\\Packages\\ZephyrUnitTest")
+  message("HKEY_CURRENT_USER\\Software\\Kitware\\CMake\\Packages\\Zephyr\n")
 else()
-  message("~/.cmake/packages/Zephyr")
-  message("~/.cmake/packages/ZephyrUnitTest")
+  message("~/.cmake/packages/Zephyr\n")
 endif()
 
 add_custom_target(pristine
@@ -30,4 +28,3 @@ add_custom_target(pristine
 )
 
 export(PACKAGE Zephyr)
-export(PACKAGE ZephyrUnittest)

--- a/share/zephyr-package/cmake/ZephyrUnittestConfig.cmake
+++ b/share/zephyr-package/cmake/ZephyrUnittestConfig.cmake
@@ -1,4 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-set(ZEPHYR_UNITTEST TRUE)
-include(${CMAKE_CURRENT_LIST_DIR}/ZephyrConfig.cmake)

--- a/share/zephyr-package/cmake/ZephyrUnittestConfigVersion.cmake
+++ b/share/zephyr-package/cmake/ZephyrUnittestConfigVersion.cmake
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-include(${CMAKE_CURRENT_LIST_DIR}/ZephyrConfigVersion.cmake)

--- a/share/zephyrunittest-package/cmake/CMakeLists.txt
+++ b/share/zephyrunittest-package/cmake/CMakeLists.txt
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Purpose of this CMake file is to install a ZephyrUnittestConfig package reference in:
+# Unix/Linux/MacOS: ~/.cmake/packages/ZephyrUnittest
+# Windows         : HKEY_CURRENT_USER
+#
+# Having ZephyrUnittestConfig package allows for find_package(ZephyrUnittest) to work when ZEPHYR_BASE is not defined.
+#
+# Create the reference by running `cmake .` in this directory.
+
+cmake_minimum_required(VERSION 3.13.1)
+project(ZephyrUnittestPackageConfig NONE)
+
+if(NOT (CMAKE_BINARY_DIR STREQUAL CMAKE_CURRENT_LIST_DIR))
+  message(WARNING "\$\{CMAKE_BINARY_DIR\} is different from \$\{CMAKE_CURRENT_LIST_DIR\}, ZephyrUnittest config package may not work as expected.")
+endif()
+
+message("ZephyrUnittest (${CMAKE_CURRENT_LIST_DIR})")
+message("has been added to the user package registry in:")
+if(WIN32)
+  message("HKEY_CURRENT_USER\\Software\\Kitware\\CMake\\Packages\\ZephyrUnittest\n")
+else()
+  message("~/.cmake/packages/ZephyrUnittest\n")
+endif()
+
+add_custom_target(pristine
+                  COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_LIST_DIR}/pristine.cmake
+)
+
+export(PACKAGE ZephyrUnittest)

--- a/share/zephyrunittest-package/cmake/ZephyrUnittestConfig.cmake
+++ b/share/zephyrunittest-package/cmake/ZephyrUnittestConfig.cmake
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+set(ZEPHYR_UNITTEST TRUE)
+include(${CMAKE_CURRENT_LIST_DIR}/../../zephyr-package/cmake/ZephyrConfig.cmake)

--- a/share/zephyrunittest-package/cmake/ZephyrUnittestConfigVersion.cmake
+++ b/share/zephyrunittest-package/cmake/ZephyrUnittestConfigVersion.cmake
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include(${CMAKE_CURRENT_LIST_DIR}/../../zephyr-package/cmake/ZephyrConfigVersion.cmake)

--- a/share/zephyrunittest-package/cmake/pristine.cmake
+++ b/share/zephyrunittest-package/cmake/pristine.cmake
@@ -13,9 +13,8 @@ file(GLOB_RECURSE GENERATED_FILES
 list(REMOVE_ITEM GENERATED_FILES
      "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt"
      "${CMAKE_CURRENT_LIST_DIR}/pristine.cmake"
-     "${CMAKE_CURRENT_LIST_DIR}/zephyr_package_search.cmake"
-     "${CMAKE_CURRENT_LIST_DIR}/ZephyrConfigVersion.cmake"
-     "${CMAKE_CURRENT_LIST_DIR}/ZephyrConfig.cmake"
+     "${CMAKE_CURRENT_LIST_DIR}/ZephyrUnittestConfigVersion.cmake"
+     "${CMAKE_CURRENT_LIST_DIR}/ZephyrUnittestConfig.cmake"
 )
 
 # Delete everything else, as those files are created by CMake.

--- a/tests/unit/base64/CMakeLists.txt
+++ b/tests/unit/base64/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 project(base64)
 set(SOURCES main.c)
-include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)
+find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/crc/CMakeLists.txt
+++ b/tests/unit/crc/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 project(crc)
 set(SOURCES main.c)
-include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)
+find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/intmath/CMakeLists.txt
+++ b/tests/unit/intmath/CMakeLists.txt
@@ -4,4 +4,4 @@ project(base64)
 set(SOURCES
   main.c
   )
-include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)
+find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/list/CMakeLists.txt
+++ b/tests/unit/list/CMakeLists.txt
@@ -7,4 +7,4 @@ set(SOURCES
   dlist.c
   sflist.c
   )
-include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)
+find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/math_extras/CMakeLists.txt
+++ b/tests/unit/math_extras/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 project(math_extras)
 set(SOURCES main.c portable.c)
-include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)
+find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/rbtree/CMakeLists.txt
+++ b/tests/unit/rbtree/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 project(rbtree)
 set(SOURCES main.c)
-include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)
+find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/timeutil/CMakeLists.txt
+++ b/tests/unit/timeutil/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 project(timeutil)
 set(SOURCES main.c test_gmtime.c  test_s32.c test_s64.c)
-include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)
+find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 project(util)
 set(SOURCES main.c ../../../lib/os/dec.c)
-include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)
+find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})

--- a/tests/ztest/base/CMakeLists.txt
+++ b/tests/ztest/base/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.13.1)
 if(BOARD STREQUAL unit_testing)
   list(APPEND SOURCES src/main.c)
 
-  include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)
+  find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
   project(base)
 else()
   find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})

--- a/tests/ztest/mock/CMakeLists.txt
+++ b/tests/ztest/mock/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.13.1)
 if(BOARD STREQUAL unit_testing)
   list(APPEND SOURCES src/main.c)
 
-  include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)
+  find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
   project(mock)
 else()
   find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})


### PR DESCRIPTION
This PR fixes the issue where `find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})` would fail to find the Unittest package on systems where zephyr-export had not been executed.

This PR ensures that the Unittest package are now correctly located on systems that uses the
`source zephyr-env.sh` as the only way to identify the Zephyr repo.

It also reverts PR #23871 as this is no longer needed, when this is fixed.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/23872

