### PR TITLE
boards: stm32: Fix boards names in yaml and/or doc files

### DIFF
--- a/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.yaml
+++ b/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.yaml
@@ -1,5 +1,5 @@
 identifier: 96b_stm32_sensor_mez
-name: 96B_STM32_SENSOR_MEZ
+name: 96Boards STM32 Sensor Mezzanine
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/black_f407ve/doc/index.rst
+++ b/boards/arm/black_f407ve/doc/index.rst
@@ -1,7 +1,7 @@
 .. _black_f407ve_board:
 
-ST BLACK_F407VE
-###############
+Black STM32 F407VE Development Board
+####################################
 
 Overview
 ********

--- a/boards/arm/black_f407zg_pro/doc/index.rst
+++ b/boards/arm/black_f407zg_pro/doc/index.rst
@@ -1,7 +1,7 @@
 .. _black_f407zg_pro_board:
 
-ST BLACK_F407ZG_PRO
-###################
+Black STM32 F407ZG Pro Development Board
+########################################
 
 Overview
 ********

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.yaml
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.yaml
@@ -1,5 +1,5 @@
 identifier: disco_l475_iot1
-name: B-L475E-IOT01A
+name: ST Disco L475 IOT01 (B-L475E-IOT01A)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/mikroe_mini_m4_for_stm32/doc/mikroe_mini_m4_for_stm32.rst
+++ b/boards/arm/mikroe_mini_m4_for_stm32/doc/mikroe_mini_m4_for_stm32.rst
@@ -1,7 +1,7 @@
 .. _mikroe_mini_m4_for_stm32:
 
 Mikroe MINI-M4 for STM32
-#########################
+########################
 
 Overview
 ********

--- a/boards/arm/mikroe_mini_m4_for_stm32/mikroe_mini_m4_for_stm32.yaml
+++ b/boards/arm/mikroe_mini_m4_for_stm32/mikroe_mini_m4_for_stm32.yaml
@@ -1,5 +1,5 @@
 identifier: mikroe_mini_m4_for_stm32
-name: MIKROE_MINI_M4_FOR_STM32
+name: Mikroe MINI-M4 for STM32
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.yaml
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_f091rc
-name: NUCLEO-F091RC
+name: ST Nucleo F091RC
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.yaml
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_f103rb
-name: NUCLEO-F103RB
+name: ST Nucleo F103RB
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.yaml
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_f207zg
-name: NUCLEO-F207ZG
+name: ST Nucleo F207ZG
 type: mcu
 arch: arm
 ram: 128

