### PR TITLE
net: sockets: Fix socket ctx check in usermode

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -51,7 +51,7 @@ static inline void *get_sock_vtable(
 				      (const struct fd_op_vtable **)vtable);
 
 #ifdef CONFIG_USERSPACE
-	if (z_is_in_user_syscall()) {
+	if (ctx != NULL && z_is_in_user_syscall()) {
 		struct z_object *zo;
 		int ret;
 


### PR DESCRIPTION
When `z_get_fd_obj_and_vtable()` function returns NULL (no valid entry
in the FD table for the socket), there is no need for further usermode
checks on the `ctx` pointer, as there is nothing to invalidate in that
case.

Fixes #25990
Fixes #25991

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>