### PR TITLE
interrupt_controller: gicv3: nested interrupt test failure fix.

### DIFF
--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -54,15 +54,17 @@ void arm_gic_irq_set_priority(unsigned int intid,
 	sys_write8(prio & GIC_PRI_MASK, IPRIORITYR(base, intid));
 
 	/* Interrupt type config */
-	idx = intid / GIC_NUM_CFG_PER_REG;
-	shift = (intid & (GIC_NUM_CFG_PER_REG - 1)) * 2;
+	if (!GIC_IS_SGI(intid)) {
+		idx = intid / GIC_NUM_CFG_PER_REG;
+		shift = (intid & (GIC_NUM_CFG_PER_REG - 1)) * 2;
 
-	val = sys_read32(ICFGR(base, idx));
-	val &= ~(GICD_ICFGR_MASK << shift);
-	if (flags & IRQ_TYPE_EDGE) {
-		val |= (GICD_ICFGR_TYPE << shift);
+		val = sys_read32(ICFGR(base, idx));
+		val &= ~(GICD_ICFGR_MASK << shift);
+		if (flags & IRQ_TYPE_EDGE) {
+			val |= (GICD_ICFGR_TYPE << shift);
+		}
+		sys_write32(val, ICFGR(base, idx));
 	}
-	sys_write32(val, ICFGR(base, idx));
 }
 
 void arm_gic_irq_enable(unsigned int intid)

--- a/include/arch/arm/aarch64/cpu.h
+++ b/include/arch/arm/aarch64/cpu.h
@@ -92,6 +92,27 @@
 #define ICC_SRE_ELx_DIB		BIT(2)
 #define ICC_SRE_EL3_EN		BIT(3)
 
+/* ICC SGI macros */
+#define SGIR_TGT_MASK		0xffff
+#define SGIR_AFF1_SHIFT		16
+#define SGIR_INTID_SHIFT	24
+#define SGIR_INTID_MASK		0xf
+#define SGIR_AFF2_SHIFT		32
+#define SGIR_IRM_SHIFT		40
+#define SGIR_IRM_MASK		0x1
+#define SGIR_AFF3_SHIFT		48
+#define SGIR_AFF_MASK		0xf
+
+#define SGIR_IRM_TO_AFF		0
+
+#define GICV3_SGIR_VALUE(_aff3, _aff2, _aff1, _intid, _irm, _tgt)	\
+	((((uint64_t) (_aff3) & SGIR_AFF_MASK) << SGIR_AFF3_SHIFT) |	\
+	 (((uint64_t) (_irm) & SGIR_IRM_MASK) << SGIR_IRM_SHIFT) |	\
+	 (((uint64_t) (_aff2) & SGIR_AFF_MASK) << SGIR_AFF2_SHIFT) |	\
+	 (((_intid) & SGIR_INTID_MASK) << SGIR_INTID_SHIFT) |		\
+	 (((_aff1) & SGIR_AFF_MASK) << SGIR_AFF1_SHIFT) |		\
+	 ((_tgt) & SGIR_TGT_MASK))
+
 /* Implementation defined register definations */
 #if defined(CONFIG_CPU_CORTEX_A72)
 

--- a/include/arch/arm/aarch64/cpu.h
+++ b/include/arch/arm/aarch64/cpu.h
@@ -139,4 +139,17 @@
 
 #define GET_EL(_mode)		(((_mode) >> MODE_EL_SHIFT) & MODE_EL_MASK)
 
+/* mpidr */
+#define MPIDR_AFFLVL_MASK	0xff
+
+#define MPIDR_AFF0_SHIFT	0
+#define MPIDR_AFF1_SHIFT	8
+#define MPIDR_AFF2_SHIFT	16
+#define MPIDR_AFF3_SHIFT	32
+
+#define MPIDR_AFFLVL(mpidr, aff_level) \
+		(((mpidr) >> MPIDR_AFF##aff_level##_SHIFT) & MPIDR_AFFLVL_MASK)
+
+#define GET_MPIDR()		read_sysreg(mpidr_el1)
+#define MPIDR_TO_CORE(mpidr)	MPIDR_AFFLVL(mpidr, 0)
 #endif /* ZEPHYR_INCLUDE_ARCH_ARM_AARCH64_CPU_H_ */

--- a/include/drivers/interrupt_controller/gic.h
+++ b/include/drivers/interrupt_controller/gic.h
@@ -210,6 +210,19 @@
 
 #endif /* CONFIG_GIC_VER <= 2 */
 
+#if defined(CONFIG_GIC_V3)
+/**
+ * @brief raise SGI to target cores
+ *
+ * @param sgi_id      SGI ID 0 to 15
+ * @param target_aff  target affinity in mpidr form.
+ *                    Aff level 1 2 3 will be extracted by api.
+ * @param target_list bitmask of target cores
+ */
+void gic_raise_sgi(unsigned int sgi_id, uint64_t target_aff,
+		   uint16_t target_list);
+#endif
+
 /* GICD_ICFGR */
 #define GICD_ICFGR_MASK			BIT_MASK(2)
 #define GICD_ICFGR_TYPE			BIT(1)
@@ -220,6 +233,12 @@
 /*
  * Common Helper Constants
  */
+#define GIC_SGI_INT_BASE		0
+#define GIC_PPI_INT_BASE		16
+
+#define GIC_IS_SGI(intid)		(((intid) >= GIC_SGI_INT_BASE) && \
+					 ((intid) < GIC_PPI_INT_BASE))
+
 
 #define GIC_SPI_INT_BASE		32
 

--- a/include/dt-bindings/interrupt-controller/arm-gic.h
+++ b/include/dt-bindings/interrupt-controller/arm-gic.h
@@ -21,6 +21,6 @@
 #define	GIC_SPI			0x0
 #define	GIC_PPI			0x1
 
-#define IRQ_DEFAULT_PRIORITY	0xa
+#define IRQ_DEFAULT_PRIORITY	0xa0
 
 #endif

--- a/tests/kernel/interrupt/src/interrupt_util.h
+++ b/tests/kernel/interrupt/src/interrupt_util.h
@@ -62,6 +62,7 @@ static inline void trigger_irq(int irq)
 
 #elif defined(CONFIG_GIC)
 #include <drivers/interrupt_controller/gic.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
 
 static inline void trigger_irq(int irq)
 {

--- a/tests/kernel/interrupt/src/interrupt_util.h
+++ b/tests/kernel/interrupt/src/interrupt_util.h
@@ -74,8 +74,12 @@ static inline void trigger_irq(int irq)
 	 * Generate a software generated interrupt and forward it to the
 	 * requesting CPU.
 	 */
+#if CONFIG_GIC_VER <= 2
 	sys_write32(GICD_SGIR_TGTFILT_REQONLY | GICD_SGIR_SGIINTID(irq),
 		    GICD_SGIR);
+#else
+	gic_raise_sgi(irq, GET_MPIDR(), BIT(MPIDR_TO_CORE(GET_MPIDR())));
+#endif
 }
 
 #elif defined(CONFIG_CPU_ARCV2)

--- a/tests/kernel/interrupt/src/nested_irq.c
+++ b/tests/kernel/interrupt/src/nested_irq.c
@@ -47,8 +47,15 @@
 #define IRQ0_LINE	14
 #define IRQ1_LINE	15
 
-#define IRQ0_PRIO	2
-#define IRQ1_PRIO	1
+/*
+ * Choose lower prio for IRQ0 and higher priority for IRQ1
+ * Minimum legal value of GICC BPR is '3' ie  <gggg.ssss>
+ * Hence choosing default priority and highest possible priority
+ * '0x0' as the priorities so that the preemption rule applies
+ * generically to all GIC versions and security states.
+ */
+#define IRQ0_PRIO	IRQ_DEFAULT_PRIORITY
+#define IRQ1_PRIO	0x0
 #else
 /*
  * For all the other platforms, use the last two available IRQ lines for


### PR DESCRIPTION
GICv3 interrupt tests ( nested interrupt test) failed because SGI generation api was not supported
in GICv3. This PR adds support to provide API for SGI generation.  This API will also be required in 
case of SMP to raise the IPI. Other associated development viz: few helper macros etc are also part of this PR.

The priority level choices in interrupt test is suitably corrected to work on possibly all combinations of GIC configurations.