### PR TITLE
boards: particle_*: update flash devicetree for supported erase sizes

### DIFF
--- a/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.dts
+++ b/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.dts
@@ -52,7 +52,6 @@
 		reg = <0>;
 		spi-max-frequency = <80000000>;
 		size = <0x200000>;
-		has-be32k;
 		has-dpd;
 		t-enter-dpd = <20000>;
 		t-exit-dpd = <100000>;

--- a/boards/arm/black_f407ve/black_f407ve.dts
+++ b/boards/arm/black_f407ve/black_f407ve.dts
@@ -104,7 +104,6 @@
 		t-enter-dpd = <4000>;
 		t-exit-dpd = <25000>;
 		jedec-id = [ef 40 15];
-		has-be32k;
 	};
 };
 

--- a/boards/arm/efr32_radio/efr32_radio.dtsi
+++ b/boards/arm/efr32_radio/efr32_radio.dtsi
@@ -77,7 +77,6 @@
 		reg = <0>;
 		spi-max-frequency = <33000000>;
 		size = <0x800000>;
-		has-be32k;
 		jedec-id = [c2 28 14];
 	};
 };

--- a/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
+++ b/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
@@ -86,7 +86,6 @@
 		reg = <0>;
 		spi-max-frequency = <80000000>;
 		size = <0x800000>;
-		has-be32k;
 		jedec-id = [c2 28 14];
 	};
 };

--- a/boards/arm/frdm_k82f/frdm_k82f.dts
+++ b/boards/arm/frdm_k82f/frdm_k82f.dts
@@ -192,7 +192,6 @@
 		wp-gpios = <&gpioe 3 0>;
 		reset-gpios = <&gpioe 0 0>;
 		size = <0x2000000>;
