### PR TITLE
[BACKPORT 1.14] net: socket: Add userspace support to setsockopt()

### DIFF
--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -367,8 +367,8 @@ int zsock_getsockopt(int sock, int level, int optname,
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
  * @endrststar
  */
-int zsock_setsockopt(int sock, int level, int optname,
-		     const void *optval, socklen_t optlen);
+__syscall int zsock_setsockopt(int sock, int level, int optname,
+			       const void *optval, socklen_t optlen);
 
 /**
  * @brief Get local host name


### PR DESCRIPTION
Allow userspace application to call setsockopt() without crashing.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>