### PR TITLE
drivers: led_strip: ws2812_gpio: Fixup one missed DT_INST conversion

### DIFF
--- a/drivers/led_strip/ws2812_gpio.c
+++ b/drivers/led_strip/ws2812_gpio.c
@@ -198,7 +198,7 @@ static const struct led_strip_driver_api ws2812_gpio_api = {
  *
  * TODO: try to make this portable, or at least port to more devices.
  */
-#define WS2812_GPIO_CLK(idx) DT_INST_0_NORDIC_NRF_CLOCK_LABEL
+#define WS2812_GPIO_CLK(idx) DT_LABEL(DT_INST(0, nordic_nrf_clock))
 
 #define WS2812_GPIO_DEVICE(idx)					\
 									\


### PR DESCRIPTION
Fixed one case in which the conversion to the new DT_INST macro's got
missed in the ws2812_gpio driver.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>