### PR TITLE
test/drivers/gpio/gpio_basic_api: disable interrupt at end of test

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/src/test_deprecated.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_deprecated.c
@@ -137,10 +137,12 @@ static int test_callback(gpio_flags_t int_flags)
 
 pass_exit:
 	gpio_remove_callback(dev, &drv_data->gpio_cb);
+	gpio_pin_configure(dev, PIN_IN, GPIO_INT_DISABLE);
 	return TC_PASS;
 
 err_exit:
 	gpio_remove_callback(dev, &drv_data->gpio_cb);
+	gpio_pin_configure(dev, PIN_IN, GPIO_INT_DISABLE);
 	return TC_FAIL;
 }
 


### PR DESCRIPTION
When switching from rising edge to falling edge of test **test_gpio_deprecated()**,
because EXTIcallback is already configured (from rising edge test),
the pin configuration abort for EBUSY reason.
It is necessary to disable interrupt at end of test, so that next test will start with clean configuration.

Fixes #25369