### PR TITLE
net: ethernet: Check that device has PTP clock before access

### DIFF
--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -1038,6 +1038,10 @@ struct device *net_eth_get_ptp_clock(struct net_if *iface)
 		return NULL;
 	}
 
+	if (!api->get_ptp_clock) {
+		return NULL;
+	}
+
 	return api->get_ptp_clock(net_if_get_device(iface));
 }
 #endif /* CONFIG_PTP_CLOCK */


### PR DESCRIPTION
Avoid null pointer access by checking that Ethernet device has
PTP clock before trying to get the actual PTP clock device.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>