### PR TITLE
Bluetooth: hci_raw: Fix build error on hci_usb_h4

### DIFF
--- a/include/bluetooth/hci_raw.h
+++ b/include/bluetooth/hci_raw.h
@@ -36,6 +36,8 @@ extern "C" {
 #define BT_HCI_ACL_COUNT 6
 #endif
 
+#define BT_BUF_TX_SIZE MAX(BT_BUF_RX_SIZE, BT_BUF_ACL_SIZE)
+
 /** @brief Send packet to the Bluetooth controller
  *
  * Send packet to the Bluetooth controller. Caller needs to


### PR DESCRIPTION
BT_BUF_TX_SIZE is actually used for setting the MPS properly.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>