### PR TITLE
Bluetooth: controller: Refactor sync info population

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1126,6 +1126,14 @@ uint8_t ll_adv_enable(uint8_t enable)
 						ticks_slot_aux +
 						HAL_TICKER_US_TO_TICKS(EVENT_MAFS_US);
 
+					/* Add sync_info into auxiliary PDU */
+					ret = ull_adv_aux_hdr_set_clear(adv,
+						ULL_ADV_PDU_HDR_FIELD_SYNC_INFO,
+						0, NULL);
+					if (ret) {
+						return ret;
+					}
+
 					ull_hdr_init(&sync->ull);
 
 					ret = ull_adv_sync_start(sync,

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -408,12 +408,14 @@ uint8_t ll_adv_params_set(uint16_t interval, uint8_t adv_type,
 			pri_com_hdr->ext_hdr_len = len -
 				offsetof(struct pdu_adv_com_ext_adv,
 					 ext_hdr_adi_adv_data);
-			pdu->len = len;
 		} else {
 			pri_com_hdr->ext_hdr_len = 0;
-			pdu->len = offsetof(struct pdu_adv_com_ext_adv,
-					    ext_hdr_adi_adv_data);
+			len = offsetof(struct pdu_adv_com_ext_adv,
+				       ext_hdr_adi_adv_data);
 		}
+
+		/* Set PDU length */
+		pdu->len = len;
 
 		/* Start filling primary PDU payload based on flags */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -435,20 +435,7 @@ uint8_t ll_adv_params_set(uint16_t interval, uint8_t adv_type,
 #if (CONFIG_BT_CTLR_ADV_AUX_SET > 0)
 		/* AuxPtr */
 		if (pri_hdr->aux_ptr) {
-			struct pdu_adv_aux_ptr *aux_ptr;
-
-			pri_dptr -= sizeof(struct pdu_adv_aux_ptr);
-
-			/* NOTE: Aux Offset will be set in advertiser LLL event
-			 */
-			aux_ptr = (void *)pri_dptr;
-
-			/* FIXME: implementation defined */
-			aux_ptr->chan_idx = 0;
-			aux_ptr->ca = 0;
-			aux_ptr->offs_units = 0;
-
-			aux_ptr->phy = find_lsb_set(phy_s) - 1;
+			ull_adv_aux_ptr_fill(&pri_dptr, phy_s);
 		}
 		adv->lll.phy_s = phy_s;
 #endif /* (CONFIG_BT_CTLR_ADV_AUX_SET > 0) */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -402,17 +402,8 @@ uint8_t ll_adv_params_set(uint16_t interval, uint8_t adv_type,
 		}
 
 		/* Calc primary PDU len */
-		len = pri_dptr - (uint8_t *)pri_com_hdr;
-		if (len > (offsetof(struct pdu_adv_com_ext_adv,
-				    ext_hdr_adi_adv_data) + sizeof(*pri_hdr))) {
-			pri_com_hdr->ext_hdr_len = len -
-				offsetof(struct pdu_adv_com_ext_adv,
-					 ext_hdr_adi_adv_data);
-		} else {
-			pri_com_hdr->ext_hdr_len = 0;
-			len = offsetof(struct pdu_adv_com_ext_adv,
-				       ext_hdr_adi_adv_data);
-		}
+		len = ull_adv_aux_hdr_len_get(pri_com_hdr, pri_dptr);
+		ull_adv_aux_hdr_len_fill(pri_com_hdr, len);
 
 		/* Set PDU length */
 		pdu->len = len;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -299,11 +299,11 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 {
 	struct pdu_adv_com_ext_adv *pri_com_hdr, *pri_com_hdr_prev;
 	struct pdu_adv_com_ext_adv *sec_com_hdr, *sec_com_hdr_prev;
-	uint8_t pri_len, pri_len_prev, sec_len, sec_len_prev;
 	struct pdu_adv_hdr *pri_hdr, pri_hdr_prev;
 	struct pdu_adv_hdr *sec_hdr, sec_hdr_prev;
 	struct pdu_adv *pri_pdu, *pri_pdu_prev;
 	struct pdu_adv *sec_pdu_prev, *sec_pdu;
+	uint8_t pri_len, sec_len, sec_len_prev;
 	uint8_t *pri_dptr, *pri_dptr_prev;
 	uint8_t *sec_dptr, *sec_dptr_prev;
 	uint8_t pri_idx, sec_idx, ad_len;
@@ -491,23 +491,14 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	/* TODO: ACAD in secondary channel PDU */
 
 	/* Calc primary PDU len */
-	pri_len_prev = pri_dptr_prev - (uint8_t *)pri_com_hdr_prev;
-	pri_len = pri_dptr - (uint8_t *)pri_com_hdr;
-	pri_com_hdr->ext_hdr_len = pri_len -
-				   offsetof(struct pdu_adv_com_ext_adv,
-					    ext_hdr_adi_adv_data);
+	pri_len = ull_adv_aux_hdr_len_get(pri_com_hdr, pri_dptr);
+	ull_adv_aux_hdr_len_fill(pri_com_hdr, pri_len);
 
 	/* set the primary PDU len */
 	pri_pdu->len = pri_len;
 
 	/* Calc previous secondary PDU len */
-	sec_len_prev = sec_dptr_prev - (uint8_t *)sec_com_hdr_prev;
-	if (sec_len_prev <= (offsetof(struct pdu_adv_com_ext_adv,
-				      ext_hdr_adi_adv_data) +
-			     sizeof(sec_hdr_prev))) {
-		sec_len_prev = offsetof(struct pdu_adv_com_ext_adv,
-					ext_hdr_adi_adv_data);
-	}
+	sec_len_prev = ull_adv_aux_hdr_len_get(sec_com_hdr_prev, sec_dptr_prev);
 
 	/* Did we parse beyond PDU length? */
 	if (sec_len_prev > sec_pdu_prev->len) {
@@ -517,19 +508,10 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	}
 
 	/* Calc current secondary PDU len */
-	sec_len = sec_dptr - (uint8_t *)sec_com_hdr;
-	if (sec_len > (offsetof(struct pdu_adv_com_ext_adv,
-				ext_hdr_adi_adv_data) +
-		       sizeof(*sec_hdr))) {
-		sec_com_hdr->ext_hdr_len =
-			sec_len - offsetof(struct pdu_adv_com_ext_adv,
-					   ext_hdr_adi_adv_data);
-	} else {
-		sec_com_hdr->ext_hdr_len = 0;
-		sec_len = offsetof(struct pdu_adv_com_ext_adv,
-				   ext_hdr_adi_adv_data);
-	}
+	sec_len = ull_adv_aux_hdr_len_get(sec_com_hdr, sec_dptr);
+	ull_adv_aux_hdr_len_fill(sec_com_hdr, sec_len);
 
+	/* AD Data, add or remove */
 	if (sec_hdr_add_fields & ULL_ADV_PDU_HDR_FIELD_AD_DATA) {
 		uint8_t *val_ptr = value;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -583,42 +583,12 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	if (pri_hdr_prev.aux_ptr) {
 		pri_dptr_prev -= sizeof(struct pdu_adv_aux_ptr);
 	}
-	{
-		struct pdu_adv_aux_ptr *aux_ptr;
+	ull_adv_aux_ptr_fill(&pri_dptr, lll->phy_s);
 
-		pri_dptr -= sizeof(struct pdu_adv_aux_ptr);
-
-		/* NOTE: Aux Offset will be set in advertiser LLL event
-		 */
-		aux_ptr = (void *)pri_dptr;
-
-		/* FIXME: implementation defined */
-		aux_ptr->chan_idx = 0U;
-		aux_ptr->ca = 0U;
-		aux_ptr->offs_units = 0U;
-
-		aux_ptr->phy = find_lsb_set(lll->phy_s) - 1;
-	}
-
-	/* TODO: reduce duplicate code if below remains similar to
-	 * primary PDU
-	 */
 	if (sec_hdr_prev.aux_ptr) {
-		struct pdu_adv_aux_ptr *aux_ptr;
-
 		sec_dptr_prev -= sizeof(struct pdu_adv_aux_ptr);
-		sec_dptr -= sizeof(struct pdu_adv_aux_ptr);
 
-		/* NOTE: Aux Offset will be set in advertiser LLL event
-		 */
-		aux_ptr = (void *)sec_dptr;
-
-		/* FIXME: implementation defined */
-		aux_ptr->chan_idx = 0U;
-		aux_ptr->ca = 0U;
-		aux_ptr->offs_units = 0U;
-
-		aux_ptr->phy = find_lsb_set(lll->phy_s) - 1;
+		ull_adv_aux_ptr_fill(&sec_dptr, lll->phy_s);
 	}
 
 	/* ADI */
@@ -688,6 +658,25 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 
 	return 0;
 }
+
+void ull_adv_aux_ptr_fill(uint8_t **dptr, uint8_t phy_s)
+{
+	struct pdu_adv_aux_ptr *aux_ptr;
+
+	*dptr -= sizeof(struct pdu_adv_aux_ptr);
+
+	/* NOTE: Aux Offset will be set in advertiser LLL event
+	 */
+	aux_ptr = (void *)*dptr;
+
+	/* FIXME: implementation defined */
+	aux_ptr->chan_idx = 0U;
+	aux_ptr->ca = 0U;
+	aux_ptr->offs_units = 0U;
+
+	aux_ptr->phy = find_lsb_set(phy_s) - 1;
+}
+
 #if (CONFIG_BT_CTLR_ADV_AUX_SET > 0)
 uint8_t ull_adv_aux_lll_handle_get(struct lll_adv_aux *lll)
 {

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -633,6 +633,389 @@ int ull_adv_aux_reset(void)
 	return 0;
 }
 
+uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
+				  uint16_t sec_hdr_add_fields,
+				  uint16_t sec_hdr_rem_fields,
+				  void *value)
+{
+	struct pdu_adv_com_ext_adv *pri_com_hdr, *pri_com_hdr_prev;
+	struct pdu_adv_com_ext_adv *sec_com_hdr, *sec_com_hdr_prev;
+	uint8_t pri_len, pri_len_prev, sec_len, sec_len_prev;
+	struct pdu_adv_hdr *pri_hdr, pri_hdr_prev;
+	struct pdu_adv_hdr *sec_hdr, sec_hdr_prev;
+	struct pdu_adv *pri_pdu, *pri_pdu_prev;
+	struct pdu_adv *sec_pdu_prev, *sec_pdu;
+	uint8_t *pri_dptr, *pri_dptr_prev;
+	uint8_t *sec_dptr, *sec_dptr_prev;
+	uint8_t pri_idx, sec_idx, ad_len;
+	struct lll_adv_sync *lll_sync;
+	struct lll_adv_aux *lll_aux;
+	struct lll_adv *lll;
+	uint8_t is_aux_new;
+
+	lll = &adv->lll;
+
+	lll_aux = lll->aux;
+	if (!lll_aux) {
+		struct ll_adv_aux_set *aux;
+
+		aux = ull_adv_aux_acquire(lll);
+		if (!aux) {
+			return BT_HCI_ERR_MEM_CAPACITY_EXCEEDED;
+		}
+
+		lll_aux = &aux->lll;
+
+		is_aux_new = 1U;
+	} else {
+		is_aux_new = 0U;
+	}
+
+	lll_sync = lll->sync;
+
+	/* Get reference to previous primary PDU data */
+	pri_pdu_prev = lll_adv_data_peek(lll);
+	pri_com_hdr_prev = (void *)&pri_pdu_prev->adv_ext_ind;
+	pri_hdr = (void *)pri_com_hdr_prev->ext_hdr_adi_adv_data;
+	pri_hdr_prev = *pri_hdr;
+	pri_dptr_prev = (uint8_t *)pri_hdr + sizeof(*pri_hdr);
+
+	/* Get reference to new primary PDU data buffer */
+	pri_pdu = lll_adv_data_alloc(lll, &pri_idx);
+	pri_pdu->type = pri_pdu_prev->type;
+	pri_pdu->rfu = 0U;
+	pri_pdu->chan_sel = 0U;
+	pri_com_hdr = (void *)&pri_pdu->adv_ext_ind;
+	pri_com_hdr->adv_mode = pri_com_hdr_prev->adv_mode;
+	pri_hdr = (void *)pri_com_hdr->ext_hdr_adi_adv_data;
+	pri_dptr = (uint8_t *)pri_hdr + sizeof(*pri_hdr);
+	*(uint8_t *)pri_hdr = 0U;
+
+	/* Get reference to previous secondary PDU data */
+	sec_pdu_prev = lll_adv_aux_data_peek(lll_aux);
+	sec_com_hdr_prev = (void *)&sec_pdu_prev->adv_ext_ind;
+	sec_hdr = (void *)sec_com_hdr_prev->ext_hdr_adi_adv_data;
+	if (!is_aux_new) {
+		sec_hdr_prev = *sec_hdr;
+	} else {
+		/* Initialize only those fields used to copy into new PDU
+		 * buffer.
+		 */
+		sec_pdu_prev->tx_addr = 0U;
+		sec_pdu_prev->rx_addr = 0U;
+		sec_pdu_prev->len = offsetof(struct pdu_adv_com_ext_adv,
+					     ext_hdr_adi_adv_data);
+		*(uint8_t *)&sec_hdr_prev = 0U;
+	}
+	sec_dptr_prev = (uint8_t *)sec_hdr + sizeof(*sec_hdr);
+
+	/* Get reference to new secondary PDU data buffer */
+	sec_pdu = lll_adv_aux_data_alloc(lll_aux, &sec_idx);
+	sec_pdu->type = pri_pdu->type;
+	sec_pdu->rfu = 0U;
+	sec_pdu->chan_sel = 0U;
+
+	sec_pdu->tx_addr = sec_pdu_prev->tx_addr;
+	sec_pdu->rx_addr = sec_pdu_prev->rx_addr;
+
+	sec_com_hdr = (void *)&sec_pdu->adv_ext_ind;
+	sec_com_hdr->adv_mode = pri_com_hdr->adv_mode;
+	sec_hdr = (void *)sec_com_hdr->ext_hdr_adi_adv_data;
+	sec_dptr = (uint8_t *)sec_hdr + sizeof(*sec_hdr);
+	*(uint8_t *)sec_hdr = 0U;
+
+	/* AdvA flag */
+	/* NOTE: as we will use auxiliary packet, we remove AdvA in
+	 * primary channel. i.e. Do nothing to not add AdvA in the primary
+	 * PDU.
+	 */
+	if (pri_hdr_prev.adv_addr) {
+		pri_dptr_prev += BDADDR_SIZE;
+
+		/* Prepare to add AdvA in secondary PDU */
+		sec_hdr->adv_addr = 1;
+
+		/* NOTE: AdvA is filled at enable */
+		sec_pdu->tx_addr = pri_pdu->tx_addr;
+	}
+	pri_pdu->tx_addr = 0U;
+	pri_pdu->rx_addr = 0U;
+
+	if (sec_hdr_prev.adv_addr) {
+		sec_dptr_prev += BDADDR_SIZE;
+		sec_hdr->adv_addr = 1;
+	}
+	if (sec_hdr->adv_addr) {
+		sec_dptr += BDADDR_SIZE;
+	}
+
+	/* No TargetA in primary and secondary channel for undirected */
+	/* No CTEInfo flag in primary and secondary channel PDU */
+
+	/* ADI flag */
+	if (pri_hdr_prev.adi) {
+		pri_dptr_prev += sizeof(struct pdu_adv_adi);
+	}
+	pri_hdr->adi = 1;
+	pri_dptr += sizeof(struct pdu_adv_adi);
+	if (sec_hdr_prev.adi) {
+		sec_dptr_prev += sizeof(struct pdu_adv_adi);
+	}
+	sec_hdr->adi = 1;
+	sec_dptr += sizeof(struct pdu_adv_adi);
+
+	/* AuxPtr flag */
+	if (pri_hdr_prev.aux_ptr) {
+		pri_dptr_prev += sizeof(struct pdu_adv_aux_ptr);
+	}
+	pri_hdr->aux_ptr = 1;
+	pri_dptr += sizeof(struct pdu_adv_aux_ptr);
+	if (sec_hdr_prev.aux_ptr) {
+		sec_dptr_prev += sizeof(struct pdu_adv_aux_ptr);
+
+		sec_hdr->aux_ptr = 1;
+		sec_dptr += sizeof(struct pdu_adv_aux_ptr);
+	}
+
+	/* No SyncInfo flag in primary channel PDU */
+	/* Add/Remove SyncInfo flag in secondary channel PDU */
+	if ((sec_hdr_add_fields & ULL_ADV_PDU_HDR_FIELD_SYNC_INFO) ||
+	    (!(sec_hdr_rem_fields & ULL_ADV_PDU_HDR_FIELD_SYNC_INFO) &&
+	     sec_hdr_prev.sync_info)) {
+		sec_hdr->sync_info = 1;
+	}
+	if (sec_hdr_prev.sync_info) {
+		sec_dptr_prev += sizeof(struct pdu_adv_sync_info);
+	}
+	if (sec_hdr->sync_info) {
+		sec_dptr += sizeof(struct pdu_adv_sync_info);
+	}
+
+	/* Tx Power flag */
+	if (pri_hdr_prev.tx_pwr) {
+		pri_dptr_prev++;
+
+		/* C1, Tx Power is optional on the LE 1M PHY, and
+		 * reserved for future use on the LE Coded PHY.
+		 */
+		if (lll->phy_p != PHY_CODED) {
+			pri_hdr->tx_pwr = 1;
+			pri_dptr++;
+		} else {
+			sec_hdr->tx_pwr = 1;
+		}
+	}
+	if (sec_hdr_prev.tx_pwr) {
+		sec_dptr_prev++;
+
+		sec_hdr->tx_pwr = 1;
+	}
+	if (sec_hdr->tx_pwr) {
+		sec_dptr++;
+	}
+
+	/* TODO: ACAD place holder */
+
+	/* Calc primary PDU len */
+	pri_len_prev = pri_dptr_prev - (uint8_t *)pri_com_hdr_prev;
+	pri_len = pri_dptr - (uint8_t *)pri_com_hdr;
+	pri_com_hdr->ext_hdr_len = pri_len -
+				   offsetof(struct pdu_adv_com_ext_adv,
+					    ext_hdr_adi_adv_data);
+
+	/* set the primary PDU len */
+	pri_pdu->len = pri_len;
+
+	/* Calc previous secondary PDU len */
+	sec_len_prev = sec_dptr_prev - (uint8_t *)sec_com_hdr_prev;
+	if (sec_len_prev <= (offsetof(struct pdu_adv_com_ext_adv,
+				      ext_hdr_adi_adv_data) +
+			     sizeof(sec_hdr_prev))) {
+		sec_len_prev = offsetof(struct pdu_adv_com_ext_adv,
+					ext_hdr_adi_adv_data);
+	}
+
+	/* Did we parse beyond PDU length? */
+	if (sec_len_prev > sec_pdu_prev->len) {
+		/* we should not encounter invalid length */
+		/* FIXME: release allocations */
+		return BT_HCI_ERR_UNSPECIFIED;
+	}
+
+	/* Calc current secondary PDU len */
+	sec_len = sec_dptr - (uint8_t *)sec_com_hdr;
+	if (sec_len > (offsetof(struct pdu_adv_com_ext_adv,
+				ext_hdr_adi_adv_data) +
+		       sizeof(*sec_hdr))) {
+		sec_com_hdr->ext_hdr_len =
+			sec_len - offsetof(struct pdu_adv_com_ext_adv,
+					   ext_hdr_adi_adv_data);
+	} else {
+		sec_com_hdr->ext_hdr_len = 0;
+		sec_len = offsetof(struct pdu_adv_com_ext_adv,
+				   ext_hdr_adi_adv_data);
+	}
+
+	/* Calc the previous AD data length in auxiliary PDU */
+	ad_len = sec_pdu_prev->len - sec_len_prev;
+
+	/* set the secondary PDU len */
+	sec_pdu->len = sec_len + ad_len;
+
+	/* Check AdvData overflow */
+	if (sec_pdu->len > CONFIG_BT_CTLR_ADV_DATA_LEN_MAX) {
+		/* FIXME: release allocations */
+		return BT_HCI_ERR_PACKET_TOO_LONG;
+	}
+
+	/* Fill AdvData in secondary PDU */
+	memcpy(sec_dptr, sec_dptr_prev, ad_len);
+
+	/* Start filling primary PDU payload based on flags */
+
+	/* No AdvData in primary channel PDU */
+
+	/* No ACAD in primary channel PDU */
+
+	/* Tx Power */
+	if (pri_hdr->tx_pwr) {
+		*--pri_dptr = *--pri_dptr_prev;
+	} else if (sec_hdr->tx_pwr) {
+		*--sec_dptr = *--sec_dptr_prev;
+	}
+
+	/* No SyncInfo in primary channel PDU */
+	/* Fill SyncInfo in secondary channel PDU */
+	if (sec_hdr_prev.sync_info) {
+		sec_dptr_prev -= sizeof(struct pdu_adv_sync_info);
+	}
+	if (sec_hdr->sync_info) {
+		struct ll_adv_sync_set *sync = (void *)HDR_LLL2EVT(lll_sync);
+		struct pdu_adv_sync_info *si;
+
+		sec_dptr -= sizeof(*si);
+
+		si = (void *)sec_dptr;
+		si->offs = 0U; /* NOTE: Filled by secondary prepare */
+		si->offs_units = 0U;
+		si->interval = sys_cpu_to_le16(sync->interval);
+		memcpy(si->sca_chm, lll_sync->data_chan_map,
+		       sizeof(si->sca_chm));
+		memcpy(&si->aa, lll_sync->access_addr, sizeof(si->aa));
+		memcpy(si->crc_init, lll_sync->crc_init, sizeof(si->crc_init));
+
+		si->evt_cntr = 0U; /* TODO: Implementation defined */
+	}
+
+	/* AuxPtr */
+	if (pri_hdr_prev.aux_ptr) {
+		pri_dptr_prev -= sizeof(struct pdu_adv_aux_ptr);
+	}
+	{
+		struct pdu_adv_aux_ptr *aux_ptr;
+
+		pri_dptr -= sizeof(struct pdu_adv_aux_ptr);
+
+		/* NOTE: Aux Offset will be set in advertiser LLL event
+		 */
+		aux_ptr = (void *)pri_dptr;
+
+		/* FIXME: implementation defined */
+		aux_ptr->chan_idx = 0U;
+		aux_ptr->ca = 0U;
+		aux_ptr->offs_units = 0U;
+
+		aux_ptr->phy = find_lsb_set(lll->phy_s) - 1;
+	}
+
+	/* TODO: reduce duplicate code if below remains similar to
+	 * primary PDU
+	 */
+	if (sec_hdr_prev.aux_ptr) {
+		struct pdu_adv_aux_ptr *aux_ptr;
+
+		sec_dptr_prev -= sizeof(struct pdu_adv_aux_ptr);
+		sec_dptr -= sizeof(struct pdu_adv_aux_ptr);
+
+		/* NOTE: Aux Offset will be set in advertiser LLL event
+		 */
+		aux_ptr = (void *)sec_dptr;
+
+		/* FIXME: implementation defined */
+		aux_ptr->chan_idx = 0U;
+		aux_ptr->ca = 0U;
+		aux_ptr->offs_units = 0U;
+
+		aux_ptr->phy = find_lsb_set(lll->phy_s) - 1;
+	}
+
+	/* ADI */
+	{
+		struct pdu_adv_adi *pri_adi, *sec_adi;
+		uint16_t did = UINT16_MAX;
+
+		pri_dptr -= sizeof(struct pdu_adv_adi);
+		sec_dptr -= sizeof(struct pdu_adv_adi);
+
+		pri_adi = (void *)pri_dptr;
+		sec_adi = (void *)sec_dptr;
+
+		if (pri_hdr_prev.adi) {
+			struct pdu_adv_adi *pri_adi_prev;
+
+			pri_dptr_prev -= sizeof(struct pdu_adv_adi);
+			sec_dptr_prev -= sizeof(struct pdu_adv_adi);
+
+			/* NOTE: memcpy shall handle overlapping buffers
+			 */
+			memcpy(pri_dptr, pri_dptr_prev,
+			       sizeof(struct pdu_adv_adi));
+			memcpy(sec_dptr, sec_dptr_prev,
+			       sizeof(struct pdu_adv_adi));
+
+			pri_adi_prev = (void *)pri_dptr_prev;
+			did = sys_le16_to_cpu(pri_adi_prev->did);
+		} else {
+			pri_adi->sid = adv->sid;
+			sec_adi->sid = adv->sid;
+		}
+
+		did++;
+
+		pri_adi->did = sys_cpu_to_le16(did);
+		sec_adi->did = sys_cpu_to_le16(did);
+	}
+
+	/* No CTEInfo field in primary channel PDU */
+
+	/* No TargetA non-conn non-scan advertising  */
+
+	/* No AdvA in primary channel due to AuxPtr being added */
+
+	/* NOTE: AdvA in aux channel is also filled at enable and RPA
+	 * timeout
+	 */
+	if (sec_hdr->adv_addr) {
+		void *bdaddr;
+
+		if (sec_hdr_prev.adv_addr) {
+			sec_dptr_prev -= BDADDR_SIZE;
+			bdaddr = sec_dptr_prev;
+		} else {
+			pri_dptr_prev -= BDADDR_SIZE;
+			bdaddr = pri_dptr_prev;
+		}
+
+		sec_dptr -= BDADDR_SIZE;
+
+		memcpy(sec_dptr, bdaddr, BDADDR_SIZE);
+	}
+
+	lll_adv_aux_data_enqueue(lll_aux, sec_idx);
+	lll_adv_data_enqueue(lll, pri_idx);
+
+	return 0;
+}
 #if (CONFIG_BT_CTLR_ADV_AUX_SET > 0)
 uint8_t ull_adv_aux_lll_handle_get(struct lll_adv_aux *lll)
 {

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -143,8 +143,11 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 					&ret_cb);
 		ret = ull_ticker_status_take(ret, &ret_cb);
 		if (ret != TICKER_STATUS_SUCCESS) {
-			/* FIXME: Use a better error code */
-			return BT_HCI_ERR_CMD_DISALLOWED;
+			/* NOTE: This failure, to start an auxiliary channel
+			 * radio event shall not occur unless a defect in the
+			 * controller design.
+			 */
+			return BT_HCI_ERR_INSUFFICIENT_RESOURCES;
 		}
 
 		aux->is_started = 1;
@@ -170,9 +173,9 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 	 */
 
 	/* TODO: handle other op values */
-	if ((op != 0x03) && (op != 0x04)) {
-		/* FIXME: error code */
-		return BT_HCI_ERR_CMD_DISALLOWED;
+	if ((op != BT_HCI_LE_EXT_ADV_OP_COMPLETE_DATA) &&
+	    (op != BT_HCI_LE_EXT_ADV_OP_UNCHANGED_DATA)) {
+		return BT_HCI_ERR_UNSUPP_FEATURE_PARAM_VAL;
 	}
 
 	/* Get the advertising set instance */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -113,6 +113,9 @@ ull_adv_aux_hdr_len_fill(struct pdu_adv_com_ext_adv *com_hdr, uint8_t len)
 
 }
 
+/* helper function to fill the aux ptr structure in common ext adv payload */
+void ull_adv_aux_ptr_fill(uint8_t **dptr, uint8_t phy_s);
+
 #if defined(CONFIG_BT_CTLR_ADV_PERIODIC)
 int ull_adv_sync_init(void);
 int ull_adv_sync_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -45,7 +45,10 @@ uint8_t ull_adv_data_set(struct ll_adv_set *adv, uint8_t len,
 uint8_t ull_scan_rsp_set(struct ll_adv_set *adv, uint8_t len,
 			 uint8_t const *const data);
 
+
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
+
+#define ULL_ADV_PDU_HDR_FIELD_SYNC_INFO BIT(5)
 
 /* helper function to handle adv done events */
 void ull_adv_done(struct node_rx_event_done *done);
@@ -77,6 +80,12 @@ void ull_adv_aux_release(struct ll_adv_aux_set *aux);
 
 /* helper function to schedule a mayfly to get aux offset */
 void ull_adv_aux_offset_get(struct ll_adv_set *adv);
+
+/* helper function to set/clear common extended header format fields */
+uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
+				  uint16_t sec_hdr_add_fields,
+				  uint16_t sec_hdr_rem_fields,
+				  void *value);
 
 #if defined(CONFIG_BT_CTLR_ADV_PERIODIC)
 int ull_adv_sync_init(void);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -88,6 +88,31 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 				  uint16_t sec_hdr_rem_fields,
 				  void *value);
 
