### PR TITLE
Bluetooth: Mesh: fix minor compilation warning

### DIFF
--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -480,7 +480,7 @@ static bool model_has_dst(struct bt_mesh_model *mod, u16_t dst)
 	if (BT_MESH_ADDR_IS_UNICAST(dst)) {
 		return (dev_comp->elem[mod->elem_idx].addr == dst);
 	} else if (BT_MESH_ADDR_IS_GROUP(dst) || BT_MESH_ADDR_IS_VIRTUAL(dst)) {
-		return bt_mesh_model_find_group(&mod, dst);
+		return !!bt_mesh_model_find_group(&mod, dst);
 	}
 
 	return (mod->elem_idx == 0 && bt_mesh_fixed_group_match(dst));

--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -55,13 +55,6 @@ static K_FIFO_DEFINE(adv_queue);
 static struct k_thread adv_thread_data;
 static K_THREAD_STACK_DEFINE(adv_thread_stack, ADV_STACK_SIZE);
 
-static const u8_t adv_type[] = {
-	[BT_MESH_ADV_PROV]   = BT_DATA_MESH_PROV,
-	[BT_MESH_ADV_DATA]   = BT_DATA_MESH_MESSAGE,
-	[BT_MESH_ADV_BEACON] = BT_DATA_MESH_BEACON,
-	[BT_MESH_ADV_URI]    = BT_DATA_URI,
-};
-
 NET_BUF_POOL_DEFINE(adv_buf_pool, CONFIG_BT_MESH_ADV_BUF_COUNT,
 		    BT_MESH_ADV_DATA_SIZE, BT_MESH_ADV_USER_DATA_SIZE, NULL);
 
@@ -91,6 +84,12 @@ static inline void adv_send_end(int err, const struct bt_mesh_send_cb *cb,
 
 static inline void adv_send(struct net_buf *buf)
 {
+	static const u8_t adv_type[] = {
+		[BT_MESH_ADV_PROV]   = BT_DATA_MESH_PROV,
+		[BT_MESH_ADV_DATA]   = BT_DATA_MESH_MESSAGE,
+		[BT_MESH_ADV_BEACON] = BT_DATA_MESH_BEACON,
+		[BT_MESH_ADV_URI]    = BT_DATA_URI,
+	};
 	const s32_t adv_int_min = ((bt_dev.hci_version >= BT_HCI_VERSION_5_0) ?
 				   ADV_INT_FAST_MS : ADV_INT_DEFAULT_MS);
 	const struct bt_mesh_send_cb *cb = BT_MESH_ADV(buf)->cb;

--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -1199,7 +1199,6 @@ int bt_mesh_prov_enable(bt_mesh_prov_bearer_t bearers)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_DEBUG)) {
-		const struct bt_mesh_prov *prov = bt_mesh_prov_get();
 		struct bt_uuid_128 uuid = { .uuid = { BT_UUID_TYPE_128 } };
 
 		memcpy(uuid.val, prov->uuid, 16);


### PR DESCRIPTION
Bluetooth: Mesh: correct the return type
Bluetooth: Mesh: fix shadow declare

CC:  mesh/access.c
mesh/access.c: In function 'model_has_dst':
mesh/access.c:483:10: warning: returning 'u16_t *' {aka 'short unsigned int *'} from
                      a function with return type '_Bool8' {aka 'unsigned char'} makes
                      integer from pointer without a cast [-Wint-conversion]
  483 |   return bt_mesh_model_find_group(&mod, dst);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

CC:  mesh/adv.c
mesh/adv.c: In function 'bt_mesh_scan_cb':
mesh/adv.c:247:13: warning: declaration of 'adv_type' shadows a global declaration [-Wshadow]
  247 |        u8_t adv_type, struct net_buf_simple *buf)
      |        ~~~~~^~~~~~~~
mesh/adv.c:58:19: note: shadowed declaration is here
   58 | static const u8_t adv_type[] = {
      |                   ^~~~~~~~

CC:  mesh/prov.c
mesh/prov.c: In function 'bt_mesh_prov_enable':
mesh/prov.c:1203:30: warning: declaration of 'prov' shadows a global declaration [-Wshadow]
 1203 |   const struct bt_mesh_prov *prov = bt_mesh_prov_get();
      |                              ^~~~
mesh/prov.c:129:35: note: shadowed declaration is here
  129 | static const struct bt_mesh_prov *prov;
      |                                   ^~~~