### PR TITLE
json: Add top-level array encoding support

### DIFF
--- a/include/data/json.h
+++ b/include/data/json.h
@@ -655,6 +655,24 @@ int json_obj_encode_buf(const struct json_obj_descr *descr, size_t descr_len,
 			const void *val, char *buffer, size_t buf_size);
 
 /**
+ * @brief Encodes an array in a contiguous memory location
+ *
+ * @param descr Pointer to the descriptor array
+ *
+ * @param val Struct holding the values
+ *
+ * @param buffer Buffer to store the JSON data
+ *
+ * @param buf_size Size of buffer, in bytes, with space for the terminating
+ * NUL character
+ *
+ * @return 0 if object has been successfully encoded. A negative value
+ * indicates an error (as defined on errno.h).
+ */
+int json_arr_encode_buf(const struct json_obj_descr *descr, const void *val,
+			char *buffer, size_t buf_size);
+
+/**
  * @brief Encodes an object using an arbitrary writer function
  *
  * @param descr Pointer to the descriptor array
@@ -674,6 +692,24 @@ int json_obj_encode_buf(const struct json_obj_descr *descr, size_t descr_len,
 int json_obj_encode(const struct json_obj_descr *descr, size_t descr_len,
 		    const void *val, json_append_bytes_t append_bytes,
 		    void *data);
+
+/**
+ * @brief Encodes an array using an arbitrary writer function
+ *
+ * @param descr Pointer to the descriptor array
+ *
+ * @param val Struct holding the values
+ *
+ * @param append_bytes Function to append bytes to the output
+ *
+ * @param data Data pointer to be passed to the append_bytes callback
+ * function.
+ *
+ * @return 0 if object has been successfully encoded. A negative value
+ * indicates an error.
+ */
+int json_arr_encode(const struct json_obj_descr *descr, const void *val,
+		    json_append_bytes_t append_bytes, void *data);
 
 #ifdef __cplusplus
 }

--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -865,6 +865,15 @@ int json_obj_encode(const struct json_obj_descr *descr, size_t descr_len,
 	return append_bytes("}", 1, data);
 }
 
+int json_arr_encode(const struct json_obj_descr *descr, const void *val,
+		    json_append_bytes_t append_bytes, void *data)
+{
+	void *ptr = (char *)val + descr->offset;
+
+	return arr_encode(descr->array.element_descr, ptr, val, append_bytes,
+			  data);
+}
+
 struct appender {
 	char *buffer;
 	size_t used;
@@ -893,6 +902,14 @@ int json_obj_encode_buf(const struct json_obj_descr *descr, size_t descr_len,
 
 	return json_obj_encode(descr, descr_len, val, append_bytes_to_buf,
 			       &appender);
+}
+
+int json_arr_encode_buf(const struct json_obj_descr *descr, const void *val,
+			char *buffer, size_t buf_size)
+{
+	struct appender appender = { .buffer = buffer, .size = buf_size };
+
+	return json_arr_encode(descr, val, append_bytes_to_buf, &appender);
 }
 
 static int measure_bytes(const char *bytes, size_t len, void *data)


### PR DESCRIPTION
The library supports the declaration of JSON arrays as both nested and
top-level elements. However, as the provided encoding functions
`json_obj_encode()` and `json_obj_encode_buf()` interpret all input
structures as objects, top-level arrays are encoded as

`{"<field_name>":[{...},...,{...}]}`

instead of

`[{...},...,{...}]`.

Add new functions `json_arr_encode()` and `json_arr_encode_buf()` that
enable top-level JSON array encoding.