### PR TITLE
drivers: counter_mcux_gpt: Fix compile error

### DIFF
--- a/drivers/counter/counter_mcux_gpt.c
+++ b/drivers/counter/counter_mcux_gpt.c
@@ -215,16 +215,7 @@ static const struct counter_driver_api mcux_gpt_driver_api = {
 		},							\
 	};								\
 									\
-	static int mcux_gpt_## n ##_init(struct device *dev)		\
-	{								\
-		IRQ_CONNECT(DT_INST_IRQN(n),				\
-			    DT_INST_IRQ(n, priority),			\
-			    mcux_gpt_isr,				\
-			    DEVICE_GET(mcux_gpt ## n), 0);		\
-		irq_enable(DT_INST_IRQN(n));				\
-		return mcux_gpt_init(dev);				\
-	}								\
-									\
+	static int mcux_gpt_## n ##_init(struct device *dev);		\
 	DEVICE_AND_API_INIT(mcux_gpt ## n,				\
 			    DT_INST_LABEL(n),				\
 			    mcux_gpt_## n ##_init,			\
@@ -232,6 +223,15 @@ static const struct counter_driver_api mcux_gpt_driver_api = {
 			    &mcux_gpt_config_ ## n,			\
 			    POST_KERNEL,				\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &mcux_gpt_driver_api)
+			    &mcux_gpt_driver_api);			\
+									\
+	static int mcux_gpt_## n ##_init(struct device *dev)		\
+	{								\
+		IRQ_CONNECT(DT_INST_IRQN(n),				\
+			    DT_INST_IRQ(n, priority),			\
+			    mcux_gpt_isr, DEVICE_GET(mcux_gpt ## n), 0);\
+		irq_enable(DT_INST_IRQN(n));				\
+		return mcux_gpt_init(dev);				\
+	}								\
 
 DT_INST_FOREACH(GPT_DEVICE_INIT_MCUX)


### PR DESCRIPTION
Return order to fix issue with __device_mcux_gptX' being undeclared.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>