### PR TITLE
ci: Add a daily full build workflow

### DIFF
--- a/.buildkite/daily.yml
+++ b/.buildkite/daily.yml
@@ -1,0 +1,32 @@
+steps:
+  - command:
+    - .buildkite/run.sh
+    env:
+      ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
+      ZEPHYR_SDK_INSTALL_DIR: "/opt/sdk/zephyr-sdk-0.11.3"
+    parallelism: 120
+    timeout_in_minutes: 150
+    retry:
+      manual: true
+    plugins:
+      - docker#v3.5.0:
+          image: "zephyrprojectrtos/ci:v0.11.8"
+          propagate-environment: true
+          volumes:
+            - "/var/lib/buildkite-agent/git-mirrors:/var/lib/buildkite-agent/git-mirrors"
+            - "/var/lib/buildkite-agent/zephyr-module-cache:/var/lib/buildkite-agent/zephyr-module-cache"
+            - "/var/lib/buildkite-agent/zephyr-ccache:/root/.ccache"
+          workdir: "/workdir/zephyr"
+    agents:
+    - "queue=default"
+
+  - wait: ~
+    continue_on_failure: true
+
+  - plugins:
+      - junit-annotate#v1.7.0:
+          artifacts: sanitycheck-*.xml
+
+notify:
+  - email: "builds+int+399+7809482394022958124@lists.zephyrproject.org"
+    if: build.state != "passed"


### PR DESCRIPTION
We use a seperate pipeline step and try and reuse the run.sh script with
some minor modifications.  There's a seperate pipeline for this purpose
that does the schedule build.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>