### PR TITLE
Sanitycheck: tweaks to allow --device-testing --build-only to work

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -2000,7 +2000,7 @@ class ProjectBuilder(FilterBuilder):
                 if results.get('returncode', 1) > 0:
                     pipeline.put({"op": "report", "test": self.instance})
                 else:
-                    if self.instance.run:
+                    if self.instance.run and self.instance.build_only is False:
                         pipeline.put({"op": "run", "test": self.instance})
                     else:
                         pipeline.put({"op": "report", "test": self.instance})
@@ -2674,7 +2674,7 @@ class TestSuite(DisablePyTestCollectionMixin):
                     # Discard silently
                     continue
 
-                if device_testing_filter and instance.build_only:
+                if device_testing_filter and instance.run is False:
                     discards[instance] = "Not runnable on device"
                     continue
 

--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -1555,8 +1555,8 @@ class TestInstance(DisablePyTestCollectionMixin):
 
         _build_only = True
 
-        # we asked for build-only on the command line
-        if opt_build_only or self.testcase.build_only:
+        # the testcase is build only
+        if self.testcase.build_only:
             self.build_only = True
             self.run = False
             return
@@ -1602,6 +1602,11 @@ class TestInstance(DisablePyTestCollectionMixin):
 
         self.build_only = not (not _build_only and runnable)
         self.run = not self.build_only
+
+        # we asked for build-only on the command line
+        if opt_build_only:
+            self.build_only = True
+
         return
 
     def create_overlay(self, platform, enable_asan=False, enable_coverage=False, coverage_platform=[]):

--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -1544,7 +1544,7 @@ class TestInstance(DisablePyTestCollectionMixin):
         return self.name < other.name
 
     # Global testsuite parameters
-    def check_build_or_run(self, build_only=False, enable_slow=False, device_testing=False, fixtures=[]):
+    def check_build_or_run(self, opt_build_only=False, enable_slow=False, device_testing=False, fixtures=[]):
 
         # right now we only support building on windows. running is still work
         # in progress.
@@ -1556,7 +1556,7 @@ class TestInstance(DisablePyTestCollectionMixin):
         _build_only = True
 
         # we asked for build-only on the command line
-        if build_only or self.testcase.build_only:
+        if opt_build_only or self.testcase.build_only:
             self.build_only = True
             self.run = False
             return
@@ -2244,7 +2244,7 @@ class TestSuite(DisablePyTestCollectionMixin):
 
         # Testsuite Options
         self.coverage_platform = []
-        self.build_only = False
+        self.opt_build_only = False
         self.cmake_only = False
         self.cleanup = False
         self.enable_slow = False
@@ -2592,7 +2592,7 @@ class TestSuite(DisablePyTestCollectionMixin):
                     platform = self.get_platform(row["platform"])
                     instance = TestInstance(self.testcases[test], platform, self.outdir)
                     instance.check_build_or_run(
-                        self.build_only,
+                        self.opt_build_only,
                         self.enable_slow,
                         self.device_testing,
                         self.fixtures
@@ -2653,7 +2653,7 @@ class TestSuite(DisablePyTestCollectionMixin):
             for plat in platforms:
                 instance = TestInstance(tc, plat, self.outdir)
                 instance.check_build_or_run(
-                    self.build_only,
+                    self.opt_build_only,
                     self.enable_slow,
                     self.device_testing,
                     self.fixtures

--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -1885,6 +1885,7 @@ class ProjectBuilder(FilterBuilder):
         self.valgrind = kwargs.get('valgrind', False)
         self.extra_args = kwargs.get('extra_args', [])
         self.device_testing = kwargs.get('device_testing', False)
+        self.opt_build_only = kwargs.get('opt_build_only', False)
         self.cmake_only = kwargs.get('cmake_only', False)
         self.cleanup = kwargs.get('cleanup', False)
         self.coverage = kwargs.get('coverage', False)
@@ -1961,7 +1962,7 @@ class ProjectBuilder(FilterBuilder):
                 instance.handler = BinaryHandler(instance, "renode")
                 instance.handler.pid_fn = os.path.join(instance.build_dir, "renode.pid")
                 instance.handler.call_make_run = True
-        elif self.device_testing:
+        elif self.device_testing and self.opt_build_only is False:
             instance.handler = DeviceHandler(instance, "device")
 
         if instance.handler:
@@ -2859,6 +2860,7 @@ class TestSuite(DisablePyTestCollectionMixin):
                                         coverage=self.enable_coverage,
                                         extra_args=self.extra_args,
                                         device_testing=self.device_testing,
+                                        opt_build_only=self.opt_build_only,
                                         cmake_only=self.cmake_only,
                                         cleanup=self.cleanup,
                                         valgrind=self.enable_valgrind,

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1036,7 +1036,7 @@ def main():
     logger.info("%d test configurations selected, %d configurations discarded due to filters." %
                 (len(suite.instances), len(discards)))
 
-    if options.device_testing:
+    if options.device_testing and options.build_only is False:
         print("\nDevice testing on:")
         hwm.dump(suite.connected_hardware, suite.selected_platforms)
         print("")
@@ -1098,7 +1098,7 @@ def main():
         coverage_tool.add_ignore_directory('samples')
         coverage_tool.generate(options.outdir)
 
-    if options.device_testing:
+    if options.device_testing and options.build_only is False:
         print("\nHardware distribution summary:\n")
         table = []
         header = ['Board', 'ID', 'Counter']

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -768,7 +768,7 @@ def main():
     suite = TestSuite(options.board_root, options.testcase_root, options.outdir)
 
     # Set testsuite options from command line.
-    suite.build_only = options.build_only
+    suite.opt_build_only = options.build_only
     suite.cmake_only = options.cmake_only
     suite.cleanup = options.runtime_artifact_cleanup
     suite.test_only = options.test_only


### PR DESCRIPTION
This is a step towards having support in sanitycheck to produce just the build artifacts for tests that are runnable on a board.