### PR TITLE
Bluetooth: controller: Remove redundant BT_LL_SW_SPLIT conditional

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -174,7 +174,7 @@ config BT_CTLR_SCAN_AUX_SET
 
 config BT_CTLR_ZLI
 	bool "Use Zero Latency IRQs"
-	depends on ZERO_LATENCY_IRQS && BT_LL_SW_SPLIT
+	depends on ZERO_LATENCY_IRQS
 	help
 	  Enable support for use of Zero Latency IRQ feature. Note, applications
 	  shall not use Zero Latency IRQ themselves when this option is selected,
@@ -236,7 +236,6 @@ config BT_CTLR_SCHED_ADVANCED
 	  Disabling this feature will lead to overlapping role in timespace
 	  leading to skipped events amongst active roles.
 
-if BT_LL_SW_SPLIT
 config BT_CTLR_LLL_PRIO
 	int "Lower Link Layer (Radio) IRQ priority"
 	range 0 3 if SOC_SERIES_NRF51X
@@ -291,8 +290,6 @@ config BT_CTLR_CONN_META
 config BT_CTLR_RX_PDU_META
 	prompt "Enable RX pdu meta data"
 	bool
-
-endif # BT_LL_SW_SPLIT
 
 config BT_CTLR_RADIO_ENABLE_FAST
 	bool "Use tTXEN/RXEN,FAST ramp-up"
@@ -450,7 +447,6 @@ config BT_TICKER_EXT
 
 config BT_CTLR_USER_EXT
 	prompt "Enable proprietary extensions in Controller"
-	depends on BT_LL_SW_SPLIT
 	bool
 	help
 	  Catch-all for enabling proprietary event types in Controller behavior.

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -45,10 +45,6 @@
 #include "ll_sw/lll.h"
 #include "ll.h"
 
-#if (!defined(CONFIG_BT_LL_SW_SPLIT))
-#include "ll_sw/ctrl.h"
-#endif /* CONFIG_BT_LL_SW_SPLIT */
-
 #include "hci_internal.h"
 
 #include "hal/debug.h"
