### PR TITLE
net: ppp: fix ringbuf usage to consume all data

### DIFF
--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -659,7 +659,6 @@ static void ppp_isr_cb_work(struct k_work *work)
 			/* Ignore empty or too short frames */
 			if (ppp->pkt && net_pkt_get_len(ppp->pkt) > 3) {
 				ppp_process_msg(ppp);
-				break;
 			}
 		}
 	} while (--tmp);


### PR DESCRIPTION
There are two issues that this PR tries to solve. First thing is that claimed ringbuf bytes are parsed until first frame is detected, but remaining data in the claimed area is just ignored / lost. This easily causes issues when running QEMU with PPP - one of the frame is lost, which results in LCP negotiation timeout.

Second issue is also related to ringbuf, but more specifically to how claim API works. ringbuf claim API returns pointer to contiguous area. In cases when data in ringbuf wraps the end of internal buffer, then single call to claim data is not enough to get all data - there is remaining part on the beginning of internal buffer. Those remaining bytes will need to wait for next ISR handler to trigger workqueue. Theoretically this means that data on the beginning of ringbuf can wait there forever, or simply to the next timeout in PPP stack when data traffic continues.

Fix both issues by draining data from ringbuf until it is empty.