### PR TITLE
[BACKPORT-v1.14] random: Add syscalls for random subsystem

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -26,6 +26,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <net/net_if.h>
 #include <net/ethernet.h>
 #include <ethernet/eth_stats.h>
+#include <random/rand32.h>
 
 #if defined(CONFIG_PTP_CLOCK_MCUX)
 #include <ptp_clock.h>

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -23,6 +23,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <stdbool.h>
 #include <errno.h>
 #include <stddef.h>
+#include <random/rand32.h>
 
 #include <net/net_pkt.h>
 #include <net/net_core.h>

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -28,6 +28,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <device.h>
 #include <misc/__assert.h>
 #include <misc/util.h>
+#include <random/rand32.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <net/net_pkt.h>

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -20,6 +20,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <net/ethernet.h>
 #include <ethernet/eth_stats.h>
 #include <soc.h>
+#include <random/rand32.h>
 #include <misc/printk.h>
 #include <clock_control.h>
 #include <clock_control/stm32_clock_control.h>

--- a/drivers/ieee802154/ieee802154_uart_pipe.c
+++ b/drivers/ieee802154/ieee802154_uart_pipe.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <kernel.h>
 #include <arch/cpu.h>
 
+#include <random/rand32.h>
 #include <device.h>
 #include <init.h>
 #include <net/net_if.h>

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #include <gpio.h>
 #include <device.h>
 #include <init.h>
+#include <random/rand32.h>
 
 #include <net/net_context.h>
 #include <net/net_if.h>

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -32,6 +32,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <net/net_core.h>
 #include <net/dummy.h>
 #include <console/uart_pipe.h>
+#include <random/rand32.h>
 
 #define SLIP_END     0300
 #define SLIP_ESC     0333

--- a/include/kernel_includes.h
+++ b/include/kernel_includes.h
@@ -27,7 +27,6 @@
 #include <misc/util.h>
 #include <misc/mempool_base.h>
 #include <kernel_version.h>
-#include <random/rand32.h>
 #include <kernel_arch_thread.h>
 #include <syscall.h>
 #include <misc/printk.h>

--- a/include/random/rand32.h
+++ b/include/random/rand32.h
@@ -20,16 +20,18 @@
 #ifndef ZEPHYR_INCLUDE_RANDOM_RAND32_H_
 #define ZEPHYR_INCLUDE_RANDOM_RAND32_H_
 
+#include <kernel.h>
 #include <zephyr/types.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern u32_t sys_rand32_get(void);
+__syscall u32_t sys_rand32_get(void);
 
 #ifdef __cplusplus
 }
 #endif
 
+#include <syscalls/rand32.h>
 #endif /* ZEPHYR_INCLUDE_RANDOM_RAND32_H_ */

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -30,6 +30,7 @@
 #include <init.h>
 #include <tracing.h>
 #include <stdbool.h>
+#include <random/rand32.h>
 
 extern struct _static_thread_data _static_thread_data_list_start[];
 extern struct _static_thread_data _static_thread_data_list_end[];

--- a/samples/bluetooth/peripheral_csc/src/main.c
+++ b/samples/bluetooth/peripheral_csc/src/main.c
@@ -14,6 +14,7 @@
 #include <misc/printk.h>
 #include <misc/byteorder.h>
 #include <zephyr.h>
+#include <random/rand32.h>
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>

--- a/samples/net/mqtt_publisher/src/main.c
+++ b/samples/net/mqtt_publisher/src/main.c
@@ -11,6 +11,7 @@ LOG_MODULE_REGISTER(net_mqtt_publisher_sample, LOG_LEVEL_DBG);
 #include <net/socket.h>
 #include <net/mqtt.h>
 
+#include <random/rand32.h>
 #include <misc/printk.h>
 #include <string.h>
 #include <errno.h>

--- a/samples/net/sockets/echo_client/src/tcp.c
+++ b/samples/net/sockets/echo_client/src/tcp.c
@@ -13,6 +13,7 @@ LOG_MODULE_DECLARE(net_echo_client_sample, LOG_LEVEL_DBG);
 #include <zephyr.h>
 #include <errno.h>
 #include <stdio.h>
+#include <random/rand32.h>
 
 #include <net/socket.h>
 #include <net/tls_credentials.h>

--- a/samples/net/sockets/echo_client/src/udp.c
+++ b/samples/net/sockets/echo_client/src/udp.c
@@ -13,6 +13,7 @@ LOG_MODULE_DECLARE(net_echo_client_sample, LOG_LEVEL_DBG);
 #include <zephyr.h>
 #include <errno.h>
 #include <stdio.h>
+#include <random/rand32.h>
 
 #include <net/socket.h>
 #include <net/tls_credentials.h>

