### PR TITLE
dts: bindings: fix up 'label' property description

### DIFF
--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -54,7 +54,7 @@ properties:
     label:
         type: string
         required: false
-        description: Human readable string describing the device (used by Zephyr for API name)
+        description: Human readable string describing the device (used as device_get_binding() argument)
 
     clocks:
         type: phandle-array

--- a/dts/bindings/clock/fixed-clock.yaml
+++ b/dts/bindings/clock/fixed-clock.yaml
@@ -11,7 +11,7 @@ properties:
     label:
       type: string
       required: false
-      description: Human readable string describing the device (used by Zephyr for API name)
+      description: Human readable string describing the device (used as device_get_binding() argument)
 
     clock-frequency:
       type: int

--- a/dts/bindings/gpio/gpio-keys.yaml
+++ b/dts/bindings/gpio/gpio-keys.yaml
@@ -14,4 +14,4 @@ child-binding:
        label:
           required: true
           type: string
-          description: Human readable string describing the device (used by Zephyr for API name)
+          description: Human readable string describing the device (used as device_get_binding() argument)

--- a/dts/bindings/gpio/gpio-leds.yaml
+++ b/dts/bindings/gpio/gpio-leds.yaml
@@ -14,4 +14,4 @@ child-binding:
        label:
           required: true
           type: string
-          description: Human readable string describing the device (used by Zephyr for API name)
+          description: Human readable string describing the device (used as device_get_binding() argument)

--- a/dts/bindings/led/pwm-leds.yaml
+++ b/dts/bindings/led/pwm-leds.yaml
@@ -15,4 +15,4 @@ child-binding:
         label:
           required: false
           type: string
-          description: Human readable string describing the device (used by Zephyr for API name)
+          description: Human readable string describing the device (used as device_get_binding() argument)

--- a/dts/bindings/mtd/partition.yaml
+++ b/dts/bindings/mtd/partition.yaml
@@ -19,7 +19,7 @@ child-binding:
        label:
           type: string
           required: false
-          description: Human readable string describing the device (used by Zephyr for API name)
+          description: Human readable string describing the device (used as device_get_binding() argument)
        read-only:
           type: boolean
           required: false

--- a/dts/bindings/pinctrl/microchip,xec-pinmux.yaml
+++ b/dts/bindings/pinctrl/microchip,xec-pinmux.yaml
@@ -13,4 +13,4 @@ child-binding:
        label:
           required: true
           type: string
-          description: Human readable string describing the device (used by Zephyr for API name)
+          description: Human readable string describing the device (used as device_get_binding() argument)

--- a/dts/bindings/usb/usb-audio.yaml
+++ b/dts/bindings/usb/usb-audio.yaml
@@ -10,4 +10,4 @@ properties:
   label:
     required: true
     type: string
-    description: Human readable string describing the device (used by Zephyr for API name)
+    description: Human readable string describing the device (used as device_get_binding() argument)


### PR DESCRIPTION
The value of a label property isn't really the name of an API. It's
the name of a device, as passed to device_get_binding().

Let's just say that directly so people know what this means in
practice instead of what's currently used as the description, which is
harder to understand and not really accurate.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>