### PR TITLE
cmake: gcc/clang: enable colour diagnostics in terminal outptut

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,11 @@ zephyr_compile_options($<TARGET_PROPERTY:compiler,no_common>)
 # @Intent: Set compiler specific flag for production of debug information
 zephyr_compile_options($<TARGET_PROPERTY:compiler,debug>)
 
+if($ENV{ZEPHYR_BUILD_COLOUR_DIAGNOSTIC})
+# @Intent: Set compiler specific flag for diagnostic messages
+zephyr_compile_options($<TARGET_PROPERTY:compiler,diagnostic>)
+endif()
+
 zephyr_compile_options(
   ${TOOLCHAIN_C_FLAGS}
 )

--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -13,6 +13,9 @@ check_set_compiler_property(PROPERTY hosted)
 # clang flags for coverage generation
 set_property(TARGET compiler PROPERTY coverage --coverage -fno-inline)
 
+# clang flag for colourful diagnostic messages
+set_compiler_property(PROPERTY diagnostic -fcolor-diagnostics)
+
 #######################################################
 # This section covers flags related to warning levels #
 #######################################################

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -179,3 +179,6 @@ set_compiler_property(PROPERTY sanitize_undefined -fsanitize=undefined)
 
 # Required ASM flags when using gcc
 set_property(TARGET asm PROPERTY required "-xassembler-with-cpp")
+
+# gcc flag for colourful diagnostic messages
+set_compiler_property(PROPERTY diagnostic -fdiagnostics-color=always)


### PR DESCRIPTION
When gcc/clang output is piped through ninja the compiler disables colour diagnostics. Using `-fdiagnostics-color` forces the compiler to enable colour output.

Colour highlighted error and warning messages are useful during development.