### PR TITLE
tests: adding test cases for device abstraction

### DIFF
--- a/tests/kernel/device/src/abstract_driver.c
+++ b/tests/kernel/device/src/abstract_driver.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include <device.h>
+#include "abstract_driver.h"
+
+#define MY_DRIVER_A	"my_driver_A"
+#define MY_DRIVER_B	"my_driver_B"
+
+/* define indivial driver A */
+static int my_driver_A_do_this(struct device *device, int foo, int bar)
+{
+	return foo + bar;
+}
+
+static void my_driver_A_do_that(struct device *device, unsigned int *baz)
+{
+	*baz = 1;
+}
+
+static struct subsystem_api my_driver_A_api_funcs = {
+	.do_this = my_driver_A_do_this,
+	.do_that = my_driver_A_do_that
+};
+
+int common_driver_init(struct device *dev)
+{
+	return 0;
+}
+
+/* define indivial driver B */
+static int my_driver_B_do_this(struct device *device, int foo, int bar)
+{
+	return foo - bar;
+}
+
+static void my_driver_B_do_that(struct device *device, unsigned int *baz)
+{
+	*baz = 2;
+}
+
+static struct subsystem_api my_driver_B_api_funcs = {
+	.do_this = my_driver_B_do_this,
+	.do_that = my_driver_B_do_that
+};
+
+/**
+ * @cond INTERNAL_HIDDEN
+ */
+DEVICE_AND_API_INIT(my_driver_A, MY_DRIVER_A, &common_driver_init, NULL, NULL,
+		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		&my_driver_A_api_funcs);
+
+DEVICE_AND_API_INIT(my_driver_B, MY_DRIVER_B, &common_driver_init, NULL, NULL,
+		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		&my_driver_B_api_funcs);
+
+/**
+ * @endcond
+ */

--- a/tests/kernel/device/src/abstract_driver.h
+++ b/tests/kernel/device/src/abstract_driver.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include <device.h>
+
+/* define subsystem common API for drivers */
+typedef int (*subsystem_do_this_t)(struct device *device, int foo, int bar);
+typedef void (*subsystem_do_that_t)(struct device *device, unsigned int *baz);
+
+struct subsystem_api {
+	subsystem_do_this_t do_this;
+	subsystem_do_that_t do_that;
+};
+
+static inline int subsystem_do_this(struct device *device, int foo, int bar)
+{
+	struct subsystem_api *api;
+
+	api = (struct subsystem_api *)device->driver_api;
+	return api->do_this(device, foo, bar);
+}
+
+static inline void subsystem_do_that(struct device *device, unsigned int *baz)
+{
+	struct subsystem_api *api;
+
+	api = (struct subsystem_api *)device->driver_api;
+	api->do_that(device, baz);
+}

