### PR TITLE
tests: nvs: Disable running the 0x00 test suite

### DIFF
--- a/tests/subsys/fs/nvs/testcase.yaml
+++ b/tests/subsys/fs/nvs/testcase.yaml
@@ -4,3 +4,4 @@ tests:
   filesystem.nvs_0x00:
     extra_args: DTC_OVERLAY_FILE=boards/qemu_x86_ev_0x00.overlay
     platform_whitelist: qemu_x86
+    build_only: true


### PR DESCRIPTION
There is an issue when running the 0x00 erase value test suite, so
disable it temporarily.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>