### PR TITLE
Bluetooth: Mesh: Transport seg with few adv bufs

### DIFF
--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -425,6 +425,7 @@ static void seg_tx_send_unacked(struct seg_tx *tx)
 	}
 
 	tx->seg_o = 0U;
+	tx->attempts--;
 
 end:
 	if (!tx->seg_pending) {
@@ -433,7 +434,6 @@ end:
 	}
 
 	tx->sending = 0U;
-	tx->attempts--;
 }
 
 static void seg_retransmit(struct k_work *work)


### PR DESCRIPTION
Fixes bug where the transport segmented tx would decrement the attempt
counter every time it ran out of buffers. If transport ran out of
buffers 4 times before the sending could complete, the transfer would
end prematurely.

Moves the attempt decrement to only execute when all segments have been
sent.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>