### PR TITLE
x86: fix dummy thread alignment

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -38,6 +38,7 @@ config X86
 	select ARCH_IS_SET
 	select ATOMIC_OPERATIONS_BUILTIN
 	select HAS_DTS
+	select ARCH_HAS_CUSTOM_SWAP_TO_MAIN if !X86_64
 	help
 	  x86 architecture
 

--- a/include/arch/x86/ia32/thread.h
+++ b/include/arch/x86/ia32/thread.h
@@ -26,12 +26,18 @@
  * since the 'fxsave' and 'fxrstor' instructions require this. In all other
  * cases a 4 byte boundary is sufficient.
  */
-
+#if defined(CONFIG_EAGER_FPU_SHARING) || defined(CONFIG_LAZY_FPU_SHARING)
 #ifdef CONFIG_SSE
 #define FP_REG_SET_ALIGN  16
 #else
 #define FP_REG_SET_ALIGN  4
 #endif
+#else
+/* Unused, no special alignment requirements, use default alignment for
+ * char buffers on this arch
+ */
+#define FP_REG_SET_ALIGN  1
+#endif /* CONFIG_*_FP_SHARING */
 
 /*
  * Bits for _thread_arch.flags, see their use in intstub.S et al.
@@ -230,19 +236,6 @@ struct _thread_arch {
 	unsigned excNestCount; /* nested exception count */
 #endif /* CONFIG_LAZY_FPU_SHARING */
 
-	/*
-	 * The location of all floating point related structures/fields MUST be
-	 * located at the end of struct k_thread.  This way only the
-	 * threads that actually utilize non-integer capabilities need to
-	 * account for the increased memory required for storing FP state when
-	 * sizing stacks.
-	 *
-	 * Given that stacks "grow down" on IA-32, and the TCS is located
-	 * at the start of a thread's "workspace" memory, the stacks of
-	 * threads that do not utilize floating point instruction can
-	 * effectively consume the memory occupied by the 'tPreempFloatReg'
-	 * struct without ill effect.
-	 */
 	tPreempFloatReg preempFloatReg; /* volatile float register storage */
 };
 

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -180,6 +180,32 @@ static inline void z_swap_unlocked(void)
 	(void) z_swap_irqlock(arch_irq_lock());
 }
 
+#endif /* !CONFIG_USE_SWITCH */
+
+/**
+ * Set up a "dummy" thread, used at early initialization to launch the
+ * first thread on a CPU.
+ *
+ * Needs to set enough fields such that the context switching code can
+ * use it to properly store state, which will just be discarded.
+ *
+ * The memory of the dummy thread can be completely uninitialized.
+ */
+static inline void z_dummy_thread_init(struct k_thread *dummy_thread)
+{
+	dummy_thread->base.thread_state = _THREAD_DUMMY;
+#ifdef CONFIG_SCHED_CPU_MASK
+	dummy_thread->base.cpu_mask = -1;
+#endif
+	dummy_thread->base.user_options = K_ESSENTIAL;
+#ifdef CONFIG_THREAD_STACK_INFO
+	dummy_thread->stack_info.start = 0U;
+	dummy_thread->stack_info.size = 0U;
+#endif
+#ifdef CONFIG_USERSPACE
+	dummy_thread->mem_domain_info.mem_domain = 0;
 #endif
 
+	_current_cpu->current = dummy_thread;
+}
 #endif /* ZEPHYR_KERNEL_INCLUDE_KSWAP_H_ */

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -64,20 +64,13 @@ void z_smp_release_global_lock(struct k_thread *thread)
 static FUNC_NORETURN void smp_init_top(void *arg)
 {
 	atomic_t *start_flag = arg;
+	struct k_thread dummy_thread;
 
 	/* Wait for the signal to begin scheduling */
 	while (!atomic_get(start_flag)) {
 	}
 
-	/* Switch out of a dummy thread.  Trick cribbed from the main
-	 * thread init.  Should probably unify implementations.
-	 */
-	struct k_thread dummy_thread = {
-		.base.user_options = K_ESSENTIAL,
-		.base.thread_state = _THREAD_DUMMY,
-	};
-
-	arch_curr_cpu()->current = &dummy_thread;
+	z_dummy_thread_init(&dummy_thread);
 	smp_timer_init();
 	z_swap_unlocked();
 


### PR DESCRIPTION
- Consolidate some code to initialize dummy threads into an inline function

- Implement a custom swap to main for x86 32-bit, which still uses a dummy thread but ensures that the memory for it is properly aligned.

- Remove comments which are not correct

Fixes: #24805

Please see individual commit messages for details.