### PR TITLE
soc: riscv: openisa_rv32m1: Convert to new dts macros

### DIFF
--- a/soc/riscv/openisa_rv32m1/soc.c
+++ b/soc/riscv/openisa_rv32m1/soc.c
@@ -146,7 +146,8 @@ void soc_interrupt_init(void)
 	(void)(EVENT_UNIT->EVTPENDCLEAR); /* Ensures write has finished. */
 
 	if (IS_ENABLED(CONFIG_MULTI_LEVEL_INTERRUPTS)) {
-		dev_intmux = device_get_binding(DT_OPENISA_RV32M1_INTMUX_INTMUX_LABEL);
+		dev_intmux = device_get_binding(
+				DT_LABEL(DT_INST(0, openisa_rv32m1_intmux)));
 		__ASSERT(dev_intmux, "no INTMUX device found");
 	}
 }


### PR DESCRIPTION
Convert from DT_OPENISA_RV32M1_INTMUX_INTMUX_LABEL to
DT_LABEL(DT_INST(0, openisa_rv32m1_intmux)).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>