### PR TITLE
cmake: re-run if gen_defines changes

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -15,6 +15,7 @@ file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/include/generated)
 # functions in kconfigfunctions.py.
 #
 # See the Devicetree user guide in the Zephyr documentation for details.
+set(GEN_DEFINES_SCRIPT          ${ZEPHYR_BASE}/scripts/dts/gen_defines.py)
 set(ZEPHYR_DTS                  ${PROJECT_BINARY_DIR}/zephyr.dts)
 set(DEVICETREE_UNFIXED_H        ${PROJECT_BINARY_DIR}/include/generated/devicetree_unfixed.h)
 set(DEVICETREE_UNFIXED_LEGACY_H ${PROJECT_BINARY_DIR}/include/generated/devicetree_legacy_unfixed.h)
@@ -157,6 +158,7 @@ if(SUPPORTS_DTS)
   set_property(DIRECTORY APPEND PROPERTY
     CMAKE_CONFIGURE_DEPENDS
     ${include_files}
+    ${GEN_DEFINES_SCRIPT}
     )
 
   #
@@ -199,7 +201,7 @@ if(SUPPORTS_DTS)
   # Run gen_defines.py to create a header file and zephyr.dts.
   #
 
-  set(CMD_EXTRACT ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/dts/gen_defines.py
+  set(CMD_EXTRACT ${PYTHON_EXECUTABLE} ${GEN_DEFINES_SCRIPT}
   --dts ${BOARD}.dts.pre.tmp
   --dtc-flags '${EXTRA_DTC_FLAGS}'
   --bindings-dirs ${DTS_ROOT_BINDINGS}


### PR DESCRIPTION
Since gen_defines.py is run using execute_process() at CMake time, the
entire build system must be regenerated if it changes. Add the
dependency tracking to make this possible.
