### PR TITLE
MAINTAINERS: initial version of MAINTAINERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,7 +18,7 @@
 /.github/workflows/                       @galak @nashif
 /.buildkite/				  @galak
 /MAINTAINERS.yml                          @ioannisg @MaureenHelm
-/arch/arc/                                @vonhust @ruuddw
+/arch/arc/                                @abrodkin @ruuddw
 /arch/arm/                                @MaureenHelm @galak @ioannisg
 /arch/arm/core/aarch32/cortex_m/cmse/     @ioannisg
 /arch/arm/core/aarch64/                   @carlocaione
@@ -26,7 +26,7 @@
 /arch/arm/include/aarch64/                @carlocaione
 /arch/arm/core/aarch32/cortex_a_r/        @MaureenHelm @galak @ioannisg @bbolen @stephanosio
 /arch/common/                             @andrewboie @ioannisg @andyross
-/soc/arc/snps_*/                          @vonhust @ruuddw
+/soc/arc/snps_*/                          @abrodkin @ruuddw
 /soc/nios2/                               @nashif @wentongwu
 /soc/arm/                                 @MaureenHelm @galak @ioannisg
 /soc/arm/arm/mps2/                        @fvincenzo
@@ -59,7 +59,7 @@
 /soc/x86/                                 @andrewboie
 /arch/xtensa/                             @andrewboie @dcpleung @andyross
 /soc/xtensa/                              @andrewboie @dcpleung @andyross
-/boards/arc/                              @vonhust @ruuddw
+/boards/arc/                              @abrodkin @ruuddw
 /boards/arm/                              @MaureenHelm @galak
 /boards/arm/96b_argonkey/                 @avisconti
 /boards/arm/96b_avenger96/                @Mani-Sadhasivam
@@ -252,7 +252,7 @@
 /drivers/watchdog/wdt_handlers.c          @andrewboie
 /drivers/wifi/                            @jukkar @tbursztyka @pfalcon
 /drivers/wifi/eswifi/                     @loicpoulain
-/dts/arc/                                 @vonhust @ruuddw @iriszzw
+/dts/arc/                                 @abrodkin @ruuddw @iriszzw
 /dts/arm/atmel/sam4e*                     @nandojve
 /dts/arm/atmel/samr21.dtsi                @benpicco
 /dts/arm/atmel/sam*5*.dtsi                @benpicco
@@ -320,7 +320,7 @@
 /include/drivers/lora.h                   @Mani-Sadhasivam
 /include/drivers/peci.h                   @albertofloyd @franciscomunoz @scottwcpg
 /include/app_memory/                      @andrewboie
-/include/arch/arc/                        @vonhust @ruuddw
+/include/arch/arc/                        @abrodkin @ruuddw
 /include/arch/arc/arch.h                  @andrewboie
 /include/arch/arc/v2/irq.h                @andrewboie
 /include/arch/arm/aarch32/                @MaureenHelm @galak @ioannisg

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,6 +17,7 @@
 /.github/				  @nashif
 /.github/workflows/                       @galak @nashif
 /.buildkite/				  @galak
+/MAINTAINERS.yml                          @ioannisg @MaureenHelm
 /arch/arc/                                @vonhust @ruuddw
 /arch/arm/                                @MaureenHelm @galak @ioannisg
 /arch/arm/core/aarch32/cortex_m/cmse/     @ioannisg
@@ -413,6 +414,7 @@
 /scripts/kconfig/                         @ulfalizer
 /scripts/sanity_chk/expr_parser.py        @nashif
 /scripts/gen_app_partitions.py            @andrewboie
