### PR TITLE
runners: minor cleanups and enhacements

### DIFF
--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -210,8 +210,8 @@ def do_run_common(command, user_args, user_runner_args):
     #
     # Use that RunnerConfig to create the ZephyrBinaryRunner instance
     # and call its run().
-    runner = runner_cls.create(runner_cfg_from_args(args, build_dir), args)
     try:
+        runner = runner_cls.create(runner_cfg_from_args(args, build_dir), args)
         runner.run(command_name)
     except ValueError as ve:
         log.err(str(ve), fatal=True)

--- a/scripts/west_commands/runners/blackmagicprobe.py
+++ b/scripts/west_commands/runners/blackmagicprobe.py
@@ -13,7 +13,7 @@ class BlackMagicProbeRunner(ZephyrBinaryRunner):
     '''Runner front-end for Black Magic probe.'''
 
     def __init__(self, cfg, gdb_serial):
-        super(BlackMagicProbeRunner, self).__init__(cfg)
+        super().__init__(cfg)
         self.gdb = [cfg.gdb] if cfg.gdb else None
         self.elf_file = cfg.elf_file
         self.gdb_serial = gdb_serial

--- a/scripts/west_commands/runners/blackmagicprobe.py
+++ b/scripts/west_commands/runners/blackmagicprobe.py
@@ -27,7 +27,7 @@ class BlackMagicProbeRunner(ZephyrBinaryRunner):
         return RunnerCaps(commands={'flash', 'debug', 'attach'})
 
     @classmethod
-    def create(cls, cfg, args):
+    def do_create(cls, cfg, args):
         return BlackMagicProbeRunner(cfg, args.gdb_serial)
 
     @classmethod

--- a/scripts/west_commands/runners/bossac.py
+++ b/scripts/west_commands/runners/bossac.py
@@ -16,7 +16,7 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
 
     def __init__(self, cfg, bossac='bossac', port=DEFAULT_BOSSAC_PORT,
             offset=None):
-        super(BossacBinaryRunner, self).__init__(cfg)
+        super().__init__(cfg)
         self.bossac = bossac
         self.port = port
         self.offset = offset

--- a/scripts/west_commands/runners/bossac.py
+++ b/scripts/west_commands/runners/bossac.py
@@ -41,7 +41,7 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
                             help='serial port to use, default is /dev/ttyACM0')
 
     @classmethod
-    def create(cls, cfg, args):
+    def do_create(cls, cfg, args):
         return BossacBinaryRunner(cfg, bossac=args.bossac,
                                   port=args.bossac_port, offset=args.offset)
 

--- a/scripts/west_commands/runners/canopen_program.py
+++ b/scripts/west_commands/runners/canopen_program.py
@@ -47,7 +47,7 @@ class CANopenBinaryRunner(ZephyrBinaryRunner):
                                "see the getting started guide for details on "
                                "how to fix")
 
-        super(CANopenBinaryRunner, self).__init__(cfg)
+        super().__init__(cfg)
         self.bin_file = cfg.bin_file
         self.confirm = confirm
         self.confirm_only = confirm_only

--- a/scripts/west_commands/runners/canopen_program.py
+++ b/scripts/west_commands/runners/canopen_program.py
@@ -87,7 +87,7 @@ class CANopenBinaryRunner(ZephyrBinaryRunner):
         parser.set_defaults(confirm=True)
 
     @classmethod
-    def create(cls, cfg, args):
+    def do_create(cls, cfg, args):
         return CANopenBinaryRunner(cfg, int(args.node_id),
                                    can_context=args.can_context,
                                    program_number=int(args.program_number),

--- a/scripts/west_commands/runners/dediprog.py
+++ b/scripts/west_commands/runners/dediprog.py
@@ -40,7 +40,7 @@ class DediProgBinaryRunner(ZephyrBinaryRunner):
                             help='Number of retries (default 5)')
 
     @classmethod
