### PR TITLE
boards: arm: nrf5340pdk: fix pin assignments

### DIFF
--- a/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp_common.dts
@@ -89,8 +89,8 @@
 &i2c1 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";
-	sda-pin = <30>;
-	scl-pin = <31>;
+	sda-pin = <2>;
+	scl-pin = <3>;
 };
 
 &uart0 {
@@ -110,9 +110,9 @@
 &spi2 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
-	sck-pin = <32>;
-	mosi-pin = <32>;
-	miso-pin = <36>;
+	sck-pin = <47>;
+	miso-pin = <46>;
+	mosi-pin = <45>;
 };
 
 &timer0 {


### PR DESCRIPTION
I2C1 used LED pins rather than the ones in the Arduino header
position.  SPI2 used Arduino D0 for both SCK and MOSI; replace all
pins with D11-D13 which are the standard location for SPI on the
Arduino header.

nRF side of #25251