### PR TITLE
soc: atmel_sam0: samd21: Fix interrupt line count

### DIFF
--- a/soc/arm/atmel_sam0/samd21/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/samd21/Kconfig.defconfig.series
@@ -25,7 +25,7 @@ config SOC_PART_NUMBER
 	default "samd21j18a" if SOC_PART_NUMBER_SAMD21J18A
 
 config NUM_IRQS
-	default 29
+	default 28
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 48000000


### PR DESCRIPTION
The Atmel SAM D21 SoC, according to the original Atmel datasheet
(Atmel-42181N), has 28 interrupt lines (0-27).

There have been mysterious changes in the number of interrupt lines and
on-chip peripherals in the recent Microchip datasheet releases, but
there is no explicit information available for this (e.g. PCN), so we
take the safest approach by assuming the lowest interrupt line number.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #25221

See https://github.com/zephyrproject-rtos/zephyr/issues/25221#issuecomment-627158132