### PR TITLE
tests: update kernel objects tests

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/src/kobject.c
+++ b/tests/kernel/mem_protect/mem_protect/src/kobject.c
@@ -177,7 +177,7 @@ static void kobject_grant_access_extra_entry(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test grant access.
+ * @brief Test grant access
  *
  * @details Will grant access to another thread for the
  * semaphore it holds.
@@ -294,9 +294,10 @@ static void access_all_grant_child_take(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test all access grant.
+ * @brief Test supervisor thread grants kernel objects all access public status
  *
- * @details Test the access by creating 2 new user threads.
+ * @details System makes kernel object kobject_public_sem public to all threads
+ * Test the access to that kernel object by creating two new user threads.
  *
  * @see k_object_access_all_grant()
  *

--- a/tests/kernel/mem_protect/obj_validation/src/main.c
+++ b/tests/kernel/mem_protect/obj_validation/src/main.c
@@ -67,7 +67,13 @@ void object_permission_checks(struct k_sem *sem, bool skip_init)
 }
 
 /**
- * @brief Tests to verify object permission
+ * @brief Test to verify object permission
+ *
+ * @details
+ * - The kernel must be able to associate kernel object memory addresses
+ *   with whether the calling thread has access to that object, the object is
+ *   of the expected type, and the object is of the expected init state.
+ * - Test support freeing kernel objects allocated at runtime manually.
  *
  * @ingroup kernel_memprotect_tests
  *

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -507,6 +507,10 @@ static void test_write_other_stack(void)
 /**
  * @brief Test to revoke access to kobject without permission
  *
+ * @details User thread can only revoke their own access to an object.
+ * In that test user thread to revokes access to unathorized object, as a result
+ * the system will assert.
+ *
  * @ingroup kernel_memprotect_tests
  */
 static void test_revoke_noperms_object(void)


### PR DESCRIPTION
1. Add code change to the test_permission_inheritance() to let it
test that child thread can't access parent thread object. Now that test
tests one more related to it feature.
2. Add new Doxygen tags with informative descriptions about the kernel
objects tests. That will make reading and understanding kernel object
tests code easier.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>