### PR TITLE
devicetree: Fix argument order for DT_*_CELL_BY_IDX

### DIFF
--- a/include/devicetree/clocks.h
+++ b/include/devicetree/clocks.h
@@ -121,16 +121,16 @@ extern "C" {
  *
  * Example usage:
  *
- *     DT_CLOCKS_CELL_BY_IDX(DT_NODELABEL(n), bus, 0) // 10
- *     DT_CLOCKS_CELL_BY_IDX(DT_NODELABEL(n), bits, 1) // 40
+ *     DT_CLOCKS_CELL_BY_IDX(DT_NODELABEL(n), 0, bus) // 10
+ *     DT_CLOCKS_CELL_BY_IDX(DT_NODELABEL(n), 1, bits) // 40
  *
  * @param node_id node identifier for a node with a clocks property
- * @param cell lowercase-and-underscores cell name
  * @param idx logical index into clocks property
+ * @param cell lowercase-and-underscores cell name
  * @return the cell value at index "idx"
  * @see DT_PHA_BY_IDX()
  */
-#define DT_CLOCKS_CELL_BY_IDX(node_id, cell, idx) \
+#define DT_CLOCKS_CELL_BY_IDX(node_id, idx, cell) \
 	DT_PHA_BY_IDX(node_id, clocks, idx, cell)
 
 /**
@@ -170,13 +170,13 @@ extern "C" {
 	DT_PHA_BY_NAME(node_id, clocks, name, cell)
 
 /**
- * @brief Equivalent to DT_CLOCKS_CELL_BY_IDX(node_id, cell, 0)
+ * @brief Equivalent to DT_CLOCKS_CELL_BY_IDX(node_id, 0, cell)
  * @param node_id node identifier for a node with a clocks property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index 0
  * @see DT_CLOCKS_CELL_BY_IDX()
  */
-#define DT_CLOCKS_CELL(node_id, cell) DT_CLOCKS_CELL_BY_IDX(node_id, cell, 0)
+#define DT_CLOCKS_CELL(node_id, cell) DT_CLOCKS_CELL_BY_IDX(node_id, 0, cell)
 
 /**
  * @brief Get a label property from a DT_DRV_COMPAT instance's clocks
@@ -213,13 +213,13 @@ extern "C" {
  * @brief Get a DT_DRV_COMPAT instance's clock specifier's cell value
  *        at an index
  * @param inst DT_DRV_COMPAT instance number
- * @param cell lowercase-and-underscores cell name
  * @param idx logical index into clocks property
+ * @param cell lowercase-and-underscores cell name
  * @return the cell value at index "idx"
  * @see DT_CLOCKS_CELL_BY_IDX()
  */
-#define DT_INST_CLOCKS_CELL_BY_IDX(inst, cell, idx) \
-	DT_CLOCKS_CELL_BY_IDX(DT_DRV_INST(inst), cell, idx)
+#define DT_INST_CLOCKS_CELL_BY_IDX(inst, idx, cell) \
+	DT_CLOCKS_CELL_BY_IDX(DT_DRV_INST(inst), idx, cell)
 
 /**
  * @brief Get a DT_DRV_COMPAT instance's clock specifier's cell value by name
@@ -234,13 +234,13 @@ extern "C" {
 	DT_CLOCKS_CELL_BY_NAME(DT_DRV_INST(inst), name, cell)
 
 /**
- * @brief Equivalent to DT_INST_CLOCKS_CELL_BY_IDX(inst, cell, 0)
+ * @brief Equivalent to DT_INST_CLOCKS_CELL_BY_IDX(inst, 0, cell)
  * @param inst DT_DRV_COMPAT instance number
  * @param cell lowercase-and-underscores cell name
  * @return the value of the cell inside the specifier at index 0
  */
 #define DT_INST_CLOCKS_CELL(inst, cell) \
-	DT_INST_CLOCKS_CELL_BY_IDX(inst, cell, 0)
+	DT_INST_CLOCKS_CELL_BY_IDX(inst, 0, cell)
 
 /**
  * @}

--- a/include/devicetree/dma.h
+++ b/include/devicetree/dma.h
@@ -141,30 +141,30 @@ extern "C" {
  *
  * Example usage:
  *
- *     DT_DMAS_CELL_BY_IDX(DT_NODELABEL(n), channel, 0) // 1
- *     DT_DMAS_CELL_BY_IDX(DT_NODELABEL(n), channel, 1) // 6
- *     DT_DMAS_CELL_BY_IDX(DT_NODELABEL(n), config, 0) // 0x400
- *     DT_DMAS_CELL_BY_IDX(DT_NODELABEL(n), config, 1) // 0x404
+ *     DT_DMAS_CELL_BY_IDX(DT_NODELABEL(n), 0, channel) // 1
+ *     DT_DMAS_CELL_BY_IDX(DT_NODELABEL(n), 1, channel) // 6
+ *     DT_DMAS_CELL_BY_IDX(DT_NODELABEL(n), 0, config) // 0x400
+ *     DT_DMAS_CELL_BY_IDX(DT_NODELABEL(n), 1, config) // 0x404
  *
  * @param node_id node identifier for a node with a dmas property
- * @param cell lowercase-and-underscores cell name
  * @param idx logical index into dmas property
+ * @param cell lowercase-and-underscores cell name
  * @return the cell value at index "idx"
  * @see DT_PHA_BY_IDX()
  */
-#define DT_DMAS_CELL_BY_IDX(node_id, cell, idx) \
-	DT_PHA_BY_IDX(node_id, dmas, cell, idx)
+#define DT_DMAS_CELL_BY_IDX(node_id, idx, cell) \
+	DT_PHA_BY_IDX(node_id, dmas, idx, cell)
 
 /**
  * @brief Get a DT_DRV_COMPAT instance's DMA specifier's cell value at an index
  * @param inst DT_DRV_COMPAT instance number
- * @param cell lowercase-and-underscores cell name
  * @param idx logical index into dmas property
+ * @param cell lowercase-and-underscores cell name
  * @return the cell value at index "idx"
  * @see DT_DMAS_CELL_BY_IDX()
  */
-#define DT_INST_DMAS_CELL_BY_IDX(inst, cell, idx) \
-	DT_PHA_BY_IDX(DT_DRV_INST(inst), dmas, cell, idx)
+#define DT_INST_DMAS_CELL_BY_IDX(inst, idx, cell) \
+	DT_PHA_BY_IDX(DT_DRV_INST(inst), dmas, idx, cell)
 
 /**
  * @brief Get a DMA specifier's cell value by name

--- a/include/devicetree/pwms.h
+++ b/include/devicetree/pwms.h
@@ -131,18 +131,18 @@ extern "C" {
  *
  * Example usage:
  *
- *     DT_PWMS_CELL_BY_IDX(DT_NODELABEL(n), channel, 0) // 1
- *     DT_PWMS_CELL_BY_IDX(DT_NODELABEL(n), channel, 1) // 3
- *     DT_PWMS_CELL_BY_IDX(DT_NODELABEL(n), flags, 0) // PWM_POLARITY_NORMAL
- *     DT_PWMS_CELL_BY_IDX(DT_NODELABEL(n), flags, 1) // PWM_POLARITY_INVERTED
+ *     DT_PWMS_CELL_BY_IDX(DT_NODELABEL(n), 0, channel) // 1
+ *     DT_PWMS_CELL_BY_IDX(DT_NODELABEL(n), 1, channel) // 3
+ *     DT_PWMS_CELL_BY_IDX(DT_NODELABEL(n), 0, flags) // PWM_POLARITY_NORMAL
+ *     DT_PWMS_CELL_BY_IDX(DT_NODELABEL(n), 1, flags) // PWM_POLARITY_INVERTED
  *
  * @param node_id node identifier for a node with a pwms property
- * @param cell lowercase-and-underscores cell name
  * @param idx logical index into pwms property
+ * @param cell lowercase-and-underscores cell name
  * @return the cell value at index "idx"
  * @see DT_PHA_BY_IDX()
  */
-#define DT_PWMS_CELL_BY_IDX(node_id, cell, idx) \
+#define DT_PWMS_CELL_BY_IDX(node_id, idx, cell) \
 	DT_PHA_BY_IDX(node_id, pwms, idx, cell)
 
 /**
@@ -192,13 +192,13 @@ extern "C" {
 	DT_PHA_BY_NAME(node_id, pwms, name, cell)
 
 /**
- * @brief Equivalent to DT_PWMS_CELL_BY_IDX(node_id, cell, 0)
+ * @brief Equivalent to DT_PWMS_CELL_BY_IDX(node_id, 0, cell)
  * @param node_id node identifier for a node with a pwms property
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index 0
  * @see DT_PWMS_CELL_BY_IDX()
  */
-#define DT_PWMS_CELL(node_id, cell) DT_PWMS_CELL_BY_IDX(node_id, cell, 0)
+#define DT_PWMS_CELL(node_id, cell) DT_PWMS_CELL_BY_IDX(node_id, 0, cell)
 
 /**
  * @brief Get a PWM specifier's channel cell value at an index
@@ -206,7 +206,7 @@ extern "C" {
  * This macro only works for PWM specifiers with cells named "channel".
  * Refer to the node's binding to check if necessary.
  *
- * This is equivalent to DT_PWMS_CELL_BY_IDX(node_id, channel, idx).
+ * This is equivalent to DT_PWMS_CELL_BY_IDX(node_id, idx, channel).
  *
  * @param node_id node identifier for a node with a pwms property
  * @param idx logical index into pwms property
@@ -214,7 +214,7 @@ extern "C" {
  * @see DT_PWMS_CELL_BY_IDX()
  */
 #define DT_PWMS_CHANNEL_BY_IDX(node_id, idx) \
-	DT_PWMS_CELL_BY_IDX(node_id, channel, idx)
+	DT_PWMS_CELL_BY_IDX(node_id, idx, channel)
 
 /**
  * @brief Get a PWM specifier's channel cell value by name
@@ -247,7 +247,7 @@ extern "C" {
  * This macro only works for PWM specifiers with cells named "flags".
  * Refer to the node's binding to check if necessary.
  *
- * This is equivalent to DT_PWMS_CELL_BY_IDX(node_id, flags, idx).
+ * This is equivalent to DT_PWMS_CELL_BY_IDX(node_id, idx, flags).
  *
  * @param node_id node identifier for a node with a pwms property
  * @param idx logical index into pwms property
@@ -255,7 +255,7 @@ extern "C" {
  * @see DT_PWMS_CELL_BY_IDX()
  */
 #define DT_PWMS_FLAGS_BY_IDX(node_id, idx) \
-	DT_PWMS_CELL_BY_IDX(node_id, flags, idx)
+	DT_PWMS_CELL_BY_IDX(node_id, idx, flags)
 
 /**
  * @brief Get a PWM specifier's flags cell value by name
@@ -317,12 +317,12 @@ extern "C" {
  * @brief Get a DT_DRV_COMPAT instance's PWM specifier's cell value
  *        at an index
  * @param inst DT_DRV_COMPAT instance number
- * @param cell lowercase-and-underscores cell name
  * @param idx logical index into pwms property
+ * @param cell lowercase-and-underscores cell name
  * @return the cell value at index "idx"
  */
-#define DT_INST_PWMS_CELL_BY_IDX(inst, cell, idx) \
-	DT_PWMS_CELL_BY_IDX(DT_DRV_INST(inst), cell, idx)
+#define DT_INST_PWMS_CELL_BY_IDX(inst, idx, cell) \
+	DT_PWMS_CELL_BY_IDX(DT_DRV_INST(inst), idx, cell)
 
 /**
  * @brief Get a DT_DRV_COMPAT instance's PWM specifier's cell value by name
@@ -337,23 +337,23 @@ extern "C" {
 	DT_PWMS_CELL_BY_NAME(DT_DRV_INST(inst), name, cell)
 
 /**
- * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, cell, 0)
+ * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, 0, cell)
  * @param inst DT_DRV_COMPAT instance number
  * @param cell lowercase-and-underscores cell name
  * @return the cell value at index 0
  */
 #define DT_INST_PWMS_CELL(inst, cell) \
-	DT_INST_PWMS_CELL_BY_IDX(inst, cell, 0)
+	DT_INST_PWMS_CELL_BY_IDX(inst, 0, cell)
 
 /**
- * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, channel, idx)
+ * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, idx, channel)
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into pwms property
  * @return the channel cell value at index "idx"
  * @see DT_INST_PWMS_CELL_BY_IDX()
  */
 #define DT_INST_PWMS_CHANNEL_BY_IDX(inst, idx) \
-	DT_INST_PWMS_CELL_BY_IDX(inst, channel, idx)
+	DT_INST_PWMS_CELL_BY_IDX(inst, idx, channel)
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_NAME(inst, name, channel)
@@ -375,14 +375,14 @@ extern "C" {
 #define DT_INST_PWMS_CHANNEL(inst) DT_INST_PWMS_CHANNEL_BY_IDX(inst, 0)
 
 /**
- * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, flags, idx)
+ * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, idx, flags)
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into pwms property
  * @return the flags cell value at index "idx"
  * @see DT_INST_PWMS_CELL_BY_IDX()
  */
 #define DT_INST_PWMS_FLAGS_BY_IDX(inst, idx) \
-	DT_INST_PWMS_CELL_BY_IDX(inst, flags, idx)
+	DT_INST_PWMS_CELL_BY_IDX(inst, idx, flags)
 
 /**
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_NAME(inst, name, flags)

--- a/tests/lib/devicetree/src/main.c
+++ b/tests/lib/devicetree/src/main.c
@@ -1001,9 +1001,9 @@ static void test_pwms(void)
 		     "label 0");
 
 	/* DT_PWMS_CELL_BY_IDX */
-	zassert_equal(DT_PWMS_CELL_BY_IDX(TEST_PH, channel, 1), 5,
+	zassert_equal(DT_PWMS_CELL_BY_IDX(TEST_PH, 1, channel), 5,
 		      "pwm 2 channel");
-	zassert_equal(DT_PWMS_CELL_BY_IDX(TEST_PH, flags, 1), 1,
+	zassert_equal(DT_PWMS_CELL_BY_IDX(TEST_PH, 1, flags), 1,
 		      "pwm 2 flags");
 
 	/* DT_PWMS_CELL_BY_NAME */
@@ -1055,9 +1055,9 @@ static void test_pwms(void)
 		     "label 0");
 
 	/* DT_INST_PWMS_CELL_BY_IDX */
-	zassert_equal(DT_INST_PWMS_CELL_BY_IDX(0, channel, 1), 5,
+	zassert_equal(DT_INST_PWMS_CELL_BY_IDX(0, 1, channel), 5,
 		      "pwm 2 channel");
-	zassert_equal(DT_INST_PWMS_CELL_BY_IDX(0, flags, 1), 1, "pwm 2 flags");
+	zassert_equal(DT_INST_PWMS_CELL_BY_IDX(0, 1, flags), 1, "pwm 2 flags");
 
 	/* DT_INST_PWMS_CELL_BY_NAME */
 	zassert_equal(DT_INST_PWMS_CELL_BY_NAME(0, green, channel), 5,
@@ -1330,9 +1330,9 @@ static void test_clocks(void)
 		     "label 0");
 
 	/* DT_CLOCKS_CELL_BY_IDX */
-	zassert_equal(DT_CLOCKS_CELL_BY_IDX(TEST_TEMP, bits, 2), 2,
+	zassert_equal(DT_CLOCKS_CELL_BY_IDX(TEST_TEMP, 2, bits), 2,
 		      "clk 2 bits");
-	zassert_equal(DT_CLOCKS_CELL_BY_IDX(TEST_TEMP, bus, 2), 8, "clk 2 bus");
+	zassert_equal(DT_CLOCKS_CELL_BY_IDX(TEST_TEMP, 2, bus), 8, "clk 2 bus");
 
 	/* DT_CLOCKS_CELL_BY_NAME */
 	zassert_equal(DT_CLOCKS_CELL_BY_NAME(TEST_TEMP, clk_a, bits), 7,
@@ -1368,9 +1368,9 @@ static void test_clocks(void)
 		     "label 0");
 
 	/* DT_INST_CLOCKS_CELL_BY_IDX */
-	zassert_equal(DT_INST_CLOCKS_CELL_BY_IDX(0, bits, 2), 2,
+	zassert_equal(DT_INST_CLOCKS_CELL_BY_IDX(0, 2, bits), 2,
 		      "clk 2 bits");
-	zassert_equal(DT_INST_CLOCKS_CELL_BY_IDX(0, bus, 2), 8, "clk 2 bus");
+	zassert_equal(DT_INST_CLOCKS_CELL_BY_IDX(0, 2, bus), 8, "clk 2 bus");
 
 	/* DT_INST_CLOCKS_CELL_BY_NAME */
 	zassert_equal(DT_INST_CLOCKS_CELL_BY_NAME(0, clk_a, bits), 7,


### PR DESCRIPTION
The cell paramater should have been last to match both the
DT_*_CELL_BY_NAME macros as well as how DT_PHA_BY_IDX works.  We fix the
DT_INST_*_CELL_BY_NAME macros as well.

The dma macro's implemented the behavior correctly, but got the argument
names in correct.  We fix that to make everything consistent.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>