### PR TITLE
boards: nucleo_wb55rg: Update HCI lib to version 1.5

### DIFF
--- a/boards/arm/nucleo_wb55rg/doc/nucleo_wb55rg.rst
+++ b/boards/arm/nucleo_wb55rg/doc/nucleo_wb55rg.rst
@@ -179,6 +179,15 @@ Other hardware features are not yet supported on this Zephyr port.
 The default configuration can be found in the defconfig file:
 ``boards/arm/nucleo_wb55rg/nucleo_wb55rg_defconfig``
 
+Bluetooth and compatibility with STM32WB Copro Wireless Binaries
+================================================================
+
+To operate bluetooth on Nucleo WB55RG, Cortex-M0 core should be flashed with
+a valid STM32WB Coprocessor binaries (either 'Full stack' or 'HCI Layer').
+These binaries are delivered in STM32WB Cube packages, under
+Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/
+To date, interoperability and backward compatibility has been tested and is
+guaranteed up to version 1.5 of STM32Cube package releases.
 
 Connections and IOs
 ===================

--- a/west.yml
+++ b/west.yml
@@ -68,7 +68,7 @@ manifest:
       revision: fa481784b3c49780f18d50bafe00390ccb62b2ec
       path: modules/hal/st
     - name: hal_stm32
-      revision: 37dcc0e120bb2bb99d3ee3b99dbbcf2bffe50258
+      revision: ff9b7f295da7e8918fbe3e0119b5271cb9cb4a55
       path: modules/hal/stm32
     - name: hal_ti
       revision: b25d4b83b16e52f501f8cd360f4efb8c31ffb578


### PR DESCRIPTION
Update STM32WB HCI lib support to version 1.5.0.
Additionally provide a doc section to clarify compatibility
with stm32wb wireless co-processor binaries.


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>

Depends on zephyrproject-rtos/hal_stm32#51