### PR TITLE
[v2.3-branch] Bluetooth: ATT: Multiple fixes

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -445,7 +445,7 @@ static void bt_att_chan_send_rsp(struct bt_att_chan *chan, struct net_buf *buf,
 	err = bt_att_chan_send(chan, buf, cb);
 	if (err) {
 		/* Responses need to be sent back using the same channel */
-		k_fifo_put(&chan->tx_queue, buf);
+		net_buf_put(&chan->tx_queue, buf);
 	}
 }
 
@@ -2500,12 +2500,12 @@ static void att_reset(struct bt_att *att)
 
 #if CONFIG_BT_ATT_PREPARE_COUNT > 0
 	/* Discard queued buffers */
-	while ((buf = k_fifo_get(&att->prep_queue, K_NO_WAIT))) {
+	while ((buf = net_buf_get(&att->prep_queue, K_NO_WAIT))) {
 		net_buf_unref(buf);
 	}
 #endif /* CONFIG_BT_ATT_PREPARE_COUNT > 0 */
 
-	while ((buf = k_fifo_get(&att->tx_queue, K_NO_WAIT))) {
+	while ((buf = net_buf_get(&att->tx_queue, K_NO_WAIT))) {
 		net_buf_unref(buf);
 	}
 
@@ -2539,7 +2539,7 @@ static void att_chan_detach(struct bt_att_chan *chan)
 	}
 
 	/* Release pending buffers */
-	while ((buf = k_fifo_get(&chan->tx_queue, K_NO_WAIT))) {
+	while ((buf = net_buf_get(&chan->tx_queue, K_NO_WAIT))) {
 		net_buf_unref(buf);
 	}
 
@@ -2970,7 +2970,7 @@ int bt_att_send(struct bt_conn *conn, struct net_buf *buf, bt_conn_tx_cb_t cb,
 	if (ret < 0) {
 		/* Queue buffer to be send later */
 		BT_DBG("Queueing buffer %p", buf);
-		k_fifo_put(&att->tx_queue, buf);
+		net_buf_put(&att->tx_queue, buf);
 	}
 
 	return 0;

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2902,8 +2902,8 @@ int bt_att_send(struct bt_conn *conn, struct net_buf *buf, bt_conn_tx_cb_t cb,
 	 * cannot be used with a custom user_data.
 	 */
 	if (cb) {
-		bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, buf, cb, user_data);
-		return 0;
+		return bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, buf, cb,
+					user_data);
 	}
 
 	ret = 0;

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -73,6 +73,7 @@ enum {
 	ATT_PENDING_CFM,
 	ATT_DISCONNECTED,
 	ATT_ENHANCED,
+	ATT_PENDING_SENT,
 
 	/* Total number of flags - must be at the end of the enum */
 	ATT_NUM_FLAGS,
@@ -85,6 +86,7 @@ struct bt_att_chan {
 	struct bt_l2cap_le_chan	chan;
 	ATOMIC_DEFINE(flags, ATT_NUM_FLAGS);
 	struct bt_att_req	*req;
+	struct k_fifo		tx_queue;
 	struct k_delayed_work	timeout_work;
 	struct k_sem            tx_sem;
 	void (*sent)(struct bt_att_chan *chan);
@@ -149,6 +151,13 @@ static int chan_send(struct bt_att_chan *chan, struct net_buf *buf,
 
 	BT_DBG("code 0x%02x", hdr->code);
 
+	/* Check if sent is pending already, if it does it cannot be modified
+	 * so the operation will need to be queued.
+	 */
+	if (atomic_test_and_set_bit(chan->flags, ATT_PENDING_SENT)) {
+		return -EAGAIN;
+	}
+
 	chan->sent = cb ? cb : chan_cb(buf);
 
 	if (IS_ENABLED(CONFIG_BT_EATT) &&
@@ -182,19 +191,12 @@ static int chan_send(struct bt_att_chan *chan, struct net_buf *buf,
 				att_sent, &chan->chan.chan);
 }
 
-static void bt_att_sent(struct bt_l2cap_chan *ch)
+static int process_queue(struct bt_att_chan *chan, struct k_fifo *queue)
 {
-	struct bt_att_chan *chan = ATT_CHAN(ch);
-	struct bt_att *att = chan->att;
 	struct net_buf *buf;
+	int err;
 
-	BT_DBG("chan %p", chan);
-
-	if (chan->sent) {
-		chan->sent(chan);
-	}
-
-	while ((buf = net_buf_get(&att->tx_queue, K_NO_WAIT))) {
+	while ((buf = net_buf_get(queue, K_NO_WAIT))) {
 		/* Check if the queued buf is a request */
 		if (chan->req && chan->req->buf == buf) {
 			/* Save request state so it can be resent */
@@ -202,12 +204,42 @@ static void bt_att_sent(struct bt_l2cap_chan *ch)
 					    &chan->req->state);
 		}
 
-		if (chan_send(chan, buf, NULL) < 0) {
+		err = chan_send(chan, buf, NULL);
+		if (err) {
 			/* Push it back if it could not be send */
-			k_queue_prepend(&att->tx_queue._queue, buf);
-			break;
+			k_queue_prepend(&queue->_queue, buf);
+			return err;
 		}
 
+		return 0;
+	}
+
+	return -ENOENT;
+}
+
+static void bt_att_sent(struct bt_l2cap_chan *ch)
+{
+	struct bt_att_chan *chan = ATT_CHAN(ch);
+	struct bt_att *att = chan->att;
+	int err;
+
+	BT_DBG("chan %p", chan);
+
+	if (chan->sent) {
+		chan->sent(chan);
+	}
+
+	atomic_clear_bit(chan->flags, ATT_PENDING_SENT);
+
+	/* Process channel queue first */
+	err = process_queue(chan, &chan->tx_queue);
+	if (!err) {
+		return;
+	}
+
+	/* Process global queue */
+	err = process_queue(chan, &att->tx_queue);
+	if (!err) {
 		return;
 	}
 
@@ -316,6 +348,18 @@ static int bt_att_chan_send(struct bt_att_chan *chan, struct net_buf *buf,
 	return chan_send(chan, buf, cb);
 }
 
+static void bt_att_chan_send_rsp(struct bt_att_chan *chan, struct net_buf *buf,
+				 bt_att_chan_sent_t cb)
+{
+	int err;
+
+	err = bt_att_chan_send(chan, buf, cb);
+	if (err) {
+		/* Responses need to be sent back using the same channel */
+		k_fifo_put(&chan->tx_queue, buf);
+	}
+}
+
 static void send_err_rsp(struct bt_att_chan *chan, u8_t req, u16_t handle,
 			 u8_t err)
 {
@@ -337,7 +381,7 @@ static void send_err_rsp(struct bt_att_chan *chan, u8_t req, u16_t handle,
 	rsp->handle = sys_cpu_to_le16(handle);
 	rsp->error = err;
 
-	(void)bt_att_chan_send(chan, buf, chan_rsp_sent);
+	bt_att_chan_send_rsp(chan, buf, chan_rsp_sent);
 }
 
 static u8_t att_mtu_req(struct bt_att_chan *chan, struct net_buf *buf)
@@ -378,7 +422,7 @@ static u8_t att_mtu_req(struct bt_att_chan *chan, struct net_buf *buf)
 	rsp = net_buf_add(pdu, sizeof(*rsp));
 	rsp->mtu = sys_cpu_to_le16(mtu_server);
 
-	(void)bt_att_chan_send(chan, pdu, chan_rsp_sent);
+	bt_att_chan_send_rsp(chan, pdu, chan_rsp_sent);
 
 	/* BLUETOOTH SPECIFICATION Version 4.2 [Vol 3, Part F] page 484:
 	 *
@@ -644,7 +688,7 @@ static u8_t att_find_info_rsp(struct bt_att_chan *chan, u16_t start_handle,
 		return 0;
 	}
 
-	(void)bt_att_chan_send(chan, data.buf, chan_rsp_sent);
+	bt_att_chan_send_rsp(chan, data.buf, chan_rsp_sent);
 
 	return 0;
 }
@@ -807,7 +851,7 @@ static u8_t att_find_type_rsp(struct bt_att_chan *chan, u16_t start_handle,
 		return 0;
 	}
 
-	(void)bt_att_chan_send(chan, data.buf, chan_rsp_sent);
+	bt_att_chan_send_rsp(chan, data.buf, chan_rsp_sent);
 
 	return 0;
 }
@@ -1038,7 +1082,7 @@ static u8_t att_read_type_rsp(struct bt_att_chan *chan, struct bt_uuid *uuid,
 		return 0;
 	}
 
-	(void)bt_att_chan_send(chan, data.buf, chan_rsp_sent);
+	bt_att_chan_send_rsp(chan, data.buf, chan_rsp_sent);
 
 	return 0;
 }
@@ -1157,7 +1201,7 @@ static u8_t att_read_rsp(struct bt_att_chan *chan, u8_t op, u8_t rsp,
 		return 0;
 	}
 
-	(void)bt_att_chan_send(chan, data.buf, chan_rsp_sent);
+	bt_att_chan_send_rsp(chan, data.buf, chan_rsp_sent);
 
 	return 0;
 }
@@ -1235,7 +1279,7 @@ static u8_t att_read_mult_req(struct bt_att_chan *chan, struct net_buf *buf)
 		}
 	}
 
-	(void)bt_att_chan_send(chan, data.buf, chan_rsp_sent);
+	bt_att_chan_send_rsp(chan, data.buf, chan_rsp_sent);
 
 	return 0;
 }
@@ -1322,7 +1366,7 @@ static u8_t att_read_mult_vl_req(struct bt_att_chan *chan, struct net_buf *buf)
 		}
 	}
 
-	(void)bt_att_chan_send(chan, data.buf, chan_rsp_sent);
+	bt_att_chan_send_rsp(chan, data.buf, chan_rsp_sent);
 
 	return 0;
 }
@@ -1438,7 +1482,7 @@ static u8_t att_read_group_rsp(struct bt_att_chan *chan, struct bt_uuid *uuid,
 		return 0;
 	}
 
-	(void)bt_att_chan_send(chan, data.buf, chan_rsp_sent);
+	bt_att_chan_send_rsp(chan, data.buf, chan_rsp_sent);
 
 	return 0;
 }
@@ -1581,7 +1625,7 @@ static u8_t att_write_rsp(struct bt_att_chan *chan, u8_t req, u8_t rsp,
 	}
 
 	if (data.buf) {
-		(void)bt_att_chan_send(chan, data.buf, chan_rsp_sent);
+		bt_att_chan_send_rsp(chan, data.buf, chan_rsp_sent);
 	}
 
 	return 0;
@@ -1705,7 +1749,7 @@ static u8_t att_prep_write_rsp(struct bt_att_chan *chan, u16_t handle,
 	net_buf_add(data.buf, len);
 	memcpy(rsp->value, value, len);
 
-	(void)bt_att_chan_send(chan, data.buf, chan_rsp_sent);
+	bt_att_chan_send_rsp(chan, data.buf, chan_rsp_sent);
 
 	return 0;
 }
@@ -1768,7 +1812,7 @@ static u8_t att_exec_write_rsp(struct bt_att_chan *chan, u8_t flags)
 		return BT_ATT_ERR_UNLIKELY;
 	}
 
-	(void)bt_att_chan_send(chan, buf, chan_rsp_sent);
+	bt_att_chan_send_rsp(chan, buf, chan_rsp_sent);
 
 	return 0;
 }
@@ -2054,7 +2098,7 @@ static u8_t att_indicate(struct bt_att_chan *chan, struct net_buf *buf)
 		return 0;
 	}
 
-	(void)bt_att_chan_send(chan, buf, chan_cfm_sent);
+	bt_att_chan_send_rsp(chan, buf, chan_cfm_sent);
 
 	return 0;
 }
@@ -2409,6 +2453,7 @@ static void att_reset(struct bt_att *att)
 
 static void att_chan_detach(struct bt_att_chan *chan)
 {
+	struct net_buf *buf;
 	int i;
 
 	BT_DBG("chan %p", chan);
@@ -2418,6 +2463,11 @@ static void att_chan_detach(struct bt_att_chan *chan)
 	/* Ensure that any waiters are woken up */
 	for (i = 0; i < CONFIG_BT_ATT_TX_MAX; i++) {
 		k_sem_give(&chan->tx_sem);
+	}
+
+	/* Release pending buffers */
+	while ((buf = k_fifo_get(&chan->tx_queue, K_NO_WAIT))) {
+		net_buf_unref(buf);
 	}
 
 	if (chan->req) {
@@ -2557,8 +2607,8 @@ static void bt_att_encrypt_change(struct bt_l2cap_chan *chan,
 	BT_DBG("Retrying");
 
 	/* Resend buffer */
-	(void)bt_att_chan_send(att_chan, att_chan->req->buf,
-			 chan_cb(att_chan->req->buf));
+	bt_att_chan_send_rsp(att_chan, att_chan->req->buf,
+			     chan_cb(att_chan->req->buf));
 
 	att_chan->req->buf = NULL;
 }
@@ -2637,6 +2687,7 @@ static struct bt_att_chan *att_chan_new(struct bt_att *att, atomic_val_t flags)
 
 	(void)memset(chan, 0, sizeof(*chan));
 	chan->chan.chan.ops = &ops;
+	k_fifo_init(&chan->tx_queue);
 	k_sem_init(&chan->tx_sem, CONFIG_BT_ATT_TX_MAX, CONFIG_BT_ATT_TX_MAX);
 	atomic_set(chan->flags, flags);
 	chan->att = att;

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -404,9 +404,60 @@ static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
 	return err;
 }
 
+static struct write_stats {
+	uint32_t count;
+	uint32_t len;
+	uint32_t total;
+	uint32_t rate;
+} write_stats;
+
+static void update_write_stats(uint16_t len)
+{
+	static uint32_t cycle_stamp;
+	uint32_t delta;
+
+	delta = k_cycle_get_32() - cycle_stamp;
+	delta = (uint32_t)k_cyc_to_ns_floor64(delta);
+
+	if (!delta) {
+		delta = 1;
+	}
+
+	write_stats.count++;
+	write_stats.total += len;
+
+	/* if last data rx-ed was greater than 1 second in the past,
+	 * reset the metrics.
+	 */
+	if (delta > 1000000000) {
+		write_stats.len = 0U;
+		write_stats.rate = 0U;
+		cycle_stamp = k_cycle_get_32();
+	} else {
+		write_stats.len += len;
+		write_stats.rate = ((uint64_t)write_stats.len << 3) *
+				   1000000000U / delta;
+	}
+}
+
+static void reset_write_stats(void)
+{
+	memset(&write_stats, 0, sizeof(write_stats));
+}
+
+static void print_write_stats(void)
+{
+	shell_print(ctx_shell, "Write #%u: %u bytes (%u bps)",
+		    write_stats.count, write_stats.total, write_stats.rate);
+}
+
 static void write_without_rsp_cb(struct bt_conn *conn, void *user_data)
 {
-	shell_print(ctx_shell, "Write transmission complete");
+	uint16_t len = POINTER_TO_UINT(user_data);
+
+	update_write_stats(len);
+
+	print_write_stats();
 }
 
 static int cmd_write_without_rsp(const struct shell *shell,
@@ -428,6 +479,7 @@ static int cmd_write_without_rsp(const struct shell *shell,
 	if (!sign) {
 		if (!strcmp(argv[0], "write-without-response-cb")) {
 			func = write_without_rsp_cb;
+			reset_write_stats();
 		}
 	}
 
@@ -458,10 +510,14 @@ static int cmd_write_without_rsp(const struct shell *shell,
 	while (repeat--) {
 		err = bt_gatt_write_without_response_cb(default_conn, handle,
 							gatt_write_buf, len,
-							sign, func, NULL);
+							sign, func,
+							UINT_TO_POINTER(len));
 		if (err) {
 			break;
 		}
+
+		k_yield();
+
 	}
 
 	shell_print(shell, "Write Complete (err %d)", err);
@@ -844,17 +900,11 @@ static ssize_t read_met(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				 value_len);
 }
 
-static u32_t write_count;
-static u32_t write_len;
-static u32_t write_rate;
-
 static ssize_t write_met(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 const void *buf, u16_t len, u16_t offset,
 			 u8_t flags)
 {
 	u8_t *value = attr->user_data;
-	static u32_t cycle_stamp;
-	u32_t delta;
 
 	if (offset + len > sizeof(met_char_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
@@ -862,22 +912,7 @@ static ssize_t write_met(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 
 	memcpy(value + offset, buf, len);
 
-	delta = k_cycle_get_32() - cycle_stamp;
-	delta = (u32_t)k_cyc_to_ns_floor64(delta);
-
-	/* if last data rx-ed was greater than 1 second in the past,
-	 * reset the metrics.
-	 */
-	if (delta > 1000000000) {
-		write_count = 0U;
-		write_len = 0U;
-		write_rate = 0U;
-		cycle_stamp = k_cycle_get_32();
-	} else {
-		write_count++;
-		write_len += len;
-		write_rate = ((u64_t)write_len << 3) * 1000000000U / delta;
-	}
+	update_write_stats(len);
 
 	return len;
 }
@@ -898,10 +933,8 @@ static int cmd_metrics(const struct shell *shell, size_t argc, char *argv[])
 	int err = 0;
 
 	if (argc < 2) {
-		shell_print(shell, "Write: count= %u, len= %u, rate= %u bps.",
-		       write_count, write_len, write_rate);
-
-		return -ENOEXEC;
+		print_write_stats();
+		return 0;
 	}
 
 	if (!strcmp(argv[1], "on")) {
@@ -1063,9 +1096,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(gatt_cmds,
 	SHELL_CMD_ARG(set, NULL, "<handle> [data...]", cmd_set, 2, 255),
 	SHELL_CMD_ARG(show-db, NULL, "[uuid] [num_matches]", cmd_show_db, 1, 2),
 #if defined(CONFIG_BT_GATT_DYNAMIC_DB)
-	SHELL_CMD_ARG(metrics, NULL,
-		      "register vendr char and measure rx <value: on, off>",
-		      cmd_metrics, 2, 0),
+	SHELL_CMD_ARG(metrics, NULL, "[value: on, off]", cmd_metrics, 1, 1),
 	SHELL_CMD_ARG(register, NULL,
 		      "register pre-predefined test service",
 		      cmd_register_test_svc, 1, 0),


### PR DESCRIPTION
ATT channel sent callback shall not be overwritting until the
operation completes as it can result in breaking flow control when
CONFIG_BT_ATT_ENFORCE_FLOW is enabled.

Fixes #25964
Fixes #26070
Fixes #26071