### PR TITLE
dts: nrf: Correct the number of pins available in gpio1

### DIFF
--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -132,6 +132,7 @@
 			reg = <0x50000300 0x200
 			       0x50000800 0x300>;
 			#gpio-cells = <2>;
+			ngpios = <10>;
 			label = "GPIO_1";
 			status = "disabled";
 		};

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -131,6 +131,7 @@
 			reg = <0x50000300 0x200
 			       0x50000800 0x300>;
 			#gpio-cells = <2>;
+			ngpios = <16>;
 			label = "GPIO_1";
 			status = "disabled";
 		};

--- a/dts/arm/nordic/nrf5340_cpuapp_common.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_common.dtsi
@@ -339,6 +339,7 @@ gpio1: gpio@842800 {
 	gpio-controller;
 	reg = <0x842800 0x300>;
 	#gpio-cells = <2>;
+	ngpios = <16>;
 	label = "GPIO_1";
 	status = "disabled";
 };

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -111,6 +111,7 @@
 			gpio-controller;
 			reg = <0x418c0800 0x300>;
 			#gpio-cells = <2>;
+			ngpios = <16>;
 			label = "GPIO_1";
 			status = "disabled";
 		};


### PR DESCRIPTION
Currently supported nRF SoCs featuring the second GPIO port (P1) do not
have all 32 pins implemented in that port. Add the "ngpios" property
in gpio1 nodes for these SoCs, so that they don't take the default
value of 32 to indicate the number of available pins but use instead:
- 10 for nRF52833
- 16 for nRF52840
- 16 for nRF5340 (both application and network core)

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>