### PR TITLE
drivers/clock_control: stm32H7 AHB clock computation depends on core

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -162,10 +162,12 @@ static int stm32_clock_control_get_subsys_rate(struct device *clock,
 	 * since it will be updated after clock configuration and hence
 	 * more likely to contain actual clock speed
 	 */
-	u32_t sys_d1cpre_ck = get_bus_clock(SystemCoreClock,
-				CONFIG_CLOCK_STM32_D1CPRE);
-	u32_t ahb_clock = get_bus_clock(sys_d1cpre_ck,
+#if defined(CONFIG_CPU_CORTEX_M4)
+	u32_t ahb_clock = SystemCoreClock;
+#else
+	u32_t ahb_clock = get_bus_clock(SystemCoreClock,
 				CONFIG_CLOCK_STM32_HPRE);
+#endif
 	u32_t apb1_clock = get_bus_clock(ahb_clock,
 				CONFIG_CLOCK_STM32_D2PPRE1);
 	u32_t apb2_clock = get_bus_clock(ahb_clock,


### PR DESCRIPTION
On cortex M4, AHB clock is equal to SystemCoreClock
On Cortex M7, AHB clock is equal to SystemCoreClock/HPRE
By the way, D1CPRE is of no use when starting from SystemCoreColck.

Signed-off-by: Alexandre Bourdiol <alexandre.bourdiol@st.com>