### PR TITLE
manifest: update west.yml for find_package(Zephyr) in mcuboot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -86,7 +86,7 @@ manifest:
       revision: 821154171b246f64eaeef3ccc267f58d8274739a
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: e88113bbebe34ff2ccc6627ffae885cfeed6fdfd
+      revision: 4bb0f9547f80e1d14cb6591db12030e2dbf891f4
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 5885efb7cabf7b566577b73129c9d277d7d8848d


### PR DESCRIPTION
This commit updates the manifest to use mcuboot revision containing the
find_package(Zephyr) feature.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

-----
People can now build Zephyr without ZEPHYR_BASE in environment, then there is a high risk that someone building mcuboot will suddenly experience build failures.

This PR depends on: https://github.com/zephyrproject-rtos/mcuboot/pull/22
