### PR TITLE
boards: qemu_arc: disable as default test platform

### DIFF
--- a/boards/arc/qemu_arc/qemu_arc_em.yaml
+++ b/boards/arc/qemu_arc/qemu_arc_em.yaml
@@ -6,7 +6,6 @@ arch: arc
 toolchain:
   - zephyr
 testing:
-  default: true
   ignore_tags:
     - net
     - bluetooth

--- a/boards/arc/qemu_arc/qemu_arc_hs.yaml
+++ b/boards/arc/qemu_arc/qemu_arc_hs.yaml
@@ -6,7 +6,6 @@ arch: arc
 toolchain:
   - zephyr
 testing:
-  default: true
   ignore_tags:
     - net
     - bluetooth


### PR DESCRIPTION
Still unstable in CI and causing lots of failures. Disabling for now
while it is getting stablised.