### PR TITLE
Bluetooth: GATT: Turn GATT notify multiple feature default off

### DIFF
--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -107,7 +107,6 @@ if BT_GATT_CACHING
 config BT_GATT_NOTIFY_MULTIPLE
 	bool "GATT Notify Multiple Characteristic Values support"
 	depends on BT_GATT_CACHING
-	default y
 	help
 	  This option enables support for the GATT Notify Multiple
 	  Characteristic Values procedure.


### PR DESCRIPTION
Turn the GATT notify multiple feature off as default value.
This feature changes the behavior of the bt_gatt_notify API in a way
that might not be backwards-compatible.
This is because the notify multiple header is larger, and therefore
limits the amount of bytes that could otherwise have been sent in a
normal notify PDU for a given ATT MTU.

Fixes: #26106

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>