### PR TITLE
tests: stream_flash: skip tests correctly

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -1410,10 +1410,12 @@ class TestCase(DisablePyTestCollectionMixin):
                 _subcases, warnings = self.scan_file(filename)
                 if warnings:
                     logger.error("%s: %s" % (filename, warnings))
+                    raise SanityRuntimeError("%s: %s" % (filename, warnings))
                 if _subcases:
                     subcases += _subcases
             except ValueError as e:
                 logger.error("%s: can't find: %s" % (filename, e))
+
         for filename in glob.glob(os.path.join(path, "*.c")):
             try:
                 _subcases, warnings = self.scan_file(filename)

--- a/tests/subsys/storage/stream/stream_flash/src/main.c
+++ b/tests/subsys/storage/stream/stream_flash/src/main.c
@@ -322,6 +322,16 @@ static void test_stream_flash_erase_page(void)
 
 	VERIFY_ERASED(FLASH_BASE, page_size);
 }
+#else
+static void test_stream_flash_erase_page(void)
+{
+	ztest_test_skip();
+}
+
+static void test_stream_flash_buffered_write_whole_page(void)
+{
+	ztest_test_skip();
+}
 #endif
 
 void test_main(void)
@@ -340,10 +350,8 @@ void test_main(void)
 	     ztest_unit_test(test_stream_flash_buffered_write_multi_page),
 	     ztest_unit_test(test_stream_flash_buf_size_greater_than_page_size),
 	     ztest_unit_test(test_stream_flash_buffered_write_callback),
-#ifdef CONFIG_STREAM_FLASH_ERASE
 	     ztest_unit_test(test_stream_flash_buffered_write_whole_page),
 	     ztest_unit_test(test_stream_flash_erase_page),
-#endif
 	     ztest_unit_test(test_stream_flash_bytes_written)
 	 );
 


### PR DESCRIPTION
User ztest_test_skip() to skip tests, not by conditionally including the
tests in the suite.

Fixes  #25057