### PR TITLE
restore socket descriptor permission management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,9 +495,9 @@ if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)
   set(ZEPHYR_CURRENT_MODULE_DIR)
 endif()
 
-set(syscall_list_h ${CMAKE_CURRENT_BINARY_DIR}/include/generated/syscall_list.h)
-set(syscalls_json  ${CMAKE_CURRENT_BINARY_DIR}/misc/generated/syscalls.json)
-set(subsys_json    ${CMAKE_CURRENT_BINARY_DIR}/misc/generated/subsystems.json)
+set(syscall_list_h   ${CMAKE_CURRENT_BINARY_DIR}/include/generated/syscall_list.h)
+set(syscalls_json    ${CMAKE_CURRENT_BINARY_DIR}/misc/generated/syscalls.json)
+set(struct_tags_json ${CMAKE_CURRENT_BINARY_DIR}/misc/generated/struct_tags.json)
 
 # The syscalls subdirs txt file is constructed by python containing a list of folders to use for
 # dependency handling, including empty folders.
@@ -589,20 +589,20 @@ endforeach()
 add_custom_command(
   OUTPUT
   ${syscalls_json}
-  ${subsys_json}
+  ${struct_tags_json}
   COMMAND
   ${PYTHON_EXECUTABLE}
   ${ZEPHYR_BASE}/scripts/parse_syscalls.py
    --include          ${ZEPHYR_BASE}/include        # Read files from this dir
   ${parse_syscalls_include_args}                    # Read files from these dirs also
   --json-file        ${syscalls_json}               # Write this file
-  --subsystem-file   ${subsys_json}                 # Write subsystem list to this file
+  --tag-struct-file  ${struct_tags_json}            # Write subsystem list to this file
   DEPENDS ${syscalls_subdirs_trigger} ${PARSE_SYSCALLS_HEADER_DEPENDS}
   )
 
 add_custom_target(${SYSCALL_LIST_H_TARGET} DEPENDS             ${syscall_list_h})
 add_custom_target(${PARSE_SYSCALLS_TARGET}
-	          DEPENDS ${syscalls_json} ${subsys_json})
+	          DEPENDS ${syscalls_json} ${struct_tags_json})
 
 # 64-bit systems do not require special handling of 64-bit system call
 # parameters or return values, indicate this to the system call boilerplate
@@ -632,7 +632,7 @@ add_custom_command(OUTPUT include/generated/syscall_dispatch.c ${syscall_list_h}
   )
 
 # This is passed into all calls to the gen_kobject_list.py script.
