### PR TITLE
scripts: west build: handle missing CMAKE_PROJECT_NAME

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -296,6 +296,12 @@ class Build(Forceable):
         if not self.cmake_cache:
             return          # That's all we can check without a cache.
 
+        if "CMAKE_PROJECT_NAME" not in self.cmake_cache:
+            # This happens sometimes when a build system is not
+            # completely generated due to an error during the
+            # CMake configuration phase.
+            self.run_cmake = True
+
         cached_app = self.cmake_cache.get('APPLICATION_SOURCE_DIR')
         log.dbg('APPLICATION_SOURCE_DIR:', cached_app,
                 level=log.VERBOSE_EXTREME)


### PR DESCRIPTION
If there is an error in the CMake configuration phase (this can happen
if a script run using execute_process() fails, for instance), the
build system is incompletely generated and future attempts to run
'west build' will fail. This manifests in the following error:

    Error: could not find CMAKE_PROJECT_NAME in Cache

Whenever we see that the cache exists but this variable is missing,
let's just force CMake to run again. This avoids the error in my
testing and is a bit more user friendly. I've seen multiple users
asking what to do in this situation; the answer is always "just build
it again", so we might as well do it for them.
