### PR TITLE
global: Fix zero-length array GNU C extension usage

### DIFF
--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -74,7 +74,7 @@ struct rng_pool {
 	uint8_t last;
 	uint8_t mask;
 	uint8_t threshold;
-	uint8_t buffer[0];
+	uint8_t buffer[];
 };
 
 #define RNG_POOL_DEFINE(name, len) uint8_t name[sizeof(struct rng_pool) + (len)]

--- a/include/bluetooth/a2dp.h
+++ b/include/bluetooth/a2dp.h
@@ -40,7 +40,7 @@ struct bt_a2dp_preset {
 	/** Length of preset */
 	uint8_t len;
 	/** Preset */
-	uint8_t preset[0];
+	uint8_t preset[];
 };
 
 /** @brief Stream End Point */

--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -454,7 +454,7 @@ struct bt_hci_handle_count {
 #define BT_HCI_OP_HOST_NUM_COMPLETED_PACKETS    BT_OP(BT_OGF_BASEBAND, 0x0035)
 struct bt_hci_cp_host_num_completed_packets {
 	uint8_t  num_handles;
-	struct bt_hci_handle_count h[0];
+	struct bt_hci_handle_count h[];
 } __packed;
 
 #define BT_HCI_OP_WRITE_INQUIRY_MODE            BT_OP(BT_OGF_BASEBAND, 0x0045)
@@ -1099,7 +1099,7 @@ struct bt_hci_ext_adv_set {
 struct bt_hci_cp_le_set_ext_adv_enable {
 	uint8_t  enable;
 	uint8_t  set_num;
-	struct bt_hci_ext_adv_set s[0];
+	struct bt_hci_ext_adv_set s[];
 } __packed;
 
 #define BT_HCI_OP_LE_READ_MAX_ADV_DATA_LEN      BT_OP(BT_OGF_LE, 0x003a)
@@ -1158,7 +1158,7 @@ struct bt_hci_cp_le_set_ext_scan_param {
 	uint8_t  own_addr_type;
 	uint8_t  filter_policy;
 	uint8_t  phys;
-	struct bt_hci_ext_scan_phy p[0];
+	struct bt_hci_ext_scan_phy p[];
 } __packed;
 
 /* Extends BT_HCI_LE_SCAN_FILTER_DUP */
@@ -1189,7 +1189,7 @@ struct bt_hci_cp_le_ext_create_conn {
 	uint8_t      own_addr_type;
 	bt_addr_le_t peer_addr;
 	uint8_t      phys;
-	struct bt_hci_ext_conn_phy p[0];
+	struct bt_hci_ext_conn_phy p[];
 } __packed;
 
 #define BT_HCI_OP_LE_PER_ADV_CREATE_SYNC        BT_OP(BT_OGF_LE, 0x0044)
@@ -1354,7 +1354,7 @@ struct bt_hci_evt_role_change {
 #define BT_HCI_EVT_NUM_COMPLETED_PACKETS        0x13
 struct bt_hci_evt_num_completed_packets {
 	uint8_t  num_handles;
-	struct bt_hci_handle_count h[0];
+	struct bt_hci_handle_count h[];
 } __packed;
 
 #define BT_HCI_EVT_PIN_CODE_REQ                 0x16
@@ -1510,11 +1510,11 @@ struct bt_hci_evt_le_advertising_info {
 	uint8_t      evt_type;
 	bt_addr_le_t addr;
 	uint8_t      length;
-	uint8_t      data[0];
+	uint8_t      data[];
 } __packed;
 struct bt_hci_evt_le_advertising_report {
 	uint8_t num_reports;
-	struct bt_hci_evt_le_advertising_info adv_info[0];
+	struct bt_hci_evt_le_advertising_info adv_info[];
 } __packed;
 
 #define BT_HCI_EVT_LE_CONN_UPDATE_COMPLETE      0x03
@@ -1593,7 +1593,7 @@ struct bt_hci_evt_le_direct_adv_info {
 } __packed;
 struct bt_hci_evt_le_direct_adv_report {
 	uint8_t num_reports;
-	struct bt_hci_evt_le_direct_adv_info direct_adv_info[0];
+	struct bt_hci_evt_le_direct_adv_info direct_adv_info[];
 } __packed;
 
 #define BT_HCI_EVT_LE_PHY_UPDATE_COMPLETE       0x0c
@@ -1628,11 +1628,11 @@ struct bt_hci_evt_le_ext_advertising_info {
 	uint16_t     interval;
 	bt_addr_le_t direct_addr;
 	uint8_t      length;
-	uint8_t      data[0];
+	uint8_t      data[];
 } __packed;
 struct bt_hci_evt_le_ext_advertising_report {
 	uint8_t num_reports;
-	struct bt_hci_evt_le_ext_advertising_info adv_info[0];
+	struct bt_hci_evt_le_ext_advertising_info adv_info[];
 } __packed;
 
 #define BT_HCI_EVT_LE_PER_ADV_SYNC_ESTABLISHED  0x0e
@@ -1654,7 +1654,7 @@ struct bt_hci_evt_le_per_advertising_report {
 	uint8_t  unused;
 	uint8_t  data_status;
 	uint8_t  length;
-	uint8_t  data[0];
+	uint8_t  data[];
 } __packed;
 
 #define BT_HCI_EVT_LE_PER_ADV_SYNC_LOST         0x10

--- a/include/bluetooth/hci_vs.h
+++ b/include/bluetooth/hci_vs.h
@@ -104,7 +104,7 @@ struct bt_hci_cp_vs_set_trace_enable {
 #define BT_HCI_OP_VS_READ_BUILD_INFO            BT_OP(BT_OGF_VS, 0x0008)
 struct bt_hci_rp_vs_read_build_info {
 	uint8_t  status;
-	uint8_t  info[0];
+	uint8_t  info[];
 } __packed;
 
 struct bt_hci_vs_static_addr {
@@ -116,7 +116,7 @@ struct bt_hci_vs_static_addr {
 struct bt_hci_rp_vs_read_static_addrs {
 	uint8_t   status;
 	uint8_t   num_addrs;
-	struct bt_hci_vs_static_addr a[0];
+	struct bt_hci_vs_static_addr a[];
 } __packed;
 
 #define BT_HCI_OP_VS_READ_KEY_HIERARCHY_ROOTS   BT_OP(BT_OGF_VS, 0x000a)
@@ -143,7 +143,7 @@ struct bt_hci_vs_cmd {
 struct bt_hci_rp_vs_read_host_stack_cmds {
 	uint8_t   status;
 	uint8_t   num_cmds;
-	struct bt_hci_vs_cmd c[0];
+	struct bt_hci_vs_cmd c[];
 } __packed;
 
 #define BT_HCI_VS_SCAN_REQ_REPORTS_DISABLED     0x00
@@ -189,7 +189,7 @@ struct bt_hci_rp_vs_read_tx_power_level {
 struct bt_hci_rp_vs_read_usb_transport_mode {
 	uint8_t  status;
 	uint8_t  num_supported_modes;
-	uint8_t  supported_mode[0];
+	uint8_t  supported_mode[];
 } __packed;
 
 #define BT_HCI_VS_USB_H2_MODE                  0x00
@@ -210,7 +210,7 @@ struct bt_hci_evt_vs {
 #define BT_HCI_EVT_VS_FATAL_ERROR              0x02
 struct bt_hci_evt_vs_fatal_error {
 	uint64_t pc;
-	uint8_t  err_info[0];
+	uint8_t  err_info[];
 } __packed;
 
 #define BT_HCI_VS_TRACE_LMP_TX                 0x01
@@ -221,7 +221,7 @@ struct bt_hci_evt_vs_fatal_error {
 #define BT_HCI_EVT_VS_TRACE_INFO               0x03
 struct bt_hci_evt_vs_trace_info {
 	uint8_t  type;
-	uint8_t  data[0];
+	uint8_t  data[];
 } __packed;
 
 #define BT_HCI_EVT_VS_SCAN_REQ_RX              0x04
@@ -267,14 +267,14 @@ struct bt_hci_rp_mesh_get_opts {
 #define BT_HCI_OC_MESH_SET_SCAN_FILTER         0x01
 struct bt_hci_mesh_pattern {
 	uint8_t pattern_len;
-	uint8_t pattern[0];
+	uint8_t pattern[];
 } __packed;
 
 struct bt_hci_cp_mesh_set_scan_filter {
 	uint8_t      scan_filter;
 	uint8_t      filter_dup;
 	uint8_t      num_patterns;
-	struct    bt_hci_mesh_pattern patterns[0];
+	struct    bt_hci_mesh_pattern patterns[];
 } __packed;
 struct bt_hci_rp_mesh_set_scan_filter {
 	uint8_t      status;
@@ -365,11 +365,11 @@ struct bt_hci_evt_mesh_scan_report {
 	int8_t         rssi;
 	uint32_t        instant;
 	uint8_t         data_len;
-	uint8_t         data[0];
+	uint8_t         data[];
 } __packed;
 struct bt_hci_evt_mesh_scanning_report {
 	uint8_t num_reports;
-	struct bt_hci_evt_mesh_scan_report reports[0];
+	struct bt_hci_evt_mesh_scan_report reports[];
 } __packed;
 
 #ifdef __cplusplus

--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -498,7 +498,7 @@ struct net_tcp_hdr {
 	uint8_t wnd[2];
 	uint16_t chksum;
 	uint8_t urg[2];
-	uint8_t optdata[0];
+	uint8_t optdata[];
 } __packed;
 
 static inline const char *net_addr_type2str(enum net_addr_type type)

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -1200,7 +1200,6 @@ struct read_data {
 	struct bt_att_chan *chan;
 	uint16_t offset;
 	struct net_buf *buf;
-	struct bt_att_read_rsp *rsp;
 	uint8_t err;
 };
 
@@ -1212,8 +1211,6 @@ static uint8_t read_cb(const struct bt_gatt_attr *attr, void *user_data)
 	int ret;
 
 	BT_DBG("handle 0x%04x", attr->handle);
-
-	data->rsp = net_buf_add(data->buf, sizeof(*data->rsp));
 
 	/*
 	 * If any attribute is founded in handle range it means that error
@@ -2280,7 +2277,7 @@ static const struct att_handler {
 		ATT_RESPONSE,
 		att_handle_find_info_rsp },
 	{ BT_ATT_OP_FIND_TYPE_RSP,
-		sizeof(struct bt_att_find_type_rsp),
+		sizeof(struct bt_att_handle_group),
 		ATT_RESPONSE,
 		att_handle_find_type_rsp },
 	{ BT_ATT_OP_READ_TYPE_RSP,
@@ -2288,16 +2285,16 @@ static const struct att_handler {
 		ATT_RESPONSE,
 		att_handle_read_type_rsp },
 	{ BT_ATT_OP_READ_RSP,
-		sizeof(struct bt_att_read_rsp),
+		0,
 		ATT_RESPONSE,
 		att_handle_read_rsp },
 	{ BT_ATT_OP_READ_BLOB_RSP,
-		sizeof(struct bt_att_read_blob_rsp),
+		0,
 		ATT_RESPONSE,
 		att_handle_read_blob_rsp },
 #if defined(CONFIG_BT_GATT_READ_MULTIPLE)
 	{ BT_ATT_OP_READ_MULT_RSP,
-		sizeof(struct bt_att_read_mult_rsp),
+		0,
 		ATT_RESPONSE,
 		att_handle_read_mult_rsp },
 #if defined(CONFIG_BT_EATT)

--- a/subsys/bluetooth/host/att_internal.h
+++ b/subsys/bluetooth/host/att_internal.h
@@ -62,7 +62,7 @@ struct bt_att_info_128 {
 #define BT_ATT_OP_FIND_INFO_RSP			0x05
 struct bt_att_find_info_rsp {
 	uint8_t  format;
-	uint8_t  info[0];
+	uint8_t  info[];
 } __packed;
 
 /* Find By Type Value Request */
@@ -71,18 +71,14 @@ struct bt_att_find_type_req {
 	uint16_t start_handle;
 	uint16_t end_handle;
 	uint16_t type;
-	uint8_t  value[0];
-} __packed;
-
-struct bt_att_handle_group {
-	uint16_t start_handle;
-	uint16_t end_handle;
+	uint8_t  value[];
 } __packed;
 
 /* Find By Type Value Response */
 #define BT_ATT_OP_FIND_TYPE_RSP			0x07
-struct bt_att_find_type_rsp {
-	struct bt_att_handle_group list[0];
+struct bt_att_handle_group {
+	uint16_t start_handle;
+	uint16_t end_handle;
 } __packed;
 
 /* Read By Type Request */
@@ -90,19 +86,19 @@ struct bt_att_find_type_rsp {
 struct bt_att_read_type_req {
 	uint16_t start_handle;
 	uint16_t end_handle;
-	uint8_t  uuid[0];
+	uint8_t  uuid[];
 } __packed;
 
 struct bt_att_data {
 	uint16_t handle;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Read By Type Response */
 #define BT_ATT_OP_READ_TYPE_RSP			0x09
 struct bt_att_read_type_rsp {
 	uint8_t  len;
-	struct bt_att_data data[0];
+	struct bt_att_data data[];
 } __packed;
 
 /* Read Request */
@@ -113,9 +109,6 @@ struct bt_att_read_req {
 
 /* Read Response */
 #define BT_ATT_OP_READ_RSP			0x0b
-struct bt_att_read_rsp {
-	uint8_t  value[0];
-} __packed;
 
 /* Read Blob Request */
 #define BT_ATT_OP_READ_BLOB_REQ			0x0c
@@ -126,50 +119,41 @@ struct bt_att_read_blob_req {
 
 /* Read Blob Response */
 #define BT_ATT_OP_READ_BLOB_RSP			0x0d
-struct bt_att_read_blob_rsp {
-	uint8_t  value[0];
-} __packed;
 
 /* Read Multiple Request */
 #define BT_ATT_READ_MULT_MIN_LEN_REQ		0x04
 
 #define BT_ATT_OP_READ_MULT_REQ			0x0e
-struct bt_att_read_mult_req {
-	uint16_t handles[0];
-} __packed;
 
 /* Read Multiple Response */
 #define BT_ATT_OP_READ_MULT_RSP			0x0f
-struct bt_att_read_mult_rsp {
-	uint8_t  value[0];
-} __packed;
 
 /* Read by Group Type Request */
 #define BT_ATT_OP_READ_GROUP_REQ		0x10
 struct bt_att_read_group_req {
 	uint16_t start_handle;
 	uint16_t end_handle;
-	uint8_t  uuid[0];
+	uint8_t  uuid[];
 } __packed;
 
 struct bt_att_group_data {
 	uint16_t start_handle;
 	uint16_t end_handle;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Read by Group Type Response */
 #define BT_ATT_OP_READ_GROUP_RSP		0x11
 struct bt_att_read_group_rsp {
 	uint8_t  len;
-	struct bt_att_group_data data[0];
+	struct bt_att_group_data data[];
 } __packed;
 
 /* Write Request */
 #define BT_ATT_OP_WRITE_REQ			0x12
 struct bt_att_write_req {
 	uint16_t handle;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Write Response */
@@ -180,7 +164,7 @@ struct bt_att_write_req {
 struct bt_att_prepare_write_req {
 	uint16_t handle;
 	uint16_t offset;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Prepare Write Respond */
@@ -188,7 +172,7 @@ struct bt_att_prepare_write_req {
 struct bt_att_prepare_write_rsp {
 	uint16_t handle;
 	uint16_t offset;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Execute Write Request */
@@ -207,14 +191,14 @@ struct bt_att_exec_write_req {
 #define BT_ATT_OP_NOTIFY			0x1b
 struct bt_att_notify {
 	uint16_t handle;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Handle Value Indication */
 #define BT_ATT_OP_INDICATE			0x1d
 struct bt_att_indicate {
 	uint16_t handle;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Handle Value Confirm */
@@ -225,15 +209,12 @@ struct bt_att_signature {
 } __packed;
 
 #define BT_ATT_OP_READ_MULT_VL_REQ		0x20
-struct bt_att_read_mult_vl_req {
-	uint16_t handles[0];
-} __packed;
 
 /* Read Multiple Respose */
 #define BT_ATT_OP_READ_MULT_VL_RSP		0x21
 struct bt_att_read_mult_vl_rsp {
 	uint16_t len;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Handle Multiple Value Notification */
@@ -241,21 +222,21 @@ struct bt_att_read_mult_vl_rsp {
 struct bt_att_notify_mult {
 	uint16_t handle;
 	uint16_t len;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Write Command */
 #define BT_ATT_OP_WRITE_CMD			0x52
 struct bt_att_write_cmd {
 	uint16_t handle;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Signed Write Command */
 #define BT_ATT_OP_SIGNED_WRITE_CMD		0xd2
 struct bt_att_signed_write_cmd {
 	uint16_t handle;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 typedef void (*bt_att_func_t)(struct bt_conn *conn, uint8_t err,

--- a/subsys/bluetooth/host/att_internal.h
+++ b/subsys/bluetooth/host/att_internal.h
@@ -138,7 +138,7 @@ struct bt_att_read_mult_req {
 	uint16_t handles[0];
 } __packed;
 
-/* Read Multiple Respose */
+/* Read Multiple Response */
 #define BT_ATT_OP_READ_MULT_RSP			0x0f
 struct bt_att_read_mult_rsp {
 	uint8_t  value[0];

--- a/subsys/bluetooth/host/avdtp_internal.h
+++ b/subsys/bluetooth/host/avdtp_internal.h
@@ -122,13 +122,13 @@ struct bt_avdtp_ind_cb {
 struct bt_avdtp_cap {
 	uint8_t cat;
 	uint8_t len;
-	uint8_t data[0];
+	uint8_t data[];
 };
 
 struct bt_avdtp_sep {
 	uint8_t seid;
 	uint8_t len;
-	struct bt_avdtp_cap caps[0];
+	struct bt_avdtp_cap caps[];
 };
 
 struct bt_avdtp_discover_params {

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2652,26 +2652,27 @@ static void gatt_find_type_rsp(struct bt_conn *conn, uint8_t err,
 			       const void *pdu, uint16_t length,
 			       void *user_data)
 {
-	const struct bt_att_find_type_rsp *rsp = pdu;
+	const struct bt_att_handle_group *rsp = pdu;
 	struct bt_gatt_discover_params *params = user_data;
-	uint8_t i;
+	uint8_t count;
 	uint16_t end_handle = 0U, start_handle;
 
 	BT_DBG("err 0x%02x", err);
 
-	if (err) {
+	if (err || (length % sizeof(struct bt_att_handle_group) != 0)) {
 		goto done;
 	}
 
+	count = length / sizeof(struct bt_att_handle_group);
+
 	/* Parse attributes found */
-	for (i = 0U; length >= sizeof(rsp->list[i]);
-	     i++, length -=  sizeof(rsp->list[i])) {
+	for (uint8_t i = 0U; i < count; i++) {
 		struct bt_uuid_16 uuid_svc;
 		struct bt_gatt_attr attr = {};
 		struct bt_gatt_service_val value;
 
-		start_handle = sys_le16_to_cpu(rsp->list[i].start_handle);
-		end_handle = sys_le16_to_cpu(rsp->list[i].end_handle);
+		start_handle = sys_le16_to_cpu(rsp[i].start_handle);
+		end_handle = sys_le16_to_cpu(rsp[i].end_handle);
 
 		BT_DBG("start_handle 0x%04x end_handle 0x%04x", start_handle,
 		       end_handle);
@@ -2693,11 +2694,6 @@ static void gatt_find_type_rsp(struct bt_conn *conn, uint8_t err,
 		if (params->func(conn, &attr, params) == BT_GATT_ITER_STOP) {
 			return;
 		}
-	}
-
-	/* Stop if could not parse the whole PDU */
-	if (length > 0) {
-		goto done;
 	}
 
 	gatt_discover_next(conn, end_handle, params);

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -41,7 +41,7 @@ struct bt_l2cap_sig_hdr {
 #define BT_L2CAP_CMD_REJECT             0x01
 struct bt_l2cap_cmd_reject {
 	uint16_t reason;
-	uint8_t  data[0];
+	uint8_t  data[];
 } __packed;
 
 struct bt_l2cap_cmd_reject_cid_data {
@@ -84,7 +84,7 @@ struct bt_l2cap_conn_rsp {
 struct bt_l2cap_conf_req {
 	uint16_t dcid;
 	uint16_t flags;
-	uint8_t  data[0];
+	uint8_t  data[];
 } __packed;
 
 #define BT_L2CAP_CONF_RSP               0x05
@@ -92,7 +92,7 @@ struct bt_l2cap_conf_rsp {
 	uint16_t scid;
 	uint16_t flags;
 	uint16_t result;
-	uint8_t  data[0];
+	uint8_t  data[];
 } __packed;
 
 /* Option type used by MTU config request data */
@@ -104,7 +104,7 @@ struct bt_l2cap_conf_rsp {
 struct bt_l2cap_conf_opt {
 	uint8_t type;
 	uint8_t len;
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 #define BT_L2CAP_DISCONN_REQ            0x06
@@ -135,7 +135,7 @@ struct bt_l2cap_info_req {
 struct bt_l2cap_info_rsp {
 	uint16_t type;
 	uint16_t result;
-	uint8_t  data[0];
+	uint8_t  data[];
 } __packed;
 
 #define BT_L2CAP_CONN_PARAM_REQ         0x12
@@ -197,7 +197,7 @@ struct bt_l2cap_ecred_conn_req {
 	uint16_t mtu;
 	uint16_t mps;
 	uint16_t credits;
-	uint16_t scid[0];
+	uint16_t scid[];
 } __packed;
 
 #define BT_L2CAP_ECRED_CONN_RSP         0x18
@@ -206,14 +206,14 @@ struct bt_l2cap_ecred_conn_rsp {
 	uint16_t mps;
 	uint16_t credits;
 	uint16_t result;
-	uint16_t dcid[0];
+	uint16_t dcid[];
 } __packed;
 
 #define BT_L2CAP_ECRED_RECONF_REQ       0x19
 struct bt_l2cap_ecred_reconf_req {
 	uint16_t mtu;
 	uint16_t mps;
-	uint16_t scid[0];
+	uint16_t scid[];
 } __packed;
 
 #define BT_L2CAP_RECONF_SUCCESS         0x0000

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -152,8 +152,8 @@ static struct node_update cdb_node_updates[CONFIG_BT_MESH_CDB_NODE_COUNT];
 static struct key_update cdb_key_updates[CONFIG_BT_MESH_CDB_SUBNET_COUNT +
 					 CONFIG_BT_MESH_CDB_APP_KEY_COUNT];
 #else
-static struct node_update cdb_node_updates[0];
-static struct key_update cdb_key_updates[0];
+static struct node_update cdb_node_updates[];
+static struct key_update cdb_key_updates[];
 #endif
 
 /* We need this so we don't overwrite app-hardcoded values in case FCB

--- a/subsys/shell/shell_history.c
+++ b/subsys/shell/shell_history.c
@@ -38,7 +38,7 @@ struct shell_history_item {
 	sys_dnode_t dnode;
 	uint16_t len;
 	uint16_t padding;
-	char data[0];
+	char data[];
 };
 
 void shell_history_mode_exit(struct shell_history *history)

--- a/subsys/testsuite/coverage/coverage.h
+++ b/subsys/testsuite/coverage/coverage.h
@@ -75,7 +75,7 @@ struct gcov_fn_info {
 	unsigned int ident;              /* unique ident of function */
 	unsigned int lineno_checksum;    /* function lineo_checksum */
 	unsigned int cfg_checksum;       /* function cfg checksum */
-	struct gcov_ctr_info ctrs[0];    /* instrumented counters */
+	struct gcov_ctr_info ctrs[];    /* instrumented counters */
 };
 
 /** Profiling data per object file

--- a/tests/bluetooth/hci_prop_evt/src/main.c
+++ b/tests/bluetooth/hci_prop_evt/src/main.c
@@ -27,7 +27,7 @@ struct hci_evt_prop {
 
 struct hci_evt_prop_report {
 	uint8_t  data_len;
-	uint8_t  data[0];
+	uint8_t  data[];
 } __packed;
 
 /* Command handler structure for cmd_handle(). */

--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -29,7 +29,7 @@ struct btp_hdr {
 	uint8_t  opcode;
 	uint8_t  index;
 	uint16_t len;
-	uint8_t  data[0];
+	uint8_t  data[];
 } __packed;
 
 #define BTP_STATUS			0x00
@@ -40,12 +40,12 @@ struct btp_status {
 /* Core Service */
 #define CORE_READ_SUPPORTED_COMMANDS	0x01
 struct core_read_supported_commands_rp {
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 #define CORE_READ_SUPPORTED_SERVICES	0x02
 struct core_read_supported_services_rp {
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 #define CORE_REGISTER_SERVICE		0x03
@@ -65,13 +65,13 @@ struct core_unregister_service_cmd {
 /* commands */
 #define GAP_READ_SUPPORTED_COMMANDS	0x01
 struct gap_read_supported_commands_rp {
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 #define GAP_READ_CONTROLLER_INDEX_LIST	0x02
 struct gap_read_controller_index_list_rp {
 	uint8_t num;
-	uint8_t index[0];
+	uint8_t index[];
 } __packed;
 
 #define GAP_SETTINGS_POWERED		0
@@ -154,8 +154,8 @@ struct gap_set_bondable_rp {
 struct gap_start_advertising_cmd {
 	uint8_t adv_data_len;
 	uint8_t scan_rsp_len;
-	uint8_t adv_data[0];
-	uint8_t scan_rsp[0];
+	uint8_t adv_data[];
+	uint8_t scan_rsp[];
 } __packed;
 struct gap_start_advertising_rp {
 	uint32_t current_settings;
@@ -296,7 +296,7 @@ struct gap_device_found_ev {
 	int8_t   rssi;
 	uint8_t  flags;
 	uint16_t eir_data_len;
-	uint8_t  eir_data[0];
+	uint8_t  eir_data[];
 } __packed;
 
 #define GAP_EV_DEVICE_CONNECTED		0x82
@@ -372,7 +372,7 @@ struct gap_pairing_consent_req_ev {
 /* commands */
 #define GATT_READ_SUPPORTED_COMMANDS	0x01
 struct gatt_read_supported_commands_rp {
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 #define GATT_SERVICE_PRIMARY		0x00
@@ -382,7 +382,7 @@ struct gatt_read_supported_commands_rp {
 struct gatt_add_service_cmd {
 	uint8_t type;
 	uint8_t uuid_length;
-	uint8_t uuid[0];
+	uint8_t uuid[];
 } __packed;
 struct gatt_add_service_rp {
 	uint16_t svc_id;
@@ -394,7 +394,7 @@ struct gatt_add_characteristic_cmd {
 	uint8_t properties;
 	uint8_t permissions;
 	uint8_t uuid_length;
-	uint8_t uuid[0];
+	uint8_t uuid[];
 } __packed;
 struct gatt_add_characteristic_rp {
 	uint16_t char_id;
@@ -405,7 +405,7 @@ struct gatt_add_descriptor_cmd {
 	uint16_t char_id;
 	uint8_t permissions;
 	uint8_t uuid_length;
-	uint8_t uuid[0];
+	uint8_t uuid[];
 } __packed;
 struct gatt_add_descriptor_rp {
 	uint16_t desc_id;
@@ -423,7 +423,7 @@ struct gatt_add_included_service_rp {
 	struct gatt_set_value_cmd {
 	uint16_t attr_id;
 	uint16_t len;
-	uint8_t value[0];
+	uint8_t value[];
 } __packed;
 
 #define GATT_START_SERVER		0x07
@@ -445,7 +445,7 @@ struct gatt_service {
 	uint16_t start_handle;
 	uint16_t end_handle;
 	uint8_t uuid_length;
-	uint8_t uuid[0];
+	uint8_t uuid[];
 } __packed;
 
 struct gatt_included {
@@ -458,13 +458,13 @@ struct gatt_characteristic {
 	uint16_t value_handle;
 	uint8_t properties;
 	uint8_t uuid_length;
-	uint8_t uuid[0];
+	uint8_t uuid[];
 } __packed;
 
 struct gatt_descriptor {
 	uint16_t descriptor_handle;
 	uint8_t uuid_length;
-	uint8_t uuid[0];
+	uint8_t uuid[];
 } __packed;
 
 #define GATT_EXCHANGE_MTU		0x0a
@@ -480,7 +480,7 @@ struct gatt_disc_all_prim_cmd {
 } __packed;
 struct gatt_disc_all_prim_rp {
 	uint8_t services_count;
-	struct gatt_service services[0];
+	struct gatt_service services[];
 } __packed;
 
 #define GATT_DISC_PRIM_UUID		0x0c
@@ -488,11 +488,11 @@ struct gatt_disc_prim_uuid_cmd {
 	uint8_t address_type;
 	uint8_t address[6];
 	uint8_t uuid_length;
-	uint8_t uuid[0];
+	uint8_t uuid[];
 } __packed;
 struct gatt_disc_prim_rp {
 	uint8_t services_count;
-	struct gatt_service services[0];
+	struct gatt_service services[];
 } __packed;
 
 #define GATT_FIND_INCLUDED		0x0d
@@ -504,7 +504,7 @@ struct gatt_find_included_cmd {
 } __packed;
 struct gatt_find_included_rp {
 	uint8_t services_count;
-	struct gatt_included included[0];
+	struct gatt_included included[];
 } __packed;
 
 #define GATT_DISC_ALL_CHRC		0x0e
@@ -516,7 +516,7 @@ struct gatt_disc_all_chrc_cmd {
 } __packed;
 struct gatt_disc_chrc_rp {
 	uint8_t characteristics_count;
-	struct gatt_characteristic characteristics[0];
+	struct gatt_characteristic characteristics[];
 } __packed;
 
 #define GATT_DISC_CHRC_UUID		0x0f
@@ -526,7 +526,7 @@ struct gatt_disc_chrc_uuid_cmd {
 	uint16_t start_handle;
 	uint16_t end_handle;
 	uint8_t uuid_length;
-	uint8_t uuid[0];
+	uint8_t uuid[];
 } __packed;
 
 #define GATT_DISC_ALL_DESC		0x10
@@ -538,7 +538,7 @@ struct gatt_disc_all_desc_cmd {
 } __packed;
 struct gatt_disc_all_desc_rp {
 	uint8_t descriptors_count;
-	struct gatt_descriptor descriptors[0];
+	struct gatt_descriptor descriptors[];
 } __packed;
 
 #define GATT_READ			0x11
@@ -550,7 +550,7 @@ struct gatt_read_cmd {
 struct gatt_read_rp {
 	uint8_t att_response;
 	uint16_t data_length;
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 #define GATT_READ_UUID			0x12
@@ -560,12 +560,12 @@ struct gatt_read_uuid_cmd {
 	uint16_t start_handle;
 	uint16_t end_handle;
 	uint8_t uuid_length;
-	uint8_t uuid[0];
+	uint8_t uuid[];
 } __packed;
 struct gatt_read_uuid_rp {
 	uint8_t att_response;
 	uint16_t data_length;
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 #define GATT_READ_LONG			0x13
@@ -578,7 +578,7 @@ struct gatt_read_long_cmd {
 struct gatt_read_long_rp {
 	uint8_t att_response;
 	uint16_t data_length;
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 #define GATT_READ_MULTIPLE		0x14
@@ -586,12 +586,12 @@ struct gatt_read_multiple_cmd {
 	uint8_t address_type;
 	uint8_t address[6];
 	uint8_t handles_count;
-	uint16_t handles[0];
+	uint16_t handles[];
 } __packed;
 struct gatt_read_multiple_rp {
 	uint8_t att_response;
 	uint16_t data_length;
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 #define GATT_WRITE_WITHOUT_RSP		0x15
@@ -600,7 +600,7 @@ struct gatt_write_without_rsp_cmd {
 	uint8_t address[6];
 	uint16_t handle;
 	uint16_t data_length;
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 #define GATT_SIGNED_WRITE_WITHOUT_RSP	0x16
@@ -609,7 +609,7 @@ struct gatt_signed_write_without_rsp_cmd {
 	uint8_t address[6];
 	uint16_t handle;
 	uint16_t data_length;
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 #define GATT_WRITE			0x17
@@ -618,7 +618,7 @@ struct gatt_write_cmd {
 	uint8_t address[6];
 	uint16_t handle;
 	uint16_t data_length;
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 struct gatt_write_rp {
 	uint8_t att_response;
@@ -631,7 +631,7 @@ struct gatt_write_long_cmd {
 	uint16_t handle;
 	uint16_t offset;
 	uint16_t data_length;
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 struct gatt_write_long_rp {
 	uint8_t att_response;
@@ -644,7 +644,7 @@ struct gatt_reliable_write_cmd {
 	uint16_t handle;
 	uint16_t offset;
 	uint16_t data_length;
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 struct gatt_reliable_write_rp {
 	uint8_t att_response;
@@ -664,17 +664,17 @@ struct gatt_get_attributes_cmd {
 	uint16_t start_handle;
 	uint16_t end_handle;
 	uint8_t type_length;
-	uint8_t type[0];
+	uint8_t type[];
 } __packed;
 struct gatt_get_attributes_rp {
 	uint8_t attrs_count;
-	uint8_t attrs[0];
+	uint8_t attrs[];
 } __packed;
 struct gatt_attr {
 	uint16_t handle;
 	uint8_t permission;
 	uint8_t type_length;
-	uint8_t type[0];
+	uint8_t type[];
 } __packed;
 
 #define GATT_GET_ATTRIBUTE_VALUE	0x1d
@@ -686,7 +686,7 @@ struct gatt_get_attribute_value_cmd {
 struct gatt_get_attribute_value_rp {
 	uint8_t att_response;
 	uint16_t value_length;
-	uint8_t value[0];
+	uint8_t value[];
 } __packed;
 
 #define GATT_CHANGE_DB			0x1e
@@ -703,14 +703,14 @@ struct gatt_notification_ev {
 	uint8_t type;
 	uint16_t handle;
 	uint16_t data_length;
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 #define GATT_EV_ATTR_VALUE_CHANGED	0x81
 struct gatt_attr_value_changed_ev {
 	uint16_t handle;
 	uint16_t data_length;
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 static inline void tester_set_bit(uint8_t *addr, unsigned int bit)
@@ -731,7 +731,7 @@ static inline uint8_t tester_test_bit(const uint8_t *addr, unsigned int bit)
 /* commands */
 #define L2CAP_READ_SUPPORTED_COMMANDS	0x01
 struct l2cap_read_supported_commands_rp {
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 #define L2CAP_CONNECT			0x02
@@ -744,7 +744,7 @@ struct l2cap_connect_cmd {
 } __packed;
 struct l2cap_connect_rp {
 	uint8_t num;
-	uint8_t chan_id[0];
+	uint8_t chan_id[];
 } __packed;
 
 #define L2CAP_DISCONNECT		0x03
@@ -810,14 +810,14 @@ struct l2cap_disconnected_ev {
 struct l2cap_data_received_ev {
 	uint8_t chan_id;
 	uint16_t data_length;
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 /* MESH Service */
 /* commands */
 #define MESH_READ_SUPPORTED_COMMANDS	0x01
 struct mesh_read_supported_commands_rp {
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 #define MESH_OUT_BLINK			BIT(0)
@@ -862,7 +862,7 @@ struct mesh_input_number_cmd {
 #define MESH_INPUT_STRING		0x07
 struct mesh_input_string_cmd {
 	uint8_t string_len;
-	uint8_t string[0];
+	uint8_t string[];
 } __packed;
 
 #define MESH_IVU_TEST_MODE		0x08
@@ -878,7 +878,7 @@ struct mesh_net_send_cmd {
 	uint16_t src;
 	uint16_t dst;
 	uint8_t payload_len;
-	uint8_t payload[0];
+	uint8_t payload[];
 } __packed;
 
 #define MESH_HEALTH_GENERATE_FAULTS	0x0b
@@ -886,8 +886,8 @@ struct mesh_health_generate_faults_rp {
 	uint8_t test_id;
 	uint8_t cur_faults_count;
 	uint8_t reg_faults_count;
-	uint8_t current_faults[0];
-	uint8_t registered_faults[0];
+	uint8_t current_faults[];
+	uint8_t registered_faults[];
 } __packed;
 
 #define MESH_HEALTH_CLEAR_FAULTS	0x0c
@@ -904,7 +904,7 @@ struct mesh_model_send_cmd {
 	uint16_t src;
 	uint16_t dst;
 	uint8_t payload_len;
-	uint8_t payload[0];
+	uint8_t payload[];
 } __packed;
 
 #define MESH_LPN_SUBSCRIBE		0x10
@@ -930,7 +930,7 @@ struct mesh_out_number_action_ev {
 #define MESH_EV_OUT_STRING_ACTION	0x81
 struct mesh_out_string_action_ev {
 	uint8_t string_len;
-	uint8_t string[0];
+	uint8_t string[];
 } __packed;
 
 #define MESH_EV_IN_ACTION		0x82
@@ -960,7 +960,7 @@ struct mesh_net_recv_ev {
 	uint16_t src;
 	uint16_t dst;
 	uint8_t payload_len;
-	uint8_t payload[0];
+	uint8_t payload[];
 } __packed;
 
 #define MESH_EV_INVALID_BEARER		0x87


### PR DESCRIPTION
Declaring zero-length arrays is allowed in GNU C as an extension and is
not part of the C language standards.

The ISO C99 has an equivalent mechanism called "flexible array member"
that serves the same purpose with slightly different syntax and
semantics:

* Flexible array members are written as `contents[]` without the `0`.
* Flexible array members have incomplete type and `sizeof` operator may
  not be applied.
* Flexible array members may only appear as the last member of a
  `struct` that is otherwise non-empty.
* A structure containing a flexible array member, or a union containing
  such a structure (possibly recursively), may not be a member of a
  structure or an element of an array.

The ISO C99 flexible array member mechanism is preferable to the GNU
zero-length array extension because:

1. The former is a standard mechanism and therefore more portable.
2. The former syntatically enforces that flexible array members must be
   the last member of a struct, whereas the latter declares any access
   to interior zero-length array members as undefined, which is highly
   error-prone.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>