### PR TITLE
Bluetooth: shell: Fix advertise command parameters

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1025,7 +1025,8 @@ static int cmd_adv_data(const struct shell *shell, size_t argc, char *argv[])
 		}
 	}
 
-	err = bt_le_ext_adv_set_data(adv, ad, ad_len, sd, sd_len);
+	err = bt_le_ext_adv_set_data(adv, ad_len > 0 ? ad : NULL, ad_len,
+					  sd_len > 0 ? sd : NULL, sd_len);
 	if (err) {
 		shell_print(shell, "Failed to set advertising set data (%d)",
 			    err);

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -738,6 +738,7 @@ static int cmd_advertise(const struct shell *shell, size_t argc, char *argv[])
 		return 0;
 	}
 
+	param.peer = NULL;
 	param.id = selected_id;
 	param.interval_min = BT_GAP_ADV_FAST_INT_MIN_2;
 	param.interval_max = BT_GAP_ADV_FAST_INT_MAX_2;


### PR DESCRIPTION
Fix the advertise command not setting the peer address parameter to
NULL, this could turn it into a directed advertiser.

Give NULL pointer when ad_len or sd_len is zero, this stops the host
from setting a zero length advertise data or scan response.