-    def create(cls, cfg, args):
+    def do_create(cls, cfg, args):
         return DediProgBinaryRunner(cfg,
                                     spi_image=args.spi_image,
                                     vcc=args.vcc,

--- a/scripts/west_commands/runners/dediprog.py
+++ b/scripts/west_commands/runners/dediprog.py
@@ -17,7 +17,7 @@ class DediProgBinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end for DediProg (dpcmd).'''
 
     def __init__(self, cfg, spi_image, vcc, retries):
-        super(DediProgBinaryRunner, self).__init__(cfg)
+        super().__init__(cfg)
         self.spi_image = spi_image
         self.vcc = vcc
         self.dpcmd_retries = retries

--- a/scripts/west_commands/runners/dfu.py
+++ b/scripts/west_commands/runners/dfu.py
@@ -20,7 +20,7 @@ class DfuUtilBinaryRunner(ZephyrBinaryRunner):
 
     def __init__(self, cfg, pid, alt, img, exe='dfu-util',
                  dfuse_config=None):
-        super(DfuUtilBinaryRunner, self).__init__(cfg)
+        super().__init__(cfg)
         self.alt = alt
         self.img = img
         self.cmd = [exe, '-d,{}'.format(pid)]

--- a/scripts/west_commands/runners/dfu.py
+++ b/scripts/west_commands/runners/dfu.py
@@ -74,7 +74,7 @@ class DfuUtilBinaryRunner(ZephyrBinaryRunner):
                             help='dfu-util executable; defaults to "dfu-util"')
 
     @classmethod
-    def create(cls, cfg, args):
+    def do_create(cls, cfg, args):
         if args.img is None:
             args.img = cfg.bin_file
 

--- a/scripts/west_commands/runners/esp32.py
+++ b/scripts/west_commands/runners/esp32.py
@@ -17,7 +17,7 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
     def __init__(self, cfg, device, baud=921600, flash_size='detect',
                  flash_freq='40m', flash_mode='dio', espidf='espidf',
                  bootloader_bin=None, partition_table_bin=None):
-        super(Esp32BinaryRunner, self).__init__(cfg)
+        super().__init__(cfg)
         self.elf = cfg.elf_file
         self.device = device
         self.baud = baud

--- a/scripts/west_commands/runners/esp32.py
+++ b/scripts/west_commands/runners/esp32.py
@@ -63,7 +63,7 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
                             help='Partition table to flash')
 
     @classmethod
-    def create(cls, cfg, args):
+    def do_create(cls, cfg, args):
         if args.esp_tool:
             espidf = args.esp_tool
         else:

--- a/scripts/west_commands/runners/hifive1.py
+++ b/scripts/west_commands/runners/hifive1.py
@@ -29,7 +29,7 @@ class HiFive1BinaryRunner(ZephyrBinaryRunner):
         pass
 
     @classmethod
-    def create(cls, cfg, args):
+    def do_create(cls, cfg, args):
         if cfg.gdb is None:
             raise ValueError('--gdb not provided at command line')
 

--- a/scripts/west_commands/runners/hifive1.py
+++ b/scripts/west_commands/runners/hifive1.py
@@ -13,7 +13,7 @@ class HiFive1BinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end for the HiFive1 board, using openocd.'''
 
     def __init__(self, cfg):
-        super(HiFive1BinaryRunner, self).__init__(cfg)
+        super().__init__(cfg)
         self.openocd_config = path.join(cfg.board_dir, 'support', 'openocd.cfg')
 
     @classmethod

--- a/scripts/west_commands/runners/intel_s1000.py
+++ b/scripts/west_commands/runners/intel_s1000.py
@@ -19,7 +19,7 @@ class IntelS1000BinaryRunner(ZephyrBinaryRunner):
     def __init__(self, cfg, xt_ocd_dir,
                  ocd_topology, ocd_jtag_instr, gdb_flash_file,
                  gdb_port=DEFAULT_XT_GDB_PORT):
-        super(IntelS1000BinaryRunner, self).__init__(cfg)
+        super().__init__(cfg)
         self.board_dir = cfg.board_dir
         self.elf_name = cfg.elf_file
         self.gdb_cmd = cfg.gdb

--- a/scripts/west_commands/runners/intel_s1000.py
+++ b/scripts/west_commands/runners/intel_s1000.py
@@ -53,7 +53,7 @@ class IntelS1000BinaryRunner(ZephyrBinaryRunner):
             help='xt-gdb port, defaults to 20000')
 
     @classmethod
-    def create(cls, cfg, args):
+    def do_create(cls, cfg, args):
         return IntelS1000BinaryRunner(
             cfg, args.xt_ocd_dir,
             args.ocd_topology, args.ocd_jtag_instr, args.gdb_flash_file,

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -90,7 +90,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         parser.set_defaults(reset_after_load=False)
 
     @classmethod
-    def create(cls, cfg, args):
+    def do_create(cls, cfg, args):
         build_conf = BuildConfiguration(cfg.build_dir)
         flash_addr = cls.get_flash_address(args, build_conf)
         return JLinkBinaryRunner(cfg, args.device,

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -56,7 +56,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def capabilities(cls):
         return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach'},
-                          flash_addr=True)
+                          flash_addr=True, erase=True)
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -80,8 +80,6 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                             e.g. \'-autoconnect 1\' ''')
         parser.add_argument('--commander', default=DEFAULT_JLINK_EXE,
                             help='J-Link Commander, default is JLinkExe')
-        parser.add_argument('--erase', default=False, action='store_true',
-                            help='if given, mass erase flash before loading')
         parser.add_argument('--reset-after-load', '--no-reset-after-load',
                             dest='reset_after_load', nargs=0,
                             action=ToggleAction,

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -30,7 +30,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                  iface='swd', speed='auto',
                  gdbserver='JLinkGDBServer', gdb_port=DEFAULT_JLINK_GDB_PORT,
                  tui=False, tool_opt=[]):
