### PR TITLE
[backport v1.14] Bluetooth: controller: legacy: Fix slave latency cancel race

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -4535,6 +4535,14 @@ static inline void isr_close_conn(void)
 			_radio.conn_curr->slave.window_widening_event_us = 0U;
 			_radio.conn_curr->slave.window_size_event_us = 0U;
 
+			/* If no tx buffers in connection context, check for any
+			 * new enqueued tx buffers and route them into
+			 * connection context.
+			 */
+			if (!_radio.conn_curr->pkt_tx_head) {
+				packet_tx_enqueue(0xFF);
+			}
+
 			/* apply latency if no more data */
 			if (_radio.conn_curr->pkt_tx_head) {
 				struct pdu_data *pdu_data_tx;


### PR DESCRIPTION
Fix missing transmit buffer demutiplexing before checking if
slave latency needs to be maintained or cancelled.

This bug was detected when new transmit buffer was enqueued
overlapping with on-air radio transmission of empty PDU
preceding the handling of radio event done.

Symptoms of this bug being data transmission latency of upto
slave latency plus one times connection interval.

Fixes #25350.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>