### PR TITLE
drivers: eth: mcux: Make MAC address Kconfig global for driver

### DIFF
--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -49,24 +49,17 @@ config ETH_MCUX_TX_BUFFERS
 	help
 	  Set the number of TX buffers provided to the MCUX driver.
 
-config ETH_MCUX_0
-	bool "MCUX Ethernet port 0"
-	help
-	  Include port 0 driver
-
-if ETH_MCUX_0
-
-choice ETH_MCUX_0_MAC_SELECT
+choice ETH_MCUX_MAC_SELECT
 	prompt "MAC address"
 	help
 	  Choose how to configure MAC address.
 
-config ETH_MCUX_0_UNIQUE_MAC
+config ETH_MCUX_UNIQUE_MAC
 	bool "Stable MAC address"
 	help
 	  Generate MAC address from MCU's unique identification register.
 
-config ETH_MCUX_0_RANDOM_MAC
+config ETH_MCUX_RANDOM_MAC
 	bool "Random MAC address"
 	help
 	  Generate a random MAC address dynamically on each reboot.
@@ -75,50 +68,23 @@ config ETH_MCUX_0_RANDOM_MAC
 	  delays in communication. (Use "ip neigh flush all" on Linux
 	  peers to clear ARP cache.)
 
-config ETH_MCUX_0_MANUAL_MAC
+config ETH_MCUX_MANUAL_MAC
 	bool "Manual MAC address"
 	help
 	  Get MAC address from the device tree.
 
 endchoice
 
-endif # ETH_MCUX_0
+config ETH_MCUX_0
+	bool "MCUX Ethernet port 0"
+	help
+	  Include port 0 driver
 
 config ETH_MCUX_1
 	bool "MCUX Ethernet port 1"
 	depends on SOC_MIMXRT1062 || SOC_MIMXRT1064
 	help
 	  Include port 1 driver
-
-if ETH_MCUX_1
-
-choice ETH_MCUX_1_MAC_SELECT
-	prompt "MAC address"
-	help
-	  Choose how to configure MAC address.
-
-config ETH_MCUX_1_UNIQUE_MAC
-	bool "Stable MAC address"
-	help
-	  Generate MAC address from MCU's unique identification register.
-
-config ETH_MCUX_1_RANDOM_MAC
-	bool "Random MAC address"
-	help
-	  Generate a random MAC address dynamically on each reboot.
-	  Note that using this choice and rebooting a board may leave
-	  stale MAC address in peers' ARP caches and lead to issues and
-	  delays in communication. (Use "ip neigh flush all" on Linux
-	  peers to clear ARP cache.)
-
-config ETH_MCUX_1_MANUAL_MAC
-	bool "Manual MAC address"
-	help
-	  Get MAC address from the device tree.
-
-endchoice
-
-endif # ETH_MCUX_1
 
 config ETH_MCUX_HW_ACCELERATION
 	bool "Enable hardware acceleration"

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -874,8 +874,7 @@ static void eth_callback(ENET_Type *base, enet_handle_t *handle,
 	}
 }
 
-#if defined(CONFIG_ETH_MCUX_0_RANDOM_MAC) || \
-    defined(CONFIG_ETH_MCUX_1_RANDOM_MAC)
+#if defined(CONFIG_ETH_MCUX_RANDOM_MAC)
 static void generate_random_mac(u8_t *mac_addr)
 {
 	u32_t entropy;
@@ -890,8 +889,7 @@ static void generate_random_mac(u8_t *mac_addr)
 }
 #endif
 
-#if defined(CONFIG_ETH_MCUX_0_UNIQUE_MAC) || \
-    defined(CONFIG_ETH_MCUX_1_UNIQUE_MAC)
+#if defined(CONFIG_ETH_MCUX_UNIQUE_MAC)
 static void generate_eth0_unique_mac(u8_t *mac_addr)
 {
 	/* Trivially "hash" up to 128 bits of MCU unique identifier */
@@ -910,7 +908,7 @@ static void generate_eth0_unique_mac(u8_t *mac_addr)
 }
 #endif
 
-#if defined(CONFIG_ETH_MCUX_1_UNIQUE_MAC)
+#if defined(CONFIG_ETH_MCUX_UNIQUE_MAC) && defined(CONFIG_ETH_MCUX_1)
 static void generate_eth1_unique_mac(u8_t *mac_addr)
 {
 	generate_eth0_unique_mac(mac_addr);
@@ -1207,13 +1205,13 @@ static struct eth_context eth_0_context = {
 	.phy_addr = 0U,
 	.phy_duplex = kPHY_FullDuplex,
 	.phy_speed = kPHY_Speed100M,
-#if defined(CONFIG_ETH_MCUX_0_UNIQUE_MAC)
+#if defined(CONFIG_ETH_MCUX_UNIQUE_MAC)
 	.generate_mac = generate_eth0_unique_mac,
 #endif
-#if defined(CONFIG_ETH_MCUX_0_RANDOM_MAC)
+#if defined(CONFIG_ETH_MCUX_RANDOM_MAC)
 	.generate_mac = generate_random_mac,
 #endif
-#if defined(CONFIG_ETH_MCUX_0_MANUAL_MAC)
+#if defined(CONFIG_ETH_MCUX_MANUAL_MAC)
 	.mac_addr = DT_ETH_MCUX_0_MAC,
 	.generate_mac = NULL,
 #endif
@@ -1269,13 +1267,13 @@ static struct eth_context eth_1_context = {
 	.phy_addr = 0U,
 	.phy_duplex = kPHY_FullDuplex,
 	.phy_speed = kPHY_Speed100M,
-#if defined(CONFIG_ETH_MCUX_1_UNIQUE_MAC)
+#if defined(CONFIG_ETH_MCUX_UNIQUE_MAC)
 	.generate_mac = generate_eth1_unique_mac,
 #endif
-#if defined(CONFIG_ETH_MCUX_1_RANDOM_MAC)
+#if defined(CONFIG_ETH_MCUX_RANDOM_MAC)
 	.generate_mac = generate_random_mac,
 #endif
-#if defined(CONFIG_ETH_MCUX_1_MANUAL_MAC)
+#if defined(CONFIG_ETH_MCUX_MANUAL_MAC)
 	.mac_addr = DT_ETH_MCUX_1_MAC,
 	.generate_mac = NULL,
 #endif


### PR DESCRIPTION
Rather than having per instance Kconfig settings for how the mac address
is determined we make this global for the driver.  This helps as we
want to move the driver away from having per Kconfig instance paramaters
and getting instance information from devicetree when needed.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>