### PR TITLE
cmake: toolchain: Add zephyr-tools

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -4,8 +4,8 @@ compiler: gcc
 
 env:
     global:
-        - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.11.3
-        - ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+        - ZEPHYR_TOOLCHAIN_VARIANT="zephyr-tools"
+        - ZEPHYR_TOOLS_DEFAULT_TOOLCHAIN="arm-zephyr-eabi"
         - MATRIX_BUILDS="5"
     matrix:
         - MATRIX_BUILD="1"
@@ -25,6 +25,9 @@ build:
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 
     ci:
+      - sudo add-apt-repository -yu ppa:zephyrproject-rtos/sdk
+      - sudo apt install zephyr-crosstool
+      - sudo apt install zephyr-qemu
       - export CCACHE_DIR=${SHIPPABLE_BUILD_DIR}/ccache/.ccache
       - >
         if [ "$IS_PULL_REQUEST" = "true" ]; then

--- a/boards/arm/qemu_cortex_r5/qemu_cortex_r5.yaml
+++ b/boards/arm/qemu_cortex_r5/qemu_cortex_r5.yaml
@@ -4,7 +4,7 @@ type: qemu
 simulation: qemu
 arch: arm
 toolchain:
-  - zephyr
+  # - zephyr
   - gnuarmemb
   - xtools
 ram: 65536

--- a/cmake/bintools/gnu/target.cmake
+++ b/cmake/bintools/gnu/target.cmake
@@ -2,16 +2,21 @@
 
 # Configures binary tools as GNU binutils
 
-find_program(CMAKE_OBJCOPY ${CROSS_COMPILE}objcopy PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_OBJDUMP ${CROSS_COMPILE}objdump PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_AS      ${CROSS_COMPILE}as      PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_AR      ${CROSS_COMPILE}ar      PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_RANLIB  ${CROSS_COMPILE}ranlib  PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_READELF ${CROSS_COMPILE}readelf PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_NM      ${CROSS_COMPILE}nm      PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+if(DEFINED TOOLCHAIN_HOME)
+  set(find_program_binutils_args PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+  set(find_program_gdb_multiarch_args PATHS ${TOOLCHAIN_HOME})
+endif()
 
-find_program(CMAKE_GDB     ${CROSS_COMPILE}gdb     PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_GDB     gdb-multiarch           PATHS ${TOOLCHAIN_HOME}                )
+find_program(CMAKE_OBJCOPY ${CROSS_COMPILE}objcopy ${find_program_binutils_args})
+find_program(CMAKE_OBJDUMP ${CROSS_COMPILE}objdump ${find_program_binutils_args})
+find_program(CMAKE_AS      ${CROSS_COMPILE}as      ${find_program_binutils_args})
+find_program(CMAKE_AR      ${CROSS_COMPILE}ar      ${find_program_binutils_args})
+find_program(CMAKE_RANLIB  ${CROSS_COMPILE}ranlib  ${find_program_binutils_args})
+find_program(CMAKE_READELF ${CROSS_COMPILE}readelf ${find_program_binutils_args})
+find_program(CMAKE_NM      ${CROSS_COMPILE}nm      ${find_program_binutils_args})
+
+find_program(CMAKE_GDB     ${CROSS_COMPILE}gdb     ${find_program_binutils_args})
+find_program(CMAKE_GDB     gdb-multiarch           ${find_program_gdb_multiarch_args})
 
 # Include bin tool abstraction macros
 include(${ZEPHYR_BASE}/cmake/bintools/gnu/target_memusage.cmake)

--- a/cmake/compiler/gcc/generic.cmake
+++ b/cmake/compiler/gcc/generic.cmake
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(DEFINED TOOLCHAIN_HOME)
+  set(find_program_gcc_args PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+endif()
+
 set_ifndef(CC gcc)
 
-find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC}   PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC} ${find_program_gcc_args})
 
 if(CMAKE_C_COMPILER STREQUAL CMAKE_C_COMPILER-NOTFOUND)
   message(FATAL_ERROR "Zephyr was unable to find the toolchain. Is the environment misconfigured?

--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(DEFINED TOOLCHAIN_HOME)
+  set(find_program_gcc_args PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+endif()
+
 set_ifndef(C++ g++)
 
 # Configures CMake for using GCC, this script is re-used by several
 # GCC-based toolchains
 
-find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC} PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC} ${find_program_gcc_args})
 if(${CMAKE_C_COMPILER} STREQUAL CMAKE_C_COMPILER-NOTFOUND)
   message(FATAL_ERROR "C compiler ${CROSS_COMPILE}${CC} not found - Please check your toolchain installation")
 endif()
