### PR TITLE
Bluetooth: Shell: Added mtu command

### DIFF
--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -1066,7 +1066,7 @@ static int cmd_set(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 }
 
-int cmd_att_mtu(const struct shell *shell, size_t argc, char *argv[])
+int cmd_mtu(const struct shell *shell, size_t argc, char *argv[])
 {
 	uint16_t mtu;
 
@@ -1074,7 +1074,7 @@ int cmd_att_mtu(const struct shell *shell, size_t argc, char *argv[])
 		mtu = bt_gatt_get_mtu(default_conn);
 		shell_print(shell, "MTU size: %d", mtu);
 	} else {
-		shell_print(shell, "No default connection");
+		shell_print(shell, "Not connected");
 	}
 
 	return 0;
@@ -1119,7 +1119,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(gatt_cmds,
 	SHELL_CMD_ARG(get, NULL, "<start handle> [end handle]", cmd_get, 2, 1),
 	SHELL_CMD_ARG(set, NULL, "<handle> [data...]", cmd_set, 2, 255),
 	SHELL_CMD_ARG(show-db, NULL, "[uuid] [num_matches]", cmd_show_db, 1, 2),
-	SHELL_CMD_ARG(att_mtu, NULL, "Output ATT MTU size", cmd_att_mtu, 1, 0),
+	SHELL_CMD_ARG(mtu, NULL, "Output ATT MTU size", cmd_mtu, 1, 0),
 #if defined(CONFIG_BT_GATT_DYNAMIC_DB)
 	SHELL_CMD_ARG(metrics, NULL, "[value: on, off]", cmd_metrics, 1, 1),
 	SHELL_CMD_ARG(register, NULL,


### PR DESCRIPTION
Added the att_mtu command to get the current MTU of
the default connection.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>