### PR TITLE
Bluetooth: host: Fix BT_CONN_LE_OPT_NONE renamed issue

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -409,7 +409,7 @@ struct bt_conn *bt_conn_create_le(const bt_addr_le_t *peer,
 {
 	struct bt_conn *conn;
 	struct bt_conn_le_create_param param = BT_CONN_LE_CREATE_PARAM_INIT(
-						BT_LE_CONN_OPT_NONE,
+						BT_CONN_LE_OPT_NONE,
 						BT_GAP_SCAN_FAST_INTERVAL,
 						BT_GAP_SCAN_FAST_INTERVAL);
 
@@ -443,7 +443,7 @@ __deprecated static inline
 int bt_conn_create_auto_le(const struct bt_le_conn_param *conn_param)
 {
 	struct bt_conn_le_create_param param = BT_CONN_LE_CREATE_PARAM_INIT(
-						BT_LE_CONN_OPT_NONE,
+						BT_CONN_LE_OPT_NONE,
 						BT_GAP_SCAN_FAST_INTERVAL,
 						BT_GAP_SCAN_FAST_WINDOW);
 


### PR DESCRIPTION
Fix BT_LE_CONN_OPT_NONE renamed to BT_CONN_LE_OPT_NONE missed in 2
places in conn.h

Regression from commit: fdb3da8aff3d4b6278134a0204f62c68500689f2

This issue got past CI because https://github.com/zephyrproject-rtos/zephyr/pull/24631 and https://github.com/zephyrproject-rtos/zephyr/pull/24829 was merged close together without a CI re-run between them.
