### PR TITLE
tests: kernel: lifo_usage: Exclude on qemu_arc_em

### DIFF
--- a/tests/kernel/lifo/lifo_usage/testcase.yaml
+++ b/tests/kernel/lifo/lifo_usage/testcase.yaml
@@ -2,4 +2,4 @@ tests:
   kernel.lifo.usage:
     tags: kernel
     # FIXME: Keeps failing sporadically in CI. See #26163
-    platform_exclude: qemu_arc_hs
+    platform_exclude: qemu_arc_em qemu_arc_hs


### PR DESCRIPTION
This test has a very high failure rate on `qemu_arc_em` and needs to be
disabled until a fix is available.

To be addressed in #26163.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>