### PR TITLE
sensors : fix bad pin value when disabling interruption

### DIFF
--- a/drivers/sensor/adxl372/adxl372.h
+++ b/drivers/sensor/adxl372/adxl372.h
@@ -297,6 +297,7 @@ struct adxl372_data {
 	struct sensor_trigger th_trigger;
 	sensor_trigger_handler_t drdy_handler;
 	struct sensor_trigger drdy_trigger;
+	struct device *dev;
 
 #if defined(CONFIG_ADXL372_TRIGGER_OWN_THREAD)
 	K_THREAD_STACK_MEMBER(thread_stack, CONFIG_ADXL372_THREAD_STACK_SIZE);
@@ -304,7 +305,6 @@ struct adxl372_data {
 	struct k_thread thread;
 #elif defined(CONFIG_ADXL372_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;
-	struct device *dev;
 #endif
 #endif /* CONFIG_ADXL372_TRIGGER */
 };

--- a/drivers/sensor/adxl372/adxl372_trigger.c
+++ b/drivers/sensor/adxl372/adxl372_trigger.c
@@ -56,7 +56,7 @@ static void adxl372_gpio_callback(struct device *dev,
 {
 	struct adxl372_data *drv_data =
 		CONTAINER_OF(cb, struct adxl372_data, gpio_cb);
-	const struct adxl372_dev_config *cfg = dev->config_info;
+	const struct adxl372_dev_config *cfg = drv_data->dev->config_info;
 
 	gpio_pin_interrupt_configure(drv_data->gpio, cfg->int_gpio,
 				     GPIO_INT_DISABLE);
@@ -161,6 +161,7 @@ int adxl372_init_interrupt(struct device *dev)
 		LOG_ERR("Failed to set gpio callback!");
 		return -EIO;
 	}
+	drv_data->dev = dev;
 
 #if defined(CONFIG_ADXL372_TRIGGER_OWN_THREAD)
 	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
@@ -172,7 +173,6 @@ int adxl372_init_interrupt(struct device *dev)
 			0, K_NO_WAIT);
 #elif defined(CONFIG_ADXL372_TRIGGER_GLOBAL_THREAD)
 	drv_data->work.handler = adxl372_work_cb;
-	drv_data->dev = dev;
 #endif
 
 	return 0;

--- a/drivers/sensor/iis2mdc/iis2mdc.h
+++ b/drivers/sensor/iis2mdc/iis2mdc.h
@@ -66,6 +66,7 @@ struct iis2mdc_data {
 	struct gpio_callback gpio_cb;
 
 	sensor_trigger_handler_t handler_drdy;
+	struct device *dev;
 
 #if defined(CONFIG_IIS2MDC_TRIGGER_OWN_THREAD)
 	K_THREAD_STACK_MEMBER(thread_stack, CONFIG_IIS2MDC_THREAD_STACK_SIZE);
@@ -73,7 +74,6 @@ struct iis2mdc_data {
 	struct k_sem gpio_sem;
 #elif defined(CONFIG_IIS2MDC_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;
-	struct device *dev;
 #endif  /* CONFIG_IIS2MDC_TRIGGER_GLOBAL_THREAD */
 #endif  /* CONFIG_IIS2MDC_TRIGGER */
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)

--- a/drivers/sensor/iis2mdc/iis2mdc_trigger.c
+++ b/drivers/sensor/iis2mdc/iis2mdc_trigger.c
@@ -73,7 +73,7 @@ static void iis2mdc_gpio_callback(struct device *dev,
 {
 	struct iis2mdc_data *iis2mdc =
 		CONTAINER_OF(cb, struct iis2mdc_data, gpio_cb);
-	const struct iis2mdc_config *const config = dev->config_info;
+	const struct iis2mdc_config *const config = iis2mdc->dev->config_info;
 
 	ARG_UNUSED(pins);
 
@@ -123,6 +123,7 @@ int iis2mdc_init_interrupt(struct device *dev)
 			    config->drdy_port);
 		return -EINVAL;
 	}
+	iis2mdc->dev = dev;
 
 #if defined(CONFIG_IIS2MDC_TRIGGER_OWN_THREAD)
 	k_sem_init(&iis2mdc->gpio_sem, 0, UINT_MAX);
@@ -133,7 +134,6 @@ int iis2mdc_init_interrupt(struct device *dev)
 			0, K_NO_WAIT);
 #elif defined(CONFIG_IIS2MDC_TRIGGER_GLOBAL_THREAD)
 	iis2mdc->work.handler = iis2mdc_work_cb;
-	iis2mdc->dev = dev;
 #endif
 
 	gpio_pin_configure(iis2mdc->gpio, config->drdy_pin,

--- a/drivers/sensor/iis3dhhc/iis3dhhc.h
+++ b/drivers/sensor/iis3dhhc/iis3dhhc.h
@@ -57,6 +57,7 @@ struct iis3dhhc_data {
 	struct gpio_callback gpio_cb;
 
 	sensor_trigger_handler_t handler_drdy;
+	struct device *dev;
 
 #if defined(CONFIG_IIS3DHHC_TRIGGER_OWN_THREAD)
 	K_THREAD_STACK_MEMBER(thread_stack, CONFIG_IIS3DHHC_THREAD_STACK_SIZE);
@@ -64,7 +65,6 @@ struct iis3dhhc_data {
 	struct k_sem gpio_sem;
 #elif defined(CONFIG_IIS3DHHC_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;
-	struct device *dev;
 #endif
 
 #endif /* CONFIG_IIS3DHHC_TRIGGER */

--- a/drivers/sensor/iis3dhhc/iis3dhhc_trigger.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc_trigger.c
@@ -84,7 +84,7 @@ static void iis3dhhc_gpio_callback(struct device *dev,
 {
 	struct iis3dhhc_data *iis3dhhc =
 		CONTAINER_OF(cb, struct iis3dhhc_data, gpio_cb);
-	const struct iis3dhhc_config *cfg = dev->config_info;
+	const struct iis3dhhc_config *cfg = iis3dhhc->dev->config_info;
 
 	ARG_UNUSED(pins);
 
@@ -135,6 +135,7 @@ int iis3dhhc_init_interrupt(struct device *dev)
 		LOG_DBG("Cannot get pointer to %s device", cfg->int_port);
 		return -EINVAL;
 	}
+	iis3dhhc->dev = dev;
 
 #if defined(CONFIG_IIS3DHHC_TRIGGER_OWN_THREAD)
 	k_sem_init(&iis3dhhc->gpio_sem, 0, UINT_MAX);
@@ -146,7 +147,6 @@ int iis3dhhc_init_interrupt(struct device *dev)
 		       0, K_NO_WAIT);
 #elif defined(CONFIG_IIS3DHHC_TRIGGER_GLOBAL_THREAD)
 	iis3dhhc->work.handler = iis3dhhc_work_cb;
-	iis3dhhc->dev = dev;
 #endif /* CONFIG_IIS3DHHC_TRIGGER_OWN_THREAD */
 
 	ret = gpio_pin_configure(iis3dhhc->gpio, cfg->int_pin,

--- a/drivers/sensor/ism330dhcx/ism330dhcx.h
+++ b/drivers/sensor/ism330dhcx/ism330dhcx.h
@@ -177,13 +177,14 @@ struct ism330dhcx_data {
 	sensor_trigger_handler_t handler_drdy_gyr;
 	sensor_trigger_handler_t handler_drdy_temp;
 
+	struct device *dev;
+
 #if defined(CONFIG_ISM330DHCX_TRIGGER_OWN_THREAD)
 	K_THREAD_STACK_MEMBER(thread_stack, CONFIG_ISM330DHCX_THREAD_STACK_SIZE);
 	struct k_thread thread;
 	struct k_sem gpio_sem;
 #elif defined(CONFIG_ISM330DHCX_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;
-	struct device *dev;
 #endif
 #endif /* CONFIG_ISM330DHCX_TRIGGER */
 

--- a/drivers/sensor/ism330dhcx/ism330dhcx_trigger.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx_trigger.c
@@ -209,7 +209,7 @@ static void ism330dhcx_gpio_callback(struct device *dev,
 {
 	struct ism330dhcx_data *ism330dhcx =
 		CONTAINER_OF(cb, struct ism330dhcx_data, gpio_cb);
-	const struct ism330dhcx_config *cfg = dev->config_info;
+	const struct ism330dhcx_config *cfg = ism330dhcx->dev->config_info;
 
 	ARG_UNUSED(pins);
 
@@ -260,6 +260,7 @@ int ism330dhcx_init_interrupt(struct device *dev)
 		LOG_ERR("Cannot get pointer to %s device", cfg->int_gpio_port);
 		return -EINVAL;
 	}
+	ism330dhcx->dev = dev;
 
 #if defined(CONFIG_ISM330DHCX_TRIGGER_OWN_THREAD)
 	k_sem_init(&ism330dhcx->gpio_sem, 0, UINT_MAX);
@@ -271,7 +272,6 @@ int ism330dhcx_init_interrupt(struct device *dev)
 			0, K_NO_WAIT);
 #elif defined(CONFIG_ISM330DHCX_TRIGGER_GLOBAL_THREAD)
 	ism330dhcx->work.handler = ism330dhcx_work_cb;
-	ism330dhcx->dev = dev;
 #endif /* CONFIG_ISM330DHCX_TRIGGER_OWN_THREAD */
 
 	ret = gpio_pin_configure(ism330dhcx->gpio, cfg->int_gpio_pin,

--- a/drivers/sensor/lis2ds12/lis2ds12.h
+++ b/drivers/sensor/lis2ds12/lis2ds12.h
@@ -120,6 +120,7 @@ struct lis2ds12_data {
 
 	struct sensor_trigger data_ready_trigger;
 	sensor_trigger_handler_t data_ready_handler;
+	struct device *dev;
 
 #if defined(CONFIG_LIS2DS12_TRIGGER_OWN_THREAD)
 	K_THREAD_STACK_MEMBER(thread_stack, CONFIG_LIS2DS12_THREAD_STACK_SIZE);
@@ -127,7 +128,6 @@ struct lis2ds12_data {
 	struct k_sem trig_sem;
 #elif defined(CONFIG_LIS2DS12_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;
-	struct device *dev;
 #endif
 
 #endif /* CONFIG_LIS2DS12_TRIGGER */

--- a/drivers/sensor/lis2ds12/lis2ds12_trigger.c
+++ b/drivers/sensor/lis2ds12/lis2ds12_trigger.c
@@ -24,7 +24,7 @@ static void lis2ds12_gpio_callback(struct device *dev,
 {
 	struct lis2ds12_data *data =
 		CONTAINER_OF(cb, struct lis2ds12_data, gpio_cb);
-	const struct lis2ds12_config *cfg = dev->config_info;
+	const struct lis2ds12_config *cfg = data->dev->config_info;
 
 	ARG_UNUSED(pins);
 
@@ -140,6 +140,7 @@ int lis2ds12_trigger_init(struct device *dev)
 		LOG_ERR("Could not set gpio callback.");
 		return -EIO;
 	}
+	data->dev = dev;
 
 #if defined(CONFIG_LIS2DS12_TRIGGER_OWN_THREAD)
 	k_sem_init(&data->trig_sem, 0, UINT_MAX);
@@ -151,7 +152,6 @@ int lis2ds12_trigger_init(struct device *dev)
 			0, K_NO_WAIT);
 #elif defined(CONFIG_LIS2DS12_TRIGGER_GLOBAL_THREAD)
 	data->work.handler = lis2ds12_work_cb;
-	data->dev = dev;
 #endif
 
 	gpio_pin_interrupt_configure(data->gpio, cfg->irq_pin,

--- a/drivers/sensor/lis2dw12/lis2dw12_trigger.c
+++ b/drivers/sensor/lis2dw12/lis2dw12_trigger.c
@@ -128,7 +128,7 @@ static int lis2dw12_handle_drdy_int(struct device *dev)
 static int lis2dw12_handle_single_tap_int(struct device *dev)
 {
 	struct lis2dw12_data *data = dev->driver_data;
-	sensor_trigger_handler_t handler = data->tap_handler;;
+	sensor_trigger_handler_t handler = data->tap_handler;
 
 	struct sensor_trigger pulse_trig = {
 		.type = SENSOR_TRIG_TAP,
@@ -145,7 +145,7 @@ static int lis2dw12_handle_single_tap_int(struct device *dev)
 static int lis2dw12_handle_double_tap_int(struct device *dev)
 {
 	struct lis2dw12_data *data = dev->driver_data;
-	sensor_trigger_handler_t handler = data->double_tap_handler;;
+	sensor_trigger_handler_t handler = data->double_tap_handler;
 
 	struct sensor_trigger pulse_trig = {
 		.type = SENSOR_TRIG_DOUBLE_TAP,

--- a/drivers/sensor/lis2mdl/lis2mdl.h
+++ b/drivers/sensor/lis2mdl/lis2mdl.h
@@ -66,6 +66,7 @@ struct lis2mdl_data {
 	struct gpio_callback gpio_cb;
 
 	sensor_trigger_handler_t handler_drdy;
+	struct device *dev;
 
 #if defined(CONFIG_LIS2MDL_TRIGGER_OWN_THREAD)
 	K_THREAD_STACK_MEMBER(thread_stack, CONFIG_LIS2MDL_THREAD_STACK_SIZE);
@@ -73,7 +74,6 @@ struct lis2mdl_data {
 	struct k_sem gpio_sem;
 #elif defined(CONFIG_LIS2MDL_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;
-	struct device *dev;
 #endif  /* CONFIG_LIS2MDL_TRIGGER_GLOBAL_THREAD */
 #endif  /* CONFIG_LIS2MDL_TRIGGER */
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)

--- a/drivers/sensor/lis2mdl/lis2mdl_trigger.c
+++ b/drivers/sensor/lis2mdl/lis2mdl_trigger.c
@@ -73,7 +73,7 @@ static void lis2mdl_gpio_callback(struct device *dev,
 {
 	struct lis2mdl_data *lis2mdl =
 		CONTAINER_OF(cb, struct lis2mdl_data, gpio_cb);
-	const struct lis2mdl_config *const config = dev->config_info;
+	const struct lis2mdl_config *const config = lis2mdl->dev->config_info;
 
 	ARG_UNUSED(pins);
 
@@ -123,6 +123,7 @@ int lis2mdl_init_interrupt(struct device *dev)
 			    config->gpio_name);
 		return -EINVAL;
 	}
+	lis2mdl->dev = dev;
 
 #if defined(CONFIG_LIS2MDL_TRIGGER_OWN_THREAD)
 	k_sem_init(&lis2mdl->gpio_sem, 0, UINT_MAX);
@@ -133,7 +134,6 @@ int lis2mdl_init_interrupt(struct device *dev)
 			0, K_NO_WAIT);
 #elif defined(CONFIG_LIS2MDL_TRIGGER_GLOBAL_THREAD)
 	lis2mdl->work.handler = lis2mdl_work_cb;
-	lis2mdl->dev = dev;
 #endif
 
 	gpio_pin_configure(lis2mdl->gpio, config->gpio_pin,

--- a/drivers/sensor/lps22hh/lps22hh.h
+++ b/drivers/sensor/lps22hh/lps22hh.h
@@ -69,6 +69,7 @@ struct lps22hh_data {
 
 	struct sensor_trigger data_ready_trigger;
 	sensor_trigger_handler_t handler_drdy;
+	struct device *dev;
 
 #if defined(CONFIG_LPS22HH_TRIGGER_OWN_THREAD)
 	K_THREAD_STACK_MEMBER(thread_stack, CONFIG_LPS22HH_THREAD_STACK_SIZE);
@@ -76,7 +77,6 @@ struct lps22hh_data {
 	struct k_sem gpio_sem;
 #elif defined(CONFIG_LPS22HH_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;
-	struct device *dev;
 #endif
 
 #endif /* CONFIG_LPS22HH_TRIGGER */

--- a/drivers/sensor/lps22hh/lps22hh_trigger.c
+++ b/drivers/sensor/lps22hh/lps22hh_trigger.c
@@ -87,11 +87,11 @@ static void lps22hh_handle_interrupt(void *arg)
 static void lps22hh_gpio_callback(struct device *dev,
 				  struct gpio_callback *cb, uint32_t pins)
 {
-	const struct lps22hh_config *cfg = dev->config_info;
 	struct lps22hh_data *lps22hh =
 		CONTAINER_OF(cb, struct lps22hh_data, gpio_cb);
 
 	ARG_UNUSED(pins);
+	const struct lps22hh_config *cfg = lps22hh->dev->config_info;
 
 	gpio_pin_interrupt_configure(lps22hh->gpio, cfg->drdy_pin,
 				     GPIO_INT_DISABLE);
@@ -140,6 +140,7 @@ int lps22hh_init_interrupt(struct device *dev)
 		LOG_DBG("Cannot get pointer to %s device", cfg->drdy_port);
 		return -EINVAL;
 	}
+	lps22hh->dev = dev;
 
 #if defined(CONFIG_LPS22HH_TRIGGER_OWN_THREAD)
 	k_sem_init(&lps22hh->gpio_sem, 0, UINT_MAX);
@@ -151,7 +152,6 @@ int lps22hh_init_interrupt(struct device *dev)
 		       0, K_NO_WAIT);
 #elif defined(CONFIG_LPS22HH_TRIGGER_GLOBAL_THREAD)
 	lps22hh->work.handler = lps22hh_work_cb;
-	lps22hh->dev = dev;
 #endif /* CONFIG_LPS22HH_TRIGGER_OWN_THREAD */
 
 	ret = gpio_pin_configure(lps22hh->gpio, cfg->drdy_pin,

--- a/drivers/sensor/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/lsm6dso/lsm6dso.h
@@ -176,6 +176,7 @@ struct lsm6dso_data {
 	sensor_trigger_handler_t handler_drdy_acc;
 	sensor_trigger_handler_t handler_drdy_gyr;
 	sensor_trigger_handler_t handler_drdy_temp;
+	struct device *dev;
 
 #if defined(CONFIG_LSM6DSO_TRIGGER_OWN_THREAD)
 	K_THREAD_STACK_MEMBER(thread_stack, CONFIG_LSM6DSO_THREAD_STACK_SIZE);
@@ -183,7 +184,6 @@ struct lsm6dso_data {
 	struct k_sem gpio_sem;
 #elif defined(CONFIG_LSM6DSO_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;
-	struct device *dev;
 #endif
 #endif /* CONFIG_LSM6DSO_TRIGGER */
 

--- a/drivers/sensor/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_trigger.c
@@ -209,7 +209,7 @@ static void lsm6dso_gpio_callback(struct device *dev,
 {
 	struct lsm6dso_data *lsm6dso =
 		CONTAINER_OF(cb, struct lsm6dso_data, gpio_cb);
-	const struct lsm6dso_config *cfg = dev->config_info;
+	const struct lsm6dso_config *cfg = lsm6dso->dev->config_info;
 
 	ARG_UNUSED(pins);
 
@@ -261,6 +261,7 @@ int lsm6dso_init_interrupt(struct device *dev)
 			    cfg->int_gpio_port);
 		return -EINVAL;
 	}
+	lsm6dso->dev = dev;
 
 #if defined(CONFIG_LSM6DSO_TRIGGER_OWN_THREAD)
 	k_sem_init(&lsm6dso->gpio_sem, 0, UINT_MAX);
@@ -272,7 +273,6 @@ int lsm6dso_init_interrupt(struct device *dev)
 			0, K_NO_WAIT);
 #elif defined(CONFIG_LSM6DSO_TRIGGER_GLOBAL_THREAD)
 	lsm6dso->work.handler = lsm6dso_work_cb;
-	lsm6dso->dev = dev;
 #endif /* CONFIG_LSM6DSO_TRIGGER_OWN_THREAD */
 
 	ret = gpio_pin_configure(lsm6dso->gpio, cfg->int_gpio_pin,

--- a/drivers/sensor/stts751/stts751.h
+++ b/drivers/sensor/stts751/stts751.h
@@ -54,6 +54,7 @@ struct stts751_data {
 
 	struct sensor_trigger data_ready_trigger;
 	sensor_trigger_handler_t thsld_handler;
+	struct device *dev;
 
 #if defined(CONFIG_STTS751_TRIGGER_OWN_THREAD)
 	K_THREAD_STACK_MEMBER(thread_stack, CONFIG_STTS751_THREAD_STACK_SIZE);
@@ -61,7 +62,6 @@ struct stts751_data {
 	struct k_sem gpio_sem;
 #elif defined(CONFIG_STTS751_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;
-	struct device *dev;
 #endif
 
 #endif /* CONFIG_STTS751_TRIGGER */

--- a/drivers/sensor/stts751/stts751_trigger.c
+++ b/drivers/sensor/stts751/stts751_trigger.c
@@ -79,9 +79,9 @@ static void stts751_handle_interrupt(void *arg)
 static void stts751_gpio_callback(struct device *dev,
 				  struct gpio_callback *cb, uint32_t pins)
 {
-	const struct stts751_config *cfg = dev->config_info;
 	struct stts751_data *stts751 =
 		CONTAINER_OF(cb, struct stts751_data, gpio_cb);
+	const struct stts751_config *cfg = stts751->dev->config_info;
 
 	ARG_UNUSED(pins);
 
@@ -131,6 +131,7 @@ int stts751_init_interrupt(struct device *dev)
 		LOG_DBG("Cannot get pointer to %s device", cfg->event_port);
 		return -EINVAL;
 	}
+	stts751->dev = dev;
 
 #if defined(CONFIG_STTS751_TRIGGER_OWN_THREAD)
 	k_sem_init(&stts751->gpio_sem, 0, UINT_MAX);
@@ -142,7 +143,6 @@ int stts751_init_interrupt(struct device *dev)
 		       0, K_NO_WAIT);
 #elif defined(CONFIG_STTS751_TRIGGER_GLOBAL_THREAD)
 	stts751->work.handler = stts751_work_cb;
-	stts751->dev = dev;
 #endif /* CONFIG_STTS751_TRIGGER_OWN_THREAD */
 
 	ret = gpio_pin_configure(stts751->gpio, cfg->event_pin,


### PR DESCRIPTION
In gpio callback function of some sensor drivers, the device structure in parameter is about the gpio and not the sensor.

Signed-off-by: laurence pasteau <laurence.pasteau@stimio.fr>