### PR TITLE
LPC entropy

### DIFF
--- a/boards/arm/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
+++ b/boards/arm/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
@@ -11,6 +11,7 @@
 		zephyr,code-partition = &sramx;
 		zephyr,console = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
+		zephyr,entropy = &rng;
 	};
 
 	aliases{

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
@@ -29,6 +29,7 @@
 		zephyr,code-partition = &sramx;
 		zephyr,console = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
+		zephyr,entropy = &rng;
 	};
 
 	gpio_keys {

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_ns.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_ns.dts
@@ -28,6 +28,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
+		zephyr,entropy = &rng;
 	};
 
 	gpio_keys {

--- a/drivers/entropy/CMakeLists.txt
+++ b/drivers/entropy/CMakeLists.txt
@@ -4,6 +4,7 @@ zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_CC13XX_CC26XX_RNG  entropy_cc13xx_cc26xx.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_ESP32_RNG          entropy_esp32.c)
+zephyr_library_sources_ifdef(CONFIG_ENTROPY_MCUX_RNG          entropy_mcux_rng.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_MCUX_RNGA          entropy_mcux_rnga.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_MCUX_TRNG          entropy_mcux_trng.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_NRF5_RNG           entropy_nrf5.c)

--- a/drivers/entropy/Kconfig.mcux
+++ b/drivers/entropy/Kconfig.mcux
@@ -18,3 +18,11 @@ config ENTROPY_MCUX_TRNG
 	help
 	  This option enables the true random number generator (TRNG)
 	  driver based on the MCUX TRNG driver.
+
+config ENTROPY_MCUX_RNG
+	bool "MCUX RNG driver"
+	depends on HAS_MCUX_RNG
+	select ENTROPY_HAS_DRIVER
+	help
+	  This option enables the true random number generator (TRNG)
+	  driver based on the MCUX RNG driver on LPC Family.

--- a/drivers/entropy/entropy_mcux_rng.c
+++ b/drivers/entropy/entropy_mcux_rng.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017 Linaro Limited.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_lpc_rng
+
+#include <device.h>
+#include <drivers/entropy.h>
+#include <random/rand32.h>
+#include <init.h>
+
+#include "fsl_rng.h"
+
+struct mcux_entropy_config {
+	RNG_Type *base;
+};
+
+static int entropy_mcux_rng_get_entropy(struct device *dev, u8_t *buffer,
+					 u16_t length)
+{
+	const struct mcux_entropy_config *config = dev->config->config_info;
+	status_t status;
+
+	ARG_UNUSED(dev);
+
+	status = RNG_GetRandomData(config->base, buffer, length);
+	__ASSERT_NO_MSG(!status);
+
+	return 0;
+}
+
+static const struct entropy_driver_api entropy_mcux_rng_api_funcs = {
+	.get_entropy = entropy_mcux_rng_get_entropy
+};
+
+static const struct mcux_entropy_config entropy_mcux_config = {
+	.base = (RNG_Type *)DT_INST_REG_ADDR(0)
+};
+
+static int entropy_mcux_rng_init(struct device *);
+
+DEVICE_AND_API_INIT(entropy_mcux_rng, DT_INST_LABEL(0),
+		    entropy_mcux_rng_init, NULL, &entropy_mcux_config,
+		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    &entropy_mcux_rng_api_funcs);
+
+static int entropy_mcux_rng_init(struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	RNG_Init(entropy_mcux_config.base);
+
+	return 0;
+}

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -187,6 +187,13 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 	};
+
+	rng: rng@3a000 {
+		compatible = "nxp,lpc-rng";
+		reg = <0x3a000 0x1000>;
+		status = "okay";
+		label = "RNG";
+	};
 };
 
 &nvic {

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -199,6 +199,13 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 	};
+
+	rng: rng@3a000 {
+		compatible = "nxp,lpc-rng";
+		reg = <0x3a000 0x1000>;
+		status = "okay";
+		label = "RNG";
+	};
 };
 
 &nvic {

--- a/dts/bindings/rng/nxp,lpc-rng.yaml
+++ b/dts/bindings/rng/nxp,lpc-rng.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2020, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: LPC RNG (Random Number Generator)
+
+compatible: "nxp,lpc-rng"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true
+
+    interrupts:
+      required: false
+
+    label:
+      required: true

--- a/modules/Kconfig.mcux
+++ b/modules/Kconfig.mcux
@@ -104,6 +104,12 @@ config HAS_MCUX_GPT
 	help
 	  Set if the general purpose timer (GPT) module is present in the SoC.
 
+config HAS_MCUX_RNG
+	bool
+	help
+	  Set if the LPC specific random number generator (RNG) module is
+	  present in the SoC.
+
 config HAS_MCUX_RNGA
 	bool
 	help

--- a/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.series
+++ b/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.series
@@ -12,6 +12,9 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 60
 
+config ENTROPY_MCUX_RNG
+	default y if HAS_MCUX_RNG
+
 source "soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.lp*"
 
 endif # SOC_SERIES_LPC55XXX

--- a/soc/arm/nxp_lpc/lpc55xxx/Kconfig.series
+++ b/soc/arm/nxp_lpc/lpc55xxx/Kconfig.series
@@ -8,6 +8,7 @@ config SOC_SERIES_LPC55XXX
 	select ARM
 	select HAS_MCUX
 	select HAS_MCUX_FLEXCOMM
+	select HAS_MCUX_RNG
 	select SOC_FAMILY_LPC
 	select CPU_CORTEX_M_HAS_SYSTICK
 	select CPU_CORTEX_M_HAS_DWT

--- a/west.yml
+++ b/west.yml
@@ -92,7 +92,7 @@ manifest:
       revision: 1c4fdba512b268033a4cf926bddd323866c3261a
       path: tools/net-tools
     - name: hal_nxp
-      revision: 39615db4095858d24d87dfd6d8e0970704aae18a
+      revision: 80a337dc4cc980f80e595971147eb41458b29ae8
       path: modules/hal/nxp
     - name: open-amp
       revision: 724f7e2a4519d7e1d40ef330042682dea950c991


### PR DESCRIPTION
Adds new RNG device for NXP's LPC family and enable it on LPC55S69 devices.

Depends on: https://github.com/zephyrproject-rtos/hal_nxp/pull/40