### PR TITLE
Bluetooth: controller: Use NRF RNG entropy device

### DIFF
--- a/subsys/bluetooth/common/rpa.c
+++ b/subsys/bluetooth/common/rpa.c
@@ -31,7 +31,7 @@ static int internal_rand(void *buf, size_t len)
 {
 /* Force using controller rand function. */
 #if defined(CONFIG_BT_CTLR) && defined(CONFIG_BT_HOST_CRYPTO)
-	return util_rand(buf, len);
+	return lll_csrand_get(buf, len);
 #else
 	return bt_rand(buf, len);
 #endif

--- a/subsys/bluetooth/controller/crypto/crypto.c
+++ b/subsys/bluetooth/controller/crypto/crypto.c
@@ -7,13 +7,15 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_crypto
 #include "common/log.h"
-#include "../util/util.h"
+
+#include "util/memq.h"
 
 #include "hal/ecb.h"
+#include "lll.h"
 
 int bt_rand(void *buf, size_t len)
 {
-	return util_rand(buf, len);
+	return lll_csrand_get(buf, len);
 }
 
 int bt_encrypt_le(const uint8_t key[16], const uint8_t plaintext[16],

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -886,7 +886,7 @@ static void le_rand(struct net_buf *buf, struct net_buf **evt)
 	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = 0x00;
 
-	util_rand(rp->rand, count);
+	lll_csrand_get(rp->rand, count);
 }
 
 static void le_read_supp_states(struct net_buf *buf, struct net_buf **evt)

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -461,7 +461,7 @@ static int hci_driver_open(void)
 
 	err = ll_init(&sem_prio_recv);
 	if (err) {
-		BT_ERR("LL initialization failed: %u", err);
+		BT_ERR("LL initialization failed: %d", err);
 		return err;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -3,6 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#include <stddef.h>
 #if defined(CONFIG_BT_CTLR_RX_PDU_META)
 #include "lll_meta.h"
 #endif /* CONFIG_BT_CTLR_RX_PDU_META */
@@ -334,6 +336,11 @@ uint32_t lll_radio_rx_ready_delay_get(uint8_t phy, uint8_t flags);
 int8_t lll_radio_tx_pwr_min_get(void);
 int8_t lll_radio_tx_pwr_max_get(void);
 int8_t lll_radio_tx_pwr_floor(int8_t tx_pwr_lvl);
+
+int lll_csrand_get(void *buf, size_t len);
+int lll_csrand_isr_get(void *buf, size_t len);
+int lll_rand_get(void *buf, size_t len);
+int lll_rand_isr_get(void *buf, size_t len);
 
 int ull_prepare_enqueue(lll_is_abort_cb_t is_abort_cb,
 			       lll_abort_cb_t abort_cb,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -131,8 +131,7 @@ int lll_init(void)
 	int err;
 
 	/* Get reference to entropy device */
-	dev_entropy =
-		device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_rng)));
+	dev_entropy = device_get_binding(DT_LABEL(DT_NODELABEL(rng)));
 	if (!dev_entropy) {
 		return -ENODEV;
 	}
@@ -179,9 +178,24 @@ int lll_init(void)
 	return 0;
 }
 
-uint8_t lll_entropy_get(uint8_t len, void *rand)
+int lll_csrand_get(void *buf, size_t len)
 {
-	return entropy_get_entropy_isr(dev_entropy, rand, len, 0);
+	return entropy_get_entropy(dev_entropy, buf, len);
+}
+
+int lll_csrand_isr_get(void *buf, size_t len)
+{
+	return entropy_get_entropy_isr(dev_entropy, buf, len, 0);
+}
+
+int lll_rand_get(void *buf, size_t len)
+{
+	return entropy_get_entropy(dev_entropy, buf, len);
+}
+
+int lll_rand_isr_get(void *buf, size_t len)
+{
+	return entropy_get_entropy_isr(dev_entropy, buf, len, 0);
 }
 
 int lll_reset(void)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
@@ -23,7 +23,6 @@ uint32_t lll_evt_offset_get(struct evt_hdr *evt);
 uint32_t lll_preempt_calc(struct evt_hdr *evt, uint8_t ticker_id,
 		uint32_t ticks_at_event);
 void lll_chan_set(uint32_t chan);
-uint8_t lll_entropy_get(uint8_t len, void *rand);
 void lll_isr_tx_status_reset(void);
 void lll_isr_rx_status_reset(void);
 void lll_isr_status_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
@@ -116,11 +116,9 @@ int lll_init(void)
 	ARG_UNUSED(clk_k32);
 
 	/* Get reference to entropy device */
