### PR TITLE
drivers: ieee802154: fix nrf5 initialization with external irq source

### DIFF
--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -31,4 +31,15 @@ config IEEE802154_NRF5_INIT_PRIO
 	  Set the initialization priority number. Do not mess with it unless
 	  you know what you are doing.
 
+config IEEE802154_NRF5_EXT_IRQ_MGMT
+	bool "Radio IRQ is managed by an external module"
+	help
+	  The driver may manage radio IRQs by itself, or use an external
+	  radio IRQ provider. When radio IRQs are managed by an external
+	  provider, the driver shall not configure radio IRQs.
+
+	  Enable this option when external radio IRQ provider is enabled in
+	  the system. One example of external radio IRQ provider could be
+	  a radio arbiter used in dynamic multiprotocol applications.
+
 endif

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -438,20 +438,24 @@ static int nrf5_stop(struct device *dev)
 	return 0;
 }
 
+#ifndef CONFIG_IEEE802154_NRF5_EXT_IRQ_MGMT
 static void nrf5_radio_irq(void *arg)
 {
 	ARG_UNUSED(arg);
 
 	nrf_802154_radio_irq_handler();
 }
+#endif
 
 static void nrf5_irq_config(struct device *dev)
 {
 	ARG_UNUSED(dev);
 
+#ifndef CONFIG_IEEE802154_NRF5_EXT_IRQ_MGMT
 	IRQ_CONNECT(RADIO_IRQn, NRF_802154_IRQ_PRIORITY,
 		    nrf5_radio_irq, NULL, 0);
 	irq_enable(RADIO_IRQn);
+#endif
 }
 
 static int nrf5_init(struct device *dev)


### PR DESCRIPTION
MPSL is a library that provides external radio IRQ source for the
802.15.4 driver. If this library is in use, the driver shall not
configure the radio IRQ.

Signed-off-by: Hubert Miś <hubert.mis@nordicsemi.no>