### PR TITLE
sys/util.h: Add ARRAY_INDEX and ARRAY_ELEM macros

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -81,6 +81,29 @@ size_t ARRAY_SIZE(T(&)[N]) { return N; }
 #define CONTAINER_OF(ptr, type, field) \
 	((type *)(((char *)(ptr)) - offsetof(type, field)))
 
+/* Given array name and pointer, it will evaluate to index of an array
+ * element pointed by that pointer or will cause compiler error if "array"
+ * is not array or "ptr" is beyond "array", e.g.:
+ *  ARRAY_INDEX(array, &array[3])
+ *  ARRAY_INDEX(array, &array[3].c)
+ * would both evaluate to:
+ *  3
+ */
+#define ARRAY_INDEX(array, ptr) \
+	((void)(IS_ARRAY(array)), \
+	 (void)(PART_OF_ARRAY(array, ptr)), \
+	 (((char *)ptr - (char *)array) / sizeof(array[0])))
+
+
+/* Align "ptr" to "array" elements, the pointer is within, e.g:
+ *  p = &array[5].c;
+ *  ARRAY_ELEM(array, &p)
+ * would evaluate to address equivalent of:
+ *  &array[5]
+ */
+#define ARRAY_ELEM(array, ptr) \
+	((__typeof__(&array[0]))&array[ARRAY_INDEX(array, ptr)])
+
 /* round "x" up/down to next multiple of "align" (which must be a power of 2) */
 #define ROUND_UP(x, align)                                   \
 	(((unsigned long)(x) + ((unsigned long)(align) - 1)) & \

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -319,6 +319,68 @@ static void test_LIST_DROP_EMPTY(void)
 	zassert_equal(strcmp(arr[2], "Case"), 0, "Failed at 0");
 }
 
+static void test_ARRAY_SIZE(void)
+{
+	#define TEST_SIZE	5
+	int int_arr[TEST_SIZE] = { 0 };
+
+	zassert_equal(ARRAY_SIZE(int_arr), TEST_SIZE, "Unexpected size");
+	#undef	TEST_SIZE
+}
+
+static void test_ARRAY_INDEX(void)
+{
+	#define TEST_SIZE	5
+	#define TEST_INDEX_A	0
+	#define TEST_INDEX_B	2
+	#define TEST_INDEX_C	4
+	struct strange {
+		int a;
+		float c;
+	} test_arr[TEST_SIZE] = { 0 }, *pa = &test_arr[TEST_INDEX_A],
+	  *pb = &test_arr[TEST_INDEX_B],
+	  /* Unaligned pointer */
+	  *pc = (void *)&test_arr[TEST_INDEX_C].c;
+
+	zassert_equal(ARRAY_INDEX(test_arr, pa), TEST_INDEX_A,
+		      "Unexpected index A");
+	zassert_equal(ARRAY_INDEX(test_arr, pb), TEST_INDEX_B,
+		      "Unexpected index B");
+	zassert_equal(ARRAY_INDEX(test_arr, pc), TEST_INDEX_C,
+		      "Unexpected index C");
+
+	#undef	TEST_SIZE
+	#undef	TEST_INDEX_A
+	#undef	TEST_INDEX_B
+	#undef	TEST_INDEX_C
+}
+
+static void test_ARRAY_ELEM(void)
+{
+	#define TEST_SIZE	5
+	#define TEST_INDEX_A	0
+	#define TEST_INDEX_B	3
+	struct strange {
+		int a;
+		float c;
+	} test_arr[TEST_SIZE] = { 0 }, *pa = &test_arr[TEST_INDEX_A],
+	  *pb = &test_arr[TEST_INDEX_B],
+	  /* Unaligned pointer */
+	  *pc = (void *)&test_arr[TEST_INDEX_B].c;
+
+
+	zassert_equal(ARRAY_ELEM(test_arr, pa), test_arr,
+		      "Unexpected index A");
+	zassert_equal(ARRAY_ELEM(test_arr, pb), &test_arr[TEST_INDEX_B],
+		      "Unexpected index B");
+	zassert_equal(ARRAY_ELEM(test_arr, pc), &test_arr[TEST_INDEX_B],
+		      "Unexpected index B");
+
+	#undef	TEST_SIZE
+	#undef	TEST_INDEX_A
+	#undef	TEST_INDEX_B
+}
+
 void test_main(void)
 {
 	ztest_test_suite(test_lib_sys_util_tests,
@@ -336,7 +398,10 @@ void test_main(void)
 			 ztest_unit_test(test_FOR_EACH_IDX),
 			 ztest_unit_test(test_FOR_EACH_IDX_FIXED_ARG),
 			 ztest_unit_test(test_IS_EMPTY),
-			 ztest_unit_test(test_LIST_DROP_EMPTY)
+			 ztest_unit_test(test_LIST_DROP_EMPTY),
+			 ztest_unit_test(test_ARRAY_SIZE),
+			 ztest_unit_test(test_ARRAY_INDEX),
+			 ztest_unit_test(test_ARRAY_ELEM)
 	);
 
 	ztest_run_test_suite(test_lib_sys_util_tests);


### PR DESCRIPTION
ARRAY_INDEX(array, ptr) evaluates to index of an 'array' element that
the "ptr" is within.
ARRAY_ELEM(array, ptr) returns pointer to an element within 'array',
pointed by 'ptr', aligned to the beginning of that element.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>