### PR TITLE
drivers/timer/hpet: Disable FSB interrupts

### DIFF
--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -35,6 +35,7 @@
 #define TCONF_PERIODIC   BIT(3)
 #define TCONF_VAL_SET    BIT(6)
 #define TCONF_MODE32     BIT(8)
+#define TCONF_FSB_EN     BIT(14) /* FSB interrupt delivery enable */
 
 #define MIN_DELAY 1000
 
@@ -137,6 +138,7 @@ int z_clock_driver_init(struct device *device)
 	 */
 	GENERAL_CONF_REG |= GCONF_LR | GCONF_ENABLE;
 	TIMER0_CONF_REG &= ~TCONF_PERIODIC;
+	TIMER0_CONF_REG &= ~TCONF_FSB_EN;
 	TIMER0_CONF_REG |= TCONF_MODE32;
 
 	max_ticks = (0x7fffffff - cyc_per_tick) / cyc_per_tick;


### PR DESCRIPTION
The front side bus interrupt delivery feature is a somewhat obscure
part of PC history (in some sense a presaging of MSI interrupts) that
we don't use.

But it's part of the spec, works on hardware, has precedence over the
"legacy" interrupt routing feature we do use, and can be legally
enabled by firmware.

Disable at init time.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>