### PR TITLE
drivers: i2c: i2c_dw: Move to devicetree detection

### DIFF
--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -37,13 +37,11 @@ zephyr_library_sources_ifdef(CONFIG_I2C_STM32_V2
 if(CONFIG_I2C_DW)
   zephyr_library_sources(i2c_dw.c)
   foreach(NUM RANGE 0 7)
-    if(CONFIG_I2C_${NUM})
-      configure_file(
-        i2c_dw_port_x.h
-        ${PROJECT_BINARY_DIR}/include/generated/i2c_dw_port_${NUM}.h
-        @ONLY
-        )
-    endif()
+    configure_file(
+      i2c_dw_port_x.h
+      ${PROJECT_BINARY_DIR}/include/generated/i2c_dw_port_${NUM}.h
+      @ONLY
+      )
   endforeach(NUM)
 endif()
 

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -654,34 +654,34 @@ static int i2c_dw_initialize(struct device *dev)
 	return 0;
 }
 
-#if CONFIG_I2C_0
+#if DT_HAS_DRV_INST(0)
 #include <i2c_dw_port_0.h>
 #endif
 
-#if CONFIG_I2C_1
+#if DT_HAS_DRV_INST(1)
 #include <i2c_dw_port_1.h>
 #endif
 
-#if CONFIG_I2C_2
+#if DT_HAS_DRV_INST(2)
 #include <i2c_dw_port_2.h>
 #endif
 
-#if CONFIG_I2C_3
+#if DT_HAS_DRV_INST(3)
 #include <i2c_dw_port_3.h>
 #endif
 
-#if CONFIG_I2C_4
+#if DT_HAS_DRV_INST(4)
 #include <i2c_dw_port_4.h>
 #endif
 
-#if CONFIG_I2C_5
+#if DT_HAS_DRV_INST(5)
 #include <i2c_dw_port_5.h>
 #endif
 
-#if CONFIG_I2C_6
+#if DT_HAS_DRV_INST(6)
 #include <i2c_dw_port_6.h>
 #endif
 
-#if CONFIG_I2C_7
+#if DT_HAS_DRV_INST(7)
 #include <i2c_dw_port_7.h>
 #endif


### PR DESCRIPTION
We can utilize the devicetree macros to determine which instances to
enable.  This will allow us to phase out the per instance Kconfig
symbols.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>