### PR TITLE
arch: arm: Set lpc55s69 image type in cortex-m vector table

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/vector_table.S
+++ b/arch/arm/core/aarch32/cortex_m/vector_table.S
@@ -57,7 +57,11 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
     .word z_arm_reserved
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
     .word z_arm_reserved
+#if defined(CONFIG_SOC_SERIES_LPC55XXX)
+    .word 0
+#else
     .word z_arm_reserved
+#endif
     .word z_arm_reserved
     .word z_arm_svc
     .word z_arm_debug_monitor


### PR DESCRIPTION
The secure boot rom in the lpc55s69 soc uses a reserved entry in the
cm33 vector table to determine the application image type and
enable/disable a preset tz-m configuration. Zero out this entry in the
vector table to set the image type as a plain image (not signed or CRC)
and disable the preset tz-m configuration. Otherwise, the address of
z_arm_reserved can potentially cause an invalid image type that can't
boot.

Eventually we will want to support other image types and write non-zero
values to this entry in the vector table, however we don't yet have
zephyr infrastructure in place to generate these types of images.
Therefore we don't introduce any Kconfig options to configure the value.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>