### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: llcp: use C99 types

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -39,7 +39,7 @@
 /* LLCP Memory Pool Descriptor */
 struct mem_pool {
 	void *free;
-	u8_t *pool;
+	uint8_t *pool;
 };
 
 #define LLCTRL_PDU_SIZE		(offsetof(struct pdu_data, llctrl) + sizeof(struct pdu_data_llctrl))
@@ -65,15 +65,15 @@ struct mem_pool {
 #endif
 
 /* TODO: Determine correct number of tx nodes */
-static u8_t buffer_mem_tx[TX_CTRL_BUF_SIZE * TX_CTRL_BUF_NUM];
+static uint8_t buffer_mem_tx[TX_CTRL_BUF_SIZE * TX_CTRL_BUF_NUM];
 static struct mem_pool mem_tx = { .pool = buffer_mem_tx };
 
 /* TODO: Determine correct number of ntf nodes */
-static u8_t buffer_mem_ntf[NTF_BUF_SIZE * NTF_BUF_NUM];
+static uint8_t buffer_mem_ntf[NTF_BUF_SIZE * NTF_BUF_NUM];
 static struct mem_pool mem_ntf = { .pool = buffer_mem_ntf };
 
 /* TODO: Determine correct number of ctx */
-static u8_t buffer_mem_ctx[PROC_CTX_BUF_SIZE * PROC_CTX_BUF_NUM];
+static uint8_t buffer_mem_ctx[PROC_CTX_BUF_SIZE * PROC_CTX_BUF_NUM];
 static struct mem_pool mem_ctx = { .pool = buffer_mem_ctx };
 
 /*
@@ -297,7 +297,7 @@ void ull_cp_run(struct ull_cp_conn *conn)
 	lr_run(conn);
 }
 
-void ull_cp_state_set(struct ull_cp_conn *conn, u8_t state)
+void ull_cp_state_set(struct ull_cp_conn *conn, uint8_t state)
 {
 	switch (state) {
 	case ULL_CP_CONNECTED:
@@ -313,7 +313,7 @@ void ull_cp_state_set(struct ull_cp_conn *conn, u8_t state)
 	}
 } 
 
-u8_t ull_cp_min_used_chans(struct ull_cp_conn *conn, u8_t phys, u8_t min_used_chans)
+uint8_t ull_cp_min_used_chans(struct ull_cp_conn *conn, uint8_t phys, uint8_t min_used_chans)
 {
 	struct proc_ctx *ctx;
 
@@ -339,7 +339,7 @@ u8_t ull_cp_min_used_chans(struct ull_cp_conn *conn, u8_t phys, u8_t min_used_ch
 	return BT_HCI_ERR_SUCCESS;
 }
 
-u8_t ull_cp_le_ping(struct ull_cp_conn *conn)
+uint8_t ull_cp_le_ping(struct ull_cp_conn *conn)
 {
 	struct proc_ctx *ctx;
 
@@ -353,7 +353,7 @@ u8_t ull_cp_le_ping(struct ull_cp_conn *conn)
 	return BT_HCI_ERR_SUCCESS;
 }
 
-u8_t ull_cp_feature_exchange(struct ull_cp_conn *conn)
+uint8_t ull_cp_feature_exchange(struct ull_cp_conn *conn)
 {
 	struct proc_ctx *ctx;
 
@@ -367,7 +367,7 @@ u8_t ull_cp_feature_exchange(struct ull_cp_conn *conn)
 	return BT_HCI_ERR_SUCCESS;
 }
 
-u8_t ull_cp_version_exchange(struct ull_cp_conn *conn)
+uint8_t ull_cp_version_exchange(struct ull_cp_conn *conn)
 {
 	struct proc_ctx *ctx;
 
@@ -381,7 +381,7 @@ u8_t ull_cp_version_exchange(struct ull_cp_conn *conn)
 	return BT_HCI_ERR_SUCCESS;
 }
 
-u8_t ull_cp_encryption_start(struct ull_cp_conn *conn)
+uint8_t ull_cp_encryption_start(struct ull_cp_conn *conn)
 {
 	struct proc_ctx *ctx;
 
@@ -397,7 +397,7 @@ u8_t ull_cp_encryption_start(struct ull_cp_conn *conn)
 	return BT_HCI_ERR_SUCCESS;
 }
 
-u8_t ull_cp_phy_update(struct ull_cp_conn *conn)
+uint8_t ull_cp_phy_update(struct ull_cp_conn *conn)
 {
 	struct proc_ctx *ctx;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.h
@@ -14,22 +14,22 @@ struct ull_cp_conn {
 		/* Local Request */
 		struct {
 			sys_slist_t pend_proc_list;
-			u8_t state;
+			uint8_t state;
 		} local;
 
 		/* Remote Request */
 		struct {
 			sys_slist_t pend_proc_list;
-			u8_t state;
-			u8_t collision;
-			u8_t incompat;
-			u8_t reject_opcode;
+			uint8_t state;
+			uint8_t collision;
+			uint8_t incompat;
+			uint8_t reject_opcode;
 		} remote;
 
 		/* Version Exchange Procedure State */
 		struct {
-			u8_t sent;
-			u8_t valid;
+			uint8_t sent;
+			uint8_t valid;
 			struct pdu_data_llctrl_version_ind cached;
 		} vex;
 
@@ -42,31 +42,31 @@ struct ull_cp_conn {
 		 * see BT Core spec 5.2 Vol 6, Part B, sec. 5.1.4
 		 */
 		struct {
-			u8_t sent;
-			u8_t valid;
-			u64_t features_peer;
-			u64_t features_used;
+			uint8_t sent;
+			uint8_t valid;
+			uint64_t features_peer;
+			uint64_t features_used;
 		} fex;
 
 		/* Minimum used channels procedure state */
 		struct {
-			u8_t phys;
-			u8_t min_used_chans;
+			uint8_t phys;
+			uint8_t min_used_chans;
 		} muc;
 
 	} llcp;
 
 	struct mocked_lll_conn {
 		/* Encryption State (temporary) */
-		u8_t enc_tx;
-		u8_t enc_rx;
+		uint8_t enc_tx;
+		uint8_t enc_rx;
 
 		/**/
-		 u16_t latency_prepare;
-		 u16_t latency_event;
-		 u16_t event_counter;
+		uint16_t latency_prepare;
+		uint16_t latency_event;
+		uint16_t event_counter;
 
-		 u8_t role;
+		uint8_t role;
 	} lll;
 };
 
@@ -88,7 +88,7 @@ void ull_cp_conn_init(struct ull_cp_conn *conn);
 /**
  * @brief XXX
  */
-void ull_cp_state_set(struct ull_cp_conn *conn, u8_t state);
+void ull_cp_state_set(struct ull_cp_conn *conn, uint8_t state);
 
 /**
  *
@@ -118,27 +118,27 @@ void ull_cp_rx(struct ull_cp_conn *conn, struct node_rx_pdu *rx);
 /**
  * @brief Initiate a LE Ping Procedure.
  */
-u8_t ull_cp_le_ping(struct ull_cp_conn *conn);
+uint8_t ull_cp_le_ping(struct ull_cp_conn *conn);
 
 /**
  * @brief Initiate a Version Exchange Procedure.
  */
-u8_t ull_cp_version_exchange(struct ull_cp_conn *conn);
+uint8_t ull_cp_version_exchange(struct ull_cp_conn *conn);
 
 /**
  * @brief Initiate a Featue Exchange Procedure.
  */
-u8_t ull_cp_feature_exchange(struct ull_cp_conn *conn);
+uint8_t ull_cp_feature_exchange(struct ull_cp_conn *conn);
 
 /**
  * @brief Initiate a Minimum used channels Procedure.
  */
-u8_t ull_cp_min_used_chans(struct ull_cp_conn *conn, u8_t phys, u8_t min_used_chans);
+uint8_t ull_cp_min_used_chans(struct ull_cp_conn *conn, uint8_t phys, uint8_t min_used_chans);
 
 /**
  * @brief Initiate a Encryption Start Procedure.
  */
-u8_t ull_cp_encryption_start(struct ull_cp_conn *conn);
+uint8_t ull_cp_encryption_start(struct ull_cp_conn *conn);
 
 /**
  */
@@ -151,4 +151,4 @@ void ull_cp_ltk_req_neq_reply(struct ull_cp_conn *conn);
 /**
  * @brief Initiate a PHY Update Procedure.
  */
-u8_t ull_cp_phy_update(struct ull_cp_conn *conn);
+uint8_t ull_cp_phy_update(struct ull_cp_conn *conn);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -194,7 +194,7 @@ static void lp_comm_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx)
 	ll_rx_enqueue(ntf);
 }
 
