### PR TITLE
devicetree: add CONFIG_LEGACY_DEVICETREE_MACROS

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -348,6 +348,14 @@ config MAKEFILE_EXPORTS
 	  Generates a file with build information that can be read by
 	  third party Makefile-based build systems.
 
+config LEGACY_DEVICETREE_MACROS
+	bool "Allow use of legacy devicetree macros"
+	default y
+	help
+	  Allows use of legacy devicetree macros which were used in
+	  Zephyr 2.2 and previous versions, rather than the devicetree.h
+	  API introduced during the Zephyr 2.3 development cycle.
+
 endmenu
 endmenu
 

--- a/doc/releases/release-notes-2.3.rst
+++ b/doc/releases/release-notes-2.3.rst
@@ -44,8 +44,8 @@ Deprecated in this release
 
     * All timeout values are now encapsulated k_timeout_t opaque structure when
       passing them to the kernel. If you want to revert to the previous s32_t
-      type for the timeout parameter pleae enable the
-      CONFIG_LEGACY_TIMEOUT_API Kconfig option
+      type for the timeout parameter, please enable
+      :option:`CONFIG_LEGACY_TIMEOUT_API`
 
 * Bluetooth
 

--- a/doc/releases/release-notes-2.3.rst
+++ b/doc/releases/release-notes-2.3.rst
@@ -73,6 +73,12 @@ Deprecated in this release
   * nrf52_pca20020 has been renamed to thingy52_nrf52832
   * nrf5340_dk_nrf5340 has been renamed to nrf5340pdk_nrf5340
 
+* Devicetree
+
+  * The C macros generated from devicetree. Use the new ``<devicetree.h>``
+    accessor API instead; see :ref:`dt-guide` for details. Use of the legacy
+    macros requires enabling :option:`CONFIG_LEGACY_DEVICETREE_MACROS`.
+
 Removed APIs in this release
 ============================
 

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -16,8 +16,20 @@
 #ifndef DEVICETREE_H
 #define DEVICETREE_H
 
+#ifdef _LINKER
+/*
+ * Linker scripts include this file too, and autoconf.h isn't
+ * automatically included for those files the way it is for C source
+ * files. Make sure we pull it in before using
+ * CONFIG_LEGACY_DEVICETREE_MACROS in that case.
+ */
+#include <autoconf.h>
+#endif
+
 #include <devicetree_unfixed.h>
+#ifdef CONFIG_LEGACY_DEVICETREE_MACROS
 #include <devicetree_legacy_unfixed.h>
+#endif
 #include <devicetree_fixups.h>
 
 #include <sys/util.h>


### PR DESCRIPTION
This default-y option allows continued use of the legacy devicetree macros.

I'm proposing we set it to default n in time for the Zephyr 2.3 release, after converting in-tree users to the new API.

Unfortunately, `__DEPRECATED_MACRO` does not suffice as a transition path for users. This is because, at least in GCC, macros defined using `__DEPRECATED_MACRO` cannot be used in preprocessor lines like `#if DT_SOME_LEGACY_MACRO`.
