### PR TITLE
tests: add new Doxygen tags to threads tests

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/src/kobject.c
+++ b/tests/kernel/mem_protect/mem_protect/src/kobject.c
@@ -717,8 +717,12 @@ static void supervisor_from_user_child(void *p1, void *p2, void *p3)
 
 	zassert_unreachable("k_object validation failure in k thread create");
 }
+
 /**
- * @brief Test to create a new supervisor thread from user.
+ * @brief Test to create a new supervisor thread from user
+ *
+ * @details The system kernel must prevent user threads from creating supervisor
+ * threads.
  *
  * @ingroup kernel_memprotect_tests
  */

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -555,10 +555,13 @@ static void umode_enter_func(void)
 }
 
 /**
- * @brief Test to check enter to usermode
- *
- * @ingroup kernel_memprotect_tests
- */
+* @brief Test to check supervisor thread enter one-way to usermode
+*
+* @details A thread running in supervisor mode must have one-way operation
+* ability to drop privileges to user mode.
+*
+* @ingroup kernel_memprotect_tests
+*/
 static void test_user_mode_enter(void)
 {
 	expect_fault = false;


### PR DESCRIPTION
Reason is that some threads tests have poor description Doxygen
tags. I decided to fix that situation in some tests which understand.

Update Doxygen tags for the next tests:
test_create_new_supervisor_thread_from_user()
test_user_mode_enter()

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>