### PR TITLE
Bluetooth: controller: Fix non-privacy directed advertiser

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -848,7 +848,7 @@ static inline bool isr_rx_ci_tgta_check(struct lll_adv *lll,
 					uint8_t rl_idx)
 {
 #if defined(CONFIG_BT_CTLR_PRIVACY)
-	if (rl_idx != FILTER_IDX_NONE) {
+	if (rl_idx != FILTER_IDX_NONE && lll->rl_idx != FILTER_IDX_NONE) {
 		return rl_idx == lll->rl_idx;
 	}
 #endif /* CONFIG_BT_CTLR_PRIVACY */

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -858,7 +858,7 @@ static inline bool isr_rx_ci_tgta_check(struct lll_adv *lll,
 					uint8_t rl_idx)
 {
 #if defined(CONFIG_BT_CTLR_PRIVACY)
-	if (rl_idx != FILTER_IDX_NONE) {
+	if (rl_idx != FILTER_IDX_NONE && lll->rl_idx != FILTER_IDX_NONE) {
 		return rl_idx == lll->rl_idx;
 	}
 #endif /* CONFIG_BT_CTLR_PRIVACY */


### PR DESCRIPTION
Fix issue with directed advertiser not accepting connection request from
non-privacy enabled peer that has given us a non-zero IRK.
When device privacy is enabled then ull_filter_lll_rl_addr_allowed will return
true, and update the rl_idx to entry in the resolving list.
When the directed advertiser is not privacy enabled then lll->rl_idx is set
to FILTER_IDX_NONE and will not use RPA for the target address.
The check rl_idx != lll->rl_idx will then fail (0 != 0xff) and the connect
request is denied, even though all addresses matches on-air.

Fixes: #26303 

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>