### PR TITLE
Synchronized printk(), smp test sleep reduction

### DIFF
--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -73,4 +73,13 @@ config PRINTK64
 	  reduce code size if it is unused elsewhere in the
 	  application.  Most apps should leave this set to y.
 
+config PRINTK_SYNC
+	bool "Serialize printk() calls"
+	default y if SMP && MP_NUM_CPUS > 1
+	help
+	  When true, a spinlock will be taken around the output from a
+	  single printk() call, preventing the output data from
+	  interleaving with concurrent usage from another CPU or an
+	  preempting interrupt.
+
 endmenu

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -42,6 +42,10 @@ typedef uint32_t printk_val_t;
  */
 #define DIGITS_BUFLEN (11 * (sizeof(printk_val_t) / 4) - 1)
 
+#ifdef CONFIG_PRINTK_SYNC
+static struct k_spinlock lock;
+#endif
+
 #ifdef CONFIG_PRINTK
 /**
  * @brief Default character output routine that does nothing
@@ -375,26 +379,47 @@ void vprintk(const char *fmt, va_list ap)
 		}
 	} else {
 		struct out_context ctx = { 0 };
+#ifdef CONFIG_PRINTK_SYNC
+		k_spinlock_key_t key = k_spin_lock(&lock);
+#endif
 
 		z_vprintk(char_out, &ctx, fmt, ap);
+
+#ifdef CONFIG_PRINTK_SYNC
+		k_spin_unlock(&lock, key);
+#endif
 	}
 }
 #else
 void vprintk(const char *fmt, va_list ap)
 {
 	struct out_context ctx = { 0 };
+#ifdef CONFIG_PRINTK_SYNC
+	k_spinlock_key_t key = k_spin_lock(&lock);
+#endif
 
 	z_vprintk(char_out, &ctx, fmt, ap);
+
+#ifdef CONFIG_PRINTK_SYNC
+	k_spin_unlock(&lock, key);
+#endif
 }
 #endif /* CONFIG_USERSPACE */
 
 void z_impl_k_str_out(char *c, size_t n)
 {
 	size_t i;
+#ifdef CONFIG_PRINTK_SYNC
+	k_spinlock_key_t key = k_spin_lock(&lock);
+#endif
 
 	for (i = 0; i < n; i++) {
 		_char_out(c[i]);
 	}
+
+#ifdef CONFIG_PRINTK_SYNC
+	k_spin_unlock(&lock, key);
+#endif
 }
 
 #ifdef CONFIG_USERSPACE

--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -447,7 +447,7 @@ void test_main(void)
 	 * thread from which they can exit correctly to run the main
 	 * test.
 	 */
-	k_sleep(K_MSEC(1000));
+	k_sleep(K_MSEC(10));
 
 	ztest_test_suite(smp,
 			 ztest_unit_test(test_smp_coop_threads),


### PR DESCRIPTION
Pulled these two small standalone patches out of https://github.com/zephyrproject-rtos/zephyr/pull/26483 so they can be reviewed in isolation.  Added a kconfig tunable to control the printk synchronization per @andrewboie suggestion.