### PR TITLE
initial steps towards devicetree-based device definitions and dependency representations

### DIFF
--- a/doc/guides/dts/macros.bnf
+++ b/doc/guides/dts/macros.bnf
@@ -50,6 +50,13 @@ node-macro =/ %s"DT_N" path-id %s"_PARENT"
 node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD"
 ; The node's status macro
 node-macro =/ %s"DT_N" path-id %s"_STATUS_" dt-name
+; The node's dependency ordinal. This is a non-negative integer
+; value that is used to represent dependency information.
+node-macro =/ %s"DT_N" path-id %s"_ORD"
+; The dependency ordinals of a node's requirements (direct dependencies).
+node-macro =/ %s"DT_N" path-id %s"_REQUIRES_ORDS"
+; The dependency ordinals of a node supports (reverse direct dependencies).
+node-macro =/ %s"DT_N" path-id %s"_SUPPORTS_ORDS"
 
 ; --------------------------------------------------------------------
 ; property-macro: a macro related to a node property

--- a/doc/reference/devicetree/index.rst
+++ b/doc/reference/devicetree/index.rst
@@ -108,6 +108,44 @@ documented elsewhere on this page.
 .. doxygengroup:: devicetree-generic-exist
    :project: Zephyr
 
+.. _devicetree-dep-ord:
+
+Inter-node dependencies
+=======================
+
+The ``devicetree.h`` API has some support for tracking dependencies between
+nodes. Dependency tracking relies on a binary "depends on" relation between
+devicetree nodes, which is defined as the `transitive closure
+<https://en.wikipedia.org/wiki/Transitive_closure>`_ of the following "directly
+depends on" relation:
+
+- every non-root node directly depends on its parent node
+- a node directly depends on any nodes its properties refer to by phandle
+- a node directly depends on its ``interrupt-parent`` if it has an
+  ``interrupts`` property
+
+A *dependency ordering* of a devicetree is a list of its nodes, where each node
+``n`` appears earlier in the list than any nodes that depend on ``n``. A node's
+*dependency ordinal* is then its zero-based index in that list. Thus, for two
+distinct devicetree nodes ``n1`` and ``n2`` with dependency ordinals ``d1`` and
+``d2``, we have:
+
+- ``d1 != d2``
+- if ``n1`` depends on ``n2``, then ``d1 > d2``
+- ``d1 > d2`` does **not** necessarily imply that ``n1`` depends on ``n2``
+
+The Zephyr build system chooses a dependency ordering of the final devicetree
+and assigns a dependency ordinal to each node. Dependency related information
+can be accessed using the following macros. The exact dependency ordering
+chosen is an implementation detail, but cyclic dependencies are detected and
+cause errors, so it's safe to assume there are none when using these macros.
+
+There are instance number-based conveniences as well; see
+:c:func:`DT_INST_DEP_ORD` and subsequent documentation.
+
+.. doxygengroup:: devicetree-dep-ord
+   :project: Zephyr
+
 Bus helpers
 ===========
 

--- a/drivers/clock_control/nrf_power_clock.c
+++ b/drivers/clock_control/nrf_power_clock.c
@@ -348,7 +348,7 @@ static const struct nrf_clock_control_config config = {
 	}
 };
 
