### PR TITLE
boards: Make GPIO pin config default for LEDs instead of PWM

### DIFF
--- a/boards/arm/frdm_k82f/pinmux.c
+++ b/boards/arm/frdm_k82f/pinmux.c
@@ -33,7 +33,7 @@ static int frdm_k82f_pinmux_init(struct device *dev)
 		device_get_binding(CONFIG_PINMUX_MCUX_PORTE_NAME);
 #endif
 
-#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(ftm3), nxp_kinetis_ftm_pwm, okay)
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(ftm3), nxp_kinetis_ftm_pwm, okay) && CONFIG_PWM
 	/* Red, green, blue LEDs as PWM channels */
 	pinmux_pin_set(portc,  8, PORT_PCR_MUX(kPORT_MuxAlt3));
 	pinmux_pin_set(portc,  9, PORT_PCR_MUX(kPORT_MuxAlt3));

--- a/boards/arm/hexiwear_k64/pinmux.c
+++ b/boards/arm/hexiwear_k64/pinmux.c
@@ -30,7 +30,7 @@ static int hexiwear_k64_pinmux_init(struct device *dev)
 		device_get_binding(CONFIG_PINMUX_MCUX_PORTE_NAME);
 #endif
 
-#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(ftm3), nxp_kinetis_ftm_pwm, okay)
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(ftm3), nxp_kinetis_ftm_pwm, okay) && CONFIG_PWM
 	/* Red, green, blue LEDs as PWM channels */
 	pinmux_pin_set(portc,  8, PORT_PCR_MUX(kPORT_MuxAlt3));
 	pinmux_pin_set(portc,  9, PORT_PCR_MUX(kPORT_MuxAlt3));

--- a/boards/arm/twr_ke18f/pinmux.c
+++ b/boards/arm/twr_ke18f/pinmux.c
@@ -34,7 +34,7 @@ static int twr_ke18f_pinmux_init(struct device *dev)
 		device_get_binding(CONFIG_PINMUX_MCUX_PORTE_NAME);
 #endif
 
-#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(ftm0), nxp_kinetis_ftm_pwm, okay)
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(ftm0), nxp_kinetis_ftm_pwm, okay) && CONFIG_PWM
 	/* Tri-color LED as PWM */
 	pinmux_pin_set(portb, 5, PORT_PCR_MUX(kPORT_MuxAlt2));
 	pinmux_pin_set(portd, 15, PORT_PCR_MUX(kPORT_MuxAlt2));
@@ -46,7 +46,7 @@ static int twr_ke18f_pinmux_init(struct device *dev)
 	pinmux_pin_set(portd, 16, PORT_PCR_MUX(kPORT_MuxAsGpio));
 #endif
 
-#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(ftm3), nxp_kinetis_ftm_pwm, okay)
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(ftm3), nxp_kinetis_ftm_pwm, okay) && CONFIG_PWM
 	/* User LEDs as PWM */
 	pinmux_pin_set(portc, 10, PORT_PCR_MUX(kPORT_MuxAlt2));
 	pinmux_pin_set(portc, 11, PORT_PCR_MUX(kPORT_MuxAlt2));

--- a/boards/riscv/rv32m1_vega/pinmux.c
+++ b/boards/riscv/rv32m1_vega/pinmux.c
@@ -85,7 +85,7 @@ static int rv32m1_vega_pinmux_init(struct device *dev)
 	pinmux_pin_set(portb, 22, PORT_PCR_MUX(kPORT_MuxAlt2));
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(tpm2), okay)
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(tpm2), okay) && CONFIG_PWM
 	/* RGB LEDs as PWM */
 	pinmux_pin_set(porta, 22, PORT_PCR_MUX(kPORT_MuxAlt6));
 	pinmux_pin_set(porta, 23, PORT_PCR_MUX(kPORT_MuxAlt6));


### PR DESCRIPTION
Add an additional check for CONFIG_PWM to decide if pins associated with
LED are configured for GPIO or PWM.

Fixes #25337

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>