### PR TITLE
soc: stm32g4: Fix typo in include filename for wwdg

### DIFF
--- a/soc/arm/st_stm32/stm32g4/soc.h
+++ b/soc/arm/st_stm32/stm32g4/soc.h
@@ -65,7 +65,7 @@
 #endif
 
 #ifdef CONFIG_WWDG_STM32
-#include <stm32l4xx_ll_wwdg.h>
+#include <stm32g4xx_ll_wwdg.h>
 #endif
 
 #ifdef CONFIG_ENTROPY_STM32_RNG


### PR DESCRIPTION
Due to a typo compiling the WWDG on the g4 family does not
work. This adds the correct include filename.

Signed-off-by: Richard Osterloh <richard.osterloh@gmail.com>