### PR TITLE
drivers: eeprom: at2x: use new DT_INST macros

### DIFF
--- a/drivers/eeprom/eeprom_at2x.c
+++ b/drivers/eeprom/eeprom_at2x.c
@@ -550,138 +550,62 @@ static const struct eeprom_driver_api eeprom_at2x_api = {
 	BUILD_ASSERT_MSG(size % page == 0U, \
 			 "Size is not an integer multiple of page size")
 
-#define EEPROM_AT2X_DEVICE(t, n) \
-	ASSERT_PAGESIZE_IS_POWER_OF_2(DT_INST_##n##_ATMEL_AT##t##_PAGESIZE); \
-	ASSERT_SIZE_PAGESIZE_VALID(DT_INST_##n##_ATMEL_AT##t##_SIZE, \
-				   DT_INST_##n##_ATMEL_AT##t##_PAGESIZE); \
-	ASSERT_AT##t##_ADDR_W_VALID(DT_INST_##n##_ATMEL_AT##t##_ADDRESS_WIDTH);\
+#define DT_INST_AT2X(inst, t) DT_INST(inst, atmel_at##t)
+
+#define EEPROM_AT2X_DEVICE(n, t) \
+	ASSERT_PAGESIZE_IS_POWER_OF_2(DT_PROP(DT_INST_AT2X(n, t), pagesize)); \
+	ASSERT_SIZE_PAGESIZE_VALID(DT_PROP(DT_INST_AT2X(n, t), size), \
+				   DT_PROP(DT_INST_AT2X(n, t), pagesize)); \
+	ASSERT_AT##t##_ADDR_W_VALID(DT_PROP(DT_INST_AT2X(n, t), \
+					    address_width)); \
 	static const struct eeprom_at2x_config eeprom_at##t##_config_##n = { \
-		.bus_dev_name = DT_INST_##n##_ATMEL_AT##t##_BUS_NAME, \
-		.bus_addr = DT_INST_##n##_ATMEL_AT##t##_BASE_ADDRESS, \
-		.max_freq = DT_INST_##n##_ATMEL_AT##t##_SPI_MAX_FREQUENCY, \
-		.spi_cs_dev_name = \
-			DT_INST_##n##_ATMEL_AT##t##_CS_GPIOS_CONTROLLER, \
-		.spi_cs_pin = DT_INST_##n##_ATMEL_AT##t##_CS_GPIOS_PIN, \
-		.wp_gpio_pin = DT_INST_##n##_ATMEL_AT##t##_WP_GPIOS_PIN, \
-		.wp_gpio_flags = DT_INST_##n##_ATMEL_AT##t##_WP_GPIOS_FLAGS, \
-		.wp_gpio_name = \
-			DT_INST_##n##_ATMEL_AT##t##_WP_GPIOS_CONTROLLER, \
-		.size = DT_INST_##n##_ATMEL_AT##t##_SIZE, \
-		.pagesize = DT_INST_##n##_ATMEL_AT##t##_PAGESIZE, \
-		.addr_width = DT_INST_##n##_ATMEL_AT##t##_ADDRESS_WIDTH, \
-		.readonly = DT_INST_##n##_ATMEL_AT##t##_READ_ONLY, \
-		.timeout =  DT_INST_##n##_ATMEL_AT##t##_TIMEOUT, \
+		.bus_dev_name = DT_BUS_LABEL(DT_INST_AT2X(n, t)), \
+		.bus_addr = DT_REG_ADDR(DT_INST_AT2X(n, t)), \
+		.max_freq = UTIL_AND( \
+			DT_NODE_HAS_PROP(DT_INST_AT2X(n, t), \
+					 spi_max_frequency), \
+			DT_PROP(DT_INST_AT2X(n, t), spi_max_frequency)), \
+		.spi_cs_dev_name = UTIL_AND( \
+			DT_SPI_DEV_HAS_CS_GPIOS(DT_INST_AT2X(n, t)), \
+			DT_SPI_DEV_CS_GPIOS_LABEL(DT_INST_AT2X(n, t))),	\
+		.spi_cs_pin = UTIL_AND( \
+			DT_SPI_DEV_HAS_CS_GPIOS(DT_INST_AT2X(n, t)), \
+			DT_SPI_DEV_CS_GPIOS_PIN(DT_INST_AT2X(n, t))), \
+		.wp_gpio_pin = UTIL_AND( \
+			DT_NODE_HAS_PROP(DT_INST_AT2X(n, t), wp_gpios), \
+			DT_GPIO_PIN(DT_INST_AT2X(n, t), wp_gpios)), \
+		.wp_gpio_flags = UTIL_AND( \
+			DT_NODE_HAS_PROP(DT_INST_AT2X(n, t), wp_gpios), \
+			DT_GPIO_FLAGS(DT_INST_AT2X(n, t), wp_gpios)), \
+		.wp_gpio_name = UTIL_AND( \
+			DT_NODE_HAS_PROP(DT_INST_AT2X(n, t), wp_gpios), \
+			DT_GPIO_LABEL(DT_INST_AT2X(n, t), wp_gpios)), \
+		.size = DT_PROP(DT_INST_AT2X(n, t), size), \
+		.pagesize = DT_PROP(DT_INST_AT2X(n, t), pagesize), \
+		.addr_width = DT_PROP(DT_INST_AT2X(n, t), address_width), \
+		.readonly = DT_PROP(DT_INST_AT2X(n, t), read_only), \
+		.timeout = DT_PROP(DT_INST_AT2X(n, t), timeout), \
 		.read_fn = eeprom_at##t##_read, \
 		.write_fn = eeprom_at##t##_write, \
 	}; \
 	static struct eeprom_at2x_data eeprom_at##t##_data_##n; \
 	DEVICE_AND_API_INIT(eeprom_at##t##_##n, \
-			    DT_INST_##n##_ATMEL_AT##t##_LABEL, \
+			    DT_LABEL(DT_INST_AT2X(n, t)), \
 			    &eeprom_at2x_init, &eeprom_at##t##_data_##n, \
 			    &eeprom_at##t##_config_##n, POST_KERNEL, \
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
 			    &eeprom_at2x_api)
 
