### PR TITLE
drivers: can: Fix use of DT_HAS_DRV_INST which does not exist

### DIFF
--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -826,7 +826,7 @@ static int mcp2515_init(struct device *dev)
 	return ret;
 }
 
-#if DT_HAS_DRV_INST(0)
+#if DT_HAS_NODE_STATUS_OKAY(DT_DRV_INST(0))
 
 static K_THREAD_STACK_DEFINE(mcp2515_int_thread_stack,
 			     CONFIG_CAN_MCP2515_INT_THREAD_STACK_SIZE);
@@ -864,4 +864,4 @@ DEVICE_AND_API_INIT(can_mcp2515_1, DT_INST_LABEL(0), &mcp2515_init,
 		    &mcp2515_data_1, &mcp2515_config_1, POST_KERNEL,
 		    CONFIG_CAN_MCP2515_INIT_PRIORITY, &can_api_funcs);
 
-#endif /* DT_HAS_DRV_INST(0) */
+#endif /* DT_HAS_NODE_STATUS_OKAY(DT_DRV_INST(0)) */

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -656,7 +656,7 @@ static const struct can_driver_api mcux_flexcan_driver_api = {
 	.register_state_change_isr = mcux_flexcan_register_state_change_isr
 };
 
-#if DT_HAS_DRV_INST(0)
+#if DT_HAS_NODE_STATUS_OKAY(DT_DRV_INST(0))
 static void mcux_flexcan_config_func_0(struct device *dev);
 
 static const struct mcux_flexcan_config mcux_flexcan_config_0 = {
@@ -756,9 +756,9 @@ NET_DEVICE_INIT(socket_can_flexcan_0, SOCKET_CAN_NAME_1, socket_can_init_0,
 
 #endif /* CONFIG_NET_SOCKETS_CAN */
 
-#endif /* DT_HAS_DRV_INST(0) */
+#endif /* DT_HAS_NODE_STATUS_OKAY(DT_DRV_INST(0)) */
 
-#if DT_HAS_DRV_INST(1)
+#if DT_HAS_NODE_STATUS_OKAY(DT_DRV_INST(1))
 static void mcux_flexcan_config_func_1(struct device *dev);
 
 static const struct mcux_flexcan_config mcux_flexcan_config_1 = {
@@ -806,4 +806,4 @@ static void mcux_flexcan_config_func_1(struct device *dev)
 	irq_enable(DT_INST_IRQ_BY_NAME(1, mb_0_15, irq));
 }
 
-#endif /* DT_HAS_DRV_INST(1) */
+#endif /* DT_HAS_NODE_STATUS_OKAY(DT_DRV_INST(1)) */


### PR DESCRIPTION
Fix use of DT_HAS_DRV_INST which does not exist.
Use DT_HAS_NODE_STATUS_OKAY(DT_DRV_INST(n)) instead.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>