### PR TITLE
timeout: correct non-legacy legacy timeout API

### DIFF
--- a/include/sys_clock.h
+++ b/include/sys_clock.h
@@ -108,8 +108,8 @@ typedef s32_t k_timeout_t;
 #define Z_TIMEOUT_TICKS(t) k_ticks_to_ms_ceil32(t)
 #define Z_FOREVER K_TICKS_FOREVER
 #define Z_TIMEOUT_MS(t) (t)
-#define Z_TIMEOUT_US(t) ((t) * 1000)
-#define Z_TIMEOUT_NS(t) ((t) * 1000000)
+#define Z_TIMEOUT_US(t) ((999 + (t)) / 1000)
+#define Z_TIMEOUT_NS(t) ((999999 + (t)) / 1000000)
 #define Z_TIMEOUT_CYC(t) k_cyc_to_ms_ceil32(MAX((t), 0))
 
 #endif


### PR DESCRIPTION
The implementation of Z_TIMEOUT_US() and Z_TIMEOUT_NS() in the legacy
timeout API is incorrect in that it multiplies the input value by the
scale factor rather than dividing it, making K_USEC(3) equivalent to
K_SECONDS(3).  Replace with implementation that doesn't surprise a
user that happens to find and use them.

Fixes #25887