### PR TITLE
dts: nrf5340_cpuapp: add cryptocell node

### DIFF
--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -89,6 +89,21 @@
 		};
 
 		/* Additional Secure peripherals */
+		cryptocell: crypto@50844000 {
+			compatible = "nordic,nrf-cc312";
+			reg = <0x50844000 0x1000>;
+			label = "CRYPTOCELL";
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			cryptocell312: crypto@50845000 {
+				compatible = "arm,cryptocell-312";
+				reg = <0x50845000 0x1000>;
+				interrupts = <68 1>;
+				label = "CRYPTOCELL312";
+			};
+		};
+
 		gpiote: gpiote@5000d000 {
 			compatible = "nordic,nrf-gpiote";
 			reg = <0x5000d000 0x1000>;

--- a/dts/bindings/crypto/arm,cryptocell-312.yaml
+++ b/dts/bindings/crypto/arm,cryptocell-312.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2018, 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: ARM TrustZone CryptoCell 312
+
+compatible: "arm,cryptocell-312"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true
+
+    label:
+      required: true
+
+    interrupts:
+      required: true

--- a/dts/bindings/crypto/nordic,nrf-cc312.yaml
+++ b/dts/bindings/crypto/nordic,nrf-cc312.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2018, 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nordic Control Interface for ARM TrustZone CryptoCell 312
+
+compatible: "nordic,nrf-cc312"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true
+
+    label:
+      required: true


### PR DESCRIPTION
Add the missing node. This is a secure-mapped peripheral, so do not
add it to the common include file nrf5340_cpuapp_common.dtsi.

Fixes: #25493
