### PR TITLE
soc: arm: k6x: Added power management module to the k6x soc

### DIFF
--- a/boards/arm/frdm_k64f/pinmux.c
+++ b/boards/arm/frdm_k64f/pinmux.c
@@ -7,6 +7,50 @@
 #include <init.h>
 #include <drivers/pinmux.h>
 #include <fsl_port.h>
+#include <fsl_uart.h>
+
+/** provide implementation of enable and disable uarts */
+void frdm_k64f_pinmux_enable_uart(void)
+{
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(portb), okay)
+	const struct device *portb =
+		DEVICE_DT_GET(DT_NODELABEL(portb));
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart0), okay) && CONFIG_SERIAL
+	pinmux_pin_set(portb, 16, PORT_PCR_MUX(kPORT_MuxAlt3));
+	pinmux_pin_set(portb, 17, PORT_PCR_MUX(kPORT_MuxAlt3));
+#endif
+}
+
+void frdm_k64f_pinmux_disable_uart(void)
+{
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart0), okay) && CONFIG_SERIAL
+	while (!(kUART_TransmissionCompleteFlag &
+		UART_GetStatusFlags((UART_Type *)UART0))) {
+	}
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(portb), okay)
+	const struct device *portb =
+		DEVICE_DT_GET(DT_NODELABEL(portb));
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart0), okay) && CONFIG_SERIAL
+	pinmux_pin_set(portb, 16, PORT_PCR_MUX(kPORT_PinDisabledOrAnalog));
+	pinmux_pin_set(portb, 17, PORT_PCR_MUX(kPORT_PinDisabledOrAnalog));
+#endif
+}
+
+/** provide functions needed by power module */
+void enable_uart(void)
+{
+	frdm_k64f_pinmux_enable_uart();
+}
+void disable_uart(void)
+{
+	frdm_k64f_pinmux_disable_uart();
+}
 
 static int frdm_k64f_pinmux_init(const struct device *dev)
 {

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -25,7 +25,15 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
+			cpu-power-states = <&state0>;
 		};
