### PR TITLE
x86: Revert "qemu_x86: use icount for 32-bit"

### DIFF
--- a/boards/x86/qemu_x86/board.cmake
+++ b/boards/x86/qemu_x86/board.cmake
@@ -11,7 +11,6 @@ if(CONFIG_X86_64)
   set(QEMU_CPU_TYPE_${ARCH} qemu64,+x2apic)
 else()
   set(QEMU_CPU_TYPE_${ARCH} qemu32,+nx,+pae)
-  set(ICOUNT_ARG -icount shift=5,align=off,sleep=off -rtc clock=vm)
 endif()
 
 set(QEMU_FLAGS_${ARCH}
@@ -20,7 +19,6 @@ set(QEMU_FLAGS_${ARCH}
   -device isa-debug-exit,iobase=0xf4,iosize=0x04
   ${REBOOT_FLAG}
   -nographic
-  ${ICOUNT_ARG}
   )
 
 # TODO: Support debug


### PR DESCRIPTION
This was causing problems on some network tests.

This reverts commit 9b055ecf82c3b8e085f269a565632e2dde5a19e6.

Fixes: #25083

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>