### PR TITLE
ci: do not run sanitycheck on linter config changes

### DIFF
--- a/scripts/ci/sanitycheck_ignore.txt
+++ b/scripts/ci/sanitycheck_ignore.txt
@@ -5,6 +5,8 @@
 # are matched, then sanitycheck will not do a full run and optionally will only
 # run on changed tests or boards.
 #
+.gitlint
+.checkpatch.conf
 .clang-format
 .codecov.yml
 .editorconfig


### PR DESCRIPTION
Do not run sanitycheck on linter configuration changes.