### PR TITLE
subsys/fs/littlefs: initialize LittleFS at POST_KERNEL

### DIFF
--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -734,4 +734,4 @@ static int littlefs_init(struct device *dev)
 	return fs_register(FS_LITTLEFS, &littlefs_fs);
 }
 
-SYS_INIT(littlefs_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(littlefs_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);


### PR DESCRIPTION
Initialize LittleFS at POST_KERNEL and not at APPLICATION stage.

When using LittleFS as settings backend for OpenThread, LittleFS needs
to be available when net_init is performed.

Arguably, FS is an OS kernel component that should be ready when
applications are starting.

Possibly, the same change should be applied to FAT fs as well.

Signed-off-by: Markus Becker <markus.becker@tridonic.com>