### PR TITLE
kernel: Revert: "Add static threads to k_thread_foreach functions"

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -55,15 +55,9 @@ void k_thread_foreach(k_thread_user_cb_t user_cb, void *user_data)
 	 * k_thread_abort from user_cb.
 	 */
 	key = k_spin_lock(&z_thread_monitor_lock);
-
-	_FOREACH_STATIC_THREAD(thread_data) {
-		user_cb(thread_data->init_thread, user_data);
-	}
-
 	for (thread = _kernel.threads; thread; thread = thread->next_thread) {
 		user_cb(thread, user_data);
 	}
-
 	k_spin_unlock(&z_thread_monitor_lock, key);
 #endif
 }
@@ -77,19 +71,11 @@ void k_thread_foreach_unlocked(k_thread_user_cb_t user_cb, void *user_data)
 	__ASSERT(user_cb != NULL, "user_cb can not be NULL");
 
 	key = k_spin_lock(&z_thread_monitor_lock);
-
-	_FOREACH_STATIC_THREAD(thread_data) {
-		k_spin_unlock(&z_thread_monitor_lock, key);
-		user_cb(thread_data->init_thread, user_data);
-		key = k_spin_lock(&z_thread_monitor_lock);
-	}
-
 	for (thread = _kernel.threads; thread; thread = thread->next_thread) {
 		k_spin_unlock(&z_thread_monitor_lock, key);
 		user_cb(thread, user_data);
 		key = k_spin_lock(&z_thread_monitor_lock);
 	}
-
 	k_spin_unlock(&z_thread_monitor_lock, key);
 #endif
 }


### PR DESCRIPTION
Revert commit mistakenly iterating over static threads in
k_thread_foreach functions. The static threads where already included
in the for-loop, and is now duplicated.

This reverts commit bd3b4b0caf34a24e4d5b88652cfa18b75d17dcfa.