### PR TITLE
Bluetooth: Mesh: Fail init on model init error

### DIFF
--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -489,6 +489,10 @@ struct bt_mesh_model_cb {
 	 *
 	 *  Called on every model instance during mesh initialization.
 	 *
+	 *  If any of the model init callbacks return an error, the Mesh
+	 *  subsystem initialization will be aborted, and the error will be
+	 *  returned to the caller of @ref bt_mesh_init.
+	 *
 	 *  @param model Model to be initialized.
 	 *
 	 *  @return 0 on success, error otherwise.

--- a/subsys/bluetooth/mesh/health_srv.c
+++ b/subsys/bluetooth/mesh/health_srv.c
@@ -389,10 +389,6 @@ static int health_srv_init(struct bt_mesh_model *model)
 	struct bt_mesh_health_srv *srv = model->user_data;
 
 	if (!srv) {
-		if (!bt_mesh_model_in_primary(model)) {
-			return 0;
-		}
-
 		BT_ERR("No Health Server context provided");
 		return -EINVAL;
 	}


### PR DESCRIPTION
Adds propagation of error returns from the model init callbacks in
Access, and removing any other checks for successful init in the
foundation models.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>