### PR TITLE
drivers: dma: sam0: fix macro definition

### DIFF
--- a/drivers/dma/dma_sam0.c
+++ b/drivers/dma/dma_sam0.c
@@ -384,7 +384,7 @@ DEVICE_DECLARE(dma_sam0_0);
 #define DMA_SAM0_IRQ_CONNECT(n)						 \
 	do {								 \
 		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, n, irq),		 \
-			    DT_INST_IRQ_HAS_IDX(0, n, priority),	 \
+			    DT_INST_IRQ_BY_IDX(0, n, priority),		 \
 			    dma_sam0_isr, DEVICE_GET(dma_sam0_0), 0);	 \
 		irq_enable(DT_INST_IRQ_BY_IDX(0, n, irq));		 \
 	} while (0)


### PR DESCRIPTION
Fix the definition of DMA_SAM0_IRQ_CONNECT
pre-processor directive, so that it does not
pass an extra argument ('priority') to the
DT_INST_IRQ_HAS_IDX macro.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>