### PR TITLE
lib: updatehub: Add missing include for FLASH_AREA

### DIFF
--- a/lib/updatehub/updatehub.c
+++ b/lib/updatehub/updatehub.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(updatehub);
 #include <power/reboot.h>
 #include <tinycrypt/sha256.h>
 #include <data/json.h>
+#include <storage/flash_map.h>
 
 #include "include/updatehub.h"
 #include "updatehub_priv.h"

--- a/lib/updatehub/updatehub_device.c
+++ b/lib/updatehub/updatehub_device.c
@@ -5,6 +5,8 @@
  */
 #include "updatehub_device.h"
 
+#include <string.h>
+
 bool updatehub_get_device_identity(char *id, int id_max_len)
 {
 	u8_t hwinfo_id[DEVICE_ID_BIN_MAX_SIZE];

--- a/lib/updatehub/updatehub_firmware.c
+++ b/lib/updatehub/updatehub_firmware.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <storage/flash_map.h>
+
 #include "updatehub_firmware.h"
 
 bool updatehub_get_firmware_version(char *version, int version_len)

--- a/samples/net/updatehub/sample.yaml
+++ b/samples/net/updatehub/sample.yaml
@@ -1,0 +1,15 @@
+sample:
+  description: UpdateHub enterprise-grade Firmware Over-the-Air (FOTA)
+  name: UpdateHub
+tests:
+  sample.net.updatehub:
+    harness: net
+    tags: net wifi
+    depends_on: netif
+    build_only: true
+    platform_whitelist: frdm_k64f sam_v71_xult
+    extra_configs:
+      - CONFIG_UPDATEHUB_PRODUCT_UID="e4d37cfe6ec48a2d069cc0bbb8b078677e9a0d8df3a027c4d8ea131130c4265f"
+      - CONFIG_UPDATEHUB_POLL_INTERVAL=1
+      - CONFIG_UPDATEHUB_CE=y
+      - CONFIG_UPDATEHUB_SERVER="10.5.3.67"


### PR DESCRIPTION
The conversion from DT_FLASH_AREA to FLASH_AREA macros don't add the
storage flash_map.h include file.

Fixes: #25332

Signed-off-by: Gerson Fernando Budke <gerson.budke@ossystems.com.br>