### PR TITLE
device: increase consistency in device declarations

### DIFF
--- a/drivers/counter/counter_gecko_rtcc.c
+++ b/drivers/counter/counter_gecko_rtcc.c
@@ -323,7 +323,7 @@ static const struct counter_driver_api counter_gecko_driver_api = {
 
 /* RTCC0 */
 
-static struct device DEVICE_NAME_GET(counter_gecko_0);
+DEVICE_DECLARE(counter_gecko_0);
 
 ISR_DIRECT_DECLARE(counter_gecko_isr_0)
 {

--- a/drivers/dma/dma_dw.c
+++ b/drivers/dma/dma_dw.c
@@ -361,7 +361,7 @@ static const struct dma_driver_api dw_dma_driver_api = {
 
 #define DW_DMAC_INIT(inst)						\
 									\
-	static struct device DEVICE_NAME_GET(dw_dma##inst);		\
+	DEVICE_DECLARE(dw_dma##inst);		\
 									\
 	static struct dw_drv_plat_data dmac##inst = {			\
 		.chan[0] = {						\

--- a/drivers/dma/dma_nios2_msgdma.c
+++ b/drivers/dma/dma_nios2_msgdma.c
@@ -204,7 +204,7 @@ static const struct dma_driver_api nios2_msgdma_driver_api = {
 };
 
 /* DMA0 */
-static struct device DEVICE_NAME_GET(dma0_nios2);
+DEVICE_DECLARE(dma0_nios2);
 
 static int nios2_msgdma0_initialize(struct device *dev)
 {

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -348,7 +348,7 @@ static const struct dma_driver_api sam_xdmac_driver_api = {
 
 /* DMA0 */
 
-static struct device DEVICE_NAME_GET(dma0_sam);
+DEVICE_DECLARE(dma0_sam);
 
 static void dma0_sam_irq_config(void)
 {

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -182,7 +182,7 @@ int e1000_probe(struct device *device)
 	return retval;
 }
 
-static struct device DEVICE_NAME_GET(eth_e1000);
+DEVICE_DECLARE(eth_e1000);
 
 static void e1000_init(struct net_if *iface)
 {

--- a/drivers/ethernet/eth_gecko.c
+++ b/drivers/ethernet/eth_gecko.c
@@ -631,7 +631,7 @@ static const struct ethernet_api eth_api = {
 	.send = eth_tx,
 };
 
-static struct device DEVICE_NAME_GET(eth_gecko);
+DEVICE_DECLARE(eth_gecko);
 
 static void eth0_irq_config(void)
 {

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -2140,7 +2140,7 @@ static const struct ethernet_api eth_api = {
 #endif
 };
 
-static struct device DEVICE_NAME_GET(eth0_sam_gmac);
+DEVICE_DECLARE(eth0_sam_gmac);
 
 static void eth0_irq_config(void)
 {

--- a/drivers/ethernet/eth_smsc911x.c
+++ b/drivers/ethernet/eth_smsc911x.c
@@ -657,7 +657,7 @@ done:
 
 /* Bindings to the platform */
 
-static struct device DEVICE_NAME_GET(eth_smsc911x_0);
+DEVICE_DECLARE(eth_smsc911x_0);
 
 int eth_init(struct device *dev)
 {

--- a/drivers/ethernet/eth_stellaris.c
+++ b/drivers/ethernet/eth_stellaris.c
@@ -320,7 +320,7 @@ static int eth_stellaris_dev_init(struct device *dev)
 	return 0;
 }
 
-static struct device DEVICE_NAME_GET(eth_stellaris);
+DEVICE_DECLARE(eth_stellaris);
 
 static void eth_stellaris_irq_config(struct device *dev)
 {

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -538,7 +538,7 @@ static const struct ethernet_api eth_api = {
 	.send = eth_tx,
 };
 
-static struct device DEVICE_NAME_GET(eth0_stm32_hal);
+DEVICE_DECLARE(eth0_stm32_hal);
 
 static void eth0_irq_config(void)
 {

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -305,7 +305,7 @@ static const struct gpio_driver_api api_funcs = {
 		.port_num = n						     \
 	};								     \
 									     \
-	static struct device DEVICE_NAME_GET(gpio_cc32xx_a##n);		     \
+	DEVICE_DECLARE(gpio_cc32xx_a##n);		     \
 	static struct gpio_cc32xx_data gpio_cc32xx_a##n##_data;		     \
 									     \
 	GPIO_CC32XX_INIT_FUNC(n)					     \

--- a/drivers/i2c/i2c_sam_twi.c
+++ b/drivers/i2c/i2c_sam_twi.c
@@ -339,7 +339,7 @@ static const struct i2c_driver_api i2c_sam_twi_driver_api = {
 };
 
 #define I2C_TWI_SAM_INIT(n)						\
-	static struct device DEVICE_NAME_GET(i2c##n##_sam);		\
+	DEVICE_DECLARE(i2c##n##_sam);		\
 									\
 	static void i2c##n##_sam_irq_config(void)			\
 	{								\

--- a/drivers/i2c/i2c_sam_twihs.c
+++ b/drivers/i2c/i2c_sam_twihs.c
@@ -326,7 +326,7 @@ static const struct i2c_driver_api i2c_sam_twihs_driver_api = {
 };
 
 #define I2C_TWIHS_SAM_INIT(n)						\
-	static struct device DEVICE_NAME_GET(i2c##n##_sam);		\
+	DEVICE_DECLARE(i2c##n##_sam);		\
 									\
 	static void i2c##n##_sam_irq_config(void)			\
 	{								\

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -882,7 +882,7 @@ static struct device *get_dev_from_tx_dma_channel(uint32_t dma_channel)
 }
 
 #define I2S_INIT(index, clk_sel)					\
-static struct device DEVICE_NAME_GET(i2s_stm32_##index);		\
+DEVICE_DECLARE(i2s_stm32_##index);		\
 									\
 static void i2s_stm32_irq_config_func_##index(struct device *dev);	\
 									\

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -955,7 +955,7 @@ static const struct i2s_driver_api i2s_sam_driver_api = {
 
 /* I2S0 */
 
-static struct device DEVICE_NAME_GET(i2s0_sam);
+DEVICE_DECLARE(i2s0_sam);
 
 static struct device *get_dev_from_dma_channel(uint32_t dma_channel)
 {

--- a/drivers/ipm/ipm_cavs_idc.c
+++ b/drivers/ipm/ipm_cavs_idc.c
@@ -26,7 +26,7 @@ struct cavs_idc_data {
 	void		*ctx;
 };
 
-static struct device DEVICE_NAME_GET(cavs_idc);
+DEVICE_DECLARE(cavs_idc);
 static struct cavs_idc_data cavs_idc_device_data;
 
 static void cavs_idc_isr(struct device *dev)

--- a/drivers/neural_net/intel_gna.c
+++ b/drivers/neural_net/intel_gna.c
@@ -42,7 +42,7 @@ static void intel_gna_config_desc_dump(struct device *dev);
 
 #define GNA_MODEL_VIRT_BASE_DEFAULT	0
 
-static struct device DEVICE_NAME_GET(gna);
+DEVICE_DECLARE(gna);
 static struct intel_gna_config_desc __aligned(GNA_PG_SIZE_IN_BYTES)
 	gna_config_desc;
 static struct intel_gna_page_table __aligned(GNA_PG_SIZE_IN_BYTES)

--- a/drivers/serial/uart_cc32xx.c
+++ b/drivers/serial/uart_cc32xx.c
@@ -32,7 +32,7 @@ struct uart_cc32xx_dev_data_t {
 #define PRIME_CHAR '\r'
 
 /* Forward decls: */
-static struct device DEVICE_NAME_GET(uart_cc32xx_0);
+DEVICE_DECLARE(uart_cc32xx_0);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void uart_cc32xx_isr(void *arg);

--- a/drivers/serial/uart_msp432p4xx.c
+++ b/drivers/serial/uart_msp432p4xx.c
@@ -33,7 +33,7 @@ struct uart_msp432p4xx_dev_data_t {
 #define DEV_DATA(dev) \
 	((struct uart_msp432p4xx_dev_data_t * const)(dev)->driver_data)
 
-static struct device DEVICE_NAME_GET(uart_msp432p4xx_0);
+DEVICE_DECLARE(uart_msp432p4xx_0);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void uart_msp432p4xx_isr(void *arg);

--- a/drivers/watchdog/wdt_sam.c
+++ b/drivers/watchdog/wdt_sam.c
@@ -34,7 +34,7 @@ struct wdt_sam_dev_cfg {
 	Wdt *regs;
 };
 
-static struct device DEVICE_NAME_GET(wdt_sam);
+DEVICE_DECLARE(wdt_sam);
 
 struct wdt_sam_dev_data {
 	wdt_callback_t cb;

--- a/drivers/watchdog/wdt_sam0.c
+++ b/drivers/watchdog/wdt_sam0.c
@@ -31,7 +31,7 @@ struct wdt_sam0_dev_data {
 	bool timeout_valid;
 };
 
-static struct device DEVICE_NAME_GET(wdt_sam0);
+DEVICE_DECLARE(wdt_sam0);
 
 static struct wdt_sam0_dev_data wdt_sam0_data = { 0 };
 

--- a/include/device.h
+++ b/include/device.h
@@ -27,6 +27,22 @@ extern "C" {
 
 #define Z_DEVICE_MAX_NAME_LEN	48
 
+/**
+ * @def DEVICE_NAME_GET
+ *
+ * @brief Expands to the full name of a global device object
+ *
+ * @details Return the full name of a device object symbol created by
+ * DEVICE_INIT(), using the dev_name provided to DEVICE_INIT().
+ *
+ * It is meant to be used for declaring extern symbols pointing on device
+ * objects before using the DEVICE_GET macro to get the device object.
+ *
+ * @param name The same as dev_name provided to DEVICE_INIT()
+ *
+ * @return The expanded name of the device object created by DEVICE_INIT()
+ */
+#define DEVICE_NAME_GET(name) (_CONCAT(__device_, name))
 
 /**
  * @def SYS_DEVICE_DEFINE
@@ -98,7 +114,7 @@ extern "C" {
 #define DEVICE_AND_API_INIT(dev_name, drv_name, init_fn, data, cfg_info, \
 			    level, prio, api)				\
 	static Z_DECL_ALIGN(struct device)				\
-		_CONCAT(__device_, dev_name) __used			\
+		DEVICE_NAME_GET(dev_name) __used			\
 	__attribute__((__section__(".device_" #level STRINGIFY(prio)))) = { \
 		.name = drv_name,					\
 		.config_info = (cfg_info),				\
@@ -152,7 +168,7 @@ extern "C" {
 			&_CONCAT(__pm_, dev_name).signal),		\
 	};								\
 	static Z_DECL_ALIGN(struct device)				\
-		_CONCAT(__device_, dev_name) __used			\
+		DEVICE_NAME_GET(dev_name) __used			\
 	__attribute__((__section__(".device_" #level STRINGIFY(prio)))) = { \
 		.name = drv_name,					\
 		.config_info = (cfg_info),				\
@@ -165,23 +181,6 @@ extern "C" {
 			    (&_CONCAT(__device_, dev_name)), level, prio)
 
 #endif
-
-/**
- * @def DEVICE_NAME_GET
- *
- * @brief Expands to the full name of a global device object
- *
- * @details Return the full name of a device object symbol created by
- * DEVICE_INIT(), using the dev_name provided to DEVICE_INIT().
- *
- * It is meant to be used for declaring extern symbols pointing on device
- * objects before using the DEVICE_GET macro to get the device object.
- *
- * @param name The same as dev_name provided to DEVICE_INIT()
- *
- * @return The expanded name of the device object created by DEVICE_INIT()
- */
-#define DEVICE_NAME_GET(name) (_CONCAT(__device_, name))
 
 /**
  * @def DEVICE_GET


### PR DESCRIPTION
This PR has two patches (updated) from #25208 to make it easier to locate and possibly transform existing device declarations by using existing helper macros consistently in places where currently the value they expand to is used directly.

Specifically `DEVICE_NAME_GET()` is used rather than prepending `__device_` to the device name, and `DEVICE_DECLARE` is used rather than an explicit declararation.