### PR TITLE
cmake: Allow projects to add additional dependencies to flash target

### DIFF
--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -199,6 +199,7 @@ foreach(target flash debug debugserver attach)
       ${target}
       --skip-rebuild
       DEPENDS ${FLASH_DEPS}
+              $<TARGET_PROPERTY:zephyr_property_target,FLASH_DEPENDENCIES>
       WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
       )
 


### PR DESCRIPTION
This is re-introducing #22937 that was unintentionally lost when merging another PR.