### PR TITLE
nrf52_bsim: Add wrappers for some more CMSIS APIs

### DIFF
--- a/arch/posix/core/cpuhalt.c
+++ b/arch/posix/core/cpuhalt.c
@@ -48,6 +48,8 @@ void arch_cpu_atomic_idle(unsigned int key)
  */
 void __weak sys_arch_reboot(int type)
 {
-	ARG_UNUSED(type);
+	posix_print_warning("%s called with type %d. Exiting\n",
+						__func__, type);
+	posix_exit(1);
 }
 #endif /* CONFIG_REBOOT */

--- a/boards/posix/nrf52_bsim/CMakeLists.txt
+++ b/boards/posix/nrf52_bsim/CMakeLists.txt
@@ -29,6 +29,7 @@ zephyr_library_sources(
 	main.c
 	time_machine.c
 	trace_hook.c
+	cmsis.c
 )
 
 zephyr_library_include_directories(

--- a/boards/posix/nrf52_bsim/cmsis.c
+++ b/boards/posix/nrf52_bsim/cmsis.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ * Copyright (c) 2020 Oticon A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include "irq_ctrl.h"
+#include "posix_core.h"
+#include "posix_board_if.h"
+#include "board_soc.h"
+
+/*
+ *  Replacement for ARMs NVIC functions()
+ */
+void NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+	hw_irq_ctrl_raise_im_from_sw(IRQn);
+}
+
+void NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+	hw_irq_ctrl_clear_irq(IRQn);
+}
+
+void NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+	hw_irq_ctrl_disable_irq(IRQn);
+}
+
+void NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+	hw_irq_ctrl_enable_irq(IRQn);
+}
+
+void NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+	hw_irq_ctrl_prio_set(IRQn, priority);
+}
+
+uint32_t NVIC_GetPriority(IRQn_Type IRQn)
+{
+	return hw_irq_ctrl_get_prio(IRQn);
+}
+
+void NVIC_SystemReset(void)
+{
+	posix_print_warning("%s called. Exiting\n", __func__);
+	posix_exit(1);
+}
+
+/*
+ * Replacements for some other CMSIS functions
+ */
+void __enable_irq(void)
+{
+	hw_irq_ctrl_change_lock(true);
+}
+
+void __disable_irq(void)
+{
+	hw_irq_ctrl_change_lock(false);
+}
+
+uint32_t __get_PRIMASK(void)
+{
+	return hw_irq_ctrl_get_current_lock();
+}

--- a/boards/posix/nrf52_bsim/irq_handler.c
+++ b/boards/posix/nrf52_bsim/irq_handler.c
@@ -13,7 +13,6 @@
 #include "kswap.h"
 #include "irq_ctrl.h"
 #include "posix_core.h"
-#include "posix_board_if.h"
 #include "board_soc.h"
 #include "sw_isr_table.h"
 #include "soc.h"
@@ -365,63 +364,6 @@ void posix_irq_offload(void (*routine)(void *), void *parameter)
 	posix_irq_disable(OFFLOAD_SW_IRQ);
 }
 #endif
-
-/*
- *  Replacement for ARMs NVIC functions()
- */
-void NVIC_SetPendingIRQ(IRQn_Type IRQn)
-{
-	hw_irq_ctrl_raise_im_from_sw(IRQn);
-}
-
-void NVIC_ClearPendingIRQ(IRQn_Type IRQn)
-{
-	hw_irq_ctrl_clear_irq(IRQn);
-}
-
-void NVIC_DisableIRQ(IRQn_Type IRQn)
-{
-	hw_irq_ctrl_disable_irq(IRQn);
-}
-
-void NVIC_EnableIRQ(IRQn_Type IRQn)
-{
-	hw_irq_ctrl_enable_irq(IRQn);
-}
-
-void NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
-{
-	hw_irq_ctrl_prio_set(IRQn, priority);
-}
-
-uint32_t NVIC_GetPriority(IRQn_Type IRQn)
-{
-	return hw_irq_ctrl_get_prio(IRQn);
-}
-
-void NVIC_SystemReset(void)
-{
-	posix_print_warning("%s called. Exiting\n", __func__);
-	posix_exit(1);
-}
-
-/*
- * Replacements for some other CMSIS functions
- */
-void __enable_irq(void)
-{
-	hw_irq_ctrl_change_lock(true);
-}
-
-void __disable_irq(void)
-{
-	hw_irq_ctrl_change_lock(false);
-}
-
-uint32_t __get_PRIMASK(void)
-{
-	return hw_irq_ctrl_get_current_lock();
-}
 
 /*
  * Very simple model of the WFE and SEV ARM instructions

--- a/boards/posix/nrf52_bsim/irq_handler.c
+++ b/boards/posix/nrf52_bsim/irq_handler.c
@@ -13,6 +13,7 @@
 #include "kswap.h"
 #include "irq_ctrl.h"
 #include "posix_core.h"
+#include "posix_board_if.h"
 #include "board_soc.h"
 #include "sw_isr_table.h"
 #include "soc.h"
@@ -365,27 +366,61 @@ void posix_irq_offload(void (*routine)(void *), void *parameter)
 }
 #endif
 
-/**
- * Replacement for ARMs NVIC_SetPendingIRQ()
- *
- * Sets the interrupt IRQn as pending
- * Note:
- * This will interrupt immediately if the interrupt
- * is not masked and irqs are not locked, and this interrupt is higher
- * priority than a possibly currently running interrupt
+/*
+ *  Replacement for ARMs NVIC functions()
  */
 void NVIC_SetPendingIRQ(IRQn_Type IRQn)
 {
 	hw_irq_ctrl_raise_im_from_sw(IRQn);
 }
 
-/**
- *  Replacement for ARMs NVIC_ClearPendingIRQ()
- *  Clear pending interrupt IRQn
- */
 void NVIC_ClearPendingIRQ(IRQn_Type IRQn)
 {
 	hw_irq_ctrl_clear_irq(IRQn);
+}
+
+void NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+	hw_irq_ctrl_disable_irq(IRQn);
+}
+
+void NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+	hw_irq_ctrl_enable_irq(IRQn);
+}
+
+void NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+	hw_irq_ctrl_prio_set(IRQn, priority);
+}
+
+uint32_t NVIC_GetPriority(IRQn_Type IRQn)
+{
+	return hw_irq_ctrl_get_prio(IRQn);
+}
+
+void NVIC_SystemReset(void)
+{
+	posix_print_warning("%s called. Exiting\n", __func__);
+	posix_exit(1);
+}
+
+/*
+ * Replacements for some other CMSIS functions
+ */
+void __enable_irq(void)
+{
+	hw_irq_ctrl_change_lock(true);
+}
+
+void __disable_irq(void)
+{
+	hw_irq_ctrl_change_lock(false);
+}
+
+uint32_t __get_PRIMASK(void)
+{
+	return hw_irq_ctrl_get_current_lock();
 }
 
 /*
@@ -402,6 +437,11 @@ void __WFE(void)
 		CPU_will_be_awaken_from_WFE = false;
 	}
 	CPU_event_set_flag = false;
+}
+
+void __WFI(void)
+{
+	__WFE();
 }
 
 void __SEV(void)


### PR DESCRIPTION
This commit adds some more wrappers for commonly used CMSIS APIs.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>