### PR TITLE
bluetooth: mesh: revisions to support building C++ applications

### DIFF
--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -11,6 +11,17 @@
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_ACCESS_H_
 
 #include <settings/settings.h>
+#include <sys/util.h>
+
+/* Internal macros used to initialize array members */
+#define BT_MESH_KEY_UNUSED_ELT_(IDX, _) BT_MESH_KEY_UNUSED,
+#define BT_MESH_ADDR_UNASSIGNED_ELT_(IDX, _) BT_MESH_ADDR_UNASSIGNED,
+#define BT_MESH_MODEL_KEYS_UNUSED			\
+	{ UTIL_LISTIFY(CONFIG_BT_MESH_MODEL_KEY_COUNT,	\
+		       BT_MESH_KEY_UNUSED_ELT_) }
+#define BT_MESH_MODEL_GROUPS_UNASSIGNED				\
+	{ UTIL_LISTIFY(CONFIG_BT_MESH_MODEL_GROUP_COUNT,	\
+		       BT_MESH_ADDR_UNASSIGNED_ELT_) }
 
 /**
  * @brief Bluetooth Mesh Access Layer
@@ -257,14 +268,12 @@ struct bt_mesh_model_op {
 #define BT_MESH_MODEL_CB(_id, _op, _pub, _user_data, _cb)                    \
 {                                                                            \
 	.id = (_id),                                                         \
-	.op = _op,                                                           \
-	.keys = { [0 ... (CONFIG_BT_MESH_MODEL_KEY_COUNT - 1)] =             \
-			BT_MESH_KEY_UNUSED },                                \
 	.pub = _pub,                                                         \
-	.groups = { [0 ... (CONFIG_BT_MESH_MODEL_GROUP_COUNT - 1)] =         \
-			BT_MESH_ADDR_UNASSIGNED },                           \
-	.user_data = _user_data,                                             \
+	.keys = BT_MESH_MODEL_KEYS_UNUSED,                                   \
+	.groups = BT_MESH_MODEL_GROUPS_UNASSIGNED,                           \
+	.op = _op,                                                           \
 	.cb = _cb,                                                           \
+	.user_data = _user_data,                                             \
 }
 
 /** @def BT_MESH_MODEL_VND_CB
@@ -284,10 +293,8 @@ struct bt_mesh_model_op {
 	.vnd.id = (_id),                                                     \
 	.op = _op,                                                           \
 	.pub = _pub,                                                         \
-	.keys = { [0 ... (CONFIG_BT_MESH_MODEL_KEY_COUNT - 1)] =             \
-			BT_MESH_KEY_UNUSED },                                \
-	.groups = { [0 ... (CONFIG_BT_MESH_MODEL_GROUP_COUNT - 1)] =         \
-			BT_MESH_ADDR_UNASSIGNED },                           \
+	.keys = BT_MESH_MODEL_KEYS_UNUSED,                                   \
+	.groups = BT_MESH_MODEL_GROUPS_UNASSIGNED,                           \
 	.user_data = _user_data,                                             \
 	.cb = _cb,                                                           \
 }

--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -51,8 +51,8 @@ extern "C" {
 {                                                   \
 	.loc              = (_loc),                 \
 	.model_count      = ARRAY_SIZE(_mods),      \
-	.models           = (_mods),                \
 	.vnd_model_count  = ARRAY_SIZE(_vnd_mods),  \
+	.models           = (_mods),                \
 	.vnd_models       = (_vnd_mods),            \
 }
 
@@ -449,8 +449,8 @@ struct bt_mesh_model_pub {
 #define BT_MESH_MODEL_PUB_DEFINE(_name, _update, _msg_len) \
 	NET_BUF_SIMPLE_DEFINE_STATIC(bt_mesh_pub_msg_##_name, _msg_len); \
 	static struct bt_mesh_model_pub _name = { \
-		.update = _update, \
 		.msg = &bt_mesh_pub_msg_##_name, \
+		.update = _update, \
 	}
 
 /** Model callback functions. */

--- a/include/bluetooth/mesh/cdb.h
+++ b/include/bluetooth/mesh/cdb.h
@@ -6,6 +6,13 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_CDB_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_CDB_H_
 
+#include <inttypes.h>
+#include <sys/atomic.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(CONFIG_BT_MESH_CDB)
 #define NODE_COUNT    CONFIG_BT_MESH_CDB_NODE_COUNT
 #define SUBNET_COUNT  CONFIG_BT_MESH_CDB_SUBNET_COUNT
@@ -259,5 +266,9 @@ struct bt_mesh_cdb_app_key *bt_mesh_cdb_app_key_get(uint16_t app_idx);
  *  @param key Application key to be stored.
  */
 void bt_mesh_cdb_app_key_store(const struct bt_mesh_cdb_app_key *key);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_MESH_CDB_H_ */


### PR DESCRIPTION
A couple changes to the headers to avoid violating C++ language requirements.

Using the mesh access macros in C++ also requires #25593.