### PR TITLE
kernel/timeout: Check for K_FOREVER in z_add_timeout()

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -86,6 +86,10 @@ static s32_t next_timeout(void)
 void z_add_timeout(struct _timeout *to, _timeout_func_t fn,
 		   k_timeout_t timeout)
 {
+	if (K_TIMEOUT_EQ(timeout, K_FOREVER)) {
+		return;
+	}
+
 #ifdef CONFIG_LEGACY_TIMEOUT_API
 	k_ticks_t ticks = timeout;
 #else


### PR DESCRIPTION
The "forever" token has always been interpreted above z_add_timeout()
(because it's always taken ticks, but K_FOREVER used to be in ms).
But it was discovered that k_delayed_work_submit_to_queue() was never
testing for this and passing a raw K_FOREVER down, where it got
interpreted as a negative timeout and caused it to fire at the next
tick.

Now that we actually see the original k_timeout_t here, we might as
well check it locally and do the correct thing (that is, nothing) if
asked to schedule a timeout that will never fire.

Fixes #24409

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>