### PR TITLE
dts: arm: Fix incorrect interrupt cells order

### DIFF
--- a/dts/arm/broadcom/viper-a72.dtsi
+++ b/dts/arm/broadcom/viper-a72.dtsi
@@ -35,14 +35,14 @@
 		arch_timer: timer {
 			compatible = "arm,arm-timer";
 			interrupt-parent = <&gic>;
-			interrupts = <GIC_PPI 13 IRQ_DEFAULT_PRIORITY
-					IRQ_TYPE_LEVEL>,
-				     <GIC_PPI 14 IRQ_DEFAULT_PRIORITY
-					IRQ_TYPE_LEVEL>,
-				     <GIC_PPI 11 IRQ_DEFAULT_PRIORITY
-					IRQ_TYPE_LEVEL>,
-				     <GIC_PPI 10 IRQ_DEFAULT_PRIORITY
-					IRQ_TYPE_LEVEL>;
+			interrupts = <GIC_PPI 13 IRQ_TYPE_LEVEL
+				      IRQ_DEFAULT_PRIORITY>,
+				     <GIC_PPI 14 IRQ_TYPE_LEVEL
+				      IRQ_DEFAULT_PRIORITY>,
+				     <GIC_PPI 11 IRQ_TYPE_LEVEL
+				      IRQ_DEFAULT_PRIORITY>,
+				     <GIC_PPI 10 IRQ_TYPE_LEVEL
+				      IRQ_DEFAULT_PRIORITY>;
 			label = "arch_timer";
 		};
 
@@ -51,12 +51,12 @@
 
 &uart0 {
 	interrupt-parent = <&gic>;
-	interrupts = <GIC_SPI 24 IRQ_DEFAULT_PRIORITY
-		      IRQ_TYPE_LEVEL>;
+	interrupts = <GIC_SPI 24 IRQ_TYPE_LEVEL
+		      IRQ_DEFAULT_PRIORITY>;
 };
 
 &uart1 {
 	interrupt-parent = <&gic>;
-	interrupts = <GIC_SPI 181 IRQ_DEFAULT_PRIORITY
-		      IRQ_TYPE_LEVEL>;
+	interrupts = <GIC_SPI 181 IRQ_TYPE_LEVEL
+		      IRQ_DEFAULT_PRIORITY>;
 };

--- a/dts/arm/qemu-virt/qemu-virt-a53.dtsi
+++ b/dts/arm/qemu-virt/qemu-virt-a53.dtsi
@@ -52,7 +52,7 @@
 			compatible = "arm,pl011";
 			reg = <0x9000000 0x1000>;
 			status = "disabled";
-			interrupts = <GIC_SPI 1 0 IRQ_TYPE_LEVEL>;
+			interrupts = <GIC_SPI 1 IRQ_TYPE_LEVEL 0>;
 			interrupt-names = "irq_0";
 			clocks = <&uartclk>;
 			label = "UART_0";
@@ -70,14 +70,14 @@
 
 		arch_timer: timer {
 			compatible = "arm,arm-timer";
-			interrupts = <GIC_PPI 13 IRQ_DEFAULT_PRIORITY
-					IRQ_TYPE_EDGE>,
-				     <GIC_PPI 14 IRQ_DEFAULT_PRIORITY
-					IRQ_TYPE_EDGE>,
-				     <GIC_PPI 11 IRQ_DEFAULT_PRIORITY
-					IRQ_TYPE_EDGE>,
-				     <GIC_PPI 10 IRQ_DEFAULT_PRIORITY
-					IRQ_TYPE_EDGE>;
+			interrupts = <GIC_PPI 13 IRQ_TYPE_EDGE
+				      IRQ_DEFAULT_PRIORITY>,
+				     <GIC_PPI 14 IRQ_TYPE_EDGE
+				      IRQ_DEFAULT_PRIORITY>,
+				     <GIC_PPI 11 IRQ_TYPE_EDGE
+				      IRQ_DEFAULT_PRIORITY>,
+				     <GIC_PPI 10 IRQ_TYPE_EDGE
+				      IRQ_DEFAULT_PRIORITY>;
 			label = "arch_timer";
 		};
 	};


### PR DESCRIPTION
In aarch64 DTs, priority and flags cells have been swapped,
fix the same.

Correct interrupt property per the GIC binding document
looks like:
interrupts = <irq_type irq_num irq_flags irq_priority>;

Signed-off-by: Abhishek Shah <abhishek.shah@broadcom.com>

Fixes #25477