-DEVICE_AND_API_INIT(clock_nrf, DT_INST_LABEL(0),
+DT_DEVICE_AND_API_INIT(DT_NODELABEL(clock),
 		    clk_init, &data, &config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &clock_control_api);
@@ -407,7 +407,7 @@ static void usb_power_isr(void)
 void nrf_power_clock_isr(void *arg)
 {
 	ARG_UNUSED(arg);
-	struct device *dev = DEVICE_GET(clock_nrf);
+	struct device *dev = DT_DEVICE_GET(DT_NODELABEL(clock));
 
 	if (clock_event_check_and_clean(NRF_CLOCK_EVENT_HFCLKSTARTED,
 					NRF_CLOCK_INT_HF_STARTED_MASK)) {

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -10,6 +10,8 @@
 
 #include "gpio_utils.h"
 
+#define GPIO(id) DT_NODELABEL(gpio##id)
+
 /* Mask holding information about which channels are allocated. */
 static atomic_t gpiote_alloc_mask;
 
@@ -390,10 +392,10 @@ static inline void fire_callbacks(struct device *port, uint32_t pins)
 }
 
 #ifdef CONFIG_GPIO_NRF_P0
-DEVICE_DECLARE(gpio_nrfx_p0);
+DT_DEVICE_DECLARE(GPIO(0));
 #endif
 #ifdef CONFIG_GPIO_NRF_P1
-DEVICE_DECLARE(gpio_nrfx_p1);
+DT_DEVICE_DECLARE(GPIO(1));
 #endif
 
 static void gpiote_event_handler(void)
@@ -405,11 +407,11 @@ static void gpiote_event_handler(void)
 	if (port_event) {
 #ifdef CONFIG_GPIO_NRF_P0
 		fired_triggers[0] =
-			check_level_trigger_pins(DEVICE_GET(gpio_nrfx_p0));
+			check_level_trigger_pins(DT_DEVICE_GET(GPIO(0)));
 #endif
 #ifdef CONFIG_GPIO_NRF_P1
 		fired_triggers[1] =
-			check_level_trigger_pins(DEVICE_GET(gpio_nrfx_p1));
+			check_level_trigger_pins(DT_DEVICE_GET(GPIO(1)));
 #endif
 
 		/* Sense detect was disabled while checking pins so
@@ -434,12 +436,12 @@ static void gpiote_event_handler(void)
 
 #ifdef CONFIG_GPIO_NRF_P0
 	if (fired_triggers[0]) {
-		fire_callbacks(DEVICE_GET(gpio_nrfx_p0), fired_triggers[0]);
+		fire_callbacks(DT_DEVICE_GET(GPIO(0)), fired_triggers[0]);
 	}
 #endif
 #ifdef CONFIG_GPIO_NRF_P1
 	if (fired_triggers[1]) {
-		fire_callbacks(DEVICE_GET(gpio_nrfx_p1), fired_triggers[1]);
+		fire_callbacks(DT_DEVICE_GET(GPIO(1)), fired_triggers[1]);
 	}
 #endif
 
@@ -448,10 +450,10 @@ static void gpiote_event_handler(void)
 		 * This may cause DETECT to be re-asserted.
 		 */
 #ifdef CONFIG_GPIO_NRF_P0
-		cfg_level_pins(DEVICE_GET(gpio_nrfx_p0));
+		cfg_level_pins(DT_DEVICE_GET(GPIO(0)));
 #endif
 #ifdef CONFIG_GPIO_NRF_P1
-		cfg_level_pins(DEVICE_GET(gpio_nrfx_p1));
+		cfg_level_pins(DT_DEVICE_GET(GPIO(1)));
 #endif
 	}
 }
@@ -480,8 +482,6 @@ static int gpio_nrfx_init(struct device *port)
  * DT_INST APIs here without wider changes.
  */
 
-#define GPIO(id) DT_NODELABEL(gpio##id)
-
 #define GPIO_NRF_DEVICE(id)						\
 	static const struct gpio_nrfx_cfg gpio_nrfx_p##id##_cfg = {	\
 		.common = {						\
@@ -494,8 +494,7 @@ static int gpio_nrfx_init(struct device *port)
 									\
 	static struct gpio_nrfx_data gpio_nrfx_p##id##_data;		\
 									\
-	DEVICE_AND_API_INIT(gpio_nrfx_p##id,				\
-			    DT_LABEL(GPIO(id)),				\
+	DT_DEVICE_AND_API_INIT(GPIO(id),				\
 			    gpio_nrfx_init,				\
 			    &gpio_nrfx_p##id##_data,			\
 			    &gpio_nrfx_p##id##_cfg,			\

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -932,7 +932,7 @@ static void uart_nrfx_isr(void *arg)
 }
 #endif /* CONFIG_UART_0_INTERRUPT_DRIVEN */
 
-DEVICE_DECLARE(uart_nrfx_uart0);
+DT_DEVICE_DECLARE(DT_DRV_INST(0));
 
 /**
  * @brief Initialize UART channel
@@ -1004,7 +1004,7 @@ static int uart_nrfx_init(struct device *dev)
 	IRQ_CONNECT(IRQN,
 		    IRQ_PRIO,
 		    uart_nrfx_isr,
-		    DEVICE_GET(uart_nrfx_uart0),
+		    DT_DEVICE_GET(DT_DRV_INST(0)),
 		    0);
 	irq_enable(IRQN);
 #endif
@@ -1155,8 +1155,7 @@ static struct uart_nrfx_data uart_nrfx_uart0_data = {
 	}
 };
 
-DEVICE_DEFINE(uart_nrfx_uart0,
-	      DT_INST_LABEL(0),
+DT_DEVICE_DEFINE(DT_DRV_INST(0),
 	      uart_nrfx_init,
 	      uart_nrfx_pm_control,
 	      &uart_nrfx_uart0_data,

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1476,7 +1476,7 @@ static int uarte_nrfx_pm_control(struct device *dev, uint32_t ctrl_command,
 #define UARTE_IRQ_CONFIGURE(idx, isr_handler)				       \
 	do {								       \
 		IRQ_CONNECT(DT_IRQN(UARTE(idx)), DT_IRQ(UARTE(idx), priority), \
-			    isr_handler, DEVICE_GET(uart_nrfx_uarte##idx), 0); \
+			    isr_handler, DT_DEVICE_GET(UARTE(idx)), 0); \
 		irq_enable(DT_IRQN(UARTE(idx)));			       \
 	} while (0)
 
@@ -1489,7 +1489,7 @@ static int uarte_nrfx_pm_control(struct device *dev, uint32_t ctrl_command,
 
 #define UART_NRF_UARTE_DEVICE(idx)					       \
 	HWFC_CONFIG_CHECK(idx);						       \
-	DEVICE_DECLARE(uart_nrfx_uarte##idx);				       \
+	DT_DEVICE_DECLARE(UARTE(idx));					       \
 	UARTE_INT_DRIVEN(idx);						       \
 	UARTE_ASYNC(idx);						       \
 	static struct uarte_nrfx_data uarte_##idx##_data = {		       \
@@ -1526,8 +1526,7 @@ static int uarte_nrfx_pm_control(struct device *dev, uint32_t ctrl_command,
 			&init_config,					       \
 			IS_ENABLED(CONFIG_UART_##idx##_INTERRUPT_DRIVEN));     \
 	}								       \
-	DEVICE_DEFINE(uart_nrfx_uarte##idx,				       \
-		      DT_LABEL(UARTE(idx)),				       \
+	DT_DEVICE_DEFINE(UARTE(idx),					       \
 		      uarte_##idx##_init,				       \
 		      uarte_nrfx_pm_control,				       \
 		      &uarte_##idx##_data,				       \

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -46,5 +46,6 @@ void __weak sys_clock_disable(void)
 {
 }
 
-SYS_DEVICE_DEFINE("sys_clock", z_clock_driver_init, z_clock_device_ctrl,
-		PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);
+DT_SYS_DEVICE_DEFINE(DEVICE_HANDLE_SYSCLOCK, "sys_clock", z_clock_driver_init, z_clock_device_ctrl,
+		     PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY,
+		     DEVICE_HANDLE_SYSCLOCK_BASIS);

--- a/include/device.h
+++ b/include/device.h
@@ -124,33 +124,25 @@ extern "C" {
  */
 #define DEVICE_DEFINE(dev_name, drv_name, init_fn, pm_control_fn,	\
 		      data, cfg_info, level, prio, api)			\
-	Z_DEVICE_DEFINE_PM(dev_name)					\
-	static Z_DECL_ALIGN(struct device)				\
-		DEVICE_NAME_GET(dev_name) __used			\
-	__attribute__((__section__(".device_" #level STRINGIFY(prio)))) = { \
-		.name = drv_name,					\
-		.config_info = (cfg_info),				\
-		.driver_api = (api),					\
-		.driver_data = (data),					\
-		Z_DEVICE_DEFINE_PM_INIT(dev_name, pm_control_fn)	\
-	};								\
-	Z_INIT_ENTRY_DEFINE(_CONCAT(__device_, dev_name), init_fn,	\
-			    (&_CONCAT(__device_, dev_name)), level, prio)
+	Z_DEVICE_DEFINE(_, dev_name, drv_name, init_fn, pm_control_fn,	\
+			data, cfg_info, level, prio, api)
 
-#define DT_DEVICE_INIT(node_id, init_fn,			\
-		       data, cfg_info, level, prio)		\
-	DEVICE_INIT(node_id, DT_LABEL(node_id), init_fn,	\
-		    data, cfg_info, level, prio)
+#define DT_DEVICE_INIT(node_id, init_fn,				\
+		       data, cfg_info, level, prio)			\
+	Z_DEVICE_DEFINE(node_id, node_id, DT_LABEL(node_id), init_fn,	\
+			data, cfg_info, level, prio)
 
 #define DT_DEVICE_AND_API_INIT(node_id, init_fn,			\
 			       data, cfg_info, level, prio, api)	\
-	DEVICE_AND_API_INIT(node_id, DT_LABEL(node_id), init_fn,	\
-			    data, cfg_info, level, prio, api)
+	Z_DEVICE_DEFINE(node_id, node_id, DT_LABEL(node_id), init_fn,	\
+			pm_control_fn,					\
+			data, cfg_info, level, prio, api)
 
 #define DT_DEVICE_DEFINE(node_id, init_fn, pm_control_fn,		\
 			 data, cfg_info, level, prio, api)		\
