### PR TITLE
boards: arm: add board for CPUNET domain

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/Kconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig
@@ -44,6 +44,17 @@ config BOARD_ENABLE_CPUNET
 	  Network MCU.
 	default y if (BT || NET_L2_IEEE802154)
 
+config DOMAIN_CPUNET_BOARD
+	string
+	default "nrf5340pdk_nrf5340_cpunet" if BOARD_NRF5340PDK_NRF5340_CPUAPP || BOARD_NRF5340PDK_NRF5340_CPUAPPNS
+	default "nrf5340dk_nrf5340_cpunet" if BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPPNS
+	depends on BOARD_ENABLE_CPUNET
+	help
+	  The board which will be used for CPUNET domain when creating a multi
+	  image application where one or more images should be located on
+	  another board. For example hci_rpmsg on the nRF5340_cpunet for
+	  Bluetooth applications.
+
 endif # BOARD_NRF5340PDK_NRF5340_CPUAPP || BOARD_NRF5340PDK_NRF5340_CPUAPPNS || BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPPNS
 
 if BOARD_NRF5340PDK_NRF5340_CPUNET || BOARD_NRF5340DK_NRF5340_CPUNET


### PR DESCRIPTION
This configuration is used to describe what board should
be associated with the CPUNET domain.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>