### PR TITLE
drivers: flash: nrf_qspi_nor: various fixes

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -500,7 +500,7 @@ static int qspi_nor_read(struct device *dev, off_t addr, void *dest,
 	}
 
 	/* read size must be non-zero multiple of 4 bytes */
-	if (size < 4U) {
+	if ((size > 0) && (size < 4U)) {
 		dest = buf;
 		size = sizeof(buf);
 	} else if (((size % 4U) != 0) || (size == 0)) {

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -493,7 +493,7 @@ static int qspi_nor_read(struct device *dev, off_t addr, void *dest,
 {
 	void *dptr = dest;
 	size_t dlen = size;
-	u8_t buf[4];
+	u8_t __aligned(4) buf[4];
 
 	if (!dest) {
 		return -EINVAL;


### PR DESCRIPTION
The check for small transfers inadvertently allowed a transfer of zero bytes, which should be an error (invalid parameter).

Also ensure the buffer is properly aligned.

Also clean up the lock/unlock idiom to make it easier to support transfers that require multiple HAL calls in a way that doesn't risk interleaving operations from multiple threads.

All this in support of nrfconnect/sdk-zephyr#305

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>