### PR TITLE
net: lib: openthread: Handle OT transmission in Thread task

### DIFF
--- a/subsys/net/lib/openthread/platform/platform-zephyr.h
+++ b/subsys/net/lib/openthread/platform/platform-zephyr.h
@@ -82,4 +82,9 @@ void platformShellInit(otInstance *aInstance);
  */
 int notify_new_rx_frame(struct net_pkt *pkt);
 
+/**
+ * Notify OpenThread task about new tx message.
+ */
+int notify_new_tx_frame(struct net_pkt *pkt);
+
 #endif  /* PLATFORM_POSIX_H_ */


### PR DESCRIPTION
OpenThread API is not thread-safe.
Moved creation of otMessage to the Thread task and created api
for passing it properly.
This way it should be less possible for an issue to occure eg.
during message buffer allocation.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>