--- a/samples/net/wpan_serial/src/main.c
+++ b/samples/net/wpan_serial/src/main.c
@@ -20,6 +20,7 @@ LOG_MODULE_REGISTER(net_wpan_serial_sample, LOG_LEVEL_DBG);
 #include <uart.h>
 #include <zephyr.h>
 #include <stdio.h>
+#include <random/rand32.h>
 
 #include <misc/printk.h>
 

--- a/subsys/bluetooth/controller/crypto/crypto.c
+++ b/subsys/bluetooth/controller/crypto/crypto.c
@@ -12,6 +12,8 @@
 
 #include "hal/ecb.h"
 
+#include <random/rand32.h>
+
 int bt_rand(void *buf, size_t len)
 {
 	u8_t *buf8 = buf;

--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -26,6 +26,8 @@ LOG_MODULE_REGISTER(net_dhcpv4, CONFIG_NET_DHCPV4_LOG_LEVEL);
 #include <net/dhcpv4.h>
 #include <net/dns_resolve.h>
 
+#include <random/rand32.h>
+
 #include "dhcpv4.h"
 #include "ipv4.h"
 

--- a/subsys/net/ip/ipv4_autoconf.c
+++ b/subsys/net/ip/ipv4_autoconf.c
@@ -19,6 +19,8 @@ LOG_MODULE_REGISTER(net_ipv4_autoconf, CONFIG_NET_IPV4_AUTO_LOG_LEVEL);
 #include <net/net_core.h>
 #include <net/net_if.h>
 
+#include <random/rand32.h>
+
 #include "ipv4_autoconf_internal.h"
 
 /* Have only one timer in order to save memory */

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -12,6 +12,7 @@
 LOG_MODULE_DECLARE(net_ipv6, CONFIG_NET_IPV6_LOG_LEVEL);
 
 #include <errno.h>
+#include <random/rand32.h>
 #include <net/net_core.h>
 #include <net/net_pkt.h>
 #include <net/net_stats.h>

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -25,6 +25,8 @@ LOG_MODULE_REGISTER(net_ctx, CONFIG_NET_CONTEXT_LOG_LEVEL);
 #include <net/ethernet.h>
 #include <net/socket_can.h>
 
+#include <random/rand32.h>
+
 #include "connection.h"
 #include "net_private.h"
 

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(net_if, CONFIG_NET_IF_LOG_LEVEL);
 #include <net/net_if.h>
 #include <net/net_mgmt.h>
 #include <net/ethernet.h>
+#include <random/rand32.h>
 
 #include "net_private.h"
 #include "ipv6.h"

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -23,6 +23,8 @@ LOG_MODULE_REGISTER(net_shell, LOG_LEVEL_DBG);
 #include <net/dns_resolve.h>
 #include <misc/printk.h>
 
+#include <random/rand32.h>
+
 #include "route.h"
 #include "icmpv6.h"
 #include "icmpv4.h"

--- a/subsys/net/ip/tcp_internal.h
+++ b/subsys/net/ip/tcp_internal.h
@@ -20,6 +20,8 @@
 #include <net/net_pkt.h>
 #include <net/net_context.h>
 
+#include <random/rand32.h>
+
 #include "connection.h"
 
 #ifdef __cplusplus

--- a/subsys/net/ip/trickle.c
+++ b/subsys/net/ip/trickle.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(net_trickle, CONFIG_NET_TRICKLE_LOG_LEVEL);
 
 #include <errno.h>
 #include <misc/util.h>
+#include <random/rand32.h>
 
 #include <net/net_core.h>
 #include <net/trickle.h>

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -11,6 +11,8 @@ LOG_MODULE_REGISTER(net_gptp, CONFIG_NET_GPTP_LOG_LEVEL);
 #include <ptp_clock.h>
 #include <net/ethernet_mgmt.h>
 
+#include <random/rand32.h>
+
 #include <net/gptp.h>
 
 #include "gptp_messages.h"

--- a/subsys/net/l2/ieee802154/ieee802154_radio_csma_ca.c
+++ b/subsys/net/l2/ieee802154/ieee802154_radio_csma_ca.c
@@ -10,6 +10,8 @@ LOG_MODULE_REGISTER(net_ieee802154_csma, CONFIG_NET_L2_IEEE802154_LOG_LEVEL);
 #include <net/net_core.h>
 #include <net/net_if.h>
 
+#include <random/rand32.h>
+
 #include <misc/util.h>
 
 #include <stdlib.h>

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -16,6 +16,8 @@ LOG_MODULE_REGISTER(net_coap, CONFIG_COAP_LOG_LEVEL);
 #include <zephyr/types.h>
 #include <misc/byteorder.h>
 
+#include <random/rand32.h>
+
 #include <net/net_ip.h>
 #include <net/net_core.h>
 #include <net/coap.h>

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(net_dns_resolve, CONFIG_DNS_RESOLVER_LOG_LEVEL);
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <random/rand32.h>
 
 #include <net/net_ip.h>
 #include <net/net_pkt.h>

--- a/subsys/net/lib/openthread/platform/random.c
+++ b/subsys/net/lib/openthread/platform/random.c
@@ -7,6 +7,8 @@
 #include <kernel.h>
 #include <string.h>
 
+#include <random/rand32.h>
+
 #include <openthread/platform/random.h>
 
 #include "platform-zephyr.h"

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <net/socket.h>
 #include <syscall_handler.h>
 #include <misc/fdtable.h>
+#include <random/rand32.h>
 
 #if defined(CONFIG_MBEDTLS)
 #if !defined(CONFIG_MBEDTLS_CFG_FILE)

--- a/subsys/random/CMakeLists.txt
+++ b/subsys/random/CMakeLists.txt
@@ -4,3 +4,9 @@ zephyr_sources_ifdef(CONFIG_TIMER_RANDOM_GENERATOR          rand32_timer.c)
 zephyr_sources_ifdef(CONFIG_X86_TSC_RANDOM_GENERATOR        rand32_timestamp.c)
 zephyr_sources_ifdef(CONFIG_ENTROPY_DEVICE_RANDOM_GENERATOR rand32_entropy_device.c)
 zephyr_sources_ifdef(CONFIG_XOROSHIRO_RANDOM_GENERATOR      rand32_xoroshiro128.c)
+
+# userspace
+if (CONFIG_TIMER_RANDOM_GENERATOR OR CONFIG_X86_TSC_RANDOM_GENERATOR OR
+	CONFIG_ENTROPY_DEVICE_RANDOM_GENERATOR OR CONFIG_XOROSHIRO_RANDOM_GENERATOR)
+	zephyr_sources_ifdef(CONFIG_USERSPACE      rand32_handlers.c)
+endif()

--- a/subsys/random/rand32_entropy_device.c
+++ b/subsys/random/rand32_entropy_device.c
@@ -10,7 +10,7 @@
 
 static atomic_t entropy_driver;
 
-u32_t sys_rand32_get(void)
+u32_t z_impl_sys_rand32_get(void)
 {
 	struct device *dev = (struct device *)atomic_get(&entropy_driver);
 	u32_t random_num;

--- a/subsys/random/rand32_handlers.c
+++ b/subsys/random/rand32_handlers.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <random/rand32.h>
+#include <syscall_handler.h>
+
+Z_SYSCALL_HANDLER(sys_rand32_get)
+{
+	return z_impl_sys_rand32_get();
+}

--- a/subsys/random/rand32_timer.c
+++ b/subsys/random/rand32_timer.c
@@ -40,7 +40,7 @@ static atomic_val_t _rand32_counter;
  * @return a 32-bit number
  */
 
-u32_t sys_rand32_get(void)
+u32_t z_impl_sys_rand32_get(void)
 {
 	return k_cycle_get_32() + atomic_add(&_rand32_counter, _RAND32_INC);
 }

--- a/subsys/random/rand32_timestamp.c
+++ b/subsys/random/rand32_timestamp.c
@@ -29,7 +29,7 @@
  * @return a 32-bit number
  */
 
-u32_t sys_rand32_get(void)
+u32_t z_impl_sys_rand32_get(void)
 {
 	return z_do_read_cpu_timestamp32();
 }

--- a/subsys/random/rand32_xoroshiro128.c
+++ b/subsys/random/rand32_xoroshiro128.c
@@ -90,7 +90,7 @@ static u32_t xoroshiro128_next(void)
 	return (u32_t)result;
 }
 
-u32_t sys_rand32_get(void)
+u32_t z_impl_sys_rand32_get(void)
 {
 	u32_t ret;
 

--- a/tests/benchmarks/mbedtls/src/benchmark.c
+++ b/tests/benchmarks/mbedtls/src/benchmark.c
@@ -69,6 +69,7 @@
 
 #include <zephyr/types.h>
 #include <misc/byteorder.h>
+#include <random/rand32.h>
 
 #include "kernel.h"
 

--- a/tests/crypto/rand32/src/main.c
+++ b/tests/crypto/rand32/src/main.c
@@ -15,6 +15,7 @@
 
 #include <ztest.h>
 #include <kernel_internal.h>
+#include <random/rand32.h>
 
 #define N_VALUES 10
 

--- a/tests/crypto/tinycrypt/src/ecc_dsa.c
+++ b/tests/crypto/tinycrypt/src/ecc_dsa.c
@@ -71,6 +71,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ztest.h>
+#include <random/rand32.h>
 
 /* Maximum size of message to be signed. */
 #define BUF_SIZE 256

--- a/tests/drivers/gpio/gpio_basic_api/src/test_pin_rw.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_pin_rw.c
@@ -14,6 +14,8 @@
 
 #include <inttypes.h>
 
+#include <random/rand32.h>
+
 #include "test_gpio.h"
 
 void test_gpio_pin_read_write(void)

--- a/tests/kernel/sched/deadline/src/main.c
+++ b/tests/kernel/sched/deadline/src/main.c
@@ -5,6 +5,7 @@
  */
 #include <zephyr.h>
 #include <ztest.h>
+#include <random/rand32.h>
 
 #define NUM_THREADS 8
 #define STACK_SIZE (256 + CONFIG_TEST_EXTRA_STACKSIZE)

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -25,6 +25,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_ARP_LOG_LEVEL);
 #include <net/net_ip.h>
 #include <net/dummy.h>
 #include <ztest.h>
+#include <random/rand32.h>
 
 #include "arp.h"
 

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <errno.h>
 #include <misc/printk.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/context/src/main.c
+++ b/tests/net/context/src/main.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_CONTEXT_LOG_LEVEL);
 #include <errno.h>
 #include <misc/printk.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <tc_util.h>
 

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <errno.h>
 #include <misc/printk.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/ip-addr/src/main.c
