### PR TITLE
drivers: lora: sx1276: make GPIO CS pin optional

### DIFF
--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -465,7 +465,9 @@ const struct Radio_s Radio = {
 
 static int sx1276_lora_init(struct device *dev)
 {
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	static struct spi_cs_control spi_cs;
+#endif
 	int ret;
 	u8_t regval;
 
@@ -480,6 +482,7 @@ static int sx1276_lora_init(struct device *dev)
 	dev_data.spi_cfg.frequency = DT_INST_PROP(0, spi_max_frequency);
 	dev_data.spi_cfg.slave = DT_INST_REG_ADDR(0);
 
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	spi_cs.gpio_pin = GPIO_CS_PIN,
 	spi_cs.gpio_dev = device_get_binding(
 			DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
@@ -490,6 +493,7 @@ static int sx1276_lora_init(struct device *dev)
 	}
 
 	dev_data.spi_cfg.cs = &spi_cs;
+#endif
 
 	/* Setup Reset gpio */
 	dev_data.reset = device_get_binding(


### PR DESCRIPTION
The cs-gpios pin on SPI controller is optional for SPI controllers that
can automatically control CS line.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>