--- a/tests/kernel/device/src/test_driver_init.c
+++ b/tests/kernel/device/src/test_driver_init.c
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <device.h>
+#include <init.h>
+#include <ztest.h>
+
+
+/**
+ * @brief Test cases to device driver initialization
+ *
+ * @ingroup all_tests
+ *
+ * @{
+ */
+
+#define MY_DRIVER_LV_1    "my_driver_level_1"
+#define MY_DRIVER_LV_2    "my_driver_level_2"
+#define MY_DRIVER_LV_3    "my_driver_level_3"
+#define MY_DRIVER_LV_4    "my_driver_level_4"
+#define MY_DRIVER_PRI_1    "my_driver_priority_1"
+#define MY_DRIVER_PRI_2    "my_driver_priority_2"
+#define MY_DRIVER_PRI_3    "my_driver_priority_3"
+#define MY_DRIVER_PRI_4    "my_driver_priority_4"
+
+#define LEVEL_PRE_KERNEL_1	1
+#define LEVEL_PRE_KERNEL_2	2
+#define LEVEL_POST_KERNEL	3
+#define LEVEL_APPLICATION	4
+
+#define PRIORITY_1	1
+#define PRIORITY_2	2
+#define PRIORITY_3	3
+#define PRIORITY_4	4
+
+
+/* this is for storing sequence during initializtion */
+int init_level_sequence[4] = {0};
+int init_priority_sequence[4] = {0};
+unsigned int seq_level_cnt;
+unsigned int seq_priority_cnt;
+
+/* define driver type 1: for testing initialize levels and priorites */
+typedef int (*my_api_configure_t)(struct device *dev, int dev_config);
+
+struct my_driver_api {
+	my_api_configure_t configure;
+};
+
+static int my_configure(struct device *dev, int config)
+{
+	return 0;
+}
+
+static const struct my_driver_api funcs_my_drivers = {
+	.configure = my_configure,
+};
+
+/* driver init function of testing level */
+static int my_driver_lv_1_init(struct device *dev)
+{
+	init_level_sequence[seq_level_cnt] = LEVEL_PRE_KERNEL_1;
+	seq_level_cnt++;
+
+	return 0;
+}
+
+static int my_driver_lv_2_init(struct device *dev)
+{
+	init_level_sequence[seq_level_cnt] = LEVEL_PRE_KERNEL_2;
+	seq_level_cnt++;
+
+	return 0;
+}
+
+static int my_driver_lv_3_init(struct device *dev)
+{
+	init_level_sequence[seq_level_cnt] = LEVEL_POST_KERNEL;
+	seq_level_cnt++;
+
+	return 0;
+}
+
+static int my_driver_lv_4_init(struct device *dev)
+{
+	init_level_sequence[seq_level_cnt] = LEVEL_APPLICATION;
+	seq_level_cnt++;
+
+	return 0;
+}
+
+/* driver init function of testing priority */
+static int my_driver_pri_1_init(struct device *dev)
+{
+	init_priority_sequence[seq_priority_cnt] = PRIORITY_1;
+	seq_priority_cnt++;
+
+	return 0;
+}
+
+static int my_driver_pri_2_init(struct device *dev)
+{
+	init_priority_sequence[seq_priority_cnt] = PRIORITY_2;
+	seq_priority_cnt++;
+
+	return 0;
+}
+
+static int my_driver_pri_3_init(struct device *dev)
+{
+	init_priority_sequence[seq_priority_cnt] = PRIORITY_3;
+	seq_priority_cnt++;
+
+	return 0;
+}
+
+static int my_driver_pri_4_init(struct device *dev)
+{
+	init_priority_sequence[seq_priority_cnt] = PRIORITY_4;
+	seq_priority_cnt++;
+
+	return 0;
+}
+
+/**
+ * @brief Test providing control device driver initialization order
+ *
+ * @details Test that kernel shall provide control over device driver
+ * initalization order, using initialization level and priority for each
+ * instance. We use DEVICE_AND_API_INIT to define device instances and set
+ * it's level and priority here, then we run check function later after
+ * all of this instance finish their initialization.
+ *
+ * @ingroup kernel_device_tests
+ */
+DEVICE_AND_API_INIT(my_driver_level_1, MY_DRIVER_LV_1, &my_driver_lv_1_init,
+		NULL, NULL, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		&funcs_my_drivers);
+
+DEVICE_AND_API_INIT(my_driver_level_2, MY_DRIVER_LV_2, &my_driver_lv_2_init,
+		NULL, NULL, PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		&funcs_my_drivers);
+
+DEVICE_AND_API_INIT(my_driver_level_3, MY_DRIVER_LV_3, &my_driver_lv_3_init,
+		NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		&funcs_my_drivers);
+
+DEVICE_AND_API_INIT(my_driver_level_4, MY_DRIVER_LV_4, &my_driver_lv_4_init,
+		NULL, NULL, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		&funcs_my_drivers);
+
+DEVICE_AND_API_INIT(my_driver_priority_1, MY_DRIVER_PRI_1,
+		&my_driver_pri_1_init, NULL, NULL, POST_KERNEL, 1,
+		&funcs_my_drivers);
+
+DEVICE_AND_API_INIT(my_driver_priority_2, MY_DRIVER_PRI_2,
+		&my_driver_pri_2_init, NULL, NULL, POST_KERNEL, 2,
+		&funcs_my_drivers);
+
+DEVICE_AND_API_INIT(my_driver_priority_3, MY_DRIVER_PRI_3,
+		&my_driver_pri_3_init, NULL, NULL, POST_KERNEL, 3,
+		&funcs_my_drivers);
+
+DEVICE_AND_API_INIT(my_driver_priority_4, MY_DRIVER_PRI_4,
+		&my_driver_pri_4_init, NULL, NULL, POST_KERNEL, 4,
+		&funcs_my_drivers);
+/**
+ * @}
+ */


### PR DESCRIPTION
Add three new test cases of device abstraction for improving current testing. 

1. Test case "test_device_init_level validate" initialize level control by DEVICE_AND_API_INIT().
2. Test case "test_device_init_priority validate" initialize priority control by DEVICE_AND_API_INIT().
3. Test case "test_abstraction_driver_common" validate abstraction of device drivers with common functionalities.

Signed-off-by: Enjia Mai <enjiax.mai@intel.com>