### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: controller: proper exit on assert

### DIFF
--- a/tests/bluetooth/controller/mock_ctrl/src/ll_assert.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ll_assert.c
@@ -14,4 +14,5 @@
 void bt_ctlr_assert_handle(char *file, u32_t line)
 {
 	printf("Assertion failed in %s:%d\n", file, line);
+	exit(-1);
 }


### PR DESCRIPTION
The LL_ASSERT macro needs to exit with error code for a unittest
to fail

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>