### PR TITLE
Devicetree API: Add missing macros for retrieving PWM period cell value

### DIFF
--- a/dts/bindings/test/vnd,pwm-controller.yaml
+++ b/dts/bindings/test/vnd,pwm-controller.yaml
@@ -12,8 +12,9 @@ properties:
       required: true
 
     "#pwm-cells":
-      const: 2
+      const: 3
 
 pwm-cells:
   - channel
+  - period
   - flags

--- a/include/devicetree/pwms.h
+++ b/include/devicetree/pwms.h
@@ -119,22 +119,25 @@ extern "C" {
  *     };
  *
  *     n: node {
- *             pwms = <&pwm1 1 PWM_POLARITY_NORMAL>,
- *                    <&pwm2 3 PWM_POLARITY_INVERTED>;
+ *             pwms = <&pwm1 1 200000 PWM_POLARITY_NORMAL>,
+ *                    <&pwm2 3 100000 PWM_POLARITY_INVERTED>;
  *     };
  *
  * Bindings fragment for the "vnd,pwm" compatible:
  *
  *     pwm-cells:
  *       - channel
+ *       - period
  *       - flags
  *
  * Example usage:
  *
  *     DT_PWMS_CELL_BY_IDX(DT_NODELABEL(n), 0, channel) // 1
  *     DT_PWMS_CELL_BY_IDX(DT_NODELABEL(n), 1, channel) // 3
- *     DT_PWMS_CELL_BY_IDX(DT_NODELABEL(n), 0, flags) // PWM_POLARITY_NORMAL
- *     DT_PWMS_CELL_BY_IDX(DT_NODELABEL(n), 1, flags) // PWM_POLARITY_INVERTED
+ *     DT_PWMS_CELL_BY_IDX(DT_NODELABEL(n), 0, period)  // 200000
+ *     DT_PWMS_CELL_BY_IDX(DT_NODELABEL(n), 1, period)  // 100000
+ *     DT_PWMS_CELL_BY_IDX(DT_NODELABEL(n), 0, flags)   // PWM_POLARITY_NORMAL
+ *     DT_PWMS_CELL_BY_IDX(DT_NODELABEL(n), 1, flags)   // PWM_POLARITY_INVERTED
  *
  * @param node_id node identifier for a node with a pwms property
  * @param idx logical index into pwms property
@@ -163,8 +166,8 @@ extern "C" {
  *     };
  *
  *     n: node {
- *             pwms = <&pwm1 1 PWM_POLARITY_NORMAL>,
- *                    <&pwm2 3 PWM_POLARITY_INVERTED>;
+ *             pwms = <&pwm1 1 200000 PWM_POLARITY_NORMAL>,
+ *                    <&pwm2 3 100000 PWM_POLARITY_INVERTED>;
  *             pwm-names = "alpha", "beta";
  *     };
  *
