### PR TITLE
west: do not load canopen runner if no module available

### DIFF
--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -13,7 +13,10 @@ from runners.core import ZephyrBinaryRunner, MissingProgram
 # Keep this list sorted by runner name.
 from runners import blackmagicprobe
 from runners import bossac
-from runners import canopen_program
+try:
+    from runners import canopen_program
+except ImportError:
+    pass
 from runners import dediprog
 from runners import dfu
 from runners import esp32


### PR DESCRIPTION
If we do not have the canopen module, we should still be able to build
and do other things. canopen is only required for canopen related
activities.