### PR TITLE
samples: wpan_serial: enable USB during sample initialization

### DIFF
--- a/samples/net/wpan_serial/src/main.c
+++ b/samples/net/wpan_serial/src/main.c
@@ -536,6 +536,9 @@ void main(void)
 		uart_line_ctrl_get(dev, UART_LINE_CTRL_DTR, &dtr);
 		if (dtr) {
 			break;
+		} else {
+			/* Give CPU resources to low priority threads. */
+			k_sleep(K_MSEC(100));
 		}
 	}
 

--- a/samples/net/wpan_serial/src/main.c
+++ b/samples/net/wpan_serial/src/main.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(wpan_serial, CONFIG_USB_DEVICE_LOG_LEVEL);
 
 #include <drivers/uart.h>
 #include <zephyr.h>
+#include <usb/usb_device.h>
 
 #include <net/buf.h>
 #include <net_private.h>
@@ -520,6 +521,12 @@ void main(void)
 	dev = device_get_binding("CDC_ACM_0");
 	if (!dev) {
 		LOG_ERR("CDC ACM device not found");
+		return;
+	}
+
+	ret = usb_enable(NULL);
+	if (ret != 0) {
+		LOG_ERR("Failed to enable USB");
 		return;
 	}
 


### PR DESCRIPTION
samples: wpan_serial: enable USB during sample initialization
Application is reponsible to enable USB.

Relax wait-for-dtr loop and give CPU resources to
low priority threads like logging.
