### PR TITLE
drivers: i2c: mcux: return to idle on failed transfers

### DIFF
--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -140,6 +140,7 @@ static int i2c_mcux_transfer(struct device *dev, struct i2c_msg *msgs,
 		 * e.g., if the bus was busy
 		 */
 		if (status != kStatus_Success) {
+			I2C_MasterTransferAbort(base, &data->handle);
 			return -EIO;
 		}
 
@@ -150,6 +151,7 @@ static int i2c_mcux_transfer(struct device *dev, struct i2c_msg *msgs,
 		 * successfully. e.g., nak, timeout, lost arbitration
 		 */
 		if (data->callback_status != kStatus_Success) {
+			I2C_MasterTransferAbort(base, &data->handle);
 			return -EIO;
 		}
 

--- a/drivers/i2c/i2c_mcux_flexcomm.c
+++ b/drivers/i2c/i2c_mcux_flexcomm.c
@@ -134,6 +134,7 @@ static int mcux_flexcomm_transfer(struct device *dev, struct i2c_msg *msgs,
 		 * e.g., if the bus was busy
 		 */
 		if (status != kStatus_Success) {
+			I2C_MasterTransferAbort(base, &data->handle);
 			return -EIO;
 		}
 
@@ -144,6 +145,7 @@ static int mcux_flexcomm_transfer(struct device *dev, struct i2c_msg *msgs,
 		 * successfully. e.g., nak, timeout, lost arbitration
 		 */
 		if (data->callback_status != kStatus_Success) {
+			I2C_MasterTransferAbort(base, &data->handle);
 			return -EIO;
 		}
 

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -146,6 +146,7 @@ static int mcux_lpi2c_transfer(struct device *dev, struct i2c_msg *msgs,
 		 * e.g., if the bus was busy
 		 */
 		if (status != kStatus_Success) {
+			LPI2C_MasterTransferAbort(base, &data->handle);
 			return -EIO;
 		}
 
@@ -156,6 +157,7 @@ static int mcux_lpi2c_transfer(struct device *dev, struct i2c_msg *msgs,
 		 * successfully. e.g., nak, timeout, lost arbitration
 		 */
 		if (data->callback_status != kStatus_Success) {
+			LPI2C_MasterTransferAbort(base, &data->handle);
 			return -EIO;
 		}
 


### PR DESCRIPTION
Abort I2C transfers through the MCUX HAL if a transfer fails to avoid deadlock in the driver/HAL.

Fixes #25098

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>