### PR TITLE
drivers: ieee802154: rf2xx: Add CS gpio flags from DT

### DIFF
--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
@@ -91,7 +91,7 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 
-	cs-gpios = <&portb 31 0>;
+	cs-gpios = <&portb 31 GPIO_ACTIVE_LOW>;
 
 	rf2xx@0 {
 		compatible = "atmel,rf2xx";

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -781,6 +781,7 @@ static inline int configure_spi(struct device *dev)
 	ctx->spi_cs.gpio_dev = device_get_binding(conf->spi.cs.devname);
 	if (ctx->spi_cs.gpio_dev) {
 		ctx->spi_cs.gpio_pin = conf->spi.cs.pin;
+		ctx->spi_cs.gpio_dt_flags = conf->spi.cs.flags;
 		ctx->spi_cs.delay = 0U;
 
 		ctx->spi_cfg.cs = &ctx->spi_cs;


### PR DESCRIPTION
The #26269 add generic SPI GPIO chip select support respecting devicetree flags for signal active level. This pass DT information to driver instance to ensure proper behavior. An update for samr21 cs-gpios flag with active low value to instruct spi driver how to handle cs signal is also provided.