### PR TITLE
ARM: Cortex-M: Fixing Context Stacking Error Reporting

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/fault.c
+++ b/arch/arm/core/aarch32/cortex_m/fault.c
@@ -266,6 +266,14 @@ static u32_t mem_manage_fault(z_arch_esf_t *esf, int from_hard_fault,
 		 * process the error further if the stack frame is on
 		 * PSP. For always-banked MemManage Fault, this is
 		 * equivalent to inspecting the RETTOBASE flag.
+		 *
+		 * Note:
+		 * It is possible that MMFAR address is not written by the
+		 * Cortex-M core; this occurs when the stacking error is
+		 * not accompanied by a data access violation error (i.e.
+		 * when stack overflows due to the exception entry frame
+		 * stacking): z_check_thread_stack_fail() shall be able to
+		 * handle the case of 'mmfar' holding the -EINVAL value.
 		 */
 		if (SCB->ICSR & SCB_ICSR_RETTOBASE_Msk) {
 			u32_t min_stack_ptr = z_check_thread_stack_fail(mmfar,

--- a/arch/arm/core/aarch32/thread.c
+++ b/arch/arm/core/aarch32/thread.c
@@ -234,7 +234,7 @@ void configure_builtin_stack_guard(struct k_thread *thread)
 #if defined(CONFIG_MPU_STACK_GUARD) || defined(CONFIG_USERSPACE)
 
 #define IS_MPU_GUARD_VIOLATION(guard_start, guard_len, fault_addr, stack_ptr) \
-	((fault_addr == -EINVAL) ? \
+	((fault_addr != -EINVAL) ? \
 	((fault_addr >= guard_start) && \
 	(fault_addr < (guard_start + guard_len)) && \
 	(stack_ptr < (guard_start + guard_len))) \

--- a/tests/arch/arm/arm_interrupt/README.txt
+++ b/tests/arch/arm/arm_interrupt/README.txt
@@ -44,44 +44,58 @@ or
 ---------------------------------------------------------------------------
 
 Sample Output:
-***** Booting Zephyr OS build zephyr-v2.0.0-1066-ga087055d4e3d *****
- Running test suite arm_interrupt
- ===================================================================
- starting test - test_arm_interrupt
- Available IRQ line: 25
- E: ***** HARD FAULT *****
- E: ARCH_EXCEPT with reason 3
+*** Booting Zephyr OS build v2.3.0-rc1-295-g630f69889088  ***
+Running test suite arm_interrupt
+===================================================================
+starting test - test_arm_interrupt
+Available IRQ line: 70
+E: >>> ZEPHYR FATAL ERROR 1: Unhandled interrupt on CPU 0
+E: Current thread: 0x20400190 (unknown)
+Caught system error -- reason 1
+E: r0/a1:  0x00000003  r1/a2:  0x20401d6c  r2/a3:  0x00000003
+E: r3/a4:  0x20401af8 r12/ip:  0x0295a8d1 r14/lr:  0x00401ad3
+E:  xpsr:  0x61000056
+E: Faulting instruction address (r15/pc): 0x00400622
+E: >>> ZEPHYR FATAL ERROR 3: Kernel oops on CPU 0
+E: Fault during interrupt handling
 
- E: r0/a1:  0x00000003  r1/a2:  0x20001240  r2/a3:  0x00000003
- E: r3/a4:  0x20001098 r12/ip:  0x00000000 r14/lr:  0x000012c9
- E:  xpsr:  0x01000029
- E: Faulting instruction address (r15/pc): 0x000003de
- E: >>> ZEPHYR FATAL ERROR 3: Kernel oops
- E: Current thread: 0x20000058 (unknown)
- Caught system error -- reason 3
- E: Fault during interrupt handling
+E: Current thread: 0x20400190 (unknown)
+Caught system error -- reason 3
+E: r0/a1:  0x00000004  r1/a2:  0x20401d6c  r2/a3:  0x00000004
+E: r3/a4:  0x20401af8 r12/ip:  0x00000000 r14/lr:  0x00401ad3
+E:  xpsr:  0x61000056
+E: Faulting instruction address (r15/pc): 0x00400640
+E: >>> ZEPHYR FATAL ERROR 4: Kernel panic on CPU 0
+E: Fault during interrupt handling
 
- E: ***** HARD FAULT *****
- E: ARCH_EXCEPT with reason 4
+E: Current thread: 0x20400190 (unknown)
+Caught system error -- reason 4
+ASSERTION FAIL [0] @ ../src/arm_interrupt.c:49
+        Intentional assert
 
- E: r0/a1:  0x00000004  r1/a2:  0x20001240  r2/a3:  0x00000004
- E: r3/a4:  0x20001098 r12/ip:  0x00000000 r14/lr:  0x000012c9
- E:  xpsr:  0x01000029
- E: Faulting instruction address (r15/pc): 0x000003e8
- E: >>> ZEPHYR FATAL ERROR 4: Kernel panic
- E: Current thread: 0x20000058 (unknown)
- Caught system error -- reason 4
- E: Fault during interrupt handling
+E: r0/a1:  0x00000004  r1/a2:  0x00000031  r2/a3:  0x80000000
+E: r3/a4:  0x00000056 r12/ip:  0x00000000 r14/lr:  0x00401ad3
+E:  xpsr:  0x41000056
+E: Faulting instruction address (r15/pc): 0x00409b34
+E: >>> ZEPHYR FATAL ERROR 4: Kernel panic on CPU 0
+E: Fault during interrupt handling
 
- PASS - test_arm_interrupt
- ===================================================================
- starting test - test_arm_user_interrupt
- PASS - test_arm_user_interrupt
- ===================================================================
- Test suite arm_interrupt succeeded
- ===================================================================
- PROJECT EXECUTION SUCCESSFUL
-
- Test suite arm_interrupt succeeded
- ===================================================================
- PROJECT EXECUTION SUCCESSFUL
+E: Current thread: 0x20400190 (unknown)
+Caught system error -- reason 4
+E: ***** MPU FAULT *****
+E:   Stacking error (context area might be not valid)
+E: r0/a1:  0x2e706106  r1/a2:  0x739e3f03  r2/a3:  0xf1c99979
+E: r3/a4:  0xe9973b26 r12/ip:  0x87d3b16f r14/lr:  0x01c98b2b
+E:  xpsr:  0x80608800
+E: Faulting instruction address (r15/pc): 0x885e4061
+E: >>> ZEPHYR FATAL ERROR 2: Stack overflow on CPU 0
+E: Current thread: 0x20400190 (unknown)
+Caught system error -- reason 2
+PASS - test_arm_interrupt
+===================================================================
+starting test - test_arm_user_interrupt
+PASS - test_arm_user_interrupt
+===================================================================
+Test suite arm_interrupt succeeded
+===================================================================
+PROJECT EXECUTION SUCCESSFUL

--- a/tests/arch/arm/arm_interrupt/README.txt
+++ b/tests/arch/arm/arm_interrupt/README.txt
@@ -6,9 +6,14 @@ Description:
 
 The first test verifies that we can handle system fault conditions
 while running in handler mode (i.e. in an ISR). Only for ARM
-Cortex-M targets. The test also verifies the behavior of the
-spurious interrupt handler, as well as the ARM spurious exception
-handler.
+Cortex-M targets. The test also verifies
+- the behavior of the spurious interrupt handler, as well as the
+  ARM spurious exception handler.
+- the ability of the Cortex-M fault handling mechanism to detect
+  stack overflow errors explicitly due to exception frame context
+  stacking (that is when the processor reports only the Stacking
+  Error and not an additional Data Access Violation error with a
+  valid corresponding MMFAR address value).
 
 The second test verifies that threads in user mode, despite being able to call
 the irq_lock() and irq_unlock() functions without triggering a CPU fault,

--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -56,6 +56,17 @@ void arm_isr_handler(void *args)
 		__ISB();
 #endif
 #endif
+	} else if (test_flag == 5) {
+#if defined(CONFIG_HW_STACK_PROTECTION)
+		/*
+		 * Verify that the Stack Overflow has been reported by the core
+		 * and the expected reason variable is reset.
+		 */
+		int reason = expected_reason;
+
+		zassert_equal(reason, -1,
+			"expected_reason has not been reset (%d)\n", reason);
+#endif
 	}
 }
 
@@ -165,6 +176,39 @@ void test_arm_interrupt(void)
 #endif
 #endif
 
+#if defined(CONFIG_HW_STACK_PROTECTION)
+	/*
+	 * Simulate a stacking error that is caused explicitly by the
+	 * exception entry context stacking, to verify that the CPU can
+	 * correctly report stacking  errors that are not also Data
+	 * access violation errors.
+	 */
+	expected_reason = K_ERR_STACK_CHK_FAIL;
+
+	__disable_irq();
+
+	/* Trigger an interrupt to cause the stacking error */
+	NVIC_ClearPendingIRQ(i);
+	NVIC_EnableIRQ(i);
+	NVIC_SetPendingIRQ(i);
+
+	/* Set test flag so the IRQ handler executes the appropriate case. */
+	test_flag = 4;
+
+	/* Manually set PSP almost at the bottom of the stack. An exception
+	 * entry will make PSP decent below the limit and into the MPU guard
+	 * section (or beyond the address pointed by PSPLIM in ARMv8-M MCUs).
+	 */
+	__set_PSP(_current->stack_info.start + 0x10);
+
+	__enable_irq();
+	__DSB();
+	__ISB();
+
+	/* No stack variable access below this point.
+	 * The IRQ will handle the verification.
+	 */
+#endif /* CONFIG_HW_STACK_PROTECTION */
 }
 
 #if defined(CONFIG_USERSPACE)


### PR DESCRIPTION
- Fix the logic in IS_MPU_GUARD_VIOLATION macro
- Add a CortexM-specific test case to verify the behavior

Fixes #25612 
