### PR TITLE
soc: nxp_imx: Fix flash size in imxrt boot header

### DIFF
--- a/soc/arm/nxp_imx/rt/soc.c
+++ b/soc/arm/nxp_imx/rt/soc.c
@@ -78,7 +78,7 @@ const clock_video_pll_config_t videoPllConfig = {
 #ifdef CONFIG_NXP_IMX_RT_BOOT_HEADER
 const __imx_boot_data_section BOOT_DATA_T boot_data = {
 	.start = CONFIG_FLASH_BASE_ADDRESS,
-	.size = CONFIG_FLASH_SIZE,
+	.size = KB(CONFIG_FLASH_SIZE),
 	.plugin = PLUGIN_FLAG,
 	.placeholder = 0xFFFFFFFF,
 };


### PR DESCRIPTION
Fixes the imxrt boot header to set the flash size in Bytes instead of
KiB.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #25189

cc: @xueyunquan