### PR TITLE
arch: arc: irq: bugs fix for fast irq in one register bank config

### DIFF
--- a/arch/arc/core/fast_irq.S
+++ b/arch/arc/core/fast_irq.S
@@ -158,9 +158,6 @@ SECTION_FUNC(TEXT, _firq_exit)
 	 */
 	_get_next_switch_handle
 
-	/* restore interrupted context' sp */
-	pop sp
-
 	cmp r0, r2
 	bne _firq_switch
 
@@ -168,6 +165,8 @@ SECTION_FUNC(TEXT, _firq_exit)
 
 .balign 4
 _firq_no_switch:
+	/* restore interrupted context' sp */
+	pop sp
 	/*
 	 * Keeping this code block close to those that use it allows using brxx
 	 * instruction instead of a pair of cmp and bxx
@@ -179,6 +178,8 @@ _firq_no_switch:
 
 .balign 4
 _firq_switch:
+	/* restore interrupted context' sp */
+	pop sp
 
 #if CONFIG_RGF_NUM_BANKS != 1
 /*

--- a/arch/arc/core/isr_wrapper.S
+++ b/arch/arc/core/isr_wrapper.S
@@ -205,17 +205,17 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 #if CONFIG_RGF_NUM_BANKS == 1
 /* free r0 here, use r0 to check whether irq is firq.
  * for rirq,  as sp will not change and r0 already saved, this action
- * in fact is an action like nop.
+ * in fact is useless
  * for firq,  r0 will be restored later
  */
-	st_s r0, [sp]
+	push r0
 #endif
 	lr r0, [_ARC_V2_AUX_IRQ_ACT]
 	ffs r0, r0
 	cmp r0, 0
 #if CONFIG_RGF_NUM_BANKS == 1
 	bnz rirq_path
-	ld_s r0, [sp]
+	pop r0
 	/* 1-register bank FIRQ handling must save registers on stack */
 	_create_irq_stack_frame
 	lr r0, [_ARC_V2_STATUS32_P0]
@@ -227,6 +227,7 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 	mov_s r2, _firq_enter
 	j_s [r2]
 rirq_path:
+	add sp, sp, 4
 	mov_s r3, _rirq_exit
 	mov_s r2, _rirq_enter
 	j_s [r2]


### PR DESCRIPTION
* The stack pointer (SP) register points to the lowest-used address of
   a downward-growing stack, so memory address [sp] is used, we can't
   modify it.

* In firq_no_switch case, we need to pop sp, which pushed before
   _isr_demux function in firq_nest function.

Fixes #26663 