### PR TITLE
boards: nrf5340pdk: fix list of board DTS 'compatibles'

### DIFF
--- a/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp_common.dts
@@ -6,8 +6,7 @@
 
 / {
 	model = "Nordic NRF5340 PDK NRF5340 Application";
-	compatible = "nordic,nrf5340-pdk-nrf5340-cpuapp",
-		"nordic,nrf5340-cpuapp-qkaa", "nordic,nrf5340-cpuapp";
+	compatible = "nordic,nrf5340-pdk-nrf5340-cpuapp";
 
 	chosen {
 		zephyr,console = &uart0;


### PR DESCRIPTION
We only need a 'compatible' entry for the DK,
not the SoC and part-number. This commit fixes
this and aligns the nRF5340 PDK DTS with the
remainder of nRF-based boards.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>