### PR TITLE
tests: update doxygen tags for syscalls tests

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/src/kobject.c
+++ b/tests/kernel/mem_protect/mem_protect/src/kobject.c
@@ -65,7 +65,10 @@ static void syscall_invalid_kobject_user_part(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test if a syscall can take a different type of kobject
+ * @brief Test syscall can take a different type of kobject
+ *
+ * @details Test syscall can take a different type of kobject and syscall will
+ * generate fatal error if check fails.
  *
  * @ingroup kernel_memprotect_tests
  *
@@ -93,7 +96,10 @@ static void thread_without_kobject_permission_user_part(void *p1, void *p2,
 }
 
 /**
- * @brief Test if a user thread can access a k_object without grant
+ * @brief Test user thread can access a k_object without grant
+ *
+ * @details The kernel will fail system call on kernel object that tracks thread
+ * permissions, on thread that don't have permission granted on the object.
  *
  * @ingroup kernel_memprotect_tests
  *
@@ -411,7 +417,7 @@ void test_kobject_access_invalid_kobject(void *p1, void *p2, void *p3)
 
 /****************************************************************************/
 /**
- * @brief object validation checks without init accss
+ * @brief Object validation checks without init access
  *
  * @details Test syscall on a kobject which is not initialized
  * and has no access

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -273,7 +273,7 @@ static void write_kerntext(void)
 static int kernel_data;
 
 /**
- * @brief Testto read from kernel data section
+ * @brief Test to read from kernel data section
  *
  * @ingroup kernel_memprotect_tests
  */
@@ -1105,6 +1105,15 @@ void test_unimplemented_syscall(void)
 	missing_syscall();
 }
 
+/**
+ * @brief Test bad syscall handler
+ *
+ * @details When a system call handler decides to terminate the calling thread,
+ * the kernel will produce error which indicates the context, where the faulting
+ * system call was made from user code.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
 void test_bad_syscall(void)
 {
 	expect_fault = true;


### PR DESCRIPTION
Reason is that some tests have poor description in Doxygen tags,
decided to fix that situation in some tests which I understand.
Also remove small misprints from some parts of code.

Update Doxygen tags for the next tests:
test_access_kobject_without_init_access
test_thread_without_kobject_permission
test_bad_syscall
test_syscall_invalid_kobject

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>