### PR TITLE
boards: kconfig: Disable QEMU icount when Bluetooth is enabled

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -31,7 +31,7 @@ menu "Board Options"
 config QEMU_ICOUNT
 	bool "QEMU icount mode"
 	depends on QEMU_TARGET
-	default y if !NETWORKING
+	default y if !NETWORKING && !BT
 	help
 	  Enable QEMU virtual instruction counter. The virtual cpu will
 	  execute one instruction every 2^N ns of virtual time. This will


### PR DESCRIPTION
Bluetooth interacts with real-world hardware and thus requires the QEMU
target to follow wall time, and not have a free running timer that is
much faster than actual wall time.

Diable the QEMU icount mechanism when Bluetooth is enabled.

Fixes #26242

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>