### PR TITLE
subsys: testsuite: fix default ztest thread priority

### DIFF
--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -33,6 +33,7 @@ config ZTEST_ASSERT_VERBOSE
 
 config ZTEST_THREAD_PRIORITY
 	int "Testing thread priority"
+	default -2 if !PREEMPT_ENABLED
 	default -1
 	help
 	  Set priority of the testing thread. Default is -1 (cooperative).


### PR DESCRIPTION
When kernel is configured to run in cooperative only mode, i.e.
CONFIG_NUM_PREEMPT_PRIORITIES=0, the ztest framwork generates
"ASSERTION FAIL" at runtime indicating invalid thread priority value.

This commit sets the default ztest thread priority to -2 when kernel is
running in cooperative only mode to ensure thread priority is in the 
allowed range.

This follows the example of [MAIN_THREAD_PRIORITY](https://github.com/zephyrproject-rtos/zephyr/blob/568211738d30ec36aa3de26e0c8434b0f37127d7/kernel/Kconfig#L77) Kconfig symbol.