### PR TITLE
west: update to fix littlefs report configuration problem

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -117,7 +117,7 @@ manifest:
       revision: 3e9a49d2672ec01435ffbf0d788db6d95ef28de0
     - name: littlefs
       path: modules/fs/littlefs
-      revision: 0aefdda69d236cb01f932117c1f32e9da09c0ec3
+      revision: 9e4498d1c73009acd84bb36036ee5e2869112a6c
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t
       revision: 957d46bc3ce0d5f628f0d525196bb4db207672ee


### PR DESCRIPTION
Reference an updated head that removes references to reporting infrastructure when reporting is disabled.

~DNM until zephyrproject-rtos/littlefs#6 is merged.~

Fixes #26415