### PR TITLE
sanitycheck: fix initial types in classes and minor cleanup

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -1258,11 +1258,15 @@ class Platform:
         return "<%s on %s>" % (self.name, self.arch)
 
 
-class TestCase(object):
+class DisablePyTestCollectionMixin(object):
+    __test__ = False
+
+
+class TestCase(DisablePyTestCollectionMixin):
     """Class representing a test application
     """
 
-    def __init__(self):
+    def __init__(self, testcase_root, workdir, name):
         """TestCase constructor.
 
         This gets called by TestSuite as it finds and reads test yaml files.
@@ -1281,23 +1285,22 @@ class TestCase(object):
             define one test, can be anything and is usually "test". This is
             really only used to distinguish between different cases when
             the testcase.yaml defines multiple tests
-        @param tc_dict Dictionary with test values for this test case
-            from the testcase.yaml file
         """
 
-        self.id = ""
+
         self.source_dir = ""
         self.yamlfile = ""
         self.cases = []
-        self.name = ""
+        self.name = self.get_unique(testcase_root, workdir, name)
+        self.id = name
 
         self.type = None
-        self.tags = None
+        self.tags = set()
         self.extra_args = None
         self.extra_configs = None
         self.arch_whitelist = None
         self.arch_exclude = None
-        self.skip = None
+        self.skip = False
         self.platform_exclude = None
         self.platform_whitelist = None
         self.toolchain_exclude = None
@@ -1309,9 +1312,9 @@ class TestCase(object):
         self.build_only = True
         self.build_on_all = False
         self.slow = False
-        self.min_ram = None
+        self.min_ram = -1
         self.depends_on = None
-        self.min_flash = None
+        self.min_flash = -1
         self.extra_sections = None
 
     @staticmethod
@@ -1430,7 +1433,7 @@ class TestCase(object):
         return self.name
 
 
-class TestInstance:
+class TestInstance(DisablePyTestCollectionMixin):
     """Class representing the execution of a particular TestCase on a platform
 
     @param test The TestCase object we want to build/execute
@@ -1461,6 +1464,7 @@ class TestInstance:
     def __lt__(self, other):
         return self.name < other.name
 
+    # Global testsuite parameters
     def check_build_or_run(self, build_only=False, enable_slow=False, device_testing=False, fixture=[]):
 
         # right now we only support building on windows. running is still work
@@ -2105,7 +2109,7 @@ class BoundedExecutor(concurrent.futures.ThreadPoolExecutor):
             return future
 
 
-class TestSuite:
+class TestSuite(DisablePyTestCollectionMixin):
     config_re = re.compile('(CONFIG_[A-Za-z0-9_]+)[=]\"?([^\"]*)\"?$')
     dt_re = re.compile('([A-Za-z0-9_]+)[=]\"?([^\"]*)\"?$')
 
@@ -2140,7 +2144,7 @@ class TestSuite:
     RELEASE_DATA = os.path.join(ZEPHYR_BASE, "scripts", "sanity_chk",
                             "sanity_last_release.csv")
 
-    def __init__(self, board_root_list, testcase_roots, outdir):
+    def __init__(self, board_root_list=[], testcase_roots=[], outdir=None):
 
         self.roots = testcase_roots
         if not isinstance(board_root_list, list):
@@ -2174,7 +2178,7 @@ class TestSuite:
         self.selected_platforms = []
         self.default_platforms = []
         self.outdir = os.path.abspath(outdir)
-        self.discards = None
+        self.discards = {}
         self.load_errors = 0
         self.instances = dict()
 
@@ -2418,15 +2422,13 @@ class TestSuite:
                     workdir = os.path.relpath(tc_path, root)
 
                     for name in parsed_data.tests.keys():
-                        tc = TestCase()
-                        tc.name = tc.get_unique(root, workdir, name)
+                        tc = TestCase(root, workdir, name)
 
                         tc_dict = parsed_data.get_test(name, self.testcase_valid_keys)
 
                         tc.source_dir = tc_path
                         tc.yamlfile = tc_path
 
-                        tc.id = name
                         tc.type = tc_dict["type"]
                         tc.tags = tc_dict["tags"]
                         tc.extra_args = tc_dict["extra_args"]
@@ -2507,8 +2509,8 @@ class TestSuite:
 
         discards = {}
         platform_filter = kwargs.get('platform')
-        exclude_platform = kwargs.get('exclude_platform')
-        testcase_filter = kwargs.get('run_individual_tests')
+        exclude_platform = kwargs.get('exclude_platform', [])
+        testcase_filter = kwargs.get('run_individual_tests', [])
         arch_filter = kwargs.get('arch')
         tag_filter = kwargs.get('tag')
         exclude_tag = kwargs.get('exclude_tag')
@@ -2664,7 +2666,7 @@ class TestSuite:
                     instances = list(filter(lambda tc: tc.platform.default, instance_list))
                     self.add_instances(instances)
 
-                for instance in list(filter(lambda tc: not tc.platform.default, instance_list)):
+                for instance in list(filter(lambda inst: not inst.platform.default, instance_list)):
                     discards[instance] = "Not a default test platform"
 
             else:


### PR DESCRIPTION
While testing sanitycheck classes, found some wrongly initialisized
variables which caused issues, fixed those..

All Test* classes should now be ignored by pytest and should not be
treated as pytest code.