### PR TITLE
Bluetooth: controller: specify entropy device explicitly

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -128,7 +128,8 @@ int lll_init(void)
 	int err;
 
 	/* Get reference to entropy device */
-	dev_entropy = device_get_binding(CONFIG_ENTROPY_NAME);
+	dev_entropy =
+		device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_rng)));
 	if (!dev_entropy) {
 		return -ENODEV;
 	}

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
@@ -115,7 +115,8 @@ int lll_init(void)
 	ARG_UNUSED(clk_k32);
 
 	/* Get reference to entropy device */
-	dev_entropy = device_get_binding(CONFIG_ENTROPY_NAME);
+	dev_entropy =
+		device_get_binding(DT_LABEL(DT_INST(0, openisa_rv32m1_trng)));
 	if (!dev_entropy) {
 		dev_entropy = NULL;
 		/* return -ENODEV; */


### PR DESCRIPTION
For the ll code we know the exact entropy device as its the one for the
SoC that we are on.  So use the new DT macro's to get the entropy device
via DT_INST rather than using CONFIG_ENTROPY_NAME.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>