### PR TITLE
tests: add new threads permissions tests, modify existing

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -41,6 +41,7 @@ extern void test_access_kobject_without_init_access(void);
 extern void test_access_kobject_without_init_with_access(void);
 extern void test_kobject_reinitialize_thread_kobj(void);
 extern void test_create_new_thread_from_user(void);
+extern void test_new_user_thread_with_in_use_stack_obj(void);
 extern void test_create_new_thread_from_user_no_access_stack(void);
 extern void test_create_new_thread_from_user_invalid_stacksize(void);
 extern void test_create_new_thread_from_user_huge_stacksize(void);
@@ -49,6 +50,7 @@ extern void test_create_new_essential_thread_from_user(void);
 extern void test_create_new_higher_prio_thread_from_user(void);
 extern void test_create_new_invalid_prio_thread_from_user(void);
 extern void test_inherit_resource_pool(void);
+extern void test_mark_thread_exit_uninitialized(void);
 
 void test_main(void)
 {
@@ -67,6 +69,7 @@ void test_main(void)
 			 ztest_unit_test(test_mem_domain_remove_partitions),
 			 ztest_unit_test(test_mem_domain_remove_thread),
 			 ztest_unit_test(test_mem_domain_destroy),
+			 ztest_unit_test(test_mark_thread_exit_uninitialized),
 			 ztest_unit_test(test_kobject_access_grant),
 			 ztest_unit_test(test_syscall_invalid_kobject),
 			 ztest_unit_test(test_thread_without_kobject_permission),
@@ -82,6 +85,8 @@ void test_main(void)
 			 ztest_unit_test(test_access_kobject_without_init_with_access),
 			 ztest_unit_test(test_kobject_reinitialize_thread_kobj),
 			 ztest_unit_test(test_create_new_thread_from_user),
+			 ztest_unit_test(
+				 test_new_user_thread_with_in_use_stack_obj),
 			 ztest_unit_test(
 				 test_create_new_thread_from_user_no_access_stack),
 			 ztest_unit_test(

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -1084,6 +1084,15 @@ void scenario_entry(void *stack_obj, size_t obj_size)
 			    true);
 }
 
+/**
+ * @brief Test kernel provides user thread read/write access to its own stack
+ * memory buffer
+ *
+ * @details Thread can access its own stack memory buffer and perform
+ * read/write operations.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
 void test_stack_buffer(void)
 {
 	printk("Reserved space: %zu\n", K_THREAD_STACK_RESERVED);


### PR DESCRIPTION
1. Found out that thread tests doesn't test next ideas of requirements,
which I think necessary to be tested and verified:
-the kernel need to prevent user threads creating new threads from
using thread or thread stack objects which are in an initialized state
-Upon thread exit, the kernel need to mark the exiting thread
and thread stack objects as uninitialized

Add new tests to test requirements above, that way we can cover more
features to be tested:
- test_new_user_thread_with_in_use_stack_obj()
- test_mark_thread_exit_uninitialized()

2. Modified test test_create_new_thread_from_user() to verify that kernel
provides new user threads access to their own thread object.

3. Also I added detailed Doxygen tags for each new test and existing
modified test.
4. Added Doxygen tag to the existing test test_stack_buffer, it
covers requirement:
-The kernel need to provide all threads read and write access to their
own stack memory buffer.

Signed-off-by: Maksim Masalski maksim.masalski@intel.com