-        super(JLinkBinaryRunner, self).__init__(cfg)
+        super().__init__(cfg)
         self.bin_name = cfg.bin_file
         self.elf_name = cfg.elf_file
         self.gdb_cmd = [cfg.gdb] if cfg.gdb else None

--- a/scripts/west_commands/runners/mdb.py
+++ b/scripts/west_commands/runners/mdb.py
@@ -58,7 +58,7 @@ class MdbBinaryRunner(ZephyrBinaryRunner):
                              targets are connected''')
 
     @classmethod
-    def create(cls, cfg, args):
+    def do_create(cls, cfg, args):
         return MdbBinaryRunner(
             cfg,
             cores=args.cores,

--- a/scripts/west_commands/runners/mdb.py
+++ b/scripts/west_commands/runners/mdb.py
@@ -15,7 +15,7 @@ class MdbBinaryRunner(ZephyrBinaryRunner):
 
     def __init__(self, cfg, cores=1, jtag='digilent', nsim_args='',
                 dig_device=''):
-        super(MdbBinaryRunner, self).__init__(cfg)
+        super().__init__(cfg)
         self.jtag = jtag
         self.cores = int(cores)
         if nsim_args != '':

--- a/scripts/west_commands/runners/misc.py
+++ b/scripts/west_commands/runners/misc.py
@@ -42,7 +42,7 @@ class MiscFlasher(ZephyrBinaryRunner):
                             directory''')
 
     @classmethod
-    def create(cls, cfg, args):
+    def do_create(cls, cfg, args):
         return MiscFlasher(cfg, args.cmd, args.args)
 
     def do_run(self, *args, **kwargs):

--- a/scripts/west_commands/runners/nios2.py
+++ b/scripts/west_commands/runners/nios2.py
@@ -41,7 +41,7 @@ class Nios2BinaryRunner(ZephyrBinaryRunner):
                             help='if given, GDB uses -tui')
 
     @classmethod
-    def create(cls, cfg, args):
+    def do_create(cls, cfg, args):
         return Nios2BinaryRunner(cfg,
                                  quartus_py=args.quartus_flash,
                                  cpu_sof=args.cpu_sof,

--- a/scripts/west_commands/runners/nios2.py
+++ b/scripts/west_commands/runners/nios2.py
@@ -19,7 +19,7 @@ class Nios2BinaryRunner(ZephyrBinaryRunner):
     #      and CONFIG_INCLUDE_RESET_VECTOR must be disabled."
 
     def __init__(self, cfg, quartus_py=None, cpu_sof=None, tui=False):
-        super(Nios2BinaryRunner, self).__init__(cfg)
+        super().__init__(cfg)
         self.hex_name = cfg.hex_file
         self.elf_name = cfg.elf_file
         self.cpu_sof = cpu_sof

--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -53,7 +53,7 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
                             e.g. "--recover"''')
 
     @classmethod
-    def create(cls, cfg, args):
+    def do_create(cls, cfg, args):
         return NrfJprogBinaryRunner(cfg, args.nrf_family, args.softreset,
                                     args.snr, erase=args.erase,
                                     tool_opt=args.tool_opt)

--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -17,7 +17,7 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
 
     def __init__(self, cfg, family, softreset, snr, erase=False,
         tool_opt=[]):
-        super(NrfJprogBinaryRunner, self).__init__(cfg)
+        super().__init__(cfg)
         self.hex_ = cfg.hex_file
         self.family = family
         self.softreset = softreset

--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -34,7 +34,7 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'flash'})
+        return RunnerCaps(commands={'flash'}, erase=True)
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -44,8 +44,6 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
         parser.add_argument('--softreset', required=False,
                             action='store_true',
                             help='use reset instead of pinreset')
-        parser.add_argument('--erase', action='store_true',
-                            help='if given, mass erase flash before loading')
         parser.add_argument('--snr', required=False,
                             help='serial number of board to use')
         parser.add_argument('--tool-opt', default=[], action='append',

--- a/scripts/west_commands/runners/nsim.py
+++ b/scripts/west_commands/runners/nsim.py
@@ -27,7 +27,7 @@ class NsimBinaryRunner(ZephyrBinaryRunner):
                  tui=False,
                  gdb_port=DEFAULT_ARC_GDB_PORT,
                  props=DEFAULT_PROPS_FILE):
-        super(NsimBinaryRunner, self).__init__(cfg)
+        super().__init__(cfg)
         self.gdb_cmd = [cfg.gdb] + (['-tui'] if tui else [])
         self.nsim_cmd = ['nsimdrv']
         self.gdb_port = gdb_port

--- a/scripts/west_commands/runners/nsim.py
+++ b/scripts/west_commands/runners/nsim.py
@@ -45,7 +45,7 @@ class NsimBinaryRunner(ZephyrBinaryRunner):
                             help='nsim props file, defaults to nsim.props')
 
     @classmethod
-    def create(cls, cfg, args):
+    def do_create(cls, cfg, args):
         if cfg.gdb is None:
             raise ValueError('--gdb not provided at command line')
 

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -27,7 +27,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                  tcl_port=DEFAULT_OPENOCD_TCL_PORT,
                  telnet_port=DEFAULT_OPENOCD_TELNET_PORT,
                  gdb_port=DEFAULT_OPENOCD_GDB_PORT):
-        super(OpenOcdBinaryRunner, self).__init__(cfg)
+        super().__init__(cfg)
 
         if not config:
             default = path.join(cfg.board_dir, 'support', 'openocd.cfg')

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -98,7 +98,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                             help='openocd gdb port, defaults to 3333')
 
     @classmethod
-    def create(cls, cfg, args):
+    def do_create(cls, cfg, args):
         return OpenOcdBinaryRunner(
             cfg,
             pre_init=args.cmd_pre_init,

--- a/scripts/west_commands/runners/pyocd.py
+++ b/scripts/west_commands/runners/pyocd.py
@@ -95,7 +95,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
                             e.g. \'--script=user.py\' ''')
 
     @classmethod
