### PR TITLE
bluetooth: gatt: Fix storing subscriptions

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -992,9 +992,9 @@ static void ccc_delayed_store(struct k_work *work)
 		}
 
 		if (bt_addr_le_is_bonded(conn->id, &conn->le.dst)) {
+			ccc_store->conn_list[i] = NULL;
 			bt_gatt_store_ccc(conn->id, &conn->le.dst);
 			bt_conn_unref(conn);
-			ccc_store->conn_list[i] = NULL;
 		}
 	}
 }


### PR DESCRIPTION
Change fixes storing subscriptions in settings. CCC write can interrupt the ccc_delayed_store. Without the change, new CCC was not stored in non-volatile memory and the work that stored CCC was not resubmitted. That resulted in lost subscription after reboot.

This fixes: #26862