### PR TITLE
make find_package(Zephyr...) REQUIRED

### DIFF
--- a/cmake/boards.cmake
+++ b/cmake/boards.cmake
@@ -101,7 +101,7 @@ if(CMAKE_SCRIPT_MODE_FILE AND NOT CMAKE_PARENT_LIST_FILE)
 cmake_minimum_required(VERSION 3.13.1)
 
 set(NO_BOILERPLATE TRUE)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 # Appending Zephyr base to list of board roots, as this is also done in boilerplate.cmake.
 # But as this file was executed in script mode, it must also be done here, to give same output.

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.13.1)
 project(Zephyr-Kernel-Doc LANGUAGES)
 
 set(NO_BOILERPLATE TRUE)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE} ..)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} ..)
 
 # Find west to (optionally) process modules for Kconfig
 find_program(

--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -1136,7 +1136,7 @@ Make sure to follow these steps in order.
       find_package(Zephyr)
       project(my_zephyr_app)
 
-   .. note:: ``find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})`` can be used if
+   .. note:: ``find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})`` can be used if
              enforcing a specific Zephyr installation by explicitly
              setting the ``ZEPHYR_BASE`` environment variable should be
              supported. All samples in Zephyr supports the ``ZEPHYR_BASE``

--- a/doc/guides/zephyr_cmake_package.rst
+++ b/doc/guides/zephyr_cmake_package.rst
@@ -152,7 +152,7 @@ To do this, use the following ``find_package()`` syntax:
 
 .. code-block:: cmake
 
-   find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+   find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 This syntax instructs CMake to first search for Zephyr using the Zephyr base environment setting
 :envvar:`ZEPHYR_BASE` and then use the normal search paths.

--- a/samples/application_development/code_relocation/CMakeLists.txt
+++ b/samples/application_development/code_relocation/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(test_relocation)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/application_development/external_lib/CMakeLists.txt
+++ b/samples/application_development/external_lib/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(external_lib)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/application_development/out_of_tree_board/CMakeLists.txt
+++ b/samples/application_development/out_of_tree_board/CMakeLists.txt
@@ -10,7 +10,7 @@ set(BOARD_ROOT ${CMAKE_CURRENT_LIST_DIR})
 # this board.
 set(BOARD nrf52840dk_nrf52840)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(out_of_tree_board)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/application_development/out_of_tree_driver/CMakeLists.txt
+++ b/samples/application_development/out_of_tree_driver/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.13.1)
 # be able to find the module's syscalls.
 list(APPEND SYSCALL_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/hello_world_module/zephyr)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 target_sources(app PRIVATE

--- a/samples/basic/blinky/CMakeLists.txt
+++ b/samples/basic/blinky/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(blinky)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/basic/blinky_pwm/CMakeLists.txt
+++ b/samples/basic/blinky_pwm/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(blink_led)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/basic/button/CMakeLists.txt
+++ b/samples/basic/button/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(button)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/basic/fade_led/CMakeLists.txt
+++ b/samples/basic/fade_led/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fade_led)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/basic/minimal/CMakeLists.txt
+++ b/samples/basic/minimal/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(minimal)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/basic/rgb_led/CMakeLists.txt
+++ b/samples/basic/rgb_led/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(rgb_led)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/basic/servo_motor/CMakeLists.txt
+++ b/samples/basic/servo_motor/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(servo_motor)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/basic/threads/CMakeLists.txt
+++ b/samples/basic/threads/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(threads)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/beacon/CMakeLists.txt
+++ b/samples/bluetooth/beacon/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(beacon)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/central/CMakeLists.txt
+++ b/samples/bluetooth/central/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(central)
 
 target_sources(app PRIVATE

--- a/samples/bluetooth/central_hr/CMakeLists.txt
+++ b/samples/bluetooth/central_hr/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(central_hr)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/bluetooth/eddystone/CMakeLists.txt
+++ b/samples/bluetooth/eddystone/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(eddystone)
 
 target_sources(app PRIVATE

--- a/samples/bluetooth/handsfree/CMakeLists.txt
+++ b/samples/bluetooth/handsfree/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(handsfree)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/bluetooth/hci_pwr_ctrl/CMakeLists.txt
+++ b/samples/bluetooth/hci_pwr_ctrl/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hci_pwr_ctrl)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/hci_rpmsg/CMakeLists.txt
+++ b/samples/bluetooth/hci_rpmsg/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hci_rpmsg)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/hci_spi/CMakeLists.txt
+++ b/samples/bluetooth/hci_spi/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hci_spi)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/bluetooth/hci_uart/CMakeLists.txt
+++ b/samples/bluetooth/hci_uart/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hci_uart)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/hci_usb/CMakeLists.txt
+++ b/samples/bluetooth/hci_usb/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hci_usb)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/ibeacon/CMakeLists.txt
+++ b/samples/bluetooth/ibeacon/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ibeacon)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/ipsp/CMakeLists.txt
+++ b/samples/bluetooth/ipsp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ipsp)
 
 target_sources(app PRIVATE

--- a/samples/bluetooth/mesh/CMakeLists.txt
+++ b/samples/bluetooth/mesh/CMakeLists.txt
@@ -7,7 +7,7 @@ if((BOARD STREQUAL nrf51_blenano) OR (BOARD STREQUAL nrf51_ble400))
   set(CONF_FILE nrf51_qfaa.conf)
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mesh)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/mesh_demo/CMakeLists.txt
+++ b/samples/bluetooth/mesh_demo/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 set(QEMU_EXTRA_FLAGS -s)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mesh_demo)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/mesh_provisioner/CMakeLists.txt
+++ b/samples/bluetooth/mesh_provisioner/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 set(QEMU_EXTRA_FLAGS -s)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mesh_provisioner)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/peripheral/CMakeLists.txt
+++ b/samples/bluetooth/peripheral/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(peripheral)
 
 target_sources(app PRIVATE

--- a/samples/bluetooth/peripheral_csc/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_csc/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(peripheral_csc)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/bluetooth/peripheral_dis/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_dis/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(peripheral_dis)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/bluetooth/peripheral_esp/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_esp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(peripheral_esp)
 
 target_sources(app PRIVATE

--- a/samples/bluetooth/peripheral_hids/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_hids/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(peripheral_hids)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/bluetooth/peripheral_hr/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_hr/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(peripheral_hr)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/bluetooth/peripheral_ht/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_ht/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(peripheral_ht)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/bluetooth/peripheral_sc_only/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_sc_only/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(peripheral_sc_only)
 
 target_sources(app PRIVATE

--- a/samples/bluetooth/scan_adv/CMakeLists.txt
+++ b/samples/bluetooth/scan_adv/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(scan_adv)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/bluetooth/st_ble_sensor/CMakeLists.txt
+++ b/samples/bluetooth/st_ble_sensor/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(st_ble_sensor)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/boards/96b_argonkey/microphone/CMakeLists.txt
+++ b/samples/boards/96b_argonkey/microphone/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/boards/96b_argonkey/sensors/CMakeLists.txt
+++ b/samples/boards/96b_argonkey/sensors/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(96b_argonkey)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/boards/arc_secure_services/CMakeLists.txt
+++ b/samples/boards/arc_secure_services/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(arc_secure_services)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/boards/bbc_microbit/display/CMakeLists.txt
+++ b/samples/boards/bbc_microbit/display/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(display)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/boards/bbc_microbit/line_follower_robot/CMakeLists.txt
+++ b/samples/boards/bbc_microbit/line_follower_robot/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(robot)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/boards/bbc_microbit/pong/CMakeLists.txt
+++ b/samples/boards/bbc_microbit/pong/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(pong)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/boards/bbc_microbit/sound/CMakeLists.txt
+++ b/samples/boards/bbc_microbit/sound/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sound)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/boards/intel_s1000_crb/audio/CMakeLists.txt
+++ b/samples/boards/intel_s1000_crb/audio/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 set(BOARD intel_s1000_crb)
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 target_sources(app PRIVATE src/audio_driver.c)

--- a/samples/boards/intel_s1000_crb/dmic/CMakeLists.txt
+++ b/samples/boards/intel_s1000_crb/dmic/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 set(BOARD intel_s1000_crb)
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 target_sources(app PRIVATE src/dmic_sample.c)

--- a/samples/boards/intel_s1000_crb/i2s/CMakeLists.txt
+++ b/samples/boards/intel_s1000_crb/i2s/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 set(BOARD intel_s1000_crb)
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 target_sources(app PRIVATE src/i2s_sample.c)

--- a/samples/boards/mec15xxevb_assy6853/power_management/CMakeLists.txt
+++ b/samples/boards/mec15xxevb_assy6853/power_management/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mec15_brd_test)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/boards/nrf/battery/CMakeLists.txt
+++ b/samples/boards/nrf/battery/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(battery)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/boards/nrf/mesh/onoff-app/CMakeLists.txt
+++ b/samples/boards/nrf/mesh/onoff-app/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 set(QEMU_EXTRA_FLAGS -s)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(onoff-app)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/CMakeLists.txt
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 set(QEMU_EXTRA_FLAGS -s)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(onoff_level_lighting_vnd_app)
 
 target_sources(app PRIVATE

--- a/samples/boards/nrf/nrfx/CMakeLists.txt
+++ b/samples/boards/nrf/nrfx/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nrfx_sample)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/boards/nrf/system_off/CMakeLists.txt
+++ b/samples/boards/nrf/system_off/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nrf_system_off)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/boards/olimex_stm32_e407/ccm/CMakeLists.txt
+++ b/samples/boards/olimex_stm32_e407/ccm/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ccm)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/boards/reel_board/mesh_badge/CMakeLists.txt
+++ b/samples/boards/reel_board/mesh_badge/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mesh_badge)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/boards/sensortile_box/CMakeLists.txt
+++ b/samples/boards/sensortile_box/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sensortile_box)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/boards/up_squared/gpio_counter/CMakeLists.txt
+++ b/samples/boards/up_squared/gpio_counter/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(gpio_counter)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/cpp_synchronization/CMakeLists.txt
+++ b/samples/cpp_synchronization/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cpp_synchronization)
 
 target_sources(app PRIVATE src/main.cpp)

