### PR TITLE
drivers: pwm: Remove per instance Kconfig symbols

### DIFF
--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -20,21 +20,6 @@ config PWM_SHELL
 	help
 	  Enable the PWM related shell commands.
 
-config PWM_0
-	bool "Enable PWM port 0"
-
-config PWM_1
-	bool "Enable PWM port 1"
-
-config PWM_2
-	bool "Enable PWM port 2"
-
-config PWM_3
-	bool "Enable PWM port 3"
-
-config PWM_4
-	bool "Enable PWM port 4"
-
 source "drivers/pwm/Kconfig.pca9685"
 
 source "drivers/pwm/Kconfig.dw"


### PR DESCRIPTION
There are now no users of the per instance Kconfig symbols so we can now
remove them.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>