### PR TITLE
net: config: Allow setting MY and PEER ports

### DIFF
--- a/samples/bluetooth/ipsp/src/main.c
+++ b/samples/bluetooth/ipsp/src/main.c
@@ -38,7 +38,9 @@ struct in6_addr in6addr_mcast = MCAST_IP6ADDR;
 
 static struct in6_addr in6addr_my = MY_IP6ADDR;
 
-#define MY_PORT 4242
+#ifndef CONFIG_NET_CONFIG_MY_PORT
+#define CONFIG_NET_CONFIG_MY_PORT 4242
+#endif
 
 #define STACKSIZE 2000
 K_THREAD_STACK_DEFINE(thread_stack, STACKSIZE);
@@ -103,7 +105,7 @@ static inline bool get_context(struct net_context **udp_recv6,
 	mcast_addr6.sin6_family = AF_INET6;
 
 	my_addr6.sin6_family = AF_INET6;
-	my_addr6.sin6_port = htons(MY_PORT);
+	my_addr6.sin6_port = htons(CONFIG_NET_CONFIG_MY_PORT);
 
 	ret = net_context_get(AF_INET6, SOCK_DGRAM, IPPROTO_UDP, udp_recv6);
 	if (ret < 0) {

--- a/samples/net/sockets/coap_client/src/coap-client.c
+++ b/samples/net/sockets/coap_client/src/coap-client.c
@@ -20,7 +20,9 @@ LOG_MODULE_REGISTER(net_coap_client_sample, LOG_LEVEL_DBG);
 
 #include "net_private.h"
 
-#define PEER_PORT 5683
+#ifndef CONFIG_NET_CONFIG_PEER_PORT
+#define CONFIG_NET_CONFIG_PEER_PORT 5683
+#endif
 #define MAX_COAP_MSG_LEN 256
 
 /* CoAP socket fd */
@@ -60,7 +62,7 @@ static int start_coap_client(void)
 	struct sockaddr_in6 addr6;
 
 	addr6.sin6_family = AF_INET6;
-	addr6.sin6_port = htons(PEER_PORT);
+	addr6.sin6_port = htons(CONFIG_NET_CONFIG_PEER_PORT);
 	addr6.sin6_scope_id = 0U;
 
 	inet_pton(AF_INET6, CONFIG_NET_CONFIG_PEER_IPV6_ADDR,

--- a/samples/net/sockets/dumb_http_server_mt/src/main.c
+++ b/samples/net/sockets/dumb_http_server_mt/src/main.c
@@ -14,7 +14,9 @@ LOG_MODULE_REGISTER(net_dumb_http_srv_mt_sample);
 #include <net/socket.h>
 #include <net/tls_credentials.h>
 
-#define MY_PORT 8080
+#ifndef CONFIG_NET_CONFIG_MY_PORT
+#define CONFIG_NET_CONFIG_MY_PORT 8080
+#endif
 
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)
 #define STACK_SIZE 4096
@@ -266,7 +268,7 @@ static void process_tcp4(void)
 
 	(void)memset(&addr4, 0, sizeof(addr4));
 	addr4.sin_family = AF_INET;
-	addr4.sin_port = htons(MY_PORT);
+	addr4.sin_port = htons(CONFIG_NET_CONFIG_MY_PORT);
 
 	ret = setup(&tcp4_listen_sock, (struct sockaddr *)&addr4,
 		    sizeof(addr4));
@@ -275,7 +277,7 @@ static void process_tcp4(void)
 	}
 
 	LOG_DBG("Waiting for IPv4 HTTP connections on port %d, sock %d",
-		MY_PORT, tcp4_listen_sock);
+		CONFIG_NET_CONFIG_MY_PORT, tcp4_listen_sock);
 
 	while (ret == 0) {
 		ret = process_tcp(&tcp4_listen_sock, tcp4_accepted);
@@ -292,7 +294,7 @@ static void process_tcp6(void)
 
 	(void)memset(&addr6, 0, sizeof(addr6));
 	addr6.sin6_family = AF_INET6;
-	addr6.sin6_port = htons(MY_PORT);
+	addr6.sin6_port = htons(CONFIG_NET_CONFIG_MY_PORT);
 
 	ret = setup(&tcp6_listen_sock, (struct sockaddr *)&addr6,
 		    sizeof(addr6));
@@ -301,7 +303,7 @@ static void process_tcp6(void)
 	}
 
 	LOG_DBG("Waiting for IPv6 HTTP connections on port %d, sock %d",
-		MY_PORT, tcp6_listen_sock);
+		CONFIG_NET_CONFIG_MY_PORT, tcp6_listen_sock);
 
 	while (ret == 0) {
 		ret = process_tcp(&tcp6_listen_sock, tcp6_accepted);

--- a/samples/net/sockets/echo_client/src/common.h
+++ b/samples/net/sockets/echo_client/src/common.h
@@ -6,9 +6,13 @@
  */
 
 /* Value of 0 will cause the IP stack to select next free port */
-#define MY_PORT 0
+#ifndef CONFIG_NET_CONFIG_MY_PORT
+#define CONFIG_NET_CONFIG_MY_PORT 0
+#endif
 
-#define PEER_PORT 4242
+#ifndef CONFIG_NET_CONFIG_PEER_PORT
+#define CONFIG_NET_CONFIG_PEER_PORT 4242
+#endif
 
 struct data {
 	const char *proto;

--- a/samples/net/sockets/echo_client/src/tcp.c
+++ b/samples/net/sockets/echo_client/src/tcp.c
@@ -225,7 +225,7 @@ int start_tcp(void)
 
 	if (IS_ENABLED(CONFIG_NET_IPV6)) {
 		addr6.sin6_family = AF_INET6;
-		addr6.sin6_port = htons(PEER_PORT);
+		addr6.sin6_port = htons(CONFIG_NET_CONFIG_PEER_PORT);
 		inet_pton(AF_INET6, CONFIG_NET_CONFIG_PEER_IPV6_ADDR,
 			  &addr6.sin6_addr);
 
@@ -238,7 +238,7 @@ int start_tcp(void)
 
 	if (IS_ENABLED(CONFIG_NET_IPV4)) {
 		addr4.sin_family = AF_INET;
-		addr4.sin_port = htons(PEER_PORT);
+		addr4.sin_port = htons(CONFIG_NET_CONFIG_PEER_PORT);
 		inet_pton(AF_INET, CONFIG_NET_CONFIG_PEER_IPV4_ADDR,
 			  &addr4.sin_addr);
 

--- a/samples/net/sockets/echo_client/src/udp.c
+++ b/samples/net/sockets/echo_client/src/udp.c
@@ -188,7 +188,7 @@ int start_udp(void)
 
 	if (IS_ENABLED(CONFIG_NET_IPV6)) {
 		addr6.sin6_family = AF_INET6;
-		addr6.sin6_port = htons(PEER_PORT);
+		addr6.sin6_port = htons(CONFIG_NET_CONFIG_PEER_PORT);
 		inet_pton(AF_INET6, CONFIG_NET_CONFIG_PEER_IPV6_ADDR,
 			  &addr6.sin6_addr);
 
@@ -201,7 +201,7 @@ int start_udp(void)
 
 	if (IS_ENABLED(CONFIG_NET_IPV4)) {
 		addr4.sin_family = AF_INET;
-		addr4.sin_port = htons(PEER_PORT);
+		addr4.sin_port = htons(CONFIG_NET_CONFIG_PEER_PORT);
 		inet_pton(AF_INET, CONFIG_NET_CONFIG_PEER_IPV4_ADDR,
 			  &addr4.sin_addr);
 

--- a/samples/net/sockets/echo_server/src/common.h
+++ b/samples/net/sockets/echo_server/src/common.h
@@ -6,7 +6,9 @@
  */
 
 
-#define MY_PORT 4242
+#ifndef CONFIG_NET_CONFIG_MY_PORT
+#define CONFIG_NET_CONFIG_MY_PORT 4242
+#endif
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS) || defined(CONFIG_NET_TCP2) || \
 	defined(CONFIG_COVERAGE)
 #define STACK_SIZE 4096

--- a/samples/net/sockets/echo_server/src/tcp.c
+++ b/samples/net/sockets/echo_server/src/tcp.c
@@ -214,7 +214,7 @@ static int process_tcp(struct data *data)
 	socklen_t client_addr_len = sizeof(client_addr);
 
 	LOG_INF("Waiting for TCP connection on port %d (%s)...",
-		MY_PORT, data->proto);
+		CONFIG_NET_CONFIG_MY_PORT, data->proto);
 
 	client = accept(data->tcp.sock, (struct sockaddr *)&client_addr,
 			&client_addr_len);
@@ -274,7 +274,7 @@ static void process_tcp4(void)
 
 	(void)memset(&addr4, 0, sizeof(addr4));
 	addr4.sin_family = AF_INET;
-	addr4.sin_port = htons(MY_PORT);
+	addr4.sin_port = htons(CONFIG_NET_CONFIG_MY_PORT);
 
 	ret = start_tcp_proto(&conf.ipv4, (struct sockaddr *)&addr4,
 			      sizeof(addr4));
@@ -300,7 +300,7 @@ static void process_tcp6(void)
 
 	(void)memset(&addr6, 0, sizeof(addr6));
 	addr6.sin6_family = AF_INET6;
-	addr6.sin6_port = htons(MY_PORT);
+	addr6.sin6_port = htons(CONFIG_NET_CONFIG_MY_PORT);
 
 	ret = start_tcp_proto(&conf.ipv6, (struct sockaddr *)&addr6,
 			      sizeof(addr6));

--- a/samples/net/sockets/echo_server/src/udp.c
+++ b/samples/net/sockets/echo_server/src/udp.c
@@ -99,7 +99,7 @@ static int process_udp(struct data *data)
 	socklen_t client_addr_len;
 
 	NET_INFO("Waiting for UDP packets on port %d (%s)...",
-		 MY_PORT, data->proto);
+		 CONFIG_NET_CONFIG_MY_PORT, data->proto);
 
 	do {
 		client_addr_len = sizeof(client_addr);
@@ -143,7 +143,7 @@ static void process_udp4(void)
 
 	(void)memset(&addr4, 0, sizeof(addr4));
 	addr4.sin_family = AF_INET;
-	addr4.sin_port = htons(MY_PORT);
+	addr4.sin_port = htons(CONFIG_NET_CONFIG_MY_PORT);
 
 	ret = start_udp_proto(&conf.ipv4, (struct sockaddr *)&addr4,
 			      sizeof(addr4));
@@ -167,7 +167,7 @@ static void process_udp6(void)
 
 	(void)memset(&addr6, 0, sizeof(addr6));
 	addr6.sin6_family = AF_INET6;
-	addr6.sin6_port = htons(MY_PORT);
+	addr6.sin6_port = htons(CONFIG_NET_CONFIG_MY_PORT);
 
 	ret = start_udp_proto(&conf.ipv6, (struct sockaddr *)&addr6,
 			      sizeof(addr6));

--- a/samples/video/tcpserversink/src/main.c
+++ b/samples/video/tcpserversink/src/main.c
@@ -21,7 +21,9 @@ LOG_MODULE_REGISTER(main);
 #define VIDEO_CAPTURE_DEV "VIDEO_SW_GENERATOR"
 #endif
 
-#define MY_PORT 5000
+#ifndef CONFIG_NET_CONFIG_MY_PORT
+#define CONFIG_NET_CONFIG_MY_PORT 5000
+#endif
 #define MAX_CLIENT_QUEUE 1
 
 static ssize_t sendall(int sock, const void *buf, size_t len)
@@ -51,7 +53,7 @@ void main(void)
 	/* Prepare Network */
 	(void)memset(&addr, 0, sizeof(addr));
 	addr.sin_family = AF_INET;
-	addr.sin_port = htons(MY_PORT);
+	addr.sin_port = htons(CONFIG_NET_CONFIG_MY_PORT);
 
 	sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 	if (sock < 0) {

--- a/subsys/net/lib/config/Kconfig
+++ b/subsys/net/lib/config/Kconfig
@@ -71,6 +71,16 @@ menuconfig NET_CONFIG_SETTINGS
 
 if NET_CONFIG_SETTINGS
 
+config CONFIG_NET_CONFIG_MY_PORT
+	int "My port"
+	help
+	  Port to use in the IP stack where applicable for self.
+
+config CONFIG_NET_CONFIG_PEER_PORT
+	int "Peer port"
+	help
+	  Port to use in the IP stack where applicable for host peer.
+
 if NET_IPV6
 
 config NET_CONFIG_MY_IPV6_ADDR

--- a/tests/net/context/src/main.c
+++ b/tests/net/context/src/main.c
@@ -68,8 +68,12 @@ static struct k_sem wait_data;
 #define WAIT_TIME K_MSEC(250)
 #define WAIT_TIME_LONG MSEC_PER_SEC
 #define SENDING 93244
-#define MY_PORT 1969
-#define PEER_PORT 16233
+#ifndef CONFIG_NET_CONFIG_MY_PORT
+#define CONFIG_NET_CONFIG_MY_PORT 1969
+#endif
+#ifndef CONFIG_NET_CONFIG_PEER_PORT
+#define CONFIG_NET_CONFIG_PEER_PORT 16233
+#endif
 
 static void net_ctx_get_fail(void)
 {
@@ -199,7 +203,7 @@ static void net_ctx_bind_uni_success_v6(void)
 {
 	struct sockaddr_in6 addr = {
 		.sin6_family = AF_INET6,
-		.sin6_port = htons(MY_PORT),
+		.sin6_port = htons(CONFIG_NET_CONFIG_MY_PORT),
 		.sin6_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
 				   0, 0, 0, 0, 0, 0, 0, 0x1 } } },
 	};
@@ -215,7 +219,7 @@ static void net_ctx_bind_uni_success_v4(void)
 {
 	struct sockaddr_in addr = {
 		.sin_family = AF_INET,
-		.sin_port = htons(MY_PORT),
+		.sin_port = htons(CONFIG_NET_CONFIG_MY_PORT),
 		.sin_addr = { { { 192, 0, 2, 1 } } },
 	};
 	int ret;
@@ -231,7 +235,7 @@ static void net_ctx_bind_mcast_success(void)
 	int ret;
 	struct sockaddr_in6 addr = {
 		.sin6_family = AF_INET6,
-		.sin6_port = htons(MY_PORT),
+		.sin6_port = htons(CONFIG_NET_CONFIG_MY_PORT),
 		.sin6_addr = { { { 0 } } },
 	};
 
@@ -284,7 +288,7 @@ static void net_ctx_connect_v6(void)
 {
 	struct sockaddr_in6 addr = {
 		.sin6_family = AF_INET6,
-		.sin6_port = htons(PEER_PORT),
+		.sin6_port = htons(CONFIG_NET_CONFIG_PEER_PORT),
 		.sin6_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
 				   0, 0, 0, 0, 0, 0, 0, 0x2 } } },
 	};
@@ -310,7 +314,7 @@ static void net_ctx_connect_v4(void)
 {
 	struct sockaddr_in addr = {
 		.sin_family = AF_INET,
-		.sin_port = htons(PEER_PORT),
+		.sin_port = htons(CONFIG_NET_CONFIG_PEER_PORT),
 		.sin_addr = { { { 192, 0, 2, 2 } } },
 	};
 	int ret;
@@ -415,7 +419,7 @@ static void net_ctx_sendto_v6(void)
 	int ret;
 	struct sockaddr_in6 addr = {
 		.sin6_family = AF_INET6,
-		.sin6_port = htons(PEER_PORT),
+		.sin6_port = htons(CONFIG_NET_CONFIG_PEER_PORT),
 		.sin6_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
 				   0, 0, 0, 0, 0, 0, 0, 0x2 } } },
 	};
@@ -435,7 +439,7 @@ static void net_ctx_sendto_v4(void)
 	int ret;
 	struct sockaddr_in addr = {
 		.sin_family = AF_INET,
-		.sin_port = htons(PEER_PORT),
+		.sin_port = htons(CONFIG_NET_CONFIG_PEER_PORT),
 		.sin_addr = { { { 192, 0, 2, 2 } } },
 	};
 
@@ -504,7 +508,7 @@ static bool net_ctx_sendto_v6_wrong_src(void)
 	int ret;
 	struct sockaddr_in6 addr = {
 		.sin6_family = AF_INET6,
-		.sin6_port = htons(PEER_PORT),
+		.sin6_port = htons(CONFIG_NET_CONFIG_PEER_PORT),
 		.sin6_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
 				   0, 0, 0, 0, 0, 0, 0, 0x3 } } },
 	};
