### PR TITLE
samples/drivers/spi_flash: add some efr32 boards

### DIFF
--- a/samples/drivers/spi_flash/boards/efr32_radio_brd4104a.conf
+++ b/samples/drivers/spi_flash/boards/efr32_radio_brd4104a.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2020 Lemonbeat GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_SPI_NOR=y

--- a/samples/drivers/spi_flash/boards/efr32_radio_brd4250b.conf
+++ b/samples/drivers/spi_flash/boards/efr32_radio_brd4250b.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2020 Lemonbeat GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_SPI_NOR=y

--- a/samples/drivers/spi_flash/boards/efr32mg_sltb004a.conf
+++ b/samples/drivers/spi_flash/boards/efr32mg_sltb004a.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2020 Lemonbeat GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_SPI_NOR=y


### PR DESCRIPTION
The boards efr32_radio_brd4104a, efr32_radio_brd4250b and
efr32mg_sltb004a have an on-board nor flash. It is already present in
the device tree, only the driver needs to be enabled.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>