### PR TITLE
tests: add new doxygen tags for memory domain tests

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -566,8 +566,11 @@ void test_mem_domain_remove_thread(void *p1, void *p2, void *p3)
 
 }
 /****************************************************************************/
+
 /**
- * @brief Test k_mem_domain_destroy API
+ * @brief Test memory domain destroy, which removes all thread assignments to it
+ *
+ * @details Test k_mem_domain_destroy API
  *
  * @ingroup kernel_memprotect_tests
  *

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -709,8 +709,10 @@ static void test_domain_add_thread_drop_to_user(void)
 	k_thread_user_mode_enter(user_half, NULL, NULL, NULL);
 }
 
-/* Show that adding a partition to a domain and then dropping to user mode
- * works as expected.
+/* @brief Test adding application memory partition to memory domain
+ *
+ * @details Show that adding a partition to a domain and then dropping to user
+ * mode works as expected.
  *
  * @ingroup kernel_memprotect_tests
  */


### PR DESCRIPTION
Add new informative Doxygen tags for the memory domain tests.
1. test_mem_domain_destroy()
Test that memory domain can be destroyed, removing all thread assignment to it. Add Doxygen tag describing that.

2. test_domain_add_part_drop_to_user()
Test that kernel supports adding application memory partitions to memory domains. Add Doxygen tag describing that.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>