### PR TITLE
cmake: make find_package(ZephyrUnittest...) REQUIRED

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -9,10 +9,10 @@
 # one of those lines:
 #
 # find_package(Zephyr)
-# find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+# find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 #
-# The `HINTS $ENV{ZEPHYR_BASE}` variant is required for any application inside
-# the Zephyr repository.
+# The `REQUIRED HINTS $ENV{ZEPHYR_BASE}` variant is required for any application
+# inside the Zephyr repository.
 #
 # It exists to reduce boilerplate code that Zephyr expects to be in
 # application CMakeLists.txt code.

--- a/tests/unit/base64/CMakeLists.txt
+++ b/tests/unit/base64/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 project(base64)
 set(SOURCES main.c)
-find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/crc/CMakeLists.txt
+++ b/tests/unit/crc/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 project(crc)
 set(SOURCES main.c)
-find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/intmath/CMakeLists.txt
+++ b/tests/unit/intmath/CMakeLists.txt
@@ -4,4 +4,4 @@ project(base64)
 set(SOURCES
   main.c
   )
-find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/list/CMakeLists.txt
+++ b/tests/unit/list/CMakeLists.txt
@@ -7,4 +7,4 @@ set(SOURCES
   dlist.c
   sflist.c
   )
-find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/math_extras/CMakeLists.txt
+++ b/tests/unit/math_extras/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 project(math_extras)
 set(SOURCES main.c portable.c)
-find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/rbtree/CMakeLists.txt
+++ b/tests/unit/rbtree/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 project(rbtree)
 set(SOURCES main.c)
-find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/timeutil/CMakeLists.txt
+++ b/tests/unit/timeutil/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 project(timeutil)
 set(SOURCES main.c test_gmtime.c  test_s32.c test_s64.c)
-find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 project(util)
 set(SOURCES main.c ../../../lib/os/dec.c)
-find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/ztest/base/CMakeLists.txt
+++ b/tests/ztest/base/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.13.1)
 if(BOARD STREQUAL unit_testing)
   list(APPEND SOURCES src/main.c)
 
-  find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+  find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
   project(base)
 else()
   find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/ztest/mock/CMakeLists.txt
+++ b/tests/ztest/mock/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.13.1)
 if(BOARD STREQUAL unit_testing)
   list(APPEND SOURCES src/main.c)
 
-  find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+  find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
   project(mock)
 else()
   find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})


### PR DESCRIPTION
This commit is a followup to PR #25808 which updates the tests to
ensure the REQUIRED keyword is also used for the ZephyrUnitest package.

This provides a better error message when building with CMake and
forgetting ZEPHYR_BASE or not registering Zephyr in the CMake package
registry.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>