### PR TITLE
drivers: SPI: Adds CS flags from devicetree

### DIFF
--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -772,6 +772,7 @@ static int mcp2515_init(struct device *dev)
 	}
 
 	dev_data->spi_cs_ctrl.gpio_pin = dev_cfg->spi_cs_pin;
+	dev_data->spi_cs_ctrl.gpio_dt_flags = dev_cfg->spi_cs_flags;
 	dev_data->spi_cs_ctrl.delay = 0U;
 
 	dev_data->spi_cfg.cs = &dev_data->spi_cs_ctrl;
@@ -851,6 +852,7 @@ static const struct mcp2515_config mcp2515_config_1 = {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	.spi_cs_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
 	.spi_cs_port = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
+	.spi_cs_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0),
 #endif  /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
 	.tq_sjw = DT_INST_PROP(0, sjw),
 	.tq_prop = DT_INST_PROP(0, prop_seg),

--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -60,6 +60,7 @@ struct mcp2515_config {
 	/* spi configuration */
 	const char *spi_port;
 	uint8_t spi_cs_pin;
+	uint8_t spi_cs_flags;
 	const char *spi_cs_port;
 	uint32_t spi_freq;
 	uint8_t spi_slave;

--- a/drivers/display/display_ili9340.c
+++ b/drivers/display/display_ili9340.c
@@ -67,6 +67,7 @@ static int ili9340_init(struct device *dev)
 	data->cs_ctrl.gpio_dev =
 		device_get_binding(DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
 	data->cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
+	data->cs_ctrl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
 	data->cs_ctrl.delay = 0U;
 	data->spi_config.cs = &(data->cs_ctrl);
 #else

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -353,6 +353,7 @@ static int st7789v_init(struct device *dev)
 	data->cs_ctrl.gpio_dev = device_get_binding(
 			DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
 	data->cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
+	data->cs_ctrl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
 	data->cs_ctrl.delay = 0U;
 	data->spi_config.cs = &(data->cs_ctrl);
 #else

--- a/drivers/display/gd7965.c
+++ b/drivers/display/gd7965.c
@@ -32,6 +32,7 @@ LOG_MODULE_REGISTER(gd7965, CONFIG_DISPLAY_LOG_LEVEL);
 #define GD7965_DC_FLAGS DT_INST_GPIO_FLAGS(0, dc_gpios)
 #define GD7965_DC_CNTRL DT_INST_GPIO_LABEL(0, dc_gpios)
 #define GD7965_CS_PIN DT_INST_SPI_DEV_CS_GPIOS_PIN(0)
+#define GD7965_CS_FLAGS DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0)
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 #define GD7965_CS_CNTRL DT_INST_SPI_DEV_CS_GPIOS_LABEL(0)
 #endif
@@ -441,6 +442,7 @@ static int gd7965_init(struct device *dev)
 	}
 
 	driver->cs_ctrl.gpio_pin = GD7965_CS_PIN;
+	driver->cs_ctrl.gpio_dt_flags = GD7965_CS_FLAGS;
 	driver->cs_ctrl.delay = 0U;
 	driver->spi_config.cs = &driver->cs_ctrl;
 #endif

--- a/drivers/display/ssd16xx.c
+++ b/drivers/display/ssd16xx.c
@@ -31,6 +31,7 @@ LOG_MODULE_REGISTER(ssd16xx);
 #define SSD16XX_DC_FLAGS DT_INST_GPIO_FLAGS(0, dc_gpios)
 #define SSD16XX_DC_CNTRL DT_INST_GPIO_LABEL(0, dc_gpios)
 #define SSD16XX_CS_PIN DT_INST_SPI_DEV_CS_GPIOS_PIN(0)
+#define SSD16XX_CS_FLAGS DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0)
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 #define SSD16XX_CS_CNTRL DT_INST_SPI_DEV_CS_GPIOS_LABEL(0)
 #endif
@@ -692,6 +693,7 @@ static int ssd16xx_init(struct device *dev)
 	}
 
 	driver->cs_ctrl.gpio_pin = SSD16XX_CS_PIN;
+	driver->cs_ctrl.gpio_dt_flags = SSD16XX_CS_FLAGS;
 	driver->cs_ctrl.delay = 0U;
 	driver->spi_config.cs = &driver->cs_ctrl;
 #endif

--- a/drivers/flash/spi_flash_w25qxxdv.c
+++ b/drivers/flash/spi_flash_w25qxxdv.c
@@ -420,6 +420,7 @@ static int spi_flash_wb_configure(struct device *dev)
 	}
 
 	data->cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