+++ b/tests/net/ip-addr/src/main.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 #include <device.h>
 #include <init.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 #include <string.h>
 #include <errno.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/ipv6_fragment/src/main.c
+++ b/tests/net/ipv6_fragment/src/main.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 #include <errno.h>
 #include <misc/printk.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/lib/dns_resolve/src/main.c
+++ b/tests/net/lib/dns_resolve/src/main.c
@@ -23,6 +23,8 @@ LOG_MODULE_REGISTER(net_test, CONFIG_DNS_RESOLVER_LOG_LEVEL);
 #include <net/net_if.h>
 #include <net/dns_resolve.h>
 
+#include <random/rand32.h>
+
 #define NET_LOG_ENABLED 1
 #include "net_private.h"
 

--- a/tests/net/lib/mqtt_publisher/src/test_mqtt_publish.c
+++ b/tests/net/lib/mqtt_publisher/src/test_mqtt_publish.c
@@ -10,6 +10,7 @@ LOG_MODULE_REGISTER(net_test, LOG_LEVEL_WRN);
 #include <net/mqtt.h>
 #include <net/socket.h>
 #include <ztest.h>
+#include <random/rand32.h>
 
 #include <string.h>
 #include <errno.h>

--- a/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
+++ b/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
@@ -10,6 +10,7 @@ LOG_MODULE_REGISTER(net_test, LOG_LEVEL_WRN);
 #include <ztest.h>
 #include <net/socket.h>
 #include <net/mqtt.h>
