### PR TITLE
correct device pm control return value for unimplemented handlers

### DIFF
--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -31,7 +31,7 @@ int __weak z_clock_driver_init(struct device *device)
 int __weak z_clock_device_ctrl(struct device *device, u32_t ctrl_command,
 			       void *context, device_pm_cb cb, void *arg)
 {
-	return 0;
+	return -ENOTSUP;
 }
 
 void __weak z_clock_set_timeout(s32_t ticks, bool idle)

--- a/include/device.h
+++ b/include/device.h
@@ -387,7 +387,7 @@ void device_busy_clear(struct device *busy_dev);
  * @param cb Unused
  * @param unused_arg Unused
  *
- * @retval 0 Always returns 0
+ * @retval -ENOTSUP for all operations.
  */
 int device_pm_control_nop(struct device *unused_device,
 			  u32_t unused_ctrl_command,

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -124,7 +124,7 @@ int device_pm_control_nop(struct device *unused_device,
 		       device_pm_cb cb,
 		       void *unused_arg)
 {
-	return 0;
+	return -ENOTSUP;
 }
 
 void device_list_get(struct device **device_list, int *device_count)

--- a/subsys/power/device.c
+++ b/subsys/power/device.c
@@ -95,7 +95,7 @@ static int _sys_pm_devices(u32_t state)
 		 * and set the device states accordingly.
 		 */
 		rc = device_set_power_state(dev, state, NULL, NULL);
-		if (rc != 0) {
+		if ((rc != -ENOTSUP) && (rc != 0)) {
 			LOG_DBG("%s did not enter %s state: %d",
 				dev->name, device_pm_state_str(state), rc);
 			return rc;

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -208,6 +208,11 @@ void test_dummy_device_pm(void)
 
 	/* Set device state to DEVICE_PM_ACTIVE_STATE */
 	ret = device_set_power_state(dev, DEVICE_PM_ACTIVE_STATE, NULL, NULL);
+	if (ret == -ENOTSUP) {
+		zassert_true((ret == -ENOTSUP),
+			     "Power management not supported on device");
+		return;
+	}
 	zassert_true((ret == 0), "Unable to set active state to device");
 
 	device_busy_set(dev);


### PR DESCRIPTION
`device_pm_control_nop` indicates success for all operations without doing anything.  So does the weak system timer pm control handler.  Make them return an error so callers are not deceived into thinking the unmodified output parameter to `device_get_power_state()` actually represents something meaningful.