### PR TITLE
drivers:sifive: fix pending clear for falling edge

### DIFF
--- a/drivers/gpio/gpio_sifive.c
+++ b/drivers/gpio/gpio_sifive.c
@@ -282,7 +282,7 @@ static int gpio_sifive_pin_interrupt_configure(struct device *dev,
 			gpio->rise_ie |= BIT(pin);
 		}
 		if ((trig & GPIO_INT_LOW_0) != 0) {
-			gpio->rise_ip = BIT(pin);
+			gpio->fall_ip = BIT(pin);
 			gpio->fall_ie |= BIT(pin);
 		}
 		irq_enable(gpio_sifive_pin_irq(cfg->gpio_irq_base, pin));


### PR DESCRIPTION
The wrong register was used clearing pending interrupts on falling
edge cases.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>