### PR TITLE
boards: atsamd21_xpro: Support driving on-board LED with PWM

### DIFF
--- a/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
+++ b/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
@@ -21,6 +21,7 @@
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;
+		pwm-led0 = &pwm_led0;
 		sw0 = &user_button;
 		i2c-0 = &sercom2;
 	};
@@ -30,6 +31,13 @@
 		led0: led_0 {
 			gpios = <&portb 30 GPIO_ACTIVE_LOW>;
 			label = "Yellow LED";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&tcc0 0>;
 		};
 	};
 
@@ -44,6 +52,14 @@
 
 &cpu0 {
 	clock-frequency = <48000000>;
+};
+
+&tcc0 {
+	status = "okay";
+	compatible = "atmel,sam0-tcc-pwm";
+	/* Gives a maximum period of 1.4s */
+	prescaler = <4>;
+	#pwm-cells = <1>;
 };
 
 &sercom0 {

--- a/boards/arm/atsamd21_xpro/atsamd21_xpro.yaml
+++ b/boards/arm/atsamd21_xpro/atsamd21_xpro.yaml
@@ -16,6 +16,7 @@ supported:
   - dma
   - gpio
   - i2c
+  - pwm
   - spi
   - usb_cdc
   - usb_device

--- a/boards/arm/atsamd21_xpro/doc/index.rst
+++ b/boards/arm/atsamd21_xpro/doc/index.rst
@@ -47,6 +47,8 @@ features:
 +-----------+------------+------------------------------------------+
 | GPIO      | on-chip    | I/O ports                                |
 +-----------+------------+------------------------------------------+
+| PWM       | on-chip    | Pulse Width Modulation                   |
++-----------+------------+------------------------------------------+
 | USART     | on-chip    | Serial ports                             |
 +-----------+------------+------------------------------------------+
 | I2C       | on-chip    | I2C ports                                |
@@ -91,7 +93,7 @@ Default Zephyr Peripheral Mapping:
 - USB DP           : PA25
 - USB DM           : PA24
 - GPIO SPI CS      : PB17
-- GPIO LED0        : PB30
+- GPIO/PWM LED0    : PB30
 
 System Clock
 ============
@@ -108,6 +110,13 @@ this BSP. SERCOM3 is the default Zephyr console.
 - SERCOM0 9600 8n1
 - SERCOM1 115200 8n1
 - SERCOM3 115200 8n1 connected to the onboard Atmel Embedded Debugger (EDBG)
+
+PWM
+===
+
+The SAMD21 MCU has 3 TCC based PWM units with up to 4 outputs each and a period
+of 24 bits or 16 bits.  If :code:`CONFIG_PWM_SAM0_TCC` is enabled then LED0 is
+driven by TCC0 instead of by GPIO.
 
 SPI Port
 ========

--- a/boards/arm/atsamd21_xpro/pinmux.c
+++ b/boards/arm/atsamd21_xpro/pinmux.c
@@ -83,6 +83,11 @@ static int board_pinmux_init(struct device *dev)
 #warning Pin mapping may not be configured
 #endif
 
+#if (ATMEL_SAM0_DT_TCC_CHECK(0, atmel_sam0_tcc_pwm) && CONFIG_PWM_SAM0_TCC)
+	/* TCC0 on WO0=PB30 */
+	pinmux_pin_set(muxb, 30, PINMUX_FUNC_E);
+#endif
+
 #ifdef CONFIG_USB_DC_SAM0
 	/* USB DP on PA25, USB DM on PA24 */
 	pinmux_pin_set(muxa, 25, PINMUX_FUNC_G);


### PR DESCRIPTION
This commit adds the PWM LED definition in the board device tree for
the on-board LED connected to the pin PB30.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

~~Includes the commits from https://github.com/zephyrproject-rtos/zephyr/pull/26156; to be merged after the parent PR is merged.~~