### PR TITLE
drivers: serial: Fix uart_poll_in() for mcux flexcomm driver

### DIFF
--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -44,7 +44,7 @@ static int mcux_flexcomm_poll_in(struct device *dev, unsigned char *c)
 	uint32_t flags = USART_GetStatusFlags(config->base);
 	int ret = -1;
 
-	if (flags & kUSART_RxFifoFullFlag) {
+	if (flags & kUSART_RxFifoNotEmptyFlag) {
 		*c = USART_ReadByte(config->base);
 		ret = 0;
 	}


### PR DESCRIPTION
Replaces kUSART_RxFifoFullFlag with kUSART_RxFifoNotEmptyFlag to
prevent Rx FIFO overrun.

Signed-off-by: Jiří Keresteš <jiri@kerestes.cz>