### PR TITLE
logging: net: Avoid copying too much data

### DIFF
--- a/subsys/logging/log_backend_net.c
+++ b/subsys/logging/log_backend_net.c
@@ -111,7 +111,7 @@ static int do_net_init(void)
 	}
 
 	if (IS_ENABLED(CONFIG_NET_HOSTNAME_ENABLE)) {
-		(void)memcpy(hostname, net_hostname_get(), MAX_HOSTNAME_LEN);
+		(void)strncpy(hostname, net_hostname_get(), MAX_HOSTNAME_LEN);
 
 	} else if (IS_ENABLED(CONFIG_NET_IPV6) &&
 		   server_addr.sa_family == AF_INET6) {


### PR DESCRIPTION
Use strncpy() in order to avoid copying extra data to hostname buffer.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>