### PR TITLE
boards: arm: nucleo_f767zi: Add flash partitions

### DIFF
--- a/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
@@ -17,6 +17,7 @@
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 		zephyr,dtcm = &dtcm;
 		zephyr,can-primary = &can1;
 	};
@@ -111,4 +112,60 @@
 
 &rng {
 	status = "okay";
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/*
+		 * The two sectors 0-1 (32+32 kbytes) are reserved for
+		 * the bootloader.
+		 */
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x0 0x00010000>;
+			read-only;
+		};
+
+		/*
+		 * The flash starting at offset 0x10000 and ending at
+		 * offset 0x1ffff is reserved for use by the application.
+		 * This represents sectors 2-3 (32+32 kbytes)
+		 */
+		storage_partition: partition@10000 {
+			label = "storage";
+			reg = <0x00010000 0x00010000>;
+		};
+
+		/*
+		 * Sector 4 (128 kbytes) unallocated.
+		 */
+
+		/*
+		 * Allocated 3 (256k x 3) sectors for image-0. Sectors 5-7.
+		 */
+		slot0_partition: partition@40000 {
+			label = "image-0";
+			reg = <0x00040000 0x000C0000>;
+		};
+
+		/*
+		 * Allocated 3 (256k x 3) sectors for image-1. Sectors 8-10.
+		 */
+		slot1_partition: partition@100000 {
+			label = "image-1";
+			reg = <0x00100000 0x000C0000>;
+		};
+
+		/*
+		 * Allocated 1 (256k) sector for image-scratch. Sector 11.
+		 */
+		scratch_partition: partition@1C0000 {
+			label = "image-scratch";
+			reg = <0x001C0000 0x00040000>;
+		};
+	};
 };

--- a/boards/arm/nucleo_f767zi/nucleo_f767zi.yaml
+++ b/boards/arm/nucleo_f767zi/nucleo_f767zi.yaml
@@ -19,6 +19,7 @@ supported:
   - i2c
   - pwm
   - spi
+  - nvs
   - watchdog
   - counter
   - can


### PR DESCRIPTION
Define flash layout to allow use of MCUboot and storage.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>