-	DEVICE_DEFINE(node_id, DT_LABEL(node_id), init_fn, pm_control_fn, \
-		data, cfg_info, level, prio, api)
+	Z_DEVICE_DEFINE(node_id, node_id, DT_LABEL(node_id), init_fn,	\
+			pm_control_fn,					\
+			data, cfg_info, level, prio, api)
 
 #define DT_DEVICE_NAME_GET(node_id) DEVICE_NAME_GET(node_id)
 #define DT_DEVICE_GET(node_id) (&DT_DEVICE_NAME_GET(node_id))
@@ -584,6 +576,21 @@ static inline int device_pm_put_sync(struct device *dev) { return -ENOTSUP; }
 /**
  * @}
  */
+
+#define Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn, pm_control_fn, \
+			data, cfg_info, level, prio, api)		\
+	Z_DEVICE_DEFINE_PM(dev_name)					\
+	static Z_DECL_ALIGN(struct device)				\
+		DEVICE_NAME_GET(dev_name) __used			\
+	__attribute__((__section__(".device_" #level STRINGIFY(prio)))) = { \
+		.name = drv_name,					\
+		.config_info = (cfg_info),				\
+		.driver_api = (api),					\
+		.driver_data = (data),					\
+		Z_DEVICE_DEFINE_PM_INIT(dev_name, pm_control_fn)	\
+	};								\
+	Z_INIT_ENTRY_DEFINE(_CONCAT(__device_, dev_name), init_fn,	\
+			    (&_CONCAT(__device_, dev_name)), level, prio)
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 #define Z_DEVICE_DEFINE_PM(dev_name)					\

--- a/include/device.h
+++ b/include/device.h
@@ -137,6 +137,25 @@ extern "C" {
 	Z_INIT_ENTRY_DEFINE(_CONCAT(__device_, dev_name), init_fn,	\
 			    (&_CONCAT(__device_, dev_name)), level, prio)
 
+#define DT_DEVICE_INIT(node_id, init_fn,			\
+		       data, cfg_info, level, prio)		\
+	DEVICE_INIT(node_id, DT_LABEL(node_id), init_fn,	\
+		    data, cfg_info, level, prio)
+
+#define DT_DEVICE_AND_API_INIT(node_id, init_fn,			\
+			       data, cfg_info, level, prio, api)	\
+	DEVICE_AND_API_INIT(node_id, DT_LABEL(node_id), init_fn,	\
+			    data, cfg_info, level, prio, api)
+
+#define DT_DEVICE_DEFINE(node_id, init_fn, pm_control_fn,		\
+			 data, cfg_info, level, prio, api)		\
+	DEVICE_DEFINE(node_id, DT_LABEL(node_id), init_fn, pm_control_fn, \
+		data, cfg_info, level, prio, api)
+
+#define DT_DEVICE_NAME_GET(node_id) DEVICE_NAME_GET(node_id)
+#define DT_DEVICE_GET(node_id) (&DT_DEVICE_NAME_GET(node_id))
+#define DT_DEVICE_DECLARE(node_id) static struct device DT_DEVICE_NAME_GET(node_id)
+
 /**
  * @def DEVICE_GET
  *

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -1259,6 +1259,59 @@
  */
 
 /**
+ * @defgroup devicetree-dep-ord Dependency tracking
+ * @ingroup devicetree
+ * @{
+ */
+
+/**
+ * @brief Get a node's dependency ordinal
+ * @param node_id Node identifier
+ * @return the node's dependency ordinal as an integer literal
+ */
+#define DT_DEP_ORD(node_id) DT_CAT(node_id, _ORD)
+
+/**
+ * @brief Get a list of dependency ordinals of a node's direct dependencies
+ *
+ * There is a comma after each ordinal in the expansion, **including**
+ * the last one:
+ *
+ *     DT_REQUIRES_DEP_ORDS(my_node) // required_ord_1, ..., required_ord_n,
+ *
+ * The one case DT_REQUIRES_DEP_ORDS() expands to nothing is when
+ * given the root node identifier @p DT_ROOT as argument. The root has
+ * no direct dependencies; every other node at least depends on its
+ * parent.
+ *
+ * @param node_id Node identifier
+ * @return a list of dependency ordinals, with each ordinal followed
+ *         by a comma (<tt>,</tt>), or an empty expansion
+ */
+#define DT_REQUIRES_DEP_ORDS(node_id) DT_CAT(node_id, _REQUIRES_ORDS)
+
+/**
+ * @brief Get a list of dependency ordinals of what depends directly on a node
+ *
+ * There is a comma after each ordinal in the expansion, **including**
+ * the last one:
+ *
+ *     DT_SUPPORTS_DEP_ORDS(my_node) // supported_ord_1, ..., supported_ord_n,
+ *
+ * DT_SUPPORTS_DEP_ORDS() may expand to nothing. This happens when @p node_id
+ * refers to a leaf node that nothing else depends on.
+ *
+ * @param node_id Node identifier
+ * @return a list of dependency ordinals, with each ordinal followed
+ *         by a comma (<tt>,</tt>), or an empty expansion
+ */
+#define DT_SUPPORTS_DEP_ORDS(node_id) DT_CAT(node_id, _SUPPORTS_ORDS)
+
+/**
+ * @}
+ */
+
+/**
  * @defgroup devicetree-generic-bus Bus helpers
  * @ingroup devicetree
  * @{
@@ -1772,6 +1825,40 @@
  */
 #define DT_INST_IRQ_HAS_NAME(inst, name) \
 	DT_IRQ_HAS_NAME(DT_DRV_INST(inst), name)
