### PR TITLE
net: lwm2m: Improve retransmission logic

### DIFF
--- a/include/net/coap.h
+++ b/include/net/coap.h
@@ -233,7 +233,8 @@ typedef int (*coap_reply_t)(const struct coap_packet *response,
  */
 struct coap_pending {
 	struct sockaddr addr;
-	s32_t timeout;
+	u32_t t0;
+	u32_t timeout;
 	u16_t id;
 	u8_t *data;
 	u16_t len;

--- a/subsys/net/lib/lwm2m/ipso_buzzer.c
+++ b/subsys/net/lib/lwm2m/ipso_buzzer.c
@@ -122,7 +122,7 @@ static int start_buzzer(struct ipso_buzzer_data *buzzer)
 	lwm2m_engine_set_bool(path, true);
 
 	float2ms(&buzzer->delay_duration, &temp);
-	k_delayed_work_submit(&buzzer->buzzer_work, temp);
+	k_delayed_work_submit(&buzzer->buzzer_work, K_MSEC(temp));
 
 	return 0;
 }

--- a/subsys/net/lib/lwm2m/ipso_timer.c
+++ b/subsys/net/lib/lwm2m/ipso_timer.c
@@ -153,7 +153,7 @@ static int start_timer(struct ipso_timer_data *timer)
 	lwm2m_engine_set_bool(path, true);
 
 	float2ms(&timer->delay_duration, &temp);
-	k_delayed_work_submit(&timer->timer_work, temp);
+	k_delayed_work_submit(&timer->timer_work, K_MSEC(temp));
 
 	return 0;
 }

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -3711,7 +3711,7 @@ static void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx,
 			lwm2m_reset_message(msg, true);
 		}
 	} else {
-		LOG_ERR("No handler for response");
+		LOG_DBG("No handler for response");
 	}
 }
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_device.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_device.c
@@ -64,7 +64,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #define DEVICE_STRING_SHORT	8
 
-#define DEVICE_SERVICE_INTERVAL K_SECONDS(10)
+#define DEVICE_SERVICE_INTERVAL_MS (MSEC_PER_SEC * 10)
 
 /*
  * Calculate resource instances as follows:
@@ -371,7 +371,7 @@ static int lwm2m_device_init(struct device *dev)
 
 	/* call device_periodic_service() every 10 seconds */
 	ret = lwm2m_engine_add_service(device_periodic_service,
-				       DEVICE_SERVICE_INTERVAL);
+				       DEVICE_SERVICE_INTERVAL_MS);
 	return ret;
 }
 

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -62,7 +62,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define LWM2M_RD_CLIENT_URI "rd"
 
 #define SECONDS_TO_UPDATE_EARLY	6
-#define STATE_MACHINE_UPDATE_INTERVAL K_MSEC(500)
+#define STATE_MACHINE_UPDATE_INTERVAL_MS 500
 
 /* Leave room for 32 hexadeciaml digits (UUID) + NULL */
 #define CLIENT_EP_LEN		33
@@ -912,7 +912,7 @@ void lwm2m_rd_client_stop(struct lwm2m_ctx *client_ctx,
 static int lwm2m_rd_client_init(struct device *dev)
 {
 	return lwm2m_engine_add_service(lwm2m_rd_client_service,
-					STATE_MACHINE_UPDATE_INTERVAL);
+					STATE_MACHINE_UPDATE_INTERVAL_MS);
 }
 
 SYS_INIT(lwm2m_rd_client_init, APPLICATION,


### PR DESCRIPTION
Improvements in LWM2M retransmission mechanism, which currently is not accurate and can lead to delays in message retransmission. The rationale for the changes is explained in the commit messages.

Together with https://github.com/zephyrproject-rtos/zephyr/pull/24492 it should improve lwm2m engine reliability in lossy networks.