### PR TITLE
boards: arm: adafruit_feather_m0_basic_proto: Set flash offset

### DIFF
--- a/boards/arm/adafruit_feather_m0_basic_proto/board.cmake
+++ b/boards/arm/adafruit_feather_m0_basic_proto/board.cmake
@@ -2,4 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(bossac "--offset=0x2000")
+
 include(${ZEPHYR_BASE}/boards/common/bossac.board.cmake)


### PR DESCRIPTION
On this board, it is required to flash beyond the locked bootloader.

Signed-off-by: Adam Serbinski <aserbinski@gmail.com>