### PR TITLE
samples: sensor: Convert to new DT_INST macros

### DIFF
--- a/samples/sensor/adt7420/src/main.c
+++ b/samples/sensor/adt7420/src/main.c
@@ -169,7 +169,7 @@ static void process(struct device *dev)
 
 void main(void)
 {
-	struct device *dev = device_get_binding(DT_INST_0_ADI_ADT7420_LABEL);
+	struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, adi_adt7420)));
 
 	if (dev == NULL) {
 		printf("Failed to get device binding\n");

--- a/samples/sensor/adxl362/src/main.c
+++ b/samples/sensor/adxl362/src/main.c
@@ -33,7 +33,7 @@ void main(void)
 {
 	struct sensor_value accel[3];
 
-	struct device *dev = device_get_binding(DT_INST_0_ADI_ADXL362_LABEL);
+	struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, adi_adxl362)));
 	if (dev == NULL) {
 		printf("Device get binding device\n");
 		return;

--- a/samples/sensor/adxl372/src/main.c
+++ b/samples/sensor/adxl372/src/main.c
@@ -47,10 +47,10 @@ void main(void)
 	int i;
 	char meter[200];
 
-	struct device *dev = device_get_binding(DT_INST_0_ADI_ADXL372_LABEL);
+	struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, adi_adxl372)));
 
 	if (dev == NULL) {
-		printf("Could not get %s device\n", DT_INST_0_ADI_ADXL372_LABEL);
+		printf("Could not get %s device\n", DT_LABEL(DT_INST(0, adi_adxl372)));
 		return;
 	}
 

--- a/samples/sensor/amg88xx/src/main.c
+++ b/samples/sensor/amg88xx/src/main.c
@@ -51,7 +51,7 @@ void main(void)
 {
 	int ret;
 	struct device *dev = device_get_binding(
-				DT_INST_0_PANASONIC_AMG88XX_LABEL);
+				DT_LABEL(DT_INST(0, panasonic_amg88xx)));
 
 	if (dev == NULL) {
 		printk("Could not get AMG88XX device\n");

--- a/samples/sensor/ams_iAQcore/src/main.c
+++ b/samples/sensor/ams_iAQcore/src/main.c
@@ -14,7 +14,7 @@ void main(void)
 	struct device *dev;
 	struct sensor_value co2, voc;
 
-	dev = device_get_binding(DT_INST_0_AMS_IAQCORE_LABEL);
+	dev = device_get_binding(DT_LABEL(DT_INST(0, ams_iaqcore)));
 	if (!dev) {
 		printk("Failed to get device binding");
 		return;

--- a/samples/sensor/apds9960/src/main.c
+++ b/samples/sensor/apds9960/src/main.c
@@ -29,7 +29,7 @@ void main(void)
 	struct sensor_value intensity, pdata;
 
 	printk("APDS9960 sample application\n");
-	dev = device_get_binding(DT_INST_0_AVAGO_APDS9960_LABEL);
+	dev = device_get_binding(DT_LABEL(DT_INST(0, avago_apds9960)));
 	if (!dev) {
 		printk("sensor: device not found.\n");
 		return;

--- a/samples/sensor/bme680/src/main.c
+++ b/samples/sensor/bme680/src/main.c
@@ -11,7 +11,7 @@
 
 void main(void)
 {
-	struct device *dev = device_get_binding(DT_INST_0_BOSCH_BME680_LABEL);
+	struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, bosch_bme680)));
 	struct sensor_value temp, press, humidity, gas_res;
 
 	printf("Device %p name is %s\n", dev, dev->config->name);

--- a/samples/sensor/ccs811/src/main.c
+++ b/samples/sensor/ccs811/src/main.c
@@ -112,7 +112,7 @@ static void do_main(struct device *dev)
 
 void main(void)
 {
-	struct device *dev = device_get_binding(DT_INST_0_AMS_CCS811_LABEL);
+	struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, ams_ccs811)));
 	struct ccs811_configver_type cfgver;
 	int rc;
 

