### PR TITLE
drivers: can: flexcan: handle rx overflow and undhandled irqs

### DIFF
--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -586,6 +586,8 @@ static void mcux_flexcan_transfer_callback(CAN_Type *base,
 	struct device *dev = (struct device *)userData;
 
 	switch (status) {
+	case kStatus_FLEXCAN_UnHandled:
+		/* fallthrough */
 	case kStatus_FLEXCAN_ErrorStatus:
 		mcux_flexcan_transfer_error_status(dev, result);
 		break;
@@ -594,6 +596,8 @@ static void mcux_flexcan_transfer_callback(CAN_Type *base,
 	case kStatus_FLEXCAN_TxIdle:
 		mcux_flexcan_transfer_tx_idle(dev, result);
 		break;
+	case kStatus_FLEXCAN_RxOverflow:
+		/* fallthrough */
 	case kStatus_FLEXCAN_RxIdle:
 		mcux_flexcan_transfer_rx_idle(dev, result);
 		break;


### PR DESCRIPTION
Add handling of RX overflows and IRQs reported as undhandled by the NXP MCUX HAL.

Fixes: #22625

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>