### PR TITLE
net: l2: openthread: Add config option to enable OpenThread ref. device

### DIFF
--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -303,4 +303,9 @@ config OT_PLAT_FLASH_PAGES_COUNT
 	help
 	  This option sets flash pages count used by OpenThread to store its settings. They are located at the end of flash.
 
+config OPENTHREAD_REFERENCE_DEVICE
+	bool "Reference device support"
+	help
+	  Enable Thread Certification reference device support in OpenThread stack
+
 endif

--- a/west.yml
+++ b/west.yml
@@ -104,7 +104,7 @@ manifest:
       revision: 29e516ec585b1a909af2b5f1c60d83e7d4d563e3
       path: modules/lib/loramac-node
     - name: openthread
-      revision: a83d18cf18bc8cd431ad6704ad0bf0e6d08c99d7
+      revision: 1db7e9ebe5bbf701ca1ff8cad623892ec48fb0f0
       path: modules/lib/openthread
     - name: segger
       revision: 6fcf61606d6012d2c44129edc033f59331e268bc


### PR DESCRIPTION
Add the option to enable Thread Certification reference device support in OpenThread stack.