### PR TITLE
Bluetooth: Convert bluetooth to using k_timeout_t struct

### DIFF
--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -157,7 +157,7 @@ static void reset_rx(void)
 	rx.discardable = false;
 }
 
-static struct net_buf *get_rx(int timeout)
+static struct net_buf *get_rx(k_timeout_t timeout)
 {
 	BT_DBG("type 0x%02x, evt 0x%02x", rx.type, rx.evt.evt);
 

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -228,7 +228,7 @@ void shci_cmd_resp_release(uint32_t flag)
 
 void shci_cmd_resp_wait(uint32_t timeout)
 {
-	k_sem_take(&ble_sys_wait_cmd_rsp, timeout);
+	k_sem_take(&ble_sys_wait_cmd_rsp, K_MSEC(timeout));
 }
 
 void ipcc_reset(void)

--- a/include/bluetooth/buf.h
+++ b/include/bluetooth/buf.h
@@ -57,11 +57,11 @@ enum bt_buf_type {
  *
  *  @param type    Type of buffer. Only BT_BUF_EVT and BT_BUF_ACL_IN are
  *                 allowed.
- *  @param timeout Timeout in milliseconds, or one of the special values
- *                 K_NO_WAIT and K_FOREVER.
+ *  @param timeout Non-negative waiting period to obtain a buffer or one of the
+ *                 special values K_NO_WAIT and K_FOREVER.
  *  @return A new buffer.
  */
-struct net_buf *bt_buf_get_rx(enum bt_buf_type type, s32_t timeout);
+struct net_buf *bt_buf_get_rx(enum bt_buf_type type, k_timeout_t timeout);
 
 /** Allocate a buffer for outgoing data
  *
@@ -70,13 +70,13 @@ struct net_buf *bt_buf_get_rx(enum bt_buf_type type, s32_t timeout);
  *
  *  @param type    Type of buffer. Only BT_BUF_CMD, BT_BUF_ACL_OUT or
  *                 BT_BUF_H4, when operating on H:4 mode, are allowed.
- *  @param timeout Timeout in milliseconds, or one of the special values
- *                 K_NO_WAIT and K_FOREVER.
+ *  @param timeout Non-negative waiting period to obtain a buffer or one of the
+ *                 special values K_NO_WAIT and K_FOREVER.
  *  @param data    Initial data to append to buffer.
  *  @param size    Initial data size.
  *  @return A new buffer.
  */
-struct net_buf *bt_buf_get_tx(enum bt_buf_type type, s32_t timeout,
+struct net_buf *bt_buf_get_tx(enum bt_buf_type type, k_timeout_t timeout,
 			      const void *data, size_t size);
 
 /** Allocate a buffer for an HCI Command Complete/Status Event
@@ -84,11 +84,11 @@ struct net_buf *bt_buf_get_tx(enum bt_buf_type type, s32_t timeout,
  *  This will set the buffer type so bt_buf_set_type() does not need to
  *  be explicitly called before bt_recv_prio().
  *
- *  @param timeout Timeout in milliseconds, or one of the special values
- *                 K_NO_WAIT and K_FOREVER.
+ *  @param timeout Non-negative waiting period to obtain a buffer or one of the
+ *                 special values K_NO_WAIT and K_FOREVER.
  *  @return A new buffer.
  */
-struct net_buf *bt_buf_get_cmd_complete(s32_t timeout);
+struct net_buf *bt_buf_get_cmd_complete(k_timeout_t timeout);
 
 /** Allocate a buffer for an HCI Event
  *
@@ -97,11 +97,11 @@ struct net_buf *bt_buf_get_cmd_complete(s32_t timeout);
  *
  *  @param evt          HCI event code
  *  @param discardable  Whether the driver considers the event discardable.
- *  @param timeout      Timeout in milliseconds, or one of the special values
- *                      K_NO_WAIT and K_FOREVER.
+ *  @param timeout      Non-negative waiting period to obtain a buffer or one of
+ *                      the special values K_NO_WAIT and K_FOREVER.
  *  @return A new buffer.
  */
-struct net_buf *bt_buf_get_evt(u8_t evt, bool discardable, s32_t timeout);
+struct net_buf *bt_buf_get_evt(u8_t evt, bool discardable, k_timeout_t timeout);
 
 /** Set the buffer type
  *

--- a/include/bluetooth/mesh/cfg_cli.h
+++ b/include/bluetooth/mesh/cfg_cli.h
@@ -832,7 +832,7 @@ int bt_mesh_cfg_hb_pub_get(u16_t net_idx, u16_t addr,
 
 /** @brief Get the current transmission timeout value.
  *
- *  @return The configured transmission timeout.
+ *  @return The configured transmission timeout in milliseconds.
  */
 s32_t bt_mesh_cfg_cli_timeout_get(void);
 

--- a/include/bluetooth/mesh/health_cli.h
+++ b/include/bluetooth/mesh/health_cli.h
@@ -182,7 +182,7 @@ int bt_mesh_health_attention_set(u16_t addr, u16_t app_idx, u8_t attention,
 
 /** @brief Get the current transmission timeout value.
  *
- *  @return The configured transmission timeout.
+ *  @return The configured transmission timeout in milliseconds.
  */
 s32_t bt_mesh_health_cli_timeout_get(void);
 

--- a/include/sys/time_units.h
+++ b/include/sys/time_units.h
@@ -22,7 +22,7 @@ extern "C" {
 
 /** @brief System-wide macro to convert milliseconds to kernel timeouts
  */
-#define SYS_TIMEOUT_MS (ms) ((ms) == SYS_FOREVER_MS ? K_FOREVER : K_MSEC(ms))
+#define SYS_TIMEOUT_MS(ms) ((ms) == SYS_FOREVER_MS ? K_FOREVER : K_MSEC(ms))
 
 /* Exhaustively enumerated, highly optimized time unit conversion API */
 

--- a/samples/bluetooth/mesh_demo/src/microbit.c
+++ b/samples/bluetooth/mesh_demo/src/microbit.c
@@ -130,7 +130,7 @@ void board_play_tune(const char *str)
 					 0);
 		}
 
-		k_sleep(duration);
+		k_sleep(K_MSEC(duration));
 
 		/* Disable the PWM */
 		pwm_pin_set_usec(pwm, BUZZER_PIN, 0, 0, 0);

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -160,7 +160,7 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		return;
 	}
 
@@ -227,7 +227,7 @@ static void gen_onoff_set(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		gen_onoff_get(model, ctx, buf);
 		return;
 	}
@@ -358,7 +358,7 @@ static void gen_level_set_unack(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		return;
 	}
 
@@ -422,7 +422,7 @@ static void gen_level_set(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		gen_level_get(model, ctx, buf);
 		return;
 	}
@@ -490,7 +490,7 @@ static void gen_delta_set_unack(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 
 		if (ctl->light->delta == delta) {
 			return;
@@ -570,7 +570,7 @@ static void gen_delta_set(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 
 		if (ctl->light->delta == delta) {
 			gen_level_get(model, ctx, buf);
@@ -653,7 +653,7 @@ static void gen_move_set_unack(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		return;
 	}
 
@@ -726,7 +726,7 @@ static void gen_move_set(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		gen_level_get(model, ctx, buf);
 		return;
 	}
@@ -1008,7 +1008,7 @@ static void vnd_set_unack(struct bt_mesh_model *model,
 	if (state->last_tid == tid &&
 	    state->last_src_addr == ctx->addr &&
 	    state->last_dst_addr == ctx->recv_dst &&
-	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - state->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		return;
 	}
 
@@ -1105,7 +1105,7 @@ static void light_lightness_set_unack(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		return;
 	}
 
@@ -1169,7 +1169,7 @@ static void light_lightness_set(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		light_lightness_get(model, ctx, buf);
 		return;
 	}
@@ -1287,7 +1287,7 @@ static void light_lightness_linear_set_unack(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		return;
 	}
 
@@ -1351,7 +1351,7 @@ static void light_lightness_linear_set(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		light_lightness_linear_get(model, ctx, buf);
 		return;
 	}
@@ -1731,7 +1731,7 @@ static void light_ctl_set_unack(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		return;
 	}
 
@@ -1808,7 +1808,7 @@ static void light_ctl_set(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		light_ctl_get(model, ctx, buf);
 		return;
 	}
@@ -2208,7 +2208,7 @@ static void light_ctl_temp_set_unack(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		return;
 	}
 
@@ -2281,7 +2281,7 @@ static void light_ctl_temp_set(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		light_ctl_temp_get(model, ctx, buf);
 		return;
 	}
@@ -2401,7 +2401,7 @@ static void gen_level_set_unack_temp(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		return;
 	}
 
@@ -2465,7 +2465,7 @@ static void gen_level_set_temp(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		gen_level_get_temp(model, ctx, buf);
 		return;
 	}
@@ -2533,7 +2533,7 @@ static void gen_delta_set_unack_temp(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 
 		if (ctl->temp->delta == delta) {
 			return;
@@ -2613,7 +2613,7 @@ static void gen_delta_set_temp(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 
 		if (ctl->temp->delta == delta) {
 			gen_level_get_temp(model, ctx, buf);
@@ -2696,7 +2696,7 @@ static void gen_move_set_unack_temp(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		return;
 	}
 
@@ -2769,7 +2769,7 @@ static void gen_move_set_temp(struct bt_mesh_model *model,
 	if (ctl->last_tid == tid &&
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		gen_level_get_temp(model, ctx, buf);
 		return;
 	}

--- a/samples/boards/reel_board/mesh_badge/src/board.h
+++ b/samples/boards/reel_board/mesh_badge/src/board.h
@@ -14,7 +14,7 @@ enum periph_device {
 };
 
 void board_refresh_display(void);
-void board_show_text(const char *text, bool center, s32_t duration);
+void board_show_text(const char *text, bool center, k_timeout_t duration);
 void board_blink_leds(void);
 void board_add_hello(u16_t addr, const char *name);
 void board_add_heartbeat(u16_t addr, u8_t hops);

--- a/samples/boards/reel_board/mesh_badge/src/mesh.c
+++ b/samples/boards/reel_board/mesh_badge/src/mesh.c
@@ -144,7 +144,7 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 
 	now = k_uptime_get();
 	if (state->last_tid == tid && state->last_tx_addr == ctx->addr &&
-	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
+	    (now - state->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
 		printk("Already received message\n");
 	}
 

--- a/samples/boards/reel_board/mesh_badge/src/reel_board.c
+++ b/samples/boards/reel_board/mesh_badge/src/reel_board.c
@@ -138,7 +138,7 @@ void board_blink_leds(void)
 	k_delayed_work_submit(&led_timer, K_MSEC(100));
 }
 
-void board_show_text(const char *text, bool center, s32_t duration)
+void board_show_text(const char *text, bool center, k_timeout_t duration)
 {
 	int i;
 
@@ -164,7 +164,7 @@ void board_show_text(const char *text, bool center, s32_t duration)
 
 	cfb_framebuffer_finalize(epd_dev);
 
-	if (duration != K_FOREVER) {
+	if (!K_TIMEOUT_EQ(duration, K_FOREVER)) {
 		k_delayed_work_submit(&epd_work, duration);
 	}
 }
@@ -344,7 +344,7 @@ static void show_statistics(void)
 	cfb_framebuffer_finalize(epd_dev);
 }
 
-static void show_sensors_data(s32_t interval)
+static void show_sensors_data(k_timeout_t interval)
 {
 	struct sensor_value val[3];
 	u8_t line = 0U;

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -6,7 +6,6 @@
 menuconfig BT
 	bool "Bluetooth"
 	select NET_BUF
-	select LEGACY_TIMEOUT_API
 	help
 	  This option enables Bluetooth support.
 

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -355,7 +355,7 @@ static void recv_thread(void *p1, void *p2, void *p3)
 			events[0].signal->signaled = 0U;
 		} else if (events[1].state ==
 			   K_POLL_STATE_FIFO_DATA_AVAILABLE) {
-			node_rx = k_fifo_get(events[1].fifo, 0);
+			node_rx = k_fifo_get(events[1].fifo, K_NO_WAIT);
 		}
 
 		events[0].state = K_POLL_STATE_NOT_READY;

--- a/subsys/bluetooth/controller/ll_sw/ll_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.c
@@ -688,13 +688,13 @@ void ll_rl_rpa_update(bool timeout)
 static void rpa_timeout(struct k_work *work)
 {
 	ll_rl_rpa_update(true);
-	k_delayed_work_submit(&rpa_work, rpa_timeout_ms);
+	k_delayed_work_submit(&rpa_work, K_MSEC(rpa_timeout_ms));
 }
 
 static void rpa_refresh_start(void)
 {
 	BT_DBG("");
-	k_delayed_work_submit(&rpa_work, rpa_timeout_ms);
+	k_delayed_work_submit(&rpa_work, K_MSEC(rpa_timeout_ms));
 }
 
 static void rpa_refresh_stop(void)

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -1022,13 +1022,13 @@ static int rl_access_check(bool check_ar)
 static void rpa_timeout(struct k_work *work)
 {
 	ull_filter_rpa_update(true);
-	k_delayed_work_submit(&rpa_work, rpa_timeout_ms);
+	k_delayed_work_submit(&rpa_work, K_MSEC(rpa_timeout_ms));
 }
 
 static void rpa_refresh_start(void)
 {
 	BT_DBG("");
-	k_delayed_work_submit(&rpa_work, rpa_timeout_ms);
+	k_delayed_work_submit(&rpa_work, K_MSEC(rpa_timeout_ms));
 }
 
 static void rpa_refresh_stop(void)

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2265,7 +2265,7 @@ u16_t bt_att_get_mtu(struct bt_conn *conn)
 	return att->chan.tx.mtu;
 }
 
-struct bt_att_req *bt_att_req_alloc(s32_t timeout)
+struct bt_att_req *bt_att_req_alloc(k_timeout_t timeout)
 {
 	struct bt_att_req *req = NULL;
 

--- a/subsys/bluetooth/host/att_internal.h
+++ b/subsys/bluetooth/host/att_internal.h
@@ -263,7 +263,7 @@ struct net_buf *bt_att_create_pdu(struct bt_conn *conn, u8_t op,
 				  size_t len);
 
 /* Allocate a new request */
-struct bt_att_req *bt_att_req_alloc(s32_t timeout);
+struct bt_att_req *bt_att_req_alloc(k_timeout_t timeout);
 
 /* Free a request */
 void bt_att_req_free(struct bt_att_req *req);

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2430,10 +2430,11 @@ int bt_conn_le_conn_update(struct bt_conn *conn,
 }
 
 #if defined(CONFIG_NET_BUF_LOG)
-struct net_buf *bt_conn_create_frag_timeout_debug(size_t reserve, s32_t timeout,
+struct net_buf *bt_conn_create_frag_timeout_debug(size_t reserve,
+						  k_timeout_t timeout,
 						  const char *func, int line)
 #else
-struct net_buf *bt_conn_create_frag_timeout(size_t reserve, s32_t timeout)
+struct net_buf *bt_conn_create_frag_timeout(size_t reserve, k_timeout_t timeout)
 #endif
 {
 	struct net_buf_pool *pool = NULL;
@@ -2452,11 +2453,12 @@ struct net_buf *bt_conn_create_frag_timeout(size_t reserve, s32_t timeout)
 
 #if defined(CONFIG_NET_BUF_LOG)
 struct net_buf *bt_conn_create_pdu_timeout_debug(struct net_buf_pool *pool,
-						 size_t reserve, s32_t timeout,
+						 size_t reserve,
+						 k_timeout_t timeout,
 						 const char *func, int line)
 #else
 struct net_buf *bt_conn_create_pdu_timeout(struct net_buf_pool *pool,
-					   size_t reserve, s32_t timeout)
+					   size_t reserve, k_timeout_t timeout)
 #endif
 {
 	struct net_buf *buf;
@@ -2496,7 +2498,7 @@ struct net_buf *bt_conn_create_pdu_timeout(struct net_buf_pool *pool,
 	}
 
 	if (!buf) {
-		BT_WARN("Unable to allocate buffer: timeout %d", timeout);
+		BT_WARN("Unable to allocate buffer within timeout");
 		return NULL;
 	}
 

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -249,7 +249,8 @@ void bt_conn_security_changed(struct bt_conn *conn, enum bt_security_err err);
 /* Prepare a PDU to be sent over a connection */
 #if defined(CONFIG_NET_BUF_LOG)
 struct net_buf *bt_conn_create_pdu_timeout_debug(struct net_buf_pool *pool,
-						 size_t reserve, s32_t timeout,
+						 size_t reserve,
+						 k_timeout_t timeout,
 						 const char *func, int line);
 #define bt_conn_create_pdu_timeout(_pool, _reserve, _timeout) \
 	bt_conn_create_pdu_timeout_debug(_pool, _reserve, _timeout, \
@@ -260,7 +261,7 @@ struct net_buf *bt_conn_create_pdu_timeout_debug(struct net_buf_pool *pool,
 					 __func__, __line__)
 #else
 struct net_buf *bt_conn_create_pdu_timeout(struct net_buf_pool *pool,
-					   size_t reserve, s32_t timeout);
+					   size_t reserve, k_timeout_t timeout);
 
 #define bt_conn_create_pdu(_pool, _reserve) \
 	bt_conn_create_pdu_timeout(_pool, _reserve, K_FOREVER)
@@ -268,7 +269,8 @@ struct net_buf *bt_conn_create_pdu_timeout(struct net_buf_pool *pool,
 
 /* Prepare a PDU to be sent over a connection */
 #if defined(CONFIG_NET_BUF_LOG)
-struct net_buf *bt_conn_create_frag_timeout_debug(size_t reserve, s32_t timeout,
+struct net_buf *bt_conn_create_frag_timeout_debug(size_t reserve,
+						  k_timeout_t timeout,
 						  const char *func, int line);
 
 #define bt_conn_create_frag_timeout(_reserve, _timeout) \
@@ -279,7 +281,8 @@ struct net_buf *bt_conn_create_frag_timeout_debug(size_t reserve, s32_t timeout,
 	bt_conn_create_frag_timeout_debug(_reserve, K_FOREVER, \
 					  __func__, __LINE__)
 #else
-struct net_buf *bt_conn_create_frag_timeout(size_t reserve, s32_t timeout);
+struct net_buf *bt_conn_create_frag_timeout(size_t reserve,
+					    k_timeout_t timeout);
 
 #define bt_conn_create_frag(_reserve) \
 	bt_conn_create_frag_timeout(_reserve, K_FOREVER)

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -53,7 +53,8 @@
 
 /* Peripheral timeout to initialize Connection Parameter Update procedure */
 #define CONN_UPDATE_TIMEOUT  K_MSEC(CONFIG_BT_CONN_PARAM_UPDATE_TIMEOUT)
-#define RPA_TIMEOUT          K_SECONDS(CONFIG_BT_RPA_TIMEOUT)
+#define RPA_TIMEOUT_MS       (CONFIG_BT_RPA_TIMEOUT * MSEC_PER_SEC)
+#define RPA_TIMEOUT          K_MSEC(RPA_TIMEOUT_MS)
 
 #define HCI_CMD_TIMEOUT      K_SECONDS(10)
 
@@ -1234,7 +1235,7 @@ static inline bool rpa_is_new(void)
 	 * timeout was started.
 	 */
 	return k_delayed_work_remaining_get(&bt_dev.rpa_update) >
-	       (RPA_TIMEOUT - K_MSEC(500));
+	       (RPA_TIMEOUT_MS - 500);
 #else
 	return false;
 #endif
@@ -8273,7 +8274,7 @@ int bt_le_set_chan_map(u8_t chan_map[5])
 				    buf, NULL);
 }
 
-struct net_buf *bt_buf_get_rx(enum bt_buf_type type, s32_t timeout)
+struct net_buf *bt_buf_get_rx(enum bt_buf_type type, k_timeout_t timeout)
 {
 	struct net_buf *buf;
 
@@ -8298,7 +8299,7 @@ struct net_buf *bt_buf_get_rx(enum bt_buf_type type, s32_t timeout)
 	return buf;
 }
 
-struct net_buf *bt_buf_get_cmd_complete(s32_t timeout)
+struct net_buf *bt_buf_get_cmd_complete(k_timeout_t timeout)
 {
 	struct net_buf *buf;
 	unsigned int key;
@@ -8321,7 +8322,7 @@ struct net_buf *bt_buf_get_cmd_complete(s32_t timeout)
 	return bt_buf_get_rx(BT_BUF_EVT, timeout);
 }
 
-struct net_buf *bt_buf_get_evt(u8_t evt, bool discardable, s32_t timeout)
+struct net_buf *bt_buf_get_evt(u8_t evt, bool discardable, k_timeout_t timeout)
 {
 	switch (evt) {
 #if defined(CONFIG_BT_CONN)

--- a/subsys/bluetooth/host/hci_raw.c
+++ b/subsys/bluetooth/host/hci_raw.c
@@ -65,7 +65,7 @@ int bt_hci_driver_register(const struct bt_hci_driver *drv)
 	return 0;
 }
 
-struct net_buf *bt_buf_get_rx(enum bt_buf_type type, s32_t timeout)
+struct net_buf *bt_buf_get_rx(enum bt_buf_type type, k_timeout_t timeout)
 {
 	struct net_buf *buf;
 
@@ -89,7 +89,7 @@ struct net_buf *bt_buf_get_rx(enum bt_buf_type type, s32_t timeout)
 	return buf;
 }
 
-struct net_buf *bt_buf_get_tx(enum bt_buf_type type, s32_t timeout,
+struct net_buf *bt_buf_get_tx(enum bt_buf_type type, k_timeout_t timeout,
 			      const void *data, size_t size)
 {
 	struct net_buf *buf;
@@ -139,12 +139,12 @@ struct net_buf *bt_buf_get_tx(enum bt_buf_type type, s32_t timeout,
 	return buf;
 }
 
-struct net_buf *bt_buf_get_cmd_complete(s32_t timeout)
+struct net_buf *bt_buf_get_cmd_complete(k_timeout_t timeout)
 {
 	return bt_buf_get_rx(BT_BUF_EVT, timeout);
 }
 
-struct net_buf *bt_buf_get_evt(u8_t evt, bool discardable, s32_t timeout)
+struct net_buf *bt_buf_get_evt(u8_t evt, bool discardable, k_timeout_t timeout)
 {
 	return bt_buf_get_rx(BT_BUF_EVT, timeout);
 }

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -411,7 +411,7 @@ static struct net_buf *l2cap_create_le_sig_pdu(struct net_buf *buf,
 
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 static void l2cap_chan_send_req(struct bt_l2cap_le_chan *chan,
-				struct net_buf *buf, s32_t timeout)
+				struct net_buf *buf, k_timeout_t timeout)
 {
 	/* BLUETOOTH SPECIFICATION Version 4.2 [Vol 3, Part A] page 126:
 	 *
@@ -422,11 +422,7 @@ static void l2cap_chan_send_req(struct bt_l2cap_le_chan *chan,
 	 * final expiration, when the response is received, or the physical
 	 * link is lost.
 	 */
-	if (timeout) {
-		k_delayed_work_submit(&chan->chan.rtx_work, timeout);
-	} else {
-		k_delayed_work_cancel(&chan->chan.rtx_work);
-	}
+	k_delayed_work_submit(&chan->chan.rtx_work, timeout);
 
 	bt_l2cap_send(chan->chan.conn, BT_L2CAP_CID_LE_SIG, buf);
 }
@@ -496,7 +492,8 @@ void bt_l2cap_encrypt_change(struct bt_conn *conn, u8_t hci_status)
 }
 
 struct net_buf *bt_l2cap_create_pdu_timeout(struct net_buf_pool *pool,
-					    size_t reserve, s32_t timeout)
+					    size_t reserve,
+					    k_timeout_t timeout)
 {
 	return bt_conn_create_pdu_timeout(pool,
 					  sizeof(struct bt_l2cap_hdr) + reserve,
@@ -1644,7 +1641,7 @@ int bt_l2cap_chan_recv_complete(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	return 0;
 }
 
-static struct net_buf *l2cap_alloc_frag(s32_t timeout, void *user_data)
+static struct net_buf *l2cap_alloc_frag(k_timeout_t timeout, void *user_data)
 {
 	struct bt_l2cap_le_chan *chan = user_data;
 	struct net_buf *frag = NULL;

--- a/subsys/bluetooth/host/l2cap_br.c
+++ b/subsys/bluetooth/host/l2cap_br.c
@@ -226,7 +226,7 @@ static u8_t l2cap_br_get_ident(void)
 }
 
 static void l2cap_br_chan_send_req(struct bt_l2cap_br_chan *chan,
-				   struct net_buf *buf, s32_t timeout)
+				   struct net_buf *buf, k_timeout_t timeout)
 {
 	/* BLUETOOTH SPECIFICATION Version 4.2 [Vol 3, Part A] page 126:
 	 *
@@ -237,11 +237,7 @@ static void l2cap_br_chan_send_req(struct bt_l2cap_br_chan *chan,
 	 * final expiration, when the response is received, or the physical
 	 * link is lost.
 	 */
-	if (timeout) {
-		k_delayed_work_submit(&chan->chan.rtx_work, timeout);
-	} else {
-		k_delayed_work_cancel(&chan->chan.rtx_work);
-	}
+	k_delayed_work_submit(&chan->chan.rtx_work, timeout);
 
 	bt_l2cap_send(chan->chan.conn, BT_L2CAP_CID_BR_SIG, buf);
 }

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -261,7 +261,8 @@ void bt_l2cap_encrypt_change(struct bt_conn *conn, u8_t hci_status);
 
 /* Prepare an L2CAP PDU to be sent over a connection */
 struct net_buf *bt_l2cap_create_pdu_timeout(struct net_buf_pool *pool,
-					    size_t reserve, s32_t timeout);
+					    size_t reserve,
+					    k_timeout_t timeout);
 
 #define bt_l2cap_create_pdu(_pool, _reserve) \
 	bt_l2cap_create_pdu_timeout(_pool, _reserve, K_FOREVER)

--- a/subsys/bluetooth/host/rfcomm.c
+++ b/subsys/bluetooth/host/rfcomm.c
@@ -531,7 +531,7 @@ static void rfcomm_check_fc(struct bt_rfcomm_dlc *dlc)
 static void rfcomm_dlc_tx_thread(void *p1, void *p2, void *p3)
 {
 	struct bt_rfcomm_dlc *dlc = p1;
-	s32_t timeout = K_FOREVER;
+	k_timeout_t timeout = K_FOREVER;
 	struct net_buf *buf;
 
 	BT_DBG("Started for dlc %p", dlc);

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -454,7 +454,7 @@ static struct net_buf *smp_create_pdu(struct bt_smp *smp, u8_t op, size_t len)
 {
 	struct bt_smp_hdr *hdr;
 	struct net_buf *buf;
-	s32_t timeout;
+	k_timeout_t timeout;
 
 	/* Don't if session had already timed out */
 	if (atomic_test_bit(smp->flags, SMP_FLAG_TIMEOUT)) {
@@ -1139,7 +1139,7 @@ static struct net_buf *smp_br_create_pdu(struct bt_smp_br *smp, u8_t op,
 {
 	struct bt_smp_hdr *hdr;
 	struct net_buf *buf;
-	s32_t timeout;
+	k_timeout_t timeout;
 
 	/* Don't if session had already timed out */
 	if (atomic_test_bit(smp->flags, SMP_FLAG_TIMEOUT)) {

--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -158,11 +158,11 @@ static void adv_thread(void *p1, void *p2, void *p3)
 		if (IS_ENABLED(CONFIG_BT_MESH_PROXY)) {
 			buf = net_buf_get(&adv_queue, K_NO_WAIT);
 			while (!buf) {
-				s32_t timeout;
+				k_timeout_t timeout;
 
 				timeout = bt_mesh_proxy_adv_start();
-				BT_DBG("Proxy Advertising up to %d ms",
-				       timeout);
+				BT_DBG("Proxy Advertising");
+
 				buf = net_buf_get(&adv_queue, timeout);
 				bt_mesh_proxy_adv_stop();
 			}
@@ -197,7 +197,7 @@ void bt_mesh_adv_update(void)
 struct net_buf *bt_mesh_adv_create_from_pool(struct net_buf_pool *pool,
 					     bt_mesh_adv_alloc_t get_id,
 					     enum bt_mesh_adv_type type,
-					     u8_t xmit, s32_t timeout)
+					     u8_t xmit, k_timeout_t timeout)
 {
 	struct bt_mesh_adv *adv;
 	struct net_buf *buf;
@@ -224,7 +224,7 @@ struct net_buf *bt_mesh_adv_create_from_pool(struct net_buf_pool *pool,
 }
 
 struct net_buf *bt_mesh_adv_create(enum bt_mesh_adv_type type, u8_t xmit,
-				   s32_t timeout)
+				   k_timeout_t timeout)
 {
 	return bt_mesh_adv_create_from_pool(&adv_buf_pool, adv_alloc, type,
 					    xmit, timeout);

--- a/subsys/bluetooth/mesh/adv.h
+++ b/subsys/bluetooth/mesh/adv.h
@@ -37,12 +37,12 @@ typedef struct bt_mesh_adv *(*bt_mesh_adv_alloc_t)(int id);
 
 /* xmit_count: Number of retransmissions, i.e. 0 == 1 transmission */
 struct net_buf *bt_mesh_adv_create(enum bt_mesh_adv_type type, u8_t xmit,
-				   s32_t timeout);
+				   k_timeout_t timeout);
 
 struct net_buf *bt_mesh_adv_create_from_pool(struct net_buf_pool *pool,
 					     bt_mesh_adv_alloc_t get_id,
 					     enum bt_mesh_adv_type type,
-					     u8_t xmit, s32_t timeout);
+					     u8_t xmit, k_timeout_t timeout);
 
 void bt_mesh_adv_send(struct net_buf *buf, const struct bt_mesh_send_cb *cb,
 		      void *cb_data);

--- a/subsys/bluetooth/mesh/beacon.c
+++ b/subsys/bluetooth/mesh/beacon.c
@@ -105,8 +105,8 @@ void bt_mesh_beacon_create(struct bt_mesh_subnet *sub,
 }
 
 /* If the interval has passed or is within 5 seconds from now send a beacon */
-#define BEACON_THRESHOLD(sub) (K_SECONDS(10 * ((sub)->beacons_last + 1)) - \
-			       K_SECONDS(5))
+#define BEACON_THRESHOLD(sub) \
+	((10 * ((sub)->beacons_last + 1)) * MSEC_PER_SEC - (5 * MSEC_PER_SEC))
 
 static int secure_beacon_send(void)
 {
@@ -128,7 +128,7 @@ static int secure_beacon_send(void)
 		}
 
 		time_diff = now - sub->beacon_sent;
-		if (time_diff < K_SECONDS(600) &&
+		if (time_diff < (600 * MSEC_PER_SEC) &&
 		    time_diff < BEACON_THRESHOLD(sub)) {
 			continue;
 		}

--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -35,7 +35,7 @@ struct comp_data {
 	struct net_buf_simple *comp;
 };
 
-static s32_t msg_timeout = K_SECONDS(2);
+static s32_t msg_timeout;
 
 static struct bt_mesh_cfg_cli *cli;
 
@@ -709,6 +709,7 @@ static int cfg_cli_init(struct bt_mesh_model *model)
 
 	cli = model->user_data;
 	cli->model = model;
+	msg_timeout = 2 * MSEC_PER_SEC;
 
 	/*
 	 * Configuration Model security is device-key based and both the local
@@ -753,7 +754,7 @@ static int cli_wait(void)
 {
 	int err;
 
-	err = k_sem_take(&cli->op_sync, msg_timeout);
+	err = k_sem_take(&cli->op_sync, SYS_TIMEOUT_MS(msg_timeout));
 
 	cli_reset();
 

--- a/subsys/bluetooth/mesh/health_cli.c
+++ b/subsys/bluetooth/mesh/health_cli.c
@@ -25,7 +25,7 @@
 #include "net.h"
 #include "foundation.h"
 
-static s32_t msg_timeout = K_SECONDS(2);
+static s32_t msg_timeout;
 
 static struct bt_mesh_health_cli *health_cli;
 
@@ -199,7 +199,7 @@ static int cli_wait(void)
 {
 	int err;
 
-	err = k_sem_take(&health_cli->op_sync, msg_timeout);
+	err = k_sem_take(&health_cli->op_sync, SYS_TIMEOUT_MS(msg_timeout));
 
 	cli_reset();
 
@@ -497,6 +497,7 @@ int bt_mesh_health_cli_set(struct bt_mesh_model *model)
 	}
 
 	health_cli = model->user_data;
+	msg_timeout = 2 * MSEC_PER_SEC;
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/health_srv.c
+++ b/subsys/bluetooth/mesh/health_srv.c
@@ -363,7 +363,7 @@ int bt_mesh_fault_update(struct bt_mesh_elem *elem)
 	/* Let periodic publishing, if enabled, take care of sending the
 	 * Health Current Status.
 	 */
-	if (bt_mesh_model_pub_period_get(mod)) {
+	if (bt_mesh_model_pub_period_get(mod) > 0) {
 		return 0;
 	}
 
@@ -435,12 +435,12 @@ void bt_mesh_attention(struct bt_mesh_model *model, u8_t time)
 		srv = model->user_data;
 	}
 
-	if (time) {
+	if (time > 0) {
 		if (srv->cb && srv->cb->attn_on) {
 			srv->cb->attn_on(model);
 		}
 
-		k_delayed_work_submit(&srv->attn_timer, time * 1000U);
+		k_delayed_work_submit(&srv->attn_timer, K_SECONDS(time));
 	} else {
 		k_delayed_work_cancel(&srv->attn_timer);
 

--- a/subsys/bluetooth/mesh/lpn.c
+++ b/subsys/bluetooth/mesh/lpn.c
@@ -29,9 +29,9 @@
 #include "lpn.h"
 
 #if defined(CONFIG_BT_MESH_LPN_AUTO)
-#define LPN_AUTO_TIMEOUT          K_SECONDS(CONFIG_BT_MESH_LPN_AUTO_TIMEOUT)
+#define LPN_AUTO_TIMEOUT (CONFIG_BT_MESH_LPN_AUTO_TIMEOUT * MSEC_PER_SEC)
 #else
-#define LPN_AUTO_TIMEOUT          0
+#define LPN_AUTO_TIMEOUT 0
 #endif
 
 #define LPN_RECV_DELAY            CONFIG_BT_MESH_LPN_RECV_DELAY
@@ -40,11 +40,11 @@
 
 #define FRIEND_REQ_RETRY_TIMEOUT  K_SECONDS(CONFIG_BT_MESH_LPN_RETRY_TIMEOUT)
 
-#define FRIEND_REQ_WAIT           K_MSEC(100)
-#define FRIEND_REQ_SCAN           K_SECONDS(1)
+#define FRIEND_REQ_WAIT           100
+#define FRIEND_REQ_SCAN           (1 * MSEC_PER_SEC)
 #define FRIEND_REQ_TIMEOUT        (FRIEND_REQ_WAIT + FRIEND_REQ_SCAN)
 
-#define POLL_RETRY_TIMEOUT        K_MSEC(100)
+#define POLL_RETRY_TIMEOUT        100
 
 #define REQ_RETRY_DURATION(lpn)   (LPN_RECV_DELAY + (lpn)->adv_duration + \
 				      (lpn)->recv_win + POLL_RETRY_TIMEOUT)
@@ -165,7 +165,7 @@ static void friend_clear_sent(int err, void *user_data)
 	}
 
 	lpn_set_state(BT_MESH_LPN_CLEAR);
-	k_delayed_work_submit(&lpn->timer, FRIEND_REQ_TIMEOUT);
+	k_delayed_work_submit(&lpn->timer, K_MSEC(FRIEND_REQ_TIMEOUT));
 }
 
 static const struct bt_mesh_send_cb clear_sent_cb = {
@@ -272,11 +272,11 @@ static void friend_req_sent(u16_t duration, int err, void *user_data)
 	lpn->adv_duration = duration;
 
 	if (IS_ENABLED(CONFIG_BT_MESH_LPN_ESTABLISHMENT)) {
-		k_delayed_work_submit(&lpn->timer, FRIEND_REQ_WAIT);
+		k_delayed_work_submit(&lpn->timer, K_MSEC(FRIEND_REQ_WAIT));
 		lpn_set_state(BT_MESH_LPN_REQ_WAIT);
 	} else {
 		k_delayed_work_submit(&lpn->timer,
-				      duration + FRIEND_REQ_TIMEOUT);
+				      K_MSEC(duration + FRIEND_REQ_TIMEOUT));
 		lpn_set_state(BT_MESH_LPN_WAIT_OFFER);
 	}
 }
@@ -340,11 +340,11 @@ static void req_sent(u16_t duration, int err, void *user_data)
 		 * response data due to HCI and other latencies.
 		 */
 		k_delayed_work_submit(&lpn->timer,
-				      LPN_RECV_DELAY - SCAN_LATENCY);
+				      K_MSEC(LPN_RECV_DELAY - SCAN_LATENCY));
 	} else {
 		k_delayed_work_submit(&lpn->timer,
-				      LPN_RECV_DELAY + duration +
-				      lpn->recv_win);
+				      K_MSEC(LPN_RECV_DELAY + duration +
+					     lpn->recv_win));
 	}
 }
 
@@ -466,7 +466,7 @@ void bt_mesh_lpn_msg_received(struct bt_mesh_net_rx *rx)
 
 	if (lpn->state == BT_MESH_LPN_TIMER) {
 		BT_DBG("Restarting establishment timer");
-		k_delayed_work_submit(&lpn->timer, LPN_AUTO_TIMEOUT);
+		k_delayed_work_submit(&lpn->timer, K_MSEC(LPN_AUTO_TIMEOUT));
 		return;
 	}
 
@@ -710,7 +710,7 @@ static void update_timeout(struct bt_mesh_lpn *lpn)
 		BT_WARN("No response from Friend during ReceiveWindow");
 		bt_mesh_scan_disable();
 		lpn_set_state(BT_MESH_LPN_ESTABLISHED);
-		k_delayed_work_submit(&lpn->timer, POLL_RETRY_TIMEOUT);
+		k_delayed_work_submit(&lpn->timer, K_MSEC(POLL_RETRY_TIMEOUT));
 	} else {
 		if (IS_ENABLED(CONFIG_BT_MESH_LPN_ESTABLISHMENT)) {
 			bt_mesh_scan_disable();
@@ -755,8 +755,8 @@ static void lpn_timeout(struct k_work *work)
 		break;
 	case BT_MESH_LPN_REQ_WAIT:
 		bt_mesh_scan_enable();
-		k_delayed_work_submit(&lpn->timer,
-				      lpn->adv_duration + FRIEND_REQ_SCAN);
+		k_delayed_work_submit(&lpn->timer, K_MSEC(lpn->adv_duration +
+							  FRIEND_REQ_SCAN));
 		lpn_set_state(BT_MESH_LPN_WAIT_OFFER);
 		break;
 	case BT_MESH_LPN_WAIT_OFFER:
@@ -791,8 +791,8 @@ static void lpn_timeout(struct k_work *work)
 		break;
 	case BT_MESH_LPN_RECV_DELAY:
 		k_delayed_work_submit(&lpn->timer,
-				      lpn->adv_duration + SCAN_LATENCY +
-				      lpn->recv_win);
+				      K_MSEC(lpn->adv_duration + SCAN_LATENCY +
+					     lpn->recv_win));
 		bt_mesh_scan_enable();
 		lpn_set_state(BT_MESH_LPN_WAIT_UPDATE);
 		break;
@@ -840,7 +840,7 @@ static s32_t poll_timeout(struct bt_mesh_lpn *lpn)
 {
 	/* If we're waiting for segment acks keep polling at high freq */
 	if (bt_mesh_tx_in_progress()) {
-		return MIN(POLL_TIMEOUT_MAX(lpn), K_SECONDS(1));
+		return MIN(POLL_TIMEOUT_MAX(lpn), 1 * MSEC_PER_SEC);
 	}
 
 	if (lpn->poll_timeout < POLL_TIMEOUT_MAX(lpn)) {
@@ -913,7 +913,7 @@ int bt_mesh_lpn_friend_sub_cfm(struct bt_mesh_net_rx *rx,
 	}
 
 	if (!lpn->sent_req) {
-		k_delayed_work_submit(&lpn->timer, poll_timeout(lpn));
+		k_delayed_work_submit(&lpn->timer, K_MSEC(poll_timeout(lpn)));
 	}
 
 	return 0;
@@ -1007,7 +1007,7 @@ int bt_mesh_lpn_friend_update(struct bt_mesh_net_rx *rx,
 	}
 
 	if (!lpn->sent_req) {
-		k_delayed_work_submit(&lpn->timer, poll_timeout(lpn));
+		k_delayed_work_submit(&lpn->timer, K_MSEC(poll_timeout(lpn)));
 	}
 
 	return 0;
@@ -1051,7 +1051,8 @@ int bt_mesh_lpn_init(void)
 		if (IS_ENABLED(CONFIG_BT_MESH_LPN_AUTO)) {
 			BT_DBG("Waiting %u ms for messages", LPN_AUTO_TIMEOUT);
 			lpn_set_state(BT_MESH_LPN_TIMER);
-			k_delayed_work_submit(&lpn->timer, LPN_AUTO_TIMEOUT);
+			k_delayed_work_submit(&lpn->timer,
+					      K_MSEC(LPN_AUTO_TIMEOUT));
 		}
 	}
 

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -263,7 +263,8 @@ static void model_resume(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 		s32_t period_ms = bt_mesh_model_pub_period_get(mod);
 
 		if (period_ms) {
-			k_delayed_work_submit(&mod->pub->timer, period_ms);
+			k_delayed_work_submit(&mod->pub->timer,
+					      K_MSEC(period_ms));
 		}
 	}
 }

--- a/subsys/bluetooth/mesh/prov_bearer.h
+++ b/subsys/bluetooth/mesh/prov_bearer.h
@@ -93,7 +93,7 @@ struct prov_bearer {
 	 *
 	 *  @return Zero on success, or (negative) error code otherwise.
 	 */
-	int (*link_open)(const u8_t uuid[16], s32_t timeout,
+	int (*link_open)(const u8_t uuid[16], k_timeout_t timeout,
 			 const struct prov_bearer_cb *cb, void *cb_data);
 
 	/** @brief Close the current link.

--- a/subsys/bluetooth/mesh/proxy.h
+++ b/subsys/bluetooth/mesh/proxy.h
@@ -25,7 +25,7 @@ void bt_mesh_proxy_beacon_send(struct bt_mesh_subnet *sub);
 
 struct net_buf_simple *bt_mesh_proxy_get_buf(void);
 
-s32_t bt_mesh_proxy_adv_start(void);
+k_timeout_t bt_mesh_proxy_adv_start(void);
 void bt_mesh_proxy_adv_stop(void);
 
 void bt_mesh_proxy_identity_start(struct bt_mesh_subnet *sub);

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -1093,9 +1093,10 @@ static void commit_mod(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 	if (mod->pub && mod->pub->update &&
 	    mod->pub->addr != BT_MESH_ADDR_UNASSIGNED) {
 		s32_t ms = bt_mesh_model_pub_period_get(mod);
-		if (ms) {
+
+		if (ms > 0) {
 			BT_DBG("Starting publish timer (period %u ms)", ms);
-			k_delayed_work_submit(&mod->pub->timer, ms);
+			k_delayed_work_submit(&mod->pub->timer, K_MSEC(ms));
 		}
 	}
 
@@ -1188,30 +1189,30 @@ SETTINGS_STATIC_HANDLER_DEFINE(bt_mesh, "bt/mesh", NULL, mesh_set, mesh_commit,
 
 static void schedule_store(int flag)
 {
-	s32_t timeout, remaining;
+	s32_t timeout_ms, remaining;
 
 	atomic_set_bit(bt_mesh.flags, flag);
 
 	if (atomic_get(bt_mesh.flags) & NO_WAIT_PENDING_BITS) {
-		timeout = K_NO_WAIT;
+		timeout_ms = 0;
 	} else if (atomic_test_bit(bt_mesh.flags, BT_MESH_RPL_PENDING) &&
 		   (!(atomic_get(bt_mesh.flags) & GENERIC_PENDING_BITS) ||
 		    (CONFIG_BT_MESH_RPL_STORE_TIMEOUT <
 		     CONFIG_BT_MESH_STORE_TIMEOUT))) {
-		timeout = K_SECONDS(CONFIG_BT_MESH_RPL_STORE_TIMEOUT);
+		timeout_ms = CONFIG_BT_MESH_RPL_STORE_TIMEOUT * MSEC_PER_SEC;
 	} else {
-		timeout = K_SECONDS(CONFIG_BT_MESH_STORE_TIMEOUT);
+		timeout_ms = CONFIG_BT_MESH_STORE_TIMEOUT * MSEC_PER_SEC;
 	}
 
 	remaining = k_delayed_work_remaining_get(&pending_store);
-	if (remaining && remaining < timeout) {
+	if ((remaining > 0) && remaining < timeout_ms) {
 		BT_DBG("Not rescheduling due to existing earlier deadline");
 		return;
 	}
 
-	BT_DBG("Waiting %d seconds", timeout / MSEC_PER_SEC);
+	BT_DBG("Waiting %d seconds", timeout_ms / MSEC_PER_SEC);
 
-	k_delayed_work_submit(&pending_store, timeout);
+	k_delayed_work_submit(&pending_store, K_MSEC(timeout_ms));
 }
 
 static void clear_iv(void)

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -1851,33 +1851,27 @@ static int cmd_provision(const struct shell *shell, size_t argc, char *argv[])
 
 int cmd_timeout(const struct shell *shell, size_t argc, char *argv[])
 {
-	s32_t timeout;
+	s32_t timeout_ms;
 
-	if (argc < 2) {
-		timeout = bt_mesh_cfg_cli_timeout_get();
-		if (timeout == K_FOREVER) {
-			shell_print(shell, "Message timeout: forever");
+	if (argc == 2) {
+		s32_t timeout_s;
+
+		timeout_s = strtol(argv[1], NULL, 0);
+		if (timeout_s < 0 || timeout_s > (INT32_MAX / 1000)) {
+			timeout_ms = SYS_FOREVER_MS;
 		} else {
-			shell_print(shell, "Message timeout: %u seconds",
-				    timeout / 1000);
+			timeout_ms = timeout_s * MSEC_PER_SEC;
 		}
 
-		return 0;
+		bt_mesh_cfg_cli_timeout_set(timeout_ms);
 	}
 
-	timeout = strtol(argv[1], NULL, 0);
-	if (timeout < 0 || timeout > (INT32_MAX / 1000)) {
-		timeout = K_FOREVER;
-	} else {
-		timeout = timeout * 1000;
-	}
-
-	bt_mesh_cfg_cli_timeout_set(timeout);
-	if (timeout == K_FOREVER) {
+	timeout_ms = bt_mesh_cfg_cli_timeout_get();
+	if (timeout_ms == SYS_FOREVER_MS) {
 		shell_print(shell, "Message timeout: forever");
 	} else {
 		shell_print(shell, "Message timeout: %u seconds",
-			    timeout / 1000);
+			    timeout_ms / 1000);
 	}
 
 	return 0;

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/common/edtt_driver_bsim.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/common/edtt_driver_bsim.c
@@ -22,12 +22,13 @@
 #include "bs_pc_base_fifo_user.h"
 
 /* Recheck if something arrived from the EDTT every 5ms */
-#define EDTT_IF_RECHECK_DELTA 5 /*ms*/
+#define EDTT_IF_RECHECK_DELTA 5 /* ms */
 
 /* We want the runs to be deterministic => we want to resync with the Phy
  * before we retry any read so the bridge device may also run
  */
-#define EDTT_SIMU_RESYNC_TIME_WITH_EDTT (EDTT_IF_RECHECK_DELTA*1e3-1)
+#define EDTT_SIMU_RESYNC_TIME_WITH_EDTT \
+	(EDTT_IF_RECHECK_DELTA * MSEC_PER_SEC - 1)
 
 int edtt_mode_enabled;
 
@@ -113,7 +114,7 @@ int edtt_read(u8_t *ptr, size_t size, int flags)
 				bs_trace_raw_time(9, "EDTT: No enough data yet,"
 						"sleeping for %i ms\n",
 						EDTT_IF_RECHECK_DELTA);
-				k_sleep(EDTT_IF_RECHECK_DELTA);
+				k_sleep(K_MSEC(EDTT_IF_RECHECK_DELTA));
 			} else {
 				bs_trace_raw_time(9, "EDTT: No enough data yet,"
 						"returning\n");


### PR DESCRIPTION
Convert bluetooth to using k_timeout struct. 
In many of the places it was practical to keep the s32_t type for the timeout since we need to use it to compare and do calculations with the value. 

I have used `tests/bluetooth/shell` and `tests/bluetooth/mesh_shell` to see that everything compiles.