### PR TITLE
linker: Allow custom boards to extend the memory layout

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -913,6 +913,7 @@ function(zephyr_linker_sources location)
   # Set up the paths to the destination files. These files are #included inside
   # the global linker.ld.
   set(snippet_base      "${__build_dir}/include/generated")
+  set(memory_path       "${snippet_base}/snippets-memory.ld")
   set(sections_path     "${snippet_base}/snippets-sections.ld")
   set(ram_sections_path "${snippet_base}/snippets-ram-sections.ld")
   set(rom_start_path    "${snippet_base}/snippets-rom-start.ld")
@@ -923,6 +924,7 @@ function(zephyr_linker_sources location)
   # Clear destination files if this is the first time the function is called.
   get_property(cleared GLOBAL PROPERTY snippet_files_cleared)
   if (NOT DEFINED cleared)
+    file(WRITE ${memory_path} "")
     file(WRITE ${sections_path} "")
     file(WRITE ${ram_sections_path} "")
     file(WRITE ${rom_start_path} "")
@@ -933,7 +935,9 @@ function(zephyr_linker_sources location)
   endif()
 
   # Choose destination file, based on the <location> argument.
-  if ("${location}" STREQUAL "SECTIONS")
+  if ("${location}" STREQUAL "MEMORY")
+    set(snippet_path "${memory_path}")
+  elseif ("${location}" STREQUAL "SECTIONS")
     set(snippet_path "${sections_path}")
   elseif("${location}" STREQUAL "RAM_SECTIONS")
     set(snippet_path "${ram_sections_path}")

--- a/include/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
@@ -84,6 +84,9 @@ MEMORY
     SRAM     (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
     /* Used by and documented in include/linker/intlist.ld */
     IDT_LIST (wx) : ORIGIN = (RAM_ADDR + RAM_SIZE), LENGTH = 2K
+
+#include <snippets-memory.ld>
+
 }
 
 ENTRY(CONFIG_KERNEL_ENTRY)

--- a/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -108,6 +108,9 @@ MEMORY
 #endif
     /* Used by and documented in include/linker/intlist.ld */
     IDT_LIST  (wx)      : ORIGIN = (RAM_ADDR + RAM_SIZE), LENGTH = 2K
+
+#include <snippets-memory.ld>
+
     }
 
 ENTRY(CONFIG_KERNEL_ENTRY)

--- a/include/arch/arm/aarch64/scripts/linker.ld
+++ b/include/arch/arm/aarch64/scripts/linker.ld
@@ -80,6 +80,9 @@ MEMORY
     SRAM      (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
     /* Used by and documented in include/linker/intlist.ld */
     IDT_LIST  (wx) : ORIGIN = (RAM_ADDR + RAM_SIZE), LENGTH = 2K
+
+#include <snippets-memory.ld>
+
 }
 
 ENTRY(CONFIG_KERNEL_ENTRY)

--- a/include/arch/nios2/linker.ld
+++ b/include/arch/nios2/linker.ld
@@ -61,6 +61,8 @@ MEMORY
     /* Used by and documented in include/linker/intlist.ld */
     IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 
+#include <snippets-memory.ld>
+
     }
 
 #else

--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -51,6 +51,9 @@ MEMORY
     RAM (rwx) : ORIGIN = CONFIG_SRAM_BASE_ADDRESS, LENGTH = KB(CONFIG_SRAM_SIZE)
     /* Used by and documented in include/linker/intlist.ld */
     IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
+
+#include <snippets-memory.ld>
+
 }
 
 ENTRY(CONFIG_KERNEL_ENTRY)

--- a/soc/riscv/openisa_rv32m1/linker.ld
+++ b/soc/riscv/openisa_rv32m1/linker.ld
@@ -79,6 +79,9 @@ MEMORY
      * to generate interrupt tables. See include/linker/intlist.ld.
      */
     IDT_LIST (wx) : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
+
+#include <snippets-memory.ld>
+
     }
 
 ENTRY(CONFIG_KERNEL_ENTRY)


### PR DESCRIPTION
Custom boards that need to place information into memory want to be able to extend the final memory layout.

This solution hooks into the same cmake snippet mechanism that is already in place for sections, noinit, etc.

Sample usage in custom board CMakeLists.txt:
```
zephyr_linker_sources(
  MEMORY
  custom-memory.ld
)
```

Sample content of custom-memory.ld
```
/* CUSTOM MEMORY START */
    VERSION_STRING (rx)    : ORIGIN = 0x08008000, LENGTH = 0x64
    START_PATTERN (rx)     : ORIGIN = 0x08008078, LENGTH = 8
/* CUSTOM MEMORY STOP */
```
