### PR TITLE
boards: arm: hexiwear_k64: Replace some missed old style DT macros

### DIFF
--- a/boards/arm/hexiwear_k64/pinmux.c
+++ b/boards/arm/hexiwear_k64/pinmux.c
@@ -53,7 +53,7 @@ static int hexiwear_k64_pinmux_init(struct device *dev)
 	pinmux_pin_set(portb, 12, PORT_PCR_MUX(kPORT_MuxAsGpio));
 
 	struct device *gpiob =
-	       device_get_binding(DT_NXP_KINETIS_GPIO_GPIO_B_LABEL);
+	       device_get_binding(DT_LABEL(DT_NODELABEL(gpiob)));
 
 	gpio_pin_configure(gpiob, 12, GPIO_OUTPUT_LOW);
 #endif
@@ -91,7 +91,7 @@ static int hexiwear_k64_pinmux_init(struct device *dev)
 	pinmux_pin_set(porta, 29, PORT_PCR_MUX(kPORT_MuxAsGpio));
 
 	struct device *gpioa =
-	       device_get_binding(DT_NXP_KINETIS_GPIO_GPIO_A_LABEL);
+	       device_get_binding(DT_LABEL(DT_NODELABEL(gpioa)));
 
 	gpio_pin_configure(gpioa, 29, GPIO_OUTPUT_HIGH);
 #endif
@@ -100,7 +100,7 @@ static int hexiwear_k64_pinmux_init(struct device *dev)
 	pinmux_pin_set(portc, 14, PORT_PCR_MUX(kPORT_MuxAsGpio));
 
 	struct device *gpioc =
-	       device_get_binding(DT_NXP_KINETIS_GPIO_GPIO_C_LABEL);
+	       device_get_binding(DT_LABEL(DT_NODELABEL(gpioc)));
 
 	gpio_pin_configure(gpioc, 14, GPIO_OUTPUT_LOW);
 #endif


### PR DESCRIPTION
Replace DT_NXP_KINETIS_GPIO_GPIO_x_LABEL with
DT_LABEL(DT_NODELABEL(gpioX)).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>