### PR TITLE
Add support for the RNG on STM32L0

### DIFF
--- a/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
+++ b/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
@@ -86,3 +86,7 @@ arduino_i2c: &i2c1 {};
 &rtc {
 	status = "okay";
 };
+
+&rng {
+	status = "okay";
+};

--- a/boards/arm/b_l072z_lrwan1/doc/index.rst
+++ b/boards/arm/b_l072z_lrwan1/doc/index.rst
@@ -135,6 +135,8 @@ The Zephyr B-L072Z-LRWAN1 Discovery board configuration supports the following h
 +-----------+------------+-------------------------------------+
 | RTC       | on-chip    | counter                             |
 +-----------+------------+-------------------------------------+
+| TRNG      | on-chip    | true random number generator        |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/drivers/clock_control/clock_stm32l0_l1.c
+++ b/drivers/clock_control/clock_stm32l0_l1.c
@@ -38,7 +38,9 @@ void config_pll_init(LL_UTILS_PLLInitTypeDef *pllinit)
  */
 void config_enable_default_clocks(void)
 {
-#if defined(CONFIG_EXTI_STM32) || defined(CONFIG_USB_DC_STM32)
+#if defined(CONFIG_EXTI_STM32) || defined(CONFIG_USB_DC_STM32) || \
+	(defined(CONFIG_SOC_SERIES_STM32L0X) &&			  \
+	 defined(CONFIG_ENTROPY_STM32_RNG))
 	/* Enable System Configuration Controller clock. */
 	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_SYSCFG);
 #endif

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -176,7 +176,17 @@ static int entropy_stm32_rng_init(struct device *dev)
 	 *  Linear Feedback Shift Register
 	 */
 	 LL_RCC_SetRNGClockSource(LL_RCC_RNG_CLKSOURCE_PLLSAI1);
-#elif CONFIG_SOC_SERIES_STM32G4X
+#elif defined(RCC_HSI48_SUPPORT)
+
+#if CONFIG_SOC_SERIES_STM32L0X
+	/* We need SYSCFG to control VREFINT, so make sure it is clocked */
+	if (!LL_APB2_GRP1_IsEnabledClock(LL_APB2_GRP1_PERIPH_SYSCFG)) {
+		return -EINVAL;
+	}
+	/* HSI48 requires VREFINT (see RM0376 section 7.2.4). */
+	LL_SYSCFG_VREFINT_EnableHSI48();
+#endif /* CONFIG_SOC_SERIES_STM32L0X */
+
 	/* Use the HSI48 for the RNG */
 	LL_RCC_HSI48_Enable();
 	while (!LL_RCC_HSI48_IsReady()) {

--- a/dts/arm/st/l0/stm32l072.dtsi
+++ b/dts/arm/st/l0/stm32l072.dtsi
@@ -7,6 +7,10 @@
 #include <st/l0/stm32l0.dtsi>
 
 / {
+	chosen {
+		zephyr,entropy = &rng;
+	};
+
 	soc {
 		pinctrl: pin-controller@50000000 {
 
@@ -68,6 +72,14 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00800000>;
 			status = "disabled";
 			label= "USB";
+		};
+
+		rng: rng@40025000 {
+			compatible = "st,stm32-rng";
+			reg = <0x40025000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00100000>;
+			status = "disabled";
+			label = "RNG";
 		};
 
 		eeprom: eeprom@8080000{

--- a/soc/arm/st_stm32/stm32l0/soc.h
+++ b/soc/arm/st_stm32/stm32l0/soc.h
@@ -82,6 +82,10 @@
 #include <stm32l0xx_ll_dma.h>
 #endif
 
+#ifdef CONFIG_ENTROPY_STM32_RNG
+#include <stm32l0xx_ll_rng.h>
+#endif
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L0_SOC_H_ */


### PR DESCRIPTION
The STM32L072 and STM32L073 come with a hardware random number generator. Add the necessary clock configuration and device tree changes to support the device.

Tested on a b_l072z_lrwan1 board (STM32L072).