### PR TITLE
kernel/timeout: Fix 32 bit rollover conditions

### DIFF
--- a/include/kernel_structs.h
+++ b/include/kernel_structs.h
@@ -220,8 +220,13 @@ typedef void (*_timeout_func_t)(struct _timeout *t);
 
 struct _timeout {
 	sys_dnode_t node;
-	int32_t dticks;
 	_timeout_func_t fn;
+#ifdef CONFIG_TIMEOUT_64BIT
+	/* Can't use k_ticks_t for header dependency reasons */
+	uint64_t dticks;
+#else
+	uint32_t dticks;
+#endif
 };
 
 /* kernel spinlock type */

--- a/include/sys_clock.h
+++ b/include/sys_clock.h
@@ -84,10 +84,18 @@ typedef struct {
 #define Z_TIMEOUT_NO_WAIT ((k_timeout_t) {})
 #define Z_TIMEOUT_TICKS(t) ((k_timeout_t) { .ticks = (t) })
 #define Z_FOREVER Z_TIMEOUT_TICKS(K_TICKS_FOREVER)
-#define Z_TIMEOUT_MS(t) Z_TIMEOUT_TICKS(k_ms_to_ticks_ceil32(MAX(t, 0)))
-#define Z_TIMEOUT_US(t) Z_TIMEOUT_TICKS(k_us_to_ticks_ceil32(MAX(t, 0)))
-#define Z_TIMEOUT_NS(t) Z_TIMEOUT_TICKS(k_ns_to_ticks_ceil32(MAX(t, 0)))
-#define Z_TIMEOUT_CYC(t) Z_TIMEOUT_TICKS(k_cyc_to_ticks_ceil32(MAX(t, 0)))
+
+#ifdef CONFIG_TIMEOUT_64BIT
+# define Z_TIMEOUT_MS(t) Z_TIMEOUT_TICKS(k_ms_to_ticks_ceil64(MAX(t, 0)))
+# define Z_TIMEOUT_US(t) Z_TIMEOUT_TICKS(k_us_to_ticks_ceil64(MAX(t, 0)))
+# define Z_TIMEOUT_NS(t) Z_TIMEOUT_TICKS(k_ns_to_ticks_ceil64(MAX(t, 0)))
+# define Z_TIMEOUT_CYC(t) Z_TIMEOUT_TICKS(k_cyc_to_ticks_ceil64(MAX(t, 0)))
+#else
+# define Z_TIMEOUT_MS(t) Z_TIMEOUT_TICKS(k_ms_to_ticks_ceil32(MAX(t, 0)))
+# define Z_TIMEOUT_US(t) Z_TIMEOUT_TICKS(k_us_to_ticks_ceil32(MAX(t, 0)))
+# define Z_TIMEOUT_NS(t) Z_TIMEOUT_TICKS(k_ns_to_ticks_ceil32(MAX(t, 0)))
+# define Z_TIMEOUT_CYC(t) Z_TIMEOUT_TICKS(k_cyc_to_ticks_ceil32(MAX(t, 0)))
+#endif
 
 /* Converts between absolute timeout expiration values (packed into
  * the negative space below K_TICKS_FOREVER) and (non-negative) delta


### PR DESCRIPTION
There were two spots where CONFIG_TIMEOUT_64BIT wasn't being correctly
honored, leading to the possibility of long timeouts overflowing
internally and doing weird stuff.

Fixes #26248

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>