### PR TITLE
[WIP] User mode networking

### DIFF
--- a/include/net/net_core.h
+++ b/include/net/net_core.h
@@ -98,7 +98,61 @@ int net_recv_data(struct net_if *iface, struct net_pkt *pkt);
  */
 int net_send_data(struct net_pkt *pkt);
 
+/**
+ * @brief Add a thread to network memory domain
+ *
+ * @details Mark a thread to be able to access networking memory. This
+ * is used in user mode only.
+ *
+ * @param thread Pointer to the thread
+ */
+void net_mem_domain_add_thread(struct k_thread *thread);
+
+/**
+ * @brief Remove a thread from network memory domain.
+ *
+ * @param thread ID of thread going to be removed from network memory domain.
+ */
+void net_mem_domain_remove_thread(struct k_thread *thread);
+
+/**
+ * @brief Grant application access to networking domain.
+ *
+ * @param thread ID of thread granting the access.
+ */
+void net_access_grant_app(struct k_thread *thread);
+
 /** @cond INTERNAL_HIDDEN */
+
+#if defined(CONFIG_NET_USER_MODE)
+#include <app_memory/app_memdomain.h>
+
+#define NET_THREAD_FLAGS K_USER
+
+extern struct k_mem_partition net_partition;
+
+#define Z_NET_PARTITION_EXISTS 1
+
+#define NET_BMEM K_APP_BMEM(net_partition)
+#define NET_DMEM K_APP_DMEM(net_partition)
+
+void net_access_grant_rx(struct k_thread *thread);
+void net_access_grant_tx(struct k_thread *thread);
+#else
+#define NET_THREAD_FLAGS 0
+#define NET_BMEM
+#define NET_DMEM
+
+static inline void net_access_grant_rx(struct k_thread *thread)
+{
+	ARG_UNUSED(thread);
+}
+
+static inline void net_access_grant_tx(struct k_thread *thread)
+{
+	ARG_UNUSED(thread);
+}
+#endif /* CONFIG_NET_USER_MODE */
 
 /* Some helper defines for traffic class support */
 #if defined(CONFIG_NET_TC_TX_COUNT) && defined(CONFIG_NET_TC_RX_COUNT)