+
+		state0: state0 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			min-residency-us = <1>;
+		};
+
 	};
 
 	/* The on-chip SRAM is split into SRAM_L and SRAM_U regions that form a

--- a/soc/arm/nxp_kinetis/k6x/CMakeLists.txt
+++ b/soc/arm/nxp_kinetis/k6x/CMakeLists.txt
@@ -8,3 +8,6 @@ zephyr_sources_ifdef(
   CONFIG_ARM_MPU
   nxp_mpu_regions.c
   )
+zephyr_library_sources_ifdef(CONFIG_PM
+  power.c
+  )

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.soc
@@ -17,6 +17,7 @@ config SOC_MK64F12
 	select HAS_MCUX_FTM
 	select HAS_MCUX_RNGA
 	select HAS_MCUX_SIM
+	select HAS_MCUX_SMC
 	select HAS_OSC
 	select HAS_MCG
 	select CPU_HAS_FPU

--- a/soc/arm/nxp_kinetis/k6x/power.c
+++ b/soc/arm/nxp_kinetis/k6x/power.c
@@ -1,0 +1,150 @@
+/*
+ * Copytight (c) 2020 Nicolai Glud <nigd@prevas.dk>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr.h>
+#include <power/power.h>
+#include <fsl_smc.h>
+
+
+#define LOG_LEVEL LOG_LEVEL_INF
+#include <logging/log.h>
+LOG_MODULE_REGISTER(soc);
+
+#ifdef CONFIG_PM
+void enable_uart(void);
+void disable_uart(void);
+
+#if defined(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME)
+static ALWAYS_INLINE void set_clock_hw_cycles_per_sec(int cycles)
+{
+	extern int z_clock_hw_cycles_per_sec;
+
+	z_clock_hw_cycles_per_sec = cycles;
+}
+#else
+static ALWAYS_INLINE void set_clock_hw_cycles_per_sec(int cycles) {}
+#endif
+
+static ALWAYS_INLINE void set_clock_to_FEI_mode(void)
+{
+	const mcg_config_t mcgConfigStruct = {
+		/* FEI - FLL with internal RTC. */
+		.mcgMode = kMCG_ModeFEI,
+		/* MCGIRCLK enabled, MCGIRCLK disabled in STOP mode */
+		.irclkEnableMode = kMCG_IrclkEnable,
+		/* Slow internal reference clock selected */
+		.ircs = kMCG_IrcSlow,
+		/* Fast IRC divider: divided by 1 */
+		.fcrdiv = 0x0U,
+		/* FLL reference clock divider: divided by 32 */
+		.frdiv = 0x0U,
+		/* Low frequency range */
+		.drs = kMCG_DrsLow,
+		/* DCO has a default range of 25% */
+		.dmx32 = kMCG_Dmx32Default,
+		/* Selects System Oscillator (OSCCLK) */
+		.oscsel = kMCG_OscselOsc,
+		.pll0Config = {
+			/* MCGPLLCLK disabled */
+			.enableMode = 0,
+			/* PLL Reference divider: divided by 20 */
+			.prdiv = 0x13U,
+			/* VCO divider: multiplied by 48 */
+			.vdiv = 0x18U,
+		},
+	};
+
+	CLOCK_SetMcgConfig(&mcgConfigStruct);
+
+	set_clock_hw_cycles_per_sec(25000000);
+}
+
+static ALWAYS_INLINE void set_clock_to_PEE_mode(void)
+{
+	const mcg_config_t mcgConfigStruct = {
+		/* PEE - PLL Engaged External */
+		.mcgMode = kMCG_ModePEE,
+		/* MCGIRCLK enabled, MCGIRCLK disabled in STOP mode */
+		.irclkEnableMode = kMCG_IrclkEnable,
+		/* Slow internal reference clock selected */
+		.ircs = kMCG_IrcSlow,
+		/* Fast IRC divider: divided by 1 */
+		.fcrdiv = 0x0U,
+		/* FLL reference clock divider: divided by 32 */
+		.frdiv = 0x0U,
+		/* Low frequency range */
+		.drs = kMCG_DrsLow,
+		/* DCO has a default range of 25% */
+		.dmx32 = kMCG_Dmx32Default,
+		/* Selects System Oscillator (OSCCLK) */
+		.oscsel = kMCG_OscselOsc,
+		.pll0Config = {
+			/* MCGPLLCLK disabled */
+			.enableMode = 0,
+			/* PLL Reference divider: divided by 20 */
+			.prdiv = 0x13U,
+			/* VCO divider: multiplied by 48 */
+			.vdiv = 0x18U,
+		},
+	};
+
+	CLOCK_SetMcgConfig(&mcgConfigStruct);
+
+	set_clock_hw_cycles_per_sec(120000000);
+}
+
+static ALWAYS_INLINE void enter_sleep_mode_1(void)
+{
+	disable_uart();
+	set_clock_to_FEI_mode();
+	SMC_PreEnterWaitModes();
+	SMC_SetPowerModeWait(SMC);
+	SMC_PostExitWaitModes();
+}
+
+static ALWAYS_INLINE void exit_sleep_mode_1(void)
+{
+	enable_uart();
+	set_clock_to_PEE_mode();
+}
+#endif
+
+void pm_power_state_set(struct pm_state_info info)
+{
+	switch (info.state) {
+	case PM_STATE_SUSPEND_TO_IDLE:
+	{
+		enter_sleep_mode_1();
+		break;
+	}
+	case PM_STATE_ACTIVE:
+	case PM_STATE_RUNTIME_IDLE:
+	case PM_STATE_SUSPEND_TO_RAM:
+	case PM_STATE_SUSPEND_TO_DISK:
+	case PM_STATE_SOFT_OFF:
+	default:
+		LOG_INF("Unsupported power state %u", info.state);
+		break;
+	}
+}
+
+/* Handle SOC specific activity after Low Power Mode Exit */
+void pm_power_state_exit_post_ops(struct pm_state_info info)
+{
+	switch (info.state) {
+	case PM_STATE_SUSPEND_TO_IDLE:
+	{
+		exit_sleep_mode_1();
+		break;
+	}
+	case PM_STATE_ACTIVE:
+	case PM_STATE_RUNTIME_IDLE:
+	case PM_STATE_SUSPEND_TO_RAM:
+	case PM_STATE_SUSPEND_TO_DISK:
+	case PM_STATE_SOFT_OFF:
+	default:
+		break;
+	}
+}


### PR DESCRIPTION
Sleep 1 utilises the kinetis wait mode to save power.
clock changes during power module operation.
Use the extern int value to set the actual clock freq.

Signed-off-by: Nicolai Glud <nicolai.glud@prevas.dk>