### PR TITLE
Bluetooth: controller: Work around compiler silliness

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1750,7 +1750,7 @@ static void le_set_ext_adv_enable(struct net_buf *buf, struct net_buf **evt)
 
 	s = (void *) cmd->s;
 	enable = cmd->enable;
-	while (set_num--) {
+	do {
 		/* TODO: duration and events parameter use. */
 #if defined(CONFIG_BT_HCI_MESH_EXT)
 		status = ll_adv_enable(s->handle, cmd->enable, 0, 0, 0, 0, 0);
@@ -1765,7 +1765,7 @@ static void le_set_ext_adv_enable(struct net_buf *buf, struct net_buf **evt)
 		}
 
 		s++;
-	}
+	} while (--set_num);
 
 	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;


### PR DESCRIPTION
For some reason GCC 9.x doesn't seem to be able to realize that set_num
will always be > 0 and so the local variable status will always be
initialized. Use a do {} while instead to keep it happy.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>