### PR TITLE
boards: arm: nucleo_wb55rg: Add missing sw2 alias.

### DIFF
--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -57,6 +57,7 @@
 		led0 = &green_led_2;
 		sw0 = &user_button_1;
 		sw1 = &user_button_2;
+		sw2 = &user_button_3;
 	};
 };
 


### PR DESCRIPTION
Pretty straightforward. Noticed it when testing the `hid-mouse` sample.