### PR TITLE
tests: kernel: context: Fix test_busy_wait timeout

### DIFF
--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -781,7 +781,7 @@ static void test_busy_wait(void)
 			INT_TO_POINTER(timeout), NULL,
 			NULL, K_PRIO_COOP(THREAD_PRIORITY), 0, K_NO_WAIT);
 
-	rv = k_sem_take(&reply_timeout, K_MSEC(timeout * 2));
+	rv = k_sem_take(&reply_timeout, K_MSEC(timeout * 2 * 2));
 
 	zassert_false(rv, " *** thread timed out waiting for " "k_busy_wait()");
 }


### PR DESCRIPTION
The commit b7e363661d3daf4475e67acf1a4d96d39df18da1 added an additional
busy wait call in the `busy_wait_thread` function -- effectively making
the minimum time required for the thread to exit twice that of the
original implementation.

This commit updates the busy wait thread completion timeout to reflect
that change.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #25176
Fixes #25194