### PR TITLE
docs: ring_buffer: Fix a bug in doc example code.

### DIFF
--- a/doc/reference/kernel/other/ring_buffers.rst
+++ b/doc/reference/kernel/other/ring_buffers.rst
@@ -136,7 +136,7 @@ is capable of holding 64 words of data and metadata information.
     struct my_struct ms;
 
     void init_my_struct {
-        ring_buf_init(&ms.rb, sizeof(ms.buffer), ms.buffer);
+        ring_buf_init(&ms.rb, MY_RING_BUF_SIZE, ms.buffer);
         ...
     }
 


### PR DESCRIPTION
The example code use of ring_buf_init() uses the buffer size in
bytes instead of 32-bit chunks, which is the correct way around.

Signed-off-by: Kuba Sanak <contact@kuba.fyi>