### PR TITLE
drivers: serial: Fix "mcux_lpuart_irq_tx_complete" returns wrong result

### DIFF
--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -134,16 +134,17 @@ static int mcux_lpuart_irq_tx_complete(struct device *dev)
 	const struct mcux_lpuart_config *config = dev->config_info;
 	uint32_t flags = LPUART_GetStatusFlags(config->base);
 
-	return (flags & kLPUART_TxDataRegEmptyFlag) != 0U;
+	return (flags & kLPUART_TransmissionCompleteFlag) != 0U;
 }
 
 static int mcux_lpuart_irq_tx_ready(struct device *dev)
 {
 	const struct mcux_lpuart_config *config = dev->config_info;
 	uint32_t mask = kLPUART_TxDataRegEmptyInterruptEnable;
+	uint32_t flags = LPUART_GetStatusFlags(config->base);
 
 	return (LPUART_GetEnabledInterrupts(config->base) & mask)
-		&& mcux_lpuart_irq_tx_complete(dev);
+		&& (flags & kLPUART_TxDataRegEmptyFlag);
 }
 
 static void mcux_lpuart_irq_rx_enable(struct device *dev)


### PR DESCRIPTION
Use "kLPUART_TransmissionCompleteFlag" instead of "kLPUART_TxDataRegEmptyFlag" to check if the tx transmition is finished.

The "kLPUART_TxDataRegEmptyFlag" would give a wrong result even if the transmition isn't over.

Signed-off-by: Andy Liu <andy@madmachine.io>