### PR TITLE
test: lib: heap: increase timeout

### DIFF
--- a/tests/lib/heap/testcase.yaml
+++ b/tests/lib/heap/testcase.yaml
@@ -7,3 +7,4 @@ tests:
   lib.heap:
     tags: heap
     platform_exclude: m2gl025_miv qemu_riscv32
+    timeout: 120


### PR DESCRIPTION
On some STM32 boards : nucleo_wb55rg, nucleo_l152re
the test lasts longer than defaut 60sec timeout.
Increase timeout to 120 sec.

Fixes #25437