### PR TITLE
tests/drivers/counter/counter_basic_api: allow equality in assert

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -276,7 +276,7 @@ static void alarm_handler(struct device *dev, u8_t chan_id, u32_t counter,
 			(counter + top - now) : (counter - now);
 	}
 
-	zassert_true(diff < counter_us_to_ticks(dev, processing_limit_us),
+	zassert_true(diff <= counter_us_to_ticks(dev, processing_limit_us),
 			"Unexpected distance between reported alarm value(%u) "
 			"and actual counter value (%u), top:%d (processing "
 			"time limit (%d us) might be exceeded?",


### PR DESCRIPTION
Since introduction of #24374, test **tests/drivers/counter/counter_basic_api**  fails on STM32 boards.
Due to 1Hz frequency of RTC used, the 'diff' could be 0.
But then 'counter_us_to_ticks(dev, processing_limit_us)' is also 0.
We should allow the equality in the assert.

fixes #25363