+/* helper function to calculate common ext adv payload header length */
+static inline uint8_t
+ull_adv_aux_hdr_len_get(struct pdu_adv_com_ext_adv *com_hdr, uint8_t *dptr)
+{
+	uint8_t len;
+
+	len = dptr - (uint8_t *)com_hdr;
+	if (len <= (offsetof(struct pdu_adv_com_ext_adv, ext_hdr_adi_adv_data) +
+		    sizeof(struct pdu_adv_hdr))) {
+		len = offsetof(struct pdu_adv_com_ext_adv,
+			       ext_hdr_adi_adv_data);
+	}
+
+	return len;
+}
+
+/* helper function to fill common ext adv payload header length */
+static inline void
+ull_adv_aux_hdr_len_fill(struct pdu_adv_com_ext_adv *com_hdr, uint8_t len)
+{
+	com_hdr->ext_hdr_len = len - offsetof(struct pdu_adv_com_ext_adv,
+					      ext_hdr_adi_adv_data);
+
+}
+
 #if defined(CONFIG_BT_CTLR_ADV_PERIODIC)
 int ull_adv_sync_init(void);
 int ull_adv_sync_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -49,6 +49,7 @@ uint8_t ull_scan_rsp_set(struct ll_adv_set *adv, uint8_t len,
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 
 #define ULL_ADV_PDU_HDR_FIELD_SYNC_INFO BIT(5)
+#define ULL_ADV_PDU_HDR_FIELD_AD_DATA   BIT(8)
 
 /* helper function to handle adv done events */
 void ull_adv_done(struct node_rx_event_done *done);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -148,19 +148,10 @@ uint8_t ll_adv_sync_param_set(uint8_t handle, uint16_t interval, uint16_t flags)
 	/* TODO: AdvData */
 
 	/* Calc tertiary PDU len */
-	ter_len = ter_dptr - (uint8_t *)ter_com_hdr;
-	if (ter_len >
-	    (offsetof(struct pdu_adv_com_ext_adv, ext_hdr_adi_adv_data) +
-	     sizeof(*ter_hdr))) {
-		ter_com_hdr->ext_hdr_len = ter_len -
-					   offsetof(struct pdu_adv_com_ext_adv,
-						    ext_hdr_adi_adv_data);
-		ter_pdu->len = ter_len;
-	} else {
-		ter_com_hdr->ext_hdr_len = 0U;
-		ter_pdu->len = offsetof(struct pdu_adv_com_ext_adv,
-				    ext_hdr_adi_adv_data);
-	}
+	ter_len = ull_adv_aux_hdr_len_get(ter_com_hdr, ter_dptr);
+	ull_adv_aux_hdr_len_fill(ter_com_hdr, ter_len);
+
+	ter_pdu->len = ter_len;
 
 	return 0;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -72,20 +72,7 @@ uint8_t ll_adv_sync_param_set(uint8_t handle, uint16_t interval, uint16_t flags)
 
 	lll_sync = adv->lll.sync;
 	if (!lll_sync) {
-		struct pdu_adv_com_ext_adv *pri_com_hdr, *pri_com_hdr_prev;
-		struct pdu_adv_com_ext_adv *sec_com_hdr, *sec_com_hdr_prev;
-		uint8_t pri_len, pri_len_prev, sec_len, sec_len_prev;
-		struct pdu_adv_hdr *pri_hdr, pri_hdr_prev;
-		struct pdu_adv_hdr *sec_hdr, sec_hdr_prev;
-		struct pdu_adv *pri_pdu, *pri_pdu_prev;
-		struct pdu_adv *sec_pdu_prev, *sec_pdu;
-		uint8_t *pri_dptr, *pri_dptr_prev;
-		uint8_t *sec_dptr, *sec_dptr_prev;
-		struct pdu_adv_sync_info *si;
-		struct lll_adv_aux *lll_aux;
-		uint8_t pri_idx, sec_idx, ad_len;
 		struct lll_adv *lll;
-		uint8_t is_aux_new;
 		int err;
 
 		sync = sync_acquire();
@@ -94,22 +81,6 @@ uint8_t ll_adv_sync_param_set(uint8_t handle, uint16_t interval, uint16_t flags)
 		}
 
 		lll = &adv->lll;
-		lll_aux = lll->aux;
-		if (!lll_aux) {
-			struct ll_adv_aux_set *aux;
-
-			aux = ull_adv_aux_acquire(lll);
-			if (!aux) {
-				return BT_HCI_ERR_MEM_CAPACITY_EXCEEDED;
-			}
-
-			lll_aux = &aux->lll;
-
-			is_aux_new = 1U;
-		} else {
-			is_aux_new = 0U;
-		}
-
 		lll_sync = &sync->lll;
 		lll->sync = lll_sync;
 		lll_sync->adv = lll;
@@ -132,329 +103,6 @@ uint8_t ll_adv_sync_param_set(uint8_t handle, uint16_t interval, uint16_t flags)
 
 		sync->is_enabled = 0U;
 		sync->is_started = 0U;
-
-		/* Get reference to previous primary PDU data */
-		pri_pdu_prev = lll_adv_data_peek(lll);
-		pri_com_hdr_prev = (void *)&pri_pdu_prev->adv_ext_ind;
-		pri_hdr = (void *)pri_com_hdr_prev->ext_hdr_adi_adv_data;
-		pri_hdr_prev = *pri_hdr;
-		pri_dptr_prev = (uint8_t *)pri_hdr + sizeof(*pri_hdr);
-
-		/* Get reference to new primary PDU data buffer */
-		pri_pdu = lll_adv_data_alloc(lll, &pri_idx);
-		pri_pdu->type = pri_pdu_prev->type;
-		pri_pdu->rfu = 0U;
-		pri_pdu->chan_sel = 0U;
-		pri_com_hdr = (void *)&pri_pdu->adv_ext_ind;
-		pri_com_hdr->adv_mode = pri_com_hdr_prev->adv_mode;
-		pri_hdr = (void *)pri_com_hdr->ext_hdr_adi_adv_data;
-		pri_dptr = (uint8_t *)pri_hdr + sizeof(*pri_hdr);
-		*(uint8_t *)pri_hdr = 0U;
-
-		/* Get reference to previous secondary PDU data */
-		sec_pdu_prev = lll_adv_aux_data_peek(lll_aux);
-		sec_com_hdr_prev = (void *)&sec_pdu_prev->adv_ext_ind;
-		sec_hdr = (void *)sec_com_hdr_prev->ext_hdr_adi_adv_data;
-		if (!is_aux_new) {
-			sec_hdr_prev = *sec_hdr;
-		} else {
-			/* Initialize only those fields used to copy into new PDU
-			 * buffer.
-			 */
-			sec_pdu_prev->tx_addr = 0U;
-			sec_pdu_prev->rx_addr = 0U;
-			sec_pdu_prev->len = offsetof(struct pdu_adv_com_ext_adv,
-						     ext_hdr_adi_adv_data);
-			*(uint8_t *)&sec_hdr_prev = 0U;
-		}
-		sec_dptr_prev = (uint8_t *)sec_hdr + sizeof(*sec_hdr);
-
-		/* Get reference to new secondary PDU data buffer */
-		sec_pdu = lll_adv_aux_data_alloc(lll_aux, &sec_idx);
-		sec_pdu->type = pri_pdu->type;
-		sec_pdu->rfu = 0U;
-		sec_pdu->chan_sel = 0U;
-
-		sec_pdu->tx_addr = sec_pdu_prev->tx_addr;
-		sec_pdu->rx_addr = sec_pdu_prev->rx_addr;
-
-		sec_com_hdr = (void *)&sec_pdu->adv_ext_ind;
-		sec_com_hdr->adv_mode = pri_com_hdr->adv_mode;
-		sec_hdr = (void *)sec_com_hdr->ext_hdr_adi_adv_data;
-		sec_dptr = (uint8_t *)sec_hdr + sizeof(*sec_hdr);
-		*(uint8_t *)sec_hdr = 0U;
-
-		/* AdvA flag */
-		/* NOTE: as we will use auxiliary packet, we remove AdvA in
-		 * primary channel. i.e. Do nothing to add AdvA in the primary
-		 * PDU.
-		 */
-		if (pri_hdr_prev.adv_addr) {
-			pri_dptr_prev += BDADDR_SIZE;
-
-			/* Prepare to add AdvA in secondary PDU */
-			sec_hdr->adv_addr = 1;
-
-			/* NOTE: AdvA is filled at enable */
-			sec_pdu->tx_addr = pri_pdu->tx_addr;
-		}
-		pri_pdu->tx_addr = 0U;
-		pri_pdu->rx_addr = 0U;
-
-		if (sec_hdr_prev.adv_addr) {
-			sec_dptr_prev += BDADDR_SIZE;
-			sec_hdr->adv_addr = 1;
-		}
-		if (sec_hdr->adv_addr) {
-			sec_dptr += BDADDR_SIZE;
-		}
-
-		/* No TargetA in primary and secondary channel for undirected */
-		/* No CTEInfo flag in primary and secondary channel PDU */
-
-		/* ADI flag */
-		if (pri_hdr_prev.adi) {
-			pri_dptr_prev += sizeof(struct pdu_adv_adi);
-		}
-		pri_hdr->adi = 1;
-		pri_dptr += sizeof(struct pdu_adv_adi);
-		if (sec_hdr_prev.adi) {
-			sec_dptr_prev += sizeof(struct pdu_adv_adi);
-		}
-		sec_hdr->adi = 1;
-		sec_dptr += sizeof(struct pdu_adv_adi);
-
-		/* AuxPtr flag */
-		if (pri_hdr_prev.aux_ptr) {
-			pri_dptr_prev += sizeof(struct pdu_adv_aux_ptr);
-		}
-		pri_hdr->aux_ptr = 1;
-		pri_dptr += sizeof(struct pdu_adv_aux_ptr);
-		if (sec_hdr_prev.aux_ptr) {
-			sec_dptr_prev += sizeof(struct pdu_adv_aux_ptr);
-
-			sec_hdr->aux_ptr = 1;
-			sec_dptr += sizeof(struct pdu_adv_aux_ptr);
-		}
-
-		/* No SyncInfo flag in primary channel PDU */
-		/* Add SyncInfo flag in secondary channel PDU */
-		sec_hdr->sync_info = 1;
-		sec_dptr += sizeof(*si);
-
-		/* Tx Power flag */
-		if (pri_hdr_prev.tx_pwr) {
-			pri_dptr_prev++;
-
-			/* C1, Tx Power is optional on the LE 1M PHY, and
-			 * reserved for future use on the LE Coded PHY.
-			 */
-			if (lll->phy_p != PHY_CODED) {
-				pri_hdr->tx_pwr = 1;
-				pri_dptr++;
-			} else {
-				sec_hdr->tx_pwr = 1;
-			}
-		}
-		if (sec_hdr_prev.tx_pwr) {
-			sec_dptr_prev++;
-
-			sec_hdr->tx_pwr = 1;
-		}
-		if (sec_hdr->tx_pwr) {
-			sec_dptr++;
-		}
-
-		/* TODO: ACAD place holder */
-
-		/* Calc primary PDU len */
-		pri_len_prev = pri_dptr_prev - (uint8_t *)pri_com_hdr_prev;
-		pri_len = pri_dptr - (uint8_t *)pri_com_hdr;
-		pri_com_hdr->ext_hdr_len = pri_len -
-					   offsetof(struct pdu_adv_com_ext_adv,
-						    ext_hdr_adi_adv_data);
-
-		/* set the primary PDU len */
-		pri_pdu->len = pri_len;
-
-		/* Calc previous secondary PDU len */
-		sec_len_prev = sec_dptr_prev - (uint8_t *)sec_com_hdr_prev;
-		if (sec_len_prev <= (offsetof(struct pdu_adv_com_ext_adv,
-					      ext_hdr_adi_adv_data) +
-				     sizeof(sec_hdr_prev))) {
-			sec_len_prev = offsetof(struct pdu_adv_com_ext_adv,
-						ext_hdr_adi_adv_data);
-		}
-
-		/* Did we parse beyond PDU length? */
-		if (sec_len_prev > sec_pdu_prev->len) {
-			/* we should not encounter invalid length */
-			/* FIXME: release allocations */
-			return BT_HCI_ERR_UNSPECIFIED;
-		}
-
-		/* Calc current secondary PDU len */
-		sec_len = sec_dptr - (uint8_t *)sec_com_hdr;
-		if (sec_len > (offsetof(struct pdu_adv_com_ext_adv,
-					ext_hdr_adi_adv_data) +
-			       sizeof(*sec_hdr))) {
-			sec_com_hdr->ext_hdr_len =
-				sec_len - offsetof(struct pdu_adv_com_ext_adv,
-						   ext_hdr_adi_adv_data);
-		} else {
-			sec_com_hdr->ext_hdr_len = 0;
-			sec_len = offsetof(struct pdu_adv_com_ext_adv,
-					   ext_hdr_adi_adv_data);
-		}
-
-		/* Calc the previous AD data length in auxiliary PDU */
-		ad_len = sec_pdu_prev->len - sec_len_prev;
-
-		/* set the secondary PDU len */
-		sec_pdu->len = sec_len + ad_len;
-
-		/* Check AdvData overflow */
-		if (sec_pdu->len > CONFIG_BT_CTLR_ADV_DATA_LEN_MAX) {
-			/* FIXME: release allocations */
-			return BT_HCI_ERR_PACKET_TOO_LONG;
-		}
-
-		/* Fill AdvData in secondary PDU */
-		memcpy(sec_dptr, sec_dptr_prev, ad_len);
-
-		/* Start filling primary PDU payload based on flags */
-
-		/* No AdvData in primary channel PDU */
-
-		/* No ACAD in primary channel PDU */
-
-		/* Tx Power */
-		if (pri_hdr->tx_pwr) {
-			*--pri_dptr = *--pri_dptr_prev;
-		} else if (sec_hdr->tx_pwr) {
-			*--sec_dptr = *--sec_dptr_prev;
-		}
-
-		/* No SyncInfo in primary channel PDU */
-		/* Fill SyncInfo in secondary channel PDU */
-		sec_dptr -= sizeof(*si);
-		si = (void *)sec_dptr;
-		si->offs = 0U; /* NOTE: Filled by secondary prepare */
-		si->offs_units = 0U;
-		si->interval = sys_cpu_to_le16(interval);
-		memcpy(si->sca_chm, lll_sync->data_chan_map,
-		       sizeof(si->sca_chm));
-		memcpy(&si->aa, lll_sync->access_addr, sizeof(si->aa));
-		memcpy(si->crc_init, lll_sync->crc_init, sizeof(si->crc_init));
-
-		si->evt_cntr = 0U; /* TODO: Implementation defined */
-
-		/* AuxPtr */
-		if (pri_hdr_prev.aux_ptr) {
-			pri_dptr_prev -= sizeof(struct pdu_adv_aux_ptr);
-		}
-		{
-			struct pdu_adv_aux_ptr *aux_ptr;
-
-			pri_dptr -= sizeof(struct pdu_adv_aux_ptr);
-
-			/* NOTE: Aux Offset will be set in advertiser LLL event
-			 */
-			aux_ptr = (void *)pri_dptr;
-
-			/* FIXME: implementation defined */
-			aux_ptr->chan_idx = 0U;
-			aux_ptr->ca = 0U;
-			aux_ptr->offs_units = 0U;
-
-			aux_ptr->phy = find_lsb_set(lll->phy_s) - 1;
-		}
-
-		/* TODO: reduce duplicate code if below remains similar to
-		 * primary PDU
-		 */
-		if (sec_hdr_prev.aux_ptr) {
-			struct pdu_adv_aux_ptr *aux_ptr;
-
-			sec_dptr_prev -= sizeof(struct pdu_adv_aux_ptr);
-			sec_dptr -= sizeof(struct pdu_adv_aux_ptr);
-
-			/* NOTE: Aux Offset will be set in advertiser LLL event
-			 */
-			aux_ptr = (void *)sec_dptr;
-
-			/* FIXME: implementation defined */
-			aux_ptr->chan_idx = 0U;
-			aux_ptr->ca = 0U;
-			aux_ptr->offs_units = 0U;
-
-			aux_ptr->phy = find_lsb_set(lll->phy_s) - 1;
-		}
-
-		/* ADI */
-		{
-			struct pdu_adv_adi *pri_adi, *sec_adi;
-			uint16_t did = UINT16_MAX;
-
-			pri_dptr -= sizeof(struct pdu_adv_adi);
-			sec_dptr -= sizeof(struct pdu_adv_adi);
-
-			pri_adi = (void *)pri_dptr;
-			sec_adi = (void *)sec_dptr;
-
-			if (pri_hdr_prev.adi) {
-				struct pdu_adv_adi *pri_adi_prev;
-
-				pri_dptr_prev -= sizeof(struct pdu_adv_adi);
-				sec_dptr_prev -= sizeof(struct pdu_adv_adi);
-
-				/* NOTE: memcpy shall handle overlapping buffers
-				 */
-				memcpy(pri_dptr, pri_dptr_prev,
-				       sizeof(struct pdu_adv_adi));
-				memcpy(sec_dptr, sec_dptr_prev,
-				       sizeof(struct pdu_adv_adi));
-
-				pri_adi_prev = (void *)pri_dptr_prev;
-				did = sys_le16_to_cpu(pri_adi_prev->did);
-			} else {
-				pri_adi->sid = adv->sid;
-				sec_adi->sid = adv->sid;
-			}
-
-			did++;
-
-			pri_adi->did = sys_cpu_to_le16(did);
-			sec_adi->did = sys_cpu_to_le16(did);
-		}
-
-		/* No CTEInfo field in primary channel PDU */
-
-		/* No TargetA non-conn non-scan advertising  */
-
-		/* No AdvA in primary channel due to AuxPtr being added */
-
-		/* NOTE: AdvA in aux channel is also filled at enable and RPA
-		 * timeout
-		 */
-		if (sec_hdr->adv_addr) {
-			void *bdaddr;
-
-			if (sec_hdr_prev.adv_addr) {
-				sec_dptr_prev -= BDADDR_SIZE;
-				bdaddr = sec_dptr_prev;
-			} else {
-				pri_dptr_prev -= BDADDR_SIZE;
-				bdaddr = pri_dptr_prev;
-			}
-
-			sec_dptr -= BDADDR_SIZE;
-
-			memcpy(sec_dptr, bdaddr, BDADDR_SIZE);
-		}
-
-		lll_adv_aux_data_enqueue(lll_aux, sec_idx);
-		lll_adv_data_enqueue(lll, pri_idx);
 	} else {
 		sync = (void *)HDR_LLL2EVT(lll_sync);
 	}
