### PR TITLE
drivers: wifi: esp: Improvements to ESP driver

### DIFF
--- a/drivers/wifi/esp/Kconfig.esp
+++ b/drivers/wifi/esp/Kconfig.esp
@@ -42,12 +42,20 @@ config WIFI_ESP_WORKQ_THREAD_PRIORITY
 	help
 	  Priority of thread used for processing driver work queue items.
 
-config WIFI_ESP_PASSIVE_TCP
-	bool "Use passive TCP"
+config WIFI_ESP_PASSIVE_MODE
+	bool "Use passive mode"
 	help
 	  This lets the ESP handle the TCP window so that data can flow
 	  at a rate that the driver can handle. Without this, data might get
 	  lost if the driver cannot empty the device buffer quickly enough.
+
+config WIFI_ESP_RESET_TIMEOUT
+	int "Reset timeout"
+	default 3000
+	help
+	  How long to wait for device to become ready after AT+RST has been
+	  sent. This can vary with chipset (ESP8266/ESP32) and firmware
+	  version. This is ignored if a reset pin is configured.
 
 choice WIFI_ESP_AT_VERSION
 	prompt "AT version"

--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -448,8 +448,9 @@ MODEM_CMD_DIRECT_DEFINE(on_cmd_ciprecvdata)
 	} else if (*endptr == 0) {
 		ret = -EAGAIN;
 		goto out;
-	} else if (*endptr != ':') {
-		LOG_ERR("Invalid end of cmd: 0x%02x != 0x%02x", *endptr, ':');
+	} else if (*endptr != _CIPRECVDATA_END) {
+		LOG_ERR("Invalid end of cmd: 0x%02x != 0x%02x", *endptr,
+			_CIPRECVDATA_END);
 		ret = len;
 		goto out;
 	}
@@ -489,7 +490,7 @@ static void esp_recvdata_work(struct k_work *work)
 	int len = CIPRECVDATA_MAX_LEN, ret;
 	char cmd[32];
 	struct modem_cmd cmds[] = {
-		MODEM_CMD_DIRECT("+CIPRECVDATA,", on_cmd_ciprecvdata),
+		MODEM_CMD_DIRECT(_CIPRECVDATA, on_cmd_ciprecvdata),
 	};
 
 	sock = CONTAINER_OF(work, struct esp_socket, recvdata_work);


### PR DESCRIPTION
- Fix passive mode protocol selection depending on AT versions
- Use Kconfig value for reset timeout
- Fix bug with parsing security from scan result
- Re-order some AT commands during init due to some commands having
  dependency on other commands

Signed-off-by: Tobias Svehagen <tobias.svehagen@gmail.com>