### PR TITLE
samples/drivers/spi_flash: fix sample regex

### DIFF
--- a/samples/drivers/spi_flash/sample.yaml
+++ b/samples/drivers/spi_flash/sample.yaml
@@ -12,9 +12,8 @@ tests:
             - "Test 1: Flash erase"
             - "Flash erase succeeded!"
             - "Test 2: Flash write"
-            - "Attempted to write 55 aa"
-            - "Data read 55 aa"
-            - "Data read matches with data written. Good!!"
+            - "Attempting to write 4 bytes"
+            - "Data read matches data written. Good!!"
     depends_on: spi
   sample.drivers.spi.flash_dpd:
     tags: spi flash


### PR DESCRIPTION
The sample.yml regex did not match the implementation anymore.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>