--- a/samples/display/cfb/CMakeLists.txt
+++ b/samples/display/cfb/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cfb)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/display/cfb_custom_font/CMakeLists.txt
+++ b/samples/display/cfb_custom_font/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/cmake/cfb.cmake NO_POLICY_SCOPE)
 project(cfb_custom_font)
 

--- a/samples/display/cfb_shell/CMakeLists.txt
+++ b/samples/display/cfb_shell/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cfb)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/display/grove_display/CMakeLists.txt
+++ b/samples/display/grove_display/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(grove_display)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/display/lvgl/CMakeLists.txt
+++ b/samples/display/lvgl/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lvgl)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/can/CMakeLists.txt
+++ b/samples/drivers/can/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(CAN)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/drivers/counter/alarm/CMakeLists.txt
+++ b/samples/drivers/counter/alarm/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(counter)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/counter/maxim_ds3231/CMakeLists.txt
+++ b/samples/drivers/counter/maxim_ds3231/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(maxim_ds3231)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/crypto/CMakeLists.txt
+++ b/samples/drivers/crypto/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(crypto)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/current_sensing/CMakeLists.txt
+++ b/samples/drivers/current_sensing/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(current_sensing)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/dac/CMakeLists.txt
+++ b/samples/drivers/dac/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(DAC)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/drivers/display/CMakeLists.txt
+++ b/samples/drivers/display/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(display)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/drivers/entropy/CMakeLists.txt
+++ b/samples/drivers/entropy/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(entropy)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/espi/CMakeLists.txt
+++ b/samples/drivers/espi/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(espi)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/flash_shell/CMakeLists.txt
+++ b/samples/drivers/flash_shell/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(flash_shell)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/ht16k33/CMakeLists.txt
+++ b/samples/drivers/ht16k33/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ht16k33)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/i2c_fujitsu_fram/CMakeLists.txt
+++ b/samples/drivers/i2c_fujitsu_fram/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(i2c_fujitsu_fram)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/kscan/CMakeLists.txt
+++ b/samples/drivers/kscan/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(kscan)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/lcd_hd44780/CMakeLists.txt
+++ b/samples/drivers/lcd_hd44780/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lcd_hd44780)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/led_apa102/CMakeLists.txt
+++ b/samples/drivers/led_apa102/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(led_apa102)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/led_apa102c_bitbang/CMakeLists.txt
+++ b/samples/drivers/led_apa102c_bitbang/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(led_apa102c)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/led_lp3943/CMakeLists.txt
+++ b/samples/drivers/led_lp3943/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(led_lp3943)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/led_lp5562/CMakeLists.txt
+++ b/samples/drivers/led_lp5562/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(led_lp5562)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/led_lpd8806/CMakeLists.txt
+++ b/samples/drivers/led_lpd8806/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(led_lpd8806)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/led_pca9633/CMakeLists.txt
+++ b/samples/drivers/led_pca9633/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(led_pca9633)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/led_ws2812/CMakeLists.txt
+++ b/samples/drivers/led_ws2812/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(led_ws2812)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/lora/receive/CMakeLists.txt
+++ b/samples/drivers/lora/receive/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lora_receive)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/lora/send/CMakeLists.txt
+++ b/samples/drivers/lora/send/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lora_send)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/peci/CMakeLists.txt
+++ b/samples/drivers/peci/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(peci)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/ps2/CMakeLists.txt
+++ b/samples/drivers/ps2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(espi)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/soc_flash_nrf/CMakeLists.txt
+++ b/samples/drivers/soc_flash_nrf/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(soc_flash_nrf)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/spi_flash/CMakeLists.txt
+++ b/samples/drivers/spi_flash/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(spi_flash)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/spi_fujitsu_fram/CMakeLists.txt
+++ b/samples/drivers/spi_fujitsu_fram/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(spi_fujitsu_fram)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/watchdog/CMakeLists.txt
+++ b/samples/drivers/watchdog/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(watchdog)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/hello_world/CMakeLists.txt
+++ b/samples/hello_world/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hello_world)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/mpu/mpu_test/CMakeLists.txt
+++ b/samples/mpu/mpu_test/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mpu_test)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/cloud/google_iot_mqtt/CMakeLists.txt
+++ b/samples/net/cloud/google_iot_mqtt/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 if(NOT EXISTS ${APPLICATION_SOURCE_DIR}/src/private_info/key.c)

--- a/samples/net/cloud/mqtt_azure/CMakeLists.txt
+++ b/samples/net/cloud/mqtt_azure/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mqtt-azure)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/dhcpv4_client/CMakeLists.txt
+++ b/samples/net/dhcpv4_client/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(dhcpv4_client)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/dns_resolve/CMakeLists.txt
+++ b/samples/net/dns_resolve/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(dns_resolve)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/eth_native_posix/CMakeLists.txt
+++ b/samples/net/eth_native_posix/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(eth_native_posix)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/net/gptp/CMakeLists.txt
+++ b/samples/net/gptp/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(gptp)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/net/gsm_modem/CMakeLists.txt
+++ b/samples/net/gsm_modem/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(gsm_modem)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/net/ipv4_autoconf/CMakeLists.txt
+++ b/samples/net/ipv4_autoconf/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ipv4_autoconf)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/lldp/CMakeLists.txt
+++ b/samples/net/lldp/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lldp)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/net/lwm2m_client/CMakeLists.txt
+++ b/samples/net/lwm2m_client/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lwm2m_client)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/mdns_responder/CMakeLists.txt
+++ b/samples/net/mdns_responder/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mdns_responder)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/mqtt_publisher/CMakeLists.txt
+++ b/samples/net/mqtt_publisher/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mqtt_publisher)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/openthread/ncp/CMakeLists.txt
+++ b/samples/net/openthread/ncp/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ncp)
 
 target_sources( app

--- a/samples/net/promiscuous_mode/CMakeLists.txt
+++ b/samples/net/promiscuous_mode/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(promiscuous_mode)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/net/sockets/big_http_download/CMakeLists.txt
+++ b/samples/net/sockets/big_http_download/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(big_http_download)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/sockets/can/CMakeLists.txt
+++ b/samples/net/sockets/can/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sockets_can)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/net/sockets/civetweb/CMakeLists.txt
+++ b/samples/net/sockets/civetweb/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hello_world)
 
 target_sources(app PRIVATE src/main.c src/libc_extensions.c)

--- a/samples/net/sockets/coap_client/CMakeLists.txt
+++ b/samples/net/sockets/coap_client/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/sockets/coap_server/CMakeLists.txt
+++ b/samples/net/sockets/coap_server/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/sockets/dumb_http_server/CMakeLists.txt
+++ b/samples/net/sockets/dumb_http_server/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(dumb_http_server)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/sockets/dumb_http_server_mt/CMakeLists.txt
+++ b/samples/net/sockets/dumb_http_server_mt/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(dumb_http_server_mt)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/sockets/echo/CMakeLists.txt
+++ b/samples/net/sockets/echo/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sockets_echo)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/sockets/echo_async/CMakeLists.txt
+++ b/samples/net/sockets/echo_async/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sockets_echo_async)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/sockets/echo_async_select/CMakeLists.txt
+++ b/samples/net/sockets/echo_async_select/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sockets_echo_async_select)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/sockets/echo_client/CMakeLists.txt
+++ b/samples/net/sockets/echo_client/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sockets_echo_client)
 
 if(CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED AND

--- a/samples/net/sockets/echo_server/CMakeLists.txt
+++ b/samples/net/sockets/echo_server/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sockets_echo_server)
 
 if(CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED AND

--- a/samples/net/sockets/http_client/CMakeLists.txt
+++ b/samples/net/sockets/http_client/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(http_client)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/sockets/http_get/CMakeLists.txt
+++ b/samples/net/sockets/http_get/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(http_get)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/sockets/net_mgmt/CMakeLists.txt
+++ b/samples/net/sockets/net_mgmt/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sockets_net_mgmt)
 
 target_sources_ifdef(CONFIG_NET_SOCKETS_NET_MGMT app PRIVATE src/main.c)

--- a/samples/net/sockets/packet/CMakeLists.txt
+++ b/samples/net/sockets/packet/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sockets_echo_server)
 
 target_sources(                     app PRIVATE src/packet.c)

--- a/samples/net/sockets/sntp_client/CMakeLists.txt
+++ b/samples/net/sockets/sntp_client/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sntp_client)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/sockets/socketpair/CMakeLists.txt
+++ b/samples/net/sockets/socketpair/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sockets_socketpair)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/sockets/tcp/CMakeLists.txt
+++ b/samples/net/sockets/tcp/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tcp)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/samples/net/sockets/websocket_client/CMakeLists.txt
+++ b/samples/net/sockets/websocket_client/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(http_client)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/stats/CMakeLists.txt
+++ b/samples/net/stats/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(stats)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/net/syslog_net/CMakeLists.txt
+++ b/samples/net/syslog_net/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/telnet/CMakeLists.txt
+++ b/samples/net/telnet/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(telnet)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/updatehub/CMakeLists.txt
+++ b/samples/net/updatehub/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.13.1)
 # This application has its own Kconfig options.
 set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/lib/updatehub/include)

