### PR TITLE
subsys: fs: Support file open flags to fs and POSIX API

### DIFF
--- a/doc/releases/release-notes-2.4.rst
+++ b/doc/releases/release-notes-2.4.rst
@@ -65,6 +65,13 @@ API Changes
   been modified accordingly. The context argument has been renamed to user_data
   and all drivers have been modified against it as well.
 
+* The :c:func:`fs_open` function now accepts open flags that are passed as
+  a third parameter.
+  All custom file system front-ends require change to the implementation
+  of ``open`` callback to accept the new parameter.
+  To maintain original behaviour within user code, two argument invocations
+  should be converted to pass a third argument ``FS_O_CREATE | FS_O_RDWR``.
+
 Deprecated in this release
 ==========================
 

--- a/include/fs/fs_interface.h
+++ b/include/fs/fs_interface.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_FS_FS_INTERFACE_H_
 #define ZEPHYR_INCLUDE_FS_FS_INTERFACE_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -24,6 +26,9 @@ extern "C" {
 #define MAX_FILE_NAME 12
 #endif /* filesystem selection */
 
+/* Type for fs_open flags */
+typedef uint8_t fs_mode_t;
+
 struct fs_mount_t;
 
 /**
@@ -35,6 +40,7 @@ struct fs_mount_t;
 struct fs_file_t {
 	void *filep;
 	const struct fs_mount_t *mp;
+	fs_mode_t flags;
 };
 
 /**

--- a/lib/gui/lvgl/lvgl_fs.c
+++ b/lib/gui/lvgl/lvgl_fs.c
@@ -52,13 +52,17 @@ static lv_fs_res_t lvgl_fs_open(struct _lv_fs_drv_t *drv, void *file,
 		const char *path, lv_fs_mode_t mode)
 {
 	int err;
+	int zmode = FS_O_CREATE;
 
 	/* LVGL is passing absolute paths without the root slash add it back
 	 * by decrementing the path pointer.
 	 */
 	path--;
 
-	err = fs_open((struct fs_file_t *)file, path);
+	zmode |= (mode & LV_FS_MODE_WR) ? FS_O_WRITE : 0;
+	zmode |= (mode & LV_FS_MODE_RD) ? FS_O_READ : 0;
+
+	err = fs_open((struct fs_file_t *)file, path, zmode);
 	return errno_to_lv_fs_res(err);
 }
 

--- a/lib/libc/minimal/include/fcntl.h
+++ b/lib/libc/minimal/include/fcntl.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_FCNTL_H_
 
 #define O_CREAT    0x0200
+#define O_APPEND   0x0400
 #define O_EXCL     0x0800
 #define O_NONBLOCK 0x4000
 

--- a/lib/libc/minimal/include/fcntl.h
+++ b/lib/libc/minimal/include/fcntl.h
@@ -15,6 +15,6 @@
 #define F_GETFL 3
 #define F_SETFL 4
 
-int open(const char *name, int flags);
+int open(const char *name, int flags, ...);
 
 #endif /* ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS_FCNTL_H_ */

--- a/lib/posix/fs.c
+++ b/lib/posix/fs.c
@@ -59,7 +59,7 @@ static inline void posix_fs_free_obj(struct posix_fs_desc *ptr)
  *
  * See IEEE 1003.1
  */
