### PR TITLE
Bluetooth: Mesh: Remove NULL reference to cfg srv

### DIFF
--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -2660,7 +2660,8 @@ static void send_friend_status(struct bt_mesh_model *model,
 	struct bt_mesh_cfg_srv *cfg = model->user_data;
 
 	bt_mesh_model_msg_init(&msg, OP_FRIEND_STATUS);
-	net_buf_simple_add_u8(&msg, cfg->frnd);
+	net_buf_simple_add_u8(&msg,
+			      cfg ? cfg->frnd : BT_MESH_FRIEND_NOT_SUPPORTED);
 
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Friend Status");


### PR DESCRIPTION
Does a NULL check on the Config Server before reading its friend field
in send_friend_status.

Fixes #23177.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>