### PR TITLE
Boards qemu cortex m0 timer rework

### DIFF
--- a/boards/arm/qemu_cortex_m0/Kconfig.defconfig
+++ b/boards/arm/qemu_cortex_m0/Kconfig.defconfig
@@ -32,9 +32,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 100
 
-config ENTROPY_NRF_FORCE_ALT
-	default y
-
 config LOG_BUFFER_SIZE
 	default 128 if LOG
 

--- a/boards/arm/qemu_cortex_m0/nrf_timer_timer.c
+++ b/boards/arm/qemu_cortex_m0/nrf_timer_timer.c
@@ -15,10 +15,12 @@
 
 #define TIMER NRF_TIMER0
 
-#define COUNTER_MAX 0xffffffff
+#define COUNTER_MAX 0xFFFFFFFFUL
+#define COUNTER_HALF_SPAN 0x80000000UL
 #define CYC_PER_TICK (sys_clock_hw_cycles_per_sec()	\
 		      / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-#define MAX_TICKS ((COUNTER_MAX - CYC_PER_TICK) / CYC_PER_TICK)
+#define MAX_TICKS ((COUNTER_HALF_SPAN - CYC_PER_TICK) / CYC_PER_TICK)
+#define MAX_CYCLES (MAX_TICKS * CYC_PER_TICK)
 
 static struct k_spinlock lock;
 
@@ -31,41 +33,131 @@ static uint32_t counter_sub(uint32_t a, uint32_t b)
 
 static void set_comparator(uint32_t cyc)
 {
-	nrf_timer_cc_set(TIMER, 0, cyc & COUNTER_MAX);
+	nrf_timer_cc_set(TIMER, NRF_TIMER_CC_CHANNEL0, cyc & COUNTER_MAX);
+}
+
+static uint32_t get_comparator(void)
+{
+	return nrf_timer_cc_get(TIMER, NRF_TIMER_CC_CHANNEL0);
+}
+
+static void event_clear(void)
+{
+	nrf_timer_event_clear(TIMER, NRF_TIMER_EVENT_COMPARE0);
+}
+
+static void int_disable(void)
+{
+	nrf_timer_int_disable(TIMER, NRF_TIMER_INT_COMPARE0_MASK);
+}
+
+static void int_enable(void)
+{
+	nrf_timer_int_enable(TIMER, NRF_TIMER_INT_COMPARE0_MASK);
 }
 
 static uint32_t counter(void)
 {
-	nrf_timer_task_trigger(TIMER, nrf_timer_capture_task_get(1));
+	nrf_timer_task_trigger(TIMER,
+		nrf_timer_capture_task_get(NRF_TIMER_CC_CHANNEL1));
 
-	return nrf_timer_cc_get(TIMER, 1);
+	return nrf_timer_cc_get(TIMER, NRF_TIMER_CC_CHANNEL1);
+}
+
+/* Function ensures that previous CC value will not set event */
+static void prevent_false_prev_evt(void)
+{
+	uint32_t now = counter();
+	uint32_t prev_val;
+
+	/* First take care of a risk of an event coming from CC being set to
+	 * next tick. Reconfigure CC to future (now tick is the furtherest
+	 * future). If CC was set to next tick we need to wait for up to 0.5us
+	 * (half of 1M tick) and clean potential event. After that time there
+	 * is no risk of unwanted event.
+	 */
+	prev_val = get_comparator();
+	event_clear();
+	set_comparator(now);
+
+	if (counter_sub(prev_val, now) == 1) {
+		k_busy_wait(1);
+		event_clear();
+	}
+
+	/* Clear interrupt that may have fired as we were setting the
+	 * comparator.
+	 */
+	NVIC_ClearPendingIRQ(TIMER0_IRQn);
+}
+
+/* If settings is next tick from now, function attempts to set next tick. If
+ * counter progresses during that time it means that 1 tick elapsed and
+ * interrupt is set pending.
+ */
+static void handle_next_tick_case(uint32_t t)
+{
+	set_comparator(t + 2);
+	while (t != counter()) {
+		/* already expired, tick elapsed but event might not be
+		 * generated. Trigger interrupt.
+		 */
+		t = counter();
+		set_comparator(t + 2);
+	}
+}
+
+/* Function safely sets absolute alarm. It assumes that provided value is
+ * less than MAX_TICKS from now. It detects late setting and also handles
+ * +1 tick case.
+ */
+static void set_absolute_ticks(uint32_t abs_val)
+{
+	uint32_t diff;
+	uint32_t t = counter();
+
+	diff = counter_sub(abs_val, t);
+	if (diff == 1) {
+		handle_next_tick_case(t);
+		return;
+	}
+
+	set_comparator(abs_val);
+}
+
+/* Sets relative ticks alarm from any context. Function is lockless. It only
+ * blocks TIMER interrupt.
+ */
+static void set_protected_absolute_ticks(uint32_t ticks)
+{
+	int_disable();
+
+	prevent_false_prev_evt();
+
+	set_absolute_ticks(ticks);
+
+	int_enable();
 }
 
 void timer0_nrf_isr(void *arg)
 {
 	ARG_UNUSED(arg);
-	TIMER->EVENTS_COMPARE[0] = 0;
+	event_clear();
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t t = counter();
+
+	uint32_t t = get_comparator();
 	uint32_t dticks = counter_sub(t, last_count) / CYC_PER_TICK;
 
 	last_count += dticks * CYC_PER_TICK;
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		uint32_t next = last_count + CYC_PER_TICK;
-
-		/* As below: we're guaranteed to get an interrupt as
-		 * long as it's set two or more cycles in the future
+		/* protection is not needed because we are in the TIMER interrupt
+		 * so it won't get preempted by the interrupt.
 		 */
-		if (counter_sub(next, t) < 3) {
-			next += CYC_PER_TICK;
-		}
-		set_comparator(next);
+		set_absolute_ticks(last_count + CYC_PER_TICK);
 	}
 
