### PR TITLE
usb_cdc: sam0: Add an option to keep ardurno-style upgrade enter 

### DIFF
--- a/include/power/reboot.h
+++ b/include/power/reboot.h
@@ -35,6 +35,15 @@ extern "C" {
 
 extern void sys_reboot(int type);
 
+
+#ifdef CONFIG_ARDUINO_LIKE_UPGRADE
+#ifdef CONFIG_SOC_SERIES_SAMD21
+
+void sys_reboot_to_upgrade(int delay_ms);
+
+#endif	// CONFIG_SOC_SERIES_SAMD21
+#endif	// CONFIG_ARDUINO_LIKE_UPGRADE
+
 #ifdef __cplusplus
 }
 #endif

--- a/scripts/west_commands/tests/test_bossac.py
+++ b/scripts/west_commands/tests/test_bossac.py
@@ -17,6 +17,7 @@ if platform.system() != 'Linux':
 
 TEST_BOSSAC_PORT = 'test-bossac-serial'
 TEST_OFFSET = 1234
+STTY_RETRIES = 3
 EXPECTED_COMMANDS = [
     ['stty', '-F', TEST_BOSSAC_PORT, 'raw', 'ispeed', '1200', 'ospeed', '1200',
      'cs8', '-cstopb', 'ignpar', 'eol', '255', 'eof', '255'],
@@ -40,7 +41,17 @@ def test_bossac_init(cc, req, runner_config):
     runner = BossacBinaryRunner(runner_config, port=TEST_BOSSAC_PORT,
                                 offset=TEST_OFFSET)
     runner.run('flash')
-    assert cc.call_args_list == [call(x) for x in EXPECTED_COMMANDS_WITH_OFFSET]
+    # The stty call can appear up to STTY_RETRIES times so pass if any of those
+    # matches the actual call_arg_list
+    matched = False
+    for i in range(STTY_RETRIES):
+        arg_list = EXPECTED_COMMANDS_WITH_OFFSET[0:1]
+        arg_list += [EXPECTED_COMMANDS_WITH_OFFSET[0] for x in range(i)]
+        arg_list += EXPECTED_COMMANDS_WITH_OFFSET[1:]
+        if cc.call_args_list == [call(x) for x in arg_list]:
+            matched = True
+            break
+    assert matched
 
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
@@ -52,7 +63,17 @@ def test_bossac_create(cc, req, runner_config):
     arg_namespace = parser.parse_args(args)
     runner = BossacBinaryRunner.create(runner_config, arg_namespace)
     runner.run('flash')
-    assert cc.call_args_list == [call(x) for x in EXPECTED_COMMANDS]
+    # The stty call can appear up to STTY_RETRIES times so pass if any of those
+    # matches the actual call_arg_list
+    matched = False
+    for i in range(STTY_RETRIES):
+        arg_list = EXPECTED_COMMANDS[0:1]
+        arg_list += [EXPECTED_COMMANDS[0] for x in range(i)]
+        arg_list += EXPECTED_COMMANDS[1:]
+        if cc.call_args_list == [call(x) for x in arg_list]:
+            matched = True
+            break
+    assert matched
 
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
@@ -65,4 +86,14 @@ def test_bossac_create_with_offset(cc, req, runner_config):
     arg_namespace = parser.parse_args(args)
     runner = BossacBinaryRunner.create(runner_config, arg_namespace)
     runner.run('flash')
-    assert cc.call_args_list == [call(x) for x in EXPECTED_COMMANDS_WITH_OFFSET]
+    # The stty call can appear up to STTY_RETRIES times so pass if any of those
+    # matches the actual call_arg_list
+    matched = False
+    for i in range(STTY_RETRIES):
+        arg_list = EXPECTED_COMMANDS_WITH_OFFSET[0:1]
+        arg_list += [EXPECTED_COMMANDS_WITH_OFFSET[0] for x in range(i)]
+        arg_list += EXPECTED_COMMANDS_WITH_OFFSET[1:]
+        if cc.call_args_list == [call(x) for x in arg_list]:
+            matched = True
+            break
+    assert matched

--- a/subsys/power/reboot.c
+++ b/subsys/power/reboot.c
@@ -14,6 +14,9 @@
 #include <drivers/timer/system_timer.h>
 #include <sys/printk.h>
 #include <power/reboot.h>
+#ifdef CONFIG_ARDUINO_LIKE_UPGRADE
+#include <soc.h>
+#endif
 
 extern void sys_arch_reboot(int type);
 extern void sys_clock_disable(void);
@@ -33,3 +36,46 @@ void sys_reboot(int type)
 		k_cpu_idle();
 	}
 }
