### PR TITLE
west.yml: check nxp time delay

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -95,7 +95,7 @@ manifest:
       revision: 1c4fdba512b268033a4cf926bddd323866c3261a
       path: tools/net-tools
     - name: hal_nxp
-      revision: 80a337dc4cc980f80e595971147eb41458b29ae8
+      revision: pull/36/head
       path: modules/hal/nxp
     - name: open-amp
       revision: 724f7e2a4519d7e1d40ef330042682dea950c991


### PR DESCRIPTION
For CI check nxp spi time delay driver update.

Signed-off-by: Frank Li <lgl88911@163.com>

Depends on zephyrproject-rtos/hal_nxp#36