### PR TITLE
x86: fix early boot pagefault reason code

### DIFF
--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -54,8 +54,9 @@ bool z_x86_check_stack_bounds(uintptr_t addr, size_t size, uint16_t cs)
 {
 	uintptr_t start, end;
 
-	if (arch_is_in_isr()) {
-		/* We were servicing an interrupt */
+	if (_current == NULL || arch_is_in_isr()) {
+		/* We were servicing an interrupt or in early boot environment
+		 * and are supposed to be on the interrupt stack */
 		int cpu_id;
 
 #ifdef CONFIG_SMP


### PR DESCRIPTION
If we get a page fault in early boot context, before
main thread is started, page faults were being
incorrectly reported as stack overflows.
z_x86_check_stack_bounds() needs to consider the
interrupt stack as the correct stack for this context.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>