### PR TITLE
zephyr_system_include_directories for system include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,9 +71,12 @@ add_library(zephyr_interface INTERFACE)
 # flags that come with zephyr_interface.
 zephyr_library_named(zephyr)
 
-zephyr_include_directories(
+zephyr_system_include_directories(
   include
   ${PROJECT_BINARY_DIR}/include/generated
+)
+
+zephyr_include_directories(
   ${USERINCLUDE}
   ${STDINCLUDE}
 )


### PR DESCRIPTION
This allow set for application custom compiler flags and these flags will not trigger warnings for internal files.