### PR TITLE
RFC: cmake: add nrf_pin_report target

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -246,6 +246,18 @@ if(SUPPORTS_DTS)
   file(WRITE ${PROJECT_BINARY_DIR}/${BOARD}.dts_compiled
        "See zephyr.dts for the final merged devicetree.")
 
+  add_custom_target(
+    nrf_pin_report
+    DEPENDS
+    ${ZEPHYR_BASE}/scripts/dts/nrf_pin_report.py
+    COMMAND
+    ${PYTHON_EXECUTABLE}
+    ${ZEPHYR_BASE}/scripts/dts/nrf_pin_report.py
+    --dts ${ZEPHYR_DTS}
+    --bindings-dirs ${DTS_ROOT_BINDINGS}
+    USES_TERMINAL
+    )
+
 else()
   file(WRITE ${DEVICETREE_UNFIXED_H} "/* WARNING. THIS FILE IS AUTO-GENERATED. DO NOT MODIFY! */")
   file(WRITE ${DEVICETREE_UNFIXED_LEGACY_H} "/* WARNING. THIS FILE IS AUTO-GENERATED. DO NOT MODIFY! */")

--- a/scripts/dts/nrf_pin_report.py
+++ b/scripts/dts/nrf_pin_report.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+from collections import defaultdict, namedtuple
+from itertools import chain
+import sys
+
+import edtlib
+
+NRF_COMPATS_WITH_PINS = [
+    'nordic,nrf-i2s',
+    'nordic,nrf-pdm',
+    'nordic,nrf-pwm',
+    'nordic,nrf-qspi',
+    'nordic,nrf-spi',
+    'nordic,nrf-spim',
+    'nordic,nrf-spis',
+    'nordic,nrf-twi',
+    'nordic,nrf-twim',
+    'nordic,nrf-twis',
+    'nordic,nrf-uart',
+    'nordic,nrf-uarte',
+]
+
+COMPATS_WITH_GPIO_PHAS_IN_PROPS = {
+    'nordic,nrf-spi': ['cs-gpios'],
+    'nordic,nrf-spim': ['cs-gpios'],
+    'nordic,nrf-spis': ['cs-gpios'],
+}
+
+COMPATS_WITH_GPIO_PHAS_IN_SUBNODES = [
+    'gpio-keys',
+    'gpio-leds',
+]
+
+PinUser = namedtuple('PinUser', 'node prop')
+
+def main():
+    args = parse_args()
+    try:
+        edt = get_edt(args)
+    except edtlib.EDTError as e:
+        sys.exit(f"Can't load {args.dts}: {e}")
+
+    print_nrf_pin_mux(edt)
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dts', required=True, help='path to zephyr.dts')
+    parser.add_argument('--bindings-dirs', nargs='+', required=True,
+                        help='DTS bindings root')
+    parser.add_argument('-O', dest='outfile',
+                        help='output file, default is standard output')
+
+    return parser.parse_args()
+
+def get_edt(args):
+    # Load EDT object.
+
+    return edtlib.EDT(args.dts, args.bindings_dirs,
+                      warn_reg_unit_address_mismatch=False)
+
+def print_nrf_pin_mux(edt):
+    # Print a summary of pin allocations from a devicetree. This might
+    # miss some users, but any user it does print should be accurate.
+
+    def pprint_node(pin_user):
+        node = pin_user.node
+        if len(node.labels) >= 1:
+            return f'{node.labels[0]} ({node.path})'
+        else:
+            return node.path
+
+    pin_map = get_pin_map(edt)
+
+    all_users = list(chain(*pin_map.values()))
+    if not all_users:
+        print('No pins used.')
+        return
+
+    # user -> pretty-print strings for that user's node and path
+    user_pprint = {user: (pprint_node(user), user.prop.name)
+                   for user in all_users}
+
+    port_pin_width = len('P0.00')
+    node_width = max(len(up[0]) for up in user_pprint.values())
+    prop_width = max(len(up[1]) for up in user_pprint.values())
+    if len('Property') > prop_width:
+        prop_width = len('Property')
+
+    def span_string(character):
+        return (character * port_pin_width + ' ' +
+                character * node_width + ' ' +
+                character * prop_width)
+
+    table_head_foot = span_string('=')
+    pin_used_twice = span_string('-')
+
+    print(table_head_foot)
+    print(' '.join(['Pin'.ljust(port_pin_width),
+                    'User'.ljust(node_width),
+                    'Property'.ljust(prop_width)]))
+    print(table_head_foot)
+    for port_pin, users in sorted(pin_map.items(), key=sort_key):
+        if len(users) > 1:
+            print(pin_used_twice)
+
+        port, pin = port_pin
+        print(f'P{port}.{pin:02} ', end='')
+        for i, user in enumerate(users):
+            if i > 0:
+                print(' ' * (port_pin_width + 1), end='')
+            node, prop = user_pprint[user]
+            print(f'{node.ljust(node_width)} {prop.ljust(prop_width)}')
+
+        if len(users) > 1:
+            print(pin_used_twice)
+    print(table_head_foot)
+
+def sort_key(port_pin_user):
+    return port_pin_user[0]
+
+def get_pin_map(edt):
+    # Find nodes in the devicetree that are using SoC pins.
+    # Returns a map: (port, pin) -> [potential users]
+
+    pin_map = defaultdict(list)
+
+    for node in edt.nodes:
+        if node.matching_compat in NRF_COMPATS_WITH_PINS:
+            add_nrf_pins(edt, node, pin_map)
+        if node.matching_compat in COMPATS_WITH_GPIO_PHAS_IN_PROPS:
+            add_gpio_phas_in_props(edt, node, pin_map)
+        if node.matching_compat in COMPATS_WITH_GPIO_PHAS_IN_SUBNODES:
+            add_gpio_phas_in_children(edt, node, pin_map)
+
+    return pin_map
+
+def add_nrf_pins(edt, node, pin_map):
+    # Handle a nordic IP block node in the devicetree, adding any pins
+    # it claims to pin_map. This is based on common patterns in
+    # nordic,nrf-xyz bindings.
+
+    if not node.enabled:
+        return
+
+    for name, prop in node.props.items():
+        if '-pin' not in name or prop.type != 'int':
+            continue
+        port_pin = pin_to_port_bit(prop.val)
+        pin_map[port_pin].append(PinUser(node, prop))
+
+def add_gpio_phas_in_props(edt, node, pin_map):
+    # Handle a node which contains a GPIO phandle-array in the
+    # devicetree, adding any pins it claims to pin_map. This uses some
+    # heuristics based on node labels.
+
+    for prop_name in COMPATS_WITH_GPIO_PHAS_IN_PROPS[node.matching_compat]:
+        if prop_name not in node.props:
+            continue
+        prop = node.props[prop_name]
+        if 'gpio' not in prop_name or prop.type != 'phandle-array':
+            continue
+        for entry in prop.val:
+            controller = entry.controller
+            if controller.matching_compat != 'nordic,nrf-gpio':
+                continue
+            port_pin = pha_entry_to_port_bit(entry)
+            pin_map[port_pin].append(PinUser(node, prop))
+
+def add_gpio_phas_in_children(edt, node, pin_map):
+    # Handle a node which contains a GPIO phandle-array in the
+    # devicetree, adding any pins it claims to pin_map. This uses some
+    # heuristics based on node labels.
+
+    for child in node.children.values():
+        for prop_name, prop in child.props.items():
+            if 'gpio' not in prop_name or prop.type != 'phandle-array':
+                continue
+            for entry in prop.val:
+                controller = entry.controller
+                if controller.matching_compat != 'nordic,nrf-gpio':
+                    continue
+                port_pin = pha_entry_to_port_bit(entry)
+                pin_map[port_pin].append(PinUser(child, prop))
+
+def pin_to_port_bit(pin):
+    # Converts a plain 'pin' number to a (port, pin) tuple.
+
+    return (pin >> 5, pin & 0x1F)
+
+def pha_entry_to_port_bit(entry):
+    # Converts a phandle-array entry to a (port, pin) tuple.
+
+    ctlr = entry.controller
+
+    if 'gpio0' in ctlr.labels:
+        port = 0
+    elif 'gpio1' in ctlr.labels:
+        port = 1
+    else:
+        port = None
+
+    for cell, val in entry.data.items():
+        if cell == 'pin':
+            pin = val
+            break
+    else:
+        pin = None
+
+    return (port if port is not None else '<ERROR>',
+            pin if pin is not None else '<ERROR>')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This target prints the devicetree's pin map to standard out. It only works for Nordic SoCs.

