### PR TITLE
actions: add labeler rule for "platform: SiLabs"

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -133,3 +133,10 @@
   - "dts/arm/st/*/*"
   - "include/drivers/*/*stm32*"
   - "soc/arm/st_stm32/**"
+"platform: SiLabs":
+  - "boards/arm/efr32_*/**/*"
+  - "boards/arm/efm32_*/**/*"
+  - "drivers/**/*gecko*"
+  - "dts/arm/silabs/**/*"
+  - "dts/bindings/**/silabs,gecko*"
+  - "soc/arm/silabs_exx32/**/*"


### PR DESCRIPTION
Update labeler action script to apply label for efm32/efr32 mcus.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>