### PR TITLE
drivers: serial: Fix uart_irq_tx_complete() in remaining mcux drivers

### DIFF
--- a/drivers/serial/uart_mcux.c
+++ b/drivers/serial/uart_mcux.c
@@ -132,16 +132,17 @@ static int uart_mcux_irq_tx_complete(struct device *dev)
 	const struct uart_mcux_config *config = dev->config_info;
 	uint32_t flags = UART_GetStatusFlags(config->base);
 
-	return (flags & kUART_TxDataRegEmptyFlag) != 0U;
+	return (flags & kUART_TransmissionCompleteFlag) != 0U;
 }
 
 static int uart_mcux_irq_tx_ready(struct device *dev)
 {
 	const struct uart_mcux_config *config = dev->config_info;
 	uint32_t mask = kUART_TxDataRegEmptyInterruptEnable;
+	uint32_t flags = UART_GetStatusFlags(config->base);
 
 	return (UART_GetEnabledInterrupts(config->base) & mask)
-		&& uart_mcux_irq_tx_complete(dev);
+		&& (flags & kUART_TxDataRegEmptyFlag);
 }
 
 static void uart_mcux_irq_rx_enable(struct device *dev)

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -142,18 +142,18 @@ static void mcux_flexcomm_irq_tx_disable(struct device *dev)
 static int mcux_flexcomm_irq_tx_complete(struct device *dev)
 {
 	const struct mcux_flexcomm_config *config = dev->config_info;
-	uint32_t flags = USART_GetStatusFlags(config->base);
 
-	return (flags & kUSART_TxFifoEmptyFlag) != 0U;
+	return (config->base->STAT & USART_STAT_TXIDLE_MASK) != 0;
 }
 
 static int mcux_flexcomm_irq_tx_ready(struct device *dev)
 {
 	const struct mcux_flexcomm_config *config = dev->config_info;
 	uint32_t mask = kUSART_TxLevelInterruptEnable;
+	uint32_t flags = USART_GetStatusFlags(config->base);
 
 	return (USART_GetEnabledInterrupts(config->base) & mask)
-		&& mcux_flexcomm_irq_tx_complete(dev);
+		&& (flags & kUSART_TxFifoEmptyFlag);
 }
 
 static void mcux_flexcomm_irq_rx_enable(struct device *dev)

--- a/drivers/serial/uart_mcux_lpsci.c
+++ b/drivers/serial/uart_mcux_lpsci.c
@@ -134,16 +134,17 @@ static int mcux_lpsci_irq_tx_complete(struct device *dev)
 	const struct mcux_lpsci_config *config = dev->config_info;
 	uint32_t flags = LPSCI_GetStatusFlags(config->base);
 
-	return (flags & kLPSCI_TxDataRegEmptyFlag) != 0U;
+	return (flags & kLPSCI_TransmissionCompleteFlag) != 0U;
 }
 
 static int mcux_lpsci_irq_tx_ready(struct device *dev)
 {
 	const struct mcux_lpsci_config *config = dev->config_info;
 	uint32_t mask = kLPSCI_TxDataRegEmptyInterruptEnable;
+	uint32_t flags = LPSCI_GetStatusFlags(config->base);
 
 	return (LPSCI_GetEnabledInterrupts(config->base) & mask)
-		&& mcux_lpsci_irq_tx_complete(dev);
+		&& (flags & kLPSCI_TxDataRegEmptyFlag);
 }
 
 static void mcux_lpsci_irq_rx_enable(struct device *dev)


### PR DESCRIPTION
Extends the fix in commit 21756751997543fa6946d67415dce1f176f36d60 to
all other mcux serial drivers. They were incorrectly checking if the
transmit buffer was empty when they should have been checking if the
transmission is complete.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Thank you @andy0808 for catching this bug