### PR TITLE
drivers: dma: stm32: Stream disable success

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -391,6 +391,7 @@ int dma_stm32_disable_stream(DMA_TypeDef *dma, u32_t id)
 
 	for (;;) {
 		if (!stm32_dma_disable_stream(dma, id)) {
+			return 0;
 		}
 		/* After trying for 5 seconds, give up */
 		if (count++ > (5 * 1000)) {


### PR DESCRIPTION
When a DMA stream is successfully disabled, the function should immediately
return with a success status.

Signed-off-by: Abe Kohandel <abe@electronshepherds.com>