### PR TITLE
spi: Make all API functions available

### DIFF
--- a/include/drivers/spi.h
+++ b/include/drivers/spi.h
@@ -309,7 +309,6 @@ static inline int spi_write(struct device *dev,
 	return spi_transceive(dev, config, tx_bufs, NULL);
 }
 
-#ifdef CONFIG_SPI_ASYNC
 /**
  * @brief Read/write the specified amount of data from the SPI driver.
  *
@@ -336,10 +335,20 @@ static inline int spi_transceive_async(struct device *dev,
 				       const struct spi_buf_set *rx_bufs,
 				       struct k_poll_signal *async)
 {
+#ifdef CONFIG_SPI_ASYNC
 	const struct spi_driver_api *api =
 		(const struct spi_driver_api *)dev->driver_api;
 
 	return api->transceive_async(dev, config, tx_bufs, rx_bufs, async);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(config);
+	ARG_UNUSED(tx_bufs);
+	ARG_UNUSED(rx_bufs);
+	ARG_UNUSED(async);
+
+	return -ENOTSUP;
+#endif /* CONFIG_SPI_ASYNC */
 }
 
 /**
@@ -391,7 +400,6 @@ static inline int spi_write_async(struct device *dev,
 {
 	return spi_transceive_async(dev, config, tx_bufs, NULL, async);
 }
-#endif /* CONFIG_SPI_ASYNC */
 
 /**
  * @brief Release the SPI device locked on by the current config


### PR DESCRIPTION
Removing ifdef around conditional API to follow zephyr coding style.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>