### PR TITLE
drivers: spi: rv32m1_lpspi: Fix null tx

### DIFF
--- a/drivers/spi/spi_rv32m1_lpspi.c
+++ b/drivers/spi/spi_rv32m1_lpspi.c
@@ -191,6 +191,8 @@ static int spi_mcux_configure(struct device *dev,
 	LPSPI_MasterTransferCreateHandle(base, &data->handle,
 					spi_mcux_master_transfer_callback, dev);
 
+	LPSPI_SetDummyData(base, 0);
+
 	data->ctx.config = spi_cfg;
 	spi_context_cs_configure(&data->ctx);
 


### PR DESCRIPTION
Initialize the dummy data transfer so spi transfer is defined even for
an undefined tx data buffer.
This is part of a fix for #20589, together with PR #26031