### PR TITLE
tests: latency_measure: allow use of other timer for timestamp

### DIFF
--- a/tests/benchmarks/latency_measure/src/main.c
+++ b/tests/benchmarks/latency_measure/src/main.c
@@ -12,6 +12,7 @@
 #include <timestamp.h>
 #include "utils.h"
 #include <tc_util.h>
+#include "timing_info.h"
 
 #define STACK_SIZE (1024 + CONFIG_TEST_EXTRA_STACKSIZE)
 
@@ -31,6 +32,7 @@ void test_thread(void *arg1, void *arg2, void *arg3)
 	PRINT_TIME_BANNER();
 
 	bench_test_init();
+	benchmark_timer_init();
 
 	int_to_thread();
 	print_dash_line();

--- a/tests/benchmarks/latency_measure/src/sema_lock_release.c
+++ b/tests/benchmarks/latency_measure/src/sema_lock_release.c
@@ -14,8 +14,8 @@
 
 #include <zephyr.h>
 
-#include "timestamp.h"
 #include "utils.h"
+#include "timing_info.h"
 
 #include <arch/cpu.h>
 
@@ -25,7 +25,8 @@
 /* the number of mutex lock/unlock cycles */
 #define N_TEST_MUTEX 1000
 
-static u32_t timestamp;
+static u32_t timestamp_start;
+static u32_t timestamp_end;
 
 K_SEM_DEFINE(lock_unlock_sema, 0, N_TEST_SEMA);
 K_MUTEX_DEFINE(TEST_MUTEX);
@@ -42,38 +43,55 @@ K_MUTEX_DEFINE(TEST_MUTEX);
 int sema_lock_unlock(void)
 {
 	int i;
+	u32_t diff;
 
 	PRINT_FORMAT(" 3 - Measure average time to signal a sema then test"
 		     " that sema");
 	bench_test_start();
-	timestamp = TIME_STAMP_DELTA_GET(0);
+	benchmark_timer_start();
+
+	TIMING_INFO_PRE_READ();
+	timestamp_start = TIMING_INFO_OS_GET_TIME();
+
 	for (i = 0; i < N_TEST_SEMA; i++) {
 		k_sem_give(&lock_unlock_sema);
 	}
-	timestamp = TIME_STAMP_DELTA_GET(timestamp);
+
+	TIMING_INFO_PRE_READ();
+	timestamp_end = TIMING_INFO_OS_GET_TIME();
+	benchmark_timer_stop();
+
 	if (bench_test_end() == 0) {
+		diff = TIMING_INFO_GET_DELTA(timestamp_start, timestamp_end);
 		PRINT_FORMAT(" Average semaphore signal time %u tcs = %u"
 			     " nsec",
-			     timestamp / N_TEST_SEMA,
-			     SYS_CLOCK_HW_CYCLES_TO_NS_AVG(timestamp,
-							   N_TEST_SEMA));
+			     diff / N_TEST_SEMA,
+			     CYCLES_TO_NS_AVG(diff, N_TEST_SEMA));
 	} else {
 		error_count++;
 		PRINT_OVERFLOW_ERROR();
 	}
 
 	bench_test_start();
-	timestamp = TIME_STAMP_DELTA_GET(0);
+	benchmark_timer_start();
+
+	TIMING_INFO_PRE_READ();
+	timestamp_start = TIMING_INFO_OS_GET_TIME();
+
 	for (i = 0; i < N_TEST_SEMA; i++) {
 		k_sem_take(&lock_unlock_sema, K_FOREVER);
 	}
