### PR TITLE
test/benchmarks/latency_measure: adapt test to 24bit Systick for STM32

### DIFF
--- a/tests/benchmarks/latency_measure/testcase.yaml
+++ b/tests/benchmarks/latency_measure/testcase.yaml
@@ -2,5 +2,14 @@ tests:
   benchmark.kernel.latency:
     arch_whitelist: x86 arm posix
     platform_exclude: qemu_x86_64
-    filter: CONFIG_PRINTK
+    filter: CONFIG_PRINTK and not CONFIG_SOC_FAMILY_STM32
     tags: benchmark
+
+# Cortex-M has 24bit systick, so default 1 TICK per seconds
+# is achievable only if frequency is below 0x00FFFFFF (around 16MHz)
+# 20 Ticks per secondes allows a frequency up to 335544300Hz (335MHz)
+  benchmark.kernel.latency.stm32:
+    filter: CONFIG_PRINTK and CONFIG_SOC_FAMILY_STM32
+    tags: benchmark
+    extra_configs:
+      - CONFIG_SYS_CLOCK_TICKS_PER_SEC=20


### PR DESCRIPTION
test/benchmarks/latency_measure: adapt test to 24bit Systick for STM32

Cortex-M has 24bit systick. But this test by default set 1 TICK per seconds,
which  is achievable only if frequency is below 0x00FFFFFF (around 16MHz), otherwise value set to systick is truncated.
20 Ticks per secondes allows a frequency up to 335544300Hz (335MHz)

Tested on nucleo_F429zi and nucleo_f207zg

Fixes #25287