### PR TITLE
canbus: canopen: program: add missing include for FLASH_AREA

### DIFF
--- a/subsys/canbus/canopen/canopen_program.c
+++ b/subsys/canbus/canopen/canopen_program.c
@@ -9,6 +9,7 @@
 #include <canbus/canopen.h>
 #include <dfu/flash_img.h>
 #include <dfu/mcuboot.h>
+#include <storage/flash_map.h>
 #include <sys/crc.h>
 
 #define LOG_LEVEL CONFIG_CANOPEN_LOG_LEVEL


### PR DESCRIPTION
Add missing include after the conversion from DT_FLASH_AREA to FLASH_AREA.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>