### PR TITLE
x86: mmu: fix type mismatch of memory address in assert

### DIFF
--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -1094,8 +1094,8 @@ static void apply_mem_partition(struct x86_page_tables *ptables,
 	}
 
 	__ASSERT(partition->start >= PHYS_RAM_ADDR,
-		 "region at %08lx[%zu] extends below system ram start 0x%08x",
-		 partition->start, partition->size, PHYS_RAM_ADDR);
+		 "region at %08lx[%zu] extends below system ram start 0x%08lx",
+		 partition->start, partition->size, (uintptr_t)PHYS_RAM_ADDR);
 	__ASSERT(((partition->start + partition->size) <=
 		  (PHYS_RAM_ADDR + PHYS_RAM_SIZE)),
 		 "region at %08lx[%zu] end at %08lx extends beyond system ram end 0x%08lx",


### PR DESCRIPTION
In one of the ASSERT() statement, the PHYS_RAM_ADDR (alias
of DT_REG_ADDR()) may be interpreted by the compiler as
long long int when it's large than 0x7FFFFFFF, but is
paired with %x, resulting in compiler warning. Fix this
by type casting it to uintptr_t and use %lx instead.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>