### PR TITLE
drivers: sensor: st: Convert to new DT_INST macros

### DIFF
--- a/drivers/sensor/iis2dlpc/iis2dlpc.c
+++ b/drivers/sensor/iis2dlpc/iis2dlpc.c
@@ -8,15 +8,17 @@
  * https://www.st.com/resource/en/datasheet/iis2dlpc.pdf
  */
 
+#define DT_DRV_COMPAT st_iis2dlpc
+
 #include <init.h>
 #include <sys/__assert.h>
 #include <sys/byteorder.h>
 #include <logging/log.h>
 #include <drivers/sensor.h>
 
-#if defined(DT_ST_IIS2DLPC_BUS_SPI)
+#if DT_ANY_INST_ON_BUS(spi)
 #include <drivers/spi.h>
-#elif defined(DT_ST_IIS2DLPC_BUS_I2C)
+#elif DT_ANY_INST_ON_BUS(i2c)
 #include <drivers/i2c.h>
 #endif
 
@@ -220,9 +222,9 @@ static int iis2dlpc_init_interface(struct device *dev)
 		return -EINVAL;
 	}
 
-#if defined(DT_ST_IIS2DLPC_BUS_SPI)
+#if DT_ANY_INST_ON_BUS(spi)
 	iis2dlpc_spi_init(dev);
-#elif defined(DT_ST_IIS2DLPC_BUS_I2C)
+#elif DT_ANY_INST_ON_BUS(i2c)
 	iis2dlpc_i2c_init(dev);
 #else
 #error "BUS MACRO NOT DEFINED IN DTS"
@@ -371,12 +373,12 @@ static int iis2dlpc_init(struct device *dev)
 }
 
 const struct iis2dlpc_device_config iis2dlpc_cfg = {
-	.bus_name = DT_INST_0_ST_IIS2DLPC_BUS_NAME,
+	.bus_name = DT_INST_BUS_LABEL(0),
 	.pm = CONFIG_IIS2DLPC_POWER_MODE,
 #ifdef CONFIG_IIS2DLPC_TRIGGER
-	.int_gpio_port = DT_INST_0_ST_IIS2DLPC_DRDY_GPIOS_CONTROLLER,
-	.int_gpio_pin = DT_INST_0_ST_IIS2DLPC_DRDY_GPIOS_PIN,
-	.int_gpio_flags = DT_INST_0_ST_IIS2DLPC_DRDY_GPIOS_FLAGS,
+	.int_gpio_port = DT_INST_GPIO_LABEL(0, drdy_gpios),
+	.int_gpio_pin = DT_INST_GPIO_PIN(0, drdy_gpios),
+	.int_gpio_flags = DT_INST_GPIO_FLAGS(0, drdy_gpios),
 #if defined(CONFIG_IIS2DLPC_INT_PIN_1)
 	.int_pin = 1,
 #elif defined(CONFIG_IIS2DLPC_INT_PIN_2)
@@ -401,6 +403,6 @@ const struct iis2dlpc_device_config iis2dlpc_cfg = {
 
 struct iis2dlpc_data iis2dlpc_data;
 
-DEVICE_AND_API_INIT(iis2dlpc, DT_INST_0_ST_IIS2DLPC_LABEL, iis2dlpc_init,
+DEVICE_AND_API_INIT(iis2dlpc, DT_INST_LABEL(0), iis2dlpc_init,
 	     &iis2dlpc_data, &iis2dlpc_cfg, POST_KERNEL,
 	     CONFIG_SENSOR_INIT_PRIORITY, &iis2dlpc_driver_api);

--- a/drivers/sensor/iis2dlpc/iis2dlpc.h
+++ b/drivers/sensor/iis2dlpc/iis2dlpc.h
@@ -131,7 +131,7 @@ struct iis2dlpc_data {
 	struct device *dev;
 #endif /* CONFIG_IIS2DLPC_TRIGGER_GLOBAL_THREAD */
 #endif /* CONFIG_IIS2DLPC_TRIGGER */
-#if defined(DT_INST_0_ST_IIS2DLPC_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	struct spi_cs_control cs_ctrl;
 #endif
 };

--- a/drivers/sensor/iis2dlpc/iis2dlpc_i2c.c
+++ b/drivers/sensor/iis2dlpc/iis2dlpc_i2c.c
@@ -8,15 +8,17 @@
  * https://www.st.com/resource/en/datasheet/iis2dlpc.pdf
  */
 
+#define DT_DRV_COMPAT st_iis2dlpc
+
 #include <string.h>
 #include <drivers/i2c.h>
 #include <logging/log.h>
 
 #include "iis2dlpc.h"
 
-#ifdef DT_ST_IIS2DLPC_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 
-static u16_t iis2dlpc_i2c_slave_addr = DT_INST_0_ST_IIS2DLPC_BASE_ADDRESS;
+static u16_t iis2dlpc_i2c_slave_addr = DT_INST_REG_ADDR(0);
 
 LOG_MODULE_DECLARE(IIS2DLPC, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -48,4 +50,4 @@ int iis2dlpc_i2c_init(struct device *dev)
 
 	return 0;
 }
-#endif /* DT_ST_IIS2DLPC_BUS_I2C */
+#endif /* DT_ANY_INST_ON_BUS(i2c) */

--- a/drivers/sensor/iis2dlpc/iis2dlpc_spi.c
+++ b/drivers/sensor/iis2dlpc/iis2dlpc_spi.c
@@ -8,22 +8,24 @@
  * https://www.st.com/resource/en/datasheet/iis2dlpc.pdf
  */
 
+#define DT_DRV_COMPAT st_iis2dlpc
+
 
 #include <string.h>
 #include "iis2dlpc.h"
 #include <logging/log.h>
 
-#ifdef DT_ST_IIS2DLPC_BUS_SPI
+#if DT_ANY_INST_ON_BUS(spi)
 
 #define IIS2DLPC_SPI_READ		(1 << 7)
 
 LOG_MODULE_DECLARE(IIS2DLPC, CONFIG_SENSOR_LOG_LEVEL);
 
 static struct spi_config iis2dlpc_spi_conf = {
-	.frequency = DT_INST_0_ST_IIS2DLPC_SPI_MAX_FREQUENCY,
+	.frequency = DT_INST_PROP(0, spi_max_frequency),
 	.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
 		      SPI_MODE_CPHA | SPI_WORD_SET(8) | SPI_LINES_SINGLE),
-	.slave     = DT_INST_0_ST_IIS2DLPC_BASE_ADDRESS,
+	.slave     = DT_INST_REG_ADDR(0),
 	.cs        = NULL,
 };
 
@@ -102,25 +104,25 @@ int iis2dlpc_spi_init(struct device *dev)
 	data->ctx = &iis2dlpc_spi_ctx;
 	data->ctx->handle = data;
 
-#if defined(DT_INST_0_ST_IIS2DLPC_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	/* handle SPI CS thru GPIO if it is the case */
 	data->cs_ctrl.gpio_dev = device_get_binding(
-		DT_INST_0_ST_IIS2DLPC_CS_GPIOS_CONTROLLER);
+		DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
 	if (!data->cs_ctrl.gpio_dev) {
 		LOG_ERR("Unable to get GPIO SPI CS device");
 		return -ENODEV;
 	}
 
-	data->cs_ctrl.gpio_pin = DT_INST_0_ST_IIS2DLPC_CS_GPIOS_PIN;
+	data->cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
 	data->cs_ctrl.delay = 0U;
 
 	iis2dlpc_spi_conf.cs = &data->cs_ctrl;
 
 	LOG_DBG("SPI GPIO CS configured on %s:%u",
-		    DT_INST_0_ST_IIS2DLPC_CS_GPIOS_CONTROLLER,
-		    DT_INST_0_ST_IIS2DLPC_CS_GPIOS_PIN);
+		    DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
+		    DT_INST_SPI_DEV_CS_GPIOS_PIN(0));
 #endif
 
 	return 0;
 }
-#endif /* DT_ST_IIS2DLPC_BUS_SPI */
+#endif /* DT_ANY_INST_ON_BUS(spi) */

--- a/drivers/sensor/iis2mdc/iis2mdc.c
+++ b/drivers/sensor/iis2mdc/iis2mdc.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/iis2mdc.pdf
  */
 
+#define DT_DRV_COMPAT st_iis2mdc
+
 #include <init.h>
 #include <sys/__assert.h>
 #include <sys/byteorder.h>
@@ -255,30 +257,30 @@ static int iis2mdc_init_interface(struct device *dev)
 }
 
 static const struct iis2mdc_config iis2mdc_dev_config = {
-	.master_dev_name = DT_INST_0_ST_IIS2MDC_BUS_NAME,
+	.master_dev_name = DT_INST_BUS_LABEL(0),
 #ifdef CONFIG_IIS2MDC_TRIGGER
-	.drdy_port = DT_INST_0_ST_IIS2MDC_DRDY_GPIOS_CONTROLLER,
-	.drdy_pin = DT_INST_0_ST_IIS2MDC_DRDY_GPIOS_PIN,
-	.drdy_flags = DT_INST_0_ST_IIS2MDC_DRDY_GPIOS_FLAGS,
+	.drdy_port = DT_INST_GPIO_LABEL(0, drdy_gpios),
+	.drdy_pin = DT_INST_GPIO_PIN(0, drdy_gpios),
+	.drdy_flags = DT_INST_GPIO_FLAGS(0, drdy_gpios),
 #endif  /* CONFIG_IIS2MDC_TRIGGER */
-#if defined(DT_ST_IIS2MDC_BUS_SPI)
+#if DT_ANY_INST_ON_BUS(spi)
 	.bus_init = iis2mdc_spi_init,
-	.spi_conf.frequency = DT_INST_0_ST_IIS2MDC_SPI_MAX_FREQUENCY,
+	.spi_conf.frequency = DT_INST_PROP(0, spi_max_frequency),
 	.spi_conf.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
 			       SPI_MODE_CPHA | SPI_WORD_SET(8) |
 			       SPI_LINES_SINGLE),
-	.spi_conf.slave     = DT_INST_0_ST_IIS2MDC_BASE_ADDRESS,
-#if defined(DT_INST_0_ST_IIS2MDC_CS_GPIOS_CONTROLLER)
-	.gpio_cs_port	    = DT_INST_0_ST_IIS2MDC_CS_GPIOS_CONTROLLER,
-	.cs_gpio	    = DT_INST_0_ST_IIS2MDC_CS_GPIOS_PIN,
+	.spi_conf.slave     = DT_INST_REG_ADDR(0),
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
+	.gpio_cs_port	    = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
+	.cs_gpio	    = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
 
 	.spi_conf.cs        =  &iis2mdc_data.cs_ctrl,
 #else
 	.spi_conf.cs        = NULL,
 #endif
-#elif defined(DT_ST_IIS2MDC_BUS_I2C)
+#elif DT_ANY_INST_ON_BUS(i2c)
 	.bus_init = iis2mdc_i2c_init,
-	.i2c_slv_addr = DT_INST_0_ST_IIS2MDC_BASE_ADDRESS,
+	.i2c_slv_addr = DT_INST_REG_ADDR(0),
 #else
 #error "BUS MACRO NOT DEFINED IN DTS"
 #endif
