### PR TITLE
Bluetooth: host: Handle advertising options for ONE_TIME and USE_NAME

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -325,8 +325,9 @@ enum {
 	 *  connection happens. If this option is not set the stack will
 	 *  take care of keeping advertising enabled even as connections
 	 *  occur.
-	 *  If Advertising directed and connectable then this behaviour is
-	 *  the default behaviour and this flag has no effect.
+	 *  If Advertising directed or the advertiser was started with
+	 *  @ref bt_le_ext_adv_start then this behavior is the default behavior
+	 *  and this flag has no effect.
 	 */
 	BT_LE_ADV_OPT_ONE_TIME = BIT(1),
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -7703,17 +7703,9 @@ int bt_le_adv_start_ext(struct bt_le_ext_adv *adv,
 		bt_conn_unref(conn);
 	}
 
+	/* Flag always set to false by le_ext_adv_param_set */
 	atomic_set_bit_to(adv->flags, BT_ADV_PERSIST, !dir_adv &&
 			  !(param->options & BT_LE_ADV_OPT_ONE_TIME));
-
-	atomic_set_bit_to(adv->flags, BT_ADV_INCLUDE_NAME,
-			  param->options & BT_LE_ADV_OPT_USE_NAME);
-
-	atomic_set_bit_to(adv->flags, BT_ADV_CONNECTABLE,
-			  param->options & BT_LE_ADV_OPT_CONNECTABLE);
-
-	atomic_set_bit_to(adv->flags, BT_ADV_USE_IDENTITY,
-			  param->options & BT_LE_ADV_OPT_USE_IDENTITY);
 
 	return 0;
 }

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -7128,60 +7128,60 @@ static inline bool ad_has_name(const struct bt_data *ad, size_t ad_len)
 static int le_adv_update(struct bt_le_ext_adv *adv,
 			 const struct bt_data *ad, size_t ad_len,
 			 const struct bt_data *sd, size_t sd_len,
-			 bool connectable, bool use_name)
+			 bool scannable, bool use_name)
 {
 	struct bt_ad d[2] = {};
 	struct bt_data data;
+	size_t d_len;
 	int err;
 
+	if (use_name) {
+		const char *name = bt_get_name();
+
+		if ((ad && ad_has_name(ad, ad_len)) ||
+		    (sd && ad_has_name(sd, sd_len))) {
+			/* Cannot use name if name is already set */
+			return -EINVAL;
+		}
+
+		data = (struct bt_data)BT_DATA(
+			BT_DATA_NAME_COMPLETE,
+			name, strlen(name));
+	}
+
+	d_len = 1;
 	d[0].data = ad;
 	d[0].len = ad_len;
 
-	err = set_ad(adv, d, 1);
+	if (use_name && !scannable) {
+		d[1].data = &data;
+		d[1].len = 1;
+		d_len = 2;
+	}
+
+	err = set_ad(adv, d, d_len);
 	if (err) {
 		return err;
 	}
 
-	d[0].data = sd;
-	d[0].len = sd_len;
+	if (scannable) {
+		d_len = 1;
+		d[0].data = sd;
+		d[0].len = sd_len;
 
-	if (use_name) {
-		const char *name;
-
-		if (sd) {
-			/* Cannot use name if name is already set */
-			if (ad_has_name(sd, sd_len)) {
-				return -EINVAL;
-			}
+		if (use_name) {
+			d[1].data = &data;
+			d[1].len = 1;
+			d_len = 2;
 		}
 
-		name = bt_get_name();
-		data = (struct bt_data)BT_DATA(
-			BT_DATA_NAME_COMPLETE,
-			name, strlen(name));
-
-		d[1].data = &data;
-		d[1].len = 1;
-	}
-
-	/*
-	 * We need to set SCAN_RSP when enabling advertising type that
-	 * allows for Scan Requests.
-	 *
-	 * If any data was not provided but we enable connectable
-	 * undirected advertising sd needs to be cleared from values set
-	 * by previous calls.
-	 * Clearing sd is done by calling set_sd() with NULL data and
-	 * zero len.
-	 * So following condition check is unusual but correct.
-	 */
-	if (d[0].data || d[1].data || connectable) {
-		err = set_sd(adv, d, 2);
+		err = set_sd(adv, d, d_len);
 		if (err) {
 			return err;
 		}
 	}
 
+	atomic_set_bit(adv->flags, BT_ADV_DATA_SET);
 	return 0;
 }
 
@@ -7189,7 +7189,7 @@ int bt_le_adv_update_data(const struct bt_data *ad, size_t ad_len,
 			  const struct bt_data *sd, size_t sd_len)
 {
 	struct bt_le_ext_adv *adv = bt_adv_lookup_legacy();
-	bool connectable, use_name;
+	bool scannable, use_name;
 
 	if (!adv) {
 		return -EINVAL;
@@ -7199,10 +7199,10 @@ int bt_le_adv_update_data(const struct bt_data *ad, size_t ad_len,
 		return -EAGAIN;
 	}
 
-	connectable = atomic_test_bit(adv->flags, BT_ADV_CONNECTABLE);
+	scannable = atomic_test_bit(adv->flags, BT_ADV_SCANNABLE);
 	use_name = atomic_test_bit(adv->flags, BT_ADV_INCLUDE_NAME);
 
-	return le_adv_update(adv, ad, ad_len, sd, sd_len, connectable,
+	return le_adv_update(adv, ad, ad_len, sd, sd_len, scannable,
 			     use_name);
 }
 
@@ -7367,7 +7367,7 @@ int bt_le_adv_start_legacy(const struct bt_le_adv_param *param,
 	struct bt_hci_cp_le_set_adv_param set_param;
 	struct bt_conn *conn = NULL;
 	struct net_buf *buf;
-	bool dir_adv = (param->peer != NULL);
+	bool dir_adv = (param->peer != NULL), scannable;
 	int err;
 	struct bt_le_ext_adv *adv;
 
@@ -7415,6 +7415,8 @@ int bt_le_adv_start_legacy(const struct bt_le_adv_param *param,
 	}
 
 	if (param->options & BT_LE_ADV_OPT_CONNECTABLE) {
+		scannable = true;
+
 		if (dir_adv) {
 			if (param->options & BT_LE_ADV_OPT_DIR_MODE_LOW_DUTY) {
 				set_param.type = BT_HCI_ADV_DIRECT_IND_LOW_DUTY;
@@ -7427,11 +7429,10 @@ int bt_le_adv_start_legacy(const struct bt_le_adv_param *param,
 			set_param.type = BT_HCI_ADV_IND;
 		}
 	} else {
-		if (sd || (param->options & BT_LE_ADV_OPT_USE_NAME)) {
-			set_param.type = BT_HCI_ADV_SCAN_IND;
-		} else {
-			set_param.type = BT_HCI_ADV_NONCONN_IND;
-		}
+		scannable = sd || (param->options & BT_LE_ADV_OPT_USE_NAME);
+
+		set_param.type = scannable ? BT_HCI_ADV_SCAN_IND :
+					     BT_HCI_ADV_NONCONN_IND;
 	}
 
 	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));
@@ -7447,8 +7448,7 @@ int bt_le_adv_start_legacy(const struct bt_le_adv_param *param,
 	}
 
 	if (!dir_adv) {
-		err = le_adv_update(adv, ad, ad_len, sd, sd_len,
-				    param->options & BT_LE_ADV_OPT_CONNECTABLE,
+		err = le_adv_update(adv, ad, ad_len, sd, sd_len, scannable,
 				    param->options & BT_LE_ADV_OPT_USE_NAME);
 		if (err) {
 			return err;
@@ -7492,6 +7492,8 @@ int bt_le_adv_start_legacy(const struct bt_le_adv_param *param,
 	atomic_set_bit_to(adv->flags, BT_ADV_CONNECTABLE,
 			  param->options & BT_LE_ADV_OPT_CONNECTABLE);
 
+	atomic_set_bit_to(adv->flags, BT_ADV_SCANNABLE, scannable);
+
 	atomic_set_bit_to(adv->flags, BT_ADV_USE_IDENTITY,
 			  param->options & BT_LE_ADV_OPT_USE_IDENTITY);
 
@@ -7503,7 +7505,7 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 				bool  has_scan_data)
 {
 	struct bt_hci_cp_le_set_ext_adv_param *cp;
-	bool dir_adv = param->peer != NULL;
+	bool dir_adv = param->peer != NULL, scannable;
 	struct net_buf *buf, *rsp;
 	int err;
 
@@ -7580,6 +7582,8 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 		cp->props |= BT_HCI_LE_ADV_PROP_SCAN;
 	}
 
+	scannable = !!(cp->props & BT_HCI_LE_ADV_PROP_SCAN);
+
 	if (dir_adv) {
 		cp->props |= BT_HCI_LE_ADV_PROP_DIRECT;
 		if (!(param->options & BT_LE_ADV_OPT_DIR_MODE_LOW_DUTY)) {
@@ -7616,11 +7620,13 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 	/* Flag only used by bt_le_adv_start API. */
 	atomic_set_bit_to(adv->flags, BT_ADV_PERSIST, false);
 
-	/* Todo: need to handle setting advertising name in correct adv/scan */
-	atomic_set_bit_to(adv->flags, BT_ADV_INCLUDE_NAME, false);
+	atomic_set_bit_to(adv->flags, BT_ADV_INCLUDE_NAME,
+			  param->options & BT_LE_ADV_OPT_USE_NAME);
 
 	atomic_set_bit_to(adv->flags, BT_ADV_CONNECTABLE,
 			  param->options & BT_LE_ADV_OPT_CONNECTABLE);
+
+	atomic_set_bit_to(adv->flags, BT_ADV_SCANNABLE, scannable);
 
 	atomic_set_bit_to(adv->flags, BT_ADV_USE_IDENTITY,
 			  param->options & BT_LE_ADV_OPT_USE_IDENTITY);
@@ -7661,9 +7667,7 @@ int bt_le_adv_start_ext(struct bt_le_ext_adv *adv,
 	}
 
 	if (!dir_adv) {
-		err = le_adv_update(adv, ad, ad_len, sd, sd_len,
-				    param->options & BT_LE_ADV_OPT_CONNECTABLE,
-				    param->options & BT_LE_ADV_OPT_USE_NAME);
+		err = bt_le_ext_adv_set_data(adv, ad, ad_len, sd, sd_len);
 		if (err) {
 			return err;
 		}
@@ -7921,6 +7925,12 @@ int bt_le_ext_adv_start(struct bt_le_ext_adv *adv,
 
 	le_adv_set_private_addr(adv);
 
+	if (atomic_test_bit(adv->flags, BT_ADV_INCLUDE_NAME) &&
+	    !atomic_test_bit(adv->flags, BT_ADV_DATA_SET)) {
+		/* Set the advertiser name */
+		bt_le_ext_adv_set_data(adv, NULL, 0, NULL, 0);
+	}
+
 	err = set_le_adv_enable_ext(adv, true, param);
 	if (err) {
 		BT_ERR("Failed to start advertiser");
@@ -7972,12 +7982,12 @@ int bt_le_ext_adv_set_data(struct bt_le_ext_adv *adv,
 			   const struct bt_data *ad, size_t ad_len,
 			   const struct bt_data *sd, size_t sd_len)
 {
-	bool connectable, use_name;
+	bool scannable, use_name;
 
-	connectable = atomic_test_bit(adv->flags, BT_ADV_CONNECTABLE);
+	scannable = atomic_test_bit(adv->flags, BT_ADV_SCANNABLE);
 	use_name = atomic_test_bit(adv->flags, BT_ADV_INCLUDE_NAME);
 
-	return le_adv_update(adv, ad, ad_len, sd, sd_len, connectable,
+	return le_adv_update(adv, ad, ad_len, sd, sd_len, scannable,
 			     use_name);
 }
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -7613,7 +7613,7 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 		}
 	}
 
-	/* Todo: Figure out how keep advertising works with multiple adv sets */
+	/* Flag only used by bt_le_adv_start API. */
 	atomic_set_bit_to(adv->flags, BT_ADV_PERSIST, false);
 
 	/* Todo: need to handle setting advertising name in correct adv/scan */

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -69,6 +69,8 @@ enum {
 	 * controller.
 	 */
 	BT_ADV_PARAMS_SET,
+	/* Advertising data has been set in the controller. */
+	BT_ADV_DATA_SET,
 	/* Advertising random address pending to be set in the controller. */
 	BT_ADV_RANDOM_ADDR_PENDING,
 	/* The private random address of the advertiser is valid for this cycle
@@ -85,6 +87,8 @@ enum {
 	BT_ADV_INCLUDE_NAME,
 	/* Advertiser set is connectable */
 	BT_ADV_CONNECTABLE,
+	/* Advertiser set is scannable */
+	BT_ADV_SCANNABLE,
 	/* Advertiser set has disabled the use of private addresses and is using
 	 * the identity address instead.
 	 */

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -773,6 +773,8 @@ static int cmd_advertise(const struct shell *shell, size_t argc, char *argv[])
 			param.options |= BT_LE_ADV_OPT_FILTER_CONN;
 		} else if (!strcmp(arg, "identity")) {
 			param.options |= BT_LE_ADV_OPT_USE_IDENTITY;
+		} else if (!strcmp(arg, "no-name")) {
+			param.options &= ~BT_LE_ADV_OPT_USE_NAME;
 		} else {
 			goto fail;
 		}
@@ -874,6 +876,8 @@ static bool adv_param_parse(size_t argc, char *argv[],
 			param->options |= BT_LE_ADV_OPT_FILTER_CONN;
 		} else if (!strcmp(arg, "identity")) {
 			param->options |= BT_LE_ADV_OPT_USE_IDENTITY;
+		} else if (!strcmp(arg, "name")) {
+			param->options |= BT_LE_ADV_OPT_USE_NAME;
 		} else if (!strcmp(arg, "low")) {
 			param->options |= BT_LE_ADV_OPT_DIR_MODE_LOW_DUTY;
 		} else if (!strcmp(arg, "directed")) {
@@ -2257,7 +2261,7 @@ static int cmd_auth_oob_tk(const struct shell *shell, size_t argc, char *argv[])
 #define EXT_ADV_CONN_OPT " [coded] [2m] [no-1m]"
 #define EXT_ADV_PARAM "<type: conn-scan conn-nscan, nconn-scan nconn-nscan> " \
 		      "[ext-adv] [no-2m] [coded] "                            \
-		      "[whitelist: wl, wl-scan, wl-conn] [identity] "         \
+		      "[whitelist: wl, wl-scan, wl-conn] [identity] [name]"   \
 		      "[directed "HELP_ADDR_LE"] [mode: low] "
 #else
 #define EXT_ADV_SCAN_OPT ""
@@ -2284,15 +2288,15 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 #if defined(CONFIG_BT_BROADCASTER)
 	SHELL_CMD_ARG(advertise, NULL,
 		      "<type: off, on, scan, nconn> [mode: discov, non_discov] "
-		      "[whitelist: wl, wl-scan, wl-conn] [identity]",
-		      cmd_advertise, 2, 3),
+		      "[whitelist: wl, wl-scan, wl-conn] [identity] [no-name]",
+		      cmd_advertise, 2, 4),
 #if defined(CONFIG_BT_PERIPHERAL)
 	SHELL_CMD_ARG(directed-adv, NULL, HELP_ADDR_LE " [mode: low]",
 		      cmd_directed_adv, 3, 1),
 #endif /* CONFIG_BT_PERIPHERAL */
 #if defined(CONFIG_BT_EXT_ADV)
-	SHELL_CMD_ARG(adv-create, NULL, EXT_ADV_PARAM, cmd_adv_create, 2, 5),
-	SHELL_CMD_ARG(adv-param, NULL, EXT_ADV_PARAM, cmd_adv_param, 2, 5),
+	SHELL_CMD_ARG(adv-create, NULL, EXT_ADV_PARAM, cmd_adv_create, 2, 8),
+	SHELL_CMD_ARG(adv-param, NULL, EXT_ADV_PARAM, cmd_adv_param, 2, 8),
 	SHELL_CMD_ARG(adv-data, NULL, "<data> [scan-response <data>] "
 				      "<type: discov, name, hex>", cmd_adv_data,
 		      1, 16),


### PR DESCRIPTION
Handle 2 todos for the advertising options ONE_TIME and USE_NAME.

For ONE_TIME document that this is the default behavior when using bt_le_ext_adv_* API and that this option has no effect.

Implement the USE_NAME option for bt_le_ext_adv_* API. When configured for extended connectable advertising the advertiser name must be set in the advertising data, otherwise it is always set in the scan response data.