### PR TITLE
net: wifi: shell: store shell in context before scan

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -251,6 +251,8 @@ static int cmd_wifi_scan(const struct shell *shell, size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_default();
 
+	context.shell = shell;
+
 	if (net_mgmt(NET_REQUEST_WIFI_SCAN, iface, NULL, 0)) {
 		shell_fprintf(shell, SHELL_WARNING, "Scan request failed\n");
 


### PR DESCRIPTION
Right now shell pointer is not assigned before doing a scan, so scan
results are printed using printk(). Save shell instance in context, so
results are printed using shell_fprintf(), thus better aligned in the
console output.

Before:
```
uart:~$ wifi scan
Scan requested
uart:~$ Num  | SSID                             (len) | Chan | RSSI | Sec  
1    | Tp-Link                          7     | 8    | -33  | WPA/WPA2
Scan request done

uart:~$
```

After:
```
uart:~$ wifi scan 
Scan requested
Num  | SSID                             (len) | Chan | RSSI | Sec  
1    | Tp-Link                          7     | 8    | -32  | WPA/WPA2
Scan request done
uart:~$
```