### PR TITLE
boards: nrf52840dk_nrf52840: Add netif capability for a board

### DIFF
--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.yaml
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.yaml
@@ -23,3 +23,4 @@ supported:
   - usb_cdc
   - usb_device
   - watchdog
+  - netif:openthread

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -82,7 +82,7 @@ static struct {
 	size_t tx_buffer_length;
 	volatile size_t tx_counter;
 #if HW_FLOW_CONTROL_AVAILABLE
-	s32_t tx_timeout;
+	int32_t tx_timeout;
 	struct k_delayed_work tx_timeout_work;
 #endif
 } uart0_cb;


### PR DESCRIPTION
The `netif` capability is needed for certain samples to be built by the
CI for a target platform. As it was missing for nrf52840dk_nrf52840,
echo samples with OpenThread support were not being built and thus not
tested by the CI.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>