### PR TITLE
DT/kconfig helper improvements

### DIFF
--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -12,13 +12,19 @@ menuconfig ETH_SAM_GMAC
 
 if ETH_SAM_GMAC
 
+# Workaround for not being able to have commas in macro arguments
+DT_ETH_SAM_GMAC_PATH := $(dt_nodelabel_path,gmac)
+
+# Just for readability, to keep the following lines shorter.
+DT_ETH_SAM_GMAC_NQ := $(dt_node_int_prop_int,$(DT_ETH_SAM_GMAC_PATH),num-queues)
+
 config ETH_SAM_GMAC_QUEUES
 	int "Number of active hardware TX and RX queues"
 	default 1
-	range 1 $(dt_node_int_prop_int,/soc/ethernet@40050088,num-queues) if SOC_SERIES_SAME70 || \
-									     SOC_SERIES_SAMV71
-	range 1 $(dt_node_int_prop_int,/soc/ethernet@40034000,num-queues) if SOC_SERIES_SAM4E
-	range 1 $(dt_node_int_prop_int,/soc/ethernet@42000800,num-queues) if SOC_SERIES_SAME54
+	range 1 $(DT_ETH_SAM_GMAC_NQ) if SOC_SERIES_SAME70 || \
+						SOC_SERIES_SAMV71 || \
+						SOC_SERIES_SAM4E || \
+						SOC_SERIES_SAME54
 	help
 	  Select the number of hardware queues used by the driver. Packets will be
 	  routed to appropriate queues based on their priority.

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -120,6 +120,10 @@ class EDT:
                 ...
         };
 
+    label2node:
+      A collections.OrderedDict that maps a node label to the node with
+      that label.
+
     chosen_nodes:
       A collections.OrderedDict that maps the properties defined on the
       devicetree's /chosen node to their values. 'chosen' is indexed by
@@ -171,7 +175,7 @@ class EDT:
 
         self._init_compat2binding(bindings_dirs)
         self._init_nodes()
-        self._init_compat2enabled()
+        self._init_luts()
 
         self._define_order()
 
@@ -516,11 +520,17 @@ class EDT:
             node._init_interrupts()
             node._init_pinctrls()
 
-    def _init_compat2enabled(self):
-        # Creates self.compat2enabled
+    def _init_luts(self):
+        # Initialize compat2enabled and label2node lookup tables
+        # (LUTs).
 
         self.compat2enabled = defaultdict(list)
+        self.label2node = OrderedDict()
+
         for node in self.nodes:
+            for label in node.labels:
+                self.label2node[label] = node
+
             if node.enabled:
                 for compat in node.compats:
                     self.compat2enabled[compat].append(node)

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -349,6 +349,20 @@ def dt_nodelabel_has_compat(kconf, _, label, compat):
     return "n"
 
 
+def dt_nodelabel_path(kconf, _, label):
+    """
+    This function takes a node label (not a label property) and
+    returns the path to the node which has that label, or an empty
+    string if there is no such node.
+    """
+    if doc_mode or edt is None:
+        return ""
+
+    node = edt.label2node.get(label)
+
+    return node.path if node else ""
+
+
 def shields_list_contains(kconf, _, shield):
     """
     Return "n" if cmake environment variable 'SHIELD_AS_LIST' doesn't exist.
@@ -381,5 +395,6 @@ functions = {
         "dt_node_int_prop_int": (dt_node_int_prop, 2, 2),
         "dt_node_int_prop_hex": (dt_node_int_prop, 2, 2),
         "dt_nodelabel_has_compat": (dt_nodelabel_has_compat, 2, 2),
+        "dt_nodelabel_path": (dt_nodelabel_path, 1, 1),
         "shields_list_contains": (shields_list_contains, 1, 1),
 }

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -81,6 +81,19 @@ def dt_chosen_enabled(kconf, _, chosen):
     return "y" if node and node.enabled else "n"
 
 
+def dt_chosen_path(kconf, _, chosen):
+    """
+    This function takes a /chosen node property and returns the path
+    to the node in the property value, or the empty string.
+    """
+    if doc_mode or edt is None:
+        return "n"
+
+    node = edt.chosen_node(chosen)
+
+    return node.path if node else ""
+
+
 def dt_nodelabel_enabled(kconf, _, label):
     """
     This function takes a 'label' and returns "y" if we find an "enabled"
@@ -382,6 +395,7 @@ functions = {
         "dt_compat_on_bus": (dt_compat_on_bus, 2, 2),
         "dt_chosen_label": (dt_chosen_label, 1, 1),
         "dt_chosen_enabled": (dt_chosen_enabled, 1, 1),
+        "dt_chosen_path": (dt_chosen_path, 1, 1),
         "dt_nodelabel_enabled": (dt_nodelabel_enabled, 1, 1),
         "dt_chosen_reg_addr_int": (dt_chosen_reg, 1, 3),
         "dt_chosen_reg_addr_hex": (dt_chosen_reg, 1, 3),

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -89,11 +89,9 @@ def dt_nodelabel_enabled(kconf, _, label):
     if doc_mode or edt is None:
         return "n"
 
-    for node in edt.nodes:
-        if label in node.labels and node.enabled:
-            return "y"
+    node = edt.label2node.get(label)
 
-    return "n"
+    return "y" if node and node.enabled else "n"
 
 
 def _node_reg_addr(node, index, unit):
@@ -317,11 +315,7 @@ def dt_compat_enabled(kconf, _, compat):
     if doc_mode or edt is None:
         return "n"
 
-    for node in edt.nodes:
-        if compat in node.compats and node.enabled:
-            return "y"
-
-    return "n"
+    return "y" if compat in edt.compat2enabled else "n"
 
 
 def dt_compat_on_bus(kconf, _, compat, bus):


### PR DESCRIPTION
We have a downstream use case for dt_node_int_prop(), which made me notice that we are hardcoding devicetree paths in Kconfig as a result in Zephyr, and also a couple of other inefficiencies in how kconfigfunctions.py is written.

Fix those up using a new label2node dict in the EDT object, and add two new kconfig helpers:

- dt_nodelabel_path()
- dt_chosen_path()

These allow accessing node properties via node label or /chosen, which avoids leaking full devicetree paths into Kconfig and in general makes things a bit nicer.

I've just done one patch for accessing SAM's gmac node as a proof of concept for now. Other SoC owners can choose to make use of this or not.