### PR TITLE
libc: newlib: assert: Override handler for C std assert

### DIFF
--- a/lib/libc/newlib/CMakeLists.txt
+++ b/lib/libc/newlib/CMakeLists.txt
@@ -3,6 +3,8 @@
 zephyr_library()
 zephyr_library_sources(libc-hooks.c)
 
+zephyr_library_sources_ifdef(CONFIG_ASSERT assert.c)
+
 # Zephyr normally uses -ffreestanding, which with current GNU toolchains
 # means that the flag macros used by newlib 3.x <inttypes.h> to signal
 # support for PRI.64 macros are not present.  To make them available we
@@ -47,4 +49,3 @@ if(CONFIG_NEWLIB_LIBC_NANO)
     -specs=nano.specs
     )
 endif()
-

--- a/lib/libc/newlib/assert.c
+++ b/lib/libc/newlib/assert.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <sys/__assert.h>
+
+/**
+ *
+ * @brief Handler of C standard library assert.
+ */
+void __assert_func(const char *file,
+		int line,
+		const char *func,
+		const char *failedexpr)
+{
+	__ASSERT_LOC(...);
+	__ASSERT_MSG_INFO("Assertion fail: (%s) at %s:%d",
+			failedexpr, file, line);
+	__ASSERT_POST_ACTION();
+}


### PR DESCRIPTION
Libraries using standard C assert from <assert.h> did not give useful
information on assertion fault, as default newlib implementation tries
to print assert info to stderr. It causes another assertion in Zephyr.

With this patch, the default handler is overridden to use native Zephyr
assert macros and give useful info when assertion fails.