### PR TITLE
scripts: checkpatch: Revert dt-binding vendor prefix check regex change

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -3087,7 +3087,7 @@ sub process {
 
 				next if $compat !~ /^([a-zA-Z0-9\-]+)\,/;
 				my $vendor = $1;
-				`grep -Eq "\\"\\^\Q$vendor\E,\\.\\*\\":" $vp_file`;
+				`grep -Eq "^$vendor\\b" $vp_file`;
 				if ( $? >> 8 ) {
 					WARN("UNDOCUMENTED_DT_STRING",
 					     "DT compatible string vendor \"$vendor\" appears un-documented -- check $vp_file\n" . $herecurr);


### PR DESCRIPTION
```
This commit reverts the device tree binding vendor prefix check regular
expression change that was introduced by the following commit:
5b10fac97efdb444b49f5e3c3ac16048ce8661c6

The changed regular expression fails to detect the correctly specified
vendor prefixes in the `vendor-prefixes.txt`.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```

Failure example: https://github.com/zephyrproject-rtos/zephyr/pull/24957#issuecomment-623764496