### PR TITLE
dt: start exposing dependency ordinals

### DIFF
--- a/doc/guides/dts/macros.bnf
+++ b/doc/guides/dts/macros.bnf
@@ -50,6 +50,13 @@ node-macro =/ %s"DT_N" path-id %s"_PARENT"
 node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD"
 ; The node's status macro
 node-macro =/ %s"DT_N" path-id %s"_STATUS_" dt-name
+; The node's dependency ordinal. This is a non-negative integer
+; value that is used to represent dependency information.
+node-macro =/ %s"DT_N" path-id %s"_ORD"
+; The dependency ordinals of a node's requirements (direct dependencies).
+node-macro =/ %s"DT_N" path-id %s"_REQUIRES_ORDS"
+; The dependency ordinals of a node supports (reverse direct dependencies).
+node-macro =/ %s"DT_N" path-id %s"_SUPPORTS_ORDS"
 
 ; --------------------------------------------------------------------
 ; property-macro: a macro related to a node property

--- a/doc/reference/devicetree/index.rst
+++ b/doc/reference/devicetree/index.rst
@@ -108,6 +108,44 @@ documented elsewhere on this page.
 .. doxygengroup:: devicetree-generic-exist
    :project: Zephyr
 
+.. _devicetree-dep-ord:
+
+Inter-node dependencies
+=======================
+
+The ``devicetree.h`` API has some support for tracking dependencies between
+nodes. Dependency tracking relies on a binary "depends on" relation between
+devicetree nodes, which is defined as the `transitive closure
+<https://en.wikipedia.org/wiki/Transitive_closure>`_ of the following "directly
+depends on" relation:
+
+- every non-root node directly depends on its parent node
+- a node directly depends on any nodes its properties refer to by phandle
+- a node directly depends on its ``interrupt-parent`` if it has an
+  ``interrupts`` property
+
+A *dependency ordering* of a devicetree is a list of its nodes, where each node
+``n`` appears earlier in the list than any nodes that depend on ``n``. A node's
+*dependency ordinal* is then its zero-based index in that list. Thus, for two
+distinct devicetree nodes ``n1`` and ``n2`` with dependency ordinals ``d1`` and
+``d2``, we have:
+
+- ``d1 != d2``
+- if ``n1`` depends on ``n2``, then ``d1 > d2``
+- ``d1 > d2`` does **not** necessarily imply that ``n1`` depends on ``n2``
+
+The Zephyr build system chooses a dependency ordering of the final devicetree
+and assigns a dependency ordinal to each node. Dependency related information
+can be accessed using the following macros. The exact dependency ordering
+chosen is an implementation detail, but cyclic dependencies are detected and
+cause errors, so it's safe to assume there are none when using these macros.
+
+There are instance number-based conveniences as well; see
+:c:func:`DT_INST_DEP_ORD` and subsequent documentation.
+
+.. doxygengroup:: devicetree-dep-ord
+   :project: Zephyr
+
 Bus helpers
 ===========
 

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -1934,5 +1934,6 @@
 #include <devicetree/pwms.h>
 #include <devicetree/fixed-partitions.h>
 #include <devicetree/zephyr.h>
+#include <devicetree/ordinals.h>
 
 #endif /* DEVICETREE_H */

