### PR TITLE
boards: disco_l475_iot1: fix corruption of storage partition

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -172,7 +172,7 @@
 		};
 		scratch_partition: partition@f8000 {
 			label = "image-scratch";
-			reg = <0x000F8000 0x00006000>;
+			reg = <0x000F8000 0x00004000>;
 		};
 
 		storage_partition: partition@fc000 {


### PR DESCRIPTION
Fixes #26413.

The devicetree for disco_l475_iot1 declares the flash partitions
"storage" and "image-scratch" with overlapping address spaces.

As a result, when one of these partitions is used it can corrupt the
contents of the other one. This is the case when mcuboot performs an
image swap using the scratch partition.

To fix the bug, the size of the scratch partition is reduced.

Signed-off-by: Hans Wilmers <hans@wilmers.no>