### PR TITLE
cmake: fix bug in generated runners.yaml

### DIFF
--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -73,7 +73,7 @@ function(create_runners_yaml)
       endforeach()
     else()
       # If the runner doesn't need any arguments, just use an empty list.
-      runner_yml_write(" []\n")
+      runner_yml_write("    []\n")
     endif()
   endforeach()
 


### PR DESCRIPTION
If a runner had no args, the format of the generated runners.yaml
was invalid due to missing indentation.

This commit fixes this issue by adding the required indentation.

Fixes #24215

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>