### PR TITLE
boards: arm: mps2_an521: Enable QEMU icount mode

### DIFF
--- a/boards/arm/mps2_an521/board.cmake
+++ b/boards/arm/mps2_an521/board.cmake
@@ -9,7 +9,7 @@ set(QEMU_FLAGS_${ARCH}
   -nographic
   -m 16
   -vga none
-  -icount auto
+  -icount shift=7,align=off,sleep=off -rtc clock=vm
   )
 
 board_set_debugger_ifnset(qemu)


### PR DESCRIPTION
```
This commit enables the QEMU icount mode for `mps2_an521`, in order to
decouple the host clock from the emulated guest clock.

This prevents guest timing instability from causing test failures when
the host CPU load is very high.

The icount `shift` value of 7 was empirically chosen to allow the tests
to complete in both realistic and reasonable amount of time.

The following are quick notes on the parameters used:

* -icount shift=7: Execute one instruction every 128ns of virtual time
* -icount align=off: Do not synchronise the host and guest clocks
* -icount sleep=off: Advance virtual time without sleeping/waiting
* -rtc clock=vm: Isolate the guest RTC time from the host

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```

This fixes the infamous `mps2_an521`-related "intermittent" CI failures.

For the motivation of this PR, refer to https://github.com/zephyrproject-rtos/zephyr/pull/24811#issuecomment-622235347.

Provides a partial fix for #14173.