### PR TITLE
cmake: find python3 on windows when multiarch are installed

### DIFF
--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -24,10 +24,18 @@ foreach(PYTHON_PREFER ${PYTHON_PREFER} "python" "python3")
                        OUTPUT_STRIP_TRAILING_WHITESPACE)
 
      if(version VERSION_LESS PYTHON_MINIMUM_REQUIRED)
-       set_property (CACHE PYTHON_PREFER_EXECUTABLE PROPERTY VALUE "PYTHON_PREFER_EXECUTABLE-NOTFOUND")
+       set(PYTHON_PREFER_EXECUTABLE "PYTHON_PREFER_EXECUTABLE-NOTFOUND")
      else()
        set(PYTHON_MINIMUM_REQUIRED ${version})
        set(PYTHON_EXACT EXACT)
+       # Python3_ROOT_DIR ensures that location will be preferred by FindPython3.
+       # On Linux, this has no impact as it will usually be /usr/bin
+       # but on Windows it solve issues when both 32 and 64 bit versions are
+       # installed, as version is not enough and FindPython3 might pick the
+       # version not on %PATH%. Setting Python3_ROOT_DIR ensures we are using
+       # the version we just tested.
+       get_filename_component(PYTHON_PATH ${PYTHON_PREFER_EXECUTABLE} DIRECTORY)
+       set(Python3_ROOT_DIR ${PYTHON_PATH})
        break()
      endif()
   endif()


### PR DESCRIPTION
Fixes: #24692

This commit fixes an issue where FindPython3 could wrongly select the
Python version not in environment path.

If user installed both 32 and 64 bit versions of the same Python, for
example 3.7.x, the current search would only specify that 3.7 is needed.

In some cases, FindPython3 could select the 32 bit version, even if the
64 bit version is the one on %PATH%.

This is fixed, by setting Python3_ROOT_DIR to point to the tested Python
in %PATH%.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>