### PR TITLE
dts: nordic: Remove no longer needed peripheral aliases

### DIFF
--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -21,24 +21,6 @@
 		};
 	};
 
-	aliases {
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		spi-0 = &spi0;
-		spi-1 = &spi1;
-		uart-0 = &uart0;
-		adc-0 = &adc;
-		gpio-0 = &gpio0;
-		gpiote-0 = &gpiote;
-		wdt-0 = &wdt;
-		qdec-0 = &qdec;
-		rtc-0 = &rtc0;
-		rtc-1 = &rtc1;
-		timer-0 = &timer0;
-		timer-1 = &timer1;
-		timer-2 = &timer2;
-	};
-
 	chosen {
 		zephyr,flash-controller = &flash_controller;
 	};

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -22,23 +22,6 @@
 		};
 	};
 
-	aliases {
-		i2c-0 = &i2c0;
-		spi-0 = &spi0;
-		uart-0 = &uart0;
-		adc-0 = &adc;
-		gpio-0 = &gpio0;
-		gpiote-0 = &gpiote;
-		wdt-0 = &wdt;
-		pwm-0 = &pwm0;
-		qdec-0 = &qdec;
-		rtc-0 = &rtc0;
-		rtc-1 = &rtc1;
-		timer-0 = &timer0;
-		timer-1 = &timer1;
-		timer-2 = &timer2;
-	};
-
 	soc {
 
 		flash_controller: flash-controller@4001e000 {

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -25,24 +25,6 @@
 		};
 	};
 
-	aliases {
-		i2c-0 = &i2c0;
-		spi-0 = &spi0;
-		spi-1 = &spi1;
-		uart-0 = &uart0;
-		adc-0 = &adc;
-		gpio-0 = &gpio0;
-		gpiote-0 = &gpiote;
-		wdt-0 = &wdt;
-		pwm-0 = &pwm0;
-		qdec-0 = &qdec;
-		rtc-0 = &rtc0;
-		rtc-1 = &rtc1;
-		timer-0 = &timer0;
-		timer-1 = &timer1;
-		timer-2 = &timer2;
-	};
-
 	soc {
 
 		flash_controller: flash-controller@4001e000 {

--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -27,24 +27,6 @@
 		};
 	};
 
-	aliases {
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		spi-0 = &spi0;
-		spi-1 = &spi1;
-		uart-0 = &uart0;
-		gpio-0 = &gpio0;
-		gpiote-0 = &gpiote;
-		wdt-0 = &wdt0;
-		usbd-0 = &usbd;
-		qdec-0 = &qdec;
-		rtc-0 = &rtc0;
-		rtc-1 = &rtc1;
-		timer-0 = &timer0;
-		timer-1 = &timer1;
-		timer-2 = &timer2;
-	};
-
 	soc {
 
 		flash_controller: flash-controller@4001e000 {

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -22,31 +22,6 @@
 		};
 	};
 
-	aliases {
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		spi-0 = &spi0;
-		spi-1 = &spi1;
-		spi-2 = &spi2;
-		uart-0 = &uart0;
-		adc-0 = &adc;
-		gpio-0 = &gpio0;
-		gpiote-0 = &gpiote;
-		wdt-0 = &wdt;
-		pwm-0 = &pwm0;
-		pwm-1 = &pwm1;
-		pwm-2 = &pwm2;
-		qdec-0 = &qdec;
-		rtc-0 = &rtc0;
-		rtc-1 = &rtc1;
-		rtc-2 = &rtc2;
-		timer-0 = &timer0;
-		timer-1 = &timer1;
-		timer-2 = &timer2;
-		timer-3 = &timer3;
-		timer-4 = &timer4;
-	};
-
 	soc {
 
 		flash_controller: flash-controller@4001e000 {

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -26,36 +26,6 @@
 		};
 	};
 
