### PR TITLE
drivers: counter: nrfx_rtc: Convert driver to new DT_INST macros

### DIFF
--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -532,7 +532,7 @@ static int init_rtc(struct device *dev, u32_t prescaler)
 	NRF_RTC_Type *rtc = nrfx_config->rtc;
 	int err;
 
-	clock = device_get_binding(DT_INST_0_NORDIC_NRF_CLOCK_LABEL);
+	clock = device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_clock)));
 	if (!clock) {
 		return -ENODEV;
 	}


### PR DESCRIPTION
Convert to using DT_LABEL(DT_INST()) to get label of the
nordic,nrf-clock device.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>