### PR TITLE
Add support for 'fixed link' configuration on Kinetics MCUX ENET driver

### DIFF
--- a/boards/arm/ip_k66f/Kconfig.defconfig
+++ b/boards/arm/ip_k66f/Kconfig.defconfig
@@ -34,6 +34,9 @@ config ETH_MCUX_0
 config ETH_MCUX_RMII_EXT_CLK
 	default y if ETH_MCUX
 
+config ETH_MCUX_NO_PHY_SMI
+	default y if ETH_MCUX
+
 endif # NETWORKING
 
 if PINMUX_MCUX

--- a/boards/arm/ip_k66f/ip_k66f.dts
+++ b/boards/arm/ip_k66f/ip_k66f.dts
@@ -93,6 +93,11 @@
 
 &enet {
 	status = "okay";
+
+	fixed-link {
+		speed = <100>;
+		full-duplex;
+	};
 };
 
 &spi1 {

--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -28,6 +28,13 @@ config ETH_MCUX_RMII_EXT_CLK
 	  Setting this option will configure MCUX clock block to feed RMII
 	  reference clock from external source (ENET_1588_CLKIN)
 
+config ETH_MCUX_NO_PHY_SMI
+	bool "Do not use SMI for PHY communication"
+	help
+	  Some PHY devices, with DSA capabilities do not use SMI for
+	  communication with MAC ENET controller. Other busses - like SPI
+	  or I2C are used instead.
+
 config ETH_MCUX_PHY_TICK_MS
 	int "PHY poll period (ms)"
 	default 1000

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -287,11 +287,16 @@ static inline struct net_if *get_iface(struct eth_context *ctx, uint16_t vlan_ta
 static void eth_mcux_phy_enter_reset(struct eth_context *context)
 {
 	/* Reset the PHY. */
+#ifndef CONFIG_ETH_MCUX_NO_PHY_SMI
 	ENET_StartSMIWrite(context->base, context->phy_addr,
 			   PHY_BASICCONTROL_REG,
 			   kENET_MiiWriteValidFrame,
 			   PHY_BCTL_RESET_MASK);
+#endif
 	context->phy_state = eth_mcux_phy_state_reset;
+#ifdef CONFIG_ETH_MCUX_NO_PHY_SMI
+	k_work_submit(&context->phy_work);
+#endif
 }
 
 static void eth_mcux_phy_start(struct eth_context *context)
@@ -307,10 +312,19 @@ static void eth_mcux_phy_start(struct eth_context *context)
 	case eth_mcux_phy_state_initial:
 		ENET_ActiveRead(context->base);
 		/* Reset the PHY. */
+#ifndef CONFIG_ETH_MCUX_NO_PHY_SMI
 		ENET_StartSMIWrite(context->base, context->phy_addr,
 				   PHY_BASICCONTROL_REG,
 				   kENET_MiiWriteValidFrame,
 				   PHY_BCTL_RESET_MASK);
+#else
+		/*
+		 * With no SMI communication one needs to wait for
+		 * iface being up by the network core.
+		 */
+		k_work_submit(&context->phy_work);
+		break;
+#endif
 #ifdef CONFIG_SOC_SERIES_IMX_RT
 		context->phy_state = eth_mcux_phy_state_initial;
 #else
@@ -396,6 +410,18 @@ static void eth_mcux_phy_event(struct eth_context *context)
 		}
 		context->phy_state = eth_mcux_phy_state_reset;
 #endif
+#ifdef CONFIG_ETH_MCUX_NO_PHY_SMI
+		/*
+		 * When the iface is available proceed with the eth link setup,
+		 * otherwise reschedule the eth_mcux_phy_event and check after
+		 * 1ms
+		 */
+		if (context->iface) {
+		       context->phy_state = eth_mcux_phy_state_reset;
+		}
+
+		k_delayed_work_submit(&context->delayed_phy_work, K_MSEC(1));
+#endif
 		break;
 	case eth_mcux_phy_state_closing:
 		if (context->enabled) {
@@ -407,6 +433,7 @@ static void eth_mcux_phy_event(struct eth_context *context)
 		break;
 	case eth_mcux_phy_state_reset:
 		/* Setup PHY autonegotiation. */
+#ifndef CONFIG_ETH_MCUX_NO_PHY_SMI
 		ENET_StartSMIWrite(context->base, context->phy_addr,
 				   PHY_AUTONEG_ADVERTISE_REG,
 				   kENET_MiiWriteValidFrame,
@@ -414,24 +441,38 @@ static void eth_mcux_phy_event(struct eth_context *context)
 				    PHY_100BASETX_HALFDUPLEX_MASK |
 				    PHY_10BASETX_FULLDUPLEX_MASK |
 				    PHY_10BASETX_HALFDUPLEX_MASK | 0x1U));
+#endif
 		context->phy_state = eth_mcux_phy_state_autoneg;
+#ifdef CONFIG_ETH_MCUX_NO_PHY_SMI
+		k_work_submit(&context->phy_work);
+#endif
 		break;
 	case eth_mcux_phy_state_autoneg:
+#ifndef CONFIG_ETH_MCUX_NO_PHY_SMI
 		/* Setup PHY autonegotiation. */
 		ENET_StartSMIWrite(context->base, context->phy_addr,
 				   PHY_BASICCONTROL_REG,
 				   kENET_MiiWriteValidFrame,
 				   (PHY_BCTL_AUTONEG_MASK |
 				    PHY_BCTL_RESTART_AUTONEG_MASK));
+#endif
 		context->phy_state = eth_mcux_phy_state_restart;
+#ifdef CONFIG_ETH_MCUX_NO_PHY_SMI
+		k_work_submit(&context->phy_work);
+#endif
 		break;
 	case eth_mcux_phy_state_wait:
 	case eth_mcux_phy_state_restart:
 		/* Start reading the PHY basic status. */
+#ifndef CONFIG_ETH_MCUX_NO_PHY_SMI
 		ENET_StartSMIRead(context->base, context->phy_addr,
 				  PHY_BASICSTATUS_REG,
 				  kENET_MiiReadValidFrame);
+#endif
 		context->phy_state = eth_mcux_phy_state_read_status;
+#ifdef CONFIG_ETH_MCUX_NO_PHY_SMI
+		k_work_submit(&context->phy_work);
+#endif
 		break;
 	case eth_mcux_phy_state_read_status:
 		/* PHY Basic status is available. */
@@ -439,9 +480,11 @@ static void eth_mcux_phy_event(struct eth_context *context)
 		link_up =  status & PHY_BSTATUS_LINKSTATUS_MASK;
 		if (link_up && !context->link_up) {
 			/* Start reading the PHY control register. */
+#ifndef CONFIG_ETH_MCUX_NO_PHY_SMI
 			ENET_StartSMIRead(context->base, context->phy_addr,
 					  PHY_CONTROL1_REG,
 					  kENET_MiiReadValidFrame);
+#endif
 			context->link_up = link_up;
 			context->phy_state = eth_mcux_phy_state_read_duplex;
 
@@ -450,6 +493,9 @@ static void eth_mcux_phy_event(struct eth_context *context)
 				net_eth_carrier_on(context->iface);
 				k_msleep(USEC_PER_MSEC);
 			}
+#ifdef CONFIG_ETH_MCUX_NO_PHY_SMI
+			k_work_submit(&context->phy_work);
+#endif
 		} else if (!link_up && context->link_up) {
 			LOG_INF("%s link down", eth_name(context->base));
 			context->link_up = link_up;
@@ -946,7 +992,9 @@ static void eth_mcux_init(struct device *dev)
 	ENET_GetDefaultConfig(&enet_config);
 	enet_config.interrupt |= kENET_RxFrameInterrupt;
 	enet_config.interrupt |= kENET_TxFrameInterrupt;
+#ifndef CONFIG_ETH_MCUX_NO_PHY_SMI
 	enet_config.interrupt |= kENET_MiiInterrupt;
+#endif
 
 	if (IS_ENABLED(CONFIG_ETH_MCUX_PROMISCUOUS_MODE)) {
 		enet_config.macSpecialConfig |= kENET_ControlPromiscuousEnable;
@@ -993,7 +1041,9 @@ static void eth_mcux_init(struct device *dev)
 	ENET_AddMulticastGroup(context->base, mdns_multicast);
 #endif
 
+#ifndef CONFIG_ETH_MCUX_NO_PHY_SMI
 	ENET_SetSMI(context->base, sys_clock, false);
+#endif
 
 	/* handle PHY setup after SMI initialization */
 	eth_mcux_phy_setup(context);

--- a/dts/bindings/ethernet/ethernet,fixed-link.yaml
+++ b/dts/bindings/ethernet/ethernet,fixed-link.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2020, DENX Software Engineering GmbH
+#		      Lukasz Majewski <lukma@denx.de>
+# SPDX-License-Identifier: Apache-2.0
+
+child-binding:
+    description: Fixed link ethernet node
+    properties:
+       speed:
+          type: int
+          required: true
+          description: The speed of fixed link
+          enum:
+            - 100
+            - 10
+       full-duplex:
+          type: boolean
+          required: false
+          description: The fixed link operates in full duplex mode

--- a/dts/bindings/ethernet/nxp,kinetis-ethernet.yaml
+++ b/dts/bindings/ethernet/nxp,kinetis-ethernet.yaml
@@ -5,7 +5,7 @@ description: NXP Kinetis Ethernet
 
 compatible: "nxp,kinetis-ethernet"
 
-include: ethernet.yaml
+include: ["ethernet.yaml", "ethernet,fixed-link.yaml"]
 
 properties:
     reg:


### PR DESCRIPTION
Following changes to Kinetics MCUX ENET driver:

- Disable usage of SMI to read status of PHY device.
**Rationale:**
Some devices - like DSA switches (ksz8794) use SPI for configuration and reading its status
(instead of MDIO). The current implementation of ENET driver (in eth_enet.c ) is very tightly coupled with SMI interrupts as they allow moving to the next stage of this driver's state machine. This change decouples driver logic from them when required.

- Add support for 'fixed-link' DTS property
With this patch set the enet driver now supports setting fixed transmission parameters between
PHY (DSA) and ENET. 

Please consider those changes as a preparatory work for DSA support for Zephyr.