### PR TITLE
drivers: sensor: add api function for getting a sensor attribute

### DIFF
--- a/drivers/sensor/sensor_handlers.c
+++ b/drivers/sensor/sensor_handlers.c
@@ -19,6 +19,18 @@ static inline int z_vrfy_sensor_attr_set(struct device *dev,
 }
 #include <syscalls/sensor_attr_set_mrsh.c>
 
+static inline int z_vrfy_sensor_attr_get(struct device *dev,
+					enum sensor_channel chan,
+					enum sensor_attribute attr,
+					struct sensor_value *val)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_SENSOR(dev, attr_get));
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(val, sizeof(struct sensor_value)));
+	return z_impl_sensor_attr_get((struct device *)dev, chan, attr,
+				     (struct sensor_value *)val);
+}
+#include <syscalls/sensor_attr_get_mrsh.c>
+
 static inline int z_vrfy_sensor_sample_fetch(struct device *dev)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_SENSOR(dev, sample_fetch));

--- a/tests/drivers/sensor/src/dummy_sensor.c
+++ b/tests/drivers/sensor/src/dummy_sensor.c
@@ -104,11 +104,31 @@ int dummy_sensor_attr_set(struct device *dev,
 {
 	struct dummy_sensor_data *data = dev->driver_data;
 
-	if (chan == SENSOR_CHAN_PROX) {
+	if (chan == SENSOR_CHAN_PROX &&
+	    attr == SENSOR_ATTR_UPPER_THRESH) {
 		data->val[4].val1 = val->val1;
 		data->val[4].val2 = val->val2;
+		return 0;
 	}
-	return 0;
+
+	return -ENOTSUP;
+}
+
+int dummy_sensor_attr_get(struct device *dev,
+		      enum sensor_channel chan,
+		      enum sensor_attribute attr,
+		      struct sensor_value *val)
+{
+	struct dummy_sensor_data *data = dev->driver_data;
+
+	if (chan == SENSOR_CHAN_PROX &&
+	    attr == SENSOR_ATTR_UPPER_THRESH) {
+		val->val1 = data->val[4].val1;
+		val->val2 = data->val[4].val2;
+		return 0;
+	}
+
+	return -ENOTSUP;
 }
 
 int dummy_sensor_trigger_set(struct device *dev,
@@ -140,6 +160,7 @@ static const struct sensor_driver_api dummy_sensor_api = {
 	.sample_fetch = &dummy_sensor_sample_fetch,
 	.channel_get = &dummy_sensor_channel_get,
 	.attr_set = dummy_sensor_attr_set,
+	.attr_get = dummy_sensor_attr_get,
 	.trigger_set = dummy_sensor_trigger_set,
 };
 

--- a/tests/drivers/sensor/src/main.c
+++ b/tests/drivers/sensor/src/main.c
@@ -141,6 +141,17 @@ void test_sensor_handle_triggers(void)
 				&trigger_elements[i].data),
 				RETURN_SUCCESS, "fail to set attributes");
 
+		/* read-back attributes for trigger */
+		zassert_equal(sensor_attr_get(dev,
+				trigger_elements[i].trig.chan,
+				trigger_elements[i].attr,
+				&data),
+				RETURN_SUCCESS, "fail to get attributes");
+		zassert_equal(trigger_elements[i].data.val1,
+			      data.val1, "read-back returned wrong val1");
+		zassert_equal(trigger_elements[i].data.val2,
+			      data.val2, "read-back returned wrong val2");
+
 		/* setting a sensor’s trigger and handler */
 		zassert_equal(sensor_trigger_set(dev,
 				&trigger_elements[i].trig,


### PR DESCRIPTION
Add an API function for getting the value of a sensor attribute and extend the existing sensor API test case to test it.

Fixes #26167.