### PR TITLE
sys/util.h: Make IS_ENABLED work for linker scripts

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -14,10 +14,14 @@
 #ifndef ZEPHYR_INCLUDE_SYS_UTIL_H_
 #define ZEPHYR_INCLUDE_SYS_UTIL_H_
 
+/* needs to be outside _ASMLANGUAGE so 'true' and 'false' can turn
+ * into '1' and '0' for asm or linker scripts
+ */
+#include <stdbool.h>
+
 #ifndef _ASMLANGUAGE
 
 #include <zephyr/types.h>
-#include <stdbool.h>
 #include <stddef.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
Z_IS_ENABLED2 uses true and false, however when we preprocess the linker
scripts we invoke the compiler with `-x assembler-with-cpp` so
_ASMLANGUAGE ends up being defined and thus stdbool.h wouldn't convert
'true' and 'false' to '1' and '0'.

Move the include of stdbool.h outside the #ifndef _ASMLANGUAGE check so
that 'true' and 'false' get converted correctly.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>