### PR TITLE
native_posix: timer: Ignore nanosleep return

### DIFF
--- a/boards/posix/native_posix/timer_model.c
+++ b/boards/posix/native_posix/timer_model.c
@@ -213,7 +213,7 @@ static void hwtimer_tick_timer_reached(void)
 			requested_time.tv_nsec = (diff -
 						 requested_time.tv_sec*1e6)*1e3;
 
-			nanosleep(&requested_time, &remaining);
+			(void) nanosleep(&requested_time, &remaining);
 		}
 	}
 


### PR DESCRIPTION
Explicitly ignore the nanosleep() return value.
nanosleep() is called to slow down native_posix in real time
mode.
There is no real reason to handle this call returning too early:
The call may return earlier if a signal was sent to the process
(e.g. the user pressed Ctrl+C), or in case of errors.
In case of SIGKILL, SIGTERM, what we do is what we should do
(not wait, but terminate the program as requested by the user ASAP)
In case of another signal, we will wait the appropriate
amount of time in the next systick (so we won't accumulate any
error over time)
So there is no real need to add extra code here to handle
those cases.

Solves coverity CID 211046

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

Fixes #26357