### PR TITLE
[DNM]: west.yml: check CI ok when TemperatureCC26X2.c is added to build

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -74,7 +74,7 @@ manifest:
       revision: 6812113dc58d134b74acdeebbffb4f80b8eeab75
       path: modules/hal/stm32
     - name: hal_ti
-      revision: aabc6a04a8e871cbb01e02c22bb409f68001dc64
+      revision: pull/16/head
       path: modules/hal/ti
     - name: libmetal
       revision: 87e9e7f2c5b4e238236fe703db61ba23e48dc2ef


### PR DESCRIPTION
Do not merge. This is here just to run through CI cycles.

This should be checked before #26144. Sorry for doing it out of order

The symbol Temperature_getTemperature() is missing when BLE is enabled.

This change just ensures that CI is not broken when TemperatureCC26X2.c is linked in.

Relates-to: zephyrproject-rtos/hal_ti#16

CC: @galak @vanti 