### PR TITLE
drivers: add GIC V3 driver

### DIFF
--- a/drivers/interrupt_controller/CMakeLists.txt
+++ b/drivers/interrupt_controller/CMakeLists.txt
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_sources_ifdef(CONFIG_ARCV2_INTERRUPT_UNIT    intc_arcv2_irq_unit.c)
-zephyr_sources_ifdef(CONFIG_GIC                     intc_gic.c)
+zephyr_sources_ifdef(CONFIG_GIC_V1                  intc_gic.c)
+zephyr_sources_ifdef(CONFIG_GIC_V2                  intc_gic.c)
+zephyr_sources_ifdef(CONFIG_GIC_V3                  intc_gicv3.c)
 zephyr_sources_ifdef(CONFIG_IOAPIC                  intc_ioapic.c)
 zephyr_sources_ifdef(CONFIG_LOAPIC                  intc_loapic.c intc_system_apic.c)
 zephyr_sources_ifdef(CONFIG_LOAPIC_SPURIOUS_VECTOR  intc_loapic_spurious.S)

--- a/drivers/interrupt_controller/intc_gic.c
+++ b/drivers/interrupt_controller/intc_gic.c
@@ -7,17 +7,12 @@
  */
 
 /*
- * NOTE: This driver currently implements the GICv1 and GICv2 interfaces. The
- *       GICv3 interface is not supported.
+ * NOTE: This driver implements the GICv1 and GICv2 interfaces.
  */
 
 #include <sw_isr_table.h>
 #include <dt-bindings/interrupt-controller/arm-gic.h>
 #include <drivers/interrupt_controller/gic.h>
-
-#if CONFIG_GIC_VER >= 3
-#error "GICv3 and above are not supported"
-#endif
 
 void arm_gic_irq_enable(unsigned int irq)
 {

--- a/drivers/interrupt_controller/intc_gic_common_priv.h
+++ b/drivers/interrupt_controller/intc_gic_common_priv.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Broadcom
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_INTC_GIC_COMMON_PRIV_H_
+#define ZEPHYR_INCLUDE_DRIVERS_INTC_GIC_COMMON_PRIV_H_
+
+/* Offsets from GICD base or GICR(n) SGI_base */
+#define GIC_DIST_IGROUPR		0x0080
+#define GIC_DIST_ISENABLER		0x0100
+#define GIC_DIST_ICENABLER		0x0180
+#define GIC_DIST_ISPENDR		0x0200
+#define GIC_DIST_ICPENDR		0x0280
+#define GIC_DIST_ISACTIVER		0x0300
+#define GIC_DIST_ICACTIVER		0x0380
+#define GIC_DIST_IPRIORITYR		0x0400
+#define GIC_DIST_ITARGETSR		0x0800
+#define GIC_DIST_ICFGR			0x0c00
+#define GIC_DIST_IGROUPMODR		0x0d00
+#define GIC_DIST_SGIR			0x0f00
+
+/* GICD GICR common access macros */
+#define IGROUPR(base, n)		(base + GIC_DIST_IGROUPR + (n) * 4)
+#define ISENABLER(base, n)		(base + GIC_DIST_ISENABLER + (n) * 4)
+#define ICENABLER(base, n)		(base + GIC_DIST_ICENABLER + (n) * 4)
+#define ISPENDR(base, n)		(base + GIC_DIST_ISPENDR + (n) * 4)
+#define ICPENDR(base, n)		(base + GIC_DIST_ICPENDR + (n) * 4)
+#define IPRIORITYR(base, n)		(base + GIC_DIST_IPRIORITYR + n)
+#define ITARGETSR(base, n)		(base + GIC_DIST_ITARGETSR + (n) * 4)
+#define ICFGR(base, n)			(base + GIC_DIST_ICFGR + (n) * 4)
+#define IGROUPMODR(base, n)		(base + GIC_DIST_IGROUPMODR + (n) * 4)
+
+/*
+ * selects redistributor SGI_base for current core for PPI and SGI
+ * selects distributor base for SPI
+ * The macro translates to distributor base for GICv2 and GICv1
+ */
+
+#if CONFIG_GIC_VER <= 2
+#define GET_DIST_BASE(intid)	GIC_DIST_BASE
+#else
+#define GET_DIST_BASE(intid)	((intid < GIC_SPI_INT_BASE) ? \
+				(GIC_GET_RDIST(GET_CPUID) + GICR_SGI_BASE_OFF) \
+				: GIC_DIST_BASE)
+#endif
+#endif /* ZEPHYR_INCLUDE_DRIVERS_INTC_GIC_COMMON_PRIV_H */

