### PR TITLE
Bluetooth: controller: split: Fix NRF_CCM overrun

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -972,7 +972,6 @@ static u8_t MALIGN(4) _ccm_scratch[(RADIO_PDU_LEN_MAX - 4) + 16];
 
 void *radio_ccm_rx_pkt_set(struct ccm *ccm, u8_t phy, void *pkt)
 {
-
 	u32_t mode;
 
 	NRF_CCM->ENABLE = CCM_ENABLE_ENABLE_Disabled;
@@ -1019,6 +1018,15 @@ void *radio_ccm_rx_pkt_set(struct ccm *ccm, u8_t phy, void *pkt)
 #endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 #endif /* CONFIG_BT_CTLR_PHY_CODED */
 	}
+
+#if !defined(CONFIG_SOC_COMPATIBLE_NRF52832) && \
+	(!defined(CONFIG_BT_CTLR_DATA_LENGTH_MAX) || \
+	 (CONFIG_BT_CTLR_DATA_LENGTH_MAX < ((RADIO_PDU_LEN_MAX) - 4)))
+	u8_t max_len = (NRF_RADIO->PCNF1 & RADIO_PCNF1_MAXLEN_Msk) >>
+			RADIO_PCNF1_MAXLEN_Pos;
+
+	NRF_CCM->MAXPACKETSIZE = max_len;
+#endif
 #endif /* !CONFIG_SOC_SERIES_NRF51X */
 
 	NRF_CCM->MODE = mode;


### PR DESCRIPTION
Fix missing assignment of NRF_CCM->MAXPACKETSIZE register
for PDU sizes smaller than 251 bytes. If there is CRC errors
causing PDU length fields to be higher than configured PDU
buffer sizes in the controller, without the MAXPACKETSIZE
register set to correct PDU size, CCM module could overrun
the PDU buffer and cause memory corruption. This fix is
applicable for all nRF52 Series SoCs except nRF52832 SoC.

Fixes #21107.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>