### PR TITLE
doc: trivial kernel doc fixes

### DIFF
--- a/doc/reference/kernel/data_passing/queues.rst
+++ b/doc/reference/kernel/data_passing/queues.rst
@@ -1,0 +1,18 @@
+.. _queues:
+
+Queues
+######
+
+
+Configuration Options
+*********************
+
+Related configuration options:
+
+* None
+
+API Reference
+*************
+
+.. doxygengroup:: queue_apis
+   :project: Zephyr

--- a/doc/reference/kernel/index.rst
+++ b/doc/reference/kernel/index.rst
@@ -74,6 +74,7 @@ argument.
 .. toctree::
    :maxdepth: 1
 
+   data_passing/queues.rst
    data_passing/fifos.rst
    data_passing/lifos.rst
    data_passing/stacks.rst

--- a/doc/reference/networking/can_api.rst
+++ b/doc/reference/networking/can_api.rst
@@ -163,9 +163,9 @@ a mailbox. When a transmitting mailbox is assigned, sending cannot be canceled.
 
 This example shows how to send a frame with extended identifier 0x1234567 and
 two bytes of data. The provided callback is called when the message is sent, or
-an error occurred. Passing `K_FOREVER` to the timeout causes the function to block
-until a transfer mailbox is assigned to the frame or an error occurred. It does
-not block until the message is sent like the example above.
+an error occurred. Passing :c:macro:`K_FOREVER` to the timeout causes the
+function to block until a transfer mailbox is assigned to the frame or an error
+occurred. It does not block until the message is sent like the example above.
 
 .. code-block:: C
 


### PR DESCRIPTION
- fix queue references from doxygen.
- use :c:macro for K_FOREVER