--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2020 Broadcom
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <assert.h>
+#include <sw_isr_table.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <drivers/interrupt_controller/gic.h>
+#include "intc_gic_common_priv.h"
+#include "intc_gicv3_priv.h"
+
+/* Redistributor base addresses for each core */
+mem_addr_t gic_rdists[GIC_NUM_CPU_IF];
+
+/*
+ * Wait for register write pending
+ * TODO: add timed wait
+ */
+static int gic_wait_rwp(u32_t intid)
+{
+	u32_t rwp_mask;
+	mem_addr_t base;
+
+	if (intid < GIC_SPI_INT_BASE) {
+		base = (GIC_GET_RDIST(GET_CPUID) + GICR_CTLR);
+		rwp_mask = BIT(GICR_CTLR_RWP);
+	} else {
+		base = GICD_CTLR;
+		rwp_mask = BIT(GICD_CTLR_RWP);
+	}
+
+	while (sys_read32(base) & rwp_mask)
+		;
+
+	return 0;
+}
+
+void arm_gic_irq_set_priority(unsigned int intid,
+			      unsigned int prio, u32_t flags)
+{
+	u32_t mask = BIT(intid & (GIC_NUM_INTR_PER_REG - 1));
+	u32_t idx = intid / GIC_NUM_INTR_PER_REG;
+	u32_t shift;
+	u32_t val;
+	mem_addr_t base = GET_DIST_BASE(intid);
+
+	/* Disable the interrupt */
+	sys_write32(mask, ICENABLER(base, idx));
+	gic_wait_rwp(intid);
+
+	/* PRIORITYR registers provide byte access */
+	sys_write8(prio & GIC_PRI_MASK, IPRIORITYR(base, intid));
+
+	/* Interrupt type config */
+	idx = intid / GIC_NUM_CFG_PER_REG;
+	shift = (intid & (GIC_NUM_CFG_PER_REG - 1)) * 2;
+
+	val = sys_read32(ICFGR(base, idx));
+	val &= ~(GICD_ICFGR_MASK << shift);
+	if (flags & IRQ_TYPE_EDGE) {
+		val |= (GICD_ICFGR_TYPE << shift);
+	}
+	sys_write32(val, ICFGR(base, idx));
+}
+
+void arm_gic_irq_enable(unsigned int intid)
+{
+	u32_t mask = BIT(intid & (GIC_NUM_INTR_PER_REG - 1));
+	u32_t idx = intid / GIC_NUM_INTR_PER_REG;
+
+	sys_write32(mask, ISENABLER(GET_DIST_BASE(intid), idx));
+}
+
+void arm_gic_irq_disable(unsigned int intid)
+{
+	u32_t mask = BIT(intid & (GIC_NUM_INTR_PER_REG - 1));
+	u32_t idx = intid / GIC_NUM_INTR_PER_REG;
+
+	sys_write32(mask, ICENABLER(GET_DIST_BASE(intid), idx));
+	/* poll to ensure write is complete */
+	gic_wait_rwp(intid);
+}
+
+bool arm_gic_irq_is_enabled(unsigned int intid)
+{
+	u32_t mask = BIT(intid & (GIC_NUM_INTR_PER_REG - 1));
+	u32_t idx = intid / GIC_NUM_INTR_PER_REG;
+	u32_t val;
+
+	val = sys_read32(ISENABLER(GET_DIST_BASE(intid), idx));
+
+	return (val & mask) != 0;
+}
+
+unsigned int arm_gic_get_active(void)
+{
+	int intid;
+
+	/* (Pending -> Active / AP) or (AP -> AP) */
+	intid = read_sysreg(ICC_IAR1_EL1);
+
+	return intid;
+}
+
+void arm_gic_eoi(unsigned int intid)
+{
+	/* (AP -> Pending) Or (Active -> Inactive) or (AP to AP) nested case */
+	write_sysreg(intid, ICC_EOIR1_EL1);
+}
+
+/*
+ * Wake up GIC redistributor.
+ * clear ProcessorSleep and wait till ChildAsleep is cleared.
+ * ProcessSleep to be cleared only when ChildAsleep is set
+ * Check if redistributor is not powered already.
+ */
+static void gicv3_rdist_enable(mem_addr_t rdist)
+{
+	if (!(sys_read32(rdist + GICR_WAKER) & BIT(GICR_WAKER_CA)))
+		return;
+
+	sys_clear_bit(rdist + GICR_WAKER, GICR_WAKER_PS);
+	while (sys_read32(rdist + GICR_WAKER) & BIT(GICR_WAKER_CA))
+		;
+}
+
+/*
+ * Initialize the cpu interface. This should be called by each core.
+ */
+static void gicv3_cpuif_init(void)
+{
+	u32_t icc_sre;
+	u32_t intid;
+
+	mem_addr_t base = gic_rdists[GET_CPUID] + GICR_SGI_BASE_OFF;
+
+	/* Disable all sgi ppi */
+	sys_write32(BIT_MASK(GIC_NUM_INTR_PER_REG), ICENABLER(base, 0));
+	/* Any sgi/ppi intid ie. 0-31 will select GICR_CTRL */
+	gic_wait_rwp(0);
+
+	/* Clear pending */
+	sys_write32(BIT_MASK(GIC_NUM_INTR_PER_REG), ICPENDR(base, 0));
+
+	/* Configure all SGIs/PPIs as G1S.
+	 * TODO: G1S or G1NS dependending on Zephyr is run in EL1S
+	 * or EL1NS respectively.
+	 * All interrupts will be delivered as irq
+	 */
+	sys_write32(0, IGROUPR(base, 0));
+	sys_write32(BIT_MASK(GIC_NUM_INTR_PER_REG), IGROUPMODR(base, 0));
+
+	/*
+	 * Configure default priorities for SGI 0:15 and PPI 0:15.
+	 */
+	for (intid = 0; intid < GIC_SPI_INT_BASE;
+	     intid += GIC_NUM_PRI_PER_REG) {
+		sys_write32(GIC_INT_DEF_PRI_X4, IPRIORITYR(base, intid));
+	}
+
+	/* Configure PPIs as level triggered */
+	sys_write32(0, ICFGR(base, 1));
+
+	/*
+	 * Check if system interface can be enabled.
+	 * 'icc_sre_el3' needs to be configured at 'EL3'
+	 * to allow access to 'icc_sre_el1' at 'EL1'
+	 * eg: z_arch_el3_plat_init can be used by platform.
+	 */
+	icc_sre = read_sysreg(ICC_SRE_EL1);
+
+	if (!(icc_sre & ICC_SRE_ELx_SRE)) {
+		icc_sre = (icc_sre | ICC_SRE_ELx_SRE |
+			   ICC_SRE_ELx_DIB | ICC_SRE_ELx_DFB);
+		write_sysreg(icc_sre, ICC_SRE_EL1);
+		icc_sre = read_sysreg(ICC_SRE_EL1);
+
+		assert(icc_sre & ICC_SRE_ELx_SRE);
+	}
+
+	write_sysreg(GIC_IDLE_PRIO, ICC_PMR_EL1);
+
+	/* Allow group1 interrupts */
+	write_sysreg(1, ICC_IGRPEN1_EL1);
+}
+
+/*
+ * TODO: Consider Zephyr in EL1NS.
+ */
+static void gicv3_dist_init(void)
+{
+	unsigned int num_ints;
+	unsigned int intid;
+	unsigned int idx;
+	mem_addr_t base = GIC_DIST_BASE;
+
+	num_ints = sys_read32(GICD_TYPER);
+	num_ints &= GICD_TYPER_ITLINESNUM_MASK;
+	num_ints = (num_ints + 1) << 5;
+
+	/*
+	 * Default configuration of all SPIs
+	 */
+	for (intid = GIC_SPI_INT_BASE; intid < num_ints;
+	     intid += GIC_NUM_INTR_PER_REG) {
+		idx = intid / GIC_NUM_INTR_PER_REG;
+		/* Disable interrupt */
+		sys_write32(BIT_MASK(GIC_NUM_INTR_PER_REG),
+			    ICENABLER(base, idx));
+		/* Clear pending */
+		sys_write32(BIT_MASK(GIC_NUM_INTR_PER_REG),
+			    ICPENDR(base, idx));
+		/* All SPIs are G1S and owned by Zephyr */
+		sys_write32(0, IGROUPR(base, idx));
+		sys_write32(BIT_MASK(GIC_NUM_INTR_PER_REG),
+			    IGROUPMODR(base, idx));
+
+	}
+	/* wait for rwp on GICD */
+	gic_wait_rwp(GIC_SPI_INT_BASE);
+
+	/* Configure default priorities for all SPIs. */
+	for (intid = GIC_SPI_INT_BASE; intid < num_ints;
+	     intid += GIC_NUM_PRI_PER_REG) {
+		sys_write32(GIC_INT_DEF_PRI_X4, IPRIORITYR(base, intid));
+	}
+
+	/* Configure all SPIs as active low, level triggered by default */
+	for (intid = GIC_SPI_INT_BASE; intid < num_ints;
+	     intid += GIC_NUM_CFG_PER_REG) {
+		idx = intid / GIC_NUM_CFG_PER_REG;
+		sys_write32(0, ICFGR(base, idx));
+	}
+
+	/* enable Group 1 secure interrupts */
+	sys_set_bit(GICD_CTLR, GICD_CTLR_ENABLE_G1S);
+}
+
+/* TODO: add arm_gic_secondary_init() for multicore support */
+int arm_gic_init(void)
+{
+	gicv3_dist_init();
+
+	/* Fixme: populate each redistributor */
+	gic_rdists[0] = GIC_RDIST_BASE;
+
+	gicv3_rdist_enable(GIC_GET_RDIST(GET_CPUID));
+
+	gicv3_cpuif_init();
+
+	return 0;
+}

