### PR TITLE
net: openthread: only auto-start when requested

### DIFF
--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -405,7 +405,7 @@ static void openthread_start(struct openthread_context *ot_context)
 	}
 }
 
-static int openthread_init(struct net_if *iface)
+int openthread_init(struct net_if *iface)
 {
 	struct openthread_context *ot_context = net_if_l2_data(iface);
 
@@ -466,9 +466,9 @@ void ieee802154_init(struct net_if *iface)
 	if (IS_ENABLED(CONFIG_IEEE802154_NET_IF_NO_AUTO_START)) {
 		LOG_DBG("Interface auto start disabled.");
 		net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+	} else {
+		openthread_init(iface);
 	}
-
-	openthread_init(iface);
 }
 
 static enum net_l2_flags openthread_flags(struct net_if *iface)


### PR DESCRIPTION
When the radio driver does not provide the EUI64, but the application provides it through

```
	struct net_if *iface = net_if_get_first_by_type(&NET_L2_GET_NAME(OPENTHREAD));
	__ASSERT(iface != NULL, "OT iface NULL");
	net_if_set_link_addr(iface, pMac, 8, NET_LINK_IEEE802154);
```

OpenThread should not be started. Instead the user should initialise it:

```
	openthread_init(iface);
	net_if_up(iface);
```

Otherwise, OpenThread will use a wrong EUI and network joining will fail.
