### PR TITLE
tests: semaphore tests overhaul

### DIFF
--- a/tests/kernel/semaphore/semaphore/src/main.c
+++ b/tests/kernel/semaphore/semaphore/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Intel Corporation
+ * Copyright (c) 2016, 2020 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -33,17 +33,19 @@ struct timeout_info {
 K_SEM_DEFINE(simple_sem, SEM_INIT_VAL, SEM_MAX_VAL);
 K_SEM_DEFINE(low_prio_sem, SEM_INIT_VAL, SEM_MAX_VAL);
 K_SEM_DEFINE(mid_prio_sem, SEM_INIT_VAL, SEM_MAX_VAL);
+K_SEM_DEFINE(high_prio_long_sem, SEM_INIT_VAL, SEM_MAX_VAL);
 K_SEM_DEFINE(high_prio_sem, SEM_INIT_VAL, SEM_MAX_VAL);
 K_SEM_DEFINE(multiple_thread_sem, SEM_INIT_VAL, SEM_MAX_VAL);
+
 K_THREAD_STACK_DEFINE(stack_1, STACK_SIZE);
 K_THREAD_STACK_DEFINE(stack_2, STACK_SIZE);
 K_THREAD_STACK_DEFINE(stack_3, STACK_SIZE);
+K_THREAD_STACK_DEFINE(stack_4, STACK_SIZE);
 K_THREAD_STACK_ARRAY_DEFINE(multiple_stack, TOTAL_THREADS_WAITING, STACK_SIZE);
 K_PIPE_DEFINE(timeout_info_pipe,
 	      sizeof(struct timeout_info) * TOTAL_THREADS_WAITING, 4);
 
-
-struct k_thread sem_tid, sem_tid_1, sem_tid_2;
+struct k_thread sem_tid_1, sem_tid_2, sem_tid_3, sem_tid_4;
 struct k_thread multiple_tid[TOTAL_THREADS_WAITING];
 
 K_SEM_DEFINE(ksema, SEM_INIT_VAL, SEM_MAX_VAL);
@@ -109,10 +111,12 @@ void sem_take_multiple_low_prio_helper(void *p1, void *p2, void *p3)
 	int32_t ret_value;
 
 	ret_value = k_sem_take(&low_prio_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "k_sem_take failed");
+	zassert_true(ret_value == 0, "k_sem_take failed with returned %d",
+		ret_value);
 
 	ret_value = k_sem_take(&multiple_thread_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "k_sem_take failed");
+	zassert_true(ret_value == 0, "k_sem_take failed with returned %d",
+		ret_value);
 
 	k_sem_give(&low_prio_sem);
 }
@@ -122,10 +126,12 @@ void sem_take_multiple_mid_prio_helper(void *p1, void *p2, void *p3)
 	int32_t ret_value;
 
 	ret_value = k_sem_take(&mid_prio_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "k_sem_take failed");
+	zassert_true(ret_value == 0, "k_sem_take failed with returned %d",
+		ret_value);
 
 	ret_value = k_sem_take(&multiple_thread_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "k_sem_take failed");
+	zassert_true(ret_value == 0, "k_sem_take failed with returned %d",
+		ret_value);
 
 	k_sem_give(&mid_prio_sem);
 }
@@ -135,10 +141,12 @@ void sem_take_multiple_high_prio_helper(void *p1, void *p2, void *p3)
 	int32_t ret_value;
 
 	ret_value = k_sem_take(&high_prio_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "k_sem_take failed");
+	zassert_true(ret_value == 0, "k_sem_take failed with returned %d",
+		ret_value);
 
 	ret_value = k_sem_take(&multiple_thread_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "k_sem_take failed");
+	zassert_true(ret_value == 0, "k_sem_take failed with returned %d",
+		ret_value);
 
 	k_sem_give(&high_prio_sem);
 }
@@ -179,6 +187,21 @@ void sem_queue_mutual_exclusion2(void *p1, void *p2, void *p3)
 	}
 }
 
