### PR TITLE
move syst initialization code to zephyr tree and Add more useful fields in SyS-T message packet

### DIFF
--- a/subsys/logging/log_output_syst.c
+++ b/subsys/logging/log_output_syst.c
@@ -4,18 +4,162 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <init.h>
 #include <stdio.h>
 #include <ctype.h>
 #include <assert.h>
+#include <kernel.h>
 #include <mipi_syst.h>
 #include <logging/log.h>
 #include <logging/log_ctrl.h>
 #include <logging/log_output.h>
 
-extern struct mipi_syst_handle log_syst_handle;
-extern void update_systh_platform_data(
-		struct mipi_syst_handle *handle,
-		const struct log_output *log_output, u32_t flag);
+static struct mipi_syst_header log_syst_header;
+static struct mipi_syst_handle log_syst_handle;
+
+#if defined(MIPI_SYST_PCFG_ENABLE_PLATFORM_STATE_DATA)
+static const char pattern[] = "SYS-T RAW DATA: ";
+static const char valToHex[] = "0123456789ABCDEF";
+
+static int out_func(int c, void *ctx)
+{
+	const struct log_output *out_ctx = (const struct log_output *)ctx;
+
+	out_ctx->buf[out_ctx->control_block->offset] = (u8_t)c;
+	out_ctx->control_block->offset++;
+
+	__ASSERT_NO_MSG(out_ctx->control_block->offset <= out_ctx->size);
+
+	if (out_ctx->control_block->offset == out_ctx->size) {
+		log_output_flush(out_ctx);
+	}
+
+	return 0;
+}
+
+static void write_raw(struct mipi_syst_handle *systh, const void *p, int n)
+{
+	int i;
+	u8_t c;
+
+#if defined(MIPI_SYST_BIG_ENDIAN)
+	for (i = n - 1; i >= 0; --i) {
+#else
+	for (i = 0; i < n; ++i) {
+#endif
+		c = ((const u8_t *)p)[i];
+		out_func(valToHex[c >> 0x4], systh->systh_platform.log_output);
+		out_func(valToHex[c & 0xF], systh->systh_platform.log_output);
+	}
+}
+
+static void write_d8(struct mipi_syst_handle *systh, u8_t v)
+{
+	write_raw(systh, &v, sizeof(v));
+}
+
+static void write_d16(struct mipi_syst_handle *systh, u16_t v)
+{
+	write_raw(systh, &v, sizeof(v));
+}
+
+static void write_d32(struct mipi_syst_handle *systh, u32_t v)
+{
+	write_raw(systh, &v, sizeof(v));
+}
+
+#if defined(MIPI_SYST_PCFG_ENABLE_64BIT_IO)
+static void write_d64(struct mipi_syst_handle *systh, u64_t v)
+{
+	write_raw(systh, &v, sizeof(v));
+}
+#endif
+
+static void write_d32ts(struct mipi_syst_handle *systh, u32_t v)
+{
+	for (int i = 0; i < strlen(pattern); i++) {
+		out_func(pattern[i], systh->systh_platform.log_output);
+	}
+
+	write_raw(systh, &v, sizeof(v));
+}
+
+static void write_flag(struct mipi_syst_handle *systh)
+{
+	u32_t flag = systh->systh_platform.flag;
+
+	if ((flag & LOG_OUTPUT_FLAG_CRLF_NONE) != 0U) {
+		return;
+	}
+
+	if ((flag & LOG_OUTPUT_FLAG_CRLF_LFONLY) != 0U) {
+		out_func('\n', systh->systh_platform.log_output);
+	} else {
+		out_func('\r', systh->systh_platform.log_output);
+		out_func('\n', systh->systh_platform.log_output);
+	}
+}
+#endif
+
+#if defined(MIPI_SYST_PCFG_ENABLE_TIMESTAMP)
+mipi_syst_u64 mipi_syst_get_epoch(void)
+{
+	return k_uptime_ticks();
+}
+#endif
+
+static void update_systh_platform_data(struct mipi_syst_handle *handle,
+				       const struct log_output *log_output,
+				       u32_t flag)
+{
+#if defined(MIPI_SYST_PCFG_ENABLE_PLATFORM_STATE_DATA)
+	handle->systh_platform.flag = (mipi_syst_u32)flag;
+	handle->systh_platform.log_output = (struct log_output *)log_output;
+#endif
+}
+
+#if defined(MIPI_SYST_PCFG_ENABLE_PLATFORM_HANDLE_DATA)
+/*
+ * Platform specific SyS-T handle initialization hook function
+ *
+ * @param systh pointer to the SyS-T handle structure
+ */
+static void platform_handle_init(struct mipi_syst_handle *systh)
+{
+	ARG_UNUSED(systh);
+}
+
+static void platform_handle_release(struct mipi_syst_handle *systh)
+{
+	ARG_UNUSED(systh);
+}
+#endif
+
+/*
+ * Platform specific global state initialization hook function
+ *
+ * @param systh pointer to the new SyS-T handle structure
+ * @param platform_data user defined data for the init function.
+ *
+ */
+static void mipi_syst_platform_init(struct mipi_syst_header *systh,
+				    const void *platform_data)
+{
+#if defined(MIPI_SYST_PCFG_ENABLE_PLATFORM_HANDLE_DATA)
+	systh->systh_inith = platform_handle_init;
+	systh->systh_releaseh = platform_handle_release;
+#endif
+#if defined(MIPI_SYST_PCFG_ENABLE_PLATFORM_STATE_DATA)
+	systh->systh_platform.write_d8 = write_d8;
+	systh->systh_platform.write_d16 = write_d16;
+	systh->systh_platform.write_d32 = write_d32;
+#if defined(MIPI_SYST_PCFG_ENABLE_64BIT_IO)
+	systh->systh_platform.write_d64 = write_d64;
+#endif
+	systh->systh_platform.write_d32ts = write_d32ts;
+	systh->systh_platform.write_flag = write_flag;
+#endif
+}
 
 /*
  *    0   MIPI_SYST_SEVERITY_MAX      no assigned severity
@@ -219,3 +363,18 @@ void log_output_hexdump_syst_process(const struct log_output *log_output,
 
 	MIPI_SYST_WRITE(&log_syst_handle, severity, 0x1A, data, length);
 }
+
+static int syst_init(struct device *arg)
+{
+	ARG_UNUSED(arg);
+
+	MIPI_SYST_INIT_STATE(&log_syst_header,
+			     mipi_syst_platform_init, (void *)0);
+
+	MIPI_SYST_INIT_HANDLE_STATE(&log_syst_header,
+				    &log_syst_handle, NULL);
+
+	return 0;
+}
+
+SYS_INIT(syst_init, POST_KERNEL, 0);

--- a/subsys/logging/log_output_syst.c
+++ b/subsys/logging/log_output_syst.c
@@ -126,7 +126,9 @@ static void update_systh_platform_data(struct mipi_syst_handle *handle,
  */
 static void platform_handle_init(struct mipi_syst_handle *systh)
 {
-	ARG_UNUSED(systh);
+#if defined(MIPI_SYST_PCFG_LENGTH_FIELD)
+	MIPI_SYST_ENABLE_HANDLE_LENGTH(systh, 1);
+#endif
 }
 
 static void platform_handle_release(struct mipi_syst_handle *systh)

--- a/subsys/logging/log_output_syst.c
+++ b/subsys/logging/log_output_syst.c
@@ -129,6 +129,10 @@ static void platform_handle_init(struct mipi_syst_handle *systh)
 #if defined(MIPI_SYST_PCFG_LENGTH_FIELD)
 	MIPI_SYST_ENABLE_HANDLE_LENGTH(systh, 1);
 #endif
+
+#if defined(MIPI_SYST_PCFG_ENABLE_TIMESTAMP)
+	MIPI_SYST_ENABLE_HANDLE_TIMESTAMP(systh, 1);
+#endif
 }
 
 static void platform_handle_release(struct mipi_syst_handle *systh)

--- a/west.yml
+++ b/west.yml
@@ -117,7 +117,7 @@ manifest:
       revision: 0aefdda69d236cb01f932117c1f32e9da09c0ec3
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t
-      revision: baf51863f19f009b92e762115ba5572a5b996b92
+      revision: 957d46bc3ce0d5f628f0d525196bb4db207672ee
     - name: nrf_hw_models
       path: modules/bsim_hw_models/nrf_hw_models
       revision: fec69703cb1ca06fcdab6d5fde01274f0fc5c759


### PR DESCRIPTION
1. move syst initialization code to zephyr tree
2. Add more useful fields (payload length and timestamp) in SyS-T message packet.

Signed-off-by: Wentong Wu <wentong.wu@intel.com>