### PR TITLE
sanitycheck: set selected_plaforms when loading tests from file

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -931,6 +931,7 @@ def main():
         suite.selected_platforms = set(p.platform.name for p in suite.instances.values())
     elif options.load_tests:
         suite.load_from_file(options.load_tests)
+        suite.selected_platforms = set(p.platform.name for p in suite.instances.values())
     elif options.test_only:
         suite.load_from_file(last_run, filter_status=['skipped'])
     else:


### PR DESCRIPTION
Missed the case we use in CI where we pre-generate the testcase list and
load it, this was resulting in empty test reports in CI.