### PR TITLE
counter: enable kinetis pit counter driver

### DIFF
--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -222,3 +222,7 @@ arduino_spi: &spi0 {
 &edma0 {
 	status = "okay";
 };
+
+&pit0 {
+	status = "okay";
+};

--- a/boards/arm/frdm_k82f/frdm_k82f.dts
+++ b/boards/arm/frdm_k82f/frdm_k82f.dts
@@ -204,3 +204,7 @@
 &usbotg {
 	status = "okay";
 };
+
+&pit0 {
+	status = "okay";
+};

--- a/boards/arm/frdm_k82f/frdm_k82f.yaml
+++ b/boards/arm/frdm_k82f/frdm_k82f.yaml
@@ -11,6 +11,7 @@ flash: 256
 supported:
   - adc
   - arduino_gpio
+  - counter
   - gpio
   - i2c
   - nvs

--- a/drivers/counter/CMakeLists.txt
+++ b/drivers/counter/CMakeLists.txt
@@ -18,3 +18,4 @@ zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_LPTMR          counter_mcux_lpt
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MAXIM_DS3231        maxim_ds3231.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_NATIVE_POSIX        counter_native_posix.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE                   counter_handlers.c)
+zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_PIT            counter_mcux_pit.c)

--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -42,4 +42,6 @@ source "drivers/counter/Kconfig.maxim_ds3231"
 
 source "drivers/counter/Kconfig.native_posix"
 
+source "drivers/counter/Kconfig.mcux_pit"
+
 endif # COUNTER

--- a/drivers/counter/Kconfig.mcux_pit
+++ b/drivers/counter/Kconfig.mcux_pit
@@ -1,0 +1,10 @@
+# MCUXpresso SDK Periodic Interrupt Timer (PIT)
+
+# Copyright 2020 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config COUNTER_MCUX_PIT
+	bool "MCUX PIT driver"
+	depends on HAS_MCUX_PIT
+	help
+	  Enable support for the MCUX Periodic Interrupt Timer (PIT).

