### PR TITLE
Fix several issues with the Google MQTT demo

### DIFF
--- a/samples/net/cloud/google_iot_mqtt/README.rst
+++ b/samples/net/cloud/google_iot_mqtt/README.rst
@@ -33,6 +33,8 @@ The application includes a key creation script.
 
 Run the ``create_keys.py`` script in the
 ``samples/net/cloud/google_iot_mqtt/src/private_info/`` directory.
+Be sure that they key type generated (RSA or ECDSA) matches your
+config of either :code:`JWT_SIGN_RSA` or :code:`JWT_SIGN_ECDSA`.
 
 Users will also be required to configure the following Kconfig options
 based on their Google Cloud IOT project.  The following values come

--- a/samples/net/cloud/google_iot_mqtt/README.rst
+++ b/samples/net/cloud/google_iot_mqtt/README.rst
@@ -35,12 +35,28 @@ Run the ``create_keys.py`` script in the
 ``samples/net/cloud/google_iot_mqtt/src/private_info/`` directory.
 
 Users will also be required to configure the following Kconfig options
-based on their Google Cloud IOT project:
+based on their Google Cloud IOT project.  The following values come
+from the Google Cloud Platform itself:
 
-- CLOUD_CLIENT_ID - created from <telemetry>/<region>/registries/<registry name>/devices/<device name>
-- CLOUD_AUDIENCE - created from telemetry without projects on front
-- CLOUD_SUBSCRIBE_CONFIG - created from /devices/<device name>/config
-- CLOUD_PUBLISH_TOPIC - created from /devices/<device name>/state
+- PROJECT_ID: When you select your project at the top of the UI, it
+  should have a "name", and there should be an ID field as well.  This
+  seems to be two words and a number, separated by hyphens.
+- REGION: The Region shows in the list of registries for your
+  registry.  And example is "us-central1".
+- REGISTRY_ID: Each registry has an id.  This is a string given when
+  creating the registry.
+- DEVICE_ID: A name given for each device.  When viewing the table of
+  devices, this will be shown.
+
+From these values, the config values can be set using the following
+template:
+
+.. code-block: kconfig
+
+   CLOUD_CLIENT_ID="projects/PROJECT_ID/locations/REGION/registries/REGISTRY_ID/devices/DEVICE_ID"
+   CLOUD_AUDIENCE="PROJECT_ID"
+   CLOUD_SUBSCRIBE_CONFIG="/devices/DEVICE_ID/config"
+   CLOUD_PUBLISH_TOPIC="/devices/DEVICE_ID/state"
 
 See `Google Cloud MQTT Documentation
 <https://cloud.google.com/iot/docs/how-tos/mqtt-bridge>`_.

--- a/samples/net/cloud/google_iot_mqtt/prj.conf
+++ b/samples/net/cloud/google_iot_mqtt/prj.conf
@@ -57,3 +57,10 @@ CONFIG_MBEDTLS_ENABLE_HEAP=y
 CONFIG_MBEDTLS_HEAP_SIZE=56240
 CONFIG_MBEDTLS_USER_CONFIG_ENABLE=y
 CONFIG_MBEDTLS_USER_CONFIG_FILE="user-tls.conf"
+
+# Please see README.rst in this directory for instructions
+# on where to get the values for these config entries.
+CONFIG_CLOUD_CLIENT_ID="projects/<PROJECT_ID>/locations/<REGION>/registries/<REGISTRY_ID>/devices/"
+CONFIG_CLOUD_AUDIENCE="<PROJECT_ID>"
+CONFIG_CLOUD_SUBSCRIBE_CONFIG="/devices/<DEVICE_ID>/config"
+CONFIG_CLOUD_PUBLISH_TOPIC="/devices/<DEVICE_ID>/state"


### PR DESCRIPTION
A change to the net configuration has broken compilation. In addition, the instructions are difficult to follow, and somewhat misleading.