### PR TITLE
storage: flash_map: Fix partition device retrieval

### DIFF
--- a/subsys/storage/flash_map/flash_map_default.c
+++ b/subsys/storage/flash_map/flash_map_default.c
@@ -13,26 +13,11 @@
 /* Get the grand parent of a node */
 #define GPARENT(node_id) DT_PARENT(DT_PARENT(node_id))
 
-/* if 'soc-nv-flash' return controller label or punt to _else_code */
-#define IS_SOC_NV_FLASH(part, _else_code) \
-	COND_CODE_1(DT_NODE_HAS_COMPAT(GPARENT(part), soc_nv_flash), \
-		    (DT_LABEL(DT_PARENT(GPARENT(part)))), (_else_code))
-
-/* if 'jedec,spi-nor' return controller label or punt to _else_code */
-#define IS_JEDEC_SPI_NOR(part, _else_code) \
-	COND_CODE_1(DT_NODE_HAS_COMPAT(GPARENT(part), jedec_spi_nor), \
-		    (DT_LABEL(GPARENT(part))), (_else_code))
-
-/* if 'nordic,qspi-nor' return controller label or punt to _else_code */
-#define IS_NORDIC_QSPI_NOR(part, _else_code) \
-	COND_CODE_1(DT_NODE_HAS_COMPAT(GPARENT(part), nordic_qspi_nor), \
-		    (DT_LABEL(GPARENT(part))), (_else_code))
-
-/* return flash controller label based on matching compatible or NULL */
-#define DT_FLASH_DEV_FROM_PART(part) \
-	IS_SOC_NV_FLASH(part, \
-	IS_JEDEC_SPI_NOR(part, \
-	IS_NORDIC_QSPI_NOR(part, NULL)))
+/* return great-grandparent label if 'soc-nv-flash' else grandparent label */
+#define DT_FLASH_DEV_FROM_PART(part)					      \
+	DT_LABEL(COND_CODE_1(DT_NODE_HAS_COMPAT(GPARENT(part), soc_nv_flash), \
+			     (DT_PARENT(GPARENT(part))),		      \
+			     (GPARENT(part))))
 
 #define FLASH_AREA_FOO(part)				\
 	{.fa_id = DT_FIXED_PARTITION_ID(part),		\


### PR DESCRIPTION
Change the default behaviour of the flash partition choice when no
matching compatible is found. The new default is the grandparent node
of the fixed-partition.

As the grandparent node is what the jedec_spi_nor and nordic_qspi_nor
compatibles were selecting, remove these as separate checks.

This allows the flash_map API to be used for implementations of the
flash API other than the 3 originally specified (soc_nv_flash,
jedec_spi_nor & nordic_qspi_nor).

Fixes #26397

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>