### PR TITLE
drivers: flash: nrf: Add warning about small writes

### DIFF
--- a/drivers/flash/Kconfig.nrf
+++ b/drivers/flash/Kconfig.nrf
@@ -64,4 +64,8 @@ config SOC_FLASH_NRF_EMULATE_ONE_BYTE_WRITE_ACCESS
 	  block size parameter (imposed by manufacturer) is possible but operation
 	  is more complex and requires basic user knowledge about NVMC controller.
 
+	  Note that this makes flash write operations non-atomic, and power loss
+	  during writes will easily result in significant loss of the contents of
+	  flash.
+
 endif # SOC_FLASH_NRF


### PR DESCRIPTION
This driver has an option SOC_FLASH_NRF_EMULATE_ONE_BYTE_WRITE_ACCESS
that emulates small writes by erasing and rewriting data.  Add a note
to the Kconfig for this option to make is clear that this makes the
flash driver susceptible to significant data loss in the event of
untimely reset or power loss.

Signed-off-by: David Brown <david.brown@linaro.org>