### PR TITLE
sanitycheck: Add filtered test cases to the JUnit full report

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -1969,6 +1969,8 @@ class ProjectBuilder(FilterBuilder):
                     logger.debug("filtering %s" % self.instance.name)
                     self.instance.status = "skipped"
                     self.instance.reason = "filter"
+                    for case in self.instance.testcase.cases:
+                        self.instance.results.update({case: 'SKIP'})
                     pipeline.put({"op": "report", "test": self.instance})
                 else:
                     pipeline.put({"op": "build", "test": self.instance})
@@ -3017,7 +3019,7 @@ class TestSuite(DisablePyTestCollectionMixin):
                             eleTestcase,
                             'skipped',
                             type="skipped",
-                            message="Skipped")
+                            message=instance.reason)
             else:
                 eleTestcase = ET.SubElement(eleTestsuite, 'testcase',
                     classname="%s:%s" % (instance.platform.name, instance.testcase.name),


### PR DESCRIPTION
If a test instance from .yaml file was skipped due to being on
a filtered list then there are no entries about it in the
sanitycheck_report.xml for a given platform. This commit fills
instance.results with skipped test cases also for skipped instances so
those test cases are visible when the full report is generated. Tested
for ./tests/kernel/mem_protect/userspace on nrf52dk_nrf52832 where
userspace.gap_filling is filtered out.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>