@@ -359,6 +361,6 @@ static int iis2mdc_init(struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(iis2mdc, DT_INST_0_ST_IIS2MDC_LABEL, iis2mdc_init,
+DEVICE_AND_API_INIT(iis2mdc, DT_INST_LABEL(0), iis2mdc_init,
 		     &iis2mdc_data, &iis2mdc_dev_config, POST_KERNEL,
 		     CONFIG_SENSOR_INIT_PRIORITY, &iis2mdc_driver_api);

--- a/drivers/sensor/iis2mdc/iis2mdc.h
+++ b/drivers/sensor/iis2mdc/iis2mdc.h
@@ -35,15 +35,15 @@ struct iis2mdc_config {
 	gpio_pin_t drdy_pin;
 	gpio_dt_flags_t drdy_flags;
 #endif  /* CONFIG_IIS2MDC_TRIGGER */
-#ifdef DT_ST_IIS2MDC_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 	u16_t i2c_slv_addr;
-#elif DT_ST_IIS2MDC_BUS_SPI
+#elif DT_ANY_INST_ON_BUS(spi)
 	struct spi_config spi_conf;
-#if defined(DT_INST_0_ST_IIS2MDC_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const char *gpio_cs_port;
 	u8_t cs_gpio;
-#endif /* DT_INST_0_ST_IIS2MDC_CS_GPIOS_CONTROLLER */
-#endif /* DT_ST_IIS2MDC_BUS_SPI */
+#endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
+#endif /* DT_ANY_INST_ON_BUS(spi) */
 };
 
 /* Sensor data */
@@ -55,9 +55,9 @@ struct iis2mdc_data {
 
 	stmdev_ctx_t *ctx;
 
-#ifdef DT_ST_IIS2MDC_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 	stmdev_ctx_t ctx_i2c;
-#elif DT_ST_IIS2MDC_BUS_SPI
+#elif DT_ANY_INST_ON_BUS(spi)
 	stmdev_ctx_t ctx_spi;
 #endif
 
@@ -76,9 +76,9 @@ struct iis2mdc_data {
 	struct device *dev;
 #endif  /* CONFIG_IIS2MDC_TRIGGER_GLOBAL_THREAD */
 #endif  /* CONFIG_IIS2MDC_TRIGGER */
-#if defined(DT_INST_0_ST_IIS2MDC_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	struct spi_cs_control cs_ctrl;
-#endif /* DT_INST_0_ST_IIS2MDC_CS_GPIOS_CONTROLLER */
+#endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
 };
 
 int iis2mdc_spi_init(struct device *dev);

--- a/drivers/sensor/iis2mdc/iis2mdc_i2c.c
+++ b/drivers/sensor/iis2mdc/iis2mdc_i2c.c
@@ -8,13 +8,15 @@
  * https://www.st.com/resource/en/datasheet/iis2mdc.pdf
  */
 
+#define DT_DRV_COMPAT st_iis2mdc
+
 #include <string.h>
 #include <drivers/i2c.h>
 #include <logging/log.h>
 
 #include "iis2mdc.h"
 
-#ifdef DT_ST_IIS2MDC_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
 LOG_MODULE_DECLARE(IIS2MDC);
@@ -51,4 +53,4 @@ int iis2mdc_i2c_init(struct device *dev)
 
 	return 0;
 }
-#endif /* DT_ST_IIS2MDC_BUS_I2C */
+#endif /* DT_ANY_INST_ON_BUS(i2c) */

--- a/drivers/sensor/iis2mdc/iis2mdc_spi.c
+++ b/drivers/sensor/iis2mdc/iis2mdc_spi.c
@@ -8,11 +8,13 @@
  * https://www.st.com/resource/en/datasheet/iis2mdc.pdf
  */
 
+#define DT_DRV_COMPAT st_iis2mdc
+
 #include <string.h>
 #include "iis2mdc.h"
 #include <logging/log.h>
 
-#ifdef DT_ST_IIS2MDC_BUS_SPI
+#if DT_ANY_INST_ON_BUS(spi)
 
 #define IIS2MDC_SPI_READ		(1 << 7)
 
@@ -105,7 +107,7 @@ int iis2mdc_spi_init(struct device *dev)
 	data->ctx = &data->ctx_spi;
 	data->ctx->handle = dev;
 
-#if defined(DT_INST_0_ST_IIS2MDC_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const struct iis2mdc_config *cfg = dev->config->config_info;
 
 	/* handle SPI CS thru GPIO if it is the case */
@@ -131,4 +133,4 @@ int iis2mdc_spi_init(struct device *dev)
 
 	return 0;
 }
-#endif /* DT_ST_IIS2MDC_BUS_SPI */
+#endif /* DT_ANY_INST_ON_BUS(spi) */

--- a/drivers/sensor/iis3dhhc/iis3dhhc.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/iis3dhhc.pdf
  */
 
+#define DT_DRV_COMPAT st_iis3dhhc
+
 #include <kernel.h>
 #include <device.h>
 #include <init.h>
@@ -218,28 +220,28 @@ static int iis3dhhc_init(struct device *dev)
 static struct iis3dhhc_data iis3dhhc_data;
 
 static const struct iis3dhhc_config iis3dhhc_config = {
-	.master_dev_name = DT_INST_0_ST_IIS3DHHC_BUS_NAME,
+	.master_dev_name = DT_INST_BUS_LABEL(0),
 #ifdef CONFIG_IIS3DHHC_TRIGGER
 #ifdef CONFIG_IIS3DHHC_DRDY_INT1
-	.int_port	= DT_INST_0_ST_IIS3DHHC_IRQ_GPIOS_CONTROLLER_0,
-	.int_pin	= DT_INST_0_ST_IIS3DHHC_IRQ_GPIOS_PIN_0,
-	.int_flags	= DT_INST_0_ST_IIS3DHHC_IRQ_GPIOS_FLAGS_0,
+	.int_port	= DT_INST_GPIO_LABEL_BY_IDX(0, irq_gpios, 0),
+	.int_pin	= DT_INST_GPIO_PIN_BY_IDX(0, irq_gpios, 0),
+	.int_flags	= DT_INST_GPIO_FLAGS_BY_IDX(0, irq_gpios, 0),
 #else
-	.int_port	= DT_INST_0_ST_IIS3DHHC_IRQ_GPIOS_CONTROLLER_1,
-	.int_pin	= DT_INST_0_ST_IIS3DHHC_IRQ_GPIOS_PIN_1,
-	.int_flags	= DT_INST_0_ST_IIS3DHHC_IRQ_GPIOS_FLAGS_1,
+	.int_port	= DT_INST_GPIO_LABEL_BY_IDX(0, irq_gpios, 1),
+	.int_pin	= DT_INST_GPIO_PIN_BY_IDX(0, irq_gpios, 1),
+	.int_flags	= DT_INST_GPIO_FLAGS_BY_IDX(0, irq_gpios, 1),
 #endif /* CONFIG_IIS3DHHC_DRDY_INT1 */
 #endif /* CONFIG_IIS3DHHC_TRIGGER */
-#if defined(DT_ST_IIS3DHHC_BUS_SPI)
+#if DT_ANY_INST_ON_BUS(spi)
 	.bus_init = iis3dhhc_spi_init,
-	.spi_conf.frequency = DT_INST_0_ST_IIS3DHHC_SPI_MAX_FREQUENCY,
+	.spi_conf.frequency = DT_INST_PROP(0, spi_max_frequency),
 	.spi_conf.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
 			       SPI_MODE_CPHA | SPI_WORD_SET(8) |
 			       SPI_LINES_SINGLE),
-	.spi_conf.slave     = DT_INST_0_ST_IIS3DHHC_BASE_ADDRESS,
-#if defined(DT_INST_0_ST_IIS3DHHC_CS_GPIOS_CONTROLLER)
-	.gpio_cs_port	    = DT_INST_0_ST_IIS3DHHC_CS_GPIOS_CONTROLLER,
-	.cs_gpio	    = DT_INST_0_ST_IIS3DHHC_CS_GPIOS_PIN,
+	.spi_conf.slave     = DT_INST_REG_ADDR(0),
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
+	.gpio_cs_port	    = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
+	.cs_gpio	    = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
 
 	.spi_conf.cs        =  &iis3dhhc_data.cs_ctrl,
 #else
@@ -250,6 +252,6 @@ static const struct iis3dhhc_config iis3dhhc_config = {
 #endif
 };
 
-DEVICE_AND_API_INIT(iis3dhhc, DT_INST_0_ST_IIS3DHHC_LABEL, iis3dhhc_init,
+DEVICE_AND_API_INIT(iis3dhhc, DT_INST_LABEL(0), iis3dhhc_init,
 		    &iis3dhhc_data, &iis3dhhc_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &iis3dhhc_api_funcs);

--- a/drivers/sensor/iis3dhhc/iis3dhhc.h
+++ b/drivers/sensor/iis3dhhc/iis3dhhc.h
@@ -32,9 +32,9 @@ struct iis3dhhc_config {
 	u8_t int_pin;
 	u8_t int_flags;
 #endif
-#ifdef DT_ST_IIS3DHHC_BUS_SPI
+#if DT_ANY_INST_ON_BUS(spi)
 	struct spi_config spi_conf;
-#if defined(DT_INST_0_ST_IIS3DHHC_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const char *gpio_cs_port;
 	u8_t cs_gpio;
 #endif
@@ -47,7 +47,7 @@ struct iis3dhhc_data {
 
 	stmdev_ctx_t *ctx;
 
-#ifdef DT_ST_IIS3DHHC_BUS_SPI
+#if DT_ANY_INST_ON_BUS(spi)
 	stmdev_ctx_t ctx_spi;
 #endif
 
@@ -68,7 +68,7 @@ struct iis3dhhc_data {
 #endif
 
 #endif /* CONFIG_IIS3DHHC_TRIGGER */
-#if defined(DT_INST_0_ST_IIS3DHHC_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	struct spi_cs_control cs_ctrl;
 #endif
 };

--- a/drivers/sensor/iis3dhhc/iis3dhhc_spi.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc_spi.c
@@ -8,21 +8,23 @@
  * https://www.st.com/resource/en/datasheet/iis3dhhc.pdf
  */
 
+#define DT_DRV_COMPAT st_iis3dhhc
+
 #include <string.h>
 #include "iis3dhhc.h"
 #include <logging/log.h>
 
-#ifdef DT_ST_IIS3DHHC_BUS_SPI
+#if DT_ANY_INST_ON_BUS(spi)
 
 #define IIS3DHHC_SPI_READ		(1 << 7)
 
 LOG_MODULE_DECLARE(IIS3DHHC, CONFIG_SENSOR_LOG_LEVEL);
 
 static struct spi_config iis3dhhc_spi_conf = {
-	.frequency = DT_INST_0_ST_IIS3DHHC_SPI_MAX_FREQUENCY,
+	.frequency = DT_INST_PROP(0, spi_max_frequency),
 	.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
 		      SPI_MODE_CPHA | SPI_WORD_SET(8) | SPI_LINES_SINGLE),
-	.slave     = DT_INST_0_ST_IIS3DHHC_BASE_ADDRESS,
+	.slave     = DT_INST_REG_ADDR(0),
 	.cs        = NULL,
 };
 
@@ -101,25 +103,25 @@ int iis3dhhc_spi_init(struct device *dev)
 	data->ctx = &iis3dhhc_spi_ctx;
 	data->ctx->handle = data;
 
-#if defined(DT_INST_0_ST_IIS3DHHC_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	/* handle SPI CS thru GPIO if it is the case */
 	data->cs_ctrl.gpio_dev = device_get_binding(
-		DT_INST_0_ST_IIS3DHHC_CS_GPIOS_CONTROLLER);
+		DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
 	if (!data->cs_ctrl.gpio_dev) {
 		LOG_ERR("Unable to get GPIO SPI CS device");
 		return -ENODEV;
 	}
 
-	data->cs_ctrl.gpio_pin = DT_INST_0_ST_IIS3DHHC_CS_GPIOS_PIN;
+	data->cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
 	data->cs_ctrl.delay = 0U;
 
 	iis3dhhc_spi_conf.cs = &data->cs_ctrl;
 
 	LOG_DBG("SPI GPIO CS configured on %s:%u",
-		    DT_INST_0_ST_IIS3DHHC_CS_GPIOS_CONTROLLER,
-		    DT_INST_0_ST_IIS3DHHC_CS_GPIOS_PIN);
+		    DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
+		    DT_INST_SPI_DEV_CS_GPIOS_PIN(0));
 #endif
 
 	return 0;
 }
-#endif /* DT_ST_IIS3DHHC_BUS_SPI */
+#endif /* DT_ANY_INST_ON_BUS(spi) */

--- a/drivers/sensor/ism330dhcx/ism330dhcx.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/ism330dhcx.pdf
  */
 
+#define DT_DRV_COMPAT st_ism330dhcx
+
 #include <drivers/sensor.h>
 #include <kernel.h>
 #include <device.h>
@@ -749,53 +751,53 @@ static int ism330dhcx_init_chip(struct device *dev)
 static struct ism330dhcx_data ism330dhcx_data;
 
 static const struct ism330dhcx_config ism330dhcx_config = {
-	.bus_name = DT_INST_0_ST_ISM330DHCX_BUS_NAME,
-#if defined(DT_ST_ISM330DHCX_BUS_SPI)
+	.bus_name = DT_INST_BUS_LABEL(0),
+#if DT_ANY_INST_ON_BUS(spi)
 	.bus_init = ism330dhcx_spi_init,
-	.spi_conf.frequency = DT_INST_0_ST_ISM330DHCX_SPI_MAX_FREQUENCY,
+	.spi_conf.frequency = DT_INST_PROP(0, spi_max_frequency),
 	.spi_conf.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
 			       SPI_MODE_CPHA | SPI_WORD_SET(8) |
 			       SPI_LINES_SINGLE),
-	.spi_conf.slave     = DT_INST_0_ST_ISM330DHCX_BASE_ADDRESS,
-#if defined(DT_INST_0_ST_ISM330DHCX_CS_GPIOS_CONTROLLER)
-	.gpio_cs_port	    = DT_INST_0_ST_ISM330DHCX_CS_GPIOS_CONTROLLER,
-	.cs_gpio	    = DT_INST_0_ST_ISM330DHCX_CS_GPIOS_PIN,
+	.spi_conf.slave     = DT_INST_REG_ADDR(0),
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
+	.gpio_cs_port	    = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
+	.cs_gpio	    = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
 
 	.spi_conf.cs        =  &ism330dhcx_data.cs_ctrl,
 #else
 	.spi_conf.cs        = NULL,
 #endif
-#elif defined(DT_ST_ISM330DHCX_BUS_I2C)
+#elif DT_ANY_INST_ON_BUS(i2c)
 	.bus_init = ism330dhcx_i2c_init,
-	.i2c_slv_addr = DT_INST_0_ST_ISM330DHCX_BASE_ADDRESS,
+	.i2c_slv_addr = DT_INST_REG_ADDR(0),
 #else
 #error "BUS MACRO NOT DEFINED IN DTS"
 #endif
 #ifdef CONFIG_ISM330DHCX_TRIGGER
-#if defined(DT_INST_0_ST_ISM330DHCX_DRDY_GPIOS_CONTROLLER_1)
+#if DT_INST_PROP_HAS_IDX(0, drdy_gpios, 1)
 	/* Two gpio pins declared in DTS */
 #if defined(CONFIG_ISM330DHCX_INT_PIN_1)
-	.int_gpio_port = DT_INST_0_ST_ISM330DHCX_DRDY_GPIOS_CONTROLLER_0,
-	.int_gpio_pin = DT_INST_0_ST_ISM330DHCX_DRDY_GPIOS_PIN_0,
-	.int_gpio_flags = DT_INST_0_ST_ISM330DHCX_DRDY_GPIOS_FLAGS_0,
+	.int_gpio_port = DT_INST_GPIO_LABEL_BY_IDX(0, drdy_gpios, 0),
+	.int_gpio_pin = DT_INST_GPIO_PIN_BY_IDX(0, drdy_gpios, 0),
+	.int_gpio_flags = DT_INST_GPIO_FLAGS_BY_IDX(0, drdy_gpios, 0),
 	.int_pin = 1,
 #elif defined(CONFIG_ISM330DHCX_INT_PIN_2)
-	.int_gpio_port = DT_INST_0_ST_ISM330DHCX_DRDY_GPIOS_CONTROLLER_1,
-	.int_gpio_pin = DT_INST_0_ST_ISM330DHCX_DRDY_GPIOS_PIN_1,
-	.int_gpio_flags = DT_INST_0_ST_ISM330DHCX_DRDY_GPIOS_FLAGS_1,
+	.int_gpio_port = DT_INST_GPIO_LABEL_BY_IDX(0, drdy_gpios, 1),
+	.int_gpio_pin = DT_INST_GPIO_PIN_BY_IDX(0, drdy_gpios, 1),
+	.int_gpio_flags = DT_INST_GPIO_FLAGS_BY_IDX(0, drdy_gpios, 1),
 	.int_pin = 2,
 #endif /* CONFIG_ISM330DHCX_INT_PIN_* */
 #else
 	/* One gpio pin declared in DTS */
-	.int_gpio_port = DT_INST_0_ST_ISM330DHCX_DRDY_GPIOS_CONTROLLER,
-	.int_gpio_pin = DT_INST_0_ST_ISM330DHCX_DRDY_GPIOS_PIN,
-	.int_gpio_flags = DT_INST_0_ST_ISM330DHCX_DRDY_GPIOS_FLAGS,
+	.int_gpio_port = DT_INST_GPIO_LABEL(0, drdy_gpios),
+	.int_gpio_pin = DT_INST_GPIO_PIN(0, drdy_gpios),
+	.int_gpio_flags = DT_INST_GPIO_FLAGS(0, drdy_gpios),
 #if defined(CONFIG_ISM330DHCX_INT_PIN_1)
 	.int_pin = 1,
 #elif defined(CONFIG_ISM330DHCX_INT_PIN_2)
 	.int_pin = 2,
 #endif /* CONFIG_ISM330DHCX_INT_PIN_* */
-#endif /* DT_INST_0_ST_ISM330DHCX_DRDY_GPIOS_CONTROLLER_1 */
+#endif /* DT_INST_PROP_HAS_IDX(0, drdy_gpios, 1) */
 
 #endif /* CONFIG_ISM330DHCX_TRIGGER */
 };
