### PR TITLE
net: l2: ppp: reject unsupported options

### DIFF
--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -82,7 +82,6 @@ static int lcp_config_info_req(struct ppp_fsm *fsm,
 	enum ppp_packet_type code;
 	enum net_verdict verdict;
 	int i, nack_idx = 0;
-	int count_rej = 0, count_nack = 0;
 
 	memset(options, 0, sizeof(options));
 	memset(nack_options, 0, sizeof(nack_options));
@@ -105,22 +104,7 @@ static int lcp_config_info_req(struct ppp_fsm *fsm,
 		case LCP_OPTION_RESERVED:
 			continue;
 
-		case LCP_OPTION_MRU:
-			break;
-
-		/* TODO: Check from ctx->lcp.my_options what options to accept
-		 */
-		case LCP_OPTION_ASYNC_CTRL_CHAR_MAP:
-			count_nack++;
-			goto ignore_option;
-
-		case LCP_OPTION_MAGIC_NUMBER:
-			count_nack++;
-			goto ignore_option;
-
 		default:
-			count_rej++;
-		ignore_option:
 			nack_options[nack_idx].type.lcp = options[i].type.lcp;
 			nack_options[nack_idx].len = options[i].len;
 
@@ -138,11 +122,7 @@ static int lcp_config_info_req(struct ppp_fsm *fsm,
 	if (nack_idx > 0) {
 		struct net_buf *nack_buf;
 
-		if (count_rej > 0) {
-			code = PPP_CONFIGURE_REJ;
-		} else {
-			code = PPP_CONFIGURE_NACK;
-		}
+		code = PPP_CONFIGURE_REJ;
 
 		/* Create net_buf containing options that are not accepted */
 		for (i = 0; i < MIN(nack_idx, ARRAY_SIZE(nack_options)); i++) {


### PR DESCRIPTION
Both ASYNC_CTRL_CHAR_MAP and MAGIC_NUMBER are not supported right
now. Send Configure-Reject for them instead of Configure-Nak, as we
don't even propose new values in reply (which should be part of
Configure-Nak).

Send also Configure-Reject for MRU option, as we don't respect it
either.

Drop both count_rej and count_nack, as we can rely solely on nack_idx to
send Configure-Reject or not.