### PR TITLE
arc: show ESF registers on exception

### DIFF
--- a/arch/arc/core/fatal.c
+++ b/arch/arc/core/fatal.c
@@ -16,21 +16,45 @@
 #include <offsets_short.h>
 #include <arch/cpu.h>
 #include <logging/log.h>
+#include <kernel_arch_data.h>
+#include <arch/arc/v2/exc.h>
+
 LOG_MODULE_DECLARE(os);
+
+#ifdef CONFIG_ARC_EXCEPTION_DEBUG
+static void dump_arc_esf(const z_arch_esf_t *esf)
+{
+	LOG_ERR(" r0: 0x%08x  r1: 0x%08x  r2: 0x%08x  r3: 0x%08x",
+		esf->r0, esf->r1, esf->r2, esf->r3);
+	LOG_ERR(" r4: 0x%08x  r5: 0x%08x  r6: 0x%08x  r7: 0x%08x",
+		esf->r4, esf->r5, esf->r6, esf->r7);
+	LOG_ERR(" r8: 0x%08x  r9: 0x%08x r10: 0x%08x r11: 0x%08x",
+		esf->r8, esf->r9, esf->r10, esf->r11);
+	LOG_ERR("r12: 0x%08x r13: 0x%08x  pc: 0x%08x",
+		esf->r12, esf->r13, esf->pc);
+	LOG_ERR(" blink: 0x%08x status32: 0x%08x", esf->blink, esf->status32);
+	LOG_ERR("lp_end: 0x%08x lp_start: 0x%08x lp_count: 0x%08x",
+		esf->lp_end, esf->lp_start, esf->lp_count);
+}
+#endif
 
 void z_arc_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 {
-	if (reason == K_ERR_CPU_EXCEPTION) {
-		LOG_ERR("Faulting instruction address = 0x%lx",
-			z_arc_v2_aux_reg_read(_ARC_V2_ERET));
+#ifdef CONFIG_ARC_EXCEPTION_DEBUG
+	if (esf != NULL) {
+		dump_arc_esf(esf);
 	}
+#endif /* CONFIG_ARC_EXCEPTION_DEBUG */
 
 	z_fatal_error(reason, esf);
 }
 
 FUNC_NORETURN void arch_syscall_oops(void *ssf_ptr)
 {
-	z_arc_fatal_error(K_ERR_KERNEL_OOPS, ssf_ptr);
+	/* TODO: convert ssf_ptr contents into an esf, they are not the same */
+	ARG_UNUSED(ssf_ptr);
+
+	z_arc_fatal_error(K_ERR_KERNEL_OOPS, NULL);
 	CODE_UNREACHABLE;
 }
 


### PR DESCRIPTION
The ESF contains register file contents including program
counter when the exception happened. If non-NULL and we
have ARC_EXCEPTION_DEBUG enabled, dump its contents to the
log stream.

Other arches do this already.

There is no need to read ERET, the ESF already contains the
interrupted PC value.

A future enhancement could create an option to additionally
push callee-saved register context into the ESF so it can
also be dumped out, but this patch does not address this.

A future enhancement could also convert the syscall
stack frame pointer passed to arch_syscall_oops() into
an ESF so that context of the failed system call can be
inferred.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>