### PR TITLE
[PoC] lib: os: fdtable: Add syscalls for POSIX read/write/close/ioctl operations

### DIFF
--- a/include/posix/sys/ioctl.h
+++ b/include/posix/sys/ioctl.h
@@ -8,7 +8,7 @@
 
 #include <stdarg.h>
 
-__syscall int sys_ioctl(int fd, unsigned long request, va_list args);
+__syscall int sys_ioctl(int fd, unsigned long request, long n_args, uintptr_t *args);
 int ioctl(int fd, unsigned long request, ...);
 
 #define FIONBIO 0x5421

--- a/include/posix/sys/ioctl.h
+++ b/include/posix/sys/ioctl.h
@@ -6,6 +6,15 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_IOCTL_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_IOCTL_H_
 
+#include <stdarg.h>
+
+__syscall int sys_ioctl(int fd, unsigned long request, va_list args);
+int ioctl(int fd, unsigned long request, ...);
+
 #define FIONBIO 0x5421
+
+#ifndef CONFIG_ARCH_POSIX
+#include <syscalls/ioctl.h>
+#endif /* CONFIG_ARCH_POSIX */
 
 #endif /* ZEPHYR_INCLUDE_POSIX_SYS_IOCTL_H_ */

--- a/include/posix/unistd.h
+++ b/include/posix/unistd.h
@@ -22,7 +22,15 @@ extern "C" {
 #endif
 
 #ifdef CONFIG_POSIX_API
-/* File related operations */
+/* File related operations. Convention: "sys_name" is a syscall (needs
+ * prototype in this file for usage). "name" is a normal userspace
+ * function (implemented as a wrapper for syscall), usable even
+ * without prototype, per classical C handling. This distinction
+ * is however implemented on demand, based on the actual usecases seen.
+ */
+__syscall int sys_close(int file);
+__syscall ssize_t sys_write(int file, const void *buffer, size_t count);
+__syscall ssize_t sys_read(int file, void *buffer, size_t count);
 extern int close(int file);
 extern ssize_t write(int file, const void *buffer, size_t count);
 extern ssize_t read(int file, void *buffer, size_t count);
@@ -49,5 +57,9 @@ int usleep(useconds_t useconds);
 #ifdef __cplusplus
 }
 #endif
+
+#ifndef CONFIG_ARCH_POSIX
+#include <syscalls/unistd.h>
+#endif /* CONFIG_ARCH_POSIX */
 
 #endif	/* ZEPHYR_INCLUDE_POSIX_UNISTD_H_ */

--- a/include/sys/fdtable.h
+++ b/include/sys/fdtable.h
@@ -138,10 +138,15 @@ enum {
 	ZFD_IOCTL_CLOSE = 0x100,
 	ZFD_IOCTL_FSYNC,
 	ZFD_IOCTL_LSEEK,
-	ZFD_IOCTL_POLL_PREPARE,
+	ZFD_IOCTL_GETSOCKNAME,
+
+	/* Codes above 0xff00 are private kernel-only requests, not
+	 * available from userspace.
+	 */
+	ZFD_IOCTL_PRIVATE = 0xff00,
+	ZFD_IOCTL_POLL_PREPARE = ZFD_IOCTL_PRIVATE,
 	ZFD_IOCTL_POLL_UPDATE,
 	ZFD_IOCTL_POLL_OFFLOAD,
-	ZFD_IOCTL_GETSOCKNAME,
 };
 
 #ifdef __cplusplus

--- a/lib/posix/eventfd.c
+++ b/lib/posix/eventfd.c
@@ -133,7 +133,8 @@ static ssize_t eventfd_write_op(void *obj, const void *buf, size_t sz)
 	return sizeof(eventfd_t);
 }
 
-static int eventfd_ioctl_op(void *obj, unsigned int request, va_list args)
+static int eventfd_ioctl_op(void *obj, unsigned long request,
+			    long n_args, uintptr_t *args)
 {
 	struct eventfd *efd = (struct eventfd *)obj;
 
@@ -144,7 +145,7 @@ static int eventfd_ioctl_op(void *obj, unsigned int request, va_list args)
 	case F_SETFL: {
 		int flags;
 
-		flags = va_arg(args, int);
+		flags = (int)args[0];
 
 		if (flags & ~EFD_FLAGS_SET) {
 			errno = EINVAL;
@@ -165,9 +166,9 @@ static int eventfd_ioctl_op(void *obj, unsigned int request, va_list args)
 		struct k_poll_event **pev;
 		struct k_poll_event *pev_end;
 
-		pfd = va_arg(args, struct zsock_pollfd *);
-		pev = va_arg(args, struct k_poll_event **);
-		pev_end = va_arg(args, struct k_poll_event *);
+		pfd = (struct zsock_pollfd *)args[0];
+		pev = (struct k_poll_event **)args[1];
+		pev_end = (struct k_poll_event *)args[2];
 
 		return eventfd_poll_prepare(obj, pfd, pev, pev_end);
 	}
@@ -176,8 +177,8 @@ static int eventfd_ioctl_op(void *obj, unsigned int request, va_list args)
 		struct zsock_pollfd *pfd;
 		struct k_poll_event **pev;
 
-		pfd = va_arg(args, struct zsock_pollfd *);
-		pev = va_arg(args, struct k_poll_event **);
+		pfd = (struct zsock_pollfd *)args[0];
+		pev = (struct k_poll_event **)args[1];
 
 		return eventfd_poll_update(obj, pfd, pev);
 	}

--- a/lib/posix/fs.c
+++ b/lib/posix/fs.c
@@ -93,7 +93,8 @@ int open(const char *name, int flags)
 	return fd;
 }
 
