### PR TITLE
samples: lwm2m_client: Convert to new DT_INST macros

### DIFF
--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -194,7 +194,7 @@ static void *temperature_get_buf(u16_t obj_inst_id, u16_t res_id,
 	struct device *dev = NULL;
 
 #if defined(CONFIG_FXOS8700_TEMP)
-	dev = device_get_binding(DT_INST_0_NXP_FXOS8700_LABEL);
+	dev = device_get_binding(DT_LABEL(DT_INST(0, nxp_fxos8700)));
 #endif
 
 	if (dev != NULL) {


### PR DESCRIPTION
Convert older DT_INST_ macro use the new include/devicetree.h
DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>