### PR TITLE
Bluetooth: Mesh: Remove net_idx params when with app key

### DIFF
--- a/doc/releases/release-notes-2.3.rst
+++ b/doc/releases/release-notes-2.3.rst
@@ -51,7 +51,6 @@ Removed APIs in this release
 Stable API changes in this release
 ==================================
 
-
 Kernel
 ******
 

--- a/doc/releases/release-notes-2.3.rst
+++ b/doc/releases/release-notes-2.3.rst
@@ -51,6 +51,11 @@ Removed APIs in this release
 Stable API changes in this release
 ==================================
 
+* Bluetooth Mesh
+
+  * The net_idx parameter has been removed from the Health Client model
+    APIs since it can be derived (by the stack) from the app_idx parameter
+
 Kernel
 ******
 

--- a/include/bluetooth/mesh/health_cli.h
+++ b/include/bluetooth/mesh/health_cli.h
@@ -74,7 +74,6 @@ int bt_mesh_health_cli_set(struct bt_mesh_model *model);
  *
  *  @see bt_mesh_health_faults
  *
- *  @param net_idx     Network index to encrypt with.
  *  @param addr        Target node element address.
  *  @param app_idx     Application index to encrypt with.
  *  @param cid         Company ID to get the registered faults of.
@@ -84,15 +83,14 @@ int bt_mesh_health_cli_set(struct bt_mesh_model *model);
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_health_fault_get(u16_t net_idx, u16_t addr, u16_t app_idx,
-			     u16_t cid, u8_t *test_id, u8_t *faults,
-			     size_t *fault_count);
+int bt_mesh_health_fault_get(u16_t addr, u16_t app_idx, u16_t cid,
+				 u8_t *test_id, u8_t *faults,
+				 size_t *fault_count);
 
 /** @brief Clear the registered faults for the given Company ID.
  *
  *  @see bt_mesh_health_faults
  *
- *  @param net_idx     Network index to encrypt with.
  *  @param addr        Target node element address.
  *  @param app_idx     Application index to encrypt with.
  *  @param cid         Company ID to clear the registered faults for.
@@ -102,13 +100,12 @@ int bt_mesh_health_fault_get(u16_t net_idx, u16_t addr, u16_t app_idx,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_health_fault_clear(u16_t net_idx, u16_t addr, u16_t app_idx,
-			       u16_t cid, u8_t *test_id, u8_t *faults,
-			       size_t *fault_count);
+int bt_mesh_health_fault_clear(u16_t addr, u16_t app_idx, u16_t cid,
+				 u8_t *test_id, u8_t *faults,
+				 size_t *fault_count);
 
 /** @brief Invoke a self-test procedure for the given Company ID.
  *
- *  @param net_idx     Network index to encrypt with.
  *  @param addr        Target node element address.
  *  @param app_idx     Application index to encrypt with.
  *  @param cid         Company ID to invoke the test for.
@@ -118,9 +115,9 @@ int bt_mesh_health_fault_clear(u16_t net_idx, u16_t addr, u16_t app_idx,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_health_fault_test(u16_t net_idx, u16_t addr, u16_t app_idx,
-			      u16_t cid, u8_t test_id, u8_t *faults,
-			      size_t *fault_count);
+int bt_mesh_health_fault_test(u16_t addr, u16_t app_idx, u16_t cid,
+				 u8_t test_id, u8_t *faults,
+				 size_t *fault_count);
 
 /** @brief Get the target node's Health fast period divisor.
  *
@@ -132,15 +129,13 @@ int bt_mesh_health_fault_test(u16_t net_idx, u16_t addr, u16_t app_idx,
  *  Health fast period divisor is 5, the Health server will publish with an
  *  interval of 500 ms when a fault is registered.
  *
- *  @param net_idx Network index to encrypt with.
  *  @param addr    Target node element address.
  *  @param app_idx Application index to encrypt with.
  *  @param divisor Health period divisor response buffer.
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_health_period_get(u16_t net_idx, u16_t addr, u16_t app_idx,
-			      u8_t *divisor);
+int bt_mesh_health_period_get(u16_t addr, u16_t app_idx, u8_t *divisor);
 
 /** @brief Set the target node's Health fast period divisor.
  *
@@ -152,7 +147,6 @@ int bt_mesh_health_period_get(u16_t net_idx, u16_t addr, u16_t app_idx,
  *  Health fast period divisor is 5, the Health server will publish with an
  *  interval of 500 ms when a fault is registered.
  *
- *  @param net_idx         Network index to encrypt with.
  *  @param addr            Target node element address.
  *  @param app_idx         Application index to encrypt with.
  *  @param divisor         New Health period divisor.
@@ -160,24 +154,21 @@ int bt_mesh_health_period_get(u16_t net_idx, u16_t addr, u16_t app_idx,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_health_period_set(u16_t net_idx, u16_t addr, u16_t app_idx,
-			      u8_t divisor, u8_t *updated_divisor);
+int bt_mesh_health_period_set(u16_t addr, u16_t app_idx, u8_t divisor,
+				 u8_t *updated_divisor);
 
 /** @brief Get the current attention timer value.
  *
- *  @param net_idx   Network index to encrypt with.
  *  @param addr      Target node element address.
  *  @param app_idx   Application index to encrypt with.
  *  @param attention Attention timer response buffer, measured in seconds.
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_health_attention_get(u16_t net_idx, u16_t addr, u16_t app_idx,
-				 u8_t *attention);
+int bt_mesh_health_attention_get(u16_t addr, u16_t app_idx, u8_t *attention);
 
 /** @brief Set the attention timer.
  *
- *  @param net_idx           Network index to encrypt with.
  *  @param addr              Target node element address.
  *  @param app_idx           Application index to encrypt with.
  *  @param attention         New attention timer time, in seconds.
@@ -186,8 +177,8 @@ int bt_mesh_health_attention_get(u16_t net_idx, u16_t addr, u16_t app_idx,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_health_attention_set(u16_t net_idx, u16_t addr, u16_t app_idx,
-				 u8_t attention, u8_t *updated_attention);
+int bt_mesh_health_attention_set(u16_t addr, u16_t app_idx, u8_t attention,
+				 u8_t *updated_attention);
 
 /** @brief Get the current transmission timeout value.
  *

--- a/samples/bluetooth/mesh_demo/src/main.c
+++ b/samples/bluetooth/mesh_demo/src/main.c
@@ -234,7 +234,6 @@ void board_button_1_pressed(void)
 {
 	NET_BUF_SIMPLE_DEFINE(msg, 3 + 4);
 	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
 		.app_idx = app_idx,
 		.addr = target,
 		.send_ttl = BT_MESH_TTL_DEFAULT,

--- a/samples/boards/reel_board/mesh_badge/src/mesh.c
+++ b/samples/boards/reel_board/mesh_badge/src/mesh.c
@@ -438,7 +438,6 @@ static void send_hello(struct k_work *work)
 {
 	NET_BUF_SIMPLE_DEFINE(msg, 3 + HELLO_MAX + 4);
 	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = NET_IDX,
 		.app_idx = APP_IDX,
 		.addr = GROUP_ADDR,
 		.send_ttl = DEFAULT_TTL,
@@ -466,7 +465,6 @@ static void send_baduser(struct k_work *work)
 {
 	NET_BUF_SIMPLE_DEFINE(msg, 3 + HELLO_MAX + 4);
 	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = NET_IDX,
 		.app_idx = APP_IDX,
 		.addr = GROUP_ADDR,
 		.send_ttl = DEFAULT_TTL,

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -688,6 +688,18 @@ int bt_mesh_model_send(struct bt_mesh_model *model,
 		       struct net_buf_simple *msg,
 		       const struct bt_mesh_send_cb *cb, void *cb_data)
 {
+	struct bt_mesh_app_key *app_key;
+
+	if (!BT_MESH_IS_DEV_KEY(ctx->app_idx)) {
+		app_key = bt_mesh_app_key_find(ctx->app_idx);
+		if (!app_key) {
+			BT_ERR("Unknown app_idx 0x%04x", ctx->app_idx);
+			return -EINVAL;
+		}
+
+		ctx->net_idx = app_key->net_idx;
+	}
+
 	struct bt_mesh_net_tx tx = {
 		.sub = bt_mesh_subnet_get(ctx->net_idx),
 		.ctx = ctx,

--- a/subsys/bluetooth/mesh/health_cli.c
+++ b/subsys/bluetooth/mesh/health_cli.c
@@ -206,12 +206,10 @@ static int cli_wait(void)
 	return err;
 }
 
-int bt_mesh_health_attention_get(u16_t net_idx, u16_t addr, u16_t app_idx,
-				 u8_t *attention)
+int bt_mesh_health_attention_get(u16_t addr, u16_t app_idx, u8_t *attention)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_ATTENTION_GET, 0);
 	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
 		.app_idx = app_idx,
 		.addr = addr,
 		.send_ttl = BT_MESH_TTL_DEFAULT,
@@ -238,12 +236,11 @@ int bt_mesh_health_attention_get(u16_t net_idx, u16_t addr, u16_t app_idx,
 	return cli_wait();
 }
 
-int bt_mesh_health_attention_set(u16_t net_idx, u16_t addr, u16_t app_idx,
-				 u8_t attention, u8_t *updated_attention)
+int bt_mesh_health_attention_set(u16_t addr, u16_t app_idx, u8_t attention,
+				 u8_t *updated_attention)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_ATTENTION_SET, 1);
 	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
 		.app_idx = app_idx,
 		.addr = addr,
 		.send_ttl = BT_MESH_TTL_DEFAULT,
@@ -281,12 +278,10 @@ int bt_mesh_health_attention_set(u16_t net_idx, u16_t addr, u16_t app_idx,
 	return cli_wait();
 }
 
-int bt_mesh_health_period_get(u16_t net_idx, u16_t addr, u16_t app_idx,
-			      u8_t *divisor)
+int bt_mesh_health_period_get(u16_t addr, u16_t app_idx, u8_t *divisor)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEALTH_PERIOD_GET, 0);
 	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
 		.app_idx = app_idx,
 		.addr = addr,
 		.send_ttl = BT_MESH_TTL_DEFAULT,
@@ -313,12 +308,11 @@ int bt_mesh_health_period_get(u16_t net_idx, u16_t addr, u16_t app_idx,
 	return cli_wait();
 }
 
-int bt_mesh_health_period_set(u16_t net_idx, u16_t addr, u16_t app_idx,
-			      u8_t divisor, u8_t *updated_divisor)
+int bt_mesh_health_period_set(u16_t addr, u16_t app_idx, u8_t divisor,
+				 u8_t *updated_divisor)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEALTH_PERIOD_SET, 1);
 	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
 		.app_idx = app_idx,
 		.addr = addr,
 		.send_ttl = BT_MESH_TTL_DEFAULT,
@@ -356,13 +350,12 @@ int bt_mesh_health_period_set(u16_t net_idx, u16_t addr, u16_t app_idx,
 	return cli_wait();
 }
 
-int bt_mesh_health_fault_test(u16_t net_idx, u16_t addr, u16_t app_idx,
-			      u16_t cid, u8_t test_id, u8_t *faults,
-			      size_t *fault_count)
+int bt_mesh_health_fault_test(u16_t addr, u16_t app_idx, u16_t cid,
+				 u8_t test_id, u8_t *faults,
+				 size_t *fault_count)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEALTH_FAULT_TEST, 3);
 	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
 		.app_idx = app_idx,
 		.addr = addr,
 		.send_ttl = BT_MESH_TTL_DEFAULT,
@@ -404,13 +397,12 @@ int bt_mesh_health_fault_test(u16_t net_idx, u16_t addr, u16_t app_idx,
 	return cli_wait();
 }
 
-int bt_mesh_health_fault_clear(u16_t net_idx, u16_t addr, u16_t app_idx,
-			       u16_t cid, u8_t *test_id, u8_t *faults,
-			       size_t *fault_count)
+int bt_mesh_health_fault_clear(u16_t addr, u16_t app_idx, u16_t cid,
+				 u8_t *test_id, u8_t *faults,
+				 size_t *fault_count)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEALTH_FAULT_CLEAR, 2);
 	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
 		.app_idx = app_idx,
 		.addr = addr,
 		.send_ttl = BT_MESH_TTL_DEFAULT,
@@ -451,13 +443,12 @@ int bt_mesh_health_fault_clear(u16_t net_idx, u16_t addr, u16_t app_idx,
 	return cli_wait();
 }
 
-int bt_mesh_health_fault_get(u16_t net_idx, u16_t addr, u16_t app_idx,
-			     u16_t cid, u8_t *test_id, u8_t *faults,
-			     size_t *fault_count)
+int bt_mesh_health_fault_get(u16_t addr, u16_t app_idx, u16_t cid,
+				 u8_t *test_id, u8_t *faults,
+				 size_t *fault_count)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEALTH_FAULT_GET, 2);
 	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
 		.app_idx = app_idx,
 		.addr = addr,
 		.send_ttl = BT_MESH_TTL_DEFAULT,

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -1737,8 +1737,8 @@ static int cmd_fault_get(const struct shell *shell, size_t argc, char *argv[])
 	cid = strtoul(argv[1], NULL, 0);
 	fault_count = sizeof(faults);
 
-	err = bt_mesh_health_fault_get(net.net_idx, net.dst, net.app_idx, cid,
-				       &test_id, faults, &fault_count);
+	err = bt_mesh_health_fault_get(net.dst, net.app_idx, cid, &test_id,
+				 faults, &fault_count);
 	if (err) {
 		shell_error(shell, "Failed to send Health Fault Get (err %d)",
 			    err);
@@ -1765,8 +1765,8 @@ static int cmd_fault_clear(const struct shell *shell, size_t argc,
 	cid = strtoul(argv[1], NULL, 0);
 	fault_count = sizeof(faults);
 
-	err = bt_mesh_health_fault_clear(net.net_idx, net.dst, net.app_idx,
-					 cid, &test_id, faults, &fault_count);
+	err = bt_mesh_health_fault_clear(net.dst, net.app_idx, cid,
+				 &test_id, faults, &fault_count);
 	if (err) {
 		shell_error(shell, "Failed to send Health Fault Clear (err %d)",
 			    err);
@@ -1789,8 +1789,8 @@ static int cmd_fault_clear_unack(const struct shell *shell, size_t argc,
 
 	cid = strtoul(argv[1], NULL, 0);
 
-	err = bt_mesh_health_fault_clear(net.net_idx, net.dst, net.app_idx,
-					 cid, NULL, NULL, NULL);
+	err = bt_mesh_health_fault_clear(net.dst, net.app_idx, cid,
+					 NULL, NULL, NULL);
 	if (err) {
 		shell_error(shell, "Health Fault Clear Unacknowledged failed "
 			    "(err %d)", err);
@@ -1815,8 +1815,8 @@ static int cmd_fault_test(const struct shell *shell, size_t argc, char *argv[])
 	test_id = strtoul(argv[2], NULL, 0);
 	fault_count = sizeof(faults);
 
-	err = bt_mesh_health_fault_test(net.net_idx, net.dst, net.app_idx,
-					cid, test_id, faults, &fault_count);
+	err = bt_mesh_health_fault_test(net.dst, net.app_idx, cid,
+				 test_id, faults, &fault_count);
 	if (err) {
 		shell_error(shell, "Failed to send Health Fault Test (err %d)",
 			    err);
@@ -1841,8 +1841,8 @@ static int cmd_fault_test_unack(const struct shell *shell, size_t argc,
 	cid = strtoul(argv[1], NULL, 0);
 	test_id = strtoul(argv[2], NULL, 0);
 
-	err = bt_mesh_health_fault_test(net.net_idx, net.dst, net.app_idx,
-					cid, test_id, NULL, NULL);
+	err = bt_mesh_health_fault_test(net.dst, net.app_idx, cid,
+				 test_id, NULL, NULL);
 	if (err) {
 		shell_error(shell, "Health Fault Test Unacknowledged failed "
 			    "(err %d)", err);
@@ -1856,8 +1856,7 @@ static int cmd_period_get(const struct shell *shell, size_t argc, char *argv[])
 	u8_t divisor;
 	int err;
 
-	err = bt_mesh_health_period_get(net.net_idx, net.dst, net.app_idx,
-					&divisor);
+	err = bt_mesh_health_period_get(net.dst, net.app_idx, &divisor);
 	if (err) {
 		shell_error(shell, "Failed to send Health Period Get (err %d)",
 			    err);
@@ -1879,8 +1878,8 @@ static int cmd_period_set(const struct shell *shell, size_t argc, char *argv[])
 
 	divisor = strtoul(argv[1], NULL, 0);
 
-	err = bt_mesh_health_period_set(net.net_idx, net.dst, net.app_idx,
-					divisor, &updated_divisor);
+	err = bt_mesh_health_period_set(net.dst, net.app_idx, divisor,
+				 &updated_divisor);
 	if (err) {
 		shell_error(shell, "Failed to send Health Period Set (err %d)",
 			    err);
@@ -1904,8 +1903,7 @@ static int cmd_period_set_unack(const struct shell *shell, size_t argc,
 
 	divisor = strtoul(argv[1], NULL, 0);
 
-	err = bt_mesh_health_period_set(net.net_idx, net.dst, net.app_idx,
-					divisor, NULL);
+	err = bt_mesh_health_period_set(net.dst, net.app_idx, divisor, NULL);
 	if (err) {
 		shell_print(shell, "Failed to send Health Period Set (err %d)",
 			    err);
@@ -1920,7 +1918,7 @@ static int cmd_attention_get(const struct shell *shell, size_t argc,
 	u8_t attention;
 	int err;
 
-	err = bt_mesh_health_attention_get(net.net_idx, net.dst, net.app_idx,
+	err = bt_mesh_health_attention_get(net.dst, net.app_idx,
 					   &attention);
 	if (err) {
 		shell_error(shell, "Failed to send Health Attention Get "
@@ -1944,8 +1942,8 @@ static int cmd_attention_set(const struct shell *shell, size_t argc,
 
 	attention = strtoul(argv[1], NULL, 0);
 
-	err = bt_mesh_health_attention_set(net.net_idx, net.dst, net.app_idx,
-					   attention, &updated_attention);
+	err = bt_mesh_health_attention_set(net.dst, net.app_idx, attention,
+				 &updated_attention);
 	if (err) {
 		shell_error(shell, "Failed to send Health Attention Set "
 			    "(err %d)", err);
@@ -1969,8 +1967,8 @@ static int cmd_attention_set_unack(const struct shell *shell, size_t argc,
 
 	attention = strtoul(argv[1], NULL, 0);
 
-	err = bt_mesh_health_attention_set(net.net_idx, net.dst, net.app_idx,
-					   attention, NULL);
+	err = bt_mesh_health_attention_set(net.dst, net.app_idx, attention,
+				 NULL);
 	if (err) {
 		shell_error(shell, "Failed to send Health Attention Set "
 			    "(err %d)", err);


### PR DESCRIPTION
According Mesh Profile 1.0.1. A application key shall
binding single network key. And Device key shall bind all
network key, and dev key only known by cfg_cli and node self,
only used by cfg_cli & cfg_srv.

Fixes: #21088

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>