### PR TITLE
Bluetooth: host: Add bond_deleted callback

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -1280,6 +1280,16 @@ struct bt_conn_auth_cb {
 	 */
 	void (*pairing_failed)(struct bt_conn *conn,
 			       enum bt_security_err reason);
+
+	/** @brief Notify that bond has been deleted.
+	 *
+	 *  This callback notifies the application that the bond information
+	 *  for the remote peer has been deleted
+	 *
+	 *  @param id   Which local identity had the bond.
+	 *  @param peer Remote address.
+	 */
+	void (*bond_deleted)(uint8_t id, const bt_addr_le_t *peer);
 };
 
 /** @brief Register authentication callbacks.

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2648,6 +2648,10 @@ static void unpair(uint8_t id, const bt_addr_le_t *addr)
 	}
 
 	bt_gatt_clear(id, addr);
+
+	if (bt_auth && bt_auth->bond_deleted) {
+		bt_auth->bond_deleted(id, addr);
+	}
 }
 
 static void unpair_remote(const struct bt_bond_info *info, void *data)

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2649,9 +2649,11 @@ static void unpair(uint8_t id, const bt_addr_le_t *addr)
 
 	bt_gatt_clear(id, addr);
 
+#if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_BREDR)
 	if (bt_auth && bt_auth->bond_deleted) {
 		bt_auth->bond_deleted(id, addr);
 	}
+#endif /* defined(CONFIG_BT_SMP) || defined(CONFIG_BT_BREDR) */
 }
 
 static void unpair_remote(const struct bt_bond_info *info, void *data)

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -2032,6 +2032,14 @@ enum bt_security_err pairing_accept(
 }
 #endif /* CONFIG_BT_SMP_APP_PAIRING_ACCEPT */
 
+void bond_deleted(uint8_t id, const bt_addr_le_t *peer)
+{
+	char addr[BT_ADDR_STR_LEN];
+
+	bt_addr_le_to_str(peer, addr, sizeof(addr));
+	shell_print(ctx_shell, "Bond deleted for %s, id %u", addr, id);
+}
+
 static struct bt_conn_auth_cb auth_cb_display = {
 	.passkey_display = auth_passkey_display,
 	.passkey_entry = NULL,
@@ -2047,6 +2055,7 @@ static struct bt_conn_auth_cb auth_cb_display = {
 #if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)
 	.pairing_accept = pairing_accept,
 #endif
+	.bond_deleted = bond_deleted,
 };
 
 static struct bt_conn_auth_cb auth_cb_display_yes_no = {
@@ -2064,6 +2073,7 @@ static struct bt_conn_auth_cb auth_cb_display_yes_no = {
 #if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)
 	.pairing_accept = pairing_accept,
 #endif
+	.bond_deleted = bond_deleted,
 };
 
 static struct bt_conn_auth_cb auth_cb_input = {
@@ -2081,6 +2091,7 @@ static struct bt_conn_auth_cb auth_cb_input = {
 #if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)
 	.pairing_accept = pairing_accept,
 #endif
+	.bond_deleted = bond_deleted,
 };
 
 static struct bt_conn_auth_cb auth_cb_confirm = {
@@ -2095,6 +2106,7 @@ static struct bt_conn_auth_cb auth_cb_confirm = {
 #if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)
 	.pairing_accept = pairing_accept,
 #endif
+	.bond_deleted = bond_deleted,
 };
 
 static struct bt_conn_auth_cb auth_cb_all = {
@@ -2112,6 +2124,7 @@ static struct bt_conn_auth_cb auth_cb_all = {
 #if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)
 	.pairing_accept = pairing_accept,
 #endif
+	.bond_deleted = bond_deleted,
 };
 
 static struct bt_conn_auth_cb auth_cb_oob = {
@@ -2129,6 +2142,7 @@ static struct bt_conn_auth_cb auth_cb_oob = {
 #if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)
 	.pairing_accept = pairing_accept,
 #endif
+	.bond_deleted = bond_deleted,
 };
 
 

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1370,7 +1370,7 @@ static int cmd_select(const struct shell *shell, size_t argc, char *argv[])
 		return err;
 	}
 
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &addr);
+	conn = bt_conn_lookup_addr_le(selected_id, &addr);
 	if (!conn) {
 		shell_error(shell, "No matching connection found");
 		return -ENOEXEC;


### PR DESCRIPTION
Add bond_deleted callback so that the application can keep track
of when bond information is deleted in the stack.
Bond information can be deleted by the application through bt_unpair
or automatically by the stack in some cases, e.g when
CONFIG_BT_KEYS_OVERWRITE_OLDEST is enabled and the oldest bond
is overwritten.

Fixes: #20978