### PR TITLE
arch: arc: optimization for irq lock/unlock

### DIFF
--- a/arch/arc/core/cache.c
+++ b/arch/arc/core/cache.c
@@ -96,7 +96,7 @@ static void dcache_flush_mlines(u32_t start_addr, u32_t size)
 	end_addr = start_addr + size - 1;
 	start_addr &= (u32_t)(~(DCACHE_LINE_SIZE - 1));
 
-	key = irq_lock(); /* --enter critical section-- */
+	key = arch_irq_lock(); /* --enter critical section-- */
 
 	do {
 		z_arc_v2_aux_reg_write(_ARC_V2_DC_FLDL, start_addr);
@@ -113,7 +113,7 @@ static void dcache_flush_mlines(u32_t start_addr, u32_t size)
 		start_addr += DCACHE_LINE_SIZE;
 	} while (start_addr <= end_addr);
 
-	irq_unlock(key); /* --exit critical section-- */
+	arch_irq_unlock(key); /* --exit critical section-- */
 
 }
 

--- a/arch/arc/core/irq_manage.c
+++ b/arch/arc/core/irq_manage.c
@@ -57,7 +57,7 @@ void z_arc_firq_stack_set(void)
 /* the z_arc_firq_stack_set must be called when irq diasbled, as
  * it can be called not only in the init phase but also other places
  */
