### PR TITLE
Bluetooth: host: Unspecified disconnect reason for no pending conn

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2104,8 +2104,9 @@ static void enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 	}
 
 	if (!conn) {
-		BT_ERR("Unable to add new conn for handle %u", handle);
-		bt_hci_disconnect(handle, BT_HCI_ERR_MEM_CAPACITY_EXCEEDED);
+		BT_ERR("No pending conn for peer %s",
+		       bt_addr_le_str(&evt->peer_addr));
+		bt_hci_disconnect(handle, BT_HCI_ERR_UNSPECIFIED);
 		return;
 	}
 


### PR DESCRIPTION
Use an unspecified reason when disconnecting a connection that did not
have a pending connection in the host.
We don't allocate connection objects in the connection complete anymore
so using memory-capacity-exceeded is misleading.

Fixes: #26450

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>