### PR TITLE
net: l2: openthread: Implement `enable` API function

### DIFF
--- a/include/net/openthread.h
+++ b/include/net/openthread.h
@@ -102,7 +102,7 @@ struct otInstance *openthread_get_default_instance(void);
  *
  * @param ot_context
  */
-void openthread_start(struct openthread_context *ot_context);
+int openthread_start(struct openthread_context *ot_context);
 
 #define OPENTHREAD_L2_CTX_TYPE struct openthread_context
 


### PR DESCRIPTION
It fixes https://github.com/zephyrproject-rtos/zephyr/issues/26220.

Solution: openthread_start function is called when L2 enable(iface, true) is called. openthread_stop is called when L2 enable(iface, false) is called. openthread_stop makes the device to leave the OpenThread network.
