### PR TITLE
arch: arm: aarch32: Add cmsis.h include for cortex m asm_inline_gcc

### DIFF
--- a/include/arch/arm/aarch32/asm_inline_gcc.h
+++ b/include/arch/arm/aarch32/asm_inline_gcc.h
@@ -24,6 +24,8 @@
 
 #if defined(CONFIG_CPU_CORTEX_R)
 #include <arch/arm/aarch32/cortex_a_r/cpu.h>
+#elif defined(CONFIG_CPU_CORTEX_M)
+#include <arch/arm/aarch32/cortex_m/cmsis.h>
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
This fixes build errors from drivers using barriers like _DMB()

Signed-off-by: Eugene Cohen <eugene@nuviainc.com>