### PR TITLE
Bluetooth: Mesh: Fix lpn groups add when node reset

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -445,6 +445,12 @@ config BT_MESH_FRIEND_SUB_LIST_SIZE
 	  Size of the Subscription List that can be supported by a
 	  Friend node for a Low Power node.
 
+config BT_MESH_LPN_SUB_ALL_NODES_ADDR
+	bool "Automatically subscribe all nodes address"
+	help
+	  Automatically subscribe all nodes address when friendship
+	  established.
+
 config BT_MESH_FRIEND_LPN_COUNT
 	int "Number of supported LPN nodes"
 	range 1 1000

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -1262,6 +1262,9 @@ static size_t mod_sub_list_clear(struct bt_mesh_model *mod)
 	/* Unref stored labels related to this model */
 	for (i = 0, clear_count = 0; i < ARRAY_SIZE(mod->groups); i++) {
 		if (mod->groups[i] != BT_MESH_ADDR_UNASSIGNED) {
+			if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER)) {
+				bt_mesh_lpn_group_del(&mod->groups[i], 1);
+			}
 			mod->groups[i] = BT_MESH_ADDR_UNASSIGNED;
 			clear_count++;
 		}

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -123,6 +123,11 @@ int bt_mesh_provision(const u8_t net_key[16], u16_t net_idx,
 
 	memcpy(bt_mesh.dev_key, dev_key, 16);
 
+	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER) &&
+	    IS_ENABLED(CONFIG_BT_MESH_LPN_SUB_ALL_NODES_ADDR)) {
+		bt_mesh_lpn_group_add(BT_MESH_ADDR_ALL_NODES);
+	}
+
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		BT_DBG("Storing network information persistently");
 		bt_mesh_store_net();
@@ -174,6 +179,12 @@ void bt_mesh_reset(void)
 	bt_mesh_tx_reset();
 
 	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER)) {
+		if (IS_ENABLED(CONFIG_BT_MESH_LPN_SUB_ALL_NODES_ADDR)) {
+			u16_t group = BT_MESH_ADDR_ALL_NODES;
+
+			bt_mesh_lpn_group_del(&group, 1);
+		}
+
 		bt_mesh_lpn_disable(true);
 	}
 

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -32,6 +32,7 @@
 #include "foundation.h"
 #include "proxy.h"
 #include "settings.h"
+#include "lpn.h"
 
 /* Tracking of what storage changes are pending for App and Net Keys. We
  * track this in a separate array here instead of within the respective
@@ -1095,6 +1096,16 @@ static void commit_mod(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 		if (ms) {
 			BT_DBG("Starting publish timer (period %u ms)", ms);
 			k_delayed_work_submit(&mod->pub->timer, ms);
+		}
+	}
+
+	if (!IS_ENABLED(CONFIG_BT_MESH_LOW_POWER)) {
+		return;
+	}
+
+	for (int i = 0; i < ARRAY_SIZE(mod->groups); i++) {
+		if (mod->groups[i] != BT_MESH_ADDR_UNASSIGNED) {
+			bt_mesh_lpn_group_add(mod->groups[i]);
 		}
 	}
 }


### PR DESCRIPTION
Add lpn groups when model sub restore after reset.

Add auto sub `ALL_NODE_ADDR` when provisioned.

Remove all groups when node unprovisoned.

Fixes: #24311
Fixes: #24009

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>