### PR TITLE
Bluetooth: controller: Fill event counter in sync info

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -85,37 +85,6 @@ void lll_adv_sync_prepare(void *param)
 	LL_ASSERT(!err || err == -EINPROGRESS);
 }
 
-void lll_adv_sync_offset_fill(uint32_t ticks_offset, uint32_t start_us,
-			     struct pdu_adv *pdu)
-{
-	struct pdu_adv_com_ext_adv *p;
-	struct pdu_adv_sync_info *si;
-	struct pdu_adv_hdr *h;
-	uint8_t *ptr;
-
-	p = (void *)&pdu->adv_ext_ind;
-	h = (void *)p->ext_hdr_adi_adv_data;
-	ptr = (uint8_t *)h + sizeof(*h);
-
-	if (h->adv_addr) {
-		ptr += BDADDR_SIZE;
-	}
-
-	if (h->adi) {
-		ptr += sizeof(struct pdu_adv_adi);
-	}
-
-	if (h->aux_ptr) {
-		ptr += sizeof(struct pdu_adv_aux_ptr);
-	}
-
-	si = (void *)ptr;
-	si->offs = (HAL_TICKER_TICKS_TO_US(ticks_offset) - start_us) / 30;
-	if (si->offs_units) {
-		si->offs /= 10;
-	}
-}
-
 static int init_reset(void)
 {
 	return 0;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.h
@@ -7,7 +7,5 @@
 int lll_adv_sync_init(void);
 int lll_adv_sync_reset(void);
 void lll_adv_sync_prepare(void *param);
-void lll_adv_sync_offset_fill(uint32_t ticks_offset, uint32_t start_us,
-			     struct pdu_adv *pdu);
 
 extern uint16_t ull_adv_sync_lll_handle_get(struct lll_adv_sync *lll);

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -77,6 +77,10 @@
 /* Standard allows 2 us timing uncertainty inside the event */
 #define EVENT_MAFS_MAX_US       (EVENT_MAFS_US + 2)
 
+/* SyncInfo field Sync Packet Offset Units field encoding */
+#define SYNC_PKT_OFFS_UNIT_30_US  30
+#define SYNC_PKT_OFFS_UNIT_300_US 300
+
 /*
  * Macros to return correct Data Channel PDU time
  * Note: formula is valid for 1M, 2M and Coded S8


### PR DESCRIPTION
Fill the referenced event counter of the Periodic
Advertising SYNC_IND PDU into the sync info struct in the
Common Extended Advertising Header Format.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>