### PR TITLE
samples: shields: Convert to new DT_INST macros

### DIFF
--- a/samples/shields/lmp90100_evb/rtd/src/main.c
+++ b/samples/shields/lmp90100_evb/rtd/src/main.c
@@ -70,7 +70,7 @@ void main(void)
 		.calibrate = 0
 	};
 
-	lmp90100 = device_get_binding(DT_INST_0_TI_LMP90100_LABEL);
+	lmp90100 = device_get_binding(DT_LABEL(DT_INST(0, ti_lmp90100)));
 	if (!lmp90100) {
 		LOG_ERR("LMP90100 device not found");
 		return;

--- a/samples/shields/x_nucleo_iks01a1/src/main.c
+++ b/samples/shields/x_nucleo_iks01a1/src/main.c
@@ -25,10 +25,10 @@ void main(void)
 {
 	struct sensor_value temp, hum, press;
 	struct sensor_value magn_xyz[3], accel_xyz[3];
-	struct device *hts221 = device_get_binding(DT_INST_0_ST_HTS221_LABEL);
-	struct device *lis3mdl = device_get_binding(DT_INST_0_ST_LIS3MDL_MAGN_LABEL);
-	struct device *lsm6ds0 = device_get_binding(DT_INST_0_ST_LSM6DS0_LABEL);
-	struct device *lps25hb = device_get_binding(DT_INST_0_ST_LPS25HB_PRESS_LABEL);
+	struct device *hts221 = device_get_binding(DT_LABEL(DT_INST(0, st_hts221)));
+	struct device *lis3mdl = device_get_binding(DT_LABEL(DT_INST(0, st_lis3mdl_magn)));
+	struct device *lsm6ds0 = device_get_binding(DT_LABEL(DT_INST(0, st_lsm6ds0)));
+	struct device *lps25hb = device_get_binding(DT_LABEL(DT_INST(0, st_lps25hb_press)));
 #if defined(CONFIG_LIS3MDL_TRIGGER)
 	struct sensor_trigger trig;
 	int cnt = 1;

--- a/samples/shields/x_nucleo_iks01a2/src/main.c
+++ b/samples/shields/x_nucleo_iks01a2/src/main.c
@@ -16,11 +16,11 @@ void main(void)
 	struct sensor_value accel1[3], accel2[3];
 	struct sensor_value gyro[3];
 	struct sensor_value magn[3];
-	struct device *hts221 = device_get_binding(DT_INST_0_ST_HTS221_LABEL);
-	struct device *lps22hb = device_get_binding(DT_INST_0_ST_LPS22HB_PRESS_LABEL);
-	struct device *lsm6dsl = device_get_binding(DT_INST_0_ST_LSM6DSL_LABEL);
-	struct device *lsm303agr_a = device_get_binding(DT_INST_0_ST_LIS2DH_LABEL);
-	struct device *lsm303agr_m = device_get_binding(DT_INST_0_ST_LIS2MDL_LABEL);
+	struct device *hts221 = device_get_binding(DT_LABEL(DT_INST(0, st_hts221)));
+	struct device *lps22hb = device_get_binding(DT_LABEL(DT_INST(0, st_lps22hb_press)));
+	struct device *lsm6dsl = device_get_binding(DT_LABEL(DT_INST(0, st_lsm6dsl)));
+	struct device *lsm303agr_a = device_get_binding(DT_LABEL(DT_INST(0, st_lis2dh)));
+	struct device *lsm303agr_m = device_get_binding(DT_LABEL(DT_INST(0, st_lis2mdl)));
 
 	if (hts221 == NULL) {
 		printf("Could not get HTS221 device\n");

--- a/samples/shields/x_nucleo_iks01a3/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks01a3/sensorhub/src/main.c
@@ -179,8 +179,8 @@ void main(void)
 	struct sensor_value accel1[3], accel2[3];
 	struct sensor_value gyro[3];
 	struct sensor_value magn[3];
-	struct device *lis2dw12 = device_get_binding(DT_INST_0_ST_LIS2DW12_LABEL);
-	struct device *lsm6dso = device_get_binding(DT_INST_0_ST_LSM6DSO_LABEL);
+	struct device *lis2dw12 = device_get_binding(DT_LABEL(DT_INST(0, st_lis2dw12)));
+	struct device *lsm6dso = device_get_binding(DT_LABEL(DT_INST(0, st_lsm6dso)));
 	int cnt = 1;
 
 	if (lis2dw12 == NULL) {

--- a/samples/shields/x_nucleo_iks01a3/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks01a3/standard/src/main.c
@@ -247,12 +247,12 @@ void main(void)
 	struct sensor_value accel1[3], accel2[3];
 	struct sensor_value gyro[3];
 	struct sensor_value magn[3];
-	struct device *hts221 = device_get_binding(DT_INST_0_ST_HTS221_LABEL);
-	struct device *lps22hh = device_get_binding(DT_INST_0_ST_LPS22HH_LABEL);
-	struct device *stts751 = device_get_binding(DT_INST_0_ST_STTS751_LABEL);
-	struct device *lis2mdl = device_get_binding(DT_INST_0_ST_LIS2MDL_LABEL);
-	struct device *lis2dw12 = device_get_binding(DT_INST_0_ST_LIS2DW12_LABEL);
-	struct device *lsm6dso = device_get_binding(DT_INST_0_ST_LSM6DSO_LABEL);
+	struct device *hts221 = device_get_binding(DT_LABEL(DT_INST(0, st_hts221)));
+	struct device *lps22hh = device_get_binding(DT_LABEL(DT_INST(0, st_lps22hh)));
+	struct device *stts751 = device_get_binding(DT_LABEL(DT_INST(0, st_stts751)));
+	struct device *lis2mdl = device_get_binding(DT_LABEL(DT_INST(0, st_lis2mdl)));
+	struct device *lis2dw12 = device_get_binding(DT_LABEL(DT_INST(0, st_lis2dw12)));
+	struct device *lsm6dso = device_get_binding(DT_LABEL(DT_INST(0, st_lsm6dso)));
 	int cnt = 1;
 
 	if (hts221 == NULL) {


### PR DESCRIPTION
Convert older DT_INST_ macro use the new include/devicetree.h
DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>