### PR TITLE
adc: adc_shell: suppress -Wchar-subscripts with isdigit()

### DIFF
--- a/drivers/adc/adc_shell.c
+++ b/drivers/adc/adc_shell.c
@@ -138,7 +138,7 @@ static int cmd_adc_channel(const struct shell *shell, size_t argc, char **argv)
 		shell_error(shell, "ADC device not found");
 		return -ENODEV;
 	}
-	if (!isdigit(argv[args_indx.conf][0])) {
+	if (!isdigit((unsigned char)argv[args_indx.conf][0])) {
 		shell_error(shell, "<channel> must be digits");
 		return -EINVAL;
 	}
@@ -229,7 +229,7 @@ static int cmd_adc_acq(const struct shell *shell, size_t argc, char **argv)
 		return -ENODEV;
 	}
 
-	if (!isdigit(argv[args_indx.conf][0])) {
+	if (!isdigit((unsigned char)argv[args_indx.conf][0])) {
 		shell_error(shell, "<time> must be digits");
 		return -EINVAL;
 	}
@@ -276,7 +276,7 @@ static int cmd_adc_reso(const struct shell *shell, size_t argc, char **argv)
 		shell_error(shell, "ADC device not found");
 		return -ENODEV;
 	}
-	if (!isdigit(argv[args_indx.conf][0])) {
+	if (!isdigit((unsigned char)argv[args_indx.conf][0])) {
 		shell_error(shell, "<resolution> must be digits");
 		return -EINVAL;
 	}


### PR DESCRIPTION
Suppress -Wchar-subscripts warnings when building with Newlib, by
casting isdigit() parameter to unsigned char.