### PR TITLE
net: sntp: close socket when connect failed

### DIFF
--- a/subsys/net/lib/sntp/sntp.c
+++ b/subsys/net/lib/sntp/sntp.c
@@ -158,6 +158,7 @@ int sntp_init(struct sntp_ctx *ctx, struct sockaddr *addr, socklen_t addr_len)
 
 	ret = connect(ctx->sock.fd, addr, addr_len);
 	if (ret < 0) {
+		(void)close(ctx->sock.fd);
 		NET_ERR("Cannot connect to UDP remote : %d", errno);
 		return -errno;
 	}


### PR DESCRIPTION
The socket must be closed when the connection failed

Signed-off-by: Julien D'Ascenzio <julien.dascenzio@paratronic.fr>