### PR TITLE
drivers: clock: stm32: fix Flash latency & clock settings for MSI & HSE

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -71,7 +71,7 @@ manifest:
       revision: 5b3ec3e182d4310e8943cc34c6c70ae57d9711da
       path: modules/hal/st
     - name: hal_stm32
-      revision: 6812113dc58d134b74acdeebbffb4f80b8eeab75
+      revision: pull/54/head
       path: modules/hal/stm32
     - name: hal_ti
       revision: aabc6a04a8e871cbb01e02c22bb409f68001dc64


### PR DESCRIPTION
According to RM, when increasing the CPU frequency, the new number of
wait states to the Flash latency bits must be written and verified before
modifying the CPU clock source and/or the CPU clock prescaler; when
decreasing the CPU frequency, after.

Signed-off-by: Giancarlo Stasi <giancarlo.stasi.co@gmail.com>