### PR TITLE
Bluetooth: Fix read_cb return value and other minor issues

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ll_settings.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_settings.c
@@ -46,7 +46,8 @@ bool ll_settings_smi_tx(void)
 static int ctlr_set(const char *name, size_t len_rd,
 		    settings_read_cb read_cb, void *store)
 {
-	int len, nlen;
+	ssize_t len;
+	int nlen;
 	const char *next;
 
 	nlen = settings_name_next(name, &next);

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -3826,7 +3826,8 @@ static int ccc_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 		struct ccc_store ccc_store[CCC_STORE_MAX];
 		struct ccc_load load;
 		bt_addr_le_t addr;
-		int len, err;
+		ssize_t len;
+		int err;
 		const char *next;
 
 		settings_name_next(name, &next);
@@ -4200,7 +4201,8 @@ static int sc_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 	struct gatt_sc_cfg *cfg;
 	u8_t id;
 	bt_addr_le_t addr;
-	int len, err;
+	ssize_t len;
+	int err;
 	const char *next;
 
 	if (!name) {
@@ -4276,7 +4278,8 @@ static int cf_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 	struct gatt_cf_cfg *cfg;
 	bt_addr_le_t addr;
 	const char *next;
-	int len, err;
+	ssize_t len;
+	int err;
 	u8_t id;
 
 	if (!name) {
@@ -4331,7 +4334,7 @@ static u8_t stored_hash[16];
 static int db_hash_set(const char *name, size_t len_rd,
 		       settings_read_cb read_cb, void *cb_arg)
 {
-	int len;
+	ssize_t len;
 
 	len = read_cb(cb_arg, stored_hash, sizeof(stored_hash));
 	if (len < 0) {

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -7369,7 +7369,7 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 		}
 	}
 
-	if (param->options & BT_LE_ADV_OPT_SCANNABLE || has_scan_data) {
+	if ((param->options & BT_LE_ADV_OPT_SCANNABLE) || has_scan_data) {
 		cp->props |= BT_HCI_LE_ADV_PROP_SCAN;
 	}
 

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -298,7 +298,7 @@ static int keys_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 	struct bt_keys *keys;
 	bt_addr_le_t addr;
 	u8_t id;
-	size_t len;
+	ssize_t len;
 	int err;
 	char val[BT_KEYS_STORAGE_LEN];
 	const char *next;

--- a/subsys/bluetooth/mesh/pb_adv.c
+++ b/subsys/bluetooth/mesh/pb_adv.c
@@ -374,7 +374,7 @@ static void gen_prov_ack(struct prov_rx *rx, struct net_buf_simple *buf)
 			prov_clear_tx();
 		}
 
-		if (link.tx.cb && link.tx.cb) {
+		if (link.tx.cb) {
 			link.tx.cb(0, link.tx.cb_data);
 		}
 	}

--- a/subsys/bluetooth/services/dis.c
+++ b/subsys/bluetooth/services/dis.c
@@ -145,7 +145,8 @@ BT_GATT_SERVICE_DEFINE(dis_svc,
 static int dis_set(const char *name, size_t len_rd,
 		   settings_read_cb read_cb, void *store)
 {
-	int len, nlen;
+	ssize_t len;
+	int nlen;
 	const char *next;
 
 	nlen = settings_name_next(name, &next);

--- a/subsys/canbus/canopen/canopen_storage.c
+++ b/subsys/canbus/canopen/canopen_storage.c
@@ -127,7 +127,7 @@ static int canopen_settings_set(const char *key, size_t len_rd,
 {
 	const char *next;
 	int nlen;
-	int len;
+	ssize_t len;
 
 	nlen = settings_name_next(key, &next);
 


### PR DESCRIPTION
Fix read_cb return value.
Used with int many places
Used with size_t in keys_set which means error handling is wrong

Fix redudant expression, checking for callback twice.
Fix parenthesis around bitmask check.