### PR TITLE
tests: can't busy_wait too long when interrupt is locked

### DIFF
--- a/tests/kernel/interrupt/src/prevent_irq.c
+++ b/tests/kernel/interrupt/src/prevent_irq.c
@@ -46,14 +46,14 @@ void test_prevent_interruption(void)
 	 * locked -- but since they are, check_lock_new isn't updated.
 	 */
 	k_timer_start(&irqlock_timer, K_MSEC(DURATION), K_NO_WAIT);
-	k_busy_wait(MS_TO_US(1000));
+	k_busy_wait(MS_TO_US(2 * DURATION));
 	zassert_not_equal(handler_result, HANDLER_TOKEN,
 		"timer interrupt was serviced while interrupts are locked");
 
 	printk("unlocking interrupts\n");
 	irq_unlock(key);
 
-	k_busy_wait(MS_TO_US(1000));
+	k_busy_wait(MS_TO_US(DURATION));
 
 	zassert_equal(handler_result, HANDLER_TOKEN,
 		"timer should have fired");


### PR DESCRIPTION
I made a fix of arc timer in #24445. This PR as suggested  by @andyross  

>   It's not needed and it spins on the CPU wasting precious cycles in CI.