### PR TITLE
tests: wdt_basic_api: pass when requested test is not supported

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -218,6 +218,12 @@ static int test_wdt_callback_1(void)
 	m_cfg_wdt0.window.max = 2000U;
 	err = wdt_install_timeout(wdt, &m_cfg_wdt0);
 	if (err < 0) {
+		if (err == -ENOTSUP) {
+			TC_PRINT("CB1 not supported on platform\n");
+			m_testcase_index++;
+			return TC_PASS;
+
+		}
 		TC_PRINT("Watchdog install error\n");
 		return TC_FAIL;
 	}


### PR DESCRIPTION
Not all watchdog devices support a warning callback before reset.  If the driver refuses to accept that configuration record the test as having passed.

NOTE: This fix allows the second callback test to pass on these boards, but does not reset.  Thus a third callback test would not be invoked.  This should be OK because the third callback test would also be rejected.

Fixes #20693