@@ -542,7 +546,7 @@ static bool net_ctx_sendto_v4_wrong_src(void)
 	int ret;
 	struct sockaddr_in addr = {
 		.sin_family = AF_INET,
-		.sin_port = htons(PEER_PORT),
+		.sin_port = htons(CONFIG_NET_CONFIG_PEER_PORT),
 		.sin_addr = { { { 192, 0, 2, 3 } } },
 	};
 

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -130,8 +130,12 @@ static bool recv_cb_called;
 #define WAIT_TIME 250
 #define WAIT_TIME_LONG MSEC_PER_SEC
 #define SENDING 93244
-#define MY_PORT 1969
-#define PEER_PORT 16233
+#ifndef CONFIG_NET_CONFIG_MY_PORT
+#define CONFIG_NET_CONFIG_MY_PORT 1969
+#endif
+#ifndef CONFIG_NET_CONFIG_PEER_PORT
+#define CONFIG_NET_CONFIG_PEER_PORT 16233
+#endif
 
 struct net_test_ipv6 {
 	u8_t mac_addr[sizeof(struct net_eth_addr)];

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -52,7 +52,9 @@ static struct coap_resource server_resources[] =  {
 	{ },
 };
 
-#define MY_PORT 12345
+#ifndef CONFIG_NET_CONFIG_MY_PORT
+#define CONFIG_NET_CONFIG_MY_PORT 12345
+#endif
 #define peer_addr { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, \
 			0, 0, 0, 0, 0, 0, 0, 0x2 } } }
 static struct sockaddr_in6 dummy_addr = {

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -58,8 +58,12 @@ K_SEM_DEFINE(wait_data, 0, UINT_MAX);
 
 #define WAIT_TIME 500
 #define WAIT_TIME_LONG MSEC_PER_SEC
-#define MY_PORT 1969
-#define PEER_PORT 13856
+#ifndef CONFIG_NET_CONFIG_MY_PORT
+#define CONFIG_NET_CONFIG_MY_PORT 1969
+#endif
+#ifndef CONFIG_NET_CONFIG_PEER_PORT
+#define CONFIG_NET_CONFIG_PEER_PORT 13856
+#endif
 
 struct net_test_mld {
 	u8_t mac_addr[sizeof(struct net_eth_addr)];

--- a/tests/net/tcp2/src/main.c
+++ b/tests/net/tcp2/src/main.c
@@ -28,20 +28,24 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_TCP_LOG_LEVEL);
 
 #include <ztest.h>
 
-#define MY_PORT 4242
-#define PEER_PORT 4242
+#ifndef CONFIG_NET_CONFIG_MY_PORT
+#define CONFIG_NET_CONFIG_MY_PORT 4242
+#endif
+#ifndef CONFIG_NET_CONFIG_PEER_PORT
+#define CONFIG_NET_CONFIG_PEER_PORT 4242
+#endif
 
 static struct in_addr my_addr  = { { { 192, 0, 2, 1 } } };
 static struct sockaddr_in my_addr_s = {
 	.sin_family = AF_INET,
-	.sin_port = htons(PEER_PORT),
+	.sin_port = htons(CONFIG_NET_CONFIG_PEER_PORT),
 	.sin_addr = { { { 192, 0, 2, 1 } } },
 };
 
 static struct in_addr peer_addr  = { { { 192, 0, 2, 2 } } };
 static struct sockaddr_in peer_addr_s = {
 	.sin_family = AF_INET,
-	.sin_port = htons(PEER_PORT),
+	.sin_port = htons(CONFIG_NET_CONFIG_PEER_PORT),
 	.sin_addr = { { { 192, 0, 2, 2 } } },
 };
 
@@ -49,7 +53,7 @@ static struct in6_addr my_addr_v6  = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
 					   0, 0, 0, 0, 0, 0, 0, 0x1 } } };
 static struct sockaddr_in6 my_addr_v6_s = {
 	.sin6_family = AF_INET6,
-	.sin6_port = htons(PEER_PORT),
+	.sin6_port = htons(CONFIG_NET_CONFIG_PEER_PORT),
 	.sin6_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
 			   0, 0, 0, 0, 0, 0, 0, 0x1 } } },
 };
