### PR TITLE
arch/x86: Add zefi, an EFI stub/packer/wrappper/loader

### DIFF
--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -134,14 +134,21 @@ go64:	movl %cr4, %eax			/* enable PAE and SSE */
 	orl $(CR0_PG | CR0_WP), %eax
 	movl %eax, %cr0
 
-	jmpl $X86_KERNEL_CS, $1f
-.code64
-1:	movl $X86_KERNEL_DS, %eax
+	jmpl $X86_KERNEL_CS, $enter_code64
+
+	/* Long mode entry point.  Arrive here from the code
+	 * immediately above (shared between main CPU startup and AP
+	 * startup), or from EFI entry in __start64
+	 */
+	.code64
+enter_code64:
+	movl $X86_KERNEL_DS, %eax
 	movw %ax, %ds
 	movw %ax, %es
 	movw %ax, %ss
 	movw %ax, %fs
 
+	movq $x86_cpuboot, %rbp
 	movw __x86_cpuboot_t_tr_OFFSET(%rbp), %ax
 	ltr %ax
 
@@ -175,6 +182,53 @@ go64:	movl %cr4, %eax			/* enable PAE and SSE */
 	/* Enter C domain now that we have a stack set up, never to return */
 	movq %rbp, %rdi
 	call z_x86_cpu_init
+
+	/* 64 bit OS entry point, used by EFI support.  UEFI
+	 * guarantees an identity-mapped page table that covers
+	 * physical memory, and the loader stub already used it to
+	 * write all of the Zephyr image, so we know it works for what
+	 * we need.  Other things need fixups to match what multiboot
+	 * 32 bit startup does.
+	 */
+.globl __start64
+__start64:
+	/* Zero the TSC */
+	xorq %rax, %rax
+	xorq %rdx, %rdx
+	movq $X86_TIME_STAMP_COUNTER_MSR, %rcx
+	wrmsr
+
+	lidt idt80
+	lgdt gdt80
+
+	/* These state and flag settings really should be done later,
+	 * in the shared startup path, they aren't required for mode
+	 * transition and having them in the 32 bit stub means they
+	 * have to be duplicated here.
+	 */
+	movq %cr4, %rax
+	orq $(CR4_PAE | CR4_OSFXSR), %rax
+	movq %rax, %cr4
+	clts
+	movq $X86_EFER_MSR, %rcx
+	rdmsr
+	orq $(X86_EFER_MSR_NXE | X86_EFER_MSR_SCE), %rax
+	wrmsr
+	cld
+
+	/* Disable 8259 PIT.  Almost certainly not needed on modern
+	 * UEFI platforms taking this code path, but...
+	 */
+	movb $0xff, %al
+	outb %al, $0x21
+	outb %al, $0xA1
+
+	/* Far call into the Zephyr code segment */
+	mov jmpdesc, %rax
+	jmp *%rax
+jmpdesc:
+	.quad enter_code64
+	.short X86_KERNEL_CS
 
 /*
  * void x86_sse_init(struct k_thread *thread);
@@ -884,10 +938,15 @@ idt:
 	IDT(250, INTR, IRQ_STACK); IDT(251, INTR, IRQ_STACK)
 	IDT(252, INTR, IRQ_STACK); IDT(253, INTR, IRQ_STACK)
 	IDT(254, INTR, IRQ_STACK); IDT(255, INTR, IRQ_STACK)
+idt_end:
 
-idt48:
-	.word (idt48 - idt - 1)
+idt48:  /* LIDT descriptor for 32 bit mode */
+	.word (idt_end - idt - 1)
 	.long idt
+
+idt80:  /* LIDT descriptor for 64 bit mode */
+	.word (idt_end - idt - 1)
+	.quad idt
 
 /*
  * Page tables. Long mode requires them, but we don't implement any memory
@@ -965,10 +1024,15 @@ gdt:
 	.word 0, 0, 0, 0, 0
 #endif
 
-gdt48:
-	.word (gdt48 - gdt - 1)
+gdt_end:
+
+gdt48:  /* LGDT descriptor for 32 bit mode */
+	.word (gdt_end - gdt - 1)
 	.long gdt
 
