### PR TITLE
scripts: vendor string matching must match Zephyr format

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -3087,7 +3087,7 @@ sub process {
 
 				next if $compat !~ /^([a-zA-Z0-9\-]+)\,/;
 				my $vendor = $1;
-				`grep -Eq "\\"\\^\Q$vendor\E,\\.\\*\\":" $vp_file`;
+				`grep -Eq "^$vendor\\b" $vp_file`;
 				if ( $? >> 8 ) {
 					WARN("UNDOCUMENTED_DT_STRING",
 					     "DT compatible string vendor \"$vendor\" appears un-documented -- check $vp_file\n" . $herecurr);


### PR DESCRIPTION
The format for the Linux vendor-prefixes.yaml is different
from the dt-vendor.txt format in Zephyr. Here's an example

Linux:

  "^arm,.*":
    description: ARM Ltd.

Zephyr:

arm	ARM Ltd.

As such, the regex for the vendor string matching needs to
be adapted. The easiest solution is just to use the
previous regex string.

Signed-off-by: Alex Porosanu <alexandru.porosanu@nxp.com>