### PR TITLE
tests: lib: cmsis_dsp: transform: Provide RIFFT bug workaround

### DIFF
--- a/tests/lib/cmsis_dsp/transform/src/rf32.c
+++ b/tests/lib/cmsis_dsp/transform/src/rf32.c
@@ -30,7 +30,7 @@ static void test_arm_rfft_f32_real_backend(
 	output = malloc(length * sizeof(float32_t));
 	zassert_not_null(output, ASSERT_MSG_BUFFER_ALLOC_FAILED);
 
-	scratch = malloc(length * sizeof(float32_t));
+	scratch = calloc(length + 2, sizeof(float32_t)); /* see #24701 */
 	zassert_not_null(scratch, ASSERT_MSG_BUFFER_ALLOC_FAILED);
 
 	/* Load data in place */

--- a/tests/lib/cmsis_dsp/transform/src/rf64.c
+++ b/tests/lib/cmsis_dsp/transform/src/rf64.c
@@ -29,7 +29,7 @@ static void test_arm_rfft_f64_real_backend(
 	output = malloc(length * sizeof(float64_t));
 	zassert_not_null(output, ASSERT_MSG_BUFFER_ALLOC_FAILED);
 
-	scratch = malloc(length * sizeof(float64_t));
+	scratch = calloc(length + 2, sizeof(float64_t)); /* see #24701 */
 	zassert_not_null(scratch, ASSERT_MSG_BUFFER_ALLOC_FAILED);
 
 	/* Load data in place */

--- a/tests/lib/cmsis_dsp/transform/src/rq15.c
+++ b/tests/lib/cmsis_dsp/transform/src/rq15.c
@@ -124,7 +124,7 @@ static void test_arm_rifft_q15(
 	arm_rfft_init_q15(&inst, length, true, true);
 
 	/* Allocate buffers */
-	scratch = malloc(length * sizeof(q15_t));
+	scratch = calloc(length + 2, sizeof(q15_t)); /* see #24701 */
 	zassert_not_null(scratch, ASSERT_MSG_BUFFER_ALLOC_FAILED);
 
 	output = malloc(2 * length * sizeof(q15_t));

--- a/tests/lib/cmsis_dsp/transform/src/rq31.c
+++ b/tests/lib/cmsis_dsp/transform/src/rq31.c
@@ -108,7 +108,7 @@ static void test_arm_rifft_q31(
 	arm_rfft_init_q31(&inst, length, true, true);
 
 	/* Allocate buffers */
-	scratch = malloc(length * sizeof(q31_t));
+	scratch = calloc(length + 2, sizeof(q31_t)); /* see #24701 */
 	zassert_not_null(scratch, ASSERT_MSG_BUFFER_ALLOC_FAILED);
 
 	output = malloc(2 * length * sizeof(q31_t));


### PR DESCRIPTION
This commit provides the workarounds for the CMSIS-DSP RIFFT input
buffer access bug reported in #24701.

The upstream issue for this bug is ARM-software/CMSIS_5#906.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #24701.