+gdt80:  /* LGDT descriptor for long mode */
+	.word (gdt_end - gdt - 1)
+	.quad gdt
 .section .lodata,"ad"
 
 /*

--- a/arch/x86/zefi/README.txt
+++ b/arch/x86/zefi/README.txt
@@ -1,0 +1,91 @@
+Operation
+=========
+
+Run the "zefi.py" script, passing a path to a built zephyr.elf file
+(NOT a "zephyr.strip" intended for grub/multiboot loading -- we need
+the symbol table) for the target as its sole argument.  It will emit a
+"zephyr.efi" file in the current directory.  Copy this to your target
+device's EFI boot partition via whatever means you like and run it
+from the EFI shell.
+
+Theory
+======
+
+This works by creating a "zephyr.efi" EFI binary containing a zephyr
+image extracted from a built zephyr.elf file.  EFI applications are
+relocatable, and cannot be placed at specific locations in memory.
+Instead, the stub code will copy the embedded zephyr sections to the
+appropriate locations at startup, clear any zero-filled (BSS, etc...)
+areas, then jump into the 64 bit entry point.
+
+Arguably this is needlessly inefficient, having to load the whole
+binary into memory and copy it vs. a bootloader like grub that will
+load it from the EFI boot filesystem into its correct location with no
+copies.  But then, the biggest Zephyr application binaries we have on
+any platform top out at 200kb or so, and grub is at minimum about 5x
+that size, and potentially MUCH more if you start enabling the default
+modules.
+
+Source Code & Linkage
+=====================
+
+The code and link environment here is non-obvious.  The simple rules
+are:
+
+1. All code must live in a single C file
+2. All symbols must be declared static
+
+And if you forget this and use a global by mistake, the build will
+work fine and then fail inexplicably at runtime with a garbage
+address.  The sole exception is the "efi_entry()" function, whose
+address is not generated at runtime by the C code here (it's address
+goes into the PE file header instead).
+
+The reason is that we're building an EFI Application Binary with a
+Linux toolchain.  EFI binaries are relocatable PE-COFF files --
+basically Windows DLLs.  But our compiler only generates code for ELF
+targets.
+
+These environments differ in the way they implemenqt position
+independent code.  Non-static global variables and function addresses
+in ELF get found via GOT and PLT tables that are populated at load
+time by a system binary (ld-linux.so).  But there is no ld-linux.so in
+EFI firmware, and the EFI loader only knows how to fill in the PE
+relocation fields, which are a different data structure.
+
+So we can only rely on the C file's internal linkage, which is done
+via the x86_64 RIP-relative addressing mode and doesn't rely on any
+support from the environment.  But that only works for symbols that
+the compiler (not the linker) knows a-priori will never be in
+externally linked shared libraries.  Which is to say: only static
+symbols work.
+
+You might ask: why build a position-independent executable in the
+first place?  Why not just link to a specific address?  The PE-COFF
+format certainly allows that, and the UEFI specification doesn't
+clearly rule it out.  But my experience with real EFI loaders is that
+they ignore the preferred load address and will put the image at
+arbitrary locations in memory.  I couldn't make it work, basically.
+
+Bugs
+====
+
+No support for 32 bit EFI environments.  This would be a very tall
+order given the linker constraints described above (i386 doesn't have
+a IP-relative addressing mode, so we'd have to do some kind of
+relocation of our own).  Will probably never happen unless we move to
+a proper PE-COFF toolchain.
+
+There is no protection against colliding mappings.  We just assume
+that the EFI environment will load our image at an address that
+doesn't overlap with the target Zephyr memory.  In practice on the
+systems I've tried, EFI uses memory near the top of 32-bit-accessible
+physical memory, while Zephyr prefers to load into the bottom of RAM
+at 0x10000.  Even given collisions, this is probably tolerable, as we
+could control the Zephyr mapping addresses per-platform if needed to
+sneak around EFI areas.  But the Zephyr loader should at least detect
+the overlap and warn about it.
+
+It runs completely standalone, writing output to the current
+directory, and uses the (x86_64 linux) host toolchain right now, when
+it should be integrated with the Zephyr toolchain and build system.

--- a/arch/x86/zefi/efi.h
+++ b/arch/x86/zefi/efi.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef _EFI_H
+#define _EFI_H
+
+/* Minimal restatement of a minimal subset of the EFI runtime API */
+
+#define __abi __attribute__((ms_abi))
+
+typedef uintptr_t __abi (*efi_fn1_t)(void *);
+typedef uintptr_t __abi (*efi_fn2_t)(void *, void *);
+typedef uintptr_t __abi (*efi_fn3_t)(void *, void *, void *);
+typedef uintptr_t __abi (*efi_fn4_t)(void *, void *, void *, void *);
+
+struct efi_simple_text_output {
+	efi_fn2_t Reset;
+	efi_fn2_t OutputString;
+	efi_fn2_t TestString;
+	efi_fn4_t QueryMode;
+	efi_fn2_t SetMode;
+	efi_fn2_t SetAttribute;
+	efi_fn1_t ClearScreen;
+	efi_fn3_t SetCursorPosition;
+	efi_fn2_t EnableCursor;
+	struct simple_text_output_mode *Mode;
+};
+
+struct efi_system_table {
+	uint64_t Signature;
+	uint32_t Revision;
+	uint32_t HeaderSize;
+	uint32_t CRC32;
+	uint32_t Reserved;
+	uint16_t *FirmwareVendor;
+	uint32_t FirmwareRevision;
+	void *ConsoleInHandle;
+	struct efi_simple_input *ConIn;
+	void *ConsoleOutHandle;
+	struct efi_simple_text_output *ConOut;
+	void *StandardErrorHandle;
+	struct efi_simple_text_output *StdErr;
+	struct efi_runtime_services *RuntimeServices;
+	struct efi_boot_services *BootServices;
+	uint64_t NumberOfTableEntries;
+	struct efi_configuration_table *ConfigurationTable;
+};
+
+#endif /* _EFI_H */

