### PR TITLE
Bluetooth: host: Fix TX thread data and HCI command deadlock

### DIFF
--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -226,6 +226,11 @@ struct bt_dev {
 	struct k_fifo		rx_queue;
 #endif
 
+#if defined(CONFIG_BT_CONN) && !defined(CONFIG_BT_HCI_RAW)
+	/* Lock for calling the driver send */
+	struct k_sem            tx_lock;
+#endif
+
 	/* Queue for outgoing HCI commands */
 	struct k_fifo		cmd_tx_queue;
 
@@ -245,6 +250,16 @@ struct bt_dev {
 	char			name[CONFIG_BT_DEVICE_NAME_MAX + 1];
 #endif
 };
+
+#if defined(CONFIG_BT_CONN) && !defined(CONFIG_BT_HCI_RAW)
+#define BT_SEND_LOCK_INIT() k_sem_init(&bt_dev.tx_lock, 1, 1)
+#define BT_SEND_LOCK()      k_sem_take(&bt_dev.tx_lock, K_FOREVER)
+#define BT_SEND_UNLOCK()    k_sem_give(&bt_dev.tx_lock)
+#else
+#define BT_SEND_LOCK_INIT()
+#define BT_SEND_LOCK()
+#define BT_SEND_UNLOCK()
+#endif /* defined(CONFIG_BT_CONN) && !defined(CONFIG_BT_HCI_RAW) */
 
 extern struct bt_dev bt_dev;
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_BREDR)

--- a/subsys/bluetooth/host/hci_ecc.c
+++ b/subsys/bluetooth/host/hci_ecc.c
@@ -287,6 +287,8 @@ static void le_p256_pub_key(struct net_buf *buf)
 
 int bt_hci_ecc_send(struct net_buf *buf)
 {
+	int err;
+
 	if (bt_buf_get_type(buf) == BT_BUF_CMD) {
 		struct bt_hci_cmd_hdr *chdr = (void *)buf->data;
 
@@ -307,7 +309,11 @@ int bt_hci_ecc_send(struct net_buf *buf)
 		}
 	}
 
-	return bt_dev.drv->send(buf);
+	BT_SEND_LOCK();
+	err = bt_dev.drv->send(buf);
+	BT_SEND_UNLOCK();
+
+	return err;
 }
 
 int default_CSPRNG(uint8_t *dst, unsigned int len)

--- a/subsys/bluetooth/host/hci_raw_internal.h
+++ b/subsys/bluetooth/host/hci_raw_internal.h
@@ -17,6 +17,10 @@ struct bt_dev_raw {
 
 extern struct bt_dev_raw bt_dev;
 
+#define BT_SEND_LOCK_INIT()
+#define BT_SEND_LOCK()
+#define BT_SEND_UNLOCK()
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Fix TX thread deadlock between TX data and TX HCI commands.
When the RX thread wants to submit an HCI command that has return
parameters (HCI LE Read Maximum Data Length command) it will block
waiting for the TX thread to send the HCI command.
However if the TX thread is blocked waiting for num complete to send
ACL packets it will not be able to send. If the RX thread is blocked,
it will not be able to process the incoming ACL queue. When this
happens on both sides at the link at the same time new data cannot be
sent. This means that no num complete event will arrive to unblock the
TX thread and the whole system is locked.

Fix this issue by not having the TX thread waiting for num completes
block sending of HCI commands by sending of HCI commands to it's own
thread.

Fixes: #25917