### PR TITLE
drivers: i2c: fix esp32 timeout parameter

### DIFF
--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -286,7 +286,7 @@ static int i2c_esp32_transmit(struct device *dev)
 
 	/* Start transmission and wait for the ISR to give the semaphore */
 	sys_set_bit(I2C_CTR_REG(config->index), I2C_TRANS_START_S);
-	if (k_sem_take(&data->fifo_sem, I2C_ESP32_TIMEOUT_MS) < 0) {
+	if (k_sem_take(&data->fifo_sem, K_MSEC(I2C_ESP32_TIMEOUT_MS)) < 0) {
 		return -ETIMEDOUT;
 	}
 


### PR DESCRIPTION
The value is millseconds and must be wrapped for use with the new timeout API.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>