### PR TITLE
qemu_x86: propagate exit reason code to the shell

### DIFF
--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -18,8 +18,15 @@ FUNC_NORETURN void arch_system_halt(unsigned int reason)
 
 	/* Causes QEMU to exit. We passed the following on the command line:
 	 * -device isa-debug-exit,iobase=0xf4,iosize=0x04
+	 *
+	 * For any value of the first argument X, the return value of the
+	 * QEMU process is (X * 2) + 1.
+	 *
+	 * It has been observed that if the emulator exits for a triple-fault
+	 * (often due to bad page tables or other CPU structures) it will
+	 * terminate with 0 error code.
 	 */
-	sys_out32(0, 0xf4);
+	sys_out32(reason, 0xf4);
 	CODE_UNREACHABLE;
 }
 #endif


### PR DESCRIPTION
This helps distingush between fatal errors if logging isn't
enabled.

As detailed in comments, pass a reason code which controls
the QEMU process' return value.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>