### PR TITLE
Fix fs ops null dereference

### DIFF
--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -130,6 +130,10 @@ ssize_t fs_read(struct fs_file_t *zfp, void *ptr, size_t size)
 {
 	int rc = -EINVAL;
 
+	if (zfp->mp == NULL) {
+		return -EBADF;
+	}
+
 	if (zfp->mp->fs->read != NULL) {
 		rc = zfp->mp->fs->read(zfp, ptr, size);
 		if (rc < 0) {
@@ -143,6 +147,10 @@ ssize_t fs_read(struct fs_file_t *zfp, void *ptr, size_t size)
 ssize_t fs_write(struct fs_file_t *zfp, const void *ptr, size_t size)
 {
 	int rc = -EINVAL;
+
+	if (zfp->mp == NULL) {
+		return -EBADF;
+	}
 
 	if (zfp->mp->fs->write != NULL) {
 		rc = zfp->mp->fs->write(zfp, ptr, size);
@@ -158,6 +166,10 @@ int fs_seek(struct fs_file_t *zfp, off_t offset, int whence)
 {
 	int rc = -EINVAL;
 
+	if (zfp->mp == NULL) {
+		return -EBADF;
+	}
+
 	if (zfp->mp->fs->lseek != NULL) {
 		rc = zfp->mp->fs->lseek(zfp, offset, whence);
 		if (rc < 0) {
@@ -171,6 +183,10 @@ int fs_seek(struct fs_file_t *zfp, off_t offset, int whence)
 off_t fs_tell(struct fs_file_t *zfp)
 {
 	int rc = -EINVAL;
+
+	if (zfp->mp == NULL) {
+		return -EBADF;
+	}
 
 	if (zfp->mp->fs->tell != NULL) {
 		rc = zfp->mp->fs->tell(zfp);
@@ -186,6 +202,10 @@ int fs_truncate(struct fs_file_t *zfp, off_t length)
 {
 	int rc = -EINVAL;
 
+	if (zfp->mp == NULL) {
+		return -EBADF;
+	}
+
 	if (zfp->mp->fs->truncate != NULL) {
 		rc = zfp->mp->fs->truncate(zfp, length);
 		if (rc < 0) {
@@ -199,6 +219,10 @@ int fs_truncate(struct fs_file_t *zfp, off_t length)
 int fs_sync(struct fs_file_t *zfp)
 {
 	int rc = -EINVAL;
+
+	if (zfp->mp == NULL) {
+		return -EBADF;
+	}
 
 	if (zfp->mp->fs->sync != NULL) {
 		rc = zfp->mp->fs->sync(zfp);

--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -109,6 +109,10 @@ int fs_close(struct fs_file_t *zfp)
 {
 	int rc = -EINVAL;
 
+	if (zfp->mp == NULL) {
+		return 0;
+	}
+
 	if (zfp->mp->fs->close != NULL) {
 		rc = zfp->mp->fs->close(zfp);
 		if (rc < 0) {


### PR DESCRIPTION
This PR contains two commits fixing NULL pointer de-references  when attempting operations on closed files: 

1.  Fix to `fs_close` that would make the function always succeed when attempting to close already closed file (it is closed anyway)
2. Fix to all `fs_*` operations (`read`, `write`, etc)  that required opened file, to return `-EBADF` instead of crashing.