### PR TITLE
Revert "boards: arm: adafruit_feather_m0_basic_proto: Set flash offset"

### DIFF
--- a/boards/arm/adafruit_feather_m0_basic_proto/board.cmake
+++ b/boards/arm/adafruit_feather_m0_basic_proto/board.cmake
@@ -2,6 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(bossac "--offset=0x2000")
-
 include(${ZEPHYR_BASE}/boards/common/bossac.board.cmake)


### PR DESCRIPTION
The PR to be reverted breaks flashing with currently used Zephyr SDK (0.11.2). The SDK uses an older version of bossac which doesn't support the `---offset` argument (instead offsetting things by itself). I suspect the submitter of the original PR tested their code on a custom setup with a different version of bossac.

Reverts zephyrproject-rtos/zephyr#24738

Signed-off-by: Kuba Sanak <contact@kuba.fyi>