### PR TITLE
 canbus: canopen: program: fix bug when flash area alignment > 4

### DIFF
--- a/subsys/canbus/canopen/canopen_program.c
+++ b/subsys/canbus/canopen/canopen_program.c
@@ -120,9 +120,14 @@ static CO_SDO_abortCode_t canopen_odf_1f50(CO_ODF_arg_t *odf_arg)
 	}
 
 	if (odf_arg->lastSegment) {
+		int align = flash_area_align(ctx.flash_img_ctx.flash_area);
+		int total_align = ((ctx.total % align) == 0) ?
+			ctx.total : ctx.total + align - (ctx.total % align);
+
 		/* ctx.total is zero if not provided by download process */
 		if (ctx.total != 0 &&
-		    ctx.total != flash_img_bytes_written(&ctx.flash_img_ctx)) {
+		    (total_align !=
+		     flash_img_bytes_written(&ctx.flash_img_ctx))) {
 			LOG_WRN("premature end of program download");
 			ctx.flash_status = FLASH_STATUS_DATA_FORMAT_ERROR;
 		} else {

--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -50,9 +50,6 @@ int flash_img_buffered_write(struct flash_img_context *ctx, uint8_t *data,
 	}
 #endif
 
-	flash_area_close(ctx->flash_area);
-	ctx->flash_area = NULL;
-
 	return rc;
 }
 


### PR DESCRIPTION
When the flash area alignment > 4, the bytes written could be greater than the total expected. So, we need to align the total expected with the flash area alignment.

For example, for an alignment of 8, an image of 133 bytes will write 136 bytes.