### PR TITLE
dts: arm64: qemu-virt: Update flash node to match what qemu models

### DIFF
--- a/dts/arm/qemu-virt/qemu-virt-a53.dtsi
+++ b/dts/arm/qemu-virt/qemu-virt-a53.dtsi
@@ -59,8 +59,13 @@
 		};
 
 		flash0: flash@0 {
-			compatible = "soc-nv-flash";
-			reg = <0x0 DT_SIZE_K(64)>;
+			compatible = "cfi-flash";
+			bank-width = <4>;
+			/* As this is pointed to by zephyr,flash we can only handle
+			 * one value in the reg property, so we comment out the
+			 * second flash bank for now
+			 */
+			reg = <0x0 DT_SIZE_M(64) /* 0x4000000 DT_SIZE_M(64) */>;
 		};
 
 		arch_timer: timer {


### PR DESCRIPTION
The flash at 0 is a cfi-flash and its 2 banks each that are 64M.  So
update qemu-virt-a53.dtsi to reflect that.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>