### PR TITLE
boards: arm: Remove OPENSDA_FW cmake variables from nxp boards

### DIFF
--- a/boards/arm/frdm_k22f/board.cmake
+++ b/boards/arm/frdm_k22f/board.cmake
@@ -1,15 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set_ifndef(OPENSDA_FW daplink)
-
-if(OPENSDA_FW STREQUAL jlink)
-  set_ifndef(BOARD_DEBUG_RUNNER jlink)
-  set_ifndef(BOARD_FLASH_RUNNER jlink)
-elseif(OPENSDA_FW STREQUAL daplink)
-  set_ifndef(BOARD_DEBUG_RUNNER pyocd)
-  set_ifndef(BOARD_FLASH_RUNNER pyocd)
-endif()
-
 board_runner_args(jlink "--device=MK22FN512xxx12")
 board_runner_args(pyocd "--target=k22f")
 

--- a/boards/arm/frdm_k22f/doc/index.rst
+++ b/boards/arm/frdm_k22f/doc/index.rst
@@ -199,8 +199,15 @@ the `Segger J-Link OpenSDA V2.1 Firmware`_. Note that Segger
 does provide an OpenSDA J-Link Board-Specific Firmware for this board, however
 it is not compatible with the DAPLink bootloader.
 
-Add the argument ``-DOPENSDA_FW=jlink`` when you invoke ``west build`` to
-override the default runner from pyOCD to J-Link:
+Add the arguments ``-DBOARD_FLASH_RUNNER=jlink`` and
+``-DBOARD_DEBUG_RUNNER=jlink`` when you invoke ``west build`` to override the
+default runner from pyOCD to J-Link:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: frdm_k22f
+   :gen-args: -DBOARD_FLASH_RUNNER=jlink -DBOARD_DEBUG_RUNNER=jlink
+   :goals: build
 
 Configuring a Console
 =====================

--- a/boards/arm/frdm_k64f/board.cmake
+++ b/boards/arm/frdm_k64f/board.cmake
@@ -1,15 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set_ifndef(OPENSDA_FW daplink)
-
-if(OPENSDA_FW STREQUAL jlink)
-  board_set_debugger_ifnset(jlink)
-  board_set_flasher_ifnset(jlink)
-elseif(OPENSDA_FW STREQUAL daplink)
-  board_set_debugger_ifnset(pyocd)
-  board_set_flasher_ifnset(pyocd)
-endif()
-
 board_runner_args(jlink "--device=MK64FN1M0xxx12")
 board_runner_args(pyocd "--target=k64f")
 

--- a/boards/arm/frdm_k64f/doc/index.rst
+++ b/boards/arm/frdm_k64f/doc/index.rst
@@ -239,13 +239,14 @@ the `OpenSDA J-Link Generic Firmware for V3.2 Bootloader`_. Note that Segger
 does provide an OpenSDA J-Link Board-Specific Firmware for this board, however
 it is not compatible with the DAPLink bootloader.
 
-Add the argument ``-DOPENSDA_FW=jlink`` when you invoke ``west build`` to
-override the default runner from pyOCD to J-Link:
+Add the arguments ``-DBOARD_FLASH_RUNNER=jlink`` and
+``-DBOARD_DEBUG_RUNNER=jlink`` when you invoke ``west build`` to override the
+default runner from pyOCD to J-Link:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
    :board: frdm_k64f
-   :gen-args: -DOPENSDA_FW=jlink
+   :gen-args: -DBOARD_FLASH_RUNNER=jlink -DBOARD_DEBUG_RUNNER=jlink
    :goals: build
 
 Configuring a Console

--- a/boards/arm/frdm_k82f/board.cmake
+++ b/boards/arm/frdm_k82f/board.cmake
@@ -1,15 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set_ifndef(OPENSDA_FW daplink)
-
-if(OPENSDA_FW STREQUAL jlink)
-  board_set_debugger_ifnset(jlink)
-  board_set_flasher_ifnset(jlink)
-elseif(OPENSDA_FW STREQUAL daplink)
-  board_set_debugger_ifnset(pyocd)
-  board_set_flasher_ifnset(pyocd)
-endif()
-
 board_runner_args(jlink "--device=MK82FN256xxx15")
 board_runner_args(pyocd "--target=k82f25615")
 

