### PR TITLE
shell: Refactor command execution to enable raw arguments

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -37,6 +37,30 @@ extern "C" {
 #define SHELL_CMD_ROOT_LVL		(0u)
 
 /**
+ * @brief Flag indicates that optional arguments will be treated as one,
+ *	  unformatted argument.
+ *
+ * By default, shell is parsing all arguments, treats all spaces as argument
+ * separators unless they are within quotation marks which are removed in that
+ * case. If command rely on unformatted argument then this flag shall be used
+ * in place of number of optional arguments in command definition to indicate
+ * that only mandatory arguments shall be parsed and remaining command string is
+ * passed as a raw string.
+ */
+#define SHELL_OPT_ARG_RAW	(0xFE)
+
+/**
+ * @brief Flag indicateding that number of optional arguments is not limited.
+ */
+#define SHELL_OPT_ARG_CHECK_SKIP (0xFF)
+
+/**
+ * @brief Flag indicating maximum number of optional arguments that can be
+ *	  validated.
+ */
+#define SHELL_OPT_ARG_MAX		(0xFD)
+
+/**
  * @brief Shell API
  * @defgroup shell_api Shell API
  * @ingroup shell

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -393,8 +393,9 @@ static int cmd_select(const struct shell *shell, size_t argc, char **argv)
 
 	argc--;
 	argv = argv + 1;
-	candidate = shell_get_last_command(shell, argc, argv, &matching_argc,
-					   &entry, true);
+	candidate = shell_get_last_command(shell->ctx->selected_cmd,
+					   argc, (const char **)argv,
+					   &matching_argc, &entry, true);
 
 	if ((candidate != NULL) && !no_args(candidate)
 	    && (argc == matching_argc)) {
@@ -453,10 +454,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_resize,
 
 SHELL_CMD_ARG_REGISTER(clear, NULL, SHELL_HELP_CLEAR, cmd_clear, 1, 0);
 SHELL_CMD_REGISTER(shell, &m_sub_shell, SHELL_HELP_SHELL, NULL);
-SHELL_CMD_ARG_REGISTER(help, NULL, SHELL_HELP_HELP, cmd_help, 1, 255);
+SHELL_CMD_ARG_REGISTER(help, NULL, SHELL_HELP_HELP, cmd_help,
+			1, SHELL_OPT_ARG_CHECK_SKIP);
 SHELL_COND_CMD_ARG_REGISTER(CONFIG_SHELL_HISTORY, history, NULL,
 			SHELL_HELP_HISTORY, cmd_history, 1, 0);
 SHELL_COND_CMD_ARG_REGISTER(CONFIG_SHELL_CMDS_RESIZE, resize, &m_sub_resize,
 			SHELL_HELP_RESIZE, cmd_resize, 1, 1);
 SHELL_COND_CMD_ARG_REGISTER(CONFIG_SHELL_CMDS_SELECT, select, NULL,
-			    SHELL_HELP_SELECT, cmd_select, 2, 255);
+			    SHELL_HELP_SELECT, cmd_select, 2,
+			    SHELL_OPT_ARG_CHECK_SKIP);

--- a/subsys/shell/shell_utils.h
+++ b/subsys/shell/shell_utils.h
@@ -36,7 +36,8 @@ static inline u16_t shell_strlen(const char *str)
 	return str == NULL ? 0U : (u16_t)strlen(str);
 }
 
-char shell_make_argv(size_t *argc, char **argv, char *cmd, uint8_t max_argc);
+char shell_make_argv(size_t *argc, const char **argv,
+		     char *cmd, uint8_t max_argc);
 
 /** @brief Removes pattern and following space
  *
@@ -56,11 +57,15 @@ const struct shell_static_entry *shell_cmd_get(
 					size_t idx,
 					struct shell_static_entry *dloc);
 
+const struct shell_static_entry *shell_find_cmd(
+					const struct shell_static_entry *parent,
+					const char *cmd_str,
+					struct shell_static_entry *dloc);
 
 /* @internal @brief Function returns pointer to a shell's subcommands array
  * for a level given by argc and matching command patter provided in argv.
  *
- * @param shell		Shell instance.
+ * @param shell		Entry. NULL for root entry.
  * @param argc		Number of arguments.
  * @param argv		Pointer to an array with arguments.
  * @param match_arg	Subcommand level of last matching argument.
@@ -70,12 +75,12 @@ const struct shell_static_entry *shell_cmd_get(
  * @return		Pointer to found command.
  */
 const struct shell_static_entry *shell_get_last_command(
-					     const struct shell *shell,
-					     size_t argc,
-					     char *argv[],
-					     size_t *match_arg,
-					     struct shell_static_entry *d_entry,
-					     bool only_static);
+					const struct shell_static_entry *entry,
+					size_t argc,
+					const char *argv[],
+					size_t *match_arg,
+					struct shell_static_entry *dloc,
+					bool only_static);
 
 int shell_command_add(char *buff, u16_t *buff_len,
 		      const char *new_cmd, const char *pattern);

