### PR TITLE
drivers: lora: update for k_timeout API

### DIFF
--- a/include/drivers/lora.h
+++ b/include/drivers/lora.h
@@ -124,8 +124,8 @@ static inline int lora_send(struct device *dev,
  * @param data      Buffer to hold received data
  * @param size      Size of the buffer to hold the received data. Max size
 		    allowed is 255.
- * @param timeout   Timeout value in milliseconds. API also accepts, K_NO_WAIT
-		    for no wait time and K_FOREVER for blocking until
+ * @param timeout   Timeout value in milliseconds. API also accepts, 0
+		    for no wait time and -1 for blocking until
 		    data arrives.
  * @param rssi      RSSI of received data
  * @param snr       SNR of received data

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -47,7 +47,7 @@ void main(void)
 
 	while (1) {
 		/* Block until data arrives */
-		len = lora_recv(lora_dev, data, MAX_DATA_LEN, K_FOREVER,
+		len = lora_recv(lora_dev, data, MAX_DATA_LEN, -1,
 				&rssi, &snr);
 		if (len < 0) {
 			LOG_ERR("LoRa receive failed");


### PR DESCRIPTION
The timeout parameter for the LoRa API is a signed integral number of
milliseconds.  The API does not document behavior on negative values,
but from legacy use of K_FOREVER a value of -1 disables the timeout.

Update the documentation to not suggest using K_FOREVER (which is not
necessarily an integer), and replace the in-tree misuse of that
constant.