### PR TITLE
device: avoid direct assignment to device api pointer

### DIFF
--- a/doc/reference/drivers/index.rst
+++ b/doc/reference/drivers/index.rst
@@ -173,8 +173,7 @@ of these APIs, and populate an instance of subsystem_api structure:
   };
 
 The driver would then pass ``my_driver_api_funcs`` as the ``api`` argument to
-``DEVICE_AND_API_INIT()``, or manually assign it to ``device->driver_api``
-in the driver init function.
+``DEVICE_AND_API_INIT()``.
 
 .. note::
 

--- a/drivers/gpio/gpio_intel_apl.c
+++ b/drivers/gpio/gpio_intel_apl.c
@@ -585,8 +585,6 @@ int gpio_intel_apl_init(struct device *dev)
 	sys_bitfield_clear_bit(cfg->reg_base + REG_MISCCFG,
 			       MISCCFG_IRQ_ROUTE_POS);
 
-	dev->driver_api = &gpio_intel_apl_api;
-
 	return 0;
 }
 

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -621,7 +621,6 @@ static int i2c_dw_initialize(struct device *dev)
 
 	/* verify that we have a valid DesignWare register first */
 	if (regs->ic_comp_type != I2C_DW_MAGIC_KEY) {
-		dev->driver_api = NULL;
 		LOG_DBG("I2C: DesignWare magic key not found, check base "
 			    "address. Stopping initialization");
 		return -EIO;


### PR DESCRIPTION
Almost all drivers use `DEVICE_AND_API_INIT()` or a wrapper of that to initialize the device API table pointer.  Fix two drivers that assigned to during initialization, and remove documentation that suggests this is appropriate.

There is one remaining case that is fixed by "drivers/gpio: Use DEVICE_AND_API_INIT for mmio32 driver" from #24873, but I believe draft process requires @tbursztyka either submit that independently or explicitly grant me permission to cherry-pick it into this (which I'm willing to do).