### PR TITLE
drivers: pwm: remove extraneous whitespace

### DIFF
--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -59,7 +59,7 @@ __subsystem struct pwm_driver_api {
 
 /**
  * @brief Set the period and pulse width for a single PWM output.
- * 
+ *
  * Passing 0 to the @param pulse will cause the pin to be driven to a constant
  * inactive level.
  * Passing a @param pulse equal @param period will cause the pin to be driven


### PR DESCRIPTION
PR was merged before this was cleaned up.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>