### PR TITLE
Backport NRF UART/E fixes

### DIFF
--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -95,7 +95,7 @@ config UART_0_NRF_HW_ASYNC_TIMER
 
 config UART_0_GPIO_MANAGEMENT
 	bool "Enable GPIO management on port 0"
-	depends on UART_0_NRF_UARTE && DEVICE_POWER_MANAGEMENT
+	depends on DEVICE_POWER_MANAGEMENT
 	default y
 	help
 	  If enabled, the driver will configure the GPIOs used by the uart to

--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -93,6 +93,15 @@ config UART_0_NRF_HW_ASYNC_TIMER
 	int "Timer instance"
 	depends on UART_0_NRF_HW_ASYNC
 
+config UART_0_GPIO_MANAGEMENT
+	bool "Enable GPIO management on port 0"
+	depends on UART_0_NRF_UARTE && DEVICE_POWER_MANAGEMENT
+	default y
+	help
+	  If enabled, the driver will configure the GPIOs used by the uart to
+	  their default configuration when device is powered down. The GPIOs
+	  will be configured back to correct state when UART is powered up.
+
 endif # UART_0_NRF_UART || UART_0_NRF_UARTE
 
 # ----------------- port 1 -----------------
@@ -156,6 +165,15 @@ config UART_1_NRF_HW_ASYNC_TIMER
 	int "Timer instance"
 	depends on UART_1_NRF_HW_ASYNC
 
+config UART_1_GPIO_MANAGEMENT
+	bool "Enable GPIO management on port 1"
+	depends on DEVICE_POWER_MANAGEMENT
+	default y
+	help
+	  If enabled, the driver will configure the GPIOs used by the uart to
+	  their default configuration when device is powered down. The GPIOs
+	  will be configured back to correct state when UART is powered up.
+
 endif # UART_1_NRF_UARTE
 
 # ----------------- port 2 -----------------
@@ -218,6 +236,15 @@ config UART_2_NRF_HW_ASYNC_TIMER
 	int "Timer instance"
 	depends on UART_2_NRF_HW_ASYNC
 
+config UART_2_GPIO_MANAGEMENT
+	bool "Enable GPIO management on port 2"
+	depends on DEVICE_POWER_MANAGEMENT
+	default y
+	help
+	  If enabled, the driver will configure the GPIOs used by the uart to
+	  their default configuration when device is powered down. The GPIOs
+	  will be configured back to correct state when UART is powered up.
+
 endif # UART_2_NRF_UARTE
 
 # ----------------- port 3 -----------------
@@ -279,6 +306,15 @@ config UART_3_NRF_HW_ASYNC
 config UART_3_NRF_HW_ASYNC_TIMER
 	int "Timer instance"
 	depends on UART_3_NRF_HW_ASYNC
