### PR TITLE
drivers: hwinfo: update NXP platforms for byte order consistency

### DIFF
--- a/drivers/hwinfo/hwinfo_imxrt.c
+++ b/drivers/hwinfo/hwinfo_imxrt.c
@@ -7,6 +7,7 @@
 #include <soc.h>
 #include <drivers/hwinfo.h>
 #include <string.h>
+#include <sys/byteorder.h>
 
 struct imxrt_uid {
 	u32_t id[2];
@@ -16,8 +17,8 @@ ssize_t z_impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
 {
 	struct imxrt_uid dev_id;
 
-	dev_id.id[0] = OCOTP->CFG1;
-	dev_id.id[1] = OCOTP->CFG2;
+	dev_id.id[0] = sys_cpu_to_be32(OCOTP->CFG2);
+	dev_id.id[1] = sys_cpu_to_be32(OCOTP->CFG1);
 
 	if (length > sizeof(dev_id.id)) {
 		length = sizeof(dev_id.id);

--- a/drivers/hwinfo/hwinfo_mcux_sim.c
+++ b/drivers/hwinfo/hwinfo_mcux_sim.c
@@ -7,6 +7,7 @@
 #include <drivers/hwinfo.h>
 #include <string.h>
 #include <fsl_sim.h>
+#include <sys/byteorder.h>
 
 #if defined(SIM_UIDH)
 #define HWINFO_DEVICE_ID_LENGTH_H 1
@@ -24,30 +25,28 @@
 				       HWINFO_DEVICE_ID_LENGTH_M + \
 				       HWINFO_DEVICE_ID_LENGTH_H)
 
-struct kinetis_uid {
-	u32_t id[HWINFO_DEVICE_ID_LENGTH_TOTAL];
-};
-
 ssize_t z_impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
 {
-	struct kinetis_uid dev_id;
+	u32_t id[HWINFO_DEVICE_ID_LENGTH_TOTAL];
+	u32_t *idp = id;
 
-	dev_id.id[0] = SIM->UIDL;
-#if (defined(FSL_FEATURE_SIM_HAS_UIDM) && FSL_FEATURE_SIM_HAS_UIDM)
-	dev_id.id[1] = SIM->UIDM;
-#else
-	dev_id.id[1] = SIM->UIDML;
-	dev_id.id[2] = SIM->UIDMH;
 #if defined(SIM_UIDH)
-	dev_id.id[3] = SIM->UIDH;
+	*idp++ = sys_cpu_to_be32(SIM->UIDH);
 #endif /* SIM_UIDH */
-#endif /* defined(FSL_FEATURE_SIM_HAS_UIDM) && FSL_FEATURE_SIM_HAS_UIDM */
 
-	if (length > sizeof(dev_id.id)) {
-		length = sizeof(dev_id.id);
+#if (defined(FSL_FEATURE_SIM_HAS_UIDM) && FSL_FEATURE_SIM_HAS_UIDM)
+	*idp++ = sys_cpu_to_be32(SIM->UIDM);
+#else
+	*idp++ = sys_cpu_to_be32(SIM->UIDMH);
+	*idp++ = sys_cpu_to_be32(SIM->UIDML);
+#endif /* defined(FSL_FEATURE_SIM_HAS_UIDM) && FSL_FEATURE_SIM_HAS_UIDM */
+	*idp++ = sys_cpu_to_be32(SIM->UIDL);
+
+	if (length > sizeof(id)) {
+		length = sizeof(id);
 	}
 
-	memcpy(buffer, dev_id.id, length);
+	memcpy(buffer, id, length);
 
 	return length;
 }


### PR DESCRIPTION
Convert 32-bit values to big-endian representation for device-independent interpretation.