### PR TITLE
kernel: fix issue with k_thread_join() timeouts

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -542,6 +542,7 @@ void z_thread_single_abort(struct k_thread *thread)
 		 */
 		while ((waiter = z_waitq_head(&thread->base.join_waiters)) !=
 		       NULL) {
+			(void)z_abort_thread_timeout(waiter);
 			_priq_wait_remove(&pended_on(waiter)->waitq, waiter);
 			z_mark_thread_as_not_pending(waiter);
 			waiter->base.pended_on = NULL;


### PR DESCRIPTION
If k_thread_join() was passed with an actual timeout value,
and not K_FOREVER, the blocking thread was not being properly
woken up when the target thread exits. The timeout itself
was never aborted, causing the joining thread to remain
un-scheduled until the timeout expires.

Amend the k_thread_join() test cases to check that the join
completed before the provided timeout period expired.

Fixes: #24744

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>