### PR TITLE
timer: hpet: support picoseconds in counter clock period reg

### DIFF
--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -64,6 +64,26 @@ config HPET_TIMER
 	  This option selects High Precision Event Timer (HPET) as a
 	  system timer.
 
+choice HPET_TIMER_COUNTER_CLK_PERIOD_UNIT
+	prompt "Time Unit of HPET Counter Clock Period"
+	depends on HPET_TIMER
+	default HPET_TIMER_COUNTER_CLK_PERIOD_UNIT_IN_FEMPTOSECONDS
+
+	config HPET_TIMER_COUNTER_CLK_PERIOD_UNIT_IN_FEMPTOSECONDS
+	bool "Femptoseconds"
+	help
+	  The COUNTER_CLK_ERIOD in general capabilities register
+	  uses femptoseconds (10^-15 seconds) to indicate the time
+	  between counter increments.
+
+	config HPET_TIMER_COUNTER_CLK_PERIOD_UNIT_IN_PICOSECONDS
+	bool "Picoseconds"
+	help
+	  The COUNTER_CLK_ERIOD in general capabilities register
+	  uses picoseconds (10^-12 seconds) to indicate the time
+	  between counter increments.
+endchoice
+
 config LOAPIC_TIMER
 	bool "LOAPIC timer"
 	depends on LOAPIC && X86

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -31,6 +31,13 @@
 
 #define MIN_DELAY 1000
 
+#ifdef CONFIG_HPET_TIMER_COUNTER_CLK_PERIOD_UNIT_IN_PICOSECONDS
+#define COUNTER_CLK_PERIOD_BASE	1000000000000ull
+#else
+/* Femptoseconds is default as specified in specification */
+#define COUNTER_CLK_PERIOD_BASE	1000000000000000ull
+#endif
+
 static struct k_spinlock lock;
 static unsigned int max_ticks;
 static unsigned int cyc_per_tick;
@@ -104,7 +111,7 @@ int z_clock_driver_init(struct device *device)
 	irq_enable(DT_INST_IRQN(0));
 
 	/* CLK_PERIOD_REG is in femtoseconds (1e-15 sec) */
-	hz = (uint32_t)(1000000000000000ull / CLK_PERIOD_REG);
+	hz = (uint32_t)(COUNTER_CLK_PERIOD_BASE / CLK_PERIOD_REG);
 	z_clock_hw_cycles_per_sec = hz;
 	cyc_per_tick = hz / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
 


### PR DESCRIPTION
The COUNTER_CLK_PERIOD in the general capabilities register
indicates the time period which the counter increments.
Traditionally, this time period is in femptoseconds
(10^-15 seconds). In some newer SoCs, this can be defined with
picoseconds (10^-12 seconds). So add the ability to specify
the time unit.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>