### PR TITLE
canbus: canopen: fix reference to CAN in Automation draft standard

### DIFF
--- a/subsys/canbus/canopen/Kconfig
+++ b/subsys/canbus/canopen/Kconfig
@@ -111,6 +111,6 @@ config CANOPEN_PROGRAM_DOWNLOAD
 	default y
 	help
 	  Enable support for program download over CANopen according
-	  to the CiA 303-2 (draft) specification.
+	  to the CiA 302-3 (draft) specification.
 
 endif # CANOPEN


### PR DESCRIPTION
Fix the reference to the CAN in Automation (CiA) draft standard for program download (302-3, not 303-2).