### PR TITLE
sample/drivers/counter/alarm: adapt test to driver change PR #25367

### DIFF
--- a/samples/drivers/counter/alarm/README.rst
+++ b/samples/drivers/counter/alarm/README.rst
@@ -8,6 +8,9 @@ Overview
 This sample provides an example of alarm application using counter API.
 It sets an alarm with an initial delay of 2 seconds. At each alarm
 expiry, a new alarm is configured with a delay multiplied by 2.
+.. note::
+   In case of 1Hz frequency (RTC for example), precision is 1 second.
+   Therefore, the sample output may differ in 1 second
 
 Requirements
 ************

--- a/samples/drivers/counter/alarm/sample.yaml
+++ b/samples/drivers/counter/alarm/sample.yaml
@@ -13,5 +13,5 @@ tests:
             - "Counter alarm sample"
             - "Set alarm in 2 sec"
             - "!!! Alarm !!!"
-            - "Now: 2"
+            - "Now: [2|3]"
     depends_on: counter


### PR DESCRIPTION
Due to counter driver implementation change introduced with PR #25367
"driver/counter/counter_ll_stm32_rtc.c: Add 1 tick to alarm"
It is necessary to adapt sample test (sanitycheck)
to take into consideration 1 tick precision/tolerance.

Fixes #25366