### PR TITLE
logging: always add ids_print() to prefix even when using net backend

### DIFF
--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -500,12 +500,12 @@ static uint32_t prefix_print(const struct log_output *log_output,
 			log_output->control_block->hostname ?
 			log_output->control_block->hostname :
 			"zephyr");
-
 	} else {
 		color_prefix(log_output, colors_on, level);
-		length += ids_print(log_output, level_on, func_on,
-				    domain_id, source_id, level);
 	}
+
+	length += ids_print(log_output, level_on, func_on,
+			domain_id, source_id, level);
 
 	return length;
 }


### PR DESCRIPTION
    when using net log backend,
    adding severity and function name to log message

Signed-off-by: David D <a8961713@gmail.com>