### PR TITLE
boards: arm: atsamr21_xpro: Add PWM support

### DIFF
--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
@@ -21,6 +21,7 @@
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;
+		pwm-led0 = &pwm_led0;
 		sw0 = &user_button;
 		i2c-0 = &sercom1;
 	};
@@ -30,6 +31,13 @@
 		led0: led_0 {
 			gpios = <&porta 19 GPIO_ACTIVE_LOW>;
 			label = "Yellow LED";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&tcc0 3>;
 		};
 	};
 
@@ -44,6 +52,13 @@
 
 &cpu0 {
 	clock-frequency = <48000000>;
+};
+
+&tcc0 {
+	status = "okay";
+	compatible = "atmel,sam0-tcc-pwm";
+	prescaler = <4>;
+	#pwm-cells = <1>;
 };
 
 &sercom0 {

--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.yaml
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.yaml
@@ -15,5 +15,6 @@ supported:
   - gpio
   - i2c
   - ieee802154
+  - pwm
   - spi
   - usb_device

--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.yaml
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.yaml
@@ -13,7 +13,7 @@ toolchain:
   - xtools
 supported:
   - gpio
-  - spi
   - i2c
   - ieee802154
+  - spi
   - usb_device

--- a/boards/arm/atsamr21_xpro/doc/index.rst
+++ b/boards/arm/atsamr21_xpro/doc/index.rst
@@ -45,6 +45,8 @@ features:
 +-----------+------------+--------------------------------------+
 | GPIO      | on-chip    | I/O ports                            |
 +-----------+------------+--------------------------------------+
+| PWM       | on-chip    | Pulse Width Modulation               |
++-----------+------------+--------------------------------------+
 | USART     | on-chip    | Serial ports                         |
 +-----------+------------+--------------------------------------+
 | SPI       | on-chip    | Serial Peripheral Interface ports    |
@@ -81,7 +83,7 @@ Default Zephyr Peripheral Mapping:
 - SERCOM5 SPI MOSI : PB22
 - SERCOM5 SPI SCK  : PB23
 - GPIO SPI CS      : PB03
-- GPIO LED0        : PB17
+- GPIO/PWM LED0    : PA19
 
 System Clock
 ============
@@ -96,6 +98,13 @@ The SAMR21 MCU has six SERCOM based USARTs with two configured as USARTs in
 this BSP. SERCOM0 is the default Zephyr console.
 
 - SERCOM0 115200 8n1 connected to the onboard Atmel Embedded Debugger (EDBG)
+
+PWM
+===
+
+The SAMR21 MCU has 3 TCC based PWM units with up to 4 outputs each and a
+period of 24 bits or 16 bits.  If :code:`CONFIG_PWM_SAM0_TCC` is enabled then
+LED0 is driven by TCC0 instead of by GPIO.
 
 SPI Port
 ========

--- a/boards/arm/atsamr21_xpro/pinmux.c
+++ b/boards/arm/atsamr21_xpro/pinmux.c
@@ -95,6 +95,13 @@ static int board_pinmux_init(struct device *dev)
 #warning Pin mapping may not be configured
 #endif
 
+#if (ATMEL_SAM0_DT_TCC_CHECK(0, atmel_sam0_tcc_pwm) && \
+	defined(CONFIG_PWM_SAM0_TCC))
+
+	/* TCC0 on WO3=PA19 */
+	pinmux_pin_set(muxa, 19, PINMUX_FUNC_F);
+#endif
+
 #ifdef CONFIG_USB_DC_SAM0
 	/* USB DP on PA25, USB DM on PA24 */
 	pinmux_pin_set(muxa, 25, PINMUX_FUNC_G);

--- a/dts/arm/atmel/samr21.dtsi
+++ b/dts/arm/atmel/samr21.dtsi
@@ -43,6 +43,42 @@
 			reg = <0x41004500 0x80>;
 			label = "PINMUX_C";
 		};
+
+		tcc0: tcc@42002000 {
+			compatible = "atmel,sam0-tcc";
+			reg = <0x42002000 0x80>;
+			interrupts = <15 0>;
+			label = "TCC_0";
+			clocks = <&gclk 26>, <&pm 0x20 8>;
+			clock-names = "GCLK", "PM";
+
+			channels = <4>;
+			counter-size = <24>;
+		};
+
+		tcc1: tcc@42002400 {
+			compatible = "atmel,sam0-tcc";
+			reg = <0x42002400 0x80>;
+			interrupts = <16 0>;
+			label = "TCC_1";
+			clocks = <&gclk 26>, <&pm 0x20 9>;
+			clock-names = "GCLK", "PM";
+
+			channels = <2>;
+			counter-size = <24>;
+		};
+
+		tcc2: tcc@42002800 {
+			compatible = "atmel,sam0-tcc";
+			reg = <0x42002800 0x80>;
+			interrupts = <17 0>;
+			label = "TCC_2";
+			clocks = <&gclk 27>, <&pm 0x20 10>;
+			clock-names = "GCLK", "PM";
+
+			channels = <2>;
+			counter-size = <16>;
+		};
 	};
 };
 


### PR DESCRIPTION
This enables PWM and connects it to the LED0.  Tested with blinky_pwm and fade_led samples.