### PR TITLE
sanitycheck: sanitylib: Fix bare --west-flash option

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -546,7 +546,7 @@ class DeviceHandler(Handler):
     def handle(self):
         out_state = "failed"
 
-        if self.suite.west_flash:
+        if self.suite.west_flash is not None:
             command = ["west", "flash", "--skip-rebuild", "-d", self.build_dir]
             if self.suite.west_runner:
                 command.append("--runner")


### PR DESCRIPTION
If we pass --west-flash with no additional argument that was getting
treated the same as if it wasn't passed at all.

Change the check to be based on 'None' to handle the bare --west-flash
case properly.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>