### PR TITLE
driver/counter/counter_ll_stm32_rtc.c: Add 1 tick to alarm

### DIFF
--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -143,7 +143,12 @@ static int rtc_stm32_set_alarm(struct device *dev, u8_t chan_id,
 	data->user_data = alarm_cfg->user_data;
 
 	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) == 0) {
-		ticks += now;
+		/* Add +1 in order to compensate the partially started tick.
+		 * Alarm will expire between requested ticks and ticks+1.
+		 * In case only 1 tick is requested, it will avoid
+		 * that tick+1 event occurs before alarm setting is finished.
+		 */
+		ticks += now + 1;
 	}
 
 	LOG_DBG("Set Alarm: %d\n", ticks);

--- a/samples/drivers/counter/alarm/README.rst
+++ b/samples/drivers/counter/alarm/README.rst
@@ -9,6 +9,10 @@ This sample provides an example of alarm application using counter API.
 It sets an alarm with an initial delay of 2 seconds. At each alarm
 expiry, a new alarm is configured with a delay multiplied by 2.
 
+.. note::
+   In case of 1Hz frequency (RTC for example), precision is 1 second.
+   Therefore, the sample output may differ in 1 second
+
 Requirements
 ************
 

--- a/samples/drivers/counter/alarm/sample.yaml
+++ b/samples/drivers/counter/alarm/sample.yaml
@@ -13,5 +13,5 @@ tests:
             - "Counter alarm sample"
             - "Set alarm in 2 sec"
             - "!!! Alarm !!!"
-            - "Now: 2"
+            - "Now: [2|3]"
     depends_on: counter


### PR DESCRIPTION
Add +1 tick to alarm in order to compensate the partially started tick.
Alarm will expire between requested ticks and ticks+1.
In case only 1 tick is requested, it will avoid that +1 Tick event occurs
before alarm setting is finished.

Fixes #25366