### PR TITLE
doc: gsg: provide a working link to the Zephyr SDK download page

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -331,7 +331,9 @@ including: compiler, assembler, linker, and their dependencies.
 
       |p|
 
-      #. Download the latest SDK as a self-extracting installation binary:
+      #. Download the `latest SDK
+	 <https://github.com/zephyrproject-rtos/sdk-ng/releases>`_ as a
+	 self-extracting installation binary:
 
          .. code-block:: bash
 

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -233,7 +233,9 @@ following target architectures:
 
 Follow these steps to install the Zephyr SDK:
 
-#. Download the latest SDK as a self-extracting installation binary:
+#. Download the `latest SDK
+   <https://github.com/zephyrproject-rtos/sdk-ng/releases>`_ as a
+   self-extracting installation binary:
 
    .. code-block:: console
 


### PR DESCRIPTION
The command-line is correct but specifies a particular release, which
may be out of date, and is not formatted as a URL that can be clicked.
Add a proper link.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>