### PR TITLE
[RFC] TCP2: Handle FIN_WAIT_1 state

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -951,6 +951,9 @@ next_state:
 	case TCP_FIN_WAIT_1:
 		if (th && FL(&fl, ==, (FIN | ACK), th_seq(th) == conn->ack)) {
 			tcp_send_timer_cancel(conn);
+			conn_seq(conn, + 1);
+			conn_ack(conn, + 1);
+			tcp_out(conn, ACK);
 			next = TCP_TIME_WAIT;
 		}
 		break;
@@ -984,9 +987,9 @@ int net_tcp_put(struct net_context *context)
 	NET_DBG("%s", conn ? log_strdup(tcp_conn_state(conn, NULL)) : "");
 
 	if (conn) {
-		tcp_out(conn, FIN | ACK);
-
 		conn_state(conn, TCP_FIN_WAIT_1);
+
+		tcp_out(conn, FIN | ACK);
 	}
 
 	net_context_unref(context);

--- a/tests/net/tcp2/src/main.c
+++ b/tests/net/tcp2/src/main.c
@@ -412,8 +412,13 @@ static void handle_client_test(sa_family_t af, struct tcphdr *th)
 		test_sem_give();
 		break;
 	case T_FIN:
+		ack = ntohs(th->th_seq) + 1U;
+		t_state = T_FIN_ACK;
+		reply = prepare_fin_ack_packet(af, htons(MY_PORT),
+					       th->th_sport);
+		break;
+	case T_FIN_ACK:
 		test_sem_give();
-		/* TODO in TCP2: it sends FIN, but doesn't wait for FIN | ACK */
 		return;
 	default:
 		zassert_true(false, "%s unexpected state", __func__);


### PR DESCRIPTION
When TCP client sends FIN and ACK, then it goes to FIN_WAIT_1 state and wait for FIN, ACK response. If stack receives FIN and ACK then sends back ACK and goes to TIME_WAIT STATE. After timeout it releases the context.

This PR does not handle following cases.
   1) In FIN_WAIT_1 state, if it receives only FIN, then it has to go CLOSING.
   2) In FIN_WAIT_1 state, if it receives only ACK, then it has to go FIN_WAIT_2.