### PR TITLE
boards: mec1501modular_assy6885: Add support for UART0

### DIFF
--- a/boards/arm/mec1501modular_assy6885/pinmux.c
+++ b/boards/arm/mec1501modular_assy6885/pinmux.c
@@ -160,6 +160,18 @@ static int board_pinmux_init(struct device *dev)
 	pinmux_pin_set(portd, MCHP_GPIO_170, MCHP_GPIO_CTRL_MUX_F0);
 
 	/* See table 2-4 from the data sheet for pin multiplexing*/
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart0), okay)
+	/* Set muxing, for UART 0 TX/RX and power up */
+	mchp_pcr_periph_slp_ctrl(PCR_UART0, MCHP_PCR_SLEEP_DIS);
+
+	UART0_REGS->CFG_SEL = (MCHP_UART_LD_CFG_INTCLK +
+		MCHP_UART_LD_CFG_RESET_SYS + MCHP_UART_LD_CFG_NO_INVERT);
+	UART0_REGS->ACTV = MCHP_UART_LD_ACTIVATE;
+
+	pinmux_pin_set(portc, MCHP_GPIO_104, MCHP_GPIO_CTRL_MUX_F1);
+	pinmux_pin_set(portc, MCHP_GPIO_105, MCHP_GPIO_CTRL_MUX_F1);
+#endif
+
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(uart1), okay)
 	/* Set muxing, for UART 1 TX/RX and power up */
 	mchp_pcr_periph_slp_ctrl(PCR_UART1, MCHP_PCR_SLEEP_DIS);


### PR DESCRIPTION
Add options to configure UART0 and pins based upon device
tree settings.

Signed-off-by: Scott Worley <scott.worley@microchip.com>

Change requested by vijay.p.hiremath@intel.com
