### PR TITLE
drivers: hwinfo: fix endianness for sam0 and nrf

### DIFF
--- a/doc/releases/release-notes-2.3.rst
+++ b/doc/releases/release-notes-2.3.rst
@@ -21,6 +21,19 @@ No security vulnerabilities received.
 API Changes
 ***********
 
+* HWINFO
+
+  * The identifier data structure for hwinfo drivers is clarified.  Drivers are
+    responsible for ensuring that the identifier data structure is a sequence
+    of bytes. The returned ID value is not supposed to be interpreted based on
+    vendor-specific assumptions of byte order and should express the identifier
+    as a raw byte sequence.
+    The changes have an impact on users that use the hwinfo API to identify
+    their devices.
+    The sam0 driver byte swaps each 32 bit word of the 128 bit identifier to
+    big endian.
+    The nordic driver byte swaps the entire 64 bit word to big endian.
+
 Deprecated in this release
 ==========================
 

--- a/drivers/hwinfo/hwinfo_nrf.c
+++ b/drivers/hwinfo/hwinfo_nrf.c
@@ -8,6 +8,7 @@
 #include <drivers/hwinfo.h>
 #include <string.h>
 #include <hal/nrf_ficr.h>
+#include <sys/byteorder.h>
 
 struct nrf_uid {
 	u32_t id[2];
@@ -17,8 +18,8 @@ ssize_t z_impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
 {
 	struct nrf_uid dev_id;
 
-	dev_id.id[0] = nrf_ficr_deviceid_get(NRF_FICR, 0);
-	dev_id.id[1] = nrf_ficr_deviceid_get(NRF_FICR, 1);
+	dev_id.id[0] = sys_cpu_to_be32(nrf_ficr_deviceid_get(NRF_FICR, 1));
+	dev_id.id[1] = sys_cpu_to_be32(nrf_ficr_deviceid_get(NRF_FICR, 0));
 
 	if (length > sizeof(dev_id.id)) {
 		length = sizeof(dev_id.id);

--- a/drivers/hwinfo/hwinfo_sam0.c
+++ b/drivers/hwinfo/hwinfo_sam0.c
@@ -9,6 +9,7 @@
 #include <soc.h>
 #include <drivers/hwinfo.h>
 #include <string.h>
+#include <sys/byteorder.h>
 
 struct sam0_uid {
 	u32_t id[4];
@@ -18,10 +19,14 @@ ssize_t z_impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
 {
 	struct sam0_uid dev_id;
 
-	dev_id.id[0] = *(const u32_t *) DT_INST_REG_ADDR_BY_IDX(0, 0);
-	dev_id.id[1] = *(const u32_t *) DT_INST_REG_ADDR_BY_IDX(0, 1);
-	dev_id.id[2] = *(const u32_t *) DT_INST_REG_ADDR_BY_IDX(0, 2);
-	dev_id.id[3] = *(const u32_t *) DT_INST_REG_ADDR_BY_IDX(0, 3);
+	dev_id.id[0] = sys_cpu_to_be32(*(const u32_t *)
+				       DT_INST_REG_ADDR_BY_IDX(0, 0));
+	dev_id.id[1] = sys_cpu_to_be32(*(const u32_t *)
+				       DT_INST_REG_ADDR_BY_IDX(0, 1));
+	dev_id.id[2] = sys_cpu_to_be32(*(const u32_t *)
+				       DT_INST_REG_ADDR_BY_IDX(0, 2));
+	dev_id.id[3] = sys_cpu_to_be32(*(const u32_t *)
+				       DT_INST_REG_ADDR_BY_IDX(0, 3));
 
 	if (length > sizeof(dev_id.id)) {
 		length = sizeof(dev_id.id);

--- a/include/drivers/hwinfo.h
+++ b/include/drivers/hwinfo.h
@@ -37,6 +37,12 @@ extern "C" {
  * If the device ID is smaller then length, the rest of the buffer is left unchanged.
  * The ID depends on the hardware and is not guaranteed unique.
  *
+ * Drivers are responsible for ensuring that the ID data structure is a
+ * sequence of bytes.  The returned ID value is not supposed to be interpreted
+ * based on vendor-specific assumptions of byte order. It should express the
+ * identifier as a raw byte sequence, doing any endian conversion necessary so
+ * that a hex representation of the bytes produces the intended serial number.
+ *
  * @param buffer  Buffer to write the ID to.
  * @param length  Max length of the buffer.
  *


### PR DESCRIPTION
HWINFO drivers should be responsible for ensuring that
 the data structure is a sequence of bytes. That is not
 what the current sam0 and nordic drivers do. The drivers
 read the data as u32_t and then memcpy the data to a
 buffer. This ensures the data has the endianness of the
 underlying MCU, which in this case is Cortex M0 which
 is little endian.

 This commit fixes the endianness so the data can be
 interpreted as a "left to right sequence of bytes".

 Fixes #23444
Fixes #24103

