### PR TITLE
tests/drivers/gpio: fix nrf52840dk_nrf52840 overlay

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nrf52840dk_nrf52840.overlay
@@ -11,3 +11,7 @@
 		in-gpios = <&gpio1 2 0>;  /* Arduino D1 */
 	};
 };
+
+&uart1 {
+	status = "disabled";
+};


### PR DESCRIPTION
Changes to Kconfig vs devicetree in 97b07b943ad79d697c20a4bdccee50c139b77ed2 resulted in uart1 being enabled, which steals the test pins away from the test.
