### PR TITLE
dts: ethernet: rework how we deal with mac-address setting

### DIFF
--- a/boards/arm/atsame54_xpro/Kconfig.defconfig
+++ b/boards/arm/atsame54_xpro/Kconfig.defconfig
@@ -16,10 +16,6 @@ config NET_L2_ETHERNET
 config ETH_SAM_GMAC
 	default y if NET_L2_ETHERNET
 
-choice ETH_SAM_GMAC_MAC_SELECT
-	default ETH_SAM_GMAC_RANDOM_MAC
-endchoice
-
 endif # NETWORKING
 
 endif # BOARD_ATSAME54_XPRO

--- a/boards/arm/atsame54_xpro/atsame54_xpro.dts
+++ b/boards/arm/atsame54_xpro/atsame54_xpro.dts
@@ -85,4 +85,5 @@
 
 &gmac {
 	status = "okay";
+	zephyr,random-mac-address;
 };

--- a/boards/arm/sam4e_xpro/Kconfig.defconfig
+++ b/boards/arm/sam4e_xpro/Kconfig.defconfig
@@ -28,10 +28,6 @@ config NET_L2_ETHERNET
 config ETH_SAM_GMAC
 	default y if NET_L2_ETHERNET
 
-choice ETH_SAM_GMAC_MAC_SELECT
-	default ETH_SAM_GMAC_RANDOM_MAC
-endchoice
-
 endif # NETWORKING
 
 endif # BOARD_SAM4E_XPRO

