### PR TITLE
[DNM] west.yml: fix mcumgr logging in Zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -92,8 +92,9 @@ manifest:
       revision: d52aff5065ab5995f785877a834112461ff93526
       path: bootloader/mcuboot
     - name: mcumgr
-      revision: 898a5a7f5224be8345e58eca3b9a84389ed61d15
+      revision: pull/82/head
       path: modules/lib/mcumgr
+      url: https://github.com/apache/mynewt-mcumgr
     - name: net-tools
       revision: 1c4fdba512b268033a4cf926bddd323866c3261a
       path: tools/net-tools


### PR DESCRIPTION
This is mainly for CI testing, so reviewers can see whether Zephyr
builds with updated mcumgr repository.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>