### PR TITLE
arch/x86: Find ACPI top-level table via UEFI

### DIFF
--- a/arch/x86/zefi/efi.h
+++ b/arch/x86/zefi/efi.h
@@ -15,6 +15,18 @@ typedef uintptr_t __abi (*efi_fn2_t)(void *, void *);
 typedef uintptr_t __abi (*efi_fn3_t)(void *, void *, void *);
 typedef uintptr_t __abi (*efi_fn4_t)(void *, void *, void *, void *);
 
+struct efi_guid {
+	uint32_t Data1;
+	uint16_t Data2;
+	uint16_t Data3;
+	uint8_t  Data4[8];
+};
+
+struct efi_configuration_table {
+	struct efi_guid VendorGuid;
+	void *VendorTable;
+};
+
 struct efi_simple_text_output {
 	efi_fn2_t Reset;
 	efi_fn2_t OutputString;

--- a/arch/x86/zefi/zefi.c
+++ b/arch/x86/zefi/zefi.c
@@ -10,6 +10,9 @@
 
 #define PUTCHAR_BUFSZ 128
 
+#define ZEPHYR_RSDT_REC_ADDR 0x7000L
+#define ZEPHYR_RSDT_MAGIC 0x544453526870655aLL /* == "ZephRSDT" */
+
 /* The linker places this dummy last in the data memory.  We can't use
  * traditional linker address symbols because we're relocatable; the
  * linker doesn't know what the runtime address will be.  The compiler
@@ -23,6 +26,10 @@ uint64_t runtime_data_end[1] = { 0x1111aa8888aa1111L };
 #define EXT_DATA_START ((void *) &runtime_data_end[1])
 
 static struct efi_system_table *efi;
+
+static struct efi_guid rsdtv2_guid =
+	{ 0x8868e871, 0xe4f1, 0x11d3,
+	  {0xbc, 0x22, 0x00, 0x80, 0xc7, 0x3c, 0x88, 0x81} };
 
 static void efi_putchar(int c)
 {
@@ -42,6 +49,33 @@ static void efi_putchar(int c)
 	}
 }
 
+static bool guid_eq(struct efi_guid *a, struct efi_guid *b)
+{
+	uint64_t *a4q = (uint64_t *)&a->Data4[0];
+	uint64_t *b4q = (uint64_t *)&b->Data4[0];
+
+	return (a->Data1 == b->Data1 &&
+		a->Data2 == b->Data2 &&
+		a->Data3 == b->Data3 &&
+		*a4q == *b4q);
+}
+
+static void find_rsdt(void)
+{
+	for (int i = 0; i < efi->NumberOfTableEntries; i++) {
+		struct efi_configuration_table *t = &efi->ConfigurationTable[i];
+		struct efi_guid *g = &t->VendorGuid;
+
+		if (guid_eq(&rsdtv2_guid, g)) {
+			printf("Located ACPIv2 RSDT at %p\n", t->VendorTable);
+			uint64_t *rec = (uint64_t *)ZEPHYR_RSDT_REC_ADDR;
+
+			rec[0] = ZEPHYR_RSDT_MAGIC;
+			rec[1] = (uint64_t) t->VendorTable;
+		}
+	}
+}
+
 /* FIXME: if you check the generated code, "ms_abi" calls like this
  * have to SPILL HALF OF THE SSE REGISTER SET TO THE STACK on entry
  * because of the way the conventions collide.  Is there a way to
@@ -52,6 +86,8 @@ uintptr_t __abi efi_entry(void *img_handle, struct efi_system_table *sys_tab)
 	efi = sys_tab;
 	z_putchar = efi_putchar;
 	printf("*** Zephyr EFI Loader ***\n");
+
+	find_rsdt();
 
 	for (int i = 0; i < sizeof(zefi_zsegs)/sizeof(zefi_zsegs[0]); i++) {
 		int nqwords = zefi_zsegs[i].sz;


### PR DESCRIPTION
We have at least one device where the legacy BIOS memory that is supposed to contain the ACPI RSDT pointer doesn't.  Also Daniel has an up_squared that, unlike mine, seems to have the same behavior.  UEFI systems are supposed to get their RSDT pointer from the EFI system table, so this implements that scheme instead.

While this is probably mergeable as is, it's really more of a proof of concept than a final version.  The shared memory area containing the record is just passed by hard coded addresses.  What we'd really want is for the zefi loader build to be integrated with the Zephyr build, so it has access to the same kconfig values, and include directories, etc... Then we could put the shared record in a kconfig-controlled address, or we could do the EFI parsing inside the Zephyr kernel by passing the system table address instead, or even try something fancy like populating a field in the Zephyr binary with the address, etc...