### PR TITLE
boards: mm_swiftio: support west command

### DIFF
--- a/boards/arm/mm_swiftio/board.cmake
+++ b/boards/arm/mm_swiftio/board.cmake
@@ -7,6 +7,6 @@
 board_set_debugger_ifnset(pyocd)
 board_set_flasher_ifnset(pyocd)
 
-board_runner_args(pyocd "--target=mimxrt1050_hyperflash")
+board_runner_args(pyocd "--target=mimxrt1050_quadspi")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
Modify burner for pyocd to support:
west flash
west debug
west debugserver

Signed-off-by: Frank Li <lgl88911@163.com>