### PR TITLE
boards: lpcxpresso55s16: Fix DT_HAS_NODE_STATUS_OKAY conversion

### DIFF
--- a/boards/arm/lpcxpresso55s16/pinmux.c
+++ b/boards/arm/lpcxpresso55s16/pinmux.c
@@ -118,7 +118,7 @@ static int lpcxpresso_55s16_pinmux_init(struct device *dev)
 	pinmux_pin_set(port0, 30, port0_pin30_config);
 #endif
 
-#if DT_HAS_NODE(DT_NODELABEL(flexcomm4)) && \
+#if DT_HAS_NODE_STATUS_OKAY(DT_NODELABEL(flexcomm4)) && \
     DT_NODE_HAS_COMPAT(DT_NODELABEL(flexcomm4), nxp_lpc_i2c)
 	/* PORT1 PIN20 is configured as FC4_TXD_SCL_MISO_WS */
 	pinmux_pin_set(port1, 20, IOCON_PIO_FUNC5  |
@@ -147,7 +147,7 @@ static int lpcxpresso_55s16_pinmux_init(struct device *dev)
 				  IOCON_PIO_OPENDRAIN_DI);
 #endif
 
-#if DT_HAS_NODE(DT_NODELABEL(hs_lspi))
+#if DT_HAS_NODE_STATUS_OKAY(DT_NODELABEL(hs_lspi))
 	/* PORT0 PIN26 is configured as HS_SPI_MOSI */
 	pinmux_pin_set(port0, 26, IOCON_PIO_FUNC9 |
 				  IOCON_PIO_MODE_PULLUP |


### PR DESCRIPTION
Rename a few cases of DT_HAS_NODE to DT_HAS_NODE_STATUS_OKAY that snuck
in after the initial global change.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>