### PR TITLE
x86: 32-bit: allow direct ISRs only with !KPTI

### DIFF
--- a/include/arch/x86/ia32/arch.h
+++ b/include/arch/x86/ia32/arch.h
@@ -204,6 +204,14 @@ typedef struct s_isrList {
 				   (flags_p)); \
 }
 
+/* Direct interrupts won't work as expected with KPTI turned on, because
+ * all non-user accessible pages in the page table are marked non-present.
+ * It's likely possible to add logic to ARCH_ISR_DIRECT_HEADER/FOOTER to do
+ * the necessary trampolining to switch page tables / stacks, but this
+ * probably loses all the latency benefits that direct interrupts provide
+ * and one might as well use a regular interrupt anyway.
+ */
+#ifndef CONFIG_X86_KPTI
 #define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
 { \
 	NANO_CPU_INT_REGISTER(isr_p, irq_p, priority_p, -1, 0); \
@@ -305,6 +313,7 @@ static inline void arch_isr_direct_footer(int swap)
 		ISR_DIRECT_FOOTER(check_reschedule); \
 	} \
 	static inline int name##_body(void)
+#endif /* !CONFIG_X86_KPTI */
 
 /**
  * @brief Exception Stack Frame


### PR DESCRIPTION
This doesn't work as expected with kernel page table isolation
turned on, and fixing it would likely lose any latency benefits
that direct ISRs are supposed to provide.

For now, just prevent these macros from being defined if KPTI
is turned on, like other arches that do not implement this
feature.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>