--- a/drivers/counter/counter_mcux_pit.c
+++ b/drivers/counter/counter_mcux_pit.c
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2020 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_kinetis_pit
+
+#include <drivers/counter.h>
+#include <fsl_pit.h>
+
+#define LOG_MODULE_NAME counter_pit
+#include <logging/log.h>
+LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_COUNTER_LOG_LEVEL);
+
+struct mcux_pit_config {
+	struct counter_config_info info;
+	PIT_Type *base;
+	bool enableRunInDebug;
+	pit_chnl_t pit_channel;
+	void (*irq_config_func)(struct device *dev);
+};
+
+struct mcux_pit_data {
+	counter_alarm_callback_t alarm_callback;
+	counter_top_callback_t top_callback;
+	void *alarm_user_data;
+	void *top_user_data;
+};
+
+static uint32_t mcux_pit_get_top_value(struct device *dev)
+{
+	const struct mcux_pit_config *config = dev->config;
+	pit_chnl_t channel = config->pit_channel;
+
+	return config->base->CHANNEL[channel].LDVAL;
+}
+
+static int mcux_pit_start(struct device *dev)
+{
+	const struct mcux_pit_config *config = dev->config;
+
+	LOG_DBG("period is %d", mcux_pit_get_top_value(dev));
+	PIT_EnableInterrupts(config->base, config->pit_channel,
+			     kPIT_TimerInterruptEnable);
+	PIT_StartTimer(config->base, config->pit_channel);
+	return 0;
+}
+
+static int mcux_pit_stop(struct device *dev)
+{
+	const struct mcux_pit_config *config = dev->config;
+
+	PIT_DisableInterrupts(config->base, config->pit_channel,
+			      kPIT_TimerInterruptEnable);
+	PIT_StopTimer(config->base, config->pit_channel);
+
+	return 0;
+}
+
+static int mcux_pit_get_value(struct device *dev, uint32_t *ticks)
+{
+	const struct mcux_pit_config *config = dev->config;
+
+	*ticks = PIT_GetCurrentTimerCount(config->base, config->pit_channel);
+
+	return 0;
+}
+
+static int mcux_pit_set_top_value(struct device *dev,
+				  const struct counter_top_cfg *cfg)
+{
+	const struct mcux_pit_config *config = dev->config;
+	struct mcux_pit_data *data = dev->data;
+	pit_chnl_t channel = config->pit_channel;
+
+	if (cfg->ticks == 0) {
+		return -EINVAL;
+	}
+
+	data->top_callback = cfg->callback;
+	data->top_user_data = cfg->user_data;
+
+	if (config->base->CHANNEL[channel].TCTRL & PIT_TCTRL_TEN_MASK) {
+		/* Timer already enabled, check flags before resetting */
+		if (cfg->flags & COUNTER_TOP_CFG_DONT_RESET) {
+			return -ENOTSUP;
+		}
+		PIT_StopTimer(config->base, channel);
+		PIT_SetTimerPeriod(config->base, channel, cfg->ticks);
+		PIT_StartTimer(config->base, channel);
+	} else {
+		PIT_SetTimerPeriod(config->base, channel, cfg->ticks);
+	}
+
+	return 0;
+}
+
+static uint32_t mcux_pit_get_pending_int(struct device *dev)
+{
+	const struct mcux_pit_config *config = dev->config;
+	uint32_t mask = PIT_TFLG_TIF_MASK;
+	uint32_t flags;
+
+	flags = PIT_GetStatusFlags(config->base, config->pit_channel);
+
+	return ((flags & mask) == mask);
+}
+
+static uint32_t mcux_pit_get_max_relative_alarm(struct device *dev)
+{
+	const struct mcux_pit_config *config = dev->config;
+
+	return config->info.max_top_value;
+}
+
+static void mcux_pit_isr(void *arg)
+{
+	struct device *dev = arg;
+	const struct mcux_pit_config *config = dev->config;
+	struct mcux_pit_data *data = dev->data;
+	uint32_t flags;
+	uint32_t current = 0;
+
+	LOG_DBG("pit counter isr");
+	flags = PIT_GetStatusFlags(config->base, config->pit_channel);
+	PIT_ClearStatusFlags(config->base, config->pit_channel, flags);
+	if (data->top_callback) {
+		data->top_callback(dev, data->top_user_data);
+	}
+	if (data->alarm_callback) {
+		PIT_StopTimer(config->base, config->pit_channel);
+		mcux_pit_get_value(dev, &current);
+		data->alarm_callback(dev, config->pit_channel, current,
+				     data->alarm_user_data);
+	}
+}
+
+static int mcux_pit_set_alarm(struct device *dev, uint8_t chan_id,
+			      const struct counter_alarm_cfg *alarm_cfg)
+{
+	const struct mcux_pit_config *config = dev->config;
+	struct mcux_pit_data *data = dev->data;
+
+	uint32_t ticks = alarm_cfg->ticks;
+
+	if (chan_id != DT_PROP(DT_DRV_INST(0), pit_channel)) {
+		LOG_ERR("Invalid channel id");
+		return -EINVAL;
+	}
+
+	if (ticks > mcux_pit_get_top_value(dev)) {
+		LOG_ERR("Invalid tciks");
+		return -EINVAL;
+	}
+
+	PIT_StopTimer(config->base, chan_id);
+	PIT_SetTimerPeriod(config->base, chan_id, ticks);
+	data->alarm_callback = alarm_cfg->callback;
+	data->alarm_user_data = alarm_cfg->user_data;
+	LOG_DBG("set alarm to %d", ticks);
+	PIT_StartTimer(config->base, chan_id);
+	return 0;
+}
+
+static int mcux_pit_cancel_alarm(struct device *dev, uint8_t chan_id)
+{
+	const struct mcux_pit_config *config = dev->config;
+	struct mcux_pit_data *data = dev->data;
+
+	if (chan_id != DT_PROP(DT_DRV_INST(0), pit_channel)) {
+		LOG_ERR("Invalid channel id");
+		return -EINVAL;
+	}
+
+	PIT_DisableInterrupts(config->base, chan_id, kPIT_TimerInterruptEnable);
+	PIT_StopTimer(config->base, chan_id);
+	data->alarm_callback = NULL;
+
+	return 0;
+}
+
+static int mcux_pit_init(struct device *dev)
+{
+	const struct mcux_pit_config *config =
+		(struct mcux_pit_config *)dev->config;
+	pit_config_t pit_config;
+
+	PIT_GetDefaultConfig(&pit_config);
+	pit_config.enableRunInDebug = config->enableRunInDebug;
+
+	PIT_Init(config->base, &pit_config);
+
+	config->irq_config_func(dev);
+
+	PIT_SetTimerPeriod(config->base, config->pit_channel,
+			   USEC_TO_COUNT(DT_PROP(DT_DRV_INST(0), pit_period),
+					 CLOCK_GetFreq(kCLOCK_BusClk)));
+
+	return 0;
+}
+
+static const struct counter_driver_api mcux_pit_driver_api = {
+	.start = mcux_pit_start,
+	.stop = mcux_pit_stop,
+	.get_value = mcux_pit_get_value,
+	.set_top_value = mcux_pit_set_top_value,
+	.set_alarm = mcux_pit_set_alarm,
+	.cancel_alarm = mcux_pit_cancel_alarm,
+	.get_pending_int = mcux_pit_get_pending_int,
+	.get_top_value = mcux_pit_get_top_value,
+	.get_max_relative_alarm = mcux_pit_get_max_relative_alarm,
+};
+
+/*
+ * This driver is single-instance. If the devicetree contains multiple
+ * instances, this will fail and the driver needs to be revisited.
+ */
+BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) <= 1,
+	     "unsupported pit instance");
+
+static struct mcux_pit_data mcux_pit_data_0;
+
+static void mcux_pit_irq_config_0(struct device *dev);
+
+static const struct mcux_pit_config mcux_pit_config_0 = {
+	.info = {
+		.max_top_value = UINT32_MAX,
+		.channels = 1,
+		.freq = DT_PROP(DT_DRV_INST(0), clock_frequency),
+	},
+	.base = (PIT_Type *)DT_INST_REG_ADDR(0),
+	.pit_channel = DT_PROP(DT_DRV_INST(0), pit_channel),
+	.irq_config_func = mcux_pit_irq_config_0,
+};
+
+DEVICE_AND_API_INIT(mcux_pit_0, DT_INST_LABEL(0), &mcux_pit_init,
+		    &mcux_pit_data_0, &mcux_pit_config_0, POST_KERNEL,
+		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &mcux_pit_driver_api);
+
+static void mcux_pit_irq_config_0(struct device *dev)
+{
+	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 0, irq),
+		    DT_INST_IRQ_BY_IDX(0, 0, priority), mcux_pit_isr,
+		    DEVICE_GET(mcux_pit_0), 0);
+	irq_enable(DT_INST_IRQ_BY_IDX(0, 0, irq));
+	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 1, irq),
+		    DT_INST_IRQ_BY_IDX(0, 1, priority), mcux_pit_isr,
+		    DEVICE_GET(mcux_pit_0), 0);
+	irq_enable(DT_INST_IRQ_BY_IDX(0, 1, irq));
+	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 2, irq),
+		    DT_INST_IRQ_BY_IDX(0, 2, priority), mcux_pit_isr,
+		    DEVICE_GET(mcux_pit_0), 0);
+	irq_enable(DT_INST_IRQ_BY_IDX(0, 2, irq));
+	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 3, irq),
+		    DT_INST_IRQ_BY_IDX(0, 3, priority), mcux_pit_isr,
+		    DEVICE_GET(mcux_pit_0), 0);
+	irq_enable(DT_INST_IRQ_BY_IDX(0, 3, irq));
+}

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -530,6 +530,18 @@
 			status = "disabled";
 			label = "EDMA0";
 		};
