### PR TITLE
drivers: pwm: stm32: fix polarity setting

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -94,7 +94,7 @@ static inline const struct pwm_stm32_config *to_config(struct device *dev)
  */
 static uint32_t get_polarity(pwm_flags_t flags)
 {
-	if (flags & PWM_POLARITY_NORMAL) {
+	if ((flags & PWM_POLARITY_MASK) == PWM_POLARITY_NORMAL) {
 		return LL_TIM_OCPOLARITY_HIGH;
 	}
 


### PR DESCRIPTION
PWM polarity was not being set correctly because flags were not checked
correctly.

Signed-off-by: Gerard Marull-Paretas <gerard@teslabs.com>