### PR TITLE
mgmt: correct MPU_ALLOW_FLASH_WRITE selection

### DIFF
--- a/subsys/mgmt/Kconfig.mcumgr
+++ b/subsys/mgmt/Kconfig.mcumgr
@@ -116,7 +116,7 @@ endif
 menuconfig MCUMGR_CMD_IMG_MGMT
 	bool "Enable mcumgr handlers for image management"
 	select FLASH
-	select MPU_ALLOW_FLASH_WRITE if CPU_HAS_MPU
+	select MPU_ALLOW_FLASH_WRITE if ARM_MPU
 	select IMG_MANAGER
 	help
 	  Enables mcumgr handlers for image management


### PR DESCRIPTION
Select `MPU_ALLOW_FLASH_WRITE` when `ARM_MPU` is enabled, not `CPU_HAS_MPU`.
`MPU_ALLOW_FLASH_WRITE` is only defined as a symbol when `ARM_MPU` is
enabled. `ARM_MPU` is only defined when `CPU_HAS_MPU` is defined, so the
`CPU_HAS_MPU` dependency can be dropped.

This fixes a build error when `MCUMGR_CMD_IMG_MGMT` is enabled but
`ARM_MPU` is not.

It also brings the `MCUMGR_CMD_IMG_MGMT` config in line with other symbols that select `MPU_ALLOW_FLASH_WRITE`  (`BT_SETTINGS`, `MCUBOOT`).