### PR TITLE
net: pkt: Move TCP 1st sent flag out of union

### DIFF
--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -178,14 +178,13 @@ struct net_pkt {
 					     * AF_UNSPEC.
 					     */
 		u8_t ppp_msg           : 1; /* This is a PPP message */
-
-		u8_t tcp_first_msg     : 1; /* Is this the first time this
-					     * pkt is sent, or is this resend
-					     * of a TCP message.
-					     * Used only if
-					     * defined(CONFIG_NET_TCP)
-					     */
 	};
+
+#if defined(CONFIG_NET_TCP)
+	u8_t tcp_first_msg     : 1; /* Is this the first time this pkt is sent,
+				     * or is this a resend of a TCP segment.
+				     */
+#endif
 
 	union {
 		/* IPv6 hop limit or IPv4 ttl for this network packet.
@@ -364,12 +363,21 @@ static inline void net_pkt_set_queued(struct net_pkt *pkt, bool send)
 
 static inline u8_t net_pkt_tcp_1st_msg(struct net_pkt *pkt)
 {
+#if defined(CONFIG_NET_TCP)
 	return pkt->tcp_first_msg;
+#else
+	return true;
+#endif
 }
 
 static inline void net_pkt_set_tcp_1st_msg(struct net_pkt *pkt, bool is_1st)
 {
+#if defined(CONFIG_NET_TCP)
 	pkt->tcp_first_msg = is_1st;
+#else
+	ARG_UNUSED(pkt);
+	ARG_UNUSED(is_1st);
+#endif
 }
 
 #if defined(CONFIG_NET_SOCKETS)


### PR DESCRIPTION
The TCP flag was conflicting with PPP flag in the same union.
This prevented TCP from working properly with PPP.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>

This was reported in slack, unfortunately I have lost the contact details, and the reporter never sent a patch for it.