### PR TITLE
TCP2 TX data path refactoring

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -645,6 +645,8 @@ static struct tcp *tcp_conn_alloc(void)
 
 	tcp_conn_ref(conn);
 
+	conn->seq = tcp_init_isn();
+
 	sys_slist_append(&tcp_conns, (sys_snode_t *)conn);
 out:
 	NET_DBG("conn: %p", conn);

--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -180,3 +180,19 @@ struct tcp { /* TCP connection */
 
 #define FL(_fl, _op, _mask, _args...)					\
 	_flags(_fl, _op, _mask, strlen("" #_args) ? _args : true)
+
+/*
+ * @brief Generate initial TCP sequence number
+ *
+ * @return Return a random TCP sequence number
+ */
+static inline u32_t tcp_init_isn(void)
+{
+	if (IS_ENABLED(CONFIG_NET_TEST_PROTOCOL) ||
+	    IS_ENABLED(CONFIG_NET_TEST)) {
+		return 0;
+	}
+
+	/* Randomise initial seq number */
+	return sys_rand32_get();
+}

--- a/tests/net/tcp2/src/main.c
+++ b/tests/net/tcp2/src/main.c
@@ -380,7 +380,6 @@ static int tester_send(struct device *dev, struct net_pkt *pkt)
 		zassert_true(false, "Undefined test case");
 	}
 
-	net_pkt_unref(pkt);
 	return 0;
 fail:
 	zassert_true(false, "%s failed", __func__);


### PR DESCRIPTION
Refactor TCP2 TX data path. After this it should be more easy to implement retransmit logic.
@ozhuraki the commits might miss some cases with test protocol logic.

Edit: I left out commits from #24852 but that one is required and must be applied before this PR.