### PR TITLE
boards/shields: ssd1306: Fix node status

### DIFF
--- a/boards/shields/ssd1306/sh1106_128x64.overlay
+++ b/boards/shields/ssd1306/sh1106_128x64.overlay
@@ -5,7 +5,7 @@
  */
 
 &arduino_i2c {
-	status = "ok";
+	status = "okay";
 
 	ssd1306@3c {
 		compatible = "solomon,ssd1306fb";


### PR DESCRIPTION
Fix node status to "okay" instead of "ok" which doesn't
seem to be in used anymore across the tree.


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>