### PR TITLE
west.yml: update hal_atmel for SAM4E

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -29,7 +29,7 @@ manifest:
       revision: a2b82e79bd8ac156fb283d5f52fa0a2373962cf9
       path: modules/hal/cmsis
     - name: hal_atmel
-      revision: 917bfefa5188a473ff49087f1fa207cbb42bf592
+      revision: c6825eab4a3eabe901d25259080f1f3661c8a7b6
       path: modules/hal/atmel
     - name: hal_altera
       revision: 23c1c1dd7a0c1cc9a399509d1819375847c95b97


### PR DESCRIPTION
Update hal_atmel to fix wrong __MPU_PRESENT definition.

see zephyrproject-rtos/hal_atmel/pull/10

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>