### PR TITLE
doc: kernel: Add sys_sem APIs to kernel documentation

### DIFF
--- a/doc/reference/kernel/synchronization/semaphores.rst
+++ b/doc/reference/kernel/synchronization/semaphores.rst
@@ -130,3 +130,13 @@ API Reference
 
 .. doxygengroup:: semaphore_apis
    :project: Zephyr
+
+User Mode Semaphore API Reference
+*********************************
+
+The sys_sem exists in user memory working as counter semaphore for user mode
+thread when user mode enabled. When user mode isn't enabled, sys_sem behaves
+like k_sem.
+
+.. doxygengroup:: user_semaphore_apis
+   :project: Zephyr

--- a/include/sys/sem.h
+++ b/include/sys/sem.h
@@ -40,6 +40,12 @@ struct sys_sem {
 };
 
 /**
+ * @defgroup user_semaphore_apis User mode semaphore APIs
+ * @ingroup kernel_apis
+ * @{
+ */
+
+/**
  * @brief Statically define and initialize a sys_sem
  *
  * The semaphore can be accessed outside the module where it is defined using:
@@ -130,6 +136,10 @@ int sys_sem_take(struct sys_sem *sem, k_timeout_t timeout);
  * @return Current value of sys_sem.
  */
 unsigned int sys_sem_count_get(struct sys_sem *sem);
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The kernel documentation was missing sys_sem APIs.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>