### PR TITLE
tests: kernel: timer_api: more attempts to make this pass on every Nordic board instance

### DIFF
--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -204,7 +204,9 @@ void test_timer_period_0(void)
 	busy_wait_ms(DURATION + 1);
 
 	/** TESTPOINT: ensure it is one-short timer */
-	TIMER_ASSERT(tdata.expire_cnt == 1, &period0_timer);
+	TIMER_ASSERT((tdata.expire_cnt == 1)
+		     || (INEXACT_MS_CONVERT
+			 && (tdata.expire_cnt == 0)), &period0_timer);
 	TIMER_ASSERT(tdata.stop_cnt == 0, &period0_timer);
 
 	/* cleanup environemtn */

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -195,7 +195,11 @@ void test_timer_period_0(void)
 {
 	init_timer_data();
 	/** TESTPOINT: set period 0 */
-	k_timer_start(&period0_timer, K_MSEC(DURATION), K_NO_WAIT);
+	k_timer_start(&period0_timer,
+		      K_TICKS(k_ms_to_ticks_floor32(DURATION)
+			      - BUSY_SLEW_THRESHOLD_TICKS(DURATION
+							  * USEC_PER_MSEC)),
+		      K_NO_WAIT);
 	tdata.timestamp = k_uptime_get();
 	busy_wait_ms(DURATION + 1);
 

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -659,7 +659,11 @@ void test_timeout_abs(void)
 	cap2_ticks = k_uptime_ticks();
 	k_timer_stop(&remain_timer);
 	zassert_true((cap_ticks + rem_ticks + 1 == exp_ticks)
-		     || (rem_ticks + cap2_ticks + 1 == exp_ticks),
+		     || (rem_ticks + cap2_ticks + 1 == exp_ticks)
+		     || (INEXACT_MS_CONVERT
+			 && (cap_ticks + rem_ticks == exp_ticks))
+		     || (INEXACT_MS_CONVERT
+			 && (rem_ticks + cap2_ticks == exp_ticks)),
 		     NULL);
 #endif
 }


### PR DESCRIPTION
It's known that Nordic boards use a different clock source for the system clock and the CPU (which controls the duration of `k_busy_wait()`.  The skew between these clocks is dependent on board electronics, temperature, and who knows what else.  However, the test was originally written presuming these clocks were in sync, which is probably true for most other platforms.

This PR adds another way of estimating the maximum potential error that can be observed on a Nordic board running this test, and uses this in two test cases that have been observed to fail (many of the others have not, but it's probably just a matter of time).

I'm not entirely comfortable with merging this at this point in the release cycle, because I can't guarantee it won't have an effect on other boards (most likely making them pass when they shouldn't). ~For one thing it may be that the correct default slew for non-Nordic boards is 0 ppm, but I've made it 1 ppm just so it's less likely other boards will fail when they shouldn't.~ updated version makes this 0.

For another if we're going to try to do this sort of error estimation we should do it outside this test and make it dependent on actual clock configurations.  That's something we might consider for 2.4.0.