### PR TITLE
boards: arm: Add Nordic nrf52820 build defines for nrf52833 DK

### DIFF
--- a/boards/arm/nrf52833dk_nrf52820/CMakeLists.txt
+++ b/boards/arm/nrf52833dk_nrf52820/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# The nrf52833dk_nrf52820 board mirrors the nRF52833 DK hardware. This
+# needs to be considered by certain system initialization functionality
+# residing in system_nrf52820.c and SoC dependent routines in nrfx_coredep.h.
+zephyr_compile_definitions(DEVELOP_IN_NRF52833)
+zephyr_compile_definitions(NRFX_COREDEP_DELAY_US_LOOP_CYCLES=3)


### PR DESCRIPTION
Add nrf52820 nrfx defines for emulation on the nrf52833 Development Kit.
Fixes assert:
	ASSERTION FAIL [nrf_gpio_pin_present_check(*p_pin)]
	@ WEST_TOPDIR/modules/hal/nordic/nrfx/hal/nrf_gpio.h:525

NCSDK-5724

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>