### PR TITLE
bluetooth: ll_sw: nrf5: Apply workaround for anomalies only when needed

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52810.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52810.h
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <nrf_erratas.h>
+
 /* NRF Radio HW timing constants
  * - provided in US and NS (for higher granularity)
  * - based on empirical measurements and sniffer logs
@@ -195,6 +197,15 @@
 
 static inline void hal_radio_reset(void)
 {
+	/* nRF52810 itself is not affected with these anomalies but it might be
+	 * needed to address them when DEVELOP_IN_NRF52832 is used.
+	 */
+	if (nrf52_errata_102() || nrf52_errata_106() || nrf52_errata_107()) {
+		/* Workaround for nRF52 anomalies 102, 106, and 107. */
+		*(volatile u32_t *)0x40001774 =
+			((*(volatile u32_t *)0x40001774) & 0xfffffffe)
+			| 0x01000000;
+	}
 }
 
 static inline void hal_radio_ram_prio_setup(void)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52811.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52811.h
@@ -359,9 +359,6 @@
 
 static inline void hal_radio_reset(void)
 {
-	/* Anomalies 102, 106 and 107 */
-	*(volatile u32_t *)0x40001774 = ((*(volatile u32_t *)0x40001774) &
-					 0xfffffffe) | 0x01000000;
 }
 
 static inline void hal_radio_ram_prio_setup(void)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52832.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52832.h
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <nrf_erratas.h>
+
 /* NRF Radio HW timing constants
  * - provided in US and NS (for higher granularity)
  * - based on empirical measurements and sniffer logs
@@ -196,9 +198,12 @@
 
 static inline void hal_radio_reset(void)
 {
-	/* Anomalies 102, 106 and 107 */
-	*(volatile u32_t *)0x40001774 = ((*(volatile u32_t *)0x40001774) &
-					 0xfffffffe) | 0x01000000;
+	if (nrf52_errata_102() || nrf52_errata_106() || nrf52_errata_107()) {
+		/* Workaround for nRF52 anomalies 102, 106, and 107. */
+		*(volatile u32_t *)0x40001774 =
+			((*(volatile u32_t *)0x40001774) & 0xfffffffe)
+			| 0x01000000;
+	}
 }
 
 static inline void hal_radio_ram_prio_setup(void)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52840.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52840.h
@@ -360,9 +360,6 @@
 
 static inline void hal_radio_reset(void)
 {
-	/* Anomalies 102, 106 and 107 */
-	*(volatile u32_t *)0x40001774 = ((*(volatile u32_t *)0x40001774) &
-					 0xfffffffe) | 0x01000000;
 }
 
 static inline void hal_radio_ram_prio_setup(void)


### PR DESCRIPTION
Workaround for nRF52 anomalies 102, 106, and 107 was applied also for
SoCs that were not affected with those, namely nRF52811 and nRF52840.
Since the side effect of this workaround is reduction of sensitivity,
this was highly undesirable.
This commit uses dedicated functions provided by MDK for checking if
a given anomaly applies to the used SoC (and its actual revision) so
that the workaround is applied only when it is really needed.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>