### PR TITLE
KW41 PWM Support

### DIFF
--- a/boards/arm/frdm_kw41z/Kconfig.defconfig
+++ b/boards/arm/frdm_kw41z/Kconfig.defconfig
@@ -24,6 +24,7 @@ config PINMUX_MCUX_PORTA
 
 config PINMUX_MCUX_PORTB
 	default y if "$(dt_nodelabel_enabled,adc0)"
+	default y if "$(dt_nodelabel_enabled,tpm1)"
 
 config PINMUX_MCUX_PORTC
 	default y

--- a/boards/arm/frdm_kw41z/doc/index.rst
+++ b/boards/arm/frdm_kw41z/doc/index.rst
@@ -82,6 +82,8 @@ The frdm_kw41z board configuration supports the following hardware features:
 | SENSOR    | off-chip   | fxos8700 polling:                   |
 |           |            | fxos8700 trigger                    |
 +-----------+------------+-------------------------------------+
+| PWM       | on-chip    | tpm                                 |
++--------------------------------------------------------------+
 
 The default configuration can be found in the defconfig file:
 

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -14,6 +14,12 @@
 		led2 = &red_led;
 		sw0 = &user_button_3;
 		sw1 = &user_button_4;
+		pwm-led0 = &blue_pwm_led;
+		pwm-led1 = &green_pwm_led;
+		pwm-led2 = &red_pwm_led;
+		blue-pwm-led = &blue_pwm_led;
+		green-pwm-led = &green_pwm_led;
+		red-pwm-led = &red_pwm_led;
 	};
 
 	chosen {
@@ -36,6 +42,22 @@
 		blue_led: led_2 {
 			gpios = <&gpioa 18 GPIO_ACTIVE_LOW>;
 			label = "User LD3";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		blue_pwm_led: pwm_led_0 {
+			pwms = <&tpm2 0 0 0>;
+			label = "User PWM LD1";
+		};
+		green_pwm_led: pwm_led_1 {
+			pwms = <&tpm2 1 0 0>;
+			label = "User PWM LD2";
+		};
+		red_pwm_led: pwm_led_2 {
+			pwms = <&tpm0 2 0 0>;
+			label = "User PWM LD3";
 		};
 	};
 
@@ -105,5 +127,17 @@
 };
 
 &gpioc {
+	status = "okay";
+};
+
+&tpm0 {
+	status = "okay";
+};
+
+&tpm1 {
+	status = "disabled";
+};
+
+&tpm2 {
 	status = "okay";
 };

--- a/boards/arm/frdm_kw41z/frdm_kw41z.yaml
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.yaml
@@ -14,3 +14,4 @@ supported:
   - i2c
   - ieee802154
   - spi
+  - pwm

--- a/boards/arm/frdm_kw41z/pinmux.c
+++ b/boards/arm/frdm_kw41z/pinmux.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NXP
+ * Copyright 2017, 2020 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -28,9 +28,15 @@ static int frdm_kw41z_pinmux_init(struct device *dev)
 	/* Red, green, blue LEDs. Note the red LED and accel INT1 are both
 	 * wired to PTC1.
 	 */
+#if defined(CONFIG_PWM) && DT_HAS_NODE(DT_NODELABEL(pwm0))
+	pinmux_pin_set(portc,  1, PORT_PCR_MUX(kPORT_MuxAlt5));
+	pinmux_pin_set(porta, 19, PORT_PCR_MUX(kPORT_MuxAlt5));
+	pinmux_pin_set(porta, 18, PORT_PCR_MUX(kPORT_MuxAlt5));
+#else
 	pinmux_pin_set(portc,  1, PORT_PCR_MUX(kPORT_MuxAsGpio));
 	pinmux_pin_set(porta, 19, PORT_PCR_MUX(kPORT_MuxAsGpio));
 	pinmux_pin_set(porta, 18, PORT_PCR_MUX(kPORT_MuxAsGpio));
