### PR TITLE
LoRa: Add support a shell with support for CW testing

### DIFF
--- a/boards/arm/96b_wistrio/96b_wistrio.dts
+++ b/boards/arm/96b_wistrio/96b_wistrio.dts
@@ -34,6 +34,7 @@
 	aliases {
 		led0 = &green_led_0;
 		eeprom-0 = &eeprom;
+		lora0 = &lora;
 	};
 };
 
@@ -61,7 +62,7 @@
 	status = "okay";
 	cs-gpios = <&gpiob 0 0>;
 
-	sx1276@0 {
+	lora: sx1276@0 {
 		compatible = "semtech,sx1276";
 		reg = <0>;
 		label = "sx1276";

--- a/drivers/lora/CMakeLists.txt
+++ b/drivers/lora/CMakeLists.txt
@@ -2,4 +2,5 @@
 
 zephyr_library_named(loramac-node)
 
+zephyr_library_sources_ifdef(CONFIG_LORA_SHELL shell.c)
 zephyr_library_sources_ifdef(CONFIG_LORA_SX1276 sx1276.c)

--- a/drivers/lora/Kconfig
+++ b/drivers/lora/Kconfig
@@ -18,6 +18,12 @@ module = LORA
 module-str = lora
 source "subsys/logging/Kconfig.template.log_config"
 
+config LORA_SHELL
+	bool "Enable LoRa Shell"
+	depends on SHELL
+	help
+	  Enable LoRa Shell for testing.
+
 config LORA_INIT_PRIORITY
 	int "LoRa initialization priority"
 	default 90

--- a/drivers/lora/shell.c
+++ b/drivers/lora/shell.c
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2020 Andreas Sandberg
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <drivers/lora.h>
+#include <inttypes.h>
+#include <shell/shell.h>
+#include <stdlib.h>
+#include <string.h>
+
+LOG_MODULE_REGISTER(lora_shell, CONFIG_LORA_LOG_LEVEL);
+
+#define DEFAULT_RADIO_NODE DT_ALIAS(lora0)
+BUILD_ASSERT(DT_HAS_NODE_STATUS_OKAY(DEFAULT_RADIO_NODE),
+	     "No default LoRa radio specified in DT");
+#define DEFAULT_RADIO DT_LABEL(DEFAULT_RADIO_NODE)
+
+static struct lora_modem_config modem_config = {
+	.frequency = 0,
+	.bandwidth = BW_125_KHZ,
+	.datarate = SF_10,
+	.coding_rate = CR_4_5,
+	.preamble_len = 8,
+	.tx_power = 4,
+};
+
+static const int bw_table[] = {
+	[BW_125_KHZ] = 125,
+	[BW_250_KHZ] = 250,
+	[BW_500_KHZ] = 500,
+};
+
+static int parse_long(long *out, const struct shell *shell, const char *arg)
+{
+	char *eptr;
+	long lval;
+
+	lval = strtol(arg, &eptr, 0);
+	if (*eptr != '\0') {
+		shell_error(shell, "'%s' is not an integer", arg);
+		return -EINVAL;
+	}
+
+	*out = lval;
+	return 0;
+}
+
+static int parse_long_range(long *out, const struct shell *shell,
+			    const char *arg, const char *name, long min,
+			    long max)
+{
+	int ret;
+
+	ret = parse_long(out, shell, arg);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (*out < min || *out > max) {
+		shell_error(shell, "Parameter '%s' is out of range. "
+			    "Valid range is %li -- %li.",
+			    name, min, max);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int parse_freq(u32_t *out, const struct shell *shell, const char *arg)
+{
+	char *eptr;
+	long long llval;
+
+	llval = strtoll(arg, &eptr, 0);
+	if (*eptr != '\0') {
+		shell_error(shell, "Invalid frequency, '%s' is not an integer",
+			    arg);
+		return -EINVAL;
+	}
+
+	if (llval < 0 || llval > UINT32_MAX) {
+		shell_error(shell, "Frequency %lli out of range", llval);
+		return -EINVAL;
+	}
+
+	*out = (u32_t)llval;
+	return 0;
+}
+
+static struct device *get_modem(const struct shell *shell)
+{
+	struct device *dev;
+
+	dev = device_get_binding(DEFAULT_RADIO);
+	if (!dev) {
+		shell_error(shell, "%s Device not found", DEFAULT_RADIO);
+		return NULL;
+	}
+
+	return dev;
+}
+
+static struct device *get_configured_modem(const struct shell *shell)
+{
+	int ret;
+	struct device *dev;
+
+	dev = get_modem(shell);
+	if (!dev) {
+		return NULL;
+	}
+
+	if (modem_config.frequency == 0) {
+		shell_error(shell, "No frequency specified.");
+		return NULL;
+	}
+
+	ret = lora_config(dev, &modem_config);
+	if (ret < 0) {
+		shell_error(shell, "LoRa config failed");
+		return NULL;
+	}
+
+	return dev;
+}
+
+static int lora_conf_dump(const struct shell *shell)
+{
+	shell_print(shell, DEFAULT_RADIO ":");
+	shell_print(shell, "  Frequency: %" PRIu32 " Hz",
+		    modem_config.frequency);
+	shell_print(shell, "  TX power: %" PRIi8 " dBm",
+		    modem_config.tx_power);
+	shell_print(shell, "  Bandwidth: %i kHz",
+		    bw_table[modem_config.bandwidth]);
+	shell_print(shell, "  Spreading factor: SF%i",
+		    (int)modem_config.datarate);
+	shell_print(shell, "  Coding rate: 4/%i",
+		    (int)modem_config.coding_rate + 4);
+	shell_print(shell, "  Preamble length: %" PRIu16,
+		    modem_config.preamble_len);
+
+	return 0;
+}
+
+static int lora_conf_set(const struct shell *shell, const char *param,
+			 const char *value)
+{
+	long lval;
+
+	if (!strcmp("freq", param)) {
+		if (parse_freq(&modem_config.frequency, shell, value) < 0) {
+			return -EINVAL;
+		}
+	} else if (!strcmp("tx-power", param)) {
+		if (parse_long_range(&lval, shell, value,
+				     "tx-power", INT8_MIN, INT8_MAX) < 0) {
+			return -EINVAL;
+		}
+		modem_config.tx_power = lval;
+	} else if (!strcmp("bw", param)) {
+		if (parse_long_range(&lval, shell, value,
+				     "bw", 0, INT8_MAX) < 0) {
+			return -EINVAL;
+		}
+		switch (lval) {
+		case 125:
+			modem_config.bandwidth = BW_125_KHZ;
+			break;
+		case 250:
+			modem_config.bandwidth = BW_250_KHZ;
+			break;
+		case 500:
+			modem_config.bandwidth = BW_500_KHZ;
+			break;
+		default:
+			shell_error(shell, "Invalid bandwidth: %s", lval);
+			return -EINVAL;
+		}
+	} else if (!strcmp("sf", param)) {
+		if (parse_long_range(&lval, shell, value, "sf", 6, 12) < 0) {
+			return -EINVAL;
+		}
+		modem_config.datarate = SF_6 + (unsigned int)lval - 6;
+	} else if (!strcmp("cr", param)) {
+		if (parse_long_range(&lval, shell, value, "cr", 5, 8) < 0) {
+			return -EINVAL;
+		}
+		modem_config.coding_rate = CR_4_5 + (unsigned int)lval - 5;
+	} else if (!strcmp("pre-len", param)) {
+		if (parse_long_range(&lval, shell, value,
+				     "pre-len", 0, UINT16_MAX) < 0) {
+			return -EINVAL;
+		}
+		modem_config.preamble_len = lval;
+	} else {
+		shell_error(shell, "Unknown parameter '%s'", param);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int cmd_lora_conf(const struct shell *shell, size_t argc, char **argv)
+{
+	int i;
+	int ret;
+
+	if (argc < 2) {
+		return lora_conf_dump(shell);
+	}
+
+	for (i = 1; i < argc; i += 2) {
+		if (i + 1 >= argc) {
+			shell_error(shell, "'%s' expects an argument",
+				    argv[i]);
+			return -EINVAL;
+		}
+
+		ret = lora_conf_set(shell, argv[i], argv[i + 1]);
+		if (ret != 0) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+static int cmd_lora_send(const struct shell *shell,
+			size_t argc, char **argv)
+{
+	int ret;
+	struct device *dev;
+
+	modem_config.tx = true;
+	dev = get_configured_modem(shell);
+	if (!dev) {
+		return -ENODEV;
+	}
+
+	ret = lora_send(dev, argv[1], strlen(argv[1]));
+	if (ret < 0) {
+		shell_error(shell, "LoRa send failed: %i", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int cmd_lora_recv(const struct shell *shell, size_t argc, char **argv)
+{
+	static char buf[0xff];
+	struct device *dev;
+	long timeout = 0;
+	int ret;
+	s16_t rssi;
+	s8_t snr;
+
+	modem_config.tx = false;
+	dev = get_configured_modem(shell);
+	if (!dev) {
+		return -ENODEV;
+	}
+
+	if (argc >= 2 && parse_long_range(&timeout, shell, argv[1],
+					  "timeout", 0, INT_MAX) < 0) {
+		return -EINVAL;
+	}
+
+	ret = lora_recv(dev, buf, sizeof(buf),
+			timeout ? K_MSEC(timeout) : K_FOREVER, &rssi, &snr);
+	if (ret < 0) {
+		shell_error(shell, "LoRa recv failed: %i", ret);
+		return ret;
+	}
+
+	shell_hexdump(shell, buf, ret);
+	shell_print(shell, "RSSI: %" PRIi16 " dBm, SNR:%" PRIi8 " dBm",
+		    rssi, snr);
+
+	return 0;
+}
+
+static int cmd_lora_test_cw(const struct shell *shell,
+			    size_t argc, char **argv)
+{
+	struct device *dev;
+	int ret;
+	u32_t freq;
+	long power, duration;
+
+	dev = get_modem(shell);
+	if (!dev) {
+		return -ENODEV;
+	}
+
+	if (parse_freq(&freq, shell, argv[1]) < 0 ||
+	    parse_long_range(&power, shell, argv[2],
+			     "power", INT8_MIN, INT8_MAX) < 0 ||
+	    parse_long_range(&duration, shell, argv[3],
+			     "duration", 0, UINT16_MAX) < 0) {
+		return -EINVAL;
+	}
+
+	ret = lora_test_cw(dev, (u32_t)freq, (s8_t)power, (u16_t)duration);
+	if (ret < 0) {
+		shell_error(shell, "LoRa test CW failed: %i", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_lora,
+	SHELL_CMD(config, NULL,
+		  "Configure the LoRa radio\n"
+		  " Usage: config [freq <Hz>] [tx-power <dBm>] [bw <kHz>] "
+		  "[sf <int>] [cr <int>] [pre-len <int>]\n",
+		  cmd_lora_conf),
+	SHELL_CMD_ARG(send, NULL,
+		      "Send LoRa packet\n"
+		      " Usage: send <data>",
+		      cmd_lora_send, 2, 0),
+	SHELL_CMD_ARG(recv, NULL,
+		      "Receive LoRa packet\n"
+		      " Usage: recv [timeout (ms)]",
+		      cmd_lora_recv, 1, 1),
+	SHELL_CMD_ARG(test_cw, NULL,
+		  "Send a continuous wave\n"
+		  " Usage: test_cw <freq (Hz)> <power (dBm)> <duration (s)>",
+		  cmd_lora_test_cw, 4, 0),
+	SHELL_SUBCMD_SET_END /* Array terminated. */
+);
+
+SHELL_CMD_REGISTER(lora, &sub_lora, "LoRa commands", NULL);

--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -446,6 +446,13 @@ static int sx1276_lora_config(struct device *dev,
 	return 0;
 }
 
+static int sx1276_lora_test_cw(struct device *dev, u32_t frequency,
+			       s8_t tx_power, u16_t duration)
+{
+	Radio.SetTxContinuousWave(frequency, tx_power, duration);
+	return 0;
+}
+
 /* Initialize Radio driver callbacks */
 const struct Radio_s Radio = {
 	.Init = SX1276Init,
@@ -468,6 +475,7 @@ const struct Radio_s Radio = {
 	.IrqProcess = NULL,
 	.RxBoosted = NULL,
 	.SetRxDutyCycle = NULL,
+	.SetTxContinuousWave = SX1276SetTxContinuousWave,
 };
 
 static int sx1276_lora_init(struct device *dev)
@@ -538,6 +546,7 @@ static const struct lora_driver_api sx1276_lora_api = {
 	.config = sx1276_lora_config,
 	.send = sx1276_lora_send,
 	.recv = sx1276_lora_recv,
+	.test_cw = sx1276_lora_test_cw,
 };
 
 DEVICE_AND_API_INIT(sx1276_lora, DT_INST_LABEL(0),

--- a/include/drivers/lora.h
+++ b/include/drivers/lora.h
@@ -75,10 +75,20 @@ typedef int (*lora_api_send)(struct device *dev,
 typedef int (*lora_api_recv)(struct device *dev, u8_t *data, u8_t size,
 			     k_timeout_t timeout, s16_t *rssi, s8_t *snr);
 
+/**
+ * @typedef lora_api_test_cw()
+ * @brief Callback API for transmitting a continuous wave
+ *
+ * @see lora_test_cw() for argument descriptions.
+ */
+typedef int (*lora_api_test_cw)(struct device *dev, u32_t frequency,
+				s8_t tx_power, u16_t duration);
+
 struct lora_driver_api {
 	lora_api_config config;
 	lora_api_send	send;
 	lora_api_recv	recv;
+	lora_api_test_cw test_cw;
 };
 
 /**
@@ -137,6 +147,30 @@ static inline int lora_recv(struct device *dev, u8_t *data, u8_t size,
 	const struct lora_driver_api *api = dev->driver_api;
 
 	return api->recv(dev, data, size, timeout, rssi, snr);
+}
+
+/**
+ * @brief Transmit an unmodulated continuous wave at a given frequency
+ *
+ * @note Only use this functionality in a test setup where the
+ * transmission does not interfere with other devices.
+ *
+ * @param dev       LoRa device
+ * @param frequency Output frequency (Hertz)
+ * @param tx_power  TX power (dBm)
+ * @param duration  Transmission duration in seconds.
+ * @return 0 on success, negative on error
+ */
+static inline int lora_test_cw(struct device *dev, u32_t frequency,
+			       s8_t tx_power, u16_t duration)
+{
+	const struct lora_driver_api *api = dev->driver_api;
+
+	if (!api->test_cw) {
+		return -ENOTSUP;
+	}
+
+	return api->test_cw(dev, frequency, tx_power, duration);
 }
 
 #endif	/* ZEPHYR_INCLUDE_DRIVERS_LORA_H_ */

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -10,6 +10,11 @@
 #include <sys/util.h>
 #include <zephyr.h>
 
+#define DEFAULT_RADIO_NODE DT_ALIAS(lora0)
+BUILD_ASSERT(DT_HAS_NODE_STATUS_OKAY(DEFAULT_RADIO_NODE),
+	     "No default LoRa radio specified in DT");
+#define DEFAULT_RADIO DT_LABEL(DEFAULT_RADIO_NODE)
+
 #define MAX_DATA_LEN 255
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
@@ -25,9 +30,9 @@ void main(void)
 	s16_t rssi;
 	s8_t snr;
 
-	lora_dev = device_get_binding(DT_LABEL(DT_INST(0, semtech_sx1276)));
+	lora_dev = device_get_binding(DEFAULT_RADIO);
 	if (!lora_dev) {
-		LOG_ERR("%s Device not found", DT_LABEL(DT_INST(0, semtech_sx1276)));
+		LOG_ERR("%s Device not found", DEFAULT_RADIO);
 		return;
 	}
 

--- a/samples/drivers/lora/send/src/main.c
+++ b/samples/drivers/lora/send/src/main.c
@@ -10,6 +10,11 @@
 #include <sys/util.h>
 #include <zephyr.h>
 
+#define DEFAULT_RADIO_NODE DT_ALIAS(lora0)
+BUILD_ASSERT(DT_HAS_NODE_STATUS_OKAY(DEFAULT_RADIO_NODE),
+	     "No default LoRa radio specified in DT");
+#define DEFAULT_RADIO DT_LABEL(DEFAULT_RADIO_NODE)
+
 #define MAX_DATA_LEN 10
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
@@ -24,9 +29,9 @@ void main(void)
 	struct lora_modem_config config;
 	int ret;
 
-	lora_dev = device_get_binding(DT_LABEL(DT_INST(0, semtech_sx1276)));
+	lora_dev = device_get_binding(DEFAULT_RADIO);
 	if (!lora_dev) {
-		LOG_ERR("%s Device not found", DT_LABEL(DT_INST(0, semtech_sx1276)));
+		LOG_ERR("%s Device not found", DEFAULT_RADIO);
 		return;
 	}
 


### PR DESCRIPTION
The shell provides a handful of commands that are useful for testing:

- lora conf ...
- lora send ...
- lora recv ...
- lora test_cw ...

Tested with an SX1262 module transmitting packets to a b_l072z_lrwan1 board with a builtin SX1276, both running the Zephyr with the LoRa shell. 

~**NOTE:** There is a dependency between #24649 and this pull request. The current version of this pull request assumes that #24649 hasn't been merged.~

**UPDATE**: Dropped support for timeouts in recv command to break the dependency between this  PR  and #24649.

**UPDATE**: Reintroduced support for timeouts in recv since #24649 has been merged. Much improved argument checking.

**UPDATE**: Rebased and switched to the new shell_hexdump to print received packets. Sorry about the noise.

**UPDATE**: Updated to work with new DT_HAS_NODE_STATUS_OKAY macro.