### PR TITLE
build: reports: add pahole target

### DIFF
--- a/cmake/reports/CMakeLists.txt
+++ b/cmake/reports/CMakeLists.txt
@@ -34,3 +34,21 @@ if(NOT ${PUNCOVER} STREQUAL PUNCOVER-NOTFOUND)
     USES_TERMINAL
     )
 endif()
+
+find_program(PAHOLE pahole)
+
+if(NOT ${PAHOLE} STREQUAL PAHOLE-NOTFOUND)
+  add_custom_target(
+    pahole
+    ${PAHOLE}
+    --anon_include
+    --nested_anon_include
+    --show_decl_info
+    $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
+    ${ZEPHYR_BINARY_DIR}/${KERNEL_ELF_NAME}
+    DEPENDS ${logical_target_for_zephyr_elf}
+            $<TARGET_PROPERTY:zephyr_property_target,${report}_DEPENDENCIES>
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    USES_TERMINAL
+    )
+endif()


### PR DESCRIPTION
Poke-a-hole (pahole) is an object-file analysis tool to find the size of the data structures, and the holes caused due to aligning the data elements to the word-size of the CPU by the compiler.

http://git.kernel.org/cgit/devel/pahole/pahole.git

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>