### PR TITLE
boards: decawave_dwm1001_dev: add devicetree node for LIS2DH12

### DIFF
--- a/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
+++ b/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
@@ -95,10 +95,18 @@
 };
 
 &i2c0 {
-	compatible = "nordic,nrf-twi";
+	compatible = "nordic,nrf-twim";
 	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <29>;
 	scl-pin = <28>;
+
+	lis2dh12: lis2dh12@19 {
+		compatible = "st,lis2dh12", "st,lis2dh";
+		reg = <0x19>;
+		irq-gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
+		label = "LIS2DH12-ACCEL";
+	};
 };
 
 &spi1 {


### PR DESCRIPTION
Add devicetree node for LIS2DH12.