### PR TITLE
modules: Fix HAL eSPI OOB transfer size defines

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
       revision: 3b54187649cc9b37161d49918f1ad28ff7c7f830
       path: modules/hal/openisa
     - name: hal_microchip
-      revision: 688cb7deebd5910357e35843595149b3feba2184
+      revision: aad89bf0531a30dcd6c87e4065f1b973fb31c11f
       path: modules/hal/microchip
     - name: hal_silabs
       revision: 78da967feeac0d51219ef733cc3ccf643336589f


### PR DESCRIPTION
Fixed masking defines for eSPI OOB RX and TX transfer
length registers. The transfer length fields are 13 bit.
The incorrect defines masked 14 bits.

Signed-off-by: Scott Worley <scott.worley@microchip.com>