### PR TITLE
tests: benchmarks: latency_measure: Fix atsame54_xpro

### DIFF
--- a/tests/benchmarks/latency_measure/boards/atsame54_xpro.conf
+++ b/tests/benchmarks/latency_measure/boards/atsame54_xpro.conf
@@ -1,0 +1,4 @@
+# eliminate timer interrupts during the benchmark
+# for platforms that do not allow frequency dividers large enough to get
+# system clock tick period in 1 sec, make system clock tick to 0.1 sec
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=10


### PR DESCRIPTION
Reduce the system timer frequency on `atsame54_xpro` to prevent timer
from ticking while measuring average context switch time between
threads.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #25224