+
+		pit0: pit@40037000 {
+			compatible = "nxp,kinetis-pit";
+			reg = <0x40037000 0x1000>;
+			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 23>;
+			interrupts = <48 0>, <49 0>, <50 0>, <51 0>;
+			status = "disabled";
+			pit-channel = <0>;
+			pit-period = <1000000>;
+			clock-frequency = <60000000>;
+			label = "PIT0";
+		};
 	};
 };
 

--- a/dts/arm/nxp/nxp_k8x.dtsi
+++ b/dts/arm/nxp/nxp_k8x.dtsi
@@ -382,6 +382,18 @@
 			clocks = <&sim KINETIS_SIM_LPO_CLK 0 0>;
 			label = "WDT_0";
 		};
+
+		pit0: pit@40037000 {
+			compatible = "nxp,kinetis-pit";
+			reg = <0x40037000 0x1000>;
+			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 23>;
+			interrupts = <48 0>, <49 0>, <50 0>, <51 0>;
+			status = "disabled";
+			pit-channel = <0>;
+			pit-period = <1000000>;
+			clock-frequency = <60000000>;
+			label = "PIT0";
+		};
 	};
 };
 

--- a/dts/bindings/rtc/nxp,kinetis-pit.yaml
+++ b/dts/bindings/rtc/nxp,kinetis-pit.yaml
@@ -1,0 +1,22 @@
+# Copyright 2020 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP MCUX Periodic Interrupt Timer (PIT)
+
+compatible: "nxp,kinetis-pit"
+
+include: [rtc.yaml]
+
+properties:
+    reg:
+      required: true
+
+    pit-channel:
+      type: int
+      required: true
+      description: pit channel to active
+
+    pit-period:
+      type: int
+      required: true
+      description: pit default period in us

