### PR TITLE
power: stm32l4: support of the Low Power sleep mode

### DIFF
--- a/soc/arm/st_stm32/stm32l4/CMakeLists.txt
+++ b/soc/arm/st_stm32/stm32l4/CMakeLists.txt
@@ -4,3 +4,7 @@ zephyr_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_sources(
   soc.c
   )
+
+zephyr_sources_ifdef(CONFIG_SYS_POWER_MANAGEMENT
+  power.c
+  )

--- a/soc/arm/st_stm32/stm32l4/Kconfig.series
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.series
@@ -14,5 +14,8 @@ config SOC_SERIES_STM32L4X
 	select HAS_STM32CUBE
 	select CPU_HAS_ARM_MPU
 	select HAS_SWO
+	select HAS_SYS_POWER_STATE_SLEEP_1
+	select HAS_SYS_POWER_STATE_SLEEP_2
+	select HAS_SYS_POWER_STATE_SLEEP_3
 	help
 	  Enable support for STM32L4 MCU series

--- a/soc/arm/st_stm32/stm32l4/power.c
+++ b/soc/arm/st_stm32/stm32l4/power.c
@@ -5,6 +5,9 @@
  */
 #include <zephyr.h>
 #include <power/power.h>
+#include <soc.h>
+#include <init.h>
+
 #include <stm32l4xx_ll_bus.h>
 #include <stm32l4xx_ll_cortex.h>
 #include <stm32l4xx_ll_pwr.h>
@@ -26,8 +29,6 @@ void sys_set_power_state(enum power_states state)
 		/* Enable the Debug Module during STOP mode */
 		LL_DBGMCU_EnableDBGStopMode();
 #endif /* CONFIG_DEBUG */
-		/* enable Power clock */
-		LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
 		/* ensure HSI is the wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
 		/* enter STOP0 mode */
@@ -44,8 +45,6 @@ void sys_set_power_state(enum power_states state)
 		/* Enable the Debug Module during STOP mode */
 		LL_DBGMCU_EnableDBGStopMode();
 #endif /* CONFIG_DEBUG */
-		/* enable Power clock */
-		LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
 		/* ensure HSI is the wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
 		/* enter STOP1 mode */
@@ -61,8 +60,6 @@ void sys_set_power_state(enum power_states state)
 		/* Enable the Debug Module during STOP mode */
 		LL_DBGMCU_EnableDBGStopMode();
 #endif /* CONFIG_DEBUG */
-		/* enable Power clock */
-		LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
 		/* ensure HSI is the wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
 #ifdef PWR_CR1_RRSTP
@@ -114,3 +111,22 @@ void _sys_pm_power_state_exit_post_ops(enum power_states state)
 	 */
 	irq_unlock(0);
 }
