### PR TITLE
Bluetooth: hci_core: Fix invalid if LE Read PHY

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1775,7 +1775,7 @@ static int hci_le_read_phy(struct bt_conn *conn)
 	cp->handle = sys_cpu_to_le16(conn->handle);
 
 	err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_READ_PHY, buf, &rsp);
-	if (!buf) {
+	if (err) {
 		return err;
 	}
 


### PR DESCRIPTION
If LE Read PHY fails the code was still trying to parse the buffer as a
valid response.

This is reproducible with BlueZ's emulator which don't implement LE Read PHY causing the command to fail.