--- a/tests/shell/src/main.c
+++ b/tests/shell/src/main.c
@@ -29,7 +29,8 @@ static void test_shell_execute_cmd(const char *cmd, int result)
 
 	TC_PRINT("shell_execute_cmd(%s): %d\n", cmd, ret);
 
-	zassert_true(ret == result, cmd);
+	zassert_true(ret == result, "cmd: %s, got:%d, expected:%d",
+							cmd, ret, result);
 }
 
 static void test_cmd_help(void)
@@ -206,7 +207,6 @@ SHELL_CMD_ARG_REGISTER(test_shell_cmd, NULL, "help", cmd_test_module, 1, 0);
 static int cmd_wildcard(const struct shell *shell, size_t argc, char **argv)
 {
 	int valid_arguments = 0;
-
 	for (size_t i = 1; i < argc; i++) {
 		if (!strcmp("argument_1", argv[i])) {
 			valid_arguments++;
@@ -306,7 +306,7 @@ static void test_set_root_cmd(void)
 	err = shell_set_root_cmd("shell");
 	zassert_equal(err, 0, "Unexpected error %d", err);
 
-	test_shell_execute_cmd("shell colors", -ENOEXEC);
+	test_shell_execute_cmd("shell colors", 1);
 	test_shell_execute_cmd("colors on", 0);
 
 	err = shell_set_root_cmd(NULL);
@@ -343,6 +343,35 @@ static void test_shell_fprintf(void)
 		     "Expected string to contain '%s', got '%s'", expect, buf);
 }
 
+#define RAW_ARG "aaa \"\" bbb"
+#define CMD_NAME test_cmd_raw_arg
+
+static int cmd_raw_arg(const struct shell *shell, size_t argc, char **argv)
+{
+	if (argc == 2) {
+		if (strcmp(argv[0], STRINGIFY(CMD_NAME))) {
+			return -1;
+		}
+		if (strcmp(argv[1], RAW_ARG)) {
+			return -1;
+		}
+	} else if (argc > 2) {
+		return -1;
+	}
+
+	return 0;
+}
+
+SHELL_CMD_ARG_REGISTER(CMD_NAME, NULL, NULL, cmd_raw_arg, 1, SHELL_OPT_ARG_RAW);
+
+static void test_raw_arg(void)
+{
+	test_shell_execute_cmd("test_cmd_raw_arg aaa \"\" bbb", 0);
+	test_shell_execute_cmd("test_cmd_raw_arg", 0);
+	test_shell_execute_cmd("select test_cmd_raw_arg", 0);
+	test_shell_execute_cmd("aaa \"\" bbb", 0);
+}
+
 void test_main(void)
 {
 	ztest_test_suite(shell_test_suite,
@@ -351,12 +380,14 @@ void test_main(void)
 			ztest_unit_test(test_cmd_shell),
 			ztest_unit_test(test_cmd_history),
 			ztest_unit_test(test_cmd_select),
-			ztest_unit_test(test_set_root_cmd),
 			ztest_unit_test(test_cmd_resize),
 			ztest_unit_test(test_shell_module),
 			ztest_unit_test(test_shell_wildcards_static),
 			ztest_unit_test(test_shell_wildcards_dynamic),
-			ztest_unit_test(test_shell_fprintf));
+			ztest_unit_test(test_shell_fprintf),
+			ztest_unit_test(test_set_root_cmd),
+			ztest_unit_test(test_raw_arg)
+			);
 
 	ztest_run_test_suite(shell_test_suite);
 }


### PR DESCRIPTION
 Added special flag that can be used to indicate that optional arguments are passed without any parsing (e.g. quotation marks removal). Modified execute command to parse command line buffer argument by argument.

After this change it is possible to forward whole command to command handler (using select).

It is now possible to specify command like:

`SHELL_CMD_ARG_REGISTER(python, NULL, "Python", cmd_python, 1,  SHELL_OPT_ARG_RAW);`

Then call
```
select python
```

and whole content from the prompt will be passed directly to the handler without splitting into arguments, removing quotation marks, etc.

Fixes #24216.
Fixes #23907.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>