### PR TITLE
drivers: entropy: Add DTS support to native-posix fake entropy driver

### DIFF
--- a/boards/posix/native_posix/dts_fixup.h
+++ b/boards/posix/native_posix/dts_fixup.h
@@ -6,3 +6,4 @@
 
 #define DT_FLASH_DEV_NAME   DT_LABEL(DT_INST(0, zephyr_sim_flash))
 #define DT_UART_0_DEV_NAME  DT_ZEPHYR_NATIVE_POSIX_UART_UART_LABEL
+#define CONFIG_ENTROPY_NAME DT_LABEL(DT_INST(0, zephyr_native_posix_rng))

--- a/boards/posix/native_posix/native_posix.dts
+++ b/boards/posix/native_posix/native_posix.dts
@@ -84,4 +84,11 @@
 		 */
 		current-speed = <0>;
 	};
+
+	rng {
+		status = "okay";
+		compatible = "zephyr,native-posix-rng";
+		label = "ENTROPY_0";
+	};
+
 };

--- a/drivers/entropy/Kconfig.native_posix
+++ b/drivers/entropy/Kconfig.native_posix
@@ -4,6 +4,7 @@ config FAKE_ENTROPY_NATIVE_POSIX
 	bool "Native posix entropy driver"
 	depends on ARCH_POSIX
 	select ENTROPY_HAS_DRIVER
+	select HAS_DTS_ENTROPY
 	help
 	  This option enables the test random number generator for the
 	  native_posix board (ARCH_POSIX). This is based on the host random() API.

--- a/drivers/entropy/fake_entropy_native_posix.c
+++ b/drivers/entropy/fake_entropy_native_posix.c
@@ -11,6 +11,8 @@
  * This entropy source should only be used for testing.
  */
 
+#define DT_DRV_COMPAT zephyr_native_posix_rng
+
 #include "device.h"
 #include <drivers/entropy.h>
 #include "init.h"
@@ -71,7 +73,7 @@ static const struct entropy_driver_api entropy_native_posix_api_funcs = {
 	.get_entropy_isr = entropy_native_posix_get_entropy_isr
 };
 
-DEVICE_AND_API_INIT(entropy_native_posix, CONFIG_ENTROPY_NAME,
+DEVICE_AND_API_INIT(entropy_native_posix, DT_INST_LABEL(0),
 		    entropy_native_posix_init, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_native_posix_api_funcs);

--- a/dts/bindings/rng/zephyr,native-posix-rng.yaml
+++ b/dts/bindings/rng/zephyr,native-posix-rng.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2020, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: Native POSIX RNG/Entropy
+
+compatible: "zephyr,native-posix-rng"
+
+include: base.yaml
+
+properties:
+    label:
+      required: true


### PR DESCRIPTION
Add a YAML and DTS node for fake entropy driver.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>