### PR TITLE
boards: fix SPI GPIO CS, display, link_board_eth, dw1000

### DIFF
--- a/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
+++ b/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
@@ -124,7 +124,7 @@
 	sck-pin  = <16>;
 	mosi-pin = <20>;
 	miso-pin = <18>;
-	cs-gpios = <&gpio0 17 0>;
+	cs-gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 
 	dw1000@0 {
 		compatible = "decawave,dw1000";

--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -55,7 +55,7 @@
 	sck-pin = <19>;
 	mosi-pin = <20>;
 	miso-pin = <21>;
-	cs-gpios = <&gpio0 17 0>;
+	cs-gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 
 	ssd16xxfb@0 {
 		compatible = "solomon,ssd16xxfb", "gooddisplay,gdeh0213b1";

--- a/boards/arm/reel_board/reel_board_v2.dts
+++ b/boards/arm/reel_board/reel_board_v2.dts
@@ -31,7 +31,7 @@
 	sck-pin = <19>;
 	mosi-pin = <20>;
 	miso-pin = <21>;
-	cs-gpios = <&gpio0 17 0>;
+	cs-gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 
 	ssd16xxfb@0 {
 		compatible = "solomon,ssd16xxfb", "gooddisplay,gdeh0213b72";

--- a/boards/shields/adafruit_2_8_tft_touch_v2/adafruit_2_8_tft_touch_v2.overlay
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/adafruit_2_8_tft_touch_v2.overlay
@@ -6,7 +6,7 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 0>;			/* D10 */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
 
 
 	ili9340@0 {

--- a/boards/shields/link_board_eth/link_board_eth.overlay
+++ b/boards/shields/link_board_eth/link_board_eth.overlay
@@ -6,7 +6,7 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 0>;		/* D10 */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
 
 	enc424j600@0 {
 		compatible = "microchip,enc424j600";

--- a/boards/shields/st7789v_generic/st7789v_tl019fqv01.overlay
+++ b/boards/shields/st7789v_generic/st7789v_tl019fqv01.overlay
@@ -6,7 +6,7 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 0>;	/* D10 */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
 
 	st7789v@0 {
 		compatible = "sitronix,st7789v";

--- a/boards/shields/st7789v_generic/st7789v_waveshare_240x240.overlay
+++ b/boards/shields/st7789v_generic/st7789v_waveshare_240x240.overlay
@@ -7,7 +7,7 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 0>;	/* D10 */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
 
 	st7789v@0 {
 		compatible = "sitronix,st7789v";

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0154a07.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0154a07.overlay
@@ -6,7 +6,7 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 0>;		/* D10 */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
 
 	ssd16xxfb@0 {
 		compatible = "solomon,ssd16xxfb", "gooddisplay,gdeh0154a07";

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b1.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b1.overlay
@@ -6,7 +6,7 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 0>;		/* D10 */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
 
 	ssd16xxfb@0 {
 		compatible = "solomon,ssd16xxfb", "gooddisplay,gdeh0213b1";

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b72.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b72.overlay
@@ -6,7 +6,7 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 0>;		/* D10 */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
 
 	ssd16xxfb@0 {
 		compatible = "solomon,ssd16xxfb", "gooddisplay,gdeh0213b72";

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh029a1.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh029a1.overlay
@@ -6,7 +6,7 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 0>;		/* D10 */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
 
 	ssd16xxfb@0 {
 		compatible = "solomon,ssd16xxfb", "gooddisplay,gdeh029a1";

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdew075t7.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdew075t7.overlay
@@ -6,7 +6,7 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 0>;		/* D10 */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
 
 	gd7965@0 {
 		compatible = "gooddisplay,gd7965";

--- a/drivers/ieee802154/ieee802154_dw1000.c
+++ b/drivers/ieee802154/ieee802154_dw1000.c
@@ -98,6 +98,7 @@ struct dwt_hi_cfg {
 	gpio_dt_flags_t rst_flags;
 	const char *spi_port;
 	uint8_t spi_cs_pin;
+	gpio_dt_flags_t spi_cs_flags;
 	const char *spi_cs_port;
 	uint32_t spi_freq;
 	uint8_t spi_slave;
@@ -141,6 +142,7 @@ static const struct dwt_hi_cfg dw1000_0_config = {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	.spi_cs_port = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
 	.spi_cs_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
+	.spi_cs_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0),
 #endif
 };
 
@@ -1517,6 +1519,7 @@ static int dw1000_init(struct device *dev)
 	}
 
 	ctx->spi_cs.gpio_pin = hi_cfg->spi_cs_pin;
+	ctx->spi_cs.gpio_dt_flags = hi_cfg->spi_cs_flags;
 	ctx->spi_cfg_slow.cs = &ctx->spi_cs;
 	ctx->spi_cfg_fast.cs = &ctx->spi_cs;
 #endif


### PR DESCRIPTION
Since commit 5963eba
("drivers: spi: CS configuration through devicetree")
the SPI GPIO CS flags are obtained from DT,
but the patch series has missed the necessary changes
for the ieee802154_dw1000 driver and decawave_dwm1001_dev board,
and in the device trees for displays and link_board_eth.