### PR TITLE
evolved steps towards devicetree-based device definitions and dependency representations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -748,6 +748,19 @@ if(CONFIG_GEN_ISR_TABLES)
   set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_SOURCE_FILES isr_tables.c)
 endif()
 
+# dev_handles.c is generated from ${ZEPHYR_PREBUILT_EXECUTABLE} by
+# gen_handles.py
+add_custom_command(
+  OUTPUT dev_handles.c
+  COMMAND
+  ${PYTHON_EXECUTABLE}
+  ${ZEPHYR_BASE}/scripts/gen_handles.py
+  --output-source dev_handles.c
+  --kernel $<TARGET_FILE:${ZEPHYR_PREBUILT_EXECUTABLE}>
+  DEPENDS ${ZEPHYR_PREBUILT_EXECUTABLE}
+  )
+set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_SOURCE_FILES dev_handles.c)
+
 if(CONFIG_CODE_DATA_RELOCATION)
   # @Intent: Linker script to relocate .text, data and .bss sections
   toolchain_ld_relocation()

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -479,6 +479,7 @@
 /scripts/kconfig/                         @ulfalizer
 /scripts/sanity_chk/expr_parser.py        @nashif
 /scripts/gen_app_partitions.py            @andrewboie
+/scripts/gen_handles.py                   @pabigot
 /scripts/get_maintainer.py                @nashif
 /scripts/dts/                             @mbolivar-nordic @galak
 /scripts/release/                         @nashif

--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -109,11 +109,14 @@ static struct onoff_manager *get_onoff_manager(const struct device *dev,
 	return &data->mgr[type];
 }
 
