### PR TITLE
drivers: sensor: mpu9250: Add support for 9-axis mems device

### DIFF
--- a/drivers/sensor/mpu6050/CMakeLists.txt
+++ b/drivers/sensor/mpu6050/CMakeLists.txt
@@ -4,3 +4,4 @@ zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_MPU6050 mpu6050.c)
 zephyr_library_sources_ifdef(CONFIG_MPU6050_TRIGGER mpu6050_trigger.c)
+zephyr_library_sources_ifdef(CONFIG_MPU6050_MPU9250_WITH_AK mpu6050_ak89xx.c)

--- a/drivers/sensor/mpu6050/Kconfig
+++ b/drivers/sensor/mpu6050/Kconfig
@@ -7,7 +7,7 @@ menuconfig MPU6050
 	bool "MPU6050 Six-Axis Motion Tracking Device"
 	depends on I2C
 	help
-	  Enable driver for MPU6050 I2C-based six-axis motion tracking device.
+	  Enable driver for MPU6050 or MPU9250 I2C-based motion tracking device.
 
 if MPU6050
 
@@ -34,6 +34,28 @@ endchoice
 
 config MPU6050_TRIGGER
 	bool
+
+choice
+	prompt "MPU9250 mode"
+	default MPU6050_MPU9250_DISABLED
+	help
+	  Usage of MPU9250 driver.
+
+config MPU6050_MPU9250_DISABLED
+	bool "Use MPU6050 driver"
+
+config MPU6050_MPU9250_WITH_AK
+	bool "Use MPU9250 with on-chip AK89XX magnetometer"
+	select MPU6050_MPU9250_MODE
+
+config MPU6050_MPU9250_NO_AK
+	bool "Use MPU9250 without magnetometer"
+	select MPU6050_MPU9250_MODE
+
+endchoice
+
+config MPU6050_MPU9250_MODE
+        bool
 
 config MPU6050_THREAD_PRIORITY
 	int "Thread priority"

--- a/drivers/sensor/mpu6050/mpu6050.h
+++ b/drivers/sensor/mpu6050/mpu6050.h
@@ -13,7 +13,11 @@
 #include <zephyr/types.h>
 
 #define MPU6050_REG_CHIP_ID		0x75
-#define MPU6050_CHIP_ID			0x68
+#ifdef CONFIG_MPU6050_MPU9250_MODE
+#define MPU6050_REG_VALUE_CHIP_ID	0x71
+#else
+#define MPU6050_REG_VALUE_CHIP_ID	0x68
+#endif
 
 #define MPU6050_REG_GYRO_CFG		0x1B
 #define MPU6050_GYRO_FS_SHIFT		3
@@ -26,8 +30,33 @@
 
 #define MPU6050_REG_DATA_START		0x3B
 
