### PR TITLE
eswifi misc fixes

### DIFF
--- a/drivers/wifi/eswifi/CMakeLists.txt
+++ b/drivers/wifi/eswifi/CMakeLists.txt
@@ -14,5 +14,8 @@ if(CONFIG_WIFI_ESWIFI)
     eswifi_offload.c
     eswifi_socket.c
     )
+
+  zephyr_sources_ifdef(CONFIG_WIFI_ESWIFI_SHELL eswifi_shell.c)
+
 zephyr_sources_ifdef(CONFIG_NET_SOCKETS_OFFLOAD eswifi_socket_offload.c)
 endif()

--- a/drivers/wifi/eswifi/Kconfig.eswifi
+++ b/drivers/wifi/eswifi/Kconfig.eswifi
@@ -22,4 +22,10 @@ config WIFI_ESWIFI_THREAD_PRIO
 	  This option sets the priority of the esWiFi threads.
 	  Do not touch it unless you know what you are doing.
 
+config WIFI_ESWIFI_SHELL
+	bool "esWiFi shell"
+	depends on SHELL
+	help
+	  Enable esWiFi shell
+
 endif

--- a/drivers/wifi/eswifi/eswifi.h
+++ b/drivers/wifi/eswifi/eswifi.h
@@ -144,4 +144,10 @@ int __eswifi_bind(struct eswifi_dev *eswifi, struct eswifi_off_socket *socket,
 int eswifi_socket_offload_init(struct eswifi_dev *leswifi);
 #endif
 
+#if defined(CONFIG_WIFI_ESWIFI_SHELL)
+void eswifi_shell_register(struct eswifi_dev *dev);
+#else
+#define eswifi_shell_register(dev)
+#endif
+
 #endif

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -244,8 +244,8 @@ static int eswifi_connect(struct eswifi_dev *eswifi)
 	char *rsp;
 	int err;
 
-	LOG_DBG("Connecting to %s (pass=%s)", eswifi->sta.ssid,
-		eswifi->sta.pass);
+	LOG_DBG("Connecting to %s (pass=%s)", log_strdup(eswifi->sta.ssid),
+		log_strdup(eswifi->sta.pass));
 
 	eswifi_lock(eswifi);
 

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -672,6 +672,8 @@ static int eswifi_init(struct device *dev)
 
 	k_work_init(&eswifi->request_work, eswifi_request_work);
 
+	eswifi_shell_register(eswifi);
+
 	return 0;
 }
 

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -53,29 +53,30 @@ static int eswifi_reset(struct eswifi_dev *eswifi)
 
 static inline int __parse_ssid(char *str, char *ssid)
 {
-	/* fnt => '"SSID"' */
+	int i = 0;
 
-	if (!*str || (*str != '"')) {
-		return -EINVAL;
-	}
-
-	str++;
-	while (*str && (*str != '"')) {
-		*ssid++ = *str++;
-	}
-
-	*ssid = '\0';
+	/* fmt => "SSID" */
 
 	if (*str != '"') {
-		return -EINVAL;
+		return 0;
+	}
+	str++;
+
+	while (*str && (*str != '"') && i < WIFI_SSID_MAX_LEN) {
+		ssid[i++] = *str++;
 	}
 
-	return -EINVAL;
+	if (*str != '"') {
+		return 0;
+	}
+
+	return i;
 }
 
 static void __parse_scan_res(char *str, struct wifi_scan_result *res)
 {
 	int field = 0;
+	int ret;
 
 	/* fmt => #001,"SSID",MACADDR,RSSI,BITRATE,MODE,SECURITY,BAND,CHANNEL */
 
@@ -91,8 +92,7 @@ static void __parse_scan_res(char *str, struct wifi_scan_result *res)
 
 		switch (++field) {
 		case 1: /* SSID */
-			__parse_ssid(str, res->ssid);
-			res->ssid_length = strlen(res->ssid);
+			res->ssid_length = __parse_ssid(str, res->ssid);
 			str += res->ssid_length;
 			break;
 		case 2: /* mac addr */
@@ -181,7 +181,7 @@ static int __parse_ipv4_address(char *str, char *ssid, uint8_t ip[4])
 	unsigned int byte = -1;
 
 	/* fmt => [JOIN   ] SSID,192.168.2.18,0,0 */
-	while (*str) {
+	while (*str && byte < 4) {
 		if (byte == -1) {
 			if (!strncmp(str, ssid, strlen(ssid))) {
 				byte = 0U;

--- a/drivers/wifi/eswifi/eswifi_shell.c
+++ b/drivers/wifi/eswifi/eswifi_shell.c
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2020 Linaro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+#include <shell/shell.h>
+
+#include "eswifi.h"
+
+static struct eswifi_dev *eswifi;
+
+void eswifi_shell_register(struct eswifi_dev *dev)
+{
+	/* only one instance supported */
+	if (eswifi) {
+		return;
+	}
+
+	eswifi = dev;
+}
+
+static int eswifi_shell_atcmd(const struct shell *shell, size_t argc,
+			      char **argv)
+{
+	int i;
+
+	if (eswifi == NULL) {
+		shell_print(shell, "no eswifi device registered");
+		return -ENOEXEC;
+	}
+
+	if (argc < 2) {
+		shell_help(shell);
+		return -ENOEXEC;
+	}
+
+	eswifi_lock(eswifi);
+
+	memset(eswifi->buf, 0, sizeof(eswifi->buf));
+	for (i = 1; i < argc; i++) {
+		strcat(eswifi->buf, argv[i]);
+	}
+	strcat(eswifi->buf, "\r");
+
+	shell_print(shell, "> %s", eswifi->buf);
+	eswifi_at_cmd(eswifi, eswifi->buf);
+	shell_print(shell, "< %s", eswifi->buf);
+
+	eswifi_unlock(eswifi);
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(eswifi_shell,
+	SHELL_CMD(atcmd, NULL, "<atcmd>", eswifi_shell_atcmd),
+	SHELL_SUBCMD_SET_END /* Array terminated. */
+);
+
+SHELL_CMD_REGISTER(eswifi, &eswifi_shell, "esWiFi debug shell", NULL);

--- a/drivers/wifi/eswifi/eswifi_socket.c
+++ b/drivers/wifi/eswifi/eswifi_socket.c
@@ -160,6 +160,10 @@ int __eswifi_off_start_client(struct eswifi_dev *eswifi,
 
 	__select_socket(eswifi, socket->index);
 
+	/* Stop any running client */
+	snprintk(eswifi->buf, sizeof(eswifi->buf), "P6=0\r");
+	eswifi_at_cmd(eswifi, eswifi->buf);
+
 	/* Set Remote IP */
 	snprintk(eswifi->buf, sizeof(eswifi->buf), "P3=%u.%u.%u.%u\r",
 		 sin_addr->s4_addr[0], sin_addr->s4_addr[1],


### PR DESCRIPTION
- Clear TCP/UDP socket connection state before connection
- Use log_strdup for strings
- Add a debug shell to interactively send at command to eswifi controller
- Fix possible buffer overflow in ipv4/ssid parsing helpers