### PR TITLE
tester: Adjust to recent changes in BTP API

### DIFF
--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -739,9 +739,12 @@ struct l2cap_connect_cmd {
 	u8_t address_type;
 	u8_t address[6];
 	u16_t psm;
+	u16_t mtu;
+	u8_t num;
 } __packed;
 struct l2cap_connect_rp {
-	u8_t chan_id;
+	u8_t num;
+	u8_t chan_id[0];
 } __packed;
 
 #define L2CAP_DISCONNECT		0x03
@@ -763,6 +766,8 @@ struct l2cap_send_data_cmd {
 struct l2cap_listen_cmd {
 	u16_t psm;
 	u8_t transport;
+	uint16_t mtu;
+	uint16_t response;
 } __packed;
 
 #define L2CAP_ACCEPT_CONNECTION		0x06
@@ -784,6 +789,10 @@ struct l2cap_connection_req_ev {
 struct l2cap_connected_ev {
 	u8_t chan_id;
 	u16_t psm;
+	u16_t mtu_remote;
+	u16_t mps_remote;
+	u16_t mtu_local;
+	u16_t mps_local;
 	u8_t address_type;
 	u8_t address[6];
 } __packed;

--- a/tests/bluetooth/tester/src/l2cap.c
+++ b/tests/bluetooth/tester/src/l2cap.c
@@ -66,6 +66,10 @@ static void connected_cb(struct bt_l2cap_chan *l2cap_chan)
 	if (!bt_conn_get_info(l2cap_chan->conn, &info)) {
 		switch (info.type) {
 		case BT_CONN_TYPE_LE:
+			ev.mtu_remote = sys_cpu_to_le16(chan->le.tx.mtu);
+			ev.mps_remote = sys_cpu_to_le16(chan->le.tx.mps);
+			ev.mtu_local = sys_cpu_to_le16(chan->le.rx.mtu);
+			ev.mps_local = sys_cpu_to_le16(chan->le.rx.mps);
 			ev.address_type = info.le.dst->type;
 			memcpy(ev.address, info.le.dst->a.val,
 			       sizeof(ev.address));
@@ -139,10 +143,16 @@ static struct channel *get_free_channel()
 static void connect(u8_t *data, u16_t len)
 {
 	const struct l2cap_connect_cmd *cmd = (void *) data;
-	struct l2cap_connect_rp rp;
+	struct l2cap_connect_rp *rp;
 	struct bt_conn *conn;
 	struct channel *chan;
+	u16_t mtu = sys_le16_to_cpu(cmd->mtu);
+	u8_t buf[sizeof(*rp) + 1];
 	int err;
+
+	if (cmd->num > 1 || mtu > DATA_MTU) {
+		goto fail;
+	}
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
 	if (!conn) {
@@ -155,17 +165,19 @@ static void connect(u8_t *data, u16_t len)
 	}
 
 	chan->le.chan.ops = &l2cap_ops;
-	chan->le.rx.mtu = DATA_MTU;
+	chan->le.rx.mtu = mtu;
 
 	err = bt_l2cap_chan_connect(conn, &chan->le.chan, cmd->psm);
 	if (err < 0) {
 		goto fail;
 	}
 
-	rp.chan_id = chan->chan_id;
+	rp = (void *)buf;
+	rp->num = 1U;
+	rp->chan_id[0] = chan->chan_id;
 
 	tester_send(BTP_SERVICE_ID_L2CAP, L2CAP_CONNECT, CONTROLLER_INDEX,
-		    (u8_t *) &rp, sizeof(rp));
+		    (u8_t *)rp, sizeof(buf));
 
 	return;
 


### PR DESCRIPTION
This patch adjusts L2CAP CoC related command and responses to the
recent BTP API changes.
BTP has been extended with Enhanced CoC support, thus few L2CAP
CoC related commands have been changed.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>