### PR TITLE
doc: fix board name in DPS310 sample

### DIFF
--- a/samples/sensor/dps310/README.rst
+++ b/samples/sensor/dps310/README.rst
@@ -18,12 +18,12 @@ This sample application uses an DPS310 sensor connected to a board via I2C.
 Connect the sensor pins according to the connection diagram given in the
 `dps310 datasheet`_ at page 18 figure 7.
 
-Build and flash this sample (for example, for the nrf52840_pca10056 board) using
-these commands:
+Build and flash this sample (for example, for the nrf52840dk_nrf52840 board)
+using these commands:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/sensors/dps310
-   :board: nrf52840_pca10056
+   :board: nrf52840dk_nrf52840
    :goals: flash
    :compact:
 


### PR DESCRIPTION
The rename of the nrf52 boards was missed in the sample documentation.

Signed-off-by: Christoph Reiter <christoph.reiter@infineon.com>