### PR TITLE
samples: usb: mass: fix to support FatFS on external file system

### DIFF
--- a/samples/subsys/usb/mass/src/main.c
+++ b/samples/subsys/usb/mass/src/main.c
@@ -26,6 +26,7 @@ static FATFS fat_fs;
 static struct fs_mount_t fs_mnt = {
 	.type = FS_FATFS,
 	.mnt_point = FATFS_MNTP,
+	.storage_dev = (void *)FLASH_AREA_ID(storage),
 	.fs_data = &fat_fs,
 };
 #elif CONFIG_FILE_SYSTEM_LITTLEFS

--- a/samples/subsys/usb/mass/src/main.c
+++ b/samples/subsys/usb/mass/src/main.c
@@ -15,6 +15,7 @@
 LOG_MODULE_REGISTER(main);
 
 #if CONFIG_DISK_ACCESS_FLASH
+#include <storage/flash_map.h>
 #if CONFIG_FAT_FILESYSTEM_ELM
 #include <fs/fs.h>
 #include <ff.h>
@@ -30,7 +31,6 @@ static struct fs_mount_t fs_mnt = {
 #elif CONFIG_FILE_SYSTEM_LITTLEFS
 #include <fs/fs.h>
 #include <fs/littlefs.h>
-#include <storage/flash_map.h>
 
 FS_LITTLEFS_DECLARE_DEFAULT_CONFIG(storage);
 static struct fs_mount_t fs_mnt = {


### PR DESCRIPTION
The flash interface header needs to be available regardless of selected filesystem implementation.

This allows the example to work with FatFS on nrf52840dk_nrf52840 if the custom configuration is updated:
```
--- a/samples/subsys/usb/mass/boards/nrf52840dk_nrf52840.conf
+++ b/samples/subsys/usb/mass/boards/nrf52840dk_nrf52840.conf
@@ -8,7 +8,8 @@ CONFIG_NORDIC_QSPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 CONFIG_MASS_STORAGE_DISK_NAME="NAND"
 
 CONFIG_FILE_SYSTEM=y
-CONFIG_FILE_SYSTEM_LITTLEFS=y
+#CONFIG_FILE_SYSTEM_LITTLEFS=y
+CONFIG_FAT_FILESYSTEM_ELM=y
 CONFIG_FLASH_LOG_LEVEL_INF=y
 
 CONFIG_FLASH_MAP=y
```

There is a possibly unrelated bug that can produce an MPU fault if the file system type is switched.