### PR TITLE
ci: Update to use SDK 0.11.3

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -4,7 +4,7 @@ compiler: gcc
 
 env:
     global:
-        - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.11.2
+        - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.11.3
         - ZEPHYR_TOOLCHAIN_VARIANT=zephyr
         - MATRIX_BUILDS="5"
     matrix:
@@ -20,7 +20,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.11.7
+        image_tag: v0.11.8
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 


### PR DESCRIPTION
Update docker image to 0.11.8 to pull in SDK 0.11.3.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>