### PR TITLE
drivers: spi: cc13xx_cc26xx: remove usage of CONFIG_SPI_0/1

### DIFF
--- a/boards/arm/cc1352r1_launchxl/Kconfig.defconfig
+++ b/boards/arm/cc1352r1_launchxl/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_CC1352R1_LAUNCHXL
 config BOARD
 	default "cc1352r1_launchxl"
 
-config SPI_0
-	default y
-	depends on SPI
-
 if SYS_POWER_MANAGEMENT
 
 # Ideally this value could be made to less than 1 ms, as there is

--- a/boards/arm/cc26x2r1_launchxl/Kconfig.defconfig
+++ b/boards/arm/cc26x2r1_launchxl/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_CC26X2R1_LAUNCHXL
 config BOARD
 	default "cc26x2r1_launchxl"
 
-config SPI_0
-	default y
-	depends on SPI
-
 if SYS_POWER_MANAGEMENT
 
 # Ideally this value could be made to less than 1 ms, as there is

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -277,14 +277,10 @@ static int spi_cc13xx_cc26xx_pm_control(struct device *dev, u32_t ctrl_command,
 #endif /* CONFIG_DEVICE_POWER_MANAGEMENT */
 
 
-#if defined(CONFIG_SPI_0) || defined(CONFIG_SPI_1)
 static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 	.transceive = spi_cc13xx_cc26xx_transceive,
 	.release = spi_cc13xx_cc26xx_release,
 };
-#else
-#warning "No SPI port configured"
-#endif
 
 #define SPI_CC13XX_CC26XX_DOMAIN_0 PRCM_DOMAIN_SERIAL
 #define SPI_CC13XX_CC26XX_DOMAIN_1 PRCM_DOMAIN_PERIPH


### PR DESCRIPTION
Clean up as we wish to move away from using these Kconfig settings.
Also removing them from the boards' default config.

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>