### PR TITLE
kernel: use designated initializers consistently

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4948,7 +4948,7 @@ struct k_poll_event {
 	.state = K_POLL_STATE_NOT_READY, \
 	.mode = event_mode, \
 	.unused = 0, \
-	{ .obj = event_obj }, \
+	.obj = event_obj, \
 	}
 
 #define K_POLL_EVENT_STATIC_INITIALIZER(event_type, event_mode, event_obj, \
@@ -4959,7 +4959,7 @@ struct k_poll_event {
 	.state = K_POLL_STATE_NOT_READY, \
 	.mode = event_mode, \
 	.unused = 0, \
-	{ .obj = event_obj }, \
+	.obj = event_obj, \
 	}
 
 /**


### PR DESCRIPTION
Use of the K_POLL_EVENT initializers in C++20 code causes a diagnostic
since C++ requires consistent use of designated initializers.  As the
initialized object is an anonymous union there is no member name to
use, but neither is one required.  Initialize the member without
wrapping it in braces as with an initializer list.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>