### PR TITLE
lib: coap: Add coap_get_option_int public method

### DIFF
--- a/include/net/coap.h
+++ b/include/net/coap.h
@@ -147,6 +147,11 @@ enum coap_response_code {
 
 #define COAP_CODE_EMPTY (0)
 
+/* block option helper */
+#define GET_BLOCK_NUM(v)        ((v) >> 4)
+#define GET_BLOCK_SIZE(v)       (((v) & 0x7))
+#define GET_MORE(v)             (!!((v) & 0x08))
+
 struct coap_observer;
 struct coap_packet;
 struct coap_pending;
@@ -563,6 +568,17 @@ int coap_append_size1_option(struct coap_packet *cpkt,
  */
 int coap_append_size2_option(struct coap_packet *cpkt,
 			     struct coap_block_context *ctx);
+
+/**
+ * @brief Get the integer representation of a CoAP option.
+ *
+ * @param cpkt Packet to be inspected
+ * @param code CoAP option code
+ *
+ * @return Integer value >= 0 in case of success or negative in case
+ * of error.
+ */
+int coap_get_option_int(const struct coap_packet *cpkt, uint16_t code);
 
 /**
  * @brief Retrieves BLOCK{1,2} and SIZE{1,2} from @a cpkt and updates

--- a/samples/net/sockets/coap_server/src/coap-server.c
+++ b/samples/net/sockets/coap_server/src/coap-server.c
@@ -39,11 +39,6 @@ LOG_MODULE_REGISTER(net_coap_server_sample, LOG_LEVEL_DBG);
 
 #define NUM_PENDINGS 3
 
-/* block option helper */
-#define GET_BLOCK_NUM(v)        ((v) >> 4)
-#define GET_BLOCK_SIZE(v)       (((v) & 0x7))
-#define GET_MORE(v)             (!!((v) & 0x08))
-
 /* CoAP socket fd */
 static int sock;
 
@@ -780,19 +775,6 @@ end:
 	return r;
 }
 
-static int get_option_int(const struct coap_packet *pkt, uint8_t opt)
-{
-	struct coap_option option;
-	int r;
-
-	r = coap_find_options(pkt, opt, &option, 1);
-	if (r <= 0) {
-		return -ENOENT;
-	}
-
-	return coap_option_value_to_int(&option);
-}
-
 static int large_update_put(struct coap_resource *resource,
 			    struct coap_packet *request,
 			    struct sockaddr *addr, socklen_t addr_len)
@@ -810,7 +792,7 @@ static int large_update_put(struct coap_resource *resource,
 	int r;
 	bool last_block;
 
-	r = get_option_int(request, COAP_OPTION_BLOCK1);
+	r = coap_get_option_int(request, COAP_OPTION_BLOCK1);
 	if (r < 0) {
 		return -EINVAL;
 	}
@@ -899,7 +881,7 @@ static int large_create_post(struct coap_resource *resource,
 	int r;
 	bool last_block;
 
-	r = get_option_int(request, COAP_OPTION_BLOCK1);
+	r = coap_get_option_int(request, COAP_OPTION_BLOCK1);
 	if (r < 0) {
 		return -EINVAL;
 	}

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -937,8 +937,6 @@ int coap_get_option_int(const struct coap_packet *cpkt, uint16_t code)
 	return val;
 }
 
-#define get_block_option(cpkt, code) coap_get_option_int(cpkt, code)
-
 static int update_descriptive_block(struct coap_block_context *ctx,
 				    int block, int size)
 {
@@ -1020,10 +1018,10 @@ int coap_update_from_block(const struct coap_packet *cpkt,
 {
 	int r, block1, block2, size1, size2;
 
-	block1 = get_block_option(cpkt, COAP_OPTION_BLOCK1);
-	block2 = get_block_option(cpkt, COAP_OPTION_BLOCK2);
-	size1 = get_block_option(cpkt, COAP_OPTION_SIZE1);
-	size2 = get_block_option(cpkt, COAP_OPTION_SIZE2);
+	block1 = coap_get_option_int(cpkt, COAP_OPTION_BLOCK1);
+	block2 = coap_get_option_int(cpkt, COAP_OPTION_BLOCK2);
+	size1 = coap_get_option_int(cpkt, COAP_OPTION_SIZE1);
+	size2 = coap_get_option_int(cpkt, COAP_OPTION_SIZE2);
 
 	size1 = size1 == -ENOENT ? 0 : size1;
 	size2 = size2 == -ENOENT ? 0 : size2;
@@ -1051,9 +1049,9 @@ size_t coap_next_block(const struct coap_packet *cpkt,
 	int block;
 
 	if (is_request(cpkt)) {
-		block = get_block_option(cpkt, COAP_OPTION_BLOCK1);
+		block = coap_get_option_int(cpkt, COAP_OPTION_BLOCK1);
 	} else {
-		block = get_block_option(cpkt, COAP_OPTION_BLOCK2);
+		block = coap_get_option_int(cpkt, COAP_OPTION_BLOCK2);
 	}
 
 	if (!GET_MORE(block)) {
@@ -1238,8 +1236,6 @@ void coap_pendings_clear(struct coap_pending *pendings, size_t len)
 	}
 }
 
-#define get_observe_option(cpkt) coap_get_option_int(cpkt, COAP_OPTION_OBSERVE)
-
 struct coap_reply *coap_response_received(
 	const struct coap_packet *response,
 	const struct sockaddr *from,
@@ -1270,7 +1266,7 @@ struct coap_reply *coap_response_received(
 			continue;
 		}
 
-		age = get_observe_option(response);
+		age = coap_get_option_int(response, COAP_OPTION_OBSERVE);
 		if (age > 0) {
 			/* age == 2 means that the notifications wrapped,
 			 * or this is the first one
@@ -1305,7 +1301,7 @@ void coap_reply_init(struct coap_reply *reply,
 
 	reply->tkl = tkl;
 
-	age = get_observe_option(request);
+	age = coap_get_option_int(request, COAP_OPTION_OBSERVE);
 
 	/* It means that the request enabled observing a resource */
 	if (age == 0) {
@@ -1347,7 +1343,7 @@ int coap_resource_notify(struct coap_resource *resource)
 
 bool coap_request_is_observe(const struct coap_packet *request)
 {
-	return get_observe_option(request) == 0;
+	return coap_get_option_int(request, COAP_OPTION_OBSERVE) == 0;
 }
 
 void coap_observer_init(struct coap_observer *observer,

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -921,9 +921,9 @@ int coap_append_size2_option(struct coap_packet *cpkt,
 	return coap_append_option_int(cpkt, COAP_OPTION_SIZE2, ctx->total_size);
 }
 
-static int get_block_option(const struct coap_packet *cpkt, uint16_t code)
+int coap_get_option_int(const struct coap_packet *cpkt, uint16_t code)
 {
-	struct coap_option option;
+	struct coap_option option = {};
 	unsigned int val;
 	int count = 1;
 
@@ -936,6 +936,8 @@ static int get_block_option(const struct coap_packet *cpkt, uint16_t code)
 
 	return val;
 }
+
+#define get_block_option(cpkt, code) coap_get_option_int(cpkt, code)
 
 static int update_descriptive_block(struct coap_block_context *ctx,
 				    int block, int size)
@@ -1236,19 +1238,7 @@ void coap_pendings_clear(struct coap_pending *pendings, size_t len)
 	}
 }
 
-static int get_observe_option(const struct coap_packet *cpkt)
-{
-	struct coap_option option = {};
-	uint16_t count = 1U;
-	int r;
-
-	r = coap_find_options(cpkt, COAP_OPTION_OBSERVE, &option, count);
-	if (r <= 0) {
-		return -ENOENT;
-	}
-
-	return coap_option_value_to_int(&option);
-}
+#define get_observe_option(cpkt) coap_get_option_int(cpkt, COAP_OPTION_OBSERVE)
 
 struct coap_reply *coap_response_received(
 	const struct coap_packet *response,


### PR DESCRIPTION
Any CoAP implementation when use at least block transfer or is a server side need access some CoAP options as integer values. This add a method at public interface and defines for block wise operations to avoid code useless code duplication.

This refactor below files:
subsys/net/lib/lwm2m/lwm2m_engine.c
samples/net/sockets/coap_server/src/coap-server.c

The motivation is #25558 that needs same approach already implemented at sample and LWM2M.