### PR TITLE
manifest: fixed fail to upgrade nRF target using nRF Connect 

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -89,7 +89,7 @@ manifest:
       revision: e88113bbebe34ff2ccc6627ffae885cfeed6fdfd
       path: bootloader/mcuboot
     - name: mcumgr
-      revision: 1f5234cad902aea6c4db073f22663fc8f003d12d
+      revision: 5885efb7cabf7b566577b73129c9d277d7d8848d
       path: modules/lib/mcumgr
     - name: net-tools
       revision: 1c4fdba512b268033a4cf926bddd323866c3261a


### PR DESCRIPTION
fixes #24706

Fixed issue of possible try to erase non page aligned
size of flash while serving image write command.
The new version has this bug fixed.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>

do not merge without a valid SHA!
~~https://github.com/zephyrproject-rtos/mcumgr/pull/22~~
https://github.com/zephyrproject-rtos/mcumgr/pull/23