### PR TITLE
random: Add syscalls for random subsystem

### DIFF
--- a/drivers/ethernet/eth.h
+++ b/drivers/ethernet/eth.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_DRIVERS_ETHERNET_ETH_H_
 
 #include <zephyr/types.h>
+#include <random/rand32.h>
 
 /* helper macro to return mac address octet from local_mac_address prop */
 #define NODE_MAC_ADDR_OCTET(node, n) DT_PROP_BY_IDX(node, local_mac_address, n)

--- a/drivers/ieee802154/ieee802154_uart_pipe.c
+++ b/drivers/ieee802154/ieee802154_uart_pipe.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <init.h>
 #include <net/net_if.h>
 #include <net/net_pkt.h>
+#include <random/rand32.h>
 
 #include <drivers/console/uart_pipe.h>
 #include <net/ieee802154_radio.h>

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -20,6 +20,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #include <drivers/gpio.h>
 #include <device.h>
 #include <init.h>
+#include <random/rand32.h>
 
 #include <net/net_context.h>
 #include <net/net_if.h>

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -31,6 +31,7 @@ LOG_MODULE_REGISTER(net_ppp, LOG_LEVEL);
 #include <sys/crc.h>
 #include <drivers/uart.h>
 #include <drivers/console/uart_mux.h>
+#include <random/rand32.h>
 
 #include "../../subsys/net/ip/net_stats.h"
 #include "../../subsys/net/ip/net_private.h"

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -32,6 +32,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <net/net_core.h>
 #include <net/dummy.h>
 #include <drivers/console/uart_pipe.h>
+#include <random/rand32.h>
 
 #define SLIP_END     0300
 #define SLIP_ESC     0333

--- a/include/kernel_includes.h
+++ b/include/kernel_includes.h
@@ -33,7 +33,6 @@
 #include <mempool_sys.h>
 #endif
 #include <kernel_version.h>
-#include <random/rand32.h>
 #include <syscall.h>
 #include <sys/printk.h>
 #include <arch/cpu.h>

--- a/include/random/rand32.h
+++ b/include/random/rand32.h
@@ -22,6 +22,7 @@
 
 #include <zephyr/types.h>
 #include <stddef.h>
+#include <kernel.h>
 
 /**
  * @brief Random Function APIs
@@ -43,7 +44,8 @@ extern "C" {
  *
  * @return 32-bit random value.
  */
-extern uint32_t sys_rand32_get(void);
+__syscall uint32_t sys_rand32_get(void);
+
 /**
  * @brief Fill the destination buffer with random data values that should
  * pass general randomness tests.
@@ -55,7 +57,7 @@ extern uint32_t sys_rand32_get(void);
  * @param len size of the destination buffer.
  *
  */
-extern void sys_rand_get(void *dst, size_t len);
+__syscall void sys_rand_get(void *dst, size_t len);
 
 /**
  * @brief Fill the destination buffer with cryptographically secure
@@ -70,7 +72,7 @@ extern void sys_rand_get(void *dst, size_t len);
  * @return 0 if success, -EIO if entropy reseed error
  *
  */
-extern int sys_csrand_get(void *dst, size_t len);
+__syscall int sys_csrand_get(void *dst, size_t len);
 
 #ifdef __cplusplus
 }
@@ -80,4 +82,5 @@ extern int sys_csrand_get(void *dst, size_t len);
  * @}
  */
 
+#include <syscalls/rand32.h>
 #endif /* ZEPHYR_INCLUDE_RANDOM_RAND32_H_ */

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -26,6 +26,7 @@
 #include <stdbool.h>
 #include <irq_offload.h>
 #include <sys/check.h>
