### PR TITLE
subsys/testsuite: Shorten the assertion messages

### DIFF
--- a/subsys/testsuite/ztest/include/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/ztest_assert.h
@@ -23,6 +23,7 @@
 extern "C" {
 #endif
 
+const char *ztest_relative_filename(const char *file);
 void ztest_test_fail(void);
 #if CONFIG_ZTEST_ASSERT_VERBOSE == 0
 
@@ -30,7 +31,7 @@ static inline void z_zassert_(bool cond, const char *file, int line)
 {
 	if (cond == false) {
 		PRINT("\n    Assertion failed at %s:%d\n",
-		      file, line);
+		      ztest_relative_filename(file), line);
 		ztest_test_fail();
 	}
 }
@@ -51,7 +52,7 @@ static inline void z_zassert(bool cond,
 
 		va_start(vargs, msg);
 		PRINT("\n    Assertion failed at %s:%d: %s: %s\n",
-		      file, line, func, default_msg);
+		      ztest_relative_filename(file), line, func, default_msg);
 		vprintk(msg, vargs);
 		printk("\n");
 		va_end(vargs);
@@ -60,7 +61,7 @@ static inline void z_zassert(bool cond,
 #if CONFIG_ZTEST_ASSERT_VERBOSE == 2
 	else {
 		PRINT("\n   Assertion succeeded at %s:%d (%s)\n",
-		      file, line, func);
+		      ztest_relative_filename(file), line, func);
 	}
 #endif
 }


### PR DESCRIPTION
At present these can be very long since they include the full path of
the filename with the error.

    Assertion failed at /home/sglass/cosarm/zephry/zephyrproject/
	zephyr/tests/drivers/flash_simulator/src/main.c:102:
	test_write_read: (0 not equal to rc)

Reduce the length by omitting the current directory (where the tests
are being run) from the output:

    Assertion failed at tests/drivers/flash_simulator/src/main.c:102:
	test_write_read: (0 not equal to rc)

This improves usability for people running tests locally.

Signed-off-by: Simon Glass <sjg@chromium.org>