### PR TITLE
lib/os/heap: facility to dump the heap structure to the cconsole for debugging

### DIFF
--- a/include/sys/sys_heap.h
+++ b/include/sys/sys_heap.h
@@ -170,4 +170,13 @@ void sys_heap_stress(void *(*alloc)(void *arg, size_t bytes),
 		     int target_percent,
 		     struct z_heap_stress_result *result);
 
+/** @brief Dump heap structure content for debugging to the console
+ *
+ * Print information on the heap structure such as its size, chunk buckets
+ * and chunk list.
+ *
+ * @param h Heap to print information about
+ */
+void sys_heap_dump(struct sys_heap *h);
+
 #endif /* ZEPHYR_INCLUDE_SYS_SYS_HEAP_H_ */

--- a/lib/os/heap.h
+++ b/lib/os/heap.h
@@ -225,5 +225,7 @@ static inline int bucket_idx(struct z_heap *h, size_t sz)
 	return 31 - __builtin_clz(usable_sz);
 }
 
+/* For debugging */
+void heap_dump(struct z_heap *h);
 
 #endif /* ZEPHYR_INCLUDE_LIB_OS_HEAP_H_ */


### PR DESCRIPTION
It is linked in only when used, so handy to always have it around for
analysis purposes.