+#include <random/rand32.h>
 
 #ifdef CONFIG_THREAD_MONITOR
 /* This lock protects the linked list of active threads; i.e. the

--- a/samples/bluetooth/peripheral_csc/src/main.c
+++ b/samples/bluetooth/peripheral_csc/src/main.c
@@ -11,6 +11,7 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
+#include <random/rand32.h>
 #include <sys/printk.h>
 #include <sys/byteorder.h>
 #include <zephyr.h>

--- a/samples/net/cloud/mqtt_azure/src/main.c
+++ b/samples/net/cloud/mqtt_azure/src/main.c
@@ -12,6 +12,7 @@ LOG_MODULE_REGISTER(mqtt_azure, LOG_LEVEL_DBG);
 #include <net/mqtt.h>
 
 #include <sys/printk.h>
+#include <random/rand32.h>
 #include <string.h>
 #include <errno.h>
 

--- a/samples/net/mqtt_publisher/src/main.c
+++ b/samples/net/mqtt_publisher/src/main.c
@@ -10,6 +10,7 @@ LOG_MODULE_REGISTER(net_mqtt_publisher_sample, LOG_LEVEL_DBG);
 #include <zephyr.h>
 #include <net/socket.h>
 #include <net/mqtt.h>
+#include <random/rand32.h>
 
 #include <string.h>
 #include <errno.h>

--- a/samples/net/sockets/echo_client/src/tcp.c
+++ b/samples/net/sockets/echo_client/src/tcp.c
@@ -16,6 +16,7 @@ LOG_MODULE_DECLARE(net_echo_client_sample, LOG_LEVEL_DBG);
 
 #include <net/socket.h>
 #include <net/tls_credentials.h>
+#include <random/rand32.h>
 
 #include "common.h"
 #include "ca_certificate.h"

--- a/samples/net/sockets/echo_client/src/udp.c
+++ b/samples/net/sockets/echo_client/src/udp.c
@@ -16,6 +16,7 @@ LOG_MODULE_DECLARE(net_echo_client_sample, LOG_LEVEL_DBG);
 
 #include <net/socket.h>
 #include <net/tls_credentials.h>
+#include <random/rand32.h>
 
 #include "common.h"
 #include "ca_certificate.h"

--- a/samples/net/sockets/websocket_client/src/main.c
+++ b/samples/net/sockets/websocket_client/src/main.c
@@ -11,6 +11,7 @@ LOG_MODULE_REGISTER(net_websocket_client_sample, LOG_LEVEL_DBG);
 #include <net/socket.h>
 #include <net/tls_credentials.h>
 #include <net/websocket.h>
+#include <random/rand32.h>
 #include <shell/shell.h>
 
 #include "ca_certificate.h"

--- a/samples/net/wpan_serial/src/main.c
+++ b/samples/net/wpan_serial/src/main.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(wpan_serial, CONFIG_USB_DEVICE_LOG_LEVEL);
 #include <drivers/uart.h>
 #include <zephyr.h>
 #include <usb/usb_device.h>
+#include <random/rand32.h>
 
 #include <net/buf.h>
 #include <net_private.h>

--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(net_dhcpv4, CONFIG_NET_DHCPV4_LOG_LEVEL);
 
 #include <errno.h>
 #include <inttypes.h>
+#include <random/rand32.h>
 #include <net/net_core.h>
 #include <net/net_pkt.h>
 #include <net/net_if.h>

--- a/subsys/net/ip/ipv4_autoconf.c
+++ b/subsys/net/ip/ipv4_autoconf.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(net_ipv4_autoconf, CONFIG_NET_IPV4_AUTO_LOG_LEVEL);
 #include <net/net_pkt.h>
 #include <net/net_core.h>
 #include <net/net_if.h>
+#include <random/rand32.h>
 
 #include "ipv4_autoconf_internal.h"
 

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -17,6 +17,7 @@ LOG_MODULE_DECLARE(net_ipv6, CONFIG_NET_IPV6_LOG_LEVEL);
 #include <net/net_stats.h>
 #include <net/net_context.h>
 #include <net/net_mgmt.h>
+#include <random/rand32.h>
 #include "net_private.h"
 #include "connection.h"
 #include "icmpv6.h"

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -14,6 +14,7 @@
 LOG_MODULE_REGISTER(net_ctx, CONFIG_NET_CONTEXT_LOG_LEVEL);
 
 #include <kernel.h>
+#include <random/rand32.h>
 #include <string.h>
 #include <errno.h>
 #include <stdbool.h>

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -10,6 +10,7 @@ LOG_MODULE_REGISTER(net_if, CONFIG_NET_IF_LOG_LEVEL);
 #include <init.h>
 #include <kernel.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 #include <syscall_handler.h>
 #include <stdlib.h>
 #include <string.h>

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(net_shell, LOG_LEVEL_DBG);
 
 #include <zephyr.h>
 #include <kernel_internal.h>
+#include <random/rand32.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <shell/shell.h>

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -11,6 +11,7 @@ LOG_MODULE_REGISTER(net_tcp, CONFIG_NET_TCP_LOG_LEVEL);
 #include <stdio.h>
 #include <stdlib.h>
 #include <zephyr.h>
+#include <random/rand32.h>
 #include <net/net_pkt.h>
 #include <net/net_context.h>
 #include <net/udp.h>

--- a/subsys/net/ip/tcp_internal.h
+++ b/subsys/net/ip/tcp_internal.h
@@ -14,6 +14,7 @@
 #define __TCP_INTERNAL_H
 
 #include <zephyr/types.h>
+#include <random/rand32.h>
 
 #include <net/net_core.h>
 #include <net/net_ip.h>

--- a/subsys/net/ip/trickle.c
+++ b/subsys/net/ip/trickle.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(net_trickle, CONFIG_NET_TRICKLE_LOG_LEVEL);
 
 #include <errno.h>
 #include <sys/util.h>
+#include <random/rand32.h>
 
 #include <net/net_core.h>
 #include <net/trickle.h>

--- a/subsys/net/l2/canbus/6locan.c
+++ b/subsys/net/l2/canbus/6locan.c
@@ -20,6 +20,7 @@ LOG_MODULE_REGISTER(net_l2_canbus, CONFIG_NET_L2_CANBUS_LOG_LEVEL);
 #include <net/ethernet.h>
 #include <net/net_ip.h>
 #include <string.h>
+#include <random/rand32.h>
 
 #define NET_CAN_WFTMAX 2
 #define NET_CAN_ALLOC_TIMEOUT K_MSEC(100)

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -14,6 +14,7 @@ LOG_MODULE_REGISTER(net_ethernet, CONFIG_NET_L2_ETHERNET_LOG_LEVEL);
 #include <net/ethernet.h>
 #include <net/ethernet_mgmt.h>
 #include <net/gptp.h>
+#include <random/rand32.h>
 
 #if defined(CONFIG_NET_LLDP)
 #include <net/lldp.h>

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -10,6 +10,7 @@ LOG_MODULE_REGISTER(net_gptp, CONFIG_NET_GPTP_LOG_LEVEL);
 #include <net/net_pkt.h>
 #include <ptp_clock.h>
 #include <net/ethernet_mgmt.h>
+#include <random/rand32.h>
 
 #include <net/gptp.h>
 

--- a/subsys/net/l2/ieee802154/ieee802154_radio_csma_ca.c
+++ b/subsys/net/l2/ieee802154/ieee802154_radio_csma_ca.c
@@ -11,6 +11,7 @@ LOG_MODULE_REGISTER(net_ieee802154_csma, CONFIG_NET_L2_IEEE802154_LOG_LEVEL);
 #include <net/net_if.h>
 
 #include <sys/util.h>
+#include <random/rand32.h>
 
 #include <stdlib.h>
 #include <errno.h>

--- a/subsys/net/l2/ppp/fsm.c
+++ b/subsys/net/l2/ppp/fsm.c
@@ -11,6 +11,7 @@ LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 #include <net/net_pkt.h>
 
 #include <net/ppp.h>
+#include <random/rand32.h>
 
 #include "net_private.h"
 

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -14,6 +14,7 @@
 LOG_MODULE_REGISTER(net_dns_resolve, CONFIG_DNS_RESOLVER_LOG_LEVEL);
 
 #include <zephyr/types.h>
+#include <random/rand32.h>
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>

--- a/subsys/net/lib/openthread/platform/settings.c
+++ b/subsys/net/lib/openthread/platform/settings.c
@@ -7,6 +7,7 @@
 #include <kernel.h>
 #include <logging/log.h>
 #include <settings/settings.h>
+#include <random/rand32.h>
 
 #include <openthread/platform/settings.h>
 

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <sys/util.h>
 #include <net/net_context.h>
 #include <net/socket.h>
+#include <random/rand32.h>
 #include <syscall_handler.h>
 #include <sys/fdtable.h>
 

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -26,6 +26,7 @@ LOG_MODULE_REGISTER(net_websocket, CONFIG_NET_WEBSOCKET_LOG_LEVEL);
 #include <net/http_client.h>
 #include <net/websocket.h>
 
+#include <random/rand32.h>
 #include <sys/byteorder.h>
 #include <sys/base64.h>
 #include <mbedtls/sha1.h>

--- a/subsys/random/CMakeLists.txt
+++ b/subsys/random/CMakeLists.txt
@@ -4,6 +4,7 @@ if (CONFIG_ENTROPY_DEVICE_RANDOM_GENERATOR OR
     CONFIG_TIMER_RANDOM_GENERATOR OR
     CONFIG_XOROSHIRO_RANDOM_GENERATOR)
 zephyr_library()
+zephyr_library_sources_ifdef(CONFIG_USERSPACE           rand32_handlers.c)
 endif()
 
 zephyr_library_sources_ifdef(CONFIG_TIMER_RANDOM_GENERATOR          rand32_timer.c)

--- a/subsys/random/rand32_ctr_drbg.c
+++ b/subsys/random/rand32_ctr_drbg.c
@@ -104,7 +104,7 @@ static int ctr_drbg_initialize(void)
 }
 
 
-int sys_csrand_get(void *dst, uint32_t outlen)
+int z_impl_sys_csrand_get(void *dst, uint32_t outlen)
 {
 	int ret;
 	unsigned int key = irq_lock();

--- a/subsys/random/rand32_entropy_device.c
+++ b/subsys/random/rand32_entropy_device.c
@@ -12,7 +12,7 @@
 static struct device *entropy_driver;
 
 #if defined(CONFIG_ENTROPY_DEVICE_RANDOM_GENERATOR)
-uint32_t sys_rand32_get(void)
+uint32_t z_impl_sys_rand32_get(void)
 {
 	struct device *dev = entropy_driver;
 	uint32_t random_num;
@@ -101,7 +101,7 @@ static int rand_get(uint8_t *dst, size_t outlen, bool csrand)
 }
 
 #if defined(CONFIG_ENTROPY_DEVICE_RANDOM_GENERATOR)
-void sys_rand_get(void *dst, size_t outlen)
+void z_impl_sys_rand_get(void *dst, size_t outlen)
 {
 	rand_get(dst, outlen, false);
 }
@@ -109,7 +109,7 @@ void sys_rand_get(void *dst, size_t outlen)
 
 #if defined(CONFIG_HARDWARE_DEVICE_CS_GENERATOR)
 
-int sys_csrand_get(void *dst, size_t outlen)
+int z_impl_sys_csrand_get(void *dst, size_t outlen)
 {
 	if (rand_get(dst, outlen, true) != 0) {
 		/* Is it the only error it should return ? entropy_sam

--- a/subsys/random/rand32_handlers.c
+++ b/subsys/random/rand32_handlers.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <random/rand32.h>
+#include <syscall_handler.h>
+
+
+static inline uint32_t z_vrfy_sys_rand32_get(void)
+{
+	return z_impl_sys_rand32_get();
+}
+#include <syscalls/sys_rand32_get_mrsh.c>
+
+static inline void z_vrfy_sys_rand_get(void *dst, size_t len)
+{
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(dst, len));
+
+	z_impl_sys_rand_get(dst, len);
+}
+#include <syscalls/sys_rand_get_mrsh.c>
+
+#if defined(CONFIG_CTR_DRBG_CSPRNG_GENERATOR)
+static inline int z_vrfy_sys_csrand_get(void *dst, size_t len)
+{
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(dst, len));
+
+	return z_impl_sys_csrand_get(dst, len);
+}
+#include <syscalls/sys_csrand_get_mrsh.c>
+#endif

--- a/subsys/random/rand32_timer.c
+++ b/subsys/random/rand32_timer.c
@@ -41,7 +41,7 @@ static atomic_val_t _rand32_counter;
  * @return a 32-bit number
  */
 
