### PR TITLE
boards: dts: nrf: Remove SoC compatible in top-level compatible

### DIFF
--- a/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51.dts
+++ b/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51.dts
@@ -9,8 +9,7 @@
 
 / {
 	model = "Seeed Studio Carbon nRF51 96board";
-	compatible = "seeed,carbon_nrf51", "nordic,nrf51822-qfac",
-		     "nordic,nrf51822";
+	compatible = "seeed,carbon_nrf51";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/96b_nitrogen/96b_nitrogen.dts
+++ b/boards/arm/96b_nitrogen/96b_nitrogen.dts
@@ -10,8 +10,7 @@
 
 / {
 	model = "Seeed Studio Nitrogen 96board";
-	compatible = "seeed,nitrogen", "nordic,nrf52832-qfaa",
-		     "nordic,nrf52832";
+	compatible = "seeed,nitrogen";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/actinius_icarus/actinius_icarus_common.dts
+++ b/boards/arm/actinius_icarus/actinius_icarus_common.dts
@@ -6,8 +6,7 @@
 
 / {
 	model = "Actinius Icarus IoT Dev Board";
-	compatible = "actinius,icarus", "nordic,nrf9160-sica",
-			 "nordic,nrf9160";
+	compatible = "actinius,icarus";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
+++ b/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "Adafruit Feather nRF52840 Express";
-	compatible = "nordic,nrf52840-qiaa", "nordic,nrf52840";
+	compatible = "adafruit,feather-nrf52840";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/bbc_microbit/bbc_microbit.dts
+++ b/boards/arm/bbc_microbit/bbc_microbit.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "BBC Micro:bit";
-	compatible = "bbc,microbit", "nordic,nrf51822-qfaa", "nordic,nrf51822";
+	compatible = "bbc,microbit";
 
 	/* These aliases are provided for compatibility with samples */
 	aliases {

--- a/boards/arm/bl652_dvk/bl652_dvk.dts
+++ b/boards/arm/bl652_dvk/bl652_dvk.dts
@@ -9,8 +9,7 @@
 
 / {
 	model = "Laird BL652 DVK";
-	compatible = "laird,bl652_dvk", "nordic,nrf52832-qfaa",
-		     "nordic,nrf52832";
+	compatible = "laird,bl652_dvk";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -9,8 +9,7 @@
 
 / {
 	model = "Laird BL654 Dev Kit";
-	compatible = "nordic,pca10056-dk", "nordic,nrf52840-qiaa",
-		     "nordic,nrf52840";
+	compatible = "nordic,pca10056-dk";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
+++ b/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
@@ -9,8 +9,7 @@
 
 / {
 	model = "Decawave DWM1001-DEV";
-	compatible = "decawave,dwm1001", "nordic,nrf52832-qfaa",
-		     "nordic,nrf52832";
+	compatible = "decawave,dwm1001";
 
 	chosen {
 		zephyr,console        = &uart0;

--- a/boards/arm/degu_evk/degu_evk.dts
+++ b/boards/arm/degu_evk/degu_evk.dts
@@ -9,8 +9,7 @@
 
 / {
 	model = "Degu Evaluation Kit";
-	compatible = "nordic,pca10056-dk", "nordic,nrf52840-qiaa",
-		     "nordic,nrf52840";
+	compatible = "nordic,pca10056-dk";
 
 	chosen {
 		zephyr,sram = &sram0;

--- a/boards/arm/holyiot_yj16019/holyiot_yj16019.dts
+++ b/boards/arm/holyiot_yj16019/holyiot_yj16019.dts
@@ -9,8 +9,7 @@
 
 / {
 	model = "Holyiot YJ-16019";
-	compatible = "holyiot,yj-16019", "nordic,nrf52832-qfaa",
-		     "nordic,nrf52832";
+	compatible = "holyiot,yj-16019";
 
 	chosen {
 		zephyr,sram = &sram0;

--- a/boards/arm/nrf51_ble400/nrf51_ble400.dts
+++ b/boards/arm/nrf51_ble400/nrf51_ble400.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "Waveshare BLE400";
-	compatible = "waveshare,BLE400", "nordic,nrf51822-qfaa", "nordic,nrf51822";
+	compatible = "waveshare,BLE400";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf51_blenano/nrf51_blenano.dts
+++ b/boards/arm/nrf51_blenano/nrf51_blenano.dts
@@ -9,8 +9,7 @@
 
 / {
 	model = "Redbear BLE Nano";
-	compatible = "redbear,blenano", "nordic,nrf51822-qfaa",
-		     "nordic,nrf51822";
+	compatible = "redbear,blenano";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf51_vbluno51/nrf51_vbluno51.dts
+++ b/boards/arm/nrf51_vbluno51/nrf51_vbluno51.dts
@@ -9,8 +9,7 @@
 
 / {
 	model = "VNG VBLUno51 BLE board";
-	compatible = "vng,vbluno51", "nordic,nrf51822-qfac",
-		     "nordic,nrf51822";
+	compatible = "vng,vbluno51";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
+++ b/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
@@ -9,8 +9,7 @@
 
 / {
 	model = "Nordic nRF51 DK NRF51422";
-	compatible = "nordic,nrf51-dk-nrf51422", "nordic,nrf51822-qfac",
-		     "nordic,nrf51822";
+	compatible = "nordic,nrf51-dk-nrf51422";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
+++ b/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
@@ -9,8 +9,7 @@
 
 / {
 	model = "Nordic nRF51 Dongle NRF51422";
-	compatible = "nordic,nrf51-dongle-nrf51422", "nordic,nrf51822-qfac",
-		     "nordic,nrf51822";
+	compatible = "nordic,nrf51-dongle-nrf51422";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
+++ b/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
@@ -10,8 +10,7 @@
 
 / {
 	model = "nRF52832-MDK Micro Dev Kit";
-	compatible = "nrf52832-mdk", "nordic,nrf52832-qfaa",
-		     "nordic,nrf52832";
+	compatible = "nrf52832-mdk";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
@@ -9,8 +9,7 @@
 
 / {
 	model = "Nordic nRF52833 DK NRF52833";
-	compatible = "nordic,nrf52833-dk-nrf52833", "nordic,nrf52833-qiaa",
-		     "nordic,nrf52833";
+	compatible = "nordic,nrf52833-dk-nrf52833";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf52840_blip/nrf52840_blip.dts
+++ b/boards/arm/nrf52840_blip/nrf52840_blip.dts
@@ -12,8 +12,7 @@
 
 / {
 	model = "Electronut Labs Blip";
-	compatible = "nordic,pca10056-dk", "nordic,nrf52840-qiaa",
-		     "nordic,nrf52840";
+	compatible = "nordic,pca10056-dk";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -9,8 +9,7 @@
 
 / {
 	model = "nRF52840-MDK Dev Kit";
-	compatible = "nordic,pca10056-dk", "nordic,nrf52840-qiaa",
-		     "nordic,nrf52840";
+	compatible = "nordic,pca10056-dk";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
@@ -9,8 +9,7 @@
 
 / {
 	model = "Papyr";
-	compatible = "nordic,pca10056-dk", "nordic,nrf52840-qiaa",
-		     "nordic,nrf52840";
+	compatible = "nordic,pca10056-dk";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
+++ b/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
@@ -9,8 +9,7 @@
 
 / {
 	model = "Nordic nRF52840 DK NRF52811";
-	compatible = "nordic,nrf52840-dk-nrf52811", "nordic,nrf52811-qfaa",
-		     "nordic,nrf52811";
+	compatible = "nordic,nrf52840-dk-nrf52811";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -9,8 +9,7 @@
 
 / {
 	model = "Nordic nRF52840 DK NRF52840";
-	compatible = "nordic,nrf52840-dk-nrf52840", "nordic,nrf52840-qiaa",
-		     "nordic,nrf52840";
+	compatible = "nordic,nrf52840-dk-nrf52840";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
+++ b/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
@@ -10,8 +10,7 @@
 
 / {
 	model = "Nordic nRF52840 Dongle NRF52840";
-	compatible = "nordic,nrf52840-dongle-nrf52840", "nordic,nrf52840-qiaa",
-		     "nordic,nrf52840";
+	compatible = "nordic,nrf52840-dongle-nrf52840";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
+++ b/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
@@ -11,8 +11,7 @@
 
 / {
 	model = "nRF52 Adafruit Feather";
-	compatible = "adafruit,nrf52_adafruit_feather", "nordic,nrf52832-qfaa",
-		     "nordic,nrf52832";
+	compatible = "adafruit,nrf52_adafruit_feather";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
+++ b/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
@@ -9,8 +9,7 @@
 
 / {
 	model = "Redbear BLE Nano 2";
-	compatible = "redbear,blenano2", "nordic,nrf52832-qfaa",
-		     "nordic,nrf52832";
+	compatible = "redbear,blenano2";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
+++ b/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
@@ -10,8 +10,7 @@
 
 / {
 	model = "Sparkfun nRF52832 Breakout";
-	compatible = "sparkfun,nrf52832", "nordic,nrf52832-qfaa",
-		     "nordic,nrf52832";
+	compatible = "sparkfun,nrf52832";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf52_vbluno52/nrf52_vbluno52.dts
+++ b/boards/arm/nrf52_vbluno52/nrf52_vbluno52.dts
@@ -9,8 +9,7 @@
 
 / {
 	model = "VNG VBLUno52 BLE 5.0 board";
-	compatible = "vng,vbluno52", "nordic,nrf52832-qfaa",
-		     "nordic,nrf52832";
+	compatible = "vng,vbluno52";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
+++ b/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
@@ -11,8 +11,7 @@
 
 / {
 	model = "Nordic nRF52 DK NRF52810";
-	compatible = "nordic,nrf52-dk-nrf52810", "nordic,nrf52810-qfaa",
-		     "nordic,nrf52810";
+	compatible = "nordic,nrf52-dk-nrf52810";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
+++ b/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
@@ -10,8 +10,7 @@
 
 / {
 	model = "Nordic nRF52 DK NRF52832";
-	compatible = "nordic,nrf52-dk-nrf52832", "nordic,nrf52832-qfaa",
-		     "nordic,nrf52832";
+	compatible = "nordic,nrf52-dk-nrf52832";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf9160_innblue21/nrf9160_innblue21_common.dts
+++ b/boards/arm/nrf9160_innblue21/nrf9160_innblue21_common.dts
@@ -6,8 +6,7 @@
 
 / {
 	model = "innblue v21 Dev Kit";
-	compatible = "innblue,innblue21",
-				 "nordic,nrf9160-sica", "nordic,nrf9160";
+	compatible = "innblue,innblue21";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dts
+++ b/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dts
@@ -6,8 +6,7 @@
 
 / {
 	model = "innblue v22 Dev Kit";
-	compatible = "innblue,innblue22",
-				"nordic,nrf9160-sica", "nordic,nrf9160";
+	compatible = "innblue,innblue22";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
@@ -10,8 +10,7 @@
 
 / {
 	model = "Nordic nRF9160 DK NRF52840";
-	compatible = "nordic,nrf9160-dk-nrf52840", "nordic,nrf52840-qiaa",
-		     "nordic,nrf52840";
+	compatible = "nordic,nrf9160-dk-nrf52840";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -6,8 +6,7 @@
 
 / {
 	model = "Nordic nRF9160 DK NRF9160";
-	compatible = "nordic,nrf9160-dk-nrf9160", "nordic,nrf9160-sica",
-		     "nordic,nrf9160";
+	compatible = "nordic,nrf9160-dk-nrf9160";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/particle_argon/particle_argon.dts
+++ b/boards/arm/particle_argon/particle_argon.dts
@@ -11,8 +11,7 @@
 
 / {
 	model = "Particle Argon";
-	compatible = "particle,argon", "particle,feather",
-		"nordic,nrf52840-qiaa", "nordic,nrf52840";
+	compatible = "particle,argon", "particle,feather";
 
 	sky13351 {
 		compatible = "skyworks,sky13351";

--- a/boards/arm/particle_boron/particle_boron.dts
+++ b/boards/arm/particle_boron/particle_boron.dts
@@ -11,8 +11,7 @@
 
 / {
 	model = "Particle Boron";
-	compatible = "particle,boron", "particle,feather",
-		"nordic,nrf52840-qiaa", "nordic,nrf52840";
+	compatible = "particle,boron", "particle,feather";
 
 	sky13351 {
 		compatible = "skyworks,sky13351";

--- a/boards/arm/particle_xenon/particle_xenon.dts
+++ b/boards/arm/particle_xenon/particle_xenon.dts
@@ -11,8 +11,7 @@
 
 / {
 	model = "Particle Xenon";
-	compatible = "particle,xenon", "particle,feather",
-		"nordic,nrf52840-qiaa", "nordic,nrf52840";
+	compatible = "particle,xenon", "particle,feather";
 
 	sky13351 {
 		compatible = "skyworks,sky13351";

--- a/boards/arm/qemu_cortex_m0/qemu_cortex_m0.dts
+++ b/boards/arm/qemu_cortex_m0/qemu_cortex_m0.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "QEMU Cortex-M0";
-	compatible = "nordic,nrf51822-qfaa", "nordic,nrf51822";
+	compatible = "bbc,qemu-microbit";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -11,8 +11,7 @@
 
 / {
 	model = "reel board";
-	compatible = "phytec,reel_board", "nordic,nrf52840-qiaa",
-		     "nordic,nrf52840";
+	compatible = "phytec,reel_board";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/reel_board/reel_board_v2.dts
+++ b/boards/arm/reel_board/reel_board_v2.dts
@@ -11,8 +11,7 @@
 
 / {
 	model = "reel board v2";
-	compatible = "phytec,reel_board_v2", "nordic,nrf52840-qiaa",
-		     "nordic,nrf52840";
+	compatible = "phytec,reel_board_v2";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
+++ b/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
@@ -11,8 +11,7 @@
 
 / {
 	model = "Nordic Thingy52 NRF52832";
-	compatible = "nordic,thingy52-nrf52832", "nordic,nrf52832-qfaa",
-		"nordic,nrf52832";
+	compatible = "nordic,thingy52-nrf52832";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/posix/nrf52_bsim/nrf52_bsim.dts
+++ b/boards/posix/nrf52_bsim/nrf52_bsim.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "nrf52 bsim";
-	compatible = "nordic,nrf52832";
+	compatible = "bsim,nrf52832";
 
 	/* We need to remove aliases to nodes we delete */
 	aliases {

--- a/samples/application_development/out_of_tree_board/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/samples/application_development/out_of_tree_board/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -9,8 +9,7 @@
 
 / {
 	model = "Nordic nRF52840 DK NRF52840";
-	compatible = "nordic,nrf52840-dk-nrf52840", "nordic,nrf52840-qiaa",
-		     "nordic,nrf52840";
+	compatible = "nordic,nrf52840-dk-nrf52840";
 
 	chosen {
 		zephyr,console = &uart0;


### PR DESCRIPTION
The SoC node has compatibles for the specific SoC in place, having the
same compatible at the top level is technically a conflict and the
top-level one should really just be about the board.  Remove the SoC
related compatibles at the top-level.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>