-	dev_entropy =
-		device_get_binding(DT_LABEL(DT_INST(0, openisa_rv32m1_trng)));
+	dev_entropy = device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
 	if (!dev_entropy) {
-		dev_entropy = NULL;
-		/* return -ENODEV; */
+		return -ENODEV;
 	}
 
 	/* Initialise LLL internals */
@@ -163,9 +161,23 @@ int lll_init(void)
 	return 0;
 }
 
-uint8_t lll_entropy_get(uint8_t len, void *rand)
+int lll_csrand_get(void *buf, size_t len)
 {
-	/* entropy_get_entropy_isr(dev_entropy, rand, len, 0); */
+	return entropy_get_entropy(dev_entropy, buf, len);
+}
+
+int lll_csrand_isr_get(void *buf, size_t len)
+{
+	return entropy_get_entropy_isr(dev_entropy, buf, len, 0);
+}
+
+int lll_rand_get(void *buf, size_t len)
+{
+	return 0;
+}
+
+int lll_rand_isr_get(void *buf, size_t len)
+{
 	return 0;
 }
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_internal.h
@@ -27,4 +27,3 @@ uint32_t lll_evt_offset_get(struct evt_hdr *evt);
 uint32_t lll_preempt_calc(struct evt_hdr *evt, uint8_t ticker_id,
 		uint32_t ticks_at_event);
 void lll_chan_set(uint32_t chan);
-uint8_t lll_entropy_get(uint8_t len, void *rand);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1389,7 +1389,7 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t laz
 		uint32_t random_delay;
 		uint32_t ret;
 
-		lll_entropy_get(sizeof(random_delay), &random_delay);
+		lll_rand_isr_get(&random_delay, sizeof(random_delay));
 		random_delay %= ULL_ADV_RANDOM_DELAY;
 		random_delay += 1;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -103,7 +103,7 @@ uint8_t ll_adv_sync_param_set(uint8_t handle, uint16_t interval, uint16_t flags)
 		err = util_aa_le32(lll_sync->access_addr);
 		LL_ASSERT(!err);
 
-		util_rand(lll_sync->crc_init, sizeof(lll_sync->crc_init));
+		lll_csrand_get(lll_sync->crc_init, sizeof(lll_sync->crc_init));
 
 		lll_sync->latency_prepare = 0;
 		lll_sync->latency_event = 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -148,7 +148,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	err = util_aa_le32(conn_lll->access_addr);
 	LL_ASSERT(!err);
 
-	util_rand(conn_lll->crc_init, sizeof(conn_lll->crc_init));
+	lll_csrand_get(conn_lll->crc_init, sizeof(conn_lll->crc_init));
 
 	conn_lll->handle = 0xFFFF;
 	conn_lll->interval = interval;
@@ -204,7 +204,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	conn_lll->event_counter = 0;
 
 	conn_lll->data_chan_count = ull_chan_map_get(conn_lll->data_chan_map);
-	util_rand(&hop, sizeof(uint8_t));
+	lll_csrand_get(&hop, sizeof(uint8_t));
 	conn_lll->data_chan_hop = 5 + (hop % 12);
 	conn_lll->data_chan_sel = 0;
 	conn_lll->data_chan_use = 0;
@@ -491,8 +491,8 @@ uint8_t ll_enc_req_send(uint16_t handle, uint8_t const *const rand,
 			memcpy(enc_req->rand, rand, sizeof(enc_req->rand));
 			enc_req->ediv[0] = ediv[0];
 			enc_req->ediv[1] = ediv[1];
-			util_rand(enc_req->skdm, sizeof(enc_req->skdm));
-			util_rand(enc_req->ivm, sizeof(enc_req->ivm));
+			lll_csrand_get(enc_req->skdm, sizeof(enc_req->skdm));
+			lll_csrand_get(enc_req->ivm, sizeof(enc_req->ivm));
 		} else if (conn->lll.enc_rx && conn->lll.enc_tx) {
 			memcpy(&conn->llcp_enc.rand[0], rand,
 			       sizeof(conn->llcp_enc.rand));

--- a/subsys/bluetooth/controller/util/util.h
+++ b/subsys/bluetooth/controller/util/util.h
@@ -16,5 +16,4 @@
 #endif
 
 uint8_t util_ones_count_get(uint8_t *octets, uint8_t octets_len);
-int util_rand(void *buf, size_t len);
 int util_aa_le32(uint8_t *dst);


### PR DESCRIPTION
Use the NRF RNG entropy device as the entropy device for bt_rand and
controller internal functions when LLL is Nordic.
Using an entropy source with a significant increase in stack usage
will invalidate all stack size configurations in the system and lead
to stack overflow issues.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>