### PR TITLE
DTS: LPC: Some additional LPC devicetree conversion

### DIFF
--- a/boards/arm/lpcxpresso54114/Kconfig.defconfig
+++ b/boards/arm/lpcxpresso54114/Kconfig.defconfig
@@ -9,16 +9,6 @@ config BOARD
 	default "lpcxpresso54114_m4" if BOARD_LPCXPRESSO54114_M4
 	default "lpcxpresso54114_m0" if BOARD_LPCXPRESSO54114_M0
 
-if PINMUX_MCUX_LPC
-
-config PINMUX_MCUX_LPC_PORT0
-	default y
-
-config PINMUX_MCUX_LPC_PORT1
-	default y
-
-endif # PINMUX_MCUX_LPC
-
 if GPIO_MCUX_LPC
 
 config GPIO_MCUX_LPC_PORT0

--- a/boards/arm/lpcxpresso54114/pinmux.c
+++ b/boards/arm/lpcxpresso54114/pinmux.c
@@ -13,14 +13,14 @@ static int lpcxpresso_54114_pinmux_init(struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-#ifdef CONFIG_PINMUX_MCUX_LPC_PORT0
+#if DT_HAS_NODE(DT_NODELABEL(pio0))
 	struct device *port0 =
-		device_get_binding(CONFIG_PINMUX_MCUX_LPC_PORT0_NAME);
+		device_get_binding(DT_LABEL(DT_NODELABEL(pio0)));
 #endif
 
-#ifdef	CONFIG_PINMUX_MCUX_LPC_PORT1
+#if DT_HAS_NODE(DT_NODELABEL(pio1))
 	struct device *port1 =
-		device_get_binding(CONFIG_PINMUX_MCUX_LPC_PORT1_NAME);
+		device_get_binding(DT_LABEL(DT_NODELABEL(pio1)));
 #endif
 
 #if DT_HAS_NODE_STATUS_OKAY(DT_NODELABEL(flexcomm0)) && \

--- a/boards/arm/lpcxpresso55s69/Kconfig.defconfig
+++ b/boards/arm/lpcxpresso55s69/Kconfig.defconfig
@@ -9,16 +9,6 @@ config BOARD
 	default "lpcxpresso55S69_cpu0" if BOARD_LPCXPRESSO55S69_CPU0
 	default "lpcxpresso55S69_cpu1" if BOARD_LPCXPRESSO55S69_CPU1
 
-if PINMUX_MCUX_LPC
-
-config PINMUX_MCUX_LPC_PORT0
-	default y
-
-config PINMUX_MCUX_LPC_PORT1
-	default y
-
-endif # PINMUX_MCUX_LPC
-
 if GPIO_MCUX_LPC
 
 config GPIO_MCUX_LPC_PORT0

--- a/boards/arm/lpcxpresso55s69/pinmux.c
+++ b/boards/arm/lpcxpresso55s69/pinmux.c
@@ -13,14 +13,14 @@ static int lpcxpresso_55s69_pinmux_init(struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-#ifdef CONFIG_PINMUX_MCUX_LPC_PORT0
+#if DT_HAS_NODE(DT_NODELABEL(pio0))
 	struct device *port0 =
-		device_get_binding(CONFIG_PINMUX_MCUX_LPC_PORT0_NAME);
+		device_get_binding(DT_LABEL(DT_NODELABEL(pio0)));
 #endif
 
-#ifdef CONFIG_PINMUX_MCUX_LPC_PORT1
+#if DT_HAS_NODE(DT_NODELABEL(pio1))
 	struct device *port1 =
-		device_get_binding(CONFIG_PINMUX_MCUX_LPC_PORT1_NAME);
+		device_get_binding(DT_LABEL(DT_NODELABEL(pio1)));
 #endif
 
 #if DT_HAS_NODE_STATUS_OKAY(DT_NODELABEL(flexcomm0)) && \

--- a/drivers/gpio/Kconfig.mcux_lpc
+++ b/drivers/gpio/Kconfig.mcux_lpc
@@ -13,13 +13,13 @@ if GPIO_MCUX_LPC
 
 config GPIO_MCUX_LPC_PORT0
 	bool "Port 0"
-	depends on PINMUX_MCUX_LPC_PORT0
+	depends on $(dt_nodelabel_enabled,pio0)
 	help
 	  Enable Port 0.
 
 config GPIO_MCUX_LPC_PORT1
 	bool "Port 1"
-	depends on PINMUX_MCUX_LPC_PORT1
+	depends on $(dt_nodelabel_enabled,pio1)
 	help
 	  Enable Port 1.
 

--- a/drivers/pinmux/Kconfig.mcux_lpc
+++ b/drivers/pinmux/Kconfig.mcux_lpc
@@ -3,32 +3,8 @@
 # Copyright (c) 2017, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig PINMUX_MCUX_LPC
+config PINMUX_MCUX_LPC
 	bool "MCUX LPC pinmux driver"
 	depends on HAS_MCUX
 	help
 	  Enable the MCUX LPC pinmux driver.
-
-if PINMUX_MCUX_LPC
-
-config PINMUX_MCUX_LPC_PORT0
-	bool "Port 0"
-	help
-	  Enable Port 0.
-
-config PINMUX_MCUX_LPC_PORT0_NAME
-	string "Pinmux Port 0 driver name"
-	depends on PINMUX_MCUX_LPC_PORT0
-	default "port0"
-
-config PINMUX_MCUX_LPC_PORT1
-	bool "Port 1"
-	help
-	  Enable Port 1.
-
-config PINMUX_MCUX_LPC_PORT1_NAME
-	string "Pinmux Port 1 driver name"
-	depends on PINMUX_MCUX_LPC_PORT1
-	default "port1"
-
-endif # PINMUX_MCUX_LPC

--- a/dts/arm/nxp/nxp_lpc54xxx.dtsi
+++ b/dts/arm/nxp/nxp_lpc54xxx.dtsi
@@ -69,6 +69,26 @@
 			#clock-cells = <2>;
 		};
 
+		iocon: iocon@40001000 {
+			compatible = "nxp,lpc-iocon";
+			reg = <0x40001000 0x100>;
+			label = "IOCON";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			clocks = <&syscon LPC_AHB_CLK_CTRL0 13>;
+			ranges = <0x0 0x40001000 0x100>;
+			pio0: pio0@0 {
+				compatible = "nxp,lpc-iocon-pio";
+				reg = <0x0 0x80>;
+				label = "PIO_0";
+			};
+			pio1: pio0@80 {
+				compatible = "nxp,lpc-iocon-pio";
+				reg = <0x80 0x80>;
+				label = "PIO_1";
+			};
+		};
+
 		gpio0: gpio@0 {
 			compatible = "nxp,lpc-gpio";
 			reg = <0x4008c000 0x2488>;

--- a/dts/arm/nxp/nxp_lpc54xxx.dtsi
+++ b/dts/arm/nxp/nxp_lpc54xxx.dtsi
@@ -7,6 +7,10 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
 
+#define LPC_AHB_CLK_CTRL0 0
+#define LPC_AHB_CLK_CTRL1 1
+#define LPC_AHB_CLK_CTRL2 2
+
 / {
 	aliases{
 		gpio-0 = &gpio0;
@@ -38,11 +42,13 @@
 		sram1:memory@20010000 {
 			compatible = "mmio-sram";
 			reg = <0x20010000 0x10000>;
+			clocks = <&syscon LPC_AHB_CLK_CTRL0 3>;
 		};
 
 		sram2:memory@20020000 {
 			compatible = "mmio-sram";
 			reg = <0x20020000 0x8000>;
+			clocks = <&syscon LPC_AHB_CLK_CTRL0 4>;
 		};
 
 		sramx:memory@40000000{
@@ -55,6 +61,14 @@
 			reg = <0 0x40000>;
 		};
 
+		syscon: syscon@40000000 {
+			compatible = "nxp,lpc-syscon";
+			reg = <0x40000000 0x1000>;
+			label = "SYSCON";
+
+			#clock-cells = <2>;
+		};
+
 		gpio0: gpio@0 {
 			compatible = "nxp,lpc-gpio";
 			reg = <0x4008c000 0x2488>;
@@ -62,6 +76,7 @@
 			label = "GPIO_0";
 			gpio-controller;
 			#gpio-cells = <2>;
+			clocks = <&syscon LPC_AHB_CLK_CTRL0 14>;
 		};
 
 		gpio1: gpio@1 {
@@ -71,6 +86,7 @@
 			label = "GPIO_1";
 			gpio-controller;
 			#gpio-cells = <2>;
+			clocks = <&syscon LPC_AHB_CLK_CTRL0 15>;
 		};
 
 		mailbox0:mailbox@4008b000 {
@@ -79,6 +95,7 @@
 			interrupts = <31 0>;
 			label = "MAILBOX_0";
 			status = "disabled";
+			clocks = <&syscon LPC_AHB_CLK_CTRL0 26>;
 		};
 
 		flexcomm0: flexcomm@40086000 {
@@ -87,6 +104,7 @@
 			interrupts = <14 0>;
 			label = "FLEXCOMM_0";
 			status = "disabled";
+			clocks = <&syscon LPC_AHB_CLK_CTRL1 11>;
 		};
 
 		flexcomm1: flexcomm@40087000 {
@@ -95,6 +113,7 @@
 			interrupts = <15 0>;
 			label = "FLEXCOMM_1";
 			status = "disabled";
+			clocks = <&syscon LPC_AHB_CLK_CTRL1 12>;
 		};
 
 		flexcomm2: flexcomm@40088000 {
@@ -103,6 +122,7 @@
 			interrupts = <16 0>;
 			label = "FLEXCOMM_2";
 			status = "disabled";
+			clocks = <&syscon LPC_AHB_CLK_CTRL1 13>;
 		};
 
 		flexcomm3: flexcomm@40089000 {
@@ -111,6 +131,7 @@
 			interrupts = <17 0>;
 			label = "FLEXCOMM_3";
 			status = "disabled";
+			clocks = <&syscon LPC_AHB_CLK_CTRL1 14>;
 		};
 
 		flexcomm4: flexcomm@4008a000 {
@@ -119,6 +140,7 @@
 			interrupts = <18 0>;
 			label = "FLEXCOMM_4";
 			status = "disabled";
+			clocks = <&syscon LPC_AHB_CLK_CTRL1 15>;
 		};
 
 		flexcomm5: flexcomm@40096000 {
@@ -127,6 +149,7 @@
 			interrupts = <19 0>;
 			label = "FLEXCOMM_5";
 			status = "disabled";
+			clocks = <&syscon LPC_AHB_CLK_CTRL1 16>;
 		};
 
 		flexcomm6: flexcomm@40097000 {
@@ -135,6 +158,7 @@
 			interrupts = <20 0>;
 			label = "FLEXCOMM_6";
 			status = "disabled";
+			clocks = <&syscon LPC_AHB_CLK_CTRL1 17>;
 		};
 
 		flexcomm7: flexcomm@40098000 {
@@ -143,6 +167,7 @@
 			interrupts = <21 0>;
 			label = "FLEXCOMM_7";
 			status = "disabled";
+			clocks = <&syscon LPC_AHB_CLK_CTRL1 18>;
 		};
 	};
 };

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -9,6 +9,10 @@
 #include <dt-bindings/i2c/i2c.h>
 #include <arm/armv8-m.dtsi>
 
+#define LPC_AHB_CLK_CTRL0 0
+#define LPC_AHB_CLK_CTRL1 1
+#define LPC_AHB_CLK_CTRL2 2
+
 / {
 	aliases {
 		gpio-0 = &gpio0;
@@ -59,28 +63,40 @@
 	sram1: memory@20010000 {
 		compatible = "mmio-sram";
 		reg = <0x20010000 DT_SIZE_K(64)>;
+		clocks = <&syscon LPC_AHB_CLK_CTRL0 3>;
 	};
 
 	sram2: memory@20020000 {
 		compatible = "mmio-sram";
 		reg = <0x20020000 DT_SIZE_K(64)>;
+		clocks = <&syscon LPC_AHB_CLK_CTRL0 4>;
 	};
 
 	sram3: memory@20030000 {
 		compatible = "mmio-sram";
 		reg = <0x20030000 DT_SIZE_K(64)>;
+		clocks = <&syscon LPC_AHB_CLK_CTRL0 5>;
 	};
 
 	sram4: memory@20040000 {
 		/* Conencted to USB bus*/
 		compatible = "mmio-sram";
 		reg = <0x20040000 DT_SIZE_K(16)>;
+		clocks = <&syscon LPC_AHB_CLK_CTRL0 6>;
 	};
 };
 
 &peripheral {
 	#address-cells = <1>;
 	#size-cells = <1>;
+
+	syscon: syscon@0 {
+		compatible = "nxp,lpc-syscon";
+		reg = <0x0 0x1000>;
+		label = "SYSCON";
+
+		#clock-cells = <2>;
+	};
 
 	iap: flash-controller@34000 {
 		compatible = "nxp,lpc-iap";
@@ -115,6 +131,7 @@
 		label = "GPIO_0";
 		gpio-controller;
 		#gpio-cells = <2>;
+		clocks = <&syscon LPC_AHB_CLK_CTRL0 14>;
 	};
 
 	gpio1: gpio@1 {
@@ -124,6 +141,7 @@
 		label = "GPIO_1";
 		gpio-controller;
 		#gpio-cells = <2>;
+		clocks = <&syscon LPC_AHB_CLK_CTRL0 15>;
 	};
 
 	flexcomm0: flexcomm@86000 {
@@ -132,6 +150,7 @@
 		interrupts = <14 0>;
 		label = "FLEXCOMM_0";
 		status = "disabled";
+		clocks = <&syscon LPC_AHB_CLK_CTRL1 11>;
 	};
 
 	flexcomm1: flexcomm@87000 {
@@ -140,6 +159,7 @@
 		interrupts = <15 0>;
 		label = "FLEXCOMM_1";
 		status = "disabled";
+		clocks = <&syscon LPC_AHB_CLK_CTRL1 12>;
 	};
 
 	flexcomm2: flexcomm@88000 {
@@ -148,6 +168,7 @@
 		interrupts = <16 0>;
 		label = "FLEXCOMM_2";
 		status = "disabled";
+		clocks = <&syscon LPC_AHB_CLK_CTRL1 13>;
 	};
 
 	flexcomm3: flexcomm@89000 {
@@ -156,6 +177,7 @@
 		interrupts = <17 0>;
 		label = "FLEXCOMM_3";
 		status = "disabled";
+		clocks = <&syscon LPC_AHB_CLK_CTRL1 14>;
 	};
 
 	flexcomm4: flexcomm@8a000 {
@@ -164,6 +186,7 @@
 		interrupts = <18 0>;
 		label = "FLEXCOMM_4";
 		status = "disabled";
+		clocks = <&syscon LPC_AHB_CLK_CTRL1 15>;
 	};
 
 	flexcomm5: flexcomm@96000 {
@@ -172,6 +195,7 @@
 		interrupts = <19 0>;
 		label = "FLEXCOMM_5";
 		status = "disabled";
+		clocks = <&syscon LPC_AHB_CLK_CTRL1 16>;
 	};
 
 	flexcomm6: flexcomm@97000 {
@@ -180,6 +204,7 @@
 		interrupts = <20 0>;
 		label = "FLEXCOMM_6";
 		status = "disabled";
+		clocks = <&syscon LPC_AHB_CLK_CTRL1 17>;
 	};
 
 	flexcomm7: flexcomm@98000 {
@@ -188,6 +213,7 @@
 		interrupts = <21 0>;
 		label = "FLEXCOMM_7";
 		status = "disabled";
+		clocks = <&syscon LPC_AHB_CLK_CTRL1 18>;
 	};
 
 	hs_lspi: spi@9f000 {
@@ -198,6 +224,7 @@
 		status = "disabled";
 		#address-cells = <1>;
 		#size-cells = <0>;
+		clocks = <&syscon LPC_AHB_CLK_CTRL2 28>;
 	};
 
 	rng: rng@3a000 {

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -124,6 +124,26 @@
 		};
 	};
 
+	iocon: iocon@1000 {
+		compatible = "nxp,lpc-iocon";
+		reg = <0x1000 0x100>;
+		label = "IOCON";
+		clocks = <&syscon LPC_AHB_CLK_CTRL0 13>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x1000 0x100>;
+		pio0: pio0@0 {
+			compatible = "nxp,lpc-iocon-pio";
+			reg = <0x0 0x80>;
+			label = "PIO_0";
+		};
+		pio1: pio0@80 {
+			compatible = "nxp,lpc-iocon-pio";
+			reg = <0x80 0x80>;
+			label = "PIO_1";
+		};
+	};
+
 	gpio0: gpio@0 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x2488>;

--- a/dts/bindings/arm/nxp,lpc-flexcomm.yaml
+++ b/dts/bindings/arm/nxp,lpc-flexcomm.yaml
@@ -13,3 +13,6 @@ properties:
 
     interrupts:
       required: true
+
+    clocks:
+      required: true

--- a/dts/bindings/clock/nxp,lpc-syscon.yaml
+++ b/dts/bindings/clock/nxp,lpc-syscon.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2020, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: LPC System Configuration (SYSCON)
+
+compatible: "nxp,lpc-syscon"
+
+include: [clock-controller.yaml, base.yaml]
+
+properties:
+    reg:
+      required: true
+
+    label:
+      required: true
+
+    "#clock-cells":
+      const: 2
+
+clock-cells:
+  - offset
+  - bits

--- a/dts/bindings/gpio/nxp,lpc-gpio.yaml
+++ b/dts/bindings/gpio/nxp,lpc-gpio.yaml
@@ -14,6 +14,9 @@ properties:
     label:
       required: true
 
+    clocks:
+      required: true
+
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/pinctrl/nxp,lpc-iocon-pio.yaml
+++ b/dts/bindings/pinctrl/nxp,lpc-iocon-pio.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2020, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: LPC I/O Pin Configuration (IOCON) Port I/O (PIO)
+
+compatible: "nxp,lpc-iocon-pio"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true
+
+    label:
+      required: true

--- a/dts/bindings/pinctrl/nxp,lpc-iocon.yaml
+++ b/dts/bindings/pinctrl/nxp,lpc-iocon.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2020, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: LPC I/O Pin Configuration (IOCON)
+
+compatible: "nxp,lpc-iocon"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true
+
+    label:
+      required: true
+
+    clocks:
+      required: true

--- a/tests/drivers/gpio/gpio_basic_api/src/main.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/main.c
@@ -99,7 +99,7 @@ static void board_setup(void)
 #elif defined(CONFIG_SOC_FAMILY_LPC)
 	/* Assumes ARDUINO pins are mapped on PORT0 on all boards*/
 	struct device *port0 =
-		device_get_binding(CONFIG_PINMUX_MCUX_LPC_PORT0_NAME);
+		device_get_binding(DT_LABEL(DT_NODELABEL(pio0)));
 	const u32_t pin_config = (
 			IOCON_PIO_FUNC0 |
 			IOCON_PIO_INV_DI |


### PR DESCRIPTION
TODO: [ ] Add support for LPC55S16 family
* Add clocks into dts (Need to figure out how to describe clocks for i2c/uart/spi, etc -- will be a follow up pr)
* converted pinmux driver to use DTS
* Add some additional nodes (syscon & iocon) to DTS