### PR TITLE
boards: arc: make nsim_em a default platform

### DIFF
--- a/boards/arc/em_starterkit/em_starterkit_em7d.yaml
+++ b/boards/arc/em_starterkit/em_starterkit_em7d.yaml
@@ -10,7 +10,6 @@ supported:
   - spi
   - gpio
 testing:
-  default: true
   ignore_tags:
     - net
     - bluetooth

--- a/boards/arc/nsim/nsim_em.yaml
+++ b/boards/arc/nsim/nsim_em.yaml
@@ -6,6 +6,7 @@ arch: arc
 toolchain:
   - zephyr
 testing:
+  default: true
   ignore_tags:
     - net
     - bluetooth


### PR DESCRIPTION
Given that nsim_em can run the tests instead of just building them as
with em_starterkit_em7d, make it a default platform instead of
em_starterkit_em7d to get most of the testing when nsim simulator is
installed on the developer machine.

Tests run are 1000x more useful than just building them, even if we do
not have a large installed base of nsim.