### PR TITLE
interrupt_controller: gic: GIC Split Mode fix ups

### DIFF
--- a/drivers/interrupt_controller/Kconfig.gic
+++ b/drivers/interrupt_controller/Kconfig.gic
@@ -36,4 +36,12 @@ config GIC_VER
 	default 2 if GIC_V2
 	default 3 if GIC_V3
 
+config GIC_MASTER
+	bool "GIC Master core controls the GIC Distributor."
+	default y
+	help
+	  As GIC Distributor is shared among multiple cores, which may be running in AMP,
+	  it is necessary that only one of the cores configures/control GIC distributor.
+	  All other cores should only configure their core-specific GIC CPU interfaces.
+
 endif # CPU_CORTEX

--- a/dts/arm/xilinx/zynqmp.dtsi
+++ b/dts/arm/xilinx/zynqmp.dtsi
@@ -30,6 +30,16 @@
 			label = "UART_0";
 		};
 
+		uart1: uart@ff010000 {
+			compatible = "xlnx,xuartps";
+			reg = <0xff010000 0x4c>;
+			status = "disabled";
+			interrupts = <GIC_SPI 22 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "irq_1";
+			label = "UART_1";
+		};
+
 		ttc0: timer@ff110000 {
 			compatible = "xlnx,ttcps";
 			status = "disabled";


### PR DESCRIPTION
During testing of R5 Split (performance) mode, the kernel was found non-functional due to the following problems in the GIC driver.

- All GIC interrupts were always routed to Core-0. This meant that any interrupts enabled by Core-1 (or others) are also routed to Core-0, and as Core-0 didn't have proper setup to support these interrupts, it ended up in a fault. This limitation is primarily because the Arm architecture hasn't really been tested with AMP support. 
- Multiples cores initializing the shared GIC controller meant that any initialization did by previous cores were over-ridden generating problems.

The first problem is fixed by reading the MPIDR register at runtime and getting the Core-ID from there. All this is done in the call to GIC IRQ_Enable routine, and so the IRQ will be enabled on the correct core always. Instead of overriding, we OR the cores, which means that the same interrupt can be routed to multiple CPUs if desired (SMP ?)

The second problem is fixed by adding a Kernel config option. This option will enable/disable dist init. The idea is that only a single image will enable this, whilst other will keep it disabled, and the
core which enables this option will act as the "master", and init the GIC distributor. This solution is only used for AMP systems. For SMP, as all cores share the same memory, we should use a global variable to ensure that only the "primary" core inits the distributor.

Signed-off-by: Bilal Wasim <bilalwasim676@gmail.com>