--- a/modules/Kconfig.mcux
+++ b/modules/Kconfig.mcux
@@ -209,4 +209,9 @@ config HAS_MCUX_RDC
 	help
 	  Set if the RDC module is present in the SoC.
 
+config HAS_MCUX_PIT
+	bool
+	help
+	  Set if the PIT module is present on the SoC.
+
 endif # HAS_MCUX

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.series
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.series
@@ -19,6 +19,10 @@ config DMA_MCUX_EDMA
 	default y if HAS_MCUX_EDMA
 	depends on DMA
 
+config COUNTER_MCUX_PIT
+	default y if HAS_MCUX_PIT
+    depends on COUNTER
+
 source "soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk*"
 
 endif # SOC_SERIES_KINETIS_K6X

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.series
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.series
@@ -10,6 +10,7 @@ config SOC_SERIES_KINETIS_K6X
 	select CPU_CORTEX_M_HAS_DWT
 	select SOC_FAMILY_KINETIS
 	select CPU_HAS_NXP_MPU
+	select HAS_MCUX_PIT
 	select CLOCK_CONTROL
 	help
 	  Enable support for Kinetis K6x MCU series

--- a/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.series
+++ b/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.series
@@ -76,6 +76,10 @@ config WDT_MCUX_WDOG
 	default y
 	depends on WATCHDOG
 
+config COUNTER_MCUX_PIT
+	default y if HAS_MCUX_PIT
+	depends on COUNTER
+
 source "soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.mk*"
 
 endif # SOC_SERIES_KINETIS_K8X

--- a/soc/arm/nxp_kinetis/k8x/Kconfig.series
+++ b/soc/arm/nxp_kinetis/k8x/Kconfig.series
@@ -17,6 +17,7 @@ config SOC_SERIES_KINETIS_K8X
 	select HAS_MCUX_FTFX
 	select HAS_MCUX_FTM
 	select HAS_MCUX_LPUART
+	select HAS_MCUX_PIT
 	select HAS_MCUX_RTC
 	select HAS_MCUX_SIM
 	select HAS_MCUX_TRNG


### PR DESCRIPTION
enable kinetis pit counter driver on frdm_k82f
tested with counter_basic_api case.
this PR depends on https://github.com/zephyrproject-rtos/hal_nxp/pull/47