### PR TITLE
x86: add CONFIG_X86_KERNEL_OFFSET

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -47,6 +47,20 @@ config X86_64
 	select USE_SWITCH_SUPPORTED
 	select SCHED_IPI_SUPPORTED
 
+config X86_KERNEL_OFFSET
+	int "Kernel offset from beginning of RAM"
+	default 1048576
+	help
+	  A lot of x86 that resemble PCs have many reserved physical memory
+	  regions within the first megabyte. Specify an offset from the
+	  beginning of RAM to load the kernel in physical memory, avoiding these
+	  regions.
+
+	  Note that this does not include the "locore" which contains real mode
+	  bootstrap code within the first 64K of physical memory.
+
+	  This value normally need to be page-aligned.
+
 config MAX_IRQ_LINES
 	int "Number of IRQ lines"
 	default 128

--- a/dts/x86/apollo_lake.dtsi
+++ b/dts/x86/apollo_lake.dtsi
@@ -22,10 +22,10 @@
 
 	};
 
-	sram0: memory@100000 {
+	sram0: memory@0 {
 		device_type = "memory";
 		compatible = "mmio-sram";
-		reg = <0x00100000 DT_SRAM_SIZE>;
+		reg = <0x0 DT_SRAM_SIZE>;
 	};
 
 	intc: ioapic@fec00000  {

--- a/dts/x86/atom.dtsi
+++ b/dts/x86/atom.dtsi
@@ -19,10 +19,10 @@
 		};
 	};
 