-static int fs_ioctl_vmeth(void *obj, unsigned int request, va_list args)
+static int fs_ioctl_vmeth(void *obj, unsigned long request,
+			  long n_args, uintptr_t *args)
 {
 	int rc;
 	struct posix_fs_desc *ptr = obj;
@@ -108,8 +109,8 @@ static int fs_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 		off_t offset;
 		int whence;
 
-		offset = va_arg(args, off_t);
-		whence = va_arg(args, int);
+		offset = (off_t)args[0];
+		whence = (int)args[1];
 
 		rc = fs_seek(&ptr->file, offset, whence);
 		break;

--- a/subsys/net/lib/sockets/socketpair.c
+++ b/subsys/net/lib/sockets/socketpair.c
@@ -879,7 +879,8 @@ pollin_done:
 	return res;
 }
 
-static int spair_ioctl(void *obj, unsigned int request, va_list args)
+static int spair_ioctl(void *obj, unsigned long request,
+		       long n_args, uintptr_t *args)
 {
 	int res;
 	struct zsock_pollfd *pfd;
@@ -915,7 +916,7 @@ static int spair_ioctl(void *obj, unsigned int request, va_list args)
 		}
 
 		case F_SETFL: {
-			flags = va_arg(args, int);
+			flags = (int)args[0];
 
 			if (flags & O_NONBLOCK) {
 				spair->flags |= SPAIR_FLAG_NONBLOCK;
@@ -936,17 +937,17 @@ static int spair_ioctl(void *obj, unsigned int request, va_list args)
 		}
 
 		case ZFD_IOCTL_POLL_PREPARE: {
-			pfd = va_arg(args, struct zsock_pollfd *);
-			pev = va_arg(args, struct k_poll_event **);
-			pev_end = va_arg(args, struct k_poll_event *);
+			pfd = (struct zsock_pollfd *)args[0];
+			pev = (struct k_poll_event **)args[1];
+			pev_end = (struct k_poll_event *)args[2];
 
 			res = zsock_poll_prepare_ctx(obj, pfd, pev, pev_end);
 			goto out;
 		}
 
 		case ZFD_IOCTL_POLL_UPDATE: {
-			pfd = va_arg(args, struct zsock_pollfd *);
-			pev = va_arg(args, struct k_poll_event **);
+			pfd = (struct zsock_pollfd *)args[0];
+			pev = (struct k_poll_event **)args[1];
 
 			res = zsock_poll_update_ctx(obj, pfd, pev);
 			goto out;

--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -407,7 +407,8 @@ static int can_close_socket(struct net_context *ctx)
 	return 0;
 }
 
-static int can_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
+static int can_sock_ioctl_vmeth(void *obj, unsigned long request,
+				long n_args, uintptr_t *args)
 {
 	if (request == ZFD_IOCTL_CLOSE) {
 		int ret;
@@ -418,7 +419,7 @@ static int can_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 		}
 	}
 
-	return sock_fd_op_vtable.fd_vtable.ioctl(obj, request, args);
+	return sock_fd_op_vtable.fd_vtable.ioctl(obj, request, n_args, args);
 }
 
 /*

--- a/subsys/net/lib/sockets/sockets_net_mgmt.c
+++ b/subsys/net/lib/sockets/sockets_net_mgmt.c
@@ -302,8 +302,8 @@ static ssize_t net_mgmt_sock_write(void *obj, const void *buffer,
 	return znet_mgmt_sendto(obj, buffer, count, 0, NULL, 0);
 }
 
-static int net_mgmt_sock_ioctl(void *obj, unsigned int request,
-			       va_list args)
+static int net_mgmt_sock_ioctl(void *obj, unsigned long request,
+			       long n_args, uintptr_t *args)
 {
 	return 0;
 }

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -280,10 +280,10 @@ static ssize_t packet_sock_write_vmeth(void *obj, const void *buffer,
 	return zpacket_sendto_ctx(obj, buffer, count, 0, NULL, 0);
 }
 
-static int packet_sock_ioctl_vmeth(void *obj, unsigned int request,
-				   va_list args)
+static int packet_sock_ioctl_vmeth(void *obj, unsigned long request,
+				   long n_args, uintptr_t *args)
 {
-	return sock_fd_op_vtable.fd_vtable.ioctl(obj, request, args);
+	return sock_fd_op_vtable.fd_vtable.ioctl(obj, request, n_args, args);
 }
 
 /*

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1197,7 +1197,7 @@ int ztls_close_ctx(struct net_context *ctx)
 		err = -EBADF;
 	}
 
-	ret = z_fdtable_call_ioctl(&sock_fd_op_vtable.fd_vtable, ctx, ZFD_IOCTL_CLOSE);
+	ret = z_fdtable_call_ioctl(&sock_fd_op_vtable.fd_vtable, ctx, ZFD_IOCTL_CLOSE, 0);
 
 	/* In case close fails, we propagate errno value set by close.
 	 * In case close succeeds, but tls_release fails, set errno
@@ -1331,7 +1331,7 @@ error:
 		__ASSERT(err == 0, "TLS context release failed");
 	}
 
-	err = z_fdtable_call_ioctl(&sock_fd_op_vtable.fd_vtable, child, ZFD_IOCTL_CLOSE);
+	err = z_fdtable_call_ioctl(&sock_fd_op_vtable.fd_vtable, child, ZFD_IOCTL_CLOSE, 0);
 	__ASSERT(err == 0, "Child socket close failed");
 
 	z_free_fd(fd);

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1936,7 +1936,8 @@ static ssize_t tls_sock_write_vmeth(void *obj, const void *buffer,
 	return ztls_sendto_ctx(obj, buffer, count, 0, NULL, 0);
 }
 
-static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
+static int tls_sock_ioctl_vmeth(void *obj, unsigned long request,
+				long n_args, uintptr_t *args)
 {
 	switch (request) {
 
@@ -1945,7 +1946,8 @@ static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 	case F_SETFL:
 	case ZFD_IOCTL_GETSOCKNAME:
 		/* Pass the call to the core socket implementation. */
