### PR TITLE
board: arc: hsdk: Enable SMP

### DIFF
--- a/boards/arc/hsdk/support/openocd.cfg
+++ b/boards/arc/hsdk/support/openocd.cfg
@@ -112,4 +112,6 @@ arc_hs_init_regs
 # Enable L2 cache support for core 1.
 $_TARGETNAME1 arc has-l2cache true
 
+target smp $_TARGETNAME1 $_TARGETNAME2 $_TARGETNAME3 $_TARGETNAME4
+
 # vi:ft=tcl


### PR DESCRIPTION
With latest SDK release v0.11.3 basic SMP support for HSDK
board was introduced in OpenOCD. Lets enable smp in openocd.cfg,
so using west we would be able to run Zephyr on all 4 cores.

Signed-off-by: Evgeniy Didin <didin@synopsys.com>