### PR TITLE
correct call sites and documentation for millisecond timeout API relative to timeout constants

### DIFF
--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -297,7 +297,7 @@ static int cmd_send(const struct shell *shell, size_t argc, char **argv)
 		    ext ? frame.ext_id : frame.std_id,
 		    ext ? "extended" : "standard", frame.dlc);
 
-	ret = can_send(can_dev, &frame, K_FOREVER, NULL, NULL);
+	ret = can_send(can_dev, &frame, SYS_FOREVER_MS, NULL, NULL);
 	if (ret) {
 		shell_error(shell, "Failed to send frame [%d]", ret);
 		return -EIO;

--- a/include/console/tty.h
+++ b/include/console/tty.h
@@ -55,10 +55,10 @@ int tty_init(struct tty_serial *tty, struct device *uart_dev);
  * @brief Set receive timeout for tty device.
  *
  * Set timeout for getchar() operation. Default timeout after
- * device initialization is K_FOREVER.
+ * device initialization is SYS_FOREVER_MS.
  *
  * @param tty tty device structure
- * @param timeout timeout in milliseconds, or K_FOREVER, or K_NO_WAIT
+ * @param timeout timeout in milliseconds, or 0, or SYS_FOREVER_MS.
  */
 static inline void tty_set_rx_timeout(struct tty_serial *tty, s32_t timeout)
 {
@@ -69,10 +69,10 @@ static inline void tty_set_rx_timeout(struct tty_serial *tty, s32_t timeout)
  * @brief Set transmit timeout for tty device.
  *
  * Set timeout for putchar() operation, for a case when output buffer is full.
- * Default timeout after device initialization is K_FOREVER.
+ * Default timeout after device initialization is SYS_FOREVER_MS.
  *
  * @param tty tty device structure
- * @param timeout timeout in milliseconds, or K_FOREVER, or K_NO_WAIT
+ * @param timeout timeout in milliseconds, or 0, or SYS_FOREVER_MS.
  */
 static inline void tty_set_tx_timeout(struct tty_serial *tty, s32_t timeout)
 {
@@ -97,7 +97,7 @@ int tty_set_rx_buf(struct tty_serial *tty, void *buf, size_t size);
  *
  * Set transmit buffer or switch to unbuffered operation for transmit.
  * Note that unbuffered mode is implicitly blocking, i.e. behaves as
- * if tty_set_tx_timeout(K_FOREVER) was set.
+ * if tty_set_tx_timeout(SYS_FOREVER_MS) was set.
  *
  * @param tty tty device structure
  * @param buf buffer, or NULL for unbuffered operation

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -333,7 +333,8 @@ __subsystem struct can_driver_api {
  * *
  * @param dev          Pointer to the device structure for the driver instance.
  * @param msg          Message to transfer.
- * @param timeout      Waiting for empty tx mailbox timeout in ms or K_FOREVER.
+ * @param timeout      Waiting for empty tx mailbox timeout in ms or
+ *                     SYS_FOREVER_MS.
  * @param callback_isr Is called when message was sent or a transmission error
  *                     occurred. If NULL, this function is blocking until
  *                     message is sent. This must be NULL if called from user
@@ -372,7 +373,8 @@ static inline int z_impl_can_send(struct device *dev,
  * @param length Number of bytes to write (max. 8).
  * @param id  Identifier of the can message.
  * @param rtr Send remote transmission request or data frame
- * @param timeout Waiting for empty tx mailbox timeout in ms or K_FOREVER
+ * @param timeout Waiting for empty tx mailbox timeout in ms or
+ *                SYS_FOREVER_MS
  *
  * @retval 0 If successful.
  * @retval -EIO General input / output error.

--- a/include/drivers/i2s.h
+++ b/include/drivers/i2s.h
@@ -294,8 +294,7 @@ enum i2s_trigger_cmd {
  * @param mem_slab memory slab to store RX/TX data.
  * @param block_size Size of one RX/TX memory block (buffer) in bytes.
  * @param timeout Read/Write timeout. Number of milliseconds to wait in case TX
- *        queue is full, RX queue is empty or one of the special values
- *        K_NO_WAIT, K_FOREVER.
+ *        queue is full or RX queue is empty, or 0, or SYS_FOREVER_MS.
  */
 struct i2s_config {
 	u8_t word_size;

--- a/include/drivers/lora.h
+++ b/include/drivers/lora.h
@@ -124,8 +124,8 @@ static inline int lora_send(struct device *dev,
  * @param data      Buffer to hold received data
  * @param size      Size of the buffer to hold the received data. Max size
 		    allowed is 255.
- * @param timeout   Timeout value in milliseconds. API also accepts, K_NO_WAIT
-		    for no wait time and K_FOREVER for blocking until
+ * @param timeout   Timeout value in milliseconds. API also accepts, 0
+		    for no wait time and SYS_FOREVER_MS for blocking until
 		    data arrives.
  * @param rssi      RSSI of received data
  * @param snr       SNR of received data

--- a/include/drivers/uart.h
+++ b/include/drivers/uart.h
@@ -456,7 +456,7 @@ static inline int uart_callback_set(struct device *dev,
  * @param buf     Pointer to transmit buffer.
  * @param len     Length of transmit buffer.
  * @param timeout Timeout in milliseconds. Valid only if flow control is
- *		  enabled. K_FOREVER disables timeout.
+ *		  enabled. SYS_FOREVER_MS disables timeout.
  *
  * @retval -EBUSY There is already an ongoing transfer.
  * @retval 0	  If successful, negative errno code otherwise.
@@ -504,7 +504,7 @@ static inline int z_impl_uart_tx_abort(struct device *dev)
  * @param dev     UART device structure.
  * @param buf     Pointer to receive buffer.
  * @param len     Buffer length.
- * @param timeout Timeout in milliseconds. K_FOREVER disables timeout.
+ * @param timeout Timeout in milliseconds. SYS_FOREVER_MS disables timeout.
  *
  * @retval -EBUSY RX already in progress.
  * @retval 0	  If successful, negative errno code otherwise.

--- a/include/net/dns_resolve.h
+++ b/include/net/dns_resolve.h
@@ -316,8 +316,8 @@ int dns_resolve_cancel_with_name(struct dns_resolve_context *ctx,
  * has happened.
  * @param user_data The user data.
  * @param timeout The timeout value for the query. Possible values:
- * K_FOREVER: the query is tried forever, user needs to cancel it manually
- *            if it takes too long time to finish
+ * SYS_FOREVER_MS: the query is tried forever, user needs to cancel it
+ *            manually if it takes too long time to finish
  * >0: start the query and let the system timeout it after specified ms
  *
  * @return 0 if resolving was started ok, < 0 otherwise
@@ -363,8 +363,8 @@ struct dns_resolve_context *dns_resolve_get_default(void);
  * has happened.
  * @param user_data The user data.
  * @param timeout The timeout value for the connection. Possible values:
- * K_FOREVER: the query is tried forever, user needs to cancel it manually
- *            if it takes too long time to finish
+ * SYS_FOREVER_MS: the query is tried forever, user needs to cancel it
+ *            manually if it takes too long time to finish
  * >0: start the query and let the system timeout it after specified ms
  *
  * @return 0 if resolving was started ok, < 0 otherwise

--- a/samples/drivers/CAN/src/main.c
+++ b/samples/drivers/CAN/src/main.c
@@ -257,7 +257,8 @@ void main(void)
 	while (1) {
 		change_led_frame.data[0] = toggle++ & 0x01 ? SET_LED : RESET_LED;
 		/* This sending call is none blocking. */
-		can_send(can_dev, &change_led_frame, K_FOREVER, tx_irq_callback,
+		can_send(can_dev, &change_led_frame, SYS_FOREVER_MS,
+			 tx_irq_callback,
 			 "LED change");
 		k_sleep(SLEEP_TIME);
 

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -47,7 +47,7 @@ void main(void)
 
 	while (1) {
 		/* Block until data arrives */
-		len = lora_recv(lora_dev, data, MAX_DATA_LEN, K_FOREVER,
+		len = lora_recv(lora_dev, data, MAX_DATA_LEN, SYS_FOREVER_MS,
 				&rssi, &snr);
 		if (len < 0) {
 			LOG_ERR("LoRa receive failed");

--- a/scripts/coccinelle/ms_timeout.cocci
+++ b/scripts/coccinelle/ms_timeout.cocci
@@ -1,0 +1,194 @@
+// Copyright (c) 2019-2020 Nordic Semiconductor ASA
+// SPDX-License-Identifer: Apache-2.0
+
+// Replace use of K_NO_WAIT and K_FOREVER in API that requires
+// timeouts be specified as integral milliseconds.
+//
+// These constants used to have the values 0 and -1 respectively; they
+// are now timeout values which are opaque non-integral values that
+// can't be converted to integers automatically.  For K_NO_WAIT replace
+// with 0; for K_FOREVER replace with SYS_FOREVER_MS, the value of
+// which is -1.
+//
+// Options: --include-headers
+
+virtual patch
+virtual report
+
+// ** Handle millisecond timeout as the last parameter
+
+// Match identifer passed as timeout
+@match_fn_l1@
+identifier fn =~ "(?x)^
+(dmic_read
+|bt_buf_get_(rx|cmd_complete|evt)
+|bt_mesh_cfg_cli_timeout_set
+|isotp_(bind|recv(_net)?|send(_net)?(_ctx)?_buf)
+|tty_set_(tx|rx)_timeout
+|can_(write|recover)
+|uart_(tx|rx_enable)
+|dns_(resolve_name|get_addr_info)
+|net_config_init
+|net_ppp_ping
+|websocket_(send|recv)_msg
+)$";
+identifier T;
+@@
+ fn(..., T);
+
+@report_fn_l1
+ extends match_fn_l1
+ depends on report
+@
+identifier K_NO_WAIT =~ "^K_NO_WAIT$";
+identifier K_FOREVER =~ "^K_FOREVER$";
+position p;
+@@
+ fn@p(...,
+(
+K_NO_WAIT
+|
+K_FOREVER
+)
+ )
+
+@script:python
+ depends on report
+@
+fn << match_fn_l1.fn;
+T << match_fn_l1.T;
+p << report_fn_l1.p;
+@@
+msg = "WARNING: [msl1] replace constant {} with ms duration in {}".format(T, fn)
+coccilib.report.print_report(p[0], msg);
+
+@fix_fn_l1
+ extends match_fn_l1
+ depends on patch
+@
+identifier K_NO_WAIT =~ "^K_NO_WAIT$";
+identifier K_FOREVER =~ "^K_FOREVER$";
+@@
+ fn(...,
+(
+- K_NO_WAIT
++ 0
+|
+- K_FOREVER
++ SYS_FOREVER_MS
+))
+
+// ** Handle millisecond timeout as second from last parameter
+
+// Match identifer passed as timeout
+@match_fn_l2@
+identifier fn =~ "(?x)^
+(http_client_req
+|websocket_connect
+)$";
+expression L1;
+identifier T;
+@@
+ fn(..., T, L1)
+
+@report_fn_l2
+ extends match_fn_l2
+ depends on report
+@
+identifier K_NO_WAIT =~ "^K_NO_WAIT$";
+identifier K_FOREVER =~ "^K_FOREVER$";
+expression X1;
+position p;
+@@
+ fn@p(...,
+(
+K_NO_WAIT
+|
+K_FOREVER
+)
+ , X1)
+
+@script:python
+ depends on report
+@
+fn << match_fn_l2.fn;
+T << match_fn_l2.T;
+p << report_fn_l2.p;
+@@
+msg = "WARNING: [msl2] replace constant {} with ms duration in {}".format(T, fn)
+coccilib.report.print_report(p[0], msg);
+
+@fix_fn_l2
+ extends match_fn_l2
+ depends on patch
+@
+identifier K_NO_WAIT =~ "^K_NO_WAIT$";
+identifier K_FOREVER =~ "^K_FOREVER$";
+expression X1;
+@@
+ fn(...,
+(
+- K_NO_WAIT
++ 0
+|
+- K_FOREVER
++ SYS_FOREVER_MS
+)
+ , X1)
+
+// ** Handle millisecond timeout as third from last parameter
+
+// Match identifer passed as timeout
+@match_fn_l3@
+identifier fn =~ "(?x)^
+(can_send
+|lora_recv
+)$";
+expression L1;
+expression L2;
+identifier T;
+@@
+ fn(..., T, L2, L1)
+
+@report_fn_l3
+ extends match_fn_l3
+ depends on report
+@
+identifier K_NO_WAIT =~ "^K_NO_WAIT$";
+identifier K_FOREVER =~ "^K_FOREVER$";
+position p;
+@@
+ fn@p(...,
+(
+K_NO_WAIT
+|
+K_FOREVER
+)
+ , L2, L1)
+
+@script:python
+ depends on report
+@
+fn << match_fn_l3.fn;
+T << match_fn_l3.T;
+p << report_fn_l3.p;
+@@
+msg = "WARNING: [msl3] replace constant {} with ms duration in {}".format(T, fn)
+coccilib.report.print_report(p[0], msg);
+
+@fix_fn_l3
+ extends match_fn_l3
+ depends on patch
+@
+identifier K_NO_WAIT =~ "^K_NO_WAIT$";
+identifier K_FOREVER =~ "^K_FOREVER$";
+@@
+ fn(...,
+(
+- K_NO_WAIT
++ 0
+|
+- K_FOREVER
++ SYS_FOREVER_MS
+)
+ , L2, L1)

--- a/subsys/canbus/canopen/CO_driver.c
+++ b/subsys/canbus/canopen/CO_driver.c
@@ -133,7 +133,7 @@ static void canopen_tx_retry(struct k_work *item)
 			msg.rtr = (buffer->rtr ? 1 : 0);
 			memcpy(msg.data, buffer->data, buffer->DLC);
 
-			err = can_send(CANmodule->dev, &msg, K_NO_WAIT,
+			err = can_send(CANmodule->dev, &msg, 0,
 				       canopen_tx_isr_callback, CANmodule);
 			if (err == CAN_TIMEOUT) {
 				break;
@@ -345,7 +345,7 @@ CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer)
 	msg.rtr = (buffer->rtr ? 1 : 0);
 	memcpy(msg.data, buffer->data, buffer->DLC);
 
-	err = can_send(CANmodule->dev, &msg, K_NO_WAIT, canopen_tx_isr_callback,
+	err = can_send(CANmodule->dev, &msg, 0, canopen_tx_isr_callback,
 		       CANmodule);
 	if (err == CAN_TIMEOUT) {
 		buffer->bufferFull = true;

--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -403,16 +403,16 @@ void test_forever_timeout(void)
 	memset(rx_buf, 0, sizeof(rx_buf));
 	memset(tx_buf, 1, sizeof(tx_buf));
 
-	uart_rx_enable(uart_dev, rx_buf, sizeof(rx_buf), K_FOREVER);
+	uart_rx_enable(uart_dev, rx_buf, sizeof(rx_buf), SYS_FOREVER_MS);
 
-	uart_tx(uart_dev, tx_buf, 5, K_FOREVER);
+	uart_tx(uart_dev, tx_buf, 5, SYS_FOREVER_MS);
 	zassert_not_equal(k_sem_take(&tx_aborted, K_MSEC(1000)), 0,
 			  "TX_ABORTED timeout");
 	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
 	zassert_not_equal(k_sem_take(&rx_rdy, K_MSEC(1000)), 0,
 			  "RX_RDY timeout");
 
-	uart_tx(uart_dev, tx_buf, 95, K_FOREVER);
+	uart_tx(uart_dev, tx_buf, 95, SYS_FOREVER_MS);
 
 	zassert_not_equal(k_sem_take(&tx_aborted, K_MSEC(1000)), 0,
 			  "TX_ABORTED timeout");


### PR DESCRIPTION
Some API that takes timeouts represented by integral milliseconds recommended using the K_NO_WAIT and K_FOREVER constants, which are no longer integers.  The script added here replaces the incorrect arguments in call sites with the recommended alternative: 0 for `K_NO_WAIT` and `SYS_FOREVER_MS` for `K_FOREVER`.

Updated to include application of the fix, and manual update of related API documentation.