+
+/**
+ * @brief Get a DT_DRV_COMPAT instance's dependency ordinal
+ *
+ * Equivalent to DT_DEP_ORD(DT_DRV_INST(inst)).
+ *
+ * @param inst instance number
+ * @return The instance's dependency ordinal
+ */
+#define DT_INST_DEP_ORD(inst) DT_DEP_ORD(DT_DRV_INST(inst))
+
+/**
+ * @brief Get a list of dependency ordinals of a DT_DRV_COMPAT instance's
+ *        direct dependencies
+ *
+ * Equivalent to DT_REQUIRES_DEP_ORDS(DT_DRV_INST(inst)).
+ *
+ * @param inst instance number
+ * @return a list of dependency ordinals for the nodes the instance depends
+ *         on directly
+ */
+#define DT_INST_REQUIRES_DEP_ORDS(inst) DT_REQUIRES_DEP_ORDS(DT_DRV_INST(inst))
+
+/**
+ * @brief Get a list of dependency ordinals of what depends directly on a
+ *        DT_DRV_COMPAT instance
+ *
+ * Equivalent to DT_SUPPORTS_DEP_ORDS(DT_DRV_INST(inst)).
+ *
+ * @param inst instance number
+ * @return a list of node identifiers for the nodes that depend directly
+ *         on the instance
+ */
+#define DT_INST_SUPPORTS_DEP_ORDS(inst) DT_SUPPORTS_DEP_ORDS(DT_DRV_INST(inst))
 
 /**
  * @}

--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -650,6 +650,71 @@ uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value);
 			F, 0, __VA_ARGS__)
 
 /**
+ * @brief Like FOR_EACH(), but with a terminator instead of a separator,
+ *        and drops empty elements from the argument list
+ *
+ * The @p sep argument to <tt>FOR_EACH(F, (sep), a, b)</tt> is a
+ * separator which is placed between calls to @p F, like this:
+ *
+ *     FOR_EACH(F, (sep), a, b) // F(a) sep F(b)
+ *                              //               ^^^ no sep here!
+ *
+ * By contrast, the @p term argument to <tt>FOR_EACH_NONEMPTY_TERM(F, (term),
+ * a, b)</tt> is added after each time @p F appears in the expansion:
+ *
+ *     FOR_EACH_NONEMPTY_TERM(F, (term), a, b) // F(a) term F(b) term
+ *                                             //                ^^^^
+ *
+ * Further, any empty elements are dropped:
+ *
+ *     FOR_EACH_NONEMPTY_TERM(F, (term), a, EMPTY, b) // F(a) term F(b) term
+ *
+ * This is more convenient in some cases, because FOR_EACH_NONEMPTY_TERM()
+ * expands to nothing when given an empty argument list, and it's
+ * often cumbersome to write a macro @p F that does the right thing
+ * even when given an empty argument.
+ *
+ * One example is when <tt>__VA_ARGS__</tt> may or may not be empty,
+ * and the results are embedded in a larger initializer:
+ *
+ *     #define SQUARE(x) ((x)*(x))
+ *
+ *     int my_array[] = {
+ *             FOR_EACH_NONEMPTY_TERM(SQUARE, (,), FOO(...))
+ *             FOR_EACH_NONEMPTY_TERM(SQUARE, (,), BAR(...))
+ *             FOR_EACH_NONEMPTY_TERM(SQUARE, (,), BAZ(...))
+ *     };
+ *
+ * This is more convenient than:
+ *
+ * 1. figuring out whether the @p FOO, @p BAR, and @p BAZ expansions
+ *    are empty and adding a comma manually (or not) between FOR_EACH()
+ *    calls
+ * 2. rewriting SQUARE so it reacts appropriately when "x" is empty
+ *    (which would be necessary if e.g. @p FOO expands to nothing)
+ *
+ * @param F Macro to invoke on each nonempty element of the variable
+ *          arguments
+ * @param term Terminator (e.g. comma or semicolon) placed after each
+ *             invocation of F. Must be in parentheses; this is required
+ *             to enable providing a comma as separator.
+ * @param ... Variable argument list. The macro @p F is invoked as
+ *            <tt>F(element)</tt> for each nonempty element in the list.
+ */
+#define FOR_EACH_NONEMPTY_TERM(F, term, ...)				\
+	COND_CODE_0(							\
+		/* are there zero non-empty arguments ? */		\
+		NUM_VA_ARGS_LESS_1(LIST_DROP_EMPTY(__VA_ARGS__, _)),	\
+		/* if so, expand to nothing */				\
+		(),							\
+		/* otherwise, expand to: */				\
+		(	/* FOR_EACH() on nonempty elements, */		\
+			FOR_EACH(F, term, LIST_DROP_EMPTY(__VA_ARGS__))	\
+			/* plus a final terminator */			\
+			__DEBRACKET term				\
+		))
+
+/**
  * @brief Call macro @p F on each provided argument, with the argument's index
  *        as an additional parameter.
  *

--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -535,6 +535,16 @@ uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value);
 #define EMPTY
 
 /**
+ * @brief Macro that expands to its argument
+ *
+ * This is useful in macros like @c FOR_EACH() when there is no
+ * transformation required on the list elements.
+ *
+ * @param V any value
+ */
+#define IDENTITY(V) V
+
+/**
  * @brief Get nth argument from argument list.
  *
  * @param N Argument index to fetch. Counter from 1.

--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -5,9 +5,84 @@
  */
 
 #include <zephyr.h>
