### PR TITLE
scripts/cocci: add Zephyr macro file

### DIFF
--- a/scripts/coccicheck
+++ b/scripts/coccicheck
@@ -93,6 +93,8 @@ else
 	NPROC="$J"
 fi
 
+OPTIONS="--macro-file $ZEPHYR_BASE/scripts/coccinelle/macros.h $OPTIONS"
+
 if [ "$FILE" != "" ] ; then
     OPTIONS="--patch $ZEPHYR_BASE $OPTIONS"
 fi

--- a/scripts/coccinelle/macros.h
+++ b/scripts/coccinelle/macros.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* File to be specified by -macro-file in invocations of coccinelle
+ * to avoid parse errors that prevent application of rules.
+ *
+ * This is not exhaustive: only defines that have been proven to
+ * inhibit context recognition are listed.  The structure of the file
+ * is expected to follow that of the Coccinelle standard.h macro file.
+ */
+
+/* Zephyr macros */
+
+/* Attributes */
+
+/* Confirmed problematic */
+#define __noinit
+#define __syscall


### PR DESCRIPTION
Zephyr uses some defines to provide additional information about the
item being declared.  When unrecognized these can confuse the
Coccinelle parser so that it does not apply semantic patches in
situations where they should be applied.

Add a macro file that extends the Coccinelle builtin macro file with
some identifiers that are specific to Zephyr.

(Found diagnosing why a patch in #24873 was not applying to some kernel files).