### PR TITLE
boards: particle_xenon: add support for second UART on feather header

### DIFF
--- a/boards/arm/particle_xenon/dts/mesh_feather_uart2_rtscts.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather_uart2_rtscts.dtsi
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2020 Peter Bigot Consulting, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Add hardware flow control to UART2, which is exposed only on Xenon
+ * mesh boards.
+ */
+&uart1 {
+	rts-pin = <35>;
+	cts-pin = <43>;
+	/* optional mesh_feather_uart2_rtscts.dtsi */
+};

--- a/boards/arm/particle_xenon/particle_xenon.dts
+++ b/boards/arm/particle_xenon/particle_xenon.dts
@@ -26,3 +26,12 @@
 		full-ohms = <(2100000 + 806000)>;
 	};
 };
+
+&uart1 { /* feather UART2 */
+	compatible = "nordic,nrf-uarte";
+	current-speed = <115200>;
+	status = "disabled";
+	tx-pin = <40>;
+	rx-pin = <42>;
+	/* optional mesh_feather_uart2_rtscts.dtsi */
+};


### PR DESCRIPTION
Provide devicetree configuration for UART2 on the mesh feather header.
The peripheral must be enabled in an overlay, optionally including a
provided overlay with the hardware flow control signals.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>