### PR TITLE
lib: updatehub: Fix bus fault

### DIFF
--- a/lib/updatehub/updatehub.c
+++ b/lib/updatehub/updatehub.c
@@ -753,7 +753,7 @@ enum updatehub_response updatehub_probe(void)
 		}
 
 		sha256size = strlen(
-			metadata_any_boards.objects[1].objects.sha256sum) + 1;
+			metadata_some_boards.objects[1].objects.sha256sum) + 1;
 
 		if (sha256size != SHA256_HEX_DIGEST_SIZE) {
 			LOG_ERR("SHA256 size is invalid");


### PR DESCRIPTION
Fix variable-size string copy patch that introduced a runtime bug that
causes a bus fault.

Fixes #24853.

Signed-off-by: Tahir Akram <mtahirbutt@hotmail.com>
Signed-off-by: Gerson Fernando Budke <gerson.budke@ossystems.com.br>

CC @otavio @mtahirbutt