### PR TITLE
kernel/timer: Handle K_FOREVER in k_timer_start()

### DIFF
--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -109,6 +109,10 @@ void k_timer_init(struct k_timer *timer,
 void z_impl_k_timer_start(struct k_timer *timer, k_timeout_t duration,
 			  k_timeout_t period)
 {
+	if (K_TIMEOUT_EQ(duration, K_FOREVER)) {
+		return;
+	}
+
 #ifdef CONFIG_LEGACY_TIMEOUT_API
 	duration = k_ms_to_ticks_ceil32(duration);
 	period = k_ms_to_ticks_ceil32(period);


### PR DESCRIPTION
The possibility of passing K_FOREVER as the initial duration argument
to k_timer_start() wasn't being handled, with the result that the
computed value became an zero timeout (effecitvely treating it as
K_NO_WAIT and firing at the next tick).

This is obviously pathlogical, but it should still do what the code
says it should and wait forever.

Make k_timer_start(..., K_FOREVER, ...) a noop.

Fixes #25820

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>