### PR TITLE
kernel: timer_api: more tweaks for inexact conversions and poor clock tolerance

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -933,6 +933,12 @@ __syscall s32_t k_usleep(s32_t us);
  * This routine causes the current thread to execute a "do nothing" loop for
  * @a usec_to_wait microseconds.
  *
+ * @note The clock used for the microsecond-resolution delay here may
+ * be skewed relative to the clock used for system timeouts like
+ * k_sleep().  For example k_busy_wait(1000) may take slightly more or
+ * less time than k_sleep(K_MSEC(1)), with the offset dependent on
+ * clock tolerances.
+ *
  * @return N/A
  */
 __syscall void k_busy_wait(u32_t usec_to_wait);


### PR DESCRIPTION
A couple failures observed in #24001 are a consequence of precision loss converting between milliseconds and 32 KiHz ticks, compounded by clock rate variation.  Other failures are due to skew between the clock used for busywait and the clock used for system time.  Also asynchronous updates to the tick counter can occur before or after the value it's compared with has been captured.

In short, tweak the test until it runs reliably on problematic hardware identified in #24001 (where "reliably" means >100 consecutive runs without failure using `CONFIG_ZTEST_RETEST_IF_PASSED=y`).

Fixes #24001
Fixes #24784 through a documentation fix clarifying that `k_busy_wait()` delays are not necessarily aligned to sysclock.