### PR TITLE
soc: nxp_imx: Fix typo in linker script for i.MX RT

### DIFF
--- a/soc/arm/nxp_imx/rt/linker.ld
+++ b/soc/arm/nxp_imx/rt/linker.ld
@@ -16,10 +16,10 @@ MEMORY
         SDRAM  (wx) : ORIGIN = DT_MMIO_SRAM_80000000_BASE_ADDRESS, LENGTH = DT_MMIO_SRAM_80000000_SIZE
 #endif
 #if (DT_REG_SIZE(DT_INST(0, nxp_imx_dtcm)) > 0) && !defined(CONFIG_DATA_DTCM)
-        DTCM    (wx) : ORIGIN = DT_REG_ADDR(DT_INST(0, nxp_imx_dtcm)), LENGTH = DT_REG_ADDR(DT_INST(0, nxp_imx_dtcm))
+        DTCM    (wx) : ORIGIN = DT_REG_ADDR(DT_INST(0, nxp_imx_dtcm)), LENGTH = DT_REG_SIZE(DT_INST(0, nxp_imx_dtcm))
 #endif
 #if (DT_REG_SIZE(DT_INST(0, nxp_imx_itcm)) > 0) && !defined(CONFIG_CODE_ITCM)
-        ITCM    (wx) : ORIGIN = DT_REG_ADDR(DT_INST(0, nxp_imx_itcm)), LENGTH = DT_REG_ADDR(DT_INST(0, nxp_imx_itcm))
+        ITCM    (wx) : ORIGIN = DT_REG_ADDR(DT_INST(0, nxp_imx_itcm)), LENGTH = DT_REG_SIZE(DT_INST(0, nxp_imx_itcm))
 #endif
      }
 


### PR DESCRIPTION
Fix typo where DT_REG_ADDR was used istead of DT_REG_SIZE in linker script for i.MX RT socs and their ITCM and DTCM memories.