### PR TITLE
editorconfig: add dts/dtsi rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -60,3 +60,8 @@ indent_size = 2
 # Makefile
 [Makefile]
 indent_style = tab
+
+# Device tree
+[*.{dts,dtsi,overlay}]
+indent_style = tab
+indent_size = 8


### PR DESCRIPTION
Rules follow linux coding standard, i.e using tab and tab size 8

Signed-off-by: Mikkel Jakobsen <mikkel.aunsbjerg@prevas.dk>