### PR TITLE
drivers: serial: nrfx: Force poll_out when lock attempts are over

### DIFF
--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -280,7 +280,7 @@ static void uart_nrfx_poll_out(struct device *dev, unsigned char c)
 			 */
 			k_msleep(1);
 			if (--safety_cnt == 0) {
-				return;
+				break;
 			}
 		}
 	} else {

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1030,7 +1030,7 @@ static void uarte_nrfx_poll_out(struct device *dev, unsigned char c)
 			 */
 			k_msleep(1);
 			if (--safety_cnt == 0) {
-				return;
+				break;
 			}
 		}
 	} else {


### PR DESCRIPTION
When the loop that tries to obtain the lock in poll_out() finishes
because of hitting the max number of trials (what normally should
never happen), force the lock to be taken instead of just giving up
with sending the data. The latter approach that was in use so far
could not deal with a situation when some thread was aborted while
keeping the lock. Other threads would then have no chance to send
anything with poll_out() until it was called from an ISR.

This is a follow-up to #22355.
Relates to #23799, see https://github.com/zephyrproject-rtos/zephyr/issues/23799#issuecomment-632751860.