### PR TITLE
drivers: pcie: Do not enable PCIe RC module shell for endpoint

### DIFF
--- a/drivers/pcie/Kconfig
+++ b/drivers/pcie/Kconfig
@@ -21,7 +21,7 @@ config PCIE_MSI
 config PCIE_SHELL
 	bool "Enable PCIe/new PCI Shell"
 	default y
-	depends on SHELL
+	depends on SHELL && !PCIE_ENDPOINT
 	help
 	  Enable commands for debugging PCI(e) using the built-in shell.
 


### PR DESCRIPTION
PCIe shell was enabled by default if shell is enabled in below commit:
commit ee985d81aa34 ("shell: enable modules by default if shell is
enabled").

However, this shell file has tests for PCIe RC, not applicable to EP.
So, should not be default enabled for PCIe EP.

If we add EP shell tests in future, they should be added under
drivers/pcie/endpoint/ directory.

Signed-off-by: Abhishek Shah <abhishek.shah@broadcom.com>