### PR TITLE
drivers: lora: sx1276: various improvements

### DIFF
--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -177,6 +177,10 @@ void SX1276IoIrqInit(DioIrqHandler **irqHandlers)
 
 	/* Setup DIO gpios */
 	for (i = 0; i < SX1276_MAX_DIO; i++) {
+		if (!irqHandlers[i]) {
+			continue;
+		}
+
 		dev_data.dio_dev[i] = device_get_binding(sx1276_dios[i].port);
 		if (dev_data.dio_dev[i] == NULL) {
 			LOG_ERR("Cannot get pointer to %s device",

--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -164,7 +164,8 @@ static void sx1276_irq_callback(struct device *dev,
 	pin = find_lsb_set(pins) - 1;
 
 	for (i = 0; i < SX1276_MAX_DIO; i++) {
-		if (pin == sx1276_dios[i].pin) {
+		if (dev == dev_data.dio_dev[i] &&
+		    pin == sx1276_dios[i].pin) {
 			(*DioIrq[i])(NULL);
 		}
 	}

--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -45,7 +45,7 @@ struct sx1276_dio {
 #define SX1276_DIO_GPIO_INIT(n) \
 	UTIL_LISTIFY(DT_INST_PROP_LEN(n, dio_gpios), SX1276_DIO_GPIO_ELEM, n)
 
-static struct sx1276_dio sx1276_dios[] = { SX1276_DIO_GPIO_INIT(0) };
+static const struct sx1276_dio sx1276_dios[] = { SX1276_DIO_GPIO_INIT(0) };
 
 #define SX1276_MAX_DIO ARRAY_SIZE(sx1276_dios)
 


### PR DESCRIPTION
- handle specifying 5 dios in dts gracefully (without dereferencing NULL pointer at runtime)
- constify dios table
- handle same pin number on different gpio controller (e.g. PC2 and PB2) properly
- call dio loramac-node handlers in workqueue to prevent spi transfers in interrupt context