### PR TITLE
drivers: gpio: cleanup select HAS_DTS_GPIO

### DIFF
--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -5,6 +5,7 @@
 
 menuconfig GPIO
 	bool "GPIO Drivers"
+	select HAS_DTS_GPIO
 	help
 	  Include GPIO drivers in system config
 

--- a/drivers/gpio/Kconfig.cc13xx_cc26xx
+++ b/drivers/gpio/Kconfig.cc13xx_cc26xx
@@ -6,6 +6,5 @@
 config GPIO_CC13XX_CC26XX
 	bool "TI SimpleLink CC13xx / CC26xx GPIO driver"
 	depends on SOC_SERIES_CC13X2_CC26X2
-	select HAS_DTS_GPIO
 	help
 	  Enable the TI SimpleLink CC13xx / CC26xx GPIO driver.

--- a/drivers/gpio/Kconfig.cc32xx
+++ b/drivers/gpio/Kconfig.cc32xx
@@ -5,7 +5,6 @@
 menuconfig GPIO_CC32XX
 	bool "TI CC32XX GPIO driver"
 	depends on SOC_FAMILY_TISIMPLELINK
-	select HAS_DTS_GPIO
 	help
 	  Enable the GPIO driver on TI SimpleLink CC32xx boards
 

--- a/drivers/gpio/Kconfig.dw
+++ b/drivers/gpio/Kconfig.dw
@@ -5,7 +5,6 @@
 
 menuconfig GPIO_DW
 	bool "Designware GPIO"
-	select HAS_DTS_GPIO
 	help
 	  Enable driver for Designware GPIO
 

--- a/drivers/gpio/Kconfig.esp32
+++ b/drivers/gpio/Kconfig.esp32
@@ -6,7 +6,6 @@
 menuconfig GPIO_ESP32
 	bool "ESP32 GPIO"
 	depends on SOC_ESP32
-	select HAS_DTS_GPIO
 	help
 	  Enables the ESP32 GPIO driver
 

--- a/drivers/gpio/Kconfig.gecko
+++ b/drivers/gpio/Kconfig.gecko
@@ -6,7 +6,6 @@
 menuconfig GPIO_GECKO
 	bool "Gecko GPIO driver"
 	depends on HAS_SILABS_GECKO
-	select HAS_DTS_GPIO
 	select SOC_GECKO_GPIO
 	help
 	  Enable the Gecko gpio driver.

--- a/drivers/gpio/Kconfig.imx
+++ b/drivers/gpio/Kconfig.imx
@@ -6,7 +6,6 @@
 menuconfig GPIO_IMX
 	bool "IMX GPIO driver"
 	depends on HAS_IMX_GPIO
-	select HAS_DTS_GPIO
 	help
 	  Enable the IMX GPIO driver.
 

--- a/drivers/gpio/Kconfig.intel
+++ b/drivers/gpio/Kconfig.intel
@@ -5,7 +5,6 @@
 
 menuconfig GPIO_INTEL_APL
 	bool "Intel Apollo Lake SoC GPIO"
-	select HAS_DTS_GPIO
 	help
 	  Enable driver for Intel Apollo Lake SoC GPIO
 

--- a/drivers/gpio/Kconfig.litex
+++ b/drivers/gpio/Kconfig.litex
@@ -6,6 +6,5 @@
 config GPIO_LITEX
 	bool "Litex GPIO driver"
 	depends on SOC_RISCV32_LITEX_VEXRISCV
-	select HAS_DTS_GPIO
 	help
 	  Enable Litex GPIO driver.

--- a/drivers/gpio/Kconfig.mcux
+++ b/drivers/gpio/Kconfig.mcux
@@ -6,7 +6,6 @@
 
 menuconfig GPIO_MCUX
 	bool "MCUX GPIO driver"
-	depends on HAS_MCUX
 	select HAS_DTS_GPIO
 	help
 	  Enable the MCUX pinmux driver.

--- a/drivers/gpio/Kconfig.mcux_igpio
+++ b/drivers/gpio/Kconfig.mcux_igpio
@@ -6,7 +6,6 @@
 menuconfig GPIO_MCUX_IGPIO
 	bool "MCUX IGPIO driver"
 	depends on HAS_MCUX_IGPIO
-	select HAS_DTS_GPIO
 	help
 	  Enable the MCUX IGPIO driver.
 

