### PR TITLE
bluetooth: Remove useless LE Set Data Length after Connected

### DIFF
--- a/include/drivers/bluetooth/hci_driver.h
+++ b/include/drivers/bluetooth/hci_driver.h
@@ -30,6 +30,11 @@ extern "C" {
 enum {
 	/* The host should never send HCI_Reset */
 	BT_QUIRK_NO_RESET = BIT(0),
+	/* The controller does not auto-initiate a DLE procedure when the
+	 * initial connection data length parameters are not equal to the
+	 * default data length parameters. Therefore the host should initiate
+	 * the DLE procedure after connection establishment. */
+	BT_QUIRK_NO_AUTO_DLE = BIT(1),
 };
 
 /* @brief The HCI event shall be given to bt_recv_prio */

--- a/include/drivers/bluetooth/hci_driver.h
+++ b/include/drivers/bluetooth/hci_driver.h
@@ -37,6 +37,8 @@ enum {
 	BT_QUIRK_NO_AUTO_DLE = BIT(1),
 };
 
+#define IS_BT_QUIRK_NO_AUTO_DLE(bt_dev) ((bt_dev)->drv->quirks & BT_QUIRK_NO_AUTO_DLE)
+
 /* @brief The HCI event shall be given to bt_recv_prio */
 #define BT_HCI_EVT_FLAG_RECV_PRIO BIT(0)
 /* @brief  The HCI event shall be given to bt_recv. */

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -518,6 +518,7 @@ static int hci_driver_open(void)
 static const struct bt_hci_driver drv = {
 	.name	= "Controller",
 	.bus	= BT_HCI_DRIVER_BUS_VIRTUAL,
+	.quirks = BT_QUIRK_NO_AUTO_DLE,
 	.open	= hci_driver_open,
 	.send	= hci_driver_send,
 };

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -37,7 +37,10 @@ enum {
 	BT_CONN_AUTO_PHY_COMPLETE,      /* Auto-initiated PHY procedure done */
 	BT_CONN_AUTO_FEATURE_EXCH,	/* Auto-initiated LE Feat done */
 	BT_CONN_AUTO_VERSION_INFO,      /* Auto-initiated LE version done */
-	BT_CONN_AUTO_DATA_LEN_COMPLETE, /* Auto-initiated Data Length done */
+
+	/* Auto-initiated Data Length done. Auto-initiated Data Length Update
+	 * is only needed for controllers with BT_QUIRK_NO_AUTO_DLE. */
+	BT_CONN_AUTO_DATA_LEN_COMPLETE,
 
 	/* Total number of flags - must be at the end of the enum */
 	BT_CONN_NUM_FLAGS,


### PR DESCRIPTION
Calling LE Write Suggested Default Data Length command is sufficient
to ensure that the LL will auto-initiate the DLE procedure. Performing
a second procedure is unecessary.

As some controllers don't follow the spec recommendation, a controller quirk is added

In Core v5.2, Vol 4, Part E, Section 7.8.35:
_The HCI_LE_Write_Suggested_Default_Data_Length command allows the
Host to specify its suggested values for the Controller's maximum
transmission number of payload octets and maximum packet
transmission time for packets containing LL Data PDUs to be used
for new connections. The Controller may use smaller or larger values
for connInitialMaxTxOctets and connInitialMaxTxTime based on local
information._

In short, this command sets connInitialMaxTxOctets
and connInitialMaxTxTime.

In Core v5.2, Vol 6, Part B, Section 4.5.10:
_For a new connection: connMaxTxOctets shall be set to
connInitialMaxTxOctets and connMaxRxOctets shall be chosen by the
Controller. If either value is not 27 then the Controller should
initiate the Data Length Update Procedure at the earliest practical
opportunity._

Therefore, calling LE Write Suggested Default Data Length command
is sufficient to ensure the DLE being performed.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>