### PR TITLE
Bluetooth: controller: Increase timeout for adv ext test

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_advx/tests_scripts/basic_advx.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_advx/tests_scripts/basic_advx.sh
@@ -14,7 +14,7 @@ function Execute(){
  compile it?)\e[39m"
     exit 1
   fi
-  timeout 30 $@ & process_ids="$process_ids $!"
+  timeout 120 $@ & process_ids="$process_ids $!"
 }
 
 : "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"


### PR DESCRIPTION
The timeout for testing advertisement extensions in babblesim
was set to 30 seconds. Depending on the hardware used for
testing this may be too low. Increased to 120 seconds

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>