### PR TITLE
Bluetooth: controller: split: include proper header file

### DIFF
--- a/subsys/bluetooth/shell/ll.c
+++ b/subsys/bluetooth/shell/ll.c
@@ -119,7 +119,7 @@ int cmd_test_end(const struct shell *shell, size_t  argc, char *argv[])
 #endif /* CONFIG_BT_CTLR_DTM */
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-#include "../controller/ll_sw/ll_adv_aux.h"
+#include "../controller/ll_sw/ull_adv_aux.h"
 #include "../controller/ll_sw/lll.h"
 
 #define OWN_ADDR_TYPE 1


### PR DESCRIPTION
After removal of legacy controller ll_adv_aux.h does not exist anymore.
This is fixed in this PR by including ull_adv_aux.h instead.
The error only shows up when Advertisement Extensions are enabled
in the LL (CONFIG_BT_CTLR_ADV_EXT=y)

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>