### PR TITLE
doc: release-notes-2.3: Add POSIX subsys highlights

### DIFF
--- a/doc/releases/release-notes-2.3.rst
+++ b/doc/releases/release-notes-2.3.rst
@@ -407,6 +407,11 @@ Libraries / Subsystems
 
   * <TBD>
 
+* POSIX subsystem:
+
+  * socketpair() function implemented.
+  * eventfd() function (Linux-like extension) implemented.
+
 HALs
 ****
 
@@ -422,6 +427,7 @@ Tests and Samples
 *****************
 
 * Added samples for USB Audio Class.
+* Added sample for using POSIX read()/write() with network sockets.
 
 Issue Related Items
 *******************


### PR DESCRIPTION
2 useful functions implemented, sample for read()/write() added
(or rather, existing sample to modified to support that).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>