### PR TITLE
sanitycheck: suppress warnings from EDT

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -1778,7 +1778,8 @@ class FilterBuilder(CMake):
         if self.testcase and self.testcase.tc_filter:
             try:
                 if os.path.exists(dts_path):
-                    edt = edtlib.EDT(dts_path, [os.path.join(ZEPHYR_BASE, "dts", "bindings")])
+                    edt = edtlib.EDT(dts_path, [os.path.join(ZEPHYR_BASE, "dts", "bindings")],
+                            warn_reg_unit_address_mismatch=False)
                 else:
                     edt = None
                 res = expr_parser.parse(self.testcase.tc_filter, filter_data, edt)


### PR DESCRIPTION
We don't need sanitycheck's use of EDT to report warnings, we'll get
them from the build system.  So the warnings are just duplication and
noise, thus lets always suppress them.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>