### PR TITLE
cmake: fix the build on windows

### DIFF
--- a/cmake/host-tools.cmake
+++ b/cmake/host-tools.cmake
@@ -54,7 +54,7 @@ else()
 
   execute_process(
     COMMAND ${PYTHON_EXECUTABLE} -c
-    "from west.util import west_topdir; print(west_topdir())"
+    "import pathlib; from west.util import west_topdir; print(pathlib.Path(west_topdir()).as_posix())"
     OUTPUT_VARIABLE  WEST_TOPDIR
     OUTPUT_STRIP_TRAILING_WHITESPACE
     WORKING_DIRECTORY ${ZEPHYR_BASE}


### PR DESCRIPTION
Commit ef3c5e551676278ccc1f42ecb572838144c5e33a changed the way
WEST_TOPDIR is initialized from calling 'west topdir' as a subprocess
to using the west API.

However, WEST_TOPDIR is a cmake variable and must be a cmake-style
path, with forward slashes. While 'west topdir' as a command does
output a forward slash separated path (basically in order to make the
zephyr build system work), west_topdir() as an API returns the path in
the host environment path style, which on Windows uses backslashes.

This turns out to be the ultimate cause of the following build error:

```
CMake Error at C:/.../CheckCCompilerFlag.cmake:41 (set):
  Syntax error in cmake code when parsing string
    -fmacro-prefix-map=C:\Users\Marti\zp=WEST_TOPDIR
```

Fix it by converting to POSIX style in Python. We could have
potentially also done this using file(TO_CMAKE_PATH "${WEST_TOPDIR}"
...), but I'm intentionally repeating the old way of doing things
since it was known to work.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>