### PR TITLE
usb: cdc_acm: re-trigger transfer for OUT endpoint on resume 

### DIFF
--- a/subsys/usb/usb_transfer.c
+++ b/subsys/usb/usb_transfer.c
@@ -286,7 +286,7 @@ void usb_cancel_transfers(void)
 		if (trans->status == -EBUSY) {
 			trans->status = -ECANCELED;
 			k_work_submit(&trans->work);
-			LOG_DBG("Cancel transfer");
+			LOG_DBG("Cancel transfer for ep: 0x%02x", trans->ep);
 		}
 
 		irq_unlock(key);


### PR DESCRIPTION
 usb: cdc_acm: re-trigger transfer for OUT endpoint on resume

Transfers are cancelled on suspend event, OUT transfers
needs to be re-trigger on resume.
Rework event handling to filter out spurious resume
events and re-trigger transfer if previous event was
a suspend event.

_Fixes #26725 for CDC ACM class, other classes/functions have to be reviewed and fixed (if necessary) in subsequent PRs._