### PR TITLE
adc: adc_shell: Fix compile error

### DIFF
--- a/drivers/adc/adc_shell.c
+++ b/drivers/adc/adc_shell.c
@@ -465,7 +465,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_adc_cmds,
 );
 
 #define ADC_SHELL_COMMAND(inst) \
-	SHELL_CMD(ADC_##inst, &sub_adc_cmds, "ADC_" #inst, NULL),
+	SHELL_CMD(ADC_##inst, &sub_adc_cmds, "ADC_" #inst, NULL)
 
 /*
  * TODO generalize with a more flexible for-each macro that doesn't


### PR DESCRIPTION
Had an extra comma between macro and macro usage that casued the
following compile error:

	adc_shell.c:477:22: error: expected expression before ',' token

Easy fix to remove trailing comma in ADC_SHELL_COMMAND

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>