### PR TITLE
boards: nordic: add gpio as supported feature on major dev boards

### DIFF
--- a/boards/arm/nrf51_ble400/nrf51_ble400.yaml
+++ b/boards/arm/nrf51_ble400/nrf51_ble400.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 16
 supported:
   - ble
+  - gpio
   - i2c
 testing:
   ignore_tags:

--- a/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.yaml
+++ b/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.yaml
@@ -11,6 +11,7 @@ supported:
   - adc
   - ble
   - counter
+  - gpio
   - i2c
   - nvs
   - pwm

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.yaml
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.yaml
@@ -15,6 +15,7 @@ supported:
   - arduino_spi
   - ble
   - counter
+  - gpio
   - i2c
   - ieee802154
   - pwm

--- a/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.yaml
+++ b/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.yaml
@@ -13,6 +13,7 @@ supported:
   - arduino_gpio
   - arduino_i2c
   - arduino_spi
+  - gpio
   - counter
   - nvs
   - i2c

--- a/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp.yaml
+++ b/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 64
 flash: 256
 supported:
+  - gpio
   - i2c
   - pwm
   - watchdog

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160.yaml
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 64
 flash: 256
 supported:
+  - gpio
   - i2c
   - pwm
   - watchdog


### PR DESCRIPTION
Absence of this feature prevents sanitycheck device testing of
gpio_basic_api.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>