### PR TITLE
linker: Clean up section name definitions

### DIFF
--- a/arch/arc/core/vector_table.ld
+++ b/arch/arc/core/vector_table.ld
@@ -8,4 +8,4 @@
 
 KEEP(*(.exc_vector_table))
 KEEP(*(".exc_vector_table.*"))
-KEEP(*(IRQ_VECTOR_TABLE))
+KEEP(*(_IRQ_VECTOR_TABLE_SECTION_NAME))

--- a/arch/arm/core/aarch32/vector_table.ld
+++ b/arch/arm/core/aarch32/vector_table.ld
@@ -8,7 +8,7 @@ _vector_start = .;
 KEEP(*(.exc_vector_table))
 KEEP(*(".exc_vector_table.*"))
 
-KEEP(*(IRQ_VECTOR_TABLE))
+KEEP(*(_IRQ_VECTOR_TABLE_SECTION_NAME))
 
 KEEP(*(.vectors))
 

--- a/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -247,7 +247,7 @@ SECTIONS
 #ifdef CONFIG_HAS_TI_CCFG
     SECTION_PROLOGUE(.ti_ccfg,,)
     {
-    KEEP(*(TI_CCFG))
+    KEEP(*(_TI_CCFG_SECTION_NAME))
     } > FLASH_CCFG
 #endif
 

--- a/include/arch/arm/aarch64/scripts/linker.ld
+++ b/include/arch/arm/aarch64/scripts/linker.ld
@@ -168,7 +168,7 @@ SECTIONS
 
     SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
     {
-        KEEP(*(IRQ_VECTOR_TABLE))
+        KEEP(*(_IRQ_VECTOR_TABLE_SECTION_NAME))
 
         KEEP(*(.openocd_dbg))
         KEEP(*(".openocd_dbg.*"))

--- a/include/linker/common-ram.ld
+++ b/include/linker/common-ram.ld
@@ -14,7 +14,7 @@
 		 * instruction.  See include/sw_isr_table.h.
 		 */
 		. = ALIGN(CONFIG_ARCH_SW_ISR_TABLE_ALIGN);
-		*(SW_ISR_TABLE)
+		*(_SW_ISR_TABLE_SECTION_NAME)
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif
 

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -9,7 +9,7 @@
 		 * instruction.  See include/sw_isr_table.h.
 		 */
 		. = ALIGN(CONFIG_ARCH_SW_ISR_TABLE_ALIGN);
-		*(SW_ISR_TABLE)
+		*(_SW_ISR_TABLE_SECTION_NAME)
 	} GROUP_LINK_IN(ROMABLE_REGION)
 #endif
 #ifdef CONFIG_CPLUSPLUS

--- a/include/linker/section_tags.h
+++ b/include/linker/section_tags.h
@@ -13,23 +13,23 @@
 
 #if !defined(_ASMLANGUAGE)
 
-#define __noinit		__in_section_unique(NOINIT)
-#define __irq_vector_table	Z_GENERIC_SECTION(IRQ_VECTOR_TABLE)
-#define __sw_isr_table		Z_GENERIC_SECTION(SW_ISR_TABLE)
+#define __noinit		__in_section_unique(_NOINIT_SECTION_NAME)
+#define __irq_vector_table	Z_GENERIC_SECTION(_IRQ_VECTOR_TABLE_SECTION_NAME)
+#define __sw_isr_table		Z_GENERIC_SECTION(_SW_ISR_TABLE_SECTION_NAME)
 
 #if defined(CONFIG_ARM)
-#define __kinetis_flash_config_section __in_section_unique(KINETIS_FLASH_CONFIG)
-#define __ti_ccfg_section Z_GENERIC_SECTION(TI_CCFG)
+#define __kinetis_flash_config_section __in_section_unique(_KINETIS_FLASH_CONFIG_SECTION_NAME)
+#define __ti_ccfg_section Z_GENERIC_SECTION(_TI_CCFG_SECTION_NAME)
 #define __ccm_data_section Z_GENERIC_SECTION(_CCM_DATA_SECTION_NAME)
 #define __ccm_bss_section Z_GENERIC_SECTION(_CCM_BSS_SECTION_NAME)
 #define __ccm_noinit_section Z_GENERIC_SECTION(_CCM_NOINIT_SECTION_NAME)
 #define __dtcm_data_section Z_GENERIC_SECTION(_DTCM_DATA_SECTION_NAME)
 #define __dtcm_bss_section Z_GENERIC_SECTION(_DTCM_BSS_SECTION_NAME)
 #define __dtcm_noinit_section Z_GENERIC_SECTION(_DTCM_NOINIT_SECTION_NAME)
