### PR TITLE
drivers: entropy: Convert drivers to use DT for label

### DIFF
--- a/drivers/entropy/entropy_gecko_trng.c
+++ b/drivers/entropy/entropy_gecko_trng.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT silabs_gecko_trng
+
  #include <drivers/entropy.h>
  #include <string.h>
  #include "soc.h"
@@ -95,7 +97,7 @@ static struct entropy_driver_api entropy_gecko_trng_api_funcs = {
 	.get_entropy_isr = entropy_gecko_trng_get_entropy_isr
 };
 
-DEVICE_AND_API_INIT(entropy_gecko_trng, CONFIG_ENTROPY_NAME,
+DEVICE_AND_API_INIT(entropy_gecko_trng, DT_INST_LABEL(0),
 			entropy_gecko_trng_init, NULL, NULL,
 			PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 			&entropy_gecko_trng_api_funcs);

--- a/drivers/entropy/entropy_litex.c
+++ b/drivers/entropy/entropy_litex.c
@@ -59,7 +59,7 @@ static const struct entropy_driver_api entropy_prbs_api = {
 	.get_entropy = entropy_prbs_get_entropy
 };
 
-DEVICE_AND_API_INIT(entropy_prbs, CONFIG_ENTROPY_NAME,
+DEVICE_AND_API_INIT(entropy_prbs, DT_INST_LABEL(0),
 		    entropy_prbs_init, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_prbs_api);

--- a/drivers/entropy/entropy_mcux_rnga.c
+++ b/drivers/entropy/entropy_mcux_rnga.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT nxp_kinetis_rnga
+
 #include <device.h>
 #include <drivers/entropy.h>
 #include <random/rand32.h>
@@ -56,7 +58,7 @@ static const struct entropy_driver_api entropy_mcux_rnga_api_funcs = {
 
 static int entropy_mcux_rnga_init(struct device *);
 
-DEVICE_AND_API_INIT(entropy_mcux_rnga, CONFIG_ENTROPY_NAME,
+DEVICE_AND_API_INIT(entropy_mcux_rnga, DT_INST_LABEL(0),
 		    entropy_mcux_rnga_init, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_mcux_rnga_api_funcs);

--- a/drivers/entropy/entropy_mcux_trng.c
+++ b/drivers/entropy/entropy_mcux_trng.c
@@ -41,7 +41,7 @@ static struct mcux_entropy_config entropy_mcux_config = {
 
 static int entropy_mcux_trng_init(struct device *);
 
-DEVICE_AND_API_INIT(entropy_mcux_trng, CONFIG_ENTROPY_NAME,
+DEVICE_AND_API_INIT(entropy_mcux_trng, DT_INST_LABEL(0),
 		    entropy_mcux_trng_init, NULL, &entropy_mcux_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_mcux_trng_api_funcs);

--- a/drivers/entropy/entropy_sam.c
+++ b/drivers/entropy/entropy_sam.c
@@ -181,7 +181,7 @@ static const struct trng_sam_dev_cfg trng_sam_cfg = {
 	.regs = (Trng *)DT_INST_REG_ADDR(0),
 };
 
-DEVICE_AND_API_INIT(entropy_sam, CONFIG_ENTROPY_NAME,
+DEVICE_AND_API_INIT(entropy_sam, DT_INST_LABEL(0),
 		    entropy_sam_init, NULL, &trng_sam_cfg,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_sam_api);


### PR DESCRIPTION
Move towards use DTS for driver instance name instead of Kconfig sybmol.
This is towards phasing out CONFIG_ENTROPY_NAME.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>