### PR TITLE
dts\arm\st\g4: Fix ADC instances naming

### DIFF
--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -34,23 +34,23 @@
 		/*
 		 * Both adc instances cannot be used in parallel right now.
 		 */
-		adc0: adc@50000000 {
+		adc1: adc@50000000 {
 			compatible = "st,stm32-adc";
 			reg = <0x50000000 0x100>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00002000>;
 			interrupts = <18 0>;
 			status = "disabled";
-			label = "ADC_0";
+			label = "ADC_1";
 			#io-channel-cells = <1>;
 		};
 
-		adc1: adc@50000100 {
+		adc2: adc@50000100 {
 			compatible = "st,stm32-adc";
 			reg = <0x50000100 0x100>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00002000>;
 			interrupts = <18 0>;
 			status = "disabled";
-			label = "ADC_1";
+			label = "ADC_2";
 			#io-channel-cells = <1>;
 		};
 


### PR DESCRIPTION
ADC instances start with ADC_1
Fixes #24718

Signed-off-by: Alexandre Bourdiol <alexandre.bourdiol@st.com>