### PR TITLE
west.yml: Update mcuboot with rename fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -86,7 +86,7 @@ manifest:
       revision: 821154171b246f64eaeef3ccc267f58d8274739a
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: e88113bbebe34ff2ccc6627ffae885cfeed6fdfd
+      revision: f6252674aaef5988222925f1dfc05e68df2da2c6
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 5885efb7cabf7b566577b73129c9d277d7d8848d


### PR DESCRIPTION
Update mcuboot version to include fix:
Update CONFIG_FLOAT to CONFIG_FPU which has been renamed in zephyr.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>