### PR TITLE
net: lwm2m: Fix PUSH mode FOTA

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -140,8 +140,11 @@ static int sock_nfds;
 struct block_context {
 	struct coap_block_context ctx;
 	int64_t timestamp;
+	uint32_t remaining_len;
 	uint8_t token[8];
 	uint8_t tkl;
+	uint8_t opaque_header_len;
+	bool last_block : 1;
 };
 
 static struct block_context block1_contexts[NUM_BLOCK1_CONTEXT];
@@ -271,6 +274,9 @@ init_block_ctx(const uint8_t *token, uint8_t tkl, struct block_context **ctx)
 	memcpy((*ctx)->token, token, tkl);
 	coap_block_transfer_init(&(*ctx)->ctx, lwm2m_default_block_size(), 0);
 	(*ctx)->timestamp = timestamp;
+	(*ctx)->remaining_len = 0;
+	(*ctx)->opaque_header_len = 0;
+	(*ctx)->last_block = false;
 
 	return 0;
 }
@@ -2198,14 +2204,20 @@ static int lwm2m_read_handler(struct lwm2m_engine_obj_inst *obj_inst,
 size_t lwm2m_engine_get_opaque_more(struct lwm2m_input_context *in,
 				    uint8_t *buf, size_t buflen, bool *last_block)
 {
-	uint16_t in_len = in->opaque_len;
+	uint32_t in_len = in->opaque_len;
+	uint16_t remaining = in->in_cpkt->max_len - in->offset;
 
 	if (in_len > buflen) {
 		in_len = buflen;
 	}
 
+	if (in_len > remaining) {
+		in_len = remaining;
+	}
+
 	in->opaque_len -= in_len;
-	if (in->opaque_len == 0U) {
+	remaining -= in_len;
+	if (in->opaque_len == 0U || remaining == 0) {
 		*last_block = true;
 	}
 
@@ -2223,14 +2235,23 @@ static int lwm2m_write_handler_opaque(struct lwm2m_engine_obj_inst *obj_inst,
 				      struct lwm2m_engine_res_inst *res_inst,
 				      struct lwm2m_input_context *in,
 				      void *data_ptr, size_t data_len,
-				      bool last_block, size_t total_size)
+				      struct block_context *block_ctx)
 {
 	size_t len = 1;
 	bool last_pkt_block = false, first_read = true;
+	int block_num = 0;
 	int ret = 0;
+	size_t total_size = 0;
+	bool last_block = true;
+
+	if (block_ctx != NULL) {
+		block_num = block_ctx->ctx.current /
+			coap_block_size_to_bytes(block_ctx->ctx.block_size);
+		last_block = block_ctx->last_block;
+	}
 
 	while (!last_pkt_block && len > 0) {
-		if (first_read) {
+		if (first_read && block_num == 0) {
 			len = engine_get_opaque(in, (uint8_t *)data_ptr,
 						data_len, &last_pkt_block);
 			if (len == 0) {
@@ -2238,24 +2259,49 @@ static int lwm2m_write_handler_opaque(struct lwm2m_engine_obj_inst *obj_inst,
 				return 0;
 			}
 
+			if (block_ctx != NULL) {
+				block_ctx->remaining_len = in->opaque_len;
+				/* engine_get_opaque returns only the actual
+				 * data length, not the header length, so we
+				 * need to calculate it.
+				 */
+				block_ctx->opaque_header_len =
+					block_ctx->ctx.total_size -
+					(block_ctx->remaining_len + len);
+			}
+
 			first_read = false;
 		} else {
+			if (block_ctx != NULL) {
+				in->opaque_len = block_ctx->remaining_len;
+			}
+
 			len = lwm2m_engine_get_opaque_more(in, (uint8_t *)data_ptr,
 							   data_len,
 							   &last_pkt_block);
+
+			if (block_ctx != NULL) {
+				block_ctx->remaining_len = in->opaque_len;
+			}
 		}
 
 		if (len == 0) {
 			return -EINVAL;
 		}
 
+		if (block_ctx != NULL) {
+			/* We shall only report the actual total data length,
+			 * excluding the header size (if any).
+			 */
+			total_size = block_ctx->ctx.total_size -
+				     block_ctx->opaque_header_len;
+		}
+
 		if (res->post_write_cb) {
-			ret = res->post_write_cb(obj_inst->obj_inst_id,
-						 res->res_id,
-						 res_inst->res_inst_id,
-						 data_ptr, len,
-						 last_pkt_block && last_block,
-						 total_size);
+			ret = res->post_write_cb(
+				obj_inst->obj_inst_id, res->res_id,
+				res_inst->res_inst_id, data_ptr, len,
+				last_pkt_block && last_block, total_size);
 			if (ret < 0) {
 				return ret;
 			}
@@ -2307,8 +2353,6 @@ int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst,
 		/* Get block1 option for checking MORE block flag */
 		ret = coap_get_option_int(msg->in.in_cpkt, COAP_OPTION_BLOCK1);
 		if (ret >= 0) {
-			last_block = !GET_MORE(ret);
-
 			/* Get block_ctx for total_size (might be zero) */
 			tkl = coap_header_get_token(msg->in.in_cpkt, token);
 			if (tkl && !get_block_ctx(token, tkl, &block_ctx)) {
@@ -2317,7 +2361,7 @@ int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst,
 					" last:%u",
 					block_ctx->ctx.total_size,
 					block_ctx->ctx.current,
-					last_block);
+					block_ctx->last_block);
 			}
 		}
 	}
@@ -2329,8 +2373,7 @@ int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst,
 			ret = lwm2m_write_handler_opaque(obj_inst, res,
 							 res_inst, &msg->in,
 							 data_ptr, data_len,
-							 last_block,
-							 total_size);
+							 block_ctx);
 			if (ret < 0) {
 				return ret;
 			}
@@ -3480,6 +3523,8 @@ static int handle_request(struct coap_packet *request,
 			LOG_ERR("Error from block update: %d", r);
 			goto error;
 		}
+
+		block_ctx->last_block = last_block;
 
 		/* Handle blockwise 1 (Part 1): Set response code */
 		if (!last_block) {

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -141,6 +141,7 @@ struct block_context {
 	struct coap_block_context ctx;
 	int64_t timestamp;
 	uint32_t remaining_len;
+	uint32_t expected;
 	uint8_t token[8];
 	uint8_t tkl;
 	uint8_t opaque_header_len;
@@ -276,6 +277,7 @@ init_block_ctx(const uint8_t *token, uint8_t tkl, struct block_context **ctx)
 	(*ctx)->timestamp = timestamp;
 	(*ctx)->remaining_len = 0;
 	(*ctx)->opaque_header_len = 0;
+	(*ctx)->expected = 0;
 	(*ctx)->last_block = false;
 
 	return 0;
@@ -299,7 +301,6 @@ get_block_ctx(const uint8_t *token, uint8_t tkl, struct block_context **ctx)
 	}
 
 	if (*ctx == NULL) {
-		LOG_ERR("Cannot find block context");
 		return -ENOENT;
 	}
 
@@ -3318,10 +3319,12 @@ static int handle_request(struct coap_packet *request,
 	uint16_t format = LWM2M_FORMAT_NONE, accept;
 	int observe = -1; /* default to -1, 0 = ENABLE, 1 = DISABLE */
 	bool well_known = false;
+	int block_opt, block_num;
 	struct block_context *block_ctx = NULL;
 	enum coap_block_size block_size;
 	uint16_t payload_len = 0U;
 	bool last_block = false;
+	bool ignore = false;
 
 	/* set CoAP request / message */
 	msg->in.in_cpkt = request;
@@ -3495,12 +3498,13 @@ static int handle_request(struct coap_packet *request,
 	coap_packet_get_payload(msg->in.in_cpkt, &payload_len);
 
 	/* Check for block transfer */
-	r = coap_get_option_int(msg->in.in_cpkt, COAP_OPTION_BLOCK1);
-	if (r > 0) {
-		last_block = !GET_MORE(r);
+
+	block_opt = coap_get_option_int(msg->in.in_cpkt, COAP_OPTION_BLOCK1);
+	if (block_opt > 0) {
+		last_block = !GET_MORE(block_opt);
 
 		/* RFC7252: 4.6. Message Size */
-		block_size = GET_BLOCK_SIZE(r);
+		block_size = GET_BLOCK_SIZE(block_opt);
 		if (!last_block &&
 		    coap_block_size_to_bytes(block_size) > payload_len) {
 			LOG_DBG("Trailing payload is discarded!");
@@ -3508,23 +3512,47 @@ static int handle_request(struct coap_packet *request,
 			goto error;
 		}
 
-		if (GET_BLOCK_NUM(r) == 0) {
+		block_num = GET_BLOCK_NUM(block_opt);
+
+		/* Try to retrieve existing block context. If one not exists,
+		 * and we've received first block, allocate new context.
+		 */
+		r = get_block_ctx(token, tkl, &block_ctx);
+		if (r < 0 && block_num == 0) {
 			r = init_block_ctx(token, tkl, &block_ctx);
+		}
+
+		if (r < 0) {
+			LOG_ERR("Cannot find block context");
+			goto error;
+		}
+
+		if (block_num < block_ctx->expected) {
+			LOG_WRN("Block already handled %d, expected %d",
+				block_num, block_ctx->expected);
+			ignore = true;
+		} else if (block_num > block_ctx->expected) {
+			LOG_WRN("Block out of order %d, expected %d",
+				block_num, block_ctx->expected);
+			r = -EFAULT;
+			goto error;
 		} else {
-			r = get_block_ctx(token, tkl, &block_ctx);
-		}
+			r = coap_update_from_block(msg->in.in_cpkt, &block_ctx->ctx);
+			if (r < 0) {
+				LOG_ERR("Error from block update: %d", r);
+				goto error;
+			}
 
-		if (r < 0) {
-			goto error;
-		}
+			block_ctx->last_block = last_block;
 
-		r = coap_update_from_block(msg->in.in_cpkt, &block_ctx->ctx);
-		if (r < 0) {
-			LOG_ERR("Error from block update: %d", r);
-			goto error;
+			/* Initial block sent by the server might be larger than
+			 * our block size therefore it is needed to take this
+			 * into account when calculating next expected block
+			 * number.
+			 */
+			block_ctx->expected += GET_BLOCK_SIZE(block_opt) -
+					       block_ctx->ctx.block_size + 1;
 		}
-
-		block_ctx->last_block = last_block;
 
 		/* Handle blockwise 1 (Part 1): Set response code */
 		if (!last_block) {
@@ -3538,70 +3566,74 @@ static int handle_request(struct coap_packet *request,
 		goto error;
 	}
 
-	switch (msg->operation) {
+	if (!ignore) {
 
-	case LWM2M_OP_READ:
-		if (observe == 0) {
-			/* add new observer */
-			if (msg->token) {
-				r = coap_append_option_int(msg->out.out_cpkt,
-							   COAP_OPTION_OBSERVE,
-							   1);
-				if (r < 0) {
-					LOG_ERR("OBSERVE option error: %d", r);
+		switch (msg->operation) {
+
+		case LWM2M_OP_READ:
+			if (observe == 0) {
+				/* add new observer */
+				if (msg->token) {
+					r = coap_append_option_int(
+						msg->out.out_cpkt,
+						COAP_OPTION_OBSERVE,
+						1);
+					if (r < 0) {
+						LOG_ERR("OBSERVE option error: %d", r);
+						goto error;
+					}
+
+					r = engine_add_observer(msg, token, tkl,
+								accept);
+					if (r < 0) {
+						LOG_ERR("add OBSERVE error: %d", r);
+						goto error;
+					}
+				} else {
+					LOG_ERR("OBSERVE request missing token");
+					r = -EINVAL;
 					goto error;
 				}
-
-				r = engine_add_observer(msg, token, tkl,
-							accept);
+			} else if (observe == 1) {
+				/* remove observer */
+				r = engine_remove_observer(token, tkl);
 				if (r < 0) {
-					LOG_ERR("add OBSERVE error: %d", r);
-					goto error;
+					LOG_ERR("remove observe error: %d", r);
 				}
-			} else {
-				LOG_ERR("OBSERVE request missing token");
-				r = -EINVAL;
-				goto error;
 			}
-		} else if (observe == 1) {
-			/* remove observer */
-			r = engine_remove_observer(token, tkl);
-			if (r < 0) {
-				LOG_ERR("remove observe error: %d", r);
-			}
+
+			r = do_read_op(msg, accept);
+			break;
+
+		case LWM2M_OP_DISCOVER:
+			r = do_discover_op(msg, well_known);
+			break;
+
+		case LWM2M_OP_WRITE:
+		case LWM2M_OP_CREATE:
+			r = do_write_op(msg, format);
+			break;
+
+		case LWM2M_OP_WRITE_ATTR:
+			r = lwm2m_write_attr_handler(obj, msg);
+			break;
+
+		case LWM2M_OP_EXECUTE:
+			r = lwm2m_exec_handler(msg);
+			break;
+
+		case LWM2M_OP_DELETE:
+			r = lwm2m_delete_handler(msg);
+			break;
+
+		default:
+			LOG_ERR("Unknown operation: %u", msg->operation);
+			r = -EINVAL;
 		}
 
-		r = do_read_op(msg, accept);
-		break;
-
-	case LWM2M_OP_DISCOVER:
-		r = do_discover_op(msg, well_known);
-		break;
-
-	case LWM2M_OP_WRITE:
-	case LWM2M_OP_CREATE:
-		r = do_write_op(msg, format);
-		break;
-
-	case LWM2M_OP_WRITE_ATTR:
-		r = lwm2m_write_attr_handler(obj, msg);
-		break;
-
-	case LWM2M_OP_EXECUTE:
-		r = lwm2m_exec_handler(msg);
-		break;
-
-	case LWM2M_OP_DELETE:
-		r = lwm2m_delete_handler(msg);
-		break;
-
-	default:
-		LOG_ERR("Unknown operation: %u", msg->operation);
-		r = -EINVAL;
-	}
-
-	if (r < 0) {
-		goto error;
+		if (r < 0) {
+			goto error;
+		}
 	}
 
 	/* Handle blockwise 1 (Part 2): Append BLOCK1 option / free context */

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -379,7 +379,7 @@ struct lwm2m_input_context {
 	uint16_t offset;
 
 	/* length of incoming opaque */
-	uint16_t opaque_len;
+	size_t opaque_len;
 
 	/* private output data */
 	void *user_data;

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -919,6 +919,17 @@ int do_write_op_tlv(struct lwm2m_message *msg)
 	struct oma_tlv tlv;
 	int ret;
 
+	/* In case of Firmware object Package resource go directly to the
+	 * message processing - consecutive blocks will not carry the TLV
+	 * header.
+	 */
+	if (msg->path.obj_id == 5 && msg->path.res_id == 0) {
+		ret = do_write_op_tlv_item(msg);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
 	while (true) {
 		/*
 		 * This initial read of TLV data won't advance frag/offset.


### PR DESCRIPTION
Firmware update in PUSH mode over LwM2M is currently not working, the device replies with an error instead of progressively accept incoming data blocks. 

This PR fixes this problem, as well as adds block number validation, to prevent the LwM2M engine from forwarding duplicate blocks to the application.