-uint32_t sys_rand32_get(void)
+uint32_t z_impl_sys_rand32_get(void)
 {
 	return k_cycle_get_32() + atomic_add(&_rand32_counter, _RAND32_INC);
 }
@@ -60,7 +60,7 @@ uint32_t sys_rand32_get(void)
  * @return N/A
  */
 
-void sys_rand_get(void *dst, size_t outlen)
+void z_impl_sys_rand_get(void *dst, size_t outlen)
 {
 	uint32_t len = 0;
 	uint32_t blocksize = 4;

--- a/subsys/random/rand32_xoroshiro128.c
+++ b/subsys/random/rand32_xoroshiro128.c
@@ -87,7 +87,7 @@ static uint32_t xoroshiro128_next(void)
 	return (uint32_t)result;
 }
 
-uint32_t sys_rand32_get(void)
+uint32_t z_impl_sys_rand32_get(void)
 {
 	uint32_t ret;
 
@@ -96,7 +96,7 @@ uint32_t sys_rand32_get(void)
 	return ret;
 }
 
-void sys_rand_get(void *dst, size_t outlen)
+void z_impl_sys_rand_get(void *dst, size_t outlen)
 {
 	uint32_t ret;
 	uint32_t blocksize = 4;

--- a/tests/benchmarks/mbedtls/src/benchmark.c
+++ b/tests/benchmarks/mbedtls/src/benchmark.c
@@ -69,6 +69,7 @@
 
 #include <zephyr/types.h>
 #include <sys/byteorder.h>
+#include <random/rand32.h>
 
 #include "kernel.h"
 

--- a/tests/crypto/rand32/src/main.c
+++ b/tests/crypto/rand32/src/main.c
@@ -15,6 +15,7 @@
 
 #include <ztest.h>
 #include <kernel_internal.h>
+#include <random/rand32.h>
 
 #define N_VALUES 10
 

--- a/tests/crypto/tinycrypt/src/ecc_dsa.c
+++ b/tests/crypto/tinycrypt/src/ecc_dsa.c
@@ -67,6 +67,7 @@
 #include <test_utils.h>
 #include "test_ecc_utils.h"
 #include <sys/util.h>
+#include <random/rand32.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/kernel/sched/deadline/src/main.c
+++ b/tests/kernel/sched/deadline/src/main.c
@@ -5,6 +5,7 @@
  */
 #include <zephyr.h>
 #include <ztest.h>
+#include <random/rand32.h>
 
 #define NUM_THREADS 8
 #define STACK_SIZE (256 + CONFIG_TEST_EXTRA_STACKSIZE)

--- a/tests/kernel/timer/timer_api/src/timer_convert.c
+++ b/tests/kernel/timer/timer_api/src/timer_convert.c
@@ -6,6 +6,7 @@
 #include <ztest.h>
 #include <zephyr/types.h>
 #include <sys/time_units.h>
+#include <random/rand32.h>
 
 #define NUM_RANDOM 100
 

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -25,6 +25,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_ARP_LOG_LEVEL);
 #include <net/net_ip.h>
 #include <net/dummy.h>
 #include <ztest.h>
