### PR TITLE
doc: feature tracking: Update with two new categories

### DIFF
--- a/doc/development_process/proposals.rst
+++ b/doc/development_process/proposals.rst
@@ -12,13 +12,24 @@ Enhancement
   exists in Zephyr.
 
 Feature request
-  A request for a feature that is not part of any release plans yet, that has
-  not been vetted, and needs further discussion and details.
+  A request for the implementation or inclusion of a new unit of functionality
+  that is not part of any release plans yet, that has not been vetted, and needs
+  further discussion and details.
 
 Feature
-  A committed and planned feature with a detailed design and implementation
-  proposal and an owner. Features must go through an RFC process and must be
-  vetted and discussed in the TSC before a target milestone is set.
+  A committed and planned unit of functionality with a detailed design and
+  implementation proposal and an owner. Features must go through an RFC process
+  and must be vetted and discussed in the TSC before a target milestone is set.
+
+Hardware Support
+  A request or plan to port an existing feature or enhancement to a particular
+  hardware platform. This ranges from porting Zephyr itself to a new
+  architecture, SoC or board to adding an implementation of a peripheral driver
+  API for an existing hardware platform.
+
+Meta
+  A label to group other GitHub issues that are part of a single feature or unit
+  of work.
 
 The following workflow should be used to process features:.
 


### PR DESCRIPTION
Update the feature tracking page with a couple of new categories that
have been identified as missing during the Release Readiness meetings:

- Hardware support
- Meta

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>