### PR TITLE
flash: shell: align test array on 4 bytes

### DIFF
--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -20,7 +20,7 @@
 extern struct device __device_start[];
 extern struct device __device_end[];
 
-static uint8_t test_arr[TEST_ARR_SIZE];
+static uint8_t __aligned(4) test_arr[TEST_ARR_SIZE];
 
 static int parse_helper(const struct shell *shell, size_t *argc,
 		char **argv[], struct device **flash_dev, uint32_t *addr)


### PR DESCRIPTION
Some flash controllers support operations only when buffers are word
aligned. An example of such is nRF QSPI, which checks input buffer using
nrfx_is_word_aligned() function inside nrfx_qspi_write().

Align test array on 4 bytes, so we will gain compatibility with more
flash controllers, including nRF QSPI.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>