### PR TITLE
net: lwm2m: Publicize firmware block context

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -323,6 +323,13 @@ void lwm2m_firmware_set_update_cb(lwm2m_engine_user_cb_t cb);
  * @return A registered callback function to receive the execute event.
  */
 lwm2m_engine_user_cb_t lwm2m_firmware_get_update_cb(void);
+
+/**
+ * @brief Get the block context of the current firmware block.
+ *
+ * @param[out] ctx A buffer to store the block context.
+ */
+struct coap_block_context *lwm2m_firmware_get_block_context();
 #endif
 #endif
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -464,3 +464,13 @@ int lwm2m_firmware_start_transfer(char *package_uri)
 
 	return 0;
 }
+
+/**
+ * @brief Get the block context of the current firmware block.
+ *
+ * @return A pointer to the firmware block context
+ */
+struct coap_block_context *lwm2m_firmware_get_block_context()
+{
+	return &firmware_block_ctx;
+}


### PR DESCRIPTION
This change is to allow access to the firmware block context in order to
give the firmware update callback implementation an indication of when
to reset the flash context. Additionally, it allows for a validity check
between the total expected size downloaded and the actual size
downloaded. A simple implementation can check if the block context's
current downloaded blocks is equal to the expected block size in order
to determine if the flash context needs to be reset. This approach
seemed the simplest, and knowing the firmware block context can have
other purposes. This has been tested by accessing the block context
during the update in the block received callback and confirming that the
callback had information regarding the current downloaded bytes.

Fixes #16122

Signed-off-by: Kyle Sun <yaomon18@yahoo.com>

Remade stale PR
@carlescufi 
@rlubos 