--- a/samples/sensor/dht/src/main.c
+++ b/samples/sensor/dht/src/main.c
@@ -32,7 +32,7 @@ static const char *now_str(void)
 
 void main(void)
 {
-	const char *const label = DT_INST_0_AOSONG_DHT_LABEL;
+	const char *const label = DT_LABEL(DT_INST(0, aosong_dht));
 	struct device *dht22 = device_get_binding(label);
 
 	if (!dht22) {

--- a/samples/sensor/ens210/src/main.c
+++ b/samples/sensor/ens210/src/main.c
@@ -14,7 +14,7 @@ void main(void)
 	struct device *dev;
 	struct sensor_value temperature, humidity;
 
-	dev = device_get_binding(DT_INST_0_AMS_ENS210_LABEL);
+	dev = device_get_binding(DT_LABEL(DT_INST(0, ams_ens210)));
 	if (!dev) {
 		printk("Failed to get device binding");
 		return;

--- a/samples/sensor/fxas21002/src/main.c
+++ b/samples/sensor/fxas21002/src/main.c
@@ -18,7 +18,7 @@ static void trigger_handler(struct device *dev, struct sensor_trigger *trigger)
 void main(void)
 {
 	struct sensor_value gyro[3];
-	struct device *dev = device_get_binding(DT_INST_0_NXP_FXAS21002_LABEL);
+	struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, nxp_fxas21002)));
 
 	if (dev == NULL) {
 		printf("Could not get fxas21002 device\n");

--- a/samples/sensor/fxos8700-hid/src/main.c
+++ b/samples/sensor/fxos8700-hid/src/main.c
@@ -55,7 +55,7 @@ LOG_MODULE_REGISTER(main);
 
 #ifdef CONFIG_FXOS8700
 #include <drivers/sensor.h>
-#define SENSOR_ACCEL_NAME DT_INST_0_NXP_FXOS8700_LABEL
+#define SENSOR_ACCEL_NAME DT_LABEL(DT_INST(0, nxp_fxos8700))
 #endif
 
 static const u8_t hid_report_desc[] = HID_MOUSE_REPORT_DESC(2);

--- a/samples/sensor/fxos8700/src/main.c
+++ b/samples/sensor/fxos8700/src/main.c
@@ -31,7 +31,7 @@ static void trigger_handler(struct device *dev, struct sensor_trigger *trigger)
 void main(void)
 {
 	struct sensor_value accel[3];
-	struct device *dev = device_get_binding(DT_INST_0_NXP_FXOS8700_LABEL);
+	struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, nxp_fxos8700)));
 
 	if (dev == NULL) {
 		printf("Could not get fxos8700 device\n");

--- a/samples/sensor/grove_light/src/main.c
+++ b/samples/sensor/grove_light/src/main.c
@@ -13,7 +13,7 @@
 
 void main(void)
 {
-	struct device *dev = device_get_binding(DT_INST_0_GROVE_LIGHT_LABEL);
+	struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, grove_light)));
 
 	if (dev == NULL) {
 		printf("device not found.  aborting test.\n");

--- a/samples/sensor/grove_temperature/src/main.c
+++ b/samples/sensor/grove_temperature/src/main.c
@@ -19,7 +19,7 @@
 
 void main(void)
 {
-	struct device *dev = device_get_binding(DT_INST_0_GROVE_TEMPERATURE_LABEL);
+	struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, grove_temperature)));
 	struct sensor_value temp;
 	int read;
 

--- a/samples/sensor/hmc5883l/src/main.c
+++ b/samples/sensor/hmc5883l/src/main.c
@@ -40,12 +40,12 @@ void main(void)
 {
 	struct device *dev;
 
-	dev = device_get_binding(DT_INST_0_HONEYWELL_HMC5883L_LABEL);
+	dev = device_get_binding(DT_LABEL(DT_INST(0, honeywell_hmc5883l)));
 
 	if (dev == NULL) {
 		printk("Could not get %s device at I2C addr 0x%02X\n",
-		       DT_INST_0_HONEYWELL_HMC5883L_LABEL,
-		       DT_INST_0_HONEYWELL_HMC5883L_BASE_ADDRESS);
+		       DT_LABEL(DT_INST(0, honeywell_hmc5883l)),
+		       DT_REG_ADDR(DT_INST(0, honeywell_hmc5883l)));
 		return;
 	}
 

--- a/samples/sensor/lis2dh/src/main.c
+++ b/samples/sensor/lis2dh/src/main.c
@@ -50,11 +50,11 @@ static void trigger_handler(struct device *dev,
 
 void main(void)
 {
-	struct device *sensor = device_get_binding(DT_INST_0_ST_LIS2DH_LABEL);
+	struct device *sensor = device_get_binding(DT_LABEL(DT_INST(0, st_lis2dh)));
 
 	if (sensor == NULL) {
 		printf("Could not get %s device\n",
-		       DT_INST_0_ST_LIS2DH_LABEL);
+		       DT_LABEL(DT_INST(0, st_lis2dh)));
 		return;
 	}
 

--- a/samples/sensor/lps22hb/src/main.c
+++ b/samples/sensor/lps22hb/src/main.c
@@ -43,7 +43,7 @@ static void process_sample(struct device *dev)
 
 void main(void)
 {
-	struct device *dev = device_get_binding(DT_INST_0_ST_LPS22HB_PRESS_LABEL);
+	struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, st_lps22hb_press)));
 
 	if (dev == NULL) {
 		printf("Could not get LPS22HB device\n");

--- a/samples/sensor/lsm303dlhc/src/main.c
+++ b/samples/sensor/lsm303dlhc/src/main.c
@@ -38,19 +38,19 @@ end:
 void main(void)
 {
 	struct device *accelerometer = device_get_binding(
-						DT_INST_0_ST_LIS2DH_LABEL);
+						DT_LABEL(DT_INST(0, st_lis2dh)));
 	struct device *magnetometer = device_get_binding(
-						DT_INST_0_ST_LSM303DLHC_MAGN_LABEL);
+						DT_LABEL(DT_INST(0, st_lsm303dlhc_magn)));
 
 	if (accelerometer == NULL) {
 		printf("Could not get %s device\n",
-				DT_INST_0_ST_LIS2DH_LABEL);
+				DT_LABEL(DT_INST(0, st_lis2dh)));
 		return;
 	}
 
 	if (magnetometer == NULL) {
 		printf("Could not get %s device\n",
-				DT_INST_0_ST_LSM303DLHC_MAGN_LABEL);
+				DT_LABEL(DT_INST(0, st_lsm303dlhc_magn)));
 		return;
 	}
 