+
+/* Initialize STM32 Power */
+static int stm32_power_init(struct device *dev)
+{
+	unsigned int ret;
+
+	ARG_UNUSED(dev);
+
+	ret = irq_lock();
+
+	/* enable Power clock */
+	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+
+	irq_unlock(ret);
+
+	return 0;
+}
+
+SYS_INIT(stm32_power_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/soc/arm/st_stm32/stm32l4/power.c
+++ b/soc/arm/st_stm32/stm32l4/power.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2019 STMicroelectronics.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr.h>
+#include <power/power.h>
+#include <stm32l4xx_ll_bus.h>
+#include <stm32l4xx_ll_cortex.h>
+#include <stm32l4xx_ll_pwr.h>
+#include <stm32l4xx_ll_rcc.h>
+
+#include <logging/log.h>
+LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+
+/* Invoke Low Power/System Off specific Tasks */
+void sys_set_power_state(enum power_states state)
+{
+	switch (state) {
+#ifdef CONFIG_SYS_POWER_SLEEP_STATES
+#ifdef CONFIG_HAS_SYS_POWER_STATE_SLEEP_1
+	case SYS_POWER_STATE_SLEEP_1:
+
+		/* this corresponds to the STOP0 mode: */
+#ifdef CONFIG_DEBUG
+		/* Enable the Debug Module during STOP mode */
+		LL_DBGMCU_EnableDBGStopMode();
+#endif /* CONFIG_DEBUG */
+		/* enable Power clock */
+		LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+		/* ensure HSI is the wake-up system clock */
+		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
+		/* enter STOP0 mode */
+		LL_PWR_SetPowerMode(LL_PWR_MODE_STOP0);
+		LL_LPM_EnableDeepSleep();
+		/* enter SLEEP mode : WFE or WFI */
+		k_cpu_idle();
+		break;
+#endif /* CONFIG_HAS_SYS_POWER_STATE_SLEEP_1 */
+#ifdef CONFIG_HAS_SYS_POWER_STATE_SLEEP_2
+	case SYS_POWER_STATE_SLEEP_2:
+		/* this corresponds to the STOP1 mode: */
+#ifdef CONFIG_DEBUG
+		/* Enable the Debug Module during STOP mode */
+		LL_DBGMCU_EnableDBGStopMode();
+#endif /* CONFIG_DEBUG */
+		/* enable Power clock */
+		LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+		/* ensure HSI is the wake-up system clock */
+		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
+		/* enter STOP1 mode */
+		LL_PWR_SetPowerMode(LL_PWR_MODE_STOP1);
+		LL_LPM_EnableDeepSleep();
+		k_cpu_idle();
+		break;
+#endif /* CONFIG_HAS_SYS_POWER_STATE_SLEEP_2 */
+#ifdef CONFIG_HAS_SYS_POWER_STATE_SLEEP_3
+	case SYS_POWER_STATE_SLEEP_3:
+		/* this corresponds to the STOP2 mode: */
+#ifdef CONFIG_DEBUG
+		/* Enable the Debug Module during STOP mode */
+		LL_DBGMCU_EnableDBGStopMode();
+#endif /* CONFIG_DEBUG */
+		/* enable Power clock */
+		LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+		/* ensure HSI is the wake-up system clock */
+		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
+#ifdef PWR_CR1_RRSTP
+		LL_PWR_DisableSRAM3Retention();
+#endif /* PWR_CR1_RRSTP */
+		/* enter STOP2 mode */
+		LL_PWR_SetPowerMode(LL_PWR_MODE_STOP2);
+		LL_LPM_EnableDeepSleep();
+		k_cpu_idle();
+		break;
+#endif /* CONFIG_HAS_SYS_POWER_STATE_SLEEP_3 */
+#endif /* CONFIG_SYS_POWER_SLEEP_STATES */
+	default:
+		LOG_DBG("Unsupported power state %u", state);
+		break;
+	}
+}
+
+/* Handle SOC specific activity after Low Power Mode Exit */
+void _sys_pm_power_state_exit_post_ops(enum power_states state)
+{
+	switch (state) {
+#ifdef CONFIG_SYS_POWER_SLEEP_STATES
+#ifdef CONFIG_HAS_SYS_POWER_STATE_SLEEP_1
+	case SYS_POWER_STATE_SLEEP_1:
+		LL_LPM_DisableSleepOnExit();
+		break;
+#endif /* CONFIG_HAS_SYS_POWER_STATE_SLEEP_1 */
+#ifdef CONFIG_HAS_SYS_POWER_STATE_SLEEP_2
+	case SYS_POWER_STATE_SLEEP_2:
+		LL_LPM_DisableSleepOnExit();
+		break;
+#endif /* CONFIG_HAS_SYS_POWER_STATE_SLEEP_2 */
+#ifdef CONFIG_HAS_SYS_POWER_STATE_SLEEP_3
+	case SYS_POWER_STATE_SLEEP_3:
+		LL_LPM_DisableSleepOnExit();
+		break;
+#endif /* CONFIG_HAS_SYS_POWER_STATE_SLEEP_3 */
+#endif /* CONFIG_SYS_POWER_SLEEP_STATES */
+	default:
+		LOG_DBG("Unsupported power state %u", state);
+		break;
+	}
+
+	/*
+	 * System is now in active mode.
+	 * Reenable interrupts which were disabled
+	 * when OS started idling code.
+	 */
+	irq_unlock(0);
+}

--- a/soc/arm/st_stm32/stm32l4/power.c
+++ b/soc/arm/st_stm32/stm32l4/power.c
@@ -7,14 +7,37 @@
 #include <power/power.h>
 #include <soc.h>
 #include <init.h>
+#include <spinlock.h>
 
 #include <stm32l4xx_ll_bus.h>
 #include <stm32l4xx_ll_cortex.h>
 #include <stm32l4xx_ll_pwr.h>
 #include <stm32l4xx_ll_rcc.h>
+#include <stm32l4xx_ll_lptim.h>
+#include <stm32l4xx_ll_system.h>
 
 #include <logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+
+#ifdef CONFIG_SYS_PM_POLICY_RESIDENCY_STM32
+static struct k_spinlock lock;
+
+static void lptim_irq_handler(struct device *unused)
+{
+	ARG_UNUSED(unused);
+
+	if ((LL_LPTIM_IsActiveFlag_ARRM(LPTIM1) != 0)
+		&& LL_LPTIM_IsEnabledIT_ARRM(LPTIM1) != 0) {
+		/* when irq occurs, counter is already set to 0 */
+		k_spinlock_key_t key = k_spin_lock(&lock);
+
+		/* do not change ARR yet, z_clock_announce will do */
+		LL_LPTIM_ClearFLAG_ARRM(LPTIM1);
+
+		k_spin_unlock(&lock, key);
+	}
+}
+#endif /* CONFIG_SYS_PM_POLICY_RESIDENCY_STM32 */
 
 /* Invoke Low Power/System Off specific Tasks */
 void sys_set_power_state(enum power_states state)
@@ -23,7 +46,6 @@ void sys_set_power_state(enum power_states state)
 #ifdef CONFIG_SYS_POWER_SLEEP_STATES
 #ifdef CONFIG_HAS_SYS_POWER_STATE_SLEEP_1
 	case SYS_POWER_STATE_SLEEP_1:
-
 		/* this corresponds to the STOP0 mode: */
 #ifdef CONFIG_DEBUG
 		/* Enable the Debug Module during STOP mode */
@@ -112,6 +134,87 @@ void _sys_pm_power_state_exit_post_ops(enum power_states state)
 	irq_unlock(0);
 }
 
