### PR TITLE
doc: env_vars: Fix link to section env_vars_zephyrrc

### DIFF
--- a/doc/guides/env_vars.rst
+++ b/doc/guides/env_vars.rst
@@ -129,7 +129,7 @@ These scripts:
 - adds some Zephyr-specific locations (such as zephyr's :file:`scripts`
   directory) to your :envvar:`PATH` environment variable
 - loads any settings from the ``zephyrrc`` files described above in
-  :file:`env_vars_zephyrrc`.
+  :ref:`env_vars_zephyrrc`.
 
 You can thus use them any time you need any of these settings.
 


### PR DESCRIPTION
Currently the doc says "above in env_vars_zephyrrc" without a link to
that section.

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>