### PR TITLE
dts: soc: atmel: sam: cleanup node labels to match SoC docs

### DIFF
--- a/boards/arm/arduino_due/arduino_due.dts
+++ b/boards/arm/arduino_due/arduino_due.dts
@@ -9,17 +9,17 @@
 	compatible = "arduino,due", "atmel,sam3x8e", "atmel,sam3x";
 
 	aliases {
-		uart-0 = &uart0;
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
+		uart-0 = &uart;
+		i2c-0 = &twi0;
+		i2c-1 = &twi1;
 		led0 = &yellow_led;
 	};
 
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
-		zephyr,console = &uart0;
-		zephyr,shell-uart = &uart0;
+		zephyr,console = &uart;
+		zephyr,shell-uart = &uart;
 	};
 
 	leds {
@@ -36,19 +36,19 @@
 	clock-frequency = <84000000>;
 };
 
-&wdog {
+&wdt {
 	status = "okay";
 };
 
-&i2c0 {
+&twi0 {
 	status = "okay";
 };
 
-&i2c1 {
+&twi1 {
 	status = "okay";
 };
 
-&uart0 {
+&uart {
 	status = "okay";
 	current-speed = <115200>;
 };

--- a/boards/arm/sam4e_xpro/sam4e_xpro.dts
+++ b/boards/arm/sam4e_xpro/sam4e_xpro.dts
@@ -13,10 +13,10 @@
 	compatible = "atmel,sam4e_xpro", "atmel,sam4e16e", "atmel,sam4e";
 
 	aliases {
-		i2c-0 = &i2c0;
+		i2c-0 = &twi0;
 		led0 = &yellow_led_1;
 		sw0 = &user_button;
-		wdog = &wdog;
+		wdog = &wdt;
 	};
 
 	chosen {
@@ -29,7 +29,7 @@
 	leds {
 		compatible = "gpio-leds";
 		yellow_led_1: led_1 {
-			gpios = <&portd 22 GPIO_ACTIVE_LOW>;
+			gpios = <&piod 22 GPIO_ACTIVE_LOW>;
 			label = "LED 1";
 		};
 	};
@@ -38,7 +38,7 @@
 		compatible = "gpio-keys";
 		user_button: button_1 {
 			label = "User Button";
-			gpios = <&porta 2 (GPIO_PULL_UP |
+			gpios = <&pioa 2 (GPIO_PULL_UP |
 					   GPIO_ACTIVE_LOW)>;
 		};
 	};
@@ -57,6 +57,6 @@
 	status = "okay";
 };
 
-&wdog {
+&wdt {
 	status = "okay";
 };

--- a/boards/arm/sam4s_xplained/sam4s_xplained.dts
+++ b/boards/arm/sam4s_xplained/sam4s_xplained.dts
@@ -12,8 +12,8 @@
 	compatible = "atmel,sam4s_xplained", "atmel,sam4s16c", "atmel,sam4s";
 
 	aliases {
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
+		i2c-0 = &twi0;
+		i2c-1 = &twi1;
 		led0 = &yellow_led_1;
 		led1 = &yellow_led_2;
 		sw0 = &user_button;
@@ -29,11 +29,11 @@
 	leds {
 		compatible = "gpio-leds";
 		yellow_led_1: led_1 {
-			gpios = <&portc 10 GPIO_ACTIVE_LOW>;
+			gpios = <&pioc 10 GPIO_ACTIVE_LOW>;
 			label = "LED 1";
 		};
 		yellow_led_2: led_2 {
-			gpios = <&portc 17 GPIO_ACTIVE_LOW>;
+			gpios = <&pioc 17 GPIO_ACTIVE_LOW>;
 			label = "LED 2";
 		};
 	};
@@ -42,7 +42,7 @@
 		compatible = "gpio-keys";
 		user_button: button_1 {
 			label = "User Button";
-			gpios = <&porta 5 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			gpios = <&pioa 5 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		};
 	};
 };
@@ -51,7 +51,7 @@
 	clock-frequency = <120000000>;
 };
 
-&i2c0 {
+&twi0 {
 	status = "okay";
 };
 
@@ -69,6 +69,6 @@
 	status = "okay";
 };
 
-&wdog {
+&wdt {
 	status = "okay";
 };

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
@@ -11,9 +11,9 @@
 	compatible = "atmel,sam_e70_xplained", "atmel,same70q21", "atmel,same70";
 
 	aliases {
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		i2c-2 = &i2c2;
+		i2c-0 = &twihs0;
+		i2c-1 = &twihs1;
+		i2c-2 = &twihs2;
 		led0 = &green_led;
 		sw0 = &sw0_user_button;
 	};
@@ -29,7 +29,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led: led_0 {
-			gpios = <&portc 8 GPIO_ACTIVE_LOW>;
+			gpios = <&pioc 8 GPIO_ACTIVE_LOW>;
 			label = "User LED";
 		};
 	};
@@ -42,7 +42,7 @@
 		 */
 		sw0_user_button: button_1 {
 			label = "User Button";
-			gpios = <&porta 11 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			gpios = <&pioa 11 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		};
 	};
 };
@@ -51,19 +51,19 @@
 	clock-frequency = <300000000>;
 };
 
