### PR TITLE
adc: nordic: move to new DT API and kconfig style

### DIFF
--- a/boards/arm/actinius_icarus/Kconfig.defconfig
+++ b/boards/arm/actinius_icarus/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_ACTINIUS_ICARUS || BOARD_ACTINIUS_ICARUS_NS
 config BOARD
 	default "actinius_icarus"
 
-config ADC_0
-	default y
-	depends on ADC
-
 config PWM_0
 	default y
 	depends on PWM

--- a/boards/arm/adafruit_feather_nrf52840/Kconfig.defconfig
+++ b/boards/arm/adafruit_feather_nrf52840/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_ADAFRUIT_FEATHER_NRF52840
 config BOARD
 	default "adafruit_feather_nrf52840"
 
-config ADC_0
-	default y
-	depends on ADC
-
 if USB
 
 config USB_NRFX

--- a/boards/arm/bl652_dvk/Kconfig.defconfig
+++ b/boards/arm/bl652_dvk/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_BL652_DVK
 config BOARD
 	default "bl652_dvk"
 
-config ADC_0
-	default y
-	depends on ADC
-
 config PWM_0
 	default y
 	depends on PWM

--- a/boards/arm/bl654_dvk/Kconfig.defconfig
+++ b/boards/arm/bl654_dvk/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_BL654_DVK
 config BOARD
 	default "bl654_dvk"
 
-config ADC_0
-	default y
-	depends on ADC
-
 config PWM_0
 	default y
 	depends on PWM

--- a/boards/arm/decawave_dwm1001_dev/Kconfig.defconfig
+++ b/boards/arm/decawave_dwm1001_dev/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_DECAWAVE_DWM1001_DEV
 config BOARD
 	default "decawave_dwm1001_dev"
 
-config ADC_0
-	default y
-	depends on ADC
-
 config PWM_0
 	default y
 	depends on PWM

--- a/boards/arm/degu_evk/Kconfig.defconfig
+++ b/boards/arm/degu_evk/Kconfig.defconfig
@@ -40,10 +40,6 @@ config IEEE802154_NRF5
 	default y
 	depends on IEEE802154
 
-config ADC_0
-	default y
-	depends on ADC
-
 if DISK_ACCESS_FLASH
 
 config DISK_FLASH_DEV_NAME

--- a/boards/arm/nrf51dk_nrf51422/Kconfig.defconfig
+++ b/boards/arm/nrf51dk_nrf51422/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_NRF51DK_NRF51422
 config BOARD
 	default "nrf51dk_nrf51422"
 
-config ADC_0
-	default y
-	depends on ADC
-
 config BT_CTLR
 	default BT
 

--- a/boards/arm/nrf51dongle_nrf51422/Kconfig.defconfig
+++ b/boards/arm/nrf51dongle_nrf51422/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_NRF51DONGLE_NRF51422
 config BOARD
 	default "nrf51dongle_nrf51422"
 
-config ADC_0
-	default y
-	depends on ADC
-
 config BT_CTLR
 	default BT
 

--- a/boards/arm/nrf52833dk_nrf52833/Kconfig.defconfig
+++ b/boards/arm/nrf52833dk_nrf52833/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_NRF52833DK_NRF52833
 config BOARD
 	default "nrf52833dk_nrf52833"
 
-config ADC_0
-	default y
-	depends on ADC
-
 config PWM_0
 	default y
 	depends on PWM

--- a/boards/arm/nrf52840_blip/Kconfig.defconfig
+++ b/boards/arm/nrf52840_blip/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_NRF52840_BLIP
 config BOARD
 	default "nrf52840_blip"
 
-config ADC_0
-	default y
-	depends on ADC
-
 if USB
 
 config USB_NRFX

--- a/boards/arm/nrf52840_mdk/Kconfig.defconfig
+++ b/boards/arm/nrf52840_mdk/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_NRF52840_MDK
 config BOARD
 	default "nrf52840_mdk"
 
-config ADC_0
-	default y
-	depends on ADC
-
 config PWM_0
 	default y
 	depends on PWM

--- a/boards/arm/nrf52840_papyr/Kconfig.defconfig
+++ b/boards/arm/nrf52840_papyr/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_NRF52840_PAPYR
 config BOARD
 	default "nrf52840_papyr"
 
-config ADC_0
-	default y
-	depends on ADC
-
 if USB
 
 config USB_NRFX

--- a/boards/arm/nrf52840dk_nrf52811/Kconfig.defconfig
+++ b/boards/arm/nrf52840dk_nrf52811/Kconfig.defconfig
@@ -11,10 +11,6 @@ config BOARD
 config BT_CTLR
 	default BT
 
