### PR TITLE
dfu: flash_img: Constify flash_img_buffered_write() data parameter

### DIFF
--- a/include/dfu/flash_img.h
+++ b/include/dfu/flash_img.h
@@ -65,7 +65,7 @@ size_t flash_img_bytes_written(struct flash_img_context *ctx);
  *
  * @return  0 on success, negative errno code on fail
  */
-int flash_img_buffered_write(struct flash_img_context *ctx, uint8_t *data,
+int flash_img_buffered_write(struct flash_img_context *ctx, const uint8_t *data,
 		    size_t len, bool flush);
 
 #ifdef __cplusplus

--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -31,7 +31,7 @@ BUILD_ASSERT((CONFIG_IMG_BLOCK_BUF_SIZE % FLASH_WRITE_BLOCK_SIZE == 0),
 	     "CONFIG_IMG_BLOCK_BUF_SIZE is not a multiple of "
 	     "FLASH_WRITE_BLOCK_SIZE");
 
-int flash_img_buffered_write(struct flash_img_context *ctx, uint8_t *data,
+int flash_img_buffered_write(struct flash_img_context *ctx, const uint8_t *data,
 			     size_t len, bool flush)
 {
 	int rc;


### PR DESCRIPTION
The data passed has no reason to be changed and can therefore be passed
as read only.

Signed-off-by: Xavier Chapron <xavier.chapron@stimio.fr>