### PR TITLE
random: entropy: Fix invalid memory access

### DIFF
--- a/subsys/random/rand32_entropy_device.c
+++ b/subsys/random/rand32_entropy_device.c
@@ -85,16 +85,15 @@ static int rand_get(uint8_t *dst, size_t outlen, bool csrand)
 		uint32_t blocksize = 4;
 
 		while (len < outlen) {
-			random_num = k_cycle_get_32();
-			if ((outlen-len) < sizeof(random_num)) {
-				blocksize = len;
-				(void)memcpy(&(dst[random_num]),
-						&random_num, blocksize);
-			} else {
-				*((uint32_t *)&dst[len]) = random_num;
+			size_t copylen = outlen - len;
+
+			if (copylen > blocksize) {
+				copylen = blocksize;
 			}
 
-			len += blocksize;
+			random_num = k_cycle_get_32();
+			(void)memcpy(&(dst[len]), &random_num, copylen);
+			len += copylen;
 		}
 	}
 


### PR DESCRIPTION
In sys_rand_get() if the entropy hardware unlikely return error, the
fallgback is using the system timer to and fill the given buffer with
that data.

The problem what that k_cycle_get_32() returns a four bytes integer and
depending the sizeof of the buffer we need copy the right amount of
data. That was not being done properly leading to invalid read/write
memory access.

Fixes #26435

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>