### PR TITLE
runners: openocd: Reset target before running Elf

### DIFF
--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -178,7 +178,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         cmd = (self.openocd_cmd + self.serial + self.cfg_cmd +
                       pre_init_cmd + ['-c', 'init',
                                        '-c', 'targets',
-                                       '-c', 'halt',
+                                       '-c', 'reset halt',
                                        '-c', 'load_image ' + self.elf_name,
                                        '-c', 'resume ' + ep_addr,
                                        '-c', 'shutdown'])


### PR DESCRIPTION
In case of flashing (which is typically used with OpenOCD)
we do reset of the target after programming application binary
in the non-volatile memory.

In case of Elf execution we need to reset the target before
loading Elf sections so that we might be sure our target
is in sane & expected state before we start execution.