### PR TITLE
tests: mem protect syscalls update Doxygen tags, fix API, misprints

### DIFF
--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017, 2020 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,6 +10,7 @@
 #include "test_syscalls.h"
 
 #define BUF_SIZE	32
+#define SLEEP_MS_LONG	15000
 
 #if defined(CONFIG_BOARD_NUCLEO_F429ZI) || defined(CONFIG_BOARD_NUCLEO_F207ZG)
 #define FAULTY_ADDRESS 0x0FFFFFFF
@@ -325,10 +326,11 @@ void test_syscall_torture(void)
 	}
 
 	/* Let the torture threads hog the system for 15 seconds before we
-	 * abort them. They will all be hammering the cpu(s) with system calls,
+	 * abort them.
+	 * They will all be hammering the cpu(s) with system calls,
 	 * hopefully smoking out any issues and causing a crash.
 	 */
-	k_msleep(15000);
+	k_sleep(K_MSEC(SLEEP_MS_LONG));
 
 	for (i = 0; i < NR_THREADS; i++) {
 		k_thread_abort(&torture_threads[i]);

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -757,7 +757,7 @@ static void test_domain_remove_thread_drop_to_user(void)
 }
 
 /**
- * Show that self-removing a partition from a domain we are a membed of,
+ * Show that self-removing a partition from a domain we are a member of,
  * and then dropping to user mode faults as expected.
  *
  * @ingroup kernel_memprotect_tests
@@ -1102,6 +1102,15 @@ void z_impl_missing_syscall(void)
 	k_panic();
 }
 
+/**
+ * @brief Test unimplemented system call
+ *
+ * @details Created a syscall with name missing_syscall() without a verification
+ * function. The kernel shall safety handle invocations of unimplemented system
+ * calls.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
 void test_unimplemented_syscall(void)
 {
 	expect_fault = true;


### PR DESCRIPTION
Add next improvements to the syscalls tests:
1. Doxygen tags updates of the existing tests. Tests description is very important, sometimes without a good description is not easy to understand what test is going to do.
2. Fixed use of API K_MSEC in test_syscall_torture
3. Removed misprints. Misprints are always make bad impression about the code.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>