### PR TITLE
API Change: DMA - callback improvement

### DIFF
--- a/doc/releases/release-notes-2.4.rst
+++ b/doc/releases/release-notes-2.4.rst
@@ -53,6 +53,12 @@ API Changes
   :c:func:`uart_irq_callback_user_data_set` and :c:func:`uart_irq_callback_set`
   user code have been modified accordingly.
 
+* ``<drivers/dma.h>`` has seen its callback normalized. It had its signature
+  changed to add a struct device pointer as first parameter. Such callback
+  signature has been generalized throuh the addition of dma_callback_t.
+  'callback_arg' argument has been renamed to 'user_data. All user code have
+  been modified accordingly.
+
 Deprecated in this release
 ==========================
 

--- a/drivers/audio/intel_dmic.c
+++ b/drivers/audio/intel_dmic.c
@@ -949,7 +949,8 @@ static int configure_registers(struct device *dev,
 	return 0;
 }
 
-static void dmic_dma_callback(void *arg, uint32_t chan, int err_code)
+static void dmic_dma_callback(struct device *dev, void *arg,
+			      uint32_t chan, int err_code)
 {
 	void *buffer;
 	size_t size;

--- a/drivers/dma/dma_dw.c
+++ b/drivers/dma/dma_dw.c
@@ -99,7 +99,7 @@ static void dw_dma_isr(void *arg)
 			 * all the blocks are transferred.
 			 */
 			chan_data->dma_blkcallback(dev,
-						   chan_data->blkcallback_arg,
+						   chan_data->blkuser_data,
 						   channel, 0);
 		}
 	}
@@ -110,7 +110,7 @@ static void dw_dma_isr(void *arg)
 		chan_data = &dev_data->chan[channel];
 		if (chan_data->dma_tfrcallback) {
 			chan_data->dma_tfrcallback(dev,
-						   chan_data->tfrcallback_arg,
+						   chan_data->tfruser_data,
 						   channel, 0);
 		}
 	}
@@ -216,11 +216,11 @@ static int dw_dma_config(struct device *dev, uint32_t channel,
 	 */
 	if (cfg->complete_callback_en) {
 		chan_data->dma_blkcallback = cfg->dma_callback;
-		chan_data->blkcallback_arg = cfg->callback_arg;
+		chan_data->blkuser_data = cfg->user_data;
 		dw_write(dev_cfg->base, DW_MASK_BLOCK, INT_UNMASK(channel));
 	} else {
 		chan_data->dma_tfrcallback = cfg->dma_callback;
-		chan_data->tfrcallback_arg = cfg->callback_arg;
+		chan_data->tfruser_data = cfg->user_data;
 		dw_write(dev_cfg->base, DW_MASK_TFR, INT_UNMASK(channel));
 	}
 

--- a/drivers/dma/dma_dw.c
+++ b/drivers/dma/dma_dw.c
@@ -98,8 +98,9 @@ static void dw_dma_isr(void *arg)
 			 * freed in the user callback function once
 			 * all the blocks are transferred.
 			 */
-			chan_data->dma_blkcallback(chan_data->blkcallback_arg,
-					channel, 0);
+			chan_data->dma_blkcallback(dev,
+						   chan_data->blkcallback_arg,
+						   channel, 0);
 		}
 	}
 
@@ -108,8 +109,9 @@ static void dw_dma_isr(void *arg)
 		status_tfr &= ~(1 << channel);
 		chan_data = &dev_data->chan[channel];
 		if (chan_data->dma_tfrcallback) {
-			chan_data->dma_tfrcallback(chan_data->tfrcallback_arg,
-					channel, 0);
+			chan_data->dma_tfrcallback(dev,
+						   chan_data->tfrcallback_arg,
+						   channel, 0);
 		}
 	}
 }

