### PR TITLE
soc: x86: apollo_lake: Make it possible to disable I2C support

### DIFF
--- a/soc/x86/apollo_lake/Kconfig.soc
+++ b/soc/x86/apollo_lake/Kconfig.soc
@@ -5,7 +5,7 @@ config SOC_APOLLO_LAKE
 	bool "Intel Apollo Lake Soc"
 	select X86
 	select CPU_APOLLO_LAKE
-	select HAS_I2C_DW
+	select HAS_I2C_DW if I2C
 	select PCIE
 	select PCIE_MSI
 	select DYNAMIC_INTERRUPTS


### PR DESCRIPTION
Make it possible for an application to set CONFIG_I2C=n if it wants.
The unconditional select was making this impossible due to resulting
unmet dependencies.

This is also in line with what some other SoC definitions do with I2C.

Fixes #25204

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>