### PR TITLE
samples: ipc: Convert to new DT_INST macros

### DIFF
--- a/samples/subsys/ipc/ipm_mcux/remote/src/main_remote.c
+++ b/samples/subsys/ipc/ipm_mcux/remote/src/main_remote.c
@@ -20,7 +20,7 @@ void ping_ipm_callback(void *context, u32_t id, volatile void *data)
 
 void main(void)
 {
-	ipm = device_get_binding(DT_INST_0_NXP_LPC_MAILBOX_LABEL);
+	ipm = device_get_binding(DT_LABEL(DT_INST(0, nxp_lpc_mailbox)));
 	if (!ipm) {
 		while (1) {
 		}

--- a/samples/subsys/ipc/ipm_mcux/src/main_master.c
+++ b/samples/subsys/ipc/ipm_mcux/src/main_master.c
@@ -33,7 +33,7 @@ void main(void)
 	printk("Hello World from MASTER! %s\n", CONFIG_ARCH);
 
 	/* Get IPM device handle */
-	ipm = device_get_binding(DT_INST_0_NXP_LPC_MAILBOX_LABEL);
+	ipm = device_get_binding(DT_LABEL(DT_INST(0, nxp_lpc_mailbox)));
 	if (!ipm) {
 		printk("Could not get IPM device handle!\n");
 		while (1) {

--- a/samples/subsys/ipc/ipm_mhu_dual_core/src/main.c
+++ b/samples/subsys/ipc/ipm_mhu_dual_core/src/main.c
@@ -49,7 +49,7 @@ void main(void)
 {
 	printk("IPM MHU sample on %s\n", CONFIG_BOARD);
 
-	mhu0 = device_get_binding(DT_INST_0_ARM_MHU_LABEL);
+	mhu0 = device_get_binding(DT_LABEL(DT_INST(0, arm_mhu)));
 	if (!mhu0) {
 		printk("CPU %d, get MHU0 fail!\n",
 				sse_200_platform_get_cpu_id());


### PR DESCRIPTION
Convert older DT_INST_ macro use the new include/devicetree.h
DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>