### PR TITLE
syscalls: Add system call for cache flush & invalidate

### DIFF
--- a/include/cache.h
+++ b/include/cache.h
@@ -32,7 +32,9 @@ void arch_dcache_invd(void *addr, size_t size);
  *
  * @return N/A
  */
-static inline void sys_cache_flush(void *addr, size_t size)
+__syscall void sys_cache_flush(void *addr, size_t size);
+
+static inline void z_impl_sys_cache_flush(void *addr, size_t size)
 {
 	if (IS_ENABLED(CONFIG_CACHE_FLUSHING)) {
 		arch_dcache_flush(addr, size);
@@ -55,7 +57,9 @@ static inline void sys_cache_flush(void *addr, size_t size)
  *
  * @return N/A
  */
-static inline void sys_cache_invd(void *addr, size_t size)
+__syscall void sys_cache_invd(void *addr, size_t size);
+
+static inline void z_impl_sys_cache_invd(void *addr, size_t size)
 {
 	if (IS_ENABLED(CONFIG_CACHE_FLUSHING)) {
 		arch_dcache_invd(addr, size);
@@ -83,6 +87,7 @@ static inline size_t sys_cache_line_size_get(void)
 #endif /* CONFIG_CACHE_FLUSHING */
 }
 
+#include <syscalls/cache.h>
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -56,6 +56,7 @@ target_sources_ifdef(
   kernel PRIVATE
   futex.c
   mem_domain.c
+  cache_handlers.c
   userspace_handler.c
   userspace.c
   )

--- a/kernel/cache_handlers.c
+++ b/kernel/cache_handlers.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cache.h>
+#include <syscall_handler.h>
+
+static inline void z_vrfy_sys_cache_flush(void *addr, size_t size)
+{
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(addr, size));
+	z_impl_sys_cache_flush(addr, size);
+}
+#include <syscalls/sys_cache_flush_mrsh.c>
+
+static inline void z_vrfy_sys_cache_invd(void *addr, size_t size)
+{
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(addr, size));
+	z_impl_sys_cache_invd(addr, size);
+}
+#include <syscalls/sys_cache_invd_mrsh.c>


### PR DESCRIPTION
include/cache.h: System calls declaration and implementation
kernel/cache_handlers.c: Defination of verification functions

Signed-off-by: Aastha Grover <aastha.grover@intel.com>
