### PR TITLE
net: ipv6: Do not add same prefix multiple times to timer list

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1921,6 +1921,8 @@ static void prefix_start_timer(struct net_if_ipv6_prefix *ifprefix,
 {
 	u64_t expire_timeout = (u64_t)MSEC_PER_SEC * (u64_t)lifetime;
 
+	(void)sys_slist_find_and_remove(&active_prefix_lifetime_timers,
+					&ifprefix->lifetime.node);
 	sys_slist_append(&active_prefix_lifetime_timers,
 			 &ifprefix->lifetime.node);
 


### PR DESCRIPTION
Make sure that we do not add same IPv6 prefix, received from RA,
multiple times to prefix timer list. This avoids possible
denial-of-service issue if we receive suitably crafted RA packet.

Fixes #25698

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>