+
+config UART_3_GPIO_MANAGEMENT
+	bool "Enable GPIO management on port 3"
+	depends on DEVICE_POWER_MANAGEMENT
+	default y
+	help
+	  If enabled, the driver will configure the GPIOs used by the uart to
+	  their default configuration when device is powered down. The GPIOs
+	  will be configured back to correct state when UART is powered up.
 
 endif # UART_3_NRF_UARTE
 

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -251,14 +251,8 @@ static void uart_nrfx_poll_out(struct device *dev,
 /** Console I/O function */
 static int uart_nrfx_err_check(struct device *dev)
 {
-	u32_t error = 0U;
-
-	if (nrf_uart_event_check(uart0_addr, NRF_UART_EVENT_ERROR)) {
-		/* register bitfields maps to the defines in uart.h */
-		error = nrf_uart_errorsrc_get_and_clear(uart0_addr);
-	}
-
-	return error;
+	/* register bitfields maps to the defines in uart.h */
+	return nrf_uart_errorsrc_get_and_clear(uart0_addr);
 }
 
 static int uart_nrfx_configure(struct device *dev,
@@ -839,6 +833,10 @@ static void uart_nrfx_irq_callback_set(struct device *dev,
 static void uart_nrfx_isr(void *arg)
 {
 	ARG_UNUSED(arg);
+
+	if (nrf_uart_event_check(uart0_addr, NRF_UART_EVENT_ERROR)) {
+		nrf_uart_event_clear(uart0_addr, NRF_UART_EVENT_ERROR);
+	}
 
 	if (irq_callback) {
 		irq_callback(irq_cb_data);

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -967,9 +967,43 @@ static const struct uart_driver_api uart_nrfx_uart_driver_api = {
 };
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-static void uart_nrfx_set_power_state(u32_t new_state)
+
+static void uart_nrfx_pins_enable(struct device *dev, bool enable)
+{
+	if (!IS_ENABLED(CONFIG_UART_0_GPIO_MANAGEMENT)) {
+		return;
+	}
+
+	u32_t tx_pin = nrf_uart_tx_pin_get(uart0_addr);
+	u32_t rx_pin = nrf_uart_rx_pin_get(uart0_addr);
+	u32_t cts_pin = nrf_uart_cts_pin_get(uart0_addr);
+	u32_t rts_pin = nrf_uart_rts_pin_get(uart0_addr);
+
+	if (enable) {
+		nrf_gpio_pin_write(tx_pin, 1);
+		nrf_gpio_cfg_output(tx_pin);
+		nrf_gpio_cfg_input(rx_pin, NRF_GPIO_PIN_NOPULL);
+
+		if (get_dev_config(dev)->rts_cts_pins_set) {
+			nrf_gpio_pin_write(rts_pin, 1);
+			nrf_gpio_cfg_output(rts_pin);
+			nrf_gpio_cfg_input(cts_pin,
+					   NRF_GPIO_PIN_NOPULL);
+		}
+	} else {
+		nrf_gpio_cfg_default(tx_pin);
+		nrf_gpio_cfg_default(rx_pin);
+		if (get_dev_config(dev)->rts_cts_pins_set) {
+			nrf_gpio_cfg_default(cts_pin);
+			nrf_gpio_cfg_default(rts_pin);
+		}
+	}
+}
+
+static void uart_nrfx_set_power_state(struct device *dev, u32_t new_state)
 {
 	if (new_state == DEVICE_PM_ACTIVE_STATE) {
+		uart_nrfx_pins_enable(dev, true);
 		nrf_uart_enable(uart0_addr);
 		nrf_uart_task_trigger(uart0_addr, NRF_UART_TASK_STARTRX);
 	} else {
@@ -977,6 +1011,7 @@ static void uart_nrfx_set_power_state(u32_t new_state)
 		       new_state == DEVICE_PM_SUSPEND_STATE ||
 		       new_state == DEVICE_PM_OFF_STATE);
 		nrf_uart_disable(uart0_addr);
+		uart_nrfx_pins_enable(dev, false);
 	}
 }
 
@@ -989,7 +1024,7 @@ static int uart_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 		u32_t new_state = *((const u32_t *)context);
 
 		if (new_state != current_state) {
-			uart_nrfx_set_power_state(new_state);
+			uart_nrfx_set_power_state(dev, new_state);
 			current_state = new_state;
 		}
 	} else {

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -266,8 +266,19 @@ static int uart_nrfx_configure(struct device *dev,
 {
 	nrf_uart_parity_t parity;
 	nrf_uart_hwfc_t hwfc;
+#ifdef UART_CONFIG_STOP_Two
+	bool two_stop_bits = false;
+#endif
 
-	if (cfg->stop_bits != UART_CFG_STOP_BITS_1) {
+	switch (cfg->stop_bits) {
+	case UART_CFG_STOP_BITS_1:
+		break;
+#ifdef UART_CONFIG_STOP_Two
+	case UART_CFG_STOP_BITS_2:
+		two_stop_bits = true;
+		break;
+#endif
+	default:
 		return -ENOTSUP;
 	}
 
@@ -307,6 +318,13 @@ static int uart_nrfx_configure(struct device *dev,
 
 	nrf_uart_configure(uart0_addr, parity, hwfc);
 
+#ifdef UART_CONFIG_STOP_Two
+	if (two_stop_bits) {
+		/* TODO Change this to nrfx HAL function when available */
+		uart0_addr->CONFIG |=
+			UART_CONFIG_STOP_Two << UART_CONFIG_STOP_Pos;
+	}
+#endif
 	get_dev_data(dev)->uart_config = *cfg;
 
 	return 0;

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -177,6 +177,10 @@ static void uarte_nrfx_isr_int(void *arg)
 		return;
 	}
 
+	if (nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_ERROR)) {
+		nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_ERROR);
+	}
+
 	if (data->int_driven->cb) {
 		data->int_driven->cb(data->int_driven->cb_data);
 	}
@@ -348,15 +352,9 @@ static int uarte_nrfx_config_get(struct device *dev, struct uart_config *cfg)
 
 static int uarte_nrfx_err_check(struct device *dev)
 {
-	u32_t error = 0U;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
-
-	if (nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_ERROR)) {
-		/* register bitfields maps to the defines in uart.h */
-		error = nrf_uarte_errorsrc_get_and_clear(uarte);
-	}
-
-	return error;
+	/* register bitfields maps to the defines in uart.h */
+	return nrf_uarte_errorsrc_get_and_clear(uarte);
 }
 
 #ifdef CONFIG_UART_ASYNC_API

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -274,8 +274,19 @@ static int uarte_nrfx_configure(struct device *dev,
 {
 	nrf_uarte_parity_t parity;
 	nrf_uarte_hwfc_t hwfc;
+#ifdef UARTE_CONFIG_STOP_Two
+	bool two_stop_bits = false;
+#endif
 
-	if (cfg->stop_bits != UART_CFG_STOP_BITS_1) {
+	switch (cfg->stop_bits) {
+	case UART_CFG_STOP_BITS_1:
+		break;
+#ifdef UARTE_CONFIG_STOP_Two
+	case UART_CFG_STOP_BITS_2:
+		two_stop_bits = true;
+		break;
+#endif
+	default:
 		return -ENOTSUP;
 	}
 
@@ -315,6 +326,13 @@ static int uarte_nrfx_configure(struct device *dev,
 
 	nrf_uarte_configure(get_uarte_instance(dev), parity, hwfc);
 
+#ifdef UARTE_CONFIG_STOP_Two
+	if (two_stop_bits) {
+		/* TODO Change this to nrfx HAL function when available */
+		get_uarte_instance(dev)->CONFIG |=
+			UARTE_CONFIG_STOP_Two << UARTE_CONFIG_STOP_Pos;
+	}
+#endif
 	get_dev_data(dev)->uart_config = *cfg;
 
 	return 0;

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1262,6 +1262,9 @@ static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
 		uarte_nrfx_pins_enable(dev, true);
 		nrf_uarte_enable(uarte);
 #ifdef CONFIG_UART_ASYNC_API
+		if (hw_rx_counting_enabled(get_dev_data(dev))) {
+			nrfx_timer_enable(&get_dev_config(dev)->timer);
+		}
 		if (get_dev_data(dev)->async) {
 			return;
 		}
@@ -1283,6 +1286,9 @@ static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
 		 * only sent after each RX if async UART API is used.
 		 */
 #ifdef CONFIG_UART_ASYNC_API
+		if (hw_rx_counting_enabled(get_dev_data(dev))) {
+			nrfx_timer_disable(&get_dev_config(dev)->timer);
+		}
 		if (get_dev_data(dev)->async) {
 			nrf_uarte_disable(uarte);
 			uarte_nrfx_pins_enable(dev, false);

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1256,6 +1256,7 @@ static void uarte_nrfx_pins_enable(struct device *dev, bool enable)
 static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
 {
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
+	struct uarte_nrfx_data *data = get_dev_data(dev);
 
 	if (new_state == DEVICE_PM_ACTIVE_STATE) {
 		uarte_nrfx_pins_enable(dev, true);
@@ -1270,6 +1271,13 @@ static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
 		assert(new_state == DEVICE_PM_LOW_POWER_STATE ||
 		       new_state == DEVICE_PM_SUSPEND_STATE ||
 		       new_state == DEVICE_PM_OFF_STATE);
+
+		/* if pm is already not active, driver will stay indefinitely
+		 * in while loop waiting for event NRF_UARTE_EVENT_RXTO
+		 */
+		if (data->pm_state != DEVICE_PM_ACTIVE_STATE) {
+			return;
+		}
 
 		/* Disabling UART requires stopping RX, but stop RX event is
 		 * only sent after each RX if async UART API is used.

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -632,13 +632,13 @@ static void rx_timeout(struct k_timer *timer)
 	}
 
 	/* Check if there is data that was not sent to user yet */
-	if (data->async->rx_total_byte_cnt
-	    != data->async->rx_total_user_byte_cnt) {
+
+	s32_t len = data->async->rx_total_byte_cnt
+		    - data->async->rx_total_user_byte_cnt;
+	if (len > 0) {
 		if (data->async->rx_timeout_left
 		    < data->async->rx_timeout_slab) {
 			/* rx_timeout ms elapsed since last receiving */
-			u32_t len = data->async->rx_total_byte_cnt
-				    - data->async->rx_total_user_byte_cnt;
 			struct uart_event evt = {
 				.type = UART_RX_RDY,
 				.data.rx.buf = data->async->rx_buf,

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -690,9 +690,7 @@ static void endrx_isr(struct device *dev)
 		data->async->rx_buf = data->async->rx_next_buf;
 		data->async->rx_next_buf = NULL;
 
-		data->async->rx_total_byte_cnt += rx_len;
-		data->async->rx_total_user_byte_cnt =
-			data->async->rx_total_byte_cnt;
+		data->async->rx_total_user_byte_cnt += rx_len;
 		data->async->rx_offset = 0;
 	} else {
 		data->async->rx_buf = NULL;

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1219,19 +1219,46 @@ static int uarte_instance_init(struct device *dev,
 }
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
+
+static void uarte_nrfx_pins_enable(struct device *dev, bool enable)
 {
+	if (!get_dev_config(dev)->gpio_mgmt) {
+		return;
+	}
+
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 	u32_t tx_pin = nrf_uarte_tx_pin_get(uarte);
 	u32_t rx_pin = nrf_uarte_rx_pin_get(uarte);
+	u32_t cts_pin = nrf_uarte_cts_pin_get(uarte);
+	u32_t rts_pin = nrf_uarte_rts_pin_get(uarte);
+
+	if (enable) {
+		nrf_gpio_pin_write(tx_pin, 1);
+		nrf_gpio_cfg_output(tx_pin);
+		nrf_gpio_cfg_input(rx_pin, NRF_GPIO_PIN_NOPULL);
+
+		if (get_dev_config(dev)->rts_cts_pins_set) {
+			nrf_gpio_pin_write(rts_pin, 1);
+			nrf_gpio_cfg_output(rts_pin);
+			nrf_gpio_cfg_input(cts_pin,
+					   NRF_GPIO_PIN_NOPULL);
+		}
+	} else {
+		nrf_gpio_cfg_default(tx_pin);
+		nrf_gpio_cfg_default(rx_pin);
+		if (get_dev_config(dev)->rts_cts_pins_set) {
+			nrf_gpio_cfg_default(cts_pin);
+			nrf_gpio_cfg_default(rts_pin);
+		}
+	}
+}
+
+static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
+{
+	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 
 	if (new_state == DEVICE_PM_ACTIVE_STATE) {
-		if (get_dev_config(dev)->gpio_mgmt) {
-			nrf_gpio_pin_write(tx_pin, 1);
-			nrf_gpio_cfg_output(tx_pin);
-			nrf_gpio_cfg_input(rx_pin, NRF_GPIO_PIN_NOPULL);
-		}
-
+		uarte_nrfx_pins_enable(dev, true);
 		nrf_uarte_enable(uarte);
 #ifdef CONFIG_UART_ASYNC_API
 		if (get_dev_data(dev)->async) {
@@ -1250,10 +1277,7 @@ static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
 #ifdef CONFIG_UART_ASYNC_API
 		if (get_dev_data(dev)->async) {
 			nrf_uarte_disable(uarte);
-			if (get_dev_config(dev)->gpio_mgmt) {
-				nrf_gpio_cfg_default(tx_pin);
-				nrf_gpio_cfg_default(rx_pin);
-			}
+			uarte_nrfx_pins_enable(dev, false);
 			return;
 		}
 #endif
@@ -1263,10 +1287,7 @@ static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
 		}
 		nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_RXTO);
 		nrf_uarte_disable(uarte);
-		if (get_dev_config(dev)->gpio_mgmt) {
-			nrf_gpio_cfg_default(tx_pin);
-			nrf_gpio_cfg_default(rx_pin);
-		}
+		uarte_nrfx_pins_enable(dev, false);
 	}
 }
 

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -66,8 +66,10 @@ struct uarte_async_cb {
 	struct k_timer tx_timeout_timer;
 
 	u8_t *rx_buf;
+	size_t rx_buf_len;
 	size_t rx_offset;
 	u8_t *rx_next_buf;
+	size_t rx_next_buf_len;
 	u32_t rx_total_byte_cnt; /* Total number of bytes received */
 	u32_t rx_total_user_byte_cnt; /* Total number of bytes passed to user */
 	u32_t rx_timeout; /* Timeout set by user */
@@ -524,7 +526,10 @@ static int uarte_nrfx_rx_enable(struct device *dev, u8_t *buf, size_t len,
 		    NRFX_CEIL_DIV(1000, CONFIG_SYS_CLOCK_TICKS_PER_SEC));
 
 	data->async->rx_buf = buf;
+	data->async->rx_buf_len = len;
 	data->async->rx_offset = 0;
+	data->async->rx_next_buf = NULL;
+	data->async->rx_next_buf_len = 0;
 	nrf_uarte_rx_buffer_set(uarte, buf, len);
 
 	nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_ENDRX);
@@ -542,7 +547,9 @@ static int uarte_nrfx_rx_buf_rsp(struct device *dev, u8_t *buf, size_t len)
 
 	if (data->async->rx_next_buf == NULL) {
 		data->async->rx_next_buf = buf;
+		data->async->rx_next_buf_len = len;
 		nrf_uarte_rx_buffer_set(uarte, buf, len);
+		nrf_uarte_shorts_enable(uarte, NRF_UARTE_SHORT_ENDRX_STARTRX);
 	} else {
 		return -EBUSY;
 	}
@@ -567,6 +574,9 @@ static int uarte_nrfx_rx_disable(struct device *dev)
 
 	if (data->async->rx_buf == NULL) {
 		return -EFAULT;
+	}
+	if (data->async->rx_next_buf != NULL) {
+		nrf_uarte_shorts_disable(uarte, NRF_UARTE_SHORT_ENDRX_STARTRX);
 	}
 
 	k_timer_stop(&data->async->rx_timeout_timer);
@@ -629,13 +639,30 @@ static void rx_timeout(struct k_timer *timer)
 		data->async->rx_timeout_left = data->async->rx_timeout;
 	}
 
-	/* Check if there is data that was not sent to user yet */
-
+	/* Check if there is data that was not sent to user yet
+	 * Note though that 'len' is a count of data bytes received, but not
+	 * necessarily the amount available in the current buffer
+	 */
 	s32_t len = data->async->rx_total_byte_cnt
 		    - data->async->rx_total_user_byte_cnt;
+
+	/* Check for current buffer being full.
+	 * if the UART receives characters before the the ENDRX is handled
+	 * and the 'next' buffer is set up, then the SHORT between ENDRX and
+	 * STARTRX will mean that data will be going into to the 'next' buffer
+	 * until the ENDRX event gets a chance to be handled.
+	 */
+	bool clipped = false;
+
+	if (len + data->async->rx_offset > data->async->rx_buf_len) {
+		len = data->async->rx_buf_len - data->async->rx_offset;
+		clipped = true;
+	}
+
 	if (len > 0) {
-		if (data->async->rx_timeout_left
-		    < data->async->rx_timeout_slab) {
+		if (clipped ||
+			(data->async->rx_timeout_left
+				< data->async->rx_timeout_slab)) {
 			/* rx_timeout ms elapsed since last receiving */
 			struct uart_event evt = {
 				.type = UART_RX_RDY,
@@ -644,12 +671,18 @@ static void rx_timeout(struct k_timer *timer)
 				.data.rx.offset = data->async->rx_offset
 			};
 			data->async->rx_offset += len;
-			data->async->rx_total_user_byte_cnt =
-				data->async->rx_total_byte_cnt;
+			data->async->rx_total_user_byte_cnt += len;
 			user_callback(dev, &evt);
 		} else {
 			data->async->rx_timeout_left -=
 				data->async->rx_timeout_slab;
+		}
+
+		/* If theres nothing left to report until the buffers are
+		 * switched then the timer can be stopped
+		 */
+		if (clipped) {
+			k_timer_stop(&data->async->rx_timeout_timer);
 		}
 	}
 
@@ -702,13 +735,28 @@ static void endrx_isr(struct device *dev)
 
 	data->async->is_in_irq = true;
 
-	if (data->async->rx_next_buf) {
-		nrf_uarte_task_trigger(uarte, NRF_UARTE_TASK_STARTRX);
-	}
+	/* ensure rx timer is stopped - it will be restarted in RXSTARTED
+	 * handler if needed
+	 */
 	k_timer_stop(&data->async->rx_timeout_timer);
 
-	size_t rx_len = nrf_uarte_rx_amount_get(uarte)
-			- data->async->rx_offset;
+	/* this is the amount that the EasyDMA controller has copied into the
+	 * buffer
+	 */
+	const int rx_amount = nrf_uarte_rx_amount_get(uarte);
+
+	/* The 'rx_offset' can be bigger than 'rx_amount', so it the length
+	 * of data we report back the the user may need to be clipped.
+	 * This can happen because the 'rx_offset' count derives from RXRDY
+	 * events, which can occur already for the next buffer before we are
+	 * here to handle this buffer. (The next buffer is now already active
+	 * because of the ENDRX_STARTRX shortcut)
+	 */
+	int rx_len = rx_amount - data->async->rx_offset;
+
+	if (rx_len < 0) {
+		rx_len = 0;
+	}
 
 	data->async->rx_total_user_byte_cnt += rx_len;
 
@@ -721,23 +769,38 @@ static void endrx_isr(struct device *dev)
 		data->async->rx_cnt.cnt = data->async->rx_total_user_byte_cnt;
 	}
 
+	/* Only send the RX_RDY event if there is something to send */
+	if (rx_len > 0) {
+		struct uart_event evt = {
+			.type = UART_RX_RDY,
+			.data.rx.buf = data->async->rx_buf,
+			.data.rx.len = rx_len,
+			.data.rx.offset = data->async->rx_offset,
+		};
+		user_callback(dev, &evt);
+	}
+
 	struct uart_event evt = {
-		.type = UART_RX_RDY,
-		.data.rx.buf = data->async->rx_buf,
-		.data.rx.len = rx_len,
-		.data.rx.offset = data->async->rx_offset,
+		.type = UART_RX_BUF_RELEASED,
+		.data.rx_buf.buf = data->async->rx_buf,
 	};
 	user_callback(dev, &evt);
 
-	evt.type = UART_RX_BUF_RELEASED;
-	evt.data.rx_buf.buf = data->async->rx_buf;
-	user_callback(dev, &evt);
-
+	/* If there is a next buffer, then STARTRX will have already been
+	 * invoked by the short (the next buffer will be filling up already)
+	 * and here we just do the swap of which buffer the driver is following,
+	 * the next rx_timeout() will update the rx_offset.
+	 */
 	if (data->async->rx_next_buf) {
 		data->async->rx_buf = data->async->rx_next_buf;
+		data->async->rx_buf_len = data->async->rx_next_buf_len;
 		data->async->rx_next_buf = NULL;
+		data->async->rx_next_buf_len = 0;
 
 		data->async->rx_offset = 0;
+
+		/* Remove the short until the subsequent next buffer is setup */
+		nrf_uarte_shorts_disable(uarte, NRF_UARTE_SHORT_ENDRX_STARTRX);
 	} else {
 		data->async->rx_buf = NULL;
 		evt.type = UART_RX_DISABLED;
@@ -823,14 +886,14 @@ static void uarte_nrfx_isr_async(struct device *dev)
 		error_isr(dev);
 	}
 
-	if (nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_RXSTARTED)) {
-		nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_RXSTARTED);
-		rxstarted_isr(dev);
-	}
-
 	if (nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_ENDRX)) {
 		nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_ENDRX);
 		endrx_isr(dev);
+	}
+
+	if (nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_RXSTARTED)) {
+		nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_RXSTARTED);
+		rxstarted_isr(dev);
 	}
 
 	if (nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_RXTO)) {


### PR DESCRIPTION
Backport all NRF UARTE fixes that have not made it to the 1.14 branch.  
Addresses #24076.