### PR TITLE
subsys: fs: implement support for external file systems

### DIFF
--- a/doc/reference/file_system/index.rst
+++ b/doc/reference/file_system/index.rst
@@ -12,13 +12,15 @@ specific API or internal functions by introducing file system registration
 mechanisms.
 
 In Zephyr, any file system implementation or library can be plugged into or
-pulled out through a file system registration API.
+pulled out through a file system registration API.  Each file system
+implementation must have a globally unique integer identifier; use
+:c:macro:`FS_TYPE_EXTERNAL_BASE` to avoid clashes with in-tree identifiers.
 
 .. code-block:: c
 
-        int fs_register(enum fs_type type, const struct fs_file_system_t *fs);
+        int fs_register(int type, const struct fs_file_system_t *fs);
 
-        int fs_unregister(enum fs_type type, const struct fs_file_system_t *fs);
+        int fs_unregister(int type, const struct fs_file_system_t *fs);
 
 Zephyr RTOS supports multiple instances of a file system by making use of
 the mount point as the disk volume name, which is used by the file system library

--- a/doc/reference/file_system/index.rst
+++ b/doc/reference/file_system/index.rst
@@ -16,9 +16,9 @@ pulled out through a file system registration API.
 
 .. code-block:: c
 
-        int fs_register(enum fs_type type, struct fs_file_system_t *fs);
+        int fs_register(enum fs_type type, const struct fs_file_system_t *fs);
 
-        int fs_unregister(enum fs_type type, struct fs_file_system_t *fs);
+        int fs_unregister(enum fs_type type, const struct fs_file_system_t *fs);
 
 Zephyr RTOS supports multiple instances of a file system by making use of
 the mount point as the disk volume name, which is used by the file system library

--- a/include/fs/fs.h
+++ b/include/fs/fs.h
@@ -45,12 +45,30 @@ enum fs_dir_entry_type {
 	FS_DIR_ENTRY_DIR
 };
 
