### PR TITLE
tests: drivers: console: Skip semihosting console device testing

### DIFF
--- a/tests/drivers/console/testcase.yaml
+++ b/tests/drivers/console/testcase.yaml
@@ -13,5 +13,5 @@ tests:
   drivers.console.semihost:
     tags: drivers console
     arch_whitelist: arm
-    filter: CONFIG_CPU_CORTEX_M
+    filter: CONFIG_CPU_CORTEX_M and CONFIG_QEMU_TARGET
     extra_args: CONF_FILE=prj_semihost.conf


### PR DESCRIPTION
The semihosting console test (`drivers.console.semihost`) is currently
only supported on the ARM Cortex-M QEMU targets.

While running this test on real hardware targets is possible, there is
no standardised way for sanitycheck to validate its output, so we
filter by `CONFIG_QEMU_TARGET` to skip running it on non-QEMU targets
(including physical hardware targets with `--device-testing`).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #25191