### PR TITLE
adc: adc_lmp90xxx: Remove DT_INST_0_* comments

### DIFF
--- a/drivers/adc/adc_lmp90xxx.c
+++ b/drivers/adc/adc_lmp90xxx.c
@@ -1118,53 +1118,53 @@ static const struct adc_driver_api lmp90xxx_adc_api = {
  */
 #if DT_HAS_COMPAT(ti_lmp90077)
 LMP90XXX_DEVICE(90077, 0, 16, 4);
-#endif /* DT_INST_0_TI_LMP90077 */
+#endif
 
 /*
  * LMP90078: 16 bit, 2 diff/4 se (4 channels), 2 currents
  */
 #if DT_HAS_COMPAT(ti_lmp90078)
 LMP90XXX_DEVICE(90078, 0, 16, 4);
-#endif /* DT_INST_0_TI_LMP90078 */
+#endif
 
 /*
  * LMP90079: 16 bit, 4 diff/7 se (7 channels), 0 currents, has VIN3-5
  */
 #if DT_HAS_COMPAT(ti_lmp90079)
 LMP90XXX_DEVICE(90079, 0, 16, 7);
-#endif /* DT_INST_0_TI_LMP90079 */
+#endif
 
 /*
  * LMP90080: 16 bit, 4 diff/7 se (7 channels), 2 currents, has VIN3-5
  */
 #if DT_HAS_COMPAT(ti_lmp90080)
 LMP90XXX_DEVICE(90080, 0, 16, 7);
-#endif /* DT_INST_0_TI_LMP90080 */
+#endif
 
 /*
  * LMP90097: 24 bit, 2 diff/4 se (4 channels), 0 currents
  */
 #if DT_HAS_COMPAT(ti_lmp90097)
 LMP90XXX_DEVICE(90097, 0, 24, 4);
-#endif /* DT_INST_0_TI_LMP90097 */
+#endif
 
 /*
  * LMP90098: 24 bit, 2 diff/4 se (4 channels), 2 currents
  */
 #if DT_HAS_COMPAT(ti_lmp90098)
 LMP90XXX_DEVICE(90098, 0, 24, 4);
-#endif /* DT_INST_0_TI_LMP90098 */
+#endif
 
 /*
  * LMP90099: 24 bit, 4 diff/7 se (7 channels), 0 currents, has VIN3-5
  */
 #if DT_HAS_COMPAT(ti_lmp90099)
 LMP90XXX_DEVICE(90099, 0, 24, 7);
-#endif /* DT_INST_0_TI_LMP90099 */
+#endif
 
 /*
  * LMP90100: 24 bit, 4 diff/7 se (7 channels), 2 currents, has VIN3-5
  */
 #if DT_HAS_COMPAT(ti_lmp90100)
 LMP90XXX_DEVICE(90100, 0, 24, 7);
-#endif /* DT_INST_0_TI_LMP90100 */
+#endif


### PR DESCRIPTION
We have a number of cases that now look like:
   #if DT_HAS_COMPAT(ti_lmp90077)
   LMP90XXX_DEVICE(90077, 0, 16, 4);
   #endif /* DT_INST_0_TI_LMP90077 */

The DT_INST_0_TI_LMP90077 comment is stale, and doesn't add much since
the #if associated with the #endif is just 2 lines up.  Removing the old
comments seems the best cleanup.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>