### PR TITLE
disk: sdhc: fix SPI clock setup

### DIFF
--- a/subsys/disk/disk_access_spi_sdhc.c
+++ b/subsys/disk/disk_access_spi_sdhc.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT zephyr_mmc_spi_slot
+
 #include <logging/log.h>
 
 LOG_MODULE_REGISTER(sdhc_spi, CONFIG_DISK_LOG_LEVEL);
@@ -784,6 +786,7 @@ static int disk_spi_sdhc_init(struct device *dev);
 static int sdhc_spi_init(struct device *dev)
 {
 	struct sdhc_spi_data *data = dev->driver_data;
+	uint32_t spi_max_frequency = DT_INST_PROP(0, spi_max_frequency);
 
 	data->spi = device_get_binding(DT_BUS_LABEL(DT_INST(0, zephyr_mmc_spi_slot)));
 
@@ -795,8 +798,12 @@ static int sdhc_spi_init(struct device *dev)
 		.slave = DT_REG_ADDR(DT_INST(0, zephyr_mmc_spi_slot)),
 	};
 	/* SPI config for default speed */
+	if (spi_max_frequency > SDHC_SPI_DEFAULT_SPEED) {
+		spi_max_frequency = SDHC_SPI_DEFAULT_SPEED;
+	}
+	LOG_DBG("Maximum SPI frequency: %u", spi_max_frequency);
 	data->spi_cfgs[SDHC_SPI_DEFAULT_SPEED_CFG] = (struct spi_config){
-		.frequency = SDHC_SPI_DEFAULT_SPEED,
+		.frequency = spi_max_frequency,
 		.operation = SPI_WORD_SET(8) | SPI_HOLD_ON_CS,
 		.slave = DT_REG_ADDR(DT_INST(0, zephyr_mmc_spi_slot)),
 	};

--- a/subsys/disk/disk_access_spi_sdhc.c
+++ b/subsys/disk/disk_access_spi_sdhc.c
@@ -16,9 +16,9 @@ LOG_MODULE_REGISTER(sdhc_spi, CONFIG_DISK_LOG_LEVEL);
 #include "disk_access_sdhc.h"
 
 /* Clock speed used during initialisation */
-#define SDHC_SPI_INITIAL_SPEED 400000
+#define SDHC_SPI_INITIAL_SPEED KHZ(400)
 /* Clock speed used after initialisation */
-#define SDHC_SPI_SPEED 4000000
+#define SDHC_SPI_DEFAULT_SPEED MHZ(25)
 
 #if !DT_NODE_HAS_STATUS(DT_INST(0, zephyr_mmc_spi_slot), okay)
 #warning NO SDHC slot specified on board
@@ -796,7 +796,7 @@ static int sdhc_spi_init(struct device *dev)
 	};
 	/* SPI config for default speed */
 	data->spi_cfgs[SDHC_SPI_DEFAULT_SPEED_CFG] = (struct spi_config){
-		.frequency = SDHC_SPI_SPEED,
+		.frequency = SDHC_SPI_DEFAULT_SPEED,
 		.operation = SPI_WORD_SET(8) | SPI_HOLD_ON_CS,
 		.slave = DT_REG_ADDR(DT_INST(0, zephyr_mmc_spi_slot)),
 	};


### PR DESCRIPTION
It was noticed that the SPI SDHC driver has a very slow read/write speed when accessing the SD card on nrf52. The investigation shows that the driver has 2 main problems:

- It keeps using the initial clock setup, because it does not pass a new configuration to `spi_context_configured()` but only change the frequency in the existing configuration. Since this is not detected as a new configuration, the old clock speed is used in the data phase.
- The clock speed is hardcoded to 4MHz, even if the specification allows a clock up to 25MHz in default speed mode.

These issues are not specific to nrf52, since `spi_context_configured()` is used on most other SPI drivers. This is probably the same issue reported on STM32: #22906.

These problems are fixed by declaring a second SPI configuration for the default speed mode, and taking the clock frequency from the `spi-max-frequency` DTS property (limited to 25MHz).

Here are some test results. Note that the nrf52 SPI driver has coarse prescalers, so the real clock speed is 250kHz when selecting 400kHz, and 16MHz when selecting 25MHz. Other platforms will probably give different results. Tested with a SanDisk 16GB microSD.

|   | master (250 kHz) | Fix 1 (4 MHz) | Fix 2 (16 MHz) |
| ------------- | ------------- | ------------- | ------------- |
| read (4 MB)  | 27 kB/s | 181 kB/s | 364 kB/s |
| write  (10 MB) | 4.6 kB/s | 29 kB/s | 41 kB/s  |

The throughput is increased by 10 times when using these patches.