### PR TITLE
Add support for openocd on stm32g0 and stm32g4 targets

### DIFF
--- a/boards/arm/nucleo_g071rb/board.cmake
+++ b/boards/arm/nucleo_g071rb/board.cmake
@@ -4,3 +4,4 @@ board_runner_args(pyocd "--flash-opt=-O reset_type=hw")
 board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/nucleo_g071rb/doc/index.rst
+++ b/boards/arm/nucleo_g071rb/doc/index.rst
@@ -133,13 +133,25 @@ Flashing
 ========
 
 Nucleo G071RB board includes an ST-LINK/V2-1 embedded debug tool interface.
+
 This interface is not yet supported by the openocd version included in the Zephyr SDK.
+
 Instead, support can be enabled on pyocd by adding "pack" support with
 the following pyocd command:
 
 .. code-block:: console
 
    $ pyocd pack --install stm32g071rb
+
+Note:
+To manually enable the openocd interface, You can still update, compile and install
+a 'local' openocd from the official openocd repo http://openocd.zylin.com .
+Then run the following openocd command where the '/usr/local/bin/openocd'is your path
+for the freshly installed openocd, given by "$ which openocd" :
+
+.. code-block:: console
+
+   $ west flash --openocd /usr/local/bin/openocd
 
 Flashing an application to Nucleo G071RB
 ----------------------------------------

--- a/boards/arm/nucleo_g071rb/support/openocd.cfg
+++ b/boards/arm/nucleo_g071rb/support/openocd.cfg
@@ -1,0 +1,7 @@
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32g0x.cfg]
+
+reset_config srst_only

--- a/boards/arm/nucleo_g431rb/board.cmake
+++ b/boards/arm/nucleo_g431rb/board.cmake
@@ -2,3 +2,4 @@
 board_runner_args(pyocd "--target=stm32g431rbtx")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/nucleo_g431rb/doc/index.rst
+++ b/boards/arm/nucleo_g431rb/doc/index.rst
@@ -186,14 +186,26 @@ flashed in the usual way (see :ref:`build_an_application` and
 Flashing
 ========
 
-Nucleo G431RB board includes an ST-LINK/V3E embedded debug tool
-interface. This interface is not yet supported by the openocd version.
+Nucleo G431RB board includes an ST-LINK/V3E embedded debug tool interface.
+
+This interface is not yet supported by the openocd version included in the Zephyr SDK.
+
 Instead, support can be enabled on pyocd by adding "pack" support with
 the following pyocd command:
 
 .. code-block:: console
 
    $ pyocd pack --install stm32g431rb
+
+Note:
+To manually enable the openocd interface, You can still update, compile and install
+a 'local' openocd from the official openocd repo http://openocd.zylin.com .
+Then run the following openocd command where the '/usr/local/bin/openocd'is your path
+for the freshly installed openocd, given by "$ which openocd" :
+
+.. code-block:: console
+
+   $ west flash --openocd /usr/local/bin/openocd
 
 Flashing an application to Nucleo G431RB
 ----------------------------------------

--- a/boards/arm/nucleo_g431rb/support/openocd.cfg
+++ b/boards/arm/nucleo_g431rb/support/openocd.cfg
@@ -1,0 +1,7 @@
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32g4x.cfg]
+
+reset_config srst_only

--- a/boards/arm/nucleo_g474re/board.cmake
+++ b/boards/arm/nucleo_g474re/board.cmake
@@ -5,3 +5,4 @@
 board_runner_args(pyocd "--target=stm32g474rbtx")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/nucleo_g474re/doc/index.rst
+++ b/boards/arm/nucleo_g474re/doc/index.rst
@@ -184,14 +184,26 @@ flashed in the usual way (see :ref:`build_an_application` and
 Flashing
 ========
 
-Nucleo G474RE board includes an ST-LINK/V3E embedded debug tool
-interface. This interface is not yet supported by the openocd version.
+Nucleo G474RE board includes an ST-LINK/V3E embedded debug tool interface.
+
+This interface is not yet supported by the openocd version included in the Zephyr SDK.
+
 Instead, support can be enabled on pyocd by adding "pack" support with
 the following pyocd command:
 
 .. code-block:: console
 
    $ pyocd pack --install stm32g474re
+
+Note:
+To manually enable the openocd interface, You can still update, compile and install
+a 'local' openocd from the official openocd repo http://openocd.zylin.com .
+Then run the following openocd command where the '/usr/local/bin/openocd'is your path
+for the freshly installed openocd, given by "$ which openocd" :
+
+.. code-block:: console
+
+   $ west flash --openocd /usr/local/bin/openocd
 
 Flashing an application to Nucleo G474RE
 ----------------------------------------

--- a/boards/arm/nucleo_g474re/support/openocd.cfg
+++ b/boards/arm/nucleo_g474re/support/openocd.cfg
@@ -1,0 +1,7 @@
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32g4x.cfg]
+
+reset_config srst_only


### PR DESCRIPTION
This patch _plus_ the update of the openocd https://github.com/zephyrproject-rtos/openocd/issues/24
will add the support of stm32g0 and stm32g4 soc with openocd.

In case a local version of the openocd which supports the G0 and G4, is required, refer to the issue mentionned below to install it and use the `west flash --openocd /usr/local/bin/openocd `

Fix https://github.com/zephyrproject-rtos/zephyr/issues/24055

Signed-off-by: Francois Ramu francois.ramu@st.com
