### PR TITLE
video initialization fix

### DIFF
--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -14,6 +14,12 @@ menuconfig VIDEO
 
 if VIDEO
 
+config VIDEO_INIT_PRIORITY
+	int "Video initialization priority"
+	default 90
+	help
+	  System initialization priority for video drivers.
+
 config VIDEO_BUFFER_POOL_SZ_MAX
 	int "Size of the largest buffer in the video pool"
 	default 1048576

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -413,14 +413,12 @@ static int video_mcux_csi_init_0(struct device *dev)
 
 	irq_enable(DT_VIDEO_MCUX_CSI_IRQ);
 
-	video_mcux_csi_init(dev);
-
-	return 0;
+	return video_mcux_csi_init(dev);
 }
 
 DEVICE_AND_API_INIT(video_mcux_csi, DT_VIDEO_MCUX_CSI_NAME,
 		    &video_mcux_csi_init_0, &video_mcux_csi_data_0,
 		    &video_mcux_csi_config_0,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,
 		    &video_mcux_csi_driver_api);
 #endif

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -273,5 +273,5 @@ static int video_sw_generator_init(struct device *dev)
 
 DEVICE_AND_API_INIT(video_sw_generator, "VIDEO_SW_GENERATOR",
 		    &video_sw_generator_init, &video_sw_generator_data_0, NULL,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,
 		    &video_sw_generator_driver_api);

--- a/samples/video/capture/src/main.c
+++ b/samples/video/capture/src/main.c
@@ -13,10 +13,10 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(main);
 
+#define VIDEO_DEV_SW "VIDEO_SW_GENERATOR"
+
 #if defined(CONFIG_VIDEO_MCUX_CSI)
 #define VIDEO_DEV DT_VIDEO_MCUX_CSI_NAME
-#else
-#define VIDEO_DEV "VIDEO_SW_GENERATOR"
 #endif
 
 void main(void)
@@ -29,12 +29,26 @@ void main(void)
 	size_t bsize;
 	int i = 0;
 
-	/* Retrieve video interface */
-	video = device_get_binding(VIDEO_DEV);
+	/* Default to software video pattern generator */
+	video = device_get_binding(VIDEO_DEV_SW);
 	if (video == NULL) {
-		LOG_ERR("Video device %s not found. Aborting test.", VIDEO_DEV);
+		LOG_ERR("Video device %s not found", VIDEO_DEV_SW);
 		return;
 	}
+
+	/* But would be better to use a real video device if any */
+#ifdef VIDEO_DEV
+	{
+		struct device *dev = device_get_binding(VIDEO_DEV);
+
+		if (dev == NULL) {
+			LOG_ERR("Video device %s not found, "
+				"fallback to software generator.", VIDEO_DEV);
+		} else {
+			video = dev;
+		}
+	}
+#endif
 
 	printk("- Device name: %s\n", VIDEO_DEV);
 


### PR DESCRIPTION
- Fix for video init order (should be initialized after standard devices)
- Fix for video pattern generator fallback in video capture sample
