### PR TITLE
Arch arm cortex m vector table rework

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/fault.c
+++ b/arch/arm/core/aarch32/cortex_m/fault.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014 Wind River Systems, Inc.
+ * Copyright (c) 2020 Nordic Semiconductor ASA.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/arch/arm/core/aarch32/cortex_m/vector_table.S
+++ b/arch/arm/core/aarch32/cortex_m/vector_table.S
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2015 Wind River Systems, Inc.
+ * Copyright (c) 2020 Nordic Semiconductor ASA.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -55,7 +56,7 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
 #if defined(CONFIG_ARM_SECURE_FIRMWARE)
     .word z_arm_secure_fault
 #else
-    .word z_arm_reserved
+    .word z_arm_exc_spurious
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
 #else
     .word 0
@@ -74,7 +75,7 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
 #if defined(CONFIG_SYS_CLOCK_EXISTS) && defined(CONFIG_CORTEX_M_SYSTICK)
     .word z_clock_isr
 #else
-    .word z_arm_reserved
+    .word z_arm_exc_spurious
 #endif /* CONFIG_SYS_CLOCK_EXISTS && CONFIG_CORTEX_M_SYSTICK */
 #else
     .word 0

--- a/arch/arm/core/aarch32/cortex_m/vector_table.S
+++ b/arch/arm/core/aarch32/cortex_m/vector_table.S
@@ -38,15 +38,15 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
 
     .word z_arm_hard_fault
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-    .word z_arm_reserved
-    .word z_arm_reserved
-    .word z_arm_reserved
-    .word z_arm_reserved
-    .word z_arm_reserved
-    .word z_arm_reserved
-    .word z_arm_reserved
+    .word 0
+    .word 0
+    .word 0
+    .word 0
+    .word 0
+    .word 0
+    .word 0
     .word z_arm_svc
-    .word z_arm_reserved
+    .word 0
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
     .word z_arm_mpu_fault
     .word z_arm_bus_fault
@@ -56,15 +56,15 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
 #else
     .word z_arm_reserved
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
-    .word z_arm_reserved
-    .word z_arm_reserved
-    .word z_arm_reserved
+    .word 0
+    .word 0
+    .word 0
     .word z_arm_svc
     .word z_arm_debug_monitor
 #else
 #error Unknown ARM architecture
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
-    .word z_arm_reserved
+    .word 0
     .word z_arm_pendsv
 #if defined(CONFIG_SYS_CLOCK_EXISTS)
     .word z_clock_isr

--- a/arch/arm/core/aarch32/cortex_m/vector_table.S
+++ b/arch/arm/core/aarch32/cortex_m/vector_table.S
@@ -66,9 +66,13 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
     .word 0
     .word z_arm_pendsv
-#if defined(CONFIG_SYS_CLOCK_EXISTS)
+#if defined(CONFIG_CPU_CORTEX_M_HAS_SYSTICK)
+#if defined(CONFIG_SYS_CLOCK_EXISTS) && defined(CONFIG_CORTEX_M_SYSTICK)
     .word z_clock_isr
 #else
     .word z_arm_reserved
-#endif
+#endif /* CONFIG_SYS_CLOCK_EXISTS && CONFIG_CORTEX_M_SYSTICK */
+#else
+    .word 0
+#endif /* CONFIG_CPU_CORTEX_M_HAS_SYSTICK */
 

--- a/arch/arm/core/aarch32/cortex_m/vector_table.S
+++ b/arch/arm/core/aarch32/cortex_m/vector_table.S
@@ -51,11 +51,15 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
     .word z_arm_mpu_fault
     .word z_arm_bus_fault
     .word z_arm_usage_fault
+#if defined(CONFIG_ARMV8_M_SE)
 #if defined(CONFIG_ARM_SECURE_FIRMWARE)
     .word z_arm_secure_fault
 #else
     .word z_arm_reserved
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
+#else
+    .word 0
+#endif /* CONFIG_ARMV8_M_SE */
     .word 0
     .word 0
     .word 0

--- a/arch/arm/core/aarch32/cortex_m/vector_table.h
+++ b/arch/arm/core/aarch32/cortex_m/vector_table.h
@@ -48,7 +48,7 @@ GTEXT(z_arm_debug_monitor)
 #error Unknown ARM architecture
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 GTEXT(z_arm_pendsv)
-GTEXT(z_arm_reserved)
+GTEXT(z_arm_exc_spurious)
 
 GTEXT(z_arm_prep_c)
 GTEXT(_isr_wrapper)

