### PR TITLE
[RFC] kernel: Extend busy waiting with mixed mode

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -521,6 +521,12 @@ config ARCH_HAS_CUSTOM_BUSY_WAIT
 	  the provided k_busy_wait(), but instead must do something custom. It must
 	  enable this option in that case.
 
+config ARCH_CUSTOM_BUSY_WAIT_THRESHOLD
+	int "Maximum period measured with custom busy wait (in microseconds)"
+	default 0
+	help
+	  If 0 then custom busy wait is used when enabled.
+
 config SYS_CLOCK_TICKS_PER_SEC
 	int "System tick frequency (in ticks/second)"
 	default 100 if QEMU_TARGET || SOC_POSIX

--- a/soc/arm/nordic_nrf/Kconfig.defconfig
+++ b/soc/arm/nordic_nrf/Kconfig.defconfig
@@ -27,6 +27,9 @@ config SYS_CLOCK_TICKS_PER_SEC
 config ARCH_HAS_CUSTOM_BUSY_WAIT
 	default y
 
+config ARCH_CUSTOM_BUSY_WAIT_THRESHOLD
+	default 10000
+
 config SYS_POWER_MANAGEMENT
 	default y
 


### PR DESCRIPTION
If custom busy wait is used then it is possible that it has different
clock source than system clock and time measured will be different
compared to one sourced from system clock due to clock sources
inaccuracy. On the other hand custom busy waiting is used when system
clock frequency is low and cannot handle delays with microseconds
precision.

Adding CONFIG_ARCH_HAS_CUSTOM_MIXED_BUSY_WAIT option which is using
system clock for coarse busy waiting and custom function for
remainder. With this approach, error that could be seen for longer
delays is reduced.

Fixed #24784.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>