### PR TITLE
net: lwm2m: Protect send() calls with a mutex 

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -24,6 +24,7 @@
 #define ZEPHYR_INCLUDE_NET_LWM2M_H_
 
 #include <kernel.h>
+#include <sys/mutex.h>
 #include <net/coap.h>
 
 /**
@@ -69,6 +70,7 @@ struct lwm2m_ctx {
 	struct coap_pending pendings[CONFIG_LWM2M_ENGINE_MAX_PENDING];
 	struct coap_reply replies[CONFIG_LWM2M_ENGINE_MAX_REPLIES];
 	struct k_delayed_work retransmit_work;
+	struct sys_mutex send_lock;
 
 #if defined(CONFIG_LWM2M_DTLS_SUPPORT)
 	/** TLS tag is set by client as a reference used when the

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -4124,7 +4124,6 @@ static void socket_receive_loop(void)
 	ssize_t len;
 	int i;
 
-	from_addr_len = sizeof(from_addr);
 	while (1) {
 		/* wait for sockets */
 		if (sock_nfds < 1) {
@@ -4161,6 +4160,7 @@ static void socket_receive_loop(void)
 				continue;
 			}
 
+			from_addr_len = sizeof(from_addr);
 			sock_fds[i].revents = 0;
 			len = recvfrom(sock_ctx[i]->sock_fd, in_buf,
 				       sizeof(in_buf) - 1, 0,


### PR DESCRIPTION
Add mutex protection for `send()` calls on the same socket. Although LwM2M engine uses cooperative threads, the internal `send()` implementation might trigger context switch when it calls a kernel function, therefore resulting in `send()` call being entered from both the LwM2M thread and the retransmit work.

Additionally, fix a small issue spotted when running FOTA on the `lwm2m_client` sample with both, IPv4 and IPv6 enabled. In case one socket communicated over IPv4 and the other one over IPv6, the communication fails on IPv6  socket due to an insufficient `sockaddr` structure size provided.