This is just an RFC for now because I'm playing dirty tricks, but it's working so far:

```
$ west build -b nrf52840dk_nrf52840 -s samples/sensor/bme280/ -t nrf_pin_report
[snip]
-- west build: running target nrf_pin_report
[snip]
===== =========================== ========
Pin   User                        Property
===== =========================== ========
P0.05 uart0 (/soc/uart@40002000)  rts-pin 
P0.06 uart0 (/soc/uart@40002000)  tx-pin  
P0.07 uart0 (/soc/uart@40002000)  cts-pin 
P0.08 uart0 (/soc/uart@40002000)  rx-pin  
P0.11 button0 (/buttons/button_0) gpios   
P0.12 button1 (/buttons/button_1) gpios   
----- --------------------------- --------
P0.13 pwm0 (/soc/pwm@4001c000)    ch0-pin 
      led0 (/leds/led_0)          gpios   
----- --------------------------- --------
P0.14 led1 (/leds/led_1)          gpios   
P0.15 led2 (/leds/led_2)          gpios   
P0.16 led3 (/leds/led_3)          gpios   
P0.19 qspi (/soc/qspi@40029000)   sck-pin 
P0.24 button2 (/buttons/button_2) gpios   
P0.25 button3 (/buttons/button_3) gpios   
P0.26 i2c0 (/soc/i2c@40003000)    sda-pin 
P0.27 i2c0 (/soc/i2c@40003000)    scl-pin 
P0.30 spi1 (/soc/spi@40004000)    mosi-pin
P0.31 spi1 (/soc/spi@40004000)    sck-pin 
P1.01 uart1 (/soc/uart@40028000)  rx-pin  
P1.02 uart1 (/soc/uart@40028000)  tx-pin  
P1.08 spi1 (/soc/spi@40004000)    miso-pin
P1.12 spi3 (/soc/spi@4002f000)    cs-gpios
P1.13 spi3 (/soc/spi@4002f000)    mosi-pin
P1.14 spi3 (/soc/spi@4002f000)    miso-pin
P1.15 spi3 (/soc/spi@4002f000)    sck-pin 
===== =========================== ========
```

I hate hunting for pins, and I hate having to grep zephyr.dts to look for conflicts, so this is useful enough for me to maintain out of tree for myself. But I thought I'd share in case we can find a way to mainline this if it's interesting to others.