### PR TITLE
[TOPIC-BLE-LLCP]: Bluetooth: llcp: release ctx at end of procedure

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -88,8 +88,9 @@ static struct proc_ctx *proc_ctx_acquire(void)
 	return ctx;
 }
 
-static void proc_ctx_release(struct proc_ctx *ctx)
+void ull_cp_priv_proc_ctx_release(struct proc_ctx *ctx)
 {
+	memset(ctx, 0xFF, sizeof(struct proc_ctx));
 	mem_release(ctx, &mem_ctx.free);
 }
 
@@ -108,6 +109,7 @@ struct node_tx *ull_cp_priv_tx_alloc(void)
 
 static void tx_release(struct node_tx *tx)
 {
+	memset(tx, 0xFF, sizeof(struct node_tx));
 	mem_release(tx, &mem_tx.free);
 }
 
@@ -126,6 +128,7 @@ struct node_rx_pdu *ull_cp_priv_ntf_alloc(void)
 
 static void ntf_release(struct node_rx_pdu *ntf)
 {
+	memset(ntf, 0xFF, sizeof(struct node_rx_pdu));
 	mem_release(ntf, &mem_ntf.free);
 }
 
@@ -164,7 +167,7 @@ static struct proc_ctx *create_procedure(enum llcp_proc proc)
 	ctx->proc = proc;
 	ctx->collision = 0U;
 	ctx->pause = 0U;
-
+	ctx->release_ctx = 0U;
 	return ctx;
 }
 
@@ -488,12 +491,26 @@ void ull_cp_rx(struct ull_cp_conn *conn, struct node_rx_pdu *rx)
 }
 
 #ifdef ZTEST_UNITTEST
