### PR TITLE
kernel: fix timer initializer field order

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1773,8 +1773,8 @@ struct k_timer {
 	{ \
 	.timeout = { \
 		.node = {},\
+		.fn = z_timer_expiration_handler, \
 		.dticks = 0, \
-		.fn = z_timer_expiration_handler \
 	}, \
 	.wait_q = Z_WAIT_Q_INIT(&obj.wait_q), \
 	.expiry_fn = expiry, \


### PR DESCRIPTION
Recent changes to struct _timeout changed the declaration order to
avoid alignment padding.  While this has no effect to C99 code C++
requires that designated initializes appear in declaration order.
Update the initializer macro so it can be used in C++ code.

Fixes #26586