### PR TITLE
manifest: updated manifest with new versions of open-amp and libmetal

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -77,7 +77,7 @@ manifest:
       revision: aabc6a04a8e871cbb01e02c22bb409f68001dc64
       path: modules/hal/ti
     - name: libmetal
-      revision: 87e9e7f2c5b4e238236fe703db61ba23e48dc2ef
+      revision: pull/6/head
       path: modules/hal/libmetal
     - name: lvgl
       revision: 74fc2e753a997bd71cefa34dd9c56dcb954b42e2
@@ -98,7 +98,7 @@ manifest:
       revision: 478f03a71256aeb2890e685ebf5a1dc6832a6b5f
       path: modules/hal/nxp
     - name: open-amp
-      revision: 724f7e2a4519d7e1d40ef330042682dea950c991
+      revision: pull/8/head
       path: modules/lib/open-amp
     - name: loramac-node
       revision: 29e516ec585b1a909af2b5f1c60d83e7d4d563e3


### PR DESCRIPTION
Fixes: #26142

open-amp and libmetal projects are now setting CMP0077.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

------
depends on:
https://github.com/zephyrproject-rtos/open-amp/pull/8
https://github.com/zephyrproject-rtos/libmetal/pull/6