### PR TITLE
settings: add const qualifier for unmodified data source

### DIFF
--- a/include/settings/settings.h
+++ b/include/settings/settings.h
@@ -567,7 +567,7 @@ int settings_name_next(const char *name, const char **next);
  *
  * @return 0 on success, non-zero on failure.
  */
-int settings_runtime_set(const char *name, void *data, size_t len);
+int settings_runtime_set(const char *name, const void *data, size_t len);
 
 /**
  * Get a value corresponding to a key from a module handler.

--- a/subsys/settings/src/settings_runtime.c
+++ b/subsys/settings/src/settings_runtime.c
@@ -11,7 +11,7 @@
 #include "settings_priv.h"
 
 struct read_cb_arg {
-	void *data;
+	const void *data;
 	size_t len;
 };
 
@@ -23,7 +23,7 @@ static ssize_t settings_runtime_read_cb(void *cb_arg, void *data, size_t len)
 	return MIN(arg->len, len);
 }
 
-int settings_runtime_set(const char *name, void *data, size_t len)
+int settings_runtime_set(const char *name, const void *data, size_t len)
 {
 	struct settings_handler_static *ch;
 	const char *name_key;


### PR DESCRIPTION
Code using this API to set a key to a value that is a string literal produces errors in C++ because the receiving parameter type is not const qualified, allowing the possibility that the callee modifies the referenced string literal memory.  Add the required const qualifiers since the set function does not change the data passed to it.

From
```
#if defined(CONFIG_BT_GATT_DIS_SW_REV)
        settings_runtime_set("bt/dis/sw",
                             CONFIG_BT_GATT_DIS_SW_REV_STR,
                             sizeof(CONFIG_BT_GATT_DIS_SW_REV_STR));
#endif
```
one gets:
```
../src/main.cxx:64:9: note: in expansion of macro 'CONFIG_BT_GATT_DIS_SW_REV_STR'
   64 |         CONFIG_BT_GATT_DIS_SW_REV_STR,
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../src/main.cxx:22:
/mnt/nordic/zp/zephyr/include/settings/settings.h:570:50: note:   initializing argument 2 of 'int settings_runtime_set(const char*, void*, size_t)'
  570 | int settings_runtime_set(const char *name, void *data, size_t len);
      |                                            ~~~~~~^~~~
In file included from <command-line>:
/mnt/nordic/zp/zephyr/samples/bluetooth/peripheral_dis/build/zephyr/include/generated/autoconf.h:257:39: error: invalid conversion from 'const void*' to 'void*' [-fpermissive]
  257 | #define CONFIG_BT_GATT_DIS_FW_REV_STR "Zephyr Firmware"
      |                                       ^~~~~~~~~~~~~~~~~
      |                                       |
      |                                       const void*
```
