### PR TITLE
tests: benchmarks: use high-res counter for MEC1501 SoC

### DIFF
--- a/arch/common/timing_info_bench.c
+++ b/arch/common/timing_info_bench.c
@@ -31,6 +31,12 @@ u64_t arch_timing_value_swap_temp;
 #define TIMING_INFO_GET_TIMER_VALUE() (TIMING_INFO_OS_GET_TIME())
 #define SUBTRACT_CLOCK_CYCLES(val)    (val)
 
+#elif CONFIG_SOC_SERIES_MEC1501X
+#define TIMING_INFO_PRE_READ()
+#define TIMING_INFO_OS_GET_TIME()     (B32TMR1_REGS->CNT)
+#define TIMING_INFO_GET_TIMER_VALUE() (TIMING_INFO_OS_GET_TIME())
+#define SUBTRACT_CLOCK_CYCLES(val)    (val)
+
 #elif CONFIG_X86
 #define TIMING_INFO_PRE_READ()
 #define TIMING_INFO_OS_GET_TIME()      (z_tsc_read())

--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -217,6 +217,11 @@ static void xec_rtos_timer_isr(void *arg)
 {
 	ARG_UNUSED(arg);
 
+#ifdef CONFIG_EXECUTION_BENCHMARKING
+	extern void read_timer_start_of_tick_handler(void);
+	read_timer_start_of_tick_handler();
+#endif
+
 	u32_t cycles;
 	s32_t ticks;
 
@@ -243,6 +248,11 @@ static void xec_rtos_timer_isr(void *arg)
 
 	k_spin_unlock(&lock, key);
 	z_clock_announce(ticks);
+
+#ifdef CONFIG_EXECUTION_BENCHMARKING
+	extern void read_timer_end_of_tick_handler(void);
+	read_timer_end_of_tick_handler();
+#endif
 }
 
 #else


### PR DESCRIPTION
The timer counter for ticks on MEC1501 SoC is based on the RTOS
timer which runs at 32kHz. This is too slow for timing benchmarks
as most cases can be finished within one or two ticks. Since
the SoC has higher frequency timers running at 48MHz, add
the necessary bits to use these for timing benchmarks.

Fix #23414

Signed-off-by: Daniel Leung <daniel.leung@intel.com>