### PR TITLE
actions: Add label for nxp boards, drivers, socs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -126,6 +126,16 @@
 "area: Shields":
   - "boards/shields/**"
   - "samples/shields/**"
+"platform: NXP":
+  - "boards/arm/frdm*/**"
+  - "boards/arm/hexiwear*/**"
+  - "boards/arm/lpcxpresso*/**"
+  - "boards/arm/*imx*/**"
+  - "drivers/**/*imx*"
+  - "drivers/**/*mcux*"
+  - "dts/arm/nxp/*/*"
+  - "dts/bindings/**/nxp*"
+  - "soc/arm/nxp*/**"
 "platform: STM32":
   - "boards/arm/nucleo_*/**"
   - "boards/arm/*stm32*/**"


### PR DESCRIPTION
Extends the github labeling action to automatically add the nxp label to
nxp-related boards, drivers, and socs.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>