### PR TITLE
doc: provide a target to only generate doxygen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,6 @@ htmldocs-fast:
 
 pdfdocs:
 	mkdir -p ${BUILDDIR} && cmake -GNinja -DDOC_TAG=${DOC_TAG} -DSPHINXOPTS=${SPHINXOPTS} -B${BUILDDIR} -Hdoc/ && ninja -C ${BUILDDIR} pdfdocs
+
+doxygen:
+	mkdir -p ${BUILDDIR} && cmake -GNinja -DDOC_TAG=${DOC_TAG} -DSPHINXOPTS=${SPHINXOPTS} -B${BUILDDIR} -Hdoc/ && ninja -C ${BUILDDIR} doxygen

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -347,6 +347,12 @@ add_custom_target(
 )
 add_dependencies(htmldocs html)
 
+
+add_custom_target(
+  doxygen
+)
+add_dependencies(doxygen doxy_real_modified_times)
+
 add_dependencies(latex content doxy_real_modified_times kconfig)
 
 add_custom_target(

--- a/scripts/ci/sanitycheck_ignore.txt
+++ b/scripts/ci/sanitycheck_ignore.txt
@@ -18,6 +18,7 @@ LICENSE
 Makefile
 tests/*
 samples/*
+doc/*
 *.rst
 *.md
 # if we change this file or associated script, it should not trigger a full


### PR DESCRIPTION
Sometimes you are only interested in doxygen, so need to wait 10 minutes
for everything to generate in this case. Now just do:

 make doxygen

and get only the doxygen output.