### PR TITLE
drivers/uart/ns16550: PCI remapping workaround

### DIFF
--- a/arch/x86/core/prep_c.c
+++ b/arch/x86/core/prep_c.c
@@ -20,6 +20,12 @@ FUNC_NORETURN void z_x86_prep_c(void *arg)
 
 	_kernel.cpus[0].nested = 0;
 
+#ifdef CONFIG_UART_PCI_REMAP
+	extern void pci_uart_remap_init(void);
+
+	pci_uart_remap_init();
+#endif
+
 #ifdef CONFIG_X86_VERY_EARLY_CONSOLE
 	z_x86_early_serial_init();
 #endif

--- a/drivers/serial/Kconfig.ns16550
+++ b/drivers/serial/Kconfig.ns16550
@@ -40,3 +40,10 @@ config UART_NS16550_ACCESS_WORD_ONLY
 	  In some case, e.g. ARC HS Development kit, the peripheral space of ns
 	  16550 (DesignWare UART) only allows word access, byte access will raise
 	  exception.
+
+config UART_PCI_REMAP
+	bool "Remap UART MMIO region before initialization"
+	default y
+	help
+	  Debug workaround to remap PCI BAR regions to 32 bit
+	  addresses before UART initialization.  See comments in code.


### PR DESCRIPTION
Some systems have firmware that maps the (PCI) UART registers into
memory beyond 4G, exposing word size bugs in our PCI and UART
subsystems and making device bringup a hellish wasteland of empty,
silent, and utterly remorseless console devices.

Put it somewhere safe at early boot while we figure this out.  The
device (00:18.0) and address (0xa0000000) work correctly on up_squared
for me.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>