### PR TITLE
Bluetooth: GATT: Pass bt_conn to CCC cfg_changed callback

### DIFF
--- a/doc/releases/release-notes-2.4.rst
+++ b/doc/releases/release-notes-2.4.rst
@@ -56,6 +56,8 @@ Removed APIs in this release
 Stable API changes in this release
 ==================================
 
+* The GATT CCC cfg_changed callback now takes a pointer of the bt_conn that
+  caused the change as an argument.
 
 Kernel
 ******

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -586,10 +586,12 @@ struct _bt_gatt_ccc {
 
 	/** @brief CCC attribute changed callback
 	 *
+	 *  @param conn   The connection that originated the change
 	 *  @param attr   The attribute that's changed value
 	 *  @param value  New value
 	 */
-	void (*cfg_changed)(const struct bt_gatt_attr *attr, uint16_t value);
+	void (*cfg_changed)(struct bt_conn *conn,
+			    const struct bt_gatt_attr *attr, uint16_t value);
 
 	/** @brief CCC attribute write validation callback
 	 *

--- a/samples/bluetooth/peripheral/src/cts.c
+++ b/samples/bluetooth/peripheral/src/cts.c
@@ -25,7 +25,8 @@
 static uint8_t ct[10];
 static uint8_t ct_update;
 
-static void ct_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
+static void ct_ccc_cfg_changed(struct bt_conn *conn,
+			       const struct bt_gatt_attr *attr, uint16_t value)
 {
 	/* TODO: Handle value */
 }

--- a/samples/bluetooth/peripheral/src/main.c
+++ b/samples/bluetooth/peripheral/src/main.c
@@ -69,7 +69,8 @@ static uint8_t simulate_vnd;
 static uint8_t indicating;
 static struct bt_gatt_indicate_params ind_params;
 
-static void vnd_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
+static void vnd_ccc_cfg_changed(struct bt_conn *conn,
+				const struct bt_gatt_attr *attr, uint16_t value)
 {
 	simulate_vnd = (value == BT_GATT_CCC_INDICATE) ? 1 : 0;
 }

--- a/samples/bluetooth/peripheral_csc/src/main.c
+++ b/samples/bluetooth/peripheral_csc/src/main.c
@@ -82,13 +82,15 @@ static uint8_t sensor_location; /* Current Sensor Location */
 static bool csc_simulate;
 static bool ctrl_point_configured;
 
