### PR TITLE
drivers: usb_dc_nrfx: Convert driver to new DT_INST macros

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -536,7 +536,7 @@ static int hf_clock_enable(bool on, bool blocking)
 	struct device *clock;
 	static bool clock_requested;
 
-	clock = device_get_binding(DT_INST_0_NORDIC_NRF_CLOCK_LABEL);
+	clock = device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_clock)));
 	if (!clock) {
 		LOG_ERR("NRF HF Clock device not found!");
 		return ret;


### PR DESCRIPTION
Convert to using DT_LABEL(DT_INST()) to get label of the
nordic,nrf-clock device.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>