--- a/arch/x86/zefi/efi.ld
+++ b/arch/x86/zefi/efi.ld
@@ -1,0 +1,49 @@
+ENTRY(efi_entry)
+
+SECTIONS {
+
+    /* Pick a reasonable base address, EFI won't load us there anyway */
+    . = 0x4000000;
+    .text : {
+        *(.text)
+        *(.rodata)
+    }
+
+    /* Must be a separately visible section to the EFI loader, doesn't
+     * need to be page-aligned and can be immediately after text/rodata */
+    .reloc :  { *(.reloc) }
+
+    /* Must be page-aligned or EFI balks */
+    . = ALIGN(4096);
+    .data : {
+        *(.data)
+        *(COMMON)
+        *(.bss)
+
+        *(.runtime_data_end) /* Must be last.  Obviously. */
+    }
+
+    /* Because binutils ld really likes to "helpfully" ignore the section
+     * directives and drop junk in weird places.
+     */
+    .trash_bin : {
+        *(.comment)
+        *(.data.rel*)
+        *(.dynamic)
+        *(.dynbss)
+        *(.dynstr)
+        *(.dynsym)
+        *(.eh_frame)
+        *(.gnu.hash)
+        *(.gnu.version*)
+        *(.got)
+        *(.got.plt)
+        *(.hash)
+        *(.note.*)
+        *(.plt)
+        *(.plt.*)
+        *(.rela.*)
+        *(.rel.local)
+    }
+
+} /* SECTIONS */

