### PR TITLE
Refactor the SX1276 driver to facilitate code reuse

### DIFF
--- a/drivers/lora/CMakeLists.txt
+++ b/drivers/lora/CMakeLists.txt
@@ -4,4 +4,5 @@ zephyr_library_named(loramac-node)
 
 zephyr_library_sources_ifdef(CONFIG_LORA_SHELL shell.c)
 zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_RADIO_DRIVERS hal_common.c)
+zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_RADIO_DRIVERS sx12xx_common.c)
 zephyr_library_sources_ifdef(CONFIG_LORA_SX1276 sx1276.c)

--- a/drivers/lora/CMakeLists.txt
+++ b/drivers/lora/CMakeLists.txt
@@ -3,4 +3,5 @@
 zephyr_library_named(loramac-node)
 
 zephyr_library_sources_ifdef(CONFIG_LORA_SHELL shell.c)
+zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_RADIO_DRIVERS hal_common.c)
 zephyr_library_sources_ifdef(CONFIG_LORA_SX1276 sx1276.c)

--- a/drivers/lora/hal_common.c
+++ b/drivers/lora/hal_common.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2019 Manivannan Sadhasivam
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+
+#include <timer.h>
+
+static uint32_t saved_time;
+
+static void timer_callback(struct k_timer *_timer)
+{
+	ARG_UNUSED(_timer);
+
+	TimerIrqHandler();
+}
+
+K_TIMER_DEFINE(lora_timer, timer_callback, NULL);
+
+uint32_t RtcGetTimerValue(void)
+{
+	return k_uptime_get_32();
+}
+
+uint32_t RtcGetTimerElapsedTime(void)
+{
+	return (k_uptime_get_32() - saved_time);
+}
+
+uint32_t RtcGetMinimumTimeout(void)
+{
+	return 1;
+}
+
+void RtcStopAlarm(void)
+{
+	k_timer_stop(&lora_timer);
+}
+
+void RtcSetAlarm(uint32_t timeout)
+{
+	k_timer_start(&lora_timer, K_MSEC(timeout), K_NO_WAIT);
+}
+
+uint32_t RtcSetTimerContext(void)
+{
+	saved_time = k_uptime_get_32();
+
+	return saved_time;
+}
+
+/* For us, 1 tick = 1 milli second. So no need to do any conversion here */
+uint32_t RtcGetTimerContext(void)
+{
+	return saved_time;
+}
+
+void DelayMsMcu(uint32_t ms)
+{
+	k_sleep(K_MSEC(ms));
+}
+
+uint32_t RtcMs2Tick(uint32_t milliseconds)
+{
+	return milliseconds;
+}
+
+uint32_t RtcTick2Ms(uint32_t tick)
+{
+	return tick;
+}
+
+void BoardCriticalSectionBegin(uint32_t *mask)
+{
+	*mask = irq_lock();
+}
+
+void BoardCriticalSectionEnd(uint32_t *mask)
+{
+	irq_unlock(*mask);
+}

