### PR TITLE
armv8 aarch64 EL3 init updates

### DIFF
--- a/arch/arm/core/aarch64/macro.inc
+++ b/arch/arm/core/aarch64/macro.inc
@@ -8,6 +8,29 @@
 #define _MACRO_H_
 
 #ifdef _ASMLANGUAGE
+/*
+ * macro to support mov of immediate constant to 64 bit register
+ * It will generate instruction sequence of 'mov'/ 'movz' and one
+ * to three 'movk' depending on the immediate value.
+ */
+.macro mov_imm, xreg, imm
+	.if ((\imm) == 0)
+		mov	\xreg, \imm
+	.else
+		.if (((\imm) >> 31) == 0 || ((\imm) >> 31) == 0x1ffffffff)
+			movz    \xreg, (\imm >> 16) & 0xffff, lsl 16
+		.else
+			.if (((\imm) >> 47) == 0 || ((\imm) >> 47) == 0x1ffff)
+				movz    \xreg, (\imm >> 32) & 0xffff, lsl 32
+			.else
+				movz    \xreg, (\imm >> 48) & 0xffff, lsl 48
+				movk    \xreg, (\imm >> 32) & 0xffff, lsl 32
+			.endif
+			movk    \xreg, (\imm >> 16) & 0xffff, lsl 16
+		.endif
+		movk    \xreg, (\imm) & 0xffff, lsl 0
+	.endif
+.endm
 
 .macro	switch_el, xreg, el3_label, el2_label, el1_label
 	mrs	\xreg, CurrentEL

--- a/arch/arm/core/aarch64/reset.S
+++ b/arch/arm/core/aarch64/reset.S
@@ -19,6 +19,11 @@
 
 _ASM_FILE_PROLOGUE
 
+/* Platform may do platform specific EL3 init */
+WTEXT(z_arch_el3_plat_init)
+SECTION_FUNC(TEXT,z_arch_el3_plat_init)
+ret
+
 /**
  *
  * @brief Reset vector
@@ -44,18 +49,63 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__reset)
 GTEXT(__start)
 SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 
-#ifdef CONFIG_SWITCH_TO_EL1
+	/* Setup vector table */
+	adr	x9, _vector_table
+
 	switch_el x1, 3f, 2f, 1f
 3:
-	/* Disable MMU and async exceptions routing to EL1 */
-	msr	sctlr_el1, xzr
+	/* Initialize VBAR */
+	msr	vbar_el3, x9
+	isb
+
+	/* Initialize sctlr_el3 to reset value */
+	mov_imm	x1, SCTLR_EL3_RES1
+	mrs     x0, sctlr_el3
+	orr	x0, x0, x1
+	msr	sctlr_el3, x0
+	isb
+
+	/* SError, IRQ and FIQ routing enablement in EL3 */
+	mrs	x0, scr_el3
+	orr	x0, x0, #(SCR_EL3_IRQ | SCR_EL3_FIQ | SCR_EL3_EA)
+	msr	scr_el3, x0
+
+	/*
+	* Disable access traps to EL3 for CPACR, Trace, FP, ASIMD,
+	* SVE from lower EL.
+	*/
+	mov_imm	x0, CPTR_EL3_RES_VAL
+	mov_imm	x1, (CPTR_EL3_TTA | CPTR_EL3_TFP | CPTR_EL3_TCPAC)
+	bic	x0, x0, x1
+	orr	x0, x0, #(CPTR_EL3_EZ)
+	msr	cptr_el3, x0
+	isb
+
+	/* Platform specific configurations needed in EL3 */
+	bl	z_arch_el3_plat_init
+
+#ifdef CONFIG_SWITCH_TO_EL1
+	/*
+	* Zephyr entry happened in EL3. Do EL3 specific init before
+	* dropping to lower EL.
+	*/
+	/* Enable access control configuration from lower EL */
+	mrs	x0, actlr_el3
+	orr     x0, x0, #(ACTLR_EL3_L2ACTLR | ACTLR_EL3_L2ECTLR \
+			 | ACTLR_EL3_L2CTLR)
+	orr     x0, x0, #(ACTLR_EL3_CPUACTLR | ACTLR_EL3_CPUECTLR)
+	msr	actlr_el3, x0
+
+	/* Initialize sctlr_el1 to reset value */
+	mov_imm	x0, SCTLR_EL1_RES1
+	msr	sctlr_el1, x0
 
 	/* Disable EA/IRQ/FIQ routing to EL3 and set EL1 to AArch64 */
 	mov	x0, xzr
 	orr	x0, x0, #(SCR_EL3_RW)
 	msr	scr_el3, x0
 
