### PR TITLE
dts: add nexus maps for Particle Mesh feather-like boards

### DIFF
--- a/boards/arm/particle_argon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather.dtsi
@@ -61,9 +61,66 @@
 			label = "Reset Button";
 		};
 	};
+
+	mesh_header: connector {
+		compatible = "particle-gen3-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 26 0>,   /* SDA */
+			   <1 0 &gpio0 27 0>,   /* SCL */
+			   <2 0 &gpio1 1 0>,    /* PWM3 */
+			   <3 0 &gpio1 2 0>,    /* PWM3 */
+			   <4 0 &gpio1 8 0>,    /* PWM1 */
+			   <5 0 &gpio1 10 0>,   /* PWM1 */
+			   <6 0 &gpio1 11 0>,   /* PWM1 */
+			   <7 0 &gpio1 12 0>,   /* PWM0 */
+			   <8 0 &gpio1 3 0>,    /* PWM1 */
+			   <9 0 &gpio0 6 0>,    /* TX */
+			   <10 0 &gpio0 8 0>,   /* RX */
+			   <11 0 &gpio1 14 0>,  /* MISO */
+			   <12 0 &gpio1 13 0>,  /* MOSI */
+			   <13 0 &gpio1 15 0>,  /* SCK */
+			   <14 0 &gpio0 31 0>,  /* SS */
+			   <15 0 &gpio0 30 0>,  /* ADC4 = AIN6 */
+			   <16 0 &gpio0 29 0>,  /* ADC3 = AIN5 */
+			   <17 0 &gpio0 28 0>,  /* ADC2 = AIN4 */
+			   <18 0 &gpio0 4 0>,   /* ADC1 = AIN2 */
+			   <19 0 &gpio0 3 0>,   /* ADC0 = AIN1 */
+			   <20 0 &gpio0 11 0>,  /* MODEn */
+			   <21 0 &gpio0 18 0>;  /* RESETn */
+	};
+
+	feather_header: feather_connector {
+		compatible = "adafruit-feather-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <12 0 &gpio0 26 0>,  /* SDA */
+			   <13 0 &gpio0 27 0>,  /* SCL */
+			   <14 0 &gpio1 1 0>,   /* PWM3 */
+			   <15 0 &gpio1 2 0>,   /* PWM3 */
+			   <16 0 &gpio1 8 0>,   /* PWM1 */
+			   <17 0 &gpio1 10 0>,  /* PWM1 */
+			   <18 0 &gpio1 11 0>,  /* PWM1 */
+			   <19 0 &gpio1 12 0>,  /* PWM0 */
+			   <20 0 &gpio1 3 0>,   /* PWM1 */
+			   /* 11 not connected */
+			   <10 0 &gpio0 6 0>,   /* TX */
+			   <9 0 &gpio0 8 0>,    /* RX */
+			   <8 0 &gpio1 14 0>,   /* MISO */
+			   <7 0 &gpio1 13 0>,   /* MOSI */
+			   <6 0 &gpio1 15 0>,   /* SCK */
+			   <5 0 &gpio0 31 0>,   /* SS */
+			   <4 0 &gpio0 30 0>,   /* ADC4 = AIN6 */
+			   <3 0 &gpio0 29 0>,   /* ADC3 = AIN5 */
+			   <2 0 &gpio0 28 0>,   /* ADC2 = AIN4 */
+			   <1 0 &gpio0 4 0>,    /* ADC1 = AIN2 */
+			   <0 0 &gpio0 3 0>;    /* ADC0 = AIN1 */
+	};
 };
 
