### PR TITLE
Guard references to sleep states on CC13x2/CC26x2

### DIFF
--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -206,7 +206,8 @@ static int i2c_cc13xx_cc26xx_transfer(struct device *dev, struct i2c_msg *msgs,
 
 	k_sem_take(&get_dev_data(dev)->lock, K_FOREVER);
 
-#ifdef CONFIG_SYS_POWER_MANAGEMENT
+#if defined(CONFIG_SYS_POWER_MANAGEMENT) && \
+	defined(CONFIG_SYS_POWER_SLEEP_STATES)
 	sys_pm_ctrl_disable_state(SYS_POWER_STATE_SLEEP_2);
 #endif
 
@@ -230,7 +231,8 @@ static int i2c_cc13xx_cc26xx_transfer(struct device *dev, struct i2c_msg *msgs,
 		}
 	}
 
-#ifdef CONFIG_SYS_POWER_MANAGEMENT
+#if defined(CONFIG_SYS_POWER_MANAGEMENT) && \
+	defined(CONFIG_SYS_POWER_SLEEP_STATES)
 	sys_pm_ctrl_enable_state(SYS_POWER_STATE_SLEEP_2);
 #endif
 

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -228,7 +228,8 @@ static int uart_cc13xx_cc26xx_fifo_read(struct device *dev, u8_t *buf,
 
 static void uart_cc13xx_cc26xx_irq_tx_enable(struct device *dev)
 {
-#ifdef CONFIG_SYS_POWER_MANAGEMENT
+#if defined(CONFIG_SYS_POWER_MANAGEMENT) && \
+	defined(CONFIG_SYS_POWER_SLEEP_STATES)
 	if (!get_dev_data(dev)->tx_constrained) {
 		/*
 		 * When tx irq is enabled, it is implicit that we are expecting
@@ -252,7 +253,8 @@ static void uart_cc13xx_cc26xx_irq_tx_disable(struct device *dev)
 {
 	UARTIntDisable(get_dev_conf(dev)->regs, UART_INT_TX);
 
-#ifdef CONFIG_SYS_POWER_MANAGEMENT
+#if defined(CONFIG_SYS_POWER_MANAGEMENT) && \
+	defined(CONFIG_SYS_POWER_SLEEP_STATES)
 	if (get_dev_data(dev)->tx_constrained) {
 		sys_pm_ctrl_enable_state(SYS_POWER_STATE_SLEEP_2);
 		get_dev_data(dev)->tx_constrained = false;
@@ -267,7 +269,8 @@ static int uart_cc13xx_cc26xx_irq_tx_ready(struct device *dev)
 
 static void uart_cc13xx_cc26xx_irq_rx_enable(struct device *dev)
 {
-#ifdef CONFIG_SYS_POWER_MANAGEMENT
+#if defined(CONFIG_SYS_POWER_MANAGEMENT) && \
+	defined(CONFIG_SYS_POWER_SLEEP_STATES)
 	/*
 	 * When rx is enabled, it is implicit that we are expecting
 	 * to receive from the uart, hence we can no longer go into
@@ -284,7 +287,8 @@ static void uart_cc13xx_cc26xx_irq_rx_enable(struct device *dev)
 
 static void uart_cc13xx_cc26xx_irq_rx_disable(struct device *dev)
 {
-#ifdef CONFIG_SYS_POWER_MANAGEMENT
+#if defined(CONFIG_SYS_POWER_MANAGEMENT) && \
+	defined(CONFIG_SYS_POWER_SLEEP_STATES)
 	if (get_dev_data(dev)->rx_constrained) {
 		sys_pm_ctrl_enable_state(SYS_POWER_STATE_SLEEP_2);
 		get_dev_data(dev)->rx_constrained = false;

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -146,7 +146,8 @@ static int spi_cc13xx_cc26xx_transceive(struct device *dev,
 
 	spi_context_lock(ctx, false, NULL);
 
-#ifdef CONFIG_SYS_POWER_MANAGEMENT
+#if defined(CONFIG_SYS_POWER_MANAGEMENT) && \
+	defined(CONFIG_SYS_POWER_SLEEP_STATES)
 	sys_pm_ctrl_disable_state(SYS_POWER_STATE_SLEEP_2);
 #endif
 
@@ -182,7 +183,8 @@ static int spi_cc13xx_cc26xx_transceive(struct device *dev,
 	spi_context_cs_control(ctx, false);
 
 done:
-#ifdef CONFIG_SYS_POWER_MANAGEMENT
+#if defined(CONFIG_SYS_POWER_MANAGEMENT) && \
+	defined(CONFIG_SYS_POWER_SLEEP_STATES)
 	sys_pm_ctrl_enable_state(SYS_POWER_STATE_SLEEP_2);
 #endif
 	spi_context_release(ctx, err);

--- a/subsys/power/policy/policy_residency_cc13x2_cc26x2.c
+++ b/subsys/power/policy/policy_residency_cc13x2_cc26x2.c
@@ -143,5 +143,9 @@ enum power_states sys_pm_policy_next_state(s32_t ticks)
 
 __weak bool sys_pm_policy_low_power_devices(enum power_states pm_state)
 {
+#ifdef CONFIG_SYS_POWER_SLEEP_STATES
 	return (pm_state == SYS_POWER_STATE_SLEEP_2);
+#else
+	return false;
+#endif
 }

--- a/subsys/power/policy/policy_residency_cc13x2_cc26x2.c
+++ b/subsys/power/policy/policy_residency_cc13x2_cc26x2.c
@@ -32,14 +32,8 @@ extern PowerCC26X2_ModuleState PowerCC26X2_module;
 /* PM Policy based on SoC/Platform residency requirements */
 static const unsigned int pm_min_residency[] = {
 #ifdef CONFIG_SYS_POWER_SLEEP_STATES
-#ifdef CONFIG_HAS_SYS_POWER_STATE_SLEEP_1
 	CONFIG_SYS_PM_MIN_RESIDENCY_SLEEP_1 * SECS_TO_TICKS / MSEC_PER_SEC,
-#endif
-
-#ifdef CONFIG_HAS_SYS_POWER_STATE_SLEEP_2
 	CONFIG_SYS_PM_MIN_RESIDENCY_SLEEP_2 * SECS_TO_TICKS / MSEC_PER_SEC,
-#endif
-
 #endif /* CONFIG_SYS_POWER_SLEEP_STATES */
 };
 


### PR DESCRIPTION
Use of macros such as `SYS_POWER_STATE_SLEEP_2` needs to be guarded by
making sure `CONFIG_SYS_POWER_SLEEP_STATES` is defined. This is causing Shippable to fail on some tests that set `CONFIG_SYS_POWER_MANAGEMENT=y` and `CONFIG_SYS_POWER_SLEEP_STATES=n`.

Full error log: https://app.shippable.com/github/zephyrproject-rtos/zephyr/runs/67344/4/console