### PR TITLE
Set sram0 to represent the physical RAM in nRF5340 and nRF9160 DKs

### DIFF
--- a/boards/arm/nrf5340pdk_nrf5340/Kconfig.defconfig
+++ b/boards/arm/nrf5340pdk_nrf5340/Kconfig.defconfig
@@ -26,8 +26,8 @@ config BOARD
 # If the secure firmware is to be combined with a non-secure image
 # (TRUSTED_EXECUTION_SECURE=y), the secure FW image SRAM shall always
 # be restricted to the secure image SRAM partition (sram-secure-partition).
-# Otherwise (if TRUSTED_EXECUTION_SECURE is not set) the whole sram0 may be
-# used by the image.
+# Otherwise (if TRUSTED_EXECUTION_SECURE is not set) the whole zephyr,sram
+# may be used by the image.
 #
 # For the non-secure version of the board, the firmware image SRAM is
 # always restricted to the allocated non-secure SRAM partition.

--- a/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp.dts
+++ b/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp.dts
@@ -10,7 +10,7 @@
 
 / {
 	chosen {
-		zephyr,sram = &sram0;
+		zephyr,sram = &sram0_image;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,sram-secure-partition = &sram0_s;

--- a/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp.dts
+++ b/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp.dts
@@ -14,5 +14,6 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,sram-secure-partition = &sram0_s;
+		zephyr,sram-non-secure-partition = &sram0_ns;
 	};
 };

--- a/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp_common.dts
@@ -164,21 +164,23 @@
 	};
 };
 
-&sram0 {
+/ {
 
-	partitions {
-		compatible = "fixed-partitions";
+	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
-		/* SRAM allocated to the Secure image */
-		sram0_s: memory@20000000 {
-			label = "secure_sram_partition";
+		sram0_image: image@20000000 {
+			/* Zephyr image(s) memory */
 		};
 
-		/* SRAM allocated to the Non-Secure image */
-		sram0_ns: memory@20010000 {
-			label = "non_secure_sram_partition";
+		sram0_s: image_s@20000000 {
+			/* Secure image memory */
+		};
+
+		sram0_ns: image_ns@20010000 {
+			/* Non-Secure image memory */
 		};
 	};
 };

--- a/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp_partition_conf.dts
+++ b/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp_partition_conf.dts
@@ -44,7 +44,7 @@
  * - Upper 64 kB SRAM allocated as Shared memory (sram0_shared)
  *   (see nrf5340pdk_nrf5340_shared_sram_planning_conf.dts)
  */
-&sram0 {
+&sram0_image {
 	reg = <0x20000000 DT_SIZE_K(448)>;
 };
 

--- a/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_shared_sram_planning_conf.dts
+++ b/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_shared_sram_planning_conf.dts
@@ -8,7 +8,7 @@
  * This file is included by both nRF5340 CPUAPP (Application MCU)
  * and nRF5340 CPUNET (Network MCU).
  * - 64 kB SRAM allocated as Shared memory (sram0_shared)
- * - Region defined after the secure SRAM partition of CPUAPP
+ * - Region defined after the image SRAM of Application MCU
  */
 
 / {
@@ -17,10 +17,14 @@
 		zephyr,ipc_shm = &sram0_shared;
 	};
 
-	/* SRAM allocated to shared memory */
-	sram0_shared: memory@20070000 {
-		device_type = "memory";
-		compatible = "mmio-sram";
-		reg = <0x20070000 DT_SIZE_K(64)>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		sram0_shared: memory@20070000 {
+			/* SRAM allocated to shared memory */
+			reg = <0x20070000 0x10000>;
+		};
 	};
 };

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160.dts
@@ -10,7 +10,7 @@
 
 / {
 	chosen {
-		zephyr,sram = &sram0;
+		zephyr,sram = &sram0_s;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 	};

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160.dts
@@ -13,5 +13,7 @@
 		zephyr,sram = &sram0_s;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,sram-secure-partition = &sram0_s;
+		zephyr,sram-non-secure-partition = &sram0_ns;
 	};
 };

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -180,6 +180,11 @@
 };
 
 / {
+	/* SRAM allocated to the Secure image */
+	sram0_s: memory@20000000 {
+		label = "secure_sram_memory";
+	};
+
 	/* SRAM allocated and used by the BSD library */
 	sram0_bsd: memory@20010000 {
 		compatible = "mmio-sram";

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -180,19 +180,23 @@
 };
 
 / {
-	/* SRAM allocated to the Secure image */
-	sram0_s: memory@20000000 {
-		label = "secure_sram_memory";
-	};
 
-	/* SRAM allocated and used by the BSD library */
-	sram0_bsd: memory@20010000 {
-		compatible = "mmio-sram";
-	};
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-	/* SRAM allocated to the Non-Secure image */
-	sram0_ns: memory@20020000 {
-		compatible = "mmio-sram";
+		sram0_s: image_s@20000000 {
+			/* Secure image memory */
+		};
+
+		sram0_bsd: image_bsd@20010000 {
+			/* BSD (shared) memory */
+		};
+
+		sram0_ns: image_ns@20020000 {
+			/* Non-Secure image memory */
+		};
 	};
 };
 

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_partition_conf.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_partition_conf.dts
@@ -39,13 +39,13 @@
 
 /* Default SRAM planning when building for nRF9160 with
  * ARM TrustZone-M support
- * - Lowest 64 kB SRAM allocated to Secure image (sram0).
+ * - Lowest 64 kB SRAM allocated to Secure image (sram0_s).
  * - 64 kB SRAM reserved for and used by the BSD socket
- *   library.
+ *   library (sram0_bsd).
  * - Upper 128 kB allocated to Non-Secure image (sram0_ns).
  */
 
-&sram0 {
+&sram0_s {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };
 


### PR DESCRIPTION
**We would like to have `sram0 `DT node represent the available SRAM memory on nrf9160 and nRF5340 SoCs. As such, sram0 shall not be resized in Board DT configuration.**

In DTS we define sram0 node as such, but in boards//nrf5340pdk_ and nrf9160dk_ we have been using sram0 to represent (also) the image RAM allocated to Zephyr builds. The consequence is that sram0 is _resized_ to match the requirements of the specific build (security domain, inter-processor shared memory, etc.), so we do not have a DTS generated macro to represent the total SRAM.

In this PR we fix this problem by having sram0 always represent the physical SRAM. 
For nRF5340 we introduce sram0_image, to represent the RAM available for Zephyr image(s), secure and non-secure.

This PR is also adding additional information regarding reserved memory areas in board DT, such as SRAM memory areas explicitly allocated to secure and non-secure Zephyr execution environment.

