### PR TITLE
drivers: pwm: fix doxygen docs

### DIFF
--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -60,9 +60,9 @@ __subsystem struct pwm_driver_api {
 /**
  * @brief Set the period and pulse width for a single PWM output.
  *
- * Passing 0 to the @param pulse will cause the pin to be driven to a constant
+ * Passing 0 to the @p pulse will cause the pin to be driven to a constant
  * inactive level.
- * Passing a @param pulse equal @param period will cause the pin to be driven
+ * Passing a @p pulse equal @p period will cause the pin to be driven
  * to a constant active level.
  *
  * @param dev Pointer to the device structure for the driver instance.


### PR DESCRIPTION
When referencing parameters, use @p and not @param.