### PR TITLE
Add a new test case for providing time duration in milliseconds

### DIFF
--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -29,6 +29,7 @@ extern void test_printk(void);
 extern void test_timeout_order(void);
 extern void test_clock_cycle(void);
 extern void test_clock_uptime(void);
+extern void test_ms_time_duration(void);
 extern void test_multilib(void);
 extern void test_thread_context(void);
 extern void test_verify_bootdelay(void);
@@ -124,6 +125,7 @@ void test_main(void)
 			 ztest_unit_test(test_version),
 			 ztest_unit_test(test_multilib),
 			 ztest_unit_test(test_thread_context),
+			 ztest_unit_test(test_ms_time_duration),
 			 ztest_unit_test(test_bounds_check_mitigation)
 			 );
 


### PR DESCRIPTION
Add a new test case to verify whether kernel allow proving time duration
in milliseconds.

Signed-off-by: Jian Kang <jianx.kang@intel.com>