### PR TITLE
doc: contribute: Fix path to series-push-hook.sh

### DIFF
--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -375,7 +375,7 @@ before pushing on zephyr repo. To do this, make the file
     while read local_ref local_sha remote_ref remote_sha
     do
         args="$remote $url $local_ref $local_sha $remote_ref $remote_sha"
-        exec ${ZEPHYR_BASE}/series-push-hook.sh $args
+        exec ${ZEPHYR_BASE}/scripts/series-push-hook.sh $args
     done
 
     exit 0


### PR DESCRIPTION
series-push-hook.sh is stored in the scripts subfolder.

Signed-off-by: Reto Schneider <reto.schneider@husqvarnagroup.com>