+void sem_take_multiple_high_prio_long_helper(void *p1, void *p2, void *p3)
+{
+	int32_t ret_value;
+
+	ret_value = k_sem_take(&high_prio_long_sem, K_FOREVER);
+	zassert_true(ret_value == 0, "k_sem_take failed with returned %d",
+		ret_value);
+
+	ret_value = k_sem_take(&multiple_thread_sem, K_FOREVER);
+	zassert_true(ret_value == 0, "k_sem_take failed with returned %d",
+		ret_value);
+
+	k_sem_give(&high_prio_long_sem);
+}
+
 /**
  * @ingroup kernel_semaphore_tests
  * @{
@@ -211,7 +234,7 @@ void test_k_sem_define(void)
  * @brief Test synchronization of threads with semaphore
  * @see k_sem_init(), #K_SEM_DEFINE(x)
  */
-void test_sema_thread2thread(void)
+void test_sem_thread2thread(void)
 {
 	int ret;
 
@@ -230,7 +253,7 @@ void test_sema_thread2thread(void)
  * @brief Test synchronization between thread and irq
  * @see k_sem_init(), #K_SEM_DEFINE(x)
  */
-void test_sema_thread2isr(void)
+void test_sem_thread2isr(void)
 {
 	int ret;
 
@@ -245,23 +268,30 @@ void test_sema_thread2isr(void)
 }
 
 /**
- * @brief Test k_sem_init() API
- *
+ * @brief Test semaphore initialization at running time
+ * @details
+ * - Initialize a semaphore with valid count and max limit.
+ * - Initialize a semaphore with invalid max limit.
+ * - Initialize a semaphore with invalid count.
+ * @ingroup kernel_semaphore_tests
  */
-void test_k_sema_init(void)
+void test_k_sem_init(void)
 {
 	int ret;
 
+	/* initialize a semaphore with valid count and max limit */
 	ret = k_sem_init(&sema, SEM_INIT_VAL, SEM_MAX_VAL);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0, "k_sem_init() failed");
 
 	k_sem_reset(&sema);
 
+	/* initialize a semaphore with invalid max limit */
 	ret = k_sem_init(&sema, SEM_INIT_VAL, 0);
-	zassert_equal(ret, -EINVAL, NULL);
+	zassert_equal(ret, -EINVAL, "k_sem_init() with invalid max limit");
 
+	/* initialize a semaphore with invalid count */
 	ret = k_sem_init(&sema, SEM_MAX_VAL + 1, SEM_MAX_VAL);
-	zassert_equal(ret, -EINVAL, NULL);
+	zassert_equal(ret, -EINVAL, "k_sem_init with invalid count");
 
 }
 
@@ -270,7 +300,7 @@ void test_k_sema_init(void)
  * @brief Test k_sem_reset() API
  * @see k_sem_reset()
  */
