### PR TITLE
adding abort on error to reset state machine

### DIFF
--- a/boards/arm/frdm_k64f/pinmux.c
+++ b/boards/arm/frdm_k64f/pinmux.c
@@ -112,9 +112,9 @@ static int frdm_k64f_pinmux_init(struct device *dev)
 #if DT_HAS_NODE_STATUS_OKAY(DT_NODELABEL(i2c0))
 	/* I2C0 SCL, SDA */
 	pinmux_pin_set(porte, 24, PORT_PCR_MUX(kPORT_MuxAlt5)
-					| PORT_PCR_ODE_MASK);
+		       | PORT_PCR_ODE_MASK);
 	pinmux_pin_set(porte, 25, PORT_PCR_MUX(kPORT_MuxAlt5)
-					| PORT_PCR_ODE_MASK);
+		       | PORT_PCR_ODE_MASK);
 #endif
 
 #if DT_HAS_NODE_STATUS_OKAY(DT_NODELABEL(adc1))
@@ -123,7 +123,7 @@ static int frdm_k64f_pinmux_init(struct device *dev)
 #endif
 
 #if DT_HAS_NODE_STATUS_OKAY(DT_NODELABEL(ftm3)) && \
-    DT_NODE_HAS_COMPAT(DT_NODELABEL(ftm3), nxp_kinetis_ftm_pwm)
+	DT_NODE_HAS_COMPAT(DT_NODELABEL(ftm3), nxp_kinetis_ftm_pwm)
 	pinmux_pin_set(portc,  8, PORT_PCR_MUX(kPORT_MuxAlt3));
 	pinmux_pin_set(portc,  9, PORT_PCR_MUX(kPORT_MuxAlt3));
 #endif
@@ -139,14 +139,17 @@ static int frdm_k64f_pinmux_init(struct device *dev)
 	pinmux_pin_set(porta, 28, PORT_PCR_MUX(kPORT_MuxAlt4));
 
 	pinmux_pin_set(portb,  0, PORT_PCR_MUX(kPORT_MuxAlt4)
-		| PORT_PCR_ODE_MASK | PORT_PCR_PE_MASK | PORT_PCR_PS_MASK);
+		       | PORT_PCR_ODE_MASK | PORT_PCR_PE_MASK | PORT_PCR_PS_MASK);
 
 	pinmux_pin_set(portb,  1, PORT_PCR_MUX(kPORT_MuxAlt4));
 
-	pinmux_pin_set(portc, 16, PORT_PCR_MUX(kPORT_MuxAlt4));
-	pinmux_pin_set(portc, 17, PORT_PCR_MUX(kPORT_MuxAlt4));
-	pinmux_pin_set(portc, 18, PORT_PCR_MUX(kPORT_MuxAlt4));
-	pinmux_pin_set(portc, 19, PORT_PCR_MUX(kPORT_MuxAlt4));
+	/* these pins are NOT needed by ethernet on FRDM-K64F
+	   - by setting them, they override UART3 TX/RX pins above
+	   pinmux_pin_set(portc, 16, PORT_PCR_MUX(kPORT_MuxAlt4));
+	   pinmux_pin_set(portc, 17, PORT_PCR_MUX(kPORT_MuxAlt4));
+	   pinmux_pin_set(portc, 18, PORT_PCR_MUX(kPORT_MuxAlt4));
+	   pinmux_pin_set(portc, 19, PORT_PCR_MUX(kPORT_MuxAlt4));
+	 */
 #endif
 
 #if DT_HAS_NODE_STATUS_OKAY(DT_NODELABEL(flexcan0))

--- a/boards/arm/frdm_k64f/pinmux.c
+++ b/boards/arm/frdm_k64f/pinmux.c
@@ -139,16 +139,18 @@ static int frdm_k64f_pinmux_init(struct device *dev)
 	pinmux_pin_set(porta, 28, PORT_PCR_MUX(kPORT_MuxAlt4));
 
 	pinmux_pin_set(portb,  0, PORT_PCR_MUX(kPORT_MuxAlt4)
-		       | PORT_PCR_ODE_MASK | PORT_PCR_PE_MASK | PORT_PCR_PS_MASK);
+		       | PORT_PCR_ODE_MASK
+		       | PORT_PCR_PE_MASK
+		       | PORT_PCR_PS_MASK);
 
 	pinmux_pin_set(portb,  1, PORT_PCR_MUX(kPORT_MuxAlt4));
 
 	/* these pins are NOT needed by ethernet on FRDM-K64F
-	   - by setting them, they override UART3 TX/RX pins above
-	   pinmux_pin_set(portc, 16, PORT_PCR_MUX(kPORT_MuxAlt4));
-	   pinmux_pin_set(portc, 17, PORT_PCR_MUX(kPORT_MuxAlt4));
-	   pinmux_pin_set(portc, 18, PORT_PCR_MUX(kPORT_MuxAlt4));
-	   pinmux_pin_set(portc, 19, PORT_PCR_MUX(kPORT_MuxAlt4));
+	 *  By setting them, they override UART3 TX/RX pins above
+	 *  pinmux_pin_set(portc, 16, PORT_PCR_MUX(kPORT_MuxAlt4));
+	 *  pinmux_pin_set(portc, 17, PORT_PCR_MUX(kPORT_MuxAlt4));
+	 *  pinmux_pin_set(portc, 18, PORT_PCR_MUX(kPORT_MuxAlt4));
+	 *  pinmux_pin_set(portc, 19, PORT_PCR_MUX(kPORT_MuxAlt4));
 	 */
 #endif
 

--- a/drivers/adc/adc_shell.c
+++ b/drivers/adc/adc_shell.c
@@ -465,7 +465,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_adc_cmds,
 );
 
 #define ADC_SHELL_COMMAND(inst) \
-	SHELL_CMD(ADC_##inst, &sub_adc_cmds, "ADC_" #inst, NULL),
+	SHELL_CMD(ADC_##inst, &sub_adc_cmds, "ADC_" #inst, NULL)
 
 /*
  * TODO generalize with a more flexible for-each macro that doesn't

--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -74,7 +74,8 @@ static int i2c_mcux_configure(struct device *dev, u32_t dev_config_raw)
 }
 
 static void i2c_mcux_master_transfer_callback(I2C_Type *base,
-					      i2c_master_handle_t *handle, status_t status, void *userData)
+					      i2c_master_handle_t *handle,
+					      status_t status, void *userData)
 {
 	struct device *dev = userData;
 	struct i2c_mcux_data *data = DEV_DATA(dev);
@@ -200,8 +201,7 @@ static int i2c_mcux_init(struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api i2c_mcux_driver_api =
-{
+static const struct i2c_driver_api i2c_mcux_driver_api = {
 	.configure = i2c_mcux_configure,
 	.transfer = i2c_mcux_transfer,
 };


### PR DESCRIPTION
Errors on I2C bus can leave the I2C state machine in a non-idle state.  Calling the MCUX I2C_MasterTransferAbort function in the FSL library will properly reset this state so that future transactions will work.

Also, commented out some lines in pinux.c for the FRDM-K64F board. These lines were set for Ethernet, but are not used by the K64F board. These lines prevented UART 3 from working correctly (or at all)