### PR TITLE
drivers: flash: stm32wb return in case of control register locked

### DIFF
--- a/drivers/flash/flash_stm32wbx.c
+++ b/drivers/flash/flash_stm32wbx.c
@@ -48,7 +48,7 @@ static int write_dword(struct device *dev, off_t offset, uint64_t val)
 
 	/* if the control register is locked, do not fail silently */
 	if (regs->CR & FLASH_CR_LOCK) {
-		rc = -EIO;
+		return -EIO;
 	}
 
 	/* Check if this double word is erased */
@@ -78,7 +78,7 @@ static int write_dword(struct device *dev, off_t offset, uint64_t val)
 	/* Clear the PG bit */
 	regs->CR &= (~FLASH_CR_PG);
 
-	return 0;
+	return rc;
 }
 
 static int erase_page(struct device *dev, uint32_t page)


### PR DESCRIPTION
In case of control register lock, driver should return the error
immediately. Otherwise, error is later overwritten by
'rc = flash_stm32_wait_flash_idle(dev);'

Signed-off-by: Alexandre Bourdiol <alexandre.bourdiol@st.com>