### PR TITLE
net: sockets: tls: Check accepted context is not NULL

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -465,7 +465,21 @@ int zsock_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 	ctx = k_fifo_get(&parent->accept_q, timeout);
 	if (ctx == NULL) {
 		z_free_fd(fd);
-		errno = EAGAIN;
+		if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+			/* For non-blocking sockets return EAGAIN because it
+			 * just means the fifo is empty at this time
+			 */
+			errno = EAGAIN;
+		} else {
+			/* For blocking sockets return EINVAL because it means
+			 * the socket was closed while we were waiting for
+			 * connections. This is the same error code returned
+			 * under Linux when calling shutdown on a blocked accept
+			 * call
+			 */
+			errno = EINVAL;
+		}
+
 		return -1;
 	}
 

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1277,6 +1277,14 @@ int ztls_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 	}
 
 	child = k_fifo_get(&parent->accept_q, K_FOREVER);
+	if (child == NULL) {
+		z_free_fd(fd);
+		/* Return EINVAL which is the same error code used under Linux
+		 * when calling shutdown on a blocked accept call
+		 */
+		errno = EINVAL;
+		return -1;
+	}
 
 	if (addr != NULL && addrlen != NULL) {
 		int len = MIN(*addrlen, sizeof(child->remote));


### PR DESCRIPTION
Fixes a NULL pointer dereferencement when closing a listening TLS socket. In that case k_fifo_get will be unblocked and return a NULL child which will then be dereferenced in the code below.