### PR TITLE
samples: net: echo-client: Add userspace support

### DIFF
--- a/samples/net/sockets/echo_client/sample.yaml
+++ b/samples/net/sockets/echo_client/sample.yaml
@@ -52,3 +52,6 @@ tests:
     slow: true
     tags: net openthread
     platform_whitelist: frdm_kw41z
+  sample.net.sockets.echo_client.userspace:
+    extra_args: CONFIG_USERSPACE=y OVERLAY_CONFIG="overlay-e1000.conf"
+    platform_whitelist: qemu_x86

--- a/samples/net/sockets/echo_client/src/common.h
+++ b/samples/net/sockets/echo_client/src/common.h
@@ -10,6 +10,17 @@
 
 #define PEER_PORT 4242
 
+#if defined(CONFIG_USERSPACE)
+#include <app_memory/app_memdomain.h>
+extern struct k_mem_partition app_partition;
+extern struct k_mem_domain app_domain;
+#define APP_BMEM K_APP_BMEM(app_partition)
+#define APP_DMEM K_APP_DMEM(app_partition)
+#else
+#define APP_BMEM
+#define APP_DMEM
+#endif
+
 struct data {
 	const char *proto;
 

--- a/samples/net/sockets/echo_client/src/echo-client.c
+++ b/samples/net/sockets/echo_client/src/echo-client.c
@@ -31,6 +31,12 @@ LOG_MODULE_REGISTER(net_echo_client_sample, LOG_LEVEL_DBG);
 #include <net/net_event.h>
 #include <net/net_conn_mgr.h>
 
+#if defined(CONFIG_USERSPACE)
+#include <app_memory/app_memdomain.h>
+K_APPMEM_PARTITION_DEFINE(app_partition);
+struct k_mem_domain app_domain;
+#endif
+
 #include "common.h"
 #include "ca_certificate.h"
 
@@ -68,7 +74,7 @@ const char lorem_ipsum[] =
 
 const int ipsum_len = sizeof(lorem_ipsum) - 1;
 
-struct configs conf = {
+APP_DMEM struct configs conf = {
 	.ipv4 = {
 		.proto = "IPv4",
 		.udp.sock = INVALID_SOCK,
@@ -81,10 +87,10 @@ struct configs conf = {
 	},
 };
 
-static struct pollfd fds[4];
-static int nfds;
+static APP_BMEM struct pollfd fds[4];
+static APP_BMEM int nfds;
 
-static bool connected;
+static APP_BMEM bool connected;
 K_SEM_DEFINE(run_app, 0, 1);
 
 static struct net_mgmt_event_callback mgmt_cb;
@@ -219,6 +225,17 @@ static void init_app(void)
 {
 	LOG_INF(APP_BANNER);
 
+#if defined(CONFIG_USERSPACE)
+	struct k_mem_partition *parts[] = {
+#if Z_LIBC_PARTITION_EXISTS
+		&z_libc_partition,
+#endif
+		&app_partition
+	};
+
+	k_mem_domain_init(&app_domain, ARRAY_SIZE(parts), parts);
+#endif
+
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)
 	int err = tls_credential_add(CA_CERTIFICATE_TAG,
 				    TLS_CREDENTIAL_CA_CERTIFICATE,
@@ -257,20 +274,11 @@ static void init_app(void)
 	init_vlan();
 }
 
-void main(void)
+static void start_client(void)
 {
-	int ret = 0, i = 0;
 	int iterations = CONFIG_NET_SAMPLE_SEND_ITERATIONS;
-
-	init_app();
-
-	if (!IS_ENABLED(CONFIG_NET_CONNECTION_MANAGER)) {
-		/* If the config library has not been configured to start the
-		 * app only after we have a connection, then we can start
-		 * it right away.
-		 */
-		k_sem_give(&run_app);
-	}
+	int i = 0;
+	int ret;
 
 	while (iterations == 0 || i < iterations) {
 		/* Wait for the connection. */
@@ -292,6 +300,27 @@ void main(void)
 
 		stop_udp_and_tcp();
 	}
+}
 
-	exit(ret);
+void main(void)
+{
+	init_app();
+
+	if (!IS_ENABLED(CONFIG_NET_CONNECTION_MANAGER)) {
+		/* If the config library has not been configured to start the
+		 * app only after we have a connection, then we can start
+		 * it right away.
+		 */
+		k_sem_give(&run_app);
+	}
+
+#if defined(CONFIG_USERSPACE)
+	k_thread_access_grant(k_current_get(), &run_app);
+	k_mem_domain_add_thread(&app_domain, k_current_get());
+
+	k_thread_user_mode_enter((k_thread_entry_t)start_client, NULL, NULL,
+				 NULL);
+#else
+	start_client();
+#endif
 }

--- a/samples/net/sockets/echo_client/src/udp.c
+++ b/samples/net/sockets/echo_client/src/udp.c
@@ -25,7 +25,7 @@ LOG_MODULE_DECLARE(net_echo_client_sample, LOG_LEVEL_DBG);
 #define UDP_SLEEP K_MSEC(150)
 #define UDP_WAIT K_SECONDS(10)
 
-char recv_buf[RECV_BUF_SIZE];
+static APP_BMEM char recv_buf[RECV_BUF_SIZE];
 
 static int send_udp_data(struct data *data)
 {


### PR DESCRIPTION
Allow echo-client to run in user mode for testing purposes.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>

I was not able to fully test this as the echo-client sample will call `sys_rand32_get()`, so it requires #25980 to work properly.