### PR TITLE
tests: timing_info: cleanup timing calculation code

### DIFF
--- a/tests/benchmarks/timing_info/src/timing_info.h
+++ b/tests/benchmarks/timing_info/src/timing_info.h
@@ -6,15 +6,9 @@
 #include <timestamp.h>
 #include <kernel_internal.h>
 
-#define CALCULATE_TIME(special_char, profile, name)			     \
-	{								     \
-		total_##profile##_##name##_time = CYCLES_TO_NS( \
-			special_char##profile##_##name##_end_time -	     \
-			special_char##profile##_##name##_start_time);	     \
-	}
-
-#define DECLARE_VAR(profile, name) \
-	uint64_t total_##profile##_##name##_time;
+#define CALCULATE_CYCLES(profile, name)					\
+	((profile##_##name##_end_time) -				\
+	 (profile##_##name##_start_time))
 
 /* Stack size for all the threads created in this benchmark */
 #define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)
@@ -103,8 +97,9 @@
 #define CYCLES_PER_SEC   (16000000/(1 << NRF_TIMER2->PRESCALER))
 
 #define CYCLES_TO_NS(x)        ((x) * (NANOSECS_PER_SEC/CYCLES_PER_SEC))
-#define PRINT_STATS(x, y, z)   PRINT_F(x, (y*((SystemCoreClock)/	\
-					      CYCLES_PER_SEC)), z)
+#define PRINT_STATS(x, y) \
+	PRINT_F(x, (y * ((SystemCoreClock) / CYCLES_PER_SEC)), \
+		CYCLES_TO_NS(y))
 
 /* Configure Timer parameters */
 static inline void benchmark_timer_init(void)
@@ -138,7 +133,7 @@ static inline uint32_t get_core_freq_MHz(void)
 #define NANOSECS_PER_SEC	(1000000000)
 #define CYCLES_PER_SEC		(48000000)
 #define CYCLES_TO_NS(x)		((x) * (NANOSECS_PER_SEC/CYCLES_PER_SEC))
-#define PRINT_STATS(x, y, z)   PRINT_F(x, y, z)
+#define PRINT_STATS(x, y)	PRINT_F(x, y, CYCLES_TO_NS(y))
 
 /* Configure Timer parameters */
 static inline void benchmark_timer_init(void)
@@ -190,7 +185,7 @@ static inline uint32_t get_core_freq_MHz(void)
 	return x86_get_timer_freq_MHz();
 }
 
-#define PRINT_STATS(x, y, z)   PRINT_F(x, y, z)
+#define PRINT_STATS(x, y)	PRINT_F(x, y, CYCLES_TO_NS(y))
 
 #else  /* All other architectures */
 /* Done because weak attribute doesn't work on static inline. */
@@ -206,7 +201,7 @@ static inline uint32_t get_core_freq_MHz(void)
 	return  (sys_clock_hw_cycles_per_sec() / 1000000);
 }
 
-#define PRINT_STATS(x, y, z)   PRINT_F(x, y, z)
+#define PRINT_STATS(x, y)	PRINT_F(x, y, CYCLES_TO_NS(y))
 #endif /* CONFIG_NRF_RTC_TIMER */
 
 /******************************************************************************/

--- a/tests/benchmarks/timing_info/src/yield_bench.c
+++ b/tests/benchmarks/timing_info/src/yield_bench.c
@@ -22,8 +22,8 @@ extern char sline[];
 
 extern uint64_t thread_sleep_start_time;
 extern uint64_t thread_sleep_end_time;
-uint64_t thread_start_time;
-uint64_t thread_end_time;
+uint64_t thread_yield_start_time;
+uint64_t thread_yield_end_time;
 static uint32_t count;
 
 void thread_yield0_test(void *p1, void *p2, void *p3);
@@ -33,8 +33,9 @@ k_tid_t yield0_tid;
 k_tid_t yield1_tid;
 void yield_bench(void)
 {
-	/* Thread yield*/
+	/* Thread yield */
 	k_sleep(K_MSEC(10));
+
 	yield0_tid = k_thread_create(&my_thread, my_stack_area,
 				     STACK_SIZE,
 				     thread_yield0_test,
@@ -47,22 +48,22 @@ void yield_bench(void)
 				     NULL, NULL, NULL,
 				     0 /*priority*/, 0, K_NO_WAIT);
 
-	/*read the time of start of the sleep till the swap happens */
+	/* read the time of start of the sleep till the swap happens */
 	arch_timing_value_swap_end = 1U;
 
 	TIMING_INFO_PRE_READ();
-	thread_sleep_start_time =   TIMING_INFO_OS_GET_TIME();
+	thread_sleep_start_time = TIMING_INFO_OS_GET_TIME();
+
 	k_sleep(K_MSEC(1000));
-	thread_sleep_end_time =   ((uint32_t)arch_timing_value_swap_common);
 
-	uint32_t yield_cycles = (thread_end_time - thread_start_time) / 2000U;
-	uint32_t sleep_cycles = thread_sleep_end_time - thread_sleep_start_time;
+	thread_sleep_end_time = arch_timing_value_swap_common;
 
-	PRINT_STATS("Thread yield", yield_cycles,
-		CYCLES_TO_NS(yield_cycles));
-	PRINT_STATS("Thread sleep", sleep_cycles,
-		CYCLES_TO_NS(sleep_cycles));
+	uint32_t yield_cycles = CALCULATE_CYCLES(thread, yield) / 2000U;
+	uint32_t sleep_cycles = CALCULATE_CYCLES(thread, sleep);
 
+	PRINT_STATS("Thread yield", yield_cycles);
+
+	PRINT_STATS("Thread sleep", sleep_cycles);
 }
 
 
@@ -70,13 +71,13 @@ void thread_yield0_test(void *p1, void *p2, void *p3)
 {
 	k_sem_take(&yield_sem, K_MSEC(10));
 	TIMING_INFO_PRE_READ();
-	thread_start_time =  TIMING_INFO_OS_GET_TIME();
+	thread_yield_start_time = TIMING_INFO_OS_GET_TIME();
 	while (count != 1000U) {
 		count++;
 		k_yield();
 	}
 	TIMING_INFO_PRE_READ();
-	thread_end_time =  TIMING_INFO_OS_GET_TIME();
+	thread_yield_end_time = TIMING_INFO_OS_GET_TIME();
 	k_thread_abort(yield1_tid);
 }
 


### PR DESCRIPTION
() This is simply to clean up the code for cycles and timing
   calculations as there are quite a bit of unnecessary AND
   operations.
() This also moves the cycle calculation closer to the print
   statement as a few calculations were done between grabbing
   counter values.
() PRINT_STATS() now takes only two parameters as the third
   one was always calling CYCLES_TO_NS(2nd) anyway.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>