### PR TITLE
kernel: userspace: fix variable initialization

### DIFF
--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -282,7 +282,7 @@ struct z_object *z_dynamic_object_create(size_t size)
 void *z_impl_k_object_alloc(enum k_objects otype)
 {
 	struct z_object *zo;
-	uintptr_t tidx;
+	uintptr_t tidx = 0;
 
 	if (otype <= K_OBJ_ANY || otype >= K_OBJ_LAST) {
 		LOG_ERR("bad object type %d requested", otype);


### PR DESCRIPTION
Need to initialize tidx before using it, to
supress compiler warning.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

The compiler warning is:
```
[68/150] Building C object zephyr/kernel/CMakeFiles/kernel.dir/userspace.c.obj
C:/Users/Ioannis/zephyrproject/zephyr/kernel/userspace.c: In function 'z_impl_k_object_alloc':
C:/Users/Ioannis/zephyrproject/zephyr/kernel/userspace.c:319:22: warning: 'tidx' may be used uninitialized in this function [-Wmaybe-uninitialized]
   zo->data.thread_id = tidx;
```

I suspect that thread_idx_alloc() will initialize the variable, but the compiler does not know it. @andrewboie I assumed 0 would be a good value here.