### PR TITLE
manifest: Point to tip of master after snapshot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -83,7 +83,7 @@ manifest:
       revision: cf7020eb4c7ef93319f2d6d2403a21e12a879bf6
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: 0f4463caec3c3a8fac1350d0d6dfbee678a8ce06
+      revision: 7e7b4ad1999bf148f88059195f8d2e1d3dccf190
       path: bootloader/mcuboot
     - name: mcumgr
       revision: dcf32c7f340a10e6e6482feb311cb4fa71953fd3


### PR DESCRIPTION
PR https://github.com/zephyrproject-rtos/mcuboot/pull/8 was mistakenly
merged instead of pushed, which made the last 4 commits of zephyr's
mcuboot divergen in SHA with respect to the upstream ones.
In order to preserve the status of the zephyr mcuboot repo as an
exact mirror of the upstream one, a snapshot has been taken to preserve
the current SHA (0f4463caec3c3a8fac1350d0d6dfbee678a8ce06) and then the
master branch has been reset to the upstream equivalent
(7e7b4ad1999bf148f88059195f8d2e1d3dccf190). This commit switches the
pointer to the latter.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>