--- a/arch/x86/zefi/printf.h
+++ b/arch/x86/zefi/printf.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdarg.h>
+#include <stdbool.h>
+
+/* Tiny, but not-as-primitive-as-it-looks implementation of something
+ * like s/n/printf().  Handles %d, %x, %p, %c and %s only, allows a
+ * "l" qualifier on %d and %x (and silently ignores one %s/%c/%p).
+ * Accepts, but ignores, field width and precision values that match:
+ * the regex: [0-9]*\.?[0-9]*
+ */
+
+struct _pfr {
+	char *buf;
+	int len;
+	int idx;
+};
+
+/* Set this function pointer to something that generates output */
+static void (*z_putchar)(int c);
+
+static void pc(struct _pfr *r, int c)
+{
+	if (r->buf) {
+		if (r->idx <= r->len) {
+			r->buf[r->idx] = c;
+		}
+	} else {
+		z_putchar(c);
+	}
+	r->idx++;
+}
+
+static void prdec(struct _pfr *r, long v)
+{
+	if (v < 0) {
+		pc(r, '-');
+		v = -v;
+	}
+
+	char digs[11 * sizeof(long)/4];
+	int i = sizeof(digs) - 1;
+
+	digs[i--] = 0;
+	while (v || i == 9) {
+		digs[i--] = '0' + (v % 10);
+		v /= 10;
+	}
+
+	while (digs[++i]) {
+		pc(r, digs[i]);
+	}
+}
+
+static void endrec(struct _pfr *r)
+{
+	if (r->buf && r->idx < r->len) {
+		r->buf[r->idx] = 0;
+	}
+}
+
+static int vpf(struct _pfr *r, const char *f, va_list ap)
+{
+	for (/**/; *f; f++) {
+		bool islong = false;
+
+		if (*f != '%') {
+			pc(r, *f);
+			continue;
+		}
+
+		if (f[1] == 'l') {
+			islong = sizeof(long) > 4;
+			f++;
+		}
+
+		/* Ignore (but accept) field width and precision values */
+		while (f[1] >= '0' && f[1] <= '9') {
+			f++;
+		}
+		if (f[1] == '.') {
+			f++;
+		}
+		while (f[1] >= '0' && f[1] <= '9') {
+			f++;
+		}
+
+		switch (*(++f)) {
+		case 0:
+			return r->idx;
+		case '%':
+			pc(r, '%');
+			break;
+		case 'c':
+			pc(r, va_arg(ap, int));
+			break;
+		case 's': {
+			char *s = va_arg(ap, char *);
+
+			while (*s)
+				pc(r, *s++);
+			break;
+		}
+		case 'p':
+			pc(r, '0');
+			pc(r, 'x'); /* fall through... */
+			islong = sizeof(long) > 4;
+		case 'x': {
+			int sig = 0;
+			unsigned long v = islong ? va_arg(ap, unsigned long)
+				: va_arg(ap, unsigned int);
+			for (int i = 2*sizeof(long) - 1; i >= 0; i--) {
+				int d = (v >> (i*4)) & 0xf;
+
+				sig += !!d;
+				if (sig || i == 0)
+					pc(r, "0123456789abcdef"[d]);
+			}
+			break;
+		}
+		case 'd':
+			prdec(r, va_arg(ap, int));
+			break;
+		default:
+			pc(r, '%');
+			pc(r, *f);
+		}
+	}
+	endrec(r);
+	return r->idx;
+}
+
+#define CALL_VPF(rec)				\
+	va_list ap;				\
+	va_start(ap, f);			\
+	ret = vpf(&r, f, ap);			\
+	va_end(ap);
+
+static inline int snprintf(char *buf, unsigned long len, const char *f, ...)
+{
+	int ret = 0;
+	struct _pfr r = { .buf = buf, .len = len };
+
+	CALL_VPF(&r);
+	return ret;
+}
+
+static inline int sprintf(char *buf, const char *f, ...)
+{
+	int ret = 0;
+	struct _pfr r = { .buf = buf, .len = 0x7fffffff };
+
+	CALL_VPF(&r);
+	return ret;
+}
+
+static inline int printf(const char *f, ...)
+{
+	int ret = 0;
+	struct _pfr r = {0};
+
+	CALL_VPF(&r);
+	return ret;
+}

