### PR TITLE
devicetree: use edt.pickle more

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -204,7 +204,7 @@ if(SUPPORTS_DTS)
   endif(DTC)
 
   #
-  # Run gen_defines.py to create a header file and zephyr.dts.
+  # Run gen_defines.py to create a header file, zephyr.dts, and edt.pickle.
   #
 
   set(CMD_EXTRACT ${PYTHON_EXECUTABLE} ${GEN_DEFINES_SCRIPT}
@@ -222,9 +222,7 @@ if(SUPPORTS_DTS)
   #
 
   set(CMD_LEGACY_EXTRACT ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/dts/gen_legacy_defines.py
-  --dts ${BOARD}.dts.pre.tmp
-  --dtc-flags '${EXTRA_DTC_FLAGS}'
-  --bindings-dirs ${DTS_ROOT_BINDINGS}
+  --edt-pickle ${EDT_PICKLE}
   --header-out ${DEVICETREE_UNFIXED_LEGACY_H}
   )
 

--- a/scripts/dts/gen_legacy_defines.py
+++ b/scripts/dts/gen_legacy_defines.py
@@ -14,9 +14,7 @@
 import argparse
 import os
 import pathlib
-import sys
-
-import edtlib
+import pickle
 
 # Set this to True to generated deprecated macro warnings. Since this
 # entire file is deprecated and must be explicitly enabled with
@@ -31,15 +29,8 @@ def main():
 
     args = parse_args()
 
-    try:
-        edt = edtlib.EDT(args.dts, args.bindings_dirs,
-                         # Suppress this warning if it's suppressed in dtc
-                         warn_reg_unit_address_mismatch=
-                             "-Wno-simple_bus_reg" not in args.dtc_flags,
-                         default_prop_types=False,
-                         support_fixed_partitions_on_any_bus = False)
-    except edtlib.EDTError as e:
-        sys.exit(f"devicetree error: {e}")
+    with open(args.edt_pickle, 'rb') as f:
+        edt = pickle.load(f)
 
     header_file = open(args.header_out, "w", encoding="utf-8")
     flash_area_num = 0
@@ -83,13 +74,8 @@ def parse_args():
     # Returns parsed command-line arguments
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--dts", required=True, help="DTS file")
-    parser.add_argument("--dtc-flags",
-                        help="'dtc' devicetree compiler flags, some of which "
-                             "might be respected here")
-    parser.add_argument("--bindings-dirs", nargs='+', required=True,
-                        help="directory with bindings in YAML format, "
-                        "we allow multiple")
+    parser.add_argument("--edt-pickle", required=True,
+                        help="pickle file containing EDT object")
     parser.add_argument("--header-out", required=True,
                         help="path to write header to")
 

--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -29,6 +29,7 @@ import logging
 from pathlib import Path
 from distutils.spawn import find_executable
 from colorama import Fore
+import pickle
 import platform
 import yaml
 try:
@@ -58,8 +59,8 @@ ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 if not ZEPHYR_BASE:
     sys.exit("$ZEPHYR_BASE environment variable undefined")
 
+# This is needed to load edt.pickle files.
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts", "dts"))
-import edtlib
 
 hw_map_local = threading.Lock()
 report_lock = threading.Lock()
@@ -1875,12 +1876,12 @@ class FilterBuilder(CMake):
         filter_data.update(self.defconfig)
         filter_data.update(self.cmake_cache)
 
-        dts_path = os.path.join(self.build_dir, "zephyr", self.platform.name + ".dts.pre.tmp")
+        edt_pickle = os.path.join(self.build_dir, "zephyr", "edt.pickle")
         if self.testcase and self.testcase.tc_filter:
             try:
-                if os.path.exists(dts_path):
-                    edt = edtlib.EDT(dts_path, [os.path.join(ZEPHYR_BASE, "dts", "bindings")],
-                            warn_reg_unit_address_mismatch=False)
+                if os.path.exists(edt_pickle):
+                    with open(edt_pickle, 'rb') as f:
+                        edt = pickle.load(f)
                 else:
                     edt = None
                 res = expr_parser.parse(self.testcase.tc_filter, filter_data, edt)


### PR DESCRIPTION
Fixes: #26746

Consolidate creation of edtlib.EDT objects from a build directory's
devicetree into one place by loading it from build/zephyr/edt.pickle
everywhere. A previous commit creates edt.pickle from gen_defines.py.

In addition to probably speeding things up slightly by not reparsing
the devicetree, the main benefit of this approach is creating a single
point of truth for the bindings directories and warnings
configuration, meaning we don't have to worry about them getting out
of sync while being passed around between devicetree creation and
usage time.
