### PR TITLE
drivers: usb: usb_dc_stm32: Rename defines to remove DT_ prefix

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -62,34 +62,40 @@ LOG_MODULE_REGISTER(usb_dc_stm32);
 #endif
 
 #if DT_HAS_COMPAT(st_stm32_otghs)
-#define DT_USB_BASE_ADDRESS		DT_REG_ADDR(DT_INST(0, st_stm32_otghs))
-#define DT_USB_IRQ			DT_IRQ_BY_NAME(DT_INST(0, st_stm32_otghs), otghs, irq)
-#define DT_USB_IRQ_PRI			DT_IRQ_BY_NAME(DT_INST(0, st_stm32_otghs), otghs, priority)
-#define DT_USB_NUM_BIDIR_ENDPOINTS	DT_PROP(DT_INST(0, st_stm32_otghs), num_bidir_endpoints)
-#define DT_USB_RAM_SIZE			DT_PROP(DT_INST(0, st_stm32_otghs), ram_size)
-#define DT_USB_MAXIMUM_SPEED		DT_PROP(DT_INST(0, st_stm32_otghs), maximum_speed)
-#define DT_USB_CLOCK_BITS		DT_CLOCKS_CELL(DT_INST(0, st_stm32_otghs), bits)
-#define DT_USB_CLOCK_BUS		DT_CLOCKS_CELL(DT_INST(0, st_stm32_otghs), bus)
+#define USB_BASE_ADDRESS	DT_REG_ADDR(DT_INST(0, st_stm32_otghs))
+#define USB_IRQ			DT_IRQ_BY_NAME(DT_INST(0, st_stm32_otghs), otghs, irq)
+#define USB_IRQ_PRI		DT_IRQ_BY_NAME(DT_INST(0, st_stm32_otghs), otghs, priority)
+#define USB_NUM_BIDIR_ENDPOINTS	DT_PROP(DT_INST(0, st_stm32_otghs), num_bidir_endpoints)
+#define USB_RAM_SIZE		DT_PROP(DT_INST(0, st_stm32_otghs), ram_size)
+#if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_otghs), maximum_speed)
+#define USB_MAXIMUM_SPEED	DT_PROP(DT_INST(0, st_stm32_otghs), maximum_speed)
+#endif
+#define USB_CLOCK_BITS		DT_CLOCKS_CELL(DT_INST(0, st_stm32_otghs), bits)
+#define USB_CLOCK_BUS		DT_CLOCKS_CELL(DT_INST(0, st_stm32_otghs), bus)
 #elif DT_HAS_COMPAT(st_stm32_otgfs)
-#define DT_USB_BASE_ADDRESS		DT_REG_ADDR(DT_INST(0, st_stm32_otgfs))
-#define DT_USB_IRQ			DT_IRQ_BY_NAME(DT_INST(0, st_stm32_otgfs), otgfs, irq)
-#define DT_USB_IRQ_PRI			DT_IRQ_BY_NAME(DT_INST(0, st_stm32_otgfs), otgfs, priority)
-#define DT_USB_NUM_BIDIR_ENDPOINTS	DT_PROP(DT_INST(0, st_stm32_otgfs), num_bidir_endpoints)
-#define DT_USB_RAM_SIZE			DT_PROP(DT_INST(0, st_stm32_otgfs), ram_size)
-#define DT_USB_MAXIMUM_SPEED		DT_PROP(DT_INST(0, st_stm32_otgfs), maximum_speed)
-#define DT_USB_CLOCK_BITS		DT_CLOCKS_CELL(DT_INST(0, st_stm32_otgfs), bits)
-#define DT_USB_CLOCK_BUS		DT_CLOCKS_CELL(DT_INST(0, st_stm32_otgfs), bus)
+#define USB_BASE_ADDRESS	DT_REG_ADDR(DT_INST(0, st_stm32_otgfs))
+#define USB_IRQ			DT_IRQ_BY_NAME(DT_INST(0, st_stm32_otgfs), otgfs, irq)
+#define USB_IRQ_PRI		DT_IRQ_BY_NAME(DT_INST(0, st_stm32_otgfs), otgfs, priority)
+#define USB_NUM_BIDIR_ENDPOINTS	DT_PROP(DT_INST(0, st_stm32_otgfs), num_bidir_endpoints)
+#define USB_RAM_SIZE		DT_PROP(DT_INST(0, st_stm32_otgfs), ram_size)
+#if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_otgfs), maximum_speed)
+#define USB_MAXIMUM_SPEED	DT_PROP(DT_INST(0, st_stm32_otgfs), maximum_speed)
+#endif
+#define USB_CLOCK_BITS		DT_CLOCKS_CELL(DT_INST(0, st_stm32_otgfs), bits)
+#define USB_CLOCK_BUS		DT_CLOCKS_CELL(DT_INST(0, st_stm32_otgfs), bus)
 #elif DT_HAS_COMPAT(st_stm32_usb)
