### PR TITLE
tests: socket: getaddrinfo: Explicitly ignore return of sys_mutex_lock

### DIFF
--- a/tests/net/socket/getaddrinfo/src/main.c
+++ b/tests/net/socket/getaddrinfo/src/main.c
@@ -108,7 +108,7 @@ static int process_dns(void)
 	socklen_t addr_len;
 	int ret, idx;
 
-	sys_mutex_lock(&wait_data, K_FOREVER);
+	(void)sys_mutex_lock(&wait_data, K_FOREVER);
 
 	NET_DBG("Waiting for IPv4 DNS packets on port %d",
 		ntohs(addr_v4.sin_port));


### PR DESCRIPTION
This is a test, and the function is called with K_FOREVER, so it's not
supposed to fail.

Fixes: #25735
CID: 210582

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>