### PR TITLE
tests: add new tests for memory partitions

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -31,6 +31,16 @@ void test_main(void)
 			 ztest_unit_test(test_mem_domain_remove_partitions_simple),
 			 ztest_unit_test(test_mem_domain_remove_partitions),
 			 ztest_unit_test(test_mark_thread_exit_uninitialized),
+			 ztest_unit_test(
+				 test_mem_domain_api_kernel_thread_only),
+			 ztest_user_unit_test(
+				 test_mem_domain_api_kernel_thread_only),
+			 ztest_unit_test(test_mem_part_auto_determ_size),
+			 ztest_unit_test(
+				 test_mem_part_auto_determ_size_per_mpu),
+			 ztest_unit_test(test_mem_part_inherit_by_child_thr),
+			 ztest_unit_test(test_macros_obtain_names_data_bss),
+			 ztest_unit_test(test_mem_part_assign_bss_vars_zero),
 			 ztest_unit_test(test_kobject_access_grant),
 			 ztest_unit_test(test_syscall_invalid_kobject),
 			 ztest_unit_test(test_thread_without_kobject_permission),

--- a/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
@@ -20,6 +20,12 @@ extern void test_mem_domain_add_partitions_invalid(void);
 extern void test_mem_domain_add_partitions_simple(void);
 extern void test_mem_domain_remove_partitions_simple(void);
 extern void test_mem_domain_remove_partitions(void);
+extern void test_mem_domain_api_kernel_thread_only(void);
+extern void test_mem_part_auto_determ_size(void);
+extern void test_mem_part_auto_determ_size_per_mpu(void);
+extern void test_mem_part_inherit_by_child_thr(void);
+extern void test_macros_obtain_names_data_bss(void);
+extern void test_mem_part_assign_bss_vars_zero(void);
 extern void test_kobject_access_grant(void);
 extern void test_syscall_invalid_kobject(void);
 extern void test_thread_without_kobject_permission(void);
@@ -63,6 +69,8 @@ static inline void set_fault_valid(bool valid)
 #define INHERIT_STACK_SIZE CONFIG_MAIN_STACK_SIZE
 #define SEMAPHORE_MAX_COUNT (10)
 #define SEMAPHORE_INIT_COUNT (0)
+#define SYNC_SEM_MAX_COUNT (1)
+#define SYNC_SEM_INIT_COUNT (0)
 #define MSG_Q_SIZE (10)
 #define MSG_Q_MAX_NUM_MSGS (10)
 #define MSG_Q_ALIGN (2)
@@ -79,6 +87,13 @@ static inline void set_fault_valid(bool valid)
 /* For mem_domain.c  */
 #define MEM_DOMAIN_STACK_SIZE CONFIG_MAIN_STACK_SIZE
 #define MEM_PARTITION_INIT_NUM (1)
+#define BLK_SIZE_MIN_MD 8
+#define BLK_SIZE_MAX_MD 16
+#define BLK_NUM_MAX_MD 4
+#define BLK_ALIGN_MD BLK_SIZE_MIN_MD
+#define DESC_SIZE	sizeof(struct sys_mem_pool_block)
+#define STACK_SIZE_MD (512 + CONFIG_TEST_EXTRA_STACKSIZE)
+#define PRIORITY_MD 5
 
 #if defined(CONFIG_X86)
 #define MEM_REGION_ALLOC (4096)


### PR DESCRIPTION
Add new tests to improve of the Zephyr QA testing of the memory protection for memory domains and partitions.
I created new tests for memory protection->memory partitions for the requirements which I think necessary to be tested. I added Doxygen tag for each test to make it clear
to understand what each test is doing and how.

**New tests for memory domains and partitions:**
1.  test_mem_domain_api_kernel_thread_only()
By creating that test I wanted to prove that access to memory domain APIs must be restricted only to supervisor threads. At the same time I wanted to prove that system can support the definition of memory domains.

2. test_mem_part_auto_determ_size()
By creating that test I want to prove that system can automatically determine application memory partition base addresses and sizes at build time, determined by its contents. Also system can support definition of memory partitions. At the same time test proves that OS supports adding and removing a thread from its memory domain assignment.

3. test_mem_part_auto_determ_size_per_mmu()
That test is very important and it proves that memory partitions are automatically sized and aligned per the constraints of the platform's memory management hardware.

4. test_mem_part_inheirt_by_child_thr() 
Prove that child thread inherits memory domain assignment of its parent.

5. test_macros_obtain_names_data_bss()
Test system provides tools to obtain the names of the data and BSS sections related to a particular application memory partition at build time.

6. test_mem_part_assign_bss_vars_zero()
Test that global data and BSS values can be assigned to application memory partitions using macros at build time. Test that BSS values will be zeroed at the build time.


Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>