### PR TITLE
Bluetooth: ATT: Multiple fixes

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -445,7 +445,7 @@ static void bt_att_chan_send_rsp(struct bt_att_chan *chan, struct net_buf *buf,
 	err = bt_att_chan_send(chan, buf, cb);
 	if (err) {
 		/* Responses need to be sent back using the same channel */
-		k_fifo_put(&chan->tx_queue, buf);
+		net_buf_put(&chan->tx_queue, buf);
 	}
 }
 
@@ -2500,12 +2500,12 @@ static void att_reset(struct bt_att *att)
 
 #if CONFIG_BT_ATT_PREPARE_COUNT > 0
 	/* Discard queued buffers */
-	while ((buf = k_fifo_get(&att->prep_queue, K_NO_WAIT))) {
+	while ((buf = net_buf_get(&att->prep_queue, K_NO_WAIT))) {
 		net_buf_unref(buf);
 	}
 #endif /* CONFIG_BT_ATT_PREPARE_COUNT > 0 */
 
-	while ((buf = k_fifo_get(&att->tx_queue, K_NO_WAIT))) {
+	while ((buf = net_buf_get(&att->tx_queue, K_NO_WAIT))) {
 		net_buf_unref(buf);
 	}
 
@@ -2539,7 +2539,7 @@ static void att_chan_detach(struct bt_att_chan *chan)
 	}
 
 	/* Release pending buffers */
-	while ((buf = k_fifo_get(&chan->tx_queue, K_NO_WAIT))) {
+	while ((buf = net_buf_get(&chan->tx_queue, K_NO_WAIT))) {
 		net_buf_unref(buf);
 	}
 
@@ -2970,7 +2970,7 @@ int bt_att_send(struct bt_conn *conn, struct net_buf *buf, bt_conn_tx_cb_t cb,
 	if (ret < 0) {
 		/* Queue buffer to be send later */
 		BT_DBG("Queueing buffer %p", buf);
-		k_fifo_put(&att->tx_queue, buf);
+		net_buf_put(&att->tx_queue, buf);
 	}
 
 	return 0;

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2902,8 +2902,8 @@ int bt_att_send(struct bt_conn *conn, struct net_buf *buf, bt_conn_tx_cb_t cb,
 	 * cannot be used with a custom user_data.
 	 */
 	if (cb) {
-		bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, buf, cb, user_data);
-		return 0;
+		return bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, buf, cb,
+					user_data);
 	}
 
 	ret = 0;


### PR DESCRIPTION
ATT channel sent callback shall not be overwritting until the
operation completes as it can result in breaking flow control when
CONFIG_BT_ATT_ENFORCE_FLOW is enabled.

Fixes #25964
Fixes #26070
Fixes #26071

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>