### PR TITLE
drivers: lora: sx1276: Consistently set CRC in lora_config

### DIFF
--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -424,16 +424,30 @@ static int sx1276_lora_config(struct device *dev,
 	Radio.SetChannel(config->frequency);
 
 	if (config->tx) {
-		Radio.SetTxConfig(MODEM_LORA, config->tx_power, 0,
+		Radio.SetTxConfig(MODEM_LORA, config->tx_power,
+				  0 /* fdev */,
 				  config->bandwidth, config->datarate,
 				  config->coding_rate, config->preamble_len,
-				  false, true, 0, 0, false, 4000);
+				  false /* fixLen */,
+				  true /* crcOn */,
+				  false /* freqHopOn */,
+				  0 /* hopPeriod */,
+				  false /* iqInverted */,
+				  4000 /* timeout (ms) */);
 	} else {
 		/* TODO: Get symbol timeout value from config parameters */
 		Radio.SetRxConfig(MODEM_LORA, config->bandwidth,
 				  config->datarate, config->coding_rate,
-				  0, config->preamble_len, 10, false, 0,
-				  false, 0, 0, false, true);
+				  0 /* bandwidthAfc */,
+				  config->preamble_len,
+				  10 /* symbTimeout */,
+				  false /* fixLen */,
+				  0 /* payloadLen */,
+				  true /* crcOn */,
+				  false /* freqHopOn */,
+				  0 /* hopPeriod */,
+				  false /* iqInverted */,
+				  true /* rxContinuous */);
 	}
 
 	return 0;


### PR DESCRIPTION
The RX and TX configurations differ in the way they enable CRCs. Enable CRCs in both cases.
