### PR TITLE
tests: drivers: hwinfo: Remove unnecessary filter

### DIFF
--- a/tests/drivers/hwinfo/api/testcase.yaml
+++ b/tests/drivers/hwinfo/api/testcase.yaml
@@ -1,4 +1,3 @@
 tests:
   drivers.device_id:
     tags: driver
-    filter: CONFIG_HWINFO


### PR DESCRIPTION
The hwinfo driver test currently filters for `CONFIG_HWINFO`, but this
symbol is set to `y` by the `prj.conf` and therefore will always be
selected.

This commit removes the unnecessary `CONFIG_HWINFO` filter.

Note that the hwinfo driver test `ifdef`s `CONFIG_HWINFO_HAS_DRIVER`,
and having an actual hwinfo driver implementation is not a requirement
(if no hwinfo driver is available, the test validates that -ENOTSUP is
returned by `hwinfo_get_device_id`).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>