### PR TITLE
ci: update ci-tools repo sha

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
       path: modules/lib/canopennode
       revision: 5c6b0566d56264efd4bf23ed58bc7cb8b32fe063
     - name: ci-tools
-      revision: cf55a47d52d38af655f3efa6d38ff105b727358a
+      revision: da9a2df574094f52d87a03f6393928bdc7dce17c
       path: tools/ci-tools
     - name: civetweb
       revision: 99129c5efc907ea613c4b73ccff07581feb58a7a


### PR DESCRIPTION
This should fix an issue with setting labels. A label was renamed and
ci-tools did not handle the error.

Fixes #25210