### PR TITLE
API Change:  UART - callback improvement

### DIFF
--- a/doc/releases/release-notes-2.4.rst
+++ b/doc/releases/release-notes-2.4.rst
@@ -46,6 +46,13 @@ API Changes
   ignore this diagnostic result or initiate another feed operation
   later.
 
+* ``<drivers/uart.h>`` has seen its callbacks normalized.
+  :c:type:`uart_callback_t` and :c:type:`uart_irq_callback_user_data_t`
+  had their signature changed to add a struct device pointer as first parameter.
+  :c:type:`uart_irq_callback_t` has been removed. :c:func:`uart_callback_set`,
+  :c:func:`uart_irq_callback_user_data_set` and :c:func:`uart_irq_callback_set`
+  user code have been modified accordingly.
+
 Deprecated in this release
 ==========================
 

--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -391,9 +391,10 @@ static inline void process_rx(void)
 	}
 }
 
-static void bt_uart_isr(struct device *unused)
+static void bt_uart_isr(struct device *unused, void *user_data)
 {
 	ARG_UNUSED(unused);
+	ARG_UNUSED(user_data);
 
 	while (uart_irq_update(h4_dev) && uart_irq_is_pending(h4_dev)) {
 		if (uart_irq_tx_ready(h4_dev)) {

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -405,7 +405,7 @@ static inline struct net_buf *get_evt_buf(uint8_t evt)
 	return bt_buf_get_evt(evt, false, K_NO_WAIT);
 }
 
-static void bt_uart_isr(struct device *unused)
+static void bt_uart_isr(struct device *unused, void *user_data)
 {
 	static int remaining;
 	uint8_t byte;
@@ -413,6 +413,7 @@ static void bt_uart_isr(struct device *unused)
 	static uint8_t hdr[4];
 
 	ARG_UNUSED(unused);
+	ARG_UNUSED(user_data);
 
 	while (uart_irq_update(h5_dev) &&
 	       uart_irq_is_pending(h5_dev)) {

--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -434,9 +434,10 @@ static bool handle_mcumgr(struct console_input *cmd, uint8_t byte)
 
 #endif /* CONFIG_UART_CONSOLE_MCUMGR */
 
-static void uart_console_isr(struct device *unused)
+static void uart_console_isr(struct device *unused, void *user_data)
 {
 	ARG_UNUSED(unused);
+	ARG_UNUSED(user_data);
 
 	while (uart_irq_update(uart_console_dev) &&
 	       uart_irq_is_pending(uart_console_dev)) {

--- a/drivers/console/uart_mcumgr.c
+++ b/drivers/console/uart_mcumgr.c
@@ -115,7 +115,7 @@ static struct uart_mcumgr_rx_buf *uart_mcumgr_rx_byte(uint8_t byte)
 /**
  * ISR that is called when UART bytes are received.
  */
-static void uart_mcumgr_isr(struct device *unused)
+static void uart_mcumgr_isr(struct device *unused, void *user_data)
 {
 	struct uart_mcumgr_rx_buf *rx_buf;
 	uint8_t buf[32];
@@ -123,6 +123,7 @@ static void uart_mcumgr_isr(struct device *unused)
 	int i;
 
 	ARG_UNUSED(unused);
+	ARG_UNUSED(user_data);
 
 	while (uart_irq_update(uart_mcumgr_dev) &&
 	       uart_irq_is_pending(uart_mcumgr_dev)) {

--- a/drivers/console/uart_mux.c
+++ b/drivers/console/uart_mux.c
@@ -243,16 +243,16 @@ static int uart_mux_init(struct device *dev)
  * data from it in uart_mux_rx_work(), we push the data to GSM mux API which
  * will call proper callbacks to pass data to correct recipient.
  */
-static void uart_mux_isr(void *user_data)
+static void uart_mux_isr(struct device *uart, void *user_data)
 {
 	struct uart_mux *real_uart = user_data;
 	int rx = 0;
 	size_t wrote = 0;
 
 	/* Read all data off UART, and send to RX worker for unmuxing */
-	while (uart_irq_update(real_uart->uart) &&
-	       uart_irq_rx_ready(real_uart->uart)) {
-		rx = uart_fifo_read(real_uart->uart, real_uart->rx_buf,
+	while (uart_irq_update(uart) &&
+	       uart_irq_rx_ready(uart)) {
+		rx = uart_fifo_read(uart, real_uart->rx_buf,
 				    sizeof(real_uart->rx_buf));
 		if (rx <= 0) {
 			continue;

--- a/drivers/console/uart_pipe.c
+++ b/drivers/console/uart_pipe.c
@@ -53,8 +53,10 @@ static void uart_pipe_rx(struct device *dev)
 	}
 }
 
-static void uart_pipe_isr(struct device *dev)
+static void uart_pipe_isr(struct device *dev, void *user_data)
 {
+	ARG_UNUSED(user_data);
+
 	uart_irq_update(dev);
 
 	if (uart_irq_is_pending(dev)) {

--- a/drivers/modem/modem_iface_uart.c
+++ b/drivers/modem/modem_iface_uart.c
@@ -47,11 +47,13 @@ static void modem_iface_uart_flush(struct modem_iface *iface)
  *
  * @retval None.
  */
-static void modem_iface_uart_isr(struct device *uart_dev)
+static void modem_iface_uart_isr(struct device *uart_dev, void *user_data)
 {
 	struct modem_context *ctx;
 	struct modem_iface_uart_data *data;
 	int rx = 0, ret;
+
+	ARG_UNUSED(user_data);
 
 	/* lookup the modem context */
 	ctx = modem_context_from_iface_dev(uart_dev);

--- a/drivers/modem/modem_receiver.c
+++ b/drivers/modem/modem_receiver.c
@@ -101,11 +101,13 @@ static void mdm_receiver_flush(struct mdm_receiver_context *ctx)
  *
  * @retval None.
  */
-static void mdm_receiver_isr(struct device *uart_dev)
+static void mdm_receiver_isr(struct device *uart_dev, void *user_data)
 {
 	struct mdm_receiver_context *ctx;
 	int rx, ret;
 	static uint8_t read_buf[MAX_READ_SIZE];
+
+	ARG_UNUSED(user_data);
 
 	/* lookup the device */
 	ctx = context_from_dev(uart_dev);

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -784,10 +784,9 @@ static void ppp_uart_flush(struct device *dev)
 	}
 }
 
-static void ppp_uart_isr(void *user_data)
+static void ppp_uart_isr(struct device *uart, void *user_data)
 {
 	struct ppp_driver_context *context = user_data;
-	struct device *uart = context->dev;
 	int rx = 0, ret;
 
 	/* get all of the data off UART as fast as we can */

--- a/drivers/serial/leuart_gecko.c
+++ b/drivers/serial/leuart_gecko.c
@@ -237,7 +237,7 @@ static void leuart_gecko_isr(void *arg)
 	struct leuart_gecko_data *data = dev->driver_data;
 
 	if (data->callback) {
-		data->callback(data->cb_data);
+		data->callback(dev, data->cb_data);
 	}
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -345,10 +345,11 @@ static void uart_cc13xx_cc26xx_irq_callback_set(
 
 static void uart_cc13xx_cc26xx_isr(void *arg)
 {
-	struct uart_cc13xx_cc26xx_data *data = get_dev_data(arg);
+	struct device *dev = (struct device *)arg;
+	struct uart_cc13xx_cc26xx_data *data = get_dev_data(dev);
 
 	if (data->callback) {
-		data->callback(data->user_data);
+		data->callback(dev, data->user_data);
 	}
 }
 

--- a/drivers/serial/uart_cc32xx.c
+++ b/drivers/serial/uart_cc32xx.c
@@ -282,7 +282,7 @@ static void uart_cc32xx_isr(void *arg)
 						    1);
 
 	if (dev_data->cb) {
-		dev_data->cb(dev_data->cb_data);
+		dev_data->cb(dev, dev_data->cb_data);
 	}
 	/*
 	 * RX/TX interrupt should have been implicitly cleared by Zephyr UART

--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -430,7 +430,7 @@ void uart_cmsdk_apb_isr(void *arg)
 
 	/* Verify if the callback has been registered */
 	if (data->irq_cb) {
-		data->irq_cb(data->irq_cb_data);
+		data->irq_cb(dev, data->irq_cb_data);
 	}
 }
 

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -437,7 +437,7 @@ void uart_esp32_isr(void *arg)
 
 	/* Verify if the callback has been registered */
 	if (data->irq_cb) {
-		data->irq_cb(data->irq_cb_data);
+		data->irq_cb(dev, data->irq_cb_data);
 	}
 }
 

--- a/drivers/serial/uart_gecko.c
+++ b/drivers/serial/uart_gecko.c
@@ -229,7 +229,7 @@ static void uart_gecko_isr(void *arg)
 	struct uart_gecko_data *data = dev->driver_data;
 
 	if (data->callback) {
-		data->callback(data->cb_data);
+		data->callback(dev, data->cb_data);
 	}
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */

--- a/drivers/serial/uart_imx.c
+++ b/drivers/serial/uart_imx.c
@@ -255,7 +255,7 @@ void uart_imx_isr(void *arg)
 	struct imx_uart_data *data = dev->driver_data;
 
 	if (data->callback) {
-		data->callback(data->cb_data);
+		data->callback(dev, data->cb_data);
 	}
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */

--- a/drivers/serial/uart_liteuart.c
+++ b/drivers/serial/uart_liteuart.c
@@ -279,7 +279,7 @@ static void liteuart_uart_irq_handler(void *arg)
 	int key = irq_lock();
 
 	if (data->callback) {
-		data->callback(data->cb_data);
+		data->callback(dev, data->cb_data);
 	}
 
 	/* clear events */

--- a/drivers/serial/uart_mcux.c
+++ b/drivers/serial/uart_mcux.c
@@ -298,7 +298,7 @@ static void uart_mcux_isr(void *arg)
 	struct uart_mcux_data *data = dev->driver_data;
 
 	if (data->callback) {
-		data->callback(data->cb_data);
+		data->callback(dev, data->cb_data);
 	}
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -236,7 +236,7 @@ static void mcux_flexcomm_isr(void *arg)
 	struct mcux_flexcomm_data *data = dev->driver_data;
 
 	if (data->callback) {
-		data->callback(data->cb_data);
+		data->callback(dev, data->cb_data);
 	}
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */

--- a/drivers/serial/uart_mcux_lpsci.c
+++ b/drivers/serial/uart_mcux_lpsci.c
@@ -227,7 +227,7 @@ static void mcux_lpsci_isr(void *arg)
 	struct mcux_lpsci_data *data = dev->driver_data;
 
 	if (data->callback) {
-		data->callback(data->cb_data);
+		data->callback(dev, data->cb_data);
 	}
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -227,7 +227,7 @@ static void mcux_lpuart_isr(void *arg)
 	struct mcux_lpuart_data *data = dev->driver_data;
 
 	if (data->callback) {
-		data->callback(data->cb_data);
+		data->callback(dev, data->cb_data);
 	}
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */

--- a/drivers/serial/uart_miv.c
+++ b/drivers/serial/uart_miv.c
@@ -300,7 +300,7 @@ static void uart_miv_irq_handler(void *arg)
 	struct uart_miv_data *data = DEV_DATA(dev);
 
 	if (data->callback) {
-		data->callback(data->cb_data);
+		data->callback(dev, data->cb_data);
 	}
 }
 

--- a/drivers/serial/uart_msp432p4xx.c
+++ b/drivers/serial/uart_msp432p4xx.c
@@ -329,7 +329,7 @@ static void uart_msp432p4xx_isr(void *arg)
 						(unsigned long)config->base);
 
 	if (dev_data->cb) {
-		dev_data->cb(dev_data->cb_data);
+		dev_data->cb(dev, dev_data->cb_data);
 	}
 	/*
 	 * Clear interrupts only after cb called, as Zephyr UART clients expect

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -950,7 +950,7 @@ static void uart_nrfx_isr(void *arg)
 	}
 
 	if (irq_callback) {
-		irq_callback(irq_cb_data);
+		irq_callback(dev, irq_cb_data);
 	}
 }
 #endif /* CONFIG_UART_0_INTERRUPT_DRIVEN */

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -622,7 +622,7 @@ static void user_callback(struct device *dev, struct uart_event *evt)
 	struct uarte_nrfx_data *data = get_dev_data(dev);
 
 	if (data->async->user_callback) {
-		data->async->user_callback(evt, data->async->user_data);
+		data->async->user_callback(dev, evt, data->async->user_data);
 	}
 }
 

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -191,7 +191,7 @@ static void uarte_nrfx_isr_int(void *arg)
 	}
 
 	if (data->int_driven->cb) {
-		data->int_driven->cb(data->int_driven->cb_data);
+		data->int_driven->cb(dev, data->int_driven->cb_data);
 	}
 }
 #endif /* UARTE_INTERRUPT_DRIVEN */

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -853,7 +853,7 @@ static void uart_ns16550_isr(void *arg)
 	struct uart_ns16550_dev_data_t * const dev_data = DEV_DATA(dev);
 
 	if (dev_data->cb) {
-		dev_data->cb(dev_data->cb_data);
+		dev_data->cb(dev, dev_data->cb_data);
 	}
 
 }

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -402,7 +402,7 @@ void pl011_isr(void *arg)
 
 	/* Verify if the callback has been registered */
 	if (data->irq_cb) {
-		data->irq_cb(data->irq_cb_data);
+		data->irq_cb(dev, data->irq_cb_data);
 	}
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */

--- a/drivers/serial/uart_rv32m1_lpuart.c
+++ b/drivers/serial/uart_rv32m1_lpuart.c
@@ -230,7 +230,7 @@ static void rv32m1_lpuart_isr(void *arg)
 	struct rv32m1_lpuart_data *data = dev->driver_data;
 
 	if (data->callback) {
-		data->callback(data->cb_data);
+		data->callback(dev, data->cb_data);
 	}
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */

--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -294,7 +294,7 @@ static void uart_sam_isr(void *arg)
 	struct uart_sam_dev_data *const dev_data = DEV_DATA(dev);
 
 	if (dev_data->irq_cb) {
-		dev_data->irq_cb(dev_data->irq_cb_data);
+		dev_data->irq_cb(dev, dev_data->irq_cb_data);
 	}
 }
 

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -662,7 +662,7 @@ static void uart_sam0_isr(void *arg)
 
 #if CONFIG_UART_INTERRUPT_DRIVEN
 	if (dev_data->cb) {
-		dev_data->cb(dev_data->cb_data);
+		dev_data->cb(dev, dev_data->cb_data);
 	}
 #endif
 

--- a/drivers/serial/uart_sifive.c
+++ b/drivers/serial/uart_sifive.c
@@ -323,7 +323,7 @@ static void uart_sifive_irq_handler(void *arg)
 	struct uart_sifive_data *data = DEV_DATA(dev);
 
 	if (data->callback)
-		data->callback(data->cb_data);
+		data->callback(dev, data->cb_data);
 }
 
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */

--- a/drivers/serial/uart_stellaris.c
+++ b/drivers/serial/uart_stellaris.c
@@ -597,7 +597,7 @@ static void uart_stellaris_isr(void *arg)
 	struct uart_stellaris_dev_data_t * const dev_data = DEV_DATA(dev);
 
 	if (dev_data->cb) {
-		dev_data->cb(dev_data->cb_data);
+		dev_data->cb(dev, dev_data->cb_data);
 	}
 }
 

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -615,7 +615,7 @@ static void uart_stm32_isr(void *arg)
 	struct uart_stm32_data *data = DEV_DATA(dev);
 
 	if (data->user_cb) {
-		data->user_cb(data->user_data);
+		data->user_cb(dev, data->user_data);
 	}
 }
 

--- a/drivers/serial/uart_xlnx_ps.c
+++ b/drivers/serial/uart_xlnx_ps.c
@@ -1139,7 +1139,7 @@ static void uart_xlnx_ps_isr(void *arg)
 	const struct uart_xlnx_ps_dev_data_t *data = DEV_DATA(dev);
 
 	if (data->user_cb) {
-		data->user_cb(data->user_data);
+		data->user_cb(dev, data->user_data);
 	}
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -295,7 +295,7 @@ static void usart_sam_isr(void *arg)
 	struct usart_sam_dev_data *const dev_data = DEV_DATA(dev);
 
 	if (dev_data->irq_cb) {
-		dev_data->irq_cb(dev_data->cb_data);
+		dev_data->irq_cb(dev, dev_data->cb_data);
 	}
 }
 

--- a/include/drivers/uart.h
+++ b/include/drivers/uart.h
@@ -230,10 +230,12 @@ struct uart_event {
  * @brief Define the application callback function signature for
  * uart_callback_set() function.
  *
+ * @param dev       UART device structure.
  * @param evt	    Pointer to uart_event structure.
  * @param user_data Pointer to data specified by user.
  */
-typedef void (*uart_callback_t)(struct uart_event *evt, void *user_data);
+typedef void (*uart_callback_t)(struct device *dev,
+				struct uart_event *evt, void *user_data);
 
 /**
  * @brief UART controller configuration structure

--- a/include/drivers/uart.h
+++ b/include/drivers/uart.h
@@ -305,15 +305,6 @@ typedef void (*uart_irq_callback_user_data_t)(struct device *dev,
 					      void *user_data);
 
 /**
- * @typedef uart_irq_callback_t
- * @brief Define the application callback function signature for legacy
- * uart_irq_callback_set().
- *
- * @param dev UART device structure.
- */
-typedef void (*uart_irq_callback_t)(struct device *dev);
-
-/**
  * @typedef uart_irq_config_func_t
  * @brief For configuring IRQ on each individual UART device.
  *

--- a/include/drivers/uart.h
+++ b/include/drivers/uart.h
@@ -298,9 +298,11 @@ enum uart_config_flow_control {
  * @brief Define the application callback function signature for
  * uart_irq_callback_user_data_set() function.
  *
+ * @param dev       UART device structure.
  * @param user_data Arbitrary user data.
  */
-typedef void (*uart_irq_callback_user_data_t)(void *user_data);
+typedef void (*uart_irq_callback_user_data_t)(struct device *dev,
+					      void *user_data);
 
 /**
  * @typedef uart_irq_callback_t
@@ -1121,10 +1123,9 @@ static inline void uart_irq_callback_user_data_set(
  * @return N/A
  */
 static inline void uart_irq_callback_set(struct device *dev,
-					 uart_irq_callback_t cb)
+					 uart_irq_callback_user_data_t cb)
 {
-	uart_irq_callback_user_data_set(dev, (uart_irq_callback_user_data_t)cb,
-					dev);
+	uart_irq_callback_user_data_set(dev, cb, NULL);
 }
 
 

--- a/include/drivers/uart.h
+++ b/include/drivers/uart.h
@@ -305,17 +305,19 @@ typedef void (*uart_irq_callback_user_data_t)(void *user_data);
  * @brief Define the application callback function signature for legacy
  * uart_irq_callback_set().
  *
- * @param port Device struct for the UART device.
+ * @param dev UART device structure.
  */
-typedef void (*uart_irq_callback_t)(struct device *port);
+typedef void (*uart_irq_callback_t)(struct device *dev);
 
 /**
  * @typedef uart_irq_config_func_t
  * @brief For configuring IRQ on each individual UART device.
  *
+ * @param dev UART device structure.
+ *
  * @internal
  */
-typedef void (*uart_irq_config_func_t)(struct device *port);
+typedef void (*uart_irq_config_func_t)(struct device *dev);
 
 /**
  * @brief UART device configuration.

--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -110,12 +110,13 @@ static void h4_acl_recv(struct net_buf *buf, int *remaining)
 	LOG_DBG("len %u", *remaining);
 }
 
-static void bt_uart_isr(struct device *unused)
+static void bt_uart_isr(struct device *unused, void *user_data)
 {
 	static struct net_buf *buf;
 	static int remaining;
 
 	ARG_UNUSED(unused);
+	ARG_UNUSED(user_data);
 
 	while (uart_irq_update(hci_uart_dev) &&
 	       uart_irq_is_pending(hci_uart_dev)) {

--- a/samples/net/wpan_serial/src/main.c
+++ b/samples/net/wpan_serial/src/main.c
@@ -127,8 +127,10 @@ static int slip_process_byte(unsigned char c)
 	return 0;
 }
 
-static void interrupt_handler(struct device *dev)
+static void interrupt_handler(struct device *dev, void *user_data)
 {
+	ARG_UNUSED(user_data);
+
 	while (uart_irq_update(dev) && uart_irq_is_pending(dev)) {
 		unsigned char byte;
 

--- a/samples/subsys/usb/cdc_acm/src/main.c
+++ b/samples/subsys/usb/cdc_acm/src/main.c
@@ -28,8 +28,10 @@ uint8_t ring_buffer[RING_BUF_SIZE];
 
 struct ring_buf ringbuf;
 
-static void interrupt_handler(struct device *dev)
+static void interrupt_handler(struct device *dev, void *user_data)
 {
+	ARG_UNUSED(user_data);
+
 	while (uart_irq_update(dev) && uart_irq_is_pending(dev)) {
 		if (uart_irq_rx_ready(dev)) {
 			int recv_len, rb_len;

--- a/samples/subsys/usb/cdc_acm_composite/src/main.c
+++ b/samples/subsys/usb/cdc_acm_composite/src/main.c
@@ -29,17 +29,14 @@ uint8_t buffer0[RING_BUF_SIZE];
 uint8_t buffer1[RING_BUF_SIZE];
 
 static struct serial_data {
-	struct device *dev;
 	struct device *peer;
 	struct serial_data *peer_data;
 	struct ring_buf ringbuf;
 } peers[2];
 
-static void interrupt_handler(void *user_data)
+static void interrupt_handler(struct device *dev, void *user_data)
 {
 	struct serial_data *dev_data = user_data;
-	struct device *dev = dev_data->dev;
-
 
 	while (uart_irq_update(dev) && uart_irq_is_pending(dev)) {
 		struct device *peer = dev_data->peer;
@@ -162,12 +159,10 @@ void main(void)
 	uart_line_set(dev0);
 	uart_line_set(dev1);
 
-	dev_data0->dev = dev0;
 	dev_data0->peer = dev1;
 	dev_data0->peer_data = dev_data1;
 	ring_buf_init(&dev_data0->ringbuf, sizeof(buffer0), buffer0);
 
-	dev_data1->dev = dev1;
 	dev_data1->peer = dev0;
 	dev_data1->peer_data = dev_data0;
 	ring_buf_init(&dev_data1->ringbuf, sizeof(buffer1), buffer1);

--- a/samples/subsys/usb/hid-cdc/src/main.c
+++ b/samples/subsys/usb/hid-cdc/src/main.c
@@ -401,8 +401,10 @@ static void write_data(struct device *dev, const char *buf, int len)
 	uart_irq_tx_disable(dev);
 }
 
-static void cdc_mouse_int_handler(struct device *dev)
+static void cdc_mouse_int_handler(struct device *dev, void *user_data)
 {
+	ARG_UNUSED(user_data);
+
 	uart_irq_update(dev);
 
 	if (uart_irq_tx_ready(dev)) {
@@ -447,8 +449,10 @@ static void cdc_mouse_int_handler(struct device *dev)
 	}
 }
 
-static void cdc_kbd_int_handler(struct device *dev)
+static void cdc_kbd_int_handler(struct device *dev, void *user_data)
 {
+	ARG_UNUSED(user_data);
+
 	uart_irq_update(dev);
 
 	if (uart_irq_tx_ready(dev)) {

--- a/subsys/console/tty.c
+++ b/subsys/console/tty.c
@@ -12,10 +12,9 @@
 static int tty_irq_input_hook(struct tty_serial *tty, uint8_t c);
 static int tty_putchar(struct tty_serial *tty, uint8_t c);
 
-static void tty_uart_isr(void *user_data)
+static void tty_uart_isr(struct device *dev, void *user_data)
 {
 	struct tty_serial *tty = user_data;
-	struct device *dev = tty->uart_dev;
 
 	uart_irq_update(dev);
 

--- a/subsys/tracing/tracing_backend_uart.c
+++ b/subsys/tracing/tracing_backend_uart.c
@@ -17,12 +17,14 @@
 static struct device *tracing_uart_dev;
 
 #ifdef CONFIG_TRACING_HANDLE_HOST_CMD
-static void uart_isr(struct device *dev)
+static void uart_isr(struct device *dev, void *user_data)
 {
 	int rx;
 	uint8_t byte;
 	static uint8_t *cmd;
 	static uint32_t length, cur;
+
+	ARG_UNUSED(user_data);
 
 	while (uart_irq_update(dev) && uart_irq_is_pending(dev)) {
 		if (!uart_irq_rx_ready(dev)) {

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -519,7 +519,7 @@ static void cdc_acm_irq_callback_work_handler(struct k_work *work)
 
 	dev_data = CONTAINER_OF(work, struct cdc_acm_dev_data_t, cb_work);
 
-	dev_data->cb(dev_data->cb_data);
+	dev_data->cb(dev_data->common.dev, dev_data->cb_data);
 }
 
 /**

--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -25,8 +25,11 @@ void set_permissions(void)
 }
 #endif
 
-void test_single_read_callback(struct uart_event *evt, void *user_data)
+void test_single_read_callback(struct device *dev,
+			       struct uart_event *evt, void *user_data)
 {
+	ARG_UNUSED(dev);
+
 	switch (evt->type) {
 	case UART_TX_DONE:
 		k_sem_give(&tx_done);
@@ -98,10 +101,9 @@ ZTEST_DMEM uint8_t buf_num = 1U;
 ZTEST_BMEM uint8_t *read_ptr;
 ZTEST_BMEM volatile size_t read_len;
 
-void test_chained_read_callback(struct uart_event *evt, void *user_data)
+void test_chained_read_callback(struct device *uart_dev,
+				struct uart_event *evt, void *user_data)
 {
-	struct device *uart_dev = (struct device *) user_data;
-
 	switch (evt->type) {
 	case UART_TX_DONE:
 		k_sem_give(&tx_done);
@@ -137,7 +139,7 @@ void test_chained_read_setup(void)
 {
 	struct device *uart_dev = device_get_binding(UART_DEVICE_NAME);
 
-	uart_callback_set(uart_dev, test_chained_read_callback, uart_dev);
+	uart_callback_set(uart_dev, test_chained_read_callback, NULL);
 }
 
 void test_chained_read(void)
@@ -172,10 +174,9 @@ void test_chained_read(void)
 ZTEST_BMEM uint8_t double_buffer[2][12];
 ZTEST_DMEM uint8_t *next_buf = double_buffer[1];
 
-void test_double_buffer_callback(struct uart_event *evt, void *user_data)
+void test_double_buffer_callback(struct device *uart_dev,
+				 struct uart_event *evt, void *user_data)
 {
-	struct device *uart_dev = (struct device *) user_data;
-
 	switch (evt->type) {
 	case UART_TX_DONE:
 		k_sem_give(&tx_done);
@@ -204,7 +205,7 @@ void test_double_buffer_setup(void)
 {
 	struct device *uart_dev = device_get_binding(UART_DEVICE_NAME);
 
-	uart_callback_set(uart_dev, test_double_buffer_callback, uart_dev);
+	uart_callback_set(uart_dev, test_double_buffer_callback, NULL);
 }
 
 void test_double_buffer(void)
@@ -235,9 +236,12 @@ void test_double_buffer(void)
 		      "RX_DISABLED timeout");
 }
 
-void test_read_abort_callback(struct uart_event *evt, void *user_data)
+void test_read_abort_callback(struct device *dev,
+			      struct uart_event *evt, void *user_data)
 {
 	int err;
+
+	ARG_UNUSED(dev);
 
 	switch (evt->type) {
 	case UART_TX_DONE:
@@ -309,8 +313,11 @@ void test_read_abort(void)
 ZTEST_BMEM volatile size_t sent;
 ZTEST_BMEM volatile size_t received;
 
-void test_write_abort_callback(struct uart_event *evt, void *user_data)
+void test_write_abort_callback(struct device *dev,
+			       struct uart_event *evt, void *user_data)
 {
+	ARG_UNUSED(dev);
+
 	switch (evt->type) {
 	case UART_TX_DONE:
 		k_sem_give(&tx_done);
@@ -376,8 +383,11 @@ void test_write_abort(void)
 }
 
 
-void test_forever_timeout_callback(struct uart_event *evt, void *user_data)
+void test_forever_timeout_callback(struct device *dev,
+				   struct uart_event *evt, void *user_data)
 {
+	ARG_UNUSED(dev);
+
 	switch (evt->type) {
 	case UART_TX_DONE:
 		k_sem_give(&tx_done);
@@ -450,10 +460,9 @@ ZTEST_DMEM uint8_t chained_write_tx_bufs[2][10] = {"Message 1", "Message 2"};
 ZTEST_DMEM bool chained_write_next_buf = true;
 ZTEST_BMEM volatile uint8_t tx_sent;
 
-void test_chained_write_callback(struct uart_event *evt, void *user_data)
+void test_chained_write_callback(struct device *uart_dev,
+				 struct uart_event *evt, void *user_data)
 {
-	struct device *uart_dev = (struct device *) user_data;
-
 	switch (evt->type) {
 	case UART_TX_DONE:
 		if (chained_write_next_buf) {
@@ -486,7 +495,7 @@ void test_chained_write_setup(void)
 {
 	struct device *uart_dev = device_get_binding(UART_DEVICE_NAME);
 
-	uart_callback_set(uart_dev, test_chained_write_callback, uart_dev);
+	uart_callback_set(uart_dev, test_chained_write_callback, NULL);
 }
 
 void test_chained_write(void)
@@ -525,9 +534,8 @@ ZTEST_BMEM uint8_t long_tx_buf[1000];
 ZTEST_BMEM volatile uint8_t evt_num;
 ZTEST_BMEM size_t long_received[2];
 
-void test_long_buffers_callback(struct uart_event *evt, void *user_data)
+void test_long_buffers_callback(struct device *uart_dev, struct uart_event *evt, void *user_data)
 {
-	struct device *uart_dev = (struct device *) user_data;
 	static bool next_buf = true;
 
 	switch (evt->type) {
@@ -565,7 +573,7 @@ void test_long_buffers_setup(void)
 {
 	struct device *uart_dev = device_get_binding(UART_DEVICE_NAME);
 
-	uart_callback_set(uart_dev, test_long_buffers_callback, uart_dev);
+	uart_callback_set(uart_dev, test_long_buffers_callback, NULL);
 }
 
 void test_long_buffers(void)

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_fifo.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_fifo.c
@@ -41,10 +41,12 @@ static const char fifo_data[] = "This is a FIFO test.\r\n";
 
 #define DATA_SIZE	(sizeof(fifo_data) - 1)
 
-static void uart_fifo_callback(struct device *dev)
+static void uart_fifo_callback(struct device *dev, void *user_data)
 {
 	uint8_t recvData;
 	static int tx_data_idx;
+
+	ARG_UNUSED(user_data);
 
 	/* Verify uart_irq_update() */
 	if (!uart_irq_update(dev)) {

--- a/west.yml
+++ b/west.yml
@@ -89,7 +89,7 @@ manifest:
       path: modules/crypto/mbedtls
       revision: 4bf099f1254332d16dcd931ccea0a88d24a7d3c7
     - name: mcuboot
-      revision: d52aff5065ab5995f785877a834112461ff93526
+      revision: pull/26/head
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 898a5a7f5224be8345e58eca3b9a84389ed61d15


### PR DESCRIPTION
- **Problem Description:**

Uart callbacks are of 3 types:
- uart_callback_t which a recent addition which takes ```struct uart_event *, void *``` as parameters
- uart_irq_callback_t which is the legacy, taking a ```struct device *``` as a parameter.
- uart_irq_callback_user_data_t which is the new one taking a ```void *``` as a parameter.

The outcome of these 3 existing next to each other is that only the later is actually being used (the second is casted to the third type).
While switching to a new callback (the first), compared to the legacy, was a good a idea, it forgot to follow what's being done with all the callbacks in other API: providing the device pointer that actually calls the callback, as a parameter.

- **Proposed Change (detailed):**

So moving forward the last step: providing struct device * and void * to uart_irq_callback_user_data_t as parameters, and getting rid entirely of the legacy one, as well as adding ```struct device *``` to uart_callback_t.

This change may sound like a nitpick but for the sole reason most uart callback users in zephyr code base have a unique device to deal with and thus they access the device or some private data directly though global variables.

Once one deals with many device and related private data, that's a totally different story. See for instance how an obvious optimization due to this callback signature change could apply to drivers/modem/modem_receiver.c for instance: there would be no need to look up for the context depending on the device pointer.

- **Dependencies:**

All users of uart_callback_set(), uart_irq_callback_user_data_set() and uart_irq_callback_set() should modify the provided callbacks accordingly.