### PR TITLE
Detect if we should run full sanitycheck or not

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -390,6 +390,7 @@
 /scripts/gen_app_partitions.py            @andrewboie
 /scripts/dts/                             @ulfalizer @galak
 /scripts/release/                         @nashif
+/scripts/ci/                              @nashif
 /arch/x86/gen_gdt.py                      @andrewboie
 /arch/x86/gen_idt.py                      @andrewboie
 /scripts/gen_kobject_list.py              @andrewboie

--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -230,7 +230,9 @@ if [ -n "$main_ci" ]; then
 	fi
 	$short_git_log
 
-	if [ -n "${BSIM_OUT_PATH}" -a -d "${BSIM_OUT_PATH}" ]; then
+	SC=`./scripts/ci/what_changed.py --commits ${commit_range}`
+
+	if [ -n "${BSIM_OUT_PATH}" -a -d "${BSIM_OUT_PATH}" -a "$SC" == "full" ]; then
 		echo "Build and run BT simulator tests"
 		# Run BLE tests in simulator on the 1st CI instance:
 		if [ "$matrix" = "1" ]; then
@@ -249,8 +251,12 @@ if [ -n "$main_ci" ]; then
 		get_tests_to_run
 	fi
 
+	if [ "$SC" == "full" ]; then
 	# Save list of tests to be run
 	${sanitycheck} ${sanitycheck_options} --save-tests test_file_3.txt || exit 1
+	else
+	echo "test,arch,platform,status,extra_args,handler,handler_time,ram_size,rom_size" > test_file_3.txt
+	fi
 
 	# Remove headers from all files but the first one to generate one
 	# single file with only one header row

--- a/scripts/ci/sanitycheck_ignore.txt
+++ b/scripts/ci/sanitycheck_ignore.txt
@@ -1,0 +1,26 @@
+# Add one pattern per line.
+#
+# The patterns listed in this file will be compared with the list of files
+# changed in a patch series (Pull Request) and if all files in the pull request
+# are matched, then sanitycheck will not do a full run and optionally will only
+# run on changed tests or boards.
+#
+.clang-format
+.codecov.yml
+.editorconfig
+.gitattributes
+.gitignore
+.known-issues
+.mailmap
+.uncrustify.cfg
+CODEOWNERS
+LICENSE
+Makefile
+tests/*
+samples/*
+*.rst
+*.md
+# if we change this file or associated script, it should not trigger a full
+# sanitycheck.
+scripts/ci/sanitycheck_ignore.txt
+scripts/ci/what_changed.py

--- a/scripts/ci/what_changed.py
+++ b/scripts/ci/what_changed.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2020 Intel Corporation
+# Check if full sanitycheck is needed.
+
+import os
+import sh
+import argparse
+import fnmatch
+
+
+if "ZEPHYR_BASE" not in os.environ:
+    exit("$ZEPHYR_BASE environment variable undefined.")
+
+repository_path = os.environ['ZEPHYR_BASE']
+sh_special_args = {
+    '_tty_out': False,
+    '_cwd': repository_path
+}
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+                description="Check if change requires full sanitycheck")
+    parser.add_argument('-c', '--commits', default=None,
+            help="Commit range in the form: a..b")
+    return parser.parse_args()
+
+def main():
+    args = parse_args()
+    if not args.commits:
+        exit(1)
+
+    # pylint does not like the 'sh' library
+    # pylint: disable=too-many-function-args,unexpected-keyword-arg
+    commit = sh.git("diff", "--name-only", args.commits, **sh_special_args)
+    files = commit.split("\n")
+
+    with open("scripts/ci/sanitycheck_ignore.txt", "r") as sc_ignore:
+        ignores = sc_ignore.read().splitlines()
+        ignores = filter(lambda x: not x.startswith("#"), ignores)
+
+    found = []
+    files = list(filter(lambda x: x, files))
+
+    for pattern in ignores:
+        if pattern:
+            found.extend(fnmatch.filter(files, pattern))
+
+    if sorted(files) != sorted(found):
+        print("full")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
See if we can avoid running full sanitycheck on trivial changes.

Depending on the files being changed, decide if we should run full sanitycheck or not. The decision is made based on a list of files maintained in sanitycheck_ignore.txt. If we are only changing any of those files, we do not run full sanitychech, for example, if the PR is only changing some documentation file (rst or md) there is no need to run full sanitycheck or if we are changing a sample or a test, we only run sanitycheck on those tests or samples, but not the full sanity... This should improve CI runtime for micro-changes.