### PR TITLE
boards: fix misleading size for partition

### DIFF
--- a/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
+++ b/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
@@ -104,11 +104,11 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000067000>;
+			reg = <0x0000C000 0x00067000>;
 		};
 		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00073000 0x000067000>;
+			reg = <0x00073000 0x00067000>;
 		};
 		scratch_partition: partition@da000 {
 			label = "image-scratch";

--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -157,11 +157,11 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000067000>;
+			reg = <0x0000C000 0x00067000>;
 		};
 		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00073000 0x000067000>;
+			reg = <0x00073000 0x00067000>;
 		};
 		scratch_partition: partition@da000 {
 			label = "image-scratch";

--- a/boards/arm/holyiot_yj16019/holyiot_yj16019.dts
+++ b/boards/arm/holyiot_yj16019/holyiot_yj16019.dts
@@ -69,11 +69,11 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000067000>;
+			reg = <0x0000C000 0x00067000>;
 		};
 		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00073000 0x000067000>;
+			reg = <0x00073000 0x00067000>;
 		};
 		scratch_partition: partition@da000 {
 			label = "image-scratch";

--- a/boards/arm/nrf52840_blip/nrf52840_blip.dts
+++ b/boards/arm/nrf52840_blip/nrf52840_blip.dts
@@ -146,11 +146,11 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000067000>;
+			reg = <0x0000C000 0x00067000>;
 		};
 		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00073000 0x000067000>;
+			reg = <0x00073000 0x00067000>;
 		};
 		scratch_partition: partition@da000 {
 			label = "image-scratch";

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -146,11 +146,11 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000067000>;
+			reg = <0x0000C000 0x00067000>;
 		};
 		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00073000 0x000067000>;
+			reg = <0x00073000 0x00067000>;
 		};
 		scratch_partition: partition@da000 {
 			label = "image-scratch";

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
@@ -141,11 +141,11 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000067000>;
+			reg = <0x0000C000 0x00067000>;
 		};
 		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00073000 0x000067000>;
+			reg = <0x00073000 0x00067000>;
 		};
 		scratch_partition: partition@da000 {
 			label = "image-scratch";

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -247,11 +247,11 @@ arduino_spi: &spi3 {
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000067000>;
+			reg = <0x0000C000 0x00067000>;
 		};
 		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00073000 0x000067000>;
+			reg = <0x00073000 0x00067000>;
 		};
 		scratch_partition: partition@da000 {
 			label = "image-scratch";

--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
@@ -64,11 +64,11 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000067000>;
+			reg = <0x0000C000 0x00067000>;
 		};
 		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00073000 0x000067000>;
+			reg = <0x00073000 0x00067000>;
 		};
 		scratch_partition: partition@da000 {
 			label = "image-scratch";

--- a/boards/arm/particle_argon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather.dtsi
@@ -136,11 +136,11 @@ feather_adc: &adc { /* feather ADC */
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000067000>;
+			reg = <0x0000C000 0x00067000>;
 		};
 		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00073000 0x000067000>;
+			reg = <0x00073000 0x00067000>;
 		};
 		scratch_partition: partition@da000 {
 			label = "image-scratch";

--- a/boards/arm/particle_boron/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather.dtsi
@@ -136,11 +136,11 @@ feather_adc: &adc { /* feather ADC */
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000067000>;
+			reg = <0x0000C000 0x00067000>;
 		};
 		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00073000 0x000067000>;
+			reg = <0x00073000 0x00067000>;
 		};
 		scratch_partition: partition@da000 {
 			label = "image-scratch";

--- a/boards/arm/particle_xenon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather.dtsi
@@ -136,11 +136,11 @@ feather_adc: &adc { /* feather ADC */
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000067000>;
+			reg = <0x0000C000 0x00067000>;
 		};
 		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00073000 0x000067000>;
+			reg = <0x00073000 0x00067000>;
 		};
 		scratch_partition: partition@da000 {
 			label = "image-scratch";

--- a/boards/arm/reel_board/dts/reel_board.dtsi
+++ b/boards/arm/reel_board/dts/reel_board.dtsi
@@ -178,11 +178,11 @@ arduino_spi: &spi3 {
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000067000>;
+			reg = <0x0000C000 0x00067000>;
 		};
 		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00073000 0x000067000>;
+			reg = <0x00073000 0x00067000>;
 		};
 		scratch_partition: partition@da000 {
 			label = "image-scratch";

--- a/samples/application_development/out_of_tree_board/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/samples/application_development/out_of_tree_board/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -58,11 +58,11 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000067000>;
+			reg = <0x0000C000 0x00067000>;
 		};
 		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00073000 0x000067000>;
+			reg = <0x00073000 0x00067000>;
 		};
 		scratch_partition: partition@da000 {
 			label = "image-scratch";


### PR DESCRIPTION
The length field for the MCUBOOT slot partitions in Nordic platforms
has always had an extra leading zero suggesting it's a 40-bit value,
being stored in a 32-bit field.  Remove the incorrect leading zero to
reduce misunderstanding of the field.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>