### PR TITLE
boards: x86/minnowboard: specify CONFIG_X86_MMU_PAGE_POOL_PAGES

### DIFF
--- a/boards/x86/minnowboard/Kconfig.defconfig
+++ b/boards/x86/minnowboard/Kconfig.defconfig
@@ -8,4 +8,7 @@ config BOARD
 config BUILD_OUTPUT_STRIPPED
 	default y
 
+config X86_MMU_PAGE_POOL_PAGES
+	default 3072 if X86_MMU
+
 endif # BOARD_MINNOWBOARD


### PR DESCRIPTION
Given that the Minnowboard has relatively large memory, the default
number of pages allocated for page tables are not enough, and
resulting in asserting in the page table initialization code.
So change the number of pages needed according to the optimal
number by the MMU code.

Fixes #24353

Signed-off-by: Daniel Leung <daniel.leung@intel.com>