### PR TITLE
x86: early_printk: allow custom UART clock, baud rate, and SoC specific initialization

### DIFF
--- a/arch/x86/core/early_serial.c
+++ b/arch/x86/core/early_serial.c
@@ -107,6 +107,14 @@ static int console_out(int c)
 
 extern void __printk_hook_install(int (*fn)(int));
 
+void __weak z_x86_early_serial_pre_init(void)
+{
+}
+
+void __weak z_x86_early_serial_post_init(void)
+{
+}
+
 void z_x86_early_serial_init(void)
 {
 #ifdef UART_NS16550_PCIE_ENABLED

--- a/arch/x86/core/prep_c.c
+++ b/arch/x86/core/prep_c.c
@@ -21,7 +21,9 @@ FUNC_NORETURN void z_x86_prep_c(void *arg)
 	_kernel.cpus[0].nested = 0;
 
 #ifdef CONFIG_X86_VERY_EARLY_CONSOLE
+	z_x86_early_serial_pre_init();
 	z_x86_early_serial_init();
+	z_x86_early_serial_post_init();
 #endif
 
 #ifdef CONFIG_MULTIBOOT_INFO

--- a/arch/x86/include/kernel_arch_func.h
+++ b/arch/x86/include/kernel_arch_func.h
@@ -42,6 +42,8 @@ extern FUNC_NORETURN void z_x86_prep_c(void *arg);
 #ifdef CONFIG_X86_VERY_EARLY_CONSOLE
 /* Setup ultra-minimal serial driver for printk() */
 void z_x86_early_serial_init(void);
+void z_x86_early_serial_pre_init(void);
+void z_x86_early_serial_post_init(void);
 #endif /* CONFIG_X86_VERY_EARLY_CONSOLE */
 
 #ifdef CONFIG_X86_MMU


### PR DESCRIPTION
The x86 early_printk is used as very early serial console to print out debug information. It is useful when doing platform bringup and debugging architecture and SoC initialization code.

This PR changes the initialization code to allow custom UART clock rate and serial baud rate defined in the UART device tree entry via `zephyr_console`. This is to accommodate SoC with UART clock other than the more usual 1.8432MHz rate.

This also adds two weak functions which are to be implemented in the SoC layer to allow SoC specific initialization of UART, e.g. power/clock gating, pinmux, etc.