### PR TITLE
soc: stm32: stm32l0: add stm32l011x4 support

### DIFF
--- a/dts/arm/st/l0/stm32l011.dtsi
+++ b/dts/arm/st/l0/stm32l011.dtsi
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2019-2020 Grinn
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/l0/stm32l0.dtsi>
+
+/ {
+	soc {
+		eeprom: eeprom@8080000{
+			reg = <0x08080000 512>;
+		};
+	};
+};

--- a/dts/arm/st/l0/stm32l011X4.dtsi
+++ b/dts/arm/st/l0/stm32l011X4.dtsi
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2019 Grinn
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/l0/stm32l011.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(2)>;
+	};
+
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};

--- a/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.stm32l011xx
+++ b/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.stm32l011xx
@@ -1,0 +1,14 @@
+# ST Microelectronics STM32L011XX MCU
+#
+# Copyright (c) 2019-2020 Grinn
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_STM32L011XX
+
+config SOC
+	default "stm32l011xx"
+
+config NUM_IRQS
+	default 32
+
+endif # SOC_STM32L011XX

--- a/soc/arm/st_stm32/stm32l0/Kconfig.soc
+++ b/soc/arm/st_stm32/stm32l0/Kconfig.soc
@@ -7,6 +7,9 @@ choice
 	prompt "STM32L0x MCU Selection"
 	depends on SOC_SERIES_STM32L0X
 
+config SOC_STM32L011XX
+	bool "STM32L011XX"
+
 config SOC_STM32L053XX
 	bool "STM32L053XX"
 


### PR DESCRIPTION
Those MCUs have 2KB RAM and 16KB FLASH memory, but they are still
powerful enough to run small configuration of Zephyr RTOS.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>