### PR TITLE
Introduce DT_DEVICE_DEFINE macros for drivers

### DIFF
--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -482,8 +482,7 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_0 = {
 			.device = DT_INST_REG_ADDR(0),},
 };
 
-DEVICE_AND_API_INIT(uart_cmsdk_apb_0,
-		    DT_INST_LABEL(0),
+DT_INST_DEVICE_DEFINE(0,
 		    &uart_cmsdk_apb_init,
 		    &uart_cmsdk_apb_dev_data_0,
 		    &uart_cmsdk_apb_dev_cfg_0, PRE_KERNEL_1,
@@ -497,7 +496,7 @@ static void uart_cmsdk_apb_irq_config_func_0(struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_0),
+		    DEVICE_GET(DT_DRV_INST(0)),
 		    0);
 	irq_enable(DT_INST_IRQN(0));
 }
@@ -507,14 +506,14 @@ static void uart_cmsdk_apb_irq_config_func_0(struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, tx, irq),
 		    DT_INST_IRQ_BY_NAME(0, tx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_0),
+		    DEVICE_GET(DT_DRV_INST(0)),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(0, tx, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, rx, irq),
 		    DT_INST_IRQ_BY_NAME(0, rx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_0),
+		    DEVICE_GET(DT_DRV_INST(0)),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(0, rx, irq));
 }
@@ -547,8 +546,7 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_1 = {
 			.device = DT_INST_REG_ADDR(1),},
 };
 
-DEVICE_AND_API_INIT(uart_cmsdk_apb_1,
-		    DT_INST_LABEL(1),
+DT_INST_DEVICE_DEFINE(1,
 		    &uart_cmsdk_apb_init,
 		    &uart_cmsdk_apb_dev_data_1,
 		    &uart_cmsdk_apb_dev_cfg_1, PRE_KERNEL_1,
@@ -562,7 +560,7 @@ static void uart_cmsdk_apb_irq_config_func_1(struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQN(1),
 		    DT_INST_IRQ(1, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_1),
+		    DEVICE_GET(DT_DRV_INST(1)),
 		    0);
 	irq_enable(DT_INST_IRQN(1));
 }
@@ -572,14 +570,14 @@ static void uart_cmsdk_apb_irq_config_func_1(struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(1, tx, irq),
 		    DT_INST_IRQ_BY_NAME(1, tx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_1),
+		    DEVICE_GET(DT_DRV_INST(1)),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(1, tx, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(1, rx, irq),
 		    DT_INST_IRQ_BY_NAME(1, rx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_1),
+		    DEVICE_GET(DT_DRV_INST(1)),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(1, rx, irq));
 }
@@ -612,8 +610,7 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_2 = {
 			.device = DT_INST_REG_ADDR(2),},
 };
 
-DEVICE_AND_API_INIT(uart_cmsdk_apb_2,
-		    DT_INST_LABEL(2),
+DT_INST_DEVICE_DEFINE(2,
 		    &uart_cmsdk_apb_init,
 		    &uart_cmsdk_apb_dev_data_2,
 		    &uart_cmsdk_apb_dev_cfg_2, PRE_KERNEL_1,
@@ -627,7 +624,7 @@ static void uart_cmsdk_apb_irq_config_func_2(struct device *dev)
 	IRQ_CONNECT(CMSDK_APB_UART_2_IRQ,
 		    DT_INST_IRQ_BY_NAME(2, priority, irq),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_2),
+		    DEVICE_GET(DT_DRV_INST(2)),
 		    0);
 	irq_enable(CMSDK_APB_UART_2_IRQ);
 }
@@ -637,14 +634,14 @@ static void uart_cmsdk_apb_irq_config_func_2(struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(2, tx, irq),
 		    DT_INST_IRQ_BY_NAME(2, tx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_2),
+		    DEVICE_GET(DT_DRV_INST(2)),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(2, tx, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(2, rx, irq),
 		    DT_INST_IRQ_BY_NAME(2, rx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_2),
+		    DEVICE_GET(DT_DRV_INST(2)),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(2, rx, irq));
 }
@@ -677,8 +674,7 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_3 = {
 			.device = DT_INST_REG_ADDR(3),},
 };
 
-DEVICE_AND_API_INIT(uart_cmsdk_apb_3,
-		    DT_INST_LABEL(3),
+DT_INST_DEVICE_DEFINE(3,
 		    &uart_cmsdk_apb_init,
 		    &uart_cmsdk_apb_dev_data_3,
 		    &uart_cmsdk_apb_dev_cfg_3, PRE_KERNEL_1,
@@ -692,7 +688,7 @@ static void uart_cmsdk_apb_irq_config_func_3(struct device *dev)
 	IRQ_CONNECT(CMSDK_APB_UART_3_IRQ,
 		    DT_INST_IRQ_BY_NAME(3, priority, irq),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_3),
+		    DEVICE_GET(DT_DRV_INST(3)),
 		    0);
 	irq_enable(CMSDK_APB_UART_3_IRQ);
 }
