### PR TITLE
devicetree: add DT_CHILD()

### DIFF
--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -209,6 +209,32 @@
 #define DT_INST(inst, compat) UTIL_CAT(DT_N_INST, DT_DASH(inst, compat))
 
 /**
+ * @brief Get a node identifier for a child node
+ *
+ * Example devicetree fragment:
+ *
+ *     / {
+ *             soc-label: soc {
+ *                     my-serial: serial@4 {
+ *                             status = "okay";
+ *                             current-speed = <115200>;
+ *                             ...
+ *                     };
+ *             };
+ *     };
+ *
+ * Example usage with @ref DT_PROP() to get the status of the child node
+ * "serial@4" of the node referenced by node label "soc-label":
+ *
+ *     DT_PROP(DT_CHILD(DT_NODELABEL(soc_label), serial_4), status) // "okay"
+ *
+ * @param node_id node identifier
+ * @param child lowercase-and-underscores child node name
+ * @return node identifier for the node with the name referred to by 'child'
+ */
+#define DT_CHILD(node_id, child) UTIL_CAT(node_id, DT_S_PREFIX(child))
+
+/**
  * @}
  */
 

--- a/tests/lib/devicetree/src/main.c
+++ b/tests/lib/devicetree/src/main.c
@@ -899,6 +899,12 @@ static void test_macro_names(void)
 	zassert_true(!strcmp(TO_STRING(DT_NODELABEL(test_nodelabel_allcaps)),
 			     "DT_N_S_test_S_gpio_deadbeef"),
 		     "nodelabel (all caps)");
+
+#define CHILD_NODE_ID DT_CHILD(DT_PATH(test, i2c_11112222), test_i2c_dev_10)
+#define FULL_PATH_ID DT_PATH(test, i2c_11112222, test_i2c_dev_10)
+
+	zassert_true(!strcmp(TO_STRING(CHILD_NODE_ID), TO_STRING(FULL_PATH_ID)),
+		     "child");
 }
 
 static int a[] = DT_PROP(TEST_ARRAYS, a);


### PR DESCRIPTION
Helper macro to get a node_id for a child node of a given node_id.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>