-#define MPU6050_REG_PWR_MGMT1		0x6B
-#define MPU6050_SLEEP_EN		BIT(6)
+#define MPU6050_REG_PWR_MGMT1			0x6B
+#define MPU6050_REG_VALUE_PWR_MGMT1_RESET	0x80
+#define MPU6050_REG_VALUE_PWR_MGMT1_CLOCK_PLL	0x01
+
+#ifdef CONFIG_MPU6050_MPU9250_WITH_AK
+#define MPU9250_AK89XX_REG_CNTL1			0x0A
+#define MPU9250_AK89XX_REG_VALUE_CNTL1_POWERDOWN	0x00
+#define MPU9250_AK89XX_REG_VALUE_CNTL1_FUSE_ROM	0x0F
+#define MPU9250_AK89XX_REG_VALUE_CNTL1_16BIT_100HZ	0x16
+#define MPU9250_AK89XX_REG_DATA			0x03
+#define MPU9250_AK89XX_REG_ID				0x00
+#define MPU9250_AK89XX_REG_VALUE_ID			0x48
+#define MPU9250_AK89XX_REG_CNTL2			0x0B
+#define MPU9250_AK89XX_REG_VALUE_CNTL2_RESET		0x01
+#define MPU9250_AK89XX_REG_ADJ_DATA			0x10
+#define MPU9250_REG_I2C_MST_CTRL			0x24
+#define MPU9250_REG_VALUE_I2C_MST_CTRL_WAIT_MAG_400KHZ	0x4D
+#define MPU9250_REG_I2C_SLV0_ADDR			0x25
+#define MPU9250_REG_VALUE_I2C_SLV0_ADDR_AK89XX		0x0C
+#define MPU9250_REG_I2C_SLV0_REG			0x26
+#define MPU9250_REG_I2C_SLV0_CTRL			0x27
+#define MPU9250_REG_I2C_SLV0_DATA0			0x63
+#define MPU9250_REG_VALUE_I2C_SLV0_CTRL		0x80
+#define MPU9250_REG_USER_CTRL				0x6A
+#define MPU9250_REG_VALUE_USER_CTRL_I2C_MASTERMODE	0x20
+#define MPU9250_REG_EXT_DATA00				0x49
+#endif /* CONFIG_MPU6050_MPU9250_WITH_AK */
 
 /* measured in degrees/sec x10 to avoid floating point */
 static const u16_t mpu6050_gyro_sensitivity_x10[] = {
@@ -48,6 +77,14 @@ struct mpu6050_data {
 	s16_t gyro_y;
 	s16_t gyro_z;
 	u16_t gyro_sensitivity_x10;
+#ifdef CONFIG_MPU6050_MPU9250_WITH_AK
+	s16_t magn_x;
+	s16_t magn_y;
+	s16_t magn_z;
+	s16_t magn_scale_x;
+	s16_t magn_scale_y;
+	s16_t magn_scale_z;
+#endif /* CONFIG_MPU6050_MPU9250_WITH_AK */
 
 #ifdef CONFIG_MPU6050_TRIGGER
 	struct device *dev;
@@ -84,6 +121,12 @@ int mpu6050_trigger_set(struct device *dev,
 			sensor_trigger_handler_t handler);
 
 int mpu6050_init_interrupt(struct device *dev);
-#endif
+#endif /* CONFIG_MPU6050_TRIGGER */
+
+#ifdef CONFIG_MPU6050_MPU9250_WITH_AK
+int mpu6050_ak89xx_init(struct device *dev);
+void mpu6050_ak89xx_convert_magn(struct sensor_value *val, s16_t raw_val,
+				  s16_t scale);
+#endif /* CONFIG_MPU6050_MPU9250_WITH_AK */
 
 #endif /* __SENSOR_MPU6050__ */

--- a/drivers/sensor/mpu6050/mpu6050_ak89xx.c
+++ b/drivers/sensor/mpu6050/mpu6050_ak89xx.c
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2020 Pauli Salmenrinne
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <drivers/i2c.h>
+#include <logging/log.h>
+#include <drivers/sensor.h>
+
+#include "mpu6050.h"
+
+LOG_MODULE_DECLARE(MPU6050, CONFIG_SENSOR_LOG_LEVEL);
+
+
+
+void mpu6050_ak89xx_convert_magn(struct sensor_value *val, s16_t raw_val,
+				  s16_t scale)
+{
+	/* The sensor returns 10^-9 Teslas after scaling.
+	 * The unit here is defined to be Gauss, and 1T = 10^4 Gauss
+         * So sensor returns 10^-9 * 10^4 = 10^-5 Gauss units
+	 */
+
+	s32_t conv_val_cg = raw_val * scale ;
+	val->val1 = conv_val_cg / 1000000;
+	val->val2 = conv_val_cg % 1000000;
+}
+
+
+static int mpu6050_ak89xx_register_prepare( struct device *dev, u8_t regaddress,
+					bool write_mode, u8_t count )
+{
+
+	/* Instruct the MPU9250 to access over its external i2c bus
+	 * given device register with given details
+	 */
+	const struct mpu6050_config *cfg = dev->config->config_info;
+	struct mpu6050_data *drv_data = dev->driver_data;
+	u8_t mode_bit = 0x00;
+
+	if (write_mode == false) {
+		mode_bit = 0x80;
+	}
+
+	/* Set target register and operation type */
+	__ASSERT_NO_MSG( (MPU9250_REG_VALUE_I2C_SLV0_ADDR_AK89XX & 0x80) == 0x00 );
+
+	/* Set target i2c address  */
+	if (i2c_reg_write_byte(drv_data->i2c, cfg->i2c_addr,
+			       MPU9250_REG_I2C_SLV0_ADDR,
+			       MPU9250_REG_VALUE_I2C_SLV0_ADDR_AK89XX | mode_bit  ) < 0 ) {
+		return -EIO;
+	}
+
+	if (i2c_reg_write_byte(drv_data->i2c, cfg->i2c_addr,
+			       MPU9250_REG_I2C_SLV0_REG,
+			       regaddress ) < 0 ) {
+		return -EIO;
+	}
+
+	/* Enable and write N bytes. Datasheet of MPU9250 is not too clear on Then
+	 *  enable bit for write, but this is how it seems to work
+	*/
+
+	__ASSERT_NO_MSG( count <= 0x7 );
+	__ASSERT_NO_MSG( count >= 0x1 );
+
+	if (i2c_reg_write_byte(drv_data->i2c, cfg->i2c_addr,
+			       MPU9250_REG_I2C_SLV0_CTRL,
+			       MPU9250_REG_VALUE_I2C_SLV0_CTRL | count ) <0) {
+		return -EIO;
+	}
+
+	/* Wait for a while to get read/write done */
+	k_sleep(K_MSEC(1));
+	return 0;
+
+}
+
+static int mpu6050_ak89xx_read_register( struct device *dev,
+		u8_t regaddress, u8_t* data, u8_t read_n )
+{
+	const struct mpu6050_config *cfg = dev->config->config_info;
+	struct mpu6050_data *drv_data = dev->driver_data;
+
+	if (mpu6050_ak89xx_register_prepare( dev, regaddress, false, read_n) <0) {
+		return -EIO;
+	}
+
+	/* Read the result */
+	if (i2c_reg_read_byte(drv_data->i2c, cfg->i2c_addr,
+			      MPU9250_REG_EXT_DATA00, data) < 0) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int mpu6050_ak89xx_write_register( struct device *dev,
+		u8_t regaddress, u8_t data, bool verify )
+{
+	const struct mpu6050_config *cfg = dev->config->config_info;
+	struct mpu6050_data *drv_data = dev->driver_data;
+	u8_t buffer;
+
+	/* Set the data to be written */
+	if (i2c_reg_write_byte(drv_data->i2c, cfg->i2c_addr,
+			       MPU9250_REG_I2C_SLV0_DATA0,
+			       data ) < 0 ) {
+		return -EIO;
+	}
+
+	/* Instruct the write operation and execute */
+	if (mpu6050_ak89xx_register_prepare( dev, regaddress, true, 1) <0 ) {
+		return -EIO;
+	}
+
+	if ( verify )
+	{
+		/* Read to verify */
+		if (mpu6050_ak89xx_read_register( dev,regaddress, &buffer, 1) <0 ) {
+			return -EIO;
+		}
+
+		if( buffer != data) {
+			return -EIO;
+		}
+	}
+
+	return 0;
+}
+
+
+static int mpu6050_ak89xx_change_mode(struct device *dev, u8_t mode)
+{
+	/* Reset the chip -> reset all settings. */
+	if ( mpu6050_ak89xx_write_register( dev, MPU9250_AK89XX_REG_CNTL1,
+			mode, true ) < 0) {
+		return -EIO;
+	}
+	/* Datasheet for AK8963 says at least 100uS wait is required */
+	k_sleep(K_MSEC(1));
+	return 0;
+}
+
+static s16_t mpu6050_ak89xx_calc_adj( s16_t reg_value )
+{
+
+	/** Datasheet says the actual register value is in 16bit output max value of 32760
+	 * that corresponds to 4912 uT flux, yielding factor of 0.149938. We make no damage
+	 * assume its 0.15.
+	 *
+	 * Now Zephyr unit is Gauss, and conversion is 1T = 10^4G
+	 * -> 0.15 * 10^4 = 1500
+	 * So if we multiply with scaling with 1500 the unit is uG.
+	 */
+	static const s16_t MPU6050_AK98XX_SCALE_TO_UG = 1500;
+
+	/** The scaling formulation is: ( ( (s16_t)buffer[0] - 128 ) / 256 + 1 ) , that yields range 0.5 - 1.5. We can safely scale
+	 *  it with 1500, due integer calculations, we reorder it a bit (multiply before divide)
+	 */
+	return (MPU6050_AK98XX_SCALE_TO_UG*( reg_value - 128 )) / 256 + MPU6050_AK98XX_SCALE_TO_UG;
+}
+
+static int mpu6050_ak89xx_fetch_adj( struct device *dev  )
+{
+	/* Read magnetometer adjustment data from the AK89XX chip */
+	struct mpu6050_data *drv_data = dev->driver_data;
+	u8_t buffer[3];
+
+	/* We need to change to FUSE access mode before we can access
+	 * adjustment registers
+	 */
+
+	if (mpu6050_ak89xx_change_mode( dev,
+			MPU9250_AK89XX_REG_VALUE_CNTL1_FUSE_ROM ) < 0) {
+		LOG_ERR("Failed to set chip in fuse access mode.");
+		return -EIO;
+	}
+
+	if (mpu6050_ak89xx_read_register(dev,
+			   MPU9250_AK89XX_REG_ADJ_DATA, buffer, 3) < 0) {
+		LOG_ERR("Failed to read adjustment data.");
+		return -EIO;
+	}
+
+	/* Change back to the powerdown mode, so we can later change it */
+	if (mpu6050_ak89xx_change_mode( dev,
+			MPU9250_AK89XX_REG_VALUE_CNTL1_POWERDOWN ) < 0) {
+		LOG_ERR("Failed to set chip in power down mode.");
+		return -EIO;
+	}
+
+	drv_data->magn_scale_x = mpu6050_ak89xx_calc_adj(buffer[0]);
+	drv_data->magn_scale_y = mpu6050_ak89xx_calc_adj(buffer[1]);
+	drv_data->magn_scale_z = mpu6050_ak89xx_calc_adj(buffer[2]);
+
+	LOG_DBG("Adjustment values %d %d %d", drv_data->magn_scale_x,
+		drv_data->magn_scale_y, drv_data->magn_scale_z );
+
+	return 0;
+}
+
+static int mpu6050_ak89xx_reset(struct device *dev)
+{
+	/* Reset the chip -> reset all settings. */
+	if ( mpu6050_ak89xx_write_register( dev,
+			MPU9250_AK89XX_REG_CNTL2,
+			MPU9250_AK89XX_REG_VALUE_CNTL2_RESET, false )  < 0 ) {
+		LOG_ERR("Failed to reset AK89XX.");
+		return -EIO;
+	}
+	return 0;
+}
+
+
+
+static int mpu6050_ak89xx_init_comm(struct device *dev)
+{
+	const struct mpu6050_config *cfg = dev->config->config_info;
+	struct mpu6050_data *drv_data = dev->driver_data;
+
+	/* Instruct MPU9250 to use its external I2C bus as master */
+	if (i2c_reg_write_byte(drv_data->i2c, cfg->i2c_addr,
+			       MPU9250_REG_USER_CTRL,
+			       MPU9250_REG_VALUE_USER_CTRL_I2C_MASTERMODE ) < 0 ) {
+		LOG_ERR("Failed to set MPU9250 external i2c mode.");
+		return -EIO;
+	}
+	/* Set MPU9250 external I2C bus at 400khz and wait for result before
+	 * issuing possible data ready interupt.
+	 */
+	if (i2c_reg_write_byte(drv_data->i2c, cfg->i2c_addr,
+			       MPU9250_REG_I2C_MST_CTRL,
+			       MPU9250_REG_VALUE_I2C_MST_CTRL_WAIT_MAG_400KHZ ) < 0 ) {
+		LOG_ERR("Failed to set MPU9250 external i2c speed.");
+		return -EIO;
+	}
+
+	if (mpu6050_ak89xx_change_mode( dev,
+			MPU9250_AK89XX_REG_VALUE_CNTL1_POWERDOWN ) < 0) {
+		LOG_ERR("Failed to set chip in power down mode.");
+		return -EIO;
+	}
+
+	return 0;
+}
+int mpu6050_ak89xx_init(struct device *dev)
+{
+
+	/* We could also set MPU9250 I2C to pass-thourgh mode for directly to chat with AK, but
+	 * here we are using the MPU9250 registers to communicate with the AK, since that allows
+	 * this driver later to be more easily to be ported for SPI access (that dont have
+	 * possibility to talk I2C directly to the AK
+	 */
+	u8_t buffer[7];
+
+	if ( mpu6050_ak89xx_init_comm(dev) <0) {
+		return -EIO;
+	}
+
+	if ( mpu6050_ak89xx_reset(dev) <0 ) {
+		return -EIO;
+	}
+
+	/* First check that the chip says hello */
+	if ( mpu6050_ak89xx_read_register( dev,
+			MPU9250_AK89XX_REG_ID, buffer, 1 ) < 0 ) {
+		LOG_ERR("Failed to read AK89XX chip id.");
+		return -EIO;
+	}
+	if ( buffer[0] != MPU9250_AK89XX_REG_VALUE_ID ) {
+		LOG_ERR("Invalid AK89XX chip id (0x%X).", buffer[0] );
+		return -EIO;
+	}
+
+	/* Fetch calibration data */
+	if ( mpu6050_ak89xx_fetch_adj( dev ) < 0 ) {
+		return -EIO;
+	}
+
+	/* Set AK sample rate and resolution */
+	if ( mpu6050_ak89xx_change_mode( dev,
+			MPU9250_AK89XX_REG_VALUE_CNTL1_16BIT_100HZ ) < 0 ) {
+		LOG_ERR("Failed set sample rate for AK89XX.");
+		return -EIO;
+	}
+
+	/* Fetch a sample from AK89XX. Then the MPU continues to
+	 * make the reads at the sample rate
+	 */
+	if ( mpu6050_ak89xx_read_register( dev,
+		MPU9250_AK89XX_REG_DATA, buffer, 7 ) < 0 ) {
+		LOG_ERR("Failed read sample from AK89XX.");
+		return -EIO;
+	}
+
+	return 0;
+}
+
+

--- a/dts/bindings/sensor/invensense,mpu9250.yaml
+++ b/dts/bindings/sensor/invensense,mpu9250.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 Pauli Salmenrinne
+# SPDX-License-Identifier: Apache-2.0
+
+description: MPU-9250 motion tracking device (I2C only)
+
+
+compatible: "invensense,mpu9250"
+
+include: i2c-device.yaml
+
+properties:
+    int-gpios:
+      type: phandle-array
+      required: false
+      description: |
+        The INT signal default configuration is active-high.  The
+        property value should ensure the flags properly describe the
+        signal that is presented to the driver.


### PR DESCRIPTION
Dear all,

this is initial proof-of-concept commit of MPU9250 driver support based on the existing mpu6050 driver. I have tested it with stm32_min_dev_blue. I say initial proof-of-concept as i have not cleared all formating issues, the content should be (mostly) fine i think.

I think the driver should work with minimal modifications with MPU9255 [1] and possibly with MPU9150 [2] but i do not have those on hand for testing.

I did not rename the driver, since i wanted to keep the changes minimal at this point and i am not sure how the naming should be.

**Questions:**

1) I would like to include the mpu9250 part to the the samples/sensor/mpu6050/ - but it requires different dts-overlay. I could do commented out version of the mpu9250 but thats not very good i am afraid. Another option would be separate sample for mpu9250. Or no sample at all. What do you think?

2) Naming of the driver (see below for other models) - Current "mpu9250 mode" for mpu6050 is probably not good, would mpuxx50 be better/ok ? The mpu9255 does not fit that scheme but mpuxxxx sounds fishy.. 

 
[1] Arduino library claims with similar code have support for 9255: https://github.com/bolderflight/MPU9250
[2] This source claims that the access on the MPU9150 should be similar to MPU9250: https://sureshjoshi.com/embedded/invensense-imus-what-to-know/



