### PR TITLE
usb: driver: nordic: Unlock mutex in case of error.

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1862,6 +1862,7 @@ int usb_dc_ep_read_continue(u8_t ep)
 			struct usbd_event *ev = usbd_evt_alloc();
 
 			if (!ev) {
+				k_mutex_unlock(&ctx->drv_lock);
 				return -ENOMEM;
 			}
 


### PR DESCRIPTION
Mutex that was previously locked must be unlocked in case
of an error.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>