### PR TITLE
mgmt: smp: add missing kernel.h include statement

### DIFF
--- a/include/mgmt/smp.h
+++ b/include/mgmt/smp.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_MGMT_SMP_H_
 #define ZEPHYR_INCLUDE_MGMT_SMP_H_
 
+#include <kernel.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
There is following error when compiling applications using smp:

```
  /zephyr/include/mgmt/smp.h:77:16: error: field 'zst_work' has incomplete type
     77 |  struct k_work zst_work;
        |                ^~~~~~~~
  /zephyr/include/mgmt/smp.h:80:16: error: field 'zst_fifo' has incomplete type
     80 |  struct k_fifo zst_fifo;
        |                ^~~~~~~~
```

Fix that by adding missing kernel.h include statement in mgmt/smp.h.