+#endif
 
 #if DT_HAS_NODE(DT_NODELABEL(i2c1))
 	/* I2C1 SCL, SDA */
@@ -61,6 +67,16 @@ static int frdm_kw41z_pinmux_init(struct device *dev)
 	pinmux_pin_set(portc, 17, PORT_PCR_MUX(kPORT_MuxAlt2));
 	pinmux_pin_set(portc, 18, PORT_PCR_MUX(kPORT_MuxAlt2));
 	pinmux_pin_set(portc, 19, PORT_PCR_MUX(kPORT_MuxAlt2));
+#endif
+
+#if defined(CONFIG_PWM) && DT_HAS_NODE(DT_NODELABEL(pwm1))
+	pinmux_pin_set(porta,  0, PORT_PCR_MUX(kPORT_MuxAlt4));
+	pinmux_pin_set(porta,  1, PORT_PCR_MUX(kPORT_MuxAlt4));
+#endif
+
+#if defined(CONFIG_PWM) && DT_HAS_NODE(DT_NODELABEL(pwm2))
+	pinmux_pin_set(portb, 16, PORT_PCR_MUX(kPORT_MuxAlt4));
+	pinmux_pin_set(portb, 17, PORT_PCR_MUX(kPORT_MuxAlt4));
 #endif
 
 	return 0;

--- a/drivers/pwm/CMakeLists.txt
+++ b/drivers/pwm/CMakeLists.txt
@@ -16,6 +16,7 @@ zephyr_library_sources_ifdef(CONFIG_PWM_MCUX		pwm_mcux.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_XEC		pwm_mchp_xec.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_LITEX		pwm_litex.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_RV32M1_TPM	pwm_rv32m1_tpm.c)
+zephyr_library_sources_ifdef(CONFIG_PWM_MCUX_TPM	pwm_mcux_tpm.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE   pwm_handlers.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_SHELL   pwm_shell.c)

--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -63,4 +63,6 @@ source "drivers/pwm/Kconfig.litex"
 
 source "drivers/pwm/Kconfig.rv32m1_tpm"
 
+source "drivers/pwm/Kconfig.mcux_tpm"
+
 endif # PWM

--- a/drivers/pwm/Kconfig.mcux_tpm
+++ b/drivers/pwm/Kconfig.mcux_tpm
@@ -1,0 +1,10 @@
+# Copyright 2020 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# MCUX TPM PWM
+
+config PWM_MCUX_TPM
+	bool "MCUX TPM PWM driver"
+	depends on HAS_MCUX_TPM && CLOCK_CONTROL
+	help
+	  Enable the MCUX TPM PWM driver.

