### PR TITLE
drivers: bluetooth: rpmsg_nrf53: use new DT API

### DIFF
--- a/drivers/bluetooth/hci/rpmsg_nrf53.c
+++ b/drivers/bluetooth/hci/rpmsg_nrf53.c
@@ -29,7 +29,10 @@ static struct device *ipm_rx_handle;
 
 /* Configuration defines */
 
-#define SHM_START_ADDR      (DT_IPC_SHM_BASE_ADDRESS + 0x400)
+#define SHM_NODE            DT_CHOSEN(zephyr_ipc_shm)
+#define SHM_BASE_ADDRESS    DT_REG_ADDR(SHM_NODE)
+
+#define SHM_START_ADDR      (SHM_BASE_ADDRESS + 0x400)
 #define SHM_SIZE            0x7c00
 #define SHM_DEVICE_NAME     "sram0.shm"
 
@@ -39,7 +42,7 @@ static struct device *ipm_rx_handle;
 #define VRING_ALIGNMENT     4
 #define VRING_SIZE          16
 
-#define VDEV_STATUS_ADDR    DT_IPC_SHM_BASE_ADDRESS
+#define VDEV_STATUS_ADDR    SHM_BASE_ADDRESS
 
 /* End of configuration defines */
 


### PR DESCRIPTION
Use DT_CHOSEN() to access the chosen node.

I have only verified the DT_IPC_SHM_BASE_ADDRESS and SHM_BASE_ADDRESS macros expand to the same values when building samples/bluetooth/hci_rpmsg using BUILD_ASSERT(), not run this sample or done any other testing.

I can't get `west build -b nrf5340pdk_nrf5340_cpuapp  samples/bluetooth/hci_rpmsg` to link; I get this error:

```
/home/mbolivar/bin/zephyr-sdk-0.11.1/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/9.2.0/../../../../arm-zephyr-eabi/bin/ld: zephyr/libzephyr.a(rpmsg_nrf53.c.obj):/home/mbolivar/zp/zephyr/drivers/bluetooth/hci/rpmsg_nrf53.c:105: multiple definition of `dispatch'; app/libapp.a(main.c.obj):/home/mbolivar/zp/zephyr/samples/bluetooth/hci_rpmsg/src/main.c:105: first defined here
```

But this patch should be OK since it's just changing a preprocessor constant.