### PR TITLE
microchip: Espi reset and oobrst fixs

### DIFF
--- a/drivers/espi/espi_mchp_xec.c
+++ b/drivers/espi/espi_mchp_xec.c
@@ -574,6 +574,15 @@ static void espi_init_flash(struct device *dev)
 }
 #endif
 
+static void espi_bus_init(struct device *dev)
+{
+	const struct espi_xec_config *config = dev->config->config_info;
+
+	/* Enable bus interrupts */
+	MCHP_GIRQ_ENSET(config->bus_girq_id) = MCHP_ESPI_ESPI_RST_GIRQ_VAL |
+		MCHP_ESPI_VW_EN_GIRQ_VAL | MCHP_ESPI_PC_GIRQ_VAL;
+}
+
 static void espi_rst_isr(struct device *dev)
 {
 	u8_t rst_sts;
@@ -586,7 +595,7 @@ static void espi_rst_isr(struct device *dev)
 	ESPI_CAP_REGS->ERST_STS |= MCHP_ESPI_RST_ISTS;
 
 	if (rst_sts & MCHP_ESPI_RST_ISTS) {
-		if (rst_sts & ~MCHP_ESPI_RST_ISTS_PIN_RO_HI) {
+		if (rst_sts & MCHP_ESPI_RST_ISTS_PIN_RO_HI) {
 			data->espi_rst_asserted = 1;
 		} else {
 			data->espi_rst_asserted = 0;
@@ -600,6 +609,7 @@ static void espi_rst_isr(struct device *dev)
 #ifdef CONFIG_ESPI_FLASH_CHANNEL
 		espi_init_flash(dev);
 #endif
+		espi_bus_init(dev);
 	}
 }
 

--- a/drivers/espi/espi_mchp_xec.c
+++ b/drivers/espi/espi_mchp_xec.c
@@ -1136,8 +1136,8 @@ static int espi_xec_init(struct device *dev)
 	/* Enable aggregated block interrupts for VWires */
 	MCHP_GIRQ_ENSET(config->vw_girq_id) = MEC_ESPI_MSVW00_SRC0_VAL |
 		MEC_ESPI_MSVW00_SRC1_VAL | MEC_ESPI_MSVW00_SRC2_VAL |
-		MEC_ESPI_MSVW01_SRC1_VAL | MEC_ESPI_MSVW02_SRC0_VAL |
-		MEC_ESPI_MSVW03_SRC0_VAL;
+		MEC_ESPI_MSVW01_SRC1_VAL | MEC_ESPI_MSVW01_SRC2_VAL |
+		MEC_ESPI_MSVW02_SRC0_VAL | MEC_ESPI_MSVW03_SRC0_VAL;
 
 	/* Enable aggregated block interrupts for peripherals supported */
 #ifdef CONFIG_ESPI_PERIPHERAL_8042_KBC


### PR DESCRIPTION
These patches fixes
1. espi bus interrupt miss after reset
2. OOB_RST_WARN interrupt miss 