### PR TITLE
dts: atmel: sam0: Add clocks for ADC and TCn devices

### DIFF
--- a/dts/arm/atmel/samd20.dtsi
+++ b/dts/arm/atmel/samd20.dtsi
@@ -19,6 +19,8 @@
 			reg = <0x42002000 0x20>;
 			interrupts = <13 0>;
 			label = "TIMER_0";
+			clocks = <&gclk 0x13>, <&pm 0x20 8>;
+			clock-names = "GCLK", "PM";
 		};
 
 		tc2: tc@42002800 {
@@ -26,6 +28,8 @@
 			reg = <0x42002800 0x20>;
 			interrupts = <15 0>;
 			label = "TIMER_2";
+			clocks = <&gclk 0x14>, <&pm 0x20 10>;
+			clock-names = "GCLK", "PM";
 		};
 
 		tc6: tc@42003800 {
@@ -33,6 +37,8 @@
 			reg = <0x42003800 0x20>;
 			interrupts = <19 0>;
 			label = "TIMER_6";
+			clocks = <&gclk 0x16>, <&pm 0x20 14>;
+			clock-names = "GCLK", "PM";
 		};
 	};
 };
@@ -75,8 +81,12 @@
 
 &tc4 {
 	interrupts = <17 0>;
+	clocks = <&gclk 0x15>, <&pm 0x20 12>;
+	clock-names = "GCLK", "PM";
 };
 
 &adc {
 	interrupts = <21 0>;
+	clocks = <&gclk 0x17>, <&pm 0x20 16>;
+	clock-names = "GCLK", "PM";
 };

--- a/dts/arm/atmel/samd21.dtsi
+++ b/dts/arm/atmel/samd21.dtsi
@@ -34,6 +34,8 @@
 			reg = <0x42003800 0x20>;
 			interrupts = <21 0>;
 			label = "TIMER_6";
+			clocks = <&gclk 0x1d>, <&pm 0x20 14>;
+			clock-names = "GCLK", "PM";
 		};
 	};
 };
@@ -76,8 +78,12 @@
 
 &tc4 {
 	interrupts = <19 0>;
+	clocks = <&gclk 0x1c>, <&pm 0x20 12>;
+	clock-names = "GCLK", "PM";
 };
 
 &adc {
+	clocks = <&gclk 0x1e>, <&pm 0x20 16>;
+	clock-names = "GCLK", "PM";
 	interrupts = <23 0>;
 };

--- a/dts/arm/atmel/samd5x.dtsi
+++ b/dts/arm/atmel/samd5x.dtsi
@@ -303,6 +303,8 @@
 			gclk = <2>;
 			prescaler = <4>;
 			#io-channel-cells = <1>;
+			clocks = <&gclk 40>, <&mclk 0x20 7>;
+			clock-names = "GCLK", "MCLK";
 		};
 
 		adc1: adc@43002000 {
@@ -320,6 +322,8 @@
 			gclk = <2>;
 			prescaler = <4>;
 			#io-channel-cells = <1>;
+			clocks = <&gclk 41>, <&mclk 0x20 8>;
+			clock-names = "GCLK", "MCLK";
 		};
 
 		tc0: tc@40003800 {
@@ -327,6 +331,8 @@
 			reg = <0x40003800 0x34>;
 			interrupts = <107 0>;
 			label = "TIMER_0";
+			clocks = <&gclk 9>, <&mclk 0x14 14>;
+			clock-names = "GCLK", "MCLK";
 		};
 
 		tc2: tc@4101A000 {
@@ -334,6 +340,8 @@
 			reg = <0x4101A000 0x34>;
 			interrupts = <109 0>;
 			label = "TIMER_2";
+			clocks = <&gclk 26>, <&mclk 0x18 13>;
+			clock-names = "GCLK", "MCLK";
 		};
 
 		tc4: tc@42001400 {
@@ -341,6 +349,8 @@
 			reg = <0x42001400 0x34>;
 			interrupts = <111 0>;
 			label = "TIMER_4";
+			clocks = <&gclk 30>, <&mclk 0x1c 5>;
+			clock-names = "GCLK", "MCLK";
 		};
 
 		tc6: tc@43001400 {
@@ -348,6 +358,8 @@
 			reg = <0x43001400 0x34>;
 			interrupts = <113 0>;
 			label = "TIMER_6";
+			clocks = <&gclk 39>, <&mclk 0x20 5>;
+			clock-names = "GCLK", "MCLK";
 		};
 	};
 };

--- a/dts/arm/atmel/samr21.dtsi
+++ b/dts/arm/atmel/samr21.dtsi
@@ -84,8 +84,12 @@
 
 &tc4 {
 	interrupts = <19 0>;
+	clocks = <&gclk 0x1c>, <&pm 0x20 12>;
+	clock-names = "GCLK", "PM";
 };
 
 &adc {
+	clocks = <&gclk 0x1e>, <&pm 0x20 16>;
+	clock-names = "GCLK", "PM";
 	interrupts = <23 0>;
 };

--- a/dts/bindings/iio/adc/atmel,sam0-adc.yaml
+++ b/dts/bindings/iio/adc/atmel,sam0-adc.yaml
@@ -14,6 +14,12 @@ properties:
     interrupts:
       required: true
 
+    clocks:
+      required: true
+
+    clock-names:
+      required: true
+
     gclk:
       type: int
       required: true

--- a/dts/bindings/timer/atmel,sam0-tc32.yaml
+++ b/dts/bindings/timer/atmel,sam0-tc32.yaml
@@ -14,5 +14,11 @@ properties:
   interrupts:
     required: true
 
+  clocks:
+    required: true
+
+  clock-names:
+    required: true
+
   label:
     required: true


### PR DESCRIPTION
Add clock references for ADC and TC devices.  Update the bindings for
these devices to require clocks property and update the dtsi files to
have the clock info.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>