### PR TITLE
arch: arm: minor fixes in the docs for ARM kernel_arch headers

### DIFF
--- a/arch/arm/include/aarch32/kernel_arch_func.h
+++ b/arch/arm/include/aarch32/kernel_arch_func.h
@@ -9,7 +9,8 @@
  * @brief Private kernel definitions (ARM)
  *
  * This file contains private kernel function definitions and various
- * other definitions for the ARM Cortex-M processor architecture family.
+ * other definitions for the 32-bit ARM Cortex-A/R/M processor architecture
+ * family.
  *
  * This file is also included by assembly language files which must #define
  * _ASMLANGUAGE before including this header file.  Note that kernel

--- a/arch/arm/include/kernel_arch_data.h
+++ b/arch/arm/include/kernel_arch_data.h
@@ -9,7 +9,7 @@
  * @brief Private kernel definitions (ARM)
  *
  * This file contains private kernel structures definitions and various
- * other definitions for the ARM Cortex-M processor architecture family.
+ * other definitions for the ARM Cortex-A/R/M processor architecture family.
  *
  * This file is also included by assembly language files which must #define
  * _ASMLANGUAGE before including this header file.  Note that kernel


### PR DESCRIPTION
Fix documentation in kernel_arch_data.h and kernel_arch_func.h
headers for ARM, to indicate that these are common headers for
all ARM architecture variants.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>