### PR TITLE
updates to support driver-specific API in userspace

### DIFF
--- a/include/syscall_handler.h
+++ b/include/syscall_handler.h
@@ -459,7 +459,7 @@ static inline int z_obj_validation_check(struct z_object *ko,
 #define Z_SYSCALL_SPECIFIC_DRIVER(_device, _dtype, _init_fn) \
 	({ \
 		struct device *_dev = (struct device *)_device; \
-		Z_SYSCALL_OBJ(_dev, _dtype) || \
+		Z_SYSCALL_OBJ(_dev, _dtype) && \
 			Z_SYSCALL_VERIFY_MSG(_dev->config->init == _init_fn, \
 					     "init function mismatch"); \
 	})

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -106,16 +106,18 @@ def kobject_to_enum(kobj):
 
     return "K_OBJ_%s" % name.upper()
 
-subsystems = [
+subsystems = {
     # Editing the list is deprecated, add the __subsystem sentinal to your driver
     # api declaration instead. e.x.
     #
     # __subsystem struct my_driver_api {
     #    ....
     #};
-]
+}
 
 def subsystem_to_enum(subsys):
+    # Map from extended subsystem to base subsystem if different
+    subsys = subsystems[subsys]
     return "K_OBJ_DRIVER_" + subsys[:-11].upper()
 
 # --- debug stuff ---
@@ -839,7 +841,7 @@ def write_validation_output(fp):
 		 Z_SYSCALL_DRIVER_OP(ptr, driver_lower_case##_driver_api, op))
                 """)
 
-    for subsystem in subsystems:
+    for subsystem in set(subsystems.values()):
         subsystem = subsystem.replace("_driver_api", "")
 
         fp.write(driver_macro_tpl % {
@@ -866,7 +868,7 @@ def write_kobj_types_output(fp):
             fp.write("#endif\n")
 
     fp.write("/* Driver subsystems */\n")
-    for subsystem in subsystems:
+    for subsystem in set(subsystems.values()):
         subsystem = subsystem.replace("_driver_api", "").upper()
         fp.write("K_OBJ_DRIVER_%s,\n" % subsystem)
 
@@ -887,7 +889,7 @@ def write_kobj_otype_output(fp):
             fp.write("#endif\n")
 
     fp.write("/* Driver subsystems */\n")
-    for subsystem in subsystems:
+    for subsystem in set(subsystems.values()):
         subsystem = subsystem.replace("_driver_api", "")
         fp.write('case K_OBJ_DRIVER_%s: ret = "%s driver"; break;\n' % (
             subsystem.upper(),
@@ -916,7 +918,7 @@ def write_kobj_size_output(fp):
 def parse_subsystems_list_file(path):
     with open(path, "r") as fp:
         subsys_list = json.load(fp)
-    subsystems.extend(subsys_list)
+    subsystems.update(subsys_list)
 
 def parse_args():
     global args


### PR DESCRIPTION
Proposed solution to #24539

## syscalls: correct Z_SYSCALL_SPECIFIC_DRIVER

The condition required to validate an extended API system call is that the device be associated with the base API, and that the device be associated with the extended driver implementing the calls.  Neither one alone is sufficient.

## scripts: syscalls: support using base subsystem for extended driver devices

Driver-specific API requires that the base API functions like `counter_get_value()` work on a device that is defined with an extended API.  Validation of APIs involves checking that the device api table is associated with a subsystem-tagged API structure.  Since the base table for an extended API is embedded in a structure that has a different type with additional members, either no kernel object or the wrong kernel object will be associated with the driver.

Recognize `__subsystem/*base_driver_api*/` in parse_syscalls as identifying an extended API that should cause drivers using it to be marked as K_OBJ_DRIVER_BASE instances.  Change the representation of known subsystems from a list to a map so that the base subsystem can be inferred from the extended subsystem.  Associate the correct base subsystem kernel object type with the extended driver instances.
