### PR TITLE
NN: Integrate CMSIS-NN 1.3.0 (CMSIS 5.7.0)

### DIFF
--- a/modules/Kconfig.cmsis
+++ b/modules/Kconfig.cmsis
@@ -28,3 +28,12 @@ menuconfig CMSIS_DSP
 if CMSIS_DSP
 source "modules/Kconfig.cmsis_dsp"
 endif
+
+menuconfig CMSIS_NN
+	bool "CMSIS-NN Library Support"
+	depends on CPU_CORTEX
+	select CMSIS_DSP
+
+if CMSIS_NN
+source "modules/Kconfig.cmsis_nn"
+endif

--- a/modules/Kconfig.cmsis_nn
+++ b/modules/Kconfig.cmsis_nn
@@ -1,0 +1,64 @@
+# Copyright (c) 2020 Silvano Cortesi <cortesis@student.ethz.ch>
+# SPDX-License-Identifier: Apache-2.0
+
+comment "Components"
+
+config CMSIS_NN_ACTIVATION
+	bool "Activation"
+	default y
+	help
+	  This option enables the NN libraries for the activation layers
+	  It can perform activation layers, including ReLU (Rectified
+	  Linear Unit), sigmoid and tanh.
+
+config CMSIS_NN_BASICMATH
+	bool "Basic Math for NN"
+	default y
+	help
+	  This option enables the NN libraries for the basic maths operations.
+	  It adds functionality for element-wise add and multiplication functions.
+
+config CMSIS_NN_CONCATENATION
+	bool "Concatenation"
+	default y
+	help
+	  This option enables the NN libraries for the concatenation layers.
+
+config CMSIS_NN_CONVOLUTION
+	bool "Convolution"
+	default y
+	help
+	  Collection of convolution, depthwise convolution functions and
+	  their variants. The convolution is implemented in 2 steps: im2col
+	  and GEMM. GEMM is performed with CMSIS-DSP arm_mat_mult similar options.
+
+config CMSIS_NN_FULLYCONNECTED
+	bool "Fully Connected"
+	default y
+	help
+	  Collection of fully-connected and matrix multiplication functions.
+
+config CMSIS_NN_NNSUPPORT
+	bool "NN Support"
+	default y
+	help
+	  When off, its default behavior is all tables are included.
+
+config CMSIS_NN_POOLING
+	bool "Pooling"
+	default y
+	help
+	  This option enables pooling layers, including max pooling
+	  and average pooling.
+
+config CMSIS_NN_RESHAPE
+	bool "Reshape"
+	default y
+	help
+	  This option enables the NN libraries for the reshape layers.
+
+config CMSIS_NN_SOFTMAX
+	bool "Softmax"
+	default y
+	help
+	  This option enables the NN libraries for the softmax layers (exp2 based).

--- a/west.yml
+++ b/west.yml
@@ -26,7 +26,7 @@ manifest:
   # Please add items below based on alphabetical order
   projects:
     - name: cmsis
-      revision: 542b2296e6d515b265e25c6b7208e8fea3014f90
+      revision: pull/6/head
       path: modules/hal/cmsis
     - name: hal_atmel
       revision: 1fe96f0a5e1a11d8101b258a3b84d35dc7178401


### PR DESCRIPTION
This commit integrates the newly added CMSIS-NN 1.3.0 (part of CMSIS
5.7.0 release) component to the Zephyr build system.

It refers to https://github.com/zephyrproject-rtos/cmsis/pull/6.
Changes were made to `Kconfig.cmsis` and `west.yml`,
`Kconfig.cmsis_nn` is added.

Signed-off-by: Silvano Cortesi <cortesis@student.ethz.ch>