### PR TITLE
tests: verify system assert when add wrong mem partition

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -24,6 +24,7 @@ extern void test_mem_domain_add_partitions_invalid(void);
 extern void test_mem_domain_add_partitions_simple(void);
 extern void test_mem_domain_remove_partitions_simple(void);
 extern void test_mem_domain_remove_partitions(void);
+extern void test_mem_part_assert_data_correct(void);
 extern void test_kobject_access_grant(void);
 extern void test_syscall_invalid_kobject(void);
 extern void test_thread_without_kobject_permission(void);
@@ -66,6 +67,7 @@ void test_main(void)
 			 ztest_unit_test(test_mem_domain_remove_partitions_simple),
 			 ztest_unit_test(test_mem_domain_remove_partitions),
 			 ztest_unit_test(test_mark_thread_exit_uninitialized),
+			 ztest_unit_test(test_mem_part_assert_data_correct),
 			 ztest_unit_test(test_kobject_access_grant),
 			 ztest_unit_test(test_syscall_invalid_kobject),
 			 ztest_unit_test(test_thread_without_kobject_permission),


### PR DESCRIPTION
Add test that verifies system will assert that the size and
starting address are compatible with the underlying memory management
system.

I faced with some difficulties:

1. I found a correct assertion which is responisble for that action
in /zephyr/kernel/mem_domain.c L153

2. I tried to add a wrong partition to a memory domain,
and system will assert if the size and address are compatible
with the underlying memory management system.

3. For x86 it is possible to trigger that assertion by
setting start addr equal 1 and size equal 0 like:
`K_MEM_PARTITION_DEFINE(wrong_part, 1, 0, K_MEM_PARTITION_P_RW_U_RW);`

4. For the ARM if to make the same action, I can't
compile the program, so unfortunately I can't port that test
to another architectures.

Looking for a comments from other developers, maybe you have another
opinion on that test and my approach. Maybe just keep that test only for x86, and for another architectures skip that test like in my code there.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>