### PR TITLE
doc: replace lifo/fifo with LIFO/FIFO

### DIFF
--- a/doc/reference/kernel/data_passing/fifos.rst
+++ b/doc/reference/kernel/data_passing/fifos.rst
@@ -3,7 +3,7 @@
 FIFOs
 #####
 
-A :dfn:`fifo` is a kernel object that implements a traditional
+A :dfn:`FIFO` is a kernel object that implements a traditional
 first in, first out (FIFO) queue, allowing threads and ISRs
 to add and remove data items of any size.
 
@@ -14,15 +14,15 @@ to add and remove data items of any size.
 Concepts
 ********
 
-Any number of fifos can be defined. Each fifo is referenced
+Any number of FIFOs can be defined. Each FIFO is referenced
 by its memory address.
 
-A fifo has the following key properties:
+A FIFO has the following key properties:
 
 * A **queue** of data items that have been added but not yet removed.
   The queue is implemented as a simple linked list.
 
-A fifo must be initialized before it can be used. This sets its queue to empty.
+A FIFO must be initialized before it can be used. This sets its queue to empty.
 
 FIFO data items must be aligned on a word boundary, as the kernel reserves
 the first word of an item for use as a pointer to the next data item in
@@ -32,26 +32,26 @@ reserved space requirements for data items if they are added with
 :cpp:func:`k_fifo_alloc_put()`, instead additional memory is temporarily
 allocated from the calling thread's resource pool.
 
-A data item may be **added** to a fifo by a thread or an ISR.
+A data item may be **added** to a FIFO by a thread or an ISR.
 The item is given directly to a waiting thread, if one exists;
-otherwise the item is added to the fifo's queue.
+otherwise the item is added to the FIFO's queue.
 There is no limit to the number of items that may be queued.
 
-A data item may be **removed** from a fifo by a thread. If the fifo's queue
+A data item may be **removed** from a FIF by a thread. If the FIFO's queue
 is empty a thread may choose to wait for a data item to be given.
-Any number of threads may wait on an empty fifo simultaneously.
+Any number of threads may wait on an empty FIFO simultaneously.
 When a data item is added, it is given to the highest priority thread
 that has waited longest.
 
 .. note::
-    The kernel does allow an ISR to remove an item from a fifo, however
-    the ISR must not attempt to wait if the fifo is empty.
+    The kernel does allow an ISR to remove an item from a FIFO, however
+    the ISR must not attempt to wait if the FIFO is empty.
 
-If desired, **multiple data items** can be added to a fifo in a single operation
+If desired, **multiple data items** can be added to a FIFO in a single operation
 if they are chained together into a singly-linked list. This capability can be
-useful if multiple writers are adding sets of related data items to the fifo,
+useful if multiple writers are adding sets of related data items to the FIFO,
 as it ensures the data items in each set are not interleaved with other data
-items. Adding multiple data items to a fifo is also more efficient than adding
+items. Adding multiple data items to a FIFO is also more efficient than adding
 them one at a time, and can be used to guarantee that anyone who removes
 the first data item in a set will be able to remove the remaining data items
 without waiting.
@@ -62,10 +62,10 @@ Implementation
 Defining a FIFO
 ===============
 
-A fifo is defined using a variable of type :c:type:`struct k_fifo`.
+A FIFO is defined using a variable of type :c:type:`struct k_fifo`.
 It must then be initialized by calling :cpp:func:`k_fifo_init()`.
 
-The following code defines and initializes an empty fifo.
+The following code defines and initializes an empty FIFO.
 
 .. code-block:: c
 
@@ -73,7 +73,7 @@ The following code defines and initializes an empty fifo.
 
     k_fifo_init(&my_fifo);
 
-Alternatively, an empty fifo can be defined and initialized at compile time
+Alternatively, an empty FIFO can be defined and initialized at compile time
 by calling :c:macro:`K_FIFO_DEFINE`.
 
 The following code has the same effect as the code segment above.
@@ -85,15 +85,15 @@ The following code has the same effect as the code segment above.
 Writing to a FIFO
 =================
 
-A data item is added to a fifo by calling :cpp:func:`k_fifo_put()`.
+A data item is added to a FIFO by calling :cpp:func:`k_fifo_put()`.
 
-The following code builds on the example above, and uses the fifo
+The following code builds on the example above, and uses the FIFO
 to send data to one or more consumer threads.
 
 .. code-block:: c
 
     struct data_item_t {
-        void *fifo_reserved;   /* 1st word reserved for use by fifo */
+        void *fifo_reserved;   /* 1st word reserved for use by FIFO */
         ...
     };
 
@@ -112,10 +112,10 @@ to send data to one or more consumer threads.
         }
     }
 
-Additionally, a singly-linked list of data items can be added to a fifo
+Additionally, a singly-linked list of data items can be added to a FIFO
 by calling :cpp:func:`k_fifo_put_list()` or :cpp:func:`k_fifo_put_slist()`.
 
