### PR TITLE
nrfjprog.py: Allow passing a glob to --snr

### DIFF
--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -8,6 +8,7 @@
 import os
 import shlex
 import sys
+from re import fullmatch, escape
 
 from runners.core import ZephyrBinaryRunner, RunnerCaps
 
@@ -45,7 +46,8 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
                             action='store_true',
                             help='use reset instead of pinreset')
         parser.add_argument('--snr', required=False,
-                            help='serial number of board to use')
+                            help="""Serial number of board to use.
+                            '*' matches one or more characters/digits.""")
         parser.add_argument('--tool-opt', default=[], action='append',
                             help='''Additional options for nrfjprog,
                             e.g. "--recover"''')
@@ -57,8 +59,7 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
                                     tool_opt=args.tool_opt)
 
     def ensure_snr(self):
-        if not self.snr:
-            self.snr = self.get_board_snr()
+        self.snr = self.get_board_snr(self.snr or "*")
 
     def get_boards(self):
         snrs = self.check_output(['nrfjprog', '--ids'])
@@ -74,7 +75,7 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
             raise RuntimeError('"nrfjprog --ids" returned 0; '
                                 'is a debugger already connected?')
 
-    def get_board_snr(self):
+    def get_board_snr(self, glob):
         # Use nrfjprog --ids to discover connected boards.
         #
         # If there's exactly one board connected, it's safe to assume
@@ -82,11 +83,17 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
         # multiple boards and we are connected to a terminal, in which
         # case use print() and input() to ask what the user wants.
 
-        snrs = self.get_boards()
+        re_glob = escape(glob).replace(r"\*", ".+")
+        snrs = [snr for snr in self.get_boards() if fullmatch(re_glob, snr)]
 
-        if len(snrs) == 1:
+        if len(snrs) == 0:
+            raise RuntimeError(
+                'There are no boards connected{}.'.format(
+                        f" matching '{glob}'" if glob != "*" else ""))
+        elif len(snrs) == 1:
             board_snr = snrs[0]
             self.verify_snr(board_snr)
+            print("Using board {}".format(board_snr))
             return board_snr
         elif not sys.stdin.isatty():
             raise RuntimeError(
@@ -96,7 +103,8 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
                 'Please specify a serial number on the command line.')
 
         snrs = sorted(snrs)
-        print('There are multiple boards connected.')
+        print('There are multiple boards connected{}.'.format(
+                        f" matching '{glob}'" if glob != "*" else ""))
         for i, snr in enumerate(snrs, 1):
             print('{}. {}'.format(i, snr))
 

--- a/scripts/west_commands/tests/test_nrfjprog.py
+++ b/scripts/west_commands/tests/test_nrfjprog.py
@@ -219,8 +219,8 @@ TEST_CASES = [(f, sr, snr, e)
               for snr in (TEST_OVR_SNR, None)
               for e in (False, True)]
 
-def get_board_snr_patch():
-    return TEST_DEF_SNR
+def get_board_snr_patch(glob):
+    return TEST_DEF_SNR if glob == "*" else TEST_OVR_SNR
 
 def require_patch(program):
     assert program == 'nrfjprog'
@@ -256,9 +256,9 @@ def test_nrfjprog_init(cc, get_snr, req, test_case, runner_config):
                                  expected_commands(*test_case)]
 
     if snr is None:
-        get_snr.assert_called_once_with()
+        get_snr.assert_called_once_with('*')
     else:
-        get_snr.assert_not_called()
+        get_snr.assert_called_once_with(snr)
 
 @pytest.mark.parametrize('test_case', TEST_CASES, ids=id_fn)
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
@@ -287,6 +287,6 @@ def test_nrfjprog_create(cc, get_snr, req, test_case, runner_config):
     assert cc.call_args_list == [call(x) for x in
                                  expected_commands(*test_case)]
     if snr is None:
-        get_snr.assert_called_once_with()
+        get_snr.assert_called_once_with('*')
     else:
-        get_snr.assert_not_called()
+        get_snr.assert_called_once_with(snr)


### PR DESCRIPTION
You can now do --snr 6*1* to achieve the same as --snr 683010000

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>