### PR TITLE
Bluetooth: host: foreach bond only SMP is enabled

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2636,7 +2636,8 @@ int bt_unpair(u8_t id, const bt_addr_le_t *addr)
 		return -EINVAL;
 	}
 
-	if (!addr || !bt_addr_le_cmp(addr, BT_ADDR_LE_ANY)) {
+	if (IS_ENABLED(CONFIG_BT_SMP) &&
+	    (!addr || !bt_addr_le_cmp(addr, BT_ADDR_LE_ANY))) {
 		bt_foreach_bond(id, unpair_remote, &id);
 		return 0;
 	}


### PR DESCRIPTION
Bluetooth: host: foreach bond only SMP is enabled

build breakage if SMP is disabled

```
In function `bt_unpair':
bluetooth/host/hci_core.c:2640: undefined reference to `bt_foreach_bond'
```