-	timestamp = TIME_STAMP_DELTA_GET(timestamp);
+
+	TIMING_INFO_PRE_READ();
+	timestamp_end = TIMING_INFO_OS_GET_TIME();
+	benchmark_timer_stop();
+
 	if (bench_test_end() == 0) {
+		diff = TIMING_INFO_GET_DELTA(timestamp_start, timestamp_end);
 		PRINT_FORMAT(" Average semaphore test time %u tcs = %u "
 			     "nsec",
-			     timestamp / N_TEST_SEMA,
-			     SYS_CLOCK_HW_CYCLES_TO_NS_AVG(timestamp,
-							   N_TEST_SEMA));
+			     diff / N_TEST_SEMA,
+			     CYCLES_TO_NS_AVG(diff, N_TEST_SEMA));
 	} else {
 		error_count++;
 		PRINT_OVERFLOW_ERROR();
@@ -93,24 +111,41 @@ int sema_lock_unlock(void)
 int mutex_lock_unlock(void)
 {
 	int i;
+	u32_t diff;
 
+	benchmark_timer_start();
 	PRINT_FORMAT(" 4- Measure average time to lock a mutex then"
 		     " unlock that mutex");
-	timestamp = TIME_STAMP_DELTA_GET(0);
+
+	TIMING_INFO_PRE_READ();
+	timestamp_start = TIMING_INFO_OS_GET_TIME();
+
 	for (i = 0; i < N_TEST_MUTEX; i++) {
 		k_mutex_lock(&TEST_MUTEX, K_FOREVER);
 	}
-	timestamp = TIME_STAMP_DELTA_GET(timestamp);
+
+	TIMING_INFO_PRE_READ();
+	timestamp_end = TIMING_INFO_OS_GET_TIME();
+
+	diff = TIMING_INFO_GET_DELTA(timestamp_start, timestamp_end);
 	PRINT_FORMAT(" Average time to lock the mutex %u tcs = %u nsec",
-		     timestamp / N_TEST_MUTEX,
-		     SYS_CLOCK_HW_CYCLES_TO_NS_AVG(timestamp, N_TEST_MUTEX));
-	timestamp = TIME_STAMP_DELTA_GET(0);
+		     diff / N_TEST_MUTEX,
+		     CYCLES_TO_NS_AVG(diff, N_TEST_MUTEX));
+
+	TIMING_INFO_PRE_READ();
+	timestamp_start = TIMING_INFO_OS_GET_TIME();
+
 	for (i = 0; i < N_TEST_MUTEX; i++) {
 		k_mutex_unlock(&TEST_MUTEX);
 	}
-	timestamp = TIME_STAMP_DELTA_GET(timestamp);
+
+	TIMING_INFO_PRE_READ();
+	timestamp_end = TIMING_INFO_OS_GET_TIME();
+
+	diff = TIMING_INFO_GET_DELTA(timestamp_start, timestamp_end);
 	PRINT_FORMAT(" Average time to unlock the mutex %u tcs = %u nsec",
-		     timestamp / N_TEST_MUTEX,
-		     SYS_CLOCK_HW_CYCLES_TO_NS_AVG(timestamp, N_TEST_MUTEX));
+		     diff / N_TEST_MUTEX,
+		     CYCLES_TO_NS_AVG(diff, N_TEST_MUTEX));
+	benchmark_timer_stop();
 	return 0;
 }

