### PR TITLE
drivers: flash: atmel_sam: Fix build error

### DIFF
--- a/drivers/flash/flash_sam.c
+++ b/drivers/flash/flash_sam.c
@@ -357,7 +357,7 @@ static const struct flash_driver_api flash_sam_api = {
 	.erase = flash_sam_erase,
 	.write = flash_sam_write,
 	.read = flash_sam_read,
-	.get_parameters = flash_sim_get_parameters,
+	.get_parameters = flash_sam_get_parameters,
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
 	.page_layout = flash_sam_page_layout,
 #endif


### PR DESCRIPTION
There is a typo in the function pointer assigned to get_parameters.  It
should be flash_sam_get_parameters.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>