### PR TITLE
net: openthread: cli: Align config of OT and Zephyr shell max cmd size

### DIFF
--- a/subsys/net/lib/openthread/platform/shell.c
+++ b/subsys/net/lib/openthread/platform/shell.c
@@ -16,7 +16,7 @@
 
 #include "platform-zephyr.h"
 
-#define OT_SHELL_BUFFER_SIZE 256
+#define OT_SHELL_BUFFER_SIZE CONFIG_SHELL_CMD_BUFF_SIZE
 
 static char rx_buffer[OT_SHELL_BUFFER_SIZE];
 


### PR DESCRIPTION
This PR enables the user to configure the maximum command length for
OpenThread's CLI using Zephyr's shell, which is currently fixed to
256 characteres. This limitation was not enough for certain allowed
OpenThread commands, like some variants of 'ot dataset mgmtsetcommand'.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>