### PR TITLE
drivers: spi: ensure the first byte has been loaded in the TX fast path

### DIFF
--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -219,6 +219,13 @@ static void spi_sam0_fast_rx(SercomSpi *regs, const struct spi_buf *rx_buf)
 	regs->DATA.reg = 0;
 	len--;
 
+	/* Ensure the data register has shifted to the shift register before
+	 * continuing.	Later writes are synchronised by waiting for the receive
+	 * to complete.
+	 */
+	while (!regs->INTFLAG.bit.DRE) {
+	}
+
 	while (len) {
 		/* Load byte N+1 into the transmit register */
 		regs->DATA.reg = 0;


### PR DESCRIPTION
The SAM0 has a data register and a shift register.  Data that is
written to the data register is transferred to the shift register by
the peripheral.

On the SAMD51, the CPU is fast enough that the first data write hasn't
been transferred to the shift register by the time the next data write
occurs, causing the second write to be dropped, causing the receiver
to wait forever.

Fix by spinning until the data register is empty.

Signed-off-by: Michael Hope <mlhx@google.com>