### PR TITLE
device: add API to iterate over devices and check their validity

### DIFF
--- a/doc/reference/power_management/index.rst
+++ b/doc/reference/power_management/index.rst
@@ -299,7 +299,7 @@ Get Device List
 
 .. code-block:: c
 
-   void device_list_get(struct device **device_list, int *device_count);
+   size_t z_device_get_all_static(struct device **device_list);
 
 The Zephyr RTOS kernel internally maintains a list of all devices in the system.
 The SOC interface uses this API to get the device list. The SOC interface can use the list to

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -225,24 +225,12 @@ SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 
 static void device_name_get(size_t idx, struct shell_static_entry *entry)
 {
-	int device_idx = 0;
-	struct device *dev;
+	struct device *dev = shell_device_lookup(idx, NULL);
 
-	entry->syntax = NULL;
+	entry->syntax = (dev != NULL) ? dev->name : NULL;
 	entry->handler = NULL;
 	entry->help  = NULL;
 	entry->subcmd = &dsub_device_name;
-
-	for (dev = __device_start; dev != __device_end; dev++) {
-		if ((dev->driver_api != NULL) &&
-		strcmp(dev->name, "") && (dev->name != NULL)) {
-			if (idx == device_idx) {
-				entry->syntax = dev->name;
-				break;
-			}
-			device_idx++;
-		}
-	}
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(flash_cmds,

--- a/drivers/i2c/i2c_shell.c
+++ b/drivers/i2c/i2c_shell.c
@@ -224,25 +224,12 @@ SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 
 static void device_name_get(size_t idx, struct shell_static_entry *entry)
 {
-	int device_idx = 0;
-	struct device *dev;
+	struct device *dev = shell_device_lookup(idx, I2C_DEVICE_PREFIX);
 
-	entry->syntax = NULL;
+	entry->syntax = (dev != NULL) ? dev->name : NULL;
 	entry->handler = NULL;
 	entry->help = NULL;
 	entry->subcmd = &dsub_device_name;
-
-	for (dev = __device_start; dev != __device_end; dev++) {
-		if ((dev->driver_api != NULL) && (dev->name != NULL) &&
-		    strstr(dev->name, I2C_DEVICE_PREFIX) != NULL &&
-		    strcmp(dev->name, "")) {
-			if (idx == device_idx) {
-				entry->syntax = dev->name;
-				break;
-			}
-			device_idx++;
-		}
-	}
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_i2c_cmds,

--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -173,24 +173,12 @@ SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 
 static void device_name_get(size_t idx, struct shell_static_entry *entry)
 {
-	int device_idx = 0;
-	struct device *dev;
+	struct device *dev = shell_device_lookup(idx, NULL);
 
-	entry->syntax = NULL;
+	entry->syntax = (dev != NULL) ? dev->name : NULL;
 	entry->handler = NULL;
 	entry->help  = NULL;
 	entry->subcmd = &dsub_channel_name;
-
-	for (dev = __device_start; dev != __device_end; dev++) {
-		if ((dev->driver_api != NULL) &&
-		strcmp(dev->name, "") && (dev->name != NULL)) {
-			if (idx == device_idx) {
-				entry->syntax = dev->name;
-				break;
-			}
-			device_idx++;
-		}
-	}
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_sensor,

--- a/include/device.h
+++ b/include/device.h
@@ -240,6 +240,17 @@ __syscall struct device *device_get_binding(const char *name);
  */
 size_t z_device_get_all_static(struct device **devices);
 
+/** @brief Determine whether a device has been successfully initialized.
+ *
+ * @param dev pointer to the device in question.
+ *
+ * @return true if and only if the device is available for use.
+ */
+static inline bool z_device_ready(const struct device *dev)
+{
+	return dev->driver_api != NULL;
+}
+
 /**
  * @}
  */

--- a/include/device.h
+++ b/include/device.h
@@ -230,6 +230,16 @@ struct device {
  */
 __syscall struct device *device_get_binding(const char *name);
 
+/** @brief Get access to the static array of static devices.
+ *
+ * @param devices where to store the pointer to the array of
+ * statically allocated devices.  The array must not be mutated
+ * through this pointer.
+ *
+ * @return the number of statically allocated devices.
+ */
+size_t z_device_get_all_static(struct device **devices);
+
 /**
  * @}
  */
@@ -403,8 +413,13 @@ static inline int device_get_power_state(struct device *device,
  *
  * @param device_list Pointer to receive the device list array
  * @param device_count Pointer to receive the device count
+ *
+ * @deprecated in 2.4 release, replace with z_device_get_all_static()
  */
-void device_list_get(struct device **device_list, int *device_count);
+__deprecated static inline void device_list_get(struct device **device_list, int *device_count)
+{
+	*device_count = z_device_get_all_static(device_list);
+}
 
 /**
  * @brief Check if any device is in the middle of a transaction

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -105,6 +105,24 @@ struct shell_static_args {
 };
 
 /**
+ * @brief Get by index a device that matches .
+ *
+ * This can be used, for example, to identify I2C_1 as the second I2C
+ * device.
+ *
+ * Devices that failed to initialize or do not have a non-empty name
+ * are excluded from the candidates for a match.
+ *
+ * @param idx the device number starting from zero.
+ *
+ * @param prefix optional name prefix used to restrict candidate
+ * devices.  Indexing is done relative to devices with names that
+ * start with this text.  Pass null if no prefix match is required.
+ */
+struct device *shell_device_lookup(size_t idx,
+				   const char *prefix);
+
+/**
  * @brief Shell command handler prototype.
  *
  * @param shell Shell instance.

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -86,15 +86,13 @@ struct device *z_impl_device_get_binding(const char *name)
 	 * performed. Reserve string comparisons for a fallback.
 	 */
 	for (dev = __device_start; dev != __device_end; dev++) {
-		if ((dev->driver_api != NULL) &&
-		    (dev->name == name)) {
+		if (z_device_ready(dev) && (dev->name == name)) {
 			return dev;
 		}
 	}
 
 	for (dev = __device_start; dev != __device_end; dev++) {
-		if ((dev->driver_api != NULL) &&
-		    (strcmp(name, dev->name) == 0)) {
+		if (z_device_ready(dev) && (strcmp(name, dev->name) == 0)) {
 			return dev;
 		}
 	}

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -117,6 +117,12 @@ static inline struct device *z_vrfy_device_get_binding(const char *name)
 #include <syscalls/device_get_binding_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
+size_t z_device_get_all_static(struct device **devices)
+{
+	*devices = __device_start;
+	return __device_end - __device_start;
+}
+
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 int device_pm_control_nop(struct device *unused_device,
 		       uint32_t unused_ctrl_command,
@@ -126,14 +132,6 @@ int device_pm_control_nop(struct device *unused_device,
 {
 	return -ENOTSUP;
 }
-
-void device_list_get(struct device **device_list, int *device_count)
-{
-
-	*device_list = __device_start;
-	*device_count = __device_end - __device_start;
-}
-
 
 int device_any_busy_check(void)
 {

--- a/subsys/power/device.c
+++ b/subsys/power/device.c
@@ -149,7 +149,7 @@ void sys_pm_resume_devices(void)
 
 void sys_pm_create_device_list(void)
 {
-	int count;
+	size_t count = z_device_get_all_static(&all_devices);
 	device_idx_t pmi;
 
 	/*
@@ -157,9 +157,8 @@ void sys_pm_create_device_list(void)
 	 * Ordering should be done based on dependencies. Devices
 	 * in the beginning of the list will be resumed first.
 	 */
-	device_list_get(&all_devices, &count);
 
-	__ASSERT_NO_MSG((0 <= count) && (count <= DEVICE_IDX_MAX));
+	__ASSERT_NO_MSG(count <= DEVICE_IDX_MAX);
 
 	/* Reserve initial slots for core devices. */
 	num_pm = ARRAY_SIZE(core_devices);

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -39,7 +39,7 @@ static bool device_get_config_level(const struct shell *shell, int level)
 	bool devices = false;
 
 	for (dev = levels[level]; dev < levels[level+1]; dev++) {
-		if (dev->driver_api != NULL) {
+		if (z_device_ready(dev)) {
 			devices = true;
 
 			shell_fprintf(shell, SHELL_NORMAL, "- %s\n", dev->name);
@@ -92,7 +92,7 @@ static int cmd_device_list(const struct shell *shell,
 	shell_fprintf(shell, SHELL_NORMAL, "devices:\n");
 
 	for (dev = __device_start; dev != __device_end; dev++) {
-		if (dev->driver_api == NULL) {
+		if (!z_device_ready(dev)) {
 			continue;
 		}
 

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -470,7 +470,7 @@ struct device *shell_device_lookup(size_t idx,
 	struct device *dev_end = dev + len;
 
 	while (dev < dev_end) {
-		if ((dev->driver_api != NULL)
+		if (z_device_ready(dev)
 		    && (dev->name != NULL)
 		    && (strlen(dev->name) != 0)
 		    && ((prefix == NULL)

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <ctype.h>
+#include <device.h>
 #include "shell_utils.h"
 #include "shell_wildcard.h"
 
@@ -458,4 +459,30 @@ void shell_cmd_trim(const struct shell *shell)
 {
 	buffer_trim(shell->ctx->cmd_buff, &shell->ctx->cmd_buff_len);
 	shell->ctx->cmd_buff_pos = shell->ctx->cmd_buff_len;
+}
+
+struct device *shell_device_lookup(size_t idx,
+				   const char *prefix)
+{
+	size_t match_idx = 0;
+	struct device *dev;
+	size_t len = z_device_get_all_static(&dev);
+	struct device *dev_end = dev + len;
+
+	while (dev < dev_end) {
+		if ((dev->driver_api != NULL)
+		    && (dev->name != NULL)
+		    && (strlen(dev->name) != 0)
+		    && ((prefix == NULL)
+			|| (strncmp(prefix, dev->name,
+				    strlen(prefix)) == 0))) {
+			if (match_idx == idx) {
+				return dev;
+			}
+			++match_idx;
+		}
+		++dev;
+	}
+
+	return NULL;
 }

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -177,10 +177,9 @@ void test_pre_kernel_detection(void)
  */
 static void test_build_suspend_device_list(void)
 {
-	int devcount;
 	struct device *devices;
+	size_t devcount = z_device_get_all_static(&devices);
 
-	device_list_get(&devices, &devcount);
 	zassert_false((devcount == 0), NULL);
 }
 


### PR DESCRIPTION
The power management infrastructure added a generic API to access the static device list, but it is not generally available.  Provide an internal standard API for this.

Replace all the shell infrastructure that iterated over devices with a helper that implements it once.  This incidently fixes bugs related to using a pointer before checking it for null, and matching a prefix wherever it occurred in the device name.

Finally add standard API to determine whether a device is OK to use, so we can replace the nulling of the API pointer with something else.

Fixes #24750