### PR TITLE
drivers: gpio_nrfx: Pass only pins associated with handler

### DIFF
--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -421,7 +421,7 @@ static inline void fire_callbacks(struct device *port, u32_t pins)
 		 */
 		if ((cb->pin_mask & pins) & data->int_en) {
 			__ASSERT(cb->handler, "No callback handler!");
-			cb->handler(port, cb, pins);
+			cb->handler(port, cb, cb->pin_mask & pins);
 		}
 	}
 }


### PR DESCRIPTION
When notifying the handler that GPIO interrupt has occurred
pass only pins that are associated with this handler.

Fixes: #24634

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>