### PR TITLE
Bluetooth: l2cap: Add missing __packed

### DIFF
--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -183,7 +183,7 @@ struct bt_l2cap_le_conn_rsp {
 	u16_t mps;
 	u16_t credits;
 	u16_t result;
-};
+} __packed;
 
 #define BT_L2CAP_LE_CREDITS             0x16
 struct bt_l2cap_le_credits {


### PR DESCRIPTION
The bt_l2cap_le_conn_rsp structure was not being defined as packed,
which is wrong since it's bein mapped directly on memory coming from the
air.

Fixes #25824.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>