### PR TITLE
dts: arm: qemu-virt: Modify timer interrupt to be level-sensitive

### DIFF
--- a/dts/arm/qemu-virt/qemu-virt-a53.dtsi
+++ b/dts/arm/qemu-virt/qemu-virt-a53.dtsi
@@ -70,13 +70,13 @@
 
 		arch_timer: timer {
 			compatible = "arm,arm-timer";
-			interrupts = <GIC_PPI 13 IRQ_TYPE_EDGE
+			interrupts = <GIC_PPI 13 IRQ_TYPE_LEVEL
 				      IRQ_DEFAULT_PRIORITY>,
-				     <GIC_PPI 14 IRQ_TYPE_EDGE
+				     <GIC_PPI 14 IRQ_TYPE_LEVEL
 				      IRQ_DEFAULT_PRIORITY>,
-				     <GIC_PPI 11 IRQ_TYPE_EDGE
+				     <GIC_PPI 11 IRQ_TYPE_LEVEL
 				      IRQ_DEFAULT_PRIORITY>,
-				     <GIC_PPI 10 IRQ_TYPE_EDGE
+				     <GIC_PPI 10 IRQ_TYPE_LEVEL
 				      IRQ_DEFAULT_PRIORITY>;
 			label = "arch_timer";
 		};


### PR DESCRIPTION
The interrupts generated by the generic timer behave in
a level-sensitive manner. Change the DT to reflect the same.

Fixes: #25585

Signed-off-by: Abhishek Shah <abhishek.shah@broadcom.com>