+	data->cs_ctrl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
 	data->cs_ctrl.delay = CONFIG_SPI_FLASH_W25QXXDV_GPIO_CS_WAIT_DELAY;
 
 	data->spi_cfg.cs = &data->cs_ctrl;

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -500,6 +500,7 @@ static int spi_nor_configure(struct device *dev)
 	}
 
 	data->cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
+	data->cs_ctrl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
 	data->cs_ctrl.delay = CONFIG_SPI_NOR_CS_WAIT_DELAY;
 
 	data->spi_cfg.cs = &data->cs_ctrl;

--- a/drivers/gpio/gpio_mcp23s17.c
+++ b/drivers/gpio/gpio_mcp23s17.c
@@ -380,6 +380,7 @@ static int mcp23s17_init(struct device *dev)
 		}
 
 		drv_data->mcp23s17_cs_ctrl.gpio_pin = config->cs_pin;
+		drv_data->mcp23s17_cs_ctrl.gpio_dt_flags = config->cs_flags;
 		drv_data->mcp23s17_cs_ctrl.delay = 0;
 
 		drv_data->spi_cfg.cs = &drv_data->mcp23s17_cs_ctrl;
@@ -415,6 +416,9 @@ static int mcp23s17_init(struct device *dev)
 		IF_ENABLED(DT_INST_SPI_DEV_HAS_CS_GPIOS(inst),		\
 			   (.cs_pin =					\
 			    DT_INST_SPI_DEV_CS_GPIOS_PIN(inst),))	\
+		IF_ENABLED(DT_INST_SPI_DEV_HAS_CS_GPIOS(inst),		\
+			   (.cs_flags =					\
+			    DT_INST_SPI_DEV_CS_GPIOS_FLAGS(inst),))	\
 	};								\
 									\
 	static struct mcp23s17_drv_data mcp23s17_##inst##_drvdata = {	\

--- a/drivers/gpio/gpio_mcp23s17.h
+++ b/drivers/gpio/gpio_mcp23s17.h
@@ -55,6 +55,7 @@ struct mcp23s17_config {
 	const uint32_t freq;
 	const char *const cs_dev;
 	const uint32_t cs_pin;
+	const uint8_t cs_flags;
 };
 
 /** Runtime driver data */

--- a/drivers/ieee802154/ieee802154_cc1200.c
+++ b/drivers/ieee802154/ieee802154_cc1200.c
@@ -770,6 +770,7 @@ static int configure_spi(struct device *dev)
 	}
 
 	cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
+	cs_ctrl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
 	cs_ctrl.delay = 0U;
 
 	cc1200->spi_cfg.cs = &cs_ctrl;

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -1064,6 +1064,7 @@ static inline int configure_spi(struct device *dev)
 	}
 
 	cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
+	cs_ctrl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
 	cs_ctrl.delay = 0U;
 
 	cc2520->spi_cfg.cs = &cs_ctrl;

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -1389,6 +1389,7 @@ static inline int configure_spi(struct device *dev)
 	}
 
 	mcr20a->cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
+	mcr20a->cs_ctrl.gpio_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
 	mcr20a->cs_ctrl.delay = 0U;
 
 	mcr20a->spi_cfg.cs = &mcr20a->cs_ctrl;

--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -745,6 +745,7 @@ static int adxl362_init(struct device *dev)
 	}
 
 	data->adxl362_cs_ctrl.gpio_pin = config->cs_gpio;
+	data->adxl362_cs_ctrl.gpio_dt_flags = config->cs_flags;
 	data->adxl362_cs_ctrl.delay = 0U;
 
 	data->spi_cfg.cs = &data->adxl362_cs_ctrl;
@@ -793,6 +794,7 @@ static const struct adxl362_config adxl362_config = {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	.gpio_cs_port = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
 	.cs_gpio = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
+	.cs_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0),
 #endif
 #if defined(CONFIG_ADXL362_TRIGGER)
 	.gpio_port = DT_INST_GPIO_LABEL(0, int1_gpios),

