### PR TITLE
arch/x86: Unbreak SMP startup on x86_64

### DIFF
--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -148,7 +148,6 @@ enter_code64:
 	movw %ax, %ss
 	movw %ax, %fs
 
-	movq $x86_cpuboot, %rbp
 	movw __x86_cpuboot_t_tr_OFFSET(%rbp), %ax
 	ltr %ax
 
@@ -224,6 +223,7 @@ __start64:
 	outb %al, $0xA1
 
 	/* Far call into the Zephyr code segment */
+	movq $x86_cpuboot, %rbp
 	mov jmpdesc, %rax
 	jmp *%rax
 jmpdesc:


### PR DESCRIPTION
A last minute "cleanup" to the EFI startup path (on a system where I
had SMP disabled) moved the load of the x86_cpuboot[0] entry into RBP
into the main startup code, which is wrong because on auxiliary CPUs
that's already set up by the 16/32 bit entry code to point to the
OTHER entries.

Put it back where it belongs.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>