### PR TITLE
net: tcp2: fix unaligned access in the TCP2 stack

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -499,7 +499,8 @@ static bool tcp_options_check(struct tcp_options *recv_options,
 				goto end;
 			}
 
-			recv_options->mss = ntohs(*((uint16_t *)(options + 2)));
+			recv_options->mss =
+				ntohs(UNALIGNED_GET((uint16_t *)(options + 2)));
 			recv_options->mss_found = true;
 			NET_DBG("MSS=%hu", recv_options->mss);
 			break;

--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -12,8 +12,8 @@
 #define MIN3(_a, _b, _c) MIN((_a), MIN((_b), (_c)))
 #endif
 
-#define th_seq(_x) ntohl((_x)->th_seq)
-#define th_ack(_x) ntohl((_x)->th_ack)
+#define th_seq(_x) ntohl(UNALIGNED_GET(&(_x)->th_seq))
+#define th_ack(_x) ntohl(UNALIGNED_GET(&(_x)->th_ack))
 
 #define tcp_slist(_slist, _op, _type, _link)				\
 ({									\
@@ -209,8 +209,9 @@ struct tcp { /* TCP connection */
 ({									\
 	bool result = false;						\
 									\
-	if (*(_fl) && (_cond) && (*(_fl) _op (_mask))) {		\
-		*(_fl) &= ~(_mask);					\
+	if (UNALIGNED_GET(_fl) && (_cond) &&				\
+	    (UNALIGNED_GET(_fl) _op(_mask))) {				\
+		UNALIGNED_PUT(UNALIGNED_GET(_fl) & ~(_mask), _fl);	\
 		result = true;						\
 	}								\
 									\


### PR DESCRIPTION
The TCP2 stack does operations directly on the packet data which may
or may not be aligned.  Unaligned access causes a fault on the
Cortex-M0+ so use the UNALIGNED_* macros instead.

Related to #26330

Signed-off-by: Michael Hope <mlhx@google.com>