### PR TITLE
LED utilities

### DIFF
--- a/drivers/led/CMakeLists.txt
+++ b/drivers/led/CMakeLists.txt
@@ -5,6 +5,7 @@ zephyr_sources_ifdef(CONFIG_LP3943 lp3943.c)
 zephyr_sources_ifdef(CONFIG_LP5562 lp5562.c)
 zephyr_sources_ifdef(CONFIG_PCA9633 pca9633.c)
 
+zephyr_sources_ifdef(CONFIG_LED_GPIO    led_gpio.c)
 zephyr_sources_ifdef(CONFIG_LED_SHELL   led_shell.c)
 
 zephyr_sources_ifdef(CONFIG_USERSPACE   led_handlers.c)

--- a/drivers/led/CMakeLists.txt
+++ b/drivers/led/CMakeLists.txt
@@ -5,4 +5,6 @@ zephyr_sources_ifdef(CONFIG_LP3943 lp3943.c)
 zephyr_sources_ifdef(CONFIG_LP5562 lp5562.c)
 zephyr_sources_ifdef(CONFIG_PCA9633 pca9633.c)
 
+zephyr_sources_ifdef(CONFIG_LED_SHELL   led_shell.c)
+
 zephyr_sources_ifdef(CONFIG_USERSPACE   led_handlers.c)

--- a/drivers/led/Kconfig
+++ b/drivers/led/Kconfig
@@ -26,6 +26,7 @@ config LED_SHELL
 	help
 	  Enable LED shell for testing.
 
+source "drivers/led/Kconfig.gpio"
 source "drivers/led/Kconfig.ht16k33"
 source "drivers/led/Kconfig.lp3943"
 source "drivers/led/Kconfig.lp5562"

--- a/drivers/led/Kconfig
+++ b/drivers/led/Kconfig
@@ -20,6 +20,12 @@ config LED_INIT_PRIORITY
 	help
 	  System initialization priority for LED drivers.
 
+config LED_SHELL
+	bool "LED shell"
+	depends on SHELL
+	help
+	  Enable LED shell for testing.
+
 source "drivers/led/Kconfig.ht16k33"
 source "drivers/led/Kconfig.lp3943"
 source "drivers/led/Kconfig.lp5562"

--- a/drivers/led/Kconfig.gpio
+++ b/drivers/led/Kconfig.gpio
@@ -1,0 +1,8 @@
+# Copyright (c) 2018 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+config LED_GPIO
+	bool "GPIO LED driver"
+	depends on GPIO
+	help
+	  Enable driver for LEDs connected to output GPIOs.

--- a/drivers/led/led_gpio.c
+++ b/drivers/led/led_gpio.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2020 Seagate Technology LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT gpio_leds
+
+/**
+ * @file
+ * @brief LED driver for GPIO connected LEDs.
+ */
+
+#include <drivers/gpio.h>
+#include <drivers/led.h>
+#include <device.h>
+#include <zephyr.h>
+
+#define LOG_LEVEL CONFIG_LED_LOG_LEVEL
+#include <logging/log.h>
+LOG_MODULE_REGISTER(led_gpio);
+
+#define DEV_CFG(dev)  ((const struct led_gpio_config *) \
+		       ((dev)->config_info))
+#define DEV_DATA(dev) ((struct led_gpio_data *) \
+		       ((dev)->driver_data))
+
+struct led_gpio_config {
+	char *gpio_controller_label;
+	u32_t gpio_pin;
+	u32_t gpio_flags;
+};
+
+struct led_gpio_data {
+	struct device *gpio_dev;
+};
+
+static int led_gpio_set_brightness(struct device *dev, u32_t led, u8_t value)
+{
+	const struct led_gpio_config *config = DEV_CFG(dev);
+	struct led_gpio_data *data = DEV_DATA(dev);
+
+	if (led != 0) {
+		return -EINVAL;
+	}
+
+	return gpio_pin_set(data->gpio_dev, config->gpio_pin, value);
+}
+
+static int led_gpio_on(struct device *dev, u32_t led)
+{
+	return led_gpio_set_brightness(dev, led, 1);
+}
+
+static int led_gpio_off(struct device *dev, u32_t led)
+{
+	return led_gpio_set_brightness(dev, led, 0);
+}
+
+static int led_gpio_init(struct device *dev)
+{
+	const struct led_gpio_config *config = DEV_CFG(dev);
+	struct led_gpio_data *data = DEV_DATA(dev);
+	int err;
+
+	data->gpio_dev = device_get_binding(config->gpio_controller_label);
+	if (data->gpio_dev == NULL) {
+		LOG_ERR("%s: device %s not found",
+			dev->name, config->gpio_controller_label);
+		return -ENODEV;
+	}
+
+	err = gpio_pin_configure(data->gpio_dev,
+				 config->gpio_pin, config->gpio_flags);
+	if (err != 0) {
+		LOG_ERR("%s: failed to configure GPIO %s %d (error: %d)",
+			dev->name, config->gpio_controller_label,
+			config->gpio_pin, err);
+	}
+
+	return err;
+}
+
+static const struct led_driver_api led_gpio_api = {
+	.set_brightness	= led_gpio_set_brightness,
+	.on		= led_gpio_on,
+	.off		= led_gpio_off,
+};
+
+#define LED_GPIO_DEVICE(id)					\
+								\
+static struct led_gpio_config led_gpio_config_##id = {		\
+	.gpio_controller_label = DT_GPIO_LABEL(id, gpios),	\
+	.gpio_pin = DT_GPIO_PIN(id, gpios),			\
+	.gpio_flags = DT_GPIO_FLAGS(id, gpios)			\
+			| GPIO_OUTPUT_INACTIVE,			\
+};								\
+								\
+static struct led_gpio_data led_gpio_data_##id;			\
+								\
+DEVICE_AND_API_INIT(led_gpio_led_##id, DT_LABEL(id),		\
+		    &led_gpio_init,				\
+		    &led_gpio_data_##id,			\
+		    &led_gpio_config_##id,			\
+		    POST_KERNEL, CONFIG_LED_INIT_PRIORITY,	\
+		    &led_gpio_api);
+
+#define LED_GPIO_INST(inst) DT_INST_FOREACH_CHILD(inst, LED_GPIO_DEVICE)
+
+DT_INST_FOREACH_STATUS_OKAY(LED_GPIO_INST)

