### PR TITLE
runners: bossa: fix support for the Arduino Due

### DIFF
--- a/scripts/west_commands/runners/bossac.py
+++ b/scripts/west_commands/runners/bossac.py
@@ -64,10 +64,13 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
         """Run bossac --help and return the output as a list of lines"""
         self.require(self.bossac)
         try:
-            self.check_output([self.bossac, '--help'])
-            return []
+            # BOSSA > 1.9.1 returns OK
+            out = self.check_output([self.bossac, '--help']).decode()
         except subprocess.CalledProcessError as ex:
-            return ex.output.decode().split('\n')
+            # BOSSA <= 1.9.1 returns an error
+            out = ex.output.decode()
+
+        return out.split('\n')
 
     def supports(self, flag):
         """Check if bossac supports a flag by searching the help"""

--- a/scripts/west_commands/tests/test_bossac.py
+++ b/scripts/west_commands/tests/test_bossac.py
@@ -69,7 +69,7 @@ def test_bossac_init(cc, req, supports, runner_config):
 
 @patch('runners.bossac.BossacBinaryRunner.supports', return_value=True)
 @patch('runners.core.BuildConfiguration._init')
-@patch('runners.core.ZephyrBinaryRunner.get_flash_address',
+@patch('runners.bossac.BossacBinaryRunner.get_flash_offset',
        return_value=None)
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
@@ -86,7 +86,7 @@ def test_bossac_create(cc, req, gfa, bcfg, supports, runner_config):
 
 @patch('runners.bossac.BossacBinaryRunner.supports', return_value=True)
 @patch('runners.core.BuildConfiguration._init')
-@patch('runners.core.ZephyrBinaryRunner.get_flash_address',
+@patch('runners.bossac.BossacBinaryRunner.get_flash_offset',
        return_value=TEST_FLASH_ADDRESS)
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
@@ -105,7 +105,7 @@ def test_bossac_create_with_offset(cc, req, gfa, bcfg, supports,
 
 @patch('runners.bossac.BossacBinaryRunner.supports', return_value=True)
 @patch('runners.core.BuildConfiguration._init')
-@patch('runners.core.ZephyrBinaryRunner.get_flash_address',
+@patch('runners.bossac.BossacBinaryRunner.get_flash_offset',
        return_value=TEST_FLASH_ADDRESS)
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')


### PR DESCRIPTION
The bossac runner uses the absolute load address as the flash offset, where it should be the actual flash offset.  This is fine on most boards as the flash starts at address zero but fails on the Arduino Due the flash starts at address +512 KiB.

Change to use the offset.  Tested on the adafruit_trinket_m0, adafruit_itsybitsy_m4_express, and arduino_due.

Related: zephyrproject-rtos/sdk-ng#234.

Also support sniffing `--help` on the git versions of bossac.
