### PR TITLE
Arch arm sw vector table cleanup

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -387,8 +387,9 @@ config BOOTLOADER_MCUBOOT
 
 	    * Setting TEXT_SECTION_OFFSET to a default value that allows space
 	      for the MCUboot image header
-	    * Activating SW_VECTOR_RELAY on Cortex-M0 (or Armv8-M baseline)
-	      targets with no built-in vector relocation mechanisms
+	    * Activating SW_VECTOR_RELAY_CLIENT on Cortex-M0
+	      (or Armv8-M baseline) targets with no built-in vector relocation
+	      mechanisms
 
 config BOOTLOADER_ESP_IDF
 	bool "ESP-IDF bootloader support"

--- a/arch/arm/core/aarch32/cortex_m/CMakeLists.txt
+++ b/arch/arm/core/aarch32/cortex_m/CMakeLists.txt
@@ -19,7 +19,9 @@ zephyr_linker_sources_ifdef(CONFIG_SW_VECTOR_RELAY
   relay_vector_table.ld
   )
 
-zephyr_linker_sources_ifdef(CONFIG_SW_VECTOR_RELAY
+if (CONFIG_SW_VECTOR_RELAY OR CONFIG_SW_VECTOR_RELAY_CLIENT)
+zephyr_linker_sources(
   RAM_SECTIONS
   vt_pointer_section.ld
   )
+endif()

--- a/arch/arm/core/aarch32/cortex_m/Kconfig
+++ b/arch/arm/core/aarch32/cortex_m/Kconfig
@@ -267,15 +267,25 @@ config DYNAMIC_DIRECT_INTERRUPTS
 
 config SW_VECTOR_RELAY
 	bool "Enable Software Vector Relay"
-	default y if BOOTLOADER_MCUBOOT
 	depends on ARMV6_M_ARMV8_M_BASELINE && !(CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP || CPU_CORTEX_M_HAS_VTOR)
 	help
-	  Add Vector Table relay handler and relay vector table, to
-	  relay interrupts based on a vector table pointer. This is only
+	  When building bootloader firmware this option adds a
+	  Vector Table relay handler and relay vector table, to
+	  relay interrupts based on a vector table pointer.
+	  This is only
 	  required for Cortex-M0 (or an Armv8-M baseline core) with no hardware
 	  vector table relocation mechanisms or for Cortex-M0+
 	  (or an Armv8-M baseline core) with no VTOR and no other hardware
 	  relocation table mechanisms.
+
+config SW_VECTOR_RELAY_CLIENT
+	bool "Enable Software Vector Relay (client)"
+	default y if BOOTLOADER_MCUBOOT
+	depends on ARMV6_M_ARMV8_M_BASELINE && !(CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP || CPU_CORTEX_M_HAS_VTOR)
+	help
+	  Another image has enabled SW_VECTOR_RELAY, and will relay interrupts
+	  to this image. Enable this to make sure the vector table pointer in
+	  RAM is left alone.
 
 endmenu
 

--- a/arch/arm/core/aarch32/cortex_m/vt_pointer_section.ld
+++ b/arch/arm/core/aarch32/cortex_m/vt_pointer_section.ld
@@ -5,4 +5,4 @@
   {
           *(.vt_pointer_section)
           *(".vt_pointer_section.*")
-  }
+  } GROUP_LINK_IN(RAMABLE_REGION)

--- a/arch/arm/core/aarch32/irq_relay.S
+++ b/arch/arm/core/aarch32/irq_relay.S
@@ -26,7 +26,10 @@
 
 _ASM_FILE_PROLOGUE
 
-#if defined(CONFIG_SW_VECTOR_RELAY)
+/* When CONFIG_BOOTLOADER_MCUBOOT is set the firmware image
+ * is chain-loadable and does not need to forward interrupts.
+ */
+#if defined(CONFIG_SW_VECTOR_RELAY) && !defined(CONFIG_BOOTLOADER_MCUBOOT)
 
 GDATA(_vector_table_pointer)
 GDATA(z_main_stack)

--- a/arch/arm/core/aarch32/prep_c.c
+++ b/arch/arm/core/aarch32/prep_c.c
@@ -53,8 +53,9 @@ static inline void relocate_vector_table(void)
 
 #else
 
-#if defined(CONFIG_SW_VECTOR_RELAY)
-Z_GENERIC_SECTION(.vt_pointer_section) void *_vector_table_pointer;
+#if defined(CONFIG_SW_VECTOR_RELAY) || defined(CONFIG_SW_VECTOR_RELAY_CLIENT)
+Z_GENERIC_SECTION(.vt_pointer_section) __attribute__((used))
+void *_vector_table_pointer;
 #endif
 
 #define VECTOR_ADDRESS 0
@@ -65,7 +66,7 @@ void __weak relocate_vector_table(void)
     !defined(CONFIG_XIP) && (CONFIG_SRAM_BASE_ADDRESS != 0)
 	size_t vector_size = (size_t)_vector_end - (size_t)_vector_start;
 	(void)memcpy(VECTOR_ADDRESS, _vector_start, vector_size);
-#elif defined(CONFIG_SW_VECTOR_RELAY)
+#elif defined(CONFIG_SW_VECTOR_RELAY) || defined(CONFIG_SW_VECTOR_RELAY_CLIENT)
 	_vector_table_pointer = _vector_start;
 #endif
 }


### PR DESCRIPTION
Now in case of boot-able application CONFIG_SW_VECTOR_RELAY_CLIENT is used to setting the
vector table pointer in RAM so the parent image can forward the
interrupts to it

This will save some flash on Cortex-M0 with SW vector relaying, and in particular, (16 + 32)x4 = 192 bytes.