--- a/drivers/sensor/adxl362/adxl362.h
+++ b/drivers/sensor/adxl362/adxl362.h
@@ -177,6 +177,7 @@ struct adxl362_config {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const char *gpio_cs_port;
 	gpio_pin_t cs_gpio;
+	gpio_dt_flags_t cs_flags;
 #endif
 #if defined(CONFIG_ADXL362_TRIGGER)
 	const char *gpio_port;

--- a/drivers/sensor/adxl372/adxl372.c
+++ b/drivers/sensor/adxl372/adxl372.c
@@ -909,6 +909,7 @@ static int adxl372_init(struct device *dev)
 	}
 
 	data->adxl372_cs_ctrl.gpio_pin = cfg->cs_gpio;
+	data->adxl372_cs_ctrl.gpio_dt_flags = cfg->cs_flags;
 	data->adxl372_cs_ctrl.delay = 0U;
 
 	data->spi_cfg.cs = &data->adxl372_cs_ctrl;
@@ -936,6 +937,7 @@ static const struct adxl372_dev_config adxl372_config = {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	.gpio_cs_port = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
 	.cs_gpio = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
+	.cs_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0),
 #endif
 #endif
 #ifdef CONFIG_ADXL372_TRIGGER

--- a/drivers/sensor/adxl372/adxl372.h
+++ b/drivers/sensor/adxl372/adxl372.h
@@ -321,6 +321,7 @@ struct adxl372_dev_config {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const char *gpio_cs_port;
 	gpio_pin_t cs_gpio;
+	gpio_dt_flags_t cs_flags;
 #endif
 #endif /* CONFIG_ADXL372_SPI */
 #ifdef CONFIG_ADXL372_TRIGGER

--- a/drivers/sensor/iis2dlpc/iis2dlpc_spi.c
+++ b/drivers/sensor/iis2dlpc/iis2dlpc_spi.c
@@ -114,6 +114,7 @@ int iis2dlpc_spi_init(struct device *dev)
 	}
 
 	data->cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
+	data->cs_ctrl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
 	data->cs_ctrl.delay = 0U;
 
 	iis2dlpc_spi_conf.cs = &data->cs_ctrl;

--- a/drivers/sensor/iis2mdc/iis2mdc.c
+++ b/drivers/sensor/iis2mdc/iis2mdc.c
@@ -273,6 +273,7 @@ static const struct iis2mdc_config iis2mdc_dev_config = {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	.gpio_cs_port	    = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
 	.cs_gpio	    = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
+	.cs_gpio_flags	    = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
 
 	.spi_conf.cs        =  &iis2mdc_data.cs_ctrl,
 #else

--- a/drivers/sensor/iis2mdc/iis2mdc.h
+++ b/drivers/sensor/iis2mdc/iis2mdc.h
@@ -42,6 +42,7 @@ struct iis2mdc_config {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const char *gpio_cs_port;
 	uint8_t cs_gpio;
+	uint8_t cs_gpio_flags;
 #endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
 };

--- a/drivers/sensor/iis2mdc/iis2mdc_spi.c
+++ b/drivers/sensor/iis2mdc/iis2mdc_spi.c
@@ -118,6 +118,7 @@ int iis2mdc_spi_init(struct device *dev)
 	}
 
 	data->cs_ctrl.gpio_pin = cfg->cs_gpio;
+	data->cs_ctrl.gpio_dt_flags = cfg->cs_gpio_flags;
 	data->cs_ctrl.delay = 0;
 
 	LOG_DBG("SPI GPIO CS configured on %s:%u",

--- a/drivers/sensor/iis3dhhc/iis3dhhc_spi.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc_spi.c
@@ -113,6 +113,7 @@ int iis3dhhc_spi_init(struct device *dev)
 	}
 
 	data->cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
+	data->cs_ctrl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
 	data->cs_ctrl.delay = 0U;
 
 	iis3dhhc_spi_conf.cs = &data->cs_ctrl;

--- a/drivers/sensor/ism330dhcx/ism330dhcx.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx.c
@@ -762,6 +762,7 @@ static const struct ism330dhcx_config ism330dhcx_config = {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	.gpio_cs_port	    = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
 	.cs_gpio	    = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
+	.cs_gpio_flags	    = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0),
 
 	.spi_conf.cs        =  &ism330dhcx_data.cs_ctrl,
 #else

