### PR TITLE
libc: malloc: log an error when malloc is called and arena size is 0

### DIFF
--- a/lib/libc/minimal/source/stdlib/malloc.c
+++ b/lib/libc/minimal/source/stdlib/malloc.c
@@ -57,7 +57,7 @@ void *malloc(size_t size)
 {
 	ARG_UNUSED(size);
 
-	LOG_DBG("CONFIG_MINIMAL_LIBC_MALLOC_ARENA_SIZE is 0");
+	LOG_ERR("CONFIG_MINIMAL_LIBC_MALLOC_ARENA_SIZE is 0");
 	errno = ENOMEM;
 
 	return NULL;


### PR DESCRIPTION
Previously, if the arena size was zero, malloc would always fail.
However, the log message was only visible if debug messages were
enabled. Logging an error will hopefully make it more obvious that
CONFIG_MINIMAL_LIBC_MALLOC_ARENA_SIZE should be >= if the minimal
libc and malloc are both used.

Fixes #26720