--- a/boards/arm/nucleo_f302r8/nucleo_f302r8.yaml
+++ b/boards/arm/nucleo_f302r8/nucleo_f302r8.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_f302r8
-name: NUCLEO-F302R8
+name: ST Nucleo F302R8
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_f303re/nucleo_f303re.yaml
+++ b/boards/arm/nucleo_f303re/nucleo_f303re.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_f303re
-name: NUCLEO-F303RE
+name: ST Nucleo F303RE
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8.yaml
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_f334r8
-name: NUCLEO-F334R8
+name: ST Nucleo F334R8
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_f401re/nucleo_f401re.yaml
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_f401re
-name: NUCLEO-F401RE
+name: ST Nucleo F401RE
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_f411re/nucleo_f411re.yaml
+++ b/boards/arm/nucleo_f411re/nucleo_f411re.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_f411re
-name: NUCLEO-F411RE
+name: ST Nucleo F411RE
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_f412zg/nucleo_f412zg.yaml
+++ b/boards/arm/nucleo_f412zg/nucleo_f412zg.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_f412zg
-name: NUCLEO-F412ZG
+name: ST Nucleo F412ZG
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.yaml
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_f413zh
-name: NUCLEO-F413zh
+name: ST Nucleo F413ZH
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.yaml
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_f429zi
-name: NUCLEO-F429ZI
+name: ST Nucleo F429ZI
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_f446re/nucleo_f446re.yaml
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_f446re
-name: NUCLEO-F446RE
+name: ST Nucleo F446RE
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.yaml
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_f746zg
-name: NUCLEO-F746ZG
+name: ST Nucleo F746ZG
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_f756zg/nucleo_f756zg.yaml
+++ b/boards/arm/nucleo_f756zg/nucleo_f756zg.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_f756zg
-name: NUCLEO-F756ZG
+name: ST Nucleo F756ZG
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_f767zi/nucleo_f767zi.yaml
+++ b/boards/arm/nucleo_f767zi/nucleo_f767zi.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_f767zi
-name: NUCLEO-F767ZI
+name: ST Nucleo F767ZI
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.yaml
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_g071rb
-name: ST Nucleo L432KC
+name: ST Nucleo G071RB
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_g431rb/nucleo_g431rb.yaml
+++ b/boards/arm/nucleo_g431rb/nucleo_g431rb.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_g431rb
-name: NUCLEO-G431RB
+name: ST Nucleo G431RB
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_g474re/nucleo_g474re.yaml
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_g474re
-name: NUCLEO-G474RE
+name: ST Nucleo G474RE
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.yaml
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_h743zi
-name: NUCLEO-H743ZI
+name: ST Nucleo H743ZI
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_l053r8/nucleo_l053r8.yaml
+++ b/boards/arm/nucleo_l053r8/nucleo_l053r8.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_l053r8
-name: NUCLEO-L053R8
+name: ST Nucleo L053R8
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.yaml
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_l073rz
-name: NUCLEO-L073RZ
+name: ST Nucleo L073RZ
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_l452re/nucleo_l452re.yaml
+++ b/boards/arm/nucleo_l452re/nucleo_l452re.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_l452re
-name: NUCLEO-L452RE
+name: ST Nucleo L452RE
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.yaml
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_l476rg
-name: NUCLEO-L476RG
+name: ST Nucleo L476RG
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_l496zg/nucleo_l496zg.yaml
+++ b/boards/arm/nucleo_l496zg/nucleo_l496zg.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_l496zg
-name: NUCLEO-L496ZG
+name: ST Nucleo L496ZG
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.yaml
+++ b/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_l4r5zi
-name: NUCLEO-L4R5ZI
+name: ST Nucleo L4R5ZI
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.yaml
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_wb55rg
-name: NUCLEO-WB55RG
+name: ST Nucleo WB55RG
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/olimex_stm32_e407/olimex_stm32_e407.yaml
+++ b/boards/arm/olimex_stm32_e407/olimex_stm32_e407.yaml
@@ -1,5 +1,5 @@
 identifier: olimex_stm32_e407
-name: STM32-E407
+name: OLIMEX-STM32-E407
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/olimex_stm32_h407/olimex_stm32_h407.yaml
+++ b/boards/arm/olimex_stm32_h407/olimex_stm32_h407.yaml
@@ -1,5 +1,5 @@
 identifier: olimex_stm32_h407
-name: STM32-H407
+name: OLIMEX-STM32-H407
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/olimex_stm32_p405/olimex_stm32_p405.yaml
+++ b/boards/arm/olimex_stm32_p405/olimex_stm32_p405.yaml
@@ -1,5 +1,5 @@
 identifier: olimex_stm32_p405
-name: STM32-P405
+name: OLIMEX-STM32-P405
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/sensortile_box/sensortile_box.yaml
+++ b/boards/arm/sensortile_box/sensortile_box.yaml
@@ -1,5 +1,5 @@
 identifier: sensortile_box
-name: SENSORTILE-BOX
+name: ST SensorTile.box
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/steval_fcu001v1/doc/index.rst
+++ b/boards/arm/steval_fcu001v1/doc/index.rst
@@ -1,7 +1,7 @@
 .. _steval_fcu001v1:
 
-STM32 Flight Controller Unit
-############################
+ST STM32 Flight Controller Unit
+###############################
 
 Overview
 ********

