### PR TITLE
drivers: flash: stm32wb: disable Page Erase at end of erase_page()

### DIFF
--- a/drivers/flash/flash_stm32wbx.c
+++ b/drivers/flash/flash_stm32wbx.c
@@ -112,7 +112,7 @@ static int erase_page(struct device *dev, uint32_t page)
 	/* Wait for the BSY bit */
 	rc = flash_stm32_wait_flash_idle(dev);
 
-	regs->CR &= (~FLASH_TYPEERASE_PAGES);
+	regs->CR &= ~FLASH_CR_PER;
 
 	return rc;
 }


### PR DESCRIPTION
drivers: flash: stm32wb: disable Page Erase at end of erase_page()

FLASH_TYPEERASE_PAGES is null and doesn't represent a bit in the register, thus this instruction has no effect.
It must be replaced by FLASH_CR_PER which is the bit that should be cleared.

Signed-off-by: Alexandre Bourdiol <alexandre.bourdiol@st.com>