### PR TITLE
boards: x86: update build_grub.sh for Python 3

### DIFF
--- a/boards/x86/common/scripts/build_grub.sh
+++ b/boards/x86/common/scripts/build_grub.sh
@@ -16,13 +16,15 @@ fi
 
 TARGET_ARCH=$1
 
+export PYTHON=python3
+
 prepare() {
   if [[ ! -d ./src ]]; then
     git clone http://git.savannah.gnu.org/r/grub.git src
   fi
 
   pushd src
-  git checkout grub-2.04-rc1-17-g8e8723a6b
+  git checkout grub-2.04
   git clean -fdx
   popd
 }


### PR DESCRIPTION
Since Python 2 is already EOL, Linux distributions are starting
to drop support for Python 2. For example, on Ubuntu 20.04,
"python" is no longer available. This breaks the bootstrap
and autogen.sh as they are both default to executing "python".
Fix this by setting the PYTHON environment variable before
building so both scripts will use python3 instead.

Also update git checkout to grab the official 2.04 release.

Fixes #25398

Signed-off-by: Daniel Leung <daniel.leung@intel.com>