### PR TITLE
samples/sensor/sensor_shell: removed deprecated set_conf_file

### DIFF
--- a/samples/sensor/sensor_shell/CMakeLists.txt
+++ b/samples/sensor/sensor_shell/CMakeLists.txt
@@ -1,13 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.8.2)
-macro(set_conf_file)
-  if(EXISTS               ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf)
-    set(CONF_FILE "prj.conf ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf")
-  else()
-    set(CONF_FILE "prj.conf")
-  endif()
-endmacro()
 
 find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 project(sensor_shell)


### PR DESCRIPTION
The samples/sensor/sensor_shell sample was introduced after deprecation
of `set_conf_file` and thus was not adopted to the new recommended board
conf file overlay.

This commit align this sample with the rest of Zephyr's samples.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>