### PR TITLE
tests: gen_isr_table: Disable gpio on lpcxpresso54114

### DIFF
--- a/tests/kernel/gen_isr_table/boards/lpcxpresso54114_m4.conf
+++ b/tests/kernel/gen_isr_table/boards/lpcxpresso54114_m4.conf
@@ -1,0 +1,4 @@
+# Copyright 2020 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_GPIO=n


### PR DESCRIPTION
One of the interrupts used by the gen_isr_table test conflicts with a
gpio interrupt on the lpc54114 soc, so disable gpio for this test on the
corresponding board. We do this for only the m4 core because the test is
not supported on the m0 core.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #23243