### PR TITLE
drivers: sensor: Fix missing DT_DRV_COMPAT

### DIFF
--- a/drivers/sensor/adxl362/adxl362_trigger.c
+++ b/drivers/sensor/adxl362/adxl362_trigger.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT adi_adxl362
+
 #include <device.h>
 #include <drivers/gpio.h>
 #include <sys/util.h>

--- a/drivers/sensor/adxl372/adxl372_trigger.c
+++ b/drivers/sensor/adxl372/adxl372_trigger.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT adi_adxl372
+
 #include <device.h>
 #include <drivers/gpio.h>
 #include <sys/util.h>

--- a/drivers/sensor/iis2dlpc/iis2dlpc_trigger.c
+++ b/drivers/sensor/iis2dlpc/iis2dlpc_trigger.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/iis2dlpc.pdf
  */
 
+#define DT_DRV_COMPAT st_iis2dlpc
+
 #include <kernel.h>
 #include <drivers/sensor.h>
 #include <drivers/gpio.h>

--- a/drivers/sensor/iis2mdc/iis2mdc_trigger.c
+++ b/drivers/sensor/iis2mdc/iis2mdc_trigger.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/iis2mdc.pdf
  */
 
+#define DT_DRV_COMPAT st_iis2mdc
+
 #include <kernel.h>
 #include <drivers/sensor.h>
 #include <drivers/gpio.h>

--- a/drivers/sensor/iis3dhhc/iis3dhhc_trigger.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc_trigger.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/iis3dhhc.pdf
  */
 
+#define DT_DRV_COMPAT st_iis3dhhc
+
 #include <kernel.h>
 #include <drivers/sensor.h>
 #include <drivers/gpio.h>

--- a/drivers/sensor/ism330dhcx/ism330dhcx_shub.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx_shub.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/ism330dhcx.pdf
  */
 
+#define DT_DRV_COMPAT st_ism330dhcx
+
 #include <device.h>
 #include <drivers/i2c.h>
 #include <sys/byteorder.h>

--- a/drivers/sensor/ism330dhcx/ism330dhcx_trigger.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx_trigger.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/ism330dhcx.pdf
  */
 
+#define DT_DRV_COMPAT st_ism330dhcx
+
 #include <kernel.h>
 #include <drivers/sensor.h>
 #include <drivers/gpio.h>

--- a/drivers/sensor/lis2dw12/lis2dw12_trigger.c
+++ b/drivers/sensor/lis2dw12/lis2dw12_trigger.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/lis2dw12.pdf
  */
 
+#define DT_DRV_COMPAT st_lis2dw12
+
 #include <kernel.h>
 #include <drivers/sensor.h>
 #include <drivers/gpio.h>

--- a/drivers/sensor/lis2mdl/lis2mdl_trigger.c
+++ b/drivers/sensor/lis2mdl/lis2mdl_trigger.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/lis2mdl.pdf
  */
 
+#define DT_DRV_COMPAT st_lis2mdl
+
 #include <kernel.h>
 #include <drivers/sensor.h>
 #include <drivers/gpio.h>

--- a/drivers/sensor/lps22hh/lps22hh_trigger.c
+++ b/drivers/sensor/lps22hh/lps22hh_trigger.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/lps22hh.pdf
  */
 
+#define DT_DRV_COMPAT st_lps22hh
+
 #include <kernel.h>
 #include <drivers/sensor.h>
 #include <drivers/gpio.h>

--- a/drivers/sensor/lsm6dso/lsm6dso_shub.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_shub.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/lsm6dso.pdf
  */
 
+#define DT_DRV_COMPAT st_lsm6dso
+
 #include <device.h>
 #include <drivers/i2c.h>
 #include <sys/byteorder.h>

--- a/drivers/sensor/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_trigger.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/lsm6dso.pdf
  */
 
+#define DT_DRV_COMPAT st_lsm6dso
+
 #include <kernel.h>
 #include <drivers/sensor.h>
 #include <drivers/gpio.h>

--- a/drivers/sensor/stts751/stts751_trigger.c
+++ b/drivers/sensor/stts751/stts751_trigger.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/stts751.pdf
  */
 
+#define DT_DRV_COMPAT st_stts751
+
 #include <kernel.h>
 #include <drivers/sensor.h>
 #include <drivers/gpio.h>


### PR DESCRIPTION
    drivers: sensor: Fix missing DT_DRV_COMPAT
    
    Some sensor drivers modify there struct's based on DT defines.  In those
    cases we need to make sure that DT_DRV_COMPAT is set on all the source
    files associated with that driver.  This updates any such files.