--- a/include/net/net_mgmt.h
+++ b/include/net/net_mgmt.h
@@ -271,6 +271,9 @@ static inline int net_mgmt_event_wait(u32_t mgmt_event_mask,
 
 /**
  * @brief Used to wait synchronously on an event mask for a specific iface
+ * @details Note that the synchronous API cannot be used if networking
+ *          stack is running in user mode as the net_mgmt thread cannot
+ *          access the data in the synchronous API context.
  * @param iface a pointer on a valid network interface to listen event to
  * @param mgmt_event_mask A mask of relevant events to wait on. Listened
  *        to events should be relevant to iface events and thus have the bit
@@ -287,6 +290,8 @@ static inline int net_mgmt_event_wait(u32_t mgmt_event_mask,
  * @return 0 on success, a negative error code otherwise. -ETIMEDOUT will
  *         be specifically returned if the timeout kick-in instead of an
  *         actual event.
+ * @return -EACCES is returned if this is called when CONFIG_NET_USER_MODE is
+ *         enabled.
  */
 #ifdef CONFIG_NET_MGMT_EVENT
 int net_mgmt_event_wait_on_iface(struct net_if *iface,

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -1382,6 +1382,21 @@ struct net_pkt *net_pkt_rx_alloc_with_buffer_debug(struct net_if *iface,
 					   _proto, _timeout,		\
 					   __func__, __LINE__)
 #endif /* NET_PKT_DEBUG_ENABLED */
+
+#if defined(CONFIG_NET_USER_MODE)
+void net_pkt_access_grant_tx(struct k_thread *thread);
+void net_pkt_access_grant_rx(struct k_thread *thread);
+#else
+static inline void net_pkt_access_grant_tx(struct k_thread *thread)
+{
+	ARG_UNUSED(thread);
+}
+
+static inline void net_pkt_access_grant_rx(struct k_thread *thread)
+{
+	ARG_UNUSED(thread);
+}
+#endif
 /** @endcond */
 
 /**

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -256,6 +256,16 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 	z_timestamp_main = k_cycle_get_32();
 #endif
 
+#if IS_ENABLED(NETWORKING) && IS_ENABLED(CONFIG_NET_USER_MODE) && \
+	!IS_ENABLED(CONFIG_NET_TEST)
+	/* If we have user mode networking enabled, grant the application
+	 * access to networking subsystem. For Ztest, this is already done
+	 * so skip it in that case.
+	 */
+	extern void net_access_grant_app(struct k_thread *);
+	net_access_grant_app(k_current_get());
+#endif
+
 	extern void main(void);
 
 	main();

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -49,6 +49,12 @@ module-help = Enables offload layer to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 endif # NET_OFFLOAD
 
+config NET_USER_MODE
+	bool "User mode networking stack"
+	depends on NET_NATIVE && USERSPACE
+	help
+	  Run the networking stack in user mode instead of kernel mode.
+
 config NET_RAW_MODE
 	bool
 	help

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -54,10 +54,10 @@ LOG_MODULE_REGISTER(net_conn, CONFIG_NET_CONN_LOG_LEVEL);
 
 #define NET_CONN_RANK(_flags)		(_flags & 0x78)
 
-static struct net_conn conns[CONFIG_NET_MAX_CONN];
+NET_BMEM static struct net_conn conns[CONFIG_NET_MAX_CONN];
 
-static sys_slist_t conn_unused;
-static sys_slist_t conn_used;
+NET_BMEM static sys_slist_t conn_unused;
+NET_BMEM static sys_slist_t conn_used;
 
 #if (CONFIG_NET_CONN_LOG_LEVEL >= LOG_LEVEL_DBG)
 static inline

--- a/subsys/net/ip/nbr.h
+++ b/subsys/net/ip/nbr.h
@@ -76,7 +76,7 @@ struct net_nbr {
 
 /* This is an array of struct net_nbr + some additional data */
 #define NET_NBR_POOL_INIT(_name, _count, _size, _remove, _extra_size)	\
-	struct {							\
+	NET_DMEM struct {						\
 		struct net_nbr nbr;					\
 		u8_t data[ROUND_UP(_size, 4)] __net_nbr_align;	\
 		u8_t extra[ROUND_UP(_extra_size, 4)] __net_nbr_align;\
@@ -105,7 +105,7 @@ struct net_nbr_table {
 /* Type of the table can be NET_NBR_LOCAL or NET_NBR_GLOBAL
  */
 #define NET_NBR_TABLE_INIT(_type, _name, _pool, _clear)			\
-	_type struct net_nbr_table_##_name {				\
+	NET_DMEM _type struct net_nbr_table_##_name {			\
 		struct net_nbr_table table;				\
 	} net_##_name __used = {					\
 		.table = {						\

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -439,6 +439,7 @@ void net_access_grant_rx(struct k_thread *thread)
 	net_mem_domain_add_thread(thread);
 
 	net_pkt_access_grant_rx(thread);
+	net_context_access_grant(thread);
 	net_tc_access_grant_rx(thread);
 	net_if_access_grant_rx(thread);
 }
@@ -448,6 +449,7 @@ void net_access_grant_tx(struct k_thread *thread)
 	net_mem_domain_add_thread(thread);
 
 	net_pkt_access_grant_tx(thread);
+	net_context_access_grant(thread);
 	net_tc_access_grant_tx(thread);
 	net_if_access_grant_tx(thread);
 }

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -438,6 +438,7 @@ void net_access_grant_rx(struct k_thread *thread)
 {
 	net_mem_domain_add_thread(thread);
 
+	net_pkt_access_grant_rx(thread);
 	net_tc_access_grant_rx(thread);
 }
 
@@ -445,6 +446,7 @@ void net_access_grant_tx(struct k_thread *thread)
 {
 	net_mem_domain_add_thread(thread);
 
+	net_pkt_access_grant_tx(thread);
 	net_tc_access_grant_tx(thread);
 }
 
@@ -452,6 +454,7 @@ void net_access_grant_app(struct k_thread *thread)
 {
 	net_mem_domain_add_thread(thread);
 
+	net_pkt_access_grant_tx(thread);
 	net_context_access_grant(thread);
 	net_tc_access_grant_tx(thread);
 }

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -440,6 +440,7 @@ void net_access_grant_rx(struct k_thread *thread)
 
 	net_pkt_access_grant_rx(thread);
 	net_context_access_grant(thread);
+	net_ipv6_access_grant(thread);
 	net_tc_access_grant_rx(thread);
 	net_if_access_grant_rx(thread);
 }
@@ -450,6 +451,7 @@ void net_access_grant_tx(struct k_thread *thread)
 
 	net_pkt_access_grant_tx(thread);
 	net_context_access_grant(thread);
+	net_ipv6_access_grant(thread);
 	net_tc_access_grant_tx(thread);
 	net_if_access_grant_tx(thread);
 }

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -440,6 +440,7 @@ void net_access_grant_rx(struct k_thread *thread)
 
 	net_pkt_access_grant_rx(thread);
 	net_tc_access_grant_rx(thread);
+	net_if_access_grant_rx(thread);
 }
 
 void net_access_grant_tx(struct k_thread *thread)
@@ -448,6 +449,7 @@ void net_access_grant_tx(struct k_thread *thread)
 
 	net_pkt_access_grant_tx(thread);
 	net_tc_access_grant_tx(thread);
+	net_if_access_grant_tx(thread);
 }
 
 void net_access_grant_app(struct k_thread *thread)