-#define __imx_boot_conf_section	Z_GENERIC_SECTION(IMX_BOOT_CONF)
-#define __imx_boot_data_section	Z_GENERIC_SECTION(IMX_BOOT_DATA)
-#define __imx_boot_ivt_section	Z_GENERIC_SECTION(IMX_BOOT_IVT)
-#define __imx_boot_dcd_section	Z_GENERIC_SECTION(IMX_BOOT_DCD)
+#define __imx_boot_conf_section Z_GENERIC_SECTION(_IMX_BOOT_CONF_SECTION_NAME)
+#define __imx_boot_data_section Z_GENERIC_SECTION(_IMX_BOOT_DATA_SECTION_NAME)
+#define __imx_boot_ivt_section Z_GENERIC_SECTION(_IMX_BOOT_IVT_SECTION_NAME)
+#define __imx_boot_dcd_section Z_GENERIC_SECTION(_IMX_BOOT_DCD_SECTION_NAME)
 #endif /* CONFIG_ARM */
 
 #if defined(CONFIG_NOCACHE_MEMORY)

--- a/include/linker/sections.h
+++ b/include/linker/sections.h
@@ -30,6 +30,35 @@
 
 #define _UNDEFINED_SECTION_NAME undefined
 
+/* Interrupts */
+#define _IRQ_VECTOR_TABLE_SECTION_NAME	.gnu.linkonce.irq_vector_table
+#define _SW_ISR_TABLE_SECTION_NAME	.gnu.linkonce.sw_isr_table
+
+/* Architecture-specific sections */
+#if defined(CONFIG_ARM)
+#define _KINETIS_FLASH_CONFIG_SECTION_NAME  kinetis_flash_config
+#define _TI_CCFG_SECTION_NAME	.ti_ccfg
+
+#define _CCM_DATA_SECTION_NAME		.ccm_data
+#define _CCM_BSS_SECTION_NAME		.ccm_bss
+#define _CCM_NOINIT_SECTION_NAME	.ccm_noinit
+
+#define _DTCM_DATA_SECTION_NAME	.dtcm_data
+#define _DTCM_BSS_SECTION_NAME		.dtcm_bss
+#define _DTCM_NOINIT_SECTION_NAME	.dtcm_noinit
+#endif
+
+#define _IMX_BOOT_CONF_SECTION_NAME	.boot_hdr.conf
+#define _IMX_BOOT_DATA_SECTION_NAME	.boot_hdr.data
+#define _IMX_BOOT_IVT_SECTION_NAME	.boot_hdr.ivt
+#define _IMX_BOOT_DCD_SECTION_NAME	.boot_hdr.dcd_data
+
+#ifdef CONFIG_NOCACHE_MEMORY
+#define _NOCACHE_SECTION_NAME nocache
+#endif
+
+/* Short section references for use in ASM files */
+#if defined(_ASMLANGUAGE)
 /* Various text section names */
 #define TEXT text
 #if defined(CONFIG_X86)
@@ -43,33 +72,7 @@
 #define RODATA rodata
 #define DATA data
 #define NOINIT noinit
-
-/* Interrupts */
-#define IRQ_VECTOR_TABLE	.gnu.linkonce.irq_vector_table
-#define SW_ISR_TABLE		.gnu.linkonce.sw_isr_table
-
-/* Architecture-specific sections */
-#if defined(CONFIG_ARM)
-#define KINETIS_FLASH_CONFIG  kinetis_flash_config
-#define TI_CCFG	.ti_ccfg
-
-#define _CCM_DATA_SECTION_NAME		.ccm_data
-#define _CCM_BSS_SECTION_NAME		.ccm_bss
-#define _CCM_NOINIT_SECTION_NAME	.ccm_noinit
-
-#define _DTCM_DATA_SECTION_NAME	.dtcm_data
-#define _DTCM_BSS_SECTION_NAME		.dtcm_bss
-#define _DTCM_NOINIT_SECTION_NAME	.dtcm_noinit
-#endif
-
-#define IMX_BOOT_CONF	.boot_hdr.conf
-#define IMX_BOOT_DATA	.boot_hdr.data
-#define IMX_BOOT_IVT	.boot_hdr.ivt
-#define IMX_BOOT_DCD	.boot_hdr.dcd_data
-
-#ifdef CONFIG_NOCACHE_MEMORY
-#define _NOCACHE_SECTION_NAME nocache
-#endif
+#endif /* _ASMLANGUAGE */
 
 #include <linker/section_tags.h>
 


### PR DESCRIPTION
This commit cleans up the section name definitions in the linker
sections header file (`include/linker/sections.h`) to have the uniform
format of `_(SECTION)_SECTION_NAME`.

In addition, the scope of the short section reference aliases (e.g.
`TEXT, `DATA`, `BSS`) are now limited to the ASM code, as they are
currently used (and intended to be used) only by the ASM code to
specify the target section for functions and variables, and these short
names can cause name conflicts with the symbols used in the C code.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>