### PR TITLE
drivers: can: update for k_timeout API

### DIFF
--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -198,7 +198,7 @@ static int cmd_send(const struct shell *shell, size_t argc, char **argv)
 		    ext ? frame.ext_id : frame.std_id,
 		    ext ? "extended" : "standard", frame.dlc);
 
-	ret = can_send(can_dev, &frame, K_FOREVER, NULL, NULL);
+	ret = can_send(can_dev, &frame, -1, NULL, NULL);
 	if (ret) {
 		shell_error(shell, "Failed to send frame [%d]", ret);
 		return -EIO;

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -333,7 +333,8 @@ __subsystem struct can_driver_api {
  * *
  * @param dev          Pointer to the device structure for the driver instance.
  * @param msg          Message to transfer.
- * @param timeout      Waiting for empty tx mailbox timeout in ms or K_FOREVER.
+ * @param timeout      Waiting for empty tx mailbox timeout in ms or -1 to
+ *                     disable timeout.
  * @param callback_isr Is called when message was sent or a transmission error
  *                     occurred. If NULL, this function is blocking until
  *                     message is sent. This must be NULL if called from user
@@ -372,7 +373,8 @@ static inline int z_impl_can_send(struct device *dev,
  * @param length Number of bytes to write (max. 8).
  * @param id  Identifier of the can message.
  * @param rtr Send remote transmission request or data frame
- * @param timeout Waiting for empty tx mailbox timeout in ms or K_FOREVER
+ * @param timeout Waiting for empty tx mailbox timeout in ms or -1
+ *                to disable timeout.
  *
  * @retval 0 If successful.
  * @retval -EIO General input / output error.
@@ -554,7 +556,8 @@ enum can_state z_impl_can_get_state(struct device *dev,
  * Recover the CAN controller from bus-off state to error-active state.
  *
  * @param dev     Pointer to the device structure for the driver instance.
- * @param timeout Timeout for waiting for the recovery.
+ * @param timeout Timeout for waiting for the recovery, in milliseconds.
+ *                Pass -1 to disable timeout.
  *
  * @retval 0 on success.
  * @retval CAN_TIMEOUT on timeout.

--- a/samples/drivers/CAN/src/main.c
+++ b/samples/drivers/CAN/src/main.c
@@ -257,7 +257,7 @@ void main(void)
 	while (1) {
 		change_led_frame.data[0] = toggle++ & 0x01 ? SET_LED : RESET_LED;
 		/* This sending call is none blocking. */
-		can_send(can_dev, &change_led_frame, K_FOREVER, tx_irq_callback,
+		can_send(can_dev, &change_led_frame, -1, tx_irq_callback,
 			 "LED change");
 		k_sleep(SLEEP_TIME);
 

--- a/subsys/canbus/canopen/CO_driver.c
+++ b/subsys/canbus/canopen/CO_driver.c
@@ -133,7 +133,7 @@ static void canopen_tx_retry(struct k_work *item)
 			msg.rtr = (buffer->rtr ? 1 : 0);
 			memcpy(msg.data, buffer->data, buffer->DLC);
 
-			err = can_send(CANmodule->dev, &msg, K_NO_WAIT,
+			err = can_send(CANmodule->dev, &msg, 0,
 				       canopen_tx_isr_callback, CANmodule);
 			if (err == CAN_TIMEOUT) {
 				break;
@@ -345,7 +345,7 @@ CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer)
 	msg.rtr = (buffer->rtr ? 1 : 0);
 	memcpy(msg.data, buffer->data, buffer->DLC);
 
-	err = can_send(CANmodule->dev, &msg, K_NO_WAIT, canopen_tx_isr_callback,
+	err = can_send(CANmodule->dev, &msg, 0, canopen_tx_isr_callback,
 		       CANmodule);
 	if (err == CAN_TIMEOUT) {
 		buffer->bufferFull = true;

--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -403,16 +403,16 @@ void test_forever_timeout(void)
 	memset(rx_buf, 0, sizeof(rx_buf));
 	memset(tx_buf, 1, sizeof(tx_buf));
 
-	uart_rx_enable(uart_dev, rx_buf, sizeof(rx_buf), K_FOREVER);
+	uart_rx_enable(uart_dev, rx_buf, sizeof(rx_buf), -1);
 
-	uart_tx(uart_dev, tx_buf, 5, K_FOREVER);
+	uart_tx(uart_dev, tx_buf, 5, -1);
 	zassert_not_equal(k_sem_take(&tx_aborted, K_MSEC(1000)), 0,
 			  "TX_ABORTED timeout");
 	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
 	zassert_not_equal(k_sem_take(&rx_rdy, K_MSEC(1000)), 0,
 			  "RX_RDY timeout");
 
-	uart_tx(uart_dev, tx_buf, 95, K_FOREVER);
+	uart_tx(uart_dev, tx_buf, 95, -1);
 
 	zassert_not_equal(k_sem_take(&tx_aborted, K_MSEC(1000)), 0,
 			  "TX_ABORTED timeout");


### PR DESCRIPTION
The timeout parameter for the CAN API is a signed integral number of
milliseconds.  The API does not document behavior on negative values,
but from legacy use of K_FOREVER a value of -1 disables the timeout.

Update the documentation to not suggest using K_FOREVER (which is not
necessarily an integer), and replace the in-tree misuse of that
constant.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>