### PR TITLE
driver: timer: stm32_lptim: don't reset backup domain

### DIFF
--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -110,8 +110,6 @@ int z_clock_driver_init(struct device *device)
 #endif /* LL_APB1_GRP1_PERIPH_PWR */
 	/* enable backup domain */
 	LL_PWR_EnableBkUpAccess();
-	LL_RCC_ForceBackupDomainReset();
-	LL_RCC_ReleaseBackupDomainReset();
 
 	/* enable LSE clock */
 	LL_RCC_LSE_DisableBypass();


### PR DESCRIPTION
We don't need to reset backup domain to set LSE clock source.
It's dangerous to reset backup domain, it removes:
	- RTC configuration
	- backup registers
	- RCC Backup domain control register

fix  #25895