### PR TITLE
I2C: bitbang: Fix stop and repeated start conditions

### DIFF
--- a/drivers/i2c/i2c_bitbang.c
+++ b/drivers/i2c/i2c_bitbang.c
@@ -108,6 +108,10 @@ static void i2c_start(struct i2c_bitbang *context)
 
 static void i2c_repeated_start(struct i2c_bitbang *context)
 {
+	i2c_set_sda(context, 1);
+	i2c_set_scl(context, 1);
+	i2c_delay(context->delays[T_HIGH]);
+
 	i2c_delay(context->delays[T_SU_STA]);
 	i2c_start(context);
 }

--- a/drivers/i2c/i2c_bitbang.c
+++ b/drivers/i2c/i2c_bitbang.c
@@ -114,19 +114,12 @@ static void i2c_repeated_start(struct i2c_bitbang *context)
 
 static void i2c_stop(struct i2c_bitbang *context)
 {
+	i2c_set_sda(context, 0);
+	i2c_delay(context->delays[T_LOW]);
+
 	i2c_set_scl(context, 1);
 	i2c_delay(context->delays[T_HIGH]);
 
-	if (i2c_get_sda(context)) {
-		/*
-		 * SDA is already high, so we need to make it low so that
-		 * we can create a rising edge. This means we're effectively
-		 * doing a START.
-		 */
-		i2c_delay(context->delays[T_SU_STA]);
-		i2c_set_sda(context, 0);
-		i2c_delay(context->delays[T_HD_STA]);
-	}
 	i2c_delay(context->delays[T_SU_STP]);
 	i2c_set_sda(context, 1);
 	i2c_delay(context->delays[T_BUF]); /* In case we start again too soon */


### PR DESCRIPTION
Fix the STOP and REPEATED START conditions of the I2C bitbang library. The implementation has been verified against the _I2C-bus specification and user manual_ (NXP UM10204, https://www.nxp.com/docs/en/user-guide/UM10204.pdf).

The behaviour is now similar to what the Linux kernel I2C GPIO bit banging driver is doing (see https://elixir.bootlin.com/linux/latest/source/drivers/i2c/algos/i2c-algo-bit.c#L115).

The fixes have been verified against both an AT24 EEPROM and an NXP FXOS8700 device (of which neither worked with the previous implementation).