@@ -702,14 +698,14 @@ static void uart_cmsdk_apb_irq_config_func_3(struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(3, tx, irq),
 		    DT_INST_IRQ_BY_NAME(3, tx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_3),
+		    DEVICE_GET(DT_DRV_INST(3)),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(3, tx, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(3, rx, irq),
 		    DT_INST_IRQ_BY_NAME(3, rx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_3),
+		    DEVICE_GET(DT_DRV_INST(3)),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(3, rx, irq));
 }
@@ -742,8 +738,7 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_4 = {
 			.device = DT_INST_REG_ADDR(4),},
 };
 
-DEVICE_AND_API_INIT(uart_cmsdk_apb_4,
-		    DT_INST_LABEL(4),
+DT_INST_DEVICE_DEFINE(4,
 		    &uart_cmsdk_apb_init,
 		    &uart_cmsdk_apb_dev_data_4,
 		    &uart_cmsdk_apb_dev_cfg_4, PRE_KERNEL_1,
@@ -757,7 +752,7 @@ static void uart_cmsdk_apb_irq_config_func_4(struct device *dev)
 	IRQ_CONNECT(CMSDK_APB_UART_4_IRQ,
 		    DT_INST_IRQ_BY_NAME(4, priority, irq),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_4),
+		    DEVICE_GET(DT_DRV_INST(4)),
 		    0);
 	irq_enable(CMSDK_APB_UART_4_IRQ);
 }
@@ -767,14 +762,14 @@ static void uart_cmsdk_apb_irq_config_func_4(struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(4, tx, irq),
 		    DT_INST_IRQ_BY_NAME(4, tx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_4),
+		    DEVICE_GET(DT_DRV_INST(4)),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(4, tx, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(4, rx, irq),
 		    DT_INST_IRQ_BY_NAME(4, rx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_4),
+		    DEVICE_GET(DT_DRV_INST(4)),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(4, rx, irq));
 }

--- a/include/device.h
+++ b/include/device.h
@@ -129,6 +129,60 @@ extern "C" {
 #endif
 
 /**
+ * @def DT_DEVICE_DEFINE
+ *
+ * @brief Create device object and set it up for boot time initialization,
+ * with the option to set driver_api based on devicetree node_id.
+ *
+ * This macro is a devicetree aware wrapper around DEVICE_AND_API_INIT
+ * in which the dev_name is based on the devicetree node_id and the
+ * drv_name comes from the label property of that node_id.
+ *
+ * @param node_id a devicetree node identifier
+ * @param init_fn Address to the init function of the driver.
+ * @param data Pointer to the device's configuration data.
+ * @param cfg_info The address to the structure containing the
+ * configuration information for this instance of the driver.
+ * @param level The initialization level at which configuration occurs.
+ * @param prio The initialization priority of the device, relative to
+ * @param api Provides an initial pointer to the API function struct
+ *
+ * @details The driver api is also set here, eliminating the need to do that
+ * during initialization.
+ */
+#define DT_DEVICE_DEFINE(node_id, init_fn, data, cfg_info, level, \
+			       prio, api)			  \
+	DEVICE_AND_API_INIT(node_id, DT_LABEL(node_id), init_fn,  \
+			    data, cfg_info, level, prio, api)
+
+/**
+ * @def DT_INST_DEVICE_DEFINE
+ *
+ * @brief Create device object and set it up for boot time initialization,
+ * with the option to set driver_api based on devicetree a DT_DRV_COMPAT
+ * instance.
+ *
+ * This macro is a devicetree aware wrapper around DEVICE_AND_API_INIT
+ * in which the dev_name is based on the devicetree node_id and the
+ * drv_name comes from the label property of that node_id.
+ *
+ * @param inst devicetree instance number
+ * @param init_fn Address to the init function of the driver.
+ * @param data Pointer to the device's configuration data.
+ * @param cfg_info The address to the structure containing the
+ * configuration information for this instance of the driver.
+ * @param level The initialization level at which configuration occurs.
+ * @param prio The initialization priority of the device, relative to
+ * @param api Provides an initial pointer to the API function struct
+ *
+ * @details The driver api is also set here, eliminating the need to do that
+ * during initialization.
+ */
+#define DT_INST_DEVICE_DEFINE(inst, init_fn, data, cfg_info, level, prio, api)\
+	DT_DEVICE_DEFINE(DT_DRV_INST(inst), init_fn, data, cfg_info,	      \
+			 level, prio, api)
+
+/**
  * @def DEVICE_DEFINE
  *
  * @brief Create device object and set it up for boot time initialization,


### PR DESCRIPTION
Create a wrapper macro DT_DEVICE_DEFINE (and DT_INST_DEVICE_DEFINE) that drivers can use to hide a few details [like how to `dev_name` and `drv_name` are set].

TODO:

- [ ] Update comment block for DT_DEVICE_DEFINE and DT_INST_DEVICE_DEFINE
- [ ] decide if we should have a DT_DEVICE_GET to hide `dev_name`