### PR TITLE
manifest: update mcuboot to upmerged to upstream 33fbef5

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -86,7 +86,7 @@ manifest:
       path: modules/crypto/mbedtls
       revision: 4bf099f1254332d16dcd931ccea0a88d24a7d3c7
     - name: mcuboot
-      revision: 032eb725c79268c2e111eff3f05663b1c0ff34cb
+      revision: d52aff5065ab5995f785877a834112461ff93526
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 898a5a7f5224be8345e58eca3b9a84389ed61d15


### PR DESCRIPTION
MCUBoot was synchronized with upsteram
https://github.com/JuulLabs-OSS/mcuboot/commit/33fbef5

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>

introduces: https://github.com/zephyrproject-rtos/mcuboot/pull/25