### PR TITLE
Bluetooth: Mesh: Friend with unknown appkey

### DIFF
--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -911,9 +911,11 @@ static int sdu_recv_unseg(struct bt_mesh_net_rx *rx, u8_t hdr,
 		return 0;
 	}
 
-	BT_WARN("No matching AppKey");
+	if (rx->local_match) {
+		BT_WARN("No matching AppKey");
+	}
 
-	return -EINVAL;
+	return 0;
 }
 
 static int sdu_recv_seg(struct seg_rx *seg, u8_t hdr, u8_t aszmic,
@@ -1005,9 +1007,11 @@ static int sdu_recv_seg(struct seg_rx *seg, u8_t hdr, u8_t aszmic,
 		return 0;
 	}
 
-	BT_WARN("No matching AppKey");
+	if (rx->local_match) {
+		BT_WARN("No matching AppKey");
+	}
 
-	return -EINVAL;
+	return 0;
 }
 
 static struct seg_tx *seg_tx_lookup(u16_t seq_zero, u8_t obo, u16_t addr)


### PR DESCRIPTION
Ensures that friend messages are enqueued, even if the packet is
received with an appkey is unknown to the friend. Previously, sdu_recv
would return EINVAL if the appkey was unknown, which would prevent the
lower transport layer from adding the packet to the friend queue. This
is irrelevant for the logic in lower transport, and should not be
returned as an error.

Fixes #24014.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>