-	aliases {
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		spi-0 = &spi0;
-		spi-1 = &spi1;
-		spi-2 = &spi2;
-		spi-3 = &spi3;
-		uart-0 = &uart0;
-		uart-1 = &uart1;
-		adc-0 = &adc;
-		gpio-0 = &gpio0;
-		gpio-1 = &gpio1;
-		gpiote-0 = &gpiote;
-		wdt-0 = &wdt;
-		usbd-0 = &usbd;
-		pwm-0 = &pwm0;
-		pwm-1 = &pwm1;
-		pwm-2 = &pwm2;
-		pwm-3 = &pwm3;
-		qdec-0 = &qdec;
-		rtc-0 = &rtc0;
-		rtc-1 = &rtc1;
-		rtc-2 = &rtc2;
-		timer-0 = &timer0;
-		timer-1 = &timer1;
-		timer-2 = &timer2;
-		timer-3 = &timer3;
-		timer-4 = &timer4;
-	};
-
 	soc {
 
 		flash_controller: flash-controller@4001e000 {

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -22,39 +22,6 @@
 		};
 	};
 
-	aliases {
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		spi-0 = &spi0;
-		spi-1 = &spi1;
-		spi-2 = &spi2;
-		spi-3 = &spi3;
-		qspi-0 = &qspi;
-		uart-0 = &uart0;
-		uart-1 = &uart1;
-		adc-0 = &adc;
-		gpio-0 = &gpio0;
-		gpio-1 = &gpio1;
-		gpiote-0 = &gpiote;
-		wdt-0 = &wdt;
-		usbd-0 = &usbd;
-		cc310 = &cryptocell;
-		arm-cryptocell-310 = &cryptocell310;
-		pwm-0 = &pwm0;
-		pwm-1 = &pwm1;
-		pwm-2 = &pwm2;
-		pwm-3 = &pwm3;
-		qdec-0 = &qdec;
-		rtc-0 = &rtc0;
-		rtc-1 = &rtc1;
-		rtc-2 = &rtc2;
-		timer-0 = &timer0;
-		timer-1 = &timer1;
-		timer-2 = &timer2;
-		timer-3 = &timer3;
-		timer-4 = &timer4;
-	};
-
 	soc {
 
 		flash_controller: flash-controller@4001e000 {

--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -28,45 +28,6 @@
 		};
 	};
 
-	aliases {
-		flash-controller = &flash_controller;
-		rtc-0 = &rtc0;
-		rtc-1 = &rtc1;
-		uart-0 = &uart0;
-		uart-1 = &uart1;
-		uart-2 = &uart2;
-		uart-3 = &uart3;
-		adc-0 = &adc;
-		egu-0 = &egu0;
-		egu-1 = &egu1;
-		egu-2 = &egu2;
-		egu-3 = &egu3;
-		egu-4 = &egu4;
-		egu-5 = &egu5;
-		gpio-0 = &gpio0;
-		gpio-1 = &gpio1;
-		gpiote-0 = &gpiote;
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		i2c-2 = &i2c2;
-		i2c-3 = &i2c3;
-		ipc-0 = &ipc;
-		pdm-0 = &pdm0;
-		spi-0 = &spi0;
-		spi-1 = &spi1;
-		spi-2 = &spi2;
-		spi-3 = &spi3;
-		spi-4 = &spi4;
-		pwm-0 = &pwm0;
-		pwm-1 = &pwm1;
-		pwm-2 = &pwm2;
-		pwm-3 = &pwm3;
-		wdt-0 = &wdt;
-		timer-0 = &timer0;
-		timer-1 = &timer1;
-		timer-2 = &timer2;
-	};
-
 	chosen {
 		zephyr,flash-controller = &flash_controller;
 	};

--- a/dts/arm/nordic/nrf5340_cpuappns.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns.dtsi
@@ -30,37 +30,6 @@
 		};
 	};
 
-	aliases {
-		flash-controller = &flash_controller;
-		rtc-0 = &rtc0;
-		rtc-1 = &rtc1;
-		uart-0 = &uart0;
-		uart-1 = &uart1;
-		uart-2 = &uart2;
-		uart-3 = &uart3;
-		adc-0 = &adc;
-		gpio-0 = &gpio0;
-		gpio-1 = &gpio1;
-		gpiote-0 = &gpiote;
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		i2c-2 = &i2c2;
-		i2c-3 = &i2c3;
-		spi-0 = &spi0;
-		spi-1 = &spi1;
-		spi-2 = &spi2;
-		spi-3 = &spi3;
-		spi-4 = &spi4;
-		pwm-0 = &pwm0;
-		pwm-1 = &pwm1;
-		pwm-2 = &pwm2;
-		pwm-3 = &pwm3;
-		wdt-0 = &wdt;
-		timer-0 = &timer0;
-		timer-1 = &timer1;
-		timer-2 = &timer2;
-	};
-
 	chosen {
 		zephyr,flash-controller = &flash_controller;
 	};

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -33,23 +33,6 @@
 		};
 	};
 
