### PR TITLE
disk: Convert to new DT_INST macros

### DIFF
--- a/subsys/disk/disk_access_spi_sdhc.c
+++ b/subsys/disk/disk_access_spi_sdhc.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(sdhc_spi, CONFIG_DISK_LOG_LEVEL);
 /* Clock speed used after initialisation */
 #define SDHC_SPI_SPEED 4000000
 
-#ifndef DT_INST_0_ZEPHYR_MMC_SPI_SLOT_LABEL
+#if !DT_NODE_HAS_PROP(DT_INST(0, zephyr_mmc_spi_slot), label)
 #warning NO SDHC slot specified on board
 #else
 struct sdhc_spi_data {
@@ -766,17 +766,17 @@ static int sdhc_spi_init(struct device *dev)
 {
 	struct sdhc_spi_data *data = dev->driver_data;
 
-	data->spi = device_get_binding(DT_INST_0_ZEPHYR_MMC_SPI_SLOT_BUS_NAME);
+	data->spi = device_get_binding(DT_BUS_LABEL(DT_INST(0, zephyr_mmc_spi_slot)));
 
 	data->cfg.frequency = SDHC_SPI_INITIAL_SPEED;
 	data->cfg.operation = SPI_WORD_SET(8) | SPI_HOLD_ON_CS;
-	data->cfg.slave = DT_INST_0_ZEPHYR_MMC_SPI_SLOT_BASE_ADDRESS;
+	data->cfg.slave = DT_REG_ADDR(DT_INST(0, zephyr_mmc_spi_slot));
 	data->cs = device_get_binding(
-		DT_INST_0_ZEPHYR_MMC_SPI_SLOT_CS_GPIOS_CONTROLLER);
+		DT_SPI_DEV_CS_GPIOS_LABEL(DT_INST(0, zephyr_mmc_spi_slot)));
 	__ASSERT_NO_MSG(data->cs != NULL);
 
-	data->pin = DT_INST_0_ZEPHYR_MMC_SPI_SLOT_CS_GPIOS_PIN;
-	data->flags = DT_INST_0_ZEPHYR_MMC_SPI_SLOT_CS_GPIOS_FLAGS;
+	data->pin = DT_SPI_DEV_CS_GPIOS_PIN(DT_INST(0, zephyr_mmc_spi_slot));
+	data->flags = DT_SPI_DEV_CS_GPIOS_FLAGS(DT_INST(0, zephyr_mmc_spi_slot));
 
 	disk_spi_sdhc_init(dev);
 
@@ -898,7 +898,7 @@ static int disk_spi_sdhc_init(struct device *dev)
 static struct sdhc_spi_data sdhc_spi_data_0;
 
 DEVICE_AND_API_INIT(sdhc_spi_0,
-	DT_INST_0_ZEPHYR_MMC_SPI_SLOT_LABEL,
+	DT_LABEL(DT_INST(0, zephyr_mmc_spi_slot)),
 	sdhc_spi_init, &sdhc_spi_data_0, NULL,
 	APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
 #endif

--- a/subsys/disk/disk_access_usdhc.c
+++ b/subsys/disk/disk_access_usdhc.c
@@ -2593,57 +2593,57 @@ static int usdhc_board_access_init(struct usdhc_priv *priv)
 	u32_t gpio_level;
 
 	if (priv->nusdhc == 0) {
-#ifdef DT_INST_0_NXP_IMX_USDHC_PWR_GPIOS_CONTROLLER
+#if DT_NODE_HAS_PROP(DT_INST(0, nxp_imx_usdhc), pwr_gpios)
 		priv->board_cfg.pwr_gpio =
 			device_get_binding(
-				DT_INST_0_NXP_IMX_USDHC_PWR_GPIOS_CONTROLLER);
+				DT_GPIO_LABEL(DT_INST(0, nxp_imx_usdhc), pwr_gpios));
 		if (!priv->board_cfg.pwr_gpio) {
 			return -ENODEV;
 		}
 		priv->board_cfg.pwr_pin =
-			DT_INST_0_NXP_IMX_USDHC_PWR_GPIOS_PIN;
+			DT_GPIO_PIN(DT_INST(0, nxp_imx_usdhc), pwr_gpios);
 		priv->board_cfg.pwr_flags =
-			DT_INST_0_NXP_IMX_USDHC_PWR_GPIOS_FLAGS;
+			DT_GPIO_FLAGS(DT_INST(0, nxp_imx_usdhc), pwr_gpios);
 #endif
-#ifdef DT_INST_0_NXP_IMX_USDHC_CD_GPIOS_CONTROLLER
+#if DT_NODE_HAS_PROP(DT_INST(0, nxp_imx_usdhc), cd_gpios)
 		priv->detect_type = SD_DETECT_GPIO_CD;
 		priv->board_cfg.detect_gpio =
 			device_get_binding(
-				DT_INST_0_NXP_IMX_USDHC_CD_GPIOS_CONTROLLER);
+				DT_GPIO_LABEL(DT_INST(0, nxp_imx_usdhc), cd_gpios));
 		if (!priv->board_cfg.detect_gpio) {
 			return -ENODEV;
 		}
 		priv->board_cfg.detect_pin =
-			DT_INST_0_NXP_IMX_USDHC_CD_GPIOS_PIN;
+			DT_GPIO_PIN(DT_INST(0, nxp_imx_usdhc), cd_gpios);
 		priv->board_cfg.detect_flags =
-			DT_INST_0_NXP_IMX_USDHC_CD_GPIOS_FLAGS;
+			DT_GPIO_FLAGS(DT_INST(0, nxp_imx_usdhc), cd_gpios);
 #endif
 
 	} else if (priv->nusdhc == 1) {
-#ifdef DT_INST_1_NXP_IMX_USDHC_PWR_GPIOS_CONTROLLER
+#if DT_NODE_HAS_PROP(DT_INST(1, nxp_imx_usdhc), pwr_gpios)
 		priv->board_cfg.pwr_gpio =
 			device_get_binding(
-				DT_INST_1_NXP_IMX_USDHC_PWR_GPIOS_CONTROLLER);
+				DT_GPIO_LABEL(DT_INST(1, nxp_imx_usdhc), pwr_gpios));
 		if (!priv->board_cfg.pwr_gpio) {
 			return -ENODEV;
 		}
 		priv->board_cfg.pwr_pin =
