### PR TITLE
boards: arm: mec2016evb_assy6797: Use new dts macros

### DIFF
--- a/boards/arm/mec2016evb_assy6797/pinmux.c
+++ b/boards/arm/mec2016evb_assy6797/pinmux.c
@@ -15,7 +15,7 @@ static int board_pinmux_init(struct device *dev)
 	ARG_UNUSED(dev);
 
 	/* See table 2-4 from the Data sheet*/
-#ifdef DT_NS16550_400F2400_BASE_ADDRESS
+#if DT_HAS_NODE(DT_NODELABEL(uart0))
 	/* Set muxing, for UART 0 and power up */
 	PCR_INST->CLK_REQ_2_b.UART_0_CLK_REQ = 1;
 	UART0_INST->CONFIG = 0;
@@ -24,7 +24,7 @@ static int board_pinmux_init(struct device *dev)
 	GPIO_100_137_INST->GPIO_105_PIN_CONTROL_b.MUX_CONTROL = 1;
 #endif
 
-#ifdef DT_NS16550_400F2800_BASE_ADDRESS
+#if DT_HAS_NODE(DT_NODELABEL(uart1))
 	/* Set muxing, for UART 1 and power up */
 	PCR_INST->CLK_REQ_2_b.UART_1_CLK_REQ = 1;
 	UART1_INST->CONFIG = 0;


### PR DESCRIPTION
Convert old style ifdef(DT_NS16550_400F2400_BASE_ADDRESS) to
if DT_HAS_NODE(DT_NODELABEL(uart0)) to decide to config pins for UART0
and similarly for UART1.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>