### PR TITLE
Bluetooth: Mesh: fix different signedness

### DIFF
--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -613,7 +613,7 @@ int bt_mesh_input_string(const char *str)
 		return -EINVAL;
 	}
 
-	strncpy(link.auth, str, prov->input_size);
+	strncpy((char *)link.auth, str, prov->input_size);
 
 	send_input_complete();
 


### PR DESCRIPTION
CC:  subsys/bluetooth/mesh/prov.c
subsys/bluetooth/mesh/prov.c: In function 'bt_mesh_input_string':
subsys/bluetooth/mesh/prov.c:616:14:
        warning: pointer targets in passing argument 1 of
        'strncpy' differ in signedness [-Wpointer-sign]
  616 |  strncpy(link.auth, str, prov->input_size);
      |          ~~~~^~~~~
      |              |
      |              uint8_t * {aka unsigned char *}

Signed-off-by: chao an <anchao@xiaomi.com>