### PR TITLE
test: thread: add a test case for essential thread abort

### DIFF
--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -38,6 +38,7 @@ extern void test_threads_cpu_mask(void);
 extern void test_threads_suspend_timeout(void);
 extern void test_threads_suspend(void);
 extern void test_abort_from_isr(void);
+extern void test_essential_thread_abort(void);
 
 struct k_thread tdata;
 #define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)
@@ -487,6 +488,7 @@ void test_main(void)
 			 ztest_unit_test(test_abort_handler),
 			 ztest_1cpu_unit_test(test_delayed_thread_abort),
 			 ztest_unit_test(test_essential_thread_operation),
+			 ztest_unit_test(test_essential_thread_abort),
 			 ztest_unit_test(test_systhreads_main),
 			 ztest_unit_test(test_systhreads_idle),
 			 ztest_1cpu_unit_test(test_customdata_get_set_coop),

--- a/tests/kernel/threads/thread_apis/src/test_essential_thread.c
+++ b/tests/kernel/threads/thread_apis/src/test_essential_thread.c
@@ -32,8 +32,9 @@ static void thread_entry(void *p1, void *p2, void *p3)
 }
 
 /**
- * @ingroup kernel_thread_tests
  * @brief Test to validate essential flag set/clear
+ *
+ * @ingroup kernel_thread_tests
  *
  * @see #K_ESSENTIAL(x)
  */
@@ -46,4 +47,50 @@ void test_essential_thread_operation(void)
 
 	k_sem_take(&sync_sem, K_FOREVER);
 	k_thread_abort(tid);
+}
+
+void k_sys_fatal_error_handler(unsigned int reason,
+				      const z_arch_esf_t *esf)
+{
+	ARG_UNUSED(esf);
+	ARG_UNUSED(reason);
+
+	z_thread_essential_clear();
+}
+
+static void abort_thread_entry(void *p1, void *p2, void *p3)
+{
+	z_thread_essential_set();
+
+	if (z_is_thread_essential()) {
+		k_busy_wait(100);
+	} else {
+		zassert_unreachable("The thread is not set as essential");
+	}
+
+	k_sem_give(&sync_sem);
+	k_sleep(K_FOREVER);
+}
+
+/**
+ * @brief Abort an essential thread
+ *
+ * @details The kernel shall raise a fatal system error if an essential thread
+ *          aborts, implement k_sys_fatal_error_handler to handle this error.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @see #K_ESSENTIAL(x)
+ */
+
+void test_essential_thread_abort(void)
+{
+	k_tid_t tid = k_thread_create(&kthread_thread, kthread_stack, STACKSIZE,
+				      (k_thread_entry_t)abort_thread_entry,
+				      NULL, NULL, NULL, K_PRIO_PREEMPT(0), 0,
+				      K_NO_WAIT);
+
+	k_sem_take(&sync_sem, K_FOREVER);
+	k_thread_abort(tid);
+
 }


### PR DESCRIPTION
Abort a essential thread and handle the fatal error.
Remove CONFIG_MP_NUM_CPUS for all cases to support multiple cpu
Adjust some codes to make test cases run successfully on multi-cpu
platfomrs.

Signed-off-by: Meng xianglin <xianglinx.meng@intel.com>