### PR TITLE
sanitycheck: support only_tags in platform definition

### DIFF
--- a/boards/x86/qemu_x86/qemu_x86_nommu.yaml
+++ b/boards/x86/qemu_x86/qemu_x86_nommu.yaml
@@ -8,6 +8,6 @@ toolchain:
   - xtools
 testing:
   default: true
-  ignore_tags:
-     - net
-     - bluetooth
+  only_tags:
+     - kernel
+     - userspace

--- a/doc/guides/test/sanitycheck.rst
+++ b/doc/guides/test/sanitycheck.rst
@@ -154,6 +154,8 @@ testing:
   ignore_tags:
     Do not attempt to build (and therefore run) tests marked with this list of
     tags.
+  only_tags:
+    Only execute tests with this list of tags on a specific platform.
 
 Test Cases
 **********

--- a/samples/basic/minimal/sample.yaml
+++ b/samples/basic/minimal/sample.yaml
@@ -1,6 +1,8 @@
 sample:
   description: minimal sample, the smallest possible Zephyr application
   name: minimal
+common:
+  tags: footprint
 tests:
   sample.minimal.mt.arm:
     build_only: true

--- a/scripts/sanity_chk/platform-schema.yaml
+++ b/scripts/sanity_chk/platform-schema.yaml
@@ -49,6 +49,11 @@ mapping:
     mapping:
       "default":
         type: bool
+      "only_tags":
+        type: seq
+        seq:
+          -
+            type: str
       "ignore_tags":
         type: seq
         seq:

--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -1306,6 +1306,7 @@ class Platform:
         self.ram = 128
 
         self.ignore_tags = []
+        self.only_tags = []
         self.default = False
         # if no flash size is specified by the board, take a default of 512K
         self.flash = 512
@@ -1330,6 +1331,7 @@ class Platform:
         self.ram = data.get("ram", 128)
         testing = data.get("testing", {})
         self.ignore_tags = testing.get("ignore_tags", [])
+        self.only_tags = testing.get("only_tags", [])
         self.default = testing.get("default", False)
         # if no flash size is specified by the board, take a default of 512K
         self.flash = data.get("flash", 512)
@@ -2797,7 +2799,11 @@ class TestSuite(DisablePyTestCollectionMixin):
                     continue
 
                 if set(plat.ignore_tags) & tc.tags:
-                    discards[instance] = "Excluded tags per platform"
+                    discards[instance] = "Excluded tags per platform (exclude_tags)"
+                    continue
+
+                if not tc.tags or (plat.only_tags and tc.tags - set(plat.only_tags)):
+                    discards[instance] = "Excluded tags per platform (only_tags)"
                     continue
 
                 # if nothing stopped us until now, it means this configuration

--- a/scripts/tests/sanitycheck/test_testsuite_class.py
+++ b/scripts/tests/sanitycheck/test_testsuite_class.py
@@ -147,7 +147,7 @@ TESTDATA_PART1 = [
     ("arch_exclude", ['x86_demo'], None, None, "In test case arch exclude"),
     ("arch_whitelist", ['arm'], None, None, "Not in test case arch whitelist"),
     ("skip", True, None, None, "Skip filter"),
-    ("tags", set(['sensor', 'bluetooth']), "ignore_tags", ['bluetooth'], "Excluded tags per platform"),
+    ("tags", set(['sensor', 'bluetooth']), "ignore_tags", ['bluetooth'], "Excluded tags per platform (exclude_tags)"),
     ("min_flash", "2024", "flash", "1024", "Not enough FLASH"),
     ("min_ram", "500", "ram", "256", "Not enough RAM"),
     ("None", "None", "env", ['BSIM_OUT_PATH', 'demo_env'], "Environment (BSIM_OUT_PATH, demo_env) not satisfied"),

--- a/tests/kernel/mp/testcase.yaml
+++ b/tests/kernel/mp/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.multiprocessing:
+    tags: smp
     filter: CONFIG_MP_NUM_CPUS > 1

--- a/tests/kernel/smp/testcase.yaml
+++ b/tests/kernel/smp/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.multiprocessing.smp:
+    tags: smp
     filter: (CONFIG_MP_NUM_CPUS > 1)

--- a/tests/kernel/spinlock/testcase.yaml
+++ b/tests/kernel/spinlock/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.multiprocessing.spinlock:
+    tags: smp spinlock
     filter: CONFIG_SMP and CONFIG_MP_NUM_CPUS > 1

--- a/tests/subsys/fs/nvs/testcase.yaml
+++ b/tests/subsys/fs/nvs/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  tags: nvs
 tests:
   filesystem.nvs:
     platform_whitelist: qemu_x86


### PR DESCRIPTION
Support running/building only specific tags and ignoring everything else.