### PR TITLE
net: tcp2: Fix dereference after null check in tcp_in()

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1203,7 +1203,7 @@ next_state:
 			}
 		}
 
-		if (len) {
+		if (th && len) {
 			if (th_seq(th) == conn->ack) {
 				if (tcp_data_get(conn, pkt) < 0) {
 					break;


### PR DESCRIPTION
Fix dereference after null check in tcp_in().

Coverity CID :210051

Fixes #25783

Signed-off-by: Oleg Zhurakivskyy <oleg.zhurakivskyy@intel.com>