### PR TITLE
actions: mark pull requests with conflicts

### DIFF
--- a/.github/workflows/conflict.yml
+++ b/.github/workflows/conflict.yml
@@ -1,0 +1,12 @@
+on:
+  push:
+    branches:
+      - master
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@master
+        with:
+          CONFLICT_LABEL_NAME: "has conflicts"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This action will go over pull requests after something was pushed to the
tree and marks pull requests with conflicts.