### PR TITLE
doc: api_lifecycle: Use DEPRECATED instead of LEGACY in Kconfig

### DIFF
--- a/doc/development_process/api_lifecycle.rst
+++ b/doc/development_process/api_lifecycle.rst
@@ -201,7 +201,7 @@ The following are the requirements for deprecating an existing API:
   - Mark as deprecated. This can be done by using the compiler itself
     (``__deprecated`` for  function declarations and ``__DEPRECATED_MACRO`` for
     macro definitions), or by introducing a Kconfig option (typically one that
-    contains the ``LEGACY`` word in it) that, when enabled, reverts the APIs
+    contains the ``DEPRECATED`` word in it) that, when enabled, reverts the APIs
     back to their previous form
   - Document the deprecation
   - Include the deprecation in the "API Changes" of the release notes for the


### PR DESCRIPTION
Recommend that Kconfig symbols related to deprecated features use
'DEPRECATED' in the symbol name instead of 'LEGACY'.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>