### PR TITLE
coccinelle: update timeout support script and apply patches

### DIFF
--- a/drivers/adc/adc_lmp90xxx.c
+++ b/drivers/adc/adc_lmp90xxx.c
@@ -609,7 +609,7 @@ static int lmp90xxx_adc_read_channel(struct device *dev, u8_t channel,
 						&adc_done);
 			if (adc_done == 0xFFU) {
 				LOG_DBG("sleeping for 1 ms");
-				k_sleep(1);
+				k_sleep(K_MSEC(1));
 			} else {
 				break;
 			}

--- a/drivers/ethernet/phy_gecko.c
+++ b/drivers/ethernet/phy_gecko.c
@@ -44,7 +44,7 @@ static int mdio_bus_wait(ETH_TypeDef *eth)
 			return -ETIMEDOUT;
 		}
 
-		k_sleep(10);
+		k_sleep(K_MSEC(10));
 	}
 
 	return 0;
@@ -127,7 +127,7 @@ static int phy_soft_reset(const struct phy_gecko_dev *phy)
 			return -ETIMEDOUT;
 		}
 
-		k_sleep(50);
+		k_sleep(K_MSEC(50));
 
 		retval = phy_read(phy, MII_BMCR, &phy_reg);
 		if (retval < 0) {
@@ -228,7 +228,7 @@ int phy_gecko_auto_negotiate(const struct phy_gecko_dev *phy,
 			goto auto_negotiate_exit;
 		}
 
-		k_sleep(100);
+		k_sleep(K_MSEC(100));
 
 		retval = phy_read(phy, MII_BMSR, &val);
 		if (retval < 0) {

--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -94,11 +94,11 @@ void SX1276Reset(void)
 	gpio_pin_configure(dev_data.reset, GPIO_RESET_PIN,
 			   GPIO_OUTPUT_ACTIVE | GPIO_RESET_FLAGS);
 
-	k_sleep(1);
+	k_sleep(K_MSEC(1));
 
 	gpio_pin_set(dev_data.reset, GPIO_RESET_PIN, 0);
 
-	k_sleep(6);
+	k_sleep(K_MSEC(6));
 }
 
 void BoardCriticalSectionBegin(uint32_t *mask)
@@ -489,9 +489,9 @@ static int sx1276_lora_init(struct device *dev)
 	ret = gpio_pin_configure(dev_data.reset, GPIO_RESET_PIN,
 				 GPIO_OUTPUT_ACTIVE | GPIO_RESET_FLAGS);
 
-	k_sleep(100);
+	k_sleep(K_MSEC(100));
 	gpio_pin_set(dev_data.reset, GPIO_RESET_PIN, 0);
-	k_sleep(100);
+	k_sleep(K_MSEC(100));
 
 	ret = sx1276_read(SX1276_REG_VERSION, &regval, 1);
 	if (ret < 0) {

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -351,7 +351,7 @@ static int gsm_init(struct device *device)
 
 	k_delayed_work_init(&gsm->gsm_configure_work, gsm_configure);
 
-	(void)k_delayed_work_submit(&gsm->gsm_configure_work, 0);
+	(void)k_delayed_work_submit(&gsm->gsm_configure_work, K_NO_WAIT);
 
 	LOG_DBG("iface->read %p iface->write %p",
 		gsm->context.iface.read, gsm->context.iface.write);

--- a/drivers/sensor/ccs811/ccs811_trigger.c
+++ b/drivers/sensor/ccs811/ccs811_trigger.c
@@ -189,7 +189,7 @@ int ccs811_init_interrupt(struct device *dev)
 			CONFIG_CCS811_THREAD_STACK_SIZE,
 			(k_thread_entry_t)irq_thread, dev,
 			0, NULL, K_PRIO_COOP(CONFIG_CCS811_THREAD_PRIORITY),
-			0, 0);
+			0, K_NO_WAIT);
 #elif defined(CONFIG_CCS811_TRIGGER_GLOBAL_THREAD)
 	drv_data->work.handler = work_cb;
 #else

--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -258,7 +258,7 @@ static int _sock_send(struct esp_data *dev, struct esp_socket *sock)
 	k_sem_give(&dev->iface_data.rx_sem);
 
 	/* Wait for '>' */
-	ret = k_sem_take(&dev->sem_tx_ready, 5000);
+	ret = k_sem_take(&dev->sem_tx_ready, K_MSEC(5000));
 	if (ret < 0) {
 		LOG_DBG("Timeout waiting for tx");
 		goto out;

--- a/samples/basic/blink_led/src/main.c
+++ b/samples/basic/blink_led/src/main.c
@@ -89,6 +89,6 @@ void main(void)
 			}
 		}
 
