### PR TITLE
soc: ti_simplelink: kconfig: ble: kconfig for cc13xx-cc26xx

### DIFF
--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.series
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.series
@@ -59,4 +59,12 @@ config NET_CONFIG_IEEE802154_DEV_NAME
 
 endif # IEEE802154
 
+if BT
+
+config BLE_CC13XX_CC26XX
+	bool
+	default y
+
+endif # BT
+
 endif # SOC_SERIES_CC13X2_CC26X2


### PR DESCRIPTION
This Kconfig option is a placeholder for now.

The intent is to control whether additional BLE support is enabled for the cc13xx_cc26xx platform in hal/ti and subsys/bluetooth.

In hal/ti, we would prefer to conditionally compile the support files (see zephyrproject-rtos/hal_ti#13). This change is required to support the SimpleLink BLE port (WIP #21631).

CC: @vanti @galak 