### PR TITLE
dts: bindings: st,stm32-sdmmc: remove unneeded type

### DIFF
--- a/dts/bindings/mmc/st,stm32-sdmmc.yaml
+++ b/dts/bindings/mmc/st,stm32-sdmmc.yaml
@@ -8,7 +8,6 @@ properties:
     clocks:
         required: true
     label:
-        type: string
         required: true
     reg:
         required: true


### PR DESCRIPTION
The label property does not need to have its type set
explicitly to string, so remove it.

Signed-off-by: Anthony Brandon <anthony@amarulasolutions.com>