### PR TITLE
soc: arm: atmel_sam: sam4: Enable MPU/FPU

### DIFF
--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -23,6 +23,14 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			mpu: mpu@e000ed90 {
+				compatible = "arm,armv7m-mpu";
+				reg = <0xe000ed90 0x40>;
+				arm,num-mpu-regions = <8>;
+			};
 		};
 	};
 

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -24,6 +24,14 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			mpu: mpu@e000ed90 {
+				compatible = "arm,armv7m-mpu";
+				reg = <0xe000ed90 0x40>;
+				arm,num-mpu-regions = <8>;
+			};
 		};
 	};
 

--- a/soc/arm/atmel_sam/sam4e/Kconfig.series
+++ b/soc/arm/atmel_sam/sam4e/Kconfig.series
@@ -2,7 +2,7 @@
 
 # Copyright (c) 2017 Justin Watson
 # Copyright (c) 2018 Vincent van der Locht
-# Copyright (c) 2019 Gerson Fernando Budke
+# Copyright (c) 2019-2020 Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_SAM4E
@@ -10,6 +10,8 @@ config SOC_SERIES_SAM4E
 	select ARM
 	select CPU_CORTEX_M4
 	select CPU_CORTEX_M_HAS_DWT
+	select CPU_HAS_ARM_MPU
+	select CPU_HAS_FPU
 	select SOC_FAMILY_SAM
 	select ASF
 	help

--- a/soc/arm/atmel_sam/sam4e/dts_fixup.h
+++ b/soc/arm/atmel_sam/sam4e/dts_fixup.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2019 Gerson Fernando Budke
+ * Copyright (c) 2019-2020 Gerson Fernando Budke <nandojve@gmail.com>
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/soc/arm/atmel_sam/sam4e/soc.h
+++ b/soc/arm/atmel_sam/sam4e/soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Gerson Fernando Budke
+ * Copyright (c) 2019-2020 Gerson Fernando Budke <nandojve@gmail.com>
  * Copyright (c) 2018 Vincent van der Locht
  * Copyright (c) 2017 Justin Watson
  * Copyright (c) 2016 Intel Corporation.
@@ -14,6 +14,8 @@
 
 #ifndef _ATMEL_SAM4E_SOC_H_
 #define _ATMEL_SAM4E_SOC_H_
+
+#include <sys/util.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/atmel_sam/sam4s/Kconfig.series
+++ b/soc/arm/atmel_sam/sam4s/Kconfig.series
@@ -2,6 +2,7 @@
 
 # Copyright (c) 2017 Justin Watson
 # Copyright (c) 2018 Vincent van der Locht
+# Copyright (c) 2020 Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_SAM4S
@@ -9,6 +10,7 @@ config SOC_SERIES_SAM4S
 	select ARM
 	select CPU_CORTEX_M4
 	select CPU_CORTEX_M_HAS_DWT
+	select CPU_HAS_ARM_MPU
 	select SOC_FAMILY_SAM
 	select ASF
 	help

--- a/soc/arm/atmel_sam/sam4s/dts_fixup.h
+++ b/soc/arm/atmel_sam/sam4s/dts_fixup.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Gerson Fernando Budke
+ * Copyright (c) 2019-2020 Gerson Fernando Budke <nandojve@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/soc/arm/atmel_sam/sam4s/soc.h
+++ b/soc/arm/atmel_sam/sam4s/soc.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2020 Gerson Fernando Budke <nandojve@gmail.com>
  * Copyright (c) 2018 Vincent van der Locht
  * Copyright (c) 2017 Justin Watson
  * Copyright (c) 2016 Intel Corporation.
@@ -13,6 +14,8 @@
 
 #ifndef _ATMEL_SAM4S_SOC_H_
 #define _ATMEL_SAM4S_SOC_H_
+
+#include <sys/util.h>
 
 #ifndef _ASMLANGUAGE
 


### PR DESCRIPTION
Add missing definitions to enable MPU and FPU support when appropriated.

fixes #23947
~includes the commits from #24487 (blocked by #24487)~