### PR TITLE
x86_64: fix crash on nested interrupts

### DIFF
--- a/arch/x86/core/intel64/cpu.c
+++ b/arch/x86/core/intel64/cpu.c
@@ -86,7 +86,8 @@ struct x86_cpuboot x86_cpuboot[] = {
 	{
 		.tr = X86_KERNEL_CPU0_TR,
 		.gs_base = &tss0,
-		.sp = (u64_t) z_interrupt_stacks[0] + CONFIG_ISR_STACK_SIZE,
+		.sp = (u64_t) (z_interrupt_stacks[0] + CONFIG_ISR_STACK_SIZE +
+			       ARCH_THREAD_STACK_RESERVED),
 		.fn = z_x86_prep_c,
 #ifdef CONFIG_X86_MMU
 		.ptables = &z_x86_flat_ptables,


### PR DESCRIPTION
x86_64 supports 4 levels of interrupt nesting, with
the interrupt stack divided up into sub-stacks for
each nesting level.

Unfortunately, the initial interrupt stack pointer
on the first CPU was not taking into account reserved
space for guard areas, causing a stack overflow exception
when attempting to use the last interrupt nesting level,
as that page had been set up as a stack guard.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>