### PR TITLE
doc: boards: fix capitalization of chip name

### DIFF
--- a/boards/arm/nrf9160dk_nrf52840/doc/index.rst
+++ b/boards/arm/nrf9160dk_nrf52840/doc/index.rst
@@ -1,6 +1,6 @@
 .. _nrf9160dk_nrf52840:
 
-nRF9160 DK - NRF52840
+nRF9160 DK - nRF52840
 #####################
 
 Overview


### PR DESCRIPTION
Fix the capitalization of "nRF52840".

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>