### PR TITLE
Bluetooth: host: Add non-connectable directed advertising support

### DIFF
--- a/doc/releases/release-notes-2.3.rst
+++ b/doc/releases/release-notes-2.3.rst
@@ -54,8 +54,9 @@ Deprecated in this release
   * bt_le_scan_param::filter_dup, use bt_le_scan_param::options instead
   * bt_conn_create_le(), use bt_conn_le_create() instead
   * bt_conn_create_auto_le(), use bt_conn_le_create_auto() instead
-  * bt_conn_create_slave_le(), use bt_conn_le_create_slave() instead
-  * BT_LE_ADV_* macros, use BT_HCI_ADV_* macros instead
+  * bt_conn_create_slave_le(), use bt_le_adv_start() instead with
+    bt_le_adv_param::peer set to the remote peers address.
+  * BT_LE_ADV_* macros, use BT_GAP_ADV_* enums instead
 
 Removed APIs in this release
 ============================

--- a/include/bluetooth/gap.h
+++ b/include/bluetooth/gap.h
@@ -123,6 +123,11 @@ enum {
 #define BT_GAP_SID_INVALID                      0xff
 #define BT_GAP_NO_TIMEOUT                       0x0000
 
+/* The maximum allowed high duty cycle directed advertising timeout, 1.28
+ * seconds in 10 ms unit.
+ */
+#define BT_GAP_ADV_HIGH_DUTY_CYCLE_MAX_TIMEOUT  128
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -1088,12 +1088,6 @@ struct bt_hci_cp_le_set_ext_scan_rsp_data {
 	u8_t  data[251];
 } __packed;
 
-/* If the advertising is high duty cycle connectable directed advertising, then
- * Duration[i] shall be less than or equal to 1.28 seconds and shall not be
- * equal to 0.
- */
-#define BT_HCI_LE_EXT_ADV_DURATION_HI_DC_MAX    128
-
 #define BT_HCI_OP_LE_SET_EXT_ADV_ENABLE         BT_OP(BT_OGF_LE, 0x0039)
 struct bt_hci_ext_adv_set {
 	u8_t  handle;

--- a/samples/bluetooth/hci_pwr_ctrl/src/main.c
+++ b/samples/bluetooth/hci_pwr_ctrl/src/main.c
@@ -38,9 +38,9 @@ static K_THREAD_STACK_DEFINE(pwr_thread_stack, 320);
 
 static const s8_t txp[DEVICE_BEACON_TXPOWER_NUM] = {4, 0, -3, -8,
 						    -15, -18, -23, -30};
-static const struct bt_le_adv_param *param = BT_LE_ADV_PARAM
-	(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_USE_NAME,
-	0x0020, 0x0020);
+static const struct bt_le_adv_param *param =
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_USE_NAME,
+			0x0020, 0x0020, NULL);
 
 static void read_conn_rssi(u16_t handle, s8_t *rssi)
 {

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -171,6 +171,9 @@ static inline int bt_conn_send(struct bt_conn *conn, struct net_buf *buf)
 	return bt_conn_send_cb(conn, buf, NULL, NULL);
 }
 
+/* Check if a connection object with the peer already exists */
+bool bt_conn_exists_le(u8_t id, const bt_addr_le_t *peer);
+
 /* Add a new LE connection */
 struct bt_conn *bt_conn_add_le(u8_t id, const bt_addr_le_t *peer);
 

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -98,6 +98,9 @@ struct bt_le_ext_adv {
 	/* Current local Random Address */
 	bt_addr_le_t		random_addr;
 
+	/* Current target address */
+	bt_addr_le_t            target_addr;
+
 	ATOMIC_DEFINE(flags, BT_ADV_NUM_FLAGS);
 
 #if defined(CONFIG_BT_EXT_ADV)


### PR DESCRIPTION
This patch introduces two major changes to the directed advertising
feature of the bluetooth host.

Deprecating the bt_conn_create_slave_le, and removing
bt_conn_le_create_slave which has never been released. This behaviour
has now been moved by to providing the peer direct address into the
advertising parameters.

Introducing directed advertising support for nonconnectable
directed extended advertising, both scannable and non-scannable.

A bug was also fixed in the the directed-adv command in the shell
when the argument "low" was given. The advertiseng parameter pointer
declared with BT_LE_ADV_CONN_DIR_LOW_DUTY was declared in a scope that
was no longer valid when it was used to start the advertiser.

Add shell options to configure an extended advertiser for directed
advertising.
Add shell options to provide arbitrary advertising data as well as
giving scan response data.