### PR TITLE
drivers: serial: Xilinx UART driver interrupt-driven operation support

### DIFF
--- a/drivers/serial/Kconfig.xlnx
+++ b/drivers/serial/Kconfig.xlnx
@@ -7,5 +7,6 @@ config UART_XLNX_PS
 	bool "Xilinx serial driver for MPSoC"
 	depends on SOC_XILINX_ZYNQMP
 	select SERIAL_HAS_DRIVER
+	select SERIAL_SUPPORT_INTERRUPT
 	help
 	  This option enables the UART driver for Xilinx MPSoC platforms.

--- a/drivers/serial/uart_xlnx_ps.c
+++ b/drivers/serial/uart_xlnx_ps.c
@@ -645,7 +645,7 @@ static const struct uart_driver_api uart_xlnx_ps_driver_api = {
 #define UART_XLNX_PS_IRQ_CONF_FUNC(port) \
 DEVICE_DECLARE(uart_xlnx_ps_##port); \
 \
-static void uart_xlnx_ps_irq_config_0(struct device *dev) \
+static void uart_xlnx_ps_irq_config_##port(struct device *dev) \
 { \
 	IRQ_CONNECT(DT_INST_IRQN(port), \
 		    DT_INST_IRQ(port, priority), \

--- a/drivers/serial/uart_xlnx_ps.c
+++ b/drivers/serial/uart_xlnx_ps.c
@@ -21,7 +21,6 @@
  *  UART_REG_ADDR_INTERVAL
  */
 
-
 #include <errno.h>
 #include <kernel.h>
 #include <arch/cpu.h>
@@ -34,6 +33,11 @@
 #include <drivers/uart.h>
 #include <sys/sys_io.h>
 
+/* For all register offsets and bits / bit masks:
+ * Comp. Xilinx Zynq-7000 Technical Reference Manual (ug585), chap. B.33
+ */
+
+/* Register offsets within the UART device's register space */
 #define XUARTPS_CR_OFFSET	0x0000U  /**< Control Register [8:0] */
 #define XUARTPS_MR_OFFSET	0x0004U  /**< Mode Register [9:0] */
 #define XUARTPS_IER_OFFSET	0x0008U  /**< Interrupt Enable [12:0] */
@@ -108,6 +112,13 @@
 #define XUARTPS_IXR_RTRIG	0x00000001U /**< RX FIFO trigger interrupt. */
 #define XUARTPS_IXR_MASK	0x00003FFFU /**< Valid bit mask */
 
+/* Modem Control Register Bits Definition */
+#define XUARTPS_MODEMCR_FCM_RTS_CTS	0x00000020 /**< RTS/CTS hardware flow control. */
+#define XUARTPS_MODEMCR_FCM_NONE	0x00000000 /**< No hardware flow control. */
+#define XUARTPS_MODEMCR_FCM_MASK	0x00000020 /**< Hardware flow control mask. */
+#define XUARTPS_MODEMCR_RTS_SHIFT	1U         /**< RTS bit shift */
+#define XUARTPS_MODEMCR_DTR_SHIFT	0U         /**< DTR bit shift */
+
 /* Channel Status Register */
 #define XUARTPS_SR_TNFUL	0x00004000U /**< TX FIFO Nearly Full Status */
 #define XUARTPS_SR_TTRIG	0x00002000U /**< TX FIFO Trigger Status */
@@ -120,18 +131,24 @@
 #define XUARTPS_SR_RXEMPTY	0x00000002U /**< RX FIFO empty */
 #define XUARTPS_SR_RTRIG	0x00000001U /**< RX FIFO fill over trigger */
 
+/** Device configuration structure */
 struct uart_xlnx_ps_dev_config {
 	struct uart_device_config uconf;
 	u32_t baud_rate;
 };
 
 /** Device data structure */
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
 struct uart_xlnx_ps_dev_data_t {
+	u32_t parity;
+	u32_t stopbits;
+	u32_t databits;
+	u32_t flowctrl;
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	uart_irq_callback_user_data_t user_cb;
 	void *user_data;
-};
 #endif
+};
 
 #define DEV_CFG(dev) \
 	((const struct uart_xlnx_ps_dev_config * const) \
@@ -141,26 +158,70 @@ struct uart_xlnx_ps_dev_data_t {
 
 static const struct uart_driver_api uart_xlnx_ps_driver_api;
 
+/**
+ * @brief Disables the UART's RX and TX function.
+ *
+ * Writes 'Disable RX' and 'Disable TX' command bits into the respective
+ * UART's Command Register, thus disabling the operation of the UART.
+ *
+ * While writing the disable command bits, the opposing enable command
+ * bits, which are set when enabling the UART, are cleared.
+ *
+ * This function must be called before any configuration parameters
+ * of the UART are modified at run-time.
+ *
+ * @param reg_base Base address of the respective UART's register space.
+ */
 static void xlnx_ps_disable_uart(u32_t reg_base)
 {
 	u32_t regval;
 
 	regval = sys_read32(reg_base + XUARTPS_CR_OFFSET);
 	regval &= (~XUARTPS_CR_EN_DIS_MASK);
+	/* Set control register bits [5]: TX_DIS and [3]: RX_DIS */
 	regval |= XUARTPS_CR_TX_DIS | XUARTPS_CR_RX_DIS;
 	sys_write32(regval, reg_base + XUARTPS_CR_OFFSET);
 }
 
+/**
+ * @brief Enables the UART's RX and TX function.
+ *
+ * Writes 'Enable RX' and 'Enable TX' command bits into the respective
+ * UART's Command Register, thus enabling the operation of the UART.
+ *
+ * While writing the enable command bits, the opposing disable command
+ * bits, which are set when disabling the UART, are cleared.
+ *
+ * This function must not be called while any configuration parameters
+ * of the UART are being modified at run-time.
+ *
+ * @param reg_base Base address of the respective UART's register space.
+ */
 static void xlnx_ps_enable_uart(u32_t reg_base)
 {
 	u32_t regval;
 
 	regval = sys_read32(reg_base + XUARTPS_CR_OFFSET);
 	regval &= (~XUARTPS_CR_EN_DIS_MASK);
+	/* Set control register bits [4]: TX_EN and [2]: RX_EN */
 	regval |= XUARTPS_CR_TX_EN | XUARTPS_CR_RX_EN;
 	sys_write32(regval, reg_base + XUARTPS_CR_OFFSET);
 }
 
+/**
+ * @brief Calculates and sets the values of the BAUDDIV and BAUDGEN registers.
+ *
+ * Calculates and sets the values of the BAUDDIV and BAUDGEN registers, which
+ * determine the prescaler applied to the clock driving the UART, based on
+ * the target baud rate, which is provided as a decimal value.
+ *
+ * The calculation of the values to be written to the BAUDDIV and BAUDGEN
+ * registers is described in the Zynq-7000 TRM, chapter 19.2.3 'Baud Rate
+ * Generator'.
+ *
+ * @param dev UART device struct
+ * @param baud_rate The desired baud rate as a decimal value
+ */
 static void set_baudrate(struct device *dev, u32_t baud_rate)
 {
 	const struct uart_xlnx_ps_dev_config *dev_cfg = DEV_CFG(dev);
@@ -198,14 +259,16 @@ static void set_baudrate(struct device *dev, u32_t baud_rate)
 			}
 		}
 
-		/* Disable uart before changing baud rate */
-		reg_base = dev_cfg->uconf.regs;
-		xlnx_ps_disable_uart(reg_base);
+		/*
+		 * Set baud rate divisor and generator.
+		 * -> This function is always called from a context in which
+		 * the receiver/transmitter is disabled, the baud rate can
+		 * be changed safely at this time.
+		 */
 
-		/* Set baud rate divisor and generator */
+		reg_base = dev_cfg->uconf.regs;
 		sys_write32(divisor, reg_base + XUARTPS_BAUDDIV_OFFSET);
 		sys_write32(generator, reg_base + XUARTPS_BAUDGEN_OFFSET);
-		xlnx_ps_enable_uart(reg_base);
 	}
 }
 
@@ -225,9 +288,11 @@ static int uart_xlnx_ps_init(struct device *dev)
 	u32_t reg_base;
 
 	reg_base = dev_cfg->uconf.regs;
+
+	/* Disable RX/TX before changing any configuration data */
 	xlnx_ps_disable_uart(reg_base);
 
-	/* Set mode */
+	/* Set initial character length / start/stop bit / parity configuration */
 	reg_val = sys_read32(reg_base + XUARTPS_MR_OFFSET);
 	reg_val &= (~(XUARTPS_MR_CHARLEN_MASK | XUARTPS_MR_STOPMODE_MASK |
 		    XUARTPS_MR_PARITY_MASK));
@@ -235,8 +300,8 @@ static int uart_xlnx_ps_init(struct device *dev)
 		   XUARTPS_MR_PARITY_NONE;
 	sys_write32(reg_val, reg_base + XUARTPS_MR_OFFSET);
 
-	/* Set RX FIFO trigger at 8 data bytes. */
-	sys_write32(0x08U, reg_base + XUARTPS_RXWM_OFFSET);
+	/* Set RX FIFO trigger at 1 data bytes. */
+	sys_write32(0x01U, reg_base + XUARTPS_RXWM_OFFSET);
 
 	/* Set RX timeout to 1, which will be 4 character time */
 	sys_write32(0x1U, reg_base + XUARTPS_RXTOUT_OFFSET);
@@ -244,10 +309,17 @@ static int uart_xlnx_ps_init(struct device *dev)
 	/* Disable all interrupts, polling mode is default */
 	sys_write32(XUARTPS_IXR_MASK, reg_base + XUARTPS_IDR_OFFSET);
 
+	/* Set the baud rate */
 	set_baudrate(dev, dev_cfg->baud_rate);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
+
+	/* Clear any pending interrupt flags */
+	sys_write32(XUARTPS_IXR_MASK, reg_base + XUARTPS_ISR_OFFSET);
+
+	/* Attach to & unmask the corresponding interrupt vector */
 	dev_cfg->uconf.irq_config_func(dev);
+
 #endif
 
 	xlnx_ps_enable_uart(reg_base);
@@ -311,6 +383,446 @@ static void uart_xlnx_ps_poll_out(struct device *dev, unsigned char c)
 	do {
 		reg_val = sys_read32(reg_base + XUARTPS_SR_OFFSET);
 	} while ((reg_val & XUARTPS_SR_TXEMPTY) == 0);
+}
+
+/**
+ * @brief Converts a parity enum value to a Mode Register bit mask.
+ *
+ * Converts a value of an enumeration type provided by the driver
+ * framework for the configuration of the UART's parity setting
+ * into a bit mask within the Mode Register.
+ *
+ * It is assumed that the Mode Register contents that are being
+ * modified within this function come with the bits modified by
+ * this function already masked out by the caller.
+ *
+ * @param mode_reg Pointer to the Mode Register contents to which
+ *                 the parity configuration shall be added.
+ * @param parity   Enumeration value to be converted to a bit mask.
+ *
+ * @return Indication of success, always true for this function
+ *         as all parity modes supported by the API are also supported
+ *         by the hardware.
+ */
+static inline bool uart_xlnx_ps_cfg2ll_parity(
+	u32_t *mode_reg,
+	enum uart_config_parity parity)
+{
+	/*
+	 * Translate the new parity configuration to the mode register's
+	 * bits [5..3] (PAR):
+	 *  000b : even
+	 *  001b : odd
+	 *  010b : space
+	 *  011b : mark
+	 *  1xxb : none
+	 */
+
+	switch (parity) {
+	default:
+	case UART_CFG_PARITY_EVEN:
+		*mode_reg |= XUARTPS_MR_PARITY_EVEN;
+		break;
+	case UART_CFG_PARITY_ODD:
+		*mode_reg |= XUARTPS_MR_PARITY_ODD;
+		break;
+	case UART_CFG_PARITY_SPACE:
+		*mode_reg |= XUARTPS_MR_PARITY_SPACE;
+		break;
+	case UART_CFG_PARITY_MARK:
+		*mode_reg |= XUARTPS_MR_PARITY_MARK;
+		break;
+	case UART_CFG_PARITY_NONE:
+		*mode_reg |= XUARTPS_MR_PARITY_NONE;
+		break;
+	}
+
+	return true;
+}
+
+/**
+ * @brief Converts a stop bit enum value to a Mode Register bit mask.
+ *
+ * Converts a value of an enumeration type provided by the driver
+ * framework for the configuration of the UART's stop bit setting
+ * into a bit mask within the Mode Register.
+ *
+ * It is assumed that the Mode Register contents that are being
+ * modified within this function come with the bits modified by
+ * this function already masked out by the caller.
+ *
+ * @param mode_reg Pointer to the Mode Register contents to which
+ *                 the stop bit configuration shall be added.
+ * @param stopbits Enumeration value to be converted to a bit mask.
+ *
+ * @return Indication of success or failure in case of an unspported
+ *         stop bit configuration being provided by the caller.
+ */
+static inline bool uart_xlnx_ps_cfg2ll_stopbits(
+	u32_t *mode_reg,
+	enum uart_config_stop_bits stopbits)
+{
+	/*
+	 * Translate the new stop bit configuration to the mode register's
+	 * bits [7..6] (NBSTOP):
+	 *  00b : 1 stop bit
+	 *  01b : 1.5 stop bits
+	 *  10b : 2 stop bits
+	 *  11b : reserved
+	 */
+
+	switch (stopbits) {
+	case UART_CFG_STOP_BITS_0_5:
+		/* Controller doesn't support 0.5 stop bits */
+		return false;
+	default:
+	case UART_CFG_STOP_BITS_1:
+		*mode_reg |= XUARTPS_MR_STOPMODE_1_BIT;
+		break;
+	case UART_CFG_STOP_BITS_1_5:
+		*mode_reg |= XUARTPS_MR_STOPMODE_1_5_BIT;
+		break;
+	case UART_CFG_STOP_BITS_2:
+		*mode_reg |= XUARTPS_MR_STOPMODE_2_BIT;
+		break;
+	}
+
+	return true;
+}
+
+/**
+ * @brief Converts a data bit enum value to a Mode Register bit mask.
+ *
+ * Converts a value of an enumeration type provided by the driver
+ * framework for the configuration of the UART's data bit setting
+ * into a bit mask within the Mode Register.
+ *
+ * It is assumed that the Mode Register contents that are being
+ * modified within this function come with the bits modified by
+ * this function already masked out by the caller.
+ *
+ * @param mode_reg Pointer to the Mode Register contents to which
+ *                 the data bit configuration shall be added.
+ * @param databits Enumeration value to be converted to a bit mask.
+ *
+ * @return Indication of success or failure in case of an unspported
+ *         data bit configuration being provided by the caller.
+ */
+static inline bool uart_xlnx_ps_cfg2ll_databits(
+	u32_t *mode_reg,
+	enum uart_config_data_bits databits)
+{
+	/*
+	 * Translate the new data bit configuration to the mode register's
+	 * bits [2..1] (CHRL):
+	 *  0xb : 8 data bits
+	 *  10b : 7 data bits
+	 *  11b : 6 data bits
+	 */
+
+	switch (databits) {
+	case UART_CFG_DATA_BITS_5:
+	case UART_CFG_DATA_BITS_9:
+		/* Controller doesn't support 5 or 9 data bits */
+		return false;
+	default:
+	case UART_CFG_DATA_BITS_8:
+		*mode_reg |= XUARTPS_MR_CHARLEN_8_BIT;
+		break;
+	case UART_CFG_DATA_BITS_7:
+		*mode_reg |= XUARTPS_MR_CHARLEN_7_BIT;
+		break;
+	case UART_CFG_DATA_BITS_6:
+		*mode_reg |= XUARTPS_MR_CHARLEN_6_BIT;
+		break;
+	}
+
+	return true;
+}
+
+/**
+ * @brief Converts a flow control enum value to a Modem Control
+ *        Register bit mask.
+ *
+ * Converts a value of an enumeration type provided by the driver
+ * framework for the configuration of the UART's flow control
+ * setting into a bit mask within the Modem Control Register.
+ *
+ * It is assumed that the Modem Control Register contents that are
+ * being modified within this function come with the bits modified
+ * by this function already masked out by the caller.
+ *
+ * @param modemcr_reg Pointer to the Modem Control Register contents
+ *                    to which the flow control configuration shall
+ *                    be added.
+ * @param hwctrl Enumeration value to be converted to a bit mask.
+ *
+ * @return Indication of success or failure in case of an unspported
+ *         flow control configuration being provided by the caller.
+ */
+static inline bool uart_xlnx_ps_cfg2ll_hwctrl(
+	u32_t *modemcr_reg,
+	enum uart_config_flow_control hwctrl)
+{
+	/*
+	 * Translate the new flow control configuration to the modem
+	 * control register's bit [5] (FCM):
+	 *  0b : no flow control
+	 *  1b : RTS/CTS
+	 */
+
+	if (hwctrl == UART_CFG_FLOW_CTRL_RTS_CTS) {
+		*modemcr_reg |= XUARTPS_MODEMCR_FCM_RTS_CTS;
+	} else if (hwctrl ==  UART_CFG_FLOW_CTRL_NONE) {
+		*modemcr_reg |= XUARTPS_MODEMCR_FCM_NONE;
+	} else {
+		/* Only no flow control or RTS/CTS is supported. */
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * @brief Configures the UART device at run-time.
+ *
+ * Configures the UART device at run-time according to the
+ * configuration data provided by the caller.
+ *
+ * @param dev UART device struct
+ * @param cfg The configuration parameters to be applied.
+ *
+ * @return 0 if the configuration completed successfully, ENOTSUP
+ *         error if an unsupported configuration parameter is detected.
+ */
+static int uart_xlnx_ps_configure(struct device *dev,
+	const struct uart_config *cfg)
+{
+	struct uart_xlnx_ps_dev_config *dev_cfg =
+	(struct uart_xlnx_ps_dev_config *)DEV_CFG(dev);
+
+	u32_t reg_base    = dev_cfg->uconf.regs;
+	u32_t mode_reg    = 0;
+	u32_t modemcr_reg = 0;
+
+	/* Read the current mode register & modem control register values */
+	mode_reg    = sys_read32(reg_base + XUARTPS_MR_OFFSET);
+	modemcr_reg = sys_read32(reg_base + XUARTPS_MODEMCR_OFFSET);
+
+	/* Mask out all items that might be re-configured */
+	mode_reg    &= (~XUARTPS_MR_PARITY_MASK);
+	mode_reg    &= (~XUARTPS_MR_STOPMODE_MASK);
+	mode_reg    &= (~XUARTPS_MR_CHARLEN_MASK);
+	modemcr_reg &= (~XUARTPS_MODEMCR_FCM_MASK);
+
+	/* Assemble the updated registers, validity checks contained within */
+	if ((!uart_xlnx_ps_cfg2ll_parity(&mode_reg, cfg->parity)) ||
+		(!uart_xlnx_ps_cfg2ll_stopbits(&mode_reg, cfg->stop_bits)) ||
+		(!uart_xlnx_ps_cfg2ll_databits(&mode_reg, cfg->data_bits)) ||
+		(!uart_xlnx_ps_cfg2ll_hwctrl(&modemcr_reg, cfg->flow_ctrl))) {
+		return -ENOTSUP;
+	}
+
+	/* Disable the controller before modifying any config registers */
+	xlnx_ps_disable_uart(reg_base);
+
+	/* Set the baud rate */
+	set_baudrate(dev, cfg->baudrate);
+	dev_cfg->baud_rate = cfg->baudrate;
+
+	/* Write the two control registers */
+	sys_write32(mode_reg,    reg_base + XUARTPS_MR_OFFSET);
+	sys_write32(modemcr_reg, reg_base + XUARTPS_MODEMCR_OFFSET);
+
+	/* Re-enable the controller */
+	xlnx_ps_enable_uart(reg_base);
+
+	return 0;
+};
+
+/**
+ * @brief Converts a Mode Register bit mask to a parity configuration
+ *        enum value.
+ *
+ * Converts a bit mask representing the UART's parity setting within
+ * the UART's Mode Register into a value of an enumeration type provided
+ * by the UART driver API.
+ *
+ * @param mode_reg The current Mode Register contents from which the
+ *                 parity setting shall be extracted.
+ *
+ * @return The current parity setting mapped to the UART driver API's
+ *         enum type.
+ */
+static inline enum uart_config_parity uart_xlnx_ps_ll2cfg_parity(
+	u32_t mode_reg)
+{
+	/*
+	 * Obtain the current parity configuration from the mode register's
+	 * bits [5..3] (PAR):
+	 *  000b : even -> reset value
+	 *  001b : odd
+	 *  010b : space
+	 *  011b : mark
+	 *  1xxb : none
+	 */
+
+	switch ((mode_reg & XUARTPS_MR_PARITY_MASK)) {
+	case XUARTPS_MR_PARITY_EVEN:
+	default:
+		return UART_CFG_PARITY_EVEN;
+	case XUARTPS_MR_PARITY_ODD:
+		return UART_CFG_PARITY_ODD;
+	case XUARTPS_MR_PARITY_SPACE:
+		return UART_CFG_PARITY_SPACE;
+	case XUARTPS_MR_PARITY_MARK:
+		return UART_CFG_PARITY_MARK;
+	case XUARTPS_MR_PARITY_NONE:
+		return UART_CFG_PARITY_NONE;
+	}
+}
+
+/**
+ * @brief Converts a Mode Register bit mask to a stop bit configuration
+ *        enum value.
+ *
+ * Converts a bit mask representing the UART's stop bit setting within
+ * the UART's Mode Register into a value of an enumeration type provided
+ * by the UART driver API.
+ *
+ * @param mode_reg The current Mode Register contents from which the
+ *                 stop bit setting shall be extracted.
+ *
+ * @return The current stop bit setting mapped to the UART driver API's
+ *         enum type.
+ */
+static inline enum uart_config_stop_bits uart_xlnx_ps_ll2cfg_stopbits(
+	u32_t mode_reg)
+{
+	/*
+	 * Obtain the current stop bit configuration from the mode register's
+	 * bits [7..6] (NBSTOP):
+	 *  00b : 1 stop bit -> reset value
+	 *  01b : 1.5 stop bits
+	 *  10b : 2 stop bits
+	 *  11b : reserved
+	 */
+
+	switch ((mode_reg & XUARTPS_MR_STOPMODE_MASK)) {
+	case XUARTPS_MR_STOPMODE_1_BIT:
+	default:
+		return UART_CFG_STOP_BITS_1;
+	case XUARTPS_MR_STOPMODE_1_5_BIT:
+		return UART_CFG_STOP_BITS_1_5;
+	case XUARTPS_MR_STOPMODE_2_BIT:
+		return UART_CFG_STOP_BITS_2;
+	}
+}
+
+/**
+ * @brief Converts a Mode Register bit mask to a data bit configuration
+ *        enum value.
+ *
+ * Converts a bit mask representing the UART's data bit setting within
+ * the UART's Mode Register into a value of an enumeration type provided
+ * by the UART driver API.
+ *
+ * @param mode_reg The current Mode Register contents from which the
+ *                 data bit setting shall be extracted.
+ *
+ * @return The current data bit setting mapped to the UART driver API's
+ *         enum type.
+ */
+static inline enum uart_config_data_bits uart_xlnx_ps_ll2cfg_databits(
+	u32_t mode_reg)
+{
+	/*
+	 * Obtain the current data bit configuration from the mode register's
+	 * bits [2..1] (CHRL):
+	 *  0xb : 8 data bits -> reset value
+	 *  10b : 7 data bits
+	 *  11b : 6 data bits
+	 */
+
+	switch ((mode_reg & XUARTPS_MR_CHARLEN_MASK)) {
+	case XUARTPS_MR_CHARLEN_8_BIT:
+	default:
+		return UART_CFG_DATA_BITS_8;
+	case XUARTPS_MR_CHARLEN_7_BIT:
+		return UART_CFG_DATA_BITS_7;
+	case XUARTPS_MR_CHARLEN_6_BIT:
+		return UART_CFG_DATA_BITS_6;
+	}
+}
+
+/**
+ * @brief Converts a Modem Control Register bit mask to a flow control
+ *        configuration enum value.
+ *
+ * Converts a bit mask representing the UART's flow control setting within
+ * the UART's Modem Control Register into a value of an enumeration type
+ * provided by the UART driver API.
+ *
+ * @param modemcr_reg The current Modem Control Register contents from
+ *                    which the parity setting shall be extracted.
+ *
+ * @return The current flow control setting mapped to the UART driver API's
+ *         enum type.
+ */
+static inline enum uart_config_flow_control uart_xlnx_ps_ll2cfg_hwctrl(
+	u32_t modemcr_reg)
+{
+	/*
+	 * Obtain the current flow control configuration from the modem
+	 * control register's bit [5] (FCM):
+	 *  0b : no flow control -> reset value
+	 *  1b : RTS/CTS
+	 */
+
+	if ((modemcr_reg & XUARTPS_MODEMCR_FCM_MASK)
+		== XUARTPS_MODEMCR_FCM_RTS_CTS) {
+		return UART_CFG_FLOW_CTRL_RTS_CTS;
+	}
+
+	return UART_CFG_FLOW_CTRL_NONE;
+}
+
+/**
+ * @brief Returns the current configuration of the UART at run-time.
+ *
+ * Returns the current configuration of the UART at run-time by obtaining
+ * the current configuration from the UART's Mode and Modem Control Registers
+ * (exception: baud rate).
+ *
+ * @param dev UART device struct
+ * @param cfg Pointer to the data structure to which the current configuration
+ *            shall be written.
+ *
+ * @return always 0.
+ */
+static int uart_xlnx_ps_config_get(struct device *dev,
+	struct uart_config *cfg)
+{
+	const struct uart_xlnx_ps_dev_config *dev_cfg = DEV_CFG(dev);
+
+	/*
+	 * Read the Mode & Modem control registers - they contain
+	 * the current data / stop bit and parity settings (Mode
+	 * Register) and the current flow control setting (Modem
+	 * Control register).
+	 */
+
+	u32_t reg_base    = dev_cfg->uconf.regs;
+	u32_t mode_reg    = sys_read32(reg_base + XUARTPS_MR_OFFSET);
+	u32_t modemcr_reg = sys_read32(reg_base + XUARTPS_MODEMCR_OFFSET);
+
+	cfg->baudrate  = dev_cfg->baud_rate;
+	cfg->parity    = uart_xlnx_ps_ll2cfg_parity(mode_reg);
+	cfg->stop_bits = uart_xlnx_ps_ll2cfg_stopbits(mode_reg);
+	cfg->data_bits = uart_xlnx_ps_ll2cfg_databits(mode_reg);
+	cfg->flow_ctrl = uart_xlnx_ps_ll2cfg_hwctrl(modemcr_reg);
+
+	return 0;
 }
 
 #if CONFIG_UART_INTERRUPT_DRIVEN
@@ -387,7 +899,9 @@ static void uart_xlnx_ps_irq_tx_enable(struct device *dev)
 	u32_t reg_base;
 
 	reg_base = dev_cfg->uconf.regs;
-	sys_write32(XUARTPS_IXR_TTRIG, reg_base + XUARTPS_IER_OFFSET);
+	sys_write32(
+		(XUARTPS_IXR_TTRIG | XUARTPS_IXR_TXEMPTY),
+		reg_base + XUARTPS_IER_OFFSET);
 }
 
 /**
@@ -403,7 +917,9 @@ static void uart_xlnx_ps_irq_tx_disable(struct device *dev)
 	u32_t reg_base;
 
 	reg_base = dev_cfg->uconf.regs;
-	sys_write32(XUARTPS_IXR_TTRIG, reg_base + XUARTPS_IDR_OFFSET);
+	sys_write32(
+		(XUARTPS_IXR_TTRIG | XUARTPS_IXR_TXEMPTY),
+		reg_base + XUARTPS_IDR_OFFSET);
 }
 
 /**
@@ -421,9 +937,12 @@ static int uart_xlnx_ps_irq_tx_ready(struct device *dev)
 
 	reg_base = dev_cfg->uconf.regs;
 	reg_val = sys_read32(reg_base + XUARTPS_ISR_OFFSET);
-	if ((reg_val & XUARTPS_IXR_TTRIG) == 0) {
+	if ((reg_val & (XUARTPS_IXR_TTRIG | XUARTPS_IXR_TXEMPTY)) == 0) {
 		return 0;
 	} else {
+		sys_write32(
+			(XUARTPS_IXR_TTRIG | XUARTPS_IXR_TXEMPTY),
+			reg_base + XUARTPS_ISR_OFFSET);
 		return 1;
 	}
 }
@@ -500,6 +1019,7 @@ static int uart_xlnx_ps_irq_rx_ready(struct device *dev)
 	if ((reg_val & XUARTPS_IXR_RTRIG) == 0) {
 		return 0;
 	} else {
+		sys_write32(XUARTPS_IXR_RTRIG, reg_base + XUARTPS_ISR_OFFSET);
 		return 1;
 	}
 }
@@ -517,8 +1037,13 @@ static void uart_xlnx_ps_irq_err_enable(struct device *dev)
 	u32_t reg_base;
 
 	reg_base = dev_cfg->uconf.regs;
-	sys_write32(XUARTPS_IXR_PARITY | XUARTPS_IXR_FRAMING,
-		    reg_base + XUARTPS_IER_OFFSET);
+	sys_write32(
+		  XUARTPS_IXR_TOVR    /* [12] Transmitter FIFO Overflow */
+		| XUARTPS_IXR_TOUT    /* [8]  Receiver Timerout */
+		| XUARTPS_IXR_PARITY  /* [7]  Parity Error */
+		| XUARTPS_IXR_FRAMING /* [6]  Receiver Framing Error */
+		| XUARTPS_IXR_RXOVR,  /* [5]  Receiver Overflow Error */
+	    reg_base + XUARTPS_IER_OFFSET);
 }
 
 /**
@@ -534,8 +1059,13 @@ static void uart_xlnx_ps_irq_err_disable(struct device *dev)
 	u32_t reg_base;
 
 	reg_base = dev_cfg->uconf.regs;
-	sys_write32(XUARTPS_IXR_PARITY | XUARTPS_IXR_FRAMING,
-		    reg_base + XUARTPS_IDR_OFFSET);
+	sys_write32(
+		  XUARTPS_IXR_TOVR    /* [12] Transmitter FIFO Overflow */
+		| XUARTPS_IXR_TOUT    /* [8]  Receiver Timerout */
+		| XUARTPS_IXR_PARITY  /* [7]  Parity Error */
+		| XUARTPS_IXR_FRAMING /* [6]  Receiver Framing Error */
+		| XUARTPS_IXR_RXOVR,  /* [5]  Receiver Overflow Error */
+	    reg_base + XUARTPS_IDR_OFFSET);
 }
 
 /**
@@ -617,8 +1147,9 @@ static void uart_xlnx_ps_isr(void *arg)
 static const struct uart_driver_api uart_xlnx_ps_driver_api = {
 	.poll_in = uart_xlnx_ps_poll_in,
 	.poll_out = uart_xlnx_ps_poll_out,
+	.configure = uart_xlnx_ps_configure,
+	.config_get = uart_xlnx_ps_config_get,
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-
 	.fifo_fill = uart_xlnx_ps_fifo_fill,
 	.fifo_read = uart_xlnx_ps_fifo_read,
 	.irq_tx_enable = uart_xlnx_ps_irq_tx_enable,
@@ -633,7 +1164,6 @@ static const struct uart_driver_api uart_xlnx_ps_driver_api = {
 	.irq_is_pending = uart_xlnx_ps_irq_is_pending,
 	.irq_update = uart_xlnx_ps_irq_update,
 	.irq_callback_set = uart_xlnx_ps_irq_callback_set,
-
 #endif
 };
 
@@ -648,22 +1178,21 @@ DEVICE_DECLARE(uart_xlnx_ps_##port); \
 static void uart_xlnx_ps_irq_config_##port(struct device *dev) \
 { \
 	IRQ_CONNECT(DT_INST_IRQN(port), \
-		    DT_INST_IRQ(port, priority), \
-		    uart_xlnx_ps_isr, DEVICE_GET(uart_xlnx_ps_##port), \
-		    0); \
+	DT_INST_IRQ(port, priority), \
+	uart_xlnx_ps_isr, DEVICE_GET(uart_xlnx_ps_##port), \
+	0); \
 	irq_enable(DT_INST_IRQN(port)); \
 }
-
-#define UART_XLNX_PS_DEV_DATA(port) \
-static struct uart_xlnx_ps_dev_data_t uart_xlnx_ps_dev_data_##port
 
 #else
 
 #define UART_XLNX_PS_IRQ_CONF_FUNC_SET(port)
 #define UART_XLNX_PS_IRQ_CONF_FUNC(port)
-#define UART_XLNX_PS_DEV_DATA(port)
 
 #endif /*CONFIG_UART_INTERRUPT_DRIVEN */
