### PR TITLE
drivers: lora: sx1276: support more board designs

### DIFF
--- a/boards/arm/96b_wistrio/96b_wistrio.dts
+++ b/boards/arm/96b_wistrio/96b_wistrio.dts
@@ -73,6 +73,7 @@
 			<&gpioh 0 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
 			<&gpioc 13 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
 		spi-max-frequency = <1000000>;
+		power-amplifier-output = "pa-boost";
 	};
 };
 

--- a/drivers/lora/Kconfig.sx1276
+++ b/drivers/lora/Kconfig.sx1276
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-menuconfig LORA_SX1276
+config LORA_SX1276
 	bool "Semtech SX1276 driver"
 	select HAS_SEMTECH_RADIO_DRIVERS
 	select HAS_SEMTECH_LORAMAC
@@ -12,22 +12,3 @@ menuconfig LORA_SX1276
 	depends on SPI
 	help
 	  Enable LoRa driver for Semtech SX1276.
-
-choice
-	prompt "SX1276 PA Output pin"
-	default PA_BOOST_PIN
-	depends on LORA_SX1276
-	help
-	  Antenna connection type.
-
-config PA_RFO_PIN
-	bool "PA_RFO_PIN"
-	help
-	  Antenna connected to PA_RFO pin.
-
-config PA_BOOST_PIN
-	bool "PA_BOOST_PIN"
-	help
-	  Antenna connected to PA_BOOST pin.
-
-endchoice

--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -39,6 +39,16 @@ LOG_MODULE_REGISTER(sx1276);
 #define GPIO_PA_BOOST_ENABLE_FLAGS			\
 	DT_INST_GPIO_FLAGS(0, pa_boost_enable_gpios)
 
+#define GPIO_TCXO_POWER_PIN	DT_INST_GPIO_PIN(0, tcxo_power_gpios)
+#define GPIO_TCXO_POWER_FLAGS	DT_INST_GPIO_FLAGS(0, tcxo_power_gpios)
+
+#if DT_INST_NODE_HAS_PROP(0, tcxo_power_startup_delay_ms)
+#define TCXO_POWER_STARTUP_DELAY_MS			\
+	DT_INST_PROP(0, tcxo_power_startup_delay_ms)
+#else
+#define TCXO_POWER_STARTUP_DELAY_MS		0
+#endif
+
 /*
  * Those macros must be in sync with 'power-amplifier-output' dts property.
  */
@@ -106,6 +116,10 @@ static struct sx1276_data {
 	DT_INST_NODE_HAS_PROP(0, pa_boost_enable_gpios)
 	uint8_t tx_power;
 #endif
+#if DT_INST_NODE_HAS_PROP(0, tcxo_power_gpios)
+	struct device *tcxo_power;
+	bool tcxo_power_enabled;
+#endif
 	struct device *spi;
 	struct spi_config spi_cfg;
 	struct device *dio_dev[SX1276_MAX_DIO];
@@ -165,7 +179,25 @@ void SX1276SetAntSwLowPower(bool low_power)
 
 void SX1276SetBoardTcxo(uint8_t state)
 {
-	/* TODO */
+#if DT_INST_NODE_HAS_PROP(0, tcxo_power_gpios)
+	bool enable = state;
+
+	if (enable == dev_data.tcxo_power_enabled) {
+		return;
+	}
+
+	if (enable) {
+		gpio_pin_set(dev_data.tcxo_power, GPIO_TCXO_POWER_PIN, 1);
+
+		if (TCXO_POWER_STARTUP_DELAY_MS > 0) {
+			k_sleep(K_MSEC(TCXO_POWER_STARTUP_DELAY_MS));
+		}
+	} else {
+		gpio_pin_set(dev_data.tcxo_power, GPIO_TCXO_POWER_PIN, 0);
+	}
+
+	dev_data.tcxo_power_enabled = enable;
+#endif
 }
 
 void SX1276SetAntSw(uint8_t opMode)
@@ -192,6 +224,8 @@ void SX1276SetAntSw(uint8_t opMode)
 
 void SX1276Reset(void)
 {
+	SX1276SetBoardTcxo(true);
+
 	gpio_pin_configure(dev_data.reset, GPIO_RESET_PIN,
 			   GPIO_OUTPUT_ACTIVE | GPIO_RESET_FLAGS);
 
@@ -483,6 +517,19 @@ static int sx1276_lora_init(struct device *dev)
 	}
 
 	dev_data.spi_cfg.cs = &spi_cs;
+#endif
+
+#if DT_INST_NODE_HAS_PROP(0, tcxo_power_gpios)
+	dev_data.tcxo_power = device_get_binding(
+			DT_INST_GPIO_LABEL(0, tcxo_power_gpios));
+	if (!dev_data.tcxo_power) {
+		LOG_ERR("Cannot get pointer to %s device",
+		       DT_INST_GPIO_LABEL(0, tcxo_power_gpios));
+		return -EIO;
+	}
+
+	gpio_pin_configure(dev_data.tcxo_power, GPIO_TCXO_POWER_PIN,
+			   GPIO_OUTPUT_INACTIVE | GPIO_TCXO_POWER_FLAGS);
 #endif
 
 	/* Setup Reset gpio */

--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -23,6 +23,15 @@ LOG_MODULE_REGISTER(sx1276);
 #define GPIO_RESET_FLAGS	DT_INST_GPIO_FLAGS(0, reset_gpios)
 #define GPIO_CS_PIN		DT_INST_SPI_DEV_CS_GPIOS_PIN(0)
 
+#define PA_PIN			DT_ENUM_IDX(DT_DRV_INST(0),	\
+					    power_amplifier_output)
+
+/*
+ * Those macros must be in sync with 'power-amplifier-output' dts property.
+ */
+#define SX1276_PA_RFO				0
+#define SX1276_PA_BOOST				1
+
 #define SX1276_REG_PA_CONFIG			0x09
 #define SX1276_REG_PA_DAC			0x4d
 #define SX1276_REG_VERSION			0x42
