### PR TITLE
arch: arm: aarch64: Force LP64 ABI

### DIFF
--- a/cmake/compiler/gcc/target_arm.cmake
+++ b/cmake/compiler/gcc/target_arm.cmake
@@ -1,11 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 if(CONFIG_ARM64)
-  list(APPEND TOOLCHAIN_C_FLAGS
-    -mcpu=${GCC_M_CPU}
-    )
-  list(APPEND TOOLCHAIN_LD_FLAGS
-    -mcpu=${GCC_M_CPU}
-    )
+  list(APPEND TOOLCHAIN_C_FLAGS   -mcpu=${GCC_M_CPU})
+  list(APPEND TOOLCHAIN_LD_FLAGS  -mcpu=${GCC_M_CPU})
+
+  list(APPEND TOOLCHAIN_C_FLAGS   -mabi=lp64)
+  list(APPEND TOOLCHAIN_LD_FLAGS  -mabi=lp64)
 else()
   list(APPEND TOOLCHAIN_C_FLAGS   -mcpu=${GCC_M_CPU})
   list(APPEND TOOLCHAIN_LD_FLAGS  -mcpu=${GCC_M_CPU})


### PR DESCRIPTION
This commit adds the GCC `-mabi=lp64` flag to force the LP64 (64-bit
long and pointer) ABI, which is mandatory for running the Zephyr
AArch64 architecture port.

Note that this flag is, strictly speaking, not necessary in most cases
because the AArch64 GCC defaults to using the LP64 ABI. This flag is
required, however, if compiling Zephyr with a GCC that is configured
with `--with-abi=ilp32`, which makes ILP32 the default ABI.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>