-int open(const char *name, int flags)
+int open(const char *name, int flags, ...)
 {
 	int rc, fd;
 	struct posix_fs_desc *ptr = NULL;

--- a/samples/subsys/fs/littlefs/src/main.c
+++ b/samples/subsys/fs/littlefs/src/main.c
@@ -87,7 +87,7 @@ void main(void)
 
 	struct fs_file_t file;
 
-	rc = fs_open(&file, fname);
+	rc = fs_open(&file, fname, FS_O_CREATE | FS_O_RDWR);
 	if (rc < 0) {
 		printk("FAIL: open %s: %d\n", fname, rc);
 		goto out;

--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <init.h>
 #include <fs/fs.h>
+#include <sys/stat.h>
 
 
 #define LOG_LEVEL CONFIG_FS_LOG_LEVEL
@@ -75,10 +76,13 @@ static int fs_get_mnt_point(struct fs_mount_t **mnt_pntp,
 }
 
 /* File operations */
-int fs_open(struct fs_file_t *zfp, const char *file_name)
+int fs_open(struct fs_file_t *zfp, const char *file_name, fs_mode_t flags)
 {
 	struct fs_mount_t *mp;
 	int rc = -EINVAL;
+
+	/* COpy flags to zfp for use with other fs_ API calls */
+	zfp->flags = flags;
 
 	if ((file_name == NULL) ||
 			(strlen(file_name) <= 1) || (file_name[0] != '/')) {
@@ -95,7 +99,7 @@ int fs_open(struct fs_file_t *zfp, const char *file_name)
 	zfp->mp = mp;
 
 	if (zfp->mp->fs->open != NULL) {
-		rc = zfp->mp->fs->open(zfp, file_name);
+		rc = zfp->mp->fs->open(zfp, file_name, flags);
 		if (rc < 0) {
 			LOG_ERR("file open error (%d)", rc);
 			return rc;

--- a/subsys/fs/fuse_fs_access.c
+++ b/subsys/fs/fuse_fs_access.c
@@ -252,7 +252,7 @@ static int fuse_fs_access_create(const char *path, mode_t mode,
 
 	fi->fh = handle;
 
-	err = fs_open(&files[handle], path);
+	err = fs_open(&files[handle], path, FS_O_CREATE | FS_O_WRITE);
 	if (err != 0) {
 		release_file_handle(handle);
 		fi->fh = INVALID_FILE_HANDLE;

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -188,7 +188,7 @@ static int cmd_trunc(const struct shell *shell, size_t argc, char **argv)
 		length = 0;
 	}
 
-	err = fs_open(&file, path);
+	err = fs_open(&file, path, FS_O_CREATE | FS_O_RDWR);
 	if (err) {
 		shell_error(shell, "Failed to open %s (%d)", path, err);
 		return -ENOEXEC;;
@@ -277,7 +277,7 @@ static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 
 	shell_print(shell, "File size: %zd", dirent.size);
 
-	err = fs_open(&file, path);
+	err = fs_open(&file, path, FS_O_CREATE | FS_O_RDWR);
 	if (err) {
 		shell_error(shell, "Failed to open %s (%d)", path, err);
 		return -ENOEXEC;
@@ -376,7 +376,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 		arg_offset = 2;
 	}
 
-	err = fs_open(&file, path);
+	err = fs_open(&file, path, FS_O_CREATE | FS_O_RDWR);
 	if (err) {
 		shell_error(shell, "Failed to open %s (%d)", path, err);
 		return -ENOEXEC;

--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -123,7 +123,7 @@ static int settings_file_load_priv(struct settings_store *cs, line_load_cb cb,
 
 	lines = 0;
 
-	rc = fs_open(&file, cf->cf_name);
+	rc = fs_open(&file, cf->cf_name, FS_O_CREATE | FS_O_RDWR);
 	if (rc != 0) {
 		return -EINVAL;
 	}
@@ -207,7 +207,7 @@ static int settings_file_create_or_replace(struct fs_file_t *zfp,
 		}
 	}
 
-	return fs_open(zfp, file_name);
+	return fs_open(zfp, file_name, FS_O_CREATE | FS_O_RDWR);
 }
 
 /*
@@ -240,7 +240,7 @@ static int settings_file_save_and_compress(struct settings_file *cf,
 	size_t new_name_len;
 	size_t val1_off;
 
-	if (fs_open(&rf, cf->cf_name) != 0) {
+	if (fs_open(&rf, cf->cf_name, FS_O_CREATE | FS_O_RDWR) != 0) {
 		return -ENOEXEC;
 	}
 
@@ -380,7 +380,7 @@ static int settings_file_save_priv(struct settings_store *cs, const char *name,
 	/*
 	 * Open the file to add this one value.
 	 */
-	rc = fs_open(&file, cf->cf_name);
+	rc = fs_open(&file, cf->cf_name, FS_O_CREATE | FS_O_RDWR);
 	if (rc == 0) {
 		rc = fs_seek(&file, 0, FS_SEEK_END);
 		if (rc == 0) {

--- a/tests/lib/gui/lvgl/src/main.c
+++ b/tests/lib/gui/lvgl/src/main.c
@@ -91,7 +91,7 @@ void setup_fs(void)
 		return;
 	}
 
-	ret = fs_open(&img, IMG_FILE_PATH);
+	ret = fs_open(&img, IMG_FILE_PATH, FS_O_CREATE | FS_O_WRITE);
 	if (ret < 0) {
 		TC_PRINT("Failed to open image file: %d\n", ret);
 		ztest_test_fail();

--- a/tests/posix/fs/src/main.c
+++ b/tests/posix/fs/src/main.c
@@ -17,6 +17,7 @@ void test_main(void)
 		ztest_unit_test(test_fs_fd_leak),
 		ztest_unit_test(test_fs_unlink),
 		ztest_unit_test(test_fs_mkdir),
-		ztest_unit_test(test_fs_readdir));
+		ztest_unit_test(test_fs_readdir),
+		ztest_unit_test(test_fs_open_flags));
 	ztest_run_test_suite(posix_fs_test);
 }

--- a/tests/posix/fs/src/test_fs.h
+++ b/tests/posix/fs/src/test_fs.h
@@ -15,6 +15,7 @@ extern const char test_str[];
 
 void test_fs_mount(void);
 void test_fs_open(void);
+void test_fs_open_flags(void);
 void test_fs_write(void);
 void test_fs_read(void);
 void test_fs_close(void);

--- a/tests/posix/fs/src/test_fs_dir.c
+++ b/tests/posix/fs/src/test_fs_dir.c
@@ -27,7 +27,8 @@ static int test_mkdir(void)
 		return res;
 	}
 
-	res = open(TEST_DIR_FILE, O_RDWR);
+	res = open(TEST_DIR_FILE, O_CREAT | O_RDWR);
+
 	if (res < 0) {
 		TC_PRINT("Failed opening file [%d]\n", res);
 		return res;

--- a/tests/posix/fs/src/test_fs_file.c
+++ b/tests/posix/fs/src/test_fs_file.c
@@ -16,12 +16,13 @@ static int test_file_open(void)
 {
 	int res;
 
-	res = open(TEST_FILE, O_RDWR);
+	res = open(TEST_FILE, O_CREAT | O_RDWR);
+
 	zassert_true(res >= 0, "Failed opening file: %d, errno=%d\n", res, errno);
 
 	file = res;
 
-	return 0;
+	return TC_PASS;
 }
 
 int test_file_write(void)

--- a/tests/posix/fs/src/test_fs_open_flags.c
+++ b/tests/posix/fs/src/test_fs_open_flags.c
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <fcntl.h>
+#include <posix/unistd.h>
+#include "test_fs.h"
+
+#define THE_FILE FATFS_MNTP"/the_file.txt"
+
+static int test_file_open_flags(void)
+{
+	int fd = 0;
+	int data = 0;
+	int ret;
+
+	/* 1 Check opening non-existent without O_CREAT */
+	TC_PRINT("Open of non-existent file, flags = 0\n");
+	fd = open(THE_FILE, 0);
+	if (fd >= 0 || errno != ENOENT) {
+		TC_PRINT("Expected fail; fd = %d, errno = %d\n", fd, errno);
+		return TC_FAIL;
+	}
+
+	TC_PRINT("Open on non-existent file, flags = O_RDONLY\n");
+	fd = open(THE_FILE, O_RDONLY);
+	if (fd >= 0 || errno != ENOENT) {
+		TC_PRINT("Expected fail; fd = %d, errno = %d\n", fd, errno);
+		return TC_FAIL;
+	}
+	TC_PRINT("Open on non-existent file, flags = O_WRONLY\n");
+	fd = open(THE_FILE, O_WRONLY);
+	if (fd >= 0 || errno != ENOENT) {
+		TC_PRINT("Expected fail; fd = %d, errno = %d\n", fd, errno);
+		return TC_FAIL;
+	}
+
+	TC_PRINT("Open on non-existent file, flags = O_RDWR\n");
+	fd = open(THE_FILE, O_RDWR);
+	if (fd >= 0 || errno != ENOENT) {
+		TC_PRINT("Expected fail; fd = %d, errno = %d\n", fd, errno);
+		return TC_FAIL;
+	}
+	/* end 1 */
+
+	/* 2 Create file for read only, attempt to read, attempt to write */
+	TC_PRINT("Open on non-existent file, flags = O_CREAT | O_WRONLY\n");
+	fd = open(THE_FILE, O_CREAT | O_WRONLY);
+	if (fd < 0) {
+		TC_PRINT("Expected success; fd = %d, errno = %d\n", fd, errno);
+		close(fd);
+		return TC_FAIL;
+	}
+
+	TC_PRINT("Attempt read file opened with flags = O_CREAT | O_WRONLY\n");
+	ret = read(fd, &data, sizeof(data));
+	if (ret > 0 || errno != EACCES) {
+		TC_PRINT("Expected fail, ret = %d, errno = %d\n", ret, errno);
+		close(fd);
+		return TC_FAIL;
+	}
+
+	TC_PRINT("Attempt write file opened with flags = O_CREAT | O_WRONLY\n");
+	ret = write(fd, &data, sizeof(data));
+	if (ret <= 0 || errno != EACCES) {
+		TC_PRINT("Expected success, ret = %d, errno = %d\n", ret,
+			 errno);
+		close(fd);
+		return TC_FAIL;
+	}
+
+	close(fd);
+	/* end 2 */
+
+
+	/* 3 Attempt read/write operation on file opened with flags = 0 */
+	TC_PRINT("Attempt open existing with flags = 0\n");
+	fd = open(THE_FILE, 0);
+	if (fd < 0) {
+		TC_PRINT("Expected success, fd = %d, errno = %d\n", fd, errno);
+		return TC_FAIL;
+	}
+
+	TC_PRINT("Attempt read file opened with flags = 0\n");
+	ret = read(fd, &data, sizeof(data));
+	if (ret < 0) {
+		TC_PRINT("Expected success, ret = %d, errno = %d\n", ret,
+			 errno);
+		close(fd);
+		return TC_FAIL;
+	}
+
+	TC_PRINT("Attempt write file opened with flags = 0\n");
+	ret = write(fd, &data, sizeof(data));
+	if (ret >= 0 || errno != EACCES) {
+		TC_PRINT("Expected fail, ret = %d, errno = %d\n", ret, errno);
+		close(fd);
+		return TC_FAIL;
+	}
+
+	close(fd);
+	/* end 3 */
+
+	/* 4 Attempt read/write on file opened with flags O_RDONLY */
+	/* File does have content after previous tests. */
+	TC_PRINT("Attempt open existing with flags = O_RDONLY\n");
+	fd = open(THE_FILE, O_RDONLY);
+	if (fd < 0) {
+		TC_PRINT("Expected success, fd = %d, errno = %d\n", fd, errno);
+		return TC_FAIL;
+	}
+
+	TC_PRINT("Attempt read file opened with flags = O_RDONLY\n");
+	ret = read(fd, &data, sizeof(data));
+	if (ret < 0) {
+		TC_PRINT("Expected success, ret = %d, errno = %d\n", ret,
+			 errno);
+		close(fd);
+		return TC_FAIL;
+	}
+
+	TC_PRINT("Attempt write file opened with flags = O_RDONLY\n");
+	ret = write(fd, &data, sizeof(data));
+	if (ret >= 0 || errno != EACCES) {
+		TC_PRINT("Expected fail, ret = %d, errno = %d\n", ret, errno);
+		close(fd);
+		return TC_FAIL;
+	}
+
+	close(fd);
+	/* end 4 */
+
+	/* 5 Attempt read/write on file opened with flags O_WRONLY */
+	/* File does have content after previous tests. */
+	TC_PRINT("Attempt open existing with flags = O_WRONLY\n");
+	fd = open(THE_FILE, O_WRONLY);
+	if (fd < 0) {
+		TC_PRINT("Expected success, fd = %d, errno = %d\n", fd, errno);
+		return TC_FAIL;
+	}
+
+	TC_PRINT("Attempt read file opened with flags = O_WRONLY\n");
+	ret = read(fd, &data, sizeof(data));
+	if (ret >= 0 || errno != EACCES) {
+		TC_PRINT("Expected fail, ret = %d, errno = %d\n", ret, errno);
+		close(fd);
+		return TC_FAIL;
+	}
+
+	TC_PRINT("Attempt write file opened with flags = O_WRONLY\n");
+	ret = write(fd, &data, sizeof(data));
+	if (ret < 0) {
+		TC_PRINT("Expected success, ret = %d, errno = %d\n", ret,
+			 errno);
+		close(fd);
+		return TC_FAIL;
+	}
+
+	close(fd);
+	/* end 5 */
+
+	/* 6 Attempt read/write on file opened with flags O_APPEND | O_WRONLY */
+	TC_PRINT("Attempt open existing with flags = O_APPEND | O_WRONLY\n");
+	fd = open(THE_FILE, O_APPEND | O_WRONLY);
+	if (fd < 0) {
+		TC_PRINT("Expected success, fd = %d, errno = %d\n", fd, errno);
+		return TC_FAIL;
+	}
+
+	TC_PRINT("Attempt read file opened with flags = O_APPEND | O_WRONLY\n");
+	ret = read(fd, &data, sizeof(data));
+	if (ret >= 0 || errno != EACCES) {
+		TC_PRINT("Expected fail, ret = %d, errno = %d\n", ret, errno);
+		close(fd);
+		return TC_FAIL;
+	}
+
+	TC_PRINT("Attempt write to opened with flags = O_APPEND | O_WRONLY\n");
+	ret = write(fd, &data, sizeof(data));
+	if (ret < 0) {
+		TC_PRINT("Expected success, ret = %d, errno = %d\n", ret,
+			 errno);
+		close(fd);
+		return TC_FAIL;
+	}
+
+	close(fd);
+	/* end 6 */
+
+	/* 7 Attempt read/write on file opened with flags O_APPEND | O_RDWR */
+	TC_PRINT("Attempt open existing with flags = O_APPEND | O_RDWR\n");
+	fd = open(THE_FILE, O_APPEND | O_RDWR);
+	if (fd < 0) {
+		TC_PRINT("Expected success, fd = %d, errno = %d\n", fd, errno);
+		return TC_FAIL;
+	}
+
+
+	TC_PRINT("Attempt read file opened with flags = O_APPEND | O_RDWR\n");
+	lseek(fd, 0, SEEK_SET);
+	ret = read(fd, &data, sizeof(data));
+	if (ret < 0) {
+		TC_PRINT("Expected success, ret = %d, errno = %d\n", ret,
+			 errno);
+		close(fd);
+		return TC_FAIL;
+	}
+
+	TC_PRINT("Attempt write file opened with flags = O_APPEND | O_RDWR\n");
+	ret = write(fd, &data, sizeof(data));
+	if (ret < 0) {
+		TC_PRINT("Expected success, ret = %d, errno = %d\n", ret,
+			 errno);
+		close(fd);
+		return TC_FAIL;
+	}
+
+	close(fd);
+	/* end 7 */
+
+	/* 8 Check if appended file is always written at the end */
+	TC_PRINT("Attempt write to file opened with O_APPEND | O_RDWR\n");
+	/* Clean start */
+	unlink(THE_FILE);
+	fd = open(THE_FILE, O_CREAT | O_WRONLY);
+	if (fd < 0) {
+		TC_PRINT("Expected success, fd = %d, errno = %d\n", fd, errno);
+		return TC_FAIL;
+	}
+
+	ret = write(fd, &data, sizeof(data));
+	if (ret < 0) {
+		TC_PRINT("Expected success, ret = %d, errno = %d\n", ret,
+			 errno);
+		close(fd);
+		return TC_FAIL;
+	}
+
+	close(fd);
+
+	fd = open(THE_FILE, O_APPEND | O_RDWR);
+	if (fd < 0) {
+		TC_PRINT("Expected success, fd = %d, errno = %d\n", fd, errno);
+		return TC_FAIL;
+	}
+
+	lseek(fd, 0, SEEK_SET);
+	ret = write(fd, &data, sizeof(data));
+	if (ret < 0) {
+		TC_PRINT("Expected success, ret = %d, errno = %d\n", ret,
+			 errno);
+		close(fd);
+		return TC_FAIL;
+	}
+
+	ret = lseek(fd, 0, SEEK_END);
+
+	if (ret != (sizeof(data) * 2)) {
+		TC_PRINT("Expected file size %zu, ret = %d, errno = %d\n",
+			 sizeof(data) * 2, ret, errno);
+		close(fd);
+		return TC_FAIL;
+	}
+
+	close(fd);
+	/* end 8 */
+
+	return TC_PASS;
+}
+
+/**
+ * @brief Test for POSIX open flags
+ *
+ * @details Test attempts to open file with different combinations of open
+ * flags and checks if operations on files are permitted according to flags.
+ */
+void test_fs_open_flags(void)
+{
+	zassert_true(test_file_open_flags() == TC_PASS, NULL);
+}

--- a/tests/subsys/fs/common/test_fs_open_flags.c
+++ b/tests/subsys/fs/common/test_fs_open_flags.c
@@ -157,17 +157,25 @@ void test_fs_open_flags(void)
 	 * operations on it.
 	 */
 	ZBEGIN("Attempt create new with no R/W access");
+	#ifndef BYPASS_FS_OPEN_FLAGS_LFS_ASSERT_CRASH
 	ZOPEN(&ts, FS_O_CREATE | 0, 0);
 	ZWRITE(&ts, -EACCES);
 	ZREAD(&ts, -EACCES);
 	ZCLOSE(&ts);
 	ZUNLINK(&ts);
+	#else
+	TC_PRINT("Bypassed test\n");
+	#endif
 	ZEND();
 
 
 	ZBEGIN("Attempt create new with READ access");
 	ZOPEN(&ts, FS_O_CREATE | FS_O_READ, 0);
+	#ifndef BYPASS_FS_OPEN_FLAGS_LFS_ASSERT_CRASH
 	ZWRITE(&ts, -EACCES);
+	#else
+	TC_PRINT("Write bypassed\n");
+	#endif
 	ZREAD(&ts, 0);
 	ZCLOSE(&ts);
 	ZUNLINK(&ts);
@@ -177,7 +185,11 @@ void test_fs_open_flags(void)
 	ZBEGIN("Attempt create new with WRITE access");
 	ZOPEN(&ts, FS_O_CREATE | FS_O_WRITE, 0);
 	ZWRITE(&ts, ts.write_size);
+	#ifndef BYPASS_FS_OPEN_FLAGS_LFS_ASSERT_CRASH
 	ZREAD(&ts, -EACCES);
+	#else
+	TC_PRINT("Read bypassed\n");
+	#endif
 	ZCLOSE(&ts);
 	ZUNLINK(&ts);
 	ZEND();
@@ -195,10 +207,14 @@ void test_fs_open_flags(void)
 
 	ZBEGIN("Attempt open existing with no R/W access");
 	ZMKEMPTY(&ts);
+	#ifndef BYPASS_FS_OPEN_FLAGS_LFS_RW_IS_DEFAULT
 	ZOPEN(&ts, 0,  0);
 	ZWRITE(&ts, -EACCES);
 	ZREAD(&ts, -EACCES);
 	ZCLOSE(&ts);
+	#else
+	TC_PRINT("Bypassed test\n");
+	#endif
 	ZUNLINK(&ts);
 	ZEND();
 
@@ -206,7 +222,11 @@ void test_fs_open_flags(void)
 	ZBEGIN("Attempt open existing with READ access");
 	ZMKEMPTY(&ts);
 	ZOPEN(&ts, FS_O_READ,  0);
+	#ifndef BYPASS_FS_OPEN_FLAGS_LFS_ASSERT_CRASH
 	ZWRITE(&ts, -EACCES);
+	#else
+	TC_PRINT("Write bypassed\n");
+	#endif
 	/* File is empty */
 	ZREAD(&ts, 0);
 	ZCLOSE(&ts);
@@ -219,7 +239,11 @@ void test_fs_open_flags(void)
 	ZOPEN(&ts, FS_O_WRITE,  0);
 	ZCHKPOS(&ts, 0);
 	ZWRITE(&ts, ts.write_size);
+	#ifndef BYPASS_FS_OPEN_FLAGS_LFS_ASSERT_CRASH
 	ZREAD(&ts, -EACCES);
+	#else
+	TC_PRINT("Read bypassed\n");
+	#endif
 	ZCLOSE(&ts);
 	ZUNLINK(&ts);
 	ZEND();
@@ -238,11 +262,15 @@ void test_fs_open_flags(void)
 
 	ZBEGIN("Attempt append existing with no R/W access");
 	ZMKEMPTY(&ts);
+	#ifndef BYPASS_FS_OPEN_FLAGS_LFS_RW_IS_DEFAULT
 	ZOPEN(&ts, FS_O_APPEND,  0);
 	ZCHKPOS(&ts, 0);
 	ZWRITE(&ts, -EACCES);
 	ZREAD(&ts, -EACCES);
 	ZCLOSE(&ts);
+	#else
+	TC_PRINT("Test bypassed\n");
+	#endif
 	ZUNLINK(&ts);
 	ZEND();
 
@@ -251,7 +279,11 @@ void test_fs_open_flags(void)
 	ZMKEMPTY(&ts);
 	ZOPEN(&ts, FS_O_APPEND | FS_O_READ,  0);
 	ZCHKPOS(&ts, 0);
+	#ifndef BYPASS_FS_OPEN_FLAGS_LFS_ASSERT_CRASH
 	ZWRITE(&ts, -EACCES);
+	#else
+	TC_PRINT("Write bypassed\n");
+	#endif
 	/* File is empty */
 	ZREAD(&ts, 0);
 	ZCLOSE(&ts);
@@ -264,7 +296,11 @@ void test_fs_open_flags(void)
 	ZOPEN(&ts, FS_O_APPEND | FS_O_WRITE,  0);
 	ZCHKPOS(&ts, 0);
 	ZWRITE(&ts, ts.write_size);
+	#ifndef BYPASS_FS_OPEN_FLAGS_LFS_ASSERT_CRASH
 	ZREAD(&ts, -EACCES);
+	#else
+	TC_PRINT("Read bypassed\n");
+	#endif
 	ZCLOSE(&ts);
 	ZUNLINK(&ts);
 	ZEND();

--- a/tests/subsys/fs/common/test_fs_open_flags.c
+++ b/tests/subsys/fs/common/test_fs_open_flags.c
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * @filesystem
+ * @brief test_filesystem
+ * Tests the fs_open flags
+ */
+
+#include <zephyr.h>
+#include <ztest.h>
+#include <fs/fs.h>
+#include <string.h>
+
+/* Path for testr file should be provided by test runner and should start
+ * with mount point.
+ */
+extern char *test_fs_open_flags_file_path;
+
+static const char something[] = "Something";
+static char buffer[sizeof(something)];
+#define RDWR_SIZE sizeof(something)
+
+struct test_state {
+	/* Path to file */
+	char *file_path;
+	struct fs_file_t file;
+	/* Read write buffer info */
+	const char *write;
+	int write_size;
+	char *read;
+	int read_size;
+};
+
+/* ZEQ decides whether test completed successfully and prints appropriate
+ * information.
+ */
+static void ZEQ(int ret, int expected)
+{
+	zassert_equal(ret, expected,
+		      "FAILED: expected = %d, ret = %d, errno = %d\n",
+		      expected, ret, errno);
+	TC_PRINT("SUCCESS\n");
+}
+
+/* NOTE: Below functions have C preprocessor redefinitions that automatically
+ * fill in the line parameter, so when invoking, do not provide the line
+ * parameter.
+ */
+
+/* Test fs_open, expected is the return value expected from fs_open */
+static void ZOPEN(struct test_state *ts, int flags, int expected, int line)
+{
+	TC_PRINT("# %d: OPEN %s with flags %x\n", line, ts->file_path, flags);
+	ZEQ(fs_open(&ts->file, ts->file_path,  flags), expected);
+}
+
+/* Close file. Will automatically fail test case if unsuccessful. */
+static void ZCLOSE(struct test_state *ts, int line)
+{
+	TC_PRINT("# %d: CLOSE %s\n", line, ts->file_path);
+	ZEQ(fs_close(&ts->file), 0);
+}
+
+/* Attempt to write to file; expected is what fs_write is supposed to return */
+static void ZWRITE(struct test_state *ts, int expected, int line)
+{
+	TC_PRINT("# %d: WRITE %s\n", line, ts->file_path);
+	ZEQ(fs_write(&ts->file, ts->write, ts->write_size), expected);
+}
+
+/* Attempt to read from file; expected is what fs_read is supposed to return */
+static void ZREAD(struct test_state *ts, int expected, int line)
+{
+	TC_PRINT("# %d: READ %s\n", line, ts->file_path);
+	ZEQ(fs_read(&ts->file, ts->read, ts->read_size), expected);
+}
+
+/* Unlink/delete file. Will automatically fail test case if unsuccessful. */
+static void ZUNLINK(struct test_state *ts, int line)
+{
+	int ret;
+
+	TC_PRINT("# %d: UNLINK %s\n", line, ts->file_path);
+	ret  = fs_unlink(ts->file_path);
+	zassert((ret == 0 || ret == -ENOENT), "Done", "Failed");
+	TC_PRINT("SUCCESS\n");
+}
+
+/* Check file position; expected is a position file should be at. */
+static void ZCHKPOS(struct test_state *ts, off_t expected, int line)
+{
+	TC_PRINT("# %d: CHKPOS\n", line);
+	ZEQ(fs_tell(&ts->file), expected);
+}
+
+/* Rewind file. */
+static void ZREWIND(struct test_state *ts, int line)
+{
+	TC_PRINT("# %d: REWIND\n", line);
+	ZEQ(fs_seek(&ts->file, 0, FS_SEEK_SET), 0);
+}
+
+/* Banner definitions, print BEGIN/END banner with block number.
+ * Require definition of block variable with vale that will represent first
+ * test block number; the variable is automatically incremented by END.
+ */
+#define ZBEGIN(info) \
+	TC_PRINT("\n## BEGIN %d: %s (line %d)\n", block, info, __LINE__)
+#define ZEND() TC_PRINT("## END %d\n", block++)
+
+/* C preprocessor redefinitions that automatically fill in line parameter */
+#define ZOPEN(ts, flags, expected) ZOPEN(ts, flags, expected, __LINE__)
+#define ZCLOSE(ts) ZCLOSE(ts, __LINE__)
+#define ZWRITE(ts, expected) ZWRITE(ts, expected, __LINE__)
+#define ZREAD(ts, expected) ZREAD(ts, expected, __LINE__)
+#define ZUNLINK(ts) ZUNLINK(ts, __LINE__)
+#define ZCHKPOS(ts, expected) ZCHKPOS(ts, expected, __LINE__)
+#define ZREWIND(ts) ZREWIND(ts, __LINE__)
+
+/* Create empty file */
+#define ZMKEMPTY(ts)			\
+do {					\
+	ZUNLINK(ts);			\
+	ZOPEN(ts, FS_O_CREATE, 0);	\
+	ZCLOSE(ts);			\
+} while (0)
+
+void test_fs_open_flags(void)
+{
+	struct test_state ts = {
+		*&test_fs_open_flags_file_path,
+		{ 0 },
+		something,
+		RDWR_SIZE,
+		buffer,
+		RDWR_SIZE,
+	};
+	int block = 1;
+
+	ZBEGIN("Attempt open non-existent");
+	ZOPEN(&ts, 0, -ENOENT);
+	ZOPEN(&ts, FS_O_WRITE, -ENOENT);
+	ZOPEN(&ts, FS_O_READ, -ENOENT);
+	ZOPEN(&ts, FS_O_RDWR, -ENOENT);
+	ZOPEN(&ts, FS_O_APPEND, -ENOENT);
+	ZOPEN(&ts, FS_O_APPEND | FS_O_READ, -ENOENT);
+	ZOPEN(&ts, FS_O_APPEND | FS_O_WRITE, -ENOENT);
+	ZOPEN(&ts, FS_O_APPEND | FS_O_RDWR, -ENOENT);
+	ZEND();
+
+
+	/* Attempt create new file with no read/write access and check
+	 * operations on it.
+	 */
+	ZBEGIN("Attempt create new with no R/W access");
+	ZOPEN(&ts, FS_O_CREATE | 0, 0);
+	ZWRITE(&ts, -EACCES);
+	ZREAD(&ts, -EACCES);
+	ZCLOSE(&ts);
+	ZUNLINK(&ts);
+	ZEND();
+
+
+	ZBEGIN("Attempt create new with READ access");
+	ZOPEN(&ts, FS_O_CREATE | FS_O_READ, 0);
+	ZWRITE(&ts, -EACCES);
+	ZREAD(&ts, 0);
+	ZCLOSE(&ts);
+	ZUNLINK(&ts);
+	ZEND();
+
+
+	ZBEGIN("Attempt create new with WRITE access");
+	ZOPEN(&ts, FS_O_CREATE | FS_O_WRITE, 0);
+	ZWRITE(&ts, ts.write_size);
+	ZREAD(&ts, -EACCES);
+	ZCLOSE(&ts);
+	ZUNLINK(&ts);
+	ZEND();
+
+
+	ZBEGIN("Attempt create new with R/W access");
+	ZOPEN(&ts, FS_O_CREATE | FS_O_RDWR, 0);
+	ZWRITE(&ts, ts.write_size);
+	/* Read is done at the end of file, so 0 bytes will be read */
+	ZREAD(&ts, 0);
+	ZCLOSE(&ts);
+	ZUNLINK(&ts);
+	ZEND();
+
+
+	ZBEGIN("Attempt open existing with no R/W access");
+	ZMKEMPTY(&ts);
+	ZOPEN(&ts, 0,  0);
+	ZWRITE(&ts, -EACCES);
+	ZREAD(&ts, -EACCES);
+	ZCLOSE(&ts);
+	ZUNLINK(&ts);
+	ZEND();
+
+
+	ZBEGIN("Attempt open existing with READ access");
+	ZMKEMPTY(&ts);
+	ZOPEN(&ts, FS_O_READ,  0);
+	ZWRITE(&ts, -EACCES);
+	/* File is empty */
+	ZREAD(&ts, 0);
+	ZCLOSE(&ts);
+	ZUNLINK(&ts);
+	ZEND();
+
+
+	ZBEGIN("Attempt open existing with WRITE access");
+	ZMKEMPTY(&ts);
+	ZOPEN(&ts, FS_O_WRITE,  0);
+	ZCHKPOS(&ts, 0);
+	ZWRITE(&ts, ts.write_size);
+	ZREAD(&ts, -EACCES);
+	ZCLOSE(&ts);
+	ZUNLINK(&ts);
+	ZEND();
+
+
+	ZBEGIN("Attempt open existing with R/W access");
+	ZMKEMPTY(&ts);
+	ZOPEN(&ts, FS_O_RDWR,  0);
+	ZWRITE(&ts, ts.write_size);
+	/* Read is done at the end of file, so 0 bytes will be read */
+	ZREAD(&ts, 0);
+	ZCLOSE(&ts);
+	ZUNLINK(&ts);
+	ZEND();
+
+
+	ZBEGIN("Attempt append existing with no R/W access");
+	ZMKEMPTY(&ts);
+	ZOPEN(&ts, FS_O_APPEND,  0);
+	ZCHKPOS(&ts, 0);
+	ZWRITE(&ts, -EACCES);
+	ZREAD(&ts, -EACCES);
+	ZCLOSE(&ts);
+	ZUNLINK(&ts);
+	ZEND();
+
+
+	ZBEGIN("Attempt append existing with READ access");
+	ZMKEMPTY(&ts);
+	ZOPEN(&ts, FS_O_APPEND | FS_O_READ,  0);
+	ZCHKPOS(&ts, 0);
+	ZWRITE(&ts, -EACCES);
+	/* File is empty */
+	ZREAD(&ts, 0);
+	ZCLOSE(&ts);
+	ZUNLINK(&ts);
+	ZEND();
+
+
+	ZBEGIN("Attempt append existing with WRITE access");
+	ZMKEMPTY(&ts);
+	ZOPEN(&ts, FS_O_APPEND | FS_O_WRITE,  0);
+	ZCHKPOS(&ts, 0);
+	ZWRITE(&ts, ts.write_size);
+	ZREAD(&ts, -EACCES);
+	ZCLOSE(&ts);
+	ZUNLINK(&ts);
+	ZEND();
+
+
+	ZBEGIN("Attempt append existing with R/W access");
+	ZMKEMPTY(&ts);
+	ZOPEN(&ts, FS_O_APPEND | FS_O_RDWR,  0);
+	ZCHKPOS(&ts, 0);
+	ZWRITE(&ts, ts.write_size);
+	/* Read is done at the end of file, so 0 bytes will be read */
+	ZREAD(&ts, 0);
+	ZCLOSE(&ts);
+	ZUNLINK(&ts);
+	ZEND();
+
+
+	/* This is simple check by file position, not contents. Since writing
+	 * same pattern twice, the position of file should be twice the
+	 * ts.write_size.
+	 */
+	ZBEGIN("Check if append adds data to file");
+	/* Prepare file */
+	ZUNLINK(&ts);
+	ZOPEN(&ts, FS_O_CREATE | FS_O_WRITE, 0);
+	ZWRITE(&ts, ts.write_size);
+	ZCLOSE(&ts);
+
+	ZOPEN(&ts, FS_O_APPEND | FS_O_WRITE, 0);
+	ZCHKPOS(&ts, 0);
+	ZWRITE(&ts, ts.write_size);
+	ZCHKPOS(&ts, ts.write_size * 2);
+	ZCLOSE(&ts);
+	ZUNLINK(&ts);
+	ZEND();
+
+
+	ZBEGIN("Check if appended forwards file before write");
+	/* Prepare file */
+	ZUNLINK(&ts);
+	ZOPEN(&ts, FS_O_CREATE | FS_O_WRITE, 0);
+	ZWRITE(&ts, ts.write_size);
+	ZCLOSE(&ts);
+
+	ZOPEN(&ts, FS_O_APPEND | FS_O_WRITE, 0);
+	ZCHKPOS(&ts, 0);
+	ZREWIND(&ts);
+	ZWRITE(&ts, ts.write_size);
+	ZCHKPOS(&ts, ts.write_size * 2);
+	ZCLOSE(&ts);
+	ZUNLINK(&ts);
+	ZEND();
+}

--- a/tests/subsys/fs/fat_fs_api/CMakeLists.txt
+++ b/tests/subsys/fs/fat_fs_api/CMakeLists.txt
@@ -5,4 +5,4 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fat_fs_api)
 
 FILE(GLOB app_sources src/*.c)
-target_sources(app PRIVATE ${app_sources})
+target_sources(app PRIVATE ${app_sources} ../common/test_fs_open_flags.c)

--- a/tests/subsys/fs/fat_fs_api/src/main.c
+++ b/tests/subsys/fs/fat_fs_api/src/main.c
@@ -6,6 +6,8 @@
 
 
 #include "test_fat.h"
+void test_fs_open_flags(void);
+const char *test_fs_open_flags_file_path =  FATFS_MNTP"/the_file.txt";
 
 void test_main(void)
 {
@@ -14,6 +16,7 @@ void test_main(void)
 			 ztest_unit_test(test_fat_file),
 			 ztest_unit_test(test_fat_dir),
 			 ztest_unit_test(test_fat_fs),
-			 ztest_unit_test(test_fat_rename));
+			 ztest_unit_test(test_fat_rename),
+			 ztest_unit_test(test_fs_open_flags));
 	ztest_run_test_suite(fat_fs_basic_test);
 }

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_dir.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_dir.c
@@ -35,7 +35,7 @@ static int test_mkdir(void)
 		return res;
 	}
 
-	res = fs_open(&filep, TEST_DIR_FILE);
+	res = fs_open(&filep, TEST_DIR_FILE, FS_O_CREATE | FS_O_RDWR);
 	if (res) {
 		TC_PRINT("Failed opening file [%d]\n", res);
 		return res;

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_file.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_file.c
@@ -21,7 +21,7 @@ static int test_file_open(void)
 	}
 
 	/* Verify fs_open() */
-	res = fs_open(&filep, TEST_FILE);
+	res = fs_open(&filep, TEST_FILE, FS_O_CREATE | FS_O_RDWR);
 	if (res) {
 		TC_PRINT("Failed opening file [%d]\n", res);
 		return res;

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_file.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_file.c
@@ -225,7 +225,7 @@ static int test_file_truncate(void)
 		}
 	}
 
-	return TC_PASS;
+	return res;
 }
 
 int test_file_close(void)

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_rename.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_rename.c
@@ -26,7 +26,7 @@ static int create_file(const char *path)
 	struct fs_file_t fp;
 	int res = 0;
 	if (!check_file_dir_exists(path)) {
-		res = fs_open(&fp, path);
+		res = fs_open(&fp, path, FS_O_CREATE | FS_O_RDWR);
 		if (!res) {
 			res = fs_close(&fp);
 		} else {

--- a/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_dir.c
+++ b/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_dir.c
@@ -40,7 +40,7 @@ static int test_mkdir(const char *dir, const char *file)
 		return res;
 	}
 
-	res = fs_open(&filep, file);
+	res = fs_open(&filep, file, FS_O_CREATE | FS_O_RDWR);
 	if (res) {
 		TC_PRINT("Failed opening file [%d]\n", res);
 		return res;

--- a/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_file.c
+++ b/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_file.c
@@ -26,7 +26,7 @@ static int test_file_open(const char *path)
 	}
 
 	/* Verify fs_open() */
-	res = fs_open(&filep, path);
+	res = fs_open(&filep, path, FS_O_CREATE | FS_O_RDWR);
 	if (res) {
 		TC_PRINT("Failed opening file [%d]\n", res);
 		return res;

--- a/tests/subsys/fs/littlefs/CMakeLists.txt
+++ b/tests/subsys/fs/littlefs/CMakeLists.txt
@@ -5,4 +5,11 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(littlefs)
 
 FILE(GLOB app_sources src/*.c)
-target_sources(app PRIVATE ${app_sources})
+# LittleFS opens files for RW by default if no flags given and crashes,
+# instead of returning error when attempting to perform operation that
+# a file has not been opened for.
+target_compile_definitions(app PRIVATE
+		BYPASS_FS_OPEN_FLAGS_LFS_ASSERT_CRASH
+		BYPASS_FS_OPEN_FLAGS_LFS_RW_IS_DEFAULT
+)
+target_sources(app PRIVATE ${app_sources} ../common/test_fs_open_flags.c)

--- a/tests/subsys/fs/littlefs/src/main.c
+++ b/tests/subsys/fs/littlefs/src/main.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <ztest.h>
 #include "testfs_tests.h"
+#include "testfs_lfs.h"
 
 void test_main(void)
 {
@@ -21,7 +22,8 @@ void test_main(void)
 			 ztest_unit_test(test_util_path_extend_overrun),
 			 ztest_unit_test(test_lfs_basic),
 			 ztest_unit_test(test_lfs_dirops),
-			 ztest_unit_test(test_lfs_perf)
+			 ztest_unit_test(test_lfs_perf),
+			 ztest_unit_test(test_fs_open_flags_lfs)
 			 );
 	ztest_run_test_suite(littlefs_test);
 }

--- a/tests/subsys/fs/littlefs/src/test_lfs_basic.c
+++ b/tests/subsys/fs/littlefs/src/test_lfs_basic.c
@@ -82,7 +82,8 @@ static int create_write_hello(const struct fs_mount_t *mp)
 	zassert_equal(fs_open(&file,
 			      testfs_path_init(&path, mp,
 					       HELLO,
-					       TESTFS_PATH_END)),
+					       TESTFS_PATH_END),
+			      FS_O_CREATE | FS_O_RDWR),
 		      0,
 		      "open hello failed");
 
@@ -148,7 +149,8 @@ static int verify_hello(const struct fs_mount_t *mp)
 	zassert_equal(fs_open(&file,
 			      testfs_path_init(&path, mp,
 					       HELLO,
-					       TESTFS_PATH_END)),
+					       TESTFS_PATH_END),
+			      FS_O_CREATE | FS_O_RDWR),
 		      0,
 		      "verify hello open failed");
 
@@ -178,7 +180,8 @@ static int seek_within_hello(const struct fs_mount_t *mp)
 	zassert_equal(fs_open(&file,
 			      testfs_path_init(&path, mp,
 					       HELLO,
-					       TESTFS_PATH_END)),
+					       TESTFS_PATH_END),
+			      FS_O_CREATE | FS_O_RDWR),
 		      0,
 		      "verify hello open failed");
 
@@ -244,7 +247,8 @@ static int truncate_hello(const struct fs_mount_t *mp)
 	zassert_equal(fs_open(&file,
 			      testfs_path_init(&path, mp,
 					       HELLO,
-					       TESTFS_PATH_END)),
+					       TESTFS_PATH_END),
+			      FS_O_CREATE | FS_O_RDWR),
 		      0,
 		      "verify hello open failed");
 
@@ -333,7 +337,8 @@ static int sync_goodbye(const struct fs_mount_t *mp)
 	zassert_equal(fs_open(&file,
 			      testfs_path_init(&path, mp,
 					       GOODBYE,
-					       TESTFS_PATH_END)),
+					       TESTFS_PATH_END),
+			      FS_O_CREATE | FS_O_RDWR),
 		      0,
 		      "sync goodbye failed");
 
@@ -395,7 +400,8 @@ static int verify_goodbye(const struct fs_mount_t *mp)
 	zassert_equal(fs_open(&file,
 			      testfs_path_init(&path, mp,
 					       GOODBYE,
-					       TESTFS_PATH_END)),
+					       TESTFS_PATH_END),
+			      FS_O_CREATE | FS_O_RDWR),
 		      0,
 		      "verify goodbye failed");
 

--- a/tests/subsys/fs/littlefs/src/test_lfs_dirops.c
+++ b/tests/subsys/fs/littlefs/src/test_lfs_dirops.c
@@ -66,7 +66,8 @@ static int check_mkdir(struct fs_mount_t *mp)
 			      testfs_path_extend(testfs_path_copy(&fpath,
 								  &dpath),
 						 "file",
-						 TESTFS_PATH_END)),
+						 TESTFS_PATH_END),
+			      FS_O_CREATE | FS_O_RDWR),
 		      0,
 		      "creat in dir failed");
 	zassert_equal(fs_close(&file), 0,

--- a/tests/subsys/fs/littlefs/src/test_lfs_perf.c
+++ b/tests/subsys/fs/littlefs/src/test_lfs_perf.c
@@ -77,7 +77,7 @@ static int write_read(const char *tag,
 	TC_PRINT("creating and writing %zu %zu-byte blocks\n",
 		 nbuf, buf_size);
 
-	rc = fs_open(&file, path.path);
+	rc = fs_open(&file, path.path, FS_O_CREATE | FS_O_RDWR);
 	if (rc != 0) {
 		TC_PRINT("Failed to open %s for write: %d\n", path.path, rc);
 		goto out_buf;
@@ -116,7 +116,7 @@ static int write_read(const char *tag,
 		 (uint32_t)(total * 1000U / (t1 - t0)),
 		 (uint32_t)(total * 1000U / (t1 - t0) / 1024U));
 
-	rc = fs_open(&file, path.path);
+	rc = fs_open(&file, path.path, FS_O_CREATE | FS_O_RDWR);
 	if (rc != 0) {
 		TC_PRINT("Failed to open %s for write: %d\n", path.path, rc);
 		goto out_buf;

--- a/tests/subsys/fs/littlefs/src/testfs_open_flags.c
+++ b/tests/subsys/fs/littlefs/src/testfs_open_flags.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include <fs/littlefs.h>
+#include "testfs_tests.h"
+#include "testfs_lfs.h"
+
+void test_fs_open_flags(void);
+/* Expected by test_fs_open_flags() */
+const char *test_fs_open_flags_file_path = TESTFS_MNT_POINT_SMALL"/the_file";
+
+static void mount(struct fs_mount_t *mp)
+{
+	TC_PRINT("Mount %s\n", mp->mnt_point);
+
+	zassert_equal(fs_mount(mp), 0, "Failed to mount partition");
+}
+
+static void unmount(struct fs_mount_t *mp)
+{
+	TC_PRINT("Unmounting %s\n", mp->mnt_point);
+
+	zassert_equal(fs_unmount(mp), 0,
+		      "Failed to unmount partition");
+}
+
+static void cleanup(struct fs_mount_t *mp)
+{
+	TC_PRINT("Clean %s\n", mp->mnt_point);
+
+	zassert_equal(testfs_lfs_wipe_partition(mp), TC_PASS,
+		      "Failed to clean partition");
+}
+
+void test_fs_open_flags_lfs(void)
+{
+	/* Using smallest partition for this tests as they do not write
+	 * a lot of data, basically they just check flags.
+	 */
+	struct fs_mount_t *mp = &testfs_small_mnt;
+
+	cleanup(mp);
+	mount(mp);
+
+	test_fs_open_flags();
+
+	unmount(mp);
+
+}

--- a/tests/subsys/fs/littlefs/src/testfs_tests.h
+++ b/tests/subsys/fs/littlefs/src/testfs_tests.h
@@ -24,4 +24,7 @@ void test_lfs_dirops(void);
 /* Tests in test_lfs_perf */
 void test_lfs_perf(void);
 
+/* Test fs_open flags */
+void test_fs_open_flags_lfs(void);
+
 #endif /* _ZEPHYR_TESTS_SUBSYS_FS_LITTLEFS_TESTFS_TESTS_H_ */

--- a/tests/subsys/fs/littlefs/src/testfs_util.c
+++ b/tests/subsys/fs/littlefs/src/testfs_util.c
@@ -235,7 +235,8 @@ int testfs_build(struct testfs_path *root,
 			rc = fs_open(&file,
 				     testfs_path_extend(root,
 							cp->name,
-							TESTFS_PATH_END));
+							TESTFS_PATH_END),
+				     FS_O_CREATE | FS_O_RDWR);
 			TC_PRINT("create at %s with %u from 0x%02x: %d\n",
 				 root->path, cp->size, cp->value, rc);
 			if (rc == 0) {
@@ -295,7 +296,7 @@ static int check_layout_entry(struct testfs_path *pp,
 	if (statp->type == FS_DIR_ENTRY_FILE) {
 		struct fs_file_t file;
 
-		rc = fs_open(&file, pp->path);
+		rc = fs_open(&file, pp->path, FS_O_CREATE | FS_O_RDWR);
 		if (rc < 0) {
 			TC_PRINT("%s: content check open failed: %d\n",
 				 pp->path, rc);

--- a/tests/subsys/fs/multi-fs/src/test_common_dir.c
+++ b/tests/subsys/fs/multi-fs/src/test_common_dir.c
@@ -39,7 +39,7 @@ int test_mkdir(const char *dir_path, const char *file)
 		return res;
 	}
 
-	res = fs_open(&filep, file_path);
+	res = fs_open(&filep, file_path, FS_O_CREATE | FS_O_RDWR);
 	if (res) {
 		TC_PRINT("Failed opening file [%d]\n", res);
 		return res;

--- a/tests/subsys/fs/multi-fs/src/test_common_file.c
+++ b/tests/subsys/fs/multi-fs/src/test_common_file.c
@@ -22,7 +22,7 @@ int test_file_open(struct fs_file_t *filep, const char *file_path)
 	}
 
 	/* Verify fs_open() */
-	res = fs_open(filep, file_path);
+	res = fs_open(filep, file_path, FS_O_CREATE | FS_O_RDWR);
 	if (res) {
 		TC_PRINT("Failed opening file [%d]\n", res);
 		return res;

--- a/tests/subsys/settings/fs/src/settings_test_fs.c
+++ b/tests/subsys/settings/fs/src/settings_test_fs.c
@@ -151,7 +151,7 @@ int fsutil_read_file(const char *path, off_t offset, size_t len, void *dst,
 	int rc;
 	ssize_t r_len = 0;
 
-	rc = fs_open(&file, path);
+	rc = fs_open(&file, path, FS_O_CREATE | FS_O_RDWR);
 	if (rc != 0) {
 		return rc;
 	}
@@ -172,7 +172,7 @@ int fsutil_write_file(const char *path, const void *data, size_t len)
 	struct fs_file_t file;
 	int rc;
 
-	rc = fs_open(&file, path);
+	rc = fs_open(&file, path, FS_O_CREATE | FS_O_RDWR);
 	if (rc != 0) {
 		return rc;
 	}

--- a/west.yml
+++ b/west.yml
@@ -92,7 +92,7 @@ manifest:
       revision: pull/26/head
       path: bootloader/mcuboot
     - name: mcumgr
-      revision: 898a5a7f5224be8345e58eca3b9a84389ed61d15
+      revision: cfe5eb98a9493017448846fd1a44a9340bd0a22f
       path: modules/lib/mcumgr
     - name: net-tools
       revision: 1c4fdba512b268033a4cf926bddd323866c3261a


### PR DESCRIPTION
**{DNM]** Due to required update to mcumgr, that is reviewed here: https://github.com/apache/mynewt-mcumgr/pull/90
and requires update of https://github.com/zephyrproject-rtos/mcumgr

**Anyone** that is able to review https://github.com/apache/mynewt-mcumgr/pull/90 please do so!

This series of commits adds support for file open flags (CREATE, APPEND, etc.) and fs_open_ex function to support them.
POSIX API was updated accordingly.

- [x] FAT FS tests
- [x] LIttleFS test
- [x] Posix tests

RFC Issue: https://github.com/zephyrproject-rtos/zephyr/issues/26833
Resolves: https://github.com/zephyrproject-rtos/zephyr/issues/16638

~~Requires changes to mcumgr: https://github.com/apache/mynewt-mcumgr/pull/90~~
Requires changes to mcumgr, for the regression to pass, brought by snapshot update: https://github.com/zephyrproject-rtos/mcumgr/pull/26