### PR TITLE
scripts: gen_offset_header: add argument help text

### DIFF
--- a/scripts/gen_offset_header.py
+++ b/scripts/gen_offset_header.py
@@ -61,6 +61,7 @@ def gen_offset_header(input_name, input_file, output_file):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
+        description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
 
     parser.add_argument(


### PR DESCRIPTION
Help text is set to documentation string of the script.

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>