-config ADC_0
-	default y
-	depends on ADC
-
 config PWM_0
 	default y
 	depends on PWM

--- a/boards/arm/nrf52840dk_nrf52840/Kconfig.defconfig
+++ b/boards/arm/nrf52840dk_nrf52840/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_NRF52840DK_NRF52840
 config BOARD
 	default "nrf52840dk_nrf52840"
 
-config ADC_0
-	default y
-	depends on ADC
-
 config PWM_0
 	default y
 	depends on PWM

--- a/boards/arm/nrf52840dongle_nrf52840/Kconfig.defconfig
+++ b/boards/arm/nrf52840dongle_nrf52840/Kconfig.defconfig
@@ -24,10 +24,6 @@ config FLASH_LOAD_OFFSET
 	default 0x1000
 	depends on BOARD_HAS_NRF5_BOOTLOADER && !USE_DT_CODE_PARTITION
 
-config ADC_0
-	default y
-	depends on ADC
-
 config PWM_0
 	default y
 	depends on PWM

--- a/boards/arm/nrf52dk_nrf52810/Kconfig.defconfig
+++ b/boards/arm/nrf52dk_nrf52810/Kconfig.defconfig
@@ -8,8 +8,4 @@ if BOARD_NRF52DK_NRF52810
 config BOARD
 	default "nrf52dk_nrf52810"
 
-config ADC_0
-	default y
-	depends on ADC
-
 endif # BOARD_NRF52DK_NRF52810

--- a/boards/arm/nrf52dk_nrf52832/Kconfig.defconfig
+++ b/boards/arm/nrf52dk_nrf52832/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_NRF52DK_NRF52832
 config BOARD
 	default "nrf52dk_nrf52832"
 
-config ADC_0
-	default y
-	depends on ADC
-
 config PWM_0
 	default y
 	depends on PWM

--- a/boards/arm/nrf5340pdk_nrf5340/Kconfig.defconfig
+++ b/boards/arm/nrf5340pdk_nrf5340/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_NRF5340PDK_NRF5340_CPUAPP || BOARD_NRF5340PDK_NRF5340_CPUAPPNS
 config BOARD
 	default "nrf5340pdk_nrf5340_cpuapp"
 
-config ADC_0
-	default y
-	depends on ADC
-
 config PWM_0
 	default y
 	depends on PWM

--- a/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
+++ b/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_NRF9160DK_NRF9160 || BOARD_NRF9160DK_NRF9160NS
 config BOARD
 	default "nrf9160dk_nrf9160"
 
-config ADC_0
-	default y
-	depends on ADC
-
 config PWM_0
 	default y
 	depends on PWM

--- a/boards/arm/particle_argon/Kconfig.defconfig
+++ b/boards/arm/particle_argon/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_PARTICLE_ARGON
 config BOARD
 	default "particle_argon"
 
-config ADC_0
-	default y
-	depends on ADC
-
 if USB
 
 config USB_NRFX

--- a/boards/arm/particle_boron/Kconfig.defconfig
+++ b/boards/arm/particle_boron/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_PARTICLE_BORON
 config BOARD
 	default "particle_boron"
 
-config ADC_0
-	default y
-	depends on ADC
-
 if USB
 
 config USB_NRFX

--- a/boards/arm/particle_xenon/Kconfig.defconfig
+++ b/boards/arm/particle_xenon/Kconfig.defconfig
@@ -9,10 +9,6 @@ if BOARD_PARTICLE_XENON
 config BOARD
 	default "particle_xenon"
 
-config ADC_0
-	default y
-	depends on ADC
-
 if USB
 
 config USB_NRFX

--- a/boards/arm/thingy52_nrf52832/Kconfig.defconfig
+++ b/boards/arm/thingy52_nrf52832/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_THINGY52_NRF52832
 config BOARD
 	default "thingy52_nrf52832"
 
-config ADC_0
-	default y
-	depends on ADC
-
 config I2C
 	default y
 

--- a/drivers/adc/Kconfig.nrfx
+++ b/drivers/adc/Kconfig.nrfx
@@ -3,10 +3,14 @@
 # Copyright (c) 2018, Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+# Workaround for not being able to have commas in macro arguments
+DT_COMPAT_NORDIC_NRF_ADC   := nordic,nrf-adc
+DT_COMPAT_NORDIC_NRF_SAADC := nordic,nrf-saadc
+
 config ADC_NRFX_ADC
 	bool "nRF ADC nrfx driver"
 	default y
