### PR TITLE
STM32H7: manage Dual core boot whatever option bytes configuration

### DIFF
--- a/boards/arm/nucleo_h745zi_q/Kconfig.defconfig
+++ b/boards/arm/nucleo_h745zi_q/Kconfig.defconfig
@@ -33,16 +33,6 @@ config CLOCK_STM32_D3PPRE
 config STM32H7_DUAL_CORE
 	default y
 
-# Dual core boot configuration.
-# Boot method is selected in common file to avoid
-# desync issues.
-choice STM32H7_DUAL_CORE_BOOT
-	# Use out of the box config by default
-	# default STM32H7_BOOT_CM4_CM7
-	default STM32H7_BOOT_CM7_CM4GATED
-	depends on STM32H7_DUAL_CORE
-endchoice
-
 if NETWORKING
 
 config NET_L2_ETHERNET

--- a/boards/arm/stm32h747i_disco/Kconfig.defconfig
+++ b/boards/arm/stm32h747i_disco/Kconfig.defconfig
@@ -38,13 +38,4 @@ config CLOCK_STM32_D3PPRE
 config STM32H7_DUAL_CORE
 	default y
 
-# Dual core boot configuration. Boot method is selected in common file to avoid
-# desync issues.
-choice STM32H7_DUAL_CORE_BOOT
-	# Use out of the box config by default
-	# default STM32H7_BOOT_CM4_CM7
-	default STM32H7_BOOT_CM7_CM4GATED
-	depends on STM32H7_DUAL_CORE
-endchoice
-
 endif # BOARD_STM32H747I_DISCO_M7

--- a/boards/arm/stm32h747i_disco/doc/index.rst
+++ b/boards/arm/stm32h747i_disco/doc/index.rst
@@ -157,7 +157,11 @@ By default:
 
 Also, default out of the box board configuration enables CM7 and CM4 boot when
 board is powered (Option bytes BCM7 and BCM4 are checked).
-In that configuration, Kconfig boot option ``STM32H7_BOOT_CM4_CM7`` should be selected.
+It is possible to change Option Bytes so that CM7 boots first in stand alone,
+and CM7 will wakeup CM4 after clock initialization.
+Drivers are able to take into account both Option Bytes configurations
+automatically.
+
 Zephyr flash configuration has been set to meet these default settings.
 
 Flashing an application to STM32H747I M7 Core

--- a/soc/arm/st_stm32/stm32h7/Kconfig.series
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.series
@@ -21,26 +21,3 @@ config SOC_SERIES_STM32H7X
 config STM32H7_DUAL_CORE
 	bool "Enable Dual Core"
 	depends on SOC_SERIES_STM32H7X
-
-choice STM32H7_DUAL_CORE_BOOT
-	prompt "STM32H7x Boot type selection"
-	depends on STM32H7_DUAL_CORE
-
-config STM32H7_BOOT_CM4_CM7
-	bool "Boot both CM4 and CM7"
-	help
-	  Cortex-M7 and Cortex-M4 running from the flash (each from a bank)
-	  System configuration performed by the Cortex-M7
-	  Cortex-M4 goes to STOP after boot, then woken-up by Cortex-M7 using
-	  a HW semaphore
-
-config STM32H7_BOOT_CM7_CM4GATED
-	bool "Boot CM7. CM4 boot gated"
-	help
-	  Cortex-M4 boot is gated using Flash option bytes
-	  Cortex-M7 and Cortex-M4 running from the flash (each from a bank)
-	  Cortex-M7 boots , performs the System configuration then enable the
-	  Cortex-M4 boot using RCC.
-	  This mode requires option byte setting update (BCM4 unchecked)
-
-endchoice

--- a/soc/arm/st_stm32/stm32h7/soc_m4.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m4.c
@@ -17,7 +17,6 @@
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 #include "stm32_hsem.h"
 
-#if defined(CONFIG_STM32H7_BOOT_CM4_CM7)
 void stm32h7_m4_boot_stop(void)
 {
 	/*
@@ -50,7 +49,6 @@ void stm32h7_m4_boot_stop(void)
 	  */
 	LL_LPM_EnableSleep();
 }
-#endif /* CONFIG_STM32H7_BOOT_CM4_CM7 */
 
 /**
  * @brief Perform basic hardware initialization at boot.
@@ -76,16 +74,19 @@ static int stm32h7_m4_init(struct device *arg)
 	/*HW semaphore Clock enable*/
 	LL_AHB4_GRP1_EnableClock(LL_AHB4_GRP1_PERIPH_HSEM);
 
-#if defined(CONFIG_STM32H7_BOOT_CM4_CM7)
-	/* Activate HSEM notification for Cortex-M4*/
-	LL_HSEM_EnableIT_C2IER(HSEM, CFG_HW_ENTRY_STOP_MODE_MASK_SEMID);
+	/* In case CM4 has not been forced boot by CM7,
+	 * CM4 needs to be stopped until CM7 has setup clock configuration
+	 */
+	if (!LL_RCC_IsCM4BootForced()) {
+		/* Activate HSEM notification for Cortex-M4 */
+		LL_HSEM_EnableIT_C2IER(HSEM, CFG_HW_ENTRY_STOP_MODE_MASK_SEMID);
 
-	/* Boot and enter stop mode */
-	stm32h7_m4_boot_stop();
+		/* Boot and enter stop mode */
+		stm32h7_m4_boot_stop();
 
-	/* Clear HSEM flag */
-	LL_HSEM_ClearFlag_C2ICR(HSEM, CFG_HW_ENTRY_STOP_MODE_MASK_SEMID);
-#endif /* CONFIG_STM32H7_BOOT_CM4_CM7 */
+		/* Clear HSEM flag */
+		LL_HSEM_ClearFlag_C2ICR(HSEM, CFG_HW_ENTRY_STOP_MODE_MASK_SEMID);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
STM32H7: manage Dual core boot whatever option bytes configuration

Manage Dual core boot automatically whatever Option Bytes configuration.
No more need of KConfig STM32H7_DUAL_CORE_BOOT to match Option Bytes.

Signed-off-by: Alexandre Bourdiol <alexandre.bourdiol@st.com>