### PR TITLE
drivers: flash: spi_nor: add SFDP support

### DIFF
--- a/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
+++ b/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
@@ -86,8 +86,13 @@
 		reg = <0>;
 		spi-max-frequency = <80000000>;
 		size = <0x800000>;
-		has-be32k;
 		jedec-id = [c2 28 14];
+		sfdp-bfp = [
+			 e5 20 f1 ff  ff ff 7f 00  44 eb 08 6b  08 3b 04 bb
+			 ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
+			 10 d8 00 ff  23 72 f5 00  82 ed 04 b7  44 83 38 44
+			 30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
+		];
 	};
 };
 

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -215,8 +215,13 @@ arduino_i2c: &i2c0 {
 		sck-frequency = <8000000>;
 		label = "MX25R64";
 		jedec-id = [c2 28 17];
+		sfdp-bfp = [
+			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb
+			ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
+			10 d8 00 ff  23 72 f5 00  82 ed 04 cc  44 83 68 44
+			30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
+		];
 		size = <67108864>;
-		has-be32k;
 		has-dpd;
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <35000>;

--- a/boards/arm/particle_xenon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather.dtsi
@@ -202,11 +202,15 @@ feather_i2c: &i2c0 { };
 		wp-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 		hold-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
 		size = <0x2000000>;
-		has-be32k;
 		has-dpd;
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <100000>;
 		jedec-id = [c2 20 16];
+		sfdp-bfp = [
+			e5 20 f1 ff  ff ff ff 01  44 eb 08 6b  08 3b 04 bb
+			ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
+			10 d8 00 ff
+		];
 	};
 };
 

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1969,6 +1969,7 @@ PREDEFINED             = "CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT" \
                          "CONFIG_DEVICE_IDLE_PM" \
                          "CONFIG_ERRNO" \
                          "CONFIG_EXECUTION_BENCHMARKING" \
+                         "CONFIG_FLASH_JESD216_API" \
                          "CONFIG_FLASH_PAGE_LAYOUT" \
                          "CONFIG_FPU" \
                          "CONFIG_FPU_SHARING" \

--- a/drivers/flash/CMakeLists.txt
+++ b/drivers/flash/CMakeLists.txt
@@ -36,3 +36,4 @@ zephyr_include_directories_ifdef(
 	)
 
 zephyr_library_sources_ifdef(CONFIG_FLASH_SHELL flash_shell.c)
+zephyr_library_sources_ifdef(CONFIG_FLASH_JESD216 jesd216.c)

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -23,6 +23,14 @@ config FLASH_JESD216
 	 Selected by drivers that support JESD216-compatible flash
 	 devices to enable building a common support module.
 
+config FLASH_JESD216_API
+	bool "Provide API to read JESD216 flash parameters"
+	help
+	  This option extends the Zephyr flash API with the ability
+	  to access the Serial Flash Discoverable Parameter section
+	  allowing runtime determination of serial flash parameters
+	  for flash drivers that expose this capability.
+
 menuconfig FLASH
 	bool "Flash hardware support"
 	help

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -17,6 +17,12 @@ config FLASH_HAS_PAGE_LAYOUT
 	  This option is enabled when the SoC flash driver supports
 	  retrieving the layout of flash memory pages.
 
+config FLASH_JESD216
+	bool
+	help
+	 Selected by drivers that support JESD216-compatible flash
+	 devices to enable building a common support module.
+
 menuconfig FLASH
 	bool "Flash hardware support"
 	help

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -25,6 +25,7 @@ config FLASH_JESD216
 
 config FLASH_JESD216_API
 	bool "Provide API to read JESD216 flash parameters"
+	depends on FLASH_JESD216
 	help
 	  This option extends the Zephyr flash API with the ability
 	  to access the Serial Flash Discoverable Parameter section

--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -9,6 +9,33 @@ menuconfig SPI_NOR
 
 if SPI_NOR
 
+choice SPI_NOR_SFDP
+	prompt "Source for Serial Flash Discoverable Parameters"
+	default SPI_NOR_SFDP_MINIMAL
+
+config SPI_NOR_SFDP_MINIMAL
+	bool "Fixed flash configuration"
+	help
+	  Synthesize a minimal configuration assuming 256 By page size and
+	  standard 4 KiBy and 64 KiBy erase instructions.  Requires the size and
+	  jedec-id properties in the devicetree jedec,spi-nor node.
+
+config SPI_NOR_SFDP_DEVICETREE
+	bool "Basic Flash Parameters from devicetree node"
+	help
+	  The JESD216 Basic Flash Parameters table must be provided in the
+	  sfdp-bfp property in devicetree.  The size and jedec-id properties are
+	  also required.
+
+config SPI_NOR_SFDP_RUNTIME
+	bool "Read flash parameters at runtime"
+	help
+	  Read all flash device characteristics from the device at runtime.
+	  This option is the most flexible as it should provide functionality
+	  for all supported JESD216-compatible devices.
+
+endchoice
+
 config SPI_NOR_INIT_PRIORITY
 	int
 	default 80

--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -4,6 +4,7 @@
 menuconfig SPI_NOR
 	bool "SPI NOR Flash"
 	select FLASH_HAS_DRIVER_ENABLED
+	select FLASH_JESD216
 	depends on SPI
 
 if SPI_NOR

--- a/drivers/flash/flash_handlers.c
+++ b/drivers/flash/flash_handlers.c
@@ -85,4 +85,13 @@ static inline int z_vrfy_flash_sfdp_read(struct device *dev, off_t offset,
 }
 #include <syscalls/flash_sfdp_read.c>
 
+static inline int z_vrfy_flash_read_jedec_id(struct device *dev,
+					     uint8_t *id)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_FLASH(dev, read_jedec_id));
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(id, 3));
+	return z_impl_flash_read_jedec_id(dev, id);
+}
+#include <syscalls/flash_sfdp_jedec_id.c>
+
 #endif /* CONFIG_FLASH_JESD216_API */

--- a/drivers/flash/flash_handlers.c
+++ b/drivers/flash/flash_handlers.c
@@ -72,4 +72,17 @@ static inline size_t z_vrfy_flash_get_page_count(struct device *dev)
 }
 #include <syscalls/flash_get_page_count_mrsh.c>
 
-#endif
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+
+#ifdef CONFIG_FLASH_JESD216_API
+
+static inline int z_vrfy_flash_sfdp_read(struct device *dev, off_t offset,
+					 void *data, size_t len)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_FLASH(dev, sfdp_read));
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(data, len));
+	return z_impl_flash_sfdp_read(dev, offset, data, len);
+}
+#include <syscalls/flash_sfdp_read.c>
+
+#endif /* CONFIG_FLASH_JESD216_API */

