### PR TITLE
[backport v2.2] Bluetooth: controller: split: Validate chan map and hop value

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -79,7 +79,13 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	       sizeof(lll->data_chan_map));
 	lll->data_chan_count = util_ones_count_get(&lll->data_chan_map[0],
 			       sizeof(lll->data_chan_map));
+	if (lll->data_chan_count < 2) {
+		return;
+	}
 	lll->data_chan_hop = pdu_adv->connect_ind.hop;
+	if ((lll->data_chan_hop < 5) || (lll->data_chan_hop > 16)) {
+		return;
+	}
 	interval = sys_le16_to_cpu(pdu_adv->connect_ind.interval);
 	lll->interval = interval;
 	lll->latency = sys_le16_to_cpu(pdu_adv->connect_ind.latency);


### PR DESCRIPTION
Add validation of channel map and hop increment value
received in CONNECT_IND PDU.

Zero bit count leads to controller assert or divide-by-zero
fault.

Hop increment shall be between 5 and 16 by BT Specification.

Relates to #23705.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>