### PR TITLE
dts/arm/st: f2 USB OTGFS clock on AHB2 bus

### DIFF
--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -216,7 +216,7 @@
 			num-bidir-endpoints = <4>;
 			ram-size = <1280>;
 			maximum-speed = "full-speed";
-			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x20000000>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000080>;
 			phys = <&otgfs_phy>;
 			status = "disabled";
 			label = "OTGFS";


### PR DESCRIPTION
dts/arm/st: f2 USB OTGFS clock on AHB2 bus

Signed-off-by: Alexandre Bourdiol <alexandre.bourdiol@st.com>