### PR TITLE
checkpatch: suppress SPDX license line check

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -16,4 +16,5 @@
 --ignore MINMAX
 --ignore CONST_STRUCT
 --ignore FILE_PATH_CHANGES
+--ignore SPDX_LICENSE_TAG
 --exclude ext


### PR DESCRIPTION
Zephyr has not committed to complying with the upstream requirement
that the SPDX declaration be on the first line of a file, so disable
the warning.

Alternative to #24921