### PR TITLE
tests: lib: mem_alloc: restrict newlib config to more than 16K RAM

### DIFF
--- a/tests/lib/mem_alloc/testcase.yaml
+++ b/tests/lib/mem_alloc/testcase.yaml
@@ -5,6 +5,7 @@ tests:
     platform_exclude: twr_ke18f
     tags: clib minimal_libc userspace
   libraries.libc.newlib:
+    min_ram: 16
     extra_args: CONF_FILE=prj_newlib.conf
     arch_exclude: posix
     platform_exclude: twr_ke18f


### PR DESCRIPTION
tests: lib: mem_alloc: restrict newlib config to more than 16K RAM

This test fails for newlib configuration, for nucleo_f030r8 which has only 8K of RAM.
But each step of the test is successfull when executed solely or with smaller buffer size.
Note: test is working on nucleo_f091rc which has larger RAM (32K)

Signed-off-by: Alexandre Bourdiol <alexandre.bourdiol@st.com>