### PR TITLE
spi-device: provide CS gpio flags and update drivers to use them

### DIFF
--- a/boards/arc/hsdk/hsdk.dts
+++ b/boards/arc/hsdk/hsdk.dts
@@ -47,7 +47,7 @@
 	status = "okay";
 	clock-frequency = <33333333>;
 
-	cs-gpios = <&gpio0 9 0>;
+	cs-gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 	ili9340@0 {
 		compatible = "ilitek,ili9340";
 		cmd-data-gpios = <&gpio0 21 0>;

--- a/boards/arm/96b_wistrio/96b_wistrio.dts
+++ b/boards/arm/96b_wistrio/96b_wistrio.dts
@@ -60,7 +60,7 @@
 
 &spi1 {
 	status = "okay";
-	cs-gpios = <&gpiob 0 0>;
+	cs-gpios = <&gpiob 0 GPIO_ACTIVE_LOW>;
 
 	lora: sx1276@0 {
 		compatible = "semtech,sx1276";

--- a/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
+++ b/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
@@ -52,7 +52,7 @@
 	dopo = <1>;
 	#address-cells = <1>;
 	#size-cells = <0>;
-	cs-gpios = <&porta 5 0>;
+	cs-gpios = <&porta 5 GPIO_ACTIVE_LOW>;
 };
 
 &sercom2 {

--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
@@ -91,7 +91,7 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 
-	cs-gpios = <&portb 31 0>;
+	cs-gpios = <&portb 31 GPIO_ACTIVE_LOW>;
 
 	rf2xx@0 {
 		compatible = "atmel,rf2xx";

--- a/boards/arm/bl652_dvk/bl652_dvk.dts
+++ b/boards/arm/bl652_dvk/bl652_dvk.dts
@@ -95,7 +95,7 @@
 	sck-pin = <25>;
 	mosi-pin = <23>;
 	miso-pin = <24>;
-	cs-gpios = <&gpio0 22 0>;
+	cs-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 };
 
 &spi1 {
@@ -104,7 +104,7 @@
 	sck-pin = <16>;
 	mosi-pin = <20>;
 	miso-pin = <14>;
-	cs-gpios = <&gpio0 12 0>;
+	cs-gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 };
 
 &flash0 {

--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -119,7 +119,7 @@
 	sck-pin = <41>;
 	mosi-pin = <40>;
 	miso-pin = <4>;
-	cs-gpios = <&gpio1 12 0>;
+	cs-gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
 };
 
 &spi1 {
@@ -128,7 +128,7 @@
 	sck-pin = <19>;
 	mosi-pin = <20>;
 	miso-pin = <21>;
-	cs-gpios = <&gpio0 17 0>;
+	cs-gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 	mx25r6435f@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;

--- a/boards/arm/cc1352r1_launchxl/cc1352r1_launchxl.dts
+++ b/boards/arm/cc1352r1_launchxl/cc1352r1_launchxl.dts
@@ -92,7 +92,7 @@
 	mosi-pin = <9>;
 	miso-pin = <8>;
 	cs-pin = <11>;
-	cs-gpios = <&gpio0 11 0>;
+	cs-gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 };
 
 &rtc {

--- a/boards/arm/cc26x2r1_launchxl/cc26x2r1_launchxl.dts
+++ b/boards/arm/cc26x2r1_launchxl/cc26x2r1_launchxl.dts
@@ -92,7 +92,7 @@
 	mosi-pin = <9>;
 	miso-pin = <8>;
 	cs-pin = <11>;
-	cs-gpios = <&gpio0 11 0>;
+	cs-gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 };
 
 &rtc {

--- a/boards/arm/efr32_radio/efr32_radio.dtsi
+++ b/boards/arm/efr32_radio/efr32_radio.dtsi
@@ -67,7 +67,7 @@
 	location-tx = <GECKO_LOCATION(11) GECKO_PORT_C GECKO_PIN(6)>;
 	location-clk = <GECKO_LOCATION(11) GECKO_PORT_C GECKO_PIN(8)>;
 
-	cs-gpios = <&gpioa 4 0>;
+	cs-gpios = <&gpioa 4 GPIO_ACTIVE_LOW>;
 
 	status = "okay";
 

--- a/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
+++ b/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
@@ -76,7 +76,7 @@
 	location-tx = <GECKO_LOCATION(29) GECKO_PORT_K GECKO_PIN(0)>;
 	location-clk = <GECKO_LOCATION(18) GECKO_PORT_F GECKO_PIN(7)>;
 
-	cs-gpios = <&gpiok 1 0>;
+	cs-gpios = <&gpiok 1 GPIO_ACTIVE_LOW>;
 
 	status = "okay";
 

--- a/boards/arm/nrf51_ble400/nrf51_ble400.dts
+++ b/boards/arm/nrf51_ble400/nrf51_ble400.dts
@@ -92,7 +92,7 @@
 	sck-pin = <25>;
 	mosi-pin = <24>;
 	miso-pin = <23>;
-	cs-gpios = <&gpio0 30 0>;
+	cs-gpios = <&gpio0 30 GPIO_ACTIVE_LOW>;
 };
 
 &uart0 {

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
@@ -188,7 +188,7 @@ arduino_spi: &spi3 {
 	sck-pin = <23>;
 	miso-pin = <22>;
 	mosi-pin = <21>;
-	cs-gpios = <&arduino_header 16 0>; /* D10 */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
 };
 
 &flash0 {

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -228,7 +228,7 @@ arduino_spi: &spi3 {
 	sck-pin = <47>;
 	miso-pin = <46>;
 	mosi-pin = <45>;
-	cs-gpios = <&arduino_header 16 0>; /* D10 */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
 };
 
 &flash0 {

--- a/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
+++ b/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
@@ -190,7 +190,7 @@ arduino_spi: &spi2 {
 	sck-pin = <25>;
 	mosi-pin = <23>;
 	miso-pin = <24>;
-	cs-gpios = <&arduino_header 16 0>; /* D10 */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
 };
 
 &flash0 {

--- a/boards/arm/particle_argon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather.dtsi
@@ -193,7 +193,7 @@ feather_i2c: &i2c0 { };
 	sck-pin = <19>;
 	mosi-pin = <20>;
 	miso-pin = <21>;
-	cs-gpios = <&gpio0 17 0>;
+	cs-gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 	mx25l32: mx25l3233f@0 {
 		compatible = "jedec,spi-nor";
 		label = "MX25L3233F";

--- a/boards/arm/particle_boron/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather.dtsi
@@ -193,7 +193,7 @@ feather_i2c: &i2c0 { };
 	sck-pin = <19>;
 	mosi-pin = <20>;
 	miso-pin = <21>;
-	cs-gpios = <&gpio0 17 0>;
+	cs-gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 	mx25l32: mx25l3233f@0 {
 		compatible = "jedec,spi-nor";
 		label = "MX25L3233F";

--- a/boards/arm/particle_xenon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather.dtsi
@@ -193,7 +193,7 @@ feather_i2c: &i2c0 { };
 	sck-pin = <19>;
 	mosi-pin = <20>;
 	miso-pin = <21>;
-	cs-gpios = <&gpio0 17 0>;
+	cs-gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 	mx25l32: mx25l3233f@0 {
 		compatible = "jedec,spi-nor";
 		label = "MX25L3233F";

--- a/boards/arm/reel_board/dts/reel_board.dtsi
+++ b/boards/arm/reel_board/dts/reel_board.dtsi
@@ -159,7 +159,7 @@ arduino_spi: &spi3 {
 	sck-pin = <47>;
 	miso-pin = <46>;
 	mosi-pin = <45>;
-	cs-gpios = <&arduino_header 16 0>; /* D10 */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
 };
 
 &flash0 {

--- a/boards/arm/ruuvi_ruuvitag/ruuvi_ruuvitag.dts
+++ b/boards/arm/ruuvi_ruuvitag/ruuvi_ruuvitag.dts
@@ -78,7 +78,7 @@
 	sck-pin = <29>;
 	mosi-pin = <25>;
 	miso-pin = <28>;
-	cs-gpios = <&gpio0 3 0>, <&gpio0 8 0>;
+	cs-gpios = <&gpio0 3 GPIO_ACTIVE_LOW>, <&gpio0 8 GPIO_ACTIVE_LOW>;
 
 	bme280@0 {
 		compatible = "bosch,bme280";

--- a/boards/arm/sensortile_box/sensortile_box.dts
+++ b/boards/arm/sensortile_box/sensortile_box.dts
@@ -81,7 +81,7 @@
 &spi1 {
 	status = "okay";
 
-	cs-gpios = <&gpioe 11 0>, <&gpioe 12 0>, <&gpioe 10 0>;
+	cs-gpios = <&gpioe 11 GPIO_ACTIVE_LOW>, <&gpioe 12 GPIO_ACTIVE_LOW>, <&gpioe 10 GPIO_ACTIVE_LOW>;
 
 	lis2dw12@0 {
 		compatible = "st,lis2dw12";
@@ -111,7 +111,7 @@
 &spi3 {
 	status = "okay";
 
-	cs-gpios = <&gpioa 15 0>;
+	cs-gpios = <&gpioa 15 GPIO_ACTIVE_LOW>;
 
 	lis2mdl@0 {
 		compatible = "st,lis2mdl";

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -66,7 +66,7 @@
 
 &spi5 {
 	status = "okay";
-	cs-gpios = <&gpioc 2 0>;
+	cs-gpios = <&gpioc 2 GPIO_ACTIVE_LOW>;
 	ili9340@0 {
 		compatible = "ilitek,ili9340";
 		label = "DISPLAY";

--- a/boards/riscv/rv32m1_vega/rv32m1_vega.dtsi
+++ b/boards/riscv/rv32m1_vega/rv32m1_vega.dtsi
@@ -137,7 +137,7 @@ arduino_spi: &lpspi0 {
 
 &lpspi1 {
 	status = "okay";
-	cs-gpios = <&gpiob 22 0>;
+	cs-gpios = <&gpiob 22 GPIO_ACTIVE_LOW>;
 	mx25r32: mx25r3235f@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;

--- a/boards/shields/dfrobot_can_bus_v2_0/dfrobot_can_bus_v2_0.overlay
+++ b/boards/shields/dfrobot_can_bus_v2_0/dfrobot_can_bus_v2_0.overlay
@@ -6,7 +6,7 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 0>; /* D10 */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
 
 	can1: mcp2515@0 {
 		compatible = "microchip,mcp2515";

--- a/boards/shields/mikroe_eth_click/mikroe_eth_click.overlay
+++ b/boards/shields/mikroe_eth_click/mikroe_eth_click.overlay
@@ -4,7 +4,7 @@
 
 &mikrobus_spi {
 	status = "okay";
-	cs-gpios = <&mikrobus_header 2 0>; /* CS */
+	cs-gpios = <&mikrobus_header 2 GPIO_ACTIVE_LOW>; /* CS */
 
 	eth_click@0 {
 		compatible = "microchip,enc28j60";

--- a/doc/reference/storage/disk/sdhc.rst
+++ b/doc/reference/storage/disk/sdhc.rst
@@ -33,7 +33,7 @@ SDHC card has been initialized:
 
     &spi1 {
             status = "okay";
-            cs-gpios = <&porta 27 0>;
+            cs-gpios = <&porta 27 GPIO_ACTIVE_LOW>;
 
             sdhc0: sdhc@0 {
                     compatible = "zephyr,mmc-spi-slot";

--- a/drivers/adc/adc_lmp90xxx.c
+++ b/drivers/adc/adc_lmp90xxx.c
@@ -109,7 +109,8 @@ LOG_MODULE_REGISTER(adc_lmp90xxx);
 struct lmp90xxx_config {
 	const char *spi_dev_name;
 	const char *spi_cs_dev_name;
-	uint8_t spi_cs_pin;
+	gpio_pin_t spi_cs_pin;
+	gpio_dt_flags_t spi_cs_dt_flags;
 	struct spi_config spi_cfg;
 	const char *drdyb_dev_name;
 	gpio_pin_t drdyb_pin;
@@ -946,6 +947,7 @@ static int lmp90xxx_init(struct device *dev)
 		}
 
 		data->spi_cs.gpio_pin = config->spi_cs_pin;
+		data->spi_cs.gpio_dt_flags = config->spi_cs_dt_flags;
 	}
 
 	err = lmp90xxx_soft_reset(dev);
@@ -1079,6 +1081,10 @@ static const struct adc_driver_api lmp90xxx_adc_api = {
 		.spi_cs_pin = UTIL_AND( \
 			DT_SPI_DEV_HAS_CS_GPIOS(DT_INST_LMP90XXX(n, t)), \
 			DT_SPI_DEV_CS_GPIOS_PIN(DT_INST_LMP90XXX(n, t)) \
+			), \
+		.spi_cs_dt_flags = UTIL_AND( \
+			DT_SPI_DEV_HAS_CS_GPIOS(DT_INST_LMP90XXX(n, t)), \
+			DT_SPI_DEV_CS_GPIOS_FLAGS(DT_INST_LMP90XXX(n, t)) \
 			), \
 		.spi_cfg = { \
 			.operation = (SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | \

--- a/drivers/adc/adc_mcp320x.c
+++ b/drivers/adc/adc_mcp320x.c
@@ -28,7 +28,8 @@ LOG_MODULE_REGISTER(adc_mcp320x, CONFIG_ADC_LOG_LEVEL);
 struct mcp320x_config {
 	const char *spi_dev_name;
 	const char *spi_cs_dev_name;
-	uint8_t spi_cs_pin;
+	gpio_pin_t spi_cs_pin;
+	gpio_dt_flags_t spi_cs_dt_flags;
 	struct spi_config spi_cfg;
 	uint8_t channels;
 };
@@ -294,6 +295,7 @@ static int mcp320x_init(struct device *dev)
 		}
 
 		data->spi_cs.gpio_pin = config->spi_cs_pin;
+		data->spi_cs.gpio_dt_flags = config->spi_cs_dt_flags;
 	}
 
 	k_thread_create(&data->thread, data->stack,
@@ -335,6 +337,11 @@ static const struct adc_driver_api mcp320x_adc_api = {
 			UTIL_AND( \
 			DT_SPI_DEV_HAS_CS_GPIOS(INST_DT_MCP320X(n, t)), \
 			DT_SPI_DEV_CS_GPIOS_PIN(INST_DT_MCP320X(n, t)) \
+			), \
+		.spi_cs_dt_flags = \
+			UTIL_AND( \
+			DT_SPI_DEV_HAS_CS_GPIOS(INST_DT_MCP320X(n, t)), \
+			DT_SPI_DEV_CS_GPIOS_DT_FLAGS(INST_DT_MCP320X(n, t)) \
 			), \
 		.spi_cfg = { \
 			.operation = (SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | \

--- a/drivers/eeprom/eeprom_at2x.c
+++ b/drivers/eeprom/eeprom_at2x.c
@@ -39,7 +39,8 @@ struct eeprom_at2x_config {
 	uint16_t bus_addr;
 	uint32_t max_freq;
 	const char *spi_cs_dev_name;
-	uint8_t spi_cs_pin;
+	gpio_pin_t spi_cs_pin;
+	gpio_dt_flags_t spi_cs_dt_flags;
 	gpio_pin_t wp_gpio_pin;
 	gpio_dt_flags_t wp_gpio_flags;
 	const char *wp_gpio_name;
@@ -510,6 +511,7 @@ static int eeprom_at2x_init(struct device *dev)
 		}
 
 		data->spi_cs.gpio_pin = config->spi_cs_pin;
+		data->spi_cs.gpio_dt_flags = config->spi_cs_dt_flags;
 		data->spi_cfg.cs = &data->spi_cs;
 	}
 #endif /* CONFIG_EEPROM_AT25 */
@@ -576,6 +578,9 @@ static const struct eeprom_driver_api eeprom_at2x_api = {
 		.spi_cs_pin = UTIL_AND( \
 			DT_SPI_DEV_HAS_CS_GPIOS(INST_DT_AT2X(n, t)), \
 			DT_SPI_DEV_CS_GPIOS_PIN(INST_DT_AT2X(n, t))), \
+		.spi_cs_dt_flags = UTIL_AND( \
+			DT_SPI_DEV_HAS_CS_GPIOS(INST_DT_AT2X(n, t)), \
+			DT_SPI_DEV_CS_GPIOS_DT_FLAGS(INST_DT_AT2X(n, t))), \
 		.wp_gpio_pin = UTIL_AND( \
 			DT_NODE_HAS_PROP(INST_DT_AT2X(n, t), wp_gpios), \
 			DT_GPIO_PIN(INST_DT_AT2X(n, t), wp_gpios)), \

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -742,6 +742,7 @@ static int eth_enc28j60_init(struct device *dev)
 	}
 
 	context->spi_cs.gpio_pin = config->spi_cs_pin;
+	context->spi_cs.gpio_dt_flags = config->spi_cs_dt_flags;
 	context->spi_cfg.cs = &context->spi_cs;
 #endif
 
@@ -827,6 +828,7 @@ static const struct eth_enc28j60_config eth_enc28j60_0_config = {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	.spi_cs_port = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
 	.spi_cs_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
+	.spi_cs_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0),
 #endif
 	.full_duplex = IS_ENABLED(CONFIG_ETH_ENC28J60_0_FULL_DUPLEX),
 	.timeout = CONFIG_ETH_ENC28J60_TIMEOUT,

--- a/drivers/ethernet/eth_enc28j60_priv.h
+++ b/drivers/ethernet/eth_enc28j60_priv.h
@@ -218,7 +218,8 @@ struct eth_enc28j60_config {
 	uint8_t gpio_pin;
 	gpio_dt_flags_t gpio_flags;
 	const char *spi_port;
-	uint8_t spi_cs_pin;
+	gpio_pin_t spi_cs_pin;
+	gpio_dt_flags_t spi_cs_dt_flags;
 	const char *spi_cs_port;
 	uint32_t spi_freq;
 	uint8_t spi_slave;

--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -621,6 +621,7 @@ static int enc424j600_init(struct device *dev)
 	}
 
 	context->spi_cs.gpio_pin = config->spi_cs_pin;
+	context->spi_cs.gpio_dt_flags = config->spi_cs_dt_flags;
 	context->spi_cfg.cs = &context->spi_cs;
 #endif
 
@@ -763,6 +764,7 @@ static const struct enc424j600_config enc424j600_0_config = {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	.spi_cs_port = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
 	.spi_cs_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
+	.spi_cs_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0),
 #endif
 	.timeout = CONFIG_ETH_ENC424J600_TIMEOUT,
 };

--- a/drivers/ethernet/eth_enc424j600_priv.h
+++ b/drivers/ethernet/eth_enc424j600_priv.h
@@ -277,7 +277,8 @@ struct enc424j600_config {
 	uint8_t gpio_pin;
 	gpio_dt_flags_t gpio_flags;
 	const char *spi_port;
-	uint8_t spi_cs_pin;
+	gpio_pin_t spi_cs_pin;
+	gpio_dt_flags_t spi_cs_dt_flags;
 	const char *spi_cs_port;
 	uint32_t spi_freq;
 	uint8_t spi_slave;

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -64,7 +64,8 @@ struct spi_flash_at45_config {
 	const char *spi_bus;
 	struct spi_config spi_cfg;
 	const char *cs_gpio;
-	int cs_pin;
+	gpio_pin_t cs_pin;
+	gpio_dt_flags_t cs_dt_flags;
 #if IS_ENABLED(CONFIG_FLASH_PAGE_LAYOUT)
 	struct flash_pages_layout pages_layout;
 #endif
@@ -558,6 +559,7 @@ static int spi_flash_at45_init(struct device *dev)
 		}
 
 		dev_data->spi_cs.gpio_pin = dev_config->cs_pin;
+		dev_data->spi_cs.gpio_dt_flags = dev_config->cs_dt_flags;
 		dev_data->spi_cs.delay = 0;
 	}
 
@@ -674,7 +676,8 @@ static const struct flash_driver_api spi_flash_at45_api = {
 		},							     \
 		IF_ENABLED(DT_INST_SPI_DEV_HAS_CS_GPIOS(idx), (		     \
 			.cs_gpio = DT_INST_SPI_DEV_CS_GPIOS_LABEL(idx),      \
-			.cs_pin  = DT_INST_SPI_DEV_CS_GPIOS_PIN(idx),))	     \
+			.cs_pin  = DT_INST_SPI_DEV_CS_GPIOS_PIN(idx),	     \
+			.cs_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(idx),)) \
 		IF_ENABLED(CONFIG_FLASH_PAGE_LAYOUT, (			     \
 			.pages_layout = {				     \
 				.pages_count = INST_##idx##_PAGES,	     \

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -604,7 +604,11 @@ done:
 #define BME280_HAS_CS(inst) DT_INST_SPI_DEV_HAS_CS_GPIOS(inst)
 
 #define BME280_DATA_SPI_CS(inst)					\
-	{ .spi_cs = { .gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(inst), }, }
+	{ .spi_cs = {							\
+		.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(inst),		\
+		.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(inst),	\
+		},							\
+	}
 
 #define BME280_DATA_SPI(inst)						\
 	COND_CODE_1(BME280_HAS_CS(inst),				\

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -192,8 +192,10 @@
 
 	hs_lspi: spi@9f000 {
 		compatible = "nxp,lpc-spi";
-		cs-gpios = <&gpio0 20 0>,<&gpio1 1 0>,<&gpio1 12 0>,
-			<&gpio1 26 0>;
+		cs-gpios = <&gpio0 20 GPIO_ACTIVE_LOW>,
+			<&gpio1 1 GPIO_ACTIVE_LOW>,
+			<&gpio1 12 GPIO_ACTIVE_LOW>,
+			<&gpio1 26 GPIO_ACTIVE_LOW>;
 		reg = <0x9f000 0x1000>;
 		interrupts = <59 0>;
 		label = "HS_LSPI";

--- a/samples/drivers/spi_flash_at45/nrf9160dk_nrf9160.overlay
+++ b/samples/drivers/spi_flash_at45/nrf9160dk_nrf9160.overlay
@@ -8,7 +8,7 @@
 	sck-pin = <11>;
 	mosi-pin = <12>;
 	miso-pin = <13>;
-	cs-gpios = <&gpio0 20 0>, <&gpio0 10 0>;
+	cs-gpios = <&gpio0 20 GPIO_ACTIVE_LOW>, <&gpio0 10 GPIO_ACTIVE_LOW>;
 
 	at45db041e@0 {
 		compatible = "atmel,at45";

--- a/samples/net/wifi/boards/reel_board.overlay
+++ b/samples/net/wifi/boards/reel_board.overlay
@@ -6,7 +6,7 @@
 
 &spi3 {
 	status = "ok";
-	cs-gpios = <&gpio1 3 0>;
+	cs-gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
 	sck-pin = <36>;
 	mosi-pin = <37>;
 	miso-pin = <38>;

--- a/samples/sensor/adxl362/boards/nrf52dk_nrf52832.overlay
+++ b/samples/sensor/adxl362/boards/nrf52dk_nrf52832.overlay
@@ -9,7 +9,7 @@
 	sck-pin = <25>;
 	mosi-pin = <23>;
 	miso-pin = <24>;
-	cs-gpios = <&gpio0 22 0>;
+	cs-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 
 	adxl362@0 {
 		compatible = "adi,adxl362";

--- a/samples/sensor/adxl372/boards/nrf52dk_nrf52832.overlay
+++ b/samples/sensor/adxl372/boards/nrf52dk_nrf52832.overlay
@@ -5,7 +5,7 @@
  */
 
 &spi2 {
-	cs-gpios = <&gpio0 22 0>;
+	cs-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 	adxl372@0 {
 		compatible = "adi,adxl372";
 		reg = <0>;

--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -25,6 +25,7 @@ LOG_MODULE_REGISTER(main);
 #define CS_CTRL_GPIO_DRV_NAME CONFIG_SPI_LOOPBACK_CS_CTRL_GPIO_DRV_NAME
 struct spi_cs_control spi_cs = {
 	.gpio_pin = CONFIG_SPI_LOOPBACK_CS_CTRL_GPIO_PIN,
+	.gpio_dt_flags = GPIO_ACTIVE_LOW,
 	.delay = 0,
 };
 #define SPI_CS (&spi_cs)


### PR DESCRIPTION
The generic SPI GPIO chip select support now respects devicetree flags for signal active level.  Update all cs-gpios properties to specify active low.

Automated by:
```
git grep -wl cs-gpios -- '*/*.dts*' \
  | xargs sed -i -r -e '/cs-gpios/s@ 0>@ GPIO_ACTIVE_LOW>@g'
git grep -wl cs-gpios -- '*/*.overlay' \
  | xargs sed -i -r -e '/cs-gpios/s@ 0>@ GPIO_ACTIVE_LOW>@g'
```

Separate commits update various drivers and one test where `struct spi_cs_control` `gpio_dt_flags` was not being set.

These two drivers need attention but are not being touched:
* sensor/iis2mdc assigns a label to the flags field so hasn't been tested
* sensor/iis3dhhc stores the pin configuration but initializes the `spi_cs_control` from other data

Looking into that is outside the scope of cleaning up to fix problems introduced by #26269