### PR TITLE
Fix SPI CS handling in LoRa radios 

### DIFF
--- a/drivers/lora/sx126x.c
+++ b/drivers/lora/sx126x.c
@@ -34,6 +34,7 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(semtech_sx1261) +
 #define HAVE_GPIO_CS		DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 #define GPIO_CS_LABEL		DT_INST_SPI_DEV_CS_GPIOS_LABEL(0)
 #define GPIO_CS_PIN		DT_INST_SPI_DEV_CS_GPIOS_PIN(0)
+#define GPIO_CS_FLAGS		DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0)
 
 #define GPIO_RESET_LABEL	DT_INST_GPIO_LABEL(0, reset_gpios)
 #define GPIO_RESET_PIN		DT_INST_GPIO_PIN(0, reset_gpios)
@@ -441,11 +442,14 @@ static int sx126x_lora_init(struct device *dev)
 
 #if HAVE_GPIO_CS
 	dev_data.spi_cs.gpio_dev = device_get_binding(GPIO_CS_LABEL);
-	dev_data.spi_cs.gpio_pin = GPIO_CS_PIN;
 	if (!dev_data.spi_cs.gpio_dev) {
 		LOG_ERR("Cannot get pointer to %s device", GPIO_CS_LABEL);
 		return -EIO;
 	}
+
+	dev_data.spi_cs.gpio_pin = GPIO_CS_PIN;
+	dev_data.spi_cs.gpio_dt_flags = GPIO_CS_FLAGS;
+	dev_data.spi_cs.delay = 0U;
 
 	dev_data.spi_cfg.cs = &dev_data.spi_cs;
 #endif

--- a/drivers/lora/sx1276.c
+++ b/drivers/lora/sx1276.c
@@ -23,6 +23,7 @@ LOG_MODULE_REGISTER(sx1276);
 #define GPIO_RESET_PIN		DT_INST_GPIO_PIN(0, reset_gpios)
 #define GPIO_RESET_FLAGS	DT_INST_GPIO_FLAGS(0, reset_gpios)
 #define GPIO_CS_PIN		DT_INST_SPI_DEV_CS_GPIOS_PIN(0)
+#define GPIO_CS_FLAGS		DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0)
 
 #define GPIO_ANTENNA_ENABLE_PIN				\
 	DT_INST_GPIO_PIN(0, antenna_enable_gpios)
@@ -541,7 +542,6 @@ static int sx1276_lora_init(struct device *dev)
 	dev_data.spi_cfg.slave = DT_INST_REG_ADDR(0);
 
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	spi_cs.gpio_pin = GPIO_CS_PIN,
 	spi_cs.gpio_dev = device_get_binding(
 			DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
 	if (!spi_cs.gpio_dev) {
@@ -549,6 +549,10 @@ static int sx1276_lora_init(struct device *dev)
 		       DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
 		return -EIO;
 	}
+
+	spi_cs.gpio_pin = GPIO_CS_PIN;
+	spi_cs.gpio_dt_flags = GPIO_CS_FLAGS;
+	spi_cs.delay = 0U;
 
 	dev_data.spi_cfg.cs = &spi_cs;
 #endif


### PR DESCRIPTION
Use CS flags from the device tree. Fixes a bug introduced by #26269.