### PR TITLE
drivers: modem_cmd_handler: change parse order

### DIFF
--- a/drivers/modem/modem_cmd_handler.h
+++ b/drivers/modem/modem_cmd_handler.h
@@ -33,9 +33,9 @@ static int name_(struct modem_cmd_handler_data *data, u16_t len, \
 	.delim = adelim_, \
 }
 
-#define CMD_RESP	0
+#define CMD_HANDLER	0
 #define CMD_UNSOL	1
-#define CMD_HANDLER	2
+#define CMD_RESP	2
 #define CMD_MAX		3
 
 struct modem_cmd_handler_data;


### PR DESCRIPTION
The order in which the commands are parsed is:
response
unsolicited
handler

For responses where the string is a substring of another response,
the proper response is not matched.

This commit changes the order of the parsing to:
handler,
unsolicited,
response

This enables parsing of responses that are substrings of another
response.