### PR TITLE
drivers: spi: fix the fast path on the SAM0 driver

### DIFF
--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -364,10 +364,6 @@ static bool spi_sam0_is_regular(const struct spi_buf_set *tx_bufs,
 		rx_count = rx_bufs->count;
 	}
 
-	if (!tx || !rx) {
-		return false;
-	}
-
 	while (tx_count != 0 && rx_count != 0) {
 		if (tx->len != rx->len) {
 			return false;


### PR DESCRIPTION
To keep the bus fully loaded, the SAM0 has a fast path that recognises
special cases like TX only, RX only, or TX/RX of the same size.
Commit #ea2431f32f7 accidentally disabled this.

Fixing this increases the utilisation from around 30 % to around 90 % at 48
MHz.

Signed-off-by: Michael Hope <mlhx@google.com>