### PR TITLE
Bluetooth: ATT: Fix passing wrong pointer when disconnecting

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2091,7 +2091,8 @@ static void att_reset(struct bt_att *att)
 	/* Notify pending requests */
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&att->reqs, req, tmp, node) {
 		if (req->func) {
-			req->func(NULL, BT_ATT_ERR_UNLIKELY, NULL, 0, req);
+			req->func(NULL, BT_ATT_ERR_UNLIKELY, NULL, 0,
+				  req->user_data);
 		}
 
 		att_req_destroy(req);


### PR DESCRIPTION
When disconnecting att_reset is called and all requests are notified
but instead of passing req->user_data like it should it pass the req
itself which nowdays comes from a k_mem_slab, rather than being a
contiguous memory that would contain the request and its user data,
which would likely cause invalid access.

Fixes #24373

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>