### PR TITLE
drivers: flash: at45: fix page-size writing wrap

### DIFF
--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -355,6 +355,7 @@ static int spi_flash_at45_write(struct device *dev, off_t offset,
 			break;
 		}
 
+		data    = (uint8_t *)data + chunk_len;
 		offset += chunk_len;
 		len    -= chunk_len;
 	}

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -429,7 +429,7 @@ static int perform_erase_op(struct device *dev, uint8_t opcode, off_t offset)
 static int spi_flash_at45_erase(struct device *dev, off_t offset, size_t size)
 {
 	const struct spi_flash_at45_config *cfg = get_dev_config(dev);
-	int err;
+	int err = 0;
 
 	if (!is_valid_request(offset, size, cfg->chip_size)) {
 		return -ENODEV;


### PR DESCRIPTION
When writing buffers larger then page-size, there is already a routine that checks wrap around and adjusts offsets, but this routine was missing incrementing the data pointer, which would results in rewriting the same page-size bytes over and over. This adds the proper increment code.

Also added a gcc non-initialized warning fix. 