@@ -22,7 +26,7 @@ else()
     set(cplusplus_compiler ${CMAKE_C_COMPILER})
   endif()
 endif()
-find_program(CMAKE_CXX_COMPILER ${cplusplus_compiler} PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_CXX_COMPILER ${cplusplus_compiler} ${find_program_gcc_args})
 
 set(NOSTDINC "")
 

--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -52,9 +52,8 @@ include(${ZEPHYR_BASE}/cmake/gcc-m-cpu.cmake)
 if("${ARCH}" STREQUAL "arm")
   include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_arm.cmake)
 elseif("${ARCH}" STREQUAL "arc")
-  list(APPEND TOOLCHAIN_C_FLAGS
-    -mcpu=${GCC_M_CPU}
-    )
+  list(APPEND TOOLCHAIN_C_FLAGS   -mcpu=${GCC_M_CPU})
+  list(APPEND TOOLCHAIN_LD_FLAGS  -mcpu=${GCC_M_CPU})
 elseif("${ARCH}" STREQUAL "riscv")
   include(${CMAKE_CURRENT_LIST_DIR}/target_riscv.cmake)
 elseif("${ARCH}" STREQUAL "x86")

--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -69,13 +69,18 @@ if(NOT no_libgcc)
     OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 
-  assert_exists(LIBGCC_FILE_NAME)
+  # The libgcc path queried above may not be accessible from the host system if
+  # the toolchain executable is running inside a sandboxed environment (e.g. as
+  # a Snap package); in this case, rely on the toolchain to properly resolve
+  # the relative libgcc path.
+  if(EXISTS ${LIBGCC_FILE_NAME})
+    get_filename_component(LIBGCC_DIR ${LIBGCC_FILE_NAME} DIRECTORY)
 
-  get_filename_component(LIBGCC_DIR ${LIBGCC_FILE_NAME} DIRECTORY)
+    assert_exists(LIBGCC_DIR)
 
-  assert_exists(LIBGCC_DIR)
+    LIST(APPEND LIB_INCLUDE_DIR "-L\"${LIBGCC_DIR}\"")
+  endif()
 
-  LIST(APPEND LIB_INCLUDE_DIR "-L\"${LIBGCC_DIR}\"")
   LIST(APPEND TOOLCHAIN_LIBS gcc)
 endif()
 

--- a/cmake/compiler/gcc/target_riscv.cmake
+++ b/cmake/compiler/gcc/target_riscv.cmake
@@ -7,6 +7,7 @@ if(CONFIG_64BIT)
     string(CONCAT riscv_mabi  ${riscv_mabi} "64")
     string(CONCAT riscv_march ${riscv_march} "64ima")
     list(APPEND TOOLCHAIN_C_FLAGS -mcmodel=medany)
+    list(APPEND TOOLCHAIN_LD_FLAGS -mcmodel=medany)
 else()
     string(CONCAT riscv_mabi  "i" ${riscv_mabi} "32")
     string(CONCAT riscv_march ${riscv_march} "32ima")
@@ -31,4 +32,9 @@ if(CONFIG_COMPRESSED_ISA)
 endif()
 
 list(APPEND TOOLCHAIN_C_FLAGS -mabi=${riscv_mabi} -march=${riscv_march})
-list(APPEND TOOLCHAIN_LD_FLAGS -mabi=${riscv_mabi} -march=${riscv_march})
+
+# The double quotes below ensure that the `-mabi` and `-march` flags are
+# evaluated together by `target_ld_options`. This is necessary because
+# specifying only either one of the flags will cause compilation to fail and
+# that will effectively omit these flags.
+list(APPEND TOOLCHAIN_LD_FLAGS "-mabi=${riscv_mabi} -march=${riscv_march}")

