### PR TITLE
[backport v2.2] Bluetooth: SMP: Fix bond lost on pairing failure.

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -1793,10 +1793,13 @@ static void smp_pairing_complete(struct bt_smp *smp, u8_t status)
 	} else {
 		u8_t auth_err = auth_err_get(status);
 
-		/*
-		 * Clear the key pool entry in case of pairing failure.
+		/* Clear the key pool entry in case of pairing failure if the
+		 * keys already existed before the pairing procedure or the
+		 * pairing failed during key distribution.
 		 */
-		if (smp->chan.chan.conn->le.keys) {
+		if (smp->chan.chan.conn->le.keys &&
+		    (!smp->chan.chan.conn->le.keys->enc_size ||
+		     atomic_test_bit(smp->flags, SMP_FLAG_KEYS_DISTR))) {
 			bt_keys_clear(smp->chan.chan.conn->le.keys);
 			smp->chan.chan.conn->le.keys = NULL;
 		}


### PR DESCRIPTION
Fix an an issue where established bonding information in the peripheral
are deleted when the central does not have the bond information.
This could be because the central has removed the bond information, or
this is in fact not the central but someone spoofing it's identity, or
an accidental RPA match.

This is a regression from: a3e89e84a801d9bc048b0ee2177f0fb11d1a925a

Backport of #24087

Fixes: #24086