### PR TITLE
tests: socketpair: fix userspace thread permissions

### DIFF
--- a/tests/net/socket/socketpair/prj.conf
+++ b/tests/net/socket/socketpair/prj.conf
@@ -1,5 +1,3 @@
-CONFIG_MP_NUM_CPUS=1
-
 # General config
 CONFIG_NEWLIB_LIBC=y
 

--- a/tests/net/socket/socketpair/src/main.c
+++ b/tests/net/socket/socketpair/src/main.c
@@ -6,21 +6,11 @@
 
 #include <ztest.h>
 
+#include "test_socketpair_thread.h"
+
 /* in happy_path.c */
 extern void test_socketpair_AF_LOCAL__SOCK_STREAM__0(void);
 extern void test_socketpair_AF_UNIX__SOCK_STREAM__0(void);
-
-/* in nonblock.c */
-extern void test_socketpair_write_nonblock(void);
-extern void test_socketpair_read_nonblock(void);
-
-/* in block.c */
-extern void test_socketpair_write_block(void);
-extern void test_socketpair_read_block(void);
-
-/* in closed_ends.c */
-extern void test_socketpair_close_one_end_and_write_to_the_other(void);
-extern void test_socketpair_close_one_end_and_read_from_the_other(void);
 
 /* in expected_failures.c */
 extern void test_socketpair_expected_failures(void);
@@ -31,63 +21,74 @@ extern void test_socketpair_unsupported_calls(void);
 /* in fcntl.c */
 extern void test_socketpair_fcntl(void);
 
+/* in nonblock.c */
+extern void test_socketpair_read_nonblock(void);
+extern void test_socketpair_write_nonblock(void);
+
+/* in block.c */
+extern void test_socketpair_read_block(void);
+extern void test_socketpair_write_block(void);
+
+/* in closed_ends.c */
+extern void test_socketpair_close_one_end_and_read_from_the_other(void);
+extern void test_socketpair_close_one_end_and_write_to_the_other(void);
+
 /* in poll.c */
 extern void test_socketpair_poll_timeout(void);
 extern void test_socketpair_poll_timeout_nonblocking(void);
-extern void test_socketpair_poll_close_remote_end_POLLIN(void);
-extern void test_socketpair_poll_close_remote_end_POLLOUT(void);
 extern void test_socketpair_poll_immediate_data(void);
 extern void test_socketpair_poll_delayed_data(void);
+extern void test_socketpair_poll_close_remote_end_POLLIN(void);
+extern void test_socketpair_poll_close_remote_end_POLLOUT(void);
+
+/* work queue for tests that need an async event */
+static K_THREAD_STACK_DEFINE(test_socketpair_work_q_stack, 512);
+struct k_work_q test_socketpair_work_q;
 
 void test_main(void)
 {
 	k_thread_system_pool_assign(k_current_get());
 
+	k_thread_access_grant(k_current_get(),
+		&test_socketpair_work_q.queue);
+
+	k_work_q_start(&test_socketpair_work_q, test_socketpair_work_q_stack,
+		K_THREAD_STACK_SIZEOF(test_socketpair_work_q_stack),
+		CONFIG_MAIN_THREAD_PRIORITY);
+
 	ztest_test_suite(
 		socketpair,
+
 		ztest_user_unit_test(test_socketpair_AF_LOCAL__SOCK_STREAM__0),
 		ztest_user_unit_test(test_socketpair_AF_UNIX__SOCK_STREAM__0),
 
-		ztest_user_unit_test(test_socketpair_write_nonblock),
-		ztest_user_unit_test(test_socketpair_read_nonblock),
-
-		ztest_user_unit_test(
-			test_socketpair_close_one_end_and_write_to_the_other),
-		ztest_user_unit_test(
-			test_socketpair_close_one_end_and_read_from_the_other),
-
 		ztest_user_unit_test(test_socketpair_expected_failures),
-
 		ztest_user_unit_test(test_socketpair_unsupported_calls),
 
 		ztest_user_unit_test(test_socketpair_fcntl),
 
+		ztest_user_unit_test(test_socketpair_read_nonblock),
+		ztest_user_unit_test(test_socketpair_write_nonblock),
+
+		ztest_user_unit_test(test_socketpair_read_block),
+		ztest_user_unit_test(test_socketpair_write_block),
+
+		ztest_user_unit_test(
+			test_socketpair_close_one_end_and_read_from_the_other),
+		ztest_user_unit_test(
+			test_socketpair_close_one_end_and_write_to_the_other),
+
 		ztest_user_unit_test(test_socketpair_poll_timeout),
 		ztest_user_unit_test(
 			test_socketpair_poll_timeout_nonblocking),
-		ztest_user_unit_test(test_socketpair_poll_immediate_data)
-	);
-
-	ztest_run_test_suite(socketpair);
-
-/* 20200509: @cfriedt: experiencing some issues with userspace thread
- * / memory permissions that will require some sorting out. Currently
- * these tests succeeed for native_posix_64.
- *
- * This feature is experimental at present.
- */
-#if 0
-	ztest_test_suite(
-		socketpair_only_kernel,
-		ztest_user_unit_test(test_socketpair_write_block),
-		ztest_user_unit_test(test_socketpair_read_block),
+		ztest_user_unit_test(test_socketpair_poll_immediate_data),
 		ztest_user_unit_test(test_socketpair_poll_delayed_data),
+
 		ztest_user_unit_test(
 			test_socketpair_poll_close_remote_end_POLLIN),
 		ztest_user_unit_test(
 			test_socketpair_poll_close_remote_end_POLLOUT)
 	);
 
-	ztest_run_test_suite(socketpair_only_kernel);
-#endif
+	ztest_run_test_suite(socketpair);
 }

--- a/tests/net/socket/socketpair/src/test_socketpair_thread.h
+++ b/tests/net/socket/socketpair/src/test_socketpair_thread.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2020 Friedt Professional Engineering Services, Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TEST_SOCKETPAIR_THREAD_H_
+#define TEST_SOCKETPAIR_THREAD_H_
+
+#include <kernel.h>
+
+extern struct k_work_q test_socketpair_work_q;
+
+#endif /* TEST_SOCKETPAIR_THREAD_H_ */


### PR DESCRIPTION
Kernel objects were being directly accessed without previously calling k_thread_access_grant().
    
This change allows each test that requires an asynchronous event to send it to a common work queue with correct permissions given to the userspace thread.
    
Also, clarified some conditions in subsys/net/lib/sockets/socketpair.c and added / reordered some calls to respect whether semaphores were held / object were valid.
    
Fixes #25270