### PR TITLE
doc: remove licensing for moved ext/ components

### DIFF
--- a/doc/LICENSING.rst
+++ b/doc/LICENSING.rst
@@ -20,11 +20,3 @@ licensing in this document.
   *Origin:* Linux Kernel
 
   *Licensing:* `GPLv2 License`_
-
-*ext/hal/cmsis/*
-  *Origin:* https://github.com/ARM-software/CMSIS_5.git
-
-  *Licensing*: Apache 2.0 (see `ext/hal/cmsis source`_)
-
-.. _ext/hal/cmsis source:
-   https://github.com/zephyrproject-rtos/zephyr/blob/master/ext/hal/cmsis/Include/cmsis_version.h


### PR DESCRIPTION
ext/hal/cmsis was moved out of the ext folder and into external modules
so we should remove the licensing exceptions noted in this document.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>