### PR TITLE
scripts: Create CVE assistance script

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -435,6 +435,7 @@
 /scripts/tracing/                         @wentongwu
 /scripts/sanity_chk/                      @nashif
 /scripts/sanitycheck                      @nashif
+/scripts/security/                        @d3zd3z
 /scripts/series-push-hook.sh              @erwango
 /scripts/west_commands/                   @mbolivar-nordic
 /scripts/west-commands.yml                @mbolivar-nordic

--- a/scripts/security/cve-template.json
+++ b/scripts/security/cve-template.json
@@ -33,7 +33,7 @@
     "credit": [
         {
             "lang": "eng",
-            "value": "NCC Group for report"
+            "value": "<credit>"
         }
     ],
     "data_format": "MITRE",
@@ -43,7 +43,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "XXBuffer Overflow vulnerability in USB DFU of zephyr allows a USB connected host to cause possible remote code execution.\nThis issue affects:\nzephyrproject-rtos zephyr\nversion 1.14.0 and later versions."
+                "value": "<description>\nThis issue affects:\nzephyrproject-rtos zephyr\nversion 1.14.0 and later versions."
             }
         ]
     },
@@ -80,26 +80,6 @@
     },
     "references": {
         "reference_data": [
-            {
-                "refsource": "CONFIRM",
-                "url": "https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-25"
-            },
-            {
-                "refsource": "CONFIRM",
-                "url": "https://docs.zephyrproject.org/latest/security/vulnerabilities.html#CVE-2020-10019"
-            },
-            {
-                "refsource": "CONFIRM",
-                "url": "https://github.com/zephyrproject-rtos/zephyr/pull/23190"
-            },
-            {
-                "refsource": "CONFIRM",
-                "url": "https://github.com/zephyrproject-rtos/zephyr/pull/23457"
-            },
-            {
-                "refsource": "CONFIRM",
-                "url": "https://github.com/zephyrproject-rtos/zephyr/pull/23460"
-            }
         ]
     },
     "source": {

--- a/scripts/security/cve-template.json
+++ b/scripts/security/cve-template.json
@@ -1,0 +1,111 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "vulnerabilities@zephyrproject.org",
+        "DATE_PUBLIC": "2020-05-01T00:00:00.000Z",
+        "ID": "CVE-2020-XXXXX",
+        "STATE": "PUBLIC",
+        "TITLE": ""
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "zephyr",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": ">=",
+                                            "version_value": "1.14.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "zephyrproject-rtos"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "NCC Group for report"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [
+            {
+                "lang": "eng",
+                "value": "XXBuffer Overflow vulnerability in USB DFU of zephyr allows a USB connected host to cause possible remote code execution.\nThis issue affects:\nzephyrproject-rtos zephyr\nversion 1.14.0 and later versions."
+            }
+        ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8.1,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-120 Buffer Overflow"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "refsource": "CONFIRM",
+                "url": "https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-25"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://docs.zephyrproject.org/latest/security/vulnerabilities.html#CVE-2020-10019"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://github.com/zephyrproject-rtos/zephyr/pull/23190"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://github.com/zephyrproject-rtos/zephyr/pull/23457"
+            },
+            {
+                "refsource": "CONFIRM",
+                "url": "https://github.com/zephyrproject-rtos/zephyr/pull/23460"
+            }
+        ]
+    },
+    "source": {
+        "defect": [
+            "https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-XX"
+        ],
+        "discovery": "EXTERNAL"
+    }
+}