--- a/drivers/sensor/ism330dhcx/ism330dhcx.h
+++ b/drivers/sensor/ism330dhcx/ism330dhcx.h
@@ -107,6 +107,7 @@ struct ism330dhcx_config {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const char *gpio_cs_port;
 	uint8_t cs_gpio;
+	uint8_t cs_gpio_flags;
 #endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */
 };

--- a/drivers/sensor/ism330dhcx/ism330dhcx_spi.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx_spi.c
@@ -117,6 +117,7 @@ int ism330dhcx_spi_init(struct device *dev)
 	}
 
 	data->cs_ctrl.gpio_pin = cfg->cs_gpio;
+	data->cs_ctrl.gpio_dt_flags = cfg->cs_gpio_flags;
 	data->cs_ctrl.delay = 0;
 
 	LOG_DBG("SPI GPIO CS configured on %s:%u",

--- a/drivers/sensor/lis2dh/lis2dh.c
+++ b/drivers/sensor/lis2dh/lis2dh.c
@@ -360,6 +360,7 @@ static const struct lis2dh_config lis2dh_config = {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	.gpio_cs_port	    = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
 	.cs_gpio	    = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
+	.cs_gpio_flags	    = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0),
 	.spi_conf.cs        =  &lis2dh_data.cs_ctrl,
 #else
 	.spi_conf.cs        = NULL,

--- a/drivers/sensor/lis2dh/lis2dh.h
+++ b/drivers/sensor/lis2dh/lis2dh.h
@@ -207,6 +207,7 @@ struct lis2dh_config {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const char *gpio_cs_port;
 	uint8_t cs_gpio;
+	uint8_t cs_gpio_flags;
 #endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
 

--- a/drivers/sensor/lis2dh/lis2dh_spi.c
+++ b/drivers/sensor/lis2dh/lis2dh_spi.c
@@ -164,6 +164,7 @@ int lis2dh_spi_init(struct device *dev)
 	}
 
 	data->cs_ctrl.gpio_pin = cfg->cs_gpio;
+	data->cs_ctrl.gpio_dt_flags = cfg->cs_gpio_flags;
 	data->cs_ctrl.delay = 0;
 
 	LOG_DBG("SPI GPIO CS configured on %s:%u",

--- a/drivers/sensor/lis2ds12/lis2ds12_spi.c
+++ b/drivers/sensor/lis2ds12/lis2ds12_spi.c
@@ -167,6 +167,7 @@ int lis2ds12_spi_init(struct device *dev)
 	}
 
 	lis2ds12_cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
+	lis2ds12_cs_ctrl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
 	lis2ds12_cs_ctrl.delay = 0U;
 
 	lis2ds12_spi_conf.cs = &lis2ds12_cs_ctrl;

--- a/drivers/sensor/lis2dw12/lis2dw12_spi.c
+++ b/drivers/sensor/lis2dw12/lis2dw12_spi.c
@@ -114,6 +114,7 @@ int lis2dw12_spi_init(struct device *dev)
 	}
 
 	data->cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
+	data->cs_ctrl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
 	data->cs_ctrl.delay = 0U;
 
 	lis2dw12_spi_conf.cs = &data->cs_ctrl;

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -273,6 +273,7 @@ static const struct lis2mdl_config lis2mdl_dev_config = {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	.gpio_cs_port	    = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
 	.cs_gpio	    = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
+	.cs_gpio_flags	    = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0),
 
 	.spi_conf.cs        =  &lis2mdl_data.cs_ctrl,
 #else

--- a/drivers/sensor/lis2mdl/lis2mdl.h
+++ b/drivers/sensor/lis2mdl/lis2mdl.h
@@ -42,6 +42,7 @@ struct lis2mdl_config {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const char *gpio_cs_port;
 	uint8_t cs_gpio;
+	uint8_t cs_gpio_flags;
 #endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
 };

--- a/drivers/sensor/lis2mdl/lis2mdl_spi.c
+++ b/drivers/sensor/lis2mdl/lis2mdl_spi.c
@@ -118,6 +118,7 @@ int lis2mdl_spi_init(struct device *dev)
 	}
 
 	data->cs_ctrl.gpio_pin = cfg->cs_gpio;
