### PR TITLE
drivers: hwinfo: fix ESP32 implementation

### DIFF
--- a/drivers/hwinfo/hwinfo_esp32.c
+++ b/drivers/hwinfo/hwinfo_esp32.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019 Leandro A. F. Pereira
+ * Copyright (c) 2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,18 +10,29 @@
 #include <drivers/hwinfo.h>
 #include <string.h>
 
-ssize_t _impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
+ssize_t z_impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
 {
-	uint32_t fuse_rdata[] = {
-		sys_read32(EFUSE_BLK0_RDATA1_REG),
-		sys_read32(EFUSE_BLK0_RDATA2_REG),
-	};
+	u32_t rdata1 = sys_read32(EFUSE_BLK0_RDATA1_REG);
+	u32_t rdata2 = sys_read32(EFUSE_BLK0_RDATA2_REG);
+	u8_t id[6];
 
-	if (length > sizeof(fuse_rdata)) {
-		length = sizeof(fuse_rdata);
+	/* The first word provides the lower 32 bits of the MAC
+	 * address; the low 16 bits of the second word provide the
+	 * upper 16 bytes of the MAC address.  The upper 16 bits are
+	 * (apparently) a checksum, and reserved.  See ESP32 Technical
+	 * Reference Manual V4.1 section 20.5.
+	 */
+	id[0] = (u8_t)(rdata2 >> 8);
+	id[1] = (u8_t)(rdata2 >> 0);
+	id[2] = (u8_t)(rdata1 >> 24);
+	id[3] = (u8_t)(rdata1 >> 16);
+	id[4] = (u8_t)(rdata1 >> 8);
+	id[5] = (u8_t)(rdata1 >> 0);
+
+	if (length > sizeof(id)) {
+		length = sizeof(id);
 	}
-
-	memcpy(buffer, fuse_rdata, length);
+	memcpy(buffer, id, length);
 
 	return length;
 }


### PR DESCRIPTION
~*PR depends on #24266; DNM until that's merged*~

Add the missing prefix z_ required to make the ESP32 version override
the weak implementation.

General practice in ESP32 seems to be to use the MAC address, so
extract that in its canonical byte order.