+/scripts/get_maintainer.py                @nashif
 /scripts/dts/                             @ulfalizer @galak
 /scripts/release/                         @nashif
 /scripts/ci/                              @nashif

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1,0 +1,1198 @@
+# This file contains information on who maintains what. It is parsed by
+# get_maintainer.py.
+#
+# File format
+# ###########
+#
+# "Area title" (the quotes are only needed for titles with special characters,
+#  like colons):
+#     status:
+#         One of the following:
+#
+#         * maintained:
+#             The area has a Maintainer (approved by the TSC) who
+#             looks after the area.
+#
+#         * orphaned:
+#             No current maintainer (but maybe you could take the role as you
+#             write your new code).
+#
+#         * obsolete:
+#             Old code. Something being marked obsolete generally means it has
+#             been replaced by something better that you should be using
+#             instead.
+#
+#     maintainers:
+#         List of GitHub handles for the people who maintain the area. Usually,
+#         there's only one maintainer.
+#
+#     collaborators (not to be confused with the GitHub collaborator role):
+#         Very involved contributors, who know the area well and contribute
+#         significantly to it.
+#
+#     labels:
+#         List of GitHub labels to add to pull requests that modify the area.
+#
+#     files:
+#         List of paths and/or glob patterns giving the files in the area,
+#         relative to the root directory.
+#
+#         If a path or glob pattern ends in a '/', it matches all files within
+#         the given directory or directories. Otherwise, an exact match is
+#         required.
+#
+#         Paths to directories should always have a trailing '/'.
+#
+#     files-regex:
+#         List of regular expressions applied to paths to determine if they
+#         belong to the area. The regular expression may match anywhere within
+#         the path, but can be anchored with ^ and $ as usual.
+#
+#         Can be combined with a 'files' key.
+#
+#         Note: Prefer plain 'files' patterns where possible. get_maintainer.py
+#         will check that they match some file, but won't check regexes
+#         (because it might be slow).
+#
+#     files-exclude:
+#         Like 'files', but any matching files will be excluded from the area.
+#
+#     files-regex-exclude:
+#         Like 'files-regex', but any matching files will be excluded from the
+#         area.
+#
+#     description: >-
+#         Plain-English description. Describe what the system is about, from an
+#         outsider's perspective.
+#
+#
+# All areas must have a 'files' and/or 'files-regex' key. The other keys are
+# optional.
+#
+# It is very advisable to have a `status` key in all entries. Exceptions to
+# this would be sub-areas which add extra fields (for ex. more `collaborators`
+# who work only in that sub-area) to other areas.
+#
+#
+# Workflow
+# ########
+#
+# Ideally, any file in the tree will be covered by some area.
+#
+# When a GitHub pull request is sent, this happens:
+#
+#     * A user mentioned in 'maintainers' is added as Assignee to
+#       the pull request
+#
+#     * Users mentioned in 'maintainers' and 'collaborators' are added as
+#       reviewers to the pull request
+#
+#     * The labels listed in 'labels' are automatically added to the pull
+#       request
+#
+#     * The bot posts this comment:
+#
+#         This PR affects the following areas:
+#         <area name>:
+#           Status: ...
+#           Maintainers: <list of maintainers>
+#           Collaborators: <list of sub-maintainers>
+#
+#         <area name>:
+#           ...
+#
+#
+# Changes to MAINTAINERS.yml need to be approved as follows:
+#
+#     * Changing the 'maintainers' for an area needs approval from the
+#       Technical Steering Committee
+#
+#     * Changing the 'collaborators' lines requires the maintainer and
+#       collaborators of that area to agree (or vote on it)
+
+# Areas are sorted by name
+
+ARC arch:
+    status: maintained
+    maintainers:
+        - ruuddw
+    collaborators:
+        - abrodkin
+        - evgeniy-paltsev
+        - IRISZZW
+    files:
+        - arch/arc/
+        - include/arch/arc/
+    labels:
+        - "area: ARC"
+
+ARM arch:
+    status: maintained
+    maintainers:
+        - ioannisg
+    collaborators:
+        - carlocaione
+        - galak
+        - MaureenHelm
+        - stephanosio
+    files:
+        - arch/arm/
+        - include/arch/arm/
+        - tests/arch/arm/
+    labels:
+        - "area: ARM"
+
+Bluetooth:
+    status: maintained
+    maintainers:
+        - jhedberg
+    collaborators:
+        - joerchan
+        - Vudentz
+    files:
+        - doc/reference/bluetooth/
+        - doc/guides/bluetooth/
+        - drivers/bluetooth/
+        - include/bluetooth/
+        - include/drivers/bluetooth/
+        - samples/bluetooth/
+        - subsys/bluetooth/
+        - tests/bluetooth/
+    labels:
+        - "area: Bluetooth"
+
+Bluetooth controller:
+    status: maintained
+    maintainers:
+        - cvinayak
+    collaborators:
+        - carlescufi
+        - thoh-ot
+    files:
+        - subsys/bluetooth/controller/
+
+Bluetooth Mesh:
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+            - trond-snekvik
+    collaborators:
+        - jhedberg
+    files:
+        - subsys/bluetooth/mesh/
+        - include/bluetooth/mesh/
+    labels:
+        - "area: Bluetooth Mesh"
+
+Build system:
+    status: maintained
+    maintainers:
+        - tejlmand
+    collaborators:
+        - nashif
+    files:
+        - cmake/
+    files-regex:
+        - CMakeLists.txt$
+        - \.cmake$
+    labels:
+        - "area: Build System"
+
+C library:
+    status: orphaned
+    collaborators:
+         - nashif
+         - andrewboie
+    files:
+         - lib/libc/
+         - tests/lib/c_lib/
+    labels:
+         - "area: C Library"
+
+CMSIS API layer:
+    status: orphaned
+    collaborators:
+         - nashif
+    files:
+         - lib/cmsis_rtos_v*/
+
+Common arch:
+    status: maintained
+    maintainers:
+        - andrewboie
+    files:
+        - arch/common/
+        - include/arch/common/
+    labels:
+        - "area: Architectures"
+
+Console:
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - pfalcon
+    files:
+        - include/console/
+        - subsys/console/
+    labels:
+        - "area: Console"
+
+Debug:
+    status: maintained
+    maintainers:
+        - nashif
+    files:
+        - include/debug/
+        - subsys/debug/
+    labels:
+        - "area: Debugging"
+
+DFU:
+    status: maintained
+    maintainers:
+        - nvlsianpu
+    files:
+        - include/dfu/
+        - subsys/dfu/
+        - tests/subsys/dfu/
+
+Devicetree:
+    status: maintained
+    maintainers:
+        - galak
+    collaborators:
+        - mbolivar-nordic
+    files:
+        - scripts/dts/
+        - dts/bindings/
+        - dts/common/
+    labels:
+        - "area: Device Tree"
+
+Disk:
+    status: orphaned
+    files:
+        - subsys/disk/
+        - include/disk/
+    labels:
+        - "area: Disk Access"
+
+Display drivers:
+    status: maintained
+    maintainers:
+        - vanwinkeljan
+    collaborators:
+        - jfischer-phytec-iot
+    files:
+        - drivers/display/
+        - dts/bindings/display/
+        - include/drivers/display.h
+        - include/display/
+        - include/drivers/display.h
+        - lib/gui/
+        - subsys/fb/
+    labels:
+        - "area: Display"
+
+Documentation:
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - carlescufi
+    collaborators:
+        - nashif
+    files:
+        - doc/
+    files-regex:
+        - \.rst$
+        - /doc/
+    labels:
+        - "area: Documentation"
+
+"Drivers: ADC":
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - anangl
+    files:
+        - drivers/adc/
+        - include/drivers/adc.h
+        - tests/drivers/adc/
+    labels:
+        - "area: ADC"
+
+"Drivers: Audio":
+    status: maintained
+    maintainers:
+        - Vudentz
+    files:
+        - drivers/audio/
+        - include/audio/
+
+"Drivers: CAN":
+    status: maintained
+    maintainers:
+        - alexanderwachter
+    collaborators:
+        - henrikbrixandersen
+        - karstenkoenig
+    files:
+        - drivers/can/
+        - dts/bindings/can/
+        - include/drivers/can.h
+        - samples/drivers/CAN/
+        - tests/drivers/can/
+    labels:
+        - "area: CAN"
+
+"Drivers: Clock control":
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+       - nordic-krch
+    files:
+        - drivers/clock_control/
+        - dts/bindings/clock/
+        - include/drivers/clock_control.h
+        - include/dt-bindings/clock/
+        - tests/drivers/clock_control/
+    labels:
+        - "area: Clock control"
+
+"Drivers: Console":
+    status: orphaned
+    collaborators:
+        - pfalcon
+    files:
+        - drivers/console/
+        - include/drivers/console/
+        - tests/drivers/console/
+    labels:
+        - "area: Console"
+
+"Drivers: Counter":
+    status: maintained
+    maintainers:
+        - nordic-krch
+    files:
+        - drivers/counter/
+        - include/drivers/counter.h
+        - tests/drivers/counter/
+    labels:
+        - "area: Counter"
+
+"Drivers: Crypto":
+    status: orphaned
+    files:
+        - drivers/crypto/
+        - dts/bindings/crypto/
+        - include/crypto/
+        - samples/drivers/crypto/
+    labels:
+        - "area: Crypto / RNG"
+
+"Drivers: DAC":
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - martinjaeger
+    files:
+        - drivers/dac/
+        - include/drivers/dac.h
+        - tests/drivers/dac/
+    labels:
+        - "area: DAC"
+
+"Drivers: DMA":
+    status: orphaned
+    files:
+        - drivers/dma/
+        - include/dt-bindings/dma/
+        - tests/drivers/dma/
+    labels:
+        - "area: DMA"
+
+"Drivers: EEPROM":
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - henrikbrixandersen
+    files:
+        - drivers/eeprom/
+        - dts/bindings/mtd/*eeprom*
+        - include/drivers/eeprom.h
+        - tests/drivers/eeprom/
+    labels:
+        - "area: EEPROM"
+
+"Drivers: Entropy":
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - ceolin
+    files:
+        - drivers/entropy/
+        - include/drivers/entropy.h
+        - samples/drivers/entropy/
+        - tests/drivers/entropy/
+
+"Drivers: ESPI":
+    status: orphaned
+    files:
+        - drivers/espi/
+        - include/drivers/espi.h
+        - samples/drivers/espi/
+    labels:
+        - "eSPI"
+
+"Drivers: Ethernet":
+    status: maintained
+    maintainers:
+        - tbursztyka
+    collaborators:
+        - jukkar
+        - pfalcon
+    files:
+        - drivers/ethernet/
+    labels:
+        - "area: Ethernet"
+
+"Drivers: Flash":
+    status: maintained
+    maintainers:
+        - nvlsianpu
+    files:
+        - drivers/flash/
+        - dts/bindings/flash_controller/
+        - include/drivers/flash.h
+        - samples/drivers/flash_shell/
+    labels:
+        - "area: Flash"
+
+"Drivers: GPIO":
+    status: maintained
+    maintainers:
+        - mnkp
+    files:
+        - doc/reference/peripherals/gpio.rst
+        - drivers/gpio/
+        - include/drivers/gpio/
+        - include/drivers/gpio.h
+        - include/dt-bindings/gpio/
+        - tests/drivers/gpio/
+        - samples/drivers/gpio/
+    labels:
+        - "area: GPIO"
+
+"Drivers: HW Info":
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - alexanderwachter
+    files:
+        - drivers/hwinfo/
+        - dts/bindings/hwinfo/
+        - include/drivers/hwinfo.h
+        - tests/drivers/hwinfo/
+    labels:
+        - "area: HWINFO"
+
+"Drivers: I2C":
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - pabigot
+    files:
+        - drivers/i2c/
+        - dts/bindings/i2c/
+        - include/drivers/i2c.h
+        - include/drivers/i2c/
+    labels:
+        - "area: I2C"
+
+"Drivers: I2S":
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - anangl
+    files:
+        - doc/reference/audio/i2s.rst
+        - drivers/i2s/
+        - dts/bindings/i2s/
+        - include/drivers/i2s.h
+        - tests/drivers/i2s/
+    labels:
+        - "area: I2S"
+
+"Drivers: IEEE 802.15.4":
+    status: maintained
+    maintainers:
+        - tbursztyka
+    collaborators:
+        - jukkar
+    files:
+        - drivers/ieee802154/
+
+"Drivers: Interrupt controllers":
+    status: orphaned
+    files:
+        - drivers/interrupt_controller/
+        - dts/bindings/interrupt-controller/
+        - include/drivers/interrupt_controller/
+        - include/dt-bindings/interrupt-controller/
+
+"Drivers: IPM":
+    status: maintained
+    maintainers:
+        - andrewboie
+    files:
+        - drivers/ipm/
+    description: >-
+        Inter-processor mailboxes
+
+"Drivers: kscan":
+    status: orphaned
+    files:
+        - drivers/kscan/
+        - include/drivers/kscan.h
+        - samples/drivers/espi/
+        - tests/drivers/kscan/
+
+"Drivers: LED":
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - Mani-Sadhasivam
+    files:
+        - drivers/led/
+        - include/drivers/led/
+        - include/drivers/led.h
+        - samples/drivers/led_*/
+    labels:
+        - "area: LED"
+
+"Drivers: LED Strip":
+    status: maintained
+    maintainers:
+        - mbolivar-nordic
+    files:
+        - drivers/led_strip/
+        - dts/bindings/led_strip/
+        - include/drivers/led_strip.h
+
+"Drivers: lora":
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - Mani-Sadhasivam
+    files:
+        - drivers/lora/
+        - include/drivers/lora.h
+        - samples/drivers/lora/
+
+"Drivers: Modem":
+    status: maintained
+    maintainers:
+        - mike-scott
+    files:
+        - drivers/modem/
+    labels:
+        - "area: Modem"
+
+"Drivers: Neural networking":
+    status: orphaned
+    files:
+        - drivers/neural_net/
+
+"Drivers: PCI":
+    status: maintained
+    maintainers:
+        - dcpleung
+    collaborators:
+        - andrewboie
+    files:
+        - drivers/pcie/
+        - include/drivers/pcie/
+    labels:
+        - "area: PCI"
+
+"Drivers: peci":
+    status: orphaned
+    files:
+        - drivers/peci/
+        - include/drivers/peci.h
+        - samples/drivers/peci/
+
+"Drivers: Pinmux":
+    status: maintained
+    maintainers:
+        - mnkp
+    files:
+        - doc/reference/peripherals/pinmux.rst
+        - drivers/pinmux/
+        - include/drivers/pinmux.h
+    labels:
+        - "area: Pinmux"
+
+"Drivers: PTP Clock":
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - jukkar
+    files:
+        - drivers/ptp_clock/
+        - include/ptp_clock.h
+
+"Drivers: PWM":
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - anangl
+    files:
+        - drivers/pwm/
+        - dts/bindings/pwm/
+        - include/drivers/pwm.h
+        - tests/drivers/pwm/
+    labels:
+        - "area: PWM"
+
+"Drivers: Serial/UART":
+    status: maintained
+    maintainers:
+        - dcpleung
+    files:
+        - drivers/serial/
+        - dts/bindings/serial/
+    labels:
+        - "area: UART"
+
+"Drivers: Sensors":
+    status: maintained
+    maintainers:
+        - MaureenHelm
+    collaborators:
+        - avisconti
+    files:
+        - drivers/sensor/
+        - include/drivers/sensor.h
+        - samples/sensor/
+    labels:
+        - "area: Sensors"
+
+"Drivers: SPI":
+    status: maintained
+    maintainers:
+        - tbursztyka
+    files:
+        - drivers/spi/
+        - include/drivers/spi.h
+        - tests/drivers/spi/
+    labels:
+        - "area: SPI"
+
+"Drivers: System timer":
+    status: maintained
+    maintainers:
+        - andyross
+    files:
+        - drivers/timer/
+        - include/drivers/timer/
+    labels:
+        - "area: Timer"
+
+"Drivers: video":
+    status: orphaned
+    collaborators:
+        - loicpoulain
+    files:
+        - drivers/video/
+        - include/drivers/video.h
+        - include/drivers/video-controls.h
+    labels:
+        - "area: Video"
+
+"Drivers: Watchdog":
+    status: orphaned
+    files:
+        - doc/reference/peripherals/watchdog.rst
+        - drivers/watchdog/
+        - dts/bindings/watchdog/
+        - include/drivers/watchdog.h
+        - samples/drivers/watchdog/
+        - tests/drivers/watchdog/
+    labels:
+        - "area: Watchdog"
+
+"Drivers: WiFi":
+    status: maintained
+    maintainers:
+        - tbursztyka
+    collaborators:
+        - jukkar
+    files:
+        - drivers/wifi/
+    labels:
+        - "area: Wifi"
+
+"Drivers: WiFi es-WiFi":
+    status: orphaned
+    collaborators:
+        - loicpoulain
+    files:
+        - drivers/wifi/eswifi/
+    description: >-
+        Inventek es-WiFi
+
+Filesystems:
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - nvlsianpu
+    collaborators:
+        - de-nordic
+        - Laczen
+        - nashif
+        - pabigot
+        - vanwinkeljan
+        - wentongwu
+    files:
+        - include/fs/
+        - samples/subsys/fs/
+        - subsys/fs/
+        - tests/subsys/fs/
+    labels:
+        - "area: File System"
+
+JSON Web Token:
+    status: orphaned
+    collaborators:
+        - mrfuchs
+    files:
+        - subsys/jwt/
+
+Kconfig:
+    # Provisional entry, subject to approval
+    status: orphaned
+    files:
+        - scripts/kconfig/
+    files-regex:
+        - Kconfig[\w._-]*$
+    labels:
+        - "area: Kconfig"
+    description: >-
+        See https://docs.zephyrproject.org/latest/guides/kconfig/index.html and
+        https://docs.zephyrproject.org/latest/guides/porting/board_porting.html#default-board-configuration
+
+Kernel:
+    status: maintained
+    maintainers:
+        - andyross
+    collaborators:
+        - andrewboie
+    files:
+        - doc/reference/kernel/
+        - include/kernel*.h
+        - kernel/
+        - tests/kernel/
+    labels:
+        - "area: Kernel"
+
+Little FS:
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - pabigot
+    files:
+        - subsys/fs/Kconfig.littlefs
+        - subsys/fs/littlefs_fs.c
+        - tests/subsys/fs/littlefs
+    description: >-
+       Little FS
+
+Logging:
+    status: maintained
+    maintainers:
+        - nordic-krch
+    files:
+        - include/logging/
+        - samples/subsys/logging/
+        - subsys/logging/
+        - tests/subsys/logging/
+    labels:
+        - "area: Logging"
+
+MAINTAINERS file:
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - MaureenHelm
+    collaborators:
+        - ioannisg
+    files:
+        - MAINTAINERS.yml
+    labels:
+        - "area: Process"
+    description: >-
+        Zephyr Maintainers File
+
+MCU Manager:
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - de-nordic
+    files:
+        - subsys/mgmt/
+        - include/mgmt/
+        - samples/subsys/mgmt/
+    labels:
+        - "area: mcumgr"
+
+Native POSIX and POSIX arch:
+    status: maintained
+    maintainers:
+        - aescolar
+    files:
+        - arch/posix/
+        - boards/posix/native_posix/
+        - drivers/*/*native_posix*
+        - drivers/*/*/*native_posix*
+        - dts/posix/
+        - include/arch/posix/
+        - scripts/valgrind.supp
+        - soc/posix/
+        - tests/boards/native_posix/
+    labels:
+        - "area: native port"
+    description: >-
+        POSIX architecture and SOC, native_posix board, and related drivers
+
+Networking:
+    status: maintained
+    maintainers:
+        - jukkar
+    collaborators:
+        - tbursztyka
+        - pfalcon
+    files:
+        - drivers/net/
+        - include/net/
+        - samples/net/
+        - subsys/net/
+    files-exclude:
+        - samples/net/sockets/coap_*/
+        - samples/net/lwm2m_client/
+        - subsys/net/lib/coap/
+        - subsys/net/lib/lwm2m/
+        - subsys/net/lib/openthread/
+        - subsys/net/lib/tls_credentials/
+    labels:
+        - "area: Networking"
+
+"Networking: BSD sockets":
+    status: maintained
+    maintainers:
+        - pfalcon
+    collaborators:
+        - jukkar
+    files:
+        - samples/net/sockets/
+        - subsys/net/lib/sockets/
+        - tests/net/socket/
+    labels:
+        - "area: Sockets"
+
+"Networking: Buffers":
+    status: maintained
+    maintainers:
+        - jhedberg
+    collaborators:
+        - jukkar
+        - tbursztyka
+    files:
+        - include/net/buf.h
+        - subsys/net/buf.c
+        - tests/net/buf/
+
+"Networking: CoAP":
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - rlubos
+    collaborators:
+        - jukkar
+    files:
+        - subsys/net/lib/coap/
+        - samples/net/sockets/coap_*/
+        - tests/net/lib/coap/
+
+"Networking: LWM2M":
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - rlubos
+    collaborators:
+        - jukkar
+    files:
+        - samples/net/lwm2m_client/
+        - subsys/net/lib/lwm2m/
+    labels:
+        - "area: LWM2M"
+
+"Networking: MQTT":
+    status: maintained
+    maintainers:
+        - rlubos
+    collaborators:
+        - jukkar
+    files:
+        - subsys/net/lib/mqtt/
+        - tests/net/lib/mqtt_packet/
+        - samples/net/mqtt_publisher/
+
+NIOS-2 arch:
+    status: maintained
+    maintainers:
+        - nashif
+    files:
+        - arch/nios2/
+        - include/arch/nios2/
+    labels:
+        - "area: NIOS2"
+
+nRF52 BSIM:
+    status: maintained
+    maintainers:
+        - aescolar
+    files:
+        - boards/posix/nrf52_bsim/
+    labels:
+        - "platform: nrf52_bsim"
+
+POSIX API layer:
+    status: maintained
+    maintainers:
+        - pfalcon
+    files:
+        - include/posix/
+        - lib/posix/
+        - tests/posix/
+    labels:
+        - "area: POSIX"
+
+Power management:
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - wentongwu
+    files:
+        - include/power/power.h
+        - samples/subsys/power/
+        - subsys/power/
+    labels:
+        - "area: Power Management"
+
+RISCV arch:
+    # Provisional entry, subject to approval
+    status: orphaned
+    collaborators:
+        - mgielda
+        - nategraff-sifive
+    files:
+        - arch/riscv/
+        - include/arch/riscv/
+    labels:
+        - "area: RISCV"
+
+Sanitycheck:
+    status: maintained
+    maintainers:
+        - nashif
+    files:
+        - scripts/sanitycheck
+        - scripts/sanity_chk/
+    labels:
+        - "area: Sanitycheck"
+
+Settings:
+    status: maintained
+    maintainers:
+        - nvlsianpu
+    files:
+        - include/settings/
+        - subsys/settings/
+        - tests/subsys/settings/
+    labels:
+        - "area: Settings"
+
+Shell:
+    status: maintained
+    maintainers:
+        - jakub-uC
+    collaborators:
+        - carlescufi
+    files:
+        - include/shell/
+        - samples/subsys/shell/
+        - subsys/shell/
+        - tests/shell/
+        - tests/subsys/shell/
+    labels:
+        - "area: Shell"
+
+Shields:
+    status: maintained
+    maintainers:
+        - erwango
+    collaborators:
+        - avisconti
+        - jfischer-phytec-iot
+    files:
+        - boards/shields/
+    labels:
+        - "area: Shields"
+
+STM32:
+    status: maintained
+    maintainers:
+        - erwango
+    files:
+        - boards/arm/nucleo_*/
+        - boards/arm/stm32*_disco/
+        - boards/arm/stm32*_eval/
+        - drivers/*/*stm32*/
+        - drivers/*/*/*stm32*
+        - dts/arm/st/
+        - dts/bindings/*/*stm32*
+        - soc/arm/st_stm32/
+    labels:
+        - "platform: STM32"
+    description: >-
+        STM32 SOCs, dts files and related drivers. ST nucleo, disco and eval
+        boards.
+
+Storage:
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - nvlsianpu
+    files:
+        - subsys/storage/
+        - include/storage/
+        - tests/subsys/storage/
+    labels:
+        - "area: Storage"
+
+TF-M Integration:
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - microbuilder
+    collaborators:
+        - ioannisg
+    files:
+        - samples/tfm_integration/
+    labels:
+        - "area: TF-M"
+
+Tracing:
+    status: maintained
+    maintainers:
+        - nashif
+    collaborators:
+        - wentongwu
+    files:
+        - subsys/tracing/
+        - include/tracing/
+    labels:
+        - "area: tracing"
+
+USB:
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - jfischer-phytec-iot
+    collaborators:
+        - finikorg
+    files:
+        - drivers/usb/
+        - dts/bindings/usb/
+        - include/*/usb/
+        - include/usb/
+        - samples/subsys/usb/
+        - subsys/usb/
+        - tests/subsys/usb/
+    labels:
+        - "area: USB"
+
+Userspace:
+    status: maintained
+    maintainers:
+        - andrewboie
+    files:
+        - doc/reference/usermode/kernelobjects.rst
+        - include/app_memory/
+        - include/linker/app_smem*.ld
+    labels:
+        - "area: Userspace"
+
+VFS:
+    # Provisional entry, subject to approval
+    status: maintained
+    maintainers:
+        - de-nordic
+    files:
+        - subsys/fs/fat_fs.c
+        - tests/subsys/fs/fat_fs_api/
+    description: >-
+       VFS implementation
+
+West:
+    status: maintained
+    maintainers:
+        - mbolivar-nordic
+    collaborators:
+        - carlescufi
+    files:
+        - scripts/west-commands.yml
+        - scripts/west_commands/
+    labels:
+        - "area: West"
+
+Xtensa arch:
+    status: maintained
+    maintainers:
+        - dcpleung
+    collaborators:
+        - andyross
+        - andrewboie
+    files:
+        - arch/xtensa/
+        - include/arch/xtensa/
+        - dts/xtensa/
+        - tests/arch/xtensa_asm2/
+    labels:
+        - "area: Xtensa"
+
+x86 arch:
+    status: maintained
+    maintainers:
+        - ceolin
+    collaborators:
+        - andyross
+    files:
+        - arch/x86/
+        - include/arch/x86/
+        - tests/arch/x86/
+    labels:
+        - "area: X86"
+
+ZTest:
+    status: maintained
+    maintainers:
+        - nashif
+    files:
+        - subsys/testsuite/
+        - tests/ztest/
+        - tests/unit/util/
+    labels:
+        - "area: Testsuite"

