### PR TITLE
samples/drivers/led_apa102c_bitbang: Wrap sleep time value in K_MSEC()

### DIFF
--- a/samples/drivers/led_apa102c_bitbang/src/main.c
+++ b/samples/drivers/led_apa102c_bitbang/src/main.c
@@ -23,7 +23,7 @@
 #include <device.h>
 #include <drivers/gpio.h>
 /* in millisecond */
-#define SLEEPTIME	250
+#define SLEEPTIME	K_MSEC(250)
 
 #define GPIO_DATA_PIN	16
 #define GPIO_CLK_PIN	19


### PR DESCRIPTION
Align the parameter passed to `k_sleep` with the recent changes done
to timeout API.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>