### PR TITLE
boards: arm: mimxrt106x_evk: Remove stale eth1 ref in devicetree

### DIFF
--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -82,8 +82,6 @@
 			};
 		};
 	};
-
-	/delete-node/ eth1;
 };
 
 arduino_serial: &lpuart3 {};

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -91,8 +91,6 @@
 			};
 		};
 	};
-
-	/delete-node/ eth1;
 };
 
 arduino_i2c: &lpi2c1 {};


### PR DESCRIPTION
In conversion of nodelabels to match SoC docs, we missed a case in the
board dts files.  However these delete-node commands are not needed as
we normally handle this via the 'status' property being disabled which
enet2 is by default in the SoC dtsi files.  So we can safely just remove
the stale /delete-node/ eth1 lines.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>