+#include <random/rand32.h>
 
 #include <string.h>
 #include <errno.h>

--- a/tests/net/lib/mqtt_subscriber/src/test_mqtt_subscribe.c
+++ b/tests/net/lib/mqtt_subscriber/src/test_mqtt_subscribe.c
@@ -10,6 +10,7 @@ LOG_MODULE_REGISTER(net_test, LOG_LEVEL_WRN);
 #include <ztest.h>
 #include <net/socket.h>
 #include <net/mqtt.h>
+#include <random/rand32.h>
 
 #include <string.h>
 #include <errno.h>

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 #include <string.h>
 #include <errno.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -12,6 +12,7 @@
 #include <net/net_if.h>
 #include <net/net_ip.h>
 #include <net/ethernet.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/ptp/clock/src/main.c
+++ b/tests/net/ptp/clock/src/main.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <errno.h>
 #include <misc/printk.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/route/src/main.c
+++ b/tests/net/route/src/main.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_ROUTE_LOG_LEVEL);
 #include <errno.h>
 #include <misc/printk.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <tc_util.h>
 

--- a/tests/net/traffic_class/src/main.c
+++ b/tests/net/traffic_class/src/main.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <errno.h>
 #include <misc/printk.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/tx_timestamp/src/main.c
+++ b/tests/net/tx_timestamp/src/main.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <errno.h>
 #include <misc/printk.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 

--- a/tests/net/udp/src/main.c
+++ b/tests/net/udp/src/main.c
@@ -29,6 +29,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <net/ethernet.h>
 #include <net/dummy.h>
 #include <net/udp.h>
+#include <random/rand32.h>
 
 #include "ipv4.h"
 #include "ipv6.h"

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <errno.h>
 #include <misc/printk.h>
 #include <linker/sections.h>
+#include <random/rand32.h>
 
 #include <ztest.h>
 


### PR DESCRIPTION
Create syscalls to make possible using random APIs from user mode
threads. These APIs can have different implementations, like using
entropy driver or Xoroshiro128. Some of these implementations also
have some globals to preserve state between calls.

Make it run entire in user space would require user adding these
globals to their memeory domains and/or grant access to entropy device.
Syscalls simplify its usage.

Fixes #26499
Backport of #25980

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>