### PR TITLE
buildkite: Handle case of sanitycheck doing nothing

### DIFF
--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -33,6 +33,10 @@ fi;
 SANITY_EXIT_STATUS=$?
 
 # Rename sanitycheck junit xml for use with junit-annotate-buildkite-plugin
+# create dummy file if sanitycheck did nothing
+if [ ! -f sanity-out/sanitycheck.xml ]; then
+   touch sanity-out/sanitycheck.xml
+fi
 mv sanity-out/sanitycheck.xml sanitycheck-${BUILDKITE_JOB_ID}.xml
 buildkite-agent artifact upload sanitycheck-${BUILDKITE_JOB_ID}.xml
 


### PR DESCRIPTION
The junit-annotate step will fail if there are no sanitycheck-*.xml
files to be found which can happen if sanitycheck is run and does
nothing (for example an update to .editorconfig).

Try and create an empty sanitycheck.xml in such a case.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>