### PR TITLE
Entropy: nRF: Clear NVIC flags before CPU idling

### DIFF
--- a/boards/posix/nrf52_bsim/board_soc.h
+++ b/boards/posix/nrf52_bsim/board_soc.h
@@ -29,6 +29,7 @@
 #include "irq.h"
 #include "irq_sources.h"
 #include "NRF_regs.h"
+#include "cmsis.h"
 #include "nrf_soc_if.h"
 
 #define OFFLOAD_SW_IRQ SWI0_EGU0_IRQn

--- a/boards/posix/nrf52_bsim/cmsis.h
+++ b/boards/posix/nrf52_bsim/cmsis.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020 Oticon A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * This header defines replacements for inline
+ * ARM Cortex-M CMSIS intrinsics.
+ */
+
+#ifndef BOARDS_POSIX_NRF52_BSIM_CMSIS_H
+#define BOARDS_POSIX_NRF52_BSIM_CMSIS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Implement ARM Data Synchronization Barrier instruction as no-op. */
+static inline void __DSB(void) {}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARDS_POSIX_NRF52_BSIM_CMSIS_H */

--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -290,6 +290,15 @@ static int entropy_nrf5_get_entropy_isr(struct device *dev, uint8_t *buf, uint16
 
 			while (!nrf_rng_event_check(NRF_RNG,
 						    NRF_RNG_EVENT_VALRDY)) {
+				/*
+				 * To guarantee waking up from the event, the
+				 * SEV-On-Pend feature must be enabled (enabled
+				 * during ARCH initialization).
+				 *
+				 * DSB is recommended by spec before WFE (to
+				 * guarantee completion of memory transactions)
+				 */
+				__DSB();
 				__WFE();
 				__SEV();
 				__WFE();

--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -278,6 +278,13 @@ static int entropy_nrf5_get_entropy_isr(struct device *dev, uint8_t *buf, uint16
 		nrf_rng_event_clear(NRF_RNG, NRF_RNG_EVENT_VALRDY);
 		nrf_rng_task_trigger(NRF_RNG, NRF_RNG_TASK_START);
 
+		/* Clear NVIC pending bit. This ensures that a subsequent
+		 * RNG event will set the Cortex-M single-bit event register
+		 * to 1 (the bit is set when NVIC pending IRQ status is
+		 * changed from 0 to 1)
+		 */
+		NVIC_ClearPendingIRQ(IRQN);
+
 		do {
 			int byte;
 


### PR DESCRIPTION
Fixes #26105 

Aims at fixing an (ugly) race condition in the entropy driver.

Tested on
- nrf51dk_nrf51422
- nrf52dk_nrf52832
- nrf52833dk_nrf52833
- nrf52840dk_nrf52840