### PR TITLE
drivers: wifi: eswifi: WiFi Scan completion indication

### DIFF
--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -231,6 +231,9 @@ static void eswifi_scan(struct eswifi_dev *eswifi)
 		}
 	}
 
+	/* WiFi scan is done. */
+	eswifi->scan_cb(eswifi->iface, 0, NULL);
+
 	eswifi_unlock(eswifi);
 }
 


### PR DESCRIPTION
Updating the eswifi driver to indicate "scan completion"
to WiFi Management once scanning is done.

Tested with STM32 disco IOT kit.

Signed-off-by: Bilal Wasim <bilalwasim676@gmail.com>