### PR TITLE
drivers: wifi: eswifi: Add chip select flags

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -118,7 +118,7 @@
 	status = "okay";
 
 	cs-gpios = <&gpiod 13 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>,
-		   <&gpioe 0 GPIO_ACTIVE_HIGH>;
+		   <&gpioe 0 GPIO_ACTIVE_LOW>;
 
 	spbtle-rf@0 {
 		compatible = "zephyr,bt-hci-spi";

--- a/drivers/wifi/eswifi/eswifi_bus_spi.c
+++ b/drivers/wifi/eswifi/eswifi_bus_spi.c
@@ -256,6 +256,7 @@ int eswifi_spi_init(struct eswifi_dev *eswifi)
 	spi->spi_cs.gpio_dev =
 		device_get_binding(DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
 	spi->spi_cs.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
+	spi->spi_cs.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
 	spi->spi_cs.delay = 1000U;
 	spi->spi_cfg.cs = &spi->spi_cs;
 


### PR DESCRIPTION
Adds the chip select devicetree flags to the spi_cs_control instance.
ISM43362 chip select is ACTIVE_LOW.

Signed-off-by: Parthiban Nallathambi <parthiban@linumiz.com>