--- a/boards/arm/frdm_k82f/doc/index.rst
+++ b/boards/arm/frdm_k82f/doc/index.rst
@@ -162,7 +162,6 @@ default runner from pyOCD to J-Link:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
-   :tool: all
    :board: frdm_k82f
    :gen-args: -DBOARD_FLASH_RUNNER=jlink -DBOARD_DEBUG_RUNNER=jlink
    :goals: build

--- a/boards/arm/frdm_k82f/doc/index.rst
+++ b/boards/arm/frdm_k82f/doc/index.rst
@@ -156,14 +156,15 @@ path.
 Follow the instructions in :ref:`opensda-jlink-onboard-debug-probe` to program
 the `OpenSDA J-Link Firmware for FRDM-K82F`_.
 
-Add the argument ``-DOPENSDA_FW=jlink`` when you invoke ``west build`` or
-``cmake`` to override the default runner from pyOCD to J-Link:
+Add the arguments ``-DBOARD_FLASH_RUNNER=jlink`` and
+``-DBOARD_DEBUG_RUNNER=jlink`` when you invoke ``west build`` to override the
+default runner from pyOCD to J-Link:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
    :tool: all
    :board: frdm_k82f
-   :gen-args: -DOPENSDA_FW=jlink
+   :gen-args: -DBOARD_FLASH_RUNNER=jlink -DBOARD_DEBUG_RUNNER=jlink
    :goals: build
 
 Configuring a Console

--- a/boards/arm/frdm_kl25z/board.cmake
+++ b/boards/arm/frdm_kl25z/board.cmake
@@ -1,15 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set_ifndef(OPENSDA_FW daplink)
-
-if(OPENSDA_FW STREQUAL jlink)
-  board_set_debugger_ifnset(jlink)
-  board_set_flasher_ifnset(jlink)
-elseif(OPENSDA_FW STREQUAL daplink)
-  board_set_debugger_ifnset(pyocd)
-  board_set_flasher_ifnset(pyocd)
-endif()
-
 board_runner_args(jlink "--device=MKL25Z128xxx4")
 board_runner_args(pyocd "--target=kl25z")
 

--- a/boards/arm/frdm_kl25z/doc/index.rst
+++ b/boards/arm/frdm_kl25z/doc/index.rst
@@ -149,13 +149,14 @@ path.
 Follow the instructions in :ref:`opensda-jlink-onboard-debug-probe` to program
 the `OpenSDA J-Link FRDM-KL25Z Firmware`_.
 
-Add the argument ``-DOPENSDA_FW=jlink`` when you invoke ``west build`` to
-override the default runner from pyOCD to J-Link:
+Add the arguments ``-DBOARD_FLASH_RUNNER=jlink`` and
+``-DBOARD_DEBUG_RUNNER=jlink`` when you invoke ``west build`` to override the
+default runner from pyOCD to J-Link:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
    :board: frdm_kl25z
-   :gen-args: -DOPENSDA_FW=jlink
+   :gen-args: -DBOARD_FLASH_RUNNER=jlink -DBOARD_DEBUG_RUNNER=jlink
    :goals: build
 
 Configuring a Console

--- a/boards/arm/frdm_kw41z/board.cmake
+++ b/boards/arm/frdm_kw41z/board.cmake
@@ -1,17 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set_ifndef(OPENSDA_FW daplink)
-
-if(OPENSDA_FW STREQUAL jlink)
-  board_set_debugger_ifnset(jlink)
-  board_set_flasher_ifnset(jlink)
-elseif(OPENSDA_FW STREQUAL daplink)
-  board_set_debugger_ifnset(pyocd)
-  board_set_flasher_ifnset(pyocd)
-endif()
-
 board_runner_args(jlink "--device=MKW41Z512xxx4")
 board_runner_args(pyocd "--target=kw41z4")
 
