### PR TITLE
NXP: Configure NXP Kinetis FlexTimer DTS nodes for PWM on board level

### DIFF
--- a/boards/arm/frdm_k22f/frdm_k22f.dts
+++ b/boards/arm/frdm_k22f/frdm_k22f.dts
@@ -109,6 +109,8 @@ arduino_spi: &spi0 {
 
 &ftm3 {
 	status = "okay";
+	compatible = "nxp,kinetis-ftm-pwm";
+	#pwm-cells = <3>;
 };
 
 &uart1 {

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -126,6 +126,8 @@ arduino_spi: &spi0 {
 
 &ftm3 {
 	status = "okay";
+	compatible = "nxp,kinetis-ftm-pwm";
+	#pwm-cells = <3>;
 };
 
 &uart0 {

--- a/boards/arm/frdm_k64f/pinmux.c
+++ b/boards/arm/frdm_k64f/pinmux.c
@@ -122,7 +122,8 @@ static int frdm_k64f_pinmux_init(struct device *dev)
 	pinmux_pin_set(portb, 10, PORT_PCR_MUX(kPORT_PinDisabledOrAnalog));
 #endif
 
-#if DT_HAS_NODE(DT_NODELABEL(ftm3))
+#if DT_HAS_NODE(DT_NODELABEL(ftm3)) && \
+    DT_NODE_HAS_COMPAT(DT_NODELABEL(ftm3), nxp_kinetis_ftm_pwm)
 	pinmux_pin_set(portc,  8, PORT_PCR_MUX(kPORT_MuxAlt3));
 	pinmux_pin_set(portc,  9, PORT_PCR_MUX(kPORT_MuxAlt3));
 #endif

--- a/boards/arm/frdm_k82f/frdm_k82f.dts
+++ b/boards/arm/frdm_k82f/frdm_k82f.dts
@@ -177,6 +177,8 @@
 
 &ftm3 {
 	status = "okay";
+	compatible = "nxp,kinetis-ftm-pwm";
+	#pwm-cells = <3>;
 };
 
 &spi1 {

--- a/boards/arm/frdm_k82f/pinmux.c
+++ b/boards/arm/frdm_k82f/pinmux.c
@@ -33,7 +33,8 @@ static int frdm_k82f_pinmux_init(struct device *dev)
 		device_get_binding(CONFIG_PINMUX_MCUX_PORTE_NAME);
 #endif
 
-#if DT_HAS_NODE(DT_NODELABEL(ftm3))
+#if DT_HAS_NODE(DT_NODELABEL(ftm3)) && \
+    DT_NODE_HAS_COMPAT(DT_NODELABEL(ftm3), nxp_kinetis_ftm_pwm)
 	/* Red, green, blue LEDs as PWM channels */
 	pinmux_pin_set(portc,  8, PORT_PCR_MUX(kPORT_MuxAlt3));
 	pinmux_pin_set(portc,  9, PORT_PCR_MUX(kPORT_MuxAlt3));

--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -73,6 +73,8 @@
 
 &ftm3 {
 	status = "okay";
+	compatible = "nxp,kinetis-ftm-pwm";
+	#pwm-cells = <3>;
 };
 
 &i2c0 {

--- a/boards/arm/hexiwear_k64/pinmux.c
+++ b/boards/arm/hexiwear_k64/pinmux.c
@@ -30,7 +30,8 @@ static int hexiwear_k64_pinmux_init(struct device *dev)
 		device_get_binding(CONFIG_PINMUX_MCUX_PORTE_NAME);
 #endif
 
-#if DT_HAS_NODE(DT_NODELABEL(ftm3))
+#if DT_HAS_NODE(DT_NODELABEL(ftm3)) && \
+    DT_NODE_HAS_COMPAT(DT_NODELABEL(ftm3), nxp_kinetis_ftm_pwm)
 	/* Red, green, blue LEDs as PWM channels */
 	pinmux_pin_set(portc,  8, PORT_PCR_MUX(kPORT_MuxAlt3));
 	pinmux_pin_set(portc,  9, PORT_PCR_MUX(kPORT_MuxAlt3));

--- a/boards/arm/twr_ke18f/pinmux.c
+++ b/boards/arm/twr_ke18f/pinmux.c
@@ -34,7 +34,8 @@ static int twr_ke18f_pinmux_init(struct device *dev)
 		device_get_binding(CONFIG_PINMUX_MCUX_PORTE_NAME);
 #endif
 
-#if DT_HAS_NODE(DT_NODELABEL(ftm0))
+#if DT_HAS_NODE(DT_NODELABEL(ftm0)) && \
+    DT_NODE_HAS_COMPAT(DT_NODELABEL(ftm0), nxp_kinetis_ftm_pwm)
 	/* Tri-color LED as PWM */
 	pinmux_pin_set(portb, 5, PORT_PCR_MUX(kPORT_MuxAlt2));
 	pinmux_pin_set(portd, 15, PORT_PCR_MUX(kPORT_MuxAlt2));
@@ -46,7 +47,8 @@ static int twr_ke18f_pinmux_init(struct device *dev)
 	pinmux_pin_set(portd, 16, PORT_PCR_MUX(kPORT_MuxAsGpio));
 #endif
 
-#if DT_HAS_NODE(DT_NODELABEL(ftm3))
+#if DT_HAS_NODE(DT_NODELABEL(ftm3)) && \
+    DT_NODE_HAS_COMPAT(DT_NODELABEL(ftm3), nxp_kinetis_ftm_pwm)
 	/* User LEDs as PWM */
 	pinmux_pin_set(portc, 10, PORT_PCR_MUX(kPORT_MuxAlt2));
 	pinmux_pin_set(portc, 11, PORT_PCR_MUX(kPORT_MuxAlt2));

--- a/boards/arm/twr_ke18f/twr_ke18f.dts
+++ b/boards/arm/twr_ke18f/twr_ke18f.dts
@@ -162,10 +162,14 @@
 
 &ftm0 {
 	status = "okay";
+	compatible = "nxp,kinetis-ftm-pwm";
+	#pwm-cells = <3>;
 };
 
 &ftm3 {
 	status = "okay";
+	compatible = "nxp,kinetis-ftm-pwm";
+	#pwm-cells = <3>;
 };
 
 &lpi2c0 {

--- a/boards/arm/usb_kw24d512/usb_kw24d512.dts
+++ b/boards/arm/usb_kw24d512/usb_kw24d512.dts
@@ -55,8 +55,10 @@
 	status = "okay";
 };
 
-&pwm1 {
+&ftm1 {
 	status = "okay";
+	compatible = "nxp,kinetis-ftm-pwm";
+	#pwm-cells = <3>;
 };
 
 &uart0 {

--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT nxp_kinetis_ftm
+#define DT_DRV_COMPAT nxp_kinetis_ftm_pwm
 
 #include <drivers/clock_control.h>
 #include <errno.h>

--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -25,10 +25,6 @@
 		pinmux-c = &portc;
 		pinmux-d = &portd;
 		pinmux-e = &porte;
-		pwm-0 = &ftm0;
-		pwm-1 = &ftm1;
-		pwm-2 = &ftm2;
-		pwm-3 = &ftm3;
 		spi-0 = &spi0;
 		spi-1 = &spi1;
 		uart-0 = &uart0;
@@ -308,40 +304,36 @@
 			label = "WDT_0";
 		};
 
-		ftm0: pwm@40038000{
+		ftm0: ftm@40038000{
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40038000 0x98>;
 			interrupts = <42 0>;
-			label = "PWM_0";
+			label = "FTM_0";
 			status = "disabled";
-			#pwm-cells = <3>;
 		};
 
-		ftm1: pwm@40039000{
+		ftm1: ftm@40039000{
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40039000 0x98>;
 			interrupts = <43 0>;
-			label = "PWM_1";
+			label = "FTM_1";
 			status = "disabled";
-			#pwm-cells = <3>;
 		};
 
-		ftm2: pwm@4003a000{
+		ftm2: ftm@4003a000{
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x4003a000 0x98>;
 			interrupts = <44 0>;
-			label = "PWM_2";
+			label = "FTM_2";
 			status = "disabled";
-			#pwm-cells = <3>;
 		};
 
-		ftm3: pwm@400b9000{
+		ftm3: ftm@400b9000{
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x400b9000 0x98>;
 			interrupts = <71 0>;
-			label = "PWM_3";
+			label = "FTM_3";
 			status = "disabled";
-			#pwm-cells = <3>;
 		};
 
 		adc0: adc@4003b000{

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -25,10 +25,6 @@
 		pinmux-c = &portc;
 		pinmux-d = &portd;
 		pinmux-e = &porte;
-		pwm-0 = &ftm0;
-		pwm-1 = &ftm1;
-		pwm-2 = &ftm2;
-		pwm-3 = &ftm3;
 		spi-0 = &spi0;
 		spi-1 = &spi1;
 		spi-2 = &spi2;
@@ -387,44 +383,40 @@
 			label = "WDT_0";
 		};
 
-		ftm0: pwm@40038000{
+		ftm0: ftm@40038000{
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40038000 0x98>;
 			interrupts = <42 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
-			label = "PWM_0";
+			label = "FTM_0";
 			status = "disabled";
-			#pwm-cells = <3>;
 		};
 
-		ftm1: pwm@40039000{
+		ftm1: ftm@40039000{
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40039000 0x98>;
 			interrupts = <43 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
-			label = "PWM_1";
+			label = "FTM_1";
 			status = "disabled";
-			#pwm-cells = <3>;
 		};
 
-		ftm2: pwm@4003a000{
+		ftm2: ftm@4003a000{
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x4003a000 0x98>;
 			interrupts = <44 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
-			label = "PWM_2";
+			label = "FTM_2";
 			status = "disabled";
-			#pwm-cells = <3>;
 		};
 
-		ftm3: pwm@400b9000{
+		ftm3: ftm@400b9000{
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x400b9000 0x98>;
 			interrupts = <71 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
-			label = "PWM_3";
+			label = "FTM_3";
 			status = "disabled";
-			#pwm-cells = <3>;
 		};
 
 		adc0: adc@4003b000{

--- a/dts/arm/nxp/nxp_k8x.dtsi
+++ b/dts/arm/nxp/nxp_k8x.dtsi
@@ -22,10 +22,6 @@
 		pinmux-c = &portc;
 		pinmux-d = &portd;
 		pinmux-e = &porte;
-		pwm-0 = &ftm0;
-		pwm-1 = &ftm1;
-		pwm-2 = &ftm2;
-		pwm-3 = &ftm3;
 		spi-0 = &spi0;
 		spi-1 = &spi1;
 		spi-2 = &spi2;
@@ -278,44 +274,40 @@
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
 		};
 
-		ftm0: pwm@40038000 {
+		ftm0: ftm@40038000 {
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40038000 0x1000>;
 			interrupts = <42 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
-			label = "PWM_0";
+			label = "FTM_0";
 			status = "disabled";
-			#pwm-cells = <3>;
 		};
 
-		ftm1: pwm@40039000 {
+		ftm1: ftm@40039000 {
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40039000 0x1000>;
 			interrupts = <43 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
-			label = "PWM_1";
+			label = "FTM_1";
 			status = "disabled";
-			#pwm-cells = <3>;
 		};
 
-		ftm2: pwm@4003a000 {
+		ftm2: ftm@4003a000 {
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x4003a000 0x1000>;
 			interrupts = <44 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
-			label = "PWM_2";
+			label = "FTM_2";
 			status = "disabled";
-			#pwm-cells = <3>;
 		};
 
-		ftm3: pwm@400b9000 {
+		ftm3: ftm@400b9000 {
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x400b9000 0x1000>;
 			interrupts = <71 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
-			label = "PWM_3";
+			label = "FTM_3";
 			status = "disabled";
-			#pwm-cells = <3>;
 		};
 
 		rtc: rtc@4003d000 {

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -33,10 +33,6 @@
 		adc-0 = &adc0;
 		adc-1 = &adc1;
 		adc-2 = &adc2;
-		pwm-0 = &ftm0;
-		pwm-1 = &ftm1;
-		pwm-2 = &ftm2;
-		pwm-3 = &ftm3;
 	};
 
 	chosen {
@@ -403,43 +399,39 @@
 			#io-channel-cells = <1>;
 		};
 
-		ftm0: pwm@40038000 {
+		ftm0: ftm@40038000 {
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40038000 0x1000>;
 			interrupts = <42 0>;
 			clocks = <&pcc 0xe0 KINETIS_PCC_SRC_FIRC_ASYNC>;
-			label = "PWM_0";
-			#pwm-cells = <3>;
+			label = "FTM_0";
 			status = "disabled";
 		};
 
-		ftm1: pwm@40039000 {
+		ftm1: ftm@40039000 {
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40039000 0x1000>;
 			interrupts = <43 0>;
 			clocks = <&pcc 0xe4 KINETIS_PCC_SRC_FIRC_ASYNC>;
-			label = "PWM_1";
-			#pwm-cells = <3>;
+			label = "FTM_1";
 			status = "disabled";
 		};
 
-		ftm2: pwm@4003a000 {
+		ftm2: ftm@4003a000 {
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x4003a000 0x1000>;
 			interrupts = <44 0>;
 			clocks = <&pcc 0xe8 KINETIS_PCC_SRC_FIRC_ASYNC>;
-			label = "PWM_2";
-			#pwm-cells = <3>;
+			label = "FTM_2";
 			status = "disabled";
 		};
 
-		ftm3: pwm@40026000 {
+		ftm3: ftm@40026000 {
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40026000 0x1000>;
 			interrupts = <71 0>;
 			clocks = <&pcc 0x98 KINETIS_PCC_SRC_FIRC_ASYNC>;
-			label = "PWM_3";
-			#pwm-cells = <3>;
+			label = "FTM_3";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nxp/nxp_kv5x.dtsi
+++ b/dts/arm/nxp/nxp_kv5x.dtsi
@@ -19,10 +19,6 @@
 		pinmux-c = &portc;
 		pinmux-d = &portd;
 		pinmux-e = &porte;
-		pwm-1 = &ftm0;
-		pwm-2 = &ftm1;
-		pwm-3 = &ftm2;
-		pwm-4 = &ftm3;
 		spi-0 = &spi0;
 		spi-1 = &spi1;
 		spi-2 = &spi2;
@@ -203,40 +199,36 @@
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
 		};
 
-		ftm0: pwm@40038000 {
+		ftm0: ftm@40038000 {
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40038000 0x1000>;
 			interrupts = <42 0>;
 			label = "FTM_0";
 			status = "disabled";
-			#pwm-cells = <3>;
 		};
 
-		ftm1: pwm@40039000 {
+		ftm1: ftm@40039000 {
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40039000 0x1000>;
 			interrupts = <43 0>;
 			label = "FTM_1";
 			status = "disabled";
-			#pwm-cells = <3>;
 		};
 
-		ftm2: pwm@4003a000 {
+		ftm2: ftm@4003a000 {
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x4003a000 0x1000>;
 			interrupts = <53 0>;
 			label = "FTM_2";
 			status = "disabled";
-			#pwm-cells = <3>;
 		};
 
-		ftm3: pwm@40026000 {
+		ftm3: ftm@40026000 {
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40026000 0x1000>;
 			interrupts = <71 0>;
 			label = "FTM_3";
 			status = "disabled";
-			#pwm-cells = <3>;
 		};
 
 		spi0: spi@4002c000 {

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -16,9 +16,6 @@
 		pinmux-c = &pinmux_c;
 		pinmux-d = &pinmux_d;
 		pinmux-e = &pinmux_e;
-		pwm-0 = &pwm0;
-		pwm-1 = &pwm1;
-		pwm-2 = &pwm2;
 		spi-0 = &spi0;
 		spi-1 = &spi1;
 		uart-0 = &uart0;
@@ -280,34 +277,31 @@
 			label = "WDT_0";
 		};
 
-		pwm0: pwm@40038000{
+		ftm0: ftm@40038000{
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40038000 0x98>;
 			interrupts = <42 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
-			label = "PWM_0";
+			label = "FTM_0";
 			status = "disabled";
-			#pwm-cells = <3>;
 		};
 
-		pwm1: pwm@40039000{
+		ftm1: ftm@40039000{
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40039000 0x98>;
 			interrupts = <43 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
-			label = "PWM_1";
+			label = "FTM_1";
 			status = "disabled";
-			#pwm-cells = <3>;
 		};
 
-		pwm2: pwm@4003a000{
+		ftm2: ftm@4003a000{
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x4003a000 0x98>;
 			interrupts = <44 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
-			label = "PWM_2";
+			label = "FTM_2";
 			status = "disabled";
-			#pwm-cells = <3>;
 		};
 
 		adc0: adc@4003b000{

--- a/dts/bindings/arm/nxp,kinetis-ftm.yaml
+++ b/dts/bindings/arm/nxp,kinetis-ftm.yaml
@@ -5,7 +5,7 @@ description: Kinetis FTM
 
 compatible: "nxp,kinetis-ftm"
 
-include: [pwm-controller.yaml, base.yaml]
+include: base.yaml
 
 properties:
     reg:
@@ -13,12 +13,3 @@ properties:
 
     interrupts:
       required: true
-
-    "#pwm-cells":
-      const: 3
-
-pwm-cells:
-  - channel
-# period in terms of nanoseconds
-  - period
-  - flags

--- a/dts/bindings/pwm/nxp,kinetis-ftm-pwm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-ftm-pwm.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2017, NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: Kinetis FTM PWM
+
+compatible: "nxp,kinetis-ftm-pwm"
+
+include: [pwm-controller.yaml, "nxp,kinetis-ftm.yaml"]
+
+properties:
+    "#pwm-cells":
+      const: 3
+
+pwm-cells:
+  - channel
+# period in terms of nanoseconds
+  - period
+  - flags


### PR DESCRIPTION
Don't assume in the soc level device trees that FlexTimer nodes will always be configured as PWM. Instead, configure FlexTimer nodes for PWM at the board level for NXP Kinetis boards.

The NXP Kinetis FlexTimer IP can be configured as PWM controller, counter,
quadrature decoder, pulse-width measurements and more. Zephyr currently only has support for PWM. This PR is preparation for introduction of Zephyr support for other FlexTimer functionality.

