### PR TITLE
util.h: Define INLINE only if it was not defined

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -95,10 +95,12 @@ size_t ARRAY_SIZE(T(&)[N]) { return N; }
 #define ceiling_fraction(numerator, divider) \
 	(((numerator) + ((divider) - 1)) / (divider))
 
+#ifndef INLINE
 #ifdef INLINED
 #define INLINE inline
 #else
 #define INLINE
+#endif
 #endif
 
 /** @brief Return larger value of two provided expressions.


### PR DESCRIPTION
INLINE is a very common macro, just like MAX or MIN.
Defining it always can easily collide with libraries or
application headers.
Add a guard so we do not redefine it if it was already defined.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

Currently Zephyr seems to only use it in the mchp_xec_rtos_timer.c
And INLINED does not seem to be defined anywhere. So this macro seems like it should not be there at all.. but that would be an API change.
