### PR TITLE
actions: Add some additional labels for devicetree

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,11 +16,19 @@
   - "drivers/i2s/**/*"
 "area: C Library":
   - "lib/libc/**/*"
-"area: Device Tree":
+"area: Devicetree":
   - "dts/**/*"
+  - "!dts/bindings/**/*"
   - "**/*.dts"
+  - "**/*.dtsi"
+  - "include/devicetree.h"
   - "include/devicetree/*"
+  - "doc/guides/dts/**/*"
+"area: Devicetree Binding":
   - "include/dt-bindings/**/*"
+  - "dts/bindings/**/*"
+"area: Devicetree Tooling":
+  - "scripts/dts/**/*"
 "area: I2C":
   - "drivers/i2c/**/*"
 "area: SPI":


### PR DESCRIPTION
Add labeling of PRs for 'area: Device Tree Binding' (files under
dts/bindings/*)  and 'area: Device Tree Tooling' (files under
scripts/dts/*).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>