### PR TITLE
cmake: FindPython3: Adjust python3 program search

### DIFF
--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -9,5 +9,29 @@ if (WIN32)
   set(ENV{PYTHONIOENCODING} "utf-8")
 endif()
 
-find_package(Python3 3.6 REQUIRED)
+set(PYTHON_MINIMUM_REQUIRED 3.6)
+
+# We are using foreach here, instead of find_program(PYTHON_EXECUTABLE_SYSTEM_DEFAULT "python" "python3")
+# cause just using find_program directly could result in a python2.7 as python, and not finding a valid python3.
+foreach(PYTHON_PREFER ${PYTHON_PREFER} "python" "python3")
+  find_program(PYTHON_PREFER_EXECUTABLE ${PYTHON_PREFER})
+  if(PYTHON_PREFER_EXECUTABLE)
+      execute_process (COMMAND "${PYTHON_PREFER_EXECUTABLE}" -c
+                               "import sys; sys.stdout.write('.'.join([str(x) for x in sys.version_info[:2]]))"
+                       RESULT_VARIABLE result
+                       OUTPUT_VARIABLE version
+                       ERROR_QUIET
+                       OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+     if(version VERSION_LESS PYTHON_MINIMUM_REQUIRED)
+       set_property (CACHE PYTHON_PREFER_EXECUTABLE PROPERTY VALUE "PYTHON_PREFER_EXECUTABLE-NOTFOUND")
+     else()
+       set(PYTHON_MINIMUM_REQUIRED ${version})
+       set(PYTHON_EXACT EXACT)
+       break()
+     endif()
+  endif()
+endforeach()
+
+find_package(Python3 ${PYTHON_MINIMUM_REQUIRED} REQUIRED ${PYTHON_EXACT})
 set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})


### PR DESCRIPTION
This PR fixes #24340.

The `find_package(Python3)` will default select the highest installed Python3 version, unless exact is specified. Although it is possible to use CMake flags to control the behavior, then the discussion in #24340 indicates that CMake version 3.14 behaves differently than CMake 3.16 and 3.17.

The desired approach of whether Zephyr should follow CMake `find_package(Python3)` default behavior or another is open for debate.

But this PR provides a consistent mechanism across CMake 3.13-3.17 on how to control the behavior.

The Python3 that will be selected is per default:
`python` (if meeting required version), `python3` (if meeting required version), then highest Python.

Example 1:
```
/usr/bin/python --> python2.7
/usr/bin/python3 --> python3.6
/usr/bin/python2.7
/usr/bin/python3.6
/usr/bin/python3.8
```
Python 3.6 will be selected, because `/usr/bin/python3 --> python3.6`

Example 2:
```
/usr/bin/python --> python3.6
/usr/bin/python3 --> python3.8
/usr/bin/python3.6
/usr/bin/python3.8
```
Python 3.6 will be selected, because `/usr/bin/python --> python3.6`

Example 3:
```
/usr/bin/python --> python3.4
/usr/bin/python3 --> python3.4
/usr/bin/python3.4
/usr/bin/python3.6
/usr/bin/python3.8
```
Python 3.8 will be selected, because Python 3.4 does not meet required version.

The way this is implemented, is by manually in Zephyr test the version of `python` and `python3`, and if they meet the required version, then this version will be feed to `find_package(Python3)` along with `EXACT` flag.

This further allows Zephyr user's to control the Python3 version, using the flag `PYTHON_PREFER`, as example:
`cmake -DPYTHON_PREFER=python3.8`, which will choose Python 3.8, over `python` and `python3`.

This PR should not be merged until we are sure that Zephyr should deviate from default CMake `find_package(Python3)` behavior.