### PR TITLE
tests: logging: Add a clean ouput test and clarify output

### DIFF
--- a/tests/subsys/logging/log_immediate/src/log_immediate_test.c
+++ b/tests/subsys/logging/log_immediate/src/log_immediate_test.c
@@ -56,6 +56,10 @@ static void thread_func(void *p1, void *p2, void *p3)
  */
 static void test_log_immediate_preemption(void)
 {
+	if (!IS_ENABLED(CONFIG_LOG_IMMEDIATE_CLEAN_OUTPUT)) {
+		LOG_INF("CONFIG_LOG_IMMEDIATE_CLEAN_OUTPUT not enabled."
+			" Text output will be garbled.");
+	}
 	for (intptr_t i = 0; i < NUM_THREADS; i++) {
 		tids[i] = k_thread_create(&threads[i], stacks[i], STACK_SIZE,
 				thread_func, (void *)i, NULL, NULL,

--- a/tests/subsys/logging/log_immediate/testcase.yaml
+++ b/tests/subsys/logging/log_immediate/testcase.yaml
@@ -3,3 +3,8 @@ tests:
     tags: log_core logging
     platform_exclude: nucleo_l053r8 nucleo_f030r8
       stm32f0_disco nrf52_bsim
+  logging.log_immediate.clean_output:
+    extra_args: CONFIG_LOG_IMMEDIATE_CLEAN_OUTPUT=y
+    tags: log_core logging
+    platform_exclude: nucleo_l053r8 nucleo_f030r8
+      stm32f0_disco nrf52_bsim


### PR DESCRIPTION
Add a new test with clean output and warn the user that the version
without clean output will output garbled text.

Fixes #23799

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>