### PR TITLE
scripts: ci: Add Sanitycheck testsuite to CI

### DIFF
--- a/.github/workflows/sanitycheck_tests.yml
+++ b/.github/workflows/sanitycheck_tests.yml
@@ -1,0 +1,49 @@
+# Copyright (c) 2020 Intel Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Zephyr Sanitycheck TestSuite
+
+on:
+  push:
+    paths:
+    - 'scripts/sanity_chk/sanitylib.py'
+    - 'scripts/sanitycheck'
+    - 'scripts/tests/sanitycheck/**'
+  pull_request:
+    paths:
+    - 'scripts/sanity_chk/**'
+    - 'scripts/sanitycheck'
+    - 'scripts/tests/sanitycheck/**'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest]
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: cache-pip-linux
+      if: startsWith(runner.os, 'Linux')
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.python-version }}
+    - name: install-packages
+      run: |
+        pip3 install pytest colorama pyyaml ply mock
+    - name: Run pytest
+      env:
+        ZEPHYR_BASE: ./
+        ZEPHYR_TOOLCHAIN_VARIANT: zephyr
+      run: |
+        echo "Run Sanitycheck tests"
+        PYTHONPATH=./scripts/tests pytest ./scripts/tests/sanitycheck


### PR DESCRIPTION
run-ci.sh: pytest will execute the sanitycheck testsuite on 
matrix 1 from scripts/tests/sanitycheck directory in any 
scenario.
TestReport: Junitxml report for pytest is captured in
./pytest_out/sanitycheck_testsuite.xml and then copied to
shippable/testresults.


Signed-off-by: Aastha Grover <aastha.grover@intel.com>