-void test_sema_reset(void)
+void test_sem_reset(void)
 {
 	int ret;
 
@@ -292,7 +322,7 @@ void test_sema_reset(void)
  * @brief Test k_sem_count_get() API
  * @see k_sem_count_get()
  */
-void test_sema_count_get(void)
+void test_sem_count_get(void)
 {
 	int ret;
 
@@ -317,10 +347,17 @@ void test_sema_count_get(void)
 
 
 /**
- * @brief Test semaphore count when given by an ISR
+ * @brief Test whether a semaphore can be given by an ISR
+ * @details
+ * - Reset an initialized semaphore's count to zero
+ * - Create a loop, in each loop, do follow steps
+ * - Give the semaphore from an ISR
+ * - Get the semaphore's count
+ * - Verify whether the semaphore's count as expected
+ * @ingroup kernel_semaphore_tests
  * @see k_sem_give()
  */
-void test_simple_sem_from_isr(void)
+void test_sem_give_from_isr(void)
 {
 	uint32_t signal_count;
 
@@ -328,6 +365,8 @@ void test_simple_sem_from_isr(void)
 	 * Signal the semaphore several times from an ISR.  After each signal,
 	 * check the signal count.
 	 */
+
+	k_sem_reset(&simple_sem);
 
 	for (int i = 0; i < 5; i++) {
 		sem_give_from_isr(&simple_sem);
@@ -342,9 +381,16 @@ void test_simple_sem_from_isr(void)
 
 /**
  * @brief Test semaphore count when given by thread
+ * @details
+ * - Reset an initialized semaphore's count to zero
+ * - Create a loop, in each loop, do follow steps
+ * - Give the semaphore from a thread
+ * - Get the semaphore's count
+ * - Verify whether the semaphore's count as expected
+ * @ingroup kernel_semaphore_tests
  * @see k_sem_give()
  */
-void test_simple_sem_from_task(void)
+void test_sem_give_from_thread(void)
 {
 	uint32_t signal_count;
 
@@ -429,76 +475,113 @@ void test_sem_take_no_wait_fails(void)
 }
 
 /**
- * @brief Test k_sem_take() with timeout expiry
+ * @brief Test a semaphore take operation with an unavailable semaphore
+ * @details
+ * - Reset the semaphore's count to zero, let it unavailable.
+ * - Take an unavailable semaphore and wait it until timeout.
+ * @ingroup kernel_semaphore_tests
  * @see k_sem_take()
  */
 void test_sem_take_timeout_fails(void)
 {
-	int32_t ret_value;
-
 	/*
 	 * Test the semaphore with timeout without a k_sem_give.
 	 */
 
+	int32_t ret_value;
+	uint32_t signal_count;
+
 	k_sem_reset(&simple_sem);
 
+	signal_count = k_sem_count_get(&simple_sem);
+	zassert_true(signal_count == 0U, "k_sem_reset failed");
+
+	/* take an unavailable semaphore and wait it until timeout */
 	for (int i = 4; i >= 0; i--) {
 		ret_value = k_sem_take(&simple_sem, SEM_TIMEOUT);
 		zassert_true(ret_value == -EAGAIN,
-			     "k_sem_take succeeded when its not possible");
+				"k_sem_take succeeded when it's not possible");
 	}
-
 }
 
 /**
- * @brief Test k_sem_take() with timeout
+ * @brief Test the semaphore take operation with specified timeout
+ * @details
+ * - Create a new thread, it will give semaphore.
+ * - Reset the semaphore's count to zero.
+ * - Take semaphore and wait it given by other threads in specified timeout.
+ * @ingroup kernel_semaphore_tests
  * @see k_sem_take()
  */
 void test_sem_take_timeout(void)
 {
 	int32_t ret_value;
+	uint32_t signal_count;
 
 	/*
-	 * Signal the semaphore upon which the other thread is waiting.  The
-	 * thread (which is at a lower priority) will cause simple_sem
+	 * Signal the semaphore upon which the other thread is waiting.
+	 * The thread (which is at a lower priority) will cause simple_sem
 	 * to be signalled, thus waking up this task.
 	 */
-	k_thread_create(&sem_tid, stack_1, STACK_SIZE,
+
+	/* create a new thread, it will give semaphore */
+	k_thread_create(&sem_tid_1, stack_1, STACK_SIZE,
 			sem_give_task, &simple_sem, NULL, NULL,
 			K_PRIO_PREEMPT(0), K_USER | K_INHERIT_PERMS,
 			K_NO_WAIT);
 
 	k_sem_reset(&simple_sem);
 
+	signal_count = k_sem_count_get(&simple_sem);
+	zassert_true(signal_count == 0U, "k_sem_reset failed");
+
+	/* Take semaphore and wait it given by other threads
+	 * in specified timeout
+	 */
 	ret_value = k_sem_take(&simple_sem, SEM_TIMEOUT);
-	zassert_true(ret_value == 0, "k_sem_take failed");
-	k_thread_abort(&sem_tid);
+	zassert_true(ret_value == 0, "k_sem_take failed with returned %d",
+			ret_value);
+	k_thread_abort(&sem_tid_1);
 
 }
 
 /**
- * @brief Test k_sem_take() with forever timeout
+ * @brief Test the semaphore take operation with forever wait
+ * @details
+ * - Create a new thread, it will give semaphore.
+ * - Reset the semaphore's count to zero.
+ * - Take semaphore, wait it given by other thread forever until it's available.
+ * @ingroup kernel_semaphore_tests
  * @see k_sem_take()
  */
 void test_sem_take_timeout_forever(void)
 {
 	int32_t ret_value;
+	uint32_t signal_count;
 
 	/*
 	 * Signal the semaphore upon which the another thread is waiting.  The
 	 * thread (which is at a lower priority) will cause simple_sem
 	 * to be signalled, thus waking this task.
 	 */
-	k_thread_create(&sem_tid, stack_1, STACK_SIZE,
+
+	k_thread_create(&sem_tid_1, stack_1, STACK_SIZE,
 			sem_take_timeout_forever_helper, NULL, NULL, NULL,
 			K_PRIO_PREEMPT(0), K_USER | K_INHERIT_PERMS,
 			K_NO_WAIT);
 
 	k_sem_reset(&simple_sem);
 
+	signal_count = k_sem_count_get(&simple_sem);
+	zassert_true(signal_count == 0U, "k_sem_reset failed");
+
+	/* Take semaphore and wait it given by
+	 * other threads forever until it's available
+	 */
 	ret_value = k_sem_take(&simple_sem, K_FOREVER);
-	zassert_true(ret_value == 0, "k_sem_take failed");
-	k_thread_abort(&sem_tid);
+	zassert_true(ret_value == 0, "k_sem_take failed with returned %d",
+			ret_value);
+	k_thread_abort(&sem_tid_1);
 
 }
 
@@ -515,7 +598,8 @@ void test_sem_take_timeout_isr(void)
 	 * thread (which is at a lower priority) will cause simple_sem
 	 * to be signalled, thus waking this task.
 	 */
-	k_thread_create(&sem_tid, stack_1, STACK_SIZE,
+
+	k_thread_create(&sem_tid_1, stack_1, STACK_SIZE,
 			sem_take_timeout_isr_helper, NULL, NULL, NULL,
 			K_PRIO_PREEMPT(0), 0, K_NO_WAIT);
 
@@ -527,55 +611,86 @@ void test_sem_take_timeout_isr(void)
 }
 
 /**
- * @brief Test multiple semaphore take
+ * @brief Test semaphore take operation by multiple threads
+ * @ingroup kernel_semaphore_tests
  * @see k_sem_take()
  */
 void test_sem_take_multiple(void)
 {
 	uint32_t signal_count;
 
+	k_sem_reset(&multiple_thread_sem);
+	signal_count = k_sem_count_get(&multiple_thread_sem);
+	zassert_true(signal_count == 0U, "k_sem_reset failed");
+
 	/*
-	 * Signal the semaphore upon which the another thread is waiting.  The
-	 * thread (which is at a lower priority) will cause simple_sem
+	 * Signal the semaphore upon which the another thread is waiting.
+	 * The thread (which is at a lower priority) will cause simple_sem
 	 * to be signalled, thus waking this task.
 	 */
-	k_thread_create(&sem_tid, stack_1, STACK_SIZE,
+
+	k_thread_create(&sem_tid_1, stack_1, STACK_SIZE,
 			sem_take_multiple_low_prio_helper,
 			NULL, NULL, NULL,
 			K_PRIO_PREEMPT(3), K_USER | K_INHERIT_PERMS,
 			K_NO_WAIT);
 
-	k_thread_create(&sem_tid_1, stack_2, STACK_SIZE,
+	k_thread_create(&sem_tid_2, stack_2, STACK_SIZE,
 			sem_take_multiple_mid_prio_helper,
 			NULL, NULL, NULL,
 			K_PRIO_PREEMPT(2), K_USER | K_INHERIT_PERMS,
 			K_NO_WAIT);
 
-	k_thread_create(&sem_tid_2, stack_3, STACK_SIZE,
-			sem_take_multiple_high_prio_helper,
+	k_thread_create(&sem_tid_3, stack_3, STACK_SIZE,
+			sem_take_multiple_high_prio_long_helper,
 			NULL, NULL, NULL,
 			K_PRIO_PREEMPT(1), K_USER | K_INHERIT_PERMS,
 			K_NO_WAIT);
 
+	/* Create another high priority thread, the same priority with sem_tid_3
+	 * sem_tid_3 and sem_tid_4 are the same highest priority,
+	 * but the waiting time of sem_tid_3 is longer than sem_tid_4.
+	 * If some threads are the same priority, the sem given operation
+	 * should be decided according to waiting time.
+	 * That thread is necessary to test if a sem is available,
+	 * it should be given to the highest priority and longest waiting thread
+	 */
+	k_thread_create(&sem_tid_4, stack_4, STACK_SIZE,
+			sem_take_multiple_high_prio_helper, NULL, NULL,
+			NULL, K_PRIO_PREEMPT(1), K_USER | K_INHERIT_PERMS,
+			K_NO_WAIT);
 
-	/* time for those 3 threads to complete */
+	/* time for those 4 threads to complete */
 	k_sleep(K_MSEC(20));
 
-	/* Let these threads proceed to take the multiple_sem */
-	k_sem_give(&high_prio_sem);
+	/* Let these threads proceed to take the multiple_sem
+	 * make thread 1 to 3 waiting on multiple_thread_sem
+	 */
+	k_sem_give(&high_prio_long_sem);
 	k_sem_give(&mid_prio_sem);
 	k_sem_give(&low_prio_sem);
 
-	k_sleep(K_MSEC(200));
+	/* Delay 100ms to make sem_tid_4 waiting on multiple_thread_sem,
+	 * then waiting time of sem_tid_4 is shorter than sem_tid_3
+	 */
+	k_sleep(K_MSEC(100));
+	k_sem_give(&high_prio_sem);
 
-	/* enable the higher priority thread to run. */
+	k_sleep(K_MSEC(20));
+
+	/* enable the high prio and long waiting thread sem_tid_3 to run */
 	k_sem_give(&multiple_thread_sem);
 	k_sleep(K_MSEC(200));
 
-	/* check which threads completed. */
-	signal_count = k_sem_count_get(&high_prio_sem);
+	/* check which threads completed */
+	signal_count = k_sem_count_get(&high_prio_long_sem);
 	zassert_true(signal_count == 1U,
-		     "Higher priority threads did not execute");
+			"High priority and long waiting thread "
+			"don't get the sem");
+
+	signal_count = k_sem_count_get(&high_prio_sem);
+	zassert_true(signal_count == 0U,
+			"High priority thread shouldn't get the sem");
 
 	signal_count = k_sem_count_get(&mid_prio_sem);
 	zassert_true(signal_count == 0U,
@@ -583,35 +698,64 @@ void test_sem_take_multiple(void)
 
 	signal_count = k_sem_count_get(&low_prio_sem);
 	zassert_true(signal_count == 0U,
-		     "low priority threads shouldn't have executed");
+		     "Low priority threads shouldn't have executed");
 
-	/* enable the Medium priority thread to run. */
+	/* enable the high prio thread sem_tid_4 to run */
 	k_sem_give(&multiple_thread_sem);
 	k_sleep(K_MSEC(200));
-	/* check which threads completed. */
+
+	/* check which threads completed */
+	signal_count = k_sem_count_get(&high_prio_long_sem);
+	zassert_true(signal_count == 1U, "High priority and long waiting thread"
+			" executed again");
+
 	signal_count = k_sem_count_get(&high_prio_sem);
 	zassert_true(signal_count == 1U,
-		     "Higher priority thread executed again");
+		     "Higher priority thread did not get the sem");
 
 	signal_count = k_sem_count_get(&mid_prio_sem);
-	zassert_true(signal_count == 1U,
-		     "Medium priority thread did not get executed");
+	zassert_true(signal_count == 0U,
+		     "Medium priority thread shouldn't get the sem");
 
 	signal_count = k_sem_count_get(&low_prio_sem);
 	zassert_true(signal_count == 0U,
-		     "low priority thread shouldn't have executed");
+		     "Low priority thread shouldn't get the sem");
 
-	/* enable the low priority thread to run. */
+	/* enable the mid prio thread sem_tid_2 to run */
 	k_sem_give(&multiple_thread_sem);
 	k_sleep(K_MSEC(200));
-	/* check which threads completed. */
+
+	/* check which threads completed */
+	signal_count = k_sem_count_get(&high_prio_long_sem);
+	zassert_true(signal_count == 1U, "High priority and long waiting thread"
+			" executed again");
+
 	signal_count = k_sem_count_get(&high_prio_sem);
 	zassert_true(signal_count == 1U,
-		     "Higher priority thread executed again");
+		     "High priority thread executed again");
 
 	signal_count = k_sem_count_get(&mid_prio_sem);
 	zassert_true(signal_count == 1U,
-		     "Medium priority thread executed again");
+		     "Medium priority thread did not get the sem");
+
+	signal_count = k_sem_count_get(&low_prio_sem);
+	zassert_true(signal_count == 0U,
+		     "Low priority thread did not get the sem");
+
+	/* enable the low prio thread(thread_1) to run */
+	k_sem_give(&multiple_thread_sem);
+	k_sleep(K_MSEC(200));
+
+	/* check the thread completed */
+	signal_count = k_sem_count_get(&high_prio_long_sem);
+	zassert_true(signal_count == 1U, "High priority and long waiting thread"
+			" executed again");
+
+	signal_count = k_sem_count_get(&high_prio_sem);
+	zassert_true(signal_count == 1U, "High priority thread executed again");
+
+	signal_count = k_sem_count_get(&mid_prio_sem);
+	zassert_true(signal_count == 1U, "Mid priority thread executed again");
 
 	signal_count = k_sem_count_get(&low_prio_sem);
 	zassert_true(signal_count == 1U,
@@ -703,8 +847,10 @@ void test_sem_give_take_from_isr(void)
 	uint32_t signal_count;
 
 	k_sem_reset(&simple_sem);
+	signal_count = k_sem_count_get(&simple_sem);
+	zassert_true(signal_count == 0U, "k_sem_reset failed");
 
-	/* Give semaphore from an isr and do a check for the count */
+	/* give semaphore from an isr and do a check for the count */
 	for (int i = 0; i < SEM_MAX_VAL; i++) {
 		sem_give_from_isr(&simple_sem);
 
@@ -714,7 +860,7 @@ void test_sem_give_take_from_isr(void)
 			     i + 1, signal_count);
 	}
 
-	/* Take semaphore from an isr and do a check for the count */
+	/* take semaphore from an isr and do a check for the count */
 	for (int i = SEM_MAX_VAL; i > 0; i--) {
 		sem_take_from_isr(&simple_sem);
 
@@ -734,7 +880,7 @@ void sem_multiple_threads_wait_helper(void *p1, void *p2, void *p3)
 	/* get blocked until the test thread gives the semaphore */
 	k_sem_take(&multiple_thread_sem, K_FOREVER);
 
-	/* Inform the test thread that this thread has got multiple_thread_sem*/
+	/* inform the test thread that this thread has got multiple_thread_sem*/
 	k_sem_give(&simple_sem);
 }
 
@@ -753,7 +899,6 @@ void test_sem_multiple_threads_wait(void)
 	k_sem_reset(&simple_sem);
 	k_sem_reset(&multiple_thread_sem);
 
-
 	do {
 		for (int i = 0; i < TOTAL_THREADS_WAITING; i++) {
 			k_thread_create(&multiple_tid[i],
@@ -767,7 +912,7 @@ void test_sem_multiple_threads_wait(void)
 		/* giving time for the other threads to execute  */
 		k_sleep(K_MSEC(500));
 
-		/* Give the semaphores */
+		/* give the semaphores */
 		for (int i = 0; i < TOTAL_THREADS_WAITING; i++) {
 			k_sem_give(&multiple_thread_sem);
 		}
@@ -812,7 +957,7 @@ void test_sem_measure_timeouts(void)
 
 	k_sem_reset(&simple_sem);
 
-	/* With timeout of 1 sec */
+	/* with timeout of 1 sec */
 	start_ticks = k_uptime_get();
 
 	ret_value = k_sem_take(&simple_sem, K_SECONDS(1));
@@ -825,7 +970,7 @@ void test_sem_measure_timeouts(void)
 		     "time missmatch - expected %d, got %d",
 		     SEC2MS(1), end_ticks - start_ticks);
 
-	/* With 0 as the timeout */
+	/* with 0 as the timeout */
 	start_ticks = k_uptime_get();
 
 	ret_value = k_sem_take(&simple_sem, K_NO_WAIT);
@@ -864,8 +1009,8 @@ void test_sem_measure_timeout_from_thread(void)
 	k_sem_reset(&simple_sem);
 	k_sem_reset(&multiple_thread_sem);
 
-	/* Give a semaphore from a thread and calculate the time taken.*/
-	k_thread_create(&sem_tid, stack_1, STACK_SIZE,
+	/* give a semaphore from a thread and calculate the time taken */
+	k_thread_create(&sem_tid_1, stack_1, STACK_SIZE,
 			sem_measure_timeout_from_thread_helper,
 			NULL, NULL, NULL,
 			K_PRIO_PREEMPT(3), 0, K_NO_WAIT);
@@ -874,7 +1019,7 @@ void test_sem_measure_timeout_from_thread(void)
 	/* first sync the 2 threads */
 	k_sem_take(&simple_sem, K_FOREVER);
 
-	/* With timeout of 1 sec */
+	/* with timeout of 1 sec */
 	start_ticks = k_uptime_get();
 
 	ret_value = k_sem_take(&multiple_thread_sem, K_SECONDS(1));
@@ -1059,20 +1204,21 @@ void test_main(void)
 {
 	k_thread_access_grant(k_current_get(),
 			      &simple_sem, &multiple_thread_sem, &low_prio_sem,
-			      &mid_prio_sem, &high_prio_sem, &ksema, &sema,
-			      &stack_1, &stack_2, &stack_3, &timeout_info_pipe,
-			      &sem_tid, &sem_tid_1, &sem_tid_2,
-			      &tstack, &tdata, &mut_sem);
+				  &mid_prio_sem, &high_prio_sem, &ksema, &sema,
+				  &high_prio_long_sem, &stack_1, &stack_2,
+				  &stack_3, &stack_4, &timeout_info_pipe,
+				  &sem_tid_1, &sem_tid_2, &sem_tid_3, &sem_tid_4,
+				  &tstack, &tdata, &mut_sem);
 
 	ztest_test_suite(test_semaphore,
 			 ztest_user_unit_test(test_k_sem_define),
-			 ztest_user_unit_test(test_k_sema_init),
-			 ztest_user_unit_test(test_sema_thread2thread),
-			 ztest_unit_test(test_sema_thread2isr),
-			 ztest_user_unit_test(test_sema_reset),
-			 ztest_user_unit_test(test_sema_count_get),
-			 ztest_unit_test(test_simple_sem_from_isr),
-			 ztest_user_unit_test(test_simple_sem_from_task),
+			 ztest_user_unit_test(test_k_sem_init),
+			 ztest_user_unit_test(test_sem_thread2thread),
+			 ztest_unit_test(test_sem_thread2isr),
+			 ztest_user_unit_test(test_sem_reset),
+			 ztest_user_unit_test(test_sem_count_get),
+			 ztest_unit_test(test_sem_give_from_isr),
+			 ztest_user_unit_test(test_sem_give_from_thread),
 			 ztest_user_unit_test(test_sem_take_no_wait),
 			 ztest_user_unit_test(test_sem_take_no_wait_fails),
 			 ztest_1cpu_user_unit_test(test_sem_take_timeout_fails),
@@ -1090,4 +1236,3 @@ void test_main(void)
 			 ztest_1cpu_unit_test(test_sem_queue_mutual_exclusion));
 	ztest_run_test_suite(test_semaphore);
 }
-/******************************************************************************/


### PR DESCRIPTION
Modify current semaphore tests.
I checked the semaphore tests, and find out many gaps.
Overhaul semaphore tests:
1. Modify some tests
2.Doxygen tags update
3. Update text in zassert messages
4. Remove misprints
5. Test cases names change. Some test cases had a semaphore name in
their name, for example "simple_sem", I removed it from the test
case names. Also some test cases used "sema", some used word "sem".
I decided to make standard short word for a semaphore "sem"

Detailed explanation of the changes:
-test_k_sema_init() -updated name to test_sem_init, updated doxygen
tag, updated zassert text
-test_sem_take_timeout() -updated doxygen tag, added zassert to check
that reset was correct, updated zassert text
-test_sem_take_timeout_fails() -updated doxygen tag, added zassert
to check that reset was correct, updated zassert text
-test_sem_take_timeout_forever() -updated doxygen tag, added zassert
to check that reset was correct, updated zassert text
-test_sem_take_multiple() -updated doxygen tag, modified that test,
added one more thread sem_tid_4, with high priority and added one
more semaphore high_prio_long_sem
-test_simple_sem_from_isr() -updated name to test_sem_give_from_isr,
updated doxygen tag, zassert text fix
-test_simple_sem_from_task() -updated name
to test_sem_give_from_thread, updated doxygen tag, zassert text fix

Tested on qemu_x86, qemu_x86_64, reel_board, and iotdk