### PR TITLE
flash: sam0: set write_block_size=1 when EMULATE_BYTE_PAGES is set

### DIFF
--- a/drivers/flash/flash_sam0.c
+++ b/drivers/flash/flash_sam0.c
@@ -417,7 +417,11 @@ static const struct flash_driver_api flash_sam0_api = {
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
 	.page_layout = flash_sam0_page_layout,
 #endif
+#if CONFIG_SOC_FLASH_SAM0_EMULATE_BYTE_PAGES
+	.write_block_size = 1,
+#else
 	.write_block_size = FLASH_PAGE_SIZE,
+#endif
 };
 
 static struct flash_sam0_data flash_sam0_data_0;


### PR DESCRIPTION
The sam0 has a page size of 64 bytes, making it incompatible with
the nvs driver that specifies a maximum write block size of
32 bytes. When CONFIG_SOC_FLASH_SAM0_EMULATE_BYTE_PAGES is set,
it should report a write block size of 1 byte, which is compatible
with nvs.

Signed-off-by: Adam Serbinski <aserbinski@gmail.com>