### PR TITLE
add alignment to high-level flash clients

### DIFF
--- a/subsys/disk/disk_access_flash.c
+++ b/subsys/disk/disk_access_flash.c
@@ -19,7 +19,7 @@
 static struct device *flash_dev;
 
 /* flash read-copy-erase-write operation */
-static u8_t read_copy_buf[CONFIG_DISK_ERASE_BLOCK_SIZE];
+static u8_t __aligned(4) read_copy_buf[CONFIG_DISK_ERASE_BLOCK_SIZE];
 static u8_t *fs_buff = read_copy_buf;
 
 /* calculate number of blocks required for a given size */

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -113,8 +113,11 @@ static volatile u32_t defered_wr_sz;
  * Keep block buffer larger than BLOCK_SIZE for the case
  * the dCBWDataTransferLength is multiple of the BLOCK_SIZE and
  * the length of the transferred data is not aligned to the BLOCK_SIZE.
+ *
+ * Align for cases where the underlying disk access requires word-aligned
+ * addresses.
  */
-static u8_t page[BLOCK_SIZE + CONFIG_MASS_STORAGE_BULK_EP_MPS];
+static u8_t __aligned(4) page[BLOCK_SIZE + CONFIG_MASS_STORAGE_BULK_EP_MPS];
 
 /* Initialized during mass_storage_init() */
 static u32_t memory_size;


### PR DESCRIPTION
The USB mass storage infrastructure uses the disk-access API with alternative underlying drivers, one of which can be flash, which can be instantiated as Nordic QSPI, which requires that data buffers be 4-byte aligned.  Add the buffer alignments necessary to allow export of QSPI-based flash file systems through the USB mass storage class.