### PR TITLE
drivers: semihosting console: Output speed optimization

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -305,6 +305,16 @@ config SEMIHOST_CONSOLE
 	  This option is compatible with hardware and with QEMU, through the
 	  (automatic) use of the -semihosting-config switch when invoking it.
 
+if SEMIHOST_CONSOLE
+
+config SEMIHOST_CONSOLE_OUTPUT_BUFFER_SIZE
+	int "Semihosting output buffer size"
+	default 64
+	help
+	  Size of the semihosting console buffer in bytes
+
+endif
+
 module = UART_CONSOLE
 module-str = UART console
 source "subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
Use buffer and output multiple characters at a time to optimize the output efficiency of semihosting. There are currently several problems, if the output does not have '\r' or '\n', it will cause the output to lag, because my current project uses the LOG_* API, This series of APIs will add '\n' after the output, so there is no problem. So need to discuss whether it is necessary to add a timeout mechanism