### PR TITLE
Bluetooth: controller: Fix Peer Address Type in Conn Complete

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -2876,7 +2876,7 @@ static void le_conn_complete(struct pdu_data *pdu_data, u16_t handle,
 	lecc->status = 0x00;
 	lecc->handle = sys_cpu_to_le16(handle);
 	lecc->role = node_rx->role;
-	lecc->peer_addr.type = node_rx->peer_addr_type;
+	lecc->peer_addr.type = node_rx->peer_addr_type & 0x1;
 	memcpy(&lecc->peer_addr.a.val[0], &node_rx->peer_addr[0], BDADDR_SIZE);
 	lecc->interval = sys_cpu_to_le16(node_rx->interval);
 	lecc->latency = sys_cpu_to_le16(node_rx->latency);


### PR DESCRIPTION
The LE Connection Complete HCI event, unlike its Enhanced counterpart,
only uses 0x0 and 0x1 for Peer Address Type. Fix it so that it reflects
the specification correctly.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>