### PR TITLE
Bluetooth: GATT: Fix not being able to notify

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1720,7 +1720,6 @@ static int gatt_notify_mult(struct bt_conn *conn, uint16_t handle,
 		*buf = bt_att_create_pdu(conn, BT_ATT_OP_NOTIFY_MULT,
 					 sizeof(*nfy) + params->len);
 		if (!*buf) {
-			BT_WARN("No buffer available to send notification");
 			return -ENOMEM;
 		}
 		/* Set user_data so it can be restored when sending */
@@ -1762,7 +1761,12 @@ static int gatt_notify(struct bt_conn *conn, uint16_t handle,
 
 #if defined(CONFIG_BT_GATT_NOTIFY_MULTIPLE)
 	if (gatt_cf_notify_multi(conn)) {
-		return gatt_notify_mult(conn, handle, params);
+		int err;
+
+		err = gatt_notify_mult(conn, handle, params);
+		if (err && err != -ENOMEM) {
+			return err;
+		}
 	}
 #endif /* CONFIG_BT_GATT_NOTIFY_MULTIPLE */
 


### PR DESCRIPTION
When CONFIG_BT_GATT_NOTIFY_MULTIPLE is selected and the remote has
enabled support for using its procedure data can sometimes not fit
into the buffer since the multiple variante has a bigger header, so
instead of failing immediatelly this attempts to send the data using
the legacy PDU instead so those using bt_gatt_get_mtu - 3 can still be
sent.

Fixes #26106

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>