### PR TITLE
net: route: Skip lladdr check for ppp

### DIFF
--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -790,19 +790,27 @@ int net_route_packet(struct net_pkt *pkt, struct in6_addr *nexthop)
 	 */
 	if (net_if_l2(net_pkt_iface(pkt)) != &NET_L2_GET_NAME(DUMMY)) {
 #endif
-		if (!net_pkt_lladdr_src(pkt)->addr) {
-			NET_DBG("Link layer source address not set");
-			return -EINVAL;
-		}
+#if defined(CONFIG_NET_L2_PPP)
+		/* PPP does not populate the lladdr fields */
+		if (net_if_l2(net_pkt_iface(pkt)) != &NET_L2_GET_NAME(PPP)) {
+#endif
+			if (!net_pkt_lladdr_src(pkt)->addr) {
+				NET_DBG("Link layer source address not set");
+				return -EINVAL;
+			}
 
-		/* Sanitycheck: If src and dst ll addresses are going to be
-		 * same, then something went wrong in route lookup.
-		 */
-		if (!memcmp(net_pkt_lladdr_src(pkt)->addr, lladdr->addr,
-			    lladdr->len)) {
-			NET_ERR("Src ll and Dst ll are same");
-			return -EINVAL;
+			/* Sanitycheck: If src and dst ll addresses are going
+			 * to be same, then something went wrong in route
+			 * lookup.
+			 */
+			if (!memcmp(net_pkt_lladdr_src(pkt)->addr, lladdr->addr,
+				    lladdr->len)) {
+				NET_ERR("Src ll and Dst ll are same");
+				return -EINVAL;
+			}
+#if defined(CONFIG_NET_L2_PPP)
 		}
+#endif
 #if defined(CONFIG_NET_L2_DUMMY)
 	}
 #endif


### PR DESCRIPTION
ppp does not populate the lladdr fields in the received packet.
To enable routing for packets received on the ppp interface, the check
of the link layer addresses in the packet must be skipped.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>