--- a/boards/arm/sam4e_xpro/sam4e_xpro.dts
+++ b/boards/arm/sam4e_xpro/sam4e_xpro.dts
@@ -59,6 +59,7 @@
 
 &gmac {
 	status = "okay";
+	zephyr,random-mac-address;
 };
 
 &wdt {

--- a/boards/arm/sam_e70_xplained/Kconfig.defconfig
+++ b/boards/arm/sam_e70_xplained/Kconfig.defconfig
@@ -12,10 +12,6 @@ if ETH_SAM_GMAC
 
 # Read MAC address from AT24MAC402 EEPROM
 
-choice ETH_SAM_GMAC_MAC_SELECT
-	default ETH_SAM_GMAC_MAC_I2C_EEPROM
-endchoice
-
 config ETH_SAM_GMAC_MAC_I2C_SLAVE_ADDRESS
 	default 0x5F
 

--- a/boards/arm/sam_v71_xult/Kconfig.defconfig
+++ b/boards/arm/sam_v71_xult/Kconfig.defconfig
@@ -13,9 +13,8 @@ if ETH_SAM_GMAC
 
 # Read MAC address from AT24MAC402 EEPROM
 
-choice ETH_SAM_GMAC_MAC_SELECT
-	default ETH_SAM_GMAC_MAC_I2C_EEPROM
-endchoice
+config ETH_SAM_GMAC_MAC_I2C_EEPROM
+	default y
 
 config ETH_SAM_GMAC_MAC_I2C_SLAVE_ADDRESS
 	default 0x5F

--- a/drivers/ethernet/Kconfig.gecko
+++ b/drivers/ethernet/Kconfig.gecko
@@ -39,11 +39,6 @@ choice ETH_GECKO_MAC_SELECT
 	help
 	  Choose how to configure MAC address.
 
-config ETH_GECKO_RANDOM_MAC
-	bool "Random MAC address"
-	help
-	  Generate a random MAC address dynamically.
-
 config ETH_GECKO_MAC_MANUAL
 	bool "Manual"
 	help

--- a/drivers/ethernet/Kconfig.gecko
+++ b/drivers/ethernet/Kconfig.gecko
@@ -34,52 +34,6 @@ config ETH_GECKO_RX_THREAD_PRIO
 	help
 	  RX thread priority
 
-choice ETH_GECKO_MAC_SELECT
-	prompt "MAC address"
-	help
-	  Choose how to configure MAC address.
-
-config ETH_GECKO_MAC_MANUAL
-	bool "Manual"
-	help
-	  Assign an arbitrary MAC address.
-
-endchoice # ETH_GECKO_MAC_SELECT
-
-if ETH_GECKO_MAC_MANUAL
-
-config ETH_GECKO_MAC0
-	hex "MAC Address Byte 0"
-	default 0
-	range 0 0xff
-
-config ETH_GECKO_MAC1
-	hex "MAC Address Byte 1"
-	default 0
-	range 0 0xff
-
-config ETH_GECKO_MAC2
-	hex "MAC Address Byte 2"
-	default 0
-	range 0 0xff
-
-config ETH_GECKO_MAC3
-	hex "MAC Address Byte 3"
-	default 0
-	range 0 0xff
-
-config ETH_GECKO_MAC4
-	hex "MAC Address Byte 4"
-	default 0
-	range 0 0xff
-
-config ETH_GECKO_MAC5
-	hex "MAC Address Byte 5"
-	default 0
-	range 0 0xff
-
-endif # ETH_GECKO_MAC_MANUAL
-
 config ETH_GECKO_CARRIER_CHECK_RX_IDLE_TIMEOUT_MS
 	int "Carrier check timeout period (ms)"
 	default 500

--- a/drivers/ethernet/Kconfig.liteeth
+++ b/drivers/ethernet/Kconfig.liteeth
@@ -16,10 +16,4 @@ config ETH_LITEETH_0_IRQ_PRI
 	help
 	  IRQ priority
 
-config ETH_LITEETH_0_RANDOM_MAC
-	bool "Random MAC address"
-	depends on ENTROPY_GENERATOR
-	help
-	  Generate a random MAC address dynamically.
-
 endif # ETH_LITEETH_0

--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -65,12 +65,6 @@ config ETH_MCUX_0_UNIQUE_MAC
 	bool "Stable MAC address"
 	help
 	  Generate MAC address from MCU's unique identification register.
-
-config ETH_MCUX_0_MANUAL_MAC
-	bool "Manual MAC address"
-	help
-	  Get MAC address from the device tree.
-
 endchoice
 
 endif # ETH_MCUX_0
@@ -92,11 +86,6 @@ config ETH_MCUX_1_UNIQUE_MAC
 	bool "Stable MAC address"
 	help
 	  Generate MAC address from MCU's unique identification register.
-
-config ETH_MCUX_1_MANUAL_MAC
-	bool "Manual MAC address"
-	help
-	  Get MAC address from the device tree.
 
 endchoice
 

--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -54,42 +54,11 @@ config ETH_MCUX_0
 	help
 	  Include port 0 driver
 
-if ETH_MCUX_0
-
-choice ETH_MCUX_0_MAC_SELECT
-	prompt "MAC address"
-	help
-	  Choose how to configure MAC address.
-
-config ETH_MCUX_0_UNIQUE_MAC
-	bool "Stable MAC address"
-	help
-	  Generate MAC address from MCU's unique identification register.
-endchoice
-
-endif # ETH_MCUX_0
-
 config ETH_MCUX_1
 	bool "MCUX Ethernet port 1"
 	depends on SOC_MIMXRT1062 || SOC_MIMXRT1064
 	help
 	  Include port 1 driver
-
-if ETH_MCUX_1
-
-choice ETH_MCUX_1_MAC_SELECT
-	prompt "MAC address"
-	help
-	  Choose how to configure MAC address.
-
-config ETH_MCUX_1_UNIQUE_MAC
-	bool "Stable MAC address"
-	help
-	  Generate MAC address from MCU's unique identification register.
-
-endchoice
-
-endif # ETH_MCUX_1
 
 config ETH_MCUX_HW_ACCELERATION
 	bool "Enable hardware acceleration"

--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -66,15 +66,6 @@ config ETH_MCUX_0_UNIQUE_MAC
 	help
 	  Generate MAC address from MCU's unique identification register.
 
-config ETH_MCUX_0_RANDOM_MAC
-	bool "Random MAC address"
-	help
-	  Generate a random MAC address dynamically on each reboot.
-	  Note that using this choice and rebooting a board may leave
-	  stale MAC address in peers' ARP caches and lead to issues and
-	  delays in communication. (Use "ip neigh flush all" on Linux
-	  peers to clear ARP cache.)
-
 config ETH_MCUX_0_MANUAL_MAC
 	bool "Manual MAC address"
 	help
@@ -101,15 +92,6 @@ config ETH_MCUX_1_UNIQUE_MAC
 	bool "Stable MAC address"
 	help
 	  Generate MAC address from MCU's unique identification register.
-
-config ETH_MCUX_1_RANDOM_MAC
-	bool "Random MAC address"
-	help
-	  Generate a random MAC address dynamically on each reboot.
-	  Note that using this choice and rebooting a board may leave
-	  stale MAC address in peers' ARP caches and lead to issues and
-	  delays in communication. (Use "ip neigh flush all" on Linux
-	  peers to clear ARP cache.)
 
 config ETH_MCUX_1_MANUAL_MAC
 	bool "Manual MAC address"

--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -76,22 +76,10 @@ config ETH_SAM_GMAC_MONITOR_PERIOD
 	  periodically executed to detect and report any changes in the PHY
 	  link status to the operating system.
 
-choice ETH_SAM_GMAC_MAC_SELECT
-	prompt "MAC address"
-	help
-	  Choose how to configure MAC address.
-
-config ETH_SAM_GMAC_MAC_MANUAL
-	bool "Manual"
-	help
-	  Assign the MAC address specified in the device tree.
-
 config ETH_SAM_GMAC_MAC_I2C_EEPROM
 	bool "Read from an I2C EEPROM"
 	help
 	  Read MAC address from an I2C EEPROM.
-
-endchoice
 
 if ETH_SAM_GMAC_MAC_I2C_EEPROM
 

--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -91,11 +91,6 @@ config ETH_SAM_GMAC_MAC_I2C_EEPROM
 	help
 	  Read MAC address from an I2C EEPROM.
 
-config ETH_SAM_GMAC_RANDOM_MAC
-	bool "Random MAC address"
-	help
-	  Generate a random MAC address dynamically.
-
 endchoice
 
 if ETH_SAM_GMAC_MAC_I2C_EEPROM

--- a/drivers/ethernet/eth.h
+++ b/drivers/ethernet/eth.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020 Linaro Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_ETHERNET_ETH_H_
+#define ZEPHYR_DRIVERS_ETHERNET_ETH_H_
+
+#include <zephyr/types.h>
+
+static inline void gen_random_mac(u8_t *mac_addr, u8_t b0, u8_t b1, u8_t b2)
+{
+	u32_t entropy;
+
+	entropy = sys_rand32_get();
+
+	mac_addr[0] = b0;
+	mac_addr[1] = b1;
+	mac_addr[2] = b2;
+
+	/* Set MAC address locally administered, unicast (LAA) */
+	mac_addr[0] |= 0x02;
+
+	mac_addr[3] = (entropy >> 16) & 0xff;
+	mac_addr[4] = (entropy >>  8) & 0xff;
+	mac_addr[5] = (entropy >>  0) & 0xff;
+}
+
+#endif /* ZEPHYR_DRIVERS_ETHERNET_ETH_H_ */

--- a/drivers/ethernet/eth.h
+++ b/drivers/ethernet/eth.h
@@ -9,6 +9,26 @@
 
 #include <zephyr/types.h>
 
+/* helper macro to return mac address octet from local_mac_address prop */
+#define NODE_MAC_ADDR_OCTET(node, n) DT_PROP_BY_IDX(node, local_mac_address, n)
+
+/* Determine if a mac address is all 0's */
+#define NODE_MAC_ADDR_NULL(node) \
+	((NODE_MAC_ADDR_OCTET(node, 0) == 0) && \
+	 (NODE_MAC_ADDR_OCTET(node, 1) == 0) && \
+	 (NODE_MAC_ADDR_OCTET(node, 2) == 0) && \
+	 (NODE_MAC_ADDR_OCTET(node, 3) == 0) && \
+	 (NODE_MAC_ADDR_OCTET(node, 4) == 0) && \
+	 (NODE_MAC_ADDR_OCTET(node, 5) == 0))
+
+/* Given a device tree node for an ethernet controller will
+ * returns false if there is no local-mac-address property or
+ * the property is all zero's.  Otherwise will return True
+ */
+#define NODE_HAS_VALID_MAC_ADDR(node) \
+	UTIL_AND(DT_NODE_HAS_PROP(node, local_mac_address),\
+			(!NODE_MAC_ADDR_NULL(node)))
+
 static inline void gen_random_mac(u8_t *mac_addr, u8_t b0, u8_t b1, u8_t b2)
 {
 	u32_t entropy;

--- a/drivers/ethernet/eth_gecko.c
+++ b/drivers/ethernet/eth_gecko.c
@@ -29,6 +29,7 @@ LOG_MODULE_REGISTER(eth_gecko, CONFIG_ETHERNET_LOG_LEVEL);
 #include "phy_gecko.h"
 #include "eth_gecko_priv.h"
 
+#include "eth.h"
 
 static u8_t dma_tx_buffer[ETH_TX_BUF_COUNT][ETH_TX_BUF_SIZE]
 __aligned(ETH_BUF_ALIGNMENT);
@@ -490,21 +491,7 @@ static int eth_init(struct device *dev)
 #if defined(CONFIG_ETH_GECKO_RANDOM_MAC)
 static void generate_random_mac(u8_t mac_addr[6])
 {
-	u32_t entropy;
-
-	entropy = sys_rand32_get();
-
-	/* SiLabs' OUI */
-	mac_addr[0] = SILABS_OUI_B0;
-	mac_addr[1] = SILABS_OUI_B1;
-	mac_addr[2] = SILABS_OUI_B2;
-
-	mac_addr[3] = entropy >> 0;
-	mac_addr[4] = entropy >> 8;
-	mac_addr[5] = entropy >> 16;
-
-	/* Set MAC address locally administered, unicast (LAA) */
-	mac_addr[0] |= 0x02;
+	gen_random_mac(mac_addr, SILABS_OUI_B0, SILABS_OUI_B1, SILABS_OUI_B2);
 }
 #endif
 

--- a/drivers/ethernet/eth_gecko.c
+++ b/drivers/ethernet/eth_gecko.c
@@ -488,17 +488,10 @@ static int eth_init(struct device *dev)
 	return 0;
 }
 
-#if defined(CONFIG_ETH_GECKO_RANDOM_MAC)
-static void generate_random_mac(u8_t mac_addr[6])
-{
-	gen_random_mac(mac_addr, SILABS_OUI_B0, SILABS_OUI_B1, SILABS_OUI_B2);
-}
-#endif
-
 static void generate_mac(u8_t mac_addr[6])
 {
-#if defined(CONFIG_ETH_GECKO_RANDOM_MAC)
-	generate_random_mac(mac_addr);
+#if DT_INST_PROP(0, zephyr_random_mac_address)
+	gen_random_mac(mac_addr, SILABS_OUI_B0, SILABS_OUI_B1, SILABS_OUI_B2);
 #endif
 }
 

--- a/drivers/ethernet/eth_gecko.c
+++ b/drivers/ethernet/eth_gecko.c
@@ -659,15 +659,8 @@ static const struct eth_gecko_dev_cfg eth0_config = {
 };
 
 static struct eth_gecko_dev_data eth0_data = {
-#ifdef CONFIG_ETH_GECKO_MAC_MANUAL
-	.mac_addr = {
-		CONFIG_ETH_GECKO_MAC0,
-		CONFIG_ETH_GECKO_MAC1,
-		CONFIG_ETH_GECKO_MAC2,
-		CONFIG_ETH_GECKO_MAC3,
-		CONFIG_ETH_GECKO_MAC4,
-		CONFIG_ETH_GECKO_MAC5,
-	},
+#if NODE_HAS_VALID_MAC_ADDR(DT_DRV_INST(0))
+	.mac_addr = DT_INST_PROP(0, local_mac_address),
 #endif
 };
 

--- a/drivers/ethernet/eth_liteeth.c
+++ b/drivers/ethernet/eth_liteeth.c
@@ -177,12 +177,6 @@ static void eth_irq_handler(struct device *port)
 	}
 }
 
