### PR TITLE
drivers: wifi: esp: fix reset control logic and respect reset dts flags

### DIFF
--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -38,7 +38,7 @@ static struct modem_pin modem_pins[] = {
 #if DT_INST_NODE_HAS_PROP(0, wifi_reset_gpios)
 	MODEM_PIN(DT_INST_GPIO_LABEL(0, wifi_reset_gpios),
 		  DT_INST_GPIO_PIN(0, wifi_reset_gpios),
-		  GPIO_OUTPUT),
+		  DT_INST_GPIO_FLAGS(0, wifi_reset_gpios) | GPIO_OUTPUT),
 #endif
 };
 
@@ -745,9 +745,9 @@ static void esp_reset(struct esp_data *dev)
 	}
 
 #if DT_INST_NODE_HAS_PROP(0, wifi_reset_gpios)
-	modem_pin_write(&dev->mctx, WIFI_RESET, 0);
-	k_sleep(K_MSEC(100));
 	modem_pin_write(&dev->mctx, WIFI_RESET, 1);
+	k_sleep(K_MSEC(100));
+	modem_pin_write(&dev->mctx, WIFI_RESET, 0);
 #else
 	int retries = 3;
 


### PR DESCRIPTION
wifi-reset-gpios flags were not respected so far. This means that
setting reset as active low (which is required in most cases for ESP
modules/chips) was done inside esp driver with inverted logic. Use dts
flags instead, so "active low" property is configured the same way as
for other drivers (i.e. in device-tree instead of driver).

This change also allows to configure reset as active high, in case where
ESP's nRST signal is somehow inverted on the board (behaving as RST
signal instead).

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>