--- a/drivers/flash/jesd216.c
+++ b/drivers/flash/jesd216.c
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2020 Peter Bigot Consulting, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#include <sys/types.h>
+#include <kernel.h>
+#include "jesd216.h"
+#include "spi_nor.h"
+
+static bool extract_instr(uint16_t packed,
+			  struct jesd216_instr *res)
+{
+	bool rv = (res != NULL);
+
+	if (rv) {
+		res->instr = packed >> 8;
+		res->mode_clocks = (packed >> 5) & 0x07;
+		res->wait_states = packed & 0x1F;
+	}
+	return rv;
+}
+
+int jesd216_bfp_read_support(const struct jesd216_param_header *php,
+			     const struct jesd216_bfp *bfp,
+			     enum jesd216_mode_type mode,
+			     struct jesd216_instr *res)
+{
+	int rv = -ENOTSUP;
+
+	switch (mode) {
+	case JESD216_MODE_044:
+		if ((php->len_dw >= 15)
+		    && (sys_le32_to_cpu(bfp->dw10[5]) & BIT(9))) {
+			rv = 0;
+		}
+		break;
+	case JESD216_MODE_088:
+		if ((php->len_dw >= 19)
+		    && (sys_le32_to_cpu(bfp->dw10[9]) & BIT(9))) {
+			rv = 0;
+		}
+		break;
+	case JESD216_MODE_111:
+		rv = 0;
+		break;
+	case JESD216_MODE_112:
+		if (sys_le32_to_cpu(bfp->dw1) & BIT(16)) {
+			uint32_t dw4 = sys_le32_to_cpu(bfp->dw4);
+
+			rv = extract_instr(dw4 >> 0, res);
+		}
+		break;
+	case JESD216_MODE_114:
+		if (sys_le32_to_cpu(bfp->dw1) & BIT(22)) {
+			uint32_t dw3 = sys_le32_to_cpu(bfp->dw3);
+
+			rv = extract_instr(dw3 >> 16, res);
+		}
+		break;
+	case JESD216_MODE_118:
+		if (php->len_dw >= 17) {
+			uint32_t dw17 = sys_le32_to_cpu(bfp->dw10[7]);
+
+			if ((dw17 >> 24) != 0) {
+				rv = extract_instr(dw17 >> 16, res);
+			}
+		}
+		break;
+	case JESD216_MODE_122:
+		if (sys_le32_to_cpu(bfp->dw1) & BIT(20)) {
+			uint32_t dw4 = sys_le32_to_cpu(bfp->dw4);
+
+			rv = extract_instr(dw4 >> 16, res);
+		}
+		break;
+	case JESD216_MODE_144:
+		if (sys_le32_to_cpu(bfp->dw1) & BIT(21)) {
+			uint32_t dw3 = sys_le32_to_cpu(bfp->dw3);
+
+			rv = extract_instr(dw3 >> 0, res);
+		}
+		break;
+	case JESD216_MODE_188:
+		if (php->len_dw >= 17) {
+			uint32_t dw17 = sys_le32_to_cpu(bfp->dw10[7]);
+
+			if ((uint8_t)(dw17 >> 8) != 0) {
+				rv = extract_instr(dw17 >> 0, res);
+			}
+		}
+		break;
+	case JESD216_MODE_222:
+		if (sys_le32_to_cpu(bfp->dw5) & BIT(0)) {
+			uint32_t dw6 = sys_le32_to_cpu(bfp->dw6);
+
+			rv = extract_instr(dw6 >> 16, res);
+		}
+		break;
+	case JESD216_MODE_444:
+		if (sys_le32_to_cpu(bfp->dw5) & BIT(4)) {
+			uint32_t dw7 = sys_le32_to_cpu(bfp->dw7);
+
+			rv = extract_instr(dw7 >> 16, res);
+		}
+		break;
+	/* Not clear how to detect these; they are identified only by
+	 * enable/disable sequences.
+	 */
+	case JESD216_MODE_44D4D:
+	case JESD216_MODE_888:
+	case JESD216_MODE_8D8D8D:
+		break;
+	default:
+		rv = -EINVAL;
+	}
+
+	return rv;
+}
+
+int jesd216_bfp_erase(const struct jesd216_bfp *bfp,
+		       uint8_t idx,
+		       struct jesd216_erase_type *etp)
+{
+	__ASSERT_NO_MSG((idx > 0) && (idx <= JESD216_NUM_ERASE_TYPES));
+
+	/* Types 1 and 2 are in dw8, types 3 and 4 in dw9 */
+	const uint32_t *dwp = &bfp->dw8 + (idx - 1U) / 2U;
+	uint32_t dw = sys_le32_to_cpu(*dwp);
+
+	/* Type 2(4) is in the upper half of the value. */
+	if ((idx & 0x01) == 0x00) {
+		dw >>= 16;
+	}
+
+	/* Extract the exponent and command */
+	uint8_t exp = (uint8_t)dw;
+	uint8_t cmd = (uint8_t)(dw >> 8);
+
+	if (exp == 0) {
+		return -EINVAL;
+	}
+	etp->cmd = cmd;
+	etp->exp = exp;
+	return 0;
+}
+
+int jesd216_bfp_erase_type_times(const struct jesd216_param_header *php,
+				 const struct jesd216_bfp *bfp,
+				 uint8_t idx,
+				 uint32_t *typ_ms)
+{
+	__ASSERT_NO_MSG((idx > 0) && (idx <= JESD216_NUM_ERASE_TYPES));
+
+	/* DW10 introduced in JESD216A */
+	if (php->len_dw < 10) {
+		return -ENOTSUP;
+	}
+
+	uint32_t dw10 = sys_le32_to_cpu(bfp->dw10[0]);
+
+	/* Each 7-bit erase time entry has a 5-bit count in the lower
+	 * bits, and a 2-bit unit in the upper bits.  The actual count
+	 * is the field content plus one.
+	 *
+	 * The entries start with ET1 at bit 4.  The low four bits
+	 * encode a value that is offset and scaled to produce a
+	 * multipler to convert from typical time to maximum time.
+	 */
+	unsigned int count = 1 + ((dw10 >> (4 + (idx - 1) * 7)) & 0x1F);
+	unsigned int units = ((dw10 >> (4 + 5 + (idx - 1) * 7)) & 0x03);
+	unsigned int max_factor = 2 * (1 + (dw10 & 0x0F));
+
+	switch (units) {
+	case 0x00:		/* 1 ms */
+		*typ_ms = count;
+		break;
+	case 0x01:		/* 16 ms */
+		*typ_ms = count * 16;
+		break;
+	case 0x02:		/* 128 ms */
+		*typ_ms = count * 128;
+		break;
+	case 0x03:		/* 1 s */
+		*typ_ms = count * MSEC_PER_SEC;
+		break;
+	}
+
+	return max_factor;
+}
+
+int jesd216_bfp_decode_dw11(const struct jesd216_param_header *php,
+			    const struct jesd216_bfp *bfp,
+			    struct jesd216_bfp_dw11 *res)
+{
+	/* DW11 introduced in JESD216A */
+	if (php->len_dw < 11) {
+		return -ENOTSUP;
+	}
+
+	uint32_t dw11 = sys_le32_to_cpu(bfp->dw10[1]);
+	uint32_t value = 1 + ((dw11 >> 24) & 0x1F);
+
+	switch ((dw11 >> 29) & 0x03) {
+	case 0x00: /* 16 ms */
+		value *= 16;
+		break;
+	case 0x01:
+		value *= 256;
+		break;
+	case 0x02:
+		value *= 4 * MSEC_PER_SEC;
+		break;
+	case 0x03:
+		value *= 64 * MSEC_PER_SEC;
+		break;
+	}
+	res->chip_erase_ms = value;
+
+	value = 1 + ((dw11 >> 19) & 0x0F);
+	if (dw11 & BIT(23)) {
+		value *= 8;
+	}
+	res->byte_prog_addl_us = value;
+
+	value = 1 + ((dw11 >> 14) & 0x0F);
+	if (dw11 & BIT(18)) {
+		value *= 8;
+	}
+	res->byte_prog_first_us = value;
+
+	value = 1 + ((dw11 >> 8) & 0x01F);
+	if (dw11 & BIT(13)) {
+		value *= 64;
+	} else {
+		value *= 8;
+	}
+	res->page_prog_us = value;
+
+	res->page_size = BIT((dw11 >> 4) & 0x0F);
+	res->typ_max_factor = 2 * (1 + (dw11 & 0x0F));
+
+	return 0;
+}
+
+int jesd216_bfp_decode_dw14(const struct jesd216_param_header *php,
+			    const struct jesd216_bfp *bfp,
+			    struct jesd216_bfp_dw14 *res)
+{
+	/* DW14 introduced in JESD216A */
+	if (php->len_dw < 14) {
+		return -ENOTSUP;
+	}
+
+	uint32_t dw14 = sys_le32_to_cpu(bfp->dw10[4]);
+
+	if (dw14 & BIT(31)) {
+		return -ENOTSUP;
+	}
+
+	res->enter_dpd_instr = (dw14 >> 23) & 0xFF;
+	res->exit_dpd_instr = (dw14 >> 15) & 0xFF;
+
+	uint32_t value = 1 + ((dw14 >> 8) & 0x1F);
+
+	switch ((dw14 >> 13) & 0x03) {
+	case 0x00: /* 128 ns */
+		value *= 128;
+		break;
+	case 0x01: /* 1 us */
+		value *= NSEC_PER_USEC;
+		break;
+	case 0x02: /* 8 us */
+		value *= 8 * NSEC_PER_USEC;
+		break;
+	case 0x03: /* 64 us */
+		value *= 64 * NSEC_PER_USEC;
+		break;
+	}
+
+	res->exit_delay_ns = value;
+
+	res->poll_options = (dw14 >> 2) & 0x3F;
+
+	return 0;
+}

