### PR TITLE
tests: interrupt: include bcm platform

### DIFF
--- a/tests/kernel/interrupt/testcase.yaml
+++ b/tests/kernel/interrupt/testcase.yaml
@@ -3,5 +3,3 @@ tests:
     # nios2 excluded, see #22956
     arch_exclude: nios2
     tags: interrupt
-    # testcase is not supporting GICv3 yet, disable for bcm958402m2_a72 for now
-    platform_exclude: bcm958402m2_a72


### PR DESCRIPTION
GICv3 is now support for SGI generation and test case is updated
to use GICv3 apis. bcm958402m2_a72 can be enabled now.

Signed-off-by: Sandeep Tripathy <sandeep.tripathy@broadcom.com>