### PR TITLE
bluetooth: host: fix wrong bt/cf settings loading

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -4622,8 +4622,11 @@ static int cf_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 		cfg = find_cf_cfg(NULL);
 		if (!cfg) {
 			BT_ERR("Unable to restore CF: no cfg left");
-			return 0;
+			return -ENOMEM;
 		}
+
+		cfg->id = id;
+		bt_addr_le_copy(&cfg->peer, &addr);
 	}
 
 	if (len_rd) {


### PR DESCRIPTION
This commits fixes the loading of bt/cf settings into memory. Only data
was loaded and not the address.

Fixes: #25478.
Fixes: #25447