### PR TITLE
arch: arm64: update cpu header

### DIFF
--- a/arch/arm/core/aarch64/isr_wrapper.S
+++ b/arch/arm/core/aarch64/isr_wrapper.S
@@ -14,7 +14,7 @@
 #include <offsets_short.h>
 #include <arch/cpu.h>
 #include <sw_isr_table.h>
-#include "macro.inc"
+#include "macro_priv.inc"
 
 _ASM_FILE_PROLOGUE
 

--- a/arch/arm/core/aarch64/macro_priv.inc
+++ b/arch/arm/core/aarch64/macro_priv.inc
@@ -4,43 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _MACRO_H_
-#define _MACRO_H_
+#ifndef _MACRO_PRIV_INC_
+#define _MACRO_PRIV_INC_
 
 #ifdef _ASMLANGUAGE
-/*
- * macro to support mov of immediate constant to 64 bit register
- * It will generate instruction sequence of 'mov'/ 'movz' and one
- * to three 'movk' depending on the immediate value.
- */
-.macro mov_imm, xreg, imm
-	.if ((\imm) == 0)
-		mov	\xreg, \imm
-	.else
-		.if (((\imm) >> 31) == 0 || ((\imm) >> 31) == 0x1ffffffff)
-			movz    \xreg, (\imm >> 16) & 0xffff, lsl 16
-		.else
-			.if (((\imm) >> 47) == 0 || ((\imm) >> 47) == 0x1ffff)
-				movz    \xreg, (\imm >> 32) & 0xffff, lsl 32
-			.else
-				movz    \xreg, (\imm >> 48) & 0xffff, lsl 48
-				movk    \xreg, (\imm >> 32) & 0xffff, lsl 32
-			.endif
-			movk    \xreg, (\imm >> 16) & 0xffff, lsl 16
-		.endif
-		movk    \xreg, (\imm) & 0xffff, lsl 0
-	.endif
-.endm
-
-.macro	switch_el, xreg, el3_label, el2_label, el1_label
-	mrs	\xreg, CurrentEL
-	cmp	\xreg, 0xc
-	beq	\el3_label
-	cmp	\xreg, 0x8
-	beq	\el2_label
-	cmp	\xreg, 0x4
-	beq	\el1_label
-.endm
 
 /**
  * @brief Save volatile registers
@@ -157,4 +124,4 @@
 
 #endif /* _ASMLANGUAGE */
 
-#endif /* _MACRO_H_ */
+#endif /* _MACRO_PRIV_INC_ */

--- a/arch/arm/core/aarch64/reset.S
+++ b/arch/arm/core/aarch64/reset.S
@@ -15,7 +15,7 @@
 #include <linker/sections.h>
 #include <arch/cpu.h>
 #include "vector_table.h"
-#include "macro.inc"
+#include "macro_priv.inc"
 
 _ASM_FILE_PROLOGUE
 

--- a/arch/arm/core/aarch64/swap_helper.S
+++ b/arch/arm/core/aarch64/swap_helper.S
@@ -17,7 +17,7 @@
 #include <offsets_short.h>
 #include <arch/cpu.h>
 #include <syscall.h>
-#include "macro.inc"
+#include "macro_priv.inc"
 
 _ASM_FILE_PROLOGUE
 

--- a/arch/arm/core/aarch64/vector_table.S
+++ b/arch/arm/core/aarch64/vector_table.S
@@ -11,8 +11,9 @@
 
 #include <toolchain.h>
 #include <linker/sections.h>
+#include <arch/cpu.h>
 #include "vector_table.h"
-#include "macro.inc"
+#include "macro_priv.inc"
 
 _ASM_FILE_PROLOGUE
 

--- a/include/arch/arm/aarch64/arch.h
+++ b/include/arch/arm/aarch64/arch.h
@@ -25,6 +25,7 @@
 #include <arch/arm/aarch64/misc.h>
 #include <arch/arm/aarch64/asm_inline.h>
 #include <arch/arm/aarch64/cpu.h>
+#include <arch/arm/aarch64/macro.inc>
 #include <arch/arm/aarch64/sys_io.h>
 #include <arch/arm/aarch64/timer.h>
 #include <arch/common/addr_types.h>

