### PR TITLE
device: add api to check if device initialized or not

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -303,6 +303,18 @@ void z_sys_device_do_config_level(s32_t level);
 __syscall struct device *device_get_binding(const char *name);
 
 /**
+ * @brief device initialization success or not
+ *
+ * @param device Pointer to device structure.
+ *
+ * @return true if device successfully initialized; false if not.
+ */
+static inline bool device_is_initialized(struct device *device)
+{
+	return device->driver_api != NULL;
+}
+
+/**
  * @}
  */
 

--- a/subsys/power/device.c
+++ b/subsys/power/device.c
@@ -111,10 +111,25 @@ void sys_pm_create_device_list(void)
 	 */
 	device_list_get(&pm_device_list, &count);
 
-	/* Reserve for 32KHz, 16MHz, system clock, etc... */
-	device_count = NUM_CORE_DEVICES;
+	for (i = 0; (i < count) && (device_count < MAX_PM_DEVICES); i++) {
+		if (device_is_initialized(&pm_device_list[i]) == false) {
+			continue;
+		}
+
+		/* Check if the device is core device */
+		for (j = 0, is_core_dev = false; j < NUM_CORE_DEVICES; j++) {
+			if (!strcmp(pm_device_list[i].config->name,
+						&core_devices[j][0])) {
+				device_ordered_list[device_count++] = i;
+				break;
+			}
+		}
+	}
 
 	for (i = 0; (i < count) && (device_count < MAX_PM_DEVICES); i++) {
+		if (device_is_initialized(&pm_device_list[i]) == false) {
+			continue;
+		}
 
 		/* Check if the device is core device */
 		for (j = 0, is_core_dev = false; j < NUM_CORE_DEVICES; j++) {
@@ -125,9 +140,7 @@ void sys_pm_create_device_list(void)
 			}
 		}
 
-		if (is_core_dev) {
-			device_ordered_list[j] = i;
-		} else {
+		if (!is_core_dev) {
 			device_ordered_list[device_count++] = i;
 		}
 	}


### PR DESCRIPTION
Add api to check if device initialized success or not and
power management will create device list based on this API.

Fixes: #24750
Signed-off-by: Wentong Wu <wentong.wu@intel.com>