### PR TITLE
net: context: log_strup() missing from AF_PACKET bind() call

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -721,8 +721,9 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 		NET_DBG("Context %p binding to %d iface[%d] %p addr %s",
 			context, net_context_get_ip_proto(context),
 			ll_addr->sll_ifindex, iface,
-			net_sprint_ll_addr(net_if_get_link_addr(iface)->addr,
-					   net_if_get_link_addr(iface)->len));
+			log_strdup(net_sprint_ll_addr(
+					   net_if_get_link_addr(iface)->addr,
+					   net_if_get_link_addr(iface)->len)));
 
 		return 0;
 	}


### PR DESCRIPTION
The link address was not printed correctly as log_strdup() was
missing from the debug print.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>