### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: controller: allow multiple version requests

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -275,6 +275,7 @@ static void lp_comm_send_req(struct ull_cp_conn *conn, struct proc_ctx *ctx, u8_
 				ctx->state = LP_COMMON_STATE_WAIT_RX;
 			}
 		} else {
+			ctx->response_opcode = PDU_DATA_LLCTRL_TYPE_VERSION_IND;
 			lp_comm_complete(conn, ctx, evt, param);
 		}
 		break;

--- a/tests/bluetooth/controller/ctrl_version/src/main.c
+++ b/tests/bluetooth/controller/ctrl_version/src/main.c
@@ -248,13 +248,103 @@ void test_version_exchange_mas_rem_2(void)
 	ut_rx_q_is_empty();
 }
 
+/* +-----+                     +-------+            +-----+
+ * | UT  |                     | LL_A  |            | LT  |
+ * +-----+                     +-------+            +-----+
+ *    |                            |                   |
+ *    | Start                      |                   |
+ *    | Version Exchange Proc.     |                   |
+ *    |--------------------------->|                   |
+ *    |                            |                   |
+ *    |                            | LL_VERSION_IND    |
+ *    |                            |------------------>|
+ *    |                            |                   |
+ *    |                            |    LL_VERSION_IND |
+ *    |                            |<------------------|
+ *    |                            |                   |
+ *    |     Version Exchange Proc. |                   |
+ *    |                   Complete |                   |
+ *    |<---------------------------|                   |
+ *    | Start                      |                   |
+ *    | Version Exchange Proc.     |                   |
+ *    |--------------------------->|                   |
+ *    |                            |                   |
+ *    |     Version Exchange Proc. |                   |
+ *    |                   Complete |                   |
+ *    |<---------------------------|                   |
+ *    |                            |                   |
+ */
+void test_version_exchange_mas_loc_twice(void)
+{
+	u8_t err;
+	struct node_tx *tx;
+	struct node_rx_pdu *ntf;
+
+	struct pdu_data_llctrl_version_ind local_version_ind = {
+		.version_number = LL_VERSION_NUMBER,
+		.company_id = CONFIG_BT_CTLR_COMPANY_ID,
+		.sub_version_number = CONFIG_BT_CTLR_SUBVERSION_NUMBER,
+	};
+
+	struct pdu_data_llctrl_version_ind remote_version_ind = {
+		.version_number = 0x55,
+		.company_id = 0xABCD,
+		.sub_version_number = 0x1234,
+	};
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_MASTER);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	/* Initiate a Version Exchange Procedure */
+	err = ull_cp_version_exchange(&conn);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	/* Initiate a Version Exchange Procedure */
+	err = ull_cp_version_exchange(&conn);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_VERSION_IND, &conn, &tx, &local_version_ind);
+	lt_rx_q_is_empty(&conn);
+
+	/* Rx */
+	lt_tx(LL_VERSION_IND, &conn, &remote_version_ind);
+
+	/* Done */
+	event_done(&conn);
+
+	/* There should be one host notification */
+	ut_rx_pdu(LL_VERSION_IND, &ntf, &remote_version_ind);
+	ut_rx_q_is_empty();
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Cached values should be used, no over the air comm */
+	lt_rx_q_is_empty(&conn);
+
+	/* There should be one host notification */
+	ut_rx_pdu(LL_VERSION_IND, &ntf, &remote_version_ind);
+	ut_rx_q_is_empty();
+}
+
 void test_main(void)
 {
 	ztest_test_suite(version_exchange,
 			 ztest_unit_test_setup_teardown(test_version_exchange_mas_loc, setup, unit_test_noop),
 			 ztest_unit_test_setup_teardown(test_version_exchange_mas_loc_2, setup, unit_test_noop),
 			 ztest_unit_test_setup_teardown(test_version_exchange_mas_rem, setup, unit_test_noop),
-			 ztest_unit_test_setup_teardown(test_version_exchange_mas_rem_2, setup, unit_test_noop)
+			 ztest_unit_test_setup_teardown(test_version_exchange_mas_rem_2, setup, unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_version_exchange_mas_loc_twice, setup, unit_test_noop)
 			);
 
 	ztest_run_test_suite(version_exchange);


### PR DESCRIPTION
At the linked layer level we are only allowed to send one VERSION_IND
per connection, but the host may request version information
multiple times.
We need to ensure that we fill out data correctly in case of
multiple requests, even when we only send one VERSION_IND
over the air. We need to set the response_opcode correctly
since that is used for selecting how to decode/fill in correct data
for the host

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>