### PR TITLE
RFC: API Change: watchdog: wdt_feed error codes

### DIFF
--- a/doc/releases/release-notes-2.4.rst
+++ b/doc/releases/release-notes-2.4.rst
@@ -41,6 +41,11 @@ API Changes
   :ref:`experimental stability <api_lifecycle>`. See :ref:`util_api` for an API
   reference.
 
+* The :c:func:`wdt_feed` function will now return ``-EAGAIN`` if
+  issuing a feed would stall the caller.  Application code may need to
+  ignore this diagnostic result or initiate another feed operation
+  later.
+
 Deprecated in this release
 ==========================
 

--- a/include/drivers/watchdog.h
+++ b/include/drivers/watchdog.h
@@ -231,6 +231,9 @@ static inline int wdt_install_timeout(struct device *dev,
  * @param channel_id Index of the fed channel.
  *
  * @retval 0 If successful.
+ * @retval -EAGAIN If completing the feed operation would stall the
+ *                 caller, for example due to an in-progress watchdog
+ *                 operation such as a previous @c wdt_feed().
  * @retval -EINVAL If there is no installed timeout for supplied channel.
  */
 __syscall int wdt_feed(struct device *dev, int channel_id);


### PR DESCRIPTION
Allow feed operations that would stall due to internal peripheral
delays to complete immediately with -EAGAIN indicating that the feed
did not occur as expected.

Supports #23115 and RFC #26708.