### PR TITLE
boards: b_l4s5i iot01a  fixing corruption of storage partition

### DIFF
--- a/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -154,7 +154,7 @@
 		};
 		scratch_partition: partition@f8000 {
 			label = "image-scratch";
-			reg = <0x000F8000 0x00006000>;
+			reg = <0x000F8000 0x00004000>;
 		};
 
 		storage_partition: partition@fc000 {


### PR DESCRIPTION
The  devicetree for b_l4s5i iot01a declares the flash partitions
"storage" and "image-scratch" with overlapping address spaces.
This  PR is like the disco_l475_iot1  PR https://github.com/zephyrproject-rtos/zephyr/pull/26417

As a result, when one of these partitions is used it can corrupt the
contents of the other one. This is the case when mcuboot performs an
image swap using the scratch partition.

Consequently, the size of the scratch partition is reduced.

Signed-off-by: Francois Ramu <francois.ramu@st.com>
