### PR TITLE
Bluetooth: host: Fix high-duty cycle directed extended advertising

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -1088,6 +1088,12 @@ struct bt_hci_cp_le_set_ext_scan_rsp_data {
 	u8_t  data[251];
 } __packed;
 
+/* If the advertising is high duty cycle connectable directed advertising, then
+ * Duration[i] shall be less than or equal to 1.28 seconds and shall not be
+ * equal to 0.
+ */
+#define BT_HCI_LE_EXT_ADV_DURATION_HI_DC_MAX    128
+
 #define BT_HCI_OP_LE_SET_EXT_ADV_ENABLE         BT_OP(BT_OGF_LE, 0x0039)
 struct bt_hci_ext_adv_set {
 	u8_t  handle;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -7409,6 +7409,10 @@ int bt_le_adv_start_ext(struct bt_le_ext_adv *adv,
 			const struct bt_data *sd, size_t sd_len,
 			const bt_addr_le_t *peer)
 {
+	struct bt_le_ext_adv_start_param start_param = {
+		.timeout = 0,
+		.num_events = 0,
+	};
 	bool dir_adv = (peer != NULL);
 	struct bt_conn *conn = NULL;
 	int err = 0;
@@ -7447,9 +7451,12 @@ int bt_le_adv_start_ext(struct bt_le_ext_adv *adv,
 
 			bt_conn_set_state(conn, BT_CONN_CONNECT_ADV);
 		}
+	} else if (!(param->options & BT_LE_ADV_OPT_DIR_MODE_LOW_DUTY)) {
+		start_param.timeout = BT_HCI_LE_EXT_ADV_DURATION_HI_DC_MAX;
+		atomic_set_bit(adv->flags, BT_ADV_LIMITED);
 	}
 
-	err = set_le_adv_enable_ext(adv, true, NULL);
+	err = set_le_adv_enable_ext(adv, true, &start_param);
 	if (err) {
 		BT_ERR("Failed to start advertiser");
 		if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && conn) {


### PR DESCRIPTION
Fix high-duty cycle directed advertising when extended advertising
feature has been enabled. The duration parameter when starting extended
high duty cycle directed advertising has to be set to a non-zero value
less than or equal to 1.28 seconds.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>