--- a/tests/benchmarks/latency_measure/src/timing_info.h
+++ b/tests/benchmarks/latency_measure/src/timing_info.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2017 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _TIMING_INFO_H_
+#define _TIMING_INFO_H_
+
+#include <timestamp.h>
+
+#ifdef CONFIG_NRF_RTC_TIMER
+#include <soc.h>
+
+/* To get current count of timer, first 1 need to be written into
+ * Capture Register and Current Count will be copied into corresponding
+ * current count register.
+ */
+#define TIMING_INFO_PRE_READ()        (NRF_TIMER2->TASKS_CAPTURE[0] = 1)
+#define TIMING_INFO_OS_GET_TIME()     (NRF_TIMER2->CC[0])
+
+#elif CONFIG_SOC_SERIES_MEC1501X
+#include <soc.h>
+
+#define TIMING_INFO_PRE_READ()
+#define TIMING_INFO_OS_GET_TIME()     (B32TMR1_REGS->CNT)
+
+#else
+#define TIMING_INFO_PRE_READ()
+#define TIMING_INFO_OS_GET_TIME()      (k_cycle_get_32())
+#endif
+
+/******************************************************************************/
+/* NRF RTC TIMER runs ar very slow rate (32KHz), So in order to measure
+ * Kernel starts a dedicated timer to measure kernel stats.
+ */
+#ifdef CONFIG_NRF_RTC_TIMER
+#define NANOSECS_PER_SEC (1000000000)
+#define CYCLES_PER_SEC   (16000000/(1 << NRF_TIMER2->PRESCALER))
+
+#define CYCLES_TO_NS(x)        ((x) * (NANOSECS_PER_SEC/CYCLES_PER_SEC))
+#define CYCLES_TO_NS_AVG(x, NCYCLES)	\
+	(CYCLES_TO_NS(x) / NCYCLES)
+
+/* Configure Timer parameters */
+static inline void benchmark_timer_init(void)
+{
+	NRF_TIMER2->TASKS_CLEAR = 1;	/* Clear Timer */
+	NRF_TIMER2->MODE = 0;		/* Timer Mode */
+	NRF_TIMER2->PRESCALER = 0;	/* 16M Hz */
+	NRF_TIMER2->BITMODE = 3;	/* 32 - bit */
+}
+
+/* Stop the timer */
+static inline void benchmark_timer_stop(void)
+{
+	NRF_TIMER2->TASKS_STOP = 1;	/* Stop Timer */
+}
+
+/*Start the timer */
+static inline void benchmark_timer_start(void)
+{
+	NRF_TIMER2->TASKS_START = 1;	/* Start Timer */
+}
+
+#elif CONFIG_SOC_SERIES_MEC1501X
+
+#define NANOSECS_PER_SEC	(1000000000)
+#define CYCLES_PER_SEC		(48000000)
+#define CYCLES_TO_NS(x)		((x) * (NANOSECS_PER_SEC/CYCLES_PER_SEC))
+#define CYCLES_TO_NS_AVG(x, NCYCLES)	\
+	(CYCLES_TO_NS(x) / NCYCLES)
+
+/* Configure Timer parameters */
+static inline void benchmark_timer_init(void)
+{
+	/* Setup counter */
+	B32TMR1_REGS->CTRL =
+		MCHP_BTMR_CTRL_ENABLE |
+		MCHP_BTMR_CTRL_AUTO_RESTART |
+		MCHP_BTMR_CTRL_COUNT_UP;
+
+	B32TMR1_REGS->PRLD = 0;		/* Preload */
+	B32TMR1_REGS->CNT = 0;		/* Counter value */
+
+	B32TMR1_REGS->IEN = 0;		/* Disable interrupt */
+	B32TMR1_REGS->STS = 1;		/* Clear interrupt */
+}
+
+/* Stop the timer */
+static inline void benchmark_timer_stop(void)
+{
+	B32TMR1_REGS->CTRL &= ~MCHP_BTMR_CTRL_START;
+}
+
+/* Start the timer */
+static inline void benchmark_timer_start(void)
+{
+	B32TMR1_REGS->CTRL |= MCHP_BTMR_CTRL_START;
+}
+
+#else  /* All other architectures */
+/* Done because weak attribute doesn't work on static inline. */
+static inline void benchmark_timer_init(void)  {       }
+static inline void benchmark_timer_stop(void)  {       }
+static inline void benchmark_timer_start(void) {       }
+
+#define CYCLES_TO_NS(x) ((u32_t)k_cyc_to_ns_floor64(x))
+#define CYCLES_TO_NS_AVG(x, NCYCLES) \
+	((u32_t)(k_cyc_to_ns_floor64(x) / NCYCLES))
+
+#endif /* CONFIG_NRF_RTC_TIMER */
+
+static inline u32_t TIMING_INFO_GET_DELTA(u32_t start, u32_t end)
+{
+	return (end >= start) ? (end - start) : (ULONG_MAX - start + end);
+}
+
+#endif /* _TIMING_INFO_H_ */

--- a/tests/benchmarks/latency_measure/src/utils.h
+++ b/tests/benchmarks/latency_measure/src/utils.h
@@ -12,6 +12,8 @@
  * used in latency measurement.
  */
 
+#include "timing_info.h"
+
 #define INT_IMM8_OFFSET   1
 #define IRQ_PRIORITY      3
 
@@ -65,7 +67,7 @@ static inline void print_dash_line(void)
 #define PRINT_TIME_BANNER()						\
 	do {								\
 	PRINT_FORMAT("  tcs = timer clock cycles: 1 tcs is %u nsec",	\
-		     (u32_t)k_cyc_to_ns_floor64(1));			\
+		     CYCLES_TO_NS(1));					\
 	print_dash_line();						\
 	} while (0)
 


### PR DESCRIPTION
Some platforms have slow system clock resulting in not very
accurate latency measurements. This updates how the timestamps
are obtained by copying the mechanism from the timing_info test.
This allows using alternate higher speed timers to measure
latency.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>