### PR TITLE
boards: arm: lpcxpresso55s16: add arduino gpio and mikrobus headers

### DIFF
--- a/boards/arm/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
+++ b/boards/arm/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
@@ -55,6 +55,59 @@
 			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	mikrobus_header: mikrobus-connector {
+		compatible = "mikro-bus";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<0 0 &gpio0 16 0>,	/* AN  */
+				/* Not a GPIO*/		/* RST */
+				<2 0 &gpio1 1 0>,	/* CS   */
+				<3 0 &gpio1 2 0>,	/* SCK  */
+				<4 0 &gpio1 3 0>,	/* MISO */
+				<5 0 &gpio0 26 0>,	/* MOSI */
+							/* +3.3V */
+							/* GND */
+				<6 0 &gpio1 5 0>,	/* PWM  */
+				<7 0 &gpio1 18 0>,	/* INT  */
+				<8 0 &gpio1 24 0>,	/* RX   */
+				<9 0 &gpio0 27 0>,	/* TX   */
+				<10 0 &gpio1 20 0>,	/* SCL  */
+				<11 0 &gpio1 21 0>;	/* SDA  */
+							/* +5V */
+							/* GND */
+	};
+
+	arduino_header: arduino-connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<0 0 &gpio0 16 0>,	/* A0 */
+				<1 0 &gpio0 23 0>,	/* A1 */
+				<2 0 &gpio0 0 0>,	/* A2 */
+				/* R63 DNP, A3 not connected  */
+				/* <3 0 &gpio1 31 0>,*/	/* A3 */
+				<4 0 &gpio0 13 0>,	/* A4 */
+				<5 0 &gpio0 14 0>,	/* A5 */
+				<6 0 &gpio1 24 0>,	/* D0 */
+				<7 0 &gpio0 27 0>,	/* D1 */
+				<8 0 &gpio0 15 0>,	/* D2 */
+				<9 0 &gpio1 6 0>,	/* D3 */
+				<10 0 &gpio1 7 0>,	/* D4 */
+				<11 0 &gpio1 4 0>,	/* D5 */
+				<12 0 &gpio1 10 0>,	/* D6 */
+				<13 0 &gpio1 9 0>,	/* D7 */
+				<14 0 &gpio1 8 0>,	/* D8 */
+				<15 0 &gpio1 5 0>,	/* D9 */
+				<16 0 &gpio1 1 0>,	/* D10 */
+				<17 0 &gpio0 26 0>,	/* D11 */
+				<18 0 &gpio1 3 0>,	/* D12 */
+				<19 0 &gpio1 2 0>,	/* D13 */
+				<20 0 &gpio1 21 0>,	/* D14 */
+				<21 0 &gpio1 20 0>;	/* D15 */
+	};
 };
 
 &flexcomm0 {
@@ -63,7 +116,7 @@
 	current-speed = <115200>;
 };
 
-arduino_i2c: &flexcomm4 {
+&flexcomm4 {
 	status = "okay";
 	compatible = "nxp,lpc-i2c";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
@@ -78,6 +131,14 @@ arduino_i2c: &flexcomm4 {
 	};
 };
 
-arduino_spi: &hs_lspi {
+&hs_lspi {
 	status = "okay";
 };
+
+arduino_i2c: &flexcomm4 {};
+
+arduino_spi: &hs_lspi {};
+
+mikrobus_i2c: &flexcomm4 {};
+
+mikrobus_spi: &hs_lspi {};

--- a/boards/arm/lpcxpresso55s16/lpcxpresso55s16_ns.yaml
+++ b/boards/arm/lpcxpresso55s16/lpcxpresso55s16_ns.yaml
@@ -15,6 +15,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_gpio
   - arduino_i2c
   - arduino_spi
   - gpio

--- a/samples/shields/x_nucleo_iks01a2/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a2/sample.yaml
@@ -5,4 +5,4 @@ tests:
     harness: shield
     tags: shield
     depends_on: arduino_i2c arduino_gpio
-    platform_exclude: disco_l475_iot1 stm32mp157c_dk2
+    platform_exclude: disco_l475_iot1 lpcxpresso55s16_ns stm32mp157c_dk2

--- a/samples/shields/x_nucleo_iks01a3/sensorhub/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a3/sensorhub/sample.yaml
@@ -5,4 +5,4 @@ tests:
     harness: shield
     tags: shield
     depends_on: arduino_i2c arduino_gpio
-    platform_exclude: disco_l475_iot1 stm32mp157c_dk2
+    platform_exclude: disco_l475_iot1 lpcxpresso55s16_ns stm32mp157c_dk2

--- a/samples/shields/x_nucleo_iks01a3/standard/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a3/standard/sample.yaml
@@ -7,4 +7,4 @@ tests:
     harness: shield
     tags: shield
     depends_on: arduino_i2c arduino_gpio
-    platform_exclude: disco_l475_iot1 stm32mp157c_dk2
+    platform_exclude: disco_l475_iot1 lpcxpresso55s16_ns stm32mp157c_dk2

--- a/samples/shields/x_nucleo_iks02a1/sensorhub/sample.yaml
+++ b/samples/shields/x_nucleo_iks02a1/sensorhub/sample.yaml
@@ -5,4 +5,4 @@ tests:
     harness: shield
     tags: shield
     depends_on: arduino_i2c arduino_gpio
-    platform_exclude: disco_l475_iot1 stm32mp157c_dk2
+    platform_exclude: disco_l475_iot1 lpcxpresso55s16_ns stm32mp157c_dk2

--- a/samples/shields/x_nucleo_iks02a1/standard/sample.yaml
+++ b/samples/shields/x_nucleo_iks02a1/standard/sample.yaml
@@ -7,4 +7,4 @@ tests:
     harness: shield
     tags: shield
     depends_on: arduino_i2c arduino_gpio
-    platform_exclude: disco_l475_iot1 stm32mp157c_dk2
+    platform_exclude: disco_l475_iot1 lpcxpresso55s16_ns stm32mp157c_dk2


### PR DESCRIPTION
Add devicetree nodes for the Arduino GPIO and MikroElektronika mikroBUS headers present on the NXP LPCXpresso55S16 development board.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>