### PR TITLE
DT-related fixes in UART driver for CC13xx/CC26xx

### DIFF
--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -564,44 +564,24 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 #define UART_CC13XX_CC26XX_INT_FIELDS
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
-/*
- * DEVICE_DEFINE() requires the kernel level to be explicitly passed
- * using the actual macro name, hence we are forced to list these permutations
- * out.
- */
-#define UART_CC13XX_CC26XX_DEVICE_DEFINE_0				 \
-	DEVICE_DEFINE(uart_cc13xx_cc26xx_0, DT_INST_LABEL(0),		 \
-		uart_cc13xx_cc26xx_init_0,				 \
-		uart_cc13xx_cc26xx_pm_control,				 \
-		&uart_cc13xx_cc26xx_data_0, &uart_cc13xx_cc26xx_config_0,\
-		PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	 \
+#define UART_CC13XX_CC26XX_DEVICE_DEFINE(n)				     \
+	DEVICE_DEFINE(uart_cc13xx_cc26xx_##n, DT_INST_LABEL(n),		     \
+		uart_cc13xx_cc26xx_init_##n,				     \
+		uart_cc13xx_cc26xx_pm_control,				     \
+		&uart_cc13xx_cc26xx_data_##n, &uart_cc13xx_cc26xx_config_##n,\
+		PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	     \
 		&uart_cc13xx_cc26xx_driver_api)
 
-#define UART_CC13XX_CC26XX_DEVICE_DEFINE_1				 \
-	DEVICE_DEFINE(uart_cc13xx_cc26xx_1, DT_INST_LABEL(1),		 \
-		uart_cc13xx_cc26xx_init_1,				 \
-		uart_cc13xx_cc26xx_pm_control,				 \
-		&uart_cc13xx_cc26xx_data_1, &uart_cc13xx_cc26xx_config_1,\
-		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	 \
-		&uart_cc13xx_cc26xx_driver_api)
-
-#define UART_CC13XX_CC26XX_DEVICE_API_INIT_0				 \
-	DEVICE_AND_API_INIT(uart_cc13xx_cc26xx_0, DT_INST_LABEL(0),	 \
-		uart_cc13xx_cc26xx_init_0, &uart_cc13xx_cc26xx_data_0,	 \
-		&uart_cc13xx_cc26xx_config_0, PRE_KERNEL_1,		 \
-		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			 \
-		&uart_cc13xx_cc26xx_driver_api)
-
-#define UART_CC13XX_CC26XX_DEVICE_API_INIT_1				 \
-	DEVICE_AND_API_INIT(uart_cc13xx_cc26xx_1, DT_INST_LABEL(1),	 \
-		uart_cc13xx_cc26xx_init_1, &uart_cc13xx_cc26xx_data_1,	 \
-		&uart_cc13xx_cc26xx_config_1, POST_KERNEL,		 \
-		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			 \
+#define UART_CC13XX_CC26XX_DEVICE_API_INIT(n)				     \
+	DEVICE_AND_API_INIT(uart_cc13xx_cc26xx_##n, DT_INST_LABEL(n),	     \
+		uart_cc13xx_cc26xx_init_##n, &uart_cc13xx_cc26xx_data_##n,   \
+		&uart_cc13xx_cc26xx_config_##n, PRE_KERNEL_1,		     \
+		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			     \
 		&uart_cc13xx_cc26xx_driver_api)
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 #define UART_CC13XX_CC26XX_DEVICE_INIT(n)				\
-	UART_CC13XX_CC26XX_DEVICE_DEFINE_##n
+	UART_CC13XX_CC26XX_DEVICE_DEFINE(n)
 
 #define UART_CC13XX_CC26XX_INIT_PM_STATE				\
 	do {								\
@@ -609,7 +589,7 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 	} while (0)
 #else
 #define UART_CC13XX_CC26XX_DEVICE_INIT(n)				\
-	UART_CC13XX_CC26XX_DEVICE_API_INIT_##n
+	UART_CC13XX_CC26XX_DEVICE_API_INIT(n)
 
 #define UART_CC13XX_CC26XX_INIT_PM_STATE
 #endif


### PR DESCRIPTION
The existing driver code, after changes from the recent DT rework, does
not allow UART1 to be enabled when UART0 is not. This is because there
is an implicit assumption that DT instance 0 corresponds to UART0 and
DT instance 1 corresponds to UART1.

In particular, the power configuration is dependent on which UART is physically used.
In order to allow DT_INST_FOREACH_STATUS_OKAY() to iterate through
instances without the assumption that index 0 corresponds to UART0
(which would be incorrect in the case when only UART1 is enabled),
we need to check the base address to identify which UART is being dealt
with.

There also does not seem to be a simple way to express the fact that UART1
can be initialized later at the POST_KERNEL level. The existing code
is wrong in the sense that it always initializes DT instance 1 later,
instead of doing it for UART1 (which may not be instance 1).
In addition, UART instances on other platforms are
also initialized at the PRE_KERNEL_1 level regardless of the instance
index, so let's do the same on this platform for consistency.