### PR TITLE
samples: boards: Convert to new DT_INST macros

### DIFF
--- a/samples/boards/96b_argonkey/microphone/src/main.c
+++ b/samples/boards/96b_argonkey/microphone/src/main.c
@@ -96,10 +96,10 @@ void main(void)
 #ifdef CONFIG_LP3943
 	static struct device *ledc;
 
-	ledc = device_get_binding(DT_INST_0_TI_LP3943_LABEL);
+	ledc = device_get_binding(DT_LABEL(DT_INST(0, ti_lp3943)));
 	if (!ledc) {
 		printk("Could not get pointer to %s sensor\n",
-			DT_INST_0_TI_LP3943_LABEL);
+			DT_LABEL(DT_INST(0, ti_lp3943)));
 		return;
 	}
 
@@ -121,11 +121,11 @@ void main(void)
 
 	int ret;
 
-	struct device *mic_dev = device_get_binding(DT_INST_0_ST_MPXXDTYY_LABEL);
+	struct device *mic_dev = device_get_binding(DT_LABEL(DT_INST(0, st_mpxxdtyy)));
 
 	if (!mic_dev) {
 		printk("Could not get pointer to %s device\n",
-			DT_INST_0_ST_MPXXDTYY_LABEL);
+			DT_LABEL(DT_INST(0, st_mpxxdtyy)));
 		return;
 	}
 

--- a/samples/boards/96b_argonkey/sensors/src/main.c
+++ b/samples/boards/96b_argonkey/sensors/src/main.c
@@ -113,10 +113,10 @@ void main(void)
 #ifdef CONFIG_LP3943
 	static struct device *ledc;
 
-	ledc = device_get_binding(DT_INST_0_TI_LP3943_LABEL);
+	ledc = device_get_binding(DT_LABEL(DT_INST(0, ti_lp3943)));
 	if (!ledc) {
 		printk("Could not get pointer to %s sensor\n",
-			DT_INST_0_TI_LP3943_LABEL);
+			DT_LABEL(DT_INST(0, ti_lp3943)));
 		return;
 	}
 
@@ -151,31 +151,31 @@ void main(void)
 
 #ifdef CONFIG_LPS22HB
 	struct device *baro_dev =
-			device_get_binding(DT_INST_0_ST_LPS22HB_PRESS_LABEL);
+			device_get_binding(DT_LABEL(DT_INST(0, st_lps22hb_press)));
 
 	if (!baro_dev) {
 		printk("Could not get pointer to %s sensor\n",
-			DT_INST_0_ST_LPS22HB_PRESS_LABEL);
+			DT_LABEL(DT_INST(0, st_lps22hb_press)));
 		return;
 	}
 #endif
 
 #ifdef CONFIG_HTS221
-	struct device *hum_dev = device_get_binding(DT_INST_0_ST_HTS221_LABEL);
+	struct device *hum_dev = device_get_binding(DT_LABEL(DT_INST(0, st_hts221)));
 
 	if (!hum_dev) {
 		printk("Could not get pointer to %s sensor\n",
-			DT_INST_0_ST_HTS221_LABEL);
+			DT_LABEL(DT_INST(0, st_hts221)));
 		return;
 	}
 #endif
 
 #ifdef CONFIG_LSM6DSL
-	struct device *accel_dev = device_get_binding(DT_INST_0_ST_LSM6DSL_LABEL);
+	struct device *accel_dev = device_get_binding(DT_LABEL(DT_INST(0, st_lsm6dsl)));
 
 	if (!accel_dev) {
 		printk("Could not get pointer to %s sensor\n",
-			DT_INST_0_ST_LSM6DSL_LABEL);
+			DT_LABEL(DT_INST(0, st_lsm6dsl)));
 		return;
 	}
 
@@ -236,11 +236,11 @@ void main(void)
 #endif
 
 #ifdef CONFIG_VL53L0X
-	struct device *tof_dev = device_get_binding(DT_INST_0_ST_VL53L0X_LABEL);
+	struct device *tof_dev = device_get_binding(DT_LABEL(DT_INST(0, st_vl53l0x)));
 
 	if (!tof_dev) {
 		printk("Could not get pointer to %s sensor\n",
-			DT_INST_0_ST_VL53L0X_LABEL);
+			DT_LABEL(DT_INST(0, st_vl53l0x)));
 		return;
 	}
 #endif

--- a/samples/boards/bbc_microbit/pong/src/main.c
+++ b/samples/boards/bbc_microbit/pong/src/main.c
@@ -513,7 +513,7 @@ void main(void)
 
 	k_delayed_work_init(&refresh, game_refresh);
 
-	pwm = device_get_binding(DT_INST_0_NORDIC_NRF_SW_PWM_LABEL);
+	pwm = device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_sw_pwm)));
 
 	ble_init();
 

--- a/samples/boards/bbc_microbit/sound/src/main.c
+++ b/samples/boards/bbc_microbit/sound/src/main.c
@@ -99,7 +99,7 @@ void main(void)
 			   BIT(DT_ALIAS_SW0_GPIOS_PIN) |
 			   BIT(DT_ALIAS_SW1_GPIOS_PIN));
 
-	pwm = device_get_binding(DT_INST_0_NORDIC_NRF_SW_PWM_LABEL);
+	pwm = device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_sw_pwm)));
 
 	k_work_init(&beep_work, beep);
 	/* Notify with a beep that we've started */

