### PR TITLE
scripts: net: Fix incorrect error messages

### DIFF
--- a/scripts/net/run-sample-tests.sh
+++ b/scripts/net/run-sample-tests.sh
@@ -21,9 +21,7 @@ check_dirs ()
     then
 	echo '$ZEPHYR_BASE is unset' >&2
 	ret_zephyr=1
-    fi
-
-    if [ ! -d "$ZEPHYR_BASE" ]
+    elif [ ! -d "$ZEPHYR_BASE" ]
     then
 	echo '$ZEPHYR_BASE is set, but it is not a directory' >&2
 	ret_zephyr=1
@@ -55,9 +53,7 @@ check_dirs ()
     then
 	echo '$NET_TOOLS_BASE is unset, no net-tools found' >&2
 	ret_net_tools=1
-    fi
-
-    if [ ! -d "$NET_TOOLS_BASE" ]
+    elif [ ! -d "$NET_TOOLS_BASE" ]
     then
 	echo '$NET_TOOLS_BASE set, but it is not a directory' >&2
 	ret_net_tools=1


### PR DESCRIPTION
If environment variables ZEPHYR_BASE or NET_TOOLS_BASE are unset, an
incorrect message is printed saying that "it is set, but it is not a
directory":

$ZEPHYR_BASE is unset
$ZEPHYR_BASE is set, but it is not a directory
$NET_TOOLS_BASE is unset, no net-tools found
$NET_TOOLS_BASE set, but it is not a directory

This patch fixes that issue.

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>