-			DT_INST_1_NXP_IMX_USDHC_PWR_GPIOS_PIN;
+			DT_GPIO_PIN(DT_INST(1, nxp_imx_usdhc), pwr_gpios);
 		priv->board_cfg.pwr_flags =
-			DT_INST_1_NXP_IMX_USDHC_PWR_GPIOS_FLAGS;
+			DT_GPIO_FLAGS(DT_INST(1, nxp_imx_usdhc), pwr_gpios);
 #endif
-#ifdef DT_INST_1_NXP_IMX_USDHC_CD_GPIOS_CONTROLLER
+#if DT_NODE_HAS_PROP(DT_INST(1, nxp_imx_usdhc), cd_gpios)
 		priv->detect_type = SD_DETECT_GPIO_CD;
 		priv->board_cfg.detect_gpio =
 			device_get_binding(
-				DT_INST_1_NXP_IMX_USDHC_CD_GPIOS_CONTROLLER);
+				DT_GPIO_LABEL(DT_INST(1, nxp_imx_usdhc), cd_gpios));
 		if (!priv->board_cfg.detect_gpio) {
 			return -ENODEV;
 		}
 		priv->board_cfg.detect_pin =
-			DT_INST_1_NXP_IMX_USDHC_CD_GPIOS_PIN;
+			DT_GPIO_PIN(DT_INST(1, nxp_imx_usdhc), cd_gpios);
 		priv->board_cfg.detect_flags =
