### PR TITLE
arch: arm: Remove -march compiler flag

### DIFF
--- a/cmake/compiler/gcc/target_arm.cmake
+++ b/cmake/compiler/gcc/target_arm.cmake
@@ -15,22 +15,8 @@ else()
     list(APPEND TOOLCHAIN_LD_FLAGS  -mthumb)
   endif()
 
-  set(ARCH_FOR_cortex-m0        armv6s-m        )
-  set(ARCH_FOR_cortex-m0plus    armv6s-m        )
-  set(ARCH_FOR_cortex-m3        armv7-m         )
-  set(ARCH_FOR_cortex-m4        armv7e-m        )
-  set(ARCH_FOR_cortex-m23       armv8-m.base    )
-  set(ARCH_FOR_cortex-m33       armv8-m.main+dsp)
-  set(ARCH_FOR_cortex-m33+nodsp armv8-m.main    )
-  set(ARCH_FOR_cortex-r4        armv7-r         )
-  set(ARCH_FOR_cortex-r5        armv7-r+idiv    )
-
-  if(ARCH_FOR_${GCC_M_CPU})
-      set(ARCH_FLAG -march=${ARCH_FOR_${GCC_M_CPU}})
-  endif()
-
-  list(APPEND TOOLCHAIN_C_FLAGS -mabi=aapcs ${ARCH_FLAG})
-  list(APPEND TOOLCHAIN_LD_FLAGS -mabi=aapcs ${ARCH_FLAG})
+  list(APPEND TOOLCHAIN_C_FLAGS -mabi=aapcs)
+  list(APPEND TOOLCHAIN_LD_FLAGS -mabi=aapcs)
 
   # Defines a mapping from GCC_M_CPU to FPU
 


### PR DESCRIPTION
```
The ARM GCC `-march` compiler flag is completely redundant when the
`-mcpu` flag is specified, since the `-mcpu` selects the target ARM
architecture as well as CPU-specific optimisations.

In fact, it is disadvantageous to specify both `-march` and `-mcpu`
flags because the `-march` flag overrides and disables any CPU-specific
optimisations enabled by the `-mcpu` flag.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```

**Rationale**

> TL;DR: Whenever possible use only -mcpu=native. Avoid -march and -mtune. <sup>[1]</sup>

> What happens when -march, -mtune, and -mcpu are used in combination?  On Arm, the -march and -mtune flags override any value passed to -mcpu. <sup>[1]</sup>

> When you specify -march, you are confining the compiler to only the baseline architecture, so the compiler is unable take advantage of any architecture extensions beyond the baseline. <sup>[1]</sup>

> It is possible to use -march and list out every possible architecture extension, but this is cumbersome, non-portable, and reverse mapping multiple compiler flags to a single target is more trouble than it’s worth.  Instead, just use -mcpu=target to tell the compiler exactly what you want, and the compiler will do the rest. <sup>[1]</sup>

> -mcpu=X: On Arm, this flag is a combination of -march and -mtune.  It simultaneously specifies the target architecture and optimizes for a given microarchitecture. <sup>[1]</sup>

> [`-mcpu=name[+extension…]`] specifies the name of the target ARM processor. GCC uses this name to derive the name of the target ARM architecture (as if specified by -march) and the ARM processor type for which to tune for performance (as if specified by -mtune). **Where this option is used in conjunction with -march or -mtune, those options take precedence over the appropriate part of this option.** <sup>[2]</sup>

<sup>[1]</sup> https://community.arm.com/developer/tools-software/tools/b/tools-software-ides-blog/posts/compiler-flags-across-architectures-march-mtune-and-mcpu
<sup>[2]</sup> https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html