### PR TITLE
logging: set 'log_backend_rtt:panic_mode' before 'log_backend_std_panic'

### DIFF
--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -257,8 +257,8 @@ static void log_backend_rtt_init(void)
 
 static void panic(struct log_backend const *const backend)
 {
-	log_backend_std_panic(&log_output);
 	panic_mode = true;
+	log_backend_std_panic(&log_output);
 }
 
 static void dropped(const struct log_backend *const backend, u32_t cnt)


### PR DESCRIPTION
Call the LOG_PANIC() macro/function in the default
assert_post_action handler, otherwise queued error
messages will not be displayed.

Signed-off-by: Andrew Fernandes <andrew@fernandes.org>