### PR TITLE
device: refactor to simplify maintenance

### DIFF
--- a/doc/reference/drivers/index.rst
+++ b/doc/reference/drivers/index.rst
@@ -68,22 +68,28 @@ The following APIs for device drivers are provided by :file:`device.h`. The APIs
 are intended for use in device drivers only and should not be used in
 applications.
 
-:c:func:`DEVICE_INIT()`
-   create device object and set it up for boot time initialization.
+:c:func:`DEVICE_DEFINE()`
+   Create device object and related data structures including setting it
+   up for boot-time initialization.
 
 :c:func:`DEVICE_AND_API_INIT()`
-   Create device object and set it up for boot time initialization.
-   This also takes a pointer to driver API struct for link time
-   pointer assignment.
+   Like :c:func:`DEVICE_DEFINE()` but without support for device power
+   management.
+
+:c:func:`DEVICE_INIT()`
+   Like :c:func:`DEVICE_AND_API_INIT()` but without providing an API
+   pointer.
 
 :c:func:`DEVICE_NAME_GET()`
-   Expands to the full name of a global device object.
+   Converts a device identifier to the global identifier for a device
+   object.
 
 :c:func:`DEVICE_GET()`
    Obtain a pointer to a device object by name.
 
 :c:func:`DEVICE_DECLARE()`
-   Declare a device object.
+   Declare a device object.  Use this when you need a forward reference
+   to a device that has not yet been defined.
 
 .. _device_struct:
 
@@ -106,7 +112,7 @@ split into read-only and runtime-mutable parts. At a high level we have:
 The ``config_info`` member is for read-only configuration data set at build time. For
 example, base memory mapped IO addresses, IRQ line numbers, or other fixed
 physical characteristics of the device. This is the ``config_info`` structure
-passed to the ``DEVICE_*INIT()`` macros.
+passed to ``DEVICE_DEFINE()`` and related macros.
 
 The ``driver_data`` struct is kept in RAM, and is used by the driver for
 per-instance runtime housekeeping. For example, it may contain reference counts,
@@ -338,10 +344,11 @@ the IRQ handler argument and the definition of the device itself.
 Initialization Levels
 *********************
 
-Drivers may depend on other drivers being initialized first, or
-require the use of kernel services. The DEVICE_INIT() APIs allow the user to
-specify at what time during the boot sequence the init function will be
-executed. Any driver will specify one of four initialization levels:
+Drivers may depend on other drivers being initialized first, or require
+the use of kernel services. :c:func:`DEVICE_DEFINE()` and related APIs
+allow the user to specify at what time during the boot sequence the init
+function will be executed. Any driver will specify one of four
+initialization levels:
 
 ``PRE_KERNEL_1``
         Used for devices that have no dependencies, such as those that rely
@@ -383,7 +390,7 @@ System Drivers
 **************
 
 In some cases you may just need to run a function at boot. Special ``SYS_*``
-macros exist that map to ``DEVICE_*INIT()`` calls.
+macros exist that map to ``DEVICE_DEFINE()`` calls.
 For ``SYS_INIT()`` there are no config or runtime data structures and there
 isn't a way
 to later get a device pointer by name. The same policies for initialization
@@ -393,8 +400,11 @@ For ``SYS_DEVICE_DEFINE()`` you can obtain pointers by name, see
 :ref:`power management <power_management_api>` section.
 
 :c:func:`SYS_INIT()`
+   Run an initialization function at boot at specified priority.
 
 :c:func:`SYS_DEVICE_DEFINE()`
+   Like :c:func:`DEVICE_DEFINE` without an API table and constructing
+   the device name from the init function name.
 
 Error handling
 **************

--- a/include/init.h
+++ b/include/init.h
@@ -70,6 +70,31 @@ void z_sys_init_run_level(int32_t level);
  *
  * @param device A device driver instance pointer or NULL
  *
+ * @param level The initialization level at which configuration
+ * occurs.  See SYS_INIT().
+ *
+ * @param prio The initialization priority of the object, relative to
+ * other objects of the same initialization level. See SYS_INIT().
+ */
+#define Z_INIT_ENTRY_DEFINE(entry_name, init_fn, device, level, prio)	\
+	static const Z_DECL_ALIGN(struct init_entry)			\
+		_CONCAT(__init_, entry_name) __used			\
+	__attribute__((__section__(".init_" #level STRINGIFY(prio)))) = { \
+		.init = (init_fn),					\
+		.dev = (device),					\
+	}
+
+/**
+ * @def SYS_INIT
+ *
+ * @ingroup device_model
+ *
+ * @brief Run an initialization function at boot at specified priority
+ *
+ * @details This macro lets you run a function at system boot.
+ *
+ * @param init_fn Pointer to the boot function to run
+ *
  * @param level The initialization level at which configuration occurs.
  * Must be one of the following symbols, which are listed in the order
  * they are performed by the kernel:
@@ -100,28 +125,6 @@ void z_sys_init_run_level(int32_t level);
  * or an equivalent symbolic name (e.g. \#define MY_INIT_PRIO 32); symbolic
  * expressions are *not* permitted
  * (e.g. CONFIG_KERNEL_INIT_PRIORITY_DEFAULT + 5).
- */
-#define Z_INIT_ENTRY_DEFINE(entry_name, init_fn, device, level, prio)	\
-	static const Z_DECL_ALIGN(struct init_entry)			\
-		_CONCAT(__init_, entry_name) __used			\
-	__attribute__((__section__(".init_" #level STRINGIFY(prio)))) = { \
-		.init = (init_fn),					\
-		.dev = (device),					\
-	}
-
-/**
- * @def SYS_INIT
- *
- * @brief Run an initialization function at boot at specified priority
- *
- * @details This macro lets you run a function at system boot.
- *
- * @param init_fn Pointer to the boot function to run
- *
- * @param level The initialization level, See Z_INIT_ENTRY_DEFINE for details.
- *
- * @param prio Priority within the selected initialization level. See
- * Z_INIT_ENTRY_DEFINE for details.
  */
 #define SYS_INIT(init_fn, level, prio)					\
 	Z_INIT_ENTRY_DEFINE(Z_SYS_NAME(init_fn), init_fn, NULL, level, prio)


### PR DESCRIPTION
`DEVICE_AND_API_INIT` and `DEVICE_DEFINE` are identical except that `DEVICE_DEFINE` adds a parameter providing the device pm control function, while `DEVICE_AND_API_INIT` does not.  This requires duplicate implementations where if `CONFIG_DEVICE_POWER_MANAGEMENT` is enabled then `DEVICE_AND_API_INIT` delegates to `DEVICE_DEFINE` with a dummy pm control function, and if it is not enabled then `DEVICE_DEFINE` discards the parameter and delegates to `DEVICE_AND_API_INIT`.

`DEVICE_INIT` is like `DEVICE_AND_API_INIT` but doesn't provide an API.

Clean this up by refactoring so that `DEVICE_DEFINE` is the core implementation, providing with and without device power management right next to each other where they can be compared and maintained. Redefine `DEVICE_INIT` and `DEVICE_AND_API_INIT` delegate to `DEVICE_DEFINE`.

Also remove duplicate code by extracting the variations due to enabling device power management into macros.

This is a step intended to simplify providing dependency information for #22545 and related PRs.