### PR TITLE
sanitycheck: Various fixes

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -435,6 +435,8 @@ class BinaryHandler(Handler):
             self.instance.reason = "Valgrind error"
         elif harness.state:
             self.set_state(harness.state, handler_time)
+            if harness.state == "failed":
+                self.instance.reason = "Failed"
         else:
             self.set_state("timeout", handler_time)
             self.instance.reason = "Timeout"

--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -345,6 +345,9 @@ class BinaryHandler(Handler):
         # so we need to use try_kill_process_by_pid.
         self.try_kill_process_by_pid()
         proc.terminate()
+        # sleep for a while before attempting to kill
+        time.sleep(0.5)
+        proc.kill()
         self.terminated = True
 
     def _output_reader(self, proc, harness):

--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -1953,6 +1953,7 @@ class ProjectBuilder(FilterBuilder):
             'handler.log',
             'build.log',
             'device.log',
+            'recording.csv',
             ]
         whitelist = [os.path.join(self.instance.build_dir, file) for file in whitelist]
 


### PR DESCRIPTION
We have many cases where tests are stuck due to processes not being terminated
correctly, those block CI for hours. Calling kill() takes care of that if
terminate() was not successful.

Do not delete recordings when invoking sanitycheck with
--runtime-artifact-cleanup

In some cases we were missing the reason and reporting 'Unknown',
check for failure and set the reason.