### PR TITLE
modules: cmsis: Add CMSIS-Core(A) configurations

### DIFF
--- a/modules/Kconfig.cmsis
+++ b/modules/Kconfig.cmsis
@@ -3,15 +3,19 @@
 
 config HAS_CMSIS_CORE
 	bool
-	select HAS_CMSIS_CORE_M if CPU_CORTEX_M
+	select HAS_CMSIS_CORE_A if CPU_CORTEX_A
 	select HAS_CMSIS_CORE_R if CPU_CORTEX_R
+	select HAS_CMSIS_CORE_M if CPU_CORTEX_M
 
 if HAS_CMSIS_CORE
 
-config HAS_CMSIS_CORE_M
+config HAS_CMSIS_CORE_A
 	bool
 
 config HAS_CMSIS_CORE_R
+	bool
+
+config HAS_CMSIS_CORE_M
 	bool
 
 endif

--- a/west.yml
+++ b/west.yml
@@ -26,7 +26,7 @@ manifest:
   # Please add items below based on alphabetical order
   projects:
     - name: cmsis
-      revision: a2b82e79bd8ac156fb283d5f52fa0a2373962cf9
+      revision: 026671fc99ef7e3ca94a575f89210fce5a94747d
       path: modules/hal/cmsis
     - name: hal_atmel
       revision: 917bfefa5188a473ff49087f1fa207cbb42bf592


### PR DESCRIPTION
```
This commit updates the west.yml to point to the commit that adds the
CMSIS-Core(A) and defines the configurations to enable it, in
preparation for the AArch32 Cortex-A architecture support in Zephyr.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```

NOTE: Do not merge until https://github.com/zephyrproject-rtos/cmsis/pull/2 is merged and the `west.yml` is updated to point to the merged commit.