### PR TITLE
[backport to v1.14 branch] scripts: use debug function instead of debug_die to dump objs

### DIFF
--- a/scripts/elf_helper.py
+++ b/scripts/elf_helper.py
@@ -499,9 +499,8 @@ class ElfHelper:
                     (addr < kram_start or addr >= kram_end) and
                     (addr < krom_start or addr >= krom_end)):
 
-                self.debug_die(die,
-                               "object '%s' found in invalid location %s"
-                               % (name, hex(addr)))
+                self.debug("object '%s' found in invalid location %s"
+                            % (ko.type_obj.name, hex(addr)))
                 continue
 
             if ko.type_obj.name != "device":


### PR DESCRIPTION
In step 4 of find_kobjects, use func debug instead of debug_die
to dump debug info to avoid dump wrong info.

Fixes: #25519.

Signed-off-by: Wentong Wu <wentong.wu@intel.com>