### PR TITLE
sanitycheck: Use the C LibYAML parser if available

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -29,8 +29,16 @@ import logging
 from pathlib import Path
 from distutils.spawn import find_executable
 from colorama import Fore
-import yaml
 import platform
+import yaml
+try:
+    # Use the C LibYAML parser if available, rather than the Python parser.
+    # It's much faster.
+    from yaml import CLoader as Loader
+    from yaml import CSafeLoader as SafeLoader
+    from yaml import CDumper as Dumper
+except ImportError:
+    from yaml import Loader, SafeLoader, Dumper
 
 try:
     import serial
@@ -3449,7 +3457,7 @@ class HardwareMap:
         # use existing map
         if os.path.exists(hwm_file):
             with open(hwm_file, 'r') as yaml_file:
-                hwm = yaml.load(yaml_file, Loader=yaml.FullLoader)
+                hwm = yaml.load(yaml_file, Loader=SafeLoader)
                 hwm.sort(key=lambda x: x['serial'] or '')
 
                 # disconnect everything
@@ -3472,12 +3480,12 @@ class HardwareMap:
                 self.dump(hwm)
 
             with open(hwm_file, 'w') as yaml_file:
-                yaml.dump(hwm, yaml_file, default_flow_style=False)
+                yaml.dump(hwm, yaml_file, Dumper=Dumper, default_flow_style=False)
 
         else:
             # create new file
             with open(hwm_file, 'w') as yaml_file:
-                yaml.dump(self.detected, yaml_file, default_flow_style=False)
+                yaml.dump(self.detected, yaml_file, Dumper=Dumper, default_flow_style=False)
             logger.info("Detected devices:")
             self.dump(self.detected)
 

--- a/scripts/sanity_chk/scl.py
+++ b/scripts/sanity_chk/scl.py
@@ -8,6 +8,14 @@
 
 import logging
 import yaml
+try:
+    # Use the C LibYAML parser if available, rather than the Python parser.
+    # It's much faster.
+    from yaml import CLoader as Loader
+    from yaml import CSafeLoader as SafeLoader
+    from yaml import CDumper as Dumper
+except ImportError:
+    from yaml import Loader, SafeLoader, Dumper
 
 log = logging.getLogger("scl")
 
@@ -27,7 +35,7 @@ def yaml_load(filename):
     """
     try:
         with open(filename, 'r') as f:
-            return yaml.safe_load(f)
+            return yaml.load(f, Loader=SafeLoader)
     except yaml.scanner.ScannerError as e:	# For errors parsing schema.yaml
         mark = e.problem_mark
         cmark = e.context_mark


### PR DESCRIPTION
Use the C LibYAML parser if available, rather than the Python parser. It
is much faster.

This is a clean and rebased version of PR #20210 by
Ulf Magnusson <Ulf.Magnusson@nordicsemi.no>

Co-authored-by: Ulf Magnusson <Ulf.Magnusson@nordicsemi.no>