### PR TITLE
shell: fix showing 'command not found'

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -687,6 +687,14 @@ static int execute(const struct shell *shell)
 					  &cmd_with_handler_lvl, &args_left);
 			parent = entry;
 		} else {
+			if (cmd_lvl == 0 &&
+				(!shell_in_select_mode(shell) ||
+				 shell->ctx->selected_cmd->handler == NULL)) {
+				shell_internal_fprintf(shell, SHELL_ERROR,
+						       "%s%s\n", argv[0],
+						       SHELL_MSG_CMD_NOT_FOUND);
+			}
+
 			/* last handler found - no need to search commands in
 			 * the next iteration.
 			 */


### PR DESCRIPTION
After recent changes to shell, there is no more "no_such_command:
command not found" message when executing non-existing command. Restore
that message, so users are warned once again about wrong command,
instead of silently ignoring their request.

Fixes: 512de5ecac62 ("shell: Refactor command execution to enable raw
  arguments")
Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>