### PR TITLE
gui: lvgl: Set actual display size when using static allocated rendering buffers

### DIFF
--- a/drivers/display/display_dummy.c
+++ b/drivers/display/display_dummy.c
@@ -29,6 +29,22 @@ static int dummy_display_write(const struct device *dev, const uint16_t x,
 			       const struct display_buffer_descriptor *desc,
 			       const void *buf)
 {
+	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller then width");
+	__ASSERT(desc->pitch <= CONFIG_DUMMY_DISPLAY_X_RES,
+		"Pitch in descriptor is larger than screen size");
+	__ASSERT(desc->height <= CONFIG_DUMMY_DISPLAY_Y_RES,
+		"Height in descriptor is larger than screen size");
+	__ASSERT(x + desc->pitch <= CONFIG_DUMMY_DISPLAY_X_RES,
+		 "Writing outside screen boundaries in horizontal direction");
+	__ASSERT(y + desc->height <= CONFIG_DUMMY_DISPLAY_Y_RES,
+		 "Writing outside screen boundaries in vertical direction");
+
+	if (desc->width > desc->pitch ||
+	    x + desc->pitch > CONFIG_DUMMY_DISPLAY_X_RES ||
+	    y + desc->height > CONFIG_DUMMY_DISPLAY_Y_RES) {
+		return -EINVAL;
+	}
+
 	return 0;
 }
 

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -225,6 +225,20 @@ static int sdl_display_write(const struct device *dev, const uint16_t x,
 			desc->height, x, y);
 
 	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller then width");
+	__ASSERT(desc->pitch <= CONFIG_SDL_DISPLAY_X_RES,
+		"Pitch in descriptor is larger than screen size");
+	__ASSERT(desc->height <= CONFIG_SDL_DISPLAY_Y_RES,
+		"Height in descriptor is larger than screen size");
+	__ASSERT(x + desc->pitch <= CONFIG_SDL_DISPLAY_X_RES,
+		 "Writing outside screen boundaries in horizontal direction");
+	__ASSERT(y + desc->height <= CONFIG_SDL_DISPLAY_Y_RES,
+		 "Writing outside screen boundaries in vertical direction");
+
+	if (desc->width > desc->pitch ||
+	    x + desc->pitch > CONFIG_SDL_DISPLAY_X_RES ||
+	    y + desc->height > CONFIG_SDL_DISPLAY_Y_RES) {
+		return -EINVAL;
+	}
 
 	if (disp_data->current_pixel_format == PIXEL_FORMAT_ARGB_8888) {
 		sdl_display_write_argb8888(disp_data->buf, desc, buf);


### PR DESCRIPTION
Set actual display size, obtained via the display driver, when using static allocated rendering buffers.
If the actual screen size is not set an out-of-bound write could occur in case the maximum resolution settings
for LVGL are larger than the actual screen resolution.