### PR TITLE
boards: stm32: Extend stm32f746g_disco board with Arduino header

### DIFF
--- a/boards/arm/stm32f746g_disco/arduino_r3_connector.dtsi
+++ b/boards/arm/stm32f746g_disco/arduino_r3_connector.dtsi
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020 Marco Peter
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
+			   <1 0 &gpiof 10 0>,	/* A1 */
+			   <2 0 &gpiof 9 0>,	/* A2 */
+			   <3 0 &gpiof 8 0>,	/* A3 */
+			   <4 0 &gpiof 7 0>,	/* A4 */
+			   <5 0 &gpiof 6 0>,	/* A5 */
+			   <6 0 &gpioc 7 0>,	/* D0 */
+			   <7 0 &gpioc 6 0>,	/* D1 */
+			   <8 0 &gpiog 6 0>,	/* D2 */
+			   <9 0 &gpiob 4 0>,	/* D3 */
+			   <10 0 &gpiog 7 0>,	/* D4 */
+			   <11 0 &gpioi 0 0>,	/* D5 */
+			   <12 0 &gpioh 6 0>,	/* D6 */
+			   <13 0 &gpioi 3 0>,	/* D7 */
+			   <14 0 &gpioi 2 0>,	/* D8 */
+			   <15 0 &gpioa 15 0>,	/* D9 */
+			   <16 0 &gpioa 8 0>,	/* D10 */
+			   <17 0 &gpiob 15 0>,	/* D11 */
+			   <18 0 &gpiob 14 0>,	/* D12 */
+			   <19 0 &gpioi 1 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi2 {};
+arduino_serial: &usart6 {};

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/f7/stm32f746Xg.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F746G DISCOVERY board";
@@ -41,10 +42,6 @@
 		kscan0 = &touch_controller;
 	};
 };
-
-arduino_i2c: &i2c1 {};
-arduino_spi: &spi2 {};
-arduino_serial: &usart6 {};
 
 &i2c1 {
 	status = "okay";


### PR DESCRIPTION
Adding GPIO mapping for Arduino connector.

Signed-off-by: Marco Peter <marco@peter-net.ch>