### PR TITLE
Bluetooth & net: Fix samples and tests to pass correct timeouts

### DIFF
--- a/samples/bluetooth/peripheral/src/main.c
+++ b/samples/bluetooth/peripheral/src/main.c
@@ -335,7 +335,7 @@ void main(void)
 	 * of starting delayed work so we do it here
 	 */
 	while (1) {
-		k_sleep(MSEC_PER_SEC);
+		k_sleep(K_SECONDS(1));
 
 		/* Current Time Service updates only when time is changed */
 		cts_notify();

--- a/samples/bluetooth/peripheral_csc/src/main.c
+++ b/samples/bluetooth/peripheral_csc/src/main.c
@@ -408,7 +408,7 @@ void main(void)
 	bt_conn_cb_register(&conn_callbacks);
 
 	while (1) {
-		k_sleep(MSEC_PER_SEC);
+		k_sleep(K_SECONDS(1));
 
 		/* CSC simulation */
 		if (csc_simulate) {

--- a/samples/bluetooth/peripheral_esp/src/main.c
+++ b/samples/bluetooth/peripheral_esp/src/main.c
@@ -432,7 +432,7 @@ void main(void)
 	bt_conn_auth_cb_register(&auth_cb_display);
 
 	while (1) {
-		k_sleep(MSEC_PER_SEC);
+		k_sleep(K_SECONDS(1));
 
 		/* Temperature simulation */
 		if (simulate_temp) {

--- a/samples/bluetooth/peripheral_hr/src/main.c
+++ b/samples/bluetooth/peripheral_hr/src/main.c
@@ -127,7 +127,7 @@ void main(void)
 	 * of starting delayed work so we do it here
 	 */
 	while (1) {
-		k_sleep(MSEC_PER_SEC);
+		k_sleep(K_SECONDS(1));
 
 		/* Heartrate measurements simulation */
 		hrs_notify();

--- a/samples/bluetooth/peripheral_ht/src/main.c
+++ b/samples/bluetooth/peripheral_ht/src/main.c
@@ -120,7 +120,7 @@ void main(void)
 	 * of starting delayed work so we do it here
 	 */
 	while (1) {
-		k_sleep(MSEC_PER_SEC);
+		k_sleep(K_SECONDS(1));
 
 		/* Temperature measurements simulation */
 		hts_indicate();

--- a/samples/net/cloud/google_iot_mqtt/src/protocol.c
+++ b/samples/net/cloud/google_iot_mqtt/src/protocol.c
@@ -201,7 +201,7 @@ static int wait_for_input(int timeout)
 	return res;
 }
 
-#define ALIVE_TIME	(MSEC_PER_SEC * 60U)
+#define ALIVE_TIME	K_SECONDS(60)
 
 static struct mqtt_utf8 password = {
 	.utf8 = token

--- a/samples/net/cloud/mqtt_azure/src/main.c
+++ b/samples/net/cloud/mqtt_azure/src/main.c
@@ -342,7 +342,7 @@ static void publish_message(void)
 
 end:
 		k_delayed_work_submit(&pub_message,
-				      MSEC_PER_SEC * timeout_for_publish());
+				      K_SECONDS(timeout_for_publish()));
 		k_sem_take(&publish_msg, K_FOREVER);
 	}
 }
@@ -470,7 +470,7 @@ static void check_network_connection(struct k_work *work)
 	LOG_INF("waiting for DHCP to acquire addr");
 
 end:
-	k_delayed_work_submit(&check_network_conn, 3 * MSEC_PER_SEC);
+	k_delayed_work_submit(&check_network_conn, K_SECONDS(3));
 }
 #endif
 
@@ -493,7 +493,7 @@ static void l4_event_handler(struct net_mgmt_event_callback *cb,
 
 	if (mgmt_event == NET_EVENT_L4_CONNECTED) {
 		/* Wait for DHCP to be back in BOUND state */
-		k_delayed_work_submit(&check_network_conn, 3 * MSEC_PER_SEC);
+		k_delayed_work_submit(&check_network_conn, K_SECONDS(3));
 
 		return;
 	}

--- a/samples/net/sockets/coap_server/src/coap-server.c
+++ b/samples/net/sockets/coap_server/src/coap-server.c
@@ -995,7 +995,7 @@ static void update_counter(struct k_work *work)
 		coap_resource_notify(resource_to_notify);
 	}
 
-	k_delayed_work_submit(&observer_work, MSEC_PER_SEC * 5U);
+	k_delayed_work_submit(&observer_work, K_SECONDS(5));
 }
 
 static int create_pending_request(struct coap_packet *response,
@@ -1099,7 +1099,7 @@ static int send_notification_packet(const struct sockaddr *addr,
 		}
 	}
 
-	k_delayed_work_submit(&observer_work, MSEC_PER_SEC * 5U);
+	k_delayed_work_submit(&observer_work, K_SECONDS(5));
 
 	r = send_coap_reply(&response, addr, addr_len);
 

--- a/subsys/net/lib/openthread/platform/uart.c
+++ b/subsys/net/lib/openthread/platform/uart.c
@@ -174,7 +174,7 @@ otError otPlatUartEnable(void)
 	}
 
 	LOG_INF("Wait for host to settle");
-	k_sleep(MSEC_PER_SEC * 1);
+	k_sleep(K_SECONDS(1));
 
 	ret = uart_line_ctrl_get(ot_uart.dev,
 				 UART_LINE_CTRL_BAUD_RATE,

--- a/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect2.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect2.c
@@ -159,7 +159,7 @@ static void test_con2_main(void)
 	 * of starting delayed work so we do it here
 	 */
 	while (1) {
-		k_sleep(MSEC_PER_SEC);
+		k_sleep(K_SECONDS(1));
 
 		/* Heartrate measurements simulation */
 		hrs_notify();

--- a/tests/bluetooth/shell/src/main.c
+++ b/tests/bluetooth/shell/src/main.c
@@ -122,7 +122,7 @@ void main(void)
 	       " the stack.\n");
 
 	while (1) {
-		k_sleep(MSEC_PER_SEC);
+		k_sleep(K_SECONDS(1));
 
 #if defined(CONFIG_BT_GATT_HRS)
 		/* Heartrate measurements simulation */

--- a/tests/net/context/src/main.c
+++ b/tests/net/context/src/main.c
@@ -728,7 +728,7 @@ static void net_ctx_recv_v6_timeout(void)
 	tid = start_timeout_v6_thread(WAIT_TIME_LONG);
 
 	k_sem_reset(&wait_data);
-	k_sem_take(&wait_data, WAIT_TIME_LONG * 2U);
+	k_sem_take(&wait_data, K_MSEC(WAIT_TIME_LONG * 2));
 
 	net_ctx_send_v6();
 
@@ -756,7 +756,7 @@ static void net_ctx_recv_v4_timeout(void)
 	tid = start_timeout_v4_thread(WAIT_TIME_LONG);
 
 	k_sem_reset(&wait_data);
-	k_sem_take(&wait_data, WAIT_TIME_LONG * 2U);
+	k_sem_take(&wait_data, K_MSEC(WAIT_TIME_LONG * 2));
 
 	net_ctx_send_v4();
 
@@ -784,7 +784,7 @@ static void net_ctx_recv_v6_timeout_forever(void)
 	tid = start_timeout_v6_thread(K_FOREVER);
 
 	/* Wait a bit so that we see if recv waited or not */
-	k_sleep(WAIT_TIME);
+	k_sleep(K_MSEC(WAIT_TIME));
 
 	net_ctx_send_v6();
 
@@ -810,7 +810,7 @@ static void net_ctx_recv_v4_timeout_forever(void)
 	tid = start_timeout_v4_thread(K_FOREVER);
 
 	/* Wait a bit so that we see if recv waited or not */
-	k_sleep(WAIT_TIME);
+	k_sleep(K_MSEC(WAIT_TIME));
 
 	net_ctx_send_v4();
 

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -538,7 +538,7 @@ static void test_prefix_timeout(void)
 	net_if_ipv6_prefix_set_lf(prefix, false);
 	net_if_ipv6_prefix_set_timer(prefix, lifetime);
 
-	k_sleep((lifetime * 2U) * MSEC_PER_SEC);
+	k_sleep(K_SECONDS(lifetime * 2U));
 
 	prefix = net_if_ipv6_prefix_lookup(net_if_get_default(),
 					   &addr, len);
@@ -1338,7 +1338,7 @@ static void test_dst_iface_scope_mcast_send(void)
 		      "Interface local scope multicast packet was dropped (%d)",
 		      ret);
 
-	k_sem_take(&wait_data, WAIT_TIME);
+	k_sem_take(&wait_data, K_MSEC(WAIT_TIME));
 
 	zassert_true(recv_cb_called, "No data received on time, "
 		     "IPv6 recv test failed");

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -252,7 +252,7 @@ static void catch_join_group(void)
 
 	join_group();
 
-	if (k_sem_take(&wait_data, WAIT_TIME)) {
+	if (k_sem_take(&wait_data, K_MSEC(WAIT_TIME))) {
 		zassert_true(0, "Timeout while waiting join event");
 	}
 
@@ -269,7 +269,7 @@ static void catch_leave_group(void)
 
 	leave_group();
 
-	if (k_sem_take(&wait_data, WAIT_TIME)) {
+	if (k_sem_take(&wait_data, K_MSEC(WAIT_TIME))) {
 		zassert_true(0, "Timeout while waiting leave event");
 	}
 
@@ -288,7 +288,7 @@ static void verify_join_group(void)
 
 	join_group();
 
-	if (k_sem_take(&wait_data, WAIT_TIME)) {
+	if (k_sem_take(&wait_data, K_MSEC(WAIT_TIME))) {
 		zassert_true(0, "Timeout while waiting join event");
 	}
 
@@ -305,7 +305,7 @@ static void verify_leave_group(void)
 
 	leave_group();
 
-	if (k_sem_take(&wait_data, WAIT_TIME)) {
+	if (k_sem_take(&wait_data, K_MSEC(WAIT_TIME))) {
 		zassert_true(0, "Timeout while waiting leave event");
 	}
 
@@ -413,7 +413,7 @@ static void catch_query(void)
 
 	k_yield();
 
-	if (k_sem_take(&wait_data, WAIT_TIME)) {
+	if (k_sem_take(&wait_data, K_MSEC(WAIT_TIME))) {
 		zassert_true(0, "Timeout while waiting query event");
 	}
 
@@ -440,7 +440,7 @@ static void verify_send_report(void)
 	k_yield();
 
 	/* Did we send a report? */
-	if (k_sem_take(&wait_data, WAIT_TIME)) {
+	if (k_sem_take(&wait_data, K_MSEC(WAIT_TIME))) {
 		zassert_true(0, "Timeout while waiting report");
 	}
 
@@ -461,7 +461,7 @@ static void test_allnodes(void)
 	net_ipv6_addr_create_ll_allnodes_mcast(&addr);
 
 	/* Let the DAD succeed so that the multicast address will be there */
-	k_sleep(DAD_TIMEOUT);
+	k_sleep(K_MSEC(DAD_TIMEOUT));
 
 	ifmaddr = net_if_ipv6_maddr_lookup(&addr, &iface);
 

--- a/tests/net/tcp/src/main.c
+++ b/tests/net/tcp/src/main.c
@@ -1674,7 +1674,7 @@ static bool test_init_tcp_connect(void)
 		return false;
 	}
 
-	if (k_sem_take(&wait_in_accept, WAIT_TIME_LONG)) {
+	if (k_sem_take(&wait_in_accept, K_MSEC(WAIT_TIME_LONG))) {
 		TC_ERROR("Timeout while waiting data back\n");
 		return false;
 	}
@@ -1696,7 +1696,7 @@ static bool test_init_tcp_connect(void)
 
 	DBG("Waiting v6 connection\n");
 
-	if (k_sem_take(&wait_connect, WAIT_TIME_LONG)) {
+	if (k_sem_take(&wait_connect, K_MSEC(WAIT_TIME_LONG))) {
 		TC_ERROR("Timeout while waiting data back\n");
 		return false;
 	}
@@ -1716,7 +1716,7 @@ static bool test_init_tcp_connect(void)
 		return false;
 	}
 
-	k_sem_take(&wait_connect, WAIT_TIME);
+	k_sem_take(&wait_connect, K_MSEC(WAIT_TIME));
 	if (!connect_cb_called) {
 		TC_ERROR("No IPv4 connect cb called on time, "
 			 "TCP connect test failed\n");


### PR DESCRIPTION
With the recent Timeout API merge the kernel APIs take a `k_timeout_t` rather than ` s32_t`, so everything needs to be wrapped through the appropriate macros. Things are passing for now since the `NET_BUF` Kconfig option selects `LEGACY_TIMEOUT_API` however we should work towards converting all other code in our subsystems and then remove that `select` (certainly before the Zephyr 2.3 merge window closes).