### PR TITLE
net: sockets: Fix sendmsg() user mode param checks

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -652,11 +652,13 @@ static inline ssize_t z_vrfy_zsock_sendmsg(int sock,
 		}
 	}
 
-	msg_copy.msg_control = z_user_alloc_from_copy(msg->msg_control,
-						      msg->msg_controllen);
-	if (!msg_copy.msg_control) {
-		errno = ENOMEM;
-		goto fail;
+	if (msg->msg_controllen > 0) {
+		msg_copy.msg_control = z_user_alloc_from_copy(msg->msg_control,
+							  msg->msg_controllen);
+		if (!msg_copy.msg_control) {
+			errno = ENOMEM;
+			goto fail;
+		}
 	}
 
 	ret = z_impl_zsock_sendmsg(sock, (const struct msghdr *)&msg_copy,

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -643,11 +643,13 @@ static inline ssize_t z_vrfy_zsock_sendmsg(int sock,
 		msg_copy.msg_iov[i].iov_len = msg->msg_iov[i].iov_len;
 	}
 
-	msg_copy.msg_name = z_user_alloc_from_copy(msg->msg_name,
-						   msg->msg_namelen);
-	if (!msg_copy.msg_name) {
-		errno = ENOMEM;
-		goto fail;
+	if (msg->msg_namelen > 0) {
+		msg_copy.msg_name = z_user_alloc_from_copy(msg->msg_name,
+							   msg->msg_namelen);
+		if (!msg_copy.msg_name) {
+			errno = ENOMEM;
+			goto fail;
+		}
 	}
 
 	msg_copy.msg_control = z_user_alloc_from_copy(msg->msg_control,

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -572,8 +572,6 @@ void test_v4_sendmsg_recvfrom_connected(void)
 	msg.msg_controllen = sizeof(cmsgbuf.buf);
 	msg.msg_iov = io_vector;
 	msg.msg_iovlen = 1;
-	msg.msg_name = &server_addr;
-	msg.msg_namelen = sizeof(server_addr);
 
 	cmsg = CMSG_FIRSTHDR(&msg);
 	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
@@ -636,8 +634,6 @@ void test_v6_sendmsg_recvfrom_connected(void)
 	msg.msg_controllen = sizeof(cmsgbuf.buf);
 	msg.msg_iov = io_vector;
 	msg.msg_iovlen = 1;
-	msg.msg_name = &server_addr;
-	msg.msg_namelen = sizeof(server_addr);
 
 	cmsg = CMSG_FIRSTHDR(&msg);
 	cmsg->cmsg_len = CMSG_LEN(sizeof(int));

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -470,6 +470,54 @@ void test_v4_sendmsg_recvfrom(void)
 	zassert_equal(rv, 0, "close failed");
 }
 
+void test_v4_sendmsg_recvfrom_no_aux_data(void)
+{
+	int rv;
+	int client_sock;
+	int server_sock;
+	struct sockaddr_in client_addr;
+	struct sockaddr_in server_addr;
+	struct msghdr msg;
+	struct iovec io_vector[1];
+
+	prepare_sock_udp_v4(CONFIG_NET_CONFIG_MY_IPV4_ADDR, ANY_PORT,
+			    &client_sock, &client_addr);
+	prepare_sock_udp_v4(CONFIG_NET_CONFIG_MY_IPV4_ADDR, SERVER_PORT,
+			    &server_sock, &server_addr);
+
+	rv = bind(server_sock,
+		  (struct sockaddr *)&server_addr,
+		  sizeof(server_addr));
+	zassert_equal(rv, 0, "server bind failed");
+
+	rv = bind(client_sock,
+		  (struct sockaddr *)&client_addr,
+		  sizeof(client_addr));
+	zassert_equal(rv, 0, "client bind failed");
+
+	io_vector[0].iov_base = TEST_STR_SMALL;
+	io_vector[0].iov_len = strlen(TEST_STR_SMALL);
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = io_vector;
+	msg.msg_iovlen = 1;
+	msg.msg_name = &server_addr;
+	msg.msg_namelen = sizeof(server_addr);
+
+	comm_sendmsg_recvfrom(client_sock,
+			      (struct sockaddr *)&client_addr,
+			      sizeof(client_addr),
+			      &msg,
+			      server_sock,
+			      (struct sockaddr *)&server_addr,
+			      sizeof(server_addr));
+
+	rv = close(client_sock);
+	zassert_equal(rv, 0, "close failed");
+	rv = close(server_sock);
+	zassert_equal(rv, 0, "close failed");
+}
+
 void test_v6_sendmsg_recvfrom(void)
 {
 	int rv;
@@ -920,6 +968,8 @@ void test_main(void)
 			 ztest_unit_test(test_so_txtime),
 			 ztest_unit_test(test_v4_sendmsg_recvfrom),
 			 ztest_user_unit_test(test_v4_sendmsg_recvfrom),
+			 ztest_unit_test(test_v4_sendmsg_recvfrom_no_aux_data),
+			 ztest_user_unit_test(test_v4_sendmsg_recvfrom_no_aux_data),
 			 ztest_unit_test(test_v6_sendmsg_recvfrom),
 			 ztest_user_unit_test(test_v6_sendmsg_recvfrom),
 			 ztest_unit_test(test_v4_sendmsg_recvfrom_connected),


### PR DESCRIPTION
If we are calling sendmsg() for a connected socket, then msg_namelen
is 0 and msg_name is NULL. Check these allowed values properly.

Also modify unit tests so that we test this scenario.

Fixes #25925

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>