--- a/samples/net/vlan/CMakeLists.txt
+++ b/samples/net/vlan/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(vlan)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/net/wifi/CMakeLists.txt
+++ b/samples/net/wifi/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(wifi)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/net/wpan_serial/CMakeLists.txt
+++ b/samples/net/wpan_serial/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(wpan_serial)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/samples/net/wpanusb/CMakeLists.txt
+++ b/samples/net/wpanusb/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(wpanusb)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/samples/net/zperf/CMakeLists.txt
+++ b/samples/net/zperf/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(zperf)
 
 target_sources(app PRIVATE

--- a/samples/nfc/nfc_hello/CMakeLists.txt
+++ b/samples/nfc/nfc_hello/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 list(APPEND QEMU_EXTRA_FLAGS -serial tcp:localhost:8888)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nfc_hello)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/philosophers/CMakeLists.txt
+++ b/samples/philosophers/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(philosophers)
 
 if(DEFINED DEBUG_PRINTF)

--- a/samples/portability/cmsis_rtos_v1/philosophers/CMakeLists.txt
+++ b/samples/portability/cmsis_rtos_v1/philosophers/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(philosophers_cmsis_rtos_v1)
 
 if(DEFINED DEBUG_PRINTF)

--- a/samples/portability/cmsis_rtos_v1/timer_synchronization/CMakeLists.txt
+++ b/samples/portability/cmsis_rtos_v1/timer_synchronization/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cmsis_rtos_v1_synchronization)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/include/cmsis_rtos_v1)

--- a/samples/portability/cmsis_rtos_v2/philosophers/CMakeLists.txt
+++ b/samples/portability/cmsis_rtos_v2/philosophers/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(philosophers)
 
 if(DEFINED DEBUG_PRINTF)

--- a/samples/portability/cmsis_rtos_v2/timer_synchronization/CMakeLists.txt
+++ b/samples/portability/cmsis_rtos_v2/timer_synchronization/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cpp_synchronization)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/include/cmsis_rtos_v2)

--- a/samples/posix/eventfd/CMakeLists.txt
+++ b/samples/posix/eventfd/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(eventfd)
 
 #target_include_directories(app PRIVATE ${ZEPHYR_BASE}/include/posix)

--- a/samples/posix/gettimeofday/CMakeLists.txt
+++ b/samples/posix/gettimeofday/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(gettimeofday)
 
 #target_include_directories(app PRIVATE ${ZEPHYR_BASE}/include/posix)

--- a/samples/scheduler/metairq_dispatch/CMakeLists.txt
+++ b/samples/scheduler/metairq_dispatch/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(metairq_dispatch)
 
 target_sources(app PRIVATE src/main.c src/msgdev.c)

--- a/samples/sensor/adt7420/CMakeLists.txt
+++ b/samples/sensor/adt7420/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(adt7420)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/adxl362/CMakeLists.txt
+++ b/samples/sensor/adxl362/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(adxl362)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/sensor/adxl372/CMakeLists.txt
+++ b/samples/sensor/adxl372/CMakeLists.txt
@@ -4,7 +4,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(adxl372)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/amg88xx/CMakeLists.txt
+++ b/samples/sensor/amg88xx/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(amg88xx)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/ams_iAQcore/CMakeLists.txt
+++ b/samples/sensor/ams_iAQcore/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.13.1)
 
 set(DTC_OVERLAY_FILE "${CMAKE_CURRENT_SOURCE_DIR}/iaq_core.overlay")
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(iAQcore)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/apds9960/CMakeLists.txt
+++ b/samples/sensor/apds9960/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(apds9960)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/bme280/CMakeLists.txt
+++ b/samples/sensor/bme280/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bme280)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/bme680/CMakeLists.txt
+++ b/samples/sensor/bme680/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/bmg160/CMakeLists.txt
+++ b/samples/sensor/bmg160/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bmg160)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/bmm150/CMakeLists.txt
+++ b/samples/sensor/bmm150/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bmm150)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/bq274xx/CMakeLists.txt
+++ b/samples/sensor/bq274xx/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bq274xx)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/ccs811/CMakeLists.txt
+++ b/samples/sensor/ccs811/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ccs811)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/dht/CMakeLists.txt
+++ b/samples/sensor/dht/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(dht)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/dps310/CMakeLists.txt
+++ b/samples/sensor/dps310/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(dps310)
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/ens210/CMakeLists.txt
+++ b/samples/sensor/ens210/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.13.1)
 
 set(DTC_OVERLAY_FILE "${CMAKE_CURRENT_SOURCE_DIR}/ens210.overlay")
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ens210)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/fxas21002/CMakeLists.txt
+++ b/samples/sensor/fxas21002/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fxas21002)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/fxos8700-hid/CMakeLists.txt
+++ b/samples/sensor/fxos8700-hid/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fxos8700-hid)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/fxos8700/CMakeLists.txt
+++ b/samples/sensor/fxos8700/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fxos8700)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/grove_light/CMakeLists.txt
+++ b/samples/sensor/grove_light/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(grove_light)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/grove_temperature/CMakeLists.txt
+++ b/samples/sensor/grove_temperature/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(grove_temperature)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/hmc5883l/CMakeLists.txt
+++ b/samples/sensor/hmc5883l/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hmc5883l)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/hts221/CMakeLists.txt
+++ b/samples/sensor/hts221/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hts221)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/isl29035/CMakeLists.txt
+++ b/samples/sensor/isl29035/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(isl29035)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/lis2dh/CMakeLists.txt
+++ b/samples/sensor/lis2dh/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lis2dh)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/lps22hb/CMakeLists.txt
+++ b/samples/sensor/lps22hb/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lps22hb)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/lps22hh/CMakeLists.txt
+++ b/samples/sensor/lps22hh/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lps22hh)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/lsm303dlhc/CMakeLists.txt
+++ b/samples/sensor/lsm303dlhc/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lsm303dlhc)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/lsm6dsl/CMakeLists.txt
+++ b/samples/sensor/lsm6dsl/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lsm6dsl)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/magn_polling/CMakeLists.txt
+++ b/samples/sensor/magn_polling/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(magn_polling)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/max30101/CMakeLists.txt
+++ b/samples/sensor/max30101/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(max30101)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/max44009/CMakeLists.txt
+++ b/samples/sensor/max44009/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(max44009)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/mcp9808/CMakeLists.txt
+++ b/samples/sensor/mcp9808/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mcp9808)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/mpu6050/CMakeLists.txt
+++ b/samples/sensor/mpu6050/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mpu6050)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/ms5837/CMakeLists.txt
+++ b/samples/sensor/ms5837/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ms5837)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/sensor_shell/CMakeLists.txt
+++ b/samples/sensor/sensor_shell/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sensor_shell)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/sht3xd/CMakeLists.txt
+++ b/samples/sensor/sht3xd/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sht3xd)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/sx9500/CMakeLists.txt
+++ b/samples/sensor/sx9500/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sx9500)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/th02/CMakeLists.txt
+++ b/samples/sensor/th02/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(th02)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/thermometer/CMakeLists.txt
+++ b/samples/sensor/thermometer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(thermometer)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/ti_hdc/CMakeLists.txt
+++ b/samples/sensor/ti_hdc/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ti_hdc)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/tmp112/CMakeLists.txt
+++ b/samples/sensor/tmp112/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tmp112)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/tmp116/CMakeLists.txt
+++ b/samples/sensor/tmp116/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tmp116)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/vl53l0x/CMakeLists.txt
+++ b/samples/sensor/vl53l0x/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(vl53l0x)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/shields/lmp90100_evb/rtd/CMakeLists.txt
+++ b/samples/shields/lmp90100_evb/rtd/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.13.1)
 # This sample is specific to lmp90100_evb shield. Enforce -DSHIELD option
 set(SHIELD lmp90100_evb)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lmp90100_evb_rtd)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/shields/x_nucleo_iks01a1/CMakeLists.txt
+++ b/samples/shields/x_nucleo_iks01a1/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.13.1)
 # This sample is specific to x_nucleo_iks01a1 shield. Enforce -DSHIELD option
 set(SHIELD x_nucleo_iks01a1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(x_nucleo_iks01a1)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/shields/x_nucleo_iks01a2/CMakeLists.txt
+++ b/samples/shields/x_nucleo_iks01a2/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.13.1)
 # This sample is specific to x_nucleo_iks01a2 shield. Enforce -DSHIELD option
 set(SHIELD x_nucleo_iks01a2)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(x_nucleo_iks01a2)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/shields/x_nucleo_iks01a3/sensorhub/CMakeLists.txt
+++ b/samples/shields/x_nucleo_iks01a3/sensorhub/CMakeLists.txt
@@ -10,7 +10,7 @@ set(SHIELD x_nucleo_iks01a3_shub)
 # IKS01A3 board configured in sensorhub mode
 set(CONF_FILE shub.conf)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(x_nucleo_iks01a3)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/shields/x_nucleo_iks01a3/standard/CMakeLists.txt
