### PR TITLE
USB: Bluetooth: Fix rx_thread_stack size

### DIFF
--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -38,7 +38,7 @@ static K_FIFO_DEFINE(tx_queue);
 #define BLUETOOTH_INT_EP_MPS            MIN(BT_BUF_RX_SIZE, USB_MAX_FS_INT_MPS)
 
 /* HCI RX/TX threads */
-static K_THREAD_STACK_DEFINE(rx_thread_stack, 512);
+static K_THREAD_STACK_DEFINE(rx_thread_stack, CONFIG_BT_HCI_TX_STACK_SIZE);
 static struct k_thread rx_thread_data;
 static K_THREAD_STACK_DEFINE(tx_thread_stack, 512);
 static struct k_thread tx_thread_data;


### PR DESCRIPTION
Increase rx_thread_stack size to follow BT_HCI_TX_STACK_SIZE
value defined by the Bluetooth subsystem.

Below, thread 0x20000d28, the hci_rx_thread earlier had 512
bytes which could be insufficient under edge cases like an
interrupt being asserted at the deepest stack usage.

Logging output as part of update to stack size:
<inf> thread_analyzer: Thread analyze:
<inf> thread_analyzer:  workqueue           : unused 648 usage 376 /
	1024 (36 %)
<inf> thread_analyzer:  thread_analyzer     : unused 264 usage 248 /
	512 (48 %)
<inf> thread_analyzer:  0x20000e30          : unused 280 usage 232 /
	512 (45 %)
<inf> thread_analyzer:  0x20000d28          : unused 584 usage 440 /
	1024 (42 %)
<inf> thread_analyzer:  BT RX               : unused 320 usage 192 /
	512 (37 %)
<inf> thread_analyzer:  BT RX pri           : unused 284 usage 164 /
	448 (36 %)
<inf> thread_analyzer:  sysworkq            : unused 824 usage 200 /
	1024 (19 %)
<inf> thread_analyzer:  logging             : unused 200 usage 568 /
	768 (73 %)
<inf> thread_analyzer:  idle 00             : unused 272 usage 48 /
	320 (15 %)

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>