### PR TITLE
net: openthread: Use different kconfig switch for shim and src

### DIFF
--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -38,6 +38,19 @@ menuconfig NET_L2_OPENTHREAD
 
 if NET_L2_OPENTHREAD
 
+choice OPENTHREAD_IMPLEMENTATION
+	prompt "OpenThread Selection"
+	help
+	  Select OpenThread to use for build. Custom OpenThread implementations
+	  can be added to the application Kconfig.
+
+config OPENTHREAD_SOURCES
+	bool "OpenThread from sources"
+	help
+	  Build Zephyrs OpenThread port from sources.
+
+endchoice
+
 config OPENTHREAD_DTLS
 	# Hidden option to enable DTLS support in OpenThread
 	bool

--- a/west.yml
+++ b/west.yml
@@ -107,7 +107,7 @@ manifest:
       revision: 170a2579dd890f78f5056f0959cdb9c9bea259a1
       path: modules/lib/loramac-node
     - name: openthread
-      revision: e3b80d6e4c8d368c856dfce774bc792ffde54cfe
+      revision: a0a7e20213aba98d18f50cd52008f9dbffd1bc5c
       path: modules/lib/openthread
     - name: segger
       revision: 6fcf61606d6012d2c44129edc033f59331e268bc


### PR DESCRIPTION
Different switch was used for build to allow including all shim body
in zephyr without the need for building openthread from this repo. This
allows developer to include custom OpenThread sources as part of the
application.
This change is needed as Thread is a subject of certification and
sources provided by zephyr may not necesairly pass certification or be
precertified. User is allowed to use certified OpenThread version
this way.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>