### PR TITLE
drivers: timer: nrf_rtc: fix TICKLESS=n processing

### DIFF
--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -177,7 +177,7 @@ void rtc1_nrf_isr(void *arg)
 		set_absolute_ticks(last_count + CYC_PER_TICK);
 	}
 
-	z_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1);
+	z_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : (dticks > 0));
 }
 
 int z_clock_driver_init(struct device *device)


### PR DESCRIPTION
Some kernel tests use `CONFIG_TICKLESS_KERNEL=n` with
`CONFIG_SYS_CLOCK_TICKS_PER_SEC=1` to detect when a test runs longer
than 1 second.  These tests break if a tick is announced every time a
timeout occurs.  Only announce if the measured duration since the last
tick is at least the duration of a tick.

Fixes #24660