### PR TITLE
kernel: don't allow mutex ops in ISRs

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3610,6 +3610,8 @@ __syscall int k_mutex_init(struct k_mutex *mutex);
  * A thread is permitted to lock a mutex it has already locked. The operation
  * completes immediately and the lock count is increased by 1.
  *
+ * Mutexes may not be locked in ISRs.
+ *
  * @param mutex Address of the mutex.
  * @param timeout Waiting period to lock the mutex,
  *                or one of the special values K_NO_WAIT and
@@ -3630,6 +3632,9 @@ __syscall int k_mutex_lock(struct k_mutex *mutex, k_timeout_t timeout);
  * The mutex cannot be claimed by another thread until it has been unlocked by
  * the calling thread as many times as it was previously locked by that
  * thread.
+ *
+ * Mutexes may not be unlocked in ISRs, as mutexes must only be manipulated
+ * in thread context due to ownership and priority inheritance semantics.
  *
  * @param mutex Address of the mutex.
  *

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -122,6 +122,8 @@ int z_impl_k_mutex_lock(struct k_mutex *mutex, k_timeout_t timeout)
 	k_spinlock_key_t key;
 	bool resched = false;
 
+	__ASSERT(!arch_is_in_isr(), "mutexes cannot be used inside ISRs");
+
 	sys_trace_void(SYS_TRACE_ID_MUTEX_LOCK);
 	key = k_spin_lock(&lock);
 
@@ -210,6 +212,8 @@ static inline int z_vrfy_k_mutex_lock(struct k_mutex *mutex,
 int z_impl_k_mutex_unlock(struct k_mutex *mutex)
 {
 	struct k_thread *new_owner;
+
+	__ASSERT(!arch_is_in_isr(), "mutexes cannot be used inside ISRs");
 
 	CHECKIF(mutex->owner == NULL) {
 		return -EINVAL;


### PR DESCRIPTION
Mutex operations check ownership against _current. But in an
ISR, _current is just whatever thread was interrupted when the
ISR fired. Explicitly do not allow this.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>