### PR TITLE
tests: kernel: timer_api: remove extra adjustment to expected result

### DIFF
--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -566,7 +566,7 @@ void test_timer_user_data(void)
 void test_timer_remaining(void)
 {
 	uint32_t dur_ticks = k_ms_to_ticks_ceil32(DURATION);
-	uint32_t target_rem_ticks = k_ms_to_ticks_ceil32(DURATION / 2) + 1;
+	uint32_t target_rem_ticks = k_ms_to_ticks_ceil32(DURATION / 2);
 	uint32_t rem_ms, rem_ticks, exp_ticks;
 	int32_t delta_ticks;
 	uint32_t slew_ticks;


### PR DESCRIPTION
The converted target value for remaining ticks was increased by one to match original code, which used a one-sided test.  The current test is two-sided, so that increment is already present in the allowed 1 tick error for boards with no slew, and incorporating it into the absolute error can cause the test to fail..

Fixes #26039