--- a/boards/arm/steval_fcu001v1/steval_fcu001v1.yaml
+++ b/boards/arm/steval_fcu001v1/steval_fcu001v1.yaml
@@ -1,5 +1,5 @@
 identifier: steval_fcu001v1
-name: FLIGHT-CONTROLLER-BOARD
+name: ST STM32 Flight Controller Unit
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm3210c_eval/doc/index.rst
+++ b/boards/arm/stm3210c_eval/doc/index.rst
@@ -1,7 +1,7 @@
 .. _stm3210c_eval_board:
 
-STM3210C-EVAL
-#############
+ST STM3210C Evaluation
+######################
 
 Overview
 ********

--- a/boards/arm/stm3210c_eval/stm3210c_eval.yaml
+++ b/boards/arm/stm3210c_eval/stm3210c_eval.yaml
@@ -1,5 +1,5 @@
 identifier: stm3210c_eval
-name: STM3210C-EVAL
+name: ST STM3210C Evaluation
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32373c_eval/doc/index.rst
+++ b/boards/arm/stm32373c_eval/doc/index.rst
@@ -1,7 +1,7 @@
 .. _stm32373c_eval_board:
 
-STM32373C-EVAL
-##############
+ST STM32373C Evaluation
+#######################
 
 Overview
 ********

--- a/boards/arm/stm32373c_eval/stm32373c_eval.yaml
+++ b/boards/arm/stm32373c_eval/stm32373c_eval.yaml
@@ -1,5 +1,5 @@
 identifier: stm32373c_eval
-name: STM32373C-EVAL
+name: ST STM32373C Evaluation
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32_min_dev/stm32_min_dev_black.yaml
+++ b/boards/arm/stm32_min_dev/stm32_min_dev_black.yaml
@@ -1,5 +1,5 @@
 identifier: stm32_min_dev_black
-name: STM32 Minimum Development Board (Black)
+name: STM32 Minimum Development Board
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32_min_dev/stm32_min_dev_blue.yaml
+++ b/boards/arm/stm32_min_dev/stm32_min_dev_blue.yaml
@@ -1,5 +1,5 @@
 identifier: stm32_min_dev_blue
-name: STM32 Minimum Development Board (Blue)
+name: STM32 Minimum Development Board
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32f030_demo/stm32f030_demo.yaml
+++ b/boards/arm/stm32f030_demo/stm32f030_demo.yaml
@@ -1,5 +1,5 @@
 identifier: stm32f030_demo
-name: STM32F030_DEMO
+name: STM32F030 DEMO BOARD
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32f072_eval/doc/index.rst
+++ b/boards/arm/stm32f072_eval/doc/index.rst
@@ -1,7 +1,7 @@
 .. _stm32f072_eval_board:
 
-ST STM32F072-EVAL
-###################
+ST STM32F072 Evaluation
+#######################
 
 Overview
 ********

--- a/boards/arm/stm32f072_eval/stm32f072_eval.yaml
+++ b/boards/arm/stm32f072_eval/stm32f072_eval.yaml
@@ -1,5 +1,5 @@
 identifier: stm32f072_eval
-name: STM32F072-EVAL
+name: ST STM32F072 Evaluation
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32f072b_disco/doc/index.rst
+++ b/boards/arm/stm32f072b_disco/doc/index.rst
@@ -1,7 +1,7 @@
 .. _stm32f072b_disco_board:
 
-ST STM32F072B-DISCO
-###################
+ST STM32F072B Discovery
+#######################
 
 Overview
 ********

--- a/boards/arm/stm32f072b_disco/stm32f072b_disco.yaml
+++ b/boards/arm/stm32f072b_disco/stm32f072b_disco.yaml
@@ -1,5 +1,5 @@
 identifier: stm32f072b_disco
-name: STM32F072B-DISCO
+name: ST STM32F072B Discovery
 type: mcu
 arch: arm
 ram: 16

