### PR TITLE
boards: mec1501modular: Remove NO_DEFAULT_PATH from find_file

### DIFF
--- a/boards/arm/mec1501modular_assy6885/CMakeLists.txt
+++ b/boards/arm/mec1501modular_assy6885/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
     set(EVERGLADES_SPI_GEN_FILENAME everglades_spi_gen.exe)
   endif()
 
-  find_file(EVERGLADES_SPI_GEN_FINDFILE ${EVERGLADES_SPI_GEN_FILENAME} NO_DEFAULT_PATH)
+  find_file(EVERGLADES_SPI_GEN_FINDFILE ${EVERGLADES_SPI_GEN_FILENAME})
   if(EVERGLADES_SPI_GEN_FINDFILE STREQUAL EVERGLADES_SPI_GEN_FINDFILE-NOTFOUND)
     message(WARNING "Microchip SPI Image Generation tool (${EVERGLADES_SPI_GEN_FILENAME}) is not available. SPI Image will not be generated.")
   else()


### PR DESCRIPTION
Removing this flag allows to find the spi binary generation tool
in cmake's default paths. This also aligns this CMakeList with
the version currently found in the MEC EVB

Signed-off-by: Francisco Munoz <francisco.munoz.ruiz@intel.com>