+#ifdef CONFIG_SYS_PM_POLICY_RESIDENCY_STM32
+/* Initialize STM32 LPTIM */
+static void stm32_lptim_init(void)
+{
+	/* enable LPTIM clock source */
+	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_LPTIM1);
+	LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_LPTIM1);
+
+#ifdef CONFIG_STM32_LPTIM_CLOCK_LSI
+	/* enable LSI clock */
+#ifdef CONFIG_SOC_SERIES_STM32WBX
+	LL_RCC_LSI1_Enable();
+	while (!LL_RCC_LSI1_IsReady()) {
+#else
+	LL_RCC_LSI_Enable();
+	while (!LL_RCC_LSI_IsReady()) {
+#endif /* CONFIG_SOC_SERIES_STM32WBX */
+		/* Wait for LSI ready */
+	}
+
+	LL_RCC_SetLPTIMClockSource(LL_RCC_LPTIM1_CLKSOURCE_LSI);
+
+#else /* CONFIG_STM32_LPTIM_CLOCK_LSI */
+#ifdef LL_APB1_GRP1_PERIPH_PWR
+	/* Enable the power interface clock */
+	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+#endif /* LL_APB1_GRP1_PERIPH_PWR */
+	/* enable backup domain */
+	LL_PWR_EnableBkUpAccess();
+
+	/* enable LSE clock */
+	LL_RCC_LSE_DisableBypass();
+	LL_RCC_LSE_Enable();
+	while (!LL_RCC_LSE_IsReady()) {
+		/* Wait for LSE ready */
+	}
+	LL_RCC_SetLPTIMClockSource(LL_RCC_LPTIM1_CLKSOURCE_LSE);
+
+#endif /* CONFIG_STM32_LPTIM_CLOCK_LSI */
+
+	/* Clear the event flag and possible pending interrupt */
+	IRQ_CONNECT(DT_IRQN(DT_NODELABEL(lptim1)),
+		    DT_IRQ(DT_NODELABEL(lptim1), priority),
+		    lptim_irq_handler, 0, 0);
+	irq_enable(DT_IRQN(DT_NODELABEL(lptim1)));
+
+	/* configure the LPTIM1 counter */
+	LL_LPTIM_SetClockSource(LPTIM1, LL_LPTIM_CLK_SOURCE_INTERNAL);
+	/*
+	 * configure the LPTIM1 prescaler with default value of 8
+	 * this will allow sleep period from 0 to 16000ms
+	 */
+	LL_LPTIM_SetPrescaler(LPTIM1, LL_LPTIM_PRESCALER_DIV8);
+	LL_LPTIM_SetPolarity(LPTIM1, LL_LPTIM_OUTPUT_POLARITY_REGULAR);
+	LL_LPTIM_SetUpdateMode(LPTIM1, LL_LPTIM_UPDATE_MODE_IMMEDIATE);
+	LL_LPTIM_SetCounterMode(LPTIM1, LL_LPTIM_COUNTER_MODE_INTERNAL);
+	LL_LPTIM_DisableTimeout(LPTIM1);
+	/* counting start is initiated by software */
+	LL_LPTIM_TrigSw(LPTIM1);
+
+	/* LPTIM1 interrupt set-up before enabling */
+	/* no Compare match Interrupt */
+	LL_LPTIM_DisableIT_CMPM(LPTIM1);
+	LL_LPTIM_ClearFLAG_CMPM(LPTIM1);
+
+	/* Autoreload match Interrupt */
+	LL_LPTIM_EnableIT_ARRM(LPTIM1);
+	LL_LPTIM_ClearFLAG_ARRM(LPTIM1);
+	/* ARROK bit validates the write operation to ARR register */
+	LL_LPTIM_ClearFlag_ARROK(LPTIM1);
+	LL_LPTIM_DisableIT_ARROK(LPTIM1);
+#ifdef CONFIG_DEBUG
+	/* stop LPTIM1 during DEBUG */
+	LL_DBGMCU_APB1_GRP1_FreezePeriph(LL_DBGMCU_APB1_GRP1_LPTIM1_STOP);
+#endif
+	/*  Enable the LPTIM1 counter */
+	LL_LPTIM_Enable(LPTIM1);
+
+}
+#endif /* CONFIG_SYS_PM_POLICY_RESIDENCY_STM32 */
+
 /* Initialize STM32 Power */
 static int stm32_power_init(struct device *dev)
 {
@@ -124,6 +227,10 @@ static int stm32_power_init(struct device *dev)
 	/* enable Power clock */
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
 
+	/* LPTIM initalization */
+	if (IS_ENABLED(CONFIG_SYS_PM_POLICY_RESIDENCY_STM32)) {
+		stm32_lptim_init();
+	}
 	irq_unlock(ret);
 
 	return 0;

--- a/subsys/power/device.c
+++ b/subsys/power/device.c
@@ -45,6 +45,16 @@ static const char *const core_devices[] = {
 static const char *const core_devices[] = {
 	"",
 };
+#elif defined(CONFIG_SOC_SERIES_STM32L4X)
+#define MAX_PM_DEVICES	15
+#define NUM_CORE_DEVICES	4
+#define MAX_DEV_NAME_LEN	16
+static const char core_devices[NUM_CORE_DEVICES][MAX_DEV_NAME_LEN] = {
+	"CLOCK_32K",
+	"CLOCK_16M",
+	"sys_clock",
+	"UART_0",
+};
 #else
 #error "Add SoC's core devices list for PM"
 #endif

--- a/subsys/power/policy/CMakeLists.txt
+++ b/subsys/power/policy/CMakeLists.txt
@@ -3,3 +3,4 @@
 zephyr_sources_ifdef(CONFIG_SYS_PM_POLICY_DUMMY policy_dummy.c)
 zephyr_sources_ifdef(CONFIG_SYS_PM_POLICY_RESIDENCY_DEFAULT policy_residency.c)
 zephyr_sources_ifdef(CONFIG_SYS_PM_POLICY_RESIDENCY_CC13X2_CC26X2 policy_residency_cc13x2_cc26x2.c)
+zephyr_sources_ifdef(CONFIG_SYS_PM_POLICY_RESIDENCY_STM32 policy_residency_stm32.c)

--- a/subsys/power/policy/Kconfig
+++ b/subsys/power/policy/Kconfig
@@ -7,8 +7,9 @@ choice
 
 config SYS_PM_POLICY_RESIDENCY
 	bool "PM Policy based on CPU residency"
-	select SYS_PM_POLICY_RESIDENCY_DEFAULT if !SOC_SERIES_CC13X2_CC26X2
+	select SYS_PM_POLICY_RESIDENCY_DEFAULT if !SOC_SERIES_CC13X2_CC26X2 && !SOC_SERIES_STM32L4X
 	select SYS_PM_POLICY_RESIDENCY_CC13X2_CC26X2 if SOC_SERIES_CC13X2_CC26X2
+	select SYS_PM_POLICY_RESIDENCY_STM32 if SOC_SERIES_STM32L4X
 	help
 	  Select this option for PM policy based on CPU residencies.
 
@@ -35,6 +36,12 @@ config SYS_PM_POLICY_RESIDENCY_CC13X2_CC26X2
 	  Use the residency policy implementation for TI CC13x2/CC26x2
 
 if SYS_PM_POLICY_RESIDENCY
+
+config SYS_PM_POLICY_RESIDENCY_STM32
+	bool "Application PM Policy for STM32 soc"
+	depends on SOC_FAMILY_STM32
+	help
+	  Use the residency policy implementation for STM32 soc
 
 config SYS_PM_MIN_RESIDENCY_SLEEP_1
 	int "Sleep State 1 minimum residency"

--- a/subsys/power/policy/policy_residency_stm32.c
+++ b/subsys/power/policy/policy_residency_stm32.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2020 STMicroelectronics.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <kernel.h>
+#include "pm_policy.h"
+
+#include <stm32l4xx_ll_lptim.h>
+
+#define LOG_LEVEL CONFIG_SYS_PM_LOG_LEVEL /* From power module Kconfig */
+#include <logging/log.h>
+LOG_MODULE_DECLARE(power);
+
+#ifdef CONFIG_STM32_LPTIM_CLOCK_LSE
+#define LPTIM_CLOCK 32768
+#define LPTIM_TIMEBASE 0xFFFF
+#else
+#define LPTIM_CLOCK 32000
+#define LPTIM_TIMEBASE 0xF9FF
+#endif
+
+#define LPTIM_MAX_MS (((LPTIM_TIMEBASE + 1) / LPTIM_CLOCK) * 1000)
+
+#define SECS_TO_TICKS		CONFIG_SYS_CLOCK_TICKS_PER_SEC
+/* Wakeup delay from stop mode in microseconds */
+#define WAKEDELAYSTOP    24
+/* Wakeup delay from standby in microseconds */
+#define WAKEDELAYSTANDBY    32
+/* Wakeup delay from shutdown in microseconds */
+#define WAKEDELAYSHUTDOWN   330
+
+u32_t table_prescaler[8] = {
+	LL_LPTIM_PRESCALER_DIV1,
+	LL_LPTIM_PRESCALER_DIV2,
+	LL_LPTIM_PRESCALER_DIV4,
+	LL_LPTIM_PRESCALER_DIV8,
+	LL_LPTIM_PRESCALER_DIV16,
+	LL_LPTIM_PRESCALER_DIV32,
+	LL_LPTIM_PRESCALER_DIV64,
+	LL_LPTIM_PRESCALER_DIV128,
+};
+
+/* PM Policy based on STM32 SoC/Platform residency requirements */
+static const unsigned int pm_min_residency[] = {
+	CONFIG_SYS_PM_MIN_RESIDENCY_SLEEP_1 * SECS_TO_TICKS / MSEC_PER_SEC,
+	CONFIG_SYS_PM_MIN_RESIDENCY_SLEEP_2 * SECS_TO_TICKS / MSEC_PER_SEC,
+	CONFIG_SYS_PM_MIN_RESIDENCY_SLEEP_3 * SECS_TO_TICKS / MSEC_PER_SEC
+};
+
+/* wake up delay in us for each PM_MIN residency timing */
+static int wakeupdelay[] = {
+	WAKEDELAYSTOP,
+	WAKEDELAYSTOP,
+	WAKEDELAYSTOP,
+	WAKEDELAYSTANDBY,
+	WAKEDELAYSHUTDOWN,
+};
+
+enum power_states sys_pm_policy_next_state(s32_t ticks)
+{
+	int i;
+
+	if ((ticks != K_TICKS_FOREVER) && (ticks < pm_min_residency[0])) {
+		LOG_DBG("Not enough time for PM operations: %d", ticks);
+		return SYS_POWER_STATE_ACTIVE;
+	}
+
+	for (i = ARRAY_SIZE(pm_min_residency) - 1; i >= 0; i--) {
+#ifdef CONFIG_SYS_PM_STATE_LOCK
+		if (!sys_pm_ctrl_is_state_enabled((enum power_states)(i))) {
+			continue;
+		}
+#endif
+		if ((ticks == K_TICKS_FOREVER) ||
+		    (ticks >= pm_min_residency[i])) {
+			/* Set timeout for wakeup event */
+			if (ticks != K_TICKS_FOREVER) {
+					/* NOTE: Ideally we'd like to set a
+					 * timer to wake up just a little
+					 * earlier to take care of the wakeup
+					 * sequence, ie. by WAKEDELAY
+					 * microsecs. However, given
+					 * k_timer_start (called later by
+					 * ClockP_start) does not currently
+					 * have sub-millisecond accuracy, wakeup
+					 * would be at up to (WAKEDELAY
+					 * + 1 ms) ahead of the next timeout.
+					 * This also has the implication that
+					 * SYS_PM_MIN_RESIDENCY_SLEEP_2
+					 * must be greater than 1.
+					 */
+				ticks -= (wakeupdelay[i] *
+						CONFIG_SYS_CLOCK_TICKS_PER_SEC
+						+ 1000000) / 1000000;
+				/* now get the corresponding timeout in ms */
+				u32_t timeout = ticks * 1000 /
+					CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+				/* the clock prescaler is set to DIV8 */
+				int arr = (((timeout * LPTIM_CLOCK / 8))
+					/ 1000) - 1;
+				/*
+				 * LPTIM setTimeout cannot handle any
+				 * more ticks than LPTIM_TIMEBASE
+				 */
+				arr = MIN(arr, LPTIM_TIMEBASE);
+				LL_LPTIM_SetAutoReload(LPTIM1, arr);
+				/* ARROK bit validates the write operation */
+				LL_LPTIM_ClearFlag_ARROK(LPTIM1);
+				/* reset the current counter match value */
+				LL_LPTIM_ClearFLAG_ARRM(LPTIM1);
+				/* enable and run the LPTIM counter */
+				LL_LPTIM_StartCounter(LPTIM1,
+					LL_LPTIM_OPERATING_MODE_ONESHOT);
+				}
+
+			LOG_DBG("Selected power state %d "
+					"(ticks: %d, min_residency: %u)",
+					i, ticks, pm_min_residency[i]);
+			return (enum power_states)(i);
+		}
+	}
+
+	LOG_DBG("No suitable power state found!");
+	return SYS_POWER_STATE_ACTIVE;
+}
+
+__weak bool sys_pm_policy_low_power_devices(enum power_states pm_state)
+{
+	return sys_pm_is_sleep_state(pm_state);
+}


### PR DESCRIPTION
With this patch, the low power mode on stm32L4 is enabling the Low Power Timer to measure  the sleep time duration and wakeup from sleep mode on this LP timer expiration.
The SLEEP modes (corresponding to STM32 stop 0,1,2 modes) are supported on this device.
When low power is enabled on the system and when going to sleep, the lptim counts and wakes up the kernel though its interrupt routine. 
The soc policy decides to go to sleep, if compatible with its residency when calling the sys_pm_policy_next_state for a nb of kernel ticks.
With this fixed configuration, the lptim is clocked by the LSE with a prescaler of 8 (DIV8), so that possible timeout in ms is > PM minimum residency and < 16000.
This means that if the system wants to sleep more than 16s, it will be waken Up each 160s, though.

This PR is included in the  https://github.com/zephyrproject-rtos/zephyr/pull/19026

Note that DEEP_SLEEP modes are not enabled yet, as LPTIM cannot run during stm32 standby or shutdown modes.

Signed-off-by: Francois Ramu francois.ramu@st.com