@@ -457,6 +459,7 @@ void net_access_grant_app(struct k_thread *thread)
 	net_pkt_access_grant_tx(thread);
 	net_context_access_grant(thread);
 	net_tc_access_grant_tx(thread);
+	net_if_access_grant_tx(thread);
 }
 
 #else /* CONFIG_NET_USER_MODE */

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -62,6 +62,7 @@ void net_tc_access_grant_rx(struct k_thread *thread);
 void net_if_access_grant_tx(struct k_thread *thread);
 void net_if_access_grant_rx(struct k_thread *thread);
 void net_context_access_grant(struct k_thread *thread);
+void net_ipv6_access_grant(struct k_thread *thread);
 #else
 static inline void net_tc_access_grant_tx(struct k_thread *thread)
 {
@@ -84,6 +85,11 @@ static inline void net_if_access_grant_rx(struct k_thread *thread)
 }
 
 static inline void net_context_access_grant(struct k_thread *thread)
+{
+	ARG_UNUSED(thread);
+}
+
+static inline void net_ipv6_access_grant(struct k_thread *thread)
 {
 	ARG_UNUSED(thread);
 }

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -59,6 +59,8 @@ static inline void net_tc_rx_init(void) { }
 #if defined(CONFIG_NET_USER_MODE)
 void net_tc_access_grant_tx(struct k_thread *thread);
 void net_tc_access_grant_rx(struct k_thread *thread);
+void net_if_access_grant_tx(struct k_thread *thread);
+void net_if_access_grant_rx(struct k_thread *thread);
 #else
 static inline void net_tc_access_grant_tx(struct k_thread *thread)
 {
@@ -66,6 +68,16 @@ static inline void net_tc_access_grant_tx(struct k_thread *thread)
 }
 
 static inline void net_tc_access_grant_rx(struct k_thread *thread)
+{
+	ARG_UNUSED(thread);
+}
+
+static inline void net_if_access_grant_tx(struct k_thread *thread)
+{
+	ARG_UNUSED(thread);
+}
+
+static inline void net_if_access_grant_rx(struct k_thread *thread)
 {
 	ARG_UNUSED(thread);
 }

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -61,6 +61,7 @@ void net_tc_access_grant_tx(struct k_thread *thread);
 void net_tc_access_grant_rx(struct k_thread *thread);
 void net_if_access_grant_tx(struct k_thread *thread);
 void net_if_access_grant_rx(struct k_thread *thread);
+void net_context_access_grant(struct k_thread *thread);
 #else
 static inline void net_tc_access_grant_tx(struct k_thread *thread)
 {
@@ -78,6 +79,11 @@ static inline void net_if_access_grant_tx(struct k_thread *thread)
 }
 
 static inline void net_if_access_grant_rx(struct k_thread *thread)
