### PR TITLE
tests: drivers: clock_control: nrf: increased LFCLK startup time

### DIFF
--- a/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
+++ b/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
@@ -37,7 +37,7 @@ static const struct device_data devices[] = {
 			{
 				.subsys = CLOCK_CONTROL_NRF_SUBSYS_LF,
 				.startup_us = (CLOCK_CONTROL_NRF_K32SRC ==
-					NRF_CLOCK_LFCLK_RC) ? 1000 : 300000
+					NRF_CLOCK_LFCLK_RC) ? 1000 : 500000
 			}
 		},
 		.subsys_cnt = CLOCK_CONTROL_NRF_TYPE_COUNT


### PR DESCRIPTION
Fixed occasional test failures when clock was not ready after
specified time.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>