### PR TITLE
doc: relnotes: Add a short comment about the timeout change

### DIFF
--- a/doc/releases/release-notes-2.3.rst
+++ b/doc/releases/release-notes-2.3.rst
@@ -24,6 +24,16 @@ API Changes
 Deprecated in this release
 ==========================
 
+* Kernel
+
+  * k_uptime_delta_32(), use k_uptime_delta()
+  * Timeout values
+
+    * All timeout values are now encapsulated k_timeout_t opaque structure when
+      passing them to the kernel. If you want to revert to the previous s32_t
+      type for the timeout parameter pleae enable the
+      CONFIG_LEGACY_TIMEOUT_API Kconfig option
+
 * Bluetooth
 
   * BT_LE_SCAN_FILTER_DUPLICATE, use BT_LE_SCAN_OPT_FILTER_DUPLICATE instead


### PR DESCRIPTION
Briefly describe how the s32_t parameter has been "deprecated" in favor
of k_timeout_t.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>