### PR TITLE
Add refcounting to fd layer

### DIFF
--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -19,17 +19,13 @@
 #include <sys/fdtable.h>
 #include <sys/speculation.h>
 #include <syscall_handler.h>
+#include <sys/atomic.h>
 
 struct fd_entry {
 	void *obj;
 	const struct fd_op_vtable *vtable;
+	atomic_t refcount;
 };
-
-/* A few magic values for fd_entry::obj used in the code. */
-#define FD_OBJ_RESERVED (void *)1
-#define FD_OBJ_STDIN  (void *)0x10
-#define FD_OBJ_STDOUT (void *)0x11
-#define FD_OBJ_STDERR (void *)0x12
 
 #ifdef CONFIG_POSIX_API
 static const struct fd_op_vtable stdinout_fd_op_vtable;
@@ -38,24 +34,53 @@ static const struct fd_op_vtable stdinout_fd_op_vtable;
 static struct fd_entry fdtable[CONFIG_POSIX_MAX_FDS] = {
 #ifdef CONFIG_POSIX_API
 	/*
-	 * Predefine entries for stdin/stdout/stderr. Object pointer
-	 * is unused and just should be !0 (random different values
-	 * are used to posisbly help with debugging).
+	 * Predefine entries for stdin/stdout/stderr.
 	 */
-	{FD_OBJ_STDIN,  &stdinout_fd_op_vtable},
-	{FD_OBJ_STDOUT, &stdinout_fd_op_vtable},
-	{FD_OBJ_STDERR, &stdinout_fd_op_vtable},
+	{
+		/* STDIN */
+		.vtable = &stdinout_fd_op_vtable,
+		.refcount = ATOMIC_INIT(1)
+	},
+	{
+		/* STDOUT */
+		.vtable = &stdinout_fd_op_vtable,
+		.refcount = ATOMIC_INIT(1)
+	},
+	{
+		/* STDERR */
+		.vtable = &stdinout_fd_op_vtable,
+		.refcount = ATOMIC_INIT(1)
+	},
 #endif
 };
 
 static K_MUTEX_DEFINE(fdtable_lock);
