### PR TITLE
kconfig: modules: add MBEDTLS_PKCS1_V21_ENABLED config option

### DIFF
--- a/modules/Kconfig.tls-generic
+++ b/modules/Kconfig.tls-generic
@@ -340,4 +340,11 @@ config MBEDTLS_USER_CONFIG_FILE
 	  User config file that can contain mbedTLS configs that were not
 	  covered by the generic config file.
 
+config MBEDTLS_PKCS1_V21_ENABLED
+	bool "PKCS#1 v2.1 encoding"
+	select MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
+	help
+	  Enable PKCS#1 v2.1 encoding specified by RFC3447 utilizing RSAES-OAEP
+	  and RSASSA-PSS operations.
+
 endmenu


### PR DESCRIPTION
Enable PKCS1 v2.1 support with a new config option.  PKCS1 v2.1 defines a
more signature methodology by making use of  RSAES-OAEP and RSAASSA-PSS.

Depends on PR#12 in mbedtls:  https://github.com/zephyrproject-rtos/mbedtls/pull/12

Signed-off-by: Eugene Cohen <eugene@nuviainc.com>