### PR TITLE
usb: Set thread names in usb device classes

### DIFF
--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -354,10 +354,14 @@ static int bluetooth_init(struct device *dev)
 			(k_thread_entry_t)hci_rx_thread, NULL, NULL, NULL,
 			K_PRIO_COOP(8), 0, K_NO_WAIT);
 
+	k_thread_name_set(&rx_thread_data, "usb_bt_rx");
+
 	k_thread_create(&tx_thread_data, tx_thread_stack,
 			K_THREAD_STACK_SIZEOF(tx_thread_stack),
 			(k_thread_entry_t)hci_tx_thread, NULL, NULL, NULL,
 			K_PRIO_COOP(8), 0, K_NO_WAIT);
+
+	k_thread_name_set(&tx_thread_data, "usb_bt_tx");
 
 	return 0;
 }

--- a/subsys/usb/class/bt_h4.c
+++ b/subsys/usb/class/bt_h4.c
@@ -238,10 +238,14 @@ static int bt_h4_init(struct device *dev)
 			(k_thread_entry_t)hci_rx_thread, NULL, NULL, NULL,
 			K_PRIO_COOP(8), 0, K_NO_WAIT);
 
+	k_thread_name_set(&rx_thread_data, "usb_bt_h4_rx");
+
 	k_thread_create(&tx_thread_data, tx_thread_stack,
 			K_THREAD_STACK_SIZEOF(tx_thread_stack),
 			(k_thread_entry_t)hci_tx_thread, NULL, NULL, NULL,
 			K_PRIO_COOP(8), 0, K_NO_WAIT);
+
+	k_thread_name_set(&tx_thread_data, "usb_bt_h4_tx");
 
 	return 0;
 }

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -992,6 +992,8 @@ static int mass_storage_init(struct device *dev)
 			(k_thread_entry_t)mass_thread_main, NULL, NULL, NULL,
 			DISK_THREAD_PRIO, 0, K_NO_WAIT);
 
+	k_thread_name_set(&mass_thread_data, "usb_mass");
+
 	return 0;
 }
 

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -1094,6 +1094,8 @@ static int rndis_init(struct device *arg)
 			(k_thread_entry_t)cmd_thread,
 			NULL, NULL, NULL, K_PRIO_COOP(8), 0, K_NO_WAIT);
 
+	k_thread_name_set(&cmd_thread_data, "usb_rndis");
+
 	return 0;
 }
 


### PR DESCRIPTION
Sets thread names for all usb device class threads (bluetooth, bt_h4,
mass storage, and rndis) to aid debug.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>