### PR TITLE
net: lldp: Sent LLDP packet was missing proper net_pkt type

### DIFF
--- a/subsys/net/l2/ethernet/lldp/lldp.c
+++ b/subsys/net/l2/ethernet/lldp/lldp.c
@@ -111,6 +111,8 @@ static int lldp_send(struct ethernet_lldp *lldp)
 		goto out;
 	}
 
+	net_pkt_set_lldp(pkt, true);
+
 	if (net_pkt_write(pkt, (u8_t *)lldp->lldpdu,
 			  sizeof(struct net_lldpdu))) {
 		net_pkt_unref(pkt);


### PR DESCRIPTION
The LLDP packet was created but its type was not set to LLDP
and was sent as ARP message.

Fixes #25084

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>