### PR TITLE
devicetree: atmel sam0: Convert UART to DT_INST and full devicetree

### DIFF
--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -1045,15 +1045,14 @@ static const struct uart_driver_api uart_sam0_driver_api = {
 };
 
 #if CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API
-#define DT_ATMEL_SAM0_UART_SERCOM_IRQ(n, m) DT_ATMEL_SAM0_UART_SERCOM_ ## n ## _IRQ_ ## m
-#define DT_ATMEL_SAM0_UART_SERCOM_IRQ_PRIORITY(n, m) DT_ATMEL_SAM0_UART_SERCOM_ ## n ## _IRQ_ ## m ## _PRIORITY
 
 #define SAM0_UART_IRQ_CONNECT(n, m)					\
 	do {								\
-	IRQ_CONNECT(DT_ATMEL_SAM0_UART_SERCOM_IRQ(n, m),		\
-		    DT_ATMEL_SAM0_UART_SERCOM_IRQ_PRIORITY(n, m),	\
-		    uart_sam0_isr, DEVICE_GET(uart_sam0_##n), 0);	\
-	irq_enable(DT_ATMEL_SAM0_UART_SERCOM_IRQ(n, m));		\
+		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, m, irq),		\
+			    DT_INST_IRQ_BY_IDX(n, m, priority),		\
+			    uart_sam0_isr,				\
+			    DEVICE_GET(uart_sam0_##n), 0);		\
+		irq_enable(DT_INST_IRQ_BY_IDX(n, m, irq));		\
 	} while (0)
 
 #define UART_SAM0_IRQ_HANDLER_DECL(n)					\
@@ -1084,120 +1083,53 @@ static void uart_sam0_irq_config_##n(struct device *dev)		\
 #endif
 
 #if CONFIG_UART_ASYNC_API
-#ifndef DT_ATMEL_SAM0_UART_SERCOM_0_TXDMA
-#define DT_ATMEL_SAM0_UART_SERCOM_0_TXDMA 0xFFU
-#endif
-#ifndef DT_ATMEL_SAM0_UART_SERCOM_0_RXDMA
-#define DT_ATMEL_SAM0_UART_SERCOM_0_RXDMA 0xFFU
-#endif
-#ifndef DT_ATMEL_SAM0_UART_SERCOM_1_TXDMA
-#define DT_ATMEL_SAM0_UART_SERCOM_1_TXDMA 0xFFU
-#endif
-#ifndef DT_ATMEL_SAM0_UART_SERCOM_1_RXDMA
-#define DT_ATMEL_SAM0_UART_SERCOM_1_RXDMA 0xFFU
-#endif
-#ifndef DT_ATMEL_SAM0_UART_SERCOM_2_TXDMA
-#define DT_ATMEL_SAM0_UART_SERCOM_2_TXDMA 0xFFU
-#endif
-#ifndef DT_ATMEL_SAM0_UART_SERCOM_2_RXDMA
-#define DT_ATMEL_SAM0_UART_SERCOM_2_RXDMA 0xFFU
-#endif
-#ifndef DT_ATMEL_SAM0_UART_SERCOM_3_TXDMA
-#define DT_ATMEL_SAM0_UART_SERCOM_3_TXDMA 0xFFU
-#endif
-#ifndef DT_ATMEL_SAM0_UART_SERCOM_3_RXDMA
-#define DT_ATMEL_SAM0_UART_SERCOM_3_RXDMA 0xFFU
-#endif
-#ifndef DT_ATMEL_SAM0_UART_SERCOM_4_TXDMA
-#define DT_ATMEL_SAM0_UART_SERCOM_4_TXDMA 0xFFU
-#endif
-#ifndef DT_ATMEL_SAM0_UART_SERCOM_4_RXDMA
-#define DT_ATMEL_SAM0_UART_SERCOM_4_RXDMA 0xFFU
-#endif
-#ifndef DT_ATMEL_SAM0_UART_SERCOM_5_TXDMA
-#define DT_ATMEL_SAM0_UART_SERCOM_5_TXDMA 0xFFU
-#endif
-#ifndef DT_ATMEL_SAM0_UART_SERCOM_5_RXDMA
-#define DT_ATMEL_SAM0_UART_SERCOM_5_RXDMA 0xFFU
-#endif
-
-#define UART_SAM0_DMA_CHANNELS(n)				 \
-	.tx_dma_request = SERCOM##n##_DMAC_ID_TX,		 \
-	.tx_dma_channel = DT_ATMEL_SAM0_UART_SERCOM_##n##_TXDMA, \
-	.rx_dma_request = SERCOM##n##_DMAC_ID_RX,		 \
-	.rx_dma_channel = DT_ATMEL_SAM0_UART_SERCOM_##n##_RXDMA
+#define UART_SAM0_DMA_CHANNELS(n)					\
+	.tx_dma_request = ATMEL_SAM0_DT_INST_DMA_TRIGSRC(n, tx),	\
+	.tx_dma_channel = ATMEL_SAM0_DT_INST_DMA_CHANNEL(n, tx),	\
+	.rx_dma_request = ATMEL_SAM0_DT_INST_DMA_TRIGSRC(n, rx),	\
+	.rx_dma_channel = ATMEL_SAM0_DT_INST_DMA_CHANNEL(n, rx),
 #else
 #define UART_SAM0_DMA_CHANNELS(n)
 #endif
 
 #define UART_SAM0_SERCOM_PADS(n) \
-	(DT_ATMEL_SAM0_UART_SERCOM_##n##_RXPO << SERCOM_USART_CTRLA_RXPO_Pos) |	\
-	(DT_ATMEL_SAM0_UART_SERCOM_##n##_TXPO << SERCOM_USART_CTRLA_TXPO_Pos)
+	(DT_INST_PROP(n, rxpo) << SERCOM_USART_CTRLA_RXPO_Pos) |	\
+	(DT_INST_PROP(n, txpo) << SERCOM_USART_CTRLA_TXPO_Pos)
 
 #ifdef MCLK
-#define UART_SAM0_CONFIG_DEFN(n)						\
-static const struct uart_sam0_dev_cfg uart_sam0_config_##n = {			\
-	.regs = (SercomUsart *)DT_ATMEL_SAM0_UART_SERCOM_##n##_BASE_ADDRESS,	\
-	.baudrate = DT_ATMEL_SAM0_UART_SERCOM_##n##_CURRENT_SPEED,		\
-	.mclk = MCLK_SERCOM##n,							\
-	.mclk_mask = MCLK_SERCOM##n##_MASK,					\
-	.gclk_core_id = SERCOM##n##_GCLK_ID_CORE,				\
-	.pads = UART_SAM0_SERCOM_PADS(n),					\
-	UART_SAM0_IRQ_HANDLER_FUNC(n)						\
-	UART_SAM0_DMA_CHANNELS(n)						\
+#define UART_SAM0_CONFIG_DEFN(n)					\
+static const struct uart_sam0_dev_cfg uart_sam0_config_##n = {		\
+	.regs = (SercomUsart *)DT_INST_REG_ADDR(n),			\
+	.baudrate = DT_INST_PROP(n, current_speed),			\
+	.mclk = (volatile uint32_t *)MCLK_MASK_DT_INT_REG_ADDR(n),	\
+	.mclk_mask = BIT(DT_INST_CLOCKS_CELL_BY_NAME(n, mclk, bit)),	\
+	.gclk_core_id = DT_INST_CLOCKS_CELL_BY_NAME(n, gclk, periph_ch),\
+	.pads = UART_SAM0_SERCOM_PADS(n),				\
+	UART_SAM0_IRQ_HANDLER_FUNC(n)					\
+	UART_SAM0_DMA_CHANNELS(n)					\
 }
 #else
-#define UART_SAM0_CONFIG_DEFN(n)						\
-static const struct uart_sam0_dev_cfg uart_sam0_config_##n = {			\
-	.regs = (SercomUsart *)DT_ATMEL_SAM0_UART_SERCOM_##n##_BASE_ADDRESS,	\
-	.baudrate = DT_ATMEL_SAM0_UART_SERCOM_##n##_CURRENT_SPEED,		\
-	.pm_apbcmask = PM_APBCMASK_SERCOM##n,					\
-	.gclk_clkctrl_id = GCLK_CLKCTRL_ID_SERCOM##n##_CORE,			\
-	.pads = UART_SAM0_SERCOM_PADS(n),					\
-	UART_SAM0_IRQ_HANDLER_FUNC(n)						\
-	UART_SAM0_DMA_CHANNELS(n)						\
+#define UART_SAM0_CONFIG_DEFN(n)					\
+static const struct uart_sam0_dev_cfg uart_sam0_config_##n = {		\
+	.regs = (SercomUsart *)DT_INST_REG_ADDR(n),			\
+	.baudrate = DT_INST_PROP(n, current_speed),			\
+	.pm_apbcmask = BIT(DT_INST_CLOCKS_CELL_BY_NAME(n, pm, bit)),	\
+	.gclk_clkctrl_id = DT_INST_CLOCKS_CELL_BY_NAME(n, gclk, clkctrl_id),\
+	.pads = UART_SAM0_SERCOM_PADS(n),				\
+	UART_SAM0_IRQ_HANDLER_FUNC(n)					\
+	UART_SAM0_DMA_CHANNELS(n)					\
 }
 #endif
 
-#define UART_SAM0_DEVICE_INIT(n)						\
-static struct uart_sam0_dev_data uart_sam0_data_##n;				\
-UART_SAM0_IRQ_HANDLER_DECL(n);							\
-UART_SAM0_CONFIG_DEFN(n);							\
-DEVICE_AND_API_INIT(uart_sam0_##n, DT_ATMEL_SAM0_UART_SERCOM_##n##_LABEL,	\
-		    uart_sam0_init, &uart_sam0_data_##n,			\
-		    &uart_sam0_config_##n, PRE_KERNEL_1,			\
-		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,				\
-		    &uart_sam0_driver_api);					\
+#define UART_SAM0_DEVICE_INIT(n)					\
+static struct uart_sam0_dev_data uart_sam0_data_##n;			\
+UART_SAM0_IRQ_HANDLER_DECL(n);						\
+UART_SAM0_CONFIG_DEFN(n);						\
+DEVICE_AND_API_INIT(uart_sam0_##n, DT_INST_LABEL(n),			\
+		    uart_sam0_init, &uart_sam0_data_##n,		\
+		    &uart_sam0_config_##n, PRE_KERNEL_1,		\
+		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			\
+		    &uart_sam0_driver_api);				\
 UART_SAM0_IRQ_HANDLER(n)
 
-#if DT_ATMEL_SAM0_UART_SERCOM_0_BASE_ADDRESS
-UART_SAM0_DEVICE_INIT(0)
-#endif
-
-#if DT_ATMEL_SAM0_UART_SERCOM_1_BASE_ADDRESS
-UART_SAM0_DEVICE_INIT(1)
-#endif
-
-#if DT_ATMEL_SAM0_UART_SERCOM_2_BASE_ADDRESS
-UART_SAM0_DEVICE_INIT(2)
-#endif
-
-#if DT_ATMEL_SAM0_UART_SERCOM_3_BASE_ADDRESS
-UART_SAM0_DEVICE_INIT(3)
-#endif
-
-#if DT_ATMEL_SAM0_UART_SERCOM_4_BASE_ADDRESS
-UART_SAM0_DEVICE_INIT(4)
-#endif
-
-#if DT_ATMEL_SAM0_UART_SERCOM_5_BASE_ADDRESS
-UART_SAM0_DEVICE_INIT(5)
-#endif
-
-#if DT_ATMEL_SAM0_UART_SERCOM_6_BASE_ADDRESS
-UART_SAM0_DEVICE_INIT(6)
-#endif
-
-#if DT_ATMEL_SAM0_UART_SERCOM7_BASE_ADDRESS
-UART_SAM0_DEVICE_INIT(7)
-#endif
+DT_INST_FOREACH(UART_SAM0_DEVICE_INIT)

--- a/dts/arm/atmel/samd20.dtsi
+++ b/dts/arm/atmel/samd20.dtsi
@@ -39,26 +39,38 @@
 
 &sercom0 {
 	interrupts = <7 0>;
+	clocks = <&gclk 0xd>, <&pm 0x20 2>;
+	clock-names = "GCLK", "PM";
 };
 
 &sercom1 {
 	interrupts = <8 0>;
+	clocks = <&gclk 0xe>, <&pm 0x20 3>;
+	clock-names = "GCLK", "PM";
 };
 
 &sercom2 {
 	interrupts = <9 0>;
+	clocks = <&gclk 0xf>, <&pm 0x20 4>;
+	clock-names = "GCLK", "PM";
 };
 
 &sercom3 {
 	interrupts = <10 0>;
+	clocks = <&gclk 0x10>, <&pm 0x20 5>;
+	clock-names = "GCLK", "PM";
 };
 
 &sercom4 {
 	interrupts = <11 0>;
+	clocks = <&gclk 0x11>, <&pm 0x20 6>;
+	clock-names = "GCLK", "PM";
 };
 
 &sercom5 {
 	interrupts = <12 0>;
+	clocks = <&gclk 0x12>, <&pm 0x20 7>;
+	clock-names = "GCLK", "PM";
 };
 
 &tc4 {

--- a/dts/arm/atmel/samd21.dtsi
+++ b/dts/arm/atmel/samd21.dtsi
@@ -21,11 +21,12 @@
 			label = "USB0";
 		};
 
-		dma: dmac@41004800 {
+		dmac: dmac@41004800 {
 			compatible = "atmel,sam0-dmac";
 			reg = <0x41004800 0x50>;
 			interrupts = <6 0>;
 			label = "DMA_0";
+			#dma-cells = <2>;
 		};
 
 		tc6: tc@42003800 {

--- a/dts/arm/atmel/samd21.dtsi
+++ b/dts/arm/atmel/samd21.dtsi
@@ -39,26 +39,38 @@
 
 &sercom0 {
 	interrupts = <9 0>;
+	clocks = <&gclk 0x14>, <&pm 0x20 2>;
+	clock-names = "GCLK", "PM";
 };
 
 &sercom1 {
 	interrupts = <10 0>;
+	clocks = <&gclk 0x15>, <&pm 0x20 3>;
+	clock-names = "GCLK", "PM";
 };
 
 &sercom2 {
 	interrupts = <11 0>;
+	clocks = <&gclk 0x16>, <&pm 0x20 4>;
+	clock-names = "GCLK", "PM";
 };
 
 &sercom3 {
 	interrupts = <12 0>;
+	clocks = <&gclk 0x17>, <&pm 0x20 5>;
+	clock-names = "GCLK", "PM";
 };
 
 &sercom4 {
 	interrupts = <13 0>;
+	clocks = <&gclk 0x18>, <&pm 0x20 6>;
+	clock-names = "GCLK", "PM";
 };
 
 &sercom5 {
 	interrupts = <14 0>;
+	clocks = <&gclk 0x19>, <&pm 0x20 7>;
+	clock-names = "GCLK", "PM";
 };
 
 &tc4 {

--- a/dts/arm/atmel/samd2x.dtsi
+++ b/dts/arm/atmel/samd2x.dtsi
@@ -73,6 +73,19 @@
 			};
 		};
 
+		pm: pm@40000400 {
+			compatible = "atmel,samd2x-pm";
+			reg = <0x40000400 0x400>;
+			interrupts = <0 0>;
+			#clock-cells = <2>;
+		};
+
+		gclk: gclk@40000c00 {
+			compatible = "atmel,samd2x-gclk";
+			reg = <0x40000c00 0x400>;
+			#clock-cells = <1>;
+		};
+
 		eic: eic@40001800 {
 			compatible = "atmel,sam0-eic";
 			reg = <0x40001800 0x1C>;

--- a/dts/arm/atmel/samd5x.dtsi
+++ b/dts/arm/atmel/samd5x.dtsi
@@ -72,6 +72,18 @@
 				<0x00806018 0x4>;
 		};
 
+		mclk: mclk@40000800 {
+			compatible = "atmel,samd5x-mclk";
+			reg = <0x40000800 0x400>;
+			#clock-cells = <2>;
+		};
+
+		gclk: gclk@40001c00 {
+			compatible = "atmel,samd5x-gclk";
+			reg = <0x40001c00 0x400>;
+			#clock-cells = <1>;
+		};
+
 		nvmctrl: nvmctrl@41004000  {
 			compatible = "atmel,sam0-nvmctrl";
 			label = "FLASH_CTRL";
@@ -143,6 +155,8 @@
 			interrupts = <46 0>, <47 0>, <48 0>, <49 0>;
 			status = "disabled";
 			label = "SERCOM0";
+			clocks = <&gclk 7>, <&mclk 0x14 12>;
+			clock-names = "GCLK", "MCLK";
 		};
 
 		sercom1: sercom@40003400 {
@@ -151,6 +165,8 @@
 			interrupts = <50 0>, <51 0>, <52 0>, <53 0>;
 			status = "disabled";
 			label = "SERCOM1";
+			clocks = <&gclk 8>, <&mclk 0x14 13>;
+			clock-names = "GCLK", "MCLK";
 		};
 
 		sercom2: sercom@41012000 {
@@ -159,6 +175,8 @@
 			interrupts = <54 0>, <55 0>, <56 0>, <57 0>;
 			status = "disabled";
 			label = "SERCOM2";
+			clocks = <&gclk 23>, <&mclk 0x18 9>;
+			clock-names = "GCLK", "MCLK";
 		};
 
 		sercom3: sercom@41014000 {
@@ -167,6 +185,8 @@
 			interrupts = <58 0>, <59 0>, <60 0>, <61 0>;
 			status = "disabled";
 			label = "SERCOM3";
+			clocks = <&gclk 24>, <&mclk 0x18 10>;
+			clock-names = "GCLK", "MCLK";
 		};
 
 		sercom4: sercom@43000000 {
@@ -175,6 +195,8 @@
 			interrupts = <62 0>, <63 0>, <64 0>, <65 0>;
 			status = "disabled";
 			label = "SERCOM4";
+			clocks = <&gclk 34>, <&mclk 0x20 0>;
+			clock-names = "GCLK", "MCLK";
 		};
 
 		sercom5: sercom@43000400 {
@@ -183,6 +205,8 @@
 			interrupts = <66 0>, <67 0>, <68 0>, <69 0>;
 			status = "disabled";
 			label = "SERCOM5";
+			clocks = <&gclk 35>, <&mclk 0x20 1>;
+			clock-names = "GCLK", "MCLK";
 		};
 
 		sercom6: sercom@43000800 {
@@ -191,6 +215,8 @@
 			interrupts = <70 0>, <71 0>, <72 0>, <73 0>;
 			status = "disabled";
 			label = "SERCOM6";
+			clocks = <&gclk 36>, <&mclk 0x20 2>;
+			clock-names = "GCLK", "MCLK";
 		};
 
 		sercom7: sercom@43000C00 {
@@ -199,6 +225,8 @@
 			interrupts = <74 0>, <75 0>, <76 0>, <77 0>;
 			status = "disabled";
 			label = "SERCOM7";
+			clocks = <&gclk 37>, <&mclk 0x20 3>;
+			clock-names = "GCLK", "MCLK";
 		};
 
 		porta: gpio@41008000 {

--- a/dts/arm/atmel/samd5x.dtsi
+++ b/dts/arm/atmel/samd5x.dtsi
@@ -101,11 +101,12 @@
 			};
 		};
 
-		dma: dmac@4100A000 {
+		dmac: dmac@4100A000 {
 			compatible = "atmel,sam0-dmac";
 			reg = <0x4100A000 0x50>;
 			interrupts = <31 0>, <32 0>, <33 0>, <34 0>, <35 0>;
 			label = "DMA_0";
+			#dma-cells = <2>;
 		};
 
 		eic: eic@40002800 {

--- a/dts/arm/atmel/samr21.dtsi
+++ b/dts/arm/atmel/samr21.dtsi
@@ -22,11 +22,12 @@
 			label = "USB0";
 		};
 
-		dma: dmac@41004800 {
+		dmac: dmac@41004800 {
 			compatible = "atmel,sam0-dmac";
 			reg = <0x41004800 0x50>;
 			interrupts = <6 0>;
 			label = "DMA_0";
+			#dma-cells = <2>;
 		};
 
 		portc: gpio@41004500 {

--- a/dts/arm/atmel/samr21.dtsi
+++ b/dts/arm/atmel/samr21.dtsi
@@ -47,26 +47,38 @@
 
 &sercom0 {
 	interrupts = <9 0>;
+	clocks = <&gclk 0x14>, <&pm 0x20 2>;
+	clock-names = "GCLK", "PM";
 };
 
 &sercom1 {
 	interrupts = <10 0>;
+	clocks = <&gclk 0x15>, <&pm 0x20 3>;
+	clock-names = "GCLK", "PM";
 };
 
 &sercom2 {
 	interrupts = <11 0>;
+	clocks = <&gclk 0x16>, <&pm 0x20 4>;
+	clock-names = "GCLK", "PM";
 };
 
 &sercom3 {
 	interrupts = <12 0>;
+	clocks = <&gclk 0x17>, <&pm 0x20 5>;
+	clock-names = "GCLK", "PM";
 };
 
 &sercom4 {
 	interrupts = <13 0>;
+	clocks = <&gclk 0x18>, <&pm 0x20 6>;
+	clock-names = "GCLK", "PM";
 };
 
 &sercom5 {
 	interrupts = <14 0>;
+	clocks = <&gclk 0x19>, <&pm 0x20 7>;
+	clock-names = "GCLK", "PM";
 };
 
 &tc4 {

--- a/dts/bindings/arm/atmel,sam0-sercom.yaml
+++ b/dts/bindings/arm/atmel,sam0-sercom.yaml
@@ -10,3 +10,6 @@ properties:
 
     interrupts:
       required: true
+
+    clocks:
+      required: true

--- a/dts/bindings/arm/atmel,samd2x-pm.yaml
+++ b/dts/bindings/arm/atmel,samd2x-pm.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2020, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: Atmel SAMD2x Power Manger (PM)
+
+compatible: "atmel,samd2x-pm"
+
+include: [clock-controller.yaml, base.yaml]
+
+properties:
+    reg:
+      required: true
+
+    "#clock-cells":
+      const: 2
+
+clock-cells:
+  - offset
+  - bit

--- a/dts/bindings/clock/atmel,samd2x-gclk.yaml
+++ b/dts/bindings/clock/atmel,samd2x-gclk.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2020, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: Atmel SAMD2x Generic Clock Controller (GCLK)
+
+compatible: "atmel,samd2x-gclk"
+
+include: [clock-controller.yaml, base.yaml]
+
+properties:
+    reg:
+      required: true
+
+    "#clock-cells":
+      const: 1
+
+clock-cells:
+  - clkctrl_id

--- a/dts/bindings/clock/atmel,samd5x-gclk.yaml
+++ b/dts/bindings/clock/atmel,samd5x-gclk.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2020, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: Atmel SAMD5x Generic Clock Controller (GCLK)
+
+compatible: "atmel,samd5x-gclk"
+
+include: [clock-controller.yaml, base.yaml]
+
+properties:
+    reg:
+      required: true
+
+    "#clock-cells":
+      const: 1
+
+clock-cells:
+  - periph_ch

--- a/dts/bindings/clock/atmel,samd5x-mclk.yaml
+++ b/dts/bindings/clock/atmel,samd5x-mclk.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2020, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: Atmel SAMD5x Generic Clock Controller (MCLK)
+
+compatible: "atmel,samd5x-mclk"
+
+include: [clock-controller.yaml, base.yaml]
+
+properties:
+    reg:
+      required: true
+
+    "#clock-cells":
+      const: 2
+
+clock-cells:
+  - offset
+  - bit

--- a/dts/bindings/dma/atmel,sam0-dmac.yaml
+++ b/dts/bindings/dma/atmel,sam0-dmac.yaml
@@ -2,7 +2,7 @@ description: Atmel SAM0 DMA controller
 
 compatible: "atmel,sam0-dmac"
 
-include: base.yaml
+include: dma-controller.yaml
 
 properties:
     reg:
@@ -10,3 +10,10 @@ properties:
 
     interrupts:
       required: true
+
+    "#dma-cells":
+      const: 2
+
+dma-cells:
+  - channel
+  - trigsrc

--- a/dts/bindings/i2c/atmel,sam0-i2c.yaml
+++ b/dts/bindings/i2c/atmel,sam0-i2c.yaml
@@ -14,6 +14,12 @@ properties:
     interrupts:
       required: true
 
+    clocks:
+      required: true
+
+    clock-names:
+      required: true
+
     dma:
       type: int
       required: false

--- a/dts/bindings/serial/atmel,sam0-uart.yaml
+++ b/dts/bindings/serial/atmel,sam0-uart.yaml
@@ -11,6 +11,12 @@ properties:
     interrupts:
       required: true
 
+    clocks:
+      required: true
+
+    clock-names:
+      required: true
+
     rxpo:
       type: int
       required: true

--- a/dts/bindings/serial/atmel,sam0-uart.yaml
+++ b/dts/bindings/serial/atmel,sam0-uart.yaml
@@ -27,12 +27,19 @@ properties:
       required: true
       description: Transmit Data Pinout
 
-    rxdma:
-      type: int
-      required: false
-      description: Receive DMA channel
+    dmas:
+      description: |
+        Optional TX & RX dma specifiers.  Each specifier will have a phandle
+        reference to the dmac controller, the channel number, and peripheral
+        trigger source.
 
-    txdma:
-      type: int
-      required: false
-      description: Transmit DMA channel
+        For example dmas for TX, RX on SERCOM3
+           dmas = <&dmac 0 0xb>, <&dmac 0 0xa>;
+
+    dma-names:
+      description: |
+        Required if the dmas property exists.  This should be "tx" and "rx"
+        to match the dmas property.
+
+        For example
+           dma-names = "tx", "rx";

--- a/dts/bindings/spi/atmel,sam0-spi.yaml
+++ b/dts/bindings/spi/atmel,sam0-spi.yaml
@@ -11,6 +11,12 @@ properties:
     reg:
       required: true
 
+    clocks:
+      required: true
+
+    clock-names:
+      required: true
+
     dipo:
       type: int
       required: true

--- a/soc/arm/atmel_sam0/common/atmel_sam0_dt.h
+++ b/soc/arm/atmel_sam0/common/atmel_sam0_dt.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 Linaro Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @file
+ * @brief Atmel SAM0 MCU family devicetree helper macros
+ */
+
+#ifndef _ATMEL_SAM0_DT_H_
+#define _ATMEL_SAM0_DT_H_
+
+/* Helper macro to get MCLK register address for corresponding
+ * that has corresponding clock enable bit.
+ */
+#define MCLK_MASK_DT_INT_REG_ADDR(n) \
+	(DT_REG_ADDR(DT_INST_PHANDLE_BY_NAME(n, clocks, mclk)) + \
+	 DT_INST_CLOCKS_CELL_BY_NAME(n, mclk, offset))
+
+/* Helper macros for use with ATMEL SAM0 DMAC controller
+ * return 0xff as default value if there is no 'dmas' property
+ */
+#define ATMEL_SAM0_DT_INST_DMA_CELL(n, name, cell)		\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, dmas),		\
+		    (DT_INST_DMAS_CELL_BY_NAME(n, name, cell)),	\
+		    (0xff))
+#define ATMEL_SAM0_DT_INST_DMA_TRIGSRC(n, name) \
+	ATMEL_SAM0_DT_INST_DMA_CELL(n, name, trigsrc)
+#define ATMEL_SAM0_DT_INST_DMA_CHANNEL(n, name) \
+	ATMEL_SAM0_DT_INST_DMA_CELL(n, name, channel)
+
+#endif /* _ATMEL_SAM0_SOC_DT_H_ */

--- a/soc/arm/atmel_sam0/samd20/soc.h
+++ b/soc/arm/atmel_sam0/samd20/soc.h
@@ -53,6 +53,8 @@
 
 #endif /* _ASMLANGUAGE */
 
+#include "../common/atmel_sam0_dt.h"
+
 /** Processor Clock (HCLK) Frequency */
 #define SOC_ATMEL_SAM0_HCLK_FREQ_HZ DT_ARM_CORTEX_M0PLUS_0_CLOCK_FREQUENCY
 /** Master Clock (MCK) Frequency */

--- a/soc/arm/atmel_sam0/samd21/soc.h
+++ b/soc/arm/atmel_sam0/samd21/soc.h
@@ -47,6 +47,8 @@
 
 #endif /* _ASMLANGUAGE */
 
+#include "../common/atmel_sam0_dt.h"
+
 /** Processor Clock (HCLK) Frequency */
 #define SOC_ATMEL_SAM0_HCLK_FREQ_HZ DT_ARM_CORTEX_M0PLUS_0_CLOCK_FREQUENCY
 /** Master Clock (MCK) Frequency */

--- a/soc/arm/atmel_sam0/samd51/soc.h
+++ b/soc/arm/atmel_sam0/samd51/soc.h
@@ -39,6 +39,7 @@
 
 #include "sercom_fixup_samd5x.h"
 #include "tc_fixup_samd5x.h"
+#include "../common/atmel_sam0_dt.h"
 
 #define SOC_ATMEL_SAM0_OSC32K_FREQ_HZ 32768
 

--- a/soc/arm/atmel_sam0/same51/soc.h
+++ b/soc/arm/atmel_sam0/same51/soc.h
@@ -31,6 +31,7 @@
 
 #include "sercom_fixup_samd5x.h"
 #include "tc_fixup_samd5x.h"
+#include "../common/atmel_sam0_dt.h"
 
 #define SOC_ATMEL_SAM0_OSC32K_FREQ_HZ 32768
 

--- a/soc/arm/atmel_sam0/same53/soc.h
+++ b/soc/arm/atmel_sam0/same53/soc.h
@@ -32,6 +32,7 @@
 #include "sercom_fixup_samd5x.h"
 #include "tc_fixup_samd5x.h"
 #include "gmac_fixup_samd5x.h"
+#include "../common/atmel_sam0_dt.h"
 
 #define SOC_ATMEL_SAM0_OSC32K_FREQ_HZ 32768
 

--- a/soc/arm/atmel_sam0/same54/soc.h
+++ b/soc/arm/atmel_sam0/same54/soc.h
@@ -30,6 +30,7 @@
 #include "sercom_fixup_samd5x.h"
 #include "tc_fixup_samd5x.h"
 #include "gmac_fixup_samd5x.h"
+#include "../common/atmel_sam0_dt.h"
 
 #define SOC_ATMEL_SAM0_OSC32K_FREQ_HZ 32768
 

--- a/soc/arm/atmel_sam0/samr21/soc.h
+++ b/soc/arm/atmel_sam0/samr21/soc.h
@@ -33,6 +33,8 @@
 
 #endif /* _ASMLANGUAGE */
 
+#include "../common/atmel_sam0_dt.h"
+
 /** Processor Clock (HCLK) Frequency */
 #define SOC_ATMEL_SAM0_HCLK_FREQ_HZ DT_ARM_CORTEX_M0PLUS_0_CLOCK_FREQUENCY
 /** Master Clock (MCK) Frequency */


### PR DESCRIPTION
Add clock support for MCLK, GCLK, and PM to allow SAM0 drivers to be full devicetree based.  Also move to proper dma devicetree support.