--- a/cmake/compiler/xcc/generic.cmake
+++ b/cmake/compiler/xcc/generic.cmake
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(DEFINED TOOLCHAIN_HOME)
+  set(find_program_xcc_args PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+endif()
+
 set_ifndef(CC gcc)
 
-find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC}   PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC} ${find_program_xcc_args})
 
 if(CMAKE_C_COMPILER STREQUAL CMAKE_C_COMPILER-NOTFOUND)
   message(FATAL_ERROR "Zephyr was unable to find the toolchain. Is the environment misconfigured?

--- a/cmake/compiler/xcc/target.cmake
+++ b/cmake/compiler/xcc/target.cmake
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(DEFINED TOOLCHAIN_HOME)
+  set(find_program_xcc_args PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+endif()
+
 set_ifndef(C++ g++)
 
 # Configures CMake for using GCC, this script is re-used by several
 # GCC-based toolchains
 
-find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC} PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC} ${find_program_xcc_args})
 
 if(CONFIG_CPLUSPLUS)
   set(cplusplus_compiler ${CROSS_COMPILE}${C++})
@@ -19,7 +23,7 @@ else()
     set(cplusplus_compiler ${CMAKE_C_COMPILER})
   endif()
 endif()
-find_program(CMAKE_CXX_COMPILER ${cplusplus_compiler} PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_CXX_COMPILER ${cplusplus_compiler} ${find_program_xcc_args})
 
 set(NOSTDINC "")
 

--- a/cmake/emu/qemu.cmake
+++ b/cmake/emu/qemu.cmake
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(DEFINED QEMU_BIN_PREFIX)
+  set_ifndef(QEMU_binary_name ${QEMU_BIN_PREFIX}-qemu-system)
+else()
+  set_ifndef(QEMU_binary_name qemu-system)
+endif()
+
 if("${ARCH}" STREQUAL "x86")
   set_ifndef(QEMU_binary_suffix i386)
 elseif(DEFINED QEMU_ARCH)
@@ -14,12 +20,12 @@ find_program(
   QEMU
   PATHS ${qemu_alternate_path}
   NO_DEFAULT_PATH
-  NAMES qemu-system-${QEMU_binary_suffix}
+  NAMES ${QEMU_binary_name}-${QEMU_binary_suffix}
   )
 else()
 find_program(
   QEMU
-  qemu-system-${QEMU_binary_suffix}
+  ${QEMU_binary_name}-${QEMU_binary_suffix}
   )
 endif()
 

