### PR TITLE
doc: release notes: add note about FP Kconfig symbol name changes

### DIFF
--- a/doc/releases/release-notes-2.3.rst
+++ b/doc/releases/release-notes-2.3.rst
@@ -103,6 +103,11 @@ Stable API changes in this release
   * The video_dequeue() API call now takes a k_timeout_t for the timeout
     parameter. This reverts to s32_t if CONFIG_LEGACY_TIMEOUT_API is enabled.
 
+* Floating Point Services
+
+  * FLOAT and FP_SHARING Kconfig options have been renamed to FPU and FPU_SHARING,
+    respectively.
+
 Kernel
 ******
 


### PR DESCRIPTION
We add a note in the Zephyr v2.3.0 release notes to highlight
a renaming in the Floating Point Services main Kconfig options,
which was done in the 2.3 release cycle.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>