### PR TITLE
scripts: bossac: add support for BOSSAC 1.9.1

### DIFF
--- a/boards/arm/adafruit_feather_m0_basic_proto/board.cmake
+++ b/boards/arm/adafruit_feather_m0_basic_proto/board.cmake
@@ -2,6 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(bossac "--offset=0x2000")
-
 include(${ZEPHYR_BASE}/boards/common/bossac.board.cmake)

--- a/boards/arm/adafruit_itsybitsy_m4_express/board.cmake
+++ b/boards/arm/adafruit_itsybitsy_m4_express/board.cmake
@@ -1,6 +1,4 @@
 # Copyright (c) 2020 Google LLC.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(bossac "--offset=0x4000")
-
 include(${ZEPHYR_BASE}/boards/common/bossac.board.cmake)

--- a/boards/arm/adafruit_trinket_m0/board.cmake
+++ b/boards/arm/adafruit_trinket_m0/board.cmake
@@ -1,6 +1,4 @@
 # Copyright (c) 2018 Google LLC.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(bossac "--offset=0x2000")
-
 include(${ZEPHYR_BASE}/boards/common/bossac.board.cmake)

--- a/scripts/west_commands/tests/test_bossac.py
+++ b/scripts/west_commands/tests/test_bossac.py
@@ -33,9 +33,10 @@ EXPECTED_COMMANDS_WITH_OFFSET = [
 def require_patch(program):
     assert program in ['bossac', 'stty']
 
+@patch('runners.bossac.BossacBinaryRunner.supports', return_value=True)
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
-def test_bossac_init(cc, req, runner_config):
+def test_bossac_init(cc, req, supports, runner_config):
     '''Test commands using a runner created by constructor.'''
     runner = BossacBinaryRunner(runner_config, port=TEST_BOSSAC_PORT,
                                 offset=TEST_OFFSET)

--- a/scripts/west_commands/tests/test_bossac.py
+++ b/scripts/west_commands/tests/test_bossac.py
@@ -17,18 +17,42 @@ if platform.system() != 'Linux':
 
 TEST_BOSSAC_PORT = 'test-bossac-serial'
 TEST_OFFSET = 1234
+TEST_FLASH_ADDRESS = 5678
+
 EXPECTED_COMMANDS = [
     ['stty', '-F', TEST_BOSSAC_PORT, 'raw', 'ispeed', '1200', 'ospeed', '1200',
      'cs8', '-cstopb', 'ignpar', 'eol', '255', 'eof', '255'],
     ['bossac', '-p', TEST_BOSSAC_PORT, '-R', '-e', '-w', '-v',
      '-b', RC_KERNEL_BIN],
 ]
+
 EXPECTED_COMMANDS_WITH_OFFSET = [
     ['stty', '-F', TEST_BOSSAC_PORT, 'raw', 'ispeed', '1200', 'ospeed', '1200',
      'cs8', '-cstopb', 'ignpar', 'eol', '255', 'eof', '255'],
     ['bossac', '-p', TEST_BOSSAC_PORT, '-R', '-e', '-w', '-v',
      '-b', RC_KERNEL_BIN, '-o', str(TEST_OFFSET)],
 ]
+
+EXPECTED_COMMANDS_WITH_FLASH_ADDRESS = [
+    [
+        'stty', '-F', TEST_BOSSAC_PORT, 'raw', 'ispeed', '1200', 'ospeed',
+        '1200', 'cs8', '-cstopb', 'ignpar', 'eol', '255', 'eof', '255'
+    ],
+    [
+        'bossac',
+        '-p',
+        TEST_BOSSAC_PORT,
+        '-R',
+        '-e',
+        '-w',
+        '-v',
+        '-b',
+        RC_KERNEL_BIN,
+        '-o',
+        str(TEST_FLASH_ADDRESS),
+    ],
+]
+
 
 def require_patch(program):
     assert program in ['bossac', 'stty']
@@ -43,9 +67,13 @@ def test_bossac_init(cc, req, supports, runner_config):
     runner.run('flash')
     assert cc.call_args_list == [call(x) for x in EXPECTED_COMMANDS_WITH_OFFSET]
 
+@patch('runners.bossac.BossacBinaryRunner.supports', return_value=True)
+@patch('runners.core.BuildConfiguration._init')
+@patch('runners.core.ZephyrBinaryRunner.get_flash_address',
+       return_value=None)
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
-def test_bossac_create(cc, req, runner_config):
+def test_bossac_create(cc, req, gfa, bcfg, supports, runner_config):
     '''Test commands using a runner created from command line parameters.'''
     args = ['--bossac-port', str(TEST_BOSSAC_PORT)]
     parser = argparse.ArgumentParser()
@@ -55,9 +83,15 @@ def test_bossac_create(cc, req, runner_config):
     runner.run('flash')
     assert cc.call_args_list == [call(x) for x in EXPECTED_COMMANDS]
 
+
+@patch('runners.bossac.BossacBinaryRunner.supports', return_value=True)
+@patch('runners.core.BuildConfiguration._init')
+@patch('runners.core.ZephyrBinaryRunner.get_flash_address',
+       return_value=TEST_FLASH_ADDRESS)
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
-def test_bossac_create_with_offset(cc, req, runner_config):
+def test_bossac_create_with_offset(cc, req, gfa, bcfg, supports,
+                                   runner_config):
     '''Test commands using a runner created from command line parameters.'''
     args = ['--bossac-port', str(TEST_BOSSAC_PORT),
             '--offset', str(TEST_OFFSET)]
@@ -67,3 +101,25 @@ def test_bossac_create_with_offset(cc, req, runner_config):
     runner = BossacBinaryRunner.create(runner_config, arg_namespace)
     runner.run('flash')
     assert cc.call_args_list == [call(x) for x in EXPECTED_COMMANDS_WITH_OFFSET]
+
+
+@patch('runners.bossac.BossacBinaryRunner.supports', return_value=True)
+@patch('runners.core.BuildConfiguration._init')
+@patch('runners.core.ZephyrBinaryRunner.get_flash_address',
+       return_value=TEST_FLASH_ADDRESS)
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
+@patch('runners.core.ZephyrBinaryRunner.check_call')
+def test_bossac_create_with_flash_address(cc, req, gfa, bcfg, supports,
+                                          runner_config):
+    args = [
+        '--bossac-port',
+        str(TEST_BOSSAC_PORT),
+    ]
+    parser = argparse.ArgumentParser()
+    BossacBinaryRunner.add_parser(parser)
+    arg_namespace = parser.parse_args(args)
+    runner = BossacBinaryRunner.create(runner_config, arg_namespace)
+    runner.run('flash')
+    assert cc.call_args_list == [
+        call(x) for x in EXPECTED_COMMANDS_WITH_FLASH_ADDRESS
+    ]


### PR DESCRIPTION
BOSSA 1.7 has built-in bootloader offset handling while 1.9.1
requires the user to explicitly supply the offset.  Add support for both by sniffing the
help output and warn the user if the flags needs adding.

If the user is using 1.9.1, pull the offset from the configuration instead of setting explicitly.

Once this has landed I'll send a PR to update the Zephyr SDK as well.

Related: #22062 zephyrproject-rtos/sdk-ng/issues/234

@KubaFYI FYI