@@ -58,7 +62,7 @@ static struct in6_addr peer_addr_v6  = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
 					     0, 0, 0, 0, 0, 0, 0, 0x2 } } };
 static struct sockaddr_in6 peer_addr_v6_s = {
 	.sin6_family = AF_INET6,
-	.sin6_port = htons(PEER_PORT),
+	.sin6_port = htons(CONFIG_NET_CONFIG_PEER_PORT),
 	.sin6_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
 			   0, 0, 0, 0, 0, 0, 0, 0x2 } } },
 };
@@ -423,7 +427,7 @@ static void handle_client_test(sa_family_t af, struct tcphdr *th)
 		test_verify_flags(th, SYN);
 		seq = 0U;
 		ack = ntohs(th->th_seq) + 1U;
-		reply = prepare_syn_ack_packet(af, htons(MY_PORT),
+		reply = prepare_syn_ack_packet(af, htons(CONFIG_NET_CONFIG_MY_PORT),
 					       th->th_sport);
 		t_state = T_SYN_ACK;
 		break;
@@ -437,7 +441,7 @@ static void handle_client_test(sa_family_t af, struct tcphdr *th)
 		test_verify_flags(th, PSH | ACK);
 		seq++;
 		ack = ack + 1U;
-		reply = prepare_ack_packet(af, htons(MY_PORT), th->th_sport);
+		reply = prepare_ack_packet(af, htons(CONFIG_NET_CONFIG_MY_PORT), th->th_sport);
 		t_state = T_FIN;
 		test_sem_give();
 		break;
@@ -445,7 +449,7 @@ static void handle_client_test(sa_family_t af, struct tcphdr *th)
 		test_verify_flags(th, FIN | ACK);
 		ack = ntohs(th->th_seq) + 1U;
 		t_state = T_FIN_ACK;
-		reply = prepare_fin_ack_packet(af, htons(MY_PORT),
+		reply = prepare_fin_ack_packet(af, htons(CONFIG_NET_CONFIG_MY_PORT),
 					       th->th_sport);
 		break;
 	case T_FIN_ACK:
@@ -600,36 +604,36 @@ static void handle_server_test(sa_family_t af, struct tcphdr *th)
 	case T_SYN:
 		seq = 0U;
 		ack = 0U;
-		reply = prepare_syn_packet(af, htons(MY_PORT),
-					   htons(PEER_PORT));
+		reply = prepare_syn_packet(af, htons(CONFIG_NET_CONFIG_MY_PORT),
+					   htons(CONFIG_NET_CONFIG_PEER_PORT));
 		t_state = T_SYN_ACK;
 		break;
 	case T_SYN_ACK:
 		test_verify_flags(th, SYN | ACK);
 		seq++;
 		ack = ntohs(th->th_seq) + 1U;
-		reply = prepare_ack_packet(af, htons(MY_PORT),
-					   htons(PEER_PORT));
+		reply = prepare_ack_packet(af, htons(CONFIG_NET_CONFIG_MY_PORT),
+					   htons(CONFIG_NET_CONFIG_PEER_PORT));
 		t_state = T_DATA;
 		break;
 	case T_DATA:
-		reply = prepare_data_packet(af, htons(MY_PORT),
-					    htons(PEER_PORT), "A", 1U);
+		reply = prepare_data_packet(af, htons(CONFIG_NET_CONFIG_MY_PORT),
+					    htons(CONFIG_NET_CONFIG_PEER_PORT), "A", 1U);
 		t_state = T_DATA_ACK;
 		break;
 	case T_DATA_ACK:
 		test_verify_flags(th, ACK);
 		seq++;
-		reply = prepare_fin_ack_packet(af, htons(MY_PORT),
-					       htons(PEER_PORT));
+		reply = prepare_fin_ack_packet(af, htons(CONFIG_NET_CONFIG_MY_PORT),
+					       htons(CONFIG_NET_CONFIG_PEER_PORT));
 		t_state = T_FIN;
 		break;
 	case T_FIN:
 		test_verify_flags(th, FIN | ACK);
 		seq++;
 		ack++;
-		reply = prepare_ack_packet(af, htons(MY_PORT),
-					   htons(PEER_PORT));
+		reply = prepare_ack_packet(af, htons(CONFIG_NET_CONFIG_MY_PORT),
+					   htons(CONFIG_NET_CONFIG_PEER_PORT));
 		t_state = T_FIN_ACK;
 		break;
 	case T_FIN_ACK:
@@ -933,7 +937,7 @@ send_next:
 		test_verify_flags(th, SYN);
 		seq = 0U;
 		ack = ntohs(th->th_seq) + 1U;
-		reply = prepare_syn_ack_packet(af, htons(MY_PORT),
+		reply = prepare_syn_ack_packet(af, htons(CONFIG_NET_CONFIG_MY_PORT),
 					       th->th_sport);
 		t_state = T_SYN_ACK;
 		break;
@@ -947,7 +951,7 @@ send_next:
 		test_verify_flags(th, PSH | ACK);
 		seq++;
 		ack = ack + 1U;
-		reply = prepare_ack_packet(af, htons(MY_PORT), th->th_sport);
+		reply = prepare_ack_packet(af, htons(CONFIG_NET_CONFIG_MY_PORT), th->th_sport);
 		t_state = T_FIN;
 		test_sem_give();
 		break;
@@ -955,11 +959,11 @@ send_next:
 		test_verify_flags(th, FIN | ACK);
 		ack = ntohs(th->th_seq) + 1U;
 		t_state = T_FIN_2;
-		reply = prepare_ack_packet(af, htons(MY_PORT), th->th_sport);
+		reply = prepare_ack_packet(af, htons(CONFIG_NET_CONFIG_MY_PORT), th->th_sport);
 		break;
 	case T_FIN_2:
 		t_state = T_FIN_ACK;
-		reply = prepare_fin_packet(af, htons(MY_PORT), th->th_sport);
+		reply = prepare_fin_packet(af, htons(CONFIG_NET_CONFIG_MY_PORT), th->th_sport);
 		break;
 	case T_FIN_ACK:
 		test_verify_flags(th, ACK);
@@ -1057,7 +1061,7 @@ static void handle_client_closing_test(sa_family_t af, struct tcphdr *th)
 		test_verify_flags(th, SYN);
 		seq = 0U;
 		ack = ntohs(th->th_seq) + 1U;
-		reply = prepare_syn_ack_packet(af, htons(MY_PORT),
+		reply = prepare_syn_ack_packet(af, htons(CONFIG_NET_CONFIG_MY_PORT),
 					       th->th_sport);
 		t_state = T_SYN_ACK;
 		break;
@@ -1071,7 +1075,7 @@ static void handle_client_closing_test(sa_family_t af, struct tcphdr *th)
 		test_verify_flags(th, PSH | ACK);
 		seq++;
 		ack = ack + 1U;
-		reply = prepare_ack_packet(af, htons(MY_PORT), th->th_sport);
+		reply = prepare_ack_packet(af, htons(CONFIG_NET_CONFIG_MY_PORT), th->th_sport);
 		t_state = T_FIN;
 		test_sem_give();
 		break;
@@ -1079,12 +1083,12 @@ static void handle_client_closing_test(sa_family_t af, struct tcphdr *th)
 		test_verify_flags(th, FIN | ACK);
 		ack = ntohs(th->th_seq) + 1U;
 		t_state = T_CLOSING;
-		reply = prepare_fin_packet(af, htons(MY_PORT), th->th_sport);
+		reply = prepare_fin_packet(af, htons(CONFIG_NET_CONFIG_MY_PORT), th->th_sport);
 		break;
 	case T_CLOSING:
 		test_verify_flags(th, ACK);
 		t_state = T_FIN_ACK;
-		reply = prepare_ack_packet(af, htons(MY_PORT), th->th_sport);
+		reply = prepare_ack_packet(af, htons(CONFIG_NET_CONFIG_MY_PORT), th->th_sport);
 		break;
 	default:
 		zassert_true(false, "%s unexpected state", __func__);


### PR DESCRIPTION
It is already possible to set various IP address related settings, but not ports.

Make this more symmetric by allowing the same for ports.
Change sample/test use to reflect the change.

Signed-off-by: Torstein Grindvik <torstein.grindvik@gmail.com>