### PR TITLE
doc: cmake: using common python.cmake code

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -26,7 +26,7 @@ else()
   message(STATUS "West: not found")
 endif()
 
-find_package(PythonInterp 3.6 REQUIRED)
+include(${ZEPHYR_BASE}/cmake/python.cmake)
 set(DOXYGEN_SKIP_DOT True)
 find_package(Doxygen REQUIRED)
 find_package(LATEX)


### PR DESCRIPTION
Fixes: #24903

This commit now includes `${ZEPHYR_BASE}/cmake/python.cmake` to locate
python3.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>