### PR TITLE
tests: timer_api: fix assertion in test_timer_remaining()

### DIFF
--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -544,7 +544,7 @@ void test_timer_remaining(void)
 	zassert_true(rem_ms <= (DURATION / 2) + k_ticks_to_ms_floor64(1),
 		     NULL);
 
-	zassert_true(rem_ticks <= dur_ticks / 2, NULL);
+	zassert_true(rem_ticks <= ((dur_ticks / 2) + 1), NULL);
 
 	/* Note +1 tick precision: even though we're calcluating in
 	 * ticks, we're waiting in k_busy_wait(), not for a timer


### PR DESCRIPTION
This commit fixes the assertion in test_timer_remaining() that checks
whether the remaining ticks on a timer is less than or equal to half of
the timer duration after a busy wait of that time. If the timer
duration corresponds to an odd number of ticks, 1 should be added to
the upper bound given k_timer_remaining_ticks() returns
`<ticks til next deadline> - <elapsed ticks>`,
and `<elapsed ticks>` is truncated to closest integer tick count.

For example, if
```
    dur_ticks = 3277
    <ticks til next deadline> = 3277
    <elapsed ticks> = 1638.5 rounded to 1638
```

rem_ticks would be 1639, which is 1 greater than dur_ticks/2.

Fixes #25331

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>