### PR TITLE
drivers: pwm: Clarify that a period values

### DIFF
--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -59,6 +59,11 @@ __subsystem struct pwm_driver_api {
 
 /**
  * @brief Set the period and pulse width for a single PWM output.
+ * 
+ * Passing 0 to the @param pulse will cause the pin to be driven to a constant
+ * inactive level.
+ * Passing a @param pulse equal @param period will cause the pin to be driven
+ * to a constant active level.
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param pwm PWM pin.


### PR DESCRIPTION
At the moment there is no way to disable a pwm signal.
This PR adds a statement to the period parameter that passing
zero will disable the signal.

At the moment, not all drivers follow this rule. We need to check every driver and implement that behavior.