### PR TITLE
net: sntp: Namespace private SNTP definitions

### DIFF
--- a/subsys/net/lib/sntp/sntp.c
+++ b/subsys/net/lib/sntp/sntp.c
@@ -24,9 +24,9 @@ static void sntp_pkt_dump(struct sntp_pkt *pkt)
 		return;
 	}
 
-	NET_DBG("li               %x", LVM_GET_LI(pkt->lvm));
-	NET_DBG("vn               %x", LVM_GET_VN(pkt->lvm));
-	NET_DBG("mode             %x", LVM_GET_MODE(pkt->lvm));
+	NET_DBG("li               %x", SNTP_GET_LI(pkt->lvm));
+	NET_DBG("vn               %x", SNTP_GET_VN(pkt->lvm));
+	NET_DBG("mode             %x", SNTP_GET_MODE(pkt->lvm));
 	NET_DBG("stratum:         %x", pkt->stratum);
 	NET_DBG("poll:            %x", pkt->poll);
 	NET_DBG("precision:       %x", pkt->precision);
@@ -57,12 +57,12 @@ static s32_t parse_response(u8_t *data, u16_t len, u32_t orig_ts,
 		return -EINVAL;
 	}
 
-	if (LVM_GET_MODE(pkt->lvm) != SNTP_MODE_SERVER) {
+	if (SNTP_GET_MODE(pkt->lvm) != SNTP_MODE_SERVER) {
 		/* For unicast and manycast, server should return 4.
 		 * For broadcast (which is not supported now), server should
 		 * return 5.
 		 */
-		NET_DBG("Unexpected mode: %d", LVM_GET_MODE(pkt->lvm));
+		NET_DBG("Unexpected mode: %d", SNTP_GET_MODE(pkt->lvm));
 		return -EINVAL;
 	}
 
@@ -190,9 +190,9 @@ int sntp_query(struct sntp_ctx *ctx, u32_t timeout, struct sntp_time *time)
 	}
 
 	/* prepare request pkt */
-	LVM_SET_LI(tx_pkt.lvm, 0);
-	LVM_SET_VN(tx_pkt.lvm, SNTP_VERSION_NUMBER);
-	LVM_SET_MODE(tx_pkt.lvm, SNTP_MODE_CLIENT);
+	SNTP_SET_LI(tx_pkt.lvm, 0);
+	SNTP_SET_VN(tx_pkt.lvm, SNTP_VERSION_NUMBER);
+	SNTP_SET_MODE(tx_pkt.lvm, SNTP_MODE_CLIENT);
 	ctx->expected_orig_ts = get_uptime_in_sec() + OFFSET_1970_JAN_1;
 	tx_pkt.tx_tm_s = htonl(ctx->expected_orig_ts);
 

--- a/subsys/net/lib/sntp/sntp_pkt.h
+++ b/subsys/net/lib/sntp/sntp_pkt.h
@@ -9,21 +9,21 @@
 
 #include <zephyr/types.h>
 
-#define LI_MASK   0xC0
-#define VN_MASK   0x38
-#define MODE_MASK 0x07
+#define SNTP_LI_MASK   0xC0
+#define SNTP_VN_MASK   0x38
+#define SNTP_MODE_MASK 0x07
 
-#define LI_SHIFT   6
-#define VN_SHIFT   3
-#define MODE_SHIFT 0
+#define SNTP_LI_SHIFT   6
+#define SNTP_VN_SHIFT   3
+#define SNTP_MODE_SHIFT 0
 
-#define LVM_GET_LI(x)    ((x & LI_MASK) >> LI_SHIFT)
-#define LVM_GET_VN(x)    ((x & VN_MASK) >> VN_SHIFT)
-#define LVM_GET_MODE(x)  ((x & MODE_MASK) >> MODE_SHIFT)
+#define SNTP_GET_LI(x)    ((x & SNTP_LI_MASK) >> SNTP_LI_SHIFT)
+#define SNTP_GET_VN(x)    ((x & SNTP_VN_MASK) >> SNTP_VN_SHIFT)
+#define SNTP_GET_MODE(x)  ((x & SNTP_MODE_MASK) >> SNTP_MODE_SHIFT)
 
-#define LVM_SET_LI(x, v)   (x = x | (v << LI_SHIFT))
-#define LVM_SET_VN(x, v)   (x = x | (v << VN_SHIFT))
-#define LVM_SET_MODE(x, v) (x = x | (v << MODE_SHIFT))
+#define SNTP_SET_LI(x, v)   (x = x | (v << SNTP_LI_SHIFT))
+#define SNTP_SET_VN(x, v)   (x = x | (v << SNTP_VN_SHIFT))
+#define SNTP_SET_MODE(x, v) (x = x | (v << SNTP_MODE_SHIFT))
 
 struct sntp_pkt {
 	u8_t lvm;		/* li, vn, and mode in big endian fashion */


### PR DESCRIPTION
SNTP implementation defined symbols like "MODE_MASK", which can easily
conflict with similary laxly defined symbols in other modules, and
indeed, we hit a case like that (below). So, prefix these symbols with
"Z_", it being current (rather not ideal) "Zephyr private API prefix",
followed by "SNTP_", to make it clear it's related to SNTP, leading to
combined prefix of "Z_SNTP_".

subsys/net/lib/sntp/sntp_pkt.h:14: error: "MODE_MASK" redefined
include/arch/arm/aarch32/cortex_a_r/cpu.h:17: note: this is the
  location of the previous definition

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>