### PR TITLE
net: config: align Kconfig debug levels with OpenThread ones

### DIFF
--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -53,22 +53,25 @@ choice
 	help
 	  This option selects log level for OpenThread stack.
 
-config OPENTHREAD_LOG_LEVEL_ERROR
-	bool "Error"
-config OPENTHREAD_LOG_LEVEL_WARNING
+config OPENTHREAD_LOG_LEVEL_CRIT
+	bool "Critical"
+config OPENTHREAD_LOG_LEVEL_WARN
 	bool "Warning"
+config OPENTHREAD_LOG_LEVEL_NOTE
+	bool "Notice"
 config OPENTHREAD_LOG_LEVEL_INFO
-	bool "Info"
-config OPENTHREAD_LOG_LEVEL_DEBUG
+	bool "Informational"
+config OPENTHREAD_LOG_LEVEL_DEBG
 	bool "Debug"
 endchoice
 
 config OPENTHREAD_LOG_LEVEL
 	int
-	default 1 if OPENTHREAD_LOG_LEVEL_ERROR
-	default 2 if OPENTHREAD_LOG_LEVEL_WARNING
-	default 3 if OPENTHREAD_LOG_LEVEL_INFO
-	default 4 if OPENTHREAD_LOG_LEVEL_DEBUG
+	default 1 if OPENTHREAD_LOG_LEVEL_CRIT
+	default 2 if OPENTHREAD_LOG_LEVEL_WARN
+	default 3 if OPENTHREAD_LOG_LEVEL_NOTE
+	default 4 if OPENTHREAD_LOG_LEVEL_INFO
+	default 5 if OPENTHREAD_LOG_LEVEL_DEBG
 	default 0
 
 menuconfig OPENTHREAD_L2_DEBUG

--- a/subsys/net/lib/openthread/platform/logging.c
+++ b/subsys/net/lib/openthread/platform/logging.c
@@ -44,6 +44,7 @@ void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion,
 	case OT_LOG_LEVEL_WARN:
 		LOG_WRN("%s", log_strdup(logString));
 		break;
+	case OT_LOG_LEVEL_NOTE:
 	case OT_LOG_LEVEL_INFO:
 		LOG_INF("%s", log_strdup(logString));
 		break;


### PR DESCRIPTION
OpenThread moved from 4 to 5 debug levels and it was not possible to configure all of them with Kconfig.

Reference: https://github.com/zephyrproject-rtos/openthread/blob/zephyr/include/openthread/platform/logging.h#L45-L107

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>