### PR TITLE
tests: mem protection tests updated tags

### DIFF
--- a/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_concept.c
+++ b/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_concept.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Intel Corporation
+ * Copyright (c) 2016, 2020 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_concept.c
+++ b/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_concept.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Intel Corporation
+ * Copyright (c) 2020 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,13 +17,13 @@
  *
  * @ingroup kernel_heap_tests
  *
- * @see k_malloc(), k_free()
- *
  * @details The 8 blocks of memory of size 16 bytes are allocated
  * by k_calloc() API. When allocated using k_calloc() the memory buffers
  * have to be zeroed. Check is done, if the blocks are memset to 0 and
  * read/write is allowed. The test is then teared up by freeing all the
  * blocks allocated.
+ *
+ * @see k_malloc(), k_free()
  */
 void test_mheap_malloc_align4(void)
 {

--- a/tests/kernel/mem_pool/mem_pool_api/src/test_mpool_api.c
+++ b/tests/kernel/mem_pool/mem_pool_api/src/test_mpool_api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Intel Corporation
+ * Copyright (c) 2016, 2020 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/kernel/mem_pool/mem_pool_api/src/test_mpool_api.c
+++ b/tests/kernel/mem_pool/mem_pool_api/src/test_mpool_api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Intel Corporation
+ * Copyright (c) 2020 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -197,6 +197,10 @@ void test_mpool_alloc_timeout(void)
 
 /**
  * @brief Validate allocation and free from system heap memory pool
+ *
+ * @details System shall support assigning the common system heap
+ * as its memory pool, also the kernel shall support freeing memory drawn
+ * from a thread's resource pool.
  *
  * @see k_thread_system_pool_assign(), z_thread_malloc(), k_free()
  */

--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -2,7 +2,7 @@
  * Parts derived from tests/kernel/fatal/src/main.c, which has the
  * following copyright and license:
  *
- * Copyright (c) 2020 Intel Corporation
+ * Copyright (c) 2017, 2020 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -2,7 +2,7 @@
  * Parts derived from tests/kernel/fatal/src/main.c, which has the
  * following copyright and license:
  *
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2020 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2020 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Intel Corporation
+ * Copyright (c) 2017, 2020 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/kernel/mem_protect/stackprot/src/main.c
+++ b/tests/kernel/mem_protect/stackprot/src/main.c
@@ -120,6 +120,14 @@ void test_stackprot(void)
 	print_loop(__func__);
 }
 
+/**
+ * @brief Test optional mechanism to detect stack overflow
+ *
+ * @details Test that the system provides an optional mechanism to detect
+ * when supervisor threads overflow stack memory buffer.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
 void test_create_alt_thread(void)
 {
 	/* Start thread */

--- a/tests/kernel/mem_slab/mslab/src/main.c
+++ b/tests/kernel/mem_slab/mslab/src/main.c
@@ -199,7 +199,9 @@ void test_slab_free_all_blocks(void **p)
  *
  * @ingroup kernel_memory_slab_tests
  *
- * @details This routine calls test_slab_get_all_blocks() to get all
+ * @details Verify that system allows for the definitions of boot-time
+ * memory regions.
+ * This routine calls test_slab_get_all_blocks() to get all
  * memory blocks from the map and calls test_slab_free_all_blocks()
  * to free all memory blocks. It also tries to wait (with and without
  * timeout) for a memory block.


### PR DESCRIPTION
Update current tests Doxygen tags to make them more informative for tests:
-test_mslab()
-test_create_alt_thread()
-test_sys_heap_mem_pool_assign()

For QA is very important to understand goal of each test. I think, adding informative Doxygen tags to the test will help developers to understand Zephyr testing system better.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>