### PR TITLE
logging: Clarify that hexdump messages have no function prefix

### DIFF
--- a/doc/reference/logging/index.rst
+++ b/doc/reference/logging/index.rst
@@ -111,17 +111,17 @@ it is not set or set lower than the override value.
 :option:`CONFIG_LOG_MAX_LEVEL`: Maximal (lowest severity) level which is
 compiled in.
 
-:option:`CONFIG_LOG_FUNC_NAME_PREFIX_ERR`: Prepend ERROR log messages with
-function name.
+:option:`CONFIG_LOG_FUNC_NAME_PREFIX_ERR`: Prepend standard ERROR log messages
+with function name. Hexdump messages are not prepended.
 
-:option:`CONFIG_LOG_FUNC_NAME_PREFIX_WRN`: Prepend WARNING log messages with
-function name.
+:option:`CONFIG_LOG_FUNC_NAME_PREFIX_WRN`: Prepend standard WARNING log messages
+with function name. Hexdump messages are not prepended.
 
-:option:`CONFIG_LOG_FUNC_NAME_PREFIX_INF`: Prepend INFO log messages with
-function name.
+:option:`CONFIG_LOG_FUNC_NAME_PREFIX_INF`: Prepend standard INFO log messages
+with function name. Hexdump messages are not prepended.
 
-:option:`CONFIG_LOG_FUNC_NAME_PREFIX_DBG`: Prepend DEBUG log messages with
-function name.
+:option:`CONFIG_LOG_FUNC_NAME_PREFIX_DBG`: Prepend standard DEBUG log messages
+with function name. Hexdump messages are not prepended.
 
 :option:`CONFIG_LOG_PRINTK`: Redirect printk calls to the logger.
 

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -86,7 +86,7 @@ config LOG_MIPI_SYST_ENABLE
 
 if !LOG_MINIMAL
 
-menu "Prepend log message with function name"
+menu "Prepend non-hexdump log message with function name"
 	depends on !LOG_FRONTEND
 
 config LOG_FUNC_NAME_PREFIX_ERR


### PR DESCRIPTION
It was not clear that hexdump messages does not support prepending
with function name. Added clarification.

Fixes #26170.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>