### PR TITLE
drivers: adc: adc_shell: Kconfig ADC_SHELL must depends on SHELL

### DIFF
--- a/drivers/adc/Kconfig
+++ b/drivers/adc/Kconfig
@@ -17,6 +17,7 @@ if ADC
 
 config ADC_SHELL
 	bool "Enable ADC Shell"
+	depends on SHELL
 	help
 	  Enable ADC Shell for testing.
 


### PR DESCRIPTION
To avoid linking errors ADC_SHELL must depends on SHELL.

Signed-off-by: Paolo Teti <paolo.teti@gmail.com>