### PR TITLE
boards: shields: Fix frdm_kw41z shield doc formatting

### DIFF
--- a/boards/shields/frdm_kw41z/doc/index.rst
+++ b/boards/shields/frdm_kw41z/doc/index.rst
@@ -30,9 +30,9 @@ host controller interface (HCI):
 
 #. Open :file:`source/common/app_preinclude.h` and add the following line:
 
-.. code-block:: console
+   .. code-block:: console
 
-	#define gSerialMgrRxBufSize_c 64
+      #define gSerialMgrRxBufSize_c 64
 
 #. Build the project to generate a binary :file:`hci_black_box_frdmkw41z.bin`.
 
@@ -44,8 +44,10 @@ host controller interface (HCI):
 #. Remove the USB cable to power down the board.
 
 #. Configure the jumpers J30 and J31 such that:
+
    - J30 pin 1 is attached to J31 pin 2
    - J30 pin 2 is attached to J31 pin 1
+
    The jumpers should be parallel to the Arduino headers. This configuration
    routes the UART RX and TX signals to the Arduino header, rather than to the
    OpenSDA circuit.


### PR DESCRIPTION
Fixes whitespace in the frdm_kw41z shield document to allow continuation
in the numbered list of Bluetooth controller instructions and to format
the jumper configuration sublist correctly.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>