### PR TITLE
xtensa: changing $ENV{ZEPHYR_SDK_INSTALL_DIR} to CMake var

### DIFF
--- a/soc/xtensa/intel_apl_adsp/common/bootloader/CMakeLists.txt
+++ b/soc/xtensa/intel_apl_adsp/common/bootloader/CMakeLists.txt
@@ -23,7 +23,7 @@ add_executable(bootloader
 
 add_dependencies(bootloader ${SYSCALL_LIST_H_TARGET})
 
-set(zephyr_sdk $ENV{ZEPHYR_SDK_INSTALL_DIR})
+set(zephyr_sdk ${ZEPHYR_SDK_INSTALL_DIR})
 
 target_include_directories(bootloader PUBLIC
   ./


### PR DESCRIPTION
ZEPHYR_SDK_INSTALL_DIR will be set as an internal CMake variable when
using the Zephyr SDK.
The Zephyr SDK zephyr/host-tools.cmake will ensure to set the CMake
ZEPHYR_SDK_INSTALL_DIR variable to the environment setting, or the
install directory in case the CMake package was used.

Users not using the environment variable will experience the following
error:
```
Linking C executable zephyr/.../bootloader/bootloader.elf
FAILED: zephyr/.../bootloader/bootloader.elf
<path>/xtensa-zephyr-elf/bin/ld: cannot find -lhal
```

This commit ensures code build correctly both when setting the
environment variable ZEPHYR_SDK_INSTALL_DIR, and when using Zephyr SDK
CMake `find_package(Zephyr-sdk)`

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>