### PR TITLE
Updated extern array with size 0 declarations to fix compiler warnings

### DIFF
--- a/include/logging/log_backend.h
+++ b/include/logging/log_backend.h
@@ -62,8 +62,8 @@ struct log_backend {
 	bool autostart;
 };
 
-extern const struct log_backend __log_backends_start[0];
-extern const struct log_backend __log_backends_end[0];
+extern const struct log_backend __log_backends_start[];
+extern const struct log_backend __log_backends_end[];
 
 /**
  * @brief Macro for creating a logger backend instance.

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -413,8 +413,8 @@ static inline char z_log_minimal_level_to_char(int level)
  */
 #define LOG_LEVEL_INTERNAL_RAW_STRING LOG_LEVEL_NONE
 
-extern struct log_source_const_data __log_const_start[0];
-extern struct log_source_const_data __log_const_end[0];
+extern struct log_source_const_data __log_const_start[];
+extern struct log_source_const_data __log_const_end[];
 
 /** @brief Get name of the log source.
  *
@@ -456,8 +456,8 @@ static inline u32_t log_sources_count(void)
 	return log_const_source_id(__log_const_end);
 }
 
-extern struct log_source_dynamic_data __log_dynamic_start[0];
-extern struct log_source_dynamic_data __log_dynamic_end[0];
+extern struct log_source_dynamic_data __log_dynamic_start[];
+extern struct log_source_dynamic_data __log_dynamic_end[];
 
 /** @brief Creates name of variable and section for runtime log data.
  *

--- a/subsys/cpp/cpp_init_array.c
+++ b/subsys/cpp/cpp_init_array.c
@@ -11,8 +11,8 @@
 
 typedef void (*func_ptr)(void);
 
-extern func_ptr __init_array_start[0];
-extern func_ptr __init_array_end[0];
+extern func_ptr __init_array_start[];
+extern func_ptr __init_array_end[];
 
 /**
  * @brief Execute initialization routines referenced in .init_array section

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -7,8 +7,8 @@
 #include "shell_utils.h"
 #include "shell_wildcard.h"
 
-extern const struct shell_cmd_entry __shell_root_cmds_start[0];
-extern const struct shell_cmd_entry __shell_root_cmds_end[0];
+extern const struct shell_cmd_entry __shell_root_cmds_start[];
+extern const struct shell_cmd_entry __shell_root_cmds_end[];
 
 static inline const struct shell_cmd_entry *shell_root_cmd_get(u32_t id)
 {


### PR DESCRIPTION
GCC throws a warning if an extern array is declared with `[0]` and if the array is accessed in any way. Changing the declaration to use `[]` instead of `[0]` fixes this issue. 

Fixes #26017