### PR TITLE
tests: cmsis_rtos_v2: adjust timer period to avoid starvation

### DIFF
--- a/tests/portability/cmsis_rtos_v2/src/timer.c
+++ b/tests/portability/cmsis_rtos_v2/src/timer.c
@@ -8,7 +8,7 @@
 #include <cmsis_os2.h>
 
 #define ONESHOT_TIME_TICKS      100
-#define PERIOD_TICKS            50
+#define PERIOD_TICKS            MAX(50, k_ms_to_ticks_ceil32(5))
 #define NUM_PERIODS             5
 
 u32_t num_oneshots_executed;


### PR DESCRIPTION
Most boards run with 10 kHz ticks producing a period of 5 ms for 50
tick interval used in the timer periodic test.  On Nordic 50 ticks
corresponds to 1.5 ms which is too short to complete the TC_PRINT()
call within the handler, causing the periodic timer to starve the
osDelay that would turn off the timer.

Adjust the period to be at least 5 ms or 50 ticks to avoid this
problem while not breaking other platform with slower tick rates.

Fixes #25196