### PR TITLE
Test: timer: add new test cases for timer

### DIFF
--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -177,6 +177,39 @@ void test_timer_duration_period(void)
 }
 
 /**
+ *
+ * @brief Test restart the timer
+ *
+ * @details Validates initial duration and period of timer. Start the timer with
+ * specific duration and period. Then starts the timer again, and check
+ * the status of timer.
+ *
+ * @ingroup kernel_timer_tests
+ *
+ * @see k_timer_init(), k_timer_start(), k_timer_stop, k_uptime_get(),
+ * k_busy_wait()
+ *
+ */
+void test_timer_restart(void)
+{
+	init_timer_data();
+	k_timer_start(&status_anytime_timer, K_MSEC(DURATION),
+		      K_MSEC(PERIOD));
+	busy_wait_ms(DURATION + PERIOD * (EXPIRE_TIMES - 1) + PERIOD / 2);
+
+	/** TESTPOINT: restart the timer */
+	k_timer_start(&status_anytime_timer, K_MSEC(DURATION),
+		      K_MSEC(PERIOD));
+	/* Restart timer, timer's status is reset to zero */
+	TIMER_ASSERT(k_timer_status_get(&status_anytime_timer) == 0,
+		     &status_anytime_timer);
+
+	/* cleanup environment */
+	k_timer_stop(&status_anytime_timer);
+}
+
+
+/**
  * @brief Test Timer with zero period value
  *
  * Validates initial timer duration, keeping timer period to zero.
@@ -379,6 +412,9 @@ void test_timer_status_get_anytime(void)
 	/** TESTPOINT: status get at any time */
 	TIMER_ASSERT(k_timer_status_get(&status_anytime_timer) == EXPIRE_TIMES,
 		     &status_anytime_timer);
+	busy_wait_ms(PERIOD);
+	TIMER_ASSERT(k_timer_status_get(&status_anytime_timer) == 1,
+		     &status_anytime_timer);
 
 	/* cleanup environment */
 	k_timer_stop(&status_anytime_timer);
@@ -408,7 +444,7 @@ void test_timer_status_sync(void)
 	for (int i = 0; i < EXPIRE_TIMES; i++) {
 		/** TESTPOINT: check timer not expire */
 		TIMER_ASSERT(tdata.expire_cnt == i, &status_sync_timer);
-		/** TESTPOINT： expired times returned by status sync */
+		/** TESTPOINT: expired times returned by status sync */
 		TIMER_ASSERT(k_timer_status_sync(&status_sync_timer) == 1,
 			     &status_sync_timer);
 		/** TESTPOINT: check timer not expire */
@@ -499,6 +535,7 @@ static void user_data_timer_handler(struct k_timer *timer)
 	}
 
 	intptr_t data_retrieved = (intptr_t)k_timer_user_data_get(timer);
+
 	user_data_correct[timer_num] = user_data[timer_num] == data_retrieved;
 }
 
@@ -582,6 +619,8 @@ void test_timer_remaining(void)
 	rem_ticks = k_timer_remaining_ticks(&remain_timer);
 	exp_ticks = k_timer_expires_ticks(&remain_timer);
 	k_timer_stop(&remain_timer);
+	TIMER_ASSERT(tdata.expire_cnt == 0, &remain_timer);
+	TIMER_ASSERT(tdata.stop_cnt == 1, &remain_timer);
 
 	/*
 	 * While the busy_wait_ms() works with the maximum possible resolution,
@@ -685,7 +724,7 @@ void test_main(void)
 	timer_init(&status_timer, status_expire, status_stop);
 	timer_init(&status_anytime_timer, NULL, NULL);
 	timer_init(&status_sync_timer, duration_expire, duration_stop);
-	timer_init(&remain_timer, NULL, NULL);
+	timer_init(&remain_timer, duration_expire, duration_stop);
 
 	k_thread_access_grant(k_current_get(), &ktimer, &timer0, &timer1,
 			      &timer2, &timer3, &timer4);
@@ -693,6 +732,7 @@ void test_main(void)
 	ztest_test_suite(timer_api,
 			 ztest_unit_test(test_time_conversions),
 			 ztest_user_unit_test(test_timer_duration_period),
+			 ztest_user_unit_test(test_timer_restart),
 			 ztest_user_unit_test(test_timer_period_0),
 			 ztest_user_unit_test(test_timer_expirefn_null),
 			 ztest_user_unit_test(test_timer_periodicity),


### PR DESCRIPTION
Add new test cases for timer to improve testing infrastructure. 
Add different waiting time in existing cases. 
In test_timer_duration_period(), stop a running timer in mid-countdown and check for proper completion of duration and period. 
In test_timer_status_get_anytime(), read the timer status again to check how many times the timer has expired since its status was last read.
For new test cases, restart timer and check whether the timer's status is reset zero. 