### PR TITLE
editorconfig: indent Kconfig files with tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -69,3 +69,7 @@ indent_size = 8
 # Git commit messages
 [COMMIT_EDITMSG]
 max_line_length = 72
+
+# Kconfig
+[Kconfig*]
+indent_style=tab


### PR DESCRIPTION
Configure editors for indenting Kconfig* files with tabs.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>