### PR TITLE
kernel: pipe: if timeout is not K_NO_WAIT and >= min_xfer bytes transferred, then return immediately

### DIFF
--- a/tests/kernel/pipe/pipe/src/main.c
+++ b/tests/kernel/pipe/pipe/src/main.c
@@ -14,6 +14,8 @@ extern void test_pipe_get_on_empty_pipe(void);
 extern void test_pipe_forever_timeout(void);
 extern void test_pipe_get_timeout(void);
 extern void test_pipe_get_invalid_size(void);
+extern void test_pipe_get_min_xfer(void);
+extern void test_pipe_put_min_xfer(void);
 
 extern struct k_pipe test_pipe;
 extern struct k_sem put_sem, get_sem, sync_sem, multiple_send_sem;
@@ -36,7 +38,9 @@ void test_main(void)
 			 ztest_user_unit_test(test_pipe_get_on_empty_pipe),
 			 ztest_user_unit_test(test_pipe_forever_timeout),
 			 ztest_user_unit_test(test_pipe_get_timeout),
-			 ztest_user_unit_test(test_pipe_get_invalid_size)
+			 ztest_user_unit_test(test_pipe_get_invalid_size),
+			 ztest_user_unit_test(test_pipe_get_min_xfer),
+			 ztest_user_unit_test(test_pipe_put_min_xfer)
 			 );
 
 	ztest_run_test_suite(test_pipe);


### PR DESCRIPTION
If `timeout != K_NO_WAIT`, then return immediately when not all `bytes_to_read` / `bytes_to_write` have been transfered, but `>= min_xfer` have been transferred.

Fixes #24485