### PR TITLE
benchmarks: timing_info: fix x86 cycles to nsec conversion

### DIFF
--- a/tests/benchmarks/timing_info/src/arch/x86/tsc.c
+++ b/tests/benchmarks/timing_info/src/arch/x86/tsc.c
@@ -45,5 +45,5 @@ uint32_t x86_get_timer_freq_MHz(void)
 
 uint32_t x86_cyc_to_ns_floor64(uint64_t cyc)
 {
-	return ((cyc) * USEC_PER_SEC / tsc_freq);
+	return ((cyc) * NSEC_PER_SEC / tsc_freq);
 }


### PR DESCRIPTION
The conversion from cycles to nanoseconds was using the incorrect
macro which resulted in microseconds instead. So fix it by
using the correct macro.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>