-enum fs_type {
+/** @brief Enumeration to uniquely identify file system types.
+ *
+ * Zephyr supports in-tree file systems and external ones.  Each
+ * requires a unique identifier used to register the file system
+ * implementation and to associate a mount point with the file system
+ * type.  This anonymous enum defines global identifiers for the
+ * in-tree file systems.
+ *
+ * External file systems should be registered using unique identifiers
+ * starting at @c FS_TYPE_EXTERNAL_BASE.  It is the responsibility of
+ * applications that use external file systems to ensure that these
+ * identifiers are unique if multiple file system implementations are
+ * used by the application.
+ */
+enum {
+	/** Identifier for in-tree FatFS file system. */
 	FS_FATFS = 0,
-	FS_LITTLEFS,
-	FS_TYPE_END,
-};
 
+	/** Identifier for in-tree LittleFS file system. */
+	FS_LITTLEFS,
+
+	/** Base identifier for external file systems. */
+	FS_TYPE_EXTERNAL_BASE,
+};
 
 /**
  * @brief File system mount info structure
@@ -65,7 +83,7 @@ enum fs_type {
  */
 struct fs_mount_t {
 	sys_dnode_t node;
-	enum fs_type type;
+	int type;
 	const char *mnt_point;
 	void *fs_data;
 	void *storage_dev;
@@ -494,7 +512,7 @@ int fs_statvfs(const char *path, struct fs_statvfs *stat);
  * @retval 0 Success
  * @retval -ERRNO errno code if error
  */
-int fs_register(enum fs_type type, const struct fs_file_system_t *fs);
+int fs_register(int type, const struct fs_file_system_t *fs);
 
 /**
  * @brief Unregister a file system
@@ -507,7 +525,7 @@ int fs_register(enum fs_type type, const struct fs_file_system_t *fs);
  * @retval 0 Success
  * @retval -ERRNO errno code if error
  */
-int fs_unregister(enum fs_type type, const struct fs_file_system_t *fs);
+int fs_unregister(int type, const struct fs_file_system_t *fs);
 
 /**
  * @}

--- a/include/fs/fs.h
+++ b/include/fs/fs.h
@@ -494,7 +494,7 @@ int fs_statvfs(const char *path, struct fs_statvfs *stat);
  * @retval 0 Success
  * @retval -ERRNO errno code if error
  */
-int fs_register(enum fs_type type, struct fs_file_system_t *fs);
+int fs_register(enum fs_type type, const struct fs_file_system_t *fs);
 
 /**
  * @brief Unregister a file system
@@ -507,7 +507,7 @@ int fs_register(enum fs_type type, struct fs_file_system_t *fs);
  * @retval 0 Success
  * @retval -ERRNO errno code if error
  */
-int fs_unregister(enum fs_type type, struct fs_file_system_t *fs);
+int fs_unregister(enum fs_type type, const struct fs_file_system_t *fs);
 
 /**
  * @}

--- a/include/fs/fs_interface.h
+++ b/include/fs/fs_interface.h
@@ -13,6 +13,10 @@
 extern "C" {
 #endif
 
+#if (CONFIG_FILE_SYSTEM_MAX_FILE_NAME - 0) > 0
+#define MAX_FILE_NAME CONFIG_FILE_SYSTEM_MAX_FILE_NAME
+#else /* CONFIG_FILE_SYSTEM_MAX_FILE_NAME */
+/* Select from enabled file systems */
 #if defined(CONFIG_FILE_SYSTEM_LITTLEFS)
 #define MAX_FILE_NAME 256
 #elif defined(CONFIG_FAT_FILESYSTEM_ELM)
@@ -25,6 +29,7 @@ extern "C" {
 /* Use standard 8.3 when no filesystem is explicitly selected */
 #define MAX_FILE_NAME 12
 #endif /* filesystem selection */
+#endif /* CONFIG_FILE_SYSTEM_MAX_FILE_NAME */
 
 /* Type for fs_open flags */
 typedef uint8_t fs_mode_t;

--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -28,6 +28,14 @@ config FAT_FILESYSTEM_ELM
 	help
 	  Use the ELM FAT File system implementation.
 
+config FILE_SYSTEM_MAX_TYPES
+	int "Maximum number of distinct file system types allowed"
+	default 2
+	help
+	  Zephyr provides several file system types including FatFS and
+	  LittleFS, but it is possible to define additional ones and
+	  register them.  A slot is required for each type.
+
 menu "FatFs Settings"
 	visible if FAT_FILESYSTEM_ELM
 

--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -36,6 +36,18 @@ config FILE_SYSTEM_MAX_TYPES
 	  LittleFS, but it is possible to define additional ones and
 	  register them.  A slot is required for each type.
 
+config FILE_SYSTEM_MAX_FILE_NAME
+       int "Optional override for maximum file name length"
+       default -1
+       help
+         Specify the maximum file name allowed across all enabled file
+         system types.  Zero or a negative value selects the maximum
+         file name length for enabled in-tree file systems.  This
+         default may be inappropriate when registering an out-of-tree
+         file system.  Selecting a value less than the actual length
+         supported by a file system may result in memory access
+         violations.
+
 menu "FatFs Settings"
 	visible if FAT_FILESYSTEM_ELM
 

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -407,7 +407,7 @@ static int fatfs_unmount(struct fs_mount_t *mountp)
 }
 
 /* File system interface */
-static struct fs_file_system_t fatfs_fs = {
+static const struct fs_file_system_t fatfs_fs = {
 	.open = fatfs_open,
 	.close = fatfs_close,
 	.read = fatfs_read,

--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -24,7 +24,7 @@ static sys_dlist_t fs_mnt_list;
 static struct k_mutex mutex;
 
 /* file system map table */
-static struct fs_file_system_t *fs_map[FS_TYPE_END];
+static const struct fs_file_system_t *fs_map[FS_TYPE_END];
 
 static int fs_get_mnt_point(struct fs_mount_t **mnt_pntp,
 			    const char *name, size_t *match_len)
@@ -526,7 +526,7 @@ int fs_statvfs(const char *abs_path, struct fs_statvfs *stat)
 int fs_mount(struct fs_mount_t *mp)
 {
 	struct fs_mount_t *itr;
-	struct fs_file_system_t *fs;
+	const struct fs_file_system_t *fs;
 	sys_dnode_t *node;
 	int rc = -EINVAL;
 
@@ -664,7 +664,7 @@ int fs_readmount(int *number, const char **name)
 }
 
 /* Register File system */
-int fs_register(enum fs_type type, struct fs_file_system_t *fs)
+int fs_register(enum fs_type type, const struct fs_file_system_t *fs)
 {
 	int rc = 0;
 
@@ -682,7 +682,7 @@ reg_err:
 }
 
 /* Unregister File system */
-int fs_unregister(enum fs_type type, struct fs_file_system_t *fs)
+int fs_unregister(enum fs_type type, const struct fs_file_system_t *fs)
 {
 	int rc = 0;
 

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -722,7 +722,7 @@ static int littlefs_unmount(struct fs_mount_t *mountp)
 }
 
 /* File system interface */
-static struct fs_file_system_t littlefs_fs = {
+static const struct fs_file_system_t littlefs_fs = {
 	.open = littlefs_open,
 	.close = littlefs_close,
 	.read = littlefs_read,

--- a/tests/subsys/fs/fs_api/src/test_fs.c
+++ b/tests/subsys/fs/fs_api/src/test_fs.c
@@ -19,7 +19,7 @@ static char buffer[BUF_LEN];
 static char *read_pos = buffer;
 static char *cur = buffer;
 static int file_length;
-static struct fs_mount_t *mp[FS_TYPE_END];
+static struct fs_mount_t *mp[FS_TYPE_EXTERNAL_BASE];
 static bool nospace;
 
 static

--- a/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
@@ -27,7 +27,7 @@ static struct fs_mount_t test_fs_mnt_1 = {
 };
 
 static struct fs_mount_t test_fs_mnt_unsupported_fs = {
-		.type = FS_TYPE_END,
+		.type = FS_TYPE_EXTERNAL_BASE,
 		.mnt_point = "/MMCBLOCK:",
 		.fs_data = &test_data,
 };

--- a/tests/subsys/fs/fs_api/src/test_multi_fs.c
+++ b/tests/subsys/fs/fs_api/src/test_multi_fs.c
@@ -87,13 +87,15 @@ static int test_fs_deinit(void)
 	return 0;
 }
 
-static int test_fs_unsupported(void)
+static int test_fs_external(void)
 {
-	if (fs_register(FS_TYPE_END, &temp_fs) == 0) {
+	/* There is no way to statically determine whether a file
+	 * system is unsupported, but  */
+	if (fs_register(FS_TYPE_EXTERNAL_BASE, &temp_fs) != -ENOSPC) {
 		return TC_FAIL;
 	}
 
-	if (fs_unregister(FS_TYPE_END, &temp_fs) == 0) {
+	if (fs_unregister(FS_TYPE_EXTERNAL_BASE, &temp_fs) != -EINVAL) {
 		return TC_FAIL;
 	}
 
@@ -115,8 +117,8 @@ void test_fs_register(void)
 {
 	zassert_true(test_fs_init() == 0, "Failed to register filesystems");
 	zassert_true(test_fs_readmount() == 0, "Failed to readmount");
+	zassert_true(test_fs_external() == 0, "Supported other file system");
 	zassert_true(test_fs_deinit() == 0, "Failed to unregister filesystems");
-	zassert_true(test_fs_unsupported() == 0, "Supported other file system");
 }
 
 /**


### PR DESCRIPTION
The documentation claims that Zephyr supports external file system implementations, and there's no reason not to do so.  However the implementation uses a fixed enumeration to index a map from file system types to implementations, which is not extensible.  Rework the API to allow this.
    
Note that the file system type cannot legally be an enum anymore, since we need to support file system types that don't have an identifier assigned in that enum.  Rely on the implicit conversion of enum values to int to preserve backwards compatibility.

Also make the file system implementation objects `const`.

This work inspired by #25570.
