### PR TITLE
drivers: dma: stm32: DMA V1 channel direction

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -227,7 +227,7 @@ static int dma_stm32_configure(struct device *dev, u32_t id,
 	}
 
 #ifdef CONFIG_DMA_STM32_V1
-	if ((stream->direction == MEMORY_TO_MEMORY) &&
+	if ((config->channel_direction == MEMORY_TO_MEMORY) &&
 		(!dev_config->support_m2m)) {
 		LOG_ERR("Memcopy not supported for device %s",
 			dev->config->name);


### PR DESCRIPTION
The channel direction for a V1 DMA is not allowed to be memory to memory
and there is a check in place for this. However, the check is being
performed on the stream prior to actually configuring the stream. This
results in the check always failing regardless of the channel direction.

The check has been modified to be performed on the incoming
configuration.

Signed-off-by: Abe Kohandel <abe@electronshepherds.com>