### PR TITLE
bluetooth: controller: openisa/RV32M1: Convert DT_ALIAS to NODELABEL

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/debug.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/debug.h
@@ -81,9 +81,9 @@ extern struct device *vega_debug_portd;
  */
 #define DEBUG_INIT() \
 	do { \
-		vega_debug_portb = device_get_binding(DT_ALIAS_GPIO_B_LABEL); \
-		vega_debug_portc = device_get_binding(DT_ALIAS_GPIO_C_LABEL); \
-		vega_debug_portd = device_get_binding(DT_ALIAS_GPIO_D_LABEL); \
+		vega_debug_portb = device_get_binding(DT_LABEL(DT_NODELABEL(gpiob))); \
+		vega_debug_portc = device_get_binding(DT_LABEL(DT_NODELABEL(gpioc))); \
+		vega_debug_portd = device_get_binding(DT_LABEL(DT_NODELABEL(gpiod))); \
 		\
 		gpio_pin_set(DEBUG0_PORT, DEBUG0_PIN, 1); \
 		gpio_pin_set(DEBUG0_PORT, DEBUG0_PIN, 0); \


### PR DESCRIPTION
Use the new DT_NODELABEL macro instead of aliases to get the specific
gpios ports.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>