### PR TITLE
samples: posix: eventfd: Add harness in sample.yaml verifing the output

### DIFF
--- a/samples/posix/eventfd/sample.yaml
+++ b/samples/posix/eventfd/sample.yaml
@@ -8,3 +8,16 @@ common:
 tests:
   sample.posix.eventfd:
     tags: posix
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        -  "Writing 1 to efd"
+        -  "Writing 2 to efd"
+        -  "Writing 3 to efd"
+        -  "Writing 4 to efd"
+        -  "Completed write loop"
+        -  "About to read"
+        -  "Read 10 (0xa) from efd"
+        -  "Finished"


### PR DESCRIPTION
The sample does not provide a way to verify its operation and causes fails
on all platforms. Added regex checks in sample.yaml so the sample can be
verified.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>