+
+int ctx_buffers_free(void)
+{
+	int nr_of_free_ctx;
+
+	nr_of_free_ctx = mem_free_count_get(mem_ctx.free);
+
+	return nr_of_free_ctx;
+}
+
 void test_int_mem_proc_ctx(void)
 {
 	struct proc_ctx *ctx1;
 	struct proc_ctx *ctx2;
+	int nr_of_free_ctx;
 
 	ull_cp_init();
+
+	nr_of_free_ctx = ctx_buffers_free();
+	zassert_equal(nr_of_free_ctx, PROC_CTX_BUF_NUM, NULL);
 
 	for (int i = 0U; i < PROC_CTX_BUF_NUM; i++) {
 		ctx1 = proc_ctx_acquire();
@@ -502,12 +519,18 @@ void test_int_mem_proc_ctx(void)
 		zassert_not_null(ctx1, NULL);
 	}
 
+	nr_of_free_ctx = ctx_buffers_free();
+	zassert_equal(nr_of_free_ctx, 0, NULL);
+
 	ctx2 = proc_ctx_acquire();
 
 	/* The last acquire should fail */
 	zassert_is_null(ctx2, NULL);
 
 	proc_ctx_release(ctx1);
+	nr_of_free_ctx = ctx_buffers_free();
+	zassert_equal(nr_of_free_ctx, 1, NULL);
+
 	ctx1 = proc_ctx_acquire();
 
 	/* Releasing returns the context to the avilable pool */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -40,6 +40,9 @@ struct proc_ctx {
 	/* Procedure pause */
 	int pause;
 
+	/* TX node awaiting ack */
+	struct node_tx *tx_ack;
+
 	/*
 	 * This flag is set to 1 when we are finished with the control
 	 * procedure and it is safe to release the context ctx
@@ -696,4 +699,5 @@ bool lr_is_disconnected(struct ull_cp_conn *conn);
 bool lr_is_idle(struct ull_cp_conn *conn);
 bool rr_is_disconnected(struct ull_cp_conn *conn);
 bool rr_is_idle(struct ull_cp_conn *conn);
+int ctx_buffers_free(void);
 #endif

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -40,8 +40,11 @@ struct proc_ctx {
 	/* Procedure pause */
 	int pause;
 
-	/* TX node awaiting ack */
-	struct node_tx * tx_ack;
+	/*
+	 * This flag is set to 1 when we are finished with the control
+	 * procedure and it is safe to release the context ctx
+	 */
+	int release_ctx;
 
 	/* Procedure data */
 	union {
@@ -678,6 +681,15 @@ static inline void pdu_decode_phy_update_ind(struct proc_ctx *ctx, struct pdu_da
 {
 	return ull_cp_priv_pdu_decode_phy_update_ind(ctx, pdu);
 }
+
+
+void ull_cp_priv_proc_ctx_release(struct proc_ctx *ctx);
+
+static inline void proc_ctx_release(struct proc_ctx *ctx)
+{
+	ull_cp_priv_proc_ctx_release(ctx);
+}
+
 
 #ifdef ZTEST_UNITTEST
 bool lr_is_disconnected(struct ull_cp_conn *conn);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -143,6 +143,9 @@ static void lr_act_run(struct ull_cp_conn *conn)
 		case PROC_FEATURE_EXCHANGE:
 			lp_comm_run(conn, ctx, NULL);
 			break;
+		case PROC_MIN_USED_CHANS:
+			lp_comm_run(conn, ctx, NULL);
+			break;
 		case PROC_VERSION_EXCHANGE:
 			lp_comm_run(conn, ctx, NULL);
 			break;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -193,6 +193,9 @@ static void rr_act_run(struct ull_cp_conn *conn)
 		case PROC_FEATURE_EXCHANGE:
 			rp_comm_run(conn, ctx, NULL);
 			break;
+		case PROC_MIN_USED_CHANS:
+			rp_comm_run(conn, ctx, NULL);
+			break;
 		case PROC_VERSION_EXCHANGE:
 			rp_comm_run(conn, ctx, NULL);
 			break;

--- a/tests/bluetooth/controller/ctrl_api/src/main.c
+++ b/tests/bluetooth/controller/ctrl_api/src/main.c
@@ -90,6 +90,112 @@ void test_api_disconnect(void)
 	zassert_true(rr_is_disconnected(&conn), NULL);
 }
 
+void test_int_disconnect_loc(void)
+{
+	u64_t err;
+	int nr_free_ctx;
+	struct node_tx *tx;
+	struct ull_cp_conn conn;
+
+	struct pdu_data_llctrl_version_ind local_version_ind = {
+		.version_number = LL_VERSION_NUMBER,
+		.company_id = CONFIG_BT_CTLR_COMPANY_ID,
+		.sub_version_number = CONFIG_BT_CTLR_SUBVERSION_NUMBER,
+	};
+
+	test_setup(&conn);
+	test_set_role(&conn, BT_HCI_ROLE_MASTER);
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	nr_free_ctx = ctx_buffers_free();
+	zassert_equal(nr_free_ctx, PROC_CTX_BUF_NUM, NULL);
+
+	err = ull_cp_version_exchange(&conn);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	nr_free_ctx = ctx_buffers_free();
+	zassert_equal(nr_free_ctx, PROC_CTX_BUF_NUM - 1, NULL);
+
+	event_prepare(&conn);
+	lt_rx(LL_VERSION_IND, &conn, &tx, &local_version_ind);
+	lt_rx_q_is_empty(&conn);
+	event_done(&conn);
+
+	/*
+	 * Now we disconnect before getting a response
+	 */
+	ull_cp_state_set(&conn, ULL_CP_DISCONNECTED);
+
+	nr_free_ctx = ctx_buffers_free();
+	zassert_equal(nr_free_ctx, PROC_CTX_BUF_NUM, NULL);
+
+	ut_rx_q_is_empty();
+
+	/*
+	 * nothing should happen when running a new event
+	 */
+	event_prepare(&conn);
+	event_done(&conn);
+
+	nr_free_ctx = ctx_buffers_free();
+	zassert_equal(nr_free_ctx, PROC_CTX_BUF_NUM, NULL);
+
+	/*
+	 * all buffers should still be empty
+	 */
+	lt_rx_q_is_empty(&conn);
+	ut_rx_q_is_empty();
+}
+
+void test_int_disconnect_rem(void)
+{
+	int nr_free_ctx;
+	struct pdu_data_llctrl_version_ind remote_version_ind = {
+		.version_number = 0x55,
+		.company_id = 0xABCD,
+		.sub_version_number = 0x1234,
+	};
+
+	test_setup(&conn);
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_MASTER);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	nr_free_ctx = ctx_buffers_free();
+	zassert_equal(nr_free_ctx, PROC_CTX_BUF_NUM, NULL);
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Rx */
+	lt_tx(LL_VERSION_IND, &conn, &remote_version_ind);
+
+	nr_free_ctx = ctx_buffers_free();
+	zassert_equal(nr_free_ctx, PROC_CTX_BUF_NUM, NULL);
+
+	/* Disconnect before we reply */
+
+	/* Done */
+	event_done(&conn);
+
+	ull_cp_state_set(&conn, ULL_CP_DISCONNECTED);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Done */
+	event_done(&conn);
+
+	nr_free_ctx = ctx_buffers_free();
+	zassert_equal(nr_free_ctx, PROC_CTX_BUF_NUM, NULL);
+
+	/* There should not be a host notifications */
+	ut_rx_q_is_empty();
+
+}
+
 void test_main(void)
 {
 	ztest_test_suite(internal,
@@ -98,7 +204,9 @@ void test_main(void)
 			 ztest_unit_test(test_int_mem_ntf),
 			 ztest_unit_test(test_int_create_proc),
 			 ztest_unit_test(test_int_local_pending_requests),
-			 ztest_unit_test(test_int_remote_pending_requests)
+			 ztest_unit_test(test_int_remote_pending_requests),
+			 ztest_unit_test(test_int_disconnect_loc),
+			 ztest_unit_test(test_int_disconnect_rem)
 			);
 
 	ztest_test_suite(public,


### PR DESCRIPTION
When a control procedure is finished, or upon disconnection, we need
to release the context to avoid running out of memory.
I believe I found the best location for this, pls .correct me if I am wrong

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>