### PR TITLE
storag/stream: fix stream_flash_bytes_written() return value

### DIFF
--- a/include/storage/stream_flash.h
+++ b/include/storage/stream_flash.h
@@ -90,7 +90,7 @@ int stream_flash_init(struct stream_flash_ctx *ctx, struct device *fdev,
  *
  * @param ctx context
  *
- * @return Number of bytes written to flash.
+ * @return Number of payload bytes written to flash.
  */
 size_t stream_flash_bytes_written(struct stream_flash_ctx *ctx);
 
@@ -105,6 +105,9 @@ size_t stream_flash_bytes_written(struct stream_flash_ctx *ctx);
  * @param data data to write
  * @param len Number of bytes to write
  * @param flush when true this forces any buffered data to be written to flash
+ *        A flush write should be the last write operation in a sequence of
+ *        write operations for given context (although this is not mandatory
+ *        if the total data size is a multiple of the buffer size).
  *
  * @return non-negative on success, negative errno code on fail
  */

--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -165,9 +165,12 @@ int stream_flash_buffered_write(struct stream_flash_ctx *ctx, const uint8_t *dat
 
 			memset(ctx->buf + ctx->buf_bytes, filler, fill_length);
 			ctx->buf_bytes += fill_length;
+		} else {
+			fill_length = 0;
 		}
 
 		rc = flash_sync(ctx);
+		ctx->bytes_written -= fill_length;
 	}
 
 	return rc;


### PR DESCRIPTION
stream_flash_bytes_written() returned number o bytes physically
written to the flash. This number might be bigger than the requested
number as is aligned to the device write-block-size.

stream_flash_bytes_written() should return number of bytes
written requested by the user.

fixes #26150

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>