### PR TITLE
drivers: display: fix a typo in the ili9340 driver

### DIFF
--- a/drivers/display/display_ili9340.c
+++ b/drivers/display/display_ili9340.c
@@ -146,8 +146,8 @@ static int ili9340_write(const struct device *dev, const uint16_t x,
 	uint16_t write_h;
 
 	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller then width");
-	__ASSERT((desc->pitch * ILI9340_RGB_SIZE * desc->height) <= desc->bu_size,
-			"Input buffer to small");
+	__ASSERT((desc->pitch * ILI9340_RGB_SIZE * desc->height)
+		 <= desc->buf_size, "Input buffer to small");
 
 	LOG_DBG("Writing %dx%d (w,h) @ %dx%d (x,y)", desc->width, desc->height,
 			x, y);


### PR DESCRIPTION
The typo is inside an __ASSERT which is why the driver is normally OK.

Signed-off-by: Michael Hope <mlhx@google.com>