### PR TITLE
samples: posix: eventfd: bugfix for regex check

### DIFF
--- a/samples/posix/eventfd/sample.yaml
+++ b/samples/posix/eventfd/sample.yaml
@@ -19,5 +19,5 @@ tests:
         -  "Writing 4 to efd"
         -  "Completed write loop"
         -  "About to read"
-        -  "Read 10 (0xa) from efd"
+        -  "Read 10 \\(0xa\\) from efd"
         -  "Finished"


### PR DESCRIPTION
Bugfix for regex adding "\\\\" before "(" and ")" for proper regex parsing

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>