### PR TITLE
lora: Remove the a tx parameter in modem_config 

### DIFF
--- a/drivers/lora/shell.c
+++ b/drivers/lora/shell.c
@@ -89,6 +89,23 @@ static int parse_freq(u32_t *out, const struct shell *shell, const char *arg)
 	return 0;
 }
 
+
+static int parse_bool(bool *out, const struct shell *shell, const char *arg,
+		      const char *name)
+{
+	if (!strcmp(arg, "true") || !strcmp(arg, "1")) {
+		*out = true;
+	} else if (!strcmp(arg, "false") || !strcmp(arg, "0")) {
+		*out = false;
+	} else {
+		shell_error(shell, "Parameter '%s': '%s' is not a Boolean.",
+			    name, arg);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 static struct device *get_modem(const struct shell *shell)
 {
 	struct device *dev;
@@ -141,6 +158,10 @@ static int lora_conf_dump(const struct shell *shell)
 		    (int)modem_config.coding_rate + 4);
 	shell_print(shell, "  Preamble length: %" PRIu16,
 		    modem_config.preamble_len);
+	shell_print(shell, "  Public network sync word: %s",
+		    modem_config.public_network ? "true" : "false");
+	shell_print(shell, "  I/Q inverted: %s",
+		    modem_config.iq_inverted ? "true" : "false");
 
 	return 0;
 }
@@ -195,6 +216,12 @@ static int lora_conf_set(const struct shell *shell, const char *param,
 			return -EINVAL;
 		}
 		modem_config.preamble_len = lval;
+	} else if (!strcmp("public", param)) {
+		return parse_bool(&modem_config.public_network, shell, value,
+				  "public");
+	} else if (!strcmp("iq-inv", param)) {
+		return parse_bool(&modem_config.iq_inverted, shell, value,
+				  "iq-inv");
 	} else {
 		shell_error(shell, "Unknown parameter '%s'", param);
 		return -EINVAL;
@@ -315,7 +342,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_lora,
 	SHELL_CMD(config, NULL,
 		  "Configure the LoRa radio\n"
 		  " Usage: config [freq <Hz>] [tx-power <dBm>] [bw <kHz>] "
-		  "[sf <int>] [cr <int>] [pre-len <int>]\n",
+		  "[sf <int>] [cr <int>] [pre-len <int>] [public <bool>] "
+		  "[iq-inv <bool>]\n",
 		  cmd_lora_conf),
 	SHELL_CMD_ARG(send, NULL,
 		      "Send LoRa packet\n"

--- a/drivers/lora/shell.c
+++ b/drivers/lora/shell.c
@@ -234,7 +234,6 @@ static int cmd_lora_send(const struct shell *shell,
 	int ret;
 	struct device *dev;
 
-	modem_config.tx = true;
 	dev = get_configured_modem(shell);
 	if (!dev) {
 		return -ENODEV;
@@ -258,7 +257,6 @@ static int cmd_lora_recv(const struct shell *shell, size_t argc, char **argv)
 	s16_t rssi;
 	s8_t snr;
 
-	modem_config.tx = false;
 	dev = get_configured_modem(shell);
 	if (!dev) {
 		return -ENODEV;

--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -365,7 +365,10 @@ void SX1276SetRfTxPower(int8_t power)
 
 static int sx1276_config_valid(const struct lora_modem_config *config)
 {
-	if (config->frequency == 0)
+	if (config->frequency == 0 ||
+	    config->bandwidth < BW_MIN || config->bandwidth > BW_MAX ||
+	    config->datarate < SF_MIN || config->datarate > SF_MAX ||
+	    config->coding_rate < CR_MIN || config->coding_rate > CR_MAX)
 		return -EINVAL;
 
 	return 0;

--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -382,6 +382,7 @@ static int sx1276_apply_config(const struct lora_modem_config *config, bool tx)
 	if (ret < 0)
 		return ret;
 
+	Radio.SetPublicNetwork(config->public_network);
 	Radio.SetChannel(config->frequency);
 
 	if (tx) {
@@ -392,7 +393,7 @@ static int sx1276_apply_config(const struct lora_modem_config *config, bool tx)
 				  true /* crcOn */,
 				  false /* freqHopOn */,
 				  0 /* hopPeriod */,
-				  false /* iqInverted */,
+				  config->iq_inverted,
 				  4000 /* timeout */);
 	} else {
 		/* TODO: Get symbol timeout value from config parameters */
@@ -406,7 +407,7 @@ static int sx1276_apply_config(const struct lora_modem_config *config, bool tx)
 				  false /* crcOn */,
 				  0 /* freqHopOn */,
 				  0 /* hopPeriod */,
-				  false /* iqInverted */,
+				  config->iq_inverted,
 				  true /* rxContinuous */);
 	}
 
@@ -529,6 +530,7 @@ const struct Radio_s Radio = {
 	.RxBoosted = NULL,
 	.SetRxDutyCycle = NULL,
 	.SetTxContinuousWave = SX1276SetTxContinuousWave,
+	.SetPublicNetwork = SX1276SetPublicNetwork,
 };
 
 static int sx1276_lora_init(struct device *dev)

--- a/include/drivers/lora.h
+++ b/include/drivers/lora.h
@@ -54,6 +54,8 @@ struct lora_modem_config {
 	enum lora_coding_rate coding_rate;
 	u16_t preamble_len;
 	s8_t tx_power;
+	bool public_network;
+	bool iq_inverted;
 };
 
 /**

--- a/include/drivers/lora.h
+++ b/include/drivers/lora.h
@@ -45,7 +45,6 @@ struct lora_modem_config {
 	enum lora_coding_rate coding_rate;
 	u16_t preamble_len;
 	s8_t tx_power;
-	bool tx;
 };
 
 /**

--- a/include/drivers/lora.h
+++ b/include/drivers/lora.h
@@ -19,6 +19,9 @@ enum lora_signal_bandwidth {
 	BW_125_KHZ = 0,
 	BW_250_KHZ,
 	BW_500_KHZ,
+
+	BW_MIN = BW_125_KHZ,
+	BW_MAX = BW_500_KHZ,
 };
 
 enum lora_datarate {
@@ -29,6 +32,9 @@ enum lora_datarate {
 	SF_10,
 	SF_11,
 	SF_12,
+
+	SF_MIN = SF_6,
+	SF_MAX = SF_12,
 };
 
 enum lora_coding_rate {
@@ -36,6 +42,9 @@ enum lora_coding_rate {
 	CR_4_6 = 2,
 	CR_4_7 = 3,
 	CR_4_8 = 4,
+
+	CR_MIN = CR_4_5,
+	CR_MAX = CR_4_8,
 };
 
 struct lora_modem_config {

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -42,7 +42,6 @@ void main(void)
 	config.preamble_len = 8;
 	config.coding_rate = CR_4_5;
 	config.tx_power = 14;
-	config.tx = false;
 
 	ret = lora_config(lora_dev, &config);
 	if (ret < 0) {

--- a/samples/drivers/lora/send/src/main.c
+++ b/samples/drivers/lora/send/src/main.c
@@ -41,7 +41,6 @@ void main(void)
 	config.preamble_len = 8;
 	config.coding_rate = CR_4_5;
 	config.tx_power = 4;
-	config.tx = true;
 
 	ret = lora_config(lora_dev, &config);
 	if (ret < 0) {


### PR DESCRIPTION
This pull request contain a set of changes that modify the behaviour of `lora_config` and introduce options to configure more aspects of the radio.

The biggest difference is the removal of the tx parameter and lazy application of the configuration. There are two reasons for this: 1) The tx parameter makes the configuration interface a bit clunky to use and is really an implementation detail of the LoRaMAC driver, and 2) it makes the behaviour of send/receive calls more predictable since it forces the radio into a known good state before starting the operation.

The drawback of this approach is that we now configure the modem every time someone calls `lora_send` or `lora_recv`. This is unlikely to be a big problem in practice since these operations should be relatively in frequent. If it turns out to be a problem, the Zephyr driver could track the state of the radio and apply the configuration if needed.