### PR TITLE
tests: portability: cmsis_rtos_v1: Increase clock tolerance

### DIFF
--- a/tests/portability/cmsis_rtos_v1/src/kernel_apis.c
+++ b/tests/portability/cmsis_rtos_v1/src/kernel_apis.c
@@ -10,6 +10,20 @@
 
 #define WAIT_TIME_US 1000000
 
+/* Specify accepted tolerance. On some Zephyr platforms  (e.g. nRF5x) the busy
+ * wait loop and the system timer are based on different mechanisms and may not
+ * align perfectly.
+ */
+#if CONFIG_NRF_RTC_TIMER
+/* High frequency clock used for k_busy_wait may have up to 8% tolerance.
+ * Additionally, if RC is used for low frequency clock then it has 5% tolerance.
+ */
+#define TOLERANCE_PPC \
+	1 + 8 + (IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC) ? 5 : 0)
+#else
+#define TOLERANCE_PPC 1
+#endif
+
 /**
  * @brief Test kernel start
  *
@@ -48,12 +62,8 @@ void test_kernel_systick(void)
 	diff = (uint32_t)k_cyc_to_ns_floor64(stop_time -
 					 start_time) / NSEC_PER_USEC;
 
-	/* Check that it's within 1%.  On some Zephyr platforms
-	 * (e.g. nRF5x) the busy wait loop and the system timer are
-	 * based on different mechanisms and may not align perfectly.
-	 */
-	max = WAIT_TIME_US + (WAIT_TIME_US / 100);
-	min = WAIT_TIME_US - (WAIT_TIME_US / 100);
+	max = WAIT_TIME_US + (TOLERANCE_PPC * WAIT_TIME_US / 100);
+	min = WAIT_TIME_US - (TOLERANCE_PPC * WAIT_TIME_US / 100);
 
 	zassert_true(diff <= max && diff >= min,
 		     "start %d stop %d (diff %d) wait %d\n",


### PR DESCRIPTION
Increased accepted difference between system clock and
k_busy_wait clock. Some platforms (e.g. Nordic SoC) are using
different clocks for system clock (low frequency) and k_busy_wait
(high frequency). If those clocks are driven from low accuracy
source like RC oscillator then difference may be significant.

Fixes #26280. 
Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>