### PR TITLE
drivers: usb_dc_nrfx: Abort write on ep_ctx_reset

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -637,6 +637,11 @@ static void ep_ctx_reset(struct nrf_usbd_ep_ctx *ep_ctx)
 	ep_ctx->buf.curr = ep_ctx->buf.data;
 	ep_ctx->buf.len  = 0U;
 
+	/* Abort ongoing write operation. */
+	if (ep_ctx->write_in_progress) {
+		nrfx_usbd_ep_abort(ep_addr_to_nrfx(ep_ctx->cfg.addr));
+	}
+
 	ep_ctx->read_complete = true;
 	ep_ctx->read_pending = false;
 	ep_ctx->write_in_progress = false;
@@ -1053,6 +1058,12 @@ static void usbd_event_transfer_data(nrfx_usbd_evt_t const *const p_event)
 			ev->evt.ep_evt.ep = ep_ctx;
 			usbd_evt_put(ev);
 			usbd_work_schedule();
+		}
+		break;
+
+		case NRFX_USBD_EP_ABORTED: {
+			LOG_DBG("Endpoint 0x%02x write aborted",
+				p_event->data.eptransfer.ep);
 		}
 		break;
 


### PR DESCRIPTION
Change adds abort of ongoing write operation in ep_ctx_reset. This is required to keep the state of Zephyr driver consistent with state of nrfx driver. This fixes a bug where nrfx_usbd was stuck in busy state.

The problem was replicated when the USB device was disconnected from virtual machine and connected to host. In case there was ongoing write operation, it never ended. The nrfx driver was kept in busy state. Because of that, the application was unable to write to the endpoint.