### PR TITLE
samples: echo_server: Fix missed renaming of nrf52840_pca10056

### DIFF
--- a/samples/net/sockets/echo_server/README.rst
+++ b/samples/net/sockets/echo_server/README.rst
@@ -63,7 +63,7 @@ Build echo-server sample application like this:
    :goals: build
    :compact:
 
-Example building for the nRF52840_pca10056 with OpenThread support:
+Example building for the nrf52840dk_nrf52840 with OpenThread support:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/net/sockets/echo_server


### PR DESCRIPTION
This is a follow-up to commit 4253eae0054db2aa5e6361ff185fc34d8e68ed3a (PR #23524).

The board known earlier as nrf52840_pca10056 is now named nrf52840dk_nrf52840.
