### PR TITLE
[RFC] soc: stm32: include HAL headers based on usage

### DIFF
--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -7,8 +7,10 @@
 menuconfig CLOCK_CONTROL_STM32_CUBE
 	bool "STM32 Reset & Clock Control"
 	depends on SOC_FAMILY_STM32
+	select USE_STM32_LL_BUS if SOC_SERIES_STM32MP1X || SOC_SERIES_STM32H7X
+	select USE_STM32_LL_RCC if SOC_SERIES_STM32MP1X || SOC_SERIES_STM32H7X
+	select USE_STM32_LL_SYSTEM if SOC_SERIES_STM32H7X
 	select USE_STM32_LL_UTILS
-	select USE_STM32_LL_RCC if SOC_SERIES_STM32MP1X
 	help
 	  Enable driver for Reset & Clock Control subsystem found
 	  in STM32 family of MCUs

--- a/drivers/gpio/Kconfig.stm32
+++ b/drivers/gpio/Kconfig.stm32
@@ -6,6 +6,7 @@
 menuconfig GPIO_STM32
 	bool "GPIO Driver for STM32 family of MCUs"
 	depends on SOC_FAMILY_STM32
+	select USE_STM32_LL_GPIO
 	select HAS_DTS_GPIO
 	help
 	  Enable GPIO driver for STM32 line of MCUs

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -23,6 +23,7 @@ config HWINFO_STM32
 	bool "STM32 hwinfo"
 	default y
 	depends on SOC_FAMILY_STM32
+	select USE_STM32_LL_UTILS
 	select HWINFO_HAS_DRIVER
 	help
 	  Enable STM32 hwinfo driver.

--- a/drivers/interrupt_controller/Kconfig.stm32
+++ b/drivers/interrupt_controller/Kconfig.stm32
@@ -8,6 +8,7 @@ if SOC_FAMILY_STM32
 config EXTI_STM32
 	bool "External Interrupt/Event Controller (EXTI) Driver for STM32 family of MCUs"
 	default y if SOC_FAMILY_STM32
+	select USE_STM32_LL_EXTI
 	help
 	  Enable EXTI driver for STM32 line of MCUs
 

--- a/drivers/serial/Kconfig.stm32
+++ b/drivers/serial/Kconfig.stm32
@@ -8,6 +8,7 @@ menuconfig UART_STM32
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	depends on SOC_FAMILY_STM32
+	select USE_STM32_LL_USART
 	help
 	  This option enables the UART driver for STM32 family of
 	  processors.

--- a/drivers/watchdog/Kconfig.stm32
+++ b/drivers/watchdog/Kconfig.stm32
@@ -8,6 +8,7 @@
 menuconfig IWDG_STM32
 	bool "Independent Watchdog (IWDG) Driver for STM32 family of MCUs"
 	depends on SOC_FAMILY_STM32
+	select USE_STM32_LL_IWDG
 	help
 	  Enable IWDG driver for STM32 line of MCUs
 
@@ -23,5 +24,6 @@ config IWDG_STM32_TIMEOUT
 config WWDG_STM32
 	bool "System Window Watchdog (WWDG) Driver for STM32 family of MCUs"
 	depends on SOC_FAMILY_STM32
+	select USE_STM32_LL_WWDG
 	help
 	  Enable WWDG driver for STM32 line of MCUs

--- a/modules/Kconfig.stm32
+++ b/modules/Kconfig.stm32
@@ -530,11 +530,21 @@ config USE_STM32_LL_BDMA
 	  Enable STM32Cube Basic direct memory access controller (BDMA) LL
 	  module driver
 
+config USE_STM32_LL_BUS
+	bool
+	help
+	  Enable STM32Cube Basic bus LL module driver
+
 config USE_STM32_LL_COMP
 	bool
 	help
 	  Enable STM32Cube Ultra Low Power Comparator channels (COMP) LL module
 	  driver
+
+config USE_STM32_LL_CORTEX
+	bool
+	help
+	  Enable STM32Cube Basic Cortex LL module driver
 
 config USE_STM32_LL_CRC
 	bool
@@ -569,6 +579,12 @@ config USE_STM32_LL_DMA2D
 	  Enable STM32Cube Chrom-Art Accelerator™ controller (DMA2D) LL module
 	  driver
 
+config USE_STM32_LL_DMAMUX
+	bool
+	help
+	  Enable STM32Cube DMAMUX LL module
+	  driver
+
 config USE_STM32_LL_EXTI
 	bool
 	help
