### PR TITLE
net: mqtt: fix for transport that is not supporting sendmsg

### DIFF
--- a/subsys/net/lib/mqtt/mqtt.c
+++ b/subsys/net/lib/mqtt/mqtt.c
@@ -167,6 +167,18 @@ static int client_write_msg(struct mqtt_client *client,
 	MQTT_TRC("[%p]: Transport writing message.", client);
 
 	err_code = mqtt_transport_write_msg(client, message);
+	if (err_code == ENOTSUP) {
+		for (int i = 0; i < message->msg_iovlen; i++) {
+			err_code = client_write(client,
+						   message->msg_iov[i].iov_base,
+						   message->msg_iov[i].iov_len
+						   );
+			if (err_code < 0) {
+				break;
+			}
+		}
+	}
+
 	if (err_code < 0) {
 		MQTT_TRC("Transport write failed, err_code = %d, "
 			 "closing connection", err_code);


### PR DESCRIPTION
Since PR22794, the mqtt library is using a new transport handler
mqtt_transport_write_msg. If sendmsg is not implemented by the
underlying transport, this results in a failure of the transport handler.

This is now solved by resorting to the old transport handler in case
mqtt_transport_write_msg fails with ENOTSUP.

Signed-off-by: Hans Wilmers <hans@wilmers.no>