### PR TITLE
drivers: serial: uart_nrfx_uarte: init cleanup rx

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -468,6 +468,21 @@ static int uarte_nrfx_init(struct device *dev)
 			     NRF_UARTE_INT_RXTO_MASK);
 	nrf_uarte_enable(uarte);
 
+	/**
+	 * Stop any currently running RX operations. This can occur when a
+	 * bootloader sets up the UART hardware and does not clean it up
+	 * before jumping to the next application.
+	 */
+	if (nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_RXSTARTED)) {
+		nrf_uarte_task_trigger(uarte, NRF_UARTE_TASK_STOPRX);
+		while (!nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_RXTO)) {
+			/* Busy wait for event to register */
+		}
+		nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_RXSTARTED);
+		nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_ENDRX);
+		nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_RXTO);
+	}
+
 	k_timer_init(&data->async->rx_timeout_timer, rx_timeout, NULL);
 	k_timer_user_data_set(&data->async->rx_timeout_timer, dev);
 	k_timer_init(&data->async->tx_timeout_timer, tx_timeout, NULL);


### PR DESCRIPTION
When `CONFIG_UART_ASYNC_API` is enabled, cleanup any pending synchronous
receptions at initialization time. Pending receptions are present when
this driver is used with the default mcuboot application.

When `CONFIG_UART_ASYNC_API` is not enabled, RX is always enabled by
this driver. As mcuboot does not use the async API, and does not cleanup
the UART driver before jumping to the next application, that application
boots with RX still enabled. This results in a 500uA increase in current
consumption.

Fixes #26555