### PR TITLE
soc: fix some configuration error of arc emsdp

### DIFF
--- a/soc/arc/snps_emsdp/Kconfig.defconfig
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig
@@ -11,10 +11,6 @@ config NUM_IRQ_PRIO_LEVELS
 	# 0 for Fast Interrupts (FIRQs) and 1-3 for Regular Interrupts (IRQs).
 	default 4
 
-config NUM_IRQS
-	# must be > the highest interrupt number used
-	default 128
-
 source "soc/arc/snps_emsdp/Kconfig.defconfig.em4"
 source "soc/arc/snps_emsdp/Kconfig.defconfig.em5d"
 source "soc/arc/snps_emsdp/Kconfig.defconfig.em6"

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em11d
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em11d
@@ -37,4 +37,7 @@ config ZTEST_STACKSIZE
 	default 2048
 	depends on ZTEST
 
+config NUM_IRQS
+	default 111
+
 endif # SOC_EMSDP_EM11D

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em4
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em4
@@ -37,4 +37,7 @@ config ZTEST_STACKSIZE
 	default 2048
 	depends on ZTEST
 
+config NUM_IRQS
+	default 113
+
 endif # SOC_EMSDP_EM4

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em5d
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em5d
@@ -37,4 +37,7 @@ config ZTEST_STACKSIZE
 	default 2048
 	depends on ZTEST
 
+config NUM_IRQS
+	default 111
+
 endif # SOC_EMSDP_EM5D

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em6
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em6
@@ -37,4 +37,7 @@ config ZTEST_STACKSIZE
 	default 2048
 	depends on ZTEST
 
+config NUM_IRQS
+	default 113
+
 endif # SOC_EMSDP_EM6

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em7d
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em7d
@@ -37,4 +37,7 @@ config ZTEST_STACKSIZE
 	default 2048
 	depends on ZTEST
 
+config NUM_IRQS
+	default 111
+
 endif # SOC_EMSDP_EM7D

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em7d_esp
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em7d_esp
@@ -27,4 +27,7 @@ config CACHE_FLUSHING
 config FP_FPU_DA
 	default y
 
+config NUM_IRQS
+	default 112
+
 endif # SOC_EMSDP_EM7D_ESP

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em9d
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em9d
@@ -37,4 +37,7 @@ config ZTEST_STACKSIZE
 	default 2048
 	depends on ZTEST
 
+config NUM_IRQS
+	default 111
+
 endif # SOC_EMSDP_EM9D

--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -32,6 +32,14 @@ extern u32_t _irq_vector_table[];
 #define ISR5_OFFSET	4
 #define ISR6_OFFSET	5
 
+#if defined(CONFIG_SOC_ARC_EMSDP)
+/* ARC EMSDP' console will use irq 108 / irq 107, will conflict
+ * with isr used here, so add a workaround
+ */
+#undef CONFIG_NUM_IRQS
+#define CONFIG_NUM_IRQS 105
+#endif
+
 #define IRQ_LINE(offset)	(CONFIG_NUM_IRQS - ((offset) + 1))
 #define TABLE_INDEX(offset)	(IRQ_TABLE_SIZE - ((offset) + 1))
 #define TRIG_CHECK_SIZE         6


### PR DESCRIPTION
  * arc emsdp has 112 interrupts at maximum, not 128
  * arc emsdp's console will use irq 108/107 which will
    conflict with irqs used in tests/kernel/gen_isr_table (emsdp has 112 irqs),
    so add a workaround for emsdp.

Fixes #25510

  
