### PR TITLE
xtensa: esp32: enable building with Zephyr SDK

### DIFF
--- a/boards/common/esp32.board.cmake
+++ b/boards/common/esp32.board.cmake
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(esp32)
-
 if(NOT DEFINED ESP_IDF_PATH)
   if(DEFINED ENV{ESP_IDF_PATH})
     message(WARNING "Setting ESP_IDF_PATH in the environment is deprecated. Use cmake -DESP_IDF_PATH=... instead.")
@@ -9,6 +7,9 @@ if(NOT DEFINED ESP_IDF_PATH)
   endif()
 endif()
 
-assert(ESP_IDF_PATH "ESP_IDF_PATH is not set")
-
-board_finalize_runner_args(esp32 "--esp-idf-path=${ESP_IDF_PATH}")
+if(DEFINED ESP_IDF_PATH)
+  board_set_flasher_ifnset(esp32)
+  board_finalize_runner_args(esp32 "--esp-idf-path=${ESP_IDF_PATH}")
+else()
+  message(WARNING "ESP_IDF_PATH is not set. Image flashing is not supported.")
+endif()

--- a/boards/xtensa/esp32/esp32.yaml
+++ b/boards/xtensa/esp32/esp32.yaml
@@ -3,6 +3,8 @@ name: ESP-32
 type: mcu
 arch: xtensa
 toolchain:
+  - zephyr
+  - xtools
   - espressif
 supported:
   - gpio

--- a/soc/xtensa/esp32/linker.ld
+++ b/soc/xtensa/esp32/linker.ld
@@ -137,13 +137,44 @@ SECTIONS
     *(.init)
     _init_end = ABSOLUTE(.);
 
+    /* see below in CONFIG_CPLUSPLUS for why these are here */
+    . = ALIGN(4);
+    __init_array_start = .;
+    KEEP(*(SORT_BY_NAME(".init_array*")))
+    __init_array_end = .;
+
     /* This goes here, not at top of linker script, so addr2line finds it last,
        and uses it in preference to the first symbol in IRAM */
     _iram_start = ABSOLUTE(0);
   } GROUP_LINK_IN(ROMABLE_REGION)
 
 #include <linker/common-ram.ld>
-#include <linker/common-rom.ld>
+
+/* esptool only copies PROGBITS sections from ELF to binary image.
+ * However, init_array is of type INIT_ARRAY and thus not being copied.
+ * This breaks C++ applications where init arrays are needed.
+ * So workaround this by defining our own C++ section.
+ */
+#ifdef CONFIG_CPLUSPLUS
+#  undef CONFIG_CPLUSPLUS
+#  include <linker/common-rom.ld>
+#  define CONFIG_CPLUSPLUS
+#else
+#  include <linker/common-rom.ld>
+#endif
+
+#ifdef CONFIG_CPLUSPLUS
+  SECTION_PROLOGUE(_CTOR_SECTION_NAME,,)
+  {
+    . = ALIGN(4);
+    __CTOR_LIST__ = .;
+    LONG((__CTOR_END__ - __CTOR_LIST__) / 4 - 2)
+    KEEP(*(SORT_BY_NAME(".ctors*")))
+    LONG(0)
+    __CTOR_END__ = .;
+  } GROUP_LINK_IN(ROMABLE_REGION)
+#endif
+
 
   SECTION_PROLOGUE(_TEXT_SECTION_NAME, , ALIGN(4))
   {

--- a/soc/xtensa/esp32/linker.ld
+++ b/soc/xtensa/esp32/linker.ld
@@ -21,7 +21,10 @@
 #define ROMABLE_REGION iram0_0_seg :iram0_0_phdr
 
 PROVIDE ( __stack = 0x3ffe3f20 );
+PROVIDE ( _heap_sentry = 0x40000000 );
 
+PROVIDE ( abort = 0x4000bba4 );
+PROVIDE ( __getreent = 0x4000be8c );
 PROVIDE ( esp32_rom_uart_tx_one_char = 0x40009200 );
 PROVIDE ( esp32_rom_uart_rx_one_char = 0x400092d0 );
 PROVIDE ( esp32_rom_uart_attach = 0x40008fd0 );
@@ -261,6 +264,7 @@ SECTIONS
     *(COMMON)
     . = ALIGN (8);
     __bss_end = ABSOLUTE(.);
+    _end = ALIGN (8);
   } GROUP_LINK_IN(RAMABLE_REGION)
 
 
