### PR TITLE
tcp2: Implement a blocking connect

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -280,10 +280,19 @@ static void tcp_send_queue_flush(struct tcp *conn)
 
 static int tcp_conn_unref(struct tcp *conn)
 {
-	int ref_count = atomic_dec(&conn->ref_count) - 1;
-	int key;
+	int key, ref_count = atomic_get(&conn->ref_count);
 
 	NET_DBG("conn: %p, ref_count=%d", conn, ref_count);
+
+#if !defined(CONFIG_NET_TEST_PROTOCOL)
+	if (conn->in_connect) {
+		NET_DBG("conn: %p is waiting on connect semaphore", conn);
+		tcp_send_queue_flush(conn);
+		goto out;
+	}
+#endif /* CONFIG_NET_TEST_PROTOCOL */
+
+	ref_count = atomic_dec(&conn->ref_count) - 1;
 
 	if (ref_count) {
 		tp_out(net_context_get_family(conn->context), conn->iface,
@@ -870,6 +879,9 @@ static struct tcp *tcp_conn_alloc(void)
 	conn->send_data = tcp_pkt_alloc(conn, 0);
 	k_delayed_work_init(&conn->send_data_timer, tcp_resend_data);
 
+	k_sem_init(&conn->connect_sem, 0, UINT_MAX);
+	conn->in_connect = false;
+
 	tcp_conn_ref(conn);
 
 	sys_slist_append(&tcp_conns, (sys_snode_t *)conn);
@@ -1139,6 +1151,7 @@ next_state:
 				}
 				conn_ack(conn, + len);
 			}
+			k_sem_give(&conn->connect_sem);
 			next = TCP_ESTABLISHED;
 			net_context_set_state(conn->context,
 					      NET_CONTEXT_CONNECTED);
@@ -1375,8 +1388,6 @@ int net_tcp_connect(struct net_context *context,
 	struct tcp *conn;
 	int ret = 0;
 
-	ARG_UNUSED(timeout);
-
 	NET_DBG("context: %p, local: %s, remote: %s", context,
 		log_strdup(net_sprint_addr(
 			    local_addr->sa_family,
@@ -1459,6 +1470,18 @@ int net_tcp_connect(struct net_context *context,
 	 */
 	tcp_in(conn, NULL);
 
+	if (!IS_ENABLED(CONFIG_NET_TEST_PROTOCOL)) {
+		conn->in_connect = true;
+
+		if (k_sem_take(&conn->connect_sem, timeout) != 0 &&
+		    conn->state != TCP_ESTABLISHED) {
+			conn->in_connect = false;
+			tcp_conn_unref(conn);
+			ret = -ETIMEDOUT;
+			goto out;
+		}
+		conn->in_connect = false;
+	}
  out:
 	NET_DBG("conn: %p, ret=%d", conn, ret);
 

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1373,7 +1373,7 @@ int net_tcp_connect(struct net_context *context,
 		    void *user_data)
 {
 	struct tcp *conn;
-	int ret;
+	int ret = 0;
 
 	ARG_UNUSED(timeout);
 
@@ -1433,7 +1433,7 @@ int net_tcp_connect(struct net_context *context,
 		break;
 
 	default:
-		return -EPROTONOSUPPORT;
+		ret = -EPROTONOSUPPORT;
 	}
 
 	NET_DBG("conn: %p src: %s, dst: %s", conn,
@@ -1451,7 +1451,7 @@ int net_tcp_connect(struct net_context *context,
 				tcp_recv, context,
 				&context->conn_handler);
 	if (ret < 0) {
-		return ret;
+		goto out;
 	}
 
 	/* Input of a (nonexistent) packet with no flags set will cause
@@ -1459,7 +1459,10 @@ int net_tcp_connect(struct net_context *context,
 	 */
 	tcp_in(conn, NULL);
 
-	return 0;
+ out:
+	NET_DBG("conn: %p, ret=%d", conn, ret);
+
+	return ret;
 }
 
 int net_tcp_accept(struct net_context *context, net_tcp_accept_cb_t cb,

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1115,6 +1115,7 @@ next_state:
 			next = TCP_ESTABLISHED;
 			net_context_set_state(conn->context,
 					      NET_CONTEXT_CONNECTED);
+
 			if (len) {
 				if (tcp_data_get(conn, pkt) < 0) {
 					break;
@@ -1129,20 +1130,19 @@ next_state:
 		 * ACK , shouldn't we go to SYN RECEIVED state? See Figure
 		 * 6 of RFC 793
 		 */
-		if (FL(&fl, &, ACK, th && th_ack(th) == conn->seq)) {
+		if (FL(&fl, &, SYN | ACK, th && th_ack(th) == conn->seq)) {
 			tcp_send_timer_cancel(conn);
-			next = TCP_ESTABLISHED;
-			net_context_set_state(conn->context,
-					      NET_CONTEXT_CONNECTED);
-			if (FL(&fl, &, PSH)) {
+			conn_ack(conn, th_seq(th) + 1);
+			if (len) {
 				if (tcp_data_get(conn, pkt) < 0) {
 					break;
 				}
+				conn_ack(conn, + len);
 			}
-			if (FL(&fl, &, SYN)) {
-				conn_ack(conn, th_seq(th) + 1);
-				tcp_out(conn, ACK);
-			}
+			next = TCP_ESTABLISHED;
+			net_context_set_state(conn->context,
+					      NET_CONTEXT_CONNECTED);
+			tcp_out(conn, ACK);
 		}
 		break;
 	case TCP_ESTABLISHED:

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1283,7 +1283,7 @@ int net_tcp_put(struct net_context *context)
 
 	NET_DBG("%s", conn ? log_strdup(tcp_conn_state(conn, NULL)) : "");
 
-	if (conn) {
+	if (conn && conn->state == TCP_ESTABLISHED) {
 		k_mutex_lock(&conn->lock, K_FOREVER);
 
 		tcp_out(conn, FIN | ACK);

--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -201,6 +201,8 @@ struct tcp { /* TCP connection */
 	size_t send_retries;
 	struct k_delayed_work timewait_timer;
 	struct net_if *iface;
+	struct k_sem connect_sem; /* semaphore for blocking connect */
+	bool in_connect;
 	net_tcp_accept_cb_t accept_cb;
 	atomic_t ref_count;
 };

--- a/tests/net/tcp2/src/main.c
+++ b/tests/net/tcp2/src/main.c
@@ -167,9 +167,8 @@ static void test_sem_give(void)
 static void test_sem_take(k_timeout_t timeout, int line)
 {
 	sem = true;
-	k_sem_take(&test_sem, timeout);
 
-	if (sem) {
+	if (k_sem_take(&test_sem, timeout) != 0) {
 		zassert_true(false, "semaphore timed out (line %d)", line);
 	}
 }

--- a/tests/net/tcp2/src/main.c
+++ b/tests/net/tcp2/src/main.c
@@ -497,7 +497,7 @@ static void test_client_ipv4(void)
 	ret = net_context_connect(ctx, (struct sockaddr *)&peer_addr_s,
 				  sizeof(struct sockaddr_in),
 				  NULL,
-				  K_NO_WAIT, NULL);
+				  K_MSEC(100), NULL);
 	if (ret < 0) {
 		zassert_true(false, "Failed to connect to peer");
 	}
@@ -559,7 +559,7 @@ static void test_client_ipv6(void)
 	ret = net_context_connect(ctx, (struct sockaddr *)&peer_addr_v6_s,
 				  sizeof(struct sockaddr_in6),
 				  NULL,
-				  K_NO_WAIT, NULL);
+				  K_MSEC(100), NULL);
 	if (ret < 0) {
 		zassert_true(false, "Failed to connect to peer");
 	}
@@ -910,7 +910,7 @@ static void test_client_syn_resend(void)
 	ret = net_context_connect(ctx, (struct sockaddr *)&peer_addr_s,
 				  sizeof(struct sockaddr_in),
 				  NULL,
-				  K_NO_WAIT, NULL);
+				  K_MSEC(1000), NULL);
 	if (ret < 0) {
 		zassert_true(false, "Failed to connect to peer");
 	}
@@ -1015,7 +1015,7 @@ static void test_client_fin_wait_2_ipv4(void)
 	ret = net_context_connect(ctx, (struct sockaddr *)&peer_addr_s,
 				  sizeof(struct sockaddr_in),
 				  NULL,
-				  K_NO_WAIT, NULL);
+				  K_MSEC(100), NULL);
 	if (ret < 0) {
 		zassert_true(false, "Failed to connect to peer");
 	}
@@ -1136,7 +1136,7 @@ static void test_client_closing_ipv6(void)
 	ret = net_context_connect(ctx, (struct sockaddr *)&peer_addr_v6_s,
 				  sizeof(struct sockaddr_in6),
 				  NULL,
-				  K_NO_WAIT, NULL);
+				  K_MSEC(100), NULL);
 	if (ret < 0) {
 		zassert_true(false, "Failed to connect to peer");
 	}

--- a/tests/net/tcp2/src/main.c
+++ b/tests/net/tcp2/src/main.c
@@ -911,9 +911,8 @@ static void test_client_syn_resend(void)
 				  sizeof(struct sockaddr_in),
 				  NULL,
 				  K_MSEC(1000), NULL);
-	if (ret < 0) {
-		zassert_true(false, "Failed to connect to peer");
-	}
+
+	zassert_true(ret < 0, "Connect on no response from peer");
 
 	/* test handler will release the sem once it receives SYN again */
 	test_sem_take(K_MSEC(500), __LINE__);


### PR DESCRIPTION
In order to implement a blocking connect, add a semaphore
and block on it in net_tcp_connect().

The semaphore is released when ESTABLISHED state is reached.

In case tcp_conn_unref() is called while waiting on the semaphore,
defer the unreference, tcp_conn_unref() will be called from
net_tcp_connect().

Fixes #26695