### PR TITLE
xtensa: enable XTENSA_HAL at SoC level

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -62,7 +62,6 @@ config XTENSA
 	select HAS_DTS
 	select USE_SWITCH
 	select USE_SWITCH_SUPPORTED
-	select XTENSA_HAL if "$(ZEPHYR_TOOLCHAIN_VARIANT)" != "xcc"
 	help
 	  Xtensa architecture
 

--- a/soc/xtensa/intel_apl_adsp/Kconfig.soc
+++ b/soc/xtensa/intel_apl_adsp/Kconfig.soc
@@ -4,6 +4,7 @@
 config SOC_INTEL_APL_ADSP
 	bool "intel_apl_adsp"
 	select XTENSA
+	select XTENSA_HAL if "$(ZEPHYR_TOOLCHAIN_VARIANT)" != "xcc"
 	select XTENSA_RESET_VECTOR
 	select XTENSA_USE_CORE_CRT1
 	select ATOMIC_OPERATIONS_BUILTIN

--- a/soc/xtensa/intel_s1000/Kconfig.soc
+++ b/soc/xtensa/intel_s1000/Kconfig.soc
@@ -4,5 +4,6 @@
 config SOC_INTEL_S1000
 	bool "intel_s1000"
 	select XTENSA
+	select XTENSA_HAL if "$(ZEPHYR_TOOLCHAIN_VARIANT)" != "xcc"
 	select HAS_I2C_DW if I2C
 	select HAS_SPI_DW if SPI

--- a/soc/xtensa/sample_controller/Kconfig.soc
+++ b/soc/xtensa/sample_controller/Kconfig.soc
@@ -4,3 +4,4 @@
 config SOC_XTENSA_SAMPLE_CONTROLLER
 	bool "Xtensa sample_controller core"
 	select XTENSA
+	select XTENSA_HAL


### PR DESCRIPTION
This moves enabling XTENSA_HAL to the SoC definitions.
As Xtensa SoCs are highly configurable, it is possible
that the generic Xtensa HAL provided in the tree is
not suitable. So only enable XTENSA_HAL only if
the generic version can be used.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>