### PR TITLE
cmake: west: invoke west using same python as rest of build system

### DIFF
--- a/cmake/host-tools.cmake
+++ b/cmake/host-tools.cmake
@@ -22,8 +22,20 @@ else()
     RESULT_VARIABLE west_version_output_result
     )
 
+  if(WEST_PYTHON)
+    if(NOT (${WEST_PYTHON} STREQUAL ${PYTHON_EXECUTABLE}))
+      set(PYTHON_EXECUTABLE_OUT_OF_SYNC "\nNote:\n\
+  The Python version used by west is:  ${WEST_PYTHON}\n\
+  The Python version used by CMake is: ${PYTHON_EXECUTABLE}\n\
+  This might be correct, but please verify your installation.\n")
+    endif()
+  endif()
+
   if(west_version_output_result)
-    message(FATAL_ERROR "Unable to import west.version from '${PYTHON_EXECUTABLE}'")
+    message(FATAL_ERROR "Unable to import west.version from '${PYTHON_EXECUTABLE}'\n\
+  Please install with:\n\
+      ${PYTHON_EXECUTABLE} -m pip install west\
+  ${PYTHON_EXECUTABLE_OUT_OF_SYNC}")
   endif()
 
   if(${west_version} VERSION_LESS ${MIN_WEST_VERSION})
@@ -32,18 +44,21 @@ else()
     ${item}\n\
   But the minimum supported version is ${MIN_WEST_VERSION}\n\
   Please upgrade with:\n\
-      pip3 install --upgrade west")
+      ${PYTHON_EXECUTABLE} -m pip install --upgrade west\
+  ${PYTHON_EXECUTABLE_OUT_OF_SYNC}")
   endif()
+
   # Just output information for a single version. This will still work
   # even after output is one line.
   message(STATUS "Found west: ${WEST} (found suitable version \"${west_version}\", minimum required is \"${MIN_WEST_VERSION}\")")
 
-    execute_process(
-      COMMAND ${WEST}  topdir
-      OUTPUT_VARIABLE  WEST_TOPDIR
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      WORKING_DIRECTORY ${ZEPHYR_BASE}
-      )
+  execute_process(
+    COMMAND ${PYTHON_EXECUTABLE} -c
+    "from west.util import west_topdir; print(west_topdir())"
+    OUTPUT_VARIABLE  WEST_TOPDIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    WORKING_DIRECTORY ${ZEPHYR_BASE}
+    )
 endif()
 
 # dtc is an optional dependency

--- a/cmake/zephyr_module.cmake
+++ b/cmake/zephyr_module.cmake
@@ -21,7 +21,7 @@ endif()
 set(KCONFIG_MODULES_FILE ${CMAKE_BINARY_DIR}/Kconfig.modules)
 
 if(WEST)
-  set(WEST_ARG "--west-path" ${WEST} "--zephyr-base" ${ZEPHYR_BASE})
+  set(WEST_ARG "--zephyr-base" ${ZEPHYR_BASE})
 endif()
 
 if(WEST OR ZEPHYR_MODULES)

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -6,6 +6,7 @@ import argparse
 import os
 import pathlib
 import shlex
+import sys
 
 from west import log
 from west.configuration import config
@@ -396,7 +397,8 @@ class Build(Forceable):
         # to Just Work:
         #
         # west build -- -DOVERLAY_CONFIG=relative-path.conf
