### PR TITLE
net: openthread: Fix warning from the logger module

### DIFF
--- a/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
+++ b/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
@@ -14,6 +14,7 @@
 #define OPENTHREAD_CORE_ZEPHYR_CONFIG_H_
 
 #include <devicetree.h>
+#include <toolchain.h>
 
 /**
  * @def OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS
@@ -161,9 +162,13 @@
 
 #define OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION__COUNT_ARGS(aLogLevel, unused, \
 							aFormat, ...) \
-	otPlatLog(aLogLevel, \
+	do { \
+		ARG_UNUSED(unused); \
+		otPlatLog( \
+		  aLogLevel, \
 		  (otLogRegion)_OT_CONF_PLAT_LOG_FUN_NARGS__GET(__VA_ARGS__),\
-		  aFormat, ##__VA_ARGS__)
+		  aFormat, ##__VA_ARGS__); \
+	} while (false)
 
 #ifdef OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION
 #error OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION \


### PR DESCRIPTION
Currently, OpenThread builds produce warning from the OT logger module,
because we don't use one of the parameters provided by logger macro.
Explicitly mark the parameter as unused to prevent warnings being
thrown.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>