### PR TITLE
Shell: Add shell_set_root_cmd function

### DIFF
--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -147,6 +147,13 @@
 		__log_backends_end = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
+	SECTION_DATA_PROLOGUE(shell_sections,,)
+	{
+		_shell_list_start = .;
+		KEEP(*(SORT(._shell.static.*)));
+		_shell_list_end = .;
+	} GROUP_LINK_IN(ROMABLE_REGION)
+
 	SECTION_DATA_PROLOGUE(shell_root_cmds_sections,,)
 	{
 		__shell_root_cmds_start = .;

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -837,6 +837,19 @@ void shell_help(const struct shell *shell);
  */
 int shell_execute_cmd(const struct shell *shell, const char *cmd);
 
+/** @brief Set root command for all shell instances.
+ *
+ * It allows setting from the code the root command. It is an equivalent of
+ * calling select command with one of the root commands as the argument
+ * (e.g "select log") except it sets command for all shell instances.
+ *
+ * @param cmd String with one of the root commands or null pointer to reset.
+ *
+ * @retval 0 if root command is set.
+ * @retval -EINVAL if invalid root command is provided.
+ */
+int shell_set_root_cmd(const char *cmd);
+
 /**
  * @}
  */

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -629,7 +629,7 @@ extern void shell_print_stream(const void *user_ctx, const char *data,
 	SHELL_STATS_DEFINE(_name);					      \
 	static K_THREAD_STACK_DEFINE(_name##_stack, CONFIG_SHELL_STACK_SIZE); \
 	static struct k_thread _name##_thread;				      \
-	static const struct shell _name = {				      \
+	static const Z_STRUCT_SECTION_ITERABLE(shell, _name) = {	      \
 		.default_prompt = _prompt,				      \
 		.iface = _transport_iface,				      \
 		.ctx = &UTIL_CAT(_name, _ctx),				      \

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -638,8 +638,7 @@ static int execute(const struct shell *shell)
 						       SHELL_MSG_CMD_NOT_FOUND);
 				return -ENOEXEC;
 			}
-			if (IS_ENABLED(CONFIG_SHELL_CMDS_SELECT) &&
-			    shell_in_select_mode(shell)		 &&
+			if (shell_in_select_mode(shell)		 &&
 			    shell->ctx->selected_cmd->handler != NULL) {
 				p_static_entry = shell->ctx->selected_cmd;
 				shell->ctx->active_cmd = *p_static_entry;

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -252,8 +252,7 @@ void shell_cmd_get(const struct shell *shell,
 	*entry = NULL;
 
 	if (lvl == SHELL_CMD_ROOT_LVL) {
-		if (shell_in_select_mode(shell)	&&
-		    IS_ENABLED(CONFIG_SHELL_CMDS_SELECT)) {
+		if (shell_in_select_mode(shell)) {
 			const struct shell_static_entry *ptr =
 						       shell->ctx->selected_cmd;
 			if (ptr->subcmd->u.entry[idx].syntax != NULL) {
@@ -360,6 +359,23 @@ const struct shell_static_entry *shell_get_last_command(
 	}
 
 	return entry;
+}
+
+int shell_set_root_cmd(const char *cmd)
+{
+	const struct shell_static_entry *entry;
+
+	entry = cmd ? shell_root_cmd_find(cmd) : NULL;
+
+	if (cmd && (entry == NULL)) {
+		return -EINVAL;
+	}
+
+	Z_STRUCT_SECTION_FOREACH(shell, sh) {
+		sh->ctx->selected_cmd = entry;
+	}
+
+	return 0;
 }
 
 int shell_command_add(char *buff, u16_t *buff_len,

--- a/tests/shell/src/main.c
+++ b/tests/shell/src/main.c
@@ -295,6 +295,27 @@ static void test_cmd_select(void)
 	test_shell_execute_cmd("on", -ENOEXEC);
 }
 
+static void test_set_root_cmd(void)
+{
+	int err;
+
+	test_shell_execute_cmd("shell colors on", 0);
+	err = shell_set_root_cmd("__shell__");
+	zassert_equal(err, -EINVAL, "Unexpected error %d", err);
+
+	err = shell_set_root_cmd("shell");
+	zassert_equal(err, 0, "Unexpected error %d", err);
+
+	test_shell_execute_cmd("shell colors", -ENOEXEC);
+	test_shell_execute_cmd("colors on", 0);
+
+	err = shell_set_root_cmd(NULL);
+	zassert_equal(err, 0, "Unexpected error %d", err);
+
+	test_shell_execute_cmd("colors", -ENOEXEC);
+	test_shell_execute_cmd("shell colors on", 0);
+}
+
 void test_main(void)
 {
 	ztest_test_suite(shell_test_suite,
@@ -303,6 +324,7 @@ void test_main(void)
 			ztest_unit_test(test_cmd_shell),
 			ztest_unit_test(test_cmd_history),
 			ztest_unit_test(test_cmd_select),
+			ztest_unit_test(test_set_root_cmd),
 			ztest_unit_test(test_cmd_resize),
 			ztest_unit_test(test_shell_module),
 			ztest_unit_test(test_shell_wildcards_static),


### PR DESCRIPTION
New function allows to set from the code the root command. It is an equivalent of calling 'select <rootcmd>' except it sets command for all shell instances.

Additionally, dedicated section with shell instances was added to allow iterating over all shell instances.