### PR TITLE
drivers: modem: Add debug log for matching direct cmds

### DIFF
--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -318,6 +318,8 @@ static void cmd_handler_process(struct modem_cmd_handler *cmd_handler,
 				/* Wait for more data */
 				break;
 			} else if (ret > 0) {
+				LOG_DBG("match direct cmd [%s] (ret:%d)",
+					log_strdup(cmd->cmd), ret);
 				data->rx_buf = net_buf_skip(data->rx_buf, ret);
 			}
 


### PR DESCRIPTION
Add a log message for when a direct cmd is matched to ease debugging.

Signed-off-by: Tobias Svehagen <tobias.svehagen@gmail.com>