### PR TITLE
sys: util: Document limitation of IS_EMPTY macro

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -466,6 +466,11 @@ uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value);
  * to replacement lists being empty or containing numbers or macro name
  * like tokens.
  *
+ * @note Not all arguments are accepted by this macro and compilation will fail
+ *	 if argument cannot be concatenated with literal constant. That will
+ *	 happen if argument does not start with letter or number. Example
+ *	 arguments that will fail during compilation: .arg, (arg), "arg", {arg}.
+ *
  * Example:
  *
  *	#define EMPTY


### PR DESCRIPTION
IS_EMPTY macro does not accept all type of arguments.
Added clarification.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>