### PR TITLE
DT Fixes for LPC55S6x

### DIFF
--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
@@ -26,7 +26,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
-		zephyr,code-partition = &sramx;
+		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,entropy = &rng;

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
@@ -87,9 +87,9 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@10000000 {
+		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x10000000 0x00010000>;
+			reg = <0x00000000 0x00010000>;
 			read-only;
 		};
 		/*
@@ -97,21 +97,21 @@
 		 * 0x1001ffff (sectors 16-31) is reserved for use
 		 * by the application.
 		 */
-		storage_partition: partition@1001e000 {
+		storage_partition: partition@1e000 {
 			label = "storage";
-			reg = <0x1001e000 0x00002000>;
+			reg = <0x0001e000 0x00002000>;
 		};
-		slot0_partition: partition@10020000 {
+		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x10020000 0x00020000>;
+			reg = <0x00020000 0x00020000>;
 		};
-		slot1_partition: partition@10040000 {
+		slot1_partition: partition@40000 {
 			label = "image-1";
-			reg = <0x10040000 0x00020000>;
+			reg = <0x00040000 0x00020000>;
 		};
-		scratch_partition: partition@10060000 {
+		scratch_partition: partition@60000 {
 			label = "image-scratch";
-			reg = <0x10060000 0x0003d800>;
+			reg = <0x00060000 0x0003d800>;
 		};
 	};
 };


### PR DESCRIPTION
Fix two problems with the LPC55S6x device tree:

1. The flash partitions were addresses instead of offsets, which was adding the base address of flash twice.
2. The code partition was set to RAM, not one of the flash partitions, which resulted in the code being nonsensically linked.