### PR TITLE
kernel: Refactor work_q_start feature

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3216,6 +3216,28 @@ static inline bool k_work_pending(struct k_work *work)
 }
 
 /**
+ * @brief Start a workqueue with specified k_thread option flags.
+ *
+ * This routine starts workqueue @a work_q. The workqueue spawns its work
+ * processing thread with the provided options, which runs forever.
+ *
+ * @param work_q Address of workqueue.
+ * @param stack Pointer to work queue thread's stack space, as defined by
+ *		K_THREAD_STACK_DEFINE()
+ * @param stack_size Size of the work queue thread's stack (in bytes), which
+ *		should either be the same constant passed to
+ *		K_THREAD_STACK_DEFINE() or the value of K_THREAD_STACK_SIZEOF().
+ * @param prio Priority of the work queue's thread.
+ * @param options k_thread options to be used for work_q thread.
+ *
+ * @return N/A
+ * @req K-WORK-001
+ */
+extern void k_work_q_start_ex(struct k_work_q *work_q,
+				k_thread_stack_t *stack,
+				size_t stack_size, int prio, u32_t options);
+
+/**
  * @brief Start a workqueue.
  *
  * This routine starts workqueue @a work_q. The workqueue spawns its work
@@ -3230,19 +3252,24 @@ static inline bool k_work_pending(struct k_work *work)
  * @param prio Priority of the work queue's thread.
  *
  * @return N/A
+ * @req K-WORK-001
  */
-extern void k_work_q_start(struct k_work_q *work_q,
-			   k_thread_stack_t *stack,
-			   size_t stack_size, int prio);
+static inline void k_work_q_start(struct k_work_q *work_q,
+				k_thread_stack_t *stack,
+				size_t stack_size, int prio)
+{
+	k_work_q_start_ex(work_q, stack, stack_size, prio, 0);
+}
 
 /**
- * @brief Start a workqueue in user mode
+ * @brief Start a workqueue in user mode specifying k_thread options
  *
  * This works identically to k_work_q_start() except it is callable from user
  * mode, and the worker thread created will run in user mode.
  * The caller must have permissions granted on both the work_q parameter's
  * thread and queue objects, and the same restrictions on priority apply as
- * k_thread_create().
+ * k_thread_create(). Provided k_thread options will be applied to the thread
+ * created for use in this work_q.
  *
  * @param work_q Address of workqueue.
  * @param stack Pointer to work queue thread's stack space, as defined by
@@ -3251,12 +3278,14 @@ extern void k_work_q_start(struct k_work_q *work_q,
  *		should either be the same constant passed to
  *		K_THREAD_STACK_DEFINE() or the value of K_THREAD_STACK_SIZEOF().
  * @param prio Priority of the work queue's thread.
+ * @param options Option flags to be used in the resulting work_q k_thread's
+ * creation.
  *
  * @return N/A
+ * @req K-WORK-001
  */
-extern void k_work_q_user_start(struct k_work_q *work_q,
-				k_thread_stack_t *stack,
-				size_t stack_size, int prio);
+extern void k_work_q_user_start_ex(struct k_work_q *work_q, k_thread_stack_t *stack,
+				size_t stack_size, int prio, u32_t options);
 
 /**
  * @brief Initialize a delayed work item.

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3231,7 +3231,6 @@ static inline bool k_work_pending(struct k_work *work)
  * @param options k_thread options to be used for work_q thread.
  *
  * @return N/A
- * @req K-WORK-001
  */
 extern void k_work_q_start_ex(struct k_work_q *work_q,
 				k_thread_stack_t *stack,
@@ -3252,7 +3251,6 @@ extern void k_work_q_start_ex(struct k_work_q *work_q,
  * @param prio Priority of the work queue's thread.
  *
  * @return N/A
- * @req K-WORK-001
  */
 static inline void k_work_q_start(struct k_work_q *work_q,
 				k_thread_stack_t *stack,
@@ -3282,7 +3280,6 @@ static inline void k_work_q_start(struct k_work_q *work_q,
  * creation.
  *
  * @return N/A
- * @req K-WORK-001
  */
 extern void k_work_q_user_start_ex(struct k_work_q *work_q, k_thread_stack_t *stack,
 				size_t stack_size, int prio, u32_t options);

--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -26,12 +26,12 @@ static struct k_spinlock lock;
 
 extern void z_work_q_main(void *work_q_ptr, void *p2, void *p3);
 
-void k_work_q_start(struct k_work_q *work_q, k_thread_stack_t *stack,
-		    size_t stack_size, int prio)
+void k_work_q_start_ex(struct k_work_q *work_q, k_thread_stack_t *stack,
+		    size_t stack_size, int prio, u32_t options)
 {
 	k_queue_init(&work_q->queue);
 	(void)k_thread_create(&work_q->thread, stack, stack_size, z_work_q_main,
-			work_q, NULL, NULL, prio, 0, K_NO_WAIT);
+			work_q, NULL, NULL, prio, options, K_NO_WAIT);
 
 	k_thread_name_set(&work_q->thread, WORKQUEUE_THREAD_NAME);
 }

--- a/lib/os/work_q.c
+++ b/lib/os/work_q.c
@@ -39,8 +39,8 @@ void z_work_q_main(void *work_q_ptr, void *p2, void *p3)
 	}
 }
 
-void k_work_q_user_start(struct k_work_q *work_q, k_thread_stack_t *stack,
-			 size_t stack_size, int prio)
+void k_work_q_user_start_ex(struct k_work_q *work_q, k_thread_stack_t *stack,
+			 size_t stack_size, int prio, u32_t options)
 {
 	k_queue_init(&work_q->queue);
 
@@ -48,7 +48,7 @@ void k_work_q_user_start(struct k_work_q *work_q, k_thread_stack_t *stack,
 	 * domain configuration of the caller
 	 */
 	k_thread_create(&work_q->thread, stack, stack_size, z_work_q_main,
-			work_q, 0, 0, prio, K_USER | K_INHERIT_PERMS,
+			work_q, 0, 0, prio, K_USER | K_INHERIT_PERMS | options,
 			K_FOREVER);
 	k_object_access_grant(&work_q->queue, &work_q->thread);
 	k_thread_name_set(&work_q->thread, WORKQUEUE_THREAD_NAME);


### PR DESCRIPTION
Extension and rename of k_work_q_start() and k_work_q_user_start() to include an additional arg to enable k_thread options to be applied to work_q internal thread. This feature enables the optional inclusion of floating point support within a work_q, for example.

Static inline versions of the original functions have been created in kernel.h which call these new functions with their previously hard coded k_thread options. These inline functions will support backwards compatibility, while new consumers of these functions can choose to use these old function signatures or the new ones.

This is my first commit to Zephyr so please let me know if there are any changes that are needed!

--

Converting to draft while this change is iterated on, it sounds like some deeper cuts would be the right decision at this time.

Signed-off-by: Erik Tidemand <eriktid@fb.com>