### PR TITLE
usb: dfu: correct image names to match alt numbers

### DIFF
--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -60,8 +60,8 @@ LOG_MODULE_REGISTER(usb_dfu);
 
 #define USB_DFU_MAX_XFER_SIZE		CONFIG_USB_REQUEST_BUFFER_SIZE
 
-#define FIRMWARE_IMAGE_0_LABEL "image-1"
-#define FIRMWARE_IMAGE_1_LABEL "image-0"
+#define FIRMWARE_IMAGE_0_LABEL "image-0"
+#define FIRMWARE_IMAGE_1_LABEL "image-1"
 
 /* MCUBoot waits for CONFIG_USB_DFU_WAIT_DELAY_MS time in total to let DFU to
  * be commenced. It intermittently checks every INTERMITTENT_CHECK_DELAY


### PR DESCRIPTION
*This was introduced in 40da5f3f408e6cbed6a9f1b2b22ccc5ad75d7eff.  It appears to be unintentional, and is highly confusing.*

One would expect alt=0 to be named image-0 and alt=1 to be named
image-1.  Make it so.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>