### PR TITLE
drivers: gpio: Fix mcux lpc driver interrupts for port 1

### DIFF
--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -211,7 +211,7 @@ static u32_t attach_pin_to_isr(u32_t port, u32_t pin, u32_t isr_no)
 	if (isr_no < PIN_INT4_IRQn) {
 		pint_idx = isr_no - PIN_INT0_IRQn;
 	} else {
-		pint_idx = isr_no - PIN_INT4_IRQn;
+		pint_idx = isr_no - PIN_INT4_IRQn + 4;
 	}
 
 	INPUTMUX_AttachSignal(INPUTMUX, pint_idx,


### PR DESCRIPTION
The mcux lpc driver assumes that PINT interrupts are assigned to GPIO
port instances in groups of four, meaning that GPIO0 uses PIN_INT0-3 and
GPIO1 uses PIN_INT4-7. There was a mistake in the pin assignment
calculation that caused GPIO1 to incorrectly attach pins to PIN_INT0-3.

This caused the gpio isr to be invoked with what appeared to be the
wrong device argument and therefore not invoke any of the expected gpio
callbacks. But actually, it was the wrong irq that fired.

Found when adding support for the accelerometer interrupt on the
lpcxpresso55s69 board.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>