### PR TITLE
Bluetooth: host: Add PHY update procedure options

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -81,10 +81,23 @@ struct bt_conn_le_phy_info {
 	uint8_t rx_phy; /** Connection receive PHY */
 };
 
+/** Connection PHY options */
+enum {
+	/** Convenience value when no options are specified. */
+	BT_CONN_LE_PHY_OPT_NONE = 0,
+
+	/** LE Coded using S=2 coding preferred when transmitting. */
+	BT_CONN_LE_PHY_OPT_CODED_S2  = BIT(0),
+
+	/** LE Coded using S=8 coding preferred when transmitting. */
+	BT_CONN_LE_PHY_OPT_CODED_S8  = BIT(1),
+};
+
 /** Preferred PHY parameters for LE connections */
 struct bt_conn_le_phy_param {
-	uint8_t pref_tx_phy; /** Bitmask of preferred transmit PHYs */
-	uint8_t pref_rx_phy; /** Bitmask of preferred receive PHYs */
+	uint16_t options;     /** Connection PHY options. */
+	uint8_t  pref_tx_phy; /** Bitmask of preferred transmit PHYs */
+	uint8_t  pref_rx_phy; /** Bitmask of preferred receive PHYs */
 };
 
 /** Initialize PHY parameters
@@ -94,6 +107,7 @@ struct bt_conn_le_phy_param {
  */
 #define BT_CONN_LE_PHY_PARAM_INIT(_pref_tx_phy, _pref_rx_phy) \
 { \
+	.option = BT_CONN_LE_PHY_OPT_NONE, \
 	.pref_tx_phy = (_pref_tx_phy), \
 	.pref_rx_phy = (_pref_rx_phy), \
 }
