### PR TITLE
soc: arm: atmel_sam: Clock clean-up

### DIFF
--- a/soc/arm/atmel_sam/common/atmel_sam_dt.h
+++ b/soc/arm/atmel_sam/common/atmel_sam_dt.h
@@ -11,6 +11,8 @@
 #ifndef _ATMEL_SAM_DT_H_
 #define _ATMEL_SAM_DT_H_
 
+#include <devicetree.h>
+
 /* Devicetree related macros to construct pin mux config data */
 
 /* Get a node id from a pinctrl-0 prop at index 'i' */
@@ -42,5 +44,10 @@
 		ATMEL_SAM_PIN_2_PIO_PERIPH_ID(inst, idx),	\
 		ATMEL_SAM_PIN_PERIPH(inst, idx) << 16		\
 	}
+
+/* Devicetree macros related to clock */
+
+#define ATMEL_SAM_DT_CPU_CLK_FREQ_HZ \
+		DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
 
 #endif /* _ATMEL_SAM_SOC_DT_H_ */

--- a/soc/arm/atmel_sam/sam3x/soc.h
+++ b/soc/arm/atmel_sam/sam3x/soc.h
@@ -35,18 +35,13 @@
 #error Library does not support the specified device.
 #endif
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
-
-#define ID_UART0   ID_UART
-#define UART0      UART
-
 #include "../common/soc_pmc.h"
 #include "../common/soc_gpio.h"
 #include "../common/atmel_sam_dt.h"
 
 /** Processor Clock (HCLK) Frequency */
-#define SOC_ATMEL_SAM_HCLK_FREQ_HZ DT_ARM_CORTEX_M3_0_CLOCK_FREQUENCY
+#define SOC_ATMEL_SAM_HCLK_FREQ_HZ ATMEL_SAM_DT_CPU_CLK_FREQ_HZ
+
 /** Master Clock (MCK) Frequency */
 #define SOC_ATMEL_SAM_MCK_FREQ_HZ SOC_ATMEL_SAM_HCLK_FREQ_HZ
 

--- a/soc/arm/atmel_sam/sam4e/soc.h
+++ b/soc/arm/atmel_sam/sam4e/soc.h
@@ -39,12 +39,12 @@
 #include "../common/soc_gpio.h"
 #include "../common/atmel_sam_dt.h"
 
-#endif /* !_ASMLANGUAGE */
-
 /** Processor Clock (HCLK) Frequency */
-#define SOC_ATMEL_SAM_HCLK_FREQ_HZ DT_ARM_CORTEX_M4F_0_CLOCK_FREQUENCY
+#define SOC_ATMEL_SAM_HCLK_FREQ_HZ ATMEL_SAM_DT_CPU_CLK_FREQ_HZ
 
 /** Master Clock (MCK) Frequency */
 #define SOC_ATMEL_SAM_MCK_FREQ_HZ SOC_ATMEL_SAM_HCLK_FREQ_HZ
+
+#endif /* !_ASMLANGUAGE */
 
 #endif /* _ATMEL_SAM4E_SOC_H_ */

--- a/soc/arm/atmel_sam/sam4s/soc.h
+++ b/soc/arm/atmel_sam/sam4s/soc.h
@@ -50,12 +50,12 @@
 #include "../common/soc_gpio.h"
 #include "../common/atmel_sam_dt.h"
 
-#endif /* !_ASMLANGUAGE */
-
 /** Processor Clock (HCLK) Frequency */
-#define SOC_ATMEL_SAM_HCLK_FREQ_HZ DT_ARM_CORTEX_M4_0_CLOCK_FREQUENCY
+#define SOC_ATMEL_SAM_HCLK_FREQ_HZ ATMEL_SAM_DT_CPU_CLK_FREQ_HZ
 
 /** Master Clock (MCK) Frequency */
 #define SOC_ATMEL_SAM_MCK_FREQ_HZ SOC_ATMEL_SAM_HCLK_FREQ_HZ
+
+#endif /* !_ASMLANGUAGE */
 
 #endif /* _ATMEL_SAM4S_SOC_H_ */

--- a/soc/arm/atmel_sam/same70/soc.h
+++ b/soc/arm/atmel_sam/same70/soc.h
@@ -67,8 +67,12 @@
 #include "../common/soc_gpio.h"
 #include "../common/atmel_sam_dt.h"
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
+/** Processor Clock (HCLK) Frequency */
+#define SOC_ATMEL_SAM_HCLK_FREQ_HZ ATMEL_SAM_DT_CPU_CLK_FREQ_HZ
+
+/** Master Clock (MCK) Frequency */
+#define SOC_ATMEL_SAM_MCK_FREQ_HZ \
+	(SOC_ATMEL_SAM_HCLK_FREQ_HZ / CONFIG_SOC_ATMEL_SAME70_MDIV)
 
 #endif /* _ASMLANGUAGE */
 
@@ -116,11 +120,5 @@
 #define DMA_PERID_TC1_RX      41
 #define DMA_PERID_TC2_RX      42
 #define DMA_PERID_TC3_RX      43
-
-/** Processor Clock (HCLK) Frequency */
-#define SOC_ATMEL_SAM_HCLK_FREQ_HZ DT_ARM_CORTEX_M7_0_CLOCK_FREQUENCY
-/** Master Clock (MCK) Frequency */
-#define SOC_ATMEL_SAM_MCK_FREQ_HZ \
-		(SOC_ATMEL_SAM_HCLK_FREQ_HZ / CONFIG_SOC_ATMEL_SAME70_MDIV)
 
 #endif /* _ATMEL_SAME70_SOC_H_ */

--- a/soc/arm/atmel_sam/samv71/soc.h
+++ b/soc/arm/atmel_sam/samv71/soc.h
@@ -68,8 +68,12 @@
 #include "../common/soc_gpio.h"
 #include "../common/atmel_sam_dt.h"
 
-/* Add include for DTS generated information */
-#include <devicetree.h>
+/** Processor Clock (HCLK) Frequency */
+#define SOC_ATMEL_SAM_HCLK_FREQ_HZ ATMEL_SAM_DT_CPU_CLK_FREQ_HZ
+
+/** Master Clock (MCK) Frequency */
+#define SOC_ATMEL_SAM_MCK_FREQ_HZ \
+	(SOC_ATMEL_SAM_HCLK_FREQ_HZ / CONFIG_SOC_ATMEL_SAMV71_MDIV)
 
 #endif /* _ASMLANGUAGE */
 
@@ -126,11 +130,5 @@
 #define DMA_PERID_I2SC0_RX_R  49
 #define DMA_PERID_I2SC1_TX_R  50
 #define DMA_PERID_I2SC1_RX_R  51
-
-/** Processor Clock (HCLK) Frequency */
-#define SOC_ATMEL_SAM_HCLK_FREQ_HZ DT_ARM_CORTEX_M7_0_CLOCK_FREQUENCY
-/** Master Clock (MCK) Frequency */
-#define SOC_ATMEL_SAM_MCK_FREQ_HZ \
-		(SOC_ATMEL_SAM_HCLK_FREQ_HZ / CONFIG_SOC_ATMEL_SAMV71_MDIV)
 
 #endif /* _ATMEL_SAMV71_SOC_H_ */


### PR DESCRIPTION
Small clock clean-up. This moves all devicetree entries on SoC to atmel_sam_dt.h.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>