### PR TITLE
nrf5: Add FEM configuration options

### DIFF
--- a/modules/Kconfig.nordic
+++ b/modules/Kconfig.nordic
@@ -58,6 +58,27 @@ config NRF_802154_CCA_CORR_LIMIT
 	  Limit for occurrences above correlator threshold. When not equal to
 	  zero the correlator based signal detect is enabled.
 
+config NRF_802154_FEM_PRESENT
+	bool "Enable Front End Module (FEM) control"
+	default n
+	help
+	  Enable FEM control and its configuration options.
+
+choice
+	prompt "FEM interface type"
+	default NRF_802154_FEM_TYPE_3_PIN
+	depends on NRF_802154_FEM_PRESENT
+	help
+	  Set FEM interface type
+
+config NRF_802154_FEM_TYPE_2_PIN
+	bool "FEM with 2 pin (PA, LNA) interface"
+
+config NRF_802154_FEM_TYPE_3_PIN
+	bool "FEM with 3 pin (PA, LNA, PDN) interface"
+
+endchoice
+
 endif # NRF_802154_RADIO_DRIVER
 
 endmenu

--- a/west.yml
+++ b/west.yml
@@ -53,7 +53,7 @@ manifest:
       revision: a12d92816a53a521d79cefcf5c38b9dc8a4fed6e
       path: modules/hal/cypress
     - name: hal_nordic
-      revision: 1ebfdf148b2ca1d9ab9267ab2cd64cc00f32d505
+      revision: pull/38/head
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 3b54187649cc9b37161d49918f1ad28ff7c7f830


### PR DESCRIPTION
This PR adds new Kconfig options which allow for enabling
Front End Module (FEM) support.

Signed-off-by: Wojciech Bober <wojciech.bober@nordicsemi.no>