### PR TITLE
Bluetooth: controller: split: Workaround nRF52832 CCM overrun

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - 2019 Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020 Nordic Semiconductor ASA
  * Copyright (c) 2016 Vinayak Kariappa Chettimada
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -9,22 +9,17 @@
 #include <sys/mempool_base.h>
 #include <toolchain.h>
 
+#include <nrfx/hal/nrf_radio.h>
+#include <nrfx/hal/nrf_rtc.h>
+#include <nrfx/hal/nrf_timer.h>
+#include <nrfx/hal/nrf_ccm.h>
+
 #include "util/mem.h"
 #include "hal/ccm.h"
 #include "hal/radio.h"
 #include "hal/ticker.h"
 #include "ll_sw/pdu.h"
 #include "radio_nrf5.h"
-
-#include <nrfx/hal/nrf_radio.h>
-#include <nrfx/hal/nrf_rtc.h>
-#include <nrfx/hal/nrf_ccm.h>
-
-#if defined(CONFIG_SOC_SERIES_NRF51X)
-#define RADIO_PDU_LEN_MAX (BIT(5) - 1)
-#else
-#define RADIO_PDU_LEN_MAX (BIT(8) - 1)
-#endif
 
 #if defined(CONFIG_BT_CTLR_GPIO_PA_PIN)
 #if ((CONFIG_BT_CTLR_GPIO_PA_PIN) > 31)
@@ -387,9 +382,10 @@ u32_t radio_crc_is_valid(void)
 }
 
 static u8_t MALIGN(4) _pkt_empty[PDU_EM_SIZE_MAX];
-static u8_t MALIGN(4) _pkt_scratch[
-			((RADIO_PDU_LEN_MAX + 3) > PDU_AC_SIZE_MAX) ?
-			(RADIO_PDU_LEN_MAX + 3) : PDU_AC_SIZE_MAX];
+static u8_t MALIGN(4) _pkt_scratch[((HAL_RADIO_PDU_LEN_MAX + 3) >
+				    PDU_AC_SIZE_MAX) ?
+				   (HAL_RADIO_PDU_LEN_MAX + 3) :
+				   PDU_AC_SIZE_MAX];
 
 void *radio_pkt_empty_get(void)
 {
@@ -400,6 +396,20 @@ void *radio_pkt_scratch_get(void)
 {
 	return _pkt_scratch;
 }
+
+#if defined(CONFIG_SOC_COMPATIBLE_NRF52832) && \
+	defined(CONFIG_BT_CTLR_LE_ENC) && \
+	(!defined(CONFIG_BT_CTLR_DATA_LENGTH_MAX) || \
+	 (CONFIG_BT_CTLR_DATA_LENGTH_MAX < (HAL_RADIO_PDU_LEN_MAX - 4)))
+static u8_t MALIGN(4) _pkt_decrypt[((HAL_RADIO_PDU_LEN_MAX + 3) >
+				    PDU_AC_SIZE_MAX) ?
+				   (HAL_RADIO_PDU_LEN_MAX + 3) :
+				   PDU_AC_SIZE_MAX];
+void *radio_pkt_decrypt_get(void)
+{
+	return _pkt_decrypt;
+}
+#endif
 
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)
 static u8_t sw_tifs_toggle;
@@ -968,7 +978,7 @@ void radio_gpio_pa_lna_disable(void)
 }
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN || CONFIG_BT_CTLR_GPIO_LNA_PIN */
 
-static u8_t MALIGN(4) _ccm_scratch[(RADIO_PDU_LEN_MAX - 4) + 16];
+static u8_t MALIGN(4) _ccm_scratch[(HAL_RADIO_PDU_LEN_MAX - 4) + 16];
 
 void *radio_ccm_rx_pkt_set(struct ccm *ccm, u8_t phy, void *pkt)
 {
@@ -1021,7 +1031,7 @@ void *radio_ccm_rx_pkt_set(struct ccm *ccm, u8_t phy, void *pkt)
 
 #if !defined(CONFIG_SOC_COMPATIBLE_NRF52832) && \
 	(!defined(CONFIG_BT_CTLR_DATA_LENGTH_MAX) || \
-	 (CONFIG_BT_CTLR_DATA_LENGTH_MAX < ((RADIO_PDU_LEN_MAX) - 4)))
+	 (CONFIG_BT_CTLR_DATA_LENGTH_MAX < ((HAL_RADIO_PDU_LEN_MAX) - 4)))
 	u8_t max_len = (NRF_RADIO->PCNF1 & RADIO_PCNF1_MAXLEN_Msk) >>
 			RADIO_PCNF1_MAXLEN_Pos;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
@@ -43,6 +43,7 @@ u32_t radio_crc_is_valid(void);
 
 void *radio_pkt_empty_get(void);
 void *radio_pkt_scratch_get(void);
+void *radio_pkt_decrypt_get(void);
 
 void radio_switch_complete_and_rx(u8_t phy_rx);
 void radio_switch_complete_and_tx(u8_t phy_rx, u8_t flags_rx, u8_t phy_tx,

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nrfx/hal/nrf_timer.h>
-
 #define HAL_RADIO_NS2US_CEIL(ns)  ((ns + 999)/1000)
 #define HAL_RADIO_NS2US_ROUND(ns) ((ns + 500)/1000)
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/radio_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/radio_vendor_hal.h
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2018 Nordic Semiconductor ASA
+ * Copyright (c) 2018-2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#if defined(CONFIG_SOC_SERIES_NRF51X)
+#define HAL_RADIO_PDU_LEN_MAX (BIT(5) - 1)
+#else
+#define HAL_RADIO_PDU_LEN_MAX (BIT(8) - 1)
+#endif
 
 #include "hal/nrf5/radio/radio.h"
 #include "hal/nrf5/radio/radio_nrf5_txp.h"


### PR DESCRIPTION
Implemented an intermediate decrypt buffer to cover the CCM
overrun under CRC error conditions. The workaround is
applicable to nRF52832 SoC only, which is missing the
MAXPACKETSIZE register in the NRF_CCM peripheral.

Fixes #21107 for nRF52832 SoC.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>