### PR TITLE
tests: littlefs: Increase timeout to 180s

### DIFF
--- a/tests/subsys/fs/littlefs/testcase.yaml
+++ b/tests/subsys/fs/littlefs/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   filesystem.littlefs:
     platform_whitelist: nrf52840dk_nrf52840 native_posix native_posix_64
     tags: filesystem
+    timeout: 180


### PR DESCRIPTION
The test takes ~175s to end on nrf5284dk_nrf52840 and was failing
due to too short default timeout (60s).

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>