### PR TITLE
samples: littlefs: fix reg error in particle_xenon overlay

### DIFF
--- a/samples/subsys/fs/littlefs/boards/particle_xenon.overlay
+++ b/samples/subsys/fs/littlefs/boards/particle_xenon.overlay
@@ -25,7 +25,7 @@
 			reg = <0x00200000 0x00004000>;
 		};
 		/* A bigger partition for something else. */
-		partition@220000 {
+		partition@204000 {
 			label = "scratch";
 			reg = <0x00204000 0x001fc000>;
 		};


### PR DESCRIPTION
Eliminate "unit address and first address in 'reg'" diagnostic for the
storage partition redefinition.