### PR TITLE
drivers: modem: gpio api and string len

### DIFF
--- a/drivers/modem/modem_pin.c
+++ b/drivers/modem/modem_pin.c
@@ -22,7 +22,7 @@ int modem_pin_read(struct modem_context *ctx, u32_t pin)
 		return -ENODEV;
 	}
 
-	return gpio_pin_get_raw(ctx->pins[pin].gpio_port_dev,
+	return gpio_pin_get(ctx->pins[pin].gpio_port_dev,
 				ctx->pins[pin].pin);
 }
 
@@ -32,7 +32,7 @@ int modem_pin_write(struct modem_context *ctx, u32_t pin, u32_t value)
 		return -ENODEV;
 	}
 
-	return gpio_pin_set_raw(ctx->pins[pin].gpio_port_dev,
+	return gpio_pin_set(ctx->pins[pin].gpio_port_dev,
 				ctx->pins[pin].pin, value);
 }
 

--- a/drivers/modem/modem_shell.c
+++ b/drivers/modem/modem_shell.c
@@ -111,7 +111,7 @@ static int cmd_modem_send(const struct shell *shell, size_t argc,
 		}
 
 		if (i == argc - 1) {
-			ret = ms_send(mdm_ctx, "\r", 2);
+			ret = ms_send(mdm_ctx, "\r", 1);
 		} else {
 			ret = ms_send(mdm_ctx, " ", 1);
 		}

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -64,10 +64,6 @@ static struct modem_pin modem_pins[] = {
 #define MDM_POWER_DISABLE		0
 #define MDM_RESET_NOT_ASSERTED		1
 #define MDM_RESET_ASSERTED		0
-#if DT_INST_NODE_HAS_PROP(0, mdm_vint_gpios)
-#define MDM_VINT_ENABLE			1
-#define MDM_VINT_DISABLE		0
-#endif
 
 #define MDM_CMD_TIMEOUT			K_SECONDS(10)
 #define MDM_DNS_TIMEOUT			K_SECONDS(70)
@@ -642,7 +638,7 @@ static int pin_init(void)
 #if DT_INST_NODE_HAS_PROP(0, mdm_vint_gpios)
 	LOG_DBG("Waiting for MDM_VINT_PIN = 0");
 
-	while (modem_pin_read(&mctx, MDM_VINT) != MDM_VINT_DISABLE) {
+	while (modem_pin_read(&mctx, MDM_VINT) > 0) {
 #if defined(CONFIG_MODEM_UBLOX_SARA_U2)
 		/* try to power off again */
 		LOG_DBG("MDM_POWER_PIN -> DISABLE");
@@ -677,7 +673,7 @@ static int pin_init(void)
 	LOG_DBG("Waiting for MDM_VINT_PIN = 1");
 	do {
 		k_sleep(K_MSEC(100));
-	} while (modem_pin_read(&mctx, MDM_VINT) != MDM_VINT_ENABLE);
+	} while (modem_pin_read(&mctx, MDM_VINT) == 0);
 #else
 	k_sleep(K_SECONDS(10));
 #endif


### PR DESCRIPTION
This commit references modem_pin() and modem_shell()

modem_pin(): use new gpio api
The existing pin driver does not respect gpio
configuration in device tree for active high / low
This commit allows for the device tree to determine the
active logic level.
Fixes #23692

modem_shell(): use correct string length
The ms_send macro uses iface.write() to send a string.
iface.write() requires the length of the string not the
size of the string.
This commit corrects the string length.
