### PR TITLE
west: runners: jlink: Disable DAP after flashing

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -159,6 +159,16 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
             lines.append('r') # Reset and halt the target
 
         lines.append('g') # Start the CPU
+
+        # Reset the Debug Port CTRL/STAT register
+        # Under normal operation this is done automatically, but if other
+        # JLink tools are running, it is not performed.
+        # The J-Link scripting layer chains commands, meaning that writes are
+        # not actually performed until after the next operation. After writing
+        # the register, read it back to perform this flushing.
+        lines.append('writeDP 1 0')
+        lines.append('readDP 1')
+
         lines.append('q') # Close the connection and quit
 
         self.logger.debug('JLink commander script:')


### PR DESCRIPTION
Disables the Debug-Access-Port of the microcontroller after flashing.
If not disabled, the DAP consumes ~1.6mA until the debugger disables it
or a hard power cycle is applied.

The added command reset the value of the CTRL/STAT register of the DAP.
This clears the CSYSPWRUPREQ and CDBGPRWUPREQ bits, leaving the debug
hardware free to power off the appropriate hardware. In no way does it
hinder the ability to later connect to the device for debugging.

The second write is required as the first write is not applied.
Alternate approaches like `read before write` and `sleep before write`
were tested and did not work. `Write before write` works 100% of the
time.

This resolves the jlink portion of #26139

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>