### PR TITLE
eth: fix: Check if passed iface pointer is not NULL

### DIFF
--- a/subsys/net/l2/ethernet/eth_stats.h
+++ b/subsys/net/l2/ethernet/eth_stats.h
@@ -163,8 +163,14 @@ static inline void eth_stats_update_multicast_tx(struct net_if *iface)
 static inline void eth_stats_update_errors_rx(struct net_if *iface)
 {
 	struct net_stats_eth *stats;
-	const struct ethernet_api *api = ((const struct ethernet_api *)
-		net_if_get_device(iface)->driver_api);
+	const struct ethernet_api *api;
+
+	if (!iface) {
+		return;
+	}
+
+	api = ((const struct ethernet_api *)
+	       net_if_get_device(iface)->driver_api);
 
 	if (!api->get_stats) {
 		return;


### PR DESCRIPTION
The eth_stats_update_errors_rx() implicitly assumes that passed pointer
to struct net_if is not NULL.

This is not true for MCUX's eth_rx() (in eth_mcux.c), where we can
execute eth_stats_update_errors_rx() after net_recv_data() returning
-EINVAL because of passed NULL iface pointer.

This change fixes this problem with adding extra check on iface not
being NULL before it is dereferenced.


Signed-off-by: Lukasz Majewski <lukma@denx.de>