### PR TITLE
net: ipv6: RA prefix option length not checked

### DIFF
--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -2361,6 +2361,12 @@ static enum net_verdict handle_ra_input(struct net_pkt *pkt,
 
 			break;
 		case NET_ICMPV6_ND_OPT_PREFIX_INFO:
+			if (nd_opt_hdr->len != 4) {
+				NET_ERR("DROP: Invalid %s length (%d)",
+					"prefix opt", nd_opt_hdr->len);
+				goto drop;
+			}
+
 			if (!handle_ra_prefix(pkt)) {
 				goto drop;
 			}
@@ -2370,8 +2376,8 @@ static enum net_verdict handle_ra_input(struct net_pkt *pkt,
 		case NET_ICMPV6_ND_OPT_6CO:
 			/* RFC 6775, 4.2 (Length)*/
 			if (!(nd_opt_hdr->len == 2U || nd_opt_hdr->len == 3U)) {
-				NET_ERR("DROP: Invalid 6CO length %d",
-					nd_opt_hdr->len);
+				NET_ERR("DROP: Invalid %s length %d",
+					"6CO", nd_opt_hdr->len);
 				goto drop;
 			}
 


### PR DESCRIPTION
The Router Advertisement can have prefix option. It's length
is 4 but the code did not check that which meant that we could
accept malformed packet. See RFC 4861 chapter 4.6.2 for details.

Fixes #25694

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>