--- a/arch/x86/zefi/zefi.c
+++ b/arch/x86/zefi/zefi.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdint.h>
+#include "efi.h"
+#include "printf.h"
+#include <zefi-segments.h>
+
+#define PUTCHAR_BUFSZ 128
+
+/* The linker places this dummy last in the data memory.  We can't use
+ * traditional linker address symbols because we're relocatable; the
+ * linker doesn't know what the runtime address will be.  The compiler
+ * has to emit code to find this thing's address at runtime via an
+ * offset from RIP.  It's a qword so we can guarantee alignment of the
+ * stuff after.
+ */
+static __attribute__((section(".runtime_data_end")))
+uint64_t runtime_data_end[1] = { 0x1111aa8888aa1111L };
+
+#define EXT_DATA_START ((void *) &runtime_data_end[1])
+
+static struct efi_system_table *efi;
+
+static void efi_putchar(int c)
+{
+	static uint16_t efibuf[PUTCHAR_BUFSZ + 1];
+	static int n;
+
+	if (c == '\n') {
+		efi_putchar('\r');
+	}
+
+	efibuf[n++] = c;
+
+	if (c == '\n' || n == PUTCHAR_BUFSZ) {
+		efibuf[n] = 0;
+		efi->ConOut->OutputString(efi->ConOut, efibuf);
+		n = 0;
+	}
+}
+
+/* FIXME: if you check the generated code, "ms_abi" calls like this
+ * have to SPILL HALF OF THE SSE REGISTER SET TO THE STACK on entry
+ * because of the way the conventions collide.  Is there a way to
+ * prevent/suppress that?
+ */
+uintptr_t __abi efi_entry(void *img_handle, struct efi_system_table *sys_tab)
+{
+	efi = sys_tab;
+	z_putchar = efi_putchar;
+	printf("*** Zephyr EFI Loader ***\n");
+
+	for (int i = 0; i < sizeof(zefi_zsegs)/sizeof(zefi_zsegs[0]); i++) {
+		int nqwords = zefi_zsegs[i].sz;
+		uint64_t *dst = (uint64_t *)zefi_zsegs[i].addr;
+
+		printf("Zeroing %d bytes of memory at %p\n", 8 * nqwords, dst);
+		for (int j = 0; j < nqwords; j++) {
+			dst[j] = 0;
+		}
+	}
+
+	for (int i = 0; i < sizeof(zefi_dsegs)/sizeof(zefi_dsegs[0]); i++) {
+		int nqwords = zefi_dsegs[i].sz;
+		int off = zefi_dsegs[i].off;
+		uint64_t *dst = (uint64_t *)zefi_dsegs[i].addr;
+		uint64_t *src = &((uint64_t *)EXT_DATA_START)[off];
+
+		printf("Copying %d data bytes to %p from image offset %d\n",
+		       8 * nqwords, dst, zefi_dsegs[i].off);
+		for (int j = 0; j < nqwords; j++) {
+			dst[j] = src[j];
+		}
+	}
+
+	unsigned char *code = (void *)zefi_entry;
+
+	printf("Jumping to Entry Point: %p (%x %x %x %x %x %x)\n",
+	       code, code[0], code[1], code[2], code[3],
+	       code[4], code[5], code[6]);
+
+	/* The EFI console seems to be buffered, give it a little time
+	 * to drain before we start banging on the same UART from the
+	 * OS.
+	 */
+	for (volatile int i = 0; i < 50000000; i++) {
+	}
+
+	__asm__ volatile("cli; jmp *%0" :: "r"(code));
+
+	return 0;
+}
+
+/* Trick cribbed shamelessly from gnu-efi.  We need to emit a ".reloc"
+ * section into the image with a single dummy entry for the EFI loader
+ * to think we're a valid PE file, gcc won't because it thinks we're
+ * ELF.
+ */
+uint32_t relocation_dummy;
+__asm__(".section .reloc\n"
+	"base_relocation_block:\n"
+	".long relocation_dummy - base_relocation_block\n"
+	".long 0x0a\n"
+	".word	0\n");