-include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/frdm_kw41z/doc/index.rst
+++ b/boards/arm/frdm_kw41z/doc/index.rst
@@ -170,13 +170,14 @@ path.
 Follow the instructions in :ref:`opensda-jlink-onboard-debug-probe` to program
 the `OpenSDA J-Link FRDM-KW41Z Firmware`_.
 
-Add the argument ``-DOPENSDA_FW=jlink`` when you invoke ``west build`` to
-override the default runner from pyOCD to J-Link:
+Add the arguments ``-DBOARD_FLASH_RUNNER=jlink`` and
+``-DBOARD_DEBUG_RUNNER=jlink`` when you invoke ``west build`` to override the
+default runner from pyOCD to J-Link:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
    :board: frdm_kw41z
-   :gen-args: -DOPENSDA_FW=jlink
+   :gen-args: -DBOARD_FLASH_RUNNER=jlink -DBOARD_DEBUG_RUNNER=jlink
    :goals: build
 
 Configuring a Console

--- a/boards/arm/hexiwear_k64/board.cmake
+++ b/boards/arm/hexiwear_k64/board.cmake
@@ -1,17 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set_ifndef(OPENSDA_FW jlink)
-
-if(OPENSDA_FW STREQUAL jlink)
-  board_set_debugger_ifnset(jlink)
-  board_set_flasher_ifnset(jlink)
-elseif(OPENSDA_FW STREQUAL daplink)
-  board_set_debugger_ifnset(pyocd)
-  board_set_flasher_ifnset(pyocd)
-endif()
-
 board_runner_args(pyocd "--target=k64f")
 board_runner_args(jlink "--device=MK64FN1M0xxx12")
 
-include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/hexiwear_k64/doc/index.rst
+++ b/boards/arm/hexiwear_k64/doc/index.rst
@@ -189,13 +189,14 @@ program the `OpenSDA DAPLink Hexiwear Firmware`_. Check that switches SW1 and
 SW2 are **on**, and SW3 and SW4 are **off**  to ensure K64F SWD signals are
 connected to the OpenSDA microcontroller.
 
-Add the argument ``-DOPENSDA_FW=daplink`` when you invoke ``west build`` to
-override the default runner from J-Link to pyOCD:
+Add the arguments ``-DBOARD_FLASH_RUNNER=pyocd`` and
+``-DBOARD_DEBUG_RUNNER=pyocd`` when you invoke ``west build`` to override the
+default runner from J-Link to pyOCD:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
    :board: hexiwear_k64
-   :gen-args: -DOPENSDA_FW=daplink
+   :gen-args: -DBOARD_FLASH_RUNNER=pyocd -DBOARD_DEBUG_RUNNER=pyocd
    :goals: build
 
 Configuring a Console

--- a/boards/arm/hexiwear_kw40z/board.cmake
+++ b/boards/arm/hexiwear_kw40z/board.cmake
@@ -1,15 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set_ifndef(OPENSDA_FW jlink)
-
-if(OPENSDA_FW STREQUAL jlink)
-  board_set_debugger_ifnset(jlink)
-  board_set_flasher_ifnset(jlink)
-elseif(OPENSDA_FW STREQUAL daplink)
-  board_set_debugger_ifnset(pyocd)
-  board_set_flasher_ifnset(pyocd)
-endif()
-
 board_runner_args(jlink "--device=MKW40Z160xxx4")
 board_runner_args(pyocd "--target=kw40z4")
 

--- a/boards/arm/lpcxpresso54114/board.cmake
+++ b/boards/arm/lpcxpresso54114/board.cmake
@@ -4,13 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set_ifndef(LPCLINK_FW jlink)
-
-if(LPCLINK_FW STREQUAL jlink)
-  board_set_debugger_ifnset(jlink)
-  board_set_flasher_ifnset(jlink)
-endif()
-
 if(CONFIG_BOARD_LPCXPRESSO54114_M4)
 board_runner_args(jlink "--device=LPC54114J256_M4" "--reset-after-load")
 elseif(CONFIG_BOARD_LPCXPRESSO54114_M0)

