### PR TITLE
PCI MMIO configuration support

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -100,6 +100,14 @@ config ACPI
 	help
 	  Allow retrieval of platform configuration at runtime.
 
+config PCIE_MMIO_CFG
+	bool "Use MMIO PCI configuration space access"
+	select ACPI
+	help
+	  Selects the use of the memory-mapped PCI Express Extended
+	  Configuration Space instead of the traditional 0xCF8/0xCFC
+	  IO Port registers.
+
 config X86_MEMMAP_ENTRIES
 	int "Number of memory map entries"
 	range 1 256

--- a/arch/x86/core/pcie.c
+++ b/arch/x86/core/pcie.c
@@ -7,18 +7,82 @@
 #include <kernel.h>
 #include <drivers/pcie/pcie.h>
 
+#ifdef CONFIG_ACPI
+#include <arch/x86/acpi.h>
+#endif
+
 #ifdef CONFIG_PCIE_MSI
 #include <drivers/pcie/msi.h>
 #endif
 
-/*
- * The Configuration Mechanism (previously, Configuration Mechanism #1)
- * uses two 32-bit ports in the I/O space, here called CAP and CDP.
- *
- * N.B.: this code relies on the fact that the PCIE_BDF() format (as
- * defined in dt-bindings/pcie/pcie.h) and the CAP agree on the bus/dev/func
- * bitfield positions and sizes.
- */
+/* PCI Express Extended Configuration Mechanism (MMIO) */
+
+#define MAX_PCI_BUS_SEGMENTS 4
+
+static struct {
+	uint32_t start_bus;
+	uint32_t n_buses;
+	uint8_t *mmio;
+} bus_segs[MAX_PCI_BUS_SEGMENTS];
+
+static void pcie_mm_init(void)
+{
+#ifdef CONFIG_ACPI
+	struct acpi_mcfg *m = z_acpi_find_table(ACPI_MCFG_SIGNATURE);
+
+	if (m != NULL) {
+		int n = (m->sdt.len - sizeof(*m)) / sizeof(m->pci_segs[0]);
+
+		for (int i = 0; i < n && i < MAX_PCI_BUS_SEGMENTS; i++) {
+			bus_segs[i].start_bus = m->pci_segs[i].start_bus;
+			bus_segs[i].n_buses = 1 + m->pci_segs[i].end_bus
+				- m->pci_segs[i].start_bus;
+			bus_segs[i].mmio =
+				(void *)(long)m->pci_segs[i].base_addr;
+		}
+	}
+#endif
+}
+
+static inline void pcie_mm_conf(pcie_bdf_t bdf, unsigned int reg,
+				bool write, uint32_t *data)
+{
+	if (bus_segs[0].mmio == NULL) {
+		pcie_mm_init();
+	}
+
+	for (int i = 0; i < ARRAY_SIZE(bus_segs); i++) {
+		int off = PCIE_BDF_TO_BUS(bdf) - bus_segs[i].start_bus;
+
+		if (off >= 0 && off < bus_segs[i].n_buses) {
+			bdf = PCIE_BDF(off,
+				       PCIE_BDF_TO_DEV(bdf),
+				       PCIE_BDF_TO_FUNC(bdf));
+
+			volatile uint32_t *regs
+				= (void *)&bus_segs[0].mmio[bdf << 4];
+
+			if (write) {
+				regs[reg] = *data;
+			} else {
+				*data = regs[reg];
+			}
+		}
+	}
+}
+
+void z_pcie_add_mmu_regions(void)
+{
+	for (int i = 0; i < ARRAY_SIZE(bus_segs); i++) {
+		/* 32 devices & 8 functions per bus, 4k per device */
+		uintptr_t sz = bus_segs[i].n_buses * (32 * 8 * 4096);
+
+		z_x86_add_mmu_region((uintptr_t) bus_segs[i].mmio,
+				     sz, MMU_ENTRY_READ | MMU_ENTRY_WRITE);
+	}
+}
+
+/* Traditional Configuration Mechanism */
 
 #define PCIE_X86_CAP	0xCF8U	/* Configuration Address Port */
 #define PCIE_X86_CAP_BDF_MASK	0x00FFFF00U  /* b/d/f bits */
