### PR TITLE
samples: subsys: mgmt: smp_svr: increase fs support stack size

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/overlay-fs.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/overlay-fs.conf
@@ -2,5 +2,8 @@
 CONFIG_FILE_SYSTEM=y
 CONFIG_FILE_SYSTEM_LITTLEFS=y
 
+# Add 256 bytes to accommodate upload command (lfs_stat overflows)
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2304
+
 # Enable file system commands
 CONFIG_MCUMGR_CMD_FS_MGMT=y


### PR DESCRIPTION
The upload command invokes lfs_stat() on the destination file which
overflows the stack.  Adding 256 bytes seems to make it work.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>