@@ -282,6 +286,28 @@ SECTIONS
     . = ALIGN (8);
     _heap_start = ABSOLUTE(.);
   } GROUP_LINK_IN(RAMABLE_REGION)
+
+  .xt.insn 0 :
+  {
+    KEEP (*(.xt.insn))
+    KEEP (*(.gnu.linkonce.x.*))
+  }
+  .xt.prop 0 :
+  {
+    KEEP (*(.xt.prop))
+    KEEP (*(.xt.prop.*))
+    KEEP (*(.gnu.linkonce.prop.*))
+  }
+  .xt.lit 0 :
+  {
+    KEEP (*(.xt.lit))
+    KEEP (*(.xt.lit.*))
+    KEEP (*(.gnu.linkonce.p.*))
+  }
+  .debug.xt.callgraph 0 :
+  {
+    KEEP (*(.debug.xt.callgraph .debug.xt.callgraph.* .gnu.linkonce.xt.callgraph.*))
+  }
 
 #ifdef CONFIG_GEN_ISR_TABLES
 #include <linker/intlist.ld>

--- a/soc/xtensa/esp32/linker.ld
+++ b/soc/xtensa/esp32/linker.ld
@@ -244,7 +244,7 @@ SECTIONS
   SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
   {
     . = ALIGN (8);
-    _bss_start = ABSOLUTE(.);
+    __bss_start = ABSOLUTE(.);
     *(.dynsbss)
     *(.sbss)
     *(.sbss.*)
@@ -260,7 +260,7 @@ SECTIONS
     *(.gnu.linkonce.b.*)
     *(COMMON)
     . = ALIGN (8);
-    _bss_end = ABSOLUTE(.);
+    __bss_end = ABSOLUTE(.);
   } GROUP_LINK_IN(RAMABLE_REGION)
 
 

--- a/soc/xtensa/esp32/soc.c
+++ b/soc/xtensa/esp32/soc.c
@@ -13,6 +13,7 @@
 
 #include <kernel_structs.h>
 #include <string.h>
+#include <linker/linker-defs.h>
 #include <toolchain/gcc.h>
 #include <zephyr/types.h>
 
@@ -29,8 +30,6 @@ void __attribute__((section(".iram1"))) __start(void)
 	volatile uint32_t *wdt_timg_reg = (uint32_t *)TIMG_WDTCONFIG0_REG(0);
 	volatile uint32_t *app_cpu_config_reg = (uint32_t *)DPORT_APPCPU_CTRL_B_REG;
 	extern uint32_t _init_start;
-	extern uint32_t _bss_start;
-	extern uint32_t _bss_end;
 
 	/* Move the exception vector table to IRAM. */
 	__asm__ __volatile__ (
@@ -39,12 +38,11 @@ void __attribute__((section(".iram1"))) __start(void)
 		: "r"(&_init_start));
 
 	/* Zero out BSS.  Clobber _bss_start to avoid memset() elision. */
-	(void)memset(&_bss_start, 0,
-		     (&_bss_end - &_bss_start) * sizeof(_bss_start));
+	(void)memset(__bss_start, 0, __bss_end - __bss_start);
 	__asm__ __volatile__ (
 		""
 		:
-		: "g"(&_bss_start)
+		: "g"(__bss_start)
 		: "memory");
 
 	/* The watchdog timer is enabled in the bootloader.  We're done booting,


### PR DESCRIPTION
This allows building application targeting the ESP32 board
using the Zephyr SDK, in addition to the official Espressif
toolchain.

Requires https://github.com/zephyrproject-rtos/sdk-ng/pull/213