-	/* On eret return to EL1 with DAIF masked */
+	/* On eret return to secure EL1h with DAIF masked */
 	mov	x0, xzr
 	orr	x0, x0, #(DAIF_MASK)
 	orr	x0, x0, #(SPSR_EL3_TO_EL1)
@@ -65,39 +115,21 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 	adr	x0, 1f
 	msr	elr_el3, x0
 	eret
-2:
-	/* Boot from EL2 not supported */
-	bl	.
-1:
 #endif
-	/* Setup vector table */
-	adr	x0, _vector_table
-
-	switch_el x1, 3f, 2f, 1f
-3:
-	/* Initialize VBAR */
-	msr	vbar_el3, x0
-
-	/* SError, IRQ and FIQ routing enablement in EL3 */
-	mrs	x0, scr_el3
-	orr	x0, x0, #(SCR_EL3_IRQ | SCR_EL3_FIQ | SCR_EL3_EA)
-	msr	scr_el3, x0
-
-	/* Disable access trapping in EL3 for NEON/FP */
-	msr	cptr_el3, xzr
-
 	/*
 	 * Enable the instruction cache, stack pointer and data access
-	 * alignment checks and disable speculative loads.
+	 * alignment checks.
 	 */
 	mov	x1, #(SCTLR_I_BIT | SCTLR_A_BIT | SCTLR_SA_BIT)
 	mrs	x0, sctlr_el3
 	orr	x0, x0, x1
 	msr	sctlr_el3, x0
+	isb
 	b	0f
+
 2:
 	/* Initialize VBAR */
-	msr	vbar_el2, x0
+	msr	vbar_el2, x9
 
 	/* SError, IRQ and FIQ routing enablement in EL2 */
 	mrs	x0, hcr_el2
@@ -109,29 +141,30 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 
 	/*
 	 * Enable the instruction cache, stack pointer and data access
-	 * alignment checks and disable speculative loads.
+	 * alignment checks.
 	 */
 	mov	x1, #(SCTLR_I_BIT | SCTLR_A_BIT | SCTLR_SA_BIT)
 	mrs	x0, sctlr_el2
 	orr	x0, x0, x1
 	msr	sctlr_el2, x0
 	b	0f
+
 1:
 	/* Initialize VBAR */
-	msr	vbar_el1, x0
+	msr	vbar_el1, x9
 
 	/* Disable access trapping in EL1 for NEON/FP */
-	mov	x1, #(CPACR_EL1_FPEN_NOTRAP)
-	msr	cpacr_el1, x1
+	mov	x0, #(CPACR_EL1_FPEN_NOTRAP)
+	msr	cpacr_el1, x0
 
 	/*
-	 * Enable the instruction cache, stack pointer and data access
-	 * alignment checks and disable speculative loads.
+	 * Enable the instruction cache and el1 stack alignment check.
 	 */
-	mov	x1, #(SCTLR_I_BIT | SCTLR_A_BIT | SCTLR_SA_BIT)
+	mov	x1, #(SCTLR_I_BIT | SCTLR_SA_BIT)
 	mrs	x0, sctlr_el1
 	orr	x0, x0, x1
 	msr	sctlr_el1, x0
+
 0:
 	isb
 

--- a/arch/arm/core/aarch64/reset.S
+++ b/arch/arm/core/aarch64/reset.S
@@ -19,7 +19,11 @@
 
 _ASM_FILE_PROLOGUE
 
