### PR TITLE
aarch32: fix a build failure

### DIFF
--- a/arch/arm/include/aarch32/cortex_a_r/exc.h
+++ b/arch/arm/include/aarch32/cortex_a_r/exc.h
@@ -35,7 +35,7 @@ extern volatile irq_offload_routine_t offload_routine;
 /* Check the CPSR mode bits to see if we are in IRQ or FIQ mode */
 static ALWAYS_INLINE bool arch_is_in_isr(void)
 {
-	return (_kernel.nested != 0);
+	return (_kernel.cpus[0].nested != 0);
 }
 
 /**


### PR DESCRIPTION
Some wires were crossed when an older PR was merged that
had build conflicts with newer code. Update this header
to reflect were the 'nested' member is in the kernel CPU
struct.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>