### PR TITLE
net: l2: ppp: fsm: use packet work object instead of shared one

### DIFF
--- a/include/net/ppp.h
+++ b/include/net/ppp.h
@@ -219,19 +219,6 @@ struct ppp_fsm {
 	/** Timeout timer */
 	struct k_delayed_work timer;
 
-	/* We need to send a packet from separate thread so that we do not
-	 * receive reply before we are ready to receive it. The issue was seen
-	 * with QEMU where the link to peer is so fast that we received the
-	 * reply before the net_send_data() returned.
-	 */
-	struct {
-		/** Packet sending timer. */
-		struct k_delayed_work work;
-
-		/** Packet to send */
-		struct net_pkt *pkt;
-	} sender;
-
 	struct {
 		/** Acknowledge Configuration Information */
 		int (*config_info_ack)(struct ppp_fsm *fsm,

--- a/subsys/net/l2/ppp/fsm.c
+++ b/subsys/net/l2/ppp/fsm.c
@@ -132,13 +132,12 @@ static void ppp_fsm_timeout(struct k_work *work)
 
 static void ppp_pkt_send(struct k_work *work)
 {
-	struct ppp_fsm *fsm = CONTAINER_OF(work, struct ppp_fsm,
-					   sender.work);
+	struct net_pkt *pkt = CONTAINER_OF(work, struct net_pkt, work);
 	int ret;
 
-	ret = net_send_data(fsm->sender.pkt);
+	ret = net_send_data(pkt);
 	if (ret < 0) {
-		net_pkt_unref(fsm->sender.pkt);
+		net_pkt_unref(pkt);
 	}
 }
 
@@ -150,7 +149,6 @@ void ppp_fsm_init(struct ppp_fsm *fsm, uint16_t protocol)
 	fsm->flags = 0U;
 
 	k_delayed_work_init(&fsm->timer, ppp_fsm_timeout);
-	k_delayed_work_init(&fsm->sender.work, ppp_pkt_send);
 }
 
 static void terminate(struct ppp_fsm *fsm, enum ppp_state next_state)
@@ -509,14 +507,8 @@ int ppp_send_pkt(struct ppp_fsm *fsm, struct net_if *iface,
 		 * have returned from this function. That is bad because the
 		 * fsm would be in wrong state and the received pkt is dropped.
 		 */
-		fsm->sender.pkt = pkt;
-
-		/* FIXME: qemu_x86 crashes if timeout is 0 when running ppp
-		 * driver unit test. As a workaround set the timeout to 1 msec
-		 * in that case.
-		 */
-		(void)k_delayed_work_submit(&fsm->sender.work,
-			  IS_ENABLED(CONFIG_NET_TEST) ? K_MSEC(1) : K_NO_WAIT);
+		k_work_init(net_pkt_work(pkt), ppp_pkt_send);
+		k_work_submit(net_pkt_work(pkt));
 	} else {
 		ret = net_send_data(pkt);
 		if (ret < 0) {


### PR DESCRIPTION
Single work object for whole fsm was not being able to handle more than
single packet at a time. Because of that we have overwritten already
scheduled packets, resulting in fsm timeout and net_pkt leak.

Use net_pkt work object instead, so we can safely schedule more than a
single packet.

This commit also drops workaround for qemu_x86 unit testing.

Tested with qemu_x86 and pppd using master branch + some not (yet) mainlined patches. pppd logs **before** this change:
```
00:06:07.700130 rcvd [LCP ConfReq id=0x1]
00:06:07.700164 sent [LCP ConfReq id=0x1 <asyncmap 0x0> <magic 0x4e8bf5bb> <pcomp>]
00:06:07.700170 sent [LCP ConfAck id=0x1]
00:06:07.702071 rcvd [LCP ConfRej id=0x1 <asyncmap 0x0> <magic 0x4e8bf5bb> <pcomp>]
00:06:07.702085 sent [LCP ConfReq id=0x2]
00:06:07.703318 rcvd [LCP ConfAck id=0x2]
00:06:07.703346 sent [LCP EchoReq id=0x0 magic=0x0]
00:06:07.703353 sent [IPCP ConfReq id=0x1 <addr 192.0.2.2>]
00:06:07.703359 sent [IPV6CP ConfReq id=0x1 <addr fe80::c40e:a527:a6f2:58bb>]
00:06:07.703566 rcvd [IPCP ConfReq id=0x1 <addr 0.0.0.0> <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
00:06:07.703582 sent [IPCP ConfRej id=0x1 <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
00:06:07.705138 rcvd [LCP EchoRep id=0x0 magic=0x0]
00:06:07.705187 rcvd [IPV6CP ConfAck id=0x1 <addr fe80::c40e:a527:a6f2:58bb>]
00:06:07.705222 rcvd [IPCP ConfReq id=0x2 <addr 0.0.0.0>]
00:06:07.705232 sent [IPCP ConfNak id=0x2 <addr 192.0.2.1>]
00:06:07.705906 rcvd [IPCP ConfReq id=0x3 <addr 192.0.2.1>]
00:06:07.705919 sent [IPCP ConfAck id=0x3 <addr 192.0.2.1>]
00:06:10.706418 sent [IPCP ConfReq id=0x1 <addr 192.0.2.2>]
00:06:10.706450 sent [IPV6CP ConfReq id=0x1 <addr fe80::c40e:a527:a6f2:58bb>]
00:06:10.707295 rcvd [IPCP ConfAck id=0x1 <addr 192.0.2.2>]
00:06:10.708900 Cannot determine ethernet address for proxy ARP
00:06:10.708915 local  IP address 192.0.2.2
00:06:10.708923 remote IP address 192.0.2.1
00:06:10.709219 Script /etc/ppp/ip-up started (pid 343523)
00:06:10.709240 rcvd [IPV6CP ConfAck id=0x1 <addr fe80::c40e:a527:a6f2:58bb>]
00:06:10.711448 Script /etc/ppp/ip-up finished (pid 343523), status = 0x0
00:06:13.709597 sent [IPV6CP ConfReq id=0x1 <addr fe80::c40e:a527:a6f2:58bb>]
00:06:13.710314 rcvd [IPV6CP ConfAck id=0x1 <addr fe80::c40e:a527:a6f2:58bb>]
00:06:13.716012 rcvd [IPV6CP ConfReq id=0x1 <addr fe80::0000:5eff:fe00:53f1>]
00:06:13.716031 sent [IPV6CP ConfAck id=0x1 <addr fe80::0000:5eff:fe00:53f1>]
00:06:13.716157 local  LL address fe80::c40e:a527:a6f2:58bb
00:06:13.716175 remote LL address fe80::0000:5eff:fe00:53f1
00:06:13.716532 Script /etc/ppp/ipv6-up started (pid 343543)
00:06:13.716548 rcvd [IPCP ConfReq id=0x4 <addr 0.0.0.0> <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
00:06:13.716654 Connect time 0.1 minutes.
00:06:13.716672 Sent 661 bytes, received 50 bytes.
00:06:13.718289 Script /etc/ppp/ip-down started (pid 343545)
00:06:13.718324 sent [IPCP ConfReq id=0x2 <addr 192.0.2.2>]
00:06:13.718331 sent [IPCP ConfRej id=0x4 <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
00:06:13.718603 Script /etc/ppp/ipv6-up finished (pid 343543), status = 0x0
00:06:13.720854 rcvd [IPCP ConfReq id=0x5 <addr 0.0.0.0>]
00:06:13.720871 sent [IPCP ConfNak id=0x5 <addr 192.0.2.1>]
00:06:13.721492 rcvd [IPCP ConfReq id=0x6 <addr 192.0.2.1>]
00:06:13.721511 sent [IPCP ConfAck id=0x6 <addr 192.0.2.1>]
00:06:13.723695 Script /etc/ppp/ip-down finished (pid 343545), status = 0x0
00:06:16.721662 sent [IPCP ConfReq id=0x2 <addr 192.0.2.2>]
00:06:16.722689 rcvd [IPCP ConfAck id=0x2 <addr 192.0.2.2>]
00:06:16.724217 Cannot determine ethernet address for proxy ARP
00:06:16.724236 local  IP address 192.0.2.2
00:06:16.724246 remote IP address 192.0.2.1
00:06:16.724463 Script /etc/ppp/ip-up started (pid 343557)
00:06:16.726377 Script /etc/ppp/ip-up finished (pid 343557), status = 0x0
00:06:19.726989 rcvd [IPCP ConfReq id=0x7 <addr 0.0.0.0> <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
00:06:19.727021 Connect time 0.1 minutes.
00:06:19.727028 Sent 726 bytes, received 78 bytes.
00:06:19.728598 Script /etc/ppp/ip-down started (pid 343559)
00:06:19.728617 sent [IPCP ConfReq id=0x3 <addr 192.0.2.2>]
00:06:19.728643 sent [IPCP ConfRej id=0x7 <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
00:06:19.729099 rcvd [IPCP ConfAck id=0x3 <addr 192.0.2.2>]
00:06:19.729406 rcvd [IPCP ConfReq id=0x8 <addr 0.0.0.0>]
00:06:19.729422 sent [IPCP ConfNak id=0x8 <addr 192.0.2.1>]
00:06:19.730025 rcvd [IPCP ConfReq id=0x9 <addr 192.0.2.1>]
00:06:19.730038 sent [IPCP ConfAck id=0x9 <addr 192.0.2.1>]
00:06:19.731855 Cannot determine ethernet address for proxy ARP
00:06:19.731907 local  IP address 192.0.2.2
00:06:19.731914 remote IP address 192.0.2.1
00:06:19.734673 Script /etc/ppp/ip-down finished (pid 343559), status = 0x0
00:06:19.734861 Script /etc/ppp/ip-up started (pid 343566)
00:06:19.736316 Script /etc/ppp/ip-up finished (pid 343566), status = 0x0
```
and network allocation packets (unavailable packets are leaked):
```
uart:~$ net mem
Fragment length 128 bytes
Network buffer pools:
Address         Total   Avail   Name
0x14cb10        16      16      RX
0x14cb34        16      10      TX
0x14cc84        64      64      RX DATA (rx_bufs)
0x14ccbc        64      52      TX DATA (tx_bufs)
```

**after** change:
```
00:08:28.484267 rcvd [LCP ConfReq id=0x1]
00:08:28.484299 sent [LCP ConfReq id=0x1 <asyncmap 0x0> <magic 0x18a9c874> <pcomp>]
00:08:28.484306 sent [LCP ConfAck id=0x1]
00:08:28.486206 rcvd [LCP ConfRej id=0x1 <asyncmap 0x0> <magic 0x18a9c874> <pcomp>]
00:08:28.486222 sent [LCP ConfReq id=0x2]
00:08:28.487434 rcvd [LCP ConfAck id=0x2]
00:08:28.487461 sent [LCP EchoReq id=0x0 magic=0x0]
00:08:28.487469 sent [IPCP ConfReq id=0x1 <addr 192.0.2.2>]
00:08:28.487476 sent [IPV6CP ConfReq id=0x1 <addr fe80::89fd:35b2:879a:2fe5>]
00:08:28.487724 rcvd [IPCP ConfReq id=0x1 <addr 0.0.0.0> <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
00:08:28.487741 sent [IPCP ConfRej id=0x1 <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
00:08:28.489348 rcvd [IPV6CP ConfReq id=0x1 <addr fe80::0000:5eff:fe00:53e0>]
00:08:28.489363 sent [IPV6CP ConfAck id=0x1 <addr fe80::0000:5eff:fe00:53e0>]
00:08:28.489371 rcvd [LCP EchoRep id=0x0 magic=0x0]
00:08:28.489529 rcvd [IPCP ConfAck id=0x1 <addr 192.0.2.2>]
00:08:28.489567 rcvd [IPV6CP ConfAck id=0x1 <addr fe80::89fd:35b2:879a:2fe5>]
00:08:28.489775 local  LL address fe80::89fd:35b2:879a:2fe5
00:08:28.489854 remote LL address fe80::0000:5eff:fe00:53e0
00:08:28.490533 Script /etc/ppp/ipv6-up started (pid 344013)
00:08:28.490547 rcvd [IPCP ConfReq id=0x2 <addr 0.0.0.0>]
00:08:28.490553 sent [IPCP ConfNak id=0x2 <addr 192.0.2.1>]
00:08:28.492370 Script /etc/ppp/ipv6-up finished (pid 344013), status = 0x0
00:08:28.492765 rcvd [IPCP ConfReq id=0x3 <addr 192.0.2.1>]
00:08:28.492785 sent [IPCP ConfAck id=0x3 <addr 192.0.2.1>]
00:08:28.494107 Cannot determine ethernet address for proxy ARP
00:08:28.494126 local  IP address 192.0.2.2
00:08:28.494134 remote IP address 192.0.2.1
00:08:28.494302 Script /etc/ppp/ip-up started (pid 344015)
00:08:28.496096 Script /etc/ppp/ip-up finished (pid 344015), status = 0x0
```
and network allocation packets (none are missing):
```
uart:~$ net mem
Fragment length 128 bytes
Network buffer pools:
Address         Total   Avail   Name
0x14cb10        16      16      RX
0x14cb34        16      16      TX
0x14cc84        64      64      RX DATA (rx_bufs)
0x14ccbc        64      64      TX DATA (tx_bufs)
```