### PR TITLE
modules: hal_nordic: Remove dependency on CONFIG_ENTROPY_NAME 

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -53,7 +53,7 @@ manifest:
       revision: a12d92816a53a521d79cefcf5c38b9dc8a4fed6e
       path: modules/hal/cypress
     - name: hal_nordic
-      revision: 0774efffa3d095025a55611719020fa23278eeda
+      revision: 5505d0baa66a89848f643120fafad232876df695
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 3b54187649cc9b37161d49918f1ad28ff7c7f830


### PR DESCRIPTION
Update the hal_nordic module revision so that the nrf_radio_802154
does not use the CONFIG_ENTROPY_NAME symbol which is no longer used
in the Zephyr tree.

See https://github.com/zephyrproject-rtos/hal_nordic/pull/32.