+{
+	ARG_UNUSED(thread);
+}
+
+static inline void net_context_access_grant(struct k_thread *thread)
 {
 	ARG_UNUSED(thread);
 }

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -56,6 +56,21 @@ static inline void net_tc_tx_init(void) { }
 static inline void net_tc_rx_init(void) { }
 #endif
 
+#if defined(CONFIG_NET_USER_MODE)
+void net_tc_access_grant_tx(struct k_thread *thread);
+void net_tc_access_grant_rx(struct k_thread *thread);
+#else
+static inline void net_tc_access_grant_tx(struct k_thread *thread)
+{
+	ARG_UNUSED(thread);
+}
+
+static inline void net_tc_access_grant_rx(struct k_thread *thread)
+{
+	ARG_UNUSED(thread);
+}
+#endif
+
 #if defined(CONFIG_NET_NATIVE)
 enum net_verdict net_ipv4_input(struct net_pkt *pkt);
 enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback);

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -32,10 +32,10 @@ LOG_MODULE_REGISTER(net_ethernet, CONFIG_NET_L2_ETHERNET_LOG_LEVEL);
 
 #define NET_BUF_TIMEOUT K_MSEC(100)
 
-static const struct net_eth_addr multicast_eth_addr __unused = {
+NET_DMEM static const struct net_eth_addr multicast_eth_addr __unused = {
 	{ 0x33, 0x33, 0x00, 0x00, 0x00, 0x00 } };
 
-static const struct net_eth_addr broadcast_eth_addr = {
+NET_DMEM static const struct net_eth_addr broadcast_eth_addr = {
 	{ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } };
 
 const struct net_eth_addr *net_eth_broadcast_addr(void)

--- a/tests/net/mgmt/testcase.yaml
+++ b/tests/net/mgmt/testcase.yaml
@@ -1,6 +1,13 @@
 common:
   depends_on: netif
+  min_ram: 16
+  tags: net mgmt
 tests:
-  net.management:
-    min_ram: 16
-    tags: net mgmt
+  net.management.kernel_mode:
+    extra_configs:
+      - CONFIG_NET_USER_MODE=n
+      - CONFIG_USERSPACE=n
+  net.management.user_mode:
+    extra_configs:
+      - CONFIG_NET_USER_MODE=y
+      - CONFIG_USERSPACE=y

--- a/tests/net/vlan/testcase.yaml
+++ b/tests/net/vlan/testcase.yaml
@@ -1,6 +1,13 @@
 common:
   depends_on: netif
+  min_ram: 32
+  tags: net vlan
 tests:
-  net.vlan:
-    min_ram: 32
-    tags: net vlan
+  net.vlan.kernel_mode:
+    extra_configs:
+      - CONFIG_NET_USER_MODE=n
+      - CONFIG_USERSPACE=n
+  net.vlan.user_mode:
+    extra_configs:
+      - CONFIG_NET_USER_MODE=y
+      - CONFIG_USERSPACE=y


### PR DESCRIPTION
Prototyping with user mode networking concept. The idea is to run networking TX / RX threads in user mode which would isolate the networking code from kernel and improve safety of the system.
The code will create a *net_domain* memory domain, it places necessary networking objects into this domain when possible and sets permissions so that given threads can access these objects.

This is very much WIP and does not work properly yet. Currently there is a permission issue when submitting net_pkt to be sent to TX workqueue and when trying to run the work.

I converted two networking unit tests to use user mode networking, tests/net/mgmt and tests/net/vlan.
You can try these like this:
```
cd tests/net/vlan
cmake . -B build -DCONFIG_NET_USER_MODE=y -DCONFIG_USERSPACE=y -DBOARD=qemu_x86
make -C build run
```

Edit: I prepared a short presentation to May Networking Forum.
https://docs.google.com/document/d/1xJY-j62e87g9cpubnMTq55e0AHIKb6ZwKKP4ERuIlCY/edit?ts=5eaef197#heading=h.23483d4v9wp2