### PR TITLE
drivers: wifi: esp: Fix wifi-reset-gpios handling

### DIFF
--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -28,16 +28,16 @@ LOG_MODULE_REGISTER(wifi_esp);
 
 /* pin settings */
 enum modem_control_pins {
-#if DT_INST_NODE_HAS_PROP(0, reset_gpios)
+#if DT_INST_NODE_HAS_PROP(0, wifi_reset_gpios)
 	WIFI_RESET,
 #endif
 	NUM_PINS,
 };
 
 static struct modem_pin modem_pins[] = {
-#if DT_INST_NODE_HAS_PROP(0, reset_gpios)
-	MODEM_PIN(DT_INST_GPIO_LABEL(0, reset_gpios),
-		  DT_INST_GPIO_PIN(0, reset_gpios),
+#if DT_INST_NODE_HAS_PROP(0, wifi_reset_gpios)
+	MODEM_PIN(DT_INST_GPIO_LABEL(0, wifi_reset_gpios),
+		  DT_INST_GPIO_PIN(0, wifi_reset_gpios),
 		  GPIO_OUTPUT),
 #endif
 };
@@ -744,7 +744,7 @@ static void esp_reset(struct esp_data *dev)
 		net_if_down(dev->net_iface);
 	}
 
-#if DT_INST_NODE_HAS_PROP(0, reset_gpios)
+#if DT_INST_NODE_HAS_PROP(0, wifi_reset_gpios)
 	modem_pin_write(&dev->mctx, WIFI_RESET, 0);
 	k_sleep(K_MSEC(100));
 	modem_pin_write(&dev->mctx, WIFI_RESET, 1);


### PR DESCRIPTION
wifi-reset-gpios is currently ignored after conversion to DT_INST
macros. Use wifi_reset_gpios instead of reset_gpios to fix the problem.

Fixes: a464ae7163a7 ("drivers: wifi: esp: Convert to new DT_INST
  macros")
Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>