### PR TITLE
Bluetooth: controller: Fix handling of ext adv HCI commands

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -1039,6 +1039,8 @@ struct bt_hci_cp_le_set_adv_set_random_addr {
 
 #define BT_HCI_LE_ADV_TX_POWER_NO_PREF 0x7F
 
+#define BT_HCI_LE_ADV_HANDLE_MAX       0xEF
+
 #define BT_HCI_OP_LE_SET_EXT_ADV_PARAM          BT_OP(BT_OGF_LE, 0x0036)
 struct bt_hci_cp_le_set_ext_adv_param {
 	uint8_t      handle;

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -94,6 +94,17 @@ config BT_CTLR_HCI_VS_BUILD_INFO
 	  character is required at the beginning to separate it from the
 	  already included information.
 
+config BT_CTLR_HCI_ADV_HANDLE_MAPPING
+	bool "Enable advertising set handle mapping between HCI and LL"
+	depends on BT_CTLR_ADV_EXT
+	default y if BT_HCI_RAW
+	help
+	  Enable mapping of advertising set handles between HCI and LL when
+	  using external host since it can use arbitrary numbers as set handles
+	  (as defined by Core specification) as opposed to LL which always uses
+	  zero-based numbering. When using with Zephyr host this option can be
+	  disabled to remove extra mapping logic.
+
 config BT_CTLR_DUP_FILTER_LEN
 	int "Number of addresses in the scan duplicate filter"
 	depends on BT_OBSERVER

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1653,7 +1653,7 @@ static void le_set_ext_adv_param(struct net_buf *buf, struct net_buf **evt)
 				   cmd->sid, cmd->scan_req_notify_enable);
 
 	rp = hci_cmd_complete(evt, sizeof(*rp));
-	rp->status = 0x00;
+	rp->status = status;
 	rp->tx_power = tx_pwr;
 }
 

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -129,6 +129,18 @@ static struct net_buf *cmd_status(uint8_t status)
 	return bt_hci_cmd_status_create(_opcode, status);
 }
 
