### PR TITLE
soc: stm32: stm32f1: adc: Remove use of DT_FOO_LABEL defines

### DIFF
--- a/soc/arm/st_stm32/stm32f1/dts_fixup.h
+++ b/soc/arm/st_stm32/stm32f1/dts_fixup.h
@@ -2,6 +2,6 @@
 
 /* SoC level DTS fixup file */
 
-#define DT_ADC_1_NAME			DT_ST_STM32_ADC_40012400_LABEL
+#define DT_ADC_0_NAME			DT_LABEL(DT_INST(0, st_stm32_adc))
 
 /* End of SoC Level DTS fixup file */


### PR DESCRIPTION
Complete STM32 conversion to new DT macros by removing
remaining occurences of DT_ST_STM32_ADC_FOO_LABEL.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>