### PR TITLE
tests/drivers: Include flash.h in MPU test only when needed

### DIFF
--- a/tests/drivers/flash_simulator/src/main.c
+++ b/tests/drivers/flash_simulator/src/main.c
@@ -5,7 +5,9 @@
  */
 
 #include <ztest.h>
+#ifdef CONFIG_FLASH
 #include <drivers/flash.h>
+#endif
 #include <device.h>
 
 /* configuration derived from DT */


### PR DESCRIPTION
The flash.h is not always needed by the test.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>