@@ -596,10 +612,21 @@ config USE_STM32_LL_HRTIM
 	help
 	  Enable STM32Cube High-Resolution Timer (HRTIM) LL module driver
 
+config USE_STM32_LL_HSEM
+	bool
+	help
+	  Enable STM32Cube Hardware Semaphore (HSEM) LL module driver
+
 config USE_STM32_LL_I2C
 	bool
 	help
 	  Enable STM32Cube Inter-integrated circuit (I2C) interface LL module
+	  driver
+
+config USE_STM32_LL_IWDG
+	bool
+	help
+	  Enable STM32Cube Independent Watchdog (IWDG) interface LL module
 	  driver
 
 config USE_STM32_LL_IPCC
@@ -667,6 +694,11 @@ config USE_STM32_LL_SWPMI
 	  Enable STM32Cube Single Wire Protocol Master Interface (SWPMI) LL
 	  module driver
 
+config USE_STM32_LL_SYSTEM
+	bool
+	help
+	  Enable STM32Cube System LL module driver
+
 config USE_STM32_LL_TIM
 	bool
 	help
@@ -688,5 +720,10 @@ config USE_STM32_LL_UTILS
 	bool
 	help
 	  Enable STM32Cube Utility functions (UTILS) LL module driver
+
+config USE_STM32_LL_WWDG
+	bool
+	help
+	  Enable STM32Cube System Window Watchdog (WWDG) LL module driver
 
 endif # HAS_STM32CUBE

--- a/soc/arm/st_stm32/stm32h7/Kconfig.series
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.series
@@ -12,13 +12,17 @@ config SOC_SERIES_STM32H7X
 	select HAS_STM32CUBE
 	select CPU_HAS_ARM_MPU
 	select REQUIRES_FULL_LIBC
-	select USE_STM32_HAL_RCC_EX if CPU_CORTEX_M4
+	select USE_STM32_LL_BUS
+	select USE_STM32_LL_CORTEX
+	select USE_STM32_LL_PWR
+	select USE_STM32_LL_RCC
 	help
 	  Enable support for STM32H7 MCU series
 
 config STM32H7_DUAL_CORE
 	bool "Enable Dual Core"
 	depends on SOC_SERIES_STM32H7X
+	select USE_STM32_LL_HSEM
 
 choice STM32H7_DUAL_CORE_BOOT
 	prompt "STM32H7x Boot type selection"

--- a/soc/arm/st_stm32/stm32h7/soc.h
+++ b/soc/arm/st_stm32/stm32h7/soc.h
@@ -1,79 +1,138 @@
 /*
  * Copyright (c) 2019 Linaro Limited
+ * Copyright (c) 2020 Teslabs Engineering S.L.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _STM32F7_SOC_H_
-#define _STM32F7_SOC_H_
+#ifndef _STM32H7_SOC_H_
+#define _STM32H7_SOC_H_
 
 #include <sys/util.h>
 
 #ifndef _ASMLANGUAGE
 
 #include <autoconf.h>
-#include <stm32h7xx.h>
-
-/* Add include for DTS generated information */
 #include <devicetree.h>
 
 #ifdef CONFIG_STM32H7_DUAL_CORE
-
 #define LL_HSEM_ID_0   (0U) /* HW semaphore 0 */
 #define LL_HSEM_MASK_0 (1 << LL_HSEM_ID_0)
 #define LL_HSEM_ID_1   (1U) /* HW semaphore 1 */
 #define LL_HSEM_MASK_1 (1 << LL_HSEM_ID_1)
-
-#include <stm32h7xx_ll_hsem.h>
-
-#ifdef CONFIG_CPU_CORTEX_M4
-
-#include <stm32h7xx_ll_bus.h>
-#include <stm32h7xx_ll_pwr.h>
-#include <stm32h7xx_ll_cortex.h>
-
-#endif /* CONFIG_CPU_CORTEX_M4 */
-
 #endif /* CONFIG_STM32H7_DUAL_CORE */
 
-#ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
+#include <stm32h7xx.h>
+
+#ifdef CONFIG_USE_STM32_LL_ADC
+#include <stm32h7xx_ll_adc.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_BDMA
+#include <stm32h7xx_ll_bdma.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_BUS
 #include <stm32h7xx_ll_bus.h>
