### PR TITLE
Enable EEPROM in  B-L072Z-LRWAN1 Discovery

### DIFF
--- a/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
+++ b/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
@@ -53,6 +53,7 @@
 		led2 = &blue_led;
 		led3 = &red_led;
 		sw0 = &user_button;
+		eeprom-0 = &eeprom;
 	};
 };
 
@@ -88,5 +89,9 @@ arduino_i2c: &i2c1 {};
 };
 
 &rng {
+	status = "okay";
+};
+
+&eeprom {
 	status = "okay";
 };

--- a/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.yaml
+++ b/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.yaml
@@ -18,3 +18,4 @@ supported:
   - gpio
   - pinmux
   - counter
+  - eeprom

--- a/boards/arm/b_l072z_lrwan1/doc/index.rst
+++ b/boards/arm/b_l072z_lrwan1/doc/index.rst
@@ -137,6 +137,8 @@ The Zephyr B-L072Z-LRWAN1 Discovery board configuration supports the following h
 +-----------+------------+-------------------------------------+
 | TRNG      | on-chip    | true random number generator        |
 +-----------+------------+-------------------------------------+
+| EEPROM    | on-chip    | eeprom                              |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/arm/b_l072z_lrwan1/doc/index.rst
+++ b/boards/arm/b_l072z_lrwan1/doc/index.rst
@@ -15,7 +15,7 @@ This kit provides:
 
         - Embedded ultra-low-power STM32L072CZ Series MCUs, based on
           Arm* Cortex* -M0+ core, with 192 Kbytes of Flash
-          memory, 20 Kbytes of RAM, 20 Kbytes of EEPROM
+          memory, 20 Kbytes of RAM, 6 Kbytes of EEPROM
         - Frequency range: 860 MHz - 930 MHz
         - USB 2.0 FS
         - 4-channel,12-bit ADC, 2xDAC


### PR DESCRIPTION
The  B-L072Z-LRWAN1 Discovery kit has a built-in EEPROM that works with Zephyr's STM32 eeprom driver. Enable it.

Testing: Tested using the EEPROM shell. Reading and writing works. Values are persistent across reboots. 