### PR TITLE
drivers: wifi: esp: Fix DT_DRV_COMPAT to match binding

### DIFF
--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT espressif_esp_wifi
+#define DT_DRV_COMPAT espressif_esp
 
 #define LOG_LEVEL CONFIG_WIFI_LOG_LEVEL
 #include <logging/log.h>


### PR DESCRIPTION
Change DT_DRV_COMPAT to espressif_esp to match the dts binding
"espressif,esp".

Signed-off-by: Tobias Svehagen <tobias.svehagen@gmail.com>