### PR TITLE
net: tcp2: Acknowledge the incoming FIN+ACK in FIN_WAIT_1

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -951,6 +951,8 @@ next_state:
 	case TCP_FIN_WAIT_1:
 		if (th && FL(&fl, ==, (FIN | ACK), th_seq(th) == conn->ack)) {
 			tcp_send_timer_cancel(conn);
+			conn_ack(conn, + 1);
+			tcp_out(conn, ACK);
 			next = TCP_TIME_WAIT;
 		}
 		break;
@@ -984,9 +986,14 @@ int net_tcp_put(struct net_context *context)
 	NET_DBG("%s", conn ? log_strdup(tcp_conn_state(conn, NULL)) : "");
 
 	if (conn) {
+		k_mutex_lock(&conn->lock, K_FOREVER);
+
 		tcp_out(conn, FIN | ACK);
+		conn_seq(conn, + 1);
 
 		conn_state(conn, TCP_FIN_WAIT_1);
+
+		k_mutex_unlock(&conn->lock);
 	}
 
 	net_context_unref(context);


### PR DESCRIPTION
In order to avoid retransmissions from the peer's side
on active connection close, acknowledge the incoming FIN+ACK
in FIN_WAIT_1 state.