### PR TITLE
drivers: timer: nrf: Fix premature timeouts

### DIFF
--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -88,6 +88,11 @@ static void prevent_false_prev_evt(void)
 		k_busy_wait(15);
 		event_clear();
 	}
+
+	/* Clear interrupt that may have fired as we were setting the
+	 * comparator.
+	 */
+	NVIC_ClearPendingIRQ(RTC1_IRQn);
 }
 
 /* If settings is next tick from now, function attempts to set next tick. If

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -14,6 +14,7 @@
 #include <spinlock.h>
 
 #define RTC NRF_RTC1
+#define RTC_IRQn NRFX_IRQ_NUMBER_GET(RTC)
 
 #define COUNTER_SPAN BIT(24)
 #define COUNTER_MAX (COUNTER_SPAN - 1U)
@@ -92,7 +93,7 @@ static void prevent_false_prev_evt(void)
 	/* Clear interrupt that may have fired as we were setting the
 	 * comparator.
 	 */
-	NVIC_ClearPendingIRQ(RTC1_IRQn);
+	NVIC_ClearPendingIRQ(RTC_IRQn);
 }
 
 /* If settings is next tick from now, function attempts to set next tick. If
@@ -165,7 +166,7 @@ static void set_protected_absolute_ticks(u32_t ticks)
  * it by pointer at runtime, maybe?) so we don't have this leaky
  * symbol.
  */
-void rtc1_nrf_isr(void *arg)
+void rtc_nrf_isr(void *arg)
 {
 	ARG_UNUSED(arg);
 	event_clear();
@@ -201,11 +202,11 @@ int z_clock_driver_init(struct device *device)
 	/* TODO: replace with counter driver to access RTC */
 	nrf_rtc_prescaler_set(RTC, 0);
 	event_clear();
-	NVIC_ClearPendingIRQ(RTC1_IRQn);
+	NVIC_ClearPendingIRQ(RTC_IRQn);
 	int_enable();
 
-	IRQ_CONNECT(RTC1_IRQn, 1, rtc1_nrf_isr, 0, 0);
-	irq_enable(RTC1_IRQn);
+	IRQ_CONNECT(RTC_IRQn, 1, rtc_nrf_isr, 0, 0);
+	irq_enable(RTC_IRQn);
 
 	nrf_rtc_task_trigger(RTC, NRF_RTC_TASK_CLEAR);
 	nrf_rtc_task_trigger(RTC, NRF_RTC_TASK_START);

--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -185,7 +185,7 @@ typedef void (*vth)(void); /* Vector Table Handler */
  *
  * Note: qemu_cortex_m0 uses TIMER0 to implement system timer.
  */
-void rtc1_nrf_isr(void);
+void rtc_nrf_isr(void);
 void nrf_power_clock_isr(void);
 #if defined(CONFIG_SOC_SERIES_NRF51X) || defined(CONFIG_SOC_SERIES_NRF52X)
 #if defined(CONFIG_BOARD_QEMU_CORTEX_M0)
@@ -198,7 +198,7 @@ vth __irq_vector_table _irq_vector_table[] = {
 	nrf_power_clock_isr,
 	isr0, isr1, isr2,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	rtc1_nrf_isr
+	rtc_nrf_isr
 };
 #endif /* CONFIG_BOARD_QEMU_CORTEX_M0 */
 #elif defined(CONFIG_SOC_SERIES_NRF53X) || defined(CONFIG_SOC_SERIES_NRF91X)
@@ -207,14 +207,14 @@ vth __irq_vector_table _irq_vector_table[] = {
 	0, 0, 0, 0, 0, nrf_power_clock_isr, 0, 0,
 	isr0, isr1, isr2,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	rtc1_nrf_isr
+	rtc_nrf_isr
 };
 #else
 vth __irq_vector_table _irq_vector_table[] = {
 	0, 0, 0, 0, 0, nrf_power_clock_isr, 0, 0,
 	isr0, isr1, isr2,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	rtc1_nrf_isr
+	rtc_nrf_isr
 };
 #endif
 #endif


### PR DESCRIPTION
If timeout is being overwrite exactly when previous one is expiring
then hardware event was cleared correctly but interrupt was already
triggered. Interrupt routine was assuming that compare event is set
and proceed with that assumption. However, in that corner case when
compare event was overwritten and event was cleared, that was not the
case.

As the outcome, timeout was triggered prematurely. Fixed by
clearing pending interrupt after handling previous compare value.

Bug is quite severe as I've seen premature timer expiration. In my case, timer set for 1sec was expiring immediately.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>