### PR TITLE
boards: intel_s1000_crb: add zephyr,flash-controller to DTS

### DIFF
--- a/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
+++ b/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
@@ -17,6 +17,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,flash-controller = &flash0;
 	};
 };
 


### PR DESCRIPTION
The board has a SPI NOR flash enabled by default but was missing
the "zephyr,flash-controller" in DTS. This prevents the flash
shell sample to compile. So add the DTS entry.

Fixes #26764

Signed-off-by: Daniel Leung <daniel.leung@intel.com>