### PR TITLE
edtlib: handle include in child-binding

### DIFF
--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -424,6 +424,9 @@ class EDT:
                 _err("'include:' in {} should be a string or a list of strings"
                      .format(binding_path))
 
+        if "child-binding" in binding and "include" in binding["child-binding"]:
+            self._merge_included_bindings(binding["child-binding"], binding_path)
+
         # Legacy syntax
         if "inherits" in binding:
             self._warn("the 'inherits:' syntax in {} is deprecated and will "


### PR DESCRIPTION
Support the ability for there to be an include in a child-binding
section.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>