### PR TITLE
drivers: display: mb_display: Convert to DT_LABEL() macro

### DIFF
--- a/drivers/display/mb_display.c
+++ b/drivers/display/mb_display.c
@@ -26,51 +26,51 @@
 
 /* Onboard LED Row 1 */
 #define LED_ROW1_GPIO_PIN   13
-#define LED_ROW1_GPIO_PORT  DT_GPIO_P0_DEV_NAME
+#define LED_ROW1_GPIO_PORT  DT_LABEL(DT_NODELABEL(gpio0))
 
 /* Onboard LED Row 2 */
 #define LED_ROW2_GPIO_PIN   14
-#define LED_ROW2_GPIO_PORT  DT_GPIO_P0_DEV_NAME
+#define LED_ROW2_GPIO_PORT  DT_LABEL(DT_NODELABEL(gpio0))
 
 /* Onboard LED Row 3 */
 #define LED_ROW3_GPIO_PIN   15
-#define LED_ROW3_GPIO_PORT  DT_GPIO_P0_DEV_NAME
+#define LED_ROW3_GPIO_PORT  DT_LABEL(DT_NODELABEL(gpio0))
 
 /* Onboard LED Column 1 */
 #define LED_COL1_GPIO_PIN   4
-#define LED_COL1_GPIO_PORT  DT_GPIO_P0_DEV_NAME
+#define LED_COL1_GPIO_PORT  DT_LABEL(DT_NODELABEL(gpio0))
 
 /* Onboard LED Column 2 */
 #define LED_COL2_GPIO_PIN   5
-#define LED_COL2_GPIO_PORT  DT_GPIO_P0_DEV_NAME
+#define LED_COL2_GPIO_PORT  DT_LABEL(DT_NODELABEL(gpio0))
 
 /* Onboard LED Column 3 */
 #define LED_COL3_GPIO_PIN   6
-#define LED_COL3_GPIO_PORT  DT_GPIO_P0_DEV_NAME
+#define LED_COL3_GPIO_PORT  DT_LABEL(DT_NODELABEL(gpio0))
 
 /* Onboard LED Column 4 */
 #define LED_COL4_GPIO_PIN   7
-#define LED_COL4_GPIO_PORT  DT_GPIO_P0_DEV_NAME
+#define LED_COL4_GPIO_PORT  DT_LABEL(DT_NODELABEL(gpio0))
 
 /* Onboard LED Column 5 */
 #define LED_COL5_GPIO_PIN   8
-#define LED_COL5_GPIO_PORT  DT_GPIO_P0_DEV_NAME
+#define LED_COL5_GPIO_PORT  DT_LABEL(DT_NODELABEL(gpio0))
 
 /* Onboard LED Column 6 */
 #define LED_COL6_GPIO_PIN   9
-#define LED_COL6_GPIO_PORT  DT_GPIO_P0_DEV_NAME
+#define LED_COL6_GPIO_PORT  DT_LABEL(DT_NODELABEL(gpio0))
 
 /* Onboard LED Column 7 */
 #define LED_COL7_GPIO_PIN   10
-#define LED_COL7_GPIO_PORT  DT_GPIO_P0_DEV_NAME
+#define LED_COL7_GPIO_PORT  DT_LABEL(DT_NODELABEL(gpio0))
 
 /* Onboard LED Column 8 */
 #define LED_COL8_GPIO_PIN   11
-#define LED_COL8_GPIO_PORT  DT_GPIO_P0_DEV_NAME
+#define LED_COL8_GPIO_PORT  DT_LABEL(DT_NODELABEL(gpio0))
 
 /* Onboard LED Column 9 */
 #define LED_COL9_GPIO_PIN   12
-#define LED_COL9_GPIO_PORT  DT_GPIO_P0_DEV_NAME
+#define LED_COL9_GPIO_PORT  DT_LABEL(DT_NODELABEL(gpio0))
 
 
 #define DISPLAY_ROWS 3
@@ -430,7 +430,7 @@ static int mb_display_init(struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	display.dev = device_get_binding(DT_GPIO_P0_DEV_NAME);
+	display.dev = device_get_binding(DT_LABEL(DT_NODELABEL(gpio0)));
 
 	__ASSERT(dev, "No GPIO device found");
 


### PR DESCRIPTION
Convert old dts_fixup.h style DT_GPIO_P0_DEV_NAME macro to new
DT_LABEL(DT_NODELABEL(gpio0))

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>