### PR TITLE
irq: Remove return value from IRQ_CONNECT and IRQ_DIRECT_CONNECT

### DIFF
--- a/boards/posix/native_posix/board_irq.h
+++ b/boards/posix/native_posix/board_irq.h
@@ -27,15 +27,12 @@ void posix_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
  * @param isr_p Interrupt service routine
  * @param isr_param_p ISR parameter
  * @param flags_p IRQ options
- *
- * @return The vector assigned to this interrupt
  */
 #define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
-({ \
+{ \
 	posix_isr_declare(irq_p, 0, isr_p, isr_param_p); \
 	posix_irq_priority_set(irq_p, priority_p, flags_p); \
-	irq_p; \
-})
+}
 
 
 /**
@@ -44,12 +41,11 @@ void posix_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
  * See include/irq.h for details.
  */
 #define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
-({ \
+{ \
 	posix_isr_declare(irq_p, ISR_FLAG_DIRECT, (void (*)(void *))isr_p, \
 			  NULL); \
 	posix_irq_priority_set(irq_p, priority_p, flags_p); \
-	irq_p; \
-})
+}
 
 /**
  * POSIX Architecture (board) specific ISR_DIRECT_DECLARE(),

--- a/boards/posix/nrf52_bsim/board_irq.h
+++ b/boards/posix/nrf52_bsim/board_irq.h
@@ -27,15 +27,12 @@ void posix_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
  * @param isr_p Interrupt service routine
  * @param isr_param_p ISR parameter
  * @param flags_p IRQ options
- *
- * @return The vector assigned to this interrupt
  */
 #define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
-({ \
+{ \
 	posix_isr_declare(irq_p, 0, isr_p, isr_param_p); \
 	posix_irq_priority_set(irq_p, priority_p, flags_p); \
-	irq_p; \
-})
+}
 
 
 /**
@@ -44,12 +41,11 @@ void posix_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
  * See include/irq.h for details.
  */
 #define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
-({ \
+{ \
 	posix_isr_declare(irq_p, ISR_FLAG_DIRECT, (void (*)(void *))isr_p, \
 			  NULL); \
 	posix_irq_priority_set(irq_p, priority_p, flags_p); \
-	irq_p; \
-})
+}
 
 /**
  * POSIX Architecture (board) specific ISR_DIRECT_DECLARE(),

--- a/include/arch/arc/v2/irq.h
+++ b/include/arch/arc/v2/irq.h
@@ -51,11 +51,10 @@ extern void z_irq_spurious(void *unused);
  * runtime.
  */
 #define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
-({ \
+{ \
 	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
 	z_irq_priority_set(irq_p, priority_p, flags_p); \
-	irq_p; \
-})
+}
 
 /**
  * Configure a 'direct' static interrupt.
@@ -79,7 +78,7 @@ extern void z_irq_spurious(void *unused);
  * All arguments must be computable at build time.
  */
 #define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
