### PR TITLE
drivers: adc: adc_stm32: enable internal voltage reference source

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -568,6 +568,7 @@ static int adc_stm32_init(struct device *dev)
 
 #if defined(CONFIG_SOC_SERIES_STM32F0X) || \
 	defined(CONFIG_SOC_SERIES_STM32L0X) || \
+	defined(CONFIG_SOC_SERIES_STM32L4X) || \
 	defined(CONFIG_SOC_SERIES_STM32WBX) || \
 	defined(CONFIG_SOC_SERIES_STM32G4X)
 	if (LL_ADC_IsActiveFlag_ADRDY(adc)) {


### PR DESCRIPTION
Like other STM32 series the STM32L4x SoCs have an internal voltage
reference source that need to be enabled.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>