### PR TITLE
boards: qemu_cortex_r5: Remove ignore tags for working tests

### DIFF
--- a/boards/arm/qemu_cortex_r5/qemu_cortex_r5.yaml
+++ b/boards/arm/qemu_cortex_r5/qemu_cortex_r5.yaml
@@ -13,5 +13,3 @@ testing:
   default: true
   ignore_tags:
     - benchmark
-    - memory_protection
-    - userspace


### PR DESCRIPTION
While the Cortex-R arch port does not currently support memory
protection and userspace, the `memory_protection` and `userspace` test
tags should not be ignored because doing so can unintentionally disable
other relevant tests.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>