### PR TITLE
drivers: ethernet: sam_gmac: Fix Kconfig device tree property reference

### DIFF
--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -15,7 +15,7 @@ if ETH_SAM_GMAC
 config ETH_SAM_GMAC_QUEUES
 	int "Number of active hardware TX and RX queues"
 	default 1
-	range 1 $(dt_node_int_prop_int,/soc/ethernet@40050088,num-queues)
+	range 1 $(dt_node_int_prop_int,eth-0,num-queues)
 	help
 	  Select the number of hardware queues used by the driver. Packets will be
 	  routed to appropriate queues based on their priority.

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -12,6 +12,8 @@
 / {
 	aliases {
 		watchdog0 = &wdt;
+
+		eth-0 = &gmac;
 	};
 
 	cpus {


### PR DESCRIPTION
This commit fixes the path-based device tree property reference in
Kconfig, which contains SoC-specific GMAC device address (in this case,
SAM E70), to use alias instead.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

This fixes a bug/oversight introduced in #24057.