### PR TITLE
swiftio_mm no support pw control

### DIFF
--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -74,6 +74,5 @@
 
 &usdhc1 {
 	status = "okay";
-	pwr-gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
 	cd-gpios = <&gpio2 28 GPIO_ACTIVE_LOW>;
 };


### PR DESCRIPTION
swiftio_mm no support pw control.
remove pw gpio from dts.

Signed-off-by: Frank Li <lgl88911@163.com>