### PR TITLE
arch: arc: skip to raise ici int when it's already raised

### DIFF
--- a/arch/arc/core/arc_connect.c
+++ b/arch/arc/core/arc_connect.c
@@ -26,8 +26,17 @@ static struct k_spinlock arc_connect_spinlock;
 /* Generate an inter-core interrupt to the target core */
 void z_arc_connect_ici_generate(uint32_t core)
 {
+	uint32_t ret = 0;
+
 	LOCKED(&arc_connect_spinlock) {
-		z_arc_connect_cmd(ARC_CONNECT_CMD_INTRPT_GENERATE_IRQ, core);
+		z_arc_connect_cmd(ARC_CONNECT_CMD_INTRPT_READ_STATUS, core);
+		ret = z_arc_connect_cmd_readback();
+
+		/* raise an ici when there is no previous ici int */
+		if ((ret & 0x1) == 0x0) {
+			z_arc_connect_cmd(ARC_CONNECT_CMD_INTRPT_GENERATE_IRQ,
+					  core);
+		}
 	}
 }
 


### PR DESCRIPTION
before raising ici int, check whether there is already
one. if yes, skip to raise; if no, raise the ici int

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>