### PR TITLE
drivers: flash: replace DT_FLASH_DEV_NAME with DT macro

### DIFF
--- a/boards/posix/native_posix/native_posix.dts
+++ b/boards/posix/native_posix/native_posix.dts
@@ -17,6 +17,7 @@
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,flash = &flash0;
 		zephyr,entropy = &rng;
+		zephyr,flash-controller = &flashcontroller0;
 	};
 
 	aliases {

--- a/boards/posix/nrf52_bsim/nrf52_bsim.dts
+++ b/boards/posix/nrf52_bsim/nrf52_bsim.dts
@@ -30,6 +30,10 @@
 		/delete-property/ qdec-0;
 	};
 
+	chosen {
+		/delete-property/ zephyr,flash-controller;
+	};
+
 	soc {
 		/delete-node/ flash-controller@4001e000;
 		/delete-node/ memory@20000000;

--- a/boards/x86/qemu_x86/qemu_x86.dts
+++ b/boards/x86/qemu_x86/qemu_x86.dts
@@ -33,6 +33,7 @@
 		zephyr,uart-pipe = &uart1;
 		zephyr,bt-mon-uart = &uart1;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,flash-controller = &sim_flash;
 	};
 
 	soc {
@@ -47,7 +48,7 @@
 		};
 	};
 
