### PR TITLE
sys: util: Improve IS_EMPTY macro

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -28,6 +28,7 @@
 
 #ifndef _ASMLANGUAGE
 
+#include <../../modules/lib/p99/p99/p99_args.h>
 #include <zephyr/types.h>
 #include <stddef.h>
 
@@ -483,7 +484,7 @@ uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value);
  *
  * @param a macro to check for emptiness
  */
-#define IS_EMPTY(a) Z_IS_EMPTY_(a, true, false,)
+#define IS_EMPTY(a) P99_IS_EMPTY(a)
 
 /**
  * @brief Remove empty arguments from list.

--- a/include/sys/util_internal.h
+++ b/include/sys/util_internal.h
@@ -64,11 +64,6 @@
 /* Used to remove brackets from around a single argument. */
 #define __DEBRACKET(...) __VA_ARGS__
 
-/* Used by IS_EMPTY() */
-#define Z_IS_EMPTY_(...) Z_IS_EMPTY__(__VA_ARGS__)
-#define Z_IS_EMPTY__(a, ...) Z_IS_EMPTY___(_ZZ##a##ZZ0, __VA_ARGS__)
-#define Z_IS_EMPTY___(...) GET_ARG_N(3, __VA_ARGS__)
-
 /* Used by LIST_DROP_EMPTY() */
 /* Adding ',' after each element would add empty element at the end of
  * list, which is hard to remove, so instead precede each element with ',',

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -296,6 +296,12 @@ static void test_IS_EMPTY(void)
 		     "Expected to be empty");
 	zassert_false(IS_EMPTY(test_IS_EMPTY_NOT_EMPTY),
 		      "Expected to be non-empty");
+	zassert_false(IS_EMPTY("string"),
+		      "Expected to be non-empty");
+	zassert_false(IS_EMPTY({ .x = 10 }),
+		      "Expected to be non-empty");
+	zassert_false(IS_EMPTY((a + b)),
+		      "Expected to be non-empty");
 }
 
 static void test_LIST_DROP_EMPTY(void)

--- a/west.yml
+++ b/west.yml
@@ -21,6 +21,8 @@ manifest:
   remotes:
     - name: upstream
       url-base: https://github.com/zephyrproject-rtos
+    - name: gustedt
+      url-base: https://gitlab.inria.fr/gustedt
 
   #
   # Please add items below based on alphabetical order
@@ -133,6 +135,11 @@ manifest:
     - name: trusted-firmware-m
       path: modules/tee/tfm
       revision: 7de2daa1967b2dc12cbe0fcc0171ac3064ea596b
+    - name: p99
+      path: modules/lib/p99
+      remote: gustedt
+      revision: 142a8c4ddbdf7fa86e2cec80c17484c98e63415d
+
 
   self:
     path: zephyr


### PR DESCRIPTION
Replaced IS_EMPTY implementation with one found at
https://gustedt.wordpress.com/2010/06/08/detect-empty-macro-arguments/
which does not have limitation with regards to argument types. Former
implementation did not support arguments starting with brackets, dots,
quotations, etc.
    
Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>