### PR TITLE
soc: arm: replace DT_ARM_CORTEX_*_CLOCK_FREQUENCY with new dt macros

### DIFF
--- a/soc/arm/atmel_sam0/common/atmel_sam0_dt.h
+++ b/soc/arm/atmel_sam0/common/atmel_sam0_dt.h
@@ -35,4 +35,8 @@
 	DT_HAS_NODE(DT_NODELABEL(sercom##n)) && \
 	DT_NODE_HAS_COMPAT(DT_NODELABEL(sercom##n), compat)
 
+/* Common macro for use to set HCLK_FREQ_HZ */
+#define ATMEL_SAM0_DT_CPU_CLK_FREQ_HZ \
+	DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
+
 #endif /* _ATMEL_SAM0_SOC_DT_H_ */

--- a/soc/arm/atmel_sam0/samd20/soc.h
+++ b/soc/arm/atmel_sam0/samd20/soc.h
@@ -56,7 +56,8 @@
 #include "../common/atmel_sam0_dt.h"
 
 /** Processor Clock (HCLK) Frequency */
-#define SOC_ATMEL_SAM0_HCLK_FREQ_HZ DT_ARM_CORTEX_M0PLUS_0_CLOCK_FREQUENCY
+#define SOC_ATMEL_SAM0_HCLK_FREQ_HZ ATMEL_SAM0_DT_CPU_CLK_FREQ_HZ
+
 /** Master Clock (MCK) Frequency */
 #define SOC_ATMEL_SAM0_MCK_FREQ_HZ SOC_ATMEL_SAM0_HCLK_FREQ_HZ
 #define SOC_ATMEL_SAM0_XOSC32K_FREQ_HZ 32768

--- a/soc/arm/atmel_sam0/samd21/soc.h
+++ b/soc/arm/atmel_sam0/samd21/soc.h
@@ -50,7 +50,8 @@
 #include "../common/atmel_sam0_dt.h"
 
 /** Processor Clock (HCLK) Frequency */
-#define SOC_ATMEL_SAM0_HCLK_FREQ_HZ DT_ARM_CORTEX_M0PLUS_0_CLOCK_FREQUENCY
+#define SOC_ATMEL_SAM0_HCLK_FREQ_HZ ATMEL_SAM0_DT_CPU_CLK_FREQ_HZ
+
 /** Master Clock (MCK) Frequency */
 #define SOC_ATMEL_SAM0_MCK_FREQ_HZ SOC_ATMEL_SAM0_HCLK_FREQ_HZ
 #define SOC_ATMEL_SAM0_XOSC32K_FREQ_HZ 32768

--- a/soc/arm/atmel_sam0/samr21/soc.h
+++ b/soc/arm/atmel_sam0/samr21/soc.h
@@ -36,7 +36,8 @@
 #include "../common/atmel_sam0_dt.h"
 
 /** Processor Clock (HCLK) Frequency */
-#define SOC_ATMEL_SAM0_HCLK_FREQ_HZ DT_ARM_CORTEX_M0PLUS_0_CLOCK_FREQUENCY
+#define SOC_ATMEL_SAM0_HCLK_FREQ_HZ ATMEL_SAM0_DT_CPU_CLK_FREQ_HZ
+
 /** Master Clock (MCK) Frequency */
 #define SOC_ATMEL_SAM0_MCK_FREQ_HZ SOC_ATMEL_SAM0_HCLK_FREQ_HZ
 #define SOC_ATMEL_SAM0_XOSC32K_FREQ_HZ 32768

--- a/soc/arm/nxp_kinetis/k6x/soc.c
+++ b/soc/arm/nxp_kinetis/k6x/soc.c
@@ -106,7 +106,7 @@ static ALWAYS_INLINE void clock_init(void)
 #endif
 #if CONFIG_USB_KINETIS
 	CLOCK_EnableUsbfs0Clock(kCLOCK_UsbSrcPll0,
-				DT_ARM_CORTEX_M4F_0_CLOCK_FREQUENCY);
+				DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency));
 #endif
 }
 

--- a/soc/arm/nxp_kinetis/kl2x/soc.c
+++ b/soc/arm/nxp_kinetis/kl2x/soc.c
@@ -68,7 +68,7 @@ static ALWAYS_INLINE void clock_init(void)
 #endif
 #if CONFIG_USB_KINETIS
 	CLOCK_EnableUsbfs0Clock(kCLOCK_UsbSrcPll0,
-				DT_ARM_CORTEX_M0PLUS_0_CLOCK_FREQUENCY);
+				DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency));
 #endif
 }
 

--- a/soc/arm/nxp_kinetis/kwx/soc_kw2xd.c
+++ b/soc/arm/nxp_kinetis/kwx/soc_kw2xd.c
@@ -132,7 +132,7 @@ static ALWAYS_INLINE void clock_init(void)
 	CLOCK_SetSimConfig(&simConfig);
 #if CONFIG_USB_KINETIS
 	CLOCK_EnableUsbfs0Clock(kCLOCK_UsbSrcPll0,
-				DT_ARM_CORTEX_M4_0_CLOCK_FREQUENCY);
+				DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency));
 #endif
 }
 

--- a/soc/arm/nxp_lpc/lpc54xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc54xxx/soc.c
@@ -33,6 +33,7 @@
  * @return N/A
  *
  */
+#define CPU_FREQ DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
 
 static ALWAYS_INLINE void clock_init(void)
 {
@@ -50,10 +51,10 @@ static ALWAYS_INLINE void clock_init(void)
 	CLOCK_AttachClk(kFRO12M_to_MAIN_CLK);
 
 	/* Set FLASH wait states for core */
-	CLOCK_SetFLASHAccessCyclesForFreq(DT_ARM_CORTEX_M4F_0_CLOCK_FREQUENCY);
+	CLOCK_SetFLASHAccessCyclesForFreq(CPU_FREQ);
 
 	/* Set up high frequency FRO output to selected frequency */
-	CLOCK_SetupFROClocking(DT_ARM_CORTEX_M4F_0_CLOCK_FREQUENCY);
+	CLOCK_SetupFROClocking(CPU_FREQ);
 
 	/* Set up dividers */
 	/* Set AHBCLKDIV divider to value 1 */


### PR DESCRIPTION
Replace DT_ARM_CORTEX_*_0_CLOCK_FREQUENCY with a PATH based reference
to cpu@0 (DT_PATH(cpus, cpu_0)) and than getting the clock_frequency
property:

    DT_ARM_CORTEX_*_CLOCK_FREQUENCY ->
	DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>