### PR TITLE
tests: timing_info: need to calibrate TSC frequency on x86

### DIFF
--- a/tests/benchmarks/timing_info/CMakeLists.txt
+++ b/tests/benchmarks/timing_info/CMakeLists.txt
@@ -8,6 +8,8 @@ FILE(GLOB app_sources src/[^u]*.c)
 target_sources(app PRIVATE ${app_sources})
 target_sources_ifdef(CONFIG_USERSPACE app PRIVATE src/userspace_bench.c)
 
+target_sources_ifdef(CONFIG_X86 app PRIVATE src/arch/x86/tsc.c)
+
 target_include_directories(app PRIVATE
   ${ZEPHYR_BASE}/kernel/include
   ${ZEPHYR_BASE}/arch/${ARCH}/include

--- a/tests/benchmarks/timing_info/src/arch/x86/tsc.c
+++ b/tests/benchmarks/timing_info/src/arch/x86/tsc.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+#include <zephyr.h>
+#include <tc_util.h>
+#include <ksched.h>
+#include <sys_clock.h>
+
+#define CALIB_LOOPS	8
+
+static u64_t tsc_freq;
+
+void calibrate_timer(void)
+{
+	u32_t cyc_start = k_cycle_get_32();
+	u64_t tsc_start = z_tsc_read();
+
+	k_busy_wait(10 * USEC_PER_MSEC);
+
+	u32_t cyc_end = k_cycle_get_32();
+	u64_t tsc_end = z_tsc_read();
+
+	u64_t cyc_freq = sys_clock_hw_cycles_per_sec();
+
+	/*
+	 * cycles are in 32-bit, and delta must be
+	 * calculated in 32-bit percision. Or it would
+	 * wrapping around in 64-bit.
+	 */
+	u64_t dcyc = (u32_t)cyc_end - (u32_t)cyc_start;
+
+	u64_t dtsc = tsc_end - tsc_start;
+
+	tsc_freq = (cyc_freq * dtsc) / dcyc;
+}
+
+u32_t x86_get_timer_freq_MHz(void)
+{
+	return (u32_t)(tsc_freq / 1000000);
+}
+
+u32_t x86_cyc_to_ns_floor64(u64_t cyc)
+{
+	return ((cyc) * USEC_PER_SEC / tsc_freq);
+}

--- a/tests/benchmarks/timing_info/src/main_benchmark.c
+++ b/tests/benchmarks/timing_info/src/main_benchmark.c
@@ -16,16 +16,24 @@
 #include <ksched.h>
 #include "timing_info.h"
 
+void __weak calibrate_timer(void)
+{
+}
+
 void main(void)
 {
-	u32_t freq = get_core_freq_MHz();
+	u32_t freq;
+
+	calibrate_timer();
+
+	freq = get_core_freq_MHz();
 
 	/* Configure and start timer */
 	benchmark_timer_init();
 	benchmark_timer_start();
 
 	TC_START("Time Measurement");
-	TC_PRINT("Timing Results: Clock Frequency: %d MHz\n", freq);
+	TC_PRINT("Timing Results: Clock Frequency: %u MHz\n", freq);
 
 	/*******************************************************************/
 	/* System parameters and thread Benchmarking*/

--- a/tests/benchmarks/timing_info/src/timing_info.h
+++ b/tests/benchmarks/timing_info/src/timing_info.h
@@ -174,6 +174,24 @@ static inline u32_t get_core_freq_MHz(void)
 	return CYCLES_PER_SEC;
 }
 
+#elif defined(CONFIG_X86)
+
+static inline void benchmark_timer_init(void)  {       }
+static inline void benchmark_timer_stop(void)  {       }
+static inline void benchmark_timer_start(void) {       }
+
+extern u32_t x86_cyc_to_ns_floor64(u64_t cyc);
+extern u32_t x86_get_timer_freq_MHz(void);
+
+#define CYCLES_TO_NS(x) x86_cyc_to_ns_floor64(x)
+
+static inline u32_t get_core_freq_MHz(void)
+{
+	return x86_get_timer_freq_MHz();
+}
+
+#define PRINT_STATS(x, y, z)   PRINT_F(x, y, z)
+
 #else  /* All other architectures */
 /* Done because weak attribute doesn't work on static inline. */
 static inline void benchmark_timer_init(void)  {       }


### PR DESCRIPTION
For x86, TSC is being used to gather timing information. However,
CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC is not the same as TSC
frequency when HPET (or other) timer is used. So use the system
clock to calibrate the TSC frequency so we can use it to
calculate timing information.

Partial fix for #25458

Signed-off-by: Daniel Leung <daniel.leung@intel.com>