### PR TITLE
Add a PWM driver for the SAM0 and enable on the Arduino Zero

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -198,6 +198,7 @@
 /drivers/pinmux/stm32/                    @idlethread
 /drivers/pinmux/*hsdk*                    @iriszzw
 /drivers/pwm/*litex*                      @mateusz-holenko @kgugala @pgielda
+/drivers/pwm/*sam0*                       @nzmichaelh
 /drivers/sensor/                          @MaureenHelm
 /drivers/sensor/ams_iAQcore/              @alexanderwachter
 /drivers/sensor/ens210/                   @alexanderwachter

--- a/boards/arm/arduino_zero/arduino_zero.dts
+++ b/boards/arm/arduino_zero/arduino_zero.dts
@@ -23,6 +23,7 @@
 		led0 = &led0;
 		led1 = &led1;
 		led2 = &led2;
+		pwm-led0 = &pwm_led0;
 	};
 
 	leds {
@@ -41,6 +42,13 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led0: pwm_led_0 {
+			pwms = <&tcc2 1>;
+		};
+	};
 };
 
 &cpu0 {
@@ -70,6 +78,15 @@
 	dopo = <1>;
 	#address-cells = <1>;
 	#size-cells = <0>;
+};
+
+&tcc2 {
+	status = "okay";
+	compatible = "atmel,sam0-tcc-pwm";
+	/* Gives a maximum period of 1.4 s */
+	prescaler = <1024>;
+
+	#pwm-cells = <1>;
 };
 
 &flash0 {

--- a/boards/arm/arduino_zero/arduino_zero.yaml
+++ b/boards/arm/arduino_zero/arduino_zero.yaml
@@ -15,6 +15,7 @@ supported:
   - gpio
   - hwinfo
   - pinmux
+  - pwm
   - spi
   - uart
   - usb_device

--- a/boards/arm/arduino_zero/doc/index.rst
+++ b/boards/arm/arduino_zero/doc/index.rst
@@ -45,6 +45,8 @@ features:
 +-----------+------------+------------------------------------------+
 | GPIO      | on-chip    | I/O ports                                |
 +-----------+------------+------------------------------------------+
+| PWM       | on-chip    | Pulse Width Modulation                   |
++-----------+------------+------------------------------------------+
 | USART     | on-chip    | Serial ports                             |
 +-----------+------------+------------------------------------------+
 | SPI       | on-chip    | Serial Peripheral Interface ports        |
@@ -77,6 +79,13 @@ Serial Port
 The SAMD21 MCU has 6 SERCOM based USARTs. One of the USARTs
 (SERCOM5) is connected to the onboard Atmel Embedded Debugger (EDBG).
 SERCOM0 is available on the D0/D1 pins.
+
+PWM
+===
+
+The SAMD21 MCU has 3 TCC based PWM units with up to 4 outputs each and a period
+of 24 bits or 16 bits.  If :code:`CONFIG_PWM_SAM0_TCC` is enabled then LED0 is
+driven by TCC2 instead of by GPIO.
 
 SPI Port
 ========

--- a/boards/arm/arduino_zero/pinmux.c
+++ b/boards/arm/arduino_zero/pinmux.c
@@ -63,6 +63,12 @@ static int board_pinmux_init(struct device *dev)
 #warning Pin mapping may not be configured
 #endif
 
+#if ATMEL_SAM0_DT_TCC_CHECK(2, atmel_sam0_tcc_pwm) &&                          \
+	defined(CONFIG_PWM_SAM0_TCC)
+	/* LED0 on PA17/TCC2/WO[1] */
+	pinmux_pin_set(muxa, 17, PINMUX_FUNC_E);
+#endif
+
 #ifdef CONFIG_USB_DC_SAM0
 	/* USB DP on PA25, USB DM on PA24 */
 	pinmux_pin_set(muxa, 25, PINMUX_FUNC_G);

--- a/drivers/pwm/CMakeLists.txt
+++ b/drivers/pwm/CMakeLists.txt
@@ -17,6 +17,7 @@ zephyr_library_sources_ifdef(CONFIG_PWM_XEC		pwm_mchp_xec.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_LITEX		pwm_litex.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_RV32M1_TPM	pwm_rv32m1_tpm.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_MCUX_TPM	pwm_mcux_tpm.c)
+zephyr_library_sources_ifdef(CONFIG_PWM_SAM0_TCC	pwm_sam0_tcc.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE   pwm_handlers.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_SHELL   pwm_shell.c)

--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -51,4 +51,6 @@ source "drivers/pwm/Kconfig.rv32m1_tpm"
 
 source "drivers/pwm/Kconfig.mcux_tpm"
 
+source "drivers/pwm/Kconfig.sam0"
+
 endif # PWM

--- a/drivers/pwm/Kconfig.sam0
+++ b/drivers/pwm/Kconfig.sam0
@@ -1,0 +1,10 @@
+# Atmel SAM0 TCC as PWM configuration
+
+# Copyright (c) 2020 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+config PWM_SAM0_TCC
+	bool "Atmel SAM0 MCU Family TCC PWM Driver"
+	depends on SOC_FAMILY_SAM0
+	help
+	  Enable PWM driver for Atmel SAM0 MCUs using the TCC timer/counter.

--- a/drivers/pwm/pwm_sam0_tcc.c
+++ b/drivers/pwm/pwm_sam0_tcc.c
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2020 Google LLC.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * PWM driver using the SAM0 Timer/Counter (TCC) in Normal PWM (NPWM) mode.
+ * Supports the SAMD21 and SAMD5x series.
+ */
+
+#define DT_DRV_COMPAT atmel_sam0_tcc_pwm
+
+#include <device.h>
+#include <errno.h>
+#include <drivers/pwm.h>
+#include <soc.h>
+
+/* Static configuration */
+struct pwm_sam0_config {
+	Tcc *regs;
+	uint8_t channels;
+	uint8_t counter_size;
+	uint16_t prescaler;
+	uint32_t freq;
+
+#ifdef MCLK
+	volatile uint32_t *mclk;
+	uint32_t mclk_mask;
+	uint16_t gclk_id;
+#else
+	uint32_t pm_apbcmask;
+	uint16_t gclk_clkctrl_id;
+#endif
+};
+
+#define DEV_CFG(dev) ((const struct pwm_sam0_config *const)(dev)->config_info)
+
+/* Wait for the peripheral to finish all commands */
+static void wait_synchronization(Tcc *regs)
+{
+	while (regs->SYNCBUSY.reg != 0) {
+	}
+}
+
+static int pwm_sam0_get_cycles_per_sec(struct device *dev, uint32_t ch,
+				       uint64_t *cycles)
+{
+	const struct pwm_sam0_config *const cfg = DEV_CFG(dev);
+
+	if (ch >= cfg->channels) {
+		return -EINVAL;
+	}
+	*cycles = cfg->freq;
+
+	return 0;
+}
+
+static int pwm_sam0_pin_set(struct device *dev, uint32_t ch,
+			    uint32_t period_cycles, uint32_t pulse_cycles,
+			    pwm_flags_t flags)
+{
+	const struct pwm_sam0_config *const cfg = DEV_CFG(dev);
+	Tcc *regs = cfg->regs;
+	uint32_t top = 1 << cfg->counter_size;
+	uint32_t invert_mask = 1 << ch;
+	bool invert = ((flags & PWM_POLARITY_INVERTED) != 0);
+	bool inverted = ((regs->DRVCTRL.vec.INVEN & invert_mask) != 0);
+
+	if (ch >= cfg->channels) {
+		return -EINVAL;
+	}
+	if (period_cycles >= top || pulse_cycles >= top) {
+		return -EINVAL;
+	}
+
+	/*
+	 * Update the buffered width and period.  These will be automatically
+	 * loaded on the next cycle.
+	 */
+#ifdef TCC_PERBUF_PERBUF
+	/* SAME51 naming */
+	regs->CCBUF[ch].reg = TCC_CCBUF_CCBUF(pulse_cycles);
+	regs->PERBUF.reg = TCC_PERBUF_PERBUF(period_cycles);
+#else
+	/* SAMD21 naming */
+	regs->CCB[ch].reg = TCC_CCB_CCB(pulse_cycles);
+	regs->PERB.reg = TCC_PERB_PERB(period_cycles);
+#endif
+
+	if (invert != inverted) {
+		regs->CTRLA.bit.ENABLE = 0;
+		wait_synchronization(regs);
+
+		regs->DRVCTRL.vec.INVEN ^= invert_mask;
+		regs->CTRLA.bit.ENABLE = 1;
+		wait_synchronization(regs);
+	}
+
+	return 0;
+}
+
+static int pwm_sam0_init(struct device *dev)
+{
+	const struct pwm_sam0_config *const cfg = DEV_CFG(dev);
+	Tcc *regs = cfg->regs;
+
+	/* Enable the clocks */
+#ifdef MCLK
+	GCLK->PCHCTRL[cfg->gclk_id].reg =
+		GCLK_PCHCTRL_GEN_GCLK0 | GCLK_PCHCTRL_CHEN;
+	*cfg->mclk |= cfg->mclk_mask;
+#else
+	GCLK->CLKCTRL.reg = cfg->gclk_clkctrl_id | GCLK_CLKCTRL_GEN_GCLK0 |
+			    GCLK_CLKCTRL_CLKEN;
+	PM->APBCMASK.reg |= cfg->pm_apbcmask;
+#endif
+
+	regs->CTRLA.bit.SWRST = 1;
+	wait_synchronization(regs);
+
+	regs->CTRLA.reg = cfg->prescaler;
+	regs->WAVE.reg = TCC_WAVE_WAVEGEN_NPWM;
+	regs->PER.reg = TCC_PER_PER(1);
+
+	regs->CTRLA.bit.ENABLE = 1;
+	wait_synchronization(regs);
+
+	return 0;
+}
+
+static const struct pwm_driver_api pwm_sam0_driver_api = {
+	.pin_set = pwm_sam0_pin_set,
+	.get_cycles_per_sec = pwm_sam0_get_cycles_per_sec,
+};
+
+#ifdef MCLK
+#define PWM_SAM0_INIT_CLOCKS(inst)					       \
+	.mclk = (volatile uint32_t *)MCLK_MASK_DT_INT_REG_ADDR(inst),	       \
+	.mclk_mask = BIT(DT_INST_CLOCKS_CELL_BY_NAME(inst, mclk, bit)),	       \
+	.gclk_id = DT_INST_CLOCKS_CELL_BY_NAME(inst, gclk, periph_ch)
+#else
+#define PWM_SAM0_INIT_CLOCKS(inst)					       \
+	.pm_apbcmask = BIT(DT_INST_CLOCKS_CELL_BY_NAME(inst, pm, bit)),	       \
+	.gclk_clkctrl_id = DT_INST_CLOCKS_CELL_BY_NAME(inst, gclk, clkctrl_id)
+#endif
+
+#define PWM_SAM0_INIT(inst)						       \
+	static const struct pwm_sam0_config pwm_sam0_config_##inst = {	       \
+		.regs = (Tcc *)DT_INST_REG_ADDR(inst),			       \
+		.channels = DT_INST_PROP(inst, channels),		       \
+		.counter_size = DT_INST_PROP(inst, counter_size),	       \
+		.prescaler = UTIL_CAT(TCC_CTRLA_PRESCALER_DIV,		       \
+				      DT_INST_PROP(inst, prescaler)),	       \
+		.freq = SOC_ATMEL_SAM0_GCLK0_FREQ_HZ /			       \
+			DT_INST_PROP(inst, prescaler),			       \
+		PWM_SAM0_INIT_CLOCKS(inst),				       \
+	};								       \
+									       \
+	DEVICE_AND_API_INIT(pwm_sam0_##inst, DT_INST_LABEL(inst),	       \
+			    &pwm_sam0_init, NULL, &pwm_sam0_config_##inst,     \
+			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,   \
+			    &pwm_sam0_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(PWM_SAM0_INIT)

--- a/dts/arm/atmel/samd21.dtsi
+++ b/dts/arm/atmel/samd21.dtsi
@@ -37,6 +37,42 @@
 			clocks = <&gclk 0x1d>, <&pm 0x20 14>;
 			clock-names = "GCLK", "PM";
 		};
