### PR TITLE
libc: newlib: libc-hooks: Provide our own implementation of __chk_fail()

### DIFF
--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -275,6 +275,18 @@ __weak int *__errno(void)
 	return z_errno();
 }
 
+/* This function gets called if static buffer overflow detection is enabled
+ * on stdlib side (Newlib here), in case such an overflow is detected. Newlib
+ * provides an implementation not suitable for us, so we override it here.
+ */
+__weak FUNC_NORETURN void __chk_fail(void)
+{
+	static const char chk_fail_msg[] = "* buffer overflow detected *\n";
+	_write(2, chk_fail_msg, sizeof(chk_fail_msg) - 1);
+	k_oops();
+	CODE_UNREACHABLE;
+}
+
 #if CONFIG_XTENSA
 extern int _read(int fd, char *buf, int nbytes);
 extern int _open(const char *name, int mode);


### PR DESCRIPTION
The version as shipped in Newlib itself is coded a bit sloppily for an
embedded environment. We thus want to override it (and make it weak, to
allow user apps to override it in turn, if needed). The desired
properties of the implementation are:

1. It should call _write() (Newlib implementation calls write()).
2. It should be minimal (Newlib implementation allocates message
on the stack, i.e. misses "static const").

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>