### PR TITLE
sys: util: Add FOR_EACH_WITH_IDX, deprecate MACRO_MAP

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -208,7 +208,7 @@ extern "C" {
 
 #define __LOG_ARG_CAST(_x) (log_arg_t)(_x),
 
-#define __LOG_ARGUMENTS(...) MACRO_MAP(__LOG_ARG_CAST, __VA_ARGS__)
+#define __LOG_ARGUMENTS(...) FOR_EACH(__LOG_ARG_CAST, __VA_ARGS__)
 
 #define _LOG_INTERNAL_LONG(_src_level, _str, ...)		  \
 	do {							  \

--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -441,7 +441,97 @@ u8_t u8_to_dec(char *buf, u8_t buflen, u8_t value);
 #define UTIL_INC_16 17
 #define UTIL_INC_17 18
 #define UTIL_INC_18 19
-#define UTIL_INC_19 19
+#define UTIL_INC_19 20
+#define UTIL_INC_20 21
+#define UTIL_INC_21 22
+#define UTIL_INC_22 23
+#define UTIL_INC_23 24
+#define UTIL_INC_24 25
+#define UTIL_INC_25 26
+#define UTIL_INC_26 27
+#define UTIL_INC_27 28
+#define UTIL_INC_28 29
+#define UTIL_INC_29 30
+#define UTIL_INC_30 31
+#define UTIL_INC_31 32
+#define UTIL_INC_32 33
+#define UTIL_INC_33 34
+#define UTIL_INC_34 35
+#define UTIL_INC_35 36
+#define UTIL_INC_36 37
+#define UTIL_INC_37 38
+#define UTIL_INC_38 39
+#define UTIL_INC_39 40
+#define UTIL_INC_40 41
+#define UTIL_INC_41 42
+#define UTIL_INC_42 43
+#define UTIL_INC_43 44
+#define UTIL_INC_44 45
+#define UTIL_INC_45 46
+#define UTIL_INC_46 47
+#define UTIL_INC_47 48
+#define UTIL_INC_48 49
+#define UTIL_INC_49 50
+#define UTIL_INC_50 51
+#define UTIL_INC_51 52
+#define UTIL_INC_52 53
+#define UTIL_INC_53 54
+#define UTIL_INC_54 55
+#define UTIL_INC_55 56
+#define UTIL_INC_56 57
+#define UTIL_INC_57 58
+#define UTIL_INC_58 59
+#define UTIL_INC_59 60
+#define UTIL_INC_50 51
+#define UTIL_INC_51 52
+#define UTIL_INC_52 53
+#define UTIL_INC_53 54
+#define UTIL_INC_54 55
+#define UTIL_INC_55 56
+#define UTIL_INC_56 57
+#define UTIL_INC_57 58
+#define UTIL_INC_58 59
+#define UTIL_INC_59 60
+#define UTIL_INC_60 61
+#define UTIL_INC_61 62
+#define UTIL_INC_62 63
+#define UTIL_INC_63 64
+#define UTIL_INC_64 65
+#define UTIL_INC_65 66
+#define UTIL_INC_66 67
+#define UTIL_INC_67 68
+#define UTIL_INC_68 69
+#define UTIL_INC_69 70
+#define UTIL_INC_70 71
+#define UTIL_INC_71 72
+#define UTIL_INC_72 73
+#define UTIL_INC_73 74
+#define UTIL_INC_74 75
+#define UTIL_INC_75 76
+#define UTIL_INC_76 77
+#define UTIL_INC_77 78
+#define UTIL_INC_78 79
+#define UTIL_INC_79 80
+#define UTIL_INC_80 81
+#define UTIL_INC_81 82
+#define UTIL_INC_82 83
+#define UTIL_INC_83 84
+#define UTIL_INC_84 85
+#define UTIL_INC_85 86
+#define UTIL_INC_86 87
+#define UTIL_INC_87 88
+#define UTIL_INC_88 89
+#define UTIL_INC_89 90
+#define UTIL_INC_90 91
+#define UTIL_INC_91 92
+#define UTIL_INC_92 93
+#define UTIL_INC_93 94
+#define UTIL_INC_94 95
+#define UTIL_INC_95 96
+#define UTIL_INC_96 97
+#define UTIL_INC_97 98
+#define UTIL_INC_98 99
+#define UTIL_INC_99 100
 
 #define UTIL_DEC(x) UTIL_PRIMITIVE_CAT(UTIL_DEC_, x)
 #define UTIL_DEC_0 0
@@ -778,6 +868,87 @@ u8_t u8_to_dec(char *buf, u8_t buflen, u8_t value);
  * behavior.
  */
 #define UTIL_LISTIFY(LEN, F, ...) UTIL_EVAL(UTIL_REPEAT(LEN, F, __VA_ARGS__))
+
+/* Set of internal macros used for FOR_EACH series of macros. */
+#define Z_FOR_EACH_IDX(count, n, macro, semicolon, fixed_arg0, fixed_arg1, ...)\
+	UTIL_WHEN(count)						\
+	(								\
+		UTIL_OBSTRUCT(macro)					\
+		(							\
+			fixed_arg0, fixed_arg1, n, GET_ARG1(__VA_ARGS__)\
+		)semicolon						\
+		UTIL_OBSTRUCT(Z_FOR_EACH_IDX_INDIRECT) ()		\
+		(							\
+			UTIL_DEC(count), UTIL_INC(n), macro, semicolon, \
+			fixed_arg0, fixed_arg1,				\
+			GET_ARGS_LESS_1(__VA_ARGS__)			\
+		)							\
+	)
+
+#define Z_FOR_EACH_IDX_INDIRECT() Z_FOR_EACH_IDX
+
+#define Z_FOR_EACH_IDX2(count, iter, macro, sc, fixed_arg0, fixed_arg1, ...) \
+	UTIL_EVAL(Z_FOR_EACH_IDX(count, iter, macro, sc,\
+				 fixed_arg0, fixed_arg1, __VA_ARGS__))
+
+#define Z_FOR_EACH_SWALLOW_NOTHING(F, fixed_arg, index, arg) \
+	F(index, arg, fixed_arg)
+
+#define Z_FOR_EACH_SWALLOW_FIXED_ARG(F, fixed_arg, index, arg) F(index, arg)
+
+#define Z_SWALLOW_INDEX_FIXED_ARG(F, fixed_arg, index, arg) F(arg)
+#define Z_SWALLOW_INDEX(F, fixed_arg, index, arg) F(arg, fixed_arg)
+
+/**
+ * @brief Calls macro F for each provided argument with index as first argument
+ *	  and nth parameter as the second argument.
+ *
+ * Example:
+ *
+ *     #define F(idx, x) int a##idx = x;
+ *     FOR_EACH_IDX(F, 4, 5, 6)
+ *
+ * will result in following code:
+ *
+ *     int a0 = 4;
+ *     int a1 = 5;
+ *     int a2 = 6;
+ *
+ * @param F Macro takes index and first argument and nth variable argument as
+ *	    the second one.
+ * @param ... Variable list of argument. For each argument macro F is executed.
+ */
+#define FOR_EACH_IDX(F, ...) \
+	Z_FOR_EACH_IDX2(NUM_VA_ARGS_LESS_1(__VA_ARGS__, _), \
+			0, Z_FOR_EACH_SWALLOW_FIXED_ARG, /*no ;*/, \
+			F, 0, __VA_ARGS__)
+
+/**
+ * @brief Calls macro F for each provided argument with index as first argument
+ *	  and nth parameter as the second argument and fixed argument as the
+ *	  third one.
+ *
+ * Example:
+ *
+ *     #define F(idx, x, fixed_arg) int fixed_arg##idx = x;
+ *     FOR_EACH_IDX_FIXED_ARG(F, a, 4, 5, 6)
+ *
+ * will result in following code:
+ *
+ *     int a0 = 4;
+ *     int a1 = 5;
+ *     int a2 = 6;
+ *
+ * @param F Macro takes index and first argument and nth variable argument as
+ *	    the second one and fixed argumnet as the third.
+ * @param fixed_arg Fixed argument passed to F macro.
+ * @param ... Variable list of argument. For each argument macro F is executed.
+ */
+#define FOR_EACH_IDX_FIXED_ARG(F, fixed_arg, ...) \
+	Z_FOR_EACH_IDX2(NUM_VA_ARGS_LESS_1(__VA_ARGS__, _), \
+			0, Z_FOR_EACH_SWALLOW_NOTHING, /*no ;*/, \
+			F, fixed_arg, __VA_ARGS__)
+
 
 /**@brief Implementation details for NUM_VAR_ARGS */
 #define NUM_VA_ARGS_LESS_1_IMPL(				\

--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -844,7 +844,8 @@ u8_t u8_to_dec(char *buf, u8_t buflen, u8_t value);
 #define UTIL_REPEAT_INDIRECT() UTIL_REPEAT
 
 /**
- * Generates a sequence of code.
+ * @brief Generates a sequence of code.
+ *
  * Useful for generating code like;
  *
  * NRF_PWM0, NRF_PWM1, NRF_PWM2,
@@ -1009,7 +1010,8 @@ u8_t u8_to_dec(char *buf, u8_t buflen, u8_t value);
 	_51, _52, _53, _54, _55, _56, _57, _58, _59, _60,	\
 	_61, _62, N, ...) N
 
-/**@brief Macro to get the number of arguments in a call variadic macro call.
+/**
+ * @brief Macro to get the number of arguments in a call variadic macro call.
  * First argument is not counted.
  *
  * param[in]    ...     List of arguments

--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -1026,9 +1026,9 @@ u8_t u8_to_dec(char *buf, u8_t buflen, u8_t value);
 	10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, ~)
 
 /**
- * @brief Mapping macro
- *
  * Macro that process all arguments using given macro
+ *
+ * @deprecated Use FOR_EACH instead.
  *
  * @param ... Macro name to be used for argument processing followed by
  *            arguments to process. Macro should have following
@@ -1036,43 +1036,7 @@ u8_t u8_to_dec(char *buf, u8_t buflen, u8_t value);
  *
  * @return All arguments processed by given macro
  */
-#define MACRO_MAP(...) MACRO_MAP_(__VA_ARGS__)
-#define MACRO_MAP_(...)							\
-	/* To make sure it works also for 2 arguments in total */	\
-	MACRO_MAP_N(NUM_VA_ARGS_LESS_1(__VA_ARGS__), __VA_ARGS__)
-
-/**
- * @brief Mapping N arguments macro
- *
- * Macro similar to @ref MACRO_MAP but maps exact number of arguments.
- * If there is more arguments given, the rest would be ignored.
- *
- * @param N   Number of arguments to map
- * @param ... Macro name to be used for argument processing followed by
- *            arguments to process. Macro should have following
- *            form: MACRO(argument).
- *
- * @return Selected number of arguments processed by given macro
- */
-#define MACRO_MAP_N(N, ...) MACRO_MAP_N_(N, __VA_ARGS__)
-#define MACRO_MAP_N_(N, ...) UTIL_CAT(MACRO_MAP_, N)(__VA_ARGS__,)
-
-#define MACRO_MAP_0(...)
-#define MACRO_MAP_1(macro, a, ...)  macro(a)
-#define MACRO_MAP_2(macro, a, ...)  macro(a)MACRO_MAP_1(macro, __VA_ARGS__,)
-#define MACRO_MAP_3(macro, a, ...)  macro(a)MACRO_MAP_2(macro, __VA_ARGS__,)
-#define MACRO_MAP_4(macro, a, ...)  macro(a)MACRO_MAP_3(macro, __VA_ARGS__,)
-#define MACRO_MAP_5(macro, a, ...)  macro(a)MACRO_MAP_4(macro, __VA_ARGS__,)
-#define MACRO_MAP_6(macro, a, ...)  macro(a)MACRO_MAP_5(macro, __VA_ARGS__,)
-#define MACRO_MAP_7(macro, a, ...)  macro(a)MACRO_MAP_6(macro, __VA_ARGS__,)
-#define MACRO_MAP_8(macro, a, ...)  macro(a)MACRO_MAP_7(macro, __VA_ARGS__,)
-#define MACRO_MAP_9(macro, a, ...)  macro(a)MACRO_MAP_8(macro, __VA_ARGS__,)
-#define MACRO_MAP_10(macro, a, ...) macro(a)MACRO_MAP_9(macro, __VA_ARGS__,)
-#define MACRO_MAP_11(macro, a, ...) macro(a)MACRO_MAP_10(macro, __VA_ARGS__,)
-#define MACRO_MAP_12(macro, a, ...) macro(a)MACRO_MAP_11(macro, __VA_ARGS__,)
-#define MACRO_MAP_13(macro, a, ...) macro(a)MACRO_MAP_12(macro, __VA_ARGS__,)
-#define MACRO_MAP_14(macro, a, ...) macro(a)MACRO_MAP_13(macro, __VA_ARGS__,)
-#define MACRO_MAP_15(macro, a, ...) macro(a)MACRO_MAP_14(macro, __VA_ARGS__,)
+#define MACRO_MAP(...) __DEPRECATED_MACRO FOR_EACH(__VA_ARGS__)
 
 /**
  * @brief Mapping macro that pastes results together

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -231,6 +231,20 @@ static void test_FOR_EACH(void)
 	zassert_equal(array[2], 3, "Unexpected value %d", array[2]);
 }
 
+static void fsum(u32_t incr, u32_t *sum)
+{
+	*sum = *sum + incr;
+}
+
+static void test_FOR_EACH_FIXED_ARG(void)
+{
+	u32_t sum = 0;
+
+	FOR_EACH_FIXED_ARG(fsum, &sum, 1, 2, 3)
+
+	zassert_equal(sum, 6, "Unexpected value %d", sum);
+}
+
 static void test_FOR_EACH_IDX(void)
 {
 	#define FOR_EACH_IDX_MACRO_TEST(n, arg) u8_t a##n = arg;

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -217,6 +217,63 @@ static void test_z_max_z_min(void)
 	zassert_equal(inc_func(), 4, "Unexpected return value");
 }
 
+static void test_FOR_EACH(void)
+{
+	#define FOR_EACH_MACRO_TEST(arg) *buf++ = arg;
+
+	u8_t array[3] = {0};
+	u8_t *buf = array;
+
+	FOR_EACH(FOR_EACH_MACRO_TEST, 1, 2, 3)
+
+	zassert_equal(array[0], 1, "Unexpected value %d", array[0]);
+	zassert_equal(array[1], 2, "Unexpected value %d", array[1]);
+	zassert_equal(array[2], 3, "Unexpected value %d", array[2]);
+}
+
+static void test_FOR_EACH_IDX(void)
+{
+	#define FOR_EACH_IDX_MACRO_TEST(n, arg) u8_t a##n = arg;
+
+	FOR_EACH_IDX(FOR_EACH_IDX_MACRO_TEST, 1, 2, 3)
+
+	zassert_equal(a0, 1, "Unexpected value %d", a0);
+	zassert_equal(a1, 2, "Unexpected value %d", a1);
+	zassert_equal(a2, 3, "Unexpected value %d", a2);
+
+	#define FOR_EACH_IDX_MACRO_TEST2(n, arg) array[n] = arg;
+	u8_t array[32] = {0};
+
+	FOR_EACH_IDX(FOR_EACH_IDX_MACRO_TEST2, 1, 2, 3, 4, 5, 6, 7, 8,
+						9, 10, 11, 12, 13, 14, 15);
+	for (int i = 0; i < 15; i++) {
+		zassert_equal(array[i], i + 1,
+				"Unexpected value: %d", array[i]);
+	}
+	zassert_equal(array[15], 0, "Unexpected value: %d", array[15]);
+
+	#define FOR_EACH_IDX_MACRO_TEST3(n, arg) &a##n,
+
+	u8_t *a[] = {
+		FOR_EACH_IDX(FOR_EACH_IDX_MACRO_TEST3, 1, 2, 3)
+	};
+
+	zassert_equal(ARRAY_SIZE(a), 3, "Unexpected value:%d", ARRAY_SIZE(a));
+}
+
+static void test_FOR_EACH_IDX_FIXED_ARG(void)
+{
+	#undef FOO
+	#define FOO(n, arg, fixed_arg) \
+		u8_t fixed_arg##n = arg;
+
+	FOR_EACH_IDX_FIXED_ARG(FOO, a, 1, 2, 3)
+
+	zassert_equal(a0, 1, "Unexpected value %d", a0);
+	zassert_equal(a1, 2, "Unexpected value %d", a1);
+	zassert_equal(a2, 3, "Unexpected value %d", a2);
+}
+
 void test_main(void)
 {
 	ztest_test_suite(test_lib_sys_util_tests,
@@ -228,7 +285,11 @@ void test_main(void)
 			 ztest_unit_test(test_IF_ENABLED),
 			 ztest_unit_test(test_UTIL_LISTIFY),
 			 ztest_unit_test(test_MACRO_MAP_CAT),
-			 ztest_unit_test(test_z_max_z_min)
+			 ztest_unit_test(test_z_max_z_min),
+			 ztest_unit_test(test_FOR_EACH),
+			 ztest_unit_test(test_FOR_EACH_FIXED_ARG),
+			 ztest_unit_test(test_FOR_EACH_IDX),
+			 ztest_unit_test(test_FOR_EACH_IDX_FIXED_ARG)
 	);
 
 	ztest_run_test_suite(test_lib_sys_util_tests);


### PR DESCRIPTION
Added `FOR_EACH_WITH_IDX` which for each of variable length arguments provided calls a macro with index as first argument and actual argument as the second one.

Example:
```
#define F(idx, n) u8_t a##idx = n;
FOR_EACH_WITH_IDX(F, 5,6,7)
```
generates:
```
u8_t a0=5;
u8_t a1=6;
u8_t a2=7;
```

Additionally refactored `FOR_EACH` and `FOR_EACH_FIXED_ARG` which now share the same engine as `FOR_EACH_WITH_IDX` and previously each had dedicated implementation.

Deprecated `MACRO_MAP` which has same functionality as `FOR_EACH`. Replaced one and only usage in the tree.

Added missing doxygen for some macros.
Fixes #23435.