--- a/drivers/gpio/Kconfig.mcux_lpc
+++ b/drivers/gpio/Kconfig.mcux_lpc
@@ -6,7 +6,6 @@
 menuconfig GPIO_MCUX_LPC
 	bool "MCUX LPC GPIO driver"
 	depends on HAS_MCUX
-	select HAS_DTS_GPIO
 	help
 	  Enable the MCUX LPC pinmux driver.
 

--- a/drivers/gpio/Kconfig.nrfx
+++ b/drivers/gpio/Kconfig.nrfx
@@ -5,7 +5,6 @@ menuconfig GPIO_NRFX
 	bool "nRF GPIO driver"
 	default y
 	depends on SOC_FAMILY_NRF
-	select HAS_DTS_GPIO
 	help
 	  Enable GPIO driver for nRF line of MCUs.
 

--- a/drivers/gpio/Kconfig.rv32m1
+++ b/drivers/gpio/Kconfig.rv32m1
@@ -6,7 +6,6 @@
 menuconfig GPIO_RV32M1
 	bool "RV32M1 GPIO driver"
 	depends on SOC_OPENISA_RV32M1_RISCV32
-	select HAS_DTS_GPIO
 	help
 	  Enable the RV32M1 GPIO driver.
 

--- a/drivers/gpio/Kconfig.sam
+++ b/drivers/gpio/Kconfig.sam
@@ -7,6 +7,5 @@ config GPIO_SAM
 	bool "Atmel SAM GPIO (PORT) driver"
 	default y
 	depends on SOC_FAMILY_SAM
-	select HAS_DTS_GPIO
 	help
 	  Enable support for the Atmel SAM 'PORT' GPIO controllers.

--- a/drivers/gpio/Kconfig.sam0
+++ b/drivers/gpio/Kconfig.sam0
@@ -7,6 +7,5 @@ config GPIO_SAM0
 	bool "Atmel SAM0 GPIO (PORT) driver"
 	default y
 	depends on SOC_FAMILY_SAM0
-	select HAS_DTS_GPIO
 	help
 	  Enable support for the Atmel SAM0 'PORT' GPIO controllers.

--- a/drivers/gpio/Kconfig.sifive
+++ b/drivers/gpio/Kconfig.sifive
@@ -6,7 +6,6 @@
 menuconfig GPIO_SIFIVE
 	bool "SiFive Freedom Processor GPIO driver"
 	depends on SOC_RISCV_SIFIVE_FREEDOM
-	select HAS_DTS_GPIO
 	help
 	  Enable driver for the SiFive Freedom GPIO controller.
 

--- a/drivers/gpio/Kconfig.stellaris
+++ b/drivers/gpio/Kconfig.stellaris
@@ -6,6 +6,5 @@
 config GPIO_STELLARIS
 	bool "TI Stellaris GPIO Driver"
 	depends on SOC_TI_LM3S6965
-	select HAS_DTS_GPIO
 	help
 	  Enable support for the Stellaris GPIO controllers.

--- a/drivers/gpio/Kconfig.stm32
+++ b/drivers/gpio/Kconfig.stm32
@@ -6,7 +6,6 @@
 menuconfig GPIO_STM32
 	bool "GPIO Driver for STM32 family of MCUs"
 	depends on SOC_FAMILY_STM32
-	select HAS_DTS_GPIO
 	help
 	  Enable GPIO driver for STM32 line of MCUs
 

--- a/drivers/gpio/Kconfig.sx1509b
+++ b/drivers/gpio/Kconfig.sx1509b
@@ -10,7 +10,6 @@ menuconfig GPIO_SX1509B
 	bool "SX1509B I2C GPIO chip"
 	default $(dt_compat_enabled,$(DT_COMPAT_SEMTECH_SX1509B))
 	depends on I2C
-	select HAS_DTS_GPIO
 	help
 	  Enable driver for SX1509B I2C GPIO chip.
 

--- a/drivers/gpio/Kconfig.xec
+++ b/drivers/gpio/Kconfig.xec
@@ -6,7 +6,6 @@
 menuconfig GPIO_XEC
 	bool "XEC Microchip GPIO driver"
 	depends on SOC_FAMILY_MEC
-	select HAS_DTS_GPIO
 	help
 	  Enable the Microchip XEC gpio driver.
 


### PR DESCRIPTION
All GPIO controller drivers support DTS so we can select HAS_DTS_GPIO
at the GPIO driver subsystem level rather than for each specific driver.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>