### PR TITLE
scripts: process_gperf: typo fix

### DIFF
--- a/scripts/process_gperf.py
+++ b/scripts/process_gperf.py
@@ -8,7 +8,7 @@
 gperf C file post-processor
 
 We use gperf to build up a perfect hashtable of pointer values. The way gperf
-does this is to create a table 'wordlist' indexed by a string repreesentation
+does this is to create a table 'wordlist' indexed by a string representation
 of a pointer address, and then doing memcmp() on a string passed in for
 comparison
 


### PR DESCRIPTION
Fix double "e" in "repreesentation"

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>