+#include <random/rand32.h>
 
 #include "arp.h"
 

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <errno.h>
 #include <sys/printk.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/context/src/main.c
+++ b/tests/net/context/src/main.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_CONTEXT_LOG_LEVEL);
 #include <errno.h>
 #include <sys/printk.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <tc_util.h>
 

--- a/tests/net/hostname/src/main.c
+++ b/tests/net/hostname/src/main.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
+#include <random/rand32.h>
 #include <sys/printk.h>
 #include <linker/sections.h>
 

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <errno.h>
 #include <sys/printk.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/ip-addr/src/main.c
+++ b/tests/net/ip-addr/src/main.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 #include <device.h>
 #include <init.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 #include <string.h>
 #include <errno.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/ipv6_fragment/src/main.c
+++ b/tests/net/ipv6_fragment/src/main.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 #include <errno.h>
 #include <sys/printk.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/lib/dns_addremove/src/main.c
+++ b/tests/net/lib/dns_addremove/src/main.c
@@ -13,6 +13,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_DNS_RESOLVER_LOG_LEVEL);
 #include <string.h>
 #include <errno.h>
 #include <sys/printk.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/lib/dns_resolve/src/main.c
+++ b/tests/net/lib/dns_resolve/src/main.c
@@ -13,6 +13,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_DNS_RESOLVER_LOG_LEVEL);
 #include <string.h>
 #include <errno.h>
 #include <sys/printk.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/lib/mqtt_publisher/src/test_mqtt_publish.c
