### PR TITLE
doc: lock breathe version to a compatible one

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,6 +1,6 @@
 # DOC: used to generate docs
 
-breathe>=4.9.1
+breathe>=4.9.1,<4.15.0
 docutils>=0.14
 sphinx>=1.7.5,<3.0
 sphinx_rtd_theme


### PR DESCRIPTION
After Sphinx released 3.0.0, breathe came up with 4.15.0 to match the
functionality, but 4.15.0 turns out not to be quite compatible with
Sphinx < 3.0.0, so lock it to the last good known version, 4.14.2.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>