### PR TITLE
lib: updatehub: kick watchdog

### DIFF
--- a/lib/updatehub/include/updatehub.h
+++ b/lib/updatehub/include/updatehub.h
@@ -69,6 +69,17 @@ enum updatehub_response updatehub_probe(void);
  */
 enum updatehub_response updatehub_update(void);
 
+#if defined(CONFIG_WATCHDOG)
+/**
+ * @brief Kick the watchdog
+ *
+ * @details This function, if implemented elsewhere in the firmware, is
+ * called whenever a valid packet has been received and written into flash.
+ * This can be used to kick a watchdog during firmware download.
+ */
+__weak void updatehub_watchdog_kick(void);
+#endif
+
 /**
  * @}
  */

--- a/lib/updatehub/updatehub.c
+++ b/lib/updatehub/updatehub.c
@@ -431,6 +431,9 @@ static void install_update_cb(void)
 	}
 
 	ctx.code_status = UPDATEHUB_OK;
+#if defined(CONFIG_WATCHDOG)
+	updatehub_watchdog_kick();
+#endif
 
 cleanup:
 	k_free(data);
@@ -869,4 +872,8 @@ void updatehub_autohandler(void)
 {
 	k_delayed_work_init(&updatehub_work_handle, autohandler);
 	k_delayed_work_submit(&updatehub_work_handle, K_NO_WAIT);
+}
+
+void updatehub_watchdog_kick(void)
+{
 }


### PR DESCRIPTION
MOTIVATION:

If a watchdog is used, it may be needed to kick it while the update is
running. A good place to do so is after each successfully received data
block.

IMPLEMENTATION:

If CONFIG_WATCHDOG is set, a function updatehub_watchdog_kick() is called
each time a new block was successfully received and written to flash.

The function updatehub_watchdog_kick() is declared with __weak linkage,
and can be implemented elsewhere in the application to invoke desired
functionality.

Signed-off-by: Hans Wilmers <hans@wilmers.no>