### PR TITLE
scripts: sanitylib.py: handle unexpected QEMU crash

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -831,6 +831,10 @@ class QEMUHandler(Handler):
         handler_time = time.time() - start_time
         logger.debug("QEMU complete (%s) after %f seconds" %
                      (out_state, handler_time))
+
+        if out_state in ["unexpected byte", "unexpected eof"]:
+            out_state = "failed"
+
         handler.set_state(out_state, handler_time)
         if out_state == "timeout":
             handler.instance.reason = "Timeout"


### PR DESCRIPTION
When unexpected QEMU crash happened, record it as failed.

Fixes: #26679.

Signed-off-by: Wentong Wu <wentong.wu@intel.com>