### PR TITLE
doc: lock sphinx version to a compatible one

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         pip3 install setuptools
         pip3 install 'breathe>=4.9.1' 'docutils>=0.14' \
-                     'sphinx>=1.7.5' sphinx_rtd_theme sphinx-tabs \
+                     'sphinx>=1.7.5,<3.0' sphinx_rtd_theme sphinx-tabs \
                      sphinxcontrib-svg2pdfconverter 'west>=0.6.2'
         pip3 install pyelftools
 

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -2,7 +2,7 @@
 
 breathe>=4.9.1
 docutils>=0.14
-sphinx>=1.7.5
+sphinx>=1.7.5,<3.0
 sphinx_rtd_theme
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
Version 3.0.0 release recently break doc build, lock version of sphinx
to something compatible while we upgrade dependencies...