### PR TITLE
tests: mailbox: add new tests

### DIFF
--- a/tests/kernel/mbox/mbox_api/src/main.c
+++ b/tests/kernel/mbox/mbox_api/src/main.c
@@ -7,6 +7,8 @@
 #include <ztest.h>
 extern void test_mbox_kinit(void);
 extern void test_mbox_kdefine(void);
+extern void test_enhance_capability(void);
+extern void test_define_multi_mbox(void);
 extern void test_mbox_put_get_null(void);
 extern void test_mbox_put_get_buffer(void);
 extern void test_mbox_async_put_get_buffer(void);
@@ -33,6 +35,8 @@ void test_main(void)
 	ztest_test_suite(mbox_api,
 			 ztest_1cpu_unit_test(test_mbox_kinit),/*keep init first!*/
 			 ztest_1cpu_unit_test(test_mbox_kdefine),
+			 ztest_unit_test(test_enhance_capability),
+			 ztest_unit_test(test_define_multi_mbox),
 			 ztest_1cpu_unit_test(test_mbox_put_get_null),
 			 ztest_unit_test(test_mbox_put_get_buffer),
 			 ztest_1cpu_unit_test(test_mbox_async_put_get_buffer),

--- a/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
+++ b/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
@@ -13,7 +13,6 @@
 #define STACK_SIZE (640 + CONFIG_TEST_EXTRA_STACKSIZE)
 #endif
 #define MAIL_LEN 64
-
 /**TESTPOINT: init via K_MBOX_DEFINE*/
 K_MBOX_DEFINE(kmbox);
 K_MEM_POOL_DEFINE(mpooltx, 8, MAIL_LEN, 1, 4);
@@ -562,6 +561,58 @@ void test_mbox_kdefine(void)
 {
 	info_type = PUT_GET_NULL;
 	tmbox(&kmbox);
+}
+
+/**
+ *
+ * @brief Test mailbox enhance capabilities
+ *
+ * @details
+ * - Define and initilized a message queue and a mailbox
+ * - Verify the capability of message queue and mailbox
+ * - with same data.
+ *
+ */
+void test_enhance_capability(void)
+{
+	info_type = ASYNC_PUT_GET_BUFFER;
+	struct k_msgq msgq;
+
+	ZTEST_BMEM char __aligned(4) buffer[8];
+	k_msgq_init(&msgq, buffer, 4, 2);
+	/* send buffer with message queue */
+	int ret = k_msgq_put(&msgq, &data[info_type], K_NO_WAIT);
+
+	zassert_equal(ret, 0, "message queue put successful");
+
+	/* send same buffer with mailbox */
+	tmbox(&mbox);
+}
+
+/*
+ *
+ * @brife Test any number of mailbox can be defined
+ *
+ * @details
+ * - Define multi mailbox and verify the mailbox whether as
+ *   expected
+ * - Verify the mailbox can be used
+ *
+ */
+void test_define_multi_mbox(void)
+{
+	/**TESTPOINT: init via k_mbox_init*/
+	struct k_mbox mbox1, mbox2, mbox3;
+
+	k_mbox_init(&mbox1);
+	k_mbox_init(&mbox2);
+	k_mbox_init(&mbox3);
+
+	/* verify via send message */
+	info_type = PUT_GET_NULL;
+	tmbox(&mbox1);
+	tmbox(&mbox2);
+	tmbox(&mbox3);
 }
 
 void test_mbox_put_get_null(void)


### PR DESCRIPTION
Add 2 new test cases for verify mailbox features
I noticed mailbox is a kernel object that provides enhanced message queue capabilities that go beyond the capabilities of a message queue object, so I add " test_enhance_capability " to verify the mailbox capability.
And any number of mailboxes can be defined, so I add " test_define_multi_mbox " to verify this feature.

Signed-off-by: Jian Kang <jianx.kang@intel.com>