### PR TITLE
drivers: modem: gsm: Do not reference possible null pointer

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -244,14 +244,14 @@ static int gsm_setup_mccmno(struct gsm_modem *gsm)
 static void set_ppp_carrier_on(struct gsm_modem *gsm)
 {
 	struct device *ppp_dev = device_get_binding(CONFIG_NET_PPP_DRV_NAME);
-	const struct ppp_api *api =
-				(const struct ppp_api *)ppp_dev->driver_api;
+	const struct ppp_api *api;
 
 	if (!ppp_dev) {
 		LOG_ERR("Cannot find PPP %s!", "device");
 		return;
 	}
 
+	api = (const struct ppp_api *)ppp_dev->driver_api;
 	api->start(ppp_dev);
 }
 


### PR DESCRIPTION
The ppp_dev was used even if its value could be NULL.

Fixes #25781
Coverity-CID: 210031

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>