### PR TITLE
dts: ti,bq274xx: remove default properties

### DIFF
--- a/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dts
+++ b/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dts
@@ -98,6 +98,10 @@
 		compatible = "ti,bq274xx";
 		label = "BQ274XX";
 		reg = <0x55>;
+		design-voltage = <3700>;
+		design-capacity = <1800>;
+		taper-current = <45>;
+		terminate-voltage = <3000>;
 	};
 
 	lis2dh12-accel@19 {

--- a/dts/bindings/sensor/ti,bq274xx.yaml
+++ b/dts/bindings/sensor/ti,bq274xx.yaml
@@ -13,24 +13,20 @@ include: i2c-device.yaml
 properties:
     design-voltage:
       type: int
-      required: false
-      description: Battery Design Volatge in (3300 - 4400)mV
-      default: 3700
+      required: true
+      description: Battery Design Voltage in mV (3300 - 4400)
 
     design-capacity:
       type: int
-      required: false
+      required: true
       description: Battery Design Capacity in mAh
-      default: 1800
 
     taper-current:
       type: int
-      required: false
+      required: true
       description: Battery Taper current in mAh
-      default: 45
 
     terminate-voltage:
       type: int
-      required: false
+      required: true
       description: Battery Terminate Voltage in mV
-      default: 3000


### PR DESCRIPTION
The parameters for this fuel gauge depend on the hardware design and
the expected battery.  These should not be defaulted to a value that
may be inappropriate.  Require that they be explicitly provided.

See: https://github.com/zephyrproject-rtos/zephyr/issues/25164#issuecomment-638931323
