### PR TITLE
USB Audio: support sampling frequency select

### DIFF
--- a/dts/bindings/usb/usb-audio-hp.yaml
+++ b/dts/bindings/usb/usb-audio-hp.yaml
@@ -10,6 +10,10 @@ compatible: "usb-audio-hp"
 include: usb-audio.yaml
 
 properties:
+  frequency:
+    type: array
+    default: [48000]
+    required: false
   resolution:
     type: int
     default: 16

--- a/dts/bindings/usb/usb-audio-hs.yaml
+++ b/dts/bindings/usb/usb-audio-hs.yaml
@@ -19,6 +19,10 @@ properties:
      - 16
      - 24
      - 32
+  mic-frequency:
+    type: array
+    default: [48000]
+    required: false
   mic-sync-type:
     required: false
     default: "Synchronous"
@@ -40,6 +44,11 @@ properties:
      - 16
      - 24
      - 32
+  hp-frequency:
+    type: array
+    default: [48000]
+    required: false
+
 # microphone channel configuration options
   mic-channel-l:
     type: boolean

--- a/dts/bindings/usb/usb-audio-mic.yaml
+++ b/dts/bindings/usb/usb-audio-mic.yaml
@@ -19,6 +19,10 @@ properties:
      - 16
      - 24
      - 32
+  frequency:
+    type: array
+    default: [48000]
+    required: false
   sync-type:
     required: false
     default: "Synchronous"

--- a/include/usb/class/usb_audio.h
+++ b/include/usb/class/usb_audio.h
@@ -96,6 +96,15 @@ enum usb_audio_fucs {
 	USB_AUDIO_FU_LOUDNESS_CONTROL		= 0x0A
 };
 
+/** Endpoint Control Selectors
+ * Refer to Table A-19 from audio10.pdf
+ */
+enum usb_audio_epcs {
+	USB_AUDIO_EP_CONTROL_UNDEFINED		= 0x00,
+	USB_AUDIO_EP_SAMPLING_FREQ_CONTROL	= 0x01,
+	USB_AUDIO_EP_PITCH_CONTROL		= 0x02,
+};
+
 /** USB Terminal Types
  * Refer to Table 2-1 - Table 2-4 from termt10.pdf
  */
@@ -195,12 +204,25 @@ typedef void (*usb_audio_data_completion_cb_t)(const struct device *dev,
  *
  * @warning Host may not use all of configured features.
  *
+ * @param dev The device for which the callback was called.
  * @param evt Pointer to an event to be parsed by the App.
- *	      Pointer sturct is temporary and is valid only during the
+ *	      Pointer struct is temporary and is valid only during the
  *	      execution of this callback.
  */
 typedef void (*usb_audio_feature_updated_cb_t)(struct device *dev,
 				const struct usb_audio_fu_evt *evt);
+
+/**
+ * @brief Callback type used to inform the app that Host has changed
+ *	  the sampling frequency configured for the device.
+ *	  Applicable for all devices.
+ *
+ * @param dev  The device for which the callback was called.
+ * @param freq The frequency set by the Host.
+ */
+typedef void (*usb_audio_sampling_freq_cb_t)(struct device *dev,
+					     enum usb_audio_direction dir,
+					     const uint32_t freq);
 
 /**
  * @brief Audio callbacks used to interact with audio devices by user App.
@@ -230,6 +252,9 @@ struct usb_audio_ops {
 
 	/* Callback called when features were modified by the Host */
 	usb_audio_feature_updated_cb_t feature_update_cb;
+
+	/* Callback called when sampling frequency was modified by the Host */
+	usb_audio_sampling_freq_cb_t sampling_freq_update_cb;
 };
 
 /** @brief Get the frame size that is accepted by the Host.

--- a/samples/subsys/usb/audio/headset/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/subsys/usb/audio/headset/boards/nrf52840dk_nrf52840.overlay
@@ -8,10 +8,12 @@
 	hs_0 {
 		label = "HEADSET";
 		compatible = "usb-audio-hs";
+		mic-frequency = < 44100 48000 >;
 		mic-feature-mute;
 		mic-channel-l;
 		mic-channel-r;
 
+		hp-frequency = < 44100 48000 >;
 		hp-feature-mute;
 		hp-channel-l;
 		hp-channel-r;

--- a/samples/subsys/usb/audio/headset/src/main.c
+++ b/samples/subsys/usb/audio/headset/src/main.c
@@ -52,9 +52,18 @@ static void feature_update(struct device *dev,
 	}
 }
 
+static void sampling_freq_update(struct device *dev,
+				 enum usb_audio_direction dir,
+				 const uint32_t freq)
+{
+	LOG_INF("Changed sampling frequency: %u direction %s", freq,
+		(dir == USB_AUDIO_IN) ? log_strdup("in") : log_strdup("out"));
+}
+
 static const struct usb_audio_ops ops = {
 	.data_received_cb = data_received,
 	.feature_update_cb = feature_update,
+	.sampling_freq_update_cb = sampling_freq_update,
 };
 
 void main(void)

--- a/subsys/usb/class/audio/audio.c
+++ b/subsys/usb/class/audio/audio.c
@@ -717,7 +717,8 @@ static int audio_custom_handler(struct usb_setup_packet *pSetup, int32_t *len,
 		 * must be the second interface associated with the device.
 		 */
 		if_desc = (struct usb_if_descriptor *)((uint8_t *)if_desc +
-						USB_ACTIVE_IF_DESC_SIZE);
+						USB_ACTIVE_IF_DESC_SIZE +
+						USB_PASSIVE_IF_DESC_SIZE);
 		ep_desc = (struct usb_ep_descriptor *)((uint8_t *)if_desc +
 						USB_PASSIVE_IF_DESC_SIZE +
 						USB_AC_CS_IF_DESC_SIZE +

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -1228,8 +1228,12 @@ static int class_handler(struct usb_setup_packet *pSetup,
 			continue;
 		}
 
+		/* An exception for AUDIO_CLASS is temporary and shall not be
+		 * considered as valid solution for other classes.
+		 */
 		if (iface->class_handler &&
-		    if_descr->bInterfaceNumber == (pSetup->wIndex & 0xFF)) {
+		    (if_descr->bInterfaceNumber == ((pSetup->wIndex) & 0xFF) ||
+		     if_descr->bInterfaceClass == AUDIO_CLASS)) {
 			return iface->class_handler(pSetup, len, data);
 		}
 	}


### PR DESCRIPTION
These commit adds support for the host to select different sampling frequencies.
There is a new callback for changed sampling frequencies, I kept is separate from features because it's not a feature from the perspective of the USB Audio 1.0 standard. But from an API perspective it could make sense.

Writing the frequencies to the format descriptor was surprisingly hard and in fix_format_descriptors() I had to loop over all devices to find the mapping between the interface descriptor and device data.