### PR TITLE
boards: mimxrt10{50,60,64}_evk: Enable ft5336 touch interrupt

### DIFF
--- a/boards/arm/mimxrt1050_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1050_evk/Kconfig.defconfig
@@ -39,6 +39,9 @@ if KSCAN
 config KSCAN_FT5336
 	default y
 
+config KSCAN_FT5336_INTERRUPT
+	default y
+
 config KSCAN_INIT_PRIORITY
 	default 60
 

--- a/boards/arm/mimxrt1050_evk/doc/index.rst
+++ b/boards/arm/mimxrt1050_evk/doc/index.rst
@@ -141,6 +141,8 @@ The MIMXRT1050 SoC has five pairs of pinmux/gpio controllers.
 +---------------+-----------------+---------------------------+
 | GPIO_AD_B0_10 | GPIO/ENET_INT   | GPIO/Ethernet             |
 +---------------+-----------------+---------------------------+
+| GPIO_AD_B0_11 | GPIO            | Touch Interrupt           |
++---------------+-----------------+---------------------------+
 | GPIO_AD_B0_12 | LPUART1_TX      | UART Console              |
 +---------------+-----------------+---------------------------+
 | GPIO_AD_B0_13 | LPUART1_RX      | UART Console              |

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -126,7 +126,7 @@ arduino_serial: &lpuart3 {};
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		label = "FT5336";
-		int-gpios = <&gpio1 11 0>;
+		int-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/boards/arm/mimxrt1050_evk/pinmux.c
+++ b/boards/arm/mimxrt1050_evk/pinmux.c
@@ -109,6 +109,15 @@ static int mimxrt1050_evk_init(struct device *dev)
 	CLOCK_EnableClock(kCLOCK_Iomuxc);
 	CLOCK_EnableClock(kCLOCK_IomuxcSnvs);
 
+#if DT_NODE_HAS_PROP(DT_INST(0, focaltech_ft5336), int_gpios)
+	IOMUXC_SetPinMux(IOMUXC_GPIO_AD_B0_11_GPIO1_IO11, 0);
+
+	IOMUXC_SetPinConfig(IOMUXC_GPIO_AD_B0_11_GPIO1_IO11,
+			    IOMUXC_SW_PAD_CTL_PAD_PKE_MASK |
+			    IOMUXC_SW_PAD_CTL_PAD_SPEED(2) |
+			    IOMUXC_SW_PAD_CTL_PAD_DSE(6));
+#endif
+
 #if !DT_HAS_NODE(DT_NODELABEL(enet))
 	/* LED */
 	IOMUXC_SetPinMux(IOMUXC_GPIO_AD_B0_09_GPIO1_IO09, 0);

--- a/boards/arm/mimxrt1060_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1060_evk/Kconfig.defconfig
@@ -32,6 +32,9 @@ if KSCAN
 config KSCAN_FT5336
 	default y
 
+config KSCAN_FT5336_INTERRUPT
+	default y
+
 config KSCAN_INIT_PRIORITY
 	default 60
 

--- a/boards/arm/mimxrt1060_evk/doc/index.rst
+++ b/boards/arm/mimxrt1060_evk/doc/index.rst
@@ -128,6 +128,8 @@ The MIMXRT1060 SoC has five pairs of pinmux/gpio controllers.
 +---------------+-----------------+---------------------------+
 | GPIO_AD_B0_10 | GPIO/ENET_INT   | GPIO/Ethernet             |
 +---------------+-----------------+---------------------------+
+| GPIO_AD_B0_11 | GPIO            | Touch Interrupt           |
++---------------+-----------------+---------------------------+
 | GPIO_AD_B0_12 | LPUART1_TX      | UART Console              |
 +---------------+-----------------+---------------------------+
 | GPIO_AD_B0_13 | LPUART1_RX      | UART Console              |

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -116,7 +116,7 @@ arduino_serial: &lpuart3 {};
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		label = "FT5336";
-		int-gpios = <&gpio1 11 0>;
+		int-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/boards/arm/mimxrt1060_evk/pinmux.c
+++ b/boards/arm/mimxrt1060_evk/pinmux.c
@@ -24,6 +24,15 @@ static int mimxrt1060_evk_init(struct device *dev)
 	CLOCK_EnableClock(kCLOCK_Iomuxc);
 	CLOCK_EnableClock(kCLOCK_IomuxcSnvs);
 
