### PR TITLE
boards: native_posix: Polling console

### DIFF
--- a/include/console/console.h
+++ b/include/console/console.h
@@ -69,8 +69,7 @@ int console_getchar(void);
 
 /** @brief Output a char to console (buffered).
  *
- *  Puts a character into console output buffer. It will be sent
- *  to a console asynchronously, e.g. using an IRQ handler.
+ *  Puts a character into console output buffer.
  *
  *  @return <0 on error, otherwise 0.
  */

--- a/subsys/console/CMakeLists.txt
+++ b/subsys/console/CMakeLists.txt
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_sources_ifdef(CONFIG_CONSOLE_GETCHAR tty.c getchar.c)
+zephyr_sources_ifdef(CONFIG_CONSOLE_GETCHAR getchar.c)
 zephyr_sources_ifdef(CONFIG_CONSOLE_GETLINE getline.c)
+zephyr_sources_ifdef(CONFIG_CONSOLE_RX_INTERRUPT_DRIVEN tty.c)

--- a/subsys/console/Kconfig
+++ b/subsys/console/Kconfig
@@ -8,19 +8,40 @@ menuconfig CONSOLE_SUBSYS
 
 if CONSOLE_SUBSYS
 
+choice CONSOLE_RX_TYPE
+	prompt "Console RX type"
+
+config CONSOLE_RX_INTERRUPT_DRIVEN
+	bool "Console RX is interrupt driven"
+	depends on UART_CONSOLE && SERIAL_SUPPORT_INTERRUPT
+
+config CONSOLE_RX_POLLING
+	bool "Console RX is polling"
+	depends on UART_CONSOLE
+	select RING_BUFFER
+
+endchoice
+
+config CONSOLE_POLLING_RX_POLL_PERIOD
+	int "RX polling period (in milliseconds)"
+	default 10
+	depends on CONSOLE_RX_POLLING
+	help
+	  Determines how often UART is polled for RX byte.
+
 choice
 	prompt "Console 'get' function selection"
 	optional
-	depends on UART_CONSOLE && SERIAL_SUPPORT_INTERRUPT
+	depends on UART_CONSOLE
 
 config CONSOLE_GETCHAR
 	bool "Character by character input and output"
 	select UART_CONSOLE_DEBUG_SERVER_HOOKS
-	select CONSOLE_HANDLER
+	select CONSOLE_HANDLER if CONSOLE_RX_INTERRUPT_DRIVEN
 
 config CONSOLE_GETLINE
 	bool "Line by line input"
-	select CONSOLE_HANDLER
+	select CONSOLE_HANDLER if CONSOLE_RX_INTERRUPT_DRIVEN
 
 endchoice
 

--- a/subsys/console/getchar.c
+++ b/subsys/console/getchar.c
@@ -6,53 +6,122 @@
 
 #include <zephyr.h>
 #include <device.h>
+#include <sys/ring_buffer.h>
 #include <console/console.h>
 #include <console/tty.h>
 #include <drivers/uart.h>
 
-static struct tty_serial console_serial;
+static const struct device *uart_dev;
 
-static uint8_t console_rxbuf[CONFIG_CONSOLE_GETCHAR_BUFSIZE];
+#if defined(CONFIG_CONSOLE_RX_INTERRUPT_DRIVEN)
+
+static struct tty_serial console_serial;
 static uint8_t console_txbuf[CONFIG_CONSOLE_PUTCHAR_BUFSIZE];
+static uint8_t console_rxbuf[CONFIG_CONSOLE_GETCHAR_BUFSIZE];
+
+#else
+
+#define POLL_PERIOD K_MSEC(CONFIG_CONSOLE_POLLING_RX_POLL_PERIOD)
+
+void poll_timer_handler(struct k_timer *dummy);
+
+RING_BUF_DECLARE(console_rx_ringbuf, CONFIG_CONSOLE_GETCHAR_BUFSIZE);
+
+K_SEM_DEFINE(rx_sem, 0, CONFIG_CONSOLE_GETCHAR_BUFSIZE);
+
+K_TIMER_DEFINE(poll_timer, poll_timer_handler, NULL);
+
+
+void poll_timer_handler(struct k_timer *dummy)
+{
+	int ret = 0;
+	uint8_t c;
+
+	while (true) {
+		if (ring_buf_space_get(&console_rx_ringbuf) == 0) {
+			return;
+		}
+
+		ret = uart_poll_in(uart_dev, &c);
+		if (ret != 0) {
+			return;
+		}
+
+		ring_buf_put(&console_rx_ringbuf, &c, 1);
+
+		k_sem_give(&rx_sem);
+	}
+}
+
+#endif
+
 
 ssize_t console_write(void *dummy, const void *buf, size_t size)
 {
 	ARG_UNUSED(dummy);
 
+#if defined(CONFIG_CONSOLE_RX_INTERRUPT_DRIVEN)
 	return tty_write(&console_serial, buf, size);
+#else
+	for (int i = 0; i < size; i++) {
+		uint8_t c = ((uint8_t *)buf)[i];
+
+		uart_poll_out(uart_dev, c);
+	}
+	return size;
+#endif
 }
 
 ssize_t console_read(void *dummy, void *buf, size_t size)
 {
 	ARG_UNUSED(dummy);
-
+#if defined(CONFIG_CONSOLE_RX_INTERRUPT_DRIVEN)
 	return tty_read(&console_serial, buf, size);
+#else
+	return 0;
+#endif
 }
 
 int console_putchar(char c)
 {
+#if defined(CONFIG_CONSOLE_RX_INTERRUPT_DRIVEN)
 	return tty_write(&console_serial, &c, 1);
+#else
+	uart_poll_out(uart_dev, c);
+	return 0;
+#endif
 }
 
 int console_getchar(void)
 {
 	uint8_t c;
+#if defined(CONFIG_CONSOLE_RX_INTERRUPT_DRIVEN)
 	int res;
 
 	res = tty_read(&console_serial, &c, 1);
 	if (res < 0) {
 		return res;
 	}
+#else
+	int res = k_sem_take(&rx_sem, K_FOREVER);
+
+	if (res < 0) {
+		return res;
+	}
+
+	ring_buf_get(&console_rx_ringbuf, &c, sizeof(c));
+#endif
 
 	return c;
 }
 
 int console_init(void)
 {
-	const struct device *uart_dev;
+	uart_dev = device_get_binding(CONFIG_UART_CONSOLE_ON_DEV_NAME);
+
+#if defined(CONFIG_CONSOLE_RX_INTERRUPT_DRIVEN)
 	int ret;
 
-	uart_dev = device_get_binding(CONFIG_UART_CONSOLE_ON_DEV_NAME);
 	ret = tty_init(&console_serial, uart_dev);
 
 	if (ret) {
@@ -70,6 +139,10 @@ int console_init(void)
 
 	tty_set_tx_buf(&console_serial, console_txbuf, sizeof(console_txbuf));
 	tty_set_rx_buf(&console_serial, console_rxbuf, sizeof(console_rxbuf));
+
+#else
+	k_timer_start(&poll_timer, POLL_PERIOD, POLL_PERIOD);
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
This PR makes it possible to run samples requiring the console on native posix boards. This is done my allowing the console subsystem to run in polling mode. The interrupt driven console is still the default. For the posix boards we now enable SERIAL by default to align with other boards, and to make it possible to enable the console subsystem.

The previous implementation of console required the serial driver to be interrupt driven. The native posix board requires the serial driver to be polling as the CPU is simulated to be infinitely fast.