-DEVICE_DECLARE(clock_nrf);
+
+DEVICE_DT_DECLARE(DT_NODELABEL(clock));
+
+#define CLOCK_DEVICE DEVICE_DT_GET(DT_NODELABEL(clock))
 
 struct onoff_manager *z_nrf_clock_control_get_onoff(clock_control_subsys_t sys)
 {
-	return get_onoff_manager(DEVICE_GET(clock_nrf),
+	return get_onoff_manager(CLOCK_DEVICE,
 				(enum clock_control_nrf_type)sys);
 }
 
@@ -249,7 +252,7 @@ static void hfclk192m_stop(void)
 
 static uint32_t *get_hf_flags(void)
 {
-	struct nrf_clock_control_data *data = DEVICE_GET(clock_nrf)->data;
+	struct nrf_clock_control_data *data = CLOCK_DEVICE->data;
 
 	return &data->subsys[CLOCK_CONTROL_NRF_TYPE_HFCLK].flags;
 }
@@ -276,7 +279,7 @@ static void generic_hfclk_start(void)
 
 	if (already_started) {
 		/* Clock already started by z_nrf_clock_bt_ctlr_hf_request */
-		clkstarted_handle(DEVICE_GET(clock_nrf),
+		clkstarted_handle(CLOCK_DEVICE,
 				  CLOCK_CONTROL_NRF_TYPE_HFCLK);
 		return;
 	}
@@ -394,7 +397,7 @@ static int api_blocking_start(const struct device *dev,
 
 static clock_control_subsys_t get_subsys(struct onoff_manager *mgr)
 {
-	struct nrf_clock_control_data *data = DEVICE_GET(clock_nrf)->data;
+	struct nrf_clock_control_data *data = CLOCK_DEVICE->data;
 	size_t offset = (size_t)(mgr - data->mgr);
 
 	return (clock_control_subsys_t)offset;
@@ -405,7 +408,7 @@ static void onoff_stop(struct onoff_manager *mgr,
 {
 	int res;
 
-	res = stop(DEVICE_GET(clock_nrf), get_subsys(mgr), CTX_ONOFF);
+	res = stop(CLOCK_DEVICE, get_subsys(mgr), CTX_ONOFF);
 	notify(mgr, res);
 }
 
@@ -425,7 +428,7 @@ static void onoff_start(struct onoff_manager *mgr,
 {
 	int err;
 
-	err = async_start(DEVICE_GET(clock_nrf), get_subsys(mgr),
+	err = async_start(CLOCK_DEVICE, get_subsys(mgr),
 			  onoff_started_callback, notify, CTX_ONOFF);
 	if (err < 0) {
 		notify(mgr, err);
@@ -528,7 +531,7 @@ void z_nrf_clock_control_lf_on(enum nrf_lfclk_start_mode start_mode)
 	if (atomic_set(&on, 1) == 0) {
 		int err;
 		struct onoff_manager *mgr =
-				get_onoff_manager(DEVICE_GET(clock_nrf),
+				get_onoff_manager(CLOCK_DEVICE,
 						  CLOCK_CONTROL_NRF_TYPE_LFCLK);
 
 		sys_notify_init_spinwait(&cli.notify);
@@ -557,7 +560,7 @@ void z_nrf_clock_control_lf_on(enum nrf_lfclk_start_mode start_mode)
 
 static void clock_event_handler(nrfx_clock_evt_type_t event)
 {
-	const struct device *dev = DEVICE_GET(clock_nrf);
+	const struct device *dev = CLOCK_DEVICE;
 
 	switch (event) {
 	case NRFX_CLOCK_EVT_HFCLK_STARTED:
@@ -666,10 +669,10 @@ static const struct nrf_clock_control_config config = {
 	}
 };
 
-DEVICE_AND_API_INIT(clock_nrf, DT_INST_LABEL(0),
-		    clk_init, &data, &config, PRE_KERNEL_1,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-		    &clock_control_api);
+DEVICE_DT_DEFINE(DT_NODELABEL(clock), clk_init, device_pm_control_nop,
+		 &data, &config,
+		 PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		 &clock_control_api);
 
 static int cmd_status(const struct shell *shell, size_t argc, char **argv)
 {
@@ -677,10 +680,10 @@ static int cmd_status(const struct shell *shell, size_t argc, char **argv)
 	bool hf_status;
 	bool lf_status = nrfx_clock_is_running(NRF_CLOCK_DOMAIN_LFCLK, NULL);
 	struct onoff_manager *hf_mgr =
-				get_onoff_manager(DEVICE_GET(clock_nrf),
+				get_onoff_manager(CLOCK_DEVICE,
 						  CLOCK_CONTROL_NRF_TYPE_HFCLK);
 	struct onoff_manager *lf_mgr =
-				get_onoff_manager(DEVICE_GET(clock_nrf),
+				get_onoff_manager(CLOCK_DEVICE,
 						  CLOCK_CONTROL_NRF_TYPE_LFCLK);
 	uint32_t abs_start, abs_stop;
 	int key = irq_lock();

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -850,7 +850,7 @@ static const struct qspi_nor_config flash_id = {
 	.size = INST_0_BYTES,
 };
 
-DEVICE_AND_API_INIT(qspi_flash_memory, DT_INST_LABEL(0),
-		    &qspi_nor_init, &qspi_nor_memory_data,
-		    &flash_id, POST_KERNEL, CONFIG_NORDIC_QSPI_NOR_INIT_PRIORITY,
-		    &qspi_nor_api);
+DEVICE_DT_DEFINE(DT_DRV_INST(0), &qspi_nor_init, device_pm_control_nop,
+		 &qspi_nor_memory_data, &flash_id,
+		 POST_KERNEL, CONFIG_NORDIC_QSPI_NOR_INIT_PRIORITY,
+		 &qspi_nor_api);

--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -281,9 +281,10 @@ static int nrf_flash_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(nrf_flash, DT_INST_LABEL(0), nrf_flash_init,
-		NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-		&flash_nrf_api);
+DEVICE_DT_DEFINE(DT_DRV_INST(0), nrf_flash_init, device_pm_control_nop,
+		 NULL, NULL,
+		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		 &flash_nrf_api);
 
 #ifndef CONFIG_SOC_FLASH_NRF_RADIO_SYNC_NONE
 

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -1039,7 +1039,7 @@ static const struct spi_nor_config spi_nor_config_0 = {
 
 static struct spi_nor_data spi_nor_data_0;
 
-DEVICE_AND_API_INIT(spi_flash_memory, DT_INST_LABEL(0),
-		    &spi_nor_init, &spi_nor_data_0, &spi_nor_config_0,
-		    POST_KERNEL, CONFIG_SPI_NOR_INIT_PRIORITY,
-		    &spi_nor_api);
+DEVICE_DT_DEFINE(DT_DRV_INST(0), &spi_nor_init, device_pm_control_nop,
+		 &spi_nor_data_0, &spi_nor_config_0,
+		 POST_KERNEL, CONFIG_SPI_NOR_INIT_PRIORITY,
+		 &spi_nor_api);

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -666,7 +666,7 @@ static struct sx1509b_drv_data sx1509b_drvdata = {
 	.lock = Z_SEM_INITIALIZER(sx1509b_drvdata.lock, 1, 1),
 };
 
-DEVICE_AND_API_INIT(sx1509b, DT_INST_LABEL(0),
-		    sx1509b_init, &sx1509b_drvdata, &sx1509b_cfg,
-		    POST_KERNEL, CONFIG_GPIO_SX1509B_INIT_PRIORITY,
-		    &api_table);
+DEVICE_DT_DEFINE(DT_DRV_INST(0), sx1509b_init, device_pm_control_nop,
+		 &sx1509b_drvdata, &sx1509b_cfg,
+		 POST_KERNEL, CONFIG_GPIO_SX1509B_INIT_PRIORITY,
+		 &api_table);

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -296,8 +296,7 @@ static int twi_nrfx_pm_control(const struct device *dev,
 			.frequency = I2C_FREQUENCY(idx),		       \
 		}							       \
 	};								       \
-	DEVICE_DEFINE(twi_##idx,					       \
-		      DT_LABEL(I2C(idx)),				       \
+	DEVICE_DT_DEFINE(I2C(idx),					       \
 		      twi_##idx##_init,					       \
 		      twi_nrfx_pm_control,				       \
 		      &twi_##idx##_data,				       \

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -349,8 +349,7 @@ static int twim_nrfx_pm_control(const struct device *dev,
 			.frequency = I2C_FREQUENCY(idx),		       \
 		}							       \
 	};								       \
-	DEVICE_DEFINE(twim_##idx,					       \
-		      DT_LABEL(I2C(idx)),				       \
+	DEVICE_DT_DEFINE(I2C(idx),					       \
 		      twim_##idx##_init,				       \
 		      twim_nrfx_pm_control,				       \
 		      &twim_##idx##_data,				       \

--- a/drivers/regulator/regulator_fixed.c
+++ b/drivers/regulator/regulator_fixed.c
@@ -383,10 +383,9 @@ static const struct driver_config regulator_##id##_cfg = { \
 \
 static struct REG_DATA_TAG(id) regulator_##id##_data; \
 \
-DEVICE_AND_API_INIT(regulator_##id, DT_INST_LABEL(id), \
-		    REG_INIT(id), \
-		    &regulator_##id##_data, &regulator_##id##_cfg, \
-		    POST_KERNEL, CONFIG_REGULATOR_FIXED_INIT_PRIORITY, \
-		    &REG_API(id));
+DEVICE_DT_DEFINE(DT_DRV_INST(id), REG_INIT(id), device_pm_control_nop, \
+		 &regulator_##id##_data, &regulator_##id##_cfg,	       \
+		 POST_KERNEL, CONFIG_REGULATOR_FIXED_INIT_PRIORITY,    \
+		 &REG_API(id));
 
 DT_INST_FOREACH_STATUS_OKAY(REGULATOR_DEVICE)

--- a/drivers/sensor/ccs811/ccs811.c
+++ b/drivers/sensor/ccs811/ccs811.c
@@ -593,6 +593,7 @@ out:
 
 static struct ccs811_data ccs811_driver;
 
-DEVICE_AND_API_INIT(ccs811, DT_INST_LABEL(0), ccs811_init, &ccs811_driver,
-		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
-		    &ccs811_driver_api);
+DEVICE_DT_DEFINE(DT_DRV_INST(0), ccs811_init, device_pm_control_nop,
+		 &ccs811_driver, NULL,
+		 POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
+		 &ccs811_driver_api);

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -52,7 +52,7 @@ BUILD_ASSERT((PROP(hw_flow_control) && HW_FLOW_CONTROL_AVAILABLE) ||
 
 static NRF_UART_Type *const uart0_addr = (NRF_UART_Type *)DT_INST_REG_ADDR(0);
 
-DEVICE_DECLARE(uart_nrfx_uart0);
+DEVICE_DT_DECLARE(DT_DRV_INST(0));
 
 /* Device data structure */
 struct uart_nrfx_data {
@@ -755,7 +755,7 @@ void uart_nrfx_isr(const struct device *uart)
 
 static void rx_timeout(struct k_timer *timer)
 {
-	rx_rdy_evt(DEVICE_GET(uart_nrfx_uart0));
+	rx_rdy_evt(DEVICE_DT_GET(DT_DRV_INST(0)));
 }
 
 #if HW_FLOW_CONTROL_AVAILABLE
@@ -772,7 +772,7 @@ static void tx_timeout(struct k_timer *timer)
 	evt.data.tx.len = uart0_cb.tx_buffer_length;
 	uart0_cb.tx_buffer_length = 0;
 	uart0_cb.tx_counter = 0;
-	user_callback(DEVICE_GET(uart_nrfx_uart0), &evt);
+	user_callback(DEVICE_DT_GET(DT_DRV_INST(0)), &evt);
 }
 #endif
 
@@ -1042,7 +1042,7 @@ static int uart_nrfx_init(const struct device *dev)
 	IRQ_CONNECT(IRQN,
 		    IRQ_PRIO,
 		    uart_nrfx_isr,
-		    DEVICE_GET(uart_nrfx_uart0),
+		    DEVICE_DT_GET(DT_DRV_INST(0)),
 		    0);
 	irq_enable(IRQN);
 #endif
@@ -1195,8 +1195,7 @@ static struct uart_nrfx_data uart_nrfx_uart0_data = {
 	}
 };
 
-DEVICE_DEFINE(uart_nrfx_uart0,
-	      DT_INST_LABEL(0),
+DEVICE_DT_DEFINE(DT_DRV_INST(0),
 	      uart_nrfx_init,
 	      uart_nrfx_pm_control,
 	      &uart_nrfx_uart0_data,

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1617,7 +1617,7 @@ static int uarte_nrfx_pm_control(const struct device *dev,
 #define UARTE_IRQ_CONFIGURE(idx, isr_handler)				       \
 	do {								       \
 		IRQ_CONNECT(DT_IRQN(UARTE(idx)), DT_IRQ(UARTE(idx), priority), \
-			    isr_handler, DEVICE_GET(uart_nrfx_uarte##idx), 0); \
+			    isr_handler, DEVICE_DT_GET(UARTE(idx)), 0); \
 		irq_enable(DT_IRQN(UARTE(idx)));			       \
 	} while (0)
 
@@ -1630,7 +1630,7 @@ static int uarte_nrfx_pm_control(const struct device *dev,
 
 #define UART_NRF_UARTE_DEVICE(idx)					       \
 	HWFC_CONFIG_CHECK(idx);						       \
-	DEVICE_DECLARE(uart_nrfx_uarte##idx);				       \
+	DEVICE_DT_DECLARE(UARTE(idx));					       \
 	UARTE_INT_DRIVEN(idx);						       \
 	UARTE_ASYNC(idx);						       \
 	static struct uarte_nrfx_data uarte_##idx##_data = {		       \
@@ -1667,8 +1667,7 @@ static int uarte_nrfx_pm_control(const struct device *dev,
 			&init_config,					       \
 			IS_ENABLED(CONFIG_UART_##idx##_INTERRUPT_DRIVEN));     \
 	}								       \
-	DEVICE_DEFINE(uart_nrfx_uarte##idx,				       \
-		      DT_LABEL(UARTE(idx)),				       \
+	DEVICE_DT_DEFINE(UARTE(idx),					       \
 		      uarte_##idx##_init,				       \
 		      uarte_nrfx_pm_control,				       \
 		      &uarte_##idx##_data,				       \

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -383,7 +383,7 @@ static int spi_nrfx_pm_control(const struct device *dev,
 			.miso_pull = SPI_NRFX_MISO_PULL(idx),		       \
 		}							       \
 	};								       \
-	DEVICE_DEFINE(spi_##idx, DT_LABEL(SPI(idx)),			       \
+	DEVICE_DT_DEFINE(SPI(idx),					       \
 		      spi_##idx##_init,					       \
 		      spi_nrfx_pm_control,				       \
 		      &spi_##idx##_data,				       \

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -436,8 +436,7 @@ static int spim_nrfx_pm_control(const struct device *dev,
 			SPI_NRFX_SPIM_EXTENDED_CONFIG(idx)		       \
 		}							       \
 	};								       \
-	DEVICE_DEFINE(spi_##idx,					       \
-		      SPIM_PROP(idx, label),				       \
+	DEVICE_DT_DEFINE(SPIM(idx),					       \
 		      spi_##idx##_init,					       \
 		      spim_nrfx_pm_control,				       \
 		      &spi_##idx##_data,				       \

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -49,5 +49,7 @@ void __weak sys_clock_disable(void)
 {
 }
 
-SYS_DEVICE_DEFINE("sys_clock", z_clock_driver_init, z_clock_device_ctrl,
-		PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);
+DT_SYS_DEVICE_DEFINE(DEVICE_HANDLE_SYSCLOCK, "sys_clock",
+		     z_clock_driver_init, z_clock_device_ctrl,
+		     PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY,
+		     DEVICE_HANDLE_SYSCLOCK_BASIS);

--- a/include/device.h
+++ b/include/device.h
@@ -139,6 +139,96 @@ extern "C" {
 			    (&_CONCAT(__device_, dev_name)), level, prio)
 
 /**
+ * @def DEVICE_DT_DEFINE
+ *
+ * @brief Like DEVICE_DEFINE but taking metadata from a devicetree node
+ *
+ * @details This macro defines a device object that is automatically
+ * configured by the kernel during system initialization.  The device
+ * object name is derived from the node identifier (encoding the
+ * devicetree path to the node), and the driver name is from the @p
+ * label property of the devicetree node.
+ *
+ * Device objects defined through this API can be obtained directly
+ * through DEVICE_DT_GET() using @p node_id.
+ *
+ * @param node_id The devicetree node identifier.
+ *
+ * @param init_fn Address to the init function of the driver.
+ *
+ * @param pm_control_fn Pointer to device_pm_control function.
+ * Can be empty function (device_pm_control_nop) if not implemented.
+ *
+ * @param data_ptr Pointer to the device's private data.
+ *
+ * @param cfg_ptr The address to the structure containing the
+ * configuration information for this instance of the driver.
+ *
+ * @param level The initialization level.  See SYS_INIT() for
+ * details.
+ *
+ * @param prio Priority within the selected initialization level. See
+ * SYS_INIT() for details.
+ *
+ * @param api_ptr Provides an initial pointer to the API function struct
+ * used by the driver. Can be NULL.
+ */
+#define DEVICE_DT_DEFINE(node_id, init_fn, pm_control_fn,		\
+			 data_ptr, cfg_ptr, level, prio, api_ptr)	\
+	DEVICE_DEFINE(node_id, DT_LABEL(node_id), init_fn, pm_control_fn, \
+		      data_ptr, cfg_ptr, level, prio, api_ptr)
+
+/**
+ * @def DEVICE_DT_NAME_GET
+ *
+ * @brief The name of the struct device object for @p node_id
+ *
+ * @details Return the full name of a device object symbol created by
+ * DEVICE_DT_DEFINE(), using the dev_name derived from @p node_id
+ *
+ * It is meant to be used for declaring extern symbols pointing on device
+ * objects before using the DEVICE_DT_GET macro to get the device object.
+ *
+ * @param node_id The same as node_id provided to DEVICE_DT_DEFINE()
+ *
+ * @return The expanded name of the device object created by
+ * DEVICE_DT_DEFINE()
+ */
+#define DEVICE_DT_NAME_GET(node_id) DEVICE_NAME_GET(node_id)
+
+/**
+ * @def DEVICE_DT_GET
+ *
+ * @brief Obtain a pointer to a device object by @p node_id
+ *
+ * @details Return the address of a device object created by
+ * DEVICE_DT_INIT(), using the dev_name derived from @p node_id
+ *
+ * @param node_id The same as node_id provided to DEVICE_DT_DEFINE()
+ *
+ * @return A pointer to the device object created by DEVICE_DT_DEFINE()
+ */
+#define DEVICE_DT_GET(node_id) (&DEVICE_DT_NAME_GET(node_id))
+
+/** @def DEVICE_DT_DECLARE
+ *
+ * @brief Declare a device object associated with @p node_id
+ *
+ * This macro can be used at the top-level to declare a device, such
+ * that DEVICE_DT_GET() may be used before the full declaration in
+ * DEVICE_DT_DEFINE().
+ *
+ * This is often useful when configuring interrupts statically in a
+ * device's init or per-instance config function, as the init function
+ * itself is required by DEVICE_DT_DEFINE() and use of DEVICE_DT_GET()
+ * inside it creates a circular dependency.
+ *
+ * @param node_id The same as node_id provided to DEVICE_DT_DEFINE()
+ */
+#define DEVICE_DT_DECLARE(node_id)				\
+	static const struct device DEVICE_DT_NAME_GET(node_id)
+
+/**
  * @def DEVICE_GET
  *
  * @brief Obtain a pointer to a device object by name

--- a/include/device.h
+++ b/include/device.h
@@ -125,18 +125,9 @@ extern "C" {
  */
 #define DEVICE_DEFINE(dev_name, drv_name, init_fn, pm_control_fn,	\
 		      data_ptr, cfg_ptr, level, prio, api_ptr)		\
-	Z_DEVICE_DEFINE_PM(dev_name)					\
-	static const Z_DECL_ALIGN(struct device)			\
-		DEVICE_NAME_GET(dev_name) __used			\
-	__attribute__((__section__(".device_" #level STRINGIFY(prio)))) = { \
-		.name = drv_name,					\
-		.config = (cfg_ptr),					\
-		.api = (api_ptr),					\
-		.data = (data_ptr),					\
-		Z_DEVICE_DEFINE_PM_INIT(dev_name, pm_control_fn)	\
-	};								\
-	Z_INIT_ENTRY_DEFINE(_CONCAT(__device_, dev_name), init_fn,	\
-			    (&_CONCAT(__device_, dev_name)), level, prio)
+	Z_DEVICE_DEFINE(DT_INVALID_NODE, dev_name, drv_name, init_fn,	\
+			pm_control_fn,					\
+			data_ptr, cfg_ptr, level, prio, api_ptr)
 
 /**
  * @def DEVICE_DT_DEFINE
@@ -175,8 +166,9 @@ extern "C" {
  */
 #define DEVICE_DT_DEFINE(node_id, init_fn, pm_control_fn,		\
 			 data_ptr, cfg_ptr, level, prio, api_ptr)	\
-	DEVICE_DEFINE(node_id, DT_LABEL(node_id), init_fn, pm_control_fn, \
-		      data_ptr, cfg_ptr, level, prio, api_ptr)
+	Z_DEVICE_DEFINE(node_id, node_id, DT_LABEL(node_id), init_fn,	\
+			pm_control_fn,					\
+			data_ptr, cfg_ptr, level, prio, api_ptr)
 
 /**
  * @def DEVICE_DT_NAME_GET
@@ -663,6 +655,21 @@ static inline int device_pm_put_sync(const struct device *dev) { return -ENOTSUP
 /**
  * @}
  */
+
+#define Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn, pm_control_fn, \
+			data_ptr, cfg_ptr, level, prio, api_ptr)	\
+	Z_DEVICE_DEFINE_PM(dev_name)					\
+	static const Z_DECL_ALIGN(struct device)			\
+		DEVICE_NAME_GET(dev_name) __used			\
+	__attribute__((__section__(".device_" #level STRINGIFY(prio)))) = { \
+		.name = drv_name,					\
+		.config = (cfg_ptr),					\
+		.api = (api_ptr),					\
+		.data = (data_ptr),					\
+		Z_DEVICE_DEFINE_PM_INIT(dev_name, pm_control_fn)	\
+	};								\
+	Z_INIT_ENTRY_DEFINE(_CONCAT(__device_, dev_name), init_fn,	\
+			    (&_CONCAT(__device_, dev_name)), level, prio)
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 #define Z_DEVICE_DEFINE_PM(dev_name)					\

--- a/include/device.h
+++ b/include/device.h
@@ -21,10 +21,36 @@
 
 #include <init.h>
 #include <sys/device_mmio.h>
+#include <sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/** @brief Type used to represent devices and functions.
+ *
+ * The extreme values and zero have special significance.  Negative
+ * values identify functionality that does not correspond to a Zephyr
+ * device, such as the system clock or a SYS_INIT() function.
+ */
+typedef int16_t device_handle_t;
+
+/** @brief Flag value used in lists of device handles to separate
+ * distinct groups.
+ *
+ * This is the minimum value for the device_handle_t type.
+ */
+#define DEVICE_HANDLE_SEP INT16_MIN
+
+/** @brief Flag value used in lists of device handles to indicate the
+ * end of the list.
+ *
+ * This is the maximum value for the device_handle_t type.
+ */
+#define DEVICE_HANDLE_ENDS INT16_MAX
+
+/** @brief Flag value used to identify an unknown device. */
+#define DEVICE_HANDLE_NULL 0
 
 #define Z_DEVICE_MAX_NAME_LEN	48
 
@@ -165,10 +191,12 @@ extern "C" {
  * used by the driver. Can be NULL.
  */
 #define DEVICE_DT_DEFINE(node_id, init_fn, pm_control_fn,		\
-			 data_ptr, cfg_ptr, level, prio, api_ptr)	\
+			 data_ptr, cfg_ptr, level, prio,		\
+			 api_ptr, ...)					\
 	Z_DEVICE_DEFINE(node_id, node_id, DT_LABEL(node_id), init_fn,	\
 			pm_control_fn,					\
-			data_ptr, cfg_ptr, level, prio, api_ptr)
+			data_ptr, cfg_ptr, level, prio,			\
+			api_ptr, __VA_ARGS__)
 
 /**
  * @def DEVICE_DT_NAME_GET
@@ -218,7 +246,24 @@ extern "C" {
  * @param node_id The same as node_id provided to DEVICE_DT_DEFINE()
  */
 #define DEVICE_DT_DECLARE(node_id)				\
-	static const struct device DEVICE_DT_NAME_GET(node_id)
+	extern const struct device DEVICE_DT_NAME_GET(node_id)
+
+/* TBD: Synthesize a driver name from a system device.	Possibly
+ * redundant with the badly named drv_name parameter which should
+ * really be dev_label as it is not generic to the driver.
+ */
+#define Z_SYS_HANDLE_NAME(handle) _CONCAT(__sys_init_hdl_, handle)
+
+/* TBD: How to forward the handle parameter into Z_DEVICE_DEFINE so it
+ * can fill in the device ordinal.
+ */
+#define DT_SYS_DEVICE_DEFINE(handle, drv_name, init_fn,			\
+			     pm_control_fn, level, prio, ...)		\
+	Z_DEVICE_DEFINE(DT_INVALID_NODE, Z_SYS_HANDLE_NAME(handle),	\
+			drv_name, init_fn,				\
+			pm_control_fn,					\
+			NULL, NULL, level, prio, NULL,			\
+			__VA_ARGS__)
 
 /**
  * @def DEVICE_GET
@@ -276,9 +321,6 @@ struct device_pm {
 	struct k_poll_signal signal;
 };
 
-/**
- * @brief Runtime device structure (in memory) per driver instance
- */
 struct device {
 	/** Name of the device instance */
 	const char *name;
@@ -288,6 +330,14 @@ struct device {
 	const void *api;
 	/** Address of the device instance private data */
 	void * const data;
+	/** optional pointer to handles associated with the device.
+	 *
+	 * This encodes a sequence of sets of device handles that have
+	 * some relationship to this node.  The individual sets are
+	 * extracted with dedicated API, such as
+	 * device_get_requires_handles().
+	 */
+	const device_handle_t *const handles;
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 	/** Power Management function */
 	int (*device_pm_control)(const struct device *dev, uint32_t command,
@@ -296,6 +346,78 @@ struct device {
 	struct device_pm * const pm;
 #endif
 };
+
+/**
+ * @brief Get the handle for a given device
+ *
+ * @param dev the device for which a handle is desired.
+ *
+ * @return the handle for the device.
+ */
+static inline device_handle_t
+device_get_handle(const struct device *dev)
+{
+	extern const struct device __device_start[];
+
+	/* TODO: If/when devices can be constructed that are not part of the
+	 * fixed we'll need another solution.
+	 */
+	return (device_handle_t)(dev - __device_start);
+}
+
+/**
+ * @brief Get the device corresponding to a handle.
+ *
+ * @param dev_handle the device handle
+ *
+ * @return the device that has that handle, or a null pointer if @p
+ * dev_handle does not identify a device.
+ */
+static inline const struct device *
+device_from_handle(device_handle_t dev_handle)
+{
+	extern const struct device __device_start[];
+	extern const struct device __device_end[];
+	const struct device *dev = NULL;
+	size_t numdev = __device_end - __device_start;
+
+	if (dev_handle < numdev) {
+		dev = &__device_start[dev_handle];
+	}
+
+	return dev;
+}
+
+/**
+ * @brief Get the set of devices on which a given device depends
+ *
+ * @param dev the device for which a dependencies are desired.
+ *
+ * @param count pointer to a place to store the number of devices provided at
+ * the returned pointer.  The value is not set if the call returns a null
+ * pointer.  The value may be set to zero.
+ *
+ * @return a pointer to a sequence of @p *count device handles, or a null
+ * pointer if @p dh does not provide dependency information.
+ */
+static inline const device_handle_t *
+device_get_requires_handles(const struct device *dev,
+			    size_t *count)
+{
+	const device_handle_t *rv = dev->handles;
+
+	if (rv != NULL) {
+		size_t i = 0;
+
+		while ((rv[i] != DEVICE_HANDLE_ENDS)
+		       && (rv[i] != DEVICE_HANDLE_SEP)) {
+			++i;
+		}
+		*count = i;
+	}
+
+	return rv;
+}
 
 /**
  * @brief Retrieve the device structure for a driver by name
@@ -656,17 +778,58 @@ static inline int device_pm_put_sync(const struct device *dev) { return -ENOTSUP
  * @}
  */
 
-#define Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn, pm_control_fn, \
-			data_ptr, cfg_ptr, level, prio, api_ptr)	\
+/** Synthesize the name of the object that holds device ordinal and
+ * dependency data.  If the object doesn't come from a devicetree
+ * node, use dev_name.
+ */
+#define Z_DEVICE_HANDLE_NAME(node_id, dev_name)				\
+	_CONCAT(__devicehdl_,						\
+		COND_CODE_1(DT_NODE_EXISTS(node_id),			\
+			    (node_id),					\
+			    (dev_name)))
+
+#define Z_DEVICE_EXTRA_HANDLES(...)				\
+	FOR_EACH_NONEMPTY_TERM(IDENTITY, (,), __VA_ARGS__)
+
+/* Construct objects that are referenced from struct device.  These
+ * include power management and dependency handles.
+ */
+#define Z_DEVICE_DEFINE_PRE(node_id, dev_name, ...)			\
 	Z_DEVICE_DEFINE_PM(dev_name)					\
-	static const Z_DECL_ALIGN(struct device)			\
+	Z_DEVICE_DEFINE_HANDLES(node_id, dev_name, __VA_ARGS__)
+
+#define Z_DEVICE_DEFINE_HANDLES(node_id, dev_name, ...)			\
+	static const device_handle_t Z_DEVICE_HANDLE_NAME(node_id,dev_name)[] = { \
+	COND_CODE_1(DT_NODE_EXISTS(node_id), (				\
+			DT_DEP_ORD(node_id),				\
+			DT_REQUIRES_DEP_ORDS(node_id)			\
+		),(							\
+			DEVICE_HANDLE_NULL,				\
+		))							\
+			DEVICE_HANDLE_SEP,				\
+			Z_DEVICE_EXTRA_HANDLES(__VA_ARGS__)		\
+			DEVICE_HANDLE_ENDS,				\
+		};
+
+#define Z_DEVICE_DEFINE_INIT(node_id, dev_name, pm_control_fn)		\
+		.handles = Z_DEVICE_HANDLE_NAME(node_id, dev_name),	\
+		Z_DEVICE_DEFINE_PM_INIT(dev_name, pm_control_fn)
+
+/* Like DEVICE_DEFINE but takes a node_id AND a dev_name, and trailing
+ * dependency handles that come from outside devicetree.
+ */
+#define Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn, pm_control_fn, \
+			data_ptr, cfg_ptr, level, prio, api_ptr, ...)	\
+	Z_DEVICE_DEFINE_PRE(node_id, dev_name, __VA_ARGS__)		\
+	COND_CODE_1(DT_NODE_EXISTS(node_id), (), (static))		\
+		const Z_DECL_ALIGN(struct device)			\
 		DEVICE_NAME_GET(dev_name) __used			\
 	__attribute__((__section__(".device_" #level STRINGIFY(prio)))) = { \
 		.name = drv_name,					\
 		.config = (cfg_ptr),					\
 		.api = (api_ptr),					\
 		.data = (data_ptr),					\
-		Z_DEVICE_DEFINE_PM_INIT(dev_name, pm_control_fn)	\
+		Z_DEVICE_DEFINE_INIT(node_id, dev_name, pm_control_fn)	\
 	};								\
 	Z_INIT_ENTRY_DEFINE(_CONCAT(__device_, dev_name), init_fn,	\
 			    (&_CONCAT(__device_, dev_name)), level, prio)

--- a/include/device.h
+++ b/include/device.h
@@ -52,6 +52,12 @@ typedef int16_t device_handle_t;
 /** @brief Flag value used to identify an unknown device. */
 #define DEVICE_HANDLE_NULL 0
 
+/* TBR how to generate these as unique identifiers and associate them
+ * with a data structure.
+ */
+#define DEVICE_HANDLE_SYSCLOCK 30000
+#define DEVICE_HANDLE_SYSCLOCK_BASIS 30001
+
 #define Z_DEVICE_MAX_NAME_LEN	48
 
 /**

--- a/include/device.h
+++ b/include/device.h
@@ -799,11 +799,16 @@ static inline int device_pm_put_sync(const struct device *dev) { return -ENOTSUP
 	Z_DEVICE_DEFINE_HANDLES(node_id, dev_name, __VA_ARGS__)
 
 #define Z_DEVICE_DEFINE_HANDLES(node_id, dev_name, ...)			\
-	static const device_handle_t Z_DEVICE_HANDLE_NAME(node_id,dev_name)[] = { \
+	extern const device_handle_t					\
+		Z_DEVICE_HANDLE_NAME(node_id, dev_name)[];		\
+	const device_handle_t						\
+	__attribute__((__weak__,					\
+		       __section__(".__device_handles_pass1")))		\
+	Z_DEVICE_HANDLE_NAME(node_id, dev_name)[] = {			\
 	COND_CODE_1(DT_NODE_EXISTS(node_id), (				\
 			DT_DEP_ORD(node_id),				\
 			DT_REQUIRES_DEP_ORDS(node_id)			\
-		),(							\
+		), (							\
 			DEVICE_HANDLE_NULL,				\
 		))							\
 			DEVICE_HANDLE_SEP,				\

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -37,6 +37,17 @@
 	}
 	ASSERT(SIZEOF(initlevel_error) == 0, "Undefined initialization levels used.")
 
+	SECTION_DATA_PROLOGUE(device_handles,,)
+	{
+		__device_handles_start = .;
+#ifdef LINKER_PASS2
+		KEEP(*(SORT(.__device_handles_pass2)));
+#else /* LINKER_PASS2 */
+		KEEP(*(SORT(.__device_handles_pass1)));
+#endif /* LINKER_PASS2 */
+		__device_handles_end = .;
+	} GROUP_LINK_IN(ROMABLE_REGION)
+
 #ifdef CONFIG_CPLUSPLUS
 	SECTION_PROLOGUE(_CTOR_SECTION_NAME,,)
 	{

--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -86,5 +86,9 @@ GEN_ABSOLUTE_SYM(K_THREAD_SIZEOF, sizeof(struct k_thread));
 /* size of the device structure. Used by linker scripts */
 GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_SIZEOF, sizeof(const struct device));
 
+/* member offsets in the device structure. Used in image post-processing */
+GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_HANDLES_OFFSET,
+		 offsetof(struct device, handles));
+
 /* LCOV_EXCL_STOP */
 #endif /* ZEPHYR_KERNEL_INCLUDE_KERNEL_OFFSETS_H_ */

--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -5,9 +5,74 @@
  */
 
 #include <zephyr.h>
+#include <device.h>
 #include <sys/printk.h>
+#include <stdio.h>
+
+#define UART0 DT_NODELABEL(uart0)
+
+#define GEN_AUX(...) FOR_EACH_NONEMPTY_TERM(IDENTITY, (,), __VA_ARGS__)
+
+extern const uint8_t __device_handles_start[];
+extern const uint8_t __device_handles_end[];
+
+static void dump_handles(const char *tag,
+			 const device_handle_t *cp)
+{
+	const device_handle_t *cps = cp;
+	unsigned int setnum = 0;
+	char buf[128] = {0};
+	char *bp = buf;
+	struct device *devlist;
+	size_t devcnt = z_device_get_all_static(&devlist);
+
+	printk("handles sets for %s: %p:\n", tag, cp);
+	while (true) {
+		if ((*cp == DEVICE_HANDLE_SEP)
+		    || (*cp == DEVICE_HANDLE_ENDS)) {
+			printk("\tS%u: %u elts:%s\n", setnum, (unsigned int)(cp - cps), buf);
+			bp = buf;
+			*bp = 0;
+			cps = cp + 1;
+			++setnum;
+			if (*cp == DEVICE_HANDLE_ENDS) {
+				break;
+			}
+		} else {
+			bp += snprintf(bp, buf + sizeof(buf) -  bp, " %d", *cp);
+			if (setnum == 0) {
+				bp += snprintf(bp, buf + sizeof(buf) - bp, "[%s]",
+					       devlist[*cp].name);
+			}
+		}
+		++cp;
+	}
+	printk("%s has %u sets\n", tag, setnum);
+}
+
+static void showhandles(void)
+{
+	struct device *devlist;
+	size_t devcnt = z_device_get_all_static(&devlist);
+	const struct device *dpe = devlist + devcnt;
+	struct device *dp = devlist;
+
+	printk("%zu devices at %p:\n", devcnt, devlist);
+	printk("%u bytes handles at %p\n",
+	       __device_handles_end - __device_handles_start,
+	       __device_handles_start);
+	while (dp < dpe) {
+		const char *name = dp->name ? dp->name : "<?>";
+
+		printk("%u: %p: %s\n", (unsigned int)(dp - devlist), dp, name);
+		if (dp->handles) {
+			dump_handles(name, dp->handles);
+		}
+		++dp;
+	}
+}
 
 void main(void)
 {
-	printk("Hello World! %s\n", CONFIG_BOARD);
+	showhandles();
 }

--- a/scripts/gen_handles.py
+++ b/scripts/gen_handles.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2017 Intel Corporation
+# Copyright (c) 2020 Nordic Semiconductor NA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+import sys
+import argparse
+import os
+import struct
+import pickle
+from distutils.version import LooseVersion
+
+import elftools
+from elftools.elf.elffile import ELFFile
+from elftools.elf.sections import SymbolTableSection
+import elftools.elf.enums
+
+if LooseVersion(elftools.__version__) < LooseVersion('0.24'):
+    sys.exit("pyelftools is out of date, need version 0.24 or later")
+
+ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
+sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/dts"))
+
+scr = os.path.basename(sys.argv[0])
+
+def debug(text):
+    if not args.verbose:
+        return
+    sys.stdout.write(scr + ": " + text + "\n")
+
+def parse_args():
+    global args
+
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument("-k", "--kernel", required=False,
+                        help="Input zephyr ELF binary")
+    parser.add_argument("-o", "--output-source", required=True,
+            help="Output source file")
+
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Print extra debugging information")
+    args = parser.parse_args()
+    if "VERBOSE" in os.environ:
+        args.verbose = 1
+
+
+def symbol_data(elf, sym):
+    addr = sym.entry.st_value
+    len = sym.entry.st_size
+    for section in elf.iter_sections():
+        start = section['sh_addr']
+        end = start + section['sh_size']
+
+        if (start <= addr) and (addr + len) <= end:
+            offset = addr - section['sh_addr']
+            return bytes(section.data()[offset:offset + len])
+
+def symbol_handle_data(elf, sym):
+    data = symbol_data(elf, sym)
+    if data:
+        format = "<" if elf.little_endian else ">"
+        format += "%uh" % (len(data) / 2)
+        return struct.unpack(format, data)
+
+def process_device_symbol(sym, section, elf, edt):
+    if not sym.name.startswith("__device_"):
+        return False
+    return False
+
+# These match the corresponding constants in <device.h>
+DEVICE_HANDLE_SEP = -32768
+DEVICE_HANDLE_ENDS = 32767
+
+class Device:
+    """
+    Represents information about a device object and its references to other objects.
+    """
+    def __init__(self, elf, ld_constants, sym, addr):
+        self.elf = elf
+        self.ld_constants = ld_constants
+        self.sym = sym
+        self.addr = addr
+        # Point to the handles instance associated with the device;
+        # assigned by correlating the device struct handles pointer
+        # value with the addr of a Handles instance.
+        self.__handles = None
+
+    @property
+    def obj_handles(self):
+        """
+        Returns the value from the device struct handles field, pointing to the
+        array of handles for devices this device depends on.
+        """
+        if self.__handles is None:
+            data = symbol_data(self.elf, self.sym)
+            format = "<" if self.elf.little_endian else ">"
+            if self.elf.elfclass == 32:
+                format += "I"
+                size = 4
+            else:
+                format += "Q"
+                size = 8
+            offset = self.ld_constants["DEVICE_STRUCT_HANDLES_OFFSET"]
+            self.__handles = struct.unpack(format, data[offset:offset + size])[0]
+        return self.__handles
+
+class Handles:
+    def __init__(self, sym, addr, handles, node):
+        self.sym = sym
+        self.addr = addr
+        self.handles = handles
+        self.node = node
+        self.dep_ord = None
+        self.dev_deps = None
+        self.ext_deps = None
+
+def main():
+    parse_args()
+
+    assert args.kernel, "--kernel ELF required for --gperf-output"
+    elf = ELFFile(open(args.kernel, "rb"))
+
+    edtser = os.path.join(os.path.split(args.kernel)[0], "edt.pickle")
+    with open(edtser, 'rb') as f:
+        edt = pickle.load(f)
+
+    devices = []
+    handles = []
+    # Leading _ are stripped from the stored constant key
+    want_constants = set(["__device_start",
+                          "_DEVICE_STRUCT_SIZEOF",
+                          "_DEVICE_STRUCT_HANDLES_OFFSET"])
+    ld_constants = dict()
+
+    for section in elf.iter_sections():
+        if isinstance(section, SymbolTableSection):
+            for sym in section.iter_symbols():
+                if sym.name in want_constants:
+                    ld_constants[sym.name.lstrip("_")] = sym.entry.st_value
+                    continue
+                if sym.entry.st_info.type != 'STT_OBJECT':
+                    continue
+                if sym.name.startswith("__device"):
+                    addr = sym.entry.st_value
+                    if sym.name.startswith("__device_"):
+                        devices.append(Device(elf, ld_constants, sym, addr))
+                        debug("device %s" % (sym.name,))
+                    elif sym.name.startswith("__devicehdl_"):
+                        hdls = symbol_handle_data(elf, sym)
+
+                        # The first element of the hdls array is the dependency
+                        # ordinal of the device, which identifies the devicetree
+                        # node.
+                        node = edt.dep_ord2node[hdls[0]] if (hdls and hdls[0] != 0) else None
+                        handles.append(Handles(sym, addr, hdls, node))
+                        debug("handles %s %d %s" % (sym.name, hdls[0] if hdls else -1, node))
+
+    assert len(want_constants) == len(ld_constants), "linker map data incomplete"
+
+    devices = sorted(devices, key = lambda k: k.sym.entry.st_value)
+
+    device_start_addr = ld_constants["device_start"]
+    device_size = 0
+
+    assert len(devices) == len(handles), 'mismatch devices and handles'
+
+    used_nodes = set()
+    for handle in handles:
+        for device in devices:
+            if handle.addr == device.obj_handles:
+                handle.device = device
+                break
+        device = handle.device
+        assert device, 'no device for %s' % (handle.sym.name,)
+
+        device.handle = handle
+
+        if device_size == 0:
+            device_size = device.sym.entry.st_size
+
+        # Where in the sequence of devices this particular node occurs
+        device.dev_ordinal = (device.sym.entry.st_value - device_start_addr) / device_size
+        debug("%s dev ordinal %d" % (device.sym.name, device.dev_ordinal))
+
+        n = handle.node
+        if n is not None:
+            debug("%s dev ordinal %d\n\t%s" % (n.path, device.dev_ordinal, ' ; '.join(str(_) for _ in handle.handles)))
+            used_nodes.add(n)
+            n.__device = device
+        else:
+            debug("orphan %d" % (device.dev_ordinal,))
+        hv = handle.handles
+        hvi = 1
+        handle.dev_deps = []
+        handle.ext_deps = []
+        deps = handle.dev_deps
+        while True:
+            h = hv[hvi]
+            if h == DEVICE_HANDLE_ENDS:
+                break
+            if h == DEVICE_HANDLE_SEP:
+                deps = handle.ext_deps
+            else:
+                deps.append(h)
+                n = edt
+            hvi += 1
+
+    # Compute the dependency graph induced from the full graph restricted to the
+    # the nodes that exist in the application.  Note that the edges in the
+    # induced graph correspond to paths in the full graph.
+    root = edt.dep_ord2node[0]
+    assert root not in used_nodes
+
+    for sn in used_nodes:
+        # Where we're storing the final set of nodes: these are all used
+        sn.__depends = set()
+
+        deps = set(sn.depends_on)
+        debug("\nNode: %s\nOrig deps:\n\t%s" % (sn.path, "\n\t".join([dn.path for dn in deps])))
+        while len(deps) > 0:
+            dn = deps.pop()
+            if dn in used_nodes:
+                # this is used
+                sn.__depends.add(dn)
+            elif dn != root:
+                # forward the dependency up one level
+                for ddn in dn.depends_on:
+                    deps.add(ddn)
+        debug("final deps:\n\t%s\n" % ("\n\t".join([ _dn.path for _dn in sn.__depends])))
+
+    with open(args.output_source, "w") as fp:
+        fp.write('#include <device.h>\n')
+
+        for dev in devices:
+            hs = dev.handle
+            assert hs, "no hs for %s" % (dev.sym.name,)
+            dep_paths = []
+            ext_paths = []
+            hdls = []
+
+            sn = hs.node
+            if sn:
+                hdls.extend(dn.__device.dev_ordinal for dn in sn.__depends)
+                for dn in sn.depends_on:
+                    if dn in sn.__depends:
+                        dep_paths.append(dn.path)
+                    else:
+                        dep_paths.append('(%s)' % dn.path)
+            if len(hs.ext_deps) > 0:
+                # TODO: map these to something smaller?
+                ext_paths.extend(map(str, hs.ext_deps))
+                hdls.append(DEVICE_HANDLE_SEP)
+                hdls.extend(hs.ext_deps)
+
+            # When CONFIG_USERSPACE is enabled the pre-built elf is
+            # also used to get hashes that identify kernel objects by
+            # address.  We can't allow the size of any object in the
+            # final elf to change.  (We don't expect to end up with
+            # more, but we do expect to eliminate the device handle
+            # that used to be first.)
+            while len(hdls) < len(hs.handles):
+                hdls.append(DEVICE_HANDLE_ENDS)
+            assert len(hdls) == len(hs.handles), "%s handle overflow" % (dev.sym.name,)
+
+            lines = [
+                '',
+                '/* %d : %s:' % (dev.dev_ordinal, (sn and sn.path) or "sysinit"),
+            ]
+
+            if len(dep_paths) > 0:
+                lines.append(' * - %s' % ('\n * - '.join(dep_paths)))
+            if len(ext_paths) > 0:
+                lines.append(' * + %s' % ('\n * + '.join(ext_paths)))
+
+            lines.extend([
+                ' */',
+                'const device_handle_t __attribute__((__section__(".__device_handles_pass2")))',
+                '%s[] = { %s };' % (hs.sym.name, ', '.join([str(int(_h)) for _h in hdls])),
+                '',
+            ])
+
+            fp.write('\n'.join(lines))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/26616#issuecomment-672012086 has the most recent status summary.  **Please look at that before reviewing** so you can focus on what's supposed to be in this PR separate from the supporting capabilities.

That summary is updated every time this PR is pushed, most recently 2020-08-21T10:26-05:00.

This supersedes #26388 which is similar but was a trial for whether the handles could be identified solely from devictree.  They can't (#26575), so this shows current status of an approach that post-processes the prebuilt ELF file and will generate correct and complete dependency data.

The solution here extends the `DEVICE_INIT()` macro infrastructure to take the declaration names and other information from a devicetree node.  For devices defined in this way dependency information from the devicetree and from external sources are stored in an array referenced from the driver structure.  This array uses the ordinals from the devicetree, and is placed in a linker section that will be discarded in the final link.

A new script `gen_handles.py` reads the prebuilt binary and uses the device handle array data to associate each device with the devicetree node associated with it.  The dependency graph of the whole devicetree is then reduced to a dependency graph involving only devices present in the application.  Ordinals for these devices are assigned based on their offset in the Zephyr device section, and new handle values are generated that replace the ones used in the pre-build link.

Issues to be addressed:
* Dependency information is available only when the drivers use devicetree nodes to define the device structure.  All drivers will have to be updated to do this.
* Many devices will not have any recorded dependencies.  Each of those currently costs 2 bytes for the device-specific handle array that holds the empty sequence.  Those can be replaced by aliases to a common empty sequence array.
* Although non-device handles can be added there is currently no mechanism to define them for reference from other devices and init functions.

The tooling-supplied ordinal is not used in the application.  The rework would enable:

    struct device *dev = &DEVICE_DT_GET(nodeid);

as a mechanism to access the device structure, if the underlying names were made global.