### PR TITLE
boards: up_squared_adsp: Add flasher script

### DIFF
--- a/boards/xtensa/up_squared_adsp/tools/up_squared_adsp_flash.sh
+++ b/boards/xtensa/up_squared_adsp/tools/up_squared_adsp_flash.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Copyright (c) 2020 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+BUILD=$1
+FIRMWARE=${BUILD}/zephyr/zephyr.ri
+FLASHER=${ZEPHYR_BASE}/boards/xtensa/up_squared_adsp/tools/fw_loader.py
+
+if [ -z "$2" ]
+  then
+    echo "Signing using default key"
+    west sign -d ${BUILD} -t rimage
+else
+    echo "Signing with key " $key
+    west sign -d ${BUILD} -t rimage -- -k $2
+fi
+
+${FLASHER} -f ${FIRMWARE} 2>&1


### PR DESCRIPTION
Add script signing and flashing up_squared_adsp board. Can be used with command below:

```
$ west flash <PATH>/boards/xtensa/up_squared_adsp/tools/up_squared_adsp_flash.sh
```