### PR TITLE
arch: arm: aarch32: add IRQ relay mechanism to ARMv7/8-M

### DIFF
--- a/arch/arm/core/aarch32/CMakeLists.txt
+++ b/arch/arm/core/aarch32/CMakeLists.txt
@@ -21,7 +21,7 @@ zephyr_library_sources(
 zephyr_library_sources_ifdef(CONFIG_GEN_SW_ISR_TABLE isr_wrapper.S)
 zephyr_library_sources_ifdef(CONFIG_CPLUSPLUS __aeabi_atexit.c)
 zephyr_library_sources_ifdef(CONFIG_IRQ_OFFLOAD irq_offload.c)
-zephyr_library_sources_ifdef(CONFIG_CPU_CORTEX_M0 irq_relay.S)
+zephyr_library_sources_ifdef(CONFIG_SW_VECTOR_RELAY irq_relay.S)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE userspace.S)
 
 add_subdirectory_ifdef(CONFIG_CPU_CORTEX_M cortex_m)

--- a/arch/arm/core/aarch32/cortex_m/Kconfig
+++ b/arch/arm/core/aarch32/cortex_m/Kconfig
@@ -276,6 +276,7 @@ config SW_VECTOR_RELAY
 
 config SW_VECTOR_RELAY_CLIENT
 	bool "Enable Software Vector Relay (client)"
+	depends on !SW_VECTOR_RELAY
 	default y if BOOTLOADER_MCUBOOT && !(CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP || CPU_CORTEX_M_HAS_VTOR)
 	help
 	  Another image has enabled SW_VECTOR_RELAY, and will relay interrupts

--- a/arch/arm/core/aarch32/cortex_m/Kconfig
+++ b/arch/arm/core/aarch32/cortex_m/Kconfig
@@ -267,21 +267,16 @@ config DYNAMIC_DIRECT_INTERRUPTS
 
 config SW_VECTOR_RELAY
 	bool "Enable Software Vector Relay"
-	depends on ARMV6_M_ARMV8_M_BASELINE && !(CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP || CPU_CORTEX_M_HAS_VTOR)
 	help
-	  When building bootloader firmware this option adds a
-	  Vector Table relay handler and relay vector table, to
+	  When building a bootloader firmware this option adds a
+	  vector table relay handler and a vector relay table, to
 	  relay interrupts based on a vector table pointer.
-	  This is only
-	  required for Cortex-M0 (or an Armv8-M baseline core) with no hardware
-	  vector table relocation mechanisms or for Cortex-M0+
-	  (or an Armv8-M baseline core) with no VTOR and no other hardware
-	  relocation table mechanisms.
+	  This is only required but not limited to Cortex-M Baseline CPUs
+	  with no hardware vector table relocation mechanisms (e.g. VTOR).
 
 config SW_VECTOR_RELAY_CLIENT
 	bool "Enable Software Vector Relay (client)"
-	default y if BOOTLOADER_MCUBOOT
-	depends on ARMV6_M_ARMV8_M_BASELINE && !(CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP || CPU_CORTEX_M_HAS_VTOR)
+	default y if BOOTLOADER_MCUBOOT && !(CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP || CPU_CORTEX_M_HAS_VTOR)
 	help
 	  Another image has enabled SW_VECTOR_RELAY, and will relay interrupts
 	  to this image. Enable this to make sure the vector table pointer in

--- a/arch/arm/core/aarch32/cortex_m/Kconfig
+++ b/arch/arm/core/aarch32/cortex_m/Kconfig
@@ -276,12 +276,13 @@ config SW_VECTOR_RELAY
 
 config SW_VECTOR_RELAY_CLIENT
 	bool "Enable Software Vector Relay (client)"
-	depends on !SW_VECTOR_RELAY
-	default y if BOOTLOADER_MCUBOOT && !(CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP || CPU_CORTEX_M_HAS_VTOR)
+	default y if BOOTLOADER_MCUBOOT
+	depends on ARMV6_M_ARMV8_M_BASELINE && !(CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP || CPU_CORTEX_M_HAS_VTOR)
 	help
-	  Another image has enabled SW_VECTOR_RELAY, and will relay interrupts
-	  to this image. Enable this to make sure the vector table pointer in
-	  RAM is left alone.
+	  Another image has enabled SW_VECTOR_RELAY, and will be forwarding
+	  exceptions and HW interrupts to this image. Enable this option to make
+	  sure the vector table pointer in RAM is set properly by the image upon
+	  initialization.
 
 endmenu
 

--- a/arch/arm/core/aarch32/cortex_m/relay_vector_table.ld
+++ b/arch/arm/core/aarch32/cortex_m/relay_vector_table.ld
@@ -6,5 +6,3 @@
 
 KEEP(*(.vector_relay_table))
 KEEP(*(".vector_relay_table.*"))
-KEEP(*(.vector_relay_handler))
-KEEP(*(".vector_relay_handler.*"))

--- a/arch/arm/core/aarch32/irq_relay.S
+++ b/arch/arm/core/aarch32/irq_relay.S
@@ -29,7 +29,7 @@ _ASM_FILE_PROLOGUE
 GDATA(_vector_table_pointer)
 GDATA(z_main_stack)
 
-SECTION_FUNC(vector_relay_handler, __vector_relay_handler)
+SECTION_FUNC(TEXT, __vector_relay_handler)
 	mrs	r0, ipsr;
 	lsls	r0, r0, $0x02;
 

