### PR TITLE
net: sockets: fix conn_handler check in zsock_getsockname_ctx

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -1585,7 +1585,7 @@ int zsock_getsockname_ctx(struct net_context *ctx, struct sockaddr *addr,
 	socklen_t newlen = 0;
 
 	/* If we don't have a connection handler, the socket is not bound */
-	if (ctx->conn_handler) {
+	if (!ctx->conn_handler) {
 		SET_ERRNO(-EINVAL);
 	}
 


### PR DESCRIPTION
The check was inverted, so a bound socket was detected as not bound.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>