### PR TITLE
cmake: raise a fatal error when C compiler is not found

### DIFF
--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -6,6 +6,9 @@ set_ifndef(C++ g++)
 # GCC-based toolchains
 
 find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC} PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+if(${CMAKE_C_COMPILER} STREQUAL CMAKE_C_COMPILER-NOTFOUND)
+  message(FATAL_ERROR "C compiler ${CROSS_COMPILE}${CC} not found - Please check your toolchain installation")
+endif()
 
 if(CONFIG_CPLUSPLUS)
   set(cplusplus_compiler ${CROSS_COMPILE}${C++})


### PR DESCRIPTION
This commit introduces an early error in case a valid C compiler is not
found in the system.

This will help to early identify misconfigured systems with the error:
`  C compiler <compiler> not found - Please check your toolchain installation`

instead of an obscure error, such as:
```
No such file or directory: LIBGCC_FILE_NAME: ''
```

-----
This PR is triggered by spending a couple of hours investigating: #25183

where the error message was:
```
No such file or directory: LIBGCC_FILE_NAME: ''
```
when trying to build using the Zephyr SDK.

With this patch, there would be an error as soon as no C compiler is found:
```
  C compiler /opt/zephyr-sdk/xtensa/esp32/xtensa-zephyr-elf/bin/xtensa-zephyr-elf-gcc not found - Please check your toolchain installation
```
making it much easier to spot such an issue.
