### PR TITLE
cmake: Set the ZEPHYR_<MODULE_NAME>_MODULE_DIR in parent scope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,6 +472,7 @@ if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)
 
     string(TOUPPER ${module_name} MODULE_NAME_UPPER)
     set(ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR ${module_path})
+    set(ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR ${module_path} PARENT_SCOPE)
   endforeach()
 
   foreach(module_name ${module_names})


### PR DESCRIPTION
To allow samples to obtain `ZEPHYR_<MODULE_NAME>_MODULE_DIR` it is
necessary to also ensure the module variable is available in parent
scope.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>