### PR TITLE
usb: Correct USB setup packet endianness in USB core.

### DIFF
--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -215,10 +215,10 @@ int cdc_acm_class_handle_req(struct usb_setup_packet *pSetup,
 	struct usb_dev_data *common;
 
 	common = usb_get_dev_data_by_iface(&cdc_acm_data_devlist,
-					   sys_le16_to_cpu(pSetup->wIndex));
+					   (uint8_t)pSetup->wIndex);
 	if (common == NULL) {
 		LOG_WRN("Device data not found for interface %u",
-			sys_le16_to_cpu(pSetup->wIndex));
+			pSetup->wIndex);
 		return -ENODEV;
 	}
 
@@ -236,7 +236,7 @@ int cdc_acm_class_handle_req(struct usb_setup_packet *pSetup,
 		break;
 
 	case SET_CONTROL_LINE_STATE:
-		dev_data->line_state = (uint8_t)sys_le16_to_cpu(pSetup->wValue);
+		dev_data->line_state = (uint8_t)pSetup->wValue;
 		LOG_DBG("CDC_SET_CONTROL_LINE_STATE 0x%x",
 			dev_data->line_state);
 		break;

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -137,7 +137,7 @@ static int hid_on_get_idle(struct hid_device_info *dev_data,
 			   uint8_t **data)
 {
 #ifdef CONFIG_USB_DEVICE_SOF
-	uint8_t report_id = sys_le16_to_cpu(setup->wValue) & 0xFF;
+	uint8_t report_id = (uint8_t)setup->wValue;
 
 	if (report_id > CONFIG_USB_HID_REPORTS) {
 		LOG_ERR("Report id out of limit: %d", report_id);
@@ -194,8 +194,8 @@ static int hid_on_set_idle(struct hid_device_info *dev_data,
 			   uint8_t **data)
 {
 #ifdef CONFIG_USB_DEVICE_SOF
-	uint8_t rate = ((sys_le16_to_cpu(setup->wValue) & 0xFF00) >> 8);
-	uint8_t report_id = sys_le16_to_cpu(setup->wValue) & 0xFF;
+	uint8_t rate = (uint8_t)(setup->wValue >> 8);
+	uint8_t report_id = (uint8_t)setup->wValue;
 
 	if (report_id > CONFIG_USB_HID_REPORTS) {
 		LOG_ERR("Report id out of limit: %d", report_id);
@@ -258,7 +258,7 @@ static int hid_on_set_protocol(struct hid_device_info *dev_data,
 			       uint8_t **data)
 {
 #ifdef CONFIG_USB_HID_BOOT_PROTOCOL
-	uint16_t protocol = sys_le16_to_cpu(setup->wValue);
+	uint16_t protocol = (uint8_t)setup->wValue;
 
 	if (protocol > HID_PROTOCOL_REPORT) {
 		LOG_ERR("Unsupported protocol: %u", protocol);
@@ -404,14 +404,15 @@ static int hid_class_handle_req(struct usb_setup_packet *setup,
 	struct hid_device_info *dev_data;
 	struct usb_dev_data *common;
 
-	LOG_DBG("Class request: bRequest 0x%x bmRequestType 0x%x len %d",
+	LOG_DBG("Class request:"
+		"bRequest 0x%02x, bmRequestType 0x%02x len %d",
 		setup->bRequest, setup->bmRequestType, *len);
 
 	common = usb_get_dev_data_by_iface(&usb_hid_devlist,
-					   sys_le16_to_cpu(setup->wIndex));
+					   (uint8_t)setup->wIndex);
 	if (common == NULL) {
 		LOG_WRN("Device data not found for interface %u",
-			sys_le16_to_cpu(setup->wIndex));
+			setup->wIndex);
 		return -ENODEV;
 	}
 
@@ -447,7 +448,7 @@ static int hid_class_handle_req(struct usb_setup_packet *setup,
 			}
 			break;
 		default:
-			LOG_ERR("Unhandled request 0x%x", setup->bRequest);
+			LOG_ERR("Unhandled request 0x%02x", setup->bRequest);
 			break;
 		}
 	} else {
@@ -480,7 +481,7 @@ static int hid_class_handle_req(struct usb_setup_packet *setup,
 			}
 			break;
 		default:
-			LOG_ERR("Unhandled request 0x%x", setup->bRequest);
+			LOG_ERR("Unhandled request 0x%02x", setup->bRequest);
 			break;
 		}
 	}
@@ -491,15 +492,16 @@ static int hid_class_handle_req(struct usb_setup_packet *setup,
 static int hid_custom_handle_req(struct usb_setup_packet *setup,
 				 int32_t *len, uint8_t **data)
 {
-	LOG_DBG("Standard request: bRequest 0x%x bmRequestType 0x%x len %d",
+	LOG_DBG("Standard request:"
+		"bRequest 0x%02x, bmRequestType 0x%02x, len %d",
 		setup->bRequest, setup->bmRequestType, *len);
 
 	if (REQTYPE_GET_DIR(setup->bmRequestType) == REQTYPE_DIR_TO_HOST &&
 	    REQTYPE_GET_RECIP(setup->bmRequestType) ==
 					REQTYPE_RECIP_INTERFACE &&
 					setup->bRequest == REQ_GET_DESCRIPTOR) {
-		uint8_t value = sys_le16_to_cpu(setup->wValue) >> 8;
-		uint8_t iface_num = sys_le16_to_cpu(setup->wIndex);
+		uint8_t value = (uint8_t)(setup->wValue >> 8);
+		uint8_t iface_num = (uint8_t)setup->wIndex;
 		struct hid_device_info *dev_data;
 		struct usb_dev_data *common;
 		const struct usb_cfg_data *cfg;
@@ -508,7 +510,7 @@ static int hid_custom_handle_req(struct usb_setup_packet *setup,
 		common = usb_get_dev_data_by_iface(&usb_hid_devlist, iface_num);
 		if (common == NULL) {
 			LOG_WRN("Device data not found for interface %u",
-				sys_le16_to_cpu(setup->wIndex));
+				iface_num);
 			return -EINVAL;
 		}
 

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -237,8 +237,8 @@ static bool write(uint8_t *buf, uint16_t size)
 static int mass_storage_class_handle_req(struct usb_setup_packet *pSetup,
 					 int32_t *len, uint8_t **data)
 {
-	if (sys_le16_to_cpu(pSetup->wIndex) != mass_cfg.if0.bInterfaceNumber ||
-	    sys_le16_to_cpu(pSetup->wValue) != 0) {
+	if (pSetup->wIndex != mass_cfg.if0.bInterfaceNumber ||
+	    pSetup->wValue != 0) {
 		LOG_WRN("Invalid setup parameters");
 		return -EINVAL;
 	}
@@ -247,7 +247,7 @@ static int mass_storage_class_handle_req(struct usb_setup_packet *pSetup,
 	case MSC_REQUEST_RESET:
 		LOG_DBG("MSC_REQUEST_RESET");
 
-		if (sys_le16_to_cpu(pSetup->wLength)) {
+		if (pSetup->wLength) {
 			LOG_WRN("Invalid length");
 			return -EINVAL;
 		}
@@ -258,7 +258,7 @@ static int mass_storage_class_handle_req(struct usb_setup_packet *pSetup,
 	case MSC_REQUEST_GET_MAX_LUN:
 		LOG_DBG("MSC_REQUEST_GET_MAX_LUN");
 
-		if (sys_le16_to_cpu(pSetup->wLength) != 1) {
+		if (pSetup->wLength != 1) {
 			LOG_WRN("Invalid length");
 			return -EINVAL;
 		}
@@ -269,7 +269,7 @@ static int mass_storage_class_handle_req(struct usb_setup_packet *pSetup,
 		break;
 
 	default:
-		LOG_WRN("Unknown request 0x%x, value 0x%x",
+		LOG_WRN("Unknown request 0x%02x, value 0x%02x",
 			pSetup->bRequest, pSetup->wValue);
 		return -EINVAL;
 	}


### PR DESCRIPTION
USB is sending data from LSB to MSB. Same happens for each field
of the USB setup packet.
This patch convert USB setup packet to proper form when its read
out from the line.

Follow up of: #26205

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>