### PR TITLE
drivers: dma: atmel_sam0: Convert to use devicetree macros for dma dev

### DIFF
--- a/drivers/dma/dma_sam0.c
+++ b/drivers/dma/dma_sam0.c
@@ -458,6 +458,6 @@ static const struct dma_driver_api dma_sam0_api = {
 	.get_status = dma_sam0_get_status,
 };
 
-DEVICE_AND_API_INIT(dma_sam0_0, CONFIG_DMA_0_NAME, &dma_sam0_init,
+DEVICE_AND_API_INIT(dma_sam0_0, DT_INST_LABEL(0), &dma_sam0_init,
 		    &dmac_data, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &dma_sam0_api);

--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -36,6 +36,7 @@ struct i2c_sam0_dev_config {
 	void (*irq_config_func)(struct device *dev);
 
 #ifdef CONFIG_I2C_SAM0_DMA_DRIVEN
+	char *dma_dev;
 	u8_t write_dma_request;
 	u8_t read_dma_request;
 	u8_t dma_channel;
@@ -711,7 +712,7 @@ static int i2c_sam0_initialize(struct device *dev)
 
 #ifdef CONFIG_I2C_SAM0_DMA_DRIVEN
 
-	data->dma = device_get_binding(CONFIG_DMA_0_NAME);
+	data->dma = device_get_binding(cfg->dma_dev);
 
 #endif
 
@@ -733,6 +734,7 @@ static const struct i2c_driver_api i2c_sam0_driver_api = {
 
 #ifdef CONFIG_I2C_SAM0_DMA_DRIVEN
 #define I2C_SAM0_DMA_CHANNELS(n)					\
+	.dma_dev = ATMEL_SAM0_DT_INST_DMA_NAME(n, tx),			\
 	.write_dma_request = ATMEL_SAM0_DT_INST_DMA_TRIGSRC(n, tx),	\
 	.read_dma_request = ATMEL_SAM0_DT_INST_DMA_TRIGSRC(n, rx),	\
 	.dma_channel = ATMEL_SAM0_DT_INST_DMA_CHANNEL(n, rx),

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -36,6 +36,7 @@ struct uart_sam0_dev_cfg {
 	void (*irq_config_func)(struct device *dev);
 #endif
 #if CONFIG_UART_ASYNC_API
+	char *dma_dev;
 	u8_t tx_dma_request;
 	u8_t tx_dma_channel;
 	u8_t rx_dma_request;
@@ -555,7 +556,7 @@ static int uart_sam0_init(struct device *dev)
 
 #ifdef CONFIG_UART_ASYNC_API
 	dev_data->cfg = cfg;
-	dev_data->dma = device_get_binding(CONFIG_DMA_0_NAME);
+	dev_data->dma = device_get_binding(cfg->dma_dev);
 
 	k_delayed_work_init(&dev_data->tx_timeout_work, uart_sam0_tx_timeout);
 	k_delayed_work_init(&dev_data->rx_timeout_work, uart_sam0_rx_timeout);
@@ -1084,6 +1085,7 @@ static void uart_sam0_irq_config_##n(struct device *dev)		\
 
 #if CONFIG_UART_ASYNC_API
 #define UART_SAM0_DMA_CHANNELS(n)					\
+	.dma_dev = ATMEL_SAM0_DT_INST_DMA_NAME(n, tx),			\
 	.tx_dma_request = ATMEL_SAM0_DT_INST_DMA_TRIGSRC(n, tx),	\
 	.tx_dma_channel = ATMEL_SAM0_DT_INST_DMA_CHANNEL(n, tx),	\
 	.rx_dma_request = ATMEL_SAM0_DT_INST_DMA_TRIGSRC(n, rx),	\

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -33,6 +33,7 @@ struct spi_sam0_config {
 	u16_t gclk_clkctrl_id;
 #endif
 #ifdef CONFIG_SPI_ASYNC
+	char *dma_dev;
 	u8_t tx_dma_request;
 	u8_t tx_dma_channel;
 	u8_t rx_dma_request;
@@ -700,7 +701,7 @@ static int spi_sam0_init(struct device *dev)
 
 #ifdef CONFIG_SPI_ASYNC
 
-	data->dma = device_get_binding(CONFIG_DMA_0_NAME);
+	data->dma = device_get_binding(cfg->dma_dev);
 
 #endif
 
@@ -723,6 +724,7 @@ static const struct spi_driver_api spi_sam0_driver_api = {
 
 #if CONFIG_SPI_ASYNC
 #define SPI_SAM0_DMA_CHANNELS(n)					\
+	.dma_dev = ATMEL_SAM0_DT_INST_DMA_NAME(n, tx),			\
 	.tx_dma_request = ATMEL_SAM0_DT_INST_DMA_TRIGSRC(n, tx),	\
 	.tx_dma_channel = ATMEL_SAM0_DT_INST_DMA_CHANNEL(n, tx),	\
 	.rx_dma_request = ATMEL_SAM0_DT_INST_DMA_TRIGSRC(n, rx),	\

--- a/soc/arm/atmel_sam0/common/atmel_sam0_dt.h
+++ b/soc/arm/atmel_sam0/common/atmel_sam0_dt.h
@@ -29,6 +29,11 @@
 	ATMEL_SAM0_DT_INST_DMA_CELL(n, name, trigsrc)
 #define ATMEL_SAM0_DT_INST_DMA_CHANNEL(n, name) \
 	ATMEL_SAM0_DT_INST_DMA_CELL(n, name, channel)
+#define ATMEL_SAM0_DT_INST_DMA_NAME(n, name)			\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, dmas),		\
+		    (DT_INST_DMAS_LABEL_BY_NAME(n, name)),	\
+		    (NULL))
+
 
 /* Use to check if a sercom 'n' is enabled for a given 'compat' */
 #define ATMEL_SAM0_DT_SERCOM_CHECK(n, compat) \


### PR DESCRIPTION
Convert to using DT_INST_LABEL() in the dma driver and convert dma users
to use the DMA property macros to get the dma controller name.  We make
the assumption in the drivers that there is a single DMA controller
instance.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>