### PR TITLE
shell: Support output using a va_list

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -727,6 +727,21 @@ void shell_fprintf(const struct shell *shell, enum shell_vt100_color color,
 		   const char *fmt, ...);
 
 /**
+ * @brief vprintf-like function which sends formatted data stream to the shell.
+ *
+ * This function can be used from the command handler or from threads, but not
+ * from an interrupt context. It is similar to shell_fprintf() but takes a
+ * va_list instead of variable arguments.
+ *
+ * @param[in] shell	Pointer to the shell instance.
+ * @param[in] color	Printed text color.
+ * @param[in] fmt	Format string.
+ * @param[in] args	List of parameters to print.
+ */
+void shell_vfprintf(const struct shell *shell, enum shell_vt100_color color,
+		   const char *fmt, va_list args);
+
+/**
  * @brief Print data in hexadecimal format.
  *
  * @param[in] shell	Pointer to the shell instance.

--- a/include/shell/shell_dummy.h
+++ b/include/shell/shell_dummy.h
@@ -1,4 +1,6 @@
 /*
+ * Shell backend used for testing
+ *
  * Copyright (c) 2018 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -17,6 +19,12 @@ extern const struct shell_transport_api shell_dummy_transport_api;
 
 struct shell_dummy {
 	bool initialized;
+
+	/** current number of bytes in buffer (0 if no output) */
+	size_t len;
+
+	/** output buffer to collect shell output */
+	char buf[100];
 };
 
 #define SHELL_DUMMY_DEFINE(_name)					\
@@ -36,6 +44,18 @@ struct shell_dummy {
  * @returns Pointer to the shell instance.
  */
 const struct shell *shell_backend_dummy_get_ptr(void);
+
+/**
+ * @brief Returns the buffered output in the shell and resets the pointer
+ *
+ * The returned data is always followed by a nul character at position *sizep
+ *
+ * @param shell		Shell pointer
+ * @param sizep		Returns size of data in shell buffer
+ * @returns pointer to buffer containing shell output
+ */
+const char *shell_backend_dummy_get_output(const struct shell *shell,
+					   size_t *sizep);
 
 #ifdef __cplusplus
 }

--- a/subsys/shell/shell_dummy.c
+++ b/subsys/shell/shell_dummy.c
@@ -1,4 +1,6 @@
 /*
+ * Shell backend used for testing
+ *
  * Copyright (c) 2018 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -55,13 +57,22 @@ static int write(const struct shell_transport *transport,
 		 const void *data, size_t length, size_t *cnt)
 {
 	struct shell_dummy *sh_dummy = (struct shell_dummy *)transport->ctx;
+	size_t store_cnt;
 
 	if (!sh_dummy->initialized) {
 		*cnt = 0;
 		return -ENODEV;
 	}
 
+	store_cnt = length;
+	if (sh_dummy->len + store_cnt >= sizeof(sh_dummy->buf)) {
+		store_cnt = sizeof(sh_dummy->buf) - sh_dummy->len - 1;
+	}
+	memcpy(sh_dummy->buf + sh_dummy->len, data, store_cnt);
+	sh_dummy->len += store_cnt;
+
 	*cnt = length;
+
 	return 0;
 }
 
@@ -98,4 +109,17 @@ SYS_INIT(enable_shell_dummy, POST_KERNEL, 0);
 const struct shell *shell_backend_dummy_get_ptr(void)
 {
 	return &shell_dummy;
+}
+
+const char *shell_backend_dummy_get_output(const struct shell *shell,
+					   size_t *sizep)
+{
+	struct shell_dummy *sh_dummy;
+
+	sh_dummy = (struct shell_dummy *)shell->iface->ctx;
+	sh_dummy->buf[sh_dummy->len] = '\0';
+	*sizep = sh_dummy->len;
+	sh_dummy->len = 0;
+
+	return sh_dummy->buf;
 }

--- a/tests/shell/src/main.c
+++ b/tests/shell/src/main.c
@@ -316,6 +316,33 @@ static void test_set_root_cmd(void)
 	test_shell_execute_cmd("shell colors on", 0);
 }
 
+static void test_shell_fprintf(void)
+{
+	static const char expect[] = "testing 1 2 3";
+	const struct shell *shell;
+	const char *buf;
+	size_t size;
+
+	shell = shell_backend_dummy_get_ptr();
+	zassert_not_null(shell, "Failed to get shell");
+
+	/* Clear the output buffer */
+	shell_backend_dummy_get_output(shell, &size);
+
+	shell_fprintf(shell, SHELL_VT100_COLOR_DEFAULT, "testing %d %s %c",
+		      1, "2", '3');
+	buf = shell_backend_dummy_get_output(shell, &size);
+	zassert_true(size >= sizeof(expect), "Expected size > %u, got %d",
+		     sizeof(expect), size);
+
+	/*
+	 * There are prompts and various ANSI characters in the output, so just
+	 * check that the string is in there somewhere.
+	 */
+	zassert_true(strstr(buf, expect),
+		     "Expected string to contain '%s', got '%s'", expect, buf);
+}
+
 void test_main(void)
 {
 	ztest_test_suite(shell_test_suite,
@@ -328,7 +355,8 @@ void test_main(void)
 			ztest_unit_test(test_cmd_resize),
 			ztest_unit_test(test_shell_module),
 			ztest_unit_test(test_shell_wildcards_static),
-			ztest_unit_test(test_shell_wildcards_dynamic));
+			ztest_unit_test(test_shell_wildcards_dynamic),
+			ztest_unit_test(test_shell_fprintf));
 
 	ztest_run_test_suite(shell_test_suite);
 }


### PR DESCRIPTION
At present it is not possible to write a printf()-like function in board
code which outputs to the shell. Add shell_vfprintf() to permit this.

I am not sure if there should be a test somewhere for this.

Signed-off-by: Simon Glass <sjg@chromium.org>