### PR TITLE
kernel: init: allow to jitter boot delay

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -319,6 +319,13 @@ config BOOT_DELAY
 	  achieved by waiting for DCD on the serial port--however, not
 	  all serial ports have DCD.
 
+config BOOT_DELAY_RANDOM
+	bool "Randomize boot delay"
+	help
+	  This option randomizes the bootup delay between 0 and the
+	  value of BOOT_DELAY. This can be used e.g., to jitter boot-up
+	  of wireless network devices.
+
 config EXECUTION_BENCHMARKING
 	bool "Timing metrics"
 	help


### PR DESCRIPTION
When a big amount of networked devices  collectively gets switched on,
e.g. by a mains switch, quickly overwhelms a wireless network.

This PR allows to jitter the start-up of the devices.

Cleaned-up the boot banner after the boot delay. At that point in time
is irrelevant.

Signed-off-by: Markus Becker <markus.becker@tridonic.com>