### PR TITLE
dma: stm32: increase driver init priority

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -646,7 +646,7 @@ static struct dma_stm32_data dma_stm32_data_##index = {			\
 DEVICE_AND_API_INIT(dma_##index, DT_INST_LABEL(index),	\
 		    &dma_stm32_init,					\
 		    &dma_stm32_data_##index, &dma_stm32_config_##index,	\
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
+		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
 		    &dma_funcs)
 
 #define irq_func(chan)                                                  \


### PR DESCRIPTION
DMA driver shall be initialized before any of its
clients. Right now, its initialization priority is
lower than that of UARTs. So, increase its init
priority to support future async uart drivers.