### PR TITLE
drivers: flash: nrf_qspi_nor: port downstream fixes for mcumgr support

### DIFF
--- a/drivers/flash/Kconfig.nordic_qspi_nor
+++ b/drivers/flash/Kconfig.nordic_qspi_nor
@@ -29,4 +29,15 @@ config NORDIC_QSPI_NOR_FLASH_LAYOUT_PAGE_SIZE
 	  that API.  By default the page size corresponds to the block
 	  size (65536).  Other option include the sector size (4096).
 
+config NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE
+	int "Size of a stack-based buffer to support writes from NVMC"
+	default 0
+	help
+	  The QSPI peripheral uses DMA and cannot write data that is
+	  read from the internal flash.  A non-zero value here enables
+	  a stack buffer into which data is copied to allow the write
+	  to proceed.  Multiple transfers will be initiated if the
+	  data is larger than the configured limit.  Must be a
+	  multiple of 4.  The feature is disabled when set to 0.
+
 endif # NORDIC_QSPI_NOR

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -543,6 +543,28 @@ static int qspi_nor_read(struct device *dev, off_t addr, void *dest,
 	return rc;
 }
 
+/* addr aligned, sptr not null, slen less than 4 */
+static inline nrfx_err_t write_sub_word(struct device *dev, off_t addr,
+					const void *sptr, size_t slen)
+{
+	uint8_t __aligned(4) buf[4];
+	nrfx_err_t res;
+
+	/* read out the whole word so that unchanged data can be
+	 * written back
+	 */
+	res = nrfx_qspi_read(buf, sizeof(buf), addr);
+	qspi_wait_for_completion(dev, res);
+
+	if (res == NRFX_SUCCESS) {
+		memcpy(sptr, buf, slen);
+		res = nrfx_qspi_write(src, size, addr);
+		qspi_wait_for_completion(dev, res);
+	}
+
+	return res;
+}
+
 static int qspi_nor_write(struct device *dev, off_t addr, const void *src,
 			  size_t size)
 {
@@ -550,8 +572,9 @@ static int qspi_nor_write(struct device *dev, off_t addr, const void *src,
 		return -EINVAL;
 	}
 
-	/* write size must be non-zero multiple of 4 bytes */
-	if (((size % 4U) != 0) || (size == 0)) {
+	/* write size must be non-zero, less than 4, or a multiple of 4 */
+	if ((size == 0)
+	    || ((size > 4) && ((size % 4U) != 0))) {
 		return -EINVAL;
 	}
 	/* address must be 4-byte aligned */
@@ -575,11 +598,16 @@ static int qspi_nor_write(struct device *dev, off_t addr, const void *src,
 		return -EINVAL;
 	}
 
+	nrfx_err_t res = NRFX_SUCCESS;
+
 	qspi_lock(dev);
 
-	nrfx_err_t res = nrfx_qspi_write(src, size, addr);
-
-	qspi_wait_for_completion(dev, res);
+	if (size < 4U) {
+		res = write_sub_word(dev, addr, src, size);
+	} else {
+		res = nrfx_qspi_write(src, size, addr);
+		qspi_wait_for_completion(dev, res);
+	}
 
 	qspi_unlock(dev);
 

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -557,11 +557,49 @@ static inline nrfx_err_t write_sub_word(struct device *dev, off_t addr,
 	qspi_wait_for_completion(dev, res);
 
 	if (res == NRFX_SUCCESS) {
-		memcpy(sptr, buf, slen);
-		res = nrfx_qspi_write(src, size, addr);
+		memcpy(buf, sptr, slen);
+		res = nrfx_qspi_write(buf, sizeof(buf), addr);
 		qspi_wait_for_completion(dev, res);
 	}
 
+	return res;
+}
+
+BUILD_ASSERT((CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE % 4) == 0,
+	     "NOR stack buffer must be multiple of 4 bytes");
+
+#define NVMC_WRITE_OK (CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE > 0)
+
+/* If enabled write using a stack-allocated aligned SRAM buffer as
+ * required for DMA transfers by QSPI peripheral.
+ *
+ * If not enabled return the error the peripheral would have produced.
+ */
+static inline nrfx_err_t write_from_nvmc(struct device *dev, off_t addr,
+					 const void *sptr, size_t slen)
+{
+#if NVMC_WRITE_OK
+	uint8_t __aligned(4) buf[CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE];
+	const uint8_t *sp = sptr;
+	nrfx_err_t res = NRFX_SUCCESS;
+
+	while ((slen > 0) && (res == NRFX_SUCCESS)) {
+		size_t len = MIN(slen, sizeof(buf));
+
+		memcpy(buf, sp, len);
+		res = nrfx_qspi_write(buf, sizeof(buf),
+				      addr);
+		qspi_wait_for_completion(dev, res);
+
+		if (res == NRFX_SUCCESS) {
+			slen -= len;
+			sp += len;
+			addr += len;
+		}
+	}
+#else /* NVMC_WRITE_OK */
+	nrfx_err_t res = NRFX_ERROR_INVALID_ADDR;
+#endif /* NVMC_WRITE_OK */
 	return res;
 }
 
@@ -604,6 +642,8 @@ static int qspi_nor_write(struct device *dev, off_t addr, const void *src,
 
 	if (size < 4U) {
 		res = write_sub_word(dev, addr, src, size);
+	} else if (((uintptr_t)src < CONFIG_SRAM_BASE_ADDRESS)) {
+		res = write_from_nvmc(dev, addr, src, size);
 	} else {
 		res = nrfx_qspi_write(src, size, addr);
 		qspi_wait_for_completion(dev, res);


### PR DESCRIPTION
Two changes initially made downstream and now ported upstream to fix failures in mcumgr capabilities due to the Nordic QSPI peripheral requiring aligned transfers of 32-bit words to/from SRAM:

* If an aligned write is requested but the transfer size is not a multiple of 4 then read the current word content, replace the prefix that is to change, and write back the whole word.
* If a write is requested from a pointer to NVMC, and a Kconfig option enables it, perform the write by copying blocks from NVMC to a stack-allocated buffer.

Inspired by commits in nrfconnect/sdk-zephyr#305 though significantly reworked for upstream.