### PR TITLE
doc: add IDs to some sections

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -8,6 +8,8 @@ documentation on your local system using the same documentation sources
 as we use to create the online documentation found at
 https://docs.zephyrproject.org
 
+.. _documentation-overview:
+
 Documentation overview
 **********************
 
@@ -44,6 +46,8 @@ The reStructuredText files are processed by the Sphinx documentation system,
 and make use of the breathe extension for including the doxygen-generated API
 material.  Additional tools are required to generate the
 documentation locally, as described in the following sections.
+
+.. _documentation-processors:
 
 Installing the documentation processors
 ***************************************

--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -372,6 +372,8 @@ Basics
    Additionally, ``west`` allows you to :ref:`set a default board
    <west-building-config>`.
 
+.. _build-directory-contents:
+
 Build Directory Contents
 ========================
 

--- a/doc/guides/bluetooth/bluetooth-arch.rst
+++ b/doc/guides/bluetooth/bluetooth-arch.rst
@@ -379,6 +379,8 @@ should also be enabled.
 The API reference for Mesh can be found in the
 :ref:`Mesh API reference section <bluetooth_mesh>`.
 
+.. _bluetooth-persistent-storage:
+
 Persistent storage
 ==================
 


### PR DESCRIPTION
Add documentation IDs to some sections to be able
to directly link to them.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>