### PR TITLE
drivers: i2c: Check non-null pointer before dereferencing in i2c shell

### DIFF
--- a/drivers/i2c/i2c_shell.c
+++ b/drivers/i2c/i2c_shell.c
@@ -233,9 +233,9 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 	entry->subcmd = &dsub_device_name;
 
 	for (dev = __device_start; dev != __device_end; dev++) {
-		if ((dev->driver_api != NULL) &&
+		if ((dev->driver_api != NULL) && (dev->name != NULL) &&
 		    strstr(dev->name, I2C_DEVICE_PREFIX) != NULL &&
-		    strcmp(dev->name, "") && (dev->name != NULL)) {
+		    strcmp(dev->name, "")) {
 			if (idx == device_idx) {
 				entry->syntax = dev->name;
 				break;


### PR DESCRIPTION
Fixes the i2c shell to check the device name pointer is non-null before
dereferencing it.

Coverity CID: 210558

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #25786