### PR TITLE
stm32_pinctrl: remove duplicate definition

### DIFF
--- a/include/dt-bindings/pinctrl/stm32-pinctrl-common.h
+++ b/include/dt-bindings/pinctrl/stm32-pinctrl-common.h
@@ -28,17 +28,8 @@
 #define STM32_PORTS_MAX (STM32_PORTK + 1)
 #endif
 
-/**
- * @brief helper macro to encode an IO port pin in a numerical format
- */
-#define STM32PIN(_port, _pin) \
-	(_port << 4 | _pin)
-
-
 #define STM32_PINMUX_FUNC_GPIO 0
 #define STM32_PINMUX_FUNC_ANALOG (STM32_PINMUX_FUNC_ALT_MAX)
-
-
 
 /**
  * @brief helper macro to encode an IO port pin in a numerical format


### PR DESCRIPTION
remove duplicate definition of STM32PIN

Signed-off-by: Parthiban Nallathambi <parthiban@linumiz.com>