--- a/boards/arm/stm32f0_disco/doc/index.rst
+++ b/boards/arm/stm32f0_disco/doc/index.rst
@@ -1,6 +1,6 @@
 .. _stm32f0_disco_board:
 
-ST STM32F0 DISCOVERY
+ST STM32F0 Discovery
 ####################
 
 Overview

--- a/boards/arm/stm32f0_disco/stm32f0_disco.yaml
+++ b/boards/arm/stm32f0_disco/stm32f0_disco.yaml
@@ -1,5 +1,5 @@
 identifier: stm32f0_disco
-name: STM32F0DISCOVERY
+name: ST STM32F0 Discovery
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32f3_disco/doc/index.rst
+++ b/boards/arm/stm32f3_disco/doc/index.rst
@@ -1,6 +1,6 @@
 .. _stm32f3_disco_board:
 
-ST STM32F3 DISCOVERY
+ST STM32F3 Discovery
 ####################
 
 Overview

--- a/boards/arm/stm32f3_disco/stm32f3_disco.yaml
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.yaml
@@ -1,5 +1,5 @@
 identifier: stm32f3_disco
-name: STM32F3DISCOVERY
+name: ST STM32F3 Discovery
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32f411e_disco/doc/index.rst
+++ b/boards/arm/stm32f411e_disco/doc/index.rst
@@ -1,7 +1,7 @@
 .. _stm32f411e_disco_board:
 
-STM32F411E-DISCO
-################
+ST STM32F411E Discovery
+#######################
 
 Overview
 ********

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.yaml
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.yaml
@@ -1,5 +1,5 @@
 identifier: stm32f411e_disco
-name: 32F411EDISCOVERY
+name: ST STM32F411E Discovery
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.yaml
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.yaml
@@ -1,5 +1,5 @@
 identifier: stm32f412g_disco
-name: STM32F412G-DISCO
+name: ST STM32F412G Discovery
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32f429i_disc1/doc/index.rst
+++ b/boards/arm/stm32f429i_disc1/doc/index.rst
@@ -1,7 +1,7 @@
 .. _stm32f429i_disc1_board:
 
-ST STM32F429I-DISC1 Discovery board
-###################################
+ST STM32F429I Discovery
+#######################
 
 Overview
 ********

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.yaml
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.yaml
@@ -1,5 +1,5 @@
 identifier: stm32f429i_disc1
-name: STM32F429I-DISC1
+name: ST STM32F429I Discovery
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.yaml
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.yaml
@@ -1,5 +1,5 @@
 identifier: stm32f469i_disco
-name: STM32F469I-DISCO
+name: ST STM32F469I Discovery
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32f4_disco/doc/index.rst
+++ b/boards/arm/stm32f4_disco/doc/index.rst
@@ -1,7 +1,7 @@
 .. _stm32f4_disco_board:
 
-ST STM32F4DISCOVERY
-###################
+ST STM32F4 Discovery
+####################
 
 Overview
 ********

--- a/boards/arm/stm32f4_disco/stm32f4_disco.yaml
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.yaml
@@ -1,5 +1,5 @@
 identifier: stm32f4_disco
-name: STM32F407G-DISC1
+name: ST STM32F4 Discovery
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32f723e_disco/stm32f723e_disco.yaml
+++ b/boards/arm/stm32f723e_disco/stm32f723e_disco.yaml
@@ -1,5 +1,5 @@
 identifier: stm32f723e_disco
-name: STM32F723EDISCOVERY
+name: ST STM32F723E Discovery
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.yaml
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.yaml
@@ -1,5 +1,5 @@
 identifier: stm32f746g_disco
-name: STM32F746GDISCOVERY
+name: ST STM32F746G Discovery
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.yaml
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.yaml
@@ -1,5 +1,5 @@
 identifier: stm32f769i_disco
-name: STM32F769IDISCOVERY
+name: ST STM32F769I Discovery
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32g0316_disco/doc/index.rst
+++ b/boards/arm/stm32g0316_disco/doc/index.rst
@@ -1,7 +1,7 @@
 .. _stm32g0316_disco_board:
 
