### PR TITLE
Bluetooth: kconfig: Disable advertising extension until feature complete

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -448,7 +448,8 @@ config BT_CTLR_ADV_EXT
 	bool "LE Advertising Extensions" if !BT_LL_SW_SPLIT
 	depends on BT_CTLR_ADV_EXT_SUPPORT
 	select BT_CTLR_SCAN_REQ_NOTIFY
-	default y if BT_EXT_ADV
+	# Uncomment when "LE Advertising Set Terminated event" is implemented
+	# default y if BT_EXT_ADV
 	help
 	  Enable support for Bluetooth 5.0 LE Advertising Extensions in the
 	  Controller.


### PR DESCRIPTION
Disable the controller advertising extension feature default setting until
the feature is complete. The zephyr host requires the LE Advertising Set
Terminated event to function. Without this event a peripheral connection
cannot pair because the local on-air address is not set, and the advertising
state will not be cleaned up, so advertising cannot be started again.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>