### PR TITLE
Add GET_N_ARG and GET_ARGS_LESS_N macros

### DIFF
--- a/drivers/clock_control/nrf_power_clock.c
+++ b/drivers/clock_control/nrf_power_clock.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(clock_control, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
 /* Helper logging macros which prepends subsys name to the log. */
 #ifdef CONFIG_LOG
 #define CLOCK_LOG(lvl, dev, subsys, ...) \
-	LOG_##lvl("%s: " GET_ARG1(__VA_ARGS__), \
+	LOG_##lvl("%s: " GET_ARG_N(1, __VA_ARGS__), \
 		get_sub_config(dev, (enum clock_control_nrf_type)subsys)->name \
 		COND_CODE_0(NUM_VA_ARGS_LESS_1(__VA_ARGS__),\
 				(), (, GET_ARGS_LESS_1(__VA_ARGS__))))

--- a/drivers/clock_control/nrf_power_clock.c
+++ b/drivers/clock_control/nrf_power_clock.c
@@ -22,7 +22,7 @@ LOG_MODULE_REGISTER(clock_control, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
 	LOG_##lvl("%s: " GET_ARG_N(1, __VA_ARGS__), \
 		get_sub_config(dev, (enum clock_control_nrf_type)subsys)->name \
 		COND_CODE_0(NUM_VA_ARGS_LESS_1(__VA_ARGS__),\
-				(), (, GET_ARGS_LESS_1(__VA_ARGS__))))
+				(), (, GET_ARGS_LESS_N(1, __VA_ARGS__))))
 #else
 #define CLOCK_LOG(...)
 #endif