@@ -555,7 +203,13 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 			return 0;
 		}
 
-		/* TODO: remove sync_info from auxiliary PDU */
+		/* Remove sync_info from auxiliary PDU */
+		err = ull_adv_aux_hdr_set_clear(adv, 0,
+						ULL_ADV_PDU_HDR_FIELD_SYNC_INFO,
+						NULL);
+		if (err) {
+			return err;
+		}
 
 		err = sync_stop(sync);
 		if (err) {
@@ -581,7 +235,31 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 	}
 
 	if (adv->is_enabled && !sync->is_started) {
-		/* TODO: */
+		volatile uint32_t ret_cb = TICKER_STATUS_BUSY;
+		uint32_t ticks_anc_sync;
+		uint8_t err;
+
+		/* FIXME: Find absolute ticks until after auxliary PDU on air
+		 *        to place the periodic advertising PDU.
+		 */
+		ticks_anc_sync = ticker_ticks_now_get();
+
+		/* Add sync_info into auxiliary PDU */
+		err = ull_adv_aux_hdr_set_clear(adv,
+						ULL_ADV_PDU_HDR_FIELD_SYNC_INFO,
+						0, NULL);
+		if (err) {
+			return err;
+		}
+
+		ull_hdr_init(&sync->ull);
+
+		err = ull_adv_sync_start(sync, ticks_anc_sync, &ret_cb);
+		if (err) {
+			return BT_HCI_ERR_CMD_DISALLOWED;
+		}
+
+		sync->is_started = 1U;
 	}
 
 	return 0;

