### PR TITLE
cmake: binutils objdump disassemble all sections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1213,10 +1213,15 @@ endif()
 if(CONFIG_OUTPUT_DISASSEMBLY)
   set(out_disassembly_cmd    "")
   set(out_disassembly_byprod "")
+  if(CONFIG_OUTPUT_DISASSEMBLE_ALL)
+    set(disassembly_type DISASSEMBLE_ALL)
+  else()
+    set(disassembly_type DISASSEMBLE_SOURCE)
+  endif()
   bintools_objdump(
     RESULT_CMD_LIST    out_disassembly_cmd
     RESULT_BYPROD_LIST out_disassembly_byprod
-    DISASSEMBLE_SOURCE
+    ${disassembly_type}
     FILE_INPUT         ${KERNEL_ELF_NAME}
     FILE_OUTPUT        ${KERNEL_LST_NAME}
     )

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -288,6 +288,14 @@ config OUTPUT_DISASSEMBLY
 	help
 	  Create an .lst file with the assembly listing of the firmware.
 
+config OUTPUT_DISASSEMBLE_ALL
+	bool "Disassemble all sections with source. Fill zeros."
+	default n
+	depends on OUTPUT_DISASSEMBLY
+	help
+	  The .lst file will contain complete disassembly of the firmware
+	  not just those expected to contain instructions including zeros
+
 config OUTPUT_PRINT_MEMORY_USAGE
 	bool "Print memory usage to stdout"
 	default y

--- a/cmake/bintools/gnu/target_objdump.cmake
+++ b/cmake/bintools/gnu/target_objdump.cmake
@@ -10,6 +10,7 @@
 #
 #      DISASSEMBLE        <Display the assembler mnemonics for the machine instructions from input>
 #      DISASSEMBLE_SOURCE < Display source code intermixed with disassembly, if possible>
+#      DISASSEMBLE_ALL    <Display disassembly of all sections not just the instruction sections>
 #
 #      FILE_INPUT         <The input file>
 #      FILE_OUTPUT        <The output file>
@@ -19,7 +20,7 @@ function(bintools_objdump)
     # Prefix of output variables
     BINTOOLS_OBJDUMP
     # List of argument names without values, hence boolean
-    "DISASSEMBLE;DISASSEMBLE_SOURCE"
+    "DISASSEMBLE;DISASSEMBLE_SOURCE;DISASSEMBLE_ALL"
     # List of argument names with one value
     "RESULT_CMD_LIST;RESULT_BYPROD_LIST;FILE_INPUT;FILE_OUTPUT"
     # List of argument names with multible values
@@ -41,6 +42,8 @@ function(bintools_objdump)
     set(obj_dump_disassemble "-S") # --source
   elseif(${BINTOOLS_OBJDUMP_DISASSEMBLE})
     set(obj_dump_disassemble "-d") # --disassemble
+  elseif(${BINTOOLS_OBJDUMP_DISASSEMBLE_ALL})
+    set(obj_dump_disassemble "-SDz") # --source --disassemble-all --disassemble-zeroes
   endif()
 
   # Handle output


### PR DESCRIPTION
Added support for creating an assembly listing containing all sections like rodata, data and debug sections, not just those expected to contain instructions. This will be helpful when there is important content in the data sections. Added a new config option OUTPUT_DISASSEMBLE_ALL to select between this and the original one. This new config option does will be 'n' by default.