### PR TITLE
Bluetooth: hci_ecc: Follow BT spec when public key is invalid

### DIFF
--- a/subsys/bluetooth/host/hci_ecc.c
+++ b/subsys/bluetooth/host/hci_ecc.c
@@ -194,7 +194,7 @@ static void emulate_le_generate_dhkey(void)
 
 	if (ret == TC_CRYPTO_FAIL) {
 		evt->status = BT_HCI_ERR_UNSPECIFIED;
-		(void)memset(evt->dhkey, 0, sizeof(evt->dhkey));
+		(void)memset(evt->dhkey, 0xff, sizeof(evt->dhkey));
 	} else {
 		evt->status = 0U;
 		/* Convert from big-endian (provided by crypto API) to


### PR DESCRIPTION
Follow Bluetooth specification recommendation of setting the output
of the DH_Key field in the LE Generate DHKey Complete event when the
public key is invalid.

 If the Remote_P-256_Public_Key parameter of the HCI_LE_Generate_DHKey
 command (see Section 7.8.37) was invalid (see [Vol 3] Part H, Section
 2.3.5.6.1), then all octets of the DH_Key event parameter should be
 set to 0xFF.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>