### PR TITLE
drivers: console: gsm_mux: fix timeout after timeout API change

### DIFF
--- a/drivers/console/gsm_mux.c
+++ b/drivers/console/gsm_mux.c
@@ -17,10 +17,8 @@ LOG_MODULE_REGISTER(gsm_mux, CONFIG_GSM_MUX_LOG_LEVEL);
 #include "gsm_mux.h"
 
 /* Default values are from the specification 07.10 */
-#define T1 100  /* 100 ms */
-#define T2 340  /* 333 ms */
-#define T1_MSEC K_MSEC(T1)
-#define T2_MSEC K_MSEC(T2)
+#define T1_MSEC 100  /* 100 ms */
+#define T2_MSEC 340  /* 333 ms */
 
 #define N1 256 /* default I frame size, GSM 07.10 ch 6.2.2.1 */
 #define N2 3   /* retry 3 times */
@@ -469,7 +467,7 @@ static void dlci_run_timer(uint32_t current_time)
 	}
 
 	if (new_timer != UINT_MAX) {
-		k_delayed_work_submit(&t1_timer, new_timer);
+		k_delayed_work_submit(&t1_timer, K_MSEC(new_timer));
 	}
 }
 
@@ -634,7 +632,7 @@ static void gsm_mux_t2_timeout(struct k_work *work)
 
 	if (entry) {
 		k_delayed_work_submit(&mux->t2_timer,
-				      K_MSEC(entry->req_start + T2 -
+				      K_MSEC(entry->req_start + T2_MSEC -
 					     current_time));
 	}
 }
@@ -677,7 +675,7 @@ static int gsm_mux_send_control_message(struct gsm_mux *mux, uint8_t dlci_addres
 
 	/* Let's start the timer if necessary */
 	if (!k_delayed_work_remaining_get(&mux->t2_timer)) {
-		k_delayed_work_submit(&mux->t2_timer, T2_MSEC);
+		k_delayed_work_submit(&mux->t2_timer, K_MSEC(T2_MSEC));
 	}
 
 	return gsm_mux_modem_send(mux, buf->data, buf->len);
@@ -1469,8 +1467,8 @@ struct gsm_mux *gsm_mux_create(struct device *uart)
 		mux->mru = CONFIG_GSM_MUX_MRU_DEFAULT_LEN;
 		mux->retries = N2;
 		mux->t1_timeout_value = CONFIG_GSM_MUX_T1_TIMEOUT ?
-			CONFIG_GSM_MUX_T1_TIMEOUT : T1;
-		mux->t2_timeout_value = T2;
+			CONFIG_GSM_MUX_T1_TIMEOUT : T1_MSEC;
+		mux->t2_timeout_value = T2_MSEC;
 		mux->is_initiator = CONFIG_GSM_MUX_INITIATOR;
 		mux->state = GSM_MUX_SOF;
 		mux->buf = NULL;


### PR DESCRIPTION
New timeout API uses opaque k_timeout_t type. Adjust code to work with
that properly.