### PR TITLE
arch: arm: Remove dead code from ARCH_IRQ_CONNECT macros

### DIFF
--- a/include/arch/arm/aarch32/irq.h
+++ b/include/arch/arm/aarch32/irq.h
@@ -109,14 +109,12 @@ extern void z_arm_interrupt_init(void);
 ({ \
 	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
 	z_arm_irq_priority_set(irq_p, priority_p, flags_p); \
-	irq_p; \
 })
 
 #define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
 ({ \
 	Z_ISR_DECLARE(irq_p, ISR_FLAG_DIRECT, isr_p, NULL); \
 	z_arm_irq_priority_set(irq_p, priority_p, flags_p); \
-	irq_p; \
 })
 
 #ifdef CONFIG_SYS_POWER_MANAGEMENT

--- a/include/arch/arm/aarch64/irq.h
+++ b/include/arch/arm/aarch64/irq.h
@@ -86,14 +86,12 @@ extern void z_arm64_interrupt_init(void);
 ({ \
 	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
 	z_arm64_irq_priority_set(irq_p, priority_p, flags_p); \
-	irq_p; \
 })
 
 #define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
 ({ \
 	Z_ISR_DECLARE(irq_p, ISR_FLAG_DIRECT, isr_p, NULL); \
 	z_arm64_irq_priority_set(irq_p, priority_p, flags_p); \
-	irq_p; \
 })
 
 /* Spurious interrupt handler. Throws an error if called */


### PR DESCRIPTION
Remove line in ARCH_IRQ_CONNECT and ARCH_IRQ_DIRECT_CONNECT macros
that just has the irq line number.  This doesn't really have any
functionality and can cause warnings under certain cases.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>