### PR TITLE
Bluetooth: controller: Non-overlapping sync PDUs

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -54,9 +54,13 @@ int ull_adv_aux_reset(void);
 uint8_t const *ll_adv_aux_random_addr_get(struct ll_adv_set const *const adv,
 				       uint8_t *const addr);
 
+/* helper function to initialize event timings */
+uint32_t ull_adv_aux_evt_init(struct ll_adv_aux_set *aux);
+
 /* helper function to start auxiliary advertising */
 uint32_t ull_adv_aux_start(struct ll_adv_aux_set *aux, uint32_t ticks_anchor,
-			uint32_t volatile *ret_cb);
+			   uint32_t ticks_slot_overhead,
+			   uint32_t volatile *ret_cb);
 
 /* helper function to stop auxiliary advertising */
 uint8_t ull_adv_aux_stop(struct ll_adv_aux_set *aux);


### PR DESCRIPTION
Updated implementation to schedule non-overlapping
ADV_EXT_IND, AUX_ADV_IND, and AUX_SYNC_IND PDUs.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>