### PR TITLE
usb: doc: Add note about cdc+dfu Windows OS exception.

### DIFF
--- a/samples/subsys/usb/cdc_acm/overlay-composite-cdc-dfu.conf
+++ b/samples/subsys/usb/cdc_acm/overlay-composite-cdc-dfu.conf
@@ -1,5 +1,10 @@
 # Overlay file for composite configuration
 # CDC ACM + USB DFU
+#
+# This composite configuration may not work for Windows OS Host.
+# Windows OS does not send reset after DFU_DETACH request
+# (does not re-enumerates) and thus make it unable for the device
+# to restart in DFU mode.
 
 CONFIG_USB_COMPOSITE_DEVICE=y
 


### PR DESCRIPTION
Add a note for composite (CDC+DFU) device overlay.
Composite device CDC+DFU may not work with Windows OS host.
Windows OS does not send reset after DFU_DETACH request
(does not re-enumerates) and thus make it unable for
the device to restart in DFU mode.

Closes #23337.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>