### PR TITLE
samples: sensor: bq274xx: Fix platform whitelist

### DIFF
--- a/samples/sensor/bq274xx/sample.yaml
+++ b/samples/sensor/bq274xx/sample.yaml
@@ -4,6 +4,6 @@ sample:
 tests:
   sample.sensor.bq274xx:
     harness: sensor
-    platform_whitelist: nrf9160_innblue21
+    platform_whitelist: nrf9160_innblue22
     tags: sensors
     depends_on: i2c


### PR DESCRIPTION
The sensor is on the nrf9160_innblue22 not nrf9160_innblue21.  This
causes CI build failures since there is no dts node for the sensor
on the nrf9160_innblue21 board.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>