### PR TITLE
drivers: hwinfo: update stm32 implementation byte order

### DIFF
--- a/drivers/hwinfo/hwinfo_stm32.c
+++ b/drivers/hwinfo/hwinfo_stm32.c
@@ -7,6 +7,7 @@
 #include <soc.h>
 #include <drivers/hwinfo.h>
 #include <string.h>
+#include <sys/byteorder.h>
 
 struct stm32_uid {
 	u32_t id[3];
@@ -16,9 +17,9 @@ ssize_t z_impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
 {
 	struct stm32_uid dev_id;
 
-	dev_id.id[0] = LL_GetUID_Word0();
-	dev_id.id[1] = LL_GetUID_Word1();
-	dev_id.id[2] = LL_GetUID_Word2();
+	dev_id.id[0] = sys_cpu_to_be32(LL_GetUID_Word2());
+	dev_id.id[1] = sys_cpu_to_be32(LL_GetUID_Word1());
+	dev_id.id[2] = sys_cpu_to_be32(LL_GetUID_Word0());
 
 	if (length > sizeof(dev_id.id)) {
 		length = sizeof(dev_id.id);


### PR DESCRIPTION
The unique identifier for this platform is a 96-bit value, where the
upper 56 bits provide an ASCII encoding of the lot number, and the
lower 40 bits provide the wafer number and X, Y position on the wafer.
Extract the value into big-endian form for device-independent
interpretation.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>