### PR TITLE
arch: arc: fix the bug of firq stack setup for slave cores

### DIFF
--- a/arch/arc/core/reset.S
+++ b/arch/arc/core/reset.S
@@ -145,7 +145,9 @@ _slave_core_wait:
 	st 0, [arc_cpu_wake_flag]
 
 #if defined(CONFIG_ARC_FIRQ_STACK)
+	push r0
 	jl z_arc_firq_stack_set
+	pop r0
 #endif
 	j z_arc_slave_start
 


### PR DESCRIPTION
r0 is the slave core number, needs to be saved before call
z_arc_firq_stack_set and be restored later.

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>