### PR TITLE
drivers: ethernet: sam_gmac: simplify ETH_SAM_GMAC_QUEUES Kconfig

### DIFF
--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -15,7 +15,7 @@ if ETH_SAM_GMAC
 config ETH_SAM_GMAC_QUEUES
 	int "Number of active hardware TX and RX queues"
 	default 1
-	range 1 $(dt_node_int_prop_int,/soc/ethernet@40050088,num-queues)
+	range 1 6
 	help
 	  Select the number of hardware queues used by the driver. Packets will be
 	  routed to appropriate queues based on their priority.

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -49,6 +49,10 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 /*
  * Verify Kconfig configuration
  */
+#if CONFIG_ETH_SAM_GMAC_QUEUES > DT_INST_PROP(0, num_queues)
+#error Number of active hardware TX and RX queues is invalid
+#endif
+
 /* No need to verify things for unit tests */
 #if !defined(CONFIG_NET_TEST)
 #if CONFIG_NET_BUF_DATA_SIZE * CONFIG_ETH_SAM_GMAC_BUF_RX_COUNT \


### PR DESCRIPTION
Make the max range for ETH_SAM_GMAC_QUEUES Kconfig symbol a fixed value
rather than coming from devicetree.  We than add an error check to
verify the value against the device tree 'num-queues' property in the
driver itself.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>