### PR TITLE
boards: riscv: Conditionalize pinmuxes on rv32m1_vega board

### DIFF
--- a/boards/riscv/rv32m1_vega/pinmux.c
+++ b/boards/riscv/rv32m1_vega/pinmux.c
@@ -40,25 +40,25 @@ static int rv32m1_vega_pinmux_init(struct device *dev)
 		device_get_binding(DT_LABEL(DT_NODELABEL(porte)));
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(lpuart0), okay)
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(lpuart0), okay) && CONFIG_SERIAL
 	/* LPUART0 RX, TX */
 	pinmux_pin_set(portc, 7, PORT_PCR_MUX(kPORT_MuxAlt3));
 	pinmux_pin_set(portc, 8, PORT_PCR_MUX(kPORT_MuxAlt3));
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(lpuart1), okay)
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(lpuart1), okay) && CONFIG_SERIAL
 	/* LPUART1 RX, TX */
 	pinmux_pin_set(portc, 29, PORT_PCR_MUX(kPORT_MuxAlt2));
 	pinmux_pin_set(portc, 30, PORT_PCR_MUX(kPORT_MuxAlt2));
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(lpi2c0), okay)
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(lpi2c0), okay) && CONFIG_I2C
 	/* LPI2C0 SCL, SDA - Arduino header */
 	pinmux_pin_set(portc, 10, PORT_PCR_MUX(kPORT_MuxAlt4));
 	pinmux_pin_set(portc, 9, PORT_PCR_MUX(kPORT_MuxAlt4));
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(lpi2c3), okay)
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(lpi2c3), okay) && CONFIG_I2C
 	/* LPI2C3 SCL, SDA - FXOS8700 */
 	pinmux_pin_set(porte, 30, PORT_PCR_MUX(kPORT_MuxAlt3));
 	pinmux_pin_set(porte, 29, PORT_PCR_MUX(kPORT_MuxAlt3));
@@ -69,7 +69,7 @@ static int rv32m1_vega_pinmux_init(struct device *dev)
 	pinmux_pin_set(porte, 22, PORT_PCR_MUX(kPORT_MuxAsGpio));
 	pinmux_pin_set(porte, 27, PORT_PCR_MUX(kPORT_MuxAsGpio));
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(lpspi0), okay)
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(lpspi0), okay) && CONFIG_SPI
 	/* LPSPI0 SCK, SOUT, PCS2, SIN */
 	pinmux_pin_set(portb,  4, PORT_PCR_MUX(kPORT_MuxAlt2));
 	pinmux_pin_set(portb,  5, PORT_PCR_MUX(kPORT_MuxAlt2));
@@ -77,7 +77,7 @@ static int rv32m1_vega_pinmux_init(struct device *dev)
 	pinmux_pin_set(portb,  7, PORT_PCR_MUX(kPORT_MuxAlt2));
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(lpspi1), okay)
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(lpspi1), okay) && CONFIG_SPI
 	/* LPSPI1 SCK, SIN, SOUT, CS */
 	pinmux_pin_set(portb, 20, PORT_PCR_MUX(kPORT_MuxAlt2));
 	pinmux_pin_set(portb, 21, PORT_PCR_MUX(kPORT_MuxAlt2));


### PR DESCRIPTION
Conditionalizes pinmuxes on associated driver configs (CONFIG_SERIAL,
CONFIG_I2C, etc.) for the rv32m1_vega board to avoid possible conflicts
between peripherals.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>