### PR TITLE
Assorted interrupt test clean-up

### DIFF
--- a/tests/kernel/interrupt/src/nested_irq.c
+++ b/tests/kernel/interrupt/src/nested_irq.c
@@ -24,7 +24,10 @@
 #if defined(CONFIG_CPU_CORTEX_M)
 /*
  * For Cortex-M NVIC, unused and available IRQs are automatically detected when
- * when the test is run.
+ * the test is run.
+ *
+ * The IRQ priorities start at 1 because the priority 0 is reserved for the
+ * SVCall exception and Zero-Latency IRQs (see `_EXCEPTION_RESERVED_PRIO`).
  */
 #define IRQ0_PRIO	2
 #define IRQ1_PRIO	1

--- a/tests/kernel/interrupt/src/prevent_irq.c
+++ b/tests/kernel/interrupt/src/prevent_irq.c
@@ -8,19 +8,28 @@
 #include "interrupt_util.h"
 
 #define DURATION	5
+#define HANDLER_TOKEN	0xDEADBEEF
 
 static struct k_timer irqlock_timer;
-
-volatile u32_t check_lock_new;
-u32_t check_lock_old = 0xBEEF;
+volatile u32_t handler_result;
 
 static void timer_handler(struct k_timer *timer)
 {
 	ARG_UNUSED(timer);
-	check_lock_new = 0xBEEF;
+	handler_result = HANDLER_TOKEN;
 	printk("timer fired\n");
 }
 
+/**
+ * @brief Test interrupt prevention
+ *
+ * @ingroup kernel_interrupt_tests
+ *
+ * This routine tests if the kernel is capable of preventing interruption, by
+ * locking interrupts and busy-waiting to see if the system timer interrupt is
+ * serviced while interrupts are locked; in addition, this test also verifies
+ * that the system timer interrupt is serviced after interrupts are unlocked.
+ */
 void test_prevent_interruption(void)
 {
 	int key;
@@ -28,7 +37,7 @@ void test_prevent_interruption(void)
 	printk("locking interrupts\n");
 	key = irq_lock();
 
-	check_lock_new = 0;
+	handler_result = 0;
 
 	k_timer_init(&irqlock_timer, timer_handler, NULL);
 
@@ -38,15 +47,15 @@ void test_prevent_interruption(void)
 	 */
 	k_timer_start(&irqlock_timer, DURATION, K_NO_WAIT);
 	k_busy_wait(MS_TO_US(1000));
-	zassert_not_equal(check_lock_new, check_lock_old,
-		"Interrupt locking didn't work properly");
+	zassert_not_equal(handler_result, HANDLER_TOKEN,
+		"timer interrupt was serviced while interrupts are locked");
 
 	printk("unlocking interrupts\n");
 	irq_unlock(key);
 
 	k_busy_wait(MS_TO_US(1000));
 
-	zassert_equal(check_lock_new, check_lock_old,
+	zassert_equal(handler_result, HANDLER_TOKEN,
 		"timer should have fired");
 
 	k_timer_stop(&irqlock_timer);


### PR DESCRIPTION
Assorted clean-up and documentation for the kernel interrupt tests (`test/kernel/interrupt`)