### PR TITLE
Bluetooth: Fix NULL pointer dereference when bt_send() fails

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -5197,8 +5197,7 @@ static void send_cmd(void)
 	if (err) {
 		BT_ERR("Unable to send to driver (err %d)", err);
 		k_sem_give(&bt_dev.ncmd_sem);
-		hci_cmd_done(cmd(buf)->opcode, BT_HCI_ERR_UNSPECIFIED,
-			     NULL);
+		hci_cmd_done(cmd(buf)->opcode, BT_HCI_ERR_UNSPECIFIED, buf);
 		net_buf_unref(bt_dev.sent_cmd);
 		bt_dev.sent_cmd = NULL;
 		net_buf_unref(buf);


### PR DESCRIPTION
The last parameter to hci_cmd_done() is expected to be a valid net_buf
since the function immediately tries to dereference it. Fix this by
passing the appropriate buffer reference to the function.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>