### PR TITLE
west: runners/misc-flasher: fix passing extra args to script

### DIFF
--- a/scripts/west_commands/runners/misc.py
+++ b/scripts/west_commands/runners/misc.py
@@ -11,6 +11,7 @@ core on a special-purpose SoC which requires a complicated script to
 network boot.'''
 
 from runners.core import ZephyrBinaryRunner, RunnerCaps
+import argparse
 
 class MiscFlasher(ZephyrBinaryRunner):
     '''Runner for handling special purpose flashing commands.'''
@@ -37,7 +38,7 @@ class MiscFlasher(ZephyrBinaryRunner):
         parser.add_argument('cmd',
                             help='''command to run; it will be passed the
                             build directory as its first argument''')
-        parser.add_argument('args', nargs='*',
+        parser.add_argument('args', nargs=argparse.REMAINDER,
                             help='''additional arguments to pass after the build
                             directory''')
 


### PR DESCRIPTION
The argparse module, by default, complains about non-defined
arguments. This prevents passing arguments prefixed with '-'
or '--' to the target script (e.g. calling another Python
script using argparse). This changes the misc-flasher script
so that any arguments not recognized by west will be passed
to the target script.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>