-#define DT_USB_BASE_ADDRESS		DT_REG_ADDR(DT_INST(0, st_stm32_usb))
-#define DT_USB_IRQ			DT_IRQ_BY_NAME(DT_INST(0, st_stm32_usb), usb, irq)
-#define DT_USB_IRQ_PRI			DT_IRQ_BY_NAME(DT_INST(0, st_stm32_usb), usb, priority)
-#define DT_USB_NUM_BIDIR_ENDPOINTS	DT_PROP(DT_INST(0, st_stm32_usb), num_bidir_endpoints)
-#define DT_USB_RAM_SIZE			DT_PROP(DT_INST(0, st_stm32_usb), ram_size)
-#define DT_USB_MAXIMUM_SPEED		DT_PROP(DT_INST(0, st_stm32_usb), maximum_speed)
-#define DT_USB_CLOCK_BITS		DT_CLOCKS_CELL(DT_INST(0, st_stm32_usb), bits)
-#define DT_USB_CLOCK_BUS		DT_CLOCKS_CELL(DT_INST(0, st_stm32_usb), bus)
+#define USB_BASE_ADDRESS	DT_REG_ADDR(DT_INST(0, st_stm32_usb))
+#define USB_IRQ			DT_IRQ_BY_NAME(DT_INST(0, st_stm32_usb), usb, irq)
+#define USB_IRQ_PRI		DT_IRQ_BY_NAME(DT_INST(0, st_stm32_usb), usb, priority)
+#define USB_NUM_BIDIR_ENDPOINTS	DT_PROP(DT_INST(0, st_stm32_usb), num_bidir_endpoints)
+#define USB_RAM_SIZE		DT_PROP(DT_INST(0, st_stm32_usb), ram_size)
+#if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_usb), maximum_speed)
+#define USB_MAXIMUM_SPEED	DT_PROP(DT_INST(0, st_stm32_usb), maximum_speed)
+#endif
+#define USB_CLOCK_BITS		DT_CLOCKS_CELL(DT_INST(0, st_stm32_usb), bits)
+#define USB_CLOCK_BUS		DT_CLOCKS_CELL(DT_INST(0, st_stm32_usb), bus)
 #if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_usb), enable_pin_remap)
-#define DT_USB_ENABLE_PIN_REMAP		DT_PROP(DT_INST(0, st_stm32_usb), enable_pin_remap)
+#define USB_ENABLE_PIN_REMAP	DT_PROP(DT_INST(0, st_stm32_usb), enable_pin_remap)
 #endif
 #endif
 
@@ -112,7 +118,7 @@ LOG_MODULE_REGISTER(usb_dc_stm32);
  * per endpoint.
  *
  */
-#define USB_BTABLE_SIZE  (8 * DT_USB_NUM_BIDIR_ENDPOINTS)
+#define USB_BTABLE_SIZE  (8 * USB_NUM_BIDIR_ENDPOINTS)
 
 #else /* USB_OTG_FS */
 
@@ -134,10 +140,10 @@ LOG_MODULE_REGISTER(usb_dc_stm32);
 #endif
 
 /* We need one RX FIFO and n TX-IN FIFOs */
-#define FIFO_NUM (1 + DT_USB_NUM_BIDIR_ENDPOINTS)
+#define FIFO_NUM (1 + USB_NUM_BIDIR_ENDPOINTS)
 
 /* 4-byte words FIFO */
-#define FIFO_WORDS (DT_USB_RAM_SIZE / 4)
+#define FIFO_WORDS (USB_RAM_SIZE / 4)
 
 /* Allocate FIFO memory evenly between the FIFOs */
 #define FIFO_EP_WORDS (FIFO_WORDS / FIFO_NUM)