--- a/scripts/get_maintainer.py
+++ b/scripts/get_maintainer.py
@@ -1,0 +1,552 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Lists maintainers for files or commits. Similar in function to
+scripts/get_maintainer.pl from Linux, but geared towards GitHub. The mapping is
+in MAINTAINERS.yml.
+
+The comment at the top of MAINTAINERS.yml in Zephyr documents the file format.
+
+See the help texts for the various subcommands for more information. They can
+be viewed with e.g.
+
+    ./get_maintainer.py path --help
+
+This executable doubles as a Python library. Identifiers not prefixed with '_'
+are part of the library API. The library documentation can be viewed with this
+command:
+
+    $ pydoc get_maintainer
+"""
+
+import argparse
+import operator
+import os
+import pathlib
+import re
+import shlex
+import subprocess
+import sys
+
+from yaml import load, YAMLError
+try:
+    # Use the speedier C LibYAML parser if available
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
+
+
+def _main():
+    # Entry point when run as an executable
+
+    args = _parse_args()
+    try:
+        args.cmd_fn(Maintainers(args.maintainers), args)
+    except (MaintainersError, GitError) as e:
+        _serr(e)
+
+
+def _parse_args():
+    # Parses arguments when run as an executable
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=__doc__)
+
+    parser.add_argument(
+        "-m", "--maintainers",
+        metavar="MAINTAINERS_FILE",
+        help="Maintainers file to load. If not specified, MAINTAINERS.yml in "
+             "the top-level repository directory is used, and must exist. "
+             "Paths in the maintainers file will always be taken as relative "
+             "to the top-level directory.")
+
+    subparsers = parser.add_subparsers(
+        help="Available commands (each has a separate --help text)")
+
+    id_parser = subparsers.add_parser(
+        "path",
+        help="List area(s) for paths")
+    id_parser.add_argument(
+        "paths",
+        metavar="PATH",
+        nargs="*",
+        help="Path to list areas for")
+    id_parser.set_defaults(cmd_fn=Maintainers._path_cmd)
+
+    commits_parser = subparsers.add_parser(
+        "commits",
+        help="List area(s) for commit range")
+    commits_parser.add_argument(
+        "commits",
+        metavar="COMMIT_RANGE",
+        nargs="*",
+        help="Commit range to list areas for (default: HEAD~..)")
+    commits_parser.set_defaults(cmd_fn=Maintainers._commits_cmd)
+
+    list_parser = subparsers.add_parser(
+        "list",
+        help="List files in areas")
+    list_parser.add_argument(
+        "area",
+        metavar="AREA",
+        nargs="?",
+        help="Name of area to list files in. If not specified, all "
+             "non-orphaned files are listed (all files that do not appear in "
+             "any area).")
+    list_parser.set_defaults(cmd_fn=Maintainers._list_cmd)
+
+    areas_parser = subparsers.add_parser(
+        "areas",
+        help="List areas and maintainers")
+    areas_parser.add_argument(
+        "maintainer",
+        metavar="MAINTAINER",
+        nargs="?",
+        help="List all areas maintained by maintaier.")
+
+    areas_parser.set_defaults(cmd_fn=Maintainers._areas_cmd)
+
+    orphaned_parser = subparsers.add_parser(
+        "orphaned",
+        help="List orphaned files (files that do not appear in any area)")
+    orphaned_parser.add_argument(
+        "path",
+        metavar="PATH",
+        nargs="?",
+        help="Limit to files under PATH")
+    orphaned_parser.set_defaults(cmd_fn=Maintainers._orphaned_cmd)
+
+    args = parser.parse_args()
+    if not hasattr(args, "cmd_fn"):
+        # Called without a subcommand
+        sys.exit(parser.format_usage().rstrip())
+
+    return args
+
+
+class Maintainers:
+    """
+    Represents the contents of a maintainers YAML file.
+
+    These attributes are available:
+
+    areas:
+        A dictionary that maps area names to Area instances, for all areas
+        defined in the maintainers file
+
+    filename:
+        The path to the maintainers file
+    """
+    def __init__(self, filename=None):
+        """
+        Creates a Maintainers instance.
+
+        filename (default: None):
+            Path to the maintainers file to parse. If None, MAINTAINERS.yml in
+            the top-level directory of the Git repository is used, and must
+            exist.
+        """
+        self._toplevel = pathlib.Path(_git("rev-parse", "--show-toplevel"))
+
+        if filename is None:
+            self.filename = self._toplevel / "MAINTAINERS.yml"
+        else:
+            self.filename = pathlib.Path(filename)
+
+        self.areas = {}
+        for area_name, area_dict in _load_maintainers(self.filename).items():
+            area = Area()
+            area.name = area_name
+            area.status = area_dict.get("status")
+            area.maintainers = area_dict.get("maintainers", [])
+            area.collaborators = area_dict.get("collaborators", [])
+            area.inform = area_dict.get("inform", [])
+            area.labels = area_dict.get("labels", [])
+            area.description = area_dict.get("description")
+
+            # area._match_fn(path) tests if the path matches files and/or
+            # files-regex
+            area._match_fn = \
+                _get_match_fn(area_dict.get("files"),
+                              area_dict.get("files-regex"))
+
+            # Like area._match_fn(path), but for files-exclude and
+            # files-regex-exclude
+            area._exclude_match_fn = \
+                _get_match_fn(area_dict.get("files-exclude"),
+                              area_dict.get("files-regex-exclude"))
+
+            self.areas[area_name] = area
+
+    def path2areas(self, path):
+        """
+        Returns a list of Area instances for the areas that contain 'path',
+        taken as relative to the current directory
+        """
+        # Make directory paths end in '/' so that foo/bar matches foo/bar/.
+        # Skip this check in _contains() itself, because the isdir() makes it
+        # twice as slow in cases where it's not needed.
+        is_dir = os.path.isdir(path)
+
+        # Make 'path' relative to the repository root and normalize it.
+        # normpath() would remove a trailing '/', so we add it afterwards.
+        path = os.path.normpath(os.path.join(
+            os.path.relpath(os.getcwd(), self._toplevel),
+            path))
+
+        if is_dir:
+            path += "/"
+
+        return [area for area in self.areas.values()
+                if area._contains(path)]
+
+    def commits2areas(self, commits):
+        """
+        Returns a set() of Area instances for the areas that contain files that
+        are modified by the commit range in 'commits'. 'commits' could be e.g.
+        "HEAD~..", to inspect the tip commit
+        """
+        res = set()
+        # Final '--' is to make sure 'commits' is interpreted as a commit range
+        # rather than a path. That might give better error messages.
+        for path in _git("diff", "--name-only", commits, "--").splitlines():
+            res.update(self.path2areas(path))
+        return res
+
+    def __repr__(self):
+        return "<Maintainers for '{}'>".format(self.filename)
+
+    #
+    # Command-line subcommands
+    #
+
+    def _path_cmd(self, args):
+        # 'path' subcommand implementation
+
+        for path in args.paths:
+            if not os.path.exists(path):
+                _serr("'{}': no such file or directory".format(path))
+
+        res = set()
+        orphaned = []
+        for path in args.paths:
+            areas = self.path2areas(path)
+            res.update(areas)
+            if not areas:
+                orphaned.append(path)
+
+        _print_areas(res)
+        if orphaned:
+            if res:
+                print()
+            print("Orphaned paths (not in any area):\n" + "\n".join(orphaned))
+
+    def _commits_cmd(self, args):
+        # 'commits' subcommand implementation
+
+        commits = args.commits or ("HEAD~..",)
+        _print_areas({area for commit_range in commits
+                           for area in self.commits2areas(commit_range)})
+
+    def _areas_cmd(self, args):
+        # 'areas' subcommand implementation
+        for area in self.areas.values():
+            if args.maintainer:
+                if args.maintainer in area.maintainers:
+                    print("{:25}\t{}".format(area.name, ",".join(area.maintainers)))
+            else:
+                print("{:25}\t{}".format(area.name, ",".join(area.maintainers)))
+
+    def _list_cmd(self, args):
+        # 'list' subcommand implementation
+
+        if args.area is None:
+            # List all files that appear in some area
+            for path in _ls_files():
+                for area in self.areas.values():
+                    if area._contains(path):
+                        print(path)
+                        break
+        else:
+            # List all files that appear in the given area
+            area = self.areas.get(args.area)
+            if area is None:
+                _serr("'{}': no such area defined in '{}'"
+                      .format(args.area, self.filename))
+
+            for path in _ls_files():
+                if area._contains(path):
+                    print(path)
+
+    def _orphaned_cmd(self, args):
+        # 'orphaned' subcommand implementation
+
+        if args.path is not None and not os.path.exists(args.path):
+            _serr("'{}': no such file or directory".format(args.path))
+
+        for path in _ls_files(args.path):
+            for area in self.areas.values():
+                if area._contains(path):
+                    break
+            else:
+                print(path)  # We get here if we never hit the 'break'
+
+
+class Area:
+    """
+    Represents an entry for an area in MAINTAINERS.yml.
+
+    These attributes are available:
+
+    status:
+        The status of the area, as a string. None if the area has no 'status'
+        key. See MAINTAINERS.yml.
+
+    maintainers:
+        List of maintainers. Empty if the area has no 'maintainers' key.
+
+    collaborators:
+        List of collaborators. Empty if the area has no 'collaborators' key.
+
+    inform:
+        List of people to inform on pull requests. Empty if the area has no
+        'inform' key.
+
+    labels:
+        List of GitHub labels for the area. Empty if the area has no 'labels'
+        key.
+
+    description:
+        Text from 'description' key, or None if the area has no 'description'
+        key
+    """
+    def _contains(self, path):
+        # Returns True if the area contains 'path', and False otherwise
+
+        return self._match_fn and self._match_fn(path) and not \
+            (self._exclude_match_fn and self._exclude_match_fn(path))
+
+    def __repr__(self):
+        return "<Area {}>".format(self.name)
+
+
+def _print_areas(areas):
+    first = True
+    for area in sorted(areas, key=operator.attrgetter("name")):
+        if not first:
+            print()
+        first = False
+
+        print("""\
+{}
+\tstatus: {}
+\tmaintainers: {}
+\tcollaborators: {}
+\tinform: {}
+\tlabels: {}
+\tdescription: {}""".format(area.name,
+                            area.status,
+                            ", ".join(area.maintainers),
+                            ", ".join(area.collaborators),
+                            ", ".join(area.inform),
+                            ", ".join(area.labels),
+                            area.description or ""))
+
+
+def _get_match_fn(globs, regexes):
+    # Constructs a single regex that tests for matches against the globs in
+    # 'globs' and the regexes in 'regexes'. Parts are joined with '|' (OR).
+    # Returns the search() method of the compiled regex.
+    #
+    # Returns None if there are neither globs nor regexes, which should be
+    # interpreted as no match.
+
+    if not (globs or regexes):
+        return None
+
+    regex = ""
+
+    if globs:
+        glob_regexes = []
+        for glob in globs:
+            # Construct a regex equivalent to the glob
+            glob_regex = glob.replace(".", "\\.").replace("*", "[^/]*") \
+                             .replace("?", "[^/]")
+
+            if not glob.endswith("/"):
+                # Require a full match for globs that don't end in /
+                glob_regex += "$"
+
+            glob_regexes.append(glob_regex)
+
+        # The glob regexes must anchor to the beginning of the path, since we
+        # return search(). (?:) is a non-capturing group.
+        regex += "^(?:{})".format("|".join(glob_regexes))
+
+    if regexes:
+        if regex:
+            regex += "|"
+        regex += "|".join(regexes)
+
+    return re.compile(regex).search
+
+
+def _load_maintainers(path):
+    # Returns the parsed contents of the maintainers file 'filename', also
+    # running checks on the contents. The returned format is plain Python
+    # dicts/lists/etc., mirroring the structure of the file.
+
+    with open(path, encoding="utf-8") as f:
+        try:
+            yaml = load(f, Loader=Loader)
+        except YAMLError as e:
+            raise MaintainersError("{}: YAML error: {}".format(path, e))
+
+        _check_maintainers(path, yaml)
+        return yaml
+
+
+def _check_maintainers(maints_path, yaml):
+    # Checks the maintainers data in 'yaml', which comes from the maintainers
+    # file at maints_path, which is a pathlib.Path instance
+
+    root = maints_path.parent
+
+    def ferr(msg):
+        _err("{}: {}".format(maints_path, msg))  # Prepend the filename
+
+    if not isinstance(yaml, dict):
+        ferr("empty or malformed YAML (not a dict)")
+
+    ok_keys = {"status", "maintainers", "collaborators", "inform", "files",
+               "files-exclude", "files-regex", "files-regex-exclude",
+               "labels", "description"}
+
+    ok_status = {"maintained", "odd fixes", "orphaned", "obsolete"}
+    ok_status_s = ", ".join('"' + s + '"' for s in ok_status)  # For messages
+
+    for area_name, area_dict in yaml.items():
+        if not isinstance(area_dict, dict):
+            ferr("malformed entry for area '{}' (not a dict)"
+                 .format(area_name))
+
+        for key in area_dict:
+            if key not in ok_keys:
+                ferr("unknown key '{}' in area '{}'"
+                     .format(key, area_name))
+
+        if "status" in area_dict and \
+           area_dict["status"] not in ok_status:
+            ferr("bad 'status' key on area '{}', should be one of {}"
+                 .format(area_name, ok_status_s))
+
+        if not area_dict.keys() & {"files", "files-regex"}:
+            ferr("either 'files' or 'files-regex' (or both) must be specified "
+                 "for area '{}'".format(area_name))
+
+        for list_name in "maintainers", "collaborators", "inform", "files", \
+                         "files-regex", "labels":
+            if list_name in area_dict:
+                lst = area_dict[list_name]
+                if not (isinstance(lst, list) and
+                        all(isinstance(elm, str) for elm in lst)):
+                    ferr("malformed '{}' value for area '{}' -- should "
+                         "be a list of strings".format(list_name, area_name))
+
+        for files_key in "files", "files-exclude":
+            if files_key in area_dict:
+                for glob_pattern in area_dict[files_key]:
+                    # This could be changed if it turns out to be too slow,
+                    # e.g. to only check non-globbing filenames. The tuple() is
+                    # needed due to pathlib's glob() returning a generator.
+                    paths = tuple(root.glob(glob_pattern))
+                    if not paths:
+                        ferr("glob pattern '{}' in '{}' in area '{}' does not "
+                             "match any files".format(glob_pattern, files_key,
+                                                      area_name))
+                    if not glob_pattern.endswith("/"):
+                        for path in paths:
+                            if path.is_dir():
+                                ferr("glob pattern '{}' in '{}' in area '{}' "
+                                     "matches a directory, but has no "
+                                     "trailing '/'"
+                                     .format(glob_pattern, files_key,
+                                             area_name))
+
+        for files_regex_key in "files-regex", "files-regex-exclude":
+            if files_regex_key in area_dict:
+                for regex in area_dict[files_regex_key]:
+                    try:
+                        re.compile(regex)
+                    except re.error as e:
+                        ferr("bad regular expression '{}' in '{}' in "
+                             "'{}': {}".format(regex, files_regex_key,
+                                               area_name, e.msg))
+
+        if "description" in area_dict and \
+           not isinstance(area_dict["description"], str):
+            ferr("malformed 'description' value for area '{}' -- should be a "
+                 "string".format(area_name))
+
+
+def _git(*args):
+    # Helper for running a Git command. Returns the rstrip()ed stdout output.
+    # Called like git("diff"). Exits with SystemError (raised by sys.exit()) on
+    # errors.
+
+    git_cmd = ("git",) + args
+    git_cmd_s = " ".join(shlex.quote(word) for word in git_cmd)  # For errors
+
+    try:
+        git_process = subprocess.Popen(
+            git_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except FileNotFoundError:
+        _giterr("git executable not found (when running '{}'). Check that "
+                "it's in listed in the PATH environment variable"
+                .format(git_cmd_s))
+    except OSError as e:
+        _giterr("error running '{}': {}".format(git_cmd_s, e))
+
+    stdout, stderr = git_process.communicate()
+    if git_process.returncode:
+        _giterr("error running '{}'\n\nstdout:\n{}\nstderr:\n{}".format(
+            git_cmd_s, stdout.decode("utf-8"), stderr.decode("utf-8")))
+
+    return stdout.decode("utf-8").rstrip()
+
+
+def _ls_files(path=None):
+    cmd = ["ls-files"]
+    if path is not None:
+        cmd.append(path)
+    return _git(*cmd).splitlines()
+
+
+def _err(msg):
+    raise MaintainersError(msg)
+
+
+def _giterr(msg):
+    raise GitError(msg)
+
+
+def _serr(msg):
+    # For reporting errors when get_maintainer.py is run as a script.
+    # sys.exit() shouldn't be used otherwise.
+    sys.exit("{}: error: {}".format(sys.argv[0], msg))
+
+
+class MaintainersError(Exception):
+    "Exception raised for MAINTAINERS.yml-related errors"
+
+
+class GitError(Exception):
+    "Exception raised for Git-related errors"
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
Pushing the initial version of Zephyr MAINTAINERS file.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Data base for holding maintainer-ship info in Zephyr

- Aligns with TSC terminology (Maintainers, Collaborators)
- Covers most of the Zephyr source Tree (initial source: https://docs.google.com/spreadsheets/d/1QxfZuM1qQIXy_EJldQeS6nErt7DjHw3SZ2vfiKVdo5M/edit#gid=0)
- Adds orphaned areas as well

- ~~Requires TSC approval~~ (motion approved)
