### PR TITLE
samples: canbus: canopen: add test case with program download support

### DIFF
--- a/samples/subsys/canbus/canopen/sample.yaml
+++ b/samples/subsys/canbus/canopen/sample.yaml
@@ -1,12 +1,17 @@
 sample:
   name: CANopen sample
+common:
+  tags: can canopen
+  depends_on: can
+  platform_whitelist: twr_ke18f frdm_k64f
+  harness: console
+  harness_config:
+    type: one_line
+    regex:
+      - "(.*)CANopen stack initialized"
 tests:
   sample.subsys.canbus.canopen:
-    tags: CAN
-    depends_on: can
-    platform_whitelist: twr_ke18f frdm_k64f
-    harness: console
-    harness_config:
-      type: one_line
-      regex:
-        - "(.*)CANopen stack initialized"
+    tags: introduction
+  sample.subsys.canbus.canopen.program_download:
+    extra_configs:
+      - CONFIG_BOOTLOADER_MCUBOOT=y


### PR DESCRIPTION
Add a test case for building with program download support enabled.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>