### PR TITLE
drivers: dma: i2s: stm32: I2S Master DMA support

### DIFF
--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -839,7 +839,7 @@ static struct device *get_dev_from_tx_dma_channel(u32_t dma_channel)
 	return active_dma_tx_channel[dma_channel];
 }
 
-/* src_dev and dest_dev should be 'MEM' or 'PERIPH'. */
+/* src_dev and dest_dev should be 'MEMORY' or 'PERIPHERAL'. */
 #define I2S_DMA_CHANNEL_INIT(index, dir, dir_cap, src_dev, dest_dev)	\
 .dir = {								\
 	.dma_name = DT_I2S_##index##_DMA_CONTROLLER_##dir_cap,		\
@@ -847,7 +847,7 @@ static struct device *get_dev_from_tx_dma_channel(u32_t dma_channel)
 	.dma_cfg = {							\
 		.block_count = 2,					\
 		.dma_slot = DT_I2S_##index##_DMA_SLOT_##dir_cap,	\
-		.channel_direction = PERIPHERAL_TO_MEMORY,		\
+		.channel_direction = src_dev##_TO_##dest_dev,		\
 		.source_data_size = 2,  /* 16bit default */		\
 		.dest_data_size = 2,    /* 16bit default */		\
 		.source_burst_length = 0, /* SINGLE transfer */		\
@@ -888,8 +888,8 @@ struct queue_item rx_##index##_ring_buf[CONFIG_I2S_STM32_RX_BLOCK_COUNT + 1];\
 struct queue_item tx_##index##_ring_buf[CONFIG_I2S_STM32_TX_BLOCK_COUNT + 1];\
 									\
 static struct i2s_stm32_data i2s_stm32_data_##index = {			\
-	I2S_DMA_CHANNEL_INIT(index, rx, RX, PERIPH, MEM),		\
-	I2S_DMA_CHANNEL_INIT(index, tx, TX, MEM, PERIPH),		\
+	I2S_DMA_CHANNEL_INIT(index, rx, RX, PERIPHERAL, MEMORY),	\
+	I2S_DMA_CHANNEL_INIT(index, tx, TX, MEMORY, PERIPHERAL),	\
 };									\
 DEVICE_AND_API_INIT(i2s_stm32_##index, DT_I2S_##index##_NAME,		\
 		    &i2s_stm32_initialize, &i2s_stm32_data_##index,	\

--- a/include/dt-bindings/dma/stm32_dma.h
+++ b/include/dt-bindings/dma/stm32_dma.h
@@ -5,11 +5,11 @@
  */
 /* macros for channel-config */
 #define STM32_DMA_CONFIG_DIRECTION(config)		(config & 0x3 << 6)
-#define STM32_DMA_CONFIG_PERIPH_ADDR_INC(config)	(config & 0x1 << 9)
-#define STM32_DMA_CONFIG_MEM_ADDR_INC(config)		(config & 0x1 << 10)
-#define STM32_DMA_CONFIG_PERIPH_DATA_SIZE(config)	(config & (0x3 << 11))
-#define STM32_DMA_CONFIG_MEM_DATA_SIZE(config)		(config & (0x3 << 13))
-#define STM32_DMA_CONFIG_PERIPH_INC_FIXED(config)	(config & 0x1 << 15)
+#define STM32_DMA_CONFIG_PERIPHERAL_ADDR_INC(config)	(config & 0x1 << 9)
+#define STM32_DMA_CONFIG_MEMORY_ADDR_INC(config)	(config & 0x1 << 10)
+#define STM32_DMA_CONFIG_PERIPHERAL_DATA_SIZE(config)	(config & (0x3 << 11))
+#define STM32_DMA_CONFIG_MEMORY_DATA_SIZE(config)	(config & (0x3 << 13))
+#define STM32_DMA_CONFIG_PERIPHERAL_INC_FIXED(config)	(config & 0x1 << 15)
 #define STM32_DMA_CONFIG_PRIORITY(config)		((config >> 16) & 0x3)
 
 /* macros for features */


### PR DESCRIPTION
When configuring the I2S peripheral as a master, the DMA channel
direction must be configured to transfer data from memory to the
peripheral.

Currently the configuration of channel direction is always set for
peripheral to memory regardless of whether it is the TX or the RX
channel.

Signed-off-by: Abe Kohandel <abe@electronshepherds.com>