### PR TITLE
Z_ISR_DECLARE: update for C++ support

### DIFF
--- a/include/sw_isr_table.h
+++ b/include/sw_isr_table.h
@@ -67,7 +67,7 @@ struct _isr_list {
 #define Z_ISR_DECLARE(irq, flags, func, param) \
 	static Z_DECL_ALIGN(struct _isr_list) Z_GENERIC_SECTION(.intList) \
 		__used _MK_ISR_NAME(func, __COUNTER__) = \
-			{irq, flags, &func, (void *)param}
+			{irq, flags, (void *)&func, (void *)param}
 
 #define IRQ_TABLE_SIZE (CONFIG_NUM_IRQS - CONFIG_GEN_IRQ_START_VECTOR)
 


### PR DESCRIPTION
The implicit conversion of pointer-to-function to pointer-to-void is
not acceptable in C++.  Provide a C-style explicit cast to force the
reinterpretation.

Fixes #24322