### PR TITLE
doc: release: add note for SW_VECTOR_RELAY feature in Mainline Cortex-M

### DIFF
--- a/doc/releases/release-notes-2.4.rst
+++ b/doc/releases/release-notes-2.4.rst
@@ -74,6 +74,9 @@ Architectures
 
 * ARM:
 
+  * Interrupt vector relaying feature support is extended to Cortex-M Mainline
+    architecture variants
+
 
 * POSIX:
 


### PR DESCRIPTION
Add a note in 2.4 release notes regarding SW_VECTOR_RELAY
feature, now supported also in Mainline Cortex-M architecture.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

 ~Blocked by #26276~