### PR TITLE
samples: net: mqtt: Add userspace support to mqtt_publisher

### DIFF
--- a/samples/net/mqtt_publisher/sample.yaml
+++ b/samples/net/mqtt_publisher/sample.yaml
@@ -1,12 +1,15 @@
 sample:
-  description: TBD
-  name: TBD
+  description: MQTT publisher sample application
+  name: MQTT publisher
+common:
+  harness: net
+  tags: net mqtt
 tests:
   sample.net.mqtt_publisher:
-    harness: net
     platform_whitelist: frdm_k64f qemu_x86
-    tags: net mqtt
+  sample.net.mqtt_publisher.userspace:
+    platform_whitelist: frdm_k64f qemu_x86
+    extra_args: CONFIG_USERSPACE=y
   sample.net.mqtt_publisher.bt:
-    harness: net
     platform_whitelist: 96b_nitrogen
     tags: net mqtt bluetooth


### PR DESCRIPTION
Allow mqtt_publisher sample application to be run in user mode.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>

Edit: This requires #25980 to work properly. Tested with and without TLS, both worked ok.