### PR TITLE
dma: stm32 driver cleanup

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -24,6 +24,18 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(dma_stm32, CONFIG_DMA_LOG_LEVEL);
 
+static u32_t table_m_size[] = {
+	LL_DMA_MDATAALIGN_BYTE,
+	LL_DMA_MDATAALIGN_HALFWORD,
+	LL_DMA_MDATAALIGN_WORD,
+};
+
+static u32_t table_p_size[] = {
+	LL_DMA_PDATAALIGN_BYTE,
+	LL_DMA_PDATAALIGN_HALFWORD,
+	LL_DMA_PDATAALIGN_WORD,
+};
+
 static void dma_stm32_dump_stream_irq(struct device *dev, u32_t id)
 {
 	const struct dma_stm32_config *config = dev->config->config_info;

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -24,8 +24,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(dma_stm32, CONFIG_DMA_LOG_LEVEL);
 
-#include <drivers/clock_control/stm32_clock_control.h>
-
 static void dma_stm32_dump_stream_irq(struct device *dev, u32_t id)
 {
 	const struct dma_stm32_config *config = dev->config->config_info;

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -324,6 +324,10 @@ static int dma_stm32_configure(struct device *dev, u32_t id,
 		periph_addr_adj = config->head_block->dest_addr_adj;
 		break;
 	/* Direction has been asserted in dma_stm32_get_direction. */
+	default:
+		LOG_ERR("Channel direction error. %d",
+				config->channel_direction);
+		return -EINVAL;
 	}
 
 	ret = dma_stm32_get_memory_increment(memory_addr_adj,

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -313,6 +313,16 @@ static int dma_stm32_configure(struct device *dev, u32_t id,
 	stream->src_size	= config->source_data_size;
 	stream->dst_size	= config->dest_data_size;
 
+	if ((&config->head_block->source_address == NULL)
+	     || (!config->head_block->source_address)) {
+		LOG_WRN("source_buffer address is null.");
+	}
+
+	if ((&config->head_block->dest_address == NULL)
+	     || (!config->head_block->dest_address)) {
+		LOG_WRN("dest_buffer address is null.");
+	}
+
 	if (stream->direction == MEMORY_TO_PERIPHERAL) {
 		DMA_InitStruct.MemoryOrM2MDstAddress =
 					config->head_block->source_address;

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -68,19 +68,22 @@ static void dma_stm32_irq_handler(void *arg)
 	stream = &data->streams[id];
 	stream->busy = false;
 
+	/* the dma stream id is in range from STREAM_OFFSET..<dma-requests> */
 	if (func_ll_is_active_tc[id](dma)) {
 		func_ll_clear_tc[id](dma);
-
-		stream->dma_callback(stream->callback_arg, id, 0);
+		stream->dma_callback(stream->callback_arg, id + STREAM_OFFSET,
+					0);
 	} else if (stm32_dma_is_unexpected_irq_happened(dma, id)) {
 		LOG_ERR("Unexpected irq happened.");
-		stream->dma_callback(stream->callback_arg, id, -EIO);
+		stream->dma_callback(stream->callback_arg, id + STREAM_OFFSET,
+					-EIO);
 	} else {
 		LOG_ERR("Transfer Error.");
 		dma_stm32_dump_stream_irq(dev, id);
 		dma_stm32_clear_stream_irq(dev, id);
 
-		stream->dma_callback(stream->callback_arg, id, -EIO);
+		stream->dma_callback(stream->callback_arg, id + STREAM_OFFSET,
+					-EIO);
 	}
 }
 
@@ -199,7 +202,7 @@ static int dma_stm32_configure(struct device *dev, u32_t id,
 			       struct dma_config *config)
 {
 	struct dma_stm32_data *data = dev->driver_data;
-	struct dma_stm32_stream *stream = &data->streams[id];
+	struct dma_stm32_stream *stream = &data->streams[id - STREAM_OFFSET];
 	const struct dma_stm32_config *dev_config =
 					dev->config->config_info;
 	DMA_TypeDef *dma = (DMA_TypeDef *)dev_config->base;
@@ -207,11 +210,16 @@ static int dma_stm32_configure(struct device *dev, u32_t id,
 	u32_t msize;
 	int ret;
 
+	/* give channel from index 0 */
+	id = id - STREAM_OFFSET;
+
 	if (id >= data->max_streams) {
+		LOG_ERR("Channel %d is not valid for this dma.", id);
 		return -EINVAL;
 	}
 
 	if (stream->busy) {
+		LOG_ERR("dma stream %d is busy.", id);
 		return -EBUSY;
 	}
 
@@ -383,7 +391,7 @@ static int dma_stm32_configure(struct device *dev, u32_t id,
 	return ret;
 }
 
-int dma_stm32_disable_stream(DMA_TypeDef *dma, u32_t id)
+static int dma_stm32_disable_stream(DMA_TypeDef *dma, u32_t id)
 {
 	int count = 0;
 
@@ -406,7 +414,10 @@ static int dma_stm32_reload(struct device *dev, u32_t id,
 	const struct dma_stm32_config *config = dev->config->config_info;
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
 	struct dma_stm32_data *data = dev->driver_data;
-	struct dma_stm32_stream *stream = &data->streams[id];
+	struct dma_stm32_stream *stream = &data->streams[id - STREAM_OFFSET];
+
+	/* give channel from index 0 */
+	id = id - STREAM_OFFSET;
 
 	if (id >= data->max_streams) {
 		return -EINVAL;
@@ -433,6 +444,7 @@ static int dma_stm32_reload(struct device *dev, u32_t id,
 		LL_DMA_SetDataLength(dma, table_ll_stream[id],
 				     size / stream->dst_size);
 	}
+
 	return 0;
 }
 
@@ -441,6 +453,9 @@ static int dma_stm32_start(struct device *dev, u32_t id)
 	const struct dma_stm32_config *config = dev->config->config_info;
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
 	struct dma_stm32_data *data = dev->driver_data;
+
+	/* give channel from index 0 */
+	id = id - STREAM_OFFSET;
 
 	/* Only M2P or M2M mode can be started manually. */
 	if (id >= data->max_streams) {
@@ -456,17 +471,21 @@ static int dma_stm32_start(struct device *dev, u32_t id)
 
 static int dma_stm32_stop(struct device *dev, u32_t id)
 {
-	struct dma_stm32_data *data = dev->driver_data;
-	struct dma_stm32_stream *stream = &data->streams[id];
 	const struct dma_stm32_config *config =
 				dev->config->config_info;
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
+	struct dma_stm32_data *data = dev->driver_data;
+	struct dma_stm32_stream *stream = &data->streams[id - STREAM_OFFSET];
+
+	/* give channel from index 0 */
+	id = id - STREAM_OFFSET;
 
 	if (id >= data->max_streams) {
 		return -EINVAL;
 	}
 
 	LL_DMA_DisableIT_TC(dma, table_ll_stream[id]);
+
 #if defined(CONFIG_DMA_STM32_V1)
 	stm32_dma_disable_fifo_irq(dma, id);
 #endif

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -426,10 +426,17 @@ static int dma_stm32_configure(struct device *dev, u32_t id,
 		DMA_InitStruct.NbData = config->head_block->block_size /
 					config->dest_data_size;
 	}
-
+#if defined(CONFIG_DMA_STM32_V2)
+	/*
+	 * the with dma V2,
+	 * the request ID is stored in the dma_slot
+	 */
+	DMA_InitStruct.PeriphRequest = config->dma_slot;
+#endif
 	LL_DMA_Init(dma, table_ll_stream[id], &DMA_InitStruct);
 
 	LL_DMA_EnableIT_TC(dma, table_ll_stream[id]);
+	/* Half-Transfer irq is not handled */
 
 #if defined(CONFIG_DMA_STM32_V1)
 	if (DMA_InitStruct.FIFOMode == LL_DMA_FIFOMODE_ENABLE) {

--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -7,18 +7,6 @@
 #ifndef DMA_STM32_H_
 #define DMA_STM32_H_
 
-static u32_t table_m_size[] = {
-	LL_DMA_MDATAALIGN_BYTE,
-	LL_DMA_MDATAALIGN_HALFWORD,
-	LL_DMA_MDATAALIGN_WORD,
-};
-
-static u32_t table_p_size[] = {
-	LL_DMA_PDATAALIGN_BYTE,
-	LL_DMA_PDATAALIGN_HALFWORD,
-	LL_DMA_PDATAALIGN_WORD,
-};
-
 /* Maximum data sent in single transfer (Bytes) */
 #define DMA_STM32_MAX_DATA_ITEMS	0xffff
 

--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -16,7 +16,7 @@ struct dma_stm32_stream {
 	bool busy;
 	u32_t src_size;
 	u32_t dst_size;
-	void *callback_arg;
+	void *callback_arg; /* holds the client data */
 	void (*dma_callback)(void *arg, u32_t id,
 			     int error_code);
 };
@@ -47,6 +47,10 @@ extern u32_t (*func_ll_is_active_tc[])(DMA_TypeDef *DMAx);
 extern void (*func_ll_clear_tc[])(DMA_TypeDef *DMAx);
 extern u32_t (*func_ll_is_active_ht[])(DMA_TypeDef *DMAx);
 extern void (*func_ll_clear_ht[])(DMA_TypeDef *DMAx);
+#ifdef CONFIG_DMA_STM32_V2
+extern u32_t (*func_ll_is_active_gi[])(DMA_TypeDef *DMAx);
+extern void (*func_ll_clear_gi[])(DMA_TypeDef *DMAx);
+#endif
 #ifdef CONFIG_DMA_STM32_V1
 extern u32_t table_ll_channel[];
 #endif
@@ -58,6 +62,7 @@ bool stm32_dma_is_unexpected_irq_happened(DMA_TypeDef *dma, u32_t id);
 void stm32_dma_enable_stream(DMA_TypeDef *dma, u32_t id);
 int stm32_dma_disable_stream(DMA_TypeDef *dma, u32_t id);
 void stm32_dma_config_channel_function(DMA_TypeDef *dma, u32_t id, u32_t slot);
+
 #ifdef CONFIG_DMA_STM32_V1
 void stm32_dma_disable_fifo_irq(DMA_TypeDef *dma, u32_t id);
 bool stm32_dma_check_fifo_mburst(LL_DMA_InitTypeDef *DMAx);

--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -45,6 +45,15 @@ struct dma_stm32_config {
 	u32_t base;
 };
 
+#ifdef CONFIG_DMA_STM32_V1
+/* from DTS the dma stream id is in range 0..<dma-requests>-1 */
+#define STREAM_OFFSET 0
+#else
+/* from DTS the dma stream id is in range 1..<dma-requests> */
+/* so decrease to set range from 0 from now on */
+#define STREAM_OFFSET 1
+#endif /* CONFIG_DMA_STM32_V1 */
+
 extern u32_t table_ll_stream[];
 extern u32_t (*func_ll_is_active_tc[])(DMA_TypeDef *DMAx);
 extern void (*func_ll_clear_tc[])(DMA_TypeDef *DMAx);

--- a/drivers/dma/dma_stm32_v1.c
+++ b/drivers/dma/dma_stm32_v1.c
@@ -169,7 +169,7 @@ void stm32_dma_clear_stream_irq(DMA_TypeDef *dma, u32_t id)
 
 bool stm32_dma_is_irq_happened(DMA_TypeDef *dma, u32_t id)
 {
-	if (func_ll_is_active_fe[id](dma)) {
+	if (func_ll_is_active_fe[id](dma) && LL_DMA_IsEnabledIT_FE(dma, id)) {
 		return true;
 	}
 
@@ -178,7 +178,7 @@ bool stm32_dma_is_irq_happened(DMA_TypeDef *dma, u32_t id)
 
 bool stm32_dma_is_unexpected_irq_happened(DMA_TypeDef *dma, u32_t id)
 {
-	if (func_ll_is_active_fe[id](dma)) {
+	if (func_ll_is_active_fe[id](dma) && LL_DMA_IsEnabledIT_FE(dma, id)) {
 		LOG_ERR("FiFo error.");
 		stm32_dma_dump_stream_irq(dma, id);
 		stm32_dma_clear_stream_irq(dma, id);

--- a/drivers/dma/dma_stm32_v2.c
+++ b/drivers/dma/dma_stm32_v2.c
@@ -117,7 +117,7 @@ static void (*func_ll_clear_te[])(DMA_TypeDef *DMAx) = {
 #endif /* LL_DMA_IFCR_CTEIF8 */
 };
 
-static void (*func_ll_clear_gi[])(DMA_TypeDef *DMAx) = {
+void (*func_ll_clear_gi[])(DMA_TypeDef *DMAx) = {
 	LL_DMA_ClearFlag_GI1,
 	LL_DMA_ClearFlag_GI2,
 	LL_DMA_ClearFlag_GI3,
@@ -152,7 +152,7 @@ static u32_t (*func_ll_is_active_te[])(DMA_TypeDef *DMAx) = {
 };
 
 
-static u32_t (*func_ll_is_active_gi[])(DMA_TypeDef *DMAx) = {
+u32_t (*func_ll_is_active_gi[])(DMA_TypeDef *DMAx) = {
 	LL_DMA_IsActiveFlag_GI1,
 	LL_DMA_IsActiveFlag_GI2,
 	LL_DMA_IsActiveFlag_GI3,
@@ -182,7 +182,6 @@ void stm32_dma_dump_stream_irq(DMA_TypeDef *dma, u32_t id)
 void stm32_dma_clear_stream_irq(DMA_TypeDef *dma, u32_t id)
 {
 	func_ll_clear_te[id](dma);
-	func_ll_clear_gi[id](dma);
 }
 
 bool stm32_dma_is_irq_happened(DMA_TypeDef *dma, u32_t id)
@@ -207,7 +206,6 @@ void stm32_dma_enable_stream(DMA_TypeDef *dma, u32_t id)
 
 int stm32_dma_disable_stream(DMA_TypeDef *dma, u32_t id)
 {
-
 	if (!LL_DMA_IsEnabledChannel(dma, table_ll_stream[id])) {
 		return 0;
 	}

--- a/dts/bindings/dma/st,stm32-dma.yaml
+++ b/dts/bindings/dma/st,stm32-dma.yaml
@@ -23,15 +23,67 @@ properties:
 
 # Parameter syntax of stm32 follows the dma client dts syntax
 # in the Linux kernel declared in
-# https://git.kernel.org/pub/scm/linux/kernel/git/devicetree/devicetree-rebasing.git/plain/Bindings/dma/stm32-dma.txt
+# https://git.kernel.org/pub/scm/linux/kernel/git/devicetree/devicetree-rebasing.git/plain/Bindings/dma/st,stm32-dma.yaml
 #
-# channel: DMA channel
-# slot: DMA stream of the DMA channel for DMA V1 or for DMA V2 with MUX peripheral request else NA
-# channel-config: configuration of the selected DMA channel
-# features: fifo threshold if relevant for DMA V1 or TBD for DMA V2
 
 dma-cells:
   - channel
   - slot
   - channel-config
   - features
+
+description: |
+  The STM32 DMA is a general-purpose direct memory access controller
+  capable of supporting 5 or 6 or 7 or 8 independent DMA channels.
+  Each channel can have up to 8 requests.
+  DMA clients connected to the STM32 DMA controller must use the format
+  described in the dma.txt file, using a four-cell specifier for each
+  channel: a phandle to the DMA controller plus the following four integer cells:
+    1. channel: the dma stream from 0 in V1 or 1 in V2 to <dma-requests>
+    2. slot: DMA periph request ID in DMA_V2 or DMAMUX, dma request in V1
+    3. channel-config: A 32bit mask specifying the DMA channel configuration
+    which is device dependent:
+        -bit 6-7 : Direction  (see dma.h)
+       	       0x0: MEM to MEM
+       	       0x1: MEM to PERIPH
+       	       0x2: PERIPH to MEM
+       	       0x3: reserved for PERIPH to PERIPH
+        -bit 9 : Peripheral Increment Address
+       	       0x0: no address increment between transfers
+       	       0x1: increment address between transfers
+        -bit 10 : Memory Increment Address
+       	       0x0: no address increment between transfers
+       	       0x1: increment address between transfers
+        -bit 11-12 : Peripheral data size
+       	       0x0: Byte (8 bits)
+       	       0x1: Half-word (16 bits)
+       	       0x2: Word (32 bits)
+       	       0x3: reserved
+        -bit 13-14 : Memory data size
+       	       0x0: Byte (8 bits)
+       	       0x1: Half-word (16 bits)
+       	       0x2: Word (32 bits)
+       	       0x3: reserved
+        -bit 15: Peripheral Increment Offset Size (not USED for DMA V2)
+       	       0x0: offset size is linked to the peripheral bus width
+       	       0x1: offset size is fixed to 4 (32-bit alignment)
+        -bit 16-17 : Priority level
+       	       0x0: low
+       	       0x1: medium
+       	       0x2: high
+       	       0x3: very high
+    4. features: A 32bit bitfield value specifying DMA features
+        -bit 0-1 or not used: DMA FIFO threshold selection
+       	       0x0: 1/4 full FIFO
+       	       0x1: 1/2 full FIFO
+       	       0x2: 3/4 full FIFO
+       	       0x3: full FIFO
+    examples for stm32wb55x
+     dma2: dma-controller@40020400 {
+         compatible = "st,stm32-dma";
+         ...
+         st,mem2mem;
+         dma-requests = <7>;
+         status = "disabled";
+         label = "DMA_2";
+        };

--- a/include/dt-bindings/dma/stm32_dma.h
+++ b/include/dt-bindings/dma/stm32_dma.h
@@ -1,16 +1,38 @@
 /*
  * Copyright (c) 2019 Song Qiang <songqiang1304521@gmail.com>
+ * Copyright (c) 2020 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_DMA_STM32_DMA_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_DMA_STM32_DMA_H_
+
 /* macros for channel-config */
-#define STM32_DMA_CONFIG_DIRECTION(config)		(config & 0x3 << 6)
-#define STM32_DMA_CONFIG_PERIPH_ADDR_INC(config)	(config & 0x1 << 9)
-#define STM32_DMA_CONFIG_MEM_ADDR_INC(config)		(config & 0x1 << 10)
-#define STM32_DMA_CONFIG_PERIPH_DATA_SIZE(config)	(config & (0x3 << 11))
-#define STM32_DMA_CONFIG_MEM_DATA_SIZE(config)		(config & (0x3 << 13))
-#define STM32_DMA_CONFIG_PERIPH_INC_FIXED(config)	(config & 0x1 << 15)
+/* direction defined on bits 6-7 */
+/* 0 -> MEM_TO_MEM, 1 -> MEM_TO_PERIPH, 2 -> PERIPH_TO_MEM */
+#define STM32_DMA_CONFIG_DIRECTION(config)		((config >> 6) & 0x3)
+/* periph increment defined on bit 9 as true/false */
+#define STM32_DMA_CONFIG_PERIPHERAL_ADDR_INC(config)	((config >> 9) & 0x1)
+/* mem increment defined on bit 10 as true/false */
+#define STM32_DMA_CONFIG_MEMORY_ADDR_INC(config)	((config >> 10) & 0x1)
+/* perih data size defined on bits 11-12 */
+/* 0 -> 1 byte, 1 -> 2 bytes, 2 -> 4 bytes */
+#define STM32_DMA_CONFIG_PERIPHERAL_DATA_SIZE(config)	\
+	((((config >> 11) & 0x3) == 0) ? 1 : (((config >> 11) & 0x3) * 2))
+/* memory data size defined on bits 13, 14 */
+/* 0 -> 1 byte, 1 -> 2 bytes, 2 -> 4 bytes */
+#define STM32_DMA_CONFIG_MEMORY_DATA_SIZE(config)	\
+	((((config >> 13) & 0x3) == 0) ? 1 : (((config >> 13) & 0x3) * 2))
+/* priority increment offset defined on bit 15 */
+#define STM32_DMA_CONFIG_PERIPHERAL_INC_FIXED(config)	((config >> 15) & 0x1)
+/* priority defined on bits 16-17 as 0, 1, 2, 3 */
 #define STM32_DMA_CONFIG_PRIORITY(config)		((config >> 16) & 0x3)
 
 /* macros for features */
+#ifdef CONFIG_DMA_STM32_V1
 #define STM32_DMA_FEATURES_FIFO_THRESHOLD(features)	(features & 0x3)
+#else
+#define STM32_DMA_FEATURES_FIFO_THRESHOLD(features)	0
+#endif /* CONFIG_DMA_STM32_V1 */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_DMA_STM32_DMA_H_ */


### PR DESCRIPTION
This PR prepares the dma for spi: stm32: Enable DMA client #23157
with changes which are independent from the spi.

It can replace the dma: stm32 driver cleanup #24070

Signed-off-by: Francois Ramu francois.ramu@st.com