### PR TITLE
RFC: create a list of device pointers per driver subsystem

### DIFF
--- a/drivers/adc/adc_mcux_adc16.c
+++ b/drivers/adc/adc_mcux_adc16.c
@@ -305,3 +305,13 @@ static const struct adc_driver_api mcux_adc16_driver_api = {
 	}
 
 DT_INST_FOREACH(ACD16_MCUX_INIT)
+
+#define SUBSYS_DEVICE_REGISTER(subsys, name) \
+	static const Z_DECL_ALIGN(struct device *) subsys##name \
+	__in_section(_##subsys##_devices, static, subsys##name) __used = \
+	DEVICE_GET(name)
+
+#define ADC_DEVICE_REGISTER(name) SUBSYS_DEVICE_REGISTER(adc, name)
+
+ADC_DEVICE_REGISTER(mcux_adc16_0);
+ADC_DEVICE_REGISTER(mcux_adc16_1);

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -174,3 +174,13 @@
 		KEEP(*("._tracing_backend.*"));
 		_tracing_backend_list_end = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)
+
+#define DEVICE_SECTION(subsys) \
+	SECTION_DATA_PROLOGUE(subsys##_devices_sections,,) \
+	{ \
+		__##subsys##_devices_entry_start = .; \
+		KEEP(*(SORT_BY_NAME(".*devices.*"))) \
+		__##subsys##_devices_entry_end = .; \
+	} GROUP_LINK_IN(ROMABLE_REGION)
+
+	DEVICE_SECTION(adc)


### PR DESCRIPTION
This the starts of a means to allow a list of devices per driver
class/subsystem for things like the shell to utilize.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>