### PR TITLE
tests: arch: arm_interrupt: minor style fixes in comments/README

### DIFF
--- a/tests/arch/arm/arm_interrupt/README.txt
+++ b/tests/arch/arm/arm_interrupt/README.txt
@@ -6,7 +6,9 @@ Description:
 
 The first test verifies that we can handle system fault conditions
 while running in handler mode (i.e. in an ISR). Only for ARM
-Cortex-M targets. The test also verifies
+Cortex-M targets.
+
+The test also verifies
 - the behavior of the spurious interrupt handler, as well as the
   ARM spurious exception handler.
 - the ability of the Cortex-M fault handling mechanism to detect

--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -180,7 +180,7 @@ void test_arm_interrupt(void)
 	/*
 	 * Simulate a stacking error that is caused explicitly by the
 	 * exception entry context stacking, to verify that the CPU can
-	 * correctly report stacking  errors that are not also Data
+	 * correctly report stacking errors that are not also Data
 	 * access violation errors.
 	 */
 	expected_reason = K_ERR_STACK_CHK_FAIL;
@@ -196,7 +196,7 @@ void test_arm_interrupt(void)
 	test_flag = 4;
 
 	/* Manually set PSP almost at the bottom of the stack. An exception
-	 * entry will make PSP decent below the limit and into the MPU guard
+	 * entry will make PSP descend below the limit and into the MPU guard
 	 * section (or beyond the address pointed by PSPLIM in ARMv8-M MCUs).
 	 */
 	__set_PSP(_current->stack_info.start + 0x10);


### PR DESCRIPTION
Add some missed style fixes in inline comments and test README.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Leftovers from the review in #25609 which was merged, before I had time to apply the fixes.