@@ -839,6 +841,6 @@ static int ism330dhcx_init(struct device *dev)
 
 static struct ism330dhcx_data ism330dhcx_data;
 
-DEVICE_AND_API_INIT(ism330dhcx, DT_INST_0_ST_ISM330DHCX_LABEL, ism330dhcx_init,
+DEVICE_AND_API_INIT(ism330dhcx, DT_INST_LABEL(0), ism330dhcx_init,
 		    &ism330dhcx_data, &ism330dhcx_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &ism330dhcx_api_funcs);

--- a/drivers/sensor/ism330dhcx/ism330dhcx.h
+++ b/drivers/sensor/ism330dhcx/ism330dhcx.h
@@ -100,15 +100,15 @@ struct ism330dhcx_config {
 	u8_t int_gpio_flags;
 	u8_t int_pin;
 #endif /* CONFIG_ISM330DHCX_TRIGGER */
-#ifdef DT_ST_ISM330DHCX_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 	u16_t i2c_slv_addr;
-#elif DT_ST_ISM330DHCX_BUS_SPI
+#elif DT_ANY_INST_ON_BUS(spi)
 	struct spi_config spi_conf;
-#if defined(DT_INST_0_ST_ISM330DHCX_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const char *gpio_cs_port;
 	u8_t cs_gpio;
-#endif /* DT_INST_0_ST_ISM330DHCX_CS_GPIOS_CONTROLLER */
-#endif /* DT_ST_ISM330DHCX_BUS_I2C */
+#endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
+#endif /* DT_ANY_INST_ON_BUS(i2c) */
 };
 
 union samples {
@@ -159,9 +159,9 @@ struct ism330dhcx_data {
 
 	stmdev_ctx_t *ctx;
 
-	#ifdef DT_ST_ISM330DHCX_BUS_I2C
+	#if DT_ANY_INST_ON_BUS(i2c)
 	stmdev_ctx_t ctx_i2c;
-	#elif DT_ST_ISM330DHCX_BUS_SPI
+	#elif DT_ANY_INST_ON_BUS(spi)
 	stmdev_ctx_t ctx_spi;
 	#endif
 
@@ -187,7 +187,7 @@ struct ism330dhcx_data {
 #endif
 #endif /* CONFIG_ISM330DHCX_TRIGGER */
 
-#if defined(DT_INST_0_ST_ISM330DHCX_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	struct spi_cs_control cs_ctrl;
 #endif
 };

--- a/drivers/sensor/ism330dhcx/ism330dhcx_i2c.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx_i2c.c
@@ -8,13 +8,15 @@
  * https://www.st.com/resource/en/datasheet/ism330dhcx.pdf
  */
 
+#define DT_DRV_COMPAT st_ism330dhcx
+
 #include <string.h>
 #include <drivers/i2c.h>
 #include <logging/log.h>
 
 #include "ism330dhcx.h"
 
-#ifdef DT_ST_ISM330DHCX_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 
 LOG_MODULE_DECLARE(ISM330DHCX, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -50,4 +52,4 @@ int ism330dhcx_i2c_init(struct device *dev)
 
 	return 0;
 }
-#endif /* DT_ST_ISM330DHCX_BUS_I2C */
+#endif /* DT_ANY_INST_ON_BUS(i2c) */

--- a/drivers/sensor/ism330dhcx/ism330dhcx_spi.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx_spi.c
@@ -8,11 +8,13 @@
  * https://www.st.com/resource/en/datasheet/ism330dhcx.pdf
  */
 
+#define DT_DRV_COMPAT st_ism330dhcx
+
 #include <string.h>
 #include "ism330dhcx.h"
 #include <logging/log.h>
 
-#ifdef DT_ST_ISM330DHCX_BUS_SPI
+#if DT_ANY_INST_ON_BUS(spi)
 
 #define ISM330DHCX_SPI_READ		(1 << 7)
 
@@ -104,7 +106,7 @@ int ism330dhcx_spi_init(struct device *dev)
 	data->ctx = &data->ctx_spi;
 	data->ctx->handle = dev;
 
-#if defined(DT_INST_0_ST_ISM330DHCX_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const struct ism330dhcx_config *cfg = dev->config->config_info;
 
 	/* handle SPI CS thru GPIO if it is the case */
@@ -123,4 +125,4 @@ int ism330dhcx_spi_init(struct device *dev)
 
 	return 0;
 }
-#endif /* DT_ST_ISM330DHCX_BUS_SPI */
+#endif /* DT_ANY_INST_ON_BUS(spi) */

--- a/drivers/sensor/lis2dh/lis2dh.c
+++ b/drivers/sensor/lis2dh/lis2dh.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT st_lis2dh
+
 
 #include <init.h>
 #include <sys/byteorder.h>
@@ -21,7 +23,7 @@ LOG_MODULE_REGISTER(lis2dh, CONFIG_SENSOR_LOG_LEVEL);
  * multiplied by 100.
  */
 static const u32_t lis2dh_reg_val_to_scale[] = {
-#if defined(DT_INST_0_ST_LSM303AGR_ACCEL)
+#if DT_HAS_NODE(DT_INST(0, st_lsm303agr_accel))
 	ACCEL_SCALE(1563),
 	ACCEL_SCALE(3126),
 	ACCEL_SCALE(6252),
@@ -291,7 +293,7 @@ int lis2dh_init(struct device *dev)
 		return -EINVAL;
 	}
 
-	if (IS_ENABLED(DT_INST_0_ST_LIS2DH_DISCONNECT_SDO_SA0_PULL_UP)) {
+	if (IS_ENABLED(DT_INST_PROP(0, disconnect_sdo_sa0_pull_up))) {
 		status = lis2dh->hw_tf->update_reg(dev, LIS2DH_REG_CTRL0,
 						   LIS2DH_SDO_PU_DISC_MASK,
 						   LIS2DH_SDO_PU_DISC_MASK);
@@ -347,29 +349,29 @@ int lis2dh_init(struct device *dev)
 static struct lis2dh_data lis2dh_data;
 
 static const struct lis2dh_config lis2dh_config = {
-	.bus_name = DT_INST_0_ST_LIS2DH_BUS_NAME,
-#if defined(DT_ST_LIS2DH_BUS_SPI)
+	.bus_name = DT_INST_BUS_LABEL(0),
+#if DT_ANY_INST_ON_BUS(spi)
 	.bus_init = lis2dh_spi_init,
-	.spi_conf.frequency = DT_INST_0_ST_LIS2DH_SPI_MAX_FREQUENCY,
+	.spi_conf.frequency = DT_INST_PROP(0, spi_max_frequency),
 	.spi_conf.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
 			       SPI_MODE_CPHA | SPI_WORD_SET(8) |
 			       SPI_LINES_SINGLE),
-	.spi_conf.slave     = DT_INST_0_ST_LIS2DH_BASE_ADDRESS,
-#if defined(DT_INST_0_ST_LIS2DH_CS_GPIOS_CONTROLLER)
-	.gpio_cs_port	    = DT_INST_0_ST_LIS2DH_CS_GPIOS_CONTROLLER,
-	.cs_gpio	    = DT_INST_0_ST_LIS2DH_CS_GPIOS_PIN,
+	.spi_conf.slave     = DT_INST_REG_ADDR(0),
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
+	.gpio_cs_port	    = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
+	.cs_gpio	    = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
 	.spi_conf.cs        =  &lis2dh_data.cs_ctrl,
 #else
 	.spi_conf.cs        = NULL,
 #endif
-#elif defined(DT_ST_LIS2DH_BUS_I2C)
+#elif DT_ANY_INST_ON_BUS(i2c)
 	.bus_init = lis2dh_i2c_init,
-	.i2c_slv_addr = DT_INST_0_ST_LIS2DH_BASE_ADDRESS,
+	.i2c_slv_addr = DT_INST_REG_ADDR(0),
 #else
 #error "BUS MACRO NOT DEFINED IN DTS"
 #endif
 };
 
-DEVICE_AND_API_INIT(lis2dh, DT_INST_0_ST_LIS2DH_LABEL, lis2dh_init, &lis2dh_data,
+DEVICE_AND_API_INIT(lis2dh, DT_INST_LABEL(0), lis2dh_init, &lis2dh_data,
 		    &lis2dh_config, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &lis2dh_driver_api);

--- a/drivers/sensor/lis2dh/lis2dh.h
+++ b/drivers/sensor/lis2dh/lis2dh.h
@@ -15,13 +15,13 @@
 #include <drivers/sensor.h>
 #include <string.h>
 
-#define LIS2DH_BUS_ADDRESS		DT_INST_0_ST_LIS2DH_BASE_ADDRESS
-#define LIS2DH_BUS_DEV_NAME		DT_INST_0_ST_LIS2DH_BUS_NAME
+#define LIS2DH_BUS_ADDRESS		DT_INST_REG_ADDR(0)
+#define LIS2DH_BUS_DEV_NAME		DT_INST_BUS_LABEL(0)
 
 #define LIS2DH_REG_WAI			0x0f
 #define LIS2DH_CHIP_ID			0x33
 
-#if defined(DT_ST_LIS2DH_BUS_SPI)
+#if DT_ANY_INST_ON_BUS(spi)
 #include <drivers/spi.h>
 
 #define LIS2DH_SPI_READ_BIT		BIT(7)
@@ -31,7 +31,7 @@
 /* LIS2DH supports only SPI mode 0, word size 8 bits, MSB first */
 #define LIS2DH_SPI_CFG			SPI_WORD_SET(8)
 
-#elif defined(DT_ST_LIS2DH_BUS_I2C)
+#elif DT_ANY_INST_ON_BUS(i2c)
 #include <drivers/i2c.h>
 #else
 #error "define bus type (I2C/SPI)"
@@ -174,19 +174,19 @@
 /* sample buffer size includes status register */
 #define LIS2DH_BUF_SZ			7
 
-#if defined(DT_INST_0_ST_LIS2DH_IRQ_GPIOS_CONTROLLER_1)
+#if DT_INST_PROP_HAS_IDX(0, irq_gpios, 1)
 /* INT1 and INT2 are configured */
-#define DT_LIS2DH_INT1_GPIOS_PIN		DT_INST_0_ST_LIS2DH_IRQ_GPIOS_PIN_0
-#define DT_LIS2DH_INT1_GPIOS_FLAGS		DT_INST_0_ST_LIS2DH_IRQ_GPIOS_FLAGS_0
-#define DT_LIS2DH_INT1_GPIO_DEV_NAME	DT_INST_0_ST_LIS2DH_IRQ_GPIOS_CONTROLLER_0
-#define DT_LIS2DH_INT2_GPIOS_PIN		DT_INST_0_ST_LIS2DH_IRQ_GPIOS_PIN_1
-#define DT_LIS2DH_INT2_GPIOS_FLAGS		DT_INST_0_ST_LIS2DH_IRQ_GPIOS_FLAGS_1
-#define DT_LIS2DH_INT2_GPIO_DEV_NAME	DT_INST_0_ST_LIS2DH_IRQ_GPIOS_CONTROLLER_1
+#define DT_LIS2DH_INT1_GPIOS_PIN		DT_INST_GPIO_PIN_BY_IDX(0, irq_gpios, 0)
+#define DT_LIS2DH_INT1_GPIOS_FLAGS		DT_INST_GPIO_FLAGS_BY_IDX(0, irq_gpios, 0)
+#define DT_LIS2DH_INT1_GPIO_DEV_NAME	DT_INST_GPIO_LABEL_BY_IDX(0, irq_gpios, 0)
+#define DT_LIS2DH_INT2_GPIOS_PIN		DT_INST_GPIO_PIN_BY_IDX(0, irq_gpios, 1)
+#define DT_LIS2DH_INT2_GPIOS_FLAGS		DT_INST_GPIO_FLAGS_BY_IDX(0, irq_gpios, 1)
+#define DT_LIS2DH_INT2_GPIO_DEV_NAME	DT_INST_GPIO_LABEL_BY_IDX(0, irq_gpios, 1)
 #else
 /* INT1 only */
-#define DT_LIS2DH_INT1_GPIOS_PIN		DT_INST_0_ST_LIS2DH_IRQ_GPIOS_PIN
-#define DT_LIS2DH_INT1_GPIOS_FLAGS		DT_INST_0_ST_LIS2DH_IRQ_GPIOS_FLAGS
-#define DT_LIS2DH_INT1_GPIO_DEV_NAME	DT_INST_0_ST_LIS2DH_IRQ_GPIOS_CONTROLLER
+#define DT_LIS2DH_INT1_GPIOS_PIN		DT_INST_GPIO_PIN(0, irq_gpios)
+#define DT_LIS2DH_INT1_GPIOS_FLAGS		DT_INST_GPIO_FLAGS(0, irq_gpios)
+#define DT_LIS2DH_INT1_GPIO_DEV_NAME	DT_INST_GPIO_LABEL(0, irq_gpios)
 #endif
 
 union lis2dh_sample {
@@ -200,15 +200,15 @@ union lis2dh_sample {
 struct lis2dh_config {
 	char *bus_name;
 	int (*bus_init)(struct device *dev);
-#ifdef DT_ST_LIS2DH_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 	u16_t i2c_slv_addr;
-#elif DT_ST_LIS2DH_BUS_SPI
+#elif DT_ANY_INST_ON_BUS(spi)
 	struct spi_config spi_conf;
-#if defined(DT_INST_0_ST_LIS2DH_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const char *gpio_cs_port;
 	u8_t cs_gpio;
-#endif /* DT_INST_0_ST_LIS2DH_CS_GPIOS_CONTROLLER */
-#endif /* DT_ST_LIS2DH_BUS_SPI */
+#endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
+#endif /* DT_ANY_INST_ON_BUS(spi) */
 
 };
 
@@ -254,12 +254,12 @@ struct lis2dh_data {
 #endif
 
 #endif /* CONFIG_LIS2DH_TRIGGER */
-#if defined(DT_INST_0_ST_LIS2DH_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	struct spi_cs_control cs_ctrl;
-#endif /* DT_INST_0_ST_LIS2MDL_CS_GPIOS_CONTROLLER */
+#endif /* DT_SPI_DEV_HAS_CS_GPIOS(DT_INST(0, st_lis2mdl)) */
 };
 
-#if defined(DT_ST_LIS2DH_BUS_SPI)
+#if DT_ANY_INST_ON_BUS(spi)
 int lis2dh_spi_access(struct lis2dh_data *ctx, u8_t cmd,
 		      void *data, size_t length);
 #endif

--- a/drivers/sensor/lis2dh/lis2dh_i2c.c
+++ b/drivers/sensor/lis2dh/lis2dh_i2c.c
@@ -8,13 +8,15 @@
  * https://www.st.com/resource/en/datasheet/lis2dh.pdf
  */
 
+#define DT_DRV_COMPAT st_lis2dh
+
 #include <string.h>
 #include <drivers/i2c.h>
 #include <logging/log.h>
 
 #include "lis2dh.h"
 
-#ifdef DT_ST_LIS2DH_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 
 LOG_MODULE_DECLARE(lis2dh, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -89,4 +91,4 @@ int lis2dh_i2c_init(struct device *dev)
 
 	return 0;
 }
-#endif /* DT_ST_LIS2DH_BUS_I2C */
+#endif /* DT_ANY_INST_ON_BUS(i2c) */

--- a/drivers/sensor/lis2dh/lis2dh_spi.c
+++ b/drivers/sensor/lis2dh/lis2dh_spi.c
@@ -8,11 +8,13 @@
  * https://www.st.com/resource/en/datasheet/lis2dh.pdf
  */
 
+#define DT_DRV_COMPAT st_lis2dh
+
 #include <string.h>
 #include "lis2dh.h"
 #include <logging/log.h>
 
-#ifdef DT_ST_LIS2DH_BUS_SPI
+#if DT_ANY_INST_ON_BUS(spi)
 
 LOG_MODULE_DECLARE(lis2dh, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -151,7 +153,7 @@ int lis2dh_spi_init(struct device *dev)
 
 	data->hw_tf = &lis2dh_spi_transfer_fn;
 
-#if defined(DT_INST_0_ST_LIS2DH_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const struct lis2dh_config *cfg = dev->config->config_info;
 
 	/* handle SPI CS thru GPIO if it is the case */
@@ -170,4 +172,4 @@ int lis2dh_spi_init(struct device *dev)
 
 	return 0;
 }
-#endif /* DT_ST_LIS2DH_BUS_SPI */
+#endif /* DT_ANY_INST_ON_BUS(spi) */

--- a/drivers/sensor/lis2dh/lis2dh_trigger.c
+++ b/drivers/sensor/lis2dh/lis2dh_trigger.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT st_lis2dh
+
 #include <sys/util.h>
 #include <kernel.h>
 #include <logging/log.h>
@@ -103,7 +105,7 @@ static int lis2dh_start_trigger_int1(struct device *dev)
 					 LIS2DH_EN_DRDY1_INT1);
 }
 
-#if defined(DT_INST_0_ST_LIS2DH_IRQ_GPIOS_CONTROLLER_1)
+#if DT_INST_PROP_HAS_IDX(0, irq_gpios, 1)
 #define LIS2DH_ANYM_CFG (LIS2DH_INT_CFG_ZHIE_ZUPE | LIS2DH_INT_CFG_YHIE_YUPE |\
 			 LIS2DH_INT_CFG_XHIE_XUPE)
 
@@ -163,7 +165,7 @@ static int lis2dh_start_trigger_int2(struct device *dev)
 	return lis2dh->hw_tf->write_reg(dev, LIS2DH_REG_INT2_CFG,
 					LIS2DH_ANYM_CFG);
 }
-#endif /* DT_INST_0_ST_LIS2DH_IRQ_GPIOS_CONTROLLER_1 */
+#endif /* DT_INST_PROP_HAS_IDX(0, irq_gpios, 1) */
 
 int lis2dh_trigger_set(struct device *dev,
 		       const struct sensor_trigger *trig,
@@ -172,10 +174,10 @@ int lis2dh_trigger_set(struct device *dev,
 	if (trig->type == SENSOR_TRIG_DATA_READY &&
 	    trig->chan == SENSOR_CHAN_ACCEL_XYZ) {
 		return lis2dh_trigger_drdy_set(dev, trig->chan, handler);
-#if defined(DT_INST_0_ST_LIS2DH_IRQ_GPIOS_CONTROLLER_1)
+#if DT_INST_PROP_HAS_IDX(0, irq_gpios, 1)
 	} else if (trig->type == SENSOR_TRIG_DELTA) {
 		return lis2dh_trigger_anym_set(dev, handler);
-#endif /* DT_INST_0_ST_LIS2DH_IRQ_GPIOS_CONTROLLER_1 */
+#endif /* DT_INST_PROP_HAS_IDX(0, irq_gpios, 1) */
 	}
 
 	return -ENOTSUP;
@@ -251,7 +253,7 @@ static void lis2dh_gpio_int1_callback(struct device *dev,
 #endif
 }
 
-#if defined(DT_INST_0_ST_LIS2DH_IRQ_GPIOS_CONTROLLER_1)
+#if DT_INST_PROP_HAS_IDX(0, irq_gpios, 1)
 static void lis2dh_gpio_int2_callback(struct device *dev,
 				      struct gpio_callback *cb, u32_t pins)
 {
@@ -268,7 +270,7 @@ static void lis2dh_gpio_int2_callback(struct device *dev,
 	k_work_submit(&lis2dh->work);
 #endif
 }
-#endif /* DT_INST_0_ST_LIS2DH_IRQ_GPIOS_CONTROLLER_1 */
+#endif /* DT_INST_PROP_HAS_IDX(0, irq_gpios, 1) */
 
 static void lis2dh_thread_cb(void *arg)
 {
@@ -286,7 +288,7 @@ static void lis2dh_thread_cb(void *arg)
 		return;
 	}
 
-#if defined(DT_INST_0_ST_LIS2DH_IRQ_GPIOS_CONTROLLER_1)
+#if DT_INST_PROP_HAS_IDX(0, irq_gpios, 1)
 	if (unlikely(atomic_test_and_clear_bit(&lis2dh->trig_flags,
 		     START_TRIG_INT2))) {
 		status = lis2dh_start_trigger_int2(dev);
@@ -296,7 +298,7 @@ static void lis2dh_thread_cb(void *arg)
 		}
 		return;
 	}
-#endif /* DT_INST_0_ST_LIS2DH_IRQ_GPIOS_CONTROLLER_1 */
+#endif /* DT_INST_PROP_HAS_IDX(0, irq_gpios, 1) */
 
 	if (atomic_test_and_clear_bit(&lis2dh->trig_flags,
 				      TRIGGED_INT1)) {
@@ -312,7 +314,7 @@ static void lis2dh_thread_cb(void *arg)
 		return;
 	}
 
-#if defined(DT_INST_0_ST_LIS2DH_IRQ_GPIOS_CONTROLLER_1)
+#if DT_INST_PROP_HAS_IDX(0, irq_gpios, 1)
 	if (atomic_test_and_clear_bit(&lis2dh->trig_flags,
 				      TRIGGED_INT2)) {
 		struct sensor_trigger anym_trigger = {
@@ -338,7 +340,7 @@ static void lis2dh_thread_cb(void *arg)
 
 		return;
 	}
-#endif /* DT_INST_0_ST_LIS2DH_IRQ_GPIOS_CONTROLLER_1 */
+#endif /* DT_INST_PROP_HAS_IDX(0, irq_gpios, 1) */
 }
 
 #ifdef CONFIG_LIS2DH_TRIGGER_OWN_THREAD
@@ -371,7 +373,7 @@ int lis2dh_init_interrupt(struct device *dev)
 {
 	struct lis2dh_data *lis2dh = dev->driver_data;
 	int status;
-#if defined(DT_INST_0_ST_LIS2DH_IRQ_GPIOS_CONTROLLER_1)
+#if DT_INST_PROP_HAS_IDX(0, irq_gpios, 1)
 	u8_t raw[2];
 #endif
 
@@ -417,7 +419,7 @@ int lis2dh_init_interrupt(struct device *dev)
 
 	LOG_INF("int1 on pin=%d", DT_LIS2DH_INT1_GPIOS_PIN);
 
-#if defined(DT_INST_0_ST_LIS2DH_IRQ_GPIOS_CONTROLLER_1)
+#if DT_INST_PROP_HAS_IDX(0, irq_gpios, 1)
 	/* setup any motion gpio interrupt */
 	lis2dh->gpio_int2 = device_get_binding(DT_LIS2DH_INT2_GPIO_DEV_NAME);
 	if (lis2dh->gpio_int2 == NULL) {
@@ -476,7 +478,7 @@ int lis2dh_init_interrupt(struct device *dev)
 		LOG_ERR("INT2 latch enable reg write failed (%d)", status);
 		return status;
 	}
-#endif /* DT_INST_0_ST_LIS2DH_IRQ_GPIOS_CONTROLLER_1 */
+#endif /* DT_INST_PROP_HAS_IDX(0, irq_gpios, 1) */
 
 	return status;
 }

--- a/drivers/sensor/lis2ds12/lis2ds12.c
+++ b/drivers/sensor/lis2ds12/lis2ds12.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/lis2ds12.pdf
  */
 
+#define DT_DRV_COMPAT st_lis2ds12
+
 #include <drivers/sensor.h>
 #include <kernel.h>
 #include <device.h>
@@ -24,18 +26,18 @@ LOG_MODULE_REGISTER(LIS2DS12, CONFIG_SENSOR_LOG_LEVEL);
 static struct lis2ds12_data lis2ds12_data;
 
 static struct lis2ds12_config lis2ds12_config = {
-	.comm_master_dev_name = DT_INST_0_ST_LIS2DS12_BUS_NAME,
-#if defined(DT_ST_LIS2DS12_BUS_SPI)
+	.comm_master_dev_name = DT_INST_BUS_LABEL(0),
+#if DT_ANY_INST_ON_BUS(spi)
 	.bus_init = lis2ds12_spi_init,
-#elif defined(DT_ST_LIS2DS12_BUS_I2C)
+#elif DT_ANY_INST_ON_BUS(i2c)
 	.bus_init = lis2ds12_i2c_init,
 #else
 #error "BUS MACRO NOT DEFINED IN DTS"
 #endif
 #ifdef CONFIG_LIS2DS12_TRIGGER
-	.irq_port	= DT_INST_0_ST_LIS2DS12_IRQ_GPIOS_CONTROLLER,
-	.irq_pin	= DT_INST_0_ST_LIS2DS12_IRQ_GPIOS_PIN,
-	.irq_flags	= DT_INST_0_ST_LIS2DS12_IRQ_GPIOS_FLAGS,
+	.irq_port	= DT_INST_GPIO_LABEL(0, irq_gpios),
+	.irq_pin	= DT_INST_GPIO_PIN(0, irq_gpios),
+	.irq_flags	= DT_INST_GPIO_FLAGS(0, irq_gpios),
 #endif
 };
 
@@ -316,6 +318,6 @@ static int lis2ds12_init(struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(lis2ds12, DT_INST_0_ST_LIS2DS12_LABEL, lis2ds12_init,
+DEVICE_AND_API_INIT(lis2ds12, DT_INST_LABEL(0), lis2ds12_init,
 		    &lis2ds12_data, &lis2ds12_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lis2ds12_api_funcs);

--- a/drivers/sensor/lis2ds12/lis2ds12_i2c.c
+++ b/drivers/sensor/lis2ds12/lis2ds12_i2c.c
@@ -8,15 +8,17 @@
  * https://www.st.com/resource/en/datasheet/lis2ds12.pdf
  */
 
+#define DT_DRV_COMPAT st_lis2ds12
+
 #include <string.h>
 #include <drivers/i2c.h>
 #include <logging/log.h>
 
 #include "lis2ds12.h"
 
-#ifdef DT_ST_LIS2DS12_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 
-static u16_t lis2ds12_i2c_slave_addr = DT_INST_0_ST_LIS2DS12_BASE_ADDRESS;
+static u16_t lis2ds12_i2c_slave_addr = DT_INST_REG_ADDR(0);
 
 LOG_MODULE_DECLARE(LIS2DS12, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -71,4 +73,4 @@ int lis2ds12_i2c_init(struct device *dev)
 
 	return 0;
 }
-#endif /* DT_ST_LIS2DS12_BUS_I2C */
+#endif /* DT_ANY_INST_ON_BUS(i2c) */

--- a/drivers/sensor/lis2ds12/lis2ds12_spi.c
+++ b/drivers/sensor/lis2ds12/lis2ds12_spi.c
@@ -8,27 +8,29 @@
  * https://www.st.com/resource/en/datasheet/lis2ds12.pdf
  */
 
+#define DT_DRV_COMPAT st_lis2ds12
+
 
 #include <string.h>
 #include <drivers/spi.h>
 #include "lis2ds12.h"
 #include <logging/log.h>
 
-#ifdef DT_ST_LIS2DS12_BUS_SPI
+#if DT_ANY_INST_ON_BUS(spi)
 
 #define LIS2DS12_SPI_READ		(1 << 7)
 
 LOG_MODULE_DECLARE(LIS2DS12, CONFIG_SENSOR_LOG_LEVEL);
 
-#if defined(DT_INST_0_ST_LIS2DS12_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 static struct spi_cs_control lis2ds12_cs_ctrl;
 #endif
 
 static struct spi_config lis2ds12_spi_conf = {
-	.frequency = DT_INST_0_ST_LIS2DS12_SPI_MAX_FREQUENCY,
+	.frequency = DT_INST_PROP(0, spi_max_frequency),
 	.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
 		      SPI_MODE_CPHA | SPI_WORD_SET(8) | SPI_LINES_SINGLE),
-	.slave     = DT_INST_0_ST_LIS2DS12_BASE_ADDRESS,
+	.slave     = DT_INST_REG_ADDR(0),
 	.cs        = NULL,
 };
 
@@ -155,25 +157,25 @@ int lis2ds12_spi_init(struct device *dev)
 
 	data->hw_tf = &lis2ds12_spi_transfer_fn;
 
-#if defined(DT_INST_0_ST_LIS2DS12_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	/* handle SPI CS thru GPIO if it is the case */
 	lis2ds12_cs_ctrl.gpio_dev = device_get_binding(
-		DT_INST_0_ST_LIS2DS12_CS_GPIOS_CONTROLLER);
+		DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
 	if (!lis2ds12_cs_ctrl.gpio_dev) {
 		LOG_ERR("Unable to get GPIO SPI CS device");
 		return -ENODEV;
 	}
 
-	lis2ds12_cs_ctrl.gpio_pin = DT_INST_0_ST_LIS2DS12_CS_GPIOS_PIN;
+	lis2ds12_cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
 	lis2ds12_cs_ctrl.delay = 0U;
 
 	lis2ds12_spi_conf.cs = &lis2ds12_cs_ctrl;
 
 	LOG_DBG("SPI GPIO CS configured on %s:%u",
-		    DT_INST_0_ST_LIS2DS12_CS_GPIOS_CONTROLLER,
-		    DT_INST_0_ST_LIS2DS12_CS_GPIOS_PIN);
+		    DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
+		    DT_INST_SPI_DEV_CS_GPIOS_PIN(0));
 #endif
 
 	return 0;
 }
-#endif /* DT_ST_LIS2DS12_BUS_SPI */
+#endif /* DT_ANY_INST_ON_BUS(spi) */

--- a/drivers/sensor/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/lis2dw12/lis2dw12.c
@@ -8,15 +8,17 @@
  * https://www.st.com/resource/en/datasheet/lis2dw12.pdf
  */
 
+#define DT_DRV_COMPAT st_lis2dw12
+
 #include <init.h>
 #include <sys/__assert.h>
 #include <sys/byteorder.h>
 #include <logging/log.h>
 #include <drivers/sensor.h>
 
-#if defined(DT_ST_LIS2DW12_BUS_SPI)
+#if DT_ANY_INST_ON_BUS(spi)
 #include <drivers/spi.h>
-#elif defined(DT_ST_LIS2DW12_BUS_I2C)
+#elif DT_ANY_INST_ON_BUS(i2c)
 #include <drivers/i2c.h>
 #endif
 
@@ -220,9 +222,9 @@ static int lis2dw12_init_interface(struct device *dev)
 		return -EINVAL;
 	}
 
-#if defined(DT_ST_LIS2DW12_BUS_SPI)
+#if DT_ANY_INST_ON_BUS(spi)
 	lis2dw12_spi_init(dev);
-#elif defined(DT_ST_LIS2DW12_BUS_I2C)
+#elif DT_ANY_INST_ON_BUS(i2c)
 	lis2dw12_i2c_init(dev);
 #else
 #error "BUS MACRO NOT DEFINED IN DTS"
@@ -371,12 +373,12 @@ static int lis2dw12_init(struct device *dev)
 }
 
 const struct lis2dw12_device_config lis2dw12_cfg = {
-	.bus_name = DT_INST_0_ST_LIS2DW12_BUS_NAME,
+	.bus_name = DT_INST_BUS_LABEL(0),
 	.pm = CONFIG_LIS2DW12_POWER_MODE,
 #ifdef CONFIG_LIS2DW12_TRIGGER
-	.int_gpio_port = DT_INST_0_ST_LIS2DW12_IRQ_GPIOS_CONTROLLER,
-	.int_gpio_pin = DT_INST_0_ST_LIS2DW12_IRQ_GPIOS_PIN,
-	.int_gpio_flags = DT_INST_0_ST_LIS2DW12_IRQ_GPIOS_FLAGS,
+	.int_gpio_port = DT_INST_GPIO_LABEL(0, irq_gpios),
+	.int_gpio_pin = DT_INST_GPIO_PIN(0, irq_gpios),
+	.int_gpio_flags = DT_INST_GPIO_FLAGS(0, irq_gpios),
 #if defined(CONFIG_LIS2DW12_INT_PIN_1)
 	.int_pin = 1,
 #elif defined(CONFIG_LIS2DW12_INT_PIN_2)
@@ -401,6 +403,6 @@ const struct lis2dw12_device_config lis2dw12_cfg = {
 
 struct lis2dw12_data lis2dw12_data;
 
-DEVICE_AND_API_INIT(lis2dw12, DT_INST_0_ST_LIS2DW12_LABEL, lis2dw12_init,
+DEVICE_AND_API_INIT(lis2dw12, DT_INST_LABEL(0), lis2dw12_init,
 	     &lis2dw12_data, &lis2dw12_cfg, POST_KERNEL,
 	     CONFIG_SENSOR_INIT_PRIORITY, &lis2dw12_driver_api);

--- a/drivers/sensor/lis2dw12/lis2dw12.h
+++ b/drivers/sensor/lis2dw12/lis2dw12.h
@@ -134,7 +134,7 @@ struct lis2dw12_data {
 	struct device *dev;
 #endif /* CONFIG_LIS2DW12_TRIGGER_GLOBAL_THREAD */
 #endif /* CONFIG_LIS2DW12_TRIGGER */
-#if defined(DT_INST_0_ST_LIS2DW12_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	struct spi_cs_control cs_ctrl;
 #endif
 };

--- a/drivers/sensor/lis2dw12/lis2dw12_i2c.c
+++ b/drivers/sensor/lis2dw12/lis2dw12_i2c.c
@@ -8,15 +8,17 @@
  * https://www.st.com/resource/en/datasheet/lis2dw12.pdf
  */
 
+#define DT_DRV_COMPAT st_lis2dw12
+
 #include <string.h>
 #include <drivers/i2c.h>
 #include <logging/log.h>
 
 #include "lis2dw12.h"
 
-#ifdef DT_ST_LIS2DW12_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 
-static u16_t lis2dw12_i2c_slave_addr = DT_INST_0_ST_LIS2DW12_BASE_ADDRESS;
+static u16_t lis2dw12_i2c_slave_addr = DT_INST_REG_ADDR(0);
 
 LOG_MODULE_DECLARE(LIS2DW12, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -48,4 +50,4 @@ int lis2dw12_i2c_init(struct device *dev)
 
 	return 0;
 }
-#endif /* DT_ST_LIS2DW12_BUS_I2C */
+#endif /* DT_ANY_INST_ON_BUS(i2c) */

--- a/drivers/sensor/lis2dw12/lis2dw12_spi.c
+++ b/drivers/sensor/lis2dw12/lis2dw12_spi.c
@@ -8,22 +8,24 @@
  * https://www.st.com/resource/en/datasheet/lis2dw12.pdf
  */
 
+#define DT_DRV_COMPAT st_lis2dw12
+
 
 #include <string.h>
 #include "lis2dw12.h"
 #include <logging/log.h>
 
-#ifdef DT_ST_LIS2DW12_BUS_SPI
+#if DT_ANY_INST_ON_BUS(spi)
 
 #define LIS2DW12_SPI_READ		(1 << 7)
 
 LOG_MODULE_DECLARE(LIS2DW12, CONFIG_SENSOR_LOG_LEVEL);
 
 static struct spi_config lis2dw12_spi_conf = {
-	.frequency = DT_INST_0_ST_LIS2DW12_SPI_MAX_FREQUENCY,
+	.frequency = DT_INST_PROP(0, spi_max_frequency),
 	.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
 		      SPI_MODE_CPHA | SPI_WORD_SET(8) | SPI_LINES_SINGLE),
-	.slave     = DT_INST_0_ST_LIS2DW12_BASE_ADDRESS,
+	.slave     = DT_INST_REG_ADDR(0),
 	.cs        = NULL,
 };
 
@@ -102,25 +104,25 @@ int lis2dw12_spi_init(struct device *dev)
 	data->ctx = &lis2dw12_spi_ctx;
 	data->ctx->handle = data;
 
-#if defined(DT_INST_0_ST_LIS2DW12_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	/* handle SPI CS thru GPIO if it is the case */
 	data->cs_ctrl.gpio_dev = device_get_binding(
-		DT_INST_0_ST_LIS2DW12_CS_GPIOS_CONTROLLER);
+		DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
 	if (!data->cs_ctrl.gpio_dev) {
 		LOG_ERR("Unable to get GPIO SPI CS device");
 		return -ENODEV;
 	}
 
-	data->cs_ctrl.gpio_pin = DT_INST_0_ST_LIS2DW12_CS_GPIOS_PIN;
+	data->cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
 	data->cs_ctrl.delay = 0U;
 
 	lis2dw12_spi_conf.cs = &data->cs_ctrl;
 
 	LOG_DBG("SPI GPIO CS configured on %s:%u",
-		    DT_INST_0_ST_LIS2DW12_CS_GPIOS_CONTROLLER,
-		    DT_INST_0_ST_LIS2DW12_CS_GPIOS_PIN);
+		    DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
+		    DT_INST_SPI_DEV_CS_GPIOS_PIN(0));
 #endif
 
 	return 0;
 }
-#endif /* DT_ST_LIS2DW12_BUS_SPI */
+#endif /* DT_ANY_INST_ON_BUS(spi) */

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/lis2mdl.pdf
  */
 
+#define DT_DRV_COMPAT st_lis2mdl
+
 #include <init.h>
 #include <sys/__assert.h>
 #include <sys/byteorder.h>
@@ -255,30 +257,30 @@ static int lis2mdl_init_interface(struct device *dev)
 }
 
 static const struct lis2mdl_config lis2mdl_dev_config = {
-	.master_dev_name = DT_INST_0_ST_LIS2MDL_BUS_NAME,
+	.master_dev_name = DT_INST_BUS_LABEL(0),
 #ifdef CONFIG_LIS2MDL_TRIGGER
-	.gpio_name = DT_INST_0_ST_LIS2MDL_IRQ_GPIOS_CONTROLLER,
-	.gpio_pin = DT_INST_0_ST_LIS2MDL_IRQ_GPIOS_PIN,
-	.gpio_flags = DT_INST_0_ST_LIS2MDL_IRQ_GPIOS_FLAGS,
+	.gpio_name = DT_INST_GPIO_LABEL(0, irq_gpios),
+	.gpio_pin = DT_INST_GPIO_PIN(0, irq_gpios),
+	.gpio_flags = DT_INST_GPIO_FLAGS(0, irq_gpios),
 #endif  /* CONFIG_LIS2MDL_TRIGGER */
-#if defined(DT_ST_LIS2MDL_BUS_SPI)
+#if DT_ANY_INST_ON_BUS(spi)
 	.bus_init = lis2mdl_spi_init,
-	.spi_conf.frequency = DT_INST_0_ST_LIS2MDL_SPI_MAX_FREQUENCY,
+	.spi_conf.frequency = DT_INST_PROP(0, spi_max_frequency),
 	.spi_conf.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
 			       SPI_MODE_CPHA | SPI_WORD_SET(8) |
 			       SPI_LINES_SINGLE),