-        final_cmake_args = ['-B{}'.format(self.build_dir),
+        final_cmake_args = ['-DWEST_PYTHON={}'.format(sys.executable),
+                            '-B{}'.format(self.build_dir),
                             '-S{}'.format(self.source_dir),
                             '-G{}'.format(config_get('generator',
                                                      DEFAULT_CMAKE_GENERATOR))]

--- a/scripts/west_commands/zcmake.py
+++ b/scripts/west_commands/zcmake.py
@@ -45,6 +45,7 @@ def run_cmake(args, cwd=None, capture_output=False, dry_run=False):
     _ensure_min_version(cmake, dry_run)
 
     cmd = [cmake] + args
+
     kwargs = dict()
     if capture_output:
         kwargs['stdout'] = subprocess.PIPE

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -22,8 +22,6 @@ import os
 import sys
 import yaml
 import pykwalify.core
-import subprocess
-import re
 from pathlib import Path, PurePath
 
 METADATA_SCHEMA = '''
@@ -176,37 +174,23 @@ def main():
                              list`""")
     parser.add_argument('-x', '--extra-modules', nargs='+', default=[],
                         help='List of extra modules to parse')
-    parser.add_argument('-w', '--west-path', default='west',
-                        help='Path to west executable')
     parser.add_argument('-z', '--zephyr-base',
                         help='Path to zephyr repository')
     args = parser.parse_args()
 
     if args.modules is None:
-        p = subprocess.Popen([args.west_path, 'list', '--format={posixpath}'],
-                             cwd=args.zephyr_base,
-                             stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE)
-        out, err = p.communicate()
-        if p.returncode == 0:
-            projects = out.decode(sys.getdefaultencoding()).splitlines()
-        elif re.match((r'Error: .* is not in a west installation\.'
-                       '|FATAL ERROR: no west installation found from .*'
-                       '|FATAL ERROR: no west workspace.*'),
-                      err.decode(sys.getdefaultencoding())):
-            # Only accept the error the event we are outside a west
-            # workspace.
-            #
-            # TODO: we can just use "west topdir" instead if we can
-            # depend on west 0.7.0 or later.
+        # West is imported here, as it is optional (and thus maybe not installed)
+        # if user is providing a specific modules list.
+        from west.manifest import Manifest
+        from west.util import WestNotFound
+        try:
+            manifest = Manifest.from_file()
+            projects = [p.posixpath for p in manifest.get_projects([])]
+        except WestNotFound:
+            # Only accept WestNotFound, meaning we are not in a west
+            # workspace. Such setup is allowed, as west may be installed
+            # but the project is not required to use west.
             projects = []
-        else:
-            print(err.decode(sys.getdefaultencoding()))
-            # A real error occurred, raise an exception
-            raise subprocess.CalledProcessError(cmd=p.args,
-                                                returncode=p.returncode)
-    else:
-        projects = args.modules
 
     projects += args.extra_modules
     extra_modules = set(args.extra_modules)
@@ -217,7 +201,7 @@ def main():
 
     for project in projects:
         # Avoid including Zephyr base project as module.
-        if project == os.environ.get('ZEPHYR_BASE'):
+        if project == args.zephyr_base:
             continue
 
         meta = process_module(project)


### PR DESCRIPTION
When running CMake, then Python3 will be used.
This is detected through FindPython3, with a preference for using the
python or python3 in path, if any of those matches the required Python
minimal version in Zephyr.

It is also possible for users to specify a different Python, as example
by using:
`cmake -DPYTHON_PREFER=/usr/bin/python3.x`

However, when running `west` as native command, then west will be
invoked on linux based on the python defined in:
`west` launcher, which could be: `#!/usr/bin/python3.y`

Thus there could be mismatch in Pythons used for `west` and the python
used for other scripts.

This is even worse on windows, where a user might experience:
```
>.\opt\bin\Scripts\west.exe --version
Traceback (most recent call last):
  File "C:\Python37\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  ...
  File "C:\Python37\lib\socket.py", line 49, in <module>
    import _socket
ImportError: Module use of python38.dll conflicts with this version of
Python.
```

when testing out a newer Python, but the python in path is still a 3.7.

By importing `west` into zephyr_module.py and by using
`python -c "from west.app.main import main; main(['<command>'])"`
we ensure the same python is used in all python scripts.

Also it allows the user to control the python to use for west.

It also ensures that the west version being tested,m is also the version
being used, where old code would test the version imported by python,
but using the west in path (which could be a different version)

If the west version installed in the current Python, and west invocation
is using a different Python interpreter, then an additional help text
is printed, to easier assist users with debugging.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>