### PR TITLE
boards: efm32/efr32: Enlarge storage_partition for nvs sample

### DIFF
--- a/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a_common.dtsi
+++ b/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a_common.dtsi
@@ -121,10 +121,10 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* Set 4Kb of storage at the end of the 1024Kb of flash */
-		storage_partition: partition@ff000 {
+		/* Set 6Kb of storage at the end of the 1024Kb of flash */
+		storage_partition: partition@fe800 {
 			label = "storage";
-			reg = <0x000ff000 0x00001000>;
+			reg = <0x000fe800 0x00001800>;
 		};
 
 	};

--- a/boards/arm/efm32wg_stk3800/efm32wg_stk3800.dts
+++ b/boards/arm/efm32wg_stk3800/efm32wg_stk3800.dts
@@ -90,10 +90,10 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* Set 4Kb of storage at the end of the 256Kb of flash */
-		storage_partition: partition@3f000 {
+		/* Set 6Kb of storage at the end of the 256Kb of flash */
+		storage_partition: partition@3e800 {
 			label = "storage";
-			reg = <0x0003f000 0x00001000>;
+			reg = <0x0003e800 0x00001800>;
 		};
 
 	};

--- a/boards/arm/efr32_radio/efr32_radio_brd4250b.dts
+++ b/boards/arm/efr32_radio/efr32_radio_brd4250b.dts
@@ -43,16 +43,16 @@
 			reg = <0x0001f800 0x00017800>;
 		};
 
-		/* Reserve 32 kB for the scratch partition */
+		/* Reserve 30 kB for the scratch partition */
 		scratch_partition: partition@37000 {
 			label = "image-scratch";
-			reg = <0x00037000 0x00008000>;
+			reg = <0x00037000 0x00007800>;
 		};
 
-		/* Set 4Kb of storage at the end of the 256Kb of flash */
-		storage_partition: partition@3f000 {
+		/* Set 6Kb of storage at the end of the 256Kb of flash */
+		storage_partition: partition@3e800 {
 			label = "storage";
-			reg = <0x0003f000 0x00001000>;
+			reg = <0x0003e800 0x00001800>;
 		};
 
 	};

--- a/boards/arm/efr32_slwstk6061a/efr32_slwstk6061a.dts
+++ b/boards/arm/efr32_slwstk6061a/efr32_slwstk6061a.dts
@@ -155,16 +155,16 @@
 			reg = <0x0001f800 0x00017800>;
 		};
 
-		/* Reserve 32 kB for the scratch partition */
+		/* Reserve 30 kB for the scratch partition */
 		scratch_partition: partition@37000 {
 			label = "image-scratch";
-			reg = <0x00037000 0x00008000>;
+			reg = <0x00037000 0x00007800>;
 		};
 
-		/* Set 4Kb of storage at the end of the 256Kb of flash */
-		storage_partition: partition@3f000 {
+		/* Set 6Kb of storage at the end of the 256Kb of flash */
+		storage_partition: partition@3e800 {
 			label = "storage";
-			reg = <0x0003f000 0x00001000>;
+			reg = <0x0003e800 0x00001800>;
 		};
 
 	};

--- a/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
+++ b/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
@@ -154,10 +154,10 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* Set 4Kb of storage at the end of the 1024Kb of flash */
-		storage_partition: partition@ff000 {
+		/* Set 6Kb of storage at the end of the 1024Kb of flash */
+		storage_partition: partition@fe800 {
 			label = "storage";
-			reg = <0x000ff000 0x00001000>;
+			reg = <0x000fe800 0x00001800>;
 		};
 
 	};


### PR DESCRIPTION
The nvs sample requires a storage_partition of 3 flash pages, but these boards
only provided 2 flash pages. Because of this the nvs sample failed.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>