### PR TITLE
boards: Remove Kconfig I2C_[0-9] usage

### DIFF
--- a/boards/arc/em_starterkit/Kconfig.defconfig
+++ b/boards/arc/em_starterkit/Kconfig.defconfig
@@ -38,12 +38,6 @@ if I2C_DW
 config I2C_DW_CLOCK_SPEED
 	default 100
 
-config I2C_0
-	default y
-
-config I2C_1
-	default y
-
 endif # I2C_DW
 
 endif # I2C

--- a/boards/arm/96b_nitrogen/Kconfig.defconfig
+++ b/boards/arm/96b_nitrogen/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_96B_NITROGEN
 config BOARD
 	default "96b_nitrogen"
 
-config I2C_0
-	default y
-	depends on I2C
-
 config SPI_1
 	default y
 	depends on SPI

--- a/boards/arm/b_l072z_lrwan1/Kconfig.defconfig
+++ b/boards/arm/b_l072z_lrwan1/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_B_L072Z_LRWAN1
 config BOARD
 	default "b_l072z_lrwan1"
 
-config I2C_1
-	default y
-	depends on I2C
-
 choice COUNTER_RTC_STM32_CLOCK_SRC
 	default COUNTER_RTC_STM32_CLOCK_LSE
 	depends on COUNTER

--- a/boards/arm/frdm_k22f/Kconfig.defconfig
+++ b/boards/arm/frdm_k22f/Kconfig.defconfig
@@ -39,10 +39,6 @@ config PINMUX_MCUX_PORTE
 
 endif # PINMUX_MCUX
 
-config I2C_0
-	default y
-	depends on I2C
-
 config SPI_0
 	default y
 	depends on SPI

--- a/boards/arm/frdm_k64f/Kconfig.defconfig
+++ b/boards/arm/frdm_k64f/Kconfig.defconfig
@@ -39,10 +39,6 @@ config PINMUX_MCUX_PORTE
 
 endif # PINMUX_MCUX
 
-config I2C_0
-	default y
-	depends on I2C
-
 config TEMP_KINETIS
 	default y if "$(dt_nodelabel_enabled,adc1)"
 	depends on SENSOR

--- a/boards/arm/frdm_k82f/Kconfig.defconfig
+++ b/boards/arm/frdm_k82f/Kconfig.defconfig
@@ -34,10 +34,6 @@ config FXOS8700_DRDY_INT1
 	default y
 	depends on FXOS8700
 
-config I2C_3
-	default y
-	depends on I2C
-
 if PINMUX_MCUX
 
 config PINMUX_MCUX_PORTA

--- a/boards/arm/frdm_kl25z/Kconfig.defconfig
+++ b/boards/arm/frdm_kl25z/Kconfig.defconfig
@@ -42,8 +42,4 @@ config PINMUX_MCUX_PORTE
 
 endif # PINMUX_MCUX
 
-config I2C_0
-	default y
-	depends on I2C
-
 endif # BOARD_FRDM_KL25Z

--- a/boards/arm/frdm_kw41z/Kconfig.defconfig
+++ b/boards/arm/frdm_kw41z/Kconfig.defconfig
@@ -30,10 +30,6 @@ config PINMUX_MCUX_PORTC
 
 endif # PINMUX_MCUX
 
-config I2C_1
-	default y
-	depends on I2C
-
 config FXOS8700_DRDY_INT1
 	default y
 	depends on FXOS8700

--- a/boards/arm/hexiwear_k64/Kconfig.defconfig
+++ b/boards/arm/hexiwear_k64/Kconfig.defconfig
@@ -39,16 +39,6 @@ config PINMUX_MCUX_PORTE
 
 endif # PINMUX_MCUX
 
-if I2C
-
-config I2C_0
-	default y
-
-config I2C_1
-	default y
-
-endif # I2C
-
 if ADC
 
 config BATTERY_SENSE

--- a/boards/arm/hexiwear_kw40z/Kconfig.defconfig
+++ b/boards/arm/hexiwear_kw40z/Kconfig.defconfig
@@ -30,8 +30,4 @@ config PINMUX_MCUX_PORTC
 
 endif # PINMUX_MCUX
 
-config I2C_1
-	default y
-	depends on I2C
-
 endif # BOARD_HEXIWEAR_KW40Z

--- a/boards/arm/lpcxpresso54114/Kconfig.defconfig
+++ b/boards/arm/lpcxpresso54114/Kconfig.defconfig
@@ -29,10 +29,6 @@ config GPIO_MCUX_LPC_PORT1
 
 endif # GPIO_MCUX_LPC
 
-config I2C_4
-	default y
-	depends on I2C
-
 config SPI_5
 	default y
 	depends on SPI

--- a/boards/arm/lpcxpresso55s69/Kconfig.defconfig
+++ b/boards/arm/lpcxpresso55s69/Kconfig.defconfig
@@ -29,10 +29,6 @@ config GPIO_MCUX_LPC_PORT1
 
 endif # GPIO_MCUX_LPC
 
