### PR TITLE
python: subfolder_list.py now generates shorter link names

### DIFF
--- a/scripts/subfolder_list.py
+++ b/scripts/subfolder_list.py
@@ -4,6 +4,7 @@
 import os
 import argparse
 
+
 def touch(trigger):
     # If no trigger file is provided then do a return.
     if trigger is None:
@@ -18,17 +19,20 @@ def touch(trigger):
 
 def main():
     parser = argparse.ArgumentParser(
-        description='This script will walk the specified directory and write the file specified \
-                     with the list of all sub-directories found. If to the output file already \
-                     exists, the file will only be updated in case sub-directories has been added \
-                     or removed since previous invocation.')
+        description='This script will walk the specified directory and write \
+                     the file specified with the list of all sub-directories \
+                     found. If to the output file already exists, the file \
+                     will only be updated in case sub-directories has been \
+                     added or removed since previous invocation.')
 
     parser.add_argument('-d', '--directory', required=True,
                         help='Directory to walk for sub-directory discovery')
     parser.add_argument('-c', '--create-links', required=False,
-                        help='Create links for each directory found in directory given')
+                        help='Create links for each directory found in \
+                              directory given')
     parser.add_argument('-o', '--out-file', required=True,
-                        help='File to write containing a list of all directories found')
+                        help='File to write containing a list of all \
+                              directories found')
     parser.add_argument('-t', '--trigger-file', required=False,
                         help='Trigger file to be be touched to re-run CMake')
 
@@ -39,7 +43,8 @@ def main():
         if not os.path.exists(args.create_links):
             os.makedirs(args.create_links)
         directory = args.directory
-        symlink   = args.create_links + os.path.sep + directory.replace(os.path.sep, '_')
+        symbase = os.path.basename(directory)
+        symlink = args.create_links + os.path.sep + symbase
         if not os.path.exists(symlink):
             os.symlink(directory, symlink)
         dirlist.extend(symlink)
@@ -50,16 +55,18 @@ def main():
         dirs.sort()
         for subdir in dirs:
             if args.create_links is not None:
-                directory = os.path.join(root, subdir)
-                symlink   = args.create_links + os.path.sep + directory.replace(os.path.sep, '_')
+                targetdirectory = os.path.join(root, subdir)
+                reldir = os.path.relpath(targetdirectory, directory)
+                linkname = symbase + '_' + reldir.replace(os.path.sep, '_')
+                symlink = args.create_links + os.path.sep + linkname
                 if not os.path.exists(symlink):
-                    os.symlink(directory, symlink)
+                    os.symlink(targetdirectory, symlink)
                 dirlist.extend(symlink)
             else:
                 dirlist.extend(os.path.join(root, subdir))
             dirlist.extend(os.linesep)
 
-    new      = ''.join(dirlist)
+    new = ''.join(dirlist)
     existing = ''
 
     if os.path.exists(args.out_file):
@@ -75,6 +82,7 @@ def main():
 
     # Always touch trigger file to ensure json files are updated
     touch(args.trigger_file)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Fixes: #24576

The name of the symbolic link would be constructed using the full path
name to the target folder.

This is not needed and caused the issue raised in #24576.

This has been fixed by no longer using the toplevel target directory
in the link name, for example:
Old style: _project_zephyr_workspace_zephyr_include_sys
New style: include_sys

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>