### PR TITLE
boards: decawave_dwm1001_dev: make button active low

### DIFF
--- a/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
+++ b/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
@@ -53,7 +53,7 @@
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
-			gpios = <&gpio0 2 GPIO_PULL_UP>;
+			gpios = <&gpio0 2 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button switch 0";
 		};
 	};


### PR DESCRIPTION
Make the board button active low.

Signed-off-by: Stéphane D'Alu <sdalu@sdalu.com>