### PR TITLE
soc: arm: stm32l4: Remove Kconfig symbol GPIO_STM32_PORTH to fix build

### DIFF
--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l422xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l422xx
@@ -11,8 +11,4 @@ config SOC
 config NUM_IRQS
 	default 83
 
-config GPIO_STM32_PORTH
-	default y
-	depends on GPIO_STM32
-
 endif # SOC_STM32L422XX


### PR DESCRIPTION
Recent stm32 gpio driver changed removed the per port Kconfig symbols.
We had a type in flight issue in which the stm32l422xx got added and set
GPIO_STM32_PORTH.  Just remove the Kconfig symbol as its not needed
anymore to fix build issues.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>