### PR TITLE
drivers: lora: select REQUIRES_FULL_LIBC instead of NEWLIB_LIBC

### DIFF
--- a/drivers/lora/Kconfig
+++ b/drivers/lora/Kconfig
@@ -8,7 +8,7 @@
 
 menuconfig LORA
 	bool "LoRa support [EXPERIMENTAL]"
-	depends on NEWLIB_LIBC
+	select REQUIRES_FULL_LIBC
 	help
 	  Include LoRa drivers in the system configuration.
 


### PR DESCRIPTION
The lora drivers currently depends on NEWLIB_LIBC. In practice they
actually do not need anything from newlib, but the loramac-node
library uses math functions from math.h that are not available in the
minimal libc.

Therefore it's better to use REQUIRES_FULL_LIBC for that. At the same
time, use select instead of a depends so that it works out of the box

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>