### PR TITLE
sanitycheck: add --persistent-hardware-map

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from distutils.spawn import find_executable
 from colorama import Fore
 import yaml
+import platform
 
 try:
     import serial
@@ -3242,8 +3243,30 @@ class HardwareMap:
         for i in self.connected_hardware:
             i['counter'] = 0
 
-    def scan_hw(self):
+    def scan_hw(self, persistent=False):
         from serial.tools import list_ports
+
+        if persistent and platform.system() == 'Linux':
+            # On Linux, /dev/serial/by-id provides symlinks to
+            # '/dev/ttyACMx' nodes using names which are unique as
+            # long as manufacturers fill out USB metadata nicely.
+            #
+            # This creates a map from '/dev/ttyACMx' device nodes
+            # to '/dev/serial/by-id/usb-...' symlinks. The symlinks
+            # go into the hardware map because they stay the same
+            # even when the user unplugs / replugs the device.
+            #
+            # Some inexpensive USB/serial adapters don't result
+            # in unique names here, though, so use of this feature
+            # requires explicitly setting persistent=True.
+            by_id = Path('/dev/serial/by-id')
+            def readlink(link):
+                return str((by_id / link).resolve())
+
+            persistent_map = {readlink(link): str(link)
+                              for link in by_id.iterdir()}
+        else:
+            persistent_map = {}
 
         serial_devices = list_ports.comports()
         logger.info("Scanning connected hardware...")
@@ -3257,7 +3280,7 @@ class HardwareMap:
                 s_dev = {}
                 s_dev['platform'] = "unknown"
                 s_dev['id'] = d.serial_number
-                s_dev['serial'] = d.device
+                s_dev['serial'] = persistent_map.get(d.device, d.device)
                 s_dev['product'] = d.product
                 s_dev['runner'] = 'unknown'
                 for runner, _ in self.runner_mapping.items():

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -551,6 +551,12 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
                         --device-testing
                         """)
 
+    parser.add_argument("--persistent-hardware-map", action='store_true',
+                        help="""With --generate-hardware-map, tries to use
+                        persistent names for serial devices on platforms
+                        that support this feature (currently only Linux).
+                        """)
+
     parser.add_argument("--hardware-map",
                         help="""Load hardware map from a file. This will be used
                         for testing on hardware that is listed in the file.
@@ -685,7 +691,7 @@ def main():
 
     hwm = HardwareMap()
     if options.generate_hardware_map:
-        hwm.scan_hw()
+        hwm.scan_hw(persistent=options.persistent_hardware_map)
         hwm.write_map(options.generate_hardware_map)
         return
 


### PR DESCRIPTION
This option prefers serial device names which are stable across device plug/un-plug on platforms that support it (currently just Linux, via /dev/serial/by-id).

This feature is opt-in as not all USB serial device manufacturers include the appropriate metadata for udev to generate unique names for their devices.