-&adc0 {
+&afec0 {
 	status = "okay";
 };
 
-&adc1 {
+&afec1 {
 	status = "okay";
 };
 
-&i2c0 {
+&twihs0 {
 	status = "okay";
 };
 
-&i2c2 {
+&twihs2 {
 	status = "okay";
 };
 
@@ -76,7 +76,7 @@
 	status = "okay";
 };
 
-&wdog {
+&wdt {
 	status = "okay";
 };
 

--- a/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -12,9 +12,9 @@
 	compatible = "atmel,sam_v71_xult", "atmel,samv71q21", "atmel,samv71";
 
 	aliases {
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		i2c-2 = &i2c2;
+		i2c-0 = &twihs0;
+		i2c-1 = &twihs1;
+		i2c-2 = &twihs2;
 		led0 = &yellow_led0;
 		led1 = &yellow_led1;
 		sw0 = &sw0_user_button;
@@ -32,11 +32,11 @@
 	leds {
 		compatible = "gpio-leds";
 		yellow_led0: led_0 {
-			gpios = <&porta 23 GPIO_ACTIVE_LOW>;
+			gpios = <&pioa 23 GPIO_ACTIVE_LOW>;
 			label = "User LED 0";
 		};
 		yellow_led1: led_1 {
-			gpios = <&portc 9 GPIO_ACTIVE_LOW>;
+			gpios = <&pioc 9 GPIO_ACTIVE_LOW>;
 			label = "User LED 1";
 		};
 	};
@@ -50,11 +50,11 @@
 		 */
 		sw0_user_button: button_1 {
 			label = "User Button 0";
-			gpios = <&porta 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			gpios = <&pioa 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		};
 		sw1_user_button: button_2 {
 			label = "User Button 1";
-			gpios = <&portb 12 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			gpios = <&piob 12 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		};
 	};
 };
@@ -63,19 +63,19 @@
 	clock-frequency = <300000000>;
 };
 
-&adc0 {
+&afec0 {
 	status = "okay";
 };
 
-&adc1 {
+&afec1 {
 	status = "okay";
 };
 
-&i2c0 {
+&twihs0 {
 	status = "okay";
 };
 
-&i2c2 {
+&twihs2 {
 	status = "okay";
 };
 
@@ -88,7 +88,7 @@
 	status = "okay";
 };
 
-&wdog {
+&wdt {
 	status = "okay";
 };
 
@@ -104,23 +104,23 @@
 	status = "okay";
 };
 
-&porta {
+&pioa {
 	status = "okay";
 };
 
-&portb {
+&piob {
 	status = "okay";
 };
 
-&portc {
+&pioc {
 	status = "okay";
 };
 
-&portd {
+&piod {
 	status = "okay";
 };
 
-&porte {
+&pioe {
 	status = "okay";
 };
 

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	aliases {
-		watchdog0 = &wdog;
+		watchdog0 = &wdt;
 	};
 
 	cpus {
@@ -36,7 +36,7 @@
 
 	soc {
 		/* Only used for HWINFO device ID */
-		flash-controller@400e0a00 {
+		eefc: flash-controller@400e0a00 {
 			compatible = "atmel,sam-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x400e0a00 0x200>;
@@ -46,7 +46,7 @@
 			#size-cells = <1>;
 		};
 
-		wdog: watchdog@400e1a50 {
+		wdt: watchdog@400e1a50 {
 			compatible = "atmel,sam-watchdog";
 			reg = <0x400e1a50 0xc>;
 			interrupts = <4 0>;
@@ -55,7 +55,7 @@
 			status = "disabled";
 		};
 
-		i2c0: i2c@4008c000 {
+		twi0: i2c@4008c000 {
 			compatible = "atmel,sam-i2c-twi";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x4008c000 0x128>;
@@ -67,7 +67,7 @@
 			#size-cells = <0>;
 		};
 
-		i2c1: i2c@40090000 {
+		twi1: i2c@40090000 {
 			compatible = "atmel,sam-i2c-twi";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x40090000 0x128>;
@@ -79,7 +79,7 @@
 			#size-cells = <0>;
 		};
 
-		uart0: uart@400e0800 {
+		uart: uart@400e0800 {
 			compatible = "atmel,sam-uart";
 			reg = <0x400e0800 0x124>;
 			interrupts = <8 1>;

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -10,7 +10,7 @@
 
 / {
 	aliases {
-		watchdog0 = &wdog;
+		watchdog0 = &wdt;
 	};
 
 	cpus {
@@ -35,7 +35,7 @@
 
 	soc {
 		/* Only used for HWINFO device ID */
-		flash-controller@400e0a00 {
+		eefc: flash-controller@400e0a00 {
 			compatible = "atmel,sam-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x400e0a00 0x200>;
@@ -45,7 +45,7 @@
 			#size-cells = <1>;
 		};
 
-		wdog: watchdog@400e1850 {
+		wdt: watchdog@400e1850 {
 			compatible = "atmel,sam-watchdog";
 			reg = <0x400e1850 0x10>;
 			interrupts = <4 0>;
@@ -54,7 +54,7 @@
 			status = "disabled";
 		};
 
-		i2c0: i2c@400a8000 {
+		twi0: i2c@400a8000 {
 			compatible = "atmel,sam-i2c-twi";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x400a8000 0x4000>;
@@ -66,7 +66,7 @@
 			#size-cells = <0>;
 		};
 
-		i2c1: i2c@400ac000 {
+		twi1: i2c@400ac000 {
 			compatible = "atmel,sam-i2c-twi";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x400ac000 0x4000>;
@@ -125,7 +125,7 @@
 			label = "USART_1";
 		};
 
-		porta: gpio@400e0e00 {
+		pioa: gpio@400e0e00 {
 			compatible = "atmel,sam-gpio";
 			reg = <0x400e0e00 0x200>;
 			interrupts = <9 1>;
@@ -135,7 +135,7 @@
 			#gpio-cells = <2>;
 		};
 
-		portb: gpio@400e1000 {
+		piob: gpio@400e1000 {
 			compatible = "atmel,sam-gpio";
 			reg = <0x400e1000 0x200>;
 			interrupts = <10 1>;
@@ -145,7 +145,7 @@
 			#gpio-cells = <2>;
 		};
 
-		portc: gpio@400e1200 {
+		pioc: gpio@400e1200 {
 			compatible = "atmel,sam-gpio";
 			reg = <0x400e1200 0x200>;
 			interrupts = <11 1>;
@@ -155,7 +155,7 @@
 			#gpio-cells = <2>;
 		};
 
-		portd: gpio@400e1400 {
+		piod: gpio@400e1400 {
 			compatible = "atmel,sam-gpio";
 			reg = <0x400e1400 0x200>;
 			interrupts = <12 1>;
@@ -165,7 +165,7 @@
 			#gpio-cells = <2>;
 		};
 
-		porte: gpio@400e1600 {
+		pioe: gpio@400e1600 {
 			compatible = "atmel,sam-gpio";
 			reg = <0x400e1600 0x200>;
 			interrupts = <13 1>;

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -11,7 +11,7 @@
 
 / {
 	aliases {
-		watchdog0 = &wdog;
+		watchdog0 = &wdt;
 	};
 
 	cpus {
@@ -36,7 +36,7 @@
 
 	soc {
 		/* Only used for HWINFO device ID */
-		flash-controller@400e0a00 {
+		eefc: flash-controller@400e0a00 {
 			compatible = "atmel,sam-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x400e0a00 0x200>;
@@ -46,7 +46,7 @@
 			#size-cells = <1>;
 		};
 
-		wdog: watchdog@400e1450 {
+		wdt: watchdog@400e1450 {
 			compatible = "atmel,sam-watchdog";
 			reg = <0x400e1450 0xc>;
 			interrupts = <4 0>;
@@ -54,7 +54,8 @@
 			label = "WATCHDOG_0";
 			status = "disabled";
 		};
-		i2c0: i2c@40018000 {
+
+		twi0: i2c@40018000 {
 			compatible = "atmel,sam-i2c-twi";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x40018000 0x128>;
@@ -66,7 +67,7 @@
 			#size-cells = <0>;
 		};
 
-		i2c1: i2c@4001c000 {
+		twi1: i2c@4001c000 {
 			compatible = "atmel,sam-i2c-twi";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x4001c000 0x128>;
@@ -125,7 +126,7 @@
 			label = "USART_1";
 		};
 
-		porta: gpio@400e0e00 {
+		pioa: gpio@400e0e00 {
 			compatible = "atmel,sam-gpio";
 			reg = <0x400e0e00 0x190>;
 			interrupts = <11 1>;
@@ -135,7 +136,7 @@
 			#gpio-cells = <2>;
 		};
 
-		portb: gpio@400e1000 {
+		piob: gpio@400e1000 {
 			compatible = "atmel,sam-gpio";
 			reg = <0x400e1000 0x190>;
 			interrupts = <12 1>;
@@ -145,7 +146,7 @@
 			#gpio-cells = <2>;
 		};
 
-		portc: gpio@400e1200 {
+		pioc: gpio@400e1200 {
 			compatible = "atmel,sam-gpio";
 			reg = <0x400e1200 0x190>;
 			interrupts = <13 1>;

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -11,7 +11,7 @@
 
 / {
 	aliases {
-		watchdog0 = &wdog;
+		watchdog0 = &wdt;
 	};
 
 	cpus {
@@ -38,7 +38,7 @@
 	};
 
 	soc {
-		flash-controller@400e0c00 {
+		eefc: flash-controller@400e0c00 {
 			compatible = "atmel,sam-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x400e0c00 0x200>;
@@ -58,7 +58,7 @@
 
 		};
 
-		wdog: watchdog@400e1850 {
+		wdt: watchdog@400e1850 {
 			compatible = "atmel,sam-watchdog";
 			reg = <0x400e1850 0xc>;
 			interrupts = <4 0>;
@@ -67,7 +67,7 @@
 			status = "disabled";
 		};
 
-		i2c0: i2c@40018000 {
+		twihs0: i2c@40018000 {
 			compatible = "atmel,sam-i2c-twihs";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
@@ -79,7 +79,7 @@
 			status = "disabled";
 		};
 
-		i2c1: i2c@4001c000 {
+		twihs1: i2c@4001c000 {
 			compatible = "atmel,sam-i2c-twihs";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
@@ -91,7 +91,7 @@
 			status = "disabled";
 		};
 
-		i2c2: i2c@40060000 {
+		twihs2: i2c@40060000 {
 			compatible = "atmel,sam-i2c-twihs";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
@@ -197,7 +197,7 @@
 			label = "USART_2";
 		};
 
-		adc0: adc@4003c000 {
+		afec0: adc@4003c000 {
 			compatible = "atmel,sam-afec";
 			reg = <0x4003c000 0x100>;
 			interrupts = <29 0>;
@@ -207,7 +207,7 @@
 			#io-channel-cells = <1>;
 		};
 
-		adc1: adc@40064000 {
+		afec1: adc@40064000 {
 			compatible = "atmel,sam-afec";
 			reg = <0x40064000 0x100>;
 			interrupts = <40 0>;
@@ -217,7 +217,7 @@
 			#io-channel-cells = <1>;
 		};
 
-		porta: gpio@400e0e00 {
+		pioa: gpio@400e0e00 {
 			compatible = "atmel,sam-gpio";
 			reg = <0x400e0e00 0x190>;
 			interrupts = <10 1>;
@@ -227,7 +227,7 @@
 			#gpio-cells = <2>;
 		};
 
-		portb: gpio@400e1000 {
+		piob: gpio@400e1000 {
 			compatible = "atmel,sam-gpio";
 			reg = <0x400e1000 0x190>;
 			interrupts = <11 1>;
@@ -237,7 +237,7 @@
 			#gpio-cells = <2>;
 		};
 
-		portc: gpio@400e1200 {
+		pioc: gpio@400e1200 {
 			compatible = "atmel,sam-gpio";
 			reg = <0x400e1200 0x190>;
 			interrupts = <12 1>;
@@ -247,7 +247,7 @@
 			#gpio-cells = <2>;
 		};
 
-		portd: gpio@400e1400 {
+		piod: gpio@400e1400 {
 			compatible = "atmel,sam-gpio";
 			reg = <0x400e1400 0x190>;
 			interrupts = <16 1>;
@@ -257,7 +257,7 @@
 			#gpio-cells = <2>;
 		};
 
-		porte: gpio@400e1600 {
+		pioe: gpio@400e1600 {
 			compatible = "atmel,sam-gpio";
 			reg = <0x400e1600 0x190>;
 			interrupts = <17 1>;

--- a/samples/net/sockets/echo_client/boards/sam4s_xplained.overlay
+++ b/samples/net/sockets/echo_client/boards/sam4s_xplained.overlay
@@ -7,16 +7,16 @@
 &spi0 {
         status = "okay";
         label = "SPI_RF2XX";
-        cs-gpios = <&porta 31 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+        cs-gpios = <&pioa 31 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 
         rf2xx@0 {
                 compatible = "atmel,rf2xx";
                 reg = <0x0>;
                 label = "RF2XX_0";
                 spi-max-frequency = <6000000>;
-                irq-gpios = <&portb 2 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
-                reset-gpios = <&porta 3 GPIO_ACTIVE_LOW>;
-                slptr-gpios = <&portb 3 GPIO_ACTIVE_HIGH>;
+                irq-gpios = <&piob 2 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+                reset-gpios = <&pioa 3 GPIO_ACTIVE_LOW>;
+                slptr-gpios = <&piob 3 GPIO_ACTIVE_HIGH>;
                 status = "okay";
         };
 };

--- a/samples/net/sockets/echo_client/boards/sam_v71_xult.overlay
+++ b/samples/net/sockets/echo_client/boards/sam_v71_xult.overlay
@@ -7,16 +7,16 @@
 &spi0 {
         status = "okay";
         label = "SPI_RF2XX";
-        cs-gpios = <&portd 25 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+        cs-gpios = <&piod 25 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 
         rf2xx@0 {
                 compatible = "atmel,rf2xx";
                 reg = <0x0>;
                 label = "RF2XX_0";
                 spi-max-frequency = <6000000>;
-                irq-gpios = <&portb 0 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
-                reset-gpios = <&porta 3 GPIO_ACTIVE_LOW>;
-                slptr-gpios = <&portb 1 GPIO_ACTIVE_HIGH>;
+                irq-gpios = <&piob 0 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+                reset-gpios = <&pioa 3 GPIO_ACTIVE_LOW>;
+                slptr-gpios = <&piob 1 GPIO_ACTIVE_HIGH>;
                 status = "okay";
         };
 };

--- a/samples/net/sockets/echo_server/boards/sam4e_xpro.overlay
+++ b/samples/net/sockets/echo_server/boards/sam4e_xpro.overlay
@@ -7,16 +7,16 @@
 &spi0 {
         status = "okay";
         label = "SPI_RF2XX";
-        cs-gpios = <&portb 14 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+        cs-gpios = <&piob 14 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 
         rf2xx@0 {
                 compatible = "atmel,rf2xx";
                 reg = <0x0>;
                 label = "RF2XX_0";
                 spi-max-frequency = <6000000>;
-                irq-gpios = <&porta 21 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
-                reset-gpios = <&porta 3 GPIO_ACTIVE_LOW>;
-                slptr-gpios = <&porta 22 GPIO_ACTIVE_HIGH>;
+                irq-gpios = <&pioa 21 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+                reset-gpios = <&pioa 3 GPIO_ACTIVE_LOW>;
+                slptr-gpios = <&pioa 22 GPIO_ACTIVE_HIGH>;
                 status = "okay";
         };
 };

--- a/samples/net/sockets/echo_server/boards/sam_v71_xult.overlay
+++ b/samples/net/sockets/echo_server/boards/sam_v71_xult.overlay
@@ -7,16 +7,16 @@
 &spi0 {
         status = "okay";
         label = "SPI_RF2XX";
-        cs-gpios = <&portd 25 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+        cs-gpios = <&piod 25 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 
         rf2xx@0 {
                 compatible = "atmel,rf2xx";
                 reg = <0x0>;
                 label = "RF2XX_0";
                 spi-max-frequency = <6000000>;
-                irq-gpios = <&portb 0 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
-                reset-gpios = <&porta 3 GPIO_ACTIVE_LOW>;
-                slptr-gpios = <&portb 1 GPIO_ACTIVE_HIGH>;
+                irq-gpios = <&piob 0 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+                reset-gpios = <&pioa 3 GPIO_ACTIVE_LOW>;
+                slptr-gpios = <&piob 1 GPIO_ACTIVE_HIGH>;
                 status = "okay";
         };
 };

--- a/tests/drivers/gpio/gpio_basic_api/boards/sam_e70_xplained.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/sam_e70_xplained.overlay
@@ -7,7 +7,7 @@
 / {
 	resources {
 		compatible = "test,gpio_basic_api";
-		out-gpios = <&portd 21 0>;
-		in-gpios = <&portd 20 0>;
+		out-gpios = <&piod 21 0>;
+		in-gpios = <&piod 20 0>;
 	};
 };


### PR DESCRIPTION
Update dts files to use node labels that match Atmel SoC docs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>