### PR TITLE
settings_fcb: Fix storing the data

### DIFF
--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -317,12 +317,16 @@ static int settings_fcb_save_priv(struct settings_store *cs, const char *name,
 	wbs = cf->cf_fcb.f_align;
 	len = settings_line_len_calc(name, val_len);
 
-	for (i = 0; i < cf->cf_fcb.f_sector_cnt - 1; i++) {
+	for (i = 0; i < cf->cf_fcb.f_sector_cnt; i++) {
 		rc = fcb_append(&cf->cf_fcb, len, &loc.loc);
 		if (rc != -ENOSPC) {
 			break;
 		}
-		settings_fcb_compress(cf);
+
+		/* FCB can compress up to cf->cf_fcb.f_sector_cnt - 1 times. */
+		if (i < (cf->cf_fcb.f_sector_cnt - 1)) {
+			settings_fcb_compress(cf);
+		}
 	}
 	if (rc) {
 		return -EINVAL;


### PR DESCRIPTION
Change fixes storing the data by adding missing write retry after the last compression. Without the change error was returned instead of retrying.

fixes #25522