### PR TITLE
disk: sdhc: Control CS line via SPI driver

### DIFF
--- a/subsys/disk/Kconfig
+++ b/subsys/disk/Kconfig
@@ -98,6 +98,15 @@ config DISK_ACCESS_SPI_SDHC
 	help
 	  File system on a SDHC card accessed over SPI.
 
+if DISK_ACCESS_SPI_SDHC
+
+config DISK_SDHC_SPI_CS_CONTROL_DELAY
+	int "CS line control delay in microseconds"
+	default 0
+	help
+	  Delay in microseconds to control CS line before and after transmitting.
+endif
+
 config DISK_ACCESS_USDHC
 	bool "NXP i.MXRT USDHC driver"
 	depends on (HAS_MCUX_USDHC1 || HAS_MCUX_USDHC2)


### PR DESCRIPTION
Set CS control context to use SPI driver's CS line control function.
Remove sdhc_spi driver specific CS line control.
If 'cs-gpios' property was not defined in dts, set NULL for CS context.
(Hardware CS control will be enabled that implemented by
 some SPI controllers in this case.)

Signed-off-by: Tokita Hiroshi <tokita.hiroshi@gmail.com>