-	depends on HAS_HW_NRF_ADC
+	depends on HAS_HW_NRF_ADC && $(dt_nodelabel_has_compat,adc,$(DT_COMPAT_NORDIC_NRF_ADC))
 	select NRFX_ADC
 	select ADC_CONFIGURABLE_INPUTS
 	help
@@ -25,7 +29,14 @@ config ADC_NRFX_ADC_CHANNEL_COUNT
 config ADC_NRFX_SAADC
 	bool "nRF SAADC nrfx driver"
 	default y
-	depends on HAS_HW_NRF_SAADC
+	depends on HAS_HW_NRF_SAADC && $(dt_nodelabel_has_compat,adc,$(DT_COMPAT_NORDIC_NRF_SAADC))
 	select ADC_CONFIGURABLE_INPUTS
 	help
-	  Enable support for nrfx SAADC driver for nRF52 MCU series.
+	  Enable support for nrfx SAADC driver.
+
+# We enable ADC_0 here for the sake of other code in Zephyr that
+# depends on it. Device instantiation within nRF ADC drivers is
+# entirely driven by whether the devicetree nodes with compatibles
+# nordic,nrf-adc and nordic,nrf-saadc are enabled.
+config ADC_0
+	def_bool ADC_NRFX_ADC || ADC_NRFX_SAADC

--- a/drivers/adc/adc_nrfx_adc.c
+++ b/drivers/adc/adc_nrfx_adc.c
@@ -12,6 +12,8 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(adc_nrfx_adc);
 
+#define DT_DRV_COMPAT nordic_nrf_adc
+
 struct driver_data {
 	struct adc_context ctx;
 
@@ -259,8 +261,7 @@ static int init_adc(struct device *dev)
 		return -EBUSY;
 	}
 
-	IRQ_CONNECT(DT_NORDIC_NRF_ADC_ADC_0_IRQ_0,
-		    DT_NORDIC_NRF_ADC_ADC_0_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
 		    nrfx_isr, nrfx_adc_irq_handler, 0);
 
 	adc_context_unlock_unconditionally(&m_data.ctx);
@@ -277,9 +278,9 @@ static const struct adc_driver_api adc_nrfx_driver_api = {
 	.ref_internal  = 1200,
 };
 
-#ifdef CONFIG_ADC_0
-DEVICE_AND_API_INIT(adc_0, DT_NORDIC_NRF_ADC_ADC_0_LABEL,
+#if DT_HAS_DRV_INST(0)
+DEVICE_AND_API_INIT(adc_0, DT_INST_LABEL(0),
 		    init_adc, NULL, NULL,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &adc_nrfx_driver_api);
-#endif /* CONFIG_ADC_0 */
+#endif

--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -12,6 +12,8 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(adc_nrfx_saadc);
 
+#define DT_DRV_COMPAT nordic_nrf_saadc
+
 struct driver_data {
 	struct adc_context ctx;
 
@@ -397,10 +399,9 @@ static int init_saadc(struct device *dev)
 	nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_CALIBRATEDONE);
 	nrf_saadc_int_enable(NRF_SAADC,
 			     NRF_SAADC_INT_END | NRF_SAADC_INT_CALIBRATEDONE);
-	NRFX_IRQ_ENABLE(DT_NORDIC_NRF_SAADC_ADC_0_IRQ_0);
+	NRFX_IRQ_ENABLE(DT_INST_IRQN(0));
 
-	IRQ_CONNECT(DT_NORDIC_NRF_SAADC_ADC_0_IRQ_0,
-		    DT_NORDIC_NRF_SAADC_ADC_0_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
 		    saadc_irq_handler, DEVICE_GET(adc_0), 0);
 
 	adc_context_unlock_unconditionally(&m_data.ctx);
@@ -417,9 +418,9 @@ static const struct adc_driver_api adc_nrfx_driver_api = {
 	.ref_internal  = 600,
 };
 
-#ifdef CONFIG_ADC_0
-DEVICE_AND_API_INIT(adc_0, DT_NORDIC_NRF_SAADC_ADC_0_LABEL,
+#if DT_HAS_DRV_INST(0)
+DEVICE_AND_API_INIT(adc_0, DT_INST_LABEL(0),
 		    init_saadc, NULL, NULL,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &adc_nrfx_driver_api);
-#endif /* CONFIG_ADC_0 */
+#endif


### PR DESCRIPTION
Use the new devicetree API. Remove per-board enabling of ADC_0 by
setting ADC_0 to default y when the 'adc' node label points at an
enabled node of the expected compatible (depending on SoC).