+++ b/tests/net/lib/mqtt_publisher/src/test_mqtt_publish.c
@@ -14,6 +14,8 @@ LOG_MODULE_REGISTER(net_test, LOG_LEVEL_WRN);
 #include <string.h>
 #include <errno.h>
 
+#include <random/rand32.h>
+
 #include "config.h"
 
 /* This is mqtt payload message. */

--- a/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
+++ b/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
@@ -10,6 +10,7 @@ LOG_MODULE_REGISTER(net_test, LOG_LEVEL_WRN);
 #include <ztest.h>
 #include <net/socket.h>
 #include <net/mqtt.h>
+#include <random/rand32.h>
 
 #include <string.h>
 #include <errno.h>

--- a/tests/net/lib/mqtt_subscriber/src/test_mqtt_subscribe.c
+++ b/tests/net/lib/mqtt_subscriber/src/test_mqtt_subscribe.c
@@ -10,6 +10,7 @@ LOG_MODULE_REGISTER(net_test, LOG_LEVEL_WRN);
 #include <ztest.h>
 #include <net/socket.h>
 #include <net/mqtt.h>
+#include <random/rand32.h>
 
 #include <string.h>
 #include <errno.h>

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -27,6 +27,8 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 #include <net/net_mgmt.h>
 #include <net/net_event.h>
 
