### PR TITLE
net: openthread: make diag compile

### DIFF
--- a/samples/net/sockets/echo_client/overlay-ot.conf
+++ b/samples/net/sockets/echo_client/overlay-ot.conf
@@ -30,3 +30,6 @@ CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN=768
 # A sample configuration to enable Thread Joiner, uncomment if needed
 #CONFIG_OPENTHREAD_JOINER=y
 #CONFIG_OPENTHREAD_JOINER_AUTOSTART=y
+
+# Enable diagnostic module, uncomment if needed
+#CONFIG_OPENTHREAD_DIAG=y

--- a/samples/net/sockets/echo_server/overlay-ot.conf
+++ b/samples/net/sockets/echo_server/overlay-ot.conf
@@ -29,3 +29,6 @@ CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN=768
 
 # A sample configuration to enable Thread Commissioner, uncomment if needed
 #CONFIG_OPENTHREAD_COMMISSIONER=y
+
+# Enable diagnostic module, uncomment if needed
+#CONFIG_OPENTHREAD_DIAG=y

--- a/subsys/net/lib/openthread/platform/CMakeLists.txt
+++ b/subsys/net/lib/openthread/platform/CMakeLists.txt
@@ -12,6 +12,7 @@ zephyr_library_sources(
   spi.c
   )
 
+zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_DIAG diag.c)
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_NCP uart.c)
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_SHELL shell.c)
 

--- a/subsys/net/lib/openthread/platform/diag.c
+++ b/subsys/net/lib/openthread/platform/diag.c
@@ -5,8 +5,6 @@
  */
 
 #include <kernel.h>
-#include <openthread-config.h>
-#include <openthread/openthread.h>
 #include <openthread/platform/diag.h>
 
 #include "platform-zephyr.h"
@@ -17,11 +15,11 @@
  */
 static bool sDiagMode;
 
-void otPlatDiagProcess(otInstance *aInstance,
-		       int argc,
-		       char *argv[],
-		       char *aOutput,
-		       size_t aOutputMaxLen)
+otError otPlatDiagProcess(otInstance *aInstance,
+			  uint8_t argc,
+			  char   *argv[],
+			  char   *aOutput,
+			  size_t  aOutputMaxLen)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(aInstance);
@@ -29,6 +27,8 @@ void otPlatDiagProcess(otInstance *aInstance,
 	/* Add more plarform specific diagnostics features here. */
 	snprintk(aOutput, aOutputMaxLen,
 		 "diag feature '%s' is not supported\r\n", argv[0]);
+
+	return OT_ERROR_NOT_IMPLEMENTED;
 }
 
 void otPlatDiagModeSet(bool aMode)
@@ -52,8 +52,8 @@ void otPlatDiagTxPowerSet(int8_t aTxPower)
 }
 
 void otPlatDiagRadioReceived(otInstance *aInstance,
-			     RadioPacket *aFrame,
-			     ThreadError aError)
+			     otRadioFrame *aFrame,
+			     otError aError)
 {
 	ARG_UNUSED(aInstance);
 	ARG_UNUSED(aFrame);

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -253,7 +253,7 @@ void transmit_message(struct k_work *tx_job)
 
 static inline void handle_tx_done(otInstance *aInstance)
 {
-	if (IS_ENABLED(OPENTHREAD_ENABLE_DIAG) && otPlatDiagModeGet()) {
+	if (IS_ENABLED(CONFIG_OPENTHREAD_DIAG) && otPlatDiagModeGet()) {
 		otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame,
 					    tx_result);
 	} else {
@@ -295,7 +295,7 @@ static void openthread_handle_received_frame(otInstance *instance,
 					      time->nanosecond / NSEC_PER_USEC;
 #endif
 
-	if (IS_ENABLED(OPENTHREAD_ENABLE_DIAG) && otPlatDiagModeGet()) {
+	if (IS_ENABLED(CONFIG_OPENTHREAD_DIAG) && otPlatDiagModeGet()) {
 		otPlatDiagRadioReceiveDone(instance,
 					   &recv_frame, OT_ERROR_NONE);
 	} else {


### PR DESCRIPTION
Fix compilation error when the DIAG module is enabled.
All core functionalities are provided.

Signed-off-by: Piotr Szkotak <piotr.szkotak@nordicsemi.no>