--- a/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
@@ -202,7 +202,6 @@ static void test_advx_main(void)
 	}
 	printk("success.\n");
 
-
 	k_sleep(K_MSEC(400));
 
 	printk("Stopping advertising...");
@@ -331,15 +330,18 @@ static void test_advx_main(void)
 
 	k_sleep(K_MSEC(1000));
 
-	printk("Starting non-conn non-scan with aux 1M advertising...");
-	err = ll_adv_aux_ad_data_set(handle, AD_OP, AD_FRAG_PREF,
-				     sizeof(adv_data), (void *)adv_data);
+	printk("Enabling non-conn non-scan without aux 1M advertising...");
+	err = ll_adv_enable(handle, 1, 0, 0);
 	if (err) {
 		goto exit;
 	}
+	printk("success.\n");
 
-	printk("enabling...");
-	err = ll_adv_enable(handle, 1, 0, 0);
+	k_sleep(K_MSEC(400));
+
+	printk("Adding data, so non-conn non-scan with aux 1M advertising...");
+	err = ll_adv_aux_ad_data_set(handle, AD_OP, AD_FRAG_PREF,
+				     sizeof(adv_data), (void *)adv_data);
 	if (err) {
 		goto exit;
 	}
@@ -376,6 +378,15 @@ static void test_advx_main(void)
 
 	k_sleep(K_MSEC(1000));
 
