### PR TITLE
net: lwm2m: Initialize socket FD to an invalid value

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -891,6 +891,7 @@ void lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
 			   lwm2m_ctx_event_cb_t event_cb)
 {
 	client.ctx = client_ctx;
+	client.ctx->sock_fd = -1;
 	client.event_cb = event_cb;
 
 	set_sm_state(ENGINE_INIT);


### PR DESCRIPTION
During registration, first thing LWM2M does is trying to close a socket
indicated by sock_fd stored in its context. In case it is not
initialized to some invalid value (-1 in this case), LWM2M may close an
ambigous socket.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>