--- a/drivers/pwm/pwm_mcux_tpm.c
+++ b/drivers/pwm/pwm_mcux_tpm.c
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2019 Henrik Brix Andersen <henrik@brixandersen.dk>
+ * Copyright 2020 NXP
+ *
+ * Heavily based on pwm_mcux_ftm.c, which is:
+ * Copyright (c) 2017, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_kinetis_tpm
+
+#include <drivers/clock_control.h>
+#include <errno.h>
+#include <drivers/pwm.h>
+#include <soc.h>
+#include <fsl_tpm.h>
+#include <fsl_clock.h>
+
+#define LOG_LEVEL CONFIG_PWM_LOG_LEVEL
+#include <logging/log.h>
+LOG_MODULE_REGISTER(pwm_mcux_tpm);
+
+#define MAX_CHANNELS ARRAY_SIZE(TPM0->CONTROLS)
+
+struct mcux_tpm_config {
+	TPM_Type *base;
+	char *clock_name;
+	clock_control_subsys_t clock_subsys;
+	tpm_clock_source_t tpm_clock_source;
+	tpm_clock_prescale_t prescale;
+	u8_t channel_count;
+	tpm_pwm_mode_t mode;
+};
+
+struct mcux_tpm_data {
+	u32_t clock_freq;
+	u32_t period_cycles;
+	tpm_chnl_pwm_signal_param_t channel[MAX_CHANNELS];
+};
+
+static int mcux_tpm_pin_set(struct device *dev, u32_t pwm,
+			      u32_t period_cycles, u32_t pulse_cycles,
+			      pwm_flags_t flags)
+{
+	const struct mcux_tpm_config *config = dev->config->config_info;
+	struct mcux_tpm_data *data = dev->driver_data;
+	u8_t duty_cycle;
+
+	if ((period_cycles == 0U) || (pulse_cycles > period_cycles)) {
+		LOG_ERR("Invalid combination: period_cycles=%d, "
+			    "pulse_cycles=%d", period_cycles, pulse_cycles);
+		return -EINVAL;
+	}
+
+	if (pwm >= config->channel_count) {
+		LOG_ERR("Invalid channel");
+		return -ENOTSUP;
+	}
+
+	duty_cycle = pulse_cycles * 100U / period_cycles;
+	data->channel[pwm].dutyCyclePercent = duty_cycle;
+
+	if ((flags & PWM_POLARITY_INVERTED) == 0) {
+		data->channel[pwm].level = kTPM_HighTrue;
+	} else {
+		data->channel[pwm].level = kTPM_LowTrue;
+	}
+
+	LOG_DBG("pulse_cycles=%d, period_cycles=%d, duty_cycle=%d, flags=%d",
+		pulse_cycles, period_cycles, duty_cycle, flags);
+
+	if (period_cycles != data->period_cycles) {
+		u32_t pwm_freq;
+		status_t status;
+
+		if (data->period_cycles != 0) {
+			/* Only warn when not changing from zero */
+			LOG_WRN("Changing period cycles from %d to %d"
+				" affects all %d channels in %s",
+				data->period_cycles, period_cycles,
+				config->channel_count, dev->config->name);
+		}
+
+		data->period_cycles = period_cycles;
+
+		pwm_freq = (data->clock_freq >> config->prescale) /
+			   period_cycles;
+
+		LOG_DBG("pwm_freq=%d, clock_freq=%d", pwm_freq,
+			data->clock_freq);
+
+		if (pwm_freq == 0U) {
+			LOG_ERR("Could not set up pwm_freq=%d", pwm_freq);
+			return -EINVAL;
+		}
+
+		TPM_StopTimer(config->base);
+
+		status = TPM_SetupPwm(config->base, data->channel,
+				      config->channel_count, config->mode,
+				      pwm_freq, data->clock_freq);
+
+		if (status != kStatus_Success) {
+			LOG_ERR("Could not set up pwm");
+			return -ENOTSUP;
+		}
+		TPM_StartTimer(config->base, config->tpm_clock_source);
+	} else {
+		TPM_UpdateChnlEdgeLevelSelect(config->base, pwm,
+					      data->channel[pwm].level);
+		TPM_UpdatePwmDutycycle(config->base, pwm, config->mode,
+				       duty_cycle);
+	}
+
+	return 0;
+}
+
+static int mcux_tpm_get_cycles_per_sec(struct device *dev, u32_t pwm,
+					 u64_t *cycles)
+{
+	const struct mcux_tpm_config *config = dev->config->config_info;
+	struct mcux_tpm_data *data = dev->driver_data;
+
+	*cycles = data->clock_freq >> config->prescale;
+
+	return 0;
+}
+
+static int mcux_tpm_init(struct device *dev)
+{
+	const struct mcux_tpm_config *config = dev->config->config_info;
+	struct mcux_tpm_data *data = dev->driver_data;
+	tpm_chnl_pwm_signal_param_t *channel = data->channel;
+	struct device *clock_dev;
+	tpm_config_t tpm_config;
+	int i;
+
+	if (config->channel_count > ARRAY_SIZE(data->channel)) {
+		LOG_ERR("Invalid channel count");
+		return -EINVAL;
+	}
+
+	clock_dev = device_get_binding(config->clock_name);
+	if (clock_dev == NULL) {
+		LOG_ERR("Could not get clock device");
+		return -EINVAL;
+	}
+
+	if (clock_control_on(clock_dev, config->clock_subsys)) {
+		LOG_ERR("Could not turn on clock");
+		return -EINVAL;
+	}
+
+	if (clock_control_get_rate(clock_dev, config->clock_subsys,
+				   &data->clock_freq)) {
+		LOG_ERR("Could not get clock frequency");
+		return -EINVAL;
+	}
+
+	for (i = 0; i < config->channel_count; i++) {
+		channel->chnlNumber = i;
+		channel->level = kTPM_NoPwmSignal;
+		channel->dutyCyclePercent = 0;
+		channel->firstEdgeDelayPercent = 0;
+		channel++;
+	}
+
+	TPM_GetDefaultConfig(&tpm_config);
+	tpm_config.prescale = config->prescale;
+
+	TPM_Init(config->base, &tpm_config);
+
+	return 0;
+}
+
+static const struct pwm_driver_api mcux_tpm_driver_api = {
+	.pin_set = mcux_tpm_pin_set,
+	.get_cycles_per_sec = mcux_tpm_get_cycles_per_sec,
+};
+
+#define TPM_DEVICE(n) \
+	static const struct mcux_tpm_config mcux_tpm_config_##n = { \
+		.base =	(TPM_Type *) \
+			DT_INST_REG_ADDR(n), \
+		.clock_name = \
+			DT_INST_CLOCKS_LABEL(n), \
+		.clock_subsys = (clock_control_subsys_t) \
+			DT_INST_CLOCKS_CELL(n, name), \
+		.tpm_clock_source = kTPM_SystemClock, \
+		.prescale = kTPM_Prescale_Divide_16, \
+		.channel_count = FSL_FEATURE_TPM_CHANNEL_COUNTn((TPM_Type *) \
+			DT_INST_REG_ADDR(n)), \
+		.mode = kTPM_EdgeAlignedPwm, \
+	}; \
+	static struct mcux_tpm_data mcux_tpm_data_##n; \
+	DEVICE_AND_API_INIT(mcux_tpm_##n, \
+			    DT_INST_LABEL(n), \
+			    &mcux_tpm_init, &mcux_tpm_data_##n, \
+			    &mcux_tpm_config_##n, \
+			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+			    &mcux_tpm_driver_api)
+
+DT_INST_FOREACH(TPM_DEVICE)

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -1,7 +1,12 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright 2020 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <arm/armv6-m.dtsi>
 #include <dt-bindings/clock/kinetis_sim.h>