-config I2C_4
-	default y
-	depends on I2C
-
 config SPI_8
 	default y
 	depends on SPI

--- a/boards/arm/mimxrt1010_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1010_evk/Kconfig.defconfig
@@ -12,8 +12,4 @@ choice CODE_LOCATION
 	default CODE_FLEXSPI
 endchoice
 
-config I2C_1
-	default y
-	depends on I2C_MCUX_LPI2C
-
 endif # BOARD_MIMXRT1010_EVK

--- a/boards/arm/mimxrt1015_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1015_evk/Kconfig.defconfig
@@ -12,8 +12,4 @@ choice CODE_LOCATION
 	default CODE_FLEXSPI
 endchoice
 
-config I2C_1
-	default y
-	depends on I2C_MCUX_LPI2C
-
 endif # BOARD_MIMXRT1015_EVK

--- a/boards/arm/mimxrt1020_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1020_evk/Kconfig.defconfig
@@ -16,16 +16,6 @@ choice DATA_LOCATION
 	default DATA_SEMC
 endchoice
 
-if I2C_MCUX_LPI2C
-
-config I2C_1
-	default y
-
-config I2C_4
-	default y
-
-endif # I2C_MCUX_LPI2C
-
 if NETWORKING
 
 config NET_L2_ETHERNET

--- a/boards/arm/mimxrt1050_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1050_evk/Kconfig.defconfig
@@ -23,10 +23,6 @@ config DISK_ACCESS_USDHC1
 config I2C
 	default y if KSCAN
 
-config I2C_1
-	default y
-	depends on I2C_MCUX_LPI2C
-
 config SPI_3
 	default y
 	depends on SPI_MCUX_LPSPI

--- a/boards/arm/mimxrt1060_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1060_evk/Kconfig.defconfig
@@ -20,10 +20,6 @@ endchoice
 config I2C
 	default y if KSCAN
 
-config I2C_1
-	default y
-	depends on I2C_MCUX_LPI2C
-
 config KSCAN
 	default y if LVGL
 

--- a/boards/arm/mimxrt1064_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1064_evk/Kconfig.defconfig
@@ -19,10 +19,6 @@ endchoice
 config I2C
 	default y if KSCAN
 
-config I2C_1
-	default y
-	depends on I2C_MCUX_LPI2C
-
 config KSCAN
 	default y if LVGL
 

--- a/boards/arm/twr_ke18f/Kconfig.defconfig
+++ b/boards/arm/twr_ke18f/Kconfig.defconfig
@@ -8,16 +8,6 @@ if BOARD_TWR_KE18F
 config BOARD
 	default "twr_ke18f"
 
-if I2C
-
-config I2C_0
-	default y
-
-config I2C_1
-	default y
-
-endif # I2C
-
 if SPI_MCUX_LPSPI
 
 config SPI_0

--- a/boards/arm/twr_kv58f220m/Kconfig.defconfig
+++ b/boards/arm/twr_kv58f220m/Kconfig.defconfig
@@ -20,10 +20,6 @@ config MCG_VDIV0
 config MCG_FCRDIV
 	default 1
 
-config I2C_1
-	default y
-	depends on I2C
-
 if PINMUX_MCUX
 
 config PINMUX_MCUX_PORTA

--- a/boards/arm/usb_kw24d512/Kconfig.defconfig
+++ b/boards/arm/usb_kw24d512/Kconfig.defconfig
@@ -40,16 +40,6 @@ config PINMUX_MCUX_PORTD
 
 endif # PINMUX_MCUX
 
-if I2C
-
-config I2C_0
-	default y
-
-config I2C_1
-	default n
-
-endif # I2C
-
 config SPI_1
 	default y
 	depends on SPI

--- a/boards/x86/gpmrb/Kconfig.defconfig
+++ b/boards/x86/gpmrb/Kconfig.defconfig
@@ -12,16 +12,6 @@ config BOARD
 config BUILD_OUTPUT_STRIPPED
 	default y
 
-if I2C
-
-config I2C_0
-	default y
-
-config I2C_1
-	default y
-
-endif # I2C
-
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 19200000 if HPET_TIMER		# guess
 	default 1100000000 if LOAPIC_TIMER	# another guess

--- a/boards/x86/up_squared/Kconfig.defconfig
+++ b/boards/x86/up_squared/Kconfig.defconfig
@@ -8,16 +8,6 @@ config BOARD
 config BUILD_OUTPUT_STRIPPED
 	default y
 
-if I2C
-
-config I2C_0
-	default y
-
-config I2C_1
-	default y
-
-endif # I2C
-
 config APIC_TIMER
 	default y if !HPET_TIMER
 

--- a/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
+++ b/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
@@ -96,8 +96,6 @@ if I2C
 
 config I2C_DW
 	default y
-config I2C_0
-	default y
 
 endif
 


### PR DESCRIPTION
The Kconfig I2C_[0-9] sybmols don't have any meaning for the majority of
SoCs.  The drivers doesn't utilize them and no sample or test code does
either so we can remove setting them in board Kconfig.defconfig files.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>