### PR TITLE
Remove static analyzer warnings about binary bitwise operator used with signed integer in LOG_XYZ macros.

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -15,19 +15,19 @@
 #include <sys/util.h>
 #include <sys/printk.h>
 
-#define LOG_LEVEL_NONE 0
-#define LOG_LEVEL_ERR  1
-#define LOG_LEVEL_WRN  2
-#define LOG_LEVEL_INF  3
-#define LOG_LEVEL_DBG  4
+#define LOG_LEVEL_NONE 0U
+#define LOG_LEVEL_ERR  1U
+#define LOG_LEVEL_WRN  2U
+#define LOG_LEVEL_INF  3U
+#define LOG_LEVEL_DBG  4U
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #ifndef CONFIG_LOG
-#define CONFIG_LOG_DEFAULT_LEVEL 0
-#define CONFIG_LOG_MAX_LEVEL 0
+#define CONFIG_LOG_DEFAULT_LEVEL 0U
+#define CONFIG_LOG_MAX_LEVEL 0U
 #endif
 
 #if !defined(CONFIG_LOG) || defined(CONFIG_LOG_MINIMAL)
@@ -357,7 +357,7 @@ static inline char z_log_minimal_level_to_char(int level)
 /******************************************************************************/
 
 /** @brief Number of bits used to encode log level. */
-#define LOG_LEVEL_BITS 3
+#define LOG_LEVEL_BITS 3U
 
 /** @brief Filter slot size. */
 #define LOG_FILTER_SLOT_SIZE LOG_LEVEL_BITS
@@ -366,7 +366,7 @@ static inline char z_log_minimal_level_to_char(int level)
 #define LOG_FILTERS_NUM_OF_SLOTS (32 / LOG_FILTER_SLOT_SIZE)
 
 /** @brief Slot mask. */
-#define LOG_FILTER_SLOT_MASK (BIT(LOG_FILTER_SLOT_SIZE) - 1)
+#define LOG_FILTER_SLOT_MASK (BIT(LOG_FILTER_SLOT_SIZE) - 1U)
 
 /** @brief Bit offset of a slot.
  *

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -53,11 +53,16 @@ extern "C" {
 #define Z_LOG_RESOLVED_LEVEL1(_level, _default) \
 	__COND_CODE(_LOG_XXXX##_level, (_level), (_default))
 
-#define _LOG_XXXX0 _LOG_YYYY,
-#define _LOG_XXXX1 _LOG_YYYY,
-#define _LOG_XXXX2 _LOG_YYYY,
-#define _LOG_XXXX3 _LOG_YYYY,
-#define _LOG_XXXX4 _LOG_YYYY,
+#define _LOG_XXXX0  _LOG_YYYY,
+#define _LOG_XXXX0U _LOG_YYYY,
+#define _LOG_XXXX1  _LOG_YYYY,
+#define _LOG_XXXX1U _LOG_YYYY,
+#define _LOG_XXXX2  _LOG_YYYY,
+#define _LOG_XXXX2U _LOG_YYYY,
+#define _LOG_XXXX3  _LOG_YYYY,
+#define _LOG_XXXX3U _LOG_YYYY,
+#define _LOG_XXXX4  _LOG_YYYY,
+#define _LOG_XXXX4U _LOG_YYYY,
 
 /**
  * @brief Macro for conditional code generation if provided log level allows.
@@ -79,10 +84,14 @@ extern "C" {
 #define Z_LOG_EVAL1(_eval_level, _iftrue, _iffalse) \
 	__COND_CODE(_LOG_ZZZZ##_eval_level, _iftrue, _iffalse)
 
-#define _LOG_ZZZZ1 _LOG_YYYY,
-#define _LOG_ZZZZ2 _LOG_YYYY,
-#define _LOG_ZZZZ3 _LOG_YYYY,
-#define _LOG_ZZZZ4 _LOG_YYYY,
+#define _LOG_ZZZZ1  _LOG_YYYY,
+#define _LOG_ZZZZ1U _LOG_YYYY,
+#define _LOG_ZZZZ2  _LOG_YYYY,
+#define _LOG_ZZZZ2U _LOG_YYYY,
+#define _LOG_ZZZZ3  _LOG_YYYY,
+#define _LOG_ZZZZ3U _LOG_YYYY,
+#define _LOG_ZZZZ4  _LOG_YYYY,
+#define _LOG_ZZZZ4U _LOG_YYYY,
 
 /** @brief Macro for getting log level for given module.
  *


### PR DESCRIPTION
clang-tidy complains: "warning: use of a signed integer operand with a binary bitwise operator"
```
LOG_ERR("Index is out of bounds");
        ^
/path/zephyr/include/logging/log.h:40:25: note: expanded from macro 'LOG_ERR'
#define LOG_ERR(...)    Z_LOG(LOG_LEVEL_ERR, __VA_ARGS__)
                        ^
/path/zephyr/include/logging/log_core.h:287:2: note: expanded from macro 'Z_LOG'
        __LOG(_level,                                  \
        ^
/path/zephyr/include/logging/log_core.h:259:19: note: expanded from macro '__LOG'
                                   (_level <= LOG_RUNTIME_FILTER(_filter))) {  \
                                              ^
/path/zephyr/include/logging/log_core.h:397:2: note: expanded from macro 'LOG_RUNTIME_FILTER'
        LOG_FILTER_SLOT_GET(&(_filter)->filters, LOG_FILTER_AGGR_SLOT_IDX)
        ^
/path/zephyr/include/logging/log_core.h:378:4: note: expanded from macro 'LOG_FILTER_SLOT_GET'
        ((*(_filters) >> LOG_FILTER_SLOT_SHIFT(_id)) & LOG_FILTER_SLOT_MASK)
          ^
```