### PR TITLE
doc: clarify how to set $FOO_ROOT in CMakeLists.txt

### DIFF
--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -667,7 +667,8 @@ This will use your custom board configuration and will generate the
 Zephyr binary into your application directory.
 
 You can also define the ``BOARD_ROOT`` variable in the application
-:file:`CMakeLists.txt` file.
+:file:`CMakeLists.txt` file. Make sure to do so **before** pulling in the Zephyr
+boilerplate with ``find_package(Zephyr ...)``.
 
 
 SOC Definitions
@@ -724,7 +725,8 @@ This will use your custom platform configurations and will generate the
 Zephyr binary into your application directory.
 
 You can also define the ``SOC_ROOT`` variable in the application
-:file:`CMakeLists.txt` file.
+:file:`CMakeLists.txt` file. Make sure to do so **before** pulling in the
+Zephyr boilerplate with ``find_package(Zephyr ...)``.
 
 .. _dts_root:
 
@@ -755,8 +757,9 @@ its location through the ``DTS_ROOT`` CMake Cache variable:
    :goals: build
    :compact:
 
-You can also define the variable in the application
-:file:`CMakeLists.txt` file.
+You can also define the variable in the application :file:`CMakeLists.txt`
+file. Make sure to do so **before** pulling in the Zephyr boilerplate with
+``find_package(Zephyr ...)``.
 
 
 Application Debugging


### PR DESCRIPTION
I received feedback that setting e.g. BOARD_ROOT in CMakeLists.txt is
not quite well specified; in particular, it's important to do so
before pulling in the boilerplate via find_package(). Clear that up.

Reported-by: Pete Skeggs <peter.skeggs@nordicsemi.no>
Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>