### PR TITLE
net: Replace NET_WAIT_FOREVER by SYS_FOREVER_MS

### DIFF
--- a/include/net/net_timeout.h
+++ b/include/net/net_timeout.h
@@ -28,12 +28,6 @@
 extern "C" {
 #endif
 
-/**
- * Symbol to indicate that the caller wants the timeout to be waited forever.
- * This can be used when a network API expects a millisecond timeout.
- */
-#define NET_WAIT_FOREVER (-1)
-
 /** Let the max timeout be 100 ms lower because of
  * possible rounding in delayed work implementation.
  */

--- a/include/net/websocket.h
+++ b/include/net/websocket.h
@@ -118,7 +118,7 @@ struct websocket_request {
  * @param req Websocket request. User should allocate and fill the request
  *        data.
  * @param timeout Max timeout to wait for the connection. The timeout value is
- *        in milliseconds. Value NET_WAIT_FOREVER means to wait forever.
+ *        in milliseconds. Value SYS_FOREVER_MS means to wait forever.
  * @param user_data User specified data that is passed to the callback.
  *
  * @return Websocket id to be used when sending/receiving Websocket data.
@@ -143,7 +143,7 @@ int websocket_connect(int http_sock, struct websocket_request *req,
  *        is the only message, then opcode should have proper opcode (text or
  *        binary) set.
  * @param timeout How long to try to send the message. The value is in
- *        milliseconds. Value NET_WAIT_FOREVER means to wait forever.
+ *        milliseconds. Value SYS_FOREVER_MS means to wait forever.
  *
  * @return <0 if error, >=0 amount of bytes sent
  */
@@ -163,7 +163,7 @@ int websocket_send_msg(int ws_sock, const u8_t *payload, size_t payload_len,
  * @param message_type Type of the message.
  * @param remaining How much there is data left in the message after this read.
  * @param timeout How long to try to receive the message.
- *        The value is in milliseconds. Value NET_WAIT_FOREVER means to wait
+ *        The value is in milliseconds. Value SYS_FOREVER_MS means to wait
  *        forever.
  *
  * @return <0 if error, >=0 amount of bytes received

--- a/samples/net/cloud/mqtt_azure/src/main.c
+++ b/samples/net/cloud/mqtt_azure/src/main.c
@@ -309,7 +309,7 @@ static void poll_mqtt(void)
 	int rc;
 
 	while (mqtt_connected) {
-		rc = wait(NET_WAIT_FOREVER);
+		rc = wait(SYS_FOREVER_MS);
 		if (rc > 0) {
 			mqtt_input(&client_ctx);
 		}

--- a/samples/net/sockets/websocket_client/src/main.c
+++ b/samples/net/sockets/websocket_client/src/main.c
@@ -175,7 +175,7 @@ static size_t how_much_to_send(size_t max_len)
 static ssize_t sendall_with_ws_api(int sock, const void *buf, size_t len)
 {
 	return websocket_send_msg(sock, buf, len, WEBSOCKET_OPCODE_DATA_TEXT,
-				  true, true, NET_WAIT_FOREVER);
+				  true, true, SYS_FOREVER_MS);
 }
 
 static ssize_t sendall_with_bsd_api(int sock, const void *buf, size_t len)

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -897,11 +897,7 @@ int dns_resolve_name(struct dns_resolve_context *ctx,
 		return -EINVAL;
 	}
 
-	if (timeout == NET_WAIT_FOREVER) {
-		tout = K_FOREVER;
-	} else {
-		tout = K_MSEC(timeout);
-	}
+	tout = SYS_TIMEOUT_MS(timeout);
 
 	/* Timeout cannot be 0 as we cannot resolve name that fast.
 	 */

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -491,12 +491,7 @@ int http_client_req(int sock, struct http_request *req,
 	req->internal.response.recv_buf_len = req->recv_buf_len;
 	req->internal.user_data = user_data;
 	req->internal.sock = sock;
-
-	if (timeout == NET_WAIT_FOREVER) {
-		req->internal.timeout = K_FOREVER;
-	} else {
-		req->internal.timeout = K_MSEC(timeout);
-	}
+	req->internal.timeout = SYS_TIMEOUT_MS(timeout);
 
 	method = http_method_str(req->method);
 

--- a/subsys/net/lib/mqtt/mqtt_transport_websocket.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_websocket.c
@@ -96,7 +96,7 @@ int mqtt_client_websocket_write(struct mqtt_client *client, const u8_t *data,
 		ret = websocket_send_msg(client->transport.websocket.sock,
 					 data + offset, datalen - offset,
 					 WEBSOCKET_OPCODE_DATA_BINARY,
-					 true, true, NET_WAIT_FOREVER);
+					 true, true, SYS_FOREVER_MS);
 		if (ret < 0) {
 			return -errno;
 		}
@@ -125,7 +125,7 @@ int mqtt_client_websocket_write_msg(struct mqtt_client *client,
 		ret = websocket_send_msg(client->transport.websocket.sock,
 					 message->msg_iov[i].iov_base,
 					 message->msg_iov[i].iov_len, opcode,
-					 true, final, NET_WAIT_FOREVER);
+					 true, final, SYS_FOREVER_MS);
 		if (ret < 0) {
 			return ret;
 		}
@@ -140,7 +140,7 @@ int mqtt_client_websocket_write_msg(struct mqtt_client *client,
 int mqtt_client_websocket_read(struct mqtt_client *client, u8_t *data,
 			       u32_t buflen, bool shall_block)
 {
-	s32_t timeout = NET_WAIT_FOREVER;
+	s32_t timeout = SYS_FOREVER_MS;
 	u32_t message_type = 0U;
 	int ret;
 

--- a/subsys/net/lib/sntp/sntp_simple.c
+++ b/subsys/net/lib/sntp/sntp_simple.c
@@ -36,7 +36,7 @@ int sntp_simple(const char *server, u32_t timeout, struct sntp_time *time)
 		goto freeaddr;
 	}
 
-	if (timeout == NET_WAIT_FOREVER) {
+	if (timeout == SYS_FOREVER_MS) {
 		deadline = (u64_t)timeout;
 	} else {
 		deadline = k_uptime_get() + (u64_t)timeout;

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -1066,7 +1066,7 @@ int z_impl_zsock_poll(struct zsock_pollfd *fds, int nfds, int poll_timeout)
 
 	if (poll_timeout < 0) {
 		timeout = K_FOREVER;
-		poll_timeout = NET_WAIT_FOREVER;
+		poll_timeout = SYS_FOREVER_MS;
 	} else {
 		timeout = K_MSEC(poll_timeout);
 	}

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -476,7 +476,7 @@ static int websocket_prepare_and_send(struct websocket_context *ctx,
 #else
 	k_timeout_t tout = K_FOREVER;
 
-	if (timeout != NET_WAIT_FOREVER) {
+	if (timeout != SYS_FOREVER_MS) {
 		tout = K_MSEC(timeout);
 	}
 
@@ -666,7 +666,7 @@ int websocket_recv_msg(int ws_sock, u8_t *buf, size_t buf_len,
 	int ret;
 	k_timeout_t tout = K_FOREVER;
 
-	if (timeout != NET_WAIT_FOREVER) {
+	if (timeout != SYS_FOREVER_MS) {
 		tout = K_MSEC(timeout);
 	}
 
@@ -913,13 +913,13 @@ static int websocket_recv(struct websocket_context *ctx, u8_t *buf,
 
 static ssize_t websocket_read_vmeth(void *obj, void *buffer, size_t count)
 {
-	return (ssize_t)websocket_recv(obj, buffer, count, NET_WAIT_FOREVER);
+	return (ssize_t)websocket_recv(obj, buffer, count, SYS_FOREVER_MS);
 }
 
 static ssize_t websocket_write_vmeth(void *obj, const void *buffer,
 				     size_t count)
 {
-	return (ssize_t)websocket_send(obj, buffer, count, NET_WAIT_FOREVER);
+	return (ssize_t)websocket_send(obj, buffer, count, SYS_FOREVER_MS);
 }
 
 static ssize_t websocket_sendto_ctx(void *obj, const void *buf, size_t len,
@@ -928,7 +928,7 @@ static ssize_t websocket_sendto_ctx(void *obj, const void *buf, size_t len,
 				    socklen_t addrlen)
 {
 	struct websocket_context *ctx = obj;
-	s32_t timeout = NET_WAIT_FOREVER;
+	s32_t timeout = SYS_FOREVER_MS;
 
 	if (flags & ZSOCK_MSG_DONTWAIT) {
 		timeout = 0;
@@ -945,7 +945,7 @@ static ssize_t websocket_recvfrom_ctx(void *obj, void *buf, size_t max_len,
 				      socklen_t *addrlen)
 {
 	struct websocket_context *ctx = obj;
-	s32_t timeout = NET_WAIT_FOREVER;
+	s32_t timeout = SYS_FOREVER_MS;
 
 	if (flags & ZSOCK_MSG_DONTWAIT) {
 		timeout = 0;

--- a/tests/net/context/src/main.c
+++ b/tests/net/context/src/main.c
@@ -781,7 +781,7 @@ static void net_ctx_recv_v6_timeout_forever(void)
 	recv_cb_timeout_called = false;
 
 	/* Start a thread that will send data to receiver. */
-	tid = start_timeout_v6_thread(NET_WAIT_FOREVER);
+	tid = start_timeout_v6_thread(SYS_FOREVER_MS);
 
 	/* Wait a bit so that we see if recv waited or not */
 	k_sleep(WAIT_TIME);
@@ -807,7 +807,7 @@ static void net_ctx_recv_v4_timeout_forever(void)
 	recv_cb_timeout_called = false;
 
 	/* Start a thread that will send data to receiver. */
-	tid = start_timeout_v4_thread(NET_WAIT_FOREVER);
+	tid = start_timeout_v4_thread(SYS_FOREVER_MS);
 
 	/* Wait a bit so that we see if recv waited or not */
 	k_sleep(WAIT_TIME);

--- a/tests/net/socket/websocket/src/main.c
+++ b/tests/net/socket/websocket/src/main.c
@@ -347,7 +347,7 @@ static void test_send_and_recv_lorem_ipsum(void)
 	ret = websocket_send_msg(POINTER_TO_INT(&ctx),
 				 lorem_ipsum, test_msg_len,
 				 WEBSOCKET_OPCODE_DATA_TEXT, true, true,
-				 NET_WAIT_FOREVER);
+				 SYS_FOREVER_MS);
 	zassert_equal(ret, test_msg_len,
 		      "Should have sent %zd bytes but sent %d instead",
 		      test_msg_len, ret);
@@ -367,7 +367,7 @@ static void test_recv_two_large_split_msg(void)
 
 	ret = websocket_send_msg(POINTER_TO_INT(&ctx), lorem_ipsum,
 				 test_msg_len, WEBSOCKET_OPCODE_DATA_TEXT,
-				 false, true, NET_WAIT_FOREVER);
+				 false, true, SYS_FOREVER_MS);
 	zassert_equal(ret, test_msg_len,
 		      "1st should have sent %zd bytes but sent %d instead",
 		      test_msg_len, ret);


### PR DESCRIPTION
As we now have SYS_FOREVER_MS, use that instead of network
specific NET_WAIT_FOREVER.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>