### PR TITLE
doc: kernel: Use K_NO_WAIT instead of 0 for one-shot timers

### DIFF
--- a/doc/reference/kernel/timing/timers.rst
+++ b/doc/reference/kernel/timing/timers.rst
@@ -26,10 +26,10 @@ A timer has the following key properties:
 
 * A :dfn:`period` specifying the time interval between all timer expirations
   after the first one, measured in milliseconds. It must be non-negative.
-  A period of zero means that the timer is a one shot timer that stops
-  after a single expiration. (For example then, if a timer is started with a
-  duration of 200 and a period of 75, it will first expire after 200ms and
-  then every 75ms after that.)
+  If the period is set to :c:macro:`K_NO_WAIT` it means that the timer is a one
+  shot timer that stops after a single expiration. (For example then, if a timer
+  is started with a duration of 200 and a period of 75, it will first expire
+  after 200ms and then every 75ms after that.)
 
 * An :dfn:`expiry function` that is executed each time the timer expires.
   The function is executed by the system clock interrupt handler.
@@ -165,7 +165,7 @@ if the timer has expired on not.
     ...
 
     /* start one shot timer that expires after 200 ms */
-    k_timer_start(&my_status_timer, K_MSEC(200), 0);
+    k_timer_start(&my_status_timer, K_MSEC(200), K_NO_WAIT);
 
     /* do work */
     ...
@@ -196,7 +196,7 @@ are separated by the specified time interval.
     ...
 
     /* start one shot timer that expires after 500 ms */
-    k_timer_start(&my_sync_timer, K_MSEC(500), 0);
+    k_timer_start(&my_sync_timer, K_MSEC(500), K_NO_WAIT);
 
     /* do other work */
     ...


### PR DESCRIPTION
After the transition to k_timeout_t, immediate values are not valid
unless the legacy timeout system is used, so transition to using a valid
kernel timeout value instead (K_NO_WAIT).

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>