### PR TITLE
drivers: eth: stm32: Fix invalid assertion check

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -478,7 +478,7 @@ static void eth_iface_init(struct net_if *iface)
 		dev_data->iface = iface;
 
 		/* Now that the iface is setup, we are safe to enable IRQs. */
-		__ASSERT_NO_MSG(DEV_CFG(dev)->config_func() != NULL);
+		__ASSERT_NO_MSG(DEV_CFG(dev)->config_func != NULL);
 		DEV_CFG(dev)->config_func();
 	}
 


### PR DESCRIPTION
The check for assertion on the "config_func" was added to validate that the function pointer is valid. However, in the code we are invoking the "config_func" and comparing its output with NULL. This causes build failures with CONFIG_ASSERT=1. Caused by PR-25393.

Tested on Nucleo F767Zi board.

Fixes #25427

Signed-off-by: Bilal Wasim <bilalwasim676@gmail.com>