### PR TITLE
LPC55xxx SPI fixes

### DIFF
--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -510,7 +510,6 @@ static int eth_enc28j60_rx(struct device *dev, uint16_t *vlan_tag)
 	struct eth_enc28j60_runtime *context = dev->driver_data;
 	uint16_t lengthfr;
 	uint8_t counter;
-	uint8_t dummy[4];
 
 	/* Errata 6. The Receive Packet Pending Interrupt Flag (EIR.PKTIF)
 	 * does not reliably/accurately report the status of pending packet.
@@ -601,13 +600,13 @@ static int eth_enc28j60_rx(struct device *dev, uint16_t *vlan_tag)
 		} while (frm_len > 0);
 
 		/* Let's pop the useless CRC */
-		eth_enc28j60_read_mem(dev, dummy, 4);
+		eth_enc28j60_read_mem(dev, NULL, 4);
 
 		/* Pops one padding byte from spi circular buffer
 		 * introduced by the device when the frame length is odd
 		 */
 		if (lengthfr & 0x01) {
-			eth_enc28j60_read_mem(dev, dummy, 1);
+			eth_enc28j60_read_mem(dev, NULL, 1);
 		}
 
 #if defined(CONFIG_NET_VLAN)

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -46,24 +46,22 @@ static void spi_mcux_transfer_next_packet(struct device *dev)
 		return;
 	}
 
+	transfer.configFlags = 0;
 	if (ctx->tx_len == 0) {
 		/* rx only, nothing to tx */
 		transfer.txData = NULL;
 		transfer.rxData = ctx->rx_buf;
 		transfer.dataSize = ctx->rx_len;
-		transfer.configFlags = kSPI_FrameAssert;
 	} else if (ctx->rx_len == 0) {
 		/* tx only, nothing to rx */
 		transfer.txData = (uint8_t *) ctx->tx_buf;
 		transfer.rxData = NULL;
 		transfer.dataSize = ctx->tx_len;
-		transfer.configFlags = kSPI_FrameAssert;
 	} else if (ctx->tx_len == ctx->rx_len) {
 		/* rx and tx are the same length */
 		transfer.txData = (uint8_t *) ctx->tx_buf;
 		transfer.rxData = ctx->rx_buf;
 		transfer.dataSize = ctx->tx_len;
-		transfer.configFlags = kSPI_FrameAssert;
 	} else if (ctx->tx_len > ctx->rx_len) {
 		/* Break up the tx into multiple transfers so we don't have to
 		 * rx into a longer intermediate buffer. Leave chip select
@@ -72,7 +70,6 @@ static void spi_mcux_transfer_next_packet(struct device *dev)
 		transfer.txData = (uint8_t *) ctx->tx_buf;
 		transfer.rxData = ctx->rx_buf;
 		transfer.dataSize = ctx->rx_len;
-		transfer.configFlags = 0;
 	} else {
 		/* Break up the rx into multiple transfers so we don't have to
 		 * tx from a longer intermediate buffer. Leave chip select
@@ -81,7 +78,6 @@ static void spi_mcux_transfer_next_packet(struct device *dev)
 		transfer.txData = (uint8_t *) ctx->tx_buf;
 		transfer.rxData = ctx->rx_buf;
 		transfer.dataSize = ctx->tx_len;
-		transfer.configFlags = 0;
 	}
 
 	if (ctx->tx_count <= 1 && ctx->rx_count <= 1) {

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -192,10 +192,12 @@
 
 	hs_lspi: spi@9f000 {
 		compatible = "nxp,lpc-spi";
-		cs-gpios = <&gpio0 20 GPIO_ACTIVE_LOW>,
+		/* Enabling cs-gpios below will allow using GPIO CS,
+		 rather than Flexcomm SS */
+		/* cs-gpios = <&gpio0 20 GPIO_ACTIVE_LOW>,
 			<&gpio1 1 GPIO_ACTIVE_LOW>,
 			<&gpio1 12 GPIO_ACTIVE_LOW>,
-			<&gpio1 26 GPIO_ACTIVE_LOW>;
+			<&gpio1 26 GPIO_ACTIVE_LOW>; */
 		reg = <0x9f000 0x1000>;
 		interrupts = <59 0>;
 		label = "HS_LSPI";


### PR DESCRIPTION
 - reverts part of pull #26213 that affects enc28j60
 - spi_mcux_flexcomm CS remains asserted low between transfers
 - GPIO CS on HS_SPI disabled by default
 - update hal_nxp to a version which allows NULL Rx buffers


Depends on: https://github.com/zephyrproject-rtos/hal_nxp/pull/46 