### PR TITLE
Bluetooth: host: Fix adv object not released on directed adv timeout

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2015,6 +2015,14 @@ static void le_conn_complete_adv_timeout(void)
 
 		atomic_clear_bit(adv->flags, BT_ADV_ENABLED);
 
+		if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
+		    !BT_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+			/* No advertising set terminated event, must be a
+			 * legacy advertiser set.
+			 */
+			adv_delete_legacy();
+		}
+
 		/* There is no need to check ID address as only one
 		 * connection in slave role can be in pending state.
 		 */


### PR DESCRIPTION
Fix the advertise object not release when a high-duty cycle directed
advertiser timeout happens. If the extended advertising feature has been
enabled in the host, but not supported by the controller then the
advertising object must be released in the connection complete event
since there will not be a advertising set terminated event.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>