### PR TITLE
RFC: usb: hid: Export only defines if  USB device driver disabled.

### DIFF
--- a/include/usb/class/usb_hid.h
+++ b/include/usb/class/usb_hid.h
@@ -57,32 +57,6 @@ struct usb_hid_descriptor {
 
 /* Public headers */
 
-typedef int (*hid_cb_t)(struct usb_setup_packet *setup, s32_t *len,
-			u8_t **data);
-typedef void (*hid_int_ready_callback)(void);
-typedef void (*hid_protocol_cb_t)(u8_t protocol);
-typedef void (*hid_idle_cb_t)(u16_t report_id);
-
-struct hid_ops {
-	hid_cb_t get_report;
-	hid_cb_t get_idle;
-	hid_cb_t get_protocol;
-	hid_cb_t set_report;
-	hid_cb_t set_idle;
-	hid_cb_t set_protocol;
-	hid_protocol_cb_t protocol_change;
-	hid_idle_cb_t on_idle;
-	/*
-	 * int_in_ready is an optional callback that is called when
-	 * the current interrupt IN transfer has completed.  This can
-	 * be used to wait for the endpoint to go idle or to trigger
-	 * the next transfer.
-	 */
-	hid_int_ready_callback int_in_ready;
-#ifdef CONFIG_ENABLE_HID_INT_OUT_EP
-	hid_int_ready_callback int_out_ready;
-#endif
-};
 
 /* HID Report Definitions */
 
@@ -430,6 +404,35 @@ enum hid_kbd_led {
 	HID_KBD_LED_KANA	= 0x10,
 };
 
+#if defined(CONFIG_USB_DEVICE_HID)
+
+typedef int (*hid_cb_t)(struct usb_setup_packet *setup, s32_t *len,
+			u8_t **data);
+typedef void (*hid_int_ready_callback)(void);
+typedef void (*hid_protocol_cb_t)(u8_t protocol);
+typedef void (*hid_idle_cb_t)(u16_t report_id);
+
+struct hid_ops {
+	hid_cb_t get_report;
+	hid_cb_t get_idle;
+	hid_cb_t get_protocol;
+	hid_cb_t set_report;
+	hid_cb_t set_idle;
+	hid_cb_t set_protocol;
+	hid_protocol_cb_t protocol_change;
+	hid_idle_cb_t on_idle;
+	/*
+	 * int_in_ready is an optional callback that is called when
+	 * the current interrupt IN transfer has completed.  This can
+	 * be used to wait for the endpoint to go idle or to trigger
+	 * the next transfer.
+	 */
+	hid_int_ready_callback int_in_ready;
+#ifdef CONFIG_ENABLE_HID_INT_OUT_EP
+	hid_int_ready_callback int_out_ready;
+#endif
+};
+
 /* Register HID device */
 void usb_hid_register_device(struct device *dev, const u8_t *desc, size_t size,
 			     const struct hid_ops *op);
@@ -444,6 +447,8 @@ int hid_int_ep_read(const struct device *dev, u8_t *data, u32_t max_data_len,
 
 /* Initialize USB HID */
 int usb_hid_init(const struct device *dev);
+
+#endif /* defined(CONFIG_USB_DEVICE_HID) */
 
 #ifdef __cplusplus
 }

--- a/samples/bluetooth/peripheral_hids/src/hog.c
+++ b/samples/bluetooth/peripheral_hids/src/hog.c
@@ -16,6 +16,8 @@
 #include <sys/byteorder.h>
 #include <zephyr.h>
 
+#include <usb/class/usb_hid.h>
+
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/conn.h>
@@ -57,35 +59,7 @@ static struct hids_report input = {
 
 static u8_t simulate_input;
 static u8_t ctrl_point;
-static u8_t report_map[] = {
-	0x05, 0x01, /* Usage Page (Generic Desktop Ctrls) */
-	0x09, 0x02, /* Usage (Mouse) */
-	0xA1, 0x01, /* Collection (Application) */
-	0x09, 0x01, /*   Usage (Pointer) */
-	0xA1, 0x00, /*   Collection (Physical) */
-	0x05, 0x09, /*     Usage Page (Button) */
-	0x19, 0x01, /*     Usage Minimum (0x01) */
-	0x29, 0x03, /*     Usage Maximum (0x03) */
-	0x15, 0x00, /*     Logical Minimum (0) */
-	0x25, 0x01, /*     Logical Maximum (1) */
-	0x95, 0x03, /*     Report Count (3) */
-	0x75, 0x01, /*     Report Size (1) */
-	0x81, 0x02, /*     Input (Data,Var,Abs,No Wrap,Linear,...) */
-	0x95, 0x01, /*     Report Count (1) */
-	0x75, 0x05, /*     Report Size (5) */
-	0x81, 0x03, /*     Input (Const,Var,Abs,No Wrap,Linear,...) */
-	0x05, 0x01, /*     Usage Page (Generic Desktop Ctrls) */
-	0x09, 0x30, /*     Usage (X) */
-	0x09, 0x31, /*     Usage (Y) */
-	0x15, 0x81, /*     Logical Minimum (129) */
-	0x25, 0x7F, /*     Logical Maximum (127) */
-	0x75, 0x08, /*     Report Size (8) */
-	0x95, 0x02, /*     Report Count (2) */
-	0x81, 0x06, /*     Input (Data,Var,Rel,No Wrap,Linear,...) */
-	0xC0,       /*   End Collection */
-	0xC0,       /* End Collection */
-};
-
+static u8_t report_map[] = HID_MOUSE_REPORT_DESC(3);
 
 static ssize_t read_info(struct bt_conn *conn,
 			  const struct bt_gatt_attr *attr, void *buf,


### PR DESCRIPTION
* Allow re-use of HID definitions for BLE HID over GATTP even if
  USB device driver is disabled.

Another take on #25044, with feedback on the approach to use.