### PR TITLE
testsuite: Allow user to override minimal logging

### DIFF
--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -85,7 +85,7 @@ config TEST_LOGGING_DEFAULTS
 	bool "Enable test case logging defaults"
 	depends on TEST
 	select LOG
-	select LOG_MINIMAL
+	imply LOG_MINIMAL
 	default y
 	help
 	  Option which implements default policy of enabling logging in


### PR DESCRIPTION
The testsuite was always forcing minimal logging. This is problematic
as it does not allow user to see full logging string. Allow user to
override the minimal logging if needed, the default is still to
enable minimal logging.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>