### PR TITLE
drivers: usb: unify endpoint helper macros

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -312,7 +312,7 @@ static inline uint8_t nrfx_addr_to_ep(nrfx_usbd_ep_t ep)
 
 static inline bool ep_is_valid(const uint8_t ep)
 {
-	uint8_t ep_num = ep & ~USB_EP_DIR_MASK;
+	uint8_t ep_num = USB_EP_GET_IDX(ep);
 
 	if (NRF_USBD_EPIN_CHECK(ep)) {
 		if (unlikely(ep_num == NRF_USBD_EPISO_FIRST)) {

--- a/drivers/usb/device/usb_dc_sam0.c
+++ b/drivers/usb/device/usb_dc_sam0.c
@@ -343,9 +343,9 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data *const cfg)
 {
 	struct usb_sam0_data *data = usb_sam0_get_data();
 	UsbDevice *regs = &REGS->DEVICE;
-	uint8_t ep = USB_EP_GET_IDX(cfg->ep_addr);
-	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep];
-	UsbDeviceDescriptor *desc = &data->descriptors[ep];
+	uint8_t ep_idx = USB_EP_GET_IDX(cfg->ep_addr);
+	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep_idx];
+	UsbDeviceDescriptor *desc = &data->descriptors[ep_idx];
 	UsbDeviceDescBank *bank;
 	void *buf;
 	int type;
@@ -417,10 +417,10 @@ int usb_dc_ep_set_stall(const uint8_t ep)
 {
 	UsbDevice *regs = &REGS->DEVICE;
 	uint8_t for_in = USB_EP_GET_DIR(ep);
-	uint8_t ep_num = USB_EP_GET_IDX(ep);
-	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep_num];
+	uint8_t ep_idx = USB_EP_GET_IDX(ep);
+	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep_idx];
 
-	if (ep_num >= USB_NUM_ENDPOINTS) {
+	if (ep_idx >= USB_NUM_ENDPOINTS) {
 		LOG_ERR("endpoint index/address out of range");
 		return -1;
 	}
@@ -438,10 +438,10 @@ int usb_dc_ep_clear_stall(const uint8_t ep)
 {
 	UsbDevice *regs = &REGS->DEVICE;
 	uint8_t for_in = USB_EP_GET_DIR(ep);
-	uint8_t ep_num = USB_EP_GET_IDX(ep);
-	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep_num];
+	uint8_t ep_idx = USB_EP_GET_IDX(ep);
+	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep_idx];
 
-	if (ep_num >= USB_NUM_ENDPOINTS) {
+	if (ep_idx >= USB_NUM_ENDPOINTS) {
 		LOG_ERR("endpoint index/address out of range");
 		return -1;
 	}
@@ -459,10 +459,10 @@ int usb_dc_ep_is_stalled(const uint8_t ep, uint8_t *stalled)
 {
 	UsbDevice *regs = &REGS->DEVICE;
 	uint8_t for_in = USB_EP_GET_DIR(ep);
-	uint8_t ep_num = USB_EP_GET_IDX(ep);
-	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep_num];
+	uint8_t ep_idx = USB_EP_GET_IDX(ep);
+	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep_idx];
 
