### PR TITLE
net: mqtt: Constify utf8 pointer in mqtt_utf8 struct

### DIFF
--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -150,7 +150,7 @@ enum mqtt_suback_return_code {
 
 /** @brief Abstracts UTF-8 encoded strings. */
 struct mqtt_utf8 {
-	uint8_t *utf8;             /**< Pointer to UTF-8 string. */
+	const uint8_t *utf8;       /**< Pointer to UTF-8 string. */
 	uint32_t size;             /**< Size of UTF string, in bytes. */
 };
 


### PR DESCRIPTION
mqtt_utf8 structure is used to store the client_id, user_name, password,
topic, will_message.
There is no reason for the mqtt code to modify such data, therefore we
can constify the utf8 pointer.

This would also means that theses client, topic, ... strings can be
safely stored in ROM.

Signed-off-by: Xavier Chapron <xavier.chapron@stimio.fr>