### PR TITLE
tests: fix text output in timing_info test

### DIFF
--- a/tests/benchmarks/timing_info/src/main_benchmark.c
+++ b/tests/benchmarks/timing_info/src/main_benchmark.c
@@ -33,7 +33,7 @@ void main(void)
 	benchmark_timer_start();
 
 	TC_START("Time Measurement");
-	TC_PRINT("Timing Results: Clock Frequency: %u MHz\n", freq);
+	TC_PRINT("Timing results: Clock frequency: %u MHz\n", freq);
 
 	/*******************************************************************/
 	/* System parameters and thread Benchmarking*/
@@ -66,7 +66,7 @@ void main(void)
 #endif
 
 
-	TC_PRINT("Timing Measurement  finished\n");
+	TC_PRINT("Time Measurement finished\n");
 
 	/* for sanity regression test utility. */
 	TC_END_RESULT(TC_PASS);

--- a/tests/benchmarks/timing_info/src/msg_passing_bench.c
+++ b/tests/benchmarks/timing_info/src/msg_passing_bench.c
@@ -284,42 +284,42 @@ void msg_passing_bench(void)
 	/*******************************************************************/
 
 	/* Only print lower 32bit of time result */
-	PRINT_STATS("Message Queue Put with context switch",
+	PRINT_STATS("Message queue put with context switch",
 		    (uint32_t)((__msg_q_put_w_cxt_end_time -
 			     __msg_q_put_w_cxt_start_time) & 0xFFFFFFFFULL),
 		    (uint32_t) (total_msg_q_put_w_cxt_time  & 0xFFFFFFFFULL));
 
-	PRINT_STATS("Message Queue Put without context switch",
+	PRINT_STATS("Message queue put without context switch",
 		    (uint32_t)((__msg_q_put_wo_cxt_end_time -
 			     __msg_q_put_wo_cxt_start_time) & 0xFFFFFFFFULL),
 		    (uint32_t) (total_msg_q_put_wo_cxt_time  & 0xFFFFFFFFULL));
 
-	PRINT_STATS("Message Queue get with context switch",
+	PRINT_STATS("Message queue get with context switch",
 		    (uint32_t)((__msg_q_get_w_cxt_end_time -
 			     __msg_q_get_w_cxt_start_time) & 0xFFFFFFFFULL),
 		    (uint32_t) (total_msg_q_get_w_cxt_time & 0xFFFFFFFFULL));
 
-	PRINT_STATS("Message Queue get without context switch",
+	PRINT_STATS("Message queue get without context switch",
 		    (uint32_t)((msg_q_get_wo_cxt_end_time -
 			     msg_q_get_wo_cxt_start_time) & 0xFFFFFFFFULL),
 		    (uint32_t) (total_msg_q_get_wo_cxt_time  & 0xFFFFFFFFULL));
 
-	PRINT_STATS("MailBox synchronous put",
+	PRINT_STATS("Mailbox synchronous put",
 		    (uint32_t)((mbox_sync_put_end_time - mbox_sync_put_start_time)
 			    & 0xFFFFFFFFULL),
 		    (uint32_t) (total_mbox_sync_put_time  & 0xFFFFFFFFULL));
 
-	PRINT_STATS("MailBox synchronous get",
+	PRINT_STATS("Mailbox synchronous get",
 		    (uint32_t)((mbox_sync_get_end_time - mbox_sync_get_start_time)
 			    & 0xFFFFFFFFULL),
 		    (uint32_t) (total_mbox_sync_get_time  & 0xFFFFFFFFULL));
 
-	PRINT_STATS("MailBox asynchronous put",
+	PRINT_STATS("Mailbox asynchronous put",
 		    (uint32_t)((mbox_async_put_end_time - mbox_async_put_start_time)
 			    & 0xFFFFFFFFULL),
 		    (uint32_t) (total_mbox_async_put_time  & 0xFFFFFFFFULL));
 
-	PRINT_STATS("MailBox get without context switch",
+	PRINT_STATS("Mailbox get without context switch",
 		    (uint32_t)((mbox_get_w_cxt_end_time - mbox_get_w_cxt_start_time)
 			    & 0xFFFFFFFFULL),
 		    (uint32_t) (total_mbox_get_w_cxt_time  & 0xFFFFFFFFULL));

--- a/tests/benchmarks/timing_info/src/semaphore_bench.c
+++ b/tests/benchmarks/timing_info/src/semaphore_bench.c
@@ -104,15 +104,15 @@ void semaphore_bench(void)
 	/* TC_PRINT("test_time1 , %d cycles\n", (uint32_t)test_time1); */
 	/* TC_PRINT("test_time2 , %d cycles\n", (uint32_t)test_time2); */
 
-	PRINT_STATS("Semaphore Take with context switch",
+	PRINT_STATS("Semaphore take with context switch",
 		sem_cycles, CYCLES_TO_NS(sem_cycles));
-	PRINT_STATS("Semaphore Give with context switch",
+	PRINT_STATS("Semaphore give with context switch",
 		sem_give_cycles, CYCLES_TO_NS(sem_give_cycles));
 
-	PRINT_STATS("Semaphore Take without context switch",
+	PRINT_STATS("Semaphore take without context switch",
 		sem_take_wo_cxt_cycles,
 		CYCLES_TO_NS(sem_take_wo_cxt_cycles));
-	PRINT_STATS("Semaphore Give without context switch",
+	PRINT_STATS("Semaphore give without context switch",
 		sem_give_wo_cxt_cycles,
 		CYCLES_TO_NS(sem_give_wo_cxt_cycles));
 

--- a/tests/benchmarks/timing_info/src/thread_bench.c
+++ b/tests/benchmarks/timing_info/src/thread_bench.c
@@ -233,7 +233,7 @@ void system_thread_bench(void)
 		(uint32_t) (CYCLES_TO_NS(tick_overhead_cycles)));
 
 	/*thread creation*/
-	PRINT_STATS("Thread Creation",
+	PRINT_STATS("Thread creation",
 		(uint32_t)((thread_create_end_time - thread_create_start_time) &
 			   0xFFFFFFFFULL),
 		(uint32_t) ((total_thread_create_time) & 0xFFFFFFFFULL));
@@ -251,13 +251,13 @@ void system_thread_bench(void)
 		(uint32_t) (total_thread_abort_time  & 0xFFFFFFFFULL));
 
 	/*thread suspend*/
-	PRINT_STATS("Thread Suspend",
+	PRINT_STATS("Thread suspend",
 		(uint32_t)((thread_suspend_end_time - thread_suspend_start_time) &
 			   0xFFFFFFFFULL),
 		(uint32_t) (total_thread_suspend_time  & 0xFFFFFFFFULL));
 
 	/*thread resume*/
-	PRINT_STATS("Thread Resume",
+	PRINT_STATS("Thread resume",
 		(uint32_t)((thread_resume_end_time - thread_suspend_end_time)
 			   & 0xFFFFFFFFULL),
 		(uint32_t) (total_thread_resume_time  & 0xFFFFFFFFULL));
@@ -315,10 +315,10 @@ void heap_malloc_free_bench(void)
 		sum_free += heap_free_end_time - heap_free_start_time;
 	}
 
-	PRINT_STATS("Heap Malloc",
+	PRINT_STATS("Heap malloc",
 		(uint32_t)((sum_malloc / count) & 0xFFFFFFFFULL),
 		(uint32_t)(CYCLES_TO_NS(sum_malloc / count)));
-	PRINT_STATS("Heap Free",
+	PRINT_STATS("Heap free",
 		(uint32_t)((sum_free / count) & 0xFFFFFFFFULL),
 		(uint32_t)(CYCLES_TO_NS(sum_free / count)));
 

--- a/tests/benchmarks/timing_info/src/userspace_bench.c
+++ b/tests/benchmarks/timing_info/src/userspace_bench.c
@@ -148,7 +148,7 @@ void user_thread_creation(void)
 
 	total_user_thread_creation_time = CYCLES_TO_NS(total_cycles);
 
-	PRINT_STATS("User thread Creation",
+	PRINT_STATS("User thread creation",
 		    total_cycles,
 		    (uint32_t) (total_user_thread_creation_time  & 0xFFFFFFFFULL));
 
@@ -272,12 +272,12 @@ void validation_overhead(void)
 	uint32_t  total_validation_overhead_obj_time =
 		CYCLES_TO_NS(total_cycles_obj);
 
-	PRINT_STATS("Validation overhead k object init",
+	PRINT_STATS("Validation overhead k_object init",
 		    total_cycles_obj_init,
 		    (uint32_t) (total_validation_overhead_obj_init_time  &
 			     0xFFFFFFFFULL));
 
-	PRINT_STATS("Validation overhead k object permission",
+	PRINT_STATS("Validation overhead k_object permission",
 		    total_cycles_obj,
 		    (uint32_t) (total_validation_overhead_obj_time  &
 			     0xFFFFFFFFULL));

--- a/tests/benchmarks/timing_info/src/yield_bench.c
+++ b/tests/benchmarks/timing_info/src/yield_bench.c
@@ -58,9 +58,9 @@ void yield_bench(void)
 	uint32_t yield_cycles = (thread_end_time - thread_start_time) / 2000U;
 	uint32_t sleep_cycles = thread_sleep_end_time - thread_sleep_start_time;
 
-	PRINT_STATS("Thread Yield", yield_cycles,
+	PRINT_STATS("Thread yield", yield_cycles,
 		CYCLES_TO_NS(yield_cycles));
-	PRINT_STATS("Thread Sleep", sleep_cycles,
+	PRINT_STATS("Thread sleep", sleep_cycles,
 		CYCLES_TO_NS(sleep_cycles));
 
 }


### PR DESCRIPTION
After reviewing that test I found output looks too messy.
1. Remove words starting from capital letter in the middle of the
sentence.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>