### PR TITLE
tests/drivers: i2s: Fix use of k_sleep

### DIFF
--- a/tests/drivers/i2s/i2s_api/src/test_i2s_loopback.c
+++ b/tests/drivers/i2s/i2s_api/src/test_i2s_loopback.c
@@ -319,7 +319,7 @@ void test_i2s_transfer_restart(void)
 	TC_PRINT("Stop transmission\n");
 
 	/* Keep interface inactive */
-	k_sleep(TEST_I2S_TRANSFER_RESTART_PAUSE_LENGTH_US);
+	k_sleep(K_USEC(TEST_I2S_TRANSFER_RESTART_PAUSE_LENGTH_US));
 
 	TC_PRINT("Start transmission\n");
 
@@ -396,7 +396,7 @@ void test_i2s_transfer_rx_overrun(void)
 	zassert_equal(ret, 0, "TX DRAIN trigger failed");
 
 	/* Wait for transmission to finish */
-	k_sleep(TEST_I2S_TRANSFER_RX_OVERRUN_PAUSE_LENGTH_US);
+	k_sleep(K_USEC(TEST_I2S_TRANSFER_RX_OVERRUN_PAUSE_LENGTH_US));
 
 	/* Read all available data blocks in RX queue */
 	for (int i = 0; i < NUM_RX_BLOCKS; i++) {

--- a/tests/drivers/i2s/i2s_api/src/test_i2s_states.c
+++ b/tests/drivers/i2s/i2s_api/src/test_i2s_states.c
@@ -363,7 +363,7 @@ void test_i2s_state_error_neg(void)
 	}
 
 	/* Wait for transmission to finish */
-	k_sleep(TEST_I2S_STATE_ERROR_NEG_PAUSE_LENGTH_US);
+	k_sleep(K_USEC(TEST_I2S_STATE_ERROR_NEG_PAUSE_LENGTH_US));
 
 	/* Read all available data blocks in RX queue */
 	for (int i = 0; i < NUM_RX_BLOCKS; i++) {


### PR DESCRIPTION
k_sleep requires k_timeout_t as argument.
Use K_USEC helper when required in i2s driver tests.

Fixes #25180

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>