### PR TITLE
samples: net: google_iot_mqtt: fix CONFIG_CLOUD_CLIENT_ID value

### DIFF
--- a/samples/net/cloud/google_iot_mqtt/prj.conf
+++ b/samples/net/cloud/google_iot_mqtt/prj.conf
@@ -60,7 +60,7 @@ CONFIG_MBEDTLS_USER_CONFIG_FILE="user-tls.conf"
 
 # Please see README.rst in this directory for instructions
 # on where to get the values for these config entries.
-CONFIG_CLOUD_CLIENT_ID="projects/<PROJECT_ID>/locations/<REGION>/registries/<REGISTRY_ID>/devices/"
+CONFIG_CLOUD_CLIENT_ID="projects/<PROJECT_ID>/locations/<REGION>/registries/<REGISTRY_ID>/devices/<DEVICE_ID>"
 CONFIG_CLOUD_AUDIENCE="<PROJECT_ID>"
 CONFIG_CLOUD_SUBSCRIBE_CONFIG="/devices/<DEVICE_ID>/config"
 CONFIG_CLOUD_PUBLISH_TOPIC="/devices/<DEVICE_ID>/state"


### PR DESCRIPTION
According to
https://cloud.google.com/iot/docs/how-tos/mqtt-bridge#configuring_mqtt_clients
MQTT client ID format.

Signed-off-by: Alexey Markevich <buhhunyx@gmail.com>