### PR TITLE
[DNM] west.yml: Update mcuboot to enable single image applications

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -86,7 +86,7 @@ manifest:
       revision: 821154171b246f64eaeef3ccc267f58d8274739a
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: e88113bbebe34ff2ccc6627ffae885cfeed6fdfd
+      revision: pull/18/head
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 5885efb7cabf7b566577b73129c9d277d7d8848d

--- a/west.yml
+++ b/west.yml
@@ -21,6 +21,8 @@ manifest:
   remotes:
     - name: upstream
       url-base: https://github.com/zephyrproject-rtos
+    - name: juul
+      url-base: https://github.com/JuulLabs-OSS
 
   #
   # Please add items below based on alphabetical order
@@ -86,7 +88,8 @@ manifest:
       revision: 821154171b246f64eaeef3ccc267f58d8274739a
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: pull/18/head
+      remote: juul
+      revision: pull/741/head
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 5885efb7cabf7b566577b73129c9d277d7d8848d


### PR DESCRIPTION
Enable using single image applications with mcuboot; such applications
are always using single partition and updates of such applications
overwrite the existing one.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

Changes to mcuboot reviewed here: https://github.com/JuulLabs-OSS/mcuboot/pull/741