### PR TITLE
checkpatch: Enable check for C99 comments again

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -18,4 +18,5 @@
 --ignore CONST_STRUCT
 --ignore FILE_PATH_CHANGES
 --ignore SPDX_LICENSE_TAG
+--ignore C99_COMMENT_TOLERANCE
 --exclude ext


### PR DESCRIPTION
When checkpatch was updated, this behavour seems to have changed.
This change re-adds the check for C99 comments to prevent them.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>