### PR TITLE
dts: arm: nxp: nxp_lpc55s6x: Fix sram ranges property

### DIFF
--- a/dts/arm/nxp/nxp_lpc55S6x.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x.dtsi
@@ -12,7 +12,7 @@
 / {
 	soc {
 		sram: sram@14000000 {
-			ranges = <0x400000 0x1400000 0x20000000>;
+			ranges = <0x4000000 0x14000000 0x20000000>;
 		};
 
 		peripheral: peripheral@50000000 {

--- a/dts/arm/nxp/nxp_lpc55S6x_ns.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_ns.dtsi
@@ -6,8 +6,8 @@
 
 / {
 	soc {
-		sram: sram@400000 {
-			ranges = <0x400000 0x400000 0x20000000>;
+		sram: sram@4000000 {
+			ranges = <0x4000000 0x4000000 0x20000000>;
 		};
 
 		peripheral: peripheral@40000000 {


### PR DESCRIPTION
There was a typo bug in the SRAM ranges property that causes the SRAM
nodes to appear at the wrong addresses.  Need to translate by
0x10000000 not 0x1000000.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>