+
+#define UART_XLNX_PS_DEV_DATA(port) \
+static struct uart_xlnx_ps_dev_data_t uart_xlnx_ps_dev_data_##port
 
 #define UART_XLNX_PS_DEV_CFG(port) \
 static struct uart_xlnx_ps_dev_config uart_xlnx_ps_dev_cfg_##port = { \
@@ -676,23 +1205,13 @@ static struct uart_xlnx_ps_dev_config uart_xlnx_ps_dev_cfg_##port = { \
 	.baud_rate = DT_INST_PROP(port, current_speed), \
 }
 
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
 #define UART_XLNX_PS_INIT(port) \
 DEVICE_AND_API_INIT(uart_xlnx_ps_##port, DT_INST_LABEL(port), \
-		    uart_xlnx_ps_init, \
-		    &uart_xlnx_ps_dev_data_##port, \
-		    &uart_xlnx_ps_dev_cfg_##port, \
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
-		    &uart_xlnx_ps_driver_api)
-#else
-#define UART_XLNX_PS_INIT(port) \
-DEVICE_AND_API_INIT(uart_xlnx_ps_##port, DT_INST_LABEL(port), \
-		    uart_xlnx_ps_init, \
-		    NULL, \
-		    &uart_xlnx_ps_dev_cfg_##port, \
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
-		    &uart_xlnx_ps_driver_api)
-#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
+	uart_xlnx_ps_init, \
+	&uart_xlnx_ps_dev_data_##port, \
+	&uart_xlnx_ps_dev_cfg_##port, \
+	PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+	&uart_xlnx_ps_driver_api)
 
 #if DT_HAS_DRV_INST(0)
 UART_XLNX_PS_IRQ_CONF_FUNC(0);


### PR DESCRIPTION
Second attempt to merge the modifications of this driver after #23722.
Fixed and amended the implementation so that interrupt-driven operation is supported on both supported instances of this device. 

- added SERIAL_SUPPORT_INTERRUPT in Kconfig.xlnx.
- fixed UART_XLNX_PS_IRQ_CONF_FUNC macro which only worked for UART0,
but not for UART1.
- added the interface for getting/setting the device configuration at run-time, which is also checked by the test case drivers/uart/uart_basic_api aside from the interrupt-driven FIFO operation. Includes driver API enum data type to register bits and vice versa conversion functions.
- Modified interrupt enable/disable flag setting & clearing for interrupt-driven FIFO operation checked by the same test case.

Tested on Cortex-R5 and -A9 QEMU targets as well as the Zynq-7000 based Zedboard.