### PR TITLE
boards/arm: unify boot partition size for nRF boards

### DIFF
--- a/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp_common.dts
@@ -138,15 +138,15 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x10000>;
+			reg = <0x00000000 0x0000C000>;
 		};
-		slot0_partition: partition@10000 {
+		slot0_partition: partition@c000 {
 			label = "image-0";
 		};
-		slot0_ns_partition: partition@40000 {
+		slot0_ns_partition: partition@3e000 {
 			label = "image-0-nonsecure";
 		};
-		slot1_partition: partition@80000 {
+		slot1_partition: partition@7e000 {
 			label = "image-1";
 		};
 		slot1_ns_partition: partition@b0000 {

--- a/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp_partition_conf.dts
+++ b/boards/arm/nrf5340pdk_nrf5340/nrf5340pdk_nrf5340_cpuapp_partition_conf.dts
@@ -22,15 +22,15 @@
  */
 
 &slot0_partition {
-	reg = <0x00010000 0x30000>;
+	reg = <0x0000c000 0x30000>;
 };
 
 &slot0_ns_partition {
-	reg = <0x00040000 0x40000>;
+	reg = <0x0003e000 0x40000>;
 };
 
 &slot1_partition {
-	reg = <0x00080000 0x30000>;
+	reg = <0x0007e000 0x30000>;
 };
 
 &slot1_ns_partition {

--- a/boards/arm/nrf9160_innblue21/nrf9160_innblue21_common.dts
+++ b/boards/arm/nrf9160_innblue21/nrf9160_innblue21_common.dts
@@ -167,15 +167,15 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x10000>;
+			reg = <0x00000000 0xc000>;
 		};
-		slot0_partition: partition@10000 {
+		slot0_partition: partition@c000 {
 			label = "image-0";
 		};
-		slot0_ns_partition: partition@40000 {
+		slot0_ns_partition: partition@3e000 {
 			label = "image-0-nonsecure";
 		};
-		slot1_partition: partition@80000 {
+		slot1_partition: partition@7e000 {
 			label = "image-1";
 		};
 		slot1_ns_partition: partition@b0000 {

--- a/boards/arm/nrf9160_innblue21/nrf9160_innblue21_partition_conf.dts
+++ b/boards/arm/nrf9160_innblue21/nrf9160_innblue21_partition_conf.dts
@@ -22,15 +22,15 @@
  */
 
 &slot0_partition {
-	reg = <0x00010000 0x30000>;
+	reg = <0x0000c000 0x30000>;
 };
 
 &slot0_ns_partition {
-	reg = <0x00040000 0x40000>;
+	reg = <0x0003e000 0x40000>;
 };
 
 &slot1_partition {
-	reg = <0x00080000 0x30000>;
+	reg = <0x0007e000 0x30000>;
 };
 
 &slot1_ns_partition {

--- a/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dts
+++ b/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dts
@@ -175,15 +175,15 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x10000>;
+			reg = <0x00000000 0xc000>;
 		};
-		slot0_partition: partition@10000 {
+		slot0_partition: partition@c000 {
 			label = "image-0";
 		};
-		slot0_ns_partition: partition@40000 {
+		slot0_ns_partition: partition@3e000 {
 			label = "image-0-nonsecure";
 		};
-		slot1_partition: partition@80000 {
+		slot1_partition: partition@7e000 {
 			label = "image-1";
 		};
 		slot1_ns_partition: partition@b0000 {

--- a/boards/arm/nrf9160_innblue22/nrf9160_innblue22_partition_conf.dts
+++ b/boards/arm/nrf9160_innblue22/nrf9160_innblue22_partition_conf.dts
@@ -22,15 +22,15 @@
  */
 
 &slot0_partition {
-	reg = <0x00010000 0x30000>;
+	reg = <0x0000c000 0x30000>;
 };
 
 &slot0_ns_partition {
-	reg = <0x00040000 0x40000>;
+	reg = <0x0003e000 0x40000>;
 };
 
 &slot1_partition {
-	reg = <0x00080000 0x30000>;
+	reg = <0x0007e000 0x30000>;
 };
 
 &slot1_ns_partition {

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -154,15 +154,15 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x10000>;
+			reg = <0x00000000 0xc000>;
 		};
-		slot0_partition: partition@10000 {
+		slot0_partition: partition@c000 {
 			label = "image-0";
 		};
-		slot0_ns_partition: partition@40000 {
+		slot0_ns_partition: partition@3e000 {
 			label = "image-0-nonsecure";
 		};
-		slot1_partition: partition@80000 {
+		slot1_partition: partition@7e000 {
 			label = "image-1";
 		};
 		slot1_ns_partition: partition@b0000 {

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_partition_conf.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_partition_conf.dts
@@ -22,15 +22,15 @@
  */
 
 &slot0_partition {
-	reg = <0x00010000 0x30000>;
+	reg = <0x0000c000 0x30000>;
 };
 
 &slot0_ns_partition {
-	reg = <0x00040000 0x40000>;
+	reg = <0x0003e000 0x40000>;
 };
 
 &slot1_partition {
-	reg = <0x00080000 0x30000>;
+	reg = <0x0007e000 0x30000>;
 };
 
 &slot1_ns_partition {


### PR DESCRIPTION
The DTS for nRF53 and nRF91 boards has been modified to cut the size
of boot partition from 64KiB to 48KiB, making it the same size as for
nRF52.

Resolves #25664

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>