### PR TITLE
net: l2: ppp: fix packet length for sending Term-Req and Term-Ack

### DIFF
--- a/subsys/net/l2/ppp/fsm.c
+++ b/subsys/net/l2/ppp/fsm.c
@@ -417,13 +417,14 @@ int ppp_send_pkt(struct ppp_fsm *fsm, struct net_if *iface,
 
 	case PPP_TERMINATE_REQ:
 	case PPP_TERMINATE_ACK:
+		len = sizeof(ppp);
 		break;
 
 	default:
 		break;
 	}
 
-	if (len == 0) {
+	if (len < sizeof(ppp)) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Each PPP packet sent on wire needs to have at least 4 bytes length. Set
that length for outgoing Term-Req and Term-Ack packets. Also update
length validation to check for at least 4 bytes instead of at least 1
byte.