### PR TITLE
drivers: interrupt_controller: GIC barrier before EOI

### DIFF
--- a/drivers/interrupt_controller/intc_gic.c
+++ b/drivers/interrupt_controller/intc_gic.c
@@ -79,6 +79,16 @@ unsigned int arm_gic_get_active(void)
 
 void arm_gic_eoi(unsigned int irq)
 {
+	/*
+	 * Ensure the write to peripheral registers are *complete* before the write
+	 * to GIC_EOIR.
+	 *
+	 * Note: The completion gurantee depends on various factors of system design
+	 * and the barrier is the best core can do by which execution of further
+	 * instructions waits till the barrier is alive.
+	 */
+	__DSB();
+
 	/* set to inactive */
 	sys_write32(irq, GICC_EOIR);
 }


### PR DESCRIPTION
It is desired to have the peripheral writes completed to clear the
interrupt condition and de-assert the interrupt request to GIC before
EOI write. Failing which spurious interrupt will occur. A barrier is needed
to ensure peripheral register write transfers are complete before EOI is done.

There is discussion with arm TF-A software here
ref: https://lists.trustedfirmware.org/pipermail/tf-a/2020-June/000566.html
Also I had discussions with arm support on this.
 
The requirement is clear but different software implementation may choose to have the barrier at different places.
In Zephyr I thought 'isr_wrapper' to manage this but finally have put in GIC itself. Based on comments I can contain
within GIC driver or move it to 'isr_wrapper'.  Especially for cortex-M + NVIC  this needs to be handled at 'isr_wrapper'.