### PR TITLE
[backport v2.2] Bluetooth: controller: Update Bluetooth version to 5.2

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -512,6 +512,7 @@ struct bt_hci_rp_write_auth_payload_timeout {
 #define BT_HCI_VERSION_4_2                      8
 #define BT_HCI_VERSION_5_0                      9
 #define BT_HCI_VERSION_5_1                      10
+#define BT_HCI_VERSION_5_2                      11
 
 #define BT_HCI_OP_READ_LOCAL_VERSION_INFO       BT_OP(BT_OGF_INFO, 0x0001)
 struct bt_hci_rp_read_local_version_info {

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LL_VERSION_NUMBER BT_HCI_VERSION_5_1
+#define LL_VERSION_NUMBER BT_HCI_VERSION_5_2
 
 int ll_init(struct k_sem *sem_rx);
 void ll_reset(void);


### PR DESCRIPTION
backport of #25072 

Fixes #25130 

This will allow for Bluetooth Controller qualified design listing with v5.2.