--- a/drivers/dma/dma_dw.h
+++ b/drivers/dma/dma_dw.h
@@ -32,11 +32,11 @@ extern "C" {
 struct dma_chan_data {
 	uint32_t direction;
 	void *blkcallback_arg;
-	void (*dma_blkcallback)(void *arg, uint32_t channel,
-		int error_code);
+	void (*dma_blkcallback)(struct device *dev, void *arg,
+				uint32_t channel, int error_code);
 	void *tfrcallback_arg;
-	void (*dma_tfrcallback)(void *arg, uint32_t channel,
-		int error_code);
+	void (*dma_tfrcallback)(struct device *dev, void *arg,
+				uint32_t channel, int error_code);
 };
 
 #define DW_MAX_CHAN		8

--- a/drivers/dma/dma_dw.h
+++ b/drivers/dma/dma_dw.h
@@ -32,11 +32,9 @@ extern "C" {
 struct dma_chan_data {
 	uint32_t direction;
 	void *blkcallback_arg;
-	void (*dma_blkcallback)(struct device *dev, void *arg,
-				uint32_t channel, int error_code);
+	dma_callback_t dma_blkcallback;
 	void *tfrcallback_arg;
-	void (*dma_tfrcallback)(struct device *dev, void *arg,
-				uint32_t channel, int error_code);
+	dma_callback_t dma_tfrcallback;
 };
 
 #define DW_MAX_CHAN		8

--- a/drivers/dma/dma_dw.h
+++ b/drivers/dma/dma_dw.h
@@ -31,9 +31,9 @@ extern "C" {
 /* data for each DMA channel */
 struct dma_chan_data {
 	uint32_t direction;
-	void *blkcallback_arg;
+	void *blkuser_data;
 	dma_callback_t dma_blkcallback;
-	void *tfrcallback_arg;
+	void *tfruser_data;
 	dma_callback_t dma_tfrcallback;
 };
 

--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -39,8 +39,7 @@ struct call_back {
 	edma_handle_t edma_handle;
 	struct device *dev;
 	void *callback_arg;
-	void (*dma_callback)(struct device *dev, void *callback_arg,
-			     uint32_t channel, int error_code);
+	dma_callback_t dma_callback;
 	enum dma_channel_direction dir;
 	bool busy;
 };

--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -37,9 +37,10 @@ static __aligned(32) edma_tcd_t
 struct call_back {
 	edma_transfer_config_t transferConfig;
 	edma_handle_t edma_handle;
+	struct device *dev;
 	void *callback_arg;
-	void (*dma_callback)(void *callback_arg, uint32_t channel,
-			     int error_code);
+	void (*dma_callback)(struct device *dev, void *callback_arg,
+			     uint32_t channel, int error_code);
 	enum dma_channel_direction dir;
 	bool busy;
 };
@@ -73,7 +74,7 @@ static void nxp_edma_callback(edma_handle_t *handle, void *param,
 		ret = 0;
 	}
 	LOG_DBG("transfer %d", tcds);
-	data->dma_callback(data->callback_arg, channel, ret);
+	data->dma_callback(data->dev, data->callback_arg, channel, ret);
 }
 
 static void channel_irq(edma_handle_t *handle)
@@ -330,6 +331,7 @@ static int dma_mcux_edma_configure(struct device *dev, uint32_t channel,
 		LOG_DBG("INSTALL call back on channel %d", channel);
 		data->callback_arg = config->callback_arg;
 		data->dma_callback = config->dma_callback;
+		data->dev = dev;
 	}
 
 	irq_unlock(key);

--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -38,7 +38,7 @@ struct call_back {
 	edma_transfer_config_t transferConfig;
 	edma_handle_t edma_handle;
 	struct device *dev;
-	void *callback_arg;
+	void *user_data;
 	dma_callback_t dma_callback;
 	enum dma_channel_direction dir;
 	bool busy;
@@ -73,7 +73,7 @@ static void nxp_edma_callback(edma_handle_t *handle, void *param,
 		ret = 0;
 	}
 	LOG_DBG("transfer %d", tcds);
-	data->dma_callback(data->dev, data->callback_arg, channel, ret);
+	data->dma_callback(data->dev, data->user_data, channel, ret);
 }
 
 static void channel_irq(edma_handle_t *handle)
@@ -328,7 +328,7 @@ static int dma_mcux_edma_configure(struct device *dev, uint32_t channel,
 	data->busy = false;
 	if (config->dma_callback) {
 		LOG_DBG("INSTALL call back on channel %d", channel);
-		data->callback_arg = config->callback_arg;
+		data->user_data = config->user_data;
 		data->dma_callback = config->dma_callback;
 		data->dev = dev;
 	}

--- a/drivers/dma/dma_nios2_msgdma.c
+++ b/drivers/dma/dma_nios2_msgdma.c
@@ -26,8 +26,7 @@ struct nios2_msgdma_dev_cfg {
 	uint32_t direction;
 	struct k_sem sem_lock;
 	void *callback_arg;
-	void (*dma_callback)(struct device *dev, void *arg,
-			     uint32_t id, int error_code);
+	dma_callback_t dma_callback;
 };
 
 #define DEV_NAME(dev) ((dev)->name)

--- a/drivers/dma/dma_nios2_msgdma.c
+++ b/drivers/dma/dma_nios2_msgdma.c
@@ -25,7 +25,7 @@ struct nios2_msgdma_dev_cfg {
 	alt_msgdma_standard_descriptor desc;
 	uint32_t direction;
 	struct k_sem sem_lock;
-	void *callback_arg;
+	void *user_data;
 	dma_callback_t dma_callback;
 };
 
@@ -61,7 +61,7 @@ static void nios2_msgdma_callback(void *context)
 
 	LOG_DBG("msgdma csr status Reg: 0x%x", status);
 
-	dev_cfg->dma_callback(dev, dev_cfg->callback_arg, 0, err_code);
+	dev_cfg->dma_callback(dev, dev_cfg->user_data, 0, err_code);
 }
 
 static int nios2_msgdma_config(struct device *dev, uint32_t channel,
@@ -103,7 +103,7 @@ static int nios2_msgdma_config(struct device *dev, uint32_t channel,
 
 	k_sem_take(&dev_cfg->sem_lock, K_FOREVER);
 	dev_cfg->dma_callback = cfg->dma_callback;
-	dev_cfg->callback_arg = cfg->callback_arg;
+	dev_cfg->user_data = cfg->user_data;
 	dev_cfg->direction = cfg->channel_direction;
 	dma_block = cfg->head_block;
 	control =  ALTERA_MSGDMA_DESCRIPTOR_CONTROL_TRANSFER_COMPLETE_IRQ_MASK |

--- a/drivers/dma/dma_nios2_msgdma.c
+++ b/drivers/dma/dma_nios2_msgdma.c
@@ -26,8 +26,8 @@ struct nios2_msgdma_dev_cfg {
 	uint32_t direction;
 	struct k_sem sem_lock;
 	void *callback_arg;
-	void (*dma_callback)(void *arg, uint32_t id,
-			     int error_code);
+	void (*dma_callback)(struct device *dev, void *arg,
+			     uint32_t id, int error_code);
 };
 
 #define DEV_NAME(dev) ((dev)->name)
@@ -45,8 +45,8 @@ static void nios2_msgdma_isr(void *arg)
 
 static void nios2_msgdma_callback(void *context)
 {
-	struct nios2_msgdma_dev_cfg *dev_cfg =
-				DEV_CFG((struct device *)context);
+	struct device *dev = (struct device *)context;
+	struct nios2_msgdma_dev_cfg *dev_cfg = DEV_CFG(dev);
 	int err_code;
 	uint32_t status;
 
@@ -62,7 +62,7 @@ static void nios2_msgdma_callback(void *context)
 
 	LOG_DBG("msgdma csr status Reg: 0x%x", status);
 
-	dev_cfg->dma_callback(dev_cfg->callback_arg, 0, err_code);
+	dev_cfg->dma_callback(dev, dev_cfg->callback_arg, 0, err_code);
 }
 
 static int nios2_msgdma_config(struct device *dev, uint32_t channel,

--- a/drivers/dma/dma_pl330.c
+++ b/drivers/dma/dma_pl330.c
@@ -536,7 +536,7 @@ static int dma_pl330_transfer_start(struct device *dev, uint32_t channel)
 
 	/* Execute callback */
 	if (channel_cfg->dma_callback) {
-		channel_cfg->dma_callback(channel_cfg->callback_arg,
+		channel_cfg->dma_callback(dev, channel_cfg->callback_arg,
 					  channel, ret);
 	}
 

--- a/drivers/dma/dma_pl330.c
+++ b/drivers/dma/dma_pl330.c
@@ -500,7 +500,7 @@ static int dma_pl330_configure(struct device *dev, uint32_t channel,
 	channel_cfg->trans_size = cfg->head_block->block_size;
 
 	channel_cfg->dma_callback = cfg->dma_callback;
-	channel_cfg->callback_arg = cfg->callback_arg;
+	channel_cfg->user_data = cfg->user_data;
 
 	if (cfg->head_block->source_addr_adj == DMA_ADDR_ADJ_INCREMENT ||
 	    cfg->head_block->source_addr_adj == DMA_ADDR_ADJ_NO_CHANGE) {
@@ -536,7 +536,7 @@ static int dma_pl330_transfer_start(struct device *dev, uint32_t channel)
 
 	/* Execute callback */
 	if (channel_cfg->dma_callback) {
-		channel_cfg->dma_callback(dev, channel_cfg->callback_arg,
+		channel_cfg->dma_callback(dev, channel_cfg->user_data,
 					  channel, ret);
 	}
 

--- a/drivers/dma/dma_pl330.h
+++ b/drivers/dma/dma_pl330.h
@@ -133,9 +133,6 @@ struct dma_pl330_ch_internal {
 	int nonsec_mode;
 };
 
-typedef void (*dma_xfer_callback)(struct device *dev, void *callback_arg,
-				  uint32_t channel, int error_code);
-
 struct dma_pl330_ch_config {
 	/* Channel configuration details */
 	uint64_t src_addr;
@@ -145,7 +142,7 @@ struct dma_pl330_ch_config {
 	enum dma_channel_direction direction;
 	uint32_t trans_size;
 	void *callback_arg;
-	dma_xfer_callback dma_callback;
+	dma_callback_t dma_callback;
 	uint32_t dma_exe_addr;
 	struct k_mutex ch_mutex;
 	int channel_active;

--- a/drivers/dma/dma_pl330.h
+++ b/drivers/dma/dma_pl330.h
@@ -133,8 +133,8 @@ struct dma_pl330_ch_internal {
 	int nonsec_mode;
 };
 
-typedef void (*dma_xfer_callback)(void *callback_arg, uint32_t channel,
-				  int error_code);
+typedef void (*dma_xfer_callback)(struct device *dev, void *callback_arg,
+				  uint32_t channel, int error_code);
 
 struct dma_pl330_ch_config {
 	/* Channel configuration details */

--- a/drivers/dma/dma_pl330.h
+++ b/drivers/dma/dma_pl330.h
@@ -141,7 +141,7 @@ struct dma_pl330_ch_config {
 	enum dma_addr_adj dst_addr_adj;
 	enum dma_channel_direction direction;
 	uint32_t trans_size;
-	void *callback_arg;
+	void *user_data;
 	dma_callback_t dma_callback;
 	uint32_t dma_exe_addr;
 	struct k_mutex ch_mutex;

--- a/drivers/dma/dma_sam0.c
+++ b/drivers/dma/dma_sam0.c
@@ -15,8 +15,8 @@ LOG_MODULE_REGISTER(dma_sam0, CONFIG_DMA_LOG_LEVEL);
 
 #define DMA_REGS	((Dmac *)DT_INST_REG_ADDR(0))
 
-typedef void (*dma_callback)(void *callback_arg, uint32_t channel,
-			     int error_code);
+typedef void (*dma_callback)(struct device *dev, void *callback_arg,
+			     uint32_t channel, int error_code);
 
 struct dma_sam0_channel {
 	dma_callback cb;
@@ -50,11 +50,12 @@ static void dma_sam0_isr(void *arg)
 
 	if (pend & DMAC_INTPEND_TERR) {
 		if (chdata->cb) {
-			chdata->cb(chdata->cb_arg, channel, -DMAC_INTPEND_TERR);
+			chdata->cb(dev, chdata->cb_arg,
+				   channel, -DMAC_INTPEND_TERR);
 		}
 	} else if (pend & DMAC_INTPEND_TCMPL) {
 		if (chdata->cb) {
-			chdata->cb(chdata->cb_arg, channel, 0);
+			chdata->cb(dev, chdata->cb_arg, channel, 0);
 		}
 	}
 

--- a/drivers/dma/dma_sam0.c
+++ b/drivers/dma/dma_sam0.c
@@ -15,11 +15,8 @@ LOG_MODULE_REGISTER(dma_sam0, CONFIG_DMA_LOG_LEVEL);
 
 #define DMA_REGS	((Dmac *)DT_INST_REG_ADDR(0))
 
-typedef void (*dma_callback)(struct device *dev, void *callback_arg,
-			     uint32_t channel, int error_code);
-
 struct dma_sam0_channel {
-	dma_callback cb;
+	dma_callback_t cb;
 	void *cb_arg;
 };
 

--- a/drivers/dma/dma_sam0.c
+++ b/drivers/dma/dma_sam0.c
@@ -17,7 +17,7 @@ LOG_MODULE_REGISTER(dma_sam0, CONFIG_DMA_LOG_LEVEL);
 
 struct dma_sam0_channel {
 	dma_callback_t cb;
-	void *cb_arg;
+	void *user_data;
 };
 
 struct dma_sam0_data {
@@ -47,12 +47,12 @@ static void dma_sam0_isr(void *arg)
 
 	if (pend & DMAC_INTPEND_TERR) {
 		if (chdata->cb) {
-			chdata->cb(dev, chdata->cb_arg,
+			chdata->cb(dev, chdata->user_data,
 				   channel, -DMAC_INTPEND_TERR);
 		}
 	} else if (pend & DMAC_INTPEND_TCMPL) {
 		if (chdata->cb) {
-			chdata->cb(dev, chdata->cb_arg, channel, 0);
+			chdata->cb(dev, chdata->user_data, channel, 0);
 		}
 	}
 
@@ -249,7 +249,7 @@ static int dma_sam0_config(struct device *dev, uint32_t channel,
 
 	channel_control = &data->channels[channel];
 	channel_control->cb = config->dma_callback;
-	channel_control->cb_arg = config->callback_arg;
+	channel_control->user_data = config->user_data;
 
 	LOG_DBG("Configured channel %d for %08X to %08X (%u)",
 		channel,

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -76,8 +76,8 @@ static void sam_xdmac_isr(void *arg)
 
 		/* Execute callback */
 		if (channel_cfg->callback) {
-			channel_cfg->callback(channel_cfg->callback_arg,
-					channel, err);
+			channel_cfg->callback(dev, channel_cfg->callback_arg,
+					      channel, err);
 		}
 	}
 }

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -28,7 +28,7 @@ LOG_MODULE_REGISTER(dma_sam_xdmac);
 
 /* DMA channel configuration */
 struct sam_xdmac_channel_cfg {
-	void *callback_arg;
+	void *user_data;
 	dma_callback_t callback;
 };
 
@@ -76,7 +76,7 @@ static void sam_xdmac_isr(void *arg)
 
 		/* Execute callback */
 		if (channel_cfg->callback) {
-			channel_cfg->callback(dev, channel_cfg->callback_arg,
+			channel_cfg->callback(dev, channel_cfg->user_data,
 					      channel, err);
 		}
 	}
@@ -258,7 +258,7 @@ static int sam_xdmac_config(struct device *dev, uint32_t channel,
 	}
 
 	dev_data->dma_channels[channel].callback = cfg->dma_callback;
-	dev_data->dma_channels[channel].callback_arg = cfg->callback_arg;
+	dev_data->dma_channels[channel].user_data = cfg->user_data;
 
 	(void)memset(&transfer_cfg, 0, sizeof(transfer_cfg));
 	transfer_cfg.sa = cfg->head_block->source_address;

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -29,7 +29,7 @@ LOG_MODULE_REGISTER(dma_sam_xdmac);
 /* DMA channel configuration */
 struct sam_xdmac_channel_cfg {
 	void *callback_arg;
-	dma_callback callback;
+	dma_callback_t callback;
 };
 
 /* Device constant configuration parameters */

--- a/drivers/dma/dma_sam_xdmac.h
+++ b/drivers/dma/dma_sam_xdmac.h
@@ -18,7 +18,8 @@ extern "C" {
 #endif
 
 /** DMA transfer callback */
-typedef void (*dma_callback)(void *arg, uint32_t channel, int error_code);
+typedef void (*dma_callback)(struct device *dev, void *arg,
+			     uint32_t channel, int error_code);
 
 /* XDMA_MBR_UBC */
 #define XDMA_UBC_NDE (0x1u << 24)

--- a/drivers/dma/dma_sam_xdmac.h
+++ b/drivers/dma/dma_sam_xdmac.h
@@ -17,10 +17,6 @@
 extern "C" {
 #endif
 
-/** DMA transfer callback */
-typedef void (*dma_callback)(struct device *dev, void *arg,
-			     uint32_t channel, int error_code);
-
 /* XDMA_MBR_UBC */
 #define XDMA_UBC_NDE (0x1u << 24)
 #define   XDMA_UBC_NDE_FETCH_DIS (0x0u << 24)

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -90,21 +90,21 @@ static void dma_stm32_irq_handler(void *arg)
 #ifdef CONFIG_DMAMUX_STM32
 		stream->busy = false;
 		/* the callback function expects the dmamux channel nb */
-		stream->dma_callback(stream->callback_arg,
-					stream->mux_channel, 0);
+		stream->dma_callback(dev, stream->callback_arg,
+				     stream->mux_channel, 0);
 #else
-		stream->dma_callback(stream->callback_arg, id + STREAM_OFFSET,
-				     0);
+		stream->dma_callback(dev, stream->callback_arg,
+				     id + STREAM_OFFSET, 0);
 #endif /* CONFIG_DMAMUX_STM32 */
 	} else if (stm32_dma_is_unexpected_irq_happened(dma, id)) {
 		LOG_ERR("Unexpected irq happened.");
 
 #ifdef CONFIG_DMAMUX_STM32
-		stream->dma_callback(stream->callback_arg,
-					stream->mux_channel, -EIO);
+		stream->dma_callback(dev, stream->callback_arg,
+				     stream->mux_channel, -EIO);
 #else
-		stream->dma_callback(stream->callback_arg, id + STREAM_OFFSET,
-				     -EIO);
+		stream->dma_callback(dev, stream->callback_arg,
+				     id + STREAM_OFFSET, -EIO);
 #endif /* CONFIG_DMAMUX_STM32 */
 	} else {
 		LOG_ERR("Transfer Error.");
@@ -112,11 +112,11 @@ static void dma_stm32_irq_handler(void *arg)
 		dma_stm32_clear_stream_irq(dev, id);
 
 #ifdef CONFIG_DMAMUX_STM32
-		stream->dma_callback(stream->callback_arg,
-					stream->mux_channel, -EIO);
+		stream->dma_callback(dev, stream->callback_arg,
+				     stream->mux_channel, -EIO);
 #else
-		stream->dma_callback(stream->callback_arg, id + STREAM_OFFSET,
-				     -EIO);
+		stream->dma_callback(dev, stream->callback_arg,
+				     id + STREAM_OFFSET, -EIO);
 #endif /* CONFIG_DMAMUX_STM32 */
 	}
 }

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -90,20 +90,20 @@ static void dma_stm32_irq_handler(void *arg)
 #ifdef CONFIG_DMAMUX_STM32
 		stream->busy = false;
 		/* the callback function expects the dmamux channel nb */
-		stream->dma_callback(dev, stream->callback_arg,
+		stream->dma_callback(dev, stream->user_data,
 				     stream->mux_channel, 0);
 #else
-		stream->dma_callback(dev, stream->callback_arg,
+		stream->dma_callback(dev, stream->user_data,
 				     id + STREAM_OFFSET, 0);
 #endif /* CONFIG_DMAMUX_STM32 */
 	} else if (stm32_dma_is_unexpected_irq_happened(dma, id)) {
 		LOG_ERR("Unexpected irq happened.");
 
 #ifdef CONFIG_DMAMUX_STM32
-		stream->dma_callback(dev, stream->callback_arg,
+		stream->dma_callback(dev, stream->user_data,
 				     stream->mux_channel, -EIO);
 #else
-		stream->dma_callback(dev, stream->callback_arg,
+		stream->dma_callback(dev, stream->user_data,
 				     id + STREAM_OFFSET, -EIO);
 #endif /* CONFIG_DMAMUX_STM32 */
 	} else {
@@ -112,10 +112,10 @@ static void dma_stm32_irq_handler(void *arg)
 		dma_stm32_clear_stream_irq(dev, id);
 
 #ifdef CONFIG_DMAMUX_STM32
-		stream->dma_callback(dev, stream->callback_arg,
+		stream->dma_callback(dev, stream->user_data,
 				     stream->mux_channel, -EIO);
 #else
-		stream->dma_callback(dev, stream->callback_arg,
+		stream->dma_callback(dev, stream->user_data,
 				     id + STREAM_OFFSET, -EIO);
 #endif /* CONFIG_DMAMUX_STM32 */
 	}
@@ -310,7 +310,7 @@ static int dma_stm32_configure(struct device *dev, uint32_t id,
 	stream->busy		= true;
 	stream->dma_callback	= config->dma_callback;
 	stream->direction	= config->channel_direction;
-	stream->callback_arg    = config->callback_arg;
+	stream->user_data       = config->user_data;
 	stream->src_size	= config->source_data_size;
 	stream->dst_size	= config->dest_data_size;
 

--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -20,8 +20,8 @@ struct dma_stm32_stream {
 	uint32_t src_size;
 	uint32_t dst_size;
 	void *callback_arg; /* holds the client data */
-	void (*dma_callback)(void *arg, uint32_t id,
-			     int error_code);
+	void (*dma_callback)(struct device *dev, void *arg,
+			     uint32_t id, int error_code);
 };
 
 struct dma_stm32_data {

--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -19,7 +19,7 @@ struct dma_stm32_stream {
 	bool busy;
 	uint32_t src_size;
 	uint32_t dst_size;
-	void *callback_arg; /* holds the client data */
+	void *user_data; /* holds the client data */
 	dma_callback_t dma_callback;
 };
 

--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -20,8 +20,7 @@ struct dma_stm32_stream {
 	uint32_t src_size;
 	uint32_t dst_size;
 	void *callback_arg; /* holds the client data */
-	void (*dma_callback)(struct device *dev, void *arg,
-			     uint32_t id, int error_code);
+	dma_callback_t dma_callback;
 };
 
 struct dma_stm32_data {

--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -181,13 +181,15 @@ static void i2c_sam0_isr(void *arg)
 
 #ifdef CONFIG_I2C_SAM0_DMA_DRIVEN
 
-static void i2c_sam0_dma_write_done(void *arg, uint32_t id, int error_code)
+static void i2c_sam0_dma_write_done(struct device *dma_dev, void *arg,
+				    uint32_t id, int error_code)
 {
 	struct device *dev = arg;
 	struct i2c_sam0_dev_data *data = DEV_DATA(dev);
 	const struct i2c_sam0_dev_config *const cfg = DEV_CFG(dev);
 	SercomI2cm *i2c = cfg->regs;
 
+	ARG_UNUSED(dma_dev);
 	ARG_UNUSED(id);
 
 	int key = irq_lock();
@@ -274,13 +276,15 @@ static bool i2c_sam0_dma_write_start(struct device *dev)
 	return true;
 }
 
-static void i2c_sam0_dma_read_done(void *arg, uint32_t id, int error_code)
+static void i2c_sam0_dma_read_done(struct device *dma_dev, void *arg,
+				   uint32_t id, int error_code)
 {
 	struct device *dev = arg;
 	struct i2c_sam0_dev_data *data = DEV_DATA(dev);
 	const struct i2c_sam0_dev_config *const cfg = DEV_CFG(dev);
 	SercomI2cm *i2c = cfg->regs;
 
+	ARG_UNUSED(dma_dev);
 	ARG_UNUSED(id);
 
 	int key = irq_lock();

--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -248,7 +248,7 @@ static bool i2c_sam0_dma_write_start(struct device *dev)
 	dma_cfg.channel_direction = MEMORY_TO_PERIPHERAL;
 	dma_cfg.source_data_size = 1;
 	dma_cfg.dest_data_size = 1;
-	dma_cfg.callback_arg = dev;
+	dma_cfg.user_data = dev;
 	dma_cfg.dma_callback = i2c_sam0_dma_write_done;
 	dma_cfg.block_count = 1;
 	dma_cfg.head_block = &dma_blk;
@@ -345,7 +345,7 @@ static bool i2c_sam0_dma_read_start(struct device *dev)
 	dma_cfg.channel_direction = PERIPHERAL_TO_MEMORY;
 	dma_cfg.source_data_size = 1;
 	dma_cfg.dest_data_size = 1;
-	dma_cfg.callback_arg = dev;
+	dma_cfg.user_data = dev;
 	dma_cfg.dma_callback = i2c_sam0_dma_read_done;
 	dma_cfg.block_count = 1;
 	dma_cfg.head_block = &dma_blk;

--- a/drivers/i2s/i2s_cavs.c
+++ b/drivers/i2s/i2s_cavs.c
@@ -166,7 +166,7 @@ I2S_DEVICE_OBJECT_DECLARE(1);
 I2S_DEVICE_OBJECT_DECLARE(2);
 I2S_DEVICE_OBJECT_DECLARE(3);
 
-static void i2s_dma_tx_callback(void *, uint32_t, int);
+static void i2s_dma_tx_callback(struct device *, void *, uint32_t, int);
 static void i2s_tx_stream_disable(struct i2s_cavs_dev_data *,
 		volatile struct i2s_cavs_ssp *const, struct device *);
 static void i2s_rx_stream_disable(struct i2s_cavs_dev_data *,
@@ -186,8 +186,8 @@ static inline void i2s_purge_stream_buffers(struct stream *strm,
 }
 
 /* This function is executed in the interrupt context */
-static void i2s_dma_tx_callback(void *arg, uint32_t channel,
-		int status)
+static void i2s_dma_tx_callback(struct device *dma_dev, void *arg,
+				uint32_t channel, int status)
 {
 	struct device *dev = (struct device *)arg;
 	const struct i2s_cavs_config *const dev_cfg = DEV_CFG(dev);
@@ -242,7 +242,8 @@ static void i2s_dma_tx_callback(void *arg, uint32_t channel,
 	}
 }
 
-static void i2s_dma_rx_callback(void *arg, uint32_t channel, int status)
+static void i2s_dma_rx_callback(struct device *dma_dev, void *arg,
+				uint32_t channel, int status)
 {
 	struct device *dev = (struct device *)arg;
 	const struct i2s_cavs_config *const dev_cfg = DEV_CFG(dev);

--- a/drivers/i2s/i2s_cavs.c
+++ b/drivers/i2s/i2s_cavs.c
@@ -63,7 +63,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 				.source_burst_length = CAVS_I2S_DMA_BURST_SIZE,\
 				.dest_burst_length = CAVS_I2S_DMA_BURST_SIZE,\
 				.dma_callback = i2s_dma_tx_callback,	\
-				.callback_arg = I2S_DEVICE_OBJECT(i2s_id),\
+				.user_data = I2S_DEVICE_OBJECT(i2s_id),\
 				.complete_callback_en = 1,	\
 				.error_callback_en = 1,		\
 				.block_count = 1,		\
@@ -79,7 +79,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 				.source_burst_length = CAVS_I2S_DMA_BURST_SIZE,\
 				.dest_burst_length = CAVS_I2S_DMA_BURST_SIZE,\
 				.dma_callback = i2s_dma_rx_callback,\
-				.callback_arg = I2S_DEVICE_OBJECT(i2s_id),\
+				.user_data = I2S_DEVICE_OBJECT(i2s_id),\
 				.complete_callback_en = 1,	\
 				.error_callback_en = 1,		\
 				.block_count = 1,		\

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -492,7 +492,8 @@ static void rx_stream_disable(struct stream *stream, struct device *dev);
 static void tx_stream_disable(struct stream *stream, struct device *dev);
 
 /* This function is executed in the interrupt context */
-static void dma_rx_callback(void *arg, uint32_t channel, int status)
+static void dma_rx_callback(struct device *dma_dev, void *arg,
+			    uint32_t channel, int status)
 {
 	struct device *dev = get_dev_from_rx_dma_channel(channel);
 	const struct i2s_stm32_cfg *cfg = DEV_CFG(dev);
@@ -558,7 +559,8 @@ rx_disable:
 	rx_stream_disable(stream, dev);
 }
 
-static void dma_tx_callback(void *arg, uint32_t channel, int status)
+static void dma_tx_callback(struct device *dma_dev, void *arg,
+			    uint32_t channel, int status)
 {
 	struct device *dev = get_dev_from_tx_dma_channel(channel);
 	const struct i2s_stm32_cfg *cfg = DEV_CFG(dev);

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -186,7 +186,7 @@ static int start_dma(struct device *dev_dma, uint32_t channel,
 }
 
 /* This function is executed in the interrupt context */
-static void dma_rx_callback(struct device *dma_dev, void *callback_arg,
+static void dma_rx_callback(struct device *dma_dev, void *user_data,
 			    uint32_t channel, int status)
 {
 	struct device *dev = get_dev_from_dma_channel(channel);
@@ -196,7 +196,7 @@ static void dma_rx_callback(struct device *dma_dev, void *callback_arg,
 	struct stream *stream = &dev_data->rx;
 	int ret;
 
-	ARG_UNUSED(callback_arg);
+	ARG_UNUSED(user_data);
 	__ASSERT_NO_MSG(stream->mem_block != NULL);
 
 	/* Stop reception if there was an error */
@@ -246,7 +246,7 @@ rx_disable:
 }
 
 /* This function is executed in the interrupt context */
-static void dma_tx_callback(struct device *dma_dev, void *callback_arg,
+static void dma_tx_callback(struct device *dma_dev, void *user_data,
 			    uint32_t channel, int status)
 {
 	struct device *dev = get_dev_from_dma_channel(channel);
@@ -257,7 +257,7 @@ static void dma_tx_callback(struct device *dma_dev, void *callback_arg,
 	size_t mem_block_size;
 	int ret;
 
-	ARG_UNUSED(callback_arg);
+	ARG_UNUSED(user_data);
 	__ASSERT_NO_MSG(stream->mem_block != NULL);
 
 	/* All block data sent */

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -104,8 +104,8 @@ struct i2s_sam_dev_data {
 #define MODULO_INC(val, max) { val = (++val < max) ? val : 0; }
 
 static struct device *get_dev_from_dma_channel(uint32_t dma_channel);
-static void dma_rx_callback(void *, uint32_t, int);
-static void dma_tx_callback(void *, uint32_t, int);
+static void dma_rx_callback(struct device *, void *, uint32_t, int);
+static void dma_tx_callback(struct device *, void *, uint32_t, int);
 static void rx_stream_disable(struct stream *, Ssc *const, struct device *);
 static void tx_stream_disable(struct stream *, Ssc *const, struct device *);
 
@@ -186,7 +186,8 @@ static int start_dma(struct device *dev_dma, uint32_t channel,
 }
 
 /* This function is executed in the interrupt context */
-static void dma_rx_callback(void *callback_arg, uint32_t channel, int status)
+static void dma_rx_callback(struct device *dma_dev, void *callback_arg,
+			    uint32_t channel, int status)
 {
 	struct device *dev = get_dev_from_dma_channel(channel);
 	const struct i2s_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
@@ -245,7 +246,8 @@ rx_disable:
 }
 
 /* This function is executed in the interrupt context */
-static void dma_tx_callback(void *callback_arg, uint32_t channel, int status)
+static void dma_tx_callback(struct device *dma_dev, void *callback_arg,
+			    uint32_t channel, int status)
 {
 	struct device *dev = get_dev_from_dma_channel(channel);
 	const struct i2s_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -120,8 +120,10 @@ static int uart_sam0_set_baudrate(SercomUsart *const usart, uint32_t baudrate,
 
 #if CONFIG_UART_ASYNC_API
 
-static void uart_sam0_dma_tx_done(void *arg, uint32_t id, int error_code)
+static void uart_sam0_dma_tx_done(struct device *dma_dev, void *arg,
+				  uint32_t id, int error_code)
 {
+	ARG_UNUSED(dma_dev);
 	ARG_UNUSED(id);
 	ARG_UNUSED(error_code);
 
@@ -222,8 +224,10 @@ static void uart_sam0_notify_rx_processed(struct uart_sam0_dev_data *dev_data,
 			   &evt, dev_data->async_cb_data);
 }
 
-static void uart_sam0_dma_rx_done(void *arg, uint32_t id, int error_code)
+static void uart_sam0_dma_rx_done(struct device *dma_dev, void *arg,
+				  uint32_t id, int error_code)
 {
+	ARG_UNUSED(dma_dev);
 	ARG_UNUSED(id);
 	ARG_UNUSED(error_code);
 

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -581,7 +581,7 @@ static int uart_sam0_init(struct device *dev)
 		dma_cfg.channel_direction = MEMORY_TO_PERIPHERAL;
 		dma_cfg.source_data_size = 1;
 		dma_cfg.dest_data_size = 1;
-		dma_cfg.callback_arg = dev;
+		dma_cfg.user_data = dev;
 		dma_cfg.dma_callback = uart_sam0_dma_tx_done;
 		dma_cfg.block_count = 1;
 		dma_cfg.head_block = &dma_blk;
@@ -609,7 +609,7 @@ static int uart_sam0_init(struct device *dev)
 		dma_cfg.channel_direction = PERIPHERAL_TO_MEMORY;
 		dma_cfg.source_data_size = 1;
 		dma_cfg.dest_data_size = 1;
-		dma_cfg.callback_arg = dev;
+		dma_cfg.user_data = dev;
 		dma_cfg.dma_callback = uart_sam0_dma_rx_done;
 		dma_cfg.block_count = 1;
 		dma_cfg.head_block = &dma_blk;

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -60,7 +60,7 @@ uint32_t nop_tx;
 static void dma_callback(struct device *dev, void *arg,
 			 uint32_t channel, int status)
 {
-	/* callback_arg directly holds the client data */
+	/* arg directly holds the client data */
 	struct spi_stm32_data *data = arg;
 
 	if (status != 0) {
@@ -129,7 +129,7 @@ static int spi_stm32_dma_tx_load(struct device *dev, const uint8_t *buf,
 	/* direction is given by the DT */
 	stream->dma_cfg.head_block = &blk_cfg;
 	/* give the client data as arg, as the callback comes from the dma */
-	stream->dma_cfg.callback_arg = data;
+	stream->dma_cfg.user_data = data;
 	/* pass our client origin to the dma: data->dma_tx.dma_channel */
 	ret = dma_config(data->dev_dma_tx, data->dma_tx.channel,
 			&stream->dma_cfg);
@@ -178,7 +178,7 @@ static int spi_stm32_dma_rx_load(struct device *dev, uint8_t *buf, size_t len)
 
 	/* direction is given by the DT */
 	stream->dma_cfg.head_block = &blk_cfg;
-	stream->dma_cfg.callback_arg = data;
+	stream->dma_cfg.user_data = data;
 
 
 	/* pass our client origin to the dma: data->dma_rx.channel */

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -57,7 +57,8 @@ LOG_MODULE_REGISTER(spi_ll_stm32);
 uint32_t nop_tx;
 
 /* This function is executed in the interrupt context */
-static void dma_callback(void *arg, uint32_t channel, int status)
+static void dma_callback(struct device *dev, void *arg,
+			 uint32_t channel, int status)
 {
 	/* callback_arg directly holds the client data */
 	struct spi_stm32_data *data = arg;

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -436,7 +436,8 @@ static int spi_sam0_transceive_sync(struct device *dev,
 
 #ifdef CONFIG_SPI_ASYNC
 
-static void spi_sam0_dma_rx_done(void *arg, uint32_t id, int error_code);
+static void spi_sam0_dma_rx_done(struct device *dma_dev, void *arg,
+				 uint32_t id, int error_code);
 
 static int spi_sam0_dma_rx_load(struct device *dev, uint8_t *buf,
 				size_t len)
@@ -582,7 +583,8 @@ static int spi_sam0_dma_advance_buffers(struct device *dev)
 	return 0;
 }
 
-static void spi_sam0_dma_rx_done(void *arg, uint32_t id, int error_code)
+static void spi_sam0_dma_rx_done(struct device *dma_dev, void *arg,
+				 uint32_t id, int error_code)
 {
 	struct device *dev = arg;
 	const struct spi_sam0_config *cfg = dev->config_info;

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -452,7 +452,7 @@ static int spi_sam0_dma_rx_load(struct device *dev, uint8_t *buf,
 	dma_cfg.channel_direction = PERIPHERAL_TO_MEMORY;
 	dma_cfg.source_data_size = 1;
 	dma_cfg.dest_data_size = 1;
-	dma_cfg.callback_arg = dev;
+	dma_cfg.user_data = dev;
 	dma_cfg.dma_callback = spi_sam0_dma_rx_done;
 	dma_cfg.block_count = 1;
 	dma_cfg.head_block = &dma_blk;

--- a/include/drivers/dma.h
+++ b/include/drivers/dma.h
@@ -162,8 +162,8 @@ struct dma_config {
 	uint32_t block_count;
 	struct dma_block_config *head_block;
 	void *callback_arg;
-	void (*dma_callback)(void *callback_arg, uint32_t channel,
-			     int error_code);
+	void (*dma_callback)(struct device *dev, void *callback_arg,
+			     uint32_t channel, int error_code);
 };
 
 /**

--- a/include/drivers/dma.h
+++ b/include/drivers/dma.h
@@ -102,6 +102,21 @@ struct dma_block_config {
 };
 
 /**
+ * @typedef dma_callback_t
+ * @brief Callback function for DMA transfer completion
+ *
+ *  If enabled, callback function will be invoked at transfer completion
+ *  or when error happens.
+ *
+ * @param dev Pointer to the DMA device calling the callback.
+ * @param user_data A pointer to some user data or NULL
+ * @param channel The channel number
+ * @param status 0 on success, a negative errno otherwise
+ */
+typedef void (*dma_callback_t)(struct device *dev, void *user_data,
+			       uint32_t channel, int status);
+
+/**
  * @brief DMA configuration structure.
  *
  *     dma_slot             [ 0 : 6 ]   - which peripheral and direction
@@ -139,9 +154,7 @@ struct dma_block_config {
  *
  *     callback_arg  private argument from DMA client.
  *
- * dma_callback is the callback function pointer. If enabled, callback function
- *              will be invoked at transfer completion or when error happens
- *              (error_code: zero-transfer success, non zero-error happens).
+ *     dma_callback see dma_callback_t for details
  */
 struct dma_config {
 	uint32_t  dma_slot :             7;
@@ -162,8 +175,7 @@ struct dma_config {
 	uint32_t block_count;
 	struct dma_block_config *head_block;
 	void *callback_arg;
-	void (*dma_callback)(struct device *dev, void *callback_arg,
-			     uint32_t channel, int error_code);
+	dma_callback_t dma_callback;
 };
 
 /**

--- a/include/drivers/dma.h
+++ b/include/drivers/dma.h
@@ -152,7 +152,7 @@ typedef void (*dma_callback_t)(struct device *dev, void *user_data,
  *     block_count  is the number of blocks used for block chaining, this
  *     depends on availability of the DMA controller.
  *
- *     callback_arg  private argument from DMA client.
+ *     user_data  private data from DMA client.
  *
  *     dma_callback see dma_callback_t for details
  */
@@ -174,7 +174,7 @@ struct dma_config {
 	uint32_t  dest_burst_length :   16;
 	uint32_t block_count;
 	struct dma_block_config *head_block;
-	void *callback_arg;
+	void *user_data;
 	dma_callback_t dma_callback;
 };
 

--- a/tests/boards/altera_max10/msgdma/src/dma.c
+++ b/tests/boards/altera_max10/msgdma/src/dma.c
@@ -26,7 +26,8 @@ static char rx_data[DMA_BUFF_SIZE];
 static struct dma_config dma_cfg = {0};
 static struct dma_block_config dma_block_cfg = {0};
 
-static void dma_user_callback(void *arg, uint32_t id, int error_code)
+static void dma_user_callback(struct device *dma_dev, void *arg,
+			      uint32_t id, int error_code)
 {
 	if (error_code == 0) {
 		TC_PRINT("DMA completed successfully\n");

--- a/tests/boards/intel_s1000_crb/main/src/dma_test.c
+++ b/tests/boards/intel_s1000_crb/main/src/dma_test.c
@@ -100,7 +100,8 @@ static struct transfers transfer_blocks[MAX_TRANSFERS] = {
 static struct device *dma_device;
 static uint32_t current_block_count, total_block_count;
 
-static void test_done(void *arg, uint32_t channel, int error_code)
+static void test_done(struct device *dma_dev, void *arg,
+		      uint32_t channel, int error_code)
 {
 	uint32_t src, dst;
 	size_t size;
@@ -114,8 +115,8 @@ static void test_done(void *arg, uint32_t channel, int error_code)
 		src = (uint32_t)transfer_blocks[current_block_count].source;
 		dst = (uint32_t)transfer_blocks[current_block_count].destination;
 		size = transfer_blocks[current_block_count].size;
-		dma_reload(dma_device, channel, src, dst, size);
-		dma_start(dma_device, channel);
+		dma_reload(dma_dev, channel, src, dst, size);
+		dma_start(dma_dev, channel);
 	} else {
 		printk("DMA transfer done\n");
 		k_sem_give(&dma_sem);

--- a/tests/boards/intel_s1000_crb/main/src/dma_test.c
+++ b/tests/boards/intel_s1000_crb/main/src/dma_test.c
@@ -166,7 +166,7 @@ static int test_task(uint32_t chan_id, uint32_t blen, uint32_t block_count)
 	(void)memset(rx_data4, 0, sizeof(rx_data4));
 
 	/*
-	 * dma_block_cfg4 is assigned to 0 by default. Hence if callback_arg is
+	 * dma_block_cfg4 is assigned to 0 by default. Hence if user_data is
 	 * not assigned, it will be NULL implying there are no more blocks to
 	 * transfer
 	 */

--- a/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
@@ -34,7 +34,8 @@ static const char tx_data[] = "It is harder to be kind than to be wise........";
 static char rx_data[RX_BUFF_SIZE] = { 0 };
 #endif
 
-static void test_done(void *arg, uint32_t id, int error_code)
+static void test_done(struct device *dma_dev, void *arg,
+		      uint32_t id, int error_code)
 {
 	if (error_code == 0) {
 		TC_PRINT("DMA transfer done\n");

--- a/tests/drivers/dma/loop_transfer/src/dma.c
+++ b/tests/drivers/dma/loop_transfer/src/dma.c
@@ -96,7 +96,7 @@ void main(void)
 	dma_cfg.dest_data_size = 1U;
 	dma_cfg.source_burst_length = 1U;
 	dma_cfg.dest_burst_length = 1U;
-	dma_cfg.callback_arg = NULL;
+	dma_cfg.user_data = NULL;
 	dma_cfg.dma_callback = dma_user_callback;
 	dma_cfg.block_count = 1U;
 	dma_cfg.head_block = &dma_block_cfg;

--- a/tests/drivers/dma/loop_transfer/src/dma.c
+++ b/tests/drivers/dma/loop_transfer/src/dma.c
@@ -59,12 +59,11 @@ static void test_error(void)
 	printk("DMA could not proceed, an error occurred\n");
 }
 
-static void dma_user_callback(void *arg, uint32_t id, int error_code)
+static void dma_user_callback(struct device *dma_dev, void *arg,
+			      uint32_t id, int error_code)
 {
-	struct device *dev = (struct device *)arg;
-
 	if (error_code == 0) {
-		test_transfer(dev, id);
+		test_transfer(dma_dev, id);
 	} else {
 		test_error();
 	}
@@ -97,7 +96,7 @@ void main(void)
 	dma_cfg.dest_data_size = 1U;
 	dma_cfg.source_burst_length = 1U;
 	dma_cfg.dest_burst_length = 1U;
-	dma_cfg.callback_arg = dma;
+	dma_cfg.callback_arg = NULL;
 	dma_cfg.dma_callback = dma_user_callback;
 	dma_cfg.block_count = 1U;
 	dma_cfg.head_block = &dma_block_cfg;


### PR DESCRIPTION

- **Problem Description:**

DMA callback do not provide the DMA device's callback caller as parameter, forcing users to use the callback_arg parameter instead for this purpose, which in turn limits its usage (they cannot provide some private data, or have to mangle thing together storing the DMA dev pointer into the private data).

 - **Proposed Change (detailed):**

All other API provide the callback's caller device pointer, and thus adding it as first parameter to the DMA callback.

 - **Dependencies:**

All users of function need to adapt their callbacks accordingly.

Provide the DMA device instance to the callback.