### PR TITLE
drivers: serial: uart_sam0: Fix build error with CONFIG_UART_ASYNC_API

### DIFF
--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -554,9 +554,6 @@ static int uart_sam0_init(struct device *dev)
 #endif
 
 #ifdef CONFIG_UART_ASYNC_API
-
-	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
-
 	dev_data->cfg = cfg;
 	dev_data->dma = device_get_binding(CONFIG_DMA_0_NAME);
 


### PR DESCRIPTION
When we build this driver with CONFIG_UART_ASYNC_API enabled we get the
following build error:

uart_sam0.c: In function 'uart_sam0_init':
uart_sam0.c:558:35: error: redefinition of 'dev_data'
  558 |  struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
uart_sam0.c:498:35: note: previous definition of 'dev_data' was here
  498 |  struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);

Fix this be removnig the duplicate at line 558.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>