### PR TITLE
[Experimental] arch: arm: include cmsis.h under cpu/arch.h

### DIFF
--- a/include/arch/arm/aarch32/asm_inline_gcc.h
+++ b/include/arch/arm/aarch32/asm_inline_gcc.h
@@ -24,6 +24,8 @@
 
 #if defined(CONFIG_CPU_CORTEX_R)
 #include <arch/arm/aarch32/cortex_a_r/cpu.h>
+#elif defined(CONFIG_CPU_CORTEX_M)
+#include <arch/arm/aarch32/cortex_m/cmsis.h>
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Drivers/applications should not directly include cmsis.h header,
adding <arch/cpu.h> will take care of adding appropriate
cmsis header for given core. Header include order:

<arch/cpu.h> -> <arch/arm/arch.h> -> <arch/arm/cortex_m/cmsis.h> ->
<core_cm*.h>

Signed-off-by: Abhishek Shah <abhishek.shah@broadcom.com>