### PR TITLE
drivers: timer: nrf_rtc: Convert driver to new DT_INST macros

### DIFF
--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -83,7 +83,7 @@ int z_clock_driver_init(struct device *device)
 
 	ARG_UNUSED(device);
 
-	clock = device_get_binding(DT_INST_0_NORDIC_NRF_CLOCK_LABEL);
+	clock = device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_clock)));
 	if (!clock) {
 		return -1;
 	}


### PR DESCRIPTION
Convert to using DT_LABEL(DT_INST()) to get label of the
nordic,nrf-clock device.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>