-		has-be32k;
 		jedec-id = [c2 25 36];
 	};
 };

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -216,7 +216,6 @@ arduino_i2c: &i2c0 {
 		label = "MX25R64";
 		jedec-id = [c2 28 17];
 		size = <67108864>;
-		has-be32k;
 		has-dpd;
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <35000>;

--- a/boards/arm/particle_argon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather.dtsi
@@ -143,6 +143,8 @@ arduino_i2c: &i2c0 { /* feather I2C */
 		wp-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 		hold-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
 		size = <0x2000000>;
+		sfdp-basic-8 = <0x520f200c>;
+		sfdp-basic-9 = <0xff00d810>;
 		has-dpd;
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <100000>;

--- a/boards/arm/particle_argon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather.dtsi
@@ -143,7 +143,6 @@ arduino_i2c: &i2c0 { /* feather I2C */
 		wp-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 		hold-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
 		size = <0x2000000>;
-		has-be32k;
 		has-dpd;
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <100000>;

--- a/boards/arm/particle_boron/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather.dtsi
@@ -143,6 +143,8 @@ arduino_i2c: &i2c0 { /* feather I2C */
 		wp-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 		hold-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
 		size = <0x2000000>;
+		sfdp-basic-8 = <0x520f200c>;
+		sfdp-basic-9 = <0xff00d810>;
 		has-dpd;
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <100000>;

--- a/boards/arm/particle_boron/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather.dtsi
@@ -143,7 +143,6 @@ arduino_i2c: &i2c0 { /* feather I2C */
 		wp-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 		hold-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
 		size = <0x2000000>;
-		has-be32k;
 		has-dpd;
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <100000>;

--- a/boards/arm/particle_xenon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather.dtsi
@@ -143,6 +143,8 @@ arduino_i2c: &i2c0 { /* feather I2C */
 		wp-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 		hold-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
 		size = <0x2000000>;
+		sfdp-basic-8 = <0x520f200c>;
+		sfdp-basic-9 = <0xff00d810>;
 		has-dpd;
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <100000>;

--- a/boards/arm/particle_xenon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather.dtsi
@@ -143,7 +143,6 @@ arduino_i2c: &i2c0 { /* feather I2C */
 		wp-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 		hold-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
 		size = <0x2000000>;
-		has-be32k;
 		has-dpd;
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <100000>;

--- a/boards/riscv/rv32m1_vega/rv32m1_vega.dtsi
+++ b/boards/riscv/rv32m1_vega/rv32m1_vega.dtsi
@@ -145,7 +145,6 @@ arduino_spi: &lpspi0 {
 		label = "MX25R32";
 		jedec-id = [c2 28 16];
 		size = <33554432>;
-		has-be32k;
 	};
 };
 

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -351,14 +351,15 @@ static int spi_nor_write(struct device *dev, off_t addr, const void *src,
 		size_t to_write = size;
 
 		/* Don't write more than a page. */
-		if (to_write >= SPI_NOR_PAGE_SIZE) {
-			to_write = SPI_NOR_PAGE_SIZE;
+		if (to_write >= params->page_size) {
+			to_write = params->page_size;
 		}
 
 		/* Don't write across a page boundary */
-		if (((addr + to_write - 1U) / SPI_NOR_PAGE_SIZE)
-		    != (addr / SPI_NOR_PAGE_SIZE)) {
-			to_write = SPI_NOR_PAGE_SIZE - (addr % SPI_NOR_PAGE_SIZE);
+		if (((addr + to_write - 1U) / params->page_size)
+		    != (addr / params->page_size)) {
+			to_write = params->page_size -
+				   (addr % params->page_size);
 		}
 
 		spi_nor_cmd_write(dev, SPI_NOR_CMD_WREN);
@@ -380,9 +381,34 @@ out:
 	return ret;
 }
 
+#define GET_ERASE_SIZE(config, idx) (1U << config->erase_size_exp[idx])
+
+static int spi_nor_select_erase_type(struct device *dev, off_t addr,
+				     size_t size)
+{
+	const struct spi_nor_config *params = dev->config->config_info;
+	int idx = -1;
+
+	for (int i = 0; i < ARRAY_SIZE(params->erase_cmd); i++) {
+		if (params->erase_size_exp[i] == 0 ||
+		    GET_ERASE_SIZE(params, i) > size ||
+		    !SPI_NOR_IS_ALIGNED(addr, size)) {
+			continue;
+		}
+
+		if (idx == -1 ||
+		    GET_ERASE_SIZE(params, i) > GET_ERASE_SIZE(params, idx)) {
+			idx = i;
+		}
+	}
+
+	return idx;
+}
+
 static int spi_nor_erase(struct device *dev, off_t addr, size_t size)
 {
 	const struct spi_nor_config *params = dev->config->config_info;
+	const u8_t *erase_cmd = params->erase_cmd;
 	int ret = 0;
 
 	/* should be between 0 and flash size */
@@ -392,44 +418,29 @@ static int spi_nor_erase(struct device *dev, off_t addr, size_t size)
 
 	acquire_device(dev);
 
-	while (size) {
-		/* write enable */
+	/* chip erase */
+	if (size == params->size && params->has_chip_erase) {
 		spi_nor_cmd_write(dev, SPI_NOR_CMD_WREN);
+		spi_nor_cmd_write(dev, SPI_NOR_CMD_CE);
+		spi_nor_wait_until_ready(dev);
+		goto out;
+	}
 
-		if (size == params->size) {
-			/* chip erase */
-			spi_nor_cmd_write(dev, SPI_NOR_CMD_CE);
-			size -= params->size;
-		} else if ((size >= SPI_NOR_BLOCK_SIZE)
-			   && SPI_NOR_IS_BLOCK_ALIGNED(addr)) {
-			/* 64 KiB block erase */
-			spi_nor_cmd_addr_write(dev, SPI_NOR_CMD_BE, addr,
-			NULL, 0);
-			addr += SPI_NOR_BLOCK_SIZE;
-			size -= SPI_NOR_BLOCK_SIZE;
-		} else if ((size >= SPI_NOR_BLOCK32_SIZE)
-			   && SPI_NOR_IS_BLOCK32_ALIGNED(addr)
-			   && params->has_be32k) {
-			/* 32 KiB block erase */
-			spi_nor_cmd_addr_write(dev, SPI_NOR_CMD_BE_32K, addr,
-					       NULL, 0);
-			addr += SPI_NOR_BLOCK32_SIZE;
-			size -= SPI_NOR_BLOCK32_SIZE;
-		} else if ((size >= SPI_NOR_SECTOR_SIZE)
-			   && SPI_NOR_IS_SECTOR_ALIGNED(addr)) {
-			/* sector erase */
-			spi_nor_cmd_addr_write(dev, SPI_NOR_CMD_SE, addr,
-					       NULL, 0);
-			addr += SPI_NOR_SECTOR_SIZE;
-			size -= SPI_NOR_SECTOR_SIZE;
-		} else {
-			/* minimal erase size is at least a sector size */
-			LOG_DBG("unsupported at 0x%lx size %zu", (long)addr,
-				size);
+	/* block erase */
+	while (size) {
+		int idx = spi_nor_select_erase_type(dev, addr, size);
+
+		if (idx == -1) {
+			/* too small or misaligned */
 			ret = -EINVAL;
 			goto out;
 		}
 
+		spi_nor_cmd_write(dev, SPI_NOR_CMD_WREN);
+		spi_nor_cmd_addr_write(dev, erase_cmd[idx],
+					addr, NULL, 0);
+		addr += GET_ERASE_SIZE(params, idx);
+		size -= GET_ERASE_SIZE(params, idx);
 		spi_nor_wait_until_ready(dev);
 	}
 
@@ -571,10 +582,19 @@ static const struct flash_driver_api spi_nor_api = {
 
 static const struct spi_nor_config flash_id = {
 	.id = DT_INST_PROP(0, jedec_id),
-#if DT_INST_NODE_HAS_PROP(0, has_be32k)
-	.has_be32k = true,
-#endif /* DT_INST_NODE_HAS_PROP(0, has_be32k) */
 	.size = DT_INST_PROP(0, size) / 8,
+
+	.page_size = (1 << SFDP_B11_PAGE_SIZE(DT_INST_PROP(0, sfdp_basic_11))),
+	.has_chip_erase = !DT_INST_PROP(0, has_no_chip_erase),
+	.erase_size_exp = { SFDP_B8_ERASE_SIZE_1(DT_INST_PROP(0, sfdp_basic_8)),
+			    SFDP_B8_ERASE_SIZE_2(DT_INST_PROP(0, sfdp_basic_8)),
+			    SFDP_B9_ERASE_SIZE_3(DT_INST_PROP(0, sfdp_basic_9)),
+			    SFDP_B9_ERASE_SIZE_4(DT_INST_PROP(0, sfdp_basic_9))
+			  },
+	.erase_cmd = { SFDP_B8_ERASE_CMD_1(DT_INST_PROP(0, sfdp_basic_8)),
+		       SFDP_B8_ERASE_CMD_2(DT_INST_PROP(0, sfdp_basic_8)),
+		       SFDP_B9_ERASE_CMD_3(DT_INST_PROP(0, sfdp_basic_9)),
+		       SFDP_B9_ERASE_CMD_4(DT_INST_PROP(0, sfdp_basic_9)) },
 };
 
 static struct spi_nor_data spi_nor_memory_data;

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -55,9 +55,9 @@ LOG_MODULE_REGISTER(spi_nor, CONFIG_FLASH_LOG_LEVEL);
 #define T_RES1_MS ceiling_fraction(DT_INST_PROP(0, t_exit_dpd), NSEC_PER_MSEC)
 #endif /* T_EXIT_DPD */
 #if DT_INST_NODE_HAS_PROP(0, dpd_wakeup_sequence)
-#define T_DPDD_MS ceiling_fraction(DT_INST_PROP(0, dpd_wakeup_sequence_0), NSEC_PER_MSEC)
-#define T_CRDP_MS ceiling_fraction(DT_INST_PROP(0, dpd_wakeup_sequence_1), NSEC_PER_MSEC)
-#define T_RDP_MS ceiling_fraction(DT_INST_PROP(0, dpd_wakeup_sequence_2), NSEC_PER_MSEC)
+#define T_DPDD_MS ceiling_fraction(DT_PROP_BY_IDX(DT_DRV_INST(0), dpd_wakeup_sequence, 0), NSEC_PER_MSEC)
+#define T_CRDP_MS ceiling_fraction(DT_PROP_BY_IDX(DT_DRV_INST(0), dpd_wakeup_sequence, 1), NSEC_PER_MSEC)
+#define T_RDP_MS ceiling_fraction(DT_PROP_BY_IDX(DT_DRV_INST(0), dpd_wakeup_sequence, 2), NSEC_PER_MSEC)
 #else /* DPD_WAKEUP_SEQUENCE */
 #define T_DPDD_MS 0
 #endif /* DPD_WAKEUP_SEQUENCE */

--- a/dts/bindings/mtd/jedec,spi-nor-common.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor-common.yaml
@@ -11,11 +11,6 @@ properties:
     required: true
     description: JEDEC ID as manufacturer ID, memory type, memory density
 
-  has-be32k:
-    type: boolean
-    required: false
-    description: Indicates the device supports the BE32K (0xD8) command
-
   requires-ulbpr:
     type: boolean
     required: false

--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -24,3 +24,29 @@ properties:
     type: phandle-array
     required: false
     description: RESETn pin
+  sfdp-basic-8:
+    type: int
+    required: false
+    default: 0xD810200C
+    description: |
+      Corresponds to the 8th DWORD of the JEDEC Basic Flash Parameter Table,
+      providing erase type 1 and 2 size and instruction.
+  sfdp-basic-9:
+    type: int
+    required: false
+    default: 0x0000520F
+    description: |
+      Corresponds to the 9th DWORD of the JEDEC Basic Flash Parameter Table,
+      providing erase type 3 and 4 size and instruction.
+  sfdp-basic-11:
+    type: int
+    required: false
+    default: 0x00000080
+    description: |
+      Corresponds to the 11th DWORD of the JEDEC Basic Flash Parameter Table,
+      providing page size. Only bits 7:4 are respected, setting the other bits
+      has no effect.
+  has-no-chip-erase:
+    type: boolean
+    required: false
+    description: Indicates device does no support chip erase

--- a/tests/subsys/fs/littlefs/boards/particle_xenon.conf
+++ b/tests/subsys/fs/littlefs/boards/particle_xenon.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2019 Peter Bigot Consulting, LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_SPI=y
+CONFIG_SPI_NOR=y
+CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096

--- a/tests/subsys/fs/littlefs/boards/particle_xenon.overlay
+++ b/tests/subsys/fs/littlefs/boards/particle_xenon.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 Peter Bigot Consulting, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&mx25l32 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "small";
+			reg = <0x00000000 0x00010000>;
+		};
+		partition@10000 {
+			label = "medium";
+			reg = <0x00010000 0x000F0000>;
+		};
+		partition@100000 {
+			label = "large";
+			reg = <0x00100000 0x00300000>;
+		};
+	};
+};

--- a/tests/subsys/fs/littlefs/testcase.yaml
+++ b/tests/subsys/fs/littlefs/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   filesystem.littlefs:
-    platform_whitelist: nrf52840dk_nrf52840 native_posix native_posix_64
+    platform_whitelist: nrf52840dk_nrf52840 native_posix native_posix_64 particle_xenon
     tags: filesystem


### PR DESCRIPTION
Use the new SFDP parameters to describe the supported erase sizes.

Draft until #23658 is merged; also temporarily contains #25039.  The last two commits will be part of this PR when ready.