### PR TITLE
boards: arm: nxp_kinetis: Remove Kconfig PWM_[0-3] usage

### DIFF
--- a/boards/arm/frdm_k22f/Kconfig.defconfig
+++ b/boards/arm/frdm_k22f/Kconfig.defconfig
@@ -43,10 +43,6 @@ config I2C_0
 	default y
 	depends on I2C
 
-config PWM_3
-	default y
-	depends on PWM_MCUX_FTM
-
 config SPI_0
 	default y
 	depends on SPI

--- a/boards/arm/frdm_k64f/Kconfig.defconfig
+++ b/boards/arm/frdm_k64f/Kconfig.defconfig
@@ -47,10 +47,6 @@ config TEMP_KINETIS
 	default y if "$(dt_nodelabel_enabled,adc1)"
 	depends on SENSOR
 
-config PWM_3
-	default y
-	depends on PWM_MCUX_FTM
-
 config SPI_0
 	default y
 	depends on SPI

--- a/boards/arm/frdm_k82f/Kconfig.defconfig
+++ b/boards/arm/frdm_k82f/Kconfig.defconfig
@@ -57,10 +57,6 @@ config PINMUX_MCUX_PORTE
 
 endif # PINMUX_MCUX
 
-config PWM_3
-	default y
-	depends on PWM_MCUX_FTM
-
 config SPI_1
 	default y
 	depends on SPI

--- a/boards/arm/hexiwear_k64/Kconfig.defconfig
+++ b/boards/arm/hexiwear_k64/Kconfig.defconfig
@@ -56,10 +56,6 @@ config BATTERY_SENSE
 
 endif # ADC
 
-config PWM_3
-	default y
-	depends on PWM_MCUX_FTM
-
 if SPI
 
 config SPI_0

--- a/boards/arm/twr_ke18f/Kconfig.defconfig
+++ b/boards/arm/twr_ke18f/Kconfig.defconfig
@@ -55,14 +55,4 @@ config TEMP_KINETIS
 	default y if "$(dt_nodelabel_enabled,adc0)"
 	depends on SENSOR
 
-if PWM
-
-config PWM_0
-	default y
-
-config PWM_3
-	default y
-
-endif # PWM
-
 endif # BOARD_TWR_KE18F

--- a/boards/arm/usb_kw24d512/Kconfig.defconfig
+++ b/boards/arm/usb_kw24d512/Kconfig.defconfig
@@ -50,10 +50,6 @@ config I2C_1
 
 endif # I2C
 
-config PWM_1
-	default y
-	depends on PWM_MCUX_FTM
-
 config SPI_1
 	default y
 	depends on SPI


### PR DESCRIPTION
The Kconfig PWM_[0-3] sybmols don't have any meaning for kinetis family
SoCs.  The driver doesn't utilize them and no sample or test code does
either so we can remove setting them in board Kconfig.defconfig files.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>