### PR TITLE
Fix net_if_send_data for non-l2 iface 

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -356,6 +356,12 @@ enum net_verdict net_if_send_data(struct net_if *iface, struct net_pkt *pkt)
 		goto done;
 	}
 
+	if (IS_ENABLED(CONFIG_NET_OFFLOAD) && !net_if_l2(iface)) {
+		NET_WARN("no l2 for iface %p, discard pkt", iface);
+		verdict = NET_DROP;
+		goto done;
+	}
+
 	/* If the ll address is not set at all, then we must set
 	 * it here.
 	 * Workaround Linux bug, see:


### PR DESCRIPTION
Some services like DHCHPv4 directly send raw packets to the iface.
This causes issue when the iface does not implement l2, e.g.
because it is a socket offload interface. fix that.

Fixes: #24382
Signed-off-by: Loic Poulain <loic.poulain@linaro.org>