-		return sock_fd_op_vtable.fd_vtable.ioctl(obj, request, args);
+		return sock_fd_op_vtable.fd_vtable.ioctl(obj, request,
+							 n_args, args);
 
 	case ZFD_IOCTL_CLOSE:
 		return ztls_close_ctx(obj);
@@ -1955,9 +1957,9 @@ static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 		struct k_poll_event **pev;
 		struct k_poll_event *pev_end;
 
-		pfd = va_arg(args, struct zsock_pollfd *);
-		pev = va_arg(args, struct k_poll_event **);
-		pev_end = va_arg(args, struct k_poll_event *);
+		pfd = (struct zsock_pollfd *)args[0];
+		pev = (struct k_poll_event **)args[1];
+		pev_end = (struct k_poll_event *)args[2];
 
 		return ztls_poll_prepare_ctx(obj, pfd, pev, pev_end);
 	}
@@ -1966,8 +1968,8 @@ static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 		struct zsock_pollfd *pfd;
 		struct k_poll_event **pev;
 
-		pfd = va_arg(args, struct zsock_pollfd *);
-		pev = va_arg(args, struct k_poll_event **);
+		pfd = (struct zsock_pollfd *)args[0];
+		pev = (struct k_poll_event **)args[1];
 
 		return ztls_poll_update_ctx(obj, pfd, pev);
 	}

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -417,7 +417,8 @@ int websocket_disconnect(int ws_sock)
 	return ret;
 }
 
-static int websocket_ioctl_vmeth(void *obj, unsigned int request, va_list args)
+static int websocket_ioctl_vmeth(void *obj, unsigned long request,
+				 long n_args, uintptr_t *args)
 {
 	if (request == ZFD_IOCTL_CLOSE) {
 		struct websocket_context *ctx = obj;
@@ -434,7 +435,7 @@ static int websocket_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 		return ret;
 	}
 
-	return sock_fd_op_vtable.fd_vtable.ioctl(obj, request, args);
+	return sock_fd_op_vtable.fd_vtable.ioctl(obj, request, n_args, args);
 }
 
 static int websocket_prepare_and_send(struct websocket_context *ctx,

--- a/tests/net/socket/socket_helpers.h
+++ b/tests/net/socket/socket_helpers.h
@@ -6,7 +6,12 @@
 
 #include <ztest_assert.h>
 
+#ifdef CONFIG_POSIX_API
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#else
 #include <net/socket.h>
+#endif
 
 #define clear_buf(buf) memset(buf, 0, sizeof(buf))
 

--- a/tests/net/socket/tcp/testcase.yaml
+++ b/tests/net/socket/tcp/testcase.yaml
@@ -1,6 +1,11 @@
 common:
   depends_on: netif
+  min_ram: 32
+  tags: net socket userspace
 tests:
   net.socket.tcp:
-    min_ram: 32
-    tags: net socket userspace
+    extra_configs:
+      - CONFIG_POSIX_API=n
+  net.socket.tcp.posix:
+    extra_configs:
+      - CONFIG_POSIX_API=y


### PR DESCRIPTION
Fdtable is a kernel-level structure, so functions accessing it, like
read(), write(), close(), should be syscalls. This conversion however
emphasizes a difference between "syscall" and "C standard library
function". C stdlib functions should be represented by just a
standard linkage symbol, and can be used even without prototype.
Syscall is however a special code sequence, which may require special
attributes and thus a prototype for usage. To deal with these
distinction, we define a convention that "sys_name" is a syscall,
while "name" is a normal C function (implemented as a wrapper around
syscall). (And we also need to define "_name" to interface with Newlib
(actually, just "_write".))

Fixes: #25407

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>
