### PR TITLE
Use proper section macros in networking

### DIFF
--- a/include/linker/common-ram.ld
+++ b/include/linker/common-ram.ld
@@ -99,29 +99,11 @@
 		KEEP(*(SORT_BY_NAME("._net_buf_pool.static.*")))
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-	SECTION_DATA_PROLOGUE(net_if,,SUBALIGN(4))
-	{
-		__net_if_start = .;
-		*(".net_if.*")
-		KEEP(*(SORT_BY_NAME(".net_if.*")))
-		__net_if_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
-	SECTION_DATA_PROLOGUE(net_if_dev,,SUBALIGN(4))
-	{
-		__net_if_dev_start = .;
-		*(".net_if_dev.*")
-		KEEP(*(SORT_BY_NAME(".net_if_dev.*")))
-		__net_if_dev_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
-	SECTION_DATA_PROLOGUE(net_l2_data,,SUBALIGN(4))
-	{
-		__net_l2_data_start = .;
-		*(".net_l2.data")
-		KEEP(*(SORT_BY_NAME(".net_l2.data*")))
-		__net_l2_data_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+#if defined(CONFIG_NETWORKING)
+	Z_ITERABLE_SECTION_RAM(net_if, 4)
+	Z_ITERABLE_SECTION_RAM(net_if_dev, 4)
+	Z_ITERABLE_SECTION_RAM(net_l2, 4)
+#endif /* NETWORKING */
 
 #if defined(CONFIG_UART_MUX)
 	SECTION_DATA_PROLOGUE(uart_mux,,SUBALIGN(4))

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -86,26 +86,12 @@
 		__app_shmem_regions_end = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
-	SECTION_PROLOGUE(net_l2,,)
-	{
-		__net_l2_start = .;
-		*(".net_l2.init")
-		KEEP(*(SORT_BY_NAME(".net_l2.init*")))
-		__net_l2_end = .;
-	} GROUP_LINK_IN(ROMABLE_REGION)
-
 #if defined(CONFIG_NET_SOCKETS)
 	Z_ITERABLE_SECTION_ROM(net_socket_register, 4)
 #endif
 
 #if defined(CONFIG_NET_L2_PPP)
-	SECTION_PROLOGUE(net_ppp_proto,,)
-	{
-		__net_ppp_proto_start = .;
-		*(".net_ppp_proto.*")
-		KEEP(*(SORT_BY_NAME(".net_ppp_proto.*")))
-		__net_ppp_proto_end = .;
-	} GROUP_LINK_IN(ROMABLE_REGION)
+	Z_ITERABLE_SECTION_ROM(ppp_protocol_handler, 4)
 #endif
 
 	Z_ITERABLE_SECTION_ROM(bt_l2cap_fixed_chan, 4)

--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -2179,23 +2179,23 @@ struct net_if_api {
 		NET_IF_DHCPV4_INIT			\
 	}
 
-#define NET_IF_GET_NAME(dev_name, sfx) (__net_if_##dev_name##_##sfx)
-#define NET_IF_DEV_GET_NAME(dev_name, sfx) (__net_if_dev_##dev_name##_##sfx)
+#define NET_IF_GET_NAME(dev_name, sfx) __net_if_##dev_name##_##sfx
+#define NET_IF_DEV_GET_NAME(dev_name, sfx) __net_if_dev_##dev_name##_##sfx
 
 #define NET_IF_GET(dev_name, sfx)					\
 	((struct net_if *)&NET_IF_GET_NAME(dev_name, sfx))
 
 #define NET_IF_INIT(dev_name, sfx, _l2, _mtu, _num_configs)		\
-	static struct net_if_dev (NET_IF_DEV_GET_NAME(dev_name, sfx))	\
-	__used __attribute__((__section__(".net_if_dev.data"))) = {	\
+	static Z_STRUCT_SECTION_ITERABLE(net_if_dev,			\
+				NET_IF_DEV_GET_NAME(dev_name, sfx)) = { \
 		.dev = &(DEVICE_NAME_GET(dev_name)),			\
 		.l2 = &(NET_L2_GET_NAME(_l2)),				\
 		.l2_data = &(NET_L2_GET_DATA(dev_name, sfx)),		\
 		.mtu = _mtu,						\
 	};								\
-	static struct net_if						\
-	(NET_IF_GET_NAME(dev_name, sfx))[_num_configs] __used		\
-	__attribute__((__section__(".net_if.data"))) = {		\
+	static Z_DECL_ALIGN(struct net_if)				\
+		       NET_IF_GET_NAME(dev_name, sfx)[_num_configs]	\
+		       __used __in_section(_net_if, static, net_if) = {	\
 		[0 ... (_num_configs - 1)] = {				\
 			.if_dev = &(NET_IF_DEV_GET_NAME(dev_name, sfx)), \
 			NET_IF_CONFIG_INIT				\

--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -160,22 +160,6 @@ struct net_if_router {
 	uint8_t _unused : 5;
 };
 
-/*
- * Special alignment is needed for net_if which is stored in
- * a net_if linker section if there are more than one network
- * interface in the system. If there is only one network interface,
- * then this alignment is not needed, unfortunately this cannot be
- * known beforehand.
- *
- * The net_if struct needs to be aligned to 32 byte boundary,
- * otherwise the __net_if_end will point to wrong location and net_if
- * initialization done in net_if_init() will not find proper values
- * for the second interface.
- *
- * So this alignment is a workaround and should eventually be removed.
- */
-#define __net_if_align __aligned(32)
-
 enum net_if_flag {
 	/** Interface is up/ready to receive and transmit */
 	NET_IF_UP,
@@ -480,7 +464,7 @@ struct net_if {
 	 */
 	int tx_pending;
 #endif
-} __net_if_align;
+};
 
 /**
  * @brief Set a value in network interface flags

--- a/include/net/net_l2.h
+++ b/include/net/net_l2.h
@@ -77,7 +77,7 @@ struct net_l2 {
 };
 
 /** @cond INTERNAL_HIDDEN */
-#define NET_L2_GET_NAME(_name) __net_l2_##_name
+#define NET_L2_GET_NAME(_name) _net_l2_##_name
 #define NET_L2_DECLARE_PUBLIC(_name)					\
 	extern const struct net_l2 NET_L2_GET_NAME(_name)
 #define NET_L2_GET_CTX_TYPE(_name) _name##_CTX_TYPE
@@ -126,19 +126,18 @@ NET_L2_DECLARE_PUBLIC(CANBUS_L2);
 #endif /* CONFIG_NET_L2_CANBUS */
 
 #define NET_L2_INIT(_name, _recv_fn, _send_fn, _enable_fn, _get_flags_fn) \
-	const struct net_l2 (NET_L2_GET_NAME(_name)) __used		\
-	__attribute__((__section__(".net_l2.init"))) = {		\
+	const Z_STRUCT_SECTION_ITERABLE(net_l2,				\
+					NET_L2_GET_NAME(_name)) = {	\
 		.recv = (_recv_fn),					\
 		.send = (_send_fn),					\
 		.enable = (_enable_fn),					\
 		.get_flags = (_get_flags_fn),				\
 	}
 
-#define NET_L2_GET_DATA(name, sfx) (__net_l2_data_##name##sfx)
+#define NET_L2_GET_DATA(name, sfx) _net_l2_data_##name##sfx
 
 #define NET_L2_DATA_INIT(name, sfx, ctx_type)				\
-	static ctx_type NET_L2_GET_DATA(name, sfx) __used		\
-	__attribute__((__section__(".net_l2.data")));
+	static ctx_type NET_L2_GET_DATA(name, sfx) __used;
 
 /** @endcond */
 

--- a/subsys/net/l2/ppp/link.c
+++ b/subsys/net/l2/ppp/link.c
@@ -18,11 +18,7 @@ LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 
 static void lcp_up(struct ppp_context *ctx)
 {
-	struct ppp_protocol_handler *proto;
-
-	for (proto = __net_ppp_proto_start;
-	     proto != __net_ppp_proto_end;
-	     proto++) {
+	Z_STRUCT_SECTION_FOREACH(ppp_protocol_handler, proto) {
 		if (proto->protocol == PPP_LCP) {
 			continue;
 		}
@@ -35,13 +31,9 @@ static void lcp_up(struct ppp_context *ctx)
 
 static void do_network(struct ppp_context *ctx)
 {
-	const struct ppp_protocol_handler *proto;
-
 	ppp_change_phase(ctx, PPP_NETWORK);
 
-	for (proto = __net_ppp_proto_start;
-	     proto != __net_ppp_proto_end;
-	     proto++) {
+	Z_STRUCT_SECTION_FOREACH(ppp_protocol_handler, proto) {
 		if (proto->protocol == PPP_CCP || proto->protocol == PPP_ECP) {
 			if (proto->open) {
 				proto->open(ctx);
@@ -54,9 +46,7 @@ static void do_network(struct ppp_context *ctx)
 	 */
 	/* TODO possible encryption stuff here*/
 
-	for (proto = __net_ppp_proto_start;
-	     proto != __net_ppp_proto_end;
-	     proto++) {
+	Z_STRUCT_SECTION_FOREACH(ppp_protocol_handler, proto) {
 		if (proto->protocol == PPP_CCP || proto->protocol == PPP_ECP ||
 		    proto->protocol >= 0xC000) {
 			continue;
@@ -69,7 +59,8 @@ static void do_network(struct ppp_context *ctx)
 	}
 
 	if (ctx->network_protos_open == 0) {
-		proto = ppp_lcp_get();
+		const struct ppp_protocol_handler *proto = ppp_lcp_get();
+
 		if (proto) {
 			proto->close(ctx, "No network protocols open");
 		}

--- a/subsys/net/l2/ppp/network.c
+++ b/subsys/net/l2/ppp/network.c
@@ -55,11 +55,7 @@ void ppp_network_done(struct ppp_context *ctx, int proto)
 
 void ppp_network_all_down(struct ppp_context *ctx)
 {
-	struct ppp_protocol_handler *proto;
-
-	for (proto = __net_ppp_proto_start;
-	     proto != __net_ppp_proto_end;
-	     proto++) {
+	Z_STRUCT_SECTION_FOREACH(ppp_protocol_handler, proto) {
 		if (proto->protocol != PPP_LCP && proto->lower_down) {
 			proto->lower_down(ctx);
 		}

--- a/subsys/net/l2/ppp/ppp_internal.h
+++ b/subsys/net/l2/ppp/ppp_internal.h
@@ -44,12 +44,6 @@ struct ppp_packet {
 /** Max number of IPV6CP options */
 #define MAX_IPV6CP_OPTIONS 1
 
-/*
- * Special alignment is needed for ppp_protocol_handler. This is the
- * same issue as in net_if. See net_if.h __net_if_align for explanation.
- */
-#define __ppp_proto_align __aligned(32)
-
 /** Protocol handler information. */
 struct ppp_protocol_handler {
 	/** Protocol init function */
@@ -74,7 +68,7 @@ struct ppp_protocol_handler {
 
 	/** PPP protocol number */
 	uint16_t protocol;
-} __ppp_proto_align;
+};
 
 #define PPP_PROTO_GET_NAME(proto_name)		\
 	(ppp_protocol_handler_##proto_name)

--- a/subsys/net/l2/ppp/ppp_internal.h
+++ b/subsys/net/l2/ppp/ppp_internal.h
@@ -82,9 +82,8 @@ struct ppp_protocol_handler {
 #define PPP_PROTOCOL_REGISTER(name, proto, init_func, proto_handler,	\
 			      proto_lower_up, proto_lower_down,		\
 			      proto_open, proto_close)			\
-	static const struct ppp_protocol_handler			\
-	(PPP_PROTO_GET_NAME(name)) __used				\
-	__attribute__((__section__(".net_ppp_proto.data"))) = {		\
+	static const Z_STRUCT_SECTION_ITERABLE(ppp_protocol_handler,	\
+					PPP_PROTO_GET_NAME(name)) = {	\
 		.protocol = proto,					\
 		.init = init_func,					\
 		.handler = proto_handler,				\
@@ -93,9 +92,6 @@ struct ppp_protocol_handler {
 		.open = proto_open,					\
 		.close = proto_close,					\
 	}
-
-extern struct ppp_protocol_handler __net_ppp_proto_start[];
-extern struct ppp_protocol_handler __net_ppp_proto_end[];
 
 const char *ppp_phase_str(enum ppp_phase phase);
 const char *ppp_state_str(enum ppp_state state);


### PR DESCRIPTION
Convert networking code to use `Z_STRUCT_SECTION_FOREACH()` and `Z_STRUCT_SECTION_ITERABLE()` macros.
Also remove special alignment from net_if and ppp_protocol_handlers structs as they no longer seem to be needed.