### PR TITLE
net: tcp2: Fix compile failure on native_posix_64

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -42,7 +42,7 @@ static int tcp_pkt_linearize(struct net_pkt *pkt, size_t pos, size_t len)
 	size_t len1, len2;
 
 	if (net_pkt_get_len(pkt) < (pos + len)) {
-		NET_ERR("Insufficient packet len=%d (pos+len=%zu)",
+		NET_ERR("Insufficient packet len=%zd (pos+len=%zu)",
 			net_pkt_get_len(pkt), pos + len);
 		ret = -EINVAL;
 		goto out;


### PR DESCRIPTION
Need to use %zd in formatter string for net_pkt_get_len since it returns
a size_t otherwise we get something like:

	error: format ‘%d’ expects argument of type ‘int’, but argument
	3 has type ‘size_t’ {aka ‘long unsigned int’} [-Werror=format=]

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>