-	.spi_conf.slave     = DT_INST_0_ST_LIS2MDL_BASE_ADDRESS,
-#if defined(DT_INST_0_ST_LIS2MDL_CS_GPIOS_CONTROLLER)
-	.gpio_cs_port	    = DT_INST_0_ST_LIS2MDL_CS_GPIOS_CONTROLLER,
-	.cs_gpio	    = DT_INST_0_ST_LIS2MDL_CS_GPIOS_PIN,
+	.spi_conf.slave     = DT_INST_REG_ADDR(0),
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
+	.gpio_cs_port	    = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
+	.cs_gpio	    = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
 
 	.spi_conf.cs        =  &lis2mdl_data.cs_ctrl,
 #else
 	.spi_conf.cs        = NULL,
 #endif
-#elif defined(DT_ST_LIS2MDL_BUS_I2C)
+#elif DT_ANY_INST_ON_BUS(i2c)
 	.bus_init = lis2mdl_i2c_init,
-	.i2c_slv_addr = DT_INST_0_ST_LIS2MDL_BASE_ADDRESS,
+	.i2c_slv_addr = DT_INST_REG_ADDR(0),
 #else
 #error "BUS MACRO NOT DEFINED IN DTS"
 #endif
@@ -359,6 +361,6 @@ static int lis2mdl_init(struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(lis2mdl, DT_INST_0_ST_LIS2MDL_LABEL, lis2mdl_init,
+DEVICE_AND_API_INIT(lis2mdl, DT_INST_LABEL(0), lis2mdl_init,
 		     &lis2mdl_data, &lis2mdl_dev_config, POST_KERNEL,
 		     CONFIG_SENSOR_INIT_PRIORITY, &lis2mdl_driver_api);

--- a/drivers/sensor/lis2mdl/lis2mdl.h
+++ b/drivers/sensor/lis2mdl/lis2mdl.h
@@ -35,15 +35,15 @@ struct lis2mdl_config {
 	u32_t gpio_pin;
 	u8_t gpio_flags;
 #endif  /* CONFIG_LIS2MDL_TRIGGER */
-#ifdef DT_ST_LIS2MDL_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 	u16_t i2c_slv_addr;
-#elif DT_ST_LIS2MDL_BUS_SPI
+#elif DT_ANY_INST_ON_BUS(spi)
 	struct spi_config spi_conf;
-#if defined(DT_INST_0_ST_LIS2MDL_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const char *gpio_cs_port;
 	u8_t cs_gpio;
-#endif /* DT_INST_0_ST_LIS2MDL_CS_GPIOS_CONTROLLER */
-#endif /* DT_ST_LIS2MDL_BUS_SPI */
+#endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
+#endif /* DT_ANY_INST_ON_BUS(spi) */
 };
 
 /* Sensor data */
@@ -55,9 +55,9 @@ struct lis2mdl_data {
 
 	stmdev_ctx_t *ctx;
 
-#ifdef DT_ST_LIS2MDL_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 	stmdev_ctx_t ctx_i2c;
-#elif DT_ST_LIS2MDL_BUS_SPI
+#elif DT_ANY_INST_ON_BUS(spi)
 	stmdev_ctx_t ctx_spi;
 #endif
 
@@ -76,9 +76,9 @@ struct lis2mdl_data {
 	struct device *dev;
 #endif  /* CONFIG_LIS2MDL_TRIGGER_GLOBAL_THREAD */
 #endif  /* CONFIG_LIS2MDL_TRIGGER */
-#if defined(DT_INST_0_ST_LIS2MDL_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	struct spi_cs_control cs_ctrl;
-#endif /* DT_INST_0_ST_LIS2MDL_CS_GPIOS_CONTROLLER */
+#endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
 };
 
 int lis2mdl_spi_init(struct device *dev);

--- a/drivers/sensor/lis2mdl/lis2mdl_i2c.c
+++ b/drivers/sensor/lis2mdl/lis2mdl_i2c.c
@@ -8,13 +8,15 @@
  * https://www.st.com/resource/en/datasheet/lis2mdl.pdf
  */
 
+#define DT_DRV_COMPAT st_lis2mdl
+
 #include <string.h>
 #include <drivers/i2c.h>
 #include <logging/log.h>
 
 #include "lis2mdl.h"
 
-#ifdef DT_ST_LIS2MDL_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
 LOG_MODULE_DECLARE(LIS2MDL);
@@ -51,4 +53,4 @@ int lis2mdl_i2c_init(struct device *dev)
 
 	return 0;
 }
-#endif /* DT_ST_LIS2MDL_BUS_I2C */
+#endif /* DT_ANY_INST_ON_BUS(i2c) */

--- a/drivers/sensor/lis2mdl/lis2mdl_spi.c
+++ b/drivers/sensor/lis2mdl/lis2mdl_spi.c
@@ -8,11 +8,13 @@
  * https://www.st.com/resource/en/datasheet/lis2mdl.pdf
  */
 
+#define DT_DRV_COMPAT st_lis2mdl
+
 #include <string.h>
 #include "lis2mdl.h"
 #include <logging/log.h>
 
-#ifdef DT_ST_LIS2MDL_BUS_SPI
+#if DT_ANY_INST_ON_BUS(spi)
 
 #define LIS2MDL_SPI_READ		(1 << 7)
 
@@ -105,7 +107,7 @@ int lis2mdl_spi_init(struct device *dev)
 	data->ctx = &data->ctx_spi;
 	data->ctx->handle = dev;
 
-#if defined(DT_INST_0_ST_LIS2MDL_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const struct lis2mdl_config *cfg = dev->config->config_info;
 
 	/* handle SPI CS thru GPIO if it is the case */
@@ -131,4 +133,4 @@ int lis2mdl_spi_init(struct device *dev)
 
 	return 0;
 }
-#endif /* DT_ST_LIS2MDL_BUS_SPI */
+#endif /* DT_ANY_INST_ON_BUS(spi) */

--- a/drivers/sensor/lis3mdl/lis3mdl.c
+++ b/drivers/sensor/lis3mdl/lis3mdl.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT st_lis3mdl_magn
+
 #include <drivers/i2c.h>
 #include <init.h>
 #include <sys/__assert.h>
@@ -64,7 +66,7 @@ int lis3mdl_sample_fetch(struct device *dev, enum sensor_channel chan)
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 
 	/* fetch magnetometer sample */
-	if (i2c_burst_read(drv_data->i2c, DT_INST_0_ST_LIS3MDL_MAGN_BASE_ADDRESS,
+	if (i2c_burst_read(drv_data->i2c, DT_INST_REG_ADDR(0),
 			   LIS3MDL_REG_SAMPLE_START, (u8_t *)buf, 8) < 0) {
 		LOG_DBG("Failed to fetch megnetometer sample.");
 		return -EIO;
@@ -75,7 +77,7 @@ int lis3mdl_sample_fetch(struct device *dev, enum sensor_channel chan)
 	 * the same read as magnetometer data, so do another
 	 * burst read to fetch the temperature sample
 	 */
-	if (i2c_burst_read(drv_data->i2c, DT_INST_0_ST_LIS3MDL_MAGN_BASE_ADDRESS,
+	if (i2c_burst_read(drv_data->i2c, DT_INST_REG_ADDR(0),
 			   LIS3MDL_REG_SAMPLE_START + 6,
 			   (u8_t *)(buf + 3), 2) < 0) {
 		LOG_DBG("Failed to fetch temperature sample.");
@@ -104,16 +106,16 @@ int lis3mdl_init(struct device *dev)
 	u8_t chip_cfg[6];
 	u8_t id, idx;
 
-	drv_data->i2c = device_get_binding(DT_INST_0_ST_LIS3MDL_MAGN_BUS_NAME);
+	drv_data->i2c = device_get_binding(DT_INST_BUS_LABEL(0));
 
 	if (drv_data->i2c == NULL) {
 		LOG_ERR("Could not get pointer to %s device.",
-			DT_INST_0_ST_LIS3MDL_MAGN_BUS_NAME);
+			DT_INST_BUS_LABEL(0));
 		return -EINVAL;
 	}
 
 	/* check chip ID */
-	if (i2c_reg_read_byte(drv_data->i2c, DT_INST_0_ST_LIS3MDL_MAGN_BASE_ADDRESS,
+	if (i2c_reg_read_byte(drv_data->i2c, DT_INST_REG_ADDR(0),
 			      LIS3MDL_REG_WHO_AM_I, &id) < 0) {
 		LOG_ERR("Failed to read chip ID.");
 		return -EIO;
@@ -147,7 +149,7 @@ int lis3mdl_init(struct device *dev)
 	chip_cfg[5] = LIS3MDL_BDU_EN;
 
 	if (i2c_write(drv_data->i2c,
-		      chip_cfg, 6, DT_INST_0_ST_LIS3MDL_MAGN_BASE_ADDRESS) < 0) {
+		      chip_cfg, 6, DT_INST_REG_ADDR(0)) < 0) {
 		LOG_DBG("Failed to configure chip.");
 		return -EIO;
 	}
@@ -164,6 +166,6 @@ int lis3mdl_init(struct device *dev)
 
 struct lis3mdl_data lis3mdl_driver;
 
-DEVICE_AND_API_INIT(lis3mdl, DT_INST_0_ST_LIS3MDL_MAGN_LABEL, lis3mdl_init,
+DEVICE_AND_API_INIT(lis3mdl, DT_INST_LABEL(0), lis3mdl_init,
 		    &lis3mdl_driver, NULL, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lis3mdl_driver_api);

--- a/drivers/sensor/lis3mdl/lis3mdl_trigger.c
+++ b/drivers/sensor/lis3mdl/lis3mdl_trigger.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT st_lis3mdl_magn
+
 #include <device.h>
 #include <drivers/i2c.h>
 #include <sys/__assert.h>
@@ -25,11 +27,11 @@ int lis3mdl_trigger_set(struct device *dev,
 	__ASSERT_NO_MSG(trig->type == SENSOR_TRIG_DATA_READY);
 
 	/* dummy read: re-trigger interrupt */
-	i2c_burst_read(drv_data->i2c, DT_INST_0_ST_LIS3MDL_MAGN_BASE_ADDRESS,
+	i2c_burst_read(drv_data->i2c, DT_INST_REG_ADDR(0),
 			   LIS3MDL_REG_SAMPLE_START, (u8_t *)buf, 6);
 
 	gpio_pin_interrupt_configure(drv_data->gpio,
-			DT_INST_0_ST_LIS3MDL_MAGN_IRQ_GPIOS_PIN,
+			DT_INST_GPIO_PIN(0, irq_gpios),
 			GPIO_INT_DISABLE);
 
 	drv_data->data_ready_handler = handler;
@@ -40,7 +42,7 @@ int lis3mdl_trigger_set(struct device *dev,
 	drv_data->data_ready_trigger = *trig;
 
 	gpio_pin_interrupt_configure(drv_data->gpio,
-			DT_INST_0_ST_LIS3MDL_MAGN_IRQ_GPIOS_PIN,
+			DT_INST_GPIO_PIN(0, irq_gpios),
 			GPIO_INT_EDGE_TO_ACTIVE);
 
 	return 0;
@@ -55,7 +57,7 @@ static void lis3mdl_gpio_callback(struct device *dev,
 	ARG_UNUSED(pins);
 
 	gpio_pin_interrupt_configure(dev,
-				     DT_INST_0_ST_LIS3MDL_MAGN_IRQ_GPIOS_PIN,
+				     DT_INST_GPIO_PIN(0, irq_gpios),
 				     GPIO_INT_DISABLE);
 
 #if defined(CONFIG_LIS3MDL_TRIGGER_OWN_THREAD)
@@ -76,7 +78,7 @@ static void lis3mdl_thread_cb(void *arg)
 	}
 
 	gpio_pin_interrupt_configure(drv_data->gpio,
-			DT_INST_0_ST_LIS3MDL_MAGN_IRQ_GPIOS_PIN,
+			DT_INST_GPIO_PIN(0, irq_gpios),
 			GPIO_INT_EDGE_TO_ACTIVE);
 }
 
@@ -111,21 +113,21 @@ int lis3mdl_init_interrupt(struct device *dev)
 
 	/* setup data ready gpio interrupt */
 	drv_data->gpio =
-		device_get_binding(DT_INST_0_ST_LIS3MDL_MAGN_IRQ_GPIOS_CONTROLLER);
+		device_get_binding(DT_INST_GPIO_LABEL(0, irq_gpios));
 	if (drv_data->gpio == NULL) {
 		LOG_DBG("Cannot get pointer to %s device.",
-			    DT_INST_0_ST_LIS3MDL_MAGN_IRQ_GPIOS_CONTROLLER);
+			    DT_INST_GPIO_LABEL(0, irq_gpios));
 		return -EINVAL;
 	}
 
 	gpio_pin_configure(drv_data->gpio,
-			   DT_INST_0_ST_LIS3MDL_MAGN_IRQ_GPIOS_PIN,
+			   DT_INST_GPIO_PIN(0, irq_gpios),
 			   GPIO_INPUT |
-			   DT_INST_0_ST_LIS3MDL_MAGN_IRQ_GPIOS_FLAGS);
+			   DT_INST_GPIO_FLAGS(0, irq_gpios));
 
 	gpio_init_callback(&drv_data->gpio_cb,
 			   lis3mdl_gpio_callback,
-			   BIT(DT_INST_0_ST_LIS3MDL_MAGN_IRQ_GPIOS_PIN));
+			   BIT(DT_INST_GPIO_PIN(0, irq_gpios)));
 
 	if (gpio_add_callback(drv_data->gpio, &drv_data->gpio_cb) < 0) {
 		LOG_DBG("Could not set gpio callback.");
@@ -152,7 +154,7 @@ int lis3mdl_init_interrupt(struct device *dev)
 #endif
 
 	gpio_pin_interrupt_configure(drv_data->gpio,
-			DT_INST_0_ST_LIS3MDL_MAGN_IRQ_GPIOS_PIN,
+			DT_INST_GPIO_PIN(0, irq_gpios),
 			GPIO_INT_EDGE_TO_ACTIVE);
 
 	return 0;

--- a/drivers/sensor/lps22hb/lps22hb.c
+++ b/drivers/sensor/lps22hb/lps22hb.c
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT st_lps22hb_press
+
 #include <drivers/sensor.h>
 #include <kernel.h>
 #include <device.h>
@@ -151,12 +153,12 @@ static int lps22hb_init(struct device *dev)
 }
 
 static const struct lps22hb_config lps22hb_config = {
-	.i2c_master_dev_name = DT_INST_0_ST_LPS22HB_PRESS_BUS_NAME,
-	.i2c_slave_addr = DT_INST_0_ST_LPS22HB_PRESS_BASE_ADDRESS,
+	.i2c_master_dev_name = DT_INST_BUS_LABEL(0),
+	.i2c_slave_addr = DT_INST_REG_ADDR(0),
 };
 
 static struct lps22hb_data lps22hb_data;
 
-DEVICE_AND_API_INIT(lps22hb, DT_INST_0_ST_LPS22HB_PRESS_LABEL, lps22hb_init,
+DEVICE_AND_API_INIT(lps22hb, DT_INST_LABEL(0), lps22hb_init,
 		    &lps22hb_data, &lps22hb_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lps22hb_api_funcs);

--- a/drivers/sensor/lps22hh/lps22hh.c
+++ b/drivers/sensor/lps22hh/lps22hh.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/lps22hh.pdf
  */
 
+#define DT_DRV_COMPAT st_lps22hh
+
 #include <drivers/sensor.h>
 #include <kernel.h>
 #include <device.h>
@@ -199,35 +201,35 @@ static int lps22hh_init(struct device *dev)
 static struct lps22hh_data lps22hh_data;
 
 static const struct lps22hh_config lps22hh_config = {
-	.master_dev_name = DT_INST_0_ST_LPS22HH_BUS_NAME,
+	.master_dev_name = DT_INST_BUS_LABEL(0),
 #ifdef CONFIG_LPS22HH_TRIGGER
-	.drdy_port	= DT_INST_0_ST_LPS22HH_DRDY_GPIOS_CONTROLLER,
-	.drdy_pin	= DT_INST_0_ST_LPS22HH_DRDY_GPIOS_PIN,
-	.drdy_flags	= DT_INST_0_ST_LPS22HH_DRDY_GPIOS_FLAGS,
+	.drdy_port	= DT_INST_GPIO_LABEL(0, drdy_gpios),
+	.drdy_pin	= DT_INST_GPIO_PIN(0, drdy_gpios),
+	.drdy_flags	= DT_INST_GPIO_FLAGS(0, drdy_gpios),
 #endif
-#if defined(DT_ST_LPS22HH_BUS_SPI)
+#if DT_ANY_INST_ON_BUS(spi)
 	.bus_init = lps22hh_spi_init,
-	.spi_conf.frequency = DT_INST_0_ST_LPS22HH_SPI_MAX_FREQUENCY,
+	.spi_conf.frequency = DT_INST_PROP(0, spi_max_frequency),
 	.spi_conf.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
 			       SPI_MODE_CPHA | SPI_WORD_SET(8) |
 			       SPI_LINES_SINGLE),
-	.spi_conf.slave     = DT_INST_0_ST_LPS22HH_BASE_ADDRESS,
-#if defined(DT_INST_0_ST_LPS22HH_CS_GPIOS_CONTROLLER)
-	.gpio_cs_port	    = DT_INST_0_ST_LPS22HH_CS_GPIOS_CONTROLLER,
-	.cs_gpio	    = DT_INST_0_ST_LPS22HH_CS_GPIOS_PIN,
+	.spi_conf.slave     = DT_INST_REG_ADDR(0),
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
+	.gpio_cs_port	    = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
+	.cs_gpio	    = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
 
 	.spi_conf.cs        =  &lps22hh_data.cs_ctrl,
 #else
 	.spi_conf.cs        = NULL,
 #endif
-#elif defined(DT_ST_LPS22HH_BUS_I2C)
+#elif DT_ANY_INST_ON_BUS(i2c)
 	.bus_init = lps22hh_i2c_init,
-	.i2c_slv_addr = DT_INST_0_ST_LPS22HH_BASE_ADDRESS,
+	.i2c_slv_addr = DT_INST_REG_ADDR(0),
 #else
 #error "BUS MACRO NOT DEFINED IN DTS"
 #endif
 };
 
-DEVICE_AND_API_INIT(lps22hh, DT_INST_0_ST_LPS22HH_LABEL, lps22hh_init,
+DEVICE_AND_API_INIT(lps22hh, DT_INST_LABEL(0), lps22hh_init,
 		    &lps22hh_data, &lps22hh_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lps22hh_api_funcs);

--- a/drivers/sensor/lps22hh/lps22hh.h
+++ b/drivers/sensor/lps22hh/lps22hh.h
@@ -38,11 +38,11 @@ struct lps22hh_config {
 	u8_t drdy_pin;
 	u8_t drdy_flags;
 #endif
-#ifdef DT_ST_LPS22HH_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 	u16_t i2c_slv_addr;
-#elif DT_ST_LPS22HH_BUS_SPI
+#elif DT_ANY_INST_ON_BUS(spi)
 	struct spi_config spi_conf;
-#if defined(DT_INST_0_ST_LPS22HH_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const char *gpio_cs_port;
 	u8_t cs_gpio;
 #endif
@@ -56,9 +56,9 @@ struct lps22hh_data {
 
 	stmdev_ctx_t *ctx;
 
-#ifdef DT_ST_LPS22HH_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 	stmdev_ctx_t ctx_i2c;
-#elif DT_ST_LPS22HH_BUS_SPI
+#elif DT_ANY_INST_ON_BUS(spi)
 	stmdev_ctx_t ctx_spi;
 #endif
 
@@ -80,7 +80,7 @@ struct lps22hh_data {
 #endif
 
 #endif /* CONFIG_LPS22HH_TRIGGER */
-#if defined(DT_INST_0_ST_LPS22HH_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	struct spi_cs_control cs_ctrl;
 #endif
 };

--- a/drivers/sensor/lps22hh/lps22hh_i2c.c
+++ b/drivers/sensor/lps22hh/lps22hh_i2c.c
@@ -8,13 +8,15 @@
  * https://www.st.com/resource/en/datasheet/lps22hh.pdf
  */
 
+#define DT_DRV_COMPAT st_lps22hh
+
 #include <string.h>
 #include <drivers/i2c.h>
 #include <logging/log.h>
 
 #include "lps22hh.h"
 
-#ifdef DT_ST_LPS22HH_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 
 LOG_MODULE_DECLARE(LPS22HH, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -50,4 +52,4 @@ int lps22hh_i2c_init(struct device *dev)
 
 	return 0;
 }
-#endif /* DT_ST_LPS22HH_BUS_I2C */
+#endif /* DT_ANY_INST_ON_BUS(i2c) */

--- a/drivers/sensor/lps22hh/lps22hh_spi.c
+++ b/drivers/sensor/lps22hh/lps22hh_spi.c
@@ -8,12 +8,14 @@
  * https://www.st.com/resource/en/datasheet/lps22hh.pdf
  */
 
+#define DT_DRV_COMPAT st_lps22hh
+
 
 #include <string.h>
 #include "lps22hh.h"
 #include <logging/log.h>
 
-#ifdef DT_ST_LPS22HH_BUS_SPI
+#if DT_ANY_INST_ON_BUS(spi)
 
 #define LPS22HH_SPI_READ		(1 << 7)
 
@@ -105,7 +107,7 @@ int lps22hh_spi_init(struct device *dev)
 	data->ctx = &data->ctx_spi;
 	data->ctx->handle = dev;
 
-#if defined(DT_INST_0_ST_LPS22HH_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const struct lps22hh_config *cfg = dev->config->config_info;
 
 	/* handle SPI CS thru GPIO if it is the case */
@@ -124,4 +126,4 @@ int lps22hh_spi_init(struct device *dev)
 
 	return 0;
 }
-#endif /* DT_ST_LPS22HH_BUS_SPI */
+#endif /* DT_ANY_INST_ON_BUS(spi) */

--- a/drivers/sensor/lps25hb/lps25hb.c
+++ b/drivers/sensor/lps25hb/lps25hb.c
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT st_lps25hb_press
+
 #include <drivers/sensor.h>
 #include <kernel.h>
 #include <device.h>
@@ -179,12 +181,12 @@ static int lps25hb_init(struct device *dev)
 }
 
 static const struct lps25hb_config lps25hb_config = {
-	.i2c_master_dev_name = DT_INST_0_ST_LPS25HB_PRESS_BUS_NAME,
-	.i2c_slave_addr = DT_INST_0_ST_LPS25HB_PRESS_BASE_ADDRESS,
+	.i2c_master_dev_name = DT_INST_BUS_LABEL(0),
+	.i2c_slave_addr = DT_INST_REG_ADDR(0),
 };
 
 static struct lps25hb_data lps25hb_data;
 
-DEVICE_AND_API_INIT(lps25hb, DT_INST_0_ST_LPS25HB_PRESS_LABEL, lps25hb_init,
+DEVICE_AND_API_INIT(lps25hb, DT_INST_LABEL(0), lps25hb_init,
 		    &lps25hb_data, &lps25hb_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lps25hb_api_funcs);

--- a/drivers/sensor/lsm303dlhc_magn/lsm303dlhc_magn.c
+++ b/drivers/sensor/lsm303dlhc_magn/lsm303dlhc_magn.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT st_lsm303dlhc_magn
+
 #include <drivers/i2c.h>
 #include <init.h>
 #include <drivers/sensor.h>
@@ -131,13 +133,13 @@ static int lsm303dlhc_magn_init(struct device *dev)
 }
 
 static const struct lsm303dlhc_magn_config lsm303dlhc_magn_config = {
-	.i2c_name = DT_INST_0_ST_LSM303DLHC_MAGN_BUS_NAME,
-	.i2c_address = DT_INST_0_ST_LSM303DLHC_MAGN_BASE_ADDRESS,
+	.i2c_name = DT_INST_BUS_LABEL(0),
+	.i2c_address = DT_INST_REG_ADDR(0),
 };
 
 static struct lsm303dlhc_magn_data lsm303dlhc_magn_driver;
 
-DEVICE_AND_API_INIT(lsm303dlhc_magn, DT_INST_0_ST_LSM303DLHC_MAGN_LABEL,
+DEVICE_AND_API_INIT(lsm303dlhc_magn, DT_INST_LABEL(0),
 		    lsm303dlhc_magn_init, &lsm303dlhc_magn_driver,
 		    &lsm303dlhc_magn_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lsm303dlhc_magn_driver_api);

--- a/drivers/sensor/lsm6ds0/lsm6ds0.c
+++ b/drivers/sensor/lsm6ds0/lsm6ds0.c
@@ -8,6 +8,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT st_lsm6ds0
+
 #include <drivers/sensor.h>
 #include <kernel.h>
 #include <device.h>
@@ -499,12 +501,12 @@ static int lsm6ds0_init(struct device *dev)
 }
 
 static const struct lsm6ds0_config lsm6ds0_config = {
-	.i2c_master_dev_name = DT_INST_0_ST_LSM6DS0_BUS_NAME,
-	.i2c_slave_addr = DT_INST_0_ST_LSM6DS0_BASE_ADDRESS,
+	.i2c_master_dev_name = DT_INST_BUS_LABEL(0),
+	.i2c_slave_addr = DT_INST_REG_ADDR(0),
 };
 
 static struct lsm6ds0_data lsm6ds0_data;
 
-DEVICE_AND_API_INIT(lsm6ds0, DT_INST_0_ST_LSM6DS0_LABEL, lsm6ds0_init,
+DEVICE_AND_API_INIT(lsm6ds0, DT_INST_LABEL(0), lsm6ds0_init,
 		    &lsm6ds0_data, &lsm6ds0_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lsm6ds0_api_funcs);

--- a/drivers/sensor/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.c
@@ -8,6 +8,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT st_lsm6dsl
+
 #include <drivers/sensor.h>
 #include <kernel.h>
 #include <device.h>
@@ -772,7 +774,7 @@ static int lsm6dsl_init_chip(struct device *dev)
 }
 
 static struct lsm6dsl_config lsm6dsl_config = {
-	.comm_master_dev_name = DT_INST_0_ST_LSM6DSL_BUS_NAME,
+	.comm_master_dev_name = DT_INST_BUS_LABEL(0),
 };
 
 static int lsm6dsl_init(struct device *dev)
@@ -787,7 +789,7 @@ static int lsm6dsl_init(struct device *dev)
 		return -EINVAL;
 	}
 
-#ifdef DT_ST_LSM6DSL_BUS_SPI
+#if DT_ANY_INST_ON_BUS(spi)
 	lsm6dsl_spi_init(dev);
 #else
 	lsm6dsl_i2c_init(dev);
@@ -818,6 +820,6 @@ static int lsm6dsl_init(struct device *dev)
 
 static struct lsm6dsl_data lsm6dsl_data;
 
-DEVICE_AND_API_INIT(lsm6dsl, DT_INST_0_ST_LSM6DSL_LABEL, lsm6dsl_init,
+DEVICE_AND_API_INIT(lsm6dsl, DT_INST_LABEL(0), lsm6dsl_init,
 		    &lsm6dsl_data, &lsm6dsl_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lsm6dsl_api_funcs);

--- a/drivers/sensor/lsm6dsl/lsm6dsl_i2c.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_i2c.c
@@ -7,15 +7,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT st_lsm6dsl
+
 #include <string.h>
 #include <drivers/i2c.h>
 #include <logging/log.h>
 
 #include "lsm6dsl.h"
 
-#ifdef DT_ST_LSM6DSL_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 
-static u16_t lsm6dsl_i2c_slave_addr = DT_INST_0_ST_LSM6DSL_BASE_ADDRESS;
+static u16_t lsm6dsl_i2c_slave_addr = DT_INST_REG_ADDR(0);
 
 LOG_MODULE_DECLARE(LSM6DSL, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -62,4 +64,4 @@ int lsm6dsl_i2c_init(struct device *dev)
 
 	return 0;
 }
-#endif /* DT_ST_LSM6DSL_BUS_I2C */
+#endif /* DT_ANY_INST_ON_BUS(i2c) */

--- a/drivers/sensor/lsm6dsl/lsm6dsl_spi.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_spi.c
@@ -7,28 +7,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT st_lsm6dsl
+
 #include <string.h>
 #include <drivers/spi.h>
 #include "lsm6dsl.h"
 #include <logging/log.h>
 
-#ifdef DT_ST_LSM6DSL_BUS_SPI
+#if DT_ANY_INST_ON_BUS(spi)
 
 #define LSM6DSL_SPI_READ		(1 << 7)
 
 LOG_MODULE_DECLARE(LSM6DSL, CONFIG_SENSOR_LOG_LEVEL);
 
-#if defined(DT_INST_0_ST_LSM6DSL_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 static struct spi_cs_control lsm6dsl_cs_ctrl;
 #endif
 
 #define SPI_CS NULL
 
 static struct spi_config lsm6dsl_spi_conf = {
-	.frequency = DT_INST_0_ST_LSM6DSL_SPI_MAX_FREQUENCY,
+	.frequency = DT_INST_PROP(0, spi_max_frequency),
 	.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
 		      SPI_MODE_CPHA | SPI_WORD_SET(8) | SPI_LINES_SINGLE),
-	.slave     = DT_INST_0_ST_LSM6DSL_BASE_ADDRESS,
+	.slave     = DT_INST_REG_ADDR(0),
 	.cs        = SPI_CS,
 };
 
@@ -146,25 +148,25 @@ int lsm6dsl_spi_init(struct device *dev)
 
 	data->hw_tf = &lsm6dsl_spi_transfer_fn;
 
-#if defined(DT_INST_0_ST_LSM6DSL_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	/* handle SPI CS thru GPIO if it is the case */
 	lsm6dsl_cs_ctrl.gpio_dev = device_get_binding(
-		DT_INST_0_ST_LSM6DSL_CS_GPIOS_CONTROLLER);
+		DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
 	if (!lsm6dsl_cs_ctrl.gpio_dev) {
 		LOG_ERR("Unable to get GPIO SPI CS device");
 		return -ENODEV;
 	}
 
-	lsm6dsl_cs_ctrl.gpio_pin = DT_INST_0_ST_LSM6DSL_CS_GPIOS_PIN;
+	lsm6dsl_cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
 	lsm6dsl_cs_ctrl.delay = 0U;
 
 	lsm6dsl_spi_conf.cs = &lsm6dsl_cs_ctrl;
 
 	LOG_DBG("SPI GPIO CS configured on %s:%u",
-		    DT_INST_0_ST_LSM6DSL_CS_GPIOS_CONTROLLER,
-		    DT_INST_0_ST_LSM6DSL_CS_GPIOS_PIN);
+		    DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
+		    DT_INST_SPI_DEV_CS_GPIOS_PIN(0));
 #endif
 
 	return 0;
 }
-#endif /* DT_ST_LSM6DSL_BUS_SPI */
+#endif /* DT_ANY_INST_ON_BUS(spi) */

--- a/drivers/sensor/lsm6dsl/lsm6dsl_trigger.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_trigger.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT st_lsm6dsl
+
 #include <device.h>
 #include <drivers/i2c.h>
 #include <sys/__assert.h>
@@ -23,7 +25,7 @@ static inline void setup_irq(struct lsm6dsl_data *drv_data,
 		: GPIO_INT_DISABLE;
 
 	gpio_pin_interrupt_configure(drv_data->gpio,
-				     DT_INST_0_ST_LSM6DSL_IRQ_GPIOS_PIN,
+				     DT_INST_GPIO_PIN(0, irq_gpios),
 				     flags);
 }
 
@@ -56,7 +58,7 @@ int lsm6dsl_trigger_set(struct device *dev,
 	drv_data->data_ready_trigger = *trig;
 
 	setup_irq(drv_data, true);
-	if (gpio_pin_get(drv_data->gpio, DT_INST_0_ST_LSM6DSL_IRQ_GPIOS_PIN) > 0) {
+	if (gpio_pin_get(drv_data->gpio, DT_INST_GPIO_PIN(0, irq_gpios)) > 0) {
 		handle_irq(drv_data);
 	}
 
@@ -117,19 +119,19 @@ int lsm6dsl_init_interrupt(struct device *dev)
 	struct lsm6dsl_data *drv_data = dev->driver_data;
 
 	/* setup data ready gpio interrupt */
-	drv_data->gpio = device_get_binding(DT_INST_0_ST_LSM6DSL_IRQ_GPIOS_CONTROLLER);
+	drv_data->gpio = device_get_binding(DT_INST_GPIO_LABEL(0, irq_gpios));
 	if (drv_data->gpio == NULL) {
 		LOG_ERR("Cannot get pointer to %s device.",
-			    DT_INST_0_ST_LSM6DSL_IRQ_GPIOS_CONTROLLER);
+			    DT_INST_GPIO_LABEL(0, irq_gpios));
 		return -EINVAL;
 	}
 
-	gpio_pin_configure(drv_data->gpio, DT_INST_0_ST_LSM6DSL_IRQ_GPIOS_PIN,
-			   GPIO_INPUT | DT_INST_0_ST_LSM6DSL_IRQ_GPIOS_FLAGS);
+	gpio_pin_configure(drv_data->gpio, DT_INST_GPIO_PIN(0, irq_gpios),
+			   GPIO_INPUT | DT_INST_GPIO_FLAGS(0, irq_gpios));
 
 	gpio_init_callback(&drv_data->gpio_cb,
 			   lsm6dsl_gpio_callback,
-			   BIT(DT_INST_0_ST_LSM6DSL_IRQ_GPIOS_PIN));
+			   BIT(DT_INST_GPIO_PIN(0, irq_gpios)));
 
 	if (gpio_add_callback(drv_data->gpio, &drv_data->gpio_cb) < 0) {
 		LOG_ERR("Could not set gpio callback.");

--- a/drivers/sensor/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/lsm6dso/lsm6dso.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/lsm6dso.pdf
  */
 
+#define DT_DRV_COMPAT st_lsm6dso
+
 #include <drivers/sensor.h>
 #include <kernel.h>
 #include <device.h>
@@ -749,32 +751,32 @@ static int lsm6dso_init_chip(struct device *dev)
 static struct lsm6dso_data lsm6dso_data;
 
 static const struct lsm6dso_config lsm6dso_config = {
-	.bus_name = DT_INST_0_ST_LSM6DSO_BUS_NAME,
-#if defined(DT_ST_LSM6DSO_BUS_SPI)
+	.bus_name = DT_INST_BUS_LABEL(0),
+#if DT_ANY_INST_ON_BUS(spi)
 	.bus_init = lsm6dso_spi_init,
-	.spi_conf.frequency = DT_INST_0_ST_LSM6DSO_SPI_MAX_FREQUENCY,
+	.spi_conf.frequency = DT_INST_PROP(0, spi_max_frequency),
 	.spi_conf.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
 			       SPI_MODE_CPHA | SPI_WORD_SET(8) |
 			       SPI_LINES_SINGLE),
-	.spi_conf.slave     = DT_INST_0_ST_LSM6DSO_BASE_ADDRESS,
-#if defined(DT_INST_0_ST_LSM6DSO_CS_GPIOS_CONTROLLER)
-	.gpio_cs_port	    = DT_INST_0_ST_LSM6DSO_CS_GPIOS_CONTROLLER,
-	.cs_gpio	    = DT_INST_0_ST_LSM6DSO_CS_GPIOS_PIN,
+	.spi_conf.slave     = DT_INST_REG_ADDR(0),
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
+	.gpio_cs_port	    = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
+	.cs_gpio	    = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
 
 	.spi_conf.cs        =  &lsm6dso_data.cs_ctrl,
 #else
 	.spi_conf.cs        = NULL,
 #endif
-#elif defined(DT_ST_LSM6DSO_BUS_I2C)
+#elif DT_ANY_INST_ON_BUS(i2c)
 	.bus_init = lsm6dso_i2c_init,
-	.i2c_slv_addr = DT_INST_0_ST_LSM6DSO_BASE_ADDRESS,
+	.i2c_slv_addr = DT_INST_REG_ADDR(0),
 #else
 #error "BUS MACRO NOT DEFINED IN DTS"
 #endif
 #ifdef CONFIG_LSM6DSO_TRIGGER
-	.int_gpio_port = DT_INST_0_ST_LSM6DSO_IRQ_GPIOS_CONTROLLER,
-	.int_gpio_pin = DT_INST_0_ST_LSM6DSO_IRQ_GPIOS_PIN,
-	.int_gpio_flags = DT_INST_0_ST_LSM6DSO_IRQ_GPIOS_FLAGS,
+	.int_gpio_port = DT_INST_GPIO_LABEL(0, irq_gpios),
+	.int_gpio_pin = DT_INST_GPIO_PIN(0, irq_gpios),
+	.int_gpio_flags = DT_INST_GPIO_FLAGS(0, irq_gpios),
 #if defined(CONFIG_LSM6DSO_INT_PIN_1)
 	.int_pin = 1,
 #elif defined(CONFIG_LSM6DSO_INT_PIN_2)
@@ -823,6 +825,6 @@ static int lsm6dso_init(struct device *dev)
 
 static struct lsm6dso_data lsm6dso_data;
 
-DEVICE_AND_API_INIT(lsm6dso, DT_INST_0_ST_LSM6DSO_LABEL, lsm6dso_init,
+DEVICE_AND_API_INIT(lsm6dso, DT_INST_LABEL(0), lsm6dso_init,
 		    &lsm6dso_data, &lsm6dso_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lsm6dso_api_funcs);

--- a/drivers/sensor/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/lsm6dso/lsm6dso.h
@@ -100,15 +100,15 @@ struct lsm6dso_config {
 	u8_t int_gpio_flags;
 	u8_t int_pin;
 #endif /* CONFIG_LSM6DSO_TRIGGER */
-#ifdef DT_ST_LSM6DSO_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 	u16_t i2c_slv_addr;
-#elif DT_ST_LSM6DSO_BUS_SPI
+#elif DT_ANY_INST_ON_BUS(spi)
 	struct spi_config spi_conf;
-#if defined(DT_INST_0_ST_LSM6DSO_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const char *gpio_cs_port;
 	u8_t cs_gpio;
-#endif /* DT_INST_0_ST_LSM6DSO_CS_GPIOS_CONTROLLER */
-#endif /* DT_ST_LSM6DSO_BUS_I2C */
+#endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
+#endif /* DT_ANY_INST_ON_BUS(i2c) */
 };
 
 union samples {
@@ -159,9 +159,9 @@ struct lsm6dso_data {
 
 	stmdev_ctx_t *ctx;
 
-	#ifdef DT_ST_LSM6DSO_BUS_I2C
+	#if DT_ANY_INST_ON_BUS(i2c)
 	stmdev_ctx_t ctx_i2c;
-	#elif DT_ST_LSM6DSO_BUS_SPI
+	#elif DT_ANY_INST_ON_BUS(spi)
 	stmdev_ctx_t ctx_spi;
 	#endif
 
@@ -187,7 +187,7 @@ struct lsm6dso_data {
 #endif
 #endif /* CONFIG_LSM6DSO_TRIGGER */
 
-#if defined(DT_INST_0_ST_LSM6DSO_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	struct spi_cs_control cs_ctrl;
 #endif
 };

--- a/drivers/sensor/lsm6dso/lsm6dso_i2c.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_i2c.c
@@ -8,13 +8,15 @@
  * https://www.st.com/resource/en/datasheet/lsm6dso.pdf
  */
 
+#define DT_DRV_COMPAT st_lsm6dso
+
 #include <string.h>
 #include <drivers/i2c.h>
 #include <logging/log.h>
 
 #include "lsm6dso.h"
 
-#ifdef DT_ST_LSM6DSO_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 
 LOG_MODULE_DECLARE(LSM6DSO, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -50,4 +52,4 @@ int lsm6dso_i2c_init(struct device *dev)
 
 	return 0;
 }
-#endif /* DT_ST_LSM6DSO_BUS_I2C */
+#endif /* DT_ANY_INST_ON_BUS(i2c) */

--- a/drivers/sensor/lsm6dso/lsm6dso_spi.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_spi.c
@@ -8,11 +8,13 @@
  * https://www.st.com/resource/en/datasheet/lsm6dso.pdf
  */
 
+#define DT_DRV_COMPAT st_lsm6dso
+
 #include <string.h>
 #include "lsm6dso.h"
 #include <logging/log.h>
 
-#ifdef DT_ST_LSM6DSO_BUS_SPI
+#if DT_ANY_INST_ON_BUS(spi)
 
 #define LSM6DSO_SPI_READ		(1 << 7)
 
@@ -104,7 +106,7 @@ int lsm6dso_spi_init(struct device *dev)
 	data->ctx = &data->ctx_spi;
 	data->ctx->handle = dev;
 
-#if defined(DT_INST_0_ST_LSM6DSO_CS_GPIOS_CONTROLLER)
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const struct lsm6dso_config *cfg = dev->config->config_info;
 
 	/* handle SPI CS thru GPIO if it is the case */
@@ -123,4 +125,4 @@ int lsm6dso_spi_init(struct device *dev)
 
 	return 0;
 }
-#endif /* DT_ST_LSM6DSO_BUS_SPI */
+#endif /* DT_ANY_INST_ON_BUS(spi) */

--- a/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro.c
+++ b/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro.c
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT st_lsm9ds0_gyro
+
 #include <drivers/sensor.h>
 #include <kernel.h>
 #include <device.h>
@@ -344,18 +346,18 @@ static int lsm9ds0_gyro_init(struct device *dev)
 }
 
 static const struct lsm9ds0_gyro_config lsm9ds0_gyro_config = {
-	.i2c_master_dev_name = DT_INST_0_ST_LSM9DS0_GYRO_BUS_NAME,
-	.i2c_slave_addr = DT_INST_0_ST_LSM9DS0_GYRO_BASE_ADDRESS,
+	.i2c_master_dev_name = DT_INST_BUS_LABEL(0),
+	.i2c_slave_addr = DT_INST_REG_ADDR(0),
 #if defined(CONFIG_LSM9DS0_GYRO_TRIGGER_DRDY)
-	.gpio_drdy_dev_name = DT_INST_0_ST_LSM9DS0_GYRO_IRQ_GPIOS_CONTROLLER,
-	.gpio_drdy_int_pin = DT_INST_0_ST_LSM9DS0_GYRO_IRQ_GPIOS_PIN,
-	.gpio_drdy_int_flags = DT_INST_0_ST_LSM9DS0_GYRO_IRQ_GPIOS_FLAGS,
+	.gpio_drdy_dev_name = DT_INST_GPIO_LABEL(0, irq_gpios),
+	.gpio_drdy_int_pin = DT_INST_GPIO_PIN(0, irq_gpios),
+	.gpio_drdy_int_flags = DT_INST_GPIO_FLAGS(0, irq_gpios),
 #endif
 };
 
 static struct lsm9ds0_gyro_data lsm9ds0_gyro_data;
 
-DEVICE_AND_API_INIT(lsm9ds0_gyro, DT_INST_0_ST_LSM9DS0_GYRO_LABEL,
+DEVICE_AND_API_INIT(lsm9ds0_gyro, DT_INST_LABEL(0),
 		    lsm9ds0_gyro_init, &lsm9ds0_gyro_data, &lsm9ds0_gyro_config,
 		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &lsm9ds0_gyro_api_funcs);

--- a/drivers/sensor/lsm9ds0_mfd/lsm9ds0_mfd.c
+++ b/drivers/sensor/lsm9ds0_mfd/lsm9ds0_mfd.c
@@ -8,6 +8,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT st_lsm9ds0_mfd
+
 #include <drivers/sensor.h>
 #include <kernel.h>
 #include <device.h>
@@ -787,12 +789,12 @@ int lsm9ds0_mfd_init(struct device *dev)
 }
 
 static const struct lsm9ds0_mfd_config lsm9ds0_mfd_config = {
-	.i2c_master_dev_name = DT_INST_0_ST_LSM9DS0_MFD_BUS_NAME,
-	.i2c_slave_addr = DT_INST_0_ST_LSM9DS0_MFD_BASE_ADDRESS,
+	.i2c_master_dev_name = DT_INST_BUS_LABEL(0),
+	.i2c_slave_addr = DT_INST_REG_ADDR(0),
 };
 
 static struct lsm9ds0_mfd_data lsm9ds0_mfd_data;
 
-DEVICE_AND_API_INIT(lsm9ds0_mfd, DT_INST_0_ST_LSM9DS0_MFD_LABEL, lsm9ds0_mfd_init,
+DEVICE_AND_API_INIT(lsm9ds0_mfd, DT_INST_LABEL(0), lsm9ds0_mfd_init,
 		    &lsm9ds0_mfd_data, &lsm9ds0_mfd_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lsm9ds0_mfd_api_funcs);

--- a/drivers/sensor/stts751/stts751.c
+++ b/drivers/sensor/stts751/stts751.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/stts751.pdf
  */
 
+#define DT_DRV_COMPAT st_stts751
+
 #include <drivers/sensor.h>
 #include <kernel.h>
 #include <device.h>
@@ -196,20 +198,20 @@ static int stts751_init(struct device *dev)
 static struct stts751_data stts751_data;
 
 static const struct stts751_config stts751_config = {
-	.master_dev_name = DT_INST_0_ST_STTS751_BUS_NAME,
+	.master_dev_name = DT_INST_BUS_LABEL(0),
 #ifdef CONFIG_STTS751_TRIGGER
-	.event_port	= DT_INST_0_ST_STTS751_DRDY_GPIOS_CONTROLLER,
-	.event_pin	= DT_INST_0_ST_STTS751_DRDY_GPIOS_PIN,
-	.int_flags	= DT_INST_0_ST_STTS751_DRDY_GPIOS_FLAGS,
+	.event_port	= DT_INST_GPIO_LABEL(0, drdy_gpios),
+	.event_pin	= DT_INST_GPIO_PIN(0, drdy_gpios),
+	.int_flags	= DT_INST_GPIO_FLAGS(0, drdy_gpios),
 #endif
-#if defined(DT_ST_STTS751_BUS_I2C)
+#if DT_ANY_INST_ON_BUS(i2c)
 	.bus_init = stts751_i2c_init,
-	.i2c_slv_addr = DT_INST_0_ST_STTS751_BASE_ADDRESS,
+	.i2c_slv_addr = DT_INST_REG_ADDR(0),
 #else
 #error "BUS MACRO NOT DEFINED IN DTS"
 #endif
 };
 
-DEVICE_AND_API_INIT(stts751, DT_INST_0_ST_STTS751_LABEL, stts751_init,
+DEVICE_AND_API_INIT(stts751, DT_INST_LABEL(0), stts751_init,
 		    &stts751_data, &stts751_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &stts751_api_funcs);

--- a/drivers/sensor/stts751/stts751.h
+++ b/drivers/sensor/stts751/stts751.h
@@ -32,7 +32,7 @@ struct stts751_config {
 	u8_t event_pin;
 	u8_t int_flags;
 #endif
-#ifdef DT_ST_STTS751_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 	u16_t i2c_slv_addr;
 #endif
 };
@@ -43,7 +43,7 @@ struct stts751_data {
 
 	stmdev_ctx_t *ctx;
 
-#ifdef DT_ST_STTS751_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 	stmdev_ctx_t ctx_i2c;
 #endif
 

--- a/drivers/sensor/stts751/stts751_i2c.c
+++ b/drivers/sensor/stts751/stts751_i2c.c
@@ -8,13 +8,15 @@
  * https://www.st.com/resource/en/datasheet/stts751.pdf
  */
 
+#define DT_DRV_COMPAT st_stts751
+
 #include <string.h>
 #include <drivers/i2c.h>
 #include <logging/log.h>
 
 #include "stts751.h"
 
-#ifdef DT_ST_STTS751_BUS_I2C
+#if DT_ANY_INST_ON_BUS(i2c)
 
 LOG_MODULE_DECLARE(STTS751, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -50,4 +52,4 @@ int stts751_i2c_init(struct device *dev)
 
 	return 0;
 }
-#endif /* DT_ST_STTS751_BUS_I2C */
+#endif /* DT_ANY_INST_ON_BUS(i2c) */


### PR DESCRIPTION
Convert older DT_INST_ macro use the new include/devicetree.h
DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>