### PR TITLE
west.yml: Update hal_ti to update cc32xx to SimpleLink SDK 4.10.00.07

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -71,7 +71,7 @@ manifest:
       revision: ff9b7f295da7e8918fbe3e0119b5271cb9cb4a55
       path: modules/hal/stm32
     - name: hal_ti
-      revision: 7cdfe31375516308883226d8b98bc75d570c8140
+      revision: 811363a384cbd2d2b699cae7b8c4375de8218b65
       path: modules/hal/ti
     - name: libmetal
       revision: 60f40977eccb7e067a83933cec859e266bff4849


### PR DESCRIPTION
This is to update west.yml to point to hal_ti with the latest changes
from TI SimpleLink SDK 4.10.00.07 for CC32xx.

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>