### PR TITLE
drivers: spi: Add optional delays to mcux dspi and lpspi drivers

### DIFF
--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -25,6 +25,9 @@ struct spi_mcux_config {
 	char *clock_name;
 	clock_control_subsys_t clock_subsys;
 	void (*irq_config_func)(struct device *dev);
+	uint32_t pcs_sck_delay;
+	uint32_t sck_pcs_delay;
+	uint32_t transfer_delay;
 };
 
 struct spi_mcux_data {
@@ -173,6 +176,10 @@ static int spi_mcux_configure(struct device *dev,
 
 	master_config.baudRate = spi_cfg->frequency;
 
+	master_config.pcsToSckDelayInNanoSec = config->pcs_sck_delay;
+	master_config.lastSckToPcsDelayInNanoSec = config->sck_pcs_delay;
+	master_config.betweenTransferDelayInNanoSec = config->transfer_delay;
+
 	clock_dev = device_get_binding(config->clock_name);
 	if (clock_dev == NULL) {
 		return -EINVAL;
@@ -284,6 +291,15 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 		.clock_subsys =						\
 		(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),	\
 		.irq_config_func = spi_mcux_config_func_##n,		\
+		.pcs_sck_delay = UTIL_AND(				\
+			DT_INST_NODE_HAS_PROP(n, pcs_sck_delay),	\
+			DT_INST_PROP(n, pcs_sck_delay)),		\
+		.sck_pcs_delay = UTIL_AND(				\
+			DT_INST_NODE_HAS_PROP(n, sck_pcs_delay),	\
+			DT_INST_PROP(n, sck_pcs_delay)),		\
+		.transfer_delay = UTIL_AND(				\
+			DT_INST_NODE_HAS_PROP(n, transfer_delay),	\
+			DT_INST_PROP(n, transfer_delay)),		\
 	};								\
 									\
 	static struct spi_mcux_data spi_mcux_data_##n = {		\

--- a/dts/bindings/spi/nxp,imx-lpspi.yaml
+++ b/dts/bindings/spi/nxp,imx-lpspi.yaml
@@ -16,3 +16,24 @@ properties:
 
     clocks:
       required: true
+
+    pcs-sck-delay:
+      type: int
+      required: false
+      description: |
+        Delay in nanoseconds from the chip select assert to the first clock
+        edge. If not set, the minimum supported delay is used.
+
+    sck-pcs-delay:
+      type: int
+      required: false
+      description: |
+        Delay in nanoseconds from the last clock edge to the chip select
+        deassert. If not set, the minimum supported delay is used.
+
+    transfer-delay:
+      type: int
+      required: false
+      description: |
+        Delay in nanoseconds from the chip select deassert to the next chip
+        select assert. If not set, the minimum supported delay is used.

--- a/dts/bindings/spi/nxp,kinetis-dspi.yaml
+++ b/dts/bindings/spi/nxp,kinetis-dspi.yaml
@@ -16,3 +16,24 @@ properties:
 
     clocks:
       required: true
+
+    pcs-sck-delay:
+      type: int
+      required: false
+      description: |
+        Delay in nanoseconds from the chip select assert to the first clock
+        edge. If not set, the minimum supported delay is used.
+
+    sck-pcs-delay:
+      type: int
+      required: false
+      description: |
+        Delay in nanoseconds from the last clock edge to the chip select
+        deassert. If not set, the minimum supported delay is used.
+
+    transfer-delay:
+      type: int
+      required: false
+      description: |
+        Delay in nanoseconds from the chip select deassert to the next chip
+        select assert. If not set, the minimum supported delay is used.


### PR DESCRIPTION
Adds optional device tree properties to set delays between spi chip
select assert/deassert and clock edges in the mcux dspi and lpspi
drivers. If these properties are not set, then the minimum supported
delays are used.

Verified that tests/drivers/spi/spi_loopback/ still passes on
mimxrt1050_evk (lpspi driver) and frdm_k64f (dspi driver).

~~Still need to verify delay timing with a scope.~~

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #24939
Alternative to #23918

cc: @lgl88911 