### PR TITLE
dts: avoid resizing sram0 for nrf9160 and nrf5340

### DIFF
--- a/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp_partition_conf.dts
+++ b/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp_partition_conf.dts
@@ -44,10 +44,6 @@
  * - Upper 64 kB SRAM allocated as Shared memory (sram0_shared)
  *   (see nrf5340pdk_nrf5340_shared_sram_planning_conf.dts)
  */
-&sram0 {
-	reg = <0x20000000 DT_SIZE_K(448)>;
-};
-
 &sram0_s {
 	reg = <0x20000000 0x10000>;
 };

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160.dts
@@ -10,7 +10,7 @@
 
 / {
 	chosen {
-		zephyr,sram = &sram0;
+		zephyr,sram = &sram0_s;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 	};

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_partition_conf.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_partition_conf.dts
@@ -39,13 +39,13 @@
 
 /* Default SRAM planning when building for nRF9160 with
  * ARM TrustZone-M support
- * - Lowest 64 kB SRAM allocated to Secure image (sram0).
+ * - Lowest 64 kB SRAM allocated to Secure image (sram0_s).
  * - 64 kB SRAM reserved for and used by the BSD socket
- *   library.
+ *   library (sram0_bsd).
  * - Upper 128 kB allocated to Non-Secure image (sram0_ns).
  */
 
-&sram0 {
+&sram0_s {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };
 


### PR DESCRIPTION
This node is needed to have the size of the RAM available.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>