--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -364,7 +364,7 @@ static inline char *log_strdup(const char *str)
 #define LOG_MODULE_REGISTER(...)					\
 	Z_LOG_EVAL(							\
 		_LOG_LEVEL_RESOLVE(__VA_ARGS__),			\
-		(_LOG_MODULE_DATA_CREATE(GET_ARG1(__VA_ARGS__),		\
+		(_LOG_MODULE_DATA_CREATE(GET_ARG_N(1, __VA_ARGS__),	\
 				      _LOG_LEVEL_RESOLVE(__VA_ARGS__))),\
 		()/*Empty*/						\
 	)								\
@@ -398,20 +398,22 @@ static inline char *log_strdup(const char *str)
  */
 #define LOG_MODULE_DECLARE(...)						      \
 	extern const struct log_source_const_data			      \
-			LOG_ITEM_CONST_DATA(GET_ARG1(__VA_ARGS__));	      \
+			LOG_ITEM_CONST_DATA(GET_ARG_N(1, __VA_ARGS__));	      \
 	extern struct log_source_dynamic_data				      \
-			LOG_ITEM_DYNAMIC_DATA(GET_ARG1(__VA_ARGS__));	      \
+			LOG_ITEM_DYNAMIC_DATA(GET_ARG_N(1, __VA_ARGS__));     \
 									      \
 	static const struct log_source_const_data *			      \
 		__log_current_const_data __unused =			      \
 			_LOG_LEVEL_RESOLVE(__VA_ARGS__) ?		      \
-			&LOG_ITEM_CONST_DATA(GET_ARG1(__VA_ARGS__)) : NULL;   \
+			&LOG_ITEM_CONST_DATA(GET_ARG_N(1, __VA_ARGS__)) :     \
+			NULL;						      \
 									      \
 	static struct log_source_dynamic_data *				      \
 		__log_current_dynamic_data __unused =			      \
 			(_LOG_LEVEL_RESOLVE(__VA_ARGS__) &&		      \
 			IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) ?	      \
-			&LOG_ITEM_DYNAMIC_DATA(GET_ARG1(__VA_ARGS__)) : NULL; \
+			&LOG_ITEM_DYNAMIC_DATA(GET_ARG_N(1, __VA_ARGS__)) :   \
+			NULL;						      \
 									      \
 	static const uint32_t __log_level __unused =			      \
 					_LOG_LEVEL_RESOLVE(__VA_ARGS__)

--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -298,8 +298,8 @@ static inline char *log_strdup(const char *str)
 #else
 #define _LOG_LEVEL_RESOLVE(...) \
 	Z_LOG_EVAL(LOG_LEVEL, \
-		  (GET_ARG2(__VA_ARGS__, LOG_LEVEL)), \
-		  (GET_ARG2(__VA_ARGS__, CONFIG_LOG_DEFAULT_LEVEL)))
+		  (GET_ARG_N(2, __VA_ARGS__, LOG_LEVEL)), \
+		  (GET_ARG_N(2, __VA_ARGS__, CONFIG_LOG_DEFAULT_LEVEL)))
 #endif
 
 /* Return first argument */

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -152,7 +152,7 @@ extern "C" {
  *	  used.
  */
 
-#define Z_LOG_STR(...) "%s: " GET_ARG1(__VA_ARGS__), __func__\
+#define Z_LOG_STR(...) "%s: " GET_ARG_N(1, __VA_ARGS__), __func__\
 		COND_CODE_0(NUM_VA_ARGS_LESS_1(__VA_ARGS__),\
 			    (),\
 			    (, GET_ARGS_LESS_1(__VA_ARGS__))\

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -155,7 +155,7 @@ extern "C" {
 #define Z_LOG_STR(...) "%s: " GET_ARG_N(1, __VA_ARGS__), __func__\
 		COND_CODE_0(NUM_VA_ARGS_LESS_1(__VA_ARGS__),\
 			    (),\
-			    (, GET_ARGS_LESS_1(__VA_ARGS__))\
+			    (, GET_ARGS_LESS_N(1, __VA_ARGS__))\
 			   )
 
 

--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -534,8 +534,28 @@ uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value);
  */
 #define EMPTY
 
+/**
+ * @brief Get nth argument from argument list.
+ *
+ * @param N Argument index to fetch. Counter from 1.
+ * @param ... Variable list of argments from which one argument is returned.
+ *
+ * @return Nth argument.
+ */
+#define GET_ARG_N(N, ...) _Z_GET_ARG_N(N, 1, __VA_ARGS__)
+
+/**
+ * @brief Strips n first arguments from the argument list.
+ *
+ * @param N Number of arguments to discard.
+ * @param ... Variable list of argments.
+ *
+ * @return argument list without N first arguments.
+ */
+#define GET_ARGS_LESS_N(N, ...) _Z_GET_ARG_N(UTIL_INC(N), 0, __VA_ARGS__)
+
 /** @brief Expands to @p arg1 */
-#define GET_ARG1(arg1, ...) arg1
+#define GET_ARG1(...) GET_ARG_N(1, )
 
 /** @brief Expands to @p arg2 */
 #define GET_ARG2(arg1, arg2, ...) arg2

--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -554,8 +554,11 @@ uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value);
  */
 #define GET_ARGS_LESS_N(N, ...) _Z_GET_ARG_N(UTIL_INC(N), 0, __VA_ARGS__)
 
-/** @brief Expands to @p arg1 */
-#define GET_ARG1(...) GET_ARG_N(1, )
+/** Expands to the first argument.
+ *
+ * @deprecated Use GET_ARG_N instead.
+ */
+#define GET_ARG1(...) GET_ARG_N(1, __VA_ARGS__)
 
 /** @brief Expands to @p arg2 */
 #define GET_ARG2(arg1, arg2, ...) arg2

--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -566,8 +566,11 @@ uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value);
  */
 #define GET_ARG2(...) __DEPRECATED GET_ARG_N(2, __VA_ARGS__)
 
-/** @brief Expands to all arguments except the first one (@p val) */
-#define GET_ARGS_LESS_1(val, ...) __VA_ARGS__
+/** Expands to all arguments except the first one.
+ *
+ * @deprecated Use GET_ARGS_LESS_N instead.
+ */
+#define GET_ARGS_LESS_1(...) __DEPRECATED GET_ARGS_LESS_N(1, __VA_ARGS__)
 
 /**
  * @brief Like <tt>a || b</tt>, but does evaluation and

--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -560,8 +560,11 @@ uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value);
  */
 #define GET_ARG1(...) GET_ARG_N(1, __VA_ARGS__)
 
-/** @brief Expands to @p arg2 */
-#define GET_ARG2(arg1, arg2, ...) arg2
+/** Expands to the second argument.
+ *
+ * @deprecated Use GET_ARG_N instead.
+ */
+#define GET_ARG2(...) __DEPRECATED GET_ARG_N(2, __VA_ARGS__)
 
 /** @brief Expands to all arguments except the first one (@p val) */
 #define GET_ARGS_LESS_1(val, ...) __VA_ARGS__


### PR DESCRIPTION
Another portion of preprocessor magic. More generic version of existing (and deprecated in that PR) macros: `GET_ARG1`, `GET_ARG2`, `GET_ARGS_LESS_1`.

- `GET_N_ARG(n, ...)` returns n'th argument (counting from 1)
- `GET_ARGS_LESS_N(n,...)` strips first n arguments

Deprecated `GET_ARG1`, `GET_ARG2`, `GET_ARGS_LESS_1`