--- a/boards/arm/lpcxpresso55s16/board.cmake
+++ b/boards/arm/lpcxpresso55s16/board.cmake
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-board_set_debugger_ifnset(jlink)
-board_set_flasher_ifnset(jlink)
-
 board_runner_args(jlink "--device=LPC55S16")
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/lpcxpresso55s69/board.cmake
+++ b/boards/arm/lpcxpresso55s69/board.cmake
@@ -8,13 +8,6 @@
 ## DAP Link implementation in pyocd is underway,
 ## until then jlink can be used or copy image to storage
 
-set_ifndef(OPENSDA_FW jlink)
-
-if(OPENSDA_FW STREQUAL jlink)
-  board_set_debugger_ifnset(jlink)
-  board_set_flasher_ifnset(jlink)
-endif()
-
 if(CONFIG_BOARD_LPCXPRESSO55S69_CPU0)
 board_runner_args(jlink "--device=LPC55S69_core0")
 endif()

--- a/boards/arm/mimxrt1010_evk/board.cmake
+++ b/boards/arm/mimxrt1010_evk/board.cmake
@@ -3,12 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-set_ifndef(OPENSDA_FW jlink)
-
-if(OPENSDA_FW STREQUAL jlink)
-  board_set_debugger_ifnset(jlink)
-  board_set_flasher_ifnset(jlink)
-endif()
 
 board_runner_args(jlink "--device=MIMXRT1011")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/mimxrt1015_evk/board.cmake
+++ b/boards/arm/mimxrt1015_evk/board.cmake
@@ -3,12 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-set_ifndef(OPENSDA_FW jlink)
-
-if(OPENSDA_FW STREQUAL jlink)
-  board_set_debugger_ifnset(jlink)
-  board_set_flasher_ifnset(jlink)
-endif()
 
 board_runner_args(jlink "--device=MIMXRT1015")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/mimxrt1020_evk/board.cmake
+++ b/boards/arm/mimxrt1020_evk/board.cmake
@@ -4,18 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set_ifndef(OPENSDA_FW jlink)
-
-if(OPENSDA_FW STREQUAL jlink)
-  board_set_debugger_ifnset(jlink)
-  board_set_flasher_ifnset(jlink)
-elseif(OPENSDA_FW STREQUAL daplink)
-  board_set_debugger_ifnset(pyocd)
-  board_set_flasher_ifnset(pyocd)
-endif()
-
 board_runner_args(pyocd "--target=mimxrt1020")
 board_runner_args(jlink "--device=MIMXRT1021xxx5A")
 
-include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/mimxrt1050_evk/board.cmake
+++ b/boards/arm/mimxrt1050_evk/board.cmake
@@ -4,18 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set_ifndef(OPENSDA_FW jlink)
-
-if(OPENSDA_FW STREQUAL jlink)
-  board_set_debugger_ifnset(jlink)
-  board_set_flasher_ifnset(jlink)
-elseif(OPENSDA_FW STREQUAL daplink)
-  board_set_debugger_ifnset(pyocd)
-  board_set_flasher_ifnset(pyocd)
-endif()
-
 board_runner_args(pyocd "--target=mimxrt1050_hyperflash")
 board_runner_args(jlink "--device=MCIMXRT1052")
 
-include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/mimxrt1060_evk/board.cmake
+++ b/boards/arm/mimxrt1060_evk/board.cmake
@@ -4,18 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set_ifndef(OPENSDA_FW jlink)
-
-if(OPENSDA_FW STREQUAL jlink)
-  board_set_debugger_ifnset(jlink)
-  board_set_flasher_ifnset(jlink)
-elseif(OPENSDA_FW STREQUAL daplink)
-  board_set_debugger_ifnset(pyocd)
-  board_set_flasher_ifnset(pyocd)
-endif()
-
 board_runner_args(pyocd "--target=cortex_m")
 board_runner_args(jlink "--device=MIMXRT1062xxx6A")
 
