### PR TITLE
drivers: wifi: esp: respect wifi-reset-gpios dts flags

### DIFF
--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -38,7 +38,7 @@ static struct modem_pin modem_pins[] = {
 #if DT_INST_NODE_HAS_PROP(0, wifi_reset_gpios)
 	MODEM_PIN(DT_INST_GPIO_LABEL(0, wifi_reset_gpios),
 		  DT_INST_GPIO_PIN(0, wifi_reset_gpios),
-		  GPIO_OUTPUT),
+		  DT_INST_GPIO_FLAGS(0, wifi_reset_gpios) | GPIO_OUTPUT),
 #endif
 };
 


### PR DESCRIPTION
wifi-reset-gpios flags were not respected so far. Take them into
account, so configuring reset as active low works as expected.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>