### PR TITLE
west.yml: update hal stm32xx modules

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -74,7 +74,7 @@ manifest:
       revision: 5b3ec3e182d4310e8943cc34c6c70ae57d9711da
       path: modules/hal/st
     - name: hal_stm32
-      revision: 6b330f0af95c867bf27534b3b58be03c0fb9e7ad
+      revision: cea57f86d3ade46c0b99dab32b2ac63435ed0693
       path: modules/hal/stm32
     - name: hal_ti
       revision: aabc6a04a8e871cbb01e02c22bb409f68001dc64


### PR DESCRIPTION
This updates the stm32cube/stm32xx to latest branches

Requires zephyrproject-rtos/hal_stm32#60

Signed-off-by: Francois Ramu <francois.ramu@st.com>