### PR TITLE
Network changes for k_timeout_t

### DIFF
--- a/include/net/dns_resolve.h
+++ b/include/net/dns_resolve.h
@@ -178,7 +178,7 @@ struct dns_resolve_context {
 	/** This timeout is also used when a buffer is required from the
 	 * buffer pools.
 	 */
-	s32_t buf_timeout;
+	k_timeout_t buf_timeout;
 
 	/** Result callbacks. We have multiple callbacks here so that it is
 	 * possible to do multiple queries at the same time.
@@ -197,7 +197,7 @@ struct dns_resolve_context {
 		void *user_data;
 
 		/** TX timeout */
-		s32_t timeout;
+		k_timeout_t timeout;
 
 		/** String containing the thing to resolve like www.example.com
 		 */

--- a/include/net/http_client.h
+++ b/include/net/http_client.h
@@ -174,7 +174,7 @@ struct http_client_internal_data {
 	int sock;
 
 	/** Request timeout */
-	s32_t timeout;
+	k_timeout_t timeout;
 };
 
 /**
@@ -271,6 +271,7 @@ struct http_request {
  * @param req HTTP request information
  * @param timeout Max timeout to wait for the data. The timeout value cannot be
  *        0 as there would be no time to receive the data.
+ *        The timeout value is in milliseconds.
  * @param user_data User specified data that is passed to the callback.
  *
  * @return <0 if error, >=0 amount of data sent to the server

--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -866,7 +866,7 @@ int net_context_connect(struct net_context *context,
 			const struct sockaddr *addr,
 			socklen_t addrlen,
 			net_context_connect_cb_t cb,
-			s32_t timeout,
+			k_timeout_t timeout,
 			void *user_data);
 
 /**
@@ -896,7 +896,7 @@ int net_context_connect(struct net_context *context,
  */
 int net_context_accept(struct net_context *context,
 		       net_tcp_accept_cb_t cb,
-		       s32_t timeout,
+		       k_timeout_t timeout,
 		       void *user_data);
 
 /**
@@ -922,7 +922,7 @@ int net_context_send(struct net_context *context,
 		     const void *buf,
 		     size_t len,
 		     net_context_send_cb_t cb,
-		     s32_t timeout,
+		     k_timeout_t timeout,
 		     void *user_data);
 
 /**
@@ -952,7 +952,7 @@ int net_context_sendto(struct net_context *context,
 		       const struct sockaddr *dst_addr,
 		       socklen_t addrlen,
 		       net_context_send_cb_t cb,
-		       s32_t timeout,
+		       k_timeout_t timeout,
 		       void *user_data);
 
 /**
@@ -977,7 +977,7 @@ int net_context_sendmsg(struct net_context *context,
 			const struct msghdr *msghdr,
 			int flags,
 			net_context_send_cb_t cb,
-			s32_t timeout,
+			k_timeout_t timeout,
 			void *user_data);
 
 /**
@@ -1018,7 +1018,7 @@ int net_context_sendmsg(struct net_context *context,
  */
 int net_context_recv(struct net_context *context,
 		     net_context_recv_cb_t cb,
-		     s32_t timeout,
+		     k_timeout_t timeout,
 		     void *user_data);
 
 /**

--- a/include/net/net_core.h
+++ b/include/net/net_core.h
@@ -20,6 +20,8 @@
 #include <sys/__assert.h>
 #include <kernel.h>
 
+#include <net/net_timeout.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/net/net_mgmt.h
+++ b/include/net/net_mgmt.h
@@ -244,8 +244,7 @@ static inline void net_mgmt_event_notify(u32_t mgmt_event, struct net_if *iface)
  *        event might bring along. NULL otherwise.
  * @param info_length tells how long the info memory area is. Only valid if
  *        the info is not NULL.
- * @param timeout a delay in milliseconds. K_FOREVER can be used to wait
- *        indefinitely.
+ * @param timeout A timeout delay. K_FOREVER can be used to wait indefinitely.
  *
  * @return 0 on success, a negative error code otherwise. -ETIMEDOUT will
  *         be specifically returned if the timeout kick-in instead of an
@@ -257,14 +256,14 @@ int net_mgmt_event_wait(u32_t mgmt_event_mask,
 			struct net_if **iface,
 			const void **info,
 			size_t *info_length,
-			int timeout);
+			k_timeout_t timeout);
 #else
 static inline int net_mgmt_event_wait(u32_t mgmt_event_mask,
 				      u32_t *raised_event,
 				      struct net_if **iface,
 				      const void **info,
 				      size_t *info_length,
-				      int timeout)
+				      k_timeout_t timeout)
 {
 	return 0;
 }
@@ -283,8 +282,7 @@ static inline int net_mgmt_event_wait(u32_t mgmt_event_mask,
  *        event might bring along. NULL otherwise.
  * @param info_length tells how long the info memory area is. Only valid if
  *        the info is not NULL.
- * @param timeout a delay in milliseconds. K_FOREVER can be used to wait
- *        indefinitely.
+ * @param timeout A timeout delay. K_FOREVER can be used to wait indefinitely.
  *
  * @return 0 on success, a negative error code otherwise. -ETIMEDOUT will
  *         be specifically returned if the timeout kick-in instead of an
@@ -296,14 +294,14 @@ int net_mgmt_event_wait_on_iface(struct net_if *iface,
 				 u32_t *raised_event,
 				 const void **info,
 				 size_t *info_length,
-				 int timeout);
+				 k_timeout_t timeout);
 #else
 static inline int net_mgmt_event_wait_on_iface(struct net_if *iface,
 					       u32_t mgmt_event_mask,
 					       u32_t *raised_event,
 					       const void **info,
 					       size_t *info_length,
-					       int timeout)
+					       k_timeout_t timeout)
 {
 	return 0;
 }

--- a/include/net/net_offload.h
+++ b/include/net/net_offload.h
@@ -219,15 +219,21 @@ static inline int net_offload_connect(struct net_if *iface,
 				      const struct sockaddr *addr,
 				      socklen_t addrlen,
 				      net_context_connect_cb_t cb,
-				      s32_t timeout,
+				      k_timeout_t timeout,
 				      void *user_data)
 {
 	NET_ASSERT(iface);
 	NET_ASSERT(net_if_offload(iface));
 	NET_ASSERT(net_if_offload(iface)->connect);
 
-	return net_if_offload(iface)->connect(context, addr, addrlen, cb,
-				       timeout, user_data);
+	return net_if_offload(iface)->connect(
+		context, addr, addrlen, cb,
+#ifdef CONFIG_LEGACY_TIMEOUT_API
+		Z_TIMEOUT_MS(timeout),
+#else
+		k_ticks_to_ms_floor64(timeout.ticks),
+#endif
+		user_data);
 }
 
 /**
@@ -260,14 +266,21 @@ static inline int net_offload_connect(struct net_if *iface,
 static inline int net_offload_accept(struct net_if *iface,
 				     struct net_context *context,
 				     net_tcp_accept_cb_t cb,
-				     s32_t timeout,
+				     k_timeout_t timeout,
 				     void *user_data)
 {
 	NET_ASSERT(iface);
 	NET_ASSERT(net_if_offload(iface));
 	NET_ASSERT(net_if_offload(iface)->accept);
 
-	return net_if_offload(iface)->accept(context, cb, timeout, user_data);
+	return net_if_offload(iface)->accept(
+		context, cb,
+#ifdef CONFIG_LEGACY_TIMEOUT_API
+		Z_TIMEOUT_MS(timeout),
+#else
+		k_ticks_to_ms_floor64(timeout.ticks),
+#endif
+		user_data);
 }
 
 /**
@@ -299,14 +312,21 @@ static inline int net_offload_accept(struct net_if *iface,
 static inline int net_offload_send(struct net_if *iface,
 				   struct net_pkt *pkt,
 				   net_context_send_cb_t cb,
-				   s32_t timeout,
+				   k_timeout_t timeout,
 				   void *user_data)
 {
 	NET_ASSERT(iface);
 	NET_ASSERT(net_if_offload(iface));
 	NET_ASSERT(net_if_offload(iface)->send);
 
-	return net_if_offload(iface)->send(pkt, cb, timeout, user_data);
+	return net_if_offload(iface)->send(
+		pkt, cb,
+#ifdef CONFIG_LEGACY_TIMEOUT_API
+		Z_TIMEOUT_MS(timeout),
+#else
+		k_ticks_to_ms_floor64(timeout.ticks),
+#endif
+		user_data);
 }
 
 /**
@@ -342,15 +362,21 @@ static inline int net_offload_sendto(struct net_if *iface,
 				     const struct sockaddr *dst_addr,
 				     socklen_t addrlen,
 				     net_context_send_cb_t cb,
-				     s32_t timeout,
+				     k_timeout_t timeout,
 				     void *user_data)
 {
 	NET_ASSERT(iface);
 	NET_ASSERT(net_if_offload(iface));
 	NET_ASSERT(net_if_offload(iface)->sendto);
 
-	return net_if_offload(iface)->sendto(pkt, dst_addr, addrlen, cb,
-				      timeout, user_data);
+	return net_if_offload(iface)->sendto(
+		pkt, dst_addr, addrlen, cb,
+#ifdef CONFIG_LEGACY_TIMEOUT_API
+		Z_TIMEOUT_MS(timeout),
+#else
+		k_ticks_to_ms_floor64(timeout.ticks),
+#endif
+		user_data);
 }
 
 /**
@@ -389,14 +415,21 @@ static inline int net_offload_sendto(struct net_if *iface,
 static inline int net_offload_recv(struct net_if *iface,
 				   struct net_context *context,
 				   net_context_recv_cb_t cb,
-				   s32_t timeout,
+				   k_timeout_t timeout,
 				   void *user_data)
 {
 	NET_ASSERT(iface);
 	NET_ASSERT(net_if_offload(iface));
 	NET_ASSERT(net_if_offload(iface)->recv);
 
-	return net_if_offload(iface)->recv(context, cb, timeout, user_data);
+	return net_if_offload(iface)->recv(
+		context, cb,
+#ifdef CONFIG_LEGACY_TIMEOUT_API
+		Z_TIMEOUT_MS(timeout),
+#else
+		k_ticks_to_ms_floor64(timeout.ticks),
+#endif
+		user_data);
 }
 
 /**
@@ -455,7 +488,7 @@ static inline int net_offload_connect(struct net_if *iface,
 				      const struct sockaddr *addr,
 				      socklen_t addrlen,
 				      net_context_connect_cb_t cb,
-				      s32_t timeout,
+				      k_timeout_t timeout,
 				      void *user_data)
 {
 	return 0;
@@ -464,7 +497,7 @@ static inline int net_offload_connect(struct net_if *iface,
 static inline int net_offload_accept(struct net_if *iface,
 				     struct net_context *context,
 				     net_tcp_accept_cb_t cb,
-				     s32_t timeout,
+				     k_timeout_t timeout,
 				     void *user_data)
 {
 	return 0;
@@ -473,7 +506,7 @@ static inline int net_offload_accept(struct net_if *iface,
 static inline int net_offload_send(struct net_if *iface,
 				   struct net_pkt *pkt,
 				   net_context_send_cb_t cb,
-				   s32_t timeout,
+				   k_timeout_t timeout,
 				   void *user_data)
 {
 	return 0;
@@ -484,7 +517,7 @@ static inline int net_offload_sendto(struct net_if *iface,
 				     const struct sockaddr *dst_addr,
 				     socklen_t addrlen,
 				     net_context_send_cb_t cb,
-				     s32_t timeout,
+				     k_timeout_t timeout,
 				     void *user_data)
 {
 	return 0;
@@ -493,7 +526,7 @@ static inline int net_offload_sendto(struct net_if *iface,
 static inline int net_offload_recv(struct net_if *iface,
 				   struct net_context *context,
 				   net_context_recv_cb_t cb,
-				   s32_t timeout,
+				   k_timeout_t timeout,
 				   void *user_data)
 {
 	return 0;

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -1034,27 +1034,27 @@ static inline bool net_pkt_is_being_overwritten(struct net_pkt *pkt)
  */
 
 struct net_buf *net_pkt_get_reserve_data_debug(struct net_buf_pool *pool,
-					       s32_t timeout,
+					       k_timeout_t timeout,
 					       const char *caller,
 					       int line);
 
 #define net_pkt_get_reserve_data(pool, timeout)				\
 	net_pkt_get_reserve_data_debug(pool, timeout, __func__, __LINE__)
 
-struct net_buf *net_pkt_get_reserve_rx_data_debug(s32_t timeout,
+struct net_buf *net_pkt_get_reserve_rx_data_debug(k_timeout_t timeout,
 						  const char *caller,
 						  int line);
 #define net_pkt_get_reserve_rx_data(timeout)				\
 	net_pkt_get_reserve_rx_data_debug(timeout, __func__, __LINE__)
 
-struct net_buf *net_pkt_get_reserve_tx_data_debug(s32_t timeout,
+struct net_buf *net_pkt_get_reserve_tx_data_debug(k_timeout_t timeout,
 						  const char *caller,
 						  int line);
 #define net_pkt_get_reserve_tx_data(timeout)				\
 	net_pkt_get_reserve_tx_data_debug(timeout, __func__, __LINE__)
 
 struct net_buf *net_pkt_get_frag_debug(struct net_pkt *pkt,
-				       s32_t timeout,
+				       k_timeout_t timeout,
 				       const char *caller, int line);
 #define net_pkt_get_frag(pkt, timeout)					\
 	net_pkt_get_frag_debug(pkt, timeout, __func__, __LINE__)
@@ -1118,13 +1118,12 @@ void net_pkt_print_frags(struct net_pkt *pkt);
  *
  * @param timeout Affects the action taken should the net buf pool be empty.
  *        If K_NO_WAIT, then return immediately. If K_FOREVER, then
- *        wait as long as necessary. Otherwise, wait up to the specified
- *        number of milliseconds before timing out.
+ *        wait as long as necessary. Otherwise, wait up to the specified time.
  *
  * @return Network buffer if successful, NULL otherwise.
  */
 #if !defined(NET_PKT_DEBUG_ENABLED)
-struct net_buf *net_pkt_get_reserve_rx_data(s32_t timeout);
+struct net_buf *net_pkt_get_reserve_rx_data(k_timeout_t timeout);
 #endif
 
 /**
@@ -1136,13 +1135,12 @@ struct net_buf *net_pkt_get_reserve_rx_data(s32_t timeout);
  *
  * @param timeout Affects the action taken should the net buf pool be empty.
  *        If K_NO_WAIT, then return immediately. If K_FOREVER, then
- *        wait as long as necessary. Otherwise, wait up to the specified
- *        number of milliseconds before timing out.
+ *        wait as long as necessary. Otherwise, wait up to the specified time.
  *
  * @return Network buffer if successful, NULL otherwise.
  */
 #if !defined(NET_PKT_DEBUG_ENABLED)
-struct net_buf *net_pkt_get_reserve_tx_data(s32_t timeout);
+struct net_buf *net_pkt_get_reserve_tx_data(k_timeout_t timeout);
 #endif
 
 /**
@@ -1152,13 +1150,12 @@ struct net_buf *net_pkt_get_reserve_tx_data(s32_t timeout);
  * @param pkt Network packet.
  * @param timeout Affects the action taken should the net buf pool be empty.
  *        If K_NO_WAIT, then return immediately. If K_FOREVER, then
- *        wait as long as necessary. Otherwise, wait up to the specified
- *        number of milliseconds before timing out.
+ *        wait as long as necessary. Otherwise, wait up to the specified time.
  *
  * @return Network buffer if successful, NULL otherwise.
  */
 #if !defined(NET_PKT_DEBUG_ENABLED)
-struct net_buf *net_pkt_get_frag(struct net_pkt *pkt, s32_t timeout);
+struct net_buf *net_pkt_get_frag(struct net_pkt *pkt, k_timeout_t timeout);
 #endif
 
 /**
@@ -1299,31 +1296,31 @@ const char *net_pkt_pool2str(struct net_buf_pool *pool);
  */
 #if defined(NET_PKT_DEBUG_ENABLED)
 
-struct net_pkt *net_pkt_alloc_debug(s32_t timeout,
+struct net_pkt *net_pkt_alloc_debug(k_timeout_t timeout,
 				    const char *caller, int line);
 #define net_pkt_alloc(_timeout)					\
 	net_pkt_alloc_debug(_timeout, __func__, __LINE__)
 
 struct net_pkt *net_pkt_alloc_from_slab_debug(struct k_mem_slab *slab,
-					      s32_t timeout,
+					      k_timeout_t timeout,
 					      const char *caller, int line);
 #define net_pkt_alloc_from_slab(_slab, _timeout)			\
 	net_pkt_alloc_from_slab_debug(_slab, _timeout, __func__, __LINE__)
 
-struct net_pkt *net_pkt_rx_alloc_debug(s32_t timeout,
+struct net_pkt *net_pkt_rx_alloc_debug(k_timeout_t timeout,
 				       const char *caller, int line);
 #define net_pkt_rx_alloc(_timeout)				\
 	net_pkt_rx_alloc_debug(_timeout, __func__, __LINE__)
 
 struct net_pkt *net_pkt_alloc_on_iface_debug(struct net_if *iface,
-					     s32_t timeout,
+					     k_timeout_t timeout,
 					     const char *caller,
 					     int line);
 #define net_pkt_alloc_on_iface(_iface, _timeout)			\
 	net_pkt_alloc_on_iface_debug(_iface, _timeout, __func__, __LINE__)
 
 struct net_pkt *net_pkt_rx_alloc_on_iface_debug(struct net_if *iface,
-						s32_t timeout,
+						k_timeout_t timeout,
 						const char *caller,
 						int line);
 #define net_pkt_rx_alloc_on_iface(_iface, _timeout)			\
@@ -1333,7 +1330,7 @@ struct net_pkt *net_pkt_rx_alloc_on_iface_debug(struct net_if *iface,
 int net_pkt_alloc_buffer_debug(struct net_pkt *pkt,
 			       size_t size,
 			       enum net_ip_protocol proto,
-			       s32_t timeout,
+			       k_timeout_t timeout,
 			       const char *caller, int line);
 #define net_pkt_alloc_buffer(_pkt, _size, _proto, _timeout)		\
 	net_pkt_alloc_buffer_debug(_pkt, _size, _proto, _timeout,	\
@@ -1343,7 +1340,7 @@ struct net_pkt *net_pkt_alloc_with_buffer_debug(struct net_if *iface,
 						size_t size,
 						sa_family_t family,
 						enum net_ip_protocol proto,
-						s32_t timeout,
+						k_timeout_t timeout,
 						const char *caller,
 						int line);
 #define net_pkt_alloc_with_buffer(_iface, _size, _family,		\
@@ -1356,7 +1353,7 @@ struct net_pkt *net_pkt_rx_alloc_with_buffer_debug(struct net_if *iface,
 						   size_t size,
 						   sa_family_t family,
 						   enum net_ip_protocol proto,
-						   s32_t timeout,
+						   k_timeout_t timeout,
 						   const char *caller,
 						   int line);
 #define net_pkt_rx_alloc_with_buffer(_iface, _size, _family,		\
@@ -1373,12 +1370,12 @@ struct net_pkt *net_pkt_rx_alloc_with_buffer_debug(struct net_if *iface,
  * @details for the time being, 2 pools are used. One for TX and one for RX.
  *          This allocator has to be used for TX.
  *
- * @param timeout Maximum time in milliseconds to wait for an allocation.
+ * @param timeout Maximum time to wait for an allocation.
  *
  * @return a pointer to a newly allocated net_pkt on success, NULL otherwise.
  */
 #if !defined(NET_PKT_DEBUG_ENABLED)
-struct net_pkt *net_pkt_alloc(s32_t timeout);
+struct net_pkt *net_pkt_alloc(k_timeout_t timeout);
 #endif
 
 /**
@@ -1391,13 +1388,13 @@ struct net_pkt *net_pkt_alloc(s32_t timeout);
  *          then buffer on its local slab/pool (if any).
  *
  * @param slab    The slab to use for allocating the packet
- * @param timeout Maximum time in milliseconds to wait for an allocation.
+ * @param timeout Maximum time to wait for an allocation.
  *
  * @return a pointer to a newly allocated net_pkt on success, NULL otherwise.
  */
 #if !defined(NET_PKT_DEBUG_ENABLED)
 struct net_pkt *net_pkt_alloc_from_slab(struct k_mem_slab *slab,
-					s32_t timeout);
+					k_timeout_t timeout);
 #endif
 
 /**
@@ -1406,27 +1403,29 @@ struct net_pkt *net_pkt_alloc_from_slab(struct k_mem_slab *slab,
  * @details for the time being, 2 pools are used. One for TX and one for RX.
  *          This allocator has to be used for RX.
  *
- * @param timeout Maximum time in milliseconds to wait for an allocation.
+ * @param timeout Maximum time to wait for an allocation.
  *
  * @return a pointer to a newly allocated net_pkt on success, NULL otherwise.
  */
 #if !defined(NET_PKT_DEBUG_ENABLED)
-struct net_pkt *net_pkt_rx_alloc(s32_t timeout);
+struct net_pkt *net_pkt_rx_alloc(k_timeout_t timeout);
 #endif
 
 /**
  * @brief Allocate a network packet for a specific network interface.
  *
  * @param iface The network interface the packet is supposed to go through.
- * @param timeout Maximum time in milliseconds to wait for an allocation.
+ * @param timeout Maximum time to wait for an allocation.
  *
  * @return a pointer to a newly allocated net_pkt on success, NULL otherwise.
  */
 #if !defined(NET_PKT_DEBUG_ENABLED)
-struct net_pkt *net_pkt_alloc_on_iface(struct net_if *iface, s32_t timeout);
+struct net_pkt *net_pkt_alloc_on_iface(struct net_if *iface,
+				       k_timeout_t timeout);
 
 /* Same as above but specifically for RX packet */
-struct net_pkt *net_pkt_rx_alloc_on_iface(struct net_if *iface, s32_t timeout);
+struct net_pkt *net_pkt_rx_alloc_on_iface(struct net_if *iface,
+					  k_timeout_t timeout);
 #endif
 
 /**
@@ -1440,7 +1439,7 @@ struct net_pkt *net_pkt_rx_alloc_on_iface(struct net_if *iface, s32_t timeout);
  * @param pkt     The network packet requiring buffer to be allocated.
  * @param size    The size of buffer being requested.
  * @param proto   The IP protocol type (can be 0 for none).
- * @param timeout Maximum time in milliseconds to wait for an allocation.
+ * @param timeout Maximum time to wait for an allocation.
  *
  * @return 0 on success, negative errno code otherwise.
  */
@@ -1448,7 +1447,7 @@ struct net_pkt *net_pkt_rx_alloc_on_iface(struct net_if *iface, s32_t timeout);
 int net_pkt_alloc_buffer(struct net_pkt *pkt,
 			 size_t size,
 			 enum net_ip_protocol proto,
-			 s32_t timeout);
+			 k_timeout_t timeout);
 #endif
 
 /**
@@ -1458,7 +1457,7 @@ int net_pkt_alloc_buffer(struct net_pkt *pkt,
  * @param size    The size of buffer.
  * @param family  The family to which the packet belongs.
  * @param proto   The IP protocol type (can be 0 for none).
- * @param timeout Maximum time in milliseconds to wait for an allocation.
+ * @param timeout Maximum time to wait for an allocation.
  *
  * @return a pointer to a newly allocated net_pkt on success, NULL otherwise.
  */
@@ -1467,14 +1466,14 @@ struct net_pkt *net_pkt_alloc_with_buffer(struct net_if *iface,
 					  size_t size,
 					  sa_family_t family,
 					  enum net_ip_protocol proto,
-					  s32_t timeout);
+					  k_timeout_t timeout);
 
 /* Same as above but specifically for RX packet */
 struct net_pkt *net_pkt_rx_alloc_with_buffer(struct net_if *iface,
 					     size_t size,
 					     sa_family_t family,
 					     enum net_ip_protocol proto,
-					     s32_t timeout);
+					     k_timeout_t timeout);
 #endif
 
 /**
@@ -1629,7 +1628,7 @@ int net_pkt_copy(struct net_pkt *pkt_dst,
  *
  * @return NULL if error, cloned packet otherwise.
  */
-struct net_pkt *net_pkt_clone(struct net_pkt *pkt, s32_t timeout);
+struct net_pkt *net_pkt_clone(struct net_pkt *pkt, k_timeout_t timeout);
 
 /**
  * @brief Clone pkt and increase the refcount of its buffer.
@@ -1639,7 +1638,8 @@ struct net_pkt *net_pkt_clone(struct net_pkt *pkt, s32_t timeout);
  *
  * @return NULL if error, cloned packet otherwise.
  */
-struct net_pkt *net_pkt_shallow_clone(struct net_pkt *pkt, s32_t timeout);
+struct net_pkt *net_pkt_shallow_clone(struct net_pkt *pkt,
+				      k_timeout_t timeout);
 
 /**
  * @brief Read some data from a net_pkt

--- a/include/net/net_timeout.h
+++ b/include/net/net_timeout.h
@@ -28,6 +28,12 @@
 extern "C" {
 #endif
 
+/**
+ * Symbol to indicate that the caller wants the timeout to be waited forever.
+ * This can be used when a network API expects a millisecond timeout.
+ */
+#define NET_WAIT_FOREVER (-1)
+
 /** Let the max timeout be 100 ms lower because of
  * possible rounding in delayed work implementation.
  */

--- a/include/net/ppp.h
+++ b/include/net/ppp.h
@@ -611,7 +611,8 @@ static inline void ppp_mgmt_raise_carrier_off_event(struct net_if *iface)
  * @brief Send PPP Echo-Request to peer. We expect to receive Echo-Reply back.
  *
  * @param idx PPP network interface index
- * @param timeout Amount of time to wait Echo-Reply.
+ * @param timeout Amount of time to wait Echo-Reply. The value is in
+ * milliseconds.
  *
  * @return 0 if Echo-Reply was received, < 0 if there is a timeout or network
  * index is not a valid PPP network index.

--- a/include/net/promiscuous.h
+++ b/include/net/promiscuous.h
@@ -36,9 +36,9 @@ extern "C" {
  * @return Received net_pkt, NULL if not received any packet.
  */
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
-struct net_pkt *net_promisc_mode_wait_data(s32_t timeout);
+struct net_pkt *net_promisc_mode_wait_data(k_timeout_t timeout);
 #else
-static inline struct net_pkt *net_promisc_mode_wait_data(s32_t timeout)
+static inline struct net_pkt *net_promisc_mode_wait_data(k_timeout_t timeout)
 {
 	ARG_UNUSED(timeout);
 

--- a/include/net/websocket.h
+++ b/include/net/websocket.h
@@ -117,8 +117,8 @@ struct websocket_request {
  *        packets to the Websocket server.
  * @param req Websocket request. User should allocate and fill the request
  *        data.
- * @param timeout Max timeout to wait for the connection. The timeout value
- *        cannot be 0 as there would be no time to receive the data.
+ * @param timeout Max timeout to wait for the connection. The timeout value is
+ *        in milliseconds. Value NET_WAIT_FOREVER means to wait forever.
  * @param user_data User specified data that is passed to the callback.
  *
  * @return Websocket id to be used when sending/receiving Websocket data.
@@ -142,7 +142,8 @@ int websocket_connect(int http_sock, struct websocket_request *req,
  *        must have opcode WEBSOCKET_OPCODE_CONTINUE. If final == true and this
  *        is the only message, then opcode should have proper opcode (text or
  *        binary) set.
- * @param timeout How long to try to send the message.
+ * @param timeout How long to try to send the message. The value is in
+ *        milliseconds. Value NET_WAIT_FOREVER means to wait forever.
  *
  * @return <0 if error, >=0 amount of bytes sent
  */
@@ -162,6 +163,8 @@ int websocket_send_msg(int ws_sock, const u8_t *payload, size_t payload_len,
  * @param message_type Type of the message.
  * @param remaining How much there is data left in the message after this read.
  * @param timeout How long to try to receive the message.
+ *        The value is in milliseconds. Value NET_WAIT_FOREVER means to wait
+ *        forever.
  *
  * @return <0 if error, >=0 amount of bytes received
  */

--- a/samples/net/dns_resolve/src/main.c
+++ b/samples/net/dns_resolve/src/main.c
@@ -28,7 +28,7 @@ static void do_mdns_ipv6_lookup(struct k_work *work);
 #endif
 #endif
 
-#define DNS_TIMEOUT K_SECONDS(2)
+#define DNS_TIMEOUT (2 * MSEC_PER_SEC)
 
 void dns_result_cb(enum dns_resolve_status status,
 		   struct dns_addrinfo *info,

--- a/samples/net/sockets/big_http_download/src/big_http_download.c
+++ b/samples/net/sockets/big_http_download/src/big_http_download.c
@@ -29,7 +29,7 @@
 #include "ca_certificate.h"
 #endif
 
-#define sleep(x) k_sleep(x * 1000)
+#define sleep(x) k_sleep(K_MSEC((x) * MSEC_PER_SEC))
 
 #endif
 

--- a/samples/net/sockets/coap_client/src/coap-client.c
+++ b/samples/net/sockets/coap_client/src/coap-client.c
@@ -42,7 +42,7 @@ static struct coap_block_context blk_ctx;
 
 static void wait(void)
 {
-	if (poll(fds, nfds, K_FOREVER) < 0) {
+	if (poll(fds, nfds, -1) < 0) {
 		LOG_ERR("Error in poll:%d", errno);
 	}
 }

--- a/samples/net/sockets/coap_server/src/coap-server.c
+++ b/samples/net/sockets/coap_server/src/coap-server.c
@@ -984,7 +984,7 @@ static void retransmit_request(struct k_work *work)
 		return;
 	}
 
-	k_delayed_work_submit(&retransmit_work, pending->timeout);
+	k_delayed_work_submit(&retransmit_work, K_MSEC(pending->timeout));
 }
 
 static void update_counter(struct k_work *work)
@@ -1021,7 +1021,7 @@ static int create_pending_request(struct coap_packet *response,
 		return 0;
 	}
 
-	k_delayed_work_submit(&retransmit_work, pending->timeout);
+	k_delayed_work_submit(&retransmit_work, K_MSEC(pending->timeout));
 
 	return 0;
 }

--- a/samples/net/sockets/dumb_http_server_mt/src/main.c
+++ b/samples/net/sockets/dumb_http_server_mt/src/main.c
@@ -64,11 +64,11 @@ static void process_tcp6(void);
 
 K_THREAD_DEFINE(tcp4_thread_id, STACK_SIZE,
 		process_tcp4, NULL, NULL, NULL,
-		THREAD_PRIORITY, 0, K_FOREVER);
+		THREAD_PRIORITY, 0, -1);
 
 K_THREAD_DEFINE(tcp6_thread_id, STACK_SIZE,
 		process_tcp6, NULL, NULL, NULL,
-		THREAD_PRIORITY, 0, K_FOREVER);
+		THREAD_PRIORITY, 0, -1);
 
 static ssize_t sendall(int sock, const void *buf, size_t len)
 {

--- a/samples/net/sockets/echo_client/src/echo-client.c
+++ b/samples/net/sockets/echo_client/src/echo-client.c
@@ -121,7 +121,7 @@ static void wait(void)
 	/* Wait for event on any socket used. Once event occurs,
 	 * we'll check them all.
 	 */
-	if (poll(fds, nfds, K_FOREVER) < 0) {
+	if (poll(fds, nfds, -1) < 0) {
 		LOG_ERR("Error in poll:%d", errno);
 	}
 }

--- a/samples/net/sockets/echo_server/src/tcp.c
+++ b/samples/net/sockets/echo_server/src/tcp.c
@@ -43,11 +43,11 @@ static void process_tcp6(void);
 
 K_THREAD_DEFINE(tcp4_thread_id, STACK_SIZE,
 		process_tcp4, NULL, NULL, NULL,
-		THREAD_PRIORITY, 0, K_FOREVER);
+		THREAD_PRIORITY, 0, -1);
 
 K_THREAD_DEFINE(tcp6_thread_id, STACK_SIZE,
 		process_tcp6, NULL, NULL, NULL,
-		THREAD_PRIORITY, 0, K_FOREVER);
+		THREAD_PRIORITY, 0, -1);
 
 static ssize_t sendall(int sock, const void *buf, size_t len)
 {

--- a/samples/net/sockets/echo_server/src/udp.c
+++ b/samples/net/sockets/echo_server/src/udp.c
@@ -25,11 +25,11 @@ static void process_udp6(void);
 
 K_THREAD_DEFINE(udp4_thread_id, STACK_SIZE,
 		process_udp4, NULL, NULL, NULL,
-		THREAD_PRIORITY, 0, K_FOREVER);
+		THREAD_PRIORITY, 0, -1);
 
 K_THREAD_DEFINE(udp6_thread_id, STACK_SIZE,
 		process_udp6, NULL, NULL, NULL,
-		THREAD_PRIORITY, 0, K_FOREVER);
+		THREAD_PRIORITY, 0, -1);
 
 static int start_udp_proto(struct data *data, struct sockaddr *bind_addr,
 			   socklen_t bind_addrlen)

--- a/samples/net/sockets/http_client/src/main.c
+++ b/samples/net/sockets/http_client/src/main.c
@@ -152,7 +152,7 @@ void main(void)
 	struct sockaddr_in6 addr6;
 	struct sockaddr_in addr4;
 	int sock4 = -1, sock6 = -1;
-	s32_t timeout = K_SECONDS(3);
+	s32_t timeout = 3 * MSEC_PER_SEC;
 	int ret;
 	int port = HTTP_PORT;
 

--- a/samples/net/sockets/net_mgmt/src/main.c
+++ b/samples/net/sockets/net_mgmt/src/main.c
@@ -63,7 +63,7 @@ static void trigger_events(void)
 
 K_THREAD_DEFINE(trigger_events_thread_id, STACK_SIZE,
 		trigger_events, NULL, NULL, NULL,
-		THREAD_PRIORITY, 0, K_FOREVER);
+		THREAD_PRIORITY, 0, -1);
 
 static char *get_ip_addr(char *ipaddr, size_t len, sa_family_t family,
 			 struct net_mgmt_msghdr *hdr)

--- a/samples/net/sockets/sntp_client/src/main.c
+++ b/samples/net/sockets/sntp_client/src/main.c
@@ -41,7 +41,7 @@ void main(void)
 	}
 
 	LOG_INF("Sending SNTP IPv4 request...");
-	rv = sntp_query(&ctx, K_SECONDS(4), &sntp_time);
+	rv = sntp_query(&ctx, 4 * MSEC_PER_SEC, &sntp_time);
 	if (rv < 0) {
 		LOG_ERR("SNTP IPv4 request failed: %d", rv);
 		goto end;
@@ -69,7 +69,7 @@ void main(void)
 
 	LOG_INF("Sending SNTP IPv6 request...");
 	/* With such a timeout, this is expected to fail. */
-	rv = sntp_query(&ctx, K_NO_WAIT, &sntp_time);
+	rv = sntp_query(&ctx, 0, &sntp_time);
 	if (rv < 0) {
 		LOG_ERR("SNTP IPv6 request: %d", rv);
 		goto end;

--- a/samples/net/sockets/websocket_client/src/main.c
+++ b/samples/net/sockets/websocket_client/src/main.c
@@ -175,7 +175,7 @@ static size_t how_much_to_send(size_t max_len)
 static ssize_t sendall_with_ws_api(int sock, const void *buf, size_t len)
 {
 	return websocket_send_msg(sock, buf, len, WEBSOCKET_OPCODE_DATA_TEXT,
-				  true, true, K_FOREVER);
+				  true, true, NET_WAIT_FOREVER);
 }
 
 static ssize_t sendall_with_bsd_api(int sock, const void *buf, size_t len)
@@ -199,7 +199,7 @@ static void recv_data_wso_api(int sock, size_t amount, u8_t *buf,
 					 buf_len - read_pos,
 					 &message_type,
 					 &remaining,
-					 K_NO_WAIT);
+					 0);
 		if (ret <= 0) {
 			if (ret == -EAGAIN) {
 				k_sleep(K_MSEC(50));
@@ -326,7 +326,7 @@ void main(void)
 	};
 	int sock4 = -1, sock6 = -1;
 	int websock4 = -1, websock6 = -1;
-	s32_t timeout = K_SECONDS(3);
+	s32_t timeout = 3 * MSEC_PER_SEC;
 	struct sockaddr_in6 addr6;
 	struct sockaddr_in addr4;
 	size_t amount;

--- a/samples/net/syslog_net/src/main.c
+++ b/samples/net/syslog_net/src/main.c
@@ -12,14 +12,14 @@ LOG_MODULE_REGISTER(net_syslog, LOG_LEVEL_DBG);
 #include <net/net_core.h>
 #include <net/net_pkt.h>
 
-#define SLEEP_BETWEEN_PRINTS K_SECONDS(3)
+#define SLEEP_BETWEEN_PRINTS 3
 
 void main(void)
 {
-	int count = K_SECONDS(60) / SLEEP_BETWEEN_PRINTS;
+	int count = 60 / SLEEP_BETWEEN_PRINTS;
 
 	/* Allow some setup time before starting to send data */
-	k_sleep(SLEEP_BETWEEN_PRINTS);
+	k_sleep(K_SECONDS(SLEEP_BETWEEN_PRINTS));
 
 	LOG_DBG("Starting");
 
@@ -29,7 +29,7 @@ void main(void)
 		LOG_INF("Info message");
 		LOG_DBG("Debug message");
 
-		k_sleep(SLEEP_BETWEEN_PRINTS);
+		k_sleep(K_SECONDS(SLEEP_BETWEEN_PRINTS));
 
 	} while (count--);
 

--- a/samples/net/zperf/src/zperf_shell.c
+++ b/samples/net/zperf/src/zperf_shell.c
@@ -793,9 +793,10 @@ static int shell_cmd_upload(const struct shell *shell, size_t argc,
 	}
 
 	if (argc > 3) {
-		duration_in_ms = K_SECONDS(strtoul(argv[start + 3], NULL, 10));
+		duration_in_ms = MSEC_PER_SEC * strtoul(argv[start + 3],
+							NULL, 10);
 	} else {
-		duration_in_ms = K_SECONDS(1);
+		duration_in_ms = MSEC_PER_SEC * 1;
 	}
 
 	if (argc > 4) {
@@ -912,9 +913,10 @@ static int shell_cmd_upload2(const struct shell *shell, size_t argc,
 	}
 
 	if (argc > 2) {
-		duration_in_ms = K_SECONDS(strtoul(argv[start + 2], NULL, 10));
+		duration_in_ms = MSEC_PER_SEC * strtoul(argv[start + 2],
+							NULL, 10);
 	} else {
-		duration_in_ms = K_SECONDS(1);
+		duration_in_ms = MSEC_PER_SEC * 1;
 	}
 
 	if (argc > 3) {

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -409,7 +409,7 @@ struct net_buf *net_buf_get(struct k_fifo *fifo, k_timeout_t timeout)
 {
 	struct net_buf *buf, *frag;
 
-	NET_BUF_DBG("%s():%d: fifo %p timeout %d", func, line, fifo, timeout);
+	NET_BUF_DBG("%s():%d: fifo %p", func, line, fifo);
 
 	buf = k_fifo_get(fifo, timeout);
 	if (!buf) {

--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -405,7 +405,7 @@ fail:
 static void dhcpv4_update_timeout_work(u32_t timeout)
 {
 	if (!k_delayed_work_remaining_get(&timeout_work) ||
-	    K_SECONDS(timeout) <
+	    (MSEC_PER_SEC * timeout) <
 	    k_delayed_work_remaining_get(&timeout_work)) {
 		k_delayed_work_cancel(&timeout_work);
 		k_delayed_work_submit(&timeout_work, K_SECONDS(timeout));
@@ -427,7 +427,7 @@ static void dhcpv4_enter_selecting(struct net_if *iface)
 
 static bool dhcpv4_check_timeout(s64_t start, u32_t time, s64_t timeout)
 {
-	start += K_SECONDS(time);
+	start += MSEC_PER_SEC * time;
 	if (start < 0) {
 		start = -start;
 	}

--- a/subsys/net/ip/ipv4_autoconf.c
+++ b/subsys/net/ip/ipv4_autoconf.c
@@ -226,17 +226,17 @@ static u32_t ipv4_autoconf_get_timeout(struct net_if_ipv4_autoconf *ipv4auto)
 	case NET_IPV4_AUTOCONF_PROBE:
 		if (ipv4auto->conflict_cnt >= IPV4_AUTOCONF_MAX_CONFLICTS) {
 			NET_DBG("Rate limiting");
-			return K_SECONDS(IPV4_AUTOCONF_RATE_LIMIT_INTERVAL);
+			return MSEC_PER_SEC * IPV4_AUTOCONF_RATE_LIMIT_INTERVAL;
 
 		} else if (ipv4auto->probe_cnt == IPV4_AUTOCONF_PROBE_NUM) {
-			return K_SECONDS(IPV4_AUTOCONF_ANNOUNCE_INTERVAL);
+			return MSEC_PER_SEC * IPV4_AUTOCONF_ANNOUNCE_INTERVAL;
 		}
 
 		return IPV4_AUTOCONF_PROBE_WAIT * MSEC_PER_SEC +
 			(sys_rand32_get() % MSEC_PER_SEC);
 
 	case NET_IPV4_AUTOCONF_ANNOUNCE:
-		return K_SECONDS(IPV4_AUTOCONF_ANNOUNCE_INTERVAL);
+		return MSEC_PER_SEC * IPV4_AUTOCONF_ANNOUNCE_INTERVAL;
 
 	default:
 		break;
@@ -250,7 +250,7 @@ static void ipv4_autoconf_submit_work(u32_t timeout)
 	if (!k_delayed_work_remaining_get(&ipv4auto_timer) ||
 	    timeout < k_delayed_work_remaining_get(&ipv4auto_timer)) {
 		k_delayed_work_cancel(&ipv4auto_timer);
-		k_delayed_work_submit(&ipv4auto_timer, timeout);
+		k_delayed_work_submit(&ipv4auto_timer, K_MSEC(timeout));
 
 		NET_DBG("Next wakeup in %d ms",
 			k_delayed_work_remaining_get(&ipv4auto_timer));
@@ -313,7 +313,7 @@ static void ipv4_autoconf_timeout(struct k_work *work)
 	if (timeout_update != UINT32_MAX && timeout_update > 0) {
 		NET_DBG("Waiting for %u ms", timeout_update);
 
-		k_delayed_work_submit(&ipv4auto_timer, timeout_update);
+		k_delayed_work_submit(&ipv4auto_timer, K_MSEC(timeout_update));
 	}
 }
 
@@ -323,7 +323,7 @@ static void ipv4_autoconf_start_timer(struct net_if *iface,
 	sys_slist_append(&ipv4auto_ifaces, &ipv4auto->node);
 
 	ipv4auto->timer_start = k_uptime_get();
-	ipv4auto->timer_timeout = K_SECONDS(IPV4_AUTOCONF_START_DELAY);
+	ipv4auto->timer_timeout = MSEC_PER_SEC * IPV4_AUTOCONF_START_DELAY;
 	ipv4auto->iface = iface;
 
 	ipv4_autoconf_submit_work(ipv4auto->timer_timeout);

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -77,8 +77,8 @@ static void ipv6_nd_restart_reachable_timer(struct net_nbr *nbr, s64_t time);
 /* Protocol constants from RFC 4861 Chapter 10 */
 #define MAX_MULTICAST_SOLICIT 3
 #define MAX_UNICAST_SOLICIT   3
-#define DELAY_FIRST_PROBE_TIME K_SECONDS(5)
-#define RETRANS_TIMER K_MSEC(1000)
+#define DELAY_FIRST_PROBE_TIME (5 * MSEC_PER_SEC)
+#define RETRANS_TIMER 1000 /* ms */
 
 extern void net_neighbor_data_remove(struct net_nbr *nbr);
 extern void net_neighbor_table_clear(struct net_nbr_table *table);
@@ -333,7 +333,7 @@ bool net_ipv6_nbr_rm(struct net_if *iface, struct in6_addr *addr)
 	return true;
 }
 
-#define NS_REPLY_TIMEOUT K_SECONDS(1)
+#define NS_REPLY_TIMEOUT (1 * MSEC_PER_SEC)
 
 static void ipv6_ns_reply_timeout(struct k_work *work)
 {
@@ -367,7 +367,7 @@ static void ipv6_ns_reply_timeout(struct k_work *work)
 			if (!k_delayed_work_remaining_get(
 						&ipv6_ns_reply_timer)) {
 				k_delayed_work_submit(&ipv6_ns_reply_timer,
-						remaining);
+						      K_MSEC(remaining));
 			}
 
 			continue;
@@ -1395,7 +1395,7 @@ static void ipv6_nd_restart_reachable_timer(struct net_nbr *nbr, s64_t time)
 
 	remaining = k_delayed_work_remaining_get(&ipv6_nd_reachable_timer);
 	if (!remaining || remaining > time) {
-		k_delayed_work_submit(&ipv6_nd_reachable_timer, time);
+		k_delayed_work_submit(&ipv6_nd_reachable_timer, K_MSEC(time));
 	}
 }
 
@@ -1913,7 +1913,7 @@ int net_ipv6_send_ns(struct net_if *iface,
 		/* Let's start the timer if necessary */
 		if (!k_delayed_work_remaining_get(&ipv6_ns_reply_timer)) {
 			k_delayed_work_submit(&ipv6_ns_reply_timer,
-					      NS_REPLY_TIMEOUT);
+					      K_MSEC(NS_REPLY_TIMEOUT));
 		}
 	}
 
@@ -2131,7 +2131,7 @@ static inline u32_t remaining_lifetime(struct net_if_addr *ifaddr)
 		(u64_t)time_diff(k_uptime_get_32(),
 				 ifaddr->lifetime.timer_start);
 
-	return (u32_t)(remaining / K_MSEC(1000));
+	return (u32_t)(remaining / MSEC_PER_SEC);
 }
 
 static inline void handle_prefix_autonomous(struct net_pkt *pkt,

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -878,7 +878,7 @@ int net_context_connect(struct net_context *context,
 			const struct sockaddr *addr,
 			socklen_t addrlen,
 			net_context_connect_cb_t cb,
-			s32_t timeout,
+			k_timeout_t timeout,
 			void *user_data)
 {
 	struct sockaddr *laddr = NULL;
@@ -1053,7 +1053,7 @@ unlock:
 
 int net_context_accept(struct net_context *context,
 		       net_tcp_accept_cb_t cb,
-		       s32_t timeout,
+		       k_timeout_t timeout,
 		       void *user_data)
 {
 	int ret = 0;
@@ -1285,7 +1285,7 @@ static void context_finalize_packet(struct net_context *context,
 }
 
 static struct net_pkt *context_alloc_pkt(struct net_context *context,
-					 size_t len, s32_t timeout)
+					 size_t len, k_timeout_t timeout)
 {
 	struct net_pkt *pkt;
 
@@ -1344,7 +1344,7 @@ static int context_sendto(struct net_context *context,
 			  const struct sockaddr *dst_addr,
 			  socklen_t addrlen,
 			  net_context_send_cb_t cb,
-			  s32_t timeout,
+			  k_timeout_t timeout,
 			  void *user_data,
 			  bool sendto)
 {
@@ -1630,7 +1630,7 @@ int net_context_send(struct net_context *context,
 		     const void *buf,
 		     size_t len,
 		     net_context_send_cb_t cb,
-		     s32_t timeout,
+		     k_timeout_t timeout,
 		     void *user_data)
 {
 	socklen_t addrlen;
@@ -1673,7 +1673,7 @@ int net_context_sendmsg(struct net_context *context,
 			const struct msghdr *msghdr,
 			int flags,
 			net_context_send_cb_t cb,
-			s32_t timeout,
+			k_timeout_t timeout,
 			void *user_data)
 {
 	int ret;
@@ -1694,7 +1694,7 @@ int net_context_sendto(struct net_context *context,
 		       const struct sockaddr *dst_addr,
 		       socklen_t addrlen,
 		       net_context_send_cb_t cb,
-		       s32_t timeout,
+		       k_timeout_t timeout,
 		       void *user_data)
 {
 	int ret;
@@ -1755,7 +1755,7 @@ unlock:
 #if defined(CONFIG_NET_UDP)
 static int recv_udp(struct net_context *context,
 		    net_context_recv_cb_t cb,
-		    s32_t timeout,
+		    k_timeout_t timeout,
 		    void *user_data)
 {
 	struct sockaddr local_addr = {
@@ -1854,7 +1854,7 @@ static enum net_verdict net_context_raw_packet_received(
 
 static int recv_raw(struct net_context *context,
 		    net_context_recv_cb_t cb,
-		    s32_t timeout,
+		    k_timeout_t timeout,
 		    struct sockaddr *local_addr,
 		    void *user_data)
 {
@@ -1886,7 +1886,7 @@ static int recv_raw(struct net_context *context,
 
 int net_context_recv(struct net_context *context,
 		     net_context_recv_cb_t cb,
-		     s32_t timeout,
+		     k_timeout_t timeout,
 		     void *user_data)
 {
 	int ret;
@@ -1954,7 +1954,7 @@ int net_context_recv(struct net_context *context,
 	}
 
 #if defined(CONFIG_NET_CONTEXT_SYNC_RECV)
-	if (timeout) {
+	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
 		int ret;
 
 		/* Make sure we have the lock, then the

--- a/subsys/net/ip/net_mgmt.c
+++ b/subsys/net/ip/net_mgmt.c
@@ -261,7 +261,7 @@ static int mgmt_event_wait_call(struct net_if *iface,
 				struct net_if **event_iface,
 				const void **info,
 				size_t *info_length,
-				int timeout)
+				k_timeout_t timeout)
 {
 	struct mgmt_event_wait sync_data = {
 		.sync_call = Z_SEM_INITIALIZER(sync_data.sync_call, 0, 1),
@@ -353,7 +353,7 @@ int net_mgmt_event_wait(u32_t mgmt_event_mask,
 			struct net_if **iface,
 			const void **info,
 			size_t *info_length,
-			int timeout)
+			k_timeout_t timeout)
 {
 	return mgmt_event_wait_call(NULL, mgmt_event_mask,
 				    raised_event, iface, info, info_length,
@@ -365,7 +365,7 @@ int net_mgmt_event_wait_on_iface(struct net_if *iface,
 				 u32_t *raised_event,
 				 const void **info,
 				 size_t *info_length,
-				 int timeout)
+				 k_timeout_t timeout)
 {
 	NET_ASSERT(NET_MGMT_ON_IFACE(mgmt_event_mask));
 	NET_ASSERT(iface);

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -360,12 +360,12 @@ void net_pkt_print_frags(struct net_pkt *pkt)
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
 struct net_buf *net_pkt_get_reserve_data_debug(struct net_buf_pool *pool,
-					       s32_t timeout,
+					       k_timeout_t timeout,
 					       const char *caller,
 					       int line)
 #else /* NET_LOG_LEVEL >= LOG_LEVEL_DBG */
 struct net_buf *net_pkt_get_reserve_data(struct net_buf_pool *pool,
-					 s32_t timeout)
+					 k_timeout_t timeout)
 #endif /* NET_LOG_LEVEL >= LOG_LEVEL_DBG */
 {
 	struct net_buf *frag;
@@ -405,11 +405,11 @@ struct net_buf *net_pkt_get_reserve_data(struct net_buf_pool *pool,
  */
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
 struct net_buf *net_pkt_get_frag_debug(struct net_pkt *pkt,
-				       s32_t timeout,
+				       k_timeout_t timeout,
 				       const char *caller, int line)
 #else
 struct net_buf *net_pkt_get_frag(struct net_pkt *pkt,
-				 s32_t timeout)
+				 k_timeout_t timeout)
 #endif
 {
 #if defined(CONFIG_NET_CONTEXT_NET_PKT_POOL)
@@ -443,13 +443,13 @@ struct net_buf *net_pkt_get_frag(struct net_pkt *pkt,
 }
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
-struct net_buf *net_pkt_get_reserve_rx_data_debug(s32_t timeout,
+struct net_buf *net_pkt_get_reserve_rx_data_debug(k_timeout_t timeout,
 						  const char *caller, int line)
 {
 	return net_pkt_get_reserve_data_debug(&rx_bufs, timeout, caller, line);
 }
 
-struct net_buf *net_pkt_get_reserve_tx_data_debug(s32_t timeout,
+struct net_buf *net_pkt_get_reserve_tx_data_debug(k_timeout_t timeout,
 						  const char *caller, int line)
 {
 	return net_pkt_get_reserve_data_debug(&tx_bufs, timeout, caller, line);
@@ -457,12 +457,12 @@ struct net_buf *net_pkt_get_reserve_tx_data_debug(s32_t timeout,
 
 #else /* NET_LOG_LEVEL >= LOG_LEVEL_DBG */
 
-struct net_buf *net_pkt_get_reserve_rx_data(s32_t timeout)
+struct net_buf *net_pkt_get_reserve_rx_data(k_timeout_t timeout)
 {
 	return net_pkt_get_reserve_data(&rx_bufs, timeout);
 }
 
-struct net_buf *net_pkt_get_reserve_tx_data(s32_t timeout)
+struct net_buf *net_pkt_get_reserve_tx_data(k_timeout_t timeout)
 {
 	return net_pkt_get_reserve_data(&tx_bufs, timeout);
 }
@@ -850,14 +850,14 @@ void net_pkt_print(void)
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
 static struct net_buf *pkt_alloc_buffer(struct net_buf_pool *pool,
-					size_t size, s32_t timeout,
+					size_t size, k_timeout_t timeout,
 					const char *caller, int line)
 #else
 static struct net_buf *pkt_alloc_buffer(struct net_buf_pool *pool,
-					size_t size, s32_t timeout)
+					size_t size, k_timeout_t timeout)
 #endif
 {
-	u32_t alloc_start = k_uptime_get_32();
+	u64_t end = z_timeout_end_calc(timeout);
 	struct net_buf *first = NULL;
 	struct net_buf *current = NULL;
 
@@ -882,10 +882,15 @@ static struct net_buf *pkt_alloc_buffer(struct net_buf_pool *pool,
 
 		size -= current->size;
 
-		if (timeout != K_NO_WAIT && timeout != K_FOREVER) {
-			u32_t diff = k_uptime_get_32() - alloc_start;
+		if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT) &&
+		    !K_TIMEOUT_EQ(timeout, K_FOREVER)) {
+			s64_t remaining = end - z_tick_get();
 
-			timeout -= MIN(timeout, diff);
+			if (remaining <= 0) {
+				break;
+			}
+
+			timeout = Z_TIMEOUT_TICKS(remaining);
 		}
 
 #if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
@@ -912,11 +917,11 @@ error:
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
 static struct net_buf *pkt_alloc_buffer(struct net_buf_pool *pool,
-					size_t size, s32_t timeout,
+					size_t size, k_timeout_t timeout,
 					const char *caller, int line)
 #else
 static struct net_buf *pkt_alloc_buffer(struct net_buf_pool *pool,
-					size_t size, s32_t timeout)
+					size_t size, k_timeout_t timeout)
 #endif
 {
 	struct net_buf *buf;
@@ -1088,17 +1093,17 @@ void net_pkt_trim_buffer(struct net_pkt *pkt)
 int net_pkt_alloc_buffer_debug(struct net_pkt *pkt,
 			       size_t size,
 			       enum net_ip_protocol proto,
-			       s32_t timeout,
+			       k_timeout_t timeout,
 			       const char *caller,
 			       int line)
 #else
 int net_pkt_alloc_buffer(struct net_pkt *pkt,
 			 size_t size,
 			 enum net_ip_protocol proto,
-			 s32_t timeout)
+			 k_timeout_t timeout)
 #endif
 {
-	u32_t alloc_start = k_uptime_get_32();
+	u64_t end = z_timeout_end_calc(timeout);
 	struct net_buf_pool *pool = NULL;
 	size_t alloc_len = 0;
 	size_t hdr_len = 0;
@@ -1137,10 +1142,15 @@ int net_pkt_alloc_buffer(struct net_pkt *pkt,
 		pool = pkt->slab == &tx_pkts ? &tx_bufs : &rx_bufs;
 	}
 
-	if (timeout != K_NO_WAIT && timeout != K_FOREVER) {
-		u32_t diff = k_uptime_get_32() - alloc_start;
+	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT) &&
+	    !K_TIMEOUT_EQ(timeout, K_FOREVER)) {
+		s64_t remaining = end - z_tick_get();
 
-		timeout -= MIN(timeout, diff);
+		if (remaining <= 0) {
+			timeout = K_NO_WAIT;
+		} else {
+			timeout = Z_TIMEOUT_TICKS(remaining);
+		}
 	}
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
@@ -1165,10 +1175,10 @@ int net_pkt_alloc_buffer(struct net_pkt *pkt,
 }
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
-static struct net_pkt *pkt_alloc(struct k_mem_slab *slab, s32_t timeout,
+static struct net_pkt *pkt_alloc(struct k_mem_slab *slab, k_timeout_t timeout,
 				 const char *caller, int line)
 #else
-static struct net_pkt *pkt_alloc(struct k_mem_slab *slab, s32_t timeout)
+static struct net_pkt *pkt_alloc(struct k_mem_slab *slab, k_timeout_t timeout)
 #endif
 {
 	struct net_pkt *pkt;
@@ -1225,10 +1235,10 @@ static struct net_pkt *pkt_alloc(struct k_mem_slab *slab, s32_t timeout)
 }
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
-struct net_pkt *net_pkt_alloc_debug(s32_t timeout,
+struct net_pkt *net_pkt_alloc_debug(k_timeout_t timeout,
 				    const char *caller, int line)
 #else
-struct net_pkt *net_pkt_alloc(s32_t timeout)
+struct net_pkt *net_pkt_alloc(k_timeout_t timeout)
 #endif
 {
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
@@ -1240,11 +1250,11 @@ struct net_pkt *net_pkt_alloc(s32_t timeout)
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
 struct net_pkt *net_pkt_alloc_from_slab_debug(struct k_mem_slab *slab,
-					      s32_t timeout,
+					      k_timeout_t timeout,
 					      const char *caller, int line)
 #else
 struct net_pkt *net_pkt_alloc_from_slab(struct k_mem_slab *slab,
-					s32_t timeout)
+					k_timeout_t timeout)
 #endif
 {
 	if (!slab) {
@@ -1259,10 +1269,10 @@ struct net_pkt *net_pkt_alloc_from_slab(struct k_mem_slab *slab,
 }
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
-struct net_pkt *net_pkt_rx_alloc_debug(s32_t timeout,
+struct net_pkt *net_pkt_rx_alloc_debug(k_timeout_t timeout,
 				       const char *caller, int line)
 #else
-struct net_pkt *net_pkt_rx_alloc(s32_t timeout)
+struct net_pkt *net_pkt_rx_alloc(k_timeout_t timeout)
 #endif
 {
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
@@ -1274,11 +1284,13 @@ struct net_pkt *net_pkt_rx_alloc(s32_t timeout)
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
 static struct net_pkt *pkt_alloc_on_iface(struct k_mem_slab *slab,
-					  struct net_if *iface, s32_t timeout,
+					  struct net_if *iface,
+					  k_timeout_t timeout,
 					  const char *caller, int line)
 #else
 static struct net_pkt *pkt_alloc_on_iface(struct k_mem_slab *slab,
-					  struct net_if *iface, s32_t timeout)
+					  struct net_if *iface,
+					  k_timeout_t timeout)
 
 #endif
 {
@@ -1299,11 +1311,12 @@ static struct net_pkt *pkt_alloc_on_iface(struct k_mem_slab *slab,
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
 struct net_pkt *net_pkt_alloc_on_iface_debug(struct net_if *iface,
-					     s32_t timeout,
+					     k_timeout_t timeout,
 					     const char *caller,
 					     int line)
 #else
-struct net_pkt *net_pkt_alloc_on_iface(struct net_if *iface, s32_t timeout)
+struct net_pkt *net_pkt_alloc_on_iface(struct net_if *iface,
+				       k_timeout_t timeout)
 #endif
 {
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
@@ -1315,11 +1328,12 @@ struct net_pkt *net_pkt_alloc_on_iface(struct net_if *iface, s32_t timeout)
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
 struct net_pkt *net_pkt_rx_alloc_on_iface_debug(struct net_if *iface,
-						s32_t timeout,
+						k_timeout_t timeout,
 						const char *caller,
 						int line)
 #else
-struct net_pkt *net_pkt_rx_alloc_on_iface(struct net_if *iface, s32_t timeout)
+struct net_pkt *net_pkt_rx_alloc_on_iface(struct net_if *iface,
+					  k_timeout_t timeout)
 #endif
 {
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
@@ -1336,7 +1350,7 @@ pkt_alloc_with_buffer(struct k_mem_slab *slab,
 		      size_t size,
 		      sa_family_t family,
 		      enum net_ip_protocol proto,
-		      s32_t timeout,
+		      k_timeout_t timeout,
 		      const char *caller,
 		      int line)
 #else
@@ -1346,10 +1360,10 @@ pkt_alloc_with_buffer(struct k_mem_slab *slab,
 		      size_t size,
 		      sa_family_t family,
 		      enum net_ip_protocol proto,
-		      s32_t timeout)
+		      k_timeout_t timeout)
 #endif
 {
-	u32_t alloc_start = k_uptime_get_32();
+	u64_t end = z_timeout_end_calc(timeout);
 	struct net_pkt *pkt;
 	int ret;
 
@@ -1367,10 +1381,15 @@ pkt_alloc_with_buffer(struct k_mem_slab *slab,
 
 	net_pkt_set_family(pkt, family);
 
-	if (timeout != K_NO_WAIT && timeout != K_FOREVER) {
-		u32_t diff = k_uptime_get_32() - alloc_start;
+	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT) &&
+	    !K_TIMEOUT_EQ(timeout, K_FOREVER)) {
+		s64_t remaining = end - z_tick_get();
 
-		timeout -= MIN(timeout, diff);
+		if (remaining <= 0) {
+			timeout = K_NO_WAIT;
+		} else {
+			timeout = Z_TIMEOUT_TICKS(remaining);
+		}
 	}
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
@@ -1393,7 +1412,7 @@ struct net_pkt *net_pkt_alloc_with_buffer_debug(struct net_if *iface,
 						size_t size,
 						sa_family_t family,
 						enum net_ip_protocol proto,
-						s32_t timeout,
+						k_timeout_t timeout,
 						const char *caller,
 						int line)
 #else
@@ -1401,7 +1420,7 @@ struct net_pkt *net_pkt_alloc_with_buffer(struct net_if *iface,
 					  size_t size,
 					  sa_family_t family,
 					  enum net_ip_protocol proto,
-					  s32_t timeout)
+					  k_timeout_t timeout)
 #endif
 {
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
@@ -1418,7 +1437,7 @@ struct net_pkt *net_pkt_rx_alloc_with_buffer_debug(struct net_if *iface,
 						   size_t size,
 						   sa_family_t family,
 						   enum net_ip_protocol proto,
-						   s32_t timeout,
+						   k_timeout_t timeout,
 						   const char *caller,
 						   int line)
 #else
@@ -1426,7 +1445,7 @@ struct net_pkt *net_pkt_rx_alloc_with_buffer(struct net_if *iface,
 					     size_t size,
 					     sa_family_t family,
 					     enum net_ip_protocol proto,
-					     s32_t timeout)
+					     k_timeout_t timeout)
 #endif
 {
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
@@ -1725,7 +1744,7 @@ static void clone_pkt_attributes(struct net_pkt *pkt, struct net_pkt *clone_pkt)
 	}
 }
 
-struct net_pkt *net_pkt_clone(struct net_pkt *pkt, s32_t timeout)
+struct net_pkt *net_pkt_clone(struct net_pkt *pkt, k_timeout_t timeout)
 {
 	size_t cursor_offset = net_pkt_get_current_offset(pkt);
 	struct net_pkt *clone_pkt;
@@ -1774,7 +1793,7 @@ struct net_pkt *net_pkt_clone(struct net_pkt *pkt, s32_t timeout)
 	return clone_pkt;
 }
 
-struct net_pkt *net_pkt_shallow_clone(struct net_pkt *pkt, s32_t timeout)
+struct net_pkt *net_pkt_shallow_clone(struct net_pkt *pkt, k_timeout_t timeout)
 {
 	struct net_pkt *clone_pkt;
 	struct net_buf *buf;

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1645,7 +1645,7 @@ static int cmd_net_dns_query(const struct shell *shell, size_t argc,
 {
 
 #if defined(CONFIG_DNS_RESOLVER)
-#define DNS_TIMEOUT K_MSEC(2000) /* ms */
+#define DNS_TIMEOUT (MSEC_PER_SEC * 2) /* ms */
 	enum dns_query_type qtype = DNS_QUERY_TYPE_A;
 	char *host, *type = NULL;
 	int ret, arg = 1;

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -2970,7 +2970,7 @@ static int ping_ipv6(const struct shell *shell,
 			break;
 		}
 
-		k_sleep(interval);
+		k_msleep(interval);
 	}
 
 	remove_ipv6_ping_handler();
@@ -3075,7 +3075,7 @@ static int ping_ipv4(const struct shell *shell,
 			break;
 		}
 
-		k_sleep(interval);
+		k_msleep(interval);
 	}
 
 	remove_ipv4_ping_handler();

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -3213,7 +3213,7 @@ static int cmd_net_ppp_ping(const struct shell *shell, size_t argc,
 			return -ENOEXEC;
 		}
 
-		ret = net_ppp_ping(idx, K_SECONDS(1));
+		ret = net_ppp_ping(idx, MSEC_PER_SEC * 1);
 		if (ret < 0) {
 			if (ret == -EAGAIN) {
 				PR_INFO("PPP Echo-Req timeout.\n");

--- a/subsys/net/ip/promiscuous.c
+++ b/subsys/net/ip/promiscuous.c
@@ -25,7 +25,7 @@ LOG_MODULE_REGISTER(net_promisc, CONFIG_NET_PROMISC_LOG_LEVEL);
 static K_FIFO_DEFINE(promiscuous_queue);
 static atomic_t enabled = ATOMIC_INIT(0);
 
-struct net_pkt *net_promisc_mode_wait_data(s32_t timeout)
+struct net_pkt *net_promisc_mode_wait_data(k_timeout_t timeout)
 {
 	return k_fifo_get(&promiscuous_queue, timeout);
 }

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1007,10 +1007,13 @@ int net_tcp_connect(struct net_context *context,
 		    const struct sockaddr *remote_addr,
 		    struct sockaddr *local_addr,
 		    u16_t remote_port, u16_t local_port,
-		    s32_t timeout, net_context_connect_cb_t cb, void *user_data)
+		    k_timeout_t timeout, net_context_connect_cb_t cb,
+		    void *user_data)
 {
 	struct tcp *conn;
 	int ret;
+
+	ARG_UNUSED(timeout);
 
 	NET_DBG("context: %p, local: %s, remote: %s", context,
 		log_strdup(tcp_endpoint_to_string((void *)local_addr)),

--- a/subsys/net/ip/tcp_internal.h
+++ b/subsys/net/ip/tcp_internal.h
@@ -740,14 +740,14 @@ int net_tcp_connect(struct net_context *context,
 		    struct sockaddr *laddr,
 		    u16_t rport,
 		    u16_t lport,
-		    s32_t timeout,
+		    k_timeout_t timeout,
 		    net_context_connect_cb_t cb,
 		    void *user_data);
 #else
 static inline int net_tcp_connect(struct net_context *context,
 				  const struct sockaddr *addr,
 				  struct sockaddr *laddr,
-				  u16_t rport, u16_t lport, s32_t timeout,
+				  u16_t rport, u16_t lport, k_timeout_t timeout,
 				  net_context_connect_cb_t cb, void *user_data)
 {
 	ARG_UNUSED(context);

--- a/subsys/net/ip/trickle.c
+++ b/subsys/net/ip/trickle.c
@@ -80,7 +80,7 @@ static void double_interval_timeout(struct k_work *work)
 
 	trickle->Istart = k_uptime_get_32() + rand_time;
 	k_delayed_work_init(&trickle->timer, trickle_timeout);
-	k_delayed_work_submit(&trickle->timer, rand_time);
+	k_delayed_work_submit(&trickle->timer, K_MSEC(rand_time));
 
 	NET_DBG("last end %u new end %u for %u I %u",
 		last_end, get_end(trickle), trickle->Istart, trickle->I);
@@ -100,7 +100,7 @@ static inline void reschedule(struct net_trickle *trickle)
 	}
 
 	k_delayed_work_init(&trickle->timer, double_interval_timeout);
-	k_delayed_work_submit(&trickle->timer, diff);
+	k_delayed_work_submit(&trickle->timer, K_MSEC(diff));
 }
 
 static void trickle_timeout(struct k_work *work)
@@ -134,7 +134,7 @@ static void setup_new_interval(struct net_trickle *trickle)
 
 	trickle->Istart = k_uptime_get_32();
 
-	k_delayed_work_submit(&trickle->timer, t);
+	k_delayed_work_submit(&trickle->timer, K_MSEC(t));
 
 	NET_DBG("new interval at %d ends %d t %d I %d",
 		trickle->Istart,

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(net_arp, CONFIG_NET_ARP_LOG_LEVEL);
 #include "net_private.h"
 
 #define NET_BUF_TIMEOUT K_MSEC(100)
-#define ARP_REQUEST_TIMEOUT K_SECONDS(2)
+#define ARP_REQUEST_TIMEOUT (2 * MSEC_PER_SEC)
 
 static bool arp_cache_initialized;
 static struct arp_entry arp_entries[CONFIG_NET_ARP_TABLE_SIZE];
@@ -173,7 +173,7 @@ static void arp_entry_register_pending(struct arp_entry *entry)
 	/* Let's start the timer if necessary */
 	if (!k_delayed_work_remaining_get(&arp_request_timer)) {
 		k_delayed_work_submit(&arp_request_timer,
-				      ARP_REQUEST_TIMEOUT);
+				      K_MSEC(ARP_REQUEST_TIMEOUT));
 	}
 }
 
@@ -201,8 +201,8 @@ static void arp_request_timeout(struct k_work *work)
 
 	if (entry) {
 		k_delayed_work_submit(&arp_request_timer,
-				      entry->req_start +
-				      ARP_REQUEST_TIMEOUT - current);
+				      K_MSEC(entry->req_start +
+					     ARP_REQUEST_TIMEOUT - current));
 	}
 }
 

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -735,7 +735,7 @@ void gptp_update_pdelay_req_interval(int port, s8_t log_val)
 		new_itv = 1;
 	}
 
-	k_timer_start(&state_pdelay->pdelay_timer, new_itv, K_NO_WAIT);
+	k_timer_start(&state_pdelay->pdelay_timer, K_MSEC(new_itv), K_NO_WAIT);
 }
 
 void gptp_update_sync_interval(int port, s8_t log_val)
@@ -785,7 +785,8 @@ void gptp_update_sync_interval(int port, s8_t log_val)
 		new_itv = 1;
 	}
 
-	k_timer_start(&state_pss_send->half_sync_itv_timer, new_itv, period);
+	k_timer_start(&state_pss_send->half_sync_itv_timer, K_MSEC(new_itv),
+		      period);
 }
 
 void gptp_update_announce_interval(int port, s8_t log_val)
@@ -814,7 +815,8 @@ void gptp_update_announce_interval(int port, s8_t log_val)
 		new_itv = 1;
 	}
 
-	k_timer_start(&state_ann->ann_send_periodic_timer, new_itv, K_NO_WAIT);
+	k_timer_start(&state_ann->ann_send_periodic_timer, K_MSEC(new_itv),
+		      K_NO_WAIT);
 }
 
 struct port_user_data {

--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -596,7 +596,7 @@ void gptp_handle_sync(int port, struct net_pkt *pkt)
 	struct gptp_port_ds *port_ds;
 	struct gptp_hdr *hdr;
 	u64_t upstream_sync_itv;
-	s32_t duration;
+	k_timeout_t duration;
 
 	state = &GPTP_PORT_STATE(port)->sync_rcv;
 	port_ds = GPTP_PORT_DS(port);
@@ -605,7 +605,7 @@ void gptp_handle_sync(int port, struct net_pkt *pkt)
 	upstream_sync_itv = NSEC_PER_SEC * GPTP_POW2(hdr->log_msg_interval);
 
 	/* Convert ns to ms. */
-	duration = (upstream_sync_itv / 1000000U);
+	duration = K_MSEC((upstream_sync_itv / 1000000U));
 
 	/* Start timeout timer. */
 	k_timer_start(&state->follow_up_discard_timer, duration, K_NO_WAIT);

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -352,9 +352,9 @@ static void gptp_mi_pss_rcv_compute(int port)
 static void start_rcv_sync_timer(struct gptp_port_ds *port_ds,
 				 struct gptp_pss_rcv_state *state)
 {
-	s32_t duration;
+	k_timeout_t duration;
 
-	duration = port_ds->sync_receipt_timeout_time_itv;
+	duration = K_MSEC(port_ds->sync_receipt_timeout_time_itv);
 
 	k_timer_start(&state->rcv_sync_receipt_timeout_timer, duration,
 		      K_NO_WAIT);
@@ -455,7 +455,7 @@ static void gptp_mi_pss_send_state_machine(int port)
 	struct gptp_pss_send_state *state;
 	struct gptp_port_ds *port_ds;
 	struct gptp_global_ds *global_ds;
-	s32_t duration;
+	k_timeout_t duration;
 
 	global_ds = GPTP_GLOBAL_DS();
 	state = &GPTP_PORT_STATE(port)->pss_send;
@@ -503,8 +503,8 @@ static void gptp_mi_pss_send_state_machine(int port)
 		state->send_sync_receipt_timeout_timer_expired = false;
 
 		/* Convert ns to ms. */
-		duration = gptp_uscaled_ns_to_timer_ms(
-						&port_ds->half_sync_itv);
+		duration = K_MSEC(gptp_uscaled_ns_to_timer_ms(
+					  &port_ds->half_sync_itv));
 
 		/* Start 0.5 * syncInterval timeout timer. */
 		k_timer_start(&state->half_sync_itv_timer, duration,
@@ -546,8 +546,9 @@ static void gptp_mi_pss_send_state_machine(int port)
 			k_timer_stop(&state->send_sync_receipt_timeout_timer);
 			state->send_sync_receipt_timeout_timer_expired = false;
 
-			duration = port_ds->sync_receipt_timeout_time_itv /
-				(NSEC_PER_USEC * USEC_PER_MSEC);
+			duration =
+				K_MSEC(port_ds->sync_receipt_timeout_time_itv /
+				       (NSEC_PER_USEC * USEC_PER_MSEC));
 
 			k_timer_start(&state->send_sync_receipt_timeout_timer,
 				      duration, K_NO_WAIT);
@@ -1492,8 +1493,8 @@ static void gptp_mi_port_announce_information_state_machine(int port)
 		k_timer_stop(&state->ann_rcpt_expiry_timer);
 		state->ann_expired = false;
 		k_timer_start(&state->ann_rcpt_expiry_timer,
-			      gptp_uscaled_ns_to_timer_ms(
-				   &bmca_data->ann_rcpt_timeout_time_interval),
+			      K_MSEC(gptp_uscaled_ns_to_timer_ms(
+				  &bmca_data->ann_rcpt_timeout_time_interval)),
 			      K_NO_WAIT);
 		/* Fallthrough. */
 
@@ -1890,8 +1891,8 @@ static void gptp_mi_port_announce_transmit_state_machine(int port)
 		k_timer_stop(&state->ann_send_periodic_timer);
 		state->ann_trigger = false;
 		k_timer_start(&state->ann_send_periodic_timer,
-			      gptp_uscaled_ns_to_timer_ms(
-				      &bmca_data->announce_interval),
+			      K_MSEC(gptp_uscaled_ns_to_timer_ms(
+					     &bmca_data->announce_interval)),
 			      K_NO_WAIT);
 
 		state->state = GPTP_PA_TRANSMIT_POST_IDLE;

--- a/subsys/net/l2/ethernet/lldp/lldp.c
+++ b/subsys/net/l2/ethernet/lldp/lldp.c
@@ -56,7 +56,7 @@ static void lldp_submit_work(u32_t timeout)
 	if (!k_delayed_work_remaining_get(&lldp_tx_timer) ||
 	    timeout < k_delayed_work_remaining_get(&lldp_tx_timer)) {
 		k_delayed_work_cancel(&lldp_tx_timer);
-		k_delayed_work_submit(&lldp_tx_timer, timeout);
+		k_delayed_work_submit(&lldp_tx_timer, K_MSEC(timeout));
 
 		NET_DBG("Next wakeup in %d ms",
 			k_delayed_work_remaining_get(&lldp_tx_timer));
@@ -187,7 +187,7 @@ static void lldp_tx_timeout(struct k_work *work)
 	if (timeout_update < (UINT32_MAX - 1)) {
 		NET_DBG("Waiting for %u ms", timeout_update);
 
-		k_delayed_work_submit(&lldp_tx_timer, timeout_update);
+		k_delayed_work_submit(&lldp_tx_timer, K_MSEC(timeout_update));
 	}
 }
 
@@ -201,7 +201,7 @@ static void lldp_start_timer(struct ethernet_context *ctx,
 
 	ctx->lldp[slot].tx_timer_start = k_uptime_get();
 	ctx->lldp[slot].tx_timer_timeout =
-		K_SECONDS(CONFIG_NET_LLDP_TX_INTERVAL);
+				CONFIG_NET_LLDP_TX_INTERVAL * MSEC_PER_SEC;
 
 	lldp_submit_work(ctx->lldp[slot].tx_timer_timeout);
 }

--- a/subsys/net/l2/ieee802154/ieee802154_mgmt.c
+++ b/subsys/net/l2/ieee802154/ieee802154_mgmt.c
@@ -156,7 +156,7 @@ static int ieee802154_scan(u32_t mgmt_request, struct net_if *iface,
 		}
 
 		/* Context aware sleep */
-		k_sleep(scan->duration);
+		k_sleep(K_MSEC(scan->duration));
 
 		if (!ctx->scan_ctx) {
 			NET_DBG("Scan request cancelled");

--- a/subsys/net/l2/ppp/fsm.c
+++ b/subsys/net/l2/ppp/fsm.c
@@ -19,7 +19,7 @@ LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 #define BUF_ALLOC_TIMEOUT K_MSEC(100)
 
 /* This timeout is in milliseconds */
-#define FSM_TIMEOUT CONFIG_NET_L2_PPP_TIMEOUT
+#define FSM_TIMEOUT K_MSEC(CONFIG_NET_L2_PPP_TIMEOUT)
 
 #define MAX_NACK_LOOPS CONFIG_NET_L2_PPP_MAX_NACK_LOOPS
 
@@ -118,8 +118,7 @@ static void ppp_fsm_timeout(struct k_work *work)
 
 			fsm->retransmits--;
 
-			(void)k_delayed_work_submit(&fsm->timer,
-						    FSM_TIMEOUT);
+			(void)k_delayed_work_submit(&fsm->timer, FSM_TIMEOUT);
 		}
 
 		break;
@@ -517,7 +516,7 @@ int ppp_send_pkt(struct ppp_fsm *fsm, struct net_if *iface,
 		 * in that case.
 		 */
 		(void)k_delayed_work_submit(&fsm->sender.work,
-				IS_ENABLED(CONFIG_NET_TEST) ? K_MSEC(1) : 0);
+			  IS_ENABLED(CONFIG_NET_TEST) ? K_MSEC(1) : K_NO_WAIT);
 	} else {
 		ret = net_send_data(pkt);
 		if (ret < 0) {

--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -373,7 +373,7 @@ int net_ppp_ping(int idx, s32_t timeout)
 		return ret;
 	}
 
-	ret = k_sem_take(&ctx->shell.wait_echo_reply, timeout);
+	ret = k_sem_take(&ctx->shell.wait_echo_reply, K_MSEC(timeout));
 
 	ctx->shell.echo_reply.cb = NULL;
 

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -357,7 +357,7 @@ int net_config_init(const char *app_info, u32_t flags, s32_t timeout)
 				break;
 			}
 
-			if (k_sem_take(&waiter, loop)) {
+			if (k_sem_take(&waiter, K_MSEC(loop))) {
 				if (!k_sem_count_get(&counter)) {
 					break;
 				}
@@ -402,7 +402,7 @@ int net_config_init(const char *app_info, u32_t flags, s32_t timeout)
 	 * to wait multiple events, sleep smaller amounts of data.
 	 */
 	while (count--) {
-		if (k_sem_take(&waiter, loop)) {
+		if (k_sem_take(&waiter, K_MSEC(loop))) {
 			if (!k_sem_count_get(&counter)) {
 				break;
 			}
@@ -452,7 +452,7 @@ static int init_app(struct device *device)
 
 	/* Initialize the application automatically if needed */
 	ret = net_config_init("Initializing network", flags,
-			      K_SECONDS(CONFIG_NET_CONFIG_INIT_TIMEOUT));
+			      CONFIG_NET_CONFIG_INIT_TIMEOUT * MSEC_PER_SEC);
 	if (ret < 0) {
 		NET_ERR("Network initialization failed (%d)", ret);
 	}

--- a/subsys/net/lib/conn_mgr/conn_mgr.c
+++ b/subsys/net/lib/conn_mgr/conn_mgr.c
@@ -172,7 +172,7 @@ static void conn_mgr(void)
 
 K_THREAD_DEFINE(conn_mgr_thread, CONFIG_NET_CONNECTION_MANAGER_STACK_SIZE,
 		(k_thread_entry_t)conn_mgr, NULL, NULL, NULL,
-		K_PRIO_COOP(2), 0, K_NO_WAIT);
+		K_PRIO_COOP(2), 0, 0);
 
 void net_conn_mgr_resend_status(void)
 {

--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -216,8 +216,8 @@ int z_impl_z_zsock_getaddrinfo_internal(const char *host, const char *service,
 		 * we do not need to start to cancel any pending DNS queries.
 		 */
 		int ret = k_sem_take(&ai_state.sem,
-				     CONFIG_NET_SOCKETS_DNS_TIMEOUT +
-				     K_MSEC(100));
+				     K_MSEC(CONFIG_NET_SOCKETS_DNS_TIMEOUT +
+					    100));
 		if (ret == -EAGAIN) {
 			return DNS_EAI_AGAIN;
 		}
@@ -243,9 +243,9 @@ int z_impl_z_zsock_getaddrinfo_internal(const char *host, const char *service,
 	if (family == AF_UNSPEC && IS_ENABLED(CONFIG_NET_IPV6)) {
 		ret = exec_query(host, AF_INET6, &ai_state);
 		if (ret == 0) {
-			int ret = k_sem_take(&ai_state.sem,
-					     CONFIG_NET_SOCKETS_DNS_TIMEOUT +
-					     K_MSEC(100));
+			int ret = k_sem_take(
+				&ai_state.sem,
+				K_MSEC(CONFIG_NET_SOCKETS_DNS_TIMEOUT + 100));
 			if (ret == -EAGAIN) {
 				return DNS_EAI_AGAIN;
 			}

--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -37,7 +37,8 @@ extern const struct socket_op_vtable sock_fd_op_vtable;
 
 static const struct socket_op_vtable can_sock_fd_op_vtable;
 
-static inline int k_fifo_wait_non_empty(struct k_fifo *fifo, int32_t timeout)
+static inline int k_fifo_wait_non_empty(struct k_fifo *fifo,
+					k_timeout_t timeout)
 {
 	struct k_poll_event events[] = {
 		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_FIFO_DATA_AVAILABLE,
@@ -214,7 +215,7 @@ ssize_t zcan_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 {
 	struct sockaddr_can can_addr;
 	struct zcan_frame zframe;
-	s32_t timeout = K_FOREVER;
+	k_timeout_t timeout = K_FOREVER;
 	int ret;
 
 	/* Setting destination address does not probably make sense here so
@@ -263,7 +264,7 @@ static ssize_t zcan_recvfrom_ctx(struct net_context *ctx, void *buf,
 {
 	struct zcan_frame zframe;
 	size_t recv_len = 0;
-	s32_t timeout = K_FOREVER;
+	k_timeout_t timeout = K_FOREVER;
 	struct net_pkt *pkt;
 
 	if ((flags & ZSOCK_MSG_DONTWAIT) || sock_is_nonblock(ctx)) {

--- a/subsys/net/lib/sockets/sockets_net_mgmt.c
+++ b/subsys/net/lib/sockets/sockets_net_mgmt.c
@@ -34,10 +34,10 @@ struct net_mgmt_socket {
 	u32_t mask;
 
 	/* Message allocation timeout */
-	s32_t alloc_timeout;
+	k_timeout_t alloc_timeout;
 
 	/* net_mgmt event timeout */
-	s32_t wait_timeout;
+	k_timeout_t wait_timeout;
 
 	/* Socket protocol */
 	int proto;
@@ -151,7 +151,7 @@ static ssize_t znet_mgmt_recvfrom(struct net_mgmt_socket *mgmt, void *buf,
 				  socklen_t *addrlen)
 {
 	struct sockaddr_nm *nm_addr = (struct sockaddr_nm *)src_addr;
-	s32_t timeout = mgmt->wait_timeout;
+	k_timeout_t timeout = mgmt->wait_timeout;
 	u32_t raised_event = 0;
 	u8_t *copy_to = buf;
 	struct net_mgmt_msghdr hdr;
@@ -190,7 +190,7 @@ again:
 	}
 
 	if ((mgmt->mask & raised_event) != raised_event) {
-		if (timeout == K_FOREVER) {
+		if (K_TIMEOUT_EQ(timeout, K_FOREVER)) {
 			goto again;
 		}
 

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -28,7 +28,8 @@ extern const struct socket_op_vtable sock_fd_op_vtable;
 
 static const struct socket_op_vtable packet_sock_fd_op_vtable;
 
-static inline int k_fifo_wait_non_empty(struct k_fifo *fifo, int32_t timeout)
+static inline int k_fifo_wait_non_empty(struct k_fifo *fifo,
+					k_timeout_t timeout)
 {
 	struct k_poll_event events[] = {
 		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_FIFO_DATA_AVAILABLE,
@@ -146,7 +147,7 @@ ssize_t zpacket_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 			   int flags, const struct sockaddr *dest_addr,
 			   socklen_t addrlen)
 {
-	s32_t timeout = K_FOREVER;
+	k_timeout_t timeout = K_FOREVER;
 	int status;
 
 	if (!dest_addr) {
@@ -184,7 +185,7 @@ ssize_t zpacket_recvfrom_ctx(struct net_context *ctx, void *buf, size_t max_len,
 			     socklen_t *addrlen)
 {
 	size_t recv_len = 0;
-	s32_t timeout = K_FOREVER;
+	k_timeout_t timeout = K_FOREVER;
 	struct net_pkt *pkt;
 
 	if ((flags & ZSOCK_MSG_DONTWAIT) || sock_is_nonblock(ctx)) {

--- a/subsys/net/lib/websocket/websocket_internal.h
+++ b/subsys/net/lib/websocket/websocket_internal.h
@@ -78,10 +78,6 @@ struct websocket_context {
 	/** Websocket connection masking value */
 	u32_t masking_value;
 
-	/** Timeout for Websocket operations.
-	 */
-	s32_t timeout;
-
 	/** Amount of data received. */
 	u64_t total_read;
 

--- a/subsys/shell/shell_telnet.c
+++ b/subsys/shell/shell_telnet.c
@@ -28,7 +28,7 @@ struct shell_telnet *sh_telnet;
 /* Various definitions mapping the TELNET service configuration options */
 #define TELNET_PORT      CONFIG_SHELL_TELNET_PORT
 #define TELNET_LINE_SIZE CONFIG_SHELL_TELNET_LINE_BUF_SIZE
-#define TELNET_TIMEOUT   K_MSEC(CONFIG_SHELL_TELNET_SEND_TIMEOUT)
+#define TELNET_TIMEOUT   CONFIG_SHELL_TELNET_SEND_TIMEOUT
 
 #define TELNET_MIN_MSG 2
 
@@ -232,7 +232,7 @@ static void telnet_accept(struct net_context *client,
 		goto error;
 	}
 
-	if (net_context_recv(client, telnet_recv, 0, NULL)) {
+	if (net_context_recv(client, telnet_recv, K_NO_WAIT, NULL)) {
 		LOG_ERR("Unable to setup reception (family %u)",
 			net_context_get_family(client));
 		goto error;
@@ -422,7 +422,7 @@ static int write(const struct shell_transport *transport,
 		 */
 		timeout = (timeout == 0) ? TELNET_TIMEOUT : timeout;
 
-		k_delayed_work_submit(&sh_telnet->send_work, timeout);
+		k_delayed_work_submit(&sh_telnet->send_work, K_MSEC(timeout));
 	}
 
 	sh_telnet->shell_handler(SHELL_TRANSPORT_EVT_TX_RDY,

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -740,8 +740,8 @@ static void rx_chksum_offload_disabled_test_v6(void)
 	test_started = true;
 	start_receiving = true;
 
-	ret = net_context_recv(udp_v6_ctx_1, recv_cb_offload_disabled, 0,
-			       NULL);
+	ret = net_context_recv(udp_v6_ctx_1, recv_cb_offload_disabled,
+			       K_NO_WAIT, NULL);
 	zassert_equal(ret, 0, "Recv UDP failed (%d)\n", ret);
 
 	start_receiving = false;
@@ -796,8 +796,8 @@ static void rx_chksum_offload_disabled_test_v4(void)
 	test_started = true;
 	start_receiving = true;
 
-	ret = net_context_recv(udp_v4_ctx_1, recv_cb_offload_disabled, 0,
-			       NULL);
+	ret = net_context_recv(udp_v4_ctx_1, recv_cb_offload_disabled,
+			       K_NO_WAIT, NULL);
 	zassert_equal(ret, 0, "Recv UDP failed (%d)\n", ret);
 
 	start_receiving = false;
@@ -852,8 +852,8 @@ static void rx_chksum_offload_enabled_test_v6(void)
 	test_started = true;
 	start_receiving = true;
 
-	ret = net_context_recv(udp_v6_ctx_2, recv_cb_offload_enabled, 0,
-			       NULL);
+	ret = net_context_recv(udp_v6_ctx_2, recv_cb_offload_enabled,
+			       K_NO_WAIT, NULL);
 	zassert_equal(ret, 0, "Recv UDP failed (%d)\n", ret);
 
 	ret = net_context_sendto(udp_v6_ctx_2, test_data, len,
@@ -906,8 +906,8 @@ static void rx_chksum_offload_enabled_test_v4(void)
 	test_started = true;
 	start_receiving = true;
 
-	ret = net_context_recv(udp_v4_ctx_2, recv_cb_offload_enabled, 0,
-			       NULL);
+	ret = net_context_recv(udp_v4_ctx_2, recv_cb_offload_enabled,
+			       K_NO_WAIT, NULL);
 	zassert_equal(ret, 0, "Recv UDP failed (%d)\n", ret);
 
 	ret = net_context_sendto(udp_v4_ctx_2, test_data, len,

--- a/tests/net/context/src/main.c
+++ b/tests/net/context/src/main.c
@@ -65,7 +65,7 @@ static bool test_sending;
 
 static struct k_sem wait_data;
 
-#define WAIT_TIME 250
+#define WAIT_TIME K_MSEC(250)
 #define WAIT_TIME_LONG MSEC_PER_SEC
 #define SENDING 93244
 #define MY_PORT 1969
@@ -678,7 +678,7 @@ void timeout_thread(struct net_context *ctx, void *param2, void *param3)
 	s32_t timeout = POINTER_TO_INT(param3);
 	int ret;
 
-	ret = net_context_recv(ctx, recv_cb_timeout, timeout,
+	ret = net_context_recv(ctx, recv_cb_timeout, K_MSEC(timeout),
 			       INT_TO_POINTER(family));
 	if (ret != -ETIMEDOUT && expecting_cb_failure) {
 		zassert_true(expecting_cb_failure,
@@ -781,10 +781,10 @@ static void net_ctx_recv_v6_timeout_forever(void)
 	recv_cb_timeout_called = false;
 
 	/* Start a thread that will send data to receiver. */
-	tid = start_timeout_v6_thread(K_FOREVER);
+	tid = start_timeout_v6_thread(NET_WAIT_FOREVER);
 
 	/* Wait a bit so that we see if recv waited or not */
-	k_sleep(K_MSEC(WAIT_TIME));
+	k_sleep(WAIT_TIME);
 
 	net_ctx_send_v6();
 
@@ -807,10 +807,10 @@ static void net_ctx_recv_v4_timeout_forever(void)
 	recv_cb_timeout_called = false;
 
 	/* Start a thread that will send data to receiver. */
-	tid = start_timeout_v4_thread(K_FOREVER);
+	tid = start_timeout_v4_thread(NET_WAIT_FOREVER);
 
 	/* Wait a bit so that we see if recv waited or not */
-	k_sleep(K_MSEC(WAIT_TIME));
+	k_sleep(WAIT_TIME);
 
 	net_ctx_send_v4();
 

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -440,7 +440,7 @@ static bool send_iface(struct net_if *iface, int val, bool expect_fail)
 		return false;
 	}
 
-	if (!expect_fail && k_sem_take(&wait_data, WAIT_TIME)) {
+	if (!expect_fail && k_sem_take(&wait_data, K_MSEC(WAIT_TIME))) {
 		DBG("Timeout while waiting interface %d data\n", val);
 		return false;
 	}

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -179,7 +179,7 @@ static void prepare_ra_message(struct net_pkt *pkt)
 	pkt->buffer = NULL;
 
 	net_pkt_alloc_buffer(pkt, sizeof(struct net_eth_hdr) +
-			     sizeof(icmpv6_ra), AF_UNSPEC, 0);
+			     sizeof(icmpv6_ra), AF_UNSPEC, K_NO_WAIT);
 	net_pkt_cursor_init(pkt);
 
 	hdr.type = htons(NET_ETH_PTYPE_IPV6);
@@ -565,7 +565,7 @@ static void test_prefix_timeout_long(void)
 	zassert_equal(ifprefix->lifetime.wrap_counter, 2000,
 		      "Wrap counter wrong (%d)",
 		      ifprefix->lifetime.wrap_counter);
-	remaining = K_SECONDS((u64_t)lifetime) -
+	remaining = MSEC_PER_SEC * (u64_t)lifetime -
 		NET_TIMEOUT_MAX_VALUE * (u64_t)ifprefix->lifetime.wrap_counter;
 
 	zassert_equal(remaining, ifprefix->lifetime.timer_timeout,
@@ -925,7 +925,7 @@ static void test_address_lifetime(void)
 				     0, 0, 0, 0, 0, 0, 0x20, 0x1 } } };
 	struct net_if *iface = net_if_get_default();
 	u32_t vlifetime = 0xffff;
-	u64_t timeout = K_SECONDS((u64_t)vlifetime);
+	u64_t timeout = (u64_t)vlifetime * MSEC_PER_SEC;
 	struct net_if_addr *ifaddr;
 	u64_t remaining;
 	bool ret;
@@ -953,7 +953,7 @@ static void test_address_lifetime(void)
 
 	zassert_equal(ifaddr->lifetime.wrap_counter, 2,
 		      "Wrap counter wrong (%d)", ifaddr->lifetime.wrap_counter);
-	remaining = K_SECONDS((u64_t)vlifetime) -
+	remaining = MSEC_PER_SEC * (u64_t)vlifetime -
 		NET_TIMEOUT_MAX_VALUE * (u64_t)ifaddr->lifetime.wrap_counter;
 
 	zassert_equal(remaining, ifaddr->lifetime.timer_timeout,
@@ -966,8 +966,8 @@ static void test_address_lifetime(void)
 	zassert_equal(ifaddr->lifetime.wrap_counter, 2,
 		      "Wrap counter wrong (%d)", ifaddr->lifetime.wrap_counter);
 
-	ifaddr->lifetime.timer_timeout = K_MSEC(10);
-	ifaddr->lifetime.timer_start = k_uptime_get_32() - K_MSEC(10);
+	ifaddr->lifetime.timer_timeout = 10;
+	ifaddr->lifetime.timer_start = k_uptime_get_32() - 10;
 	ifaddr->lifetime.wrap_counter = 0;
 
 	net_address_lifetime_timeout();
@@ -1258,7 +1258,7 @@ static void net_ctx_recv(struct net_context *ctx)
 {
 	int ret;
 
-	ret = net_context_recv(ctx, recv_cb, 0, NULL);
+	ret = net_context_recv(ctx, recv_cb, K_NO_WAIT, NULL);
 	zassert_equal(ret, 0, "Context recv IPv6 UDP failed");
 }
 

--- a/tests/net/ipv6_fragment/src/main.c
+++ b/tests/net/ipv6_fragment/src/main.c
@@ -908,7 +908,7 @@ static u16_t pkt_recv_data_len;
 
 #define WAIT_TIME K_SECONDS(1)
 
-#define ALLOC_TIMEOUT 500
+#define ALLOC_TIMEOUT K_MSEC(500)
 
 struct net_if_test {
 	u8_t idx;

--- a/tests/net/lib/dns_addremove/src/main.c
+++ b/tests/net/lib/dns_addremove/src/main.c
@@ -71,7 +71,7 @@ static struct dns_resolve_context resv_ipv6_2;
 #endif
 
 /* this must be higher that the DNS_TIMEOUT */
-#define WAIT_TIME ((DNS_TIMEOUT + 300) * 3)
+#define WAIT_TIME K_MSEC((DNS_TIMEOUT + 300) * 3)
 
 struct net_if_test {
 	u8_t idx;

--- a/tests/net/lib/dns_resolve/src/main.c
+++ b/tests/net/lib/dns_resolve/src/main.c
@@ -68,7 +68,7 @@ static u16_t current_dns_id;
 static struct dns_addrinfo addrinfo;
 
 /* this must be higher that the DNS_TIMEOUT */
-#define WAIT_TIME (DNS_TIMEOUT + 300)
+#define WAIT_TIME K_MSEC(DNS_TIMEOUT + 300)
 
 struct net_if_test {
 	u8_t idx;
@@ -279,7 +279,7 @@ static void dns_query_invalid_timeout(void)
 				NULL,
 				dns_result_cb_dummy,
 				NULL,
-				K_NO_WAIT);
+				0);
 	zassert_equal(ret, -EINVAL, "Wrong return code for timeout");
 }
 

--- a/tests/net/mgmt/src/mgmt.c
+++ b/tests/net/mgmt/src/mgmt.c
@@ -29,7 +29,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_MGMT_EVENT_LOG_LEVEL);
 /* Notifier infra */
 static u32_t event2throw;
 static u32_t throw_times;
-static int throw_sleep;
+static k_timeout_t throw_sleep;
 static bool with_info;
 static K_THREAD_STACK_DEFINE(thrower_stack, 512 + CONFIG_TEST_EXTRA_STACKSIZE);
 static struct k_thread thrower_thread_data;

--- a/tests/net/route/src/main.c
+++ b/tests/net/route/src/main.c
@@ -85,7 +85,7 @@ static int msg_sending;
 
 K_SEM_DEFINE(wait_data, 0, UINT_MAX);
 
-#define WAIT_TIME 250
+#define WAIT_TIME K_MSEC(250)
 
 struct net_route_test {
 	u8_t mac_addr[sizeof(struct net_eth_addr)];

--- a/tests/net/socket/getaddrinfo/src/main.c
+++ b/tests/net/socket/getaddrinfo/src/main.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #define MAX_BUF_SIZE 128
 #define STACK_SIZE (1024 + CONFIG_TEST_EXTRA_STACKSIZE)
 #define THREAD_PRIORITY K_PRIO_COOP(8)
-#define WAIT_TIME 250
+#define WAIT_TIME K_MSEC(250)
 
 static u8_t recv_buf[MAX_BUF_SIZE];
 
@@ -165,7 +165,7 @@ static int process_dns(void)
 
 K_THREAD_DEFINE(dns_server_thread_id, STACK_SIZE,
 		process_dns, NULL, NULL, NULL,
-		THREAD_PRIORITY, 0, K_FOREVER);
+		THREAD_PRIORITY, 0, -1);
 
 void test_getaddrinfo_setup(void)
 {

--- a/tests/net/socket/net_mgmt/src/main.c
+++ b/tests/net/socket/net_mgmt/src/main.c
@@ -327,7 +327,7 @@ static void trigger_events(void)
 
 K_THREAD_DEFINE(trigger_events_thread_id, STACK_SIZE,
 		trigger_events, NULL, NULL, NULL,
-		THREAD_PRIORITY, 0, K_FOREVER);
+		THREAD_PRIORITY, 0, -1);
 
 static char *get_ip_addr(char *ipaddr, size_t len, sa_family_t family,
 			 struct net_mgmt_msghdr *hdr)

--- a/tests/net/socket/poll/src/main.c
+++ b/tests/net/socket/poll/src/main.c
@@ -124,8 +124,8 @@ void test_poll(void)
 	zassert_equal(res, 0, "");
 
 	tstamp = k_uptime_get_32();
-	res = poll(pollout, ARRAY_SIZE(pollout), K_MSEC(200));
-	zassert_true(k_uptime_get_32() - tstamp < K_MSEC(100), "");
+	res = poll(pollout, ARRAY_SIZE(pollout), 200);
+	zassert_true(k_uptime_get_32() - tstamp < 100, "");
 	zassert_equal(res, 1, "");
 	zassert_equal(pollout[0].revents, POLLOUT, "");
 
@@ -146,8 +146,8 @@ void test_poll(void)
 	zassert_equal(res, 0, "");
 
 	tstamp = k_uptime_get_32();
-	res = poll(pollout, ARRAY_SIZE(pollout), K_MSEC(200));
-	zassert_true(k_uptime_get_32() - tstamp < K_MSEC(100), "");
+	res = poll(pollout, ARRAY_SIZE(pollout), 200);
+	zassert_true(k_uptime_get_32() - tstamp < 100, "");
 	zassert_equal(res, 1, "");
 	zassert_equal(pollout[0].revents, POLLOUT, "");
 

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -757,7 +757,7 @@ static struct net_linkaddr server_link_addr = {
 #define MY_IPV6_ADDR "2001:db8:100::1"
 #define PEER_IPV6_ADDR "2001:db8:100::2"
 #define TEST_TXTIME 0xff112233445566ff
-#define WAIT_TIME 250
+#define WAIT_TIME K_MSEC(250)
 
 static void eth_fake_iface_init(struct net_if *iface)
 {

--- a/tests/net/socket/websocket/src/main.c
+++ b/tests/net/socket/websocket/src/main.c
@@ -73,7 +73,7 @@ static int test_recv_buf(u8_t *feed_buf, size_t feed_len,
 	ctx_ptr = POINTER_TO_INT(&test_data);
 
 	return websocket_recv_msg(ctx_ptr, recv_buf, recv_len,
-				  msg_type, remaining, K_NO_WAIT);
+				  msg_type, remaining, 0);
 }
 
 /* Websocket frame, header is 6 bytes, FIN bit is set, opcode is text (1),
@@ -347,7 +347,7 @@ static void test_send_and_recv_lorem_ipsum(void)
 	ret = websocket_send_msg(POINTER_TO_INT(&ctx),
 				 lorem_ipsum, test_msg_len,
 				 WEBSOCKET_OPCODE_DATA_TEXT, true, true,
-				 K_FOREVER);
+				 NET_WAIT_FOREVER);
 	zassert_equal(ret, test_msg_len,
 		      "Should have sent %zd bytes but sent %d instead",
 		      test_msg_len, ret);
@@ -367,7 +367,7 @@ static void test_recv_two_large_split_msg(void)
 
 	ret = websocket_send_msg(POINTER_TO_INT(&ctx), lorem_ipsum,
 				 test_msg_len, WEBSOCKET_OPCODE_DATA_TEXT,
-				 false, true, K_FOREVER);
+				 false, true, NET_WAIT_FOREVER);
 	zassert_equal(ret, test_msg_len,
 		      "1st should have sent %zd bytes but sent %d instead",
 		      test_msg_len, ret);

--- a/tests/net/udp/src/main.c
+++ b/tests/net/udp/src/main.c
@@ -225,7 +225,7 @@ u8_t ipv6_hop_by_hop_ext_hdr[] = {
 0x3E, 0x3F, 0x40, 0x41, 0x42, 0x43, 0x44, 0x45,
 };
 
-#define TIMEOUT 200
+#define TIMEOUT K_MSEC(200)
 
 static bool send_ipv6_udp_msg(struct net_if *iface,
 			      struct in6_addr *src,


### PR DESCRIPTION
Initial set of patches for networking related code. This converts most of the networking APIs to use k_timeout_t and should be merged first.