### PR TITLE
drivers: wdt_sam0: remove log message during boot

### DIFF
--- a/drivers/watchdog/wdt_sam0.c
+++ b/drivers/watchdog/wdt_sam0.c
@@ -125,7 +125,6 @@ static int wdt_sam0_setup(struct device *dev, u8_t options)
 static int wdt_sam0_disable(struct device *dev)
 {
 	if (!wdt_sam0_is_enabled()) {
-		LOG_ERR("Watchdog not enabled");
 		return -EFAULT;
 	}
 


### PR DESCRIPTION
The recent change in 2.2.0 that disables the watchdog
on boot introduced a hard fault when a log message
is generated too early before even the RTC is
initialized.
This commit removes the log message.
