### PR TITLE
driver: wifi: eswifi: Various cleanups

### DIFF
--- a/drivers/wifi/eswifi/Kconfig.eswifi
+++ b/drivers/wifi/eswifi/Kconfig.eswifi
@@ -8,6 +8,8 @@ menuconfig WIFI_ESWIFI
 	select NET_L2_WIFI_MGMT
 	select WIFI_OFFLOAD
 	select NET_OFFLOAD
+	select NET_SOCKETS
+	select NET_SOCKETS_OFFLOAD
 
 if WIFI_ESWIFI
 

--- a/drivers/wifi/eswifi/eswifi_bus_spi.c
+++ b/drivers/wifi/eswifi/eswifi_bus_spi.c
@@ -5,9 +5,8 @@
  */
 
 #define DT_DRV_COMPAT inventek_eswifi
-#define LOG_LEVEL CONFIG_WIFI_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(wifi_eswifi_bus_spi);
+#include "eswifi_log.h"
+LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 
 #include <zephyr.h>
 #include <kernel.h>

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -5,9 +5,8 @@
  */
 
 #define DT_DRV_COMPAT inventek_eswifi
-#define LOG_LEVEL CONFIG_WIFI_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(wifi_eswifi_core);
+#include "eswifi_log.h"
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <zephyr.h>
 #include <kernel.h>

--- a/drivers/wifi/eswifi/eswifi_log.h
+++ b/drivers/wifi/eswifi/eswifi_log.h
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2020 Linumiz
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_WIFI_ESWIFI_ESWIFI_LOG_H_
+#define ZEPHYR_DRIVERS_WIFI_ESWIFI_ESWIFI_LOG_H_
+
+#define LOG_MODULE_NAME wifi_eswifi
+#define LOG_LEVEL CONFIG_WIFI_LOG_LEVEL
+
+#include <logging/log.h>
+
+#endif /* ZEPHYR_DRIVERS_WIFI_ESWIFI_ESWIFI_LOG_H_ */

--- a/drivers/wifi/eswifi/eswifi_offload.c
+++ b/drivers/wifi/eswifi/eswifi_offload.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #define LOG_LEVEL CONFIG_WIFI_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(wifi_eswifi_offload);
+#include "eswifi_log.h"
+LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 
 #include <zephyr.h>
 #include <kernel.h>

--- a/drivers/wifi/eswifi/eswifi_socket.c
+++ b/drivers/wifi/eswifi/eswifi_socket.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
-LOG_MODULE_REGISTER(wifi_eswifi, CONFIG_WIFI_LOG_LEVEL);
+#include "eswifi_log.h"
+LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 
 #include <zephyr.h>
 #include <kernel.h>

--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
-LOG_MODULE_REGISTER(wifi_eswifi, CONFIG_WIFI_LOG_LEVEL);
+#include "eswifi_log.h"
+LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 
 #include <zephyr.h>
 #include <kernel.h>

--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -447,7 +447,7 @@ static int eswifi_socket_poll(struct zsock_pollfd *fds, int nfds, int msecs)
 		return -1;
 	}
 
-	ret = k_sem_take(&socket->read_sem, msecs);
+	ret = k_sem_take(&socket->read_sem, K_MSEC(msecs));
 	return ret;
 }
 

--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -30,6 +30,8 @@ LOG_MODULE_DECLARE(LOG_MODULE_NAME);
  */
 #define SD_TO_OBJ(sd) ((void *)(sd + 1))
 #define OBJ_TO_SD(obj) (((int)obj) - 1)
+/* Default socket context (50CE) */
+#define ESWIFI_INIT_CONTEXT	INT_TO_POINTER(0x50CE)
 
 static struct eswifi_dev *eswifi;
 static const struct socket_op_vtable eswifi_socket_fd_op_vtable;
@@ -391,8 +393,7 @@ static int eswifi_socket_open(int family, int type, int proto)
 
 	eswifi_lock(eswifi);
 
-	/* Assign dummy context SOCkEt(50CE) */
-	idx = __eswifi_socket_new(eswifi, family, type, proto, 0x50CE);
+	idx = __eswifi_socket_new(eswifi, family, type, proto, ESWIFI_INIT_CONTEXT);
 	if (idx < 0) {
 		goto unlock;
 	}
@@ -458,7 +459,7 @@ static int eswifi_socket_bind(void *obj, const struct sockaddr *addr,
 	struct eswifi_off_socket *socket;
 	int ret;
 
-	if ((addrlen == NULL) || (addr == NULL) ||
+	if ((addrlen == 0) || (addr == NULL) ||
 	    (sock > ESWIFI_OFFLOAD_MAX_SOCKETS)) {
 		return -EINVAL;
 	}


### PR DESCRIPTION
use common log module across all eswifi sources, which allows
to compile with CONFIG_NET_SOCKETS_OFFLOAD.

Also fix k_timeout_t compilation failure when CONFIG_NET_SOCKETS_OFFLOAD
enabled and warnings.

Signed-off-by: Parthiban Nallathambi <parthiban@linumiz.com>