### PR TITLE
tests/nvs: Enable test suite with 0x00 erase value

### DIFF
--- a/tests/subsys/fs/nvs/testcase.yaml
+++ b/tests/subsys/fs/nvs/testcase.yaml
@@ -4,4 +4,3 @@ tests:
   filesystem.nvs_0x00:
     extra_args: DTC_OVERLAY_FILE=boards/qemu_x86_ev_0x00.overlay
     platform_whitelist: qemu_x86
-    build_only: true


### PR DESCRIPTION
The NVS tests have been disabled here with commit
 tests: nvs: Disable running the 0x00 test suite
 (22be0d8fd5902da11c9bf55a44012abc7c2cf1c1)
due to problems with flash_simulator.

With introduction of below fixes:
 drivers/flash/flash_simulator: Fix flash_sim_write
 (bec0c7f279d818cd623e597438059863c4d43353)
 drivers/flash/fash_simulator: Fix initialization for non-posix
 (849a5432dfb942339e2fc3660022f450d11397cb)

the tests can be enabled back.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>