### PR TITLE
subsys: littlefs: add support for sync()

### DIFF
--- a/drivers/flash/flash_sam0.c
+++ b/drivers/flash/flash_sam0.c
@@ -338,6 +338,11 @@ done:
 	return err;
 }
 
+static int flash_sam0_sync(struct device *dev)
+{
+	return 0;
+}
+
 static int flash_sam0_write_protection(struct device *dev, bool enable)
 {
 	off_t offset;
@@ -411,6 +416,7 @@ static int flash_sam0_init(struct device *dev)
 
 static const struct flash_driver_api flash_sam0_api = {
 	.write_protection = flash_sam0_write_protection,
+	.sync = flash_sam0_sync,
 	.erase = flash_sam0_erase,
 	.write = flash_sam0_write,
 	.read = flash_sam0_read,

--- a/include/drivers/flash.h
+++ b/include/drivers/flash.h
@@ -41,6 +41,7 @@ typedef int (*flash_api_read)(struct device *dev, off_t offset, void *data,
 typedef int (*flash_api_write)(struct device *dev, off_t offset,
 			       const void *data, size_t len);
 typedef int (*flash_api_erase)(struct device *dev, off_t offset, size_t size);
+typedef int (*flash_api_sync)(struct device *dev);
 typedef int (*flash_api_write_protection)(struct device *dev, bool enable);
 
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
@@ -74,6 +75,7 @@ __subsystem struct flash_driver_api {
 	flash_api_read read;
 	flash_api_write write;
 	flash_api_erase erase;
+	flash_api_sync sync;
 	flash_api_write_protection write_protection;
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 	flash_api_pages_layout page_layout;
@@ -162,6 +164,16 @@ static inline int z_impl_flash_erase(struct device *dev, off_t offset,
 		(const struct flash_driver_api *)dev->driver_api;
 
 	return api->erase(dev, offset, size);
+}
+
+__syscall int flash_sync(struct device *dev);
+
+static inline int z_impl_flash_sync(struct device *dev)
+{
+	const struct flash_driver_api *api =
+		(const struct flash_driver_api *)dev->driver_api;
+
+	return api->sync(dev);
 }
 
 /**

--- a/include/storage/flash_map.h
+++ b/include/storage/flash_map.h
@@ -145,6 +145,8 @@ int flash_area_write(const struct flash_area *fa, off_t off, const void *src,
  */
 int flash_area_erase(const struct flash_area *fa, off_t off, size_t len);
 
+int flash_area_sync(const struct flash_area *fa);
+
 /**
  * @brief Get write block size of the flash area
  *

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -166,7 +166,11 @@ static int lfs_api_erase(const struct lfs_config *c, lfs_block_t block)
 
 static int lfs_api_sync(const struct lfs_config *c)
 {
-	return LFS_ERR_OK;
+	const struct flash_area *fa = c->context;
+
+	int rc = flash_area_sync(fa);
+
+	return errno_to_lfs(rc);
 }
 
 static void release_file_data(struct fs_file_t *fp)

--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -240,6 +240,26 @@ int flash_area_erase(const struct flash_area *fa, off_t off, size_t len)
 	return rc;
 }
 
+int flash_area_sync(const struct flash_area *fa)
+{
+	struct device *flash_dev;
+	int rc;
+
+	flash_dev = device_get_binding(fa->fa_dev_name);
+
+	rc = flash_write_protection_set(flash_dev, false);
+	if (rc) {
+		return rc;
+	}
+
+	rc = flash_sync(flash_dev);
+
+	/* Ignore errors here - this does not affect write operation */
+	(void) flash_write_protection_set(flash_dev, true);
+
+	return rc;
+}
+
 u8_t flash_area_align(const struct flash_area *fa)
 {
 	struct device *dev;


### PR DESCRIPTION
NAND memory devices have an on-chip buffer used to cache one or more pages of the flash cell array. The LittleFS API provides for a "sync" that is used to ensure the cache is flushed to the flash array.

At the moment, the flash API does not have an API for syncing and the LittleFS stub is a nop.

I propose that the flash API be updated to include a sync function.

This commit adds support to the underlying flash_map infrastructure for this purpose.

Fixes #24111