### PR TITLE
net: openthread: Fix the order of adding net pkt in ot_receive_handler

### DIFF
--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -190,12 +190,17 @@ void ot_receive_handler(otMessage *aMessage, void *context)
 	}
 
 	if (!pkt_list_is_full(ot_context)) {
-		if (net_recv_data(ot_context->iface, pkt) < 0) {
-			NET_ERR("net_recv_data failed");
+		if (pkt_list_add(ot_context, pkt) != 0) {
+			NET_ERR("pkt_list_add failed");
 			goto out;
 		}
 
-		pkt_list_add(ot_context, pkt);
+		if (net_recv_data(ot_context->iface, pkt) < 0) {
+			NET_ERR("net_recv_data failed");
+			pkt_list_remove_first(ot_context);
+			goto out;
+		}
+
 		pkt = NULL;
 	} else {
 		NET_INFO("Packet list is full");

--- a/subsys/net/l2/openthread/openthread_utils.c
+++ b/subsys/net/l2/openthread/openthread_utils.c
@@ -58,6 +58,22 @@ int pkt_list_add(struct openthread_context *context, struct net_pkt *pkt)
 	return 0;
 }
 
+void pkt_list_remove_first(struct openthread_context *context)
+{
+	u16_t idx = context->pkt_list_in_idx;
+
+	if (idx == 0U) {
+		idx = CONFIG_OPENTHREAD_PKT_LIST_SIZE - 1;
+	} else {
+		idx--;
+	}
+	context->pkt_list_in_idx = idx;
+
+	if (context->pkt_list_full) {
+		context->pkt_list_full = 0U;
+	}
+}
+
 struct net_pkt *pkt_list_peek(struct openthread_context *context)
 {
 	if ((context->pkt_list_in_idx == context->pkt_list_out_idx) &&

--- a/subsys/net/l2/openthread/openthread_utils.h
+++ b/subsys/net/l2/openthread/openthread_utils.h
@@ -29,6 +29,7 @@ void rm_ipv6_maddr_from_zephyr(struct openthread_context *context);
 int pkt_list_add(struct openthread_context *context, struct net_pkt *pkt);
 struct net_pkt *pkt_list_peek(struct openthread_context *context);
 void pkt_list_remove_last(struct openthread_context *context);
+void pkt_list_remove_first(struct openthread_context *context);
 
 inline int pkt_list_is_full(struct openthread_context *context)
 {


### PR DESCRIPTION
Net pkt is added into the ot net list after queued net pkt into
the net_rx which bases on it. It affects in losting net pkt when for
instance ot thread is preemptive.

Signed-off-by: Lukasz Maciejonczyk <lukasz.maciejonczyk@nordicsemi.no>