### PR TITLE
flash: improvements to erase diagnostics

### DIFF
--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -429,6 +429,12 @@ static int spi_flash_at45_erase(struct device *dev, off_t offset, size_t size)
 		return -ENODEV;
 	}
 
+	/* Diagnose region errors before starting to erase. */
+	if (((offset % cfg->page_size) != 0)
+	    || ((size % cfg->page_size) != 0)) {
+		return -EINVAL;
+	}
+
 	acquire(dev);
 
 	if (size == cfg->chip_size) {

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -385,9 +385,19 @@ static int spi_nor_erase(struct device *dev, off_t addr, size_t size)
 	const struct spi_nor_config *params = dev->config_info;
 	int ret = 0;
 
-	/* should be between 0 and flash size */
+	/* erase area must be subregion of device */
 	if ((addr < 0) || ((size + addr) > params->size)) {
 		return -ENODEV;
+	}
+
+	/* address must be sector-aligned */
+	if (!SPI_NOR_IS_SECTOR_ALIGNED(addr)) {
+		return -EINVAL;
+	}
+
+	/* size must be a multiple of sectors */
+	if ((size % SPI_NOR_SECTOR_SIZE) != 0) {
+		return -EINVAL;
 	}
 
 	acquire_device(dev);


### PR DESCRIPTION
The primary goal here is to not start erasing regions when we know we won't successfully complete them, as suggested [here](https://github.com/zephyrproject-rtos/zephyr/pull/25661#discussion_r431770883).

The behavior of the flash API when asked to erase (or write or read) an empty span (`size == 0`) is not specified.  The existing driver behavior was preserved for that case.