-&adc { /* feather ADC */
+feather_adc: &adc { /* feather ADC */
 	status = "okay";
 };
 
@@ -126,6 +183,8 @@ arduino_i2c: &i2c0 { /* feather I2C */
 	scl-pin = <27>;
 };
 
+feather_i2c: &i2c0 { };
+
 /* TWI1 used on Boron; also see mesh_feather_spi1_spi1.dtsi */
 
 &spi2 { /* dedicated MX25L */
@@ -153,7 +212,7 @@ arduino_i2c: &i2c0 { /* feather I2C */
 
 /* see mesh_feather_spi1_spi3.dtsi */
 
-&uart0 { /* feather UART1 */
+feather_serial: &uart0 { /* feather UART1 */
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "okay";

--- a/boards/arm/particle_argon/dts/mesh_feather_spi_spi1.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather_spi_spi1.dtsi
@@ -9,7 +9,7 @@
  * NOTE: This file is replicated in particle_{argon,xenon}.
  * Changes should be made in all instances. */
 
-&spi1 { /* feather SPI */
+feather_spi: &spi1 { /* feather SPI */
 	status = "okay";
 	sck-pin = <47>;
 	mosi-pin = <45>;

--- a/boards/arm/particle_argon/dts/mesh_feather_spi_spi3.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather_spi_spi3.dtsi
@@ -9,7 +9,7 @@
  * NOTE: This file is replicated in particle_{argon,boron,xenon}.
  * Changes should be made in all instances. */
 
-&spi3 { /* feather SPI */
+feather_spi: &spi3 { /* feather SPI */
 	status = "okay";
 	sck-pin = <47>;
 	mosi-pin = <45>;

--- a/boards/arm/particle_argon/particle_argon.yaml
+++ b/boards/arm/particle_argon/particle_argon.yaml
@@ -15,3 +15,6 @@ supported:
   - usb_device
   - ble
   - ieee802154
+  - feather_serial
+  - feather_i2c
+  - feather_spi

--- a/boards/arm/particle_boron/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather.dtsi
@@ -61,9 +61,66 @@
 			label = "Reset Button";
 		};
 	};
+
+	mesh_header: connector {
+		compatible = "particle-gen3-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 26 0>,   /* SDA */
+			   <1 0 &gpio0 27 0>,   /* SCL */
+			   <2 0 &gpio1 1 0>,    /* PWM3 */
+			   <3 0 &gpio1 2 0>,    /* PWM3 */
+			   <4 0 &gpio1 8 0>,    /* PWM1 */
+			   <5 0 &gpio1 10 0>,   /* PWM1 */
+			   <6 0 &gpio1 11 0>,   /* PWM1 */
+			   <7 0 &gpio1 12 0>,   /* PWM0 */
+			   <8 0 &gpio1 3 0>,    /* PWM1 */
+			   <9 0 &gpio0 6 0>,    /* TX */
+			   <10 0 &gpio0 8 0>,   /* RX */
+			   <11 0 &gpio1 14 0>,  /* MISO */
+			   <12 0 &gpio1 13 0>,  /* MOSI */
+			   <13 0 &gpio1 15 0>,  /* SCK */
+			   <14 0 &gpio0 31 0>,  /* SS */
+			   <15 0 &gpio0 30 0>,  /* ADC4 = AIN6 */
+			   <16 0 &gpio0 29 0>,  /* ADC3 = AIN5 */
+			   <17 0 &gpio0 28 0>,  /* ADC2 = AIN4 */
+			   <18 0 &gpio0 4 0>,   /* ADC1 = AIN2 */
+			   <19 0 &gpio0 3 0>,   /* ADC0 = AIN1 */
+			   <20 0 &gpio0 11 0>,  /* MODEn */
+			   <21 0 &gpio0 18 0>;  /* RESETn */
+	};
+
+	feather_header: feather_connector {
+		compatible = "adafruit-feather-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <12 0 &gpio0 26 0>,  /* SDA */
+			   <13 0 &gpio0 27 0>,  /* SCL */
+			   <14 0 &gpio1 1 0>,   /* PWM3 */
+			   <15 0 &gpio1 2 0>,   /* PWM3 */
+			   <16 0 &gpio1 8 0>,   /* PWM1 */
+			   <17 0 &gpio1 10 0>,  /* PWM1 */
+			   <18 0 &gpio1 11 0>,  /* PWM1 */
+			   <19 0 &gpio1 12 0>,  /* PWM0 */
+			   <20 0 &gpio1 3 0>,   /* PWM1 */
+			   /* 11 not connected */
+			   <10 0 &gpio0 6 0>,   /* TX */
+			   <9 0 &gpio0 8 0>,    /* RX */
+			   <8 0 &gpio1 14 0>,   /* MISO */
+			   <7 0 &gpio1 13 0>,   /* MOSI */
+			   <6 0 &gpio1 15 0>,   /* SCK */
+			   <5 0 &gpio0 31 0>,   /* SS */
+			   <4 0 &gpio0 30 0>,   /* ADC4 = AIN6 */
+			   <3 0 &gpio0 29 0>,   /* ADC3 = AIN5 */
+			   <2 0 &gpio0 28 0>,   /* ADC2 = AIN4 */
+			   <1 0 &gpio0 4 0>,    /* ADC1 = AIN2 */
+			   <0 0 &gpio0 3 0>;    /* ADC0 = AIN1 */
+	};
 };
 
-&adc { /* feather ADC */
+feather_adc: &adc { /* feather ADC */
 	status = "okay";
 };
 
@@ -126,6 +183,8 @@ arduino_i2c: &i2c0 { /* feather I2C */
 	scl-pin = <27>;
 };
 
+feather_i2c: &i2c0 { };
+
 /* TWI1 used on Boron; also see mesh_feather_spi1_spi1.dtsi */
 
 &spi2 { /* dedicated MX25L */
@@ -153,7 +212,7 @@ arduino_i2c: &i2c0 { /* feather I2C */
 
 /* see mesh_feather_spi1_spi3.dtsi */
 
-&uart0 { /* feather UART1 */
+feather_serial: &uart0 { /* feather UART1 */
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "okay";

--- a/boards/arm/particle_boron/dts/mesh_feather_spi_spi3.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather_spi_spi3.dtsi
@@ -9,7 +9,7 @@
  * NOTE: This file is replicated in particle_{argon,boron,xenon}.
  * Changes should be made in all instances. */
 
-&spi3 { /* feather SPI */
+feather_spi: &spi3 { /* feather SPI */
 	status = "okay";
 	sck-pin = <47>;
 	mosi-pin = <45>;

--- a/boards/arm/particle_boron/particle_boron.yaml
+++ b/boards/arm/particle_boron/particle_boron.yaml
@@ -15,3 +15,6 @@ supported:
   - usb_device
   - ble
   - ieee802154
+  - feather_serial
+  - feather_i2c
+  - feather_spi

--- a/boards/arm/particle_xenon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather.dtsi
@@ -61,9 +61,66 @@
 			label = "Reset Button";
 		};
 	};
+
+	mesh_header: connector {
+		compatible = "particle-gen3-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 26 0>,   /* SDA */
+			   <1 0 &gpio0 27 0>,   /* SCL */
+			   <2 0 &gpio1 1 0>,    /* PWM3 */
+			   <3 0 &gpio1 2 0>,    /* PWM3 */
+			   <4 0 &gpio1 8 0>,    /* PWM1 */
+			   <5 0 &gpio1 10 0>,   /* PWM1 */
+			   <6 0 &gpio1 11 0>,   /* PWM1 */
+			   <7 0 &gpio1 12 0>,   /* PWM0 */
+			   <8 0 &gpio1 3 0>,    /* PWM1 */
+			   <9 0 &gpio0 6 0>,    /* TX */
+			   <10 0 &gpio0 8 0>,   /* RX */
+			   <11 0 &gpio1 14 0>,  /* MISO */
+			   <12 0 &gpio1 13 0>,  /* MOSI */
+			   <13 0 &gpio1 15 0>,  /* SCK */
+			   <14 0 &gpio0 31 0>,  /* SS */
+			   <15 0 &gpio0 30 0>,  /* ADC4 = AIN6 */
+			   <16 0 &gpio0 29 0>,  /* ADC3 = AIN5 */
+			   <17 0 &gpio0 28 0>,  /* ADC2 = AIN4 */
+			   <18 0 &gpio0 4 0>,   /* ADC1 = AIN2 */
+			   <19 0 &gpio0 3 0>,   /* ADC0 = AIN1 */
+			   <20 0 &gpio0 11 0>,  /* MODEn */
+			   <21 0 &gpio0 18 0>;  /* RESETn */
+	};
+
+	feather_header: feather_connector {
+		compatible = "adafruit-feather-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <12 0 &gpio0 26 0>,  /* SDA */
+			   <13 0 &gpio0 27 0>,  /* SCL */
+			   <14 0 &gpio1 1 0>,   /* PWM3 */
+			   <15 0 &gpio1 2 0>,   /* PWM3 */
+			   <16 0 &gpio1 8 0>,   /* PWM1 */
+			   <17 0 &gpio1 10 0>,  /* PWM1 */
+			   <18 0 &gpio1 11 0>,  /* PWM1 */
+			   <19 0 &gpio1 12 0>,  /* PWM0 */
+			   <20 0 &gpio1 3 0>,   /* PWM1 */
+			   /* 11 not connected */
+			   <10 0 &gpio0 6 0>,   /* TX */
+			   <9 0 &gpio0 8 0>,    /* RX */
+			   <8 0 &gpio1 14 0>,   /* MISO */
+			   <7 0 &gpio1 13 0>,   /* MOSI */
+			   <6 0 &gpio1 15 0>,   /* SCK */
+			   <5 0 &gpio0 31 0>,   /* SS */
+			   <4 0 &gpio0 30 0>,   /* ADC4 = AIN6 */
+			   <3 0 &gpio0 29 0>,   /* ADC3 = AIN5 */
+			   <2 0 &gpio0 28 0>,   /* ADC2 = AIN4 */
+			   <1 0 &gpio0 4 0>,    /* ADC1 = AIN2 */
+			   <0 0 &gpio0 3 0>;    /* ADC0 = AIN1 */
+	};
 };
 
-&adc { /* feather ADC */
+feather_adc: &adc { /* feather ADC */
 	status = "okay";
 };
 
@@ -126,6 +183,8 @@ arduino_i2c: &i2c0 { /* feather I2C */
 	scl-pin = <27>;
 };
 
+feather_i2c: &i2c0 { };
+
 /* TWI1 used on Boron; also see mesh_feather_spi1_spi1.dtsi */
 
 &spi2 { /* dedicated MX25L */
@@ -153,7 +212,7 @@ arduino_i2c: &i2c0 { /* feather I2C */
 
 /* see mesh_feather_spi1_spi3.dtsi */
 
-&uart0 { /* feather UART1 */
+feather_serial: &uart0 { /* feather UART1 */
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "okay";

--- a/boards/arm/particle_xenon/dts/mesh_feather_spi_spi1.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather_spi_spi1.dtsi
@@ -9,7 +9,7 @@
  * NOTE: This file is replicated in particle_{argon,xenon}.
  * Changes should be made in all instances. */
 
-&spi1 { /* feather SPI */
+feather_spi: &spi1 { /* feather SPI */
 	status = "okay";
 	sck-pin = <47>;
 	mosi-pin = <45>;

--- a/boards/arm/particle_xenon/dts/mesh_feather_spi_spi3.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather_spi_spi3.dtsi
@@ -9,7 +9,7 @@
  * NOTE: This file is replicated in particle_{argon,boron,xenon}.
  * Changes should be made in all instances. */
 
-&spi3 { /* feather SPI */
+feather_spi: &spi3 { /* feather SPI */
 	status = "okay";
 	sck-pin = <47>;
 	mosi-pin = <45>;

--- a/boards/arm/particle_xenon/particle_xenon.yaml
+++ b/boards/arm/particle_xenon/particle_xenon.yaml
@@ -20,3 +20,6 @@ supported:
   - usb_device
   - ble
   - ieee802154
+  - feather_serial
+  - feather_i2c
+  - feather_spi

--- a/dts/bindings/gpio/particle-gen3-header.yaml
+++ b/dts/bindings/gpio/particle-gen3-header.yaml
@@ -1,0 +1,43 @@
+# Copyright (C) 2020 Peter Bigot Consulting, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    GPIO pins exposed on Particle Gen3 (Feather) headers.
+
+    The Particle Gen3 boards are compatible with the Adafruit Feather
+    "shields" but use a different orientation and pin numbering scheme.
+
+    With the board oriented with the micro USB at the top:
+    * A 12-pin header on the right.  9 pins on this header are exposed
+      by this binding
+    * A 16-pin header.  13 pins on this header are exposed by this
+      binding.
+
+    This binding provides a nexus mapping for 22 pins where parent pins
+    0 through 8 correspond to the pins on the 12-pin header, starting
+    from the bottom; and pins 9 through 21 correspond to pins on the
+    16-pin header, skipping the bottom pin then assigning 9 through 19,
+    skipping over GND, and replacing the lower 3V3 with pin 20.  The
+    physical layout is depicted below.
+
+        21 RESETn
+        -  3V3
+        20 MODEn
+        -  GND
+        19 ADC0                  LiPo+   -
+        18 ADC1                  ENABLE  -
+        17 ADC2                  VBUS    -
+        16 ADC3                  PWM1    8
+        15 ADC4                  PWM0    7
+        14 SS                    PWM1    6
+        13 SCK                   PWM1    5
+        12 MOSI                  PWM1    4
+        11 MISO                  PWM3    3
+        10 RX                    PWM3    2
+         9 TX                    SCL     1
+        -  n/c                   SDA     0
+
+
+compatible: "particle-gen3-header"
+
+include: [gpio-nexus.yaml, base.yaml]

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -310,6 +310,7 @@ ovti	OmniVision Technologies
 oxsemi	Oxford Semiconductor, Ltd.
 panasonic	Panasonic Corporation
 parade	Parade Technologies Inc.
+particle	Particle.io
 pda	Precision Design Associates, Inc.
 pericom	Pericom Technology Inc.
 pervasive	Pervasive Displays, Inc.


### PR DESCRIPTION
The Gen3 (formerly "mesh") Particle product line has a header that is structurally related to the Adafruit Feather, and is generally compatible with Featherwing shields.  Provide nexus maps for both the native header layout, and for the subset feather header layout, and add alias labels for the peripherals that would be referenced from shield overlays.
