### PR TITLE
boards: arm: mps2_an385: Enable QEMU icount mode

### DIFF
--- a/boards/arm/mps2_an385/board.cmake
+++ b/boards/arm/mps2_an385/board.cmake
@@ -8,7 +8,7 @@ set(QEMU_FLAGS_${ARCH}
   -machine mps2-an385
   -nographic
   -vga none
-  -icount auto
+  -icount shift=7,align=off,sleep=off -rtc clock=vm
   )
 
 board_set_debugger_ifnset(qemu)


### PR DESCRIPTION
```
This commit enables the QEMU icount mode for `mps2_an385`, in order to
decouple the host clock from the emulated guest clock.

This prevents guest timing instability from causing test failures when
the host CPU load is very high.

The icount `shift` value of 7 was empirically chosen to allow the tests
to complete in both realistic and reasonable amount of time.

The following are quick notes on the parameters used:

* -icount shift=7: Execute one instruction every 128ns of virtual time
* -icount align=off: Do not synchronise the host and guest clocks
* -icount sleep=off: Advance virtual time without sleeping/waiting
* -rtc clock=vm: Isolate the guest RTC time from the host

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```

This fixes the infamous `mps2_an385`-related "intermittent" CI failures.

I have locally run `mps2_an385` sanitycheck to verify that this fixes the current problem -- it passed 10/10 times. Without this fix, it is practically impossible to get the sanitycheck to pass in the first run.

https://gist.github.com/stephanosio/03c38bb39deca2efa96eda6bc68de5b2

Provides a partial fix for #14173.