### PR TITLE
net: openthread: ACK timeout and RX timestamp

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -17,6 +17,7 @@
 struct nrf5_802154_rx_frame {
 	void *fifo_reserved; /* 1st word reserved for use by fifo. */
 	u8_t *psdu; /* Pointer to a received frame. */
+	u32_t time; /* RX timestamp. */
 	u8_t lqi; /* Last received frame LQI value. */
 	s8_t rssi; /* Last received frame RSSI value. */
 };

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -549,6 +549,10 @@ otRadioCaps otPlatRadioGetCaps(otInstance *aInstance)
 			OT_RADIO_CAPS_TRANSMIT_RETRIES;
 	}
 
+	if (radio_caps & IEEE802154_HW_TX_RX_ACK) {
+		caps |= OT_RADIO_CAPS_ACK_TIMEOUT;
+	}
+
 	return caps;
 }
 

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -282,6 +282,13 @@ static void openthread_handle_received_frame(otInstance *instance,
 	recv_frame.mInfo.mRxInfo.mLqi = net_pkt_ieee802154_lqi(pkt);
 	recv_frame.mInfo.mRxInfo.mRssi = net_pkt_ieee802154_rssi(pkt);
 
+#if defined(CONFIG_NET_PKT_TIMESTAMP)
+	struct net_ptp_time *time = net_pkt_timestamp(pkt);
+
+	recv_frame.mInfo.mRxInfo.mTimestamp = time->second * USEC_PER_SEC +
+					      time->nanosecond / NSEC_PER_USEC;
+#endif
+
 	if (IS_ENABLED(OPENTHREAD_ENABLE_DIAG) && otPlatDiagModeGet()) {
 		otPlatDiagRadioReceiveDone(instance,
 					   &recv_frame, OT_ERROR_NONE);

--- a/west.yml
+++ b/west.yml
@@ -53,7 +53,7 @@ manifest:
       revision: a12d92816a53a521d79cefcf5c38b9dc8a4fed6e
       path: modules/hal/cypress
     - name: hal_nordic
-      revision: 5505d0baa66a89848f643120fafad232876df695
+      revision: 8a693c5ffc8b50fc148190fe10cca5538759b8f0
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 3b54187649cc9b37161d49918f1ad28ff7c7f830


### PR DESCRIPTION
A couple of improvements:
* Translate IEEE802154_HW_TX_RX_ACK capability and forward it to OpenThread,
* Set `mTimestamp` field in OpenThread RX frame,
* Implement these features for nRF5 radio driver