### PR TITLE
Fix static analyzer warning about too few arguments in BUILD_ASSERT in (K_MEM_POOL_DEFINE).

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4807,7 +4807,7 @@ struct k_mem_pool {
 			.flags = SYS_MEM_POOL_KERNEL			\
 		} \
 	}; \
-	BUILD_ASSERT(WB_UP(maxsz) >= _MPOOL_MINBLK)
+	BUILD_ASSERT(WB_UP(maxsz) >= _MPOOL_MINBLK, "K_MEM_POOL_DEFINE: size of the largest block (parameter maxsz) is too small")
 
 /**
  * @brief Allocate memory from a memory pool.


### PR DESCRIPTION
clang-tidy complains: "error: too few arguments provided to function-like macro invocation [clang-diagnostic-error]"

```
K_MEM_POOL_DEFINE(my_pool, CBOR_ATTR_BLK_SIZE_MIN, CBOR_ATTR_BLK_SIZE_MAX, CBOR_ATTR_BLK_NUM_MAX, CBOR_ATTR_BLK_ALIGN); // NOLINT
^
/path/zephyr/include/kernel.h:4558:44: note: expanded from macro 'K_MEM_POOL_DEFINE'
        BUILD_ASSERT(WB_UP(maxsz) >= _MPOOL_MINBLK)
                                                  ^
/path/zephyr/include/toolchain/common.h:144:9: note: macro 'BUILD_ASSERT' defined here
#define BUILD_ASSERT(EXPR, MSG)                          \
        ^
/path/app/src/cbor_cose/cbor_attributes.c:56:1: error: type specifier missing, defaults to 'int' [clang-diagnostic-implicit-int]
K_MEM_POOL_DEFINE(my_pool, CBOR_ATTR_BLK_SIZE_MIN, CBOR_ATTR_BLK_SIZE_MAX, CBOR_ATTR_BLK_NUM_MAX, CBOR_ATTR_BLK_ALIGN); // NOLINT
^
/path/zephyr/include/kernel.h:4558:2: note: expanded from macro 'K_MEM_POOL_DEFINE'
        BUILD_ASSERT(WB_UP(maxsz) >= _MPOOL_MINBLK)
        ^
```