@@ -398,6 +412,9 @@ int bt_conn_le_data_len_update(struct bt_conn *conn,
 			       const struct bt_conn_le_data_len_param *param);
 
 /** @brief Update the connection PHY parameters.
+ *
+ *  Update the preferred transmit and receive PHYs of the connection.
+ *  Use @ref BT_GAP_LE_PHY_NONE to indicate no preference.
  *
  *  @param conn Connection object.
  *  @param param Updated connection parameters.

--- a/include/bluetooth/gap.h
+++ b/include/bluetooth/gap.h
@@ -78,6 +78,8 @@ extern "C" {
 
 /** LE PHY types */
 enum {
+	/** Convenience macro for when no PHY is set. */
+	BT_GAP_LE_PHY_NONE                    = 0,
 	/** LE 1M PHY */
 	BT_GAP_LE_PHY_1M                      = BIT(0),
 	 /** LE 2M PHY */

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2118,17 +2118,35 @@ int bt_conn_le_data_len_update(struct bt_conn *conn,
 int bt_conn_le_phy_update(struct bt_conn *conn,
 			  const struct bt_conn_le_phy_param *param)
 {
-	if (conn->le.phy.tx_phy == param->pref_tx_phy &&
-	    conn->le.phy.rx_phy == param->pref_rx_phy) {
-		return -EALREADY;
-	}
+	uint8_t phy_opts, all_phys;
 
 	if (IS_ENABLED(CONFIG_BT_AUTO_PHY_UPDATE) &&
 	    !atomic_test_bit(conn->flags, BT_CONN_AUTO_PHY_COMPLETE)) {
 		return -EAGAIN;
 	}
 
-	return bt_le_set_phy(conn, param->pref_tx_phy, param->pref_rx_phy);
+	if ((param->options & BT_CONN_LE_PHY_OPT_CODED_S2) &&
+	    (param->options & BT_CONN_LE_PHY_OPT_CODED_S8)) {
+		phy_opts = BT_HCI_LE_PHY_CODED_ANY;
+	} else if (param->options & BT_CONN_LE_PHY_OPT_CODED_S2) {
+		phy_opts = BT_HCI_LE_PHY_CODED_S2;
+	} else if (param->options & BT_CONN_LE_PHY_OPT_CODED_S8) {
+		phy_opts = BT_HCI_LE_PHY_CODED_S8;
+	} else {
+		phy_opts = BT_HCI_LE_PHY_CODED_ANY;
+	}
+
+	all_phys = 0U;
+	if (param->pref_tx_phy == BT_GAP_LE_PHY_NONE) {
+		all_phys |= BT_HCI_LE_PHY_TX_ANY;
+	}
+
+	if (param->pref_rx_phy == BT_GAP_LE_PHY_NONE) {
+		all_phys |= BT_HCI_LE_PHY_RX_ANY;
+	}
+
+	return bt_le_set_phy(conn, all_phys, param->pref_tx_phy,
+			     param->pref_rx_phy, phy_opts);
 }
 #endif
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1788,7 +1788,8 @@ static int hci_le_read_phy(struct bt_conn *conn)
 }
 #endif /* defined(CONFIG_BT_USER_PHY_UPDATE) */
 
-int bt_le_set_phy(struct bt_conn *conn, uint8_t pref_tx_phy, uint8_t pref_rx_phy)
+int bt_le_set_phy(struct bt_conn *conn, uint8_t all_phys,
+		  uint8_t pref_tx_phy, uint8_t pref_rx_phy, uint8_t phy_opts)
 {
 	struct bt_hci_cp_le_set_phy *cp;
 	struct net_buf *buf;
@@ -1800,10 +1801,10 @@ int bt_le_set_phy(struct bt_conn *conn, uint8_t pref_tx_phy, uint8_t pref_rx_phy
 
 	cp = net_buf_add(buf, sizeof(*cp));
 	cp->handle = sys_cpu_to_le16(conn->handle);
-	cp->all_phys = 0U;
+	cp->all_phys = all_phys;
 	cp->tx_phys = pref_tx_phy;
 	cp->rx_phys = pref_rx_phy;
-	cp->phy_opts = BT_HCI_LE_PHY_CODED_ANY;
+	cp->phy_opts = phy_opts;
 
 	return bt_hci_cmd_send(BT_HCI_OP_LE_SET_PHY, buf);
 }
@@ -1929,9 +1930,9 @@ static void conn_auto_initiate(struct bt_conn *conn)
 	if (IS_ENABLED(CONFIG_BT_AUTO_PHY_UPDATE) &&
 	    !atomic_test_bit(conn->flags, BT_CONN_AUTO_PHY_COMPLETE) &&
 	    BT_FEAT_LE_PHY_2M(bt_dev.le.features)) {
-		err = bt_le_set_phy(conn,
+		err = bt_le_set_phy(conn, 0U, BT_HCI_LE_PHY_PREFER_2M,
 				    BT_HCI_LE_PHY_PREFER_2M,
-				    BT_HCI_LE_PHY_PREFER_2M);
+				    BT_HCI_LE_PHY_CODED_ANY);
 		if (!err) {
 			atomic_set_bit(conn->flags, BT_CONN_AUTO_PHY_UPDATE);
 			return;

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -255,7 +255,8 @@ int bt_hci_disconnect(uint16_t handle, uint8_t reason);
 
 bool bt_le_conn_params_valid(const struct bt_le_conn_param *param);
 int bt_le_set_data_len(struct bt_conn *conn, uint16_t tx_octets, uint16_t tx_time);
-int bt_le_set_phy(struct bt_conn *conn, uint8_t tx_phy, uint8_t rx_phy);
+int bt_le_set_phy(struct bt_conn *conn, uint8_t all_phys,
+		  uint8_t pref_tx_phy, uint8_t pref_rx_phy, uint8_t phy_opts);
 
 int bt_le_scan_update(bool fast_scan);
 

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1568,10 +1568,19 @@ static int cmd_conn_phy_update(const struct shell *shell, size_t argc,
 	int err;
 
 	param.pref_tx_phy = strtoul(argv[1], NULL, 16);
-	if (argc > 2) {
-		param.pref_rx_phy = strtoul(argv[2], NULL, 16);
-	} else {
-		param.pref_rx_phy = param.pref_tx_phy;
+	param.pref_rx_phy = param.pref_tx_phy;
+	param.options = BT_CONN_LE_PHY_OPT_NONE;
+
+	for (size_t argn = 2; argn < argc; argn++) {
+		const char *arg = argv[argn];
+
+		if (!strcmp(arg, "s2")) {
+			param.options |= BT_CONN_LE_PHY_OPT_CODED_S2;
+		} else if (!strcmp(arg, "s8")) {
+			param.options |= BT_CONN_LE_PHY_OPT_CODED_S8;
+		} else {
+			param.pref_rx_phy = strtoul(arg, NULL, 16);
+		}
 	}
 
 	err = bt_conn_le_phy_update(default_conn, &param);
@@ -2431,8 +2440,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 		      cmd_conn_data_len_update, 2, 1),
 #endif
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
-	SHELL_CMD_ARG(phy-update, NULL, "<tx_phy> [rx_phy]",
-		      cmd_conn_phy_update, 2, 1),
+	SHELL_CMD_ARG(phy-update, NULL, "<tx_phy> [rx_phy] [s2] [s8]",
+		      cmd_conn_phy_update, 2, 3),
 #endif
 #if defined(CONFIG_BT_CENTRAL)
 	SHELL_CMD_ARG(channel-map, NULL, "<channel-map: XXXXXXXXXX> (36-0)",


### PR DESCRIPTION
Add options for phy update procedure. User can now set no preference
option for a particular PHY as well as preference for LE Coded PHY
coding scheme.

Fixes: #25165 