### PR TITLE
drivers: eth: stm32: Fix driver crash caused by RX IRQ trigger

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -401,10 +401,6 @@ static int eth_initialize(struct device *dev)
 		return -EIO;
 	}
 
-	__ASSERT_NO_MSG(cfg->config_func != NULL);
-
-	cfg->config_func();
-
 	heth = &dev_data->heth;
 
 #if defined(CONFIG_ETH_STM32_HAL_RANDOM_MAC)
@@ -480,6 +476,10 @@ static void eth_iface_init(struct net_if *iface)
 	 */
 	if (dev_data->iface == NULL) {
 		dev_data->iface = iface;
+
+		/* Now that the iface is setup, we are safe to enable IRQs. */
+		__ASSERT_NO_MSG(DEV_CFG(dev)->config_func() != NULL);
+		DEV_CFG(dev)->config_func();
 	}
 
 	/* Register Ethernet MAC Address with the upper layer */


### PR DESCRIPTION
All initialization of the Ethernet interface is done in the eth_initialize function which is invoked by the boot code. This function sets up DMA, programs the Ethernet module and enables IRQs. However, this function does not setup "netif" interface info which is done when the ethernet device is enumerated by the NET stack via the "iface_api.init" func. However, after the eth_initialize func is called, it is possible that the system receives RX interrupts, and the "rx_thread" accesses the "netif" pointer to get iface info. However, because the "netif" info is not necessarily populated at this time, we get a crash (as OS does NULL access).

Fixed by enabling Ethernet IRQ after the interface is properly setup.

Tested on Nucleo F767Zi board.

Fixes #25408

Signed-off-by: Bilal Wasim <bilalwasim676@gmail.com>