--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
-find_program(CMAKE_LINKER     ${CROSS_COMPILE}ld      PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+if(DEFINED TOOLCHAIN_HOME)
+  set(find_program_ld_args PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+endif()
+
+find_program(CMAKE_LINKER     ${CROSS_COMPILE}ld      ${find_program_ld_args})
 
 set_ifndef(LINKERFLAGPREFIX -Wl)
 

--- a/cmake/toolchain/zephyr-tools/Kconfig
+++ b/cmake/toolchain/zephyr-tools/Kconfig
@@ -1,0 +1,6 @@
+# Copyright (c) 2020 Stephanos Ioannidis <root@stephanos.io>
+# SPDX-License-Identifier: Apache-2.0
+
+config TOOLCHAIN_ZEPHYR_TOOLS
+	def_bool y
+	select HAS_NEWLIB_LIBC_NANO if (ARC || (ARM && !ARM64) || RISCV)

--- a/cmake/toolchain/zephyr-tools/generic.cmake
+++ b/cmake/toolchain/zephyr-tools/generic.cmake
@@ -1,0 +1,24 @@
+# Copyright (c) 2020 Stephanos Ioannidis <root@stephanos.io>
+# SPDX-License-Identifier: Apache-2.0
+
+set_ifndef(ZEPHYR_TOOLS_DEFAULT_TOOLCHAIN $ENV{ZEPHYR_TOOLS_DEFAULT_TOOLCHAIN})
+assert(ZEPHYR_TOOLS_DEFAULT_TOOLCHAIN "ZEPHYR_TOOLS_DEFAULT_TOOLCHAIN is not set")
+
+set(COMPILER gcc)
+set(LINKER ld)
+set(BINTOOLS gnu)
+
+set(CROSS_COMPILE ${ZEPHYR_TOOLS_DEFAULT_TOOLCHAIN}-)
+set(TOOLCHAIN_HAS_NEWLIB ON CACHE BOOL "True if toolchain supports newlib")
+
+# Assume that the C++ compiler executable name is 'gxx' if 'g++' for the
+# default toolchain cannot be found. This is necessary in order to support the
+# Snap packages that have the 'g++' executable aliased as 'gxx' because Snap
+# does not allow using the '+' character in the command/alias names.
+find_program(ZEPHYR_TOOLS_CXX_COMPILER ${CROSS_COMPILE}g++)
+
+if(${ZEPHYR_TOOLS_CXX_COMPILER} STREQUAL ZEPHYR_TOOLS_CXX_COMPILER-NOTFOUND)
+  set(C++ gxx)
+endif()
+
+message(STATUS "Found toolchain: zephyr-tools")

--- a/cmake/toolchain/zephyr-tools/target.cmake
+++ b/cmake/toolchain/zephyr-tools/target.cmake
@@ -1,0 +1,41 @@
+# Copyright (c) 2020 Stephanos Ioannidis <root@stephanos.io>
+# SPDX-License-Identifier: Apache-2.0
+
+set(CROSS_COMPILE_TARGET_arc_CPU        arc)
+set(CROSS_COMPILE_TARGET_arc_SYS        elf)
+if(CONFIG_ARM64)
+  set(CROSS_COMPILE_TARGET_arm_CPU      aarch64)
+  set(CROSS_COMPILE_TARGET_arm_SYS      elf)
+else()
+  set(CROSS_COMPILE_TARGET_arm_CPU      arm)
+  set(CROSS_COMPILE_TARGET_arm_SYS      eabi)
+endif()
+set(CROSS_COMPILE_TARGET_nios2_CPU      nios2)
+set(CROSS_COMPILE_TARGET_nios2_SYS      elf)
+set(CROSS_COMPILE_TARGET_riscv_CPU      riscv64)
+set(CROSS_COMPILE_TARGET_riscv_SYS      elf)
+set(CROSS_COMPILE_TARGET_x86_CPU        x86_64)
+set(CROSS_COMPILE_TARGET_x86_SYS        elf)
+set(CROSS_COMPILE_TARGET_xtensa_CPU     xtensa)
+set(CROSS_COMPILE_TARGET_xtensa_SYS     elf)
+
+set(CROSS_COMPILE_TARGET_CPU ${CROSS_COMPILE_TARGET_${ARCH}_CPU})
+set(CROSS_COMPILE_TARGET_SYS ${CROSS_COMPILE_TARGET_${ARCH}_SYS})
+
+if("${ARCH}" STREQUAL "xtensa")
+  set(CROSS_COMPILE ${CROSS_COMPILE_TARGET_CPU}-${SOC_NAME}_zephyr-${CROSS_COMPILE_TARGET_SYS}-)
+else()
+  set(CROSS_COMPILE ${CROSS_COMPILE_TARGET_CPU}-zephyr-${CROSS_COMPILE_TARGET_SYS}-)
+endif()
+
+if("${ARCH}" STREQUAL "x86")
+  if(CONFIG_X86_64)
+    list(APPEND TOOLCHAIN_C_FLAGS -m64)
+    list(APPEND TOOLCHAIN_LD_FLAGS -m64)
+  else()
+    list(APPEND TOOLCHAIN_C_FLAGS -m32)
+    list(APPEND TOOLCHAIN_LD_FLAGS -m32)
+  endif()
+endif()
+
+set(QEMU_BIN_PREFIX zephyr)

--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -2483,6 +2483,10 @@ class TestSuite(DisablePyTestCollectionMixin):
         if toolchain == "gccarmemb":
             # Remove this translation when gccarmemb is no longer supported.
             toolchain = "gnuarmemb"
+        elif toolchain == "zephyr-tools":
+            # Map 'zephyr-tools' toolchain type to 'zephyr' since they are
+            # functionally equivalent
+            toolchain = "zephyr"
 
         try:
             if not toolchain:

--- a/soc/xtensa/intel_apl_adsp/common/bootloader/CMakeLists.txt
+++ b/soc/xtensa/intel_apl_adsp/common/bootloader/CMakeLists.txt
@@ -23,8 +23,6 @@ add_executable(bootloader
 
 add_dependencies(bootloader ${SYSCALL_LIST_H_TARGET})
 
-set(zephyr_sdk $ENV{ZEPHYR_SDK_INSTALL_DIR})
-
 target_include_directories(bootloader PUBLIC
   ./
   ${ZEPHYR_BASE}/include
@@ -39,9 +37,15 @@ set_source_files_properties(${ARCH_DIR}/${ARCH}/core/startup/reset-vector.S PROP
 target_compile_options(bootloader PUBLIC -fno-inline-functions -mlongcalls -mtext-section-literals -imacros${CMAKE_BINARY_DIR}/zephyr/include/generated/autoconf.h)
 
 target_link_libraries(bootloader PUBLIC -Wl,--no-check-sections -ucall_user_start -Wl,-static -nostdlib)
-target_link_libraries(bootloader PRIVATE -lhal -L${zephyr_sdk}/xtensa/intel_apl_adsp/xtensa-zephyr-elf/lib)
 target_link_libraries(bootloader PRIVATE -T${SOC_DIR}/${ARCH}/${SOC_FAMILY}/common/bootloader/boot_ldr.x)
 
 if(CONFIG_XTENSA_HAL)
+  # Use Xtensa HAL module if available
   target_link_libraries(bootloader PRIVATE XTENSA_HAL)
+  target_link_libraries(bootloader PRIVATE modules_xtensa_hal)
+else()
+  # Use toolchain-embedded Xtensa HAL otherwise
+  set(zephyr_sdk $ENV{ZEPHYR_SDK_INSTALL_DIR})
+
+  target_link_libraries(bootloader PRIVATE -lhal -L${zephyr_sdk}/xtensa/intel_apl_adsp/xtensa-zephyr-elf/lib)
 endif()


### PR DESCRIPTION
### Summary

```
This commit introduces a new toolchain type called `zephyr-tools`.

The `zephyr-tools` toolchain type is intended to be used with the new
package-based `zephyr-crosstool-ng` toolchain distribution, and
requires the toolchain executables to be available in the `PATH`.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```

### Environment Configuration

1. Install toolchain packages.

    **[Ubuntu Package](https://github.com/stephanosio/deb-zephyr)**
    ```
    sudo add-apt-repository ppa:zephyrproject-rtos/sdk
    sudo apt install zephyr-crosstool
    sudo apt install zephyr-qemu
    ```

    **[Linux Snap Package](https://github.com/stephanosio/snap-zephyr)**
    ```
    sudo snap install zephyr-crosstool-*
    sudo snap install zephyr-qemu
    ```

    **[macOS Brew Package](https://github.com/stephanosio/homebrew-zephyr)**
    ```
    brew tap stephanosio/homebrew-zephyr
    brew install zephyr-crosstool
    brew install zephyr-qemu
    ```

    **[Windows Chocolatey Package](https://github.com/stephanosio/chocolatey-zephyr)**
    ```
    choco install zephyr-crosstool
    choco install zephyr-qemu
    ```

2. Set toolchain configurations

    **Linux and macOS**
    ```sh
    export ZEPHYR_TOOLCHAIN_VARIANT="zephyr-tools"
    export ZEPHYR_TOOLS_DEFAULT_TOOLCHAIN="arm-zephyr-eabi"
    ```

    **Windows**
    ```sh
    set ZEPHYR_TOOLCHAIN_VARIANT=zephyr-tools
    set ZEPHYR_TOOLS_DEFAULT_TOOLCHAIN=arm-zephyr-eabi
    ```

    _NOTE: `ZEPHYR_TOOLS_DEFAULT_TOOLCHAIN` is the "generic" toolchain used for pre-"target" pre-processing. It does not really matter which you choose, as long as it is available in the `PATH`._

3. Check out this PR branch

    ```
    git fetch upstream pull/25475/head:pr_25475
    git checkout pr_25475
    ```

### Progress

#### Toolchain
- [x] Linux toolchains successfully build Zephyr targets
- [x] macOS toolchains successfully build Zephyr targets
- [x] Windows toolchains successfully build Zephyr targets
- [x] Snap (Linux) toolchain packages are available
- [x] Brew (macOS) toolchain packages are available
- [x] Chocolatey (Windows) toolchain packages are available (xtensa toolchain packages are pending approval)

#### QEMU
- [x] Linux QEMU successfully emulates Zephyr targets
- [x] macOS QEMU successfully emulates Zephyr targets
- [x] Windows QEMU successfully emulates Zephyr targets
- [x] Snap (Linux) QEMU packages are available
- [x] Brew (macOS) QEMU packages are available
- [x] Chocolatey (Windows) QEMU packages are available (xtensa toolchain packages are pending approval)

#### OpenOCD
- [ ] Linux OpenOCD successfully debugs Zephyr targets
- [ ] macOS OpenOCD successfully debugs Zephyr targets
- [ ] Windows OpenOCD successfully debugs Zephyr targets
- [ ] Snap (Linux) OpenOCD packages are available
- [ ] Brew (macOS) OpenOCD packages are available
- [ ] Chocolatey (Windows) QEMU packages are available