### PR TITLE
hal_st: Make it a zephyr library.

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -49,7 +49,7 @@ config BT_SPI
 config BT_STM32_IPM
 	bool "IPM HCI"
 	select USE_STM32_HAL_CORTEX
-	select HAS_STLIB
+	select HAS_STM32LIB
 	help
 	  TODO
 

--- a/modules/Kconfig.stm32
+++ b/modules/Kconfig.stm32
@@ -3,6 +3,9 @@
 # Copyright (c) 2016 Linaro Limited.
 # SPDX-License-Identifier: Apache-2.0
 
+config HAS_STM32LIB
+	bool
+
 config HAS_STM32CUBE
 	bool
 	select HAS_CMSIS_CORE

--- a/west.yml
+++ b/west.yml
@@ -68,7 +68,7 @@ manifest:
       revision: fa481784b3c49780f18d50bafe00390ccb62b2ec
       path: modules/hal/st
     - name: hal_stm32
-      revision: ff9b7f295da7e8918fbe3e0119b5271cb9cb4a55
+      revision: d1bc80d021f4ebc31f6e8b36f14b738cc26c7b03
       path: modules/hal/stm32
     - name: hal_ti
       revision: ebf0a6f11cd6ff9f735db8391a6351ffeeda4cc3

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
       revision: 78da967feeac0d51219ef733cc3ccf643336589f
       path: modules/hal/silabs
     - name: hal_st
-      revision: fa481784b3c49780f18d50bafe00390ccb62b2ec
+      revision: 5b3ec3e182d4310e8943cc34c6c70ae57d9711da
       path: modules/hal/st
     - name: hal_stm32
       revision: d1bc80d021f4ebc31f6e8b36f14b738cc26c7b03


### PR DESCRIPTION
Depends on zephyrproject-rtos/hal_st/pull/4 and zephyrproject-rtos/hal_stm32/pull/52

Fixes #19614

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>