### PR TITLE
cmake: docs: Fix 'test_relocation' -> 'code_relacotion'

### DIFF
--- a/doc/guides/code-relocation.rst
+++ b/doc/guides/code-relocation.rst
@@ -94,7 +94,7 @@ This section shows additional configuration options that can be set in
 Sample
 ======
 A sample showcasing this feature is provided at
-``$ZEPHYR_BASE/samples/application_development/test_relocation/``
+``$ZEPHYR_BASE/samples/application_development/code_relocation/``
 
 This is an example of using the code relocation feature.
 

--- a/samples/application_development/code_relocation/CMakeLists.txt
+++ b/samples/application_development/code_relocation/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(test_relocation)
+project(code_relocation)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})


### PR DESCRIPTION
Incorrect name used for sample in two places.
Fixs this.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>