@@ -75,7 +71,7 @@ static struct net_buf *process_prio_evt(struct node_rx_pdu *node_rx,
 #if defined(CONFIG_BT_CONN)
 	if (node_rx->hdr.user_meta == HCI_CLASS_EVT_CONNECTION) {
 		uint16_t handle;
-		struct pdu_data *pdu_data = PDU_DATA(node_rx);
+		struct pdu_data *pdu_data = (void *)node_rx->pdu;
 
 		handle = node_rx->hdr.handle;
 		if (node_rx->hdr.type == NODE_RX_TYPE_TERMINATE) {

--- a/subsys/bluetooth/controller/hci/hci_internal.h
+++ b/subsys/bluetooth/controller/hci/hci_internal.h
@@ -29,15 +29,6 @@ extern atomic_t hci_state_mask;
 				     * data)
 				     */
 
-
-#if defined(CONFIG_BT_LL_SW_SPLIT)
-#define PDU_DATA(node_rx) ((void *)node_rx->pdu)
-#else
-#define PDU_DATA(node_rx) ((void *) \
-				((struct radio_pdu_node_rx *)node_rx)->pdu_data)
-#endif /* CONFIG_BT_LL_SW_SPLIT */
-
-
 void hci_init(struct k_poll_signal *signal_host_buf);
 struct net_buf *hci_cmd_handle(struct net_buf *cmd, void **node_rx);
 void hci_evt_encode(struct node_rx_pdu *node_rx, struct net_buf *buf);

--- a/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
@@ -14,6 +14,7 @@
 #include "hal/ccm.h"
 #include "hal/radio.h"
 
+#include "util/util.h"
 #include "util/memq.h"
 
 #include "pdu.h"
@@ -21,15 +22,14 @@
 #include "ll.h"
 #include "lll.h"
 
-#if defined(CONFIG_BT_LL_SW_SPLIT)
-#include "util/util.h"
-
 #include "lll_scan.h"
 #include "ull_scan_types.h"
 #include "ull_scan_internal.h"
+
 #include "lll_adv.h"
 #include "ull_adv_types.h"
 #include "ull_adv_internal.h"
+
 #include "lll_conn.h"
 #include "ull_conn_types.h"
 #include "ull_conn_internal.h"
@@ -197,7 +197,6 @@ uint8_t ll_tx_pwr_lvl_set(uint8_t handle_type, uint16_t handle,
 
 	return BT_HCI_ERR_SUCCESS;
 }
-#endif /* CONFIG_BT_LL_SW_SPLIT */
 
 void ll_tx_pwr_get(int8_t *min, int8_t *max)
 {

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/mayfly.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/mayfly.c
@@ -13,19 +13,16 @@
 #include "util/memq.h"
 #include "util/mayfly.h"
 
+#include "ll_sw/lll.h"
+
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_hal_mayfly
 #include "common/log.h"
 #include "hal/debug.h"
 
-#if defined(CONFIG_BT_LL_SW_SPLIT)
-#include "ll_sw/lll.h"
 #define MAYFLY_CALL_ID_LLL    TICKER_USER_ID_LLL
 #define MAYFLY_CALL_ID_WORKER TICKER_USER_ID_ULL_HIGH
 #define MAYFLY_CALL_ID_JOB    TICKER_USER_ID_ULL_LOW
-#else
-#error Unknown LL variant.
-#endif
 
 void mayfly_enable_cb(uint8_t caller_id, uint8_t callee_id, uint8_t enable)
 {
@@ -45,10 +42,8 @@ uint32_t mayfly_is_enabled(uint8_t caller_id, uint8_t callee_id)
 	(void)caller_id;
 
 	switch (callee_id) {
-#if defined(CONFIG_BT_LL_SW_SPLIT)
 	case MAYFLY_CALL_ID_LLL:
 		return irq_is_enabled(HAL_SWI_RADIO_IRQ);
-#endif /* CONFIG_BT_LL_SW_SPLIT */
 
 	case MAYFLY_CALL_ID_WORKER:
 		return irq_is_enabled(HAL_SWI_WORKER_IRQ);
@@ -67,7 +62,6 @@ uint32_t mayfly_is_enabled(uint8_t caller_id, uint8_t callee_id)
 uint32_t mayfly_prio_is_equal(uint8_t caller_id, uint8_t callee_id)
 {
 	return (caller_id == callee_id) ||
-#if defined(CONFIG_BT_LL_SW_SPLIT)
 #if (CONFIG_BT_CTLR_LLL_PRIO == CONFIG_BT_CTLR_ULL_HIGH_PRIO)
 	       ((caller_id == MAYFLY_CALL_ID_LLL) &&
 		(callee_id == MAYFLY_CALL_ID_WORKER)) ||
@@ -86,7 +80,6 @@ uint32_t mayfly_prio_is_equal(uint8_t caller_id, uint8_t callee_id)
 	       ((caller_id == MAYFLY_CALL_ID_JOB) &&
 		(callee_id == MAYFLY_CALL_ID_WORKER)) ||
 #endif
-#endif
 	       0;
 }
 
@@ -95,11 +88,9 @@ void mayfly_pend(uint8_t caller_id, uint8_t callee_id)
 	(void)caller_id;
 
 	switch (callee_id) {
-#if defined(CONFIG_BT_LL_SW_SPLIT)
 	case MAYFLY_CALL_ID_LLL:
 		hal_swi_lll_pend();
 		break;
-#endif /* CONFIG_BT_LL_SW_SPLIT */
 
 	case MAYFLY_CALL_ID_WORKER:
 		hal_swi_worker_pend();

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/swi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/swi.h
@@ -11,8 +11,6 @@ static inline void hal_swi_init(void)
 	/* No platform-specific initialization required. */
 }
 
-/* SW IRQs required for the nRF5 BLE Controller. */
-#if defined(CONFIG_BT_LL_SW_SPLIT)
 /* Split architecture uses max. two SWI */
 #define HAL_SWI_RADIO_IRQ  SWI4_IRQn
 #define HAL_SWI_WORKER_IRQ RTC0_IRQn
@@ -29,10 +27,6 @@ static inline void hal_swi_lll_pend(void)
 	NVIC_SetPendingIRQ(HAL_SWI_RADIO_IRQ);
 }
 
-#else
-#error "CTRL architecture not defined"
-#endif
-
 static inline void hal_swi_worker_pend(void)
 {
 	NVIC_SetPendingIRQ(HAL_SWI_WORKER_IRQ);
@@ -44,9 +38,6 @@ static inline void hal_swi_job_pend(void)
 }
 
 #elif defined(CONFIG_SOC_SERIES_NRF53X)
-
-/* SW IRQs required for the nRF5 BLE Controller. */
-#if defined(CONFIG_BT_LL_SW_SPLIT)
 
 static inline void hal_swi_init(void)
 {
@@ -80,8 +71,4 @@ static inline void hal_swi_job_pend(void)
 	NVIC_SetPendingIRQ(HAL_SWI_JOB_IRQ);
 }
 
-#else
-#error "Legacy Controller architecture is not supported. "
-#endif /* CONFIG_BT_LL_SW_SPLIT */
-
-#endif /* CONFIG_SOC_SERIES_NRF51X || CONFIG_SOC_COMPATIBLE_NRF52X */
+#endif /* CONFIG_SOC_SERIES_NRF53X */

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ticker.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ticker.c
@@ -16,27 +16,25 @@
 
 #include "ticker/ticker.h"
 
+#include "ll_sw/lll.h"
+
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_hal_ticker
 #include "common/log.h"
 #include "hal/debug.h"
 
-#if defined(CONFIG_BT_LL_SW_SPLIT)
-#include "ll_sw/lll.h"
 #define TICKER_MAYFLY_CALL_ID_ISR     TICKER_USER_ID_LLL
 #define TICKER_MAYFLY_CALL_ID_TRIGGER TICKER_USER_ID_ULL_HIGH
 #define TICKER_MAYFLY_CALL_ID_WORKER  TICKER_USER_ID_ULL_HIGH
 #define TICKER_MAYFLY_CALL_ID_JOB     TICKER_USER_ID_ULL_LOW
 #define TICKER_MAYFLY_CALL_ID_PROGRAM TICKER_USER_ID_THREAD
+
 static uint8_t const caller_id_lut[] = {
 	TICKER_CALL_ID_ISR,
 	TICKER_CALL_ID_WORKER,
 	TICKER_CALL_ID_JOB,
 	TICKER_CALL_ID_PROGRAM
 };
-#else
-#error Unknown LL variant.
-#endif
 
 uint8_t hal_ticker_instance0_caller_id_get(uint8_t user_id)
 {
@@ -58,7 +56,6 @@ void hal_ticker_instance0_sched(uint8_t caller_id, uint8_t callee_id, uint8_t ch
 	 * schedule.
 	 */
 	switch (caller_id) {
-#if defined(CONFIG_BT_LL_SW_SPLIT)
 	case TICKER_CALL_ID_ISR:
 		switch (callee_id) {
 		case TICKER_CALL_ID_JOB:
@@ -82,7 +79,6 @@ void hal_ticker_instance0_sched(uint8_t caller_id, uint8_t callee_id, uint8_t ch
 			break;
 		}
 		break;
-#endif /* CONFIG_BT_LL_SW_SPLIT */
 
 	case TICKER_CALL_ID_TRIGGER:
 		switch (callee_id) {

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -2567,8 +2567,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 	SHELL_CMD_ARG(test_rx, NULL, "<chan> <phy> <mod_idx>", cmd_test_rx,
 		      4, 0),
 	SHELL_CMD_ARG(test_end, NULL, HELP_NONE, cmd_test_end, 1, 0),
-#endif /* CONFIG_BT_CTLR_ADV_EXT */
-	SHELL_CMD(ull_reset, NULL, HELP_NONE, cmd_ull_reset),
+#endif /* CONFIG_BT_CTLR_DTM */
 	SHELL_SUBCMD_SET_END
 );
 

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -2550,7 +2550,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 #if defined(CONFIG_BT_HCI_MESH_EXT)
 	SHELL_CMD(mesh_adv, NULL, "<on, off>", cmd_mesh_adv),
 #endif /* CONFIG_BT_HCI_MESH_EXT */
-#if defined(CONFIG_BT_LL_SW_SPLIT)
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 #if defined(CONFIG_BT_BROADCASTER)
 	SHELL_CMD_ARG(advx, NULL,
@@ -2569,10 +2568,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 		      4, 0),
 	SHELL_CMD_ARG(test_end, NULL, HELP_NONE, cmd_test_end, 1, 0),
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
-#endif /* defined(CONFIG_BT_LL_SW_SPLIT) */
-#if defined(CONFIG_BT_LL_SW_SPLIT)
 	SHELL_CMD(ull_reset, NULL, HELP_NONE, cmd_ull_reset),
-#endif /* CONFIG_BT_LL_SW_SPLIT */
 	SHELL_SUBCMD_SET_END
 );
 

--- a/subsys/bluetooth/shell/ll.c
+++ b/subsys/bluetooth/shell/ll.c
@@ -346,10 +346,3 @@ exit:
 }
 #endif /* CONFIG_BT_OBSERVER */
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
-
-int cmd_ull_reset(const struct shell *shell, size_t  argc, char *argv[])
-{
-	ll_reset();
-
-	return 0;
-}

--- a/subsys/bluetooth/shell/ll.c
+++ b/subsys/bluetooth/shell/ll.c
@@ -136,11 +136,9 @@ int cmd_test_end(const struct shell *shell, size_t  argc, char *argv[])
 #define AD_OP 0x03
 #define AD_FRAG_PREF 0x00
 
-#if defined(CONFIG_BT_LL_SW_SPLIT)
 static const struct bt_data adv_data[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, BT_LE_AD_NO_BREDR),
 	};
-#endif
 
 int cmd_advx(const struct shell *shell, size_t argc, char *argv[])
 {
@@ -257,7 +255,6 @@ do_enable:
 		goto exit;
 	}
 
-#if defined(CONFIG_BT_LL_SW_SPLIT)
 	if (ad) {
 		shell_print(shell, "ad data set...");
 		err = ll_adv_aux_ad_data_set(handle, AD_OP, AD_FRAG_PREF,
@@ -267,7 +264,6 @@ do_enable:
 			goto exit;
 		}
 	}
-#endif
 
 disable:
 	shell_print(shell, "adv enable (%u)...", enable);
@@ -351,12 +347,9 @@ exit:
 #endif /* CONFIG_BT_OBSERVER */
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 
-#if defined(CONFIG_BT_LL_SW_SPLIT)
 int cmd_ull_reset(const struct shell *shell, size_t  argc, char *argv[])
 {
 	ll_reset();
 
 	return 0;
 }
-
-#endif /* CONFIG_BT_LL_SW_SPLIT */

--- a/subsys/bluetooth/shell/ll.h
+++ b/subsys/bluetooth/shell/ll.h
@@ -21,6 +21,4 @@ int cmd_scanx(const struct shell *shell, size_t  argc, char *argv[]);
 int cmd_test_tx(const struct shell *shell, size_t  argc, char *argv[]);
 int cmd_test_rx(const struct shell *shell, size_t  argc, char *argv[]);
 int cmd_test_end(const struct shell *shell, size_t  argc, char *argv[]);
-
-int cmd_ull_reset(const struct shell *shell, size_t  argc, char *argv[]);
 #endif /* __LL_H */


### PR DESCRIPTION
Remove redundant use of BT_LL_SW_SPLIT conditional.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>