### PR TITLE
net: Make it possible to include net/buf.h even if CONFIG_NET_BUF=n

### DIFF
--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -15,6 +15,10 @@
 #include <sys/util.h>
 #include <zephyr.h>
 
+#ifndef CONFIG_NET_BUF_USER_DATA_SIZE
+#define CONFIG_NET_BUF_USER_DATA_SIZE 0
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Since CONFIG_NET_BUF_USER_DATA_SIZE was not defined when
CONFIG_NET_BUF=n, compilation would fail on struct net_buf.user_data.

Signed-off-by: Tobias Svehagen <tobias.svehagen@gmail.com>