-	k_spin_unlock(&lock, key);
-	z_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1);
+	z_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : (dticks > 0));
 }
 
 int z_clock_driver_init(struct device *device)
@@ -81,14 +173,9 @@ int z_clock_driver_init(struct device *device)
 
 	clock_control_on(clock, CLOCK_CONTROL_NRF_SUBSYS_HF);
 
-	nrf_timer_frequency_set(TIMER, NRF_TIMER_FREQ_1MHz);
+	/* FIXME switch to 1 MHz once this is fixed in QEMU */
+	nrf_timer_frequency_set(TIMER, NRF_TIMER_FREQ_2MHz);
 	nrf_timer_bit_width_set(TIMER, NRF_TIMER_BIT_WIDTH_32);
-	nrf_timer_cc_set(TIMER, 0, CYC_PER_TICK);
-	nrf_timer_int_enable(TIMER, TIMER_INTENSET_COMPARE0_Msk);
-
-	/* Clear the event flag and possible pending interrupt */
-	nrf_timer_event_clear(TIMER, NRF_TIMER_EVENT_COMPARE0);
-	NVIC_ClearPendingIRQ(TIMER0_IRQn);
 
 	IRQ_CONNECT(TIMER0_IRQn, 1, timer0_nrf_isr, 0, 0);
 	irq_enable(TIMER0_IRQn);
@@ -100,68 +187,60 @@ int z_clock_driver_init(struct device *device)
 		set_comparator(counter() + CYC_PER_TICK);
 	}
 
+	event_clear();
+	NVIC_ClearPendingIRQ(TIMER0_IRQn);
+	int_enable();
+
 	return 0;
 }
 
 void z_clock_set_timeout(int32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
+	uint32_t cyc;
 
-#ifdef CONFIG_TICKLESS_KERNEL
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
 	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
 	ticks = MAX(MIN(ticks - 1, (int32_t)MAX_TICKS), 0);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t cyc, dt, t = counter();
-	bool zli_fixup = IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS);
+	uint32_t unannounced = counter_sub(counter(), last_count);
 
