### PR TITLE
warnings: silence two compiler warnings

### DIFF
--- a/include/net/net_l2.h
+++ b/include/net/net_l2.h
@@ -77,7 +77,7 @@ struct net_l2 {
 };
 
 /** @cond INTERNAL_HIDDEN */
-#define NET_L2_GET_NAME(_name) (__net_l2_##_name)
+#define NET_L2_GET_NAME(_name) __net_l2_##_name
 #define NET_L2_DECLARE_PUBLIC(_name)					\
 	extern const struct net_l2 NET_L2_GET_NAME(_name)
 #define NET_L2_GET_CTX_TYPE(_name) _name##_CTX_TYPE

--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -226,7 +226,7 @@ static int settings_line_raw_read_until(off_t seek, char *out, size_t len_req,
 	size_t exp_size, read_size;
 	uint8_t rbs = settings_io_cb.rwbs;
 	off_t off;
-	int rc;
+	int rc = -EINVAL;
 
 	if (len_req == 0) {
 		return -EINVAL;
@@ -428,7 +428,7 @@ int settings_line_name_read(char *out, size_t len_req, size_t *len_read,
 int settings_line_entry_copy(void *dst_ctx, off_t dst_off, void *src_ctx,
 			     off_t src_off, size_t len)
 {
-	int rc;
+	int rc = -EINVAL;
 	char buf[16];
 	size_t chunk_size;
 
@@ -474,7 +474,7 @@ static int settings_line_cmp(char const *val, size_t val_len,
 	size_t len_read, exp_len;
 	size_t rem;
 	char buf[16];
-	int rc;
+	int rc = -EINVAL;
 	off_t off = 0;
 
 	if (val_len == 0) {


### PR DESCRIPTION
When compiling network and settings subsystems, I was getting the following compiler warnings:
```
/home/markus/src/wrp-n4m/zephyr/subsys/settings/src/settings_line.c: In function 'settings_line_cmp':
/home/markus/src/wrp-n4m/zephyr/subsys/settings/src/settings_line.c:477:6: warning: 'rc' may be used uninitialized in this function [-Wmaybe-uninitialized]
  477 |  int rc;
      |      ^~
/home/markus/src/wrp-n4m/zephyr/subsys/settings/src/settings_line.c: In function 'settings_line_entry_copy':
/home/markus/src/wrp-n4m/zephyr/subsys/settings/src/settings_line.c:453:9: warning: 'rc' may be used uninitialized in this function [-Wmaybe-uninitialized]
  453 |  return rc;
```

```
In file included from /home/markus/src/wrp-n4m/zephyr/include/net/net_if.h:29,
                 from /home/markus/src/wrp-n4m/app/src/main/node/main.cpp:20:
/home/markus/src/wrp-n4m/zephyr/include/net/net_l2.h:80:32: warning: unnecessary parentheses in declaration of '__net_l2_OPENTHREAD' [-Wparentheses]
   80 | #define NET_L2_GET_NAME(_name) (__net_l2_##_name)
      |                                ^
/home/markus/src/wrp-n4m/zephyr/include/net/net_l2.h:82:29: note: in expansion of macro 'NET_L2_GET_NAME'
   82 |  extern const struct net_l2 NET_L2_GET_NAME(_name)
      |                             ^~~~~~~~~~~~~~~
/home/markus/src/wrp-n4m/zephyr/include/net/net_l2.h:114:1: note: in expansion of macro 'NET_L2_DECLARE_PUBLIC'
  114 | NET_L2_DECLARE_PUBLIC(OPENTHREAD_L2);
      | ^~~~~~~~~~~~~~~~~~~~~
```

This patch fixes the two warnings.