--- a/samples/boards/intel_s1000_crb/audio/src/audio_driver.c
+++ b/samples/boards/intel_s1000_crb/audio/src/audio_driver.c
@@ -304,9 +304,9 @@ static void audio_driver_config_periph_streams(void)
 		return;
 	}
 
-	codec_dev = device_get_binding(DT_INST_0_TI_TLV320DAC_LABEL);
+	codec_dev = device_get_binding(DT_LABEL(DT_INST(0, ti_tlv320dac)));
 	if (!codec_dev) {
-		LOG_ERR("unable to find device %s", DT_INST_0_TI_TLV320DAC_LABEL);
+		LOG_ERR("unable to find device %s", DT_LABEL(DT_INST(0, ti_tlv320dac)));
 		return;
 	}
 

--- a/samples/boards/intel_s1000_crb/i2s/src/i2s_sample.c
+++ b/samples/boards/intel_s1000_crb/i2s/src/i2s_sample.c
@@ -140,9 +140,9 @@ static void i2s_audio_init(void)
 		return;
 	}
 
-	codec_device = device_get_binding(DT_INST_0_TI_TLV320DAC_LABEL);
+	codec_device = device_get_binding(DT_LABEL(DT_INST(0, ti_tlv320dac)));
 	if (!codec_device) {
-		LOG_ERR("unable to find " DT_INST_0_TI_TLV320DAC_LABEL " device");
+		LOG_ERR("unable to find " DT_LABEL(DT_INST(0, ti_tlv320dac)) " device");
 		return;
 	}
 

--- a/samples/boards/reel_board/mesh_badge/src/periphs.c
+++ b/samples/boards/reel_board/mesh_badge/src/periphs.c
@@ -18,10 +18,10 @@ struct device_info {
 };
 
 static struct device_info dev_info[] = {
-	{ NULL, DT_INST_0_TI_HDC1010_LABEL },
-	{ NULL, DT_INST_0_NXP_MMA8652FC_LABEL },
-	{ NULL, DT_INST_0_AVAGO_APDS9960_LABEL },
-	{ NULL, DT_INST_0_SOLOMON_SSD16XXFB_LABEL },
+	{ NULL, DT_LABEL(DT_INST(0, ti_hdc1010)) },
+	{ NULL, DT_LABEL(DT_INST(0, nxp_mma8652fc)) },
+	{ NULL, DT_LABEL(DT_INST(0, avago_apds9960)) },
+	{ NULL, DT_LABEL(DT_INST(0, solomon_ssd16xxfb)) },
 };
 
 int get_hdc1010_val(struct sensor_value *val)

--- a/samples/boards/reel_board/mesh_badge/src/reel_board.c
+++ b/samples/boards/reel_board/mesh_badge/src/reel_board.c
@@ -593,7 +593,7 @@ void board_refresh_display(void)
 
 int board_init(void)
 {
-	epd_dev = device_get_binding(DT_INST_0_SOLOMON_SSD16XXFB_LABEL);
+	epd_dev = device_get_binding(DT_LABEL(DT_INST(0, solomon_ssd16xxfb)));
 	if (epd_dev == NULL) {
 		printk("SSD16XX device not found\n");
 		return -ENODEV;

--- a/samples/boards/sensortile_box/src/main.c
+++ b/samples/boards/sensortile_box/src/main.c
@@ -271,17 +271,17 @@ void main(void)
 
 	printk("SensorTile.box test!!\n");
 
-	struct device *hts221 = device_get_binding(DT_INST_0_ST_HTS221_LABEL);
-	struct device *lis2dw12 = device_get_binding(DT_INST_0_ST_LIS2DW12_LABEL);
-	struct device *lps22hh = device_get_binding(DT_INST_0_ST_LPS22HH_LABEL);
-	struct device *lsm6dso = device_get_binding(DT_INST_0_ST_LSM6DSO_LABEL);
-	struct device *stts751 = device_get_binding(DT_INST_0_ST_STTS751_LABEL);
-	struct device *iis3dhhc = device_get_binding(DT_INST_0_ST_IIS3DHHC_LABEL);
-	struct device *lis2mdl = device_get_binding(DT_INST_0_ST_LIS2MDL_LABEL);
+	struct device *hts221 = device_get_binding(DT_LABEL(DT_INST(0, st_hts221)));
+	struct device *lis2dw12 = device_get_binding(DT_LABEL(DT_INST(0, st_lis2dw12)));
+	struct device *lps22hh = device_get_binding(DT_LABEL(DT_INST(0, st_lps22hh)));
+	struct device *lsm6dso = device_get_binding(DT_LABEL(DT_INST(0, st_lsm6dso)));
+	struct device *stts751 = device_get_binding(DT_LABEL(DT_INST(0, st_stts751)));
+	struct device *iis3dhhc = device_get_binding(DT_LABEL(DT_INST(0, st_iis3dhhc)));
+	struct device *lis2mdl = device_get_binding(DT_LABEL(DT_INST(0, st_lis2mdl)));
 
 	if (!hts221) {
 		printk("Could not get pointer to %s sensor\n",
-			DT_INST_0_ST_HTS221_LABEL);
+			DT_LABEL(DT_INST(0, st_hts221)));
 		return;
 	}
 


### PR DESCRIPTION
Convert older DT_INST_ macro use the new include/devicetree.h
DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>