### PR TITLE
tests: exclude qemu_arc_hs in lifo_usage test

### DIFF
--- a/tests/kernel/lifo/lifo_usage/testcase.yaml
+++ b/tests/kernel/lifo/lifo_usage/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   kernel.lifo.usage:
     tags: kernel
-    #platform_exclude: m2gl025_miv
+    # FIXME: Keeps failing sporadically in CI. See #26163
+    platform_exclude: qemu_arc_hs


### PR DESCRIPTION
Fails very frequently in CI, disabling until a fix is available, see