### PR TITLE
drivers: Remove useless device start/end pointers

### DIFF
--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -17,9 +17,6 @@
 #define BUF_ARRAY_CNT 16
 #define TEST_ARR_SIZE 0x1000
 
-extern struct device __device_start[];
-extern struct device __device_end[];
-
 static uint8_t __aligned(4) test_arr[TEST_ARR_SIZE];
 
 static int parse_helper(const struct shell *shell, size_t *argc,

--- a/drivers/i2c/i2c_shell.c
+++ b/drivers/i2c/i2c_shell.c
@@ -16,9 +16,6 @@ LOG_MODULE_REGISTER(i2c_shell, CONFIG_LOG_DEFAULT_LEVEL);
 
 #define I2C_DEVICE_PREFIX "I2C_"
 
-extern struct device __device_start[];
-extern struct device __device_end[];
-
 /* Maximum bytes we can write or read at once */
 #define MAX_I2C_BYTES	16
 

--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -16,9 +16,6 @@
 	"when no channels are provided. Syntax:\n" \
 	"<device_name> <channel name 0> .. <channel name N>"
 
-extern struct device __device_start[];
-extern struct device __device_end[];
-
 const char *sensor_channel_name[SENSOR_CHAN_ALL] = {
 	[SENSOR_CHAN_ACCEL_X] =		"accel_x",
 	[SENSOR_CHAN_ACCEL_Y] =		"accel_y",


### PR DESCRIPTION
Commit id a538dcd8f8d got rid of the usage of these pointers so they are
useless now and can be removed in this drivers.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>