### PR TITLE
doc: make device pm APIs show in doxygen docs

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1966,6 +1966,7 @@ PREDEFINED             = "CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT" \
                          "CONFIG_BT_SMP" \
                          "CONFIG_BT_SMP_APP_PAIRING_ACCEPT" \
                          "CONFIG_DEVICE_POWER_MANAGEMENT" \
+                         "CONFIG_DEVICE_IDLE_PM" \
                          "CONFIG_ERRNO" \
                          "CONFIG_EXECUTION_BENCHMARKING" \
                          "CONFIG_FLASH_PAGE_LAYOUT" \


### PR DESCRIPTION
Those were not being processed due to Kconfig only exposing the noop
functions.