### PR TITLE
test: dma: Fix k_sleep() parameter error

### DIFF
--- a/tests/drivers/dma/loop_transfer/src/dma.c
+++ b/tests/drivers/dma/loop_transfer/src/dma.c
@@ -103,7 +103,7 @@ void main(void)
 		return;
 	}
 
-	k_sleep(SLEEPTIME);
+	k_sleep(K_MSEC(SLEEPTIME));
 
 	if (transfer_count < TRANSFER_LOOPS) {
 		transfer_count = TRANSFER_LOOPS;


### PR DESCRIPTION
Sleeping milliseconds should use k_sleep(K_MSEC(x)) rather than
k_sleep(x).