### PR TITLE
requirements-build-test.txt: Updating mock module version

### DIFF
--- a/scripts/requirements-build-test.txt
+++ b/scripts/requirements-build-test.txt
@@ -20,4 +20,4 @@ coverage
 pytest
 
 # used for mocking functions in pytest
-mock
+mock>=4.0.1


### PR DESCRIPTION
Updating mock module version to >=4.0.1 as sanitycheck testsuite
might fail in some systems due to an old version.

Signed-off-by: Aastha Grover <aastha.grover@intel.com>