### PR TITLE
soc: arm: viper: Fix callee saved register corruption in el3 init

### DIFF
--- a/soc/arm/bcm_vk/viper/plat_core.S
+++ b/soc/arm/bcm_vk/viper/plat_core.S
@@ -20,7 +20,7 @@ GTEXT(plat_l2_init)
 
 SECTION_FUNC(TEXT, z_arch_el3_plat_init)
 
-	mov	x19, x30
+	mov	x20, x30
 	/* Enable GIC v3 system interface */
 	mov_imm	x0, (ICC_SRE_ELx_DFB | ICC_SRE_ELx_DIB | \
 		     ICC_SRE_ELx_SRE | ICC_SRE_EL3_EN)
@@ -28,7 +28,7 @@ SECTION_FUNC(TEXT, z_arch_el3_plat_init)
 	/* L2 config */
 	bl	plat_l2_init
 
-	mov	x30, x19
+	mov	x30, x20
 	ret
 
 


### PR DESCRIPTION
x19 is callee saved register. z_arch_el3_plat_init being a callee,
it should save it before using it. However, at this point, stack
has not been setup. So, let's just use x20 instead which is not
being used by caller yet. This bug was causing VBAR_EL1 corruption,
but since [10:0] bits are reserved, bug was hidden.

Signed-off-by: Abhishek Shah <abhishek.shah@broadcom.com>