### PR TITLE
include: sys: time_units: fix 32-bit near conversion for overflow

### DIFF
--- a/include/sys/time_units.h
+++ b/include/sys/time_units.h
@@ -108,7 +108,7 @@ static TIME_CONSTEXPR ALWAYS_INLINE u64_t z_tmcvt(u64_t t, u32_t from_hz,
 	 */
 	if (div_ratio) {
 		t += off;
-		if (result32) {
+		if (result32 && (t < BIT64(32))) {
 			return ((u32_t)t) / (from_hz / to_hz);
 		} else {
 			return t / (from_hz / to_hz);

--- a/tests/kernel/timer/timer_api/src/timer_convert.c
+++ b/tests/kernel/timer/timer_api/src/timer_convert.c
@@ -167,6 +167,7 @@ void test_time_conversions(void)
 		test_conversion(&tests[i], 1);
 		test_conversion(&tests[i], 0x7fffffff);
 		test_conversion(&tests[i], 0x80000000);
+		test_conversion(&tests[i], 0xfffffff0);
 		if (tests[i].precision == 64) {
 			test_conversion(&tests[i], 0xffffffff);
 			test_conversion(&tests[i], 0x100000000ULL);


### PR DESCRIPTION
Adjusting the input value to allow round to nearest can cause an
overflow which invalidates the expectation that the 32-bit result is
the low 32 bits of the 64-bit result.  If the adjustment overflows do
the full-precision conversion and truncate in the caller.

Fixes #25870.