### PR TITLE
drivers: uart: update for k_timeout API

### DIFF
--- a/include/drivers/uart.h
+++ b/include/drivers/uart.h
@@ -456,7 +456,7 @@ static inline int uart_callback_set(struct device *dev,
  * @param buf     Pointer to transmit buffer.
  * @param len     Length of transmit buffer.
  * @param timeout Timeout in milliseconds. Valid only if flow control is
- *		  enabled. K_FOREVER disables timeout.
+ *		  enabled. -1 disables timeout.
  *
  * @retval -EBUSY There is already an ongoing transfer.
  * @retval 0	  If successful, negative errno code otherwise.
@@ -504,7 +504,7 @@ static inline int z_impl_uart_tx_abort(struct device *dev)
  * @param dev     UART device structure.
  * @param buf     Pointer to receive buffer.
  * @param len     Buffer length.
- * @param timeout Timeout in milliseconds. K_FOREVER disables timeout.
+ * @param timeout Timeout in milliseconds. -1 disables timeout.
  *
  * @retval -EBUSY RX already in progress.
  * @retval 0	  If successful, negative errno code otherwise.

--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -403,16 +403,16 @@ void test_forever_timeout(void)
 	memset(rx_buf, 0, sizeof(rx_buf));
 	memset(tx_buf, 1, sizeof(tx_buf));
 
-	uart_rx_enable(uart_dev, rx_buf, sizeof(rx_buf), K_FOREVER);
+	uart_rx_enable(uart_dev, rx_buf, sizeof(rx_buf), -1);
 
-	uart_tx(uart_dev, tx_buf, 5, K_FOREVER);
+	uart_tx(uart_dev, tx_buf, 5, -1);
 	zassert_not_equal(k_sem_take(&tx_aborted, K_MSEC(1000)), 0,
 			  "TX_ABORTED timeout");
 	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
 	zassert_not_equal(k_sem_take(&rx_rdy, K_MSEC(1000)), 0,
 			  "RX_RDY timeout");
 
-	uart_tx(uart_dev, tx_buf, 95, K_FOREVER);
+	uart_tx(uart_dev, tx_buf, 95, -1);
 
 	zassert_not_equal(k_sem_take(&tx_aborted, K_MSEC(1000)), 0,
 			  "TX_ABORTED timeout");


### PR DESCRIPTION
The timeout parameter for the UART asynchronous API is a signed
integral number of milliseconds.  The API does not document behavior
on negative values, but from legacy use of K_FOREVER a value of -1
disables the timeout.

Update the documentation to not suggest using K_FOREVER (which is not
necessarily an integer), and replace the in-tree misuse of that
constant.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>