### PR TITLE
tests: adding test cases of spinlock

### DIFF
--- a/tests/kernel/spinlock/src/main.c
+++ b/tests/kernel/spinlock/src/main.c
@@ -129,10 +129,56 @@ void test_spinlock_bounce(void)
 	bounce_done = 1;
 }
 
+/**
+ * @brief Test basic mutual exclusion using interrupt masking
+ *
+ * @details
+ * - Spinlocks can be initialized at run-time.
+ * - Spinlocks in uniprocessor context should achieve mutual exclusion using
+ *   interrupt masking.
+ *
+ * @ingroup kernel_spinlock_tests
+ *
+ * @see k_spin_lock(), k_spin_unlock()
+ */
+void test_spinlock_mutual_exclusion(void)
+{
+	k_spinlock_key_t key;
+	struct k_spinlock lock_runtime;
+	unsigned int irq_key;
+
+	lock_runtime.locked = 0;
+
+	key = k_spin_lock(&lock_runtime);
+
+	zassert_true(lock_runtime.locked, "Spinlock failed to lock");
+
+	/* check irq has not locked */
+	zassert_true(arch_irq_unlocked(key.key),
+			"irq should be first locked!");
+
+	/*
+	 * We make irq locked nested to check if interrupt
+	 * disable happened or not.
+	 */
+	irq_key = arch_irq_lock();
+
+	/* check irq has already locked */
+	zassert_false(arch_irq_unlocked(irq_key),
+			"irq should be already locked!");
+
+	arch_irq_unlock(irq_key);
+
+	k_spin_unlock(&lock_runtime, key);
+
+	zassert_true(!lock_runtime.locked, "Spinlock failed to unlock");
+}
+
 void test_main(void)
 {
 	ztest_test_suite(spinlock,
 			 ztest_unit_test(test_spinlock_basic),
-			 ztest_unit_test(test_spinlock_bounce));
+			 ztest_unit_test(test_spinlock_bounce),
+			 ztest_unit_test(test_spinlock_mutual_exclusion));
 	ztest_run_test_suite(spinlock);
 }


### PR DESCRIPTION
Add test case for testing achieve mutual exclusion using interrupt
masking, and initialize at runtime.

Add a new test case "test_spinlock_mutual_exclusion" to verify:
1. Spinlock in uni-processor context should achieve mutual exclusion using interrupt masking, we check interrupt is enabled or not before and after using spinlock.
2. Spinlock can initialize at rumtime, we declare a local spinlock and initialize it ourself. 


Signed-off-by: Enjia Mai <enjiax.mai@intel.com>