### PR TITLE
samples: drivers/entropy yaml regex fix

### DIFF
--- a/samples/drivers/entropy/sample.yaml
+++ b/samples/drivers/entropy/sample.yaml
@@ -11,4 +11,4 @@ tests:
       regex:
         - "Entropy Example! (.*)"
         - "entropy device is (.*), name is (.*)"
-        - "(  0x([0-9a-f]){2}){9}"
+        - "(\\s*0x([0-9a-f]){2}){9}"


### PR DESCRIPTION
The last regex in the yaml file did not match when executing the test on
an embedded target. The expected two spaces are not present at the
beginning of the line.

Fixes #23919

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>