### PR TITLE
Xch/snprintf vs snprintk

### DIFF
--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -338,7 +338,7 @@ static u8_t *recv_cb(u8_t *buf, size_t *off)
 				while (bytes && buf) {
 					char msg[8 + 1];
 
-					snprintf(msg, sizeof(msg),
+					snprintk(msg, sizeof(msg),
 						 ">slip %2d", count);
 
 					LOG_HEXDUMP_DBG(buf->data, buf->len,

--- a/drivers/wifi/eswifi/eswifi.h
+++ b/drivers/wifi/eswifi/eswifi.h
@@ -114,7 +114,7 @@ static inline void eswifi_unlock(struct eswifi_dev *eswifi)
 int eswifi_at_cmd(struct eswifi_dev *eswifi, char *cmd);
 static inline int __select_socket(struct eswifi_dev *eswifi, u8_t idx)
 {
-	snprintf(eswifi->buf, sizeof(eswifi->buf), "P0=%d\r", idx);
+	snprintk(eswifi->buf, sizeof(eswifi->buf), "P0=%d\r", idx);
 	return eswifi_at_cmd(eswifi, eswifi->buf);
 }
 

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -247,7 +247,7 @@ static int eswifi_connect(struct eswifi_dev *eswifi)
 	eswifi_lock(eswifi);
 
 	/* Set SSID */
-	snprintf(eswifi->buf, sizeof(eswifi->buf), "C1=%s\r", eswifi->sta.ssid);
+	snprintk(eswifi->buf, sizeof(eswifi->buf), "C1=%s\r", eswifi->sta.ssid);
 	err = eswifi_at_cmd(eswifi, eswifi->buf);
 	if (err < 0) {
 		LOG_ERR("Unable to set SSID");
@@ -255,7 +255,7 @@ static int eswifi_connect(struct eswifi_dev *eswifi)
 	}
 
 	/* Set passphrase */
-	snprintf(eswifi->buf, sizeof(eswifi->buf), "C2=%s\r", eswifi->sta.pass);
+	snprintk(eswifi->buf, sizeof(eswifi->buf), "C2=%s\r", eswifi->sta.pass);
 	err = eswifi_at_cmd(eswifi, eswifi->buf);
 	if (err < 0) {
 		LOG_ERR("Unable to set passphrase");
@@ -263,7 +263,7 @@ static int eswifi_connect(struct eswifi_dev *eswifi)
 	}
 
 	/* Set Security type */
-	snprintf(eswifi->buf, sizeof(eswifi->buf), "C3=%u\r",
+	snprintk(eswifi->buf, sizeof(eswifi->buf), "C3=%u\r",
 		 eswifi->sta.security);
 	err = eswifi_at_cmd(eswifi, eswifi->buf);
 	if (err < 0) {
@@ -522,7 +522,7 @@ static int eswifi_mgmt_ap_enable(struct device *dev,
 	}
 
 	/* security */
-	snprintf(eswifi->buf, sizeof(eswifi->buf), "A1=%u\r",
+	snprintk(eswifi->buf, sizeof(eswifi->buf), "A1=%u\r",
 		 eswifi->sta.security);
 	err = eswifi_at_cmd(eswifi, eswifi->buf);
 	if (err < 0) {
@@ -532,7 +532,7 @@ static int eswifi_mgmt_ap_enable(struct device *dev,
 
 	/* Passkey */
 	if (eswifi->sta.security != ESWIFI_SEC_OPEN) {
-		snprintf(eswifi->buf, sizeof(eswifi->buf), "A2=%s\r",
+		snprintk(eswifi->buf, sizeof(eswifi->buf), "A2=%s\r",
 			 eswifi->sta.pass);
 		err = eswifi_at_cmd(eswifi, eswifi->buf);
 		if (err < 0) {
@@ -542,7 +542,7 @@ static int eswifi_mgmt_ap_enable(struct device *dev,
 	}
 
 	/* Set SSID (0=no MAC, 1=append MAC) */
-	snprintf(eswifi->buf, sizeof(eswifi->buf), "AS=0,%s\r",
+	snprintk(eswifi->buf, sizeof(eswifi->buf), "AS=0,%s\r",
 		 eswifi->sta.ssid);
 	err = eswifi_at_cmd(eswifi, eswifi->buf);
 	if (err < 0) {
@@ -551,7 +551,7 @@ static int eswifi_mgmt_ap_enable(struct device *dev,
 	}
 
 	/* Set Channel */
-	snprintf(eswifi->buf, sizeof(eswifi->buf), "AC=%u\r",
+	snprintk(eswifi->buf, sizeof(eswifi->buf), "AC=%u\r",
 		 eswifi->sta.channel);
 	err = eswifi_at_cmd(eswifi, eswifi->buf);
 	if (err < 0) {
@@ -573,7 +573,7 @@ static int eswifi_mgmt_ap_enable(struct device *dev,
 		goto error;
 	}
 
-	snprintf(eswifi->buf, sizeof(eswifi->buf), "Z6=%s\r",
+	snprintk(eswifi->buf, sizeof(eswifi->buf), "Z6=%s\r",
 		 net_sprint_ipv4_addr(&unicast->address.in_addr));
 	err = eswifi_at_cmd(eswifi, eswifi->buf);
 	if (err < 0) {
@@ -582,7 +582,7 @@ static int eswifi_mgmt_ap_enable(struct device *dev,
 	}
 
 	/* Enable AP */
-	snprintf(eswifi->buf, sizeof(eswifi->buf), "AD\r");
+	snprintk(eswifi->buf, sizeof(eswifi->buf), "AD\r");
 	err = eswifi_at_cmd(eswifi, eswifi->buf);
 	if (err < 0) {
 		LOG_ERR("Unable to active access point");

--- a/drivers/wifi/eswifi/eswifi_offload.c
+++ b/drivers/wifi/eswifi/eswifi_offload.c
@@ -50,7 +50,7 @@ static int eswifi_off_listen(struct net_context *context, int backlog)
 	__select_socket(eswifi, socket->index);
 
 	/* Set backlog */
-	snprintf(eswifi->buf, sizeof(eswifi->buf), "P8=%d\r", backlog);
+	snprintk(eswifi->buf, sizeof(eswifi->buf), "P8=%d\r", backlog);
 	err = eswifi_at_cmd(eswifi, eswifi->buf);
 	if (err < 0) {
 		LOG_ERR("Unable to start set listen backlog");
@@ -196,7 +196,7 @@ static int __eswifi_off_send_pkt(struct eswifi_dev *eswifi,
 	__select_socket(eswifi, socket->index);
 
 	/* header */
-	snprintf(eswifi->buf, sizeof(eswifi->buf), "S3=%u\r", bytes);
+	snprintk(eswifi->buf, sizeof(eswifi->buf), "S3=%u\r", bytes);
 	offset = strlen(eswifi->buf);
 
 	/* copy payload */

--- a/drivers/wifi/eswifi/eswifi_socket.c
+++ b/drivers/wifi/eswifi/eswifi_socket.c
@@ -41,7 +41,7 @@ static int __read_data(struct eswifi_dev *eswifi, size_t len, char **data)
 	int ret;
 
 	/* Set max read size */
-	snprintf(size, sizeof(size), "R1=%u\r", len);
+	snprintk(size, sizeof(size), "R1=%u\r", len);
 	ret = eswifi_at_cmd(eswifi, size);
 	if (ret < 0) {
 		LOG_ERR("Unable to set read size");
@@ -49,7 +49,7 @@ static int __read_data(struct eswifi_dev *eswifi, size_t len, char **data)
 	}
 
 	/* Set timeout */
-	snprintf(timeout, sizeof(timeout), "R2=%u\r", 30); /* 30 ms */
+	snprintk(timeout, sizeof(timeout), "R2=%u\r", 30); /* 30 ms */
 	ret = eswifi_at_cmd(eswifi, timeout);
 	if (ret < 0) {
 		LOG_ERR("Unable to set timeout");
@@ -73,7 +73,7 @@ int __eswifi_bind(struct eswifi_dev *eswifi, struct eswifi_off_socket *socket,
 	socket->port = sys_be16_to_cpu(net_sin(addr)->sin_port);
 
 	/* Set Local Port */
-	snprintf(eswifi->buf, sizeof(eswifi->buf), "P2=%d\r", socket->port);
+	snprintk(eswifi->buf, sizeof(eswifi->buf), "P2=%d\r", socket->port);
 	err = eswifi_at_cmd(eswifi, eswifi->buf);
 	if (err < 0) {
 		LOG_ERR("Unable to set local port");
@@ -161,7 +161,7 @@ int __eswifi_off_start_client(struct eswifi_dev *eswifi,
 	__select_socket(eswifi, socket->index);
 
 	/* Set Remote IP */
-	snprintf(eswifi->buf, sizeof(eswifi->buf), "P3=%u.%u.%u.%u\r",
+	snprintk(eswifi->buf, sizeof(eswifi->buf), "P3=%u.%u.%u.%u\r",
 		 sin_addr->s4_addr[0], sin_addr->s4_addr[1],
 		 sin_addr->s4_addr[2], sin_addr->s4_addr[3]);
 
@@ -172,7 +172,7 @@ int __eswifi_off_start_client(struct eswifi_dev *eswifi,
 	}
 
 	/* Set Remote Port */
-	snprintf(eswifi->buf, sizeof(eswifi->buf), "P4=%d\r",
+	snprintk(eswifi->buf, sizeof(eswifi->buf), "P4=%d\r",
 		(u16_t)sys_be16_to_cpu(net_sin(addr)->sin_port));
 	err = eswifi_at_cmd(eswifi, eswifi->buf);
 	if (err < 0) {
@@ -181,7 +181,7 @@ int __eswifi_off_start_client(struct eswifi_dev *eswifi,
 	}
 
 	/* Start TCP/UDP client */
-	snprintf(eswifi->buf, sizeof(eswifi->buf), "P6=1\r");
+	snprintk(eswifi->buf, sizeof(eswifi->buf), "P6=1\r");
 	err = eswifi_at_cmd(eswifi, eswifi->buf);
 	if (err < 0) {
 		LOG_ERR("Unable to start TCP/UDP client");
@@ -277,7 +277,7 @@ int __eswifi_socket_new(struct eswifi_dev *eswifi, int family, int type,
 		return -EIO;
 	}
 
-	snprintf(eswifi->buf, sizeof(eswifi->buf), "P1=%d\r", socket->type);
+	snprintk(eswifi->buf, sizeof(eswifi->buf), "P1=%d\r", socket->type);
 	err = eswifi_at_cmd(eswifi, eswifi->buf);
 	if (err < 0) {
 		LOG_ERR("Unable to set transport protocol");

--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -171,7 +171,7 @@ static int map_credentials(int sd, const void *optval, socklen_t optlen)
 				return -EINVAL;
 			}
 
-			snprintf(eswifi->buf, sizeof(eswifi->buf),
+			snprintk(eswifi->buf, sizeof(eswifi->buf),
 				 "PG=%d,%d,%d\r", 0, id, cert->len);
 			bytes = strlen(eswifi->buf);
 			memcpy(&eswifi->buf[bytes], cert->buf, cert->len);
@@ -184,7 +184,7 @@ static int map_credentials(int sd, const void *optval, socklen_t optlen)
 				return ret;
 			}
 
-			snprintf(eswifi->buf, sizeof(eswifi->buf), "PF=0,0\r");
+			snprintk(eswifi->buf, sizeof(eswifi->buf), "PF=0,0\r");
 			ret = eswifi_at_cmd(eswifi, eswifi->buf);
 			if (ret < 0) {
 				return ret;
@@ -251,7 +251,7 @@ static ssize_t eswifi_socket_send(void *obj, const void *buf, size_t len,
 	__select_socket(eswifi, socket->index);
 
 	/* header */
-	snprintf(eswifi->buf, sizeof(eswifi->buf), "S3=%u\r", len);
+	snprintk(eswifi->buf, sizeof(eswifi->buf), "S3=%u\r", len);
 	offset = strlen(eswifi->buf);
 
 	/* copy payload */

--- a/subsys/debug/thread_analyzer.c
+++ b/subsys/debug/thread_analyzer.c
@@ -61,7 +61,7 @@ static void thread_analyze_cb(const struct k_thread *cthread, void *user_data)
 	name = k_thread_name_get((k_tid_t)thread);
 	if (!name || name[0] == '\0') {
 		name = hexname;
-		sprintf(hexname, "%p", (void *)thread);
+		snprintk(hexname, sizeof(hexname), "%p", (void *)thread);
 	}
 
 	err = k_thread_stack_space_get(thread, &unused);

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -659,7 +659,7 @@ void log_output_dropped_process(const struct log_output *log_output, u32_t cnt)
 	struct device *dev = (struct device *)log_output->control_block->ctx;
 
 	cnt = MIN(cnt, 9999);
-	len = snprintf(buf, sizeof(buf), "%d", cnt);
+	len = snprintk(buf, sizeof(buf), "%d", cnt);
 
 	buffer_write(outf, (u8_t *)prefix, sizeof(prefix) - 1, dev);
 	buffer_write(outf, buf, len, dev);

--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -823,7 +823,7 @@ int do_write_op_json(struct lwm2m_message *msg)
 			}
 
 			/* combine base_name + name */
-			snprintf(full_name, sizeof(full_name), "%s%s",
+			snprintk(full_name, sizeof(full_name), "%s%s",
 				 base_name, value);
 
 			/* parse full_name into path */

--- a/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
@@ -129,7 +129,7 @@ size_t plain_text_put_float32fix(struct lwm2m_output_context *out,
 	char buf[sizeof("000000")];
 
 	/* value of 123 -> "000123" -- ignore sign */
-	len = snprintf(buf, sizeof(buf), "%06d", abs(value->val2));
+	len = snprintk(buf, sizeof(buf), "%06d", abs(value->val2));
 	if (len != 6U) {
 		strcpy(buf, "0");
 	} else {

--- a/subsys/net/lib/openthread/platform/diag.c
+++ b/subsys/net/lib/openthread/platform/diag.c
@@ -27,7 +27,7 @@ void otPlatDiagProcess(otInstance *aInstance,
 	ARG_UNUSED(aInstance);
 
 	/* Add more plarform specific diagnostics features here. */
-	snprintf(aOutput, aOutputMaxLen,
+	snprintk(aOutput, aOutputMaxLen,
 		 "diag feature '%s' is not supported\r\n", argv[0]);
 }
 

--- a/subsys/net/lib/openthread/platform/shell.c
+++ b/subsys/net/lib/openthread/platform/shell.c
@@ -52,7 +52,7 @@ static int ot_cmd(const struct shell *shell, size_t argc, char *argv[])
 			buf_ptr += arg_len + 1;
 		}
 
-		arg_len = snprintf(buf_ptr, buf_len, "%s", argv[i]);
+		arg_len = snprintk(buf_ptr, buf_len, "%s", argv[i]);
 
 		if (arg_len >= buf_len) {
 			shell_fprintf(shell, SHELL_WARNING,

--- a/subsys/net/lib/sockets/getnameinfo.c
+++ b/subsys/net/lib/sockets/getnameinfo.c
@@ -25,7 +25,7 @@ int zsock_getnameinfo(const struct sockaddr *addr, socklen_t addrlen,
 	}
 
 	if (serv != NULL) {
-		snprintf(serv, servlen, "%hu", ntohs(a->sin_port));
+		snprintk(serv, servlen, "%hu", ntohs(a->sin_port));
 	}
 
 	return 0;


### PR DESCRIPTION
This is a first draft of changes that could avoid linking both snprintk andsnprintf when possible.
It is linked to https://github.com/zephyrproject-rtos/zephyr/issues/24197.

I have for now focus only on `drivers` and `subsys` folders.

They are a few snprintf that can't be easily changed:

- `shell_fprintf.c`: `shell_fprintf_fmt()` but I'm not sure about the #ifdef to choose between `z_prf` and `z_vprintk`.
- `lwm2m_rw_plain_text.c`: `plain_text_put_float64fix()` as printk doesn't support printing %lld values.
- All the ones that I've missed.

This is obviously just a start, that might be enough or not depending on the modules a project uses.