### PR TITLE
boards: nsim: for smp testing, using mdb

### DIFF
--- a/boards/arc/nsim/nsim_hs_smp.yaml
+++ b/boards/arc/nsim/nsim_hs_smp.yaml
@@ -1,7 +1,7 @@
 identifier: nsim_hs_smp
 name: Multi-core HS nSIM simulator
 type: mcu
-simulation: nsim
+simulation: mdb
 arch: arc
 toolchain:
   - zephyr

--- a/scripts/sanity_chk/platform-schema.yaml
+++ b/scripts/sanity_chk/platform-schema.yaml
@@ -20,7 +20,7 @@ mapping:
     enum: [ 'mcu', 'qemu', 'sim', 'unit', 'native']
   "simulation":
     type: str
-    enum: [ 'qemu', 'simics', 'xt-sim', 'renode', 'nsim']
+    enum: [ 'qemu', 'simics', 'xt-sim', 'renode', 'nsim', 'mdb']
   "arch":
     type: str
   "toolchain":


### PR DESCRIPTION
This board require a special setup and does not work with standalone
nsim.

Fixes #24363