--- a/include/arch/arm/aarch64/asm_inline_gcc.h
+++ b/include/arch/arm/aarch64/asm_inline_gcc.h
@@ -23,6 +23,21 @@
 extern "C" {
 #endif
 
+static ALWAYS_INLINE void __DSB(void)
+{
+	__asm__ volatile ("dsb sy" : : : "memory");
+}
+
+static ALWAYS_INLINE void __DMB(void)
+{
+	__asm__ volatile ("dmb sy" : : : "memory");
+}
+
+static ALWAYS_INLINE void __ISB(void)
+{
+	__asm__ volatile ("isb" : : : "memory");
+}
+
 static ALWAYS_INLINE unsigned int arch_irq_lock(void)
 {
 	unsigned int key;

--- a/include/arch/arm/aarch64/cpu.h
+++ b/include/arch/arm/aarch64/cpu.h
@@ -66,6 +66,46 @@
 #define SPSR_EL3_h		BIT(0)
 #define SPSR_EL3_TO_EL1		(0x2 << 1)
 
+/* System register interface to GICv3 */
+#define ICC_IGRPEN1_EL1		S3_0_C12_C12_7
+#define ICC_SGI1R		S3_0_C12_C11_5
+#define ICC_SRE_EL1		S3_0_C12_C12_5
+#define ICC_SRE_EL2		S3_4_C12_C9_5
+#define ICC_SRE_EL3		S3_6_C12_C12_5
+#define ICC_CTLR_EL1		S3_0_C12_C12_4
+#define ICC_CTLR_EL3		S3_6_C12_C12_4
+#define ICC_PMR_EL1		S3_0_C4_C6_0
+#define ICC_RPR_EL1		S3_0_C12_C11_3
+#define ICC_IGRPEN1_EL3		S3_6_C12_C12_7
+#define ICC_IGRPEN0_EL1		S3_0_C12_C12_6
+#define ICC_HPPIR0_EL1		S3_0_C12_C8_2
+#define ICC_HPPIR1_EL1		S3_0_C12_C12_2
+#define ICC_IAR0_EL1		S3_0_C12_C8_0
+#define ICC_IAR1_EL1		S3_0_C12_C12_0
+#define ICC_EOIR0_EL1		S3_0_C12_C8_1
+#define ICC_EOIR1_EL1		S3_0_C12_C12_1
+#define ICC_SGI0R_EL1		S3_0_C12_C11_7
+
+/* register constants */
+#define ICC_SRE_ELx_SRE		BIT(0)
+#define ICC_SRE_ELx_DFB		BIT(1)
+#define ICC_SRE_ELx_DIB		BIT(2)
+#define ICC_SRE_EL3_EN		BIT(3)
+
+#ifndef _ASMLANGUAGE
+/* Core sysreg macros */
+#define read_sysreg(reg) ({					\
+	u64_t val;						\
+	__asm__ volatile("mrs %0, " STRINGIFY(reg) : "=r" (val));\
+	val;							\
+})
+
+#define write_sysreg(val, reg) ({				\
+	__asm__ volatile("msr " STRINGIFY(reg) ", %0" : : "r" (val));\
+})
+
+#endif  /* !_ASMLANGUAGE */
+
 #define __ISB()			__asm__ volatile ("isb sy" : : : "memory")
 #define __DMB()			__asm__ volatile ("dmb sy" : : : "memory")
 

--- a/include/arch/arm/aarch64/cpu.h
+++ b/include/arch/arm/aarch64/cpu.h
@@ -106,9 +106,6 @@
 
 #endif  /* !_ASMLANGUAGE */
 
-#define __ISB()			__asm__ volatile ("isb sy" : : : "memory")
-#define __DMB()			__asm__ volatile ("dmb sy" : : : "memory")
-
 #define MODE_EL_SHIFT		(0x2)
 #define MODE_EL_MASK		(0x3)
 

--- a/include/arch/arm/aarch64/macro.inc
+++ b/include/arch/arm/aarch64/macro.inc
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Broadcom.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM_AARCH64_MACRO_INC_
+#define ZEPHYR_INCLUDE_ARCH_ARM_AARCH64_MACRO_INC_
+
+#ifdef _ASMLANGUAGE
+
+.macro	switch_el, xreg, el3_label, el2_label, el1_label
+	mrs	\xreg, CurrentEL
+	cmp	\xreg, 0xc
+	beq	\el3_label
+	cmp	\xreg, 0x8
+	beq	\el2_label
+	cmp	\xreg, 0x4
+	beq	\el1_label
+.endm
+
+/*
+ * macro to support mov of immediate constant to 64 bit register
+ * It will generate instruction sequence of 'mov'/ 'movz' and one
+ * to three 'movk' depending on the immediate value.
+ */
+.macro mov_imm, xreg, imm
+	.if ((\imm) == 0)
+		mov	\xreg, \imm
+	.else
+		.if (((\imm) >> 31) == 0 || ((\imm) >> 31) == 0x1ffffffff)
+			movz    \xreg, (\imm >> 16) & 0xffff, lsl 16
+		.else
+			.if (((\imm) >> 47) == 0 || ((\imm) >> 47) == 0x1ffff)
+				movz    \xreg, (\imm >> 32) & 0xffff, lsl 32
+			.else
+				movz    \xreg, (\imm >> 48) & 0xffff, lsl 48
+				movk    \xreg, (\imm >> 32) & 0xffff, lsl 32
+			.endif
+			movk    \xreg, (\imm >> 16) & 0xffff, lsl 16
+		.endif
+		movk    \xreg, (\imm) & 0xffff, lsl 0
+	.endif
+.endm
+#endif /* _ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_AARCH64_MACRO_INC_ */


### PR DESCRIPTION
Add more defines applicable for armv8.0-A
- Make 'mov_imm' macro available for assembly code out side
  arch directory.
- Add macro for 'dsb sy' barrier.
  TODO: refine more granular options
- Add core system register GAS defines for GIC.
- Add system register access macro.

changes in V2: 
- Split the patch. 
- Moved barriers defines to inline function ( Check-patch is one main reason for this)
- Addressed suggested changes.

Changes in V3:
- nit,  lower case to upper case in some of the sysreg GAS defines.

Signed-off-by: Sandeep Tripathy <sandeep.tripathy@broadcom.com>