### PR TITLE
shell: uart: Add option to route shell through USB CDC ACM

### DIFF
--- a/subsys/shell/Kconfig.backends
+++ b/subsys/shell/Kconfig.backends
@@ -30,6 +30,15 @@ config SHELL_PROMPT_UART
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_SHELL_UART := zephyr,shell-uart
 
+config UART_SHELL_USE_CDC_ACM
+	bool "Deliver Shell through USB CDC AMC"
+	depends on USB_DEVICE_STACK
+	depends on USB_CDC_ACM
+	help
+	  This option allows for directing shell through USB CDC ACM-based
+	  serial. Make sure UART_SHELL_ON_DEV_NAME is set to a
+	  UART_SHELL_USE_CDC_ACM-based value.
+
 config UART_SHELL_ON_DEV_NAME
 	string "Device Name of UART Device for SHELL_BACKEND_SERIAL"
 	default "$(dt_chosen_label,$(DT_CHOSEN_Z_SHELL_UART))" if HAS_DTS

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -9,6 +9,8 @@
 #include <init.h>
 #include <logging/log.h>
 
+#include <usb/usb_device.h>
+
 #define LOG_MODULE_NAME shell_uart
 LOG_MODULE_REGISTER(shell_uart);
 
@@ -273,6 +275,10 @@ static int enable_shell_uart(struct device *arg)
 	u32_t level =
 		(CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > LOG_LEVEL_DBG) ?
 		CONFIG_LOG_MAX_LEVEL : CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL;
+	
+	if (IS_ENABLED(CONFIG_UART_SHELL_USE_CDC_ACM)) {
+		usb_enable(NULL);
+	}
 
 	if (dev == NULL) {
 		return -ENODEV;
@@ -282,7 +288,9 @@ static int enable_shell_uart(struct device *arg)
 
 	return 0;
 }
-SYS_INIT(enable_shell_uart, POST_KERNEL, 0);
+SYS_INIT(enable_shell_uart, POST_KERNEL,
+		IS_ENABLED(CONFIG_UART_SHELL_USE_CDC_ACM) ?
+			CONFIG_APPLICATION_INIT_PRIORITY : 0);
 
 const struct shell *shell_backend_uart_get_ptr(void)
 {


### PR DESCRIPTION
Addition of a simple way of permitting routing of shell through a USB CDC ACM UART.

Fixes: #26051.

Signed-off-by: Kuba Sanak <contact@kuba.fyi>