+#include <dt-bindings/clock/kinetis_mcg.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
 
@@ -46,6 +51,8 @@
 		mcg: clock-controller@40064000 {
 			compatible = "nxp,kw41z-mcg";
 			reg = <0x40064000 0x13>;
+			label = "MCG";
+			#clock-cells = <1>;
 		};
 
 		osc: clock-controller@40065000 {
@@ -196,27 +203,36 @@
 		};
 
 		tpm0: pwm@40038000 {
-			compatible = "nxp,kw41z-pwm";
+			compatible = "nxp,kinetis-tpm";
 			reg = <0x40038000 0x88>;
-			prescaler = <2>;
-			period = <1000>;
+			interrupts = <0x84 0>;
 			/* channel information needed - fixme */
+			label = "PWM_0";
+			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 24>;
+			status = "disabled";
+			#pwm-cells = <3>;
 		};
 
 		tpm1: pwm@40039000 {
-			compatible = "nxp,kw41z-pwm";
+			compatible = "nxp,kinetis-tpm";
 			reg = <0x40039000 0x88>;
-			prescaler = <2>;
-			period = <1000>;
+			interrupts = <0x88 0>;
 			/* channel information needed - fixme */
+			label = "PWM_1";
+			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 25>;
+			status = "disabled";
+			#pwm-cells = <3>;
 		};
 
 		tpm2: pwm@4003a000 {
-			compatible = "nxp,kw41z-pwm";
+			compatible = "nxp,kinetis-tpm";
 			reg = <0x4003a000 0x88>;
-			prescaler = <2>;
-			period = <1000>;
+			interrupts = <0x8C 0>;
 			/* channel information needed - fixme */
+			label = "PWM_2";
+			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 26>;
+			status = "disabled";
+			#pwm-cells = <3>;
 		};
 
 		adc0: adc@4003b000{

--- a/dts/bindings/pwm/nxp,kinetis-tpm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-tpm.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2019 Henrik Brix Andersen <henrik@brixandersen.dk>
+# SPDX-License-Identifier: Apache-2.0
+
+description: MCUX Timer/PWM Module (TPM)
+
+compatible: "nxp,kinetis-tpm"
+
+include: [pwm-controller.yaml, base.yaml]
+
+properties:
+    reg:
+      required: true
+
+    interrupts:
+      required: true
+
+    "#pwm-cells":
+      const: 3
+
+pwm-cells:
+  - channel
+# period in terms of nanoseconds
+  - period
+  - flags

--- a/modules/Kconfig.mcux
+++ b/modules/Kconfig.mcux
@@ -182,4 +182,10 @@ config HAS_MCUX_DAC32
 	bool
 	help
 	  Set if the Digital-to-Analog (DAC32) module is present in the SoC.
+
+config HAS_MCUX_TPM
+	bool
+	help
+	  Set if the Timer/PWM Module is present in the SoC
+
 endif # HAS_MCUX

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
@@ -51,6 +51,10 @@ config SOC_FLASH_MCUX
 	default y
 	depends on FLASH
 
+config PWM_MCUX_TPM
+	default y
+	depends on PWM
+
 if NETWORKING
 
 config NET_L2_IEEE802154

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.soc
@@ -53,6 +53,7 @@ config SOC_MKW41Z4
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_RTC
 	select HAS_MCUX_SIM
+	select HAS_MCUX_TPM
 	select HAS_MCUX_TRNG
 	select HAS_OSC
 	select HAS_MCG

--- a/soc/arm/nxp_kinetis/kwx/soc_kw4xz.c
+++ b/soc/arm/nxp_kinetis/kwx/soc_kw4xz.c
@@ -18,6 +18,7 @@
 #define ER32KSEL_LPO1KHZ	(3)
 
 #define LPUART0SRC_OSCERCLK	(1)
+#define TPMSRC_MCGPLLCLK	(1)
 
 #define CLKDIV1_DIVBY2		(1)
 
@@ -68,6 +69,13 @@ static ALWAYS_INLINE void clock_init(void)
 
 #if DT_HAS_NODE(DT_NODELABEL(lpuart0))
 	CLOCK_SetLpuartClock(LPUART0SRC_OSCERCLK);
+#endif
+
+#if defined(CONFIG_PWM) && \
+	(DT_HAS_NODE(DT_NODELABEL(pwm0)) || \
+	 DT_HAS_NODE(DT_NODELABEL(pwm1)) || \
+	 DT_HAS_NODE(DT_NODELABEL(pwm2)))
+	CLOCK_SetTpmClock(TPMSRC_MCGPLLCLK);
 #endif
 }
 

--- a/west.yml
+++ b/west.yml
@@ -92,7 +92,7 @@ manifest:
       revision: 1c4fdba512b268033a4cf926bddd323866c3261a
       path: tools/net-tools
     - name: hal_nxp
-      revision: a75db450ff25edb854648fce7aebbd52707585e1
+      revision: 39615db4095858d24d87dfd6d8e0970704aae18a
       path: modules/hal/nxp
     - name: open-amp
       revision: 5720c73ef3bd885824b2d2184f606443e03f73c4


### PR DESCRIPTION
This patch-set adds support for the TPM driver for KW4x family of SoCs. The TPM driver is based on the RV32M1 TPM driver, and the corresponding SDK driver.
This patch-set depends on https://github.com/zephyrproject-rtos/hal_nxp/pull/39