@@ -172,9 +178,9 @@ struct usb_dc_stm32_ep_state {
 struct usb_dc_stm32_state {
 	PCD_HandleTypeDef pcd;	/* Storage for the HAL_PCD api */
 	usb_dc_status_callback status_cb; /* Status callback */
-	struct usb_dc_stm32_ep_state out_ep_state[DT_USB_NUM_BIDIR_ENDPOINTS];
-	struct usb_dc_stm32_ep_state in_ep_state[DT_USB_NUM_BIDIR_ENDPOINTS];
-	u8_t ep_buf[DT_USB_NUM_BIDIR_ENDPOINTS][EP_MPS];
+	struct usb_dc_stm32_ep_state out_ep_state[USB_NUM_BIDIR_ENDPOINTS];
+	struct usb_dc_stm32_ep_state in_ep_state[USB_NUM_BIDIR_ENDPOINTS];
+	u8_t ep_buf[USB_NUM_BIDIR_ENDPOINTS][EP_MPS];
 
 #ifdef USB
 	u32_t pma_offset;
@@ -189,7 +195,7 @@ static struct usb_dc_stm32_ep_state *usb_dc_stm32_get_ep_state(u8_t ep)
 {
 	struct usb_dc_stm32_ep_state *ep_state_base;
 
-	if (EP_IDX(ep) >= DT_USB_NUM_BIDIR_ENDPOINTS) {
+	if (EP_IDX(ep) >= USB_NUM_BIDIR_ENDPOINTS) {
 		return NULL;
 	}
 
@@ -218,8 +224,8 @@ static int usb_dc_stm32_clock_enable(void)
 {
 	struct device *clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
 	struct stm32_pclken pclken = {
-		.bus = DT_USB_CLOCK_BUS,
-		.enr = DT_USB_CLOCK_BITS,
+		.bus = USB_CLOCK_BUS,
+		.enr = USB_CLOCK_BITS,
 	};
 
 	/*
@@ -310,11 +316,11 @@ static u32_t usb_dc_stm32_get_maximum_speed(void)
 	u32_t speed = USB_OTG_SPEED_FULL;
 #endif
 
-#ifdef DT_USB_MAXIMUM_SPEED
+#ifdef USB_MAXIMUM_SPEED
 
-	if (!strncmp(DT_USB_MAXIMUM_SPEED, "high-speed", 10)) {
+	if (!strncmp(USB_MAXIMUM_SPEED, "high-speed", 10)) {
 		speed = USB_OTG_SPEED_HIGH;
-	} else if (!strncmp(DT_USB_MAXIMUM_SPEED, "full-speed", 10)) {
+	} else if (!strncmp(USB_MAXIMUM_SPEED, "full-speed", 10)) {
 #if DT_HAS_COMPAT(st_stm32_usbphyc) && DT_HAS_COMPAT(st_stm32_otghs)
 		speed = USB_OTG_SPEED_HIGH_IN_FULL;
 #else
@@ -325,7 +331,7 @@ static u32_t usb_dc_stm32_get_maximum_speed(void)
 			"USB controller will default to its maximum HW "
 			"capability");
 	}
-#endif /* DT_USB_MAXIMUM_SPEED */
+#endif
 
 	return speed;
 }
@@ -339,7 +345,7 @@ static int usb_dc_stm32_init(void)
 #ifdef USB
 	usb_dc_stm32_state.pcd.Instance = USB;
 	usb_dc_stm32_state.pcd.Init.speed = PCD_SPEED_FULL;
-	usb_dc_stm32_state.pcd.Init.dev_endpoints = DT_USB_NUM_BIDIR_ENDPOINTS;
+	usb_dc_stm32_state.pcd.Init.dev_endpoints = USB_NUM_BIDIR_ENDPOINTS;
 	usb_dc_stm32_state.pcd.Init.phy_itface = PCD_PHY_EMBEDDED;
 	usb_dc_stm32_state.pcd.Init.ep0_mps = PCD_EP0MPS_64;
 	usb_dc_stm32_state.pcd.Init.low_power_enable = 0;
@@ -349,7 +355,7 @@ static int usb_dc_stm32_init(void)
 #else
 	usb_dc_stm32_state.pcd.Instance = USB_OTG_FS;
 #endif
-	usb_dc_stm32_state.pcd.Init.dev_endpoints = DT_USB_NUM_BIDIR_ENDPOINTS;
+	usb_dc_stm32_state.pcd.Init.dev_endpoints = USB_NUM_BIDIR_ENDPOINTS;
 	usb_dc_stm32_state.pcd.Init.speed = usb_dc_stm32_get_maximum_speed();
 #if DT_HAS_COMPAT(st_stm32_usbphyc) && DT_HAS_COMPAT(st_stm32_otghs)
 	usb_dc_stm32_state.pcd.Init.phy_itface = USB_OTG_HS_EMBEDDED_PHY;
@@ -392,22 +398,22 @@ static int usb_dc_stm32_init(void)
 	/* Start PMA configuration for the endpoints after the BTABLE. */
 	usb_dc_stm32_state.pma_offset = USB_BTABLE_SIZE;
 
-	for (i = 0U; i < DT_USB_NUM_BIDIR_ENDPOINTS; i++) {
+	for (i = 0U; i < USB_NUM_BIDIR_ENDPOINTS; i++) {
 		k_sem_init(&usb_dc_stm32_state.in_ep_state[i].write_sem, 1, 1);
 	}
 #else /* USB_OTG_FS */
 	/* TODO: make this dynamic (depending usage) */
 	HAL_PCDEx_SetRxFiFo(&usb_dc_stm32_state.pcd, FIFO_EP_WORDS);
-	for (i = 0U; i < DT_USB_NUM_BIDIR_ENDPOINTS; i++) {
+	for (i = 0U; i < USB_NUM_BIDIR_ENDPOINTS; i++) {
 		HAL_PCDEx_SetTxFiFo(&usb_dc_stm32_state.pcd, i,
 				    FIFO_EP_WORDS);
 		k_sem_init(&usb_dc_stm32_state.in_ep_state[i].write_sem, 1, 1);
 	}
 #endif /* USB */
 
-	IRQ_CONNECT(DT_USB_IRQ, DT_USB_IRQ_PRI,
+	IRQ_CONNECT(USB_IRQ, USB_IRQ_PRI,
 		    usb_dc_stm32_isr, 0, 0);
-	irq_enable(DT_USB_IRQ);
+	irq_enable(USB_IRQ);
 	return 0;
 }
 
@@ -437,7 +443,7 @@ int usb_dc_attach(void)
 	 * For STM32F0 series SoCs on QFN28 and TSSOP20 packages enable PIN
 	 * pair PA11/12 mapped instead of PA9/10 (e.g. stm32f070x6)
 	 */
-#if DT_USB_ENABLE_PIN_REMAP == 1
+#if USB_ENABLE_PIN_REMAP == 1
 	if (LL_APB1_GRP2_IsEnabledClock(LL_APB1_GRP2_PERIPH_SYSCFG)) {
 		LL_SYSCFG_EnablePinRemap();
 	} else {
@@ -565,7 +571,7 @@ int usb_dc_ep_check_cap(const struct usb_dc_ep_cfg_data * const cfg)
 		return -1;
 	}
 
-	if (ep_idx > (DT_USB_NUM_BIDIR_ENDPOINTS - 1)) {
+	if (ep_idx > (USB_NUM_BIDIR_ENDPOINTS - 1)) {
 		LOG_ERR("endpoint index/address out of range");
 		return -1;
 	}
@@ -588,7 +594,7 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data * const ep_cfg)
 
 #ifdef USB
 	if (ep_cfg->ep_mps > ep_state->ep_pma_buf_len) {
-		if (DT_USB_RAM_SIZE <=
+		if (USB_RAM_SIZE <=
 		    (usb_dc_stm32_state.pma_offset + ep_cfg->ep_mps)) {
 			return -EINVAL;
 		}
@@ -756,7 +762,7 @@ int usb_dc_ep_write(const u8_t ep, const u8_t *const data,
 	}
 
 	if (!k_is_in_isr()) {
-		irq_disable(DT_USB_IRQ);
+		irq_disable(USB_IRQ);
 	}
 
 	if (ep == EP0_IN && len > USB_MAX_CTRL_MPS) {
@@ -780,7 +786,7 @@ int usb_dc_ep_write(const u8_t ep, const u8_t *const data,
 	}
 
 	if (!k_is_in_isr()) {
-		irq_enable(DT_USB_IRQ);
+		irq_enable(USB_IRQ);
 	}
 
 	if (!ret && ret_bytes) {
@@ -924,7 +930,7 @@ void HAL_PCD_ResetCallback(PCD_HandleTypeDef *hpcd)
 	/* The DataInCallback will never be called at this point for any pending
 	 * transactions. Reset the IN semaphores to prevent perpetual locked state.
 	 * */
-	for (i = 0; i < DT_USB_NUM_BIDIR_ENDPOINTS; i++) {
+	for (i = 0; i < USB_NUM_BIDIR_ENDPOINTS; i++) {
 		k_sem_give(&usb_dc_stm32_state.in_ep_state[i].write_sem);
 	}
 


### PR DESCRIPTION
We want to limit DT_ prefix to macros from devicetree.h and generation.
So rename DT_USB* to just USB*.

Also fixup how USB_MAXIMUM_SPEED was defined.  We should only define it
if the property exists.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>