-static void csc_meas_ccc_cfg_changed(const struct bt_gatt_attr *attr,
+static void csc_meas_ccc_cfg_changed(struct bt_conn *conn,
+				     const struct bt_gatt_attr *attr,
 				     uint16_t value)
 {
 	csc_simulate = value == BT_GATT_CCC_NOTIFY;
 }
 
-static void ctrl_point_ccc_cfg_changed(const struct bt_gatt_attr *attr,
+static void ctrl_point_ccc_cfg_changed(struct bt_conn *conn,
+				       const struct bt_gatt_attr *attr,
 				       uint16_t value)
 {
 	ctrl_point_configured = value == BT_GATT_CCC_INDICATE;

--- a/samples/bluetooth/peripheral_esp/src/main.c
+++ b/samples/bluetooth/peripheral_esp/src/main.c
@@ -125,7 +125,8 @@ static struct humidity_sensor sensor_3 = {
 		.meas.meas_uncertainty = 0x01,
 };
 
-static void temp_ccc_cfg_changed(const struct bt_gatt_attr *attr,
+static void temp_ccc_cfg_changed(struct bt_conn *conn,
+				 const struct bt_gatt_attr *attr,
 				 uint16_t value)
 {
 	simulate_temp = value == BT_GATT_CCC_NOTIFY;

--- a/samples/bluetooth/peripheral_hids/src/hog.c
+++ b/samples/bluetooth/peripheral_hids/src/hog.c
@@ -111,7 +111,8 @@ static ssize_t read_report(struct bt_conn *conn,
 				 sizeof(struct hids_report));
 }
 
-static void input_ccc_changed(const struct bt_gatt_attr *attr, uint16_t value)
+static void input_ccc_changed(struct bt_conn *conn,
+			      const struct bt_gatt_attr *attr, uint16_t value)
 {
 	simulate_input = (value == BT_GATT_CCC_NOTIFY) ? 1 : 0;
 }

--- a/samples/bluetooth/peripheral_ht/src/hts.c
+++ b/samples/bluetooth/peripheral_ht/src/hts.c
@@ -31,7 +31,8 @@ static uint8_t simulate_htm;
 static uint8_t indicating;
 static struct bt_gatt_indicate_params ind_params;
 
-static void htmc_ccc_cfg_changed(const struct bt_gatt_attr *attr,
+static void htmc_ccc_cfg_changed(struct bt_conn *conn,
+				 const struct bt_gatt_attr *attr,
 				 uint16_t value)
 {
 	simulate_htm = (value == BT_GATT_CCC_INDICATE) ? 1 : 0;

--- a/samples/bluetooth/st_ble_sensor/src/main.c
+++ b/samples/bluetooth/st_ble_sensor/src/main.c
@@ -82,7 +82,8 @@ struct bt_conn *conn;
 /* Notification state */
 volatile bool notify_enable;
 
-static void mpu_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
+static void mpu_ccc_cfg_changed(struct bt_conn *conn,
+				const struct bt_gatt_attr *attr, uint16_t value)
 {
 	ARG_UNUSED(attr);
 	notify_enable = (value == BT_GATT_CCC_NOTIFY);

--- a/samples/boards/bbc_microbit/pong/src/ble.c
+++ b/samples/boards/bbc_microbit/pong/src/ble.c
@@ -500,7 +500,8 @@ static void ble_timeout(struct k_work *work)
 	}
 }
 
-static void pong_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t val)
+static void pong_ccc_cfg_changed(struct bt_conn *conn,
+				 const struct bt_gatt_attr *attr, uint16_t val)
 {
 	printk("val %u\n", val);
 

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1488,7 +1488,8 @@ ssize_t bt_gatt_attr_read_ccc(struct bt_conn *conn,
 				 sizeof(value));
 }
 
-static void gatt_ccc_changed(const struct bt_gatt_attr *attr,
+static void gatt_ccc_changed(struct bt_conn *conn,
+			     const struct bt_gatt_attr *attr,
 			     struct _bt_gatt_ccc *ccc)
 {
 	int i;
@@ -1505,7 +1506,7 @@ static void gatt_ccc_changed(const struct bt_gatt_attr *attr,
 	if (value != ccc->value) {
 		ccc->value = value;
 		if (ccc->cfg_changed) {
-			ccc->cfg_changed(attr, value);
+			ccc->cfg_changed(conn, attr, value);
 		}
 	}
 }
@@ -1572,7 +1573,7 @@ ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
 
 	/* Update cfg if don't match */
 	if (cfg->value != ccc->value) {
-		gatt_ccc_changed(attr, ccc);
+		gatt_ccc_changed(conn, attr, ccc);
 
 #if defined(CONFIG_BT_SETTINGS_CCC_STORE_ON_WRITE)
 		if ((!gatt_ccc_conn_is_queued(conn)) &&
@@ -2272,7 +2273,7 @@ static uint8_t update_ccc(const struct bt_gatt_attr *attr, void *user_data)
 			}
 		}
 
-		gatt_ccc_changed(attr, ccc);
+		gatt_ccc_changed(conn, attr, ccc);
 
 		if (IS_ENABLED(CONFIG_BT_GATT_SERVICE_CHANGED) &&
 		    ccc == &sc_ccc) {
@@ -2346,7 +2347,7 @@ static uint8_t disconnected_cb(const struct bt_gatt_attr *attr, void *user_data)
 	if (!value_used) {
 		ccc->value = 0U;
 		if (ccc->cfg_changed) {
-			ccc->cfg_changed(attr, ccc->value);
+			ccc->cfg_changed(conn, attr, ccc->value);
 		}
 
 		BT_DBG("ccc %p reseted", ccc);

--- a/subsys/bluetooth/mesh/proxy.c
+++ b/subsys/bluetooth/mesh/proxy.c
@@ -607,13 +607,14 @@ struct net_buf_simple *bt_mesh_proxy_get_buf(void)
 }
 
 #if defined(CONFIG_BT_MESH_PB_GATT)
-static void prov_ccc_changed(const struct bt_gatt_attr *attr, uint16_t value)
+static void prov_ccc_changed(struct bt_conn *conn,
+			     const struct bt_gatt_attr *attr, uint16_t value)
 {
 	BT_DBG("value 0x%04x", value);
 }
 
 static ssize_t prov_ccc_write(struct bt_conn *conn,
-			   const struct bt_gatt_attr *attr, uint16_t value)
+			      const struct bt_gatt_attr *attr, uint16_t value)
 {
 	struct bt_mesh_proxy_client *client;
 
@@ -726,7 +727,8 @@ int bt_mesh_proxy_prov_disable(bool disconnect)
 #endif /* CONFIG_BT_MESH_PB_GATT */
 
 #if defined(CONFIG_BT_MESH_GATT_PROXY)
-static void proxy_ccc_changed(const struct bt_gatt_attr *attr, uint16_t value)
+static void proxy_ccc_changed(struct bt_conn *conn,
+			      const struct bt_gatt_attr *attr, uint16_t value)
 {
 	BT_DBG("value 0x%04x", value);
 }

--- a/subsys/bluetooth/services/bas.c
+++ b/subsys/bluetooth/services/bas.c
@@ -27,9 +27,11 @@ LOG_MODULE_REGISTER(bas);
 
 static uint8_t battery_level = 100U;
 
-static void blvl_ccc_cfg_changed(const struct bt_gatt_attr *attr,
-				       uint16_t value)
+static void blvl_ccc_cfg_changed(struct bt_conn *conn,
+				 const struct bt_gatt_attr *attr,
+				 uint16_t value)
 {
+	ARG_UNUSED(conn);
 	ARG_UNUSED(attr);
 
 	bool notif_enabled = (value == BT_GATT_CCC_NOTIFY);

--- a/subsys/bluetooth/services/hrs.c
+++ b/subsys/bluetooth/services/hrs.c
@@ -27,8 +27,10 @@ LOG_MODULE_REGISTER(hrs);
 
 static uint8_t hrs_blsc;
 
-static void hrmc_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
+static void hrmc_ccc_cfg_changed(struct bt_conn *conn,
+				 const struct bt_gatt_attr *attr, uint16_t value)
 {
+	ARG_UNUSED(conn);
 	ARG_UNUSED(attr);
 
 	bool notif_enabled = (value == BT_GATT_CCC_NOTIFY);

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -706,7 +706,8 @@ static const struct bt_uuid_128 vnd1_echo_uuid = BT_UUID_INIT_128(
 
 static uint8_t echo_enabled;
 
-static void vnd1_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
+static void vnd1_ccc_cfg_changed(struct bt_conn *conn,
+				 const struct bt_gatt_attr *attr, uint16_t value)
 {
 	echo_enabled = (value == BT_GATT_CCC_NOTIFY) ? 1 : 0;
 }

--- a/subsys/mgmt/smp_bt.c
+++ b/subsys/mgmt/smp_bt.c
@@ -65,7 +65,8 @@ static ssize_t smp_bt_chr_write(struct bt_conn *conn,
 	return len;
 }
 
-static void smp_bt_ccc_changed(const struct bt_gatt_attr *attr, uint16_t value)
+static void smp_bt_ccc_changed(struct bt_conn *conn,
+			       const struct bt_gatt_attr *attr, uint16_t value)
 {
 }
 

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_3_1.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_3_1.c
@@ -86,7 +86,8 @@ static ssize_t write_value_v6(struct bt_conn *conn,
  * @param attr  The attribute whose descriptor configuration has changed
  * @param value The new value of the descriptor configuration
  */
-static void value_v6_ccc_cfg_changed(const struct bt_gatt_attr *attr,
+static void value_v6_ccc_cfg_changed(struct bt_conn *conn,
+				     const struct bt_gatt_attr *attr,
 				     uint16_t value)
 {
 	value_v6_ntf_active = value == BT_GATT_CCC_NOTIFY;

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_3_2.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_3_2.c
@@ -88,7 +88,8 @@ static ssize_t write_value_v6(struct bt_conn *conn,
  * @param attr  The attribute whose descriptor configuration has changed
  * @param value The new value of the descriptor configuration
  */
-static void value_v6_ccc_cfg_changed(const struct bt_gatt_attr *attr,
+static void value_v6_ccc_cfg_changed(struct bt_conn *conn,
+				     const struct bt_gatt_attr *attr,
 				     uint16_t value)
 {
 	value_v6_ntf_active = value == BT_GATT_CCC_NOTIFY;

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_3_3.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_3_3.c
@@ -88,7 +88,8 @@ static ssize_t write_value_v6(struct bt_conn *conn,
  * @param attr  The attribute whose descriptor configuration has changed
  * @param value The new value of the descriptor configuration
  */
-static void value_v6_ccc_cfg_changed(const struct bt_gatt_attr *attr,
+static void value_v6_ccc_cfg_changed(struct bt_conn *conn,
+				     const struct bt_gatt_attr *attr,
 				     uint16_t value)
 {
 	value_v6_ntf_active = value == BT_GATT_CCC_NOTIFY;

--- a/tests/bluetooth/gatt/src/main.c
+++ b/tests/bluetooth/gatt/src/main.c
@@ -34,7 +34,8 @@ static const struct bt_uuid_128 test1_nfy_uuid = BT_UUID_INIT_128(
 
 static uint8_t nfy_enabled;
 
-static void test1_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
+static void test1_ccc_cfg_changed(struct bt_conn *conn,
+				  const struct bt_gatt_attr *attr, uint16_t value)
 {
 	nfy_enabled = (value == BT_GATT_CCC_NOTIFY) ? 1 : 0;
 }

--- a/tests/bluetooth/tester/src/gatt.c
+++ b/tests/bluetooth/tester/src/gatt.c
@@ -472,7 +472,8 @@ static bool ccc_added;
 
 static uint8_t ccc_value;
 
-static void ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
+static void ccc_cfg_changed(struct bt_conn *conn,
+			    const struct bt_gatt_attr *attr, uint16_t value)
 {
 	ccc_value = value;
 }


### PR DESCRIPTION
When CCC cfg_changed callback is called, it will now have
a pointer of the bt_conn that caused the change.

This behaviour is more consistent with other callbacks.

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>