### PR TITLE
west.yml: Update hal_silabs module to SiLabs SDK v2.7.3

### DIFF
--- a/drivers/watchdog/wdt_gecko.c
+++ b/drivers/watchdog/wdt_gecko.c
@@ -137,7 +137,7 @@ static int wdt_gecko_install_timeout(struct device *dev,
 				     const struct wdt_timeout_cfg *cfg)
 {
 	struct wdt_gecko_data *data = DEV_DATA(dev);
-	WDOG_Init_TypeDef init_defaults = WDOG_INIT_DEFAULT;
+	data->wdog_config = (WDOG_Init_TypeDef)WDOG_INIT_DEFAULT;
 	u32_t installed_timeout;
 
 	if (data->timeout_installed) {
@@ -152,7 +152,9 @@ static int wdt_gecko_install_timeout(struct device *dev,
 		return -EINVAL;
 	}
 
-	data->wdog_config = init_defaults;
+#if defined(_WDOG_CTRL_CLKSEL_MASK)
+	data->wdog_config.clkSel = wdogClkSelULFRCO;
+#endif
 
 	data->wdog_config.perSel = (WDOG_PeriodSel_TypeDef)
 		wdt_gecko_get_persel_from_timeout(cfg->window.max);

--- a/west.yml
+++ b/west.yml
@@ -62,7 +62,7 @@ manifest:
       revision: 03c8819ac3105cc2aee295a8d330de0e665b705f
       path: modules/hal/microchip
     - name: hal_silabs
-      revision: 0fb710f258d7ed84a75cfea40319eaf531b61d1e
+      revision: 78da967feeac0d51219ef733cc3ccf643336589f
       path: modules/hal/silabs
     - name: hal_st
       revision: fa481784b3c49780f18d50bafe00390ccb62b2ec


### PR DESCRIPTION
This commit updates west.yml to point hal_silabs module to SiLabs SDK v2.7.3.

Depends on zephyrproject-rtos/hal_silabs/pull/5.