### PR TITLE
shell: improve hexdump by dumping printable characters

### DIFF
--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -98,6 +98,17 @@ static int cmd_demo_params(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
+static int cmd_demo_hexdump(const struct shell *shell, size_t argc, char **argv)
+{
+	shell_print(shell, "argc = %d", argc);
+	for (size_t cnt = 0; cnt < argc; cnt++) {
+		shell_print(shell, "argv[%d]", cnt);
+		shell_hexdump(shell, argv[cnt], strlen(argv[cnt]));
+	}
+
+	return 0;
+}
+
 static int cmd_version(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
@@ -109,6 +120,7 @@ static int cmd_version(const struct shell *shell, size_t argc, char **argv)
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_demo,
+	SHELL_CMD(hexdump, NULL, "Hexdump params command.", cmd_demo_hexdump),
 	SHELL_CMD(params, NULL, "Print params command.", cmd_demo_params),
 	SHELL_CMD(ping, NULL, "Ping command.", cmd_demo_ping),
 	SHELL_SUBCMD_SET_END /* Array terminated. */


### PR DESCRIPTION
Improve hexdump output of shell_hexdump() to match what is currently
printed by LOG_HEXDUMP*() family of functions. That way string buffers
that are sent/received using shell commands can be easily presented
using shell_hexdump() without loosing user experience (with previous
shell_hexdump() that printed only hex bytes) and code validity (printed
buffers are not always NULL terminated with only printable characters).

Basically this changes:
```
uart:~$ demo hexdump akljalskjf alsjf lkajsfkl jaslkfjalksjflkjaslkjfklasjfkljas
argc = 5
argv[0]
00000000: 68 65 78 64 75 6D 70 
argv[1]
00000000: 61 6B 6C 6A 61 6C 73 6B 6A 66 
argv[2]
00000000: 61 6C 73 6A 66 
argv[3]
00000000: 6C 6B 61 6A 73 66 6B 6C 
argv[4]
00000000: 6A 61 73 6C 6B 66 6A 61 6C 6B 73 6A 66 6C 6B 6A 
00000010: 61 73 6C 6B 6A 66 6B 6C 61 73 6A 66 6B 6C 6A 61 
00000020: 73
```
to:
```
uart:~$ demo hexdump akljalskjf alsjf lkajsfkl jaslkfjalksjflkjaslkjfklasjfkljas
argc = 5
argv[0]
00000000: 68 65 78 64 75 6d 70                             |hexdump          |
argv[1]
00000000: 61 6b 6c 6a 61 6c 73 6b  6a 66                   |akljalsk jf      |
argv[2]
00000000: 61 6c 73 6a 66                                   |alsjf            |
argv[3]
00000000: 6c 6b 61 6a 73 66 6b 6c                          |lkajsfkl         |
argv[4]
00000000: 6a 61 73 6c 6b 66 6a 61  6c 6b 73 6a 66 6c 6b 6a |jaslkfja lksjflkj|
00000010: 61 73 6c 6b 6a 66 6b 6c  61 73 6a 66 6b 6c 6a 61 |aslkjfkl asjfklja|
00000020: 73                                               |s                |
```

One of the use cases is LoRa shell with `send` and `recv` commands: #24577