### PR TITLE
arch: riscv: irq: fix build warning

### DIFF
--- a/arch/riscv/core/irq_manage.c
+++ b/arch/riscv/core/irq_manage.c
@@ -34,16 +34,12 @@ int arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
 			     void (*routine)(void *parameter), void *parameter,
 			     u32_t flags)
 {
-	unsigned int level;
-
 	ARG_UNUSED(flags);
 
 	z_isr_install(irq, routine, parameter);
 
 #if defined(CONFIG_RISCV_HAS_PLIC)
-	level = irq_get_level(irq);
-
-	if (level == 2) {
+	if (irq_get_level(irq) == 2) {
 		irq = irq_from_level_2(irq);
 
 		riscv_plic_set_priority(irq, priority);


### PR DESCRIPTION
In arch_irq_connect_dynamic the 'level' variable is only used on
platforms that define CONFIG_RISCV_HAS_PLIC.  For the other platforms
we'll get a warning about an unused variable.  Mark 'level' as
ARG_UNUSED in those cases.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>