### PR TITLE
Bluetooth: host: Add support for multiple advertising set

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -434,7 +434,16 @@ enum {
 
 /** LE Advertising Parameters. */
 struct bt_le_adv_param {
-	/** Local identity */
+	/** Local identity.
+	 *
+	 *  @note When extended advertising :option:`CONFIG_BT_EXT_ADV` is not
+	 *        enabled or not supported by the controller it is not possible
+	 *        to scan and advertise simultaneously using two different
+	 *        random addresses.
+	 *
+	 *  @note It is not possible to have multiple connectable advertising
+	 *        sets advertising simultaneously using different identities.
+	 */
 	u8_t  id;
 
 	/** Advertising Set Identifier, valid range 0x00 - 0x0f.
@@ -1038,7 +1047,7 @@ struct bt_le_oob {
  *        cases:
  *        - Creating a connection in progress, wait for the connected callback.
  *       In addition when extended advertising :option:`CONFIG_BT_EXT_ADV` is
- *       not enabled or supported by the controller:
+ *       not enabled or not supported by the controller:
  *        - Advertiser is enabled using a Random Static Identity Address for a
  *          different local identity.
  *        - The local identity conflicts with the local identity used by other

--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -622,8 +622,8 @@ struct bt_conn_cb {
 	 *    @ref bt_conn_le_create_param timeout parameter, which defaults to
 	 *    :option:`CONFIG_BT_CREATE_CONN_TIMEOUT` seconds.
 	 *  - @p BT_HCI_ERR_ADV_TIMEOUT High duty cycle directed connectable
-	 *    advertiser started by @ref bt_le_adv_start or bt_le_ext_adv_start
-	 *    failed to be connected within the timeout.
+	 *    advertiser started by @ref bt_le_adv_start failed to be connected
+	 *    within the timeout.
 	 */
 	void (*connected)(struct bt_conn *conn, u8_t err);
 

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -106,7 +106,7 @@ config BT_EXT_ADV_LEGACY_SUPPORT
 
 config BT_EXT_ADV_MAX_ADV_SET
 	int "Maximum number of simultaneous advertising sets"
-	range 1 1
+	range 1 64
 	default 1
 	help
 	  Maximum number of simultaneous Bluetooth advertising sets

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -340,9 +340,7 @@ static void conn_update_timeout(struct k_work *work)
 		/* A new reference likely to have been released here,
 		 * Resume advertising.
 		 */
-		if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
-		    atomic_test_bit(bt_dev.flags, BT_DEV_KEEP_ADVERTISING) &&
-		    !atomic_test_bit(bt_dev.flags, BT_DEV_ADVERTISING)) {
+		if (IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
 			bt_le_adv_resume();
 		}
 
@@ -1639,7 +1637,7 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 	BT_DBG("%s -> %s", state2str(conn->state), state2str(state));
 
 	if (conn->state == state) {
-		BT_WARN("no transition");
+		BT_WARN("no transition %s", state2str(state));
 		return;
 	}
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -5383,8 +5383,15 @@ static int le_set_event_mask(void)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CONN)) {
-		if (IS_ENABLED(CONFIG_BT_SMP) &&
-		    BT_FEAT_LE_PRIVACY(bt_dev.le.features)) {
+		if ((IS_ENABLED(CONFIG_BT_SMP) &&
+		     BT_FEAT_LE_PRIVACY(bt_dev.le.features)) ||
+		    (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
+		     BT_FEAT_LE_EXT_ADV(bt_dev.le.features))) {
+			/* C24:
+			 * Mandatory if the LE Controller supports Connection
+			 * State and either LE Feature (LL Privacy) or
+			 * LE Feature (Extended Advertising) is supported, ...
+			 */
 			mask |= BT_EVT_MASK_LE_ENH_CONN_COMPLETE;
 		} else {
 			mask |= BT_EVT_MASK_LE_CONN_COMPLETE;

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -33,11 +33,6 @@ enum {
 	BT_DEV_HAS_PUB_KEY,
 	BT_DEV_PUB_KEY_BUSY,
 
-	BT_DEV_ADVERTISING,
-	BT_DEV_ADVERTISING_NAME,
-	BT_DEV_ADVERTISING_CONNECTABLE,
-	BT_DEV_ADVERTISING_IDENTITY,
-	BT_DEV_KEEP_ADVERTISING,
 	BT_DEV_SCANNING,
 	BT_DEV_EXPLICIT_SCAN,
 	BT_DEV_ACTIVE_SCAN,
@@ -84,6 +79,22 @@ enum {
 	 * events, or both.
 	 */
 	BT_ADV_LIMITED,
+	/* Advertiser set is currently advertising in the controller. */
+	BT_ADV_ENABLED,
+	/* Advertiser should include name in advertising data */
+	BT_ADV_INCLUDE_NAME,
+	/* Advertiser set is connectable */
+	BT_ADV_CONNECTABLE,
+	/* Advertiser set has disabled the use of private addresses and is using
+	 * the identity address instead.
+	 */
+	BT_ADV_USE_IDENTITY,
+	/* Advertiser has been configured to keep advertising after a connection
+	 * has been established as long as there are connections available.
+	 */
+	BT_ADV_PERSIST,
+	/* Advertiser has been temporarily disabled. */
+	BT_ADV_PAUSED,
 
 	BT_ADV_NUM_FLAGS,
 };
@@ -153,7 +164,7 @@ struct bt_dev_br {
 /* State tracking for the local Bluetooth controller */
 struct bt_dev {
 	/* Local Identity Address(es) */
-	bt_addr_le_t		id_addr[CONFIG_BT_ID_MAX];
+	bt_addr_le_t            id_addr[CONFIG_BT_ID_MAX];
 	u8_t                    id_count;
 
 	struct bt_conn_le_create_param create_param;
@@ -167,6 +178,7 @@ struct bt_dev {
 #endif
 	/* Current local Random Address */
 	bt_addr_le_t            random_addr;
+	u8_t                    adv_conn_id;
 
 	/* Controller version & manufacturer information */
 	u8_t			hci_version;

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1045,6 +1045,7 @@ static int cmd_adv_start(const struct shell *shell, size_t argc, char *argv[])
 	int err;
 
 	if (!adv) {
+		shell_print(shell, "Advertiser[%d] not created", selected_adv);
 		return -EINVAL;
 	}
 
@@ -1091,6 +1092,7 @@ static int cmd_adv_stop(const struct shell *shell, size_t argc, char *argv[])
 	int err;
 
 	if (!adv) {
+		shell_print(shell, "Advertiser[%d] not created", selected_adv);
 		return -EINVAL;
 	}
 
@@ -1110,6 +1112,7 @@ static int cmd_adv_delete(const struct shell *shell, size_t argc, char *argv[])
 	int err;
 
 	if (!adv) {
+		shell_print(shell, "Advertiser[%d] not created", selected_adv);
 		return -EINVAL;
 	}
 
@@ -2296,7 +2299,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 				      "<type: discov, name, hex>", cmd_adv_data,
 		      1, 16),
 	SHELL_CMD_ARG(adv-start, NULL, "[timeout] [num_events]", cmd_adv_start,
-		      1, 2),
+		      1, 4),
 	SHELL_CMD_ARG(adv-stop, NULL, "", cmd_adv_stop, 1, 0),
 	SHELL_CMD_ARG(adv-delete, NULL, "", cmd_adv_delete, 1, 0),
 	SHELL_CMD_ARG(adv-select, NULL, "[adv]", cmd_adv_select, 1, 1),


### PR DESCRIPTION
Add support for multiple advertising set. Move the advertising state
flags to be per advertising set and loop over advertising sets instead
of looking up legacy advertiser set or handle 0.

Since it is not certain that the advertising set terminated event can
arrive directly after the connection complete event there is currently
a limitation that there can only be one local identity used by
connectable advertisers at a time. This guarantees that we know
the local identity being used in the connection complete event.

Only attempt to restart the background scanner in connection complete
event when the new connection is a master role connection or the
initiator was successfully canceled.

Enable enhanced connection complete when extended advertising has been
enabled. This event is mandatory if extended advertising is supported.