### PR TITLE
boards: arm: b_l072z_lrwan1: Fix flashing of big firmware

### DIFF
--- a/boards/arm/b_l072z_lrwan1/support/openocd.cfg
+++ b/boards/arm/b_l072z_lrwan1/support/openocd.cfg
@@ -4,7 +4,7 @@ transport select hla_swd
 
 set WORKAREASIZE 0x2000
 
-source [find target/stm32l0.cfg]
+source [find target/stm32l0_dual_bank.cfg]
 
 # There is only system reset line and JTAG/SWD command can be issued when SRST
 reset_config srst_only


### PR DESCRIPTION
OpenOCD currently uses a single-bank STM32 configuration for the B_L072Z_LRWAN1 board. This causes flashing to fail when the firmware image is larger than the first bank. Switch to the dual bank
configuration to make this work.

Fixes #25349

Signed-off-by: Andreas Sandberg <andreas@sandberg.pp.se>