### PR TITLE
more fixes for integer timeouts

### DIFF
--- a/drivers/modem/modem_socket.c
+++ b/drivers/modem/modem_socket.c
@@ -289,7 +289,7 @@ int modem_socket_poll(struct modem_socket_config *cfg,
 		return found_count;
 	}
 
-	ret = k_sem_take(&cfg->sem_poll, msecs);
+	ret = k_sem_take(&cfg->sem_poll, K_MSEC(msecs));
 	for (i = 0; i < nfds; i++) {
 		sock = modem_socket_from_fd(cfg, fds[i].fd);
 		if (!sock) {

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -252,7 +252,7 @@ static ssize_t send_socket_data(struct modem_socket *sock,
 	}
 
 	k_sem_reset(&mdata.sem_response);
-	ret = k_sem_take(&mdata.sem_response, timeout);
+	ret = k_sem_take(&mdata.sem_response, K_MSEC(timeout));
 
 	if (ret == 0) {
 		ret = modem_cmd_handler_get_error(&mdata.cmd_handler_data);

--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -586,7 +586,7 @@ static int esp_recv(struct net_context *context,
 		return 0;
 	}
 
-	ret = k_sem_take(&sock->sem_data_ready, timeout);
+	ret = k_sem_take(&sock->sem_data_ready, K_MSEC(timeout));
 
 	sock->recv_cb = NULL;
 

--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -401,7 +401,7 @@ static int winc1500_connect(struct net_context *context,
 	}
 
 	if (timeout != 0 &&
-	    k_sem_take(&w1500_data.socket_data[socket].wait_sem, timeout)) {
+	    k_sem_take(&w1500_data.socket_data[socket].wait_sem, K_MSEC(timeout))) {
 		return -ETIMEDOUT;
 	}
 


### PR DESCRIPTION
Update the coccinelle script for integer timeout conversion to recognize non-constant timeouts passed as arguments, and run it.