### PR TITLE
usb: disk_access: Imperfecion in disk access?

### DIFF
--- a/samples/subsys/usb/mass/prj.conf
+++ b/samples/subsys/usb/mass/prj.conf
@@ -9,7 +9,7 @@ CONFIG_LOG=y
 CONFIG_USB_DRIVER_LOG_LEVEL_ERR=y
 CONFIG_USB_MASS_STORAGE=y
 CONFIG_USB_DEVICE_LOG_LEVEL_ERR=y
-CONFIG_USB_MASS_STORAGE_LOG_LEVEL_ERR=y
+CONFIG_USB_MASS_STORAGE_LOG_LEVEL_DBG=y
 
 # If the target's code needs to do file operations, enable target's
 # FAT FS code. (Without this only the host can access the fs contents)

--- a/subsys/disk/disk_access_flash.c
+++ b/subsys/disk/disk_access_flash.c
@@ -14,7 +14,7 @@
 #include <device.h>
 #include <drivers/flash.h>
 
-#define SECTOR_SIZE 512
+#define SECTOR_SIZE 1024
 
 static struct device *flash_dev;
 

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -51,7 +51,7 @@ LOG_MODULE_REGISTER(usb_msc);
 /* max USB packet size */
 #define MAX_PACKET	CONFIG_MASS_STORAGE_BULK_EP_MPS
 
-#define BLOCK_SIZE	512
+#define BLOCK_SIZE	1024
 #define DISK_THREAD_STACK_SZ	512
 #define DISK_THREAD_PRIO	-5
 


### PR DESCRIPTION
Addressed issue
---
I've found out that after #24696 was merged the issue #26275 was introduced. What the issue introducing PR did was addition of Nordic specific USB mass storage sample using on board external flash memory.

AFAIK external flash is: 64kB size with 1kB page size.

**The origin of the issue**
---
Right now both [disk_access_flash.c](https://github.com/zephyrproject-rtos/zephyr/blob/6789ecbd5e13cc19e69f25314cf486493df9dde3/subsys/disk/disk_access_flash.c#L17)/[mass_storage.c](https://github.com/zephyrproject-rtos/zephyr/blob/6789ecbd5e13cc19e69f25314cf486493df9dde3/subsys/usb/class/mass_storage.c#L54) are using fixed 512Bytes in size page.
From my POV this is imperfection of the disk access abstraction. This is what surely causes a failure in USB 3CV test.

**What the failing test does**
---
The test is performing multiple writes/reads to/from the device. It works just fine when reading 64kB, but fails to write 64kB (stucks ~43kB). With this patch works just fine.

**Purpose of the PR**
---
This PR is open for discussion as I am not 100% sure this is what should be done and if yes what path should be followed to address the issue.

The real question here is: How should the page size be shared across relevant places. I can fix it in the usb mass storage but I think there should be general solution for that and by this PR I am asking for opinion. 

Closes: #26275

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>