-    def create(cls, cfg, args):
+    def do_create(cls, cfg, args):
         build_conf = BuildConfiguration(cfg.build_dir)
         flash_addr = cls.get_flash_address(args, build_conf)
 

--- a/scripts/west_commands/runners/pyocd.py
+++ b/scripts/west_commands/runners/pyocd.py
@@ -22,7 +22,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
                  gdb_port=DEFAULT_PYOCD_GDB_PORT,
                  telnet_port=DEFAULT_PYOCD_TELNET_PORT, tui=False,
                  board_id=None, daparg=None, frequency=None, tool_opt=None):
-        super(PyOcdBinaryRunner, self).__init__(cfg)
+        super().__init__(cfg)
 
         self.target_args = ['-t', target]
         self.pyocd = pyocd

--- a/scripts/west_commands/runners/qemu.py
+++ b/scripts/west_commands/runners/qemu.py
@@ -24,7 +24,7 @@ class QemuBinaryRunner(ZephyrBinaryRunner):
         pass                    # Nothing to do.
 
     @classmethod
-    def create(cls, cfg, args):
+    def do_create(cls, cfg, args):
         return QemuBinaryRunner(cfg)
 
     def do_run(self, command, **kwargs):

--- a/scripts/west_commands/runners/stm32flash.py
+++ b/scripts/west_commands/runners/stm32flash.py
@@ -79,7 +79,7 @@ class Stm32flashBinaryRunner(ZephyrBinaryRunner):
                             help='verify writes, default False')
 
     @classmethod
-    def create(cls, cfg, args):
+    def do_create(cls, cfg, args):
         return Stm32flashBinaryRunner(cfg, device=args.device, action=args.action,
             baud=args.baud_rate, force_binary=args.force_binary,
             start_addr=args.start_addr, exec_addr=args.execution_addr,

--- a/scripts/west_commands/runners/stm32flash.py
+++ b/scripts/west_commands/runners/stm32flash.py
@@ -19,7 +19,7 @@ class Stm32flashBinaryRunner(ZephyrBinaryRunner):
     def __init__(self, cfg, device, action='write', baud=57600,
                  force_binary=False, start_addr=0, exec_addr=None,
                  serial_mode='8e1', reset=False, verify=False):
-        super(Stm32flashBinaryRunner, self).__init__(cfg)
+        super().__init__(cfg)
 
         self.device = device
         self.action = action

--- a/scripts/west_commands/runners/xtensa.py
+++ b/scripts/west_commands/runners/xtensa.py
@@ -26,7 +26,7 @@ class XtensaBinaryRunner(ZephyrBinaryRunner):
                             help='path to XTensa tools')
 
     @classmethod
-    def create(cls, cfg, args):
+    def do_create(cls, cfg, args):
         # Override any GDB with the one provided by the XTensa tools.
         cfg.gdb = path.join(args.xcc_tools, 'bin', 'xt-gdb')
         return XtensaBinaryRunner(cfg)


### PR DESCRIPTION
This pull request doesn't do much on its own. It's meant as an easy to review way to lay some groundwork for future patches.

- clean up how runners call super() (this has just been bothering me for a while)
- add a layer of indirection between create() and the actual runner implementation, which allows us to check that common options we pass to create() are in fact supported by the runner's declared capabilities
- promotes --erase to a common option that may or may not be supported and declared via RunnerCaps
