### PR TITLE
Bluetooth: Mesh: Fixes duplicated close callback

### DIFF
--- a/subsys/bluetooth/mesh/pb_gatt.c
+++ b/subsys/bluetooth/mesh/pb_gatt.c
@@ -46,10 +46,6 @@ static void protocol_timeout(struct k_work *work)
 
 	BT_DBG("Protocol timeout");
 
-	if (link.conn) {
-		bt_mesh_pb_gatt_close(link.conn);
-	}
-
 	reset_state();
 
 	cb->link_closed(&pb_gatt, link.cb_data,


### PR DESCRIPTION
When PB-GATT Procedure timeout, func `bt_mesh_pb_gatt_close`
will also dumplicated with `link_closed()`

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>