### PR TITLE
boards: arm: nrf52840_mdk: Add support for Nordic nRF5 bootloader

### DIFF
--- a/boards/arm/nrf52840_mdk/Kconfig
+++ b/boards/arm/nrf52840_mdk/Kconfig
@@ -3,8 +3,19 @@
 # Copyright (c) 2018 makerdiary.com
 # SPDX-License-Identifier: Apache-2.0
 
+if BOARD_NRF52840_MDK
+
 config BOARD_ENABLE_DCDC
 	bool "Enable DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
-	depends on BOARD_NRF52840_MDK
+
+config BOARD_HAS_NRF5_BOOTLOADER
+	bool "Board has nRF5 bootloader"
+	default y
+	help
+	 If selected, applications are linked so that they can be loaded by
+	 Nordic nRF5 bootloader. Disable CONFIG_GPIO_AS_PINRESET if this is
+	 is selected.
+
+endif # BOARD_NRF52840_MDK

--- a/boards/arm/nrf52840_mdk/Kconfig.defconfig
+++ b/boards/arm/nrf52840_mdk/Kconfig.defconfig
@@ -8,6 +8,31 @@ if BOARD_NRF52840_MDK
 config BOARD
 	default "nrf52840_mdk"
 
+
+# To let the nRF5 bootloader load an application, the application
+# must be linked after Nordic MBR, that is factory-programmed on the board.
+
+# Nordic nRF5 booatloader exists outside of the partitions specified in the
+# DTS file, so we manually override FLASH_LOAD_OFFEST to link the application
+# correctly, after Nordic MBR.
+
+# When building MCUBoot, MCUBoot itself will select USE_CODE_PARTITION
+# which will make it link into the correct partition specified in DTS file,
+# so no override is necessary.
+
+config FLASH_LOAD_OFFSET
+	default 0x1000
+	depends on BOARD_HAS_NRF5_BOOTLOADER && !USE_DT_CODE_PARTITION
+
+
+# To start the nrf bootloader in dfu mode, the default reset pin P0.18 must be a simple
+# GPIO, otherwise dfu functionality is not accessible any more.
+# To avoid losing this, make it default
+config GPIO_AS_PINRESET
+	default n if BOARD_HAS_NRF5_BOOTLOADER && !USE_DT_CODE_PARTITION
+	default y
+
+
 if USB
 
 config USB_NRFX

--- a/boards/arm/nrf52840_mdk/fstab-debugger.dts
+++ b/boards/arm/nrf52840_mdk/fstab-debugger.dts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Flash partition table without support for Nordic nRF5 bootloader */
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x000000000 0x0000C000>;
+		};
+
+		slot0_partition: partition@C000 {
+			label = "image-0";
+			reg = <0x0000C000 0x00067000>;
+		};
+		slot1_partition: partition@73000 {
+			label = "image-1";
+			reg = <0x00073000 0x000067000>;
+		};
+		scratch_partition: partition@da000 {
+			label = "image-scratch";
+			reg = <0x000da000 0x0001e000>;
+		};
+		storage_partition: partition@f8000 {
+			label = "storage";
+			reg = <0x000f8000 0x00008000>;
+		};
+	};
+};

--- a/boards/arm/nrf52840_mdk/fstab-stock.dts
+++ b/boards/arm/nrf52840_mdk/fstab-stock.dts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Flash partition table compatible with Nordic nRF5 bootloader */
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* MCUboot placed after Nordic MBR.
+		 * The size of this partition ensures that MCUBoot
+		 * can be built with CDC ACM support and w/o optimizations.
+		 */
+		boot_partition: partition@1000 {
+			label = "mcuboot";
+			reg = <0x00001000 0x000f000>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 0x00005e000>;
+		};
+		slot1_partition: partition@6e000 {
+			label = "image-1";
+			reg = <0x006e000 0x00005e000>;
+		};
+		storage_partition: partition@cc000 {
+			label = "storage";
+			reg = <0x000cc000 0x00004000>;
+		};
+		scratch_partition: partition@d0000 {
+			label = "image-scratch";
+			reg = <0x000d0000 0x00010000>;
+		};
+
+		/* Nordic nRF5 bootloader <0xe0000 0x1c000>
+		 *
+		 * In addition, the last and second last flash pages
+		 * are used by the nRF5 bootloader and MBR to store settings.
+		 */
+	};
+};

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -130,48 +130,13 @@
 	ch2-inverted;
 };
 
-&flash0 {
-	/*
-	 * For more information, see:
-	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
-	 */
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
+/* Include flash partition table.
+ * Two partition tables are available:
+ * fstab-stock		-compatible with Nordic nRF5 bootloader, default
+ * fstab-debugger	-to use an external debugger, w/o the nRF5 bootloader
+ */
+#include "fstab-stock.dts"
 
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
-		};
-		slot0_partition: partition@c000 {
-			label = "image-0";
-			reg = <0x0000C000 0x00067000>;
-		};
-		slot1_partition: partition@73000 {
-			label = "image-1";
-			reg = <0x00073000 0x00067000>;
-		};
-		scratch_partition: partition@da000 {
-			label = "image-scratch";
-			reg = <0x000da000 0x0001e000>;
-		};
-
-		/*
-		 * The flash starting at 0x000f8000 and ending at
-		 * 0x000fffff is reserved for use by the application.
-		 */
-
-		/*
-		 * Storage partition will be used by FCB/LittleFS/NVS
-		 * if enabled.
-		 */
-		storage_partition: partition@f8000 {
-			label = "storage";
-			reg = <0x000f8000 0x00008000>;
-		};
-	};
-};
 
 &usbd {
 	compatible = "nordic,nrf-usbd";

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk_defconfig
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk_defconfig
@@ -18,4 +18,3 @@ CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
 
 # additional board options
-CONFIG_GPIO_AS_PINRESET=y


### PR DESCRIPTION
Add support for using Nordic nRF5 bootloader to:
- flash a Zephyr application
- flash a MCUboot image as an application
- based on nrf52840dongle_nrf52840 nRF5 bootloader support

As is, this will also change the default to using the nrf5 bootloader and the matching flash partition layout.

Additionally the GPIO pin reset will not be enabled by default, as this will brick the dongles, because the default reset pin is used to start the bootloader in DFU mode.

fixes #26131
