### PR TITLE
Boards: list EEPROM as being supported by qemu_x86 and native_posix

### DIFF
--- a/boards/posix/native_posix/native_posix.yaml
+++ b/boards/posix/native_posix/native_posix.yaml
@@ -6,6 +6,7 @@ toolchain:
   - zephyr
   - llvm
 supported:
+  - eeprom
   - netif:eth
   - usb_device
 testing:

--- a/boards/posix/native_posix/native_posix_64.yaml
+++ b/boards/posix/native_posix/native_posix_64.yaml
@@ -6,5 +6,6 @@ toolchain:
   - zephyr
   - llvm
 supported:
+  - eeprom
   - netif:eth
   - usb_device

--- a/boards/x86/qemu_x86/qemu_x86.yaml
+++ b/boards/x86/qemu_x86/qemu_x86.yaml
@@ -11,5 +11,6 @@ supported:
   - nvs
   - netif:serial-net
   - ieee802154
+  - eeprom
 testing:
   default: true


### PR DESCRIPTION
List `eeprom` as being supported by the native_posix, native_posix_64, and qemu_x86 boards.