### PR TITLE
boards: arm: st_stm32: add lptimer to nucleo_l432kc board

### DIFF
--- a/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
@@ -62,6 +62,10 @@
 	status = "okay";
 };
 
+&lptim1 {
+	status = "okay";
+};
+
 &flash0 {
 	partitions {
 		compatible = "fixed-partitions";


### PR DESCRIPTION
Enable the lptim1 timer on the Nucleo L432KC board. It can work with
both the LSI and the LSE as the board has a 32.768 kHz crystal.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>