@@ -32,7 +96,8 @@
  * Helper function for exported configuration functions. Configuration access
  * ain't atomic, so spinlock to keep drivers from clobbering each other.
  */
-static void pcie_conf(pcie_bdf_t bdf, unsigned int reg, bool write, uint32_t *data)
+static inline void pcie_io_conf(pcie_bdf_t bdf, unsigned int reg,
+				bool write, uint32_t *data)
 {
 	static struct k_spinlock lock;
 	k_spinlock_key_t k;
@@ -54,11 +119,22 @@ static void pcie_conf(pcie_bdf_t bdf, unsigned int reg, bool write, uint32_t *da
 	k_spin_unlock(&lock, k);
 }
 
+static inline void pcie_conf(pcie_bdf_t bdf, unsigned int reg,
+			     bool write, uint32_t *data)
+
+{
+#ifdef CONFIG_PCIE_MMIO_CFG
+	pcie_mm_conf(bdf, reg, write, data);
+#else
+	pcie_io_conf(bdf, reg, write, data);
+#endif
+}
+
 /* these functions are explained in include/drivers/pcie/pcie.h */
 
 uint32_t pcie_conf_read(pcie_bdf_t bdf, unsigned int reg)
 {
-	uint32_t data;
+	uint32_t data = 0;
 
 	pcie_conf(bdf, reg, false, &data);
 	return data;

--- a/arch/x86/core/prep_c.c
+++ b/arch/x86/core/prep_c.c
@@ -30,10 +30,6 @@ FUNC_NORETURN void z_x86_prep_c(void *arg)
 	ARG_UNUSED(info);
 #endif
 
-#ifdef CONFIG_ACPI
-	z_acpi_init();
-#endif
-
 #ifdef CONFIG_X86_MMU
 	z_x86_paging_init();
 #endif

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -15,6 +15,8 @@
 #include <logging/log.h>
 LOG_MODULE_DECLARE(os);
 
+void z_pcie_add_mmu_regions(void);
+
 #define PHYS_RAM_ADDR DT_REG_ADDR(DT_CHOSEN(zephyr_sram))
 #define PHYS_RAM_SIZE DT_REG_SIZE(DT_CHOSEN(zephyr_sram))
 
@@ -849,6 +851,10 @@ void z_x86_paging_init(void)
 	}
 
 	z_x86_soc_add_mmu_regions();
+
+#ifdef CONFIG_PCIE_MMIO_CFG
+	z_pcie_add_mmu_regions();
+#endif
 
 	pages_free = (page_pos - page_pool) / MMU_PAGE_SIZE;
 

--- a/include/arch/x86/acpi.h
+++ b/include/arch/x86/acpi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Intel Corporation
+ * Copyright (c) 2020 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,51 +8,42 @@
 
 #ifndef _ASMLANGUAGE
 
-extern void z_acpi_init(void);
-extern struct acpi_cpu *z_acpi_get_cpu(int);
+extern void *z_acpi_find_table(uint32_t signature);
 
-/*
- * The RSDP is a "floating" structure which simply points to the RSDT.
- */
-
-#define ACPI_RSDP_SIGNATURE	0x2052545020445352 /* 'RSD PTR ' */
-
-struct acpi_rsdp {
-	uint64_t signature;	/* ACPI_RSDP_SIG */
-	uint8_t checksum;
-	uint8_t dontcare[7];
-	uint32_t rsdt;		/* physical address of RSDT */
-} __packed;
-
-/*
- * All SDTs have a common header.
- */
-
+/* Standard table header */
 struct acpi_sdt {
-	uint32_t signature;
-	uint32_t length;		/* in bytes, of entire table */
-	uint8_t dontcare0;
-	uint8_t checksum;		/* of entire table */
-	uint8_t dontcare1[26];
+	uint32_t sig;
+	uint32_t len;
+	uint8_t rev;
+	uint8_t csum;
+	char oemid[6];
+	char oem_table_id[8];
+	uint32_t oemrevision;
+	uint32_t creator_id;
+	uint32_t creator_rev;
 } __packed;
 
-/*
- * The RSDT is the container for an array of pointers to other SDTs.
- */
+/* MCFG table storing MMIO addresses for PCI configuration space */
 
-#define ACPI_RSDT_SIGNATURE 0x54445352	/* 'RSDT' */
+#define ACPI_MCFG_SIGNATURE 0x4746434d  /* 'MCFG' */
 
-struct acpi_rsdt {
+struct acpi_mcfg {
 	struct acpi_sdt sdt;
-	uint32_t sdts[];  /* physical addresses of other SDTs */
+	uint64_t _rsvd;
+	struct {
+		uint64_t base_addr;
+		uint16_t seg_group_num;
+		uint8_t start_bus;
+		uint8_t end_bus;
+	} pci_segs[];
 } __packed;
 
-/*
- * The MADT is the "Multiple APIC Descriptor Table", which
- * we use to enumerate the CPUs and I/O APICs in the system.
- */
+/* MADT table storing IO-APIC and multiprocessor configuration  */
 
 #define ACPI_MADT_SIGNATURE 0x43495041	/* 'APIC' */
+
+#define ACPI_MADT_FLAGS_PICS 0x01	/* legacy 8259s installed */
+#define ACPI_MADT_ENTRY_CPU	0
 
 struct acpi_madt_entry {
 	uint8_t type;
@@ -61,18 +52,10 @@ struct acpi_madt_entry {
 
 struct acpi_madt {
 	struct acpi_sdt sdt;
-	uint32_t lapic;	/* local APIC MMIO address */
-	uint32_t flags;	/* see ACPI_MADT_FLAGS_* below */
+	uint32_t lapic; /* local APIC MMIO address */
+	uint32_t flags; /* see ACPI_MADT_FLAGS_* below */
 	struct acpi_madt_entry entries[];
 } __packed;
-
-#define ACPI_MADT_FLAGS_PICS 0x01	/* legacy 8259s installed */
-
-/*
- * There's an MADT "local APIC" entry for each CPU in the system.
- */
-
-#define ACPI_MADT_ENTRY_CPU	0
 
 struct acpi_cpu {
 	struct acpi_madt_entry entry;
@@ -80,6 +63,8 @@ struct acpi_cpu {
 	uint8_t id;	/* local APIC ID */
 	uint8_t flags;	/* see ACPI_MADT_CPU_FLAGS_* */
 } __packed;
+
+struct acpi_cpu *z_acpi_get_cpu(int n);
 
 #define ACPI_CPU_FLAGS_ENABLED 0x01
 

--- a/soc/x86/apollo_lake/Kconfig.defconfig
+++ b/soc/x86/apollo_lake/Kconfig.defconfig
@@ -18,6 +18,9 @@ config HPET_TIMER
 config APIC_TIMER
 	default y if !HPET_TIMER
 
+config PCIE_MMIO_CFG
+	default y
+
 if APIC_TIMER
 
 config APIC_TIMER_IRQ


### PR DESCRIPTION
Support for the PCI Express Extended Configuration Mechanism.

I wrote this in a hurry thinking I needed it.  I don't.  But it's still a nice-to-have in the tree.  I'm reliably told that devices exist (though probably not ones desperately in need of a Zephyr driver) whose capabilities lists run beyond the 256 byte region classic PCI is able to access and require the 4k MMIO mechanism to use.

Beyond that, it's hard to imagine why you'd want this in your code given the complexity, honestly.  But it was fun to write.