+#include <device.h>
 #include <sys/printk.h>
+#include <stdio.h>
+
+#define UART0 DT_NODELABEL(uart0)
+
+#define GEN_AUX(...) FOR_EACH_NONEMPTY_TERM(IDENTITY, (,), __VA_ARGS__)
+
+static void dump_ords(const char *tag,
+		      const device_handle_t *cp)
+{
+	const device_handle_t *cps = cp;
+	unsigned int setnum = 0;
+	char buf[128] = {0};
+	char *bp = buf;
+
+	printk("ordinal sets for %s:\n", tag);
+	while (true) {
+		if ((*cp == DEVICE_HANDLE_SEP)
+		    || (*cp == DEVICE_HANDLE_ENDS)) {
+			printk("\tS%u: %u elts:%s\n", setnum, (unsigned int)(cp - cps), buf);
+			bp = buf;
+			cps = cp + 1;
+			++setnum;
+			if (*cp == DEVICE_HANDLE_ENDS) {
+				break;
+			}
+		} else {
+			bp += snprintf(bp, buf + sizeof(buf) -  bp, " %d", *cp);
+		}
+		++cp;
+	}
+	printk("%s has %u sets\n", tag, setnum);
+}
 
 void main(void)
 {
-	printk("Hello World! %s\n", CONFIG_BOARD);
+	struct device *devlist;
+	size_t devcnt = z_device_get_all_static(&devlist);
+	const struct device *dpe = devlist + devcnt;
+	struct device *dp = devlist;
+
+	if (false) {
+		static const device_handle_t sets[] = {
+			GEN_AUX()
+			DEVICE_HANDLE_SEP,
+			GEN_AUX(1)
+			DEVICE_HANDLE_SEP,
+			GEN_AUX(1, 2)
+			DEVICE_HANDLE_ENDS,
+		};
+		dump_ords("test", sets);
+	}
+
+	printk("%zu devices at %p:\n", devcnt, devlist);
+	while (dp < dpe) {
+		const device_handle_t *cp;
+		const char *name = dp->name ? dp->name : "<?>";
+		size_t nc;
+
+		if (false) {
+			dump_ords(name, dp->ords);
+		}
+
+		cp = device_get_requires_ord(dp, &nc);
+		printk("%p: %s\n", dp, name);
+		if (cp != NULL) {
+			printk("\tSelf %d, parent %d, %u req:",
+			       device_get_self_ord(dp),
+			       device_get_parent_ord(dp),
+			       nc);
+
+			const device_handle_t *cpe = cp + nc;
+			while (cp < cpe) {
+				printk(" %d", *cp++);
+			}
+			printk("\n");
+		}
+		++dp;
+	}
 }

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -84,6 +84,7 @@ def main():
                               f"DT_{node.parent.z_path_id}")
 
             write_child_functions(node)
+            write_dep_info(node)
             write_idents_and_existence(node)
             write_bus(node)
             write_special_props(node)
@@ -144,7 +145,7 @@ DTS input file:
 Directories with bindings:
   {", ".join(map(relativize, edt.bindings_dirs))}
 
-Nodes in dependency order (ordinal and path):
+Node dependency ordering (ordinal and path):
 """
 
     for scc in edt.scc_order():
@@ -167,7 +168,7 @@ def write_node_comment(node):
     s = f"""\
 Devicetree node: {node.path}
 
-Node's generated path identifier: DT_{node.z_path_id}
+Node identifier: DT_{node.z_path_id}
 """
 
     if node.matching_compat:
@@ -175,18 +176,6 @@ Node's generated path identifier: DT_{node.z_path_id}
 Binding (compatible = {node.matching_compat}):
   {relativize(node.binding_path)}
 """
