### PR TITLE
tests: eventfd: drop POSIX_API ifdeffery

### DIFF
--- a/tests/posix/eventfd/src/main.c
+++ b/tests/posix/eventfd/src/main.c
@@ -14,11 +14,7 @@
 #define PTHREAD_STACK_MIN 0
 #endif
 
-#if CONFIG_POSIX_API
 #include <net/socket.h>
-#else
-#include <sys/socket.h>
-#endif
 
 #include <poll.h>
 


### PR DESCRIPTION
Test is configured with CONFIG_POSIX_API=y, so there is no reason to
check for it being enabled in C. Additionally when CONFIG_POSIX_API=n a
much "bigger" posix/sys/socket.h was included instead of net/socket.h,
which should be rather opposite.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>