### PR TITLE
sanitycheck: handle timeouts correctly with qemu

### DIFF
--- a/boards/arm/qemu_cortex_a53/qemu_cortex_a53.yaml
+++ b/boards/arm/qemu_cortex_a53/qemu_cortex_a53.yaml
@@ -9,3 +9,6 @@ toolchain:
 ram: 128
 testing:
   default: true
+  ignore_tags:
+    - net
+    - bluetooth

--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -898,7 +898,10 @@ class QEMUHandler(Handler):
                     except ProcessLookupError:
                         pass
                     proc.wait()
-                    self.returncode = 0
+                    if harness.state == "passed":
+                        self.returncode = 0
+                    else:
+                        self.returncode = proc.returncode
                 else:
                     proc.terminate()
                     proc.kill()

--- a/tests/subsys/jwt/testcase.yaml
+++ b/tests/subsys/jwt/testcase.yaml
@@ -2,4 +2,5 @@ tests:
   libraries.encoding.jwt:
     min_ram: 96
     min_flash: 72
+    timeout: 120
     tags: jwt


### PR DESCRIPTION
In some cases we were not handling return code correctly and evaluating
timeouts as a pass. Report failure correctly.

Fixes #26065