### PR TITLE
posix/fs: Fix POSIX lseek to return position upon completion

### DIFF
--- a/lib/posix/fs.c
+++ b/lib/posix/fs.c
@@ -95,7 +95,7 @@ int open(const char *name, int flags)
 
 static int fs_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 {
-	int rc;
+	int rc = 0;
 	struct posix_fs_desc *ptr = obj;
 
 	switch (request) {
@@ -112,6 +112,9 @@ static int fs_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 		whence = va_arg(args, int);
 
 		rc = fs_seek(&ptr->file, offset, whence);
+		if (rc == 0) {
+			rc = fs_tell(&ptr->file);
+		}
 		break;
 	}
 
@@ -125,7 +128,7 @@ static int fs_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 		return -1;
 	}
 
-	return 0;
+	return rc;
 }
 
 /**

--- a/tests/posix/fs/src/test_fs_file.c
+++ b/tests/posix/fs/src/test_fs_file.c
@@ -85,7 +85,7 @@ static int test_file_read(void)
 	/* Now test after non-zero lseek. */
 
 	res = lseek(file, 2, SEEK_SET);
-	if (res != 0) {
+	if (res != 2) {
 		TC_PRINT("lseek failed [%d]\n", (int)res);
 		close(file);
 		return TC_FAIL;
@@ -109,7 +109,7 @@ static int test_file_read(void)
 		return TC_FAIL;
 	}
 
-	return res;
+	return TC_PASS;
 }
 
 static int test_file_close(void)


### PR DESCRIPTION
Bring standard behaviour to lseek, where new file position is returned
on success.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>