+	data->cs_ctrl.gpio_dt_flags = cfg->cs_gpio_flags;
 	data->cs_ctrl.delay = 0;
 
 	LOG_DBG("SPI GPIO CS configured on %s:%u",

--- a/drivers/sensor/lps22hh/lps22hh.c
+++ b/drivers/sensor/lps22hh/lps22hh.c
@@ -217,6 +217,7 @@ static const struct lps22hh_config lps22hh_config = {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	.gpio_cs_port	    = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
 	.cs_gpio	    = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
+	.cs_gpio_flags	    = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0),
 
 	.spi_conf.cs        =  &lps22hh_data.cs_ctrl,
 #else

--- a/drivers/sensor/lps22hh/lps22hh.h
+++ b/drivers/sensor/lps22hh/lps22hh.h
@@ -45,6 +45,7 @@ struct lps22hh_config {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const char *gpio_cs_port;
 	uint8_t cs_gpio;
+	uint8_t cs_gpio_flags;
 #endif
 #endif
 };

--- a/drivers/sensor/lps22hh/lps22hh_spi.c
+++ b/drivers/sensor/lps22hh/lps22hh_spi.c
@@ -118,6 +118,7 @@ int lps22hh_spi_init(struct device *dev)
 	}
 
 	data->cs_ctrl.gpio_pin = cfg->cs_gpio;
+	data->cs_ctrl.gpio_dt_flags = cfg->cs_gpio_flags;
 	data->cs_ctrl.delay = 0;
 
 	LOG_DBG("SPI GPIO CS configured on %s:%u",

--- a/drivers/sensor/lsm6dsl/lsm6dsl_spi.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_spi.c
@@ -158,6 +158,7 @@ int lsm6dsl_spi_init(struct device *dev)
 	}
 
 	lsm6dsl_cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
+	lsm6dsl_cs_ctrl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
 	lsm6dsl_cs_ctrl.delay = 0U;
 
 	lsm6dsl_spi_conf.cs = &lsm6dsl_cs_ctrl;

--- a/drivers/sensor/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/lsm6dso/lsm6dso.c
@@ -762,6 +762,7 @@ static const struct lsm6dso_config lsm6dso_config = {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	.gpio_cs_port	    = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
 	.cs_gpio	    = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
+	.cs_gpio_flags	    = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0),
 
 	.spi_conf.cs        =  &lsm6dso_data.cs_ctrl,
 #else

--- a/drivers/sensor/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/lsm6dso/lsm6dso.h
@@ -107,6 +107,7 @@ struct lsm6dso_config {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	const char *gpio_cs_port;
 	uint8_t cs_gpio;
+	uint8_t cs_gpio_flags;
 #endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */
 };

--- a/drivers/sensor/lsm6dso/lsm6dso_spi.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_spi.c
@@ -117,6 +117,7 @@ int lsm6dso_spi_init(struct device *dev)
 	}
 
 	data->cs_ctrl.gpio_pin = cfg->cs_gpio;
+	data->cs_ctrl.gpio_dt_flags = cfg->cs_gpio_flags;
 	data->cs_ctrl.delay = 0;
 
 	LOG_DBG("SPI GPIO CS configured on %s:%u",

--- a/drivers/sensor/ms5607/ms5607_spi.c
+++ b/drivers/sensor/ms5607/ms5607_spi.c
@@ -181,6 +181,7 @@ int ms5607_spi_init(struct device *dev)
 	}
 
 	ms5607_cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
+	ms5607_cs_ctrl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
 	ms5607_cs_ctrl.delay = 0U;
 
 	ms5607_spi_conf.cs = &ms5607_cs_ctrl;

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -147,32 +147,27 @@ static inline void spi_context_complete(struct spi_context *ctx, int status)
 #endif /* CONFIG_SPI_ASYNC */
 }
 
