### PR TITLE
Add Bossac Runner OSX compatibility

### DIFF
--- a/scripts/west_commands/runners/bossac.py
+++ b/scripts/west_commands/runners/bossac.py
@@ -46,19 +46,23 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
                                   port=args.bossac_port, offset=args.offset)
 
     def do_run(self, command, **kwargs):
-        if platform.system() != 'Linux':
-            msg = 'CAUTION: No flash tool for your host system found!'
+        if platform.system() == 'Windows':
+            msg = 'CAUTION: BOSSAC runner not support on Windows!'
             raise NotImplementedError(msg)
 
-        self.require('stty')
         self.require(self.bossac)
-        cmd_stty = ['stty', '-F', self.port, 'raw', 'ispeed', '1200',
-                    'ospeed', '1200', 'cs8', '-cstopb', 'ignpar', 'eol', '255',
-                    'eof', '255']
+
+        if platform.system() == 'Linux':
+            self.require('stty')
+            cmd_stty = ['stty', '-F', self.port, 'raw', 'ispeed', '1200',
+                        'ospeed', '1200', 'cs8', '-cstopb', 'ignpar', 'eol', '255',
+                        'eof', '255']
+            self.check_call(cmd_stty)
+
         cmd_flash = [self.bossac, '-p', self.port, '-R', '-e', '-w', '-v',
                      '-b', self.cfg.bin_file]
+
         if self.offset is not None:
             cmd_flash += ['-o', '%s' % self.offset]
 
-        self.check_call(cmd_stty)
         self.check_call(cmd_flash)


### PR DESCRIPTION
Add the ability to use the bossac runner on osx.
Explicitly mention that tool is not supported on windows in the error that is raised.
Linux systems still use 'stty' for port settings before calling the flash tool. OSX worked without this step.

Tested on OSX Mojave 10.14.6 and an Adafruit trinket M0. Unfortunately I have no access to further OSes or hardware to more widely test this.
