### PR TITLE
editorconfig: use 72 characters line width git commit messages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -65,3 +65,7 @@ indent_style = tab
 [*.{dts,dtsi,overlay}]
 indent_style = tab
 indent_size = 8
+
+# Git commit messages
+[COMMIT_EDITMSG]
+max_line_length = 72


### PR DESCRIPTION
Configure editors for wrapping lines at 72 characters line width for Git commit messages.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>