### PR TITLE
Bluetooth: controller: Fix compilation regression

### DIFF
--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -110,8 +110,8 @@ uint8_t ll_rssi_get(uint16_t handle, uint8_t *const rssi);
 uint8_t ll_tx_pwr_lvl_get(uint8_t handle_type,
 		       uint16_t handle, uint8_t type, int8_t *const tx_pwr_lvl);
 void ll_tx_pwr_get(int8_t *const min, int8_t *const max);
-uint8_t ll_tx_pwr_lvl_set(uint8_t handle_type,
-		       uint16_t handle, int8_t const *const tx_pwr_lvl);
+uint8_t ll_tx_pwr_lvl_set(uint8_t handle_type, uint16_t handle,
+			  int8_t *const tx_pwr_lvl);
 
 uint8_t ll_apto_get(uint16_t handle, uint16_t *const apto);
 uint8_t ll_apto_set(uint16_t handle, uint16_t apto);

--- a/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
@@ -119,7 +119,7 @@ uint8_t ll_tx_pwr_lvl_get(uint8_t handle_type,
 
 
 uint8_t ll_tx_pwr_lvl_set(uint8_t handle_type, uint16_t handle,
-		       int8_t const *const tx_pwr_lvl)
+			  int8_t *const tx_pwr_lvl)
 {
 #if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL)
 	if (*tx_pwr_lvl == BT_HCI_VS_LL_TX_POWER_LEVEL_NO_PREF) {

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.h
@@ -52,6 +52,10 @@ struct lll_scan_aux {
 	uint8_t phy:3;
 
 	uint32_t window_size_us;
+
+#if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL)
+	int8_t tx_pwr_lvl;
+#endif /* CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL */
 };
 
 int lll_scan_init(void);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -11,6 +11,7 @@
 #include <bluetooth/hci.h>
 
 #include "hal/ccm.h"
+#include "hal/radio.h"
 #include "hal/ticker.h"
 
 #include "util/util.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -12,8 +12,9 @@
 #include "util/memq.h"
 #include "util/mayfly.h"
 
-#include "hal/ticker.h"
 #include "hal/ccm.h"
+#include "hal/radio.h"
+#include "hal/ticker.h"
 
 #include "ticker/ticker.h"
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -9,6 +9,7 @@
 #include <bluetooth/hci.h>
 
 #include "hal/ccm.h"
+#include "hal/radio.h"
 #include "hal/ticker.h"
 
 #include "util/util.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -12,8 +12,9 @@
 #include "util/memq.h"
 #include "util/mayfly.h"
 
-#include "hal/ticker.h"
 #include "hal/ccm.h"
+#include "hal/radio.h"
+#include "hal/ticker.h"
 
 #include "ticker/ticker.h"
 


### PR DESCRIPTION
Fix compilation regression due to addition of const
qualifier to tx_pwr_lvl parameter of ll_tx_pwr_lvl_set
function. Support for BT_CTLR_TX_PWR_DYNAMIC_CONTROL
needs the tx_pwr_lvl to be updated and returned.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>