### PR TITLE
mcumgr smpsvr configurability enhancements

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
@@ -107,6 +107,18 @@ Zephyr. The ``smp_svr`` sample comes in different flavours.
             -- \
             -DOVERLAY_CONFIG=overlay-bt-tiny.conf
 
+   .. group-tab:: Serial
+
+      To build the serial sample:
+
+      .. code-block:: console
+
+         west build \
+            -b frdm_k64f \
+            samples/subsys/mgmt/mcumgr/smp_svr \
+            -- \
+            -DOVERLAY_CONFIG=overlay-serial.conf
+
    .. group-tab:: UDP
 
       The UDP transport for SMP supports both IPv4 and IPv6.

--- a/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
@@ -109,7 +109,7 @@ Zephyr. The ``smp_svr`` sample comes in different flavours.
 
    .. group-tab:: Serial
 
-      To build the serial sample:
+      To build the serial sample with file-system support:
 
       .. code-block:: console
 
@@ -117,7 +117,7 @@ Zephyr. The ``smp_svr`` sample comes in different flavours.
             -b frdm_k64f \
             samples/subsys/mgmt/mcumgr/smp_svr \
             -- \
-            -DOVERLAY_CONFIG=overlay-serial.conf
+            -DOVERLAY_CONFIG='overlay-serial.conf;overlay-fs.conf'
 
    .. group-tab:: UDP
 

--- a/samples/subsys/mgmt/mcumgr/smp_svr/overlay-fs.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/overlay-fs.conf
@@ -1,0 +1,6 @@
+# Enable the LittleFS file system.
+CONFIG_FILE_SYSTEM=y
+CONFIG_FILE_SYSTEM_LITTLEFS=y
+
+# Enable file system commands
+CONFIG_MCUMGR_CMD_FS_MGMT=y

--- a/samples/subsys/mgmt/mcumgr/smp_svr/overlay-serial.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/overlay-serial.conf
@@ -1,0 +1,2 @@
+# Enable the serial mcumgr transport.
+CONFIG_MCUMGR_SMP_UART=y


### PR DESCRIPTION
Add overlay support for serial transport.

Add overlay support for file system, added to the serial transport example to remind people how to supply multiple overlays (not intuitive).