-include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/mimxrt1064_evk/board.cmake
+++ b/boards/arm/mimxrt1064_evk/board.cmake
@@ -4,18 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set_ifndef(OPENSDA_FW jlink)
-
-if(OPENSDA_FW STREQUAL jlink)
-  board_set_debugger_ifnset(jlink)
-  board_set_flasher_ifnset(jlink)
-elseif(OPENSDA_FW STREQUAL daplink)
-  board_set_debugger_ifnset(pyocd)
-  board_set_flasher_ifnset(pyocd)
-endif()
-
 board_runner_args(pyocd "--target=cortex_m")
 board_runner_args(jlink "--device=MIMXRT1064")
 
-include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/twr_ke18f/board.cmake
+++ b/boards/arm/twr_ke18f/board.cmake
@@ -1,15 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set_ifndef(OPENSDA_FW daplink)
-
-if(OPENSDA_FW STREQUAL jlink)
-  board_set_debugger_ifnset(jlink)
-  board_set_flasher_ifnset(jlink)
-elseif(OPENSDA_FW STREQUAL daplink)
-  board_set_debugger_ifnset(pyocd)
-  board_set_flasher_ifnset(pyocd)
-endif()
-
 board_runner_args(jlink "--device=MKE18F512xxx16")
 board_runner_args(pyocd "--target=ke18f16")
 

--- a/boards/arm/twr_ke18f/doc/index.rst
+++ b/boards/arm/twr_ke18f/doc/index.rst
@@ -163,13 +163,14 @@ path.
 Follow the instructions in :ref:`opensda-jlink-onboard-debug-probe` to program
 the `OpenSDA J-Link Firmware for TWR-KE18F`_.
 
-Add the argument ``-DOPENSDA_FW=jlink`` when you invoke ``west build`` to
-override the default runner from pyOCD to J-Link:
+Add the arguments ``-DBOARD_FLASH_RUNNER=jlink`` and
+``-DBOARD_DEBUG_RUNNER=jlink`` when you invoke ``west build`` to override the
+default runner from pyOCD to J-Link:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
    :board: twr_ke18f
-   :gen-args: -DOPENSDA_FW=jlink
+   :gen-args: -DBOARD_FLASH_RUNNER=jlink -DBOARD_DEBUG_RUNNER=jlink
    :goals: build
 
 Configuring a Console

--- a/boards/arm/twr_kv58f220m/board.cmake
+++ b/boards/arm/twr_kv58f220m/board.cmake
@@ -1,12 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set_ifndef(OPENSDA_FW jlink)
-
-if(OPENSDA_FW STREQUAL jlink)
-  board_set_debugger_ifnset(jlink)
-  board_set_flasher_ifnset(jlink)
-endif()
-
 board_runner_args(jlink "--device=MKV58F1M0xxx24")
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
The OPENSDA_FW and LPCLINK_FW cmake variables are remnants of pre-west
days where we used an environment variable to set the desired debug host
tool, such as jlink or pyocd, based on which debug probe firmware was
loaded on the board. We now have two possible ways to do this, neither
of which requires the nxp-specific OPENSDA_FW or LPCLINK_FW variables:

1. Set standardized cmake runner variables when generating the build
   system:
   $ west build -- -DBOARD_FLASH_RUNNER=jlink -DBOARD_DEBUG_RUNNER=jlink

2. Use the west "--runner" argument with the debug and flash commands:
   $ west debug -r jlink

Remove the now unnecessary OPENSDA_FW ond LPCLINK_FW variables and
update board documentation accordingly.

A few boards (hexiwear_k64, mimxrt10{50,60,64}_evk) reordered
pyocd.board.cmake and jlink.board.cmake includes to preserve the default
runner when OPENSDA_FW was not explicitly set.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>