### PR TITLE
drivers: serial: uart_nrfx_uarte: rx disable block

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -608,6 +608,16 @@ static int uarte_nrfx_rx_disable(struct device *dev)
 
 	nrf_uarte_task_trigger(uarte, NRF_UARTE_TASK_STOPRX);
 
+	/* Wait for the hardware to signal the RX is finished. If the UART
+	 * hardware is disabled before this occurs, it will not power down
+	 * correctly. This results in ~500uA additional current consumption.
+	 */
+	while (!nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_RXTO)) {
+		/* Busy wait for event to register */
+	}
+	nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_ENDRX);
+	nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_RXTO);
+
 	return 0;
 }
 


### PR DESCRIPTION
Force `uarte_nrfx_rx_disable` to wait until the UARTE hardware has completed the RX disable sequence before returning. 
If this is not done, and the UARTE hardware is disabled before it occurs, the module is not powered down correctly. 
This results in ~500uA of additional current consumption.