### PR TITLE
shell: Move default terminal width and height to Kconfig

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -47,6 +47,16 @@ config SHELL_PRINTF_BUFF_SIZE
 	  It is working like stdio buffering in Linux systems
 	  to limit number of peripheral access calls.
 
+config SHELL_DEFAULT_TERMINAL_WIDTH
+	int "Default terminal width"
+	default 80
+	help
+	  Default terminal width is used to break lines.
+
+config SHELL_DEFAULT_TERMINAL_HEIGHT
+	int "Default terminal height"
+	default 24
+
 config SHELL_ARGC_MAX
 	int "Maximum arguments in shell command"
 	default 12

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1118,8 +1118,10 @@ static int instance_init(const struct shell *shell, const void *p_config,
 	flag_mode_delete_set(shell,
 			     IS_ENABLED(CONFIG_SHELL_BACKSPACE_MODE_DELETE));
 	shell->ctx->state = SHELL_STATE_INITIALIZED;
-	shell->ctx->vt100_ctx.cons.terminal_wid = SHELL_DEFAULT_TERMINAL_WIDTH;
-	shell->ctx->vt100_ctx.cons.terminal_hei = SHELL_DEFAULT_TERMINAL_HEIGHT;
+	shell->ctx->vt100_ctx.cons.terminal_wid =
+					CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH;
+	shell->ctx->vt100_ctx.cons.terminal_hei =
+					CONFIG_SHELL_DEFAULT_TERMINAL_HEIGHT;
 	shell->ctx->vt100_ctx.cons.name_len = shell_strlen(shell->ctx->prompt);
 	flag_use_colors_set(shell, IS_ENABLED(CONFIG_SHELL_VT100_COLORS));
 

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -28,7 +28,7 @@
 #define SHELL_HELP_STATISTICS_RESET	\
 	"Reset shell statistics for the Logger module."
 #define SHELL_HELP_RESIZE						\
-	"Console gets terminal screen size or assumes 80 in case"	\
+	"Console gets terminal screen size or assumes default in case"	\
 	" the readout fails. It must be executed after each terminal"	\
 	" width change to ensure correct text display."
 #define SHELL_HELP_RESIZE_DEFAULT				\
@@ -55,6 +55,9 @@
 
 /* 10 == {esc, [, 2, 5, 0, ;, 2, 5, 0, '\0'} */
 #define SHELL_CURSOR_POSITION_BUFFER	(10u)
+
+#define SHELL_DEFAULT_TERMINAL_WIDTH 80
+#define SHELL_DEFAULT_TERMINAL_HEIGHT 24
 
 /* Function reads cursor position from terminal. */
 static int cursor_position_get(const struct shell *shell, u16_t *x, u16_t *y)
@@ -350,7 +353,7 @@ static int cmd_resize_default(const struct shell *shell,
 	ARG_UNUSED(argv);
 
 	SHELL_VT100_CMD(shell, SHELL_VT100_SETCOL_80);
-	shell->ctx->vt100_ctx.cons.terminal_wid =  SHELL_DEFAULT_TERMINAL_WIDTH;
+	shell->ctx->vt100_ctx.cons.terminal_wid = SHELL_DEFAULT_TERMINAL_WIDTH;
 	shell->ctx->vt100_ctx.cons.terminal_hei = SHELL_DEFAULT_TERMINAL_HEIGHT;
 
 	return 0;
@@ -369,9 +372,9 @@ static int cmd_resize(const struct shell *shell, size_t argc, char **argv)
 	err = terminal_size_get(shell);
 	if (err != 0) {
 		shell->ctx->vt100_ctx.cons.terminal_wid =
-				SHELL_DEFAULT_TERMINAL_WIDTH;
+				CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH;
 		shell->ctx->vt100_ctx.cons.terminal_hei =
-				SHELL_DEFAULT_TERMINAL_HEIGHT;
+				CONFIG_SHELL_DEFAULT_TERMINAL_HEIGHT;
 		shell_warn(shell, "No response from the terminal, assumed 80x24"
 			   " screen size");
 		return -ENOEXEC;

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -15,9 +15,6 @@
 extern "C" {
 #endif
 
-#define SHELL_DEFAULT_TERMINAL_WIDTH	(80u) /* Default PuTTY width. */
-#define SHELL_DEFAULT_TERMINAL_HEIGHT	(24u) /* Default PuTTY height. */
-
 static inline void shell_raw_fprintf(const struct shell_fprintf *const ctx,
 				     const char *fmt, ...)
 {

--- a/subsys/shell/shell_utils.h
+++ b/subsys/shell/shell_utils.h
@@ -15,11 +15,6 @@ extern "C" {
 
 #define SHELL_MSG_SPECIFY_SUBCOMMAND	"Please specify a subcommand.\n"
 
-#define SHELL_DEFAULT_TERMINAL_WIDTH	(80u) /* Default PuTTY width. */
-#define SHELL_DEFAULT_TERMINAL_HEIGHT	(24u) /* Default PuTTY height. */
-
-
-
 s32_t row_span_with_buffer_offsets_get(struct shell_multiline_cons *cons,
 				       u16_t offset1,
 				       u16_t offset2);


### PR DESCRIPTION
Default values were fixed in the code. Moved to Kconfig to allow
customized configuration. Custom configuration may be used to prevent
line breaking injected on terminal width.

Fixes #25246.
Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>