### PR TITLE
arch: arm: aarch32: Fix read_timer_end_of_isr register preservation

### DIFF
--- a/arch/arm/core/aarch32/isr_wrapper.S
+++ b/arch/arm/core/aarch32/isr_wrapper.S
@@ -188,16 +188,9 @@ _idle_state_cleared:
 
 	ldm r1!,{r0,r3}	/* arg in r0, ISR in r3 */
 #ifdef CONFIG_EXECUTION_BENCHMARKING
-	stm sp!,{r0-r3} /* Save r0 to r3 into stack */
-	push {r0, lr}
+	push {r0, r3}	/* Save r0 and r3 into stack */
 	bl read_timer_end_of_isr
-#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-	pop {r0, r3}
-	mov lr,r3
-#else
-	pop {r0, lr}
-#endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
-	ldm sp!,{r0-r3} /* Restore r0 to r3 regs */
+	pop {r0, r3}	/* Restore r0 and r3 regs */
 #endif /* CONFIG_EXECUTION_BENCHMARKING */
 	blx r3		/* call ISR */
 

--- a/arch/common/timing_info_bench.c
+++ b/arch/common/timing_info_bench.c
@@ -43,13 +43,7 @@ u64_t arch_timing_value_swap_temp;
 #define TIMING_INFO_GET_TIMER_VALUE()  (TIMING_INFO_OS_GET_TIME())
 #define SUBTRACT_CLOCK_CYCLES(val)     (val)
 
-#elif defined(CONFIG_ARM64)
-#define TIMING_INFO_PRE_READ()
-#define TIMING_INFO_OS_GET_TIME()      (k_cycle_get_32())
-#define TIMING_INFO_GET_TIMER_VALUE()  (k_cycle_get_32())
-#define SUBTRACT_CLOCK_CYCLES(val)     ((u32_t)val)
-
-#elif defined(CONFIG_ARM)
+#elif defined(CONFIG_CPU_CORTEX_M)
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 #define TIMING_INFO_PRE_READ()
 #define TIMING_INFO_OS_GET_TIME()      (k_cycle_get_32())

--- a/arch/common/timing_info_bench.c
+++ b/arch/common/timing_info_bench.c
@@ -19,7 +19,7 @@ u32_t arch_timing_value_swap_end;
 u64_t arch_timing_value_swap_common;
 u64_t arch_timing_value_swap_temp;
 
