### PR TITLE
doc: fix 'ext' removal path

### DIFF
--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -976,8 +976,8 @@ Create a Debugger Configuration
 
    - In the SVD Path tab:
 
-     - File path: :file:`<zephyr
-       base>\\modules\\hal\\nxp\\mcux\\devices\\MK64F12\\MK64F12.xml`
+     - File path: :file:`<workspace
+       top>\\modules\\hal\\nxp\\mcux\\devices\\MK64F12\\MK64F12.xml`
 
      .. note::
 	This is optional. It provides the SoC's memory-mapped register


### PR DESCRIPTION
The removal of mentions of 'ext' from the documentation needs an
adjustment in the Eclipse debugging page, since 'modules' is not a
subdirectory of the zephyr base directory.

