### PR TITLE
tests: filter out nsim as it's very slow to run lib_heap test

### DIFF
--- a/tests/lib/heap/testcase.yaml
+++ b/tests/lib/heap/testcase.yaml
@@ -7,4 +7,5 @@ tests:
   lib.heap:
     tags: heap
     platform_exclude: m2gl025_miv qemu_riscv32
+    filter: not CONFIG_SOC_NSIM
     timeout: 120


### PR DESCRIPTION
nsim is slow, if the MEMSZ is too targe, the test will
run a long time and make sanitycheck timeout.

There are two possible fixes to pass the sanitycheck test
  * filter out nsim, not to block the sanitcheck test
  * use a small MEMSZ for nsim to reduce the execution time.

Considering there are potential improvements for nsim (because
some qemu targets can pass), we use the 1st fix to pass the
sanitycheck temporarily.

Fixes #24747