### PR TITLE
samples: spi_fujistu_fram: Fix buffer length

### DIFF
--- a/samples/drivers/spi_fujitsu_fram/src/main.c
+++ b/samples/drivers/spi_fujitsu_fram/src/main.c
@@ -58,6 +58,7 @@ static int mb85rs64v_access(struct device *spi, struct spi_config *spi_cfg,
 		}
 	} else {
 		tx.count = 1;
+		bufs[0].len = 1;
 	}
 
 	return spi_write(spi, spi_cfg, &tx);


### PR DESCRIPTION
bufs[0].len has to be set to 1, if not spi_write don't work 
for the read_id and the disable of the write protect
Signed-off-by: Fin Maaß <56227405+maass-hamburg@users.noreply.github.com>