--- a/drivers/flash/jesd216.h
+++ b/drivers/flash/jesd216.h
@@ -1,0 +1,418 @@
+/*
+ * Copyright (c) 2020 Peter Bigot Consulting, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_FLASH_JESD216_H_
+#define ZEPHYR_DRIVERS_FLASH_JESD216_H_
+
+#include <errno.h>
+#include <sys/byteorder.h>
+#include <sys/util.h>
+#include <zephyr/types.h>
+
+/* Following are structures and constants supporting the JEDEC Serial
+ * Flash Discoverable Parameters standard, JESD216 and its successors,
+ * available at
+ * https://www.jedec.org/standards-documents/docs/jesd216b
+ */
+
+#define JESD216_CMD_READ_SFDP   0x5A
+#define JESD216_CMD_BURST_SFDP  0x5B
+
+/* Layout of a JESD216 parameter header. */
+struct jesd216_param_header {
+	uint8_t id_lsb;		/* ID LSB */
+	uint8_t rev_minor;	/* Minor revision number */
+	uint8_t rev_major;	/* Major revision number */
+	uint8_t len_dw;		/* Length of table in 32-bit DWORDs */
+	uint8_t ptp[3];		/* Address of table in SFDP space (LSB@0) */
+	uint8_t id_msb;		/* ID MSB */
+} __packed;
+
+/* Get the number of bytes required for the parameter table. */
+static inline uint32_t jesd216_param_len(const struct jesd216_param_header *hp)
+{
+	return sizeof(uint32_t) * hp->len_dw;
+}
+
+/* Get the ID that identifies the content of the parameter table. */
+static inline uint16_t jesd216_param_id(const struct jesd216_param_header *hp)
+{
+	return ((uint16_t)hp->id_msb << 8) | hp->id_lsb;
+}
+
+/* Get the address within the SFDP where the data for the table is
+ * stored.
+ */
+static inline uint32_t jesd216_param_addr(const struct jesd216_param_header *hp)
+{
+	return ((hp->ptp[2] << 16)
+		| (hp->ptp[1] << 8)
+		| (hp->ptp[0] << 0));
+}
+
+/* Layout of the Serial Flash Discoverable Parameters header. */
+struct jesd216_sfdp_header {
+	uint32_t magic;		/* "SFDP" in little endian */
+	uint8_t rev_minor;	/* Minor revision number */
+	uint8_t rev_major;	/* Major revision number */
+	uint8_t nph;		/* Number of parameter headers */
+	uint8_t access;		/* Access protocol */
+	struct jesd216_param_header phdr[]; /* Headers */
+} __packed;
+
+/* SFDP access protocol for backwards compatibility with JESD216B. */
+#define JESD216_SFDP_AP_LEGACY 0xFF
+
+/* The expected value from the jesd216_sfdp::magic field in host byte
+ * order.
+ */
+#define JESD216_SFDP_MAGIC 0x50444653
+
+/* All JESD216 data is read from the device in little-endian byte
+ * order.  For JEDEC parameter tables defined through JESD216D-01 the
+ * parameters are defined by 32-bit words that may need to be
+ * byte-swapped to extract their information.
+ *
+ * A 16-bit ID from the parameter header is used to identify the
+ * content of each table.  The first parameter table in the SFDP
+ * hierarchy must be a Basic Flash Parameter table (ID 0xFF00).
+ */
+
+/* JESD216D-01 section 6.4: Basic Flash Parameter */
+#define JESD216_SFDP_PARAM_ID_BFP 0xFF00
+/* JESD216D-01 section 6.5: Sector Map Parameter */
+#define JESD216_SFDP_PARAM_ID_SECTOR_MAP 0xFF81
+/* JESD216D-01 section 6.6: 4-Byte Address Instruction Parameter */
+#define JESD216_SFDP_PARAM_ID_4B_ADDR_INSTR 0xFF84
+/* JESD216D-01 section 6.7: xSPI (Profile 1.0) Parameter */
+#define JESD216_SFDP_PARAM_ID_XSPI_PROFILE_1V0 0xFF05
+/* JESD216D-01 section 6.8: xSPI (Profile 2.0) Parameter */
+#define JESD216_SFDP_PARAM_ID_XSPI_PROFILE_2V0 0xFF06
+
+/* Macro to define the number of bytes required for the SFDP pheader
+ * and @p nph parameter headers.
+ *
+ * @param nph the number of parameter headers to be read.  1 is
+ * sufficient for basic functionality.
+ *
+ * @return required buffer size in bytes.
+ */
+#define JESD216_SFDP_SIZE(nph) (sizeof(struct jesd216_sfdp_header)	\
+				+ ((nph) * sizeof(struct jesd216_param_header)))
+
+/** Extract the magic number from the SFDP structure in host byte order.
+ *
+ * If this compares equal to JESD216_SFDP_MAGIC then the SFDP header
+ * may have been read correctly.
+ */
+static inline uint32_t jesd216_sfdp_magic(const struct jesd216_sfdp_header *hp)
+{
+	return sys_le32_to_cpu(hp->magic);
+}
+
+/* Layout of the Basic Flash Parameters table.
+ *
+ * SFDP through JESD216B supported 9 DWORD values.  JESD216C extended
+ * this to 17, and JESD216D to 20.
+ *
+ * All values are expected to be stored as little-endian and must be
+ * converted to host byte order to extract the bit fields defined in
+ * the standard.  Rather than pre-define layouts to access to all
+ * potential fields this header provides functions for specific fields
+ * known to be important, such as density and erase command support.
+ */
+struct jesd216_bfp {
+	uint32_t dw1;
+	uint32_t dw2;
+	uint32_t dw3;
+	uint32_t dw4;
+	uint32_t dw5;
+	uint32_t dw6;
+	uint32_t dw7;
+	uint32_t dw8;
+	uint32_t dw9;
+	uint32_t dw10[];
+} __packed;
+
+/* Provide a few word-specific flags and bitfield ranges for values
+ * that an application or driver might expect to want to extract.
+ *
+ * See the JESD216 specification for the interpretation of these
+ * bitfields.
+ */
+#define JESD216_SFDP_BFP_DW1_DTRCLK_FLG BIT(19)
+#define JESD216_SFDP_BFP_DW1_ADDRBYTES_MASK (BIT(17) | BIT(18))
+#define JESD216_SFDP_BFP_DW1_ADDRBYTES_SHFT 17
+#define JESD216_SFDP_BFP_DW1_ADDRBYTES_VAL_3B 0
+#define JESD216_SFDP_BFP_DW1_ADDRBYTES_VAL_3B4B 1
+#define JESD216_SFDP_BFP_DW1_ADDRBYTES_VAL_4B 2
+#define JESD216_SFDP_BFP_DW1_4KERASEINSTR_SHFT 8
+#define JESD216_SFDP_BFP_DW1_4KERASEINSTR_MASK (0xFF << JESD216_SFDP_BFP_DW1_4KERASEINSTR_SHFT)
+#define JESD216_SFDP_BFP_DW1_WEISWVSR_FLG BIT(4)
+#define JESD216_SFDP_BFP_DW1_VSRBP_FLG BIT(3)
+#define JESD216_SFDP_BFP_DW1_WRTGRAN_FLG BIT(2)
+#define JESD216_SFDP_BFP_DW1_BSERSZ_SHFT 0
+#define JESD216_SFDP_BFP_DW1_BSERSZ_MASK (0x03 << JESD216_SFDP_BFP_DW1_BSERSZ_SHFT)
+#define JESD216_SFDP_BFP_DW1_BSERSZ_VAL_4KSUP 0x01
+#define JESD216_SFDP_BFP_DW1_BSERSZ_VAL_4KNOTSUP 0x03
+
+#define JESD216_SFDP_BFP_DW12_SUSPRESSUP_FLG BIT(31)
+
+/* Data can be extracted from the BFP words using these APIs:
+ *
+ * * DW1 (capabilities) use DW1 bitfield macros above or
+ *   jesd216_read_support().
+ * * DW2 (density) use jesd216_bfp_density().
+ * * DW3-DW7 (instr) use jesd216_bfp_read_support().
+ * * DW8-DW9 (erase types) use jesd216_bfp_erase().
+ *
+ * JESD216A (16 DW)
+ *
+ * * DW10 (erase times) use jesd216_bfp_erase_type_times().
+ * * DW11 (other times) use jesd216_bfp_decode_dw11().
+ * * DW12-13 (suspend/resume) no API except
+ *   JESD216_SFDP_BFP_DW12_SUSPRESSUP_FLG.
+ * * DW14 (deep power down) use jesd216_bfp_decode_dw14().
+ * * DW15-16 no API except jesd216_bfp_read_support().
+ *
+ * JESD216C (20 DW)
+ * * DW17-20 (quad/oct support) no API except jesd216_bfp_read_support().
+ */
+
+/* Extract the density of the chip in bits from BFP DW2. */
+static inline uint64_t jesd216_bfp_density(const struct jesd216_bfp *hp)
+{
+	uint32_t dw = sys_le32_to_cpu(hp->dw2);
+
+	if (dw & BIT(31)) {
+		return BIT64(dw & BIT_MASK(31));
+	}
+	return 1U + (uint64_t)dw;
+}
+
+/* Protocol mode enumeration types.
+ *
+ * Modes are identified by fields representing the number of I/O
+ * signals and the data rate in the transfer.  The I/O width may be 1,
+ * 2, 4, or 8 I/O signals.  The data rate may be single or double.
+ * SDR is assumed; DDR is indicated by a D following the I/O width.
+ *
+ * A transfer has three phases, and width/rate is specified for each
+ * in turn:
+ * * Transfer of the command
+ * * Transfer of the command modifier (e.g. address)
+ * * Transfer of the data.
+ *
+ * Modes explicitly mentioned in JESD216 or JESD251 are given
+ * enumeration values below, which can be used to extract information
+ * about instruction support.
+ */
+enum jesd216_mode_type {
+	JESD216_MODE_044,	/* implied instruction, execute in place */
+	JESD216_MODE_088,
+	JESD216_MODE_111,
+	JESD216_MODE_112,
+	JESD216_MODE_114,
+	JESD216_MODE_118,
+	JESD216_MODE_122,
+	JESD216_MODE_144,
+	JESD216_MODE_188,
+	JESD216_MODE_222,
+	JESD216_MODE_444,
+	JESD216_MODE_44D4D,
+	JESD216_MODE_888,
+	JESD216_MODE_8D8D8D,
+	JESD216_MODE_LIMIT,
+};
+
+/* Command to use for fast read operations in a specified protocol
+ * mode.
+ */
+struct jesd216_instr {
+	uint8_t instr;
+	uint8_t mode_clocks;
+	uint8_t wait_states;
+};
+
+/* Determine whether a particular operational mode is supported for
+ * read, and possibly what command may be used.
+ *
+ * @note For @p mode JESD216_MODE_111 this function will return zero
+ * to indicate that standard read (instruction 03h) is supported, but
+ * without providing information on how.  SFDP does not provide an
+ * indication of support for 1-1-1 Fast Read (0Bh).
+ *
+ * @param php pointer to the BFP header.
+ *
+ * @param bfp pointer to the BFP table.
+ *
+ * @param mode the desired protocol mode.
+ *
+ * @param res where to store instruction information.  Pass a null
+ * pointer to test for support without retrieving instruction
+ * information.
+ *
+ * @retval positive if instruction is supported and *res has been set.
+ *
+ * @retval 0 if instruction is supported but *res has not been set
+ * (e.g. no instruction needed, or instruction cannot be read from
+ * BFP).
+ *
+ * @retval -ENOTSUP if instruction is not supported.
+ */
+int jesd216_bfp_read_support(const struct jesd216_param_header *php,
+			     const struct jesd216_bfp *bfp,
+			     enum jesd216_mode_type mode,
+			     struct jesd216_instr *res);
+
+/* Description of a supported erase operation. */
+struct jesd216_erase_type {
+	/* The command opcode used for an erase operation. */
+	uint8_t cmd;
+
+	/* The value N when the erase operation erases a 2^N byte
+	 * region.
+	 */
+	uint8_t exp;
+};
+
+/* The number of erase types defined in a JESD216 Basic Flash
+ * Parameter table.
+ */
+#define JESD216_NUM_ERASE_TYPES 4
+
+/* Extract a supported erase size and command from BFP DW8 or DW9.
+ *
+ * @param bfp pointer to the parameter table.
+ *
+ * @param idx the erase type index, from 1 through 4.  Only index 1 is
+ * guaranteed to be present.
+ *
+ * @param etp where to store the command and size used for the erase.
+ *
+ * @retval 0 if the erase type index provided usable information.
+ * @retval -EINVAL if the erase type index is undefined.
+ */
+int jesd216_bfp_erase(const struct jesd216_bfp *bfp,
+		      uint8_t idx,
+		      struct jesd216_erase_type *etp);
+
+/* Extract typical and maximum erase times from DW10.
+ *
+ * @param php pointer to the BFP header.
+ *
+ * @param bfp pointer to the BFP table.
+ *
+ * @param idx the erase type index, from 1 through 4.  For meaningful
+ * results the index should be one for which jesd216_bfp_erase()
+ * returns success.
+ *
+ * @param typ_ms where to store the typical erase time (in
+ * milliseconds) for the specified erase type.
+ *
+ * @retval -ENOTSUP if the erase type index is undefined.
+ * @retval positive is a multiplier that converts typical erase times
+ * to maximum erase times.
+ */
+int jesd216_bfp_erase_type_times(const struct jesd216_param_header *php,
+				 const struct jesd216_bfp *bfp,
+				 uint8_t idx,
+				 uint32_t *typ_ms);
+
+/* Get the page size from the Basic Flash Parameters.
+ *
+ * @param php pointer to the BFP header.
+ *
+ * @param bfp pointer to the BFP table.
+ *
+ * @return the page size in bytes from the parameters if supported,
+ * otherwise 256.
+ */
+static inline uint32_t jesd216_bfp_page_size(const struct jesd216_param_header *php,
+					     const struct jesd216_bfp *bfp)
+{
+	/* Page size introduced in JESD216A */
+	if (php->len_dw < 11) {
+		return 256;
+	}
+
+	uint32_t dw11 = sys_le32_to_cpu(bfp->dw10[1]);
+	uint8_t exp = (dw11 >> 4) & 0x0F;
+
+	return BIT(exp);
+}
+
+/* Decoded data from JESD216 DW11. */
+struct jesd216_bfp_dw11 {
+	/* Typical time for chip (die) erase, in milliseconds */
+	uint16_t chip_erase_ms;
+
+	/* Typical time for first byte program, in microseconds */
+	uint16_t byte_prog_first_us;
+
+	/* Typical time per byte for byte program after first, in
+	 * microseconds
+	 */
+	uint16_t byte_prog_addl_us;
+
+	/* Typical time for page program, in microseconds */
+	uint16_t page_prog_us;
+
+	/* Multiplier to get maximum time from typical times. */
+	uint16_t typ_max_factor;
+
+	/* Number of bytes in a page. */
+	uint16_t page_size;
+};
+
+/* Get data from BFP DW11.
+ *
+ * @param php pointer to the BFP header.
+ *
+ * @param bfp pointer to the BFP table.
+ *
+ * @param res pointer to where to store the decoded data.
+ *
+ * @retval -ENOTSUP if this information is not available from this BFP table.
+ * @retval 0 on successful storage into @c *res.
+ */
+int jesd216_bfp_decode_dw11(const struct jesd216_param_header *php,
+			    const struct jesd216_bfp *bfp,
+			    struct jesd216_bfp_dw11 *res);
+
+/* Decode data from JESD216 DW14 */
+struct jesd216_bfp_dw14 {
+	/* Instruct used to enter deep power-down */
+	uint8_t enter_dpd_instr;
+
+	/* Instruct used to exit deep power-down */
+	uint8_t exit_dpd_instr;
+
+	/* Bits defining ways busy status may be polled. */
+	uint8_t poll_options;
+
+	/* Time after issuing exit instruction until device is ready
+	 * to accept a command, in nanoseconds.
+	 */
+	uint32_t exit_delay_ns;
+};
+
+/* Get data from BFP DW14.
+ *
+ * @param php pointer to the BFP header.
+ *
+ * @param bfp pointer to the BFP table.
+ *
+ * @param res pointer to where to store the decoded data.
+ *
+ * @retval -ENOTSUP if this information is not available from this BFP table.
+ * @retval 0 on successful storage into @c *res.
+ */
+int jesd216_bfp_decode_dw14(const struct jesd216_param_header *php,
+			    const struct jesd216_bfp *bfp,
+			    struct jesd216_bfp_dw14 *res);
+
+#endif /* ZEPHYR_DRIVERS_FLASH_JESD216_H_ */

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -16,7 +16,14 @@
 #include "flash_priv.h"
 #include <nrfx_qspi.h>
 
