### PR TITLE
riscv: linker: replace DT_FLASH_{BASE_ADDRESS,SIZE} with new macros

### DIFF
--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -12,6 +12,7 @@
  */
 
 #include <soc.h>
+#include <devicetree.h>
 
 #include <autoconf.h>
 #include <linker/sections.h>
@@ -33,7 +34,19 @@
 MEMORY
 {
 #ifdef CONFIG_XIP
-    ROM (rx)  : ORIGIN = DT_FLASH_BASE_ADDRESS, LENGTH = KB(DT_FLASH_SIZE)
+#if DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_flash), soc_nv_flash)
+#define ROM_BASE DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
+#define ROM_SIZE DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
+#elif DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_flash), jedec_spi_nor)
+/* For jedec,spi-nor we expect the spi controller to memory map the flash
+ * and for that mapping to be the second register property of the spi
+ * controller.
+ */
+#define SPI_CTRL DT_PARENT(DT_CHOSEN(zephyr_flash))
+#define ROM_BASE DT_REG_ADDR_BY_IDX(SPI_CTRL, 1)
+#define ROM_SIZE DT_REG_SIZE_BY_IDX(SPI_CTRL, 1)
+#endif
+    ROM (rx)  : ORIGIN = ROM_BASE, LENGTH = ROM_SIZE
 #endif
     RAM (rwx) : ORIGIN = CONFIG_SRAM_BASE_ADDRESS, LENGTH = KB(CONFIG_SRAM_SIZE)
     /* Used by and documented in include/linker/intlist.ld */

--- a/soc/riscv/openisa_rv32m1/linker.ld
+++ b/soc/riscv/openisa_rv32m1/linker.ld
@@ -49,8 +49,8 @@
 
 #else
 
-#define ROM_BASE DT_FLASH_BASE_ADDRESS
-#define ROM_SIZE (KB(DT_FLASH_SIZE) - VECTOR_SIZE)
+#define ROM_BASE DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
+#define ROM_SIZE (DT_REG_SIZE(DT_CHOSEN(zephyr_flash)) - VECTOR_SIZE)
 
 #define VECTOR_BASE (ROM_BASE + ROM_SIZE)
 

--- a/soc/riscv/openisa_rv32m1/linker.ld
+++ b/soc/riscv/openisa_rv32m1/linker.ld
@@ -33,15 +33,15 @@
 #ifdef CONFIG_BOOTLOADER_MCUBOOT
 
 
-#define ROM_BASE (DT_CODE_PARTITION_OFFSET)
-#define ROM_SIZE (DT_CODE_PARTITION_SIZE)
+#define ROM_BASE (DT_REG_ADDR(DT_CHOSEN(zephyr_code_partition)))
+#define ROM_SIZE (DT_REG_SIZE(DT_CHOSEN(zephyr_code_partition)))
 
 #define VECTOR_BASE (ROM_BASE + CONFIG_TEXT_SECTION_OFFSET)
 
 #else
 
-#define ROM_BASE DT_CODE_PARTITION_OFFSET
-#define ROM_SIZE (DT_CODE_PARTITION_SIZE - VECTOR_SIZE)
+#define ROM_BASE (DT_REG_ADDR(DT_CHOSEN(zephyr_code_partition)))
+#define ROM_SIZE (DT_REG_SIZE(DT_CHOSEN(zephyr_code_partition)) - VECTOR_BASE)
 
 #define VECTOR_BASE (ROM_BASE + ROM_SIZE)
 


### PR DESCRIPTION
The riscv linker scripts utilize DT_FLASH_BASE_ADDRESS and
DT_FLASH_SIZE, as we want to phase out the old generator we need to
replace these defines with macros from devicetree.h.

We support two flash configurations at this point, either a QSPI flash
like on the hifive board or a SoC flash like on the rv32m1_vega.  We
update the linker scripts to check the compat of the zephyr,flash node
and based on if its 'jedec,spi-nor' or 'soc-nv-flash' we determine how
to extract the "flash" base address and size.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>