### PR TITLE
samples: prod_consumer: run faster

### DIFF
--- a/samples/userspace/prod_consumer/src/app_b.c
+++ b/samples/userspace/prod_consumer/src/app_b.c
@@ -50,7 +50,7 @@ static void processor_thread(void *p1, void *p2, void *p3)
 	 * meanwhile data coming in from the driver will be buffered in the
 	 * incoming queue/
 	 */
-	k_sleep(K_MSEC(4000));
+	k_sleep(K_MSEC(400));
 
 	/* Consume data blobs from shared_queue_incoming.
 	 * Do some processing, and the put the processed data
@@ -64,7 +64,7 @@ static void processor_thread(void *p1, void *p2, void *p3)
 		 * a sandboxed App B
 		 */
 		LOG_DBG("processing payload #%d", process_count);
-		k_busy_wait(1000000);
+		k_busy_wait(100000);
 		process_count++;
 		LOG_INF("processing payload #%d complete", process_count);
 

--- a/samples/userspace/prod_consumer/src/sample_driver_foo.c
+++ b/samples/userspace/prod_consumer/src/sample_driver_foo.c
@@ -59,7 +59,7 @@ static int sample_driver_foo_state_set(struct device *dev, bool active)
 
 	data->timer.user_data = dev;
 	if (active) {
-		k_timer_start(&data->timer, K_MSEC(1000), K_MSEC(1000));
+		k_timer_start(&data->timer, K_MSEC(100), K_MSEC(100));
 	} else {
 		k_timer_stop(&data->timer);
 	}


### PR DESCRIPTION
The whole sample now completes in about 2 seconds.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>