### PR TITLE
boards: arm: nucleo_f767zi: Add support for Hardware RNG

### DIFF
--- a/boards/arm/nucleo_f767zi/doc/index.rst
+++ b/boards/arm/nucleo_f767zi/doc/index.rst
@@ -120,6 +120,8 @@ features:
 +-----------+------------+-------------------------------------+
 | ADC       | on-chip    | ADC Controller                      |
 +-----------+------------+-------------------------------------+
+| RNG       | on-chip    | True Random number generator        |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
@@ -108,3 +108,7 @@
 &adc1 {
 	status = "okay";
 };
+
+&rng {
+	status = "okay";
+};

--- a/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f767xx
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f767xx
@@ -11,4 +11,11 @@ config SOC
 config NUM_IRQS
 	default 110
 
+if ENTROPY_GENERATOR
+
+config ENTROPY_STM32_RNG
+	default y
+
+endif # ENTROPY_GENERATOR
+
 endif # SOC_STM32F767XX


### PR DESCRIPTION
Added / Tested support for RNG on the STM32F767ZI nucleo board. Updated the SoC defconfig to auto-enable the driver when ENTROPY_GENERATOR is enabled, and updated the board README.

Signed-off-by: Bilal Wasim <bilalwasim676@gmail.com>