### PR TITLE
drivers: pwm: clarify expected behavior

### DIFF
--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -60,10 +60,10 @@ __subsystem struct pwm_driver_api {
 /**
  * @brief Set the period and pulse width for a single PWM output.
  *
- * Passing 0 to the @p pulse will cause the pin to be driven to a constant
+ * Passing 0 as @p pulse will cause the pin to be driven to a constant
  * inactive level.
- * Passing a @p pulse equal @p period will cause the pin to be driven
- * to a constant active level.
+ * Passing a non-zero @p pulse equal to @p period will cause the pin
+ * to be driven to a constant active level.
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param pwm PWM pin.


### PR DESCRIPTION
As written the specification when both period and pulse are zero is inconsistent: allowed behavior would be to drive the pin at constant active or constant inactive, depending on which condition was checked first.

Clarify that driving constant active level requres a non-zero pulse equal to period.

NOTE: I'm not sure what drivers actually do.  Hopefully this is a clarification that can be merged, not an API behavior that needs to be discussed.  @alexanderwachter @carlescufi 