--- a/scripts/security/scan.py
+++ b/scripts/security/scan.py
@@ -1,0 +1,139 @@
+#! /usr/bin/env python3
+
+from github import Github
+from git import Git
+import netrc
+import pickle
+import pprint
+import requests
+import re
+
+jira_host = 'zephyrprojectsec.atlassian.net'
+baseurl = f"https://{jira_host}/rest/api/2/"
+
+# Custom field names.
+cve_field = 'customfield_10035'
+embargo_field = 'customfield_10051'
+
+# Get authentication information.
+def get_auth(host):
+    auth = netrc.netrc().authenticators(host)
+    if auth is None:
+        raise Exception("Expecting a single authenticator for host")
+    return (auth[0], auth[2])
+auth = get_auth(jira_host)
+
+pr_re = re.compile(r'^https://github.com/zephyrproject-rtos/zephyr/pull/(\d+)$')
+
+gh_token = get_auth('github.com')[1]
+gh = Github(gh_token)
+repo = gh.get_repo("zephyrproject-rtos/zephyr")
+gitwork = Git(".")
+
+with open('token') as fd:
+    token = fd.readline().rstrip()
+
+def query(text, field, params={}):
+    result = []
+    start = 1
+
+    while True:
+        params["startAt"] = start
+        r = requests.get(baseurl + text, auth=auth, params=params)
+        if r.status_code != 200:
+            print(r)
+            raise Exception("Failure in query")
+        j = r.json()
+        # print(len(j[field]), j["maxResults"])
+
+        # The Jira API is inconsistent.  If the results returned are
+        # directly a list, just use that.
+        if isinstance(j, list):
+            return j
+        # for k in j.keys():
+        #     print(k)
+
+        result.extend(j[field])
+
+        if len(j[field]) < j["maxResults"]:
+            break
+
+        start += j["maxResults"]
+
+    return result
+
+def get_remote_links(key):
+    return query("issue/" + key + "/remotelink", 'unknown')
+
+class Issue(object):
+    def __init__(self, js):
+        self.key = js["key"]
+        fields = js["fields"]
+        self.fixversion = fields["fixVersions"]
+        self._status = fields["status"]
+        self._issuetype = fields["issuetype"]
+        self.cve = fields[cve_field]
+        self.embargo = fields[embargo_field]
+        self.subtasks = fields["subtasks"]
+
+        self.fields = fields
+
+        self.remotes = None
+        # Only query the remotes lazily, because it is slow.
+        # self.remotes = get_remote_links(self.key)
+
+    def status(self):
+        return self._status["name"]
+
+    def issuetype(self):
+        return self._issuetype["name"]
+
+    def getlinks(self):
+        if self.remotes is None:
+            self.remotes = get_remote_links(self.key)
+        return [x["object"]["url"] for x in self.remotes]
+
+def main():
+    p = { 'jql': 'project="ZEPSEC"' }
+    j = query("search", "issues", params=p)
+
+    pp = pprint.PrettyPrinter()
+    # j = r.json()
+
+    # pp.pprint(j['issues'][1])
+    issues = []
+    for jissue in j:
+        # print(jissue['key'])
+        issue = Issue(jissue)
+        issues.append(issue)
+
+    # Filter out the issues that are "Public".
+    issues = [x for x in issues if x.status() != "Public"]
+    issues = [x for x in issues if x.status() != "Rejected"]
+
+    # Select open primary issues (with CVE).
+    if False:
+        issues = [x for x in issues if x.issuetype() != "Backport"]
+        issues = [x for x in issues if x.cve is not None]
+
+    # Select unresolved backports
+    if True:
+        issues = [x for x in issues if x.issuetype() == "Backport"]
+
+    for issue in issues:
+        # print(issue.key, issue.cve)
+        print(issue.key, issue.status())
+        for link in issue.getlinks():
+            print("    ", link)
+            m = pr_re.search(link)
+            if m is not None:
+                pr = int(m.group(1))
+                gpr = repo.get_pull(pr)
+                print("        ", pr, gpr.state, gpr.title)
+                for c in gpr.get_commits():
+                    print("        ", pr, c)
+                    # pp.pprint(c.raw_data)
+                    print("            ", gitwork.describe(c.sha))
+
+if __name__ == '__main__':
+    main()

