### PR TITLE
 STM32 LPTIM driver doesn't restart counter after sleeping K_TICKS_FOREVER

### DIFF
--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -178,10 +178,14 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 	}
 
 	if (ticks == K_TICKS_FOREVER) {
-		/* disable LPTIM */
-		LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_LPTIM1);
+		/* disable LPTIM clock to avoid counting */
 		LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_LPTIM1);
 		return;
+	}
+
+	/* if LPTIM clock was previously stopped, it must now be restored */
+	if (!LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_LPTIM1)) {
+		LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_LPTIM1);
 	}
 
 	/* passing ticks==1 means "announce the next tick",


### PR DESCRIPTION
This patch changes the LPTIM when setting a timeout 'FOREVER' 
In this case, the LPTIM clock is stops and the systems goes to sleep until wakeUp. Because it is stopped, the LPTIM can no more exit the sleep mode but another wakeup authorized source could.
Later on, when LPTIM has to be re-enabled, just restore its clock with `LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_LPTIM1);`
This is for example the user button like in the sample application ; samples/subsys/power/stm32_pm/

This fixes https://github.com/zephyrproject-rtos/zephyr/issues/25952

Signed-off-by: Francois Ramu francois.ramu@st.com