### PR TITLE
WiFi: winc1500: add new config flag

### DIFF
--- a/drivers/wifi/winc1500/Kconfig.winc1500
+++ b/drivers/wifi/winc1500/Kconfig.winc1500
@@ -15,6 +15,12 @@ config WIFI_WINC1500_NAME
 	string "Driver name"
 	default "WINC1500"
 
+config WINC1500_DRV_USE_OLD_SPI_SW
+	bool "Use old SPI access method in the vendor HAL"
+	help
+	  This option, when enabled, causes USE_OLD_SPI_SW
+	  setting to be passed to vendor HAL.
+
 config WIFI_WINC1500_THREAD_STACK_SIZE
 	int "HAL callback handler thread stack size"
 	default 2048

--- a/drivers/wifi/winc1500/wifi_winc1500_nm_bsp_internal.h
+++ b/drivers/wifi/winc1500/wifi_winc1500_nm_bsp_internal.h
@@ -16,6 +16,10 @@
 
 extern tstrNmBusCapabilities egstrNmBusCapabilities;
 
+#if defined(CONFIG_WINC1500_DRV_USE_OLD_SPI_SW)
+#define USE_OLD_SPI_SW
+#endif /*CONFIG_WINC1500_DRV_USE_OLD_SPI_SW*/
+
 #define NM_EDGE_INTERRUPT	(1)
 
 #define NM_DEBUG		CONF_WINC_DEBUG

--- a/west.yml
+++ b/west.yml
@@ -29,7 +29,7 @@ manifest:
       revision: c3bd2094f92d574377f7af2aec147ae181aa5f8e
       path: modules/hal/cmsis
     - name: hal_atmel
-      revision: 9f0a699a2f0253dc9688211ef696daa7b8fadb75
+      revision: d17b7dd92d209b20bc1e15431d068edc29bf438d
       path: modules/hal/atmel
     - name: hal_altera
       revision: 23c1c1dd7a0c1cc9a399509d1819375847c95b97


### PR DESCRIPTION
There is a hardcoded macro in Winc1500 HAL SPI driver

that would prevent the driver from working.

 This macro is now defined only based on KConfig entry.

 This KConfig entry is by default not set.

 To enable, use "CONFIG_WINC1500_DRV_USE_OLD_SPI_SW=y

in proj.conf or board.conf

Signed-off-by: Raja D.Singh <rdsingh@iotwizards.com>