### PR TITLE
dts: arm: xilinx: move ZynqMP RPU RAM base address to avoid BTCM memory gap

### DIFF
--- a/dts/arm/xilinx/zynqmp.dtsi
+++ b/dts/arm/xilinx/zynqmp.dtsi
@@ -15,9 +15,9 @@
 			reg = <0xc0000000 DT_SIZE_M(32)>;
 		};
 
-		sram0: memory@0 {
+		sram0: memory@100000 {
 			compatible = "mmio-sram";
-			reg = <0 DT_SIZE_M(64)>;
+			reg = <0x00100000 DT_SIZE_M(64)>;
 		};
 
 		uart0: uart@ff000000 {


### PR DESCRIPTION
Moved the RAM base address, and therefore effectively the start of the binary's text section, to 0x0 + 1MB in order to prevent a part of the code ending up in the memory range 0x20000 to 0x30000, which is not available (access causes an exception) on actual ZynqMP RPU hardware if the RPU isn't running in Lock Step Mode (comp. Zynq UltraScale+ Device TRM, Xilinx doc. ref. UG1085, Figure 4-6). QEMU either doesn't care about this limitation or the simulated RPU is configured differently than the default configuration of an actual RPU as generated by the Vivado toolchain.

While the RAM address space starts at 0x0 for both APU and RPU (accessible RAM at this address is required for the exception vectors unless HIVECS is configured), the first 256 kB of the address space as seen by the RPUs are occupied by two Tightly Coupled Memory areas (ATCM and BTCM) which can be configured as either 2x 128 kB global or 2x 64 kB core-local with identical base addresses per core (comp. UG1085, Table 4-4). Therefore, the TCMs shouldn't be considered general purpose RAM.

Signed-off-by: Immo Birnbaum <Immo.Birnbaum@weidmueller.com>