-#ifdef CONFIG_ETH_LITEETH_0_RANDOM_MAC
-static void generate_mac(u8_t *mac_addr)
-	gen_random_mac(mac_addr, 0x10, 0xe2, 0xd5);
-}
-#endif
-
 #ifdef CONFIG_ETH_LITEETH_0
 
 static struct eth_liteeth_dev_data eth_data = {
@@ -211,9 +205,9 @@ static void eth_iface_init(struct net_if *iface)
 	/* initialize ethernet L2 */
 	ethernet_init(iface);
 
-#ifdef CONFIG_ETH_LITEETH_0_RANDOM_MAC
+#if DT_INST_PROP(0, zephyr_random_mac_address)
 	/* generate random MAC address */
-	generate_mac(context->mac_addr);
+	gen_random_mac(context->mac_addr, 0x10, 0xe2, 0xd5);
 #endif
 
 	/* set MAC address */

--- a/drivers/ethernet/eth_liteeth.c
+++ b/drivers/ethernet/eth_liteeth.c
@@ -22,6 +22,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <sys/printk.h>
 
+#include "eth.h"
+
 /* flags */
 #define LITEETH_EV_TX		0x1
 #define LITEETH_EV_RX		0x1
@@ -177,15 +179,7 @@ static void eth_irq_handler(struct device *port)
 
 #ifdef CONFIG_ETH_LITEETH_0_RANDOM_MAC
 static void generate_mac(u8_t *mac_addr)
-{
-	u32_t entropy;
-
-	entropy = sys_rand32_get();
-
-	mac_addr[3] = entropy >> 8;
-	mac_addr[4] = entropy >> 16;
-	/* Locally administered, unicast */
-	mac_addr[5] = ((entropy >> 0) & 0xfc) | 0x02;
+	gen_random_mac(mac_addr, 0x10, 0xe2, 0xd5);
 }
 #endif
 

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -43,6 +43,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <drivers/clock_control.h>
 #endif
 
+#include "eth.h"
+
 #define FREESCALE_OUI_B0 0x00
 #define FREESCALE_OUI_B1 0x04
 #define FREESCALE_OUI_B2 0x9f
@@ -880,15 +882,8 @@ static void eth_callback(ENET_Type *base, enet_handle_t *handle,
     defined(CONFIG_ETH_MCUX_1_RANDOM_MAC)
 static void generate_random_mac(u8_t *mac_addr)
 {
-	u32_t entropy;
-
-	entropy = sys_rand32_get();
-
-	mac_addr[0] |= 0x02; /* force LAA bit */
-
-	mac_addr[3] = entropy >> 8;
-	mac_addr[4] = entropy >> 16;
-	mac_addr[5] = entropy >> 0;
+	gen_random_mac(mac_addr, FREESCALE_OUI_B0,
+		       FREESCALE_OUI_B1, FREESCALE_OUI_B2);
 }
 #endif
 

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -887,8 +887,8 @@ static void generate_random_mac(u8_t *mac_addr)
 }
 #endif
 
-#if defined(CONFIG_ETH_MCUX_0_UNIQUE_MAC) || \
-    defined(CONFIG_ETH_MCUX_1_UNIQUE_MAC)
+#if !DT_INST_NODE_HAS_PROP(0, local_mac_address) || \
+    DT_HAS_NODE_STATUS_OKAY(DT_DRV_INST(1)) && !DT_INST_NODE_HAS_PROP(1, local_mac_address)
 static void generate_eth0_unique_mac(u8_t *mac_addr)
 {
 	/* Trivially "hash" up to 128 bits of MCU unique identifier */
@@ -907,7 +907,7 @@ static void generate_eth0_unique_mac(u8_t *mac_addr)
 }
 #endif
 
-#if defined(CONFIG_ETH_MCUX_1_UNIQUE_MAC)
+#if DT_HAS_NODE_STATUS_OKAY(DT_DRV_INST(1)) && !DT_INST_NODE_HAS_PROP(1, local_mac_address)
 static void generate_eth1_unique_mac(u8_t *mac_addr)
 {
 	generate_eth0_unique_mac(mac_addr);
@@ -1204,15 +1204,14 @@ static struct eth_context eth_0_context = {
 	.phy_addr = 0U,
 	.phy_duplex = kPHY_FullDuplex,
 	.phy_speed = kPHY_Speed100M,
-#if defined(CONFIG_ETH_MCUX_0_UNIQUE_MAC)
-	.generate_mac = generate_eth0_unique_mac,
-#endif
 #if DT_INST_PROP(0, zephyr_random_mac_address)
 	.generate_mac = generate_random_mac,
 #endif
 #if NODE_HAS_VALID_MAC_ADDR(DT_DRV_INST(0))
 	.mac_addr = DT_INST_PROP(0, local_mac_address),
 	.generate_mac = NULL,
+#else
+	.generate_mac = generate_eth0_unique_mac,
 #endif
 };
 
@@ -1271,15 +1270,14 @@ static struct eth_context eth_1_context = {
 	.phy_addr = 0U,
 	.phy_duplex = kPHY_FullDuplex,
 	.phy_speed = kPHY_Speed100M,
-#if defined(CONFIG_ETH_MCUX_1_UNIQUE_MAC)
-	.generate_mac = generate_eth1_unique_mac,
-#endif
 #if DT_INST_PROP(1, zephyr_random_mac_address)
 	.generate_mac = generate_random_mac,
 #endif
 #if NODE_HAS_VALID_MAC_ADDR(DT_DRV_INST(1))
 	.mac_addr = DT_INST_PROP(1, local_mac_address),
 	.generate_mac = NULL,
+#else
+	.generate_mac = generate_eth1_unique_mac,
 #endif
 };
 

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -878,8 +878,8 @@ static void eth_callback(ENET_Type *base, enet_handle_t *handle,
 	}
 }
 
-#if defined(CONFIG_ETH_MCUX_0_RANDOM_MAC) || \
-    defined(CONFIG_ETH_MCUX_1_RANDOM_MAC)
+#if DT_INST_PROP(0, zephyr_random_mac_address) || \
+    DT_INST_PROP(1, zephyr_random_mac_address)
 static void generate_random_mac(u8_t *mac_addr)
 {
 	gen_random_mac(mac_addr, FREESCALE_OUI_B0,
@@ -1207,7 +1207,7 @@ static struct eth_context eth_0_context = {
 #if defined(CONFIG_ETH_MCUX_0_UNIQUE_MAC)
 	.generate_mac = generate_eth0_unique_mac,
 #endif
-#if defined(CONFIG_ETH_MCUX_0_RANDOM_MAC)
+#if DT_INST_PROP(0, zephyr_random_mac_address)
 	.generate_mac = generate_random_mac,
 #endif
 #if defined(CONFIG_ETH_MCUX_0_MANUAL_MAC)
@@ -1274,7 +1274,7 @@ static struct eth_context eth_1_context = {
 #if defined(CONFIG_ETH_MCUX_1_UNIQUE_MAC)
 	.generate_mac = generate_eth1_unique_mac,
 #endif
-#if defined(CONFIG_ETH_MCUX_1_RANDOM_MAC)
+#if DT_INST_PROP(1, zephyr_random_mac_address)
 	.generate_mac = generate_random_mac,
 #endif
 #if defined(CONFIG_ETH_MCUX_1_MANUAL_MAC)

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -1210,7 +1210,7 @@ static struct eth_context eth_0_context = {
 #if DT_INST_PROP(0, zephyr_random_mac_address)
 	.generate_mac = generate_random_mac,
 #endif
-#if defined(CONFIG_ETH_MCUX_0_MANUAL_MAC)
+#if NODE_HAS_VALID_MAC_ADDR(DT_DRV_INST(0))
 	.mac_addr = DT_INST_PROP(0, local_mac_address),
 	.generate_mac = NULL,
 #endif
@@ -1277,7 +1277,7 @@ static struct eth_context eth_1_context = {
 #if DT_INST_PROP(1, zephyr_random_mac_address)
 	.generate_mac = generate_random_mac,
 #endif
-#if defined(CONFIG_ETH_MCUX_1_MANUAL_MAC)
+#if NODE_HAS_VALID_MAC_ADDR(DT_DRV_INST(1))
 	.mac_addr = DT_INST_PROP(1, local_mac_address),
 	.generate_mac = NULL,
 #endif

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -35,6 +35,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <net/lldp.h>
 
 #include "eth_native_posix_priv.h"
+#include "eth.h"
 
 #define NET_BUF_TIMEOUT K_MSEC(100)
 
@@ -415,12 +416,10 @@ static void eth_iface_init(struct net_if *iface)
 
 #if defined(CONFIG_ETH_NATIVE_POSIX_RANDOM_MAC)
 	/* 00-00-5E-00-53-xx Documentation RFC 7042 */
-	ctx->mac_addr[0] = 0x00;
-	ctx->mac_addr[1] = 0x00;
-	ctx->mac_addr[2] = 0x5E;
+	gen_random_mac(ctx->mac_addr, 0x00, 0x00, 0x5E);
+
 	ctx->mac_addr[3] = 0x00;
 	ctx->mac_addr[4] = 0x53;
-	ctx->mac_addr[5] = sys_rand32_get();
 
 	/* The TUN/TAP setup script will by default set the MAC address of host
 	 * interface to 00:00:5E:00:53:FF so do not allow that.

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -41,6 +41,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include "phy_sam_gmac.h"
 #include "eth_sam_gmac_priv.h"
 
+#include "eth.h"
+
 #ifdef CONFIG_SOC_FAMILY_SAM0
 #include "eth_sam0_gmac.h"
 #endif
@@ -1797,19 +1799,12 @@ static void get_mac_addr_from_i2c_eeprom(u8_t mac_addr[6])
 }
 #endif
 
-#if defined(CONFIG_ETH_SAM_GMAC_RANDOM_MAC)
-static void generate_random_mac(u8_t mac_addr[6])
-{
-	gen_random_mac(mac_addr, ATMEL_OUI_B0, ATMEL_OUI_B1, ATMEL_OUI_B2);
-}
-#endif
-
 static void generate_mac(u8_t mac_addr[6])
 {
 #if defined(CONFIG_ETH_SAM_GMAC_MAC_I2C_EEPROM)
 	get_mac_addr_from_i2c_eeprom(mac_addr);
-#elif defined(CONFIG_ETH_SAM_GMAC_RANDOM_MAC)
-	generate_random_mac(mac_addr);
+#elif DT_INST_PROP(0, zephyr_random_mac_address)
+	gen_random_mac(mac_addr, ATMEL_OUI_B0, ATMEL_OUI_B1, ATMEL_OUI_B2);
 #endif
 }
 

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1800,17 +1800,7 @@ static void get_mac_addr_from_i2c_eeprom(u8_t mac_addr[6])
 #if defined(CONFIG_ETH_SAM_GMAC_RANDOM_MAC)
 static void generate_random_mac(u8_t mac_addr[6])
 {
-	u32_t entropy;
-
-	entropy = sys_rand32_get();
-
-	mac_addr[0] = ATMEL_OUI_B0 | 0x02; /* force LAA bit */
-	mac_addr[1] = ATMEL_OUI_B1;
-	mac_addr[2] = ATMEL_OUI_B2;
-
-	mac_addr[3] = entropy >> 8;
-	mac_addr[4] = entropy >> 16;
-	mac_addr[5] = entropy >> 0;
+	gen_random_mac(mac_addr, ATMEL_OUI_B0, ATMEL_OUI_B1, ATMEL_OUI_B2);
 }
 #endif
 

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -2201,7 +2201,7 @@ static const struct eth_sam_dev_cfg eth0_config = {
 };
 
 static struct eth_sam_dev_data eth0_data = {
-#ifdef CONFIG_ETH_SAM_GMAC_MAC_MANUAL
+#if NODE_HAS_VALID_MAC_ADDR(DT_DRV_INST(0))
 	.mac_addr = DT_INST_PROP(0, local_mac_address),
 #endif
 	.queue_list = {

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -24,6 +24,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <drivers/clock_control.h>
 #include <drivers/clock_control/stm32_clock_control.h>
 
+#include "eth.h"
 #include "eth_stm32_hal_priv.h"
 
 #if defined(CONFIG_ETH_STM32_HAL_USE_DTCM_FOR_DMA_BUFFER) && \
@@ -362,15 +363,7 @@ void HAL_ETH_RxCpltCallback(ETH_HandleTypeDef *heth_handle)
 #if defined(CONFIG_ETH_STM32_HAL_RANDOM_MAC)
 static void generate_mac(u8_t *mac_addr)
 {
-	u32_t entropy;
-
-	entropy = sys_rand32_get();
-
-	mac_addr[0] |= 0x02; /* force LAA bit */
-
-	mac_addr[3] = entropy >> 16;
-	mac_addr[4] = entropy >> 8;
-	mac_addr[5] = entropy >> 0;
+	gen_random_mac(mac_addr, ST_OUI_B0, ST_OUI_B1, ST_OUI_B2);
 }
 #endif
 

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -473,7 +473,6 @@
 			interrupts = <83 0>, <84 0>, <85 0>;
 			interrupt-names = "TX", "RX", "ERR_MISC";
 			status = "disabled";
-			local-mac-address = [00 00 00 00 00 00];
 			label = "ETH_0";
 			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0 0>;
 			ptp {

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -536,7 +536,6 @@
 			interrupts = <114 0>;
 			interrupt-names = "COMMON";
 			status = "disabled";
-			local-mac-address = [00 00 00 00 00 00];
 			label = "ETH_0";
 			ptp {
 				compatible = "nxp,kinetis-ptp";

--- a/dts/arm/nxp/nxp_rt1060.dtsi
+++ b/dts/arm/nxp/nxp_rt1060.dtsi
@@ -30,7 +30,6 @@
 			interrupts = <152 0>;
 			interrupt-names = "COMMON";
 			status = "disabled";
-			local-mac-address = [00 00 00 00 00 00];
 			label = "ETH_1";
 			ptp {
 				compatible = "nxp,kinetis-ptp";

--- a/dts/bindings/ethernet/ethernet.yaml
+++ b/dts/bindings/ethernet/ethernet.yaml
@@ -12,3 +12,16 @@ properties:
       description: Specifies the MAC address that was assigned to the network device
     label:
       required: true
+    zephyr,random-mac-address:
+      type: boolean
+      required: false
+      description: |
+        Use a random MAC address generated when the driver is initialized.
+        Note that using this choice and rebooting a board may leave stale
+        MAC address in peers' ARP caches and lead to issues and delays in
+        communication.  (Use "ip neigh flush all" on Linux peers to clear
+        ARP cache.)
+
+        It is driver specific how the OUI octets are handled.
+
+        If set we ignore any setting of the local-mac-address property.


### PR DESCRIPTION
Rework the ethernet drivers to determine how they set the mac-address.  In the majority of cases with just utilize devicetree and a combination of 'local-mac-address' property and 'zephyr,random-mac-address' property.