### PR TITLE
net: mqtt: Make client "cleansession" flag configurable.

### DIFF
--- a/subsys/net/lib/mqtt/Kconfig
+++ b/subsys/net/lib/mqtt/Kconfig
@@ -35,4 +35,16 @@ config MQTT_LIB_WEBSOCKET
 	help
 	  Enable Websocket support for socket MQTT Library.
 
+config MQTT_CLEAN_SESSION
+	bool "MQTT Clean Session Flag."
+	help
+	  When a client connects to a MQTT broker using a persistent session,
+	  the message broker saves all subscriptions. When the client
+	  disconnects, the message broker stores unacknowledged QoS 1 messages
+	  and new QoS 1 messages published to topics to which the client is
+	  subscribed. When the client reconnects to the persistent session,
+	  all subscriptions are reinstated and all stored messages are sent to
+	  the client. Setting this flag to 0 allows the client to create a
+	  persistent session.
+
 endif # MQTT_LIB

--- a/subsys/net/lib/mqtt/mqtt.c
+++ b/subsys/net/lib/mqtt/mqtt.c
@@ -190,7 +190,7 @@ void mqtt_client_init(struct mqtt_client *client)
 	mqtt_mutex_init(client);
 
 	client->protocol_version = MQTT_VERSION_3_1_1;
-	client->clean_session = 1U;
+	client->clean_session = MQTT_CLEAN_SESSION;
 	client->keepalive = MQTT_KEEPALIVE;
 }
 

--- a/subsys/net/lib/mqtt/mqtt_internal.h
+++ b/subsys/net/lib/mqtt/mqtt_internal.h
@@ -26,6 +26,11 @@ extern "C" {
  */
 #define MQTT_KEEPALIVE CONFIG_MQTT_KEEPALIVE
 
+/**@brief Clean session on every connect (1) or keep subscriptions and messages
+ *        between connects (0)
+ */
+#define MQTT_CLEAN_SESSION (IS_ENABLED(CONFIG_MQTT_CLEAN_SESSION) ? 1U : 0U)
+
 /**@brief Minimum mandatory size of fixed header. */
 #define MQTT_FIXED_HEADER_MIN_SIZE 2
 


### PR DESCRIPTION
`cleansession` flag on the mqtt client is hardcoded to `1`, some use cases might require `0`. This commit makes that flag configurable via `Kconfig`

Signed-off-by: Xavier Naveira <xnaveira@gmail.com>