### PR TITLE
boards: qemu_cortex_r5: Fix memory size

### DIFF
--- a/boards/arm/qemu_cortex_r5/qemu_cortex_r5.yaml
+++ b/boards/arm/qemu_cortex_r5/qemu_cortex_r5.yaml
@@ -7,8 +7,8 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 128
-flash: 1024
+ram: 65536
+flash: 32768
 testing:
   default: true
   ignore_tags:

--- a/dts/arm/xilinx/zynqmp.dtsi
+++ b/dts/arm/xilinx/zynqmp.dtsi
@@ -12,12 +12,12 @@
 	soc {
 		flash0: flash@c0000000 {
 			compatible = "soc-nv-flash";
-			reg = <0xc0000000 DT_SIZE_K(64)>;
+			reg = <0xc0000000 DT_SIZE_M(32)>;
 		};
 
 		sram0: memory@0 {
 			compatible = "mmio-sram";
-			reg = <0 DT_SIZE_K(256)>;
+			reg = <0 DT_SIZE_M(64)>;
 		};
 
 		uart0: uart@ff000000 {


### PR DESCRIPTION
This commit fixes the incorrect memory (FLASH and SRAM) size
specification in the device tree and the board test yaml files.

The `qemu_cortex_r5` board (using `fdt-single_arch-zcu102-arm.dtb` FDT)
has 64MiB RAM at the address 0 and 32MiB QSPI flash at 0xc0000000.

QEMU `info mtree`:

0000000000000000-ffffffffffffffff (prio 0, i/o): memory@00000000
  0000000000000000-000000000002ffff (prio 0, ram): ddr_bank1_1@0x0
  0000000000030000-000000000003ffff (prio 0, ram): ddr_bank1_2@0x30000
  0000000000040000-0000000003ffffff (prio 0, ram): ddr_bank1_3@0x40000

00000000c0000000-00000000c1ffffff (prio 0, i/o): lqspi

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>