### PR TITLE
tests: memory protection test thread stack object uninitialized after exit

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -85,6 +85,7 @@ void test_main(void)
 			 ztest_unit_test(test_access_kobject_without_init_with_access),
 			 ztest_unit_test(test_kobject_reinitialize_thread_kobj),
 			 ztest_unit_test(test_create_new_thread_from_user),
+			 ztest_unit_test(test_mark_thread_exit_uninitialized),
 			 ztest_unit_test(
 				 test_new_user_thread_with_in_use_stack_obj),
 			 ztest_unit_test(


### PR DESCRIPTION
Add new test test_mark_thread_exit_uninitialized() that tests thread and its stack object become uninitialized after exit.

Documentation says: "When thread exits, thread stack objects and thread itself must be marked by kernel as uninitialized". Created a test that proves documentation.

Logic of the test:
When thread is initialized and running z_object_validate will return 0 for thread object and its thread stack object.
When thread exit, z_object_validate will return -1 for thread object and its thread stack object.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>