### PR TITLE
devicetree: gen_defines: Generate lists of children node identifiers

### DIFF
--- a/doc/guides/dts/macros.bnf
+++ b/doc/guides/dts/macros.bnf
@@ -43,9 +43,8 @@ node-macro =/ %s"DT_N" path-id %s"_IRQ_NAME_" dt-name
 node-macro =/ %s"DT_N" path-id %s"_COMPAT_MATCHES_" dt-name
 ; The node identifier for the node's parent in the devicetree.
 node-macro =/ %s"DT_N" path-id %s"_PARENT"
-; These are used internally by DT_FOREACH_CHILD, which iterates over
-; each child node.
-node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD"
+; The node identifier for the list of node's child identifiers.
+node-macro =/ %s"DT_N" path-id %s"_CHILD_IDENTIFIERS"
 
 ; --------------------------------------------------------------------
 ; property-macro: a macro related to a node property

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -1525,6 +1525,79 @@
 	DT_IRQ_HAS_NAME(DT_DRV_INST(inst), name)
 
 /**
+ * @brief Invokes given macro for all child nodes of a parent.
+ *
+ * @param parent	parent node to iterate
+ * @param fun		macro to invoke
+ *
+ * Macro should be defined to take two parameters, where first will be
+ * the parent node, and second will be child node provided by the loop.
+ *
+ * Example:
+ *
+ *	#define PARENT DT_INST(0, fixed_partitions)
+ *	#define MKSTR(discard, a) #a,
+ *	const char *nodes[] {
+ *		DT_FOR_EACH_CHILD(PARENT, MKSTR)
+ *	};
+ *
+ * Would generate list of strings representing child nodes, partitions,
+ * of first instance of "fixed-partitions" compatible.
+ *
+ */
+#define DT_FOR_EACH_CHILD(parent, fun) DT_FOR_EACH_CHILD_(parent, fun)
+#define DT_FOR_EACH_CHILD_(parent, fun) \
+       DT_FOR_EACH_CHILD__(parent, fun, DT_CHILDREN(parent), ~)
+#define DT_FOR_EACH_CHILD__(parent, fun, ...) \
+       DT_FOR_EACH_CHILD___(fun, parent, NUM_VA_ARGS_LESS_1(__VA_ARGS__),\
+			    __VA_ARGS__)
+#define DT_FOR_EACH_CHILD___(fun, parent, N, ...) \
+       DT_FOR_EACH_CHILD____(fun, parent, N, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____(fun, parent, N, ...) \
+       DT_FOR_EACH_CHILD____##N(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____0(fun, parent, node)
+#define DT_FOR_EACH_CHILD____1(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____0(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____2(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____1(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____3(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____2(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____4(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____3(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____5(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____4(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____6(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____5(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____7(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____6(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____8(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____7(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____9(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____8(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____10(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____9(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____11(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____10(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____12(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____11(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____13(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____12(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____14(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____13(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____15(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____14(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____16(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____15(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____17(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____16(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____18(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____17(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____19(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____18(fun, parent, __VA_ARGS__)
+#define DT_FOR_EACH_CHILD____20(fun, parent, node, ...) \
+       fun(parent, node) DT_FOR_EACH_CHILD____19(fun, parent, __VA_ARGS__)
+
+/**
  * @}
  */
 
@@ -1539,6 +1612,7 @@
 #define DT_DASH(...) MACRO_MAP_CAT(DT_DASH_PREFIX, __VA_ARGS__)
 /** @internal helper for DT_DASH(): prepends _ to a name */
 #define DT_DASH_PREFIX(name) _##name
+
 
 /* have these last so the have access to all previously defined macros */
 #include <devicetree/adc.h>

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -158,6 +158,15 @@
 #define DT_NODELABEL(label) DT_CAT(DT_N_NODELABEL_, label)
 
 /**
+ * @brief returns list of child node identifiers.
+ * List contains only primary child nodes (no aliases).
+ *
+ * @param path parent node path
+ * @return list of child node identifiers under path.
+ */
+#define DT_CHILDREN(path) DT_CAT(path, _CHILD_IDENTIFIERS)
+
+/**
  * @brief Get a node identifier for an alias
  *
  * Example devicetree fragment:

--- a/tests/lib/devicetree/src/main.c
+++ b/tests/lib/devicetree/src/main.c
@@ -1367,18 +1367,40 @@ static void test_parent(void)
 
 static void test_child_nodes_list(void)
 {
-	#define TEST_MKSTR(i) #i,
-	#define TEST_LIST DT_CHILDREN(DT_PATH(test, test_children))
-	static const char * const arr[] = {
-		FOR_EACH(TEST_MKSTR, TEST_LIST)
+	#define TEST_MKPAIR(parent, child) { #parent, #child },
+	#define TEST_MKSTR(a) _TEST_MKSTR(a)
+	#define _TEST_MKSTR(a) #a
+	#define TEST_PARENT DT_PATH(test, test_children)
+	static struct {
+		const char *parent;
+		const char *child;
+	} pairs[] = {
+		DT_FOR_EACH_CHILD(TEST_PARENT, TEST_MKPAIR)
 	};
 
-	zassert_equal(sizeof(arr) / sizeof(char *), 3,
+	zassert_equal(ARRAY_SIZE(pairs), 3,
 		      "Bad number of children");
 
-	zassert_equal(arr[0], "child_alpha", "Child 0 did not match");
-	zassert_equal(arr[1], "child_beta", "Child 1 did not match");
-	zassert_equal(arr[2], "child_charlie", "Child 2 did not match");
+	zassert_false(strlen(TEST_MKSTR(TEST_PARENT)) == 0,
+		      "TEST_PARENT evaluated to empty string");
+
+	zassert_equal(pairs[0].parent, TEST_MKSTR(TEST_PARENT),
+		      "Parent 0 did not match");
+	zassert_equal(pairs[1].parent, TEST_MKSTR(TEST_PARENT),
+		      "Parent 1 did not match");
+	zassert_equal(pairs[2].parent, TEST_MKSTR(TEST_PARENT),
+		      "Parent 2 did not match");
+	zassert_equal(pairs[0].child, "child_alpha",
+		      "Child 0 did not match");
+	zassert_equal(pairs[1].child, "child_beta",
+		      "Child 1 did not match");
+	zassert_equal(pairs[2].child, "child_charlie",
+		      "Child 2 did not match");
+
+	#undef TEST_MKSTR
+	#undef _TEST_MKSTR
+	#undef TEST_PARENT
+	#undef TEST_MKPAIR
 }
 
 void test_main(void)

--- a/tests/lib/devicetree/src/main.c
+++ b/tests/lib/devicetree/src/main.c
@@ -1367,30 +1367,18 @@ static void test_parent(void)
 
 static void test_child_nodes_list(void)
 {
-	#define TEST_FUNC(child) { DT_PROP(child, val) },
-	#define TEST_MKSTR(a) _TEST_MKSTR(a)
-	#define _TEST_MKSTR(a) #a
-	#define TEST_PARENT DT_PATH(test, test_children)
-	static struct {
-		const char *v;
-	} vals[] = {
-		DT_FOREACH_CHILD(TEST_PARENT, TEST_FUNC)
+	#define TEST_MKSTR(i) #i,
+	#define TEST_LIST DT_CHILDREN(DT_PATH(test, test_children))
+	static const char * const arr[] = {
+		FOR_EACH(TEST_MKSTR, TEST_LIST)
 	};
 
-	zassert_equal(ARRAY_SIZE(vals), 3,
+	zassert_equal(sizeof(arr) / sizeof(char *), 3,
 		      "Bad number of children");
 
-	zassert_false(strlen(TEST_MKSTR(TEST_PARENT)) == 0,
-		      "TEST_PARENT evaluated to empty string");
-
-	zassert_equal(vals[0].v, "zero", "Child 0 did not match");
-	zassert_equal(vals[1].v, "one", "Child 1 did not match");
-	zassert_equal(vals[2].v, "two", "Child 2 did not match");
-
-	#undef TEST_MKSTR
-	#undef _TEST_MKSTR
-	#undef TEST_PARENT
-	#undef TEST_FUNC
+	zassert_equal(arr[0], "child_alpha", "Child 0 did not match");
+	zassert_equal(arr[1], "child_beta", "Child 1 did not match");
+	zassert_equal(arr[2], "child_charlie", "Child 2 did not match");
 }
 
 void test_main(void)


### PR DESCRIPTION
For each node, a list of identifiers of children nodes is generated
in form of:
DT_S_<path_to_node>_CHILD_IDENTIFIERS <id0>[, <id1>[, ...]]

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

Purpose of this commit is to generate list of identifiers from dts nodes, to be able to more automatically traverse dts tree.
For example useful to process list of flash partitions.