### PR TITLE
gitattributes: Tell linguist to ignore test pattern files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,7 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 .mailmap export-ignore
+
+# Tell linguist that generated test pattern files should not be included in the
+# language statistics.
+*.pat linguist-generated=true


### PR DESCRIPTION
Tell GitHub linguist to ignore the `.pat` generated test pattern files
that are used by the CMSIS-DSP tests (and potentially others as well,
in the future).

This prevents GitHub from classifying them as "Max language" in the
language statistics.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>