### PR TITLE
Esp wifi fix busy error after disconnect

### DIFF
--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -213,7 +213,8 @@ static int _sock_send(struct esp_data *dev, struct esp_socket *sock)
 	};
 
 	if (!esp_flag_is_set(dev, EDF_STA_CONNECTED)) {
-		return -ENETUNREACH;
+		ret = -ENETUNREACH;
+		goto free_pkt;
 	}
 
 	pkt_len = net_pkt_get_len(sock->tx_pkt);
@@ -290,6 +291,7 @@ clear_modem_cmds:
 					    NULL, 0U, false);
 	k_sem_give(&dev->cmd_handler_data.sem_tx_lock);
 
+free_pkt:
 	net_pkt_unref(sock->tx_pkt);
 	sock->tx_pkt = NULL;
 


### PR DESCRIPTION
sock->tx_pkt is assigned in esp_sendto(). This packet has to be freed
eventually. In current implementation this is a responsibility of
_sock_send() which is called either directly, or indirectly by work
queue esp_send_work(). _sock_send() is freeing sock->tx_pkt in all
cases except when if (!esp_flag_is_set(dev, EDF_STA_CONNECTED)).

ESP modem is not notifying about closed UDP link when connection to
network is lost. This means that  sock->flag has still
ESP_SOCK_CONNETED bit set. On next esp_sendto() call, sock->tx_pkt
is assigned, then _sock_send() is called returning -ENETUNREACH
without freeing sock->tx_pkt. This results in permanent -EBUSY
error on every next esp_sendto() call.

This does not happen for TCP link because modem notifies about closed
TCP link. sock->flag ESP_SOCK_CONNETED bit is unset. In that case
next call esp_sendto() fails on esp_connect() returning -ENETUNREACH,
before sock->tx_pkt is assigned.

To solve this problem sock->tx_pkt must be also freed when there is no
WiFi connection.