### PR TITLE
drivers: flash: nrf: Fix flash operation timeout

### DIFF
--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -379,7 +379,7 @@ static void time_slot_delay(uint32_t ticks_at_expire, uint32_t ticks_delay,
 	 */
 	err = ticker_start(instance_index, /* Radio instance ticker */
 			   0, /* user_id */
-			   0, /* ticker_id */
+			   (ticker_id + 1), /* ticker_id */
 			   ticks_at_expire, /* current tick */
 			   ticks_delay, /* one-shot delayed timeout */
 			   0, /* periodic timeout  */

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -109,7 +109,7 @@
 #endif
 
 #if defined(CONFIG_SOC_FLASH_NRF_RADIO_SYNC)
-#define FLASH_TICKER_NODES        1 /* No. of tickers reserved for flashing */
+#define FLASH_TICKER_NODES        2 /* No. of tickers reserved for flashing */
 #define FLASH_TICKER_USER_APP_OPS 1 /* No. of additional ticker operations */
 #else
 #define FLASH_TICKER_NODES        0


### PR DESCRIPTION
Fix flash operation timeout due to incorrect use of
secondary ticker to abort any radio in use. Ticker id 0
is reserved for split controller's pipeline preempt timeout.
Using the same ticker id caused the secondary ticker to
not be started if controller is using the same ticker id
for pipeline preempt timeout.

Fixes #26333.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>