### PR TITLE
drivers: flash: Use DT_INST_LABEL instead of DT_FLASH_DEV_NAME

### DIFF
--- a/drivers/flash/flash_gecko.c
+++ b/drivers/flash/flash_gecko.c
@@ -206,6 +206,6 @@ static const struct flash_driver_api flash_gecko_driver_api = {
 
 static struct flash_gecko_data flash_gecko_0_data;
 
-DEVICE_AND_API_INIT(flash_gecko_0, DT_FLASH_DEV_NAME,
+DEVICE_AND_API_INIT(flash_gecko_0, DT_INST_LABEL(0),
 		    flash_gecko_init, &flash_gecko_0_data, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_gecko_driver_api);

--- a/drivers/flash/flash_sam.c
+++ b/drivers/flash/flash_sam.c
@@ -352,7 +352,7 @@ static const struct flash_sam_dev_cfg flash_sam_cfg = {
 
 static struct flash_sam_dev_data flash_sam_data;
 
-DEVICE_AND_API_INIT(flash_sam, DT_FLASH_DEV_NAME,
+DEVICE_AND_API_INIT(flash_sam, DT_INST_LABEL(0),
 		    flash_sam_init, &flash_sam_data, &flash_sam_cfg,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &flash_sam_api);

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -382,6 +382,6 @@ static int stm32_flash_init(struct device *dev)
 	return flash_stm32_write_protection(dev, false);
 }
 
-DEVICE_AND_API_INIT(stm32_flash, DT_FLASH_DEV_NAME,
+DEVICE_AND_API_INIT(stm32_flash, DT_INST_LABEL(0),
 		    stm32_flash_init, &flash_data, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_stm32_api);

--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -171,6 +171,6 @@ static int flash_mcux_init(struct device *dev)
 	return (rc == kStatus_Success) ? 0 : -EIO;
 }
 
-DEVICE_AND_API_INIT(flash_mcux, DT_FLASH_DEV_NAME,
+DEVICE_AND_API_INIT(flash_mcux, DT_INST_LABEL(0),
 			flash_mcux_init, &flash_data, NULL, POST_KERNEL,
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_mcux_api);

--- a/drivers/flash/soc_flash_rv32m1.c
+++ b/drivers/flash/soc_flash_rv32m1.c
@@ -164,6 +164,6 @@ static int flash_mcux_init(struct device *dev)
 	return (rc == kStatus_Success) ? 0 : -EIO;
 }
 
-DEVICE_AND_API_INIT(flash_mcux, DT_FLASH_DEV_NAME,
+DEVICE_AND_API_INIT(flash_mcux, DT_INST_LABEL(0),
 			flash_mcux_init, &flash_data, NULL, POST_KERNEL,
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_mcux_api);


### PR DESCRIPTION
Replace use of DT_FLASH_DEV_NAME with DT_INST_LABEL in drivers as we
want to phase out DT_FLASH_DEV_NAME.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>