### PR TITLE
bluetooth: controller: openisa/RV32M1: Convert irqs to new dts macros

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/ll_irqs.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/ll_irqs.h
@@ -13,15 +13,15 @@
  * LPTMR1 -> INTMUX_CH2. We expect it to be the only IRQ source for this channel
  * We'll use the INTMUX ISR for channel 2 instead of LPTMR1 ISR
  */
-#define LL_RTC0_IRQn_1st_lvl DT_OPENISA_RV32M1_INTMUX_CH_4004F080_IRQ_0
-#define LL_RTC0_IRQn_2nd_lvl DT_OPENISA_RV32M1_LPTMR_40033000_IRQ_0
+#define LL_RTC0_IRQn_1st_lvl DT_IRQN(DT_NODELABEL(intmux0_ch2))
+#define LL_RTC0_IRQn_2nd_lvl DT_IRQN(DT_NODELABEL(lptmr1))
 
 /*
  * radio -> INTMUX_CH3. We expect it to be the only IRQ source for this channel
  * We'll use the INTMUX ISR for channel 3 instead of radio ISR
  */
-#define LL_RADIO_IRQn_1st_lvl DT_OPENISA_RV32M1_INTMUX_CH_4004F0C0_IRQ_0
-#define LL_RADIO_IRQn_2nd_lvl DT_OPENISA_RV32M1_GENFSK_41033000_IRQ_0
+#define LL_RADIO_IRQn_1st_lvl DT_IRQN(DT_NODELABEL(intmux0_ch3))
+#define LL_RADIO_IRQn_2nd_lvl DT_IRQN(DT_NODELABEL(generic_fsk))
 
 #define LL_RTC0_IRQn LL_RTC0_IRQn_1st_lvl
 #define LL_RADIO_IRQn LL_RADIO_IRQn_1st_lvl


### PR DESCRIPTION
Convert old style defines for IRQ numbers to using DT_IRQN and
DT_NODELABEL to extract IRQ numbers.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>