### PR TITLE
tests: stack modifying and adding test case

### DIFF
--- a/tests/kernel/stack/stack/src/test_stack_contexts.c
+++ b/tests/kernel/stack/stack/src/test_stack_contexts.c
@@ -93,6 +93,17 @@ static void tstack_thread_isr(struct k_stack *pstack)
 
 /**
  * @brief Test to verify data passing between threads via stack
+ *
+ * @details Static define and Dynamic define stacks,
+ * Then initialize them.
+ * Current thread push or pop data item into the stack.
+ * Create a new thread pop or push data item into the stack.
+ * Controlled by semaphore.
+ * Verify data passing between threads via stack
+ * And verify stack can be define at compile time.
+ *
+ * @ingroup kernel_stack_tests
+ *
  * @see k_stack_init(), k_stack_push(), #K_STACK_DEFINE(x), k_stack_pop()
  */
 void test_stack_thread2thread(void)


### PR DESCRIPTION
1.test_single_stack_play(), test_dual_stack_play(), test_isr_stack_play()
Test that data passing between thread and ISR by using dual stack or single stack, and add some comments to describe it.
2.test_stack_pop_can_wait()
There is no timeout parameter in API k_stack_push(), and the test point is to make pop can wait
when empty, as you see, I used multithreads to implement this point.

Signed-off-by: Ningx Zhao ningx.zhao@intel.com