@@ -172,12 +175,15 @@ extern "C" {
  *
  *     pwm-cells:
  *       - channel
+ *       - period
  *       - flags
  *
  * Example usage:
  *
  *     DT_PWMS_CELL_BY_NAME(DT_NODELABEL(n), alpha, channel) // 1
  *     DT_PWMS_CELL_BY_NAME(DT_NODELABEL(n), beta, channel)  // 3
+ *     DT_PWMS_CELL_BY_NAME(DT_NODELABEL(n), alpha, period)  // 200000
+ *     DT_PWMS_CELL_BY_NAME(DT_NODELABEL(n), beta, period)   // 100000
  *     DT_PWMS_CELL_BY_NAME(DT_NODELABEL(n), alpha, flags)   // PWM_POLARITY_NORMAL
  *     DT_PWMS_CELL_BY_NAME(DT_NODELABEL(n), beta, flags)    // PWM_POLARITY_INVERTED
  *
@@ -240,6 +246,47 @@ extern "C" {
  * @see DT_PWMS_CHANNEL_BY_IDX()
  */
 #define DT_PWMS_CHANNEL(node_id) DT_PWMS_CHANNEL_BY_IDX(node_id, 0)
+
+/**
+ * @brief Get PWM specifier's period cell value at an index
+ *
+ * This macro only works for PWM specifiers with cells named "period".
+ * Refer to the node's binding to check if necessary.
+ *
+ * This is equivalent to DT_PWMS_CELL_BY_IDX(node_id, idx, period).
+ *
+ * @param node_id node identifier for a node with a pwms property
+ * @param idx logical index into pwms property
+ * @return the period cell value at index "idx"
+ * @see DT_PWMS_CELL_BY_IDX()
+ */
+#define DT_PWMS_PERIOD_BY_IDX(node_id, idx) \
+	DT_PWMS_CELL_BY_IDX(node_id, idx, period)
+
+/**
+ * @brief Get a PWM specifier's period cell value by name
+ *
+ * This macro only works for PWM specifiers with cells named "period".
+ * Refer to the node's binding to check if necessary.
+ *
+ * This is equivalent to DT_PWMS_CELL_BY_NAME(node_id, name, period).
+ *
+ * @param node_id node identifier for a node with a pwms property
+ * @param name lowercase-and-underscores name of a pwms element
+ *             as defined by the node's pwm-names property
+ * @return the period cell value in the specifier at the named element
+ * @see DT_PWMS_CELL_BY_NAME()
+ */
+#define DT_PWMS_PERIOD_BY_NAME(node_id, name) \
+	DT_PWMS_CELL_BY_NAME(node_id, name, period)
+
+/**
+ * @brief Equivalent to DT_PWMS_PERIOD_BY_IDX(node_id, 0)
+ * @param node_id node identifier for a node with a pwms property
+ * @return the period cell value at index 0
+ * @see DT_PWMS_PERIOD_BY_IDX()
+ */
+#define DT_PWMS_PERIOD(node_id) DT_PWMS_PERIOD_BY_IDX(node_id, 0)
 
 /**
  * @brief Get a PWM specifier's flags cell value at an index
@@ -373,6 +420,35 @@ extern "C" {
  * @see DT_INST_PWMS_CHANNEL_BY_IDX()
  */
 #define DT_INST_PWMS_CHANNEL(inst) DT_INST_PWMS_CHANNEL_BY_IDX(inst, 0)
+
+/**
+ * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, idx, period)
+ * @param inst DT_DRV_COMPAT instance number
+ * @param idx logical index into pwms property
+ * @return the period cell value at index "idx"
+ * @see DT_INST_PWMS_CELL_BY_IDX()
+ */
+#define DT_INST_PWMS_PERIOD_BY_IDX(inst, idx) \
+	DT_INST_PWMS_CELL_BY_IDX(inst, idx, period)
+
+/**
+ * @brief Equivalent to DT_INST_PWMS_CELL_BY_NAME(inst, name, period)
+ * @param inst DT_DRV_COMPAT instance number
+ * @param name lowercase-and-underscores name of a pwms element
+ *             as defined by the node's pwm-names property
+ * @return the period cell value in the specifier at the named element
+ * @see DT_INST_PWMS_CELL_BY_NAME()
+ */
+#define DT_INST_PWMS_PERIOD_BY_NAME(inst, name) \
+	DT_INST_PWMS_CELL_BY_NAME(inst, name, period)
+
+/**
+ * @brief Equivalent to DT_INST_PWMS_PERIOD_BY_IDX(inst, 0)
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the period cell value at index 0
+ * @see DT_INST_PWMS_PERIOD_BY_IDX()
+ */
+#define DT_INST_PWMS_PERIOD(inst) DT_INST_PWMS_PERIOD_BY_IDX(inst, 0)
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, idx, flags)

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -40,7 +40,7 @@
 			pha-gpios = <&test_gpio_1 50 60>, <&test_gpio_3 70>, <&test_gpio_2 80 90>;
 			foos = <&test_gpio_1 100>, <&test_gpio_2 110>;
 			foo-names = "A", "b-c";
-			pwms = <&test_pwm1 8 3>, <&test_pwm2 5 1>;
+			pwms = <&test_pwm1 8 200 3>, <&test_pwm2 5 100 1>;
 			pwm-names = "red", "green";
 		};
 
