### PR TITLE
tests: dlist add and modify some testcases

### DIFF
--- a/tests/unit/list/main.c
+++ b/tests/unit/list/main.c
@@ -9,11 +9,13 @@
 extern void test_slist(void);
 extern void test_sflist(void);
 extern void test_dlist(void);
+extern void test_check_dlist_perf(void);
 
 void test_main(void)
 {
 	ztest_test_suite(dlist,
 			 ztest_unit_test(test_dlist),
+			 ztest_unit_test(test_check_dlist_perf),
 			 ztest_unit_test(test_slist),
 			 ztest_unit_test(test_sflist)
 			 );


### PR DESCRIPTION
1. Add a new testcase: test_check_dlist_perf()
Test that some operations(i.e. peek head, peek tail, insert and remove) should be running in a constant time. 
Set a double list, and insert regularly item data into it, then record respectively the time spent by  one operations of above in order to verify it runs in a constant time. And add new informative Doxygen tags to describe it.

Signed-off-by: Ningx Zhao <ningx.zhao@intel.com>