### PR TITLE
Bluetooth: controller: Add missing aux acquire on periodic adv

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -133,19 +133,12 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 	/* Allocate or existing Auxiliary channel instance */
 	lll_aux = lll->aux;
 	if (!lll_aux) {
-		aux = aux_acquire();
+		aux = ull_adv_aux_acquire(lll);
 		if (!aux) {
 			return BT_HCI_ERR_MEM_CAPACITY_EXCEEDED;
 		}
 
 		lll_aux = &aux->lll;
-		lll->aux = lll_aux;
-		lll_aux->adv = lll;
-
-		/* NOTE: ull_hdr_init(&aux->ull); is done on start */
-		lll_hdr_init(lll_aux, aux);
-
-		aux->is_started = 0U;
 
 		is_aux_new = 1U;
 	} else {
@@ -644,6 +637,28 @@ uint8_t ull_adv_aux_stop(struct ll_adv_aux_set *aux)
 	aux->is_started = 0U;
 
 	return 0;
+}
+
+struct ll_adv_aux_set *ull_adv_aux_acquire(struct lll_adv *lll)
+{
+	struct lll_adv_aux *lll_aux;
+	struct ll_adv_aux_set *aux;
+
+	aux = aux_acquire();
+	if (!aux) {
+		return aux;
+	}
+
+	lll_aux = &aux->lll;
+	lll->aux = lll_aux;
+	lll_aux->adv = lll;
+
+	/* NOTE: ull_hdr_init(&aux->ull); is done on start */
+	lll_hdr_init(lll_aux, aux);
+
+	aux->is_started = 0U;
+
+	return aux;
 }
 
 void ull_adv_aux_release(struct ll_adv_aux_set *aux)

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -61,6 +61,9 @@ uint32_t ull_adv_aux_start(struct ll_adv_aux_set *aux, uint32_t ticks_anchor,
 /* helper function to stop auxiliary advertising */
 uint8_t ull_adv_aux_stop(struct ll_adv_aux_set *aux);
 
+/* helper function to acquire and initialize auxiliary advertising instance */
+struct ll_adv_aux_set *ull_adv_aux_acquire(struct lll_adv *lll);
+
 /* helper function to release auxiliary advertising instance */
 void ull_adv_aux_release(struct ll_adv_aux_set *aux);
 


### PR DESCRIPTION
Added implementation to acquire and initialize auxiliary
channel instance on use of periodic advertising.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>