### PR TITLE
include: posix: Add <sys/select.h> header for POSIX subsystem

### DIFF
--- a/include/posix/sys/select.h
+++ b/include/posix/sys/select.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_POSIX_SYS_SELECT_H_
+#define ZEPHYR_INCLUDE_POSIX_SYS_SELECT_H_
+
+#include <net/socket_select.h>
+#include <sys/_timeval.h>
+
+#define fd_set zsock_fd_set
+#define FD_SETSIZE ZSOCK_FD_SETSIZE
+#define FD_ZERO ZSOCK_FD_ZERO
+#define FD_SET ZSOCK_FD_SET
+#define FD_CLR ZSOCK_FD_CLR
+#define FD_ISSET ZSOCK_FD_ISSET
+
+struct timeval;
+
+static inline int select(int nfds, fd_set *readfds,
+			 fd_set *writefds, fd_set *exceptfds,
+			 struct timeval *timeout)
+{
+	return zsock_select(nfds, readfds, writefds, exceptfds,
+			    (struct zsock_timeval *)timeout);
+}
+
+#endif /* ZEPHYR_INCLUDE_POSIX_SYS_SELECT_H_ */

--- a/samples/net/sockets/echo_async_select/prj.conf
+++ b/samples/net/sockets/echo_async_select/prj.conf
@@ -1,5 +1,6 @@
 # General config
 CONFIG_NEWLIB_LIBC=y
+CONFIG_MAIN_STACK_SIZE=1200
 
 # Networking config
 CONFIG_NETWORKING=y

--- a/samples/net/sockets/echo_async_select/sample.yaml
+++ b/samples/net/sockets/echo_async_select/sample.yaml
@@ -2,8 +2,15 @@ sample:
   description: BSD Sockets API TCP echo server sample
     using non-blocking sockets
   name: socket_echo_async
+common:
+  harness: net
+  platform_whitelist: qemu_x86
+  tags: net socket
 tests:
   sample.net.sockets.echo_async_select:
-    harness: net
-    platform_whitelist: qemu_x86
-    tags: net socket
+    extra_configs:
+      - CONFIG_NET_SOCKETS_POSIX_NAMES=y
+  sample.net.sockets.echo_async_select.posix:
+    extra_configs:
+      - CONFIG_NET_SOCKETS_POSIX_NAMES=n
+      - CONFIG_POSIX_API=y


### PR DESCRIPTION
Provides implementation of select() call in terms of zsock_select().

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>