### PR TITLE
ci: do not use latest breathe release for docs

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -30,7 +30,7 @@ jobs:
     - name: install-pip
       run: |
         pip3 install setuptools
-        pip3 install 'breathe>=4.9.1' 'docutils>=0.14' \
+        pip3 install 'breathe>=4.9.1,<4.15.0' 'docutils>=0.14' \
                      'sphinx>=1.7.5,<3.0' sphinx_rtd_theme sphinx-tabs \
                      sphinxcontrib-svg2pdfconverter 'west>=0.6.2'
         pip3 install pyelftools

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -61,8 +61,8 @@ jobs:
     - name: install-pip
       run: |
         pip3 install setuptools
-        pip3 install 'breathe>=4.9.1' 'docutils>=0.14' \
-                     'sphinx>=1.7.5' sphinx_rtd_theme sphinx-tabs \
+        pip3 install 'breathe>=4.9.1,<4.15.0' 'docutils>=0.14' \
+                     'sphinx>=1.7.5,<3.0' sphinx_rtd_theme sphinx-tabs \
                      sphinxcontrib-svg2pdfconverter 'west>=0.6.2'
         pip3 install pyelftools
 

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,6 +1,6 @@
 # DOC: used to generate docs
 
-breathe>=4.9.1
+breathe>=4.9.1,<4.15.0
 docutils>=0.14
 sphinx>=1.7.5,<3.0
 sphinx_rtd_theme


### PR DESCRIPTION
breathe v4.15.0 was just released and fixes some compatibility issues
with latest sphinx, the combo works, however with many warnings that we
still need to either fix or whitelist. This is temporary until we are
able to use those new versions.