### PR TITLE
api: drivers: serial: uart_async: Call UART_RX_RDY event after rx_disable()

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1988,6 +1988,7 @@ PREDEFINED             = "CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT" \
                          "CONFIG_THREAD_STACK_INFO" \
                          "CONFIG_UART_DRV_CMD" \
                          "CONFIG_UART_INTERRUPT_DRIVEN" \
+                         "CONFIG_UART_ASYNC_API" \
                          "CONFIG_USERSPACE" \
                          "CONFIG_USE_SWITCH" \
                          "NET_MGMT_DEFINE_REQUEST_HANDLER(x)=" \

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -693,6 +693,11 @@ static void rxto_isr(void)
 {
 	nrf_uart_event_clear(uart0_addr, NRF_UART_EVENT_RXTO);
 
+	/* Send rxrdy if there is any data pending. */
+	if (uart0_cb.rx_counter - uart0_cb.rx_offset) {
+		rx_rdy_evt();
+	}
+
 	buf_released_evt();
 	if (uart0_cb.rx_secondary_buffer_length) {
 		uart0_cb.rx_buffer = uart0_cb.rx_secondary_buffer;

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -762,8 +762,8 @@ static void endrx_isr(struct device *dev)
 				.type = UART_RX_DISABLED,
 			};
 			user_callback(dev, &evt);
+			return;
 		}
-		return;
 	}
 
 	data->async->is_in_irq = true;
@@ -811,6 +811,11 @@ static void endrx_isr(struct device *dev)
 			.data.rx.offset = data->async->rx_offset,
 		};
 		user_callback(dev, &evt);
+	}
+
+	if (!data->async->rx_enabled) {
+		data->async->is_in_irq = false;
+		return;
 	}
 
 	struct uart_event evt = {
@@ -1262,6 +1267,7 @@ static int uarte_instance_init(struct device *dev,
 	int err;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 	struct uarte_nrfx_data *data = get_dev_data(dev);
+
 
 	nrf_gpio_pin_write(config->pseltxd, 1);
 	nrf_gpio_cfg_output(config->pseltxd);

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -970,21 +970,6 @@ static int uart_sam0_rx_disable(struct device *dev)
 	regs->INTENCLR.reg = SERCOM_USART_INTENCLR_RXC;
 	dma_stop(dev_data->dma, cfg->rx_dma_channel);
 
-	if (dev_data->rx_next_len) {
-		struct uart_event evt = {
-			.type = UART_RX_BUF_RELEASED,
-			.data.rx_buf = {
-				.buf = dev_data->rx_next_buf,
-			},
-		};
-
-		dev_data->rx_next_buf = NULL;
-		dev_data->rx_next_len = 0U;
-
-		if (dev_data->async_cb) {
-			dev_data->async_cb(&evt, dev_data->async_cb_data);
-		}
-	}
 
 	if (dma_get_status(dev_data->dma, cfg->rx_dma_channel,
 			   &st) == 0 && st.pending_length != 0U) {
@@ -1005,6 +990,22 @@ static int uart_sam0_rx_disable(struct device *dev)
 
 	if (dev_data->async_cb) {
 		dev_data->async_cb(&evt, dev_data->async_cb_data);
+	}
+
+	if (dev_data->rx_next_len) {
+		struct uart_event evt = {
+			.type = UART_RX_BUF_RELEASED,
+			.data.rx_buf = {
+				.buf = dev_data->rx_next_buf,
+			},
+		};
+
+		dev_data->rx_next_buf = NULL;
+		dev_data->rx_next_len = 0U;
+
+		if (dev_data->async_cb) {
+			dev_data->async_cb(&evt, dev_data->async_cb_data);
+		}
 	}
 
 	evt.type = UART_RX_DISABLED;


### PR DESCRIPTION
As proposed in #25317 modified API description and updated the test and nrf implementations.

Short summary:
Before: calling `rx_disable()` stops receiver and discards any pending, received data.
After: after calling`rx_disable()` `UART_RX_RDY` event is generated if there is any pending data.

PR contains changes in all 3 drivers which implemented asynchronous API.