### PR TITLE
[topic-usb]First step to rework USB core.

### DIFF
--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -174,11 +174,6 @@ struct usb_interface_cfg_data {
  * may only be updated after calls to usb_deconfig
  */
 struct usb_cfg_data {
-	/**
-	 * USB device description, see
-	 * http://www.beyondlogic.org/usbnutshell/usb5.shtml#DeviceDescriptors
-	 */
-	const uint8_t *usb_device_description;
 	/** Pointer to interface descriptor */
 	const void *interface_descriptor;
 	/** Function for interface runtime configuration */

--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -144,11 +144,11 @@ struct usb_ep_cfg_data {
 };
 
 /**
- * @brief USB Interface Configuration
+ * @brief USB request handlers
  *
- * This structure contains USB interface configuration.
+ * This structure contains USB request handlers
  */
-struct usb_interface_cfg_data {
+struct usb_request_handlers {
 	/** Handler for USB Class specific Control (EP 0) communications */
 	usb_request_handler class_handler;
 	/** Handler for USB Vendor specific commands */
@@ -182,8 +182,8 @@ struct usb_cfg_data {
 	void (*cb_usb_status)(struct usb_cfg_data *cfg,
 			      enum usb_dc_status_code cb_status,
 			      const uint8_t *param);
-	/** USB interface (Class) handler and storage space */
-	struct usb_interface_cfg_data interface;
+	/** USB request handlers */
+	struct usb_request_handlers request_handlers;
 	/** Number of individual endpoints in the device configuration */
 	uint8_t num_endpoints;
 	/**
@@ -191,7 +191,7 @@ struct usb_cfg_data {
 	 * number of EP associated with the device description,
 	 * not including control endpoints
 	 */
-	struct usb_ep_cfg_data *endpoint;
+	struct usb_ep_cfg_data *endpoints;
 };
 
 /**

--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -62,10 +62,10 @@ extern "C" {
 	static __in_section(usb, descriptor_##p, 5) __used __aligned(1)
 
 /*
- * This macro should be used to place the struct usb_cfg_data
+ * This macro should be used to place the struct usb_class_data
  * inside usb data section in the RAM.
  */
-#define USBD_CFG_DATA_DEFINE(p, name) \
+#define USBD_CLASS_DATA_DEFINE(p, name) \
 	static __in_section(usb, data_##p, name) __used
 
 /*************************************************************************
@@ -180,32 +180,34 @@ struct usb_request_handlers {
 };
 
 /**
- * @brief USB device configuration
+ * @brief USB Class data
  *
- * The Application instantiates this with given parameters added
- * using the "usb_set_config" function. Once this function is called
- * changes to this structure will result in undefined behavior. This structure
- * may only be updated after calls to usb_deconfig
+ * This structure is initialized during build time based on
+ * chosen configuration of the USB device.
+ * The structure represent class in the core USB stack.
  */
-struct usb_cfg_data {
+struct usb_class_data {
 	/** Function for interface runtime configuration */
 	usb_interface_config interface_config;
 	/** Callback to be notified on USB connection status change */
-	void (*cb_usb_status)(struct usb_cfg_data *cfg,
+	void (*cb_usb_status)(struct usb_class_data *class_data,
 			      enum usb_dc_status_code cb_status,
 			      const uint8_t *param);
 	/** USB request handlers */
 	struct usb_request_handlers request_handlers;
-	/* Number of interface containers for this function */
+	/** Number of interface containers for this class */
 	const uint8_t num_if_containers;
-	/* Pointer to table of interface containers for this function */
+	/** Pointer to table of interface containers for this class */
 	struct usb_if_container *const if_containers;
-	/** Number of individual endpoints in the function configuration */
+	/**
+	 * Number of individual endpoints for this class, not including
+	 * conntrol endpoints.
+	 */
 	uint8_t num_endpoints;
 	/**
 	 * Pointer to an array of endpoint structs of length equal to the
-	 * number of EP associated with the function description,
-	 * not including control endpoints
+	 * number of EP associated with this class, not including control
+	 * endpoints.
 	 */
 	struct usb_ep_cfg_data *endpoints;
 };

--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -144,6 +144,20 @@ struct usb_ep_cfg_data {
 };
 
 /**
+ * @brief USB Interface container
+ *
+ * This structure represents interface related data
+ * requred for USB core stack part to correctly address
+ * the requests. Right now interface container provides
+ * only one alternate setting, this may change in the future.
+ */
+struct usb_if_container {
+	const struct usb_if_descriptor *const iface;
+	const struct usb_if_descriptor *const iface_alt;
+	uint8_t curr_alt;
+};
+
+/**
  * @brief USB request handlers
  *
  * This structure contains USB request handlers
@@ -174,8 +188,6 @@ struct usb_request_handlers {
  * may only be updated after calls to usb_deconfig
  */
 struct usb_cfg_data {
-	/** Pointer to interface descriptor */
-	const void *interface_descriptor;
 	/** Function for interface runtime configuration */
 	usb_interface_config interface_config;
 	/** Callback to be notified on USB connection status change */
@@ -184,11 +196,15 @@ struct usb_cfg_data {
 			      const uint8_t *param);
 	/** USB request handlers */
 	struct usb_request_handlers request_handlers;
-	/** Number of individual endpoints in the device configuration */
+	/* Number of interface containers for this function */
+	const uint8_t num_if_containers;
+	/* Pointer to table of interface containers for this function */
+	struct usb_if_container *const if_containers;
+	/** Number of individual endpoints in the function configuration */
 	uint8_t num_endpoints;
 	/**
 	 * Pointer to an array of endpoint structs of length equal to the
-	 * number of EP associated with the device description,
+	 * number of EP associated with the function description,
 	 * not including control endpoints
 	 */
 	struct usb_ep_cfg_data *endpoints;

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -151,7 +151,6 @@ static int wpanusb_vendor_handler(struct usb_setup_packet *setup,
 }
 
 USBD_CFG_DATA_DEFINE(primary, wpanusb) struct usb_cfg_data wpanusb_config = {
-	.usb_device_description = NULL,
 	.interface_descriptor = &wpanusb_desc.if0,
 	.cb_usb_status = wpanusb_status_cb,
 	.interface = {

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -153,13 +153,13 @@ static int wpanusb_vendor_handler(struct usb_setup_packet *setup,
 USBD_CFG_DATA_DEFINE(primary, wpanusb) struct usb_cfg_data wpanusb_config = {
 	.interface_descriptor = &wpanusb_desc.if0,
 	.cb_usb_status = wpanusb_status_cb,
-	.interface = {
+	.request_handlers = {
 		.vendor_handler = wpanusb_vendor_handler,
 		.class_handler = NULL,
 		.custom_handler = NULL,
 	},
 	.num_endpoints = ARRAY_SIZE(wpanusb_ep),
-	.endpoint = wpanusb_ep,
+	.endpoints = wpanusb_ep,
 };
 
 /* Decode wpanusb commands */
@@ -250,7 +250,7 @@ static int stop(void)
 
 static int tx(struct net_pkt *pkt)
 {
-	uint8_t ep = wpanusb_config.endpoint[WPANUSB_IN_EP_IDX].ep_addr;
+	uint8_t ep = wpanusb_config.endpoints[WPANUSB_IN_EP_IDX].ep_addr;
 	struct net_buf *buf = net_buf_frag_last(pkt->buffer);
 	uint8_t seq = net_buf_pull_u8(buf);
 	int retries = 3;
@@ -384,7 +384,7 @@ int net_recv_data(struct net_if *iface, struct net_pkt *pkt)
 	 */
 	*p = net_pkt_ieee802154_lqi(pkt);
 
-	ep = wpanusb_config.endpoint[WPANUSB_IN_EP_IDX].ep_addr;
+	ep = wpanusb_config.endpoints[WPANUSB_IN_EP_IDX].ep_addr;
 
 	ret = usb_transfer_sync(ep, tx_buf, len + 2,
 				USB_TRANS_WRITE | USB_TRANS_NO_ZLP);

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -89,12 +89,12 @@ static struct usb_if_container wpanusb_if_containers[] = {
 	}
 };
 
-static void wpanusb_status_cb(struct usb_cfg_data *cfg,
+static void wpanusb_status_cb(struct usb_class_data *class_data,
 			      enum usb_dc_status_code status,
 			      const uint8_t *param)
 {
 	ARG_UNUSED(param);
-	ARG_UNUSED(cfg);
+	ARG_UNUSED(class_data);
 
 	/* Check the USB status and do needed action if required */
 	switch (status) {
@@ -158,7 +158,7 @@ static int wpanusb_vendor_handler(struct usb_setup_packet *setup,
 	return 0;
 }
 
-USBD_CFG_DATA_DEFINE(primary, wpanusb) struct usb_cfg_data wpanusb_config = {
+USBD_CLASS_DATA_DEFINE(primary, wpanusb) struct usb_class_data wpanusb_class = {
 	.cb_usb_status = wpanusb_status_cb,
 	.request_handlers = {
 		.vendor_handler = wpanusb_vendor_handler,
@@ -259,7 +259,7 @@ static int stop(void)
 
 static int tx(struct net_pkt *pkt)
 {
-	uint8_t ep = wpanusb_config.endpoints[WPANUSB_IN_EP_IDX].ep_addr;
+	uint8_t ep = wpanusb_class.endpoints[WPANUSB_IN_EP_IDX].ep_addr;
 	struct net_buf *buf = net_buf_frag_last(pkt->buffer);
 	uint8_t seq = net_buf_pull_u8(buf);
 	int retries = 3;
@@ -393,7 +393,7 @@ int net_recv_data(struct net_if *iface, struct net_pkt *pkt)
 	 */
 	*p = net_pkt_ieee802154_lqi(pkt);
 
-	ep = wpanusb_config.endpoints[WPANUSB_IN_EP_IDX].ep_addr;
+	ep = wpanusb_class.endpoints[WPANUSB_IN_EP_IDX].ep_addr;
 
 	ret = usb_transfer_sync(ep, tx_buf, len + 2,
 				USB_TRANS_WRITE | USB_TRANS_NO_ZLP);

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -81,6 +81,14 @@ static struct usb_ep_cfg_data wpanusb_ep[] = {
 	},
 };
 
+static struct usb_if_container wpanusb_if_containers[] = {
+	{
+		.iface = &wpanusb_desc.if0,
+		.iface_alt = NULL,
+		.curr_alt = 0,
+	}
+};
+
 static void wpanusb_status_cb(struct usb_cfg_data *cfg,
 			      enum usb_dc_status_code status,
 			      const uint8_t *param)
@@ -151,13 +159,14 @@ static int wpanusb_vendor_handler(struct usb_setup_packet *setup,
 }
 
 USBD_CFG_DATA_DEFINE(primary, wpanusb) struct usb_cfg_data wpanusb_config = {
-	.interface_descriptor = &wpanusb_desc.if0,
 	.cb_usb_status = wpanusb_status_cb,
 	.request_handlers = {
 		.vendor_handler = wpanusb_vendor_handler,
 		.class_handler = NULL,
 		.custom_handler = NULL,
 	},
+	.num_if_containers = ARRAY_SIZE(wpanusb_if_containers),
+	.if_containers = wpanusb_if_containers,
 	.num_endpoints = ARRAY_SIZE(wpanusb_ep),
 	.endpoints = wpanusb_ep,
 };

--- a/samples/subsys/usb/webusb/src/main.c
+++ b/samples/subsys/usb/webusb/src/main.c
@@ -276,7 +276,7 @@ int vendor_handle_req(struct usb_setup_packet *pSetup,
 }
 
 /* Custom and Vendor request handlers */
-static struct webusb_req_handlers req_handlers = {
+static struct usb_request_handlers req_handlers = {
 	.custom_handler = custom_handle_req,
 	.vendor_handler = vendor_handle_req,
 };

--- a/samples/subsys/usb/webusb/src/webusb.c
+++ b/samples/subsys/usb/webusb/src/webusb.c
@@ -146,7 +146,7 @@ static void webusb_read_cb(uint8_t ep, int size, void *priv)
 		goto done;
 	}
 
-	usb_transfer(cfg->endpoint[WEBUSB_IN_EP_IDX].ep_addr, rx_buf, size,
+	usb_transfer(cfg->endpoints[WEBUSB_IN_EP_IDX].ep_addr, rx_buf, size,
 		     USB_TRANS_WRITE, webusb_write_cb, cfg);
 done:
 	usb_transfer(ep, rx_buf, sizeof(rx_buf), USB_TRANS_READ,
@@ -180,7 +180,7 @@ static void webusb_dev_status_cb(struct usb_cfg_data *cfg,
 		break;
 	case USB_DC_CONFIGURED:
 		LOG_DBG("USB device configured");
-		webusb_read_cb(cfg->endpoint[WEBUSB_OUT_EP_IDX].ep_addr,
+		webusb_read_cb(cfg->endpoints[WEBUSB_OUT_EP_IDX].ep_addr,
 			       0, cfg);
 		break;
 	case USB_DC_DISCONNECTED:
@@ -214,11 +214,11 @@ static struct usb_ep_cfg_data webusb_ep_data[] = {
 USBD_CFG_DATA_DEFINE(primary, webusb) struct usb_cfg_data webusb_config = {
 	.interface_descriptor = &webusb_desc.if0,
 	.cb_usb_status = webusb_dev_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = NULL,
 		.custom_handler = webusb_custom_handle_req,
 		.vendor_handler = webusb_vendor_handle_req,
 	},
 	.num_endpoints = ARRAY_SIZE(webusb_ep_data),
-	.endpoint = webusb_ep_data
+	.endpoints = webusb_ep_data
 };

--- a/samples/subsys/usb/webusb/src/webusb.c
+++ b/samples/subsys/usb/webusb/src/webusb.c
@@ -212,7 +212,6 @@ static struct usb_ep_cfg_data webusb_ep_data[] = {
 };
 
 USBD_CFG_DATA_DEFINE(primary, webusb) struct usb_cfg_data webusb_config = {
-	.usb_device_description = NULL,
 	.interface_descriptor = &webusb_desc.if0,
 	.cb_usb_status = webusb_dev_status_cb,
 	.interface = {

--- a/samples/subsys/usb/webusb/src/webusb.c
+++ b/samples/subsys/usb/webusb/src/webusb.c
@@ -138,19 +138,19 @@ static void webusb_write_cb(uint8_t ep, int size, void *priv)
 
 static void webusb_read_cb(uint8_t ep, int size, void *priv)
 {
-	struct usb_cfg_data *cfg = priv;
+	struct usb_class_data *class_data = priv;
 
-	LOG_DBG("cfg %p ep %x size %u", cfg, ep, size);
+	LOG_DBG("class_data %p ep %x size %u", class_data, ep, size);
 
 	if (size <= 0) {
 		goto done;
 	}
 
-	usb_transfer(cfg->endpoints[WEBUSB_IN_EP_IDX].ep_addr, rx_buf, size,
-		     USB_TRANS_WRITE, webusb_write_cb, cfg);
+	usb_transfer(class_data->endpoints[WEBUSB_IN_EP_IDX].ep_addr, rx_buf,
+		     size, USB_TRANS_WRITE, webusb_write_cb, class_data);
 done:
 	usb_transfer(ep, rx_buf, sizeof(rx_buf), USB_TRANS_READ,
-		     webusb_read_cb, cfg);
+		     webusb_read_cb, class_data);
 }
 
 /**
@@ -160,12 +160,12 @@ done:
  *
  * @return  N/A.
  */
-static void webusb_dev_status_cb(struct usb_cfg_data *cfg,
+static void webusb_dev_status_cb(struct usb_class_data *class_data,
 				 enum usb_dc_status_code status,
 				 const uint8_t *param)
 {
 	ARG_UNUSED(param);
-	ARG_UNUSED(cfg);
+	ARG_UNUSED(class_data);
 
 	/* Check the USB status and do needed action if required */
 	switch (status) {
@@ -180,8 +180,8 @@ static void webusb_dev_status_cb(struct usb_cfg_data *cfg,
 		break;
 	case USB_DC_CONFIGURED:
 		LOG_DBG("USB device configured");
-		webusb_read_cb(cfg->endpoints[WEBUSB_OUT_EP_IDX].ep_addr,
-			       0, cfg);
+		webusb_read_cb(class_data->endpoints[WEBUSB_OUT_EP_IDX].ep_addr,
+			       0, class_data);
 		break;
 	case USB_DC_DISCONNECTED:
 		LOG_DBG("USB device disconnected");
@@ -219,7 +219,7 @@ static struct usb_if_container webusb_if_data[] = {
 	}
 };
 
-USBD_CFG_DATA_DEFINE(primary, webusb) struct usb_cfg_data webusb_config = {
+USBD_CLASS_DATA_DEFINE(primary, webusb) struct usb_class_data webusb_class = {
 	.cb_usb_status = webusb_dev_status_cb,
 	.request_handlers = {
 		.class_handler = NULL,

--- a/samples/subsys/usb/webusb/src/webusb.c
+++ b/samples/subsys/usb/webusb/src/webusb.c
@@ -211,14 +211,23 @@ static struct usb_ep_cfg_data webusb_ep_data[] = {
 	}
 };
 
+static struct usb_if_container webusb_if_data[] = {
+	{
+		.iface = &webusb_desc.if0,
+		.iface_alt = NULL,
+		.curr_alt = 0,
+	}
+};
+
 USBD_CFG_DATA_DEFINE(primary, webusb) struct usb_cfg_data webusb_config = {
-	.interface_descriptor = &webusb_desc.if0,
 	.cb_usb_status = webusb_dev_status_cb,
 	.request_handlers = {
 		.class_handler = NULL,
 		.custom_handler = webusb_custom_handle_req,
 		.vendor_handler = webusb_vendor_handle_req,
 	},
+	.num_if_containers = ARRAY_SIZE(webusb_if_data),
+	.if_containers = webusb_if_data,
 	.num_endpoints = ARRAY_SIZE(webusb_ep_data),
 	.endpoints = webusb_ep_data
 };

--- a/samples/subsys/usb/webusb/src/webusb.c
+++ b/samples/subsys/usb/webusb/src/webusb.c
@@ -33,7 +33,7 @@ LOG_MODULE_REGISTER(webusb);
 #define WEBUSB_IN_EP_IDX		0
 #define WEBUSB_OUT_EP_IDX		1
 
-static struct webusb_req_handlers *req_handlers;
+static struct usb_request_handlers *req_handlers;
 
 uint8_t rx_buf[64];
 
@@ -126,7 +126,7 @@ int webusb_vendor_handle_req(struct usb_setup_packet *pSetup,
  *
  * @return N/A
  */
-void webusb_register_request_handlers(struct webusb_req_handlers *handlers)
+void webusb_register_request_handlers(struct usb_request_handlers *handlers)
 {
 	req_handlers = handlers;
 }

--- a/samples/subsys/usb/webusb/src/webusb.h
+++ b/samples/subsys/usb/webusb/src/webusb.h
@@ -15,29 +15,14 @@
 #define __WEBUSB_SERIAL_H__
 
 /**
- * WebUSB request handlers
- */
-struct webusb_req_handlers {
-	/* Handler for WebUSB Vendor specific commands */
-	usb_request_handler vendor_handler;
-	/**
-	 * The custom request handler gets a first chance at handling
-	 * the request before it is handed over to the 'chapter 9' request
-	 * handler
-	 */
-	usb_request_handler custom_handler;
-};
-
-/**
- * @brief Register Custom and Vendor request callbacks
+ * @brief Register request callbacks
  *
- * Function to register Custom and Vendor request callbacks
- * for handling requests.
+ * Function to register request callbacks for handling requests.
  *
- * @param [in] handlers Pointer to WebUSB request handlers structure
+ * @param [in] handlers Pointer request handlers structure
  *
  * @return N/A
  */
-void webusb_register_request_handlers(struct webusb_req_handlers *handlers);
+void webusb_register_request_handlers(struct usb_request_handlers *handlers);
 
 #endif /* __WEBUSB_SERIAL_H__ */

--- a/subsys/tracing/tracing_backend_usb.c
+++ b/subsys/tracing/tracing_backend_usb.c
@@ -127,13 +127,13 @@ USBD_CFG_DATA_DEFINE(primary, tracing_backend_usb)
 	struct usb_cfg_data tracing_backend_usb_config = {
 	.interface_descriptor = &dev_desc.if0,
 	.cb_usb_status = dev_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = NULL,
 		.custom_handler = NULL,
 		.vendor_handler = NULL,
 	},
 	.num_endpoints = ARRAY_SIZE(ep_cfg),
-	.endpoint = ep_cfg,
+	.endpoints = ep_cfg,
 };
 
 static void tracing_backend_usb_output(const struct tracing_backend *backend,

--- a/subsys/tracing/tracing_backend_usb.c
+++ b/subsys/tracing/tracing_backend_usb.c
@@ -125,7 +125,6 @@ static struct usb_ep_cfg_data ep_cfg[] = {
 
 USBD_CFG_DATA_DEFINE(primary, tracing_backend_usb)
 	struct usb_cfg_data tracing_backend_usb_config = {
-	.usb_device_description = NULL,
 	.interface_descriptor = &dev_desc.if0,
 	.cb_usb_status = dev_status_cb,
 	.interface = {

--- a/subsys/tracing/tracing_backend_usb.c
+++ b/subsys/tracing/tracing_backend_usb.c
@@ -70,11 +70,11 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_device_desc dev_desc = {
 	},
 };
 
-static void dev_status_cb(struct usb_cfg_data *cfg,
+static void dev_status_cb(struct usb_class_data *class_data,
 			  enum usb_dc_status_code status,
 			  const uint8_t *param)
 {
-	ARG_UNUSED(cfg);
+	ARG_UNUSED(class_data);
 	ARG_UNUSED(param);
 
 	usb_device_status = status;
@@ -131,8 +131,8 @@ static struct usb_if_container if_cfg[] = {
 	}
 };
 
-USBD_CFG_DATA_DEFINE(primary, tracing_backend_usb)
-	struct usb_cfg_data tracing_backend_usb_config = {
+USBD_CLASS_DATA_DEFINE(primary, tracing_backend_usb)
+	struct usb_class_data tracing_backend_usb_class = {
 	.cb_usb_status = dev_status_cb,
 	.request_handlers = {
 		.class_handler = NULL,

--- a/subsys/tracing/tracing_backend_usb.c
+++ b/subsys/tracing/tracing_backend_usb.c
@@ -123,15 +123,24 @@ static struct usb_ep_cfg_data ep_cfg[] = {
 	},
 };
 
+static struct usb_if_container if_cfg[] = {
+	{
+		.iface = &dev_desc.if0,
+		.iface_alt = NULL,
+		.curr_alt = 0,
+	}
+};
+
 USBD_CFG_DATA_DEFINE(primary, tracing_backend_usb)
 	struct usb_cfg_data tracing_backend_usb_config = {
-	.interface_descriptor = &dev_desc.if0,
 	.cb_usb_status = dev_status_cb,
 	.request_handlers = {
 		.class_handler = NULL,
 		.custom_handler = NULL,
 		.vendor_handler = NULL,
 	},
+	.num_if_containers = ARRAY_SIZE(if_cfg),
+	.if_containers = if_cfg,
 	.num_endpoints = ARRAY_SIZE(ep_cfg),
 	.endpoints = ep_cfg,
 };

--- a/subsys/usb/class/audio/audio.c
+++ b/subsys/usb/class/audio/audio.c
@@ -275,7 +275,7 @@ static void audio_dc_sof(struct usb_cfg_data *cfg,
 	uint8_t ep_addr;
 
 	/* In endpoint always at index 0 */
-	ep_addr = cfg->endpoint[0].ep_addr;
+	ep_addr = cfg->endpoints[0].ep_addr;
 	if ((ep_addr & USB_EP_DIR_MASK) && (dev_data->tx_enable)) {
 		if (dev_data->ops && dev_data->ops->data_request_cb) {
 			dev_data->ops->data_request_cb(
@@ -812,7 +812,7 @@ int usb_audio_send(const struct device *dev, struct net_buf *buffer,
 	struct usb_audio_dev_data *audio_dev_data = dev->driver_data;
 	struct usb_cfg_data *cfg = (void *)dev->config_info;
 	/* EP ISO IN is always placed first in the endpoint table */
-	uint8_t ep = cfg->endpoint[0].ep_addr;
+	uint8_t ep = cfg->endpoints[0].ep_addr;
 
 	if (!(ep & USB_EP_DIR_MASK)) {
 		LOG_ERR("Wrong device");
@@ -926,13 +926,13 @@ void usb_audio_register(struct device *dev,
 		.interface_config = audio_interface_config,		  \
 		.interface_descriptor = &dev##_desc_##i.std_ac_interface, \
 		.cb_usb_status = audio_cb_usb_status,			  \
-		.interface = {						  \
+		.request_handlers = {					  \
 			.class_handler = audio_class_handle_req,	  \
 			.custom_handler = audio_custom_handler,		  \
 			.vendor_handler = NULL,				  \
 		},							  \
 		.num_endpoints = ARRAY_SIZE(dev##_usb_audio_ep_data_##i), \
-		.endpoint = dev##_usb_audio_ep_data_##i,		  \
+		.endpoints = dev##_usb_audio_ep_data_##i,		  \
 	};								  \
 	DEVICE_AND_API_INIT(dev##_usb_audio_device_##i,			  \
 			    DT_LABEL(DT_INST(i, COMPAT_##dev)),		  \

--- a/subsys/usb/class/audio/audio.c
+++ b/subsys/usb/class/audio/audio.c
@@ -923,7 +923,6 @@ void usb_audio_register(struct device *dev,
 #define DEFINE_AUDIO_DEVICE(dev, i)					  \
 	USBD_CFG_DATA_DEFINE(primary, audio)				  \
 	struct usb_cfg_data dev##_audio_config_##i = {			  \
-		.usb_device_description	= NULL,				  \
 		.interface_config = audio_interface_config,		  \
 		.interface_descriptor = &dev##_desc_##i.std_ac_interface, \
 		.cb_usb_status = audio_cb_usb_status,			  \

--- a/subsys/usb/class/audio/audio.c
+++ b/subsys/usb/class/audio/audio.c
@@ -86,6 +86,19 @@ struct dev##_descriptor_##i dev##_desc_##i = {				      \
 };									      \
 static struct usb_ep_cfg_data dev##_usb_audio_ep_data_##i[] = {		      \
 	INIT_EP_DATA(cb, addr),						      \
+};									      \
+static struct usb_if_container						      \
+dev##_usb_audio_iface_data_##i[] = {					      \
+	{								      \
+		.iface = &dev##_desc_##i.std_ac_interface,		      \
+		.iface_alt = NULL,					      \
+		.curr_alt = 0,						      \
+	},								      \
+	{								      \
+		.iface = &dev##_desc_##i.as_interface_alt_0,		      \
+		.iface_alt = &dev##_desc_##i.as_interface_alt_1,	      \
+		.curr_alt = 0,						      \
+	},								      \
 }
 
 /**
@@ -144,6 +157,24 @@ struct dev##_descriptor_##i dev##_desc_##i = {				  \
 static struct usb_ep_cfg_data dev##_usb_audio_ep_data_##i[] = {		  \
 	INIT_EP_DATA(usb_transfer_ep_callback, AUTO_EP_IN),		  \
 	INIT_EP_DATA(audio_receive_cb, AUTO_EP_OUT),			  \
+};									  \
+static struct usb_if_container						  \
+dev##_usb_audio_iface_data_##i[] = {					  \
+	{								  \
+		.iface = &dev##_desc_##i.std_ac_interface,		  \
+		.iface_alt = NULL,					  \
+		.curr_alt = 0,						  \
+	},								  \
+	{								  \
+		.iface = &dev##_desc_##i.as_interface_alt_0_0,		  \
+		.iface_alt = &dev##_desc_##i.as_interface_alt_0_1,	  \
+		.curr_alt = 0,						  \
+	},								  \
+	{								  \
+		.iface = &dev##_desc_##i.as_interface_alt_1_0,		  \
+		.iface_alt = &dev##_desc_##i.as_interface_alt_1_1,	  \
+		.curr_alt = 0,						  \
+	},								  \
 }
 
 #define DEFINE_AUDIO_DEV_DATA(dev, i, __out_pool, __in_pool_size)   \
@@ -901,8 +932,8 @@ void usb_audio_register(struct device *dev,
 {
 	struct usb_audio_dev_data *audio_dev_data = dev->driver_data;
 	const struct usb_cfg_data *cfg = dev->config_info;
-	const struct std_if_descriptor *iface_descr =
-		cfg->interface_descriptor;
+	const struct usb_if_descriptor *iface_descr =
+		cfg->if_containers[0].iface;
 	const struct cs_ac_if_descriptor *header =
 		(struct cs_ac_if_descriptor *)
 		((uint8_t *)iface_descr + USB_PASSIVE_IF_DESC_SIZE);
@@ -924,13 +955,14 @@ void usb_audio_register(struct device *dev,
 	USBD_CFG_DATA_DEFINE(primary, audio)				  \
 	struct usb_cfg_data dev##_audio_config_##i = {			  \
 		.interface_config = audio_interface_config,		  \
-		.interface_descriptor = &dev##_desc_##i.std_ac_interface, \
 		.cb_usb_status = audio_cb_usb_status,			  \
 		.request_handlers = {					  \
 			.class_handler = audio_class_handle_req,	  \
 			.custom_handler = audio_custom_handler,		  \
 			.vendor_handler = NULL,				  \
 		},							  \
+		.num_if_containers = ARRAY_SIZE(dev##_usb_audio_iface_data_##i),\
+		.if_containers = dev##_usb_audio_iface_data_##i,	  \
 		.num_endpoints = ARRAY_SIZE(dev##_usb_audio_ep_data_##i), \
 		.endpoints = dev##_usb_audio_ep_data_##i,		  \
 	};								  \

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -323,13 +323,13 @@ USBD_CFG_DATA_DEFINE(primary, hci) struct usb_cfg_data bluetooth_config = {
 	.interface_config = bluetooth_interface_config,
 	.interface_descriptor = &bluetooth_cfg.if0,
 	.cb_usb_status = bluetooth_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = bluetooth_class_handler,
 		.custom_handler = NULL,
 		.vendor_handler = NULL,
 	},
 	.num_endpoints = ARRAY_SIZE(bluetooth_ep_data),
-	.endpoint = bluetooth_ep_data,
+	.endpoints = bluetooth_ep_data,
 };
 
 static int bluetooth_init(struct device *dev)

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -320,7 +320,6 @@ static void bluetooth_interface_config(struct usb_desc_header *head,
 }
 
 USBD_CFG_DATA_DEFINE(primary, hci) struct usb_cfg_data bluetooth_config = {
-	.usb_device_description = NULL,
 	.interface_config = bluetooth_interface_config,
 	.interface_descriptor = &bluetooth_cfg.if0,
 	.cb_usb_status = bluetooth_status_cb,

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -115,6 +115,14 @@ static struct usb_ep_cfg_data bluetooth_ep_data[] = {
 	},
 };
 
+static struct usb_if_container bluetooth_interfaces[] = {
+	{
+		.iface = &bluetooth_cfg.if0,
+		.iface_alt = NULL,
+		.curr_alt = 0,
+	}
+};
+
 static void hci_tx_thread(void)
 {
 	LOG_DBG("Start USB Bluetooth thread");
@@ -321,13 +329,14 @@ static void bluetooth_interface_config(struct usb_desc_header *head,
 
 USBD_CFG_DATA_DEFINE(primary, hci) struct usb_cfg_data bluetooth_config = {
 	.interface_config = bluetooth_interface_config,
-	.interface_descriptor = &bluetooth_cfg.if0,
 	.cb_usb_status = bluetooth_status_cb,
 	.request_handlers = {
 		.class_handler = bluetooth_class_handler,
 		.custom_handler = NULL,
 		.vendor_handler = NULL,
 	},
+	.num_if_containers = ARRAY_SIZE(bluetooth_interfaces),
+	.if_containers = bluetooth_interfaces,
 	.num_endpoints = ARRAY_SIZE(bluetooth_ep_data),
 	.endpoints = bluetooth_ep_data,
 };

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -204,11 +204,11 @@ static void acl_read_cb(uint8_t ep, int size, void *priv)
 		     BT_BUF_ACL_SIZE, USB_TRANS_READ, acl_read_cb, NULL);
 }
 
-static void bluetooth_status_cb(struct usb_cfg_data *cfg,
+static void bluetooth_status_cb(struct usb_class_data *class_data,
 				enum usb_dc_status_code status,
 				const uint8_t *param)
 {
-	ARG_UNUSED(cfg);
+	ARG_UNUSED(class_data);
 
 	/* Check the USB status and do needed action if required */
 	switch (status) {
@@ -327,7 +327,7 @@ static void bluetooth_interface_config(struct usb_desc_header *head,
 	bluetooth_cfg.if0.bInterfaceNumber = bInterfaceNumber;
 }
 
-USBD_CFG_DATA_DEFINE(primary, hci) struct usb_cfg_data bluetooth_config = {
+USBD_CLASS_DATA_DEFINE(primary, hci) struct usb_class_data bluetooth_class = {
 	.interface_config = bluetooth_interface_config,
 	.cb_usb_status = bluetooth_status_cb,
 	.request_handlers = {

--- a/subsys/usb/class/bt_h4.c
+++ b/subsys/usb/class/bt_h4.c
@@ -208,7 +208,6 @@ static void bt_h4_interface_config(struct usb_desc_header *head,
 }
 
 USBD_CFG_DATA_DEFINE(primary, hci_h4) struct usb_cfg_data bt_h4_config = {
-	.usb_device_description = NULL,
 	.interface_config = bt_h4_interface_config,
 	.interface_descriptor = &bt_h4_cfg.if0,
 	.cb_usb_status = bt_h4_status_cb,

--- a/subsys/usb/class/bt_h4.c
+++ b/subsys/usb/class/bt_h4.c
@@ -211,13 +211,13 @@ USBD_CFG_DATA_DEFINE(primary, hci_h4) struct usb_cfg_data bt_h4_config = {
 	.interface_config = bt_h4_interface_config,
 	.interface_descriptor = &bt_h4_cfg.if0,
 	.cb_usb_status = bt_h4_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = NULL,
 		.custom_handler = NULL,
 		.vendor_handler = bt_h4_vendor_handler,
 	},
 	.num_endpoints = ARRAY_SIZE(bt_h4_ep_data),
-	.endpoint = bt_h4_ep_data,
+	.endpoints = bt_h4_ep_data,
 };
 
 static int bt_h4_init(struct device *dev)

--- a/subsys/usb/class/bt_h4.c
+++ b/subsys/usb/class/bt_h4.c
@@ -92,6 +92,14 @@ static struct usb_ep_cfg_data bt_h4_ep_data[] = {
 	},
 };
 
+static struct usb_if_container bt_h4_if_data[] = {
+	{
+		.iface = &bt_h4_cfg.if0,
+		.iface_alt = NULL,
+		.curr_alt = 0,
+	}
+};
+
 static void bt_h4_read(uint8_t ep, int size, void *priv)
 {
 	static uint8_t data[BT_H4_BULK_EP_MPS];
@@ -209,13 +217,14 @@ static void bt_h4_interface_config(struct usb_desc_header *head,
 
 USBD_CFG_DATA_DEFINE(primary, hci_h4) struct usb_cfg_data bt_h4_config = {
 	.interface_config = bt_h4_interface_config,
-	.interface_descriptor = &bt_h4_cfg.if0,
 	.cb_usb_status = bt_h4_status_cb,
 	.request_handlers = {
 		.class_handler = NULL,
 		.custom_handler = NULL,
 		.vendor_handler = bt_h4_vendor_handler,
 	},
+	.num_if_containers = ARRAY_SIZE(bt_h4_if_data),
+	.if_containers = bt_h4_if_data,
 	.num_endpoints = ARRAY_SIZE(bt_h4_ep_data),
 	.endpoints = bt_h4_ep_data,
 };

--- a/subsys/usb/class/bt_h4.c
+++ b/subsys/usb/class/bt_h4.c
@@ -150,10 +150,10 @@ static void hci_rx_thread(void)
 	}
 }
 
-static void bt_h4_status_cb(struct usb_cfg_data *cfg,
+static void bt_h4_status_cb(struct usb_class_data *class_data,
 			    enum usb_dc_status_code status, const uint8_t *param)
 {
-	ARG_UNUSED(cfg);
+	ARG_UNUSED(class_data);
 
 	/* Check the USB status and do needed action if required */
 	switch (status) {
@@ -215,7 +215,7 @@ static void bt_h4_interface_config(struct usb_desc_header *head,
 	bt_h4_cfg.if0.bInterfaceNumber = bInterfaceNumber;
 }
 
-USBD_CFG_DATA_DEFINE(primary, hci_h4) struct usb_cfg_data bt_h4_config = {
+USBD_CLASS_DATA_DEFINE(primary, hci_h4) struct usb_class_data bt_h4_class = {
 	.interface_config = bt_h4_interface_config,
 	.cb_usb_status = bt_h4_status_cb,
 	.request_handlers = {

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -289,7 +289,7 @@ static void tx_work_handler(struct k_work *work)
 		CONTAINER_OF(work, struct cdc_acm_dev_data_t, tx_work);
 	struct device *dev = dev_data->common.dev;
 	struct usb_cfg_data *cfg = (void *)dev->config_info;
-	uint8_t ep = cfg->endpoint[ACM_IN_EP_IDX].ep_addr;
+	uint8_t ep = cfg->endpoints[ACM_IN_EP_IDX].ep_addr;
 	uint8_t *data;
 	size_t len;
 
@@ -420,7 +420,7 @@ static void cdc_acm_do_cb(struct cdc_acm_dev_data_t *dev_data,
 		LOG_DBG("USB device connected");
 		break;
 	case USB_DC_CONFIGURED:
-		cdc_acm_read_cb(cfg->endpoint[ACM_OUT_EP_IDX].ep_addr, 0,
+		cdc_acm_read_cb(cfg->endpoints[ACM_OUT_EP_IDX].ep_addr, 0,
 				dev_data);
 		dev_data->tx_ready = true;
 		dev_data->tx_irq_ena = true;
@@ -791,7 +791,7 @@ static int cdc_acm_send_notification(struct device *dev, uint16_t serial_state)
 
 	dev_data->notification_sent = 0U;
 
-	usb_write(cfg->endpoint[ACM_INT_EP_IDX].ep_addr,
+	usb_write(cfg->endpoints[ACM_INT_EP_IDX].ep_addr,
 		  (const uint8_t *)&notification, sizeof(notification), NULL);
 
 	/* Wait for notification to be sent */
@@ -991,12 +991,12 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 		.interface_config = cdc_interface_config,		\
 		.interface_descriptor = &cdc_acm_cfg_##x.if0,		\
 		.cb_usb_status = cdc_acm_dev_status_cb,			\
-		.interface = {						\
+		.request_handlers = {					\
 			.class_handler = cdc_acm_class_handle_req,	\
 			.custom_handler = NULL,				\
 		},							\
 		.num_endpoints = ARRAY_SIZE(cdc_acm_ep_data_##x),	\
-		.endpoint = cdc_acm_ep_data_##x,			\
+		.endpoints = cdc_acm_ep_data_##x,			\
 	};
 
 #if (CONFIG_USB_COMPOSITE_DEVICE || CONFIG_CDC_ACM_IAD)

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -988,7 +988,6 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 #define DEFINE_CDC_ACM_CFG_DATA(x, _)					\
 	USBD_CFG_DATA_DEFINE(primary, cdc_acm)				\
 	struct usb_cfg_data cdc_acm_config_##x = {			\
-		.usb_device_description = NULL,				\
 		.interface_config = cdc_interface_config,		\
 		.interface_descriptor = &cdc_acm_cfg_##x.if0,		\
 		.cb_usb_status = cdc_acm_dev_status_cb,			\

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -288,8 +288,8 @@ static void tx_work_handler(struct k_work *work)
 	struct cdc_acm_dev_data_t *dev_data =
 		CONTAINER_OF(work, struct cdc_acm_dev_data_t, tx_work);
 	struct device *dev = dev_data->common.dev;
-	struct usb_cfg_data *cfg = (void *)dev->config_info;
-	uint8_t ep = cfg->endpoints[ACM_IN_EP_IDX].ep_addr;
+	struct usb_class_data *class_data = (void *)dev->config_info;
+	uint8_t ep = class_data->endpoints[ACM_IN_EP_IDX].ep_addr;
 	uint8_t *data;
 	size_t len;
 
@@ -400,7 +400,7 @@ static void cdc_acm_do_cb(struct cdc_acm_dev_data_t *dev_data,
 			  const uint8_t *param)
 {
 	struct device *dev = dev_data->common.dev;
-	struct usb_cfg_data *cfg = (void *)dev->config_info;
+	struct usb_class_data *class_data = (void *)dev->config_info;
 
 	/* Store the new status */
 	if (!(status == USB_DC_SOF || status == USB_DC_INTERFACE)) {
@@ -420,8 +420,8 @@ static void cdc_acm_do_cb(struct cdc_acm_dev_data_t *dev_data,
 		LOG_DBG("USB device connected");
 		break;
 	case USB_DC_CONFIGURED:
-		cdc_acm_read_cb(cfg->endpoints[ACM_OUT_EP_IDX].ep_addr, 0,
-				dev_data);
+		cdc_acm_read_cb(class_data->endpoints[ACM_OUT_EP_IDX].ep_addr,
+				0, dev_data);
 		dev_data->tx_ready = true;
 		dev_data->tx_irq_ena = true;
 		dev_data->rx_irq_ena = true;
@@ -448,18 +448,19 @@ static void cdc_acm_do_cb(struct cdc_acm_dev_data_t *dev_data,
 	}
 }
 
-static void cdc_acm_dev_status_cb(struct usb_cfg_data *cfg,
+static void cdc_acm_dev_status_cb(struct usb_class_data *class_data,
 				  enum usb_dc_status_code status,
 				  const uint8_t *param)
 {
 	struct cdc_acm_dev_data_t *dev_data;
 	struct usb_dev_data *common;
 
-	LOG_DBG("cfg %p status %d", cfg, status);
+	LOG_DBG("class_data %p status %d", class_data, status);
 
-	common = usb_get_dev_data_by_cfg(&cdc_acm_data_devlist, cfg);
+	common = usb_get_dev_data_by_class_data(&cdc_acm_data_devlist,
+						class_data);
 	if (common == NULL) {
-		LOG_WRN("Device data not found for cfg %p", cfg);
+		LOG_WRN("Device data not found for class_data %p", class_data);
 		return;
 	}
 
@@ -778,7 +779,7 @@ static void cdc_acm_baudrate_set(struct device *dev, uint32_t baudrate)
 static int cdc_acm_send_notification(struct device *dev, uint16_t serial_state)
 {
 	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
-	struct usb_cfg_data * const cfg = (void *)dev->config_info;
+	struct usb_class_data *const class_data = (void *)dev->config_info;
 	struct cdc_acm_notification notification;
 	uint32_t cnt = 0U;
 
@@ -791,7 +792,7 @@ static int cdc_acm_send_notification(struct device *dev, uint16_t serial_state)
 
 	dev_data->notification_sent = 0U;
 
-	usb_write(cfg->endpoints[ACM_INT_EP_IDX].ep_addr,
+	usb_write(class_data->endpoints[ACM_INT_EP_IDX].ep_addr,
 		  (const uint8_t *)&notification, sizeof(notification), NULL);
 
 	/* Wait for notification to be sent */
@@ -997,9 +998,9 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 		}							\
 	}
 
-#define DEFINE_CDC_ACM_CFG_DATA(x, _)					\
-	USBD_CFG_DATA_DEFINE(primary, cdc_acm)				\
-	struct usb_cfg_data cdc_acm_config_##x = {			\
+#define DEFINE_CDC_ACM_CLASS_DATA(x, _)					\
+	USBD_CLASS_DATA_DEFINE(primary, cdc_acm)			\
+	struct usb_class_data cdc_acm_class_##x = {			\
 		.interface_config = cdc_interface_config,		\
 		.cb_usb_status = cdc_acm_dev_status_cb,			\
 		.request_handlers = {					\
@@ -1079,7 +1080,7 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 	DEVICE_AND_API_INIT(cdc_acm_##x,				\
 			    CONFIG_USB_CDC_ACM_DEVICE_NAME "_" #x,	\
 			    &cdc_acm_init, &cdc_acm_dev_data_##x,	\
-			    &cdc_acm_config_##x,			\
+			    &cdc_acm_class_##x,				\
 			    POST_KERNEL,				\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &cdc_acm_driver_api);
@@ -1092,6 +1093,6 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 
 UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_DESCR_AUTO, _)
 UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_EP_IF_AUTO, _)
-UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_CFG_DATA, _)
+UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_CLASS_DATA, _)
 UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_DEV_DATA, _)
 UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_DEVICE, _)

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -976,25 +976,38 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 		.ep_addr = addr,					\
 	}
 
-#define DEFINE_CDC_ACM_EP(x, int_ep_addr, out_ep_addr, in_ep_addr)	\
+#define DEFINE_CDC_ACM_EP_IF(x, int_ep_addr, out_ep_addr, in_ep_addr)	\
 	static struct usb_ep_cfg_data cdc_acm_ep_data_##x[] = {		\
 		INITIALIZER_EP_DATA(cdc_acm_int_in, int_ep_addr),	\
 		INITIALIZER_EP_DATA(usb_transfer_ep_callback,		\
 				    out_ep_addr),			\
 		INITIALIZER_EP_DATA(usb_transfer_ep_callback,		\
 				    in_ep_addr),			\
+	};								\
+	static struct usb_if_container cdc_acm_if_data_##x[] = {	\
+		{							\
+			.iface = &cdc_acm_cfg_##x.if0,			\
+			.iface_alt = NULL,				\
+			.curr_alt = 0,					\
+		},							\
+		{							\
+			.iface = &cdc_acm_cfg_##x.if1,			\
+			.iface_alt = NULL,				\
+			.curr_alt = 0,					\
+		}							\
 	}
 
 #define DEFINE_CDC_ACM_CFG_DATA(x, _)					\
 	USBD_CFG_DATA_DEFINE(primary, cdc_acm)				\
 	struct usb_cfg_data cdc_acm_config_##x = {			\
 		.interface_config = cdc_interface_config,		\
-		.interface_descriptor = &cdc_acm_cfg_##x.if0,		\
 		.cb_usb_status = cdc_acm_dev_status_cb,			\
 		.request_handlers = {					\
 			.class_handler = cdc_acm_class_handle_req,	\
 			.custom_handler = NULL,				\
 		},							\
+		.num_if_containers = ARRAY_SIZE(cdc_acm_if_data_##x),	\
+		.if_containers = cdc_acm_if_data_##x,			\
 		.num_endpoints = ARRAY_SIZE(cdc_acm_ep_data_##x),	\
 		.endpoints = cdc_acm_ep_data_##x,			\
 	};
@@ -1074,11 +1087,11 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 #define DEFINE_CDC_ACM_DESCR_AUTO(x, _) \
 	DEFINE_CDC_ACM_DESCR(x, AUTO_EP_IN, AUTO_EP_OUT, AUTO_EP_IN);
 
-#define DEFINE_CDC_ACM_EP_AUTO(x, _) \
-	DEFINE_CDC_ACM_EP(x, AUTO_EP_IN, AUTO_EP_OUT, AUTO_EP_IN);
+#define DEFINE_CDC_ACM_EP_IF_AUTO(x, _) \
+	DEFINE_CDC_ACM_EP_IF(x, AUTO_EP_IN, AUTO_EP_OUT, AUTO_EP_IN);
 
 UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_DESCR_AUTO, _)
-UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_EP_AUTO, _)
+UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_EP_IF_AUTO, _)
 UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_CFG_DATA, _)
 UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_DEV_DATA, _)
 UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_DEVICE, _)

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -635,12 +635,12 @@ static void hid_interface_config(struct usb_desc_header *head,
 		.interface_config = hid_interface_config,		\
 		.interface_descriptor = &hid_cfg_##x.if0,		\
 		.cb_usb_status = hid_status_cb,				\
-		.interface = {						\
+		.request_handlers = {					\
 			.class_handler = hid_class_handle_req,		\
 			.custom_handler = hid_custom_handle_req,	\
 		},							\
 		.num_endpoints = ARRAY_SIZE(hid_ep_data_##x),		\
-		.endpoint = hid_ep_data_##x,				\
+		.endpoints = hid_ep_data_##x,				\
 	};
 
 int usb_hid_init(const struct device *dev)
@@ -680,7 +680,7 @@ int hid_int_ep_write(const struct device *dev, const uint8_t *data, uint32_t dat
 {
 	const struct usb_cfg_data *cfg = dev->config_info;
 
-	return usb_write(cfg->endpoint[HID_INT_IN_EP_IDX].ep_addr, data,
+	return usb_write(cfg->endpoints[HID_INT_IN_EP_IDX].ep_addr, data,
 			 data_len, bytes_ret);
 }
 
@@ -690,7 +690,7 @@ int hid_int_ep_read(const struct device *dev, uint8_t *data, uint32_t max_data_l
 #ifdef CONFIG_ENABLE_HID_INT_OUT_EP
 	const struct usb_cfg_data *cfg = dev->config_info;
 
-	return usb_read(cfg->endpoint[HID_INT_OUT_EP_IDX].ep_addr,
+	return usb_read(cfg->endpoints[HID_INT_OUT_EP_IDX].ep_addr,
 			data, max_data_len, ret_bytes);
 #else
 	return -ENOTSUP;

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -632,7 +632,6 @@ static void hid_interface_config(struct usb_desc_header *head,
 #define DEFINE_HID_CFG_DATA(x, _)					\
 	USBD_CFG_DATA_DEFINE(primary, hid)				\
 	struct usb_cfg_data hid_config_##x = {				\
-		.usb_device_description = NULL,				\
 		.interface_config = hid_interface_config,		\
 		.interface_descriptor = &hid_cfg_##x.if0,		\
 		.cb_usb_status = hid_status_cb,				\

--- a/subsys/usb/class/loopback.c
+++ b/subsys/usb/class/loopback.c
@@ -163,12 +163,12 @@ USBD_CFG_DATA_DEFINE(primary, loopback) struct usb_cfg_data loopback_config = {
 	.interface_config = loopback_interface_config,
 	.interface_descriptor = &loopback_cfg.if0,
 	.cb_usb_status = loopback_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = NULL,
 		.custom_handler = NULL,
 		.vendor_handler = loopback_vendor_handler,
 	},
 	.num_endpoints = ARRAY_SIZE(ep_cfg),
-	.endpoint = ep_cfg,
+	.endpoints = ep_cfg,
 };
 /* usb.rst device config data end */

--- a/subsys/usb/class/loopback.c
+++ b/subsys/usb/class/loopback.c
@@ -160,7 +160,6 @@ static void loopback_interface_config(struct usb_desc_header *head,
 
 /* usb.rst device config data start */
 USBD_CFG_DATA_DEFINE(primary, loopback) struct usb_cfg_data loopback_config = {
-	.usb_device_description = NULL,
 	.interface_config = loopback_interface_config,
 	.interface_descriptor = &loopback_cfg.if0,
 	.cb_usb_status = loopback_status_cb,

--- a/subsys/usb/class/loopback.c
+++ b/subsys/usb/class/loopback.c
@@ -105,11 +105,11 @@ static struct usb_if_container if_cfg[] = {
 	}
 };
 
-static void loopback_status_cb(struct usb_cfg_data *cfg,
+static void loopback_status_cb(struct usb_class_data *class_data,
 			       enum usb_dc_status_code status,
 			       const uint8_t *param)
 {
-	ARG_UNUSED(cfg);
+	ARG_UNUSED(class_data);
 
 	switch (status) {
 	case USB_DC_INTERFACE:
@@ -167,7 +167,8 @@ static void loopback_interface_config(struct usb_desc_header *head,
 }
 
 /* usb.rst device config data start */
-USBD_CFG_DATA_DEFINE(primary, loopback) struct usb_cfg_data loopback_config = {
+USBD_CLASS_DATA_DEFINE(primary, loopback)
+struct usb_class_data loopback_class = {
 	.interface_config = loopback_interface_config,
 	.cb_usb_status = loopback_status_cb,
 	.request_handlers = {

--- a/subsys/usb/class/loopback.c
+++ b/subsys/usb/class/loopback.c
@@ -97,6 +97,14 @@ static struct usb_ep_cfg_data ep_cfg[] = {
 };
 /* usb.rst endpoint configuration end */
 
+static struct usb_if_container if_cfg[] = {
+	{
+		.iface = &loopback_cfg.if0,
+		.iface_alt = NULL,
+		.curr_alt = 0,
+	}
+};
+
 static void loopback_status_cb(struct usb_cfg_data *cfg,
 			       enum usb_dc_status_code status,
 			       const uint8_t *param)
@@ -161,13 +169,14 @@ static void loopback_interface_config(struct usb_desc_header *head,
 /* usb.rst device config data start */
 USBD_CFG_DATA_DEFINE(primary, loopback) struct usb_cfg_data loopback_config = {
 	.interface_config = loopback_interface_config,
-	.interface_descriptor = &loopback_cfg.if0,
 	.cb_usb_status = loopback_status_cb,
 	.request_handlers = {
 		.class_handler = NULL,
 		.custom_handler = NULL,
 		.vendor_handler = loopback_vendor_handler,
 	},
+	.num_if_containers = ARRAY_SIZE(if_cfg),
+	.if_containers = if_cfg,
 	.num_endpoints = ARRAY_SIZE(ep_cfg),
 	.endpoints = ep_cfg,
 };

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -893,12 +893,12 @@ USBD_CFG_DATA_DEFINE(primary, msd) struct usb_cfg_data mass_storage_config = {
 	.interface_config = mass_interface_config,
 	.interface_descriptor = &mass_cfg.if0,
 	.cb_usb_status = mass_storage_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = mass_storage_class_handle_req,
 		.custom_handler = NULL,
 	},
 	.num_endpoints = ARRAY_SIZE(mass_ep_data),
-	.endpoint = mass_ep_data
+	.endpoints = mass_ep_data
 };
 
 static void mass_thread_main(int arg1, int unused)

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -890,7 +890,6 @@ static void mass_interface_config(struct usb_desc_header *head,
 
 /* Configuration of the Mass Storage Device send to the USB Driver */
 USBD_CFG_DATA_DEFINE(primary, msd) struct usb_cfg_data mass_storage_config = {
-	.usb_device_description = NULL,
 	.interface_config = mass_interface_config,
 	.interface_descriptor = &mass_cfg.if0,
 	.cb_usb_status = mass_storage_status_cb,

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -144,6 +144,14 @@ static struct usb_ep_cfg_data mass_ep_data[] = {
 	}
 };
 
+static struct usb_if_container mass_if_data[] = {
+	{
+		.iface = &mass_cfg.if0,
+		.iface_alt = NULL,
+		.curr_alt = 0,
+	}
+};
+
 /* CSW Status */
 enum Status {
 	CSW_PASSED,
@@ -891,12 +899,13 @@ static void mass_interface_config(struct usb_desc_header *head,
 /* Configuration of the Mass Storage Device send to the USB Driver */
 USBD_CFG_DATA_DEFINE(primary, msd) struct usb_cfg_data mass_storage_config = {
 	.interface_config = mass_interface_config,
-	.interface_descriptor = &mass_cfg.if0,
 	.cb_usb_status = mass_storage_status_cb,
 	.request_handlers = {
 		.class_handler = mass_storage_class_handle_req,
 		.custom_handler = NULL,
 	},
+	.num_if_containers = ARRAY_SIZE(mass_if_data),
+	.if_containers = mass_if_data,
 	.num_endpoints = ARRAY_SIZE(mass_ep_data),
 	.endpoints = mass_ep_data
 };

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -844,12 +844,12 @@ static void mass_storage_bulk_in(uint8_t ep,
  *
  * @return  N/A.
  */
-static void mass_storage_status_cb(struct usb_cfg_data *cfg,
+static void mass_storage_status_cb(struct usb_class_data *class_data,
 				   enum usb_dc_status_code status,
 				   const uint8_t *param)
 {
 	ARG_UNUSED(param);
-	ARG_UNUSED(cfg);
+	ARG_UNUSED(class_data);
 
 	/* Check the USB status and do needed action if required */
 	switch (status) {
@@ -897,7 +897,8 @@ static void mass_interface_config(struct usb_desc_header *head,
 }
 
 /* Configuration of the Mass Storage Device send to the USB Driver */
-USBD_CFG_DATA_DEFINE(primary, msd) struct usb_cfg_data mass_storage_config = {
+USBD_CLASS_DATA_DEFINE(primary, msd)
+struct usb_class_data mass_storage_class = {
 	.interface_config = mass_interface_config,
 	.cb_usb_status = mass_storage_status_cb,
 	.request_handlers = {

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -429,7 +429,6 @@ static void ecm_interface_config(struct usb_desc_header *head,
 }
 
 USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
-	.usb_device_description = NULL,
 	.interface_config = ecm_interface_config,
 	.interface_descriptor = &cdc_ecm_cfg.if0,
 	.cb_usb_status = ecm_status_cb,

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -432,11 +432,11 @@ USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
 	.interface_config = ecm_interface_config,
 	.interface_descriptor = &cdc_ecm_cfg.if0,
 	.cb_usb_status = ecm_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = ecm_class_handler,
 		.custom_handler = NULL,
 		.vendor_handler = NULL,
 	},
 	.num_endpoints = ARRAY_SIZE(ecm_ep_data),
-	.endpoint = ecm_ep_data,
+	.endpoints = ecm_ep_data,
 };

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -369,11 +369,11 @@ static inline void ecm_status_interface(const uint8_t *desc)
 	netusb_enable(&ecm_function);
 }
 
-static void ecm_status_cb(struct usb_cfg_data *cfg,
+static void ecm_status_cb(struct usb_class_data *class_data,
 			  enum usb_dc_status_code status,
 			  const uint8_t *param)
 {
-	ARG_UNUSED(cfg);
+	ARG_UNUSED(class_data);
 
 	/* Check the USB status and do needed action if required */
 	switch (status) {
@@ -441,7 +441,7 @@ static void ecm_interface_config(struct usb_desc_header *head,
 #endif
 }
 
-USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
+USBD_CLASS_DATA_DEFINE(primary, netusb) struct usb_class_data netusb_class = {
 	.interface_config = ecm_interface_config,
 	.cb_usb_status = ecm_status_cb,
 	.request_handlers = {

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -192,6 +192,19 @@ static struct usb_ep_cfg_data ecm_ep_data[] = {
 	},
 };
 
+static struct usb_if_container ecm_if_data[] = {
+	{
+		.iface = &cdc_ecm_cfg.if0,
+		.iface_alt = NULL,
+		.curr_alt = 0,
+	},
+	{
+		.iface = &cdc_ecm_cfg.if1_0,
+		.iface_alt = &cdc_ecm_cfg.if1_1,
+		.curr_alt = 0,
+	}
+};
+
 static int ecm_class_handler(struct usb_setup_packet *setup, int32_t *len,
 			     uint8_t **data)
 {
@@ -430,13 +443,14 @@ static void ecm_interface_config(struct usb_desc_header *head,
 
 USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
 	.interface_config = ecm_interface_config,
-	.interface_descriptor = &cdc_ecm_cfg.if0,
 	.cb_usb_status = ecm_status_cb,
 	.request_handlers = {
 		.class_handler = ecm_class_handler,
 		.custom_handler = NULL,
 		.vendor_handler = NULL,
 	},
+	.num_if_containers  = ARRAY_SIZE(ecm_if_data),
+	.if_containers = ecm_if_data,
 	.num_endpoints = ARRAY_SIZE(ecm_ep_data),
 	.endpoints = ecm_ep_data,
 };

--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -281,7 +281,6 @@ static void eem_interface_config(struct usb_desc_header *head,
 }
 
 USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
-	.usb_device_description = NULL,
 	.interface_config = eem_interface_config,
 	.interface_descriptor = &cdc_eem_cfg.if0,
 	.cb_usb_status = eem_status_cb,

--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -284,11 +284,11 @@ USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
 	.interface_config = eem_interface_config,
 	.interface_descriptor = &cdc_eem_cfg.if0,
 	.cb_usb_status = eem_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = NULL,
 		.custom_handler = NULL,
 		.vendor_handler = NULL,
 	},
 	.num_endpoints = ARRAY_SIZE(eem_ep_data),
-	.endpoint = eem_ep_data,
+	.endpoints = eem_ep_data,
 };

--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -243,11 +243,11 @@ static inline void eem_status_interface(const uint8_t *desc)
 	netusb_enable(&eem_function);
 }
 
-static void eem_status_cb(struct usb_cfg_data *cfg,
+static void eem_status_cb(struct usb_class_data *class_data,
 			  enum usb_dc_status_code status,
 			  const uint8_t *param)
 {
-	ARG_UNUSED(cfg);
+	ARG_UNUSED(class_data);
 
 	/* Check the USB status and do needed action if required */
 	switch (status) {
@@ -288,7 +288,7 @@ static void eem_interface_config(struct usb_desc_header *head,
 	cdc_eem_cfg.if0.bInterfaceNumber = bInterfaceNumber;
 }
 
-USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
+USBD_CLASS_DATA_DEFINE(primary, netusb) struct usb_class_data netusb_class = {
 	.interface_config = eem_interface_config,
 	.cb_usb_status = eem_status_cb,
 	.request_handlers = {

--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -90,6 +90,14 @@ static struct usb_ep_cfg_data eem_ep_data[] = {
 	},
 };
 
+static struct usb_if_container eem_if_data[] = {
+	{
+		.iface = &cdc_eem_cfg.if0,
+		.iface_alt = NULL,
+		.curr_alt = 0,
+	}
+};
+
 static inline uint16_t eem_pkt_size(uint16_t hdr)
 {
 	if (hdr & BIT(15)) {
@@ -282,13 +290,14 @@ static void eem_interface_config(struct usb_desc_header *head,
 
 USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
 	.interface_config = eem_interface_config,
-	.interface_descriptor = &cdc_eem_cfg.if0,
 	.cb_usb_status = eem_status_cb,
 	.request_handlers = {
 		.class_handler = NULL,
 		.custom_handler = NULL,
 		.vendor_handler = NULL,
 	},
+	.num_if_containers = ARRAY_SIZE(eem_if_data),
+	.if_containers = eem_if_data,
 	.num_endpoints = ARRAY_SIZE(eem_ep_data),
 	.endpoints = eem_ep_data,
 };

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -1167,7 +1167,6 @@ static void netusb_interface_config(struct usb_desc_header *head,
 }
 
 USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
-	.usb_device_description = NULL,
 	.interface_config = netusb_interface_config,
 	.interface_descriptor = &rndis_cfg.if0,
 	.cb_usb_status = rndis_status_cb,

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -1170,13 +1170,13 @@ USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
 	.interface_config = netusb_interface_config,
 	.interface_descriptor = &rndis_cfg.if0,
 	.cb_usb_status = rndis_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = rndis_class_handler,
 		.custom_handler = NULL,
 		.vendor_handler = NULL,
 	},
 	.num_endpoints = ARRAY_SIZE(rndis_ep_data),
-	.endpoint = rndis_ep_data,
+	.endpoints = rndis_ep_data,
 };
 
 /* Initialize this before eth_netusb device init */

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -273,6 +273,19 @@ static struct usb_ep_cfg_data rndis_ep_data[] = {
 	},
 };
 
+static struct usb_if_container rndis_if_data[] = {
+	{
+		.iface = &rndis_cfg.if0,
+		.iface_alt = NULL,
+		.curr_alt = 0,
+	},
+	{
+		.iface = &rndis_cfg.if1,
+		.iface_alt = NULL,
+		.curr_alt = 0,
+	}
+};
+
 static int parse_rndis_header(const uint8_t *buffer, uint32_t buf_len)
 {
 	struct rndis_payload_packet *hdr = (void *)buffer;
@@ -1168,13 +1181,14 @@ static void netusb_interface_config(struct usb_desc_header *head,
 
 USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
 	.interface_config = netusb_interface_config,
-	.interface_descriptor = &rndis_cfg.if0,
 	.cb_usb_status = rndis_status_cb,
 	.request_handlers = {
 		.class_handler = rndis_class_handler,
 		.custom_handler = NULL,
 		.vendor_handler = NULL,
 	},
+	.num_if_containers = ARRAY_SIZE(rndis_if_data),
+	.if_containers = rndis_if_data,
 	.num_endpoints = ARRAY_SIZE(rndis_ep_data),
 	.endpoints = rndis_ep_data,
 };

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -1128,11 +1128,11 @@ static struct netusb_function rndis_function = {
 	.send_pkt = rndis_send,
 };
 
-static void rndis_status_cb(struct usb_cfg_data *cfg,
+static void rndis_status_cb(struct usb_class_data *class_data,
 			    enum usb_dc_status_code status,
 			    const uint8_t *param)
 {
-	ARG_UNUSED(cfg);
+	ARG_UNUSED(class_data);
 
 	/* Check the USB status and do needed action if required */
 	switch (status) {
@@ -1179,7 +1179,7 @@ static void netusb_interface_config(struct usb_desc_header *head,
 #endif
 }
 
-USBD_CFG_DATA_DEFINE(primary, netusb) struct usb_cfg_data netusb_config = {
+USBD_CLASS_DATA_DEFINE(primary, netusb) struct usb_class_data netusb_class = {
 	.interface_config = netusb_interface_config,
 	.cb_usb_status = rndis_status_cb,
 	.request_handlers = {

--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -709,7 +709,7 @@ USBD_CFG_DATA_DEFINE(primary, dfu) struct usb_cfg_data dfu_config = {
 	.interface_config = dfu_interface_config,
 	.interface_descriptor = &dfu_cfg.if0,
 	.cb_usb_status = dfu_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = dfu_class_handle_req,
 		.custom_handler = dfu_custom_handle_req,
 	},
@@ -724,7 +724,7 @@ USBD_CFG_DATA_DEFINE(secondary, dfu) struct usb_cfg_data dfu_mode_config = {
 	.interface_config = NULL,
 	.interface_descriptor = &dfu_mode_desc.sec_dfu_cfg.if0,
 	.cb_usb_status = dfu_status_cb,
-	.interface = {
+	.request_handlers = {
 		.class_handler = dfu_class_handle_req,
 		.custom_handler = dfu_custom_handle_req,
 	},

--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -579,8 +579,7 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 		 */
 
 		/* Set the DFU mode descriptors to be used after reset */
-		dfu_config.usb_device_description = (uint8_t *) &dfu_mode_desc;
-		if (usb_set_config(dfu_config.usb_device_description) != 0) {
+		if (usb_set_config((uint8_t *)&dfu_mode_desc) != 0) {
 			LOG_ERR("usb_set_config failed in DFU_DETACH");
 			return -EIO;
 		}
@@ -707,7 +706,6 @@ static void dfu_interface_config(struct usb_desc_header *head,
 
 /* Configuration of the DFU Device send to the USB Driver */
 USBD_CFG_DATA_DEFINE(primary, dfu) struct usb_cfg_data dfu_config = {
-	.usb_device_description = NULL,
 	.interface_config = dfu_interface_config,
 	.interface_descriptor = &dfu_cfg.if0,
 	.cb_usb_status = dfu_status_cb,
@@ -723,7 +721,6 @@ USBD_CFG_DATA_DEFINE(primary, dfu) struct usb_cfg_data dfu_config = {
  * which is an alternative (secondary) device descriptor.
  */
 USBD_CFG_DATA_DEFINE(secondary, dfu) struct usb_cfg_data dfu_mode_config = {
-	.usb_device_description = NULL,
 	.interface_config = NULL,
 	.interface_descriptor = &dfu_mode_desc.sec_dfu_cfg.if0,
 	.cb_usb_status = dfu_status_cb,

--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -302,7 +302,7 @@ USBD_TERM_DESCR_DEFINE(secondary) struct usb_desc_header term_descr = {
 	.bDescriptorType = 0,
 };
 
-static struct usb_cfg_data dfu_config;
+static struct usb_class_data dfu_class;
 
 /* Device data structure */
 struct dfu_data_t {
@@ -620,12 +620,12 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
  *
  * @return  N/A.
  */
-static void dfu_status_cb(struct usb_cfg_data *cfg,
+static void dfu_status_cb(struct usb_class_data *class_data,
 			  enum usb_dc_status_code status,
 			  const uint8_t *param)
 {
 	ARG_UNUSED(param);
-	ARG_UNUSED(cfg);
+	ARG_UNUSED(class_data);
 
 	/* Check the USB status and do needed action if required */
 	switch (status) {
@@ -726,7 +726,7 @@ static void dfu_interface_config(struct usb_desc_header *head,
 }
 
 /* Configuration of the DFU Device send to the USB Driver */
-USBD_CFG_DATA_DEFINE(primary, dfu) struct usb_cfg_data dfu_config = {
+USBD_CLASS_DATA_DEFINE(primary, dfu) struct usb_class_data dfu_class = {
 	.interface_config = dfu_interface_config,
 	.cb_usb_status = dfu_status_cb,
 	.request_handlers = {
@@ -742,7 +742,7 @@ USBD_CFG_DATA_DEFINE(primary, dfu) struct usb_cfg_data dfu_config = {
  * Dummy configuration, this is necessary to configure DFU mode descriptor
  * which is an alternative (secondary) device descriptor.
  */
-USBD_CFG_DATA_DEFINE(secondary, dfu) struct usb_cfg_data dfu_mode_config = {
+USBD_CLASS_DATA_DEFINE(secondary, dfu) struct usb_class_data dfu_mode_class = {
 	.interface_config = NULL,
 	.cb_usb_status = dfu_status_cb,
 	.request_handlers = {

--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -115,6 +115,14 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_dfu_config dfu_cfg = {
 	},
 };
 
+static struct usb_if_container dfu_runtime_ifs[] = {
+	{
+		.iface = &dfu_cfg.if0,
+		.iface_alt = NULL,
+		.curr_alt = 0,
+	}
+};
+
 /* dfu mode device descriptor */
 
 struct dev_dfu_mode_descriptor {
@@ -196,6 +204,19 @@ struct dev_dfu_mode_descriptor dfu_mode_desc = {
 				sys_cpu_to_le16(DFU_VERSION),
 		},
 	},
+};
+
+static struct usb_if_container dfu_mode_ifs[] = {
+	{
+		.iface = &dfu_mode_desc.sec_dfu_cfg.if0,
+		.iface_alt = NULL,
+		.curr_alt = 0
+	},
+	{
+		.iface = &dfu_mode_desc.sec_dfu_cfg.if1,
+		.iface_alt = NULL,
+		.curr_alt = 0
+	}
 };
 
 struct usb_string_desription {
@@ -707,12 +728,13 @@ static void dfu_interface_config(struct usb_desc_header *head,
 /* Configuration of the DFU Device send to the USB Driver */
 USBD_CFG_DATA_DEFINE(primary, dfu) struct usb_cfg_data dfu_config = {
 	.interface_config = dfu_interface_config,
-	.interface_descriptor = &dfu_cfg.if0,
 	.cb_usb_status = dfu_status_cb,
 	.request_handlers = {
 		.class_handler = dfu_class_handle_req,
 		.custom_handler = dfu_custom_handle_req,
 	},
+	.num_if_containers = ARRAY_SIZE(dfu_runtime_ifs),
+	.if_containers = dfu_runtime_ifs,
 	.num_endpoints = 0,
 };
 
@@ -722,12 +744,13 @@ USBD_CFG_DATA_DEFINE(primary, dfu) struct usb_cfg_data dfu_config = {
  */
 USBD_CFG_DATA_DEFINE(secondary, dfu) struct usb_cfg_data dfu_mode_config = {
 	.interface_config = NULL,
-	.interface_descriptor = &dfu_mode_desc.sec_dfu_cfg.if0,
 	.cb_usb_status = dfu_status_cb,
 	.request_handlers = {
 		.class_handler = dfu_class_handle_req,
 		.custom_handler = dfu_custom_handle_req,
 	},
+	.num_if_containers = ARRAY_SIZE(dfu_mode_ifs),
+	.if_containers = dfu_mode_ifs,
 	.num_endpoints = 0,
 };
 

--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -229,7 +229,7 @@ static int usb_validate_ep_cfg_data(struct usb_ep_descriptor * const ep_descr,
 				    uint32_t *requested_ep)
 {
 	for (int i = 0; i < cfg_data->num_endpoints; i++) {
-		struct usb_ep_cfg_data *ep_data = cfg_data->endpoint;
+		struct usb_ep_cfg_data *ep_data = cfg_data->endpoints;
 
 		/*
 		 * Trying to find the right entry in the usb_ep_cfg_data.
@@ -525,7 +525,7 @@ struct usb_dev_data *usb_get_dev_data_by_ep(sys_slist_t *list, uint8_t ep)
 	SYS_SLIST_FOR_EACH_CONTAINER(list, dev_data, node) {
 		struct device *dev = dev_data->dev;
 		const struct usb_cfg_data *cfg = dev->config_info;
-		const struct usb_ep_cfg_data *ep_data = cfg->endpoint;
+		const struct usb_ep_cfg_data *ep_data = cfg->endpoints;
 
 		for (uint8_t i = 0; i < cfg->num_endpoints; i++) {
 			if (ep_data[i].ep_addr == ep) {

--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -285,10 +285,15 @@ static int usb_validate_ep_cfg_data(struct usb_ep_descriptor * const ep_descr,
 static struct usb_cfg_data *usb_get_cfg_data(struct usb_if_descriptor *iface)
 {
 	size_t length = (__usb_data_end - __usb_data_start);
+	struct usb_cfg_data *cfg = NULL;
 
 	for (size_t i = 0; i < length; i++) {
-		if (__usb_data_start[i].interface_descriptor == iface) {
-			return &__usb_data_start[i];
+		cfg = &__usb_data_start[i];
+
+		for (size_t j = 0; j < cfg->num_if_containers; j++) {
+			if (cfg->if_containers[j].iface == iface) {
+				return cfg;
+			}
 		}
 	}
 
@@ -505,11 +510,13 @@ struct usb_dev_data *usb_get_dev_data_by_iface(sys_slist_t *list,
 	SYS_SLIST_FOR_EACH_CONTAINER(list, dev_data, node) {
 		struct device *dev = dev_data->dev;
 		const struct usb_cfg_data *cfg = dev->config_info;
-		const struct usb_if_descriptor *if_desc =
-						cfg->interface_descriptor;
+		const struct usb_if_descriptor *if_desc = NULL;
 
-		if (if_desc->bInterfaceNumber == iface_num) {
-			return dev_data;
+		for (int i = 0; i < cfg->num_if_containers; i++) {
+			if_desc = cfg->if_containers[i].iface;
+			if (if_desc->bInterfaceNumber == iface_num) {
+				return dev_data;
+			}
 		}
 	}
 

--- a/subsys/usb/usb_descriptor.h
+++ b/subsys/usb/usb_descriptor.h
@@ -43,8 +43,8 @@ struct usb_dev_data {
 	sys_snode_t node;
 };
 
-struct usb_dev_data *usb_get_dev_data_by_cfg(sys_slist_t *list,
-					     struct usb_cfg_data *cfg);
+struct usb_dev_data *usb_get_dev_data_by_class_data(sys_slist_t *list,
+					struct usb_class_data *class_data);
 struct usb_dev_data *usb_get_dev_data_by_iface(sys_slist_t *list,
 					       uint8_t iface_num);
 struct usb_dev_data *usb_get_dev_data_by_ep(sys_slist_t *list, uint8_t ep);

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -820,7 +820,10 @@ static bool usb_handle_std_interface_req(struct usb_setup_packet *setup,
 		return false;
 
 	case REQ_GET_INTERFACE:
-		/* there is only one interface, return n-1 (= 0) */
+		/* Interfaces that have alternates are handled by classes code.
+		 * Zero must be returned for all interfaces that do not have
+		 * alternate settings.
+		 */
 		data[0] = 0U;
 		*len = 1;
 		break;
@@ -1200,8 +1203,6 @@ int usb_wakeup_request(void)
  * go through the interfaces one after the other and compare the
  * bInterfaceNumber with the wIndex and and then call the appropriate
  * callback of the USB function.
- * Note, a USB function can have more than one interface and the
- * request does not have to be directed to the first interface (unlikely).
  * These functions can be simplified and moved to usb_handle_request()
  * when legacy initialization throgh the usb_set_config() and
  * usb_enable() is no longer needed.
@@ -1213,24 +1214,28 @@ static int class_handler(struct usb_setup_packet *pSetup,
 	size_t size = (__usb_data_end - __usb_data_start);
 	const struct usb_if_descriptor *if_descr;
 	const struct usb_request_handlers *handlers;
+	const struct usb_cfg_data *cfg = NULL;
+	uint8_t interface_number = (uint8_t)pSetup->wIndex;
 
 	LOG_DBG("bRequest 0x%02x, wIndex 0x%04x",
 		pSetup->bRequest, pSetup->wIndex);
 
 	for (size_t i = 0; i < size; i++) {
-		handlers = &(__usb_data_start[i].request_handlers);
-		if_descr = __usb_data_start[i].interface_descriptor;
-		/*
-		 * Wind forward until it is within the range
-		 * of the current descriptor.
-		 */
-		if ((uint8_t *)if_descr < usb_dev.descriptors) {
-			continue;
-		}
+		cfg = &__usb_data_start[i];
+		handlers = &cfg->request_handlers;
 
-		if (handlers->class_handler &&
-		    if_descr->bInterfaceNumber == (pSetup->wIndex & 0xFF)) {
-			return handlers->class_handler(pSetup, len, data);
+		/* Check if handler exist, if no there is no point
+		 * to search through interface containers
+		 */
+		if (handlers->class_handler) {
+			for (int j = 0; j < cfg->num_if_containers; j++) {
+				if_descr = cfg->if_containers[j].iface;
+				if (if_descr->bInterfaceNumber ==
+					interface_number) {
+					return handlers->class_handler(pSetup,
+								len, data);
+				}
+			}
 		}
 	}
 
@@ -1243,29 +1248,28 @@ static int custom_handler(struct usb_setup_packet *pSetup,
 	size_t size = (__usb_data_end - __usb_data_start);
 	const struct usb_if_descriptor *if_descr;
 	const struct usb_request_handlers *handlers;
+	const struct usb_cfg_data *cfg = NULL;
+	uint8_t interface_number = (uint8_t)pSetup->wIndex;
 
 	LOG_DBG("bRequest 0x%02x, wIndex 0x%04x",
 		pSetup->bRequest, pSetup->wIndex);
 
 	for (size_t i = 0; i < size; i++) {
-		handlers = &(__usb_data_start[i].request_handlers);
-		if_descr = __usb_data_start[i].interface_descriptor;
-		/*
-		 * Wind forward until it is within the range
-		 * of the current descriptor.
-		 */
-		if ((uint8_t *)if_descr < usb_dev.descriptors) {
-			continue;
-		}
+		cfg = &__usb_data_start[i];
+		handlers = &cfg->request_handlers;
 
-		/* An exception for AUDIO_CLASS is temporary and shall not be
-		 * considered as valid solution for other classes.
+		/* Check if handler exist, if no there is no point
+		 * to search through interface containers
 		 */
-		if (handlers->custom_handler &&
-		    (if_descr->bInterfaceNumber == (pSetup->wIndex & 0xFF) ||
-		     if_descr->bInterfaceClass == AUDIO_CLASS)) {
-			return handlers->custom_handler(pSetup, len, data);
-
+		if (handlers->custom_handler) {
+			for (int j = 0; j < cfg->num_if_containers; j++) {
+				if_descr = cfg->if_containers[j].iface;
+				if (if_descr->bInterfaceNumber ==
+					interface_number) {
+					return handlers->custom_handler(pSetup,
+								len, data);
+				}
+			}
 		}
 	}
 

--- a/tests/subsys/usb/desc_sections/src/desc_sections.c
+++ b/tests/subsys/usb/desc_sections/src/desc_sections.c
@@ -92,7 +92,6 @@ struct usb_test_config {
 #define DEFINE_TEST_CFG_DATA(x, _)				\
 	USBD_CFG_DATA_DEFINE(primary, test_##x)			\
 	struct usb_cfg_data test_config_##x = {			\
-	.usb_device_description = NULL,				\
 	.interface_config = interface_config,			\
 	.interface_descriptor = &test_cfg_##x.if0,		\
 	.cb_usb_status = NULL,					\

--- a/tests/subsys/usb/desc_sections/src/desc_sections.c
+++ b/tests/subsys/usb/desc_sections/src/desc_sections.c
@@ -95,13 +95,13 @@ struct usb_test_config {
 	.interface_config = interface_config,			\
 	.interface_descriptor = &test_cfg_##x.if0,		\
 	.cb_usb_status = NULL,					\
-	.interface = {						\
+	.request_handlers = {					\
 		.class_handler = NULL,				\
 		.custom_handler = NULL,				\
 		.vendor_handler = NULL,				\
 	},							\
 	.num_endpoints = ARRAY_SIZE(ep_cfg_##x),		\
-	.endpoint = ep_cfg_##x,					\
+	.endpoints = ep_cfg_##x,				\
 	};
 
 #define NUM_INSTANCES 2
@@ -138,7 +138,7 @@ static bool find_cfg_data_ep(const struct usb_ep_descriptor * const ep_descr,
 			     uint8_t ep_count)
 {
 	for (int i = 0; i < cfg_data->num_endpoints; i++) {
-		if (cfg_data->endpoint[i].ep_addr ==
+		if (cfg_data->endpoints[i].ep_addr ==
 				ep_descr->bEndpointAddress) {
 			LOG_DBG("found ep[%d] %x", i,
 				ep_descr->bEndpointAddress);

--- a/tests/subsys/usb/device/src/main.c
+++ b/tests/subsys/usb/device/src/main.c
@@ -78,13 +78,13 @@ static struct usb_ep_cfg_data device_ep[] = {
 USBD_CFG_DATA_DEFINE(primary, device) struct usb_cfg_data device_config = {
 	.interface_descriptor = &dev_desc.if0,
 	.cb_usb_status = status_cb,
-	.interface = {
+	.request_handlers = {
 		.vendor_handler = NULL,
 		.class_handler = NULL,
 		.custom_handler = NULL,
 	},
 	.num_endpoints = ARRAY_SIZE(device_ep),
-	.endpoint = device_ep,
+	.endpoints = device_ep,
 };
 
 static void test_usb_disable(void)

--- a/tests/subsys/usb/device/src/main.c
+++ b/tests/subsys/usb/device/src/main.c
@@ -76,7 +76,6 @@ static struct usb_ep_cfg_data device_ep[] = {
 };
 
 USBD_CFG_DATA_DEFINE(primary, device) struct usb_cfg_data device_config = {
-	.usb_device_description = NULL,
 	.interface_descriptor = &dev_desc.if0,
 	.cb_usb_status = status_cb,
 	.interface = {

--- a/tests/subsys/usb/device/src/main.c
+++ b/tests/subsys/usb/device/src/main.c
@@ -53,11 +53,11 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_device_desc dev_desc = {
 				       BULK_EP_MPS, 0),
 };
 
-static void status_cb(struct usb_cfg_data *cfg,
+static void status_cb(struct usb_class_data *class_data,
 		      enum usb_dc_status_code status,
 		      const uint8_t *param)
 {
-	ARG_UNUSED(cfg);
+	ARG_UNUSED(class_data);
 	ARG_UNUSED(status);
 	ARG_UNUSED(param);
 }
@@ -83,7 +83,7 @@ static struct usb_if_container device_if[] = {
 	}
 };
 
-USBD_CFG_DATA_DEFINE(primary, device) struct usb_cfg_data device_config = {
+USBD_CLASS_DATA_DEFINE(primary, device) struct usb_class_data device_class = {
 	.cb_usb_status = status_cb,
 	.request_handlers = {
 		.vendor_handler = NULL,

--- a/tests/subsys/usb/device/src/main.c
+++ b/tests/subsys/usb/device/src/main.c
@@ -75,14 +75,23 @@ static struct usb_ep_cfg_data device_ep[] = {
 	},
 };
 
+static struct usb_if_container device_if[] = {
+	{
+		.iface = &dev_desc.if0,
+		.iface_alt = NULL,
+		.curr_alt = 0,
+	}
+};
+
 USBD_CFG_DATA_DEFINE(primary, device) struct usb_cfg_data device_config = {
-	.interface_descriptor = &dev_desc.if0,
 	.cb_usb_status = status_cb,
 	.request_handlers = {
 		.vendor_handler = NULL,
 		.class_handler = NULL,
 		.custom_handler = NULL,
 	},
+	.num_if_containers = ARRAY_SIZE(device_if),
+	.if_containers = device_if,
 	.num_endpoints = ARRAY_SIZE(device_ep),
 	.endpoints = device_ep,
 };


### PR DESCRIPTION
usb: Rework the USB core internals.

Rework the way how the interfaces are handled by the USB core stack.
Until now USB stack was aware of only the first interface associated
with each class. This led to a problem when not first interface was
addressed by the request.

This patch allow to filter out the request at core level.
**This is not done in this PR but inits foreground**

The usb_cfg_data struct is legacy of initial implementation
of USB device stack. Initially the USB device stack was
implemented to support single class devices with
no composite support. This structure was intended to be used to
configure the device in run time by calling usb_set_config().

Because of how things grow the structure was used to represent
the classes instead of devices.

This patch removes device configuration descriptor pointer.
Adds pointer to table of USB interface containers associated with
he function it represents. Each container consist of pointer to
interface descriptor, its alternate setting (if exists) and currently
selected alternate setting. This help USB core stack to properly address
SET/GET interface requests.

This patch renames some of the `usb_cfg_data` fields to better
represent its meaning. The `usb_cfg_data` struct is renamed itself
as this name is no longer valid (look up).

**This patch is first step to rework the USB core stack and is not meant
to be considered as final form of USB core.**

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>
