### PR TITLE
roll-up fixes for PVS-Studio bug assessment

### DIFF
--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -571,7 +571,8 @@ static int nvs_startup(struct nvs_fs *fs)
 	}
 	/* all sectors are closed, this is not a nvs fs */
 	if (closed_sectors == fs->sector_count) {
-		return -EDEADLK;
+		rc = -EDEADLK;
+		goto end;
 	}
 
 	if (i == fs->sector_count) {
@@ -617,7 +618,8 @@ static int nvs_startup(struct nvs_fs *fs)
 			 */
 			if (fs->ate_wra == fs->data_wra && last_ate.len) {
 				/* not a delete ate */
-				return -ESPIPE;
+				rc = -ESPIPE;
+				goto end;
 			}
 		}
 

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -423,8 +423,7 @@ static char *mntpt_prepare(char *mntpt)
 
 	cpy_mntpt = k_malloc(strlen(mntpt) + 1);
 	if (cpy_mntpt) {
-		((u8_t *)mntpt)[strlen(mntpt)] = '\0';
-		memcpy(cpy_mntpt, mntpt, strlen(mntpt));
+		strcpy(cpy_mntpt, mntpt);
 	}
 	return cpy_mntpt;
 }

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -907,7 +907,8 @@ int net_context_connect(struct net_context *context,
 
 	if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
 	    addr->sa_family == AF_PACKET) {
-		return -EOPNOTSUPP;
+		ret = -EOPNOTSUPP;
+		goto unlock;
 	}
 
 	if (net_context_get_state(context) == NET_CONTEXT_LISTENING) {

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1506,6 +1506,7 @@ int net_tcp_put(struct net_context *context)
 	if (net_context_get_ip_proto(context) == IPPROTO_TCP) {
 		if ((net_context_get_state(context) == NET_CONTEXT_CONNECTED ||
 		     net_context_get_state(context) == NET_CONTEXT_LISTENING)
+		    && context->tcp
 		    && !context->tcp->fin_rcvd) {
 			NET_DBG("TCP connection in active close, not "
 				"disposing yet (waiting %dms)", FIN_TIMEOUT);

--- a/subsys/net/l2/ppp/fsm.c
+++ b/subsys/net/l2/ppp/fsm.c
@@ -359,14 +359,14 @@ int ppp_send_pkt(struct ppp_fsm *fsm, struct net_if *iface,
 	if (!iface) {
 		struct ppp_context *ctx;
 
-		if (fsm->protocol == PPP_LCP) {
+		if (fsm && fsm->protocol == PPP_LCP) {
 			ctx = CONTAINER_OF(fsm, struct ppp_context, lcp.fsm);
 #if defined(CONFIG_NET_IPV4)
-		} else if (fsm->protocol == PPP_IPCP) {
+		} else if (fsm && fsm->protocol == PPP_IPCP) {
 			ctx = CONTAINER_OF(fsm, struct ppp_context, ipcp.fsm);
 #endif
 #if defined(CONFIG_NET_IPV6)
-		} else if (fsm->protocol == PPP_IPV6CP) {
+		} else if (fsm && fsm->protocol == PPP_IPV6CP) {
 			ctx = CONTAINER_OF(fsm, struct ppp_context,
 					   ipv6cp.fsm);
 #endif

--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -823,7 +823,7 @@ int do_write_op_json(struct lwm2m_message *msg)
 			}
 
 			/* combine base_name + name */
-			snprintf(full_name, TOKEN_BUF_LEN, "%s%s",
+			snprintf(full_name, sizeof(full_name), "%s%s",
 				 base_name, value);
 
 			/* parse full_name into path */

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -337,7 +337,7 @@ static size_t put_end_tlv(struct lwm2m_output_context *out, u16_t mark_pos,
 	tlv_setup(&tlv, tlv_type, tlv_id, len);
 	len = oma_tlv_put(&tlv, out, NULL, true) - tlv.length;
 
-	return 0;
+	return len;
 }
 
 static size_t put_begin_oi(struct lwm2m_output_context *out,

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1186,13 +1186,13 @@ void shell_thread(void *shell_handle, void *arg_log_backend,
 		err = k_poll(shell->ctx->events, SHELL_SIGNAL_TXDONE,
 			     K_FOREVER);
 
-		k_mutex_lock(&shell->ctx->wr_mtx, K_FOREVER);
-
 		if (err != 0) {
 			shell_internal_fprintf(shell, SHELL_ERROR,
 					       "Shell thread error: %d", err);
 			return;
 		}
+
+		k_mutex_lock(&shell->ctx->wr_mtx, K_FOREVER);
 
 		if (shell->iface->api->update) {
 			shell->iface->api->update(shell->iface);


### PR DESCRIPTION
https://habr.com/en/company/pvs-studio/blog/495284/ provides a nice summary of problems found in Zephyr with the PVS-Studio tool.  Several of these were subsequently fixed, but AFAICT no complete review and patch has been done.

This PR contains patches for the remaining in-tree problems.  Problems identified in mbedtls and lvgl have not been addressed.

* f1 already: subsys/bluetooth/mesh/pb_adv.c
* f2 already: subsys/logging/log_backend_net.c
* f3 thispr: subsys/net/lib/lwm2m/lwm2m_rw_json.c 
* f4 already: subsys/bluetooth/host/keys.c
* f5 thispr: subsys/fs/shell.c 
* f6 already: subsys/bluetooth/mesh/access.c
* f7 already: subsys/net/ip/tcp2.c
* f8 thispr: subsys/net/ip/tcp.c
* f9 thispr: subsys/net/l2/ppp/fsm.c
* f10 external: in mbedtls, SEP
* f11 external: in lvgl, SEP
* f12 thispr: subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
* f13 thispr: subsys/fs/nvs/nvs.c
* f14 thispr: subsys/fs/nvs/nvs.c
* f15 thispr: subsys/net/ip/net_context.c
* f16 thispr: subsys/shell/shell.c
