### PR TITLE
drivers: gpio_nrfx: Replace atomic_set_bit_to() with atomic_and()

### DIFF
--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -78,7 +78,7 @@ static void gpiote_pin_cleanup(atomic_t *mask, uint32_t abs_pin)
 	for (size_t i = 0; i < GPIOTE_CH_NUM; i++) {
 		if ((nrf_gpiote_event_pin_get(NRF_GPIOTE, i) == abs_pin)
 		    && (intenset & BIT(i))) {
-			atomic_set_bit_to(mask, i, 0);
+			(void)atomic_and(mask, ~BIT(i));
 			nrf_gpiote_event_disable(NRF_GPIOTE, i);
 			nrf_gpiote_int_disable(NRF_GPIOTE, BIT(i));
 			return;


### PR DESCRIPTION
A call to atomic_set_bit_to() was used for clearing bits in an atomic_t
variable that stores information about allocated GPIOTE channels.
This caused an issue to be reported by Coverity, as the function treats
its first parameter as an array and it was provided with a pointer to
a singleton.
This commit replaces that call with atomic_and(), to prevent the issue
from being reported and for consistency with the way bits are set for
allocated GPIOTE channels (what is done with a call to atomic_or()).

Fixes #26353.