### PR TITLE
Bluetooth: host: Fix scan filter_dup parameter on big endian systems

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -747,7 +747,7 @@ struct bt_le_scan_param {
 
 	union {
 		/** Bit-field of scanning filter options. */
-		u8_t  filter_dup __deprecated;
+		u32_t filter_dup __deprecated;
 
 		/** Bit-field of scanning options. */
 		u32_t options;


### PR DESCRIPTION
Fix filter_dup and options in union with mixed size integral types,
this is not portable, and causes malfunction on big-endian systems.

Fixes: #24180