### PR TITLE
[v2.2.x] ci: do not use latest sphinx/breathe releases for docs

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -30,8 +30,8 @@ jobs:
     - name: install-pip
       run: |
         pip3 install setuptools
-        pip3 install 'breathe>=4.9.1' 'docutils>=0.14' \
-                     'sphinx>=1.7.5' sphinx_rtd_theme sphinx-tabs \
+        pip3 install 'breathe>=4.9.1,<4.15.0' 'docutils>=0.14' \
+                     'sphinx>=1.7.5,<3.0' sphinx_rtd_theme sphinx-tabs \
                      sphinxcontrib-svg2pdfconverter 'west>=0.6.2'
         pip3 install pyelftools
 

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -61,8 +61,8 @@ jobs:
     - name: install-pip
       run: |
         pip3 install setuptools
-        pip3 install 'breathe>=4.9.1' 'docutils>=0.14' \
-                     'sphinx>=1.7.5' sphinx_rtd_theme sphinx-tabs \
+        pip3 install 'breathe>=4.9.1,<4.15.0' 'docutils>=0.14' \
+                     'sphinx>=1.7.5,<3.0' sphinx_rtd_theme sphinx-tabs \
                      sphinxcontrib-svg2pdfconverter 'west>=0.6.2'
         pip3 install pyelftools
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,7 +1,7 @@
 Pillow
 PyYAML>=5.1
 anytree
-breathe>=4.9.1
+breathe>=4.9.1,<4.15.0
 colorama
 docutils>=0.14
 gcovr>=4.2
@@ -15,7 +15,7 @@ pykwalify
 pyocd>=0.24.0
 pyserial
 pytest
-sphinx>=1.7.5
+sphinx>=1.7.5,<3.0.0
 sphinx_rtd_theme
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
Sphinx version 3.0.0 release recently break doc build, lock version
of sphinx to something compatible while we upgrade dependencies...

breathe v4.15.0 was just released and fixes some compatibility issues
with latest sphinx, the combo works, however with many warnings that we
still need to either fix or whitelist. This is temporary until we are
able to use those new versions.

Backport of #24109 and #24166

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>