### PR TITLE
Bluetooth: host: Add hardware error event handling

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -1344,6 +1344,11 @@ struct bt_hci_evt_cmd_status {
 	uint16_t opcode;
 } __packed;
 
+#define BT_HCI_EVT_HARDWARE_ERROR               0x10
+struct bt_hci_evt_hardware_error {
+	uint8_t  hardware_code;
+} __packed;
+
 #define BT_HCI_EVT_ROLE_CHANGE                  0x12
 struct bt_hci_evt_role_change {
 	uint8_t   status;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4270,6 +4270,15 @@ static void bt_hci_evt_read_remote_version_complete(struct net_buf *buf)
 }
 #endif /* CONFIG_BT_REMOTE_VERSION */
 
+static void hci_hardware_error(struct net_buf *buf)
+{
+	struct bt_hci_evt_hardware_error *evt;
+
+	evt = net_buf_pull_mem(buf, sizeof(*evt));
+
+	BT_ERR("Hardware error, hardware code: %d", evt->hardware_code);
+}
+
 #if defined(CONFIG_BT_SMP)
 static void le_ltk_neg_reply(uint16_t handle)
 {
@@ -5266,6 +5275,8 @@ static const struct event_handler normal_events[] = {
 		      bt_hci_evt_read_remote_version_complete,
 		      sizeof(struct bt_hci_evt_remote_version_info)),
 #endif /* CONFIG_BT_REMOTE_VERSION */
+	EVENT_HANDLER(BT_HCI_EVT_HARDWARE_ERROR, hci_hardware_error,
+		      sizeof(struct bt_hci_evt_hardware_error)),
 };
 
 static void hci_event(struct net_buf *buf)


### PR DESCRIPTION
Add handling of the HCI_Hardware_Error event to log the hardware code.
This event was unmasked in set_event_mask.

Adding this mostly to improve documentation, since it shows up as "unhandled event 0x10" now, and the 0x10 event code did not have a definition.
We could consider if we should do anything at this point.