### PR TITLE
samples: drivers: counter: alarm: Add samd20_xpro

### DIFF
--- a/samples/drivers/counter/alarm/Kconfig
+++ b/samples/drivers/counter/alarm/Kconfig
@@ -7,4 +7,8 @@ config COUNTER_RTC0
 	bool
 	default y if SOC_FAMILY_NRF
 
+config COUNTER_SAM0_TC32
+	bool
+	default y if BOARD_ATSAMD20_XPRO
+
 source "Kconfig.zephyr"

--- a/samples/drivers/counter/alarm/sample.yaml
+++ b/samples/drivers/counter/alarm/sample.yaml
@@ -5,7 +5,7 @@ tests:
     tags: drivers
     harness: console
     platform_whitelist: nucleo_f746zg nrf51dk_nrf51422 nrf52dk_nrf52832
-                        nrf52840dk_nrf52840 nrf9160dk_nrf9160
+                        nrf52840dk_nrf52840 nrf9160dk_nrf9160 atsamd20_xpro
     harness_config:
         type: multi_line
         ordered: true

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -15,6 +15,12 @@
 
 struct counter_alarm_cfg alarm_cfg;
 
+#if defined(CONFIG_BOARD_ATSAMD20_XPRO)
+#define TIMER DT_LABEL(DT_NODELABEL(tc4))
+#else
+#define TIMER DT_RTC_0_NAME
+#endif
+
 static void test_counter_interrupt_fn(struct device *counter_dev,
 				      u8_t chan_id, u32_t ticks,
 				      void *user_data)
@@ -58,7 +64,7 @@ void main(void)
 	int err;
 
 	printk("Counter alarm sample\n\n");
-	counter_dev = device_get_binding(DT_RTC_0_NAME);
+	counter_dev = device_get_binding(TIMER);
 	if (counter_dev == NULL) {
 		printk("Device not found\n");
 		return;


### PR DESCRIPTION
Add samd20_xpro board support to show how to use sam0 TC32.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>