### PR TITLE
boards: stm32f030_demo: enable stm32flash in addition to OpenOCD

### DIFF
--- a/boards/arm/stm32f030_demo/board.cmake
+++ b/boards/arm/stm32f030_demo/board.cmake
@@ -4,4 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+board_runner_args(stm32flash "--start-addr=0x08000000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stm32flash.board.cmake)


### PR DESCRIPTION
This PR makes it possible to use stm32flash for flashing (with west) the
STM32F030 Demo Board. OpenOCD is still the default, so in order to use
stm32flash, one must invoke `west flash` with `-r stm32flash`.

Signed-off-by: Grzegorz Szymaszek <gszymaszek@short.pl>