### PR TITLE
storage/stream: fix possible unaligned write on buffer flush request

### DIFF
--- a/include/storage/stream_flash.h
+++ b/include/storage/stream_flash.h
@@ -70,7 +70,8 @@ struct stream_flash_ctx {
  * @param ctx context to be initialized
  * @param fdev Flash device to operate on
  * @param buf Write buffer
- * @param buf_len Length of write buffer. Can not be larger than the page size
+ * @param buf_len Length of write buffer. Can not be larger than the page size.
+ *                Must be multiple of the flash device write-block-size.
  * @param offset Offset within flash device to start writing to
  * @param size Number of bytes available for performing buffered write.
  *             If this is '0', the size will be set to the total size

--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -112,6 +112,8 @@ int stream_flash_buffered_write(struct stream_flash_ctx *ctx, const u8_t *data,
 	int processed = 0;
 	int rc = 0;
 	int buf_empty_bytes;
+	size_t fill_length;
+	u8_t filler;
 
 	if (!ctx || !data) {
 		return -EFAULT;
@@ -144,6 +146,27 @@ int stream_flash_buffered_write(struct stream_flash_ctx *ctx, const u8_t *data,
 	}
 
 	if (flush && ctx->buf_bytes > 0) {
+		fill_length = flash_get_write_block_size(ctx->fdev);
+		if (ctx->buf_bytes % fill_length) {
+			fill_length -= ctx->buf_bytes % fill_length;
+			/*
+			 * Leverage the fact that unwritten memory
+			 * should be erased in order to get the erased
+			 * byte-value.
+			 */
+			rc = flash_read(ctx->fdev,
+					ctx->offset + ctx->bytes_written,
+					(void *)&filler,
+					1);
+
+			if (rc != 0) {
+				return rc;
+			}
+
+			memset(ctx->buf + ctx->buf_bytes, filler, fill_length);
+			ctx->buf_bytes += fill_length;
+		}
+
 		rc = flash_sync(ctx);
 	}
 
@@ -167,6 +190,11 @@ int stream_flash_init(struct stream_flash_ctx *ctx, struct device *fdev,
 	size_t total_size = 0;
 	const struct flash_pages_layout *layout;
 	const struct flash_driver_api *api = fdev->driver_api;
+
+	if (buf_len % flash_get_write_block_size(fdev)) {
+		LOG_ERR("Buffer size is not aligned to minimal write-block-size");
+		return -EFAULT;
+	}
 
 	/* Calculate the total size of the flash device */
 	api->page_layout(fdev, &layout, &layout_size);

--- a/tests/subsys/storage/stream/stream_flash/testcase.yaml
+++ b/tests/subsys/storage/stream/stream_flash/testcase.yaml
@@ -2,6 +2,10 @@ tests:
   storage.stream_flash:
     platform_whitelist: native_posix native_posix_64
     tags: stream_flash
+  storage.stream_flash.dword_wbs:
+    extra_args: DTC_OVERLAY_FILE=unaligned_flush.overlay
+    platform_whitelist: native_posix native_posix_64
+    tags: stream_flash
   storage.stream_flash.no_erase:
     extra_args: OVERLAY_CONFIG=no_erase.overlay
     platform_whitelist: native_posix native_posix_64

--- a/tests/subsys/storage/stream/stream_flash/unaligned_flush.overlay
+++ b/tests/subsys/storage/stream/stream_flash/unaligned_flush.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&flash0 {
+	write-block-size = < 0x8 >;
+};


### PR DESCRIPTION
On buffer flush request it is very probably that write buffer
contains amount of data which is non write-block-size aligned.
Flash memory need to be write at minimal by write-block-size chunks.
This patch addresses mechanism which ensure such behavior by adding
missing bytes.

fixes #25471

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>