### PR TITLE
Fix locked IRQ support in LiteX timer

### DIFF
--- a/drivers/timer/litex_timer.c
+++ b/drivers/timer/litex_timer.c
@@ -10,6 +10,7 @@
 #include <arch/cpu.h>
 #include <device.h>
 #include <irq.h>
+#include <spinlock.h>
 #include <drivers/timer/system_timer.h>
 
 #define TIMER_BASE	        DT_INST_REG_ADDR(0)
@@ -18,13 +19,14 @@
 #define TIMER_EN_ADDR		((TIMER_BASE) + 0x20)
 #define TIMER_EV_PENDING_ADDR	((TIMER_BASE) + 0x3c)
 #define TIMER_EV_ENABLE_ADDR	((TIMER_BASE) + 0x40)
+#define TIMER_TOTAL_UPDATE	((TIMER_BASE) + 0x44)
+#define TIMER_TOTAL		((TIMER_BASE) + 0x48)
 
 #define TIMER_EV	0x1
 #define TIMER_IRQ	DT_INST_IRQN(0)
 #define TIMER_DISABLE	0x0
 #define TIMER_ENABLE	0x1
-
-static u32_t accumulated_cycle_count;
+#define UPDATE_TOTAL	0x1
 
 static void litex_timer_irq_handler(void *device)
 {
@@ -32,7 +34,6 @@ static void litex_timer_irq_handler(void *device)
 	int key = irq_lock();
 
 	sys_write8(TIMER_EV, TIMER_EV_PENDING_ADDR);
-	accumulated_cycle_count += k_ticks_to_cyc_floor32(1);
 	z_clock_announce(1);
 
 	irq_unlock(key);
@@ -40,7 +41,16 @@ static void litex_timer_irq_handler(void *device)
 
 u32_t z_timer_cycle_get_32(void)
 {
-	return accumulated_cycle_count;
+	static struct k_spinlock lock;
+	u32_t timer_total;
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	litex_write8(UPDATE_TOTAL, TIMER_TOTAL_UPDATE);
+	timer_total = (u32_t)litex_read64(TIMER_TOTAL);
+
+	k_spin_unlock(&lock, key);
+
+	return timer_total;
 }
 
 /* tickless kernel is not supported */

--- a/soc/riscv/litex-vexriscv/soc.h
+++ b/soc/riscv/litex-vexriscv/soc.h
@@ -36,6 +36,18 @@ static inline unsigned int litex_read32(unsigned long addr)
 		| sys_read8(addr + 0xc);
 }
 
+static inline u64_t litex_read64(unsigned long addr)
+{
+	return (((u64_t)sys_read8(addr)) << 56)
+		| ((u64_t)sys_read8(addr + 0x4) << 48)
+		| ((u64_t)sys_read8(addr + 0x8) << 40)
+		| ((u64_t)sys_read8(addr + 0xc) << 32)
+		| ((u64_t)sys_read8(addr + 0x10) << 24)
+		| ((u64_t)sys_read8(addr + 0x14) << 16)
+		| ((u64_t)sys_read8(addr + 0x18) << 8)
+		| (u64_t)sys_read8(addr + 0x1c);
+}
+
 static inline void litex_write8(unsigned char value, unsigned long addr)
 {
 	sys_write8(value, addr);


### PR DESCRIPTION
This reimplements z_timer_cycle_get_32() so it works
when IRQs are locked and solves the hung
k_busy_wait() problem.

This fixes #23622.