### PR TITLE
spi: spi_mcux_lpspi: Update delay time to fast spi

### DIFF
--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -170,6 +170,12 @@ static int spi_mcux_configure(struct device *dev,
 		: kLPSPI_MsbFirst;
 
 	master_config.baudRate = spi_cfg->frequency;
+	master_config.betweenTransferDelayInNanoSec =
+		NSEC_PER_SEC / master_config.baudRate * 2;
+	master_config.lastSckToPcsDelayInNanoSec =
+		NSEC_PER_SEC / master_config.baudRate * 2;
+	master_config.pcsToSckDelayInNanoSec =
+		NSEC_PER_SEC / master_config.baudRate * 2;
 
 	clock_dev = device_get_binding(config->clock_name);
 	if (clock_dev == NULL) {


### PR DESCRIPTION
Spi using default config 500K cal delay time.
It will cause spi slow.
Now update delay time by spi clock.

Signed-off-by: Frank Li <lgl88911@163.com>

May fix #24939