### PR TITLE
doc: bluetooth: Add 2.2.x Host qualification listing

### DIFF
--- a/doc/guides/bluetooth/bluetooth-qual.rst
+++ b/doc/guides/bluetooth/bluetooth-qual.rst
@@ -30,7 +30,7 @@ Host qualifications
 
    * - 1.13
      - `QDID 119517 <https://launchstudio.bluetooth.com/ListingDetails/70189>`__
-     - Nordic
+     - Nordic Semiconductor
 
 Mesh qualifications
 ===================
@@ -59,12 +59,12 @@ Controller qualifications
 
    * - 1.14.x
      - `QDID 135679 <https://launchstudio.bluetooth.com/ListingDetails/90777>`__
-     - Nordic
+     - Nordic Semiconductor
      - nRF52x
 
    * - 1.9 to 1.13
      - `QDID 101395 <https://launchstudio.bluetooth.com/ListingDetails/25166>`__
-     - Nordic
+     - Nordic Semiconductor
      - nRF52x
 
 ICS Features

--- a/doc/guides/bluetooth/bluetooth-qual.rst
+++ b/doc/guides/bluetooth/bluetooth-qual.rst
@@ -20,6 +20,10 @@ Host qualifications
      - Link
      - Qualifying Company
 
+   * - 2.2.x
+     - `QDID 151074 <https://launchstudio.bluetooth.com/ListingDetails/109287>`_
+     - Demant A/S
+
    * - 1.14.x
      - `QDID 139258 <https://launchstudio.bluetooth.com/ListingDetails/95152>`__
      - The Linux Foundation


### PR DESCRIPTION
Add the new listing from Demant/Oticon.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>