### PR TITLE
net: http_client: add missing kernel.h include statement

### DIFF
--- a/include/net/http_client.h
+++ b/include/net/http_client.h
@@ -20,6 +20,7 @@
  * @{
  */
 
+#include <kernel.h>
 #include <net/net_ip.h>
 #include <net/http_parser.h>
 


### PR DESCRIPTION
There is following error when compiling applications using http_client:

```
/zephyr/include/net/http_client.h:157:24: error: field 'work' has incomplete type
  157 |  struct k_delayed_work work;
      |                        ^~~~
/zephyr/include/net/http_client.h:177:2: error: unknown type name 'k_timeout_t'
  177 |  k_timeout_t timeout;
      |  ^~~~~~~~~~~
```

Fix that by adding missing kernel.h include statement in http_client.h.