### PR TITLE
sanitycheck: support coverage with unit tests

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -1854,6 +1854,8 @@ class ProjectBuilder(FilterBuilder):
         elif instance.testcase.type == "unit":
             instance.handler = BinaryHandler(instance, "unit")
             instance.handler.binary = os.path.join(instance.build_dir, "testbinary")
+            if self.coverage:
+                args.append("COVERAGE=1")
         elif instance.platform.type == "native":
             handler = BinaryHandler(instance, "native")
 

--- a/subsys/testsuite/unittest.cmake
+++ b/subsys/testsuite/unittest.cmake
@@ -71,6 +71,10 @@ if(COVERAGE)
     -fprofile-arcs
     -ftest-coverage
     )
+
+  target_link_libraries(testbinary PRIVATE
+    -lgcov
+    )
 endif()
 
 if(LIBS)


### PR DESCRIPTION
Fix setting coverage for unit tests and link against gcov when coverage
is enabled.

Fixes #24674