### PR TITLE
x86/soc: remove INT_VEC_IRQ0

### DIFF
--- a/soc/x86/atom/soc.h
+++ b/soc/x86/atom/soc.h
@@ -22,8 +22,6 @@
 #include <random/rand32.h>
 #endif
 
-#define INT_VEC_IRQ0 0x20 /* vector number for IRQ0 */
-
 /*
  * UART
  */

--- a/soc/x86/ia32/soc.h
+++ b/soc/x86/ia32/soc.h
@@ -27,7 +27,6 @@
  */
 #define UART_NS16550_ACCESS_IOPORT
 
-#define INT_VEC_IRQ0 0x20 /* Vector number for IRQ0 */
 /* PCI definitions */
 #define PCI_BUS_NUMBERS 1
 


### PR DESCRIPTION
This macro is not being used anymore, so remove it.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>