### PR TITLE
NXP: Enable eDMA on KE1xF SoC series

### DIFF
--- a/boards/arm/twr_ke18f/twr_ke18f.dts
+++ b/boards/arm/twr_ke18f/twr_ke18f.dts
@@ -233,6 +233,10 @@
 	status = "okay";
 };
 
+&edma {
+	status = "okay";
+};
+
 &flash0 {
 	/*
 	 * For more information, see:

--- a/boards/arm/twr_ke18f/twr_ke18f.yaml
+++ b/boards/arm/twr_ke18f/twr_ke18f.yaml
@@ -13,6 +13,7 @@ supported:
   - can
   - counter
   - dac
+  - dma
   - i2c
   - pwm
   - spi

--- a/drivers/dma/Kconfig.mcux_edma
+++ b/drivers/dma/Kconfig.mcux_edma
@@ -20,10 +20,10 @@ config DMA_TCD_QUEUE_SIZE
 
 config DMA_MCUX_TEST_SLOT_START
 	int "test slot start num"
-	depends on SOC_SERIES_KINETIS_K6X
-	default 58
+	depends on (SOC_SERIES_KINETIS_K6X || SOC_SERIES_KINETIS_KE1XF)
+	default 58 if SOC_SERIES_KINETIS_K6X
+	default 60 if SOC_SERIES_KINETIS_KE1XF
 	help
 	  test slot start num
-
 
 endif # DMA_MCUX_EDMA

--- a/drivers/dma/Kconfig.mcux_edma
+++ b/drivers/dma/Kconfig.mcux_edma
@@ -6,7 +6,7 @@
 config DMA_MCUX_EDMA
 	bool "Enable MCUX DMA driver"
 	depends on HAS_MCUX_EDMA
-	select NOCACHE_MEMORY if HAS_MCUX_CACHE
+	imply NOCACHE_MEMORY if HAS_MCUX_CACHE
 	help
 	  DMA driver for MCUX series SoCs.
 

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -87,6 +87,22 @@
 	};
 
 	soc {
+		edma: dma-controller@40008000 {
+			compatible = "nxp,mcux-edma";
+			dma-channels = <16>;
+			dma-requests = <64>;
+			nxp,mem2mem;
+			reg = <0x40008000 0x1000>, <0x40021000 0x1000>;
+			interrupts = <0 0>, <1 0>, <2 0>, <3 0>,
+				     <4 0>, <5 0>, <6 0>, <7 0>,
+				     <8 0>, <9 0>, <10 0>, <11 0>,
+				     <12 0>, <13 0>, <14 0>, <15 0>,
+				     <16 0>;
+			status = "disabled";
+			label = "EDMA";
+			#dma-cells = <2>;
+		};
+
 		mpu: mpu@4000d000 {
 			compatible = "nxp,kinetis-mpu";
 			reg = <0x4000d000 0x1000>;

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.series
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.series
@@ -85,6 +85,10 @@ config DAC_MCUX_DAC32
 	default y
 	depends on DAC
 
+config DMA_MCUX_EDMA
+	default y
+	depends on DMA
+
 source "soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.mke*"
 
 endif # SOC_SERIES_KINETIS_KE1XF

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.series
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.series
@@ -27,5 +27,6 @@ config SOC_SERIES_KINETIS_KE1XF
 	select HAS_MCUX_FTM
 	select HAS_MCUX_LPTMR
 	select HAS_MCUX_DAC32
+	select HAS_MCUX_EDMA
 	help
 	  Enable support for Kinetis KE1xF MCU series


### PR DESCRIPTION
This series of commits enables eDMA on the NXP KE1xF SoC series and on the NXP TWR-KE18F development board.