### PR TITLE
net: sockets: remove POSIX_NAMES dependency on SOCKETS_OFFLOAD

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -102,7 +102,6 @@ config NET_SOCKETS_TLS_MAX_CIPHERSUITES
 
 config NET_SOCKETS_OFFLOAD
 	bool "Offload Socket APIs [EXPERIMENTAL]"
-	select NET_SOCKETS_POSIX_NAMES
 	help
 	  Enables direct offloading of socket operations to dedicated TCP/IP
 	  hardware.


### PR DESCRIPTION
This is no longer required since drivers implementing the sockets
offload interface were migrated to use pure zsock_ instead of
raw POSIX types and functions.

Signed-off-by: Adam Porter <porter.adam@gmail.com>