-	if (ep_num >= USB_NUM_ENDPOINTS) {
+	if (ep_idx >= USB_NUM_ENDPOINTS) {
 		LOG_ERR("endpoint index/address out of range");
 		return -1;
 	}
@@ -490,9 +490,9 @@ int usb_dc_ep_halt(uint8_t ep)
 /* Flush the selected endpoint */
 int usb_dc_ep_flush(uint8_t ep)
 {
-	uint8_t ep_num = USB_EP_GET_IDX(ep);
+	uint8_t ep_idx = USB_EP_GET_IDX(ep);
 
-	if (ep_num >= USB_NUM_ENDPOINTS) {
+	if (ep_idx >= USB_NUM_ENDPOINTS) {
 		LOG_ERR("endpoint index/address out of range");
 		return -1;
 	}
@@ -508,10 +508,10 @@ int usb_dc_ep_enable(const uint8_t ep)
 {
 	UsbDevice *regs = &REGS->DEVICE;
 	uint8_t for_in = USB_EP_GET_DIR(ep);
-	uint8_t ep_num = USB_EP_GET_IDX(ep);
-	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep_num];
+	uint8_t ep_idx = USB_EP_GET_IDX(ep);
+	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep_idx];
 
-	if (ep_num >= USB_NUM_ENDPOINTS) {
+	if (ep_idx >= USB_NUM_ENDPOINTS) {
 		LOG_ERR("endpoint index/address out of range");
 		return -EINVAL;
 	}
@@ -533,10 +533,10 @@ int usb_dc_ep_enable(const uint8_t ep)
 int usb_dc_ep_disable(uint8_t ep)
 {
 	UsbDevice *regs = &REGS->DEVICE;
-	uint8_t ep_num = USB_EP_GET_IDX(ep);
-	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep_num];
+	uint8_t ep_idx = USB_EP_GET_IDX(ep);
+	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep_idx];
 
-	if (ep_num >= USB_NUM_ENDPOINTS) {
+	if (ep_idx >= USB_NUM_ENDPOINTS) {
 		LOG_ERR("endpoint index/address out of range");
 		return -EINVAL;
 	}
@@ -553,14 +553,14 @@ int usb_dc_ep_write(uint8_t ep, const uint8_t *buf, uint32_t len, uint32_t *ret_
 {
 	struct usb_sam0_data *data = usb_sam0_get_data();
 	UsbDevice *regs = &REGS->DEVICE;
-	uint8_t ep_num = USB_EP_GET_IDX(ep);
-	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep_num];
-	UsbDeviceDescriptor *desc = &data->descriptors[ep_num];
+	uint8_t ep_idx = USB_EP_GET_IDX(ep);
+	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep_idx];
+	UsbDeviceDescriptor *desc = &data->descriptors[ep_idx];
 	uint32_t addr = desc->DeviceDescBank[1].ADDR.reg;
 	uint32_t capacity = usb_sam0_pcksize_bytes[
 			desc->DeviceDescBank[1].PCKSIZE.bit.SIZE];
 
-	if (ep_num >= USB_NUM_ENDPOINTS) {
+	if (ep_idx >= USB_NUM_ENDPOINTS) {
 		LOG_ERR("endpoint index/address out of range");
 		return -1;
 	}
@@ -596,15 +596,15 @@ int usb_dc_ep_read_ex(uint8_t ep, uint8_t *buf, uint32_t max_data_len,
 {
 	struct usb_sam0_data *data = usb_sam0_get_data();
 	UsbDevice *regs = &REGS->DEVICE;
-	uint8_t ep_num = USB_EP_GET_IDX(ep);
-	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep_num];
-	UsbDeviceDescriptor *desc = &data->descriptors[ep_num];
+	uint8_t ep_idx = USB_EP_GET_IDX(ep);
+	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep_idx];
+	UsbDeviceDescriptor *desc = &data->descriptors[ep_idx];
 	uint32_t addr = desc->DeviceDescBank[0].ADDR.reg;
 	uint32_t bytes = desc->DeviceDescBank[0].PCKSIZE.bit.BYTE_COUNT;
 	uint32_t take;
 	int remain;
 
-	if (ep_num >= USB_NUM_ENDPOINTS) {
+	if (ep_idx >= USB_NUM_ENDPOINTS) {
 		LOG_ERR("endpoint index/address out of range");
 		return -1;
 	}
@@ -664,10 +664,10 @@ int usb_dc_ep_read_continue(uint8_t ep)
 {
 	struct usb_sam0_data *data = usb_sam0_get_data();
 	UsbDevice *regs = &REGS->DEVICE;
-	uint8_t ep_num = USB_EP_GET_IDX(ep);
-	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep_num];
+	uint8_t ep_idx = USB_EP_GET_IDX(ep);
+	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep_idx];
 
-	if (ep_num >= USB_NUM_ENDPOINTS) {
+	if (ep_idx >= USB_NUM_ENDPOINTS) {
 		LOG_ERR("endpoint index/address out of range");
 		return -1;
 	}
@@ -682,14 +682,14 @@ int usb_dc_ep_set_callback(const uint8_t ep, const usb_dc_ep_callback cb)
 {
 	struct usb_sam0_data *data = usb_sam0_get_data();
 	uint8_t for_in = USB_EP_GET_DIR(ep);
-	uint8_t ep_num = USB_EP_GET_IDX(ep);
+	uint8_t ep_idx = USB_EP_GET_IDX(ep);
 
-	if (ep_num >= USB_NUM_ENDPOINTS) {
+	if (ep_idx >= USB_NUM_ENDPOINTS) {
 		LOG_ERR("endpoint index/address out of range");
 		return -1;
 	}
 
-	data->ep_cb[for_in ? 1 : 0][ep_num] = cb;
+	data->ep_cb[for_in ? 1 : 0][ep_idx] = cb;
 
 	return 0;
 }
@@ -699,11 +699,11 @@ int usb_dc_ep_mps(const uint8_t ep)
 	struct usb_sam0_data *data = usb_sam0_get_data();
 	UsbDevice *regs = &REGS->DEVICE;
 	uint8_t for_in = USB_EP_GET_DIR(ep);
-	uint8_t ep_num = USB_EP_GET_IDX(ep);
-	UsbDeviceDescriptor *desc = &data->descriptors[ep_num];
-	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep_num];
+	uint8_t ep_idx = USB_EP_GET_IDX(ep);
+	UsbDeviceDescriptor *desc = &data->descriptors[ep_idx];
+	UsbDeviceEndpoint *endpoint = &regs->DeviceEndpoint[ep_idx];
 
-	if (ep_num >= USB_NUM_ENDPOINTS) {
+	if (ep_idx >= USB_NUM_ENDPOINTS) {
 		LOG_ERR("endpoint index/address out of range");
 		return -1;
 	}

--- a/include/drivers/usb/usb_dc.h
+++ b/include/drivers/usb/usb_dc.h
@@ -26,6 +26,17 @@
 #define USB_EP_DIR_IN		0x80
 #define USB_EP_DIR_OUT		0x00
 
+/** Get endpoint index (number) from endpoint address */
+#define USB_EP_GET_IDX(ep) ((ep) & ~USB_EP_DIR_MASK)
+/** Get direction from endpoint address */
+#define USB_EP_GET_DIR(ep) ((ep) & USB_EP_DIR_MASK)
+/** Get endpoint address from endpoint index and direction */
+#define USB_EP_GET_ADDR(idx, dir) ((idx) | ((dir) & USB_EP_DIR_MASK))
+/** True if the endpoint is an IN endpoint */
+#define USB_EP_DIR_IS_IN(ep) (USB_EP_GET_DIR(ep) == USB_EP_DIR_IN)
+/** True if the endpoint is an OUT endpoint */
+#define USB_EP_DIR_IS_OUT(ep) (USB_EP_GET_DIR(ep) == USB_EP_DIR_OUT)
+
 /**
  * USB endpoint Transfer Type mask.
  */


### PR DESCRIPTION
Unify endpoint index and direction helper macros
across all usb device drivers.

ep_idx is common used designator for endpoint index,
rename ep_num to ep_idx in usb_dc_sam0 driver.