### PR TITLE
devicetree: re-work DT_INST_FOREACH()

### DIFF
--- a/doc/guides/dts/macros.bnf
+++ b/doc/guides/dts/macros.bnf
@@ -125,6 +125,10 @@ prop-suf = 1*( "_" gen-name ["_" dt-name] )
 other-macro =  %s"DT_N_" alternate-id
 ; Total count of enabled instances of a compatible.
 other-macro =/ %s"DT_N_INST_" dt-name %s"_NUM"
+; These are used internally by DT_INST_FOREACH, which iterates over
+; each enabled instance of a compatible.
+other-macro =/ %s"DT_FOREACH_INST_" dt-name
+other-macro =/ %s"DT_FOREACH_IMPL_" DIGIT
 ; E.g.: #define DT_CHOSEN_zephyr_flash
 other-macro =/ %s"DT_CHOSEN_" dt-name
 ; Declares that a compatible has at least one node on a bus.

--- a/drivers/adc/adc_mcp320x.c
+++ b/drivers/adc/adc_mcp320x.c
@@ -363,8 +363,10 @@ static const struct adc_driver_api mcp320x_adc_api = {
  */
 #define MCP3208_DEVICE(n) MCP320X_DEVICE(3208, n, 8)
 
+#define CALL_WITH_ARG(arg, expr) expr(arg);
+
 #define DT_INST_MCP320X_FOREACH(t, inst_expr) \
-	UTIL_LISTIFY(DT_NUM_INST(microchip_mcp##t), DT_CALL_WITH_ARG, inst_expr)
+	UTIL_LISTIFY(DT_NUM_INST(microchip_mcp##t), CALL_WITH_ARG, inst_expr)
 
 DT_INST_MCP320X_FOREACH(3204, MCP3204_DEVICE);
 DT_INST_MCP320X_FOREACH(3208, MCP3208_DEVICE);

--- a/drivers/eeprom/eeprom_at2x.c
+++ b/drivers/eeprom/eeprom_at2x.c
@@ -599,8 +599,10 @@ static const struct eeprom_driver_api eeprom_at2x_api = {
 #define EEPROM_AT24_DEVICE(n) EEPROM_AT2X_DEVICE(n, 24)
 #define EEPROM_AT25_DEVICE(n) EEPROM_AT2X_DEVICE(n, 25)
 
+#define CALL_WITH_ARG(arg, expr) expr(arg);
+
 #define DT_INST_AT2X_FOREACH(t, inst_expr) \
-	UTIL_LISTIFY(DT_NUM_INST(atmel_at##t), DT_CALL_WITH_ARG, inst_expr)
+	UTIL_LISTIFY(DT_NUM_INST(atmel_at##t), CALL_WITH_ARG, inst_expr)
 
 #ifdef CONFIG_EEPROM_AT24
 DT_INST_AT2X_FOREACH(24, EEPROM_AT24_DEVICE);

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -1389,7 +1389,8 @@
  * Has to accept instance_number as only parameter.
  */
 #define DT_INST_FOREACH(inst_expr) \
-	UTIL_LISTIFY(DT_NUM_INST(DT_DRV_COMPAT), DT_CALL_WITH_ARG, inst_expr)
+	COND_CODE_1(DT_HAS_COMPAT(DT_DRV_COMPAT), \
+		    (UTIL_CAT(DT_FOREACH_INST_, DT_DRV_COMPAT)(inst_expr)), ())
 
 /**
  * @brief Does a DT_DRV_COMPAT instance have a property?
@@ -1489,7 +1490,5 @@
 #define DT_DASH(...) MACRO_MAP_CAT(DT_DASH_PREFIX, __VA_ARGS__)
 /** @internal helper for DT_DASH(): prepends _ to a name */
 #define DT_DASH_PREFIX(name) _##name
-/** @internal DT_INST_FOREACH helper */
-#define DT_CALL_WITH_ARG(arg, expr) expr(arg);
 
 #endif /* DEVICETREE_H */

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -525,9 +525,24 @@ def write_global_compat_info(edt):
             if bus is not None and bus not in compat2buses[compat]:
                 compat2buses[compat].append(bus)
 
-    out_comment("Number of enabled instances of each compatible\n")
+    out_comment("Helpers for calling a macro/function a fixed number of times"
+                "\n")
+    for numinsts in range(1, max(compat2numinst.values(), default=0) + 1):
+        out_define(f"DT_FOREACH_IMPL_{numinsts}(fn)",
+                   " ".join([f"fn({i});" for i in range(numinsts)]))
+
+    out_comment("Macros for enabled instances of each compatible\n")
+    n_inst_macros = {}
+    for_each_macros = {}
     for compat, numinst in compat2numinst.items():
-        out_define(f"DT_N_INST_{str2ident(compat)}_NUM", numinst)
+        ident = str2ident(compat)
+        n_inst_macros[f"DT_N_INST_{ident}_NUM"] = numinst
+        for_each_macros[f"DT_FOREACH_INST_{ident}(fn)"] = \
+            f"DT_FOREACH_IMPL_{numinst}(fn)"
+    for macro, value in n_inst_macros.items():
+        out_define(macro, value)
+    for macro, value in for_each_macros.items():
+        out_define(macro, value)
 
     out_comment("Bus information for enabled nodes of each compatible\n")
     for compat, buses in compat2buses.items():


### PR DESCRIPTION
Due to the use of UTIL_EVAL*() macros, the UTIL_LISTIFY() macro used
by DT_INST_FOREACH(foo) can cause long build errors when there is a
build error in the expansion for "foo". More than a thousand lines of
build error output have been observed for an error in a single line of
faulty C.

To improve the situation, re-work the implementation details so the
errors are a bit shorter and easier to read. The use of COND_CODE_1
still makes the error messages quite long, due to GCC generating notes
for various intermediate expansions (__DEBRACKET,
__GET_ARG_2_DEBRACKET, __COND_CODE, Z_COND_CODE_1, COND_CODE1), but
it's better than the long list of UTIL_EVAL notes.