--- a/samples/sensor/lsm6dsl/src/main.c
+++ b/samples/sensor/lsm6dsl/src/main.c
@@ -100,7 +100,7 @@ void main(void)
 	int cnt = 0;
 	char out_str[64];
 	struct sensor_value odr_attr;
-	struct device *lsm6dsl_dev = device_get_binding(DT_INST_0_ST_LSM6DSL_LABEL);
+	struct device *lsm6dsl_dev = device_get_binding(DT_LABEL(DT_INST(0, st_lsm6dsl)));
 
 	if (lsm6dsl_dev == NULL) {
 		printk("Could not get LSM6DSL device\n");

--- a/samples/sensor/max30101/src/main.c
+++ b/samples/sensor/max30101/src/main.c
@@ -11,7 +11,7 @@
 void main(void)
 {
 	struct sensor_value green;
-	struct device *dev = device_get_binding(DT_INST_0_MAX_MAX30101_LABEL);
+	struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, max_max30101)));
 
 	if (dev == NULL) {
 		printf("Could not get max30101 device\n");

--- a/samples/sensor/mcp9808/src/main.c
+++ b/samples/sensor/mcp9808/src/main.c
@@ -96,7 +96,7 @@ static void trigger_handler(struct device *dev, struct sensor_trigger *trig)
 
 void main(void)
 {
-	const char *const devname = DT_INST_0_MICROCHIP_MCP9808_LABEL;
+	const char *const devname = DT_LABEL(DT_INST(0, microchip_mcp9808));
 	struct device *dev = device_get_binding(devname);
 	int rc;
 

--- a/samples/sensor/mpu6050/src/main.c
+++ b/samples/sensor/mpu6050/src/main.c
@@ -86,7 +86,7 @@ static void handle_mpu6050_drdy(struct device *dev,
 
 void main(void)
 {
-	const char *const label = DT_INST_0_INVENSENSE_MPU6050_LABEL;
+	const char *const label = DT_LABEL(DT_INST(0, invensense_mpu6050));
 	struct device *mpu6050 = device_get_binding(label);
 
 	if (!mpu6050) {

--- a/samples/sensor/ms5837/src/main.c
+++ b/samples/sensor/ms5837/src/main.c
@@ -15,7 +15,7 @@ LOG_MODULE_REGISTER(main);
 void main(void)
 {
 	struct sensor_value oversampling_rate = { 8192, 0 };
-	struct device *dev = device_get_binding(DT_INST_0_MEAS_MS5837_LABEL);
+	struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, meas_ms5837)));
 
 	if (dev == NULL) {
 		LOG_ERR("Could not find MS5837 device, aborting test.");

--- a/samples/sensor/ti_hdc/src/main.c
+++ b/samples/sensor/ti_hdc/src/main.c
@@ -15,7 +15,7 @@
 void main(void)
 {
 	printk("Running on %s!\n", CONFIG_ARCH);
-	struct device *dev = device_get_binding(DT_INST_0_TI_HDC_LABEL);
+	struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, ti_hdc)));
 
 	__ASSERT(dev != NULL, "Failed to get device binding");
 

--- a/samples/sensor/tmp116/src/main.c
+++ b/samples/sensor/tmp116/src/main.c
@@ -16,7 +16,7 @@ void main(void)
 	struct sensor_value temp_value;
 	int ret;
 
-	dev = device_get_binding(DT_INST_0_TI_TMP116_LABEL);
+	dev = device_get_binding(DT_LABEL(DT_INST(0, ti_tmp116)));
 	__ASSERT(dev != NULL, "Failed to get TMP116 device binding");
 
 	printk("Device %s - %p is ready\n", dev->config->name, dev);

--- a/samples/sensor/vl53l0x/src/main.c
+++ b/samples/sensor/vl53l0x/src/main.c
@@ -12,7 +12,7 @@
 
 void main(void)
 {
-	struct device *dev = device_get_binding(DT_INST_0_ST_VL53L0X_LABEL);
+	struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, st_vl53l0x)));
 	struct sensor_value value;
 	int ret;
 


### PR DESCRIPTION
Convert older DT_INST_ macro use the new include/devicetree.h
DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>