### PR TITLE
Tcp2 data retransmit

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -635,6 +635,9 @@ static struct tcp *tcp_conn_alloc(void)
 
 	conn->win = tcp_window;
 
+	conn->seq = (IS_ENABLED(CONFIG_NET_TEST_PROTOCOL) ||
+		     IS_ENABLED(CONFIG_NET_TEST)) ? 0 : sys_rand32_get();
+
 	sys_slist_init(&conn->send_queue);
 
 	k_delayed_work_init(&conn->send_timer, tcp_send_process);

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -433,8 +433,9 @@ static bool tcp_options_check(struct tcp_options *recv_options,
 				goto end;
 			}
 
-			recv_options->mss = opt;
+			recv_options->mss = ntohs(*((u16_t *)(options + 2)));
 			recv_options->mss_found = true;
+			NET_DBG("MSS=%hu", recv_options->mss);
 			break;
 		case TCPOPT_WINDOW:
 			if (opt_len != 3) {

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -930,7 +930,7 @@ next_state:
 				tcp_data_get(conn, pkt);
 				conn_ack(conn, + len);
 				tcp_out(conn, ACK);
-			} else if (th_seq(th) < conn->ack) {
+			} else if (net_tcp_seq_greater(conn->ack, th_seq(th))) {
 				tcp_out(conn, ACK); /* peer has resent */
 			}
 		}

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -299,6 +299,12 @@ static void tcp_send_process(struct k_work *work)
 
 		pkt = forget ? tcp_slist(&conn->send_queue, get, struct net_pkt,
 						next) : tcp_pkt_clone(pkt);
