### PR TITLE
sys_heap heap allocator optimizations

### DIFF
--- a/include/mempool_heap.h
+++ b/include/mempool_heap.h
@@ -36,17 +36,17 @@ struct k_mem_pool {
  * objects defined, and include extra so there's enough metadata space
  * available for the maximum number of minimum-sized objects to be
  * stored: 8 bytes for each desired chunk header, and a 24 word block
- * to reserve room for a "typical" set of bucket list heads (this size
- * was picked more to conform with existing test expectations than any
- * rigorous theory -- we have tests that rely on being able to
- * allocate the blocks promised and ones that make assumptions about
+ * to reserve room for a "typical" set of bucket list heads and one heap
+ * footer(this size was picked more to conform with existing test
+ * expectations than any rigorous theory -- we have tests that rely on being
+ * able to allocate the blocks promised and ones that make assumptions about
  * when memory will run out).
  */
 #define Z_MEM_POOL_DEFINE(name, minsz, maxsz, nmax, align)		\
 		K_HEAP_DEFINE(poolheap_##name,				\
 			      ((maxsz) * (nmax))			\
 			      + 8 * ((maxsz) * (nmax) / (minsz))	\
-			      + 24 * sizeof(void *));			\
+			      + 25 * sizeof(void *));			\
 		struct k_mem_pool name = {				\
 			.heap = &poolheap_##name			\
 		}

--- a/include/mempool_heap.h
+++ b/include/mempool_heap.h
@@ -35,8 +35,8 @@ struct k_mem_pool {
  * that k_heap does not.  We make space for the number of maximum
  * objects defined, and include extra so there's enough metadata space
  * available for the maximum number of minimum-sized objects to be
- * stored: 8 bytes for each desired chunk header, and a 24 word block
- * to reserve room for a "typical" set of bucket list heads and one heap
+ * stored: 8 bytes for each desired chunk header, and a 15 word block
+ * to reserve room for a "typical" set of bucket list heads and the heap
  * footer(this size was picked more to conform with existing test
  * expectations than any rigorous theory -- we have tests that rely on being
  * able to allocate the blocks promised and ones that make assumptions about
@@ -46,7 +46,7 @@ struct k_mem_pool {
 		K_HEAP_DEFINE(poolheap_##name,				\
 			      ((maxsz) * (nmax))			\
 			      + 8 * ((maxsz) * (nmax) / (minsz))	\
-			      + 25 * sizeof(void *));			\
+			      + 15 * sizeof(void *));			\
 		struct k_mem_pool name = {				\
 			.heap = &poolheap_##name			\
 		}

--- a/lib/os/heap-validate.c
+++ b/lib/os/heap-validate.c
@@ -50,22 +50,13 @@ static inline void check_nexts(struct z_heap *h, int bidx)
 
 	bool emptybit = (h->avail_buckets & (1 << bidx)) == 0;
 	bool emptylist = b->next == 0;
-	bool emptycount = b->list_size == 0;
-	bool empties_match = emptybit == emptylist && emptybit == emptycount;
+	bool empties_match = emptybit == emptylist;
 
 	(void)empties_match;
 	CHECK(empties_match);
 
 	if (b->next != 0) {
 		CHECK(valid_chunk(h, b->next));
-	}
-
-	if (b->list_size == 2) {
-		CHECK(next_free_chunk(h, b->next) == prev_free_chunk(h, b->next));
-		CHECK(next_free_chunk(h, b->next) != b->next);
-	} else if (b->list_size == 1) {
-		CHECK(next_free_chunk(h, b->next) == prev_free_chunk(h, b->next));
-		CHECK(next_free_chunk(h, b->next) == b->next);
 	}
 }
 
@@ -100,10 +91,6 @@ bool sys_heap_validate(struct sys_heap *heap)
 		}
 
 		if (empty && h->buckets[b].next != 0) {
-			return false;
-		}
-
-		if (n != h->buckets[b].list_size) {
 			return false;
 		}
 	}

--- a/lib/os/heap-validate.c
+++ b/lib/os/heap-validate.c
@@ -34,7 +34,8 @@ static bool valid_chunk(struct z_heap *h, chunkid_t c)
 	return (chunk_size(h, c) > 0
 		&& (c + chunk_size(h, c) <= h->len)
 		&& in_bounds(h, c)
-		&& (!left_chunk(h, c) || in_bounds(h, left_chunk(h, c)))
+		&& (right_chunk(h, left_chunk(h, c)) == c)
+		&& (left_chunk(h, right_chunk(h, c)) == c)
 		&& (chunk_used(h, c) || in_bounds(h, prev_free_chunk(h, c)))
 		&& (chunk_used(h, c) || in_bounds(h, next_free_chunk(h, c))));
 }