-set(gen_kobject_list_include_args --include ${subsys_json})
+set(gen_kobject_list_include_args --include ${struct_tags_json})
 
 set(DRV_VALIDATION ${PROJECT_BINARY_DIR}/include/generated/driver-validation.h)
 add_custom_command(
@@ -646,7 +646,7 @@ add_custom_command(
   DEPENDS
   ${ZEPHYR_BASE}/scripts/gen_kobject_list.py
   ${PARSE_SYSCALLS_TARGET}
-  ${subsys_json}
+  ${struct_tags_json}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 add_custom_target(${DRIVER_VALIDATION_H_TARGET} DEPENDS ${DRV_VALIDATION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -594,6 +594,8 @@ add_custom_command(
   ${PYTHON_EXECUTABLE}
   ${ZEPHYR_BASE}/scripts/parse_syscalls.py
    --include          ${ZEPHYR_BASE}/include        # Read files from this dir
+   --include          ${ZEPHYR_BASE}/drivers        # For net sockets
+   --include          ${ZEPHYR_BASE}/subsys/net     # More net sockets
   ${parse_syscalls_include_args}                    # Read files from these dirs also
   --json-file        ${syscalls_json}               # Write this file
   --tag-struct-file  ${struct_tags_json}            # Write subsystem list to this file

--- a/drivers/modem/modem_socket.h
+++ b/drivers/modem/modem_socket.h
@@ -23,7 +23,7 @@
 extern "C" {
 #endif
 
-struct modem_socket {
+__net_socket struct modem_socket {
 	sa_family_t family;
 	enum net_sock_type type;
 	enum net_ip_protocol ip_proto;

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -375,7 +375,7 @@ static inline void *z_impl_k_object_alloc(enum k_objects otype)
  *
  * @param obj
  */
-static inline void k_obj_free(void *obj)
+static inline void k_object_free(void *obj)
 {
 	ARG_UNUSED(obj);
 }

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -353,6 +353,27 @@ __syscall void *k_object_alloc(enum k_objects otype);
 
 #ifdef CONFIG_DYNAMIC_OBJECTS
 /**
+ * Allocate memory and install as a generic kernel object
+ *
+ * This is a low-level function to allocate some memory, and register that
+ * allocated memory in the kernel object lookup tables with type K_OBJ_ANY.
+ * Initialization state and thread permissions will be cleared. The
+ * returned z_object's data value will be uninitialized.
+ *
+ * Most users will want to use k_object_alloc() instead.
+ *
+ * Memory allocated will be drawn from the calling thread's reasource pool
+ * and may be freed later by passing the actual object pointer (found
+ * in the returned z_object's 'name' member) to k_object_free().
+ *
+ * @param size Size of the allocated object
+ * @return NULL on insufficient memory
+ * @return A pointer to the associated z_object that is installed in the
+ *	kernel object tables
+ */
+struct z_object *z_dynamic_object_create(size_t size);
+
+/**
  * Free a kernel object previously allocated with k_object_alloc()
  *
  * This will return memory for a kernel object back to resource pool it was
@@ -370,6 +391,14 @@ static inline void *z_impl_k_object_alloc(enum k_objects otype)
 
 	return NULL;
 }
+
+static inline struct z_object *z_dynamic_object_create(size_t size)
+{
+	ARG_UNUSED(size);
+
+	return NULL;
+}
+
 /**
  * @brief Free an object
  *

--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -196,7 +196,7 @@ struct tls_context;
  * If there is no such source address there, the packet cannot be sent
  * anyway. This saves 12 bytes / context in IPv6.
  */
-struct net_context {
+__net_socket struct net_context {
 	/** User data.
 	 *
 	 *  First member of the structure to let users either have user data

--- a/include/syscall_handler.h
+++ b/include/syscall_handler.h
@@ -26,6 +26,38 @@ enum _obj_init_check {
 };
 
 /**
+ * Return true if we are currently handling a system call from user mode
+ *
+ * Inside z_vrfy functions, we always know that we are handling
+ * a system call invoked from user context.
+ *
+ * However, some checks that are only relevant to user mode must
+ * instead be placed deeper within the implementation. This
+ * API is useful to conditionally make these checks.
+ *
+ * For performance reasons, whenever possible, checks should be placed
+ * in the relevant z_vrfy function since these are completely skipped
+ * when a syscall is invoked.
+ *
+ * This will return true only if we are handling a syscall for a
+ * user thread. If the system call was invoked from supervisor mode,
+ * or we are not handling a system call, this will return false.
+ *
+ * @return whether the current context is handling a syscall for a user
+ *         mode thread
+ */
+static inline bool z_is_in_user_syscall(void)
+{
+	/* This gets set on entry to the syscall's generasted z_mrsh
+	 * function and then cleared on exit. This code path is only
+	 * encountered when a syscall is made from user mode, system
+	 * calls from supervisor mode bypass everything directly to
+	 * the implementation function.
+	 */
+	return !k_is_in_isr() && _current->syscall_frame != NULL;
+}
+
+/**
  * Ensure a system object is a valid object of the expected type
  *
  * Searches for the object and ensures that it is indeed an object

--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -132,10 +132,16 @@
 #define __syscall
 #endif /* #ifndef ZTEST_UNITTEST */
 
-/* Used as a sentinel by parse_syscalls.py to identify what API structs
- * define driver subsystems.
+/* Definitions for struct declaration tags. These are sentinel values used by
+ * parse_syscalls.py to gather a list of names of struct declarations that
+ * have these tags applied for them.
  */
+
+/* Indicates this is a driver subsystem */
 #define __subsystem
+
+/* Indicates this is a network socket object */
+#define __net_socket
 
 #ifndef BUILD_ASSERT
 /* Compile-time assertion that makes the build to fail.

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -466,6 +466,7 @@ void z_setup_new_thread(struct k_thread *new_thread,
 	z_object_init(stack);
 	new_thread->stack_obj = stack;
 	new_thread->mem_domain_info.mem_domain = NULL;
+	new_thread->syscall_frame = NULL;
 
 	/* Any given thread has access to itself */
 	k_object_access_grant(new_thread, new_thread);

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -785,7 +785,7 @@ static uintptr_t handler_bad_syscall(uintptr_t bad_id, uintptr_t arg2,
 				     void *ssf)
 {
 	LOG_ERR("Bad system call id %" PRIuPTR " invoked", bad_id);
-	arch_syscall_oops(_current->syscall_frame);
+	arch_syscall_oops(ssf);
 	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
 }
 
@@ -794,7 +794,7 @@ static uintptr_t handler_no_syscall(uintptr_t arg1, uintptr_t arg2,
 				    uintptr_t arg5, uintptr_t arg6, void *ssf)
 {
 	LOG_ERR("Unimplemented system call");
-	arch_syscall_oops(_current->syscall_frame);
+	arch_syscall_oops(ssf);
 	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
 }
 

--- a/kernel/userspace_handler.c
+++ b/kernel/userspace_handler.c
@@ -62,10 +62,6 @@ static inline void z_vrfy_k_object_release(void *object)
 
 static inline void *z_vrfy_k_object_alloc(enum k_objects otype)
 {
-	Z_OOPS(Z_SYSCALL_VERIFY_MSG(otype > K_OBJ_ANY && otype < K_OBJ_LAST &&
-				    otype != K_OBJ_THREAD_STACK_ELEMENT,
-				    "bad object type %d requested", otype));
-
 	return z_impl_k_object_alloc(otype);
 }
 #include <syscalls/k_object_alloc_mrsh.c>

--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -18,6 +18,7 @@
 #include <kernel.h>
 #include <sys/fdtable.h>
 #include <sys/speculation.h>
+#include <syscall_handler.h>
 
 struct fd_entry {
 	void *obj;
@@ -132,6 +133,16 @@ int z_reserve_fd(void)
 void z_finalize_fd(int fd, void *obj, const struct fd_op_vtable *vtable)
 {
 	/* Assumes fd was already bounds-checked. */
+#ifdef CONFIG_USERSPACE
+	/* descriptor context objects are inserted into the table when they
+	 * are ready for use. Mark the object as initialized and grant the
+	 * caller (and only the caller) access.
+	 *
+	 * This call is a no-op if obj is invalid or points to something
+	 * not a kernel object.
+	 */
+	z_object_recycle(obj);
+#endif
 	fdtable[fd].obj = obj;
 	fdtable[fd].vtable = vtable;
 }

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -918,7 +918,7 @@ def write_kobj_size_output(fp):
 def parse_subsystems_list_file(path):
     with open(path, "r") as fp:
         subsys_list = json.load(fp)
-    subsystems.extend(subsys_list)
+    subsystems.extend(subsys_list["__subsystem"])
 
 def parse_args():
     global args

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -80,6 +80,10 @@ from collections import OrderedDict
 #
 #  - The third items is a boolean indicating whether this item can be
 #    dynamically allocated with k_object_alloc()
+#
+# Key names in all caps do not correspond to a specific data type but instead
+# indicate that objects of its type are of a family of compatible data
+# structures
 
 # Regular dictionaries are ordered only with Python 3.6 and
 # above. Good summary and pointers to official documents at:
@@ -97,6 +101,7 @@ kobjects = OrderedDict([
     ("k_timer", (None, False, True)),
     ("z_thread_stack_element", (None, False, False)),
     ("device", (None, False, False)),
+    ("NET_SOCKET", (None, False, False)),
     ("sys_mutex", (None, True, False)),
     ("k_futex", (None, True, False))
 ])
@@ -117,6 +122,9 @@ subsystems = [
     #    ....
     #};
 ]
+
+# Names of all structs tagged with __net_socket, found by parse_syscalls.py
+net_sockets = [ ]
 
 def subsystem_to_enum(subsys):
     return "K_OBJ_DRIVER_" + subsys[:-11].upper()
@@ -402,6 +410,8 @@ def analyze_die_struct(die):
         type_env[offset] = KobjectType(offset, name, size)
     elif name in subsystems:
         type_env[offset] = KobjectType(offset, name, size, api=True)
+    elif name in net_sockets:
+        type_env[offset] = KobjectType(offset, "NET_SOCKET", size)
     else:
         at = AggregateType(offset, name, size)
         type_env[offset] = at
@@ -919,6 +929,7 @@ def parse_subsystems_list_file(path):
     with open(path, "r") as fp:
         subsys_list = json.load(fp)
     subsystems.extend(subsys_list["__subsystem"])
+    net_sockets.extend(subsys_list["__net_socket"])
 
 def parse_args():
     global args

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -79,7 +79,8 @@ from collections import OrderedDict
 #    the object to be located in user-accessible memory.
 #
 #  - The third items is a boolean indicating whether this item can be
-#    dynamically allocated with k_object_alloc()
+#    dynamically allocated with k_object_alloc(). Keep this in sync with
+#    the switch statement in z_impl_k_object_alloc().
 #
 # Key names in all caps do not correspond to a specific data type but instead
 # indicate that objects of its type are of a family of compatible data

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -77,25 +77,28 @@ from collections import OrderedDict
 #
 #  - The second item is a boolean indicating whether it is permissible for
 #    the object to be located in user-accessible memory.
+#
+#  - The third items is a boolean indicating whether this item can be
+#    dynamically allocated with k_object_alloc()
 
 # Regular dictionaries are ordered only with Python 3.6 and
 # above. Good summary and pointers to official documents at:
 # https://stackoverflow.com/questions/39980323/are-dictionaries-ordered-in-python-3-6
 kobjects = OrderedDict([
-    ("k_mem_slab", (None, False)),
-    ("k_msgq", (None, False)),
-    ("k_mutex", (None, False)),
-    ("k_pipe", (None, False)),
-    ("k_queue", (None, False)),
-    ("k_poll_signal", (None, False)),
-    ("k_sem", (None, False)),
-    ("k_stack", (None, False)),
-    ("k_thread", (None, False)),
-    ("k_timer", (None, False)),
-    ("z_thread_stack_element", (None, False)),
-    ("device", (None, False)),
-    ("sys_mutex", (None, True)),
-    ("k_futex", (None, True))
+    ("k_mem_slab", (None, False, True)),
+    ("k_msgq", (None, False, True)),
+    ("k_mutex", (None, False, True)),
+    ("k_pipe", (None, False, True)),
+    ("k_queue", (None, False, True)),
+    ("k_poll_signal", (None, False, True)),
+    ("k_sem", (None, False, True)),
+    ("k_stack", (None, False, True)),
+    ("k_thread", (None, False, True)), # But see #
+    ("k_timer", (None, False, True)),
+    ("z_thread_stack_element", (None, False, False)),
+    ("device", (None, False, False)),
+    ("sys_mutex", (None, True, False)),
+    ("k_futex", (None, True, False))
 ])
 
 def kobject_to_enum(kobj):
@@ -609,7 +612,7 @@ def find_kobjects(elf, syms):
         if ko.type_obj.api:
             continue
 
-        _, user_ram_allowed = kobjects[ko.type_obj.name]
+        _, user_ram_allowed, _ = kobjects[ko.type_obj.name]
         if not user_ram_allowed and app_smem_start <= addr < app_smem_end:
             debug("object '%s' found in invalid location %s"
                   % (ko.type_obj.name, hex(addr)))
@@ -853,7 +856,7 @@ def write_validation_output(fp):
 def write_kobj_types_output(fp):
     fp.write("/* Core kernel objects */\n")
     for kobj, obj_info in kobjects.items():
-        dep, _ = obj_info
+        dep, _, _ = obj_info
         if kobj == "device":
             continue
 
@@ -874,7 +877,7 @@ def write_kobj_types_output(fp):
 def write_kobj_otype_output(fp):
     fp.write("/* Core kernel objects */\n")
     for kobj, obj_info in kobjects.items():
-        dep, _ = obj_info
+        dep, _, _ = obj_info
         if kobj == "device":
             continue
 
@@ -898,10 +901,9 @@ def write_kobj_otype_output(fp):
 def write_kobj_size_output(fp):
     fp.write("/* Non device/stack objects */\n")
     for kobj, obj_info in kobjects.items():
-        dep, _ = obj_info
-        # device handled by default case. Stacks are not currently handled,
-        # if they eventually are it will be a special case.
-        if kobj in {"device", STACK_TYPE}:
+        dep, _, alloc = obj_info
+
+        if not alloc:
             continue
 
         if dep:

--- a/scripts/gen_syscalls.py
+++ b/scripts/gen_syscalls.py
@@ -284,15 +284,19 @@ def marshall_defs(func_name, func_type, args):
 
     if func_type == "void":
         mrsh += "\t" + "%s;\n" % vrfy_call
+        mrsh += "\t" + "_current->syscall_frame = NULL;\n"
         mrsh += "\t" + "return 0;\n"
     else:
         mrsh += "\t" + "%s ret = %s;\n" % (func_type, vrfy_call)
+
         if need_split(func_type):
             ptr = "((u64_t *)%s)" % mrsh_rval(nmrsh - 1, nmrsh)
             mrsh += "\t" + "Z_OOPS(Z_SYSCALL_MEMORY_WRITE(%s, 8));\n" % ptr
             mrsh += "\t" + "*%s = ret;\n" % ptr
+            mrsh += "\t" + "_current->syscall_frame = NULL;\n"
             mrsh += "\t" + "return 0;\n"
         else:
+            mrsh += "\t" + "_current->syscall_frame = NULL;\n"
             mrsh += "\t" + "return (uintptr_t) ret;\n"
 
     mrsh += "}\n"

--- a/scripts/parse_syscalls.py
+++ b/scripts/parse_syscalls.py
@@ -40,7 +40,7 @@ __syscall\s+                    # __syscall attribute, must be first
 [)]                             # Closing parenthesis
 ''', regex_flags)
 
-struct_tags = ["__subsystem"]
+struct_tags = ["__subsystem", "__net_socket"]
 
 tagged_struct_decl_template = r'''
 %s\s+                           # tag, must be first

--- a/scripts/parse_syscalls.py
+++ b/scripts/parse_syscalls.py
@@ -10,9 +10,13 @@ Script to scan Zephyr include directories and emit system call and subsystem met
 System calls require a great deal of boilerplate code in order to implement
 completely. This script is the first step in the build system's process of
 auto-generating this code by doing a text scan of directories containing
-header files, and building up a database of system calls and their
+C or header files, and building up a database of system calls and their
 function call prototypes. This information is emitted to a generated
 JSON file for further processing.
+
+This script also scans for struct definitions such as __subsystem and
+__net_socket, emitting a JSON dictionary mapping tags to all the struct
+declarations found that were tagged with them.
 
 If the output JSON file already exists, its contents are checked against
 what information this script would have outputted; if the result is that the
@@ -26,24 +30,37 @@ import argparse
 import os
 import json
 
+regex_flags = re.MULTILINE | re.VERBOSE
+
 syscall_regex = re.compile(r'''
 __syscall\s+                    # __syscall attribute, must be first
 ([^(]+)                         # type and name of system call (split later)
 [(]                             # Function opening parenthesis
 ([^)]*)                         # Arg list (split later)
 [)]                             # Closing parenthesis
-''', re.MULTILINE | re.VERBOSE)
+''', regex_flags)
 
-subsys_regex = re.compile(r'''
-__subsystem\s+                  # __subsystem attribute, must be first
+struct_tags = ["__subsystem"]
+
+tagged_struct_decl_template = r'''
+%s\s+                           # tag, must be first
 struct\s+                       # struct keyword is next
 ([^{]+)                         # name of subsystem
 [{]                             # Open curly bracket
-''', re.MULTILINE | re.VERBOSE)
+'''
+
+def tagged_struct_update(target_list, tag, contents):
+    regex = re.compile(tagged_struct_decl_template % tag, regex_flags)
+    items = [mo.groups()[0].strip() for mo in regex.finditer(contents)]
+    target_list.extend(items)
+
 
 def analyze_headers(multiple_directories):
     syscall_ret = []
-    subsys_ret = []
+    tagged_ret = {}
+
+    for tag in struct_tags:
+        tagged_ret[tag] = []
 
     for base_path in multiple_directories:
         for root, dirs, files in os.walk(base_path, topdown=True):
@@ -51,10 +68,12 @@ def analyze_headers(multiple_directories):
             files.sort()
             for fn in files:
 
-                # toolchain/common.h has the definitions of __syscall and __subsystem which we
+                # toolchain/common.h has the definitions of these tagswhich we
                 # don't want to trip over
                 path = os.path.join(root, fn)
-                if not fn.endswith(".h") or path.endswith(os.path.join(os.sep, 'toolchain', 'common.h')):
+                if (not (path.endswith(".h") or path.endswith(".c")) or
+                        path.endswith(os.path.join(os.sep, 'toolchain',
+                                                   'common.h'))):
                     continue
 
                 with open(path, "r", encoding="utf-8") as fp:
@@ -63,16 +82,15 @@ def analyze_headers(multiple_directories):
                 try:
                     syscall_result = [(mo.groups(), fn)
                                       for mo in syscall_regex.finditer(contents)]
-                    subsys_result = [mo.groups()[0].strip()
-                                     for mo in subsys_regex.finditer(contents)]
+                    for tag in struct_tags:
+                        tagged_struct_update(tagged_ret[tag], tag, contents)
                 except Exception:
                     sys.stderr.write("While parsing %s\n" % fn)
                     raise
 
                 syscall_ret.extend(syscall_result)
-                subsys_ret.extend(subsys_result)
 
-    return syscall_ret, subsys_ret
+    return syscall_ret, tagged_ret
 
 
 def update_file_if_changed(path, new):
@@ -102,18 +120,19 @@ def parse_args():
         "-j", "--json-file", required=True,
         help="Write system call prototype information as json to file")
     parser.add_argument(
-        "-s", "--subsystem-file", required=True,
-        help="Write subsystem name information as json to file")
+        "-t", "--tag-struct-file", required=True,
+        help="Write tagged struct name information as json to file")
+
     args = parser.parse_args()
 
 
 def main():
     parse_args()
 
-    syscalls, subsys = analyze_headers(args.include)
+    syscalls, tagged = analyze_headers(args.include)
 
     # Only write json files if they don't exist or have changes since
-    # they will force and incremental rebuild.
+    # they will force an incremental rebuild.
 
     syscalls_in_json = json.dumps(
         syscalls,
@@ -122,12 +141,12 @@ def main():
     )
     update_file_if_changed(args.json_file, syscalls_in_json)
 
-    subsys_in_json = json.dumps(
-        subsys,
+    tagged_struct_in_json = json.dumps(
+        tagged,
         indent=4,
         sort_keys=True
     )
-    update_file_if_changed(args.subsystem_file, subsys_in_json)
+    update_file_if_changed(args.tag_struct_file, tagged_struct_in_json)
 
 
 if __name__ == "__main__":

--- a/subsys/net/lib/sockets/socketpair.c
+++ b/subsys/net/lib/sockets/socketpair.c
@@ -48,7 +48,7 @@ enum {
  * - write operations may block if the remote @a recv_q is full
  * - each endpoint may be blocking or non-blocking
  */
-struct spair {
+__net_socket struct spair {
 	int remote; /**< the remote endpoint file descriptor */
 	u32_t flags; /**< status and option bits */
 	struct k_sem sem; /**< semaphore for exclusive structure access */

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -49,6 +49,23 @@ static inline void *get_sock_vtable(
 				       (const struct fd_op_vtable **)vtable);
 }
 
+void *z_impl_zsock_get_context_object(int sock)
+{
+	const struct socket_op_vtable *ignored;
+
+	return get_sock_vtable(sock, &ignored);
+}
+
+#ifdef CONFIG_USERSPACE
+void *z_vrfy_zsock_get_context_object(int sock)
+{
+	/* All checking done in implementation */
+	return z_impl_zsock_get_context_object(sock);
+}
+
+#include <syscalls/zsock_get_context_object_mrsh.c>
+#endif
+
 static void zsock_received_cb(struct net_context *ctx,
 			      struct net_pkt *pkt,
 			      union net_ip_header *ip_hdr,

--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -71,13 +71,6 @@ int zcan_socket(int family, int type, int proto)
 
 	k_fifo_init(&ctx->recv_q);
 
-#ifdef CONFIG_USERSPACE
-	/* Set net context object as initialized and grant access to the
-	 * calling thread (and only the calling thread)
-	 */
-	z_object_recycle(ctx);
-#endif
-
 	z_finalize_fd(fd, ctx,
 		      (const struct fd_op_vtable *)&can_sock_fd_op_vtable);
 

--- a/subsys/net/lib/sockets/sockets_net_mgmt.c
+++ b/subsys/net/lib/sockets/sockets_net_mgmt.c
@@ -23,7 +23,7 @@ LOG_MODULE_REGISTER(net_sock_mgmt, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 #define MSG_ALLOC_TIMEOUT K_MSEC(100)
 
-struct net_mgmt_socket {
+__net_socket struct net_mgmt_socket {
 	/* Network interface related to this socket */
 	struct net_if *iface;
 

--- a/subsys/net/lib/sockets/sockets_net_mgmt.c
+++ b/subsys/net/lib/sockets/sockets_net_mgmt.c
@@ -80,13 +80,6 @@ int znet_mgmt_socket(int family, int type, int proto)
 	mgmt->alloc_timeout = MSG_ALLOC_TIMEOUT;
 	mgmt->wait_timeout = K_FOREVER;
 
-#if defined(CONFIG_USERSPACE)
-	/* Set net context object as initialized and grant access to the
-	 * calling thread (and only the calling thread)
-	 */
-	z_object_recycle(mgmt);
-#endif
-
 	z_finalize_fd(fd, mgmt,
 		     (const struct fd_op_vtable *)&net_mgmt_sock_fd_op_vtable);
 

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -68,14 +68,6 @@ static int zpacket_socket(int family, int type, int proto)
 
 	/* recv_q and accept_q are in union */
 	k_fifo_init(&ctx->recv_q);
-
-#ifdef CONFIG_USERSPACE
-	/* Set net context object as initialized and grant access to the
-	 * calling thread (and only the calling thread)
-	 */
-	z_object_recycle(ctx);
-#endif
-
 	z_finalize_fd(fd, ctx,
 		      (const struct fd_op_vtable *)&packet_sock_fd_op_vtable);
 

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1159,13 +1159,6 @@ static int ztls_socket(int family, int type, int proto)
 	/* recv_q and accept_q are in union */
 	k_fifo_init(&ctx->recv_q);
 
-#ifdef CONFIG_USERSPACE
-	/* Set net context object as initialized and grant access to the
-	 * calling thread (and only the calling thread)
-	 */
-	z_object_recycle(ctx);
-#endif
-
 	if (tls_proto != 0) {
 		/* If TLS protocol is used, allocate TLS context */
 		ctx->tls = tls_alloc();
@@ -1284,10 +1277,6 @@ int ztls_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 	}
 
 	child = k_fifo_get(&parent->accept_q, K_FOREVER);
-
-	#ifdef CONFIG_USERSPACE
-		z_object_recycle(child);
-	#endif
 
 	if (addr != NULL && addrlen != NULL) {
 		int len = MIN(*addrlen, sizeof(child->remote));

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -364,14 +364,6 @@ int websocket_connect(int sock, struct websocket_request *wreq,
 	}
 
 	ctx->sock = fd;
-
-#ifdef CONFIG_USERSPACE
-	/* Set net context object as initialized and grant access to the
-	 * calling thread (and only the calling thread)
-	 */
-	z_object_recycle(ctx);
-#endif
-
 	z_finalize_fd(fd, ctx,
 		      (const struct fd_op_vtable *)&websocket_fd_op_vtable);
 

--- a/subsys/net/lib/websocket/websocket_internal.h
+++ b/subsys/net/lib/websocket/websocket_internal.h
@@ -10,6 +10,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <toolchain/common.h>
+
 #define WS_SHA1_OUTPUT_LEN 20
 
 /* Min Websocket header length */
@@ -24,7 +26,7 @@
 /**
  * Websocket connection information
  */
-struct websocket_context {
+__net_socket struct websocket_context {
 	union {
 		/** User data.
 		 */

--- a/tests/kernel/mem_protect/syscalls/src/test_syscalls.h
+++ b/tests/kernel/mem_protect/syscalls/src/test_syscalls.h
@@ -21,6 +21,8 @@ __syscall int syscall_arg64(u64_t arg);
 __syscall u64_t syscall_arg64_big(u32_t arg1, u32_t arg2, u64_t arg3,
 				  u32_t arg4, u32_t arg5, u64_t arg6);
 
+__syscall bool syscall_context(void);
+
 #include <syscalls/test_syscalls.h>
 
 #endif /* _TEST_SYSCALLS_H_ */

--- a/tests/net/socket/net_mgmt/src/main.c
+++ b/tests/net/socket/net_mgmt/src/main.c
@@ -350,6 +350,16 @@ static void test_net_mgmt_setup(void)
 	fd = socket(AF_NET_MGMT, SOCK_DGRAM, NET_MGMT_EVENT_PROTO);
 	zassert_false(fd < 0, "Cannot create net_mgmt socket (%d)", errno);
 
+#ifdef CONFIG_USERSPACE
+	/* Set the underlying net_context to global access scope so that
+	 * other scenario threads may use it
+	 */
+	void *ctx = zsock_get_context_object(fd);
+
+	zassert_not_null(ctx, "null net_context");
+	k_object_access_all_grant(ctx);
+#endif /* CONFIG_USERSPACE */
+
 	memset(&sockaddr, 0, sizeof(sockaddr));
 
 	sockaddr.nm_family = AF_NET_MGMT;

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -446,8 +446,73 @@ void test_v4_accept_timeout(void)
 	k_sleep(TCP_TEARDOWN_TIMEOUT);
 }
 
+#ifdef CONFIG_USERSPACE
+#define CHILD_STACK_SZ		(2048 + CONFIG_TEST_EXTRA_STACKSIZE)
+struct k_thread child_thread;
+K_THREAD_STACK_DEFINE(child_stack, CHILD_STACK_SZ);
+ZTEST_BMEM volatile int result;
+
+static void child_entry(void *p1, void *p2, void *p3)
+{
+	int sock = (int)p1;
+
+	result = close(sock);
+}
+
+static void spawn_child(int sock)
+{
+	k_thread_create(&child_thread, child_stack,
+			K_THREAD_STACK_SIZEOF(child_stack), child_entry,
+			(void *)sock, NULL, NULL, 0, K_USER,
+			K_FOREVER);
+}
+#endif
+
+void test_socket_permission(void)
+{
+#ifdef CONFIG_USERSPACE
+	int sock;
+	struct sockaddr_in saddr;
+	struct net_context *ctx;
+
+	prepare_sock_tcp_v4(CONFIG_NET_CONFIG_MY_IPV4_ADDR, ANY_PORT,
+			    &sock, &saddr);
+
+	ctx = zsock_get_context_object(sock);
+	zassert_not_null(ctx, "zsock_get_context_object() failed");
+
+	/* Spawn a child thread which doesn't inherit our permissions,
+	 * it will try to perform a socket operation and fail due to lack
+	 * of permissions on it.
+	 */
+	spawn_child(sock);
+	k_thread_start(&child_thread);
+	k_thread_join(&child_thread, K_FOREVER);
+
+	zassert_not_equal(result, 0, "child succeeded with no permission");
+
+	/* Now spawn the same child thread again, but this time we grant
+	 * permission on the net_context before we start it, and the
+	 * child should now succeed.
+	 */
+	spawn_child(sock);
+	k_object_access_grant(ctx, &child_thread);
+	k_thread_start(&child_thread);
+	k_thread_join(&child_thread, K_FOREVER);
+
+	zassert_equal(result, 0, "child failed with permissions");
+#else
+	ztest_test_skip();
+#endif /* CONFIG_USERSPACE */
+}
+
 void test_main(void)
 {
+#ifdef CONFIG_USERSPACE
+	/* ztest thread inherit permissions from main */
+	k_thread_access_grant(k_current_get(), &child_thread, child_stack);
+#endif
+
 	ztest_test_suite(
 		socket_tcp,
 		ztest_user_unit_test(test_v4_send_recv),
@@ -457,7 +522,9 @@ void test_main(void)
 		ztest_user_unit_test(test_v4_sendto_recvfrom_null_dest),
 		ztest_user_unit_test(test_v6_sendto_recvfrom_null_dest),
 		ztest_unit_test(test_open_close_immediately),
-		ztest_user_unit_test(test_v4_accept_timeout));
+		ztest_user_unit_test(test_v4_accept_timeout),
+		ztest_user_unit_test(test_socket_permission)
+		);
 
 	ztest_run_test_suite(socket_tcp);
 }


### PR DESCRIPTION
A change made to the socket system calls to use actual file descriptors (instead of `struct net_context` stuffed into an integer) unintentionally lost the ability to manage per-thread permissions of file descriptors, which is needed in MPU-based user mode memory models (currently all arches that implement user mode in Zephyr).

This PR:

- Adds an API `z_is_in_user_syscall()` so that system call verification checks may be done deep within implementation functions if those checks are only relevant to syscalls originating from user mode.
- All network context object types which have `__net_socket` in their declaration will have their instances tracked as kernel objects with type `K_OBJ_NET_SOCKET`
- Socket APIs once again check for object permissions after the object is retrieved from file descriptor tables. This check only applies if the system call originated from user mode.
- Add a custom API that, given a file descriptor, returns a pointer to the associated `struct net_context` so that APIs like `k_object_access_grant()` may be used.
- Add tests for new APIs, and show that permission management is working as expected across user threads.
- Add some infrastructure for registering `K_OBJ_NET_SOCKET` objects dynamically, needed by the `socketpair` implementation (which pulls data from a heap instead of a pool like other socket types).

Please review individual commit messages for more information.

Process-based virtual memory is coming to Zephyr for systems with an MMU later this year. In the fullness of time, we can adopt file descriptors that have process-level scope (instead of global scope), removing the need for this management on those types of systems. We will likely continue to need this infrastructure indefinitely for MPU-based systems, but it is the same permission model we already use for all kernel objects and device driver instances.