### PR TITLE
drivers: spi: sifive: Fix bug with checking if tx fifo is full

### DIFF
--- a/drivers/spi/spi_sifive.c
+++ b/drivers/spi/spi_sifive.c
@@ -95,7 +95,7 @@ int spi_config(struct device *dev, u32_t frequency, u16_t operation)
 
 void spi_sifive_send(struct device *dev, u16_t frame)
 {
-	while (SPI_REG(dev, REG_TXDATA) & SF_TXDATA_FULL) {
+	while (sys_read32(SPI_REG(dev, REG_TXDATA)) & SF_TXDATA_FULL) {
 	}
 
 	sys_write32((u32_t) frame, SPI_REG(dev, REG_TXDATA));


### PR DESCRIPTION
The check of the SF_TXDATA_FULL flag is only done on the register
address and not on the actual register content.

Signed-off-by: Tobias Svehagen <tobias.svehagen@gmail.com>