### PR TITLE
[backport v1.14] Bluetooth: controller: split: Fix NRF_CCM overrun

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -992,7 +992,6 @@ static u8_t MALIGN(4) _ccm_scratch[(RADIO_PDU_LEN_MAX - 4) + 16];
 
 void *radio_ccm_rx_pkt_set(struct ccm *ccm, u8_t phy, void *pkt)
 {
-
 	u32_t mode;
 
 	NRF_CCM->ENABLE = CCM_ENABLE_ENABLE_Disabled;
@@ -1038,6 +1037,15 @@ void *radio_ccm_rx_pkt_set(struct ccm *ccm, u8_t phy, void *pkt)
 #endif /* CONFIG_SOC_NRF52840 */
 #endif /* CONFIG_BT_CTLR_PHY_CODED */
 	}
+
+#if !defined(CONFIG_SOC_COMPATIBLE_NRF52832) && \
+	(!defined(CONFIG_BT_CTLR_DATA_LENGTH_MAX) || \
+	 (CONFIG_BT_CTLR_DATA_LENGTH_MAX < ((RADIO_PDU_LEN_MAX) - 4)))
+	u8_t max_len = (NRF_RADIO->PCNF1 & RADIO_PCNF1_MAXLEN_Msk) >>
+			RADIO_PCNF1_MAXLEN_Pos;
+
+	NRF_CCM->MAXPACKETSIZE = max_len;
+#endif
 #endif /* CONFIG_SOC_SERIES_NRF52X */
 
 	NRF_CCM->MODE = mode;


### PR DESCRIPTION
Fix missing assignment of NRF_CCM->MAXPACKETSIZE register
for PDU sizes smaller than 251 bytes. If there is CRC errors
causing PDU length fields to be higher than configured PDU
buffer sizes in the controller, without the MAXPACKETSIZE
register set to correct PDU size, CCM module could overrun
the PDU buffer and cause memory corruption. This fix is
applicable for all nRF52 Series SoCs except nRF52832 SoC.

Fixes #21107.
Backport of #25619.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>