--- a/drivers/led/led_shell.c
+++ b/drivers/led/led_shell.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2020 Seagate Technology LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <shell/shell.h>
+#include <drivers/led.h>
+#include <stdlib.h>
+
+#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
+#include <logging/log.h>
+LOG_MODULE_REGISTER(led_shell);
+
+enum {
+	arg_idx_dev		= 1,
+	arg_idx_led		= 2,
+	arg_idx_brightness	= 3,
+};
+
+static int parse_common_args(const struct shell *shell, char **argv,
+			   struct device **dev, u32_t *led)
+{
+	char *end_ptr;
+
+	*dev = device_get_binding(argv[arg_idx_dev]);
+	if (!*dev) {
+		shell_error(shell,
+			    "LED device %s not found", argv[arg_idx_dev]);
+		return -ENODEV;
+	}
+
+	*led = strtoul(argv[arg_idx_led], &end_ptr, 0);
+	if (*end_ptr != '\0') {
+		shell_error(shell, "Invalid LED number parameter %s",
+			    argv[arg_idx_led]);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int cmd_off(const struct shell *shell, size_t argc, char **argv)
+{
+	struct device *dev;
+	u32_t led;
+	int err;
+
+	err = parse_common_args(shell, argv, &dev, &led);
+	if (err < 0) {
+		return err;
+	}
+
+	shell_print(shell, "%s: turning off LED %d", dev->name, led);
+
+	err = led_off(dev, led);
+	if (err) {
+		shell_error(shell, "Error: %d", err);
+	}
+
+	return err;
+}
+
+static int cmd_on(const struct shell *shell, size_t argc, char **argv)
+{
+	struct device *dev;
+	u32_t led;
+	int err;
+
+	err = parse_common_args(shell, argv, &dev, &led);
+	if (err < 0) {
+		return err;
+	}
+
+	shell_print(shell, "%s: turning on LED %d", dev->name, led);
+
+	err = led_on(dev, led);
+	if (err) {
+		shell_error(shell, "Error: %d", err);
+	}
+
+	return err;
+}
+
+static int cmd_set_brightness(const struct shell *shell,
+			      size_t argc, char **argv)
+{
+	struct device *dev;
+	u32_t led;
+	int err;
+	char *end_ptr;
+	unsigned long brightness;
+
+	err = parse_common_args(shell, argv, &dev, &led);
+	if (err < 0) {
+		return err;
+	}
+
+	brightness = strtoul(argv[arg_idx_brightness], &end_ptr, 0);
+	if (*end_ptr != '\0') {
+		shell_error(shell, "Invalid LED brightness parameter %s",
+			     argv[arg_idx_brightness]);
+		return -EINVAL;
+	}
+	if (brightness > 255) {
+		shell_error(shell, "Invalid LED brightness value %d (max 255)",
+			     brightness);
+		return -EINVAL;
+	}
+
+	shell_print(shell, "%s: setting LED %d brightness to %d",
+		    dev->name, led, brightness);
+
+	err = led_set_brightness(dev, led, (u8_t) brightness);
+	if (err) {
+		shell_error(shell, "Error: %d", err);
+	}
+
+	return err;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_led,
+	SHELL_CMD_ARG(off, NULL, "<device> <led_num>", cmd_off, 3, 0),
+	SHELL_CMD_ARG(on, NULL, "<device> <led_num>", cmd_on, 3, 0),
+	SHELL_CMD_ARG(set_brightness, NULL,
+		      "<device> <led_num> <brightness [0-255]>",
+		      cmd_set_brightness, 4, 0),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_CMD_REGISTER(led, &sub_led, "LED commands", NULL);


### PR DESCRIPTION
This pull request adds a couple of utilities to the LED subsystem:

- A "led" shell command. This allows to run the LED API functions from
  the Zephyr shell. This can be helpful to test a LED driver without
  writing a dedicated sample.

- A driver for GPIO LEDs. Used in combination with the "led" shell
  command, this driver allows to test the gpio-leds DT nodes without
  using a dedicated sample. Eventually this could also be used to
  offload the GPIO LEDs configuration from a user sample.