### PR TITLE
drivers: i2s: stm32: Add I2S master clock output

### DIFF
--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -223,6 +223,13 @@ static int i2s_stm32_configure(struct device *dev, enum i2s_dir dir,
 		return ret;
 	}
 
+	/* set I2S Master Clock */
+	if (stream->master) {
+		LL_I2S_EnableMasterClock(cfg->i2s);
+	} else {
+		LL_I2S_DisableMasterClock(cfg->i2s);
+	}
+
 	/* set I2S Data Format */
 	if (i2s_cfg->word_size == 16U) {
 		LL_I2S_SetDataFormat(cfg->i2s, LL_I2S_DATAFORMAT_16B);


### PR DESCRIPTION
Some external audio devices require a master clock to be provided by
the I2S peripheral to work correctly. To allow for the operation of
these devices the master clock output should always be enabled when in
master mode.

Specific applications requiring this signal to be output can configure
the desitnation pin via the pinmux driver.