--- a/arch/arm/core/aarch32/fault_s.S
+++ b/arch/arm/core/aarch32/fault_s.S
@@ -20,6 +20,7 @@ _ASM_FILE_PROLOGUE
 GTEXT(z_arm_fault)
 
 GTEXT(z_arm_hard_fault)
+#if defined(CONFIG_CPU_CORTEX_M)
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
 /* HardFault is used for all fault conditions on ARMv6-M. */
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
@@ -30,14 +31,16 @@ GTEXT(z_arm_usage_fault)
 GTEXT(z_arm_secure_fault)
 #endif /* CONFIG_ARM_SECURE_FIRMWARE*/
 GTEXT(z_arm_debug_monitor)
-#elif defined(CONFIG_ARMV7_R)
+#endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
+GTEXT(z_arm_exc_spurious)
+#elif defined(CONFIG_CPU_CORTEX_R)
 GTEXT(z_arm_undef_instruction)
 GTEXT(z_arm_prefetch_abort)
 GTEXT(z_arm_data_abort)
+GTEXT(z_arm_reserved)
 #else
 #error Unknown ARM architecture
-#endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
-GTEXT(z_arm_reserved)
+#endif /* CONFIG_CPU_CORTEX_M */
 
 /**
  *
@@ -64,10 +67,12 @@ GTEXT(z_arm_reserved)
  *   z_arm_usage_fault
  *   z_arm_secure_fault
  *   z_arm_debug_monitor
+ *   z_arm_exc_spurious
  *   z_arm_reserved
  */
 
 SECTION_SUBSEC_FUNC(TEXT,__fault,z_arm_hard_fault)
+#if defined(CONFIG_CPU_CORTEX_M)
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
 /* HardFault is used for all fault conditions on ARMv6-M. */
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
@@ -78,23 +83,24 @@ SECTION_SUBSEC_FUNC(TEXT,__fault,z_arm_usage_fault)
 SECTION_SUBSEC_FUNC(TEXT,__fault,z_arm_secure_fault)
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
 SECTION_SUBSEC_FUNC(TEXT,__fault,z_arm_debug_monitor)
-#elif defined(CONFIG_ARMV7_R)
+#endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
+SECTION_SUBSEC_FUNC(TEXT,__fault,z_arm_exc_spurious)
+#elif defined(CONFIG_CPU_CORTEX_R)
 SECTION_SUBSEC_FUNC(TEXT,__fault,z_arm_undef_instruction)
 SECTION_SUBSEC_FUNC(TEXT,__fault,z_arm_prefetch_abort)
 SECTION_SUBSEC_FUNC(TEXT,__fault,z_arm_data_abort)
+SECTION_SUBSEC_FUNC(TEXT,__fault,z_arm_reserved)
 #else
 #error Unknown ARM architecture
-#endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
-SECTION_SUBSEC_FUNC(TEXT,__fault,z_arm_reserved)
+#endif /* CONFIG_CPU_CORTEX_M */
 
-#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) || \
-	defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+#if defined(CONFIG_CPU_CORTEX_M)
 	mrs r0, MSP
 	mrs r1, PSP
 	mov r2, lr /* EXC_RETURN */
 
 	push {r0, lr}
-#elif defined(CONFIG_ARMV7_R)
+#elif defined(CONFIG_CPU_CORTEX_R)
 	/*
 	 * Pass null for the esf to z_arm_fault for now. A future PR will add
 	 * better exception debug for Cortex-R that subsumes what esf

--- a/tests/arch/arm/arm_interrupt/README.txt
+++ b/tests/arch/arm/arm_interrupt/README.txt
@@ -7,7 +7,8 @@ Description:
 The first test verifies that we can handle system fault conditions
 while running in handler mode (i.e. in an ISR). Only for ARM
 Cortex-M targets. The test also verifies the behavior of the
-spurious interrupt handler.
+spurious interrupt handler, as well as the ARM spurious exception
+handler.
 
 The second test verifies that threads in user mode, despite being able to call
 the irq_lock() and irq_unlock() functions without triggering a CPU fault,


### PR DESCRIPTION
Ready for review.
This PR does the following changes
- removes z_arm_reserved function pointer from the Cortex-M vector table entries that correspond to exceptions reserved for future use by the ARM specification. This should be a "no-op" as these addresses are not read/written/fetched by the code. The entries are set to 0x0.
- renames z_arm_reserved to z_arm_exc_spurious and use the function pointer for vector entries that correspond to existing but not used exception
- adds a test to verify the behavior of z_arm_exc_spurious