-	aliases {
-		flash-controller = &flash_controller;
-		rtc-0 = &rtc0;
-		rtc-1 = &rtc1;
-		uart-0 = &uart0;
-		gpio-0 = &gpio0;
-		gpio-1 = &gpio1;
-		gpiote-0 = &gpiote;
-		i2c-0 = &i2c0;
-		ipc-0 = &ipc;
-		spi-0 = &spi0;
-		wdt-0 = &wdt;
-		timer-0 = &timer0;
-		timer-1 = &timer1;
-		timer-2 = &timer2;
-	};
-
 	flash_controller: flash-controller@41080000 {
 		compatible = "nordic,nrf53-flash-controller";
 		reg = <0x41080000 0x1000>;

--- a/dts/arm/nordic/nrf9160.dtsi
+++ b/dts/arm/nordic/nrf9160.dtsi
@@ -28,45 +28,6 @@
 		};
 	};
 
-	aliases {
-		flash-controller = &flash_controller;
-		rtc-0 = &rtc0;
-		rtc-1 = &rtc1;
-		uart-0 = &uart0;
-		uart-1 = &uart1;
-		uart-2 = &uart2;
-		uart-3 = &uart3;
-		adc-0 = &adc;
-		egu-0 = &egu0;
-		egu-1 = &egu1;
-		egu-2 = &egu2;
-		egu-3 = &egu3;
-		egu-4 = &egu4;
-		egu-5 = &egu5;
-		gpio-0 = &gpio0;
-		gpiote-0 = &gpiote;
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		i2c-2 = &i2c2;
-		i2c-3 = &i2c3;
-		i2s-0 = &i2s0;
-		pdm-0 = &pdm0;
-		spi-0 = &spi0;
-		spi-1 = &spi1;
-		spi-2 = &spi2;
-		spi-3 = &spi3;
-		pwm-0 = &pwm0;
-		pwm-1 = &pwm1;
-		pwm-2 = &pwm2;
-		pwm-3 = &pwm3;
-		wdt-0 = &wdt;
-		timer-0 = &timer0;
-		timer-1 = &timer1;
-		timer-2 = &timer2;
-		cc310 = &cryptocell;
-		arm-cryptocell-310 = &cryptocell310;
-	};
-
 	chosen {
 		zephyr,flash-controller = &flash_controller;
 	};

--- a/dts/arm/nordic/nrf9160ns.dtsi
+++ b/dts/arm/nordic/nrf9160ns.dtsi
@@ -28,43 +28,6 @@
 		};
 	};
 
-	aliases {
-		flash-controller = &flash_controller;
-		rtc-0 = &rtc0;
-		rtc-1 = &rtc1;
-		uart-0 = &uart0;
-		uart-1 = &uart1;
-		uart-2 = &uart2;
-		uart-3 = &uart3;
-		adc-0 = &adc;
-		egu-0 = &egu0;
-		egu-1 = &egu1;
-		egu-2 = &egu2;
-		egu-3 = &egu3;
-		egu-4 = &egu4;
-		egu-5 = &egu5;
-		gpio-0 = &gpio0;
-		gpiote-0 = &gpiote; /* FIXME alias should be gpiote-1 */
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		i2c-2 = &i2c2;
-		i2c-3 = &i2c3;
-		i2s-0 = &i2s0;
-		pdm-0 = &pdm0;
-		spi-0 = &spi0;
-		spi-1 = &spi1;
-		spi-2 = &spi2;
-		spi-3 = &spi3;
-		pwm-0 = &pwm0;
-		pwm-1 = &pwm1;
-		pwm-2 = &pwm2;
-		pwm-3 = &pwm3;
-		wdt-0 = &wdt;
-		timer-0 = &timer0;
-		timer-1 = &timer1;
-		timer-2 = &timer2;
-	};
-
 	chosen {
 		zephyr,flash-controller = &flash_controller;
 	};


### PR DESCRIPTION
Aliases defined for peripheral nodes in the nRF SoC definitions were
used in drivers to properly match the hardware instances.
After the drivers were converted to use the new DT API, these aliases
became needless.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>