### PR TITLE
dts: nxp: convert UART drivers to new dt macros

### DIFF
--- a/boards/arm/frdm_kl25z/Kconfig.defconfig
+++ b/boards/arm/frdm_kl25z/Kconfig.defconfig
@@ -42,10 +42,6 @@ config PINMUX_MCUX_PORTE
 
 endif # PINMUX_MCUX
 
-config UART_MCUX_LPSCI_0
-	default y if UART_CONSOLE
-	depends on UART_MCUX_LPSCI
-
 config I2C_0
 	default y
 	depends on I2C

--- a/boards/arm/lpcxpresso54114/Kconfig.defconfig
+++ b/boards/arm/lpcxpresso54114/Kconfig.defconfig
@@ -9,10 +9,6 @@ config BOARD
 	default "lpcxpresso54114_m4" if BOARD_LPCXPRESSO54114_M4
 	default "lpcxpresso54114_m0" if BOARD_LPCXPRESSO54114_M0
 
-config UART_MCUX_FLEXCOMM_0
-	default y if UART_CONSOLE
-	depends on UART_MCUX_FLEXCOMM
-
 if PINMUX_MCUX_LPC
 
 config PINMUX_MCUX_LPC_PORT0

--- a/boards/arm/lpcxpresso55s69/Kconfig.defconfig
+++ b/boards/arm/lpcxpresso55s69/Kconfig.defconfig
@@ -9,10 +9,6 @@ config BOARD
 	default "lpcxpresso55S69_cpu0" if BOARD_LPCXPRESSO55S69_CPU0
 	default "lpcxpresso55S69_cpu1" if BOARD_LPCXPRESSO55S69_CPU1
 
-config UART_MCUX_FLEXCOMM_0
-	default y if UART_CONSOLE
-	depends on UART_MCUX_FLEXCOMM
-
 if PINMUX_MCUX_LPC
 
 config PINMUX_MCUX_LPC_PORT0

--- a/drivers/serial/Kconfig.mcux_flexcomm
+++ b/drivers/serial/Kconfig.mcux_flexcomm
@@ -3,16 +3,10 @@
 # Copyright 2017, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig UART_MCUX_FLEXCOMM
+config UART_MCUX_FLEXCOMM
 	bool "MCUX FLEXCOMM UART driver"
 	depends on HAS_MCUX_FLEXCOMM
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	help
 	  Enable the MCUX USART driver.
-
-config UART_MCUX_FLEXCOMM_0
-	bool "USART 0"
-	depends on UART_MCUX_FLEXCOMM
-	help
-	  Enable USART 0.

--- a/drivers/serial/Kconfig.mcux_lpsci
+++ b/drivers/serial/Kconfig.mcux_lpsci
@@ -3,16 +3,10 @@
 # Copyright (c) 2017, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig UART_MCUX_LPSCI
+config UART_MCUX_LPSCI
 	bool "MCUX LPSCI driver"
 	depends on HAS_MCUX_LPSCI && CLOCK_CONTROL
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	help
 	  Enable the MCUX LPSCI driver.
-
-config UART_MCUX_LPSCI_0
-	bool "UART 0"
-	depends on UART_MCUX_LPSCI
-	help
-	  Enable UART 0.

--- a/soc/arm/nxp_kinetis/kl2x/soc.c
+++ b/soc/arm/nxp_kinetis/kl2x/soc.c
@@ -63,7 +63,7 @@ static ALWAYS_INLINE void clock_init(void)
 	CLOCK_SetInternalRefClkConfig(kMCG_IrclkEnable, kMCG_IrcSlow, 0);
 	CLOCK_SetSimConfig(&simConfig);
 
-#ifdef CONFIG_UART_MCUX_LPSCI_0
+#if DT_HAS_NODE(DT_NODELABEL(uart0))
 	CLOCK_SetLpsci0Clock(LPSCI0SRC_MCGFLLCLK);
 #endif
 #if CONFIG_USB_KINETIS


### PR DESCRIPTION
Converts the following drivers to new DT_INST macros:

```
 serial/uart_mcux_flexcomm.c
 serial/uart_mcux_lpsci.c
```