### PR TITLE
drivers: ieee802154: rf2xx: Add EUI-64 from DT and iface no auto start

### DIFF
--- a/drivers/ieee802154/Kconfig.rf2xx
+++ b/drivers/ieee802154/Kconfig.rf2xx
@@ -18,6 +18,18 @@ config IEEE802154_RF2XX_DRV_NAME
 	help
 	  This option sets the driver name
 
+config IEEE802154_RF2XX_NET_IF_NO_AUTO_START
+	bool "RF2X must wait configuration before change to operational mode"
+	help
+	  This option allows user to set any configuration and/or filter before
+	  radio became operational. For instance, the EUI-64 value can be
+	  configured using NET_REQUEST_IEEE802154_SET_EXT_ADDR available from
+	  ieee802154 management interface. When all configurations are done
+	  net_if_up() can be invoked to bring interface up.
+
+	  This option can be useful when using OpenThread or Zigbee. If you
+	  have any doubt about this option leave it as default value.
+
 config IEEE802154_RF2XX_RX_STACK_SIZE
 	int "Driver's internal RX thread stack size"
 	default 800

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -319,7 +319,7 @@ static inline u8_t *get_mac(struct device *dev)
 
 	/*
 	 * Clear bit 0 to ensure it isn't a multicast address and set
-	 * bit 1 to indicate address is locally administrered and may
+	 * bit 1 to indicate address is locally administered and may
 	 * not be globally unique.
 	 */
 	ctx->mac_addr[0] = (ctx->mac_addr[0] & ~0x01) | 0x02;
@@ -791,6 +791,11 @@ static void rf2xx_iface_init(struct net_if *iface)
 	net_if_set_link_addr(iface, mac, 8, NET_LINK_IEEE802154);
 
 	ctx->iface = iface;
+
+#if defined(CONFIG_IEEE802154_RF2XX_NET_IF_NO_AUTO_START)
+	LOG_DBG("Interface auto start disabled. Waiting configuration...");
+	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+#endif
 
 	ieee802154_init(iface);
 }

--- a/drivers/ieee802154/ieee802154_rf2xx.h
+++ b/drivers/ieee802154/ieee802154_rf2xx.h
@@ -88,8 +88,6 @@ struct rf2xx_dt_spi_t {
 };
 
 struct rf2xx_config {
-	u8_t inst;
-
 	struct rf2xx_dt_gpio_t irq;
 	struct rf2xx_dt_gpio_t reset;
 	struct rf2xx_dt_gpio_t slptr;
@@ -97,6 +95,9 @@ struct rf2xx_config {
 	struct rf2xx_dt_gpio_t clkm;
 
 	struct rf2xx_dt_spi_t spi;
+
+	u8_t inst;
+	u8_t has_mac;
 };
 
 struct rf2xx_context {

--- a/dts/bindings/ieee802154/atmel,rf2xx.yaml
+++ b/dts/bindings/ieee802154/atmel,rf2xx.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, Gerson Fernando Budke
+# Copyright (c) 2019-2020 Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 description: ATMEL AT86RF2xx 802.15.4 wireless transceiver
@@ -31,3 +31,8 @@ properties:
       type: phandle-array
       required: false
       description: Master clock signal output
+
+    local-mac-address:
+      type: uint8-array
+      description:
+        Specifies the MAC address that was assigned to the network device


### PR DESCRIPTION
Add local-mac-address on DT and enable it on rf2xx driver. If user define local-mac-address this value will be used as default mac address. Otherwise driver automatically add a random mac address.

On application level user can change default mac address using net_mgmt command with NET_REQUEST_IEEE802154_SET_EXT_ADDR parameter defined on include/net/ieee802154_mgmt.h header.

~Refactor get_mac to rf2xx_get_mac and turn it as a weak method. This allows any user to create their own set mac address. This is important because RF2xx is a transceiver over SPI and may need mac address be defined when system is booting.~
Add a Kconfig option that sets NET_IF_NO_AUTO_START at driver init. This way user can control when net_if will be up with proper configuration.

Fixes #23193

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>