### PR TITLE
nrf_radio_802154: Use chosen zephyr,entropy to get entropy device

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: e1168a2f3290f5ca17ec0c47efbf6c601c60108a
+      revision: e5a1a6fc9caf7b1333144aee8fececd6252d908d
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 3b54187649cc9b37161d49918f1ad28ff7c7f830


### PR DESCRIPTION
See https://github.com/zephyrproject-rtos/hal_nordic/pull/40.

---

Update the hal_nordic module revision, so that the following commit
becomes effective:

nrf_radio_802154: Use chosen zephyr,entropy to get entropy device

Use the label property of the node pointed by "zephyr,entropy" chosen
entry as the name of the entropy device to bind to. The pointed node
does not necessarily need to be a "nordic,nrf-rng" compatible one, what
was incorrectly assumed when CONFIG_ENTROPY_NAME was replaced in commit
5505d0baa66a89848f643120fafad232876df695.
