### PR TITLE
drivers: audio: mpxxdtyy: Conver to use DT_ANY_INST_ON_BUS macro

### DIFF
--- a/drivers/audio/mpxxdtyy-i2s.c
+++ b/drivers/audio/mpxxdtyy-i2s.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT st_mpxxdtyy
+
 #include "mpxxdtyy.h"
 #include <drivers/i2s.h>
 
@@ -11,7 +13,7 @@
 #include <logging/log.h>
 LOG_MODULE_DECLARE(mpxxdtyy);
 
-#ifdef DT_ST_MPXXDTYY_BUS_I2S
+#if DT_ANY_INST_ON_BUS(i2s)
 
 #define NUM_RX_BLOCKS			4
 #define PDM_BLOCK_MAX_SIZE_BYTES	512
@@ -138,4 +140,4 @@ int mpxxdtyy_i2s_configure(struct device *dev, struct dmic_cfg *cfg)
 	data->state = DMIC_STATE_CONFIGURED;
 	return 0;
 }
-#endif /* DT_ST_MPXXDTYY_BUS_I2S */
+#endif /* DT_ANY_INST_ON_BUS(i2s) */

--- a/drivers/audio/mpxxdtyy.c
+++ b/drivers/audio/mpxxdtyy.c
@@ -141,11 +141,11 @@ int sw_filter_lib_run(TPDMFilter_InitStruct *pdm_filter,
 }
 
 static const struct _dmic_ops mpxxdtyy_driver_api = {
-#ifdef DT_ST_MPXXDTYY_BUS_I2S
+#if DT_ANY_INST_ON_BUS(i2s)
 	.configure		= mpxxdtyy_i2s_configure,
 	.trigger		= mpxxdtyy_i2s_trigger,
 	.read			= mpxxdtyy_i2s_read,
-#endif /* DT_ST_MPXXDTYY_BUS_I2S */
+#endif /* DT_ANY_INST_ON_BUS(i2s) */
 };
 
 static int mpxxdtyy_initialize(struct device *dev)

--- a/drivers/audio/mpxxdtyy.h
+++ b/drivers/audio/mpxxdtyy.h
@@ -37,12 +37,12 @@ int sw_filter_lib_run(TPDMFilter_InitStruct *pdm_filter,
 		      void *pdm_block, void *pcm_block,
 		      size_t pdm_size, size_t pcm_size);
 
-#ifdef DT_ST_MPXXDTYY_BUS_I2S
+#if DT_ANY_INST_ON_BUS(i2s)
 int mpxxdtyy_i2s_read(struct device *dev, u8_t stream, void **buffer,
 		      size_t *size, s32_t timeout);
 int mpxxdtyy_i2s_trigger(struct device *dev, enum dmic_trigger cmd);
 int mpxxdtyy_i2s_configure(struct device *dev, struct dmic_cfg *cfg);
-#endif /* DT_ST_MPXXDTYY_BUS_I2S */
+#endif /* DT_ANY_INST_ON_BUS(i2s) */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Convert driver to use new DT_ANY_INST_ON_BUS(i2s) away from
DT_ST_MPXXDTYY_BUS_I2S.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>