--- a/lib/os/heap-validate.c
+++ b/lib/os/heap-validate.c
@@ -88,7 +88,7 @@ bool sys_heap_validate(struct sys_heap *heap)
 			if (!valid_chunk(h, c)) {
 				return false;
 			}
-			chunk_set_used(h, c, true);
+			set_chunk_used(h, c, true);
 		}
 
 		bool empty = (h->avail_buckets & (1 << b)) == 0;
@@ -129,7 +129,7 @@ bool sys_heap_validate(struct sys_heap *heap)
 		}
 		prev_chunk = c;
 
-		chunk_set_used(h, c, false);
+		set_chunk_used(h, c, false);
 	}
 	if (c != h->len) {
 		return false;  /* Should have exactly consumed the buffer */
@@ -151,7 +151,7 @@ bool sys_heap_validate(struct sys_heap *heap)
 			if (chunk_used(h, c)) {
 				return false;
 			}
-			chunk_set_used(h, c, true);
+			set_chunk_used(h, c, true);
 		}
 	}
 
@@ -159,7 +159,7 @@ bool sys_heap_validate(struct sys_heap *heap)
 	 * fields.  One more linear pass to fix them up
 	 */
 	for (c = h->chunk0; c <= max_chunkid(h); c = right_chunk(h, c)) {
-		chunk_set_used(h, c, !chunk_used(h, c));
+		set_chunk_used(h, c, !chunk_used(h, c));
 	}
 	return true;
 }

--- a/lib/os/heap-validate.c
+++ b/lib/os/heap-validate.c
@@ -19,7 +19,7 @@
 
 static size_t max_chunkid(struct z_heap *h)
 {
-	return h->len - bytes_to_chunksz(h, 1);
+	return h->len - min_chunk_size(h);
 }
 
 static bool in_bounds(struct z_heap *h, chunkid_t c)

--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -221,7 +221,6 @@ void sys_heap_init(struct sys_heap *heap, void *mem, size_t bytes)
 	h->buf = (uint64_t *)addr;
 	h->buckets = (void *)(addr + CHUNK_UNIT * hdr_chunks);
 	h->len = buf_sz;
