### PR TITLE
cmake: Correct PATHS usage

### DIFF
--- a/cmake/bintools/gnu/target.cmake
+++ b/cmake/bintools/gnu/target.cmake
@@ -2,16 +2,16 @@
 
 # Configures binary tools as GNU binutils
 
-find_program(CMAKE_OBJCOPY ${CROSS_COMPILE}objcopy PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_OBJDUMP ${CROSS_COMPILE}objdump PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_AS      ${CROSS_COMPILE}as      PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_AR      ${CROSS_COMPILE}ar      PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_RANLIB  ${CROSS_COMPILE}ranlib  PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_READELF ${CROSS_COMPILE}readelf PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_NM      ${CROSS_COMPILE}nm      PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_OBJCOPY ${CROSS_COMPILE}objcopy PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_OBJDUMP ${CROSS_COMPILE}objdump PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_AS      ${CROSS_COMPILE}as      PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_AR      ${CROSS_COMPILE}ar      PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_RANLIB  ${CROSS_COMPILE}ranlib  PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_READELF ${CROSS_COMPILE}readelf PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_NM      ${CROSS_COMPILE}nm      PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 
-find_program(CMAKE_GDB     ${CROSS_COMPILE}gdb     PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_GDB     gdb-multiarch           PATH ${TOOLCHAIN_HOME}                )
+find_program(CMAKE_GDB     ${CROSS_COMPILE}gdb     PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_GDB     gdb-multiarch           PATHS ${TOOLCHAIN_HOME}                )
 
 # Include bin tool abstraction macros
 include(${ZEPHYR_BASE}/cmake/bintools/gnu/target_memusage.cmake)

--- a/cmake/bintools/llvm/target.cmake
+++ b/cmake/bintools/llvm/target.cmake
@@ -3,8 +3,8 @@
 # Configures binary toos as llvm binary tool set
 
 if(DEFINED TOOLCHAIN_HOME)
-  set(find_program_clang_args PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-  set(find_program_binutils_args PATH ${TOOLCHAIN_HOME})
+  set(find_program_clang_args PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+  set(find_program_binutils_args PATHS ${TOOLCHAIN_HOME})
 endif()
 
 find_program(CMAKE_AR      llvm-ar      ${find_program_clang_args}   )

--- a/cmake/compiler/clang/generic.cmake
+++ b/cmake/compiler/clang/generic.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(DEFINED TOOLCHAIN_HOME)
-  set(find_program_clang_args PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+  set(find_program_clang_args PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 endif()
 
 find_program(CMAKE_C_COMPILER clang ${find_program_clang_args})

--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -12,7 +12,7 @@ if(NOT DEFINED NOSYSDEF_CFLAG)
 endif()
 
 if(DEFINED TOOLCHAIN_HOME)
-  set(find_program_clang_args PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+  set(find_program_clang_args PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 endif()
 
 find_program(CMAKE_C_COMPILER   clang   ${find_program_clang_args})

--- a/cmake/compiler/gcc/generic.cmake
+++ b/cmake/compiler/gcc/generic.cmake
@@ -2,7 +2,7 @@
 
 set_ifndef(CC gcc)
 
-find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC}   PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC}   PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 
 if(CMAKE_C_COMPILER STREQUAL CMAKE_C_COMPILER-NOTFOUND)
   message(FATAL_ERROR "Zephyr was unable to find the toolchain. Is the environment misconfigured?

--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -5,7 +5,7 @@ set_ifndef(C++ g++)
 # Configures CMake for using GCC, this script is re-used by several
 # GCC-based toolchains
 
-find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC} PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC} PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 if(${CMAKE_C_COMPILER} STREQUAL CMAKE_C_COMPILER-NOTFOUND)
   message(FATAL_ERROR "C compiler ${CROSS_COMPILE}${CC} not found - Please check your toolchain installation")
 endif()
@@ -22,7 +22,7 @@ else()
     set(cplusplus_compiler ${CMAKE_C_COMPILER})
   endif()
 endif()
-find_program(CMAKE_CXX_COMPILER ${cplusplus_compiler} PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_CXX_COMPILER ${cplusplus_compiler} PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 
 set(NOSTDINC "")
 

--- a/cmake/compiler/xcc/generic.cmake
+++ b/cmake/compiler/xcc/generic.cmake
@@ -2,7 +2,7 @@
 
 set_ifndef(CC gcc)
 
-find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC}   PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC}   PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 
 if(CMAKE_C_COMPILER STREQUAL CMAKE_C_COMPILER-NOTFOUND)
   message(FATAL_ERROR "Zephyr was unable to find the toolchain. Is the environment misconfigured?

--- a/cmake/compiler/xcc/target.cmake
+++ b/cmake/compiler/xcc/target.cmake
@@ -5,7 +5,7 @@ set_ifndef(C++ g++)
 # Configures CMake for using GCC, this script is re-used by several
 # GCC-based toolchains
 
-find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC} PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC} PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 
 if(CONFIG_CPLUSPLUS)
   set(cplusplus_compiler ${CROSS_COMPILE}${C++})
@@ -19,7 +19,7 @@ else()
     set(cplusplus_compiler ${CMAKE_C_COMPILER})
   endif()
 endif()
-find_program(CMAKE_CXX_COMPILER ${cplusplus_compiler} PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_CXX_COMPILER ${cplusplus_compiler} PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 
 set(NOSTDINC "")
 

--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-find_program(CMAKE_LINKER     ${CROSS_COMPILE}ld      PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_LINKER     ${CROSS_COMPILE}ld      PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 
 set_ifndef(LINKERFLAGPREFIX -Wl)
 


### PR DESCRIPTION
`PATH` is not a valid option for `find_program`; correct all such
usages to `PATHS`.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Reference: https://cmake.org/cmake/help/latest/command/find_program.html