### PR TITLE
logging: Add fields initialization in z_log_msg_std_alloc

### DIFF
--- a/include/logging/log_msg.h
+++ b/include/logging/log_msg.h
@@ -7,6 +7,7 @@
 #define ZEPHYR_INCLUDE_LOGGING_LOG_MSG_H_
 
 #include <sys/atomic.h>
+#include <sys/util.h>
 #include <string.h>
 
 #ifdef __cplusplus
@@ -326,6 +327,13 @@ static inline struct log_msg *z_log_msg_std_alloc(void)
 		msg->hdr.ref_cnt = 1;
 		msg->hdr.params.raw = 0U;
 		msg->hdr.params.std.type = LOG_MSG_TYPE_STD;
+
+		if (IS_ENABLED(CONFIG_USERSPACE)) {
+			/* it may be used in msg_free() function. */
+			msg->hdr.ids.level = 0;
+			msg->hdr.ids.domain_id = 0;
+			msg->hdr.ids.source_id = 0;
+		}
 	}
 
 	return msg;


### PR DESCRIPTION
Added initialization of ids fields in the log message in
z_log_msg_std_alloc(). If user space is enabled then msg_free()
function is reading log level and previously it may have been
uninitialized.

Fixes #24224.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>