### PR TITLE
drivers: timer: lptim: depend on SYS_POWER_MANAGEMENT

### DIFF
--- a/drivers/timer/Kconfig.stm32_lptim
+++ b/drivers/timer/Kconfig.stm32_lptim
@@ -6,7 +6,7 @@
 menuconfig STM32_LPTIM_TIMER
 	bool "STM32 Low Power Timer [EXPERIMENTAL]"
 	depends on (SOC_SERIES_STM32L4X || SOC_SERIES_STM32WBX)
-	depends on CLOCK_CONTROL && DEVICE_POWER_MANAGEMENT
+	depends on CLOCK_CONTROL && SYS_POWER_MANAGEMENT
 	select TICKLESS_CAPABLE
 	help
 	  This module implements a kernel device driver for the LowPower Timer


### PR DESCRIPTION
The LPTIM driver is supposed to be only available when the SoC is
allowed to enter power sleep mode, as described in commit f30f5fff72e9
("drivers: timer: lptim is [EXPERIMENTAL] for stm32 soc series only").

For that it should depends on SYS_POWER_MANAGEMENT (which gates the 
SYS_POWER_SLEEP_STATES and SYS_POWER_DEEP_SLEEP_STATES options) instead
of DEVICE_POWER_MANAGEMENT.

Fixes #25989

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>