### PR TITLE
net: ieee802154: Allow to disable auto-start of 802.15.4 interfaces

### DIFF
--- a/drivers/ieee802154/Kconfig
+++ b/drivers/ieee802154/Kconfig
@@ -12,6 +12,19 @@ menuconfig IEEE802154
 
 if IEEE802154
 
+config IEEE802154_NET_IF_NO_AUTO_START
+	bool "Disable 802.15.4 interface auto-start"
+	help
+	  This option allows user to set any configuration and/or filter before
+	  the radio becomes operational. For instance, the EUI-64 value can be
+	  configured using net_if_set_link_addr(iface, mac, 8,
+	  NET_LINK_IEEE802154).
+	  When all configurations are done net_if_up() has to be invoked to
+	  bring the interface up.
+
+	  This option can be useful when using OpenThread or Zigbee. If you
+	  have any doubt about this option leave it as default value.
+
 config IEEE802154_RAW_MODE
 	bool "Use IEEE 802.15.4 driver without the MAC stack"
 	select NET_RAW_MODE

--- a/drivers/ieee802154/Kconfig.rf2xx
+++ b/drivers/ieee802154/Kconfig.rf2xx
@@ -18,18 +18,6 @@ config IEEE802154_RF2XX_DRV_NAME
 	help
 	  This option sets the driver name
 
-config IEEE802154_RF2XX_NET_IF_NO_AUTO_START
-	bool "RF2X must wait configuration before change to operational mode"
-	help
-	  This option allows user to set any configuration and/or filter before
-	  radio became operational. For instance, the EUI-64 value can be
-	  configured using NET_REQUEST_IEEE802154_SET_EXT_ADDR available from
-	  ieee802154 management interface. When all configurations are done
-	  net_if_up() can be invoked to bring interface up.
-
-	  This option can be useful when using OpenThread or Zigbee. If you
-	  have any doubt about this option leave it as default value.
-
 config IEEE802154_RF2XX_RX_STACK_SIZE
 	int "Driver's internal RX thread stack size"
 	default 800

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -792,11 +792,6 @@ static void rf2xx_iface_init(struct net_if *iface)
 
 	ctx->iface = iface;
 
-#if defined(CONFIG_IEEE802154_RF2XX_NET_IF_NO_AUTO_START)
-	LOG_DBG("Interface auto start disabled. Waiting configuration...");
-	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
-#endif
-
 	ieee802154_init(iface);
 }
 

--- a/subsys/net/l2/ieee802154/ieee802154.c
+++ b/subsys/net/l2/ieee802154/ieee802154.c
@@ -338,6 +338,11 @@ void ieee802154_init(struct net_if *iface)
 	ctx->channel = IEEE802154_NO_CHANNEL;
 	ctx->flags = NET_L2_MULTICAST;
 
+	if (IS_ENABLED(CONFIG_IEEE802154_NET_IF_NO_AUTO_START)) {
+		LOG_DBG("Interface auto start disabled.");
+		net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+	}
+
 	ieee802154_mgmt_init(iface);
 
 #ifdef CONFIG_NET_L2_IEEE802154_SECURITY

--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -453,6 +453,11 @@ static int openthread_init(struct net_if *iface)
 
 void ieee802154_init(struct net_if *iface)
 {
+	if (IS_ENABLED(CONFIG_IEEE802154_NET_IF_NO_AUTO_START)) {
+		LOG_DBG("Interface auto start disabled.");
+		net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+	}
+
 	openthread_init(iface);
 }
 


### PR DESCRIPTION
Some radio drivers need configuration before start-up. Up to now only
the RF2XX drivers allowed this, but other radio drivers need this as
well. In particular for setting EUI64 addresses.

Signed-off-by: Markus Becker <markus.becker@tridonic.com>