### PR TITLE
LoRa improvements

### DIFF
--- a/drivers/lora/Kconfig
+++ b/drivers/lora/Kconfig
@@ -9,7 +9,6 @@
 menuconfig LORA
 	bool "LoRa support [EXPERIMENTAL]"
 	depends on NEWLIB_LIBC
-	select LEGACY_TIMEOUT_API
 	help
 	  Include LoRa drivers in the system configuration.
 

--- a/drivers/lora/Kconfig
+++ b/drivers/lora/Kconfig
@@ -7,7 +7,7 @@
 # Top-level configuration file for LORA drivers.
 
 menuconfig LORA
-	bool "LoRa support"
+	bool "LoRa support [EXPERIMENTAL]"
 	depends on NEWLIB_LIBC
 	select LEGACY_TIMEOUT_API
 	help

--- a/drivers/lora/Kconfig.sx1276
+++ b/drivers/lora/Kconfig.sx1276
@@ -10,7 +10,6 @@ menuconfig LORA_SX1276
 	select HAS_SEMTECH_LORAMAC
 	select HAS_SEMTECH_SX1276
 	depends on SPI
-	depends on COUNTER
 	help
 	  Enable LoRa driver for Semtech SX1276.
 

--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -138,7 +138,7 @@ static void timer_callback(struct k_timer *_timer)
 
 void RtcSetAlarm(u32_t timeout)
 {
-	k_timer_start(&dev_data.timer, timeout, K_NO_WAIT);
+	k_timer_start(&dev_data.timer, K_MSEC(timeout), K_NO_WAIT);
 }
 
 u32_t RtcSetTimerContext(void)
@@ -156,7 +156,7 @@ u32_t RtcGetTimerContext(void)
 
 void DelayMsMcu(u32_t ms)
 {
-	k_sleep(ms);
+	k_sleep(K_MSEC(ms));
 }
 
 u32_t RtcMs2Tick(uint32_t milliseconds)
