### PR TITLE
drivers: serial: nrf uarte: Fix for the RX byte counter

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -664,6 +664,17 @@ static void rx_timeout(struct k_timer *timer)
 	s32_t len = data->async->rx_total_byte_cnt
 		    - data->async->rx_total_user_byte_cnt;
 
+	if (!hw_rx_counting_enabled(data) &&
+	    (len < 0)) {
+		/* Prevent too low value of rx_cnt.cnt which may occur due to
+		 * latencies in handling of the RXRDY interrupt. Because whole
+		 * buffer was filled we can be sure that rx_total_user_byte_cnt
+		 * is current total number of received bytes.
+		 */
+		data->async->rx_cnt.cnt = data->async->rx_total_user_byte_cnt;
+		len = 0;
+	}
+
 	/* Check for current buffer being full.
 	 * if the UART receives characters before the the ENDRX is handled
 	 * and the 'next' buffer is set up, then the SHORT between ENDRX and
@@ -786,15 +797,6 @@ static void endrx_isr(struct device *dev)
 	}
 
 	data->async->rx_total_user_byte_cnt += rx_len;
-
-	if (!hw_rx_counting_enabled(data)) {
-		/* Prevent too low value of rx_cnt.cnt which may occur due to
-		 * latencies in handling of the RXRDY interrupt. Because whole
-		 * buffer was filled we can be sure that rx_total_user_byte_cnt
-		 * is current total number of received bytes.
-		 */
-		data->async->rx_cnt.cnt = data->async->rx_total_user_byte_cnt;
-	}
 
 	/* Only send the RX_RDY event if there is something to send */
 	if (rx_len > 0) {


### PR DESCRIPTION
In case of the following sequence of UART events:
 - UART_ENDRX
 - UART_RXRDY
 - TIMER_RXTIMEOUT

The application receives one more byte that was received, due to RX counter alignment upon ENDRX event.

The proposed fix moves the RX byte counter alignment to the RX timeout event handler.

Fixes: #33280 

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>