### PR TITLE
west.yml: Update to nordic HAL to conver to new DT macros

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -53,7 +53,7 @@ manifest:
       revision: a12d92816a53a521d79cefcf5c38b9dc8a4fed6e
       path: modules/hal/cypress
     - name: hal_nordic
-      revision: 8a693c5ffc8b50fc148190fe10cca5538759b8f0
+      revision: 1ebfdf148b2ca1d9ab9267ab2cd64cc00f32d505
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 3b54187649cc9b37161d49918f1ad28ff7c7f830


### PR DESCRIPTION
Convert some PWM SW NRF5 defines in the HAL to the new DT macros.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>