### PR TITLE
arch: arm: cortex_m: align Cortex-M vector table according to VTOR requirements

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/relay_vector_table.ld
+++ b/arch/arm/core/aarch32/cortex_m/relay_vector_table.ld
@@ -1,8 +1,32 @@
 /*
- * Copyright (c) 2019 Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#if defined(CONFIG_CPU_CORTEX_M_HAS_VTOR)
+/*
+ * In an MCU with VTOR, the VTOR.TBLOFF is set to the start address of the
+ * vector_relay_table, when building with support for interrupt relaying.
+ * Therefore, vector_relay_table must respect the alignment requirements
+ * of VTOR.TBLOFF described below.
+ */
+
+/* VTOR bits 0:6 are reserved (RES0). This requires that the base address
+ * of the vector table is 32-word aligned.
+ */
+. = ALIGN( 1 << LOG2CEIL(4 * 32) );
+
+/* When setting TBLOFF in VTOR we must align the offset to the number of
+ * exception entries in the vector table. The minimum alignment of 32 words
+ * is sufficient for the 16 ARM Core exceptions and up to 16 HW interrupts.
+ * For more than 16 HW interrupts, we adjust the alignment by rounding up
+ * to the next power of two; this restriction guarantees a functional VTOR
+ * setting in any Cortex-M implementation (might not be required in every
+ * Cortex-M processor).
+ */
+. = ALIGN( 1 << LOG2CEIL(4 * (16 + CONFIG_NUM_IRQS)) );
+#endif
 
 KEEP(*(.vector_relay_table))
 KEEP(*(".vector_relay_table.*"))

--- a/arch/arm/core/aarch32/vector_table.ld
+++ b/arch/arm/core/aarch32/vector_table.ld
@@ -1,8 +1,32 @@
 /*
- * Copyright (c) 2019 Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#if defined(CONFIG_CPU_CORTEX_M_HAS_VTOR)
+/*
+ * In an MCU with VTOR, the VTOR.TBLOFF is set to the start address of the
+ * exc_vector_table (i.e. _vector_start) during initialization. Therefore,
+ * exc_vector_table must respect the alignment requirements of VTOR.TBLOFF
+ * described below.
+ */
+
+/* VTOR bits 0:6 are reserved (RES0). This requires that the base address
+ * of the vector table is 32-word aligned.
+ */
+. = ALIGN( 1 << LOG2CEIL(4 * 32) );
+
+/* When setting TBLOFF in VTOR we must align the offset to the number of
+ * exception entries in the vector table. The minimum alignment of 32 words
+ * is sufficient for the 16 ARM Core exceptions and up to 16 HW interrupts.
+ * For more than 16 HW interrupts, we adjust the alignment by rounding up
+ * to the next power of two; this restriction guarantees a functional VTOR
+ * setting in any Cortex-M implementation (might not be required in every
+ * Cortex-M processor).
+ */
+. = ALIGN( 1 << LOG2CEIL(4 * (16 + CONFIG_NUM_IRQS)) );
+#endif
 
 _vector_start = .;
 KEEP(*(.exc_vector_table))


### PR DESCRIPTION
Enforce VTOR table offset alignment requirements on Cortex-M
vector table start address.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

In Cortex-M boot, we have always been setting VTOR to `_vector_start `(or `relay_vector_table `if we want to forward interrupts) as follows:
```
static inline void relocate_vector_table(void)
{
	SCB->VTOR = VECTOR_ADDRESS & SCB_VTOR_TBLOFF_Msk;
	__DSB();
	__ISB();
}
```
Therefore, `_vector_start `is "masked" with SCB_VTOR_TBLOFF_Msk, clearing the 7 least-significant bits, thus, enforcing 32-word alignment requirement for vector starting address. However, we do not ensure that the linker aligns _vector_start accordingly (we rely on the fact that the vector table section is almost-always placed in the beginning of the image ROM, which respects the required alignment, but this is not always guaranteed!). 

In addition to that, certain Cortex-M implementations require that the VTOR.TBLOFF field is further aligned with the number of exceptions (ARM core + NVIC HW irqs), meaning that we might need to align with powers-of-two larger than 32-words.

This PR explicitly enforces the required alignments.
- the 32-word alignment is always required
- the alignment with the size of the exception table is not always required (is needed at least for nRF SoCs and for Baseline Cortex-M, but for most non-Nordic, Atmel Mainline SoCs it seems to not be needed). In that case the cost would be some extra padding before vector_start, if this is not already placed by the linker in a convenient address (already aligned). This does not seem to happen now for any SoC, but it theory it can happen.

This PR is required for #26276, which enables to use IRQ forwarding on Mainline Cortex-M; in that use-case we need to have 2 vector tables (one that is just relaying and the "real" one) and they both need to be aligned properly.