+	printk("Enabling extended...");
+	err = ll_adv_enable(handle, 1, 0, 0);
+	if (err) {
+		goto exit;
+	}
+	printk("success.\n");
+
+	k_sleep(K_MSEC(400));
+
 	printk("Starting periodic 1M advertising...");
 	err = ll_adv_sync_param_set(handle, ADV_INTERVAL_PERIODIC, 0);
 	if (err) {
@@ -384,12 +395,6 @@ static void test_advx_main(void)
 
 	printk("enabling periodic...");
 	err = ll_adv_sync_enable(handle, 1);
-	if (err) {
-		goto exit;
-	}
-
-	printk("enabling extended...");
-	err = ll_adv_enable(handle, 1, 0, 0);
 	if (err) {
 		goto exit;
 	}
@@ -431,6 +436,40 @@ static void test_advx_main(void)
 
 	printk("Disabling periodic...");
 	err = ll_adv_sync_enable(handle, 0);
+	if (err) {
+		goto exit;
+	}
+	printk("success.\n");
+
+	k_sleep(K_MSEC(1000));
+
+	printk("enabling periodic...");
+	err = ll_adv_sync_enable(handle, 1);
+	if (err) {
+		goto exit;
+	}
+	printk("success.\n");
+
+	printk("Enabling extended...");
+	err = ll_adv_enable(handle, 1, 0, 0);
+	if (err) {
+		goto exit;
+	}
+	printk("success.\n");
+
+	k_sleep(K_MSEC(400));
+
+	printk("Disabling periodic...");
+	err = ll_adv_sync_enable(handle, 0);
+	if (err) {
+		goto exit;
+	}
+	printk("success.\n");
+
+	k_sleep(K_MSEC(400));
+
+	printk("Disabling...");
+	err = ll_adv_enable(handle, 0, 0, 0);
 	if (err) {
 		goto exit;
 	}

--- a/tests/bluetooth/bsim_bt/bsim_test_advx/tests_scripts/basic_advx.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_advx/tests_scripts/basic_advx.sh
@@ -31,7 +31,7 @@ Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_advx_prj_conf\
   -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=scanx
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
-  -D=2 -sim_length=12e6 $@
+  -D=2 -sim_length=60e6 $@
 
 for process_id in $process_ids; do
   wait $process_id || let "exit_code=$?"


### PR DESCRIPTION
Refactor out sync info field population into a utility
function with set and clear interface to add or remove
the common extended advertising header format fields.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>