-({ \
+{ \
 	Z_ISR_DECLARE(irq_p, ISR_FLAG_DIRECT, isr_p, NULL); \
 	BUILD_ASSERT(priority_p || !IS_ENABLED(CONFIG_ARC_FIRQ) || \
 	(IS_ENABLED(CONFIG_ARC_FIRQ_STACK) && \
@@ -88,8 +87,7 @@ extern void z_irq_spurious(void *unused);
 	"is not configured or CONFIG_ARC_FIRQ_STACK " \
 	"and CONFIG_ARC_STACK_CHECKING are configured together"); \
 	z_irq_priority_set(irq_p, priority_p, flags_p); \
-	irq_p; \
-})
+}
 
 
 static inline void arch_isr_direct_header(void)

--- a/include/arch/arm/aarch32/irq.h
+++ b/include/arch/arm/aarch32/irq.h
@@ -106,18 +106,16 @@ extern void z_arm_interrupt_init(void);
  * runtime.
  */
 #define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
-({ \
+{ \
 	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
 	z_arm_irq_priority_set(irq_p, priority_p, flags_p); \
-	irq_p; \
-})
+}
 
 #define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
-({ \
+{ \
 	Z_ISR_DECLARE(irq_p, ISR_FLAG_DIRECT, isr_p, NULL); \
 	z_arm_irq_priority_set(irq_p, priority_p, flags_p); \
-	irq_p; \
-})
+}
 
 #ifdef CONFIG_SYS_POWER_MANAGEMENT
 extern void _arch_isr_direct_pm(void);

--- a/include/arch/arm/aarch64/irq.h
+++ b/include/arch/arm/aarch64/irq.h
@@ -83,18 +83,16 @@ extern void z_arm64_interrupt_init(void);
  * runtime.
  */
 #define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
-({ \
+{ \
 	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
 	z_arm64_irq_priority_set(irq_p, priority_p, flags_p); \
-	irq_p; \
-})
+}
 
 #define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
-({ \
+{ \
 	Z_ISR_DECLARE(irq_p, ISR_FLAG_DIRECT, isr_p, NULL); \
 	z_arm64_irq_priority_set(irq_p, priority_p, flags_p); \
-	irq_p; \
-})
+}
 
 /* Spurious interrupt handler. Throws an error if called */
 extern void z_irq_spurious(void *unused);

--- a/include/arch/nios2/arch.h
+++ b/include/arch/nios2/arch.h
@@ -39,10 +39,9 @@ extern "C" {
  * controller and no flags are currently supported.
  */
 #define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
-({ \
+{ \
 	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
-	irq_p; \
-})
+}
 
 extern void z_irq_spurious(void *unused);
 

--- a/include/arch/riscv/arch.h
+++ b/include/arch/riscv/arch.h
@@ -90,17 +90,15 @@ void z_irq_spurious(void *unused);
 
 #if defined(CONFIG_RISCV_HAS_PLIC)
 #define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
-({ \
+{ \
 	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
 	arch_irq_priority_set(irq_p, priority_p); \
-	irq_p; \
-})
+}
 #else
 #define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
-({ \
+{ \
 	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
-	irq_p; \
-})
+}
 #endif
 
 /*

--- a/include/arch/x86/ia32/arch.h
+++ b/include/arch/x86/ia32/arch.h
@@ -177,7 +177,7 @@ typedef struct s_isrList {
  * between the vector and the IRQ line as well as triggering flags
  */
 #define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
-({ \
+{ \
 	__asm__ __volatile__(							\
 		".pushsection .intList\n\t" \
 		".long %c[isr]_irq%c[irq]_stub\n\t"	/* ISR_LIST.fnc */ \
@@ -202,16 +202,14 @@ typedef struct s_isrList {
 		  [irq] "i" (irq_p)); \
 	z_irq_controller_irq_config(Z_IRQ_TO_INTERRUPT_VECTOR(irq_p), (irq_p), \
 				   (flags_p)); \
-	Z_IRQ_TO_INTERRUPT_VECTOR(irq_p); \
-})
+}
 
 #define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
-({ \
+{ \
 	NANO_CPU_INT_REGISTER(isr_p, irq_p, priority_p, -1, 0); \
 	z_irq_controller_irq_config(Z_IRQ_TO_INTERRUPT_VECTOR(irq_p), (irq_p), \
 				   (flags_p)); \
-	Z_IRQ_TO_INTERRUPT_VECTOR(irq_p); \
-})
+}
 
 #ifdef CONFIG_SYS_POWER_MANAGEMENT
 /*

--- a/include/arch/xtensa/arch.h
+++ b/include/arch/xtensa/arch.h
@@ -42,10 +42,9 @@ extern "C" {
 extern void z_irq_priority_set(u32_t irq, u32_t prio, u32_t flags);
 
 #define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
-({ \
+{ \
 	Z_ISR_DECLARE(irq_p, flags_p, isr_p, isr_param_p); \
-	irq_p; \
-})
+}
 
 /* Spurious interrupt handler. Throws an error if called */
 extern void z_irq_spurious(void *unused);

--- a/include/irq.h
+++ b/include/irq.h
@@ -44,8 +44,6 @@ extern "C" {
  * @param isr_p Address of interrupt service routine.
  * @param isr_param_p Parameter passed to interrupt service routine.
  * @param flags_p Architecture-specific IRQ configuration flags..
- *
- * @return Interrupt vector assigned to this interrupt.
  */
 #define IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
 	ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p)
@@ -109,8 +107,6 @@ irq_connect_dynamic(unsigned int irq, unsigned int priority,
  * @param priority_p Interrupt priority.
  * @param isr_p Address of interrupt service routine.
  * @param flags_p Architecture-specific IRQ configuration flags.
- *
- * @return Interrupt vector assigned to this interrupt.
  */
 #define IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
 	ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p)


### PR DESCRIPTION
The return value of the interrupt is never used, so remove the
functionality from the API.  We ripple this change into the
ARCH_IRQ_CONNECT and ARCH_IRQ_DIRECT_CONNECT implementations.  With
this change we can also remove the compound expression as that is
not needed anymore.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>