@@ -305,7 +305,7 @@
 
 		test_pwm1: pwm@55551111 {
 			compatible = "vnd,pwm";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 			reg = < 0x55551111 0x1000 >;
 			label = "TEST_PWM_CTRL_1";
 			status = "okay";
@@ -313,7 +313,7 @@
 
 		test_pwm2: pwm@55552222 {
 			compatible = "vnd,pwm";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 			reg = < 0x55552222 0x1000 >;
 			label = "TEST_PWM_CTRL_2";
 			status = "okay";

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1003,17 +1003,22 @@ static void test_pwms(void)
 	/* DT_PWMS_CELL_BY_IDX */
 	zassert_equal(DT_PWMS_CELL_BY_IDX(TEST_PH, 1, channel), 5,
 		      "pwm 2 channel");
+	zassert_equal(DT_PWMS_CELL_BY_IDX(TEST_PH, 1, period), 100,
+		      "pwm 2 period");
 	zassert_equal(DT_PWMS_CELL_BY_IDX(TEST_PH, 1, flags), 1,
 		      "pwm 2 flags");
 
 	/* DT_PWMS_CELL_BY_NAME */
 	zassert_equal(DT_PWMS_CELL_BY_NAME(TEST_PH, red, channel), 8,
 		      "pwm-red channel");
+	zassert_equal(DT_PWMS_CELL_BY_NAME(TEST_PH, red, period), 200,
+		      "pwm-red period");
 	zassert_equal(DT_PWMS_CELL_BY_NAME(TEST_PH, red, flags), 3,
 		      "pwm-red flags");
 
 	/* DT_PWMS_CELL */
 	zassert_equal(DT_PWMS_CELL(TEST_PH, channel), 8, "pwm channel");
+	zassert_equal(DT_PWMS_CELL(TEST_PH, period), 200, "pwm period");
 	zassert_equal(DT_PWMS_CELL(TEST_PH, flags), 3, "pwm flags");
 
 	/* DT_PWMS_CHANNEL_BY_IDX */
@@ -1026,15 +1031,25 @@ static void test_pwms(void)
 	/* DT_PWMS_CHANNEL */
 	zassert_equal(DT_PWMS_CHANNEL(TEST_PH), 8, "pwm channel");
 
+	/* DT_PWMS_PERIOD_BY_IDX */
+	zassert_equal(DT_PWMS_PERIOD_BY_IDX(TEST_PH, 1), 100, "pwm period");
+
+	/* DT_PWMS_PERIOD_BY_NAME */
+	zassert_equal(DT_PWMS_PERIOD_BY_NAME(TEST_PH, green), 100,
+		      "pwm period");
+
+	/* DT_PWMS_PERIOD */
+	zassert_equal(DT_PWMS_PERIOD(TEST_PH), 200, "pwm period");
+
 	/* DT_PWMS_FLAGS_BY_IDX */
-	zassert_equal(DT_PWMS_FLAGS_BY_IDX(TEST_PH, 1), 1, "pwm channel");
+	zassert_equal(DT_PWMS_FLAGS_BY_IDX(TEST_PH, 1), 1, "pwm flags");
 
 	/* DT_PWMS_FLAGS_BY_NAME */
 	zassert_equal(DT_PWMS_FLAGS_BY_NAME(TEST_PH, green), 1,
-		      "pwm channel");
+		      "pwm flags");
 
 	/* DT_PWMS_FLAGS */
-	zassert_equal(DT_PWMS_FLAGS(TEST_PH), 3, "pwm channel");
+	zassert_equal(DT_PWMS_FLAGS(TEST_PH), 3, "pwm flags");
 
 	/* DT_INST */
 	zassert_equal(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT), 1,
@@ -1057,16 +1072,22 @@ static void test_pwms(void)
 	/* DT_INST_PWMS_CELL_BY_IDX */
 	zassert_equal(DT_INST_PWMS_CELL_BY_IDX(0, 1, channel), 5,
 		      "pwm 2 channel");
-	zassert_equal(DT_INST_PWMS_CELL_BY_IDX(0, 1, flags), 1, "pwm 2 flags");
+	zassert_equal(DT_INST_PWMS_CELL_BY_IDX(0, 1, period), 100,
+		      "pwm 2 period");
+	zassert_equal(DT_INST_PWMS_CELL_BY_IDX(0, 1, flags), 1,
+		      "pwm 2 flags");
 
 	/* DT_INST_PWMS_CELL_BY_NAME */
 	zassert_equal(DT_INST_PWMS_CELL_BY_NAME(0, green, channel), 5,
 		      "pwm-green channel");
+	zassert_equal(DT_INST_PWMS_CELL_BY_NAME(0, green, period), 100,
+		      "pwm-green period");
 	zassert_equal(DT_INST_PWMS_CELL_BY_NAME(0, green, flags), 1,
 		      "pwm-green flags");
 
 	/* DT_INST_PWMS_CELL */
 	zassert_equal(DT_INST_PWMS_CELL(0, channel), 8, "pwm channel");
+	zassert_equal(DT_INST_PWMS_CELL(0, period), 200, "pwm period");
 	zassert_equal(DT_INST_PWMS_CELL(0, flags), 3, "pwm flags");
 
 	/* DT_INST_PWMS_CHANNEL_BY_IDX */
@@ -1077,6 +1098,15 @@ static void test_pwms(void)
 
 	/* DT_INST_PWMS_CHANNEL */
 	zassert_equal(DT_INST_PWMS_CHANNEL(0), 8, "pwm channel");
+
+	/* DT_INST_PWMS_PERIOD_BY_IDX */
+	zassert_equal(DT_INST_PWMS_PERIOD_BY_IDX(0, 1), 100, "pwm period");
+
+	/* DT_INST_PWMS_PERIOD_BY_NAME */
+	zassert_equal(DT_INST_PWMS_PERIOD_BY_NAME(0, red), 200, "pwm periodx");
+
+	/* DT_INST_PWMS_PERIOD */
+	zassert_equal(DT_INST_PWMS_PERIOD(0), 200, "pwm period");
 
 	/* DT_INST_PWMS_FLAGS_BY_IDX */
 	zassert_equal(DT_INST_PWMS_FLAGS_BY_IDX(0, 1), 1, "pwm channel");


### PR DESCRIPTION
The new DT_ macros for dealing with PWM controllers lack macros for retrieving the value of the 'period' cell for PWM controllers supporting this cell type.