+
+		tcc0: tcc@42002000 {
+			compatible = "atmel,sam0-tcc";
+			reg = <0x42002000 0x80>;
+			interrupts = <15 0>;
+			label = "TCC_0";
+			clocks = <&gclk 26>, <&pm 0x20 8>;
+			clock-names = "GCLK", "PM";
+
+			channels = <4>;
+			counter-size = <24>;
+		};
+
+		tcc1: tcc@42002400 {
+			compatible = "atmel,sam0-tcc";
+			reg = <0x42002400 0x80>;
+			interrupts = <16 0>;
+			label = "TCC_1";
+			clocks = <&gclk 26>, <&pm 0x20 9>;
+			clock-names = "GCLK", "PM";
+
+			channels = <2>;
+			counter-size = <24>;
+		};
+
+		tcc2: tcc@42002800 {
+			compatible = "atmel,sam0-tcc";
+			reg = <0x42002800 0x80>;
+			interrupts = <17 0>;
+			label = "TCC_2";
+			clocks = <&gclk 27>, <&pm 0x20 10>;
+			clock-names = "GCLK", "PM";
+
+			channels = <2>;
+			counter-size = <16>;
+		};
 	};
 };
 

--- a/dts/bindings/pwm/atmel,sam0-tcc-pwm.yaml
+++ b/dts/bindings/pwm/atmel,sam0-tcc-pwm.yaml
@@ -1,0 +1,62 @@
+# Copyright (c) 2020 Google LLC.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Atmel SAM0 TCC in PWM mode
+
+compatible: "atmel,sam0-tcc-pwm"
+
+include: [pwm-controller.yaml, base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  clocks:
+    required: true
+
+  clock-names:
+    required: true
+
+  label:
+    required: true
+
+  channels:
+    type: int
+    required: true
+    description: Number of channels this TCC has
+    enum:
+      - 2
+      - 3
+      - 4
+      - 6
+
+  counter-size:
+    type: int
+    required: true
+    description: Width of the TCC counter in bits
+    enum:
+      - 16
+      - 24
+
+  prescaler:
+    type: int
+    required: true
+    description: PWM prescaler
+    enum:
+      - 1
+      - 2
+      - 4
+      - 8
+      - 16
+      - 64
+      - 256
+      - 1024
+
+  "#pwm-cells":
+    const: 1
+
+pwm-cells:
+  - channel

--- a/soc/arm/atmel_sam0/common/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/common/Kconfig.defconfig.series
@@ -26,6 +26,9 @@ config I2C_SAM0
 config PINMUX_SAM0
 	default PINMUX
 
+config PWM_SAM0_TCC
+	default PWM
+
 config SPI_SAM0
 	default SPI
 

--- a/soc/arm/atmel_sam0/common/atmel_sam0_dt.h
+++ b/soc/arm/atmel_sam0/common/atmel_sam0_dt.h
@@ -39,6 +39,10 @@
 #define ATMEL_SAM0_DT_SERCOM_CHECK(n, compat) \
 	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(sercom##n), compat, okay)
 
+/* Use to check if TCC 'n' is enabled for a given 'compat' */
+#define ATMEL_SAM0_DT_TCC_CHECK(n, compat) \
+	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(tcc##n), compat, okay)
+
 /* Common macro for use to set HCLK_FREQ_HZ */
 #define ATMEL_SAM0_DT_CPU_CLK_FREQ_HZ \
 	DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)


### PR DESCRIPTION
This adds a PWM driver, enables PWM on the Arduino Zero, and connects it to the main LED.  Tested by running samples/basic/blinky_pwm and /fade_led.