### PR TITLE
soc: intel_s1000: fix SMP build error

### DIFF
--- a/soc/xtensa/intel_s1000/memory.h
+++ b/soc/xtensa/intel_s1000/memory.h
@@ -73,6 +73,6 @@
 #define LPRAM_SIZE				(DT_REG_SIZE(DT_NODELABEL(sram1)))
 
 /* Boot vector resideing in LP-SRAM for core #1 */
-#define LPSRAM_BOOT_VECTOR_ADDR			(LP_SRAM_BASE + 0x08)
+#define LPSRAM_BOOT_VECTOR_ADDR			(LPRAM_BASE + 0x08)
 
 #endif /* __INC_MEMORY_H */


### PR DESCRIPTION
During devicetree macro changes, LPSRAM_BOOT_VECTOR_ADDR
pointed to another macro which was renamed to a non-existent
one. Fix it so that SMP builds again.

Fixes #24720

Signed-off-by: Daniel Leung <daniel.leung@intel.com>