### PR TITLE
CODEOWNERS: Cover all OpenThread directories in net

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -447,12 +447,12 @@
 /subsys/net/lib/lwm2m/                    @rlubos
 /subsys/net/lib/config/                   @jukkar @tbursztyka @pfalcon
 /subsys/net/lib/mqtt/                     @jukkar @tbursztyka @rlubos
-/subsys/net/lib/openthread/               @rlubos
 /subsys/net/lib/coap/                     @rveerama1
 /subsys/net/lib/sockets/                  @jukkar @tbursztyka @pfalcon
 /subsys/net/lib/tls_credentials/          @rlubos
 /subsys/net/l2/                           @jukkar @tbursztyka
 /subsys/net/l2/canbus/                    @alexanderwachter @jukkar
+/subsys/net/*/openthread/                 @rlubos
 /subsys/power/                            @wentongwu @pabigot
 /subsys/random/                           @dleach02
 /subsys/settings/                         @nvlsianpu


### PR DESCRIPTION
Current entry covered only /subsys/net/lib/openthread and not
/subsys/net/l2/openthread.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>