--- a/drivers/interrupt_controller/intc_gicv3_priv.h
+++ b/drivers/interrupt_controller/intc_gicv3_priv.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Broadcom
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_INTC_GICV3_PRIV_H_
+#define ZEPHYR_INCLUDE_DRIVERS_INTC_GICV3_PRIV_H_
+
+#include <zephyr/types.h>
+#include <device.h>
+
+/*
+ * GIC Register Interface Base Addresses
+ */
+
+#define GIC_RDIST_BASE	DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 1)
+
+#define GIC_GET_RDIST(cpuid)		gic_rdists[cpuid]
+
+/* SGI base is at 64K offset from Redistributor */
+#define GICR_SGI_BASE_OFF		0x10000
+
+/* GICR registers offset from RD_base(n) */
+#define GICR_CTLR			0x0000
+#define GICR_IIDR			0x0004
+#define GICR_TYPER			0x0008
+#define GICR_STATUSR			0x0010
+#define GICR_WAKER			0x0014
+
+/* Register bit definations */
+
+/* GICD_CTLR Interrupt group definitions */
+#define GICD_CTLR_ENABLE_G0		0
+#define GICD_CTLR_ENABLE_G1NS		1
+#define GICD_CTLR_ENABLE_G1S		2
+
+/* GICD_CTLR Register write progress bit */
+#define GICD_CTLR_RWP			31
+
+/* GICR_CTLR */
+#define GICR_CTLR_RWP			3
+
+/* GICR_WAKER */
+#define GICR_WAKER_PS			1
+#define GICR_WAKER_CA			2
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_INTC_GICV3_PRIV_H_ */