+
+#ifdef CONFIG_ARDUINO_LIKE_UPGRADE
+
+void sys_reboot_to_upgrade(int delay_ms)
+{
+	k_sleep(Z_TIMEOUT_MS(delay_ms));
+
+	(void)irq_lock();
+#ifdef CONFIG_SYS_CLOCK_EXISTS
+	sys_clock_disable();
+#endif
+
+#ifdef CONFIG_SOC_SERIES_SAMD21
+	while (!NVMCTRL->INTFLAG.reg & NVMCTRL_INTFLAG_READY) {
+		/* Wait for readiness */
+	}
+
+	/* Clear all status bits */
+	NVMCTRL->STATUS.reg |= NVMCTRL_STATUS_MASK;
+	/* Erased first word of the application section causes the stock
+	 * bootloader to stay in upload mode. SAMD non-volatile memory is
+	 * addressed per half-word so raw byte address needs to be divided by
+	 * (word size) / (half-word size) = 2
+	 */
+	NVMCTRL->ADDR.reg  = NVMCTRL_ADDR_ADDR((CONFIG_FLASH_LOAD_OFFSET + 4) /
+						2);
+	NVMCTRL->CTRLA.reg = NVMCTRL_CTRLA_CMD_ER | NVMCTRL_CTRLA_CMDEX_KEY;
+
+	while (!NVMCTRL->INTFLAG.reg & NVMCTRL_INTFLAG_READY) {
+		/* Wait for readiness */
+	}
+#endif	// CONFIG_SOC_SERIES_SAMD21
+
+	sys_arch_reboot(SYS_REBOOT_COLD);
+
+	/* should never get here */
+	printk("Failed to reboot: spinning endlessly...\n");
+	for (;;) {
+		k_cpu_idle();
+	}
+}
+
+#endif	// CONFIG_ARDUINO_LIKE_UPGRADE

--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -106,6 +106,15 @@ config USB_MAX_POWER
 	  Set bMaxPower value in the Standard Configuration Descriptor,
 	  the result is 2mA times the value provided.
 
+config ARDUINO_LIKE_UPGRADE
+	bool "Enable triggering ofupgrade mode on Arduino-compatible boards"
+	select REBOOT
+	depends on BOARD_ADAFRUIT_FEATHER_M0_BASIC_PROTO
+	help
+	  WARNING - Using this functionality might soft-brick boards with
+	  non-stock bootloaders. This option enables host-triggering of upgrade
+	  mode on Arduino-compatible boards.
+
 source "subsys/usb/class/Kconfig"
 
 endif # USB_DEVICE_STACK

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -48,6 +48,10 @@
 #include <usb/usb_common.h>
 #include <usb_descriptor.h>
 
+#ifdef CONFIG_ARDUINO_LIKE_UPGRADE
+#include <power/reboot.h>
+#endif
+
 #ifndef CONFIG_UART_INTERRUPT_DRIVEN
 #error "CONFIG_UART_INTERRUPT_DRIVEN must be set for CDC ACM driver"
 #endif
@@ -239,6 +243,13 @@ int cdc_acm_class_handle_req(struct usb_setup_packet *pSetup,
 		dev_data->line_state = (u8_t)sys_le16_to_cpu(pSetup->wValue);
 		LOG_DBG("CDC_SET_CONTROL_LINE_STATE 0x%x",
 			dev_data->line_state);
+#ifdef CONFIG_ARDUINO_LIKE_UPGRADE
+		if (sys_le32_to_cpu(dev_data->line_coding.dwDTERate) == 1200 &&
+			dev_data->line_state == 0) {
+			LOG_INF("Detected 1200");
+			sys_reboot_to_upgrade(250);
+		}
+#endif
 		break;
 
 	case GET_LINE_CODING:


### PR DESCRIPTION
Many of the Zephyr supported boards are Arduino compatible.
However after being flashed with Zephyr, even if they keep their
original bootloader they lose the ability to have the firmware
uploaded to them hands-free, from the Arduino IDE. This commit
allows for enabling of such ability.

Currently only enabled for adafruit_feather_m0_basic_proto board
but the code should work in principle with other adafruit M0 SoCs.

Depends on #25361 for the flashing part to work.