### PR TITLE
west.yml: Make nxp and openisa hal a zephyr_library

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
       revision: 00580f43b9d48f2079d611ce12f0fbc78d3040f1
       path: modules/hal/nordic
     - name: hal_openisa
-      revision: 3b54187649cc9b37161d49918f1ad28ff7c7f830
+      revision: 40d049f69c50b58ea20473bee14cf93f518bf262
       path: modules/hal/openisa
     - name: hal_microchip
       revision: aad89bf0531a30dcd6c87e4065f1b973fb31c11f

--- a/west.yml
+++ b/west.yml
@@ -95,7 +95,7 @@ manifest:
       revision: 1c4fdba512b268033a4cf926bddd323866c3261a
       path: tools/net-tools
     - name: hal_nxp
-      revision: 44c6b1998d9526713c00f5c6a49b8a910419c50a
+      revision: a239b33c64db9ce5c8809ba54d50ade0d1864411
       path: modules/hal/nxp
     - name: open-amp
       revision: 724f7e2a4519d7e1d40ef330042682dea950c991


### PR DESCRIPTION
Stops leaking long source paths in build directories and makes them
deterministic.

This follows zephyrproject-rtos/hal_nordic#6 and zephyrproject-rtos/hal_stm32#23

Depends on:
- [x] zephyrproject-rtos/hal_nxp#45
- [x] zephyrproject-rtos/hal_openisa#5

