### PR TITLE
drivers: pcie: Compile pcie.c only in X86

### DIFF
--- a/drivers/pcie/CMakeLists.txt
+++ b/drivers/pcie/CMakeLists.txt
@@ -1,4 +1,6 @@
-zephyr_sources(pcie.c)
+# Right now only X86 implements required symbols
+# e.g pcie_conf_read and pcie_conf_write
+zephyr_sources_ifdef(CONFIG_X86 pcie.c)
 zephyr_sources_ifdef(CONFIG_PCIE_MSI msi.c)
 zephyr_sources_ifdef(CONFIG_PCIE_SHELL shell.c)
 


### PR DESCRIPTION
PCIe requires some symbols that are implemented only in X86
architecture like pcie_conf_read. This pr is conditionally compiling
pcie.c only for X86. This condition is not in Kconfig because there is
support to PCIe endpoint drivers.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>