### PR TITLE
device: avoid casting away const from config_info pointer

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -389,8 +389,8 @@ static void adc_stm32_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;
 	struct adc_stm32_data *data = (struct adc_stm32_data *)dev->driver_data;
-	struct adc_stm32_cfg *config =
-		(struct adc_stm32_cfg *)dev->config_info;
+	const struct adc_stm32_cfg *config =
+		(const struct adc_stm32_cfg *)dev->config_info;
 	ADC_TypeDef *adc = config->base;
 
 	*data->buffer++ = LL_ADC_REG_ReadConversionData32(adc);
@@ -449,8 +449,8 @@ static int adc_stm32_check_acq_time(u16_t acq_time)
 static void adc_stm32_setup_speed(struct device *dev, u8_t id,
 				  u8_t acq_time_index)
 {
-	struct adc_stm32_cfg *config =
-		(struct adc_stm32_cfg *)dev->config_info;
+	const struct adc_stm32_cfg *config =
+		(const struct adc_stm32_cfg *)dev->config_info;
 	ADC_TypeDef *adc = config->base;
 
 #if defined(CONFIG_SOC_SERIES_STM32F0X) || defined(CONFIG_SOC_SERIES_STM32L0X)
@@ -522,8 +522,8 @@ static int adc_stm32_channel_setup(struct device *dev,
 	!defined(CONFIG_SOC_SERIES_STM32L1X)
 static void adc_stm32_calib(struct device *dev)
 {
-	struct adc_stm32_cfg *config =
-		(struct adc_stm32_cfg *)dev->config_info;
+	const struct adc_stm32_cfg *config =
+		(const struct adc_stm32_cfg *)dev->config_info;
 	ADC_TypeDef *adc = config->base;
 
 #if defined(CONFIG_SOC_SERIES_STM32F3X) || \

--- a/drivers/audio/mpxxdtyy.h
+++ b/drivers/audio/mpxxdtyy.h
@@ -20,7 +20,7 @@ extern "C" {
 #define MPXXDTYY_MAX_PDM_FREQ		3250000 /* 3.25MHz */
 
 #define DEV_CFG(dev) \
-	((struct mpxxdtyy_config *const)(dev)->config_info)
+	((const struct mpxxdtyy_config *const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct mpxxdtyy_data *const)(dev)->driver_data)
 

--- a/drivers/counter/counter_gecko_rtcc.c
+++ b/drivers/counter/counter_gecko_rtcc.c
@@ -41,7 +41,7 @@ struct counter_gecko_data {
 
 #define DEV_NAME(dev) ((dev)->name)
 #define DEV_CFG(dev) \
-	((struct counter_gecko_config * const)(dev)->config_info)
+	((const struct counter_gecko_config * const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct counter_gecko_data *const)(dev)->driver_data)
 

--- a/drivers/display/grove_lcd_rgb.c
+++ b/drivers/display/grove_lcd_rgb.c
@@ -104,7 +104,7 @@ static inline void sleep(u32_t sleep_in_ms)
  *******************************************/
 void glcd_print(struct device *port, char *data, u32_t size)
 {
-	const struct glcd_driver * const rom = (struct glcd_driver *)
+	const struct glcd_driver * const rom = (const struct glcd_driver *)
 						port->config_info;
 	struct glcd_data *dev = port->driver_data;
 	u8_t buf[] = { GLCD_CMD_SET_CGRAM_ADDR, 0 };
@@ -119,7 +119,7 @@ void glcd_print(struct device *port, char *data, u32_t size)
 
 void glcd_cursor_pos_set(struct device *port, u8_t col, u8_t row)
 {
-	const struct glcd_driver * const rom = (struct glcd_driver *)
+	const struct glcd_driver * const rom = (const struct glcd_driver *)
 						port->config_info;
 	struct glcd_data *dev = port->driver_data;
 
@@ -140,7 +140,7 @@ void glcd_cursor_pos_set(struct device *port, u8_t col, u8_t row)
 
 void glcd_clear(struct device *port)
 {
-	const struct glcd_driver * const rom = (struct glcd_driver *)
+	const struct glcd_driver * const rom = (const struct glcd_driver *)
 						port->config_info;
 	struct glcd_data *dev = port->driver_data;
 	u8_t clear[] = { 0, GLCD_CMD_SCREEN_CLEAR };
@@ -153,7 +153,7 @@ void glcd_clear(struct device *port)
 
 void glcd_display_state_set(struct device *port, u8_t opt)
 {
-	const struct glcd_driver * const rom = (struct glcd_driver *)
+	const struct glcd_driver * const rom = (const struct glcd_driver *)
 						port->config_info;
 	struct glcd_data *dev = port->driver_data;
 	u8_t data[] = { 0, 0 };

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -32,7 +32,7 @@ struct entropy_stm32_rng_dev_data {
 	((struct entropy_stm32_rng_dev_data *)(dev)->driver_data)
 
 #define DEV_CFG(dev) \
-	((struct entropy_stm32_rng_dev_cfg *)(dev)->config_info)
+	((const struct entropy_stm32_rng_dev_cfg *)(dev)->config_info)
 
 static void entropy_stm32_rng_reset(RNG_TypeDef *rng)
 {
@@ -144,7 +144,7 @@ static int entropy_stm32_rng_get_entropy(struct device *dev, u8_t *buffer,
 static int entropy_stm32_rng_init(struct device *dev)
 {
 	struct entropy_stm32_rng_dev_data *dev_data;
-	struct entropy_stm32_rng_dev_cfg *dev_cfg;
+	const struct entropy_stm32_rng_dev_cfg *dev_cfg;
 	int res;
 
 	__ASSERT_NO_MSG(dev != NULL);

--- a/drivers/ethernet/eth_gecko_priv.h
+++ b/drivers/ethernet/eth_gecko_priv.h
@@ -96,7 +96,7 @@ struct eth_gecko_dev_data {
 
 #define DEV_NAME(dev) ((dev)->name)
 #define DEV_CFG(dev) \
-	((struct eth_gecko_dev_cfg *)(dev)->config_info)
+	((const struct eth_gecko_dev_cfg *)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct eth_gecko_dev_data *)(dev)->driver_data)
 

--- a/drivers/ethernet/eth_stellaris.c
+++ b/drivers/ethernet/eth_stellaris.c
@@ -272,7 +272,7 @@ static void eth_stellaris_isr(void *arg)
 static void eth_stellaris_init(struct net_if *iface)
 {
 	struct device *dev = net_if_get_device(iface);
-	struct eth_stellaris_config *dev_conf = DEV_CFG(dev);
+	const struct eth_stellaris_config *dev_conf = DEV_CFG(dev);
 	struct eth_stellaris_runtime *dev_data = DEV_DATA(dev);
 
 	dev_data->iface = iface;

--- a/drivers/ethernet/eth_stellaris_priv.h
+++ b/drivers/ethernet/eth_stellaris_priv.h
@@ -11,7 +11,7 @@
 #define DEV_DATA(dev) \
 	((struct eth_stellaris_runtime *)(dev)->driver_data)
 #define DEV_CFG(dev) \
-	((struct eth_stellaris_config *const)(dev)->config_info)
+	((const struct eth_stellaris_config *const)(dev)->config_info)
 /*
  *  Register mapping
  */

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -370,7 +370,7 @@ static void generate_mac(u8_t *mac_addr)
 static int eth_initialize(struct device *dev)
 {
 	struct eth_stm32_hal_dev_data *dev_data;
-	struct eth_stm32_hal_dev_cfg *cfg;
+	const struct eth_stm32_hal_dev_cfg *cfg;
 	ETH_HandleTypeDef *heth;
 	u8_t hal_ret;
 	int ret = 0;

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -45,7 +45,7 @@ struct eth_stm32_hal_dev_data {
 };
 
 #define DEV_CFG(dev) \
-	((struct eth_stm32_hal_dev_cfg *)(dev)->config_info)
+	((const struct eth_stm32_hal_dev_cfg *)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct eth_stm32_hal_dev_data *)(dev)->driver_data)
 

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -58,7 +58,7 @@ static struct nrf5_802154_data nrf5_data;
 	((struct nrf5_802154_data * const)(dev)->driver_data)
 
 #define NRF5_802154_CFG(dev) \
-	((struct nrf5_802154_config * const)(dev)->config_info)
+	((const struct nrf5_802154_config * const)(dev)->config_info)
 
 static void nrf5_get_eui64(u8_t *mac)
 {

--- a/drivers/neural_net/intel_gna.c
+++ b/drivers/neural_net/intel_gna.c
@@ -26,7 +26,7 @@ LOG_MODULE_REGISTER(neural_net);
 
 #define DEV_NAME(dev) ((dev)->name)
 #define DEV_CFG(dev) \
-	((struct intel_gna_config *const)(dev)->config_info)
+	((const struct intel_gna_config *const)(dev)->config_info)
 #define DEV_DATA(dev) \
 	((struct intel_gna_data *const)(dev)->driver_data)
 
@@ -221,7 +221,7 @@ static int intel_gna_initialize(struct device *dev)
 
 static int intel_gna_configure(struct device *dev, struct gna_config *cfg)
 {
-	struct intel_gna_config *const dev_cfg = DEV_CFG(dev);
+	const struct intel_gna_config *const dev_cfg = DEV_CFG(dev);
 	struct intel_gna_data *const gna = DEV_DATA(dev);
 	volatile struct intel_gna_regs *regs = gna->regs;
 

--- a/drivers/pwm/pwm_dw.c
+++ b/drivers/pwm/pwm_dw.c
@@ -73,7 +73,7 @@ struct pwm_dw_config {
 static inline int pwm_dw_timer_base_addr(struct device *dev, u32_t timer)
 {
 	const struct pwm_dw_config * const cfg =
-	    (struct pwm_dw_config *)dev->config_info;
+	    (const struct pwm_dw_config *)dev->config_info;
 
 	return (cfg->addr + (timer * REG_OFFSET));
 }
@@ -89,7 +89,7 @@ static inline int pwm_dw_timer_base_addr(struct device *dev, u32_t timer)
 static inline int pwm_dw_timer_ldcnt2_addr(struct device *dev, u32_t timer)
 {
 	const struct pwm_dw_config * const cfg =
-	    (struct pwm_dw_config *)dev->config_info;
+	    (const struct pwm_dw_config *)dev->config_info;
 
 	return (cfg->addr + REG_TMR_LOAD_CNT2 + (timer * REG_OFFSET_LOAD_CNT2));
 }
@@ -144,7 +144,7 @@ static int pwm_dw_pin_set_cycles(struct device *dev,
 				 u32_t pulse_cycles, pwm_flags_t flags)
 {
 	const struct pwm_dw_config * const cfg =
-	    (struct pwm_dw_config *)dev->config_info;
+	    (const struct pwm_dw_config *)dev->config_info;
 	int i;
 	u32_t on, off;
 

--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -320,7 +320,7 @@ static int pwm_led_esp32_pin_set_cycles(struct device *dev,
 	int timer;
 	int ret;
 	const struct pwm_led_esp32_config * const config =
-		(struct pwm_led_esp32_config *) dev->config_info;
+		(const struct pwm_led_esp32_config *) dev->config_info;
 
 	ARG_UNUSED(period_cycles);
 
@@ -373,7 +373,7 @@ static int pwm_led_esp32_get_cycles_per_sec(struct device *dev, u32_t pwm,
 	int timer;
 	int speed_mode;
 
-	config = (struct pwm_led_esp32_config *) dev->config_info;
+	config = (const struct pwm_led_esp32_config *) dev->config_info;
 
 	channel = pwm_led_esp32_get_gpio_config(pwm, config->ch_cfg);
 	if (channel < 0) {

--- a/drivers/pwm/pwm_nrf5_sw.c
+++ b/drivers/pwm/pwm_nrf5_sw.c
@@ -92,7 +92,7 @@ static int pwm_nrf5_sw_pin_set(struct device *dev, u32_t pwm,
 			       u32_t period_cycles, u32_t pulse_cycles,
 			       pwm_flags_t flags)
 {
-	struct pwm_config *config;
+	const struct pwm_config *config;
 	NRF_TIMER_Type *timer;
 	struct pwm_data *data;
 	u8_t ppi_index;
@@ -100,7 +100,7 @@ static int pwm_nrf5_sw_pin_set(struct device *dev, u32_t pwm,
 	u16_t div;
 	u32_t ret;
 
-	config = (struct pwm_config *)dev->config_info;
+	config = (const struct pwm_config *)dev->config_info;
 	timer = config->timer;
 	data = dev->driver_data;
 
@@ -216,9 +216,9 @@ pin_set_pwm_off:
 static int pwm_nrf5_sw_get_cycles_per_sec(struct device *dev, u32_t pwm,
 					  u64_t *cycles)
 {
-	struct pwm_config *config;
+	const struct pwm_config *config;
 
-	config = (struct pwm_config *)dev->config_info;
+	config = (const struct pwm_config *)dev->config_info;
 
 	/* HF timer frequency is derived from 16MHz source with a prescaler */
 	*cycles = 16000000UL / BIT(config->prescaler);
@@ -233,10 +233,10 @@ static const struct pwm_driver_api pwm_nrf5_sw_drv_api_funcs = {
 
 static int pwm_nrf5_sw_init(struct device *dev)
 {
-	struct pwm_config *config;
+	const struct pwm_config *config;
 	NRF_TIMER_Type *timer;
 
-	config = (struct pwm_config *)dev->config_info;
+	config = (const struct pwm_config *)dev->config_info;
 	timer = config->timer;
 
 	/* setup HF timer */

--- a/drivers/watchdog/wdt_gecko.c
+++ b/drivers/watchdog/wdt_gecko.c
@@ -36,7 +36,7 @@ struct wdt_gecko_data {
 #define DEV_DATA(dev) \
 	((struct wdt_gecko_data *)(dev)->driver_data)
 #define DEV_CFG(dev) \
-	((struct wdt_gecko_cfg *)(dev)->config_info)
+	((const struct wdt_gecko_cfg *)(dev)->config_info)
 
 static u32_t wdt_gecko_get_timeout_from_persel(int perSel)
 {

--- a/include/drivers/counter.h
+++ b/include/drivers/counter.h
@@ -211,7 +211,7 @@ __syscall bool counter_is_counting_up(const struct device *dev);
 static inline bool z_impl_counter_is_counting_up(const struct device *dev)
 {
 	const struct counter_config_info *config =
-			(struct counter_config_info *)dev->config_info;
+			(const struct counter_config_info *)dev->config_info;
 
 	return config->flags & COUNTER_CONFIG_INFO_COUNT_UP;
 }
@@ -228,7 +228,7 @@ __syscall u8_t counter_get_num_of_channels(const struct device *dev);
 static inline u8_t z_impl_counter_get_num_of_channels(const struct device *dev)
 {
 	const struct counter_config_info *config =
-			(struct counter_config_info *)dev->config_info;
+			(const struct counter_config_info *)dev->config_info;
 
 	return config->channels;
 }
@@ -246,7 +246,7 @@ __syscall u32_t counter_get_frequency(const struct device *dev);
 static inline u32_t z_impl_counter_get_frequency(const struct device *dev)
 {
 	const struct counter_config_info *config =
-			(struct counter_config_info *)dev->config_info;
+			(const struct counter_config_info *)dev->config_info;
 
 	return config->freq;
 }
@@ -265,7 +265,7 @@ static inline u32_t z_impl_counter_us_to_ticks(const struct device *dev,
 					       u64_t us)
 {
 	const struct counter_config_info *config =
-			(struct counter_config_info *)dev->config_info;
+			(const struct counter_config_info *)dev->config_info;
 	u64_t ticks = (us * config->freq) / USEC_PER_SEC;
 
 	return (ticks > (u64_t)UINT32_MAX) ? UINT32_MAX : ticks;
@@ -285,7 +285,7 @@ static inline u64_t z_impl_counter_ticks_to_us(const struct device *dev,
 					       u32_t ticks)
 {
 	const struct counter_config_info *config =
-			(struct counter_config_info *)dev->config_info;
+			(const struct counter_config_info *)dev->config_info;
 
 	return ((u64_t)ticks * USEC_PER_SEC) / config->freq;
 }
@@ -302,7 +302,7 @@ __syscall u32_t counter_get_max_top_value(const struct device *dev);
 static inline u32_t z_impl_counter_get_max_top_value(const struct device *dev)
 {
 	const struct counter_config_info *config =
-			(struct counter_config_info *)dev->config_info;
+			(const struct counter_config_info *)dev->config_info;
 
 	return config->max_top_value;
 }

--- a/scripts/coccinelle/const_config_info.cocci
+++ b/scripts/coccinelle/const_config_info.cocci
@@ -1,0 +1,137 @@
+// Copyright (c) 2020 Nordic Semiconductor ASA
+// SPDX-License-Identifer: Apache-2.0
+
+// Enforce preservation of const qualifier on config_info casts
+//
+// Drivers cast the device config_info pointer to a driver-specific
+// structure.  The object is const-qualified; make sure the cast
+// doesn't inadvertently remove that qualifier.
+//
+// Also add the qualifier to pointer definitions where it's missing.
+//
+// Note that this patch may produce incorrect results if config_info
+// appears as a tag in non-device aggregate types.
+//
+// Options: --include-headers
+
+virtual patch
+virtual report
+
+// bare: (struct T*)E
+@r_cci_bare_patch
+ depends on patch
+ disable optional_qualifier
+@
+identifier T;
+expression E;
+@@
+ (
++const
+ struct T*)E->config_info
+
+// bare const: (struct T* const)E
+@r_cci_bare_lc_patch
+ depends on patch
+ disable optional_qualifier
+@
+identifier T;
+expression E;
+@@
+ (
++const
+ struct T * const)E->config_info
+
+// asg: struct T *D = (const struct T*)
+@r_cci_asg_patch
+ depends on patch
+ disable optional_qualifier
+@
+identifier T;
+identifier D;
+expression E;
+@@
++const
+ struct T * D = (const struct T*)E->config_info;
+
+// asg to const local: struct T * const D = (const struct T*)
+@r_cci_lc_asg_patch
+ depends on patch
+ disable optional_qualifier
+@
+identifier T;
+identifier D;
+expression E;
+@@
++const
+ struct T * const D = (const struct T*)E->config_info;
+
+// asg via macro: struct T * D = DEV_CFG()
+@r_cci_asg_macro_patch
+ depends on patch
+ disable optional_qualifier
+@
+identifier T;
+identifier D;
+expression E;
+@@
++const
+ struct T * D = DEV_CFG(E);
+
+// asg via macro to const local: struct T * const D = DEV_CFG()
+@r_cci_lc_asg_macro_patch
+ depends on patch
+ disable optional_qualifier
+@
+identifier T;
+identifier D;
+expression E;
+@@
++const
+ struct T * const D = DEV_CFG(E);
+
+// asg via macro: struct T * D; ... ; D = (const struct T*)CI;
+@r_cci_delayed_asg_patch
+ depends on patch
+ disable optional_qualifier
+@
+identifier T;
+identifier D;
+expression E;
+@@
++const
+ struct T * D;
+ ...
+ D = (const struct T*)E->config_info;
+
+// delayed asg via macro: struct T * D; ... ; D = DEV_CFG();
+@r_cci_delayed_asg_macro_patch
+ depends on patch
+ disable optional_qualifier
+@
+identifier T;
+identifier D;
+expression E;
+@@
++const
+ struct T * D;
+ ...
+ D = DEV_CFG(E);
+
+@r_cci_report
+ depends on report
+ disable optional_qualifier
+@
+identifier T;
+expression E;
+position p;
+@@
+ (struct T*)E->config_info@p
+
+@script:python
+ depends on report
+@
+t << r_cci_report.T;
+p << r_cci_report.p;
+@@
+msg = "WARNING: cast of config_info to struct {} requires 'const'".format(t)
+coccilib.report.print_report(p[0], msg)

--- a/tests/lib/devicetree/src/main.c
+++ b/tests/lib/devicetree/src/main.c
@@ -1220,7 +1220,7 @@ static inline struct test_gpio_data *to_data(struct device *dev)
 
 static inline const struct test_gpio_info *to_info(struct device *dev)
 {
-	return (struct test_gpio_info *)dev->config_info;
+	return (const struct test_gpio_info *)dev->config_info;
 }
 
 static void test_devices(void)


### PR DESCRIPTION
The driver-specific config_info structure referenced from the device structure is marked const.  Some drivers fail to preserve that qualifier when casting the pointer to the driver-specific structure, violating MISRA 11.8.

Changes produced by scripts/coccinelle/const_config_info.cocci which is added in this PR.

Fixes #25247
