### PR TITLE
drivers: spi_ll_stm32: fix COND_CODE_1 usage

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -886,7 +886,7 @@ static void spi_stm32_irq_config_func_##id(struct device *dev)		\
 .dma_##dir = {								\
 	 COND_CODE_1(DT_INST_DMAS_HAS_NAME(id, dir),			\
 		     (SPI_DMA_CHANNEL_INIT(id, dir, DIR, src, dest)),	\
-		     NULL)						\
+		     (NULL))						\
 	     },
 #else
 #define SPI_DMA_CHANNEL(id, dir, DIR, src, dest)


### PR DESCRIPTION
The consequent and alternate expressions for COND_CODE_1 must be
enclosed in parentheses, like this:

COND_CODE_1(PREDICATE, (consequent), (alternate))

The parens are missing in exactly one place in the tree. Fix it.

Reported-by: Peter Bigot <peter.bigot@nordicsemi.no>
Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>