### PR TITLE
kconfigfunctions: add dt_path_enabled, dt_alias_enabled

### DIFF
--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -418,6 +418,15 @@ def shields_list_contains(kconf, _, shield):
     return "y" if shield in list.split(";") else "n"
 
 
+# Keys in this dict are the function names as they appear
+# in Kconfig files. The values are tuples in this form:
+#
+#       (python_function, minimum_number_of_args, maximum_number_of_args)
+#
+# Each python function is given a kconf object and its name in the
+# Kconfig file, followed by arguments from the Kconfig file.
+#
+# See the kconfiglib documentation for more details.
 functions = {
         "dt_compat_enabled": (dt_compat_enabled, 1, 1),
         "dt_compat_on_bus": (dt_compat_on_bus, 2, 2),

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -88,10 +88,44 @@ def dt_chosen_path(kconf, _, chosen):
     return node.path if node else ""
 
 
+def dt_node_enabled(kconf, name, node):
+    """
+    This function is used to test if a node is enabled (has status
+    'okay') or not.
+
+    The 'node' argument is a string which is either a path or an
+    alias, or both, depending on 'name'.
+
+    If 'name' is 'dt_path_enabled', 'node' is an alias or a path. If
+    'name' is 'dt_alias_enabled, 'node' is an alias.
+    """
+
+    if doc_mode or edt is None:
+        return "n"
+
+    if name == "dt_alias_enabled":
+        if node.startswith("/"):
+            # EDT.get_node() works with either aliases or paths. If we
+            # are specifically being asked about an alias, reject paths.
+            return "n"
+    else:
+        # Make sure this is being called appropriately.
+        assert name == "dt_path_enabled"
+
+    try:
+        node = edt.get_node(node)
+    except edtlib.EDTError:
+        return "n"
+
+    return "y" if node and node.enabled else "n"
+
+
 def dt_nodelabel_enabled(kconf, _, label):
     """
-    This function takes a 'label' and returns "y" if we find an "enabled"
-    node that has a 'nodelabel' of 'label' in the EDT otherwise we return "n"
+    This function is like dt_node_enabled(), but the 'label' argument
+    should be a node label, like "foo" is here:
+
+       foo: some-node { ... };
     """
     if doc_mode or edt is None:
         return "n"
@@ -390,6 +424,8 @@ functions = {
         "dt_chosen_label": (dt_chosen_label, 1, 1),
         "dt_chosen_enabled": (dt_chosen_enabled, 1, 1),
         "dt_chosen_path": (dt_chosen_path, 1, 1),
+        "dt_path_enabled": (dt_node_enabled, 1, 1),
+        "dt_alias_enabled": (dt_node_enabled, 1, 1),
         "dt_nodelabel_enabled": (dt_nodelabel_enabled, 1, 1),
         "dt_chosen_reg_addr_int": (dt_chosen_reg, 1, 3),
         "dt_chosen_reg_addr_hex": (dt_chosen_reg, 1, 3),


### PR DESCRIPTION
This is just like dt_nodelabel_enabled, but for aliases and paths.

It is explicitly being added for the benefit of out of tree applications, just to be able to rely on it in Zephyr without having to maintain out of tree patches.
