### PR TITLE
drivers: spi: Set dummy data in mcux drivers

### DIFF
--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -185,6 +185,8 @@ static int spi_mcux_configure(struct device *dev,
 	DSPI_MasterTransferCreateHandle(base, &data->handle,
 					spi_mcux_master_transfer_callback, dev);
 
+	DSPI_SetDummyData(base, 0);
+
 	data->ctx.config = spi_cfg;
 	spi_context_cs_configure(&data->ctx);
 

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -180,6 +180,8 @@ static int spi_mcux_configure(struct device *dev,
 	SPI_MasterTransferCreateHandle(base, &data->handle,
 				       spi_mcux_master_transfer_callback, dev);
 
+	SPI_SetDummyData(base, 0);
+
 	data->ctx.config = spi_cfg;
 	spi_context_cs_configure(&data->ctx);
 

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -186,6 +186,8 @@ static int spi_mcux_configure(struct device *dev,
 	LPSPI_MasterTransferCreateHandle(base, &data->handle,
 					spi_mcux_master_transfer_callback, dev);
 
+	LPSPI_SetDummyData(base, 0);
+
 	data->ctx.config = spi_cfg;
 	spi_context_cs_configure(&data->ctx);
 


### PR DESCRIPTION
Sets the "dummy data" value to send when the transmit buffer is null.
Fixes the spi_null_tx_buf test in tests/drivers/spi/spi_loopback on the
lpcxpresso54114 board.

Tested on frdm_k64f, mimxrt1050_evk, and lpcxpresso54114_m4 boards.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #24376

cc: @Tobi0610 