### PR TITLE
lib: updatehub: Improve security

### DIFF
--- a/lib/updatehub/shell.c
+++ b/lib/updatehub/shell.c
@@ -55,11 +55,11 @@ static int cmd_info(const struct shell *shell, size_t argc, char **argv)
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	char *device_id = k_malloc(DEVICE_ID_MAX_SIZE);
+	char *device_id = k_malloc(DEVICE_ID_HEX_MAX_SIZE);
 	char *firmware_version = k_malloc(BOOT_IMG_VER_STRLEN_MAX);
 
+	updatehub_get_device_identity(device_id, DEVICE_ID_HEX_MAX_SIZE);
 	updatehub_get_firmware_version(firmware_version, BOOT_IMG_VER_STRLEN_MAX);
-	updatehub_get_device_identity(device_id, DEVICE_ID_MAX_SIZE);
 
 	shell_fprintf(shell, SHELL_NORMAL, "Unique device id: %s\n",
 		      device_id);

--- a/lib/updatehub/updatehub_device.c
+++ b/lib/updatehub/updatehub_device.c
@@ -7,23 +7,16 @@
 
 bool updatehub_get_device_identity(char *id, int id_max_len)
 {
-	int i, id_len = 0;
-	char buf[3];
-	u8_t hwinfo_id[id_max_len];
+	u8_t hwinfo_id[DEVICE_ID_BIN_MAX_SIZE];
 	size_t length;
 
-	length = hwinfo_get_device_id(hwinfo_id, sizeof(hwinfo_id) - 1);
+	length = hwinfo_get_device_id(hwinfo_id, DEVICE_ID_BIN_MAX_SIZE);
 	if (length <= 0) {
 		return false;
 	}
 
 	memset(id, 0, id_max_len);
+	length = bin2hex(hwinfo_id, length, id, id_max_len - 1);
 
-	for (i = 0; i < length; i++) {
-		snprintk(buf, sizeof(buf), "%02x", hwinfo_id[i]);
-		id_len = strlen(id);
-		strncat(id, buf, id_max_len - id_len);
-	}
-
-	return true;
+	return length > 0;
 }

--- a/lib/updatehub/updatehub_device.h
+++ b/lib/updatehub/updatehub_device.h
@@ -10,7 +10,8 @@
 #include <zephyr.h>
 #include <drivers/hwinfo.h>
 
-#define DEVICE_ID_MAX_SIZE 65
+#define DEVICE_ID_BIN_MAX_SIZE	64
+#define DEVICE_ID_HEX_MAX_SIZE	((DEVICE_ID_BIN_MAX_SIZE * 2) + 1)
 
 bool updatehub_get_device_identity(char *id, int id_max_len);
 


### PR DESCRIPTION
There are some issues related to security on UpdateHub and this address the following fixes:
- Fix variable-size string copy
- Switch from snprintk in favor of bin2hex
- ~~Remove all heap allocations and update stacks sizes~~
- Improvemenets on probe security

~~Fixes #24212~~