### PR TITLE
usb: audio: Correct typo in USB audio binding.

### DIFF
--- a/dts/bindings/usb/usb-audio-hp.yaml
+++ b/dts/bindings/usb/usb-audio-hp.yaml
@@ -107,8 +107,8 @@ properties:
     required: false
     description: Enable Bass Boost feature.
                  Currently not supported.
-  feature-loduness:
+  feature-loudness:
     type: boolean
     required: false
     description: Enable Loudness feature.
-                     Currently not supported.
+                 Currently not supported.

--- a/dts/bindings/usb/usb-audio-hs.yaml
+++ b/dts/bindings/usb/usb-audio-hs.yaml
@@ -128,11 +128,11 @@ properties:
     required: false
     description: Enable Bass Boost feature.
                  Currently not supported.
-  mic-mic-feature-loduness:
+  mic-feature-loudness:
     type: boolean
     required: false
     description: Enable Loudness feature.
-                     Currently not supported.
+                 Currently not supported.
 # headphones channel configuration options
   hp-channel-l:
     type: boolean
@@ -221,8 +221,8 @@ properties:
     required: false
     description: Enable Bass Boost feature.
                  Currently not supported.
-  hp-feature-loduness:
+  hp-feature-loudness:
     type: boolean
     required: false
     description: Enable Loudness feature.
-                     Currently not supported.
+                 Currently not supported.

--- a/dts/bindings/usb/usb-audio-mic.yaml
+++ b/dts/bindings/usb/usb-audio-mic.yaml
@@ -119,8 +119,8 @@ properties:
     required: false
     description: Enable Bass Boost feature.
                  Currently not supported.
-  feature-loduness:
+  feature-loudness:
     type: boolean
     required: false
     description: Enable Loudness feature.
-                     Currently not supported.
+                 Currently not supported.


### PR DESCRIPTION
One of the configuration options for microphone part in headset
was misspelled. This patch corrects the error.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>