### PR TITLE
bluetooth: hci_rpmsg: check SHM_SIZE against shared mem size using DT

### DIFF
--- a/drivers/bluetooth/hci/rpmsg_nrf53.c
+++ b/drivers/bluetooth/hci/rpmsg_nrf53.c
@@ -36,6 +36,10 @@ static struct device *ipm_rx_handle;
 #define SHM_SIZE            0x7c00
 #define SHM_DEVICE_NAME     "sram0.shm"
 
+BUILD_ASSERT((SHM_START_ADDR + SHM_SIZE - SHM_BASE_ADDRESS)
+		<= DT_REG_SIZE(SHM_NODE),
+	"Allocated size exceeds available shared memory reserved for IPC");
+
 #define VRING_COUNT         2
 #define VRING_TX_ADDRESS    (SHM_START_ADDR + SHM_SIZE - 0x400)
 #define VRING_RX_ADDRESS    (VRING_TX_ADDRESS - 0x400)

--- a/samples/bluetooth/hci_rpmsg/src/main.c
+++ b/samples/bluetooth/hci_rpmsg/src/main.c
@@ -43,6 +43,10 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define SHM_SIZE            0x7c00
 #define SHM_DEVICE_NAME     "sram0.shm"
 
+BUILD_ASSERT((SHM_START_ADDR + SHM_SIZE - SHM_BASE_ADDRESS)
+		<= DT_REG_SIZE(SHM_NODE),
+	"Allocated size exceeds available shared memory reserved for IPC");
+
 #define VRING_COUNT         2
 #define VRING_TX_ADDRESS    (SHM_START_ADDR + SHM_SIZE - 0x400)
 #define VRING_RX_ADDRESS    (VRING_TX_ADDRESS - 0x400)


### PR DESCRIPTION
Add a build-time assert to check that the configured SHM_SIZE
does not exceed the memory allocated as shared memory. USe DT
to extract the shared memory size.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>