### PR TITLE
samples: nrf52: mesh: added delay

### DIFF
--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/main.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/main.c
@@ -175,6 +175,7 @@ void main(void)
 	}
 
 	bt_ready();
+	k_sleep(100);
 
 	light_default_status_init();
 


### PR DESCRIPTION
Added small delay after initiating reading of stored
persistent data. After provisioning of Node, Reset Counter
value was not get updated if we do short time multiple
resets. By adding small delay, now issue has solved.

Signed-off-by: Vikrant More <vikrant8051@gmail.com>