### PR TITLE
boards: arm: Fix deprecated "gccarmemb" toolchain references

### DIFF
--- a/boards/arm/96b_avenger96/96b_avenger96.yaml
+++ b/boards/arm/96b_avenger96/96b_avenger96.yaml
@@ -4,7 +4,7 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
-  - gccarmemb
+  - gnuarmemb
   - xtools
 supported:
   - gpio

--- a/boards/arm/efm32gg_stk3701a/efm32gg_stk3701a.yaml
+++ b/boards/arm/efm32gg_stk3701a/efm32gg_stk3701a.yaml
@@ -6,7 +6,7 @@ ram: 512
 flash: 2048
 toolchain:
   - zephyr
-  - gccarmemb
+  - gnuarmemb
   - xtools
 supported:
   - i2c

--- a/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a.yaml
+++ b/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a.yaml
@@ -6,7 +6,7 @@ ram: 256
 flash: 1024
 toolchain:
   - zephyr
-  - gccarmemb
+  - gnuarmemb
   - xtools
 supported:
   - i2c

--- a/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a_jg.yaml
+++ b/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a_jg.yaml
@@ -6,7 +6,7 @@ ram: 256
 flash: 1024
 toolchain:
   - zephyr
-  - gccarmemb
+  - gnuarmemb
   - xtools
 supported:
   - i2c

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.yaml
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.yaml
@@ -4,7 +4,7 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
-  - gccarmemb
+  - gnuarmemb
   - xtools
 ram: 96
 flash: 1024

--- a/boards/arm/stm32mp157c_dk2/stm32mp157c_dk2.yaml
+++ b/boards/arm/stm32mp157c_dk2/stm32mp157c_dk2.yaml
@@ -4,7 +4,7 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
-  - gccarmemb
+  - gnuarmemb
   - xtools
 supported:
   - arduino_i2c


### PR DESCRIPTION
The "gccarmemb" toolchain type has been renamed to "gnuarmemb" to
better reflect the official naming.

This commit replaces all references to the "gccarmemb" toolchain type
to "gnuarmemb".

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>