### PR TITLE
STM32 HSEM Id list update and rework impacted drivers

### DIFF
--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -18,6 +18,7 @@
 #include <sys/printk.h>
 #include <drivers/clock_control.h>
 #include <drivers/clock_control/stm32_clock_control.h>
+#include "stm32_hsem.h"
 
 struct entropy_stm32_rng_dev_cfg {
 	struct stm32_pclken pclken;
@@ -187,6 +188,7 @@ static int entropy_stm32_rng_init(struct device *dev)
 	LL_SYSCFG_VREFINT_EnableHSI48();
 #endif /* CONFIG_SOC_SERIES_STM32L0X */
 
+	z_stm32_hsem_lock(CFG_HW_CLK48_CONFIG_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 	/* Use the HSI48 for the RNG */
 	LL_RCC_HSI48_Enable();
 	while (!LL_RCC_HSI48_IsReady()) {
@@ -194,6 +196,14 @@ static int entropy_stm32_rng_init(struct device *dev)
 	}
 
 	LL_RCC_SetRNGClockSource(LL_RCC_RNG_CLKSOURCE_HSI48);
+
+#if !defined(CONFIG_SOC_SERIES_STM32WBX)
+	/* Specially for STM32WB, don't unlock the HSEM to prevent M0 core
+	 * to disable HSI48 clock used for RNG.
+	 */
+	z_stm32_hsem_unlock(CFG_HW_CLK48_CONFIG_SEMID);
+#endif /* CONFIG_SOC_SERIES_STM32WBX */
+
 #endif /* CONFIG_SOC_SERIES_STM32L4X */
 
 	dev_data->clock = device_get_binding(STM32_CLOCK_CONTROL_NAME);

--- a/drivers/flash/flash_stm32wbx.c
+++ b/drivers/flash/flash_stm32wbx.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019 Linaro Limited
+ * Copyright (c) 2020 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -18,6 +19,8 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #include <sys/__assert.h>
 
 #include "flash_stm32.h"
+#include "stm32_hsem.h"
+#include "shci.h"
 
 #define STM32WBX_PAGE_SHIFT	12
 
@@ -45,6 +48,9 @@ static int write_dword(struct device *dev, off_t offset, uint64_t val)
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 	uint32_t tmp;
 	int ret, rc;
+	uint32_t cpu1_sem_status;
+	uint32_t cpu2_sem_status = 0;
+	uint32_t key;
 
 	/* if the control register is locked, do not fail silently */
 	if (regs->CR & FLASH_CR_LOCK) {
@@ -62,15 +68,105 @@ static int write_dword(struct device *dev, off_t offset, uint64_t val)
 		return -EIO;
 	}
 
-	/* Set the PG bit */
-	regs->CR |= FLASH_CR_PG;
+	/* Implementation of STM32 AN5289, proposed in STM32WB Cube Application
+	 * BLE_RfWithFlash
+	 * https://github.com/STMicroelectronics/STM32CubeWB/tree/master/Projects/P-NUCLEO-WB55.Nucleo/Applications/BLE/BLE_RfWithFlash
+	 */
 
-	/* Flush the register write */
-	tmp = regs->CR;
+	do {
+		/**
+		 * When the PESD bit mechanism is used by CPU2 to protect its
+		 * timing, the PESD bit should be polled here.
+		 * If the PESD is set, the CPU1 will be stalled when reading
+		 * literals from an ISR that may occur after the flash
+		 * processing has been requested but suspended due to the PESD
+		 * bit.
+		 *
+		 * Note: This code is required only when the PESD mechanism is
+		 * used to protect the CPU2 timing.
+		 * However, keeping that code make it compatible with both
+		 * mechanisms.
+		 */
+		while (LL_FLASH_IsActiveFlag_OperationSuspended())
+			;
 
-	/* Perform the data write operation at the desired memory address */
-	flash[0] = (uint32_t)val;
-	flash[1] = (uint32_t)(val >> 32);
+		/* Enter critical section */
+		key = irq_lock();
+
+		/**
+		 *  Depending on the application implementation, in case a
+		 *  multitasking is possible with an OS, it should be checked
+		 *  here if another task in the application disallowed flash
+		 *  processing to protect some latency in critical code
+		 *  execution.
+		 *  When flash processing is ongoing, the CPU cannot access the
+		 *  flash anymore.Trying to access the flash during that time
+		 *  stalls the CPU.
+		 *  The only way for CPU1 to disallow flash processing is to
+		 *  take CFG_HW_BLOCK_FLASH_REQ_BY_CPU1_SEMID.
+		 */
+		cpu1_sem_status = LL_HSEM_GetStatus(HSEM,
+			CFG_HW_BLOCK_FLASH_REQ_BY_CPU1_SEMID);
+		if (cpu1_sem_status == 0) {
+			/**
+			 *  Check now if the CPU2 disallows flash processing to
+			 *  protect its timing. If the semaphore is locked, the
+			 *  CPU2 does not allow flash processing
+			 *
+			 *  Note: By default, the CPU2 uses the PESD mechanism
+			 *  to protect its timing, therefore, it is useless to
+			 *  get/release the semaphore.
+			 *
+			 *  However, keeping that code make it compatible with
+			 *  bothmechanisms.
+			 *  The protection by semaphore is enabled on CPU2 side
+			 *  with the command SHCI_C2_SetFlashActivityControl()
+			 *
+			 */
+			cpu2_sem_status = LL_HSEM_1StepLock(HSEM,
+				CFG_HW_BLOCK_FLASH_REQ_BY_CPU2_SEMID);
+			if (cpu2_sem_status == 0) {
+				/**
+				 * When CFG_HW_BLOCK_FLASH_REQ_BY_CPU2_SEMID is
+				 * taken, it is allowed to only write one
+				 * single 64bits data.
+				 * When several 64bits data need to be erased,
+				 * the application shall first exit from the
+				 * critical section and try again.
+				 */
+				/* Set the PG bit */
+				regs->CR |= FLASH_CR_PG;
+
+				/* Flush the register write */
+				tmp = regs->CR;
+
+				/* Perform the data write operation at desired
+				 * memory address
+				 */
+				flash[0] = (uint32_t)val;
+				flash[1] = (uint32_t)(val >> 32);
+
+				/**
+				 *  Release the semaphore to give the
+				 *  opportunity to CPU2 to protect its timing
+				 *  versus the next flash operation by taking
+				 *  this semaphore.
+				 *  Note that the CPU2 is polling on this
+				 *  semaphore so CPU1 shall release it as fast
+				 *  as possible.
+				 *  This is why this code is protected by a
+				 *  critical section.
+				 */
+				LL_HSEM_ReleaseLock(HSEM,
+					CFG_HW_BLOCK_FLASH_REQ_BY_CPU2_SEMID,
+					0);
+			}
+		}
+
+		/* Exit critical section */
+		irq_unlock(key);
+
+	} while (cpu2_sem_status || cpu1_sem_status);
 
 	/* Wait until the BSY bit is cleared */
 	rc = flash_stm32_wait_flash_idle(dev);
@@ -83,6 +179,10 @@ static int write_dword(struct device *dev, off_t offset, uint64_t val)
 
 static int erase_page(struct device *dev, uint32_t page)
 {
+	uint32_t cpu1_sem_status;
+	uint32_t cpu2_sem_status = 0;
+	uint32_t key;
+
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 	int rc;
 
@@ -97,17 +197,100 @@ static int erase_page(struct device *dev, uint32_t page)
 		return rc;
 	}
 
-	/* Check erase operation allowed */
-	if (regs->CR & FLASH_SR_PESD) {
-		return -EBUSY;
-	}
+	/* Implementation of STM32 AN5289, proposed in STM32WB Cube Application
+	 * BLE_RfWithFlash
+	 * https://github.com/STMicroelectronics/STM32CubeWB/tree/master/Projects/P-NUCLEO-WB55.Nucleo/Applications/BLE/BLE_RfWithFlash
+	 */
 
-	/* Proceed to erase the page */
-	regs->CR |= FLASH_CR_PER;
-	regs->CR &= ~FLASH_CR_PNB_Msk;
-	regs->CR |= page << FLASH_CR_PNB_Pos;
+	do {
+		/**
+		 * When the PESD bit mechanism is used by CPU2 to protect its
+		 * timing, the PESD bit should be polled here.
+		 * If the PESD is set, the CPU1 will be stalled when reading
+		 * literals from an ISR that may occur after the flash
+		 * processing has been requested but suspended due to the PESD
+		 * bit.
+		 *
+		 * Note: This code is required only when the PESD mechanism is
+		 * used to protect the CPU2 timing.
+		 * However, keeping that code make it compatible with both
+		 * mechanisms.
+		 */
+		while (LL_FLASH_IsActiveFlag_OperationSuspended())
+			;
 
-	regs->CR |= FLASH_CR_STRT;
+		/* Enter critical section */
+		key = irq_lock();
+
+		/**
+		 *  Depending on the application implementation, in case a
+		 *  multitasking is possible with an OS, it should be checked
+		 *  here if another task in the application disallowed flash
+		 *  processing to protect some latency in critical code
+		 *  execution.
+		 *  When flash processing is ongoing, the CPU cannot access the
+		 *  flash anymore.Trying to access the flash during that time
+		 *  stalls the CPU.
+		 *  The only way for CPU1 to disallow flash processing is to
+		 *  take CFG_HW_BLOCK_FLASH_REQ_BY_CPU1_SEMID.
+		 */
+		cpu1_sem_status = LL_HSEM_GetStatus(HSEM,
+			CFG_HW_BLOCK_FLASH_REQ_BY_CPU1_SEMID);
+		if (cpu1_sem_status == 0) {
+			/**
+			 *  Check now if the CPU2 disallows flash processing to
+			 *  protect its timing. If the semaphore is locked, the
+			 *  CPU2 does not allow flash processing
+			 *
+			 *  Note: By default, the CPU2 uses the PESD mechanism
+			 *  to protect its timing, therefore, it is useless to
+			 *  get/release the semaphore.
+			 *
+			 *  However, keeping that code make it compatible with
+			 *  bothmechanisms.
+			 *  The protection by semaphore is enabled on CPU2 side
+			 *  with the command SHCI_C2_SetFlashActivityControl()
+			 *
+			 */
+			cpu2_sem_status = LL_HSEM_1StepLock(HSEM,
+				CFG_HW_BLOCK_FLASH_REQ_BY_CPU2_SEMID);
+			if (cpu2_sem_status == 0) {
+				/**
+				 * When CFG_HW_BLOCK_FLASH_REQ_BY_CPU2_SEMID is
+				 * taken, it is allowed to only erase one
+				 * sector.
+				 * When several sectors need to be erased,
+				 * the application shall first exit from the
+				 * critical section and try again.
+				 */
+				regs->CR |= FLASH_CR_PER;
+				regs->CR &= ~FLASH_CR_PNB_Msk;
+				regs->CR |= page << FLASH_CR_PNB_Pos;
+
+				regs->CR |= FLASH_CR_STRT;
+
+				/**
+				 *  Release the semaphore to give the
+				 *  opportunity to CPU2 to protect its timing
+				 *  versus the next flash operation by taking
+				 *  this semaphore.
+				 *  Note that the CPU2 is polling on this
+				 *  semaphore so CPU1 shall release it as fast
+				 *  as possible.
+				 *  This is why this code is protected by a
+				 *  critical section.
+				 */
+				LL_HSEM_ReleaseLock(HSEM,
+					CFG_HW_BLOCK_FLASH_REQ_BY_CPU2_SEMID,
+					0);
+			}
+		}
+
+		/* Exit critical section */
+		irq_unlock(key);
+
+	} while (cpu2_sem_status || cpu1_sem_status);
+
 
 	/* Wait for the BSY bit */
 	rc = flash_stm32_wait_flash_idle(dev);
@@ -122,6 +305,19 @@ int flash_stm32_block_erase_loop(struct device *dev, unsigned int offset,
 {
 	int i, rc = 0;
 
+#if defined(CONFIG_BT)
+	/**
+	 *  Notify the CPU2 that some flash erase activity may be executed
+	 *  On reception of this command, the CPU2 enables the BLE timing
+	 *  protection versus flash erase processing.
+	 *  The Erase flash activity will be executed only when the BLE RF is
+	 *  idle for at least 25ms.
+	 *  The CPU2 will prevent all flash activity (write or erase) in all
+	 *  cases when the BL RF Idle is shorter than 25ms.
+	 */
+	SHCI_C2_FLASH_EraseActivity(ERASE_ACTIVITY_ON);
+#endif /* CONFIG_BT */
+
 	i = get_page(offset);
 	for (; i <= get_page(offset + len - 1) ; ++i) {
 		rc = erase_page(dev, i);
@@ -129,6 +325,15 @@ int flash_stm32_block_erase_loop(struct device *dev, unsigned int offset,
 			break;
 		}
 	}
+
+#if defined(CONFIG_BT)
+	/**
+	 *  Notify the CPU2 there will be no request anymore to erase the flash
+	 *  On reception of this command, the CPU2 disables the BLE timing
+	 *  protection versus flash erase processing
+	 */
+	SHCI_C2_FLASH_EraseActivity(ERASE_ACTIVITY_OFF);
+#endif /* CONFIG_BT */
 
 	return rc;
 }

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -52,6 +52,7 @@
 #include <drivers/clock_control/stm32_clock_control.h>
 #include <sys/util.h>
 #include <drivers/gpio.h>
+#include "stm32_hsem.h"
 
 #define LOG_LEVEL CONFIG_USB_DRIVER_LOG_LEVEL
 #include <logging/log.h>
@@ -109,8 +110,6 @@ LOG_MODULE_REGISTER(usb_dc_stm32);
  * Kconfig system.
  */
 #ifdef USB
-
-#define CFG_HW_RCC_CRRCR_CCIPR_SEMID	5
 
 #define EP0_MPS 64U
 #define EP_MPS 64U
@@ -251,10 +250,7 @@ static int usb_dc_stm32_clock_enable(void)
 	}
 #endif /* CONFIG_SOC_SERIES_STM32L0X */
 
-#ifdef CONFIG_SOC_SERIES_STM32WBX
-	while (LL_HSEM_1StepLock(HSEM, CFG_HW_RCC_CRRCR_CCIPR_SEMID)) {
-	}
-#endif /* CONFIG_SOC_SERIES_STM32WBX */
+	z_stm32_hsem_lock(CFG_HW_CLK48_CONFIG_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 
 	LL_RCC_HSI48_Enable();
 	while (!LL_RCC_HSI48_IsReady()) {
@@ -262,6 +258,14 @@ static int usb_dc_stm32_clock_enable(void)
 	}
 
 	LL_RCC_SetUSBClockSource(LL_RCC_USB_CLKSOURCE_HSI48);
+
+#if !defined(CONFIG_SOC_SERIES_STM32WBX)
+	/* Specially for STM32WB, don't unlock the HSEM to prevent M0 core
+	 * to disable HSI48 clock used for RNG.
+	 */
+	z_stm32_hsem_unlock(CFG_HW_CLK48_CONFIG_SEMID);
+#endif /* CONFIG_SOC_SERIES_STM32WBX */
+
 #elif defined(LL_RCC_USB_CLKSOURCE_NONE)
 	/* When MSI is configured in PLL mode with a 32.768 kHz clock source,
 	 * the MSI frequency can be automatically trimmed by hardware to reach
@@ -913,7 +917,9 @@ int usb_dc_detach(void)
 	LOG_ERR("Not implemented");
 
 #ifdef CONFIG_SOC_SERIES_STM32WBX
-	LL_HSEM_ReleaseLock(HSEM, CFG_HW_RCC_CRRCR_CCIPR_SEMID, 0);
+	/* Specially for STM32WB, unlock the HSEM when USB is no more used. */
+	z_stm32_hsem_unlock(CFG_HW_CLK48_CONFIG_SEMID);
+
 	/*
 	 * TODO: AN5289 notes a process of locking Sem0, with possible waits
 	 * via interrupts before switching off CLK48, but lacking any actual

--- a/soc/arm/st_stm32/common/stm32_hsem.h
+++ b/soc/arm/st_stm32/common/stm32_hsem.h
@@ -13,27 +13,60 @@
 /** HW semaphore Complement ID list defined in hw_conf.h from STM32WB
  * and used also for H7 dualcore targets
  */
-/** Index of the semaphore used to manage the entry Stop Mode procedure */
-#define CFG_HW_ENTRY_STOP_MODE_SEMID        4U
+/**
+ *  Index of the semaphore used by CPU2 to prevent the CPU1 to either write or
+ *  erase data in flash. The CPU1 shall not either write or erase in flash when
+ *  this semaphore is taken by the CPU2. When the CPU1 needs to either write or
+ *  erase in flash, it shall first get the semaphore and release it just
+ *  after writing a raw (64bits data) or erasing one sector.
+ *  On v1.4.0 and older CPU2 wireless firmware, this semaphore is unused and
+ *  CPU2 is using PES bit. By default, CPU2 is using the PES bit to protect its
+ *  timing. The CPU1 may request the CPU2 to use the semaphore instead of the
+ *  PES bit by sending the system command SHCI_C2_SetFlashActivityControl()
+ */
+#define CFG_HW_BLOCK_FLASH_REQ_BY_CPU2_SEMID                    7U
+
+/**
+ *  Index of the semaphore used by CPU1 to prevent the CPU2 to either write or
+ *  erase data in flash. In order to protect its timing, the CPU1 may get this
+ *  semaphore to prevent the  CPU2 to either write or erase in flash
+ *  (as this will stall both CPUs)
+ *  The PES bit shall not be used as this may stall the CPU2 in some cases.
+ */
+#define CFG_HW_BLOCK_FLASH_REQ_BY_CPU1_SEMID                    6U
+
+/**
+ *  Index of the semaphore used to manage the CLK48 clock configuration
+ *  When the USB is required, this semaphore shall be taken before configuring
+ *  the CLK48 for USB and should be released after the application switch OFF
+ *  the clock when the USB is not used anymore. When using the RNG, it is good
+ *  enough to use CFG_HW_RNG_SEMID to control CLK48.
+ *  More details in AN5289
+ */
+#define CFG_HW_CLK48_CONFIG_SEMID                               5U
+#define CFG_HW_RCC_CRRCR_CCIPR_SEMID     CFG_HW_CLK48_CONFIG_SEMID
+
+/* Index of the semaphore used to manage the entry Stop Mode procedure */
+#define CFG_HW_ENTRY_STOP_MODE_SEMID                            4U
 #define CFG_HW_ENTRY_STOP_MODE_MASK_SEMID   (1U << CFG_HW_ENTRY_STOP_MODE_SEMID)
 
-/** Index of the semaphore used to access the RCC and PWR */
-#define CFG_HW_RCC_SEMID                    3U
+/* Index of the semaphore used to access the RCC */
+#define CFG_HW_RCC_SEMID                                        3U
 
-/** Index of the semaphore used to access the FLASH */
-#define CFG_HW_FLASH_SEMID                  2U
+/* Index of the semaphore used to access the FLASH */
+#define CFG_HW_FLASH_SEMID                                      2U
 
-/** Index of the semaphore used to access the PKA */
-#define CFG_HW_PKA_SEMID                    1U
+/* Index of the semaphore used to access the PKA */
+#define CFG_HW_PKA_SEMID                                        1U
 
-/** Index of the semaphore used to access the RNG */
-#define CFG_HW_RNG_SEMID                    0U
+/* Index of the semaphore used to access the RNG */
+#define CFG_HW_RNG_SEMID                                        0U
 
 /** Index of the semaphore used to access GPIO */
-#define CFG_HW_GPIO_SEMID                   5U
+#define CFG_HW_GPIO_SEMID                                       8U
 
 /** Index of the semaphore used to access the EXTI */
-#define CFG_HW_EXTI_SEMID                   6U
+#define CFG_HW_EXTI_SEMID                                       9U
 
 #elif defined(CONFIG_SOC_SERIES_STM32MP1X)
 /** HW semaphore from STM32MP1
@@ -42,19 +75,24 @@
  * but reserved for MPU.
  */
 /** Index of the semaphore used to access GPIO */
-#define CFG_HW_GPIO_SEMID                   0U
+#define CFG_HW_GPIO_SEMID                     0U
 
 /** Index of the semaphore used to access the EXTI */
-#define CFG_HW_EXTI_SEMID                   1U
+#define CFG_HW_EXTI_SEMID                     1U
 
 #else
 /** Fake semaphore ID definition for compilation purpose only */
-#define CFG_HW_RCC_SEMID                    0U
-#define CFG_HW_FLASH_SEMID                  0U
-#define CFG_HW_PKA_SEMID                    0U
-#define CFG_HW_RNG_SEMID                    0u
-#define CFG_HW_GPIO_SEMID                   0U
-#define CFG_HW_EXTI_SEMID                   0U
+#define CFG_HW_BLOCK_FLASH_REQ_BY_CPU2_SEMID  0U
+#define CFG_HW_BLOCK_FLASH_REQ_BY_CPU1_SEMID  0U
+#define CFG_HW_CLK48_CONFIG_SEMID             0U
+#define CFG_HW_RCC_CRRCR_CCIPR_SEMID          0U
+#define CFG_HW_ENTRY_STOP_MODE_SEMID          0U
+#define CFG_HW_RCC_SEMID                      0U
+#define CFG_HW_FLASH_SEMID                    0U
+#define CFG_HW_PKA_SEMID                      0U
+#define CFG_HW_RNG_SEMID                      0U
+#define CFG_HW_GPIO_SEMID                     0U
+#define CFG_HW_EXTI_SEMID                     0U
 
 #endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
 


### PR DESCRIPTION
STM32 HSEM Id list update and rework impacted drivers.

Due to STM32WB Cube update, HSEM Id list has been updated. It introduces new semaphores for flash operations.
This PR contains 3 commits:
* soc: arm: st_stm32: update HSEM ID from STM32WB cube update
* drivers: STM32: Rework CLK48 HSEM protection 
* drivers: flash: stm32wb: rework dualcore flash operation