### PR TITLE
modules: hal_nordic: Fix inclusions in nrfx glue layer

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -53,7 +53,7 @@ manifest:
       revision: a12d92816a53a521d79cefcf5c38b9dc8a4fed6e
       path: modules/hal/cypress
     - name: hal_nordic
-      revision: 5505d0baa66a89848f643120fafad232876df695
+      revision: pull/33/head
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 3b54187649cc9b37161d49918f1ad28ff7c7f830


### PR DESCRIPTION
Update the hal_nordic module revision so that the following commit
is applied:

nrfx_glue: Move #include directives outside of extern "C" blocks

To prevent compilation errors when some C++ elements, like a
template definition, happen to appear in those included files or files
included by them.

Fixes #23850.

https://github.com/zephyrproject-rtos/hal_nordic/pull/33 needs to go in first.