### PR TITLE
net: http_client: Fix payload issue on HTTP upload

### DIFF
--- a/include/net/http_client.h
+++ b/include/net/http_client.h
@@ -238,7 +238,9 @@ struct http_request {
 	/** Payload, may be NULL */
 	const char *payload;
 
-	/** Payload length, may be 0. Only used if payload field is not NULL */
+	/** Payload length is used to calculate Content-Length. Set to 0
+	 * for chunked transfers.
+	 */
 	size_t payload_len;
 
 	/** User supplied callback function to call when optional headers need


### PR DESCRIPTION
Bug fix and improved `payload` handling in `http_client_req`.

Changes to `http_client_req` behaviour:

If the user provides `payload_len` it is used to generate the `Content-Length`
header. This is done even if `payload_cb` is used to provide the actual data.
If no `payload_len` is specified then no `Content-Length` is generated.

If `payload_cb` is provided it is called to send the payload data.
Otherwise `payload` is used as the payload buffer and sent. If
`payload_len` is not zero, it is used as the size of `payload`. Otherwise
`payload` is assumed to be a string and `strlen` is used to determine its size.
This is to maintain current behaviour and not break existing samples.

Fixes #24431