### PR TITLE
tests: kernel: timer_api: fix formatting specifiers in diagnostic

### DIFF
--- a/tests/kernel/timer/timer_api/src/timer_convert.c
+++ b/tests/kernel/timer/timer_api/src/timer_convert.c
@@ -14,6 +14,12 @@ enum units { UNIT_ticks, UNIT_cyc, UNIT_ms, UNIT_us, UNIT_ns };
 
 enum round { ROUND_floor, ROUND_ceil, ROUND_near };
 
+static const char *const round_s[] = {
+	[ROUND_floor] = "floor",
+	[ROUND_ceil] = "ceil",
+	[ROUND_near] = "near",
+};
+
 struct test_rec {
 	enum units src;
 	enum units dst;
@@ -156,9 +162,10 @@ void test_conversion(struct test_rec *t, uint64_t val)
 	}
 
 	zassert_true(diff <= maxdiff && diff >= mindiff,
-		     "Convert %lld from %lldhz to %lldhz (= %lld) failed. "
-		     "diff %lld should be in [%lld:%lld]",
-		     val, from_hz, to_hz, result, diff, mindiff, maxdiff);
+		     "Convert %llu (%llx) from %u Hz to %u Hz %u-bit %s\n"
+		     "result %llu (%llx) diff %lld (%llx) should be in [%lld:%lld]",
+		     val, val, from_hz, to_hz, t->precision, round_s[t->round],
+		     result, result, diff, diff, mindiff, maxdiff);
 }
 
 void test_time_conversions(void)


### PR DESCRIPTION
Several of the values passed to the conversion failure diagnostic are
unsigned and/or 32-bit values, while all format specifiers are for
signed 64-bit integers.  Make the specifiers consistent with the
argument.

This eliminates bogus diagnostic output like:
```
    Assertion failed at WEST_TOPDIR/zephyr/tests/kernel/timer/timer_api/src/timer_convert.c:157: test_conversion: (diff <= maxdiff && diff >= mindiff && 0 i
s false)
Convert 0 from ERRhz to 0hz (= 0) failed. diff 0 should be in [999:32768]
```

as demonstrated in https://github.com/zephyrproject-rtos/zephyr/issues/25750#issuecomment-635868467