### PR TITLE
drivers: uart: mcux_lpuart: Convert to DT_INST

### DIFF
--- a/boards/arm/frdm_k82f/Kconfig.defconfig
+++ b/boards/arm/frdm_k82f/Kconfig.defconfig
@@ -84,8 +84,4 @@ config SPI_1
 	default y
 	depends on SPI
 
-config UART_MCUX_LPUART_4
-	default y if UART_CONSOLE
-	depends on UART_MCUX_LPUART
-
 endif # BOARD_FRDM_K82F

--- a/boards/arm/frdm_kw41z/Kconfig.defconfig
+++ b/boards/arm/frdm_kw41z/Kconfig.defconfig
@@ -43,10 +43,6 @@ config GPIO_MCUX_PORTC
 
 endif # GPIO_MCUX
 
-config UART_MCUX_LPUART_0
-	default y if UART_CONSOLE
-	depends on UART_MCUX_LPUART
-
 config I2C_1
 	default y
 	depends on I2C

--- a/boards/arm/hexiwear_kw40z/Kconfig.defconfig
+++ b/boards/arm/hexiwear_kw40z/Kconfig.defconfig
@@ -39,13 +39,9 @@ config GPIO_MCUX_PORTB
 	default n
 
 config GPIO_MCUX_PORTC
-	default y if UART_MCUX_LPUART_0 || I2C_1
+	default y if "$(dt_nodelabel_enabled,lpuart0)" || "$(dt_nodelabel_enabled,i2c1)"
 
 endif # GPIO_MCUX
-
-config UART_MCUX_LPUART_0
-	default y
-	depends on UART_MCUX_LPUART
 
 config I2C_1
 	default y

--- a/boards/arm/mimxrt1010_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1010_evk/Kconfig.defconfig
@@ -16,8 +16,4 @@ config I2C_1
 	default y
 	depends on I2C_MCUX_LPI2C
 
-config UART_MCUX_LPUART_1
-	default y
-	depends on UART_MCUX_LPUART
-
 endif # BOARD_MIMXRT1010_EVK

--- a/boards/arm/mimxrt1015_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1015_evk/Kconfig.defconfig
@@ -16,14 +16,4 @@ config I2C_1
 	default y
 	depends on I2C_MCUX_LPI2C
 
-if UART_MCUX_LPUART
-
-config UART_MCUX_LPUART_1
-	default y
-
-config UART_MCUX_LPUART_4
-	default y if BT_UART
-
-endif # UART_MCUX_LPUART
-
 endif # BOARD_MIMXRT1015_EVK

--- a/boards/arm/mimxrt1020_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1020_evk/Kconfig.defconfig
@@ -26,16 +26,6 @@ config I2C_4
 
 endif # I2C_MCUX_LPI2C
 
-if UART_MCUX_LPUART
-
-config UART_MCUX_LPUART_1
-	default y
-
-config UART_MCUX_LPUART_2
-	default y if BT_UART
-
-endif # UART_MCUX_LPUART
-
 if NETWORKING
 
 config NET_L2_ETHERNET

--- a/boards/arm/mimxrt1050_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1050_evk/Kconfig.defconfig
@@ -31,16 +31,6 @@ config SPI_3
 	default y
 	depends on SPI_MCUX_LPSPI
 
-if UART_MCUX_LPUART
-
-config UART_MCUX_LPUART_1
-	default y
-
-config UART_MCUX_LPUART_3
-	default y if BT_UART
-
-endif # UART_MCUX_LPUART
-
 config KSCAN
 	default y if LVGL
 

--- a/boards/arm/mimxrt1060_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1060_evk/Kconfig.defconfig
@@ -24,16 +24,6 @@ config I2C_1
 	default y
 	depends on I2C_MCUX_LPI2C
 
-if UART_MCUX_LPUART
-
-config UART_MCUX_LPUART_1
-	default y
-
-config UART_MCUX_LPUART_3
-	default y if BT_UART
-
-endif # UART_MCUX_LPUART
-
 config KSCAN
 	default y if LVGL
 

--- a/boards/arm/mimxrt1064_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1064_evk/Kconfig.defconfig
@@ -23,10 +23,6 @@ config I2C_1
 	default y
 	depends on I2C_MCUX_LPI2C
 
-config UART_MCUX_LPUART_1
-	default y
-	depends on UART_MCUX_LPUART
-
 config KSCAN
 	default y if LVGL
 

--- a/boards/arm/mm_swiftio/Kconfig.defconfig
+++ b/boards/arm/mm_swiftio/Kconfig.defconfig
@@ -20,8 +20,4 @@ config DISK_ACCESS_USDHC1
 	default y
 	depends on DISK_ACCESS_USDHC
 
-config UART_MCUX_LPUART_1
-	default y
-	depends on UART_MCUX_LPUART
-
 endif # BOARD_MM_SWIFTIO

--- a/boards/arm/twr_ke18f/Kconfig.defconfig
+++ b/boards/arm/twr_ke18f/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_TWR_KE18F
 config BOARD
 	default "twr_ke18f"
 
-config UART_MCUX_LPUART_0
-	default y if UART_CONSOLE
-	depends on UART_MCUX_LPUART
-
 if I2C
 
 config I2C_0

--- a/drivers/serial/Kconfig.mcux_lpuart
+++ b/drivers/serial/Kconfig.mcux_lpuart
@@ -3,39 +3,10 @@
 # Copyright (c) 2017, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig UART_MCUX_LPUART
+config UART_MCUX_LPUART
 	bool "MCUX LPUART driver"
 	depends on HAS_MCUX_LPUART && CLOCK_CONTROL
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	help
 	  Enable the MCUX LPUART driver.
-
-if UART_MCUX_LPUART
-
-config UART_MCUX_LPUART_0
-	bool "UART 0"
-	help
-	  Enable UART 0.
-
-config UART_MCUX_LPUART_1
-	bool "UART 1"
-	help
-	  Enable UART 1.
-
-config UART_MCUX_LPUART_2
-	bool "UART 2"
-	help
-	  Enable UART 2.
-
-config UART_MCUX_LPUART_3
-	bool "UART 3"
-	help
-	  Enable UART 3.
-
-config UART_MCUX_LPUART_4
-	bool "UART 4"
-	help
-	  Enable UART 4.
-
-endif # UART_MCUX_LPUART

--- a/soc/arm/nxp_kinetis/kwx/soc_kw4xz.c
+++ b/soc/arm/nxp_kinetis/kwx/soc_kw4xz.c
@@ -66,7 +66,7 @@ static ALWAYS_INLINE void clock_init(void)
 
 	CLOCK_SetSimConfig(&simConfig);
 
-#if CONFIG_UART_MCUX_LPUART_0
+#if DT_HAS_NODE(DT_NODELABEL(lpuart0))
 	CLOCK_SetLpuartClock(LPUART0SRC_OSCERCLK);
 #endif
 }


### PR DESCRIPTION
Convert driver to use new DT_INST macros throughout.  Removed per
instance Kconfig symbols and replaced with DT_NODELABEL references
where needed.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>