### PR TITLE
board/arm/stm32h747i_disco: add support of flash with openocd

### DIFF
--- a/boards/arm/stm32h747i_disco/board.cmake
+++ b/boards/arm/stm32h747i_disco/board.cmake
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_BOARD_STM32H747I_DISCO_M7)
+board_runner_args(openocd "--config=${BOARD_DIR}/support/openocd_stm32h747i_disco_m7.cfg")
+elseif(CONFIG_BOARD_STM32H747I_DISCO_M4)
+board_runner_args(openocd "--config=${BOARD_DIR}/support/openocd_stm32h747i_disco_m4.cfg")
+endif()
+
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/stm32h747i_disco/doc/index.rst
+++ b/boards/arm/stm32h747i_disco/doc/index.rst
@@ -132,6 +132,16 @@ Applications for the ``stm32h747i_disco`` board should be built per core target,
 using either ``stm32h747i_disco_m7`` or ```stm32h747i_disco_m4`` as the target.
 See :ref:`build_an_application` for more information about application builds.
 
+.. note::
+
+   If using OpenOCD you will need a recent development version as the last
+   official release does not support H7 dualcore yet.
+   Also, with OpenOCD, sometimes, flashing is not working. It is necessary to
+   erase the flash (with STM32CubeProgrammer for example) to make it work again.
+   Debugging with OpenOCD is currently working for this board only with Cortex M7,
+   not Cortex M4.
+
+
 Flashing
 ========
 
@@ -170,6 +180,17 @@ Use the following commands to flash either m7 or m4 target:
    $ ./STM32_Programmer_CLI -c port=SWD mode=UR -w <path_to_m7_binary>  0x8000000
    $ ./STM32_Programmer_CLI -c port=SWD mode=UR -w <path_to_m4_binary>  0x8100000
 
+Alternatively it is possible to flash with OpenOcd but with some restrictions:
+Sometimes, flashing is not working. It is necessary to erase the flash
+(with STM32CubeProgrammer for example) to make it work again.
+Debugging with OpenOCD is currently working for this board only with Cortex M7,
+not Cortex M4.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm32h747i_disco_m7
+   :goals: build flash
+
 Run a serial host program to connect with your board:
 
 .. code-block:: console
@@ -180,7 +201,7 @@ You should see the following message on the console:
 
 .. code-block:: console
 
-   Hello World! arm
+   Hello World! stm32h747i_disco_m7
 
 Debugging
 =========

--- a/boards/arm/stm32h747i_disco/support/openocd_stm32h747i_disco_m4.cfg
+++ b/boards/arm/stm32h747i_disco/support/openocd_stm32h747i_disco_m4.cfg
@@ -1,0 +1,12 @@
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+set DUAL_BANK 1
+
+set DUAL_CORE 1
+
+source [find target/stm32h7x.cfg]
+
+reset_config srst_only

--- a/boards/arm/stm32h747i_disco/support/openocd_stm32h747i_disco_m7.cfg
+++ b/boards/arm/stm32h747i_disco/support/openocd_stm32h747i_disco_m7.cfg
@@ -1,0 +1,9 @@
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32h7x.cfg]
+
+reset_config srst_only
+


### PR DESCRIPTION
Allow to flash either Cortex M4 or M7 with OpenOCD
(depending on which Board/Core has been compiled)
Command: west flash

Warning: Dependency with recent OpenOCD patch:
Windows: https://gnutoolchains.com/arm-eabi/openocd/
                 version 20200408
Linux : http://openocd.zylin.com/
           SHA1: 0a804222da63c5f849efa23b019a59e2dea76842

Edit:
OpenOCD dependancy: https://github.com/zephyrproject-rtos/openocd/issues/27

Note: It is necessary to first update ST-Link firmware (see https://github.com/zephyrproject-rtos/zephyr/pull/24671)

Known Restrictions:
---------------------
Sometimes flashing doesn't work and it is necessary to erase the flash to be able make it work again.
Debugging Cortex M7 works, but it doesn't work with Cortex M4.
