### PR TITLE
boards: atsamd21_xpro: Fix DT conversion typo

### DIFF
--- a/boards/arm/atsamd21_xpro/pinmux.c
+++ b/boards/arm/atsamd21_xpro/pinmux.c
@@ -20,7 +20,7 @@ static int board_pinmux_init(struct device *dev)
 	pinmux_pin_set(muxa, 11, PINMUX_FUNC_C);
 	pinmux_pin_set(muxa, 10, PINMUX_FUNC_C);
 #endif
-#if (1, atmel_sam0_uart)
+#if ATMEL_SAM0_DT_SERCOM_CHECK(1, atmel_sam0_uart)
 	/* SERCOM3 ON RX=PA19, TX=PA16 */
 	pinmux_pin_set(muxa, 19, PINMUX_FUNC_C);
 	pinmux_pin_set(muxa, 16, PINMUX_FUNC_C);
@@ -33,7 +33,7 @@ static int board_pinmux_init(struct device *dev)
 	pinmux_pin_set(muxa, 23, PINMUX_FUNC_C);
 	pinmux_pin_set(muxa, 22, PINMUX_FUNC_C);
 #endif
-#if (4, atmel_sam0_uart)
+#if ATMEL_SAM0_DT_SERCOM_CHECK(4, atmel_sam0_uart)
 #warning Pin mapping may not be configured
 #endif
 #if ATMEL_SAM0_DT_SERCOM_CHECK(5, atmel_sam0_uart)


### PR DESCRIPTION
This commit fixes the DT macro conversion typos introduced by the
commit 4d7d3a25c127430b010363d672dec8f24c3647d4.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>