### PR TITLE
scripts: net: Add SOCKS 5 to MQTT TLS sample test

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -89,7 +89,7 @@ manifest:
       revision: 1843fdce2b008b45f9cc8b38dd9a57a575ab50f6
       path: modules/lib/mcumgr
     - name: net-tools
-      revision: 1080094bc246357c6c35e80e8b2d5d0ce7e0d963
+      revision: 1c4fdba512b268033a4cf926bddd323866c3261a
       path: tools/net-tools
     - name: hal_nxp
       revision: 60fe8c0ae6e24d165cf42770b95c7df22b778386


### PR DESCRIPTION
Start SOCKS5 proxy in the net-tools Docker image and run MQTT TLS
tests with SOCKS enabled. Since the MQTT TLS server is already
running as of the previous test, start only the danted daemon.

Rely on mosquitto MQTT port being handled by the Docker image
configuration file instead of specifying it on the command line.

Signed-off-by: Patrik Flykt <patrik.flykt@intel.com>