### PR TITLE
arch: arc: enable the workaround of sleep only for SMP case in nsim

### DIFF
--- a/arch/arc/core/cpu_idle.S
+++ b/arch/arc/core/cpu_idle.S
@@ -47,14 +47,15 @@ SECTION_FUNC(TEXT, arch_cpu_idle)
  * It's found that (in nsim_hs_smp), when cpu
  * is sleeping, no response to inter-processor interrupt
  * although it's pending and interrupts are enabled.
+ * (Here fire SNPS JIRA issue P10019563-41294 to trace)
  * here is a workround
  */
-#if !defined(CONFIG_SOC_NSIM) && !defined(CONFIG_SMP)
-	sleep r1
-#else
+#if defined(CONFIG_SOC_NSIM) && defined(CONFIG_SMP)
 	seti r1
 _z_arc_idle_loop:
 	b _z_arc_idle_loop
+#else
+	sleep r1
 #endif
 	j_s [blink]
 	nop

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -324,6 +324,13 @@ static void test_kernel_cpu_idle_atomic(void)
 
 static void test_kernel_cpu_idle(void)
 {
+/*
+ * Fixme: remove the skip code when sleep instruction in
+ * nsim_hs_smp is fixed.
+ */
+#if defined(CONFIG_SOC_NSIM) && defined(CONFIG_SMP)
+	ztest_test_skip();
+#endif
 	_test_kernel_cpu_idle(0);
 }
 


### PR DESCRIPTION
Because the issue of nsim, the sleep instruction doest not work correctly
when SMP is enabled. A workaround is introduced in commit d56a12d955,
this workaround should be enabled only for SMP case in nsim.

For other cases, no need of this workaround.

This commit fixes #24276

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>