### PR TITLE
cmake: Updating test samples to use find_package(Zephyr)

### DIFF
--- a/tests/lib/heap/CMakeLists.txt
+++ b/tests/lib/heap/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 project(heap)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/notify/CMakeLists.txt
+++ b/tests/lib/notify/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 project(sys_notify)
 
 FILE(GLOB app_sources src/*.c)


### PR DESCRIPTION
The following PR's #23941 #23601 was merged using old boilerplate
inclusion.
This commit updates those tests to use find_package(Zephyr)

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>