### PR TITLE
Bluetooth: host: Fix GATT clear bond information bugs

### DIFF
--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -62,6 +62,7 @@ struct bt_keys *bt_keys_get_addr(u8_t id, const bt_addr_le_t *addr)
 #if IS_ENABLED(CONFIG_BT_KEYS_OVERWRITE_OLDEST)
 	if (first_free_slot == ARRAY_SIZE(key_pool)) {
 		struct bt_keys *oldest = &key_pool[0];
+		bt_addr_le_t oldest_addr;
 
 		for (i = 1; i < ARRAY_SIZE(key_pool); i++) {
 			struct bt_keys *current = &key_pool[i];
@@ -71,7 +72,9 @@ struct bt_keys *bt_keys_get_addr(u8_t id, const bt_addr_le_t *addr)
 			}
 		}
 
-		bt_unpair(oldest->id, &oldest->addr);
+		/* Use a copy as bt_unpair will clear the oldest key. */
+		bt_addr_le_copy(&oldest_addr, &oldest->addr);
+		bt_unpair(oldest->id, &oldest_addr);
 		if (!bt_addr_le_cmp(&oldest->addr, BT_ADDR_LE_ANY)) {
 			first_free_slot = oldest - &key_pool[0];
 		}


### PR DESCRIPTION
Fix CCC cfg not cleared when overwriting oldest bond. Calling
bt_unpair with a pointer to the key will result in the key addr being
memset to zero and bt_gatt_clear is called with an zero-set address.
This happens because unpair (hci_core.c) calls bt_keys_clear before
calling bt_gatt_clear.

Fixes: #23961

Fix Service Changed configuration stored in flash not deleted in flash
when calling bt_gatt_clear from bt_unpair.
When clearing the check for "is bonded" should not be made. If the
bond information is already removed this check will fail.
When clearing the check for "modified" should not be made, clearing
is in itself a modification, and should always be made.