### PR TITLE
net: tcp2: Fix handling of the END TCP option

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -387,7 +387,9 @@ static bool tcp_options_check(void *buf, ssize_t len)
 
 		NET_DBG("opt: %hu, opt_len: %hu", (u16_t)opt, (u16_t)opt_len);
 
-		if (opt == TCPOPT_END || opt == TCPOPT_NOP) {
+		if (opt == TCPOPT_END) {
+			break;
+		} else if (opt == TCPOPT_NOP) {
 			continue;
 		}
 


### PR DESCRIPTION
End option indicates the end of the option list. Hence, correct way to
handle it is to break out of the option parsing routine.

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>