### PR TITLE
boards: arm: stm32g4x nucleo board at 170MHz max freq. 

### DIFF
--- a/boards/arm/nucleo_g431rb/nucleo_g431rb_defconfig
+++ b/boards/arm/nucleo_g431rb/nucleo_g431rb_defconfig
@@ -3,14 +3,13 @@
 CONFIG_SOC_SERIES_STM32G4X=y
 CONFIG_SOC_STM32G431XX=y
 
-# 170MHz system clock only in 'boost power' mode. RM0440, section
-# 5.1.5 states that the R1MODE bit must be cleared before system can
-# be 170MHz. This requires an update to the stm32 clock control
-# driver, so default to 150MHz until then.
-# CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=170000000
+# 170MHz system clock only in 'boost power' mode.
+# RM0440, section 5.1.5 states that the R1MODE bit
+# must be cleared before system can be 170MHz.
+CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=170000000
 
 # 150MHz system clock in 'normal power' mode
-CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=150000000
+# CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=150000000
 
 # enable uart driver
 CONFIG_SERIAL=y
@@ -36,11 +35,10 @@ CONFIG_CLOCK_STM32_PLL_Q_DIVISOR=2
 CONFIG_CLOCK_STM32_PLL_R_DIVISOR=2
 
 # Produce 150MHz clock at PLLCLK output
-CONFIG_CLOCK_STM32_PLL_N_MULTIPLIER=75
+# CONFIG_CLOCK_STM32_PLL_N_MULTIPLIER=75
 
-# Comment out above and uncomment below for 170MHz. Note that you
-# must have configured the mcu for boost power mode.
-# CONFIG_CLOCK_STM32_PLL_N_MULTIPLIER=85
+# Produce 170MHz clock at PLLCLK output
+CONFIG_CLOCK_STM32_PLL_N_MULTIPLIER=85
 
 # Produce Max (150MHz or 170MHz) HCLK
 CONFIG_CLOCK_STM32_AHB_PRESCALER=1

--- a/boards/arm/nucleo_g474re/nucleo_g474re_defconfig
+++ b/boards/arm/nucleo_g474re/nucleo_g474re_defconfig
@@ -3,14 +3,13 @@
 CONFIG_SOC_SERIES_STM32G4X=y
 CONFIG_SOC_STM32G474XX=y
 
-# 170MHz system clock only in 'boost power' mode. RM0440, section
-# 5.1.5 states that the R1MODE bit must be cleared before system can
-# be 170MHz. This requires an update to the stm32 clock control
-# driver, so default to 150MHz until then.
-# CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=170000000
+# 170MHz system clock only in 'boost power' mode.
+# RM0440, section 5.1.5 states that the R1MODE bit
+# must be cleared before system can be 170MHz.
+CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=170000000
 
 # 150MHz system clock in 'normal power' mode
-CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=150000000
+# CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=150000000
 
 # enable uart driver
 CONFIG_SERIAL=y
@@ -36,11 +35,10 @@ CONFIG_CLOCK_STM32_PLL_Q_DIVISOR=2
 CONFIG_CLOCK_STM32_PLL_R_DIVISOR=2
 
 # Produce 150MHz clock at PLLCLK output
-CONFIG_CLOCK_STM32_PLL_N_MULTIPLIER=75
+# CONFIG_CLOCK_STM32_PLL_N_MULTIPLIER=75
 
-# Comment out above and uncomment below for 170MHz. Note that you
-# must have configured the mcu for boost power mode.
-# CONFIG_CLOCK_STM32_PLL_N_MULTIPLIER=85
+# Produce 170MHz clock at PLLCLK output
+CONFIG_CLOCK_STM32_PLL_N_MULTIPLIER=85
 
 # Produce Max (150MHz or 170MHz) HCLK
 CONFIG_CLOCK_STM32_AHB_PRESCALER=1


### PR DESCRIPTION
The nucleo_g474 and nucleo_g431 nucleo boards are configured with SYS_CLOCK_HW_CYCLES_PER_SEC to 170MHz. 

This requires enabling the Power Boost Mode which is already set in the `drivers/clock_control/clock_stm32g4.c` by the STM32G4x/STM32L4Rx/STM32L4Sx: Fix sys clock frequency and boost voltage for highest clock frequencies #22311

Signed-off-by: Francois Ramu francois.ramu@st.com