-			DT_INST_1_NXP_IMX_USDHC_CD_GPIOS_FLAGS;
+			DT_GPIO_FLAGS(DT_INST(1, nxp_imx_usdhc), cd_gpios);
 #endif
 	} else {
 		return -ENODEV;
@@ -2705,35 +2705,35 @@ static int usdhc_access_init(const struct device *dev)
 	(void)k_mutex_lock(&z_usdhc_init_lock, K_FOREVER);
 
 	memset((char *)priv, 0, sizeof(struct usdhc_priv));
-#ifdef DT_INST_0_NXP_IMX_USDHC_LABEL
-	if (!strcmp(dev->config->name, DT_INST_0_NXP_IMX_USDHC_LABEL)) {
+#if DT_NODE_HAS_PROP(DT_INST(0, nxp_imx_usdhc), label)
+	if (!strcmp(dev->config->name, DT_LABEL(DT_INST(0, nxp_imx_usdhc)))) {
 		priv->host_config.base =
-			(USDHC_Type *)DT_INST_0_NXP_IMX_USDHC_BASE_ADDRESS;
+			(USDHC_Type *)DT_REG_ADDR(DT_INST(0, nxp_imx_usdhc));
 		priv->nusdhc = 0;
 		priv->clock_dev = device_get_binding(
-			DT_INST_0_NXP_IMX_USDHC_CLOCK_CONTROLLER);
+			DT_CLOCKS_LABEL(DT_INST(0, nxp_imx_usdhc)));
 		if (priv->clock_dev == NULL) {
 			return -EINVAL;
 		}
 		priv->clock_sys =
 			(clock_control_subsys_t)
-			DT_INST_0_NXP_IMX_USDHC_CLOCK_NAME;
+			DT_CLOCKS_CELL(DT_INST(0, nxp_imx_usdhc), name);
 	}
 #endif
 
-#ifdef DT_INST_1_NXP_IMX_USDHC_LABEL
-	if (!strcmp(dev->config->name, DT_INST_1_NXP_IMX_USDHC_LABEL)) {
+#if DT_NODE_HAS_PROP(DT_INST(1, nxp_imx_usdhc), label)
+	if (!strcmp(dev->config->name, DT_LABEL(DT_INST(1, nxp_imx_usdhc)))) {
 		priv->host_config.base =
-			(USDHC_Type *)DT_INST_1_NXP_IMX_USDHC_BASE_ADDRESS;
+			(USDHC_Type *)DT_REG_ADDR(DT_INST(1, nxp_imx_usdhc));
 		priv->nusdhc = 1;
 		priv->clock_dev = device_get_binding(
-			DT_INST_1_NXP_IMX_USDHC_CLOCK_CONTROLLER);
+			DT_CLOCKS_LABEL(DT_INST(1, nxp_imx_usdhc)));
 		if (priv->clock_dev == NULL) {
 			return -EINVAL;
 		}
 		priv->clock_sys =
 			(clock_control_subsys_t)
-			DT_INST_1_NXP_IMX_USDHC_CLOCK_NAME;
+			DT_CLOCKS_CELL(DT_INST(1, nxp_imx_usdhc), name);
 	}
 #endif
 
@@ -2876,9 +2876,9 @@ static int disk_usdhc_init(struct device *dev)
 
 #ifdef CONFIG_DISK_ACCESS_USDHC1
 static struct usdhc_priv usdhc_priv_1;
-#ifdef DT_INST_0_NXP_IMX_USDHC_LABEL
+#if DT_NODE_HAS_PROP(DT_INST(0, nxp_imx_usdhc), label)
 DEVICE_AND_API_INIT(usdhc_dev1,
-		DT_INST_0_NXP_IMX_USDHC_LABEL, disk_usdhc_init,
+		DT_LABEL(DT_INST(0, nxp_imx_usdhc)), disk_usdhc_init,
 		&usdhc_priv_1, NULL, APPLICATION,
 		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		NULL);
@@ -2889,9 +2889,9 @@ DEVICE_AND_API_INIT(usdhc_dev1,
 
 #ifdef CONFIG_DISK_ACCESS_USDHC2
 static struct usdhc_priv usdhc_priv_2;
-#ifdef DT_INST_1_NXP_IMX_USDHC_LABEL
+#if DT_NODE_HAS_PROP(DT_INST(1, nxp_imx_usdhc), label)
 DEVICE_AND_API_INIT(usdhc_dev2,
-		DT_INST_1_NXP_IMX_USDHC_LABEL, disk_usdhc_init,
+		DT_LABEL(DT_INST(1, nxp_imx_usdhc)), disk_usdhc_init,
 		usdhc_priv_2, NULL, APPLICATION,
 		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		NULL);


### PR DESCRIPTION
Convert older DT_INST_ macro use the new include/devicetree.h
DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>