### PR TITLE
boards: arm: nrf5340pdk: Fix i2c1 pin assignments

### DIFF
--- a/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp_common.dts
@@ -89,8 +89,8 @@
 &i2c1 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";
-	sda-pin = <2>;
-	scl-pin = <3>;
+	sda-pin = <34>;
+	scl-pin = <35>;
 };
 
 &uart0 {


### PR DESCRIPTION
Pins p0.02/p0.03 that were assigned to the i2c1 node are NFC pins.
Use p1.02/p1.03 instead, which are routed to the standard I2C location
in the Arduino header.

This is a follow-up to #25533.