### PR TITLE
drivers: cc13xx_cc26xx: Convert drivers to use more new DT_INST macros

### DIFF
--- a/boards/arm/cc1352r1_launchxl/cc1352r1_launchxl.dts
+++ b/boards/arm/cc1352r1_launchxl/cc1352r1_launchxl.dts
@@ -9,6 +9,13 @@
 #include <ti/cc1352r.dtsi>
 #include "boosterpack_connector.dtsi"
 
+/*
+ * Define some constants from driverlib/ioc.h in TI HAL,
+ * since we don't have a way to include the file directly.
+ */
+#define IOC_PORT_MCU_UART0_TX 0x00000010
+#define IOC_PORT_MCU_UART0_RX 0x0000000F
+
 #define BTN_GPIO_FLAGS (GPIO_ACTIVE_LOW | GPIO_PULL_UP)
 
 / {
@@ -69,8 +76,8 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <13>;
-	rx-pin = <12>;
+	tx-pin = <13 IOC_PORT_MCU_UART0_TX>;
+	rx-pin = <12 IOC_PORT_MCU_UART0_RX>;
 };
 
 &i2c0 {

--- a/boards/arm/cc26x2r1_launchxl/cc26x2r1_launchxl.dts
+++ b/boards/arm/cc26x2r1_launchxl/cc26x2r1_launchxl.dts
@@ -9,6 +9,13 @@
 #include <ti/cc2652r.dtsi>
 #include "boosterpack_connector.dtsi"
 
+/*
+ * Define some constants from driverlib/ioc.h in TI HAL,
+ * since we don't have a way to include the file directly.
+ */
+#define IOC_PORT_MCU_UART0_TX 0x00000010
+#define IOC_PORT_MCU_UART0_RX 0x0000000F
+
 #define BTN_GPIO_FLAGS (GPIO_ACTIVE_LOW | GPIO_PULL_UP)
 
 / {
@@ -69,8 +76,8 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <3>;
-	rx-pin = <2>;
+	tx-pin = <3 IOC_PORT_MCU_UART0_TX>;
+	rx-pin = <2 IOC_PORT_MCU_UART0_RX>;
 };
 
 &i2c0 {

--- a/drivers/serial/Kconfig.cc13xx_cc26xx
+++ b/drivers/serial/Kconfig.cc13xx_cc26xx
@@ -3,25 +3,10 @@
 # Copyright (c) 2019 Brett Witherspoon
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig UART_CC13XX_CC26XX
+config UART_CC13XX_CC26XX
 	bool "TI SimpleLink CC13xx / CC26xx UART driver"
 	depends on SOC_SERIES_CC13X2_CC26X2
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	help
 	  Enable the TI SimpleLink CC13xx / CC26xx UART driver.
-
-if UART_CC13XX_CC26XX
-
-config UART_CC13XX_CC26XX_0
-	bool "UART 0"
-	default y
-	help
-	  Enable UART 0.
-
-config UART_CC13XX_CC26XX_1
-	bool "UART 1"
-	help
-	  Enable UART 1.
-
-endif # UART_CC13XX_CC26XX

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT ti_cc13xx_cc26xx_uart
+
 #include <device.h>
 #include <errno.h>
 #include <sys/__assert.h>
@@ -374,9 +376,9 @@ static int postNotifyFxn(unsigned int eventType, uintptr_t eventArg,
 	/* Reconfigure the hardware if returning from standby */
 	if (eventType == PowerCC26XX_AWAKE_STANDBY) {
 		if (get_dev_conf(dev)->regs ==
-			DT_TI_CC13XX_CC26XX_UART_40001000_BASE_ADDRESS) {
+			DT_INST_REG_ADDR(0)) {
 			res_id = PowerCC26XX_PERIPH_UART0;
-		} else { /* DT_TI_CC13XX_CC26XX_UART_4000B000_BASE_ADDRESS */
+		} else { /* DT_INST_REG_ADDR(1) */
 			res_id = PowerCC26X2_PERIPH_UART1;
 		}
 
@@ -405,7 +407,7 @@ static int uart_cc13xx_cc26xx_set_power_state(struct device *dev,
 	if ((new_state == DEVICE_PM_ACTIVE_STATE) &&
 		(new_state != get_dev_data(dev)->pm_state)) {
 		if (get_dev_conf(dev)->regs ==
-			DT_TI_CC13XX_CC26XX_UART_40001000_BASE_ADDRESS) {
+			DT_INST_REG_ADDR(0)) {
 			Power_setDependency(PowerCC26XX_PERIPH_UART0);
 		} else {
 			Power_setDependency(PowerCC26X2_PERIPH_UART1);
@@ -428,7 +430,7 @@ static int uart_cc13xx_cc26xx_set_power_state(struct device *dev,
 			 * down serial domain.
 			 */
 			if (get_dev_conf(dev)->regs ==
-			    DT_TI_CC13XX_CC26XX_UART_40001000_BASE_ADDRESS) {
+			    DT_INST_REG_ADDR(0)) {
 				Power_releaseDependency(
 					PowerCC26XX_PERIPH_UART0);
 			} else {
@@ -532,9 +534,9 @@ static int uart_cc13xx_cc26xx_init_0(struct device *dev)
 	}
 #endif
 	/* Configure IOC module to map UART signals to pins */
-	IOCPortConfigureSet(DT_TI_CC13XX_CC26XX_UART_40001000_TX_PIN,
+	IOCPortConfigureSet(DT_PROP(DT_NODELABEL(uart0), tx_pin),
 			    IOC_PORT_MCU_UART0_TX, IOC_STD_OUTPUT);
-	IOCPortConfigureSet(DT_TI_CC13XX_CC26XX_UART_40001000_RX_PIN,
+	IOCPortConfigureSet(DT_PROP(DT_NODELABEL(uart0), rx_pin),
 			    IOC_PORT_MCU_UART0_RX, IOC_STD_INPUT);
 
 	/* Configure and enable UART */
@@ -545,11 +547,11 @@ static int uart_cc13xx_cc26xx_init_0(struct device *dev)
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	UARTIntClear(get_dev_conf(dev)->regs, UART_INT_RX);
 
-	IRQ_CONNECT(DT_TI_CC13XX_CC26XX_UART_40001000_IRQ_0,
-		    DT_TI_CC13XX_CC26XX_UART_40001000_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		    DT_INST_IRQ(0, priority),
 		    uart_cc13xx_cc26xx_isr, DEVICE_GET(uart_cc13xx_cc26xx_0),
 		    0);
-	irq_enable(DT_TI_CC13XX_CC26XX_UART_40001000_IRQ_0);
+	irq_enable(DT_INST_IRQN(0));
 
 	/* Causes an initial TX ready interrupt when TX interrupt is enabled */
 	UARTCharPutNonBlocking(get_dev_conf(dev)->regs, '\0');
@@ -559,13 +561,13 @@ static int uart_cc13xx_cc26xx_init_0(struct device *dev)
 }
 
 static const struct uart_device_config uart_cc13xx_cc26xx_config_0 = {
-	.regs = DT_TI_CC13XX_CC26XX_UART_40001000_BASE_ADDRESS,
-	.sys_clk_freq = DT_TI_CC13XX_CC26XX_UART_40001000_CLOCKS_CLOCK_FREQUENCY,
+	.regs = DT_INST_REG_ADDR(0),
+	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(0, clocks, clock_frequency)
 };
 
 static struct uart_cc13xx_cc26xx_data uart_cc13xx_cc26xx_data_0 = {
 	.uart_config = {
-		.baudrate = DT_TI_CC13XX_CC26XX_UART_40001000_CURRENT_SPEED,
+		.baudrate = DT_PROP(DT_NODELABEL(uart0), current_speed),
 		.parity = UART_CFG_PARITY_NONE,
 		.stop_bits = UART_CFG_STOP_BITS_1,
 		.data_bits = UART_CFG_DATA_BITS_8,
@@ -578,7 +580,7 @@ static struct uart_cc13xx_cc26xx_data uart_cc13xx_cc26xx_data_0 = {
 };
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-DEVICE_DEFINE(uart_cc13xx_cc26xx_0, DT_TI_CC13XX_CC26XX_UART_40001000_LABEL,
+DEVICE_DEFINE(uart_cc13xx_cc26xx_0, DT_INST_LABEL(0),
 		uart_cc13xx_cc26xx_init_0,
 		uart_cc13xx_cc26xx_pm_control,
 		&uart_cc13xx_cc26xx_data_0, &uart_cc13xx_cc26xx_config_0,
@@ -586,7 +588,7 @@ DEVICE_DEFINE(uart_cc13xx_cc26xx_0, DT_TI_CC13XX_CC26XX_UART_40001000_LABEL,
 		&uart_cc13xx_cc26xx_driver_api);
 #else
 DEVICE_AND_API_INIT(uart_cc13xx_cc26xx_0,
-		    DT_TI_CC13XX_CC26XX_UART_40001000_LABEL,
+		    DT_INST_LABEL(0),
 		    uart_cc13xx_cc26xx_init_0, &uart_cc13xx_cc26xx_data_0,
 		    &uart_cc13xx_cc26xx_config_0, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -635,9 +637,9 @@ static int uart_cc13xx_cc26xx_init_1(struct device *dev)
 #endif
 
 	/* Configure IOC module to map UART signals to pins */
-	IOCPortConfigureSet(DT_TI_CC13XX_CC26XX_UART_4000B000_TX_PIN,
+	IOCPortConfigureSet(DT_PROP(DT_NODELABEL(uart1), tx_pin),
 			    IOC_PORT_MCU_UART1_TX, IOC_STD_OUTPUT);
-	IOCPortConfigureSet(DT_TI_CC13XX_CC26XX_UART_4000B000_RX_PIN,
+	IOCPortConfigureSet(DT_PROP(DT_NODELABEL(uart1), rx_pin),
 			    IOC_PORT_MCU_UART1_RX, IOC_STD_INPUT);
 
 	/* Configure and enable UART */
@@ -648,11 +650,11 @@ static int uart_cc13xx_cc26xx_init_1(struct device *dev)
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	UARTIntClear(get_dev_conf(dev)->regs, UART_INT_RX);
 
-	IRQ_CONNECT(DT_TI_CC13XX_CC26XX_UART_4000B000_IRQ_0,
-		    DT_TI_CC13XX_CC26XX_UART_4000B000_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(1),
+		    DT_INST_IRQ(1, priority),
 		    uart_cc13xx_cc26xx_isr, DEVICE_GET(uart_cc13xx_cc26xx_1),
 		    0);
-	irq_enable(DT_TI_CC13XX_CC26XX_UART_4000B000_IRQ_0);
+	irq_enable(DT_INST_IRQN(1));
 
 	/* Causes an initial TX ready interrupt when TX interrupt is enabled */
 	UARTCharPutNonBlocking(get_dev_conf(dev)->regs, '\0');
@@ -662,13 +664,13 @@ static int uart_cc13xx_cc26xx_init_1(struct device *dev)
 }
 
 static const struct uart_device_config uart_cc13xx_cc26xx_config_1 = {
-	.regs = DT_TI_CC13XX_CC26XX_UART_4000B000_BASE_ADDRESS,
-	.sys_clk_freq = DT_TI_CC13XX_CC26XX_UART_4000B000_CLOCKS_CLOCK_FREQUENCY,
+	.regs = DT_INST_REG_ADDR(1),
+	.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(1, clocks, clock_frequency)
 };
 
 static struct uart_cc13xx_cc26xx_data uart_cc13xx_cc26xx_data_1 = {
 	.uart_config = {
-		.baudrate = DT_TI_CC13XX_CC26XX_UART_4000B000_CURRENT_SPEED,
+		.baudrate = DT_PROP(DT_NODELABEL(uart1), current_speed),
 		.parity = UART_CFG_PARITY_NONE,
 		.stop_bits = UART_CFG_STOP_BITS_1,
 		.data_bits = UART_CFG_DATA_BITS_8,
@@ -681,7 +683,7 @@ static struct uart_cc13xx_cc26xx_data uart_cc13xx_cc26xx_data_1 = {
 };
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-DEVICE_DEFINE(uart_cc13xx_cc26xx_1, DT_TI_CC13XX_CC26XX_UART_4000B000_LABEL,
+DEVICE_DEFINE(uart_cc13xx_cc26xx_1, DT_INST_LABEL(1),
 		uart_cc13xx_cc26xx_init_1,
 		uart_cc13xx_cc26xx_pm_control,
 		&uart_cc13xx_cc26xx_data_1, &uart_cc13xx_cc26xx_config_1,
@@ -689,7 +691,7 @@ DEVICE_DEFINE(uart_cc13xx_cc26xx_1, DT_TI_CC13XX_CC26XX_UART_4000B000_LABEL,
 		&uart_cc13xx_cc26xx_driver_api);
 #else
 DEVICE_AND_API_INIT(uart_cc13xx_cc26xx_1,
-		DT_TI_CC13XX_CC26XX_UART_4000B000_LABEL,
+		DT_INST_LABEL(1),
 		uart_cc13xx_cc26xx_init_1, &uart_cc13xx_cc26xx_data_1,
 		&uart_cc13xx_cc26xx_config_1, POST_KERNEL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -19,6 +19,11 @@
 #include <ti/drivers/Power.h>
 #include <ti/drivers/power/PowerCC26X2.h>
 
+#define GET_PIN(n, pin_name) \
+	DT_INST_PROP_BY_IDX(n, pin_name, 0)
+#define GET_PORT(n, pin_name) \
+	DT_INST_PROP_BY_IDX(n, pin_name, 1)
+
 struct uart_cc13xx_cc26xx_data {
 	struct uart_config uart_config;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
@@ -534,10 +539,10 @@ static int uart_cc13xx_cc26xx_init_0(struct device *dev)
 	}
 #endif
 	/* Configure IOC module to map UART signals to pins */
-	IOCPortConfigureSet(DT_PROP(DT_NODELABEL(uart0), tx_pin),
-			    IOC_PORT_MCU_UART0_TX, IOC_STD_OUTPUT);
-	IOCPortConfigureSet(DT_PROP(DT_NODELABEL(uart0), rx_pin),
-			    IOC_PORT_MCU_UART0_RX, IOC_STD_INPUT);
+	IOCPortConfigureSet(GET_PIN(0, tx_pin), GET_PORT(0, tx_pin),
+		IOC_STD_OUTPUT);
+	IOCPortConfigureSet(GET_PIN(0, rx_pin), GET_PORT(0, rx_pin),
+		IOC_STD_INPUT);
 
 	/* Configure and enable UART */
 	ret = uart_cc13xx_cc26xx_configure(dev,
@@ -637,10 +642,10 @@ static int uart_cc13xx_cc26xx_init_1(struct device *dev)
 #endif
 
 	/* Configure IOC module to map UART signals to pins */
-	IOCPortConfigureSet(DT_PROP(DT_NODELABEL(uart1), tx_pin),
-			    IOC_PORT_MCU_UART1_TX, IOC_STD_OUTPUT);
-	IOCPortConfigureSet(DT_PROP(DT_NODELABEL(uart1), rx_pin),
-			    IOC_PORT_MCU_UART1_RX, IOC_STD_INPUT);
+	IOCPortConfigureSet(GET_PIN(1, tx_pin), GET_PORT(1, tx_pin),
+		IOC_STD_OUTPUT);
+	IOCPortConfigureSet(GET_PIN(1, rx_pin), GET_PORT(1, rx_pin),
+		IOC_STD_INPUT);
 
 	/* Configure and enable UART */
 	ret = uart_cc13xx_cc26xx_configure(dev,

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -218,7 +218,7 @@ static int spi_cc13xx_cc26xx_set_power_state(struct device *dev,
 	if ((new_state == DEVICE_PM_ACTIVE_STATE) &&
 		(new_state != get_dev_data(dev)->pm_state)) {
 		if (get_dev_config(dev)->base ==
-			DT_TI_CC13XX_CC26XX_SPI_40000000_BASE_ADDRESS) {
+			DT_INST_REG_ADDR(0)) {
 			Power_setDependency(PowerCC26XX_PERIPH_SSI0);
 		} else {
 			Power_setDependency(PowerCC26XX_PERIPH_SSI1);
@@ -235,7 +235,7 @@ static int spi_cc13xx_cc26xx_set_power_state(struct device *dev,
 			 * Release power dependency
 			 */
 			if (get_dev_config(dev)->base ==
-				DT_TI_CC13XX_CC26XX_SPI_40000000_BASE_ADDRESS) {
+				DT_INST_REG_ADDR(0)) {
 				Power_releaseDependency(
 					PowerCC26XX_PERIPH_SSI0);
 			} else {
@@ -323,12 +323,12 @@ static int spi_cc13xx_cc26xx_init_0(struct device *dev)
 }
 
 static const struct spi_cc13xx_cc26xx_config spi_cc13xx_cc26xx_config_0 = {
-	.base = DT_TI_CC13XX_CC26XX_SPI_40000000_BASE_ADDRESS,
-	.sck_pin = DT_TI_CC13XX_CC26XX_SPI_40000000_SCK_PIN,
-	.mosi_pin = DT_TI_CC13XX_CC26XX_SPI_40000000_MOSI_PIN,
-	.miso_pin = DT_TI_CC13XX_CC26XX_SPI_40000000_MISO_PIN,
+	.base = DT_INST_REG_ADDR(0),
+	.sck_pin = DT_PROP(DT_NODELABEL(spi0), sck_pin),
+	.mosi_pin = DT_PROP(DT_NODELABEL(spi0), mosi_pin),
+	.miso_pin = DT_PROP(DT_NODELABEL(spi0), miso_pin),
 #ifdef DT_TI_CC13XX_CC26XX_SPI_40000000_CS_PIN
-	.cs_pin = DT_TI_CC13XX_CC26XX_SPI_40000000_CS_PIN,
+	.cs_pin = DT_PROP(DT_NODELABEL(spi0), cs_pin),
 #else
 	.cs_pin = IOID_UNUSED,
 #endif
@@ -340,14 +340,14 @@ static struct spi_cc13xx_cc26xx_data spi_cc13xx_cc26xx_data_0 = {
 };
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-DEVICE_DEFINE(spi_cc13xx_cc26xx_0, DT_TI_CC13XX_CC26XX_SPI_40000000_LABEL,
+DEVICE_DEFINE(spi_cc13xx_cc26xx_0, DT_INST_LABEL(0),
 		spi_cc13xx_cc26xx_init_0,
 		spi_cc13xx_cc26xx_pm_control,
 		&spi_cc13xx_cc26xx_data_0, &spi_cc13xx_cc26xx_config_0,
 		POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
 		&spi_cc13xx_cc26xx_driver_api);
 #else
-DEVICE_AND_API_INIT(spi_cc13xx_cc26xx_0, DT_TI_CC13XX_CC26XX_SPI_40000000_LABEL,
+DEVICE_AND_API_INIT(spi_cc13xx_cc26xx_0, DT_INST_LABEL(0),
 		    spi_cc13xx_cc26xx_init_0, &spi_cc13xx_cc26xx_data_0,
 		    &spi_cc13xx_cc26xx_config_0, POST_KERNEL,
 		    CONFIG_SPI_INIT_PRIORITY, &spi_cc13xx_cc26xx_driver_api);
@@ -393,12 +393,12 @@ static int spi_cc13xx_cc26xx_init_1(struct device *dev)
 }
 
 static const struct spi_cc13xx_cc26xx_config spi_cc13xx_cc26xx_config_1 = {
-	.base = DT_TI_CC13XX_CC26XX_SPI_40008000_BASE_ADDRESS,
-	.sck_pin = DT_TI_CC13XX_CC26XX_SPI_40008000_SCK_PIN,
-	.mosi_pin = DT_TI_CC13XX_CC26XX_SPI_40008000_MOSI_PIN,
-	.miso_pin = DT_TI_CC13XX_CC26XX_SPI_40008000_MISO_PIN,
+	.base = DT_INST_REG_ADDR(1),
+	.sck_pin = DT_PROP(DT_NODELABEL(spi1), sck_pin),
+	.mosi_pin = DT_PROP(DT_NODELABEL(spi1), mosi_pin),
+	.miso_pin = DT_PROP(DT_NODELABEL(spi1), miso_pin),
 #ifdef DT_TI_CC13XX_CC26XX_SPI_40008000_CS_PIN
-	.cs_pin = DT_TI_CC13XX_CC26XX_SPI_40008000_CS_PIN,
+	.cs_pin = DT_PROP(DT_NODELABEL(spi1), cs_pin),
 #else
 	.cs_pin = IOID_UNUSED,
 #endif /* DT_TI_CC13XX_CC26XX_SPI_1_CS_PIN */
@@ -410,14 +410,14 @@ static struct spi_cc13xx_cc26xx_data spi_cc13xx_cc26xx_data_1 = {
 };
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-DEVICE_DEFINE(spi_cc13xx_cc26xx_1, DT_TI_CC13XX_CC26XX_SPI_40008000_LABEL,
+DEVICE_DEFINE(spi_cc13xx_cc26xx_1, DT_INST_LABEL(1),
 		spi_cc13xx_cc26xx_init_1,
 		spi_cc13xx_cc26xx_pm_control,
 		&spi_cc13xx_cc26xx_data_1, &spi_cc13xx_cc26xx_config_1,
 		POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
 		&spi_cc13xx_cc26xx_driver_api);
 #else
-DEVICE_AND_API_INIT(spi_cc13xx_cc26xx_1, DT_TI_CC13XX_CC26XX_SPI_40008000_LABEL,
+DEVICE_AND_API_INIT(spi_cc13xx_cc26xx_1, DT_INST_LABEL(1),
 		    spi_cc13xx_cc26xx_init_1, &spi_cc13xx_cc26xx_data_1,
 		    &spi_cc13xx_cc26xx_config_1, POST_KERNEL,
 		    CONFIG_SPI_INIT_PRIORITY, &spi_cc13xx_cc26xx_driver_api);

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -284,142 +284,94 @@ static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 #warning "No SPI port configured"
 #endif
 
-#ifdef CONFIG_SPI_0
-static int spi_cc13xx_cc26xx_init_0(struct device *dev)
-{
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-	get_dev_data(dev)->pm_state = DEVICE_PM_ACTIVE_STATE;
-#endif
+#define SPI_CC13XX_CC26XX_DOMAIN_0 PRCM_DOMAIN_SERIAL
+#define SPI_CC13XX_CC26XX_DOMAIN_1 PRCM_DOMAIN_PERIPH
 
 #ifdef CONFIG_SYS_POWER_MANAGEMENT
-	/* Set Power dependencies & constraints */
-	Power_setDependency(PowerCC26XX_PERIPH_SSI0);
+#define SPI_CC13XX_CC26XX_POWER_SPI(n)					\
+	/* Set Power dependencies & constraints */			\
+	Power_setDependency(PowerCC26XX_PERIPH_SSI##n)
 #else
-	/* Enable SSI0 power domain */
-	PRCMPowerDomainOn(PRCM_DOMAIN_SERIAL);
-
-	/* Enable SSI0 peripherals */
-	PRCMPeripheralRunEnable(PRCM_PERIPH_SSI0);
-	/* Enable in sleep mode until proper power management is added */
-	PRCMPeripheralSleepEnable(PRCM_PERIPH_SSI0);
-	PRCMPeripheralDeepSleepEnable(PRCM_PERIPH_SSI0);
-
-	/* Load PRCM settings */
-	PRCMLoadSet();
-	while (!PRCMLoadGet()) {
-		continue;
-	}
-
-	/* SSI should not be accessed until power domain is on. */
-	while (PRCMPowerDomainStatus(PRCM_DOMAIN_SERIAL) !=
-	       PRCM_DOMAIN_POWER_ON) {
-		continue;
-	}
+#define SPI_CC13XX_CC26XX_POWER_SPI(n)					  \
+	do {								  \
+		/* Enable SSI##n power domain */			  \
+		PRCMPowerDomainOn(SPI_CC13XX_CC26XX_DOMAIN_##n);	  \
+									  \
+		/* Enable SSI##n peripherals */				  \
+		PRCMPeripheralRunEnable(PRCM_PERIPH_SSI##n);		  \
+		PRCMPeripheralSleepEnable(PRCM_PERIPH_SSI##n);		  \
+		PRCMPeripheralDeepSleepEnable(PRCM_PERIPH_SSI##n);	  \
+									  \
+		/* Load PRCM settings */				  \
+		PRCMLoadSet();						  \
+		while (!PRCMLoadGet()) {				  \
+			continue;					  \
+		}							  \
+									  \
+		/* SSI should not be accessed until power domain is on. */\
+		while (PRCMPowerDomainStatus(				  \
+			SPI_CC13XX_CC26XX_DOMAIN_##n) !=		  \
+			PRCM_DOMAIN_POWER_ON) {				  \
+			continue;					  \
+		}							  \
+	} while (0)
 #endif
-
-	spi_context_unlock_unconditionally(&get_dev_data(dev)->ctx);
-
-	return 0;
-}
-
-static const struct spi_cc13xx_cc26xx_config spi_cc13xx_cc26xx_config_0 = {
-	.base = DT_INST_REG_ADDR(0),
-	.sck_pin = DT_PROP(DT_NODELABEL(spi0), sck_pin),
-	.mosi_pin = DT_PROP(DT_NODELABEL(spi0), mosi_pin),
-	.miso_pin = DT_PROP(DT_NODELABEL(spi0), miso_pin),
-#ifdef DT_TI_CC13XX_CC26XX_SPI_40000000_CS_PIN
-	.cs_pin = DT_PROP(DT_NODELABEL(spi0), cs_pin),
-#else
-	.cs_pin = IOID_UNUSED,
-#endif
-};
-
-static struct spi_cc13xx_cc26xx_data spi_cc13xx_cc26xx_data_0 = {
-	SPI_CONTEXT_INIT_LOCK(spi_cc13xx_cc26xx_data_0, ctx),
-	SPI_CONTEXT_INIT_SYNC(spi_cc13xx_cc26xx_data_0, ctx),
-};
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-DEVICE_DEFINE(spi_cc13xx_cc26xx_0, DT_INST_LABEL(0),
-		spi_cc13xx_cc26xx_init_0,
-		spi_cc13xx_cc26xx_pm_control,
-		&spi_cc13xx_cc26xx_data_0, &spi_cc13xx_cc26xx_config_0,
-		POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
-		&spi_cc13xx_cc26xx_driver_api);
+#define SPI_CC13XX_CC26XX_DEVICE_INIT(n)				    \
+	DEVICE_DEFINE(spi_cc13xx_cc26xx_##n, DT_INST_LABEL(n),		    \
+		spi_cc13xx_cc26xx_init_##n,				    \
+		spi_cc13xx_cc26xx_pm_control,				    \
+		&spi_cc13xx_cc26xx_data_##n, &spi_cc13xx_cc26xx_config_##n, \
+		POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,			    \
+		&spi_cc13xx_cc26xx_driver_api)
+
+#define SPI_CC13XX_CC26XX_INIT_PM_STATE					    \
+	do {								    \
+		get_dev_data(dev)->pm_state = DEVICE_PM_ACTIVE_STATE;	    \
+	} while (0)
 #else
-DEVICE_AND_API_INIT(spi_cc13xx_cc26xx_0, DT_INST_LABEL(0),
-		    spi_cc13xx_cc26xx_init_0, &spi_cc13xx_cc26xx_data_0,
-		    &spi_cc13xx_cc26xx_config_0, POST_KERNEL,
-		    CONFIG_SPI_INIT_PRIORITY, &spi_cc13xx_cc26xx_driver_api);
-#endif
-#endif /* CONFIG_SPI_0 */
+#define SPI_CC13XX_CC26XX_DEVICE_INIT(n)				    \
+	DEVICE_AND_API_INIT(spi_cc13xx_cc26xx_##n, DT_INST_LABEL(n),	    \
+		    spi_cc13xx_cc26xx_init_##n, &spi_cc13xx_cc26xx_data_##n,\
+		    &spi_cc13xx_cc26xx_config_##n, POST_KERNEL,		    \
+		    CONFIG_SPI_INIT_PRIORITY,				    \
+		    &spi_cc13xx_cc26xx_driver_api)
 
-#ifdef CONFIG_SPI_1
-static int spi_cc13xx_cc26xx_init_1(struct device *dev)
-{
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-	get_dev_data(dev)->pm_state = DEVICE_PM_ACTIVE_STATE;
+#define SPI_CC13XX_CC26XX_INIT_PM_STATE
 #endif
 
-#ifdef CONFIG_SYS_POWER_MANAGEMENT
-	/* Set Power dependencies & constraints */
-	Power_setDependency(PowerCC26XX_PERIPH_SSI1);
-#else
-	/* Enable SSI1 power domain */
-	PRCMPowerDomainOn(PRCM_DOMAIN_PERIPH);
-
-	/* Enable SSI1 peripherals */
-	PRCMPeripheralRunEnable(PRCM_PERIPH_SSI1);
-	/* Enable in sleep mode until proper power management is added */
-	PRCMPeripheralSleepEnable(PRCM_PERIPH_SSI1);
-	PRCMPeripheralDeepSleepEnable(PRCM_PERIPH_SSI1);
-
-	/* Load PRCM settings */
-	PRCMLoadSet();
-	while (!PRCMLoadGet()) {
-		continue;
+#define SPI_CC13XX_CC26XX_INIT_FUNC(n)					    \
+	static int spi_cc13xx_cc26xx_init_##n(struct device *dev)	    \
+	{								    \
+		SPI_CC13XX_CC26XX_INIT_PM_STATE;			    \
+									    \
+		SPI_CC13XX_CC26XX_POWER_SPI(n);				    \
+									    \
+		spi_context_unlock_unconditionally(&get_dev_data(dev)->ctx);\
+									    \
+		return 0;						    \
 	}
 
-	/* SSI should not be accessed until power domain is on. */
-	while (PRCMPowerDomainStatus(PRCM_DOMAIN_PERIPH) !=
-	       PRCM_DOMAIN_POWER_ON) {
-		continue;
-	}
-#endif
+#define SPI_CC13XX_CC26XX_INIT(n)					\
+	SPI_CC13XX_CC26XX_INIT_FUNC(n)					\
+									\
+	static const struct spi_cc13xx_cc26xx_config			\
+		spi_cc13xx_cc26xx_config_##n = {			\
+		.base = DT_INST_REG_ADDR(n),				\
+		.sck_pin = DT_INST_PROP(n, sck_pin),			\
+		.mosi_pin = DT_INST_PROP(n, mosi_pin),			\
+		.miso_pin = DT_INST_PROP(n, miso_pin),			\
+		.cs_pin = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, cs_pin),	\
+			(DT_INST_PROP(n, cs_pin)), (IOID_UNUSED))	\
+	};								\
+									\
+	static struct spi_cc13xx_cc26xx_data				\
+		spi_cc13xx_cc26xx_data_##n = {				\
+		SPI_CONTEXT_INIT_LOCK(spi_cc13xx_cc26xx_data_##n, ctx),	  \
+		SPI_CONTEXT_INIT_SYNC(spi_cc13xx_cc26xx_data_##n, ctx),	  \
+	};								  \
+									  \
+	SPI_CC13XX_CC26XX_DEVICE_INIT(n)
 
-	spi_context_unlock_unconditionally(&get_dev_data(dev)->ctx);
-
-	return 0;
-}
-
-static const struct spi_cc13xx_cc26xx_config spi_cc13xx_cc26xx_config_1 = {
-	.base = DT_INST_REG_ADDR(1),
-	.sck_pin = DT_PROP(DT_NODELABEL(spi1), sck_pin),
-	.mosi_pin = DT_PROP(DT_NODELABEL(spi1), mosi_pin),
-	.miso_pin = DT_PROP(DT_NODELABEL(spi1), miso_pin),
-#ifdef DT_TI_CC13XX_CC26XX_SPI_40008000_CS_PIN
-	.cs_pin = DT_PROP(DT_NODELABEL(spi1), cs_pin),
-#else
-	.cs_pin = IOID_UNUSED,
-#endif /* DT_TI_CC13XX_CC26XX_SPI_1_CS_PIN */
-};
-
-static struct spi_cc13xx_cc26xx_data spi_cc13xx_cc26xx_data_1 = {
-	SPI_CONTEXT_INIT_LOCK(spi_cc13xx_cc26xx_data_1, ctx),
-	SPI_CONTEXT_INIT_SYNC(spi_cc13xx_cc26xx_data_1, ctx),
-};
-
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-DEVICE_DEFINE(spi_cc13xx_cc26xx_1, DT_INST_LABEL(1),
-		spi_cc13xx_cc26xx_init_1,
-		spi_cc13xx_cc26xx_pm_control,
-		&spi_cc13xx_cc26xx_data_1, &spi_cc13xx_cc26xx_config_1,
-		POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
-		&spi_cc13xx_cc26xx_driver_api);
-#else
-DEVICE_AND_API_INIT(spi_cc13xx_cc26xx_1, DT_INST_LABEL(1),
-		    spi_cc13xx_cc26xx_init_1, &spi_cc13xx_cc26xx_data_1,
-		    &spi_cc13xx_cc26xx_config_1, POST_KERNEL,
-		    CONFIG_SPI_INIT_PRIORITY, &spi_cc13xx_cc26xx_driver_api);
-#endif
-#endif /* CONFIG_SPI_1 */
+DT_INST_FOREACH(SPI_CC13XX_CC26XX_INIT)

--- a/dts/bindings/serial/ti,cc13xx-cc26xx-uart.yaml
+++ b/dts/bindings/serial/ti,cc13xx-cc26xx-uart.yaml
@@ -15,11 +15,11 @@ properties:
       required: true
 
     tx-pin:
-      type: int
+      type: array
       required: true
       description: TX pin
 
     rx-pin:
-      type: int
+      type: array
       required: true
       description: RX pin


### PR DESCRIPTION
Changing more of DT_* prefixed macros that refer to instances to use
DT_INST macros.

Verified with samples/subsys/console/echo and tests/drivers/spi/spi_loopback.

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>