### PR TITLE
cmake: removing DTS_ROOTS in test samples as they serves no purpose

### DIFF
--- a/tests/lib/devicetree/api/CMakeLists.txt
+++ b/tests/lib/devicetree/api/CMakeLists.txt
@@ -2,7 +2,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-set(DTS_ROOTS ${CMAKE_CURRENT_LIST_DIR})
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(devicetree)
 

--- a/tests/lib/devicetree/legacy_api/CMakeLists.txt
+++ b/tests/lib/devicetree/legacy_api/CMakeLists.txt
@@ -2,7 +2,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-set(DTS_ROOTS ${CMAKE_CURRENT_LIST_DIR})
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(devicetree)
 


### PR DESCRIPTION
This commit is a cleanup in two test samples.

In both samples, the following line of code were found:

    set(DTS_ROOTS ${CMAKE_CURRENT_LIST_DIR})

Firstly, it is not needed to set `DTS_ROOT` in samples, as the sample
folder is always added to `DTS_ROOT`.
Secondly, the variable is named `DTS_ROOT`, but the samples used a
misspelled version `DTS_ROOTS`, which means that variable has never
had any effect.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>