+		if (!pkt) {
+			NET_ERR("net_pkt alloc failure");
+			tcp_conn_unref(conn);
+			return;
+		}
+
 		tcp_send(pkt);
 
 		if (forget == false && !k_delayed_work_remaining_get(

--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -160,7 +160,8 @@ struct tcp { /* TCP connection */
 	u32_t ack;
 	union tcp_endpoint src;
 	union tcp_endpoint dst;
-	u16_t win;
+	u16_t recv_win;
+	u16_t send_win;
 	struct tcp_options recv_options;
 	struct k_delayed_work send_timer;
 	sys_slist_t send_queue;

--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -169,6 +169,11 @@ struct tcp { /* TCP connection */
 	struct tcp_options recv_options;
 	struct k_delayed_work send_timer;
 	sys_slist_t send_queue;
+	struct k_delayed_work send_data_timer;
+	struct net_pkt *send_data;
+	size_t send_data_total;
+	u8_t send_data_retries;
+	int unacked_len;
 	bool in_retransmission;
 	size_t send_retries;
 	struct k_delayed_work timewait_timer;

--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -77,6 +77,10 @@
 #define conn_ack(_conn, _req) (_conn)->ack += (_req)
 #endif
 
+#define conn_mss(_conn)					\
+	((_conn)->recv_options.mss_found ?		\
+	 (_conn)->recv_options.mss : NET_IPV6_MTU)
+
 #define conn_state(_conn, _s)						\
 ({									\
 	NET_DBG("%s->%s",						\

--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -32,32 +32,38 @@
 #define tcp_free(_ptr) k_free(_ptr)
 #endif
 
-#if IS_ENABLED(CONFIG_NET_TEST_PROTOCOL)
+#define TCP_PKT_ALLOC_TIMEOUT K_MSEC(100)
+
+#if defined(CONFIG_NET_TEST_PROTOCOL)
+#define tcp_pkt_clone(_pkt) tp_pkt_clone(_pkt, tp_basename(__FILE__), __LINE__)
+#define tcp_pkt_unref(_pkt) tp_pkt_unref(_pkt, tp_basename(__FILE__), __LINE__)
+#else
+#define tcp_pkt_clone(_pkt) net_pkt_clone(_pkt, TCP_PKT_ALLOC_TIMEOUT)
+#define tcp_pkt_unref(_pkt) net_pkt_unref(_pkt)
+#define tp_pkt_alloc(args...)
+#endif
+
+#define tcp_pkt_ref(_pkt) net_pkt_ref(_pkt)
 #define tcp_pkt_alloc(_conn, _len)					\
 ({									\
-	sa_family_t _family = net_context_get_family((_conn)->context);	\
-	struct net_pkt *_pkt = net_pkt_alloc_with_buffer((_conn)->iface,\
-							 (_len),	\
-							 _family,	\
-							 IPPROTO_TCP,	\
-							 K_NO_WAIT);	\
+	struct net_pkt *_pkt;						\
+									\
+	if ((_len) > 0) {						\
+		_pkt = net_pkt_alloc_with_buffer(			\
+			(_conn)->iface,					\
+			(_len),						\
+			net_context_get_family((_conn)->context),	\
+			IPPROTO_TCP,					\
+			TCP_PKT_ALLOC_TIMEOUT);				\
+	} else {							\
+		_pkt = net_pkt_alloc(TCP_PKT_ALLOC_TIMEOUT);		\
+	}								\
 									\
 	tp_pkt_alloc(_pkt, tp_basename(__FILE__), __LINE__);		\
 									\
 	_pkt;								\
 })
-#define tcp_pkt_clone(_pkt) tp_pkt_clone(_pkt, tp_basename(__FILE__), __LINE__)
-#define tcp_pkt_unref(_pkt) tp_pkt_unref(_pkt, tp_basename(__FILE__), __LINE__)
-#else
-#define tcp_pkt_alloc(_conn, _len)					\
-	net_pkt_alloc_with_buffer((_conn)->iface, (_len),		\
-				  net_context_get_family((_conn)->context), \
-				  IPPROTO_TCP, K_NO_WAIT)
 
-#define tcp_pkt_clone(_pkt) net_pkt_clone(_pkt, K_NO_WAIT)
-#define tcp_pkt_unref(_pkt) net_pkt_unref(_pkt)
-#endif
-#define tcp_pkt_ref(_pkt) net_pkt_ref(_pkt)
 
 #if IS_ENABLED(CONFIG_NET_TEST_PROTOCOL)
 #define conn_seq(_conn, _req) \

--- a/tests/net/tcp2/src/main.c
+++ b/tests/net/tcp2/src/main.c
@@ -380,7 +380,6 @@ static int tester_send(struct device *dev, struct net_pkt *pkt)
 		zassert_true(false, "Undefined test case");
 	}
 
-	net_pkt_unref(pkt);
 	return 0;
 fail:
 	zassert_true(false, "%s failed", __func__);


### PR DESCRIPTION
In order to support the retransmission for the outgoing data:

1. The outgoing data packet is appended to the send_data queue
   in net_tcp_queue_data().

2. tcp_send_queued_data() is called and will use tcp_send_data()
   to sends queued but unsent data packet by packet
   until there's an unsent data and the receiver's window isn't full.

   tcp_send_queued_data() subscribes send_data_timer
   that will handle retrasmissions with tcp_resend_data().

3. tcp_send_data() peeks a single chunk of data from the send_data
   queue that will not exceed the maximum segment size
   until the the receiver's window is full.

   tcp_send_data() uses conn->seq and conn->unack_len as the sequence
   number for the TCP packet.

   conn->unacked_len is advanced on each send.

4. On data acknowledgment:

   - acknowledged amount of data is removed from the beginning
     of the send_data queue
   - conn->seq is advanced by the acknowledged amount
   - conn->unacked_len is decremented by the acknowledged amount
   - send_data_timer is cancelled
   - tcp_send_queued_data() is called to send queued but
     prevoiusly unsent data

5. On timeout, tcp_resend_data() will reset conn->unack_len,
   peek one packet from the beginning of the send_queue and resend,
   terminating the connection on retries exceeded.

   Meanwhile the outgoing data tcp_send_queued_data() is just
   appended to the send_data but not sent.

   In case of the acknowledgement, tcp_send_queued_data() will
   start sending multiple packets until the receiver's window
   is full.

A few tests are added into net-test-suites (but not yet included into sanity check run):

https://github.com/intel/net-test-suites/commit/7641cb64384e630f1a516b17ab103dc391767990
https://github.com/intel/net-test-suites/commit/58435c014789fa2e366203ad8c3564233d605fbe
https://github.com/intel/net-test-suites/commit/e7852836fc760c6f3be0c5748198cf1514c753d1
https://github.com/intel/net-test-suites/commit/48640d5c51d29a3682d8bc8b4a0f2ed8b7ca4c84