### PR TITLE
Bluetooth: controller: split: Fix slave latency cancel race

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1058,6 +1058,10 @@ void ull_conn_done(struct node_rx_event_done *done)
 			ull_slave_done(done, &ticks_drift_plus,
 				       &ticks_drift_minus);
 
+			if (!conn->tx_head) {
+				ull_conn_tx_demux(UINT8_MAX);
+			}
+
 			if (conn->tx_head || memq_peek(lll->memq_tx.head,
 						       lll->memq_tx.tail,
 						       NULL)) {


### PR DESCRIPTION
Fix missing transmit buffer demutiplexing before checking if
slave latency needs to be maintained or cancelled.

This bug was detected when new transmit buffer was enqueued
overlapping with on-air radio transmission of empty PDU
preceding the handling of radio event done.

Symptoms of this bug being data transmission latency of upto
slave latency plus one times connection interval.

Fixes #25350.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>