### PR TITLE
net: lwm2m: Handle socket errors

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -193,6 +193,18 @@ static void sm_handle_timeout_state(struct lwm2m_message *msg,
 	}
 }
 
+/* force state machine restart */
+void engine_trigger_restart(void)
+{
+	lwm2m_engine_context_close(client.ctx);
+
+	/* Jump directly to the registration phase. In case there is no valid
+	 * security object for the LWM2M server, it will fall back to the
+	 * bootstrap procedure.
+	 */
+	set_sm_state(ENGINE_DO_REGISTRATION);
+}
+
 /* force re-update with remote peer */
 void engine_trigger_update(void)
 {

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.h
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.h
@@ -38,6 +38,7 @@
 #ifndef LWM2M_RD_CLIENT_H
 #define LWM2M_RD_CLIENT_H
 
+void engine_trigger_restart(void);
 void engine_trigger_update(void);
 #if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
 void engine_bootstrap_finish(void);


### PR DESCRIPTION
So far socket errors reported by poll/recvfrom were ignored, which could
lead to an unexpected behavior when socket was left in an undefined
state.

Fix this, by requesting a re-registration in the LWM2M state machine,
which will close the faulty socket and open a new one. Note, that simply
closing and re-opening a socket in the lwm2m engine would not work,
since this would silently invalidate any open observations on the
lwm2m server side (due to port number change). Triggering a fresh
registration will notify the server to update its observations.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>