--- a/scripts/security/tocve.py
+++ b/scripts/security/tocve.py
@@ -1,0 +1,225 @@
+#! /usr/bin/env python3
+
+import json
+import re
+import subprocess
+import sys
+
+# TODO: impact and problemtype.
+# TODO: setup publication date.
+
+# Setup Instructions
+# ==================
+#
+# You will need to install the [Atlassian Command Line
+# Interface](https://bobswift.atlassian.net/wiki/spaces/ACLI/overview)
+# Set this variable to where you have installed this tool.
+acli = '/home/<user>/ACLI/acli'
+
+# To use this script, you will need to fill in your username, and you
+# will need to generate an API token.  These can be generated at:
+# https://id.atlassian.com/manage-profile/security/api-tokens
+user = '<email>'
+token = '<token>'
+
+# You can verify this works with the following command:
+# ```
+# ./acli jira -u <email> -t <token> --action getProjectList \
+#       --server https://zephyrprojectsec.atlassian.net
+# ```
+#
+# Note that only members of the triage team will have access to issues
+# that are under embargo.
+#
+# Usage
+# =====
+#
+# Run as either `./tocve.py ZEPSEC-nn cve` to generate a CVE or as
+# `./tocve.py ZEPSEC-nn rnote` to generate release notes.  The CVE
+# command expects a cve-template.json in the current directory, which
+# can be updated with values for the fields this script does not set.
+
+# Set this to where you have installed ACLI.
+acli_base = [acli, 'jira', '-u', user,
+        '-t', token,
+        '--quiet',
+        '--outputType', 'json',
+        '--server', 'https://zephyrprojectsec.atlassian.net' ]
+
+url_base = 'https://zephyrprojectsec.atlassian.net/browse/'
+vul_doc = "https://docs.zephyrproject.org/latest/security/vulnerabilities.html"
+
+def flatten_json(j):
+    """Flatten a json input.  Given an array of single map entries,
+    fold them all into a single object."""
+    obj = {}
+    for item in j:
+        for k, v in item.items():
+            if k in obj:
+                raise Exception("Duplicate key: {}".format(k))
+            obj[k] = v
+    return obj
+
+def query(issue, action, *args):
+    cmd = acli_base.copy()
+    cmd.extend(['--issue', issue, '--action', action])
+    cmd.extend(args)
+    lines = subprocess.check_output(cmd)
+    return json.loads(lines)
+
+def query_ticket(issue):
+    data = query(issue, "getIssue")
+    return data
+
+def query_weblinks(issue):
+    data = query(issue, "getRemoteLinkList")
+    data = [flatten_json(x) for x in data]
+    return data
+
+def query_links(issue):
+    data = query(issue, "getLinkList")
+    data = [flatten_json(x) for x in data]
+    return data
+
+def clean_version(verno):
+    return re.sub(r' \(\d+\)', '', verno)
+
+class Issue():
+    def __init__(self, issue):
+        self.issue = issue
+        # print("Querying {}".format(issue))
+        self.ticket = query_ticket(issue)
+        self.weblinks = query_weblinks(issue)
+        self.links = query_links(issue)
+        # print("ticket: ", self.ticket)
+        # print("links: ", self.links)
+        # print("done")
+
+    def cve(self):
+        return self.ticket["CVE"]
+
+    def description(self):
+        return self.ticket["Description"]
+
+    def summary(self):
+        return self.ticket["Summary"]
+
+    def get_links(self):
+        links = [link["URL"] for link in self.weblinks]
+
+        # Go through the subtasks, and get their links.
+        for child in self.links:
+            if child["Type Name"] != "Sub-Task":
+                continue
+            child_id = child["To Issue"]
+            child_links = query_weblinks(child_id)
+            links.extend([link["URL"] for link in child_links])
+
+        return links
+
+    def get_affected_versions(self):
+        vre = re.compile(r"(v\d+(\.\d+)+)")
+        aff = [x[0] for x in vre.findall(self.ticket["Affects versions"])]
+
+        # Textual sort isn't quite right, but probably ok for this.
+        aff.sort()
+        return aff
+
+
+    def get_full_links(self):
+        links = [{
+            "ver": clean_version(self.ticket["Fix versions"]),
+            "URL": link["URL"]
+            } for link in self.weblinks]
+
+        for child in self.links:
+            if child["Type Name"] != "Sub-Task":
+                continue
+            child_id = child["To Issue"]
+            child_ticket = query_ticket(child_id)
+            child_links = query_weblinks(child_id)
+            links.extend([{
+                "ver": clean_version(child_ticket["Fix versions"]),
+                "URL": link["URL"],
+                } for link in child_links])
+
+        links.sort(key=lambda x: x["ver"])
+
+        return links
+
+    def get_fixed_versions(self):
+        return [x["ver"] for x in self.get_full_links()]
+
+def add_ref(refs, text):
+    refs.append({
+        "refsource": "CONFIRM",
+        "url": text})
+
+if __name__ == '__main__':
+    args = sys.argv[1:]
+    if len(args) != 2:
+        print("Usage: tocve.py ZEPSEC-nn {cve|rnote}")
+        sys.exit(1)
+    ticket = args[0]
+    command = args[1]
+
+    with open('cve-template.json') as fp:
+        cve = json.load(fp)
+    issue = Issue(ticket)
+    cve_id = issue.cve()
+
+    if command == 'cve':
+        aff_ver = issue.get_affected_versions()
+        valt = "This issue affects:\nzephyrproject-rtos zephyr"
+        for ver in aff_ver:
+            valt += "\nversion {} and later versions.".format(ver[1:])
+
+        cve["CVE_data_meta"]["ID"] = cve_id
+        cve["CVE_data_meta"]["TITLE"] = issue.summary()
+        cve["description"]["description_data"] = [{
+                "lang": "eng",
+                "value": issue.description() },
+                { "lang": "eng", "value": valt }
+                ]
+        cve["source"]["defect"] = [
+                url_base + ticket ]
+
+        refs = []
+        add_ref(refs, url_base + ticket)
+        add_ref(refs, vul_doc + "#" + cve_id)
+        for link in issue.get_links():
+            add_ref(refs, link)
+
+        cve["references"]["reference_data"] = refs
+
+        versions = []
+        for ver in aff_ver:
+            versions.append({
+                "version_affected": ">=",
+                "version_value": ver[1:]})
+        cve["affects"]["vendor"]["vendor_data"][0]["product"]["product_data"][0]["version"]["version_data"] = versions
+
+        json.dump(cve, sys.stdout, indent=4)
+
+    if command == 'rnote':
+        print(cve_id)
+        print('-' * len(cve_id))
+        print()
+        print(issue.summary())
+        print()
+        print(issue.description())
+        print()
+        aff = issue.get_fixed_versions()
+        aff[-1] = "and " + aff[-1]
+        print("This has been fixed in releases {}.".format(
+            ", ".join(aff)))
+        print()
+        print("- `CVS <{}#{}>`_".format(vul_doc, cve_id))
+        print()
+        print("- `Zephyr project bug tracker")
+        print("  <{}{}>`_".format(url_base, ticket))
+        print()
+        for link in issue.get_full_links():
+            print("- `PR fix for {}".format(link["ver"]))
+            print("  <{}>`_".format(link["URL"]))
+            print()

