### PR TITLE
[backport v2.2] Bluetooth: controller: split: Fix slave latency during conn update

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1209,9 +1209,10 @@ void ull_conn_done(struct node_rx_event_done *done)
 #endif /* CONFIG_BT_CTLR_CONN_RSSI */
 
 	/* break latency based on ctrl procedure pending */
-	if ((((conn->llcp_req - conn->llcp_ack) & 0x03) == 0x02) &&
-	    ((conn->llcp_type == LLCP_CONN_UPD) ||
-	     (conn->llcp_type == LLCP_CHAN_MAP))) {
+	if (((((conn->llcp_req - conn->llcp_ack) & 0x03) == 0x02) &&
+	     ((conn->llcp_type == LLCP_CONN_UPD) ||
+	      (conn->llcp_type == LLCP_CHAN_MAP))) ||
+	    (conn->llcp_cu.req != conn->llcp_cu.ack)) {
 		lll->latency_event = 0;
 	}
 


### PR DESCRIPTION
Fix regression in cancelling slave latency during Connection
Update Procedure.

Slave latency should not be applied between the ack of a
Connection Update Indication PDU and until the instant.
When caching was introduced, implementation missed this
consideration.

Relates to #23813.
Fixes #24183.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>