### PR TITLE
doc: gsg: add missing python3-dev dependency

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -63,7 +63,7 @@ Next, you'll install some host dependencies using your package manager.
 
             sudo apt install --no-install-recommends git cmake ninja-build gperf \
               ccache dfu-util device-tree-compiler wget \
-              python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
+              python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
               make gcc gcc-multilib g++-multilib libsdl2-dev
 
       #. Verify the version of cmake installed on your system using::

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -78,7 +78,7 @@ need one.
 
          sudo apt-get install --no-install-recommends git cmake ninja-build gperf \
            ccache dfu-util device-tree-compiler wget \
-           python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
+           python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
            make gcc gcc-multilib g++-multilib libsdl2-dev
 
    .. group-tab:: Fedora


### PR DESCRIPTION
Linux distro might not have a python3-dev package installed by default,
which will give an error during Python dependencies installation.

Closes #25128.

Signed-off-by: Andrejs Cainikovs <andrejs.cainikovs@gmail.com>