### PR TITLE
sanitycheck: add option for report suffix

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -2313,7 +2313,7 @@ class TestSuite:
                 (100 * len(self.selected_platforms) / len(self.platforms))
             ))
 
-    def save_reports(self, name, report_dir, no_update, release, only_failed):
+    def save_reports(self, name, suffix, report_dir, no_update, release, only_failed):
         if not self.instances:
             return
 
@@ -2330,12 +2330,15 @@ class TestSuite:
             filename = os.path.join(self.outdir, report_name)
             outdir = self.outdir
 
+        if suffix:
+            filename = "{}_{}".format(filename, suffix)
+
         if not no_update:
             self.xunit_report(filename + ".xml", full_report=False, append=only_failed)
             self.xunit_report(filename + "_report.xml", full_report=True, append=only_failed)
             self.csv_report(filename + ".csv")
 
-            self.target_report(outdir, append=only_failed)
+            self.target_report(outdir, suffix, append=only_failed)
             if self.discards:
                 self.discard_report(filename + "_discard.csv")
 
@@ -2802,10 +2805,13 @@ class TestSuite:
                            "reason": reason}
                 cw.writerow(rowdict)
 
-    def target_report(self, outdir, append=False):
+    def target_report(self, outdir, suffix, append=False):
         platforms = {inst.platform.name for _, inst in self.instances.items()}
         for platform in platforms:
-            filename = os.path.join(outdir,"{}.xml".format(platform))
+            if suffix:
+                filename = os.path.join(outdir,"{}_{}.xml".format(platform, suffix))
+            else:
+                filename = os.path.join(outdir,"{}.xml".format(platform))
             self.xunit_report(filename, platform, full_report=True, append=append)
 
 

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -336,6 +336,12 @@ Artificially long but functional example:
         help="""Create a report with a custom name.
         """)
 
+    parser.add_argument(
+        "--report-suffix",
+        help="""Add a suffix to all generated file names, for example to add a
+        version or a commit ID.
+        """)
+
     parser.add_argument("--report-excluded",
                         action="store_true",
                         help="""List all tests that are never run based on current scope and
@@ -904,7 +910,11 @@ def main():
 
     discards = []
 
-    last_run = os.path.join(options.outdir, "sanitycheck.csv")
+    if options.report_suffix:
+        last_run = os.path.join(options.outdir, "sanitycheck_{}.csv".format(options.report_suffix))
+    else:
+        last_run = os.path.join(options.outdir, "sanitycheck.csv")
+
     if options.only_failed:
         suite.load_from_file(last_run, filter_status=['skipped', 'passed'])
         suite.selected_platforms = set(p.platform.name for p in suite.instances.values())
@@ -1063,6 +1073,7 @@ def main():
         print(tabulate(table, headers=header, tablefmt="github"))
 
     suite.save_reports(options.report_name,
+                       options.report_suffix,
                        options.report_dir,
                        options.no_update,
                        options.release,


### PR DESCRIPTION
Add option --report-suffix to append custom string to all generated
files. This is going to be useful for generating results for a specific
version, i.e. --report-suffix zephyr-v2.2.0-1814-ge737761d23