### PR TITLE
drivers: ethernet: sam_gmac: Add SOC_FAMILY_SAM0 dependency

### DIFF
--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -5,7 +5,7 @@
 
 menuconfig ETH_SAM_GMAC
 	bool "Atmel SAM Ethernet driver"
-	depends on SOC_FAMILY_SAM
+	depends on SOC_FAMILY_SAM0 || SOC_FAMILY_SAM
 	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT
 	help
 	  Enable Atmel SAM MCU Family Ethernet driver.

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -339,11 +339,11 @@ static void test_vlan_setup(void)
 
 	/* One extra eth interface without vlan support */
 	zassert_equal(ud.eth_if_count, NET_VLAN_MAX_COUNT,
-		      "Invalid numer of VLANs %d vs %d\n",
+		      "Invalid number of VLANs %d vs %d\n",
 		      ud.eth_if_count, NET_VLAN_MAX_COUNT);
 
 	zassert_equal(ud.total_if_count, NET_VLAN_MAX_COUNT + 1 + 2,
-		      "Invalid numer of interfaces");
+		      "Invalid number of interfaces");
 
 	/* Put the extra non-vlan ethernet interface to last */
 	eth_interfaces[4] = extra_eth;


### PR DESCRIPTION
The Atmel GMAC Ethernet driver may be used by both the SAM series
(e.g. SAM E70) and SAM0 series (e.g. SAM E54) SoCs.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #25226 (see https://github.com/zephyrproject-rtos/zephyr/issues/25226#issuecomment-652787043)
Fixes #25231