### PR TITLE
bluetooth: host: fix unpacked l2cap struct

### DIFF
--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -183,7 +183,7 @@ struct bt_l2cap_le_conn_rsp {
 	u16_t mps;
 	u16_t credits;
 	u16_t result;
-};
+} __packed;
 
 #define BT_L2CAP_LE_CREDITS             0x16
 struct bt_l2cap_le_credits {


### PR DESCRIPTION
The bt_l2cap_le_conn_rsp struct in l2cap_internal.h has not been
declared __packed. This can cause alignment problems on some
platforms if the struct is placed on an unaligned address.

A __packed declaration solves this issue by forcing the compiler to
use store instructions that do not required alignment.

Fixes #25824