### PR TITLE
tests: mem protection test check CPU scrubs registers after syscall

### DIFF
--- a/tests/kernel/mem_protect/syscalls/CMakeLists.txt
+++ b/tests/kernel/mem_protect/syscalls/CMakeLists.txt
@@ -4,5 +4,7 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(syscalls)
 
+enable_language(ASM)
+
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -75,7 +75,7 @@ size_t z_impl_string_nlen_reg(char *src, size_t maxlen, int *err)
 		"ldr r1, =0xDEADBEEF;\n\t"
 		"ldr r2, =0xDEADBEEF;\n\t"
 		"ldr r3, =0xDEADBEEF;\n\t"
-		"ldr r12, =0xDEADBEEF;\n\t"
+		"ldr r4, =0xDEADBEEF;\n\t"
 		);
 #elif defined(CONFIG_ARC)
     /* ARC currently not implemented */
@@ -513,7 +513,7 @@ void test_syscall_cpu_scrubs_regs(void)
 	__asm__ volatile (
 		"\t ldr %%r3,=0" : "=r"(arm_reg_val[2]));
 	__asm__ volatile (
-		"\t ldr %%r12,=0" : "=r"(arm_reg_val[3]));
+		"\t ldr %%r4,=0" : "=r"(arm_reg_val[3]));
 
 	for (int i = 0; i < 4; i++) {
 		zassert_true(arm_reg_val[i] != DB_VAL,

--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -72,10 +72,10 @@ size_t z_impl_string_nlen_reg(char *src, size_t maxlen, int *err)
 #endif
 #elif defined(CONFIG_ARM)
 	__asm__ volatile (
+		"ldr r0, =0xDEADBEEF;\n\t"
 		"ldr r1, =0xDEADBEEF;\n\t"
 		"ldr r2, =0xDEADBEEF;\n\t"
 		"ldr r3, =0xDEADBEEF;\n\t"
-		"ldr r4, =0xDEADBEEF;\n\t"
 		);
 #elif defined(CONFIG_ARC)
     /* ARC currently not implemented */
@@ -507,13 +507,13 @@ void test_syscall_cpu_scrubs_regs(void)
 
 	ret = string_nlen_reg(user_string, BUF_SIZE, &err);
 	__asm__ volatile (
-		"\t ldr %%r1,=0" : "=r"(arm_reg_val[0]));
+		"\t ldr %%r0,=0" : "=r"(arm_reg_val[0]));
 	__asm__ volatile (
-		"\t ldr %%r2,=0" : "=r"(arm_reg_val[1]));
+		"\t ldr %%r1,=0" : "=r"(arm_reg_val[1]));
 	__asm__ volatile (
-		"\t ldr %%r3,=0" : "=r"(arm_reg_val[2]));
+		"\t ldr %%r2,=0" : "=r"(arm_reg_val[2]));
 	__asm__ volatile (
-		"\t ldr %%r4,=0" : "=r"(arm_reg_val[3]));
+		"\t ldr %%r3,=0" : "=r"(arm_reg_val[3]));
 
 	for (int i = 0; i < 4; i++) {
 		zassert_true(arm_reg_val[i] != DB_VAL,

--- a/tests/kernel/mem_protect/syscalls/src/test_syscalls.h
+++ b/tests/kernel/mem_protect/syscalls/src/test_syscalls.h
@@ -23,6 +23,8 @@ __syscall uint64_t syscall_arg64_big(uint32_t arg1, uint32_t arg2, uint64_t arg3
 
 __syscall bool syscall_context(void);
 
+__syscall size_t string_nlen_reg(char *src, size_t maxlen, int *err);
+
 #include <syscalls/test_syscalls.h>
 
 #endif /* _TEST_SYSCALLS_H_ */


### PR DESCRIPTION
Add new memory protection test, that verifies CPU scrubs registers after syscall. Leaving of sensitive data in the CPU registers, can make open a door for attacks and vulnerabilities.

To verify that CPU registers are scrubbed, I created test test_after_syscall_cpu_scrubs_regs()
Test verifies upon exit of a system call back to the calling thread, the kernel scrubs CPU registers for sensitive data. 

_Please review and give comments, if you think that my solution is not correct. Also I didn't implement that test for ARC, because not an expert in ARC, so looking for community help who knows ARC.
ARC currently not implemented and not supported for that test._

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>