### PR TITLE
tests: counter_nrf_rtc: fix platform whitelist

### DIFF
--- a/tests/drivers/counter/counter_nrf_rtc/fixed_top/testcase.yaml
+++ b/tests/drivers/counter/counter_nrf_rtc/fixed_top/testcase.yaml
@@ -2,4 +2,4 @@ tests:
   drivers.counter:
     tags: drivers
     depends_on: counter
-    platform_whitelist: nrf52840_pca0056
+    platform_whitelist: nrf52840dk_nrf52840


### PR DESCRIPTION
The board rename was missed. That's the only remaining case of a
missed rename I could find in tree, but I may have missed something.

