### PR TITLE
drivers: spi: nordic: finish conversion to new DT API

### DIFF
--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -327,30 +327,34 @@ static int spi_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 }
 #endif /* CONFIG_DEVICE_POWER_MANAGEMENT */
 
-#define SPI_NRFX_MISO_PULL_DOWN(idx) \
-	IS_ENABLED(DT_NORDIC_NRF_SPI_SPI_##idx##_MISO_PULL_DOWN)
+/*
+ * Current factors requiring use of DT_NODELABEL:
+ *
+ * - NRFX_SPI_INSTANCE() requires an SoC instance number
+ * - soc-instance-numbered kconfig enables
+ * - ORC is a SoC-instance-numbered kconfig option instead of a DT property
+ */
 
-#define SPI_NRFX_MISO_PULL_UP(idx) \
-	IS_ENABLED(DT_NORDIC_NRF_SPI_SPI_##idx##_MISO_PULL_UP)
+#define SPI(idx)			DT_NODELABEL(spi##idx)
+#define SPI_PROP(idx, prop)		DT_PROP(SPI(idx), prop)
 
 #define SPI_NRFX_MISO_PULL(idx)				\
-	(SPI_NRFX_MISO_PULL_UP(idx)			\
-		? SPI_NRFX_MISO_PULL_DOWN(idx)		\
+	(SPI_PROP(idx, miso_pull_up)			\
+		? SPI_PROP(idx, miso_pull_down)		\
 			? -1 /* invalid configuration */\
 			: NRF_GPIO_PIN_PULLUP		\
-		: SPI_NRFX_MISO_PULL_DOWN(idx)		\
+		: SPI_PROP(idx, miso_pull_down)		\
 			? NRF_GPIO_PIN_PULLDOWN		\
 			: NRF_GPIO_PIN_NOPULL)
 
 #define SPI_NRFX_SPI_DEVICE(idx)					       \
-	BUILD_ASSERT(						       \
-		!SPI_NRFX_MISO_PULL_UP(idx) || !SPI_NRFX_MISO_PULL_DOWN(idx),  \
+	BUILD_ASSERT(							       \
+		!SPI_PROP(idx, miso_pull_up) || !SPI_PROP(idx, miso_pull_down),\
 		"SPI"#idx						       \
 		": cannot enable both pull-up and pull-down on MISO line");    \
 	static int spi_##idx##_init(struct device *dev)			       \
 	{								       \
-		IRQ_CONNECT(NRFX_IRQ_NUMBER_GET(NRF_SPI##idx),		       \
-			    DT_NORDIC_NRF_SPI_SPI_##idx##_IRQ_0_PRIORITY,      \
+		IRQ_CONNECT(DT_IRQN(SPI(idx)), DT_IRQ(SPI(idx), priority),     \
 			    nrfx_isr, nrfx_spi_##idx##_irq_handler, 0);	       \
 		return init_spi(dev);					       \
 	}								       \
@@ -362,9 +366,9 @@ static int spi_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 	static const struct spi_nrfx_config spi_##idx##z_config = {	       \
 		.spi = NRFX_SPI_INSTANCE(idx),				       \
 		.config = {						       \
-			.sck_pin   = DT_NORDIC_NRF_SPI_SPI_##idx##_SCK_PIN,    \
-			.mosi_pin  = DT_NORDIC_NRF_SPI_SPI_##idx##_MOSI_PIN,   \
-			.miso_pin  = DT_NORDIC_NRF_SPI_SPI_##idx##_MISO_PIN,   \
+			.sck_pin   = SPI_PROP(idx, sck_pin),		       \
+			.mosi_pin  = SPI_PROP(idx, mosi_pin),		       \
+			.miso_pin  = SPI_PROP(idx, miso_pin),		       \
 			.ss_pin    = NRFX_SPI_PIN_NOT_USED,		       \
 			.orc       = CONFIG_SPI_##idx##_NRF_ORC,	       \
 			.frequency = NRF_SPI_FREQ_4M,			       \
@@ -373,7 +377,7 @@ static int spi_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 			.miso_pull = SPI_NRFX_MISO_PULL(idx),		       \
 		}							       \
 	};								       \
-	DEVICE_DEFINE(spi_##idx, DT_NORDIC_NRF_SPI_SPI_##idx##_LABEL,	       \
+	DEVICE_DEFINE(spi_##idx, DT_LABEL(SPI(idx)),			       \
 		      spi_##idx##_init,					       \
 		      spi_nrfx_pm_control,				       \
 		      &spi_##idx##_data,				       \

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -249,23 +249,33 @@ static int init_spis(struct device *dev, const nrfx_spis_config_t *config)
 	return 0;
 }
 
+/*
+ * Current factors requiring use of DT_NODELABEL:
+ *
+ * - NRFX_SPIS_INSTANCE() requires an SoC instance number
+ * - soc-instance-numbered kconfig enables
+ * - ORC is a SoC-instance-numbered kconfig option instead of a DT property
+ */
+
+#define SPIS(idx) DT_NODELABEL(spi##idx)
+#define SPIS_PROP(idx, prop) DT_PROP(SPIS(idx), prop)
+
 #define SPI_NRFX_SPIS_DEVICE(idx)					       \
 	static int spi_##idx##_init(struct device *dev)			       \
 	{								       \
-		IRQ_CONNECT(NRFX_IRQ_NUMBER_GET(NRF_SPIS##idx),		       \
-			    DT_NORDIC_NRF_SPIS_SPI_##idx##_IRQ_0_PRIORITY,     \
+		IRQ_CONNECT(DT_IRQN(SPIS(idx)), DT_IRQ(SPIS(idx), priority),   \
 			    nrfx_isr, nrfx_spis_##idx##_irq_handler, 0);       \
 		const nrfx_spis_config_t config = {			       \
-			.sck_pin    = DT_NORDIC_NRF_SPIS_SPI_##idx##_SCK_PIN,  \
-			.mosi_pin   = DT_NORDIC_NRF_SPIS_SPI_##idx##_MOSI_PIN, \
-			.miso_pin   = DT_NORDIC_NRF_SPIS_SPI_##idx##_MISO_PIN, \
-			.csn_pin    = DT_NORDIC_NRF_SPIS_SPI_##idx##_CSN_PIN,  \
+			.sck_pin    = SPIS_PROP(idx, sck_pin),		       \
+			.mosi_pin   = SPIS_PROP(idx, mosi_pin),		       \
+			.miso_pin   = SPIS_PROP(idx, miso_pin),		       \
+			.csn_pin    = SPIS_PROP(idx, csn_pin),		       \
 			.mode       = NRF_SPIS_MODE_0,			       \
 			.bit_order  = NRF_SPIS_BIT_ORDER_MSB_FIRST,	       \
 			.csn_pullup = NRF_GPIO_PIN_NOPULL,		       \
 			.miso_drive = NRF_GPIO_PIN_S0S1,		       \
 			.orc        = CONFIG_SPI_##idx##_NRF_ORC,	       \
-			.def        = DT_NORDIC_NRF_SPIS_SPI_##idx##_DEF_CHAR, \
+			.def        = SPIS_PROP(idx, def_char),		       \
 		};							       \
 		return init_spis(dev, &config);				       \
 	}								       \
@@ -278,7 +288,7 @@ static int init_spis(struct device *dev, const nrfx_spis_config_t *config)
 		.max_buf_len = (1 << SPIS##idx##_EASYDMA_MAXCNT_SIZE) - 1,     \
 	};								       \
 	DEVICE_AND_API_INIT(spi_##idx,					       \
-			    DT_NORDIC_NRF_SPIS_SPI_##idx##_LABEL,	       \
+			    DT_LABEL(SPIS(idx)),			       \
 			    spi_##idx##_init,				       \
 			    &spi_##idx##_data,				       \
 			    &spi_##idx##z_config,			       \


### PR DESCRIPTION
The SPIM driver has been converted already. Convert the SPI and SPIS
drivers too. Leave existing Kconfigs in place.
