### PR TITLE
Add SPI FIFO support for STM32 F7

### DIFF
--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -270,7 +270,7 @@
 		};
 
 		spi1: spi@40013000 {
-			compatible = "st,stm32-spi";
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
@@ -281,7 +281,7 @@
 		};
 
 		spi2: spi@40003800 {
-			compatible = "st,stm32-spi";
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
@@ -292,7 +292,7 @@
 		};
 
 		spi3: spi@40003c00 {
-			compatible = "st,stm32-spi";
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
@@ -303,7 +303,7 @@
 		};
 
 		spi4: spi@40013400 {
-			compatible = "st,stm32-spi";
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013400 0x400>;
@@ -314,7 +314,7 @@
 		};
 
 		spi5: spi@40015000 {
-			compatible = "st,stm32-spi";
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40015000 0x400>;
@@ -325,7 +325,7 @@
 		};
 
 		spi6: spi@40015400 {
-			compatible = "st,stm32-spi";
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40015400 0x400>;

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -324,17 +324,6 @@
 			label = "SPI_5";
 		};
 
-		spi6: spi@40015400 {
-			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015400 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00200000>;
-			interrupts = <86 5>;
-			status = "disabled";
-			label = "SPI_6";
-		};
-
 		can1: can@40006400 {
 			compatible = "st,stm32-can";
 			#address-cells = <1>;

--- a/dts/arm/st/f7/stm32f746.dtsi
+++ b/dts/arm/st/f7/stm32f746.dtsi
@@ -54,5 +54,16 @@
 			status = "disabled";
 			label = "I2C_4";
 		};
+
+		spi6: spi@40015400 {
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40015400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00200000>;
+			interrupts = <86 5>;
+			status = "disabled";
+			label = "SPI_6";
+		};
 	};
 };

--- a/dts/arm/st/f7/stm32f767.dtsi
+++ b/dts/arm/st/f7/stm32f767.dtsi
@@ -56,5 +56,16 @@
 			status = "disabled";
 			label = "I2C_4";
 		};
+
+		spi6: spi@40015400 {
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40015400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00200000>;
+			interrupts = <86 5>;
+			status = "disabled";
+			label = "SPI_6";
+		};
 	};
 };

--- a/dts/arm/st/f7/stm32f769.dtsi
+++ b/dts/arm/st/f7/stm32f769.dtsi
@@ -54,5 +54,16 @@
 			status = "disabled";
 			label = "I2C_4";
 		};
+
+		spi6: spi@40015400 {
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40015400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00200000>;
+			interrupts = <86 5>;
+			status = "disabled";
+			label = "SPI_6";
+		};
 	};
 };


### PR DESCRIPTION
Add SPI FIFO support for STM32 F7.
By the way, SPI6 is not supported by all F7 devices:  STM32F723 doesn't support SPI6.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/23677