### PR TITLE
lwm2m: init messages, pendings and replies on lwm2m_engine_start

### DIFF
--- a/include/net/coap.h
+++ b/include/net/coap.h
@@ -769,12 +769,29 @@ bool coap_pending_cycle(struct coap_pending *pending);
 void coap_pending_clear(struct coap_pending *pending);
 
 /**
+ * @brief Cancels all pending retransmissions, so they become
+ * available again.
+ *
+ * @param pendings Pointer to the array of #coap_pending structures
+ * @param len Size of the array of #coap_pending structures
+ */
+void coap_pendings_clear(struct coap_pending *pendings, size_t len);
+
+/**
  * @brief Cancels awaiting for this reply, so it becomes available
  * again. User responsibility to free the memory associated with data.
  *
  * @param reply The reply to be canceled
  */
 void coap_reply_clear(struct coap_reply *reply);
+
+/**
+ * @brief Cancels all replies, so they become available again.
+ *
+ * @param replies Pointer to the array of #coap_reply structures
+ * @param len Size of the array of #coap_reply structures
+ */
+void coap_replies_clear(struct coap_reply *replies, size_t len);
 
 /**
  * @brief Indicates that this resource was updated and that the @a

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1226,6 +1226,16 @@ void coap_pending_clear(struct coap_pending *pending)
 	pending->data = NULL;
 }
 
+void coap_pendings_clear(struct coap_pending *pendings, size_t len)
+{
+	struct coap_pending *p;
+	size_t i;
+
+	for (i = 0, p = pendings; i < len; i++, p++) {
+		coap_pending_clear(p);
+	}
+}
+
 static int get_observe_option(const struct coap_packet *cpkt)
 {
 	struct coap_option option = {};
@@ -1316,6 +1326,16 @@ void coap_reply_init(struct coap_reply *reply,
 void coap_reply_clear(struct coap_reply *reply)
 {
 	(void)memset(reply, 0, sizeof(*reply));
+}
+
+void coap_replies_clear(struct coap_reply *replies, size_t len)
+{
+	struct coap_reply *r;
+	size_t i;
+
+	for (i = 0, r = replies; i < len; i++, r++) {
+		coap_reply_clear(r);
+	}
 }
 
 int coap_resource_notify(struct coap_resource *resource)

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -4005,6 +4005,8 @@ int lwm2m_engine_context_close(struct lwm2m_ctx *client_ctx)
 	struct observe_node *obs, *tmp;
 	sys_snode_t *prev_node = NULL;
 	int sock_fd = client_ctx->sock_fd;
+	struct lwm2m_message *msg;
+	size_t i;
 
 	/* Cancel pending retransmit work */
 	k_delayed_work_cancel(&client_ctx->retransmit_work);
@@ -4020,6 +4022,16 @@ int lwm2m_engine_context_close(struct lwm2m_ctx *client_ctx)
 			prev_node = &obs->node;
 		}
 	}
+
+	for (i = 0, msg = messages; i < CONFIG_LWM2M_ENGINE_MAX_MESSAGES;
+	     i++, msg++) {
+		memset(msg, 0, sizeof(struct lwm2m_message));
+	}
+
+	coap_pendings_clear(client_ctx->pendings,
+			    CONFIG_LWM2M_ENGINE_MAX_PENDING);
+	coap_replies_clear(client_ctx->replies,
+			   CONFIG_LWM2M_ENGINE_MAX_REPLIES);
 
 	lwm2m_socket_del(client_ctx);
 	client_ctx->sock_fd = -1;


### PR DESCRIPTION
On network with poor coverage, very often request/observe packets doesn't get it's ACK and consumes from pendings/replies/message stacks. In such cases when LWM2M engine tries to recover by resetting its state, it fails because of lack of free messages.

Signed-off-by: Kiril Petrov <retfie@gmail.com>