### PR TITLE
doc: updated to reflect changes introduced with Zephyr CMake package

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -132,16 +132,15 @@ folder, here are the commands to generate the html content locally:
 .. code-block:: console
 
    # On Linux/macOS
-   cd ~/zephyr
-   source zephyr-env.sh
-   mkdir -p doc/_build && cd doc/_build
+   cd ~/zephyr/doc
    # On Windows
-   cd %userprofile%\zephyr
-   zephyr-env.cmd
-   mkdir doc\_build & cd doc/_build
+   cd %userprofile%\zephyr\doc
 
    # Use cmake to configure a Ninja-based build system:
-   cmake -GNinja ..
+   cmake -GNinja -B_build .
+
+   # Enter the build directory
+   cd _build
 
    # To generate HTML output, run ninja on the generated build system:
    ninja htmldocs
@@ -181,7 +180,6 @@ there:
 .. code-block:: console
 
    cd ~/zephyr
-   source zephyr-env.sh
 
    # To generate HTML output
    make htmldocs
@@ -227,7 +225,6 @@ To enable this mode, set the following option when invoking cmake::
 or invoke make with the following target::
 
    cd ~/zephyr
-   source zephyr-env.sh
 
    # To generate HTML output without detailed Kconfig
    make htmldocs-fast

--- a/doc/guides/modules.rst
+++ b/doc/guides/modules.rst
@@ -131,10 +131,10 @@ section.
    .. code-block:: cmake
 
       set(ZEPHYR_MODULES <path-to-module1> <path-to-module2> [...])
-      include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+      find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
-   If you choose this option, make sure to set the variable **before** including
-   the boilerplate file, as shown above.
+   If you choose this option, make sure to set the variable **before**  calling
+   ``find_package(Zephyr ...)``, as shown above.
 
 #. In a separate CMake script which is pre-loaded to populate the CMake cache,
    like this:


### PR DESCRIPTION
This commit updates the Zephyr documentation with changes introduced
by Zephyr CMake package.

It removes 'zephyr-env.sh/cmd' where no longer needed, and updates
boilerplate inclusion to find_package.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>