### PR TITLE
net: l2: ppp: drop ppp_context's is_network_up

### DIFF
--- a/include/net/ppp.h
+++ b/include/net/ppp.h
@@ -512,9 +512,6 @@ struct ppp_context {
 	/** PPP enable pending */
 	uint16_t is_enable_done : 1;
 
-	/** Network status (up / down) */
-	uint16_t is_network_up : 1;
-
 	/** IPCP status (up / down) */
 	uint16_t is_ipcp_up : 1;
 

--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -470,7 +470,6 @@ static void ipcp_up(struct ppp_fsm *fsm)
 	NET_DBG("PPP up with address %s", log_strdup(addr_str));
 	ppp_network_up(ctx, PPP_IP);
 
-	ctx->is_network_up = true;
 	ctx->is_ipcp_up = true;
 
 	NET_DBG("[%s/%p] Current state %s (%d)", fsm->name, fsm,
@@ -482,11 +481,10 @@ static void ipcp_down(struct ppp_fsm *fsm)
 	struct ppp_context *ctx = CONTAINER_OF(fsm, struct ppp_context,
 					       ipcp.fsm);
 
-	if (!ctx->is_network_up) {
+	if (!ctx->is_ipcp_up) {
 		return;
 	}
 
-	ctx->is_network_up = false;
 	ctx->is_ipcp_up = false;
 
 	ppp_network_down(ctx, PPP_IP);

--- a/subsys/net/l2/ppp/ipv6cp.c
+++ b/subsys/net/l2/ppp/ipv6cp.c
@@ -417,7 +417,6 @@ static void ipv6cp_up(struct ppp_fsm *fsm)
 
 	ppp_network_up(ctx, PPP_IPV6);
 
-	ctx->is_network_up = true;
 	ctx->is_ipv6cp_up = true;
 
 	NET_DBG("[%s/%p] Current state %s (%d)", fsm->name, fsm,
@@ -469,11 +468,10 @@ static void ipv6cp_down(struct ppp_fsm *fsm)
 	struct in6_addr peer_addr;
 	int ret;
 
-	if (!ctx->is_network_up) {
+	if (!ctx->is_ipv6cp_up) {
 		return;
 	}
 
-	ctx->is_network_up = false;
 	ctx->is_ipv6cp_up = false;
 
 	ppp_network_down(ctx, PPP_IPV6);


### PR DESCRIPTION
There is already a variable 'network_protos_up', which stores number of
network protocols being up. Additionally each network protocol has its
own state represented by is_ip{,v6}cp_up. Use the latter in FSM up() and
down() callbacks.

This fixes a case when both IPCP and IPv6CP protocols are going
down. When using ctx->is_network_up only one of them (the first) was
deinitialized correctly, second stayed always up (at least partially,
e.g. not calling ppp_network_down()).

Tested with pppd and `persist` option, sending SIGHUP to Terminate connection. Logs before this change:
```
[00:00:08.270,000] <dbg> net_l2_ppp.net_pkt_hexdump: recv L2
[00:00:08.270,000] <dbg> net_l2_ppp: 0x0014d698
c0 21 05 03 00 10 55 73  65 72 20 72 65 71 75 65 |.!....Us er reque
73 74                                            |st               
[00:00:08.270,000] <dbg> net_l2_ppp.ppp_fsm_input: (rx_workq): [LCP/0x00151e14] LCP Terminate-Req (5) id 3 payload len 12
[00:00:08.270,000] <dbg> net_l2_ppp.fsm_recv_terminate_req: (rx_workq): [LCP/0x00151e14] Current state OPENED (9)
[00:00:08.270,000] <dbg> net_l2_ppp.fsm_recv_terminate_req: (rx_workq): [LCP/0x00151e14] Terminated by peer (User request)
[00:00:08.270,000] <dbg> net_l2_ppp.ppp_change_state_debug: (rx_workq): [LCP/0x00151e14] state OPENED (9) => STOPPING (5) (fsm_recv_terminate_req():870)
[00:00:08.270,000] <dbg> net_l2_ppp.ppp_change_phase_debug: (rx_workq): [0x00151de0] phase RUNNING (4) => NETWORK (3) (ppp_link_down():114)
[00:00:08.270,000] <dbg> net_l2_ppp.ppp_fsm_lower_down: (rx_workq): [IPCP/0x00151ed0] Current state OPENED (9)
[00:00:08.270,000] <dbg> net_l2_ppp.ppp_change_state_debug: (rx_workq): [IPCP/0x00151ed0] state OPENED (9) => STARTING (1) (ppp_fsm_lower_down():274)
[00:00:08.270,000] <dbg> net_l2_ppp.ppp_network_down: (rx_workq): [0x00151de0] Proto IPv4 (0x0021) down (1)
[00:00:08.270,000] <dbg> net_l2_ppp.ppp_fsm_close: (rx_workq): [IPCP/0x00151ed0] Current state STARTING (1)
[00:00:08.270,000] <dbg> net_l2_ppp.ppp_change_state_debug: (rx_workq): [IPCP/0x00151ed0] state STARTING (1) => INITIAL (0) (ppp_fsm_close():232)
[00:00:08.270,000] <dbg> net_l2_ppp.ppp_fsm_lower_down: (rx_workq): [IPV6CP/0x00151f94] Current state OPENED (9)
[00:00:08.270,000] <dbg> net_l2_ppp.ppp_change_state_debug: (rx_workq): [IPV6CP/0x00151f94] state OPENED (9) => STARTING (1) (ppp_fsm_lower_down():274)
[00:00:08.270,000] <dbg> net_l2_ppp.ppp_fsm_close: (rx_workq): [IPV6CP/0x00151f94] Current state STARTING (1)
[00:00:08.270,000] <dbg> net_l2_ppp.ppp_change_state_debug: (rx_workq): [IPV6CP/0x00151f94] state STARTING (1) => INITIAL (0) (ppp_fsm_close():232)
[00:00:08.270,000] <dbg> net_l2_ppp.ppp_change_phase_debug: (rx_workq): [0x00151de0] phase NETWORK (3) => DEAD (0) (ppp_link_down():118)
[00:00:08.270,000] <dbg> net_l2_ppp.validate_phase_transition: (rx_workq): Invalid phase transition: NETWORK (3) => DEAD (0)
[00:00:08.270,000] <dbg> net_l2_ppp.ppp_change_phase_debug: (rx_workq): [0x00151de0] phase DEAD (0) => ESTABLISH (1) (lcp_down():93)
[00:00:08.270,000] <dbg> net_l2_ppp.ppp_send_pkt: (rx_workq): [LCP/0x00151e14] Sending 6 bytes pkt 0x0014d0f4 (options len 0)
[00:00:08.270,000] <dbg> net_l2_ppp.net_pkt_hexdump: send L2
[00:00:08.270,000] <dbg> net_l2_ppp: 0x0014d0f4
c0 21 06 03 00 04                                |.!....
```

Logs after this change:
```
[00:00:09.310,000] <dbg> net_l2_ppp.net_pkt_hexdump: recv L2
[00:00:09.310,000] <dbg> net_l2_ppp: 0x0014d64c
c0 21 05 03 00 10 55 73  65 72 20 72 65 71 75 65 |.!....Us er reque
73 74                                            |st
[00:00:09.310,000] <dbg> net_l2_ppp.ppp_fsm_input: (rx_workq): [LCP/0x00151e14] LCP Terminate-Req (5) id 3 payload len 12
[00:00:09.310,000] <dbg> net_l2_ppp.fsm_recv_terminate_req: (rx_workq): [LCP/0x00151e14] Current state OPENED (9)
[00:00:09.310,000] <dbg> net_l2_ppp.fsm_recv_terminate_req: (rx_workq): [LCP/0x00151e14] Terminated by peer (User request)
[00:00:09.310,000] <dbg> net_l2_ppp.ppp_change_state_debug: (rx_workq): [LCP/0x00151e14] state OPENED (9) => STOPPING (5) (fsm_recv_terminate_req():870)
[00:00:09.310,000] <dbg> net_l2_ppp.ppp_change_phase_debug: (rx_workq): [0x00151de0] phase RUNNING (4) => NETWORK (3) (ppp_link_down():114)
[00:00:09.310,000] <dbg> net_l2_ppp.ppp_fsm_lower_down: (rx_workq): [IPCP/0x00151ed0] Current state OPENED (9)
[00:00:09.310,000] <dbg> net_l2_ppp.ppp_change_state_debug: (rx_workq): [IPCP/0x00151ed0] state OPENED (9) => STARTING (1) (ppp_fsm_lower_down():274)
[00:00:09.310,000] <dbg> net_l2_ppp.ppp_network_down: (rx_workq): [0x00151de0] Proto IPv4 (0x0021) down (1)
[00:00:09.310,000] <dbg> net_l2_ppp.ppp_fsm_close: (rx_workq): [IPCP/0x00151ed0] Current state STARTING (1)
[00:00:09.310,000] <dbg> net_l2_ppp.ppp_change_state_debug: (rx_workq): [IPCP/0x00151ed0] state STARTING (1) => INITIAL (0) (ppp_fsm_close():232)
[00:00:09.310,000] <dbg> net_l2_ppp.ppp_fsm_lower_down: (rx_workq): [IPV6CP/0x00151f94] Current state OPENED (9)
[00:00:09.310,000] <dbg> net_l2_ppp.ppp_change_state_debug: (rx_workq): [IPV6CP/0x00151f94] state OPENED (9) => STARTING (1) (ppp_fsm_lower_down():274)
[00:00:09.310,000] <dbg> net_l2_ppp.ppp_change_phase_debug: (rx_workq): [0x00151de0] phase NETWORK (3) => TERMINATE (5) (ppp_network_down():37)
[00:00:09.310,000] <dbg> net_l2_ppp.ppp_network_down: (rx_workq): [0x00151de0] Proto IPv6 (0x0057) down (0)
[00:00:09.310,000] <dbg> net_l2_ppp.ipv6cp_down: (rx_workq): [IPV6CP/0x00151f94] Peer fe80::5dd4:2d57:cb8a:28b1 [5D:D4:2D:57:CB:8A:28:B1] removed from nbr cache
[00:00:09.310,000] <dbg> net_l2_ppp.ppp_fsm_close: (rx_workq): [IPV6CP/0x00151f94] Current state STARTING (1)
[00:00:09.310,000] <dbg> net_l2_ppp.ppp_change_state_debug: (rx_workq): [IPV6CP/0x00151f94] state STARTING (1) => INITIAL (0) (ppp_fsm_close():232)
[00:00:09.310,000] <dbg> net_l2_ppp.ppp_change_phase_debug: (rx_workq): [0x00151de0] phase TERMINATE (5) => DEAD (0) (ppp_link_down():118)
[00:00:09.310,000] <dbg> net_l2_ppp.ppp_change_phase_debug: (rx_workq): [0x00151de0] phase DEAD (0) => ESTABLISH (1) (lcp_down():93)
[00:00:09.310,000] <dbg> net_l2_ppp.ppp_send_pkt: (rx_workq): [LCP/0x00151e14] Sending 6 bytes pkt 0x0014d140 (options len 0)
[00:00:09.310,000] <dbg> net_l2_ppp.net_pkt_hexdump: send L2
[00:00:09.310,000] <dbg> net_l2_ppp: 0x0014d140
c0 21 06 03 00 04                                |.!.... 
```

The main difference is that `Proto IPv6 (0x0057) down (0)` is now visible. `(0`) means that there are 0 network protocols up, so overall PPP switches from NETWORK phase to TERMINATE phase.