### PR TITLE
Move nRF I2C drivers to new DT API

### DIFF
--- a/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.yaml
+++ b/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.yaml
@@ -11,6 +11,7 @@ supported:
   - adc
   - ble
   - counter
+  - i2c
   - nvs
   - pwm
   - spi

--- a/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.yaml
+++ b/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.yaml
@@ -10,11 +10,11 @@ ram: 32
 supported:
   - adc
   - ble
+  - counter
   - nvs
   - pwm
   - spi
   - watchdog
-  - counter
 testing:
   ignore_tags:
     - net

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.yaml
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.yaml
@@ -13,11 +13,11 @@ supported:
   - arduino_gpio
   - arduino_i2c
   - arduino_spi
-  - usb_device
-  - usb_cdc
   - ble
+  - counter
   - ieee802154
   - pwm
   - spi
+  - usb_cdc
+  - usb_device
   - watchdog
-  - counter

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.yaml
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.yaml
@@ -15,6 +15,7 @@ supported:
   - arduino_spi
   - ble
   - counter
+  - i2c
   - ieee802154
   - pwm
   - spi

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -242,17 +242,17 @@ static int twi_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 	: bitrate == 250000               ? NRF_TWI_FREQ_250K		       \
 	: bitrate == I2C_BITRATE_FAST     ? NRF_TWI_FREQ_400K		       \
 					  : I2C_NRFX_TWI_INVALID_FREQUENCY)
+#define I2C(idx) DT_NODELABEL(i2c##idx)
+#define I2C_FREQUENCY(idx)						       \
+	I2C_NRFX_TWI_FREQUENCY(DT_PROP(I2C(idx), clock_frequency))
 
 #define I2C_NRFX_TWI_DEVICE(idx)					       \
-	BUILD_ASSERT(							       \
-		I2C_NRFX_TWI_FREQUENCY(					       \
-			DT_NORDIC_NRF_TWI_I2C_##idx##_CLOCK_FREQUENCY)	       \
-		!= I2C_NRFX_TWI_INVALID_FREQUENCY,			       \
-		"Wrong I2C " #idx " frequency setting in dts");		       \
+	BUILD_ASSERT(I2C_FREQUENCY(idx)	!=				       \
+		     I2C_NRFX_TWI_INVALID_FREQUENCY,			       \
+		     "Wrong I2C " #idx " frequency setting in dts");	       \
 	static int twi_##idx##_init(struct device *dev)			       \
 	{								       \
-		IRQ_CONNECT(DT_NORDIC_NRF_TWI_I2C_##idx##_IRQ_0,	       \
-			    DT_NORDIC_NRF_TWI_I2C_##idx##_IRQ_0_PRIORITY,      \
+		IRQ_CONNECT(DT_IRQN(I2C(idx)), DT_IRQ(I2C(idx), priority),     \
 			    nrfx_isr, nrfx_twi_##idx##_irq_handler, 0);	       \
 		return init_twi(dev);					       \
 	}								       \
@@ -265,14 +265,13 @@ static int twi_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 	static const struct i2c_nrfx_twi_config twi_##idx##z_config = {	       \
 		.twi = NRFX_TWI_INSTANCE(idx),				       \
 		.config = {						       \
-			.scl       = DT_NORDIC_NRF_TWI_I2C_##idx##_SCL_PIN,    \
-			.sda       = DT_NORDIC_NRF_TWI_I2C_##idx##_SDA_PIN,    \
-			.frequency = I2C_NRFX_TWI_FREQUENCY(		       \
-				DT_NORDIC_NRF_TWI_I2C_##idx##_CLOCK_FREQUENCY) \
+			.scl       = DT_PROP(I2C(idx), scl_pin),	       \
+			.sda       = DT_PROP(I2C(idx), sda_pin),	       \
+			.frequency = I2C_FREQUENCY(idx),		       \
 		}							       \
 	};								       \
 	DEVICE_DEFINE(twi_##idx,					       \
-		      DT_NORDIC_NRF_TWI_I2C_##idx##_LABEL,		       \
+		      DT_LABEL(I2C(idx)),				       \
 		      twi_##idx##_init,					       \
 		      twi_nrfx_pm_control,				       \
 		      &twi_##idx##_data,				       \

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -244,7 +244,7 @@ static int twi_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 					  : I2C_NRFX_TWI_INVALID_FREQUENCY)
 
 #define I2C_NRFX_TWI_DEVICE(idx)					       \
-	BUILD_ASSERT(						       \
+	BUILD_ASSERT(							       \
 		I2C_NRFX_TWI_FREQUENCY(					       \
 			DT_NORDIC_NRF_TWI_I2C_##idx##_CLOCK_FREQUENCY)	       \
 		!= I2C_NRFX_TWI_INVALID_FREQUENCY,			       \
@@ -260,7 +260,7 @@ static int twi_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 		.transfer_sync = Z_SEM_INITIALIZER(                            \
 			twi_##idx##_data.transfer_sync, 1, 1),                 \
 		.completion_sync = Z_SEM_INITIALIZER(                          \
-			twi_##idx##_data.completion_sync, 0, 1)	               \
+			twi_##idx##_data.completion_sync, 0, 1)		       \
 	};								       \
 	static const struct i2c_nrfx_twi_config twi_##idx##z_config = {	       \
 		.twi = NRFX_TWI_INSTANCE(idx),				       \

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -218,7 +218,7 @@ static int twim_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 					  : I2C_NRFX_TWIM_INVALID_FREQUENCY)
 
 #define I2C_NRFX_TWIM_DEVICE(idx)					       \
-	BUILD_ASSERT(						       \
+	BUILD_ASSERT(							       \
 		I2C_NRFX_TWIM_FREQUENCY(				       \
 			DT_NORDIC_NRF_TWIM_I2C_##idx##_CLOCK_FREQUENCY)	       \
 		!= I2C_NRFX_TWIM_INVALID_FREQUENCY,			       \


### PR DESCRIPTION
Keep existing per-instance KConfigs in place.