### PR TITLE
drivers, crypto: Add support for CMAC

### DIFF
--- a/drivers/crypto/crypto_tc_shim_priv.h
+++ b/drivers/crypto/crypto_tc_shim_priv.h
@@ -22,6 +22,7 @@
 struct tc_shim_drv_state {
 	int in_use;
 	struct tc_aes_key_sched_struct session_key;
+	struct tc_cmac_struct cmac_state;
 };
 
 #endif  /* ZEPHYR_DRIVERS_CRYPTO_CRYPTO_TC_SHIM_PRIV_H_ */

--- a/include/crypto/cipher.h
+++ b/include/crypto/cipher.h
@@ -305,6 +305,26 @@ static inline int cipher_gcm_op(struct cipher_ctx *ctx,
 	return ctx->ops.gcm_crypt_hndlr(ctx, pkt, nonce);
 }
 
+/*
+ * @brief Perform CMAC operation
+ *
+ * @param[in]  ctx       Pointer to the crypto context of this op.
+ * @param[in/out]  pkt   Structure holding the Input/Output, Associated Data
+ *                       and tag buffer pointers.
+ *
+ * @return 0 on success, negative errno code on failure
+ */
+static inline int cipher_cmac_op(struct cipher_ctx *ctx,
+				 struct cipher_mac_pkt *pkt)
+{
+	__ASSERT(ctx->ops.cipher_mode == CRYPTO_CIPHER_MODE_CMAC,
+		 "MAC mode session invoking a different mode handler");
+
+	pkt->ctx = ctx;
+	return ctx->ops.cmac_crypt_hndlr(ctx, pkt);
+}
+
+
 /**
  * @}
  */


### PR DESCRIPTION
This pull request introduces the necessary API changes to perform CMAC operations using the crypto API. The pull request also includes the necessary changes to support CMAC operations using the TinyCrypt backend.

These are a step towards implementing support for secure elements in LoRaWAN.

Kudos to @ceolin for pointing me to #9227 with an old prototype that included the same functionality.