### PR TITLE
CODEOWNERS: Add CMSIS-DSP test code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -463,6 +463,7 @@
 /tests/                                   @nashif
 /tests/application_development/libcxx/    @pabigot
 /tests/arch/arm/                          @ioannisg @stephanosio
+/tests/benchmarks/cmsis_dsp/              @stephanosio
 /tests/boards/native_posix/               @aescolar @daor-oti
 /tests/boards/intel_s1000_crb/            @dcpleung @sathishkuttan
 /tests/bluetooth/                         @joerchan @jhedberg @Vudentz
@@ -478,6 +479,7 @@
 /tests/drivers/uart/uart_async_api/       @Mierunski
 /tests/kernel/                            @andrewboie @andyross @nashif
 /tests/lib/                               @nashif
+/tests/lib/cmsis_dsp/                     @stephanosio
 /tests/net/                               @jukkar @tbursztyka @pfalcon
 /tests/net/buf/                           @jukkar @jhedberg @tbursztyka @pfalcon
 /tests/net/lib/                           @jukkar @tbursztyka @pfalcon


### PR DESCRIPTION
This commit adds @stephanosio as a code owner for the CMSIS-DSP tests.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>