### PR TITLE
Revert "test: kernel: context: Exclude for qemu_cortex_r5 (temporary)"

### DIFF
--- a/tests/kernel/context/testcase.yaml
+++ b/tests/kernel/context/testcase.yaml
@@ -2,6 +2,3 @@ tests:
   kernel.common:
     tags: kernel
     min_ram: 20
-    # FIXME: Remove `qemu_cortex_r5` exclusion once Zephyr SDK 0.11.3 is
-    #        mainlined (see #22904).
-    platform_exclude: qemu_cortex_r5


### PR DESCRIPTION
This reverts commit f87bce135ae0d3a3d8d361ceaf4776d0302cf984.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>