### PR TITLE
Bluetooth: controller: Fix PREAMBLE_SIZE define

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -11,7 +11,7 @@
  * PDU fields sizes
  */
 
-#define PDU_PREAMBLE_SIZE(phy) (phy&0x3)
+#define PDU_PREAMBLE_SIZE(phy) ((((phy) & 0x3) >> 1) + 1)
 #define PDU_ACCESS_ADDR_SIZE   4
 #define PDU_HEADER_SIZE        2
 #define PDU_MIC_SIZE           4


### PR DESCRIPTION
Fix PREAMBLE_SIZE define to handle phy parameter value of 0
as 1M PHY. Certain parts of controller implementation
for control procedure evaluate to 0, in which case 1M PHY
is to be assumed.

In the related issue #26252, in the sniffer log it is seen
that the controller returns 2112 us instead of 2120 us due
to evaluation of phy parameter to 0 and passed to PKT_US
define.

Relates to #26252.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>