### PR TITLE
tests: gpio_basic_api: change GPIOs for mec15xxevb_assy6853

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/boards/mec15xxevb_assy6853.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/mec15xxevb_assy6853.overlay
@@ -9,8 +9,12 @@
 	resources {
 		compatible = "test,gpio_basic_api";
 
-		/* Remove jumper on JP15 to disconnect pull-up resistor */
-		out-gpios = <&gpio_040_076 8 0>; /* GPIO_050, JP27 Pin 11 */
-		in-gpios = <&gpio_040_076 9 0>;  /* GPIO_051, JP27 Pin 13 */
+		/*
+		 * Remove jumpers on JP31 to disconnect pull-up resistor.
+		 * Also remove jumpers on JP41 (1-2, 3-4) as the LEDs
+		 * are connected to pull-up resistors also.
+		 */
+		in-gpios  = <&gpio_140_176 14 0>; /* GPIO_156, JP31 Pin 13 */
+		out-gpios = <&gpio_140_176 15 0>; /* GPIO_157, JP31 Pin 15 */
 	};
 };


### PR DESCRIPTION
GPIO 050/051 are being used for tachometer sensor as
CONFIG_TACH_XEC is enabled by default. So for the gpio_basic_api
test, another set of GPIOs are needed. GPIO 156/157 are chosen
as they are (more or less) dedicated for two LEDs on board and
not being used for other functions (pinmux-wise).

Fixes #25272

Signed-off-by: Daniel Leung <daniel.leung@intel.com>