### PR TITLE
drivers: timer: fix the use of K_FOREVER and add support for the SAMD/E5x

### DIFF
--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -254,7 +254,7 @@ void z_clock_set_timeout(int32_t ticks, bool idle)
 
 #ifdef CONFIG_TICKLESS_KERNEL
 
-	ticks = (ticks == K_FOREVER) ? MAX_TICKS : ticks;
+	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
 	ticks = MAX(MIN(ticks - 1, (int32_t) MAX_TICKS), 0);
 
 	/* Compute number of RTC cycles until the next timeout. */
@@ -274,8 +274,8 @@ void z_clock_set_timeout(int32_t ticks, bool idle)
 
 #else /* !CONFIG_TICKLESS_KERNEL */
 
-	if (ticks == K_FOREVER) {
-		/* Disable comparator for K_FOREVER and other negative
+	if (ticks == K_TICKS_FOREVER) {
+		/* Disable comparator for K_TICKS_FOREVER and other negative
 		 * values.
 		 */
 		rtc_timeout = rtc_counter;

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -205,6 +205,10 @@ int z_clock_driver_init(struct device *device)
 	uint16_t ctrl = RTC_MODE0_CTRLA_MODE(0) | RTC_MODE0_CTRLA_PRESCALER(0);
 #endif
 
+#ifdef RTC_MODE0_CTRLA_COUNTSYNC
+	ctrl |= RTC_MODE0_CTRLA_COUNTSYNC;
+#endif
+
 #ifndef CONFIG_TICKLESS_KERNEL
 #ifdef RTC_MODE0_CTRL_MATCHCLR
 	ctrl |= RTC_MODE0_CTRL_MATCHCLR;


### PR DESCRIPTION
Change K_FOREVER for the new K_TICKS_FOREVER.

The COUNT register on the ~SAMD51~ SAMD/E5x RTC can only be read if the read synchronisation mode is enabled.

Signed-off-by: Michael Hope <mlhx@google.com>