### PR TITLE
net: lwm2m: Prevent infinite loop in do_write_op_tlv function

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -992,6 +992,8 @@ int do_write_op_tlv(struct lwm2m_message *msg)
 			       msg->operation == LWM2M_OP_CREATE))) {
 				return ret;
 			}
+		} else {
+			return -ENOTSUP;
 		}
 	}
 


### PR DESCRIPTION
In case unsopported TLV type or malformed packet is received, the
`do_write_op_tlv` function will end up in an infinite loop. Prevent that
by returning an error code in case it does not recognize TLV type.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>