### PR TITLE
cmake, samples, tests: Use semi-accurate project names

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -1483,7 +1483,7 @@ endmacro()
 function(print_usage)
   if(NOT CMAKE_MAKE_PROGRAM)
     # Create dummy project, in order to obtain make program for correct usage printing.
-    project(NONE)
+    project(dummy_print_usage)
   endif()
   message("see usage:")
   string(REPLACE ";" " " BOARD_ROOT_SPACE_SEPARATED "${BOARD_ROOT}")

--- a/samples/application_development/out_of_tree_driver/CMakeLists.txt
+++ b/samples/application_development/out_of_tree_driver/CMakeLists.txt
@@ -14,7 +14,7 @@ cmake_minimum_required(VERSION 3.13.1)
 list(APPEND SYSCALL_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/hello_world_module/zephyr)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(out_of_tree_driver)
 
 target_sources(app PRIVATE
   src/main.c

--- a/samples/boards/96b_argonkey/microphone/CMakeLists.txt
+++ b/samples/boards/96b_argonkey/microphone/CMakeLists.txt
@@ -5,6 +5,6 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(microphone)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/boards/intel_s1000_crb/audio/CMakeLists.txt
+++ b/samples/boards/intel_s1000_crb/audio/CMakeLists.txt
@@ -3,7 +3,7 @@
 set(BOARD intel_s1000_crb)
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(intel_s1000_crb_audio)
 
 target_sources(app PRIVATE src/audio_driver.c)
 target_sources(app PRIVATE src/audio_core.c)

--- a/samples/boards/intel_s1000_crb/dmic/CMakeLists.txt
+++ b/samples/boards/intel_s1000_crb/dmic/CMakeLists.txt
@@ -3,6 +3,6 @@
 set(BOARD intel_s1000_crb)
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(intel_s1000_crb_dmic)
 
 target_sources(app PRIVATE src/dmic_sample.c)

--- a/samples/boards/intel_s1000_crb/i2s/CMakeLists.txt
+++ b/samples/boards/intel_s1000_crb/i2s/CMakeLists.txt
@@ -3,7 +3,7 @@
 set(BOARD intel_s1000_crb)
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(i2s)
 
 target_sources(app PRIVATE src/i2s_sample.c)
 

--- a/samples/net/cloud/google_iot_mqtt/CMakeLists.txt
+++ b/samples/net/cloud/google_iot_mqtt/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(google_iot_mqtt)
 
 if(NOT EXISTS ${APPLICATION_SOURCE_DIR}/src/private_info/key.c)
   message(FATAL_ERROR "!!!!!! Generate key file before continuing.  See README !!!!!")

--- a/samples/net/sockets/coap_client/CMakeLists.txt
+++ b/samples/net/sockets/coap_client/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(coap_client)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/sockets/coap_server/CMakeLists.txt
+++ b/samples/net/sockets/coap_server/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(coap_server)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/syslog_net/CMakeLists.txt
+++ b/samples/net/syslog_net/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(syslog_net)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/updatehub/CMakeLists.txt
+++ b/samples/net/updatehub/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.13.1)
 set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(updatehub)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/lib/updatehub/include)
 target_sources(app PRIVATE src/main.c)

--- a/samples/sensor/bme680/CMakeLists.txt
+++ b/samples/sensor/bme680/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(bme680)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/subsys/ipc/ipm_imx/CMakeLists.txt
+++ b/samples/subsys/ipc/ipm_imx/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(ipm_imx)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/drivers)
 target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/clock_control/clock_control_api/CMakeLists.txt
+++ b/tests/drivers/clock_control/clock_control_api/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(clock_control_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/clock_control/nrf_clock_calibration/CMakeLists.txt
+++ b/tests/drivers/clock_control/nrf_clock_calibration/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(nrf_clock_calibration)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/counter/counter_basic_api/CMakeLists.txt
+++ b/tests/drivers/counter/counter_basic_api/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(counter_basic_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/counter/counter_cmos/CMakeLists.txt
+++ b/tests/drivers/counter/counter_cmos/CMakeLists.txt
@@ -4,6 +4,6 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(counter_cmos)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/counter/counter_nrf_rtc/fixed_top/CMakeLists.txt
+++ b/tests/drivers/counter/counter_nrf_rtc/fixed_top/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(fixed_top)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/counter/maxim_ds3231_api/CMakeLists.txt
+++ b/tests/drivers/counter/maxim_ds3231_api/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(maxim_ds3231_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/net/lib/coap/CMakeLists.txt
+++ b/tests/net/lib/coap/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(coap)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/portability/cmsis_rtos_v2/CMakeLists.txt
+++ b/tests/portability/cmsis_rtos_v2/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(cmsis_rtos_v2)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/include/cmsis_rtos_v2)
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/jwt/CMakeLists.txt
+++ b/tests/subsys/jwt/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(jwt)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/settings/fcb/raw/CMakeLists.txt
+++ b/tests/subsys/settings/fcb/raw/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(settings_fcb_raw)
 
 add_subdirectory(../src fcb_test_bindir)
 target_link_libraries(app PRIVATE settings_fcb_test)

--- a/tests/subsys/settings/functional/fcb/CMakeLists.txt
+++ b/tests/subsys/settings/functional/fcb/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(functional_fcb)
 
 # The code is in the library common to several tests.
 target_sources(app PRIVATE placeholder.c)

--- a/tests/subsys/settings/functional/file/CMakeLists.txt
+++ b/tests/subsys/settings/functional/file/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(functional_file)
 
 FILE(GLOB app_sources ../src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/settings/functional/nvs/CMakeLists.txt
+++ b/tests/subsys/settings/functional/nvs/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(functional_nvs)
 
 # The code is in the library common to several tests.
 target_sources(app PRIVATE placeholder.c)

--- a/tests/subsys/settings/littlefs/raw/CMakeLists.txt
+++ b/tests/subsys/settings/littlefs/raw/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(littlefs_raw)
 
 add_subdirectory(../src littlefs_test_bindir)
 


### PR DESCRIPTION
When using an IDE (e.g. Eclipse, Qt Creator), the project name gets
displayed. This greatly simplifies the navigation between projects when
having many of them open at the same time. Naming multiple projects
"NONE" defeats this functionality.

This patch tries to use sensible project names while not duplicating
too much of what is already represented in the path. This is done by
using the name of the directory the relevant CMakeLists.txt file is
stored in. To ensure unique project names, small, manual adjustments
have been done.

See also 7eabab2f5d ("samples, tests: Use semi-accurate project names")

Signed-off-by: Reto Schneider <reto.schneider@husqvarnagroup.com>