### PR TITLE
net: ieee802154_radio: Enable ed_scan unconditionally

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -182,7 +182,6 @@ static int nrf5_set_channel(struct device *dev, u16_t channel)
 	return 0;
 }
 
-#ifdef CONFIG_NET_L2_OPENTHREAD
 static int nrf5_energy_scan_start(struct device *dev,
 				  u16_t duration,
 				  energy_scan_done_cb_t done_cb)
@@ -204,7 +203,6 @@ static int nrf5_energy_scan_start(struct device *dev,
 
 	return err;
 }
-#endif /* CONFIG_NET_L2_OPENTHREAD */
 
 static int nrf5_set_pan_id(struct device *dev, u16_t pan_id)
 {
@@ -609,9 +607,7 @@ static struct ieee802154_radio_api nrf5_radio_api = {
 	.start = nrf5_start,
 	.stop = nrf5_stop,
 	.tx = nrf5_tx,
-#ifdef CONFIG_NET_L2_OPENTHREAD
 	.ed_scan = nrf5_energy_scan_start,
-#endif /* CONFIG_NET_L2_OPENTHREAD */
 	.configure = nrf5_configure,
 };
 

--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -157,15 +157,13 @@ struct ieee802154_radio_api {
 	u16_t (*get_subg_channel_count)(struct device *dev);
 #endif /* CONFIG_NET_L2_IEEE802154_SUB_GHZ */
 
-#ifdef CONFIG_NET_L2_OPENTHREAD
 	/** Run an energy detection scan.
-	 * Note: channel must be set prior to request this function.
-	 * duration parameter is in ms.
+	 *  Note: channel must be set prior to request this function.
+	 *  duration parameter is in ms.
 	 */
 	int (*ed_scan)(struct device *dev,
 		       u16_t duration,
 		       energy_scan_done_cb_t done_cb);
-#endif /* CONFIG_NET_L2_OPENTHREAD */
 };
 
 /* Make sure that the network interface API is properly setup inside

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -417,6 +417,10 @@ otError otPlatRadioEnergyScan(otInstance *aInstance, u8_t aScanChannel,
 	energy_detection_time    = aScanDuration;
 	energy_detection_channel = aScanChannel;
 
+	if (radio_api->ed_scan == NULL) {
+		return OT_ERROR_NOT_IMPLEMENTED;
+	}
+
 	clear_pending_events();
 
 	radio_api->set_channel(radio_dev, aScanChannel);


### PR DESCRIPTION
Energy scan procedure, while introduced specifically for OpenThread in
Zephyr, may also be used by other upper layers (like Zigbee).
Therefore, disable conditional inclusion of the `ed_scan` API.

Additionally, add stub functions in radio drivers that do not implement
this API yet.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>