-	sim_flash {
+	sim_flash: sim_flash {
 		compatible = "zephyr,sim-flash";
 		label = "FLASH_SIMULATOR";
 

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -29,7 +29,7 @@ static int parse_helper(const struct shell *shell, size_t *argc,
 
 	*addr = strtoul((*argv)[1], &endptr, 16);
 	*flash_dev = device_get_binding((*endptr != '\0') ? (*argv)[1] :
-			DT_FLASH_DEV_NAME);
+			DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 	if (!*flash_dev) {
 		shell_error(shell, "Flash driver was not found!");
 		return -ENODEV;

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -14,6 +14,10 @@
 		watchdog0 = &wdt;
 	};
 
+	chosen {
+		zephyr,flash-controller = &eefc;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -15,6 +15,10 @@
 		watchdog0 = &wdt;
 	};
 
+	chosen {
+		zephyr,flash-controller = &eefc;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -16,6 +16,10 @@
 		watchdog0 = &wdt;
 	};
 
+	chosen {
+		zephyr,flash-controller = &eefc;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/atmel/samd2x.dtsi
+++ b/dts/arm/atmel/samd2x.dtsi
@@ -13,6 +13,10 @@
 		watchdog0 = &wdog;
 	};
 
+	chosen {
+		zephyr,flash-controller = &nvmctrl;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/atmel/samd5x.dtsi
+++ b/dts/arm/atmel/samd5x.dtsi
@@ -9,6 +9,10 @@
 #include <dt-bindings/i2c/i2c.h>
 
 / {
+	chosen {
+		zephyr,flash-controller = &nvmctrl;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -17,6 +17,10 @@
 	};
 
 	chosen {
+		zephyr,flash-controller = &eefc;
+	};
+
+	chosen {
 		zephyr,entropy = &trng;
 	};
 

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -39,6 +39,10 @@
 		timer-2 = &timer2;
 	};
 
+	chosen {
+		zephyr,flash-controller = &flash_controller;
+	};
+
 	soc {
 
 		flash_controller: flash-controller@4001e000 {

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -8,6 +8,7 @@
 / {
 	chosen {
 		zephyr,entropy = &rng;
+		zephyr,flash-controller = &flash_controller;
 	};
 
 	cpus {

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -11,6 +11,7 @@
 / {
 	chosen {
 		zephyr,entropy = &rng;
+		zephyr,flash-controller = &flash_controller;
 	};
 
 	cpus {

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -8,6 +8,7 @@
 / {
 	chosen {
 		zephyr,entropy = &rng;
+		zephyr,flash-controller = &flash_controller;
 	};
 
 	cpus {

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -12,6 +12,7 @@
 / {
 	chosen {
 		zephyr,entropy = &rng;
+		zephyr,flash-controller = &flash_controller;
 	};
 
 	cpus {

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -8,6 +8,7 @@
 / {
 	chosen {
 		zephyr,entropy = &rng;
+		zephyr,flash-controller = &flash_controller;
 	};
 
 	cpus {

--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -67,6 +67,10 @@
 		timer-2 = &timer2;
 	};
 
+	chosen {
+		zephyr,flash-controller = &flash_controller;
+	};
+
 	soc {
 		sram0: memory@20000000 {
 			device_type = "memory";

--- a/dts/arm/nordic/nrf5340_cpuappns.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns.dtsi
@@ -61,6 +61,10 @@
 		timer-2 = &timer2;
 	};
 
+	chosen {
+		zephyr,flash-controller = &flash_controller;
+	};
+
 	soc {
 		sram0: memory@20000000 {
 			device_type = "memory";

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -11,6 +11,7 @@
 / {
 	chosen {
 		zephyr,entropy = &rng;
+		zephyr,flash-controller = &flash_controller;
 	};
 
 	cpus {

--- a/dts/arm/nordic/nrf9160.dtsi
+++ b/dts/arm/nordic/nrf9160.dtsi
@@ -67,6 +67,10 @@
 		arm-cryptocell-310 = &cryptocell310;
 	};
 
+	chosen {
+		zephyr,flash-controller = &flash_controller;
+	};
+
 	soc {
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";

--- a/dts/arm/nordic/nrf9160ns.dtsi
+++ b/dts/arm/nordic/nrf9160ns.dtsi
@@ -65,6 +65,10 @@
 		timer-2 = &timer2;
 	};
 
+	chosen {
+		zephyr,flash-controller = &flash_controller;
+	};
+
 	soc {
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";

--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -13,6 +13,7 @@
 / {
 	chosen {
 		zephyr,entropy = &rnga;
+		zephyr,flash-controller = &ftfe;
 	};
 
 	aliases {
@@ -106,7 +107,7 @@
 			#clock-cells = <3>;
 		};
 
-		flash-controller@40020000 {
+		ftfe: flash-controller@40020000 {
 			compatible = "nxp,kinetis-ftfe";
 			label = "FLASH_CTRL";
 			reg = <0x40020000 0x18>;

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -44,6 +44,7 @@
 
 	chosen {
 		zephyr,entropy = &rnga;
+		zephyr,flash-controller = &ftfe;
 	};
 
 	cpus {
@@ -140,7 +141,7 @@
 			#clock-cells = <3>;
 		};
 
-		flash-controller@40020000 {
+		ftfe: flash-controller@40020000 {
 			compatible = "nxp,kinetis-ftfe";
 			label = "FLASH_CTRL";
 			reg = <0x40020000 0x18>;

--- a/dts/arm/nxp/nxp_k8x.dtsi
+++ b/dts/arm/nxp/nxp_k8x.dtsi
@@ -40,6 +40,7 @@
 
 	chosen {
 		zephyr,entropy = &trng;
+		zephyr,flash-controller = &ftfa;
 	};
 
 	cpus {
@@ -80,7 +81,7 @@
 			enable-external-reference;
 		};
 
-		flash_controller: flash-controller@40020000 {
+		ftfa: flash-controller@40020000 {
 			compatible = "nxp,kinetis-ftfa";
 			label = "FLASH_CTRL";
 			reg = <0x40020000 0x1000>;

--- a/dts/arm/nxp/nxp_k8xfn256vxx15.dtsi
+++ b/dts/arm/nxp/nxp_k8xfn256vxx15.dtsi
@@ -28,7 +28,7 @@
 	};
 };
 
-&flash_controller {
+&ftfa {
 	flash0: flash@0 {
 		compatible = "soc-nv-flash";
 		label = "MCUX_FLASH";

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -39,6 +39,10 @@
 		pwm-3 = &ftm3;
 	};
 
+	chosen {
+		zephyr,flash-controller = &ftfe;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -155,7 +159,7 @@
 			label = "WDT_0";
 		};
 
-		flash_controller: flash-controller@40020000 {
+		ftfe: flash-controller@40020000 {
 			compatible = "nxp,kinetis-ftfe";
 			label = "FLASH_CTRL";
 			reg = <0x40020000 0x1000>;

--- a/dts/arm/nxp/nxp_ke1xf256vlx16.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf256vlx16.dtsi
@@ -28,7 +28,7 @@
 	};
 };
 
-&flash_controller {
+&ftfe {
 	flash0: flash@0 {
 		compatible = "soc-nv-flash";
 		label = "MCUX_FLASH";

--- a/dts/arm/nxp/nxp_ke1xf512vlx16.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf512vlx16.dtsi
@@ -28,7 +28,7 @@
 	};
 };
 
-&flash_controller {
+&ftfe {
 	flash0: flash@0 {
 		compatible = "soc-nv-flash";
 		label = "MCUX_FLASH";

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -14,6 +14,10 @@
 		usbd-0 = &usbotg;
 	};
 
+	chosen {
+		zephyr,flash-controller = &ftfa;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -31,7 +35,7 @@
 	};
 
 	soc {
-		flash-controller@40020000 {
+		ftfa: flash-controller@40020000 {
 			compatible = "nxp,kinetis-ftfa";
 			label = "FLASH_CTRL";
 			reg = <0x40020000 0x14>;

--- a/dts/arm/nxp/nxp_kv5x.dtsi
+++ b/dts/arm/nxp/nxp_kv5x.dtsi
@@ -34,6 +34,10 @@
 		uart-5 = &uart5;
 	};
 
+	chosen {
+		zephyr,flash-controller = &ftfe;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -71,7 +75,7 @@
 			enable-external-reference;
 		};
 
-		flash_controller: flash-controller@40020000 {
+		ftfe: flash-controller@40020000 {
 			compatible = "nxp,kinetis-ftfe";
 			label = "FLASH_CTRL";
 			reg = <0x40020000 0x1000>;

--- a/dts/arm/nxp/nxp_kv5xf1m0vlx24.dtsi
+++ b/dts/arm/nxp/nxp_kv5xf1m0vlx24.dtsi
@@ -16,7 +16,7 @@
 	};
 };
 
-&flash_controller {
+&ftfe {
 	flash0: flash@10000000 {
 		compatible = "soc-nv-flash";
 		label = "MCUX_FLASH";

--- a/dts/arm/nxp/nxp_kv5xf512vlx24.dtsi
+++ b/dts/arm/nxp/nxp_kv5xf512vlx24.dtsi
@@ -16,7 +16,7 @@
 	};
 };
 
-&flash_controller {
+&ftfe {
 	flash0: flash@10000000 {
 		compatible = "soc-nv-flash";
 		label = "MCUX_FLASH";

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -30,6 +30,7 @@
 
 	chosen {
 		zephyr,entropy = &rnga;
+		zephyr,flash-controller = &ftfl;
 	};
 
 	cpus {
@@ -78,7 +79,7 @@
 			#clock-cells = <3>;
 		};
 
-		flash-controller@40020000 {
+		ftfl: flash-controller@40020000 {
 			compatible = "nxp,kinetis-ftfl";
 			label = "FLASH_CTRL";
 			reg = <0x40020000 0x18>;

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -23,6 +23,7 @@
 
 	chosen {
 		zephyr,entropy = &trng;
+		zephyr,flash-controller = &ftfa;
 	};
 
 	cpus {
@@ -67,7 +68,7 @@
 			#clock-cells = <3>;
 		};
 
-		flash-controller@40020000 {
+		ftfa: flash-controller@40020000 {
 			compatible = "nxp,kinetis-ftfa";
 			label = "FLASH_CTRL";
 			reg = <0x40020000 0x2c>;

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -23,6 +23,7 @@
 
 	chosen {
 		zephyr,entropy = &trng;
+		zephyr,flash-controller = &ftfa;
 	};
 
 	cpus {
@@ -70,7 +71,7 @@
 			#clock-cells = <3>;
 		};
 
-		flash-controller@40020000 {
+		ftfa: flash-controller@40020000 {
 			compatible = "nxp,kinetis-ftfa";
 			label = "FLASH_CTRL";
 			reg = <0x40020000 0x2c>;

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -15,6 +15,10 @@
 		gpio-1 = &gpio1;
 	};
 
+	chosen {
+		zephyr,flash-controller = &iap;
+	};
+
 	cpus: cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/silabs/efm32_jg_pg_12b.dtsi
+++ b/dts/arm/silabs/efm32_jg_pg_12b.dtsi
@@ -13,6 +13,7 @@
 / {
 	chosen {
 		zephyr,entropy = &trng0;
+		zephyr,flash-controller = &msc;
 	};
 
 	cpus {
@@ -26,7 +27,7 @@
 	};
 
 	soc {
-		flash-controller@400e0000 {
+		msc: flash-controller@400e0000 {
 			compatible = "silabs,gecko-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x400e0000 0x104>;

--- a/dts/arm/silabs/efm32gg11b.dtsi
+++ b/dts/arm/silabs/efm32gg11b.dtsi
@@ -11,6 +11,10 @@
 #include "gpio_gecko.h"
 
 / {
+	chosen {
+		zephyr,flash-controller = &msc;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -27,7 +31,7 @@
 	};
 
 	soc {
-		flash-controller@40000000 {
+		msc: flash-controller@40000000 {
 			compatible = "silabs,gecko-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x40000000 0x110>;

--- a/dts/arm/silabs/efm32hg.dtsi
+++ b/dts/arm/silabs/efm32hg.dtsi
@@ -6,6 +6,10 @@
 #include "gpio_gecko.h"
 
 / {
+	chosen {
+		zephyr,flash-controller = &msc;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -21,7 +25,7 @@
 	};
 
 	soc {
-		flash-controller@400c0000 {
+		msc: flash-controller@400c0000 {
 			compatible = "silabs,gecko-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x400c0000 0x5c>;

--- a/dts/arm/silabs/efm32wg.dtsi
+++ b/dts/arm/silabs/efm32wg.dtsi
@@ -6,6 +6,10 @@
 #include "gpio_gecko.h"
 
 / {
+	chosen {
+		zephyr,flash-controller = &msc;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -21,7 +25,7 @@
 	};
 
 	soc {
-		flash-controller@400c0000 {
+		msc: flash-controller@400c0000 {
 			compatible = "silabs,gecko-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x400c0000 0x78>;

--- a/dts/arm/silabs/efr32bg13p.dtsi
+++ b/dts/arm/silabs/efr32bg13p.dtsi
@@ -10,6 +10,10 @@
 #include "gpio_gecko.h"
 
 / {
+	chosen {
+		zephyr,flash-controller = &msc;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -25,7 +29,7 @@
 	};
 
 	soc {
-		flash-controller@400e0000 {
+		msc: flash-controller@400e0000 {
 			compatible = "silabs,gecko-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x400e0000 0x104>;

--- a/dts/arm/silabs/efr32fg1p.dtsi
+++ b/dts/arm/silabs/efr32fg1p.dtsi
@@ -6,6 +6,10 @@
 #include "gpio_gecko.h"
 
 / {
+	chosen {
+		zephyr,flash-controller = &msc;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -21,7 +25,7 @@
 	};
 
 	soc {
-		flash-controller@400e0000 {
+		msc: flash-controller@400e0000 {
 			compatible = "silabs,gecko-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x400e0000 0x78>;

--- a/dts/arm/silabs/efr32mg.dtsi
+++ b/dts/arm/silabs/efr32mg.dtsi
@@ -8,6 +8,7 @@
 / {
 	chosen {
 		zephyr,entropy = &trng0;
+		zephyr,flash-controller = &msc;
 	};
 
 	cpus {
@@ -25,7 +26,7 @@
 	};
 
 	soc {
-		flash-controller@400e0000 {
+		msc: flash-controller@400e0000 {
 			compatible = "silabs,gecko-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x400e0000 0x104>;

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -11,6 +11,10 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
+	chosen {
+		zephyr,flash-controller = &flash;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -27,7 +31,7 @@
 	};
 
 	soc {
-		flash-controller@40022000 {
+		flash: flash-controller@40022000 {
 			compatible = "st,stm32-flash-controller", "st,stm32f0-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x40022000 0x400>;

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -11,6 +11,10 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
+	chosen {
+		zephyr,flash-controller = &flash;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -29,7 +33,7 @@
 
 	soc {
 
-		flash-controller@40022000 {
+		flash: flash-controller@40022000 {
 			compatible = "st,stm32-flash-controller", "st,stm32f1-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x40022000 0x400>;

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -10,6 +10,10 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
+	chosen {
+		zephyr,flash-controller = &flash;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -26,7 +30,7 @@
 	};
 
 	soc {
-		flash-controller@40023c00 {
+		flash: flash-controller@40023c00 {
 			compatible = "st,stm32-flash-controller", "st,stm32f2-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x40023c00 0x400>;

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -11,6 +11,10 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
+	chosen {
+		zephyr,flash-controller = &flash;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -27,7 +31,7 @@
 	};
 
 	soc {
-		flash-controller@40022000 {
+		flash: flash-controller@40022000 {
 			compatible = "st,stm32-flash-controller", "st,stm32f3-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x40022000 0x400>;

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -11,6 +11,10 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
+	chosen {
+		zephyr,flash-controller = &flash;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -27,7 +31,7 @@
 	};
 
 	soc {
-		flash-controller@40023c00 {
+		flash: flash-controller@40023c00 {
 			compatible = "st,stm32-flash-controller", "st,stm32f4-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x40023c00 0x400>;

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -13,6 +13,7 @@
 / {
 	chosen {
 		zephyr,entropy = &rng;
+		zephyr,flash-controller = &flash;
 	};
 
 	cpus {
@@ -35,7 +36,7 @@
 	};
 
 	soc {
-		flash-controller@40023c00 {
+		flash: flash-controller@40023c00 {
 			compatible = "st,stm32-flash-controller", "st,stm32f7-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x40023c00 0x400>;

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -13,6 +13,10 @@
 #include <dt-bindings/i2c/i2c.h>
 
 / {
+	chosen {
+		zephyr,flash-controller = &flash;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -29,7 +33,7 @@
 	};
 
 	soc {
-		flash-controller@40022000 {
+		flash: flash-controller@40022000 {
 			compatible = "st,stm32-flash-controller", "st,stm32g0-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x40022000 0x400>;

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -13,6 +13,7 @@
 / {
 	chosen {
 		zephyr,entropy = &rng;
+		zephyr,flash-controller = &flash;
 	};
 
 	cpus {
@@ -54,7 +55,7 @@
 			#io-channel-cells = <1>;
 		};
 
-		flash-controller@40022000 {
+		flash: flash-controller@40022000 {
 			compatible = "st,stm32-flash-controller", "st,stm32g4-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x40022000 0x400>;

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -9,9 +9,13 @@
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/clock/stm32_clock.h>
 #include <dt-bindings/gpio/gpio.h>
- #include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/i2c/i2c.h>
 
 / {
+	chosen {
+		zephyr,flash-controller = &flash;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -32,7 +36,7 @@
 	};
 
 	soc {
-		flash-controller@52002000 {
+		flash: flash-controller@52002000 {
 			compatible = "st,stm32-flash-controller", "st,stm32h7-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x52002000 0x400>;

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -11,6 +11,10 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
+	chosen {
+		zephyr,flash-controller = &flash;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -38,7 +42,7 @@
 		};
 
 		/* Driver does not currently support the l0 flash controller */
-		flash-controller@40022000 {
+		flash: flash-controller@40022000 {
 			compatible = "st,stm32-flash-controller", "st,stm32l0-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x40022000 0x400>;

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -11,6 +11,10 @@
 #include <dt-bindings/i2c/i2c.h>
 
 / {
+	chosen {
+		zephyr,flash-controller = &flash;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -224,7 +228,7 @@
 			label = "STM32_CLK_RCC";
 		};
 
-		flash-controller@40023c00 {
+		flash: flash-controller@40023c00 {
 			compatible = "st,stm32-flash-controller", "st,stm32l1-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x40023c00 0x400>;

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -14,6 +14,7 @@
 / {
 	chosen {
 		zephyr,entropy = &rng;
+		zephyr,flash-controller = &flash;
 	};
 
 	cpus {
@@ -32,7 +33,7 @@
 	};
 
 	soc {
-		flash-controller@40022000 {
+		flash: flash-controller@40022000 {
 			compatible = "st,stm32-flash-controller", "st,stm32l4-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x40022000 0x400>;

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -11,6 +11,10 @@
 #include <dt-bindings/i2c/i2c.h>
 
 / {
+	chosen {
+		zephyr,flash-controller = &flash;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -27,7 +31,7 @@
 	};
 
 	soc {
-		flash-controller@58004000 {
+		flash: flash-controller@58004000 {
 			compatible = "st,stm32-flash-controller", "st,stm32wb-flash-controller";
 			label = "FLASH_CTRL";
 			reg = <0x58004000 0x400>;

--- a/dts/riscv/rv32m1.dtsi
+++ b/dts/riscv/rv32m1.dtsi
@@ -44,6 +44,7 @@
 
 	chosen {
 		zephyr,entropy = &trng;
+		zephyr,flash-controller = &ftfe;
 	};
 
 	cpus {
@@ -556,7 +557,7 @@
 			#pwm-cells = <3>;
 		};
 
-		flash-controller@40023000 {
+		ftfe: flash-controller@40023000 {
 			compatible = "openisa,rv32m1-ftfe";
 			label = "FLASH_CTRL";
 			reg = <0x40023000 0x18>;

--- a/include/devicetree/zephyr.h
+++ b/include/devicetree/zephyr.h
@@ -36,10 +36,23 @@
  *        a label property, that property's value. Undefined otherwise.
  */
 #define DT_CHOSEN_ZEPHYR_ENTROPY_LABEL ""
+
+/**
+ * @def DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL
+ *
+ * @brief If there is a chosen node zephyr,flash-controller property which has
+ *        a label property, that property's value. Undefined otherwise.
+ */
+#define DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL ""
 #endif /* DT_DOXYGEN */
 
 #if DT_NODE_HAS_PROP(DT_CHOSEN(zephyr_entropy), label)
 #define DT_CHOSEN_ZEPHYR_ENTROPY_LABEL DT_LABEL(DT_CHOSEN(zephyr_entropy))
+#endif
+
+#if DT_NODE_HAS_PROP(DT_CHOSEN(zephyr_flash_controller), label)
+#define DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL \
+	DT_LABEL(DT_CHOSEN(zephyr_flash_controller))
 #endif
 
 /**

--- a/samples/bluetooth/mesh_demo/src/microbit.c
+++ b/samples/bluetooth/mesh_demo/src/microbit.c
@@ -249,7 +249,7 @@ void board_init(u16_t *addr)
 {
 	struct mb_display *disp = mb_display_get();
 
-	nvm = device_get_binding(DT_FLASH_DEV_NAME);
+	nvm = device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 	pwm = device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_sw_pwm)));
 
 	*addr = NRF_UICR->CUSTOMER[0];

--- a/samples/boards/reel_board/mesh_badge/src/reel_board.c
+++ b/samples/boards/reel_board/mesh_badge/src/reel_board.c
@@ -580,7 +580,7 @@ static int erase_storage(void)
 {
 	struct device *dev;
 
-	dev = device_get_binding(DT_FLASH_DEV_NAME);
+	dev = device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 
 	return flash_erase(dev, DT_FLASH_AREA_STORAGE_OFFSET,
 			   DT_FLASH_AREA_STORAGE_SIZE);

--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -27,11 +27,11 @@ LOG_MODULE_REGISTER(app);
 #define PR_WARNING(shell, fmt, ...)				\
 	shell_fprintf(shell, SHELL_WARNING, fmt, ##__VA_ARGS__)
 /*
- * When DT_FLASH_DEV_NAME is available, we use it here. Otherwise,
- * the device can be set at runtime with the set_device command.
+ * When DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL is available, we use it here.
+ * Otherwise the device can be set at runtime with the set_device command.
  */
-#ifndef DT_FLASH_DEV_NAME
-#define DT_FLASH_DEV_NAME ""
+#ifndef DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL
+#define DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL ""
 #endif
 
 /* Command usage info. */
@@ -579,12 +579,14 @@ static int cmd_set_dev(const struct shell *shell, size_t argc, char **argv)
 
 void main(void)
 {
-	flash_device = device_get_binding(DT_FLASH_DEV_NAME);
+	flash_device =
+		device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 	if (flash_device) {
-		printk("Found flash device %s.\n", DT_FLASH_DEV_NAME);
+		printk("Found flash controller %s.\n",
+			DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 		printk("Flash I/O commands can be run.\n");
 	} else {
-		printk("**No flash device found!**\n");
+		printk("**No flash controller found!**\n");
 		printk("Run set_device <name> to specify one "
 		       "before using other commands.\n");
 	}

--- a/samples/drivers/soc_flash_nrf/src/main.c
+++ b/samples/drivers/soc_flash_nrf/src/main.c
@@ -43,7 +43,8 @@ void main(void)
 	printf("\nNordic nRF5 Flash Testing\n");
 	printf("=========================\n");
 
-	flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
+	flash_dev =
+		device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 
 	if (!flash_dev) {
 		printf("Nordic nRF5 flash driver was not found!\n");

--- a/samples/mpu/mpu_test/src/main.c
+++ b/samples/mpu/mpu_test/src/main.c
@@ -50,7 +50,8 @@ static int cmd_write_mcux(const struct shell *shell, size_t argc, char *argv[])
 	u32_t value[2];
 	u32_t offset;
 
-	flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
+	flash_dev =
+		device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 
 	/* 128K reserved to the application */
 	offset = FLASH_MEM + 0x20000;
@@ -80,7 +81,8 @@ static int cmd_write_stm32(const struct shell *shell, size_t argc, char *argv[])
 
 	struct device *flash_dev;
 
-	flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
+	flash_dev =
+		device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 
 	/* 16K reserved to the application */
 	u32_t offset = FLASH_MEM + 0x4000;

--- a/samples/subsys/nvs/src/main.c
+++ b/samples/subsys/nvs/src/main.c
@@ -74,15 +74,16 @@ void main(void)
 	 *	starting at DT_FLASH_AREA_STORAGE_OFFSET
 	 */
 	fs.offset = DT_FLASH_AREA_STORAGE_OFFSET;
-	rc = flash_get_page_info_by_offs(device_get_binding(DT_FLASH_DEV_NAME),
-					 fs.offset, &info);
+	rc = flash_get_page_info_by_offs(
+		device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL),
+		fs.offset, &info);
 	if (rc) {
 		printk("Unable to get page info");
 	}
 	fs.sector_size = info.size;
 	fs.sector_count = 3U;
 
-	rc = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	rc = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 	if (rc) {
 		printk("Flash Init failed\n");
 	}

--- a/subsys/net/lib/openthread/platform/flash.c
+++ b/subsys/net/lib/openthread/platform/flash.c
@@ -24,7 +24,8 @@ otError utilsFlashInit(void)
 	struct flash_pages_info info;
 	size_t pages_count;
 
-	flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
+	flash_dev =
+		device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 
 	if (!flash_dev) {
 		return OT_ERROR_NOT_IMPLEMENTED;

--- a/tests/drivers/flash_simulator/src/main.c
+++ b/tests/drivers/flash_simulator/src/main.c
@@ -63,7 +63,8 @@ static void test_int(void)
 	int rc;
 	off_t i;
 
-	flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
+	flash_dev =
+		device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 
 	zassert_true(flash_dev != NULL,
 		     "Simulated flash driver was not found!");

--- a/tests/subsys/fs/nvs/src/main.c
+++ b/tests/subsys/fs/nvs/src/main.c
@@ -74,7 +74,7 @@ void test_nvs_init(void)
 	fs.sector_size = info.size;
 	fs.sector_count = TEST_SECTOR_COUNT;
 
-	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 }
 
@@ -107,7 +107,7 @@ void test_nvs_write(void)
 {
 	int err;
 
-	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	execute_long_pattern_write(TEST_DATA_ID);
@@ -147,7 +147,7 @@ void test_nvs_corrupted_write(void)
 	u32_t *flash_write_stat;
 	u32_t *flash_max_write_calls;
 
-	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	err = nvs_read(&fs, TEST_DATA_ID, rd_buf, sizeof(rd_buf));
@@ -217,7 +217,7 @@ void test_nvs_gc(void)
 
 	fs.sector_count = 2;
 
-	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	for (u16_t i = 0; i < max_writes; i++) {
@@ -244,7 +244,7 @@ void test_nvs_gc(void)
 
 	}
 
-	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	for (u16_t id = 0; id < max_id; id++) {
@@ -319,7 +319,7 @@ void test_nvs_gc_3sectors(void)
 
 	fs.sector_count = 3;
 
-	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 0,
 		     "unexpected write sector");
@@ -332,7 +332,7 @@ void test_nvs_gc_3sectors(void)
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 
-	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 2,
@@ -347,7 +347,7 @@ void test_nvs_gc_3sectors(void)
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 
-	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 0,
@@ -362,7 +362,7 @@ void test_nvs_gc_3sectors(void)
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 
-	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 1,
@@ -377,7 +377,7 @@ void test_nvs_gc_3sectors(void)
 		     "unexpected write sector");
 	check_content(max_id, &fs);
 
-	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 2,
@@ -443,7 +443,7 @@ void test_nvs_corrupted_sector_close_operation(void)
 	stats_walk(sim_stats, flash_sim_write_calls_find, &flash_write_stat);
 	stats_walk(sim_stats, flash_sim_erase_calls_find, &flash_erase_stat);
 
-	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	for (u16_t i = 0; i < max_writes; i++) {
@@ -475,7 +475,7 @@ void test_nvs_corrupted_sector_close_operation(void)
 	*flash_max_erase_calls = 0;
 	*flash_max_len = 0;
 
-	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	check_content(max_id, &fs);
@@ -496,7 +496,7 @@ void test_nvs_full_sector(void)
 
 	fs.sector_count = 3;
 
-	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	while (1) {
@@ -515,7 +515,7 @@ void test_nvs_full_sector(void)
 	zassert_true(err == 0,  "nvs_delete call failure: %d", err);
 
 	/* the last sector is full now, test re-initialization */
-	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	len = nvs_write(&fs, filling_id, &filling_id, sizeof(filling_id));
@@ -547,7 +547,7 @@ void test_delete(void)
 
 	fs.sector_count = 3;
 
-	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	err = nvs_init(&fs, DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	for (filling_id = 0; filling_id < 10; filling_id++) {

--- a/tests/subsys/storage/flash_map/src/main.c
+++ b/tests/subsys/storage/flash_map/src/main.c
@@ -30,7 +30,8 @@ void test_flash_area_get_sectors(void)
 	zassert_true(rc == 0, "flash_area_open() fail");
 
 	/* First erase the area so it's ready for use. */
-	flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
+	flash_dev =
+		device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 
 	rc = flash_write_protection_set(flash_dev, false);
 	zassert_false(rc, "failed to disable flash write protection");


### PR DESCRIPTION
Replace DT_FLASH_DEV_NAME with DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL.  We now
set zephyr,flash-ctlr in the chosen node of the device tree to the flash
controller device.
(NOTE: For a SoCs with on die flash, this points to the controller and
 not the 'soc-nv-flash' node.  Typically the controller is the parent of
 the 'soc-nv-flash' node).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>