### PR TITLE
drivers: eth: gmac: Convert to use k_timeout_t

### DIFF
--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1863,7 +1863,7 @@ static void monitor_work_handler(struct k_work *work)
 finally:
 	/* Submit delayed work */
 	k_delayed_work_submit(&dev_data->monitor_work,
-			      CONFIG_ETH_SAM_GMAC_MONITOR_PERIOD);
+			      K_MSEC(CONFIG_ETH_SAM_GMAC_MONITOR_PERIOD));
 }
 
 static void eth0_iface_init(struct net_if *iface)
@@ -1982,7 +1982,7 @@ static void eth0_iface_init(struct net_if *iface)
 	/* Initialise monitor */
 	k_delayed_work_init(&dev_data->monitor_work, monitor_work_handler);
 	k_delayed_work_submit(&dev_data->monitor_work,
-			      CONFIG_ETH_SAM_GMAC_MONITOR_PERIOD);
+			      K_MSEC(CONFIG_ETH_SAM_GMAC_MONITOR_PERIOD));
 
 	/* Do not start the interface until PHY link is up */
 	net_if_flag_set(iface, NET_IF_NO_AUTO_START);


### PR DESCRIPTION
Convert the code to use k_timeout_t when applicable.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>