-	/* Round up to next tick boundary */
-	cyc = ticks * CYC_PER_TICK + 1 + counter_sub(t, last_count);
+	/* If we haven't announced for more than half the 24-bit wrap
+	 * duration, then force an announce to avoid loss of a wrap
+	 * event.  This can happen if new timeouts keep being set
+	 * before the existing one triggers the interrupt.
+	 */
+	if (unannounced >= COUNTER_HALF_SPAN) {
+		ticks = 0;
+	}
+
+
+	/* Get the cycles from last_count to the tick boundary after
+	 * the requested ticks have passed starting now.
+	 */
+	cyc = ticks * CYC_PER_TICK + 1 + unannounced;
 	cyc += (CYC_PER_TICK - 1);
 	cyc = (cyc / CYC_PER_TICK) * CYC_PER_TICK;
-	cyc += last_count;
 
-	if (counter_sub(cyc, t) > 2) {
-		set_comparator(cyc);
-	} else {
-		set_comparator(cyc);
-		dt = counter_sub(cyc, counter());
-		if (dt == 0 || dt > 0x7fffff) {
-			/* Missed it! */
-			NVIC_SetPendingIRQ(TIMER0_IRQn);
-			if (IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS)) {
-				zli_fixup = false;
-			}
-		} else if (dt == 1) {
-			/* Too soon, interrupt won't arrive. */
-			set_comparator(cyc + 2);
-		}
-		/* Otherwise it was two cycles out, we're fine */
-	}
-
-#ifdef CONFIG_ZERO_LATENCY_IRQS
-	/* Failsafe.  ZLIs can preempt us even though interrupts are
-	 * masked, blowing up the sensitive timing above.  If the
-	 * feature is enabled and we haven't recorded the presence of
-	 * a pending interrupt then we need a final check (in a loop!
-	 * because this too can be interrupted) to confirm that the
-	 * comparator is still in the future.  Don't bother being
-	 * fancy with cycle counting here, just set an interrupt
-	 * "soon" that we know will get the timer back to a known
-	 * state.  This handles (via some hairy modular expressions)
-	 * the wraparound cases where we are preempted for as much as
-	 * half the counter space.
+	/* Due to elapsed time the calculation above might produce a
+	 * duration that laps the counter.  Don't let it.
 	 */
-	if (zli_fixup && counter_sub(cyc, counter()) <= 0x7fffff) {
-		while (counter_sub(cyc, counter() + 2) > 0x7fffff) {
-			cyc = counter() + 3;
-			set_comparator(cyc);
-		}
+	if (cyc > MAX_CYCLES) {
+		cyc = MAX_CYCLES;
 	}
-#endif
 
-	k_spin_unlock(&lock, key);
-#endif /* CONFIG_TICKLESS_KERNEL */
+	cyc += last_count;
+	set_protected_absolute_ticks(cyc);
+
+	/* FIXME - QEMU requires clearing the events when setting the comparator,
+	 * but the TIMER peripheral HW does not need this. Remove when fixed in
+	 * QEMU.
+	 */
+	event_clear();
+	NVIC_ClearPendingIRQ(TIMER0_IRQn);
 }
 
 uint32_t z_clock_elapsed(void)

--- a/tests/kernel/common/src/boot_delay.c
+++ b/tests/kernel/common/src/boot_delay.c
@@ -13,13 +13,7 @@
  * @ingroup all_tests
  * @{
  */
-/* FIXEME: remove this once issue is fixed */
-#if CONFIG_BOARD_QEMU_CORTEX_M0
-void test_bootdelay(void)
-{
-	ztest_test_skip();
-}
-#else
+
 /**
  * @brief This module verifies the delay specified during boot.
  */
@@ -34,7 +28,6 @@ void test_bootdelay(void)
 			(uint32_t)k_cyc_to_ns_floor64(current_cycles),
 			(NSEC_PER_MSEC * CONFIG_BOOT_DELAY));
 }
