### PR TITLE
net: lwm2m: Fix invalid logical and operator usage

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -776,7 +776,7 @@ static size_t get_objlnk(struct lwm2m_input_context *in,
 	size = get_s32(in, &value_s32);
 
 	value->obj_id = (value_s32 >> 16) & 0xFFFF;
-	value->obj_inst = value_s32 && 0xFFFF;
+	value->obj_inst = value_s32 & 0xFFFF;
 
 	return size;
 }


### PR DESCRIPTION
Binary and should be used instead.

Fixes #26356.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>