### PR TITLE
net: config: Fix improper condition in net_config_init

### DIFF
--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -375,24 +375,18 @@ int net_config_init_by_iface(struct net_if *iface, const char *app_info,
 			}
 		}
 
-		/* If the above while() loop timeouted, reset the count so that
-		 * the while() loop below will not wait more.
-		 */
-		if (timeout > 0 && count < 0) {
-			count = 0;
-		}
-
 #if defined(CONFIG_NET_NATIVE)
 		net_mgmt_del_event_callback(&mgmt_iface_cb);
 #endif
-	}
 
-	if (count == 0) {
 		/* Network interface did not come up. We will not try
 		 * to setup things in that case.
 		 */
-		NET_ERR("Timeout while waiting network %s", "interface");
-		return -ENETDOWN;
+		if (timeout > 0 && count < 0) {
+			NET_ERR("Timeout while waiting network %s",
+				"interface");
+			return -ENETDOWN;
+		}
 	}
 
 	setup_ipv4(iface);


### PR DESCRIPTION
Currently, there is a case for net_config_init function that for timeout==0 and when iface is already up, the ip setup is not proceed
and the error message "Timeout while waiting network..." is logged.

This PR fixes it.