### PR TITLE
boards: arm: add OpenOCD flash and debug support for the itsybitsy_m4

### DIFF
--- a/boards/arm/adafruit_itsybitsy_m4_express/board.cmake
+++ b/boards/arm/adafruit_itsybitsy_m4_express/board.cmake
@@ -2,3 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 include(${ZEPHYR_BASE}/boards/common/bossac.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/adafruit_itsybitsy_m4_express/doc/index.rst
+++ b/boards/arm/adafruit_itsybitsy_m4_express/doc/index.rst
@@ -120,6 +120,33 @@ Flashing
 
    You should see "Hello World! arm" in your terminal.
 
+Debugging
+=========
+
+In addition to the built-in bootloader, the ItsyBitsy can be flashed and
+debugged using a SWD probe such as the Segger J-Link.
+
+#. Connect the board to the probe by connecting the :code:`SWCLK`,
+   :code:`SWDIO`, :code:`RESET`, :code:`GND`, and :code:`3V3` pins on the
+   ItsyBitsy to the :code:`SWCLK`, :code:`SWDIO`, :code:`RESET`, :code:`GND`,
+   and :code:`VTref` pins on the `J-Link`_.
+
+#. Flash the image:
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: adafruit_itsybitsy_m4_express
+      :goals: flash -r openocd
+      :compact:
+
+#. Start debugging:
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: adafruit_itsybitsy_m4_express
+      :goals: debug
+      :compact:
+
 References
 **********
 
@@ -133,3 +160,6 @@ References
 
 .. _schematic:
     https://learn.adafruit.com/introducing-adafruit-itsybitsy-m4/downloads
+
+.. _J-Link:
+    https://www.segger.com/products/debug-probes/j-link/technology/interface-description/

--- a/boards/arm/adafruit_itsybitsy_m4_express/support/openocd.cfg
+++ b/boards/arm/adafruit_itsybitsy_m4_express/support/openocd.cfg
@@ -1,0 +1,21 @@
+source [find interface/jlink.cfg]
+
+transport select swd
+
+set CHIPNAME atsamd51g19a
+source [find target/atsame5x.cfg]
+
+# TODO(http://openocd.zylin.com/#/c/5706/): lower the clock speed to workaround
+# an erase timeout.
+adapter_khz 500
+reset_config srst_only
+
+$_TARGETNAME configure -event gdb-attach {
+        echo "Debugger attaching: halting execution"
+        reset halt
+}
+
+$_TARGETNAME configure -event gdb-detach {
+        echo "Debugger detaching: resuming execution"
+        resume
+}


### PR DESCRIPTION
The Itsybitsy exposes the SWD pins on an unpopulated header on the end
of the board.  Add a OpenOCD config and document how to use it.

Signed-off-by: Michael Hope <mlhx@google.com>