### PR TITLE
Bluetooth: host: Improve HCI command send error handling

### DIFF
--- a/subsys/bluetooth/common/log.h
+++ b/subsys/bluetooth/common/log.h
@@ -44,8 +44,10 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
 
 #if defined(CONFIG_BT_ASSERT_VERBOSE)
 #define BT_ASSERT_PRINT(test) __ASSERT_LOC(test)
+#define BT_ASSERT_PRINT_MSG(fmt, ...) __ASSERT_MSG_INFO(fmt, ##__VA_ARGS__)
 #else
 #define BT_ASSERT_PRINT(test)
+#define BT_ASSERT_PRINT_MSG(fmt, ...)
 #endif /* CONFIG_BT_ASSERT_VERBOSE */
 
 #if defined(CONFIG_BT_ASSERT_PANIC)
@@ -62,8 +64,18 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
 			BT_ASSERT_DIE();         \
 		}                                \
 	} while (0)
+
+#define BT_ASSERT_MSG(cond, fmt, ...)                              \
+	do {                                                       \
+		if (!(cond)) {                                     \
+			BT_ASSERT_PRINT(cond);                     \
+			BT_ASSERT_PRINT_MSG(fmt, ##__VA_ARGS__);   \
+			BT_ASSERT_DIE();                           \
+		}                                                  \
+	} while (0)
 #else
 #define BT_ASSERT(cond) __ASSERT_NO_MSG(cond)
+#define BT_ASSERT_MSG(cond, msg, ...) __ASSERT(cond, msg, ##__VA_ARGS__)
 #endif/* CONFIG_BT_ASSERT*/
 
 #define BT_HEXDUMP_DBG(_data, _length, _str) \


### PR DESCRIPTION
Handle HCI command send sync timeout by reporting the error back to the
application and logging a warning.
Log command status failure with information in order to make it more
visible as the HCI status code is more interesting than the -EIO error
code returned by the function.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>