### PR TITLE
drivers: peci: Add verification handlers

### DIFF
--- a/drivers/peci/CMakeLists.txt
+++ b/drivers/peci/CMakeLists.txt
@@ -3,3 +3,4 @@
 zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_PECI_XEC	peci_mchp_xec.c)
+zephyr_library_sources_ifdef(CONFIG_USERSPACE   peci_handlers.c)

--- a/drivers/peci/peci_handlers.c
+++ b/drivers/peci/peci_handlers.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <drivers/peci.h>
+#include <syscall_handler.h>
+
+
+static inline int z_vrfy_peci_config(struct device *dev, u32_t bitrate)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_PECI(dev, config));
+
+	return z_impl_peci_config(dev, bitrate);
+}
+#include <syscalls/peci_config_mrsh.c>
+
+static inline int z_vrfy_peci_enable(struct device *dev)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_PECI(dev, enable));
+
+	return z_impl_peci_enable(dev);
+}
+#include <syscalls/peci_enable_mrsh.c>
+
+static inline int z_vrfy_peci_disable(struct device *dev)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_PECI(dev, disable));
+
+	return z_impl_peci_disable(dev);
+}
+#include <syscalls/peci_disable_mrsh.c>
+
+static inline int z_vrfy_peci_transfer(struct device *dev,
+				       struct peci_msg *msg)
+{
+	struct peci_msg msg_copy;
+
+	Z_OOPS(Z_SYSCALL_DRIVER_PECI(dev, transfer));
+	Z_OOPS(z_user_from_copy(&msg_copy, msg, sizeof(*msg)));
+
+	return z_impl_peci_transfer(dev, &msg_copy);
+}
+#include <syscalls/peci_transfer_mrsh.c>


### PR DESCRIPTION
Add verification handlers for syscalls defined in peci driver.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>