### PR TITLE
west.yml: Update hal_ti for devicetree fix for msp432p4xx

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -71,7 +71,7 @@ manifest:
       revision: ff9b7f295da7e8918fbe3e0119b5271cb9cb4a55
       path: modules/hal/stm32
     - name: hal_ti
-      revision: 7dcbff2d5994bc48dc3aa2a6af619dadf91d88db
+      revision: 7cdfe31375516308883226d8b98bc75d570c8140
       path: modules/hal/ti
     - name: libmetal
       revision: 60f40977eccb7e067a83933cec859e266bff4849


### PR DESCRIPTION
As part of devicetree update to new devicetree.h  We Need to convert
as use of  DT_ARM_CORTEX_M4F_CLOCK_FREQUENCY to
DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency) in the hal_ti for the
msp432p4xx SoCs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>