-#ifdef CONFIG_NRF_RTC_TIMER
+#if defined(CONFIG_NRF_RTC_TIMER)
 #include <nrfx.h>
 
 /* To get current count of timer, first 1 need to be written into
@@ -31,38 +31,38 @@ u64_t arch_timing_value_swap_temp;
 #define TIMING_INFO_GET_TIMER_VALUE() (TIMING_INFO_OS_GET_TIME())
 #define SUBTRACT_CLOCK_CYCLES(val)    (val)
 
-#elif CONFIG_SOC_SERIES_MEC1501X
+#elif defined(CONFIG_SOC_SERIES_MEC1501X)
 #define TIMING_INFO_PRE_READ()
 #define TIMING_INFO_OS_GET_TIME()     (B32TMR1_REGS->CNT)
 #define TIMING_INFO_GET_TIMER_VALUE() (TIMING_INFO_OS_GET_TIME())
 #define SUBTRACT_CLOCK_CYCLES(val)    (val)
 
-#elif CONFIG_X86
+#elif defined(CONFIG_X86)
 #define TIMING_INFO_PRE_READ()
 #define TIMING_INFO_OS_GET_TIME()      (z_tsc_read())
 #define TIMING_INFO_GET_TIMER_VALUE()  (TIMING_INFO_OS_GET_TIME())
 #define SUBTRACT_CLOCK_CYCLES(val)     (val)
 
-#elif CONFIG_ARM64
+#elif defined(CONFIG_ARM64)
 #define TIMING_INFO_PRE_READ()
 #define TIMING_INFO_OS_GET_TIME()      (k_cycle_get_32())
 #define TIMING_INFO_GET_TIMER_VALUE()  (k_cycle_get_32())
 #define SUBTRACT_CLOCK_CYCLES(val)     ((u32_t)val)
 
-#elif CONFIG_ARM
+#elif defined(CONFIG_ARM)
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 #define TIMING_INFO_PRE_READ()
 #define TIMING_INFO_OS_GET_TIME()      (k_cycle_get_32())
 #define TIMING_INFO_GET_TIMER_VALUE()  (SysTick->VAL)
 #define SUBTRACT_CLOCK_CYCLES(val)     (SysTick->LOAD - (u32_t)val)
 
-#elif CONFIG_ARC
+#elif defined(CONFIG_ARC)
 #define TIMING_INFO_PRE_READ()
 #define TIMING_INFO_OS_GET_TIME()     (k_cycle_get_32())
 #define TIMING_INFO_GET_TIMER_VALUE() (z_arc_v2_aux_reg_read(_ARC_V2_TMR0_COUNT))
 #define SUBTRACT_CLOCK_CYCLES(val)    ((u32_t)val)
 
-#elif CONFIG_NIOS2
+#elif defined(CONFIG_NIOS2)
 #include "altera_avalon_timer_regs.h"
 #define TIMING_INFO_PRE_READ()         \
 	(IOWR_ALTERA_AVALON_TIMER_SNAPL(TIMER_0_BASE, 10))

--- a/boards/arm/qemu_cortex_r5/qemu_cortex_r5.yaml
+++ b/boards/arm/qemu_cortex_r5/qemu_cortex_r5.yaml
@@ -11,7 +11,3 @@ ram: 128
 flash: 1024
 testing:
   default: true
-  ignore_tags:
-    - benchmark
-    - memory_protection
-    - userspace

--- a/tests/benchmarks/timing_info/src/timing_info.h
+++ b/tests/benchmarks/timing_info/src/timing_info.h
@@ -56,13 +56,7 @@
 #define TIMING_INFO_GET_TIMER_VALUE()  (TIMING_INFO_OS_GET_TIME())
 #define SUBTRACT_CLOCK_CYCLES(val)     (val)
 
-#elif defined(CONFIG_ARM64)
-#define TIMING_INFO_PRE_READ()
-#define TIMING_INFO_OS_GET_TIME()      (k_cycle_get_32())
-#define TIMING_INFO_GET_TIMER_VALUE()  (k_cycle_get_32())
-#define SUBTRACT_CLOCK_CYCLES(val)     ((u32_t)val)
-
-#elif defined(CONFIG_ARM)
+#elif defined(CONFIG_CPU_CORTEX_M)
 #define TIMING_INFO_PRE_READ()
 #define TIMING_INFO_OS_GET_TIME()      (k_cycle_get_32())
 #define TIMING_INFO_GET_TIMER_VALUE()  (SysTick->VAL)

--- a/tests/benchmarks/timing_info/src/timing_info.h
+++ b/tests/benchmarks/timing_info/src/timing_info.h
@@ -33,7 +33,7 @@
  *
  * NOTE: Needed only when reading value from end of swap operation
  */
