### PR TITLE
drivers: pwm: mcux_ftm: allow configuring the clock prescaler

### DIFF
--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -153,6 +153,8 @@ static const struct pwm_driver_api mcux_ftm_driver_api = {
 	.get_cycles_per_sec = mcux_ftm_get_cycles_per_sec,
 };
 
+#define TO_FTM_PRESCALE_DIVIDE(val) _DO_CONCAT(kFTM_Prescale_Divide_, val)
+
 #define FTM_DEVICE(n) \
 	static const struct mcux_ftm_config mcux_ftm_config_##n = { \
 		.base = (FTM_Type *)DT_INST_REG_ADDR(n),\
@@ -160,7 +162,7 @@ static const struct pwm_driver_api mcux_ftm_driver_api = {
 		.clock_subsys = (clock_control_subsys_t) \
 			DT_INST_CLOCKS_CELL(n, name), \
 		.ftm_clock_source = kFTM_FixedClock, \
-		.prescale = kFTM_Prescale_Divide_16, \
+		.prescale = TO_FTM_PRESCALE_DIVIDE(DT_INST_PROP(n, prescaler)),\
 		.channel_count = FSL_FEATURE_FTM_CHANNEL_COUNTn((FTM_Type *) \
 			DT_INST_REG_ADDR(n)), \
 		.mode = kFTM_EdgeAlignedPwm, \

--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -308,6 +308,7 @@
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40038000 0x98>;
 			interrupts = <42 0>;
+			prescaler = <16>;
 			label = "FTM_0";
 			status = "disabled";
 		};
@@ -316,6 +317,7 @@
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40039000 0x98>;
 			interrupts = <43 0>;
+			prescaler = <16>;
 			label = "FTM_1";
 			status = "disabled";
 		};
@@ -324,6 +326,7 @@
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x4003a000 0x98>;
 			interrupts = <44 0>;
+			prescaler = <16>;
 			label = "FTM_2";
 			status = "disabled";
 		};
@@ -332,6 +335,7 @@
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x400b9000 0x98>;
 			interrupts = <71 0>;
+			prescaler = <16>;
 			label = "FTM_3";
 			status = "disabled";
 		};

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -388,6 +388,7 @@
 			reg = <0x40038000 0x98>;
 			interrupts = <42 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
+			prescaler = <16>;
 			label = "FTM_0";
 			status = "disabled";
 		};
@@ -397,6 +398,7 @@
 			reg = <0x40039000 0x98>;
 			interrupts = <43 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
+			prescaler = <16>;
 			label = "FTM_1";
 			status = "disabled";
 		};
@@ -406,6 +408,7 @@
 			reg = <0x4003a000 0x98>;
 			interrupts = <44 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
+			prescaler = <16>;
 			label = "FTM_2";
 			status = "disabled";
 		};
@@ -415,6 +418,7 @@
 			reg = <0x400b9000 0x98>;
 			interrupts = <71 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
+			prescaler = <16>;
 			label = "FTM_3";
 			status = "disabled";
 		};

--- a/dts/arm/nxp/nxp_k8x.dtsi
+++ b/dts/arm/nxp/nxp_k8x.dtsi
@@ -279,6 +279,7 @@
 			reg = <0x40038000 0x1000>;
 			interrupts = <42 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
+			prescaler = <16>;
 			label = "FTM_0";
 			status = "disabled";
 		};
@@ -288,6 +289,7 @@
 			reg = <0x40039000 0x1000>;
 			interrupts = <43 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
+			prescaler = <16>;
 			label = "FTM_1";
 			status = "disabled";
 		};
@@ -297,6 +299,7 @@
 			reg = <0x4003a000 0x1000>;
 			interrupts = <44 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
+			prescaler = <16>;
 			label = "FTM_2";
 			status = "disabled";
 		};
@@ -306,6 +309,7 @@
 			reg = <0x400b9000 0x1000>;
 			interrupts = <71 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
+			prescaler = <16>;
 			label = "FTM_3";
 			status = "disabled";
 		};

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -416,6 +416,7 @@
 			reg = <0x40038000 0x1000>;
 			interrupts = <42 0>;
 			clocks = <&pcc 0xe0 KINETIS_PCC_SRC_FIRC_ASYNC>;
+			prescaler = <16>;
 			label = "FTM_0";
 			status = "disabled";
 		};
@@ -425,6 +426,7 @@
 			reg = <0x40039000 0x1000>;
 			interrupts = <43 0>;
 			clocks = <&pcc 0xe4 KINETIS_PCC_SRC_FIRC_ASYNC>;
+			prescaler = <16>;
 			label = "FTM_1";
 			status = "disabled";
 		};
@@ -434,6 +436,7 @@
 			reg = <0x4003a000 0x1000>;
 			interrupts = <44 0>;
 			clocks = <&pcc 0xe8 KINETIS_PCC_SRC_FIRC_ASYNC>;
+			prescaler = <16>;
 			label = "FTM_2";
 			status = "disabled";
 		};
@@ -443,6 +446,7 @@
 			reg = <0x40026000 0x1000>;
 			interrupts = <71 0>;
 			clocks = <&pcc 0x98 KINETIS_PCC_SRC_FIRC_ASYNC>;
+			prescaler = <16>;
 			label = "FTM_3";
 			status = "disabled";
 		};

--- a/dts/arm/nxp/nxp_kv5x.dtsi
+++ b/dts/arm/nxp/nxp_kv5x.dtsi
@@ -203,6 +203,7 @@
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40038000 0x1000>;
 			interrupts = <42 0>;
+			prescaler = <16>;
 			label = "FTM_0";
 			status = "disabled";
 		};
@@ -211,6 +212,7 @@
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40039000 0x1000>;
 			interrupts = <43 0>;
+			prescaler = <16>;
 			label = "FTM_1";
 			status = "disabled";
 		};
@@ -219,6 +221,7 @@
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x4003a000 0x1000>;
 			interrupts = <53 0>;
+			prescaler = <16>;
 			label = "FTM_2";
 			status = "disabled";
 		};
@@ -227,6 +230,7 @@
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40026000 0x1000>;
 			interrupts = <71 0>;
+			prescaler = <16>;
 			label = "FTM_3";
 			status = "disabled";
 		};

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -282,6 +282,7 @@
 			reg = <0x40038000 0x98>;
 			interrupts = <42 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
+			prescaler = <16>;
 			label = "FTM_0";
 			status = "disabled";
 		};
@@ -291,6 +292,7 @@
 			reg = <0x40039000 0x98>;
 			interrupts = <43 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
+			prescaler = <16>;
 			label = "FTM_1";
 			status = "disabled";
 		};
@@ -300,6 +302,7 @@
 			reg = <0x4003a000 0x98>;
 			interrupts = <44 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
+			prescaler = <16>;
 			label = "FTM_2";
 			status = "disabled";
 		};

--- a/dts/bindings/arm/nxp,kinetis-ftm.yaml
+++ b/dts/bindings/arm/nxp,kinetis-ftm.yaml
@@ -13,3 +13,17 @@ properties:
 
     interrupts:
       required: true
+
+    prescaler:
+      type: int
+      required: true
+      enum:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 16
+        - 32
+        - 64
+        - 128
+      description: Input clock prescaler


### PR DESCRIPTION
Allow configuring the clock prescaler divider for the NXP Kinetis FlexTimer. Setting the prescaler to a lower value allows for much higher resolution/accuracy for the generated PWM waveforms.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>