### PR TITLE
boards: atsame54_xpro: Support driving on-board LED with PWM

### DIFF
--- a/boards/arm/atsame54_xpro/atsame54_xpro.dts
+++ b/boards/arm/atsame54_xpro/atsame54_xpro.dts
@@ -21,6 +21,7 @@
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;
+		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		i2c-0 = &sercom7;
 	};
@@ -33,6 +34,13 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&tcc0 2>;
+		};
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
@@ -40,6 +48,14 @@
 			label = "SW0";
 		};
 	};
+};
+
+&tcc0 {
+	status = "okay";
+	compatible = "atmel,sam0-tcc-pwm";
+	/* Gives a maximum period of 1.1s for 120MHz main clock */
+	prescaler = <8>;
+	#pwm-cells = <1>;
 };
 
 &sercom2 {

--- a/boards/arm/atsame54_xpro/atsame54_xpro.yaml
+++ b/boards/arm/atsame54_xpro/atsame54_xpro.yaml
@@ -12,6 +12,7 @@ toolchain:
   - xtools
 supported:
   - gpio
+  - pwm
   - spi
   - i2c
   - usb_device

--- a/boards/arm/atsame54_xpro/doc/index.rst
+++ b/boards/arm/atsame54_xpro/doc/index.rst
@@ -58,6 +58,8 @@ features:
 +-----------+------------+--------------------------------------+
 | GPIO      | on-chip    | I/O ports                            |
 +-----------+------------+--------------------------------------+
+| PWM       | on-chip    | Pulse Width Modulation               |
++-----------+------------+--------------------------------------+
 | USART     | on-chip    | Serial ports                         |
 +-----------+------------+--------------------------------------+
 | SPI       | on-chip    | Serial Peripheral Interface ports    |
@@ -88,7 +90,7 @@ Default Zephyr Peripheral Mapping:
 ----------------------------------
 - SERCOM2 USART TX : PB24
 - SERCOM2 USART RX : PB25
-- GPIO LED0        : PC18
+- GPIO/PWM LED0    : PC18
 - GPIO SW0         : PB31
 
 System Clock
@@ -104,6 +106,13 @@ The SAME54 MCU has 8 SERCOM based USARTs with one configured as USARTs in
 this BSP. SERCOM2 is the default Zephyr console.
 
 - SERCOM2 115200 8n1 connected to the onboard Atmel Embedded Debugger (EDBG)
+
+PWM
+===
+
+The SAME54 MCU has 5 TCC based PWM units with up to 6 outputs each and a period
+of 24 bits or 16 bits.  If :code:`CONFIG_PWM_SAM0_TCC` is enabled then LED0 is
+driven by TCC0 instead of by GPIO.
 
 SPI Port
 ========

--- a/boards/arm/atsame54_xpro/pinmux.c
+++ b/boards/arm/atsame54_xpro/pinmux.c
@@ -105,6 +105,11 @@ static int board_pinmux_init(struct device *dev)
 	pinmux_pin_set(muxd, 9, PINMUX_FUNC_C);
 #endif
 
+#if (ATMEL_SAM0_DT_TCC_CHECK(0, atmel_sam0_tcc_pwm) && CONFIG_PWM_SAM0_TCC)
+	/* TCC0 on WO2=PC18 */
+	pinmux_pin_set(muxc, 18, PINMUX_FUNC_F);
+#endif
+
 #ifdef CONFIG_USB_DC_SAM0
 	/* USB DP on PA25, USB DM on PA24 */
 	pinmux_pin_set(muxa, 25, PINMUX_FUNC_H);

--- a/dts/arm/atmel/samd5x.dtsi
+++ b/dts/arm/atmel/samd5x.dtsi
@@ -59,6 +59,12 @@
 		tc-2 = &tc2;
 		tc-4 = &tc4;
 		tc-6 = &tc6;
+
+		tcc-0 = &tcc0;
+		tcc-1 = &tcc1;
+		tcc-2 = &tcc2;
+		tcc-3 = &tcc3;
+		tcc-4 = &tcc4;
 	};
 
 	chosen {
@@ -374,6 +380,62 @@
 			label = "TIMER_6";
 			clocks = <&gclk 39>, <&mclk 0x20 5>;
 			clock-names = "GCLK", "MCLK";
+		};
+
+		tcc0: tcc@41016000 {
+			compatible = "atmel,sam0-tcc";
+			reg = <0x41016000 0x2000>;
+			interrupts = <85 0>, <86 0>, <87 0>, <88 0>, <89 0>,
+				     <90 0>, <91 0>;
+			label = "TCC_0";
+			clocks = <&gclk 25>, <&mclk 0x18 11>;
+			clock-names = "GCLK", "MCLK";
+			channels = <6>;
+			counter-size = <24>;
+		};
+
+		tcc1: tcc@41018000 {
+			compatible = "atmel,sam0-tcc";
+			reg = <0x41018000 0x2000>;
+			interrupts = <92 0>, <93 0>, <94 0>, <95 0>, <96 0>;
+			label = "TCC_1";
+			clocks = <&gclk 25>, <&mclk 0x18 12>;
+			clock-names = "GCLK", "MCLK";
+			channels = <4>;
+			counter-size = <24>;
+		};
+
+		tcc2: tcc@42000c00 {
+			compatible = "atmel,sam0-tcc";
+			reg = <0x42000c00 0x400>;
+			interrupts = <97 0>, <98 0>, <99 0>, <100 0>;
+			label = "TCC_2";
+			clocks = <&gclk 29>, <&mclk 0x1c 3>;
+			clock-names = "GCLK", "MCLK";
+			channels = <3>;
+			counter-size = <16>;
+		};
+
+		tcc3: tcc@42001000 {
+			compatible = "atmel,sam0-tcc";
+			reg = <0x42001000 0x400>;
+			interrupts = <101 0>, <102 0>, <103 0>;
+			label = "TCC_3";
+			clocks = <&gclk 29>, <&mclk 0x1c 4>;
+			clock-names = "GCLK", "MCLK";
+			channels = <2>;
+			counter-size = <16>;
+		};
+
+		tcc4: tcc@43001000 {
+			compatible = "atmel,sam0-tcc";
+			reg = <0x43001000 0x400>;
+			interrupts = <104 0>, <105 0>, <106 0>;
+			label = "TCC_4";
+			clocks = <&gclk 38>, <&mclk 0x20 4>;
+			clock-names = "GCLK", "MCLK";
+			channels = <2>;
+			counter-size = <16>;
 		};
 	};
 };


### PR DESCRIPTION
This commit adds the PWM LED definition in the board device tree for
the on-board LED connected to the pin PC18.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Verified working on `atsame54_xpro`.