-		k_sleep(K_MSEC(MSEC_PER_SEC * 4U));
+		k_sleep(K_SECONDS(4U));
 	}
 }

--- a/samples/basic/fade_led/src/main.c
+++ b/samples/basic/fade_led/src/main.c
@@ -74,6 +74,6 @@ void main(void)
 			}
 		}
 
-		k_sleep(K_MSEC(MSEC_PER_SEC));
+		k_sleep(K_SECONDS(1));
 	}
 }

--- a/samples/basic/rgb_led/src/main.c
+++ b/samples/basic/rgb_led/src/main.c
@@ -104,7 +104,7 @@ void main(void)
 						printk("pin 2 write fails!\n");
 						return;
 					}
-					k_sleep(K_MSEC(MSEC_PER_SEC));
+					k_sleep(K_SECONDS(1));
 				}
 			}
 		}

--- a/samples/basic/servo_motor/src/main.c
+++ b/samples/basic/servo_motor/src/main.c
@@ -66,6 +66,6 @@ void main(void)
 			}
 		}
 
-		k_sleep(K_MSEC(MSEC_PER_SEC));
+		k_sleep(K_SECONDS(1));
 	}
 }

--- a/samples/drivers/lora/send/src/main.c
+++ b/samples/drivers/lora/send/src/main.c
@@ -54,6 +54,6 @@ void main(void)
 		LOG_INF("Data sent!");
 
 		/* Send data at 1s interval */
-		k_sleep(1000);
+		k_sleep(K_MSEC(1000));
 	}
 }

--- a/samples/drivers/peci/src/main.c
+++ b/samples/drivers/peci/src/main.c
@@ -87,7 +87,7 @@ int peci_get_tjmax(u8_t *tjmax)
 
 		peci_resp = packet.rx_buffer.buf[0];
 		rx_fcs = packet.rx_buffer.buf[PECI_RD_PKG_LEN_DWORD];
-		k_sleep(1);
+		k_sleep(K_MSEC(1));
 		printk("\npeci_resp %x\n", peci_resp);
 		retries--;
 	} while ((peci_resp != PECI_RW_PKG_CFG_RSP_PASS) && (retries > 0));
@@ -167,7 +167,7 @@ void get_max_temp(void)
 static void monitor_temperature_func(void *dummy1, void *dummy2, void *dummy3)
 {
 	while (true) {
-		k_sleep(1000);
+		k_sleep(K_MSEC(1000));
 		if (peci_initialized) {
 			read_temp();
 		}

--- a/samples/shields/lmp90100_evb/rtd/src/main.c
+++ b/samples/shields/lmp90100_evb/rtd/src/main.c
@@ -94,6 +94,6 @@ void main(void)
 						resistance));
 		}
 
-		k_sleep(1000);
+		k_sleep(K_MSEC(1000));
 	}
 }

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -232,7 +232,7 @@ static void seg_tx_unblock_check(struct seg_tx *tx)
 		BT_DBG("Unblocked 0x%04x",
 		       (u16_t)(blocked->seq_auth & TRANS_SEQ_ZERO_MASK));
 		blocked->blocked = false;
-		k_delayed_work_submit(&blocked->retransmit, 0);
+		k_delayed_work_submit(&blocked->retransmit, K_NO_WAIT);
 	}
 }
 

--- a/subsys/canbus/canopen/canopen_sync.c
+++ b/subsys/canbus/canopen/canopen_sync.c
@@ -47,4 +47,4 @@ static void canopen_sync_thread(void *p1, void *p2, void *p3)
 
 K_THREAD_DEFINE(canopen_sync, CONFIG_CANOPEN_SYNC_THREAD_STACK_SIZE,
 		canopen_sync_thread, NULL, NULL, NULL,
-		CONFIG_CANOPEN_SYNC_THREAD_PRIORITY, 0, K_MSEC(1));
+		CONFIG_CANOPEN_SYNC_THREAD_PRIORITY, 0, 1);


### PR DESCRIPTION
The timeout API rework reversed a previous change for `K_THREAD_DEFINE()` that used a timeout value for the start delay, returning it to a value in milliseconds.   Reverse the corresponding semantic patch.

The original semantic patch only converted integer literals.  Expand this to also convert expressions that are clearly integer values (generally a multiple of `MSEC_PER_SEC`).

Apply the updated changes.

Note that this cannot fix all situations: code like:

    k_sleep(TIMEOUT);

may or may not be correct depending on how `TIMEOUT` is defined:

    #define TIMEOUT 10
    #define TIMEOUT K_MSEC(10)