### PR TITLE
edtlib: fix default type for interrupts property

### DIFF
--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -2348,7 +2348,7 @@ _DEFAULT_PROP_TYPES = {
     "reg": "array",
     "reg-names": "string-array",
     "label": "string",
-    "interrupt": "array",
+    "interrupts": "array",
     "interrupts-extended": "compound",
     "interrupt-names": "string-array",
     "interrupt-controller": "boolean",


### PR DESCRIPTION
The name of the interrupts property is typo-ed in the python script.