+#define EEPROM_AT24_DEVICE(n) EEPROM_AT2X_DEVICE(n, 24)
+#define EEPROM_AT25_DEVICE(n) EEPROM_AT2X_DEVICE(n, 25)
+
+#define DT_INST_AT2X_FOREACH(t, inst_expr) \
+	UTIL_LISTIFY(DT_NUM_INST(atmel_at##t), DT_CALL_WITH_ARG, inst_expr)
+
 #ifdef CONFIG_EEPROM_AT24
-#if DT_INST_0_ATMEL_AT24
-#define DT_INST_0_ATMEL_AT24_SPI_MAX_FREQUENCY 0
-#define DT_INST_0_ATMEL_AT24_CS_GPIOS_CONTROLLER NULL
-#define DT_INST_0_ATMEL_AT24_CS_GPIOS_PIN 0
-#ifndef DT_INST_0_ATMEL_AT24_WP_GPIOS_CONTROLLER
-#define DT_INST_0_ATMEL_AT24_WP_GPIOS_CONTROLLER NULL
-#define DT_INST_0_ATMEL_AT24_WP_GPIOS_PIN 0
-#define DT_INST_0_ATMEL_AT24_WP_GPIOS_FLAGS GPIO_ACTIVE_LOW
+DT_INST_AT2X_FOREACH(24, EEPROM_AT24_DEVICE);
 #endif
-EEPROM_AT2X_DEVICE(24, 0);
-#endif
-
-#if DT_INST_1_ATMEL_AT24
-#define DT_INST_1_ATMEL_AT24_SPI_MAX_FREQUENCY 0
-#define DT_INST_1_ATMEL_AT24_CS_GPIOS_CONTROLLER NULL
-#define DT_INST_1_ATMEL_AT24_CS_GPIOS_PIN 0
-#ifndef DT_INST_1_ATMEL_AT24_WP_GPIOS_CONTROLLER
-#define DT_INST_1_ATMEL_AT24_WP_GPIOS_CONTROLLER NULL
-#define DT_INST_1_ATMEL_AT24_WP_GPIOS_PIN 0
-#define DT_INST_1_ATMEL_AT24_WP_GPIOS_FLAGS GPIO_ACTIVE_LOW
-#endif
-EEPROM_AT2X_DEVICE(24, 1);
-#endif
-
-#if DT_INST_2_ATMEL_AT24
-#define DT_INST_2_ATMEL_AT24_SPI_MAX_FREQUENCY 0
-#define DT_INST_2_ATMEL_AT24_CS_GPIOS_CONTROLLER NULL
-#define DT_INST_2_ATMEL_AT24_CS_GPIOS_PIN 0
-#ifndef DT_INST_2_ATMEL_AT24_WP_GPIOS_CONTROLLER
-#define DT_INST_2_ATMEL_AT24_WP_GPIOS_CONTROLLER NULL
-#define DT_INST_2_ATMEL_AT24_WP_GPIOS_PIN 0
-#define DT_INST_2_ATMEL_AT24_WP_GPIOS_FLAGS GPIO_ACTIVE_LOW
-#endif
-EEPROM_AT2X_DEVICE(24, 2);
-#endif
-
-#if DT_INST_3_ATMEL_AT24
-#define DT_INST_3_ATMEL_AT24_SPI_MAX_FREQUENCY 0
-#define DT_INST_3_ATMEL_AT24_CS_GPIOS_CONTROLLER NULL
-#define DT_INST_3_ATMEL_AT24_CS_GPIOS_PIN 0
-#ifndef DT_INST_3_ATMEL_AT24_WP_GPIOS_CONTROLLER
-#define DT_INST_3_ATMEL_AT24_WP_GPIOS_CONTROLLER NULL
-#define DT_INST_3_ATMEL_AT24_WP_GPIOS_PIN 0
-#define DT_INST_3_ATMEL_AT24_WP_GPIOS_FLAGS GPIO_ACTIVE_LOW
-#endif
-EEPROM_AT2X_DEVICE(24, 3);
-#endif
-#endif /* CONFIG_EEPROM_AT24 */
 
 #ifdef CONFIG_EEPROM_AT25
-#if DT_INST_0_ATMEL_AT25
-#ifndef DT_INST_0_ATMEL_AT25_CS_GPIOS_CONTROLLER
-#define DT_INST_0_ATMEL_AT25_CS_GPIOS_CONTROLLER NULL
-#define DT_INST_0_ATMEL_AT25_CS_GPIOS_PIN 0
+DT_INST_AT2X_FOREACH(25, EEPROM_AT25_DEVICE);
 #endif
-#ifndef DT_INST_0_ATMEL_AT25_WP_GPIOS_CONTROLLER
-#define DT_INST_0_ATMEL_AT25_WP_GPIOS_CONTROLLER NULL
-#define DT_INST_0_ATMEL_AT25_WP_GPIOS_PIN 0
-#define DT_INST_0_ATMEL_AT25_WP_GPIOS_FLAGS GPIO_ACTIVE_LOW
-#endif
-EEPROM_AT2X_DEVICE(25, 0);
-#endif
-
-#if DT_INST_1_ATMEL_AT25
-#ifndef DT_INST_1_ATMEL_AT25_CS_GPIOS_CONTROLLER
-#define DT_INST_1_ATMEL_AT25_CS_GPIOS_CONTROLLER NULL
-#define DT_INST_1_ATMEL_AT25_CS_GPIOS_PIN 0
-#endif
-#ifndef DT_INST_1_ATMEL_AT25_WP_GPIOS_CONTROLLER
-#define DT_INST_1_ATMEL_AT25_WP_GPIOS_CONTROLLER NULL
-#define DT_INST_1_ATMEL_AT25_WP_GPIOS_PIN 0
-#define DT_INST_1_ATMEL_AT25_WP_GPIOS_FLAGS GPIO_ACTIVE_LOW
-#endif
-EEPROM_AT2X_DEVICE(25, 1);
-#endif
-
-#if DT_INST_2_ATMEL_AT25
-#ifndef DT_INST_2_ATMEL_AT25_CS_GPIOS_CONTROLLER
-#define DT_INST_2_ATMEL_AT25_CS_GPIOS_CONTROLLER NULL
-#define DT_INST_2_ATMEL_AT25_CS_GPIOS_PIN 0
-#endif
-#ifndef DT_INST_2_ATMEL_AT25_WP_GPIOS_CONTROLLER
-#define DT_INST_2_ATMEL_AT25_WP_GPIOS_CONTROLLER NULL
-#define DT_INST_2_ATMEL_AT25_WP_GPIOS_PIN 0
-#define DT_INST_2_ATMEL_AT25_WP_GPIOS_FLAGS GPIO_ACTIVE_LOW
-#endif
-EEPROM_AT2X_DEVICE(25, 2);
-#endif
-
-#if DT_INST_3_ATMEL_AT25
-#ifndef DT_INST_3_ATMEL_AT25_CS_GPIOS_CONTROLLER
-#define DT_INST_3_ATMEL_AT25_CS_GPIOS_CONTROLLER NULL
-#define DT_INST_3_ATMEL_AT25_CS_GPIOS_PIN 0
-#endif
-#ifndef DT_INST_3_ATMEL_AT25_WP_GPIOS_CONTROLLER
-#define DT_INST_3_ATMEL_AT25_WP_GPIOS_CONTROLLER NULL
-#define DT_INST_3_ATMEL_AT25_WP_GPIOS_PIN 0
-#define DT_INST_3_ATMEL_AT25_WP_GPIOS_FLAGS GPIO_ACTIVE_LOW
-#endif
-EEPROM_AT2X_DEVICE(25, 3);
-#endif
-#endif /* CONFIG_EEPROM_AT25 */

--- a/tests/drivers/eeprom/src/main.c
+++ b/tests/drivers/eeprom/src/main.c
@@ -13,7 +13,7 @@ static void test_size(void)
 	struct device *eeprom;
 	size_t size;
 
-	eeprom = device_get_binding(DT_ALIAS_EEPROM_0_LABEL);
+	eeprom = device_get_binding(DT_LABEL(DT_ALIAS(eeprom_0)));
 
 	size = eeprom_get_size(eeprom);
 	zassert_not_equal(0, size, "Unexpected size of zero bytes");
@@ -26,7 +26,7 @@ static void test_out_of_bounds(void)
 	size_t size;
 	int rc;
 
-	eeprom = device_get_binding(DT_ALIAS_EEPROM_0_LABEL);
+	eeprom = device_get_binding(DT_LABEL(DT_ALIAS(eeprom_0)));
 	size = eeprom_get_size(eeprom);
 
 	rc = eeprom_write(eeprom, size - 1, data, sizeof(data));
@@ -41,7 +41,7 @@ static void test_write_and_verify(void)
 	struct device *eeprom;
 	int rc;
 
-	eeprom = device_get_binding(DT_ALIAS_EEPROM_0_LABEL);
+	eeprom = device_get_binding(DT_LABEL(DT_ALIAS(eeprom_0)));
 
 	rc = eeprom_write(eeprom, 0, wr_buf1, sizeof(wr_buf1));
 	zassert_equal(0, rc, "Unexpected error code (%d)", rc);
@@ -70,7 +70,7 @@ static void test_zero_length_write(void)
 	struct device *eeprom;
 	int rc;
 
-	eeprom = device_get_binding(DT_ALIAS_EEPROM_0_LABEL);
+	eeprom = device_get_binding(DT_LABEL(DT_ALIAS(eeprom_0)));
 
 	rc = eeprom_write(eeprom, 0, wr_buf1, sizeof(wr_buf1));
 	zassert_equal(0, rc, "Unexpected error code (%d)", rc);
@@ -95,7 +95,7 @@ void test_main(void)
 {
 	static struct device *eeprom;
 
-	eeprom = device_get_binding(DT_ALIAS_EEPROM_0_LABEL);
+	eeprom = device_get_binding(DT_LABEL(DT_ALIAS(eeprom_0)));
 	zassert_not_null(eeprom, "Unable to get EEPROM device");
 
 	k_object_access_grant(eeprom, k_current_get());

--- a/tests/drivers/eeprom/testcase.yaml
+++ b/tests/drivers/eeprom/testcase.yaml
@@ -3,6 +3,6 @@ tests:
     platform_whitelist: native_posix native_posix_64 qemu_x86
     tags: drivers userspace
   peripheral.eeprom.generic:
-    build_on_all: true
+    build_only: true
     depends_on: eeprom
     tags: drivers userspace


### PR DESCRIPTION
Convert older DT_INST_ macro use the new include/devicetree.h DT_INST macro APIs.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>