### PR TITLE
actions: daily_tests: fetch all tags

### DIFF
--- a/.github/workflows/daily_test_version.yml
+++ b/.github/workflows/daily_test_version.yml
@@ -28,6 +28,8 @@ jobs:
 
     - name: checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Upload to AWS S3
       run: |


### PR DESCRIPTION
Fetch all tags or otherwise we will not be able to run 'git describe'
and post a new version.

This was preventing publication of new commits for daily testing.