### PR TITLE
drivers: sensor: Check i2c device pointer is non-null in bq274xx

### DIFF
--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -365,7 +365,7 @@ static int bq274xx_gauge_init(struct device *dev)
 		(uint16_t)config->design_capacity / (0.1 * config->taper_current);
 
 	bq274xx->i2c = device_get_binding(config->bus_name);
-	if (bq274xx == NULL) {
+	if (bq274xx->i2c == NULL) {
 		LOG_ERR("Could not get pointer to %s device.",
 			config->bus_name);
 		return -EINVAL;


### PR DESCRIPTION
Fixes the bq274xx sensor driver to check the i2c device pointer is
non-null, rather than the bq274xx sensor device pointer. This appears to
be the originally intended check based on the LOG_ERR message.

Coverity CID: 210035

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #25782

cc: @parthitce 