### PR TITLE
kernel: Add K_MS_FOREVER that can be used instead of K_FOREVER

### DIFF
--- a/include/sys_clock.h
+++ b/include/sys_clock.h
@@ -49,6 +49,7 @@ typedef u32_t k_ticks_t;
 #endif
 
 #define K_TICKS_FOREVER ((k_ticks_t) -1)
+#define K_MS_FOREVER ((k_ticks_t) -1)
 
 #ifndef CONFIG_LEGACY_TIMEOUT_API
 


### PR DESCRIPTION
Needed for K_THREAD_DEFINE() which expects time delay as ms so
K_FOREVER cannot be used there.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>