### PR TITLE
device: replace DEVICE_AND_API_INIT with DEVICE_DEFINE

### DIFF
--- a/arch/x86/core/multiboot.c
+++ b/arch/x86/core/multiboot.c
@@ -143,10 +143,10 @@ static int multiboot_framebuf_init(struct device *dev)
 	}
 }
 
-DEVICE_AND_API_INIT(multiboot_framebuf,
+DEVICE_DEFINE(multiboot_framebuf,
 		    "FRAMEBUF",
 		    multiboot_framebuf_init,
-		    &multiboot_framebuf_data,
+		    device_pm_control_nop, &multiboot_framebuf_data,
 		    NULL,
 		    PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,

--- a/boards/arm/thingy52_nrf52832/board.c
+++ b/boards/arm/thingy52_nrf52832/board.c
@@ -52,8 +52,9 @@ static const struct pwr_ctrl_cfg vdd_pwr_ctrl_cfg = {
 	.pin = VDD_PWR_CTRL_GPIO_PIN,
 };
 
-DEVICE_INIT(vdd_pwr_ctrl_init, "", pwr_ctrl_init, NULL, &vdd_pwr_ctrl_cfg,
-	    POST_KERNEL, CONFIG_BOARD_VDD_PWR_CTRL_INIT_PRIORITY);
+DEVICE_DEFINE(vdd_pwr_ctrl_init, "", pwr_ctrl_init, device_pm_control_nop,
+	      NULL, &vdd_pwr_ctrl_cfg,
+	      POST_KERNEL, CONFIG_BOARD_VDD_PWR_CTRL_INIT_PRIORITY, api);
 
 #ifdef CONFIG_SENSOR
 
@@ -70,8 +71,9 @@ static const struct pwr_ctrl_cfg ccs_vdd_pwr_ctrl_cfg = {
 	.pin = CCS_VDD_PWR_CTRL_GPIO_PIN,
 };
 
-DEVICE_INIT(ccs_vdd_pwr_ctrl_init, "", pwr_ctrl_init, NULL,
-	    &ccs_vdd_pwr_ctrl_cfg, POST_KERNEL,
-	    CONFIG_BOARD_CCS_VDD_PWR_CTRL_INIT_PRIORITY);
+DEVICE_DEFINE(ccs_vdd_pwr_ctrl_init, "", pwr_ctrl_init, device_pm_control_nop,
+	      NULL,
+	      &ccs_vdd_pwr_ctrl_cfg, POST_KERNEL,
+	      CONFIG_BOARD_CCS_VDD_PWR_CTRL_INIT_PRIORITY, api);
 
 #endif

--- a/drivers/adc/adc_lmp90xxx.c
+++ b/drivers/adc/adc_lmp90xxx.c
@@ -1108,9 +1108,10 @@ static const struct adc_driver_api lmp90xxx_adc_api = {
 		.resolution = res, \
 		.channels = ch, \
 	}; \
-	DEVICE_AND_API_INIT(lmp##t##_##n, \
+	DEVICE_DEFINE(lmp##t##_##n, \
 			    DT_LABEL(DT_INST_LMP90XXX(n, t)), \
-			    &lmp90xxx_init, &lmp##t##_data_##n, \
+			    &lmp90xxx_init, device_pm_control_nop, \
+			    &lmp##t##_data_##n,	\
 			    &lmp##t##_config_##n, POST_KERNEL, \
 			    CONFIG_ADC_LMP90XXX_INIT_PRIORITY, \
 			    &lmp90xxx_adc_api)

--- a/drivers/adc/adc_mchp_xec.c
+++ b/drivers/adc/adc_mchp_xec.c
@@ -311,7 +311,8 @@ static struct adc_xec_data adc_xec_dev_data_0 = {
 	ADC_CONTEXT_INIT_SYNC(adc_xec_dev_data_0, ctx),
 };
 
-DEVICE_AND_API_INIT(adc_xec, DT_INST_LABEL(0),
-		    adc_xec_init, &adc_xec_dev_data_0, NULL,
+DEVICE_DEFINE(adc_xec, DT_INST_LABEL(0),
+		    adc_xec_init, device_pm_control_nop, &adc_xec_dev_data_0,
+		    NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &adc_xec_api);

--- a/drivers/adc/adc_mcp320x.c
+++ b/drivers/adc/adc_mcp320x.c
@@ -346,9 +346,10 @@ static const struct adc_driver_api mcp320x_adc_api = {
 		}, \
 		.channels = ch, \
 	}; \
-	DEVICE_AND_API_INIT(mcp##t##_##n, \
+	DEVICE_DEFINE(mcp##t##_##n, \
 			    DT_LABEL(INST_DT_MCP320X(n, t)), \
-			    &mcp320x_init, &mcp##t##_data_##n, \
+			    &mcp320x_init, device_pm_control_nop, \
+			    &mcp##t##_data_##n,	\
 			    &mcp##t##_config_##n, POST_KERNEL, \
 			    CONFIG_ADC_MCP320X_INIT_PRIORITY, \
 			    &mcp320x_adc_api)

--- a/drivers/adc/adc_mcux_adc12.c
+++ b/drivers/adc/adc_mcux_adc12.c
@@ -284,11 +284,12 @@ static const struct adc_driver_api mcux_adc12_driver_api = {
 		ADC_CONTEXT_INIT_SYNC(mcux_adc12_data_##n, ctx),	\
 	};								\
 									\
-	DEVICE_AND_API_INIT(mcux_adc12_##n, DT_INST_LABEL(n),		\
-			    &mcux_adc12_init, &mcux_adc12_data_##n,	\
-			    &mcux_adc12_config_##n, POST_KERNEL,	\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &mcux_adc12_driver_api);			\
+	DEVICE_DEFINE(mcux_adc12_##n, DT_INST_LABEL(n),			\
+		      &mcux_adc12_init, device_pm_control_nop,		\
+		      &mcux_adc12_data_##n,				\
+		      &mcux_adc12_config_##n, POST_KERNEL,		\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &mcux_adc12_driver_api);				\
 									\
 	static void mcux_adc12_config_func_##n(struct device *dev)	\
 	{								\

--- a/drivers/adc/adc_mcux_adc16.c
+++ b/drivers/adc/adc_mcux_adc16.c
@@ -289,11 +289,12 @@ static const struct adc_driver_api mcux_adc16_driver_api = {
 		ADC_CONTEXT_INIT_SYNC(mcux_adc16_data_##n, ctx),	\
 	};								\
 									\
-	DEVICE_AND_API_INIT(mcux_adc16_##n, DT_INST_LABEL(n),		\
-			    &mcux_adc16_init, &mcux_adc16_data_##n,	\
-			    &mcux_adc16_config_##n, POST_KERNEL,	\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &mcux_adc16_driver_api);			\
+	DEVICE_DEFINE(mcux_adc16_##n, DT_INST_LABEL(n),			\
+		      &mcux_adc16_init, device_pm_control_nop,		\
+		      &mcux_adc16_data_##n,				\
+		      &mcux_adc16_config_##n, POST_KERNEL,		\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &mcux_adc16_driver_api);				\
 									\
 	static void mcux_adc16_config_func_##n(struct device *dev)	\
 	{								\

--- a/drivers/adc/adc_nrfx_adc.c
+++ b/drivers/adc/adc_nrfx_adc.c
@@ -290,10 +290,10 @@ static const struct adc_driver_api adc_nrfx_driver_api = {
 #define ADC_INIT(inst)							\
 	BUILD_ASSERT((inst) == 0,					\
 		     "multiple instances not supported");		\
-	DEVICE_AND_API_INIT(adc_0, DT_INST_LABEL(0),			\
-			    init_adc, NULL, NULL,			\
-			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &adc_nrfx_driver_api);
+	DEVICE_DEFINE(adc_0, DT_INST_LABEL(0),				\
+		      init_adc, device_pm_control_nop, NULL, NULL,	\
+		      POST_KERNEL,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &adc_nrfx_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(ADC_INIT)

--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -430,13 +430,14 @@ static const struct adc_driver_api adc_nrfx_driver_api = {
 #define SAADC_INIT(inst)						\
 	BUILD_ASSERT((inst) == 0,					\
 		     "multiple instances not supported");		\
-	DEVICE_AND_API_INIT(adc_0,					\
-			    DT_INST_LABEL(0),				\
-			    init_saadc,					\
-			    NULL,					\
-			    NULL,					\
-			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &adc_nrfx_driver_api);
+	DEVICE_DEFINE(adc_0,						\
+		      DT_INST_LABEL(0),					\
+		      init_saadc,					\
+		      device_pm_control_nop,				\
+		      NULL,						\
+		      NULL,						\
+		      POST_KERNEL,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &adc_nrfx_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SAADC_INIT)

--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -602,11 +602,12 @@ do {									\
 		ADC_CONTEXT_INIT_LOCK(adc_sam_data_##n, ctx),		\
 		ADC_CONTEXT_INIT_SYNC(adc_sam_data_##n, ctx),		\
 	};								\
-	DEVICE_AND_API_INIT(adc0_sam_##n, DT_INST_LABEL(n),		\
-			    adc_sam0_init, &adc_sam_data_##n,		\
-			    &adc_sam_cfg_##n, POST_KERNEL,		\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &adc_sam0_api);				\
+	DEVICE_DEFINE(adc0_sam_##n, DT_INST_LABEL(n),			\
+		      adc_sam0_init, device_pm_control_nop,		\
+		      &adc_sam_data_##n,				\
+		      &adc_sam_cfg_##n, POST_KERNEL,			\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &adc_sam0_api);					\
 	static void adc_sam0_config_##n(struct device *dev)		\
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(n),				\

--- a/drivers/adc/adc_sam_afec.c
+++ b/drivers/adc/adc_sam_afec.c
@@ -365,11 +365,12 @@ static void adc_sam_isr(void *arg)
 		ADC_CONTEXT_INIT_SYNC(adc##n##_sam_data, ctx),		\
 	};								\
 									\
-	DEVICE_AND_API_INIT(adc##n##_sam, DT_INST_LABEL(n),		\
-			    adc_sam_init, &adc##n##_sam_data,		\
-			    &adc##n##_sam_cfg, POST_KERNEL,		\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &adc_sam_api);				\
+	DEVICE_DEFINE(adc##n##_sam, DT_INST_LABEL(n),			\
+		      adc_sam_init, device_pm_control_nop,		\
+		      &adc##n##_sam_data,				\
+		      &adc##n##_sam_cfg, POST_KERNEL,			\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &adc_sam_api);					\
 									\
 	static void adc##n##_sam_cfg_func(struct device *dev)		\
 	{								\

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -724,11 +724,11 @@ static struct adc_stm32_data adc_stm32_data_##index = {			\
 	ADC_CONTEXT_INIT_SYNC(adc_stm32_data_##index, ctx),		\
 };									\
 									\
-DEVICE_AND_API_INIT(adc_##index, DT_INST_LABEL(index),	\
-		    &adc_stm32_init,					\
-		    &adc_stm32_data_##index, &adc_stm32_cfg_##index,	\
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
-		    &api_stm32_driver_api);				\
+DEVICE_DEFINE(adc_##index, DT_INST_LABEL(index),			\
+	      &adc_stm32_init, device_pm_control_nop,			\
+	      &adc_stm32_data_##index, &adc_stm32_cfg_##index,		\
+	      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
+	      &api_stm32_driver_api);					\
 									\
 static void adc_stm32_cfg_func_##index(void)				\
 {									\

--- a/drivers/audio/intel_dmic.c
+++ b/drivers/audio/intel_dmic.c
@@ -1441,5 +1441,6 @@ static struct _dmic_ops dmic_ops = {
 	.read = dmic_read_device,
 };
 
-DEVICE_AND_API_INIT(dmic, "PDM", &dmic_initialize_device, NULL, NULL,
+DEVICE_DEFINE(dmic, "PDM", &dmic_initialize_device, device_pm_control_nop,
+	      NULL, NULL,
 		POST_KERNEL, CONFIG_AUDIO_DMIC_INIT_PRIORITY, &dmic_ops);

--- a/drivers/audio/mpxxdtyy.c
+++ b/drivers/audio/mpxxdtyy.c
@@ -165,6 +165,6 @@ static int mpxxdtyy_initialize(struct device *dev)
 
 static struct mpxxdtyy_data mpxxdtyy_data;
 
-DEVICE_AND_API_INIT(mpxxdtyy, DT_INST_LABEL(0), mpxxdtyy_initialize,
-		&mpxxdtyy_data, NULL, POST_KERNEL,
+DEVICE_DEFINE(mpxxdtyy, DT_INST_LABEL(0), mpxxdtyy_initialize,
+		device_pm_control_nop, &mpxxdtyy_data, NULL, POST_KERNEL,
 		CONFIG_AUDIO_DMIC_INIT_PRIORITY, &mpxxdtyy_driver_api);

--- a/drivers/audio/tlv320dac310x.c
+++ b/drivers/audio/tlv320dac310x.c
@@ -536,6 +536,7 @@ static const struct audio_codec_api codec_driver_api = {
 	.apply_properties	= codec_apply_properties,
 };
 
-DEVICE_AND_API_INIT(tlv320dac310x, DT_INST_LABEL(0), codec_initialize,
-		&codec_device_data, &codec_device_config, POST_KERNEL,
+DEVICE_DEFINE(tlv320dac310x, DT_INST_LABEL(0), codec_initialize,
+		device_pm_control_nop, &codec_device_data,
+		&codec_device_config, POST_KERNEL,
 		CONFIG_AUDIO_CODEC_INIT_PRIORITY, &codec_driver_api);

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -274,9 +274,9 @@ static int can_loopback_init(struct device *dev)
 
 static struct can_loopback_data can_loopback_dev_data_1;
 
-DEVICE_AND_API_INIT(can_loopback_1, CONFIG_CAN_LOOPBACK_DEV_NAME,
+DEVICE_DEFINE(can_loopback_1, CONFIG_CAN_LOOPBACK_DEV_NAME,
 		    &can_loopback_init,
-		    &can_loopback_dev_data_1, NULL,
+		    device_pm_control_nop, &can_loopback_dev_data_1, NULL,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &can_api_funcs);
 

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -860,8 +860,9 @@ static const struct mcp2515_config mcp2515_config_1 = {
 	.osc_freq = DT_INST_PROP(0, osc_freq)
 };
 
-DEVICE_AND_API_INIT(can_mcp2515_1, DT_INST_LABEL(0), &mcp2515_init,
-		    &mcp2515_data_1, &mcp2515_config_1, POST_KERNEL,
+DEVICE_DEFINE(can_mcp2515_1, DT_INST_LABEL(0), &mcp2515_init,
+		    device_pm_control_nop, &mcp2515_data_1, &mcp2515_config_1,
+		    POST_KERNEL,
 		    CONFIG_CAN_MCP2515_INIT_PRIORITY, &can_api_funcs);
 
 #endif /* DT_NODE_HAS_STATUS(DT_DRV_INST(0), okay) */

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -680,8 +680,9 @@ static const struct mcux_flexcan_config mcux_flexcan_config_0 = {
 static struct mcux_flexcan_data mcux_flexcan_data_0 = {
 };
 
-DEVICE_AND_API_INIT(can_mcux_flexcan_0, DT_INST_LABEL(0),
-		    &mcux_flexcan_init, &mcux_flexcan_data_0,
+DEVICE_DEFINE(can_mcux_flexcan_0, DT_INST_LABEL(0),
+		    &mcux_flexcan_init, device_pm_control_nop,
+		    &mcux_flexcan_data_0,
 		    &mcux_flexcan_config_0, POST_KERNEL,
 		    CONFIG_CAN_INIT_PRIORITY, &mcux_flexcan_driver_api);
 
@@ -782,8 +783,9 @@ static const struct mcux_flexcan_config mcux_flexcan_config_1 = {
 static struct mcux_flexcan_data mcux_flexcan_data_1 = {
 };
 
-DEVICE_AND_API_INIT(can_mcux_flexcan_1, DT_INST_LABEL(1),
-		    &mcux_flexcan_init, &mcux_flexcan_data_1,
+DEVICE_DEFINE(can_mcux_flexcan_1, DT_INST_LABEL(1),
+		    &mcux_flexcan_init, device_pm_control_nop,
+		    &mcux_flexcan_data_1,
 		    &mcux_flexcan_config_1, POST_KERNEL,
 		    CONFIG_CAN_INIT_PRIORITY, &mcux_flexcan_driver_api);
 

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -1066,8 +1066,9 @@ static const struct can_stm32_config can_stm32_cfg_1 = {
 
 static struct can_stm32_data can_stm32_dev_data_1;
 
-DEVICE_AND_API_INIT(can_stm32_1, DT_LABEL(DT_NODELABEL(can1)), &can_stm32_init,
-		    &can_stm32_dev_data_1, &can_stm32_cfg_1,
+DEVICE_DEFINE(can_stm32_1, DT_LABEL(DT_NODELABEL(can1)), &can_stm32_init,
+		    device_pm_control_nop, &can_stm32_dev_data_1,
+		    &can_stm32_cfg_1,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &can_api_funcs);
 
@@ -1156,8 +1157,9 @@ static const struct can_stm32_config can_stm32_cfg_2 = {
 
 static struct can_stm32_data can_stm32_dev_data_2;
 
-DEVICE_AND_API_INIT(can_stm32_2, DT_LABEL(DT_NODELABEL(can2)), &can_stm32_init,
-		    &can_stm32_dev_data_2, &can_stm32_cfg_2,
+DEVICE_DEFINE(can_stm32_2, DT_LABEL(DT_NODELABEL(can2)), &can_stm32_init,
+		    device_pm_control_nop, &can_stm32_dev_data_2,
+		    &can_stm32_cfg_2,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &can_api_funcs);
 

--- a/drivers/clock_control/beetle_clock_control.c
+++ b/drivers/clock_control/beetle_clock_control.c
@@ -242,9 +242,9 @@ static const struct beetle_clock_control_cfg_t beetle_cc_cfg = {
  * @brief Clock Control device init
  *
  */
-DEVICE_AND_API_INIT(clock_control_beetle, CONFIG_ARM_CLOCK_CONTROL_DEV_NAME,
+DEVICE_DEFINE(clock_control_beetle, CONFIG_ARM_CLOCK_CONTROL_DEV_NAME,
 		    &beetle_clock_control_init,
-		    NULL, &beetle_cc_cfg,
+		    device_pm_control_nop, NULL, &beetle_cc_cfg,
 		    PRE_KERNEL_1,
 		    CONFIG_CLOCK_CONTROL_BEETLE_DEVICE_INIT_PRIORITY,
 		    &beetle_clock_control_api);

--- a/drivers/clock_control/clock_control_mcux_ccm.c
+++ b/drivers/clock_control/clock_control_mcux_ccm.c
@@ -105,8 +105,8 @@ static const struct clock_control_driver_api mcux_ccm_driver_api = {
 	.get_rate = mcux_ccm_get_subsys_rate,
 };
 
-DEVICE_AND_API_INIT(mcux_ccm, DT_INST_LABEL(0),
+DEVICE_DEFINE(mcux_ccm, DT_INST_LABEL(0),
 		    &mcux_ccm_init,
-		    NULL, NULL,
+		    device_pm_control_nop, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_ccm_driver_api);

--- a/drivers/clock_control/clock_control_mcux_mcg.c
+++ b/drivers/clock_control/clock_control_mcux_mcg.c
@@ -59,8 +59,8 @@ static const struct clock_control_driver_api mcux_mcg_driver_api = {
 	.get_rate = mcux_mcg_get_rate,
 };
 
-DEVICE_AND_API_INIT(mcux_mcg, DT_INST_LABEL(0),
+DEVICE_DEFINE(mcux_mcg, DT_INST_LABEL(0),
 		    &mcux_mcg_init,
-		    NULL, NULL,
+		    device_pm_control_nop, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_mcg_driver_api);

--- a/drivers/clock_control/clock_control_mcux_pcc.c
+++ b/drivers/clock_control/clock_control_mcux_pcc.c
@@ -72,11 +72,11 @@ static const struct clock_control_driver_api mcux_pcc_api = {
 		.base_address = DT_INST_REG_ADDR(inst)			\
 	};								\
 									\
-	DEVICE_AND_API_INIT(mcux_pcc##inst, DT_INST_LABEL(inst),	\
-			    &mcux_pcc_init,				\
-			    NULL, &mcux_pcc##inst##_config,		\
-			    PRE_KERNEL_1,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,	\
-			    &mcux_pcc_api);
+	DEVICE_DEFINE(mcux_pcc##inst, DT_INST_LABEL(inst),		\
+		      &mcux_pcc_init, device_pm_control_nop,		\
+		      NULL, &mcux_pcc##inst##_config,			\
+		      PRE_KERNEL_1,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,		\
+		      &mcux_pcc_api);
 
 DT_INST_FOREACH_STATUS_OKAY(MCUX_PCC_INIT)

--- a/drivers/clock_control/clock_control_mcux_scg.c
+++ b/drivers/clock_control/clock_control_mcux_scg.c
@@ -107,8 +107,8 @@ static const struct clock_control_driver_api mcux_scg_driver_api = {
 	.get_rate = mcux_scg_get_rate,
 };
 
-DEVICE_AND_API_INIT(mcux_scg, DT_INST_LABEL(0),
+DEVICE_DEFINE(mcux_scg, DT_INST_LABEL(0),
 		    &mcux_scg_init,
-		    NULL, NULL,
+		    device_pm_control_nop, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_scg_driver_api);

--- a/drivers/clock_control/clock_control_mcux_sim.c
+++ b/drivers/clock_control/clock_control_mcux_sim.c
@@ -95,8 +95,8 @@ static const struct clock_control_driver_api mcux_sim_driver_api = {
 	.get_rate = mcux_sim_get_subsys_rate,
 };
 
-DEVICE_AND_API_INIT(mcux_sim, NXP_KINETIS_SIM_LABEL,
+DEVICE_DEFINE(mcux_sim, NXP_KINETIS_SIM_LABEL,
 		    &mcux_sim_init,
-		    NULL, NULL,
+		    device_pm_control_nop, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_sim_driver_api);

--- a/drivers/clock_control/clock_control_rv32m1_pcc.c
+++ b/drivers/clock_control/clock_control_rv32m1_pcc.c
@@ -65,11 +65,11 @@ static const struct clock_control_driver_api rv32m1_pcc_api = {
 		.base_address = DT_INST_REG_ADDR(inst)			\
 	};								\
 									\
-	DEVICE_AND_API_INIT(rv32m1_pcc##inst, DT_INST_LABEL(inst),	\
-			    &rv32m1_pcc_init,				\
-			    NULL, &rv32m1_pcc##inst##_config,		\
-			    PRE_KERNEL_1,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,	\
-			    &rv32m1_pcc_api);
+	DEVICE_DEFINE(rv32m1_pcc##inst, DT_INST_LABEL(inst),		\
+		      &rv32m1_pcc_init, device_pm_control_nop,		\
+		      NULL, &rv32m1_pcc##inst##_config,			\
+		      PRE_KERNEL_1,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,		\
+		      &rv32m1_pcc_api);
 
 DT_INST_FOREACH_STATUS_OKAY(RV32M1_PCC_INIT)

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -506,9 +506,9 @@ static int stm32_clock_control_init(struct device *dev)
  * @brief RCC device, note that priority is intentionally set to 1 so
  * that the device init runs just after SOC init
  */
-DEVICE_AND_API_INIT(rcc_stm32, STM32_CLOCK_CONTROL_NAME,
+DEVICE_DEFINE(rcc_stm32, STM32_CLOCK_CONTROL_NAME,
 		    &stm32_clock_control_init,
-		    NULL, NULL,
+		    device_pm_control_nop, NULL, NULL,
 		    PRE_KERNEL_1,
 		    CONFIG_CLOCK_CONTROL_STM32_DEVICE_INIT_PRIORITY,
 		    &stm32_clock_control_api);

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -285,9 +285,9 @@ static int stm32_clock_control_init(struct device *dev)
  * @brief RCC device, note that priority is intentionally set to 1 so
  * that the device init runs just after SOC init
  */
-DEVICE_AND_API_INIT(rcc_stm32, STM32_CLOCK_CONTROL_NAME,
+DEVICE_DEFINE(rcc_stm32, STM32_CLOCK_CONTROL_NAME,
 		    &stm32_clock_control_init,
-		    NULL, NULL,
+		    device_pm_control_nop, NULL, NULL,
 		    PRE_KERNEL_1,
 		    CONFIG_CLOCK_CONTROL_STM32_DEVICE_INIT_PRIORITY,
 		    &stm32_clock_control_api);

--- a/drivers/clock_control/clock_stm32_ll_mp1.c
+++ b/drivers/clock_control/clock_stm32_ll_mp1.c
@@ -409,9 +409,9 @@ static int stm32_clock_control_init(struct device *dev)
  * @brief RCC device, note that priority is intentionally set to 1 so
  * that the device init runs just after SOC init
  */
-DEVICE_AND_API_INIT(rcc_stm32, STM32_CLOCK_CONTROL_NAME,
+DEVICE_DEFINE(rcc_stm32, STM32_CLOCK_CONTROL_NAME,
 		    &stm32_clock_control_init,
-		    NULL, NULL,
+		    device_pm_control_nop, NULL, NULL,
 		    PRE_KERNEL_1,
 		    CONFIG_CLOCK_CONTROL_STM32_DEVICE_INIT_PRIORITY,
 		    &stm32_clock_control_api);

--- a/drivers/clock_control/nrf_power_clock.c
+++ b/drivers/clock_control/nrf_power_clock.c
@@ -348,8 +348,9 @@ static const struct nrf_clock_control_config config = {
 	}
 };
 
-DEVICE_AND_API_INIT(clock_nrf, DT_INST_LABEL(0),
-		    clk_init, &data, &config, PRE_KERNEL_1,
+DEVICE_DEFINE(clock_nrf, DT_INST_LABEL(0),
+		    clk_init, device_pm_control_nop, &data, &config,
+		    PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &clock_control_api);
 

--- a/drivers/console/uart_mux.c
+++ b/drivers/console/uart_mux.c
@@ -821,15 +821,16 @@ void uart_mux_foreach(uart_mux_cb_t cb, void *user_data)
 		.rx_ringbuf = &rx_ringbuf_##x,				  \
 	};
 
-#define DEFINE_UART_MUX_DEVICE(x, _)					  \
-	DEVICE_AND_API_INIT(uart_mux_##x,				  \
-			    CONFIG_UART_MUX_DEVICE_NAME "_" #x,		  \
-			    &uart_mux_init,				  \
-			    &uart_mux_dev_data_##x,			  \
-			    &uart_mux_config_##x,			  \
-			    POST_KERNEL,				  \
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		  \
-			    &uart_mux_driver_api);
+#define DEFINE_UART_MUX_DEVICE(x, _)					\
+	DEVICE_DEFINE(uart_mux_##x,					\
+		      CONFIG_UART_MUX_DEVICE_NAME "_" #x,		\
+		      &uart_mux_init,					\
+		      device_pm_control_nop,				\
+		      &uart_mux_dev_data_##x,				\
+		      &uart_mux_config_##x,				\
+		      POST_KERNEL,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &uart_mux_driver_api);
 
 UTIL_LISTIFY(CONFIG_UART_MUX_DEVICE_COUNT, DEFINE_UART_MUX_CFG_DATA, _)
 UTIL_LISTIFY(CONFIG_UART_MUX_DEVICE_COUNT, DEFINE_UART_MUX_DEV_DATA, _)

--- a/drivers/counter/counter_cmos.c
+++ b/drivers/counter/counter_cmos.c
@@ -208,5 +208,5 @@ static const struct counter_driver_api api = {
 	.get_value = get_value
 };
 
-DEVICE_AND_API_INIT(counter_cmos, "CMOS", init, NULL, &info,
+DEVICE_DEFINE(counter_cmos, "CMOS", init, device_pm_control_nop, NULL, &info,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &api);

--- a/drivers/counter/counter_gecko_rtcc.c
+++ b/drivers/counter/counter_gecko_rtcc.c
@@ -383,7 +383,8 @@ static const struct counter_gecko_config counter_gecko_0_config = {
 
 static struct counter_gecko_data counter_gecko_0_data;
 
-DEVICE_AND_API_INIT(counter_gecko_0, DT_INST_LABEL(0),
-	counter_gecko_init, &counter_gecko_0_data, &counter_gecko_0_config,
+DEVICE_DEFINE(counter_gecko_0, DT_INST_LABEL(0),
+	counter_gecko_init, device_pm_control_nop, &counter_gecko_0_data,
+	&counter_gecko_0_config,
 	PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 	&counter_gecko_driver_api);

--- a/drivers/counter/counter_imx_epit.c
+++ b/drivers/counter/counter_imx_epit.c
@@ -163,11 +163,11 @@ static const struct imx_epit_config imx_epit_##idx##z_config = {	       \
 	.prescaler = DT_INST_PROP(idx, prescaler),			       \
 };									       \
 static struct imx_epit_data imx_epit_##idx##_data;			       \
-DEVICE_AND_API_INIT(epit_##idx, DT_INST_LABEL(idx),			       \
-		    &imx_epit_config_func_##idx,			       \
-		    &imx_epit_##idx##_data, &imx_epit_##idx##z_config.info,    \
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	       \
-		    &imx_epit_driver_api);				       \
+DEVICE_DEFINE(epit_##idx, DT_INST_LABEL(idx),				       \
+	      &imx_epit_config_func_##idx, device_pm_control_nop,	       \
+	      &imx_epit_##idx##_data, &imx_epit_##idx##z_config.info,	       \
+	      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	       \
+	      &imx_epit_driver_api);					       \
 static int imx_epit_config_func_##idx(struct device *dev)		       \
 {									       \
 	imx_epit_init(dev);						       \

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -394,8 +394,9 @@ static const struct counter_driver_api rtc_stm32_driver_api = {
 		.get_max_relative_alarm = rtc_stm32_get_max_relative_alarm,
 };
 
-DEVICE_AND_API_INIT(rtc_stm32, DT_INST_LABEL(0), &rtc_stm32_init,
-		    &rtc_data, &rtc_config, PRE_KERNEL_1,
+DEVICE_DEFINE(rtc_stm32, DT_INST_LABEL(0), &rtc_stm32_init,
+		    device_pm_control_nop, &rtc_data, &rtc_config,
+		    PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &rtc_stm32_driver_api);
 
 static void rtc_stm32_irq_config(struct device *dev)

--- a/drivers/counter/counter_mchp_xec.c
+++ b/drivers/counter/counter_mchp_xec.c
@@ -330,13 +330,14 @@ static int counter_xec_init(struct device *dev)
 		.girq_bit = DT_INST_PROP(inst, girq_bit),		\
 	};								\
 									\
-	DEVICE_AND_API_INIT(counter_xec_##inst, DT_INST_LABEL(inst),	\
-			    counter_xec_init,				\
-			    &counter_xec_dev_data_##inst,		\
-			    &counter_xec_dev_config_##inst,		\
-			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &counter_xec_api);				\
+	DEVICE_DEFINE(counter_xec_##inst, DT_INST_LABEL(inst),		\
+		      counter_xec_init,					\
+		      device_pm_control_nop,				\
+		      &counter_xec_dev_data_##inst,			\
+		      &counter_xec_dev_config_##inst,			\
+		      POST_KERNEL,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &counter_xec_api);				\
 									\
 	static void counter_xec_irq_config_##inst(void)			\
 	{								\

--- a/drivers/counter/counter_mcux_gpt.c
+++ b/drivers/counter/counter_mcux_gpt.c
@@ -216,14 +216,15 @@ static const struct counter_driver_api mcux_gpt_driver_api = {
 	};								\
 									\
 	static int mcux_gpt_## n ##_init(struct device *dev);		\
-	DEVICE_AND_API_INIT(mcux_gpt ## n,				\
-			    DT_INST_LABEL(n),				\
-			    mcux_gpt_## n ##_init,			\
-			    &mcux_gpt_data_ ## n,			\
-			    &mcux_gpt_config_ ## n,			\
-			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &mcux_gpt_driver_api);			\
+	DEVICE_DEFINE(mcux_gpt ## n,					\
+		      DT_INST_LABEL(n),					\
+		      mcux_gpt_## n ##_init,				\
+		      device_pm_control_nop,				\
+		      &mcux_gpt_data_ ## n,				\
+		      &mcux_gpt_config_ ## n,				\
+		      POST_KERNEL,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &mcux_gpt_driver_api);				\
 									\
 	static int mcux_gpt_## n ##_init(struct device *dev)		\
 	{								\

--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -242,8 +242,9 @@ static struct mcux_lptmr_config mcux_lptmr_config_0 = {
 	.irq_config_func = mcux_lptmr_irq_config_0,
 };
 
-DEVICE_AND_API_INIT(mcux_lptmr_0, DT_INST_LABEL(0),
-		    &mcux_lptmr_init, &mcux_lptmr_data_0,
+DEVICE_DEFINE(mcux_lptmr_0, DT_INST_LABEL(0),
+		    &mcux_lptmr_init, device_pm_control_nop,
+		    &mcux_lptmr_data_0,
 		    &mcux_lptmr_config_0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_lptmr_driver_api);

--- a/drivers/counter/counter_mcux_rtc.c
+++ b/drivers/counter/counter_mcux_rtc.c
@@ -278,8 +278,9 @@ static struct mcux_rtc_config mcux_rtc_config_0 = {
 	},
 };
 
-DEVICE_AND_API_INIT(rtc, DT_INST_LABEL(0), &mcux_rtc_init,
-		    &mcux_rtc_data_0, &mcux_rtc_config_0.info,
+DEVICE_DEFINE(rtc, DT_INST_LABEL(0), &mcux_rtc_init,
+		    device_pm_control_nop, &mcux_rtc_data_0,
+		    &mcux_rtc_config_0.info,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_rtc_driver_api);
 

--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -695,13 +695,14 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 			   (.fixed_top = RTC_PROP(idx, fixed_top),))	       \
 		LOG_INSTANCE_PTR_INIT(log, LOG_MODULE_NAME, idx)	       \
 	};								       \
-	DEVICE_AND_API_INIT(rtc_##idx,					       \
-			    DT_LABEL(RTC(idx)),				       \
-			    counter_##idx##_init,			       \
-			    &counter_##idx##_data,			       \
-			    &nrfx_counter_##idx##_config.info,		       \
-			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \
-			    &counter_nrfx_driver_api)
+	DEVICE_DEFINE(rtc_##idx,					       \
+		      DT_LABEL(RTC(idx)),				       \
+		      counter_##idx##_init,				       \
+		      device_pm_control_nop,				       \
+		      &counter_##idx##_data,				       \
+		      &nrfx_counter_##idx##_config.info,		       \
+		      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	       \
+		      &counter_nrfx_driver_api)
 
 #ifdef CONFIG_COUNTER_RTC0
 COUNTER_NRF_RTC_DEVICE(0);

--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -426,13 +426,14 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 		.timer = (NRF_TIMER_Type *)DT_REG_ADDR(TIMER(idx)),	       \
 		LOG_INSTANCE_PTR_INIT(log, LOG_MODULE_NAME, idx)	       \
 	};								       \
-	DEVICE_AND_API_INIT(timer_##idx,				       \
-			    DT_LABEL(TIMER(idx)),			       \
-			    counter_##idx##_init,			       \
-			    &counter_##idx##_data,			       \
-			    &nrfx_counter_##idx##_config.info,		       \
-			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \
-			    &counter_nrfx_driver_api)
+	DEVICE_DEFINE(timer_##idx,					       \
+		      DT_LABEL(TIMER(idx)),				       \
+		      counter_##idx##_init,				       \
+		      device_pm_control_nop,				       \
+		      &counter_##idx##_data,				       \
+		      &nrfx_counter_##idx##_config.info,		       \
+		      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	       \
+		      &counter_nrfx_driver_api)
 
 #ifdef CONFIG_COUNTER_TIMER0
 COUNTER_NRFX_TIMER_DEVICE(0);

--- a/drivers/counter/counter_sam0_tc32.c
+++ b/drivers/counter/counter_sam0_tc32.c
@@ -439,14 +439,15 @@ static const struct counter_driver_api counter_sam0_tc32_driver_api = {
 									\
 	static struct counter_sam0_tc32_data counter_sam0_tc32_dev_data_##n;\
 									\
-	DEVICE_AND_API_INIT(counter_sam0_tc32_##n,			\
-			    DT_INST_LABEL(n),				\
-			    &counter_sam0_tc32_initialize,		\
-			    &counter_sam0_tc32_dev_data_##n,		\
-			    &counter_sam0_tc32_dev_config_##n,		\
-			    PRE_KERNEL_1,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &counter_sam0_tc32_driver_api);		\
+	DEVICE_DEFINE(counter_sam0_tc32_##n,				\
+		      DT_INST_LABEL(n),					\
+		      &counter_sam0_tc32_initialize,			\
+		      device_pm_control_nop,				\
+		      &counter_sam0_tc32_dev_data_##n,			\
+		      &counter_sam0_tc32_dev_config_##n,		\
+		      PRE_KERNEL_1,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &counter_sam0_tc32_driver_api);			\
 									\
 	static void counter_sam0_tc32_config_##n(struct device *dev)	\
 	{								\

--- a/drivers/counter/maxim_ds3231.c
+++ b/drivers/counter/maxim_ds3231.c
@@ -1323,8 +1323,8 @@ static struct ds3231_data ds3231_0_data;
 #error COUNTER_MAXIM_DS3231_INIT_PRIORITY must be greater than I2C_INIT_PRIORITY
 #endif
 
-DEVICE_AND_API_INIT(ds3231_0, DT_INST_LABEL(0),
-		    ds3231_init, &ds3231_0_data,
+DEVICE_DEFINE(ds3231_0, DT_INST_LABEL(0),
+		    ds3231_init, device_pm_control_nop, &ds3231_0_data,
 		    &ds3231_0_config,
 		    POST_KERNEL, CONFIG_COUNTER_MAXIM_DS3231_INIT_PRIORITY,
 		    &ds3231_api);

--- a/drivers/counter/timer_dtmr_cmsdk_apb.c
+++ b/drivers/counter/timer_dtmr_cmsdk_apb.c
@@ -199,13 +199,14 @@ static int dtmr_cmsdk_apb_init(struct device *dev)
 		.load = UINT_MAX,					\
 	};								\
 									\
-	DEVICE_AND_API_INIT(dtmr_cmsdk_apb_##inst,			\
-			    DT_INST_LABEL(inst),			\
-			    dtmr_cmsdk_apb_init,			\
-			    &dtmr_cmsdk_apb_dev_data_##inst,		\
-			    &dtmr_cmsdk_apb_cfg_##inst, POST_KERNEL,	\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &dtmr_cmsdk_apb_api);			\
+	DEVICE_DEFINE(dtmr_cmsdk_apb_##inst,				\
+		      DT_INST_LABEL(inst),				\
+		      dtmr_cmsdk_apb_init,				\
+		      device_pm_control_nop,				\
+		      &dtmr_cmsdk_apb_dev_data_##inst,			\
+		      &dtmr_cmsdk_apb_cfg_##inst, POST_KERNEL,		\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &dtmr_cmsdk_apb_api);				\
 									\
 	static void dtimer_cmsdk_apb_config_##inst(struct device *dev)	\
 	{								\

--- a/drivers/counter/timer_tmr_cmsdk_apb.c
+++ b/drivers/counter/timer_tmr_cmsdk_apb.c
@@ -186,13 +186,14 @@ static int tmr_cmsdk_apb_init(struct device *dev)
 		.load = UINT32_MAX,					\
 	};								\
 									\
-	DEVICE_AND_API_INIT(tmr_cmsdk_apb_##inst,			\
-			    DT_INST_LABEL(inst),			\
-			    tmr_cmsdk_apb_init,				\
-			    &tmr_cmsdk_apb_dev_data_##inst,		\
-			    &tmr_cmsdk_apb_cfg_##inst, POST_KERNEL,	\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &tmr_cmsdk_apb_api);			\
+	DEVICE_DEFINE(tmr_cmsdk_apb_##inst,				\
+		      DT_INST_LABEL(inst),				\
+		      tmr_cmsdk_apb_init,				\
+		      device_pm_control_nop,				\
+		      &tmr_cmsdk_apb_dev_data_##inst,			\
+		      &tmr_cmsdk_apb_cfg_##inst, POST_KERNEL,		\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &tmr_cmsdk_apb_api);				\
 									\
 	static void timer_cmsdk_apb_config_##inst(struct device *dev)	\
 	{								\

--- a/drivers/crypto/crypto_ataes132a.c
+++ b/drivers/crypto/crypto_ataes132a.c
@@ -897,6 +897,7 @@ static struct crypto_driver_api crypto_enc_funcs = {
 
 struct ataes132a_device_data ataes132a_data;
 
-DEVICE_AND_API_INIT(ataes132a, CONFIG_CRYPTO_ATAES132A_DRV_NAME, ataes132a_init,
-		    &ataes132a_data, &ataes132a_config, POST_KERNEL,
+DEVICE_DEFINE(ataes132a, CONFIG_CRYPTO_ATAES132A_DRV_NAME, ataes132a_init,
+		    device_pm_control_nop, &ataes132a_data, &ataes132a_config,
+		    POST_KERNEL,
 		    CONFIG_CRYPTO_INIT_PRIORITY, (void *)&crypto_enc_funcs);

--- a/drivers/crypto/crypto_mtls_shim.c
+++ b/drivers/crypto/crypto_mtls_shim.c
@@ -467,7 +467,7 @@ static struct crypto_driver_api mtls_crypto_funcs = {
 	.query_hw_caps = mtls_query_caps,
 };
 
-DEVICE_AND_API_INIT(crypto_mtls, CONFIG_CRYPTO_MBEDTLS_SHIM_DRV_NAME,
-		    &mtls_shim_init, NULL, NULL,
+DEVICE_DEFINE(crypto_mtls, CONFIG_CRYPTO_MBEDTLS_SHIM_DRV_NAME,
+		    &mtls_shim_init, device_pm_control_nop, NULL, NULL,
 		    POST_KERNEL, CONFIG_CRYPTO_INIT_PRIORITY,
 		    (void *)&mtls_crypto_funcs);

--- a/drivers/crypto/crypto_nrf_ecb.c
+++ b/drivers/crypto/crypto_nrf_ecb.c
@@ -135,7 +135,7 @@ static const struct crypto_driver_api crypto_enc_funcs = {
 	.query_hw_caps = nrf_ecb_query_caps,
 };
 
-DEVICE_AND_API_INIT(nrf_ecb, CONFIG_CRYPTO_NRF_ECB_DRV_NAME,
-		    nrf_ecb_driver_init, NULL, NULL,
+DEVICE_DEFINE(nrf_ecb, CONFIG_CRYPTO_NRF_ECB_DRV_NAME,
+		    nrf_ecb_driver_init, device_pm_control_nop, NULL, NULL,
 		    POST_KERNEL, CONFIG_CRYPTO_INIT_PRIORITY,
 		    &crypto_enc_funcs);

--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -462,7 +462,8 @@ static struct crypto_stm32_config crypto_stm32_dev_config = {
 	}
 };
 
-DEVICE_AND_API_INIT(crypto_stm32, DT_INST_LABEL(0),
-		    crypto_stm32_init, &crypto_stm32_dev_data,
+DEVICE_DEFINE(crypto_stm32, DT_INST_LABEL(0),
+		    crypto_stm32_init, device_pm_control_nop,
+		    &crypto_stm32_dev_data,
 		    &crypto_stm32_dev_config, POST_KERNEL,
 		    CONFIG_CRYPTO_INIT_PRIORITY, (void *)&crypto_enc_funcs);

--- a/drivers/crypto/crypto_tc_shim.c
+++ b/drivers/crypto/crypto_tc_shim.c
@@ -321,7 +321,7 @@ static struct crypto_driver_api crypto_enc_funcs = {
 	.query_hw_caps = tc_query_caps,
 };
 
-DEVICE_AND_API_INIT(crypto_tinycrypt, CONFIG_CRYPTO_TINYCRYPT_SHIM_DRV_NAME,
-		    &tc_shim_init, NULL, NULL,
+DEVICE_DEFINE(crypto_tinycrypt, CONFIG_CRYPTO_TINYCRYPT_SHIM_DRV_NAME,
+		    &tc_shim_init, device_pm_control_nop, NULL, NULL,
 		    POST_KERNEL, CONFIG_CRYPTO_INIT_PRIORITY,
 		    (void *)&crypto_enc_funcs);

--- a/drivers/dac/dac_mcux_dac.c
+++ b/drivers/dac/dac_mcux_dac.c
@@ -104,10 +104,11 @@ static const struct dac_driver_api mcux_dac_driver_api = {
 		.low_power = DT_INST_PROP(n, low_power_mode),		\
 	};								\
 									\
-	DEVICE_AND_API_INIT(mcux_dac_##n, DT_INST_LABEL(n),		\
-			mcux_dac_init, &mcux_dac_data_##n,		\
-			&mcux_dac_config_##n,				\
-			POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,\
-			&mcux_dac_driver_api);
+	DEVICE_DEFINE(mcux_dac_##n, DT_INST_LABEL(n),			\
+		      mcux_dac_init, device_pm_control_nop,		\
+		      &mcux_dac_data_##n,				\
+		      &mcux_dac_config_##n,				\
+		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
+		      &mcux_dac_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(MCUX_DAC_INIT)

--- a/drivers/dac/dac_mcux_dac32.c
+++ b/drivers/dac/dac_mcux_dac32.c
@@ -107,10 +107,11 @@ static const struct dac_driver_api mcux_dac32_driver_api = {
 		.low_power = DT_INST_PROP(n, low_power_mode),		\
 	};								\
 									\
-	DEVICE_AND_API_INIT(mcux_dac32_##n, DT_INST_LABEL(n),		\
-			mcux_dac32_init, &mcux_dac32_data_##n,		\
-			&mcux_dac32_config_##n,				\
-			POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,\
-			&mcux_dac32_driver_api);
+	DEVICE_DEFINE(mcux_dac32_##n, DT_INST_LABEL(n),			\
+		      mcux_dac32_init, device_pm_control_nop,		\
+		      &mcux_dac32_data_##n,				\
+		      &mcux_dac32_config_##n,				\
+		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
+		      &mcux_dac32_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(MCUX_DAC32_INIT)

--- a/drivers/dac/dac_stm32.c
+++ b/drivers/dac/dac_stm32.c
@@ -142,10 +142,11 @@ static struct dac_stm32_data dac_stm32_data_##index = {			\
 	.channel_count = STM32_CHANNEL_COUNT				\
 };									\
 									\
-DEVICE_AND_API_INIT(dac_##index, DT_INST_LABEL(index),			\
-		    &dac_stm32_init, &dac_stm32_data_##index,		\
-		    &dac_stm32_cfg_##index, POST_KERNEL,		\
-		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
-		    &api_stm32_driver_api);
+DEVICE_DEFINE(dac_##index, DT_INST_LABEL(index),			\
+	      &dac_stm32_init, device_pm_control_nop,			\
+	      &dac_stm32_data_##index,					\
+	      &dac_stm32_cfg_##index, POST_KERNEL,			\
+	      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,			\
+	      &api_stm32_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(STM32_DAC_INIT)

--- a/drivers/display/display_dummy.c
+++ b/drivers/display/display_dummy.c
@@ -107,7 +107,8 @@ static const struct display_driver_api dummy_display_api = {
 	.set_pixel_format = dummy_display_set_pixel_format,
 };
 
-DEVICE_AND_API_INIT(dummy_display, CONFIG_DUMMY_DISPLAY_DEV_NAME,
-		    &dummy_display_init, &dummy_display_data, NULL,
+DEVICE_DEFINE(dummy_display, CONFIG_DUMMY_DISPLAY_DEV_NAME,
+		    &dummy_display_init, device_pm_control_nop,
+		    &dummy_display_data, NULL,
 		    APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY,
 		    &dummy_display_api);

--- a/drivers/display/display_ili9340.c
+++ b/drivers/display/display_ili9340.c
@@ -301,6 +301,6 @@ static const struct display_driver_api ili9340_api = {
 
 static struct ili9340_data ili9340_data;
 
-DEVICE_AND_API_INIT(ili9340, DT_INST_LABEL(0), &ili9340_init,
-		    &ili9340_data, NULL, APPLICATION,
+DEVICE_DEFINE(ili9340, DT_INST_LABEL(0), &ili9340_init,
+		    device_pm_control_nop, &ili9340_data, NULL, APPLICATION,
 		    CONFIG_APPLICATION_INIT_PRIORITY, &ili9340_api);

--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -254,9 +254,10 @@ static struct mcux_elcdif_config mcux_elcdif_config_1 = {
 
 static struct mcux_elcdif_data mcux_elcdif_data_1;
 
-DEVICE_AND_API_INIT(mcux_elcdif_1, DT_INST_LABEL(0),
+DEVICE_DEFINE(mcux_elcdif_1, DT_INST_LABEL(0),
 		    &mcux_elcdif_init,
-		    &mcux_elcdif_data_1, &mcux_elcdif_config_1,
+		    device_pm_control_nop, &mcux_elcdif_data_1,
+		    &mcux_elcdif_config_1,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_elcdif_api);
 

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -401,8 +401,9 @@ static const struct display_driver_api sdl_display_api = {
 	.set_pixel_format = sdl_display_set_pixel_format,
 };
 
-DEVICE_AND_API_INIT(sdl_display, CONFIG_SDL_DISPLAY_DEV_NAME, &sdl_display_init,
-		    &sdl_display_data, NULL, APPLICATION,
+DEVICE_DEFINE(sdl_display, CONFIG_SDL_DISPLAY_DEV_NAME, &sdl_display_init,
+		    device_pm_control_nop, &sdl_display_data, NULL,
+		    APPLICATION,
 		    CONFIG_APPLICATION_INIT_PRIORITY, &sdl_display_api);
 
 

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -460,8 +460,8 @@ static struct st7789v_data st7789v_data = {
 };
 
 #ifndef CONFIG_DEVICE_POWER_MANAGEMENT
-DEVICE_AND_API_INIT(st7789v, DT_INST_LABEL(0), &st7789v_init,
-		    &st7789v_data, NULL, APPLICATION,
+DEVICE_DEFINE(st7789v, DT_INST_LABEL(0), &st7789v_init,
+		    device_pm_control_nop, &st7789v_data, NULL, APPLICATION,
 		    CONFIG_APPLICATION_INIT_PRIORITY, &st7789v_api);
 #else
 DEVICE_DEFINE(st7789v, DT_INST_LABEL(0), &st7789v_init,

--- a/drivers/display/gd7965.c
+++ b/drivers/display/gd7965.c
@@ -464,7 +464,7 @@ static struct display_driver_api gd7965_driver_api = {
 };
 
 
-DEVICE_AND_API_INIT(gd7965, DT_INST_LABEL(0), gd7965_init,
-		    &gd7965_driver, NULL,
+DEVICE_DEFINE(gd7965, DT_INST_LABEL(0), gd7965_init,
+		    device_pm_control_nop, &gd7965_driver, NULL,
 		    POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
 		    &gd7965_driver_api);

--- a/drivers/display/grove_lcd_rgb.c
+++ b/drivers/display/grove_lcd_rgb.c
@@ -341,7 +341,8 @@ static struct glcd_data grove_lcd_driver = {
 	 * so grove_lcd can be referenced.
 	 * since grove_lcd_driver struct is available, populating with it
 	 */
-DEVICE_AND_API_INIT(grove_lcd, GROVE_LCD_NAME, glcd_initialize,
-			&grove_lcd_driver, &grove_lcd_config,
+DEVICE_DEFINE(grove_lcd, GROVE_LCD_NAME, glcd_initialize,
+			device_pm_control_nop, &grove_lcd_driver,
+			&grove_lcd_config,
 			POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
 			(void *)&grove_lcd_driver);

--- a/drivers/display/ssd1306.c
+++ b/drivers/display/ssd1306.c
@@ -461,7 +461,7 @@ static struct display_driver_api ssd1306_driver_api = {
 	.set_orientation = ssd1306_set_orientation,
 };
 
-DEVICE_AND_API_INIT(ssd1306, DT_INST_LABEL(0), ssd1306_init,
-		    &ssd1306_driver, NULL,
+DEVICE_DEFINE(ssd1306, DT_INST_LABEL(0), ssd1306_init,
+		    device_pm_control_nop, &ssd1306_driver, NULL,
 		    POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
 		    &ssd1306_driver_api);

--- a/drivers/display/ssd16xx.c
+++ b/drivers/display/ssd16xx.c
@@ -620,7 +620,7 @@ static struct display_driver_api ssd16xx_driver_api = {
 };
 
 
-DEVICE_AND_API_INIT(ssd16xx, DT_INST_LABEL(0), ssd16xx_init,
-		    &ssd16xx_driver, NULL,
+DEVICE_DEFINE(ssd16xx, DT_INST_LABEL(0), ssd16xx_init,
+		    device_pm_control_nop, &ssd16xx_driver, NULL,
 		    POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
 		    &ssd16xx_driver_api);

--- a/drivers/dma/dma_dw.c
+++ b/drivers/dma/dma_dw.c
@@ -409,12 +409,12 @@ static const struct dma_driver_api dw_dma_driver_api = {
 		.channel_data = &dmac##inst,				\
 	};								\
 									\
-	DEVICE_AND_API_INIT(dw_dma##inst, DT_INST_LABEL(inst),		\
-			    &dw_dma_init,				\
-			    &dw_dma##inst##_data,			\
-			    &dw_dma##inst##_config, POST_KERNEL,	\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &dw_dma_driver_api);			\
+	DEVICE_DEFINE(dw_dma##inst, DT_INST_LABEL(inst),		\
+		      &dw_dma_init, device_pm_control_nop,		\
+		      &dw_dma##inst##_data,				\
+		      &dw_dma##inst##_config, POST_KERNEL,		\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &dw_dma_driver_api);				\
 									\
 	static void dw_dma##inst##_irq_config(void)			\
 	{								\

--- a/drivers/dma/dma_nios2_msgdma.c
+++ b/drivers/dma/dma_nios2_msgdma.c
@@ -230,7 +230,8 @@ static struct nios2_msgdma_dev_cfg dma0_nios2_config = {
 	.msgdma_dev = &msgdma_dev0,
 };
 
-DEVICE_AND_API_INIT(dma0_nios2, CONFIG_DMA_0_NAME, &nios2_msgdma0_initialize,
-		    NULL, &dma0_nios2_config, POST_KERNEL,
+DEVICE_DEFINE(dma0_nios2, CONFIG_DMA_0_NAME, &nios2_msgdma0_initialize,
+		    device_pm_control_nop, NULL, &dma0_nios2_config,
+		    POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &nios2_msgdma_driver_api);

--- a/drivers/dma/dma_sam0.c
+++ b/drivers/dma/dma_sam0.c
@@ -458,6 +458,6 @@ static const struct dma_driver_api dma_sam0_api = {
 	.get_status = dma_sam0_get_status,
 };
 
-DEVICE_AND_API_INIT(dma_sam0_0, DT_INST_LABEL(0), &dma_sam0_init,
-		    &dmac_data, NULL, POST_KERNEL,
+DEVICE_DEFINE(dma_sam0_0, DT_INST_LABEL(0), &dma_sam0_init,
+		    device_pm_control_nop, &dmac_data, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &dma_sam0_api);

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -365,6 +365,7 @@ static const struct sam_xdmac_dev_cfg dma0_sam_config = {
 
 static struct sam_xdmac_dev_data dma0_sam_data;
 
-DEVICE_AND_API_INIT(dma0_sam, DT_INST_LABEL(0), &sam_xdmac_initialize,
-		    &dma0_sam_data, &dma0_sam_config, POST_KERNEL,
+DEVICE_DEFINE(dma0_sam, DT_INST_LABEL(0), &sam_xdmac_initialize,
+		    device_pm_control_nop, &dma0_sam_data, &dma0_sam_config,
+		    POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &sam_xdmac_driver_api);

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -643,11 +643,11 @@ static struct dma_stm32_data dma_stm32_data_##index = {			\
 	.streams = NULL,						\
 };									\
 									\
-DEVICE_AND_API_INIT(dma_##index, DT_INST_LABEL(index),	\
-		    &dma_stm32_init,					\
-		    &dma_stm32_data_##index, &dma_stm32_config_##index,	\
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
-		    &dma_funcs)
+DEVICE_DEFINE(dma_##index, DT_INST_LABEL(index),			\
+	      &dma_stm32_init, device_pm_control_nop,			\
+	      &dma_stm32_data_##index, &dma_stm32_config_##index,	\
+	      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
+	      &dma_funcs)
 
 #define irq_func(chan)                                                  \
 static void dma_stm32_irq_##chan(void *arg)				\

--- a/drivers/dma/dmamux_stm32.c
+++ b/drivers/dma/dmamux_stm32.c
@@ -206,10 +206,10 @@ static struct dmamux_stm32_data dmamux_stm32_data_##index = {	\
 	.mux_channels = NULL,					\
 };								\
 								\
-DEVICE_AND_API_INIT(dmamux_##index, DT_INST_LABEL(index),	\
-		    &dmamux_stm32_init,				\
-		    &dmamux_stm32_data_##index, &dmamux_stm32_config_##index,\
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,\
-		    &dma_funcs);
+DEVICE_DEFINE(dmamux_##index, DT_INST_LABEL(index),			\
+	      &dmamux_stm32_init, device_pm_control_nop,		\
+	      &dmamux_stm32_data_##index, &dmamux_stm32_config_##index,	\
+	      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
+	      &dma_funcs);
 
 DT_INST_FOREACH_STATUS_OKAY(DMAMUX_INIT)

--- a/drivers/eeprom/eeprom_at2x.c
+++ b/drivers/eeprom/eeprom_at2x.c
@@ -589,12 +589,13 @@ static const struct eeprom_driver_api eeprom_at2x_api = {
 		.write_fn = eeprom_at##t##_write, \
 	}; \
 	static struct eeprom_at2x_data eeprom_at##t##_data_##n; \
-	DEVICE_AND_API_INIT(eeprom_at##t##_##n, \
-			    DT_LABEL(INST_DT_AT2X(n, t)), \
-			    &eeprom_at2x_init, &eeprom_at##t##_data_##n, \
-			    &eeprom_at##t##_config_##n, POST_KERNEL, \
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
-			    &eeprom_at2x_api)
+	DEVICE_DEFINE(eeprom_at##t##_##n, \
+		      DT_LABEL(INST_DT_AT2X(n, t)), \
+		      &eeprom_at2x_init, device_pm_control_nop, \
+		      &eeprom_at##t##_data_##n, \
+		      &eeprom_at##t##_config_##n, POST_KERNEL, \
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+		      &eeprom_at2x_api)
 
 #define EEPROM_AT24_DEVICE(n) EEPROM_AT2X_DEVICE(n, 24)
 #define EEPROM_AT25_DEVICE(n) EEPROM_AT2X_DEVICE(n, 25)

--- a/drivers/eeprom/eeprom_simulator.c
+++ b/drivers/eeprom/eeprom_simulator.c
@@ -265,8 +265,9 @@ static int eeprom_sim_init(struct device *dev)
 	return eeprom_mock_init(dev);
 }
 
-DEVICE_AND_API_INIT(eeprom_sim_0, DT_INST_LABEL(0),
-		    &eeprom_sim_init, NULL, &eeprom_sim_config_0, POST_KERNEL,
+DEVICE_DEFINE(eeprom_sim_0, DT_INST_LABEL(0),
+		    &eeprom_sim_init, device_pm_control_nop, NULL,
+		    &eeprom_sim_config_0, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &eeprom_sim_api);
 
 #ifdef CONFIG_ARCH_POSIX

--- a/drivers/eeprom/eeprom_stm32.c
+++ b/drivers/eeprom/eeprom_stm32.c
@@ -121,7 +121,7 @@ static const struct eeprom_stm32_config eeprom_config = {
 	.size = DT_INST_REG_SIZE(0),
 };
 
-DEVICE_AND_API_INIT(eeprom_stm32, DT_INST_LABEL(0),
-		    &eeprom_stm32_init, NULL,
+DEVICE_DEFINE(eeprom_stm32, DT_INST_LABEL(0),
+		    &eeprom_stm32_init, device_pm_control_nop, NULL,
 		    &eeprom_config, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &eeprom_stm32_api);

--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -166,7 +166,8 @@ static struct entropy_cc13xx_cc26xx_data entropy_cc13xx_cc26xx_data = {
 	.sync = Z_SEM_INITIALIZER(entropy_cc13xx_cc26xx_data.sync, 0, 1),
 };
 
-DEVICE_AND_API_INIT(entropy_cc13xx_cc26xx, DT_INST_LABEL(0),
-		    entropy_cc13xx_cc26xx_init, &entropy_cc13xx_cc26xx_data,
+DEVICE_DEFINE(entropy_cc13xx_cc26xx, DT_INST_LABEL(0),
+		    entropy_cc13xx_cc26xx_init, device_pm_control_nop,
+		    &entropy_cc13xx_cc26xx_data,
 		    NULL, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_cc13xx_cc26xx_driver_api);

--- a/drivers/entropy/entropy_esp32.c
+++ b/drivers/entropy/entropy_esp32.c
@@ -56,7 +56,7 @@ static struct entropy_driver_api entropy_esp32_api_funcs = {
 	.get_entropy = entropy_esp32_get_entropy
 };
 
-DEVICE_AND_API_INIT(entropy_esp32, DT_INST_LABEL(0),
-		    entropy_esp32_init, NULL, NULL,
+DEVICE_DEFINE(entropy_esp32, DT_INST_LABEL(0),
+		    entropy_esp32_init, device_pm_control_nop, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_esp32_api_funcs);

--- a/drivers/entropy/entropy_gecko_trng.c
+++ b/drivers/entropy/entropy_gecko_trng.c
@@ -97,7 +97,8 @@ static struct entropy_driver_api entropy_gecko_trng_api_funcs = {
 	.get_entropy_isr = entropy_gecko_trng_get_entropy_isr
 };
 
-DEVICE_AND_API_INIT(entropy_gecko_trng, DT_INST_LABEL(0),
-			entropy_gecko_trng_init, NULL, NULL,
+DEVICE_DEFINE(entropy_gecko_trng, DT_INST_LABEL(0),
+			entropy_gecko_trng_init, device_pm_control_nop, NULL,
+			NULL,
 			PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 			&entropy_gecko_trng_api_funcs);

--- a/drivers/entropy/entropy_litex.c
+++ b/drivers/entropy/entropy_litex.c
@@ -59,7 +59,7 @@ static const struct entropy_driver_api entropy_prbs_api = {
 	.get_entropy = entropy_prbs_get_entropy
 };
 
-DEVICE_AND_API_INIT(entropy_prbs, DT_INST_LABEL(0),
-		    entropy_prbs_init, NULL, NULL,
+DEVICE_DEFINE(entropy_prbs, DT_INST_LABEL(0),
+		    entropy_prbs_init, device_pm_control_nop, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_prbs_api);

--- a/drivers/entropy/entropy_mcux_rng.c
+++ b/drivers/entropy/entropy_mcux_rng.c
@@ -41,8 +41,9 @@ static const struct mcux_entropy_config entropy_mcux_config = {
 
 static int entropy_mcux_rng_init(struct device *);
 
-DEVICE_AND_API_INIT(entropy_mcux_rng, DT_INST_LABEL(0),
-		    entropy_mcux_rng_init, NULL, &entropy_mcux_config,
+DEVICE_DEFINE(entropy_mcux_rng, DT_INST_LABEL(0),
+		    entropy_mcux_rng_init, device_pm_control_nop, NULL,
+		    &entropy_mcux_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_mcux_rng_api_funcs);
 

--- a/drivers/entropy/entropy_mcux_rnga.c
+++ b/drivers/entropy/entropy_mcux_rnga.c
@@ -58,8 +58,8 @@ static const struct entropy_driver_api entropy_mcux_rnga_api_funcs = {
 
 static int entropy_mcux_rnga_init(struct device *);
 
-DEVICE_AND_API_INIT(entropy_mcux_rnga, DT_INST_LABEL(0),
-		    entropy_mcux_rnga_init, NULL, NULL,
+DEVICE_DEFINE(entropy_mcux_rnga, DT_INST_LABEL(0),
+		    entropy_mcux_rnga_init, device_pm_control_nop, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_mcux_rnga_api_funcs);
 

--- a/drivers/entropy/entropy_mcux_trng.c
+++ b/drivers/entropy/entropy_mcux_trng.c
@@ -41,8 +41,9 @@ static struct mcux_entropy_config entropy_mcux_config = {
 
 static int entropy_mcux_trng_init(struct device *);
 
-DEVICE_AND_API_INIT(entropy_mcux_trng, DT_INST_LABEL(0),
-		    entropy_mcux_trng_init, NULL, &entropy_mcux_config,
+DEVICE_DEFINE(entropy_mcux_trng, DT_INST_LABEL(0),
+		    entropy_mcux_trng_init, device_pm_control_nop, NULL,
+		    &entropy_mcux_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_mcux_trng_api_funcs);
 

--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -313,8 +313,9 @@ static const struct entropy_driver_api entropy_nrf5_api_funcs = {
 	.get_entropy_isr = entropy_nrf5_get_entropy_isr
 };
 
-DEVICE_AND_API_INIT(entropy_nrf5, DT_INST_LABEL(0),
-		    entropy_nrf5_init, &entropy_nrf5_data, NULL,
+DEVICE_DEFINE(entropy_nrf5, DT_INST_LABEL(0),
+		    entropy_nrf5_init, device_pm_control_nop,
+		    &entropy_nrf5_data, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_nrf5_api_funcs);
 

--- a/drivers/entropy/entropy_rv32m1_trng.c
+++ b/drivers/entropy/entropy_rv32m1_trng.c
@@ -41,8 +41,9 @@ static struct rv32m1_entropy_config entropy_rv32m1_config = {
 
 static int entropy_rv32m1_trng_init(struct device *);
 
-DEVICE_AND_API_INIT(entropy_rv32m1_trng, DT_INST_LABEL(0),
-		    entropy_rv32m1_trng_init, NULL, &entropy_rv32m1_config,
+DEVICE_DEFINE(entropy_rv32m1_trng, DT_INST_LABEL(0),
+		    entropy_rv32m1_trng_init, device_pm_control_nop, NULL,
+		    &entropy_rv32m1_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_rv32m1_trng_api_funcs);
 

--- a/drivers/entropy/entropy_sam.c
+++ b/drivers/entropy/entropy_sam.c
@@ -181,7 +181,8 @@ static const struct trng_sam_dev_cfg trng_sam_cfg = {
 	.regs = (Trng *)DT_INST_REG_ADDR(0),
 };
 
-DEVICE_AND_API_INIT(entropy_sam, DT_INST_LABEL(0),
-		    entropy_sam_init, NULL, &trng_sam_cfg,
+DEVICE_DEFINE(entropy_sam, DT_INST_LABEL(0),
+		    entropy_sam_init, device_pm_control_nop, NULL,
+		    &trng_sam_cfg,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_sam_api);

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -221,8 +221,9 @@ static struct entropy_stm32_rng_dev_data entropy_stm32_rng_data = {
 	.rng = (RNG_TypeDef *)DT_INST_REG_ADDR(0),
 };
 
-DEVICE_AND_API_INIT(entropy_stm32_rng, DT_INST_LABEL(0),
+DEVICE_DEFINE(entropy_stm32_rng, DT_INST_LABEL(0),
 		    entropy_stm32_rng_init,
-		    &entropy_stm32_rng_data, &entropy_stm32_rng_config,
+		    device_pm_control_nop, &entropy_stm32_rng_data,
+		    &entropy_stm32_rng_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_stm32_rng_api);

--- a/drivers/entropy/fake_entropy_native_posix.c
+++ b/drivers/entropy/fake_entropy_native_posix.c
@@ -73,8 +73,9 @@ static const struct entropy_driver_api entropy_native_posix_api_funcs = {
 	.get_entropy_isr = entropy_native_posix_get_entropy_isr
 };
 
-DEVICE_AND_API_INIT(entropy_native_posix, DT_INST_LABEL(0),
-		    entropy_native_posix_init, NULL, NULL,
+DEVICE_DEFINE(entropy_native_posix, DT_INST_LABEL(0),
+		    entropy_native_posix_init, device_pm_control_nop, NULL,
+		    NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_native_posix_api_funcs);
 

--- a/drivers/espi/espi_mchp_xec.c
+++ b/drivers/espi/espi_mchp_xec.c
@@ -1217,8 +1217,9 @@ static const struct espi_xec_config espi_xec_config = {
 	.pc_girq_id = DT_INST_PROP(0, pc_girq),
 };
 
-DEVICE_AND_API_INIT(espi_xec_0, DT_INST_LABEL(0),
-		    &espi_xec_init, &espi_xec_data, &espi_xec_config,
+DEVICE_DEFINE(espi_xec_0, DT_INST_LABEL(0),
+		    &espi_xec_init, device_pm_control_nop, &espi_xec_data,
+		    &espi_xec_config,
 		    PRE_KERNEL_2, CONFIG_ESPI_INIT_PRIORITY,
 		    &espi_xec_driver_api);
 

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -1434,8 +1434,9 @@ static int ptp_mcux_init(struct device *port)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(mcux_ptp_clock_0, PTP_CLOCK_NAME, ptp_mcux_init,
-		    &ptp_mcux_0_context, NULL, POST_KERNEL,
+DEVICE_DEFINE(mcux_ptp_clock_0, PTP_CLOCK_NAME, ptp_mcux_init,
+		    device_pm_control_nop, &ptp_mcux_0_context, NULL,
+		    POST_KERNEL,
 		    CONFIG_APPLICATION_INIT_PRIORITY, &api);
 
 #endif /* CONFIG_PTP_CLOCK_MCUX */

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -661,8 +661,9 @@ static int ptp_init(struct device *port)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(eth_native_posix_ptp_clock_0, PTP_CLOCK_NAME,
-		    ptp_init, &ptp_0_context, NULL, POST_KERNEL,
+DEVICE_DEFINE(eth_native_posix_ptp_clock_0, PTP_CLOCK_NAME,
+		    ptp_init, device_pm_control_nop, &ptp_0_context, NULL,
+		    POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &api);
 
 #endif /* CONFIG_ETH_NATIVE_POSIX_PTP_CLOCK */

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -2449,8 +2449,9 @@ static int ptp_gmac_init(struct device *port)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(gmac_ptp_clock_0, PTP_CLOCK_NAME, ptp_gmac_init,
-		    &ptp_gmac_0_context, NULL, POST_KERNEL,
+DEVICE_DEFINE(gmac_ptp_clock_0, PTP_CLOCK_NAME, ptp_gmac_init,
+		    device_pm_control_nop, &ptp_gmac_0_context, NULL,
+		    POST_KERNEL,
 		    CONFIG_APPLICATION_INIT_PRIORITY, &ptp_api);
 
 #endif /* CONFIG_PTP_CLOCK_SAM_GMAC */

--- a/drivers/flash/flash_gecko.c
+++ b/drivers/flash/flash_gecko.c
@@ -207,6 +207,7 @@ static const struct flash_driver_api flash_gecko_driver_api = {
 
 static struct flash_gecko_data flash_gecko_0_data;
 
-DEVICE_AND_API_INIT(flash_gecko_0, DT_INST_LABEL(0),
-		    flash_gecko_init, &flash_gecko_0_data, NULL, POST_KERNEL,
+DEVICE_DEFINE(flash_gecko_0, DT_INST_LABEL(0),
+		    flash_gecko_init, device_pm_control_nop,
+		    &flash_gecko_0_data, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_gecko_driver_api);

--- a/drivers/flash/flash_sam.c
+++ b/drivers/flash/flash_sam.c
@@ -356,7 +356,8 @@ static const struct flash_sam_dev_cfg flash_sam_cfg = {
 
 static struct flash_sam_dev_data flash_sam_data;
 
-DEVICE_AND_API_INIT(flash_sam, DT_INST_LABEL(0),
-		    flash_sam_init, &flash_sam_data, &flash_sam_cfg,
+DEVICE_DEFINE(flash_sam, DT_INST_LABEL(0),
+		    flash_sam_init, device_pm_control_nop, &flash_sam_data,
+		    &flash_sam_cfg,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &flash_sam_api);

--- a/drivers/flash/flash_sam0.c
+++ b/drivers/flash/flash_sam0.c
@@ -426,6 +426,7 @@ static const struct flash_driver_api flash_sam0_api = {
 
 static struct flash_sam0_data flash_sam0_data_0;
 
-DEVICE_AND_API_INIT(flash_sam0, DT_INST_LABEL(0),
-		    flash_sam0_init, &flash_sam0_data_0, NULL, POST_KERNEL,
+DEVICE_DEFINE(flash_sam0, DT_INST_LABEL(0),
+		    flash_sam0_init, device_pm_control_nop,
+		    &flash_sam0_data_0, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_sam0_api);

--- a/drivers/flash/flash_simulator.c
+++ b/drivers/flash/flash_simulator.c
@@ -423,8 +423,9 @@ static int flash_init(struct device *dev)
 	return flash_mock_init(dev);
 }
 
-DEVICE_AND_API_INIT(flash_simulator, FLASH_SIMULATOR_DEV_NAME, flash_init,
-		    NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+DEVICE_DEFINE(flash_simulator, FLASH_SIMULATOR_DEV_NAME, flash_init,
+		    device_pm_control_nop, NULL, NULL, POST_KERNEL,
+		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &flash_sim_api);
 
 #ifdef CONFIG_ARCH_POSIX

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -364,6 +364,7 @@ static int stm32_flash_init(struct device *dev)
 	return flash_stm32_write_protection(dev, false);
 }
 
-DEVICE_AND_API_INIT(stm32_flash, DT_INST_LABEL(0),
-		    stm32_flash_init, &flash_data, NULL, POST_KERNEL,
+DEVICE_DEFINE(stm32_flash, DT_INST_LABEL(0),
+		    stm32_flash_init, device_pm_control_nop, &flash_data,
+		    NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_stm32_api);

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -709,7 +709,8 @@ static const struct qspi_nor_config flash_id = {
 	.size = INST_0_BYTES,
 };
 
-DEVICE_AND_API_INIT(qspi_flash_memory, DT_INST_LABEL(0),
-		    &qspi_nor_init, &qspi_nor_memory_data,
+DEVICE_DEFINE(qspi_flash_memory, DT_INST_LABEL(0),
+		    &qspi_nor_init, device_pm_control_nop,
+		    &qspi_nor_memory_data,
 		    &flash_id, POST_KERNEL, CONFIG_NORDIC_QSPI_NOR_INIT_PRIORITY,
 		    &qspi_nor_api);

--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -184,6 +184,7 @@ static int flash_mcux_init(struct device *dev)
 	return (rc == kStatus_Success) ? 0 : -EIO;
 }
 
-DEVICE_AND_API_INIT(flash_mcux, DT_INST_LABEL(0),
-			flash_mcux_init, &flash_data, NULL, POST_KERNEL,
+DEVICE_DEFINE(flash_mcux, DT_INST_LABEL(0),
+			flash_mcux_init, device_pm_control_nop, &flash_data,
+			NULL, POST_KERNEL,
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_mcux_api);

--- a/drivers/flash/soc_flash_nios2_qspi.c
+++ b/drivers/flash/soc_flash_nios2_qspi.c
@@ -482,8 +482,9 @@ struct flash_nios2_qspi_config flash_cfg = {
 	}
 };
 
-DEVICE_AND_API_INIT(flash_nios2_qspi,
+DEVICE_DEFINE(flash_nios2_qspi,
 			CONFIG_SOC_FLASH_NIOS2_QSPI_DEV_NAME,
-			flash_nios2_qspi_init, &flash_cfg, NULL,
+			flash_nios2_qspi_init, device_pm_control_nop,
+			&flash_cfg, NULL,
 			POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 			&flash_nios2_qspi_api);

--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -309,8 +309,9 @@ static int nrf_flash_init(struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(nrf_flash, DT_INST_LABEL(0), nrf_flash_init,
-		NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+DEVICE_DEFINE(nrf_flash, DT_INST_LABEL(0), nrf_flash_init,
+		device_pm_control_nop, NULL, NULL, POST_KERNEL,
+		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		&flash_nrf_api);
 
 #if defined(CONFIG_SOC_FLASH_NRF_RADIO_SYNC)

--- a/drivers/flash/soc_flash_rv32m1.c
+++ b/drivers/flash/soc_flash_rv32m1.c
@@ -163,6 +163,7 @@ static int flash_mcux_init(struct device *dev)
 	return (rc == kStatus_Success) ? 0 : -EIO;
 }
 
-DEVICE_AND_API_INIT(flash_mcux, DT_INST_LABEL(0),
-			flash_mcux_init, &flash_data, NULL, POST_KERNEL,
+DEVICE_DEFINE(flash_mcux, DT_INST_LABEL(0),
+			flash_mcux_init, device_pm_control_nop, &flash_data,
+			NULL, POST_KERNEL,
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_mcux_api);

--- a/drivers/flash/spi_flash_w25qxxdv.c
+++ b/drivers/flash/spi_flash_w25qxxdv.c
@@ -451,6 +451,7 @@ static int spi_flash_init(struct device *dev)
 
 static struct spi_flash_data spi_flash_memory_data;
 
-DEVICE_AND_API_INIT(spi_flash_memory, CONFIG_SPI_FLASH_W25QXXDV_DRV_NAME,
-	    spi_flash_init, &spi_flash_memory_data, NULL, POST_KERNEL,
+DEVICE_DEFINE(spi_flash_memory, CONFIG_SPI_FLASH_W25QXXDV_DRV_NAME,
+	    spi_flash_init, device_pm_control_nop, &spi_flash_memory_data,
+	    NULL, POST_KERNEL,
 	    CONFIG_SPI_FLASH_W25QXXDV_INIT_PRIORITY, &spi_flash_api);

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -589,7 +589,8 @@ static const struct spi_nor_config flash_id = {
 
 static struct spi_nor_data spi_nor_memory_data;
 
-DEVICE_AND_API_INIT(spi_flash_memory, DT_INST_LABEL(0),
-		    &spi_nor_init, &spi_nor_memory_data,
+DEVICE_DEFINE(spi_flash_memory, DT_INST_LABEL(0),
+		    &spi_nor_init, device_pm_control_nop,
+		    &spi_nor_memory_data,
 		    &flash_id, POST_KERNEL, CONFIG_SPI_NOR_INIT_PRIORITY,
 		    &spi_nor_api);

--- a/drivers/gpio/gpio_cc13xx_cc26xx.c
+++ b/drivers/gpio/gpio_cc13xx_cc26xx.c
@@ -292,8 +292,9 @@ static const struct gpio_driver_api gpio_cc13xx_cc26xx_driver_api = {
 	.get_pending_int = gpio_cc13xx_cc26xx_get_pending_int
 };
 
-DEVICE_AND_API_INIT(gpio_cc13xx_cc26xx, DT_INST_LABEL(0),
-		    gpio_cc13xx_cc26xx_init, &gpio_cc13xx_cc26xx_data_0,
+DEVICE_DEFINE(gpio_cc13xx_cc26xx, DT_INST_LABEL(0),
+		    gpio_cc13xx_cc26xx_init, device_pm_control_nop,
+		    &gpio_cc13xx_cc26xx_data_0,
 		    &gpio_cc13xx_cc26xx_cfg_0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_cc13xx_cc26xx_driver_api);

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -290,11 +290,12 @@ static const struct gpio_driver_api api_funcs = {
 	}
 
 #define GPIO_CC32XX_DEVICE_INIT(n)					     \
-	DEVICE_AND_API_INIT(gpio_cc32xx_a##n, DT_INST_LABEL(n),		     \
-			&gpio_cc32xx_a##n##_init, &gpio_cc32xx_a##n##_data,  \
-			&gpio_cc32xx_a##n##_config,			     \
-			POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,     \
-			&api_funcs)
+	DEVICE_DEFINE(gpio_cc32xx_a##n, DT_INST_LABEL(n),		     \
+		      &gpio_cc32xx_a##n##_init, device_pm_control_nop,	     \
+		      &gpio_cc32xx_a##n##_data,				     \
+		      &gpio_cc32xx_a##n##_config,			     \
+		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	     \
+		      &api_funcs)
 
 #define GPIO_CC32XX_INIT(n)						     \
 	static const struct gpio_cc32xx_config gpio_cc32xx_a##n##_config = { \

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -288,13 +288,14 @@ static int gpio_cmsdk_ahb_init(struct device *dev)
 										\
 	static struct gpio_cmsdk_ahb_dev_data gpio_cmsdk_port_##n##_data;	\
 										\
-	DEVICE_AND_API_INIT(gpio_cmsdk_port_## n,				\
-			    DT_INST_LABEL(n),					\
-			    gpio_cmsdk_ahb_init,				\
-			    &gpio_cmsdk_port_##n##_data,			\
-			    &gpio_cmsdk_port_## n ##_config,			\
-			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
-			    &gpio_cmsdk_ahb_drv_api_funcs);			\
+	DEVICE_DEFINE(gpio_cmsdk_port_## n,				        \
+		      DT_INST_LABEL(n),					        \
+		      gpio_cmsdk_ahb_init,				        \
+		      device_pm_control_nop,				        \
+		      &gpio_cmsdk_port_##n##_data,			        \
+		      &gpio_cmsdk_port_## n ##_config,			        \
+		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	        \
+		      &gpio_cmsdk_ahb_drv_api_funcs);			        \
 										\
 	static void gpio_cmsdk_port_##n##_config_func(struct device *dev)	\
 	{									\

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -612,8 +612,9 @@ DEVICE_DEFINE(gpio_dw_0, DT_INST_LABEL(0),
 	      &gpio_config_0, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
 #else
-DEVICE_AND_API_INIT(gpio_dw_0, DT_INST_LABEL(0),
-		    gpio_dw_initialize, &gpio_0_runtime, &gpio_config_0,
+DEVICE_DEFINE(gpio_dw_0, DT_INST_LABEL(0),
+		    gpio_dw_initialize, device_pm_control_nop,
+		    &gpio_0_runtime, &gpio_config_0,
 		    POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 		    &api_funcs);
 #endif
@@ -681,8 +682,9 @@ DEVICE_DEFINE(gpio_dw_1, DT_INST_LABEL(1),
 	      &gpio_dw_config_1, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
 #else
-DEVICE_AND_API_INIT(gpio_dw_1, DT_INST_LABEL(1),
-		    gpio_dw_initialize, &gpio_1_runtime, &gpio_dw_config_1,
+DEVICE_DEFINE(gpio_dw_1, DT_INST_LABEL(1),
+		    gpio_dw_initialize, device_pm_control_nop,
+		    &gpio_1_runtime, &gpio_dw_config_1,
 		    POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 		    &api_funcs);
 #endif
@@ -750,8 +752,9 @@ DEVICE_DEFINE(gpio_dw_2, DT_INST_LABEL(2),
 	      &gpio_dw_config_2, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
 #else
-DEVICE_AND_API_INIT(gpio_dw_2, DT_INST_LABEL(2),
-		    gpio_dw_initialize, &gpio_2_runtime, &gpio_dw_config_2,
+DEVICE_DEFINE(gpio_dw_2, DT_INST_LABEL(2),
+		    gpio_dw_initialize, device_pm_control_nop,
+		    &gpio_2_runtime, &gpio_dw_config_2,
 		    POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 		    &api_funcs);
 #endif
@@ -818,8 +821,9 @@ DEVICE_DEFINE(gpio_dw_3, DT_INST_LABEL(3),
 	      &gpio_dw_config_3, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
 #else
-DEVICE_AND_API_INIT(gpio_dw_3, DT_INST_LABEL(3),
-		    gpio_dw_initialize, &gpio_3_runtime, &gpio_dw_config_3,
+DEVICE_DEFINE(gpio_dw_3, DT_INST_LABEL(3),
+		    gpio_dw_initialize, device_pm_control_nop,
+		    &gpio_3_runtime, &gpio_dw_config_3,
 		    POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 		    &api_funcs);
 #endif

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -365,13 +365,14 @@ static struct gpio_esp32_data gpio_1_data = { /* 32..39 */
 	static struct gpio_driver_config gpio_##_id##_cfg = { \
 		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(_id),  \
 	}; \
-	DEVICE_AND_API_INIT(gpio_esp32_##_id,				\
-			    DT_INST_LABEL(_id),	\
-			    gpio_esp32_init,				\
-			    &gpio_##_id##_data, &gpio_##_id##_cfg,	\
-			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &gpio_esp32_driver)
+	DEVICE_(gpio_esp32_##_id,					\
+		DT_INST_LABEL(_id),					\
+		gpio_esp32_init,					\
+		device_pm_control_nop,					\
+		&gpio_##_id##_data, &gpio_##_id##_cfg,			\
+		POST_KERNEL,						\
+		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			\
+		&gpio_esp32_driver)
 
 /* GPIOs are divided in two groups for ESP32 because the callback
  * API works with 32-bit bitmasks to manage interrupt callbacks,

--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -347,13 +347,14 @@ static const struct gpio_gecko_config gpio_gecko_port##idx##_config = { \
 \
 static struct gpio_gecko_data gpio_gecko_port##idx##_data; \
 \
-DEVICE_AND_API_INIT(gpio_gecko_port##idx, \
-		    DT_INST_LABEL(idx), \
-		    gpio_gecko_port##idx##_init, \
-		    &gpio_gecko_port##idx##_data, \
-		    &gpio_gecko_port##idx##_config, \
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, \
-		    &gpio_gecko_driver_api); \
+DEVICE_DEFINE(gpio_gecko_port##idx, \
+	      DT_INST_LABEL(idx), \
+	      gpio_gecko_port##idx##_init, \
+	      device_pm_control_nop, \
+	      &gpio_gecko_port##idx##_data, \
+	      &gpio_gecko_port##idx##_config, \
+	      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, \
+	      &gpio_gecko_driver_api); \
 \
 static int gpio_gecko_port##idx##_init(struct device *dev) \
 { \

--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -310,9 +310,10 @@ static const struct gpio_gecko_common_config gpio_gecko_common_config = {
 
 static struct gpio_gecko_common_data gpio_gecko_common_data;
 
-DEVICE_AND_API_INIT(gpio_gecko_common, DT_LABEL(DT_INST(0, silabs_gecko_gpio)),
+DEVICE_DEFINE(gpio_gecko_common, DT_LABEL(DT_INST(0, silabs_gecko_gpio)),
 		    gpio_gecko_common_init,
-		    &gpio_gecko_common_data, &gpio_gecko_common_config,
+		    device_pm_control_nop, &gpio_gecko_common_data,
+		    &gpio_gecko_common_config,
 		    POST_KERNEL, CONFIG_GPIO_GECKO_COMMON_INIT_PRIORITY,
 		    &gpio_gecko_common_driver_api);
 

--- a/drivers/gpio/gpio_ht16k33.c
+++ b/drivers/gpio/gpio_ht16k33.c
@@ -209,12 +209,13 @@ static const struct gpio_driver_api gpio_ht16k33_api = {
 									\
 	static struct gpio_ht16k33_data gpio_ht16k33_##id##_data;	\
 									\
-	DEVICE_AND_API_INIT(gpio_ht16k33_##id,				\
-			    DT_INST_LABEL(id),	\
-			    &gpio_ht16k33_init,				\
-			    &gpio_ht16k33_##id##_data,			\
-			    &gpio_ht16k33_##id##_cfg, POST_KERNEL,	\
-			    CONFIG_GPIO_HT16K33_INIT_PRIORITY,		\
-			    &gpio_ht16k33_api);
+	DEVICE_DEFINE(gpio_ht16k33_##id,				\
+		      DT_INST_LABEL(id),				\
+		      &gpio_ht16k33_init,				\
+		      device_pm_control_nop,				\
+		      &gpio_ht16k33_##id##_data,			\
+		      &gpio_ht16k33_##id##_cfg, POST_KERNEL,		\
+		      CONFIG_GPIO_HT16K33_INIT_PRIORITY,		\
+		      &gpio_ht16k33_api);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_HT16K33_DEVICE)

--- a/drivers/gpio/gpio_imx.c
+++ b/drivers/gpio/gpio_imx.c
@@ -250,13 +250,14 @@ static const struct gpio_driver_api imx_gpio_driver_api = {
 									\
 	static struct imx_gpio_data imx_gpio_##n##_data;		\
 									\
-	DEVICE_AND_API_INIT(imx_gpio_##n, DT_INST_LABEL(n),		\
-			    imx_gpio_##n##_init,			\
-			    &imx_gpio_##n##_data,			\
-			    &imx_gpio_##n##_config,			\
-			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
-			    &imx_gpio_driver_api);			\
+	DEVICEDEFINE(imx_gpio_##n, DT_INST_LABEL(n),			\
+		     imx_gpio_##n##_init,				\
+		     device_pm_control_nop,				\
+		     &imx_gpio_##n##_data,				\
+		     &imx_gpio_##n##_config,				\
+		     POST_KERNEL,					\
+		     CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
+		     &imx_gpio_driver_api);				\
 									\
 	static int imx_gpio_##n##_init(struct device *port)		\
 	{								\

--- a/drivers/gpio/gpio_intel_apl.c
+++ b/drivers/gpio/gpio_intel_apl.c
@@ -603,13 +603,14 @@ static const struct gpio_intel_apl_config				\
 									\
 static struct gpio_intel_apl_data gpio_intel_apl_data_##n;		\
 									\
-DEVICE_AND_API_INIT(gpio_intel_apl_##n,					\
-		    DT_INST_LABEL(n),					\
-		    gpio_intel_apl_init,				\
-		    &gpio_intel_apl_data_##n,				\
-		    &gpio_intel_apl_cfg_##n,				\
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
-		    &gpio_intel_apl_api);
+DEVICE_DEFINE(gpio_intel_apl_##n,					\
+	      DT_INST_LABEL(n),						\
+	      gpio_intel_apl_init,					\
+	      device_pm_control_nop,					\
+	      &gpio_intel_apl_data_##n,					\
+	      &gpio_intel_apl_cfg_##n,					\
+	      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+	      &gpio_intel_apl_api);
 
 /* "sub" devices.  no more than GPIO_INTEL_APL_NR_SUBDEVS of these! */
 DT_INST_FOREACH_STATUS_OKAY(GPIO_INTEL_APL_DEV_CFG_DATA)

--- a/drivers/gpio/gpio_litex.c
+++ b/drivers/gpio/gpio_litex.c
@@ -229,14 +229,15 @@ static const struct gpio_driver_api gpio_litex_driver_api = {
 	}; \
 	static struct gpio_litex_data gpio_litex_data_##n; \
 \
-	DEVICE_AND_API_INIT(litex_gpio_##n, \
-			    DT_INST_LABEL(n), \
-			    gpio_litex_init, \
-			    &gpio_litex_data_##n, \
-			    &gpio_litex_cfg_##n, \
-			    POST_KERNEL, \
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
-			    &gpio_litex_driver_api \
-			   );
+	DEVICE_DEFINE(litex_gpio_##n, \
+		      DT_INST_LABEL(n), \
+		      gpio_litex_init, \
+		      device_pm_control_nop, \
+		      &gpio_litex_data_##n, \
+		      &gpio_litex_cfg_##n, \
+		      POST_KERNEL, \
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+		      &gpio_litex_driver_api \
+		);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_LITEX_INIT)

--- a/drivers/gpio/gpio_lmp90xxx.c
+++ b/drivers/gpio/gpio_lmp90xxx.c
@@ -177,12 +177,13 @@ BUILD_ASSERT(CONFIG_GPIO_LMP90XXX_INIT_PRIORITY >
 									\
 	static struct gpio_lmp90xxx_data gpio_lmp90xxx_##id##_data;	\
 									\
-	DEVICE_AND_API_INIT(gpio_lmp90xxx_##id,				\
-			    DT_INST_LABEL(id),				\
-			    &gpio_lmp90xxx_init,			\
-			    &gpio_lmp90xxx_##id##_data,			\
-			    &gpio_lmp90xxx_##id##_cfg, POST_KERNEL,	\
-			    CONFIG_GPIO_LMP90XXX_INIT_PRIORITY,		\
-			    &gpio_lmp90xxx_api);
+	DEVICE_DEFINE(gpio_lmp90xxx_##id,				\
+		      DT_INST_LABEL(id),				\
+		      &gpio_lmp90xxx_init,				\
+		      device_pm_control_nop,				\
+		      &gpio_lmp90xxx_##id##_data,			\
+		      &gpio_lmp90xxx_##id##_cfg, POST_KERNEL,		\
+		      CONFIG_GPIO_LMP90XXX_INIT_PRIORITY,		\
+		      &gpio_lmp90xxx_api);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_LMP90XXX_DEVICE)

--- a/drivers/gpio/gpio_mchp_xec.c
+++ b/drivers/gpio/gpio_mchp_xec.c
@@ -356,10 +356,11 @@ static const struct gpio_xec_config gpio_xec_port000_036_config = {
 
 static struct gpio_xec_data gpio_xec_port000_036_data;
 
-DEVICE_AND_API_INIT(gpio_xec_port000_036,
+DEVICE_DEFINE(gpio_xec_port000_036,
 		DT_LABEL(DT_NODELABEL(gpio_000_036)),
 		gpio_xec_port000_036_init,
-		&gpio_xec_port000_036_data, &gpio_xec_port000_036_config,
+		device_pm_control_nop, &gpio_xec_port000_036_data,
+		&gpio_xec_port000_036_config,
 		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		&gpio_xec_driver_api);
 
@@ -401,10 +402,11 @@ static const struct gpio_xec_config gpio_xec_port040_076_config = {
 
 static struct gpio_xec_data gpio_xec_port040_076_data;
 
-DEVICE_AND_API_INIT(gpio_xec_port040_076,
+DEVICE_DEFINE(gpio_xec_port040_076,
 		DT_LABEL(DT_NODELABEL(gpio_040_076)),
 		gpio_xec_port040_076_init,
-		&gpio_xec_port040_076_data, &gpio_xec_port040_076_config,
+		device_pm_control_nop, &gpio_xec_port040_076_data,
+		&gpio_xec_port040_076_config,
 		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		&gpio_xec_driver_api);
 
@@ -446,10 +448,11 @@ static const struct gpio_xec_config gpio_xec_port100_136_config = {
 
 static struct gpio_xec_data gpio_xec_port100_136_data;
 
-DEVICE_AND_API_INIT(gpio_xec_port100_136,
+DEVICE_DEFINE(gpio_xec_port100_136,
 		DT_LABEL(DT_NODELABEL(gpio_100_136)),
 		gpio_xec_port100_136_init,
-		&gpio_xec_port100_136_data, &gpio_xec_port100_136_config,
+		device_pm_control_nop, &gpio_xec_port100_136_data,
+		&gpio_xec_port100_136_config,
 		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		&gpio_xec_driver_api);
 
@@ -491,10 +494,11 @@ static const struct gpio_xec_config gpio_xec_port140_176_config = {
 
 static struct gpio_xec_data gpio_xec_port140_176_data;
 
-DEVICE_AND_API_INIT(gpio_xec_port140_176,
+DEVICE_DEFINE(gpio_xec_port140_176,
 		DT_LABEL(DT_NODELABEL(gpio_140_176)),
 		gpio_xec_port140_176_init,
-		&gpio_xec_port140_176_data, &gpio_xec_port140_176_config,
+		device_pm_control_nop, &gpio_xec_port140_176_data,
+		&gpio_xec_port140_176_config,
 		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		&gpio_xec_driver_api);
 
@@ -536,10 +540,11 @@ static const struct gpio_xec_config gpio_xec_port200_236_config = {
 
 static struct gpio_xec_data gpio_xec_port200_236_data;
 
-DEVICE_AND_API_INIT(gpio_xec_port200_236,
+DEVICE_DEFINE(gpio_xec_port200_236,
 		DT_LABEL(DT_NODELABEL(gpio_200_236)),
 		gpio_xec_port200_236_init,
-		&gpio_xec_port200_236_data, &gpio_xec_port200_236_config,
+		device_pm_control_nop, &gpio_xec_port200_236_data,
+		&gpio_xec_port200_236_config,
 		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		&gpio_xec_driver_api);
 
@@ -581,10 +586,11 @@ static const struct gpio_xec_config gpio_xec_port240_276_config = {
 
 static struct gpio_xec_data gpio_xec_port240_276_data;
 
-DEVICE_AND_API_INIT(gpio_xec_port240_276,
+DEVICE_DEFINE(gpio_xec_port240_276,
 		DT_LABEL(DT_NODELABEL(gpio_240_276)),
 		gpio_xec_port240_276_init,
-		&gpio_xec_port240_276_data, &gpio_xec_port240_276_config,
+		device_pm_control_nop, &gpio_xec_port240_276_data,
+		&gpio_xec_port240_276_config,
 		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		&gpio_xec_driver_api);
 

--- a/drivers/gpio/gpio_mcp23s17.c
+++ b/drivers/gpio/gpio_mcp23s17.c
@@ -433,11 +433,12 @@ static int mcp23s17_init(struct device *dev)
 	};								\
 									\
 	/* This has to init after SPI master */				\
-	DEVICE_AND_API_INIT(mcp23s17_##inst, DT_INST_LABEL(inst),	\
-			    mcp23s17_init, &mcp23s17_##inst##_drvdata,	\
-			    &mcp23s17_##inst##_config,			\
-			    POST_KERNEL,				\
-			    CONFIG_GPIO_MCP23S17_INIT_PRIORITY,		\
-			    &api_table);
+	DEVICE_DEFINE(mcp23s17_##inst, DT_INST_LABEL(inst),		\
+		      mcp23s17_init, device_pm_control_nop,		\
+		      &mcp23s17_##inst##_drvdata,			\
+		      &mcp23s17_##inst##_config,			\
+		      POST_KERNEL,					\
+		      CONFIG_GPIO_MCP23S17_INIT_PRIORITY,		\
+		      &api_table);
 
 DT_INST_FOREACH_STATUS_OKAY(MCP23S17_INIT)

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -303,13 +303,14 @@ static const struct gpio_driver_api gpio_mcux_driver_api = {
 									\
 	static struct gpio_mcux_data gpio_mcux_port## n ##_data;	\
 									\
-	DEVICE_AND_API_INIT(gpio_mcux_port## n, DT_INST_LABEL(n),	\
-			    gpio_mcux_port## n ##_init,			\
-			    &gpio_mcux_port## n ##_data,		\
-			    &gpio_mcux_port## n##_config,		\
-			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
-			    &gpio_mcux_driver_api);			\
+	DEVICE_DEFINE(gpio_mcux_port## n, DT_INST_LABEL(n),		\
+		      gpio_mcux_port## n ##_init,			\
+		      device_pm_control_nop,				\
+		      &gpio_mcux_port## n ##_data,			\
+		      &gpio_mcux_port## n##_config,			\
+		      POST_KERNEL,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
+		      &gpio_mcux_driver_api);				\
 									\
 	static int gpio_mcux_port## n ##_init(struct device *dev)	\
 	{								\

--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -246,13 +246,14 @@ static const struct gpio_driver_api mcux_igpio_driver_api = {
 									\
 	static struct mcux_igpio_data mcux_igpio_##n##_data;		\
 									\
-	DEVICE_AND_API_INIT(mcux_igpio_##n, DT_INST_LABEL(n),		\
-			    mcux_igpio_##n##_init,			\
-			    &mcux_igpio_##n##_data,			\
-			    &mcux_igpio_##n##_config,			\
-			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
-			    &mcux_igpio_driver_api);			\
+	DEVICE_DEFINE(mcux_igpio_##n, DT_INST_LABEL(n),			\
+		      mcux_igpio_##n##_init,				\
+		      device_pm_control_nop,				\
+		      &mcux_igpio_##n##_data,				\
+		      &mcux_igpio_##n##_config,				\
+		      POST_KERNEL,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
+		      &mcux_igpio_driver_api);				\
 									\
 	static int mcux_igpio_##n##_init(struct device *dev)		\
 	{								\

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -366,8 +366,9 @@ static const struct gpio_mcux_lpc_config gpio_mcux_lpc_port0_config = {
 
 static struct gpio_mcux_lpc_data gpio_mcux_lpc_port0_data;
 
-DEVICE_AND_API_INIT(gpio_mcux_lpc_port0, DT_INST_LABEL(0),
-		    lpc_gpio_0_init, &gpio_mcux_lpc_port0_data,
+DEVICE_DEFINE(gpio_mcux_lpc_port0, DT_INST_LABEL(0),
+		    lpc_gpio_0_init, device_pm_control_nop,
+		    &gpio_mcux_lpc_port0_data,
 		    &gpio_mcux_lpc_port0_config, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_mcux_lpc_driver_api);
@@ -436,8 +437,9 @@ static const struct gpio_mcux_lpc_config gpio_mcux_lpc_port1_config = {
 
 static struct gpio_mcux_lpc_data gpio_mcux_lpc_port1_data;
 
-DEVICE_AND_API_INIT(gpio_mcux_lpc_port1, DT_INST_LABEL(1),
-		    lpc_gpio_1_init, &gpio_mcux_lpc_port1_data,
+DEVICE_DEFINE(gpio_mcux_lpc_port1, DT_INST_LABEL(1),
+		    lpc_gpio_1_init, device_pm_control_nop,
+		    &gpio_mcux_lpc_port1_data,
 		    &gpio_mcux_lpc_port1_config, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_mcux_lpc_driver_api);

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -531,14 +531,15 @@ static int gpio_nrfx_init(struct device *port)
 									\
 	static struct gpio_nrfx_data gpio_nrfx_p##id##_data;		\
 									\
-	DEVICE_AND_API_INIT(gpio_nrfx_p##id,				\
-			    DT_LABEL(GPIO(id)),				\
-			    gpio_nrfx_init,				\
-			    &gpio_nrfx_p##id##_data,			\
-			    &gpio_nrfx_p##id##_cfg,			\
-			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
-			    &gpio_nrfx_drv_api_funcs)
+	DEVICE_DEFINE(gpio_nrfx_p##id,					\
+		      DT_LABEL(GPIO(id)),				\
+		      gpio_nrfx_init,					\
+		      device_pm_control_nop,				\
+		      &gpio_nrfx_p##id##_data,				\
+		      &gpio_nrfx_p##id##_cfg,				\
+		      POST_KERNEL,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
+		      &gpio_nrfx_drv_api_funcs)
 
 #ifdef CONFIG_GPIO_NRF_P0
 GPIO_NRF_DEVICE(0);

--- a/drivers/gpio/gpio_pca95xx.c
+++ b/drivers/gpio/gpio_pca95xx.c
@@ -508,9 +508,10 @@ static struct gpio_pca95xx_drv_data gpio_pca95xx_##inst##_drvdata = {	\
 	.reg_cache.pud_sel = 0xFFFF,					\
 };									\
 									\
-DEVICE_AND_API_INIT(gpio_pca95xx_##inst,				\
-	DT_INST_LABEL(inst),				\
+DEVICE_DEFINE(gpio_pca95xx_##inst,					\
+	DT_INST_LABEL(inst),						\
 	gpio_pca95xx_init,						\
+	device_pm_control_nop,						\
 	&gpio_pca95xx_##inst##_drvdata,					\
 	&gpio_pca95xx_##inst##_cfg,					\
 	POST_KERNEL, CONFIG_GPIO_PCA95XX_INIT_PRIORITY,			\

--- a/drivers/gpio/gpio_rv32m1.c
+++ b/drivers/gpio/gpio_rv32m1.c
@@ -343,13 +343,14 @@ static const struct gpio_driver_api gpio_rv32m1_driver_api = {
 									\
 	static struct gpio_rv32m1_data gpio_rv32m1_##n##_data;		\
 									\
-	DEVICE_AND_API_INIT(gpio_rv32m1_##n, DT_INST_LABEL(n),		\
-			    gpio_rv32m1_init,				\
-			    &gpio_rv32m1_##n##_data,			\
-			    &gpio_rv32m1_##n##_config,			\
-			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
-			    &gpio_rv32m1_driver_api);			\
+	DEVICE_DEFINE(gpio_rv32m1_##n, DT_INST_LABEL(n),		\
+		      gpio_rv32m1_init,					\
+		      device_pm_control_nop,				\
+		      &gpio_rv32m1_##n##_data,				\
+		      &gpio_rv32m1_##n##_config,			\
+		      POST_KERNEL,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
+		      &gpio_rv32m1_driver_api);				\
 									\
 	static int gpio_rv32m1_##n##_init(struct device *dev)		\
 	{								\

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -343,11 +343,12 @@ int gpio_sam_init(struct device *dev)
 									\
 	static struct gpio_sam_runtime port_##n##_sam_runtime;		\
 									\
-	DEVICE_AND_API_INIT(port_##n##_sam, DT_INST_LABEL(n),		\
-			    gpio_sam_init, &port_##n##_sam_runtime,	\
-			    &port_##n##_sam_config, POST_KERNEL,	\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &gpio_sam_api);				\
+	DEVICE_DEFINE(port_##n##_sam, DT_INST_LABEL(n),			\
+		      gpio_sam_init, device_pm_control_nop,		\
+		      &port_##n##_sam_runtime,				\
+		      &port_##n##_sam_config, POST_KERNEL,		\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &gpio_sam_api);					\
 									\
 	static void port_##n##_sam_config_func(struct device *dev)	\
 	{								\

--- a/drivers/gpio/gpio_sam0.c
+++ b/drivers/gpio/gpio_sam0.c
@@ -316,8 +316,9 @@ static const struct gpio_sam0_config gpio_sam0_config_0 = {
 
 static struct gpio_sam0_data gpio_sam0_data_0;
 
-DEVICE_AND_API_INIT(gpio_sam0_0, DT_LABEL(DT_NODELABEL(porta)),
-		    gpio_sam0_init, &gpio_sam0_data_0, &gpio_sam0_config_0,
+DEVICE_DEFINE(gpio_sam0_0, DT_LABEL(DT_NODELABEL(porta)),
+		    gpio_sam0_init, device_pm_control_nop, &gpio_sam0_data_0,
+		    &gpio_sam0_config_0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_sam0_api);
 #endif
@@ -337,8 +338,9 @@ static const struct gpio_sam0_config gpio_sam0_config_1 = {
 
 static struct gpio_sam0_data gpio_sam0_data_1;
 
-DEVICE_AND_API_INIT(gpio_sam0_1, DT_LABEL(DT_NODELABEL(portb)),
-		    gpio_sam0_init, &gpio_sam0_data_1, &gpio_sam0_config_1,
+DEVICE_DEFINE(gpio_sam0_1, DT_LABEL(DT_NODELABEL(portb)),
+		    gpio_sam0_init, device_pm_control_nop, &gpio_sam0_data_1,
+		    &gpio_sam0_config_1,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_sam0_api);
 #endif
@@ -358,8 +360,9 @@ static const struct gpio_sam0_config gpio_sam0_config_2 = {
 
 static struct gpio_sam0_data gpio_sam0_data_2;
 
-DEVICE_AND_API_INIT(gpio_sam0_2, DT_LABEL(DT_NODELABEL(portc)),
-		    gpio_sam0_init, &gpio_sam0_data_2, &gpio_sam0_config_2,
+DEVICE_DEFINE(gpio_sam0_2, DT_LABEL(DT_NODELABEL(portc)),
+		    gpio_sam0_init, device_pm_control_nop, &gpio_sam0_data_2,
+		    &gpio_sam0_config_2,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_sam0_api);
 #endif
@@ -379,8 +382,9 @@ static const struct gpio_sam0_config gpio_sam0_config_3 = {
 
 static struct gpio_sam0_data gpio_sam0_data_3;
 
-DEVICE_AND_API_INIT(gpio_sam0_3, DT_LABEL(DT_NODELABEL(portd)),
-		    gpio_sam0_init, &gpio_sam0_data_3, &gpio_sam0_config_3,
+DEVICE_DEFINE(gpio_sam0_3, DT_LABEL(DT_NODELABEL(portd)),
+		    gpio_sam0_init, device_pm_control_nop, &gpio_sam0_data_3,
+		    &gpio_sam0_config_3,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_sam0_api);
 #endif

--- a/drivers/gpio/gpio_sifive.c
+++ b/drivers/gpio/gpio_sifive.c
@@ -390,9 +390,10 @@ static const struct gpio_sifive_config gpio_sifive_config0 = {
 
 static struct gpio_sifive_data gpio_sifive_data0;
 
-DEVICE_AND_API_INIT(gpio_sifive_0, DT_INST_LABEL(0),
+DEVICE_DEFINE(gpio_sifive_0, DT_INST_LABEL(0),
 		    gpio_sifive_init,
-		    &gpio_sifive_data0, &gpio_sifive_config0,
+		    device_pm_control_nop, &gpio_sifive_data0,
+		    &gpio_sifive_config0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_sifive_driver);
 

--- a/drivers/gpio/gpio_stellaris.c
+++ b/drivers/gpio/gpio_stellaris.c
@@ -269,13 +269,14 @@ static const struct gpio_driver_api gpio_stellaris_driver_api = {
 		.config_func = port_## n ##_stellaris_config_func,			\
 	};										\
 											\
-	DEVICE_AND_API_INIT(gpio_stellaris_port_## n,					\
-			    DT_INST_LABEL(n),						\
-			    gpio_stellaris_init,					\
-			    &port_## n ##_stellaris_runtime,				\
-			    &gpio_stellaris_port_## n ##_config,			\
-			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
-			    &gpio_stellaris_driver_api);				\
+	DEVICE_DEFINE(gpio_stellaris_port_## n,				\
+		      DT_INST_LABEL(n),					\
+		      gpio_stellaris_init,				\
+		      device_pm_control_nop,				\
+		      &port_## n ##_stellaris_runtime,			\
+		      &gpio_stellaris_port_## n ##_config,		\
+		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
+		      &gpio_stellaris_driver_api);			\
 											\
 	static void port_## n ##_stellaris_config_func(struct device *dev)		\
 	{										\

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -581,14 +581,15 @@ static int gpio_stm32_init(struct device *device)
 		.pclken = { .bus = __bus, .enr = __cenr }		       \
 	};								       \
 	static struct gpio_stm32_data gpio_stm32_data_## __suffix;	       \
-	DEVICE_AND_API_INIT(gpio_stm32_## __suffix,			       \
-			    __name,					       \
-			    gpio_stm32_init,				       \
-			    &gpio_stm32_data_## __suffix,		       \
-			    &gpio_stm32_cfg_## __suffix,		       \
-			    POST_KERNEL,				       \
-			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	       \
-			    &gpio_stm32_driver)
+	DEVICE_DEFINE(gpio_stm32_## __suffix,				\
+		      __name,						\
+		      gpio_stm32_init,					\
+		      device_pm_control_nop,				\
+		      &gpio_stm32_data_## __suffix,			\
+		      &gpio_stm32_cfg_## __suffix,			\
+		      POST_KERNEL,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
+		      &gpio_stm32_driver)
 
 #define GPIO_DEVICE_INIT_STM32(__suffix, __SUFFIX)			\
 	GPIO_DEVICE_INIT(DT_LABEL(DT_NODELABEL(gpio##__suffix)),	\

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -667,6 +667,7 @@ static int gpio_stm32_afio_init(struct device *device)
 	return 0;
 }
 
-DEVICE_INIT(gpio_stm32_afio, "", gpio_stm32_afio_init, NULL, NULL, PRE_KERNEL_2, 0);
+DEVICE_DEFINE(gpio_stm32_afio, "", gpio_stm32_afio_init,
+	      device_pm_control_nop, NULL, NULL, PRE_KERNEL_2, 0, api);
 
 #endif /* CONFIG_SOC_SERIES_STM32F1X */

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -692,7 +692,8 @@ static struct sx1509b_drv_data sx1509b_drvdata = {
 	.lock = Z_SEM_INITIALIZER(sx1509b_drvdata.lock, 1, 1),
 };
 
-DEVICE_AND_API_INIT(sx1509b, DT_INST_LABEL(0),
-		    sx1509b_init, &sx1509b_drvdata, &sx1509b_cfg,
+DEVICE_DEFINE(sx1509b, DT_INST_LABEL(0),
+		    sx1509b_init, device_pm_control_nop, &sx1509b_drvdata,
+		    &sx1509b_cfg,
 		    POST_KERNEL, CONFIG_GPIO_SX1509B_INIT_PRIORITY,
 		    &api_table);

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -477,8 +477,9 @@ DEVICE_DEFINE(i2c_cc13xx_cc26xx, DT_INST_LABEL(0),
 		POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,
 		&i2c_cc13xx_cc26xx_driver_api);
 #else
-DEVICE_AND_API_INIT(i2c_cc13xx_cc26xx, DT_INST_LABEL(0),
-		    i2c_cc13xx_cc26xx_init, &i2c_cc13xx_cc26xx_data,
+DEVICE_DEFINE(i2c_cc13xx_cc26xx, DT_INST_LABEL(0),
+		    i2c_cc13xx_cc26xx_init, device_pm_control_nop,
+		    &i2c_cc13xx_cc26xx_data,
 		    &i2c_cc13xx_cc26xx_config, POST_KERNEL,
 		    CONFIG_I2C_INIT_PRIORITY, &i2c_cc13xx_cc26xx_driver_api);
 #endif

--- a/drivers/i2c/i2c_cc32xx.c
+++ b/drivers/i2c/i2c_cc32xx.c
@@ -381,8 +381,9 @@ static const struct i2c_cc32xx_config i2c_cc32xx_config = {
 
 static struct i2c_cc32xx_data i2c_cc32xx_data;
 
-DEVICE_AND_API_INIT(i2c_cc32xx, DT_INST_LABEL(0), &i2c_cc32xx_init,
-		    &i2c_cc32xx_data, &i2c_cc32xx_config,
+DEVICE_DEFINE(i2c_cc32xx, DT_INST_LABEL(0), &i2c_cc32xx_init,
+		    device_pm_control_nop, &i2c_cc32xx_data,
+		    &i2c_cc32xx_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &i2c_cc32xx_driver_api);
 

--- a/drivers/i2c/i2c_dw_port_x.h
+++ b/drivers/i2c/i2c_dw_port_x.h
@@ -24,11 +24,12 @@ static struct i2c_dw_dev_config i2c_@NUM@_runtime = {
 		DT_INST_REG_ADDR(@NUM@)
 };
 
-DEVICE_AND_API_INIT(i2c_@NUM@, DT_INST_LABEL(@NUM@),
-		    &i2c_dw_initialize,
-		    &i2c_@NUM@_runtime, &i2c_config_dw_@NUM@,
-		    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,
-		    &funcs);
+DEVICE_DEFINE(i2c_@NUM@, DT_INST_LABEL(@NUM@),
+	      &i2c_dw_initialize,
+	      device_pm_control_nop,
+	      &i2c_@NUM@_runtime, &i2c_config_dw_@NUM@,
+	      POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,
+	      &funcs);
 
 #if DT_INST_IRQ_HAS_CELL(@NUM@, sense)
 #define INST_@NUM@_IRQ_FLAGS  DT_INST_IRQ(@NUM@, sense)

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -608,8 +608,9 @@ static const struct i2c_esp32_config i2c_esp32_config_0 = {
 
 static struct i2c_esp32_data i2c_esp32_data_0;
 
-DEVICE_AND_API_INIT(i2c_esp32_0, DT_INST_LABEL(0), &i2c_esp32_init,
-		    &i2c_esp32_data_0, &i2c_esp32_config_0,
+DEVICE_DEFINE(i2c_esp32_0, DT_INST_LABEL(0), &i2c_esp32_init,
+		    device_pm_control_nop, &i2c_esp32_data_0,
+		    &i2c_esp32_config_0,
 		    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,
 		    &i2c_esp32_driver_api);
 #endif /* DT_NODE_HAS_STATUS(DT_DRV_INST(0), okay) */
@@ -656,8 +657,9 @@ static const struct i2c_esp32_config i2c_esp32_config_1 = {
 
 static struct i2c_esp32_data i2c_esp32_data_1;
 
-DEVICE_AND_API_INIT(i2c_esp32_1, DT_INST_LABEL(1), &i2c_esp32_init,
-		    &i2c_esp32_data_1, &i2c_esp32_config_1,
+DEVICE_DEFINE(i2c_esp32_1, DT_INST_LABEL(1), &i2c_esp32_init,
+		    device_pm_control_nop, &i2c_esp32_data_1,
+		    &i2c_esp32_config_1,
 		    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,
 		    &i2c_esp32_driver_api);
 #endif /* DT_NODE_HAS_STATUS(DT_DRV_INST(1), okay) */

--- a/drivers/i2c/i2c_gecko.c
+++ b/drivers/i2c/i2c_gecko.c
@@ -216,8 +216,9 @@ static struct i2c_gecko_config i2c_gecko_config_0 = {
 
 static struct i2c_gecko_data i2c_gecko_data_0;
 
-DEVICE_AND_API_INIT(i2c_gecko_0, DT_INST_LABEL(0),
-		    &i2c_gecko_init, &i2c_gecko_data_0, &i2c_gecko_config_0,
+DEVICE_DEFINE(i2c_gecko_0, DT_INST_LABEL(0),
+		    &i2c_gecko_init, device_pm_control_nop, &i2c_gecko_data_0,
+		    &i2c_gecko_config_0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &i2c_gecko_driver_api);
 #endif /* DT_NODE_HAS_STATUS(DT_DRV_INST(0), okay) */
@@ -250,8 +251,9 @@ static struct i2c_gecko_config i2c_gecko_config_1 = {
 
 static struct i2c_gecko_data i2c_gecko_data_1;
 
-DEVICE_AND_API_INIT(i2c_gecko_1, DT_INST_LABEL(1),
-		    &i2c_gecko_init, &i2c_gecko_data_1, &i2c_gecko_config_1,
+DEVICE_DEFINE(i2c_gecko_1, DT_INST_LABEL(1),
+		    &i2c_gecko_init, device_pm_control_nop, &i2c_gecko_data_1,
+		    &i2c_gecko_config_1,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &i2c_gecko_driver_api);
 #endif /* DT_NODE_HAS_STATUS(DT_DRV_INST(1), okay) */

--- a/drivers/i2c/i2c_gpio.c
+++ b/drivers/i2c/i2c_gpio.c
@@ -178,10 +178,11 @@ static const struct i2c_gpio_config i2c_gpio_dev_cfg_##_num = {		\
 	.bitrate	= DT_INST_PROP(_num, clock_frequency),		\
 };									\
 									\
-DEVICE_AND_API_INIT(i2c_gpio_##_num, DT_INST_LABEL(_num),		\
-	    i2c_gpio_init,						\
-	    &i2c_gpio_dev_data_##_num,					\
-	    &i2c_gpio_dev_cfg_##_num,					\
-	    PRE_KERNEL_2, CONFIG_I2C_INIT_PRIORITY, &api);
+DEVICE_DEFINE(i2c_gpio_##_num, DT_INST_LABEL(_num),			\
+	      i2c_gpio_init,						\
+	      device_pm_control_nop,					\
+	      &i2c_gpio_dev_data_##_num,				\
+	      &i2c_gpio_dev_cfg_##_num,					\
+	      PRE_KERNEL_2, CONFIG_I2C_INIT_PRIORITY, &api);
 
 DT_INST_FOREACH_STATUS_OKAY(DEFINE_I2C_GPIO)

--- a/drivers/i2c/i2c_imx.c
+++ b/drivers/i2c/i2c_imx.c
@@ -369,12 +369,13 @@ static const struct i2c_driver_api i2c_imx_driver_api = {
 									\
 	static struct i2c_imx_data i2c_imx_data_##n;			\
 									\
-	DEVICE_AND_API_INIT(i2c_imx_##n, DT_INST_LABEL(n),		\
-				&i2c_imx_init,				\
-				&i2c_imx_data_##n, &i2c_imx_config_##n,	\
-				POST_KERNEL,				\
-				CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
-				&i2c_imx_driver_api);			\
+	DEVICE_DEFINE(i2c_imx_##n, DT_INST_LABEL(n),			\
+		      &i2c_imx_init,					\
+		      device_pm_control_nop,				\
+		      &i2c_imx_data_##n, &i2c_imx_config_##n,		\
+		      POST_KERNEL,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &i2c_imx_driver_api);				\
 									\
 	static void i2c_imx_config_func_##n(struct device *dev)		\
 	{								\

--- a/drivers/i2c/i2c_litex.c
+++ b/drivers/i2c/i2c_litex.c
@@ -126,14 +126,15 @@ static const struct i2c_driver_api i2c_litex_driver_api = {
 									       \
 	static struct i2c_bitbang i2c_bitbang_##n;			       \
 									       \
-	DEVICE_AND_API_INIT(litex_i2c_##n,				       \
-			   DT_INST_LABEL(n),		       \
-			   i2c_litex_init,				       \
-			   &i2c_bitbang_##n,	                               \
-			   &i2c_litex_cfg_##n,				       \
-			   POST_KERNEL,					       \
-			   CONFIG_I2C_INIT_PRIORITY,			       \
-			   &i2c_litex_driver_api			       \
-			   );
+	DEVICE_DEFINE(litex_i2c_##n,					       \
+		      DT_INST_LABEL(n),					       \
+		      i2c_litex_init,					       \
+		      device_pm_control_nop,				       \
+		      &i2c_bitbang_##n,					       \
+		      &i2c_litex_cfg_##n,				       \
+		      POST_KERNEL,					       \
+		      CONFIG_I2C_INIT_PRIORITY,				       \
+		      &i2c_litex_driver_api				       \
+		);
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_LITEX_INIT)

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -304,11 +304,12 @@ static const struct i2c_stm32_config i2c_stm32_cfg_##name = {		\
 									\
 static struct i2c_stm32_data i2c_stm32_dev_data_##name;			\
 									\
-DEVICE_AND_API_INIT(i2c_stm32_##name, DT_LABEL(DT_NODELABEL(name)),	\
-		    &i2c_stm32_init, &i2c_stm32_dev_data_##name,	\
-		    &i2c_stm32_cfg_##name,				\
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
-		    &api_funcs);					\
+DEVICE_DEFINE(i2c_stm32_##name, DT_LABEL(DT_NODELABEL(name)),		\
+	      &i2c_stm32_init, device_pm_control_nop,			\
+	      &i2c_stm32_dev_data_##name,				\
+	      &i2c_stm32_cfg_##name,					\
+	      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+	      &api_funcs);						\
 									\
 STM32_I2C_IRQ_HANDLER(name)
 

--- a/drivers/i2c/i2c_mchp_xec.c
+++ b/drivers/i2c/i2c_mchp_xec.c
@@ -423,9 +423,10 @@ static int i2c_xec_init(struct device *dev)
 			DT_INST_REG_ADDR(n),	\
 		.port_sel = DT_INST_PROP(n, port_sel),	\
 	};								\
-	DEVICE_AND_API_INIT(i2c_xec_##n,				\
-		DT_INST_LABEL(n),			\
-		&i2c_xec_init, &i2c_xec_data_##n, &i2c_xec_config_##n,	\
+	DEVICE_DEFINE(i2c_xec_##n,					\
+		DT_INST_LABEL(n),					\
+		&i2c_xec_init, device_pm_control_nop,			\
+		&i2c_xec_data_##n, &i2c_xec_config_##n,			\
 		POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,			\
 		&i2c_xec_driver_api);
 

--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -215,12 +215,13 @@ static const struct i2c_driver_api i2c_mcux_driver_api = {
 									\
 	static struct i2c_mcux_data i2c_mcux_data_ ## n;		\
 									\
-	DEVICE_AND_API_INIT(i2c_mcux_ ## n,				\
-			DT_INST_LABEL(n),				\
-			&i2c_mcux_init, &i2c_mcux_data_ ## n,		\
-			&i2c_mcux_config_ ## n, POST_KERNEL,		\
-			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			&i2c_mcux_driver_api);				\
+	DEVICE_DEFINE(i2c_mcux_ ## n,					\
+		      DT_INST_LABEL(n),					\
+		      &i2c_mcux_init, device_pm_control_nop,		\
+		      &i2c_mcux_data_ ## n,				\
+		      &i2c_mcux_config_ ## n, POST_KERNEL,		\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &i2c_mcux_driver_api);				\
 									\
 	static void i2c_mcux_config_func_ ## n(struct device *dev)	\
 	{								\

--- a/drivers/i2c/i2c_mcux_flexcomm.c
+++ b/drivers/i2c/i2c_mcux_flexcomm.c
@@ -207,14 +207,15 @@ static const struct i2c_driver_api mcux_flexcomm_driver_api = {
 		.bitrate = DT_INST_PROP(id, clock_frequency),		\
 	};								\
 	static struct mcux_flexcomm_data mcux_flexcomm_data_##id;	\
-	DEVICE_AND_API_INIT(mcux_flexcomm_##id,				\
-			    DT_INST_LABEL(id),				\
-			    &mcux_flexcomm_init,			\
-			    &mcux_flexcomm_data_##id,			\
-			    &mcux_flexcomm_config_##id,			\
-			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &mcux_flexcomm_driver_api);			\
+	DEVICE_DEFINE(mcux_flexcomm_##id,				\
+		      DT_INST_LABEL(id),				\
+		      &mcux_flexcomm_init,				\
+		      device_pm_control_nop,				\
+		      &mcux_flexcomm_data_##id,				\
+		      &mcux_flexcomm_config_##id,			\
+		      POST_KERNEL,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &mcux_flexcomm_driver_api);			\
 	static void mcux_flexcomm_config_func_##id(struct device *dev)	\
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(id),				\

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -238,11 +238,12 @@ static const struct i2c_driver_api mcux_lpi2c_driver_api = {
 									\
 	static struct mcux_lpi2c_data mcux_lpi2c_data_##n;		\
 									\
-	DEVICE_AND_API_INIT(mcux_lpi2c_##n, DT_INST_LABEL(n),		\
-			    &mcux_lpi2c_init, &mcux_lpi2c_data_##n,	\
-			    &mcux_lpi2c_config_##n, POST_KERNEL,	\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &mcux_lpi2c_driver_api);			\
+	DEVICE_DEFINE(mcux_lpi2c_##n, DT_INST_LABEL(n),			\
+		      &mcux_lpi2c_init, device_pm_control_nop,		\
+		      &mcux_lpi2c_data_##n,				\
+		      &mcux_lpi2c_config_##n, POST_KERNEL,		\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &mcux_lpi2c_driver_api);				\
 									\
 	static void mcux_lpi2c_config_func_##n(struct device *dev)	\
 	{								\

--- a/drivers/i2c/i2c_nios2.c
+++ b/drivers/i2c/i2c_nios2.c
@@ -166,8 +166,8 @@ static struct i2c_nios2_config i2c_nios2_cfg = {
 	},
 };
 
-DEVICE_AND_API_INIT(i2c_nios2_0, DT_INST_LABEL(0), &i2c_nios2_init,
-		    NULL, &i2c_nios2_cfg,
+DEVICE_DEFINE(i2c_nios2_0, DT_INST_LABEL(0), &i2c_nios2_init,
+		    device_pm_control_nop, NULL, &i2c_nios2_cfg,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &i2c_nios2_driver_api);
 

--- a/drivers/i2c/i2c_rv32m1_lpi2c.c
+++ b/drivers/i2c/i2c_rv32m1_lpi2c.c
@@ -280,13 +280,14 @@ static const struct i2c_driver_api rv32m1_lpi2c_driver_api = {
 		.completion_sync = Z_SEM_INITIALIZER(                          \
 			rv32m1_lpi2c_##id##_data.completion_sync, 0, 1),       \
 	};                                                                     \
-	DEVICE_AND_API_INIT(rv32m1_lpi2c_##id,                                 \
-			    DT_INST_LABEL(id),                                 \
-			    &rv32m1_lpi2c_init,                                \
-			    &rv32m1_lpi2c_##id##_data,                         \
-			    &rv32m1_lpi2c_##id##_config,                       \
-			    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,             \
-			    &rv32m1_lpi2c_driver_api);	                       \
+	DEVICE_DEFINE(rv32m1_lpi2c_##id,				       \
+		      DT_INST_LABEL(id),				       \
+		      &rv32m1_lpi2c_init,				       \
+		      device_pm_control_nop,				       \
+		      &rv32m1_lpi2c_##id##_data,			       \
+		      &rv32m1_lpi2c_##id##_config,			       \
+		      POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,		       \
+		      &rv32m1_lpi2c_driver_api);			       \
 	static void rv32m1_lpi2c_irq_config_func_##id(struct device *dev)      \
 	{                                                                      \
 		IRQ_CONNECT(DT_INST_IRQN(id),                                  \

--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -795,13 +795,14 @@ static const struct i2c_sam0_dev_config i2c_sam0_dev_config_##n = {	\
 	static void i2c_sam0_irq_config_##n(struct device *dev);	\
 	I2C_SAM0_CONFIG(n);						\
 	static struct i2c_sam0_dev_data i2c_sam0_dev_data_##n;		\
-	DEVICE_AND_API_INIT(i2c_sam0_##n,				\
-			    DT_INST_LABEL(n),				\
-			    &i2c_sam0_initialize,			\
-			    &i2c_sam0_dev_data_##n,			\
-			    &i2c_sam0_dev_config_##n, POST_KERNEL,	\
-			    CONFIG_I2C_INIT_PRIORITY,			\
-			    &i2c_sam0_driver_api);			\
+	DEVICE_DEFINE(i2c_sam0_##n,					\
+		      DT_INST_LABEL(n),					\
+		      &i2c_sam0_initialize,				\
+		      device_pm_control_nop,				\
+		      &i2c_sam0_dev_data_##n,				\
+		      &i2c_sam0_dev_config_##n, POST_KERNEL,		\
+		      CONFIG_I2C_INIT_PRIORITY,				\
+		      &i2c_sam0_driver_api);				\
 	I2C_SAM0_IRQ_HANDLER(n)
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_SAM0_DEVICE)

--- a/drivers/i2c/i2c_sam_twi.c
+++ b/drivers/i2c/i2c_sam_twi.c
@@ -363,10 +363,10 @@ static const struct i2c_driver_api i2c_sam_twi_driver_api = {
 									\
 	static struct i2c_sam_twi_dev_data i2c##n##_sam_data;		\
 									\
-	DEVICE_AND_API_INIT(i2c##n##_sam, DT_INST_LABEL(n),		\
-			    &i2c_sam_twi_initialize,			\
-			    &i2c##n##_sam_data, &i2c##n##_sam_config,	\
-			    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,	\
-			    &i2c_sam_twi_driver_api);
+	DEVICE_DEFINE(i2c##n##_sam, DT_INST_LABEL(n),			\
+		      &i2c_sam_twi_initialize, device_pm_control_nop,	\
+		      &i2c##n##_sam_data, &i2c##n##_sam_config,		\
+		      POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,		\
+		      &i2c_sam_twi_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_TWI_SAM_INIT)

--- a/drivers/i2c/i2c_sam_twihs.c
+++ b/drivers/i2c/i2c_sam_twihs.c
@@ -350,10 +350,10 @@ static const struct i2c_driver_api i2c_sam_twihs_driver_api = {
 									\
 	static struct i2c_sam_twihs_dev_data i2c##n##_sam_data;		\
 									\
-	DEVICE_AND_API_INIT(i2c##n##_sam, DT_INST_LABEL(n),		\
-			    &i2c_sam_twihs_initialize,			\
-			    &i2c##n##_sam_data, &i2c##n##_sam_config,	\
-			    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,	\
-			    &i2c_sam_twihs_driver_api);
+	DEVICE_DEFINE(i2c##n##_sam, DT_INST_LABEL(n),			\
+		      &i2c_sam_twihs_initialize, device_pm_control_nop,	\
+		      &i2c##n##_sam_data, &i2c##n##_sam_config,		\
+		      POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,		\
+		      &i2c_sam_twihs_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_TWIHS_SAM_INIT)

--- a/drivers/i2c/i2c_sbcon.c
+++ b/drivers/i2c/i2c_sbcon.c
@@ -116,10 +116,10 @@ static const struct i2c_sbcon_config i2c_sbcon_dev_cfg_##_num = {	\
 	.sbcon		= (void *)DT_INST_REG_ADDR(_num), \
 };									\
 									\
-DEVICE_AND_API_INIT(i2c_sbcon_##_num, DT_INST_LABEL(_num), \
-	    i2c_sbcon_init,						\
-	    &i2c_sbcon_dev_data_##_num,					\
-	    &i2c_sbcon_dev_cfg_##_num,					\
-	    PRE_KERNEL_2, CONFIG_I2C_INIT_PRIORITY, &api);
+DEVICE_DEFINE(i2c_sbcon_##_num, DT_INST_LABEL(_num),			\
+	      i2c_sbcon_init, device_pm_control_nop,			\
+	      &i2c_sbcon_dev_data_##_num,				\
+	      &i2c_sbcon_dev_cfg_##_num,				\
+	      PRE_KERNEL_2, CONFIG_I2C_INIT_PRIORITY, &api);
 
 DT_INST_FOREACH_STATUS_OKAY(DEFINE_I2C_SBCON)

--- a/drivers/i2c/i2c_sifive.c
+++ b/drivers/i2c/i2c_sifive.c
@@ -329,13 +329,14 @@ static struct i2c_driver_api i2c_sifive_api = {
 		.f_sys = DT_INST_PROP(n, input_frequency), \
 		.f_bus = DT_INST_PROP(n, clock_frequency), \
 	}; \
-	DEVICE_AND_API_INIT(i2c_##n, \
-			    DT_INST_LABEL(n), \
-			    i2c_sifive_init, \
-			    NULL, \
-			    &i2c_sifive_cfg_##n, \
-			    POST_KERNEL, \
-			    CONFIG_I2C_INIT_PRIORITY, \
-			    &i2c_sifive_api);
+	DEVICE_DEFINE(i2c_##n, \
+		      DT_INST_LABEL(n), \
+		      i2c_sifive_init, \
+		      device_pm_control_nop, \
+		      NULL, \
+		      &i2c_sifive_cfg_##n, \
+		      POST_KERNEL, \
+		      CONFIG_I2C_INIT_PRIORITY, \
+		      &i2c_sifive_api);
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_SIFIVE_INIT)

--- a/drivers/i2c/slave/eeprom_slave.c
+++ b/drivers/i2c/slave/eeprom_slave.c
@@ -220,13 +220,14 @@ static int i2c_eeprom_slave_init(struct device *dev)
 		.buffer = i2c_eeprom_slave_##inst##_buffer		\
 	};								\
 									\
-	DEVICE_AND_API_INIT(i2c_eeprom_slave_##inst,			\
-			    DT_INST_LABEL(inst),			\
-			    &i2c_eeprom_slave_init,			\
-			    &i2c_eeprom_slave_##inst##_dev_data,	\
-			    &i2c_eeprom_slave_##inst##_cfg,		\
-			    POST_KERNEL,				\
-			    CONFIG_I2C_SLAVE_INIT_PRIORITY,		\
-			    &api_funcs);
+	DEVICE_DEFINE(i2c_eeprom_slave_##inst,				\
+		      DT_INST_LABEL(inst),				\
+		      &i2c_eeprom_slave_init,				\
+		      device_pm_control_nop,				\
+		      &i2c_eeprom_slave_##inst##_dev_data,		\
+		      &i2c_eeprom_slave_##inst##_cfg,			\
+		      POST_KERNEL,					\
+		      CONFIG_I2C_SLAVE_INIT_PRIORITY,			\
+		      &api_funcs);
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_EEPROM_INIT)

--- a/drivers/i2s/i2s_cavs.c
+++ b/drivers/i2s/i2s_cavs.c
@@ -92,14 +92,15 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 	}
 
 #define I2S_DEVICE_AND_API_INIT(i2s_id)				\
-	DEVICE_AND_API_INIT(I2S_DEVICE_NAME(i2s_id),		\
-			CONFIG_I2S_CAVS_##i2s_id##_NAME,	\
-			i2s_cavs_initialize,			\
-			&I2S_DEVICE_DATA_NAME(i2s_id),		\
-			&I2S_DEVICE_CONFIG_NAME(i2s_id),	\
-			POST_KERNEL,				\
-			CONFIG_I2S_INIT_PRIORITY,		\
-			&i2s_cavs_driver_api)
+	DEVICE_DEFINE(I2S_DEVICE_NAME(i2s_id),			\
+		      CONFIG_I2S_CAVS_##i2s_id##_NAME,		\
+		      i2s_cavs_initialize,			\
+		      device_pm_control_nop,			\
+		      &I2S_DEVICE_DATA_NAME(i2s_id),		\
+		      &I2S_DEVICE_CONFIG_NAME(i2s_id),		\
+		      POST_KERNEL,				\
+		      CONFIG_I2S_INIT_PRIORITY,			\
+		      &i2s_cavs_driver_api)
 
 /* length of the buffer queue */
 #define I2S_CAVS_BUF_Q_LEN			2

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -905,11 +905,12 @@ static struct i2s_stm32_data i2s_stm32_data_##index = {			\
 	UTIL_AND(DT_DMAS_HAS_NAME(DT_NODELABEL(i2s##index), tx),	\
 		I2S_DMA_CHANNEL_INIT(index, tx, TX, MEMORY, PERIPHERAL)),\
 };									\
-DEVICE_AND_API_INIT(i2s_stm32_##index,					\
-		    DT_LABEL(DT_NODELABEL(i2s##index)),			\
-		    &i2s_stm32_initialize, &i2s_stm32_data_##index,	\
-		    &i2s_stm32_config_##index, POST_KERNEL,		\
-		    CONFIG_I2S_INIT_PRIORITY, &i2s_stm32_driver_api);	\
+DEVICE_DEFINE(i2s_stm32_##index,					\
+	      DT_LABEL(DT_NODELABEL(i2s##index)),			\
+	      &i2s_stm32_initialize, device_pm_control_nop,		\
+	      &i2s_stm32_data_##index,					\
+	      &i2s_stm32_config_##index, POST_KERNEL,			\
+	      CONFIG_I2S_INIT_PRIORITY, &i2s_stm32_driver_api);		\
 									\
 static void i2s_stm32_irq_config_func_##index(struct device *dev)	\
 {									\

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -1019,6 +1019,7 @@ static struct i2s_sam_dev_data i2s0_sam_data = {
 	},
 };
 
-DEVICE_AND_API_INIT(i2s0_sam, DT_INST_LABEL(0), &i2s_sam_initialize,
-		    &i2s0_sam_data, &i2s0_sam_config, POST_KERNEL,
+DEVICE_DEFINE(i2s0_sam, DT_INST_LABEL(0), &i2s_sam_initialize,
+		    device_pm_control_nop, &i2s0_sam_data, &i2s0_sam_config,
+		    POST_KERNEL,
 		    CONFIG_I2S_INIT_PRIORITY, &i2s_sam_driver_api);

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -1148,8 +1148,9 @@ static struct ieee802154_radio_api cc2520_radio_api = {
 };
 
 #if defined(CONFIG_IEEE802154_RAW_MODE)
-DEVICE_AND_API_INIT(cc2520, CONFIG_IEEE802154_CC2520_DRV_NAME,
-		    cc2520_init, &cc2520_context_data, NULL,
+DEVICE_DEFINE(cc2520, CONFIG_IEEE802154_CC2520_DRV_NAME,
+		    cc2520_init, device_pm_control_nop, &cc2520_context_data,
+		    NULL,
 		    POST_KERNEL, CONFIG_IEEE802154_CC2520_INIT_PRIO,
 		    &cc2520_radio_api);
 #else
@@ -1483,8 +1484,9 @@ struct crypto_driver_api cc2520_crypto_api = {
 	.crypto_async_callback_set	= NULL
 };
 
-DEVICE_AND_API_INIT(cc2520_crypto, CONFIG_IEEE802154_CC2520_CRYPTO_DRV_NAME,
-		    cc2520_crypto_init, &cc2520_context_data, NULL,
+DEVICE_DEFINE(cc2520_crypto, CONFIG_IEEE802154_CC2520_CRYPTO_DRV_NAME,
+		    cc2520_crypto_init, device_pm_control_nop,
+		    &cc2520_context_data, NULL,
 		    POST_KERNEL, CONFIG_IEEE802154_CC2520_CRYPTO_INIT_PRIO,
 		    &cc2520_crypto_api);
 

--- a/drivers/ieee802154/ieee802154_dw1000.c
+++ b/drivers/ieee802154/ieee802154_dw1000.c
@@ -1663,8 +1663,9 @@ static struct ieee802154_radio_api dwt_radio_api = {
 #define DWT_PSDU_LENGTH		(127 - DWT_FCS_LENGTH)
 
 #if defined(CONFIG_IEEE802154_RAW_MODE)
-DEVICE_AND_API_INIT(dw1000, DT_INST_LABEL(0),
-		    dw1000_init, &dwt_0_context, &dw1000_0_config,
+DEVICE_DEFINE(dw1000, DT_INST_LABEL(0),
+		    dw1000_init, device_pm_control_nop, &dwt_0_context,
+		    &dw1000_0_config,
 		    POST_KERNEL, CONFIG_IEEE802154_DW1000_INIT_PRIO,
 		    &dwt_radio_api);
 #else

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -1475,8 +1475,9 @@ static struct ieee802154_radio_api mcr20a_radio_api = {
 };
 
 #if defined(CONFIG_IEEE802154_RAW_MODE)
-DEVICE_AND_API_INIT(mcr20a, CONFIG_IEEE802154_MCR20A_DRV_NAME,
-		    mcr20a_init, &mcr20a_context_data, NULL,
+DEVICE_DEFINE(mcr20a, CONFIG_IEEE802154_MCR20A_DRV_NAME,
+		    mcr20a_init, device_pm_control_nop, &mcr20a_context_data,
+		    NULL,
 		    POST_KERNEL, CONFIG_IEEE802154_MCR20A_INIT_PRIO,
 		    &mcr20a_radio_api);
 #else

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -708,8 +708,9 @@ NET_DEVICE_INIT(nrf5_154_radio, CONFIG_IEEE802154_NRF5_DRV_NAME,
 		&nrf5_radio_api, L2,
 		L2_CTX_TYPE, MTU);
 #else
-DEVICE_AND_API_INIT(nrf5_154_radio, CONFIG_IEEE802154_NRF5_DRV_NAME,
-		    nrf5_init, &nrf5_data, &nrf5_radio_cfg,
+DEVICE_DEFINE(nrf5_154_radio, CONFIG_IEEE802154_NRF5_DRV_NAME,
+		    nrf5_init, device_pm_control_nop, &nrf5_data,
+		    &nrf5_radio_cfg,
 		    POST_KERNEL, CONFIG_IEEE802154_NRF5_INIT_PRIO,
 		    &nrf5_radio_api);
 #endif

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -894,10 +894,11 @@ static struct ieee802154_radio_api rf2xx_radio_api = {
 	}
 
 #define IEEE802154_RF2XX_RAW_DEVICE_INIT(n)	   \
-	DEVICE_AND_API_INIT(			   \
+	DEVICE_DEFINE(				   \
 		rf2xx_##n,			   \
 		DT_INST_LABEL(n),		   \
 		&rf2xx_init,			   \
+		device_pm_control_nop,		   \
 		&rf2xx_ctx_data_##n,		   \
 		&rf2xx_ctx_config_##n,		   \
 		POST_KERNEL,			   \

--- a/drivers/interrupt_controller/intc_cavs.c
+++ b/drivers/interrupt_controller/intc_cavs.c
@@ -139,11 +139,12 @@ static const struct irq_next_level_api cavs_apis = {
 	static struct cavs_ictl_runtime cavs_##n##_runtime = {		\
 		.base_addr = DT_INST_REG_ADDR(n),			\
 	};								\
-	DEVICE_AND_API_INIT(cavs_ictl_##n, DT_INST_LABEL(n),		\
-			    cavs_ictl_##n##_initialize,			\
-			    &cavs_##n##_runtime, &cavs_config_##n,	\
-			    PRE_KERNEL_1,				\
-			    CONFIG_CAVS_ICTL_INIT_PRIORITY, &cavs_apis);\
+	DEVICE_DEFINE(cavs_ictl_##n, DT_INST_LABEL(n),			\
+		      cavs_ictl_##n##_initialize,			\
+		      device_pm_control_nop,				\
+		      &cavs_##n##_runtime, &cavs_config_##n,		\
+		      PRE_KERNEL_1,					\
+		      CONFIG_CAVS_ICTL_INIT_PRIORITY, &cavs_apis);	\
 									\
 	static void cavs_config_##n##_irq(struct device *port)		\
 	{								\

--- a/drivers/interrupt_controller/intc_dw.c
+++ b/drivers/interrupt_controller/intc_dw.c
@@ -141,8 +141,9 @@ static const struct irq_next_level_api dw_ictl_apis = {
 	.intr_get_line_state = dw_ictl_intr_get_line_state,
 };
 
-DEVICE_AND_API_INIT(dw_ictl, DT_INST_LABEL(0),
-		    dw_ictl_initialize, NULL, &dw_config,
+DEVICE_DEFINE(dw_ictl, DT_INST_LABEL(0),
+		    dw_ictl_initialize, device_pm_control_nop, NULL,
+		    &dw_config,
 		    PRE_KERNEL_1, CONFIG_DW_ICTL_INIT_PRIORITY, &dw_ictl_apis);
 
 static void dw_ictl_config_irq(struct device *port)

--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -395,9 +395,9 @@ static int stm32_exti_init(struct device *dev)
 }
 
 static struct stm32_exti_data exti_data;
-DEVICE_INIT(exti_stm32, STM32_EXTI_NAME, stm32_exti_init,
-	    &exti_data, NULL,
-	    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+DEVICE_DEFINE(exti_stm32, STM32_EXTI_NAME, stm32_exti_init,
+	    device_pm_control_nop, &exti_data, NULL,
+	    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, api);
 
 /**
  * @brief set & unset for the interrupt callbacks

--- a/drivers/interrupt_controller/intc_rv32m1_intmux.c
+++ b/drivers/interrupt_controller/intc_rv32m1_intmux.c
@@ -219,7 +219,7 @@ static int rv32m1_intmux_init(struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(intmux, DT_INST_LABEL(0),
-		    &rv32m1_intmux_init, NULL,
+DEVICE_DEFINE(intmux, DT_INST_LABEL(0),
+		    &rv32m1_intmux_init, device_pm_control_nop, NULL,
 		    &rv32m1_intmux_cfg, PRE_KERNEL_1,
 		    CONFIG_RV32M1_INTMUX_INIT_PRIORITY, &rv32m1_intmux_apis);

--- a/drivers/interrupt_controller/intc_sam0_eic.c
+++ b/drivers/interrupt_controller/intc_sam0_eic.c
@@ -414,6 +414,6 @@ static int sam0_eic_init(struct device *dev)
 }
 
 static struct sam0_eic_data eic_data;
-DEVICE_INIT(sam0_eic, DT_INST_LABEL(0), sam0_eic_init,
-	    &eic_data, NULL,
-	    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+DEVICE_DEFINE(sam0_eic, DT_INST_LABEL(0), sam0_eic_init,
+	    device_pm_control_nop, &eic_data, NULL,
+	    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, api);

--- a/drivers/interrupt_controller/intc_shared_irq.c
+++ b/drivers/interrupt_controller/intc_shared_irq.c
@@ -134,8 +134,9 @@ const struct shared_irq_config shared_irq_config_0 = {
 
 struct shared_irq_runtime shared_irq_0_runtime;
 
-DEVICE_AND_API_INIT(shared_irq_0, DT_INST_LABEL(0),
-		shared_irq_initialize, &shared_irq_0_runtime,
+DEVICE_DEFINE(shared_irq_0, DT_INST_LABEL(0),
+		shared_irq_initialize, device_pm_control_nop,
+		&shared_irq_0_runtime,
 		&shared_irq_config_0, POST_KERNEL,
 		CONFIG_SHARED_IRQ_INIT_PRIORITY, &api_funcs);
 
@@ -160,8 +161,9 @@ const struct shared_irq_config shared_irq_config_1 = {
 
 struct shared_irq_runtime shared_irq_1_runtime;
 
-DEVICE_AND_API_INIT(shared_irq_1, DT_INST_LABEL(1),
-		shared_irq_initialize, &shared_irq_1_runtime,
+DEVICE_DEFINE(shared_irq_1, DT_INST_LABEL(1),
+		shared_irq_initialize, device_pm_control_nop,
+		&shared_irq_1_runtime,
 		&shared_irq_config_1, POST_KERNEL,
 		CONFIG_SHARED_IRQ_INIT_PRIORITY, &api_funcs);
 

--- a/drivers/ipm/ipm_cavs_idc.c
+++ b/drivers/ipm/ipm_cavs_idc.c
@@ -220,9 +220,10 @@ static const struct ipm_driver_api cavs_idc_driver_api = {
 	.set_enabled = cavs_idc_set_enabled,
 };
 
-DEVICE_AND_API_INIT(IPM_CAVS_IDC_DEV_NAME,
+DEVICE_DEFINE(IPM_CAVS_IDC_DEV_NAME,
 		    DT_INST_LABEL(0),
-		    &cavs_idc_init, &cavs_idc_device_data, NULL,
+		    &cavs_idc_init, device_pm_control_nop,
+		    &cavs_idc_device_data, NULL,
 		    PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &cavs_idc_driver_api);
 

--- a/drivers/ipm/ipm_imx.c
+++ b/drivers/ipm/ipm_imx.c
@@ -215,9 +215,9 @@ static const struct imx_mu_config imx_mu_b_config = {
 
 static struct imx_mu_data imx_mu_b_data;
 
-DEVICE_AND_API_INIT(mu_b, DT_INST_LABEL(0),
+DEVICE_DEFINE(mu_b, DT_INST_LABEL(0),
 		    &imx_mu_init,
-		    &imx_mu_b_data, &imx_mu_b_config,
+		    device_pm_control_nop, &imx_mu_b_data, &imx_mu_b_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &imx_mu_driver_api);
 

--- a/drivers/ipm/ipm_mcux.c
+++ b/drivers/ipm/ipm_mcux.c
@@ -162,9 +162,10 @@ static const struct mcux_mailbox_config mcux_mailbox_0_config = {
 
 static struct mcux_mailbox_data mcux_mailbox_0_data;
 
-DEVICE_AND_API_INIT(mailbox_0, DT_INST_LABEL(0),
+DEVICE_DEFINE(mailbox_0, DT_INST_LABEL(0),
 		    &mcux_mailbox_init,
-		    &mcux_mailbox_0_data, &mcux_mailbox_0_config,
+		    device_pm_control_nop, &mcux_mailbox_0_data,
+		    &mcux_mailbox_0_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &mcux_mailbox_driver_api);
 

--- a/drivers/ipm/ipm_mhu.c
+++ b/drivers/ipm/ipm_mhu.c
@@ -186,10 +186,10 @@ static struct ipm_mhu_data ipm_mhu_data_0 = {
 	.callback_ctx = NULL,
 };
 
-DEVICE_AND_API_INIT(mhu_0,
+DEVICE_DEFINE(mhu_0,
 			DT_INST_LABEL(0),
 			&ipm_mhu_init,
-			&ipm_mhu_data_0,
+			device_pm_control_nop, &ipm_mhu_data_0,
 			&ipm_mhu_cfg_0, PRE_KERNEL_1,
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 			&ipm_mhu_driver_api);
@@ -217,10 +217,10 @@ static struct ipm_mhu_data ipm_mhu_data_1 = {
 	.callback_ctx = NULL,
 };
 
-DEVICE_AND_API_INIT(mhu_1,
+DEVICE_DEFINE(mhu_1,
 			DT_INST_LABEL(1),
 			&ipm_mhu_init,
-			&ipm_mhu_data_1,
+			device_pm_control_nop, &ipm_mhu_data_1,
 			&ipm_mhu_cfg_1, PRE_KERNEL_1,
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 			&ipm_mhu_driver_api);

--- a/drivers/ipm/ipm_nrfx_ipc.c
+++ b/drivers/ipm/ipm_nrfx_ipc.c
@@ -107,8 +107,8 @@ static const struct ipm_driver_api ipm_nrf_driver_api = {
 	.set_enabled = ipm_nrf_set_enabled
 };
 
-DEVICE_AND_API_INIT(ipm_nrf, DT_INST_LABEL(0),
-		    ipm_nrf_init, NULL, NULL,
+DEVICE_DEFINE(ipm_nrf, DT_INST_LABEL(0),
+		    ipm_nrf_init, device_pm_control_nop, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &ipm_nrf_driver_api);
 

--- a/drivers/ipm/ipm_nrfx_ipc.c
+++ b/drivers/ipm/ipm_nrfx_ipc.c
@@ -223,10 +223,10 @@ static const struct ipm_driver_api vipm_nrf_##_idx##_driver_api = {	\
 	.set_enabled = vipm_nrf_##_idx##_set_enabled			\
 };									\
 									\
-DEVICE_AND_API_INIT(vipm_nrf_##_idx, "IPM_"#_idx,			\
-		    vipm_nrf_init, NULL, NULL,				\
-		    PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
-		    &vipm_nrf_##_idx##_driver_api)
+DEVICE_DEFINE(vipm_nrf_##_idx, "IPM_"#_idx,				\
+	      vipm_nrf_init, device_pm_control_nop, NULL, NULL,		\
+	      PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
+	      &vipm_nrf_##_idx##_driver_api)
 
 #define VIPM_DEVICE(_idx, _)						\
 	IF_ENABLED(CONFIG_IPM_MSG_CH_##_idx##_ENABLE, (VIPM_DEVICE_1(_idx);))

--- a/drivers/ipm/ipm_stm32_ipcc.c
+++ b/drivers/ipm/ipm_stm32_ipcc.c
@@ -294,9 +294,10 @@ static const struct stm32_ipcc_mailbox_config stm32_ipcc_mailbox_0_config = {
 
 };
 
-DEVICE_AND_API_INIT(mailbox_0, DT_INST_LABEL(0),
+DEVICE_DEFINE(mailbox_0, DT_INST_LABEL(0),
 		    &stm32_ipcc_mailbox_init,
-		    &stm32_IPCC_data, &stm32_ipcc_mailbox_0_config,
+		    device_pm_control_nop, &stm32_IPCC_data,
+		    &stm32_ipcc_mailbox_0_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &stm32_ipcc_mailbox_driver_api);
 

--- a/drivers/kscan/kscan_ft5336.c
+++ b/drivers/kscan/kscan_ft5336.c
@@ -227,7 +227,7 @@ static const struct ft5336_config ft5336_config = {
 
 static struct ft5336_data ft5336_data;
 
-DEVICE_AND_API_INIT(ft5336, DT_INST_LABEL(0), ft5336_init,
-		    &ft5336_data, &ft5336_config,
+DEVICE_DEFINE(ft5336, DT_INST_LABEL(0), ft5336_init,
+		    device_pm_control_nop, &ft5336_data, &ft5336_config,
 		    POST_KERNEL, CONFIG_KSCAN_INIT_PRIORITY,
 		    &ft5336_driver_api);

--- a/drivers/kscan/kscan_mchp_xec.c
+++ b/drivers/kscan/kscan_mchp_xec.c
@@ -368,9 +368,9 @@ static const struct kscan_driver_api kscan_xec_driver_api = {
 
 static int kscan_xec_init(struct device *dev);
 
-DEVICE_AND_API_INIT(kscan_xec, DT_INST_LABEL(0),
+DEVICE_DEFINE(kscan_xec, DT_INST_LABEL(0),
 		    &kscan_xec_init,
-		    NULL, NULL,
+		    device_pm_control_nop, NULL, NULL,
 		    POST_KERNEL, CONFIG_KSCAN_INIT_PRIORITY,
 		    &kscan_xec_driver_api);
 

--- a/drivers/kscan/kscan_sdl.c
+++ b/drivers/kscan/kscan_sdl.c
@@ -102,7 +102,7 @@ static const struct kscan_driver_api sdl_driver_api = {
 
 static struct sdl_data sdl_data;
 
-DEVICE_AND_API_INIT(sdl, CONFIG_SDL_POINTER_KSCAN_DEV_NAME, sdl_init,
-		    &sdl_data, NULL,
+DEVICE_DEFINE(sdl, CONFIG_SDL_POINTER_KSCAN_DEV_NAME, sdl_init,
+		    device_pm_control_nop, &sdl_data, NULL,
 		    POST_KERNEL, CONFIG_KSCAN_INIT_PRIORITY,
 		    &sdl_driver_api);

--- a/drivers/led/ht16k33.c
+++ b/drivers/led/ht16k33.c
@@ -470,10 +470,11 @@ static const struct led_driver_api ht16k33_leds_api = {
 									\
 	static struct ht16k33_data ht16k33_##id##_data;			\
 									\
-	DEVICE_AND_API_INIT(ht16k33_##id, DT_INST_LABEL(id),		\
-			    &ht16k33_init, &ht16k33_##id##_data,	\
-			    &ht16k33_##id##_cfg, POST_KERNEL,		\
-			    CONFIG_LED_INIT_PRIORITY, &ht16k33_leds_api)
+	DEVICE_DEFINE(ht16k33_##id, DT_INST_LABEL(id),			\
+		      &ht16k33_init, device_pm_control_nop,		\
+		      &ht16k33_##id##_data,				\
+		      &ht16k33_##id##_cfg, POST_KERNEL,			\
+		      CONFIG_LED_INIT_PRIORITY, &ht16k33_leds_api)
 
 #ifdef CONFIG_HT16K33_KEYSCAN
 #define HT16K33_DEVICE_WITH_IRQ(id)					\
@@ -490,10 +491,11 @@ static const struct led_driver_api ht16k33_leds_api = {
 									\
 	static struct ht16k33_data ht16k33_##id##_data;			\
 									\
-	DEVICE_AND_API_INIT(ht16k33_##id, DT_INST_LABEL(id),		\
-			    &ht16k33_init, &ht16k33_##id##_data,	\
-			    &ht16k33_##id##_cfg, POST_KERNEL,		\
-			    CONFIG_LED_INIT_PRIORITY, &ht16k33_leds_api)
+	DEVICE_DEFINE(ht16k33_##id, DT_INST_LABEL(id),			\
+		      &ht16k33_init, device_pm_control_nop,		\
+		      &ht16k33_##id##_data,				\
+		      &ht16k33_##id##_cfg, POST_KERNEL,			\
+		      CONFIG_LED_INIT_PRIORITY, &ht16k33_leds_api)
 #else /* ! CONFIG_HT16K33_KEYSCAN */
 #define HT16K33_DEVICE_WITH_IRQ(id) HT16K33_DEVICE(id)
 #endif /* ! CONFIG_HT16K33_KEYSCAN */

--- a/drivers/led/lp3943.c
+++ b/drivers/led/lp3943.c
@@ -279,7 +279,7 @@ static const struct led_driver_api lp3943_led_api = {
 	.off = lp3943_led_off,
 };
 
-DEVICE_AND_API_INIT(lp3943_led, DT_INST_LABEL(0),
-		    &lp3943_led_init, &lp3943_led_data,
+DEVICE_DEFINE(lp3943_led, DT_INST_LABEL(0),
+		    &lp3943_led_init, device_pm_control_nop, &lp3943_led_data,
 		    NULL, POST_KERNEL, CONFIG_LED_INIT_PRIORITY,
 		    &lp3943_led_api);

--- a/drivers/led/lp5562.c
+++ b/drivers/led/lp5562.c
@@ -952,7 +952,7 @@ static const struct led_driver_api lp5562_led_api = {
 	.off = lp5562_led_off,
 };
 
-DEVICE_AND_API_INIT(lp5562_led, DT_INST_LABEL(0),
-		&lp5562_led_init, &lp5562_led_data,
+DEVICE_DEFINE(lp5562_led, DT_INST_LABEL(0),
+		&lp5562_led_init, device_pm_control_nop, &lp5562_led_data,
 		NULL, POST_KERNEL, CONFIG_LED_INIT_PRIORITY,
 		&lp5562_led_api);

--- a/drivers/led/pca9633.c
+++ b/drivers/led/pca9633.c
@@ -203,7 +203,8 @@ static const struct led_driver_api pca9633_led_api = {
 	.off = pca9633_led_off,
 };
 
-DEVICE_AND_API_INIT(pca9633_led, DT_INST_LABEL(0),
-		    &pca9633_led_init, &pca9633_led_data,
+DEVICE_DEFINE(pca9633_led, DT_INST_LABEL(0),
+		    &pca9633_led_init, device_pm_control_nop,
+		    &pca9633_led_data,
 		    NULL, POST_KERNEL, CONFIG_LED_INIT_PRIORITY,
 		    &pca9633_led_api);

--- a/drivers/led_strip/apa102.c
+++ b/drivers/led_strip/apa102.c
@@ -103,6 +103,6 @@ static const struct led_strip_driver_api apa102_api = {
 	.update_channels = apa102_update_channels,
 };
 
-DEVICE_AND_API_INIT(apa102_0, DT_INST_LABEL(0), apa102_init,
-		    &apa102_data_0, NULL, POST_KERNEL,
+DEVICE_DEFINE(apa102_0, DT_INST_LABEL(0), apa102_init,
+		    device_pm_control_nop, &apa102_data_0, NULL, POST_KERNEL,
 		    CONFIG_LED_STRIP_INIT_PRIORITY, &apa102_api);

--- a/drivers/led_strip/lpd880x.c
+++ b/drivers/led_strip/lpd880x.c
@@ -153,7 +153,8 @@ static const struct led_strip_driver_api lpd880x_strip_api = {
 	.update_channels = lpd880x_strip_update_channels,
 };
 
-DEVICE_AND_API_INIT(lpd880x_strip, DT_INST_LABEL(0),
-		    lpd880x_strip_init, &lpd880x_strip_data,
+DEVICE_DEFINE(lpd880x_strip, DT_INST_LABEL(0),
+		    lpd880x_strip_init, device_pm_control_nop,
+		    &lpd880x_strip_data,
 		    NULL, POST_KERNEL, CONFIG_LED_STRIP_INIT_PRIORITY,
 		    &lpd880x_strip_api);

--- a/drivers/led_strip/ws2812_gpio.c
+++ b/drivers/led_strip/ws2812_gpio.c
@@ -233,11 +233,12 @@ static const struct led_strip_driver_api ws2812_gpio_api = {
 		.has_white = WS2812_GPIO_HAS_WHITE(idx),		\
 	};								\
 									\
-	DEVICE_AND_API_INIT(ws2812_gpio_##idx, WS2812_GPIO_LABEL(idx),	\
-			    ws2812_gpio_##idx##_init,			\
-			    &ws2812_gpio_##idx##_data,			\
-			    &ws2812_gpio_##idx##_cfg, POST_KERNEL,	\
-			    CONFIG_LED_STRIP_INIT_PRIORITY,		\
-			    &ws2812_gpio_api);
+	DEVICE_DEFINE(ws2812_gpio_##idx, WS2812_GPIO_LABEL(idx),	\
+		      ws2812_gpio_##idx##_init,				\
+		      device_pm_control_nop,				\
+		      &ws2812_gpio_##idx##_data,			\
+		      &ws2812_gpio_##idx##_cfg, POST_KERNEL,		\
+		      CONFIG_LED_STRIP_INIT_PRIORITY,			\
+		      &ws2812_gpio_api);
 
 DT_INST_FOREACH_STATUS_OKAY(WS2812_GPIO_DEVICE)

--- a/drivers/led_strip/ws2812_spi.c
+++ b/drivers/led_strip/ws2812_spi.c
@@ -221,13 +221,14 @@ static const struct led_strip_driver_api ws2812_spi_api = {
 		return 0;						\
 	}								\
 									\
-	DEVICE_AND_API_INIT(ws2812_spi_##idx,				\
-			    WS2812_SPI_LABEL(idx),			\
-			    ws2812_spi_##idx##_init,			\
-			    &ws2812_spi_##idx##_data,			\
-			    &ws2812_spi_##idx##_cfg,			\
-			    POST_KERNEL,				\
-			    CONFIG_LED_STRIP_INIT_PRIORITY,		\
-			    &ws2812_spi_api);
+	DEVICE_DEFINE(ws2812_spi_##idx,					\
+		      WS2812_SPI_LABEL(idx),				\
+		      ws2812_spi_##idx##_init,				\
+		      device_pm_control_nop,				\
+		      &ws2812_spi_##idx##_data,				\
+		      &ws2812_spi_##idx##_cfg,				\
+		      POST_KERNEL,					\
+		      CONFIG_LED_STRIP_INIT_PRIORITY,			\
+		      &ws2812_spi_api);
 
 DT_INST_FOREACH_STATUS_OKAY(WS2812_SPI_DEVICE)

--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -549,7 +549,7 @@ static const struct lora_driver_api sx1276_lora_api = {
 	.test_cw = sx1276_lora_test_cw,
 };
 
-DEVICE_AND_API_INIT(sx1276_lora, DT_INST_LABEL(0),
-		    &sx1276_lora_init, NULL,
+DEVICE_DEFINE(sx1276_lora, DT_INST_LABEL(0),
+		    &sx1276_lora_init, device_pm_control_nop, NULL,
 		    NULL, POST_KERNEL, CONFIG_LORA_INIT_PRIORITY,
 		    &sx1276_lora_api);

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -627,5 +627,6 @@ static int gsm_init(struct device *device)
 	return 0;
 }
 
-DEVICE_INIT(gsm_ppp, "modem_gsm", gsm_init, &gsm, NULL, POST_KERNEL,
-	    CONFIG_MODEM_GSM_INIT_PRIORITY);
+DEVICE_DEFINE(gsm_ppp, "modem_gsm", gsm_init, device_pm_control_nop, &gsm,
+	      NULL, POST_KERNEL,
+	      CONFIG_MODEM_GSM_INIT_PRIORITY, api);

--- a/drivers/neural_net/intel_gna.c
+++ b/drivers/neural_net/intel_gna.c
@@ -519,7 +519,8 @@ static struct intel_gna_data intel_gna_driver_data = {
 	.regs = (volatile struct intel_gna_regs *)INTEL_GNA_BASE_ADDR,
 };
 
-DEVICE_AND_API_INIT(gna, CONFIG_INTEL_GNA_NAME, intel_gna_initialize,
-		    (void *)&intel_gna_driver_data, &intel_gna_config,
+DEVICE_DEFINE(gna, CONFIG_INTEL_GNA_NAME, intel_gna_initialize,
+		    device_pm_control_nop, (void *)&intel_gna_driver_data,
+		    &intel_gna_config,
 		    POST_KERNEL, CONFIG_INTEL_GNA_INIT_PRIORITY,
 		    &gna_driver_api);

--- a/drivers/peci/peci_mchp_xec.c
+++ b/drivers/peci/peci_mchp_xec.c
@@ -355,8 +355,8 @@ static int peci_xec_init(struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(peci_xec, DT_INST_LABEL(0),
+DEVICE_DEFINE(peci_xec, DT_INST_LABEL(0),
 		    &peci_xec_init,
-		    NULL, NULL,
+		    device_pm_control_nop, NULL, NULL,
 		    POST_KERNEL, CONFIG_PECI_INIT_PRIORITY,
 		    &peci_xec_driver_api);

--- a/drivers/pinmux/pinmux_cc13xx_cc26xx.c
+++ b/drivers/pinmux/pinmux_cc13xx_cc26xx.c
@@ -83,7 +83,8 @@ static const struct pinmux_driver_api pinmux_cc13xx_cc26xx_driver_api = {
 	.input = pinmux_cc13xx_cc26xx_input,
 };
 
-DEVICE_AND_API_INIT(pinmux_cc13xx_cc26xx, CONFIG_PINMUX_NAME,
-		    &pinmux_cc13xx_cc26xx_init, NULL, NULL, PRE_KERNEL_1,
+DEVICE_DEFINE(pinmux_cc13xx_cc26xx, CONFIG_PINMUX_NAME,
+		    &pinmux_cc13xx_cc26xx_init, device_pm_control_nop, NULL,
+		    NULL, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_cc13xx_cc26xx_driver_api);

--- a/drivers/pinmux/pinmux_esp32.c
+++ b/drivers/pinmux/pinmux_esp32.c
@@ -180,7 +180,7 @@ static int pinmux_initialize(struct device *device)
 /* Initialize using PRE_KERNEL_1 priority so that GPIO can use the pin
  * mux driver.
  */
-DEVICE_AND_API_INIT(pmux_dev, CONFIG_PINMUX_NAME,
-		    &pinmux_initialize, NULL, NULL,
+DEVICE_DEFINE(pmux_dev, CONFIG_PINMUX_NAME,
+		    &pinmux_initialize, device_pm_control_nop, NULL, NULL,
 		    PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &api_funcs);

--- a/drivers/pinmux/pinmux_hsdk.c
+++ b/drivers/pinmux/pinmux_hsdk.c
@@ -64,7 +64,7 @@ static const struct pinmux_driver_api pinmux_hsdk_driver_api = {
 	.input = pinmux_hsdk_input,
 };
 
-DEVICE_AND_API_INIT(pinmux_hsdk, CONFIG_PINMUX_NAME,
-			&pinmux_hsdk_init, NULL, NULL,
+DEVICE_DEFINE(pinmux_hsdk, CONFIG_PINMUX_NAME,
+			&pinmux_hsdk_init, device_pm_control_nop, NULL, NULL,
 			PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 			&pinmux_hsdk_driver_api);

--- a/drivers/pinmux/pinmux_intel_s1000.c
+++ b/drivers/pinmux/pinmux_intel_s1000.c
@@ -94,5 +94,6 @@ static int pinmux_init(struct device *device)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(pinmux, CONFIG_PINMUX_NAME, &pinmux_init, NULL, NULL,
+DEVICE_DEFINE(pinmux, CONFIG_PINMUX_NAME, &pinmux_init, device_pm_control_nop,
+	      NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY, &apis);

--- a/drivers/pinmux/pinmux_mchp_xec.c
+++ b/drivers/pinmux/pinmux_mchp_xec.c
@@ -125,10 +125,11 @@ static const struct pinmux_xec_config pinmux_xec_port000_036_config = {
 	.port_num = MCHP_GPIO_000_036,
 };
 
-DEVICE_AND_API_INIT(pinmux_xec_port000_036,
+DEVICE_DEFINE(pinmux_xec_port000_036,
 		    DT_LABEL(DT_NODELABEL(pinmux_000_036)),
 		    &pinmux_xec_init,
-		    NULL, &pinmux_xec_port000_036_config,
+		    device_pm_control_nop, NULL,
+		    &pinmux_xec_port000_036_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_xec_driver_api);
 #endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_000_036), okay) */
@@ -139,10 +140,11 @@ static const struct pinmux_xec_config pinmux_xec_port040_076_config = {
 	.port_num = MCHP_GPIO_040_076,
 };
 
-DEVICE_AND_API_INIT(pinmux_xec_port040_076,
+DEVICE_DEFINE(pinmux_xec_port040_076,
 		    DT_LABEL(DT_NODELABEL(pinmux_040_076)),
 		    &pinmux_xec_init,
-		    NULL, &pinmux_xec_port040_076_config,
+		    device_pm_control_nop, NULL,
+		    &pinmux_xec_port040_076_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_xec_driver_api);
 #endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_040_076), okay) */
@@ -153,10 +155,11 @@ static const struct pinmux_xec_config pinmux_xec_port100_136_config = {
 	.port_num = MCHP_GPIO_100_136,
 };
 
-DEVICE_AND_API_INIT(pinmux_xec_port100_136,
+DEVICE_DEFINE(pinmux_xec_port100_136,
 		    DT_LABEL(DT_NODELABEL(pinmux_100_136)),
 		    &pinmux_xec_init,
-		    NULL, &pinmux_xec_port100_136_config,
+		    device_pm_control_nop, NULL,
+		    &pinmux_xec_port100_136_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_xec_driver_api);
 #endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_100_136), okay) */
@@ -167,10 +170,11 @@ static const struct pinmux_xec_config pinmux_xec_port140_176_config = {
 	.port_num = MCHP_GPIO_140_176,
 };
 
-DEVICE_AND_API_INIT(pinmux_xec_port140_176,
+DEVICE_DEFINE(pinmux_xec_port140_176,
 		    DT_LABEL(DT_NODELABEL(pinmux_140_176)),
 		    &pinmux_xec_init,
-		    NULL, &pinmux_xec_port140_176_config,
+		    device_pm_control_nop, NULL,
+		    &pinmux_xec_port140_176_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_xec_driver_api);
 #endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_140_176), okay) */
@@ -181,10 +185,11 @@ static const struct pinmux_xec_config pinmux_xec_port200_236_config = {
 	.port_num = MCHP_GPIO_200_236,
 };
 
-DEVICE_AND_API_INIT(pinmux_xec_port200_236,
+DEVICE_DEFINE(pinmux_xec_port200_236,
 		    DT_LABEL(DT_NODELABEL(pinmux_200_236)),
 		    &pinmux_xec_init,
-		    NULL, &pinmux_xec_port200_236_config,
+		    device_pm_control_nop, NULL,
+		    &pinmux_xec_port200_236_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_xec_driver_api);
 #endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_200_236), okay) */
@@ -195,10 +200,11 @@ static const struct pinmux_xec_config pinmux_xec_port240_276_config = {
 	.port_num = MCHP_GPIO_240_276,
 };
 
-DEVICE_AND_API_INIT(pinmux_xec_port240_276,
+DEVICE_DEFINE(pinmux_xec_port240_276,
 		    DT_LABEL(DT_NODELABEL(pinmux_240_276)),
 		    &pinmux_xec_init,
-		    NULL, &pinmux_xec_port240_276_config,
+		    device_pm_control_nop, NULL,
+		    &pinmux_xec_port240_276_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_xec_driver_api);
 #endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_240_276), okay) */

--- a/drivers/pinmux/pinmux_mcux.c
+++ b/drivers/pinmux/pinmux_mcux.c
@@ -67,9 +67,9 @@ static const struct pinmux_mcux_config pinmux_mcux_porta_config = {
 	.clock_ip_name = kCLOCK_PortA,
 };
 
-DEVICE_AND_API_INIT(pinmux_porta, CONFIG_PINMUX_MCUX_PORTA_NAME,
+DEVICE_DEFINE(pinmux_porta, CONFIG_PINMUX_MCUX_PORTA_NAME,
 		    &pinmux_mcux_init,
-		    NULL, &pinmux_mcux_porta_config,
+		    device_pm_control_nop, NULL, &pinmux_mcux_porta_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_mcux_driver_api);
 #endif
@@ -80,9 +80,9 @@ static const struct pinmux_mcux_config pinmux_mcux_portb_config = {
 	.clock_ip_name = kCLOCK_PortB,
 };
 
-DEVICE_AND_API_INIT(pinmux_portb, CONFIG_PINMUX_MCUX_PORTB_NAME,
+DEVICE_DEFINE(pinmux_portb, CONFIG_PINMUX_MCUX_PORTB_NAME,
 		    &pinmux_mcux_init,
-		    NULL, &pinmux_mcux_portb_config,
+		    device_pm_control_nop, NULL, &pinmux_mcux_portb_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_mcux_driver_api);
 #endif
@@ -93,9 +93,9 @@ static const struct pinmux_mcux_config pinmux_mcux_portc_config = {
 	.clock_ip_name = kCLOCK_PortC,
 };
 
-DEVICE_AND_API_INIT(pinmux_portc, CONFIG_PINMUX_MCUX_PORTC_NAME,
+DEVICE_DEFINE(pinmux_portc, CONFIG_PINMUX_MCUX_PORTC_NAME,
 		    &pinmux_mcux_init,
-		    NULL, &pinmux_mcux_portc_config,
+		    device_pm_control_nop, NULL, &pinmux_mcux_portc_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_mcux_driver_api);
 #endif
@@ -106,9 +106,9 @@ static const struct pinmux_mcux_config pinmux_mcux_portd_config = {
 	.clock_ip_name = kCLOCK_PortD,
 };
 
-DEVICE_AND_API_INIT(pinmux_portd, CONFIG_PINMUX_MCUX_PORTD_NAME,
+DEVICE_DEFINE(pinmux_portd, CONFIG_PINMUX_MCUX_PORTD_NAME,
 		    &pinmux_mcux_init,
-		    NULL, &pinmux_mcux_portd_config,
+		    device_pm_control_nop, NULL, &pinmux_mcux_portd_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_mcux_driver_api);
 #endif
@@ -119,9 +119,9 @@ static const struct pinmux_mcux_config pinmux_mcux_porte_config = {
 	.clock_ip_name = kCLOCK_PortE,
 };
 
-DEVICE_AND_API_INIT(pinmux_porte, CONFIG_PINMUX_MCUX_PORTE_NAME,
+DEVICE_DEFINE(pinmux_porte, CONFIG_PINMUX_MCUX_PORTE_NAME,
 		    &pinmux_mcux_init,
-		    NULL, &pinmux_mcux_porte_config,
+		    device_pm_control_nop, NULL, &pinmux_mcux_porte_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_mcux_driver_api);
 #endif

--- a/drivers/pinmux/pinmux_mcux_lpc.c
+++ b/drivers/pinmux/pinmux_mcux_lpc.c
@@ -77,9 +77,10 @@ static const struct pinmux_mcux_lpc_config pinmux_mcux_lpc_port0_config = {
 	.port_no = PORT0_IDX,
 };
 
-DEVICE_AND_API_INIT(pinmux_port0, CONFIG_PINMUX_MCUX_LPC_PORT0_NAME,
+DEVICE_DEFINE(pinmux_port0, CONFIG_PINMUX_MCUX_LPC_PORT0_NAME,
 		    &pinmux_mcux_lpc_init,
-		    NULL, &pinmux_mcux_lpc_port0_config,
+		    device_pm_control_nop, NULL,
+		    &pinmux_mcux_lpc_port0_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_mcux_driver_api);
 #endif /* CONFIG_PINMUX_MCUX_LPC_PORT0 */
@@ -91,9 +92,10 @@ static const struct pinmux_mcux_lpc_config pinmux_mcux_lpc_port1_config = {
 	.port_no = PORT1_IDX,
 };
 
-DEVICE_AND_API_INIT(pinmux_port1, CONFIG_PINMUX_MCUX_LPC_PORT1_NAME,
+DEVICE_DEFINE(pinmux_port1, CONFIG_PINMUX_MCUX_LPC_PORT1_NAME,
 		    &pinmux_mcux_lpc_init,
-		    NULL, &pinmux_mcux_lpc_port1_config,
+		    device_pm_control_nop, NULL,
+		    &pinmux_mcux_lpc_port1_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_mcux_driver_api);
 #endif /* CONFIG_PINMUX_MCUX_LPC_PORT1 */

--- a/drivers/pinmux/pinmux_rv32m1.c
+++ b/drivers/pinmux/pinmux_rv32m1.c
@@ -71,11 +71,11 @@ static const struct pinmux_driver_api pinmux_rv32m1_driver_api = {
 		.clock_ip_name = INST_DT_CLOCK_IP_NAME(n),		\
 	};								\
 									\
-	DEVICE_AND_API_INIT(pinmux_rv32m1_##n, DT_INST_LABEL(n),	\
-			    &pinmux_rv32m1_init,			\
-			    NULL, &pinmux_rv32m1_##n##_config,		\
-			    PRE_KERNEL_1,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
-			    &pinmux_rv32m1_driver_api);
+	DEVICE_DEFINE(pinmux_rv32m1_##n, DT_INST_LABEL(n),		\
+		      &pinmux_rv32m1_init, device_pm_control_nop,	\
+		      NULL, &pinmux_rv32m1_##n##_config,		\
+		      PRE_KERNEL_1,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
+		      &pinmux_rv32m1_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(PINMUX_RV32M1_INIT)

--- a/drivers/pinmux/pinmux_sam0.c
+++ b/drivers/pinmux/pinmux_sam0.c
@@ -74,8 +74,9 @@ static const struct pinmux_sam0_config pinmux_sam0_config_0 = {
 	.regs = (PortGroup *)DT_REG_ADDR(DT_NODELABEL(pinmux_a)),
 };
 
-DEVICE_AND_API_INIT(pinmux_sam0_0, DT_LABEL(DT_NODELABEL(pinmux_a)),
-		    pinmux_sam0_init, NULL, &pinmux_sam0_config_0,
+DEVICE_DEFINE(pinmux_sam0_0, DT_LABEL(DT_NODELABEL(pinmux_a)),
+		    pinmux_sam0_init, device_pm_control_nop, NULL,
+		    &pinmux_sam0_config_0,
 		    PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY,
 		    &pinmux_sam0_api);
 #endif
@@ -85,8 +86,9 @@ static const struct pinmux_sam0_config pinmux_sam0_config_1 = {
 	.regs = (PortGroup *)DT_REG_ADDR(DT_NODELABEL(pinmux_b)),
 };
 
-DEVICE_AND_API_INIT(pinmux_sam0_1, DT_LABEL(DT_NODELABEL(pinmux_b)),
-		    pinmux_sam0_init, NULL, &pinmux_sam0_config_1,
+DEVICE_DEFINE(pinmux_sam0_1, DT_LABEL(DT_NODELABEL(pinmux_b)),
+		    pinmux_sam0_init, device_pm_control_nop, NULL,
+		    &pinmux_sam0_config_1,
 		    PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY,
 		    &pinmux_sam0_api);
 #endif
@@ -96,8 +98,9 @@ static const struct pinmux_sam0_config pinmux_sam0_config_2 = {
 	.regs = (PortGroup *)DT_REG_ADDR(DT_NODELABEL(pinmux_c)),
 };
 
-DEVICE_AND_API_INIT(pinmux_sam0_2, DT_LABEL(DT_NODELABEL(pinmux_c)),
-		    pinmux_sam0_init, NULL, &pinmux_sam0_config_2,
+DEVICE_DEFINE(pinmux_sam0_2, DT_LABEL(DT_NODELABEL(pinmux_c)),
+		    pinmux_sam0_init, device_pm_control_nop, NULL,
+		    &pinmux_sam0_config_2,
 		    PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY,
 		    &pinmux_sam0_api);
 #endif
@@ -107,8 +110,9 @@ static const struct pinmux_sam0_config pinmux_sam0_config_3 = {
 	.regs = (PortGroup *)DT_REG_ADDR(DT_NODELABEL(pinmux_d)),
 };
 
-DEVICE_AND_API_INIT(pinmux_sam0_3, DT_LABEL(DT_NODELABEL(pinmux_d)),
-		    pinmux_sam0_init, NULL, &pinmux_sam0_config_3,
+DEVICE_DEFINE(pinmux_sam0_3, DT_LABEL(DT_NODELABEL(pinmux_d)),
+		    pinmux_sam0_init, device_pm_control_nop, NULL,
+		    &pinmux_sam0_config_3,
 		    PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY,
 		    &pinmux_sam0_api);
 #endif

--- a/drivers/pinmux/pinmux_sifive.c
+++ b/drivers/pinmux/pinmux_sifive.c
@@ -93,8 +93,8 @@ static const struct pinmux_sifive_config pinmux_sifive_0_config = {
 	.base = SIFIVE_PINMUX_0_BASE_ADDR,
 };
 
-DEVICE_AND_API_INIT(pinmux_sifive_0, CONFIG_PINMUX_SIFIVE_0_NAME,
-		    &pinmux_sifive_init, NULL,
+DEVICE_DEFINE(pinmux_sifive_0, CONFIG_PINMUX_SIFIVE_0_NAME,
+		    &pinmux_sifive_init, device_pm_control_nop, NULL,
 		    &pinmux_sifive_0_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_sifive_driver_api);

--- a/drivers/ps2/ps2_mchp_xec.c
+++ b/drivers/ps2/ps2_mchp_xec.c
@@ -199,9 +199,10 @@ static const struct ps2_xec_config ps2_xec_config_0 = {
 
 static struct ps2_xec_data ps2_xec_port_data_0;
 
-DEVICE_AND_API_INIT(ps2_xec_0, DT_INST_LABEL(0),
+DEVICE_DEFINE(ps2_xec_0, DT_INST_LABEL(0),
 		    &ps2_xec_init_0,
-		    &ps2_xec_port_data_0, &ps2_xec_config_0,
+		    device_pm_control_nop, &ps2_xec_port_data_0,
+		    &ps2_xec_config_0,
 		    POST_KERNEL, CONFIG_PS2_INIT_PRIORITY,
 		    &ps2_xec_driver_api);
 
@@ -237,9 +238,10 @@ static const struct ps2_xec_config ps2_xec_config_1 = {
 
 static struct ps2_xec_data ps2_xec_port_data_1;
 
-DEVICE_AND_API_INIT(ps2_xec_1, DT_INST_LABEL(1),
+DEVICE_DEFINE(ps2_xec_1, DT_INST_LABEL(1),
 		    &ps2_xec_init_1,
-		    &ps2_xec_port_data_1, &ps2_xec_config_1,
+		    device_pm_control_nop, &ps2_xec_port_data_1,
+		    &ps2_xec_config_1,
 		    POST_KERNEL, CONFIG_PS2_INIT_PRIORITY,
 		    &ps2_xec_driver_api);
 

--- a/drivers/pwm/pwm_dw.c
+++ b/drivers/pwm/pwm_dw.c
@@ -198,8 +198,8 @@ static struct pwm_dw_config pwm_dw_cfg = {
 	.num_ports = PWM_DW_NUM_PORTS,
 };
 
-DEVICE_AND_API_INIT(pwm_dw_0, CONFIG_PWM_DW_0_DRV_NAME, pwm_dw_init,
-		    NULL, &pwm_dw_cfg,
+DEVICE_DEFINE(pwm_dw_0, CONFIG_PWM_DW_0_DRV_NAME, pwm_dw_init,
+		    device_pm_control_nop, NULL, &pwm_dw_cfg,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &pwm_dw_drv_api_funcs);
 

--- a/drivers/pwm/pwm_imx.c
+++ b/drivers/pwm/pwm_imx.c
@@ -166,11 +166,12 @@ static const struct pwm_driver_api imx_pwm_driver_api = {
 									\
 	static struct imx_pwm_data imx_pwm_data_##n;			\
 									\
-	DEVICE_AND_API_INIT(imx_pwm_##n, DT_INST_LABEL(n),		\
-			    &imx_pwm_init, &imx_pwm_data_##n,		\
-			    &imx_pwm_config_##n, POST_KERNEL,		\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &imx_pwm_driver_api);
+	DEVICE_DEFINE(imx_pwm_##n, DT_INST_LABEL(n),			\
+		      &imx_pwm_init, device_pm_control_nop,		\
+		      &imx_pwm_data_##n,				\
+		      &imx_pwm_config_##n, POST_KERNEL,			\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &imx_pwm_driver_api);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(fsl_imx7d_pwm)
 #define DT_DRV_COMPAT fsl_imx7d_pwm

--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -518,7 +518,8 @@ const static struct pwm_led_esp32_config pwm_led_esp32_config = {
 	},
 };
 
-DEVICE_AND_API_INIT(pwm_led_esp32_0, CONFIG_PWM_LED_ESP32_DEV_NAME_0,
-		    pwm_led_esp32_init, NULL, &pwm_led_esp32_config,
+DEVICE_DEFINE(pwm_led_esp32_0, CONFIG_PWM_LED_ESP32_DEV_NAME_0,
+		    pwm_led_esp32_init, device_pm_control_nop, NULL,
+		    &pwm_led_esp32_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &pwm_led_esp32_api);

--- a/drivers/pwm/pwm_litex.c
+++ b/drivers/pwm/pwm_litex.c
@@ -103,14 +103,15 @@ static const struct pwm_driver_api pwm_litex_driver_api = {
 		.reg_period_size = DT_INST_REG_SIZE_BY_NAME(n, period) / 4,    \
 	};								       \
 									       \
-	DEVICE_AND_API_INIT(pwm_##n,					       \
-			    DT_INST_LABEL(n),		       \
-			    pwm_litex_init,				       \
-			    NULL,					       \
-			    &pwm_litex_cfg_##n,				       \
-			    POST_KERNEL,				       \
-			    CONFIG_PWM_LITEX_INIT_PRIORITY,		       \
-			    &pwm_litex_driver_api			       \
-			   );
+	DEVICE_DEFINE(pwm_##n,						       \
+		      DT_INST_LABEL(n),					       \
+		      pwm_litex_init,					       \
+		      device_pm_control_nop,				       \
+		      NULL,						       \
+		      &pwm_litex_cfg_##n,				       \
+		      POST_KERNEL,					       \
+		      CONFIG_PWM_LITEX_INIT_PRIORITY,			       \
+		      &pwm_litex_driver_api				       \
+		);
 
 DT_INST_FOREACH_STATUS_OKAY(PWM_LITEX_INIT)

--- a/drivers/pwm/pwm_mchp_xec.c
+++ b/drivers/pwm/pwm_mchp_xec.c
@@ -387,13 +387,14 @@ static struct pwm_driver_api pwm_xec_api = {
 		.base_address = DT_INST_REG_ADDR(inst)			\
 	};								\
 									\
-	DEVICE_AND_API_INIT(pwm_xec_##inst,				\
-			    DT_INST_LABEL(inst),			\
-			    pwm_xec_init,				\
-			    NULL,					\
-			    &pwm_xec_dev_config_##inst,			\
-			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &pwm_xec_api);
+	DEVICE_DEFINE(pwm_xec_##inst,					\
+		      DT_INST_LABEL(inst),				\
+		      pwm_xec_init,					\
+		      device_pm_control_nop,				\
+		      NULL,						\
+		      &pwm_xec_dev_config_##inst,			\
+		      POST_KERNEL,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &pwm_xec_api);
 
 DT_INST_FOREACH_STATUS_OKAY(XEC_INST_INIT)

--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -163,12 +163,13 @@ static const struct pwm_driver_api pwm_mcux_driver_api = {
 		.clock_source = kCLOCK_IpgClk,				  \
 	};								  \
 									  \
-	DEVICE_AND_API_INIT(pwm_mcux_ ## n,				  \
-			    DT_INST_LABEL(n),				  \
-			    pwm_mcux_init,				  \
-			    &pwm_mcux_data_ ## n,			  \
-			    &pwm_mcux_config_ ## n,			  \
-			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,\
-			    &pwm_mcux_driver_api);
+	DEVICE_DEFINE(pwm_mcux_ ## n,					  \
+		      DT_INST_LABEL(n),					  \
+		      pwm_mcux_init,					  \
+		      device_pm_control_nop,				  \
+		      &pwm_mcux_data_ ## n,				  \
+		      &pwm_mcux_config_ ## n,				  \
+		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	  \
+		      &pwm_mcux_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(PWM_DEVICE_INIT_MCUX)

--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -168,10 +168,11 @@ static const struct pwm_driver_api mcux_ftm_driver_api = {
 		.mode = kFTM_EdgeAlignedPwm, \
 	}; \
 	static struct mcux_ftm_data mcux_ftm_data_##n; \
-	DEVICE_AND_API_INIT(mcux_ftm_##n, DT_INST_LABEL(n), \
-			    &mcux_ftm_init, &mcux_ftm_data_##n, \
-			    &mcux_ftm_config_##n, \
-			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
-			    &mcux_ftm_driver_api);
+	DEVICE_DEFINE(mcux_ftm_##n, DT_INST_LABEL(n), \
+		      &mcux_ftm_init, device_pm_control_nop, \
+		      &mcux_ftm_data_##n, \
+		      &mcux_ftm_config_##n, \
+		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+		      &mcux_ftm_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(FTM_DEVICE)

--- a/drivers/pwm/pwm_mcux_tpm.c
+++ b/drivers/pwm/pwm_mcux_tpm.c
@@ -194,11 +194,12 @@ static const struct pwm_driver_api mcux_tpm_driver_api = {
 		.mode = kTPM_EdgeAlignedPwm, \
 	}; \
 	static struct mcux_tpm_data mcux_tpm_data_##n; \
-	DEVICE_AND_API_INIT(mcux_tpm_##n, \
-			    DT_INST_LABEL(n), \
-			    &mcux_tpm_init, &mcux_tpm_data_##n, \
-			    &mcux_tpm_config_##n, \
-			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
-			    &mcux_tpm_driver_api);
+	DEVICE_DEFINE(mcux_tpm_##n, \
+		      DT_INST_LABEL(n), \
+		      &mcux_tpm_init, device_pm_control_nop,\
+		      &mcux_tpm_data_##n, \
+		      &mcux_tpm_config_##n, \
+		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+		      &mcux_tpm_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(TPM_DEVICE)

--- a/drivers/pwm/pwm_nrf5_sw.c
+++ b/drivers/pwm/pwm_nrf5_sw.c
@@ -262,10 +262,10 @@ static const struct pwm_config pwm_nrf5_sw_0_config = {
 
 static struct pwm_data pwm_nrf5_sw_0_data;
 
-DEVICE_AND_API_INIT(pwm_nrf5_sw_0,
+DEVICE_DEFINE(pwm_nrf5_sw_0,
 		    DT_INST_LABEL(0),
 		    pwm_nrf5_sw_init,
-		    &pwm_nrf5_sw_0_data,
+		    device_pm_control_nop, &pwm_nrf5_sw_0_data,
 		    &pwm_nrf5_sw_0_config,
 		    POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,

--- a/drivers/pwm/pwm_pca9685.c
+++ b/drivers/pwm/pwm_pca9685.c
@@ -168,9 +168,10 @@ static const struct pwm_pca9685_config pwm_pca9685_0_cfg = {
 static struct pwm_pca9685_drv_data pwm_pca9685_0_drvdata;
 
 /* This has to init after I2C master */
-DEVICE_AND_API_INIT(pwm_pca9685_0, CONFIG_PWM_PCA9685_0_DEV_NAME,
+DEVICE_DEFINE(pwm_pca9685_0, CONFIG_PWM_PCA9685_0_DEV_NAME,
 			pwm_pca9685_init,
-			&pwm_pca9685_0_drvdata, &pwm_pca9685_0_cfg,
+			device_pm_control_nop, &pwm_pca9685_0_drvdata,
+			&pwm_pca9685_0_cfg,
 			POST_KERNEL, CONFIG_PWM_PCA9685_INIT_PRIORITY,
 			&pwm_pca9685_drv_api_funcs);
 

--- a/drivers/pwm/pwm_rv32m1_tpm.c
+++ b/drivers/pwm/pwm_rv32m1_tpm.c
@@ -193,11 +193,12 @@ static const struct pwm_driver_api rv32m1_tpm_driver_api = {
 		.mode = kTPM_EdgeAlignedPwm, \
 	}; \
 	static struct rv32m1_tpm_data rv32m1_tpm_data_##n; \
-	DEVICE_AND_API_INIT(rv32m1_tpm_##n, \
-			    DT_INST_LABEL(n), \
-			    &rv32m1_tpm_init, &rv32m1_tpm_data_##n, \
-			    &rv32m1_tpm_config_##n, \
-			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
-			    &rv32m1_tpm_driver_api);
+	DEVICE_DEFINE(rv32m1_tpm_##n, \
+		      DT_INST_LABEL(n), \
+		      &rv32m1_tpm_init, device_pm_control_nop, \
+		      &rv32m1_tpm_data_##n, \
+		      &rv32m1_tpm_config_##n, \
+		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+		      &rv32m1_tpm_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(TPM_DEVICE)

--- a/drivers/pwm/pwm_sam.c
+++ b/drivers/pwm/pwm_sam.c
@@ -106,11 +106,12 @@ static const struct pwm_driver_api sam_pwm_driver_api = {
 		.divider = DT_INST_PROP(inst, divider),			\
 	};								\
 									\
-	DEVICE_AND_API_INIT(sam_pwm_##inst, DT_INST_LABEL(inst),	\
-			    &sam_pwm_init,				\
-			    NULL, &sam_pwm_config_##inst,		\
-			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &sam_pwm_driver_api);
+	DEVICE_DEFINE(sam_pwm_##inst, DT_INST_LABEL(inst),		\
+		      &sam_pwm_init,					\
+		      device_pm_control_nop,				\
+		      NULL, &sam_pwm_config_##inst,			\
+		      POST_KERNEL,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &sam_pwm_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SAM_INST_INIT)

--- a/drivers/pwm/pwm_sifive.c
+++ b/drivers/pwm/pwm_sifive.c
@@ -229,13 +229,14 @@ static const struct pwm_driver_api pwm_sifive_api = {
 			.f_sys = DT_INST_PROP(n, clock_frequency),  \
 			.cmpwidth = DT_INST_PROP(n, sifive_compare_width), \
 		};	\
-	DEVICE_AND_API_INIT(pwm_##n,	\
-			    DT_INST_LABEL(n),	\
-			    pwm_sifive_init,	\
-			    &pwm_sifive_data_##n,	\
-			    &pwm_sifive_cfg_##n,	\
-			    POST_KERNEL,	\
-			    CONFIG_PWM_SIFIVE_INIT_PRIORITY,	\
-			    &pwm_sifive_api);
+	DEVICE_DEFINE(pwm_##n, \
+		      DT_INST_LABEL(n), \
+		      pwm_sifive_init, \
+		      device_pm_control_nop, \
+		      &pwm_sifive_data_##n, \
+		      &pwm_sifive_cfg_##n, \
+		      POST_KERNEL, \
+		      CONFIG_PWM_SIFIVE_INIT_PRIORITY, \
+		      &pwm_sifive_api);
 
 DT_INST_FOREACH_STATUS_OKAY(PWM_SIFIVE_INIT)

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -267,12 +267,13 @@ static int pwm_stm32_init(struct device *dev)
 		},\
 	};								\
 									\
-	DEVICE_AND_API_INIT(pwm_stm32_##index,				\
-			    DT_INST_LABEL(index),	\
-			    pwm_stm32_init,				\
-			    &pwm_stm32_dev_data_##index,		\
-			    &pwm_stm32_dev_cfg_##index,			\
-			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,\
-			    &pwm_stm32_drv_api_funcs);
+	DEVICE_DEFINE(pwm_stm32_##index,				\
+		      DT_INST_LABEL(index),				\
+		      pwm_stm32_init,					\
+		      device_pm_control_nop,				\
+		      &pwm_stm32_dev_data_##index,			\
+		      &pwm_stm32_dev_cfg_##index,			\
+		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
+		      &pwm_stm32_drv_api_funcs);
 
 DT_INST_FOREACH_STATUS_OKAY(PWM_DEVICE_INIT_STM32)

--- a/drivers/sensor/adt7420/adt7420.c
+++ b/drivers/sensor/adt7420/adt7420.c
@@ -227,6 +227,7 @@ static const struct adt7420_dev_config adt7420_config = {
 #endif
 };
 
-DEVICE_AND_API_INIT(adt7420, DT_INST_LABEL(0), adt7420_init, &adt7420_driver,
+DEVICE_DEFINE(adt7420, DT_INST_LABEL(0), adt7420_init, device_pm_control_nop,
+		    &adt7420_driver,
 		    &adt7420_config, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &adt7420_driver_api);

--- a/drivers/sensor/adxl345/adxl345.c
+++ b/drivers/sensor/adxl345/adxl345.c
@@ -189,6 +189,7 @@ static const struct adxl345_dev_config adxl345_config = {
 	.i2c_addr = DT_INST_REG_ADDR(0),
 };
 
-DEVICE_AND_API_INIT(adxl345, DT_INST_LABEL(0), adxl345_init,
-		    &adxl345_data, &adxl345_config, POST_KERNEL,
+DEVICE_DEFINE(adxl345, DT_INST_LABEL(0), adxl345_init,
+		    device_pm_control_nop, &adxl345_data, &adxl345_config,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &adxl345_api_funcs);

--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -801,6 +801,7 @@ static const struct adxl362_config adxl362_config = {
 #endif
 };
 
-DEVICE_AND_API_INIT(adxl362, DT_INST_LABEL(0), adxl362_init,
-		    &adxl362_data, &adxl362_config, POST_KERNEL,
+DEVICE_DEFINE(adxl362, DT_INST_LABEL(0), adxl362_init,
+		    device_pm_control_nop, &adxl362_data, &adxl362_config,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &adxl362_api_funcs);

--- a/drivers/sensor/adxl372/adxl372.c
+++ b/drivers/sensor/adxl372/adxl372.c
@@ -1013,6 +1013,7 @@ static const struct adxl372_dev_config adxl372_config = {
 	.op_mode = ADXL372_FULL_BW_MEASUREMENT,
 };
 
-DEVICE_AND_API_INIT(adxl372, DT_INST_LABEL(0), adxl372_init,
-		    &adxl372_data, &adxl372_config, POST_KERNEL,
+DEVICE_DEFINE(adxl372, DT_INST_LABEL(0), adxl372_init,
+		    device_pm_control_nop, &adxl372_data, &adxl372_config,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &adxl372_api_funcs);

--- a/drivers/sensor/ak8975/ak8975.c
+++ b/drivers/sensor/ak8975/ak8975.c
@@ -169,7 +169,7 @@ int ak8975_init(struct device *dev)
 
 struct ak8975_data ak8975_data;
 
-DEVICE_AND_API_INIT(ak8975, DT_INST_LABEL(0), ak8975_init,
-		    &ak8975_data,
+DEVICE_DEFINE(ak8975, DT_INST_LABEL(0), ak8975_init,
+		    device_pm_control_nop, &ak8975_data,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &ak8975_driver_api);

--- a/drivers/sensor/amg88xx/amg88xx.c
+++ b/drivers/sensor/amg88xx/amg88xx.c
@@ -152,7 +152,7 @@ static const struct amg88xx_config amg88xx_config = {
 #endif
 };
 
-DEVICE_AND_API_INIT(amg88xx, DT_INST_LABEL(0), amg88xx_init,
-		    &amg88xx_driver, &amg88xx_config,
+DEVICE_DEFINE(amg88xx, DT_INST_LABEL(0), amg88xx_init,
+		    device_pm_control_nop, &amg88xx_driver, &amg88xx_config,
 		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &amg88xx_driver_api);

--- a/drivers/sensor/ams_iAQcore/iAQcore.c
+++ b/drivers/sensor/ams_iAQcore/iAQcore.c
@@ -113,6 +113,7 @@ static int iaq_core_init(struct device *dev)
 
 static struct iaq_core_data iaq_core_driver;
 
-DEVICE_AND_API_INIT(iaq_core, DT_INST_LABEL(0), iaq_core_init,
-		    &iaq_core_driver, NULL, POST_KERNEL,
+DEVICE_DEFINE(iaq_core, DT_INST_LABEL(0), iaq_core_init,
+		    device_pm_control_nop, &iaq_core_driver, NULL,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &iaq_core_driver_api);

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -542,8 +542,9 @@ static const struct apds9960_config apds9960_config = {
 static struct apds9960_data apds9960_data;
 
 #ifndef CONFIG_DEVICE_POWER_MANAGEMENT
-DEVICE_AND_API_INIT(apds9960, DT_INST_LABEL(0), &apds9960_init,
-		    &apds9960_data, &apds9960_config, POST_KERNEL,
+DEVICE_DEFINE(apds9960, DT_INST_LABEL(0), &apds9960_init,
+		    device_pm_control_nop, &apds9960_data, &apds9960_config,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &apds9960_driver_api);
 #else
 DEVICE_DEFINE(apds9960, DT_INST_LABEL(0), apds9960_init,

--- a/drivers/sensor/bma280/bma280.c
+++ b/drivers/sensor/bma280/bma280.c
@@ -162,7 +162,7 @@ int bma280_init(struct device *dev)
 
 struct bma280_data bma280_driver;
 
-DEVICE_AND_API_INIT(bma280, DT_INST_LABEL(0),
-		    bma280_init, &bma280_driver,
+DEVICE_DEFINE(bma280, DT_INST_LABEL(0),
+		    bma280_init, device_pm_control_nop, &bma280_driver,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &bma280_driver_api);

--- a/drivers/sensor/bmc150_magn/bmc150_magn.c
+++ b/drivers/sensor/bmc150_magn/bmc150_magn.c
@@ -607,6 +607,7 @@ static const struct bmc150_magn_config bmc150_magn_config = {
 
 static struct bmc150_magn_data bmc150_magn_data;
 
-DEVICE_AND_API_INIT(bmc150_magn, DT_INST_LABEL(0), bmc150_magn_init,
-	    &bmc150_magn_data, &bmc150_magn_config, POST_KERNEL,
+DEVICE_DEFINE(bmc150_magn, DT_INST_LABEL(0), bmc150_magn_init,
+	    device_pm_control_nop, &bmc150_magn_data, &bmc150_magn_config,
+	    POST_KERNEL,
 	    CONFIG_SENSOR_INIT_PRIORITY, &bmc150_magn_api_funcs);

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -588,14 +588,15 @@ done:
  */
 
 #define BME280_DEVICE_INIT(inst)					\
-	DEVICE_AND_API_INIT(bme280_##inst,				\
-			    DT_INST_LABEL(inst),			\
-			    bme280_init,				\
-			    &bme280_data_##inst,			\
-			    &bme280_config_##inst,			\
-			    POST_KERNEL,				\
-			    CONFIG_SENSOR_INIT_PRIORITY,		\
-			    &bme280_api_funcs);
+	DEVICE_DEFINE(bme280_##inst,					\
+		      DT_INST_LABEL(inst),				\
+		      bme280_init,					\
+		      device_pm_control_nop,				\
+		      &bme280_data_##inst,				\
+		      &bme280_config_##inst,				\
+		      POST_KERNEL,					\
+		      CONFIG_SENSOR_INIT_PRIORITY,			\
+		      &bme280_api_funcs);
 
 /*
  * Instantiation macros used when a device is on a SPI bus.

--- a/drivers/sensor/bme680/bme680.c
+++ b/drivers/sensor/bme680/bme680.c
@@ -426,6 +426,7 @@ static const struct sensor_driver_api bme680_api_funcs = {
 
 static struct bme680_data bme680_data;
 
-DEVICE_AND_API_INIT(bme680, DT_INST_LABEL(0), bme680_init, &bme680_data,
+DEVICE_DEFINE(bme680, DT_INST_LABEL(0), bme680_init, device_pm_control_nop,
+		    &bme680_data,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &bme680_api_funcs);

--- a/drivers/sensor/bmg160/bmg160.c
+++ b/drivers/sensor/bmg160/bmg160.c
@@ -340,7 +340,7 @@ const struct bmg160_device_config bmg160_config = {
 #endif
 };
 
-DEVICE_AND_API_INIT(bmg160, DT_INST_LABEL(0), bmg160_init,
-		    &bmg160_data,
+DEVICE_DEFINE(bmg160, DT_INST_LABEL(0), bmg160_init,
+		    device_pm_control_nop, &bmg160_data,
 		    &bmg160_config, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &bmg160_api);

--- a/drivers/sensor/bmi160/bmi160.c
+++ b/drivers/sensor/bmi160/bmi160.c
@@ -909,6 +909,7 @@ const struct bmi160_device_config bmi160_config = {
 
 
 
-DEVICE_AND_API_INIT(bmi160, DT_INST_LABEL(0), bmi160_init, &bmi160_data,
+DEVICE_DEFINE(bmi160, DT_INST_LABEL(0), bmi160_init, device_pm_control_nop,
+		&bmi160_data,
 		&bmi160_config, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		&bmi160_api);

--- a/drivers/sensor/bmm150/bmm150.c
+++ b/drivers/sensor/bmm150/bmm150.c
@@ -606,6 +606,7 @@ static const struct bmm150_config bmm150_config = {
 
 static struct bmm150_data bmm150_data;
 
-DEVICE_AND_API_INIT(bmm150, DT_INST_LABEL(0), bmm150_init,
-			&bmm150_data, &bmm150_config, POST_KERNEL,
+DEVICE_DEFINE(bmm150, DT_INST_LABEL(0), bmm150_init,
+			device_pm_control_nop, &bmm150_data, &bmm150_config,
+			POST_KERNEL,
 			CONFIG_SENSOR_INIT_PRIORITY, &bmm150_api_funcs);

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -624,10 +624,11 @@ static const struct sensor_driver_api bq274xx_battery_driver_api = {
 		.terminate_voltage = DT_INST_PROP(index, terminate_voltage),   \
 	};                                                                     \
 									       \
-	DEVICE_AND_API_INIT(bq274xx_##index, DT_INST_LABEL(index),             \
-			    &bq274xx_gauge_init, &bq274xx_driver_##index,      \
-			    &bq274xx_config_##index, POST_KERNEL,              \
-			    CONFIG_SENSOR_INIT_PRIORITY,                       \
-			    &bq274xx_battery_driver_api);
+	DEVICE_DEFINE(bq274xx_##index, DT_INST_LABEL(index),		       \
+		      &bq274xx_gauge_init, device_pm_control_nop,	       \
+		      &bq274xx_driver_##index,				       \
+		      &bq274xx_config_##index, POST_KERNEL,		       \
+		      CONFIG_SENSOR_INIT_PRIORITY,			       \
+		      &bq274xx_battery_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(BQ274XX_INIT)

--- a/drivers/sensor/ccs811/ccs811.c
+++ b/drivers/sensor/ccs811/ccs811.c
@@ -592,6 +592,7 @@ out:
 
 static struct ccs811_data ccs811_driver;
 
-DEVICE_AND_API_INIT(ccs811, DT_INST_LABEL(0), ccs811_init, &ccs811_driver,
+DEVICE_DEFINE(ccs811, DT_INST_LABEL(0), ccs811_init, device_pm_control_nop,
+		    &ccs811_driver,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &ccs811_driver_api);

--- a/drivers/sensor/dht/dht.c
+++ b/drivers/sensor/dht/dht.c
@@ -246,6 +246,6 @@ static const struct dht_config dht_config = {
 	.pin = DT_INST_GPIO_PIN(0, dio_gpios),
 };
 
-DEVICE_AND_API_INIT(dht_dev, DT_INST_LABEL(0), &dht_init,
-		    &dht_data, &dht_config,
+DEVICE_DEFINE(dht_dev, DT_INST_LABEL(0), &dht_init,
+		    device_pm_control_nop, &dht_data, &dht_config,
 		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &dht_api);

--- a/drivers/sensor/dps310/dps310.c
+++ b/drivers/sensor/dps310/dps310.c
@@ -730,8 +730,9 @@ static const struct dps310_cfg dps310_cfg_0 = {
 	.i2c_addr = DT_INST_REG_ADDR(0)
 };
 
-DEVICE_AND_API_INIT(dps310, DT_INST_LABEL(0), dps310_init,
-		    &dps310_data_0, &dps310_cfg_0, POST_KERNEL,
+DEVICE_DEFINE(dps310, DT_INST_LABEL(0), dps310_init,
+		    device_pm_control_nop, &dps310_data_0, &dps310_cfg_0,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &dps310_api_funcs);
 #endif
 
@@ -742,7 +743,8 @@ static const struct dps310_cfg dps310_cfg_1 = {
 	.i2c_addr = DT_INST_REG_ADDR(1)
 };
 
-DEVICE_AND_API_INIT(dps310, DT_INST_LABEL(1), dps310_init,
-		    &dps310_data_1, &dps310_cfg_1, POST_KERNEL,
+DEVICE_DEFINE(dps310, DT_INST_LABEL(1), dps310_init,
+		    device_pm_control_nop, &dps310_data_1, &dps310_cfg_1,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &dps310_api_funcs);
 #endif

--- a/drivers/sensor/ens210/ens210.c
+++ b/drivers/sensor/ens210/ens210.c
@@ -342,6 +342,7 @@ static int ens210_init(struct device *dev)
 
 static struct ens210_data ens210_driver;
 
-DEVICE_AND_API_INIT(ens210, DT_INST_LABEL(0), ens210_init, &ens210_driver,
+DEVICE_DEFINE(ens210, DT_INST_LABEL(0), ens210_init, device_pm_control_nop,
+		    &ens210_driver,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &en210_driver_api);

--- a/drivers/sensor/fxas21002/fxas21002.c
+++ b/drivers/sensor/fxas21002/fxas21002.c
@@ -306,7 +306,7 @@ static const struct fxas21002_config fxas21002_config = {
 
 static struct fxas21002_data fxas21002_data;
 
-DEVICE_AND_API_INIT(fxas21002, DT_INST_LABEL(0), fxas21002_init,
-		    &fxas21002_data, &fxas21002_config,
+DEVICE_DEFINE(fxas21002, DT_INST_LABEL(0), fxas21002_init,
+		    device_pm_control_nop, &fxas21002_data, &fxas21002_config,
 		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &fxas21002_driver_api);

--- a/drivers/sensor/fxos8700/fxos8700.c
+++ b/drivers/sensor/fxos8700/fxos8700.c
@@ -590,7 +590,7 @@ static const struct fxos8700_config fxos8700_config = {
 
 static struct fxos8700_data fxos8700_data;
 
-DEVICE_AND_API_INIT(fxos8700, DT_INST_LABEL(0), fxos8700_init,
-		    &fxos8700_data, &fxos8700_config,
+DEVICE_DEFINE(fxos8700, DT_INST_LABEL(0), fxos8700_init,
+		    device_pm_control_nop, &fxos8700_data, &fxos8700_config,
 		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &fxos8700_driver_api);

--- a/drivers/sensor/grove/light_sensor.c
+++ b/drivers/sensor/grove/light_sensor.c
@@ -119,6 +119,7 @@ static const struct gls_config gls_cfg = {
 	.adc_channel = DT_INST_IO_CHANNELS_INPUT(0),
 };
 
-DEVICE_AND_API_INIT(gls_dev, DT_INST_LABEL(0), &gls_init,
-		&gls_data, &gls_cfg, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
+DEVICE_DEFINE(gls_dev, DT_INST_LABEL(0), &gls_init,
+		device_pm_control_nop, &gls_data, &gls_cfg, POST_KERNEL,
+		CONFIG_SENSOR_INIT_PRIORITY,
 		&gls_api);

--- a/drivers/sensor/grove/temperature_sensor.c
+++ b/drivers/sensor/grove/temperature_sensor.c
@@ -124,6 +124,7 @@ static const struct gts_config gts_cfg = {
 	.adc_channel = DT_INST_IO_CHANNELS_INPUT(0),
 };
 
-DEVICE_AND_API_INIT(gts_dev, DT_INST_LABEL(0), &gts_init,
-		&gts_data, &gts_cfg, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
+DEVICE_DEFINE(gts_dev, DT_INST_LABEL(0), &gts_init,
+		device_pm_control_nop, &gts_data, &gts_cfg, POST_KERNEL,
+		CONFIG_SENSOR_INIT_PRIORITY,
 		&gts_api);

--- a/drivers/sensor/hmc5883l/hmc5883l.c
+++ b/drivers/sensor/hmc5883l/hmc5883l.c
@@ -160,6 +160,7 @@ int hmc5883l_init(struct device *dev)
 
 struct hmc5883l_data hmc5883l_driver;
 
-DEVICE_AND_API_INIT(hmc5883l, DT_INST_LABEL(0),
-		    hmc5883l_init, &hmc5883l_driver, NULL, POST_KERNEL,
+DEVICE_DEFINE(hmc5883l, DT_INST_LABEL(0),
+		    hmc5883l_init, device_pm_control_nop, &hmc5883l_driver,
+		    NULL, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &hmc5883l_driver_api);

--- a/drivers/sensor/hp206c/hp206c.c
+++ b/drivers/sensor/hp206c/hp206c.c
@@ -316,7 +316,7 @@ static int hp206c_init(struct device *dev)
 
 static struct hp206c_device_data hp206c_data;
 
-DEVICE_AND_API_INIT(hp206c, DT_INST_LABEL(0),
-		    hp206c_init, &hp206c_data,
+DEVICE_DEFINE(hp206c, DT_INST_LABEL(0),
+		    hp206c_init, device_pm_control_nop, &hp206c_data,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &hp206c_api);

--- a/drivers/sensor/hts221/hts221.c
+++ b/drivers/sensor/hts221/hts221.c
@@ -188,6 +188,7 @@ static const struct hts221_config hts221_cfg = {
 #endif /* CONFIG_HTS221_TRIGGER */
 };
 
-DEVICE_AND_API_INIT(hts221, DT_INST_LABEL(0), hts221_init,
-		    &hts221_driver, &hts221_cfg, POST_KERNEL,
+DEVICE_DEFINE(hts221, DT_INST_LABEL(0), hts221_init,
+		    device_pm_control_nop, &hts221_driver, &hts221_cfg,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &hts221_driver_api);

--- a/drivers/sensor/iis2dlpc/iis2dlpc.c
+++ b/drivers/sensor/iis2dlpc/iis2dlpc.c
@@ -403,6 +403,7 @@ const struct iis2dlpc_device_config iis2dlpc_cfg = {
 
 struct iis2dlpc_data iis2dlpc_data;
 
-DEVICE_AND_API_INIT(iis2dlpc, DT_INST_LABEL(0), iis2dlpc_init,
-	     &iis2dlpc_data, &iis2dlpc_cfg, POST_KERNEL,
+DEVICE_DEFINE(iis2dlpc, DT_INST_LABEL(0), iis2dlpc_init,
+	     device_pm_control_nop, &iis2dlpc_data, &iis2dlpc_cfg,
+	     POST_KERNEL,
 	     CONFIG_SENSOR_INIT_PRIORITY, &iis2dlpc_driver_api);

--- a/drivers/sensor/iis2mdc/iis2mdc.c
+++ b/drivers/sensor/iis2mdc/iis2mdc.c
@@ -361,6 +361,7 @@ static int iis2mdc_init(struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(iis2mdc, DT_INST_LABEL(0), iis2mdc_init,
-		     &iis2mdc_data, &iis2mdc_dev_config, POST_KERNEL,
+DEVICE_DEFINE(iis2mdc, DT_INST_LABEL(0), iis2mdc_init,
+		     device_pm_control_nop, &iis2mdc_data,
+		     &iis2mdc_dev_config, POST_KERNEL,
 		     CONFIG_SENSOR_INIT_PRIORITY, &iis2mdc_driver_api);

--- a/drivers/sensor/iis3dhhc/iis3dhhc.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc.c
@@ -252,6 +252,7 @@ static const struct iis3dhhc_config iis3dhhc_config = {
 #endif
 };
 
-DEVICE_AND_API_INIT(iis3dhhc, DT_INST_LABEL(0), iis3dhhc_init,
-		    &iis3dhhc_data, &iis3dhhc_config, POST_KERNEL,
+DEVICE_DEFINE(iis3dhhc, DT_INST_LABEL(0), iis3dhhc_init,
+		    device_pm_control_nop, &iis3dhhc_data, &iis3dhhc_config,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &iis3dhhc_api_funcs);

--- a/drivers/sensor/isl29035/isl29035.c
+++ b/drivers/sensor/isl29035/isl29035.c
@@ -143,6 +143,6 @@ static int isl29035_init(struct device *dev)
 
 struct isl29035_driver_data isl29035_data;
 
-DEVICE_AND_API_INIT(isl29035_dev, DT_INST_LABEL(0), &isl29035_init,
-		    &isl29035_data, NULL, POST_KERNEL,
+DEVICE_DEFINE(isl29035_dev, DT_INST_LABEL(0), &isl29035_init,
+		    device_pm_control_nop, &isl29035_data, NULL, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &isl29035_api);

--- a/drivers/sensor/ism330dhcx/ism330dhcx.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx.c
@@ -841,6 +841,7 @@ static int ism330dhcx_init(struct device *dev)
 
 static struct ism330dhcx_data ism330dhcx_data;
 
-DEVICE_AND_API_INIT(ism330dhcx, DT_INST_LABEL(0), ism330dhcx_init,
-		    &ism330dhcx_data, &ism330dhcx_config, POST_KERNEL,
+DEVICE_DEFINE(ism330dhcx, DT_INST_LABEL(0), ism330dhcx_init,
+		    device_pm_control_nop, &ism330dhcx_data,
+		    &ism330dhcx_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &ism330dhcx_api_funcs);

--- a/drivers/sensor/lis2dh/lis2dh.c
+++ b/drivers/sensor/lis2dh/lis2dh.c
@@ -372,6 +372,7 @@ static const struct lis2dh_config lis2dh_config = {
 #endif
 };
 
-DEVICE_AND_API_INIT(lis2dh, DT_INST_LABEL(0), lis2dh_init, &lis2dh_data,
+DEVICE_DEFINE(lis2dh, DT_INST_LABEL(0), lis2dh_init, device_pm_control_nop,
+		    &lis2dh_data,
 		    &lis2dh_config, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &lis2dh_driver_api);

--- a/drivers/sensor/lis2ds12/lis2ds12.c
+++ b/drivers/sensor/lis2ds12/lis2ds12.c
@@ -318,6 +318,7 @@ static int lis2ds12_init(struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(lis2ds12, DT_INST_LABEL(0), lis2ds12_init,
-		    &lis2ds12_data, &lis2ds12_config, POST_KERNEL,
+DEVICE_DEFINE(lis2ds12, DT_INST_LABEL(0), lis2ds12_init,
+		    device_pm_control_nop, &lis2ds12_data, &lis2ds12_config,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lis2ds12_api_funcs);

--- a/drivers/sensor/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/lis2dw12/lis2dw12.c
@@ -403,6 +403,7 @@ const struct lis2dw12_device_config lis2dw12_cfg = {
 
 struct lis2dw12_data lis2dw12_data;
 
-DEVICE_AND_API_INIT(lis2dw12, DT_INST_LABEL(0), lis2dw12_init,
-	     &lis2dw12_data, &lis2dw12_cfg, POST_KERNEL,
+DEVICE_DEFINE(lis2dw12, DT_INST_LABEL(0), lis2dw12_init,
+	     device_pm_control_nop, &lis2dw12_data, &lis2dw12_cfg,
+	     POST_KERNEL,
 	     CONFIG_SENSOR_INIT_PRIORITY, &lis2dw12_driver_api);

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -361,6 +361,7 @@ static int lis2mdl_init(struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(lis2mdl, DT_INST_LABEL(0), lis2mdl_init,
-		     &lis2mdl_data, &lis2mdl_dev_config, POST_KERNEL,
+DEVICE_DEFINE(lis2mdl, DT_INST_LABEL(0), lis2mdl_init,
+		     device_pm_control_nop, &lis2mdl_data,
+		     &lis2mdl_dev_config, POST_KERNEL,
 		     CONFIG_SENSOR_INIT_PRIORITY, &lis2mdl_driver_api);

--- a/drivers/sensor/lis3mdl/lis3mdl.c
+++ b/drivers/sensor/lis3mdl/lis3mdl.c
@@ -166,6 +166,6 @@ int lis3mdl_init(struct device *dev)
 
 struct lis3mdl_data lis3mdl_driver;
 
-DEVICE_AND_API_INIT(lis3mdl, DT_INST_LABEL(0), lis3mdl_init,
-		    &lis3mdl_driver, NULL, POST_KERNEL,
+DEVICE_DEFINE(lis3mdl, DT_INST_LABEL(0), lis3mdl_init,
+		    device_pm_control_nop, &lis3mdl_driver, NULL, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lis3mdl_driver_api);

--- a/drivers/sensor/lps22hb/lps22hb.c
+++ b/drivers/sensor/lps22hb/lps22hb.c
@@ -159,6 +159,7 @@ static const struct lps22hb_config lps22hb_config = {
 
 static struct lps22hb_data lps22hb_data;
 
-DEVICE_AND_API_INIT(lps22hb, DT_INST_LABEL(0), lps22hb_init,
-		    &lps22hb_data, &lps22hb_config, POST_KERNEL,
+DEVICE_DEFINE(lps22hb, DT_INST_LABEL(0), lps22hb_init,
+		    device_pm_control_nop, &lps22hb_data, &lps22hb_config,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lps22hb_api_funcs);

--- a/drivers/sensor/lps22hh/lps22hh.c
+++ b/drivers/sensor/lps22hh/lps22hh.c
@@ -230,6 +230,7 @@ static const struct lps22hh_config lps22hh_config = {
 #endif
 };
 
-DEVICE_AND_API_INIT(lps22hh, DT_INST_LABEL(0), lps22hh_init,
-		    &lps22hh_data, &lps22hh_config, POST_KERNEL,
+DEVICE_DEFINE(lps22hh, DT_INST_LABEL(0), lps22hh_init,
+		    device_pm_control_nop, &lps22hh_data, &lps22hh_config,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lps22hh_api_funcs);

--- a/drivers/sensor/lps25hb/lps25hb.c
+++ b/drivers/sensor/lps25hb/lps25hb.c
@@ -187,6 +187,7 @@ static const struct lps25hb_config lps25hb_config = {
 
 static struct lps25hb_data lps25hb_data;
 
-DEVICE_AND_API_INIT(lps25hb, DT_INST_LABEL(0), lps25hb_init,
-		    &lps25hb_data, &lps25hb_config, POST_KERNEL,
+DEVICE_DEFINE(lps25hb, DT_INST_LABEL(0), lps25hb_init,
+		    device_pm_control_nop, &lps25hb_data, &lps25hb_config,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lps25hb_api_funcs);

--- a/drivers/sensor/lsm303dlhc_magn/lsm303dlhc_magn.c
+++ b/drivers/sensor/lsm303dlhc_magn/lsm303dlhc_magn.c
@@ -139,7 +139,8 @@ static const struct lsm303dlhc_magn_config lsm303dlhc_magn_config = {
 
 static struct lsm303dlhc_magn_data lsm303dlhc_magn_driver;
 
-DEVICE_AND_API_INIT(lsm303dlhc_magn, DT_INST_LABEL(0),
-		    lsm303dlhc_magn_init, &lsm303dlhc_magn_driver,
+DEVICE_DEFINE(lsm303dlhc_magn, DT_INST_LABEL(0),
+		    lsm303dlhc_magn_init, device_pm_control_nop,
+		    &lsm303dlhc_magn_driver,
 		    &lsm303dlhc_magn_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lsm303dlhc_magn_driver_api);

--- a/drivers/sensor/lsm6ds0/lsm6ds0.c
+++ b/drivers/sensor/lsm6ds0/lsm6ds0.c
@@ -507,6 +507,7 @@ static const struct lsm6ds0_config lsm6ds0_config = {
 
 static struct lsm6ds0_data lsm6ds0_data;
 
-DEVICE_AND_API_INIT(lsm6ds0, DT_INST_LABEL(0), lsm6ds0_init,
-		    &lsm6ds0_data, &lsm6ds0_config, POST_KERNEL,
+DEVICE_DEFINE(lsm6ds0, DT_INST_LABEL(0), lsm6ds0_init,
+		    device_pm_control_nop, &lsm6ds0_data, &lsm6ds0_config,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lsm6ds0_api_funcs);

--- a/drivers/sensor/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.c
@@ -820,6 +820,7 @@ static int lsm6dsl_init(struct device *dev)
 
 static struct lsm6dsl_data lsm6dsl_data;
 
-DEVICE_AND_API_INIT(lsm6dsl, DT_INST_LABEL(0), lsm6dsl_init,
-		    &lsm6dsl_data, &lsm6dsl_config, POST_KERNEL,
+DEVICE_DEFINE(lsm6dsl, DT_INST_LABEL(0), lsm6dsl_init,
+		    device_pm_control_nop, &lsm6dsl_data, &lsm6dsl_config,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lsm6dsl_api_funcs);

--- a/drivers/sensor/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/lsm6dso/lsm6dso.c
@@ -825,6 +825,7 @@ static int lsm6dso_init(struct device *dev)
 
 static struct lsm6dso_data lsm6dso_data;
 
-DEVICE_AND_API_INIT(lsm6dso, DT_INST_LABEL(0), lsm6dso_init,
-		    &lsm6dso_data, &lsm6dso_config, POST_KERNEL,
+DEVICE_DEFINE(lsm6dso, DT_INST_LABEL(0), lsm6dso_init,
+		    device_pm_control_nop, &lsm6dso_data, &lsm6dso_config,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lsm6dso_api_funcs);

--- a/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro.c
+++ b/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro.c
@@ -357,7 +357,8 @@ static const struct lsm9ds0_gyro_config lsm9ds0_gyro_config = {
 
 static struct lsm9ds0_gyro_data lsm9ds0_gyro_data;
 
-DEVICE_AND_API_INIT(lsm9ds0_gyro, DT_INST_LABEL(0),
-		    lsm9ds0_gyro_init, &lsm9ds0_gyro_data, &lsm9ds0_gyro_config,
+DEVICE_DEFINE(lsm9ds0_gyro, DT_INST_LABEL(0),
+		    lsm9ds0_gyro_init, device_pm_control_nop,
+		    &lsm9ds0_gyro_data, &lsm9ds0_gyro_config,
 		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &lsm9ds0_gyro_api_funcs);

--- a/drivers/sensor/lsm9ds0_mfd/lsm9ds0_mfd.c
+++ b/drivers/sensor/lsm9ds0_mfd/lsm9ds0_mfd.c
@@ -795,6 +795,7 @@ static const struct lsm9ds0_mfd_config lsm9ds0_mfd_config = {
 
 static struct lsm9ds0_mfd_data lsm9ds0_mfd_data;
 
-DEVICE_AND_API_INIT(lsm9ds0_mfd, DT_INST_LABEL(0), lsm9ds0_mfd_init,
-		    &lsm9ds0_mfd_data, &lsm9ds0_mfd_config, POST_KERNEL,
+DEVICE_DEFINE(lsm9ds0_mfd, DT_INST_LABEL(0), lsm9ds0_mfd_init,
+		    device_pm_control_nop, &lsm9ds0_mfd_data,
+		    &lsm9ds0_mfd_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lsm9ds0_mfd_api_funcs);

--- a/drivers/sensor/max30101/max30101.c
+++ b/drivers/sensor/max30101/max30101.c
@@ -246,7 +246,7 @@ static struct max30101_config max30101_config = {
 
 static struct max30101_data max30101_data;
 
-DEVICE_AND_API_INIT(max30101, DT_INST_LABEL(0), max30101_init,
-		    &max30101_data, &max30101_config,
+DEVICE_DEFINE(max30101, DT_INST_LABEL(0), max30101_init,
+		    device_pm_control_nop, &max30101_data, &max30101_config,
 		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &max30101_driver_api);

--- a/drivers/sensor/max44009/max44009.c
+++ b/drivers/sensor/max44009/max44009.c
@@ -185,6 +185,6 @@ int max44009_init(struct device *dev)
 
 static struct max44009_data max44009_drv_data;
 
-DEVICE_AND_API_INIT(max44009, DT_INST_LABEL(0), max44009_init,
-	    &max44009_drv_data, NULL, POST_KERNEL,
+DEVICE_DEFINE(max44009, DT_INST_LABEL(0), max44009_init,
+	    device_pm_control_nop, &max44009_drv_data, NULL, POST_KERNEL,
 	    CONFIG_SENSOR_INIT_PRIORITY, &max44009_driver_api);

--- a/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
+++ b/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
@@ -124,13 +124,14 @@ static const struct sensor_driver_api tach_xec_driver_api = {
 									\
 	static struct tach_xec_data tach_xec_dev_data##id;		\
 									\
-	DEVICE_AND_API_INIT(tach##id,					\
-			    DT_INST_LABEL(id),	\
-			    tach_xec_init,				\
-			    &tach_xec_dev_data##id,			\
-			    &tach_xec_dev_config##id,			\
-			    POST_KERNEL,				\
-			    CONFIG_SENSOR_INIT_PRIORITY,		\
-			    &tach_xec_driver_api);
+	DEVICE_DEFINE(tach##id,						\
+		      DT_INST_LABEL(id),				\
+		      tach_xec_init,					\
+		      device_pm_control_nop,				\
+		      &tach_xec_dev_data##id,				\
+		      &tach_xec_dev_config##id,				\
+		      POST_KERNEL,					\
+		      CONFIG_SENSOR_INIT_PRIORITY,			\
+		      &tach_xec_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(TACH_XEC_DEVICE)

--- a/drivers/sensor/mcp9808/mcp9808.c
+++ b/drivers/sensor/mcp9808/mcp9808.c
@@ -99,6 +99,7 @@ static const struct mcp9808_config mcp9808_cfg = {
 #endif /* CONFIG_MCP9808_TRIGGER */
 };
 
-DEVICE_AND_API_INIT(mcp9808, DT_INST_LABEL(0), mcp9808_init,
-		    &mcp9808_data, &mcp9808_cfg, POST_KERNEL,
+DEVICE_DEFINE(mcp9808, DT_INST_LABEL(0), mcp9808_init,
+		    device_pm_control_nop, &mcp9808_data, &mcp9808_cfg,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &mcp9808_api_funcs);

--- a/drivers/sensor/mpr/mpr.c
+++ b/drivers/sensor/mpr/mpr.c
@@ -132,6 +132,7 @@ static const struct mpr_config mpr_cfg = {
 	.i2c_addr = DT_INST_REG_ADDR(0),
 };
 
-DEVICE_AND_API_INIT(mpr, DT_INST_LABEL(0), mpr_init, &mpr_data,
+DEVICE_DEFINE(mpr, DT_INST_LABEL(0), mpr_init, device_pm_control_nop,
+			&mpr_data,
 			&mpr_cfg, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 			&mpr_api_funcs);

--- a/drivers/sensor/mpu6050/mpu6050.c
+++ b/drivers/sensor/mpu6050/mpu6050.c
@@ -236,7 +236,8 @@ static const struct mpu6050_config mpu6050_cfg = {
 #endif /* CONFIG_MPU6050_TRIGGER */
 };
 
-DEVICE_AND_API_INIT(mpu6050, DT_INST_LABEL(0),
-		    mpu6050_init, &mpu6050_driver, &mpu6050_cfg,
+DEVICE_DEFINE(mpu6050, DT_INST_LABEL(0),
+		    mpu6050_init, device_pm_control_nop, &mpu6050_driver,
+		    &mpu6050_cfg,
 		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &mpu6050_driver_api);

--- a/drivers/sensor/ms5607/ms5607.c
+++ b/drivers/sensor/ms5607/ms5607.c
@@ -326,10 +326,10 @@ static const struct sensor_driver_api ms5607_api_funcs = {
 
 static struct ms5607_data ms5607_data;
 
-DEVICE_AND_API_INIT(ms5607,
+DEVICE_DEFINE(ms5607,
 		    DT_INST_LABEL(0),
 		    ms5607_init,
-		    &ms5607_data,
+		    device_pm_control_nop, &ms5607_data,
 		    &ms5607_config,
 		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY,

--- a/drivers/sensor/ms5837/ms5837.c
+++ b/drivers/sensor/ms5837/ms5837.c
@@ -323,6 +323,7 @@ static const struct ms5837_config ms5837_config = {
 	.i2c_address = DT_INST_REG_ADDR(0)
 };
 
-DEVICE_AND_API_INIT(ms5837, DT_INST_LABEL(0), ms5837_init, &ms5837_data,
+DEVICE_DEFINE(ms5837, DT_INST_LABEL(0), ms5837_init, device_pm_control_nop,
+		    &ms5837_data,
 		    &ms5837_config, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &ms5837_api_funcs);

--- a/drivers/sensor/nrf5/temp_nrf5.c
+++ b/drivers/sensor/nrf5/temp_nrf5.c
@@ -132,10 +132,10 @@ static int temp_nrf5_init(struct device *dev)
 
 static struct temp_nrf5_data temp_nrf5_driver;
 
-DEVICE_AND_API_INIT(temp_nrf5,
+DEVICE_DEFINE(temp_nrf5,
 		    DT_INST_LABEL(0),
 		    temp_nrf5_init,
-		    &temp_nrf5_driver,
+		    device_pm_control_nop, &temp_nrf5_driver,
 		    NULL,
 		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY,

--- a/drivers/sensor/nxp_kinetis_temp/temp_kinetis.c
+++ b/drivers/sensor/nxp_kinetis_temp/temp_kinetis.c
@@ -215,10 +215,11 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) <= 1,
 		},							\
 	};								\
 									\
-	DEVICE_AND_API_INIT(temp_kinetis, DT_INST_LABEL(inst),		\
-			    temp_kinetis_init, &temp_kinetis_data_0,	\
-			    &temp_kinetis_config_0, POST_KERNEL,	\
-			    CONFIG_SENSOR_INIT_PRIORITY,		\
-			    &temp_kinetis_driver_api);
+	DEVICE_DEFINE(temp_kinetis, DT_INST_LABEL(inst),		\
+		      temp_kinetis_init, device_pm_control_nop,		\
+		      &temp_kinetis_data_0,				\
+		      &temp_kinetis_config_0, POST_KERNEL,		\
+		      CONFIG_SENSOR_INIT_PRIORITY,			\
+		      &temp_kinetis_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(TEMP_KINETIS_INIT)

--- a/drivers/sensor/opt3001/opt3001.c
+++ b/drivers/sensor/opt3001/opt3001.c
@@ -163,6 +163,7 @@ int opt3001_init(struct device *dev)
 
 static struct opt3001_data opt3001_drv_data;
 
-DEVICE_AND_API_INIT(opt3001, DT_INST_LABEL(0), opt3001_init,
-		    &opt3001_drv_data, NULL, POST_KERNEL,
+DEVICE_DEFINE(opt3001, DT_INST_LABEL(0), opt3001_init,
+		    device_pm_control_nop, &opt3001_drv_data, NULL,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &opt3001_driver_api);

--- a/drivers/sensor/pms7003/pms7003.c
+++ b/drivers/sensor/pms7003/pms7003.c
@@ -181,6 +181,6 @@ static int pms7003_init(struct device *dev)
 
 static struct pms7003_data pms7003_data;
 
-DEVICE_AND_API_INIT(gts_dev, DT_INST_LABEL(0), &pms7003_init,
-		    &pms7003_data, NULL, POST_KERNEL,
+DEVICE_DEFINE(gts_dev, DT_INST_LABEL(0), &pms7003_init,
+		    device_pm_control_nop, &pms7003_data, NULL, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &pms7003_api);

--- a/drivers/sensor/sht3xd/sht3xd.c
+++ b/drivers/sensor/sht3xd/sht3xd.c
@@ -238,7 +238,8 @@ static const struct sht3xd_config sht3xd0_cfg = {
 #endif
 };
 
-DEVICE_AND_API_INIT(sht3xd0, DT_INST_LABEL(0),
-		    sht3xd_init, &sht3xd0_driver, &sht3xd0_cfg,
+DEVICE_DEFINE(sht3xd0, DT_INST_LABEL(0),
+		    sht3xd_init, device_pm_control_nop, &sht3xd0_driver,
+		    &sht3xd0_cfg,
 		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &sht3xd_driver_api);

--- a/drivers/sensor/si7006/si7006.c
+++ b/drivers/sensor/si7006/si7006.c
@@ -163,5 +163,6 @@ static int si7006_init(struct device *dev)
 
 static struct si7006_data si_data;
 
-DEVICE_AND_API_INIT(si7006, DT_INST_LABEL(0), si7006_init,
-	&si_data, NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &si7006_api);
+DEVICE_DEFINE(si7006, DT_INST_LABEL(0), si7006_init,
+	device_pm_control_nop, &si_data, NULL, POST_KERNEL,
+	CONFIG_SENSOR_INIT_PRIORITY, &si7006_api);

--- a/drivers/sensor/si7060/si7060.c
+++ b/drivers/sensor/si7060/si7060.c
@@ -132,5 +132,6 @@ static int si7060_init(struct device *dev)
 
 static struct si7060_data si_data;
 
-DEVICE_AND_API_INIT(si7060, DT_INST_LABEL(0), si7060_init,
-	&si_data, NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &si7060_api);
+DEVICE_DEFINE(si7060, DT_INST_LABEL(0), si7060_init,
+	device_pm_control_nop, &si_data, NULL, POST_KERNEL,
+	CONFIG_SENSOR_INIT_PRIORITY, &si7060_api);

--- a/drivers/sensor/stts751/stts751.c
+++ b/drivers/sensor/stts751/stts751.c
@@ -212,6 +212,7 @@ static const struct stts751_config stts751_config = {
 #endif
 };
 
-DEVICE_AND_API_INIT(stts751, DT_INST_LABEL(0), stts751_init,
-		    &stts751_data, &stts751_config, POST_KERNEL,
+DEVICE_DEFINE(stts751, DT_INST_LABEL(0), stts751_init,
+		    device_pm_control_nop, &stts751_data, &stts751_config,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &stts751_api_funcs);

--- a/drivers/sensor/sx9500/sx9500.c
+++ b/drivers/sensor/sx9500/sx9500.c
@@ -136,6 +136,7 @@ int sx9500_init(struct device *dev)
 
 struct sx9500_data sx9500_data;
 
-DEVICE_AND_API_INIT(sx9500, DT_INST_LABEL(0), sx9500_init, &sx9500_data,
+DEVICE_DEFINE(sx9500, DT_INST_LABEL(0), sx9500_init, device_pm_control_nop,
+		    &sx9500_data,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &sx9500_api_funcs);

--- a/drivers/sensor/th02/th02.c
+++ b/drivers/sensor/th02/th02.c
@@ -140,6 +140,7 @@ static int th02_init(struct device *dev)
 
 static struct th02_data th02_driver;
 
-DEVICE_AND_API_INIT(th02, DT_INST_LABEL(0), th02_init, &th02_driver,
+DEVICE_DEFINE(th02, DT_INST_LABEL(0), th02_init, device_pm_control_nop,
+		    &th02_driver,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &th02_driver_api);

--- a/drivers/sensor/ti_hdc/ti_hdc.c
+++ b/drivers/sensor/ti_hdc/ti_hdc.c
@@ -179,6 +179,7 @@ static int ti_hdc_init(struct device *dev)
 
 static struct ti_hdc_data ti_hdc_data;
 
-DEVICE_AND_API_INIT(ti_hdc, DT_INST_LABEL(0), ti_hdc_init, &ti_hdc_data,
+DEVICE_DEFINE(ti_hdc, DT_INST_LABEL(0), ti_hdc_init, device_pm_control_nop,
+		    &ti_hdc_data,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &ti_hdc_driver_api);

--- a/drivers/sensor/tmp007/tmp007.c
+++ b/drivers/sensor/tmp007/tmp007.c
@@ -128,7 +128,7 @@ int tmp007_init(struct device *dev)
 
 struct tmp007_data tmp007_driver;
 
-DEVICE_AND_API_INIT(tmp007, DT_INST_LABEL(0), tmp007_init,
-		    &tmp007_driver,
+DEVICE_DEFINE(tmp007, DT_INST_LABEL(0), tmp007_init,
+		    device_pm_control_nop, &tmp007_driver,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &tmp007_driver_api);

--- a/drivers/sensor/tmp112/tmp112.c
+++ b/drivers/sensor/tmp112/tmp112.c
@@ -209,5 +209,7 @@ int tmp112_init(struct device *dev)
 
 static struct tmp112_data tmp112_driver;
 
-DEVICE_AND_API_INIT(tmp112, DT_INST_LABEL(0), tmp112_init, &tmp112_driver,
-	    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &tmp112_driver_api);
+DEVICE_DEFINE(tmp112, DT_INST_LABEL(0), tmp112_init, device_pm_control_nop,
+	      &tmp112_driver,
+	      NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
+	      &tmp112_driver_api);

--- a/drivers/sensor/tmp116/tmp116.c
+++ b/drivers/sensor/tmp116/tmp116.c
@@ -142,6 +142,7 @@ static const struct tmp116_dev_config tmp116_config = {
 	.i2c_addr = DT_INST_REG_ADDR(0),
 };
 
-DEVICE_AND_API_INIT(hdc1080, DT_INST_LABEL(0), tmp116_init,
-		    &tmp116_data, &tmp116_config, POST_KERNEL,
+DEVICE_DEFINE(hdc1080, DT_INST_LABEL(0), tmp116_init,
+		    device_pm_control_nop, &tmp116_data, &tmp116_config,
+		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &tmp116_driver_api);

--- a/drivers/sensor/vl53l0x/vl53l0x.c
+++ b/drivers/sensor/vl53l0x/vl53l0x.c
@@ -282,6 +282,7 @@ static int vl53l0x_init(struct device *dev)
 
 static struct vl53l0x_data vl53l0x_driver;
 
-DEVICE_AND_API_INIT(vl53l0x, DT_INST_LABEL(0), vl53l0x_init, &vl53l0x_driver,
+DEVICE_DEFINE(vl53l0x, DT_INST_LABEL(0), vl53l0x_init, device_pm_control_nop,
+		    &vl53l0x_driver,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &vl53l0x_api_funcs);

--- a/drivers/serial/leuart_gecko.c
+++ b/drivers/serial/leuart_gecko.c
@@ -351,8 +351,9 @@ static const struct leuart_gecko_config leuart_gecko_0_config = {
 
 static struct leuart_gecko_data leuart_gecko_0_data;
 
-DEVICE_AND_API_INIT(leuart_0, DT_INST_LABEL(0),
-		    &leuart_gecko_init, &leuart_gecko_0_data,
+DEVICE_DEFINE(leuart_0, DT_INST_LABEL(0),
+		    &leuart_gecko_init, device_pm_control_nop,
+		    &leuart_gecko_0_data,
 		    &leuart_gecko_0_config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &leuart_gecko_driver_api);
@@ -404,8 +405,9 @@ static const struct leuart_gecko_config leuart_gecko_1_config = {
 
 static struct leuart_gecko_data leuart_gecko_1_data;
 
-DEVICE_AND_API_INIT(leuart_1, DT_INST_LABEL(1),
-		    &leuart_gecko_init, &leuart_gecko_1_data,
+DEVICE_DEFINE(leuart_1, DT_INST_LABEL(1),
+		    &leuart_gecko_init, device_pm_control_nop,
+		    &leuart_gecko_1_data,
 		    &leuart_gecko_1_config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &leuart_gecko_driver_api);

--- a/drivers/serial/uart_altera_jtag_hal.c
+++ b/drivers/serial/uart_altera_jtag_hal.c
@@ -57,8 +57,8 @@ static const struct uart_device_config uart_altera_jtag_dev_cfg_0 = {
 	.sys_clk_freq = 0, /* Unused */
 };
 
-DEVICE_AND_API_INIT(uart_altera_jtag_0, "jtag_uart0",
-		    uart_altera_jtag_init, NULL,
+DEVICE_DEFINE(uart_altera_jtag_0, "jtag_uart0",
+		    uart_altera_jtag_init, device_pm_control_nop, NULL,
 		    &uart_altera_jtag_dev_cfg_0,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_altera_jtag_driver_api);

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -573,8 +573,9 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 		&uart_cc13xx_cc26xx_driver_api)
 
 #define UART_CC13XX_CC26XX_DEVICE_API_INIT(n)				     \
-	DEVICE_AND_API_INIT(uart_cc13xx_cc26xx_##n, DT_INST_LABEL(n),	     \
-		uart_cc13xx_cc26xx_init_##n, &uart_cc13xx_cc26xx_data_##n,   \
+	DEVICE_DEFINE(uart_cc13xx_cc26xx_##n, DT_INST_LABEL(n),		     \
+		uart_cc13xx_cc26xx_init_##n, device_pm_control_nop,	     \
+		&uart_cc13xx_cc26xx_data_##n,				     \
 		&uart_cc13xx_cc26xx_config_##n, PRE_KERNEL_1,		     \
 		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			     \
 		&uart_cc13xx_cc26xx_driver_api)

--- a/drivers/serial/uart_cc32xx.c
+++ b/drivers/serial/uart_cc32xx.c
@@ -316,8 +316,9 @@ static const struct uart_driver_api uart_cc32xx_driver_api = {
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 
-DEVICE_AND_API_INIT(uart_cc32xx_0, DT_INST_LABEL(0),
-		    uart_cc32xx_init, &uart_cc32xx_dev_data_0,
+DEVICE_DEFINE(uart_cc32xx_0, DT_INST_LABEL(0),
+		    uart_cc32xx_init, device_pm_control_nop,
+		    &uart_cc32xx_dev_data_0,
 		    &uart_cc32xx_dev_cfg_0,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    (void *)&uart_cc32xx_driver_api);

--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -482,10 +482,10 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_0 = {
 			.device = DT_INST_REG_ADDR(0),},
 };
 
-DEVICE_AND_API_INIT(uart_cmsdk_apb_0,
+DEVICE_DEFINE(uart_cmsdk_apb_0,
 		    DT_INST_LABEL(0),
 		    &uart_cmsdk_apb_init,
-		    &uart_cmsdk_apb_dev_data_0,
+		    device_pm_control_nop, &uart_cmsdk_apb_dev_data_0,
 		    &uart_cmsdk_apb_dev_cfg_0, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_cmsdk_apb_driver_api);
@@ -547,10 +547,10 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_1 = {
 			.device = DT_INST_REG_ADDR(1),},
 };
 
-DEVICE_AND_API_INIT(uart_cmsdk_apb_1,
+DEVICE_DEFINE(uart_cmsdk_apb_1,
 		    DT_INST_LABEL(1),
 		    &uart_cmsdk_apb_init,
-		    &uart_cmsdk_apb_dev_data_1,
+		    device_pm_control_nop, &uart_cmsdk_apb_dev_data_1,
 		    &uart_cmsdk_apb_dev_cfg_1, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_cmsdk_apb_driver_api);
@@ -612,10 +612,10 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_2 = {
 			.device = DT_INST_REG_ADDR(2),},
 };
 
-DEVICE_AND_API_INIT(uart_cmsdk_apb_2,
+DEVICE_DEFINE(uart_cmsdk_apb_2,
 		    DT_INST_LABEL(2),
 		    &uart_cmsdk_apb_init,
-		    &uart_cmsdk_apb_dev_data_2,
+		    device_pm_control_nop, &uart_cmsdk_apb_dev_data_2,
 		    &uart_cmsdk_apb_dev_cfg_2, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_cmsdk_apb_driver_api);
@@ -677,10 +677,10 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_3 = {
 			.device = DT_INST_REG_ADDR(3),},
 };
 
-DEVICE_AND_API_INIT(uart_cmsdk_apb_3,
+DEVICE_DEFINE(uart_cmsdk_apb_3,
 		    DT_INST_LABEL(3),
 		    &uart_cmsdk_apb_init,
-		    &uart_cmsdk_apb_dev_data_3,
+		    device_pm_control_nop, &uart_cmsdk_apb_dev_data_3,
 		    &uart_cmsdk_apb_dev_cfg_3, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_cmsdk_apb_driver_api);
@@ -742,10 +742,10 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_4 = {
 			.device = DT_INST_REG_ADDR(4),},
 };
 
-DEVICE_AND_API_INIT(uart_cmsdk_apb_4,
+DEVICE_DEFINE(uart_cmsdk_apb_4,
 		    DT_INST_LABEL(4),
 		    &uart_cmsdk_apb_init,
-		    &uart_cmsdk_apb_dev_data_4,
+		    device_pm_control_nop, &uart_cmsdk_apb_dev_data_4,
 		    &uart_cmsdk_apb_dev_cfg_4, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_cmsdk_apb_driver_api);

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -528,14 +528,15 @@ static struct uart_esp32_data uart_esp32_data_##idx = {			       \
 	}								       \
 };									       \
 									       \
-DEVICE_AND_API_INIT(uart_esp32_##idx,					       \
-		    DT_INST_LABEL(idx),		       \
-		    uart_esp32_init,					       \
-		    &uart_esp32_data_##idx,				       \
-		    &uart_esp32_cfg_port_##idx,				       \
-		    PRE_KERNEL_1,					       \
-		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			       \
-		    &uart_esp32_api);					       \
+DEVICE_DEFINE(uart_esp32_##idx,						       \
+	      DT_INST_LABEL(idx),					       \
+	      uart_esp32_init,						       \
+	      device_pm_control_nop,					       \
+	      &uart_esp32_data_##idx,					       \
+	      &uart_esp32_cfg_port_##idx,				       \
+	      PRE_KERNEL_1,						       \
+	      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			       \
+	      &uart_esp32_api);						       \
 									       \
 ESP32_UART_IRQ_HANDLER(idx)
 

--- a/drivers/serial/uart_gecko.c
+++ b/drivers/serial/uart_gecko.c
@@ -337,8 +337,9 @@ static const struct uart_gecko_config uart_gecko_0_config = {
 
 static struct uart_gecko_data uart_gecko_0_data;
 
-DEVICE_AND_API_INIT(uart_0, DT_INST_LABEL(0), &uart_gecko_init,
-		    &uart_gecko_0_data, &uart_gecko_0_config, PRE_KERNEL_1,
+DEVICE_DEFINE(uart_0, DT_INST_LABEL(0), &uart_gecko_init,
+		    device_pm_control_nop, &uart_gecko_0_data,
+		    &uart_gecko_0_config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &uart_gecko_driver_api);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
@@ -392,8 +393,9 @@ static const struct uart_gecko_config uart_gecko_1_config = {
 
 static struct uart_gecko_data uart_gecko_1_data;
 
-DEVICE_AND_API_INIT(uart_1, DT_INST_LABEL(1), &uart_gecko_init,
-		    &uart_gecko_1_data, &uart_gecko_1_config, PRE_KERNEL_1,
+DEVICE_DEFINE(uart_1, DT_INST_LABEL(1), &uart_gecko_init,
+		    device_pm_control_nop, &uart_gecko_1_data,
+		    &uart_gecko_1_config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &uart_gecko_driver_api);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
@@ -450,8 +452,9 @@ static const struct uart_gecko_config usart_gecko_0_config = {
 
 static struct uart_gecko_data usart_gecko_0_data;
 
-DEVICE_AND_API_INIT(usart_0, DT_INST_LABEL(0),
-		    &uart_gecko_init, &usart_gecko_0_data,
+DEVICE_DEFINE(usart_0, DT_INST_LABEL(0),
+		    &uart_gecko_init, device_pm_control_nop,
+		    &usart_gecko_0_data,
 		    &usart_gecko_0_config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &uart_gecko_driver_api);
 
@@ -506,8 +509,9 @@ static const struct uart_gecko_config usart_gecko_1_config = {
 
 static struct uart_gecko_data usart_gecko_1_data;
 
-DEVICE_AND_API_INIT(usart_1, DT_INST_LABEL(1),
-		    &uart_gecko_init, &usart_gecko_1_data,
+DEVICE_DEFINE(usart_1, DT_INST_LABEL(1),
+		    &uart_gecko_init, device_pm_control_nop,
+		    &usart_gecko_1_data,
 		    &usart_gecko_1_config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &uart_gecko_driver_api);
 
@@ -562,8 +566,9 @@ static const struct uart_gecko_config usart_gecko_2_config = {
 
 static struct uart_gecko_data usart_gecko_2_data;
 
-DEVICE_AND_API_INIT(usart_2, DT_INST_LABEL(2),
-		    &uart_gecko_init, &usart_gecko_2_data,
+DEVICE_DEFINE(usart_2, DT_INST_LABEL(2),
+		    &uart_gecko_init, device_pm_control_nop,
+		    &usart_gecko_2_data,
 		    &usart_gecko_2_config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &uart_gecko_driver_api);
 
@@ -618,8 +623,9 @@ static const struct uart_gecko_config usart_gecko_3_config = {
 
 static struct uart_gecko_data usart_gecko_3_data;
 
-DEVICE_AND_API_INIT(usart_3, DT_INST_LABEL(3),
-		    &uart_gecko_init, &usart_gecko_3_data,
+DEVICE_DEFINE(usart_3, DT_INST_LABEL(3),
+		    &uart_gecko_init, device_pm_control_nop,
+		    &usart_gecko_3_data,
 		    &usart_gecko_3_config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &uart_gecko_driver_api);
 
@@ -674,8 +680,9 @@ static const struct uart_gecko_config usart_gecko_4_config = {
 
 static struct uart_gecko_data usart_gecko_4_data;
 
-DEVICE_AND_API_INIT(usart_4, DT_INST_LABEL(4),
-		    &uart_gecko_init, &usart_gecko_4_data,
+DEVICE_DEFINE(usart_4, DT_INST_LABEL(4),
+		    &uart_gecko_init, device_pm_control_nop,
+		    &usart_gecko_4_data,
 		    &usart_gecko_4_config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &uart_gecko_driver_api);
 
@@ -730,8 +737,9 @@ static const struct uart_gecko_config usart_gecko_5_config = {
 
 static struct uart_gecko_data usart_gecko_5_data;
 
-DEVICE_AND_API_INIT(usart_5, DT_INST_LABEL(5),
-		    &uart_gecko_init, &usart_gecko_5_data,
+DEVICE_DEFINE(usart_5, DT_INST_LABEL(5),
+		    &uart_gecko_init, device_pm_control_nop,
+		    &usart_gecko_5_data,
 		    &usart_gecko_5_config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &uart_gecko_driver_api);
 

--- a/drivers/serial/uart_imx.c
+++ b/drivers/serial/uart_imx.c
@@ -316,11 +316,12 @@ static const struct uart_driver_api uart_imx_driver_api = {
 									\
 	static const struct imx_uart_config imx_uart_##n##_config;	\
 									\
-	DEVICE_AND_API_INIT(uart_##n, DT_INST_LABEL(n), &uart_imx_init,	\
-			&imx_uart_##n##_data, &imx_uart_##n##_config,	\
-			PRE_KERNEL_1,					\
-			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			&uart_imx_driver_api);				\
+	DEVICE_DEFINE(uart_##n, DT_INST_LABEL(n), &uart_imx_init,	\
+		      device_pm_control_nop,				\
+		      &imx_uart_##n##_data, &imx_uart_##n##_config,	\
+		      PRE_KERNEL_1,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &uart_imx_driver_api);				\
 									\
 	UART_IMX_CONFIG_FUNC(n)						\
 									\

--- a/drivers/serial/uart_liteuart.c
+++ b/drivers/serial/uart_liteuart.c
@@ -318,9 +318,10 @@ static const struct uart_liteuart_device_config uart_liteuart_dev_cfg_0 = {
 	.baud_rate	= DT_INST_PROP(0, current_speed)
 };
 
-DEVICE_AND_API_INIT(uart_liteuart_0, DT_INST_LABEL(0),
+DEVICE_DEFINE(uart_liteuart_0, DT_INST_LABEL(0),
 		uart_liteuart_init,
-		&uart_liteuart_data_0, &uart_liteuart_dev_cfg_0,
+		device_pm_control_nop, &uart_liteuart_data_0,
+		&uart_liteuart_dev_cfg_0,
 		PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		(void *)&uart_liteuart_driver_api);
 

--- a/drivers/serial/uart_mcux.c
+++ b/drivers/serial/uart_mcux.c
@@ -328,13 +328,14 @@ static const struct uart_mcux_config uart_mcux_##n##_config = {		\
 									\
 	static const struct uart_mcux_config uart_mcux_##n##_config;	\
 									\
-	DEVICE_AND_API_INIT(uart_##n, DT_INST_LABEL(n),			\
-			    &uart_mcux_init,				\
-			    &uart_mcux_##n##_data,			\
-			    &uart_mcux_##n##_config,			\
-			    PRE_KERNEL_1,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &uart_mcux_driver_api);			\
+	DEVICE_DEFINE(uart_##n, DT_INST_LABEL(n),			\
+		      &uart_mcux_init,					\
+		      device_pm_control_nop,				\
+		      &uart_mcux_##n##_data,				\
+		      &uart_mcux_##n##_config,				\
+		      PRE_KERNEL_1,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &uart_mcux_driver_api);				\
 									\
 	UART_MCUX_CONFIG_FUNC(n)					\
 									\

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -323,13 +323,14 @@ static const struct mcux_flexcomm_config mcux_flexcomm_##n##_config = {	\
 									\
 	static const struct mcux_flexcomm_config mcux_flexcomm_##n##_config;\
 									\
-	DEVICE_AND_API_INIT(uart_##n, DT_INST_LABEL(n),			\
-			    &mcux_flexcomm_init,			\
-			    &mcux_flexcomm_##n##_data,			\
-			    &mcux_flexcomm_##n##_config,		\
-			    PRE_KERNEL_1,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &mcux_flexcomm_driver_api);			\
+	DEVICE_DEFINE(uart_##n, DT_INST_LABEL(n),			\
+		      &mcux_flexcomm_init,				\
+		      device_pm_control_nop,				\
+		      &mcux_flexcomm_##n##_data,			\
+		      &mcux_flexcomm_##n##_config,			\
+		      PRE_KERNEL_1,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &mcux_flexcomm_driver_api);			\
 									\
 	UART_MCUX_FLEXCOMM_CONFIG_FUNC(n)				\
 									\

--- a/drivers/serial/uart_mcux_lpsci.c
+++ b/drivers/serial/uart_mcux_lpsci.c
@@ -320,13 +320,14 @@ static const struct mcux_lpsci_config mcux_lpsci_##n##_config = {	\
 									\
 	static const struct mcux_lpsci_config mcux_lpsci_##n##_config;	\
 									\
-	DEVICE_AND_API_INIT(uart_##n, DT_INST_LABEL(n),			\
-			    &mcux_lpsci_init,				\
-			    &mcux_lpsci_##n##_data,			\
-			    &mcux_lpsci_##n##_config,			\
-			    PRE_KERNEL_1,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &mcux_lpsci_driver_api);			\
+	DEVICE_DEFINE(uart_##n, DT_INST_LABEL(n),			\
+		      &mcux_lpsci_init,					\
+		      device_pm_control_nop,				\
+		      &mcux_lpsci_##n##_data,				\
+		      &mcux_lpsci_##n##_config,				\
+		      PRE_KERNEL_1,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &mcux_lpsci_driver_api);				\
 									\
 	MCUX_LPSCI_CONFIG_FUNC(n)					\
 									\

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -328,13 +328,14 @@ static const struct mcux_lpuart_config mcux_lpuart_##n##_config = {	\
 									\
 	static const struct mcux_lpuart_config mcux_lpuart_##n##_config;\
 									\
-	DEVICE_AND_API_INIT(uart_##n, DT_INST_LABEL(n),			\
-			    &mcux_lpuart_init,				\
-			    &mcux_lpuart_##n##_data,			\
-			    &mcux_lpuart_##n##_config,			\
-			    PRE_KERNEL_1,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &mcux_lpuart_driver_api);			\
+	DEVICE_DEFINE(uart_##n, DT_INST_LABEL(n),			\
+		      &mcux_lpuart_init,				\
+		      device_pm_control_nop,				\
+		      &mcux_lpuart_##n##_data,				\
+		      &mcux_lpuart_##n##_config,			\
+		      PRE_KERNEL_1,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &mcux_lpuart_driver_api);				\
 									\
 	LPUART_MCUX_CONFIG_FUNC(n)					\
 									\

--- a/drivers/serial/uart_miv.c
+++ b/drivers/serial/uart_miv.c
@@ -403,8 +403,9 @@ static const struct uart_miv_device_config uart_miv_dev_cfg_0 = {
 #endif
 };
 
-DEVICE_AND_API_INIT(uart_miv_0, DT_INST_LABEL(0),
-		    uart_miv_init, &uart_miv_data_0, &uart_miv_dev_cfg_0,
+DEVICE_DEFINE(uart_miv_0, DT_INST_LABEL(0),
+		    uart_miv_init, device_pm_control_nop, &uart_miv_data_0,
+		    &uart_miv_dev_cfg_0,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    (void *)&uart_miv_driver_api);
 

--- a/drivers/serial/uart_msp432p4xx.c
+++ b/drivers/serial/uart_msp432p4xx.c
@@ -360,8 +360,9 @@ static const struct uart_driver_api uart_msp432p4xx_driver_api = {
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 
-DEVICE_AND_API_INIT(uart_msp432p4xx_0, DT_INST_LABEL(0),
-			uart_msp432p4xx_init, &uart_msp432p4xx_dev_data_0,
+DEVICE_DEFINE(uart_msp432p4xx_0, DT_INST_LABEL(0),
+			uart_msp432p4xx_init, device_pm_control_nop,
+			&uart_msp432p4xx_dev_data_0,
 			&uart_msp432p4xx_dev_cfg_0,
 			PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 			(void *)&uart_msp432p4xx_driver_api);

--- a/drivers/serial/uart_native_posix.c
+++ b/drivers/serial/uart_native_posix.c
@@ -338,16 +338,16 @@ static int np_uart_tty_poll_in(struct device *dev, unsigned char *p_char)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(uart_native_posix0,
+DEVICE_DEFINE(uart_native_posix0,
 	    DT_INST_LABEL(0), &np_uart_0_init,
-	    (void *)&native_uart_status_0, NULL,
+	    device_pm_control_nop, (void *)&native_uart_status_0, NULL,
 	    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 	    &np_uart_driver_api_0);
 
 #if defined(CONFIG_UART_NATIVE_POSIX_PORT_1_ENABLE)
-DEVICE_AND_API_INIT(uart_native_posix1,
+DEVICE_DEFINE(uart_native_posix1,
 	    CONFIG_UART_NATIVE_POSIX_PORT_1_NAME, &np_uart_1_init,
-	    (void *)&native_uart_status_1, NULL,
+	    device_pm_control_nop, (void *)&native_uart_status_1, NULL,
 	    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 	    &np_uart_driver_api_1);
 #endif /* CONFIG_UART_NATIVE_POSIX_PORT_1_ENABLE */

--- a/drivers/serial/uart_ns16550_port_x.h
+++ b/drivers/serial/uart_ns16550_port_x.h
@@ -49,11 +49,11 @@ static struct uart_ns16550_dev_data_t uart_ns16550_dev_data_@NUM@ = {
 #endif
 };
 
-DEVICE_AND_API_INIT(uart_ns16550_@NUM@, DT_INST_LABEL(@NUM@),
-		    &uart_ns16550_init,
-		    &uart_ns16550_dev_data_@NUM@, &uart_ns16550_dev_cfg_@NUM@,
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-		    &uart_ns16550_driver_api);
+DEVICE_DEFINE(uart_ns16550_@NUM@, DT_INST_LABEL(@NUM@),
+	      &uart_ns16550_init, device_pm_control_nop,
+	      &uart_ns16550_dev_data_@NUM@, &uart_ns16550_dev_cfg_@NUM@,
+	      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+	      &uart_ns16550_driver_api);
 
 #if DT_INST_IRQ_HAS_CELL(@NUM@, sense)
 #define INST_@NUM@_IRQ_FLAGS  DT_INST_IRQ(@NUM@, sense)

--- a/drivers/serial/uart_nsim.c
+++ b/drivers/serial/uart_nsim.c
@@ -113,7 +113,7 @@ static struct uart_device_config uart_nsim_dev_cfg_0 = {
 	.regs = DT_INST_REG_ADDR(0),
 };
 
-DEVICE_AND_API_INIT(uart_nsim0, DT_INST_LABEL(0), &uart_nsim_init,
-			NULL, &uart_nsim_dev_cfg_0,
+DEVICE_DEFINE(uart_nsim0, DT_INST_LABEL(0), &uart_nsim_init,
+			device_pm_control_nop, NULL, &uart_nsim_dev_cfg_0,
 			PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 			&uart_nsim_driver_api);

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -426,10 +426,10 @@ static struct pl011_data pl011_data_port_0 = {
 	.baud_rate = DT_INST_PROP(0, current_speed),
 };
 
-DEVICE_AND_API_INIT(pl011_port_0,
+DEVICE_DEFINE(pl011_port_0,
 		    DT_INST_LABEL(0),
 		    &pl011_init,
-		    &pl011_data_port_0,
+		    device_pm_control_nop, &pl011_data_port_0,
 		    &pl011_cfg_port_0, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &pl011_driver_api);
@@ -489,10 +489,10 @@ static struct pl011_data pl011_data_port_1 = {
 	.baud_rate = DT_INST_PROP(1, current_speed),
 };
 
-DEVICE_AND_API_INIT(pl011_port_1,
+DEVICE_DEFINE(pl011_port_1,
 		    DT_INST_LABEL(1),
 		    &pl011_init,
-		    &pl011_data_port_1,
+		    device_pm_control_nop, &pl011_data_port_1,
 		    &pl011_cfg_port_1, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &pl011_driver_api);

--- a/drivers/serial/uart_psoc6.c
+++ b/drivers/serial/uart_psoc6.c
@@ -158,8 +158,8 @@ static const struct cypress_psoc6_config cypress_psoc6_uart5_config = {
 	.scb_clock = PCLK_SCB5_CLOCK,
 };
 
-DEVICE_AND_API_INIT(uart_5, DT_LABEL(DT_NODELABEL(uart5)),
-			uart_psoc6_init, NULL,
+DEVICE_DEFINE(uart_5, DT_LABEL(DT_NODELABEL(uart5)),
+			uart_psoc6_init, device_pm_control_nop, NULL,
 			&cypress_psoc6_uart5_config,
 			PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 			(void *)&uart_psoc6_driver_api);
@@ -176,8 +176,8 @@ static const struct cypress_psoc6_config cypress_psoc6_uart6_config = {
 	.scb_clock = PCLK_SCB6_CLOCK,
 };
 
-DEVICE_AND_API_INIT(uart_6, DT_LABEL(DT_NODELABEL(uart6)),
-			uart_psoc6_init, NULL,
+DEVICE_DEFINE(uart_6, DT_LABEL(DT_NODELABEL(uart6)),
+			uart_psoc6_init, device_pm_control_nop, NULL,
 			&cypress_psoc6_uart6_config,
 			PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 			(void *)&uart_psoc6_driver_api);

--- a/drivers/serial/uart_rtt.c
+++ b/drivers/serial/uart_rtt.c
@@ -103,10 +103,11 @@ DEVICE_DEFINE(uart_rtt0, "RTT_0", uart_rtt_init, device_pm_control_nop, NULL,
 		.down_size = sizeof(uart_rtt##n##_rx_buffer),                  \
 	};                                                                     \
 									       \
-	DEVICE_AND_API_INIT(uart_rtt##n, uart_rtt##n##_name, uart_rtt_init,    \
-			    NULL, &uart_rtt##n##_config, PRE_KERNEL_2,         \
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,                \
-			    &uart_rtt_driver_api)
+	DEVICE_DEFINE(uart_rtt##n, uart_rtt##n##_name, uart_rtt_init,	       \
+		      device_pm_control_nop,				       \
+		      NULL, &uart_rtt##n##_config, PRE_KERNEL_2,	       \
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		       \
+		      &uart_rtt_driver_api)
 
 #if CONFIG_UART_RTT_1
 UART_RTT_CHANNEL(1);

--- a/drivers/serial/uart_rtt.c
+++ b/drivers/serial/uart_rtt.c
@@ -79,7 +79,8 @@ static const struct uart_driver_api uart_rtt_driver_api = {
 
 #if CONFIG_UART_RTT_0
 
-DEVICE_AND_API_INIT(uart_rtt0, "RTT_0", uart_rtt_init, NULL, NULL,
+DEVICE_DEFINE(uart_rtt0, "RTT_0", uart_rtt_init, device_pm_control_nop, NULL,
+		    NULL,
 		    /* Initialize UART device after RTT init. */
 		    PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_rtt_driver_api);

--- a/drivers/serial/uart_rv32m1_lpuart.c
+++ b/drivers/serial/uart_rv32m1_lpuart.c
@@ -334,13 +334,14 @@ static const struct uart_driver_api rv32m1_lpuart_driver_api = {
 									\
 	static const struct rv32m1_lpuart_config rv32m1_lpuart_##n##_cfg;\
 									\
-	DEVICE_AND_API_INIT(uart_##n, DT_INST_LABEL(n),			\
-			    &rv32m1_lpuart_init,			\
-			    &rv32m1_lpuart_##n##_data,			\
-			    &rv32m1_lpuart_##n##_cfg,			\
-			    PRE_KERNEL_1,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &rv32m1_lpuart_driver_api);			\
+	DEVICE_DEFINE(uart_##n, DT_INST_LABEL(n),			\
+		      &rv32m1_lpuart_init,				\
+		      device_pm_control_nop,				\
+		      &rv32m1_lpuart_##n##_data,			\
+		      &rv32m1_lpuart_##n##_cfg,				\
+		      PRE_KERNEL_1,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &rv32m1_lpuart_driver_api);			\
 									\
 	RV32M1_LPUART_CONFIG_FUNC(n)					\
 									\

--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -361,11 +361,12 @@ static const struct uart_driver_api uart_sam_driver_api = {
 									\
 	static const struct uart_sam_dev_cfg uart##n##_sam_config;	\
 									\
-	DEVICE_AND_API_INIT(uart##n##_sam, DT_INST_LABEL(n),		\
-			    &uart_sam_init, &uart##n##_sam_data,	\
-			    &uart##n##_sam_config, PRE_KERNEL_1,	\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &uart_sam_driver_api);			\
+	DEVICE_DEFINE(uart##n##_sam, DT_INST_LABEL(n),			\
+		      &uart_sam_init, device_pm_control_nop,		\
+		      &uart##n##_sam_data,				\
+		      &uart##n##_sam_config, PRE_KERNEL_1,		\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &uart_sam_driver_api);				\
 									\
 	UART_SAM_CONFIG_FUNC(n)						\
 									\

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -1129,11 +1129,12 @@ static const struct uart_sam0_dev_cfg uart_sam0_config_##n = {		\
 static struct uart_sam0_dev_data uart_sam0_data_##n;			\
 UART_SAM0_IRQ_HANDLER_DECL(n);						\
 UART_SAM0_CONFIG_DEFN(n);						\
-DEVICE_AND_API_INIT(uart_sam0_##n, DT_INST_LABEL(n),			\
-		    uart_sam0_init, &uart_sam0_data_##n,		\
-		    &uart_sam0_config_##n, PRE_KERNEL_1,		\
-		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			\
-		    &uart_sam0_driver_api);				\
+DEVICE_DEFINE(uart_sam0_##n, DT_INST_LABEL(n),				\
+	      uart_sam0_init, device_pm_control_nop,			\
+	      &uart_sam0_data_##n,					\
+	      &uart_sam0_config_##n, PRE_KERNEL_1,			\
+	      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			\
+	      &uart_sam0_driver_api);					\
 UART_SAM0_IRQ_HANDLER(n)
 
 DT_INST_FOREACH_STATUS_OKAY(UART_SAM0_DEVICE_INIT)

--- a/drivers/serial/uart_sifive.c
+++ b/drivers/serial/uart_sifive.c
@@ -393,9 +393,10 @@ static const struct uart_sifive_device_config uart_sifive_dev_cfg_0 = {
 #endif
 };
 
-DEVICE_AND_API_INIT(uart_sifive_0, DT_INST_LABEL(0),
+DEVICE_DEFINE(uart_sifive_0, DT_INST_LABEL(0),
 		    uart_sifive_init,
-		    &uart_sifive_data_0, &uart_sifive_dev_cfg_0,
+		    device_pm_control_nop, &uart_sifive_data_0,
+		    &uart_sifive_dev_cfg_0,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    (void *)&uart_sifive_driver_api);
 
@@ -432,9 +433,10 @@ static const struct uart_sifive_device_config uart_sifive_dev_cfg_1 = {
 #endif
 };
 
-DEVICE_AND_API_INIT(uart_sifive_1, DT_INST_LABEL(1),
+DEVICE_DEFINE(uart_sifive_1, DT_INST_LABEL(1),
 		    uart_sifive_init,
-		    &uart_sifive_data_1, &uart_sifive_dev_cfg_1,
+		    device_pm_control_nop, &uart_sifive_data_1,
+		    &uart_sifive_dev_cfg_1,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    (void *)&uart_sifive_driver_api);
 

--- a/drivers/serial/uart_stellaris.c
+++ b/drivers/serial/uart_stellaris.c
@@ -647,9 +647,10 @@ static struct uart_stellaris_dev_data_t uart_stellaris_dev_data_0 = {
 	.baud_rate = DT_INST_PROP(0, current_speed),
 };
 
-DEVICE_AND_API_INIT(uart_stellaris0, DT_INST_LABEL(0),
+DEVICE_DEFINE(uart_stellaris0, DT_INST_LABEL(0),
 		    &uart_stellaris_init,
-		    &uart_stellaris_dev_data_0, &uart_stellaris_dev_cfg_0,
+		    device_pm_control_nop, &uart_stellaris_dev_data_0,
+		    &uart_stellaris_dev_cfg_0,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_stellaris_driver_api);
 
@@ -685,9 +686,10 @@ static struct uart_stellaris_dev_data_t uart_stellaris_dev_data_1 = {
 	.baud_rate = DT_INST_PROP(1, current_speed),
 };
 
-DEVICE_AND_API_INIT(uart_stellaris1, DT_INST_LABEL(1),
+DEVICE_DEFINE(uart_stellaris1, DT_INST_LABEL(1),
 		    &uart_stellaris_init,
-		    &uart_stellaris_dev_data_1, &uart_stellaris_dev_cfg_1,
+		    device_pm_control_nop, &uart_stellaris_dev_data_1,
+		    &uart_stellaris_dev_cfg_1,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_stellaris_driver_api);
 
@@ -723,9 +725,10 @@ static struct uart_stellaris_dev_data_t uart_stellaris_dev_data_2 = {
 	.baud_rate = DT_INST_PROP(2, current_speed),
 };
 
-DEVICE_AND_API_INIT(uart_stellaris2, DT_INST_LABEL(2),
+DEVICE_DEFINE(uart_stellaris2, DT_INST_LABEL(2),
 		    &uart_stellaris_init,
-		    &uart_stellaris_dev_data_2, &uart_stellaris_dev_cfg_2,
+		    device_pm_control_nop, &uart_stellaris_dev_data_2,
+		    &uart_stellaris_dev_cfg_2,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_stellaris_driver_api);
 

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -770,11 +770,11 @@ static struct uart_stm32_data uart_stm32_data_##index = {		\
 	.baud_rate = DT_INST_PROP(index, current_speed)	\
 };									\
 									\
-DEVICE_AND_API_INIT(uart_stm32_##index, DT_INST_LABEL(index),\
-		    &uart_stm32_init,					\
-		    &uart_stm32_data_##index, &uart_stm32_cfg_##index,	\
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
-		    &uart_stm32_driver_api);				\
+DEVICE_DEFINE(uart_stm32_##index, DT_INST_LABEL(index),			\
+	      &uart_stm32_init, device_pm_control_nop,			\
+	      &uart_stm32_data_##index, &uart_stm32_cfg_##index,	\
+	      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+	      &uart_stm32_driver_api);					\
 									\
 STM32_UART_IRQ_HANDLER(index)
 

--- a/drivers/serial/uart_xlnx_ps.c
+++ b/drivers/serial/uart_xlnx_ps.c
@@ -1206,8 +1206,8 @@ static struct uart_xlnx_ps_dev_config uart_xlnx_ps_dev_cfg_##port = { \
 }
 
 #define UART_XLNX_PS_INIT(port) \
-DEVICE_AND_API_INIT(uart_xlnx_ps_##port, DT_INST_LABEL(port), \
-	uart_xlnx_ps_init, \
+DEVICE_DEFINE(uart_xlnx_ps_##port, DT_INST_LABEL(port), \
+	uart_xlnx_ps_init, device_pm_control_nop, \
 	&uart_xlnx_ps_dev_data_##port, \
 	&uart_xlnx_ps_dev_cfg_##port, \
 	PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \

--- a/drivers/serial/uart_xmc4xxx.c
+++ b/drivers/serial/uart_xmc4xxx.c
@@ -73,10 +73,11 @@ static const struct uart_device_config xmc4xxx_config_##index = {	\
 	.base = (void *)DT_INST_REG_ADDR(index),			\
 };									\
 									\
-	DEVICE_AND_API_INIT(uart_xmc4xxx_##index, DT_INST_LABEL(index),	\
-			    &uart_xmc4xxx_init, &xmc4xxx_data_##index,	\
-			    &xmc4xxx_config_##index, PRE_KERNEL_1,	\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &uart_xmc4xxx_driver_api);
+	DEVICE_DEFINE(uart_xmc4xxx_##index, DT_INST_LABEL(index),	\
+		      &uart_xmc4xxx_init, device_pm_control_nop,	\
+		      &xmc4xxx_data_##index,				\
+		      &xmc4xxx_config_##index, PRE_KERNEL_1,		\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &uart_xmc4xxx_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(XMC4XXX_INIT)

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -362,11 +362,12 @@ static const struct uart_driver_api usart_sam_driver_api = {
 									\
 	static const struct usart_sam_dev_cfg usart##n##_sam_config;	\
 									\
-	DEVICE_AND_API_INIT(usart##n##_sam, DT_INST_LABEL(n),		\
-			    &usart_sam_init, &usart##n##_sam_data,	\
-			    &usart##n##_sam_config, PRE_KERNEL_1,	\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &usart_sam_driver_api);			\
+	DEVICE_DEFINE(usart##n##_sam, DT_INST_LABEL(n),			\
+		      &usart_sam_init, device_pm_control_nop,		\
+		      &usart##n##_sam_data,				\
+		      &usart##n##_sam_config, PRE_KERNEL_1,		\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &usart_sam_driver_api);				\
 									\
 	USART_SAM_CONFIG_FUNC(n)					\
 									\

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -342,8 +342,9 @@ static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 	} while (0)
 #else
 #define SPI_CC13XX_CC26XX_DEVICE_INIT(n)				    \
-	DEVICE_AND_API_INIT(spi_cc13xx_cc26xx_##n, DT_INST_LABEL(n),	    \
-		    spi_cc13xx_cc26xx_init_##n, &spi_cc13xx_cc26xx_data_##n,\
+	DEVICE_DEFINE(spi_cc13xx_cc26xx_##n, DT_INST_LABEL(n),		    \
+		    spi_cc13xx_cc26xx_init_##n, device_pm_control_nop,	    \
+		    &spi_cc13xx_cc26xx_data_##n,			    \
 		    &spi_cc13xx_cc26xx_config_##n, POST_KERNEL,		    \
 		    CONFIG_SPI_INIT_PRIORITY,				    \
 		    &spi_cc13xx_cc26xx_driver_api)

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -564,8 +564,9 @@ const struct spi_dw_config spi_dw_config_0 = {
 	.op_modes = CONFIG_SPI_0_OP_MODES
 };
 
-DEVICE_AND_API_INIT(spi_dw_port_0, DT_INST_LABEL(0),
-		    spi_dw_init, &spi_dw_data_port_0, &spi_dw_config_0,
+DEVICE_DEFINE(spi_dw_port_0, DT_INST_LABEL(0),
+		    spi_dw_init, device_pm_control_nop, &spi_dw_data_port_0,
+		    &spi_dw_config_0,
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
 		    &dw_spi_api);
 
@@ -630,8 +631,9 @@ static const struct spi_dw_config spi_dw_config_1 = {
 	.op_modes = CONFIG_SPI_1_OP_MODES
 };
 
-DEVICE_AND_API_INIT(spi_dw_port_1, DT_INST_LABEL(1),
-		    spi_dw_init, &spi_dw_data_port_1, &spi_dw_config_1,
+DEVICE_DEFINE(spi_dw_port_1, DT_INST_LABEL(1),
+		    spi_dw_init, device_pm_control_nop, &spi_dw_data_port_1,
+		    &spi_dw_config_1,
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
 		    &dw_spi_api);
 
@@ -696,8 +698,9 @@ static const struct spi_dw_config spi_dw_config_2 = {
 	.op_modes = CONFIG_SPI_2_OP_MODES
 };
 
-DEVICE_AND_API_INIT(spi_dw_port_2, DT_INST_LABEL(2),
-		    spi_dw_init, &spi_dw_data_port_2, &spi_dw_config_2,
+DEVICE_DEFINE(spi_dw_port_2, DT_INST_LABEL(2),
+		    spi_dw_init, device_pm_control_nop, &spi_dw_data_port_2,
+		    &spi_dw_config_2,
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
 		    &dw_spi_api);
 
@@ -762,8 +765,9 @@ static const struct spi_dw_config spi_dw_config_3 = {
 	.op_modes = CONFIG_SPI_3_OP_MODES
 };
 
-DEVICE_AND_API_INIT(spi_dw_port_3, DT_INST_LABEL(3),
-		    spi_dw_init, &spi_dw_data_port_3, &spi_dw_config_3,
+DEVICE_DEFINE(spi_dw_port_3, DT_INST_LABEL(3),
+		    spi_dw_init, device_pm_control_nop, &spi_dw_data_port_3,
+		    &spi_dw_config_3,
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
 		    &dw_spi_api);
 

--- a/drivers/spi/spi_gecko.c
+++ b/drivers/spi/spi_gecko.c
@@ -308,14 +308,15 @@ static struct spi_driver_api spi_gecko_api = {
 	    .loc_tx = DT_INST_PROP_BY_IDX(n, location_tx, 0), \
 	    .loc_clk = DT_INST_PROP_BY_IDX(n, location_clk, 0), \
 	}; \
-	DEVICE_AND_API_INIT(spi_##n, \
-			DT_INST_LABEL(n), \
-			spi_gecko_init, \
-			&spi_gecko_data_##n, \
-			&spi_gecko_cfg_##n, \
-			POST_KERNEL, \
-			CONFIG_SPI_INIT_PRIORITY, \
-			&spi_gecko_api);
+	DEVICE_DEFINE(spi_##n, \
+		      DT_INST_LABEL(n), \
+		      spi_gecko_init, \
+		      device_pm_control_nop, \
+		      &spi_gecko_data_##n, \
+		      &spi_gecko_cfg_##n, \
+		      POST_KERNEL, \
+		      CONFIG_SPI_INIT_PRIORITY,	\
+		      &spi_gecko_api);
 
 #define SPI_ID(n) DT_INST_PROP(n, peripheral_id)
 

--- a/drivers/spi/spi_litespi.c
+++ b/drivers/spi/spi_litespi.c
@@ -173,13 +173,14 @@ static struct spi_driver_api spi_litespi_api = {
 	static struct spi_litespi_cfg spi_litespi_cfg_##n = { \
 		.base = DT_INST_REG_ADDR_BY_NAME(n, control), \
 	}; \
-	DEVICE_AND_API_INIT(spi_##n, \
-			DT_INST_LABEL(n), \
-			spi_litespi_init, \
-			&spi_litespi_data_##n, \
-			&spi_litespi_cfg_##n, \
-			POST_KERNEL, \
-			CONFIG_SPI_INIT_PRIORITY, \
-			&spi_litespi_api);
+	DEVICE_DEFINE(spi_##n, \
+		      DT_INST_LABEL(n), \
+		      spi_litespi_init,	\
+		      device_pm_control_nop, \
+		      &spi_litespi_data_##n, \
+		      &spi_litespi_cfg_##n, \
+		      POST_KERNEL, \
+		      CONFIG_SPI_INIT_PRIORITY, \
+		      &spi_litespi_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SPI_INIT)

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -911,11 +911,11 @@ static struct spi_stm32_data spi_stm32_dev_data_##id = {		\
 	SPI_DMA_CHANNEL(id, tx, TX, MEMORY, PERIPHERAL)			\
 };									\
 									\
-DEVICE_AND_API_INIT(spi_stm32_##id, DT_INST_LABEL(id),			\
-		    &spi_stm32_init,					\
-		    &spi_stm32_dev_data_##id, &spi_stm32_cfg_##id,	\
-		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,		\
-		    &api_funcs);					\
+DEVICE_DEFINE(spi_stm32_##id, DT_INST_LABEL(id),			\
+	      &spi_stm32_init, device_pm_control_nop,			\
+	      &spi_stm32_dev_data_##id, &spi_stm32_cfg_##id,		\
+	      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,			\
+	      &api_funcs);						\
 									\
 STM32_SPI_IRQ_HANDLER(id)
 

--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -290,14 +290,15 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 		SPI_CONTEXT_INIT_LOCK(spi_mcux_data_##id, ctx),		\
 		SPI_CONTEXT_INIT_SYNC(spi_mcux_data_##id, ctx),		\
 	};								\
-	DEVICE_AND_API_INIT(spi_mcux_##id,				\
-			    DT_INST_LABEL(id),				\
-			    &spi_mcux_init,				\
-			    &spi_mcux_data_##id,			\
-			    &spi_mcux_config_##id,			\
-			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &spi_mcux_driver_api);			\
+	DEVICE_DEFINE(spi_mcux_##id,					\
+		      DT_INST_LABEL(id),				\
+		      &spi_mcux_init,					\
+		      device_pm_control_nop,				\
+		      &spi_mcux_data_##id,				\
+		      &spi_mcux_config_##id,				\
+		      POST_KERNEL,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &spi_mcux_driver_api);				\
 	static void spi_mcux_config_func_##id(struct device *dev)	\
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(id),				\

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -278,14 +278,15 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 		SPI_CONTEXT_INIT_LOCK(spi_mcux_data_##id, ctx),		\
 		SPI_CONTEXT_INIT_SYNC(spi_mcux_data_##id, ctx),		\
 	};								\
-	DEVICE_AND_API_INIT(spi_mcux_##id,				\
-			    DT_INST_LABEL(id),				\
-			    &spi_mcux_init,				\
-			    &spi_mcux_data_##id,			\
-			    &spi_mcux_config_##id,			\
-			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &spi_mcux_driver_api);			\
+	DEVICE_DEFINE(spi_mcux_##id,					\
+		      DT_INST_LABEL(id),				\
+		      &spi_mcux_init,					\
+		      device_pm_control_nop,				\
+		      &spi_mcux_data_##id,				\
+		      &spi_mcux_config_##id,				\
+		      POST_KERNEL,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &spi_mcux_driver_api);				\
 	static void spi_mcux_config_func_##id(struct device *dev)	\
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(id),				\

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -291,11 +291,12 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 		SPI_CONTEXT_INIT_SYNC(spi_mcux_data_##n, ctx),		\
 	};								\
 									\
-	DEVICE_AND_API_INIT(spi_mcux_##n, DT_INST_LABEL(n),		\
-			    &spi_mcux_init, &spi_mcux_data_##n,		\
-			    &spi_mcux_config_##n, POST_KERNEL,		\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &spi_mcux_driver_api);			\
+	DEVICE_DEFINE(spi_mcux_##n, DT_INST_LABEL(n),			\
+		      &spi_mcux_init, device_pm_control_nop,		\
+		      &spi_mcux_data_##n,				\
+		      &spi_mcux_config_##n, POST_KERNEL,		\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &spi_mcux_driver_api);				\
 									\
 	static void spi_mcux_config_func_##n(struct device *dev)	\
 	{								\

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -287,14 +287,15 @@ static int init_spis(struct device *dev, const nrfx_spis_config_t *config)
 		.spis = NRFX_SPIS_INSTANCE(idx),			       \
 		.max_buf_len = (1 << SPIS##idx##_EASYDMA_MAXCNT_SIZE) - 1,     \
 	};								       \
-	DEVICE_AND_API_INIT(spi_##idx,					       \
-			    DT_LABEL(SPIS(idx)),			       \
-			    spi_##idx##_init,				       \
-			    &spi_##idx##_data,				       \
-			    &spi_##idx##z_config,			       \
-			    POST_KERNEL,				       \
-			    CONFIG_SPI_INIT_PRIORITY,			       \
-			    &spi_nrfx_driver_api)
+	DEVICE_DEFINE(spi_##idx,					       \
+		      DT_LABEL(SPIS(idx)),				       \
+		      spi_##idx##_init,					       \
+		      device_pm_control_nop,				       \
+		      &spi_##idx##_data,				       \
+		      &spi_##idx##z_config,				       \
+		      POST_KERNEL,					       \
+		      CONFIG_SPI_INIT_PRIORITY,				       \
+		      &spi_nrfx_driver_api)
 
 #ifdef CONFIG_SPI_0_NRF_SPIS
 SPI_NRFX_SPIS_DEVICE(0);

--- a/drivers/spi/spi_oc_simple.c
+++ b/drivers/spi/spi_oc_simple.c
@@ -213,13 +213,14 @@ int spi_oc_simple_init(struct device *dev)
 		SPI_CONTEXT_INIT_SYNC(spi_oc_simple_data_##inst, ctx),	\
 	};								\
 									\
-	DEVICE_AND_API_INIT(spi_oc_simple_##inst,			\
-			    DT_INST_LABEL(inst),			\
-			    spi_oc_simple_init,				\
-			    &spi_oc_simple_data_##inst,			\
-			    &spi_oc_simple_cfg_##inst,			\
-			    POST_KERNEL,				\
-			    CONFIG_SPI_INIT_PRIORITY,			\
-			    &spi_oc_simple_api);
+	DEVICE_DEFINE(spi_oc_simple_##inst,				\
+		      DT_INST_LABEL(inst),				\
+		      spi_oc_simple_init,				\
+		      device_pm_control_nop,				\
+		      &spi_oc_simple_data_##inst,			\
+		      &spi_oc_simple_cfg_##inst,			\
+		      POST_KERNEL,					\
+		      CONFIG_SPI_INIT_PRIORITY,				\
+		      &spi_oc_simple_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SPI_OC_INIT)

--- a/drivers/spi/spi_rv32m1_lpspi.c
+++ b/drivers/spi/spi_rv32m1_lpspi.c
@@ -296,12 +296,13 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 		SPI_CONTEXT_INIT_SYNC(spi_mcux_data_##n, ctx),		\
 	};								\
 									\
-	DEVICE_AND_API_INIT(spi_mcux_##n, DT_INST_LABEL(n),		\
-			    &spi_mcux_init, &spi_mcux_data_##n,		\
-			    &spi_mcux_config_##n,			\
-			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &spi_mcux_driver_api);			\
+	DEVICE_DEFINE(spi_mcux_##n, DT_INST_LABEL(n),			\
+		      &spi_mcux_init, device_pm_control_nop,		\
+		      &spi_mcux_data_##n,				\
+		      &spi_mcux_config_##n,				\
+		      POST_KERNEL,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &spi_mcux_driver_api);				\
 									\
 	static void spi_mcux_config_func_##n(struct device *dev)	\
 	{								\

--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -467,10 +467,11 @@ static const struct spi_driver_api spi_sam_driver_api = {
 		SPI_CONTEXT_INIT_LOCK(spi_sam_dev_data_##n, ctx),	\
 		SPI_CONTEXT_INIT_SYNC(spi_sam_dev_data_##n, ctx),	\
 	};								\
-	DEVICE_AND_API_INIT(spi_sam_##n,				\
-			    DT_INST_LABEL(n),				\
-			    &spi_sam_init, &spi_sam_dev_data_##n,	\
-			    &spi_sam_config_##n, POST_KERNEL,		\
-			    CONFIG_SPI_INIT_PRIORITY, &spi_sam_driver_api);
+	DEVICE_DEFINE(spi_sam_##n,					\
+		      DT_INST_LABEL(n),					\
+		      &spi_sam_init, device_pm_control_nop,		\
+		      &spi_sam_dev_data_##n,				\
+		      &spi_sam_config_##n, POST_KERNEL,			\
+		      CONFIG_SPI_INIT_PRIORITY, &spi_sam_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SPI_SAM_DEVICE_INIT)

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -763,11 +763,12 @@ static const struct spi_sam0_config spi_sam0_config_##n = {		\
 		SPI_CONTEXT_INIT_LOCK(spi_sam0_dev_data_##n, ctx),	\
 		SPI_CONTEXT_INIT_SYNC(spi_sam0_dev_data_##n, ctx),	\
 	};								\
-	DEVICE_AND_API_INIT(spi_sam0_##n,				\
-			    DT_INST_LABEL(n),				\
-			    &spi_sam0_init, &spi_sam0_dev_data_##n,	\
-			    &spi_sam0_config_##n, POST_KERNEL,		\
-			    CONFIG_SPI_INIT_PRIORITY,			\
-			    &spi_sam0_driver_api);
+	DEVICE_DEFINE(spi_sam0_##n,					\
+		      DT_INST_LABEL(n),					\
+		      &spi_sam0_init, device_pm_control_nop,		\
+		      &spi_sam0_dev_data_##n,				\
+		      &spi_sam0_config_##n, POST_KERNEL,		\
+		      CONFIG_SPI_INIT_PRIORITY,				\
+		      &spi_sam0_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SPI_SAM0_DEVICE_INIT)

--- a/drivers/spi/spi_sifive.c
+++ b/drivers/spi/spi_sifive.c
@@ -246,14 +246,15 @@ static struct spi_driver_api spi_sifive_api = {
 		.base = DT_INST_REG_ADDR_BY_NAME(n, control), \
 		.f_sys = DT_INST_PROP(n, clock_frequency), \
 	}; \
-	DEVICE_AND_API_INIT(spi_##n, \
-			DT_INST_LABEL(n), \
-			spi_sifive_init, \
-			&spi_sifive_data_##n, \
-			&spi_sifive_cfg_##n, \
-			POST_KERNEL, \
-			CONFIG_SPI_INIT_PRIORITY, \
-			&spi_sifive_api)
+	DEVICE_DEFINE(spi_##n, \
+		      DT_INST_LABEL(n), \
+		      spi_sifive_init, \
+		      device_pm_control_nop, \
+		      &spi_sifive_data_##n, \
+		      &spi_sifive_cfg_##n, \
+		      POST_KERNEL, \
+		      CONFIG_SPI_INIT_PRIORITY, \
+		      &spi_sifive_api)
 
 #ifndef CONFIG_SIFIVE_SPI_0_ROM
 #if DT_INST_NODE_HAS_PROP(0, label)

--- a/drivers/spi/spi_xec_qmspi.c
+++ b/drivers/spi/spi_xec_qmspi.c
@@ -674,9 +674,9 @@ static struct spi_qmspi_data spi_qmspi_0_dev_data = {
 	SPI_CONTEXT_INIT_SYNC(spi_qmspi_0_dev_data, ctx)
 };
 
-DEVICE_AND_API_INIT(spi_xec_qmspi_0,
+DEVICE_DEFINE(spi_xec_qmspi_0,
 		    DT_INST_LABEL(0),
-		    &qmspi_init, &spi_qmspi_0_dev_data,
+		    &qmspi_init, device_pm_control_nop, &spi_qmspi_0_dev_data,
 		    &spi_qmspi_0_config, POST_KERNEL,
 		    CONFIG_SPI_INIT_PRIORITY, &spi_qmspi_driver_api);
 

--- a/drivers/video/mt9m114.c
+++ b/drivers/video/mt9m114.c
@@ -403,8 +403,8 @@ static int mt9m114_init_0(struct device *dev)
 	return mt9m114_init(dev);
 }
 
-DEVICE_AND_API_INIT(mt9m114, DT_INST_LABEL(0), &mt9m114_init_0,
-		    &mt9m114_data_0, NULL,
+DEVICE_DEFINE(mt9m114, DT_INST_LABEL(0), &mt9m114_init_0,
+		    device_pm_control_nop, &mt9m114_data_0, NULL,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mt9m114_driver_api);
 #endif

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -419,8 +419,9 @@ static int video_mcux_csi_init_0(struct device *dev)
 	return video_mcux_csi_init(dev);
 }
 
-DEVICE_AND_API_INIT(video_mcux_csi, DT_INST_LABEL(0),
-		    &video_mcux_csi_init_0, &video_mcux_csi_data_0,
+DEVICE_DEFINE(video_mcux_csi, DT_INST_LABEL(0),
+		    &video_mcux_csi_init_0, device_pm_control_nop,
+		    &video_mcux_csi_data_0,
 		    &video_mcux_csi_config_0,
 		    POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,
 		    &video_mcux_csi_driver_api);

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -273,7 +273,8 @@ static int video_sw_generator_init(struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(video_sw_generator, "VIDEO_SW_GENERATOR",
-		    &video_sw_generator_init, &video_sw_generator_data_0, NULL,
+DEVICE_DEFINE(video_sw_generator, "VIDEO_SW_GENERATOR",
+		    &video_sw_generator_init, device_pm_control_nop,
+		    &video_sw_generator_data_0, NULL,
 		    POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,
 		    &video_sw_generator_driver_api);

--- a/drivers/watchdog/wdt_cmsdk_apb.c
+++ b/drivers/watchdog/wdt_cmsdk_apb.c
@@ -199,8 +199,8 @@ static int wdog_cmsdk_apb_init(struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(wdog_cmsdk_apb, DT_INST_LABEL(0),
+DEVICE_DEFINE(wdog_cmsdk_apb, DT_INST_LABEL(0),
 		    wdog_cmsdk_apb_init,
-		    NULL, NULL,
+		    device_pm_control_nop, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &wdog_cmsdk_apb_api);

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -251,12 +251,12 @@ static const struct wdt_driver_api wdt_api = {
 		.connect_irq = wdt_esp32_connect_irq_func##idx						   \
 	};												   \
 													   \
-	DEVICE_AND_API_INIT(wdt_esp32_##idx, DT_INST_LABEL(idx),		   \
-			    wdt_esp32_init,								   \
-			    &wdt##idx##_data,								   \
-			    &wdt_esp32_config##idx,							   \
-			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,				   \
-			    &wdt_api)
+	DEVICE_DEFINE(wdt_esp32_##idx, DT_INST_LABEL(idx),						   \
+		      wdt_esp32_init, device_pm_control_nop,						   \
+		      &wdt##idx##_data,									   \
+		      &wdt_esp32_config##idx,								   \
+		      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,					   \
+		      &wdt_api)
 
 static void wdt_esp32_isr(struct device *dev)
 {

--- a/drivers/watchdog/wdt_gecko.c
+++ b/drivers/watchdog/wdt_gecko.c
@@ -280,12 +280,13 @@ static const struct wdt_driver_api wdt_gecko_driver_api = {
 	};								\
 	static struct wdt_gecko_data wdt_gecko_data_##index;		\
 									\
-	DEVICE_AND_API_INIT(wdt_##index,				\
-				DT_INST_LABEL(index),\
-				&wdt_gecko_init, &wdt_gecko_data_##index,\
-				&wdt_gecko_cfg_##index, POST_KERNEL,	\
-				CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
-				&wdt_gecko_driver_api);			\
+	DEVICE_DEFINE(wdt_##index,					\
+		      DT_INST_LABEL(index),				\
+		      &wdt_gecko_init, device_pm_control_nop,		\
+		      &wdt_gecko_data_##index,				\
+		      &wdt_gecko_cfg_##index, POST_KERNEL,		\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
+		      &wdt_gecko_driver_api);				\
 									\
 	static void wdt_gecko_cfg_func_##index(void)			\
 	{								\

--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -180,7 +180,8 @@ static struct iwdg_stm32_data iwdg_stm32_dev_data = {
 	.Instance = (IWDG_TypeDef *)DT_INST_REG_ADDR(0)
 };
 
-DEVICE_AND_API_INIT(iwdg_stm32, DT_INST_LABEL(0),
-		    iwdg_stm32_init, &iwdg_stm32_dev_data, NULL,
+DEVICE_DEFINE(iwdg_stm32, DT_INST_LABEL(0),
+		    iwdg_stm32_init, device_pm_control_nop,
+		    &iwdg_stm32_dev_data, NULL,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &iwdg_stm32_api);

--- a/drivers/watchdog/wdt_mchp_xec.c
+++ b/drivers/watchdog/wdt_mchp_xec.c
@@ -179,7 +179,8 @@ static int wdt_xec_init(struct device *dev)
 
 static struct wdt_xec_data wdt_xec_dev_data;
 
-DEVICE_AND_API_INIT(wdt_xec, DT_INST_LABEL(0),
-		    wdt_xec_init, &wdt_xec_dev_data, NULL,
+DEVICE_DEFINE(wdt_xec, DT_INST_LABEL(0),
+		    wdt_xec_init, device_pm_control_nop, &wdt_xec_dev_data,
+		    NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &wdt_xec_api);

--- a/drivers/watchdog/wdt_mcux_wdog.c
+++ b/drivers/watchdog/wdt_mcux_wdog.c
@@ -176,9 +176,10 @@ static const struct mcux_wdog_config mcux_wdog_config_0 = {
 
 static struct mcux_wdog_data mcux_wdog_data_0;
 
-DEVICE_AND_API_INIT(mcux_wdog_0, DT_INST_LABEL(0),
+DEVICE_DEFINE(mcux_wdog_0, DT_INST_LABEL(0),
 		    &mcux_wdog_init,
-		    &mcux_wdog_data_0, &mcux_wdog_config_0,
+		    device_pm_control_nop, &mcux_wdog_data_0,
+		    &mcux_wdog_config_0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_wdog_api);
 

--- a/drivers/watchdog/wdt_mcux_wdog32.c
+++ b/drivers/watchdog/wdt_mcux_wdog32.c
@@ -208,8 +208,9 @@ static const struct mcux_wdog32_config mcux_wdog32_config_0 = {
 
 static struct mcux_wdog32_data mcux_wdog32_data_0;
 
-DEVICE_AND_API_INIT(mcux_wdog32_0, DT_INST_LABEL(0),
-		    &mcux_wdog32_init, &mcux_wdog32_data_0,
+DEVICE_DEFINE(mcux_wdog32_0, DT_INST_LABEL(0),
+		    &mcux_wdog32_init, device_pm_control_nop,
+		    &mcux_wdog32_data_0,
 		    &mcux_wdog32_config_0, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_wdog32_api);

--- a/drivers/watchdog/wdt_nrfx.c
+++ b/drivers/watchdog/wdt_nrfx.c
@@ -182,13 +182,14 @@ static void wdt_event_handler(struct device *dev)
 			.reload_value  = 2000,				       \
 		}							       \
 	};								       \
-	DEVICE_AND_API_INIT(wdt_##idx,					       \
-			    DT_LABEL(WDT(idx)),				       \
-			    wdt_##idx##_init,				       \
-			    &wdt_##idx##_data,				       \
-			    &wdt_##idx##z_config,			       \
-			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \
-			    &wdt_nrfx_driver_api)
+	DEVICE_DEFINE(wdt_##idx,					       \
+		      DT_LABEL(WDT(idx)),				       \
+		      wdt_##idx##_init,					       \
+		      device_pm_control_nop,				       \
+		      &wdt_##idx##_data,				       \
+		      &wdt_##idx##z_config,				       \
+		      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	       \
+		      &wdt_nrfx_driver_api)
 
 #ifdef CONFIG_NRFX_WDT0
 WDT_NRFX_WDT_DEVICE(0);

--- a/drivers/watchdog/wdt_sam.c
+++ b/drivers/watchdog/wdt_sam.c
@@ -251,6 +251,7 @@ static int wdt_sam_init(struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(wdt_sam, DT_INST_LABEL(0), wdt_sam_init,
-		    &wdt_sam_data, &wdt_sam_cfg, PRE_KERNEL_1,
+DEVICE_DEFINE(wdt_sam, DT_INST_LABEL(0), wdt_sam_init,
+		    device_pm_control_nop, &wdt_sam_data, &wdt_sam_cfg,
+		    PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &wdt_sam_api);

--- a/drivers/watchdog/wdt_sam0.c
+++ b/drivers/watchdog/wdt_sam0.c
@@ -273,6 +273,6 @@ static int wdt_sam0_init(struct device *dev)
 
 static struct wdt_sam0_dev_data wdt_sam0_data;
 
-DEVICE_AND_API_INIT(wdt_sam0, DT_INST_LABEL(0), wdt_sam0_init,
-		    &wdt_sam0_data, NULL, PRE_KERNEL_1,
+DEVICE_DEFINE(wdt_sam0, DT_INST_LABEL(0), wdt_sam0_init,
+		    device_pm_control_nop, &wdt_sam0_data, NULL, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &wdt_sam0_api);

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -267,8 +267,9 @@ static struct wwdg_stm32_config wwdg_stm32_dev_config = {
 	.Instance = (WWDG_TypeDef *)DT_INST_REG_ADDR(0),
 };
 
-DEVICE_AND_API_INIT(wwdg_stm32, DT_INST_LABEL(0),
-		    wwdg_stm32_init, &wwdg_stm32_dev_data, &wwdg_stm32_dev_config,
+DEVICE_DEFINE(wwdg_stm32, DT_INST_LABEL(0),
+		    wwdg_stm32_init, device_pm_control_nop,
+		    &wwdg_stm32_dev_data, &wwdg_stm32_dev_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &wwdg_stm32_api);
 

--- a/include/drivers/gpio/gpio_mmio32.h
+++ b/include/drivers/gpio/gpio_mmio32.h
@@ -53,11 +53,12 @@ static const struct gpio_mmio32_config _dev_name##_dev_cfg = {		\
 	.mask	= _mask,						\
 };									\
 									\
-DEVICE_INIT(_dev_name, _drv_name,					\
+DEVICE_DEFINE(_dev_name, _drv_name,					\
 	&gpio_mmio32_init,						\
+	device_pm_control_nop,						\
 	&_dev_name##_dev_data,						\
 	&_dev_name##_dev_cfg,						\
-	PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE)
+	PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL)
 
 #else /* CONFIG_GPIO_MMIO32 */
 

--- a/samples/application_development/out_of_tree_driver/hello_world_module/zephyr/hello_world_driver.c
+++ b/samples/application_development/out_of_tree_driver/hello_world_module/zephyr/hello_world_driver.c
@@ -30,7 +30,7 @@ static void print_impl(struct device *dev)
 	__ASSERT(data.foo == 5, "Device was not initialized!");
 }
 
-DEVICE_AND_API_INIT(hello_world, "CUSTOM_DRIVER",
-		    init, &data, NULL,
+DEVICE_DEFINE(hello_world, "CUSTOM_DRIVER",
+		    init, device_pm_control_nop, &data, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &((struct hello_world_driver_api){ .print = print_impl }));

--- a/samples/bluetooth/hci_spi/src/main.c
+++ b/samples/bluetooth/hci_spi/src/main.c
@@ -257,8 +257,9 @@ static int hci_spi_init(struct device *unused)
 	return 0;
 }
 
-DEVICE_INIT(hci_spi, "hci_spi", &hci_spi_init, NULL, NULL,
-	    APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+DEVICE_DEFINE(hci_spi, "hci_spi", &hci_spi_init, device_pm_control_nop, NULL,
+	      NULL,
+	      APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, api);
 
 void main(void)
 {

--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -296,8 +296,9 @@ static int hci_uart_init(struct device *unused)
 	return 0;
 }
 
-DEVICE_INIT(hci_uart, "hci_uart", &hci_uart_init, NULL, NULL,
-	    APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+DEVICE_DEFINE(hci_uart, "hci_uart", &hci_uart_init, device_pm_control_nop,
+	      NULL, NULL,
+	      APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, api);
 
 void main(void)
 {

--- a/samples/userspace/prod_consumer/src/sample_driver_foo.c
+++ b/samples/userspace/prod_consumer/src/sample_driver_foo.c
@@ -109,8 +109,9 @@ static int sample_driver_foo_init(struct device *dev)
 
 static struct sample_driver_foo_dev_data sample_driver_foo_dev_data_0;
 
-DEVICE_AND_API_INIT(sample_driver_foo_0, SAMPLE_DRIVER_NAME_0,
+DEVICE_DEFINE(sample_driver_foo_0, SAMPLE_DRIVER_NAME_0,
 		    &sample_driver_foo_init,
-		    &sample_driver_foo_dev_data_0, NULL,
+		    device_pm_control_nop, &sample_driver_foo_dev_data_0,
+		    NULL,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &sample_driver_foo_api);

--- a/subsys/disk/disk_access_spi_sdhc.c
+++ b/subsys/disk/disk_access_spi_sdhc.c
@@ -897,8 +897,8 @@ static int disk_spi_sdhc_init(struct device *dev)
 
 static struct sdhc_spi_data sdhc_spi_data_0;
 
-DEVICE_AND_API_INIT(sdhc_spi_0,
+DEVICE_DEFINE(sdhc_spi_0,
 	DT_LABEL(DT_INST(0, zephyr_mmc_spi_slot)),
-	sdhc_spi_init, &sdhc_spi_data_0, NULL,
+	sdhc_spi_init, device_pm_control_nop, &sdhc_spi_data_0, NULL,
 	APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
 #endif

--- a/subsys/disk/disk_access_stm32_sdmmc.c
+++ b/subsys/disk/disk_access_stm32_sdmmc.c
@@ -412,9 +412,10 @@ static struct stm32_sdmmc_priv stm32_sdmmc_priv_1 = {
 	},
 };
 
-DEVICE_AND_API_INIT(stm32_sdmmc_dev1,
+DEVICE_DEFINE(stm32_sdmmc_dev1,
 		    DT_INST_LABEL(0), disk_stm32_sdmmc_init,
-		    &stm32_sdmmc_priv_1, NULL, APPLICATION,
+		    device_pm_control_nop, &stm32_sdmmc_priv_1, NULL,
+		    APPLICATION,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    NULL);
 #endif

--- a/subsys/disk/disk_access_usdhc.c
+++ b/subsys/disk/disk_access_usdhc.c
@@ -2877,9 +2877,9 @@ static int disk_usdhc_init(struct device *dev)
 #ifdef CONFIG_DISK_ACCESS_USDHC1
 static struct usdhc_priv usdhc_priv_1;
 #if DT_NODE_HAS_STATUS(DT_INST(0, nxp_imx_usdhc), okay)
-DEVICE_AND_API_INIT(usdhc_dev1,
+DEVICE_DEFINE(usdhc_dev1,
 		DT_LABEL(DT_INST(0, nxp_imx_usdhc)), disk_usdhc_init,
-		&usdhc_priv_1, NULL, APPLICATION,
+		device_pm_control_nop, &usdhc_priv_1, NULL, APPLICATION,
 		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		NULL);
 #else
@@ -2890,9 +2890,9 @@ DEVICE_AND_API_INIT(usdhc_dev1,
 #ifdef CONFIG_DISK_ACCESS_USDHC2
 static struct usdhc_priv usdhc_priv_2;
 #if DT_NODE_HAS_STATUS(DT_INST(1, nxp_imx_usdhc), okay)
-DEVICE_AND_API_INIT(usdhc_dev2,
+DEVICE_DEFINE(usdhc_dev2,
 		DT_LABEL(DT_INST(1, nxp_imx_usdhc)), disk_usdhc_init,
-		usdhc_priv_2, NULL, APPLICATION,
+		device_pm_control_nop, usdhc_priv_2, NULL, APPLICATION,
 		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		NULL);
 #else

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -623,7 +623,8 @@ NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_BT_SCAN, bt_scan);
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_BT_DISCONNECT, bt_disconnect);
 #endif
 
-DEVICE_AND_API_INIT(net_bt, "net_bt", net_bt_init, &bt_context_data, NULL,
+DEVICE_DEFINE(net_bt, "net_bt", net_bt_init, device_pm_control_nop,
+	      &bt_context_data, NULL,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &bt_if_api);
 NET_L2_DATA_INIT(net_bt, 0, NET_L2_GET_CTX_TYPE(BLUETOOTH_L2));

--- a/subsys/usb/class/audio/audio.c
+++ b/subsys/usb/class/audio/audio.c
@@ -936,13 +936,14 @@ void usb_audio_register(struct device *dev,
 		.num_endpoints = ARRAY_SIZE(dev##_usb_audio_ep_data_##i), \
 		.endpoint = dev##_usb_audio_ep_data_##i,		  \
 	};								  \
-	DEVICE_AND_API_INIT(dev##_usb_audio_device_##i,			  \
-			    DT_LABEL(DT_INST(i, COMPAT_##dev)),		  \
-			    &usb_audio_device_init,			  \
-			    &dev##_audio_dev_data_##i,			  \
-			    &dev##_audio_config_##i, APPLICATION,	  \
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		  \
-			    DUMMY_API)
+	DEVICE_DEFINE(dev##_usb_audio_device_##i,			  \
+		      DT_LABEL(DT_INST(i, COMPAT_##dev)),		  \
+		      &usb_audio_device_init,				  \
+		      device_pm_control_nop,				  \
+		      &dev##_audio_dev_data_##i,			  \
+		      &dev##_audio_config_##i, APPLICATION,		  \
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		  \
+		      DUMMY_API)
 
 #define DEFINE_BUF_POOL(name, size) \
 	NET_BUF_POOL_FIXED_DEFINE(name, 5, size, net_buf_destroy)

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -1064,13 +1064,14 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 	};
 
 #define DEFINE_CDC_ACM_DEVICE(x, _)					\
-	DEVICE_AND_API_INIT(cdc_acm_##x,				\
-			    CONFIG_USB_CDC_ACM_DEVICE_NAME "_" #x,	\
-			    &cdc_acm_init, &cdc_acm_dev_data_##x,	\
-			    &cdc_acm_config_##x,			\
-			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &cdc_acm_driver_api);
+	DEVICE_DEFINE(cdc_acm_##x,					\
+		      CONFIG_USB_CDC_ACM_DEVICE_NAME "_" #x,		\
+		      &cdc_acm_init, device_pm_control_nop,		\
+		      &cdc_acm_dev_data_##x,				\
+		      &cdc_acm_config_##x,				\
+		      POST_KERNEL,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		      &cdc_acm_driver_api);
 
 #define DEFINE_CDC_ACM_DESCR_AUTO(x, _) \
 	DEFINE_CDC_ACM_DESCR(x, AUTO_EP_IN, AUTO_EP_OUT, AUTO_EP_IN);

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -711,13 +711,14 @@ static int usb_hid_device_init(struct device *dev)
 	struct hid_device_info usb_hid_dev_data_##x;
 
 #define DEFINE_HID_DEVICE(x, _)						\
-	DEVICE_AND_API_INIT(usb_hid_device_##x,				\
-			    CONFIG_USB_HID_DEVICE_NAME "_" #x,		\
-			    &usb_hid_device_init,			\
-			    &usb_hid_dev_data_##x,			\
-			    &hid_config_##x, POST_KERNEL,		\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
-			    &hid_api);
+	DEVICE_DEFINE(usb_hid_device_##x,				\
+		      CONFIG_USB_HID_DEVICE_NAME "_" #x,		\
+		      &usb_hid_device_init,				\
+		      device_pm_control_nop,				\
+		      &usb_hid_dev_data_##x,				\
+		      &hid_config_##x, POST_KERNEL,			\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
+		      &hid_api);
 
 UTIL_LISTIFY(CONFIG_USB_HID_DEVICE_COUNT, DEFINE_HID_DESCR, _)
 UTIL_LISTIFY(CONFIG_USB_HID_DEVICE_COUNT, DEFINE_HID_EP, _)

--- a/tests/drivers/clock_control/nrf_clock_calibration/src/mock_temp_nrf5.c
+++ b/tests/drivers/clock_control/nrf_clock_calibration/src/mock_temp_nrf5.c
@@ -43,10 +43,10 @@ static const struct sensor_driver_api mock_temp_nrf5_driver_api = {
 	.channel_get = mock_temp_nrf5_channel_get,
 };
 
-DEVICE_AND_API_INIT(mock_temp_nrf5,
+DEVICE_DEFINE(mock_temp_nrf5,
 		    DT_LABEL(DT_INST(0, nordic_nrf_temp)),
 		    mock_temp_nrf5_init,
-		    NULL,
+		    device_pm_control_nop, NULL,
 		    NULL,
 		    POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY,

--- a/tests/drivers/i2c/i2c_slave_api/common/i2c_virtual.c
+++ b/tests/drivers/i2c/i2c_slave_api/common/i2c_virtual.c
@@ -223,7 +223,7 @@ static int i2c_virtual_init(struct device *dev)
 
 static struct i2c_virtual_data i2c_virtual_dev_data_0;
 
-DEVICE_AND_API_INIT(i2c_virtual_0, CONFIG_I2C_VIRTUAL_NAME, &i2c_virtual_init,
-		    &i2c_virtual_dev_data_0, NULL,
+DEVICE_DEFINE(i2c_virtual_0, CONFIG_I2C_VIRTUAL_NAME, &i2c_virtual_init,
+		    device_pm_control_nop, &i2c_virtual_dev_data_0, NULL,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &api_funcs);

--- a/tests/drivers/ipm/src/main.c
+++ b/tests/drivers/ipm/src/main.c
@@ -30,8 +30,8 @@ extern struct ipm_driver_api ipm_dummy_api;
 
 /* Set up the dummy IPM driver */
 struct ipm_dummy_driver_data ipm_dummy0_driver_data;
-DEVICE_AND_API_INIT(ipm_dummy0, "ipm_dummy0", ipm_dummy_init,
-	    &ipm_dummy0_driver_data, NULL,
+DEVICE_DEFINE(ipm_dummy0, "ipm_dummy0", ipm_dummy_init,
+	    device_pm_control_nop, &ipm_dummy0_driver_data, NULL,
 	    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &ipm_dummy_api);
 
 /* Sending side of the console IPM driver, will forward anything sent
@@ -41,9 +41,9 @@ static struct ipm_console_sender_config_info sender_config = {
 	.bind_to = "ipm_dummy0",
 	.flags = SOURCE
 };
-DEVICE_INIT(ipm_console_send0, "ipm_send0", ipm_console_sender_init,
-	    NULL, &sender_config,
-	    APPLICATION, INIT_PRIO_IPM_SEND);
+DEVICE_DEFINE(ipm_console_send0, "ipm_send0", ipm_console_sender_init,
+	    device_pm_control_nop, NULL, &sender_config,
+	    APPLICATION, INIT_PRIO_IPM_SEND, api);
 
 /* Receiving side of the console IPM driver. These numbers are
  * more or less arbitrary
@@ -67,9 +67,9 @@ static struct ipm_console_receiver_config_info receiver_config = {
 };
 
 struct ipm_console_receiver_runtime_data receiver_data;
-DEVICE_INIT(ipm_console_recv0, "ipm_recv0", ipm_console_receiver_init,
-	    &receiver_data, &receiver_config,
-	    APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+DEVICE_DEFINE(ipm_console_recv0, "ipm_recv0", ipm_console_receiver_init,
+	    device_pm_control_nop, &receiver_data, &receiver_config,
+	    APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, api);
 
 static const char thestr[] = "everything is awesome\n";
 

--- a/tests/kernel/device/src/bad_driver.c
+++ b/tests/kernel/device/src/bad_driver.c
@@ -35,8 +35,9 @@ int bad_driver_init(struct device *dev)
 /**
  * @cond INTERNAL_HIDDEN
  */
-DEVICE_AND_API_INIT(bad_driver, BAD_DRIVER_NAME, &bad_driver_init,
-		    NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+DEVICE_DEFINE(bad_driver, BAD_DRIVER_NAME, &bad_driver_init,
+		    device_pm_control_nop, NULL, NULL, POST_KERNEL,
+		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &funcs);
 
 /**

--- a/tests/kernel/device/src/dummy_driver.c
+++ b/tests/kernel/device/src/dummy_driver.c
@@ -35,8 +35,9 @@ int dummy_init(struct device *dev)
 /**
  * @cond INTERNAL_HIDDEN
  */
-DEVICE_AND_API_INIT(dummy_driver, DUMMY_DRIVER_NAME, &dummy_init,
-		    NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+DEVICE_DEFINE(dummy_driver, DUMMY_DRIVER_NAME, &dummy_init,
+		    device_pm_control_nop, NULL, NULL, POST_KERNEL,
+		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &funcs);
 
 /**

--- a/tests/net/ptp/clock/src/main.c
+++ b/tests/net/ptp/clock/src/main.c
@@ -241,8 +241,9 @@ static int ptp_test_1_init(struct device *port)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(ptp_clock_1, PTP_CLOCK_NAME, ptp_test_1_init,
-		    &ptp_test_1_context, NULL, POST_KERNEL,
+DEVICE_DEFINE(ptp_clock_1, PTP_CLOCK_NAME, ptp_test_1_init,
+		    device_pm_control_nop, &ptp_test_1_context, NULL,
+		    POST_KERNEL,
 		    CONFIG_APPLICATION_INIT_PRIORITY, &api);
 
 static int ptp_test_2_init(struct device *port)
@@ -257,8 +258,9 @@ static int ptp_test_2_init(struct device *port)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(ptp_clock_2, PTP_CLOCK_NAME, ptp_test_2_init,
-		    &ptp_test_2_context, NULL, POST_KERNEL,
+DEVICE_DEFINE(ptp_clock_2, PTP_CLOCK_NAME, ptp_test_2_init,
+		    device_pm_control_nop, &ptp_test_2_context, NULL,
+		    POST_KERNEL,
 		    CONFIG_APPLICATION_INIT_PRIORITY, &api);
 
 struct user_data {

--- a/tests/subsys/fs/multi-fs/src/test_ram_backend.c
+++ b/tests/subsys/fs/multi-fs/src/test_ram_backend.c
@@ -89,7 +89,8 @@ static const struct flash_driver_api flash_ram_api = {
 	.page_layout = test_flash_ram_pages_layout,
 };
 
-DEVICE_AND_API_INIT(flash_ram_test, "ram_flash_test_drv", test_ram_flash_init,
-					NULL, NULL, POST_KERNEL,
+DEVICE_DEFINE(flash_ram_test, "ram_flash_test_drv", test_ram_flash_init,
+					device_pm_control_nop, NULL, NULL,
+					POST_KERNEL,
 					CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 					&flash_ram_api);


### PR DESCRIPTION
These function macros are identical except that DEVICE_DEFINE adds a parameter providing the device pm control function, while DEVICE_AND_API_INIT does not.  This requires duplicate implementations where if CONFIG_DEVICE_POWER_MANAGEMENT is enabled then DEVICE_AND_API_INIT delegates to DEVICE_DEFINE with a dummy pm control function, and if it is not enabled then DEVICE_DEFINE discards the parameter and delegates to DEVICE_AND_API_INIT.

The vast majority of device definitions do not have device power management implemented so still use DEVICE_AND_API_INIT.  But the future is wider use of device power management, and having two ways to define devices creates confusion and complicates refactoring.

Replace use of DEVICE_AND_API_INIT with use of DEVICE_DEFINE passing the default pm control function explicitly.

2020-06-09 work in progress, so many manual conversions required.....