-Finally, a data item can be added to a fifo with :cpp:func:`k_fifo_alloc_put()`.
+Finally, a data item can be added to a FIFO with :cpp:func:`k_fifo_alloc_put()`.
 With this API, there is no need to reserve space for the kernel's use in
 the data item, instead additional memory will be allocated from the calling
 thread's resource pool until the item is read.
@@ -123,9 +123,9 @@ thread's resource pool until the item is read.
 Reading from a FIFO
 ===================
 
-A data item is removed from a fifo by calling :cpp:func:`k_fifo_get()`.
+A data item is removed from a FIFO by calling :cpp:func:`k_fifo_get()`.
 
-The following code builds on the example above, and uses the fifo
+The following code builds on the example above, and uses the FIFO
 to obtain data items from a producer thread,
 which are then processed in some manner.
 
@@ -138,7 +138,7 @@ which are then processed in some manner.
         while (1) {
             rx_data = k_fifo_get(&my_fifo, K_FOREVER);
 
-            /* process fifo data item */
+            /* process FIFO data item */
             ...
         }
     }
@@ -146,7 +146,7 @@ which are then processed in some manner.
 Suggested Uses
 **************
 
-Use a fifo to asynchronously transfer data items of arbitrary size
+Use a FIFO to asynchronously transfer data items of arbitrary size
 in a "first in, first out" manner.
 
 Configuration Options

--- a/doc/reference/kernel/data_passing/lifos.rst
+++ b/doc/reference/kernel/data_passing/lifos.rst
@@ -3,7 +3,7 @@
 LIFOs
 #####
 
-A :dfn:`lifo` is a kernel object that implements a traditional
+A :dfn:`LIFO` is a kernel object that implements a traditional
 last in, first out (LIFO) queue, allowing threads and ISRs
 to add and remove data items of any size.
 
@@ -14,15 +14,15 @@ to add and remove data items of any size.
 Concepts
 ********
 
-Any number of lifos can be defined. Each lifo is referenced
+Any number of LIFOs can be defined. Each LIFO is referenced
 by its memory address.
 
-A lifo has the following key properties:
+A LIFO has the following key properties:
 
 * A **queue** of data items that have been added but not yet removed.
   The queue is implemented as a simple linked list.
 
-A lifo must be initialized before it can be used. This sets its queue to empty.
+A LIFO must be initialized before it can be used. This sets its queue to empty.
 
 LIFO data items must be aligned on a word boundary, as the kernel reserves
 the first word of an item for use as a pointer to the next data item in the
@@ -32,20 +32,20 @@ space requirements for data items if they are added with
 :cpp:func:`k_lifo_alloc_put()`, instead additional memory is temporarily
 allocated from the calling thread's resource pool.
 
-A data item may be **added** to a lifo by a thread or an ISR.
+A data item may be **added** to a LIFO by a thread or an ISR.
 The item is given directly to a waiting thread, if one exists;
-otherwise the item is added to the lifo's queue.
+otherwise the item is added to the LIFO's queue.
 There is no limit to the number of items that may be queued.
 
-A data item may be **removed** from a lifo by a thread. If the lifo's queue
+A data item may be **removed** from a LIFO by a thread. If the LIFO's queue
 is empty a thread may choose to wait for a data item to be given.
-Any number of threads may wait on an empty lifo simultaneously.
+Any number of threads may wait on an empty LIFO simultaneously.
 When a data item is added, it is given to the highest priority thread
 that has waited longest.
 
 .. note::
-    The kernel does allow an ISR to remove an item from a lifo, however
-    the ISR must not attempt to wait if the lifo is empty.
+    The kernel does allow an ISR to remove an item from a LIFO, however
+    the ISR must not attempt to wait if the LIFO is empty.
 
 Implementation
 **************
@@ -53,10 +53,10 @@ Implementation
 Defining a LIFO
 ===============
 
-A lifo is defined using a variable of type :c:type:`struct k_lifo`.
+A LIFO is defined using a variable of type :c:type:`struct k_lifo`.
 It must then be initialized by calling :cpp:func:`k_lifo_init()`.
 
-The following defines and initializes an empty lifo.
+The following defines and initializes an empty LIFO.
 
 .. code-block:: c
 
@@ -64,7 +64,7 @@ The following defines and initializes an empty lifo.
 
     k_lifo_init(&my_lifo);
 
-Alternatively, an empty lifo can be defined and initialized at compile time
+Alternatively, an empty LIFO can be defined and initialized at compile time
 by calling :c:macro:`K_LIFO_DEFINE`.
 
 The following code has the same effect as the code segment above.
@@ -76,15 +76,15 @@ The following code has the same effect as the code segment above.
 Writing to a LIFO
 =================
 
-A data item is added to a lifo by calling :cpp:func:`k_lifo_put()`.
+A data item is added to a LIFO by calling :cpp:func:`k_lifo_put()`.
 
