### PR TITLE
west.yml: Update to pull in TFM v1.1-rc2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -135,7 +135,7 @@ manifest:
       revision: c39888ff74acf421eeff9a7514fa9b172c3373f7
     - name: trusted-firmware-m
       path: modules/tee/tfm
-      revision: 7de2daa1967b2dc12cbe0fcc0171ac3064ea596b
+      revision: 58c70aeb9937c3b6b97a07cc654e48b2c56c258a
 
   self:
     path: zephyr


### PR DESCRIPTION
Update to sync with TFM v1.1-rc2 which adds support for the LPC55S69 and
STM32L5 SoCs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>