### PR TITLE
edtlib: Workaround for generating fixed-partitions compatibles

### DIFF
--- a/dts/bindings/test/vnd,spi-nor.yaml
+++ b/dts/bindings/test/vnd,spi-nor.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test NOR Flash SPI device
+
+compatible: "vnd,spi-nor"
+
+on-bus: spi
+
+include: spi-device.yaml

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -1019,6 +1019,10 @@ class Node:
             on_bus = self.on_bus
 
             for compat in self.compats:
+                # Workaround for 'fixed-partitions' compatibles that are
+                # on non None bus.
+                if compat == 'fixed-partitions':
+                    on_bus = None
                 if (compat, on_bus) in self.edt._compat2binding:
                     # Binding found
                     self.matching_compat = compat

--- a/tests/lib/devicetree/app.overlay
+++ b/tests/lib/devicetree/app.overlay
@@ -10,6 +10,8 @@
  * (and be extended to test) real hardware.
  */
 
+/delete-node/ &storage_partition;
+
 / {
 	aliases {
 		test-alias = &test_nodelabel;
@@ -182,6 +184,8 @@
 				label = "TEST_EXPANDER_SPI";
 				spi-max-frequency = <(1 * 1000 * 1000)>;
 			};
+
+
 		};
 
 		test_spi_no_cs: spi@55556666 {
@@ -199,6 +203,32 @@
 				label = "TEST_SPI_DEV_NO_CS";
 				reg = <0>;
 				spi-max-frequency = < 2000000 >;
+			};
+
+		};
+
+		test_spi_flash: spi@66667777 {
+			#address-cells = < 1 >;
+			#size-cells = < 0 >;
+			compatible = "vnd,spi";
+			reg = < 0x66667777 0x1000 >;
+			label = "TEST_SPI_CTLR_FLASH";
+			status = "okay";
+			clock-frequency = < 2000000 >;
+			test-spi-nor@1 {
+				compatible = "vnd,spi-nor";
+				label = "TEST_SPI_NOR_CTRL";
+				reg = <1>;
+				spi-max-frequency = < 2000000 >;
+				partitions {
+					compatible = "fixed-partitions";
+					#address-cells = <1>;
+					#size-cells = <1>;
+					storage_partition: partition@0 {
+						label = "storage";
+						reg = <0x00000000 0x00010000>;
+					};
+				};
 			};
 		};
 
@@ -311,5 +341,6 @@
 			label = "TEST_PWM_CTRL_2";
 			status = "okay";
 		};
+
 	};
 };


### PR DESCRIPTION
The script does not allow to generate compatibles that exist in parallel
on two different buses. This caused problem if partitions tables are
placed on flash devices connected via different buses.
The fix enables fixed-partitions compatibles to be present on different
buses at once.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>