### PR TITLE
drivers: gpio: mcux_igpio: fix infinite loop

### DIFF
--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -232,7 +232,7 @@ static const struct gpio_driver_api mcux_igpio_driver_api = {
 			    DEVICE_GET(mcux_igpio_##n), 0);		\
 									\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, i, irq));		\
-	} while (1)
+	} while (0)
 
 #define MCUX_IGPIO_INIT(n)						\
 	static int mcux_igpio_##n##_init(struct device *dev);		\


### PR DESCRIPTION
Avoid entering an infinite loop when configuring the the IGPIO IRQ.

Fixes 50129f8dd705e7f3bd49f43fb49ddc4d1ac71f54
Fixes #24579
Fixes #24612

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>