### PR TITLE
tests: pwm_api: Use smaller pwm period cycles on kw41z-based boards

### DIFF
--- a/tests/drivers/pwm/pwm_api/src/test_pwm.c
+++ b/tests/drivers/pwm/pwm_api/src/test_pwm.c
@@ -44,7 +44,8 @@
 #error "Define a PWM device"
 #endif
 
-#if defined(CONFIG_BOARD_COLIBRI_IMX7D_M4) || defined(CONFIG_SOC_MK64F12)
+#if defined(CONFIG_BOARD_COLIBRI_IMX7D_M4) || defined(CONFIG_SOC_MK64F12) || \
+	defined(CONFIG_SOC_MKW41Z4)
 #define DEFAULT_PERIOD_CYCLE 1024
 #define DEFAULT_PULSE_CYCLE 512
 #define DEFAULT_PERIOD_USEC 2000


### PR DESCRIPTION
The mcux pwm drivers use period cycles as a divisor to calculate the pwm
frequency in hertz. This operation can underflow easily with large
values of period cycles relative to the pwm clock source, causing the
driver to return an error code and the pwm_api test to fail.

Updates the test to use the smaller set of period and pulse cycles on
kw41z-based boards, fixing the test for the frdm_kw41z board.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #26664