+#if DT_NODE_HAS_PROP(DT_INST(0, focaltech_ft5336), int_gpios)
+	IOMUXC_SetPinMux(IOMUXC_GPIO_AD_B0_11_GPIO1_IO11, 0);
+
+	IOMUXC_SetPinConfig(IOMUXC_GPIO_AD_B0_11_GPIO1_IO11,
+			    IOMUXC_SW_PAD_CTL_PAD_PKE_MASK |
+			    IOMUXC_SW_PAD_CTL_PAD_SPEED(2) |
+			    IOMUXC_SW_PAD_CTL_PAD_DSE(6));
+#endif
+
 #if !DT_HAS_NODE(DT_NODELABEL(enet))
 	/* LED */
 	IOMUXC_SetPinMux(IOMUXC_GPIO_AD_B0_09_GPIO1_IO09, 0);

--- a/boards/arm/mimxrt1064_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1064_evk/Kconfig.defconfig
@@ -31,6 +31,9 @@ if KSCAN
 config KSCAN_FT5336
 	default y
 
+config KSCAN_FT5336_INTERRUPT
+	default y
+
 config KSCAN_INIT_PRIORITY
 	default 60
 

--- a/boards/arm/mimxrt1064_evk/doc/index.rst
+++ b/boards/arm/mimxrt1064_evk/doc/index.rst
@@ -125,6 +125,8 @@ The MIMXRT1064 SoC has four pairs of pinmux/gpio controllers.
 +---------------+-----------------+---------------------------+
 | GPIO_AD_B0_10 | GPIO/ENET_INT   | GPIO/Ethernet             |
 +---------------+-----------------+---------------------------+
+| GPIO_AD_B0_11 | GPIO            | Touch Interrupt           |
++---------------+-----------------+---------------------------+
 | GPIO_AD_B0_12 | LPUART1_TX      | UART Console              |
 +---------------+-----------------+---------------------------+
 | GPIO_AD_B0_13 | LPUART1_RX      | UART Console              |

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -125,7 +125,7 @@ arduino_i2c: &lpi2c1 {};
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		label = "FT5336";
-		int-gpios = <&gpio1 11 0>;
+		int-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/boards/arm/mimxrt1064_evk/pinmux.c
+++ b/boards/arm/mimxrt1064_evk/pinmux.c
@@ -23,6 +23,15 @@ static int mimxrt1064_evk_init(struct device *dev)
 	CLOCK_EnableClock(kCLOCK_Iomuxc);
 	CLOCK_EnableClock(kCLOCK_IomuxcSnvs);
 
+#if DT_NODE_HAS_PROP(DT_INST(0, focaltech_ft5336), int_gpios)
+	IOMUXC_SetPinMux(IOMUXC_GPIO_AD_B0_11_GPIO1_IO11, 0);
+
+	IOMUXC_SetPinConfig(IOMUXC_GPIO_AD_B0_11_GPIO1_IO11,
+			    IOMUXC_SW_PAD_CTL_PAD_PKE_MASK |
+			    IOMUXC_SW_PAD_CTL_PAD_SPEED(2) |
+			    IOMUXC_SW_PAD_CTL_PAD_DSE(6));
+#endif
+
 #if !DT_HAS_NODE(DT_NODELABEL(enet))
 	/* LED */
 	IOMUXC_SetPinMux(IOMUXC_GPIO_AD_B0_09_GPIO1_IO09, 0);

--- a/drivers/kscan/kscan_ft5336.c
+++ b/drivers/kscan/kscan_ft5336.c
@@ -69,6 +69,8 @@ static int ft5336_read(struct device *dev)
 	row = ((buffer[2] & 0x0f) << 8) | buffer[3];
 	column = ((buffer[4] & 0x0f) << 8) | buffer[5];
 
+	LOG_DBG("row: %d, col: %d, pressed: %d", row, column, pressed);
+
 	data->callback(dev, row, column, pressed);
 
 #ifdef CONFIG_KSCAN_FT5336_INTERRUPT


### PR DESCRIPTION
Enables the ft5336 touch controller interrupt on the mimxrt10{50,60,64}_evk
boards.

Thanks to @k0d for adding interrupt support to the ft5336 driver in #23619.