### PR TITLE
tests: queue modifying and adding test case

### DIFF
--- a/tests/kernel/queue/src/main.c
+++ b/tests/kernel/queue/src/main.c
@@ -8,25 +8,16 @@
 #include "test_queue.h"
 
 #ifndef CONFIG_USERSPACE
-static void test_queue_supv_to_user(void)
-{
-	ztest_test_skip();
-}
+#define dummy_test(_name)		\
+	static void _name(void)		\
+	{				\
+		ztest_test_skip();	\
+	}
 
-static void test_auto_free(void)
-{
-	ztest_test_skip();
-}
-
-static void test_queue_alloc_prepend_user(void)
-{
-	ztest_test_skip();
-}
-
-static void test_queue_alloc_append_user(void)
-{
-	ztest_test_skip();
-}
+dummy_test(test_queue_supv_to_user);
+dummy_test(test_queue_alloc_prepend_user);
+dummy_test(test_queue_alloc_append_user);
+dummy_test(test_auto_free);
 #endif
 
 #ifdef CONFIG_64BIT
@@ -53,6 +44,7 @@ void test_main(void)
 			 ztest_1cpu_unit_test(test_queue_get_fail),
 			 ztest_1cpu_unit_test(test_queue_loop),
 			 ztest_unit_test(test_queue_alloc),
-			 ztest_1cpu_unit_test(test_queue_poll_race));
+			 ztest_1cpu_unit_test(test_queue_poll_race),
+			 ztest_unit_test(test_multiple_queues));
 	ztest_run_test_suite(queue_api);
 }

--- a/tests/kernel/queue/src/test_queue.h
+++ b/tests/kernel/queue/src/test_queue.h
@@ -24,6 +24,7 @@ extern void test_queue_alloc_append_user(void);
 #endif
 extern void test_queue_alloc(void);
 extern void test_queue_poll_race(void);
+extern void test_multiple_queues(void);
 
 extern struct k_mem_pool test_pool;
 

--- a/tests/kernel/queue/src/test_queue_contexts.c
+++ b/tests/kernel/queue/src/test_queue_contexts.c
@@ -136,8 +136,18 @@ static void tqueue_isr_thread(struct k_queue *pqueue)
 /*test cases*/
 /**
  * @brief Verify data passing between threads using queue
+ *
+ * @details Static define and Dynamic define queues,
+ * Then initialize them.
+ * Create a new thread to wait for reading data.
+ * Current thread will append item into queue.
+ * Verify if rx_data is equal insert-data address.
+ * Verify queue can be define at compile time.
+ *
  * @ingroup kernel_queue_tests
+ *
  * @see k_queue_init(), k_queue_insert(), k_queue_append()
+ * K_THREAD_STACK_DEFINE()
  */
 void test_queue_thread2thread(void)
 {
@@ -151,7 +161,16 @@ void test_queue_thread2thread(void)
 
 /**
  * @brief Verify data passing between thread and ISR
+ *
+ * @details Create a new ISR to insert data
+ * And current thread is used for getting data
+ * Verify if the rx_data is equal insert-data address.
+ * If the received data address is the same as
+ * the created array, prove that the queue data structures
+ * are stored within the provided data items.
+ *
  * @ingroup kernel_queue_tests
+ *
  * @see k_queue_init(), k_queue_insert(), k_queue_append()
  */
 void test_queue_thread2isr(void)
@@ -166,9 +185,15 @@ void test_queue_thread2isr(void)
 
 /**
  * @brief Verify data passing between ISR and thread
+ *
+ * @details Create a new ISR and ready for getting data
+ * And current thread is used for inserting data
+ * Verify if the rx_data is equal insert-data address.
+ *
+ * @ingroup kernel_queue_tests
+ *
  * @see k_queue_init(), k_queue_insert(), k_queue_get(),
  * k_queue_append(), k_queue_remove()
- * @ingroup kernel_queue_tests
  */
 void test_queue_isr2thread(void)
 {
@@ -346,4 +371,30 @@ void test_queue_poll_race(void)
 
 	k_thread_abort(&tdata);
 	k_thread_abort(&tdata1);
+}
+
+/**
+ * @brief Verify that multiple queues can be defined
+ * simultaneously
+ *
+ * @details define multiple queues to verify
+ * they can work.
+ *
+ * @ingroup kernel_queue_tests
+ *
+ * @see k_queue_init()
+ */
+#define QUEUE_NUM 10
+void test_multiple_queues(void)
+{
+	/*define multiple queues*/
+	struct k_queue queues[QUEUE_NUM];
+
+	for (int i = 0; i < QUEUE_NUM; i++) {
+		k_queue_init(&queues[i]);
+
+		/*Indicating that they are working*/
+		tqueue_append(&queues[i]);
+		tqueue_get(&queues[i]);
+	}
 }

--- a/tests/kernel/queue/src/test_queue_user.c
+++ b/tests/kernel/queue/src/test_queue_user.c
@@ -58,10 +58,15 @@ void child_thread_get(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Verify queue elements from a user thread
+ * @brief Verify queue elements and cancel wait from a user thread
+ *
  * @details The test adds elements to queue and then
  * verified by the child user thread.
+ * Get data from a empty queue,and use K_FORVER to wait for available
+ * And to cancel wait from current thread.
+ *
  * @ingroup kernel_queue_tests
+ *
  * @see k_queue_append(), k_queue_alloc_append(),
  * k_queue_init(), k_queue_cancel_wait()
  */
@@ -109,6 +114,18 @@ void test_queue_supv_to_user(void)
 	k_sem_take(sem, K_FOREVER);
 }
 
+/**
+ * @brief verify allocate and feature "Last In, First Out"
+ *
+ * @details Create a new queue
+ * And allocated memory for the queue
+ * Initialize and insert data item in sequence.
+ * Verify the feather "Last in,First out"
+ *
+ * @ingroup kernel_queue_tests
+ *
+ * @see k_queue_alloc_prepend()
+ */
 void test_queue_alloc_prepend_user(void)
 {
 	struct k_queue *q;
@@ -131,6 +148,18 @@ void test_queue_alloc_prepend_user(void)
 	}
 }
 
+/**
+ * @brief verify feature of queue "First In, First Out"
+ *
+ * @details Create a new queue
+ * And allocated memory for the queue
+ * Initialize and insert data item in sequence.
+ * Verify the feather "First in,First out"
+ *
+ * @ingroup kernel_queue_tests
+ *
+ * @see k_queue_init(), k_queue_alloc_append()
+ */
 void test_queue_alloc_append_user(void)
 {
 	struct k_queue *q;


### PR DESCRIPTION
1.test_queue_thread2thread(), test_queue_thread2isr(), test_queue_isr2thread()
Test that data passing between ISR and thread by using queue, and add some comments to describe it.
2.test_queue_alloc_prepend_user(), test_queue_alloc_append_user()
Test that a queue's memory can be allocated at running time, and verify the function of "first in,first out" or "first in, last out" by APIs k_queue_alloc_prepend() and k_queue_alloc_append(), and add some comments to describe it.
3.Modify some code styles.
In #ifndef-#endif region at main.c, I think it's a better way to use dummy test to skip some testcases that needn't test in kernel space instead.
4.Add a new testcase test_multiple_queues()
Test that multiple queues can be defined.

Signed-off-by: Ningx Zhao ningx.zhao@intel.com