### PR TITLE
benchmarks: latency_measure: set number of CPU to 1

### DIFF
--- a/tests/benchmarks/latency_measure/prj.conf
+++ b/tests/benchmarks/latency_measure/prj.conf
@@ -18,3 +18,6 @@ CONFIG_COVERAGE=n
 
 # Disable system power management
 CONFIG_SYS_POWER_MANAGEMENT=n
+
+# Can only run under 1 CPU
+CONFIG_MP_NUM_CPUS=1


### PR DESCRIPTION
The latency measurement are not designed to run on multiple CPUs,
so limit it to just 1 CPU.

Fixes #26264

Signed-off-by: Daniel Leung <daniel.leung@intel.com>