### PR TITLE
boards: shields: mikroe_adc_click: use mikrobus_spi bus as parent

### DIFF
--- a/boards/shields/mikroe_adc_click/boards/lpcxpresso55s16_ns.overlay
+++ b/boards/shields/mikroe_adc_click/boards/lpcxpresso55s16_ns.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020 Henrik Brix Andersen <henrik@brixandersen.dk>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &mcp3204;
+
+&mikrobus_spi {
+	status = "okay";
+
+	/* LPCXpresso55S16 uses SSEL1 for mikroBUS SPI */
+	mcp3204: mcp3204@1 {
+		compatible = "microchip,mcp3204";
+		reg = <0x1>;
+		spi-max-frequency = <100000>;
+		label = "MCP3204";
+		#io-channel-cells = <1>;
+	};
+};

--- a/boards/shields/mikroe_adc_click/doc/index.rst
+++ b/boards/shields/mikroe_adc_click/doc/index.rst
@@ -20,12 +20,8 @@ Requirements
 ************
 
 This shield can only be used with a development board that provides a
-configuration for Arduino connectors and defines a node alias for the
+configuration for mikroBUS connectors and defines a node alias for the mikroBUS
 SPI interface (see :ref:`shields` for more details).
-
-The mikroBUS connector pins on the ADC Click can either be connected
-to the Arduino headers of the development board using jumper wires or
-by using an `Arduino UNO Click Shield`_.
 
 For more information about interfacing the MCP3204 and the ADC Click,
 see the following documentation:
@@ -56,6 +52,3 @@ example:
 
 .. _ADC Click:
    https://www.mikroe.com/adc-click
-
-.. _Arduino UNO Click Shield:
-   https://www.mikroe.com/arduino-uno-click-shield

--- a/boards/shields/mikroe_adc_click/mikroe_adc_click.overlay
+++ b/boards/shields/mikroe_adc_click/mikroe_adc_click.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&arduino_spi {
+&mikrobus_spi {
 	status = "okay";
 
 	mcp3204: mcp3204@0 {


### PR DESCRIPTION
Use the recently introduced mikrobus_spi devicetree node as parent node instead of relying on mapping for arduino_spi.

Also, add devicetree overlay for connecting an Mikroe ADC click shield to an NXP LPCXpresso55S16 development board.
    
The LPCXpresso55S16 uses SSEL1 (CS1) for mikroBUS SPI, whereas the generic Mikroe ADC click board definition assumes SPI CS0.