### PR TITLE
scripts: sanitylib.py: Add support for STLINK-V3 probe

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -589,6 +589,10 @@ class DeviceHandler(Handler):
                 command.append('--')
                 command.append("--cmd-pre-init")
                 command.append("hla_serial %s" % (board_id))
+            elif runner == "openocd" and product == "STLINK-V3":
+                command.append('--')
+                command.append("--cmd-pre-init")
+                command.append("hla_serial %s" % (board_id))
             elif runner == "openocd" and product == "EDBG CMSIS-DAP":
                 command.append('--')
                 command.append("--cmd-pre-init")
@@ -3361,7 +3365,7 @@ class HardwareMap:
             'J-Link OB'
         ],
         'openocd': [
-            'STM32 STLink', '^XDS110.*'
+            'STM32 STLink', '^XDS110.*', 'STLINK-V3'
         ],
         'dediprog': [
             'TTL232R-3V3',


### PR DESCRIPTION
Recent ST boards embed the new ST-Link probe V3.
It is advertised as "STLINK-V3", update sanitylmib to take it
into account.
In handle function, it is proposed to treat it separately as current
"STM32 STLink" as processing might differ in next future (hal_serial
deprecation).

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>