### PR TITLE
samples: philosophers: Fix extra_args not used

### DIFF
--- a/samples/philosophers/CMakeLists.txt
+++ b/samples/philosophers/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 project(philosophers)
 
 if(DEFINED DEBUG_PRINTF)
-  zephyr_compile_definitions(DEBUG_PRINTF)
+  zephyr_compile_definitions(DEBUG_PRINTF=${DEBUG_PRINTF})
 endif()
 if(DEFINED SAME_PRIO)
   zephyr_compile_definitions(SAME_PRIO)

--- a/samples/philosophers/sample.yaml
+++ b/samples/philosophers/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Dining Philosophers
 common:
-  extra_args: "-DDEBUG_PRINTF=1"
+  extra_args: DEBUG_PRINTF=1
   tags: introduction
   harness: console
   harness_config:

--- a/samples/portability/cmsis_rtos_v1/philosophers/CMakeLists.txt
+++ b/samples/portability/cmsis_rtos_v1/philosophers/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 project(philosophers_cmsis_rtos_v1)
 
 if(DEFINED DEBUG_PRINTF)
-  zephyr_compile_definitions(DEBUG_PRINTF)
+  zephyr_compile_definitions(DEBUG_PRINTF=${DEBUG_PRINTF})
 endif()
 if(DEFINED SAME_PRIO)
   zephyr_compile_definitions(SAME_PRIO)

--- a/samples/portability/cmsis_rtos_v1/philosophers/sample.yaml
+++ b/samples/portability/cmsis_rtos_v1/philosophers/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: CMSIS_RTOS_V1 Dining Philosophers
 common:
-  extra_args: "-DDEBUG_PRINTF=1"
+  extra_args: DEBUG_PRINTF=1
   tags: cmsis_rtos
   min_ram: 32
   min_flash: 34

--- a/samples/portability/cmsis_rtos_v2/philosophers/CMakeLists.txt
+++ b/samples/portability/cmsis_rtos_v2/philosophers/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 project(philosophers)
 
 if(DEFINED DEBUG_PRINTF)
-  zephyr_compile_definitions(DEBUG_PRINTF)
+  zephyr_compile_definitions(DEBUG_PRINTF=${DEBUG_PRINTF})
 endif()
 if(DEFINED SAME_PRIO)
   zephyr_compile_definitions(SAME_PRIO)

--- a/samples/portability/cmsis_rtos_v2/philosophers/sample.yaml
+++ b/samples/portability/cmsis_rtos_v2/philosophers/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: CMSIS_RTOS_V2 Dining Philosophers
 common:
-  extra_args: "-DDEBUG_PRINTF=1"
+  extra_args: DEBUG_PRINTF=1
   tags: cmsis_rtos
   min_ram: 32
   min_flash: 34


### PR DESCRIPTION
Fixed extra_args parameter DEBUG_PRINTF in sample.yaml not used.

Fixes #24178