### PR TITLE
drivers: usb: switch the SAM0 driver from a custom allocator to the heap

### DIFF
--- a/soc/arm/atmel_sam0/common/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/common/Kconfig.defconfig.series
@@ -38,4 +38,11 @@ config USB_DC_SAM0
 config WDT_SAM0
 	default WATCHDOG
 
+if USB
+
+config HEAP_MEM_POOL_SIZE
+	default 1024
+
+endif # USB
+
 endif # SOC_FAMILY_SAM0


### PR DESCRIPTION
Also automatically enable the heap if the USB device is selected.

Part of #23178

Signed-off-by: Michael Hope <mlhx@google.com>

Fixes #23178
Fixes #23111