-	unsigned int key = irq_lock();
+	unsigned int key = arch_irq_lock();
 
 	__asm__ volatile (
 /* only ilink will not be banked, so use ilink as channel
@@ -79,7 +79,7 @@ void z_arc_firq_stack_set(void)
 	  "i"(_ARC_V2_STATUS32_RB(1)),
 	  "i"(~_ARC_V2_STATUS32_RB(7))
 	);
-	irq_unlock(key);
+	arch_irq_unlock(key);
 }
 #endif
 
@@ -95,10 +95,7 @@ void z_arc_firq_stack_set(void)
 
 void arch_irq_enable(unsigned int irq)
 {
-	unsigned int key = irq_lock();
-
 	z_arc_v2_irq_unit_int_enable(irq);
-	irq_unlock(key);
 }
 
 /*
@@ -112,10 +109,7 @@ void arch_irq_enable(unsigned int irq)
 
 void arch_irq_disable(unsigned int irq)
 {
-	unsigned int key = irq_lock();
-
 	z_arc_v2_irq_unit_int_disable(irq);
-	irq_unlock(key);
 }
 
 /**
@@ -147,8 +141,6 @@ void z_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags)
 {
 	ARG_UNUSED(flags);
 
-	unsigned int key = irq_lock();
-
 	__ASSERT(prio < CONFIG_NUM_IRQ_PRIO_LEVELS,
 		 "invalid priority %d for irq %d", prio, irq);
 /* 0 -> CONFIG_NUM_IRQ_PRIO_LEVELS allocted to secure world
@@ -162,7 +154,6 @@ void z_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags)
 		 ARC_N_IRQ_START_LEVEL : prio;
 #endif
 	z_arc_v2_irq_unit_prio_set(irq, prio);
-	irq_unlock(key);
 }
 
 /*

--- a/arch/arc/core/timestamp.c
+++ b/arch/arc/core/timestamp.c
@@ -29,10 +29,10 @@ u64_t z_tsc_read(void)
 	u64_t t;
 	u32_t count;
 
-	key = irq_lock();
+	key = arch_irq_lock();
 	t = (u64_t)z_tick_get();
 	count = z_arc_v2_aux_reg_read(_ARC_V2_TMR0_COUNT);
-	irq_unlock(key);
+	arch_irq_unlock(key);
 	t *= k_ticks_to_cyc_floor64(1);
 	t += (u64_t)count;
 	return t;

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -340,35 +340,6 @@ u32_t z_timer_cycle_get_32(void)
 #endif
 }
 
-/**
- *
- * @brief Stop announcing ticks into the kernel
- *
- * This routine disables timer interrupt generation and delivery.
- * Note that the timer's counting cannot be stopped by software.
- *
- * @return N/A
- */
-void sys_clock_disable(void)
-{
-	unsigned int key;  /* interrupt lock level */
-	u32_t control; /* timer control register value */
-
-	key = irq_lock();
-
-	/* disable interrupt generation */
-
-	control = timer0_control_register_get();
-	timer0_control_register_set(control & ~_ARC_V2_TMR_CTRL_IE);
-
-	irq_unlock(key);
-
-	/* disable interrupt in the interrupt controller */
-
-	irq_disable(IRQ_TIMER0);
-}
-
-
 #if SMP_TIMER_DRIVER
 void smp_timer_init(void)
 {

--- a/include/arch/arc/v2/arcv2_irq_unit.h
+++ b/include/arch/arc/v2/arcv2_irq_unit.h
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2014 Wind River Systems, Inc.
+ * Copyright (c) 2020 Synopsys.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,20 +25,16 @@ extern "C" {
 #ifndef _ASMLANGUAGE
 
 /*
- * WARNING:
+ * NOTE:
  *
- * All APIs provided by this file must be invoked with INTERRUPTS LOCKED. The
+ * All APIs provided by this file are protected with INTERRUPTS LOCKED. The
  * APIs themselves are writing the IRQ_SELECT, selecting which IRQ's registers
  * it wants to write to, then write to them: THIS IS NOT AN ATOMIC OPERATION.
  *
- * Not locking the interrupts inside of the APIs allows a caller to:
+ * Locking the interrupts inside of the APIs are some kind of self-protection
+ * to guarantee the correctness of operation if the callers don't lock
+ * the interrupt.
  *
- * - lock interrupts
- * - call many of these APIs
- * - unlock interrupts
- *
- * thus being more efficient then if the APIs themselves would lock
- * interrupts.
  */
 
 /*
@@ -54,8 +51,12 @@ void z_arc_v2_irq_unit_irq_enable_set(
 	unsigned char enable
 	)
 {
+	unsigned int key = arch_irq_lock();
+
 	z_arc_v2_aux_reg_write(_ARC_V2_IRQ_SELECT, irq);
 	z_arc_v2_aux_reg_write(_ARC_V2_IRQ_ENABLE, enable);
+
+	arch_irq_unlock(key);
 }
 
 /*
@@ -97,8 +98,15 @@ void z_arc_v2_irq_unit_int_disable(int irq)
 static ALWAYS_INLINE
 bool z_arc_v2_irq_unit_int_enabled(int irq)
 {
+	bool ret;
+	unsigned int key = arch_irq_lock();
+
 	z_arc_v2_aux_reg_write(_ARC_V2_IRQ_SELECT, irq);
-	return z_arc_v2_aux_reg_read(_ARC_V2_IRQ_ENABLE) & 0x1;
+	ret = z_arc_v2_aux_reg_read(_ARC_V2_IRQ_ENABLE) & 0x1;
+
+	arch_irq_unlock(key);
+
+	return ret;
 }
 
 
@@ -114,6 +122,8 @@ static ALWAYS_INLINE
 void z_arc_v2_irq_unit_prio_set(int irq, unsigned char prio)
 {
 
+	unsigned int key = arch_irq_lock();
+
 	z_arc_v2_aux_reg_write(_ARC_V2_IRQ_SELECT, irq);
 #if defined(CONFIG_ARC_SECURE_FIRMWARE)
 	z_arc_v2_aux_reg_write(_ARC_V2_IRQ_PRIORITY,
@@ -122,23 +132,35 @@ void z_arc_v2_irq_unit_prio_set(int irq, unsigned char prio)
 #else
 	z_arc_v2_aux_reg_write(_ARC_V2_IRQ_PRIORITY, prio);
 #endif
+	arch_irq_unlock(key);
 }
 
 #if defined(CONFIG_ARC_SECURE_FIRMWARE)
+/*
+ * @brief Configure the secure state of interrupt
+ *
+ * Configure the secure state of the specified interrupt
+ *
+ * @return N/A
+ */
 static ALWAYS_INLINE
 void z_arc_v2_irq_uinit_secure_set(int irq, bool secure)
 {
-		z_arc_v2_aux_reg_write(_ARC_V2_IRQ_SELECT, irq);
+	unsigned int key = arch_irq_lock();
 
-		if (secure) {
-			z_arc_v2_aux_reg_write(_ARC_V2_IRQ_PRIORITY,
-			z_arc_v2_aux_reg_read(_ARC_V2_IRQ_PRIORITY)  |
-			_ARC_V2_IRQ_PRIORITY_SECURE);
-		} else {
-			z_arc_v2_aux_reg_write(_ARC_V2_IRQ_PRIORITY,
-			z_arc_v2_aux_reg_read(_ARC_V2_IRQ_PRIORITY) &
-			_ARC_V2_INT_PRIO_MASK);
-		}
+	z_arc_v2_aux_reg_write(_ARC_V2_IRQ_SELECT, irq);
+
+	if (secure) {
+		z_arc_v2_aux_reg_write(_ARC_V2_IRQ_PRIORITY,
+		z_arc_v2_aux_reg_read(_ARC_V2_IRQ_PRIORITY)  |
+		_ARC_V2_IRQ_PRIORITY_SECURE);
+	} else {
+		z_arc_v2_aux_reg_write(_ARC_V2_IRQ_PRIORITY,
+		z_arc_v2_aux_reg_read(_ARC_V2_IRQ_PRIORITY) &
+		_ARC_V2_INT_PRIO_MASK);
+	}
+
+	arch_irq_unlock(key);
 }
 #endif
 
@@ -156,8 +178,12 @@ void z_arc_v2_irq_uinit_secure_set(int irq, bool secure)
 static ALWAYS_INLINE
 void z_arc_v2_irq_unit_sensitivity_set(int irq, int s)
 {
+	unsigned int key = arch_irq_lock();
+
 	z_arc_v2_aux_reg_write(_ARC_V2_IRQ_SELECT, irq);
 	z_arc_v2_aux_reg_write(_ARC_V2_IRQ_TRIGGER, s);
+
+	arch_irq_unlock(key);
 }
 
 /*
@@ -165,7 +191,7 @@ void z_arc_v2_irq_unit_sensitivity_set(int irq, int s)
  *
  * Check whether processor in interrupt/exception state
  *
- * @return N/A
+ * @return 1 in interrupt/exception state; 0 not in
  */
 static ALWAYS_INLINE
 bool z_arc_v2_irq_unit_is_in_isr(void)
@@ -189,8 +215,16 @@ bool z_arc_v2_irq_unit_is_in_isr(void)
  *
  * @return N/A
  */
+static ALWAYS_INLINE
+void z_arc_v2_irq_unit_trigger_set(int irq, unsigned int trigger)
+{
+	unsigned int key = arch_irq_lock();
 
-void z_arc_v2_irq_unit_trigger_set(int irq, unsigned int trigger);
+	z_arc_v2_aux_reg_write(_ARC_V2_IRQ_SELECT, irq);
+	z_arc_v2_aux_reg_write(_ARC_V2_IRQ_TRIGGER, trigger);
+
+	arch_irq_unlock(key);
+}
 
 /*
  * @brief Returns an IRQ line trigger type
@@ -198,10 +232,21 @@ void z_arc_v2_irq_unit_trigger_set(int irq, unsigned int trigger);
  * Gets the IRQ line <irq> trigger type.
  * Valid values for <trigger> are _ARC_V2_INT_LEVEL and _ARC_V2_INT_PULSE.
  *
- * @return N/A
+ * @return trigger state
  */
+static ALWAYS_INLINE
+unsigned int z_arc_v2_irq_unit_trigger_get(int irq)
+{
+	unsigned int ret;
+	unsigned int key = arch_irq_lock();
 
-unsigned int z_arc_v2_irq_unit_trigger_get(int irq);
+	z_arc_v2_aux_reg_write(_ARC_V2_IRQ_SELECT, irq);
+	ret = z_arc_v2_aux_reg_read(_ARC_V2_IRQ_TRIGGER);
+
+	arch_irq_unlock(key);
+
+	return ret;
+}
 
 /*
  * @brief Send EOI signal to interrupt unit
@@ -209,13 +254,18 @@ unsigned int z_arc_v2_irq_unit_trigger_get(int irq);
  * This routine sends an EOI (End Of Interrupt) signal to the interrupt unit
  * to clear a pulse-triggered interrupt.
  *
- * Interrupts must be locked or the ISR operating at P0 when invoking this
- * function.
- *
  * @return N/A
  */
+static ALWAYS_INLINE
+void z_arc_v2_irq_unit_int_eoi(int irq)
+{
+	unsigned int key = arch_irq_lock();
 
-void z_arc_v2_irq_unit_int_eoi(int irq);
+	z_arc_v2_aux_reg_write(_ARC_V2_IRQ_SELECT, irq);
+	z_arc_v2_aux_reg_write(_ARC_V2_IRQ_PULSE_CANCEL, 1);
+
+	arch_irq_unlock(key);
+}
 
 #endif /* _ASMLANGUAGE */
 


### PR DESCRIPTION
When SMP is enabled, the irq_lock/unlock will get and
release a global spin lock, but the codes changed in this
commit only need to lock the local cpu.

No affect on uniprocessor, but optimizations for SMP case.

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>