--- a/drivers/lora/sx12xx_common.c
+++ b/drivers/lora/sx12xx_common.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2019 Manivannan Sadhasivam
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <drivers/lora.h>
+#include <logging/log.h>
+#include <zephyr.h>
+
+/* LoRaMac-node specific includes */
+#include <radio.h>
+
+LOG_MODULE_REGISTER(sx12xx_common, CONFIG_LORA_LOG_LEVEL);
+
+static struct sx12xx_data {
+	struct k_sem data_sem;
+	RadioEvents_t events;
+	uint8_t *rx_buf;
+	uint8_t rx_len;
+	int8_t snr;
+	int16_t rssi;
+} dev_data;
+
+static void sx12xx_ev_rx_done(uint8_t *payload, uint16_t size, int16_t rssi,
+			      int8_t snr)
+{
+	Radio.Sleep();
+
+	dev_data.rx_buf = payload;
+	dev_data.rx_len = size;
+	dev_data.rssi = rssi;
+	dev_data.snr = snr;
+
+	k_sem_give(&dev_data.data_sem);
+}
+
+static void sx12xx_ev_tx_done(void)
+{
+	Radio.Sleep();
+}
+
+int sx12xx_lora_send(struct device *dev, uint8_t *data, uint32_t data_len)
+{
+	Radio.SetMaxPayloadLength(MODEM_LORA, data_len);
+
+	Radio.Send(data, data_len);
+
+	return 0;
+}
+
+int sx12xx_lora_recv(struct device *dev, uint8_t *data, uint8_t size,
+		     k_timeout_t timeout, int16_t *rssi, int8_t *snr)
+{
+	int ret;
+
+	Radio.SetMaxPayloadLength(MODEM_LORA, 255);
+	Radio.Rx(0);
+
+	ret = k_sem_take(&dev_data.data_sem, timeout);
+	if (ret < 0) {
+		LOG_ERR("Receive timeout!");
+		return ret;
+	}
+
+	/* Only copy the bytes that can fit the buffer, drop the rest */
+	if (dev_data.rx_len > size)
+		dev_data.rx_len = size;
+
+	/*
+	 * FIXME: We are copying the global buffer here, so it might get
+	 * overwritten inbetween when a new packet comes in. Use some
+	 * wise method to fix this!
+	 */
+	memcpy(data, dev_data.rx_buf, dev_data.rx_len);
+
+	if (rssi != NULL) {
+		*rssi = dev_data.rssi;
+	}
+
+	if (snr != NULL) {
+		*snr = dev_data.snr;
+	}
+
+	return dev_data.rx_len;
+}
+
+int sx12xx_lora_config(struct device *dev, struct lora_modem_config *config)
+{
+	Radio.SetChannel(config->frequency);
+
+	if (config->tx) {
+		Radio.SetTxConfig(MODEM_LORA, config->tx_power, 0,
+				  config->bandwidth, config->datarate,
+				  config->coding_rate, config->preamble_len,
+				  false, true, 0, 0, false, 4000);
+	} else {
+		/* TODO: Get symbol timeout value from config parameters */
+		Radio.SetRxConfig(MODEM_LORA, config->bandwidth,
+				  config->datarate, config->coding_rate,
+				  0, config->preamble_len, 10, false, 0,
+				  false, 0, 0, false, true);
+	}
+
+	return 0;
+}
+
+int sx12xx_lora_test_cw(struct device *dev, uint32_t frequency, int8_t tx_power,
+			uint16_t duration)
+{
+	Radio.SetTxContinuousWave(frequency, tx_power, duration);
+	return 0;
+}
+
+int sx12xx_init(struct device *dev)
+{
+	k_sem_init(&dev_data.data_sem, 0, UINT_MAX);
+
+	dev_data.events.TxDone = sx12xx_ev_tx_done;
+	dev_data.events.RxDone = sx12xx_ev_rx_done;
+	Radio.Init(&dev_data.events);
+
+	return 0;
+}

--- a/drivers/lora/sx12xx_common.h
+++ b/drivers/lora/sx12xx_common.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020 Andreas Sandberg
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SX12XX_COMMON_H_
+#define ZEPHYR_DRIVERS_SX12XX_COMMON_H_
+
+#include <zephyr/types.h>
+#include <drivers/lora.h>
+#include <device.h>
+
+int sx12xx_lora_send(struct device *dev, uint8_t *data, uint32_t data_len);
+
+int sx12xx_lora_recv(struct device *dev, uint8_t *data, uint8_t size,
+		     k_timeout_t timeout, int16_t *rssi, int8_t *snr);
+
+int sx12xx_lora_config(struct device *dev, struct lora_modem_config *config);
+
+int sx12xx_lora_test_cw(struct device *dev, uint32_t frequency, int8_t tx_power,
+			uint16_t duration);
+
+int sx12xx_init(struct device *dev);
+
+#endif /* ZEPHYR_DRIVERS_SX12XX_COMMON_H_ */


### PR DESCRIPTION
The SX126x and the SX1276 share a significant amount of code. Refactor the current code to facilitate reuse.

Note: The CW API change is expected to go in together with the shell before this PR. The commit is included here as a "glue" commit.