### PR TITLE
devicetree: Add DT_FOREACH_CHILD macro

### DIFF
--- a/doc/guides/dts/macros.bnf
+++ b/doc/guides/dts/macros.bnf
@@ -43,6 +43,9 @@ node-macro =/ %s"DT_N" path-id %s"_IRQ_NAME_" dt-name
 node-macro =/ %s"DT_N" path-id %s"_COMPAT_MATCHES_" dt-name
 ; The node identifier for the node's parent in the devicetree.
 node-macro =/ %s"DT_N" path-id %s"_PARENT"
+; These are used internally by DT_FOREACH_CHILD, which iterates over
+; each child node.
+node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD"
 
 ; --------------------------------------------------------------------
 ; property-macro: a macro related to a node property

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -271,6 +271,18 @@
 #define DT_CHILD(node_id, child) UTIL_CAT(node_id, DT_S_PREFIX(child))
 
 /**
+ * @brief Invokes given macro for all child nodes of a parent.
+ *
+ * @param node_id node identifier
+ * @param fn macro to invoke
+ *
+ * Macro should be defined to take one parameter, which will be a node
+ * identifier for each child node of node_id.
+ */
+#define DT_FOREACH_CHILD(node_id, fn) \
+	DT_CAT(node_id, _FOREACH_CHILD)(fn)
+
+/**
  * @}
  */
 

--- a/tests/lib/devicetree/app.overlay
+++ b/tests/lib/devicetree/app.overlay
@@ -311,5 +311,20 @@
 			label = "TEST_PWM_CTRL_2";
 			status = "okay";
 		};
+
+		test_children: test-children {
+			test_child_alpha: child-alpha {
+				compatible = "vnd,enum-holder";
+				val = "zero";
+			};
+			test_child_beta: child-beta {
+				compatible = "vnd,enum-holder";
+				val = "one";
+			};
+			test_child_charlie: child-charlie {
+				compatible = "vnd,enum-holder";
+				val = "two";
+			};
+		};
 	};
 };

--- a/tests/lib/devicetree/src/main.c
+++ b/tests/lib/devicetree/src/main.c
@@ -1365,6 +1365,34 @@ static void test_parent(void)
 		     "round trip through node with no compatible");
 }
 
+static void test_child_nodes_list(void)
+{
+	#define TEST_FUNC(child) { DT_PROP(child, val) },
+	#define TEST_MKSTR(a) _TEST_MKSTR(a)
+	#define _TEST_MKSTR(a) #a
+	#define TEST_PARENT DT_PATH(test, test_children)
+	static struct {
+		const char *v;
+	} vals[] = {
+		DT_FOREACH_CHILD(TEST_PARENT, TEST_FUNC)
+	};
+
+	zassert_equal(ARRAY_SIZE(vals), 3,
+		      "Bad number of children");
+
+	zassert_false(strlen(TEST_MKSTR(TEST_PARENT)) == 0,
+		      "TEST_PARENT evaluated to empty string");
+
+	zassert_equal(vals[0].v, "zero", "Child 0 did not match");
+	zassert_equal(vals[1].v, "one", "Child 1 did not match");
+	zassert_equal(vals[2].v, "two", "Child 2 did not match");
+
+	#undef TEST_MKSTR
+	#undef _TEST_MKSTR
+	#undef TEST_PARENT
+	#undef TEST_FUNC
+}
+
 void test_main(void)
 {
 	ztest_test_suite(devicetree_api,
@@ -1392,7 +1420,8 @@ void test_main(void)
 			 ztest_unit_test(test_chosen),
 			 ztest_unit_test(test_enums),
 			 ztest_unit_test(test_clocks),
-			 ztest_unit_test(test_parent)
+			 ztest_unit_test(test_parent),
+			 ztest_unit_test(test_child_nodes_list)
 		);
 	ztest_run_test_suite(devicetree_api);
 }


### PR DESCRIPTION
The macro iterates through the list of child nodes and invokes provided
macro for each node.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>
Signed-off-by: Kumar Gala <kumar.gala@linaro.org>