### PR TITLE
[backport 24954] updatehub: Require peer verification with DTLS

### DIFF
--- a/lib/updatehub/updatehub.c
+++ b/lib/updatehub/updatehub.c
@@ -141,7 +141,7 @@ static bool start_coap_client(void)
 	}
 
 #if defined(CONFIG_UPDATEHUB_DTLS)
-	int verify = 0;
+	int verify = 1;
 	sec_tag_t sec_list[] = { CA_CERTIFICATE_TAG };
 	int protocol = IPPROTO_DTLS_1_2;
 	char port[] = "5684";


### PR DESCRIPTION
DTLS without peer verification offers no security whatsoever (and is
arguably worse than not using DTLS in the first place).

Change the verification option to require this peer verification.  To
use this, it may be necessary to install and use a root certificate.

Signed-off-by: David Brown <david.brown@linaro.org>