-static inline int spi_context_cs_active_value(struct spi_context *ctx)
+static inline
+gpio_dt_flags_t spi_context_cs_active_level(struct spi_context *ctx)
 {
 	if (ctx->config->operation & SPI_CS_ACTIVE_HIGH) {
-		return 1;
+		return GPIO_ACTIVE_HIGH;
 	}
 
-	return 0;
-}
-
-static inline int spi_context_cs_inactive_value(struct spi_context *ctx)
-{
-	if (ctx->config->operation & SPI_CS_ACTIVE_HIGH) {
-		return 0;
-	}
-
-	return 1;
+	return GPIO_ACTIVE_LOW;
 }
 
 static inline void spi_context_cs_configure(struct spi_context *ctx)
 {
 	if (ctx->config->cs && ctx->config->cs->gpio_dev) {
+		/* Validate CS active levels are equivalent */
+		__ASSERT(spi_context_cs_active_level(ctx) ==
+			 (ctx->config->cs->gpio_dt_flags & GPIO_ACTIVE_LOW),
+			 "Devicetree and spi_context CS levels are not equal");
 		gpio_pin_configure(ctx->config->cs->gpio_dev,
-				   ctx->config->cs->gpio_pin, GPIO_OUTPUT);
-		gpio_pin_set(ctx->config->cs->gpio_dev,
-			     ctx->config->cs->gpio_pin,
-			     spi_context_cs_inactive_value(ctx));
+				   ctx->config->cs->gpio_pin,
+				   ctx->config->cs->gpio_dt_flags |
+				   GPIO_OUTPUT_INACTIVE);
 	} else {
 		LOG_INF("CS control inhibited (no GPIO device)");
 	}
@@ -184,8 +179,7 @@ static inline void _spi_context_cs_control(struct spi_context *ctx,
 	if (ctx->config && ctx->config->cs && ctx->config->cs->gpio_dev) {
 		if (on) {
 			gpio_pin_set(ctx->config->cs->gpio_dev,
-				     ctx->config->cs->gpio_pin,
-				     spi_context_cs_active_value(ctx));
+				     ctx->config->cs->gpio_pin, 1);
 			k_busy_wait(ctx->config->cs->delay);
 		} else {
 			if (!force_off &&
@@ -195,8 +189,7 @@ static inline void _spi_context_cs_control(struct spi_context *ctx,
 
 			k_busy_wait(ctx->config->cs->delay);
 			gpio_pin_set(ctx->config->cs->gpio_dev,
-				     ctx->config->cs->gpio_pin,
-				     spi_context_cs_inactive_value(ctx));
+				     ctx->config->cs->gpio_pin, 0);
 		}
 	}
 }

--- a/drivers/wifi/winc1500/wifi_winc1500_nm_bus_wrapper.c
+++ b/drivers/wifi/winc1500/wifi_winc1500_nm_bus_wrapper.c
@@ -155,6 +155,7 @@ int8_t nm_bus_init(void *pvinit)
 	}
 
 	cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
+	cs_ctrl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
 	cs_ctrl.delay = 0U;
 
 	winc1500.spi_cfg.cs = &cs_ctrl;

--- a/include/drivers/spi.h
+++ b/include/drivers/spi.h
@@ -22,6 +22,7 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <device.h>
+#include <drivers/gpio.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -129,11 +130,16 @@ extern "C" {
  *    to act as a CS line
  * @param delay is a delay in microseconds to wait before starting the
  *    transmission and before releasing the CS line
+ * @param gpio_dt_flags is the devicetree flags corresponding to how the CS
+ *    line should be driven. GPIO_ACTIVE_LOW/GPIO_ACTIVE_HIGH should be
+ *    equivalent to SPI_CS_ACTIVE_HIGH/SPI_CS_ACTIVE_LOW options in struct
+ *    spi_config.
  */
 struct spi_cs_control {
 	struct device	*gpio_dev;
-	uint32_t		gpio_pin;
 	uint32_t		delay;
+	gpio_pin_t		gpio_pin;
+	gpio_dt_flags_t		gpio_dt_flags;
 };
 
 /**


### PR DESCRIPTION
The SPI drivers were previously ignoring the devicetree flags specified for CS pins.
This pull request allows flags such as `GPIO_OPEN_SOURCE` to be specified and used.
This resolves the issue raised in #26267.

Out of tree drivers that do not setup `gpio_dt_flags` will retain the same behaviour, as flags of 0x00 corresponds to the old push-pull default.

In the interest of making the diff smaller, ACTIVE_HIGH and ACTIVE_LOW from devicetree are not used to set the CS active levels as this is currently handled in an alternate struct. If it is desirable to use the CS active levels from devicetree, that can be a follow on PR.