### PR TITLE
subsys: net: ip: copy to wrong destination in z_vrfy_net_addr_pton()

### DIFF
--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -482,7 +482,7 @@ int z_vrfy_net_addr_pton(sa_family_t family, const char *src,
 		return err;
 	}
 
-	Z_OOPS(z_user_to_copy((void *)src, addr, size));
+	Z_OOPS(z_user_to_copy((void *)dst, addr, size));
 
 	return 0;
 }


### PR DESCRIPTION
subsys: net: ip: copy to wrong destination in `z_vrfy_net_addr_pton()`

In function` z_vrfy_net_addr_pton(),`
the final copy should be to '`dst`' variable not to '`src`'

This issue was not highlighted by test :  tests/net/utils/  because there was a bug in this test :
```
			 ztest_unit_test(test_net_addr),	
			 ztest_user_unit_test(test_net_addr),
```
the good result of 1st test  `ztest_unit_test(test_net_addr),` hides the bad result of the 2nd one.
After each test, there was missing some restore of initial empty filed of strutures like `ipv4_pton_1.ipv4.addr.s_addr` (field depends on each test).

Now that PR #25159 has been merged, specially with commit "tests: net: remove duplicate test",
there is only 1 test : `ztest_user_unit_test(test_net_addr),` 
which highlight the issue.

Console log (before PR):
```
*** Booting Zephyr OS build zephyr-v2.3.0-616-g98c75038c8d9  ***
Running test suite test_utils_fn
===================================================================
START - test_net_addr
START - test_ipv4_pton_1
Failed to verify À
failed
```

Tested on nucleo_f429zi board.

