### PR TITLE
file system: storage: Fix the memory size output by adding brace for manipulating operator priority properly

### DIFF
--- a/samples/subsys/fs/fat_fs/src/main.c
+++ b/samples/subsys/fs/fat_fs/src/main.c
@@ -59,7 +59,7 @@ void main(void)
 		printk("Sector size %u\n", block_size);
 
 		memory_size_mb = (uint64_t)block_count * block_size;
-		printk("Memory Size(MB) %u\n", (uint32_t)memory_size_mb>>20);
+		printk("Memory Size(MB) %u\n", (uint32_t)(memory_size_mb>>20));
 	} while (0);
 
 	mp.mnt_point = disk_mount_pt;

--- a/samples/subsys/fs/fat_fs/src/main.c
+++ b/samples/subsys/fs/fat_fs/src/main.c
@@ -59,7 +59,7 @@ void main(void)
 		printk("Sector size %u\n", block_size);
 
 		memory_size_mb = (uint64_t)block_count * block_size;
-		printk("Memory Size(MB) %u\n", (uint32_t)(memory_size_mb>>20));
+		printk("Memory Size(MB) %u\n", (uint32_t)(memory_size_mb >> 20));
 	} while (0);
 
 	mp.mnt_point = disk_mount_pt;


### PR DESCRIPTION
In fat_fs example, if we choose a large size SD card to connect with,
the result of memory size calculation coule be wrong due to the missing
brace for manipulating operator priority.

Fixes #26266.

Signed-off-by: Chung, Jui-Chou <jui-chou.chung@nordicsemi.no>