### PR TITLE
TCP2: Simplify TCP packet creation

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -824,9 +824,10 @@ int net_context_create_ipv4_new(struct net_context *context,
 				const struct in_addr *src,
 				const struct in_addr *dst)
 {
-	NET_ASSERT(((struct sockaddr_in_ptr *)&context->local)->sin_addr);
-
 	if (!src) {
+		NET_ASSERT(((
+			struct sockaddr_in_ptr *)&context->local)->sin_addr);
+
 		src = ((struct sockaddr_in_ptr *)&context->local)->sin_addr;
 	}
 
@@ -853,9 +854,10 @@ int net_context_create_ipv6_new(struct net_context *context,
 				const struct in6_addr *src,
 				const struct in6_addr *dst)
 {
-	NET_ASSERT(((struct sockaddr_in6_ptr *)&context->local)->sin6_addr);
-
 	if (!src) {
+		NET_ASSERT(((
+			struct sockaddr_in6_ptr *)&context->local)->sin6_addr);
+
 		src = ((struct sockaddr_in6_ptr *)&context->local)->sin6_addr;
 	}
 

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1391,12 +1391,13 @@ enum net_verdict tp_input(struct net_conn *net_conn,
 			responded = true;
 			NET_DBG("tcp_send(\"%s\")", tp->data);
 			{
-				struct net_pkt *pkt = tcp_pkt_alloc(0);
-				struct net_buf *nb =
-					net_pkt_get_frag(pkt, K_NO_WAIT);
-				memcpy(net_buf_add(nb, len), buf, len);
-				net_pkt_frag_insert(pkt, nb);
-				net_tcp_queue_data(conn->context, pkt);
+				struct net_pkt *data_pkt;
+
+				data_pkt = tcp_pkt_alloc(pkt->iface,
+							 pkt->family, len);
+				net_pkt_write(data_pkt, buf, len);
+				net_pkt_cursor_init(data_pkt);
+				net_tcp_queue_data(conn->context, data_pkt);
 			}
 		}
 		break;

--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -33,7 +33,7 @@
 #endif
 
 #if IS_ENABLED(CONFIG_NET_TEST_PROTOCOL)
-#define tcp_pkt_alloc(_len) tp_pkt_alloc(_len, tp_basename(__FILE__), __LINE__)
+#define tp_pkt_alloc(_pkt) tp_pkt_alloc(_pkt, tp_basename(__FILE__), __LINE__)
 #define tcp_pkt_clone(_pkt) tp_pkt_clone(_pkt, tp_basename(__FILE__), __LINE__)
 #define tcp_pkt_unref(_pkt) tp_pkt_unref(_pkt, tp_basename(__FILE__), __LINE__)
 #else

--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -37,24 +37,6 @@
 #define tcp_pkt_clone(_pkt) tp_pkt_clone(_pkt, tp_basename(__FILE__), __LINE__)
 #define tcp_pkt_unref(_pkt) tp_pkt_unref(_pkt, tp_basename(__FILE__), __LINE__)
 #else
-static struct net_pkt *tcp_pkt_alloc(size_t len)
-{
-	struct net_pkt *pkt = net_pkt_alloc(K_NO_WAIT);
-
-	pkt->family = AF_INET;
-
-	NET_ASSERT(pkt);
-
-	if (len) {
-		struct net_buf *buf = net_pkt_get_frag(pkt, K_NO_WAIT);
-
-		net_buf_add(buf, len);
-		net_pkt_frag_insert(pkt, buf);
-		NET_ASSERT(buf);
-	}
-
-	return pkt;
-}
 #define tcp_pkt_clone(_pkt) net_pkt_clone(_pkt, K_NO_WAIT)
 #define tcp_pkt_unref(_pkt) net_pkt_unref(_pkt)
 #endif

--- a/subsys/net/ip/tp.h
+++ b/subsys/net/ip/tp.h
@@ -118,9 +118,9 @@ size_t tp_str_to_hex(void *buf, size_t bufsize, const char *s);
 
 void _tp_output(sa_family_t af, struct net_if *iface, void *data,
 		size_t data_len, const char *file, int line);
-#define tp_output(_af, _iface, _data, _data_len)			\
-	_tp_output(_af, _iface, _data, _data_len, tp_basename(__FILE__),\
-		   __LINE__)
+#define tp_output(_af, _iface, _data, _data_len)	\
+	_tp_output(_af, _iface, _data, _data_len,	\
+		   tp_basename(__FILE__), __LINE__)
 
 void tp_pkt_adj(struct net_pkt *pkt, int req_len);
 
@@ -139,8 +139,9 @@ struct net_buf *tp_nbuf_clone(struct net_buf *buf, const char *file, int line,
 void tp_nbuf_unref(struct net_buf *nbuf, const char *file, int line,
 			const char *func);
 void tp_nbuf_stat(void);
+void tp_pkt_alloc(struct net_pkt *pkt,
+		  const char *file, int line);
 
-struct net_pkt *tp_pkt_alloc(size_t len, const char *file, int line);
 struct net_pkt *tp_pkt_clone(struct net_pkt *pkt, const char *file, int line);
 void tp_pkt_unref(struct net_pkt *pkt, const char *file, int line);
 void tp_pkt_stat(void);


### PR DESCRIPTION
There are existing calls to create net packet based on context, create IP header and finalize the packet before sending through net_send_data(). Test protocol also changed as well to verify with TTCN3.
