### PR TITLE
drivers: spi: spi_sam0: fix spi_sam0_fast_txrx()

### DIFF
--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -269,17 +269,15 @@ static void spi_sam0_fast_txrx(SercomSpi *regs,
 	regs->DATA.reg = *tx++;
 
 	while (tx != txend) {
-		/* Load byte N+1 into the transmit register.  TX is
-		 * single buffered and we have at most one byte in
-		 * flight so skip the DRE check.
-		 */
-		regs->DATA.reg = *tx++;
 
 		/* Read byte N+0 from the receive register */
 		while (!regs->INTFLAG.bit.RXC) {
 		}
 
 		*rx++ = regs->DATA.reg;
+
+		/* We just received the response, send the next byte */
+		regs->DATA.reg = *tx++;
 	}
 
 	/* Read the final incoming byte */


### PR DESCRIPTION
The optimisation in `spi_sam0_fast_txrx()` is broken, loading two bytes into the `DATA` register in rapid succession will lose one byte.

This can be observed by running `tests/drivers/spi/spi_loopback`.
The test will get stuck in `spi_sam0_fast_txrx()` forever waiting for the final byte.

Undo this small optimisation and only load the next byte into the `DATA` register after the response has been received.

This fixes `tests/drivers/spi/spi_loopback` for `atsame54_xpro`. (On this board connect PB27 and PB29 for the loopback test)