### PR TITLE
testsuite: Align testsuite output

### DIFF
--- a/subsys/testsuite/include/tc_util.h
+++ b/subsys/testsuite/include/tc_util.h
@@ -105,7 +105,7 @@ static inline const char *TC_RESULT_TO_STR(int result)
 #endif
 
 #ifndef TC_START
-#define TC_START(name) PRINT_DATA("starting test - %s\n", name)
+#define TC_START(name) PRINT_DATA("START - %s\n", name)
 #endif
 
 #ifndef TC_END
@@ -116,7 +116,7 @@ static inline const char *TC_RESULT_TO_STR(int result)
 /* prints result and the function name */
 #define Z_TC_END_RESULT(result, func)					\
 	do {								\
-		TC_END(result, "%s - %s\n", TC_RESULT_TO_STR(result), func); \
+		TC_END(result, " %s - %s\n", TC_RESULT_TO_STR(result), func); \
 		PRINT_LINE;						\
 	} while (0)
 #endif


### PR DESCRIPTION
Makes the output easier to read for humans.

Before:
```
Running test suite foo_bar_tests
===================================================================
starting test - test_foo_bar
PASS - test_foo_bar
===================================================================
starting test - test_bar_foo
PASS - test_bar_foo
===================================================================
```

After:
```
Running test suite foo_bar_tests
===================================================================
START - test_foo_bar
 PASS - test_foo_bar
===================================================================
START - test_bar_foo
 PASS - test_bar_foo
===================================================================
```