### PR TITLE
samples: various servo_motor fixes

### DIFF
--- a/samples/basic/servo_motor/README.rst
+++ b/samples/basic/servo_motor/README.rst
@@ -19,21 +19,6 @@ to modify the source code if you are using a different servomotor.
 Requirements
 ************
 
-The servomotor must be connected via PWM. The PWM device must be configured
-using the ``pwm-servo`` :ref:`devicetree <dt-guide>` alias. Usually you will
-need to set this up via a :ref:`devicetree overlay <set-devicetree-overlays>`
-like so:
-
-.. code-block:: DTS
-
-   / {
-   	aliases {
-   		pwm-servo = &foo;
-   	};
-   };
-
-Where ``foo`` is the node label of a PWM device in your system.
-
 You will see this error if you try to build this sample for an unsupported
 board:
 
@@ -41,7 +26,23 @@ board:
 
    Unsupported board: pwm-servo devicetree alias is not defined
 
-The sample uses PWM channel 0.
+The sample requires a servomotor whose signal pin is connected to a PWM
+device's channel 0. The PWM device must be configured using the ``pwm-servo``
+:ref:`devicetree <dt-guide>` alias. Usually you will need to set this up via a
+:ref:`devicetree overlay <set-devicetree-overlays>` like so:
+
+.. code-block:: DTS
+
+   / {
+   	aliases {
+   		pwm-servo = &some_pwm_node;
+   	};
+   };
+
+Where ``some_pwm_node`` is the node label of a PWM device in your system.
+
+See :zephyr_file:`samples/basic/servo_motor/boards/bbc_microbit.overlay` for an
+example.
 
 Wiring
 ******
@@ -50,13 +51,12 @@ BBC micro:bit
 =============
 
 You will need to connect the motor's red wire to external 5V, the black wire to
-ground and the white wire to pad 0 on the edge connector.
+ground and the white wire to the SCL pin, i.e. pin 21 on the edge connector.
 
 Building and Running
 ********************
 
-The sample has a devicetree overlay for the :ref:`bbc_microbit` which uses
-``pwm0``.
+The sample has a devicetree overlay for the :ref:`bbc_microbit`.
 
 This sample can be built for multiple boards, in this example we will build it
 for the bbc_microbit board:

--- a/samples/basic/servo_motor/boards/bbc_microbit.overlay
+++ b/samples/basic/servo_motor/boards/bbc_microbit.overlay
@@ -1,5 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-
+/ {
+	aliases {
+		pwm-servo = &sw_pwm;
+	};
+};
 
 &sw_pwm {
 	clock-prescaler = <3>;

--- a/samples/basic/servo_motor/sample.yaml
+++ b/samples/basic/servo_motor/sample.yaml
@@ -5,4 +5,4 @@ tests:
     tags: drivers pwm
     depends_on: pwm
     harness: motor
-    filter: dt_alias_exists("pwm-servo")
+    platform_whitelist: bbc_microbit

--- a/samples/basic/servo_motor/src/main.c
+++ b/samples/basic/servo_motor/src/main.c
@@ -31,11 +31,17 @@
 #define MIN_PULSE_USEC	700
 #define MAX_PULSE_USEC	2300
 
+enum direction {
+	DOWN,
+	UP,
+};
+
 void main(void)
 {
 	struct device *pwm;
 	u32_t pulse_width = MIN_PULSE_USEC;
-	u8_t dir = 0U;
+	enum direction dir = UP;
+	int ret;
 
 	printk("Servomotor control\n");
 
@@ -46,14 +52,15 @@ void main(void)
 	}
 
 	while (1) {
-		if (pwm_pin_set_usec(pwm, 0, PERIOD_USEC, pulse_width, 0)) {
+		ret = pwm_pin_set_usec(pwm, 0, PERIOD_USEC, pulse_width, 0);
+		if (ret < 0) {
 			printk("Error %d: failed to set pulse width\n", ret);
 			return;
 		}
 
-		if (dir) {
+		if (dir == DOWN) {
 			if (pulse_width <= MIN_PULSE_USEC) {
-				dir = 0U;
+				dir = UP;
 				pulse_width = MIN_PULSE_USEC;
 			} else {
 				pulse_width -= STEP_USEC;
@@ -62,7 +69,7 @@ void main(void)
 			pulse_width += STEP_USEC;
 
 			if (pulse_width >= MAX_PULSE_USEC) {
-				dir = 1U;
+				dir = DOWN;
 				pulse_width = MAX_PULSE_USEC;
 			}
 		}


### PR DESCRIPTION
Though there were issues with this sample before e959386bd2 ("samples:
servo_motor: cleanups and changes"), that commit introduced further
bugs. This happened because the new pwm-servo alias that commit
switched to wasn't provided by any boards, so it wasn't built in CI.

Before that, however, the recommendation to use bbc_microbit in the
sample documentation was also buggy in a couple of ways:

1. bbc_microbit doesn't have the pwm-0 alias the sample previously required, so it didn't build on that board

2. the documentation's comment to use pin 0 on the edge connector is wrong; PWM channel 0 is wired to GPIO P0.0 on the SoC, which is actually pin 21 on the connector

Fix it all up.

Tested on bbc_microbit. I verified the pinout and also made sure that
the sample correctly generates pulses from 700 to 2300 usec.
