### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: controller: llcp: create unique log names

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -30,7 +30,7 @@
 #include "ull_llcp_internal.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
-#define LOG_MODULE_NAME bt_ctlr_ull_llcp
+#define LOG_MODULE_NAME bt_ctlr_ull_llcp_common
 #include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
@@ -29,7 +29,7 @@
 #include "ull_llcp_internal.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
-#define LOG_MODULE_NAME bt_ctlr_ull_llcp
+#define LOG_MODULE_NAME bt_ctlr_ull_llcp_enc
 #include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -29,7 +29,7 @@
 #include "ull_llcp_internal.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
-#define LOG_MODULE_NAME bt_ctlr_ull_llcp
+#define LOG_MODULE_NAME bt_ctlr_ull_llcp_local
 #include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
@@ -31,7 +31,7 @@
 #include "ll_feat.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
-#define LOG_MODULE_NAME bt_ctlr_ull_llcp
+#define LOG_MODULE_NAME bt_ctlr_ull_llcp_pdu
 #include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -29,7 +29,7 @@
 #include "ull_llcp_internal.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
-#define LOG_MODULE_NAME bt_ctlr_ull_llcp
+#define LOG_MODULE_NAME bt_ctlr_ull_llcp_phy
 #include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -29,7 +29,7 @@
 #include "ull_llcp_internal.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
-#define LOG_MODULE_NAME bt_ctlr_ull_llcp
+#define LOG_MODULE_NAME bt_ctlr_ull_llcp_remote
 #include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"


### PR DESCRIPTION
The module names for logging must be unique for each module,
otherwise the linker will complain about duplicate symbols

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>