### PR TITLE
tests: flash_simulator: Add native posix support

### DIFF
--- a/tests/drivers/flash_simulator/boards/native_posix.overlay
+++ b/tests/drivers/flash_simulator/boards/native_posix.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2020 Jan Van Winkel <jan.van_winkel@dxplore.eu>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&flash0 {
+	erase-block-size = <1024>;
+	write-block-size = <4>;
+	reg = <0x00000000 DT_SIZE_K(1024)>;
+};

--- a/tests/drivers/flash_simulator/boards/native_posix_64.overlay
+++ b/tests/drivers/flash_simulator/boards/native_posix_64.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2020 Jan Van Winkel <jan.van_winkel@dxplore.eu>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&flash0 {
+	erase-block-size = <1024>;
+	write-block-size = <4>;
+	reg = <0x00000000 DT_SIZE_K(1024)>;
+};

--- a/tests/drivers/flash_simulator/testcase.yaml
+++ b/tests/drivers/flash_simulator/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   drivers.flash.flash_simulator:
-    platform_whitelist: qemu_x86
+    platform_whitelist: qemu_x86 native_posix native_posix_64
     tags: driver


### PR DESCRIPTION
Added support for native posix boards to flash_simulator tests by making sure that flash layout lines up with layout expected by the tests.