### PR TITLE
net: openthread: Allow to disable automatic network attachment

### DIFF
--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -109,6 +109,19 @@ config OPENTHREAD_PKT_LIST_SIZE
 	int "List size for Ip6 packet buffering"
 	default 10
 
+config OPENTHREAD_MANUAL_START
+	bool "Start OpenThread stack manually"
+	help
+	  If enabled, OpenThread stack will have to be configured and
+	  started manually, with respective API calls or CLI/NCP commands.
+	  Otherwise, OpenThread will configure the network parametrs and try to
+	  join the Thread network automatically during initialization (using
+	  credentials stored in persistend storage, obtained during
+	  commissioning or pre-commissioned with other Kconfig options,
+	  depending on configuration used).
+
+if !OPENTHREAD_MANUAL_START
+
 config OPENTHREAD_PANID
 	int "Default PAN ID"
 	default 43981
@@ -129,6 +142,8 @@ config OPENTHREAD_XPANID
 	help
 	  Extended PAN ID for OpenThread with
 	  format "de:ad:00:be:ef:00:ca:fe"
+
+endif
 
 choice
 	prompt "OpenThread device type"
@@ -181,6 +196,7 @@ config OPENTHREAD_JOINER
 config OPENTHREAD_JOINER_AUTOSTART
 	bool "Support for automatic joiner start"
 	depends on OPENTHREAD_JOINER
+	depends on !OPENTHREAD_MANUAL_START
 	help
 	  Enable automatic joiner start
 
@@ -233,6 +249,7 @@ config OPENTHREAD_COAP
 
 config OPENTHREAD_NCP
 	bool "Network Co-Processor"
+	select OPENTHREAD_MANUAL_START
 	select RING_BUFFER
 	select UART_INTERRUPT_DRIVEN
 	help
@@ -243,7 +260,6 @@ config OPENTHREAD_NCP_RADIO
 	depends on OPENTHREAD_NCP
 	help
 	  Enable NCP in OpenThread stack as radio-only
-
 
 config OPENTHREAD_NCP_SPINEL_ON_UART_DEV_NAME
 	string "UART device to use for NCP SPINEL"

--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -40,10 +40,29 @@ LOG_MODULE_REGISTER(net_l2_openthread, CONFIG_OPENTHREAD_L2_LOG_LEVEL);
 #define OT_STACK_SIZE (CONFIG_OPENTHREAD_THREAD_STACK_SIZE)
 #define OT_PRIORITY K_PRIO_COOP(CONFIG_OPENTHREAD_THREAD_PRIORITY)
 
+#if defined(CONFIG_OPENTHREAD_NETWORK_NAME)
 #define OT_NETWORK_NAME CONFIG_OPENTHREAD_NETWORK_NAME
+#else
+#define OT_NETWORK_NAME ""
+#endif
+
+#if defined(CONFIG_OPENTHREAD_CHANNEL)
 #define OT_CHANNEL CONFIG_OPENTHREAD_CHANNEL
+#else
+#define OT_CHANNEL 0
+#endif
+
+#if defined(CONFIG_OPENTHREAD_PANID)
 #define OT_PANID CONFIG_OPENTHREAD_PANID
+#else
+#define OT_PANID 0
+#endif
+
+#if defined(CONFIG_OPENTHREAD_XPANID)
 #define OT_XPANID CONFIG_OPENTHREAD_XPANID
+#else
+#define OT_XPANID ""
+#endif
 
 #if defined(CONFIG_OPENTHREAD_JOINER_PSKD)
 #define OT_JOINER_PSKD CONFIG_OPENTHREAD_JOINER_PSKD
@@ -315,6 +334,11 @@ static void openthread_start(struct openthread_context *ot_context)
 	otInstance *ot_instance = ot_context->instance;
 	otError error;
 
+	if (IS_ENABLED(CONFIG_OPENTHREAD_MANUAL_START)) {
+		NET_DBG("OpenThread manual start.");
+		return;
+	}
+
 	/* Sleepy End Device specific configuration. */
 	if (IS_ENABLED(CONFIG_OPENTHREAD_MTD_SED)) {
 		otLinkModeConfig ot_mode = otThreadGetLinkMode(ot_instance);
@@ -328,11 +352,7 @@ static void openthread_start(struct openthread_context *ot_context)
 		otLinkSetPollPeriod(ot_context->instance, OT_POLL_PERIOD);
 	}
 
-	if (IS_ENABLED(CONFIG_OPENTHREAD_NCP)) {
-		/* In NCP mode wpantund will instruct what to do. */
-		NET_DBG("OpenThread NCP.");
-		return;
-	} else if (otDatasetIsCommissioned(ot_instance)) {
+	if (otDatasetIsCommissioned(ot_instance)) {
 		/* OpenThread already has dataset stored - skip the
 		 * configuration.
 		 */


### PR DESCRIPTION
Add OpenThread configuration option, which allows to configure and start
OpenThread stack operation manually. This mode should be used in NCP
devices, as well as is needed for certification purposes, where
OpenTread stack have to be configured by the test framework and not
initialize and join the network on its own.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>