### PR TITLE
drivers/timer: stm32_lptim: Move to new DT api

### DIFF
--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -124,9 +124,10 @@ int z_clock_driver_init(struct device *device)
 #endif /* CONFIG_STM32_LPTIM_CLOCK_LSI */
 
 	/* Clear the event flag and possible pending interrupt */
-	IRQ_CONNECT(DT_LPTIM_1_IRQ, DT_LPTIM_1_IRQ_PRI,
-			lptim_irq_handler, 0, 0);
-	irq_enable(DT_LPTIM_1_IRQ);
+	IRQ_CONNECT(DT_IRQN(DT_NODELABEL(lptim1)),
+		    DT_IRQ(DT_NODELABEL(lptim1), priority),
+		    lptim_irq_handler, 0, 0);
+	irq_enable(DT_IRQN(DT_NODELABEL(lptim1)));
 
 	/* configure the LPTIM1 counter */
 	LL_LPTIM_SetClockSource(LPTIM1, LL_LPTIM_CLK_SOURCE_INTERNAL);


### PR DESCRIPTION
Use NODELABEL macros rather than DT_INST as this driver is so far
limited to support of LPTIM1 instance.


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>