--- a/arch/arm/core/aarch32/irq_relay.S
+++ b/arch/arm/core/aarch32/irq_relay.S
@@ -26,11 +26,6 @@
 
 _ASM_FILE_PROLOGUE
 
-/* When CONFIG_BOOTLOADER_MCUBOOT is set the firmware image
- * is chain-loadable and does not need to forward interrupts.
- */
-#if defined(CONFIG_SW_VECTOR_RELAY) && !defined(CONFIG_BOOTLOADER_MCUBOOT)
-
 GDATA(_vector_table_pointer)
 GDATA(z_main_stack)
 
@@ -80,5 +75,3 @@ SECTION_FUNC(vector_relay_table, __vector_relay_table)
 	.endr
 
 GTEXT(__vector_relay_table)
-
-#endif

--- a/arch/arm/core/aarch32/irq_relay.S
+++ b/arch/arm/core/aarch32/irq_relay.S
@@ -75,37 +75,10 @@ SECTION_FUNC(vector_relay_table, __vector_relay_table)
 	.word __vector_relay_handler
 	/* End of system exception */
 
+	.rept CONFIG_NUM_IRQS
 	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
-	.word __vector_relay_handler
+	.endr
+
+GTEXT(__vector_relay_table)
 
 #endif

--- a/arch/arm/core/aarch32/prep_c.c
+++ b/arch/arm/core/aarch32/prep_c.c
@@ -40,28 +40,39 @@
 #ifdef CONFIG_CPU_CORTEX_M_HAS_VTOR
 
 #ifdef CONFIG_XIP
+#ifdef CONFIG_SW_VECTOR_RELAY
+#define VECTOR_ADDRESS ((uintptr_t)__vector_relay_table)
+#else
 #define VECTOR_ADDRESS ((uintptr_t)_vector_start)
-#else
-#define VECTOR_ADDRESS CONFIG_SRAM_BASE_ADDRESS
 #endif
-static inline void relocate_vector_table(void)
-{
-	SCB->VTOR = VECTOR_ADDRESS & SCB_VTOR_TBLOFF_Msk;
-	__DSB();
-	__ISB();
-}
+#else /* CONFIG_XIP */
+#define VECTOR_ADDRESS CONFIG_SRAM_BASE_ADDRESS
+#endif /* CONFIG_XIP */
 
-#else
+#else /* CONFIG_CPU_CORTEX_M_HAS_VTOR */
+
+#define VECTOR_ADDRESS 0
+
+#endif /* CONFIG_CPU_CORTEX_M_HAS_VTOR */
 
 #if defined(CONFIG_SW_VECTOR_RELAY) || defined(CONFIG_SW_VECTOR_RELAY_CLIENT)
 Z_GENERIC_SECTION(.vt_pointer_section) __attribute__((used))
 void *_vector_table_pointer;
 #endif
 
-#define VECTOR_ADDRESS 0
 
+#ifdef CONFIG_CPU_CORTEX_M_HAS_VTOR
+static inline void relocate_vector_table(void)
+#else
 void __weak relocate_vector_table(void)
+#endif
 {
+#if defined(CONFIG_CPU_CORTEX_M_HAS_VTOR) && !defined(CONFIG_SW_VECTOR_RELAY_CLIENT)
+	SCB->VTOR = VECTOR_ADDRESS & SCB_VTOR_TBLOFF_Msk;
+	__DSB();
+	__ISB();
+#endif
+#if !defined(CONFIG_CPU_CORTEX_M_HAS_VTOR) || defined(CONFIG_SW_VECTOR_RELAY_CLIENT)
 #if defined(CONFIG_XIP) && (CONFIG_FLASH_BASE_ADDRESS != 0) || \
     !defined(CONFIG_XIP) && (CONFIG_SRAM_BASE_ADDRESS != 0)
 	size_t vector_size = (size_t)_vector_end - (size_t)_vector_start;
@@ -69,13 +80,12 @@ void __weak relocate_vector_table(void)
 #elif defined(CONFIG_SW_VECTOR_RELAY) || defined(CONFIG_SW_VECTOR_RELAY_CLIENT)
 	_vector_table_pointer = _vector_start;
 #endif
+#endif /* !defined(CONFIG_CPU_CORTEX_M_HAS_VTOR) || defined(CONFIG_SW_VECTOR_RELAY_CLIENT) */
 }
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
-
-#endif /* CONFIG_CPU_CORTEX_M_HAS_VTOR */
 
 #if defined(CONFIG_CPU_HAS_FPU)
 static inline void z_arm_floating_point_init(void)

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -163,6 +163,10 @@ extern char _image_rodata_size[];
 extern char _vector_start[];
 extern char _vector_end[];
 
+#ifdef CONFIG_SW_VECTOR_RELAY
+extern char __vector_relay_table[];
+#endif
+
 #ifdef CONFIG_COVERAGE_GCOV
 extern char __gcov_bss_start[];
 extern char __gcov_bss_end[];


### PR DESCRIPTION
This commit allows the `SW_VECTOR_RELAY` and `SW_VECTOR_RELAY_CLIENT` pair to be
enabled on the ARMv7-M architectures and covers
all additional interrupt vectors.

~~blocked by https://github.com/zephyrproject-rtos/zephyr/pull/26289~~

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>