+
+static int z_fd_ref(int fd)
+{
+	return atomic_inc(&fdtable[fd].refcount) + 1;
+}
+
+static int z_fd_unref(int fd)
+{
+	int old_rc = atomic_dec(&fdtable[fd].refcount);
+
+	if (old_rc != 1) {
+		return old_rc - 1;
+	}
+
+	fdtable[fd].obj = NULL;
+	fdtable[fd].vtable = NULL;
+
+	return 0;
+}
 
 static int _find_fd_entry(void)
 {
 	int fd;
 
 	for (fd = 0; fd < ARRAY_SIZE(fdtable); fd++) {
-		if (fdtable[fd].obj == NULL) {
+		if (!atomic_get(&fdtable[fd].refcount)) {
 			return fd;
 		}
 	}
@@ -73,7 +98,7 @@ static int _check_fd(int fd)
 
 	fd = k_array_index_sanitize(fd, ARRAY_SIZE(fdtable));
 
-	if (fdtable[fd].obj == NULL) {
+	if (!atomic_get(&fdtable[fd].refcount)) {
 		errno = EBADF;
 		return -1;
 	}
@@ -122,7 +147,8 @@ int z_reserve_fd(void)
 	fd = _find_fd_entry();
 	if (fd >= 0) {
 		/* Mark entry as used, z_finalize_fd() will fill it in. */
-		fdtable[fd].obj = FD_OBJ_RESERVED;
+		fdtable[fd].obj = NULL;
+		fdtable[fd].vtable = NULL;
 	}
 
 	k_mutex_unlock(&fdtable_lock);
@@ -145,12 +171,13 @@ void z_finalize_fd(int fd, void *obj, const struct fd_op_vtable *vtable)
 #endif
 	fdtable[fd].obj = obj;
 	fdtable[fd].vtable = vtable;
+	(void)z_fd_ref(fd);
 }
 
 void z_free_fd(int fd)
 {
 	/* Assumes fd was already bounds-checked. */
-	fdtable[fd].obj = NULL;
+	(void)z_fd_unref(fd);
 }
 
 int z_alloc_fd(void *obj, const struct fd_op_vtable *vtable)

--- a/tests/lib/fdtable/src/main.c
+++ b/tests/lib/fdtable/src/main.c
@@ -9,6 +9,17 @@
 #include <sys/fdtable.h>
 #include <errno.h>
 
+/* The thread will test that the refcounting of fd object will
+ * work as expected.
+ */
+static struct k_thread fd_thread;
+static int shared_fd;
+
+#define VTABLE_INIT ((const struct fd_op_vtable *)1)
+
+K_THREAD_STACK_DEFINE(fd_thread_stack, CONFIG_ZTEST_STACKSIZE +
+		      CONFIG_TEST_EXTRA_STACKSIZE);
+
 void test_z_reserve_fd(void)
 {
 	int fd = z_reserve_fd(); /* function being tested */
@@ -28,7 +39,7 @@ void test_z_get_fd_obj_and_vtable(void)
 	int *obj;
 	obj = z_get_fd_obj_and_vtable(fd, &vtable); /* function being tested */
 
-	zassert_equal(obj != NULL, true, "obj is NULL");
+	zassert_is_null(obj, "obj is not NULL");
 
 	z_free_fd(fd);
 }
@@ -44,10 +55,16 @@ void test_z_get_fd_obj(void)
 
 	int *obj = z_get_fd_obj(fd, vtable, err); /* function being tested */
 
-	zassert_equal(obj != NULL, true, "obj is NULL");
-	zassert_equal(errno != EBADF && errno != ENFILE, true, "errno not set");
-
 	/* take branch -- if (_check_fd(fd) < 0) */
+	zassert_is_null(obj, "obj not is NULL");
+	zassert_equal(errno, EBADF, "errno not set");
+
+	obj = (void *)1;
+	vtable = (const struct fd_op_vtable *)1;
+
+	/* This will set obj and vtable properly */
+	z_finalize_fd(fd, obj, vtable);
+
 	obj = z_get_fd_obj(-1, vtable, err); /* function being tested */
 
 	zassert_equal_ptr(obj, NULL, "obj is not NULL when fd < 0");
@@ -114,15 +131,65 @@ void test_z_free_fd(void)
 	zassert_equal_ptr(obj, NULL, "obj is not NULL after freeing");
 }
 
+static void test_cb(void *fd_ptr)
+{
+	int fd = POINTER_TO_INT(fd_ptr);
+	const struct fd_op_vtable *vtable;
+	int *obj;
+
+	obj = z_get_fd_obj_and_vtable(fd, &vtable);
+
+	zassert_not_null(obj, "obj is null");
+	zassert_not_null(vtable, "vtable is null");
+
+	/* This is very much artificial and only meaningful in this test. */
+	z_finalize_fd(fd, obj, vtable);
+
+	/* The object should not be null after the free as ref count is 1 */
+	z_free_fd(fd);
+
+	obj = z_get_fd_obj_and_vtable(fd, &vtable);
+	zassert_not_null(obj, "obj is null");
+}
+
+void test_z_fd_multiple_access(void)
+{
+	const struct fd_op_vtable *vtable = VTABLE_INIT;
+	void *obj = (void *)vtable;
+
+	shared_fd = z_reserve_fd();
+
+	z_finalize_fd(shared_fd, obj, vtable);
+
+	k_thread_create(&fd_thread, fd_thread_stack,
+			K_THREAD_STACK_SIZEOF(fd_thread_stack),
+			(k_thread_entry_t)test_cb,
+			INT_TO_POINTER(shared_fd), NULL, NULL,
+			CONFIG_ZTEST_THREAD_PRIORITY, 0, K_NO_WAIT);
+
+	k_thread_join(&fd_thread, K_FOREVER);
+
+	obj = z_get_fd_obj_and_vtable(shared_fd, &vtable);
+	zassert_not_null(obj, "obj disappeared");
+	zassert_not_null(vtable, "vtable disappeared");
+
+	z_free_fd(shared_fd);
+
+	obj = z_get_fd_obj_and_vtable(shared_fd, &vtable);
+	zassert_is_null(obj, "obj is still there");
+	zassert_equal(errno, EBADF, "fd was found");
+}
+
 void test_main(void)
 {
 	ztest_test_suite(test_fdtable,
-				ztest_unit_test(test_z_reserve_fd),
-				ztest_unit_test(test_z_get_fd_obj_and_vtable),
-				ztest_unit_test(test_z_get_fd_obj),
-				ztest_unit_test(test_z_finalize_fd),
-				ztest_unit_test(test_z_alloc_fd),
-				ztest_unit_test(test_z_free_fd)
-				);
+			 ztest_unit_test(test_z_reserve_fd),
+			 ztest_unit_test(test_z_get_fd_obj_and_vtable),
+			 ztest_unit_test(test_z_get_fd_obj),
+			 ztest_unit_test(test_z_finalize_fd),
+			 ztest_unit_test(test_z_alloc_fd),
+			 ztest_unit_test(test_z_free_fd),
+			 ztest_unit_test(test_z_fd_multiple_access)
+		);
 	ztest_run_test_suite(test_fdtable);
 }


### PR DESCRIPTION
Use proper refcounting instead of magic value in obj field when checking whether the fd is still in use. This will make sure that if fd is shared between two threads, we do not release it too soon.
