### PR TITLE
Bluetooth: controller: Fix missing skip value calculation

### DIFF
--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -1916,6 +1916,14 @@ static inline uint32_t ticker_job_insert(struct ticker_instance *instance,
 						   ticker_remainder_inc(ticker);
 			ticker->lazy_current++;
 
+			/* No. of times ticker has skipped its interval */
+			if (ticker->lazy_current > ticker->lazy_periodic) {
+				skip = ticker->lazy_current -
+				       ticker->lazy_periodic;
+			} else {
+				skip = 0U;
+			}
+
 			/* Remove any accumulated drift (possibly added due to
 			 * ticker job execution latencies).
 			 */


### PR DESCRIPTION
Fix missing recalculation of skip value of the ticker being
inserted into ordered list, when it collides and is being
attempted to be inserted at next periodic interval.
This fix is for ticker compatibility mode which is used as
default for nRF51 series.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>