### PR TITLE
Bluetooth: Mesh: Keep PB-GATT callback through disconnect

### DIFF
--- a/subsys/bluetooth/mesh/pb_gatt.c
+++ b/subsys/bluetooth/mesh/pb_gatt.c
@@ -32,10 +32,10 @@ static void reset_state(void)
 {
 	if (link.conn) {
 		bt_conn_unref(link.conn);
+		link.conn = NULL;
 	}
 
 	k_delayed_work_cancel(&link.prot_timer);
-	memset(&link, 0, offsetof(struct prov_link, prot_timer));
 
 	link.rx_buf = bt_mesh_proxy_get_buf();
 }


### PR DESCRIPTION
Removes the memset of the prov_bearer_cb in PB-GATT during resets. This
allows the provisioning link to disconnect and reconnect again without
having to call pb_gatt_open.

Fixes #26343.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>