### PR TITLE
samples: net: google_iot_mqtt: log actual error

### DIFF
--- a/samples/net/cloud/google_iot_mqtt/src/protocol.c
+++ b/samples/net/cloud/google_iot_mqtt/src/protocol.c
@@ -246,7 +246,7 @@ void mqtt_startup(char *hostname, int port)
 
 		if (err != 0) {
 			LOG_ERR("Unable to get address for broker, error %d",
-				res);
+				err);
 			return;
 		}
 		LOG_INF("DNS resolved for mqtt.googleapis.com:8833");

--- a/samples/net/cloud/google_iot_mqtt/src/protocol.c
+++ b/samples/net/cloud/google_iot_mqtt/src/protocol.c
@@ -249,7 +249,7 @@ void mqtt_startup(char *hostname, int port)
 				err);
 			return;
 		}
-		LOG_INF("DNS resolved for mqtt.googleapis.com:8833");
+		LOG_INF("DNS resolved for mqtt.googleapis.com:8883");
 
 		mqtt_client_init(client);
 


### PR DESCRIPTION
currently 0 logged always