### PR TITLE
net: fix two minor error bugs

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -35,6 +35,7 @@ LOG_MODULE_REGISTER(net_sock, CONFIG_NET_SOCKETS_LOG_LEVEL);
 		const struct socket_op_vtable *vtable; \
 		void *ctx = get_sock_vtable(sock, &vtable); \
 		if (ctx == NULL || vtable->fn == NULL) { \
+			errno = EBADF; \
 			return -1; \
 		} \
 		return vtable->fn(ctx, __VA_ARGS__); \
@@ -213,6 +214,7 @@ int z_impl_zsock_close(int sock)
 	void *ctx = z_get_fd_obj_and_vtable(sock, &vtable);
 
 	if (ctx == NULL) {
+		errno = EBADF;
 		return -1;
 	}
 
@@ -978,6 +980,7 @@ int z_impl_zsock_fcntl(int sock, int cmd, int flags)
 
 	obj = z_get_fd_obj_and_vtable(sock, &vtable);
 	if (obj == NULL) {
+		errno = EBADF;
 		return -1;
 	}
 
@@ -1510,6 +1513,7 @@ int z_impl_zsock_getsockname(int sock, struct sockaddr *addr,
 	void *ctx = z_get_fd_obj_and_vtable(sock, &vtable);
 
 	if (ctx == NULL) {
+		errno = EBADF;
 		return -1;
 	}
 

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -1473,7 +1473,7 @@ int zsock_getsockname_ctx(struct net_context *ctx, struct sockaddr *addr,
 
 	/* If we don't have a connection handler, the socket is not bound */
 	if (ctx->conn_handler) {
-		SET_ERRNO(EINVAL);
+		SET_ERRNO(-EINVAL);
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && ctx->local.family == AF_INET) {
@@ -1498,7 +1498,7 @@ int zsock_getsockname_ctx(struct net_context *ctx, struct sockaddr *addr,
 
 		memcpy(addr, &addr6, MIN(*addrlen, newlen));
 	} else {
-		SET_ERRNO(EINVAL);
+		SET_ERRNO(-EINVAL);
 	}
 
 	*addrlen = newlen;


### PR DESCRIPTION
* If the file descriptor object couldn't be looked up, set errno to `EBADF` before returning -1 to the caller

* Fix issue in `zsock_getsockname_ctx()` where the `SET_ERRNO()` calls within were not doing anything because a positive value was provided.