-
-    s += f"\nDependency Ordinal: {node.dep_ordinal}\n"
-
-    if node.depends_on:
-        s += "\nRequires:\n"
-        for dep in node.depends_on:
-            s += f"  {dep.dep_ordinal:<3} {dep.path}\n"
-
-    if node.required_by:
-        s += "\nSupports:\n"
-        for req in node.required_by:
-            s += f"  {req.dep_ordinal:<3} {req.path}\n"
 
     if node.description:
         # Indent description by two spaces
@@ -444,6 +433,31 @@ def write_vanilla_props(node):
             out_dt_define(macro, val)
     else:
         out_comment("(No generic property macros)")
+
+
+def write_dep_info(node):
+    # Write dependency-related information about the node.
+
+    def fmt_dep_list(dep_list):
+        if dep_list:
+            # Sort the list by dependency ordinal for predictability.
+            sorted_list = sorted(dep_list, key=lambda node: node.dep_ordinal)
+            return "\\\n\t" + \
+                " \\\n\t".join(f"{n.dep_ordinal}, /* {n.path} */"
+                               for n in sorted_list)
+        else:
+            return "/* nothing */"
+
+    out_comment("Node's dependency ordinal:")
+    out_dt_define(f"{node.z_path_id}_ORD", node.dep_ordinal)
+
+    out_comment("Ordinals for what this node depends on directly:")
+    out_dt_define(f"{node.z_path_id}_REQUIRES_ORDS",
+                  fmt_dep_list(node.depends_on))
+
+    out_comment("Ordinals for what depends directly on this node:")
+    out_dt_define(f"{node.z_path_id}_SUPPORTS_ORDS",
+                  fmt_dep_list(node.required_by))
 
 
 def prop2value(prop):

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -34,6 +34,10 @@
 
 		test_phandles: phandle-holder-0 {
 			compatible = "vnd,phandle-holder";
+			/*
+			 * At least one of these phandles must refer to
+			 * test_gpio_1, or dependency ordinal tests may fail.
+			 */
 			ph = <&test_gpio_1>;
 			phs = <&test_gpio_1 &test_gpio_2 &test_i2c>;
 			gpios = <&test_gpio_1 10 20>, <&test_gpio_2 30 40>;
@@ -319,6 +323,7 @@
 			status = "okay";
 		};
 
+		/* there should only be one of these */
 		test_children: test-children {
 			compatible = "vnd,child-bindings";
 

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -9,6 +9,7 @@
 #include <device.h>
 #include <drivers/gpio.h>
 
+#define TEST_CHILDREN	DT_PATH(test, test_children)
 #define TEST_DEADBEEF	DT_PATH(test, gpio_deadbeef)
 #define TEST_ABCD1234	DT_PATH(test, gpio_abcd1234)
 #define TEST_ALIAS	DT_ALIAS(test_alias)
@@ -1478,6 +1479,172 @@ static void test_great_grandchild(void)
 		      42, "great-grandchild bindings returned wrong value");
 }
 
