### PR TITLE
drivers: flash: nrf_qspi_nor: record dependency on multithreading

### DIFF
--- a/drivers/flash/Kconfig.nordic_qspi_nor
+++ b/drivers/flash/Kconfig.nordic_qspi_nor
@@ -6,6 +6,7 @@ menuconfig NORDIC_QSPI_NOR
 	select FLASH_HAS_DRIVER_ENABLED
 	select NRFX_QSPI
 	depends on HAS_HW_NRF_QSPI
+	depends on MULTITHREADING
 	help
 	  Enable support for nrfx QSPI driver with EasyDMA.
 


### PR DESCRIPTION
This driver blocks on a semaphore to receive notification when an
operation is complete, so requires CONFIG_MULTITHREADING=y.

Relates to #26372