### PR TITLE
boards: arm: Add I2C node and alias for SAM0 Xplained Pro boards

### DIFF
--- a/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
+++ b/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
@@ -14,6 +14,7 @@
 	aliases {
 		led0 = &yellow_led;
 		sw0 = &user_button;
+		i2c-0 = &sercom2;
 	};
 
 	chosen {
@@ -52,6 +53,14 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 	cs-gpios = <&porta 5 0>;
+};
+
+&sercom2 {
+	status = "okay";
+	compatible = "atmel,sam0-i2c";
+	clock-frequency = <I2C_BITRATE_FAST>;
+	#address-cells = <1>;
+	#size-cells = <0>;
 };
 
 &sercom3 {

--- a/boards/arm/atsamd20_xpro/pinmux.c
+++ b/boards/arm/atsamd20_xpro/pinmux.c
@@ -59,6 +59,27 @@ static int board_pinmux_init(struct device *dev)
 #warning Pin mapping may not be configured
 #endif
 
+#if ATMEL_SAM0_DT_SERCOM_CHECK(0, atmel_sam0_i2c)
+#warning Pin mapping may not be configured
+#endif
+#if ATMEL_SAM0_DT_SERCOM_CHECK(1, atmel_sam0_i2c)
+#warning Pin mapping may not be configured
+#endif
+#if ATMEL_SAM0_DT_SERCOM_CHECK(2, atmel_sam0_i2c)
+	/* SERCOM2 on SDA=PA08, SCL=PA09 */
+	pinmux_pin_set(muxa, 8, PINMUX_FUNC_D);
+	pinmux_pin_set(muxa, 9, PINMUX_FUNC_D);
+#endif
+#if ATMEL_SAM0_DT_SERCOM_CHECK(3, atmel_sam0_i2c)
+#warning Pin mapping may not be configured
+#endif
+#if ATMEL_SAM0_DT_SERCOM_CHECK(4, atmel_sam0_i2c)
+#warning Pin mapping may not be configured
+#endif
+#if ATMEL_SAM0_DT_SERCOM_CHECK(5, atmel_sam0_i2c)
+#warning Pin mapping may not be configured
+#endif
+
 	return 0;
 }
 

--- a/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
+++ b/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
@@ -22,6 +22,7 @@
 	aliases {
 		led0 = &led0;
 		sw0 = &user_button;
+		i2c-0 = &sercom2;
 	};
 
 	leds {
@@ -59,6 +60,14 @@
 	current-speed = <115200>;
 	rxpo = <3>;
 	txpo = <0>;
+};
+
+&sercom2 {
+	status = "okay";
+	compatible = "atmel,sam0-i2c";
+	clock-frequency = <I2C_BITRATE_FAST>;
+	#address-cells = <1>;
+	#size-cells = <0>;
 };
 
 &sercom3 {

--- a/boards/arm/atsamd21_xpro/pinmux.c
+++ b/boards/arm/atsamd21_xpro/pinmux.c
@@ -62,6 +62,27 @@ static int board_pinmux_init(struct device *dev)
 	pinmux_pin_set(muxb, 23, PINMUX_FUNC_D);
 #endif
 
+#if ATMEL_SAM0_DT_SERCOM_CHECK(0, atmel_sam0_i2c)
+#warning Pin mapping may not be configured
+#endif
+#if ATMEL_SAM0_DT_SERCOM_CHECK(1, atmel_sam0_i2c)
+#warning Pin mapping may not be configured
+#endif
+#if ATMEL_SAM0_DT_SERCOM_CHECK(2, atmel_sam0_i2c)
+	/* SERCOM2 on SDA=PA08, SCL=PA09 */
+	pinmux_pin_set(muxa, 8, PINMUX_FUNC_D);
+	pinmux_pin_set(muxa, 9, PINMUX_FUNC_D);
+#endif
+#if ATMEL_SAM0_DT_SERCOM_CHECK(3, atmel_sam0_i2c)
+#warning Pin mapping may not be configured
+#endif
+#if ATMEL_SAM0_DT_SERCOM_CHECK(4, atmel_sam0_i2c)
+#warning Pin mapping may not be configured
+#endif
+#if ATMEL_SAM0_DT_SERCOM_CHECK(5, atmel_sam0_i2c)
+#warning Pin mapping may not be configured
+#endif
+
 #ifdef CONFIG_USB_DC_SAM0
 	/* USB DP on PA25, USB DM on PA24 */
 	pinmux_pin_set(muxa, 25, PINMUX_FUNC_G);

--- a/boards/arm/atsame54_xpro/atsame54_xpro.dts
+++ b/boards/arm/atsame54_xpro/atsame54_xpro.dts
@@ -22,6 +22,7 @@
 	aliases {
 		led0 = &led0;
 		sw0 = &button0;
+		i2c-0 = &sercom7;
 	};
 
 	leds {

--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
@@ -22,6 +22,7 @@
 	aliases {
 		led0 = &led0;
 		sw0 = &user_button;
+		i2c-0 = &sercom1;
 	};
 
 	leds {


### PR DESCRIPTION
This PR adds an I2C node and alias (required by the I2C driver test) for the Atmel SAM0-family Xplained Pro boards.