### PR TITLE
driver: timer: st_stm32: fix build with the new timeout API

### DIFF
--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -188,7 +188,7 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 	LL_LPTIM_ClearFlag_ARROK(LPTIM1);
 
 #ifdef CONFIG_TICKLESS_KERNEL
-	if (ticks == K_FOREVER) {
+	if (ticks == K_TICKS_FOREVER) {
 		/* disable LPTIM */
 		LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_LPTIM1);
 		LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_LPTIM1);


### PR DESCRIPTION
Commit 7832738ae985 ("kernel/timeout: Make timeout arguments an opaque
type") changed the forever value for timer drivers to K_TICKS_FOREVER
from K_FOREVER.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>