### PR TITLE
subsys: fs: Fix fs can't support fat LFN

### DIFF
--- a/include/fs/fs_interface.h
+++ b/include/fs/fs_interface.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-#if defined(CONFIG_FILE_SYSTEM_LITTLEFS)
+#if defined(CONFIG_FILE_SYSTEM_LITTLEFS) || defined(CONFIG_FS_FATFS_LFN)
 #define MAX_FILE_NAME 256
 #else /* FAT_FS */
 #define MAX_FILE_NAME 12 /* Uses 8.3 SFN */


### PR DESCRIPTION
Zephyr fs limits fat fs name to 8.3 SFN
cause fs can't use LFN.
When config LFN increase MAX_FILE_NAME to 256.

Signed-off-by: Frank Li <lgl88911@163.com>