@@ -239,7 +248,7 @@ void SX1276SetRfTxPower(int8_t power)
 
 	pa_dac &= RF_PADAC_20DBM_MASK;
 
-#if defined CONFIG_PA_BOOST_PIN
+#if PA_PIN == SX1276_PA_BOOST
 	power = clamp_int8(power, 2, 20);
 
 	pa_config |= RF_PACONFIG_PASELECT_PABOOST;
@@ -250,7 +259,7 @@ void SX1276SetRfTxPower(int8_t power)
 		pa_dac |= RF_PADAC_20DBM_OFF;
 		pa_config |= (power - 2) & 0x0F;
 	}
-#elif CONFIG_PA_RFO_PIN
+#elif PA_PIN == SX1276_PA_RFO
 	power = clamp_int8(power, -4, 15);
 
 	pa_dac |= RF_PADAC_20DBM_OFF;

--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -231,21 +231,11 @@ void SX1276SetRfTxPower(int8_t power)
 	uint8_t pa_config = 0;
 	uint8_t pa_dac = 0;
 
-	ret = sx1276_read(SX1276_REG_PA_CONFIG, &pa_config, 1);
-	if (ret < 0) {
-		LOG_ERR("Unable to read PA config");
-		return;
-	}
-
 	ret = sx1276_read(SX1276_REG_PA_DAC, &pa_dac, 1);
 	if (ret < 0) {
 		LOG_ERR("Unable to read PA dac");
 		return;
 	}
-
-	pa_config &= RF_PACONFIG_MAX_POWER_MASK;
-	pa_config &= RF_PACONFIG_OUTPUTPOWER_MASK;
-	pa_config &= RF_PACONFIG_PASELECT_MASK;
 
 	pa_dac &= RF_PADAC_20DBM_MASK;
 

--- a/dts/bindings/lora/semtech,sx1276.yaml
+++ b/dts/bindings/lora/semtech,sx1276.yaml
@@ -54,3 +54,15 @@ properties:
       required: false
       description: |
         PA_BOOST antenna output enable pin.
+
+    tcxo-power-gpios:
+      type: phandle-array
+      required: false
+      description: |
+        TCXO power enable pin.
+
+    tcxo-power-startup-delay-ms:
+      type: int
+      required: false
+      description: |
+        Delay which has to be applied after enabling TCXO power.

--- a/dts/bindings/lora/semtech,sx1276.yaml
+++ b/dts/bindings/lora/semtech,sx1276.yaml
@@ -37,6 +37,12 @@ properties:
          - "rfo"
          - "pa-boost"
 
+    antenna-enable-gpios:
+      type: phandle-array
+      required: false
+      description: |
+        Antenna power enable pin.
+
     rfi-enable-gpios:
       type: phandle-array
       required: false

--- a/dts/bindings/lora/semtech,sx1276.yaml
+++ b/dts/bindings/lora/semtech,sx1276.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2019, Manivannan Sadhasivam
+# Copyright (c) 2020, Grinn
 # SPDX-License-Identifier: Apache-2.0
 
 description: Semtech SX1276 LoRa Modem
@@ -24,3 +25,12 @@ properties:
         Up to six pins that produce service interrupts from the modem.
 
         These signals are normally active-high.
+
+    power-amplifier-output:
+      type: string
+      required: true
+      description: |
+        Selects power amplifier output pin.
+      enum:
+         - "rfo"
+         - "pa-boost"

--- a/dts/bindings/lora/semtech,sx1276.yaml
+++ b/dts/bindings/lora/semtech,sx1276.yaml
@@ -28,9 +28,29 @@ properties:
 
     power-amplifier-output:
       type: string
-      required: true
+      required: false
       description: |
-        Selects power amplifier output pin.
+        Selects power amplifier output pin. This is required when neither
+        'rfo-enable-gpios' nor 'pa-boost-enable-gpios' is specified. In other
+        case this property is simply ignored.
       enum:
          - "rfo"
          - "pa-boost"
+
+    rfi-enable-gpios:
+      type: phandle-array
+      required: false
+      description: |
+        RFI antenna input enable pin.
+
+    rfo-enable-gpios:
+      type: phandle-array
+      required: false
+      description: |
+        RFO antenna output enable pin.
+
+    pa-boost-enable-gpios:
+      type: phandle-array
+      required: false
+      description: |
+        PA_BOOST antenna output enable pin.

--- a/tests/drivers/build_all/spi.dtsi
+++ b/tests/drivers/build_all/spi.dtsi
@@ -208,6 +208,7 @@ test_spi_sx1276: sx1276@13 {
 	spi-max-frequency = <0>;
 	reset-gpios = <&test_gpio 0 0>;
 	dio-gpios = <&test_gpio 0 0>;
+	power-amplifier-output = "rfo";
 };
 
 test_spi_st7789v: st7789v@14 {


### PR DESCRIPTION
This MR implements several new device-tree properties that will allow to configure sx1276 support on various board designs. Those are basically antenna selection pins and crystal enable pin.

Additionally one Kconfig option (power amplifier output selection) has been converted to device-tree enum string, as it is related strictly to device (PCB) design.