### PR TITLE
tests: Convert DT_ALIAS_* to new DT_ALIAS() macro

### DIFF
--- a/tests/bluetooth/mesh/src/microbit.c
+++ b/tests/bluetooth/mesh/src/microbit.c
@@ -30,15 +30,15 @@ static void configure_button(void)
 {
 	static struct gpio_callback button_cb;
 
-	gpio = device_get_binding(DT_ALIAS_SW0_GPIOS_CONTROLLER);
+	gpio = device_get_binding(DT_GPIO_LABEL(DT_ALIAS(sw0), gpios));
 
-	gpio_pin_configure(gpio, DT_ALIAS_SW0_GPIOS_PIN,
-			   DT_ALIAS_SW0_GPIOS_FLAGS | GPIO_INPUT);
+	gpio_pin_configure(gpio, DT_GPIO_PIN(DT_ALIAS(sw0), gpios),
+			   DT_GPIO_FLAGS(DT_ALIAS(sw0), gpios) | GPIO_INPUT);
 
 	gpio_init_callback(&button_cb, button_pressed,
-			   BIT(DT_ALIAS_SW0_GPIOS_PIN));
+			   BIT(DT_GPIO_PIN(DT_ALIAS(sw0), gpios)));
 
-	gpio_pin_interrupt_configure(gpio, DT_ALIAS_SW0_GPIOS_PIN,
+	gpio_pin_interrupt_configure(gpio, DT_GPIO_PIN(DT_ALIAS(sw0), gpios),
 				     GPIO_INT_EDGE_TO_ACTIVE);
 
 	gpio_add_callback(gpio, &button_cb);
@@ -55,7 +55,7 @@ void board_output_number(bt_mesh_output_action_t action, u32_t number)
 
 	oob_number = number;
 
-	gpio_pin_interrupt_configure(gpio, DT_ALIAS_SW0_GPIOS_PIN,
+	gpio_pin_interrupt_configure(gpio, DT_GPIO_PIN(DT_ALIAS(sw0), gpios),
 				     GPIO_INT_EDGE_TO_ACTIVE);
 
 	mb_display_image(disp, MB_DISPLAY_MODE_DEFAULT, K_FOREVER, &arrow, 1);
@@ -71,7 +71,7 @@ void board_prov_complete(void)
 					 { 0, 1, 1, 1, 0 });
 
 
-	gpio_pin_interrupt_configure(gpio, DT_ALIAS_SW0_GPIOS_PIN,
+	gpio_pin_interrupt_configure(gpio, DT_GPIO_PIN(DT_ALIAS(sw0), gpios),
 				     GPIO_INT_DISABLE);
 
 	mb_display_image(disp, MB_DISPLAY_MODE_DEFAULT, K_SECONDS(10),

--- a/tests/drivers/gpio/gpio_api_1pin/src/test_gpio_api.h
+++ b/tests/drivers/gpio/gpio_api_1pin/src/test_gpio_api.h
@@ -11,11 +11,11 @@
 #include <drivers/gpio.h>
 #include <ztest.h>
 
-#if defined(DT_ALIAS_LED0_GPIOS_CONTROLLER)
-#define TEST_DEV             DT_ALIAS_LED0_GPIOS_CONTROLLER
-#define TEST_PIN             DT_ALIAS_LED0_GPIOS_PIN
-#ifdef DT_ALIAS_LED0_GPIOS_FLAGS
-#define TEST_PIN_DTS_FLAGS   DT_ALIAS_LED0_GPIOS_FLAGS
+#if DT_NODE_HAS_PROP(DT_ALIAS(led0), gpios)
+#define TEST_DEV             DT_GPIO_LABEL(DT_ALIAS(led0), gpios)
+#define TEST_PIN             DT_GPIO_PIN(DT_ALIAS(led0), gpios)
+#if DT_PHA_HAS_CELL(DT_ALIAS(led0), gpios, flags)
+#define TEST_PIN_DTS_FLAGS   DT_GPIO_FLAGS(DT_ALIAS(led0), gpios)
 #else
 #define TEST_PIN_DTS_FLAGS   0
 #endif

--- a/tests/drivers/gpio/gpio_api_1pin/testcase.yaml
+++ b/tests/drivers/gpio/gpio_api_1pin/testcase.yaml
@@ -5,4 +5,4 @@ tests:
     min_flash: 48
     # Fix exclude when we can exclude just sim run
     platform_exclude: mps2_an385 mps2_an521
-    filter: DT_ALIAS_LED0_GPIOS_CONTROLLER
+    filter: dt_compat_enabled_with_alias("gpio-leds", "led0")

--- a/tests/drivers/gpio/gpio_basic_api/src/test_gpio.h
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_gpio.h
@@ -25,12 +25,12 @@
 #define PIN_OUT DT_GPIO_PIN(DT_INST(0, test_gpio_basic_api), out_gpios)
 #define PIN_IN DT_GPIO_PIN(DT_INST(0, test_gpio_basic_api), in_gpios)
 
-#elif defined(DT_ALIAS_GPIO_0_LABEL)
-#define DEV_NAME DT_ALIAS_GPIO_0_LABEL
-#elif defined(DT_ALIAS_GPIO_1_LABEL)
-#define DEV_NAME DT_ALIAS_GPIO_1_LABEL
-#elif defined(DT_ALIAS_GPIO_3_LABEL)
-#define DEV_NAME DT_ALIAS_GPIO_3_LABEL
+#elif DT_HAS_NODE(DT_ALIAS(gpio_0))
+#define DEV_NAME DT_LABEL(DT_ALIAS(gpio_0))
+#elif DT_HAS_NODE(DT_ALIAS(gpio_1))
+#define DEV_NAME DT_LABEL(DT_ALIAS(gpio_1))
+#elif DT_HAS_NODE(DT_ALIAS(gpio_3))
+#define DEV_NAME DT_LABEL(DT_ALIAS(gpio_3))
 #else
 #error Unsupported board
 #endif

--- a/tests/drivers/i2c/i2c_api/src/test_i2c.c
+++ b/tests/drivers/i2c/i2c_api/src/test_i2c.c
@@ -16,12 +16,12 @@
 #include <zephyr.h>
 #include <ztest.h>
 
-#if defined(DT_ALIAS_I2C_0_LABEL)
-#define I2C_DEV_NAME	DT_ALIAS_I2C_0_LABEL
-#elif defined(DT_ALIAS_I2C_1_LABEL)
-#define I2C_DEV_NAME	DT_ALIAS_I2C_1_LABEL
-#elif defined(DT_ALIAS_I2C_2_LABEL)
-#define I2C_DEV_NAME	DT_ALIAS_I2C_2_LABEL
+#if DT_HAS_NODE(DT_ALIAS(i2c_0))
+#define I2C_DEV_NAME	DT_LABEL(DT_ALIAS(i2c_0))
+#elif DT_HAS_NODE(DT_ALIAS(i2c_1))
+#define I2C_DEV_NAME	DT_LABEL(DT_ALIAS(i2c_1))
+#elif DT_HAS_NODE(DT_ALIAS(i2c_2))
+#define I2C_DEV_NAME	DT_LABEL(DT_ALIAS(i2c_2))
 #else
 #error "Please set the correct I2C device"
 #endif

--- a/tests/drivers/pwm/pwm_api/src/test_pwm.c
+++ b/tests/drivers/pwm/pwm_api/src/test_pwm.c
@@ -32,14 +32,14 @@
 #include <zephyr.h>
 #include <ztest.h>
 
-#if defined(DT_ALIAS_PWM_0_LABEL)
-#define PWM_DEV_NAME DT_ALIAS_PWM_0_LABEL
-#elif defined(DT_ALIAS_PWM_1_LABEL)
-#define PWM_DEV_NAME DT_ALIAS_PWM_1_LABEL
-#elif defined(DT_ALIAS_PWM_2_LABEL)
-#define PWM_DEV_NAME DT_ALIAS_PWM_2_LABEL
-#elif defined(DT_ALIAS_PWM_3_LABEL)
-#define PWM_DEV_NAME DT_ALIAS_PWM_3_LABEL
+#if DT_HAS_NODE(DT_ALIAS(pwm_0))
+#define PWM_DEV_NAME DT_LABEL(DT_ALIAS(pwm_0))
+#elif DT_HAS_NODE(DT_ALIAS(pwm_1))
+#define PWM_DEV_NAME DT_LABEL(DT_ALIAS(pwm_1))
+#elif DT_HAS_NODE(DT_ALIAS(pwm_2))
+#define PWM_DEV_NAME DT_LABEL(DT_ALIAS(pwm_2))
+#elif DT_HAS_NODE(DT_ALIAS(pwm_3))
+#define PWM_DEV_NAME DT_LABEL(DT_ALIAS(pwm_3))
 #else
 #error "Define a PWM device"
 #endif
@@ -63,7 +63,7 @@
 #if defined CONFIG_BOARD_SAM_E70_XPLAINED
 #define DEFAULT_PWM_PORT 2 /* PWM on EXT2 connector, pin 8 */
 #elif defined CONFIG_PWM_NRFX
-#define DEFAULT_PWM_PORT DT_ALIAS_PWM_0_CH0_PIN
+#define DEFAULT_PWM_PORT DT_PROP(DT_ALIAS(pwm_0), ch0_pin)
 #else
 #define DEFAULT_PWM_PORT 0
 #endif


### PR DESCRIPTION
Convert DT_ALIAS_* defines to use DT_ALIAS() plus other macros from
include/devicetree.h.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>