### PR TITLE
x86: 32-bit: enable thread stack info

### DIFF
--- a/arch/x86/core/Kconfig.ia32
+++ b/arch/x86/core/Kconfig.ia32
@@ -55,6 +55,7 @@ config X86_ENABLE_TSS
 config X86_STACK_PROTECTION
 	bool
 	default y if HW_STACK_PROTECTION
+	select THREAD_STACK_INFO
 	select SET_GDT
 	select GDT_DYNAMIC
 	select X86_ENABLE_TSS


### PR DESCRIPTION
The hardware stack overflow feature requires
CONFIG_THREAD_STACK_INFO enabled in order to distingush
stack overflows from other causes when we get an exception.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>