### PR TITLE
soc: arm: atmel_sam0: Add missing FPU selection

### DIFF
--- a/dts/arm/atmel/samd5x.dtsi
+++ b/dts/arm/atmel/samd5x.dtsi
@@ -15,7 +15,7 @@
 
 		cpu@0 {
 			device_type = "cpu";
-			compatible = "arm,cortex-m4";
+			compatible = "arm,cortex-m4f";
 			reg = <0>;
 		};
 	};

--- a/soc/arm/atmel_sam0/samd51/Kconfig.series
+++ b/soc/arm/atmel_sam0/samd51/Kconfig.series
@@ -8,6 +8,7 @@ config SOC_SERIES_SAMD51
 	select ARM
 	select CPU_CORTEX_M4
 	select SOC_FAMILY_SAM0
+	select CPU_HAS_FPU
 	select CPU_CORTEX_M_HAS_DWT
 	select ASF
 	help

--- a/soc/arm/atmel_sam0/samd51/Kconfig.series
+++ b/soc/arm/atmel_sam0/samd51/Kconfig.series
@@ -5,6 +5,7 @@
 
 config SOC_SERIES_SAMD51
 	bool "Atmel SAMD51 MCU"
+	select ARM
 	select CPU_CORTEX_M4
 	select SOC_FAMILY_SAM0
 	select CPU_CORTEX_M_HAS_DWT

--- a/soc/arm/atmel_sam0/same51/Kconfig.series
+++ b/soc/arm/atmel_sam0/same51/Kconfig.series
@@ -5,6 +5,7 @@
 
 config SOC_SERIES_SAME51
 	bool "Atmel SAME51 MCU"
+	select ARM
 	select CPU_CORTEX_M4
 	select SOC_FAMILY_SAM0
 	select CPU_CORTEX_M_HAS_DWT

--- a/soc/arm/atmel_sam0/same51/Kconfig.series
+++ b/soc/arm/atmel_sam0/same51/Kconfig.series
@@ -8,6 +8,7 @@ config SOC_SERIES_SAME51
 	select ARM
 	select CPU_CORTEX_M4
 	select SOC_FAMILY_SAM0
+	select CPU_HAS_FPU
 	select CPU_CORTEX_M_HAS_DWT
 	select ASF
 	help

--- a/soc/arm/atmel_sam0/same53/Kconfig.series
+++ b/soc/arm/atmel_sam0/same53/Kconfig.series
@@ -8,6 +8,7 @@ config SOC_SERIES_SAME53
 	select ARM
 	select CPU_CORTEX_M4
 	select SOC_FAMILY_SAM0
+	select CPU_HAS_FPU
 	select CPU_CORTEX_M_HAS_DWT
 	select ASF
 	help

--- a/soc/arm/atmel_sam0/same53/Kconfig.series
+++ b/soc/arm/atmel_sam0/same53/Kconfig.series
@@ -5,6 +5,7 @@
 
 config SOC_SERIES_SAME53
 	bool "Atmel SAME53 MCU"
+	select ARM
 	select CPU_CORTEX_M4
 	select SOC_FAMILY_SAM0
 	select CPU_CORTEX_M_HAS_DWT

--- a/soc/arm/atmel_sam0/same54/Kconfig.series
+++ b/soc/arm/atmel_sam0/same54/Kconfig.series
@@ -8,6 +8,7 @@ config SOC_SERIES_SAME54
 	select ARM
 	select CPU_CORTEX_M4
 	select SOC_FAMILY_SAM0
+	select CPU_HAS_FPU
 	select CPU_CORTEX_M_HAS_DWT
 	select ASF
 	help


### PR DESCRIPTION
The SAM D51, E51, E53 and E54 series SoCs include a single-precision FPU; therefore, the
`CPU_HAS_FPU` symbol should be selected.