### PR TITLE
posix arch: support building on aarch64 / allow host-specific cmake includes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -417,6 +417,7 @@
 /scripts/west_commands/                   @mbolivar-nordic
 /scripts/west-commands.yml                @mbolivar-nordic
 /scripts/zephyr_module.py                 @tejlmand
+/scripts/user_wordsize.py                 @cfriedt
 /scripts/valgrind.supp                    @aescolar @daor-oti
 /share/zephyr-package/                    @tejlmand
 /share/zephyrunittest-package/            @tejlmand

--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -1,13 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
-if (CONFIG_64BIT)
-	# some gcc versions fail to build without -fPIC
-	zephyr_compile_options(-m64 -fPIC)
-	zephyr_link_libraries(-m64)
-else ()
-	zephyr_compile_options(-m32)
-	zephyr_link_libraries(-m32)
-endif ()
+if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/${CMAKE_HOST_SYSTEM_NAME}.${CMAKE_HOST_SYSTEM_PROCESSOR}.cmake)
+  # @Intent: Set necessary compiler & linker options for this specific host architecture & OS
+  include(${CMAKE_HOST_SYSTEM_NAME}.${CMAKE_HOST_SYSTEM_PROCESSOR}.cmake)
+else()
+  if (CONFIG_64BIT)
+    # some gcc versions fail to build without -fPIC
+    zephyr_compile_options(-m64 -fPIC)
+    zephyr_link_libraries(-m64)
+  else ()
+    zephyr_compile_options(-m32)
+    zephyr_link_libraries(-m32)
+  endif ()
+endif()
 
 zephyr_compile_options(
   ${ARCH_FLAG}

--- a/arch/posix/Linux.aarch64.cmake
+++ b/arch/posix/Linux.aarch64.cmake
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# For Aarch64, multilib is not an actively pursued solution for most Linux
+# distributions. Userspace is (generally) either 32-bit or 64-bit but not
+# both.
+
+# @Intent: Call a script to get userspace wordsize for comparison with CONFIG_64BIT
+execute_process(
+  COMMAND
+  ${PYTHON_EXECUTABLE}
+  ${ZEPHYR_BASE}/scripts/user_wordsize.py
+  OUTPUT_VARIABLE
+  WORDSIZE
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if (CONFIG_64BIT)
+  if (${WORDSIZE} STREQUAL "32")
+    message(FATAL_ERROR
+      "CONFIG_64BIT=y but this Aarch64 machine has a 32-bit userspace.\n"
+      "If you were targeting native_posix_64, target native_posix instead.\n"
+      "Otherwise, be sure to define CONFIG_64BIT appropriately.\n"
+    )
+  endif()
+  zephyr_compile_options(-fPIC)
+else ()
+  if (${WORDSIZE} STREQUAL "64")
+    message(FATAL_ERROR
+      "CONFIG_64BIT=n but this Aarch64 machine has a 64-bit userspace.\n"
+      "If you were targeting native_posix, target native_posix_64 instead.\n"
+      "Otherwise, be sure to define CONFIG_64BIT appropriately.\n"
+    )
+  endif()
+endif ()

--- a/scripts/user_wordsize.py
+++ b/scripts/user_wordsize.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2020, Friedt Professional Engineering Services, Inc
+#
+# SPDX-License-Identifier: Apache-2.0
+import struct
+import sys
+
+def main():
+    print(struct.calcsize("P") * 8)
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This change enables specific compiler and linker options to be used in the case that an `arch/posix/os.arch.cmake` file exists.

Note: os and arch in the above case are evaluations of [CMAKE_HOST_SYSTEM_NAME](https://cmake.org/cmake/help/latest/variable/CMAKE_HOST_SYSTEM_NAME.html) and [CMAKE_HOST_SYSTEM_PROCESSOR](https://cmake.org/cmake/help/latest/variable/CMAKE_HOST_SYSTEM_PROCESSOR.html).

Otherwise, the existing "generic" compiler and linker flags in `arch/posix/CMakeLists.txt` are used.

Additional flags and checks are provided in `arch/posix/Linux.aarch64.cmake`.
    
Added `scripts/user_wordsize.py` to detect if userspace is 64-bit or 32-bit, which should be consistent with the value of `CONFIG_64BIT` for Aarch64 on Linux.
    
Fixes #24842

Output on Aarch64 with 64-bit userspace

Before (`-m32` is an x86 option for gcc):
```bash
gcc: error: unrecognized command line option ‘-m32’
ninja: build stopped: subcommand failed.
FATAL ERROR: command exited with status 1: /usr/local/bin/cmake --build /home/chrisfriedt/workspace/zephyrproject/zephyr/build --target run
```
After (notice informative message):
```
CMake Error at ../../../../arch/posix/Linux.aarch64.cmake:27 (message):
  CONFIG_64BIT=n but this Aarch64 machine has a 64-bit userspace.

  If using cmake, consider using '-DBOARD=native_posix_64'

  If using west, consider using '-b native_posix_64'
```

After (with flags):
```
west build -b native_posix_64 tests/kernel/pipe/pipe_api -t run
...
Test suite pipe_api succeeded
===================================================================
PROJECT EXECUTION SUCCESSFUL
```