### PR TITLE
ci: use GH actions on 2.1 branch

### DIFF
--- a/.github/license_config.yml
+++ b/.github/license_config.yml
@@ -1,0 +1,16 @@
+license:
+  main: apache-2.0
+  report_missing: true
+  category: Permissive
+copyright:
+  check: true
+exclude:
+  extensions:
+    - yml
+    - yaml
+    - html
+    - rst
+    - conf
+    - cfg
+  langs:
+    - HTML

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -1,0 +1,65 @@
+# Copyright (c) 2020 Linaro Limited.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Documentation GitHub Workflow
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Update PATH for west
+      run: |
+        echo "::add-path::$HOME/.local/bin"
+
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - name: install-pkgs
+      run: |
+        sudo apt-get install -y ninja-build doxygen
+
+    - name: cache-pip
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-doc-pip
+
+    - name: install-pip
+      run: |
+        pip3 install setuptools
+        pip3 install 'breathe>=4.9.1,<4.15.0' 'docutils>=0.14' \
+                     'sphinx>=1.7.5,<3.0' sphinx_rtd_theme sphinx-tabs \
+                     sphinxcontrib-svg2pdfconverter 'west>=0.6.2'
+        pip3 install pyelftools
+
+    - name: west setup
+      run: |
+        west init -l . || true
+
+    - name: build-docs
+      run: |
+        source zephyr-env.sh
+        make htmldocs
+        tar cvf htmldocs.tar --directory=./doc/_build html
+
+    - name: upload-build
+      uses: actions/upload-artifact@master
+      continue-on-error: True
+      with:
+        name: htmldocs.tar
+        path: htmldocs.tar
+
+    - name: check-warns
+      run: |
+        if [ -s doc/_build/doc.warnings ]; then
+           docwarn=$(cat doc/_build/doc.warnings)
+           docwarn="${docwarn//'%'/'%25'}"
+           docwarn="${docwarn//$'\n'/'%0A'}"
+           docwarn="${docwarn//$'\r'/'%0D'}"
+           # We treat doc warnings as errors
+           echo "::error file=doc.warnings::$docwarn"
+           exit 1
+        fi

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -1,0 +1,32 @@
+name: Scancode
+
+on: [pull_request]
+
+jobs:
+  scancode_job:
+    runs-on: ubuntu-latest
+    name: Scan code for licenses
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Scan the code
+      id: scancode
+      uses: zephyrproject-rtos/action_scancode@v3
+      with:
+        directory-to-scan: 'scan/'
+    - name: Artifact Upload
+      uses: actions/upload-artifact@v1
+      with:
+        name: scancode
+        path: ./artifacts
+
+    - name: Verify
+      run: |
+        if [ -s ./artifacts/report.txt ]; then
+          report=$(cat ./artifacts/report.txt)
+          report="${report//'%'/'%25'}"
+          report="${report//$'\n'/'%0A'}"
+          report="${report//$'\r'/'%0D'}"
+          echo "::error file=./artifacts/report.txt::$report"
+          exit 1
+        fi

--- a/.known-issues/doc/bluetooth.conf
+++ b/.known-issues/doc/bluetooth.conf
@@ -48,3 +48,21 @@
 ^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
 ^.*bt_mesh_model.__unnamed__.*
 ^[- \t]*\^
+#
+# Bluetooth mesh pub struct definition
+#
+^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]bluetooth[/\\]mesh[/\\]access.rst):(?P<lineno>[0-9]+): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
+^.*bt_mesh_model_pub.*
+^[- \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
+^.*bt_mesh_model_pub.*
+^[- \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
+^.*bt_mesh_model_pub.*
+^[- \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
+^.*bt_mesh_model_pub.*
+^[- \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
+^.*bt_mesh_model_pub.*
+^[- \t]*\^

--- a/.known-issues/doc/duplicate.conf
+++ b/.known-issues/doc/duplicate.conf
@@ -1,6 +1,6 @@
 #
-^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]file_system[/\\]index.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.
+^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]file_system[/\\]index.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration(.*)
 #
-^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]peripherals[/\\]dma.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.
+^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]peripherals[/\\]dma.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration(.*)
 #
-^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]peripherals[/\\]sensor.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.
+^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]peripherals[/\\]sensor.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration(.*)

--- a/.known-issues/doc/networking.conf
+++ b/.known-issues/doc/networking.conf
@@ -67,4 +67,4 @@
 #
 # stray duplicate definition warnings
 #
-^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]networking[/\\]net_if.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.
+^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]networking[/\\]net_if.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration(.*)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,6 +14,7 @@
 # *                                        @galak @nashif
 
 /.known-issues/                           @inakypg @nashif
+/.github/                                 @nashif
 /arch/arc/                                @vonhust @ruuddw
 /arch/arm/                                @MaureenHelm @galak @ioannisg
 /arch/arm/core/cortex_m/cmse/             @ioannisg


### PR DESCRIPTION
Move doc/license checks to use actions on 2.1 branch.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>