-#ifdef CONFIG_NRF_RTC_TIMER
+#if defined(CONFIG_NRF_RTC_TIMER)
 
 /* To get current count of timer, first 1 need to be written into
  * Capture Register and Current Count will be copied into corresponding
@@ -44,37 +44,37 @@
 #define TIMING_INFO_GET_TIMER_VALUE() (TIMING_INFO_OS_GET_TIME())
 #define SUBTRACT_CLOCK_CYCLES(val)    (val)
 
-#elif CONFIG_SOC_SERIES_MEC1501X
+#elif defined(CONFIG_SOC_SERIES_MEC1501X)
 #define TIMING_INFO_PRE_READ()
 #define TIMING_INFO_OS_GET_TIME()     (B32TMR1_REGS->CNT)
 #define TIMING_INFO_GET_TIMER_VALUE() (TIMING_INFO_OS_GET_TIME())
 #define SUBTRACT_CLOCK_CYCLES(val)    (val)
 
-#elif CONFIG_X86
+#elif defined(CONFIG_X86)
 #define TIMING_INFO_PRE_READ()
 #define TIMING_INFO_OS_GET_TIME()      (z_tsc_read())
 #define TIMING_INFO_GET_TIMER_VALUE()  (TIMING_INFO_OS_GET_TIME())
 #define SUBTRACT_CLOCK_CYCLES(val)     (val)
 
-#elif CONFIG_ARM64
+#elif defined(CONFIG_ARM64)
 #define TIMING_INFO_PRE_READ()
 #define TIMING_INFO_OS_GET_TIME()      (k_cycle_get_32())
 #define TIMING_INFO_GET_TIMER_VALUE()  (k_cycle_get_32())
 #define SUBTRACT_CLOCK_CYCLES(val)     ((u32_t)val)
 
-#elif CONFIG_ARM
+#elif defined(CONFIG_ARM)
 #define TIMING_INFO_PRE_READ()
 #define TIMING_INFO_OS_GET_TIME()      (k_cycle_get_32())
 #define TIMING_INFO_GET_TIMER_VALUE()  (SysTick->VAL)
 #define SUBTRACT_CLOCK_CYCLES(val)     (SysTick->LOAD - (u32_t)val)
 
-#elif CONFIG_ARC
+#elif defined(CONFIG_ARC)
 #define TIMING_INFO_PRE_READ()
 #define TIMING_INFO_OS_GET_TIME()     (k_cycle_get_32())
 #define TIMING_INFO_GET_TIMER_VALUE() (z_arc_v2_aux_reg_read(_ARC_V2_TMR0_COUNT))
 #define SUBTRACT_CLOCK_CYCLES(val)    ((u32_t)val)
 
-#elif CONFIG_NIOS2
+#elif defined(CONFIG_NIOS2)
 #include "altera_avalon_timer_regs.h"
 #define TIMING_INFO_PRE_READ()         \
 	(IOWR_ALTERA_AVALON_TIMER_SNAPL(TIMER_0_BASE, 10))
@@ -104,7 +104,7 @@
 /* NRF RTC TIMER runs ar very slow rate (32KHz), So in order to measure
  * Kernel starts a dedicated timer to measure kernel stats.
  */
-#ifdef CONFIG_NRF_RTC_TIMER
+#if defined(CONFIG_NRF_RTC_TIMER)
 #define NANOSECS_PER_SEC (1000000000)
 #define CYCLES_PER_SEC   (16000000/(1 << NRF_TIMER2->PRESCALER))
 
@@ -139,7 +139,7 @@ static inline u32_t get_core_freq_MHz(void)
 	return SystemCoreClock/1000000;
 }
 
-#elif CONFIG_SOC_SERIES_MEC1501X
+#elif defined(CONFIG_SOC_SERIES_MEC1501X)
 
 #define NANOSECS_PER_SEC	(1000000000)
 #define CYCLES_PER_SEC		(48000000)


### PR DESCRIPTION
The current implementation to preserve r0 and r3 registers around the
call to `read_timer_end_of_isr` function has the following problems:

1. STM and LDM mnemonics are used without proper suffixes, in attempt
   to implement PUSH and POP (i.e. STMFD and LDMFD). The suffix-less
   STM mnemonic is equivalent to STMEA (increment after), which clearly
   is not a PUSH operation, and this corrupts the interrupt stack,
   leading to crashes on the Cortex-R.

2. The current implementation unnecessarily preserves additional r1, r2
   and lr registers. There is no need to preserve r1 and r2 because the
   values contained in these registers are not used after the function
   call; as for the lr register, it is already pushed to the stack when
   the interrupt service routine enters.

This commit removes all the unnecessary register preservations and
fixes the incorrect STM and LDM usages.

Note that the PUSH and POP aliases are used in place of the STMFD and
LDMFD mnemonics because they are used throughout the rest of the code.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>