### PR TITLE
doc: Replace shippable badge with buildkite badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,9 @@
 
    <a href="https://bestpractices.coreinfrastructure.org/projects/74"><img
    src="https://bestpractices.coreinfrastructure.org/projects/74/badge"></a>
+   <a href="https://buildkite.com/zephyr/zephyr">
    <img
-   src="https://api.shippable.com/projects/58ffb2b8baa5e307002e1d79/badge?branch=master">
+   src="https://badge.buildkite.com/f5bd0dc88306cee17c9b38e78d11bb74a6291e3f40e7d13f31.svg?branch=master"></a>
 
 
 The Zephyr Project is a scalable real-time operating system (RTOS) supporting


### PR DESCRIPTION
Now that we have finished migrating CI from shippable to buildkite,
update the status badge on README.rst.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>