### PR TITLE
net: openthread: Frame Pending Bit improvements

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -493,13 +493,30 @@ static void nrf5_iface_init(struct net_if *iface)
 	ieee802154_init(iface);
 }
 
-int nrf5_configure(struct device *dev, enum ieee802154_config_type type,
-		   const struct ieee802154_config *config)
+static int nrf5_configure(struct device *dev, enum ieee802154_config_type type,
+			  const struct ieee802154_config *config)
 {
 	ARG_UNUSED(dev);
 
 	switch (type) {
 	case IEEE802154_CONFIG_AUTO_ACK_FPB:
+		if (config->auto_ack_fpb.enabled) {
+			switch (config->auto_ack_fpb.mode) {
+			case IEEE802154_FPB_ADDR_MATCH_THREAD:
+				nrf_802154_src_addr_matching_method_set(
+					NRF_802154_SRC_ADDR_MATCH_THREAD);
+				break;
+
+			case IEEE802154_FPB_ADDR_MATCH_ZIGBEE:
+				nrf_802154_src_addr_matching_method_set(
+					NRF_802154_SRC_ADDR_MATCH_ZIGBEE);
+				break;
+
+			default:
+				return -EINVAL;
+			}
+		}
+
 		nrf_802154_auto_pending_bit_set(config->auto_ack_fpb.enabled);
 		break;
 

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -48,6 +48,11 @@ struct nrf5_802154_config {
 
 static struct nrf5_802154_data nrf5_data;
 
+#define ACK_REQUEST_BYTE 1
+#define ACK_REQUEST_BIT (1 << 5)
+#define FRAME_PENDING_BYTE 1
+#define FRAME_PENDING_BIT (1 << 4)
+
 /* Convenience defines for RADIO */
 #define NRF5_802154_DATA(dev) \
 	((struct nrf5_802154_data * const)(dev)->driver_data)
@@ -109,6 +114,7 @@ static void nrf5_rx_thread(void *arg1, void *arg2, void *arg3)
 
 		net_pkt_set_ieee802154_lqi(pkt, rx_frame->lqi);
 		net_pkt_set_ieee802154_rssi(pkt, rx_frame->rssi);
+		net_pkt_set_ieee802154_ack_fpb(pkt, rx_frame->ack_fpb);
 
 #if defined(CONFIG_NET_PKT_TIMESTAMP)
 		struct net_ptp_time timestamp = {
@@ -554,6 +560,15 @@ void nrf_802154_received_timestamp_raw(uint8_t *data, int8_t power, uint8_t lqi,
 		nrf5_data.rx_frames[i].rssi = power;
 		nrf5_data.rx_frames[i].lqi = lqi;
 
+		if (data[ACK_REQUEST_BYTE] & ACK_REQUEST_BIT) {
+			nrf5_data.rx_frames[i].ack_fpb =
+						nrf5_data.last_frame_ack_fpb;
+		} else {
+			nrf5_data.rx_frames[i].ack_fpb = false;
+		}
+
+		nrf5_data.last_frame_ack_fpb = false;
+
 		k_fifo_put(&nrf5_data.rx_fifo, &nrf5_data.rx_frames[i]);
 
 		return;
@@ -564,7 +579,13 @@ void nrf_802154_received_timestamp_raw(uint8_t *data, int8_t power, uint8_t lqi,
 
 void nrf_802154_receive_failed(nrf_802154_rx_error_t error)
 {
-	/* Intentionally empty. */
+	nrf5_data.last_frame_ack_fpb = false;
+}
+
+void nrf_802154_tx_ack_started(const uint8_t *data)
+{
+	nrf5_data.last_frame_ack_fpb =
+				data[FRAME_PENDING_BYTE] & FRAME_PENDING_BIT;
 }
 
 void nrf_802154_transmitted_raw(const uint8_t *frame, uint8_t *ack,

--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -20,6 +20,7 @@ struct nrf5_802154_rx_frame {
 	u32_t time; /* RX timestamp. */
 	u8_t lqi; /* Last received frame LQI value. */
 	s8_t rssi; /* Last received frame RSSI value. */
+	bool ack_fpb; /* FPB value in ACK sent for the received frame. */
 };
 
 struct nrf5_802154_data {
@@ -42,6 +43,9 @@ struct nrf5_802154_data {
 	 * RX thread via rx_fifo object.
 	 */
 	struct nrf5_802154_rx_frame rx_frames[NRF_802154_RX_BUFFERS];
+
+	/* Frame pending bit value in ACK sent for the last received frame. */
+	bool last_frame_ack_fpb;
 
 	/* CCA complete sempahore. Unlocked when CCA is complete. */
 	struct k_sem cca_wait;

--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -84,14 +84,26 @@ enum ieee802154_tx_mode {
 	IEEE802154_TX_MODE_TXTIME_CCA,
 };
 
+/** IEEE802.15.4 Frame Pending Bit table address matching mode. */
+enum ieee802154_fpb_mode {
+	/** The pending bit shall be set only for addresses found in the list.
+	 */
+	IEEE802154_FPB_ADDR_MATCH_THREAD,
+
+	/** The pending bit shall be cleared for short addresses found in
+	 *  the list.
+	 */
+	IEEE802154_FPB_ADDR_MATCH_ZIGBEE,
+};
+
 /** IEEE802.15.4 driver configuration types. */
 enum ieee802154_config_type {
 	/** Indicates how radio driver should set Frame Pending bit in ACK
 	 *  responses for Data Requests. If enabled, radio driver should
 	 *  determine whether to set the bit or not based on the information
-	 *  provided with ``IEEE802154_CONFIG_ACK_FPB`` config. Otherwise,
-	 *  Frame Pending bit should be set to ``1``(see IEEE Std 802.15.4-2006,
-	 *  7.2.2.3.1).
+	 *  provided with ``IEEE802154_CONFIG_ACK_FPB`` config and FPB address
+	 *  matching mode specified. Otherwise, Frame Pending bit should be set
+	 *  to ``1``(see IEEE Std 802.15.4-2006, 7.2.2.3.1).
 	 */
 	IEEE802154_CONFIG_AUTO_ACK_FPB,
 
@@ -120,6 +132,7 @@ struct ieee802154_config {
 		/** ``IEEE802154_CONFIG_AUTO_ACK_FPB`` */
 		struct {
 			bool enabled;
+			enum ieee802154_fpb_mode mode;
 		} auto_ack_fpb;
 
 		/** ``IEEE802154_CONFIG_ACK_FPB`` */

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -241,6 +241,7 @@ struct net_pkt {
 #if defined(CONFIG_IEEE802154)
 	u8_t ieee802154_rssi; /* Received Signal Strength Indication */
 	u8_t ieee802154_lqi;  /* Link Quality Indicator */
+	u8_t ieee802154_ack_fpb : 1; /* Frame Pending Bit was set in the ACK */
 #endif
 #if defined(CONFIG_NET_L2_CANBUS)
 	union {
@@ -880,6 +881,17 @@ static inline void net_pkt_set_ieee802154_lqi(struct net_pkt *pkt,
 					      u8_t lqi)
 {
 	pkt->ieee802154_lqi = lqi;
+}
+
+static inline bool net_pkt_ieee802154_ack_fpb(struct net_pkt *pkt)
+{
+	return pkt->ieee802154_ack_fpb;
+}
+
+static inline void net_pkt_set_ieee802154_ack_fpb(struct net_pkt *pkt,
+						  bool fpb)
+{
+	pkt->ieee802154_ack_fpb = fpb;
 }
 #endif
 

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -281,6 +281,8 @@ static void openthread_handle_received_frame(otInstance *instance,
 	recv_frame.mChannel = platformRadioChannelGet(instance);
 	recv_frame.mInfo.mRxInfo.mLqi = net_pkt_ieee802154_lqi(pkt);
 	recv_frame.mInfo.mRxInfo.mRssi = net_pkt_ieee802154_rssi(pkt);
+	recv_frame.mInfo.mRxInfo.mAckedWithFramePending =
+						net_pkt_ieee802154_ack_fpb(pkt);
 
 #if defined(CONFIG_NET_PKT_TIMESTAMP)
 	struct net_ptp_time *time = net_pkt_timestamp(pkt);

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -641,7 +641,8 @@ void otPlatRadioEnableSrcMatch(otInstance *aInstance, bool aEnable)
 	ARG_UNUSED(aInstance);
 
 	struct ieee802154_config config = {
-		.auto_ack_fpb.enabled = aEnable
+		.auto_ack_fpb.enabled = aEnable,
+		.auto_ack_fpb.mode = IEEE802154_FPB_ADDR_MATCH_THREAD,
 	};
 
 	(void)radio_api->configure(radio_dev, IEEE802154_CONFIG_AUTO_ACK_FPB,


### PR DESCRIPTION
A couple of improvements in Frame Pending Bit handling:
* Allow specifying Frame Pending Bit mode (Thread, Ziggbe handle it differently),
* Forward the information, whether the radio driver acknowledged the frame with FPB bit set.

The latter fixes Thread Sleepy End Devices, which are currently broken in Zephyr (it stopped working due to upstream OpenThread changes introduced in recent OT update).