### PR TITLE
Makefile: ZEPHYR_BASE is not needed anymore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,6 @@
 # Top level makefile for documentation build
 #
 
-ifndef ZEPHYR_BASE
-$(error The ZEPHYR_BASE environment variable must be set)
-endif
-
 BUILDDIR ?= doc/_build
 DOC_TAG ?= development
 SPHINXOPTS ?= -q


### PR DESCRIPTION
Ever since we got Zephyr support as a CMake package, the
documentation build system does not need this environment variable to
work.
