### PR TITLE
driver: modem: ublox_sara_r4: fixed closing UDP socket

### DIFF
--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -973,7 +973,7 @@ static int offload_close(struct modem_socket *sock)
 		return 0;
 	}
 
-	if (sock->is_connected) {
+	if (sock->is_connected || sock->ip_proto == IPPROTO_UDP) {
 		snprintk(buf, sizeof(buf), "AT+USOCL=%d", sock->id);
 
 		ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler,


### PR DESCRIPTION
Following issue is addressed in this bugfix:

When using offloaded sockets with modem ublox_sara_r4,
the socket is only closed if it is in connected state
at the time of the function call. When using UDP sockets,
this leads to a socket never being closed.

Signed-off-by: Hans Wilmers <hans@wilmers.no>