-/* Platform may do platform specific EL3 init */
+/*
+ * Platform may do platform specific init at EL3.
+ * The function implementation must preserve callee saved registers as per
+ * Aarch64 ABI PCS.
+ */
 WTEXT(z_arch_el3_plat_init)
 SECTION_FUNC(TEXT,z_arch_el3_plat_init)
 ret
@@ -50,12 +54,12 @@ GTEXT(__start)
 SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 
 	/* Setup vector table */
-	adr	x9, _vector_table
+	adr	x19, _vector_table
 
 	switch_el x1, 3f, 2f, 1f
 3:
 	/* Initialize VBAR */
-	msr	vbar_el3, x9
+	msr	vbar_el3, x19
 	isb
 
 	/* Initialize sctlr_el3 to reset value */
@@ -129,7 +133,7 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 
 2:
 	/* Initialize VBAR */
-	msr	vbar_el2, x9
+	msr	vbar_el2, x19
 
 	/* SError, IRQ and FIQ routing enablement in EL2 */
 	mrs	x0, hcr_el2
@@ -151,7 +155,7 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 
 1:
 	/* Initialize VBAR */
-	msr	vbar_el1, x9
+	msr	vbar_el1, x19
 
 	/* Disable access trapping in EL1 for NEON/FP */
 	mov	x0, #(CPACR_EL1_FPEN_NOTRAP)

--- a/include/arch/arm/aarch64/cpu.h
+++ b/include/arch/arm/aarch64/cpu.h
@@ -22,6 +22,12 @@
 
 #define SPSR_MODE_EL1H		(0x5)
 
+#define SCTLR_EL3_RES1		(BIT(29) | BIT(28) | BIT(23) | \
+				BIT(22) | BIT(18) | BIT(16) | \
+				BIT(11) | BIT(5) | BIT(4))
+
+#define SCTLR_EL1_RES1		(BIT(29) | BIT(28) | BIT(23) | \
+				BIT(22) | BIT(20) | BIT(11))
 #define SCTLR_M_BIT		BIT(0)
 #define SCTLR_A_BIT		BIT(1)
 #define SCTLR_C_BIT		BIT(2)
@@ -35,6 +41,23 @@
 #define SCR_EL3_FIQ		BIT(2)
 #define SCR_EL3_EA		BIT(3)
 #define SCR_EL3_RW		BIT(10)
+
+/*
+ * TODO: ACTLR is of class implementation defined. All core implementations
+ * in armv8a have the same implementation so far w.r.t few controls.
+ * When there will be differences we have to create core specific headers.
+ */
+#define ACTLR_EL3_CPUACTLR	BIT(0)
+#define ACTLR_EL3_CPUECTLR	BIT(1)
+#define ACTLR_EL3_L2CTLR	BIT(4)
+#define ACTLR_EL3_L2ECTLR	BIT(5)
+#define ACTLR_EL3_L2ACTLR	BIT(6)
+
+#define CPTR_EL3_RES_VAL	(0x0)
+#define CPTR_EL3_EZ		BIT(8)
+#define CPTR_EL3_TFP		BIT(9)
+#define CPTR_EL3_TTA		BIT(20)
+#define CPTR_EL3_TCPAC		BIT(31)
 
 #define HCR_EL2_FMO		BIT(3)
 #define HCR_EL2_IMO		BIT(4)


### PR DESCRIPTION
1- Aarch64 EL3 init.  Initialize few recommended and few necessary settings of control registers before switching to EL1 ( arm v8.0).
2- macro to do mov immediate of 64b values to register.
3- there are misc cleanups in comments and uniform usage of register.
4- GICv3 system interface enabling can only be done at EL3. Specially for the purpose and may be
     future need introduced weak function for platform specific init at EL3.

The patch set is tested on Qemu (boots at EL1) and Broadcom SOC with Cortex A72 ( boots at El3 and drops to EL1) both are arm-v8.0.

Beyond 8.0 more arch specific and core specific changes will be required in future.
