### PR TITLE
kernel: fix runtime initialization of k_pipe object

### DIFF
--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -135,10 +135,11 @@ void k_pipe_init(struct k_pipe *pipe, unsigned char *buffer, size_t size)
 	pipe->bytes_used = 0;
 	pipe->read_index = 0;
 	pipe->write_index = 0;
-	pipe->flags = 0;
+	pipe->lock = (struct k_spinlock){};
 	z_waitq_init(&pipe->wait_q.writers);
 	z_waitq_init(&pipe->wait_q.readers);
 	SYS_TRACING_OBJ_INIT(k_pipe, pipe);
+	pipe->flags = 0;
 	z_object_init(pipe);
 }
 


### PR DESCRIPTION
Runtime initialization failed to reset the lock field, causing
problems when the pipe object is located on a stack and passed by
reference to other code.  Lacking an API for initializing a spinlock
by itself use the idiom from _K_PIPE_INITIALIZER().

To simplify maintainability the initialization order is changed
slightly to match the structure field declaration order.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>