-#endif
 
 /**
  * @}

--- a/tests/kernel/common/src/clock.c
+++ b/tests/kernel/common/src/clock.c
@@ -22,7 +22,6 @@
 	} while (0)
 #endif
 
-#ifndef CONFIG_BOARD_QEMU_CORTEX_M0
 struct timer_data {
 	int duration_count;
 	int stop_count;
@@ -37,7 +36,6 @@ static ZTEST_BMEM struct timer_data tdata;
 
 #define DURATION 100
 #define LESS_DURATION 80
-#endif
 
 /**
  * @addtogroup kernel_common_tests
@@ -127,13 +125,6 @@ void test_clock_cycle(void)
 	}
 }
 
-#ifdef CONFIG_BOARD_QEMU_CORTEX_M0
-void test_ms_time_duration(void)
-{
-	ztest_test_skip();
-}
-
-#else
 
 /*
  *help function
@@ -188,7 +179,6 @@ void test_ms_time_duration(void)
 	/** cleanup environemtn */
 	k_timer_stop(&ktimer);
 }
-#endif
 /**
  * @}
  */

--- a/tests/kernel/tickless/tickless_concept/testcase.yaml
+++ b/tests/kernel/tickless/tickless_concept/testcase.yaml
@@ -3,9 +3,7 @@ tests:
     arch_exclude: riscv32 nios2
     # FIXME: This test fails sporadically on all QEMU platforms, but fails
     # consistently when coverage is enabled. Disable until 14173 is fixed.
-    # This test fails on qemu_cortex_m0 consistently. Disable until the
-    # root cause is identified.
     # This test fails on qemu_arc_{em|hs} consistently. Disable until "icount"
     # is implemented for ARC in QEMU.
-    platform_exclude: qemu_x86_coverage qemu_cortex_m0 qemu_arc_em qemu_arc_hs
+    platform_exclude: qemu_x86_coverage qemu_arc_em qemu_arc_hs
     tags: kernel

--- a/tests/kernel/timer/timer_api/testcase.yaml
+++ b/tests/kernel/timer/timer_api/testcase.yaml
@@ -1,9 +1,9 @@
 tests:
   kernel.timer:
     tags: kernel userspace
-    platform_exclude: qemu_x86_coverage qemu_cortex_m0 qemu_arc_em qemu_arc_hs
+    platform_exclude: qemu_x86_coverage qemu_arc_em qemu_arc_hs
   kernel.timer.tickless:
     extra_args: CONF_FILE="prj_tickless.conf"
     arch_exclude: riscv32 nios2 posix
-    platform_exclude: qemu_x86_coverage qemu_cortex_m0 qemu_arc_em qemu_arc_hs
+    platform_exclude: qemu_x86_coverage qemu_arc_em qemu_arc_hs
     tags: kernel userspace

--- a/tests/kernel/timer/timer_api/testcase.yaml
+++ b/tests/kernel/timer/timer_api/testcase.yaml
@@ -1,9 +1,9 @@
 tests:
   kernel.timer:
-    tags: kernel userspace
+    tags: kernel timer userspace
     platform_exclude: qemu_x86_coverage qemu_arc_em qemu_arc_hs
   kernel.timer.tickless:
     extra_args: CONF_FILE="prj_tickless.conf"
     arch_exclude: riscv32 nios2 posix
     platform_exclude: qemu_x86_coverage qemu_arc_em qemu_arc_hs
-    tags: kernel userspace
+    tags: kernel timer userspace


### PR DESCRIPTION
QEMU Cortex-M0 Board includes a system timer driver implementation based on the nRF TIMER peripheral, because the RTC peripheral is not supported in QEMU.

In this PR we rework the timer driver, to reflect all recent changes made to the standard nrf RTC timer driver. Various issues with the driver are fixed - including a couple of hacks to make this work with QEMU.

As a result of this rework, we can now re-enable all tests that were currently disabled for cortex-m0 QEMU, namely,
- tests/kernel/common
-  tests/kernel/tickless
- tests/kernel/timer_api (this one was never enabled)

The rework also fixes the tests/kernel/interrupt test for qemu-cortex-m0

In addition to the above, the PR removes the ENTROPY_NRF_FORCE_ALT re-definition in the Board definition and adds a 'timer' label to the timer_api suite.

Fixes #22955 (@andrewboie pls, check)
