### PR TITLE
Misc linker cleanups

### DIFF
--- a/include/linker/common-ram.ld
+++ b/include/linker/common-ram.ld
@@ -13,14 +13,52 @@
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif
 
+/*
+ * Space for storing per device busy bitmap. Since we do not know beforehand
+ * the number of devices, we go through the below mechanism to allocate the
+ * required space.
+ */
+#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+#define DEVICE_COUNT \
+	((__device_end - __device_start) / _DEVICE_STRUCT_SIZEOF)
+#define DEV_BUSY_SZ	(((DEVICE_COUNT + 31) / 32) * 4)
+#define DEVICE_BUSY_BITFIELD()			\
+		FILL(0x00) ;			\
+		__device_busy_start = .;	\
+		. = . + DEV_BUSY_SZ;		\
+		__device_busy_end = .;
+#else
+#define DEVICE_BUSY_BITFIELD()
+#endif
+
 	SECTION_DATA_PROLOGUE(devices,,)
 	{
-		DEVICE_SECTIONS()
+		/* link in devices objects, which are tied to the init ones;
+		 * the objects are thus sorted the same way as their init
+		 * object parent see include/device.h
+		 */
+		__device_start = .;
+		CREATE_OBJ_LEVEL(device, PRE_KERNEL_1)
+		CREATE_OBJ_LEVEL(device, PRE_KERNEL_2)
+		CREATE_OBJ_LEVEL(device, POST_KERNEL)
+		CREATE_OBJ_LEVEL(device, APPLICATION)
+		CREATE_OBJ_LEVEL(device, SMP)
+		__device_end = .;
+		DEVICE_BUSY_BITFIELD()
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 	SECTION_DATA_PROLOGUE(initshell,,)
 	{
-		SHELL_INIT_SECTIONS()
+		/* link in shell initialization objects for all modules that
+		 * use shell and their shell commands are automatically
+		 * initialized by the kernel.
+		 */
+		__shell_module_start = .;
+		KEEP(*(".shell_module_*"));
+		__shell_module_end = .;
+		__shell_cmd_start = .;
+		KEEP(*(".shell_cmd_*"));
+		__shell_cmd_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 	SECTION_DATA_PROLOGUE(log_dynamic_sections,,)

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -2,7 +2,19 @@
 
 	SECTION_PROLOGUE(initlevel,,)
 	{
-		INIT_SECTIONS()
+		/*
+		 * link in initialization objects for all objects that are
+		 * automatically initialized by the kernel; the objects are
+		 * sorted in the order they will be initialized (i.e. ordered
+		 * by level, sorted by priority within a level)
+		 */
+		__init_start = .;
+		CREATE_OBJ_LEVEL(init, PRE_KERNEL_1)
+		CREATE_OBJ_LEVEL(init, PRE_KERNEL_2)
+		CREATE_OBJ_LEVEL(init, POST_KERNEL)
+		CREATE_OBJ_LEVEL(init, APPLICATION)
+		CREATE_OBJ_LEVEL(init, SMP)
+		__init_end = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
 #if defined(CONFIG_GEN_SW_ISR_TABLE) && !defined(CONFIG_DYNAMIC_INTERRUPTS)
@@ -21,7 +33,7 @@
 	/* verify we don't have rogue .init_<something> initlevel sections */
 	SECTION_PROLOGUE(initlevel_error,,)
 	{
-		INIT_UNDEFINED_SECTION()
+		KEEP(*(SORT(.init_[_A-Z0-9]*)))
 	}
 	ASSERT(SIZEOF(initlevel_error) == 0, "Undefined initialization levels used.")
 

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -36,26 +36,6 @@
 #endif
 
 #ifdef _LINKER
-
-
-/*
- * Space for storing per device busy bitmap. Since we do not know beforehand
- * the number of devices, we go through the below mechanism to allocate the
- * required space.
- */
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-#define DEVICE_COUNT \
-	((__device_end - __device_start) / _DEVICE_STRUCT_SIZEOF)
-#define DEV_BUSY_SZ	(((DEVICE_COUNT + 31) / 32) * 4)
-#define DEVICE_BUSY_BITFIELD()			\
-		FILL(0x00) ;			\
-		__device_busy_start = .;	\
-		. = . + DEV_BUSY_SZ;		\
-		__device_busy_end = .;
-#else
-#define DEVICE_BUSY_BITFIELD()
-#endif
-
 /*
  * generate a symbol to mark the start of the objects array for
  * the specified object and level, then link all of those objects
@@ -65,57 +45,7 @@
 #define CREATE_OBJ_LEVEL(object, level)				\
 		__##object##_##level##_start = .;		\
 		KEEP(*(SORT(.##object##_##level[0-9])));	\
-		KEEP(*(SORT(.##object##_##level[1-9][0-9])));	\
-
-/*
- * link in initialization objects for all objects that are automatically
- * initialized by the kernel; the objects are sorted in the order they will be
- * initialized (i.e. ordered by level, sorted by priority within a level)
- */
-
-#define	INIT_SECTIONS()					\
-		__init_start = .;			\
-		CREATE_OBJ_LEVEL(init, PRE_KERNEL_1)	\
-		CREATE_OBJ_LEVEL(init, PRE_KERNEL_2)	\
-		CREATE_OBJ_LEVEL(init, POST_KERNEL)	\
-		CREATE_OBJ_LEVEL(init, APPLICATION)	\
-		CREATE_OBJ_LEVEL(init, SMP)		\
-		__init_end = .;				\
-
-
-/* define a section for undefined device initialization levels */
-#define INIT_UNDEFINED_SECTION()		\
-		KEEP(*(SORT(.init_[_A-Z0-9]*)))	\
-
-
-/*
- * link in devices objects, which are tied to the init ones;
- * the objects are thus sorted the same way as their init object parent
- * see include/device.h
- */
-#define	DEVICE_SECTIONS()				\
-		__device_start = .;			\
-		CREATE_OBJ_LEVEL(device, PRE_KERNEL_1)	\
-		CREATE_OBJ_LEVEL(device, PRE_KERNEL_2)	\
-		CREATE_OBJ_LEVEL(device, POST_KERNEL)	\
-		CREATE_OBJ_LEVEL(device, APPLICATION)	\
-		CREATE_OBJ_LEVEL(device, SMP)		\
-		__device_end = .;			\
-		DEVICE_BUSY_BITFIELD()			\
-
-
-/*
- * link in shell initialization objects for all modules that use shell and
- * their shell commands are automatically initialized by the kernel.
- */
-
-#define	SHELL_INIT_SECTIONS()				\
-		__shell_module_start = .;		\
-		KEEP(*(".shell_module_*"));		\
-		__shell_module_end = .;			\
-		__shell_cmd_start = .;			\
-		KEEP(*(".shell_cmd_*"));		\
-		__shell_cmd_end = .;			\
+		KEEP(*(SORT(.##object##_##level[1-9][0-9])));
 
 /*
  * link in shell initialization objects for all modules that use shell and

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -54,15 +54,6 @@
 
 #define APP_SMEM_SECTION() KEEP(*(SORT("data_smem_*")))
 
-#ifdef CONFIG_X86 /* LINKER FILES: defines used by linker script */
-/* Should be moved to linker-common-defs.h */
-#if defined(CONFIG_XIP)
-#define ROMABLE_REGION ROM
-#else
-#define ROMABLE_REGION RAM
-#endif
-#endif
-
 /*
  * If image is loaded via kexec Linux system call, then program
  * headers need to be page aligned.

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -54,17 +54,6 @@
 
 #define APP_SMEM_SECTION() KEEP(*(SORT("data_smem_*")))
 
-/*
- * If image is loaded via kexec Linux system call, then program
- * headers need to be page aligned.
- * This can be done by section page aligning.
- */
-#ifdef CONFIG_BOOTLOADER_KEXEC
-#define KEXEC_PGALIGN_PAD(x) . = ALIGN(x);
-#else
-#define KEXEC_PGALIGN_PAD(x)
-#endif
-
 #elif defined(_ASMLANGUAGE)
 
 /* Assembly FILES: declaration defined by the linker script */


### PR DESCRIPTION
All minor stuff, no functional changes.

- Inline some stuff that was abstracted away, but only used once. These used to be repeated for every arch before the common-rom/common-ram headers were implemented.
- Delete long-unused KEXEC_PGALIGN_PAD
- Delete a duplicated x86 definition that somehow ended up in linker-defs.h