### PR TITLE
net: ipv6: Also look for nexthop in nbr list

### DIFF
--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -880,7 +880,16 @@ ignore_frag_error:
 		if (net_if_ipv6_addr_onlink(&iface, nexthop)) {
 			net_pkt_set_iface(pkt, iface);
 		} else {
-			iface = net_pkt_iface(pkt);
+			/* nexthop might be the nbr list, e.g. a link-local
+			 * address of a connected peer.
+			 */
+			nbr = net_ipv6_nbr_lookup(NULL, nexthop);
+			if (nbr) {
+				iface = nbr->iface;
+				net_pkt_set_iface(pkt, iface);
+			} else {
+				iface = net_pkt_iface(pkt);
+			}
 		}
 
 		/* If the above check returns null, we try to send


### PR DESCRIPTION
This change fixes routing for routes when the nexthop is a link-local
address of a connected peer.

The issue was that nexthop was correctly set from the routes, but the
code did not detect that the nexthop address (link local of the pc on
ppp interface) was on the ppp interface, because net_if_ipv6_addr_onlink()
only evaluated the network prefix and not any other information (like
the nbr list).

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>