### PR TITLE
net: tcp2: Refactor tcp_pkt_alloc()

### DIFF
--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -33,10 +33,27 @@
 #endif
 
 #if IS_ENABLED(CONFIG_NET_TEST_PROTOCOL)
-#define tp_pkt_alloc(_pkt) tp_pkt_alloc(_pkt, tp_basename(__FILE__), __LINE__)
+#define tcp_pkt_alloc(_conn, _len)					\
+({									\
+	sa_family_t _family = net_context_get_family((_conn)->context);	\
+	struct net_pkt *_pkt = net_pkt_alloc_with_buffer((_conn)->iface,\
+							 (_len),	\
+							 _family,	\
+							 IPPROTO_TCP,	\
+							 K_NO_WAIT);	\
+									\
+	tp_pkt_alloc(_pkt, tp_basename(__FILE__), __LINE__);		\
+									\
+	_pkt;								\
+})
 #define tcp_pkt_clone(_pkt) tp_pkt_clone(_pkt, tp_basename(__FILE__), __LINE__)
 #define tcp_pkt_unref(_pkt) tp_pkt_unref(_pkt, tp_basename(__FILE__), __LINE__)
 #else
+#define tcp_pkt_alloc(_conn, _len)					\
+	net_pkt_alloc_with_buffer((_conn)->iface, (_len),		\
+				  net_context_get_family((_conn)->context), \
+				  IPPROTO_TCP, K_NO_WAIT)
+
 #define tcp_pkt_clone(_pkt) net_pkt_clone(_pkt, K_NO_WAIT)
 #define tcp_pkt_unref(_pkt) net_pkt_unref(_pkt)
 #endif


### PR DESCRIPTION
In order to fix the line tracking of the TCP packet allocation
with the test protocol enabled, refactor tcp_pkt_alloc(),
so the line of the allocation can be tracked properly.