### PR TITLE
drivers: modem: ublox_sara_r4: fixed rssi for Sara U201

### DIFF
--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -391,7 +391,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_rssi_csq)
 {
 	int rssi;
 
-	rssi = ATOI(argv[1], 0, "qual");
+	rssi = ATOI(argv[0], 0, "signal_power");
 	if (rssi == 31) {
 		mctx.data_rssi = -46;
 	} else if (rssi >= 0 && rssi <= 31) {
@@ -401,7 +401,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_rssi_csq)
 		mctx.data_rssi = -1000;
 	}
 
-	LOG_INF("QUAL: %d", mctx.data_rssi);
+	LOG_INF("RSSI: %d", mctx.data_rssi);
 	return 0;
 }
 #endif


### PR DESCRIPTION
Calculation of RSSI was done incorrectly for Sara U201.

When evaluating +CSQ command responses, the RSSI can be calculated
from the first value, which is "signal_power". Instead, the RSSI was calculated
from the second value, which is "qual".
With the subsequent mapping to RSSI, this results in a wrong value for RSSI.

This is now corrected by using value "signal_power" to calculate the RSSI.

Tested using Sara U201.

Signed-off-by: Hans Wilmers <hans@wilmers.no>