### PR TITLE
Revert "tests: no need long busy_wait to waste cycles"

### DIFF
--- a/tests/kernel/interrupt/src/prevent_irq.c
+++ b/tests/kernel/interrupt/src/prevent_irq.c
@@ -46,14 +46,14 @@ void test_prevent_interruption(void)
 	 * locked -- but since they are, check_lock_new isn't updated.
 	 */
 	k_timer_start(&irqlock_timer, K_MSEC(DURATION), K_NO_WAIT);
-	k_busy_wait(MS_TO_US(2 * DURATION));
+	k_busy_wait(MS_TO_US(1000));
 	zassert_not_equal(handler_result, HANDLER_TOKEN,
 		"timer interrupt was serviced while interrupts are locked");
 
 	printk("unlocking interrupts\n");
 	irq_unlock(key);
 
-	k_busy_wait(MS_TO_US(DURATION));
+	k_busy_wait(MS_TO_US(1000));
 
 	zassert_equal(handler_result, HANDLER_TOKEN,
 		"timer should have fired");


### PR DESCRIPTION
This reverts commit 315cba1c40fcd53881ec5c4bbaed0da79892c554 as it was
causing CI failures for qemu_cortex_m0.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>