+static struct net_buf *cmd_complete_status(uint8_t status)
+{
+	struct net_buf *buf;
+	struct bt_hci_evt_cc_status *ccst;
+
+	buf = bt_hci_cmd_complete_create(_opcode, sizeof(*ccst));
+	ccst = net_buf_add(buf, sizeof(*ccst));
+	ccst->status = status;
+
+	return buf;
+}
+
 static void *meta_evt(struct net_buf *buf, uint8_t subevt, uint8_t melen)
 {
 	struct bt_hci_evt_le_meta_event *me;
@@ -202,29 +214,23 @@ static int link_control_cmd_handle(uint16_t  ocf, struct net_buf *cmd,
 static void set_event_mask(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_set_event_mask *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 
 	event_mask = sys_get_le64(cmd->events);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = 0x00;
+	*evt = cmd_complete_status(0x00);
 }
 
 static void set_event_mask_page_2(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_set_event_mask_page_2 *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 
 	event_mask_page_2 = sys_get_le64(cmd->events_page_2);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = 0x00;
+	*evt = cmd_complete_status(0x00);
 }
 
 static void reset(struct net_buf *buf, struct net_buf **evt)
 {
-	struct bt_hci_evt_cc_status *ccst;
-
 #if defined(CONFIG_BT_HCI_MESH_EXT)
 	int i;
 
@@ -245,8 +251,7 @@ static void reset(struct net_buf *buf, struct net_buf **evt)
 
 	if (buf) {
 		ll_reset();
-		ccst = hci_cmd_complete(evt, sizeof(*ccst));
-		ccst->status = 0x00;
+		*evt = cmd_complete_status(0x00);
 	}
 
 #if defined(CONFIG_BT_CONN)
@@ -736,12 +741,10 @@ static int status_cmd_handle(uint16_t  ocf, struct net_buf *cmd,
 static void le_set_event_mask(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_set_event_mask *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 
 	le_event_mask = sys_get_le64(cmd->events);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = 0x00;
+	*evt = cmd_complete_status(0x00);
 }
 
 static void le_read_buffer_size(struct net_buf *buf, struct net_buf **evt)
@@ -771,13 +774,11 @@ static void le_read_local_features(struct net_buf *buf, struct net_buf **evt)
 static void le_set_random_address(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_random_address *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	status = ll_addr_set(1, &cmd->bdaddr.val[0]);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 #if defined(CONFIG_BT_CTLR_FILTER)
@@ -793,34 +794,31 @@ static void le_read_wl_size(struct net_buf *buf, struct net_buf **evt)
 
 static void le_clear_wl(struct net_buf *buf, struct net_buf **evt)
 {
-	struct bt_hci_evt_cc_status *ccst;
+	uint8_t status;
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = ll_wl_clear();
+	status = ll_wl_clear();
+
+	*evt = cmd_complete_status(status);
 }
 
 static void le_add_dev_to_wl(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_add_dev_to_wl *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	status = ll_wl_add(&cmd->addr);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_rem_dev_from_wl(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_rem_dev_from_wl *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	status = ll_wl_remove(&cmd->addr);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 #endif /* CONFIG_BT_CTLR_FILTER */
 
@@ -911,7 +909,6 @@ static void le_read_supp_states(struct net_buf *buf, struct net_buf **evt)
 static void le_set_adv_param(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_adv_param *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint16_t min_interval;
 	uint8_t status;
 
@@ -924,9 +921,7 @@ static void le_set_adv_param(struct net_buf *buf, struct net_buf **evt)
 		if ((min_interval > max_interval) ||
 		    (min_interval < 0x0020) ||
 		    (max_interval > 0x4000)) {
-			ccst = hci_cmd_complete(evt, sizeof(*ccst));
-			ccst->status = BT_HCI_ERR_INVALID_PARAM;
-
+			*evt = cmd_complete_status(BT_HCI_ERR_INVALID_PARAM);
 			return;
 		}
 	}
@@ -943,8 +938,7 @@ static void le_set_adv_param(struct net_buf *buf, struct net_buf **evt)
 				   cmd->filter_policy);
 #endif /* !CONFIG_BT_CTLR_ADV_EXT */
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_read_adv_chan_tx_power(struct net_buf *buf, struct net_buf **evt)
@@ -961,7 +955,6 @@ static void le_read_adv_chan_tx_power(struct net_buf *buf, struct net_buf **evt)
 static void le_set_adv_data(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_adv_data *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
@@ -970,14 +963,12 @@ static void le_set_adv_data(struct net_buf *buf, struct net_buf **evt)
 	status = ll_adv_data_set(cmd->len, &cmd->data[0]);
 #endif /* !CONFIG_BT_CTLR_ADV_EXT */
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_set_scan_rsp_data(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_scan_rsp_data *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
@@ -986,14 +977,12 @@ static void le_set_scan_rsp_data(struct net_buf *buf, struct net_buf **evt)
 	status = ll_adv_scan_rsp_set(cmd->len, &cmd->data[0]);
 #endif /* !CONFIG_BT_CTLR_ADV_EXT */
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_set_adv_enable(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_adv_enable *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT) || defined(CONFIG_BT_HCI_MESH_EXT)
@@ -1006,8 +995,7 @@ static void le_set_adv_enable(struct net_buf *buf, struct net_buf **evt)
 	status = ll_adv_enable(cmd->enable);
 #endif /* !CONFIG_BT_CTLR_ADV_EXT || !CONFIG_BT_HCI_MESH_EXT */
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 #endif /* CONFIG_BT_BROADCASTER */
 
@@ -1015,7 +1003,6 @@ static void le_set_adv_enable(struct net_buf *buf, struct net_buf **evt)
 static void le_set_scan_param(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_scan_param *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint16_t interval;
 	uint16_t window;
 	uint8_t status;
@@ -1026,14 +1013,12 @@ static void le_set_scan_param(struct net_buf *buf, struct net_buf **evt)
 	status = ll_scan_params_set(cmd->scan_type, interval, window,
 				    cmd->addr_type, cmd->filter_policy);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_set_scan_enable(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_scan_enable *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 #if CONFIG_BT_CTLR_DUP_FILTER_LEN > 0
@@ -1048,8 +1033,7 @@ static void le_set_scan_enable(struct net_buf *buf, struct net_buf **evt)
 
 	status = ll_scan_enable(cmd->enable);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 #endif /* CONFIG_BT_OBSERVER */
 
@@ -1101,25 +1085,21 @@ static void le_create_connection(struct net_buf *buf, struct net_buf **evt)
 static void le_create_conn_cancel(struct net_buf *buf, struct net_buf **evt,
 				  void **node_rx)
 {
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	status = ll_connect_disable(node_rx);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_set_host_chan_classif(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_host_chan_classif *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	status = ll_chm_update(&cmd->ch_map[0]);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
@@ -1309,7 +1289,6 @@ static void le_write_default_data_len(struct net_buf *buf,
 				      struct net_buf **evt)
 {
 	struct bt_hci_cp_le_write_default_data_len *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint16_t max_tx_octets;
 	uint16_t max_tx_time;
 	uint8_t status;
@@ -1318,8 +1297,7 @@ static void le_write_default_data_len(struct net_buf *buf,
 	max_tx_time = sys_le16_to_cpu(cmd->max_tx_time);
 	status = ll_length_default_set(max_tx_octets, max_tx_time);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_read_max_data_len(struct net_buf *buf, struct net_buf **evt)
@@ -1366,7 +1344,6 @@ static void le_read_phy(struct net_buf *buf, struct net_buf **evt)
 static void le_set_default_phy(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_default_phy *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	if (cmd->all_phys & BT_HCI_LE_PHY_TX_ANY) {
@@ -1378,8 +1355,7 @@ static void le_set_default_phy(struct net_buf *buf, struct net_buf **evt)
 
 	status = ll_phy_default_set(cmd->tx_phys, cmd->rx_phys);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_set_phy(struct net_buf *buf, struct net_buf **evt)
@@ -1440,34 +1416,30 @@ static void le_set_phy(struct net_buf *buf, struct net_buf **evt)
 static void le_add_dev_to_rl(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_add_dev_to_rl *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	status = ll_rl_add(&cmd->peer_id_addr, cmd->peer_irk, cmd->local_irk);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_rem_dev_from_rl(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_rem_dev_from_rl *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	status = ll_rl_remove(&cmd->peer_id_addr);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_clear_rl(struct net_buf *buf, struct net_buf **evt)
 {
-	struct bt_hci_evt_cc_status *ccst;
+	uint8_t status;
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
+	status = ll_rl_clear();
 
-	ccst->status = ll_rl_clear();
+	*evt = cmd_complete_status(status);
 }
 
 static void le_read_rl_size(struct net_buf *buf, struct net_buf **evt)
@@ -1507,35 +1479,31 @@ static void le_read_local_rpa(struct net_buf *buf, struct net_buf **evt)
 static void le_set_addr_res_enable(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_addr_res_enable *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
-	uint8_t enable = cmd->enable;
+	uint8_t status;
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = ll_rl_enable(enable);
+	status = ll_rl_enable(cmd->enable);
+
+	*evt = cmd_complete_status(status);
 }
 
 static void le_set_rpa_timeout(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_rpa_timeout *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint16_t timeout = sys_le16_to_cpu(cmd->rpa_timeout);
 
 	ll_rl_timeout_set(timeout);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = 0x00;
+	*evt = cmd_complete_status(0x00);
 }
 
 static void le_set_privacy_mode(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_privacy_mode *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	status = ll_priv_mode_set(&cmd->id_addr, cmd->mode);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
@@ -1552,26 +1520,22 @@ static void le_read_tx_power(struct net_buf *buf, struct net_buf **evt)
 static void le_rx_test(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_rx_test *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	status = ll_test_rx(cmd->rx_ch, 0x01, 0);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_tx_test(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_tx_test *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	status = ll_test_tx(cmd->tx_ch, cmd->test_data_len, cmd->pkt_payload,
 			    0x01);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_test_end(struct net_buf *buf, struct net_buf **evt)
@@ -1589,26 +1553,22 @@ static void le_test_end(struct net_buf *buf, struct net_buf **evt)
 static void le_enh_rx_test(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_enh_rx_test *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	status = ll_test_rx(cmd->rx_ch, cmd->phy, cmd->mod_index);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_enh_tx_test(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_enh_tx_test *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	status = ll_test_tx(cmd->tx_ch, cmd->test_data_len, cmd->pkt_payload,
 			    cmd->phy);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 #endif /* CONFIG_BT_CTLR_DTM_HCI */
 
@@ -1619,13 +1579,11 @@ static void le_set_adv_set_random_addr(struct net_buf *buf,
 				       struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_adv_set_random_addr *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	status = ll_adv_aux_random_addr_set(cmd->handle, &cmd->bdaddr.val[0]);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_set_ext_adv_param(struct net_buf *buf, struct net_buf **evt)
@@ -1660,33 +1618,28 @@ static void le_set_ext_adv_param(struct net_buf *buf, struct net_buf **evt)
 static void le_set_ext_adv_data(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_ext_adv_data *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	status = ll_adv_aux_ad_data_set(cmd->handle, cmd->op, cmd->frag_pref,
 					cmd->len, cmd->data);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_set_ext_scan_rsp_data(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_ext_scan_rsp_data *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	status = ll_adv_aux_sr_data_set(cmd->handle, cmd->op, cmd->frag_pref,
 					cmd->len, cmd->data);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_set_ext_adv_enable(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_ext_adv_enable *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	struct bt_hci_ext_adv_set *s;
 	uint8_t set_num;
 	uint8_t enable;
@@ -1695,15 +1648,12 @@ static void le_set_ext_adv_enable(struct net_buf *buf, struct net_buf **evt)
 	set_num = cmd->set_num;
 	if (!set_num) {
 		if (cmd->enable) {
-			ccst = hci_cmd_complete(evt, sizeof(*ccst));
-			ccst->status = BT_HCI_ERR_INVALID_PARAM;
-
+			*evt = cmd_complete_status(BT_HCI_ERR_INVALID_PARAM);
 			return;
 		}
 
 		/* FIXME: Implement disable of all advertising sets */
-		ccst = hci_cmd_complete(evt, sizeof(*ccst));
-		ccst->status = BT_HCI_ERR_UNSUPP_FEATURE_PARAM_VAL;
+		*evt = cmd_complete_status(BT_HCI_ERR_UNSUPP_FEATURE_PARAM_VAL);
 
 		return;
 	}
@@ -1728,8 +1678,7 @@ static void le_set_ext_adv_enable(struct net_buf *buf, struct net_buf **evt)
 		s++;
 	} while (--set_num);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_read_max_adv_data_len(struct net_buf *buf, struct net_buf **evt)
@@ -1758,31 +1707,26 @@ static void le_read_num_adv_sets(struct net_buf *buf, struct net_buf **evt)
 static void le_remove_adv_set(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_remove_adv_set *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	status = ll_adv_aux_set_remove(cmd->handle);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_clear_adv_sets(struct net_buf *buf, struct net_buf **evt)
 {
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	status = ll_adv_aux_set_clear();
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 #if defined(CONFIG_BT_CTLR_ADV_PERIODIC)
 static void le_set_per_adv_param(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_per_adv_param *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint16_t interval;
 	uint16_t flags;
 	uint8_t status;
@@ -1792,33 +1736,28 @@ static void le_set_per_adv_param(struct net_buf *buf, struct net_buf **evt)
 
 	status = ll_adv_sync_param_set(cmd->handle, interval, flags);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_set_per_adv_data(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_per_adv_data *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	status = ll_adv_sync_ad_data_set(cmd->handle, cmd->op, cmd->len,
 					 cmd->data);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_set_per_adv_enable(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_per_adv_enable *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 	status = ll_adv_sync_enable(cmd->handle, cmd->enable);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 #endif /* CONFIG_BT_CTLR_ADV_PERIODIC */
 #endif /* CONFIG_BT_BROADCASTER */
@@ -1827,7 +1766,6 @@ static void le_set_per_adv_enable(struct net_buf *buf, struct net_buf **evt)
 static void le_set_ext_scan_param(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_ext_scan_param *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	struct bt_hci_ext_scan_phy *p;
 	uint8_t own_addr_type;
 	uint8_t filter_policy;
@@ -1891,14 +1829,12 @@ static void le_set_ext_scan_param(struct net_buf *buf, struct net_buf **evt)
 		phys_bitmask &= (phys_bitmask - 1);
 	} while (phys_bitmask);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 
 static void le_set_ext_scan_enable(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_ext_scan_enable *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 	uint8_t status;
 
 #if CONFIG_BT_CTLR_DUP_FILTER_LEN > 0
@@ -1914,8 +1850,7 @@ static void le_set_ext_scan_enable(struct net_buf *buf, struct net_buf **evt)
 	/* FIXME: Add implementation to use duration and period parameters. */
 	status = ll_scan_enable(cmd->enable);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = status;
+	*evt = cmd_complete_status(status);
 }
 #endif /* CONFIG_BT_OBSERVER */
 
@@ -2375,12 +2310,10 @@ uint8_t bt_read_static_addr(struct bt_hci_vs_static_addr addrs[], uint8_t size)
 static void vs_write_bd_addr(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_vs_write_bd_addr *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
 
 	ll_addr_set(0, &cmd->bdaddr.val[0]);
 
-	ccst = hci_cmd_complete(evt, sizeof(*ccst));
-	ccst->status = 0x00;
+	*evt = cmd_complete_status(0x00);
 }
 
 static void vs_read_build_info(struct net_buf *buf, struct net_buf **evt)

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -20,7 +20,14 @@ uint8_t ll_addr_set(uint8_t addr_type, uint8_t const *const p_bdaddr);
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 #if defined(CONFIG_BT_HCI_RAW)
 int ll_adv_cmds_set(uint8_t adv_cmds);
-#endif
+int ll_adv_cmds_is_ext(void);
+#else
+static inline int ll_adv_cmds_is_ext(void)
+{
+	return 1;
+}
+#endif /* CONFIG_BT_HCI_RAW */
+
 uint8_t ll_adv_params_set(uint8_t handle, uint16_t evt_prop, uint32_t interval,
 		       uint8_t adv_type, uint8_t own_addr_type,
 		       uint8_t direct_addr_type, uint8_t const *const direct_addr,

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -17,6 +17,26 @@ void ll_reset(void);
 uint8_t *ll_addr_get(uint8_t addr_type, uint8_t *p_bdaddr);
 uint8_t ll_addr_set(uint8_t addr_type, uint8_t const *const p_bdaddr);
 
+#if defined(CONFIG_BT_CTLR_HCI_ADV_HANDLE_MAPPING)
+uint8_t ll_adv_set_by_hci_handle_get(uint8_t hci_handle, uint8_t *handle);
+uint8_t ll_adv_set_by_hci_handle_get_or_new(uint8_t hci_handle,
+					    uint8_t *handle);
+#else
+static inline uint8_t ll_adv_set_by_hci_handle_get(uint8_t hci_handle,
+						   uint8_t *handle)
+{
+	*handle = hci_handle;
+	return 0;
+}
+
+static inline uint8_t ll_adv_set_by_hci_handle_get_or_new(uint8_t hci_handle,
+							  uint8_t *handle)
+{
+	*handle = hci_handle;
+	return 0;
+}
+#endif
+
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 #if defined(CONFIG_BT_HCI_RAW)
 int ll_adv_cmds_set(uint8_t adv_cmds);

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -7,6 +7,10 @@
 
 #define LL_VERSION_NUMBER BT_HCI_VERSION_5_2
 
+#define LL_ADV_CMDS_ANY    0 /* Any advertising cmd/evt allowed */
+#define LL_ADV_CMDS_LEGACY 1 /* Only legacy advertising cmd/evt allowed */
+#define LL_ADV_CMDS_EXT    2 /* Only extended advertising cmd/evt allowed */
+
 int ll_init(struct k_sem *sem_rx);
 void ll_reset(void);
 
@@ -14,6 +18,9 @@ uint8_t *ll_addr_get(uint8_t addr_type, uint8_t *p_bdaddr);
 uint8_t ll_addr_set(uint8_t addr_type, uint8_t const *const p_bdaddr);
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
+#if defined(CONFIG_BT_HCI_RAW)
+int ll_adv_cmds_set(uint8_t adv_cmds);
+#endif
 uint8_t ll_adv_params_set(uint8_t handle, uint16_t evt_prop, uint32_t interval,
 		       uint8_t adv_type, uint8_t own_addr_type,
 		       uint8_t direct_addr_type, uint8_t const *const direct_addr,

--- a/subsys/bluetooth/controller/ll_sw/ll_addr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_addr.c
@@ -15,6 +15,7 @@
 #include "util/memq.h"
 
 #include "pdu.h"
+#include "ll.h"
 #include "lll.h"
 
 #include "lll_adv.h"
@@ -52,14 +53,10 @@ uint8_t *ll_addr_get(uint8_t addr_type, uint8_t *bdaddr)
 uint8_t ll_addr_set(uint8_t addr_type, uint8_t const *const bdaddr)
 {
 	if (IS_ENABLED(CONFIG_BT_BROADCASTER)) {
-		uint32_t status = ull_adv_is_enabled(0);
-
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-		if ((status & (ULL_ADV_ENABLED_BITMASK_ENABLED |
-			       ULL_ADV_ENABLED_BITMASK_EXTENDED)) ==
-		     ULL_ADV_ENABLED_BITMASK_ENABLED) {
+		if (ull_adv_is_enabled(0) && !ll_adv_cmds_is_ext()) {
 #else /* !CONFIG_BT_CTLR_ADV_EXT */
-		if (status) {
+		if (ull_adv_is_enabled(0)) {
 #endif /* !CONFIG_BT_CTLR_ADV_EXT */
 			return BT_HCI_ERR_CMD_DISALLOWED;
 		}

--- a/subsys/bluetooth/controller/ll_sw/ll_addr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_addr.c
@@ -49,7 +49,7 @@ uint8_t *ll_addr_get(uint8_t addr_type, uint8_t *bdaddr)
 	return pub_addr;
 }
 
-uint32_t ll_addr_set(uint8_t addr_type, uint8_t const *const bdaddr)
+uint8_t ll_addr_set(uint8_t addr_type, uint8_t const *const bdaddr)
 {
 	if (IS_ENABLED(CONFIG_BT_BROADCASTER)) {
 		uint32_t status = ull_adv_is_enabled(0);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -80,6 +80,29 @@ static struct ll_adv_set ll_adv[BT_CTLR_ADV_SET];
 static struct ticker_ext ll_adv_ticker_ext[BT_CTLR_ADV_SET];
 #endif /* CONFIG_BT_TICKER_EXT */
 
+#if defined(CONFIG_BT_HCI_RAW) && defined(CONFIG_BT_CTLR_ADV_EXT)
+static uint8_t ll_adv_cmds;
+
+int ll_adv_cmds_set(uint8_t adv_cmds)
+{
+	if (!ll_adv_cmds) {
+		ll_adv_cmds = adv_cmds;
+
+		if (adv_cmds == LL_ADV_CMDS_LEGACY) {
+			struct ll_adv_set *adv = &ll_adv[0];
+
+			adv->is_created = 1;
+		}
+	}
+
+	if (ll_adv_cmds != adv_cmds) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+#endif
+
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 uint8_t ll_adv_params_set(uint8_t handle, uint16_t evt_prop, uint32_t interval,
 		       uint8_t adv_type, uint8_t own_addr_type,
@@ -1219,6 +1242,11 @@ int ull_adv_reset(void)
 	int err;
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
+
+#if defined(CONFIG_BT_HCI_RAW)
+	ll_adv_cmds = LL_ADV_CMDS_ANY;
+#endif
+
 #if defined(CONFIG_BT_CTLR_ADV_AUX_SET)
 	if (CONFIG_BT_CTLR_ADV_AUX_SET > 0) {
 		err = ull_adv_aux_reset();

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -57,7 +57,7 @@ uint8_t ll_adv_aux_random_addr_set(uint8_t handle, uint8_t const *const addr)
 
 	adv = ull_adv_is_created_get(handle);
 	if (!adv) {
-		return BT_HCI_ERR_CMD_DISALLOWED;
+		return BT_HCI_ERR_UNKNOWN_ADV_IDENTIFIER;
 	}
 
 	/* TODO: Fail if connectable advertising is enabled */
@@ -117,7 +117,7 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 	/* Get the advertising set instance */
 	adv = ull_adv_is_created_get(handle);
 	if (!adv) {
-		return BT_HCI_ERR_CMD_DISALLOWED;
+		return BT_HCI_ERR_UNKNOWN_ADV_IDENTIFIER;
 	}
 
 	lll = &adv->lll;
@@ -517,7 +517,7 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 	/* Get the advertising set instance */
 	adv = ull_adv_is_created_get(handle);
 	if (!adv) {
-		return BT_HCI_ERR_CMD_DISALLOWED;
+		return BT_HCI_ERR_UNKNOWN_ADV_IDENTIFIER;
 	}
 
 	lll = &adv->lll;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -6,14 +6,8 @@
 
 #define ULL_ADV_RANDOM_DELAY HAL_TICKER_US_TO_TICKS(10000)
 
-/* Bitmask values used in is_created field of adv set */
-#define ULL_ADV_CREATED_BITMASK_CREATED  BIT(0)
-#define ULL_ADV_CREATED_BITMASK_EXTENDED BIT(1)
-
 /* Bitmask value returned by ull_adv_is_enabled() */
 #define ULL_ADV_ENABLED_BITMASK_ENABLED  BIT(0)
-#define ULL_ADV_ENABLED_BITMASK_CREATED  (ULL_ADV_CREATED_BITMASK_CREATED << 1)
-#define ULL_ADV_ENABLED_BITMASK_EXTENDED (ULL_ADV_CREATED_BITMASK_EXTENDED << 1)
 
 #if defined(CONFIG_BT_CTLR_ADV_SET)
 #define BT_CTLR_ADV_SET CONFIG_BT_CTLR_ADV_SET
@@ -34,8 +28,8 @@ uint16_t ull_adv_handle_get(struct ll_adv_set *adv);
 /* Return ll_adv_set context if enabled */
 struct ll_adv_set *ull_adv_is_enabled_get(uint8_t handle);
 
-/* Return flags, for now just: enabled */
-uint32_t ull_adv_is_enabled(uint8_t handle);
+/* Return enabled status of a set */
+int ull_adv_is_enabled(uint8_t handle);
 
 /* Return filter policy used */
 uint32_t ull_adv_filter_pol_get(uint8_t handle);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -67,7 +67,7 @@ uint8_t ll_adv_sync_param_set(uint8_t handle, uint16_t interval, uint16_t flags)
 
 	adv = ull_adv_is_created_get(handle);
 	if (!adv) {
-		return BT_HCI_ERR_CMD_DISALLOWED;
+		return BT_HCI_ERR_UNKNOWN_ADV_IDENTIFIER;
 	}
 
 	lll_sync = adv->lll.sync;
@@ -532,7 +532,7 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 
 	adv = ull_adv_is_created_get(handle);
 	if (!adv) {
-		return BT_HCI_ERR_CMD_DISALLOWED;
+		return BT_HCI_ERR_UNKNOWN_ADV_IDENTIFIER;
 	}
 
 	lll_sync = adv->lll.sync;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
@@ -18,7 +18,7 @@ struct ll_adv_set {
 	uint32_t interval;
 	uint8_t  rnd_addr[BDADDR_SIZE];
 	uint8_t  sid:4;
-	uint8_t  is_created:2;
+	uint8_t  is_created:1;
 	uint16_t event_counter;
 	uint16_t max_events;
 	uint32_t ticks_remain_duration;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
@@ -19,6 +19,9 @@ struct ll_adv_set {
 	uint8_t  rnd_addr[BDADDR_SIZE];
 	uint8_t  sid:4;
 	uint8_t  is_created:1;
+#if defined(CONFIG_BT_CTLR_HCI_ADV_HANDLE_MAPPING)
+	uint8_t  hci_handle;
+#endif
 	uint16_t event_counter;
 	uint16_t max_events;
 	uint32_t ticks_remain_duration;

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -589,8 +589,7 @@ void ull_filter_adv_pdu_update(struct ll_adv_set *adv, struct pdu_adv *pdu)
 	} else {
 		pdu->tx_addr = adv->own_addr_type & 0x1;
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-		if ((adv->is_created & ULL_ADV_CREATED_BITMASK_EXTENDED) &&
-		    pdu->tx_addr) {
+		if (ll_adv_cmds_is_ext() && pdu->tx_addr) {
 			ll_adv_aux_random_addr_get(adv, adva);
 		} else
 #endif /* CONFIG_BT_CTLR_ADV_EXT */

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -216,7 +216,7 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	}
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-	if (adv->is_created & ULL_ADV_CREATED_BITMASK_EXTENDED) {
+	if (ll_adv_cmds_is_ext()) {
 		/* Enqueue connection or CSA event */
 		ll_rx_put(link, rx);
 


### PR DESCRIPTION
These patches fix handling of ext adv HCI commands, specifically mixing legacy/extended commands and handling of advertising handle parameter.