-	sram0: memory@100000 {
+	sram0: memory@0 {
 		device_type = "memory";
 		compatible = "mmio-sram";
-		reg = <0x00100000 DT_SRAM_SIZE>;
+		reg = <0x0 DT_SRAM_SIZE>;
 	};
 
 	intc: ioapic@fec00000  {

--- a/dts/x86/ia32.dtsi
+++ b/dts/x86/ia32.dtsi
@@ -27,10 +27,10 @@
 		#interrupt-cells = <3>;
 	};
 
-	sram0: memory@100000 {
+	sram0: memory@0 {
 		device_type = "memory";
 		compatible = "mmio-sram";
-		reg = <0x00100000 DT_SRAM_SIZE>;
+		reg = <0x0 DT_SRAM_SIZE>;
 	};
 
 	soc {

--- a/include/arch/x86/ia32/linker.ld
+++ b/include/arch/x86/ia32/linker.ld
@@ -340,11 +340,11 @@ SECTIONS
 	__data_ram_end = .;
 
 	/* All unused memory also owned by the kernel for heaps */
-	__kernel_ram_end = PHYS_RAM_ADDR + PHYS_RAM_SIZE;
+	__kernel_ram_end = KERNEL_BASE_ADDR + KERNEL_RAM_SIZE;
 	__kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
 
 	_image_ram_end = .;
-	_image_ram_all = (PHYS_RAM_ADDR + PHYS_RAM_SIZE) - _image_ram_start;
+	_image_ram_all = (KERNEL_BASE_ADDR + KERNEL_RAM_SIZE) - _image_ram_start;
 
 	_end = .; /* end of image */
 

--- a/include/arch/x86/intel64/linker.ld
+++ b/include/arch/x86/intel64/linker.ld
@@ -180,7 +180,7 @@ SECTIONS
 	_end = .;
 
 	/* All unused memory also owned by the kernel for heaps */
-	__kernel_ram_end = PHYS_RAM_ADDR + PHYS_RAM_SIZE;
+	__kernel_ram_end = KERNEL_BASE_ADDR + KERNEL_RAM_SIZE;
 	__kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
 
 #include <linker/debug-sections.ld>

--- a/soc/x86/apollo_lake/linker.ld
+++ b/soc/x86/apollo_lake/linker.ld
@@ -10,11 +10,14 @@
 
 #define PHYS_RAM_ADDR		DT_REG_ADDR(DT_CHOSEN(zephyr_sram))
 #define PHYS_RAM_SIZE		DT_REG_SIZE(DT_CHOSEN(zephyr_sram))
-#define PHYS_LOAD_ADDR		PHYS_RAM_ADDR
+
+#define KERNEL_BASE_ADDR    (PHYS_RAM_ADDR + CONFIG_X86_KERNEL_OFFSET)
+#define KERNEL_RAM_SIZE     (PHYS_RAM_SIZE - CONFIG_X86_KERNEL_OFFSET)
+#define PHYS_LOAD_ADDR		KERNEL_BASE_ADDR
 
 MEMORY
     {
-    RAM (wx)        : ORIGIN = PHYS_RAM_ADDR, LENGTH = PHYS_RAM_SIZE
+    RAM (wx)        : ORIGIN = KERNEL_BASE_ADDR, LENGTH = KERNEL_RAM_SIZE
 
     /*
      * It doesn't matter where this region goes as it is stripped from the

--- a/soc/x86/atom/linker.ld
+++ b/soc/x86/atom/linker.ld
@@ -20,10 +20,13 @@
 #define PHYS_RAM_ADDR		DT_REG_ADDR(DT_CHOSEN(zephyr_sram))
 #define PHYS_RAM_SIZE		DT_REG_SIZE(DT_CHOSEN(zephyr_sram))
 
+#define KERNEL_BASE_ADDR (PHYS_RAM_ADDR + CONFIG_X86_KERNEL_OFFSET)
+#define KERNEL_RAM_SIZE  (PHYS_RAM_SIZE - CONFIG_X86_KERNEL_OFFSET)
+
 #ifdef CONFIG_XIP
   #define PHYS_LOAD_ADDR	DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
 #else  /* !CONFIG_XIP */
-  #define PHYS_LOAD_ADDR	PHYS_RAM_ADDR
+  #define PHYS_LOAD_ADDR	KERNEL_BASE_ADDR
 #endif /* CONFIG_XIP */
 
 MEMORY
@@ -31,7 +34,7 @@ MEMORY
 #ifdef CONFIG_XIP
     ROM (rx)        : ORIGIN = PHYS_LOAD_ADDR, LENGTH = DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
 #endif /* CONFIG_XIP */
-    RAM (wx)        : ORIGIN = PHYS_RAM_ADDR, LENGTH = PHYS_RAM_SIZE
+    RAM (wx)        : ORIGIN = KERNEL_BASE_ADDR, LENGTH = KERNEL_RAM_SIZE
 
     /*
      * It doesn't matter where this region goes as it is stripped from the

--- a/soc/x86/ia32/linker.ld
+++ b/soc/x86/ia32/linker.ld
@@ -22,10 +22,13 @@
 #define PHYS_RAM_ADDR		DT_REG_ADDR(DT_CHOSEN(zephyr_sram))
 #define PHYS_RAM_SIZE		DT_REG_SIZE(DT_CHOSEN(zephyr_sram))
 
+#define KERNEL_BASE_ADDR (PHYS_RAM_ADDR + CONFIG_X86_KERNEL_OFFSET)
+#define KERNEL_RAM_SIZE  (PHYS_RAM_SIZE - CONFIG_X86_KERNEL_OFFSET)
+
 #ifdef CONFIG_XIP
   #define PHYS_LOAD_ADDR	DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
 #else  /* !CONFIG_XIP */
-  #define PHYS_LOAD_ADDR	PHYS_RAM_ADDR
+  #define PHYS_LOAD_ADDR	KERNEL_BASE_ADDR
 #endif /* CONFIG_XIP */
 
 MEMORY
@@ -33,7 +36,7 @@ MEMORY
 #ifdef CONFIG_XIP
     ROM (rx)        : ORIGIN = PHYS_LOAD_ADDR, LENGTH = DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
 #endif /* CONFIG_XIP */
-    RAM (wx)        : ORIGIN = PHYS_RAM_ADDR, LENGTH = PHYS_RAM_SIZE
+    RAM (wx)        : ORIGIN = KERNEL_BASE_ADDR, LENGTH = KERNEL_RAM_SIZE
 
     /*
      * It doesn't matter where this region goes as it is stripped from the


### PR DESCRIPTION
Previously, DTS specification of physical RAM bounds did not
correspond to the actual bounds of system RAM as the first
megabyte was being skipped.

There were reasons for this - the first 1MB on PC-like systems
is a no-man's-land of reserved memory regions, but we need DTS
to accurately capture physical memory bounds.

Instead, we introduce a config option which can apply an offset
to the beginning of physical memory, and apply this to the "RAM"
region defined in the linker scripts.

This also fixes a problem where an extra megabyte was being
added to the size of system RAM.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>