### PR TITLE
drivers: wifi: esp: Use UART settings from bus node

### DIFF
--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -37,14 +37,16 @@ extern "C" {
 #define _CIPSTAMAC "CIPSTAMAC"
 #endif
 
-#if DT_INST_PROP(0, uart_flow_control) == 1
+#define ESP_BUS DT_BUS(DT_DRV_INST(0))
+
+#if DT_PROP(ESP_BUS, hw_flow_control) == 1
 #define _FLOW_CONTROL "3"
 #else
 #define _FLOW_CONTROL "0"
 #endif
 
 #define _UART_CUR \
-	STRINGIFY(DT_INST_PROP(0, uart_speed))",8,1,0,"_FLOW_CONTROL
+	STRINGIFY(DT_PROP(ESP_BUS, current_speed))",8,1,0,"_FLOW_CONTROL
 
 #define CONN_CMD_MAX_LEN (sizeof("AT+"_CWJAP"=\"\",\"\"") + \
 			  WIFI_SSID_MAX_LEN + WIFI_PSK_MAX_LEN)

--- a/dts/bindings/wifi/espressif,esp.yaml
+++ b/dts/bindings/wifi/espressif,esp.yaml
@@ -14,10 +14,3 @@ properties:
     wifi-reset-gpios:
       type: phandle-array
       required: false
-
-    wifi-uart-speed:
-      type: int
-      required: true
-
-    wifi-uart-flow-control:
-      type: boolean


### PR DESCRIPTION
With the introduction of the new device-tree macros it is now possible
to use the settings for speed and flow-control from the bus node instead of
having the same properties on the esp node itself.

Signed-off-by: Tobias Svehagen <tobias.svehagen@gmail.com>