### PR TITLE
drivers: wifi: esp: Fix issue with incorrect tx timeout

### DIFF
--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -237,8 +237,8 @@ static int _sock_send(struct esp_data *dev, struct esp_socket *sock)
 	k_sem_reset(&dev->sem_tx_ready);
 
 	ret = modem_cmd_send_nolock(&dev->mctx.iface, &dev->mctx.cmd_handler,
-			     NULL, 0, cmd_buf, &dev->sem_response,
-			     ESP_CMD_TIMEOUT);
+				    cmds, ARRAY_SIZE(cmds), cmd_buf,
+				    &dev->sem_response, ESP_CMD_TIMEOUT);
 	if (ret < 0) {
 		LOG_DBG("Failed to send command");
 		goto out;
@@ -338,6 +338,10 @@ static int esp_sendto(struct net_pkt *pkt,
 	dev = esp_socket_to_dev(sock);
 
 	LOG_DBG("link %d, timeout %d", sock->link_id, timeout);
+
+	if (!esp_flag_is_set(dev, EDF_STA_CONNECTED)) {
+		return -ENETUNREACH;
+	}
 
 	if (sock->tx_pkt) {
 		return -EBUSY;


### PR DESCRIPTION
It can happen that the command '>' is received between
modem_cmd_send_nolock and modem_cmd_handler_update_cmds. Since the
command handler for '>' is not set, sem_tx_ready will not be given
and _sock_send will timeout. Make sure the command handlers are set
before the send by also passing them to modem_cmd_send_nolock.