### PR TITLE
net: ieee802154: Align thread names of radio drivers

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -472,7 +472,7 @@ static int nrf5_init(struct device *dev)
 			nrf5_rx_thread, dev, NULL, NULL,
 			K_PRIO_COOP(2), 0, K_NO_WAIT);
 
-	k_thread_name_set(&nrf5_radio->rx_thread, "802154 RX");
+	k_thread_name_set(&nrf5_radio->rx_thread, "nrf5_rx");
 
 	LOG_INF("nRF5 802154 radio initialized");
 

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -776,7 +776,8 @@ static int rf2xx_init(struct device *dev)
 			dev, NULL, NULL,
 			K_PRIO_COOP(2), 0, K_NO_WAIT);
 
-	sprintf(thread_name, "802.15.4 main [%d]", conf->inst);
+	snprintk(thread_name, sizeof(thread_name),
+		 "rf2xx_trx [%d]", conf->inst);
 	k_thread_name_set(&ctx->trx_thread, thread_name);
 
 	return 0;


### PR DESCRIPTION
The NRF5 and RF2XX drivers are using different thread names compared
to the other 802.15.4 drivers. Aligned the thread names to <chip>_rx.

Signed-off-by: Markus Becker <markus.becker@tridonic.com>