-static void lp_comm_complete(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_comm_complete(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (ctx->proc) {
 	case PROC_LE_PING:
@@ -236,7 +236,7 @@ static void lp_comm_complete(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_
 	}
 }
 
-static void lp_comm_send_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_comm_send_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (ctx->proc) {
 	case PROC_LE_PING:
@@ -284,7 +284,7 @@ static void lp_comm_send_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_
 	}
 }
 
-static void lp_comm_st_idle(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_comm_st_idle(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case LP_COMMON_EVT_RUN:
@@ -300,12 +300,12 @@ static void lp_comm_st_idle(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t
 	}
 }
 
-static void lp_comm_st_wait_tx(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_comm_st_wait_tx(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 }
 
-static void lp_comm_st_wait_tx_ack(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_comm_st_wait_tx_ack(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case LP_COMMON_EVT_ACK:
@@ -356,7 +356,7 @@ static void lp_comm_rx_decode(struct ull_cp_conn *conn, struct proc_ctx *ctx, st
 	}
 }
 
-static void lp_comm_st_wait_rx(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_comm_st_wait_rx(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case LP_COMMON_EVT_RESPONSE:
@@ -368,12 +368,12 @@ static void lp_comm_st_wait_rx(struct ull_cp_conn *conn, struct proc_ctx *ctx, u
 	}
 }
 
-static void lp_comm_st_wait_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_comm_st_wait_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 }
 
-static void lp_comm_execute_fsm(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_comm_execute_fsm(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (ctx->state) {
 	case LP_COMMON_STATE_IDLE:
@@ -480,7 +480,7 @@ static void rp_comm_tx(struct ull_cp_conn *conn, struct proc_ctx *ctx)
 	tx_enqueue(conn, tx);
 }
 
-static void rp_comm_st_idle(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_comm_st_idle(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case RP_COMMON_EVT_RUN:
@@ -492,7 +492,7 @@ static void rp_comm_st_idle(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t
 	}
 }
 
-static void rp_comm_send_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_comm_send_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (ctx->proc) {
 	case PROC_LE_PING:
@@ -546,7 +546,7 @@ static void rp_comm_send_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_
 	}
 }
 
-static void rp_comm_st_wait_rx(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_comm_st_wait_rx(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case RP_COMMON_EVT_REQUEST:
@@ -563,17 +563,17 @@ static void rp_comm_st_wait_rx(struct ull_cp_conn *conn, struct proc_ctx *ctx, u
 	}
 }
 
-static void rp_comm_st_wait_tx(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_comm_st_wait_tx(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 }
 
-static void rp_comm_st_wait_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_comm_st_wait_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 }
 
-static void rp_comm_execute_fsm(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_comm_execute_fsm(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (ctx->state) {
 	case RP_COMMON_STATE_IDLE:

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
@@ -114,7 +114,7 @@ extern void ll_rx_enqueue(struct node_rx_pdu *rx);
  * LLCP Local Procedure Encryption FSM
  */
 
-static void lp_enc_tx(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t opcode)
+static void lp_enc_tx(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
 {
 	struct node_tx *tx;
 	struct pdu_data *pdu;
@@ -166,7 +166,7 @@ static void lp_enc_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx)
 	ll_rx_enqueue(ntf);
 }
 
-static void lp_enc_complete(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_enc_complete(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	if (!ntf_alloc_is_available()) {
 		ctx->state = LP_ENC_STATE_WAIT_NTF;
@@ -177,7 +177,7 @@ static void lp_enc_complete(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t
 	}
 }
 
-static void lp_enc_send_enc_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_enc_send_enc_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	if (!tx_alloc_is_available()) {
 		ctx->state = LP_ENC_STATE_WAIT_TX_ENC_REQ;
@@ -188,7 +188,7 @@ static void lp_enc_send_enc_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, 
 	}
 }
 
-static void lp_enc_send_start_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_enc_send_start_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	if (!tx_alloc_is_available()) {
 		ctx->state = LP_ENC_STATE_WAIT_TX_START_ENC_RSP;
@@ -205,7 +205,7 @@ static void lp_enc_send_start_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx 
 	}
 }
 
-static void lp_enc_st_idle(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_enc_st_idle(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 	switch (evt) {
@@ -220,7 +220,7 @@ static void lp_enc_st_idle(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t 
 	}
 }
 
-static void lp_enc_st_wait_tx_enc_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_enc_st_wait_tx_enc_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case LP_ENC_EVT_RUN:
@@ -232,7 +232,7 @@ static void lp_enc_st_wait_tx_enc_req(struct ull_cp_conn *conn, struct proc_ctx 
 	}
 }
 
-static void lp_enc_st_wait_rx_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_enc_st_wait_rx_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 	switch (evt) {
@@ -246,7 +246,7 @@ static void lp_enc_st_wait_rx_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx 
 	}
 }
 
-static void lp_enc_st_wait_rx_start_enc_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_enc_st_wait_rx_start_enc_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 	struct pdu_data *pdu = (struct pdu_data *) param;
@@ -265,7 +265,7 @@ static void lp_enc_st_wait_rx_start_enc_req(struct ull_cp_conn *conn, struct pro
 	}
 }
 
-static void lp_enc_st_wait_tx_start_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_enc_st_wait_tx_start_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case LP_ENC_EVT_RUN:
@@ -277,7 +277,7 @@ static void lp_enc_st_wait_tx_start_enc_rsp(struct ull_cp_conn *conn, struct pro
 	}
 }
 
-static void lp_enc_st_wait_rx_start_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_enc_st_wait_rx_start_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 	switch (evt) {
@@ -291,7 +291,7 @@ static void lp_enc_st_wait_rx_start_enc_rsp(struct ull_cp_conn *conn, struct pro
 	}
 }
 
-static void lp_enc_st_wait_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_enc_st_wait_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 	switch (evt) {
@@ -304,7 +304,7 @@ static void lp_enc_st_wait_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx, u
 	}
 }
 
-static void lp_enc_execute_fsm(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_enc_execute_fsm(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (ctx->state) {
 	case LP_ENC_STATE_IDLE:
@@ -371,7 +371,7 @@ void ull_cp_priv_lp_enc_run(struct ull_cp_conn *conn, struct proc_ctx *ctx, void
  * LLCP Remote Procedure Encryption FSM
  */
 
-static void rp_enc_tx(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t opcode)
+static void rp_enc_tx(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
 {
 	struct node_tx *tx;
 	struct pdu_data *pdu;
@@ -445,9 +445,9 @@ static void rp_enc_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx)
 	ll_rx_enqueue(ntf);
 }
 
-static void rp_enc_send_start_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param);
+static void rp_enc_send_start_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param);
 
-static void rp_enc_complete(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_enc_complete(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	if (!ntf_alloc_is_available()) {
 		ctx->state = RP_ENC_STATE_WAIT_NTF;
@@ -457,7 +457,7 @@ static void rp_enc_complete(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t
 	}
 }
 
-static void rp_enc_send_ltk_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_enc_send_ltk_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	if (!ntf_alloc_is_available()) {
 		ctx->state = RP_ENC_STATE_WAIT_NTF_LTK_REQ;
@@ -467,7 +467,7 @@ static void rp_enc_send_ltk_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx, 
 	}
 }
 
-static void rp_enc_send_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_enc_send_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	if (!tx_alloc_is_available()) {
 		ctx->state = RP_ENC_STATE_WAIT_TX_ENC_RSP;
@@ -477,7 +477,7 @@ static void rp_enc_send_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, 
 	}
 }
 
-static void rp_enc_send_start_enc_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_enc_send_start_enc_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	if (!tx_alloc_is_available()) {
 		ctx->state = RP_ENC_STATE_WAIT_TX_START_ENC_REQ;
@@ -491,7 +491,7 @@ static void rp_enc_send_start_enc_req(struct ull_cp_conn *conn, struct proc_ctx 
 	}
 }
 
-static void rp_enc_send_reject_ind(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_enc_send_reject_ind(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	if (!tx_alloc_is_available()) {
 		ctx->state = RP_ENC_STATE_WAIT_TX_REJECT_IND;
@@ -502,7 +502,7 @@ static void rp_enc_send_reject_ind(struct ull_cp_conn *conn, struct proc_ctx *ct
 	}
 }
 
-static void rp_enc_send_start_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_enc_send_start_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	if (!tx_alloc_is_available()) {
 		ctx->state = RP_ENC_STATE_WAIT_TX_START_ENC_RSP;
@@ -516,7 +516,7 @@ static void rp_enc_send_start_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx 
 	}
 }
 
-static void rp_enc_state_idle(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_enc_state_idle(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case RP_ENC_EVT_RUN:
@@ -528,7 +528,7 @@ static void rp_enc_state_idle(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8
 	}
 }
 
-static void rp_enc_state_wait_rx_enc_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_enc_state_wait_rx_enc_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 	switch (evt) {
@@ -541,7 +541,7 @@ static void rp_enc_state_wait_rx_enc_req(struct ull_cp_conn *conn, struct proc_c
 	}
 }
 
-static void rp_enc_state_wait_tx_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_enc_state_wait_tx_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 	switch (evt) {
@@ -554,7 +554,7 @@ static void rp_enc_state_wait_tx_enc_rsp(struct ull_cp_conn *conn, struct proc_c
 	}
 }
 
-static void rp_enc_state_wait_ntf_ltk_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_enc_state_wait_ntf_ltk_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 	switch (evt) {
@@ -567,7 +567,7 @@ static void rp_enc_state_wait_ntf_ltk_req(struct ull_cp_conn *conn, struct proc_
 	}
 }
 
-static void rp_enc_state_wait_ltk_reply(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_enc_state_wait_ltk_reply(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 	switch (evt) {
@@ -583,7 +583,7 @@ static void rp_enc_state_wait_ltk_reply(struct ull_cp_conn *conn, struct proc_ct
 	}
 }
 
-static void rp_enc_state_wait_tx_start_enc_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_enc_state_wait_tx_start_enc_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 	switch (evt) {
@@ -596,7 +596,7 @@ static void rp_enc_state_wait_tx_start_enc_req(struct ull_cp_conn *conn, struct 
 	}
 }
 
-static void rp_enc_state_wait_tx_reject_ind(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_enc_state_wait_tx_reject_ind(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 	switch (evt) {
@@ -610,7 +610,7 @@ static void rp_enc_state_wait_tx_reject_ind(struct ull_cp_conn *conn, struct pro
 }
 
 
-static void rp_enc_state_wait_rx_start_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_enc_state_wait_rx_start_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 	switch (evt) {
@@ -623,7 +623,7 @@ static void rp_enc_state_wait_rx_start_enc_rsp(struct ull_cp_conn *conn, struct 
 	}
 }
 
-static void rp_enc_state_wait_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_enc_state_wait_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 	switch (evt) {
@@ -636,7 +636,7 @@ static void rp_enc_state_wait_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx
 	}
 }
 
-static void rp_enc_state_wait_tx_start_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_enc_state_wait_tx_start_enc_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 	switch (evt) {
@@ -649,7 +649,7 @@ static void rp_enc_state_wait_tx_start_enc_rsp(struct ull_cp_conn *conn, struct 
 	}
 }
 
-static void rp_enc_execute_fsm(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_enc_execute_fsm(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (ctx->state) {
 	case RP_ENC_STATE_IDLE:

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -26,7 +26,7 @@ struct proc_ctx {
 	enum pdu_data_llctrl_type response_opcode;
 
 	/* Procedure FSM */
-	u8_t state;
+	uint8_t state;
 
 	/* Expected opcode to be recieved next */
 	enum pdu_data_llctrl_type rx_opcode;
@@ -47,24 +47,24 @@ struct proc_ctx {
 	union {
 		/* Used by Minimum Used Channels Procedure */
 		struct {
-			u8_t phys;
-			u8_t min_used_chans;
+			uint8_t phys;
+			uint8_t min_used_chans;
 		} muc;
 
 		/* Used by Encryption Procedure */
 		struct {
-			u8_t error;
+			uint8_t error;
 		} enc;
 
 		/* PHY Update */
 		struct {
-			u8_t error;
-			u16_t instant;
+			uint8_t error;
+			uint16_t instant;
 		} pu;
 
 	} data;
 	struct {
-		u8_t type;
+		uint8_t type;
 	} unknown_response;
 
 };
@@ -633,16 +633,16 @@ static inline void pdu_encode_start_enc_rsp(struct pdu_data *pdu)
 	return ull_cp_priv_pdu_encode_start_enc_rsp(pdu);
 }
 
-void ull_cp_priv_pdu_encode_reject_ind(struct pdu_data *pdu, u8_t error_code);
+void ull_cp_priv_pdu_encode_reject_ind(struct pdu_data *pdu, uint8_t error_code);
 
-static inline void pdu_encode_reject_ind(struct pdu_data *pdu, u8_t error_code)
+static inline void pdu_encode_reject_ind(struct pdu_data *pdu, uint8_t error_code)
 {
 	return ull_cp_priv_pdu_encode_reject_ind(pdu, error_code);
 }
 
-void ull_cp_priv_pdu_encode_reject_ext_ind(struct pdu_data *pdu, u8_t reject_opcode, u8_t error_code);
+void ull_cp_priv_pdu_encode_reject_ext_ind(struct pdu_data *pdu, uint8_t reject_opcode, uint8_t error_code);
 
-static inline void pdu_encode_reject_ext_ind(struct pdu_data *pdu, u8_t reject_opcode, u8_t error_code)
+static inline void pdu_encode_reject_ext_ind(struct pdu_data *pdu, uint8_t reject_opcode, uint8_t error_code)
 {
 	return ull_cp_priv_pdu_encode_reject_ext_ind(pdu, reject_opcode, error_code);
 }
@@ -665,9 +665,9 @@ static inline void pdu_encode_phy_rsp(struct pdu_data *pdu)
 	return ull_cp_priv_pdu_encode_phy_rsp(pdu);
 }
 
-void ull_cp_priv_pdu_encode_phy_update_ind(struct pdu_data *pdu, u16_t instant);
+void ull_cp_priv_pdu_encode_phy_update_ind(struct pdu_data *pdu, uint16_t instant);
 
-static inline void pdu_encode_phy_update_ind(struct pdu_data *pdu, u16_t instant)
+static inline void pdu_encode_phy_update_ind(struct pdu_data *pdu, uint16_t instant)
 {
 	return ull_cp_priv_pdu_encode_phy_update_ind(pdu, instant);
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -172,7 +172,7 @@ static void lr_act_disconnect(struct ull_cp_conn *conn)
 	lr_dequeue(conn);
 }
 
-static void lr_st_disconnect(struct ull_cp_conn *conn, u8_t evt, void *param)
+static void lr_st_disconnect(struct ull_cp_conn *conn, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case LR_EVT_CONNECT:
@@ -185,7 +185,7 @@ static void lr_st_disconnect(struct ull_cp_conn *conn, u8_t evt, void *param)
 	}
 }
 
-static void lr_st_idle(struct ull_cp_conn *conn, u8_t evt, void *param)
+static void lr_st_idle(struct ull_cp_conn *conn, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case LR_EVT_RUN:
@@ -204,7 +204,7 @@ static void lr_st_idle(struct ull_cp_conn *conn, u8_t evt, void *param)
 	}
 }
 
-static void lr_st_active(struct ull_cp_conn *conn, u8_t evt, void *param)
+static void lr_st_active(struct ull_cp_conn *conn, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case LR_EVT_RUN:
@@ -226,7 +226,7 @@ static void lr_st_active(struct ull_cp_conn *conn, u8_t evt, void *param)
 	}
 }
 
-static void lr_execute_fsm(struct ull_cp_conn *conn, u8_t evt, void *param)
+static void lr_execute_fsm(struct ull_cp_conn *conn, uint8_t evt, void *param)
 {
 	switch (conn->llcp.local.state) {
 	case LR_STATE_DISCONNECT:

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
@@ -87,9 +87,9 @@ void ull_cp_priv_ntf_encode_unknown_rsp(struct proc_ctx *ctx,
  * Feature Exchange Procedure Helper
  */
 
-static void feature_filter(u8_t *featuresin, u64_t *featuresout)
+static void feature_filter(uint8_t *featuresin, uint64_t *featuresout)
 {
-	u64_t feat;
+	uint64_t feat;
 
 	/*
 	 * Note that in the split controller invalid bits are set
@@ -124,7 +124,7 @@ void ull_cp_priv_pdu_encode_feature_rsp(struct ull_cp_conn *conn,
 					struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_feature_rsp *p;
-	u64_t feature_rsp = LL_FEAT;
+	uint64_t feature_rsp = LL_FEAT;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
 	pdu->len = offsetof(struct pdu_data_llctrl, feature_rsp) +
@@ -159,7 +159,7 @@ void ull_cp_priv_ntf_encode_feature_rsp(struct ull_cp_conn *conn,
 void ull_cp_priv_pdu_decode_feature_req(struct ull_cp_conn *conn,
 					struct pdu_data *pdu)
 {
-	u64_t featureset;
+	uint64_t featureset;
 
 	feature_filter(pdu->llctrl.feature_req.features, &featureset);
 	conn->llcp.fex.features_used = LL_FEAT & featureset;
@@ -173,7 +173,7 @@ void ull_cp_priv_pdu_decode_feature_req(struct ull_cp_conn *conn,
 void ull_cp_priv_pdu_decode_feature_rsp(struct ull_cp_conn *conn,
 					struct pdu_data *pdu)
 {
-	u64_t featureset;
+	uint64_t featureset;
 
 	feature_filter(pdu->llctrl.feature_rsp.features, &featureset);
 	conn->llcp.fex.features_used = LL_FEAT & featureset;
@@ -208,8 +208,8 @@ void ull_cp_priv_pdu_decode_min_used_chans_ind(struct ull_cp_conn *conn, struct 
  */
 void ull_cp_priv_pdu_encode_version_ind(struct pdu_data *pdu)
 {
-	u16_t cid;
-	u16_t svn;
+	uint16_t cid;
+	uint16_t svn;
 	struct pdu_data_llctrl_version_ind *p;
 
 
@@ -295,7 +295,7 @@ void ull_cp_priv_pdu_encode_start_enc_rsp(struct pdu_data *pdu)
 	/* TODO(thoh): Fill in PDU with correct data */
 }
 
-void ull_cp_priv_pdu_encode_reject_ind(struct pdu_data *pdu, u8_t error_code)
+void ull_cp_priv_pdu_encode_reject_ind(struct pdu_data *pdu, uint8_t error_code)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
 	pdu->len = offsetof(struct pdu_data_llctrl, reject_ind) + sizeof(struct pdu_data_llctrl_reject_ind);
@@ -303,7 +303,7 @@ void ull_cp_priv_pdu_encode_reject_ind(struct pdu_data *pdu, u8_t error_code)
 	pdu->llctrl.reject_ind.error_code = error_code;
 }
 
-void ull_cp_priv_pdu_encode_reject_ext_ind(struct pdu_data *pdu, u8_t reject_opcode, u8_t error_code)
+void ull_cp_priv_pdu_encode_reject_ext_ind(struct pdu_data *pdu, uint8_t reject_opcode, uint8_t error_code)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
 	pdu->len = offsetof(struct pdu_data_llctrl, reject_ext_ind) + sizeof(struct pdu_data_llctrl_reject_ext_ind);
@@ -332,7 +332,7 @@ void ull_cp_priv_pdu_encode_phy_rsp(struct pdu_data *pdu)
 	/* TODO(thoh): Fill in PDU with correct data */
 }
 
-void ull_cp_priv_pdu_encode_phy_update_ind(struct pdu_data *pdu, u16_t instant)
+void ull_cp_priv_pdu_encode_phy_update_ind(struct pdu_data *pdu, uint16_t instant)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
 	pdu->len = offsetof(struct pdu_data_llctrl, phy_upd_ind) + sizeof(struct pdu_data_llctrl_phy_upd_ind);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -96,14 +96,14 @@ extern void ll_rx_enqueue(struct node_rx_pdu *rx);
  * LLCP Local Procedure PHY Update FSM
  */
 
-static u16_t lp_event_counter(struct ull_cp_conn *conn)
+static uint16_t lp_event_counter(struct ull_cp_conn *conn)
 {
 	/* TODO(thoh): Mocked lll_conn */
 	struct mocked_lll_conn *lll;
-	u16_t event_counter;
+	uint16_t event_counter;
 
 	/* TODO(thoh): Lazy hardcoded */
-	u16_t lazy = 0;
+	uint16_t lazy = 0;
 
 	/**/
 	lll = &conn->lll;
@@ -114,7 +114,7 @@ static u16_t lp_event_counter(struct ull_cp_conn *conn)
 	return event_counter;
 }
 
-static void lp_pu_tx(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t opcode)
+static void lp_pu_tx(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
 {
 	struct node_tx *tx;
 	struct pdu_data *pdu;
@@ -161,7 +161,7 @@ static void lp_pu_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx)
 	ll_rx_enqueue(ntf);
 }
 
-static void lp_pu_complete(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_pu_complete(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	if (!ntf_alloc_is_available()) {
 		ctx->state = LP_PU_STATE_WAIT_NTF;
@@ -172,7 +172,7 @@ static void lp_pu_complete(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t 
 	}
 }
 
-static void lp_pu_send_phy_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_pu_send_phy_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	if (!tx_alloc_is_available() || rr_get_collision(conn)) {
 		ctx->state = LP_PU_STATE_WAIT_TX_PHY_REQ;
@@ -197,7 +197,7 @@ static void lp_pu_send_phy_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, u
 	}
 }
 
-static void lp_pu_send_phy_update_ind(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_pu_send_phy_update_ind(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	if (!tx_alloc_is_available()) {
 		ctx->state = LP_PU_STATE_WAIT_TX_PHY_UPDATE_IND;
@@ -210,7 +210,7 @@ static void lp_pu_send_phy_update_ind(struct ull_cp_conn *conn, struct proc_ctx 
 	}
 }
 
-static void lp_pu_st_idle(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_pu_st_idle(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 	switch (evt) {
@@ -223,7 +223,7 @@ static void lp_pu_st_idle(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t e
 	}
 }
 
-static void lp_pu_st_wait_tx_phy_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_pu_st_wait_tx_phy_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case LP_PU_EVT_RUN:
@@ -235,7 +235,7 @@ static void lp_pu_st_wait_tx_phy_req(struct ull_cp_conn *conn, struct proc_ctx *
 	}
 }
 
-static void lp_pu_st_wait_rx_phy_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_pu_st_wait_rx_phy_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case LP_PU_EVT_RUN:
@@ -260,7 +260,7 @@ static void lp_pu_st_wait_rx_phy_rsp(struct ull_cp_conn *conn, struct proc_ctx *
 	}
 }
 
-static void lp_pu_st_wait_tx_phy_update_ind(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_pu_st_wait_tx_phy_update_ind(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case LP_PU_EVT_RUN:
@@ -272,7 +272,7 @@ static void lp_pu_st_wait_tx_phy_update_ind(struct ull_cp_conn *conn, struct pro
 	}
 }
 
-static void lp_pu_st_wait_rx_phy_update_ind(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_pu_st_wait_rx_phy_update_ind(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case LP_PU_EVT_PHY_UPDATE_IND:
@@ -289,9 +289,9 @@ static void lp_pu_st_wait_rx_phy_update_ind(struct ull_cp_conn *conn, struct pro
 	}
 }
 
-static void lp_pu_check_instant(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_pu_check_instant(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
-	u16_t event_counter = lp_event_counter(conn);
+	uint16_t event_counter = lp_event_counter(conn);
 	if (((event_counter - ctx->data.pu.instant) & 0xFFFF) <= 0x7FFF) {
 		rr_set_incompat(conn, INCOMPAT_NO_COLLISION);
 		ctx->data.pu.error = BT_HCI_ERR_SUCCESS;
@@ -299,7 +299,7 @@ static void lp_pu_check_instant(struct ull_cp_conn *conn, struct proc_ctx *ctx, 
 	}
 }
 
-static void lp_pu_st_wait_instant(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_pu_st_wait_instant(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 	switch (evt) {
@@ -312,7 +312,7 @@ static void lp_pu_st_wait_instant(struct ull_cp_conn *conn, struct proc_ctx *ctx
 	}
 }
 
-static void lp_pu_st_wait_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_pu_st_wait_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case LP_PU_EVT_RUN:
@@ -324,7 +324,7 @@ static void lp_pu_st_wait_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8
 	}
 }
 
-static void lp_pu_execute_fsm(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void lp_pu_execute_fsm(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (ctx->state) {
 	case LP_PU_STATE_IDLE:
@@ -391,14 +391,14 @@ void ull_cp_priv_lp_pu_run(struct ull_cp_conn *conn, struct proc_ctx *ctx, void 
  * LLCP Remote Procedure PHY Update FSM
  */
 
-static u16_t rp_event_counter(struct ull_cp_conn *conn)
+static uint16_t rp_event_counter(struct ull_cp_conn *conn)
 {
 	/* TODO(thoh): Mocked lll_conn */
 	struct mocked_lll_conn *lll;
-	u16_t event_counter;
+	uint16_t event_counter;
 
 	/* TODO(thoh): Lazy hardcoded */
-	u16_t lazy = 0;
+	uint16_t lazy = 0;
 
 	/**/
 	lll = &conn->lll;
@@ -409,7 +409,7 @@ static u16_t rp_event_counter(struct ull_cp_conn *conn)
 	return event_counter;
 }
 
-static void rp_pu_tx(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t opcode)
+static void rp_pu_tx(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
 {
 	struct node_tx *tx;
 	struct pdu_data *pdu;
@@ -456,7 +456,7 @@ static void rp_pu_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx)
 	ll_rx_enqueue(ntf);
 }
 
-static void rp_pu_complete(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_pu_complete(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	if (!ntf_alloc_is_available()) {
 		ctx->state = RP_PU_STATE_WAIT_NTF;
@@ -467,7 +467,7 @@ static void rp_pu_complete(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t 
 	}
 }
 
-static void rp_pu_send_phy_update_ind(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_pu_send_phy_update_ind(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	if (!tx_alloc_is_available()) {
 		ctx->state = RP_PU_STATE_WAIT_TX_PHY_UPDATE_IND;
@@ -480,7 +480,7 @@ static void rp_pu_send_phy_update_ind(struct ull_cp_conn *conn, struct proc_ctx 
 	}
 }
 
-static void rp_pu_send_phy_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_pu_send_phy_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	if (!tx_alloc_is_available()) {
 		ctx->state = RP_PU_STATE_WAIT_TX_PHY_RSP;
@@ -491,7 +491,7 @@ static void rp_pu_send_phy_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, u
 	}
 }
 
-static void rp_pu_st_idle(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_pu_st_idle(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 	switch (evt) {
@@ -504,7 +504,7 @@ static void rp_pu_st_idle(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t e
 	}
 }
 
-static void rp_pu_st_wait_rx_phy_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_pu_st_wait_rx_phy_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case RP_PU_EVT_PHY_REQ:
@@ -526,7 +526,7 @@ static void rp_pu_st_wait_rx_phy_req(struct ull_cp_conn *conn, struct proc_ctx *
 	}
 }
 
-static void rp_pu_st_wait_tx_phy_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_pu_st_wait_tx_phy_rsp(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case RP_PU_EVT_RUN:
@@ -538,7 +538,7 @@ static void rp_pu_st_wait_tx_phy_rsp(struct ull_cp_conn *conn, struct proc_ctx *
 	}
 }
 
-static void rp_pu_st_wait_tx_phy_update_ind(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_pu_st_wait_tx_phy_update_ind(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case RP_PU_EVT_RUN:
@@ -550,7 +550,7 @@ static void rp_pu_st_wait_tx_phy_update_ind(struct ull_cp_conn *conn, struct pro
 	}
 }
 
-static void rp_pu_st_wait_rx_phy_update_ind(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_pu_st_wait_rx_phy_update_ind(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case RP_PU_EVT_PHY_UPDATE_IND:
@@ -563,16 +563,16 @@ static void rp_pu_st_wait_rx_phy_update_ind(struct ull_cp_conn *conn, struct pro
 	}
 }
 
-static void rp_pu_check_instant(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_pu_check_instant(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
-	u16_t event_counter = rp_event_counter(conn);
+	uint16_t event_counter = rp_event_counter(conn);
 	if (((event_counter - ctx->data.pu.instant) & 0xFFFF) <= 0x7FFF) {
 		ctx->data.pu.error = BT_HCI_ERR_SUCCESS;
 		rp_pu_complete(conn, ctx, evt, param);
 	}
 }
 
-static void rp_pu_st_wait_instant(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_pu_st_wait_instant(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	/* TODO */
 	switch (evt) {
@@ -585,7 +585,7 @@ static void rp_pu_st_wait_instant(struct ull_cp_conn *conn, struct proc_ctx *ctx
 	}
 }
 
-static void rp_pu_st_wait_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_pu_st_wait_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case RP_PU_EVT_RUN:
@@ -597,7 +597,7 @@ static void rp_pu_st_wait_ntf(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8
 	}
 }
 
-static void rp_pu_execute_fsm(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t evt, void *param)
+static void rp_pu_execute_fsm(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (ctx->state) {
 	case RP_PU_STATE_IDLE:

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -206,7 +206,7 @@ static void rr_act_run(struct ull_cp_conn *conn)
 	}
 }
 
-static void rr_tx(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_t opcode)
+static void rr_tx(struct ull_cp_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
 {
 	struct node_tx *tx;
 	struct pdu_data *pdu;
@@ -267,7 +267,7 @@ static void rr_act_disconnect(struct ull_cp_conn *conn)
 	rr_dequeue(conn);
 }
 
-static void rr_st_disconnect(struct ull_cp_conn *conn, u8_t evt, void *param)
+static void rr_st_disconnect(struct ull_cp_conn *conn, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case RR_EVT_CONNECT:
@@ -280,7 +280,7 @@ static void rr_st_disconnect(struct ull_cp_conn *conn, u8_t evt, void *param)
 	}
 }
 
-static void rr_st_idle(struct ull_cp_conn *conn, u8_t evt, void *param)
+static void rr_st_idle(struct ull_cp_conn *conn, uint8_t evt, void *param)
 {
 	struct proc_ctx *ctx;
 
@@ -347,13 +347,13 @@ static void rr_st_idle(struct ull_cp_conn *conn, u8_t evt, void *param)
 		break;
 	}
 }
-static void rr_st_reject(struct ull_cp_conn *conn, u8_t evt, void *param)
+static void rr_st_reject(struct ull_cp_conn *conn, uint8_t evt, void *param)
 {
 	/* TODO */
 	LL_ASSERT(0);
 }
 
-static void rr_st_active(struct ull_cp_conn *conn, u8_t evt, void *param)
+static void rr_st_active(struct ull_cp_conn *conn, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case RR_EVT_RUN:
@@ -375,7 +375,7 @@ static void rr_st_active(struct ull_cp_conn *conn, u8_t evt, void *param)
 	}
 }
 
-static void rr_execute_fsm(struct ull_cp_conn *conn, u8_t evt, void *param)
+static void rr_execute_fsm(struct ull_cp_conn *conn, uint8_t evt, void *param)
 {
 	switch (conn->llcp.remote.state) {
 	case RR_STATE_DISCONNECT:
@@ -434,7 +434,7 @@ void ull_cp_priv_rr_new(struct ull_cp_conn *conn, struct node_rx_pdu *rx)
 {
 	struct proc_ctx *ctx;
 	struct pdu_data *pdu;
-	u8_t proc;
+	uint8_t proc;
 
 	pdu = (struct pdu_data *) rx->pdu;
 

--- a/tests/bluetooth/controller/common/include/helper_pdu.h
+++ b/tests/bluetooth/controller/common/include/helper_pdu.h
@@ -31,39 +31,39 @@ void helper_pdu_encode_phy_rsp(struct pdu_data *pdu, void *param);
 void helper_pdu_encode_phy_update_ind(struct pdu_data *pdu, void *param);
 void helper_pdu_encode_unknown_rsp(struct pdu_data *pdu, void *param);
 
-void helper_pdu_verify_ping_req(const char *file, u32_t line, struct pdu_data *pdu, void *param);
-void helper_pdu_verify_ping_rsp(const char *file, u32_t line, struct pdu_data *pdu, void *param);
+void helper_pdu_verify_ping_req(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
+void helper_pdu_verify_ping_rsp(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
 
 
-void helper_pdu_verify_feature_req(const char *file, u32_t line,
+void helper_pdu_verify_feature_req(const char *file, uint32_t line,
 				   struct pdu_data *pdu, void *param);
-void helper_pdu_verify_slave_feature_req(const char *file, u32_t line,
+void helper_pdu_verify_slave_feature_req(const char *file, uint32_t line,
 					 struct pdu_data *pdu, void *param);
-void helper_pdu_verify_feature_rsp(const char *file, u32_t line,
+void helper_pdu_verify_feature_rsp(const char *file, uint32_t line,
 				   struct pdu_data *pdu, void *param);
 
-void helper_pdu_verify_min_used_chans_ind(const char *file, u32_t line, struct pdu_data *pdu, void *param);
+void helper_pdu_verify_min_used_chans_ind(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
 
-void helper_pdu_verify_version_ind(const char *file, u32_t line, struct pdu_data *pdu, void *param);
+void helper_pdu_verify_version_ind(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
 
-void helper_pdu_verify_enc_req(const char *file, u32_t line, struct pdu_data *pdu, void *param);
+void helper_pdu_verify_enc_req(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
 
-void helper_pdu_verify_enc_rsp(const char *file, u32_t line, struct pdu_data *pdu, void *param);
+void helper_pdu_verify_enc_rsp(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
 
-void helper_pdu_verify_start_enc_req(const char *file, u32_t line, struct pdu_data *pdu, void *param);
+void helper_pdu_verify_start_enc_req(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
 
-void helper_pdu_verify_start_enc_rsp(const char *file, u32_t line, struct pdu_data *pdu, void *param);
+void helper_pdu_verify_start_enc_rsp(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
 
-void helper_pdu_verify_reject_ind(const char *file, u32_t line, struct pdu_data *pdu, void *param);
+void helper_pdu_verify_reject_ind(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
 
-void helper_pdu_verify_reject_ext_ind(const char *file, u32_t line, struct pdu_data *pdu, void *param);
+void helper_pdu_verify_reject_ext_ind(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
 
-void helper_pdu_verify_phy_req(const char *file, u32_t line, struct pdu_data *pdu, void *param);
-void helper_pdu_verify_phy_rsp(const char *file, u32_t line, struct pdu_data *pdu, void *param);
-void helper_pdu_verify_phy_update_ind(const char *file, u32_t line, struct pdu_data *pdu, void *param);
-void helper_pdu_verify_unknown_rsp(const char *file, u32_t line, struct pdu_data *pdu, void *param);
+void helper_pdu_verify_phy_req(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
+void helper_pdu_verify_phy_rsp(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
+void helper_pdu_verify_phy_update_ind(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
+void helper_pdu_verify_unknown_rsp(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
 
-void helper_node_verify_phy_update(const char *file, u32_t line,
+void helper_node_verify_phy_update(const char *file, uint32_t line,
 				   struct node_rx_pdu *rx, void *param);
 
 
@@ -93,7 +93,7 @@ typedef enum {
 } helper_node_opcode_t;
 
 typedef void (helper_pdu_encode_func_t) (struct pdu_data *data, void *param);
-typedef void (helper_pdu_verify_func_t) (const char *file, u32_t line, struct pdu_data *data, void *param);
+typedef void (helper_pdu_verify_func_t) (const char *file, uint32_t line, struct pdu_data *data, void *param);
 
-typedef void (helper_node_verify_func_t) (const char *file, u32_t line, struct node_rx_pdu *rx, void *param);
-typedef void (helper_func_t) (const char *file, u32_t line, struct pdu_data *data, void *param);
+typedef void (helper_node_verify_func_t) (const char *file, uint32_t line, struct node_rx_pdu *rx, void *param);
+typedef void (helper_func_t) (const char *file, uint32_t line, struct pdu_data *data, void *param);

--- a/tests/bluetooth/controller/common/include/helper_util.h
+++ b/tests/bluetooth/controller/common/include/helper_util.h
@@ -7,12 +7,12 @@
 
 void test_print_conn(struct ull_cp_conn *conn);
 
-void test_set_role(struct ull_cp_conn *conn, u8_t role);
+void test_set_role(struct ull_cp_conn *conn, uint8_t role);
 void test_setup(struct ull_cp_conn *conn);
 void event_prepare(struct ull_cp_conn *conn);
 void event_tx_ack(struct ull_cp_conn *conn, struct node_tx *tx);
 void event_done(struct ull_cp_conn *conn);
-u16_t event_counter(struct ull_cp_conn *conn);
+uint16_t event_counter(struct ull_cp_conn *conn);
 
 
 
@@ -24,9 +24,9 @@ u16_t event_counter(struct ull_cp_conn *conn);
 #define ut_rx_node(_opcode, _ntf_ref, _param) ut_rx_node_real(__FILE__, __LINE__, _opcode, _ntf_ref, _param)
 #define ut_rx_q_is_empty() ut_rx_q_is_empty_real(__FILE__, __LINE__)
 
-void lt_tx_real(const char *file, u32_t line, helper_pdu_opcode_t opcode, struct ull_cp_conn *conn, void *param);
-void lt_rx_real(const char *file, u32_t line, helper_pdu_opcode_t opcode, struct ull_cp_conn *conn, struct node_tx **tx_ref, void *param);
-void lt_rx_q_is_empty_real(const char *file, u32_t line, struct ull_cp_conn *conn);
-void ut_rx_pdu_real(const char *file, u32_t line, helper_pdu_opcode_t opcode, struct node_rx_pdu **ntf_ref, void *param);
-void ut_rx_node_real(const char *file, u32_t line, helper_node_opcode_t opcode, struct node_rx_pdu **ntf_ref, void *param);
-void ut_rx_q_is_empty_real(const char *file, u32_t line);
+void lt_tx_real(const char *file, uint32_t line, helper_pdu_opcode_t opcode, struct ull_cp_conn *conn, void *param);
+void lt_rx_real(const char *file, uint32_t line, helper_pdu_opcode_t opcode, struct ull_cp_conn *conn, struct node_tx **tx_ref, void *param);
+void lt_rx_q_is_empty_real(const char *file, uint32_t line, struct ull_cp_conn *conn);
+void ut_rx_pdu_real(const char *file, uint32_t line, helper_pdu_opcode_t opcode, struct node_rx_pdu **ntf_ref, void *param);
+void ut_rx_node_real(const char *file, uint32_t line, helper_node_opcode_t opcode, struct node_rx_pdu **ntf_ref, void *param);
+void ut_rx_q_is_empty_real(const char *file, uint32_t line);

--- a/tests/bluetooth/controller/common/src/helper_pdu.c
+++ b/tests/bluetooth/controller/common/src/helper_pdu.c
@@ -58,7 +58,7 @@ void helper_pdu_encode_feature_req(struct pdu_data *pdu, void *param)
 		sizeof(struct pdu_data_llctrl_feature_req);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_FEATURE_REQ;
 	for (int counter = 0; counter < 8; counter++) {
-		u8_t expected_value = feature_req->features[counter];
+		uint8_t expected_value = feature_req->features[counter];
 		pdu->llctrl.feature_req.features[counter] = expected_value;
 	}
 }
@@ -72,7 +72,7 @@ void helper_pdu_encode_slave_feature_req(struct pdu_data *pdu, void *param)
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_SLAVE_FEATURE_REQ;
 
 	for (int counter = 0 ; counter < 8; counter++)	{
-		u8_t expected_value = feature_req->features[counter];
+		uint8_t expected_value = feature_req->features[counter];
 		pdu->llctrl.feature_req.features[counter] = expected_value;
 	}
 }
@@ -86,7 +86,7 @@ void helper_pdu_encode_feature_rsp(struct pdu_data *pdu, void *param)
 		sizeof(struct pdu_data_llctrl_feature_rsp);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_FEATURE_RSP;
 	for (int counter = 0; counter < 8; counter++) {
-		u8_t expected_value = feature_rsp->features[counter];
+		uint8_t expected_value = feature_rsp->features[counter];
 		pdu->llctrl.feature_req.features[counter] = expected_value;
 	}
 }
@@ -198,7 +198,7 @@ void helper_pdu_encode_unknown_rsp(struct pdu_data *pdu, void *param)
 	pdu->llctrl.unknown_rsp.type = p->type;
 }
 
-void helper_pdu_verify_version_ind(const char *file, u32_t line, struct pdu_data *pdu, void *param)
+void helper_pdu_verify_version_ind(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
 {
 	struct pdu_data_llctrl_version_ind *p = param;
 
@@ -209,20 +209,20 @@ void helper_pdu_verify_version_ind(const char *file, u32_t line, struct pdu_data
 	zassert_equal(pdu->llctrl.version_ind.sub_version_number, p->sub_version_number, "Wrong sub version number.\nCalled at %s:%d\n", file, line);
 }
 
-void helper_pdu_verify_ping_req(const char *file, u32_t line, struct pdu_data *pdu, void *param)
+void helper_pdu_verify_ping_req(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
 {
 	zassert_equal(pdu->ll_id, PDU_DATA_LLID_CTRL, "Not a Control PDU.\nCalled at %s:%d\n", file, line);
 	zassert_equal(pdu->llctrl.opcode, PDU_DATA_LLCTRL_TYPE_PING_REQ, "Not a LL_PING_REQ. Called at %s:%d\n", file, line);
 }
 
-void helper_pdu_verify_ping_rsp(const char *file, u32_t line, struct pdu_data *pdu, void *param)
+void helper_pdu_verify_ping_rsp(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
 {
 	zassert_equal(pdu->ll_id, PDU_DATA_LLID_CTRL, "Not a Control PDU.\nCalled at %s:%d\n", file, line);
 	zassert_equal(pdu->llctrl.opcode, PDU_DATA_LLCTRL_TYPE_PING_RSP, "Not a LL_PING_RSP.\nCalled at %s:%d\n", file, line);
 }
 
 
-void helper_pdu_verify_feature_req(const char *file, u32_t line,
+void helper_pdu_verify_feature_req(const char *file, uint32_t line,
 				   struct pdu_data *pdu, void *param)
 {
 	struct pdu_data_llctrl_feature_req *feature_req = param;
@@ -232,7 +232,7 @@ void helper_pdu_verify_feature_req(const char *file, u32_t line,
 		      "Wrong opcode.\nCalled at %s:%d\n", file, line);
 
 	for (int counter = 0; counter < 8; counter++) {
-		u8_t expected_value = feature_req->features[counter];
+		uint8_t expected_value = feature_req->features[counter];
 		zassert_equal(pdu->llctrl.feature_req.features[counter],
 			      expected_value,
 			      "Wrong feature exchange data.\nAt %s:%d\n",
@@ -240,7 +240,7 @@ void helper_pdu_verify_feature_req(const char *file, u32_t line,
 	}
 }
 
-void helper_pdu_verify_slave_feature_req(const char *file, u32_t line,
+void helper_pdu_verify_slave_feature_req(const char *file, uint32_t line,
 					 struct pdu_data *pdu, void *param)
 {
 	struct pdu_data_llctrl_feature_req *feature_req = param;
@@ -249,14 +249,14 @@ void helper_pdu_verify_slave_feature_req(const char *file, u32_t line,
 	zassert_equal(pdu->llctrl.opcode, PDU_DATA_LLCTRL_TYPE_SLAVE_FEATURE_REQ, NULL);
 
 	for (int counter = 0; counter < 8; counter++) {
-		u8_t expected_value = feature_req->features[counter];
+		uint8_t expected_value = feature_req->features[counter];
 		zassert_equal(pdu->llctrl.feature_req.features[counter],
 			      expected_value,
 			      "Wrong feature data\nCalled at %s:%d\n",
 			      file, line);
 	}
 }
-void helper_pdu_verify_feature_rsp(const char *file, u32_t line,
+void helper_pdu_verify_feature_rsp(const char *file, uint32_t line,
 				   struct pdu_data *pdu, void *param)
 {
 	struct pdu_data_llctrl_feature_rsp *feature_rsp = param;
@@ -267,7 +267,7 @@ void helper_pdu_verify_feature_rsp(const char *file, u32_t line,
 		      pdu->llctrl.opcode, PDU_DATA_LLCTRL_TYPE_FEATURE_RSP);
 
 	for (int counter = 0; counter < 8; counter++) {
-		u8_t expected_value = feature_rsp->features[counter];
+		uint8_t expected_value = feature_rsp->features[counter];
 		zassert_equal(pdu->llctrl.feature_rsp.features[counter],
 			      expected_value,
 			      "Wrong feature data\nCalled at %s:%d\n",
@@ -275,7 +275,7 @@ void helper_pdu_verify_feature_rsp(const char *file, u32_t line,
 	}
 }
 
-void helper_pdu_verify_min_used_chans_ind(const char *file, u32_t line, struct pdu_data *pdu, void *param)
+void helper_pdu_verify_min_used_chans_ind(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
 {
 	struct pdu_data_llctrl_min_used_chans_ind *p = param;
 
@@ -285,31 +285,31 @@ void helper_pdu_verify_min_used_chans_ind(const char *file, u32_t line, struct p
 	zassert_equal(pdu->llctrl.min_used_chans_ind.min_used_chans, p->min_used_chans, "Channel count\nCalled at %s:%d\n", file, line);
 }
 
-void helper_pdu_verify_enc_req(const char *file, u32_t line, struct pdu_data *pdu, void *param)
+void helper_pdu_verify_enc_req(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
 {
 	zassert_equal(pdu->ll_id, PDU_DATA_LLID_CTRL, "Not a Control PDU.\nCalled at %s:%d\n", file, line);
 	zassert_equal(pdu->llctrl.opcode, PDU_DATA_LLCTRL_TYPE_ENC_REQ, "Not a LL_ENC_REQ. Called at %s:%d\n", file, line);
 }
 
-void helper_pdu_verify_enc_rsp(const char *file, u32_t line, struct pdu_data *pdu, void *param)
+void helper_pdu_verify_enc_rsp(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
 {
 	zassert_equal(pdu->ll_id, PDU_DATA_LLID_CTRL, "Not a Control PDU.\nCalled at %s:%d\n", file, line);
 	zassert_equal(pdu->llctrl.opcode, PDU_DATA_LLCTRL_TYPE_ENC_RSP, "Not a LL_ENC_RSP.\nCalled at %s:%d\n", file, line);
 }
 
-void helper_pdu_verify_start_enc_req(const char *file, u32_t line, struct pdu_data *pdu, void *param)
+void helper_pdu_verify_start_enc_req(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
 {
 	zassert_equal(pdu->ll_id, PDU_DATA_LLID_CTRL, "Not a Control PDU.\nCalled at %s:%d\n", file, line);
 	zassert_equal(pdu->llctrl.opcode, PDU_DATA_LLCTRL_TYPE_START_ENC_REQ, "Not a LL_START_ENC_REQ.\nCalled at %s:%d\n", file, line);
 }
 
-void helper_pdu_verify_start_enc_rsp(const char *file, u32_t line, struct pdu_data *pdu, void *param)
+void helper_pdu_verify_start_enc_rsp(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
 {
 	zassert_equal(pdu->ll_id, PDU_DATA_LLID_CTRL, "Not a Control PDU.\nCalled at %s:%d\n", file, line);
 	zassert_equal(pdu->llctrl.opcode, PDU_DATA_LLCTRL_TYPE_START_ENC_RSP, "Not a LL_START_ENC_RSP.\nCalled at %s:%d\n", file, line);
 }
 
-void helper_pdu_verify_reject_ind(const char *file, u32_t line, struct pdu_data *pdu, void *param)
+void helper_pdu_verify_reject_ind(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
 {
 	struct pdu_data_llctrl_reject_ind *p = param;
 
@@ -319,7 +319,7 @@ void helper_pdu_verify_reject_ind(const char *file, u32_t line, struct pdu_data 
 	zassert_equal(pdu->llctrl.reject_ind.error_code, p->error_code, "Error code mismatch.\nCalled at %s:%d\n", file, line);
 }
 
-void helper_pdu_verify_reject_ext_ind(const char *file, u32_t line, struct pdu_data *pdu, void *param)
+void helper_pdu_verify_reject_ext_ind(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
 {
 	struct pdu_data_llctrl_reject_ext_ind *p = param;
 
@@ -330,7 +330,7 @@ void helper_pdu_verify_reject_ext_ind(const char *file, u32_t line, struct pdu_d
 	zassert_equal(pdu->llctrl.reject_ext_ind.error_code, p->error_code, "Error code mismatch.\nCalled at %s:%d\n", file, line);
 }
 
-void helper_pdu_verify_phy_req(const char *file, u32_t line, struct pdu_data *pdu, void *param)
+void helper_pdu_verify_phy_req(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
 {
 	zassert_equal(pdu->ll_id, PDU_DATA_LLID_CTRL, "Not a Control PDU.\nCalled at %s:%d\n", file, line);
 	zassert_equal(pdu->len, offsetof(struct pdu_data_llctrl, phy_req) + sizeof(struct pdu_data_llctrl_phy_req), "Wrong length.\nCalled at %s:%d\n", file, line);
@@ -338,7 +338,7 @@ void helper_pdu_verify_phy_req(const char *file, u32_t line, struct pdu_data *pd
 	/* TODO(thoh): Fill in correct data */
 }
 
-void helper_pdu_verify_phy_rsp(const char *file, u32_t line, struct pdu_data *pdu, void *param)
+void helper_pdu_verify_phy_rsp(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
 {
 	zassert_equal(pdu->ll_id, PDU_DATA_LLID_CTRL, "Not a Control PDU.\nCalled at %s:%d\n", file, line);
 	zassert_equal(pdu->len, offsetof(struct pdu_data_llctrl, phy_rsp) + sizeof(struct pdu_data_llctrl_phy_rsp), "Wrong length.\nCalled at %s:%d\n", file, line);
@@ -346,7 +346,7 @@ void helper_pdu_verify_phy_rsp(const char *file, u32_t line, struct pdu_data *pd
 	/* TODO(thoh): Fill in correct data */
 }
 
-void helper_pdu_verify_phy_update_ind(const char *file, u32_t line, struct pdu_data *pdu, void *param)
+void helper_pdu_verify_phy_update_ind(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
 {
 	zassert_equal(pdu->ll_id, PDU_DATA_LLID_CTRL, "Not a Control PDU.\nCalled at %s:%d\n", file, line);
 	zassert_equal(pdu->len, offsetof(struct pdu_data_llctrl, phy_upd_ind) + sizeof(struct pdu_data_llctrl_phy_upd_ind), "Wrong length.\nCalled at %s:%d\n", file, line);
@@ -354,7 +354,7 @@ void helper_pdu_verify_phy_update_ind(const char *file, u32_t line, struct pdu_d
 	/* TODO(thoh): Fill in correct data */
 }
 
-void helper_node_verify_phy_update(const char *file, u32_t line, struct node_rx_pdu *rx, void *param)
+void helper_node_verify_phy_update(const char *file, uint32_t line, struct node_rx_pdu *rx, void *param)
 {
 	struct node_rx_pu *pdu = (struct node_rx_pu *)rx->pdu;
 	struct node_rx_pu *p = param;
@@ -364,7 +364,7 @@ void helper_node_verify_phy_update(const char *file, u32_t line, struct node_rx_
 }
 
 
-void helper_pdu_verify_unknown_rsp(const char *file, u32_t line, struct pdu_data *pdu, void *param)
+void helper_pdu_verify_unknown_rsp(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
 {
 	struct pdu_data_llctrl_unknown_rsp *p = param;
 

--- a/tests/bluetooth/controller/common/src/helper_util.c
+++ b/tests/bluetooth/controller/common/src/helper_util.c
@@ -34,8 +34,8 @@
 #include "helper_pdu.h"
 #include "helper_util.h"
 
-static u32_t event_active;
-static u16_t lazy;
+static uint32_t event_active;
+static uint16_t lazy;
 sys_slist_t ut_rx_q;
 static sys_slist_t lt_tx_q;
 
@@ -130,7 +130,7 @@ void test_setup(struct ull_cp_conn *conn)
 	lazy = 0;
 }
 
-void test_set_role(struct ull_cp_conn *conn, u8_t role)
+void test_set_role(struct ull_cp_conn *conn, uint8_t role)
 {
 	conn->lll.role = role;
 }
@@ -156,7 +156,7 @@ void event_prepare(struct ull_cp_conn *conn)
 	lll->latency_prepare += lazy;
 
 	/* Calc current event counter value */
-	u16_t event_counter = lll->event_counter + lll->latency_prepare;
+	uint16_t event_counter = lll->event_counter + lll->latency_prepare;
 
 	/* Store the next event counter value */
 	lll->event_counter = event_counter + 1;
@@ -189,11 +189,11 @@ void event_done(struct ull_cp_conn *conn)
 	}
 }
 
-u16_t event_counter(struct ull_cp_conn *conn)
+uint16_t event_counter(struct ull_cp_conn *conn)
 {
 	/* TODO(thoh): Mocked lll_conn */
 	struct mocked_lll_conn *lll;
-	u16_t event_counter;
+	uint16_t event_counter;
 
 	/**/
 	lll = &conn->lll;
@@ -211,7 +211,7 @@ u16_t event_counter(struct ull_cp_conn *conn)
 }
 
 
-void lt_tx_real(const char *file, u32_t line, helper_pdu_opcode_t opcode, struct ull_cp_conn *conn, void *param)
+void lt_tx_real(const char *file, uint32_t line, helper_pdu_opcode_t opcode, struct ull_cp_conn *conn, void *param)
 {
 	struct pdu_data *pdu;
 	struct node_rx_pdu *rx;
@@ -227,7 +227,7 @@ void lt_tx_real(const char *file, u32_t line, helper_pdu_opcode_t opcode, struct
 }
 
 
-void lt_rx_real(const char *file, u32_t line, helper_pdu_opcode_t opcode, struct ull_cp_conn *conn, struct node_tx **tx_ref, void *param)
+void lt_rx_real(const char *file, uint32_t line, helper_pdu_opcode_t opcode, struct ull_cp_conn *conn, struct node_tx **tx_ref, void *param)
 {
 	struct node_tx *tx;
 	struct pdu_data *pdu;
@@ -245,7 +245,7 @@ void lt_rx_real(const char *file, u32_t line, helper_pdu_opcode_t opcode, struct
 }
 
 
-void lt_rx_q_is_empty_real(const char *file, u32_t line, struct ull_cp_conn *conn)
+void lt_rx_q_is_empty_real(const char *file, uint32_t line, struct ull_cp_conn *conn)
 {
 	struct node_tx *tx;
 
@@ -255,7 +255,7 @@ void lt_rx_q_is_empty_real(const char *file, u32_t line, struct ull_cp_conn *con
 
 
 
-void ut_rx_pdu_real(const char *file, u32_t line, helper_pdu_opcode_t opcode, struct node_rx_pdu **ntf_ref, void *param)
+void ut_rx_pdu_real(const char *file, uint32_t line, helper_pdu_opcode_t opcode, struct node_rx_pdu **ntf_ref, void *param)
 {
 	struct pdu_data *pdu;
 	struct node_rx_pdu *ntf;
@@ -274,7 +274,7 @@ void ut_rx_pdu_real(const char *file, u32_t line, helper_pdu_opcode_t opcode, st
 }
 
 
-void ut_rx_node_real(const char *file, u32_t line, helper_node_opcode_t opcode, struct node_rx_pdu **ntf_ref, void *param)
+void ut_rx_node_real(const char *file, uint32_t line, helper_node_opcode_t opcode, struct node_rx_pdu **ntf_ref, void *param)
 {
 	struct node_rx_pdu *ntf;
 
@@ -291,7 +291,7 @@ void ut_rx_node_real(const char *file, u32_t line, helper_node_opcode_t opcode, 
 }
 
 
-void ut_rx_q_is_empty_real(const char *file, u32_t line)
+void ut_rx_q_is_empty_real(const char *file, uint32_t line)
 {
 	struct node_rx_pdu *ntf;
 

--- a/tests/bluetooth/controller/ctrl_encrypt/src/main.c
+++ b/tests/bluetooth/controller/ctrl_encrypt/src/main.c
@@ -79,7 +79,7 @@ static void setup(void)
  */
 void test_encryption_start_mas_loc(void)
 {
-	u8_t err;
+	uint8_t err;
 	struct node_tx *tx;
 	struct node_rx_pdu *ntf;
 
@@ -183,7 +183,7 @@ void test_encryption_start_mas_loc(void)
  */
 void test_encryption_start_mas_loc_limited_memory(void)
 {
-	u8_t err;
+	uint8_t err;
 	struct node_tx *tx;
 	struct node_rx_pdu *ntf;
 
@@ -312,7 +312,7 @@ void test_encryption_start_mas_loc_limited_memory(void)
  */
 void test_encryption_start_mas_loc_no_ltk(void)
 {
-	u8_t err;
+	uint8_t err;
 	struct node_tx *tx;
 	struct node_rx_pdu *ntf;
 

--- a/tests/bluetooth/controller/ctrl_feature_exchange/src/main.c
+++ b/tests/bluetooth/controller/ctrl_feature_exchange/src/main.c
@@ -69,11 +69,11 @@ static void setup(void)
  */
 void test_feature_exchange_mas_loc(void)
 {
-	u64_t err;
-	u64_t set_featureset[] = {
+	uint64_t err;
+	uint64_t set_featureset[] = {
 		DEFAULT_FEATURE,
 		DEFAULT_FEATURE };
-	u64_t rsp_featureset[] = {
+	uint64_t rsp_featureset[] = {
 		(LL_FEAT_BIT_MASK_VALID & FEAT_FILTER_OCTET0) | DEFAULT_FEATURE,
 		0x0 };
 	int feat_to_test = ARRAY_SIZE(set_featureset);
@@ -123,7 +123,7 @@ void test_feature_exchange_mas_loc(void)
 
 void test_feature_exchange_mas_loc_2(void)
 {
-	u8_t err;
+	uint8_t err;
 
 	test_set_role(&conn, BT_HCI_ROLE_MASTER);
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
@@ -154,13 +154,13 @@ void test_feature_exchange_mas_loc_2(void)
 #define MAS_REM_NR_OF_EVENTS 2
 void test_feature_exchange_mas_rem(void)
 {
-	u64_t set_featureset[] = {
+	uint64_t set_featureset[] = {
 		DEFAULT_FEATURE,
 		LL_FEAT_BIT_MASK_VALID,
 		EXPECTED_FEAT_EXCH_VALID,
 		0xFFFFFFFFFFFFFFFF,
 		0x0 };
-	u64_t exp_featureset[] = {
+	uint64_t exp_featureset[] = {
 		DEFAULT_FEATURE,
 		DEFAULT_FEATURE,
 		DEFAULT_FEATURE,
@@ -212,25 +212,25 @@ void test_feature_exchange_mas_rem_2(void)
 	 * but in reality we should add some more
 	 * test cases
 	 */
-	u64_t set_featureset[] = {
+	uint64_t set_featureset[] = {
 		DEFAULT_FEATURE,
 		LL_FEAT_BIT_MASK_VALID,
 		EXPECTED_FEAT_EXCH_VALID,
 		0xFFFFFFFFFFFFFFFF,
 		0x0 };
-	u64_t exp_featureset[] = {
+	uint64_t exp_featureset[] = {
 		DEFAULT_FEATURE,
 		DEFAULT_FEATURE,
 		DEFAULT_FEATURE,
 		DEFAULT_FEATURE,
 		0x0 };
-	u64_t ut_featureset[] = {
+	uint64_t ut_featureset[] = {
 		DEFAULT_FEATURE,
 		DEFAULT_FEATURE,
 		DEFAULT_FEATURE,
 		DEFAULT_FEATURE,
 		DEFAULT_FEATURE };
-	u64_t ut_exp_featureset[] = {
+	uint64_t ut_exp_featureset[] = {
 		DEFAULT_FEATURE,
 		DEFAULT_FEATURE,
 		DEFAULT_FEATURE,
@@ -238,7 +238,7 @@ void test_feature_exchange_mas_rem_2(void)
 		0x00 };
 
 	int feat_to_test = ARRAY_SIZE(set_featureset);
-	u64_t err;
+	uint64_t err;
 	struct node_tx *tx;
 	struct node_rx_pdu *ntf;
 
@@ -299,8 +299,8 @@ void test_feature_exchange_mas_rem_2(void)
 
 void test_slave_feature_exchange_sla_loc(void)
 {
-	u64_t err;
-	u64_t featureset;
+	uint64_t err;
+	uint64_t featureset;
 	struct node_tx *tx;
 	struct node_rx_pdu *ntf;
 
@@ -339,8 +339,8 @@ void test_slave_feature_exchange_sla_loc(void)
 
 void test_feature_exchange_sla_loc_unknown_rsp(void)
 {
-	u64_t err;
-	u64_t featureset;
+	uint64_t err;
+	uint64_t featureset;
 	struct node_tx *tx;
 
 	struct pdu_data_llctrl_feature_req local_feature_req;

--- a/tests/bluetooth/controller/ctrl_le_ping/src/main.c
+++ b/tests/bluetooth/controller/ctrl_le_ping/src/main.c
@@ -59,7 +59,7 @@ static void setup(void)
  */
 void test_ping_mas_loc(void)
 {
-	u8_t err;
+	uint8_t err;
 	struct node_tx *tx;
 
 	struct pdu_data_llctrl_ping_req local_ping_req = {
@@ -116,7 +116,7 @@ void test_ping_mas_loc(void)
  */
 void test_ping_sla_loc(void)
 {
-	u8_t err;
+	uint8_t err;
 	struct node_tx *tx;
 
 	struct pdu_data_llctrl_ping_req local_ping_req = {

--- a/tests/bluetooth/controller/ctrl_min_used_chans/src/main.c
+++ b/tests/bluetooth/controller/ctrl_min_used_chans/src/main.c
@@ -59,7 +59,7 @@ static void setup(void)
  */
 void test_min_used_chans_sla_loc(void)
 {
-	u8_t err;
+	uint8_t err;
 	struct node_tx *tx;
 
 	struct pdu_data_llctrl_min_used_chans_ind local_muc_ind = {
@@ -107,7 +107,7 @@ void test_min_used_chans_sla_loc(void)
 
 void test_min_used_chans_mas_loc(void)
 {
-	u8_t err;
+	uint8_t err;
 
 	/* Role */
 	test_set_role(&conn, BT_HCI_ROLE_MASTER);

--- a/tests/bluetooth/controller/ctrl_phy_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_phy_update/src/main.c
@@ -41,7 +41,7 @@ static void setup(void)
 	test_setup(&conn);
 }
 
-static bool is_instant_reached(struct ull_cp_conn *conn, u16_t instant)
+static bool is_instant_reached(struct ull_cp_conn *conn, uint16_t instant)
 {
 	return ((event_counter(conn) - instant) & 0xFFFF) <= 0x7FFF;
 }
@@ -53,11 +53,11 @@ static bool is_instant_reached(struct ull_cp_conn *conn, u16_t instant)
  */
 void test_phy_update_mas_loc(void)
 {
-	u8_t err;
+	uint8_t err;
 	struct node_tx *tx;
 	struct node_rx_pdu *ntf;
 	struct pdu_data *pdu;
-	u16_t instant;
+	uint16_t instant;
 
 	struct node_rx_pu pu = {
 		.status = BT_HCI_ERR_SUCCESS
@@ -140,7 +140,7 @@ void test_phy_update_mas_loc(void)
 
 void test_phy_update_mas_loc_unsupp_feat(void)
 {
-	u8_t err;
+	uint8_t err;
 	struct node_tx *tx;
 	struct node_rx_pdu *ntf;
 
@@ -191,7 +191,7 @@ void test_phy_update_mas_rem(void)
 	struct node_tx *tx;
 	struct node_rx_pdu *ntf;
 	struct pdu_data *pdu;
-	u16_t instant;
+	uint16_t instant;
 
 	struct node_rx_pu pu = {
 		.status = BT_HCI_ERR_SUCCESS
@@ -263,10 +263,10 @@ void test_phy_update_mas_rem(void)
 
 void test_phy_update_sla_loc(void)
 {
-	u8_t err;
+	uint8_t err;
 	struct node_tx *tx;
 	struct node_rx_pdu *ntf;
-	u16_t instant;
+	uint16_t instant;
 
 	struct node_rx_pu pu = {
 		.status = BT_HCI_ERR_SUCCESS
@@ -346,7 +346,7 @@ void test_phy_update_sla_rem(void)
 {
 	struct node_tx *tx;
 	struct node_rx_pdu *ntf;
-	u16_t instant;
+	uint16_t instant;
 
 	struct node_rx_pu pu = {
 		.status = BT_HCI_ERR_SUCCESS
@@ -423,11 +423,11 @@ void test_phy_update_sla_rem(void)
 
 void test_phy_update_mas_loc_collision(void)
 {
-	u8_t err;
+	uint8_t err;
 	struct node_tx *tx;
 	struct node_rx_pdu *ntf;
 	struct pdu_data *pdu;
-	u16_t instant;
+	uint16_t instant;
 
 	struct pdu_data_llctrl_reject_ext_ind reject_ext_ind = {
 		.reject_opcode = PDU_DATA_LLCTRL_TYPE_PHY_REQ,
@@ -555,11 +555,11 @@ void test_phy_update_mas_loc_collision(void)
 
 void test_phy_update_mas_rem_collision(void)
 {
-	u8_t err;
+	uint8_t err;
 	struct node_tx *tx;
 	struct node_rx_pdu *ntf;
 	struct pdu_data *pdu;
-	u16_t instant;
+	uint16_t instant;
 
 	struct node_rx_pu pu = {
 		.status = BT_HCI_ERR_SUCCESS
@@ -698,10 +698,10 @@ void test_phy_update_mas_rem_collision(void)
 
 void test_phy_update_sla_loc_collision(void)
 {
-	u8_t err;
+	uint8_t err;
 	struct node_tx *tx;
 	struct node_rx_pdu *ntf;
-	u16_t instant;
+	uint16_t instant;
 
 	struct pdu_data_llctrl_reject_ext_ind reject_ext_ind = {
 		.reject_opcode = PDU_DATA_LLCTRL_TYPE_PHY_REQ,

--- a/tests/bluetooth/controller/ctrl_version/src/main.c
+++ b/tests/bluetooth/controller/ctrl_version/src/main.c
@@ -64,7 +64,7 @@ static void setup(void)
  */
 void test_version_exchange_mas_loc(void)
 {
-	u8_t err;
+	uint8_t err;
 	struct node_tx *tx;
 	struct node_rx_pdu *ntf;
 
@@ -110,7 +110,7 @@ void test_version_exchange_mas_loc(void)
 
 void test_version_exchange_mas_loc_2(void)
 {
-	u8_t err;
+	uint8_t err;
 
 	ull_cp_init();
 	ull_tx_q_init(&conn.tx_q);
@@ -204,7 +204,7 @@ void test_version_exchange_mas_rem(void)
  */
 void test_version_exchange_mas_rem_2(void)
 {
-	u8_t err;
+	uint8_t err;
 	struct node_tx *tx;
 	struct node_rx_pdu *ntf;
 

--- a/tests/bluetooth/controller/mock_ctrl/src/ll_assert.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ll_assert.c
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 #include "kconfig.h"
 
-void bt_ctlr_assert_handle(char *file, u32_t line)
+void bt_ctlr_assert_handle(char *file, uint32_t line)
 {
 	printf("Assertion failed in %s:%d\n", file, line);
 	exit(-1);


### PR DESCRIPTION
Since the kernel-types have been replaced with C99 types in the
upstream branch we need to do the same here

If other PRs are merged before this one an update will be required here; I'll do 
that when necessary. 

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>