### PR TITLE
Bluetooth: host: Do not set adv random address before adv parameters

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -7445,7 +7445,7 @@ int bt_le_adv_start_ext(struct bt_le_ext_adv *adv,
 	};
 	bool dir_adv = (peer != NULL);
 	struct bt_conn *conn = NULL;
-	int err = 0;
+	int err;
 
 	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
 		return -EAGAIN;
@@ -7461,8 +7461,11 @@ int bt_le_adv_start_ext(struct bt_le_ext_adv *adv,
 
 	adv->id = param->id;
 
-	le_ext_adv_param_set(adv, param, peer,
-			     sd || (param->options & BT_LE_ADV_OPT_USE_NAME));
+	err = le_ext_adv_param_set(adv, param, peer, sd ||
+				   (param->options & BT_LE_ADV_OPT_USE_NAME));
+	if (err) {
+		return err;
+	}
 
 	if (!dir_adv) {
 		err = le_adv_update(adv, ad, ad_len, sd, sd_len,

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -67,10 +67,22 @@ enum {
 				 BIT(BT_DEV_PRESET_ID))
 
 enum {
+	/* Advertising set has been created in the host. */
 	BT_ADV_CREATED,
-
+	/* Advertising parameters has been set in the controller.
+	 * This implies that the advertising set has been created in the
+	 * controller.
+	 */
+	BT_ADV_PARAMS_SET,
+	/* Advertising random address pending to be set in the controller. */
+	BT_ADV_RANDOM_ADDR_PENDING,
+	/* The private random address of the advertiser is valid for this cycle
+	 * of the RPA timeout.
+	 */
 	BT_ADV_RPA_VALID,
-
+	/* The advertiser set is limited by a timeout, or number of advertising
+	 * events, or both.
+	 */
 	BT_ADV_LIMITED,
 
 	BT_ADV_NUM_FLAGS,


### PR DESCRIPTION
The LE Set Extended Advertising Set Random Address command may be
issued at any time after an advertising set identified by
the Advertising Handle parameter has been created using the
LE Set Extended Advertising Parameters command.

This commit fixes the advertising set issueing the set random address
command before the advertising set is created in the controller.
Since the le_adv_set_random_addr function has is used to get the the
own address parameter for the it could not simply be moved, and
moving the own address parameter handling out of this function
would create a potentioal maintaince problem.
Also this function is used for both with and without advertising
extension feature so changing it is not trivial without breaking all
the previous random address handling already put in place.
The simplest solution was therefore to postpone the command until the
parameters has been set using 2 flags.

Check the return value of LE Set Extended Advertising Parameters
command when starting an advertiser from bt_le_adv_start with
CONFIG_BT_EXT_ADV enabled.