### PR TITLE
actions: only mark bugs as stale

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -17,4 +17,4 @@ jobs:
         stale-issue-label: 'Stale'
         stale-pr-label: 'Stale PR'
         exempt-pr-labels: 'DNM,In progress'
-        exempt-issue-labels: 'In progress'
+        exempt-issue-labels: 'In progress,Enhancement,Feature,Feature Request,RFC,Meta'


### PR DESCRIPTION
Bugs are being looked at on a weekly basis, we still did not go through
many of the enhancements and long term feature issues, so do not mark
those as stale yet, this will otherwise mark more than 50% of open GH
issues as stale...