### PR TITLE
Bluetooth: Zero-initialize adv params

### DIFF
--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -95,7 +95,7 @@ static inline void adv_send(struct net_buf *buf)
 				   ADV_INT_FAST_MS : ADV_INT_DEFAULT_MS);
 	const struct bt_mesh_send_cb *cb = BT_MESH_ADV(buf)->cb;
 	void *cb_data = BT_MESH_ADV(buf)->cb_data;
-	struct bt_le_adv_param param;
+	struct bt_le_adv_param param = {};
 	u16_t duration, adv_int;
 	struct bt_data ad;
 	int err;

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -722,7 +722,7 @@ static const struct bt_data ad_discov[] = {
 
 static int cmd_advertise(const struct shell *shell, size_t argc, char *argv[])
 {
-	struct bt_le_adv_param param;
+	struct bt_le_adv_param param = {};
 	const struct bt_data *ad;
 	size_t ad_len;
 	int err;
@@ -738,7 +738,6 @@ static int cmd_advertise(const struct shell *shell, size_t argc, char *argv[])
 		return 0;
 	}
 
-	param.peer = NULL;
 	param.id = selected_id;
 	param.interval_min = BT_GAP_ADV_FAST_INT_MIN_2;
 	param.interval_max = BT_GAP_ADV_FAST_INT_MAX_2;
@@ -836,8 +835,7 @@ static int cmd_directed_adv(const struct shell *shell,
 static bool adv_param_parse(size_t argc, char *argv[],
 			   struct bt_le_adv_param *param)
 {
-	param->options = 0;
-	param->peer = NULL;
+	memset(param, 0, sizeof(struct bt_le_adv_param));
 
 	if (!strcmp(argv[1], "conn-scan")) {
 		param->options |= BT_LE_ADV_OPT_CONNECTABLE;


### PR DESCRIPTION
After #22013, bt_le_adv_param got additional fields which were passed to
the bluetooth API uninitialized in the BT Mesh module. This
zero-initializes the entire structure in all usages to avoid passing
uninitialized data now and in the future.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>