### PR TITLE
64 bit MMIO fixups

### DIFF
--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -891,7 +891,7 @@ idt48:
 
 /*
  * Page tables. Long mode requires them, but we don't implement any memory
- * protection yet, so these simply identity-map the first 4GB w/ 1GB pages.
+ * protection yet, so these simply identity-map the first 8GB w/ 1GB pages.
  */
 
 .align 4096
@@ -910,7 +910,15 @@ pdp:	.long 0x00000083		/* 0x83 = 1GB, R/W, P */
 	.long 0
 	.long 0xC0000083
 	.long 0
-	.fill 4064, 1, 0
+	.long 0x00000083
+	.long 1
+	.long 0x40000083
+	.long 1
+	.long 0x80000083
+	.long 1
+	.long 0xC0000083
+	.long 1
+	.fill (4096 - 8*8), 1, 0
 
 .section .gdt,"ad"
 

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -272,7 +272,7 @@ struct uart_ns16550_device_config {
 /** Device data structure */
 struct uart_ns16550_dev_data_t {
 #ifdef UART_NS16550_PCIE_ENABLED
-	struct uart_device_config devconf;
+	uint64_t pcimem;
 #endif
 	struct uart_config uart_config;
 	struct k_spinlock lock;
@@ -290,11 +290,11 @@ struct uart_ns16550_dev_data_t {
 
 static const struct uart_driver_api uart_ns16550_driver_api;
 
-static inline uint32_t get_port(struct device *dev)
+static inline uintptr_t get_port(struct device *dev)
 {
 #ifdef UART_NS16550_PCIE_ENABLED
 	if (DEV_CFG(dev)->pcie) {
-		return DEV_DATA(dev)->devconf.port;
+		return (uintptr_t) DEV_DATA(dev)->pcimem;
 	}
 #endif /* UART_NS16550_PCIE_ENABLED */
 
@@ -352,7 +352,7 @@ static int uart_ns16550_configure(struct device *dev,
 			goto out;
 		}
 
-		dev_data->devconf.port = pcie_get_mbar(dev_cfg->pcie_bdf, 0);
+		dev_data->pcimem = pcie_get_mbar(dev_cfg->pcie_bdf, 0);
 		pcie_set_cmd(dev_cfg->pcie_bdf, PCIE_CONF_CMDSTAT_MEM, true);
 	}
 #endif

--- a/include/drivers/pcie/pcie.h
+++ b/include/drivers/pcie/pcie.h
@@ -74,7 +74,7 @@ extern bool pcie_probe(pcie_bdf_t bdf, pcie_id_t id);
  * @brief Get the nth MMIO address assigned to an endpoint.
  * @param bdf the PCI(e) endpoint
  * @param index (0-based) index
- * @return the (32-bit) address, or PCI_CONF_BAR_NONE if nonexistent.
+ * @return the address, or PCI_CONF_BAR_NONE if nonexistent.
  *
  * A PCI(e) endpoint has 0 or more memory-mapped regions. This function
  * allows the caller to enumerate them by calling with index=0..n. If
@@ -82,17 +82,7 @@ extern bool pcie_probe(pcie_bdf_t bdf, pcie_id_t id);
  * are order-preserving with respect to the endpoint BARs: e.g., index 0
  * will return the lowest-numbered memory BAR on the endpoint.
  */
-extern uint32_t pcie_get_mbar(pcie_bdf_t bdf, unsigned int index);
-
-/**
- * @brief Get the nth I/O address assigned to an endpoint.
- * @param bdf the PCI(e) endpoint
- * @param index (0-based) index
- * @return the (32-bit) address, or PCI_CONF_BAR_NONE if nonexistent.
- *
- * Analogous to pcie_get_mbar(), except returns I/O region data.
- */
-extern uint32_t pcie_get_iobar(pcie_bdf_t bdf, unsigned int index);
+extern uintptr_t pcie_get_mbar(pcie_bdf_t bdf, unsigned int index);
 
 /**
  * @brief Set or reset bits in the endpoint command/status register.
@@ -180,7 +170,7 @@ extern void pcie_irq_enable(pcie_bdf_t bdf, unsigned int irq);
 #define PCIE_CONF_BAR_IO(w)		(((w) & 0x00000001U) == 0x00000001U)
 #define PCIE_CONF_BAR_MEM(w)		(((w) & 0x00000001U) != 0x00000001U)
 #define PCIE_CONF_BAR_64(w)		(((w) & 0x00000006U) == 0x00000004U)
-#define PCIE_CONF_BAR_ADDR(w)		((w) & 0xFFFFFFF0U)
+#define PCIE_CONF_BAR_ADDR(w)		((w) & ~0xfUL)
 #define PCIE_CONF_BAR_NONE		0U
 
 /*

--- a/include/sys/sys_io.h
+++ b/include/sys/sys_io.h
@@ -17,7 +17,7 @@ extern "C" {
 #endif
 
 typedef uint32_t io_port_t;
-typedef uint32_t mm_reg_t;
+typedef uintptr_t mm_reg_t;
 typedef uintptr_t mem_addr_t;
 
 /* Port I/O functions */


### PR DESCRIPTION
Not all memory mapped devices live in the bottom 4G of memory.  Some experimentation on up_squared showed a bunch of places where we were getting this wrong.

You can exercise this on up_squared using the rig in #26111 and setting the console UART address to 0x180000000ULL, which is just above physical memory.