### PR TITLE
dts: soc: atmel: sam: Add pinctl container node

### DIFF
--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -124,54 +124,61 @@
 			label = "USART_3";
 		};
 
-		pioa: pio@400e0e00 {
-			compatible = "atmel,sam-gpio";
-			reg = <0x400e0e00 0x190>;
-			interrupts = <11 1>;
-			peripheral-id = <11>;
-			label = "PIO_A";
-			gpio-controller;
-			#gpio-cells = <2>;
-		};
+		pinctrl@400e0e00 {
+			compatible = "atmel,sam-pinctrl";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x400e0e00 0x400e0e00 0xc00>;
 
-		piob: pio@400e1000 {
-			compatible = "atmel,sam-gpio";
-			reg = <0x400e1000 0x190>;
-			interrupts = <12 1>;
-			peripheral-id = <12>;
-			label = "PIO_B";
-			gpio-controller;
-			#gpio-cells = <2>;
-		};
+			pioa: pio@400e0e00 {
+				compatible = "atmel,sam-gpio";
+				reg = <0x400e0e00 0x190>;
+				interrupts = <11 1>;
+				peripheral-id = <11>;
+				label = "PIO_A";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
 
-		pioc: pio@400e1200 {
-			compatible = "atmel,sam-gpio";
-			reg = <0x400e1200 0x190>;
-			interrupts = <13 1>;
-			peripheral-id = <13>;
-			label = "PIO_C";
-			gpio-controller;
-			#gpio-cells = <2>;
-		};
+			piob: pio@400e1000 {
+				compatible = "atmel,sam-gpio";
+				reg = <0x400e1000 0x190>;
+				interrupts = <12 1>;
+				peripheral-id = <12>;
+				label = "PIO_B";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
 
-		piod: pio@400e1400 {
-			compatible = "atmel,sam-gpio";
-			reg = <0x400e1400 0x190>;
-			interrupts = <14 1>;
-			peripheral-id = <14>;
-			label = "PIO_D";
-			gpio-controller;
-			#gpio-cells = <2>;
-		};
+			pioc: pio@400e1200 {
+				compatible = "atmel,sam-gpio";
+				reg = <0x400e1200 0x190>;
+				interrupts = <13 1>;
+				peripheral-id = <13>;
+				label = "PIO_C";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
 
-		pioe: pio@400e1600 {
-			compatible = "atmel,sam-gpio";
-			reg = <0x400e1600 0x190>;
-			interrupts = <15 1>;
-			peripheral-id = <15>;
-			label = "PIO_E";
-			gpio-controller;
-			#gpio-cells = <2>;
+			piod: pio@400e1400 {
+				compatible = "atmel,sam-gpio";
+				reg = <0x400e1400 0x190>;
+				interrupts = <14 1>;
+				peripheral-id = <14>;
+				label = "PIO_D";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
+
+			pioe: pio@400e1600 {
+				compatible = "atmel,sam-gpio";
+				reg = <0x400e1600 0x190>;
+				interrupts = <15 1>;
+				peripheral-id = <15>;
+				label = "PIO_E";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
 		};
 	};
 };

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -125,54 +125,61 @@
 			label = "USART_1";
 		};
 
-		pioa: gpio@400e0e00 {
-			compatible = "atmel,sam-gpio";
-			reg = <0x400e0e00 0x200>;
-			interrupts = <9 1>;
-			peripheral-id = <9>;
-			label = "PORTA";
-			gpio-controller;
-			#gpio-cells = <2>;
-		};
+		pinctrl@400e0e00 {
+			compatible = "atmel,sam-pinctrl";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x400e0e00 0x400e0e00 0xa00>;
 
-		piob: gpio@400e1000 {
-			compatible = "atmel,sam-gpio";
-			reg = <0x400e1000 0x200>;
-			interrupts = <10 1>;
-			peripheral-id = <10>;
-			label = "PORTB";
-			gpio-controller;
-			#gpio-cells = <2>;
-		};
+			pioa: gpio@400e0e00 {
+				compatible = "atmel,sam-gpio";
+				reg = <0x400e0e00 0x200>;
+				interrupts = <9 1>;
+				peripheral-id = <9>;
+				label = "PORTA";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
 
-		pioc: gpio@400e1200 {
-			compatible = "atmel,sam-gpio";
-			reg = <0x400e1200 0x200>;
-			interrupts = <11 1>;
-			peripheral-id = <11>;
-			label = "PORTC";
-			gpio-controller;
-			#gpio-cells = <2>;
-		};
+			piob: gpio@400e1000 {
+				compatible = "atmel,sam-gpio";
+				reg = <0x400e1000 0x200>;
+				interrupts = <10 1>;
+				peripheral-id = <10>;
+				label = "PORTB";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
 
-		piod: gpio@400e1400 {
-			compatible = "atmel,sam-gpio";
-			reg = <0x400e1400 0x200>;
-			interrupts = <12 1>;
-			peripheral-id = <12>;
-			label = "PORTD";
-			gpio-controller;
-			#gpio-cells = <2>;
-		};
+			pioc: gpio@400e1200 {
+				compatible = "atmel,sam-gpio";
+				reg = <0x400e1200 0x200>;
+				interrupts = <11 1>;
+				peripheral-id = <11>;
+				label = "PORTC";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
 
-		pioe: gpio@400e1600 {
-			compatible = "atmel,sam-gpio";
-			reg = <0x400e1600 0x200>;
-			interrupts = <13 1>;
-			peripheral-id = <13>;
-			label = "PORTE";
-			gpio-controller;
-			#gpio-cells = <2>;
+			piod: gpio@400e1400 {
+				compatible = "atmel,sam-gpio";
+				reg = <0x400e1400 0x200>;
+				interrupts = <12 1>;
+				peripheral-id = <12>;
+				label = "PORTD";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
+
+			pioe: gpio@400e1600 {
+				compatible = "atmel,sam-gpio";
+				reg = <0x400e1600 0x200>;
+				interrupts = <13 1>;
+				peripheral-id = <13>;
+				label = "PORTE";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
 		};
 	};
 };

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -126,34 +126,41 @@
 			label = "USART_1";
 		};
 
-		pioa: gpio@400e0e00 {
-			compatible = "atmel,sam-gpio";
-			reg = <0x400e0e00 0x190>;
-			interrupts = <11 1>;
-			peripheral-id = <11>;
-			label = "PORTA";
-			gpio-controller;
-			#gpio-cells = <2>;
-		};
+		pinctrl@400e0e00 {
+			compatible = "atmel,sam-pinctrl";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x400e0e00 0x400e0e00 0x600>;
 
-		piob: gpio@400e1000 {
-			compatible = "atmel,sam-gpio";
-			reg = <0x400e1000 0x190>;
-			interrupts = <12 1>;
-			peripheral-id = <12>;
-			label = "PORTB";
-			gpio-controller;
-			#gpio-cells = <2>;
-		};
+			pioa: gpio@400e0e00 {
+				compatible = "atmel,sam-gpio";
+				reg = <0x400e0e00 0x190>;
+				interrupts = <11 1>;
+				peripheral-id = <11>;
+				label = "PORTA";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
 
-		pioc: gpio@400e1200 {
-			compatible = "atmel,sam-gpio";
-			reg = <0x400e1200 0x190>;
-			interrupts = <13 1>;
-			peripheral-id = <13>;
-			label = "PORTC";
-			gpio-controller;
-			#gpio-cells = <2>;
+			piob: gpio@400e1000 {
+				compatible = "atmel,sam-gpio";
+				reg = <0x400e1000 0x190>;
+				interrupts = <12 1>;
+				peripheral-id = <12>;
+				label = "PORTB";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
+
+			pioc: gpio@400e1200 {
+				compatible = "atmel,sam-gpio";
+				reg = <0x400e1200 0x190>;
+				interrupts = <13 1>;
+				peripheral-id = <13>;
+				label = "PORTC";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
 		};
 	};
 };

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -217,54 +217,61 @@
 			#io-channel-cells = <1>;
 		};
 
-		pioa: gpio@400e0e00 {
-			compatible = "atmel,sam-gpio";
-			reg = <0x400e0e00 0x190>;
-			interrupts = <10 1>;
-			peripheral-id = <10>;
-			label = "PORTA";
-			gpio-controller;
-			#gpio-cells = <2>;
-		};
+		pinctrl@400e0e00 {
+			compatible = "atmel,sam-pinctrl";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x400e0e00 0x400e0e00 0xa00>;
 
-		piob: gpio@400e1000 {
-			compatible = "atmel,sam-gpio";
-			reg = <0x400e1000 0x190>;
-			interrupts = <11 1>;
-			peripheral-id = <11>;
-			label = "PORTB";
-			gpio-controller;
-			#gpio-cells = <2>;
-		};
+			pioa: gpio@400e0e00 {
+				compatible = "atmel,sam-gpio";
+				reg = <0x400e0e00 0x190>;
+				interrupts = <10 1>;
+				peripheral-id = <10>;
+				label = "PORTA";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
 
-		pioc: gpio@400e1200 {
-			compatible = "atmel,sam-gpio";
-			reg = <0x400e1200 0x190>;
-			interrupts = <12 1>;
-			peripheral-id = <12>;
-			label = "PORTC";
-			gpio-controller;
-			#gpio-cells = <2>;
-		};
+			piob: gpio@400e1000 {
+				compatible = "atmel,sam-gpio";
+				reg = <0x400e1000 0x190>;
+				interrupts = <11 1>;
+				peripheral-id = <11>;
+				label = "PORTB";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
 
-		piod: gpio@400e1400 {
-			compatible = "atmel,sam-gpio";
-			reg = <0x400e1400 0x190>;
-			interrupts = <16 1>;
-			peripheral-id = <16>;
-			label = "PORTD";
-			gpio-controller;
-			#gpio-cells = <2>;
-		};
+			pioc: gpio@400e1200 {
+				compatible = "atmel,sam-gpio";
+				reg = <0x400e1200 0x190>;
+				interrupts = <12 1>;
+				peripheral-id = <12>;
+				label = "PORTC";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
 
-		pioe: gpio@400e1600 {
-			compatible = "atmel,sam-gpio";
-			reg = <0x400e1600 0x190>;
-			interrupts = <17 1>;
-			peripheral-id = <17>;
-			label = "PORTE";
-			gpio-controller;
-			#gpio-cells = <2>;
+			piod: gpio@400e1400 {
+				compatible = "atmel,sam-gpio";
+				reg = <0x400e1400 0x190>;
+				interrupts = <16 1>;
+				peripheral-id = <16>;
+				label = "PORTD";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
+
+			pioe: gpio@400e1600 {
+				compatible = "atmel,sam-gpio";
+				reg = <0x400e1600 0x190>;
+				interrupts = <17 1>;
+				peripheral-id = <17>;
+				label = "PORTE";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
 		};
 
 		pwm0: pwm0@40020000 {

--- a/dts/bindings/pinctrl/atmel,sam-pinctrl.yaml
+++ b/dts/bindings/pinctrl/atmel,sam-pinctrl.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2020, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: Atmel SAM Pinctrl container node
+
+compatible: "atmel,sam-pinctrl"
+
+include: [base.yaml]
+
+properties:
+    "#address-cells":
+      required: true
+      const: 1
+    "#size-cells":
+      required: true
+      const: 1


### PR DESCRIPTION
Group all the GPIO controllers under a pinctl node so that we have a
container for pinmux configuration data.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>