--- a/include/devicetree/ordinals.h
+++ b/include/devicetree/ordinals.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DEVICETREE_ORDINALS_H_
+#define ZEPHYR_INCLUDE_DEVICETREE_ORDINALS_H_
+
+/**
+ * @file
+ * @brief Devicetree node dependency ordinals
+ */
+
+/**
+ * @defgroup devicetree-dep-ord Dependency tracking
+ * @ingroup devicetree
+ * @{
+ */
+
+/**
+ * @brief Get a node's dependency ordinal
+ * @param node_id Node identifier
+ * @return the node's dependency ordinal as an integer literal
+ */
+#define DT_DEP_ORD(node_id) DT_CAT(node_id, _ORD)
+
+/**
+ * @brief Get a list of dependency ordinals of a node's direct dependencies
+ *
+ * There is a comma after each ordinal in the expansion, **including**
+ * the last one:
+ *
+ *     DT_REQUIRES_DEP_ORDS(my_node) // required_ord_1, ..., required_ord_n,
+ *
+ * The one case DT_REQUIRES_DEP_ORDS() expands to nothing is when
+ * given the root node identifier @p DT_ROOT as argument. The root has
+ * no direct dependencies; every other node at least depends on its
+ * parent.
+ *
+ * @param node_id Node identifier
+ * @return a list of dependency ordinals, with each ordinal followed
+ *         by a comma (<tt>,</tt>), or an empty expansion
+ */
+#define DT_REQUIRES_DEP_ORDS(node_id) DT_CAT(node_id, _REQUIRES_ORDS)
+
+/**
+ * @brief Get a list of dependency ordinals of what depends directly on a node
+ *
+ * There is a comma after each ordinal in the expansion, **including**
+ * the last one:
+ *
+ *     DT_SUPPORTS_DEP_ORDS(my_node) // supported_ord_1, ..., supported_ord_n,
+ *
+ * DT_SUPPORTS_DEP_ORDS() may expand to nothing. This happens when @p node_id
+ * refers to a leaf node that nothing else depends on.
+ *
+ * @param node_id Node identifier
+ * @return a list of dependency ordinals, with each ordinal followed
+ *         by a comma (<tt>,</tt>), or an empty expansion
+ */
+#define DT_SUPPORTS_DEP_ORDS(node_id) DT_CAT(node_id, _SUPPORTS_ORDS)
+
+/**
+ * @brief Get a DT_DRV_COMPAT instance's dependency ordinal
+ *
+ * Equivalent to DT_DEP_ORD(DT_DRV_INST(inst)).
+ *
+ * @param inst instance number
+ * @return The instance's dependency ordinal
+ */
+#define DT_INST_DEP_ORD(inst) DT_DEP_ORD(DT_DRV_INST(inst))
+
+/**
+ * @brief Get a list of dependency ordinals of a DT_DRV_COMPAT instance's
+ *        direct dependencies
+ *
+ * Equivalent to DT_REQUIRES_DEP_ORDS(DT_DRV_INST(inst)).
+ *
+ * @param inst instance number
+ * @return a list of dependency ordinals for the nodes the instance depends
+ *         on directly
+ */
+#define DT_INST_REQUIRES_DEP_ORDS(inst) DT_REQUIRES_DEP_ORDS(DT_DRV_INST(inst))
+
+/**
+ * @brief Get a list of dependency ordinals of what depends directly on a
+ *        DT_DRV_COMPAT instance
+ *
+ * Equivalent to DT_SUPPORTS_DEP_ORDS(DT_DRV_INST(inst)).
+ *
+ * @param inst instance number
+ * @return a list of node identifiers for the nodes that depend directly
+ *         on the instance
+ */
+#define DT_INST_SUPPORTS_DEP_ORDS(inst) DT_SUPPORTS_DEP_ORDS(DT_DRV_INST(inst))
+
+/**
+ * @}
+ */
+
+#endif  /* ZEPHYR_INCLUDE_DEVICETREE_ORDINALS_H_ */

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -34,6 +34,10 @@
 
 		test_phandles: phandle-holder-0 {
 			compatible = "vnd,phandle-holder";
+			/*
+			 * At least one of these phandles must refer to
+			 * test_gpio_1, or dependency ordinal tests may fail.
+			 */
 			ph = <&test_gpio_1>;
 			phs = <&test_gpio_1 &test_gpio_2 &test_i2c>;
 			gpios = <&test_gpio_1 10 20>, <&test_gpio_2 30 40>;
@@ -337,6 +341,7 @@
 			status = "okay";
 		};
 
+		/* there should only be one of these */
 		test_children: test-children {
 			compatible = "vnd,child-bindings";
 

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -9,6 +9,7 @@
 #include <device.h>
 #include <drivers/gpio.h>
 
+#define TEST_CHILDREN	DT_PATH(test, test_children)
 #define TEST_DEADBEEF	DT_PATH(test, gpio_deadbeef)
 #define TEST_ABCD1234	DT_PATH(test, gpio_abcd1234)
 #define TEST_ALIAS	DT_ALIAS(test_alias)
@@ -1549,6 +1550,172 @@ static void test_great_grandchild(void)
 		      42, "great-grandchild bindings returned wrong value");
 }
 
