### PR TITLE
dts: arm: atmel: sam3x: Fix SoC compatible

### DIFF
--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -18,7 +18,7 @@
 
 		cpu0: cpu@0 {
 			device_type = "cpu";
-			compatible = "arm,cortex-m4";
+			compatible = "arm,cortex-m3";
 			reg = <0>;
 		};
 	};

--- a/soc/arm/atmel_sam/sam3x/soc.h
+++ b/soc/arm/atmel_sam/sam3x/soc.h
@@ -46,11 +46,11 @@
 #include "../common/soc_pmc.h"
 #include "../common/soc_gpio.h"
 
-#endif /* _ASMLANGUAGE */
-
 /** Processor Clock (HCLK) Frequency */
-#define SOC_ATMEL_SAM_HCLK_FREQ_HZ DT_ARM_CORTEX_M4_0_CLOCK_FREQUENCY
+#define SOC_ATMEL_SAM_HCLK_FREQ_HZ DT_ARM_CORTEX_M3_0_CLOCK_FREQUENCY
 /** Master Clock (MCK) Frequency */
 #define SOC_ATMEL_SAM_MCK_FREQ_HZ SOC_ATMEL_SAM_HCLK_FREQ_HZ
+
+#endif /* _ASMLANGUAGE */
 
 #endif /* _ATMEL_SAM3X_SOC_H_ */


### PR DESCRIPTION
Atmel SAM3X is a Cortex-M3 SoC.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>