### PR TITLE
samples: sensor: Refactor tests and add sample loop delay

### DIFF
--- a/samples/sensor/fxos8700/sample.yaml
+++ b/samples/sensor/fxos8700/sample.yaml
@@ -1,16 +1,19 @@
+common:
+  harness: sensor
+  tags: sensors
+  depends_on: i2c gpio
 sample:
   name: FXOS8700 Accelerometer/Magnetometer Sensor
 tests:
-  sample.sensor.fxos8700:
-    harness: sensor
-    platform_whitelist: frdm_k64f hexiwear_k64 warp7_m4 bbc_microbit
-                        frdm_kl25z frdm_kw41z reel_board rv32m1_vega_ri5cy
-                        twr_ke18f
-    tags: sensors
-    depends_on: i2c gpio
+  sample.sensor.fxos8700.hybrid:
+    platform_whitelist: frdm_k64f hexiwear_k64 warp7_m4 frdm_kw41z
+                        rv32m1_vega_ri5cy twr_ke18f
     extra_configs:
       - CONFIG_FXOS8700_PULSE=y
       - CONFIG_FXOS8700_PULSE_INT1=y
       - CONFIG_FXOS8700_MOTION=y
       - CONFIG_FXOS8700_MOTION_INT1=y
       - CONFIG_FXOS8700_PM_LOW_POWER=y
+  sample.sensor.fxos8700.accel:
+    platform_whitelist: frdm_kl25z bbc_microbit reel_board
+    extra_args: CONF_FILE=prj_accel.conf

--- a/samples/sensor/fxos8700/src/main.c
+++ b/samples/sensor/fxos8700/src/main.c
@@ -77,6 +77,7 @@ void main(void)
 
 	while (1) {
 #ifdef CONFIG_FXOS8700_TRIGGER_NONE
+		k_sleep(K_MSEC(160));
 		sensor_sample_fetch(dev);
 #else
 		k_sem_take(&sem, K_FOREVER);


### PR DESCRIPTION
- Refactors the fxos8700 sensor sample for accelerometer-only boards
- Adds a delay to the sample loop when using the sensor in polling mode

Cherry-picked from #23119