### PR TITLE
drivers: uart_nrfx_uarte: Fix implementation of uart_irq_tx_ready()

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1070,13 +1070,15 @@ static void uarte_nrfx_irq_tx_disable(struct device *dev)
 static int uarte_nrfx_irq_tx_ready_complete(struct device *dev)
 {
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
+	struct uarte_nrfx_data *data = get_dev_data(dev);
 
 	/* ENDTX flag is always on so that ISR is called when we enable TX IRQ.
 	 * Because of that we have to explicitly check if ENDTX interrupt is
 	 * enabled, otherwise this function would always return true no matter
 	 * what would be the source of interrupt.
 	 */
-	return nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_ENDTX) &&
+	return !data->int_driven->disable_tx_irq &&
+	       nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_ENDTX) &&
 	       nrf_uarte_int_enable_check(uarte, NRF_UARTE_INT_ENDTX_MASK);
 }
 


### PR DESCRIPTION
Although it is not clearly specified in the UART API, this function
is supposed to return 0 when the TX interrupt is disabled, regardless
of whether anything could fit into the TX buffer or not (this can be
concluded from looking at implementations of several samples and tests
present in the tree, also almost all UART drivers are implemented this
way).

The problem in the uart_nrfx_uarte driver case is that the flag that
allows generation of the TX interrupt is not cleared directly in the
uart_irq_tx_disable() function but this clearing is deferred to the
end of the current transmission, in case one is in progress, and hence
it is done in the interrupt handler. Consequently, when the interrupt
handler is not entered between calls to uart_irq_tx_disable() and
uart_irq_tx_ready() (e.g. when both functions are called in a loop
executed in the interrupt context), the latter may return an invalid
value.

Fix this problem by additionally checking if the TX interrupt was
requested to be disabled, not only if it is already disabled in
hardware.

Fixes #24479.