### PR TITLE
Rename "PORT" definitions in the net tests and samples

### DIFF
--- a/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
+++ b/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
@@ -24,7 +24,7 @@
 
 #endif
 
-#define PORT 8080
+#define BIND_PORT 8080
 
 #ifndef USE_BIG_PAYLOAD
 #define USE_BIG_PAYLOAD 1
@@ -52,12 +52,13 @@ void main(void)
 
 	bind_addr.sin_family = AF_INET;
 	bind_addr.sin_addr.s_addr = htonl(INADDR_ANY);
-	bind_addr.sin_port = htons(PORT);
+	bind_addr.sin_port = htons(BIND_PORT);
 	CHECK(bind(serv, (struct sockaddr *)&bind_addr, sizeof(bind_addr)));
 
 	CHECK(listen(serv, 5));
 
-	printf("Single-threaded dumb HTTP server waits for a connection on port %d...\n", PORT);
+	printf("Single-threaded dumb HTTP server waits for a connection on "
+	       "port %d...\n", BIND_PORT);
 
 	while (1) {
 		struct sockaddr_in client_addr;

--- a/samples/net/sockets/echo/src/socket_echo.c
+++ b/samples/net/sockets/echo/src/socket_echo.c
@@ -22,7 +22,7 @@
 
 #endif
 
-#define PORT 4242
+#define BIND_PORT 4242
 
 void main(void)
 {
@@ -39,7 +39,7 @@ void main(void)
 
 	bind_addr.sin_family = AF_INET;
 	bind_addr.sin_addr.s_addr = htonl(INADDR_ANY);
-	bind_addr.sin_port = htons(PORT);
+	bind_addr.sin_port = htons(BIND_PORT);
 
 	if (bind(serv, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) < 0) {
 		printf("error: bind: %d\n", errno);
@@ -51,7 +51,8 @@ void main(void)
 		exit(1);
 	}
 
-	printf("Single-threaded TCP echo server waits for a connection on port %d...\n", PORT);
+	printf("Single-threaded TCP echo server waits for a connection on "
+	       "port %d...\n", BIND_PORT);
 
 	while (1) {
 		struct sockaddr_in client_addr;

--- a/samples/net/sockets/echo_async/src/socket_echo.c
+++ b/samples/net/sockets/echo_async/src/socket_echo.c
@@ -39,7 +39,7 @@
 #define NUM_FDS 5
 #endif
 
-#define PORT 4242
+#define BIND_PORT 4242
 
 /* Number of simultaneous client connections will be NUM_FDS be minus 2 */
 struct pollfd pollfds[NUM_FDS];
@@ -112,7 +112,7 @@ void main(void)
 	int serv4;
 	struct sockaddr_in bind_addr4 = {
 		.sin_family = AF_INET,
-		.sin_port = htons(PORT),
+		.sin_port = htons(BIND_PORT),
 		.sin_addr = {
 			.s_addr = htonl(INADDR_ANY),
 		},
@@ -121,7 +121,7 @@ void main(void)
 	int serv6;
 	struct sockaddr_in6 bind_addr6 = {
 		.sin6_family = AF_INET6,
-		.sin6_port = htons(PORT),
+		.sin6_port = htons(BIND_PORT),
 		.sin6_addr = IN6ADDR_ANY_INIT,
 	};
 #endif
@@ -170,7 +170,8 @@ void main(void)
 	pollfds_add(serv6);
 #endif
 
-	printf("Asynchronous TCP echo server waits for connections on port %d...\n", PORT);
+	printf("Asynchronous TCP echo server waits for connections on "
+	       "port %d...\n", BIND_PORT);
 
 	while (1) {
 		struct sockaddr_storage client_addr;

--- a/samples/net/sockets/echo_async_select/src/socket_echo_select.c
+++ b/samples/net/sockets/echo_async_select/src/socket_echo_select.c
@@ -33,7 +33,7 @@
 #define NUM_FDS 5
 #endif
 
-#define PORT 4242
+#define BIND_PORT 4242
 
 /* Number of simultaneous client connections will be NUM_FDS be minus 2 */
 fd_set readfds;
@@ -90,14 +90,14 @@ void main(void)
 	int serv4, serv6;
 	struct sockaddr_in bind_addr4 = {
 		.sin_family = AF_INET,
-		.sin_port = htons(PORT),
+		.sin_port = htons(BIND_PORT),
 		.sin_addr = {
 			.s_addr = htonl(INADDR_ANY),
 		},
 	};
 	struct sockaddr_in6 bind_addr6 = {
 		.sin6_family = AF_INET6,
-		.sin6_port = htons(PORT),
+		.sin6_port = htons(BIND_PORT),
 		.sin6_addr = IN6ADDR_ANY_INIT,
 	};
 
@@ -143,7 +143,8 @@ void main(void)
 	pollfds_add(serv4);
 	pollfds_add(serv6);
 
-	printf("Async select-based TCP echo server waits for connections on port %d...\n", PORT);
+	printf("Async select-based TCP echo server waits for connections on "
+	       "port %d...\n", BIND_PORT);
 
 	while (1) {
 		struct sockaddr_storage client_addr;

--- a/samples/net/sockets/websocket_client/src/main.c
+++ b/samples/net/sockets/websocket_client/src/main.c
@@ -15,7 +15,7 @@ LOG_MODULE_REGISTER(net_websocket_client_sample, LOG_LEVEL_DBG);
 
 #include "ca_certificate.h"
 
-#define PORT 9001
+#define SERVER_PORT 9001
 
 #if defined(CONFIG_NET_CONFIG_PEER_IPV6_ADDR)
 #define SERVER_ADDR6  CONFIG_NET_CONFIG_PEER_IPV6_ADDR
@@ -345,13 +345,13 @@ void main(void)
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4)) {
-		(void)connect_socket(AF_INET, SERVER_ADDR4, PORT,
+		(void)connect_socket(AF_INET, SERVER_ADDR4, SERVER_PORT,
 				     &sock4, (struct sockaddr *)&addr4,
 				     sizeof(addr4));
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV6)) {
-		(void)connect_socket(AF_INET6, SERVER_ADDR6, PORT,
+		(void)connect_socket(AF_INET6, SERVER_ADDR6, SERVER_PORT,
 				     &sock6, (struct sockaddr *)&addr6,
 				     sizeof(addr6));
 	}
@@ -375,7 +375,8 @@ void main(void)
 
 		websock4 = websocket_connect(sock4, &req, timeout, "IPv4");
 		if (websock4 < 0) {
-			LOG_ERR("Cannot connect to %s:%d", SERVER_ADDR4, PORT);
+			LOG_ERR("Cannot connect to %s:%d", SERVER_ADDR4,
+				SERVER_PORT);
 			close(sock4);
 		}
 	}
@@ -395,7 +396,7 @@ void main(void)
 		websock6 = websocket_connect(sock6, &req, timeout, "IPv6");
 		if (websock6 < 0) {
 			LOG_ERR("Cannot connect to [%s]:%d", SERVER_ADDR6,
-				PORT);
+				SERVER_PORT);
 			close(sock6);
 		}
 	}

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -39,7 +39,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #define DBG(fmt, ...)
 #endif
 
-#define PORT 9999
+#define TEST_PORT 9999
 
 static char *test_data = "Test data to be sent";
 
@@ -465,7 +465,7 @@ static void tx_chksum_offload_disabled_test_v6(void)
 	int ret, len;
 	struct sockaddr_in6 dst_addr6 = {
 		.sin6_family = AF_INET6,
-		.sin6_port = htons(PORT),
+		.sin6_port = htons(TEST_PORT),
 	};
 	struct sockaddr_in6 src_addr6 = {
 		.sin6_family = AF_INET6,
@@ -516,7 +516,7 @@ static void tx_chksum_offload_disabled_test_v4(void)
 	int ret, len;
 	struct sockaddr_in dst_addr4 = {
 		.sin_family = AF_INET,
-		.sin_port = htons(PORT),
+		.sin_port = htons(TEST_PORT),
 	};
 	struct sockaddr_in src_addr4 = {
 		.sin_family = AF_INET,
@@ -567,7 +567,7 @@ static void tx_chksum_offload_enabled_test_v6(void)
 	int ret, len;
 	struct sockaddr_in6 dst_addr6 = {
 		.sin6_family = AF_INET6,
-		.sin6_port = htons(PORT),
+		.sin6_port = htons(TEST_PORT),
 	};
 	struct sockaddr_in6 src_addr6 = {
 		.sin6_family = AF_INET6,
@@ -618,7 +618,7 @@ static void tx_chksum_offload_enabled_test_v4(void)
 	int ret, len;
 	struct sockaddr_in dst_addr4 = {
 		.sin_family = AF_INET,
-		.sin_port = htons(PORT),
+		.sin_port = htons(TEST_PORT),
 	};
 	struct sockaddr_in src_addr4 = {
 		.sin_family = AF_INET,
@@ -712,7 +712,7 @@ static void rx_chksum_offload_disabled_test_v6(void)
 	int ret, len;
 	struct sockaddr_in6 dst_addr6 = {
 		.sin6_family = AF_INET6,
-		.sin6_port = htons(PORT),
+		.sin6_port = htons(TEST_PORT),
 	};
 	struct sockaddr_in6 src_addr6 = {
 		.sin6_family = AF_INET6,
@@ -768,7 +768,7 @@ static void rx_chksum_offload_disabled_test_v4(void)
 	int ret, len;
 	struct sockaddr_in dst_addr4 = {
 		.sin_family = AF_INET,
-		.sin_port = htons(PORT),
+		.sin_port = htons(TEST_PORT),
 	};
 	struct sockaddr_in src_addr4 = {
 		.sin_family = AF_INET,
@@ -824,7 +824,7 @@ static void rx_chksum_offload_enabled_test_v6(void)
 	int ret, len;
 	struct sockaddr_in6 dst_addr6 = {
 		.sin6_family = AF_INET6,
-		.sin6_port = htons(PORT),
+		.sin6_port = htons(TEST_PORT),
 	};
 	struct sockaddr_in6 src_addr6 = {
 		.sin6_family = AF_INET6,
@@ -878,7 +878,7 @@ static void rx_chksum_offload_enabled_test_v4(void)
 	int ret, len;
 	struct sockaddr_in dst_addr4 = {
 		.sin_family = AF_INET,
-		.sin_port = htons(PORT),
+		.sin_port = htons(TEST_PORT),
 	};
 	struct sockaddr_in src_addr4 = {
 		.sin_family = AF_INET,

--- a/tests/net/traffic_class/src/main.c
+++ b/tests/net/traffic_class/src/main.c
@@ -52,7 +52,7 @@ static enum net_priority recv_priorities[MAX_TC][MAX_PKT_TO_RECV];
 static enum net_priority tx_tc2prio[NET_TC_TX_COUNT];
 static enum net_priority rx_tc2prio[NET_TC_RX_COUNT];
 
-#define PORT 9999
+#define TEST_PORT 9999
 
 static const char *test_data = "Test data to be sent";
 
@@ -79,7 +79,7 @@ static struct in6_addr ll_addr = { { { 0xfe, 0x80, 0x43, 0xb8, 0, 0, 0, 0,
 
 static struct sockaddr_in6 dst_addr6 = {
 	.sin6_family = AF_INET6,
-	.sin6_port = htons(PORT),
+	.sin6_port = htons(TEST_PORT),
 };
 
 static struct {

--- a/tests/net/tx_timestamp/src/main.c
+++ b/tests/net/tx_timestamp/src/main.c
@@ -39,7 +39,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #define DBG(fmt, ...)
 #endif
 
-#define PORT 9999
+#define TEST_PORT 9999
 
 static char *test_data = "Test data to be sent";
 
@@ -428,7 +428,7 @@ static void send_some_data(struct net_if *iface)
 {
 	struct sockaddr_in6 dst_addr6 = {
 		.sin6_family = AF_INET6,
-		.sin6_port = htons(PORT),
+		.sin6_port = htons(TEST_PORT),
 	};
 	struct sockaddr_in6 src_addr6 = {
 		.sin6_family = AF_INET6,

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -39,7 +39,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #define DBG(fmt, ...)
 #endif
 
-#define PORT 9999
+#define TEST_PORT 9999
 
 #define VLAN_TAG_1 100
 #define VLAN_TAG_2 200
@@ -719,7 +719,7 @@ static void test_vlan_send_data(void)
 	int ret;
 	struct sockaddr_in6 dst_addr6 = {
 		.sin6_family = AF_INET6,
-		.sin6_port = htons(PORT),
+		.sin6_port = htons(TEST_PORT),
 	};
 	struct sockaddr_in6 src_addr6 = {
 		.sin6_family = AF_INET6,


### PR DESCRIPTION
This PR renames all local definitions with the name `PORT` in the net tests and samples, in order to prevent name conflict with certain HALs (notably, Atmel SAM E5x HAL).

An example of such a name conflict:
https://github.com/zephyrproject-rtos/hal_atmel/blob/1fe96f0a5e1a11d8101b258a3b84d35dc7178401/asf/sam0/include/same54/same54p20a.h#L949