### PR TITLE
interrupt_controller: gic: Fix ICFGRn access and config

### DIFF
--- a/drivers/interrupt_controller/intc_gic.c
+++ b/drivers/interrupt_controller/intc_gic.c
@@ -56,22 +56,22 @@ void arm_gic_irq_set_priority(
 	unsigned int irq, unsigned int prio, u32_t flags)
 {
 	int int_grp, int_off;
-	u8_t val;
+	u32_t val;
 
 	/* Set priority */
 	sys_write8(prio & 0xff, GICD_IPRIORITYRn + irq);
 
 	/* Set interrupt type */
-	int_grp = irq / 4;
+	int_grp = (irq / 16) * 4;
 	int_off = (irq % 16) * 2;
 
-	val = sys_read8(GICD_ICFGRn + int_grp);
+	val = sys_read32(GICD_ICFGRn + int_grp);
 	val &= ~(GICD_ICFGR_MASK << int_off);
 	if (flags & IRQ_TYPE_EDGE) {
 		val |= (GICD_ICFGR_TYPE << int_off);
 	}
 
-	sys_write8(val, GICD_ICFGRn + int_grp);
+	sys_write32(val, GICD_ICFGRn + int_grp);
 }
 
 unsigned int arm_gic_get_active(void)


### PR DESCRIPTION
Fixing ICFGRn register access with `sys_{read,write}32`
since this register is not byte-accessible.
Type of `val` changed to u32 to match reg width.

Fixes #24339

Supersedes #24422

Signed-off-by: Bartlomiej Flak <flakbartlomiej@gmail.com>