-The following code builds on the example above, and uses the lifo
+The following code builds on the example above, and uses the LIFO
 to send data to one or more consumer threads.
 
 .. code-block:: c
 
     struct data_item_t {
-        void *lifo_reserved;   /* 1st word reserved for use by lifo */
+        void *LIFO_reserved;   /* 1st word reserved for use by LIFO */
         ...
     };
 
@@ -103,7 +103,7 @@ to send data to one or more consumer threads.
         }
     }
 
-A data item can be added to a lifo with :cpp:func:`k_lifo_alloc_put()`.
+A data item can be added to a LIFO with :cpp:func:`k_lifo_alloc_put()`.
 With this API, there is no need to reserve space for the kernel's use in
 the data item, instead additional memory will be allocated from the calling
 thread's resource pool until the item is read.
@@ -111,9 +111,9 @@ thread's resource pool until the item is read.
 Reading from a LIFO
 ===================
 
-A data item is removed from a lifo by calling :cpp:func:`k_lifo_get()`.
+A data item is removed from a LIFO by calling :cpp:func:`k_lifo_get()`.
 
-The following code builds on the example above, and uses the lifo
+The following code builds on the example above, and uses the LIFO
 to obtain data items from a producer thread,
 which are then processed in some manner.
 
@@ -126,7 +126,7 @@ which are then processed in some manner.
         while (1) {
             rx_data = k_lifo_get(&my_lifo, K_FOREVER);
 
-            /* process lifo data item */
+            /* process LIFO data item */
             ...
         }
     }
@@ -134,7 +134,7 @@ which are then processed in some manner.
 Suggested Uses
 **************
 
-Use a lifo to asynchronously transfer data items of arbitrary size
+Use a LIFO to asynchronously transfer data items of arbitrary size
 in a "last in, first out" manner.
 
 Configuration Options

--- a/doc/reference/kernel/data_passing/stacks.rst
+++ b/doc/reference/kernel/data_passing/stacks.rst
@@ -31,7 +31,7 @@ A stack must be initialized before it can be used. This sets its queue to empty.
 
 A data value can be **added** to a stack by a thread or an ISR.
 The value is given directly to a waiting thread, if one exists;
-otherwise the value is added to the lifo's queue.
+otherwise the value is added to the LIFO's queue.
 The kernel does *not* detect attempts to add a data value to a stack
 that has already reached its maximum quantity of queued values.
 

--- a/doc/reference/kernel/other/interrupts.rst
+++ b/doc/reference/kernel/other/interrupts.rst
@@ -192,7 +192,7 @@ The kernel supports several mechanisms for offloading interrupt-related
 processing to a thread.
 
 * An ISR can signal a helper thread to do interrupt-related processing
-  using a kernel object, such as a fifo, lifo, or semaphore.
+  using a kernel object, such as a FIFO, LIFO, or semaphore.
 
 * An ISR can instruct the system workqueue thread to execute a work item.
   (See :ref:`workqueues_v2`.)

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2848,7 +2848,7 @@ struct k_lifo {
 /**
  * @brief Get an element from a LIFO queue.
  *
- * This routine removes a data item from @a lifo in a "last in, first out"
+ * This routine removes a data item from @a LIFO in a "last in, first out"
  * manner. The first word of the data item is reserved for the kernel's use.
  *
  * @note Can be called by ISRs, but @a timeout must be set to K_NO_WAIT.
@@ -4861,7 +4861,7 @@ enum _poll_types_bits {
 	/* semaphore availability */
 	_POLL_TYPE_SEM_AVAILABLE,
 
-	/* queue/fifo/lifo data availability */
+	/* queue/FIFO/LIFO data availability */
 	_POLL_TYPE_DATA_AVAILABLE,
 
 	_POLL_NUM_TYPES
@@ -4880,10 +4880,10 @@ enum _poll_states_bits {
 	/* semaphore is available */
 	_POLL_STATE_SEM_AVAILABLE,
 
-	/* data is available to read on queue/fifo/lifo */
+	/* data is available to read on queue/FIFO/LIFO */
 	_POLL_STATE_DATA_AVAILABLE,
 
-	/* queue/fifo/lifo wait was cancelled */
+	/* queue/FIFO/LIFO wait was cancelled */
 	_POLL_STATE_CANCELLED,
 
 	_POLL_NUM_STATES

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -429,7 +429,7 @@ config POLL
 	  Asynchronous notification framework. Enable the k_poll() and
 	  k_poll_signal_raise() APIs.  The former can wait on multiple events
 	  concurrently, which can be either directly triggered or triggered by
-	  the availability of some kernel objects (semaphores and fifos).
+	  the availability of some kernel objects (semaphores and FIFOs).
 
 endmenu
 


### PR DESCRIPTION
Replace all occurances of lifo/fifo with LIFO/FIFO to be consistent.