### PR TITLE
Fix OCRAM configuration for i.MX RT

### DIFF
--- a/soc/arm/common/cortex_m/arm_mpu_mem_cfg.h
+++ b/soc/arm/common/cortex_m/arm_mpu_mem_cfg.h
@@ -32,7 +32,7 @@
 #elif CONFIG_FLASH_SIZE <= 65536
 #define REGION_FLASH_SIZE REGION_64M
 #else
-#error "Unsupported configuration"
+#error "Unsupported flash size configuration"
 #endif
 
 /* SRAM Region Definitions */
@@ -57,7 +57,7 @@
 #elif CONFIG_SRAM_SIZE == 32768
 #define REGION_SRAM_SIZE REGION_32M
 #else
-#error "Unsupported configuration"
+#error "Unsupported sram size configuration"
 #endif
 
 #endif /* !ARMV8_M_BASELINE && !ARMV8_M_MAINLINE */

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -121,10 +121,10 @@ endif # DATA_SEMC
 if DATA_OCRAM
 
 config SRAM_SIZE
-	default $(dt_node_reg_size_int,/memory@20200000,0,K)
+	default $(dt_node_reg_size_int,/soc/flexram@400b0000/ocram@20200000,0,K)
 
 config SRAM_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/memory@20200000)
+	default $(dt_node_reg_addr_hex,/soc/flexram@400b0000/ocram@20200000)
 
 endif # DATA_OCRAM
 


### PR DESCRIPTION
Without this I was not able to use OCRAM as the system RAM.

The first commit is a little improvement on error messages which help spotting problems.