### PR TITLE
util.h: Remove INLINE definition and user

### DIFF
--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -99,7 +99,7 @@ static void timer_restart(u32_t countdown)
  * is 0 and the START bit is set then the timer has been started and is in the
  * process of moving the preload register value into the count register.
  */
-static INLINE u32_t timer_count(void)
+static inline u32_t timer_count(void)
 {
 	u32_t ccr = TIMER_REGS->CNT;
 

--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -95,12 +95,6 @@ size_t ARRAY_SIZE(T(&)[N]) { return N; }
 #define ceiling_fraction(numerator, divider) \
 	(((numerator) + ((divider) - 1)) / (divider))
 
-#ifdef INLINED
-#define INLINE inline
-#else
-#define INLINE
-#endif
-
 /** @brief Return larger value of two provided expressions.
  *
  * @note Arguments are evaluated twice. See Z_MAX for GCC only, single


### PR DESCRIPTION
INLINE is a very common macro, just like MAX or MIN.
Defining it always can easily collide with libraries or
application headers.
An option would be to add a ifdef guard around it,
But it was used in only 1 place in Zephyr, instead
of keeping it just for that, remove it.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

Alternative to #25031