-#define qspi_nor_config spi_nor_config
+struct qspi_nor_config {
+       /* JEDEC id from devicetree */
+       uint8_t id[SPI_NOR_MAX_ID_LEN];
+
+       /* Size from devicetree, in bytes */
+       uint32_t size;
+};
+
 #define QSPI_NOR_MAX_ID_LEN SPI_NOR_MAX_ID_LEN
 
 /* Status register bits */

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -64,12 +64,32 @@ LOG_MODULE_REGISTER(spi_nor, CONFIG_FLASH_LOG_LEVEL);
 #define T_DPDD_MS 0
 #endif /* DPD_WAKEUP_SEQUENCE */
 
+/* Build-time data associated with the device. */
 struct spi_nor_config {
-	/* JEDEC id from devicetree */
-	uint8_t id[SPI_NOR_MAX_ID_LEN];
+	/* Runtime SFDP stores no static configuration. */
 
-	/* Size from devicetree, in bytes */
-	uint32_t size;
+#ifndef CONFIG_SPI_NOR_SFDP_RUNTIME
+	/* Size of device in bytes, from size property */
+	uint32_t flash_size;
+
+#ifdef CONFIG_FLASH_PAGE_LAYOUT
+	/* Flash page layout can be determined from devicetree. */
+	struct flash_pages_layout layout;
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+
+	/* Expected JEDEC ID, from jedec-id property */
+	uint8_t jedec_id[SPI_NOR_MAX_ID_LEN];
+
+#if defined(CONFIG_SPI_NOR_SFDP_DEVICETREE)
+	/* Length of BFP structure, in 32-bit words. */
+	uint8_t bfp_len;
+
+	/* Pointer to the BFP table as read from the device
+	 * (little-endian stored words), from sfdp-bfp property
+	 */
+	const struct jesd216_bfp *bfp;
+#endif /* CONFIG_SPI_NOR_SFDP_DEVICETREE */
+#endif /* CONFIG_SPI_NOR_SFDP_RUNTIME */
 };
 
 /**
@@ -80,6 +100,7 @@ struct spi_nor_config {
  * @sem: The semaphore to access to the flash
  */
 struct spi_nor_data {
+	struct k_sem sem;
 	struct device *spi;
 	struct spi_config spi_cfg;
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
@@ -91,10 +112,87 @@ struct spi_nor_data {
 	 */
 	uint32_t ts_enter_dpd;
 #endif
-	uint32_t page_size;
-	struct jesd216_erase_type erase_types[4];
-	struct k_sem sem;
+
+	/* Minimal SFDP stores no dynamic configuration.  Runtime and
+	 * devicetree store page size and erase_types; runtime also
+	 * stores flash size and layout.
+	 */
+#ifndef CONFIG_SPI_NOR_SFDP_MINIMAL
+
+	struct jesd216_erase_type erase_types[JESD216_NUM_ERASE_TYPES];
+
+	/* Number of bytes per page */
+	uint16_t page_size;
+
+#ifdef CONFIG_SPI_NOR_SFDP_RUNTIME
+	/* Size of flash, in bytes */
+	uint32_t flash_size;
+
+#ifdef CONFIG_FLASH_PAGE_LAYOUT
+	struct flash_pages_layout layout;
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+#endif /* CONFIG_SPI_NOR_SFDP_RUNTIME */
+#endif /* CONFIG_SPI_NOR_SFDP_MINIMAL */
 };
+
+#ifdef CONFIG_SPI_NOR_SFDP_MINIMAL
+/* The historically supported erase sizes. */
+static const struct jesd216_erase_type minimal_erase_types[JESD216_NUM_ERASE_TYPES] = {
+	{
+		.cmd = SPI_NOR_CMD_BE,
+		.exp = 16,
+	},
+	{
+		.cmd = SPI_NOR_CMD_SE,
+		.exp = 12,
+	},
+};
+#endif /* CONFIG_SPI_NOR_SFDP_MINIMAL */
+
+/* Get pointer to array of supported erase types.  Static const for
+ * minimal, data for runtime and devicetree.
+ */
+static inline const struct jesd216_erase_type *
+dev_erase_types(struct device *dev)
+{
+#ifdef CONFIG_SPI_NOR_SFDP_MINIMAL
+	return minimal_erase_types;
+#else /* CONFIG_SPI_NOR_SFDP_MINIMAL */
+	const struct spi_nor_data *data = dev->data;
+
+	return data->erase_types;
+#endif /* CONFIG_SPI_NOR_SFDP_MINIMAL */
+}
+
+/* Get the size of the flash device.  Data for runtime, constant for
+ * minimal and devicetree.
+ */
+static inline uint32_t dev_flash_size(struct device *dev)
+{
+#ifdef CONFIG_SPI_NOR_SFDP_RUNTIME
+	const struct spi_nor_data *data = dev->data;
+
+	return data->flash_size;
+#else /* CONFIG_SPI_NOR_SFDP_RUNTIME */
+	const struct spi_nor_config *cfg = dev->config;
+
+	return cfg->flash_size;
+#endif /* CONFIG_SPI_NOR_SFDP_RUNTIME */
+}
+
+/* Get the flash device page size.  Constant for minimal, data for
+ * runtime and devicetree.
+ */
+static inline uint16_t dev_page_size(struct device *dev)
+{
+#ifdef CONFIG_SPI_NOR_SFDP_MINIMAL
+	return 256;
+#else /* CONFIG_SPI_NOR_SFDP_MINIMAL */
+	const struct spi_nor_data *data = dev->data;
+
+	return data->page_size;
+#endif /* CONFIG_SPI_NOR_SFDP_MINIMAL */
+}
 
 static const struct flash_parameters flash_nor_parameters = {
 	.write_block_size = 1,
@@ -206,6 +304,7 @@ static int spi_nor_access(const struct device *const dev,
 #define spi_nor_cmd_addr_write(dev, opcode, addr, src, length) \
 	spi_nor_access(dev, opcode, true, addr, (void *)src, length, true)
 
+#if CONFIG_SPI_NOR_SFDP_RUNTIME
 /*
  * @brief Read content from the SFDP hierarchy
  *
@@ -244,6 +343,7 @@ static int read_sfdp(const struct device *const dev,
 	return spi_transceive(driver_data->spi, &driver_data->spi_cfg,
 			      &buf_set, &buf_set);
 }
+#endif /* CONFIG_SPI_NOR_SFDP_RUNTIME */
 
 static int enter_dpd(const struct device *const dev)
 {
@@ -328,30 +428,6 @@ static void release_device(struct device *dev)
 }
 
 /**
- * @brief Retrieve the Flash JEDEC ID and compare it with the one expected
- *
- * @param dev The device structure
- * @param flash_id The flash info structure which contains the expected JEDEC ID
- * @return 0 on success, negative errno code otherwise
- */
-static inline int spi_nor_read_id(struct device *dev,
-				  const struct spi_nor_config *const flash_id)
-{
-	uint8_t buf[SPI_NOR_MAX_ID_LEN];
-
-	if (spi_nor_cmd_read(dev, SPI_NOR_CMD_RDID, buf,
-	    SPI_NOR_MAX_ID_LEN) != 0) {
-		return -EIO;
-	}
-
-	if (memcmp(flash_id->id, buf, SPI_NOR_MAX_ID_LEN) != 0) {
-		return -ENODEV;
-	}
-
-	return 0;
-}
-
-/**
  * @brief Wait until the flash is ready
  *
  * @param dev The device structure
@@ -372,11 +448,11 @@ static int spi_nor_wait_until_ready(struct device *dev)
 static int spi_nor_read(struct device *dev, off_t addr, void *dest,
 			size_t size)
 {
-	const struct spi_nor_config *params = dev->config;
+	const size_t flash_size = dev_flash_size(dev);
 	int ret;
 
 	/* should be between 0 and flash size */
-	if ((addr < 0) || ((addr + size) > params->size)) {
+	if ((addr < 0) || ((addr + size) > flash_size)) {
 		return -EINVAL;
 	}
 
@@ -393,12 +469,12 @@ static int spi_nor_read(struct device *dev, off_t addr, void *dest,
 static int spi_nor_write(struct device *dev, off_t addr, const void *src,
 			 size_t size)
 {
-	const struct spi_nor_data *data = dev->data;
-	const struct spi_nor_config *params = dev->config;
+	const size_t flash_size = dev_flash_size(dev);
+	const uint16_t page_size = dev_page_size(dev);
 	int ret = 0;
 
 	/* should be between 0 and flash size */
-	if ((addr < 0) || ((size + addr) > params->size)) {
+	if ((addr < 0) || ((size + addr) > flash_size)) {
 		return -EINVAL;
 	}
 
@@ -408,14 +484,14 @@ static int spi_nor_write(struct device *dev, off_t addr, const void *src,
 		size_t to_write = size;
 
 		/* Don't write more than a page. */
-		if (to_write >= data->page_size) {
-			to_write = data->page_size;
+		if (to_write >= page_size) {
+			to_write = page_size;
 		}
 
 		/* Don't write across a page boundary */
-		if (((addr + to_write - 1U) / data->page_size)
-		    != (addr / data->page_size)) {
-			to_write = data->page_size - (addr % data->page_size);
+		if (((addr + to_write - 1U) / page_size)
+		    != (addr / page_size)) {
+			to_write = page_size - (addr % page_size);
 		}
 
 		spi_nor_cmd_write(dev, SPI_NOR_CMD_WREN);
@@ -439,12 +515,11 @@ out:
 
 static int spi_nor_erase(struct device *dev, off_t addr, size_t size)
 {
-	struct spi_nor_data *data = dev->data;
-	const struct spi_nor_config *params = dev->config;
+	const size_t flash_size = dev_flash_size(dev);
 	int ret = 0;
 
 	/* erase area must be subregion of device */
-	if ((addr < 0) || ((size + addr) > params->size)) {
+	if ((addr < 0) || ((size + addr) > flash_size)) {
 		return -ENODEV;
 	}
 
@@ -463,17 +538,19 @@ static int spi_nor_erase(struct device *dev, off_t addr, size_t size)
 	while ((size > 0) && (ret == 0)) {
 		spi_nor_cmd_write(dev, SPI_NOR_CMD_WREN);
 
-		if (size == params->size) {
+		if (size == flash_size) {
 			/* chip erase */
 			spi_nor_cmd_write(dev, SPI_NOR_CMD_CE);
-			size -= params->size;
+			size -= flash_size;
 		} else {
-			const struct jesd216_erase_type *etp = data->erase_types;
-			const struct jesd216_erase_type * const ete = etp
-				+ ARRAY_SIZE(data->erase_types);
+			const struct jesd216_erase_type *erase_types =
+				dev_erase_types(dev);
 			const struct jesd216_erase_type *bet = NULL;
 
-			while (etp < ete) {
+			for (uint8_t ei = 0; ei < JESD216_NUM_ERASE_TYPES; ++ei) {
+				const struct jesd216_erase_type *etp =
+					&erase_types[ei];
+
 				if ((etp->exp != 0)
 				    && SPI_NOR_IS_ALIGNED(addr, etp->exp)
 				    && SPI_NOR_IS_ALIGNED(size, etp->exp)
@@ -522,31 +599,41 @@ static int spi_nor_write_protection_set(struct device *dev, bool write_protect)
 	return ret;
 }
 
-static int spi_nor_process_bfp(struct device *dev,
-			       const struct jesd216_param_header *php)
+static int spi_nor_read_jedec_id(struct device *dev,
+				 uint8_t *id)
 {
-	struct spi_nor_data *data = dev->data;
-	union {
-		uint32_t dw[MIN(php->len_dw, 20)];
-		struct jesd216_bfp bfp;
-	} u;
-	const struct jesd216_bfp *bfp = &u.bfp;
-	struct jesd216_erase_type *etp = data->erase_types;
-	int rc = read_sfdp(dev, jesd216_param_addr(php), u.dw, sizeof(u.dw));
-
-	if (rc != 0) {
-		LOG_ERR("SFDP.BFP failed: %d", rc);
-		return rc;
+	if (id == NULL) {
+		return -EINVAL;
 	}
 
-	LOG_INF("%s: %u MiBy flash", dev->name, (uint32_t)(jesd216_bfp_density(bfp) >> 23));
+	acquire_device(dev);
+
+	spi_nor_wait_until_ready(dev);
+
+	int ret = spi_nor_cmd_read(dev, SPI_NOR_CMD_RDID, id, SPI_NOR_MAX_ID_LEN);
+
+	release_device(dev);
+
+	return ret;
+}
+
+#ifndef CONFIG_SPI_NOR_SFDP_MINIMAL
+
+static int spi_nor_process_bfp(struct device *dev,
+			       const struct jesd216_param_header *php,
+			       const struct jesd216_bfp *bfp)
+{
+	struct spi_nor_data *data = dev->data;
+	struct jesd216_erase_type *etp = data->erase_types;
+	const size_t flash_size = jesd216_bfp_density(bfp) / 8U;
+
+	LOG_INF("%s: %u MiBy flash", dev->name, (uint32_t)(flash_size >> 23));
 
 	/* Copy over the erase types, preserving their order.  (The
 	 * Sector Map Parameter table references them by index.)
 	 */
 	memset(data->erase_types, 0, sizeof(data->erase_types));
-	BUILD_ASSERT(ARRAY_SIZE(data->erase_types) == 4);
-	for (uint8_t ti = 1; ti <= 4; ++ti) {
+	for (uint8_t ti = 1; ti <= ARRAY_SIZE(data->erase_types); ++ti) {
 		if (jesd216_bfp_erase(bfp, ti, etp) == 0) {
 			LOG_DBG("Erase %u with %02x", (uint32_t)BIT(etp->exp), etp->cmd);
 		}
@@ -554,13 +641,27 @@ static int spi_nor_process_bfp(struct device *dev,
 	}
 
 	data->page_size = jesd216_bfp_page_size(php, bfp);
-	LOG_DBG("Page size %u bytes", data->page_size);
+#ifdef CONFIG_SPI_NOR_SFDP_RUNTIME
+	data->flash_size = flash_size;
+#else /* CONFIG_SPI_NOR_SFDP_RUNTIME */
+	if (flash_size != dev_flash_size(dev)) {
+		LOG_ERR("BFP flash size mismatch with devicetree");
+		return -EINVAL;
+	}
+#endif /* CONFIG_SPI_NOR_SFDP_RUNTIME */
 
-	return rc;
+	LOG_DBG("Page size %u bytes", data->page_size);
+	return 0;
 }
 
 static int spi_nor_process_sfdp(struct device *dev)
 {
+	int rc;
+
+#if defined(CONFIG_SPI_NOR_SFDP_RUNTIME)
+	/* For runtime we need to read the SFDP table, identify the
+	 * BFP block, and process it.
+	 */
 	const uint8_t decl_nph = 2;
 	union {
 		/* We only process BFP so use one parameter block */
@@ -568,8 +669,8 @@ static int spi_nor_process_sfdp(struct device *dev)
 		struct jesd216_sfdp_header sfdp;
 	} u;
 	const struct jesd216_sfdp_header *hp = &u.sfdp;
-	int rc = read_sfdp(dev, 0, u.raw, sizeof(u.raw));
 
+	rc = read_sfdp(dev, 0, u.raw, sizeof(u.raw));
 	if (rc != 0) {
 		LOG_ERR("SFDP read failed: %d", rc);
 		return rc;
@@ -596,7 +697,17 @@ static int spi_nor_process_sfdp(struct device *dev)
 			php->len_dw, jesd216_param_addr(php));
 
 		if (id == JESD216_SFDP_PARAM_ID_BFP) {
-			rc = spi_nor_process_bfp(dev, php);
+			union {
+				uint32_t dw[MIN(php->len_dw, 20)];
+				struct jesd216_bfp bfp;
+			} u;
+			const struct jesd216_bfp *bfp = &u.bfp;
+
+			rc = read_sfdp(dev, jesd216_param_addr(php), u.dw, sizeof(u.dw));
+			if (rc == 0) {
+				rc = spi_nor_process_bfp(dev, php, bfp);
+			}
+
 			if (rc != 0) {
 				LOG_INF("SFDP BFP failed: %d", rc);
 				break;
@@ -604,9 +715,89 @@ static int spi_nor_process_sfdp(struct device *dev)
 		}
 		++php;
 	}
+#elif defined(CONFIG_SPI_NOR_SFDP_DEVICETREE)
+	/* For devicetree we need to synthesize a parameter header and
+	 * process the stored BFP data as if we had read it.
+	 */
+	const struct spi_nor_config *cfg = dev->config;
+	struct jesd216_param_header bfp_hdr = {
+		.len_dw = cfg->bfp_len,
+	};
+
+	rc = spi_nor_process_bfp(dev, &bfp_hdr, cfg->bfp);
+#else
+#error Unhandled SFDP choice
+#endif
 
 	return rc;
 }
+
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+static int setup_pages_layout(struct device *dev)
+{
+	int rv = 0;
+
+#if defined(CONFIG_SPI_NOR_SFDP_RUNTIME)
+	struct spi_nor_data *data = dev->data;
+	const size_t flash_size = dev_flash_size(dev);
+	const uint32_t layout_page_size = CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE;
+	uint8_t exp = 0;
+
+	/* Find the smallest erase size. */
+	for (size_t i = 0; i < ARRAY_SIZE(data->erase_types); ++i) {
+		const struct jesd216_erase_type *etp = &data->erase_types[i];
+
+		if ((etp->cmd != 0)
+		    && ((exp == 0) || (etp->exp < exp))) {
+			exp = etp->exp;
+		}
+	}
+
+	if (exp == 0) {
+		return -ENOTSUP;
+	}
+
+	uint32_t erase_size = BIT(exp);
+
+	/* Error if layout page size is not a multiple of smallest
+	 * erase size.
+	 */
+	if ((layout_page_size % erase_size) != 0) {
+		LOG_ERR("layout page %u not compatible with erase size %u",
+			layout_page_size, erase_size);
+		return -EINVAL;
+	}
+
+	/* Warn but accept layout page sizes that leave inaccessible
+	 * space.
+	 */
+	if ((flash_size % layout_page_size) != 0) {
+		LOG_INF("layout page %u wastes space with device size %zu",
+			layout_page_size, flash_size);
+	}
+
+	data->layout.pages_size = layout_page_size;
+	data->layout.pages_count = flash_size / layout_page_size;
+	LOG_DBG("layout %u x %u By pages", data->layout.pages_count, data->layout.pages_size);
+#elif defined(CONFIG_SPI_NOR_SFDP_DEVICETREE)
+	const struct spi_nor_config *cfg = dev->config;
+	const struct flash_pages_layout *layout = &cfg->layout;
+	const size_t flash_size = dev_flash_size(dev);
+	size_t layout_size = layout->pages_size * layout->pages_count;
+
+	if (flash_size != layout_size) {
+		LOG_ERR("device size %u mismatch %zu * %zu By pages",
+			flash_size, layout->pages_count, layout->pages_size);
+		return -EINVAL;
+	}
+#else /* CONFIG_SPI_NOR_SFDP_RUNTIME */
+#error Unhandled SFDP choice
+#endif /* CONFIG_SPI_NOR_SFDP_RUNTIME */
+
+	return rv;
+}
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+#endif /* CONFIG_SPI_NOR_SFDP_MINIMAL */
 
 /**
  * @brief Configure the flash
@@ -618,7 +809,11 @@ static int spi_nor_process_sfdp(struct device *dev)
 static int spi_nor_configure(struct device *dev)
 {
 	struct spi_nor_data *data = dev->data;
-	const struct spi_nor_config *params = dev->config;
+	uint8_t jedec_id[SPI_NOR_MAX_ID_LEN];
+#ifndef CONFIG_SPI_NOR_SFDP_RUNTIME
+	const struct spi_nor_config *cfg = dev->config;
+#endif /* CONFIG_SPI_NOR_SFDP_RUNTIME */
+	int rc;
 
 	data->spi = device_get_binding(DT_INST_BUS_LABEL(0));
 	if (!data->spi) {
@@ -646,25 +841,48 @@ static int spi_nor_configure(struct device *dev)
 	/* Might be in DPD if system restarted without power cycle. */
 	exit_dpd(dev);
 
-	if (spi_nor_process_sfdp(dev) != 0) {
-		/* This driver has always assumed that both 64 KiBy
-		 * and 4 KiBy erase operations are available.
-		 */
-		data->erase_types[0] = (struct jesd216_erase_type){
-			.cmd = SPI_NOR_CMD_BE,
-			.exp = 16,
-		};
-		data->erase_types[1] = (struct jesd216_erase_type){
-			.cmd = SPI_NOR_CMD_SE,
-			.exp = 12,
-		};
-		data->page_size = 256;
-	}
+	/* now the spi bus is configured, we can verify SPI
+	 * connectivity by reading the JEDEC ID.
+	 */
 
-	/* now the spi bus is configured, we can verify the flash id */
-	if (spi_nor_read_id(dev, params) != 0) {
+	rc = spi_nor_read_jedec_id(dev, jedec_id);
+	if (rc != 0) {
+		LOG_ERR("JEDEC ID read failed: %d", rc);
 		return -ENODEV;
 	}
+
+#ifndef CONFIG_SPI_NOR_SFDP_RUNTIME
+	/* For minimal and devicetree we need to check the JEDEC ID
+	 * against the one from devicetree, to ensure we didn't find a
+	 * device that has different parameters.
+	 */
+
+	if (memcmp(jedec_id, cfg->jedec_id, sizeof(jedec_id)) != 0) {
+		LOG_ERR("Device id %02x %02x %02x does not match config %02x %02x %02x",
+			jedec_id[0], jedec_id[1], jedec_id[2],
+			cfg->jedec_id[0], cfg->jedec_id[1], cfg->jedec_id[2]);
+		return -EINVAL;
+	}
+#endif
+
+#ifndef CONFIG_SPI_NOR_SFDP_MINIMAL
+	/* For devicetree and runtime we need to process BFP data and
+	 * set up or validate page layout.
+	 */
+	rc = spi_nor_process_sfdp(dev);
+	if (rc != 0) {
+		LOG_ERR("SFDP read failed: %d", rc);
+		return -ENODEV;
+	}
+
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+	rc = setup_pages_layout(dev);
+	if (rc != 0) {
+		LOG_ERR("layout setup failed: %d", rc);
+		return -ENODEV;
+	}
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+#endif /* CONFIG_SPI_NOR_SFDP_MINIMAL */
 
 	if (IS_ENABLED(CONFIG_SPI_NOR_IDLE_IN_DPD)
 	    && (enter_dpd(dev) != 0)) {
@@ -693,32 +911,24 @@ static int spi_nor_init(struct device *dev)
 
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 
-/* instance 0 size in bytes */
-#define INST_0_BYTES (DT_INST_PROP(0, size) / 8)
-
-BUILD_ASSERT(SPI_NOR_IS_SECTOR_ALIGNED(CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE),
-	     "SPI_NOR_FLASH_LAYOUT_PAGE_SIZE must be multiple of 4096");
-
-/* instance 0 page count */
-#define LAYOUT_PAGES_COUNT (INST_0_BYTES / CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE)
-
-BUILD_ASSERT((CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE * LAYOUT_PAGES_COUNT)
-	     == INST_0_BYTES,
-	     "SPI_NOR_FLASH_LAYOUT_PAGE_SIZE incompatible with flash size");
-
-static const struct flash_pages_layout dev_layout = {
-	.pages_count = LAYOUT_PAGES_COUNT,
-	.pages_size = CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE,
-};
-#undef LAYOUT_PAGES_COUNT
-
 static void spi_nor_pages_layout(struct device *dev,
 				 const struct flash_pages_layout **layout,
 				 size_t *layout_size)
 {
-	*layout = &dev_layout;
+	/* Data for runtime, const for devicetree and minimal. */
+#ifdef CONFIG_SPI_NOR_SFDP_RUNTIME
+	const struct spi_nor_data *data = dev->data;
+
+	*layout = &data->layout;
+#else /* CONFIG_SPI_NOR_SFDP_RUNTIME */
+	const struct spi_nor_config *cfg = dev->config;
+
+	*layout = &cfg->layout;
+#endif /* CONFIG_SPI_NOR_SFDP_RUNTIME */
+
 	*layout_size = 1;
 }
+
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
 static const struct flash_parameters *
@@ -740,14 +950,72 @@ static const struct flash_driver_api spi_nor_api = {
 #endif
 };
 
-static const struct spi_nor_config flash_id = {
-	.id = DT_INST_PROP(0, jedec_id),
-	.size = DT_INST_PROP(0, size) / 8,
+#ifndef CONFIG_SPI_NOR_SFDP_RUNTIME
+/* We need to know the size and ID of the configuration data we're
+ * using so we can disable the device we see at runtime if it isn't
+ * compatible with what we're taking from devicetree or minimal.
+ */
+BUILD_ASSERT(DT_INST_NODE_HAS_PROP(0, jedec_id),
+	     "jedec,spi-nor jedec-id required for non-runtime SFDP");
+
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+
+/* For devicetree or minimal page layout we need to know the size of
+ * the device.  We can't extract it from the raw BFP data, so require
+ * it to be present in devicetree.
+ */
+BUILD_ASSERT(DT_INST_NODE_HAS_PROP(0, size),
+	     "jedec,spi-nor size required for non-runtime SFDP page layout");
+
+/* instance 0 size in bytes */
+#define INST_0_BYTES (DT_INST_PROP(0, size) / 8)
+
+BUILD_ASSERT(SPI_NOR_IS_SECTOR_ALIGNED(CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE),
+	     "SPI_NOR_FLASH_LAYOUT_PAGE_SIZE must be multiple of 4096");
+
+/* instance 0 page count */
+#define LAYOUT_PAGES_COUNT (INST_0_BYTES / CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE)
+
+BUILD_ASSERT((CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE * LAYOUT_PAGES_COUNT)
+	     == INST_0_BYTES,
+	     "SPI_NOR_FLASH_LAYOUT_PAGE_SIZE incompatible with flash size");
+
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+
+#ifdef CONFIG_SPI_NOR_SFDP_DEVICETREE
+BUILD_ASSERT(DT_INST_NODE_HAS_PROP(0, sfdp_bfp),
+	     "jedec,spi-nor sfdp-bfp required for devicetree SFDP");
+
+static const __aligned(4) uint8_t bfp_data_0[] = DT_INST_PROP(0, sfdp_bfp);
+#endif /* CONFIG_SPI_NOR_SFDP_DEVICETREE */
+
+#endif /* CONFIG_SPI_NOR_SFDP_RUNTIME */
+
+static const struct spi_nor_config spi_nor_config_0 = {
+#if !defined(CONFIG_SPI_NOR_SFDP_RUNTIME)
+
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+	.layout = {
+		.pages_count = LAYOUT_PAGES_COUNT,
+		.pages_size = CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE,
+	},
+#undef LAYOUT_PAGES_COUNT
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+
+	.flash_size = DT_INST_PROP(0, size) / 8,
+	.jedec_id = DT_INST_PROP(0, jedec_id),
+
+#ifdef CONFIG_SPI_NOR_SFDP_DEVICETREE
+	.bfp_len = sizeof(bfp_data_0) / 4,
+	.bfp = (const struct jesd216_bfp *)bfp_data_0,
+#endif /* CONFIG_SPI_NOR_SFDP_DEVICETREE */
+
+#endif /* CONFIG_SPI_NOR_SFDP_RUNTIME */
 };
 
-static struct spi_nor_data spi_nor_memory_data;
+static struct spi_nor_data spi_nor_data_0;
 
 DEVICE_AND_API_INIT(spi_flash_memory, DT_INST_LABEL(0),
-		    &spi_nor_init, &spi_nor_memory_data,
-		    &flash_id, POST_KERNEL, CONFIG_SPI_NOR_INIT_PRIORITY,
+		    &spi_nor_init, &spi_nor_data_0, &spi_nor_config_0,
+		    POST_KERNEL, CONFIG_SPI_NOR_INIT_PRIORITY,
 		    &spi_nor_api);

--- a/drivers/flash/spi_nor.h
+++ b/drivers/flash/spi_nor.h
@@ -11,17 +11,6 @@
 
 #define SPI_NOR_MAX_ID_LEN	3
 
-struct spi_nor_config {
-	/* JEDEC id from devicetree */
-	uint8_t id[SPI_NOR_MAX_ID_LEN];
-
-	/* Indicates support for BE32K */
-	bool has_be32k;
-
-	/* Size from devicetree, in bytes */
-	uint32_t size;
-};
-
 /* Status register bits */
 #define SPI_NOR_WIP_BIT         BIT(0)  /* Write in progress */
 #define SPI_NOR_WEL_BIT         BIT(1)  /* Write enable latch */
@@ -47,15 +36,8 @@ struct spi_nor_config {
 #define SPI_NOR_SECTOR_SIZE  0x1000U
 #define SPI_NOR_BLOCK_SIZE   0x10000U
 
-/* Some devices support erase operations on 32 KiBy blocks.
- * Support is indicated by the has-be32k property.
- */
-#define SPI_NOR_BLOCK32_SIZE 0x8000
-
-/* Test whether offset is aligned. */
-#define SPI_NOR_IS_PAGE_ALIGNED(_ofs) (((_ofs) & (SPI_NOR_PAGE_SIZE - 1U)) == 0)
-#define SPI_NOR_IS_SECTOR_ALIGNED(_ofs) (((_ofs) & (SPI_NOR_SECTOR_SIZE - 1U)) == 0)
-#define SPI_NOR_IS_BLOCK_ALIGNED(_ofs) (((_ofs) & (SPI_NOR_BLOCK_SIZE - 1U)) == 0)
-#define SPI_NOR_IS_BLOCK32_ALIGNED(_ofs) (((_ofs) & (SPI_NOR_BLOCK32_SIZE - 1U)) == 0)
+/* Test whether offset is aligned to a given number of bits. */
+#define SPI_NOR_IS_ALIGNED(_ofs, _bits) (((_ofs) & BIT_MASK(_bits)) == 0)
+#define SPI_NOR_IS_SECTOR_ALIGNED(_ofs) SPI_NOR_IS_ALIGNED(_ofs, 12)
 
 #endif /*__SPI_NOR_H__*/

--- a/dts/bindings/mtd/jedec,spi-nor-common.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor-common.yaml
@@ -8,7 +8,7 @@
 properties:
   jedec-id:
     type: uint8-array
-    required: true
+    required: false
     description: JEDEC ID as manufacturer ID, memory type, memory density
 
   sfdp-bfp:
@@ -92,5 +92,5 @@ properties:
 
   size:
     type: int
-    required: true
+    required: false
     description: flash capacity in bits

--- a/dts/bindings/mtd/jedec,spi-nor-common.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor-common.yaml
@@ -11,6 +11,15 @@ properties:
     required: true
     description: JEDEC ID as manufacturer ID, memory type, memory density
 
+  sfdp-bfp:
+    type: uint8-array
+    required: false
+    description: |
+      Contains the 32-bit words in little-endian byte order from the
+      JESD216 Serial Flash Discoverable Parameters Basic Flash
+      Parameters table.  This provides flash-specific configuration
+      information in cases were runtime configuration is not desired.
+
   has-be32k:
     type: boolean
     required: false

--- a/dts/bindings/mtd/jedec,spi-nor-common.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor-common.yaml
@@ -23,7 +23,7 @@ properties:
   has-be32k:
     type: boolean
     required: false
-    description: Indicates the device supports the BE32K (0xD8) command
+    description: Not used after Zephyr 2.3.0
 
   requires-ulbpr:
     type: boolean

--- a/dts/bindings/mtd/nordic,qspi-nor.yaml
+++ b/dts/bindings/mtd/nordic,qspi-nor.yaml
@@ -17,6 +17,12 @@ properties:
   label:
     required: true
 
+  jedec-id:
+    required: true
+
+  size:
+    required: true
+
   readoc:
     type: string
     required: false

--- a/include/drivers/flash.h
+++ b/include/drivers/flash.h
@@ -83,6 +83,7 @@ typedef void (*flash_api_pages_layout)(struct device *dev,
 
 typedef int (*flash_api_sfdp_read)(struct device *dev, off_t offset,
 				   void *data, size_t len);
+typedef int (*flash_api_read_jedec_id)(struct device *dev, uint8_t *id);
 
 __subsystem struct flash_driver_api {
 	flash_api_read read;
@@ -95,6 +96,7 @@ __subsystem struct flash_driver_api {
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 #if defined(CONFIG_FLASH_JESD216_API)
 	flash_api_sfdp_read sfdp_read;
+	flash_api_read_jedec_id read_jedec_id;
 #endif /* CONFIG_FLASH_JESD216_API */
 };
 
@@ -328,6 +330,31 @@ static inline int z_impl_flash_sfdp_read(struct device *dev, off_t offset,
 
 	if (api->sfdp_read != NULL) {
 		rv = api->sfdp_read(dev, offset, data, len);
+	}
+	return rv;
+}
+
+/**
+ * @brief Read the JEDEC ID from a compatible flash device.
+ *
+ * @param dev device from which id will be read
+ * @param id pointer to a buffer of at least 3 bytes into which id
+ * will be stored
+ *
+ * @retval 0 on successful store of 3-byte JEDEC id
+ * @retval -ENOTSUP if flash driver doesn't support this function
+ * @retval negative values for other errors
+ */
+__syscall int flash_read_jedec_id(struct device *dev, uint8_t *id);
+
+static inline int z_impl_flash_read_jedec_id(struct device *dev, uint8_t *id)
+{
+	int rv = -ENOTSUP;
+	const struct flash_driver_api *api =
+		(const struct flash_driver_api *)dev->api;
+
+	if (api->read_jedec_id != NULL) {
+		rv = api->read_jedec_id(dev, id);
 	}
 	return rv;
 }

--- a/samples/drivers/jesd216/CMakeLists.txt
+++ b/samples/drivers/jesd216/CMakeLists.txt
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13.1)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(flash_jesd216)
+
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers/flash)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/jesd216/README.rst
+++ b/samples/drivers/jesd216/README.rst
@@ -1,0 +1,64 @@
+.. jesd216-sample:
+
+JESD216 Sample
+##############
+
+Overview
+********
+
+This sample demonstrates how to use the JESD216 flash API to extract
+information from a compatible serial device, and serves as utility to
+generate ``jedec,spi-nor`` devicetree property values for the device.
+
+Building and Running
+********************
+
+The application will build only for a target that has a devicetree entry
+with ``jedec,spi-nor`` as a compatible, and for which the driver
+supports :option:`CONFIG_FLASH_JESD216_API`.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/jesd216
+   :board: efr32mg_sltb004a
+   :goals: build flash
+   :compact:
+
+Sample Output
+=============
+
+.. code-block:: console
+
+   MX25R8035F: SFDP v 1.6 AP ff with 2 PH
+   PH0: ff00 rev 1.6: 16 DW @ 30
+   Summary of BFP content:
+   DTR Clocking not supported
+   Addressing: 3-Byte only
+   4-KiBy erase: uniform
+   Support QSPI XIP
+   Support 1-1-1
+   Support 1-1-2: instr 3Bh, 0 mode clocks, 8 waits
+   Support 1-1-4: instr 6Bh, 0 mode clocks, 8 waits
+   Support 1-2-2: instr BBh, 0 mode clocks, 4 waits
+   Support 1-4-4: instr EBh, 2 mode clocks, 4 waits
+   Flash density: 1048576 bytes
+   ET1: instr 20h for 4096 By; typ 48 ms, max 384 ms
+   ET2: instr 52h for 32768 By; typ 240 ms, max 1920 ms
+   ET3: instr D8h for 65536 By; typ 480 ms, max 3840 ms
+   Chip erase: typ 5120 ms, max 30720 ms
+   Byte program: type 32 + 1 * B us, max 192 + 6 * B us
+   Page program: typ 896 us, max 5376 us
+   Page size: 256 By
+   Suspend: B0h ; Resume: 30h
+   DPD: Enter B9h, exit ABh ; delay 40000 ns ; poll 0x3d
+   size = <8388608>;
+   sfdp-bfp = [
+           e5 20 f1 ff  ff ff 7f 00  44 eb 08 6b  08 3b 04 bb
+           ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
+           10 d8 00 ff  23 72 f5 00  82 ed 04 b7  44 83 38 44
+           30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
+           ];
+   PH1: ffc2 rev 1.0: 4 DW @ 110
+   sfdp-ffc2 = [
+           00 36 50 16  9d f9 c0 64  fe cf ff ff  ff ff ff ff
+           ];
+   jedec-id = [c2 28 14];

--- a/samples/drivers/jesd216/boards/nrf52840dk_nrf52840.conf
+++ b/samples/drivers/jesd216/boards/nrf52840dk_nrf52840.conf
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2019 Peter Bigot Consulting, LLC
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Need this when storage is on MX25R64
+#CONFIG_NORDIC_QSPI_NOR=y
+#CONFIG_NORDIC_QSPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
+CONFIG_SPI=y
+CONFIG_SPI_NOR=y
+CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
+CONFIG_SPI_2=y

--- a/samples/drivers/jesd216/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/drivers/jesd216/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019 Peter Bigot Consulting, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+/delete-node/ &mx25r64;
+
+&qspi {
+	status = "disabled";
+};
+
+&spi2 {
+	status = "okay";
+	cs-gpios = <&gpio0 17 0>, <&gpio1 5 0>;
+	mx25r64: mx25r6435f@0 {
+		status = "okay";
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <8000000>;
+		label = "MX25R64";
+		jedec-id = [c2 28 17];
+		sfdp-bfp = [
+			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb
+			ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
+			10 d8 00 ff  23 72 f5 00  82 ed 04 cc  44 83 68 44
+			30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
+		];
+
+		size = <67108864>;
+		has-be32k;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		dpd-wakeup-sequence = <30000 20 45000>;
+		wp-gpios = <&gpio0 22 0>;
+		hold-gpios = <&gpio0 23 0>;
+	};
+};
+
+&mx25r64 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "storage";
+			reg = <0x00000000 0x00010000>;
+		};
+	};
+};

--- a/samples/drivers/jesd216/prj.conf
+++ b/samples/drivers/jesd216/prj.conf
@@ -1,0 +1,8 @@
+CONFIG_STDOUT_CONSOLE=y
+CONFIG_FLASH=y
+CONFIG_FLASH_JESD216_API=y
+
+# Assume the standard SPI NOR flash driver.  If the device uses
+# another driver add an override configuration in boards/.
+CONFIG_SPI=y
+CONFIG_SPI_NOR=y

--- a/samples/drivers/jesd216/sample.yaml
+++ b/samples/drivers/jesd216/sample.yaml
@@ -1,0 +1,14 @@
+sample:
+  name: JESD216 Sample
+tests:
+  sample.drivers.jesd216:
+    tags: spi flash
+    filter: dt_compat_enabled("jedec,spi-nor")
+    harness: console
+    harness_config:
+        type: multi_line
+        ordered: true
+        regex:
+            - "sfdp-bfp ="
+            - "jedec-id ="
+    depends_on: spi

--- a/samples/drivers/jesd216/src/main.c
+++ b/samples/drivers/jesd216/src/main.c
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2020 Peter Bigot Consulting, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <device.h>
+#include <drivers/flash.h>
+#include <jesd216.h>
+#include <stdio.h>
+#include <inttypes.h>
+#include <string.h>
+
+#if DT_NODE_HAS_STATUS(DT_INST(0, jedec_spi_nor), okay)
+#define FLASH_DEVICE DT_LABEL(DT_INST(0, jedec_spi_nor))
+#else
+#error Unsupported flash driver
+#define FLASH_DEVICE ""
+#endif
+
+typedef void (*dw_extractor)(const struct jesd216_param_header *php,
+			     const struct jesd216_bfp *bfp);
+
+static const char * const mode_tags[] = {
+	[JESD216_MODE_044] = "QSPI XIP",
+	[JESD216_MODE_088] = "OSPI XIP",
+	[JESD216_MODE_111] = "1-1-1",
+	[JESD216_MODE_112] = "1-1-2",
+	[JESD216_MODE_114] = "1-1-4",
+	[JESD216_MODE_118] = "1-1-8",
+	[JESD216_MODE_122] = "1-2-2",
+	[JESD216_MODE_144] = "1-4-4",
+	[JESD216_MODE_188] = "1-8-8",
+	[JESD216_MODE_222] = "2-2-2",
+	[JESD216_MODE_444] = "4-4-4",
+};
+
+static void summarize_dw1(const struct jesd216_param_header *php,
+			  const struct jesd216_bfp *bfp)
+{
+	uint32_t dw1 = sys_le32_to_cpu(bfp->dw1);
+
+	printf("DTR Clocking %ssupported\n",
+	       (dw1 & JESD216_SFDP_BFP_DW1_DTRCLK_FLG) ? "" : "not ");
+
+	static const char *const addr_bytes[] = {
+		[JESD216_SFDP_BFP_DW1_ADDRBYTES_VAL_3B] = "3-Byte only",
+		[JESD216_SFDP_BFP_DW1_ADDRBYTES_VAL_3B4B] = "3- or 4-Byte",
+		[JESD216_SFDP_BFP_DW1_ADDRBYTES_VAL_4B] = "4-Byte only",
+		[3] = "Reserved",
+	};
+
+	printf("Addressing: %s\n", addr_bytes[(dw1 & JESD216_SFDP_BFP_DW1_ADDRBYTES_MASK)
+					      >> JESD216_SFDP_BFP_DW1_ADDRBYTES_SHFT]);
+
+	static const char *const bsersz[] = {
+		[0] = "Reserved 00b",
+		[JESD216_SFDP_BFP_DW1_BSERSZ_VAL_4KSUP] = "uniform",
+		[2] = "Reserved 01b",
+		[JESD216_SFDP_BFP_DW1_BSERSZ_VAL_4KNOTSUP] = "not uniform",
+	};
+
+	printf("4-KiBy erase: %s\n", bsersz[(dw1 & JESD216_SFDP_BFP_DW1_BSERSZ_MASK)
+					    >> JESD216_SFDP_BFP_DW1_BSERSZ_SHFT]);
+
+	for (size_t mode = 0; mode < ARRAY_SIZE(mode_tags); ++mode) {
+		const char *tag = mode_tags[mode];
+
+		if (tag) {
+			struct jesd216_instr cmd;
+			int rc = jesd216_bfp_read_support(php, bfp,
+							  (enum jesd216_mode_type)mode,
+							  &cmd);
+
+			if (rc == 0) {
+				printf("Support %s\n", tag);
+			} else if (rc > 0) {
+				printf("Support %s: instr %02Xh, %u mode clocks, %u waits\n",
+				       tag, cmd.instr, cmd.mode_clocks, cmd.wait_states);
+			}
+		}
+	}
+}
+
+static void summarize_dw2(const struct jesd216_param_header *php,
+			  const struct jesd216_bfp *bfp)
+{
+	printf("Flash density: %u bytes\n", (uint32_t)(jesd216_bfp_density(bfp) / 8));
+}
+
+static void summarize_dw89(const struct jesd216_param_header *php,
+			   const struct jesd216_bfp *bfp)
+{
+	struct jesd216_erase_type etype;
+	uint32_t typ_ms;
+	int typ_max_mul;
+
+	for (uint8_t idx = 1; idx < JESD216_NUM_ERASE_TYPES; ++idx) {
+		if (jesd216_bfp_erase(bfp, idx, &etype) == 0) {
+			typ_max_mul = jesd216_bfp_erase_type_times(php, bfp,
+								   idx, &typ_ms);
+
+			printf("ET%u: instr %02Xh for %u By", idx, etype.cmd,
+			       (uint32_t)BIT(etype.exp));
+			if (typ_max_mul > 0) {
+				printf("; typ %u ms, max %u ms",
+				       typ_ms, typ_max_mul * typ_ms);
+			}
+			printf("\n");
+		}
+	}
+}
+
+static void summarize_dw11(const struct jesd216_param_header *php,
+			   const struct jesd216_bfp *bfp)
+{
+	struct jesd216_bfp_dw11 dw11;
+
+	if (jesd216_bfp_decode_dw11(php, bfp, &dw11) != 0) {
+		return;
+	}
+
+	printf("Chip erase: typ %u ms, max %u ms\n",
+	       dw11.chip_erase_ms, dw11.typ_max_factor * dw11.chip_erase_ms);
+
+	printf("Byte program: type %u + %u * B us, max %u + %u * B us\n",
+	       dw11.byte_prog_first_us, dw11.byte_prog_addl_us,
+	       dw11.typ_max_factor * dw11.byte_prog_first_us,
+	       dw11.typ_max_factor * dw11.byte_prog_addl_us);
+
+	printf("Page program: typ %u us, max %u us\n",
+	       dw11.page_prog_us,
+	       dw11.typ_max_factor * dw11.page_prog_us);
+
+	printf("Page size: %u By\n", dw11.page_size);
+}
+
+static void summarize_dw12(const struct jesd216_param_header *php,
+			   const struct jesd216_bfp *bfp)
+{
+	uint32_t dw12 = sys_le32_to_cpu(bfp->dw10[2]);
+	uint32_t dw13 = sys_le32_to_cpu(bfp->dw10[3]);
+
+	/* Inverted logic flag: 1 means not supported */
+	if ((dw12 & JESD216_SFDP_BFP_DW12_SUSPRESSUP_FLG) != 0) {
+		return;
+	}
+
+	uint8_t susp_instr = dw13 >> 24;
+	uint8_t resm_instr = dw13 >> 16;
+	uint8_t psusp_instr = dw13 >> 8;
+	uint8_t presm_instr = dw13 >> 0;
+
+	printf("Suspend: %02Xh ; Resume: %02Xh\n",
+	       susp_instr, resm_instr);
+	if ((susp_instr != psusp_instr)
+	    || (resm_instr != presm_instr)) {
+		printf("Program suspend: %02Xh ; Resume: %02Xh\n",
+		       psusp_instr, presm_instr);
+	}
+}
+
+static void summarize_dw14(const struct jesd216_param_header *php,
+			   const struct jesd216_bfp *bfp)
+{
+	struct jesd216_bfp_dw14 dw14;
+
+	if (jesd216_bfp_decode_dw14(php, bfp, &dw14) != 0) {
+		return;
+	}
+	printf("DPD: Enter %02Xh, exit %02Xh ; delay %u ns ; poll 0x%02x\n",
+	       dw14.enter_dpd_instr, dw14.exit_dpd_instr,
+	       dw14.exit_delay_ns, dw14.poll_options);
+}
+
+/* Indexed from 1 to match JESD216 data word numbering */
+static const dw_extractor extractor[] = {
+	[1] = summarize_dw1,
+	[2] = summarize_dw2,
+	[8] = summarize_dw89,
+	[11] = summarize_dw11,
+	[12] = summarize_dw12,
+	[14] = summarize_dw14,
+};
+
+static void dump_bfp(const struct jesd216_param_header *php,
+		     const struct jesd216_bfp *bfp)
+{
+	uint8_t dw = 1;
+	uint8_t limit = MIN(php->len_dw, ARRAY_SIZE(extractor));
+
+	printf("Summary of BFP content:\n");
+	while (dw < limit) {
+		dw_extractor ext = extractor[dw];
+
+		if (ext != 0) {
+			ext(php, bfp);
+		}
+		++dw;
+	}
+}
+
+static void dump_bytes(const struct jesd216_param_header *php,
+		       const uint32_t *dw)
+{
+	char buffer[4 * 3 + 1]; /* B1 B2 B3 B4 */
+	uint8_t nw = 0;
+
+	printf(" [\n\t");
+	while (nw < php->len_dw) {
+		const uint8_t *u8p = (const uint8_t *)&dw[nw];
+		++nw;
+
+		bool emit_nl = (nw == php->len_dw) || ((nw % 4) == 0);
+
+		sprintf(buffer, "%02x %02x %02x %02x",
+			u8p[0], u8p[1], u8p[2], u8p[3]);
+		if (emit_nl) {
+			printf("%s\n\t", buffer);
+		} else {
+			printf("%s  ", buffer);
+		}
+	}
+	printf("];\n");
+}
+
+void main(void)
+{
+	struct device *dev = device_get_binding(FLASH_DEVICE);
+
+	if (!dev) {
+		printf("%s: device not found\n", FLASH_DEVICE);
+		return;
+	}
+
+	const uint8_t decl_nph = 5;
+	union {
+		uint8_t raw[JESD216_SFDP_SIZE(decl_nph)];
+		struct jesd216_sfdp_header sfdp;
+	} u;
+	const struct jesd216_sfdp_header *hp = &u.sfdp;
+	int rc = flash_sfdp_read(dev, 0, u.raw, sizeof(u.raw));
+	uint32_t magic = jesd216_sfdp_magic(hp);
+
+	if (magic != JESD216_SFDP_MAGIC) {
+		printf("SFDP magic %08x invalid", magic);
+		return;
+	}
+
+	printf("%s: SFDP v %u.%u AP %x with %u PH\n", dev->name,
+		hp->rev_major, hp->rev_minor, hp->access, hp->nph);
+
+	const struct jesd216_param_header *php = hp->phdr;
+	const struct jesd216_param_header *phpe = php + MIN(decl_nph, hp->nph);
+
+	while (php != phpe) {
+		uint16_t id = jesd216_param_id(php);
+		uint32_t addr = jesd216_param_addr(php);
+
+		printf("PH%u: %04x rev %u.%u: %u DW @ %x\n",
+		       (php - hp->phdr), id, php->rev_major, php->rev_minor,
+		       php->len_dw, addr);
+
+		uint32_t dw[php->len_dw];
+
+		rc = flash_sfdp_read(dev, addr, dw, sizeof(dw));
+		if (rc != 0) {
+			printf("Read failed: %d\n", rc);
+			return;
+		}
+
+		if (id == JESD216_SFDP_PARAM_ID_BFP) {
+			const struct jesd216_bfp *bfp = (struct jesd216_bfp *)dw;
+
+			dump_bfp(php, bfp);
+			printf("size = <%u>;\n", (uint32_t)jesd216_bfp_density(bfp));
+			printf("sfdp-bfp =");
+		} else {
+			printf("sfdp-%04x =", id);
+		}
+
+		dump_bytes(php, dw);
+
+		++php;
+	}
+
+	uint8_t id[3];
+
+	rc = flash_read_jedec_id(dev, id);
+	if (rc == 0) {
+		printf("jedec-id = [%02x %02x %02x];\n",
+		       id[0], id[1], id[2]);
+	} else {
+		printf("JEDEC ID read failed: %d\n", rc);
+	}
+}


### PR DESCRIPTION
Implementation for #25958 with demonstration with existing SPI NOR driver and an example.

This reworks the `jedec,spi-nor` common bindings to allow describing device properties with the Basic Flash Parameters table from the [JESD216](https://www.jedec.org/standards-documents/docs/jesd216b) Serial Flash Discoverable Parameters capability.

A jesd216 module is added in drivers/flash that defines constants and data structures related to SFDP processing and provides helper functions to extract data.  Optionally this API can be exposed to applications, which enables a sample application that displays the supported features of a connected device and dumps the devicetree property settings required to support it.  Because the API is unlikely to be used generally the header documentation is not tagged for generating user documentation.

The SPI NOR driver is updated to use the jesd216 data from a BFP structure. This currently supports additional erase sizes and non-standard page sizes, but with the infrastructure in place can be extended to support 4-byte addressing, sleeping rather than busy-waiting for operation completion, and other features.  Deep-power-down may be automatically supported, though initial investigation suggests the BFP doesn't provide sufficient information on entry/exit timing.

The SPI NOR driver is updated to support specifying flash parameters through several mechanisms:
* `CONFIG_SPI_NOR_SFDP_MINIMAL` validates the JEDEC ID and provides size from devicetree.  It supports only the standard erase types and page sizes.
* `CONFIG_SPI_NOR_SFDP_DEVICETREE` takes the BFP content from the devicetree node.  It supports any runtime-detectable feature without the overhead of reading the device at runtime.
* `CONFIG_SPI_NOR_SFDP_RUNTIME` reads the BFP content at runtime.  This allows the same firmware to support any underlying JESD216-compatible flash device.

Related issues and PRs
* Closes #25958
* Supersedes #23658
* Supports STM32 QSPI #25806
* Supports NXP iMX QSPI #25669 (superseding #15364)