+#include <random/rand32.h>
+
 #include "icmpv6.h"
 #include "ipv6.h"
 

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -12,6 +12,7 @@
 #include <net/net_if.h>
 #include <net/net_ip.h>
 #include <net/ethernet.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -9,6 +9,7 @@
 #include <zephyr.h>
 #include <linker/sections.h>
 #include <ztest.h>
+#include <random/rand32.h>
 
 #include <net/ethernet.h>
 #include <net/dummy.h>

--- a/tests/net/ptp/clock/src/main.c
+++ b/tests/net/ptp/clock/src/main.c
@@ -29,6 +29,8 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <net/net_ip.h>
 #include <net/net_l2.h>
 
+#include <random/rand32.h>
+
 #define NET_LOG_ENABLED 1
 #include "net_private.h"
 

--- a/tests/net/route/src/main.c
+++ b/tests/net/route/src/main.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_ROUTE_LOG_LEVEL);
 #include <errno.h>
 #include <sys/printk.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <tc_util.h>
 

--- a/tests/net/shell/src/main.c
+++ b/tests/net/shell/src/main.c
@@ -29,6 +29,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <net/ethernet.h>
 #include <net/dummy.h>
 #include <net/udp.h>
+#include <random/rand32.h>
 
 #include "ipv4.h"
 #include "ipv6.h"

--- a/tests/net/traffic_class/src/main.c
+++ b/tests/net/traffic_class/src/main.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <errno.h>
 #include <sys/printk.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/tx_timestamp/src/main.c
+++ b/tests/net/tx_timestamp/src/main.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <errno.h>
 #include <sys/printk.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/udp/src/main.c
+++ b/tests/net/udp/src/main.c
@@ -29,6 +29,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <net/ethernet.h>
 #include <net/dummy.h>
 #include <net/udp.h>
+#include <random/rand32.h>
 
 #include "ipv4.h"
 #include "ipv6.h"

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <errno.h>
 #include <sys/printk.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 


### PR DESCRIPTION
Create syscalls to make possible using random APIs from user mode
threads. These APIs can have different implementations, like using
entropy driver or Xoroshiro128. Some of these implementations also have
some globals to preserve state between calls.

Make it run entire in user space would require user adding these globals
to their memeory domains and/or grant access to entropy device. Syscalls
simplify its usage.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>

Fixes #26499