### PR TITLE
Bluetooth: host: Remove BT_LE_CONN_OPT_2M option

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -396,6 +396,7 @@ enum {
 	 *  the 37 secondary advertising channels.
 	 *  The advertiser will send primary advertising on LE 1M PHY, and
 	 *  secondary advertising on LE 2M PHY.
+	 *  Connections will be established on LE 2M PHY.
 	 *
 	 *  Without this option the advertiser will send advertising data on the
 	 *  three primary advertising channels.
@@ -412,6 +413,7 @@ enum {
 	 *  support the LE 2M PHY.
 	 *  The advertiser will send primary advertising on LE 1M PHY, and
 	 *  secondary advertising on LE 1M PHY.
+	 *  Connections will be established on LE 1M PHY.
 	 *
 	 *  @note Cannot be set if BT_LE_ADV_OPT_CODED is set.
 	 *
@@ -424,6 +426,7 @@ enum {
 	 *  The advertiser will send both primary and secondary advertising
 	 *  on the LE Coded PHY. This gives the advertiser increased range with
 	 *  the trade-off of lower data rate and higher power consumption.
+	 *  Connections will be established on LE Coded PHY.
 	 *
 	 *  @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
 	 */

--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -276,21 +276,21 @@ int bt_conn_disconnect(struct bt_conn *conn, u8_t reason);
 
 enum {
 	/** Convenience value when no options are specified. */
-	BT_LE_CONN_OPT_NONE = 0,
+	BT_CONN_LE_OPT_NONE = 0,
 
 	/** @brief Enable LE Coded PHY.
 	 *
 	 *  Enable scanning on the LE Coded PHY.
 	 */
-	BT_LE_CONN_OPT_CODED = BIT(0),
+	BT_CONN_LE_OPT_CODED = BIT(0),
 
 	/** @brief Disable LE 1M PHY.
 	 *
 	 *  Disable scanning on the LE 1M PHY.
 	 *
-	 *  @note Requires @ref BT_LE_CONN_OPT_CODED.
+	 *  @note Requires @ref BT_CONN_LE_OPT_CODED.
 	 */
-	BT_LE_CONN_OPT_NO_1M = BIT(1),
+	BT_CONN_LE_OPT_NO_1M = BIT(1),
 };
 
 struct bt_conn_le_create_param {
@@ -346,7 +346,7 @@ struct bt_conn_le_create_param {
  *  Scan continuously by setting scan interval equal to scan window.
  */
 #define BT_CONN_LE_CREATE_CONN \
-	BT_CONN_LE_CREATE_PARAM(BT_LE_CONN_OPT_NONE, \
+	BT_CONN_LE_CREATE_PARAM(BT_CONN_LE_OPT_NONE, \
 				BT_GAP_SCAN_FAST_INTERVAL, \
 				BT_GAP_SCAN_FAST_INTERVAL)
 
@@ -355,7 +355,7 @@ struct bt_conn_le_create_param {
  *  Scan interval: 60 ms.
  */
 #define BT_CONN_LE_CREATE_CONN_AUTO \
-	BT_CONN_LE_CREATE_PARAM(BT_LE_CONN_OPT_NONE, \
+	BT_CONN_LE_CREATE_PARAM(BT_CONN_LE_OPT_NONE, \
 				BT_GAP_SCAN_FAST_INTERVAL, \
 				BT_GAP_SCAN_FAST_WINDOW)
 

--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -281,24 +281,16 @@ enum {
 	/** @brief Enable LE Coded PHY.
 	 *
 	 *  Enable scanning on the LE Coded PHY.
-	 *  Enable connection initiation on the LE Coded PHY.
 	 */
 	BT_LE_CONN_OPT_CODED = BIT(0),
-
-	/** @brief Enable LE 2M PHY.
-	 *
-	 *  Enable connection initiaton on the LE 2M PHY.
-	 */
-	BT_LE_CONN_OPT_2M = BIT(1),
 
 	/** @brief Disable LE 1M PHY.
 	 *
 	 *  Disable scanning on the LE 1M PHY.
-	 *  Disable connection initiation on the LE 1M PHY.
 	 *
 	 *  @note Requires @ref BT_LE_CONN_OPT_CODED.
 	 */
-	BT_LE_CONN_OPT_NO_1M = BIT(2),
+	BT_LE_CONN_OPT_NO_1M = BIT(1),
 };
 
 struct bt_conn_le_create_param {

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1444,8 +1444,6 @@ int bt_le_create_conn_ext(const struct bt_conn *conn)
 	num_phys = (!(bt_dev.create_param.options &
 		      BT_LE_CONN_OPT_NO_1M) ? 1 : 0) +
 		   ((bt_dev.create_param.options &
-		      BT_LE_CONN_OPT_2M) ? 1 : 0) +
-		   ((bt_dev.create_param.options &
 		      BT_LE_CONN_OPT_CODED) ? 1 : 0);
 
 	buf = bt_hci_cmd_create(BT_HCI_OP_LE_EXT_CREATE_CONN, sizeof(*cp) +
@@ -1480,16 +1478,6 @@ int bt_le_create_conn_ext(const struct bt_conn *conn)
 
 	if (!(bt_dev.create_param.options & BT_LE_CONN_OPT_NO_1M)) {
 		cp->phys |= BT_HCI_LE_EXT_SCAN_PHY_1M;
-		phy = net_buf_add(buf, sizeof(*phy));
-		phy->scan_interval = sys_cpu_to_le16(
-			bt_dev.create_param.interval);
-		phy->scan_window = sys_cpu_to_le16(
-			bt_dev.create_param.window);
-		set_phy_conn_param(conn, phy);
-	}
-
-	if (bt_dev.create_param.options & BT_LE_CONN_OPT_2M) {
-		cp->phys |= BT_HCI_LE_EXT_SCAN_PHY_2M;
 		phy = net_buf_add(buf, sizeof(*phy));
 		phy->scan_interval = sys_cpu_to_le16(
 			bt_dev.create_param.interval);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1442,9 +1442,9 @@ int bt_le_create_conn_ext(const struct bt_conn *conn)
 	}
 
 	num_phys = (!(bt_dev.create_param.options &
-		      BT_LE_CONN_OPT_NO_1M) ? 1 : 0) +
+		      BT_CONN_LE_OPT_NO_1M) ? 1 : 0) +
 		   ((bt_dev.create_param.options &
-		      BT_LE_CONN_OPT_CODED) ? 1 : 0);
+		      BT_CONN_LE_OPT_CODED) ? 1 : 0);
 
 	buf = bt_hci_cmd_create(BT_HCI_OP_LE_EXT_CREATE_CONN, sizeof(*cp) +
 				num_phys * sizeof(*phy));
@@ -1476,7 +1476,7 @@ int bt_le_create_conn_ext(const struct bt_conn *conn)
 	cp->own_addr_type = own_addr_type;
 	cp->phys = 0;
 
-	if (!(bt_dev.create_param.options & BT_LE_CONN_OPT_NO_1M)) {
+	if (!(bt_dev.create_param.options & BT_CONN_LE_OPT_NO_1M)) {
 		cp->phys |= BT_HCI_LE_EXT_SCAN_PHY_1M;
 		phy = net_buf_add(buf, sizeof(*phy));
 		phy->scan_interval = sys_cpu_to_le16(
@@ -1486,7 +1486,7 @@ int bt_le_create_conn_ext(const struct bt_conn *conn)
 		set_phy_conn_param(conn, phy);
 	}
 
-	if (bt_dev.create_param.options & BT_LE_CONN_OPT_CODED) {
+	if (bt_dev.create_param.options & BT_CONN_LE_OPT_CODED) {
 		cp->phys |= BT_HCI_LE_EXT_SCAN_PHY_CODED;
 		phy = net_buf_add(buf, sizeof(*phy));
 		phy->scan_interval = sys_cpu_to_le16(

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1211,8 +1211,6 @@ static int cmd_connect_le(const struct shell *shell, size_t argc, char *argv[])
 
 		if (!strcmp(arg, "coded")) {
 			options |= BT_LE_CONN_OPT_CODED;
-		} else if (!strcmp(arg, "2m")) {
-			options |= BT_LE_CONN_OPT_2M;
 		} else if (!strcmp(arg, "no-1m")) {
 			options |= BT_LE_CONN_OPT_NO_1M;
 		} else {
@@ -2133,8 +2131,6 @@ static int cmd_wl_connect(const struct shell *shell, size_t argc, char *argv[])
 
 		if (!strcmp(arg, "coded")) {
 			options |= BT_LE_CONN_OPT_CODED;
-		} else if (!strcmp(arg, "2m")) {
-			options |= BT_LE_CONN_OPT_2M;
 		} else if (!strcmp(arg, "no-1m")) {
 			options |= BT_LE_CONN_OPT_NO_1M;
 		} else {
@@ -2254,14 +2250,12 @@ static int cmd_auth_oob_tk(const struct shell *shell, size_t argc, char *argv[])
 
 #if defined(CONFIG_BT_EXT_ADV)
 #define EXT_ADV_SCAN_OPT " [coded] [no-1m]"
-#define EXT_ADV_CONN_OPT " [coded] [2m] [no-1m]"
 #define EXT_ADV_PARAM "<type: conn-scan conn-nscan, nconn-scan nconn-nscan> " \
 		      "[ext-adv] [no-2m] [coded] "                            \
 		      "[whitelist: wl, wl-scan, wl-conn] [identity] "         \
 		      "[directed "HELP_ADDR_LE"] [mode: low] "
 #else
 #define EXT_ADV_SCAN_OPT ""
-#define EXT_ADV_CONN_OPT ""
 #endif /* defined(CONFIG_BT_EXT_ADV) */
 
 SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
@@ -2307,7 +2301,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 #endif /* CONFIG_BT_BROADCASTER */
 #if defined(CONFIG_BT_CONN)
 #if defined(CONFIG_BT_CENTRAL)
-	SHELL_CMD_ARG(connect, NULL, HELP_ADDR_LE EXT_ADV_CONN_OPT,
+	SHELL_CMD_ARG(connect, NULL, HELP_ADDR_LE EXT_ADV_SCAN_OPT,
 		      cmd_connect_le, 3, 3),
 #if !defined(CONFIG_BT_WHITELIST)
 	SHELL_CMD_ARG(auto-conn, NULL, HELP_ADDR_LE, cmd_auto_conn, 3, 0),
@@ -2355,7 +2349,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 	SHELL_CMD_ARG(wl-clear, NULL, HELP_NONE, cmd_wl_clear, 1, 0),
 
 #if defined(CONFIG_BT_CENTRAL)
-	SHELL_CMD_ARG(wl-connect, NULL, "<on, off>" EXT_ADV_CONN_OPT,
+	SHELL_CMD_ARG(wl-connect, NULL, "<on, off>" EXT_ADV_SCAN_OPT,
 		      cmd_wl_connect, 2, 3),
 #endif /* CONFIG_BT_CENTRAL */
 #endif /* defined(CONFIG_BT_WHITELIST) */

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1210,9 +1210,9 @@ static int cmd_connect_le(const struct shell *shell, size_t argc, char *argv[])
 		const char *arg = argv[argn];
 
 		if (!strcmp(arg, "coded")) {
-			options |= BT_LE_CONN_OPT_CODED;
+			options |= BT_CONN_LE_OPT_CODED;
 		} else if (!strcmp(arg, "no-1m")) {
-			options |= BT_LE_CONN_OPT_NO_1M;
+			options |= BT_CONN_LE_OPT_NO_1M;
 		} else {
 			shell_help(shell);
 			return SHELL_CMD_HELP_PRINTED;
@@ -2130,9 +2130,9 @@ static int cmd_wl_connect(const struct shell *shell, size_t argc, char *argv[])
 		const char *arg = argv[argn];
 
 		if (!strcmp(arg, "coded")) {
-			options |= BT_LE_CONN_OPT_CODED;
+			options |= BT_CONN_LE_OPT_CODED;
 		} else if (!strcmp(arg, "no-1m")) {
-			options |= BT_LE_CONN_OPT_NO_1M;
+			options |= BT_CONN_LE_OPT_NO_1M;
 		} else {
 			shell_help(shell);
 			return SHELL_CMD_HELP_PRINTED;


### PR DESCRIPTION
Remove the BT_LE_CONN_OPT_2M option and update documentation.
This was a misunderstand about the init PHY HCI parameter.
The init PHY in the extended connection create command does not
determine which PHYs are accepted as the initial PHY of the
connection. This is instead determined by the secondary PHY of the
extended advertiser.
The init PHY parameter only specifies which conn parameters are
provided, and since we only provide one conn parameter this option
has no effect.

Rename connection options to be consistent with the rest of the API
names in conn.h