--- a/include/drivers/interrupt_controller/gic.h
+++ b/include/drivers/interrupt_controller/gic.h
@@ -175,8 +175,6 @@
  * Helper Constants
  */
 
-#define	GIC_SPI_INT_BASE	32
-
 /* GICC_CTLR */
 #define GICC_CTLR_ENABLEGRP0	BIT(0)
 #define GICC_CTLR_ENABLEGRP1	BIT(1)
@@ -197,13 +195,6 @@
 
 #endif /* CONFIG_GIC_V2 */
 
-/* GICC_IAR */
-#define	GICC_IAR_SPURIOUS	1023
-
-/* GICD_ICFGR */
-#define GICD_ICFGR_MASK		BIT_MASK(2)
-#define GICD_ICFGR_TYPE		BIT(1)
-
 /* GICD_SGIR */
 #define GICD_SGIR_TGTFILT(x)		(x << 24)
 #define GICD_SGIR_TGTFILT_CPULIST	GICD_SGIR_TGTFILT(0b00)
@@ -218,6 +209,48 @@
 #define GICD_SGIR_SGIINTID(x)		(x)
 
 #endif /* CONFIG_GIC_VER <= 2 */
+
+/* GICD_ICFGR */
+#define GICD_ICFGR_MASK			BIT_MASK(2)
+#define GICD_ICFGR_TYPE			BIT(1)
+
+/* GICD_TYPER.ITLinesNumber 0:4 */
+#define GICD_TYPER_ITLINESNUM_MASK	0x1f
+
+/*
+ * Common Helper Constants
+ */
+
+#define GIC_SPI_INT_BASE		32
+
+#define GIC_NUM_INTR_PER_REG		32
+
+#define GIC_NUM_CFG_PER_REG		16
+
+#define GIC_NUM_PRI_PER_REG		4
+
+/* GIC idle priority : value '0xff' will allow all interrupts */
+#define GIC_IDLE_PRIO			0xff
+
+/* Priority levels 0:255 */
+#define GIC_PRI_MASK			0xff
+
+/*
+ * '0xa0'is used to initialize each interrtupt default priority.
+ * This is an arbitrary value in current context.
+ * Any value '0x80' to '0xff' will work for both NS and S state.
+ * The values of individual interrupt and default has to be chosen
+ * carefully if PMR and BPR based nesting and preemption has to be done.
+ */
+#define GIC_INT_DEF_PRI_X4		0xa0a0a0a0
+
+/* GIC special interrupt id */
+#define GIC_INTID_SPURIOUS		1023
+
+/* Fixme: update from platform specific define or dt */
+#define GIC_NUM_CPU_IF			1
+/* Fixme: arch support need to provide api/macro in SMP implementation */
+#define GET_CPUID			0
 
 #ifndef _ASMLANGUAGE
 


### PR DESCRIPTION
Add basic driver for GIC V3 interrupt controller.

This implementation supports
 - distributor, re-distributor and cpu interface initialization
 - configuration and handling of SPI, PPI and SGI.
 - V2 Legacy mode is not supported and uses system interface.

Current implementation supports GIC secure state only.
All interrupts are routed to Secure EL1 as 'irq' by configuring
them as Group1 Secure.

TODO:
- MPIDR based affinity routing setting.
- percpu redistributor probe
- message based SPI and SGI generation api
- EL1NS support. Legacy mode support.
- LPI/ITS is not supported.

[update v2] Changes in this version:
   - Macro to select applicable base based on SPI/SGI/PPI and core id.   
   - GIC_DIST_XXX for common offsets naming which can be reused in GICv2 v3 common code.
   - correction of rwp for GICR.
   - Rdist base address is an array now to support multicore.
   - defines moved to header under GICv3 config. 
[update v3]
      changes around common macro placements in gic.h  intc_gic_common_priv.h
      gicv3 specific private macros are moved to intc_gicv3_priv.h
[update v4] 
      Used appt macro names to be better intuitive as per review comments
Signed-off-by: Sandeep Tripathy <sandeep.tripathy@broadcom.com>