### PR TITLE
soc: arm: nxp_lpc: Convert from Kconfig to DT_NODELABEL

### DIFF
--- a/soc/arm/nxp_lpc/lpc54xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc54xxx/soc.c
@@ -67,21 +67,23 @@ static ALWAYS_INLINE void clock_init(void)
 	/* Attach 12 MHz clock to FLEXCOMM0 */
 	CLOCK_AttachClk(kFRO12M_to_FLEXCOMM0);
 
-#ifdef CONFIG_I2C_4
+#if DT_HAS_NODE(DT_NODELABEL(flexcomm4)) && \
+    DT_NODE_HAS_COMPAT(DT_NODELABEL(flexcomm4), nxp_lpc_i2c)
 	/* attach 12 MHz clock to FLEXCOMM4 */
 	CLOCK_AttachClk(kFRO12M_to_FLEXCOMM4);
 
 	/* reset FLEXCOMM for I2C */
 	RESET_PeripheralReset(kFC4_RST_SHIFT_RSTn);
-#endif /* CONFIG_I2C_4 */
+#endif
 
-#ifdef CONFIG_SPI_5
+#if DT_HAS_NODE(DT_NODELABEL(flexcomm5)) && \
+    DT_NODE_HAS_COMPAT(DT_NODELABEL(flexcomm5), nxp_lpc_spi)
 	/* Attach 12 MHz clock to FLEXCOMM5 */
 	CLOCK_AttachClk(kFRO12M_to_FLEXCOMM5);
 
 	/* reset FLEXCOMM for SPI */
 	RESET_PeripheralReset(kFC5_RST_SHIFT_RSTn);
-#endif /* CONFIG_SPI_5 */
+#endif
 
 #endif /* CONFIG_SOC_LPC54114_M4 */
 }

--- a/soc/arm/nxp_lpc/lpc55xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc55xxx/soc.c
@@ -61,21 +61,22 @@ static ALWAYS_INLINE void clock_init(void)
 	/* Enables the clock for the I/O controller.: Enable Clock. */
     CLOCK_EnableClock(kCLOCK_Iocon);
 
-#ifdef CONFIG_I2C_4
+#if DT_HAS_NODE(DT_NODELABEL(flexcomm4)) && \
+    DT_NODE_HAS_COMPAT(DT_NODELABEL(flexcomm4), nxp_lpc_i2c)
 	/* attach 12 MHz clock to FLEXCOMM4 */
 	CLOCK_AttachClk(kFRO12M_to_FLEXCOMM4);
 
 	/* reset FLEXCOMM for I2C */
 	RESET_PeripheralReset(kFC4_RST_SHIFT_RSTn);
-#endif /* CONFIG_I2C_4 */
+#endif
 
-#ifdef CONFIG_SPI_8
-	/* Attach 12 MHz clock to FLEXCOMM8 */
+#if DT_HAS_NODE(DT_NODELABEL(hs_lspi))
+	/* Attach 12 MHz clock to HSLSPI */
 	CLOCK_AttachClk(kFRO12M_to_HSLSPI);
 
-	/* reset FLEXCOMM for SPI */
+	/* reset HSLSPI for SPI */
 	RESET_PeripheralReset(kHSLSPI_RST_SHIFT_RSTn);
-#endif /* CONFIG_SPI_8 */
+#endif
 
 #endif /* CONFIG_SOC_LPC55S69_CPU0 */
 }


### PR DESCRIPTION
As we phase out per instance Kconfig symbols convert to utilize
DT_NODELABEL for SPI and I2C instances instead.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>