### PR TITLE
Bluetooth: Mesh: Wait for proxy on node reset

### DIFF
--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -2622,6 +2622,8 @@ static void node_reset(struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
+	static struct bt_mesh_proxy_idle_cb proxy_idle = {.cb = bt_mesh_reset};
+
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NODE_RESET_STATUS, 0);
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
@@ -2638,7 +2640,15 @@ static void node_reset(struct bt_mesh_model *model,
 		BT_ERR("Unable to send Node Reset Status");
 	}
 
-	bt_mesh_reset();
+	if (!IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY)) {
+		bt_mesh_reset();
+		return;
+	}
+
+	/* If the response goes to a proxy node, we'll wait for the sending to
+	 * complete before moving on.
+	 */
+	bt_mesh_proxy_on_idle(&proxy_idle);
 }
 
 static void send_friend_status(struct bt_mesh_model *model,

--- a/subsys/bluetooth/mesh/proxy.h
+++ b/subsys/bluetooth/mesh/proxy.h
@@ -11,6 +11,12 @@
 #define BT_MESH_PROXY_CONFIG    0x02
 #define BT_MESH_PROXY_PROV      0x03
 
+
+struct bt_mesh_proxy_idle_cb {
+	sys_snode_t n;
+	void (*cb)(void);
+};
+
 int bt_mesh_proxy_send(struct bt_conn *conn, uint8_t type,
 		       struct net_buf_simple *msg);
 
@@ -35,3 +41,4 @@ bool bt_mesh_proxy_relay(struct net_buf_simple *buf, uint16_t dst);
 void bt_mesh_proxy_addr_add(struct net_buf_simple *buf, uint16_t addr);
 
 int bt_mesh_proxy_init(void);
+void bt_mesh_proxy_on_idle(struct bt_mesh_proxy_idle_cb *cb);


### PR DESCRIPTION
Adds idle wait callback to proxy by counting the number of pending
notifications.

Ensures that all connected nodes have received messages before resetting
the mesh stack.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>