### PR TITLE
console: tty: Fix k_sem_take with wait time from ISR

### DIFF
--- a/subsys/console/tty.c
+++ b/subsys/console/tty.c
@@ -73,7 +73,9 @@ static int tty_putchar(struct tty_serial *tty, uint8_t c)
 	int tx_next;
 	int res;
 
-	res = k_sem_take(&tty->tx_sem, SYS_TIMEOUT_MS(tty->tx_timeout));
+	res = k_sem_take(&tty->tx_sem,
+			 k_is_in_isr() ? K_NO_WAIT :
+					 SYS_TIMEOUT_MS(tty->tx_timeout));
 	if (res < 0) {
 		return res;
 	}


### PR DESCRIPTION
Fix k_sem_take called with a timeout value other than K_NO_WAIT from isr.
This happens when tty_irq_input_hook calls tty_putchar with the `~` character
to give the user a clue that input was lost.

This resulted in the following assert in sem.c:
	ASSERTION FAIL @ WEST_TOPDIR/zephyr/kernel/sem.c:140

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>