### PR TITLE
actions: add automatic labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,109 @@
+"area: Modem":
+  - "drivers/modem/**/*"
+"area: PWM":
+  - "drivers/pwm/**/*"
+"area: Watchdog":
+  - "drivers/watchdog/**/*"
+"area: Sensors":
+  - "drivers/sensors/**/*"
+"area: ADC":
+  - "drivers/adc/**/*"
+"area: Counter":
+  - "drivers/counter/**/*"
+"area: Timer":
+  - "drivers/timer/**/*"
+"area: I2S":
+  - "drivers/i2s/**/*"
+"area: C Library":
+  - "lib/libc/**/*"
+"area: Device Tree":
+  - "dts/**/*"
+  - "**/*.dts"
+  - "include/devicetree/*"
+  - "include/dt-bindings/**/*"
+"area: I2C":
+  - "drivers/i2c/**/*"
+"area: SPI":
+  - "drivers/spi/**/*"
+"area: Boards":
+  - "boards/**/*"
+"area: POSIX":
+  - "lib/posix/**/*"
+"area: native port":
+  - "arch/posix/**/*"
+  - "include/arch/posix/**/*"
+  - "soc/posix/**/*"
+  - "**/*native_posix*"
+"area: X86":
+  - "arch/x86/**/*"
+  - "include/arch/x86/**/*"
+"area: ARM":
+  - "arch/arm/**/*"
+  - "include/arch/arm/**/*"
+"area: NIOS2":
+  - "arch/nios2/**/*"
+  - "include/arch/nios2/**/*"
+"area: Xtensa":
+  - "arch/xtensa/**/*"
+  - "include/arch/xtensa/**/*"
+"area: RISCv32/64":
+  - "arch/risv/**/*"
+  - "include/arch/riscv/**/*"
+"area: ARC":
+  - "arch/arc/**/*"
+  - "include/arch/arc/**/*"
+"area: Networking":
+  - "subsys/net/**/*"
+  - "samples/net/**/*"
+  - "tests/net/**/*"
+  - "include/net/**/*"
+  - "include/drivers/ieee802154/**/*"
+  - "drivers/ethernet/**/*"
+  - "drivers/ieee802154/**/*"
+  - "drivers/wifi/**/*"
+  - "drivers/ptp_clock/**/*"
+  - "drivers/net/**/*"
+"area: Logging":
+  - "subsys/logging/**/*"
+"area: Shell":
+  - "subsys/shell/**/*"
+"area: Console":
+  - "subsys/console/**/*"
+"area: Test Framework":
+  - "subsys/testsuite/**/*"
+"area: Settings":
+  - "subsys/settings/**/*"
+"area: File System":
+  - "subsys/fs/**/*"
+"area: Storage":
+  - "subsys/storage/**/*"
+"area: Bluetooth":
+  - "subsys/bluetooth/**/*"
+  - "**/*bluetooth*"
+"area: Bluetooth Mesh":
+  - "subsys/bluetooth/mesh/**/*"
+"area: API":
+  - "include/**/*"
+"area: Samples":
+  - "samples/**/*"
+"area: Tests":
+  - "tests/**/*"
+"area: Kernel":
+  - "kernel/**/*"
+  - "tests/kernel/**/*"
+"area: Documentation":
+  - "**/*.rst"
+  - "**/*.md"
+"area: Build System":
+  - "cmake/**/*"
+  - "CmakeLists.txt"
+"area: Kconfig":
+  - "scripts/kconfig/**/*"
+  - "Kconfig"
+  - "Kconfig.zephyr"
+"area: Sanitycheck":
+  - "scripts/sanitycheck"
+  - "scripts/sanity_chk/**/*"
+"area: Modules":
+  - "west.yml"
+  - "modules/**/*"

--- a/.github/workflows/periodic_labeler.yml
+++ b/.github/workflows/periodic_labeler.yml
@@ -1,0 +1,13 @@
+name: Pull request labeler
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: paulfantom/periodic-labeler@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LABEL_MAPPINGS_FILE: .github/labeler.yml

--- a/scripts/ci/sanitycheck_ignore.txt
+++ b/scripts/ci/sanitycheck_ignore.txt
@@ -19,6 +19,8 @@ Makefile
 tests/*
 samples/*
 doc/*
+# GH action have no impact on code
+.github/*
 *.rst
 *.md
 # if we change this file or associated script, it should not trigger a full


### PR DESCRIPTION
Add action to labler pull requests on a regular basis. This will replace
the current labler implemented in ci-tools and will operate on a
schedule rather than on pull request trigger.