-	h->size_mask = (1 << (big_heap(h) ? 31 : 15)) - 1;
 	h->avail_buckets = 0;
 
 	size_t buckets_bytes = ((bucket_idx(h, buf_sz) + 1)

--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -92,7 +92,7 @@ static void *split_alloc(struct z_heap *h, int bidx, size_t sz)
 
 	CHECK(rem < h->len);
 
-	if (rem >= (big_heap(h) ? 2 : 1)) {
+	if (rem >= min_chunk_size(h)) {
 		chunkid_t c2 = c + sz;
 		chunkid_t c3 = right_chunk(h, c);
 
@@ -224,7 +224,7 @@ void sys_heap_init(struct sys_heap *heap, void *mem, size_t bytes)
 	size_t chunk0_size = chunksz(sizeof(struct z_heap) +
 				     nb_buckets * sizeof(struct z_heap_bucket));
 
-	CHECK(chunk0_size < buf_sz);
+	CHECK(chunk0_size + min_chunk_size(h) < buf_sz);
 
 	for (int i = 0; i < nb_buckets; i++) {
 		h->buckets[i].list_size = 0;

--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -25,8 +25,7 @@ static void free_list_remove(struct z_heap *h, int bidx,
 	CHECK(!chunk_used(h, c));
 	CHECK(b->next != 0);
 	CHECK(b->list_size > 0);
-	CHECK((((h->avail_buckets & (1 << bidx)) == 0)
-	       == (h->buckets[bidx].next == 0)));
+	CHECK(h->avail_buckets & (1 << bidx));
 
 	b->list_size--;
 
@@ -67,7 +66,7 @@ static void free_list_add(struct z_heap *h, chunkid_t c)
 		set_prev_free_chunk(h, second, c);
 	}
 
-	CHECK(h->avail_buckets & (1 << bucket_idx(h, chunk_size(h, c))));
+	CHECK(h->avail_buckets & (1 << bi));
 }
 
 /* Allocates (fit check has already been perfomred) from the next

--- a/lib/os/heap.h
+++ b/lib/os/heap.h
@@ -98,12 +98,12 @@ static inline void chunk_set(struct z_heap *h, chunkid_t c,
 	}
 }
 
-static inline chunkid_t used(struct z_heap *h, chunkid_t c)
+static inline bool chunk_used(struct z_heap *h, chunkid_t c)
 {
 	return (chunk_field(h, c, SIZE_AND_USED) & ~h->size_mask) != 0;
 }
 
-static ALWAYS_INLINE chunkid_t size(struct z_heap *h, chunkid_t c)
+static ALWAYS_INLINE size_t chunk_size(struct z_heap *h, chunkid_t c)
 {
 	return chunk_field(h, c, SIZE_AND_USED) & h->size_mask;
 }
@@ -112,32 +112,27 @@ static inline void chunk_set_used(struct z_heap *h, chunkid_t c,
 				  bool used)
 {
 	chunk_set(h, c, SIZE_AND_USED,
-		  size(h, c) | (used ? (h->size_mask + 1) : 0));
+		  chunk_size(h, c) | (used ? (h->size_mask + 1) : 0));
 }
 
-static inline chunkid_t left_size(struct z_heap *h, chunkid_t c)
-{
-	return chunk_field(h, c, LEFT_SIZE);
-}
-
-static inline chunkid_t free_prev(struct z_heap *h, chunkid_t c)
+static inline chunkid_t prev_free_chunk(struct z_heap *h, chunkid_t c)
 {
 	return chunk_field(h, c, FREE_PREV);
 }
 
-static inline chunkid_t free_next(struct z_heap *h, chunkid_t c)
+static inline chunkid_t next_free_chunk(struct z_heap *h, chunkid_t c)
 {
 	return chunk_field(h, c, FREE_NEXT);
 }
 
 static inline chunkid_t left_chunk(struct z_heap *h, chunkid_t c)
 {
-	return c - left_size(h, c);
+	return c - chunk_field(h, c, LEFT_SIZE);
 }
 
 static inline chunkid_t right_chunk(struct z_heap *h, chunkid_t c)
 {
-	return c + size(h, c);
+	return c + chunk_size(h, c);
 }
 
 static inline size_t chunk_header_bytes(struct z_heap *h)

--- a/lib/os/heap.h
+++ b/lib/os/heap.h
@@ -49,19 +49,20 @@ typedef size_t chunkid_t;
 
 #define CHUNK_UNIT 8
 
-enum chunk_fields { SIZE_AND_USED, LEFT_SIZE, FREE_PREV, FREE_NEXT };
+typedef struct { char bytes[CHUNK_UNIT]; } chunk_unit_t;
 
-struct z_heap {
-	uint64_t *buf;
-	struct z_heap_bucket *buckets;
-	uint32_t len;
-	uint32_t chunk0;
-	uint32_t avail_buckets;
-};
+enum chunk_fields { SIZE_AND_USED, LEFT_SIZE, FREE_PREV, FREE_NEXT };
 
 struct z_heap_bucket {
 	chunkid_t next;
 	size_t list_size;
+};
+
+struct z_heap {
+	uint64_t chunk0_hdr_area;  /* matches the largest header */
+	uint32_t len;
+	uint32_t avail_buckets;
+	struct z_heap_bucket buckets[0];
 };
 
 static inline bool big_heap(struct z_heap *h)
@@ -69,10 +70,17 @@ static inline bool big_heap(struct z_heap *h)
 	return sizeof(size_t) > 4 || h->len > 0x7fff;
 }
 
+static inline chunk_unit_t *chunk_buf(struct z_heap *h)
+{
+	/* the struct z_heap matches with the first chunk */
+	return (chunk_unit_t *)h;
+}
+
 static inline size_t chunk_field(struct z_heap *h, chunkid_t c,
 				 enum chunk_fields f)
 {
-	void *cmem = &h->buf[c];
+	chunk_unit_t *buf = chunk_buf(h);
+	void *cmem = &buf[c];
 
 	if (big_heap(h)) {
 		return ((uint32_t *)cmem)[f];
@@ -84,9 +92,10 @@ static inline size_t chunk_field(struct z_heap *h, chunkid_t c,
 static inline void chunk_set(struct z_heap *h, chunkid_t c,
 			     enum chunk_fields f, chunkid_t val)
 {
-	CHECK(c >= h->chunk0 && c < h->len);
+	CHECK(c < h->len);
 
-	void *cmem = &h->buf[c];
+	chunk_unit_t *buf = chunk_buf(h);
+	void *cmem = &buf[c];
 
 	if (big_heap(h)) {
 		CHECK(val == (uint32_t)val);
@@ -109,7 +118,8 @@ static inline size_t chunk_size(struct z_heap *h, chunkid_t c)
 
 static inline void set_chunk_used(struct z_heap *h, chunkid_t c, bool used)
 {
-	void *cmem = &h->buf[c];
+	chunk_unit_t *buf = chunk_buf(h);
+	void *cmem = &buf[c];
 
 	if (big_heap(h)) {
 		if (used) {

--- a/lib/os/heap.h
+++ b/lib/os/heap.h
@@ -55,7 +55,6 @@ enum chunk_fields { LEFT_SIZE, SIZE_AND_USED, FREE_PREV, FREE_NEXT };
 
 struct z_heap_bucket {
 	chunkid_t next;
-	size_t list_size;
 };
 
 struct z_heap {

--- a/lib/os/heap.h
+++ b/lib/os/heap.h
@@ -199,10 +199,16 @@ static inline size_t bytes_to_chunksz(struct z_heap *h, size_t bytes)
 	return chunksz(chunk_header_bytes(h) + bytes);
 }
 
-static int bucket_idx(struct z_heap *h, size_t sz)
+static inline int min_chunk_size(struct z_heap *h)
 {
-	/* A chunk of size 2 is the minimum size on big heaps */
-	return 31 - __builtin_clz(sz) - (big_heap(h) ? 1 : 0);
+	return bytes_to_chunksz(h, 1);
 }
+
+static inline int bucket_idx(struct z_heap *h, size_t sz)
+{
+	size_t usable_sz = sz - min_chunk_size(h) + 1;
+	return 31 - __builtin_clz(usable_sz);
+}
+
 
 #endif /* ZEPHYR_INCLUDE_LIB_OS_HEAP_H_ */

--- a/lib/os/heap.h
+++ b/lib/os/heap.h
@@ -51,7 +51,7 @@ typedef size_t chunkid_t;
 
 typedef struct { char bytes[CHUNK_UNIT]; } chunk_unit_t;
 
-enum chunk_fields { SIZE_AND_USED, LEFT_SIZE, FREE_PREV, FREE_NEXT };
+enum chunk_fields { LEFT_SIZE, SIZE_AND_USED, FREE_PREV, FREE_NEXT };
 
 struct z_heap_bucket {
 	chunkid_t next;

--- a/lib/os/heap.h
+++ b/lib/os/heap.h
@@ -108,11 +108,16 @@ static ALWAYS_INLINE size_t chunk_size(struct z_heap *h, chunkid_t c)
 	return chunk_field(h, c, SIZE_AND_USED) & h->size_mask;
 }
 
-static inline void chunk_set_used(struct z_heap *h, chunkid_t c,
-				  bool used)
+static inline void set_chunk_used(struct z_heap *h, chunkid_t c, bool used)
 {
 	chunk_set(h, c, SIZE_AND_USED,
 		  chunk_size(h, c) | (used ? (h->size_mask + 1) : 0));
+}
+
+static inline void set_chunk_size(struct z_heap *h, chunkid_t c, size_t size)
+{
+	chunk_set(h, c, SIZE_AND_USED,
+		  size | (chunk_used(h, c) ? (h->size_mask + 1) : 0));
 }
 
 static inline chunkid_t prev_free_chunk(struct z_heap *h, chunkid_t c)
@@ -125,6 +130,18 @@ static inline chunkid_t next_free_chunk(struct z_heap *h, chunkid_t c)
 	return chunk_field(h, c, FREE_NEXT);
 }
 
+static inline void set_prev_free_chunk(struct z_heap *h, chunkid_t c,
+				       chunkid_t prev)
+{
+	chunk_set(h, c, FREE_PREV, prev);
+}
+
+static inline void set_next_free_chunk(struct z_heap *h, chunkid_t c,
+				       chunkid_t next)
+{
+	chunk_set(h, c, FREE_NEXT, next);
+}
+
 static inline chunkid_t left_chunk(struct z_heap *h, chunkid_t c)
 {
 	return c - chunk_field(h, c, LEFT_SIZE);
@@ -133,6 +150,12 @@ static inline chunkid_t left_chunk(struct z_heap *h, chunkid_t c)
 static inline chunkid_t right_chunk(struct z_heap *h, chunkid_t c)
 {
 	return c + chunk_size(h, c);
+}
+
+static inline void set_left_chunk_size(struct z_heap *h, chunkid_t c,
+				       size_t size)
+{
+	chunk_set(h, c, LEFT_SIZE, size);
 }
 
 static inline size_t chunk_header_bytes(struct z_heap *h)


### PR DESCRIPTION
This goes on top of PR #23941 and therefore patches from PR #23941 are included here.

This series implements an assortment of optimizations providing both
execution efficiency and footprint overhead reduction. Because of that, a few tests presuming a higher overhead are now failing.

I'm posting this here for people to see and comment.