### PR TITLE
qemu_x86: use icount for 32-bit

### DIFF
--- a/boards/x86/qemu_x86/board.cmake
+++ b/boards/x86/qemu_x86/board.cmake
@@ -11,6 +11,7 @@ if(CONFIG_X86_64)
   set(QEMU_CPU_TYPE_${ARCH} qemu64,+x2apic)
 else()
   set(QEMU_CPU_TYPE_${ARCH} qemu32,+nx,+pae)
+  set(ICOUNT_ARG -icount shift=5,align=off,sleep=off -rtc clock=vm)
 endif()
 
 set(QEMU_FLAGS_${ARCH}
@@ -19,6 +20,7 @@ set(QEMU_FLAGS_${ARCH}
   -device isa-debug-exit,iobase=0xf4,iosize=0x04
   ${REBOOT_FLAG}
   -nographic
+  ${ICOUNT_ARG}
   )
 
 # TODO: Support debug


### PR DESCRIPTION
Options summary:

 -icount shift=5: Execute one instruction every 32ns of virtual time
 -icount align=off: Do not synchronise the host and guest clocks
 -icount sleep=off: Advance virtual time without sleeping/waiting
 -rtc clock=vm: Isolate the guest RTC time from the host

64-bit still has some issues that are being looked at.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>