### PR TITLE
net: conn: Handle multi interface AF_PACKET recv() properly

### DIFF
--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -444,7 +444,7 @@ static void eth_iface_init(struct net_if *iface)
 
 	ctx->dev_fd = eth_iface_create(ctx->if_name, false);
 	if (ctx->dev_fd < 0) {
-		LOG_ERR("Cannot create %s (%d)", ctx->if_name, ctx->dev_fd);
+		LOG_ERR("Cannot create %s (%d)", ctx->if_name, -errno);
 	} else {
 		/* Create a thread that will handle incoming data from host */
 		create_rx_handler(ctx);

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -657,8 +657,28 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 
 				mcast_pkt_delivered = true;
 			}
-		} else if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) ||
-			   IS_ENABLED(CONFIG_NET_SOCKETS_CAN)) {
+		} else if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET)) {
+			if (conn->flags & NET_CONN_LOCAL_ADDR_SET) {
+				struct sockaddr_ll *local;
+
+				local = (struct sockaddr_ll *)&conn->local_addr;
+
+				if (local->sll_ifindex !=
+				    net_if_get_by_iface(net_pkt_iface(pkt))) {
+					continue;
+				}
+
+				if (best_rank < NET_CONN_RANK(conn->flags)) {
+					best_rank = NET_CONN_RANK(conn->flags);
+					best_match = conn;
+				}
+			} else {
+				if (best_rank < NET_CONN_RANK(conn->flags)) {
+					best_rank = 0;
+					best_match = conn;
+				}
+			}
+		} else if (IS_ENABLED(CONFIG_NET_SOCKETS_CAN)) {
 			best_rank = 0;
 			best_match = conn;
 		}

--- a/tests/net/socket/af_packet/testcase.yaml
+++ b/tests/net/socket/af_packet/testcase.yaml
@@ -1,6 +1,9 @@
 common:
   depends_on: netif
   tags: net socket af_packet
+  # The test do not work in native_posix as the zeth interface creation
+  # needs root permission.
+  platform_exclude: native_posix native_posix_64
 tests:
   net.socket.packet:
     min_ram: 21


### PR DESCRIPTION
If we have multiple network interfaces and we are waiting incoming
network packets. Make sure to honor the bind of the socket so that
correct socket will receive data in certain network interface.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>