### PR TITLE
Fix system clock driver selection for cortex m

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/vector_table.S
+++ b/arch/arm/core/aarch32/cortex_m/vector_table.S
@@ -72,11 +72,14 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
     .word 0
     .word z_arm_pendsv
 #if defined(CONFIG_CPU_CORTEX_M_HAS_SYSTICK)
-#if defined(CONFIG_SYS_CLOCK_EXISTS) && defined(CONFIG_CORTEX_M_SYSTICK)
+#if defined(CONFIG_SYS_CLOCK_EXISTS)
+    /* Install z_clock_isr even if CORTEX_M_SYSTICK is not set
+     * (e.g. to support out-of-tree SysTick-based timer drivers).
+     */
     .word z_clock_isr
 #else
     .word z_arm_exc_spurious
-#endif /* CONFIG_SYS_CLOCK_EXISTS && CONFIG_CORTEX_M_SYSTICK */
+#endif /* CONFIG_SYS_CLOCK_EXISTS */
 #else
     .word 0
 #endif /* CONFIG_CPU_CORTEX_M_HAS_SYSTICK */


### PR DESCRIPTION
The selection of the Cortex M systick driver to be used as a system clock driver
is controlled by CONFIG_CORTEX_M_SYSTICK.

To replace it by another driver CONFIG_CORTEX_M_SYSTICK must be set to 'n'.
Unfortunately this also controls the interrupt vector for the systick interrupt.
It is now routed to z_arm_exc_spurious.

Remove the dependecy on CONFIG_CORTEX_M_SYSTICK and route to z_clock_isr as it
was before #24012.

Fixes #24347

Signed-off-by: Bobby Noelte <b0661n0e17e@gmail.com>