+++ b/samples/shields/x_nucleo_iks01a3/standard/CMakeLists.txt
@@ -9,7 +9,7 @@ set(SHIELD x_nucleo_iks01a3)
 
 set(CONF_FILE prj.conf)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(x_nucleo_iks01a3)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/shields/x_nucleo_iks02a1/microphone/CMakeLists.txt
+++ b/samples/shields/x_nucleo_iks02a1/microphone/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.13.1)
 # This sample is specific to x_nucleo_iks02a1 shield. Enforce -DSHIELD option
 set(SHIELD x_nucleo_iks02a1_mic)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(x_nucleo_iks02a1)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/shields/x_nucleo_iks02a1/sensorhub/CMakeLists.txt
+++ b/samples/shields/x_nucleo_iks02a1/sensorhub/CMakeLists.txt
@@ -10,7 +10,7 @@ set(SHIELD x_nucleo_iks02a1_shub)
 # IKS02A1 board configured in sensorhub mode
 set(CONF_FILE shub.conf)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(x_nucleo_iks02a1)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/shields/x_nucleo_iks02a1/standard/CMakeLists.txt
+++ b/samples/shields/x_nucleo_iks02a1/standard/CMakeLists.txt
@@ -9,7 +9,7 @@ set(SHIELD x_nucleo_iks02a1)
 
 set(CONF_FILE prj.conf)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(x_nucleo_iks02a1)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/smp/pi/CMakeLists.txt
+++ b/samples/smp/pi/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(smp_pi)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/subsys/canbus/canopen/CMakeLists.txt
+++ b/samples/subsys/canbus/canopen/CMakeLists.txt
@@ -6,7 +6,7 @@ macro(app_set_runner_args)
   board_runner_args(canopen "--node-id=${CONFIG_CANOPEN_NODE_ID}")
 endmacro()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(CANopen)
 
 target_sources(app PRIVATE src/main.c objdict/CO_OD.c)

--- a/samples/subsys/canbus/isotp/CMakeLists.txt
+++ b/samples/subsys/canbus/isotp/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ISOTP)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/subsys/console/echo/CMakeLists.txt
+++ b/samples/subsys/console/echo/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(echo)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/subsys/console/getchar/CMakeLists.txt
+++ b/samples/subsys/console/getchar/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(getchar)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/subsys/console/getline/CMakeLists.txt
+++ b/samples/subsys/console/getline/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(getline)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/subsys/fs/fat_fs/CMakeLists.txt
+++ b/samples/subsys/fs/fat_fs/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mass)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/subsys/fs/littlefs/CMakeLists.txt
+++ b/samples/subsys/fs/littlefs/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(littlefs)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/subsys/ipc/ipm_imx/CMakeLists.txt
+++ b/samples/subsys/ipc/ipm_imx/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/drivers)

--- a/samples/subsys/ipc/ipm_mcux/CMakeLists.txt
+++ b/samples/subsys/ipc/ipm_mcux/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.13.1)
 set(BOARD lpcxpresso54114_m4)
 
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 if(NOT ("${BOARD}" STREQUAL "lpcxpresso54114_m4"))
   message(FATAL_ERROR "${BOARD} was specified, but this sample only supports lpcxpresso54114_m4")

--- a/samples/subsys/ipc/ipm_mcux/remote/CMakeLists.txt
+++ b/samples/subsys/ipc/ipm_mcux/remote/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.13.1)
 #
 set(BOARD lpcxpresso54114_m0)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ipm_mcux_remote)
 
 if(NOT ("${BOARD}" STREQUAL "lpcxpresso54114_m0"))

--- a/samples/subsys/ipc/ipm_mhu_dual_core/CMakeLists.txt
+++ b/samples/subsys/ipc/ipm_mhu_dual_core/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ipm_mhu_dual_core)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/subsys/ipc/openamp/CMakeLists.txt
+++ b/samples/subsys/ipc/openamp/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 
 message(INFO " ${BOARD} compile as Master in this sample")
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(openamp)
 
 enable_language(C ASM)

--- a/samples/subsys/ipc/openamp/remote/CMakeLists.txt
+++ b/samples/subsys/ipc/openamp/remote/CMakeLists.txt
@@ -14,7 +14,7 @@ else()
 	message(FATAL_ERROR "${BOARD} was not supported for this sample")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(openamp_remote)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/subsys/ipc/openamp_rsc_table/CMakeLists.txt
+++ b/samples/subsys/ipc/openamp_rsc_table/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.13.1)
 # SPDX-License-Identifier: Apache-2.0
 #
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(openamp_rsc_table_remote)
 

--- a/samples/subsys/logging/logger/CMakeLists.txt
+++ b/samples/subsys/logging/logger/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(logger)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/subsys/logging/syst/CMakeLists.txt
+++ b/samples/subsys/logging/syst/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(syst)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/subsys/mgmt/mcumgr/smp_svr/CMakeLists.txt
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.13.1)
 # mcumgr.  It can be used as a starting point for new applications.
 
 # Standard Zephyr application boilerplate.
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(smp_svr)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/subsys/nvs/CMakeLists.txt
+++ b/samples/subsys/nvs/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nvs)
 
 

--- a/samples/subsys/power/device_pm/CMakeLists.txt
+++ b/samples/subsys/power/device_pm/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(device)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/subsys/settings/CMakeLists.txt
+++ b/samples/subsys/settings/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 #set(QEMU_EXTRA_FLAGS -s)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(settings_sample)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/subsys/shell/fs/CMakeLists.txt
+++ b/samples/subsys/shell/fs/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fs_shell)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/subsys/shell/shell_module/CMakeLists.txt
+++ b/samples/subsys/shell/shell_module/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(shell_module)
 
 target_sources(app PRIVATE src/main.c src/test_module.c)

--- a/samples/subsys/tracing/CMakeLists.txt
+++ b/samples/subsys/tracing/CMakeLists.txt
@@ -6,7 +6,7 @@ if(BOARD MATCHES "qemu_.*")
   list(APPEND QEMU_EXTRA_FLAGS -serial file:channel0_0)
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tracing_tests)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/subsys/usb/cdc_acm/CMakeLists.txt
+++ b/samples/subsys/usb/cdc_acm/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cdc_acm)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/subsys/usb/cdc_acm_composite/CMakeLists.txt
+++ b/samples/subsys/usb/cdc_acm_composite/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cdc_acm)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/subsys/usb/console/CMakeLists.txt
+++ b/samples/subsys/usb/console/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(console)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/subsys/usb/dfu/CMakeLists.txt
+++ b/samples/subsys/usb/dfu/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(dfu)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/subsys/usb/hid-cdc/CMakeLists.txt
+++ b/samples/subsys/usb/hid-cdc/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hid-cdc)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/subsys/usb/hid-mouse/CMakeLists.txt
+++ b/samples/subsys/usb/hid-mouse/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hid-mouse)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/subsys/usb/hid/CMakeLists.txt
+++ b/samples/subsys/usb/hid/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hid)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/subsys/usb/mass/CMakeLists.txt
+++ b/samples/subsys/usb/mass/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mass)
 
 if((NOT CONFIG_DISK_ACCESS_FLASH) AND (NOT CONFIG_DISK_ACCESS_RAM))

--- a/samples/subsys/usb/testusb/CMakeLists.txt
+++ b/samples/subsys/usb/testusb/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(testusb)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/subsys/usb/webusb/CMakeLists.txt
+++ b/samples/subsys/usb/webusb/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(webusb)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/usb)

