### PR TITLE
Bluetooth: Gatt: Added write callback for gatt (un)subscribe

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -1396,6 +1396,8 @@ enum {
 struct bt_gatt_subscribe_params {
 	/** Notification value callback */
 	bt_gatt_notify_func_t notify;
+	/** Subscribe CCC write request response callback */
+	bt_gatt_write_func_t write;
 	/** Subscribe value handle */
 	uint16_t value_handle;
 	/** Subscribe CCC handle */

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -3863,6 +3863,10 @@ static void gatt_write_ccc_rsp(struct bt_conn *conn, uint8_t err,
 		/* Notify with NULL data to complete unsubscribe */
 		params->notify(conn, params, NULL, 0);
 	}
+
+	if (params->write) {
+		params->write(conn, err, NULL);
+	}
 }
 
 static int gatt_write_ccc(struct bt_conn *conn, uint16_t handle, uint16_t value,


### PR DESCRIPTION
Added a callback that lets an application get write error (if any) when subscribing to a gatt characteristic.

Example scenario where this is required:
A GATT server has a notifiable and write-without-response characteristic with authorization. A client cannot write to this characteristic without being authorized, but since there are no response on the write, the client won't be informed about missing authorization. However, the CCCD of the characteristic shall support write (with response), and if the client subscribes, then it will also be prompted for authorization, and will receive this error message in the response. 

Currently (before this patch) it is not possible for the application to get the needed error response. 