+static bool ord_in_array(unsigned int ord, unsigned int *array,
+			 size_t array_size)
+{
+	size_t i;
+
+	for (i = 0; i < array_size; i++) {
+		if (array[i] == ord) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/* Magic numbers used by COMBINED_ORD_ARRAY. Must be invalid dependency
+ * ordinals.
+ */
+#define ORD_LIST_SEP		0xFFFF0000
+#define ORD_LIST_END		0xFFFF0001
+#define INJECTED_DEP_0		0xFFFF0002
+#define INJECTED_DEP_1		0xFFFF0003
+
+#define DEP_ORD_AND_COMMA(node_id) DT_DEP_ORD(node_id),
+#define CHILD_ORDINALS(node_id) DT_FOREACH_CHILD(node_id, DEP_ORD_AND_COMMA)
+
+#define COMBINED_ORD_ARRAY(node_id)		\
+	{					\
+		DT_DEP_ORD(node_id),		\
+		DT_DEP_ORD(DT_PARENT(node_id)),	\
+		CHILD_ORDINALS(node_id)		\
+		ORD_LIST_SEP,			\
+		DT_REQUIRES_DEP_ORDS(node_id)	\
+		INJECTED_DEP_0,			\
+		INJECTED_DEP_1,			\
+		ORD_LIST_SEP,			\
+		DT_SUPPORTS_DEP_ORDS(node_id)	\
+		ORD_LIST_END			\
+	}
+
+static void test_dep_ord(void)
+{
+#define ORD_IN_ARRAY(ord, array) ord_in_array(ord, array, ARRAY_SIZE(array))
+
+	unsigned int root_ord = DT_DEP_ORD(DT_ROOT),
+		test_ord = DT_DEP_ORD(DT_PATH(test)),
+		root_requires[] = { DT_REQUIRES_DEP_ORDS(DT_ROOT) },
+		test_requires[] = { DT_REQUIRES_DEP_ORDS(DT_PATH(test)) },
+		root_supports[] = { DT_SUPPORTS_DEP_ORDS(DT_ROOT) },
+		test_supports[] = { DT_SUPPORTS_DEP_ORDS(DT_PATH(test)) },
+		children_ords[] = {
+			DT_FOREACH_CHILD(TEST_CHILDREN, DEP_ORD_AND_COMMA)
+		},
+		children_combined_ords[] = COMBINED_ORD_ARRAY(TEST_CHILDREN),
+		child_a_combined_ords[] =
+			COMBINED_ORD_ARRAY(DT_NODELABEL(test_child_a));
+	size_t i;
+
+	/* DT_DEP_ORD */
+	zassert_equal(root_ord, 0,
+		      "the root node has dependency ordinal 0");
+	zassert_true(DT_DEP_ORD(DT_NODELABEL(test_child_a)) >
+		     DT_DEP_ORD(DT_NODELABEL(test_children)),
+		     "children depend on parents");
+	zassert_true(DT_DEP_ORD(DT_NODELABEL(test_irq)) >
+		     DT_DEP_ORD(DT_NODELABEL(test_intc)),
+		     "nodes depend on their interrupt controllers");
+	zassert_true(DT_DEP_ORD(DT_NODELABEL(test_phandles)) >
+		     DT_DEP_ORD(DT_NODELABEL(test_gpio_1)),
+		     "nodes depend on anything their properties "
+		     "refer to by phandle");
+
+	/* DT_REQUIRES_DEP_ORDS */
+	zassert_equal(ARRAY_SIZE(root_requires), 0,
+		      "the root node doesn't depend on anything");
+	zassert_true(ORD_IN_ARRAY(root_ord, test_requires),
+		     "/test depends on the root node");
+
+	/* DT_SUPPORTS_DEP_ORDS */
+	zassert_true(ORD_IN_ARRAY(test_ord, root_supports),
+		     "the root node supports /test");
+	zassert_false(ORD_IN_ARRAY(root_ord, test_supports),
+		      "the /test node doesn't support the root");
+
+	unsigned int children_combined_ords_expected[] = {
+		/*
+		 * Combined ordinals for /test/test-children are from
+		 * these nodes in this order:
+		 */
+		DT_DEP_ORD(TEST_CHILDREN),		/* node */
+		DT_DEP_ORD(DT_PATH(test)),		/* parent */
+		DT_DEP_ORD(DT_NODELABEL(test_child_a)),	/* children */
+		DT_DEP_ORD(DT_NODELABEL(test_child_b)),
+		DT_DEP_ORD(DT_NODELABEL(test_child_c)),
+		ORD_LIST_SEP,				/* separator */
+		DT_DEP_ORD(DT_PATH(test)),		/* requires */
+		INJECTED_DEP_0,				/* injected
+							 * dependencies
+							 */
+		INJECTED_DEP_1,
+		ORD_LIST_SEP,				/* separator */
+		DT_DEP_ORD(DT_NODELABEL(test_child_a)),	/* supports */
+		DT_DEP_ORD(DT_NODELABEL(test_child_b)),
+		DT_DEP_ORD(DT_NODELABEL(test_child_c)),
+		ORD_LIST_END,				/* terminator */
+	};
+	zassert_equal(ARRAY_SIZE(children_combined_ords),
+		      ARRAY_SIZE(children_combined_ords_expected),
+		      "%u", ARRAY_SIZE(children_combined_ords));
+	for (i = 0; i < ARRAY_SIZE(children_combined_ords); i++) {
+		zassert_equal(children_combined_ords[i],
+			      children_combined_ords_expected[i],
+			      "test-children at %zu", i);
+	}
+
+	unsigned int child_a_combined_ords_expected[] = {
+		/*
+		 * Combined ordinals for /test/test-children/child-a
+		 * are from these nodes in this order:
+		 */
+		DT_DEP_ORD(DT_NODELABEL(test_child_a)), /* node */
+		DT_DEP_ORD(TEST_CHILDREN),		/* parent */
+		/* children (none) */
+		ORD_LIST_SEP,				/* separator */
+		DT_DEP_ORD(TEST_CHILDREN),		/* requires */
+		INJECTED_DEP_0,				/* injected
+							 * dependencies
+							 */
+		INJECTED_DEP_1,
+		ORD_LIST_SEP,				/* separator */
+		/* supports (none) */
+		ORD_LIST_END,				/* terminator */
+	};
+	zassert_equal(ARRAY_SIZE(child_a_combined_ords),
+		      ARRAY_SIZE(child_a_combined_ords_expected),
+		      "%u", ARRAY_SIZE(child_a_combined_ords));
+	for (i = 0; i < ARRAY_SIZE(child_a_combined_ords); i++) {
+		zassert_equal(child_a_combined_ords[i],
+			      child_a_combined_ords_expected[i],
+			      "child-a at %zu", i);
+	}
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_child_bindings
+
+	/* DT_INST_DEP_ORD */
+	zassert_equal(DT_INST_DEP_ORD(0),
+		      DT_DEP_ORD(DT_NODELABEL(test_children)), "");
+
+	/* DT_INST_REQUIRES_DEP_ORDS */
+	unsigned int inst_requires[] = { DT_INST_REQUIRES_DEP_ORDS(0) };
+
+	zassert_equal(ARRAY_SIZE(inst_requires), 1,
+		      "/test/test-children depends only on /test");
+	zassert_equal(inst_requires[0], test_ord, "");
+
+	/* DT_INST_SUPPORTS_DEP_ORDS */
+	unsigned int inst_supports[] = { DT_INST_SUPPORTS_DEP_ORDS(0) };
+
+	zassert_equal(ARRAY_SIZE(inst_supports), 3,
+		      "/test/test-children only supports its children");
+	for (i = 0; i < ARRAY_SIZE(inst_supports); i++) {
+		zassert_true(ORD_IN_ARRAY(inst_supports[i], children_ords),
+			     "");
+	}
+}
+
 void test_main(void)
 {
 	ztest_test_suite(devicetree_api,
@@ -1508,7 +1675,8 @@ void test_main(void)
 			 ztest_unit_test(test_clocks),
 			 ztest_unit_test(test_parent),
 			 ztest_unit_test(test_child_nodes_list),
-			 ztest_unit_test(test_great_grandchild)
+			 ztest_unit_test(test_great_grandchild),
+			 ztest_unit_test(test_dep_ord)
 		);
 	ztest_run_test_suite(devicetree_api);
 }

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -231,6 +231,39 @@ static void test_FOR_EACH(void)
 	zassert_equal(array[2], 3, "Unexpected value %d", array[2]);
 }
 
+static void test_FOR_EACH_NONEMPTY_TERM(void)
+{
+	#define SQUARE(arg) (arg * arg)
+	#define SWALLOW_VA_ARGS_1(...) EMPTY
+	#define SWALLOW_VA_ARGS_2(...)
+	#define REPEAT_VA_ARGS(...) __VA_ARGS__
+
+	uint8_t array[] = {
+		FOR_EACH_NONEMPTY_TERM(SQUARE, (,))
+		FOR_EACH_NONEMPTY_TERM(SQUARE, (,),)
+		FOR_EACH_NONEMPTY_TERM(SQUARE, (,), ,)
+		FOR_EACH_NONEMPTY_TERM(SQUARE, (,), EMPTY, EMPTY)
+		FOR_EACH_NONEMPTY_TERM(SQUARE, (,), SWALLOW_VA_ARGS_1(a, b))
+		FOR_EACH_NONEMPTY_TERM(SQUARE, (,), SWALLOW_VA_ARGS_2(c, d))
+		FOR_EACH_NONEMPTY_TERM(SQUARE, (,), 1)
+		FOR_EACH_NONEMPTY_TERM(SQUARE, (,), 2, 3)
+		FOR_EACH_NONEMPTY_TERM(SQUARE, (,), REPEAT_VA_ARGS(4))
+		FOR_EACH_NONEMPTY_TERM(SQUARE, (,), REPEAT_VA_ARGS(5, 6))
+		255
+	};
+
+	size_t size = ARRAY_SIZE(array);
+
+	zassert_equal(size, 7, "Unexpected size %d", size);
+	zassert_equal(array[0], 1, "Unexpected value %d", array[0]);
+	zassert_equal(array[1], 4, "Unexpected value %d", array[1]);
+	zassert_equal(array[2], 9, "Unexpected value %d", array[2]);
+	zassert_equal(array[3], 16, "Unexpected value %d", array[3]);
+	zassert_equal(array[4], 25, "Unexpected value %d", array[4]);
+	zassert_equal(array[5], 36, "Unexpected value %d", array[5]);
+	zassert_equal(array[6], 255, "Unexpected value %d", array[6]);
+}
+
 static void fsum(uint32_t incr, uint32_t *sum)
 {
 	*sum = *sum + incr;
@@ -397,6 +430,7 @@ void test_main(void)
 			 ztest_unit_test(test_MACRO_MAP_CAT),
 			 ztest_unit_test(test_z_max_z_min),
 			 ztest_unit_test(test_FOR_EACH),
+			 ztest_unit_test(test_FOR_EACH_NONEMPTY_TERM),
 			 ztest_unit_test(test_FOR_EACH_FIXED_ARG),
 			 ztest_unit_test(test_FOR_EACH_IDX),
 			 ztest_unit_test(test_FOR_EACH_IDX_FIXED_ARG),


### PR DESCRIPTION
This is based on #26062 plus an [extra macro](https://github.com/zephyrproject-rtos/zephyr/pull/26062#issuecomment-647731800) related to #26219.

The goal is to represent dependencies between devices and non-device entities such as init functions.  This would be used both to ensure a safe initialization order (#24416), delaying initialization of devices not needed at startup (#24318), and to support device power management (turning on devices needed when a specific device is required, and turning off devices when everything that depends on them has gone away).  The concept is to use small integers as "handles" for anything involved in the dependency relation.  These integer values derive in part from the ordinals that ensure each devicetree node can be placed in an ordered list after everything it depends on.

Since devicetree dependency information requires access to the devicetree node data, API to create devices is extended to support using the node identifier rather than explicitly passing a private identifier for the device object and the label used to retrieve the device.  The device definition macros are also extended so that a specific device can also record dependencies on other things, such as sys_init functions.

The branch in its current state demonstrates recording this information.  Very little of it is complete or documented; this is a proof of concept at best.  Output of the test application shows things like:
```
*** Booting Zephyr OS build zephyr-v2.3.0-539-g10ad16d6b499  ***
6 devices at 0x2000002c:
0x2000002c: CLOCK
        Self 25, parent 7, 2 req: 7 21
0x20000040: UART_0
        Self 50, parent 7, 2 req: 7 21
0x20000054: UART_1
        Self 51, parent 7, 2 req: 7 21
0x20000068: sys_clock
        Self 0, parent 0, 1 req: 30001
0x2000007c: GPIO_0
        Self 8, parent 7, 1 req: 7
0x20000090: GPIO_1
        Self 41, parent 7, 1 req: 7
```
This iterates over all known devices showing their handle, the handle of the parent node (which may not be a device), and the handles of nodes on which the device depends.

This approach is not sufficient.  There are dependencies to things like the `/soc` parent node which have no corresponding device.  Further there is no clear relationship between the handle (e.g. `50`) and the device pointer itself (the value obtained by `device_get_binding("UART_0")`).

Handles for devices should ideally be monotonically increasing packed values that can be used as arguments to something like `device_get_by_handle(n)` in a constant-time operation, e.g. by returning `&`__devices_start[n]`.  Devicetree ordinals that don't correspond to a Zephyr object should be removed, but that can't be done at compile time.

A way to make this work is to do a pre-link processing phase, not unlike the ones used for syscalls, that would inspect the compiled device structures, extract the device tree ordinals, and map them to values that correspond to either external linker symbols (`__device_50`, `__sysinit_21`) or, preferably, small integers that can be used to index into the existing arrays of those objects.  (At this time the only entities thought to be relevant to dependencies are devices and init entries.)

The objects providing the device ordinal data in the code compiled during the first pass would then be replaced in the final link with objects that provide the corresponding handles.

While this seems doable, it's also going to be ugly.  So I'd like initial input on whether this seems viable, and whether there's an alternative solution I should be pursuing instead.  Comments, please.