### PR TITLE
sanitycheck: fix enable_coverage argument name typo

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -634,7 +634,7 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
 
     parser.add_argument("-C", "--coverage", action="store_true",
                         help="Generate coverage reports. Implies "
-                             "--enable_coverage.")
+                             "--enable-coverage.")
 
     parser.add_argument("--coverage-platform", action="append", default=[],
                         help="Plarforms to run coverage reports on. "


### PR DESCRIPTION
Argument name is --enable-coverage, whereas attribute name is
enable_coverage

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>