### PR TITLE
toolchain: Fix warning about too few arguments on BUILD_ASSERT()

### DIFF
--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -141,7 +141,7 @@
 /* Compile-time assertion that makes the build to fail.
  * Common implementation swallows the message.
  */
-#define BUILD_ASSERT(EXPR, MSG)				 \
+#define BUILD_ASSERT(EXPR, MSG...) \
 	enum _CONCAT(__build_assert_enum, __COUNTER__) { \
 		_CONCAT(__build_assert, __COUNTER__) = 1 / !!(EXPR) \
 	}


### PR DESCRIPTION
Commit c408fa88a36a595306e96d9b06422e8d1c051c57 introduced changes
to the BUILD_ASSERT() macro so the MSG argument is optional.
However, in include/toolchain/common.h, the BUILD_ASSERT()
definition has not made the MSG argument as optional which results
in build errors complaing about too few arguments. Fix by adding
some dots there.

This is observed when using XCC (based on Clang 3.9).

Fixes #24008

Signed-off-by: Daniel Leung <daniel.leung@intel.com>