### PR TITLE
Rework the way USB core stack handles USB Interface Requests. (+reword)

### DIFF
--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -174,11 +174,6 @@ struct usb_interface_cfg_data {
  * may only be updated after calls to usb_deconfig
  */
 struct usb_cfg_data {
-	/**
-	 * USB device description, see
-	 * http://www.beyondlogic.org/usbnutshell/usb5.shtml#DeviceDescriptors
-	 */
-	const uint8_t *usb_device_description;
 	/** Pointer to interface descriptor */
 	const void *interface_descriptor;
 	/** Function for interface runtime configuration */

--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -174,8 +174,6 @@ struct usb_interface_cfg_data {
  * may only be updated after calls to usb_deconfig
  */
 struct usb_cfg_data {
-	/** Pointer to interface descriptor */
-	const void *interface_descriptor;
 	/** Function for interface runtime configuration */
 	usb_interface_config interface_config;
 	/** Callback to be notified on USB connection status change */
@@ -184,6 +182,10 @@ struct usb_cfg_data {
 			      const uint8_t *param);
 	/** USB interface (Class) handler and storage space */
 	struct usb_interface_cfg_data interface;
+	/* Number of interfaces for this function */
+	const uint8_t num_of_interfaces;
+	/* Pointer to list of interfaces pointers for this function */
+	const struct usb_if_descriptor *const *const list_of_interfaces;
 	/** Number of individual endpoints in the device configuration */
 	uint8_t num_endpoints;
 	/**

--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -181,11 +181,11 @@ struct usb_cfg_data {
 			      enum usb_dc_status_code cb_status,
 			      const uint8_t *param);
 	/** USB interface (Class) handler and storage space */
-	struct usb_interface_cfg_data interface;
+	struct usb_interface_cfg_data request_handlers;
 	/* Number of interfaces for this function */
-	const uint8_t num_of_interfaces;
+	const uint8_t num_interfaces;
 	/* Pointer to list of interfaces pointers for this function */
-	const struct usb_if_descriptor *const *const list_of_interfaces;
+	const struct usb_if_descriptor *const *const interfaces;
 	/** Number of individual endpoints in the device configuration */
 	uint8_t num_endpoints;
 	/**
@@ -193,7 +193,7 @@ struct usb_cfg_data {
 	 * number of EP associated with the device description,
 	 * not including control endpoints
 	 */
-	struct usb_ep_cfg_data *endpoint;
+	struct usb_ep_cfg_data *endpoints;
 };
 
 /**

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -151,7 +151,6 @@ static int wpanusb_vendor_handler(struct usb_setup_packet *setup,
 }
 
 USBD_CFG_DATA_DEFINE(primary, wpanusb) struct usb_cfg_data wpanusb_config = {
-	.usb_device_description = NULL,
 	.interface_descriptor = &wpanusb_desc.if0,
 	.cb_usb_status = wpanusb_status_cb,
 	.interface = {

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -81,6 +81,10 @@ static struct usb_ep_cfg_data wpanusb_ep[] = {
 	},
 };
 
+static const struct usb_if_descriptor *const wpanusb_if[] = {
+	&wpanusb_desc.if0,
+};
+
 static void wpanusb_status_cb(struct usb_cfg_data *cfg,
 			      enum usb_dc_status_code status,
 			      const uint8_t *param)
@@ -151,13 +155,14 @@ static int wpanusb_vendor_handler(struct usb_setup_packet *setup,
 }
 
 USBD_CFG_DATA_DEFINE(primary, wpanusb) struct usb_cfg_data wpanusb_config = {
-	.interface_descriptor = &wpanusb_desc.if0,
 	.cb_usb_status = wpanusb_status_cb,
 	.interface = {
 		.vendor_handler = wpanusb_vendor_handler,
 		.class_handler = NULL,
 		.custom_handler = NULL,
 	},
+	.num_of_interfaces = ARRAY_SIZE(wpanusb_if),
+	.list_of_interfaces = wpanusb_if,
 	.num_endpoints = ARRAY_SIZE(wpanusb_ep),
 	.endpoint = wpanusb_ep,
 };

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -156,15 +156,15 @@ static int wpanusb_vendor_handler(struct usb_setup_packet *setup,
 
 USBD_CFG_DATA_DEFINE(primary, wpanusb) struct usb_cfg_data wpanusb_config = {
 	.cb_usb_status = wpanusb_status_cb,
-	.interface = {
+	.request_handlers = {
 		.vendor_handler = wpanusb_vendor_handler,
 		.class_handler = NULL,
 		.custom_handler = NULL,
 	},
-	.num_of_interfaces = ARRAY_SIZE(wpanusb_if),
-	.list_of_interfaces = wpanusb_if,
+	.num_interfaces = ARRAY_SIZE(wpanusb_if),
+	.interfaces = wpanusb_if,
 	.num_endpoints = ARRAY_SIZE(wpanusb_ep),
-	.endpoint = wpanusb_ep,
+	.endpoints = wpanusb_ep,
 };
 
 /* Decode wpanusb commands */
@@ -255,7 +255,7 @@ static int stop(void)
 
 static int tx(struct net_pkt *pkt)
 {
-	uint8_t ep = wpanusb_config.endpoint[WPANUSB_IN_EP_IDX].ep_addr;
+	uint8_t ep = wpanusb_config.endpoints[WPANUSB_IN_EP_IDX].ep_addr;
 	struct net_buf *buf = net_buf_frag_last(pkt->buffer);
 	uint8_t seq = net_buf_pull_u8(buf);
 	int retries = 3;
@@ -389,7 +389,7 @@ int net_recv_data(struct net_if *iface, struct net_pkt *pkt)
 	 */
 	*p = net_pkt_ieee802154_lqi(pkt);
 
-	ep = wpanusb_config.endpoint[WPANUSB_IN_EP_IDX].ep_addr;
+	ep = wpanusb_config.endpoints[WPANUSB_IN_EP_IDX].ep_addr;
 
 	ret = usb_transfer_sync(ep, tx_buf, len + 2,
 				USB_TRANS_WRITE | USB_TRANS_NO_ZLP);

--- a/samples/subsys/usb/webusb/src/webusb.c
+++ b/samples/subsys/usb/webusb/src/webusb.c
@@ -212,7 +212,6 @@ static struct usb_ep_cfg_data webusb_ep_data[] = {
 };
 
 USBD_CFG_DATA_DEFINE(primary, webusb) struct usb_cfg_data webusb_config = {
-	.usb_device_description = NULL,
 	.interface_descriptor = &webusb_desc.if0,
 	.cb_usb_status = webusb_dev_status_cb,
 	.interface = {

--- a/samples/subsys/usb/webusb/src/webusb.c
+++ b/samples/subsys/usb/webusb/src/webusb.c
@@ -146,7 +146,7 @@ static void webusb_read_cb(uint8_t ep, int size, void *priv)
 		goto done;
 	}
 
-	usb_transfer(cfg->endpoint[WEBUSB_IN_EP_IDX].ep_addr, rx_buf, size,
+	usb_transfer(cfg->endpoints[WEBUSB_IN_EP_IDX].ep_addr, rx_buf, size,
 		     USB_TRANS_WRITE, webusb_write_cb, cfg);
 done:
 	usb_transfer(ep, rx_buf, sizeof(rx_buf), USB_TRANS_READ,
@@ -180,7 +180,7 @@ static void webusb_dev_status_cb(struct usb_cfg_data *cfg,
 		break;
 	case USB_DC_CONFIGURED:
 		LOG_DBG("USB device configured");
-		webusb_read_cb(cfg->endpoint[WEBUSB_OUT_EP_IDX].ep_addr,
+		webusb_read_cb(cfg->endpoints[WEBUSB_OUT_EP_IDX].ep_addr,
 			       0, cfg);
 		break;
 	case USB_DC_DISCONNECTED:
@@ -217,13 +217,13 @@ static const struct usb_if_descriptor *const webusb_if_data[] = {
 
 USBD_CFG_DATA_DEFINE(primary, webusb) struct usb_cfg_data webusb_config = {
 	.cb_usb_status = webusb_dev_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = NULL,
 		.custom_handler = webusb_custom_handle_req,
 		.vendor_handler = webusb_vendor_handle_req,
 	},
-	.num_of_interfaces = ARRAY_SIZE(webusb_if_data),
-	.list_of_interfaces = webusb_if_data,
+	.num_interfaces = ARRAY_SIZE(webusb_if_data),
+	.interfaces = webusb_if_data,
 	.num_endpoints = ARRAY_SIZE(webusb_ep_data),
-	.endpoint = webusb_ep_data
+	.endpoints = webusb_ep_data
 };

--- a/samples/subsys/usb/webusb/src/webusb.c
+++ b/samples/subsys/usb/webusb/src/webusb.c
@@ -211,14 +211,19 @@ static struct usb_ep_cfg_data webusb_ep_data[] = {
 	}
 };
 
+static const struct usb_if_descriptor *const webusb_if_data[] = {
+	&webusb_desc.if0,
+};
+
 USBD_CFG_DATA_DEFINE(primary, webusb) struct usb_cfg_data webusb_config = {
-	.interface_descriptor = &webusb_desc.if0,
 	.cb_usb_status = webusb_dev_status_cb,
 	.interface = {
 		.class_handler = NULL,
 		.custom_handler = webusb_custom_handle_req,
 		.vendor_handler = webusb_vendor_handle_req,
 	},
+	.num_of_interfaces = ARRAY_SIZE(webusb_if_data),
+	.list_of_interfaces = webusb_if_data,
 	.num_endpoints = ARRAY_SIZE(webusb_ep_data),
 	.endpoint = webusb_ep_data
 };

--- a/subsys/tracing/tracing_backend_usb.c
+++ b/subsys/tracing/tracing_backend_usb.c
@@ -125,7 +125,6 @@ static struct usb_ep_cfg_data ep_cfg[] = {
 
 USBD_CFG_DATA_DEFINE(primary, tracing_backend_usb)
 	struct usb_cfg_data tracing_backend_usb_config = {
-	.usb_device_description = NULL,
 	.interface_descriptor = &dev_desc.if0,
 	.cb_usb_status = dev_status_cb,
 	.interface = {

--- a/subsys/tracing/tracing_backend_usb.c
+++ b/subsys/tracing/tracing_backend_usb.c
@@ -123,15 +123,20 @@ static struct usb_ep_cfg_data ep_cfg[] = {
 	},
 };
 
+static const struct usb_if_descriptor *const if_cfg[] = {
+	&dev_desc.if0,
+};
+
 USBD_CFG_DATA_DEFINE(primary, tracing_backend_usb)
 	struct usb_cfg_data tracing_backend_usb_config = {
-	.interface_descriptor = &dev_desc.if0,
 	.cb_usb_status = dev_status_cb,
 	.interface = {
 		.class_handler = NULL,
 		.custom_handler = NULL,
 		.vendor_handler = NULL,
 	},
+	.num_of_interfaces = ARRAY_SIZE(if_cfg),
+	.list_of_interfaces = if_cfg,
 	.num_endpoints = ARRAY_SIZE(ep_cfg),
 	.endpoint = ep_cfg,
 };

--- a/subsys/tracing/tracing_backend_usb.c
+++ b/subsys/tracing/tracing_backend_usb.c
@@ -130,15 +130,15 @@ static const struct usb_if_descriptor *const if_cfg[] = {
 USBD_CFG_DATA_DEFINE(primary, tracing_backend_usb)
 	struct usb_cfg_data tracing_backend_usb_config = {
 	.cb_usb_status = dev_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = NULL,
 		.custom_handler = NULL,
 		.vendor_handler = NULL,
 	},
-	.num_of_interfaces = ARRAY_SIZE(if_cfg),
-	.list_of_interfaces = if_cfg,
+	.num_interfaces = ARRAY_SIZE(if_cfg),
+	.interfaces = if_cfg,
 	.num_endpoints = ARRAY_SIZE(ep_cfg),
-	.endpoint = ep_cfg,
+	.endpoints = ep_cfg,
 };
 
 static void tracing_backend_usb_output(const struct tracing_backend *backend,

--- a/subsys/usb/class/audio/audio.c
+++ b/subsys/usb/class/audio/audio.c
@@ -924,7 +924,6 @@ void usb_audio_register(struct device *dev,
 #define DEFINE_AUDIO_DEVICE(dev, i)					  \
 	USBD_CFG_DATA_DEFINE(primary, audio)				  \
 	struct usb_cfg_data dev##_audio_config_##i = {			  \
-		.usb_device_description	= NULL,				  \
 		.interface_config = audio_interface_config,		  \
 		.interface_descriptor = &dev##_desc_##i.std_ac_interface, \
 		.cb_usb_status = audio_cb_usb_status,			  \

--- a/subsys/usb/class/audio/audio.c
+++ b/subsys/usb/class/audio/audio.c
@@ -747,6 +747,10 @@ static int audio_custom_handler(struct usb_setup_packet *pSetup, int32_t *len,
 			} else {
 				audio_dev_data->rx_enable = pSetup->wValue;
 			}
+			/* This request needs further processing in the core
+			 * USB stack, hence -EINVAL is returned. Refer to
+			 * documentation for custom_handler in the usb_device.h
+			 */
 			return -EINVAL;
 		case REQ_GET_INTERFACE:
 			if (ep_desc->bEndpointAddress & USB_EP_DIR_MASK) {

--- a/subsys/usb/class/audio/audio.c
+++ b/subsys/usb/class/audio/audio.c
@@ -289,7 +289,7 @@ static void audio_dc_sof(struct usb_cfg_data *cfg,
 	uint8_t ep_addr;
 
 	/* In endpoint always at index 0 */
-	ep_addr = cfg->endpoint[0].ep_addr;
+	ep_addr = cfg->endpoints[0].ep_addr;
 	if ((ep_addr & USB_EP_DIR_MASK) && (dev_data->tx_enable)) {
 		if (dev_data->ops && dev_data->ops->data_request_cb) {
 			dev_data->ops->data_request_cb(
@@ -827,7 +827,7 @@ int usb_audio_send(const struct device *dev, struct net_buf *buffer,
 	struct usb_audio_dev_data *audio_dev_data = dev->driver_data;
 	struct usb_cfg_data *cfg = (void *)dev->config_info;
 	/* EP ISO IN is always placed first in the endpoint table */
-	uint8_t ep = cfg->endpoint[0].ep_addr;
+	uint8_t ep = cfg->endpoints[0].ep_addr;
 
 	if (!(ep & USB_EP_DIR_MASK)) {
 		LOG_ERR("Wrong device");
@@ -917,7 +917,7 @@ void usb_audio_register(struct device *dev,
 	struct usb_audio_dev_data *audio_dev_data = dev->driver_data;
 	const struct usb_cfg_data *cfg = dev->config_info;
 	const struct usb_if_descriptor *iface_descr =
-		cfg->list_of_interfaces[0];
+		cfg->interfaces[0];
 	const struct cs_ac_if_descriptor *header =
 		(struct cs_ac_if_descriptor *)
 		((uint8_t *)iface_descr + USB_PASSIVE_IF_DESC_SIZE);
@@ -940,15 +940,15 @@ void usb_audio_register(struct device *dev,
 	struct usb_cfg_data dev##_audio_config_##i = {			  \
 		.interface_config = audio_interface_config,		  \
 		.cb_usb_status = audio_cb_usb_status,			  \
-		.interface = {						  \
+		.request_handlers = {					  \
 			.class_handler = audio_class_handle_req,	  \
 			.custom_handler = audio_custom_handler,		  \
 			.vendor_handler = NULL,				  \
 		},							  \
-		.list_of_interfaces = dev##_usb_audio_iface_data_##i,	  \
-		.num_of_interfaces = ARRAY_SIZE(dev##_usb_audio_iface_data_##i),\
+		.interfaces = dev##_usb_audio_iface_data_##i,		  \
+		.num_interfaces = ARRAY_SIZE(dev##_usb_audio_iface_data_##i),\
 		.num_endpoints = ARRAY_SIZE(dev##_usb_audio_ep_data_##i), \
-		.endpoint = dev##_usb_audio_ep_data_##i,		  \
+		.endpoints = dev##_usb_audio_ep_data_##i,		  \
 	};								  \
 	DEVICE_AND_API_INIT(dev##_usb_audio_device_##i,			  \
 			    DT_LABEL(DT_INST(i, COMPAT_##dev)),		  \

--- a/subsys/usb/class/audio/audio.c
+++ b/subsys/usb/class/audio/audio.c
@@ -86,6 +86,12 @@ struct dev##_descriptor_##i dev##_desc_##i = {				      \
 };									      \
 static struct usb_ep_cfg_data dev##_usb_audio_ep_data_##i[] = {		      \
 	INIT_EP_DATA(cb, addr),						      \
+};									      \
+static const struct usb_if_descriptor *const				      \
+dev##_usb_audio_iface_data_##i[] = {					      \
+	&dev##_desc_##i.std_ac_interface,				      \
+	&dev##_desc_##i.as_interface_alt_0,				      \
+	&dev##_desc_##i.as_interface_alt_1,				      \
 }
 
 /**
@@ -144,6 +150,14 @@ struct dev##_descriptor_##i dev##_desc_##i = {				  \
 static struct usb_ep_cfg_data dev##_usb_audio_ep_data_##i[] = {		  \
 	INIT_EP_DATA(usb_transfer_ep_callback, AUTO_EP_IN),		  \
 	INIT_EP_DATA(audio_receive_cb, AUTO_EP_OUT),			  \
+};									  \
+static const struct usb_if_descriptor *const				  \
+dev##_usb_audio_iface_data_##i[] = {					  \
+	&dev##_desc_##i.std_ac_interface,				  \
+	&dev##_desc_##i.as_interface_alt_0_0,				  \
+	&dev##_desc_##i.as_interface_alt_0_1,				  \
+	&dev##_desc_##i.as_interface_alt_1_0,				  \
+	&dev##_desc_##i.as_interface_alt_1_1,				  \
 }
 
 #define DEFINE_AUDIO_DEV_DATA(dev, i, __out_pool, __in_pool_size)   \
@@ -902,8 +916,8 @@ void usb_audio_register(struct device *dev,
 {
 	struct usb_audio_dev_data *audio_dev_data = dev->driver_data;
 	const struct usb_cfg_data *cfg = dev->config_info;
-	const struct std_if_descriptor *iface_descr =
-		cfg->interface_descriptor;
+	const struct usb_if_descriptor *iface_descr =
+		cfg->list_of_interfaces[0];
 	const struct cs_ac_if_descriptor *header =
 		(struct cs_ac_if_descriptor *)
 		((uint8_t *)iface_descr + USB_PASSIVE_IF_DESC_SIZE);
@@ -925,13 +939,14 @@ void usb_audio_register(struct device *dev,
 	USBD_CFG_DATA_DEFINE(primary, audio)				  \
 	struct usb_cfg_data dev##_audio_config_##i = {			  \
 		.interface_config = audio_interface_config,		  \
-		.interface_descriptor = &dev##_desc_##i.std_ac_interface, \
 		.cb_usb_status = audio_cb_usb_status,			  \
 		.interface = {						  \
 			.class_handler = audio_class_handle_req,	  \
 			.custom_handler = audio_custom_handler,		  \
 			.vendor_handler = NULL,				  \
 		},							  \
+		.list_of_interfaces = dev##_usb_audio_iface_data_##i,	  \
+		.num_of_interfaces = ARRAY_SIZE(dev##_usb_audio_iface_data_##i),\
 		.num_endpoints = ARRAY_SIZE(dev##_usb_audio_ep_data_##i), \
 		.endpoint = dev##_usb_audio_ep_data_##i,		  \
 	};								  \

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -320,7 +320,6 @@ static void bluetooth_interface_config(struct usb_desc_header *head,
 }
 
 USBD_CFG_DATA_DEFINE(primary, hci) struct usb_cfg_data bluetooth_config = {
-	.usb_device_description = NULL,
 	.interface_config = bluetooth_interface_config,
 	.interface_descriptor = &bluetooth_cfg.if0,
 	.cb_usb_status = bluetooth_status_cb,

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -326,15 +326,15 @@ static void bluetooth_interface_config(struct usb_desc_header *head,
 USBD_CFG_DATA_DEFINE(primary, hci) struct usb_cfg_data bluetooth_config = {
 	.interface_config = bluetooth_interface_config,
 	.cb_usb_status = bluetooth_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = bluetooth_class_handler,
 		.custom_handler = NULL,
 		.vendor_handler = NULL,
 	},
-	.list_of_interfaces = bluetooth_interfaces,
-	.num_of_interfaces = ARRAY_SIZE(bluetooth_interfaces),
+	.num_interfaces = ARRAY_SIZE(bluetooth_interfaces),
+	.interfaces = bluetooth_interfaces,
 	.num_endpoints = ARRAY_SIZE(bluetooth_ep_data),
-	.endpoint = bluetooth_ep_data,
+	.endpoints = bluetooth_ep_data,
 };
 
 static int bluetooth_init(struct device *dev)

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -115,6 +115,10 @@ static struct usb_ep_cfg_data bluetooth_ep_data[] = {
 	},
 };
 
+static const struct usb_if_descriptor *const bluetooth_interfaces[] = {
+	&bluetooth_cfg.if0,
+};
+
 static void hci_tx_thread(void)
 {
 	LOG_DBG("Start USB Bluetooth thread");
@@ -321,13 +325,14 @@ static void bluetooth_interface_config(struct usb_desc_header *head,
 
 USBD_CFG_DATA_DEFINE(primary, hci) struct usb_cfg_data bluetooth_config = {
 	.interface_config = bluetooth_interface_config,
-	.interface_descriptor = &bluetooth_cfg.if0,
 	.cb_usb_status = bluetooth_status_cb,
 	.interface = {
 		.class_handler = bluetooth_class_handler,
 		.custom_handler = NULL,
 		.vendor_handler = NULL,
 	},
+	.list_of_interfaces = bluetooth_interfaces,
+	.num_of_interfaces = ARRAY_SIZE(bluetooth_interfaces),
 	.num_endpoints = ARRAY_SIZE(bluetooth_ep_data),
 	.endpoint = bluetooth_ep_data,
 };

--- a/subsys/usb/class/bt_h4.c
+++ b/subsys/usb/class/bt_h4.c
@@ -208,7 +208,6 @@ static void bt_h4_interface_config(struct usb_desc_header *head,
 }
 
 USBD_CFG_DATA_DEFINE(primary, hci_h4) struct usb_cfg_data bt_h4_config = {
-	.usb_device_description = NULL,
 	.interface_config = bt_h4_interface_config,
 	.interface_descriptor = &bt_h4_cfg.if0,
 	.cb_usb_status = bt_h4_status_cb,

--- a/subsys/usb/class/bt_h4.c
+++ b/subsys/usb/class/bt_h4.c
@@ -214,15 +214,15 @@ static void bt_h4_interface_config(struct usb_desc_header *head,
 USBD_CFG_DATA_DEFINE(primary, hci_h4) struct usb_cfg_data bt_h4_config = {
 	.interface_config = bt_h4_interface_config,
 	.cb_usb_status = bt_h4_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = NULL,
 		.custom_handler = NULL,
 		.vendor_handler = bt_h4_vendor_handler,
 	},
-	.num_of_interfaces = ARRAY_SIZE(bt_h4_if_data),
-	.list_of_interfaces = bt_h4_if_data,
+	.num_interfaces = ARRAY_SIZE(bt_h4_if_data),
+	.interfaces = bt_h4_if_data,
 	.num_endpoints = ARRAY_SIZE(bt_h4_ep_data),
-	.endpoint = bt_h4_ep_data,
+	.endpoints = bt_h4_ep_data,
 };
 
 static int bt_h4_init(struct device *dev)

--- a/subsys/usb/class/bt_h4.c
+++ b/subsys/usb/class/bt_h4.c
@@ -92,6 +92,10 @@ static struct usb_ep_cfg_data bt_h4_ep_data[] = {
 	},
 };
 
+static const struct usb_if_descriptor *const bt_h4_if_data[] = {
+	&bt_h4_cfg.if0,
+};
+
 static void bt_h4_read(uint8_t ep, int size, void *priv)
 {
 	static uint8_t data[BT_H4_BULK_EP_MPS];
@@ -209,13 +213,14 @@ static void bt_h4_interface_config(struct usb_desc_header *head,
 
 USBD_CFG_DATA_DEFINE(primary, hci_h4) struct usb_cfg_data bt_h4_config = {
 	.interface_config = bt_h4_interface_config,
-	.interface_descriptor = &bt_h4_cfg.if0,
 	.cb_usb_status = bt_h4_status_cb,
 	.interface = {
 		.class_handler = NULL,
 		.custom_handler = NULL,
 		.vendor_handler = bt_h4_vendor_handler,
 	},
+	.num_of_interfaces = ARRAY_SIZE(bt_h4_if_data),
+	.list_of_interfaces = bt_h4_if_data,
 	.num_endpoints = ARRAY_SIZE(bt_h4_ep_data),
 	.endpoint = bt_h4_ep_data,
 };

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -988,7 +988,6 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 #define DEFINE_CDC_ACM_CFG_DATA(x, _)					\
 	USBD_CFG_DATA_DEFINE(primary, cdc_acm)				\
 	struct usb_cfg_data cdc_acm_config_##x = {			\
-		.usb_device_description = NULL,				\
 		.interface_config = cdc_interface_config,		\
 		.interface_descriptor = &cdc_acm_cfg_##x.if0,		\
 		.cb_usb_status = cdc_acm_dev_status_cb,			\

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -289,7 +289,7 @@ static void tx_work_handler(struct k_work *work)
 		CONTAINER_OF(work, struct cdc_acm_dev_data_t, tx_work);
 	struct device *dev = dev_data->common.dev;
 	struct usb_cfg_data *cfg = (void *)dev->config_info;
-	uint8_t ep = cfg->endpoint[ACM_IN_EP_IDX].ep_addr;
+	uint8_t ep = cfg->endpoints[ACM_IN_EP_IDX].ep_addr;
 	uint8_t *data;
 	size_t len;
 
@@ -420,7 +420,7 @@ static void cdc_acm_do_cb(struct cdc_acm_dev_data_t *dev_data,
 		LOG_DBG("USB device connected");
 		break;
 	case USB_DC_CONFIGURED:
-		cdc_acm_read_cb(cfg->endpoint[ACM_OUT_EP_IDX].ep_addr, 0,
+		cdc_acm_read_cb(cfg->endpoints[ACM_OUT_EP_IDX].ep_addr, 0,
 				dev_data);
 		dev_data->tx_ready = true;
 		dev_data->tx_irq_ena = true;
@@ -791,7 +791,7 @@ static int cdc_acm_send_notification(struct device *dev, uint16_t serial_state)
 
 	dev_data->notification_sent = 0U;
 
-	usb_write(cfg->endpoint[ACM_INT_EP_IDX].ep_addr,
+	usb_write(cfg->endpoints[ACM_INT_EP_IDX].ep_addr,
 		  (const uint8_t *)&notification, sizeof(notification), NULL);
 
 	/* Wait for notification to be sent */
@@ -995,14 +995,14 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 	struct usb_cfg_data cdc_acm_config_##x = {			\
 		.interface_config = cdc_interface_config,		\
 		.cb_usb_status = cdc_acm_dev_status_cb,			\
-		.interface = {						\
+		.request_handlers = {					\
 			.class_handler = cdc_acm_class_handle_req,	\
 			.custom_handler = NULL,				\
 		},							\
-		.num_of_interfaces = ARRAY_SIZE(cdc_acm_if_data_##x),	\
-		.list_of_interfaces = cdc_acm_if_data_##x,		\
+		.num_interfaces = ARRAY_SIZE(cdc_acm_if_data_##x),	\
+		.interfaces = cdc_acm_if_data_##x,		\
 		.num_endpoints = ARRAY_SIZE(cdc_acm_ep_data_##x),	\
-		.endpoint = cdc_acm_ep_data_##x,			\
+		.endpoints = cdc_acm_ep_data_##x,			\
 	};
 
 #if (CONFIG_USB_COMPOSITE_DEVICE || CONFIG_CDC_ACM_IAD)

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -976,25 +976,31 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 		.ep_addr = addr,					\
 	}
 
-#define DEFINE_CDC_ACM_EP(x, int_ep_addr, out_ep_addr, in_ep_addr)	\
+#define DEFINE_CDC_ACM_EP_IF(x, int_ep_addr, out_ep_addr, in_ep_addr)	\
 	static struct usb_ep_cfg_data cdc_acm_ep_data_##x[] = {		\
 		INITIALIZER_EP_DATA(cdc_acm_int_in, int_ep_addr),	\
 		INITIALIZER_EP_DATA(usb_transfer_ep_callback,		\
 				    out_ep_addr),			\
 		INITIALIZER_EP_DATA(usb_transfer_ep_callback,		\
 				    in_ep_addr),			\
+	};								\
+	static struct usb_if_descriptor const *const			\
+	cdc_acm_if_data_##x[] = {					\
+		&cdc_acm_cfg_##x.if0,					\
+		&cdc_acm_cfg_##x.if1,					\
 	}
 
 #define DEFINE_CDC_ACM_CFG_DATA(x, _)					\
 	USBD_CFG_DATA_DEFINE(primary, cdc_acm)				\
 	struct usb_cfg_data cdc_acm_config_##x = {			\
 		.interface_config = cdc_interface_config,		\
-		.interface_descriptor = &cdc_acm_cfg_##x.if0,		\
 		.cb_usb_status = cdc_acm_dev_status_cb,			\
 		.interface = {						\
 			.class_handler = cdc_acm_class_handle_req,	\
 			.custom_handler = NULL,				\
 		},							\
+		.num_of_interfaces = ARRAY_SIZE(cdc_acm_if_data_##x),	\
+		.list_of_interfaces = cdc_acm_if_data_##x,		\
 		.num_endpoints = ARRAY_SIZE(cdc_acm_ep_data_##x),	\
 		.endpoint = cdc_acm_ep_data_##x,			\
 	};
@@ -1074,11 +1080,11 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 #define DEFINE_CDC_ACM_DESCR_AUTO(x, _) \
 	DEFINE_CDC_ACM_DESCR(x, AUTO_EP_IN, AUTO_EP_OUT, AUTO_EP_IN);
 
-#define DEFINE_CDC_ACM_EP_AUTO(x, _) \
-	DEFINE_CDC_ACM_EP(x, AUTO_EP_IN, AUTO_EP_OUT, AUTO_EP_IN);
+#define DEFINE_CDC_ACM_EP_IF_AUTO(x, _) \
+	DEFINE_CDC_ACM_EP_IF(x, AUTO_EP_IN, AUTO_EP_OUT, AUTO_EP_IN);
 
 UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_DESCR_AUTO, _)
-UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_EP_AUTO, _)
+UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_EP_IF_AUTO, _)
 UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_CFG_DATA, _)
 UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_DEV_DATA, _)
 UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_DEVICE, _)

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -632,7 +632,6 @@ static void hid_interface_config(struct usb_desc_header *head,
 #define DEFINE_HID_CFG_DATA(x, _)					\
 	USBD_CFG_DATA_DEFINE(primary, hid)				\
 	struct usb_cfg_data hid_config_##x = {				\
-		.usb_device_description = NULL,				\
 		.interface_config = hid_interface_config,		\
 		.interface_descriptor = &hid_cfg_##x.if0,		\
 		.cb_usb_status = hid_status_cb,				\

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -283,7 +283,7 @@ static int hid_on_set_protocol(struct hid_device_info *dev_data,
 
 static void usb_set_hid_report_size(const struct usb_cfg_data *cfg, uint16_t size)
 {
-	const struct usb_if_descriptor *const if_desc = cfg->list_of_interfaces[0];
+	const struct usb_if_descriptor *const if_desc = cfg->interfaces[0];
 	struct usb_hid_config *desc =
 			CONTAINER_OF(if_desc, struct usb_hid_config, if0);
 
@@ -520,7 +520,7 @@ static int hid_custom_handle_req(struct usb_setup_packet *setup,
 		switch (value) {
 		case HID_CLASS_DESCRIPTOR_HID:
 			cfg = common->dev->config_info;
-			if_desc = cfg->list_of_interfaces[0];
+			if_desc = cfg->interfaces[0];
 			hid_desc = CONTAINER_OF(if_desc,
 						struct usb_hid_config, if0);
 
@@ -641,14 +641,14 @@ static void hid_interface_config(struct usb_desc_header *head,
 	struct usb_cfg_data hid_config_##x = {				\
 		.interface_config = hid_interface_config,		\
 		.cb_usb_status = hid_status_cb,				\
-		.interface = {						\
+		.request_handlers = {					\
 			.class_handler = hid_class_handle_req,		\
 			.custom_handler = hid_custom_handle_req,	\
 		},							\
-		.list_of_interfaces = hid_if_data_##x,			\
-		.num_of_interfaces = ARRAY_SIZE(hid_if_data_##x),	\
+		.interfaces = hid_if_data_##x,				\
+		.num_interfaces = ARRAY_SIZE(hid_if_data_##x),		\
 		.num_endpoints = ARRAY_SIZE(hid_ep_data_##x),		\
-		.endpoint = hid_ep_data_##x,				\
+		.endpoints = hid_ep_data_##x,				\
 	};
 
 int usb_hid_init(const struct device *dev)
@@ -688,7 +688,7 @@ int hid_int_ep_write(const struct device *dev, const uint8_t *data, uint32_t dat
 {
 	const struct usb_cfg_data *cfg = dev->config_info;
 
-	return usb_write(cfg->endpoint[HID_INT_IN_EP_IDX].ep_addr, data,
+	return usb_write(cfg->endpoints[HID_INT_IN_EP_IDX].ep_addr, data,
 			 data_len, bytes_ret);
 }
 
@@ -698,7 +698,7 @@ int hid_int_ep_read(const struct device *dev, uint8_t *data, uint32_t max_data_l
 #ifdef CONFIG_ENABLE_HID_INT_OUT_EP
 	const struct usb_cfg_data *cfg = dev->config_info;
 
-	return usb_read(cfg->endpoint[HID_INT_OUT_EP_IDX].ep_addr,
+	return usb_read(cfg->endpoints[HID_INT_OUT_EP_IDX].ep_addr,
 			data, max_data_len, ret_bytes);
 #else
 	return -ENOTSUP;

--- a/subsys/usb/class/loopback.c
+++ b/subsys/usb/class/loopback.c
@@ -160,7 +160,6 @@ static void loopback_interface_config(struct usb_desc_header *head,
 
 /* usb.rst device config data start */
 USBD_CFG_DATA_DEFINE(primary, loopback) struct usb_cfg_data loopback_config = {
-	.usb_device_description = NULL,
 	.interface_config = loopback_interface_config,
 	.interface_descriptor = &loopback_cfg.if0,
 	.cb_usb_status = loopback_status_cb,

--- a/subsys/usb/class/loopback.c
+++ b/subsys/usb/class/loopback.c
@@ -166,14 +166,14 @@ static void loopback_interface_config(struct usb_desc_header *head,
 USBD_CFG_DATA_DEFINE(primary, loopback) struct usb_cfg_data loopback_config = {
 	.interface_config = loopback_interface_config,
 	.cb_usb_status = loopback_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = NULL,
 		.custom_handler = NULL,
 		.vendor_handler = loopback_vendor_handler,
 	},
-	.num_of_interfaces = ARRAY_SIZE(iface),
-	.list_of_interfaces = iface,
+	.num_interfaces = ARRAY_SIZE(iface),
+	.interfaces = iface,
 	.num_endpoints = ARRAY_SIZE(ep_cfg),
-	.endpoint = ep_cfg,
+	.endpoints = ep_cfg,
 };
 /* usb.rst device config data end */

--- a/subsys/usb/class/loopback.c
+++ b/subsys/usb/class/loopback.c
@@ -97,6 +97,10 @@ static struct usb_ep_cfg_data ep_cfg[] = {
 };
 /* usb.rst endpoint configuration end */
 
+static const struct usb_if_descriptor *const iface[] = {
+	&loopback_cfg.if0,
+};
+
 static void loopback_status_cb(struct usb_cfg_data *cfg,
 			       enum usb_dc_status_code status,
 			       const uint8_t *param)
@@ -161,13 +165,14 @@ static void loopback_interface_config(struct usb_desc_header *head,
 /* usb.rst device config data start */
 USBD_CFG_DATA_DEFINE(primary, loopback) struct usb_cfg_data loopback_config = {
 	.interface_config = loopback_interface_config,
-	.interface_descriptor = &loopback_cfg.if0,
 	.cb_usb_status = loopback_status_cb,
 	.interface = {
 		.class_handler = NULL,
 		.custom_handler = NULL,
 		.vendor_handler = loopback_vendor_handler,
 	},
+	.num_of_interfaces = ARRAY_SIZE(iface),
+	.list_of_interfaces = iface,
 	.num_endpoints = ARRAY_SIZE(ep_cfg),
 	.endpoint = ep_cfg,
 };

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -890,7 +890,6 @@ static void mass_interface_config(struct usb_desc_header *head,
 
 /* Configuration of the Mass Storage Device send to the USB Driver */
 USBD_CFG_DATA_DEFINE(primary, msd) struct usb_cfg_data mass_storage_config = {
-	.usb_device_description = NULL,
 	.interface_config = mass_interface_config,
 	.interface_descriptor = &mass_cfg.if0,
 	.cb_usb_status = mass_storage_status_cb,

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -896,14 +896,14 @@ static void mass_interface_config(struct usb_desc_header *head,
 USBD_CFG_DATA_DEFINE(primary, msd) struct usb_cfg_data mass_storage_config = {
 	.interface_config = mass_interface_config,
 	.cb_usb_status = mass_storage_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = mass_storage_class_handle_req,
 		.custom_handler = NULL,
 	},
-	.num_of_interfaces = ARRAY_SIZE(mass_if_data),
-	.list_of_interfaces = mass_if_data,
+	.num_interfaces = ARRAY_SIZE(mass_if_data),
+	.interfaces = mass_if_data,
 	.num_endpoints = ARRAY_SIZE(mass_ep_data),
-	.endpoint = mass_ep_data
+	.endpoints = mass_ep_data
 };
 
 static void mass_thread_main(int arg1, int unused)

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -144,6 +144,10 @@ static struct usb_ep_cfg_data mass_ep_data[] = {
 	}
 };
 
+static const struct usb_if_descriptor *const mass_if_data[] = {
+	&mass_cfg.if0,
+};
+
 /* CSW Status */
 enum Status {
 	CSW_PASSED,
@@ -891,12 +895,13 @@ static void mass_interface_config(struct usb_desc_header *head,
 /* Configuration of the Mass Storage Device send to the USB Driver */
 USBD_CFG_DATA_DEFINE(primary, msd) struct usb_cfg_data mass_storage_config = {
 	.interface_config = mass_interface_config,
-	.interface_descriptor = &mass_cfg.if0,
 	.cb_usb_status = mass_storage_status_cb,
 	.interface = {
 		.class_handler = mass_storage_class_handle_req,
 		.custom_handler = NULL,
 	},
+	.num_of_interfaces = ARRAY_SIZE(mass_if_data),
+	.list_of_interfaces = mass_if_data,
 	.num_endpoints = ARRAY_SIZE(mass_ep_data),
 	.endpoint = mass_ep_data
 };

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -429,7 +429,6 @@ static void ecm_interface_config(struct usb_desc_header *head,
 }
 
 USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
-	.usb_device_description = NULL,
 	.interface_config = ecm_interface_config,
 	.interface_descriptor = &cdc_ecm_cfg.if0,
 	.cb_usb_status = ecm_status_cb,

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -370,6 +370,10 @@ static int ecm_custom_handler(struct usb_setup_packet *setup, int32_t *len,
 				return -ENOTSUP;
 			}
 			LOG_DBG("Set interface iface: %d, alt: %d", iface, alt);
+			/* This request needs further processing in the core
+			 * USB stack, hence -EINVAL is returned. Refer to
+			 * documentation for custom_handler in the usb_device.h
+			 */
 			return -EINVAL;
 		case REQ_GET_INTERFACE:
 			*data[0] = alternate_setting;

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -457,13 +457,13 @@ static void ecm_interface_config(struct usb_desc_header *head,
 USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
 	.interface_config = ecm_interface_config,
 	.cb_usb_status = ecm_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = ecm_class_handler,
 		.custom_handler = ecm_custom_handler,
 		.vendor_handler = NULL,
 	},
-	.num_of_interfaces  = ARRAY_SIZE(ecm_if_data),
-	.list_of_interfaces = ecm_if_data,
+	.num_interfaces  = ARRAY_SIZE(ecm_if_data),
+	.interfaces = ecm_if_data,
 	.num_endpoints = ARRAY_SIZE(ecm_ep_data),
-	.endpoint = ecm_ep_data,
+	.endpoints = ecm_ep_data,
 };

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -192,6 +192,12 @@ static struct usb_ep_cfg_data ecm_ep_data[] = {
 	},
 };
 
+static const struct usb_if_descriptor *const ecm_if_data[] = {
+	&cdc_ecm_cfg.if0,
+	&cdc_ecm_cfg.if1_0,
+	&cdc_ecm_cfg.if1_1,
+};
+
 static int ecm_class_handler(struct usb_setup_packet *setup, int32_t *len,
 			     uint8_t **data)
 {
@@ -430,13 +436,14 @@ static void ecm_interface_config(struct usb_desc_header *head,
 
 USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
 	.interface_config = ecm_interface_config,
-	.interface_descriptor = &cdc_ecm_cfg.if0,
 	.cb_usb_status = ecm_status_cb,
 	.interface = {
 		.class_handler = ecm_class_handler,
 		.custom_handler = NULL,
 		.vendor_handler = NULL,
 	},
+	.num_of_interfaces  = ARRAY_SIZE(ecm_if_data),
+	.list_of_interfaces = ecm_if_data,
 	.num_endpoints = ARRAY_SIZE(ecm_ep_data),
 	.endpoint = ecm_ep_data,
 };

--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -281,7 +281,6 @@ static void eem_interface_config(struct usb_desc_header *head,
 }
 
 USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
-	.usb_device_description = NULL,
 	.interface_config = eem_interface_config,
 	.interface_descriptor = &cdc_eem_cfg.if0,
 	.cb_usb_status = eem_status_cb,

--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -287,13 +287,13 @@ static void eem_interface_config(struct usb_desc_header *head,
 USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
 	.interface_config = eem_interface_config,
 	.cb_usb_status = eem_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = NULL,
 		.custom_handler = NULL,
 		.vendor_handler = NULL,
 	},
-	.num_of_interfaces = ARRAY_SIZE(eem_if_data),
-	.list_of_interfaces = eem_if_data,
+	.num_interfaces = ARRAY_SIZE(eem_if_data),
+	.interfaces = eem_if_data,
 	.num_endpoints = ARRAY_SIZE(eem_ep_data),
-	.endpoint = eem_ep_data,
+	.endpoints = eem_ep_data,
 };

--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -90,6 +90,10 @@ static struct usb_ep_cfg_data eem_ep_data[] = {
 	},
 };
 
+static const struct usb_if_descriptor *const eem_if_data[] = {
+	&cdc_eem_cfg.if0,
+};
+
 static inline uint16_t eem_pkt_size(uint16_t hdr)
 {
 	if (hdr & BIT(15)) {
@@ -282,13 +286,14 @@ static void eem_interface_config(struct usb_desc_header *head,
 
 USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
 	.interface_config = eem_interface_config,
-	.interface_descriptor = &cdc_eem_cfg.if0,
 	.cb_usb_status = eem_status_cb,
 	.interface = {
 		.class_handler = NULL,
 		.custom_handler = NULL,
 		.vendor_handler = NULL,
 	},
+	.num_of_interfaces = ARRAY_SIZE(eem_if_data),
+	.list_of_interfaces = eem_if_data,
 	.num_endpoints = ARRAY_SIZE(eem_ep_data),
 	.endpoint = eem_ep_data,
 };

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -1167,7 +1167,6 @@ static void netusb_interface_config(struct usb_desc_header *head,
 }
 
 USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
-	.usb_device_description = NULL,
 	.interface_config = netusb_interface_config,
 	.interface_descriptor = &rndis_cfg.if0,
 	.cb_usb_status = rndis_status_cb,

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -273,6 +273,11 @@ static struct usb_ep_cfg_data rndis_ep_data[] = {
 	},
 };
 
+static const struct usb_if_descriptor *const rndis_if_data[] = {
+	&rndis_cfg.if0,
+	&rndis_cfg.if1,
+};
+
 static int parse_rndis_header(const uint8_t *buffer, uint32_t buf_len)
 {
 	struct rndis_payload_packet *hdr = (void *)buffer;
@@ -1168,13 +1173,14 @@ static void netusb_interface_config(struct usb_desc_header *head,
 
 USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
 	.interface_config = netusb_interface_config,
-	.interface_descriptor = &rndis_cfg.if0,
 	.cb_usb_status = rndis_status_cb,
 	.interface = {
 		.class_handler = rndis_class_handler,
 		.custom_handler = NULL,
 		.vendor_handler = NULL,
 	},
+	.num_of_interfaces = ARRAY_SIZE(rndis_if_data),
+	.list_of_interfaces = rndis_if_data,
 	.num_endpoints = ARRAY_SIZE(rndis_ep_data),
 	.endpoint = rndis_ep_data,
 };

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -1174,15 +1174,15 @@ static void netusb_interface_config(struct usb_desc_header *head,
 USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
 	.interface_config = netusb_interface_config,
 	.cb_usb_status = rndis_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = rndis_class_handler,
 		.custom_handler = NULL,
 		.vendor_handler = NULL,
 	},
-	.num_of_interfaces = ARRAY_SIZE(rndis_if_data),
-	.list_of_interfaces = rndis_if_data,
+	.num_interfaces = ARRAY_SIZE(rndis_if_data),
+	.interfaces = rndis_if_data,
 	.num_endpoints = ARRAY_SIZE(rndis_ep_data),
-	.endpoint = rndis_ep_data,
+	.endpoints = rndis_ep_data,
 };
 
 /* Initialize this before eth_netusb device init */

--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -579,8 +579,7 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 		 */
 
 		/* Set the DFU mode descriptors to be used after reset */
-		dfu_config.usb_device_description = (uint8_t *) &dfu_mode_desc;
-		if (usb_set_config(dfu_config.usb_device_description) != 0) {
+		if (usb_set_config((uint8_t *)&dfu_mode_desc) != 0) {
 			LOG_ERR("usb_set_config failed in DFU_DETACH");
 			return -EIO;
 		}
@@ -707,7 +706,6 @@ static void dfu_interface_config(struct usb_desc_header *head,
 
 /* Configuration of the DFU Device send to the USB Driver */
 USBD_CFG_DATA_DEFINE(primary, dfu) struct usb_cfg_data dfu_config = {
-	.usb_device_description = NULL,
 	.interface_config = dfu_interface_config,
 	.interface_descriptor = &dfu_cfg.if0,
 	.cb_usb_status = dfu_status_cb,
@@ -723,7 +721,6 @@ USBD_CFG_DATA_DEFINE(primary, dfu) struct usb_cfg_data dfu_config = {
  * which is an alternative (secondary) device descriptor.
  */
 USBD_CFG_DATA_DEFINE(secondary, dfu) struct usb_cfg_data dfu_mode_config = {
-	.usb_device_description = NULL,
 	.interface_config = NULL,
 	.interface_descriptor = &dfu_mode_desc.sec_dfu_cfg.if0,
 	.cb_usb_status = dfu_status_cb,

--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -115,6 +115,10 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_dfu_config dfu_cfg = {
 	},
 };
 
+static const struct usb_if_descriptor *const dfu_cfg_ifs[] = {
+	&dfu_cfg.if0,
+};
+
 /* dfu mode device descriptor */
 
 struct dev_dfu_mode_descriptor {
@@ -196,6 +200,11 @@ struct dev_dfu_mode_descriptor dfu_mode_desc = {
 				sys_cpu_to_le16(DFU_VERSION),
 		},
 	},
+};
+
+static const struct usb_if_descriptor *const dfu_mode_desc_ifs[] = {
+	&dfu_mode_desc.sec_dfu_cfg.if0,
+	&dfu_mode_desc.sec_dfu_cfg.if1,
 };
 
 struct usb_string_desription {
@@ -707,12 +716,13 @@ static void dfu_interface_config(struct usb_desc_header *head,
 /* Configuration of the DFU Device send to the USB Driver */
 USBD_CFG_DATA_DEFINE(primary, dfu) struct usb_cfg_data dfu_config = {
 	.interface_config = dfu_interface_config,
-	.interface_descriptor = &dfu_cfg.if0,
 	.cb_usb_status = dfu_status_cb,
 	.interface = {
 		.class_handler = dfu_class_handle_req,
 		.custom_handler = dfu_custom_handle_req,
 	},
+	.num_of_interfaces = ARRAY_SIZE(dfu_cfg_ifs),
+	.list_of_interfaces = dfu_cfg_ifs,
 	.num_endpoints = 0,
 };
 
@@ -722,12 +732,13 @@ USBD_CFG_DATA_DEFINE(primary, dfu) struct usb_cfg_data dfu_config = {
  */
 USBD_CFG_DATA_DEFINE(secondary, dfu) struct usb_cfg_data dfu_mode_config = {
 	.interface_config = NULL,
-	.interface_descriptor = &dfu_mode_desc.sec_dfu_cfg.if0,
 	.cb_usb_status = dfu_status_cb,
 	.interface = {
 		.class_handler = dfu_class_handle_req,
 		.custom_handler = dfu_custom_handle_req,
 	},
+	.num_of_interfaces = ARRAY_SIZE(dfu_mode_desc_ifs),
+	.list_of_interfaces = dfu_mode_desc_ifs,
 	.num_endpoints = 0,
 };
 

--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -717,12 +717,12 @@ static void dfu_interface_config(struct usb_desc_header *head,
 USBD_CFG_DATA_DEFINE(primary, dfu) struct usb_cfg_data dfu_config = {
 	.interface_config = dfu_interface_config,
 	.cb_usb_status = dfu_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = dfu_class_handle_req,
 		.custom_handler = dfu_custom_handle_req,
 	},
-	.num_of_interfaces = ARRAY_SIZE(dfu_cfg_ifs),
-	.list_of_interfaces = dfu_cfg_ifs,
+	.num_interfaces = ARRAY_SIZE(dfu_cfg_ifs),
+	.interfaces = dfu_cfg_ifs,
 	.num_endpoints = 0,
 };
 
@@ -733,12 +733,12 @@ USBD_CFG_DATA_DEFINE(primary, dfu) struct usb_cfg_data dfu_config = {
 USBD_CFG_DATA_DEFINE(secondary, dfu) struct usb_cfg_data dfu_mode_config = {
 	.interface_config = NULL,
 	.cb_usb_status = dfu_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = dfu_class_handle_req,
 		.custom_handler = dfu_custom_handle_req,
 	},
-	.num_of_interfaces = ARRAY_SIZE(dfu_mode_desc_ifs),
-	.list_of_interfaces = dfu_mode_desc_ifs,
+	.num_interfaces = ARRAY_SIZE(dfu_mode_desc_ifs),
+	.interfaces = dfu_mode_desc_ifs,
 	.num_endpoints = 0,
 };
 

--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -285,10 +285,15 @@ static int usb_validate_ep_cfg_data(struct usb_ep_descriptor * const ep_descr,
 static struct usb_cfg_data *usb_get_cfg_data(struct usb_if_descriptor *iface)
 {
 	size_t length = (__usb_data_end - __usb_data_start);
+	struct usb_cfg_data *cfg = NULL;
 
 	for (size_t i = 0; i < length; i++) {
-		if (__usb_data_start[i].interface_descriptor == iface) {
-			return &__usb_data_start[i];
+		cfg = &__usb_data_start[i];
+
+		for (size_t j = 0; j < cfg->num_of_interfaces; j++) {
+			if (cfg->list_of_interfaces[j] == iface) {
+				return cfg;
+			}
 		}
 	}
 
@@ -505,11 +510,13 @@ struct usb_dev_data *usb_get_dev_data_by_iface(sys_slist_t *list,
 	SYS_SLIST_FOR_EACH_CONTAINER(list, dev_data, node) {
 		struct device *dev = dev_data->dev;
 		const struct usb_cfg_data *cfg = dev->config_info;
-		const struct usb_if_descriptor *if_desc =
-						cfg->interface_descriptor;
+		const struct usb_if_descriptor *if_desc = NULL;
 
-		if (if_desc->bInterfaceNumber == iface_num) {
-			return dev_data;
+		for (int i = 0; i < cfg->num_of_interfaces; i++) {
+			if_desc = cfg->list_of_interfaces[i];
+			if (if_desc->bInterfaceNumber == iface_num) {
+				return dev_data;
+			}
 		}
 	}
 

--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -229,7 +229,7 @@ static int usb_validate_ep_cfg_data(struct usb_ep_descriptor * const ep_descr,
 				    uint32_t *requested_ep)
 {
 	for (int i = 0; i < cfg_data->num_endpoints; i++) {
-		struct usb_ep_cfg_data *ep_data = cfg_data->endpoint;
+		struct usb_ep_cfg_data *ep_data = cfg_data->endpoints;
 
 		/*
 		 * Trying to find the right entry in the usb_ep_cfg_data.
@@ -290,8 +290,8 @@ static struct usb_cfg_data *usb_get_cfg_data(struct usb_if_descriptor *iface)
 	for (size_t i = 0; i < length; i++) {
 		cfg = &__usb_data_start[i];
 
-		for (size_t j = 0; j < cfg->num_of_interfaces; j++) {
-			if (cfg->list_of_interfaces[j] == iface) {
+		for (size_t j = 0; j < cfg->num_interfaces; j++) {
+			if (cfg->interfaces[j] == iface) {
 				return cfg;
 			}
 		}
@@ -512,8 +512,8 @@ struct usb_dev_data *usb_get_dev_data_by_iface(sys_slist_t *list,
 		const struct usb_cfg_data *cfg = dev->config_info;
 		const struct usb_if_descriptor *if_desc = NULL;
 
-		for (int i = 0; i < cfg->num_of_interfaces; i++) {
-			if_desc = cfg->list_of_interfaces[i];
+		for (int i = 0; i < cfg->num_interfaces; i++) {
+			if_desc = cfg->interfaces[i];
 			if (if_desc->bInterfaceNumber == iface_num) {
 				return dev_data;
 			}
@@ -532,7 +532,7 @@ struct usb_dev_data *usb_get_dev_data_by_ep(sys_slist_t *list, uint8_t ep)
 	SYS_SLIST_FOR_EACH_CONTAINER(list, dev_data, node) {
 		struct device *dev = dev_data->dev;
 		const struct usb_cfg_data *cfg = dev->config_info;
-		const struct usb_ep_cfg_data *ep_data = cfg->endpoint;
+		const struct usb_ep_cfg_data *ep_data = cfg->endpoints;
 
 		for (uint8_t i = 0; i < cfg->num_endpoints; i++) {
 			if (ep_data[i].ep_addr == ep) {

--- a/tests/subsys/usb/desc_sections/src/desc_sections.c
+++ b/tests/subsys/usb/desc_sections/src/desc_sections.c
@@ -92,7 +92,6 @@ struct usb_test_config {
 #define DEFINE_TEST_CFG_DATA(x, _)				\
 	USBD_CFG_DATA_DEFINE(primary, test_##x)			\
 	struct usb_cfg_data test_config_##x = {			\
-	.usb_device_description = NULL,				\
 	.interface_config = interface_config,			\
 	.interface_descriptor = &test_cfg_##x.if0,		\
 	.cb_usb_status = NULL,					\

--- a/tests/subsys/usb/desc_sections/src/desc_sections.c
+++ b/tests/subsys/usb/desc_sections/src/desc_sections.c
@@ -100,15 +100,15 @@ struct usb_test_config {
 	struct usb_cfg_data test_config_##x = {			\
 	.interface_config = interface_config,			\
 	.cb_usb_status = NULL,					\
-	.interface = {						\
+	.request_handlers = {					\
 		.class_handler = NULL,				\
 		.custom_handler = NULL,				\
 		.vendor_handler = NULL,				\
 	},							\
-	.num_of_interfaces = ARRAY_SIZE(iface_cfg_##x),		\
-	.list_of_interfaces = iface_cfg_##x,			\
+	.num_interfaces = ARRAY_SIZE(iface_cfg_##x),		\
+	.interfaces = iface_cfg_##x,				\
 	.num_endpoints = ARRAY_SIZE(ep_cfg_##x),		\
-	.endpoint = ep_cfg_##x,					\
+	.endpoints = ep_cfg_##x,				\
 	};
 
 #define NUM_INSTANCES 2
@@ -136,8 +136,8 @@ static struct usb_cfg_data *usb_get_cfg_data(struct usb_if_descriptor *iface)
 	for (size_t i = 0; i < length; i++) {
 		cfg = &__usb_data_start[i];
 
-		for (size_t j = 0; j < cfg->num_of_interfaces; j++) {
-			if (cfg->list_of_interfaces[j] == iface) {
+		for (size_t j = 0; j < cfg->num_interfaces; j++) {
+			if (cfg->interfaces[j] == iface) {
 				return cfg;
 			}
 		}
@@ -151,7 +151,7 @@ static bool find_cfg_data_ep(const struct usb_ep_descriptor * const ep_descr,
 			     uint8_t ep_count)
 {
 	for (int i = 0; i < cfg_data->num_endpoints; i++) {
-		if (cfg_data->endpoint[i].ep_addr ==
+		if (cfg_data->endpoints[i].ep_addr ==
 				ep_descr->bEndpointAddress) {
 			LOG_DBG("found ep[%d] %x", i,
 				ep_descr->bEndpointAddress);

--- a/tests/subsys/usb/device/src/main.c
+++ b/tests/subsys/usb/device/src/main.c
@@ -76,7 +76,6 @@ static struct usb_ep_cfg_data device_ep[] = {
 };
 
 USBD_CFG_DATA_DEFINE(primary, device) struct usb_cfg_data device_config = {
-	.usb_device_description = NULL,
 	.interface_descriptor = &dev_desc.if0,
 	.cb_usb_status = status_cb,
 	.interface = {

--- a/tests/subsys/usb/device/src/main.c
+++ b/tests/subsys/usb/device/src/main.c
@@ -81,15 +81,15 @@ static struct usb_if_descriptor const *const device_if[] = {
 
 USBD_CFG_DATA_DEFINE(primary, device) struct usb_cfg_data device_config = {
 	.cb_usb_status = status_cb,
-	.interface = {
+	.request_handlers = {
 		.vendor_handler = NULL,
 		.class_handler = NULL,
 		.custom_handler = NULL,
 	},
-	.num_of_interfaces = ARRAY_SIZE(device_if),
-	.list_of_interfaces = device_if,
+	.num_interfaces = ARRAY_SIZE(device_if),
+	.interfaces = device_if,
 	.num_endpoints = ARRAY_SIZE(device_ep),
-	.endpoint = device_ep,
+	.endpoints = device_ep,
 };
 
 static void test_usb_disable(void)

--- a/tests/subsys/usb/device/src/main.c
+++ b/tests/subsys/usb/device/src/main.c
@@ -75,14 +75,19 @@ static struct usb_ep_cfg_data device_ep[] = {
 	},
 };
 
+static struct usb_if_descriptor const *const device_if[] = {
+	&dev_desc.if0,
+};
+
 USBD_CFG_DATA_DEFINE(primary, device) struct usb_cfg_data device_config = {
-	.interface_descriptor = &dev_desc.if0,
 	.cb_usb_status = status_cb,
 	.interface = {
 		.vendor_handler = NULL,
 		.class_handler = NULL,
 		.custom_handler = NULL,
 	},
+	.num_of_interfaces = ARRAY_SIZE(device_if),
+	.list_of_interfaces = device_if,
 	.num_endpoints = ARRAY_SIZE(device_ep),
 	.endpoint = device_ep,
 };


### PR DESCRIPTION
Rework the way how the interfaces are handled by the USB core stack.
Until now USB stack was aware of only the first interface associated
with each class. This led to a problem when not first interface was
addressed by the request.

The usb_cfg_data struct is legacy of initial implementation
of USB device stack. It was implemented to support single function
devices with no composite support. The usb_cfg_data struct was
intended to be used to configure the device by calling
usb_set_config(). Because of how things grow this structure
was used to represent the USB functions rather than USB devices.

This patch:
 - allow to filter out the request at core level.
 - removes device configuration descriptor pointer.
   Adds pointer to list of pointers to USB interface descriptors
   associated with the function it represents.
 - renames some usb_cfg_data structure fields:
    interface -> request_handlers
	Name interface was used here as a communication interface
	between USB core stack and Class implementations.
	This naming could be missleading as USB specification defines
	interface as a part of the USB device descriptor.
    endpoint -> endpoints
	This change was made to reflect that there might be more than one
	endpoint. Additionaly it makes it consistent with newly added
	'interfaces' field.

Fixes: #24200 (USB3CV Chapter 9 tests for ECM)