--- a/samples/synchronization/CMakeLists.txt
+++ b/samples/synchronization/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(synchronization)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/testing/integration/CMakeLists.txt
+++ b/samples/testing/integration/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(integration)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/tfm_integration/psa_level_1/CMakeLists.txt
+++ b/samples/tfm_integration/psa_level_1/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.13.1)
 # Override the binary used by qemu
 set(QEMU_KERNEL_OPTION "-device;loader,file=${CMAKE_BINARY_DIR}/tfm_qemu.hex")
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 # Add "tfm" as an external project via the TF-M module's cmake file
 trusted_firmware_build(BINARY_DIR ${CMAKE_BINARY_DIR}/tfm

--- a/samples/tfm_integration/tfm_ipc/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_ipc/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.13.1)
 # Override the binary used by qemu
 set(QEMU_KERNEL_OPTION "-device;loader,file=${CMAKE_BINARY_DIR}/tfm_qemu.hex")
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 # Add "tfm" as an external project via the TF-M module's cmake file
 trusted_firmware_build(BINARY_DIR ${CMAKE_BINARY_DIR}/tfm

--- a/samples/userspace/prod_consumer/CMakeLists.txt
+++ b/samples/userspace/prod_consumer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(shared_mem)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/userspace/shared_mem/CMakeLists.txt
+++ b/samples/userspace/shared_mem/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(shared_mem)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/video/capture/CMakeLists.txt
+++ b/samples/video/capture/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(video_capture)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/video/tcpserversink/CMakeLists.txt
+++ b/samples/video/tcpserversink/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(video_tcpserversink)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/application_development/cpp/CMakeLists.txt
+++ b/tests/application_development/cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cpp)
 
 FILE(GLOB app_sources src/*.cpp)

--- a/tests/application_development/gen_inc_file/CMakeLists.txt
+++ b/tests/application_development/gen_inc_file/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(gen_inc_file)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/application_development/libcxx/CMakeLists.txt
+++ b/tests/application_development/libcxx/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cpp)
 
 FILE(GLOB app_sources src/*.cpp)

--- a/tests/arch/arm/arm_interrupt/CMakeLists.txt
+++ b/tests/arch/arm/arm_interrupt/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(arm_interrupt)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/arch/arm/arm_irq_advanced_features/CMakeLists.txt
+++ b/tests/arch/arm/arm_irq_advanced_features/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(arm_zero_latency_irqs)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/arch/arm/arm_irq_vector_table/CMakeLists.txt
+++ b/tests/arch/arm/arm_irq_vector_table/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(arm_irq_vector_table)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/arch/arm/arm_ramfunc/CMakeLists.txt
+++ b/tests/arch/arm/arm_ramfunc/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(arm_zero_latency_irqs)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/arch/arm/arm_runtime_nmi/CMakeLists.txt
+++ b/tests/arch/arm/arm_runtime_nmi/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(arm_runtime_nmi)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/arch/arm/arm_thread_swap/CMakeLists.txt
+++ b/tests/arch/arm/arm_thread_swap/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(arm_swap)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/arch/x86/boot_page_table/CMakeLists.txt
+++ b/tests/arch/x86/boot_page_table/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(boot_page_table)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/arch/x86/info/CMakeLists.txt
+++ b/tests/arch/x86/info/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(x86_info)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/arch/x86/static_idt/CMakeLists.txt
+++ b/tests/arch/x86/static_idt/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(static_idt)
 
 enable_language(C ASM)

--- a/tests/arch/x86/x86_mmu_api/CMakeLists.txt
+++ b/tests/arch/x86/x86_mmu_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(x86_mmu_api)
 
 file(GLOB source_for_app src/*.c)

--- a/tests/arch/xtensa_asm2/CMakeLists.txt
+++ b/tests/arch/xtensa_asm2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(xtensa_asm2)
 
 enable_language(ASM)

--- a/tests/benchmarks/app_kernel/CMakeLists.txt
+++ b/tests/benchmarks/app_kernel/CMakeLists.txt
@@ -5,7 +5,7 @@ if(BOARD STREQUAL "minnowboard")
   set(CONF_FILE prj_fp.conf)
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(app_kernel)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/benchmarks/boot_time/CMakeLists.txt
+++ b/tests/benchmarks/boot_time/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(boot_time)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/benchmarks/cmsis_dsp/basicmath/CMakeLists.txt
+++ b/tests/benchmarks/cmsis_dsp/basicmath/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cmsis_dsp_basicmath_benchmark)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/benchmarks/latency_measure/CMakeLists.txt
+++ b/tests/benchmarks/latency_measure/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(latency_measure)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/benchmarks/mbedtls/CMakeLists.txt
+++ b/tests/benchmarks/mbedtls/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mbedtls_benchmark)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/benchmarks/sched/CMakeLists.txt
+++ b/tests/benchmarks/sched/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sched_bench)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/benchmarks/sys_kernel/CMakeLists.txt
+++ b/tests/benchmarks/sys_kernel/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sys_kernel)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/benchmarks/timing_info/CMakeLists.txt
+++ b/tests/benchmarks/timing_info/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(timing_info)
 
 FILE(GLOB app_sources src/[^u]*.c)

--- a/tests/bluetooth/at/CMakeLists.txt
+++ b/tests/bluetooth/at/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(at)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/bluetooth/bluetooth/CMakeLists.txt
+++ b/tests/bluetooth/bluetooth/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 set(NO_QEMU_SERIAL_BT_SERVER 1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bluetooth)
 
 target_sources(app PRIVATE src/bluetooth.c)

--- a/tests/bluetooth/bsim_bt/bsim_test_app/CMakeLists.txt
+++ b/tests/bluetooth/bsim_bt/bsim_test_app/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_app)
 
 target_sources(app PRIVATE

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/CMakeLists.txt
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/CMakeLists.txt
@@ -10,7 +10,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(peripheral_test)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/hci_test_app/CMakeLists.txt
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/hci_test_app/CMakeLists.txt
@@ -10,7 +10,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hci_test_app)
 
 target_sources(app PRIVATE

--- a/tests/bluetooth/ctrl_sw_privacy/CMakeLists.txt
+++ b/tests/bluetooth/ctrl_sw_privacy/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 include_directories("./src")
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bluetooth_ctrl_sw_privacy)
 
 zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/bluetooth/controller/)

--- a/tests/bluetooth/ctrl_sw_privacy_unit/CMakeLists.txt
+++ b/tests/bluetooth/ctrl_sw_privacy_unit/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 include_directories("./src")
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bluetooth_ctrl_sw_privacy)
 
 zephyr_library_include_directories(

--- a/tests/bluetooth/ctrl_user_ext/CMakeLists.txt
+++ b/tests/bluetooth/ctrl_user_ext/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 include_directories("./src")
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bluetooth_ctrl_user_ext)
 
 zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/bluetooth/controller/)

--- a/tests/bluetooth/gatt/CMakeLists.txt
+++ b/tests/bluetooth/gatt/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bluetooth_gatt)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/bluetooth/hci_prop_evt/CMakeLists.txt
+++ b/tests/bluetooth/hci_prop_evt/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hci_prop_evt)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/bluetooth/init/CMakeLists.txt
+++ b/tests/bluetooth/init/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bluetooth_init)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/bluetooth/l2cap/CMakeLists.txt
+++ b/tests/bluetooth/l2cap/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bluetooth_gatt)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/bluetooth/ll_settings/CMakeLists.txt
+++ b/tests/bluetooth/ll_settings/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bluetooth_ll_settings)
 
 zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/bluetooth/controller/include)

--- a/tests/bluetooth/mesh/CMakeLists.txt
+++ b/tests/bluetooth/mesh/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mesh)
 
 zephyr_library_include_directories(${ZEPHYR_BASE}/samples/bluetooth)

--- a/tests/bluetooth/mesh_shell/CMakeLists.txt
+++ b/tests/bluetooth/mesh_shell/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mesh_shell)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/bluetooth/shell/CMakeLists.txt
+++ b/tests/bluetooth/shell/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bluetooth_shell)
 
 zephyr_library_include_directories(${ZEPHYR_BASE}/samples/bluetooth)

--- a/tests/bluetooth/tester/CMakeLists.txt
+++ b/tests/bluetooth/tester/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.13.1)
 
 LIST(APPEND QEMU_EXTRA_FLAGS -serial unix:/tmp/bt-stack-tester)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tester)
 
 zephyr_library_include_directories(${ZEPHYR_BASE}/samples/bluetooth)

--- a/tests/bluetooth/uuid/CMakeLists.txt
+++ b/tests/bluetooth/uuid/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bluetooth_gatt)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/boards/altera_max10/i2c_master/CMakeLists.txt
+++ b/tests/boards/altera_max10/i2c_master/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(i2c_master)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/boards/altera_max10/msgdma/CMakeLists.txt
+++ b/tests/boards/altera_max10/msgdma/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(msgdma)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/boards/altera_max10/qspi/CMakeLists.txt
+++ b/tests/boards/altera_max10/qspi/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(qspi)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/boards/altera_max10/sysid/CMakeLists.txt
+++ b/tests/boards/altera_max10/sysid/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sysid)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/boards/board_shell/CMakeLists.txt
+++ b/tests/boards/board_shell/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(board_shell)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/boards/intel_s1000_crb/cache/CMakeLists.txt
+++ b/tests/boards/intel_s1000_crb/cache/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 set(BOARD intel_s1000_crb)
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(intel_s1000_crb)
 
 target_sources(app PRIVATE src/cache_test.c)

--- a/tests/boards/intel_s1000_crb/main/CMakeLists.txt
+++ b/tests/boards/intel_s1000_crb/main/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(intel_s1000_crb)
 
 if(CONFIG_I2C)

--- a/tests/boards/native_posix/native_tasks/CMakeLists.txt
+++ b/tests/boards/native_posix/native_tasks/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(native_tasks)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/boards/native_posix/rtc/CMakeLists.txt
+++ b/tests/boards/native_posix/rtc/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(rtc)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/crypto/mbedtls/CMakeLists.txt
+++ b/tests/crypto/mbedtls/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mbedtls)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/crypto/rand32/CMakeLists.txt
+++ b/tests/crypto/rand32/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(rand32)
 
 zephyr_library_include_directories(${ZEPHYR_BASE}/kernel/include/)

--- a/tests/crypto/tinycrypt/CMakeLists.txt
+++ b/tests/crypto/tinycrypt/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tinycrypt)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/crypto/tinycrypt_hmac_prng/CMakeLists.txt
+++ b/tests/crypto/tinycrypt_hmac_prng/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tinycrypt_hmac_prng)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/deprecated/dts/CMakeLists.txt
+++ b/tests/deprecated/dts/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(test_dts)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/adc/adc_api/CMakeLists.txt
+++ b/tests/drivers/adc/adc_api/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(adc_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/build_all/CMakeLists.txt
+++ b/tests/drivers/build_all/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(build_all)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/can/api/CMakeLists.txt
+++ b/tests/drivers/can/api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(integration)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/can/stm32/CMakeLists.txt
+++ b/tests/drivers/can/stm32/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(integration)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/clock_control/clock_control_api/CMakeLists.txt
+++ b/tests/drivers/clock_control/clock_control_api/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/clock_control/nrf_clock_calibration/CMakeLists.txt
+++ b/tests/drivers/clock_control/nrf_clock_calibration/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/console/CMakeLists.txt
+++ b/tests/drivers/console/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(console)
 

--- a/tests/drivers/counter/counter_basic_api/CMakeLists.txt
+++ b/tests/drivers/counter/counter_basic_api/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/counter/counter_cmos/CMakeLists.txt
+++ b/tests/drivers/counter/counter_cmos/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/counter/counter_nrf_rtc/fixed_top/CMakeLists.txt
+++ b/tests/drivers/counter/counter_nrf_rtc/fixed_top/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/counter/maxim_ds3231_api/CMakeLists.txt
+++ b/tests/drivers/counter/maxim_ds3231_api/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/dac/dac_api/CMakeLists.txt
+++ b/tests/drivers/dac/dac_api/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(dac_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/dac/dac_loopback/CMakeLists.txt
+++ b/tests/drivers/dac/dac_loopback/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(dac_loopback)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/dma/chan_blen_transfer/CMakeLists.txt
+++ b/tests/drivers/dma/chan_blen_transfer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(chan_blen_transfer)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/dma/loop_transfer/CMakeLists.txt
+++ b/tests/drivers/dma/loop_transfer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(loop_transfer)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/eeprom/CMakeLists.txt
+++ b/tests/drivers/eeprom/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(eeprom_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/entropy/api/CMakeLists.txt
+++ b/tests/drivers/entropy/api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(entropy_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/flash_simulator/CMakeLists.txt
+++ b/tests/drivers/flash_simulator/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(flash_simulator)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/gpio/gpio_api_1pin/CMakeLists.txt
+++ b/tests/drivers/gpio/gpio_api_1pin/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(gpio_basic_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/gpio/gpio_basic_api/CMakeLists.txt
+++ b/tests/drivers/gpio/gpio_basic_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(gpio_basic_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/hwinfo/api/CMakeLists.txt
+++ b/tests/drivers/hwinfo/api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(integration)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/i2c/i2c_api/CMakeLists.txt
+++ b/tests/drivers/i2c/i2c_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(i2c_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/i2c/i2c_slave_api/CMakeLists.txt
+++ b/tests/drivers/i2c/i2c_slave_api/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(i2c_slave_api)
 
 add_subdirectory(common)

--- a/tests/drivers/i2s/i2s_api/CMakeLists.txt
+++ b/tests/drivers/i2s/i2s_api/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(i2s_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/i2s/i2s_speed/CMakeLists.txt
+++ b/tests/drivers/i2s/i2s_speed/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(i2s_speed)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/ipm/CMakeLists.txt
+++ b/tests/drivers/ipm/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ipm)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/kscan/kscan_api/CMakeLists.txt
+++ b/tests/drivers/kscan/kscan_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(kscan_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/pwm/pwm_api/CMakeLists.txt
+++ b/tests/drivers/pwm/pwm_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(pwm_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/spi/spi_loopback/CMakeLists.txt
+++ b/tests/drivers/spi/spi_loopback/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(spi_loopback)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/uart/uart_async_api/CMakeLists.txt
+++ b/tests/drivers/uart/uart_async_api/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(uart_high_level_api)
 
 target_sources(app PRIVATE

--- a/tests/drivers/uart/uart_basic_api/CMakeLists.txt
+++ b/tests/drivers/uart/uart_basic_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(uart_basic_api)
 
 target_sources(app PRIVATE

--- a/tests/drivers/watchdog/wdt_basic_api/CMakeLists.txt
+++ b/tests/drivers/watchdog/wdt_basic_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(wdt_basic_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/common/CMakeLists.txt
+++ b/tests/kernel/common/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(kernel_common)
 
 if(NOT CONFIG_ARM)

--- a/tests/kernel/context/CMakeLists.txt
+++ b/tests/kernel/context/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(kernel_context)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/device/CMakeLists.txt
+++ b/tests/kernel/device/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(device)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/early_sleep/CMakeLists.txt
+++ b/tests/kernel/early_sleep/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(early_sleep)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/fatal/CMakeLists.txt
+++ b/tests/kernel/fatal/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fatal)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/fifo/fifo_api/CMakeLists.txt
+++ b/tests/kernel/fifo/fifo_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fifo_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/fifo/fifo_timeout/CMakeLists.txt
+++ b/tests/kernel/fifo/fifo_timeout/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fifo_timeout)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/fifo/fifo_usage/CMakeLists.txt
+++ b/tests/kernel/fifo/fifo_usage/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fifo_usage)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/fpu_sharing/float_disable/CMakeLists.txt
+++ b/tests/kernel/fpu_sharing/float_disable/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(k_float_disable)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/fpu_sharing/generic/CMakeLists.txt
+++ b/tests/kernel/fpu_sharing/generic/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fpu_sharing)
 
 # Some boards are significantly slower than others resulting in the test

--- a/tests/kernel/gen_isr_table/CMakeLists.txt
+++ b/tests/kernel/gen_isr_table/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(gen_isr_table)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/interrupt/CMakeLists.txt
+++ b/tests/kernel/interrupt/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(interrupt)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/lifo/lifo_api/CMakeLists.txt
+++ b/tests/kernel/lifo/lifo_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lifo_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/lifo/lifo_usage/CMakeLists.txt
+++ b/tests/kernel/lifo/lifo_usage/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lifo_usage)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mbox/mbox_api/CMakeLists.txt
+++ b/tests/kernel/mbox/mbox_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mbox_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mbox/mbox_usage/CMakeLists.txt
+++ b/tests/kernel/mbox/mbox_usage/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mbox_usage)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mem_heap/mheap_api_concept/CMakeLists.txt
+++ b/tests/kernel/mem_heap/mheap_api_concept/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mheap_api_concept)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mem_pool/mem_pool/CMakeLists.txt
+++ b/tests/kernel/mem_pool/mem_pool/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mem_pool)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mem_pool/mem_pool_api/CMakeLists.txt
+++ b/tests/kernel/mem_pool/mem_pool_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mem_pool_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mem_pool/mem_pool_concept/CMakeLists.txt
+++ b/tests/kernel/mem_pool/mem_pool_concept/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mem_pool_concept)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mem_pool/mem_pool_threadsafe/CMakeLists.txt
+++ b/tests/kernel/mem_pool/mem_pool_threadsafe/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mem_pool_threadsafe)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mem_pool/sys_mem_pool/CMakeLists.txt
+++ b/tests/kernel/mem_pool/sys_mem_pool/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sys_mem_pool)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mem_protect/futex/CMakeLists.txt
+++ b/tests/kernel/mem_protect/futex/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(futex)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mem_protect/mem_protect/CMakeLists.txt
+++ b/tests/kernel/mem_protect/mem_protect/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mem_protect)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mem_protect/obj_validation/CMakeLists.txt
+++ b/tests/kernel/mem_protect/obj_validation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(obj_validation)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mem_protect/protection/CMakeLists.txt
+++ b/tests/kernel/mem_protect/protection/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(protection)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mem_protect/stack_random/CMakeLists.txt
+++ b/tests/kernel/mem_protect/stack_random/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(stack_random)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mem_protect/stackprot/CMakeLists.txt
+++ b/tests/kernel/mem_protect/stackprot/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(stackprot)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mem_protect/sys_sem/CMakeLists.txt
+++ b/tests/kernel/mem_protect/sys_sem/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sys_sem)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mem_protect/syscalls/CMakeLists.txt
+++ b/tests/kernel/mem_protect/syscalls/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(syscalls)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mem_protect/userspace/CMakeLists.txt
+++ b/tests/kernel/mem_protect/userspace/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(userspace)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mem_slab/mslab/CMakeLists.txt
+++ b/tests/kernel/mem_slab/mslab/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mslab)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mem_slab/mslab_api/CMakeLists.txt
+++ b/tests/kernel/mem_slab/mslab_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mslab_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mem_slab/mslab_concept/CMakeLists.txt
+++ b/tests/kernel/mem_slab/mslab_concept/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mslab_concept)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mem_slab/mslab_threadsafe/CMakeLists.txt
+++ b/tests/kernel/mem_slab/mslab_threadsafe/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mslab_threadsafe)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mp/CMakeLists.txt
+++ b/tests/kernel/mp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mp)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/kernel/msgq/msgq_api/CMakeLists.txt
+++ b/tests/kernel/msgq/msgq_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(msgq_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mutex/mutex_api/CMakeLists.txt
+++ b/tests/kernel/mutex/mutex_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mutex_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/mutex/sys_mutex/CMakeLists.txt
+++ b/tests/kernel/mutex/sys_mutex/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mutex)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/obj_tracing/CMakeLists.txt
+++ b/tests/kernel/obj_tracing/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(obj_tracing)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/pending/CMakeLists.txt
+++ b/tests/kernel/pending/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(pending)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/pipe/pipe/CMakeLists.txt
+++ b/tests/kernel/pipe/pipe/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(pipe)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/pipe/pipe_api/CMakeLists.txt
+++ b/tests/kernel/pipe/pipe_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(pipe_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/poll/CMakeLists.txt
+++ b/tests/kernel/poll/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(poll)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/profiling/profiling_api/CMakeLists.txt
+++ b/tests/kernel/profiling/profiling_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(profiling_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/queue/CMakeLists.txt
+++ b/tests/kernel/queue/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(queue)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/sched/deadline/CMakeLists.txt
+++ b/tests/kernel/sched/deadline/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(deadline)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/sched/metairq/CMakeLists.txt
+++ b/tests/kernel/sched/metairq/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(preempt)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/sched/preempt/CMakeLists.txt
+++ b/tests/kernel/sched/preempt/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(preempt)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/sched/schedule_api/CMakeLists.txt
+++ b/tests/kernel/sched/schedule_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(schedule_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/semaphore/semaphore/CMakeLists.txt
+++ b/tests/kernel/semaphore/semaphore/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(semaphore)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/sleep/CMakeLists.txt
+++ b/tests/kernel/sleep/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sleep)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/smp/CMakeLists.txt
+++ b/tests/kernel/smp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(smp)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/kernel/spinlock/CMakeLists.txt
+++ b/tests/kernel/spinlock/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(spinlock)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/kernel/stack/stack/CMakeLists.txt
+++ b/tests/kernel/stack/stack/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(stack_usage)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/threads/dynamic_thread/CMakeLists.txt
+++ b/tests/kernel/threads/dynamic_thread/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(dynamic_thread)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/threads/no-multithreading/CMakeLists.txt
+++ b/tests/kernel/threads/no-multithreading/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(no-multithreading)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/threads/thread_apis/CMakeLists.txt
+++ b/tests/kernel/threads/thread_apis/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(thread_apis)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/threads/thread_init/CMakeLists.txt
+++ b/tests/kernel/threads/thread_init/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(thread_init)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/tickless/tickless/CMakeLists.txt
+++ b/tests/kernel/tickless/tickless/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tickless)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/kernel/tickless/tickless_concept/CMakeLists.txt
+++ b/tests/kernel/tickless/tickless_concept/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tickless_concept)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/timer/starve/CMakeLists.txt
+++ b/tests/kernel/timer/starve/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(timer_starve)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/timer/timer_api/CMakeLists.txt
+++ b/tests/kernel/timer/timer_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(timer_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/timer/timer_monotonic/CMakeLists.txt
+++ b/tests/kernel/timer/timer_monotonic/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(timer_monotonic)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/workq/critical/CMakeLists.txt
+++ b/tests/kernel/workq/critical/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(critical)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/workq/work_queue/CMakeLists.txt
+++ b/tests/kernel/workq/work_queue/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(work_queue)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/workq/work_queue_api/CMakeLists.txt
+++ b/tests/kernel/workq/work_queue_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(work_queue_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/xip/CMakeLists.txt
+++ b/tests/kernel/xip/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(xip)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/c_lib/CMakeLists.txt
+++ b/tests/lib/c_lib/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(c_lib)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/cmsis_dsp/basicmath/CMakeLists.txt
+++ b/tests/lib/cmsis_dsp/basicmath/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cmsis_dsp_basicmath)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/cmsis_dsp/bayes/CMakeLists.txt
+++ b/tests/lib/cmsis_dsp/bayes/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cmsis_dsp_bayes)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/cmsis_dsp/complexmath/CMakeLists.txt
+++ b/tests/lib/cmsis_dsp/complexmath/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cmsis_dsp_complexmath)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/cmsis_dsp/distance/CMakeLists.txt
+++ b/tests/lib/cmsis_dsp/distance/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cmsis_dsp_distance)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/cmsis_dsp/fastmath/CMakeLists.txt
+++ b/tests/lib/cmsis_dsp/fastmath/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cmsis_dsp_fastmath)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/cmsis_dsp/filtering/CMakeLists.txt
+++ b/tests/lib/cmsis_dsp/filtering/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cmsis_dsp_filtering)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/cmsis_dsp/matrix/CMakeLists.txt
+++ b/tests/lib/cmsis_dsp/matrix/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cmsis_dsp_matrix)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/cmsis_dsp/statistics/CMakeLists.txt
+++ b/tests/lib/cmsis_dsp/statistics/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cmsis_dsp_statistics)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/cmsis_dsp/support/CMakeLists.txt
+++ b/tests/lib/cmsis_dsp/support/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cmsis_dsp_support)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/cmsis_dsp/svm/CMakeLists.txt
+++ b/tests/lib/cmsis_dsp/svm/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cmsis_dsp_svm)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/cmsis_dsp/transform/CMakeLists.txt
+++ b/tests/lib/cmsis_dsp/transform/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cmsis_dsp_transform)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/devicetree/api/CMakeLists.txt
+++ b/tests/lib/devicetree/api/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 set(DTS_ROOTS ${CMAKE_CURRENT_LIST_DIR})
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(devicetree)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/devicetree/legacy_api/CMakeLists.txt
+++ b/tests/lib/devicetree/legacy_api/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 set(DTS_ROOTS ${CMAKE_CURRENT_LIST_DIR})
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(devicetree)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/fdtable/CMakeLists.txt
+++ b/tests/lib/fdtable/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fdtable)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/gui/lvgl/CMakeLists.txt
+++ b/tests/lib/gui/lvgl/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lvgl)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/heap/CMakeLists.txt
+++ b/tests/lib/heap/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(heap)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/json/CMakeLists.txt
+++ b/tests/lib/json/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(json)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/mem_alloc/CMakeLists.txt
+++ b/tests/lib/mem_alloc/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mem_alloc)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/notify/CMakeLists.txt
+++ b/tests/lib/notify/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sys_notify)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/onoff/CMakeLists.txt
+++ b/tests/lib/onoff/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(onoff)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/ringbuffer/CMakeLists.txt
+++ b/tests/lib/ringbuffer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ringbuffer)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/sprintf/CMakeLists.txt
+++ b/tests/lib/sprintf/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sprintf)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/misc/test_build/CMakeLists.txt
+++ b/tests/misc/test_build/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(test_build)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/6lo/CMakeLists.txt
+++ b/tests/net/6lo/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(6lo)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/all/CMakeLists.txt
+++ b/tests/net/all/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(all)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/arp/CMakeLists.txt
+++ b/tests/net/arp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(arp)
 
 target_include_directories(

--- a/tests/net/buf/CMakeLists.txt
+++ b/tests/net/buf/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(buf)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/checksum_offload/CMakeLists.txt
+++ b/tests/net/checksum_offload/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(checksum_offload)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/context/CMakeLists.txt
+++ b/tests/net/context/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(net_context)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/dhcpv4/CMakeLists.txt
+++ b/tests/net/dhcpv4/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(dhcpv4)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/ethernet_mgmt/CMakeLists.txt
+++ b/tests/net/ethernet_mgmt/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ethernet_mgmt)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/hostname/CMakeLists.txt
+++ b/tests/net/hostname/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(iface)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/icmpv4/CMakeLists.txt
+++ b/tests/net/icmpv4/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(icmpv4)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/icmpv6/CMakeLists.txt
+++ b/tests/net/icmpv6/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(icmpv6)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/ieee802154/fragment/CMakeLists.txt
+++ b/tests/net/ieee802154/fragment/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fragment)
 
 target_include_directories(

--- a/tests/net/ieee802154/l2/CMakeLists.txt
+++ b/tests/net/ieee802154/l2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(l2)
 
 target_include_directories(

--- a/tests/net/iface/CMakeLists.txt
+++ b/tests/net/iface/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(iface)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/ip-addr/CMakeLists.txt
+++ b/tests/net/ip-addr/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ip-addr)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/ipv6/CMakeLists.txt
+++ b/tests/net/ipv6/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ipv6)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/ipv6_fragment/CMakeLists.txt
+++ b/tests/net/ipv6_fragment/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ipv6_fragment)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/lib/coap/CMakeLists.txt
+++ b/tests/net/lib/coap/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/lib/dns_addremove/CMakeLists.txt
+++ b/tests/net/lib/dns_addremove/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(dns_addremove)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/lib/dns_packet/CMakeLists.txt
+++ b/tests/net/lib/dns_packet/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(dns_packet)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/lib/dns_resolve/CMakeLists.txt
+++ b/tests/net/lib/dns_resolve/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(dns_resolve)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/lib/http_header_fields/CMakeLists.txt
+++ b/tests/net/lib/http_header_fields/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(http_header_fields)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/lib/mqtt_packet/CMakeLists.txt
+++ b/tests/net/lib/mqtt_packet/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mqtt_packet)
 
 target_include_directories(app PRIVATE

--- a/tests/net/lib/mqtt_publisher/CMakeLists.txt
+++ b/tests/net/lib/mqtt_publisher/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mqtt_publisher)
 
 target_include_directories(app PRIVATE

--- a/tests/net/lib/mqtt_pubsub/CMakeLists.txt
+++ b/tests/net/lib/mqtt_pubsub/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mqtt_subscriber)
 
 target_include_directories(app PRIVATE

--- a/tests/net/lib/mqtt_subscriber/CMakeLists.txt
+++ b/tests/net/lib/mqtt_subscriber/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mqtt_subscriber)
 
 target_include_directories(app PRIVATE

--- a/tests/net/lib/tls_credentials/CMakeLists.txt
+++ b/tests/net/lib/tls_credentials/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tls_credentials)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/lib/tls_credentials)

--- a/tests/net/mgmt/CMakeLists.txt
+++ b/tests/net/mgmt/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mgmt)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/mld/CMakeLists.txt
+++ b/tests/net/mld/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mld)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/neighbor/CMakeLists.txt
+++ b/tests/net/neighbor/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(neighbor)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/net_pkt/CMakeLists.txt
+++ b/tests/net/net_pkt/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(net_pkt)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/pm/CMakeLists.txt
+++ b/tests/net/pm/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(pm)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/ppp/driver/CMakeLists.txt
+++ b/tests/net/ppp/driver/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(iface)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/promiscuous/CMakeLists.txt
+++ b/tests/net/promiscuous/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(promiscuous)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/ptp/clock/CMakeLists.txt
+++ b/tests/net/ptp/clock/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(clock)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/route/CMakeLists.txt
+++ b/tests/net/route/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(route)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/shell/CMakeLists.txt
+++ b/tests/net/shell/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(udp)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/socket/af_packet/CMakeLists.txt
+++ b/tests/net/socket/af_packet/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(socket_udp)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/socket/getaddrinfo/CMakeLists.txt
+++ b/tests/net/socket/getaddrinfo/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(getaddrinfo)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/socket/getnameinfo/CMakeLists.txt
+++ b/tests/net/socket/getnameinfo/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(getnameinfo)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/socket/misc/CMakeLists.txt
+++ b/tests/net/socket/misc/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(socket-misc)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/socket/net_mgmt/CMakeLists.txt
+++ b/tests/net/socket/net_mgmt/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(getaddrinfo)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/socket/poll/CMakeLists.txt
+++ b/tests/net/socket/poll/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(socket_poll)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/socket/register/CMakeLists.txt
+++ b/tests/net/socket/register/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(socket_register)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/socket/select/CMakeLists.txt
+++ b/tests/net/socket/select/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(select)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/socket/socketpair/CMakeLists.txt
+++ b/tests/net/socket/socketpair/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(socketpair)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/socket/tcp/CMakeLists.txt
+++ b/tests/net/socket/tcp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(socket_tcp)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/socket/udp/CMakeLists.txt
+++ b/tests/net/socket/udp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(socket_udp)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/socket/websocket/CMakeLists.txt
+++ b/tests/net/socket/websocket/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(websocket)
 
 target_include_directories(app PRIVATE

--- a/tests/net/tcp/CMakeLists.txt
+++ b/tests/net/tcp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tcp)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/tcp2/CMakeLists.txt
+++ b/tests/net/tcp2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tcp)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/traffic_class/CMakeLists.txt
+++ b/tests/net/traffic_class/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(traffic_class)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/trickle/CMakeLists.txt
+++ b/tests/net/trickle/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(trickle)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/tx_timestamp/CMakeLists.txt
+++ b/tests/net/tx_timestamp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tx_timestamp)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/udp/CMakeLists.txt
+++ b/tests/net/udp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(udp)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/utils/CMakeLists.txt
+++ b/tests/net/utils/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(utils)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/net/vlan/CMakeLists.txt
+++ b/tests/net/vlan/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(vlan)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)

--- a/tests/portability/cmsis_rtos_v1/CMakeLists.txt
+++ b/tests/portability/cmsis_rtos_v1/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cmsis_rtos_v1)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/include/cmsis_rtos_v1)

--- a/tests/portability/cmsis_rtos_v2/CMakeLists.txt
+++ b/tests/portability/cmsis_rtos_v2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/include/cmsis_rtos_v2)

--- a/tests/posix/common/CMakeLists.txt
+++ b/tests/posix/common/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(posix_common)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/posix/fs/CMakeLists.txt
+++ b/tests/posix/fs/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fs)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/shell/CMakeLists.txt
+++ b/tests/shell/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(shell)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/canbus/frame/CMakeLists.txt
+++ b/tests/subsys/canbus/frame/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(can_frame)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/canbus/isotp/conformance/CMakeLists.txt
+++ b/tests/subsys/canbus/isotp/conformance/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(integration)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/canbus/isotp/implementation/CMakeLists.txt
+++ b/tests/subsys/canbus/isotp/implementation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(integration)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/dfu/img_util/CMakeLists.txt
+++ b/tests/subsys/dfu/img_util/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(img_util)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/dfu/mcuboot/CMakeLists.txt
+++ b/tests/subsys/dfu/mcuboot/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mcuboot)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/fs/fat_fs_api/CMakeLists.txt
+++ b/tests/subsys/fs/fat_fs_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fat_fs_api)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/fs/fat_fs_dual_drive/CMakeLists.txt
+++ b/tests/subsys/fs/fat_fs_dual_drive/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fat_fs_dual_drive)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/fs/fcb/CMakeLists.txt
+++ b/tests/subsys/fs/fcb/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fs_fcb)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/fs/littlefs/CMakeLists.txt
+++ b/tests/subsys/fs/littlefs/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(littlefs)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/fs/multi-fs/CMakeLists.txt
+++ b/tests/subsys/fs/multi-fs/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(multi-fs)
 
 zephyr_compile_definitions(

--- a/tests/subsys/fs/nvs/CMakeLists.txt
+++ b/tests/subsys/fs/nvs/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fs_nvs)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/jwt/CMakeLists.txt
+++ b/tests/subsys/jwt/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/logging/log_core/CMakeLists.txt
+++ b/tests/subsys/logging/log_core/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(log_core)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/logging/log_immediate/CMakeLists.txt
+++ b/tests/subsys/logging/log_immediate/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(log_immediate_test)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/logging/log_list/CMakeLists.txt
+++ b/tests/subsys/logging/log_list/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(log_list)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/logging/log_msg/CMakeLists.txt
+++ b/tests/subsys/logging/log_msg/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(log_msg)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/logging/log_output/CMakeLists.txt
+++ b/tests/subsys/logging/log_output/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(log_output)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/settings/fcb/base64/CMakeLists.txt
+++ b/tests/subsys/settings/fcb/base64/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(settings_fcb)
 
 add_subdirectory(../src fcb_test_bindir)

--- a/tests/subsys/settings/fcb/raw/CMakeLists.txt
+++ b/tests/subsys/settings/fcb/raw/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 add_subdirectory(../src fcb_test_bindir)

--- a/tests/subsys/settings/fcb_init/CMakeLists.txt
+++ b/tests/subsys/settings/fcb_init/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fcb_init)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/settings/functional/fcb/CMakeLists.txt
+++ b/tests/subsys/settings/functional/fcb/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 # The code is in the library common to several tests.

--- a/tests/subsys/settings/functional/file/CMakeLists.txt
+++ b/tests/subsys/settings/functional/file/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources ../src/*.c)

--- a/tests/subsys/settings/functional/nvs/CMakeLists.txt
+++ b/tests/subsys/settings/functional/nvs/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 # The code is in the library common to several tests.

--- a/tests/subsys/settings/littlefs/base64/CMakeLists.txt
+++ b/tests/subsys/settings/littlefs/base64/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(littlefs)
 
 add_subdirectory(../src littlefs_test_bindir)

--- a/tests/subsys/settings/littlefs/raw/CMakeLists.txt
+++ b/tests/subsys/settings/littlefs/raw/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 add_subdirectory(../src littlefs_test_bindir)

--- a/tests/subsys/settings/nvs/raw/CMakeLists.txt
+++ b/tests/subsys/settings/nvs/raw/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(test_settings_nvs_raw)
 
 add_subdirectory(../src nvs_test_bindir)

--- a/tests/subsys/shell/shell_history/CMakeLists.txt
+++ b/tests/subsys/shell/shell_history/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(shell)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/storage/flash_map/CMakeLists.txt
+++ b/tests/subsys/storage/flash_map/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(flash_map)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/usb/bos/CMakeLists.txt
+++ b/tests/subsys/usb/bos/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bos)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/usb/desc_sections/CMakeLists.txt
+++ b/tests/subsys/usb/desc_sections/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(os_desc)
 
 zephyr_library_include_directories(

--- a/tests/subsys/usb/device/CMakeLists.txt
+++ b/tests/subsys/usb/device/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(usb_device_test)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/usb/os_desc/CMakeLists.txt
+++ b/tests/subsys/usb/os_desc/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(os_desc)
 
 zephyr_library_include_directories(

--- a/tests/ztest/base/CMakeLists.txt
+++ b/tests/ztest/base/CMakeLists.txt
@@ -7,7 +7,7 @@ if(BOARD STREQUAL unit_testing)
   find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
   project(base)
 else()
-  find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+  find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
   project(base)
 
   FILE(GLOB app_sources src/*.c)

--- a/tests/ztest/custom_output/CMakeLists.txt
+++ b/tests/ztest/custom_output/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(integration)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/ztest/mock/CMakeLists.txt
+++ b/tests/ztest/mock/CMakeLists.txt
@@ -7,7 +7,7 @@ if(BOARD STREQUAL unit_testing)
   find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
   project(mock)
 else()
-  find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+  find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
   project(mock)
 
   FILE(GLOB app_sources src/*.c)


### PR DESCRIPTION
... because it is (required).

This makes a difference when building with CMake and forgetting
ZEPHYR_BASE or not registering Zephyr in the CMake package registry.

In this particular case, REQUIRED turns this harmless looking log
statement:
```
-- Could NOT find Zephyr (missing: Zephyr_DIR)
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/bin/cc
-- ...
-- ...
-- ...
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at CMakeLists.txt:8 (target_sources):
  Cannot specify sources for target "app" which is not built by
  this project.
```
... into this louder, clearer, faster and (last but not least) final
error:
```
CMake Error at CMakeLists.txt:5 (find_package):
  Could not find a package configuration file provided by "Zephyr" with
  any of the following names:

    ZephyrConfig.cmake
    zephyr-config.cmake

  Add the installation prefix of "Zephyr" to CMAKE_PREFIX_PATH or set
  "Zephyr_DIR" to a directory containing one of the above files.  If
  "Zephyr" provides a separate development package or SDK, be sure it
  has been installed.

-- Configuring incomplete, errors occurred!
```