### PR TITLE
samples: net: wifi: Enable esp32 offload tests

### DIFF
--- a/samples/net/wifi/sample.yaml
+++ b/samples/net/wifi/sample.yaml
@@ -7,3 +7,6 @@ sample:
 tests:
   sample.net.wifi:
     platform_whitelist: cc3220sf_launchxl disco_l475_iot1
+  sample.net.wifi.esp_8266:
+    extra_args: SHIELD=esp_8266
+    platform_whitelist: frdm_k64f sam4e_xpro disco_l475_iot1


### PR DESCRIPTION
The esp32 offload driver is used by shield esp_8266. This shield doesn't have tests enabled to ensures that dependencies are ok. This enables wifi sample to validate shield esp_8266 on CI and consequently esp32 offload driver.

Fixes: #25386