### PR TITLE
drivers: wifi: simplelink: fix typo in logged option name

### DIFF
--- a/drivers/wifi/simplelink/simplelink.c
+++ b/drivers/wifi/simplelink/simplelink.c
@@ -179,7 +179,7 @@ static int simplelink_dummy_get(sa_family_t family,
 				struct net_context **context)
 {
 
-	LOG_ERR("NET_SOCKET_OFFLOAD must be configured for this driver");
+	LOG_ERR("NET_SOCKETS_OFFLOAD must be configured for this driver");
 
 	return -1;
 }


### PR DESCRIPTION
Fix typo in logged Kconfig option name that is missing in used
configuration. This one was mostly problematic for developers wanting to
find such option in source tree using grep - NET_SOCKET_OFFLOAD was not
found in Kconfig files.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>