### PR TITLE
West flash improvements for nrf

### DIFF
--- a/boards/arm/nrf5340pdk_nrf5340/board.cmake
+++ b/boards/arm/nrf5340pdk_nrf5340/board.cmake
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_BOARD_NRF5340PDK_NRF5340_CPUAPP OR CONFIG_BOARD_NRF5340PDK_NRF5340_CPUAPPNS)
-board_runner_args(nrfjprog "--nrf-family=NRF53" "--tool-opt=--coprocessor CP_APPLICATION")
+board_runner_args(nrfjprog "--nrf-family=NRF53")
 board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
 endif()
 
 if(CONFIG_BOARD_NRF5340PDK_NRF5340_CPUNET)
-board_runner_args(nrfjprog "--nrf-family=NRF53" "--tool-opt=--coprocessor CP_NETWORK")
+board_runner_args(nrfjprog "--nrf-family=NRF53")
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)


### PR DESCRIPTION
- west flash hasn't worked for a while when there are contents in the UICR, and on 53 and 91 `--sectoranduicrerase` is not available, so those have always been using `--sectorerase`. This patch changes that to use `--chiperase` when the hex file has contents in UICR.
- west flash is unable to flash a merged hex file with contents for both cores on nRF53. This patch fixes that by splitting the hex into two parts and flashing them individually if the hex file has contents for both cores.