### PR TITLE
Bluetooth: Mesh: Fix response to Provisioning PDU with invalid type

### DIFF
--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -1064,15 +1064,15 @@ static void prov_recv(const struct prov_bearer *bearer, void *cb_data,
 
 	BT_DBG("type 0x%02x len %u", type, buf->len);
 
-	if (type != PROV_FAILED && type != link.expect) {
-		BT_WARN("Unexpected msg 0x%02x != 0x%02x", type, link.expect);
-		prov_fail(PROV_ERR_UNEXP_PDU);
+	if (type >= ARRAY_SIZE(prov_handlers)) {
+		BT_ERR("Unknown provisioning PDU type 0x%02x", type);
+		prov_fail(PROV_ERR_NVAL_FMT);
 		return;
 	}
 
-	if (type >= ARRAY_SIZE(prov_handlers)) {
-		BT_ERR("Unknown provisioning PDU type 0x%02x", type);
-		prov_fail(PROV_ERR_NVAL_PDU);
+	if (type != PROV_FAILED && type != link.expect) {
+		BT_WARN("Unexpected msg 0x%02x != 0x%02x", type, link.expect);
+		prov_fail(PROV_ERR_UNEXP_PDU);
 		return;
 	}
 


### PR DESCRIPTION
Reverse the order of these checks because invalid PDU type will
never be expected. If PDU type is invalid we should respond with
error 0x0002 - Invalid format.

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>