### PR TITLE
usb: stm32wb: Properly lock Sem5 before initializing USB.

### DIFF
--- a/soc/arm/st_stm32/stm32wb/soc.h
+++ b/soc/arm/st_stm32/stm32wb/soc.h
@@ -49,9 +49,9 @@
 #include <stm32wbxx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_FLASH
+#if defined(CONFIG_FLASH) || defined(CONFIG_USB)
 #include <stm32wbxx_ll_hsem.h>
-#endif /* CONFIG_FLASH */
+#endif /* CONFIG_FLASH || CONFIG_USB */
 
 #ifdef CONFIG_I2C_STM32
 #include <stm32wbxx_ll_i2c.h>


### PR DESCRIPTION
* AN5289 notes that Sem5 should be held before configuring
  CLK48 for USB timing.

Fixes #25880

Signed-off-by: Pete Johanson <peter@peterjohanson.com>

With this fix, I can enable my stm32wb55rg board as *both* a USB peripheral and start the BLE stack.