--- a/arch/x86/zefi/zefi.py
+++ b/arch/x86/zefi/zefi.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+import sys
+import os.path
+import subprocess
+import elftools.elf.elffile
+
+ZEPHYR_ELF = sys.argv[1]
+ENTRY_SYM = "__start64"
+GCC = "gcc"
+OBJCOPY = "objcopy"
+
+dir = os.path.dirname(os.path.abspath(__file__))
+cfile = dir + "/zefi.c"
+ldscript = dir + "/efi.ld"
+assert os.path.isfile(cfile)
+assert os.path.isfile(ldscript)
+
+#
+# Open the ELF file up and find our entry point
+#
+ef = elftools.elf.elffile.ELFFile(open(ZEPHYR_ELF, "rb"))
+
+symtab = ef.get_section_by_name(".symtab")
+entry_addr = symtab.get_symbol_by_name(ENTRY_SYM)[0].entry.st_value
+
+print("Entry point address (symbol: %s) 0x%x" % (ENTRY_SYM, entry_addr))
+
+#
+# Parse the ELF file and extract segment data
+#
+
+data_blob = b''
+data_segs = []
+zero_segs = []
+
+for seg in ef.iter_segments():
+    h = seg.header
+    if h.p_type != "PT_LOAD":
+        continue
+
+    assert h.p_memsz >= h.p_filesz
+    assert (h.p_vaddr % 8) == 0
+    assert (h.p_memsz % 8) == 0
+    assert (h.p_filesz % 8) == 0
+    assert len(seg.data()) == h.p_filesz
+
+    if h.p_filesz > 0:
+        sd = seg.data()
+        print("%d bytes of data at 0x%x, data offset %d"
+              % (len(sd), h.p_vaddr, len(data_blob)))
+        data_segs.append((h.p_vaddr, len(sd) / 8, len(data_blob) / 8))
+        data_blob = data_blob + sd
+
+    if h.p_memsz > h.p_filesz:
+        bytesz = h.p_memsz - h.p_filesz
+        addr = h.p_vaddr + h.p_filesz
+        print("%d bytes of zero-fill at 0x%x" % (bytesz, addr))
+        zero_segs.append((addr, bytesz / 8))
+
+print(len(data_blob), "bytes of data to include in image")
+
+#
+# Emit a C header containing the metadata
+#
+cf = open("zefi-segments.h", "w")
+
+cf.write("/* GENERATED CODE.  DO NOT EDIT. */\n\n")
+
+cf.write("/* Sizes and offsets specified in 8-byte units.\n")
+cf.write(" * All addresses 8-byte aligned.\n")
+cf.write(" */\n")
+
+cf.write("struct data_seg { uint64_t addr; uint32_t sz; uint32_t off; };\n\n")
+
+cf.write("static struct data_seg zefi_dsegs[] = {\n")
+for s in data_segs:
+    cf.write("    { 0x%x, %d, %d },\n"
+             % (s[0], s[1], s[2]))
+cf.write("};\n\n")
+
+cf.write("struct zero_seg { uint64_t addr; uint32_t sz; };\n\n")
+
+cf.write("static struct zero_seg zefi_zsegs[] = {\n")
+for s in zero_segs:
+    cf.write("    { 0x%x, %d },\n"
+             % (s[0], s[1]))
+cf.write("};\n\n")
+
+cf.write("static uintptr_t zefi_entry = 0x%xUL;\n" % (entry_addr))
+
+cf.close()
+
+print("\nMetadata header generated.\n")
+
+#
+# Build
+#
+
+# First stage ELF binary.  Flag notes:
+#  + Stack protector is default on some distros and needs library support
+#  + We need pic to enforce that the linker adds no relocations
+#  + UEFI can take interrupts on our stack, so no red zone
+#  + UEFI API assumes 16-bit wchar_t
+cmd = [GCC, "-shared", "-Wall", "-Werror", "-I.",
+       "-fno-stack-protector", "-fpic", "-mno-red-zone", "-fshort-wchar",
+       "-Wl,-nostdlib", "-T", ldscript, "-o", "zefi.elf", cfile]
+print(" ".join(cmd))
+subprocess.run(cmd, check = True)
+
+# Extract the .data segment and append our extra blob
+cmd = [OBJCOPY, "-O", "binary", "-j", ".data", "zefi.elf", "data.dat"]
+print(" ".join(cmd))
+subprocess.run(cmd, check = True)
+
+assert (os.stat("data.dat").st_size % 8) == 0
+df = open("data.dat", "ab")
+df.write(data_blob)
+df.close()
+
+# FIXME: this generates warnings about our unused trash section having to be moved to make room.  Set its address far away...
+subprocess.run([OBJCOPY, "--update-section", ".data=data.dat",
+                "zefi.elf"], check = True)
+
+# Convert it to a PE-COFF DLL.
+cmd = [OBJCOPY, "--target=efi-app-x86_64",
+       "-j", ".text", "-j", ".reloc", "-j", ".data",
+       "zefi.elf", "zephyr.efi"]
+print(" ".join(cmd))
+subprocess.run(cmd, check = True)
+
+print("\nBuild complete; zephyr.efi wrapper binary is ready")


### PR DESCRIPTION
This is a first cut on a tool that will convert a built Zephyr ELF
file into an EFI applciation suitable for launching directly from the
firmware of a UEFI-capable device, without the need for an external
bootloader.

It works by including the Zephyr sections into the EFI binary as
blobs, then copying them into place on startup.

Currently, it is not integrated in the build.  Right now you have to
build an image for your target (up_squared has been tested) and then
pass the resulting zephyr.elf file as an argument to the
arch/x86/zefi/zefi.py script.  It will produce a "zephyr.efi" file in
the current directory.

This involved a little surgery in x86_64 to copy over some setup that
was previously being done in 32 bit mode to a new EFI entry point.
There is no support for 32 bit UEFI targets for toolchain reasons.

See the README for more details.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>