### PR TITLE
soc: arm: nxp: kinetis: k6x: additional kconfig clock settings

### DIFF
--- a/soc/arm/nxp_kinetis/k6x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.soc
@@ -116,4 +116,18 @@ config K6X_FLASH_CLOCK_DIVIDER
 	  This option specifies the divide value for the K6X flash clock from the
 	  system clock.
 
+config K6X_PLLFLL_SELECT
+	int "Freescale K64 PLL/FLL select"
+	default 1
+	help
+	  This option specifies the PLL/FLL selection bit for the clock system.
+	  MCGFLLCLK = 0, MCGPLLCLK = 1, IRC48MHZ = 3
+
+config K6X_ER32K_SELECT
+	int "Freescale K64 ER32K select"
+	default 2
+	help
+	  This option specifies the ER32K clock selection bit for the clock system.
+	  OSC32KCLK = 0, RTC = 2, LPO1KHZ = 3
+
 endif # SOC_SERIES_KINETIS_K6X

--- a/soc/arm/nxp_kinetis/k6x/soc.c
+++ b/soc/arm/nxp_kinetis/k6x/soc.c
@@ -23,14 +23,6 @@
 #include <arch/cpu.h>
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 
-#define PLLFLLSEL_MCGFLLCLK	(0)
-#define PLLFLLSEL_MCGPLLCLK	(1)
-#define PLLFLLSEL_IRC48MHZ	(3)
-
-#define ER32KSEL_OSC32KCLK	(0)
-#define ER32KSEL_RTC		(2)
-#define ER32KSEL_LPO1KHZ	(3)
-
 #define TIMESRC_OSCERCLK        (2)
 
 static const osc_config_t oscConfig = {
@@ -63,8 +55,8 @@ static const mcg_pll_config_t pll0Config = {
 };
 
 static const sim_clock_config_t simConfig = {
-	.pllFllSel = PLLFLLSEL_MCGPLLCLK, /* PLLFLLSEL select PLL. */
-	.er32kSrc = ER32KSEL_RTC,         /* ERCLK32K selection, use RTC. */
+	.pllFllSel = CONFIG_K6X_PLLFLL_SELECT,
+	.er32kSrc = CONFIG_K6X_ER32K_SELECT,
 	.clkdiv1 = SIM_CLKDIV1_OUTDIV1(CONFIG_K6X_CORE_CLOCK_DIVIDER - 1) |
 		   SIM_CLKDIV1_OUTDIV2(CONFIG_K6X_BUS_CLOCK_DIVIDER - 1) |
 		   SIM_CLKDIV1_OUTDIV3(CONFIG_K6X_FLEXBUS_CLOCK_DIVIDER - 1) |


### PR DESCRIPTION
Allow configuration of PLLFLL and ER32K clock settings from kconfig.

Signed-off-by: Mikkel Jakobsen <mikkel.aunsbjerg@prevas.dk>