### PR TITLE
net: socket: Add sendmsg() support to AF_PACKET

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1428,6 +1428,21 @@ static int context_sendto(struct net_context *context,
 		struct sockaddr_ll *ll_addr = (struct sockaddr_ll *)dst_addr;
 		struct net_if *iface;
 
+		if (msghdr) {
+			ll_addr = msghdr->msg_name;
+			addrlen = msghdr->msg_namelen;
+
+			if (!ll_addr) {
+				ll_addr = (struct sockaddr_ll *)
+							(&context->remote);
+				addrlen = sizeof(struct sockaddr_ll);
+			}
+
+			/* For sendmsg(), the dst_addr is NULL so set it here.
+			 */
+			dst_addr = (const struct sockaddr *)ll_addr;
+		}
+
 		if (addrlen < sizeof(struct sockaddr_ll)) {
 			return -EINVAL;
 		}

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -172,6 +172,25 @@ ssize_t zpacket_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 	return status;
 }
 
+ssize_t zpacket_sendmsg_ctx(struct net_context *ctx, const struct msghdr *msg,
+			    int flags)
+{
+	k_timeout_t timeout = K_FOREVER;
+	int status;
+
+	if ((flags & ZSOCK_MSG_DONTWAIT) || sock_is_nonblock(ctx)) {
+		timeout = K_NO_WAIT;
+	}
+
+	status = net_context_sendmsg(ctx, msg, flags, NULL, timeout, NULL);
+	if (status < 0) {
+		errno = -status;
+		return -1;
+	}
+
+	return status;
+}
+
 ssize_t zpacket_recvfrom_ctx(struct net_context *ctx, void *buf, size_t max_len,
 			     int flags, struct sockaddr *src_addr,
 			     socklen_t *addrlen)
@@ -307,6 +326,12 @@ static ssize_t packet_sock_sendto_vmeth(void *obj, const void *buf, size_t len,
 	return zpacket_sendto_ctx(obj, buf, len, flags, dest_addr, addrlen);
 }
 
+static ssize_t packet_sock_sendmsg_vmeth(void *obj, const struct msghdr *msg,
+					 int flags)
+{
+	return zpacket_sendmsg_ctx(obj, msg, flags);
+}
+
 static ssize_t packet_sock_recvfrom_vmeth(void *obj, void *buf, size_t max_len,
 					  int flags, struct sockaddr *src_addr,
 					  socklen_t *addrlen)
@@ -338,6 +363,7 @@ static const struct socket_op_vtable packet_sock_fd_op_vtable = {
 	.listen = packet_sock_listen_vmeth,
 	.accept = packet_sock_accept_vmeth,
 	.sendto = packet_sock_sendto_vmeth,
+	.sendmsg = packet_sock_sendmsg_vmeth,
 	.recvfrom = packet_sock_recvfrom_vmeth,
 	.getsockopt = packet_sock_getsockopt_vmeth,
 	.setsockopt = packet_sock_setsockopt_vmeth,


### PR DESCRIPTION
The AF_PACKET was missing support for sendmsg() socket call.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>