### PR TITLE
devicetree: gen_defines: Generate label to node name mappings

### DIFF
--- a/doc/guides/dts/macros.bnf
+++ b/doc/guides/dts/macros.bnf
@@ -43,6 +43,8 @@ node-macro =/ %s"DT_N" path-id %s"_IRQ_NAME_" dt-name
 node-macro =/ %s"DT_N" path-id %s"_COMPAT_MATCHES_" dt-name
 ; The node identifier for the node's parent in the devicetree.
 node-macro =/ %s"DT_N" path-id %s"_PARENT"
+; The node identifier for the list of node's child identifiers.
+node-macro =/ %s"DT_N" path-id %s"_CHILD_IDENTIFIERS"
 
 ; --------------------------------------------------------------------
 ; property-macro: a macro related to a node property

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -145,6 +145,30 @@
  */
 #define DT_NODELABEL(label) DT_CAT(DT_N_NODELABEL_, label)
 
+
+/**
+ * @brief Get node name from its name or label.
+ *
+ * Example, in deficetree fragment:
+ *
+ *     serial0: serial@40002000 {
+ *             status = "okay";
+ *             current-speed = <115200>;
+ *             ...
+ *     };
+ *
+ * Node name is serial@40002000, which in definitions takes from
+ * serial_40002000, and serial0 is label, which takes form serial_0.
+ * Invoking:
+ *
+ *     DT_NODE_NAME(serial_40002000)
+ *     DT_NODE_NAME(serial_0)
+ *
+ * will in both cases evaluate to serial_40002000.
+ */
+#define DT_NODE_NAME(name) DT_CAT(DT_, name##_NODE_NAME))
+
+
 /**
  * @brief Get a node identifier for an alias
  *

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -67,9 +67,31 @@ def main():
             write_bus(node)
             write_special_props(node)
             write_vanilla_props(node)
+            write_node_name_map(node)
 
         write_chosen(edt)
         write_global_compat_info(edt)
+
+
+def write_node_name_map(node):
+    # Generate mappings of node name, from labels and node name itself.
+    if node.parent:
+        out_comment("Node specific translations from labels to node name")
+        node_name = node_id(node)
+        labels = [node_name] + node.labels[:]
+
+        for lbl in labels:
+            out_dt_define(f"{lbl}_NODE_NAME", f"{node_name}")
+
+
+def node_id(node):
+    # Get node identifier, in C acceptable from, for the given node, e.g.:
+    #
+    # - "/foo" will return "foo"
+    # - "/foo/bar@123" will return  "bar_123"
+    if node.parent is not None:
+        component = node.path.split("/")[-1]
+        return f"{str2ident(component)}"
 
 
 def node_z_path_id(node):


### PR DESCRIPTION
DT_NODE_NAME macro has been added that allows mapping of node label.
Supporting code, generating the mapping, has been added to
gen_defines.py.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

- [ ] tests


Purpose of this commit is to allow using node labels to get node names, for example to get access to identifiers that have been generated with node names in path, but for some reason user wants to use label.