### PR TITLE
net: l2: ppp: ipcp: clear options after protocol goes down

### DIFF
--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -481,6 +481,13 @@ static void ipcp_down(struct ppp_fsm *fsm)
 	struct ppp_context *ctx = CONTAINER_OF(fsm, struct ppp_context,
 					       ipcp.fsm);
 
+	memset(&ctx->ipcp.my_options.address, 0,
+	       sizeof(ctx->ipcp.my_options.address));
+	memset(&ctx->ipcp.my_options.dns1_address, 0,
+	       sizeof(ctx->ipcp.my_options.dns1_address));
+	memset(&ctx->ipcp.my_options.dns2_address, 0,
+	       sizeof(ctx->ipcp.my_options.dns2_address));
+
 	if (!ctx->is_ipcp_up) {
 		return;
 	}


### PR DESCRIPTION
Clear negotiated options in protocol down handler. That way all
addresses are properly requested (by sending 0.0.0.0 in Configure-Req)
in the subsequent option negotiation phases.