### PR TITLE
drivers: Convert to use DT_INST_FOREACH

### DIFF
--- a/drivers/gpio/gpio_litex.c
+++ b/drivers/gpio/gpio_litex.c
@@ -239,38 +239,4 @@ static const struct gpio_driver_api gpio_litex_driver_api = {
 			    &gpio_litex_driver_api \
 			   )
 
-#if DT_INST_NODE_HAS_PROP(0, label)
-GPIO_LITEX_INIT(0);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(1, label)
-GPIO_LITEX_INIT(1);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(2, label)
-GPIO_LITEX_INIT(2);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(3, label)
-GPIO_LITEX_INIT(3);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(4, label)
-GPIO_LITEX_INIT(4);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(5, label)
-GPIO_LITEX_INIT(5);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(6, label)
-GPIO_LITEX_INIT(6);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(7, label)
-GPIO_LITEX_INIT(7);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(8, label)
-GPIO_LITEX_INIT(8);
-#endif
+DT_INST_FOREACH(GPIO_LITEX_INIT)

--- a/drivers/i2c/i2c_litex.c
+++ b/drivers/i2c/i2c_litex.c
@@ -136,38 +136,4 @@ static const struct i2c_driver_api i2c_litex_driver_api = {
 			   &i2c_litex_driver_api			       \
 			   )
 
-#if DT_INST_NODE_HAS_PROP(0, label)
-I2C_LITEX_INIT(0);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(1, label)
-I2C_LITEX_INIT(1);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(2, label)
-I2C_LITEX_INIT(2);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(3, label)
-I2C_LITEX_INIT(3);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(4, label)
-I2C_LITEX_INIT(4);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(5, label)
-I2C_LITEX_INIT(5);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(6, label)
-I2C_LITEX_INIT(6);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(7, label)
-I2C_LITEX_INIT(7);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(8, label)
-I2C_LITEX_INIT(8);
-#endif
+DT_INST_FOREACH(I2C_LITEX_INIT)

--- a/drivers/led_strip/ws2812_gpio.c
+++ b/drivers/led_strip/ws2812_gpio.c
@@ -240,10 +240,4 @@ static const struct led_strip_driver_api ws2812_gpio_api = {
 			    CONFIG_LED_STRIP_INIT_PRIORITY,		\
 			    &ws2812_gpio_api)
 
-#if DT_INST_NODE_HAS_PROP(0, label)
-WS2812_GPIO_DEVICE(0);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(1, label)
-WS2812_GPIO_DEVICE(1);
-#endif
+DT_INST_FOREACH(WS2812_GPIO_DEVICE)

--- a/drivers/led_strip/ws2812_spi.c
+++ b/drivers/led_strip/ws2812_spi.c
@@ -230,10 +230,4 @@ static const struct led_strip_driver_api ws2812_spi_api = {
 			    CONFIG_LED_STRIP_INIT_PRIORITY,		\
 			    &ws2812_spi_api);
 
-#if DT_INST_NODE_HAS_PROP(0, label)
-WS2812_SPI_DEVICE(0);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(1, label)
-WS2812_SPI_DEVICE(1);
-#endif
+DT_INST_FOREACH(WS2812_SPI_DEVICE)

--- a/drivers/pwm/pwm_litex.c
+++ b/drivers/pwm/pwm_litex.c
@@ -113,38 +113,4 @@ static const struct pwm_driver_api pwm_litex_driver_api = {
 			    &pwm_litex_driver_api			       \
 			   )
 
-#if DT_INST_NODE_HAS_PROP(0, label)
-PWM_LITEX_INIT(0);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(1, label)
-PWM_LITEX_INIT(1);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(2, label)
-PWM_LITEX_INIT(2);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(3, label)
-PWM_LITEX_INIT(3);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(4, label)
-PWM_LITEX_INIT(4);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(5, label)
-PWM_LITEX_INIT(5);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(6, label)
-PWM_LITEX_INIT(6);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(7, label)
-PWM_LITEX_INIT(7);
-#endif
-
-#if DT_INST_NODE_HAS_PROP(8, label)
-PWM_LITEX_INIT(8);
-#endif
+DT_INST_FOREACH(PWM_LITEX_INIT)

--- a/drivers/pwm/pwm_sifive.c
+++ b/drivers/pwm/pwm_sifive.c
@@ -246,14 +246,4 @@ static const struct pwm_driver_api pwm_sifive_api = {
 			    CONFIG_PWM_SIFIVE_INIT_PRIORITY,	\
 			    &pwm_sifive_api)
 
-#if DT_INST_NODE_HAS_PROP(0, label)
-PWM_SIFIVE_INIT(0);
-#endif /* DT_INST_NODE_HAS_PROP(0, label) */
-
-#if DT_INST_NODE_HAS_PROP(1, label)
-PWM_SIFIVE_INIT(1);
-#endif /* DT_INST_NODE_HAS_PROP(1, label) */
-
-#if DT_INST_NODE_HAS_PROP(2, label)
-PWM_SIFIVE_INIT(2);
-#endif /* DT_INST_NODE_HAS_PROP(2, label) */
+DT_INST_FOREACH(PWM_SIFIVE_INIT)

--- a/drivers/spi/spi_gecko.c
+++ b/drivers/spi/spi_gecko.c
@@ -321,26 +321,4 @@ static struct spi_driver_api spi_gecko_api = {
 
 #define SPI_INIT(n) SPI_INIT2(n, SPI_ID(n))
 
-#if DT_INST_NODE_HAS_PROP(0, label)
-
-SPI_INIT(0);
-
-#endif /* DT_INST_NODE_HAS_PROP(0, label) */
-
-#if DT_INST_NODE_HAS_PROP(1, label)
-
-SPI_INIT(1);
-
-#endif /* DT_INST_NODE_HAS_PROP(1, label) */
-
-#if DT_INST_NODE_HAS_PROP(2, label)
-
-SPI_INIT(2);
-
-#endif /* DT_INST_NODE_HAS_PROP(2, label) */
-
-#if DT_INST_NODE_HAS_PROP(3, label)
-
-SPI_INIT(3);
-
-#endif /* DT_INST_NODE_HAS_PROP(3, label) */
+DT_INST_FOREACH(SPI_INIT)

--- a/drivers/spi/spi_litespi.c
+++ b/drivers/spi/spi_litespi.c
@@ -182,8 +182,4 @@ static struct spi_driver_api spi_litespi_api = {
 			CONFIG_SPI_INIT_PRIORITY, \
 			&spi_litespi_api)
 
-#if DT_INST_NODE_HAS_PROP(0, label)
-
-SPI_INIT(0);
-
-#endif /* DT_INST_NODE_HAS_PROP(0, label) */
+DT_INST_FOREACH(SPI_INIT)


### PR DESCRIPTION
Convert drivers that have the following pattern:

   #if DT_INST_NODE_HAS_PROP(0, label)
   INIT_MACRO(0)
   #endif

   ...

   #if DT_INST_NODE_HAS_PROP(n, label)
   INIT_MACRO(n)
   #endif

to use DT_INST_FOREACH(INIT_MACRO) instead.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>