### PR TITLE
samples: nrf: system_off: show how to disable deep sleep

### DIFF
--- a/samples/boards/nrf/system_off/README.rst
+++ b/samples/boards/nrf/system_off/README.rst
@@ -17,6 +17,11 @@ deep sleep on Nordic platforms.  The functional behavior is:
 
 A power monitor will be able to distinguish among these states.
 
+This sample also demonstrates the use of a :c:func:`SYS_INIT()` call to
+disable the deep sleep functionality before the kernel starts, which
+prevents the board from powering down during initialization of drivers
+that use unbounded delays to wait for startup.
+
 Requirements
 ************
 


### PR DESCRIPTION
Due to a long standing difference of requirements enabling deep sleep will by default cause any application that delays for an unbounded period to power down.  On Nordic doing so turns the system off.  Show how to prevent this from happening while still allowing deep sleep states to be available for the application's controlled use.

Workaround for #11908 until #21118 makes progress.