-STM32G0316-DISCO
-################
+ST STM32G0316 Discovery
+#######################
 
 Overview
 ********

--- a/boards/arm/stm32g0316_disco/stm32g0316_disco.yaml
+++ b/boards/arm/stm32g0316_disco/stm32g0316_disco.yaml
@@ -1,5 +1,5 @@
 identifier: stm32g0316_disco
-name: STM32G0316-DISCO
+name: ST STM32G0316 Discovery
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m4.yaml
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m4.yaml
@@ -1,5 +1,5 @@
 identifier: stm32h747i_disco_m4
-name: STM32H747IDISCOVERY
+name: ST STM32H747I Discovery
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.yaml
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.yaml
@@ -1,5 +1,5 @@
 identifier: stm32h747i_disco_m7
-name: STM32H747IDISCOVERY
+name: ST STM32H747I Discovery
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32l1_disco/doc/index.rst
+++ b/boards/arm/stm32l1_disco/doc/index.rst
@@ -1,7 +1,7 @@
 .. _stm32l1_disco_board:
 
-ST STM32LDISCOVERY and 32L152CDISCOVERY
-#######################################
+ST STM32L1 Discovery
+####################
 
 Overview
 ********

--- a/boards/arm/stm32l1_disco/stm32l1_disco.yaml
+++ b/boards/arm/stm32l1_disco/stm32l1_disco.yaml
@@ -1,5 +1,5 @@
 identifier: stm32l1_disco
-name: STM32L1DISCOVERY
+name: ST STM32L1 Discovery
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32l476g_disco/doc/index.rst
+++ b/boards/arm/stm32l476g_disco/doc/index.rst
@@ -1,7 +1,7 @@
 .. _stm32l476g_disco_board:
 
 ST STM32L476G Discovery
-########################
+#######################
 
 Overview
 ********

--- a/boards/arm/stm32l476g_disco/stm32l476g_disco.yaml
+++ b/boards/arm/stm32l476g_disco/stm32l476g_disco.yaml
@@ -1,5 +1,5 @@
 identifier: stm32l476g_disco
-name: STM32L476GDISCOVERY
+name: ST STM32L476G Discovery
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32l496g_disco/doc/index.rst
+++ b/boards/arm/stm32l496g_disco/doc/index.rst
@@ -1,7 +1,7 @@
 .. _stm32l496g_disco_board:
 
 ST STM32L496G Discovery
-########################
+#######################
 
 Overview
 ********

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.yaml
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.yaml
@@ -1,5 +1,5 @@
 identifier: stm32l496g_disco
-name: STM32L496G-DISCO
+name: ST STM32L496G Discovery
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32mp157c_dk2/stm32mp157c_dk2.yaml
+++ b/boards/arm/stm32mp157c_dk2/stm32mp157c_dk2.yaml
@@ -1,5 +1,5 @@
 identifier: stm32mp157c_dk2
-name: STM32MP157C_DK2
+name: ST STM32MP157C-DK2 Discovery
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32vl_disco/doc/index.rst
+++ b/boards/arm/stm32vl_disco/doc/index.rst
@@ -1,7 +1,7 @@
 .. _stm32vl_disco_board:
 
-ST STM32VLDISCOVERY
-###################
+ST STM32VL Discovery
+####################
 
 Overview
 ********

--- a/boards/arm/stm32vl_disco/stm32vl_disco.yaml
+++ b/boards/arm/stm32vl_disco/stm32vl_disco.yaml
@@ -1,5 +1,5 @@
 identifier: stm32vl_disco
-name: STM32VLDISCOVERY
+name: ST STM32VL Discovery
 type: mcu
 arch: arm
 toolchain:


### PR DESCRIPTION
For atuo doc generation purpose, get name value of boards' yaml files
in sync with name provided as board name in .rst file

Fixes #24927

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>