### PR TITLE
drivers: sensors: tach: Configurable pulses per cycle

### DIFF
--- a/drivers/sensor/mchp_tach_xec/Kconfig
+++ b/drivers/sensor/mchp_tach_xec/Kconfig
@@ -1,4 +1,4 @@
-# Mcrochip mec150x tachometer sensor configuration options
+# Microchip mec15xx tachometer sensor configuration options
 
 # Copyright (c) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
@@ -8,3 +8,37 @@ config TACH_XEC
 	depends on SOC_FAMILY_MEC
 	help
 	  Enable the Microchip XEC tachometer sensor.
+
+if TACH_XEC
+
+choice
+	prompt "Number of tach edges"
+	default TACH_XEC_5_TACH_EDGES
+	help
+	 This value represents the number of Tach edges that
+	 will be used to determine the interval for which the number of
+	 100KHz pulses will be counted.
+
+config TACH_XEC_9_TACH_EDGES
+	bool "Configure 9 tach edges or 4 tach periods"
+
+config TACH_XEC_5_TACH_EDGES
+	bool "Configure 5 tach edges or 2 tach periods"
+
+config TACH_XEC_3_TACH_EDGES
+	bool "Configure 3 tach edges or 1 tach period"
+
+config TACH_XEC_2_TACH_EDGES
+	bool "Configure 2 tach edges or 1/2 tach period"
+
+endchoice
+
+config TACH_XEC_EDGES
+	int
+	range 0 3
+	default 0 if TACH_XEC_2_TACH_EDGES
+	default 1 if TACH_XEC_3_TACH_EDGES
+	default 2 if TACH_XEC_5_TACH_EDGES
+	default 3 if TACH_XEC_9_TACH_EDGES
+
+endif #TACH_XEC

--- a/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
+++ b/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
@@ -26,6 +26,8 @@ struct tach_xec_data {
 #define COUNT_100KHZ_SEC	100000U
 #define SEC_TO_MINUTE		60U
 #define PIN_STS_TIMEOUT		20U
+#define TACH_CTRL_EDGES	        (CONFIG_TACH_XEC_EDGES << \
+				MCHP_TACH_CTRL_NUM_EDGES_POS)
 
 #define TACH_XEC_REG_BASE(_dev)				\
 	((TACH_Type *)					\
@@ -102,7 +104,7 @@ static int tach_xec_init(struct device *dev)
 	TACH_Type *tach = TACH_XEC_REG_BASE(dev);
 
 	tach->CONTROL = MCHP_TACH_CTRL_READ_MODE_100K_CLOCK	|
-			MCHP_TACH_CTRL_EDGES_5			|
+			TACH_CTRL_EDGES	                        |
 			MCHP_TACH_CTRL_FILTER_EN		|
 			MCHP_TACH_CTRL_EN;
 


### PR DESCRIPTION
Introduce a Kconfig option to be able to interpret rpm
values from several fans.

Signed-off-by: Francisco Munoz <francisco.munoz.ruiz@intel.com>