@@ -384,19 +384,14 @@ static void sx1276_rx_done(u8_t *payload, u16_t size, int16_t rssi, int8_t snr)
 }
 
 static int sx1276_lora_recv(struct device *dev, u8_t *data, u8_t size,
-			    s32_t timeout, s16_t *rssi, s8_t *snr)
+			    k_timeout_t timeout, s16_t *rssi, s8_t *snr)
 {
 	int ret;
 
 	Radio.SetMaxPayloadLength(MODEM_LORA, 255);
 	Radio.Rx(0);
 
-	/*
-	 * As per the API requirement, timeout value can be in ms/K_FOREVER/
-	 * K_NO_WAIT. So, let's handle all cases.
-	 */
-	ret = k_sem_take(&dev_data.data_sem, timeout == K_FOREVER ? K_FOREVER :
-			 timeout == K_NO_WAIT ? K_NO_WAIT : K_MSEC(timeout));
+	ret = k_sem_take(&dev_data.data_sem, timeout);
 	if (ret < 0) {
 		LOG_ERR("Receive timeout!");
 		return ret;

--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -164,6 +164,11 @@ u32_t RtcMs2Tick(uint32_t milliseconds)
 	return milliseconds;
 }
 
+u32_t RtcTick2Ms(uint32_t tick)
+{
+	return tick;
+}
+
 static void sx1276_dio_work_handle(struct k_work *work)
 {
 	int dio = work - dev_data.dio_work;

--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -6,13 +6,14 @@
 
 #define DT_DRV_COMPAT semtech_sx1276
 
-#include <drivers/counter.h>
 #include <drivers/gpio.h>
 #include <drivers/lora.h>
 #include <drivers/spi.h>
 #include <zephyr.h>
 
+/* LoRaMac-node specific includes */
 #include <sx1276/sx1276.h>
+#include <timer.h>
 
 #define LOG_LEVEL CONFIG_LORA_LOG_LEVEL
 #include <logging/log.h>
@@ -26,6 +27,7 @@ LOG_MODULE_REGISTER(sx1276);
 #define SX1276_REG_PA_DAC			0x4d
 #define SX1276_REG_VERSION			0x42
 
+static u32_t saved_time;
 extern DioIrqHandler *DioIrq[];
 
 struct sx1276_dio {
@@ -50,13 +52,13 @@ static const struct sx1276_dio sx1276_dios[] = { SX1276_DIO_GPIO_INIT(0) };
 #define SX1276_MAX_DIO ARRAY_SIZE(sx1276_dios)
 
 struct sx1276_data {
-	struct device *counter;
 	struct device *reset;
 	struct device *spi;
 	struct spi_config spi_cfg;
 	struct device *dio_dev[SX1276_MAX_DIO];
 	struct k_work dio_work[SX1276_MAX_DIO];
 	struct k_sem data_sem;
+	struct k_timer timer;
 	RadioEvents_t sx1276_event;
 	u8_t *rx_buf;
 	u8_t rx_len;
@@ -68,11 +70,6 @@ bool SX1276CheckRfFrequency(uint32_t frequency)
 {
 	/* TODO */
 	return true;
-}
-
-void RtcStopAlarm(void)
-{
-	counter_stop(dev_data.counter);
 }
 
 void SX1276SetAntSwLowPower(bool status)
@@ -112,49 +109,59 @@ void BoardCriticalSectionEnd(uint32_t *mask)
 	irq_unlock(*mask);
 }
 
-uint32_t RtcGetTimerElapsedTime(void)
+u32_t RtcGetTimerValue(void)
 {
-	u32_t ticks;
-	int err;
+	return k_uptime_get_32();
+}
 
-	err = counter_get_value(dev_data.counter, &ticks);
-	if (err) {
-		LOG_ERR("Failed to read counter value (err %d)", err);
-		return 0;
-	}
-
-	return ticks;
+u32_t RtcGetTimerElapsedTime(void)
+{
+	return (k_uptime_get_32() - saved_time);
 }
 
 u32_t RtcGetMinimumTimeout(void)
 {
-	/* TODO: Get this value from counter driver */
-	return 3;
+	return 1;
 }
 
-void RtcSetAlarm(uint32_t timeout)
+void RtcStopAlarm(void)
 {
-	struct counter_alarm_cfg alarm_cfg;
-
-	alarm_cfg.flags = 0;
-	alarm_cfg.ticks = timeout;
-
-	counter_set_channel_alarm(dev_data.counter, 0, &alarm_cfg);
+	k_timer_stop(&dev_data.timer);
 }
 
-uint32_t RtcSetTimerContext(void)
+static void timer_callback(struct k_timer *_timer)
 {
-	return 0;
+	ARG_UNUSED(_timer);
+
+	TimerIrqHandler();
 }
 
-uint32_t RtcMs2Tick(uint32_t milliseconds)
+void RtcSetAlarm(u32_t timeout)
 {
-	return counter_us_to_ticks(dev_data.counter, (milliseconds / 1000));
+	k_timer_start(&dev_data.timer, timeout, K_NO_WAIT);
 }
 
-void DelayMsMcu(uint32_t ms)
+u32_t RtcSetTimerContext(void)
+{
+	saved_time = k_uptime_get_32();
+
+	return saved_time;
+}
+
+/* For us, 1 tick = 1 milli second. So no need to do any conversion here */
+u32_t RtcGetTimerContext(void)
+{
+	return saved_time;
+}
+
+void DelayMsMcu(u32_t ms)
 {
 	k_sleep(ms);
+}
+
+u32_t RtcMs2Tick(uint32_t milliseconds)
+{
+	return milliseconds;
 }
 
 static void sx1276_dio_work_handle(struct k_work *work)
@@ -514,13 +521,9 @@ static int sx1276_lora_init(struct device *dev)
 		return -EIO;
 	}
 
-	dev_data.counter = device_get_binding(DT_RTC_0_NAME);
-	if (!dev_data.counter) {
-		LOG_ERR("Cannot get pointer to %s device", DT_RTC_0_NAME);
-		return -EIO;
-	}
-
 	k_sem_init(&dev_data.data_sem, 0, UINT_MAX);
+
+	k_timer_init(&dev_data.timer, timer_callback, NULL);
 
 	dev_data.sx1276_event.TxDone = sx1276_tx_done;
 	dev_data.sx1276_event.RxDone = sx1276_rx_done;

--- a/include/drivers/lora.h
+++ b/include/drivers/lora.h
@@ -73,7 +73,7 @@ typedef int (*lora_api_send)(struct device *dev,
  * @see lora_recv() for argument descriptions.
  */
 typedef int (*lora_api_recv)(struct device *dev, u8_t *data, u8_t size,
-			     s32_t timeout, s16_t *rssi, s8_t *snr);
+			     k_timeout_t timeout, s16_t *rssi, s8_t *snr);
 
 struct lora_driver_api {
 	lora_api_config config;
@@ -132,7 +132,7 @@ static inline int lora_send(struct device *dev,
  * @return Length of the data received on success, negative on error
  */
 static inline int lora_recv(struct device *dev, u8_t *data, u8_t size,
-			    s32_t timeout, s16_t *rssi, s8_t *snr)
+			    k_timeout_t timeout, s16_t *rssi, s8_t *snr)
 {
 	const struct lora_driver_api *api = dev->driver_api;
 

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -47,7 +47,7 @@ void main(void)
 
 	while (1) {
 		/* Block until data arrives */
-		len = lora_recv(lora_dev, data, MAX_DATA_LEN, SYS_FOREVER_MS,
+		len = lora_recv(lora_dev, data, MAX_DATA_LEN, K_FOREVER,
 				&rssi, &snr);
 		if (len < 0) {
 			LOG_ERR("LoRa receive failed");


### PR DESCRIPTION
1. Got rid of counter API as it is found to be not fit for upcoming LoRaWAN support.
2. Marked LoRa support as Experimental
3. Switched to new timeout API

This PR is a spinoff from #23664

Signed-off-by: Manivannan Sadhasivam <mani@kernel.org>