### PR TITLE
net: tcp2: Fix option name PAD to END

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -382,12 +382,12 @@ static bool tcp_options_check(void *buf, ssize_t len)
 
 	for ( ; len >= 2; options += opt_len, len -= opt_len) {
 		opt = options[0];
-		opt_len = (opt == TCPOPT_PAD || opt == TCPOPT_NOP) ?
+		opt_len = (opt == TCPOPT_END || opt == TCPOPT_NOP) ?
 			1 : options[1];
 
 		NET_DBG("opt: %hu, opt_len: %hu", (u16_t)opt, (u16_t)opt_len);
 
-		if (opt == TCPOPT_PAD || opt == TCPOPT_NOP) {
+		if (opt == TCPOPT_END || opt == TCPOPT_NOP) {
 			continue;
 		}
 

--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -80,7 +80,7 @@ static struct net_pkt *tcp_pkt_alloc(size_t len)
 	(_conn)->state = _s;						\
 })
 
-#define TCPOPT_PAD	0
+#define TCPOPT_END	0
 #define TCPOPT_NOP	1
 #define TCPOPT_MAXSEG	2
 #define TCPOPT_WINDOW	3


### PR DESCRIPTION
According to RFC 793 and IANA "TCP Option Kind Numbers" an option with
kind 0 is an End of Option List option and not a PAD.

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>