+static bool ord_in_array(unsigned int ord, unsigned int *array,
+			 size_t array_size)
+{
+	size_t i;
+
+	for (i = 0; i < array_size; i++) {
+		if (array[i] == ord) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/* Magic numbers used by COMBINED_ORD_ARRAY. Must be invalid dependency
+ * ordinals.
+ */
+#define ORD_LIST_SEP		0xFFFF0000
+#define ORD_LIST_END		0xFFFF0001
+#define INJECTED_DEP_0		0xFFFF0002
+#define INJECTED_DEP_1		0xFFFF0003
+
+#define DEP_ORD_AND_COMMA(node_id) DT_DEP_ORD(node_id),
+#define CHILD_ORDINALS(node_id) DT_FOREACH_CHILD(node_id, DEP_ORD_AND_COMMA)
+
+#define COMBINED_ORD_ARRAY(node_id)		\
+	{					\
+		DT_DEP_ORD(node_id),		\
+		DT_DEP_ORD(DT_PARENT(node_id)),	\
+		CHILD_ORDINALS(node_id)		\
+		ORD_LIST_SEP,			\
+		DT_REQUIRES_DEP_ORDS(node_id)	\
+		INJECTED_DEP_0,			\
+		INJECTED_DEP_1,			\
+		ORD_LIST_SEP,			\
+		DT_SUPPORTS_DEP_ORDS(node_id)	\
+		ORD_LIST_END			\
+	}
+
+static void test_dep_ord(void)
+{
+#define ORD_IN_ARRAY(ord, array) ord_in_array(ord, array, ARRAY_SIZE(array))
+
+	unsigned int root_ord = DT_DEP_ORD(DT_ROOT),
+		test_ord = DT_DEP_ORD(DT_PATH(test)),
+		root_requires[] = { DT_REQUIRES_DEP_ORDS(DT_ROOT) },
+		test_requires[] = { DT_REQUIRES_DEP_ORDS(DT_PATH(test)) },
+		root_supports[] = { DT_SUPPORTS_DEP_ORDS(DT_ROOT) },
+		test_supports[] = { DT_SUPPORTS_DEP_ORDS(DT_PATH(test)) },
+		children_ords[] = {
+			DT_FOREACH_CHILD(TEST_CHILDREN, DEP_ORD_AND_COMMA)
+		},
+		children_combined_ords[] = COMBINED_ORD_ARRAY(TEST_CHILDREN),
+		child_a_combined_ords[] =
+			COMBINED_ORD_ARRAY(DT_NODELABEL(test_child_a));
+	size_t i;
+
+	/* DT_DEP_ORD */
+	zassert_equal(root_ord, 0,
+		      "the root node has dependency ordinal 0");
+	zassert_true(DT_DEP_ORD(DT_NODELABEL(test_child_a)) >
+		     DT_DEP_ORD(DT_NODELABEL(test_children)),
+		     "children depend on parents");
+	zassert_true(DT_DEP_ORD(DT_NODELABEL(test_irq)) >
+		     DT_DEP_ORD(DT_NODELABEL(test_intc)),
+		     "nodes depend on their interrupt controllers");
+	zassert_true(DT_DEP_ORD(DT_NODELABEL(test_phandles)) >
+		     DT_DEP_ORD(DT_NODELABEL(test_gpio_1)),
+		     "nodes depend on anything their properties "
+		     "refer to by phandle");
+
+	/* DT_REQUIRES_DEP_ORDS */
+	zassert_equal(ARRAY_SIZE(root_requires), 0,
+		      "the root node doesn't depend on anything");
+	zassert_true(ORD_IN_ARRAY(root_ord, test_requires),
+		     "/test depends on the root node");
+
+	/* DT_SUPPORTS_DEP_ORDS */
+	zassert_true(ORD_IN_ARRAY(test_ord, root_supports),
+		     "the root node supports /test");
+	zassert_false(ORD_IN_ARRAY(root_ord, test_supports),
+		      "the /test node doesn't support the root");
+
+	unsigned int children_combined_ords_expected[] = {
+		/*
+		 * Combined ordinals for /test/test-children are from
+		 * these nodes in this order:
+		 */
+		DT_DEP_ORD(TEST_CHILDREN),		/* node */
+		DT_DEP_ORD(DT_PATH(test)),		/* parent */
+		DT_DEP_ORD(DT_NODELABEL(test_child_a)),	/* children */
+		DT_DEP_ORD(DT_NODELABEL(test_child_b)),
+		DT_DEP_ORD(DT_NODELABEL(test_child_c)),
+		ORD_LIST_SEP,				/* separator */
+		DT_DEP_ORD(DT_PATH(test)),		/* requires */
+		INJECTED_DEP_0,				/* injected
+							 * dependencies
+							 */
+		INJECTED_DEP_1,
+		ORD_LIST_SEP,				/* separator */
+		DT_DEP_ORD(DT_NODELABEL(test_child_a)),	/* supports */
+		DT_DEP_ORD(DT_NODELABEL(test_child_b)),
+		DT_DEP_ORD(DT_NODELABEL(test_child_c)),
+		ORD_LIST_END,				/* terminator */
+	};
+	zassert_equal(ARRAY_SIZE(children_combined_ords),
+		      ARRAY_SIZE(children_combined_ords_expected),
+		      "%u", ARRAY_SIZE(children_combined_ords));
+	for (i = 0; i < ARRAY_SIZE(children_combined_ords); i++) {
+		zassert_equal(children_combined_ords[i],
+			      children_combined_ords_expected[i],
+			      "test-children at %zu", i);
+	}
+
+	unsigned int child_a_combined_ords_expected[] = {
+		/*
+		 * Combined ordinals for /test/test-children/child-a
+		 * are from these nodes in this order:
+		 */
+		DT_DEP_ORD(DT_NODELABEL(test_child_a)), /* node */
+		DT_DEP_ORD(TEST_CHILDREN),		/* parent */
+		/* children (none) */
+		ORD_LIST_SEP,				/* separator */
+		DT_DEP_ORD(TEST_CHILDREN),		/* requires */
+		INJECTED_DEP_0,				/* injected
+							 * dependencies
+							 */
+		INJECTED_DEP_1,
+		ORD_LIST_SEP,				/* separator */
+		/* supports (none) */
+		ORD_LIST_END,				/* terminator */
+	};
+	zassert_equal(ARRAY_SIZE(child_a_combined_ords),
+		      ARRAY_SIZE(child_a_combined_ords_expected),
+		      "%u", ARRAY_SIZE(child_a_combined_ords));
+	for (i = 0; i < ARRAY_SIZE(child_a_combined_ords); i++) {
+		zassert_equal(child_a_combined_ords[i],
+			      child_a_combined_ords_expected[i],
+			      "child-a at %zu", i);
+	}
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_child_bindings
+
+	/* DT_INST_DEP_ORD */
+	zassert_equal(DT_INST_DEP_ORD(0),
+		      DT_DEP_ORD(DT_NODELABEL(test_children)), "");
+
+	/* DT_INST_REQUIRES_DEP_ORDS */
+	unsigned int inst_requires[] = { DT_INST_REQUIRES_DEP_ORDS(0) };
+
+	zassert_equal(ARRAY_SIZE(inst_requires), 1,
+		      "/test/test-children depends only on /test");
+	zassert_equal(inst_requires[0], test_ord, "");
+
+	/* DT_INST_SUPPORTS_DEP_ORDS */
+	unsigned int inst_supports[] = { DT_INST_SUPPORTS_DEP_ORDS(0) };
+
+	zassert_equal(ARRAY_SIZE(inst_supports), 3,
+		      "/test/test-children only supports its children");
+	for (i = 0; i < ARRAY_SIZE(inst_supports); i++) {
+		zassert_true(ORD_IN_ARRAY(inst_supports[i], children_ords),
+			     "");
+	}
+}
+
 void test_main(void)
 {
 	ztest_test_suite(devicetree_api,
@@ -1581,7 +1748,8 @@ void test_main(void)
 			 ztest_unit_test(test_clocks),
 			 ztest_unit_test(test_parent),
 			 ztest_unit_test(test_child_nodes_list),
-			 ztest_unit_test(test_great_grandchild)
+			 ztest_unit_test(test_great_grandchild),
+			 ztest_unit_test(test_dep_ord)
 		);
 	ztest_run_test_suite(devicetree_api);
 }


### PR DESCRIPTION
Add the first API functions that directly deal with node dependency
ordinals as determined by edtlib:

- DT_DEP_ORD(node_id): node_id's ordinal
- DT_CHILD_DEP_ORD(node_id, child): a particular child's ordinal
- DT_CHILDREN_DEP_ORDS(node_id): an array initializer for a node's
  children's ordinals
- DT_INST_ equivalents

This is not meant to be an exhaustive set of macros related to
dependency ordinals; rather, it's a starting out point meant to enable
initial struct device dependency tracking work. We'll add more as
needed.

Fixes: #26050 (though I bike-shedded the names a bit; feel free to ask for changes there)
