### PR TITLE
drivers: i2c: nrfx: Fix log level is ignored

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -9,9 +9,8 @@
 #include <dt-bindings/i2c/i2c.h>
 #include <nrfx_twi.h>
 
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_nrfx_twi);
+LOG_MODULE_REGISTER(i2c_nrfx_twi, CONFIG_I2C_LOG_LEVEL);
 
 struct i2c_nrfx_twi_data {
 	struct k_sem transfer_sync;

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -9,10 +9,8 @@
 #include <dt-bindings/i2c/i2c.h>
 #include <nrfx_twim.h>
 
-#define LOG_DOMAIN "i2c_nrfx_twim"
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_nrfx_twim);
+LOG_MODULE_REGISTER(i2c_nrfx_twim, CONFIG_I2C_LOG_LEVEL);
 
 struct i2c_nrfx_twim_data {
 	struct k_sem transfer_sync;


### PR DESCRIPTION
Fixes the problem that the log level set in Kconfig is ignored.

Signed-off-by: Christoph Reiter <christoph.reiter@infineon.com>

NOTE: git blame points to this commit https://github.com/zephyrproject-rtos/zephyr/commit/f7dac85d15fbecaa5736a1c4cb807a6c8b5e8afe as last chaninging the lines so other drivers may be affected too.

Closes #18085.