### PR TITLE
boards: arm: Fix kinetis temperature sensor config dependency

### DIFF
--- a/boards/arm/frdm_k64f/Kconfig.defconfig
+++ b/boards/arm/frdm_k64f/Kconfig.defconfig
@@ -42,7 +42,7 @@ endif # PINMUX_MCUX
 
 config TEMP_KINETIS
 	default y if "$(dt_nodelabel_enabled,adc1)"
-	depends on SENSOR
+	depends on SENSOR && ADC
 
 config SPI_0
 	default y

--- a/boards/arm/twr_ke18f/Kconfig.defconfig
+++ b/boards/arm/twr_ke18f/Kconfig.defconfig
@@ -39,6 +39,6 @@ endif # PINMUX_MCUX
 
 config TEMP_KINETIS
 	default y if "$(dt_nodelabel_enabled,adc0)"
-	depends on SENSOR
+	depends on SENSOR && ADC
 
 endif # BOARD_TWR_KE18F


### PR DESCRIPTION
Fixes the frdm_k64f and twr_ke18f boards to enable the kinetis
temperature sensor only if the sensor and adc drivers are both enabled.
This fixes a logging error seen at runtime in
samples/bluetooth/peripheral_hr.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #25311