--- a/scripts/security/tocve.py
+++ b/scripts/security/tocve.py
@@ -163,6 +163,10 @@ def add_ref(refs, text):
         "refsource": "CONFIRM",
         "url": text})
 
+def get_pr(link):
+    """Convert a link into a PR number"""
+    return link.split('/')[-1]
+
 if __name__ == '__main__':
     args = sys.argv[1:]
     if len(args) != 2:
@@ -222,12 +226,12 @@ if __name__ == '__main__':
         print("This has been fixed in releases {}.".format(
             ", ".join(aff)))
         print()
-        print("- `CVS <{}#{}>`_".format(vul_doc, cve_id))
+        print("- `{} <{}#{}>`_".format(cve_id, vul_doc, cve_id))
         print()
-        print("- `Zephyr project bug tracker")
+        print("- `Zephyr project bug tracker {}".format(ticket))
         print("  <{}{}>`_".format(url_base, ticket))
         print()
         for link in issue.get_full_links():
-            print("- `PR fix for {}".format(link["ver"]))
+            print("- `PR{} fix for {}".format(get_pr(link["URL"]), link["ver"]))
             print("  <{}>`_".format(link["URL"]))
             print()

--- a/scripts/security/tocve.py
+++ b/scripts/security/tocve.py
@@ -1,4 +1,6 @@
 #! /usr/bin/env python3
+# Copyright (c) 2020 Linaro LTD
+# SPDX-License-Identifier: Apache-2.0
 
 import json
 import logging

--- a/scripts/security/tocve.py
+++ b/scripts/security/tocve.py
@@ -112,6 +112,9 @@ class Issue():
             if child["Type Name"] != "Sub-Task":
                 continue
             child_id = child["To Issue"]
+            child_ticket = query_ticket(child_id)
+            if child_ticket["Status"].startswith("Rejected"):
+                continue
             child_links = query_weblinks(child_id)
             links.extend([link["URL"] for link in child_links])
 
@@ -137,9 +140,14 @@ class Issue():
                 continue
             child_id = child["To Issue"]
             child_ticket = query_ticket(child_id)
+            if child_ticket["Status"].startswith("Rejected"):
+                continue
             child_links = query_weblinks(child_id)
+            ver = clean_version(child_ticket["Fix versions"])
+            if len(ver) == 0:
+                ver = "branch from " + clean_version(child_ticket["Affects versions"])
             links.extend([{
-                "ver": clean_version(child_ticket["Fix versions"]),
+                "ver": ver,
                 "URL": link["URL"],
                 } for link in child_links])
 


### PR DESCRIPTION
This script is primarily intended to be used by the security team to
help generate release notes and CVE database entries based on the
security JIRA instance.

Signed-off-by: David Brown <david.brown@linaro.org>