### PR TITLE
sw_isr_table.h: fix __COUNTER__ usage

### DIFF
--- a/include/sw_isr_table.h
+++ b/include/sw_isr_table.h
@@ -58,7 +58,8 @@ struct _isr_list {
 /** This interrupt gets put directly in the vector table */
 #define ISR_FLAG_DIRECT BIT(0)
 
-#define _MK_ISR_NAME(x, y) __isr_ ## x ## _irq_ ## y
+#define _MK_ISR_NAME(x, y) __MK_ISR_NAME(x, y)
+#define __MK_ISR_NAME(x, y) __isr_ ## x ## _irq_ ## y
 
 /* Create an instance of struct _isr_list which gets put in the .intList
  * section. This gets consumed by gen_isr_tables.py which creates the vector


### PR DESCRIPTION
We can't pass `__COUNTER__` and then use it with '##' directly, because
the result is that the actual token `__COUNTER__` is what gets pasted.

Fix that with another expansion, so `__COUNTER__` is replaced with a
number before '## can' see it.
