### PR TITLE
cmake: Fixes for shields in multiple roots

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -332,6 +332,7 @@ foreach(root ${BOARD_ROOT})
   # x_nucleo_iks01a1/x_nucleo_iks01a1.overlay;x_nucleo_iks01a2/x_nucleo_iks01a2.overlay
   # we construct a list of shield names by extracting file name and
   # removing the extension.
+  unset(SHIELD_LIST)
   foreach(shield_path ${shields_refs_list})
     get_filename_component(shield ${shield_path} NAME_WE)
     list(APPEND SHIELD_LIST ${shield})


### PR DESCRIPTION
* Initialize SHIELDS_AS_LIST once before looping through
  the roots, to avoid clearing a value if an out of tree
  shield is found first, then the Zephyr root is inspect
  and SHIELDS_AS_LIST is updated again with the now
  empty/different SHIELD content.
* Reset SHIELD_LIST on each root loop, to avoid matching
  on shields from the previous iteration of the loop.

Signed-off-by: Pete Johanson <peter@peterjohanson.com>