### PR TITLE
dts: bindings: Add bindings for ARM M33F

### DIFF
--- a/dts/bindings/cpu/arm,cortex-m33f.yaml
+++ b/dts/bindings/cpu/arm,cortex-m33f.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: ARM Cortex-M33F CPU
+
+compatible: "arm,cortex-m33f"
+
+include: cpu.yaml


### PR DESCRIPTION
compatible = "arm,cortex-m33f" was already used for some time
(lpc55S6x, nrf9160...) without any related bindings.
Every works fine until you need to access one CPU node property
(eg. clock-frequency)...


Signed-off-by: Arnaud Mouiche <arnaud.mouiche@invoxia.com>