### PR TITLE
Tests: create new test cases to verify sensor APIs.

### DIFF
--- a/tests/drivers/sensor/CMakeLists.txt
+++ b/tests/drivers/sensor/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13.1)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(device)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/sensor/prj.conf
+++ b/tests/drivers/sensor/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/drivers/sensor/src/dummy_sensor.c
+++ b/tests/drivers/sensor/src/dummy_sensor.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "dummy_sensor.h"
+#include <drivers/sensor.h>
+#include <device.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(dummy_sensor, LOG_LEVEL_DBG);
+static struct dummy_sensor_data dummy_data;
+/**
+ * @brief config bus address at compile time
+ */
+static const struct dummy_sensor_config dummy_config = {
+	.i2c_name = "dummy I2C",
+	.i2c_address = 123
+};
+
+static int dummy_sensor_sample_fetch(struct device *dev,
+				enum sensor_channel chan)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(chan);
+
+	/* Just return success due to dummy sensor driver here. */
+	return 0;
+}
+
+static int dummy_sensor_channel_get(struct device *dev,
+				enum sensor_channel chan,
+				struct sensor_value *val)
+{
+	struct dummy_sensor_data *data = dev->driver_data;
+
+	switch (chan) {
+	case SENSOR_CHAN_LIGHT:
+		val->val1 = data->val[0].val1;
+		val->val2 = data->val[0].val2;
+		break;
+	case SENSOR_CHAN_RED:
+		val->val1 = data->val[1].val1;
+		val->val2 = data->val[1].val2;
+		break;
+	case SENSOR_CHAN_GREEN:
+		val->val1 = data->val[2].val1;
+		val->val2 = data->val[2].val2;
+		break;
+	case SENSOR_CHAN_BLUE:
+		val->val1 = data->val[3].val1;
+		val->val2 = data->val[3].val2;
+		break;
+	case SENSOR_CHAN_PROX:
+		val->val1 = data->val[4].val1;
+		val->val2 = data->val[4].val2;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+/* return 0 for dummy driver to imitate interrupt */
+static int dummy_init_interrupt(struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return 0;
+}
+
+static int dummy_sensor_init(struct device *dev)
+{
+	struct dummy_sensor_data *data = dev->driver_data;
+	const struct dummy_sensor_config *config = dev->config_info;
+	/* i2c should be null for dummy driver */
+	struct device *i2c = device_get_binding(config->i2c_name);
+
+	if (i2c != NULL) {
+		LOG_ERR("Should be Null for %s device!", config->i2c_name);
+		return -1;
+	}
+
+	if (dummy_init_interrupt(dev) < 0) {
+		LOG_ERR("Failed to initialize interrupt!");
+		return -1;
+	}
+
+	/* initialize the channels value for dummy driver */
+	for (int i = 0; i < SENSOR_CHANNEL_NUM; i++) {
+		data->val[i].val1 = i;
+		data->val[i].val2 = i*i;
+	}
+
+	return 0;
+}
+
+int dummy_sensor_attr_set(struct device *dev,
+		      enum sensor_channel chan,
+		      enum sensor_attribute attr,
+		      const struct sensor_value *val)
+{
+	struct dummy_sensor_data *data = dev->driver_data;
+
+	if (chan == SENSOR_CHAN_PROX) {
+		data->val[4].val1 = val->val1;
+		data->val[4].val2 = val->val2;
+	}
+	return 0;
+}
+
+int dummy_sensor_trigger_set(struct device *dev,
+			const struct sensor_trigger *trig,
+			sensor_trigger_handler_t handler)
+{
+	struct dummy_sensor_data *data = dev->driver_data;
+
+	switch (trig->type) {
+	case SENSOR_TRIG_THRESHOLD:
+	case SENSOR_TRIG_TIMER:
+	case SENSOR_TRIG_DATA_READY:
+	case SENSOR_TRIG_DELTA:
+	case SENSOR_TRIG_NEAR_FAR:
+		/* Use the same action to dummy above triggers */
+		if (handler != NULL) {
+			data->handler = handler;
+			data->handler(dev, NULL);
+		}
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static const struct sensor_driver_api dummy_sensor_api = {
+	.sample_fetch = &dummy_sensor_sample_fetch,
+	.channel_get = &dummy_sensor_channel_get,
+	.attr_set = dummy_sensor_attr_set,
+	.trigger_set = dummy_sensor_trigger_set,
+};
+
+DEVICE_DEFINE(dummy_sensor, DUMMY_SENSOR_NAME, &dummy_sensor_init,
+		    NULL, &dummy_data, &dummy_config, APPLICATION,
+		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &dummy_sensor_api);

--- a/tests/drivers/sensor/src/dummy_sensor.h
+++ b/tests/drivers/sensor/src/dummy_sensor.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __TEST_DUMMY_SENSOR_H__
+#define __TEST_DUMMY_SENSOR_H__
+
+#include <zephyr.h>
+#include <device.h>
+#include <drivers/sensor.h>
+#define DUMMY_SENSOR_NAME	"dummy_sensor"
+#define SENSOR_CHANNEL_NUM	5
+
+struct dummy_sensor_data {
+	sensor_trigger_handler_t handler;
+	struct sensor_value val[SENSOR_CHANNEL_NUM];
+};
+
+struct dummy_sensor_config {
+	char *i2c_name;
+	uint8_t i2c_address;
+};
+
+#endif //__TEST_DUMMY_SENSOR_H__

--- a/tests/drivers/sensor/src/main.c
+++ b/tests/drivers/sensor/src/main.c
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2020 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @defgroup driver_sensor_subsys_tests sensor_subsys
+ * @ingroup all_tests
+ * @{
+ * @}
+ */
+
+#include <ztest.h>
+#include "dummy_sensor.h"
+
+K_SEM_DEFINE(sem, 0, 1);
+#define RETURN_SUCCESS  (0)
+
+struct channel_sequence {
+	enum sensor_channel chan;
+	struct sensor_value data;
+};
+
+struct trigger_sequence {
+	struct sensor_trigger trig;
+	struct sensor_value data;
+	enum sensor_attribute attr;
+};
+
+static struct channel_sequence chan_elements[] = {
+	{ SENSOR_CHAN_LIGHT, { 0, 0 } },
+	{ SENSOR_CHAN_RED, { 1, 1 } },
+	{ SENSOR_CHAN_GREEN, { 2, 4 } },
+	{ SENSOR_CHAN_BLUE, { 3, 9 } },
+	{ SENSOR_CHAN_PROX, { 4, 16 } }
+};
+
+static struct trigger_sequence trigger_elements[] = {
+	/* trigger for SENSOR_TRIG_THRESHOLD */
+	{ {SENSOR_TRIG_THRESHOLD, SENSOR_CHAN_PROX},
+	{ 127, 0 }, SENSOR_ATTR_UPPER_THRESH },
+
+	/* trigger for SENSOR_TRIG_TIMER */
+	{ {SENSOR_TRIG_TIMER, SENSOR_CHAN_PROX},
+	{ 130, 127 }, SENSOR_ATTR_UPPER_THRESH },
+
+	/* trigger for SENSOR_TRIG_DATA_READY */
+	{ {SENSOR_TRIG_DATA_READY, SENSOR_CHAN_PROX},
+	{ 150, 130 }, SENSOR_ATTR_UPPER_THRESH },
+
+	/* trigger for SENSOR_TRIG_DELTA */
+	{ {SENSOR_TRIG_DELTA, SENSOR_CHAN_PROX},
+	{ 180, 150 }, SENSOR_ATTR_UPPER_THRESH },
+
+	/* trigger for SENSOR_TRIG_NEAR_FAR */
+	{ {SENSOR_TRIG_NEAR_FAR, SENSOR_CHAN_PROX},
+	{ 155, 180 }, SENSOR_ATTR_UPPER_THRESH }
+};
+
+#define TOTAL_CHAN_ELEMENTS (sizeof(chan_elements) / \
+		sizeof(struct channel_sequence))
+#define TOTAL_TRIG_ELEMENTS (sizeof(trigger_elements) / \
+		sizeof(struct trigger_sequence))
+/**
+ * @brief Test get multiple channels values.
+ *
+ * @details
+ * - get multiple channels values consistently in two operations:
+ * fetch sample and get the values of each channel individually.
+ * - check the results with sensor_value type avoids use of
+ * floating point values
+ *
+ * @ingroup driver_sensor_subsys_tests
+ *
+ * @see sensor_sample_fetch(). sensor_channel_get()
+ */
+void test_sensor_get_channels(void)
+{
+	struct device *dev;
+	struct sensor_value data;
+
+	dev = device_get_binding(DUMMY_SENSOR_NAME);
+	zassert_not_null(dev, "failed: dev is null.");
+
+	zassert_equal(sensor_sample_fetch(dev), RETURN_SUCCESS,
+			"fail to fetch sample.");
+
+	/* Get and check channels value. */
+	for (int i = 0; i < TOTAL_CHAN_ELEMENTS; i++) {
+		zassert_equal(sensor_channel_get(dev, chan_elements[i].chan,
+				&data), RETURN_SUCCESS, "fail to get channel.");
+
+		zassert_equal(data.val1, chan_elements[i].data.val1,
+				"the data is not match.");
+		zassert_equal(data.val2, chan_elements[i].data.val2,
+				"the data is not match.");
+	}
+}
+
+static void trigger_handler(struct device *dev,
+				struct sensor_trigger *trigger)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(trigger);
+
+	k_sem_give(&sem);
+}
+
+/**
+ * @brief Test sensor multiple triggers
+ *
+ * @details
+ * - set multiple triggers for dummy sensor
+ * - Handle different types of triggers, based on time, data,threshold,
+ * based on a delta value, near/far events and single/double tap.
+ * - Configuration of runtime parameters in a sensor,
+ * for example threshold values for interrupts.
+ *
+ * @ingroup driver_sensor_subsys_tests
+ *
+ * @see sensor_attr_set(). sensor_trigger_set()
+ */
+void test_sensor_handle_triggers(void)
+{
+	struct device *dev;
+	struct sensor_value data;
+
+	dev = device_get_binding(DUMMY_SENSOR_NAME);
+	zassert_not_null(dev, "failed: dev is null.");
+
+	zassert_equal(sensor_sample_fetch(dev), RETURN_SUCCESS,
+			"fail to fetch sample.");
+
+	/* setup multiple triggers */
+	for (int i = 0; i < TOTAL_TRIG_ELEMENTS; i++) {
+		/* set attributes for trigger */
+		zassert_equal(sensor_attr_set(dev,
+				trigger_elements[i].trig.chan,
+				trigger_elements[i].attr,
+				&trigger_elements[i].data),
+				RETURN_SUCCESS, "fail to set attributes");
+
+		/* setting a sensor’s trigger and handler */
+		zassert_equal(sensor_trigger_set(dev,
+				&trigger_elements[i].trig,
+				trigger_handler),
+				RETURN_SUCCESS, "fail to set trigger");
+
+		/* get channels value after trigger fired */
+		k_sem_take(&sem, K_FOREVER);
+		zassert_equal(sensor_channel_get(dev,
+				trigger_elements[i].trig.chan,
+				&data), RETURN_SUCCESS, "fail to get channel.");
+
+		/* check the result of the trigger channel */
+		zassert_equal(data.val1, trigger_elements[i].data.val1,
+				"retrived data is not match.");
+		zassert_equal(data.val2, trigger_elements[i].data.val2,
+				"retrived data is not match.");
+	}
+}
+
+/*test case main entry*/
+void test_main(void)
+{
+	ztest_test_suite(test_sensor_api,
+			 ztest_1cpu_unit_test(test_sensor_get_channels),
+			 ztest_1cpu_unit_test(test_sensor_handle_triggers));
+
+	ztest_run_test_suite(test_sensor_api);
+}

--- a/tests/drivers/sensor/testcase.yaml
+++ b/tests/drivers/sensor/testcase.yaml
@@ -1,0 +1,3 @@
+tests:
+  driver.sensor:
+    tags: driver sensor subsys


### PR DESCRIPTION
1. Create a dummy sensor driver and implement the sensor interfaces:
    .sample_fetch = &dummy_sensor_sample_fetch,
    .channel_get = &dummy_sensor_channel_get,
    .attr_set = dummy_sensor_attr_set,
    .trigger_set = dummy_sensor_trigger_set.

2. Create below two test cases to verify the sensor subsys APIs:
    test_sensor_get_channels() for verifying sensor channel APIs,
    test_sensor_handle_triggers for verifying sensor trigger APIs.

Signed-off-by: YouhuaX Zhu <youhuax.zhu@intel.com>