### PR TITLE
CODEOWNERS: Add @Mierunski and @anangl for nRF UART drivers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -200,6 +200,7 @@
 /drivers/sensor/st*/                      @avisconti
 /drivers/serial/uart_altera_jtag_hal.c    @wentongwu
 /drivers/serial/*ns16550*                 @andrewboie
+/drivers/serial/*nrfx*                    @Mierunski @anangl
 /drivers/serial/Kconfig.litex             @mateusz-holenko @kgugala @pgielda
 /drivers/serial/uart_liteuart.c           @mateusz-holenko @kgugala @pgielda
 /drivers/serial/Kconfig.rtt               @carlescufi @pkral78


### PR DESCRIPTION
Add code owners for nRF UART drivers and the corresponding Kconfig file
so that some reviewers are automatically assigned for these files.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>