### PR TITLE
dts: board macro cleanup

### DIFF
--- a/boards/arm/lpcxpresso55s69/pinmux.c
+++ b/boards/arm/lpcxpresso55s69/pinmux.c
@@ -49,7 +49,7 @@ static int lpcxpresso_55s69_pinmux_init(struct device *dev)
 
 #endif
 
-#ifdef DT_GPIO_KEYS_SW0_GPIOS_CONTROLLER
+#if DT_PHA_HAS_CELL(DT_ALIAS(sw0), gpios, pin)
 	const u32_t sw0_config = (
 			IOCON_PIO_FUNC0 |
 			IOCON_PIO_MODE_PULLUP |
@@ -59,10 +59,11 @@ static int lpcxpresso_55s69_pinmux_init(struct device *dev)
 			IOCON_PIO_SLEW_STANDARD |
 			IOCON_PIO_OPENDRAIN_DI
 			);
-	pinmux_pin_set(port0, DT_ALIAS_SW0_GPIOS_PIN, sw0_config);
+	pinmux_pin_set(port0, DT_GPIO_PIN(DT_ALIAS(sw0), gpios), sw0_config);
 #endif
 
-#ifdef DT_GPIO_KEYS_SW1_GPIOS_CONTROLLER
+
+#if DT_PHA_HAS_CELL(DT_ALIAS(sw1), gpios, pin)
 	const u32_t sw1_config = (
 			IOCON_PIO_FUNC0 |
 			IOCON_PIO_MODE_PULLUP |
@@ -72,10 +73,10 @@ static int lpcxpresso_55s69_pinmux_init(struct device *dev)
 			IOCON_PIO_SLEW_STANDARD |
 			IOCON_PIO_OPENDRAIN_DI
 			);
-	pinmux_pin_set(port1, DT_ALIAS_SW1_GPIOS_PIN, sw1_config);
+	pinmux_pin_set(port1, DT_GPIO_PIN(DT_ALIAS(sw1), gpios), sw1_config);
 #endif
 
-#ifdef DT_GPIO_KEYS_SW2_GPIOS_CONTROLLER
+#if DT_PHA_HAS_CELL(DT_ALIAS(sw2), gpios, pin)
 	const u32_t sw2_config = (
 			IOCON_PIO_FUNC0 |
 			IOCON_PIO_MODE_PULLUP |
@@ -85,7 +86,7 @@ static int lpcxpresso_55s69_pinmux_init(struct device *dev)
 			IOCON_PIO_SLEW_STANDARD |
 			IOCON_PIO_OPENDRAIN_DI
 			);
-	pinmux_pin_set(port1, DT_ALIAS_SW2_GPIOS_PIN, sw2_config);
+	pinmux_pin_set(port1, DT_GPIO_PIN(DT_ALIAS(sw2), gpios), sw2_config);
 #endif
 
 #if DT_HAS_NODE(DT_NODELABEL(flexcomm4)) && \

--- a/boards/arm/warp7_m4/pinmux.c
+++ b/boards/arm/warp7_m4/pinmux.c
@@ -20,7 +20,7 @@ static int warp7_m4_pinmux_init(struct device *dev)
 		IOMUXC_SW_PAD_CTL_PAD_ENET1_RGMII_RD0_DSE(0);
 #endif
 
-#ifdef DT_ALIAS_SW0_GPIOS_PIN
+#if DT_PHA_HAS_CELL(DT_ALIAS(sw0), gpios, pin)
 	IOMUXC_SW_MUX_CTL_PAD_ENET1_RGMII_RD1 =
 		IOMUXC_SW_MUX_CTL_PAD_ENET1_RGMII_RD1_MUX_MODE(5);
 #endif

--- a/boards/riscv/rv32m1_vega/pinmux.c
+++ b/boards/riscv/rv32m1_vega/pinmux.c
@@ -112,16 +112,17 @@ static int rv32m1_vega_pinmux_init(struct device *dev)
 	pinmux_pin_set(portd, 4, PORT_PCR_MUX(kPORT_MuxAsGpio));
 	pinmux_pin_set(portd, 5, PORT_PCR_MUX(kPORT_MuxAsGpio));
 
-	struct device *gpio_dev = device_get_binding(DT_ALIAS_GPIO_B_LABEL);
+	struct device *gpio_dev =
+		device_get_binding(DT_LABEL(DT_NODELABEL(gpiob));
 
 	gpio_pin_configure(gpio_dev, 29, GPIO_OUTPUT);
 
-	gpio_dev = device_get_binding(DT_ALIAS_GPIO_C_LABEL);
+	gpio_dev = device_get_binding(DT_LABEL(DT_NODELABEL(gpioc));
 	gpio_pin_configure(gpio_dev, 28, GPIO_OUTPUT);
 	gpio_pin_configure(gpio_dev, 29, GPIO_OUTPUT);
 	gpio_pin_configure(gpio_dev, 30, GPIO_OUTPUT);
 
-	gpio_dev = device_get_binding(DT_ALIAS_GPIO_D_LABEL);
+	gpio_dev = device_get_binding(DT_LABEL(DT_NODELABEL(gpiod));
 	gpio_pin_configure(gpio_dev, 0, GPIO_OUTPUT);
 	gpio_pin_configure(gpio_dev, 1, GPIO_OUTPUT);
 	gpio_pin_configure(gpio_dev, 2, GPIO_OUTPUT);


### PR DESCRIPTION
cleanup several boards related to GPIO SW button and DT_ALIAS defines to new dts devicetree.h macros.