### PR TITLE
net: buf.h: Add static initialiser to net_buf_struct

### DIFF
--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -892,7 +892,7 @@ extern const struct net_buf_data_alloc net_buf_heap_alloc;
  */
 #define NET_BUF_POOL_HEAP_DEFINE(_name, _count, _destroy)                     \
 	static struct net_buf net_buf_##_name[_count] __noinit;               \
-	struct net_buf_pool _name __net_buf_align                             \
+	static struct net_buf_pool _name __net_buf_align                      \
 			__in_section(_net_buf_pool, static, _name) =          \
 		NET_BUF_POOL_INITIALIZER(_name, &net_buf_heap_alloc,          \
 					 net_buf_##_name, _count, _destroy)
@@ -944,7 +944,7 @@ extern const struct net_buf_data_cb net_buf_fixed_cb;
 		.cb = &net_buf_fixed_cb,                                      \
 		.alloc_data = (void *)&net_buf_fixed_##_name,                 \
 	};                                                                    \
-	struct net_buf_pool _name __net_buf_align                             \
+	static struct net_buf_pool _name __net_buf_align                      \
 			__in_section(_net_buf_pool, static, _name) =          \
 		NET_BUF_POOL_INITIALIZER(_name, &net_buf_fixed_alloc_##_name, \
 					 net_buf_##_name, _count, _destroy)
@@ -983,7 +983,7 @@ extern const struct net_buf_data_cb net_buf_var_cb;
 		.cb = &net_buf_var_cb,                                        \
 		.alloc_data = &net_buf_mem_pool_##_name,                      \
 	};                                                                    \
-	struct net_buf_pool _name __net_buf_align                             \
+	static struct net_buf_pool _name __net_buf_align                      \
 			__in_section(_net_buf_pool, static, _name) =          \
 		NET_BUF_POOL_INITIALIZER(_name, &net_buf_data_alloc_##_name,  \
 					 _net_buf_##_name, _count, _destroy)


### PR DESCRIPTION
This is necessary to avoid collision between drivers that calls
NET_BUF_POOL_DEFINE with the same name.

Signed-off-by: Xavier Chapron <xavier.chapron@stimio.fr>