### PR TITLE
board: iotdk: disable unused peripherals in dts

### DIFF
--- a/dts/arc/arc_iot.dtsi
+++ b/dts/arc/arc_iot.dtsi
@@ -79,6 +79,7 @@
 			interrupts = <87 0>;
 			interrupt-parent = <&intc>;
 
+			status = "disabled";
 		};
 
 		uart2: uart@80014200 {
@@ -89,6 +90,7 @@
 			interrupts = <88 0>;
 			interrupt-parent = <&intc>;
 
+			status = "disabled";
 		};
 
 		uart3: uart@80014300 {
@@ -99,6 +101,7 @@
 			interrupts = <89 0>;
 			interrupt-parent = <&intc>;
 
+			status = "disabled";
 		};
 
 		gpio8b0: gpio@80017800 {
@@ -109,6 +112,8 @@
 
 			gpio-controller;
 			#gpio-cells = <2>;
+
+			status = "disabled";
 		};
 
 		gpio8b1: gpio@80017900 {
@@ -119,6 +124,8 @@
 
 			gpio-controller;
 			#gpio-cells = <2>;
+
+			status = "disabled";
 		};
 
 		gpio8b2: gpio@80017a00 {
@@ -129,6 +136,8 @@
 
 			gpio-controller;
 			#gpio-cells = <2>;
+
+			status = "disabled";
 		};
 
 		gpio8b3: gpio@80017b00 {
@@ -139,6 +148,8 @@
 
 			gpio-controller;
 			#gpio-cells = <2>;
+
+			status = "disabled";
 		};
 
 		gpio4b0: gpio@80017c00 {
@@ -159,6 +170,8 @@
 
 			gpio-controller;
 			#gpio-cells = <2>;
+
+			status = "disabled";
 		};
 
 		gpio4b2: gpio@80017e00 {
@@ -169,6 +182,8 @@
 
 			gpio-controller;
 			#gpio-cells = <2>;
+
+			status = "disabled";
 		};
 
 


### PR DESCRIPTION
By defaut, only one uart is used as console.
Disable unused peripherals in dts to avoid
conflicts (issue #23475), save memory footprint,
and reduce the boot time.

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>

Fixes #23475