### PR TITLE
dts: bindings: Remove duplicate in partition.yaml

### DIFF
--- a/dts/bindings/mtd/partition.yaml
+++ b/dts/bindings/mtd/partition.yaml
@@ -17,7 +17,6 @@ child-binding:
     description: Flash partition child node
     properties:
        label:
-          required: true
           type: string
           required: false
           description: Human readable string describing the device (used by Zephyr for API name)


### PR DESCRIPTION
The label property of the fixed-partitions child binding was duplicated with
two different values. This is invalid yaml, but went unnoticed by pyYAML.
Removed first entry to preserve value produced by pyYAML behavior of
overwriting duplicates.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>