### PR TITLE
Bluetooth: controller: Enforce support for Read RSSI command in Kconfig

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -62,6 +62,7 @@ config BT_CTLR_TIFS_HW_SUPPORT
 
 config BT_CTLR
 	bool "Bluetooth Controller"
+	select BT_CTLR_CONN_RSSI if BT_CONN && BT_HCI_RAW
 	help
 	  Enables support for SoC native controller implementations.
 
@@ -801,7 +802,6 @@ config BT_CTLR_TX_RETRY_DISABLE
 
 config BT_CTLR_CONN_RSSI
 	bool "Connection RSSI"
-	default y if BT_HCI_RAW
 	help
 	  Enable connection RSSI measurement.
 


### PR DESCRIPTION
Enforce support for Read RSSI command if BT_CONN and BT_HCI_RAW are
selected. According to the Bluetooth specification, support for the
Read RSSI command is mandatory if the Connection State is
supported. BT_HCI_RAW indicates that the controller is an
independently qualifiable module and not part of a combined
host/controller build. This change avoids a configuration that cannot
be possibly qualified.

Signed-off-by: Wolfgang Puffitsch <wopu@demant.com>

Fixes #22873 