-#include <stm32h7xx_ll_rcc.h>
-#include <stm32h7xx_ll_pwr.h>
-#include <stm32h7xx_ll_system.h>
-#endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
-
-#ifdef CONFIG_EXTI_STM32
+#endif
+#ifdef CONFIG_USE_STM32_LL_COMP
+#include <stm32h7xx_ll_comp.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_CORTEX
+#include <stm32h7xx_ll_cortex.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_CRC
+#include <stm32h7xx_ll_crc.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_CRS
+#include <stm32h7xx_ll_crs.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_DAC
+#include <stm32h7xx_ll_dac.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_DELAYBLOCK
+#include <stm32h7xx_ll_delayblock.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_DMA
+#include <stm32h7xx_ll_dma.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_DMA2D
+#include <stm32h7xx_ll_dma2d.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_DMAMUX
+#include <stm32h7xx_ll_dmamux.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_EXTI
 #include <stm32h7xx_ll_exti.h>
-#endif /* CONFIG_EXTI_STM32 */
-
-#ifdef CONFIG_GPIO_STM32
+#endif
+#ifdef CONFIG_USE_STM32_LL_FMC
+#include <stm32h7xx_ll_fmc.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_GPIO
 #include <stm32h7xx_ll_gpio.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_HRTIM
+#include <stm32h7xx_ll_hrtim.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_HSEM
+#include <stm32h7xx_ll_hsem.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_I2C
+#include <stm32h7xx_ll_i2c.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_IWDG
+#include <stm32h7xx_ll_iwdg.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_LPTIM
+#include <stm32h7xx_ll_lptim.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_LPUART
+#include <stm32h7xx_ll_lpuart.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_MDMA
+#include <stm32h7xx_ll_mdma.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_OPAMP
+#include <stm32h7xx_ll_opamp.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_PWR
+#include <stm32h7xx_ll_pwr.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_RCC
+#include <stm32h7xx_ll_rcc.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_RNG
+#include <stm32h7xx_ll_rng.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_RTC
+#include <stm32h7xx_ll_rtc.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_SDMMC
+#include <stm32h7xx_ll_sdmmc.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_SPI
+#include <stm32h7xx_ll_spi.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_SWPMI
+#include <stm32h7xx_ll_swpmi.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_SYSTEM
 #include <stm32h7xx_ll_system.h>
-#endif /* CONFIG_GPIO_STM32 */
-
-#ifdef CONFIG_WWDG_STM32
+#endif
+#ifdef CONFIG_USE_STM32_LL_TIM
+#include <stm32h7xx_ll_tim.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_USART
+#include <stm32h7xx_ll_usart.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_USB
+#include <stm32h7xx_ll_usb.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_UTILS
+#include <stm32h7xx_ll_utils.h>
+#endif
+#ifdef CONFIG_USE_STM32_LL_WWDG
 #include <stm32h7xx_ll_wwdg.h>
 #endif
 
-#ifdef CONFIG_SERIAL_HAS_DRIVER
-#include <stm32h7xx_ll_usart.h>
-#endif /* CONFIG_SERIAL_HAS_DRIVER */
-
-#ifdef CONFIG_HWINFO_STM32
-#include <stm32h7xx_ll_utils.h>
-#endif
-
-#ifdef CONFIG_COUNTER_RTC_STM32
-#include <stm32h7xx_ll_rtc.h>
-#include <stm32h7xx_ll_exti.h>
-#include <stm32h7xx_ll_pwr.h>
-#endif /* CONFIG_COUNTER_RTC_STM32 */
-
-#ifdef CONFIG_I2C_STM32
-#include <stm32h7xx_ll_i2c.h>
-#endif /* CONFIG_I2C_STM32 */
-
 #endif /* !_ASMLANGUAGE */
 
-#endif /* _STM32F7_SOC_H7_ */
+#endif /* _STM32H7_SOC_H_ */


### PR DESCRIPTION
As of today STM32 `soc.h` file includes HAL header files based on driver configuration instead of HAL usage. The proposed changes do the opposite, that is:

- Driver selects which HAL components it needs (`USE_STM32_LL_XXX` or `USE_STM32_HAL_XX`)
- `soc.h` file includes HAL headers based on selected configuration

Advantages:

- It is more clear what a driver needs/uses by looking at `Kconfig`
- If an application uses HAL directly (e.g. because it has a custom driver) it just needs to select `USE_STM32_XXX` and the right headers will be included.

The changes have been only applied to H7 series for demonstration purposes.