### PR TITLE
bluetooth: host: Dynamic bt_conn_le_create timeout

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -328,6 +328,15 @@ struct bt_conn_le_create_param {
 	 *  Set zero to use same as LE 1M PHY scan window.
 	 */
 	u16_t window_coded;
+
+	/** Connection initiation timeout (N * 10 MS)
+	 *
+	 *  Set zero to use the default :option:`CONFIG_BT_CREATE_CONN_TIMEOUT`
+	 *  timeout.
+	 *
+	 *  @note Unused in @ref bt_conn_create_auto_le
+	 */
+	u16_t timeout;
 };
 
 /** Helper to declare create connection parameters inline
@@ -343,6 +352,7 @@ struct bt_conn_le_create_param {
 		.window = (_window), \
 		.interval_coded = 0, \
 		.window_coded = 0, \
+		.timeout = 0, \
 	 } })
 
 /** Default LE create connection parameters.
@@ -610,7 +620,8 @@ struct bt_conn_cb {
 	 *  - @ref BT_HCI_ERR_UNKNOWN_CONN_ID Creating the connection started by
 	 *    @ref bt_conn_create_le was canceled either by the user through
 	 *    @ref bt_conn_disconnect or by the timeout in the host through
-	 *    :option:`CONFIG_BT_CREATE_CONN_TIMEOUT`.
+	 *    @ref bt_conn_le_create_param timeout parameter, which defaults to
+	 *    :option:`CONFIG_BT_CREATE_CONN_TIMEOUT` seconds.
 	 *  - @p BT_HCI_ERR_ADV_TIMEOUT Directed advertiser started by @ref
 	 *    bt_conn_create_slave_le with high duty cycle timed out after 1.28
 	 *    seconds.

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -477,8 +477,8 @@ config BT_MAX_PAIRED
 config BT_CREATE_CONN_TIMEOUT
 	int "Timeout for pending LE Create Connection command in seconds"
 	default 3
-	range 1 BT_RPA_TIMEOUT if BT_PRIVACY
-	range 1 65535
+	range 1 BT_RPA_TIMEOUT if BT_PRIVACY && (BT_RPA_TIMEOUT < 655)
+	range 1 655
 
 config BT_CONN_PARAM_UPDATE_TIMEOUT
 	int "Peripheral connection parameter update timeout in milliseconds"

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1248,7 +1248,7 @@ static inline bool rpa_timeout_valid_check(void)
 #if defined(CONFIG_BT_PRIVACY)
 	/* Check if create conn timeout will happen before RPA timeout. */
 	return k_delayed_work_remaining_get(&bt_dev.rpa_update) >
-	       K_SECONDS(CONFIG_BT_CREATE_CONN_TIMEOUT);
+	       (10 * bt_dev.create_param.timeout);
 #else
 	return true;
 #endif
@@ -1388,17 +1388,12 @@ int bt_le_create_conn_ext(const struct bt_conn *conn)
 	}
 
 	if (bt_dev.create_param.options & BT_LE_CONN_OPT_CODED) {
-		u16_t interval = bt_dev.create_param.interval_coded ?
-			bt_dev.create_param.interval_coded :
-			bt_dev.create_param.interval;
-		u16_t window = bt_dev.create_param.window_coded ?
-			bt_dev.create_param.window_coded :
-			bt_dev.create_param.window;
-
 		cp->phys |= BT_HCI_LE_EXT_SCAN_PHY_CODED;
 		phy = net_buf_add(buf, sizeof(*phy));
-		phy->scan_interval = sys_cpu_to_le16(interval);
-		phy->scan_window = sys_cpu_to_le16(window);
+		phy->scan_interval = sys_cpu_to_le16(
+			bt_dev.create_param.interval_coded);
+		phy->scan_window = sys_cpu_to_le16(
+			bt_dev.create_param.window_coded);
 		set_phy_conn_param(conn, phy);
 	}
 


### PR DESCRIPTION
Extends the bt_conn_le_create_param struct to provide the option
to set a custom timeout for the initiation of the connection.

Timeout is not added as a parameter to the BT_CONN_LE_CREATE_PARAM
macro due to the expectation that CONFIG_BT_CREATE_CONN_TIMEOUT
will be the typical value that users will expect.

Fixes #23468 