### PR TITLE
actions: add labels for CAN and EEPROM driver areas

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,6 +10,14 @@
   - "drivers/adc/**/*"
 "area: Counter":
   - "drivers/counter/**/*"
+"area: CAN":
+  - "include/drivers/can.h"
+  - "include/canbus/*/**"
+  - "drivers/can/**/*"
+  - "subsys/canbus/*/**"
+"area: EEPROM":
+  - "include/drivers/eeprom.h"
+  - "drivers/eeprom/**/*"
 "area: Timer":
   - "drivers/timer/**/*"
 "area: I2S":


### PR DESCRIPTION
Add automatic labeling of the CAN and EEPROM driver areas.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>