### PR TITLE
drivers: timer: xlnx_psttc: Convert driver to DT_INST macro

### DIFF
--- a/drivers/timer/xlnx_psttc_timer.c
+++ b/drivers/timer/xlnx_psttc_timer.c
@@ -5,16 +5,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT xlnx_ttcps
+
 #include <soc.h>
 #include <drivers/timer/system_timer.h>
 #include "xlnx_psttc_timer_priv.h"
 
 #define TIMER_INDEX		CONFIG_XLNX_PSTTC_TIMER_INDEX
-#define TIMER_DT(v)		UTIL_CAT(UTIL_CAT(DT_INST_, TIMER_INDEX), _##v)
 
-#define TIMER_IRQ		TIMER_DT(XLNX_TTCPS_IRQ_0)
-#define TIMER_BASE_ADDR		TIMER_DT(XLNX_TTCPS_BASE_ADDRESS)
-#define TIMER_CLOCK_FREQUECY	TIMER_DT(XLNX_TTCPS_CLOCK_FREQUENCY)
+#define TIMER_IRQ		DT_INST_IRQN(0)
+#define TIMER_BASE_ADDR		DT_INST_REG_ADDR(0)
+#define TIMER_CLOCK_FREQUECY	DT_INST_PROP(0, clock_frequency)
 
 #define TICKS_PER_SEC		CONFIG_SYS_CLOCK_TICKS_PER_SEC
 #define CYCLES_PER_SEC		TIMER_CLOCK_FREQUECY
@@ -28,7 +29,7 @@
 #define CYCLES_NEXT_MIN		(10000)
 #define CYCLES_NEXT_MAX		(XTTC_MAX_INTERVAL_COUNT)
 
-BUILD_ASSERT(TIMER_DT(XLNX_TTCPS_CLOCK_FREQUENCY) ==
+BUILD_ASSERT(TIMER_CLOCK_FREQUECY ==
 			CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC,
 	     "Configured system timer frequency does not match the TTC "
 	     "clock frequency in the device tree");


### PR DESCRIPTION
Convert older DT_INST_ macro use the new include/devicetree.h
DT_INST macro APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>