### PR TITLE
userspace: mark z_app_regions as const

### DIFF
--- a/include/app_memory/app_memdomain.h
+++ b/include/app_memory/app_memdomain.h
@@ -117,7 +117,7 @@ struct z_app_region {
 	extern char Z_APP_BSS_START(name)[]; \
 	extern char Z_APP_BSS_SIZE(name)[]; \
 	Z_GENERIC_SECTION(.app_regions.name) \
-	struct z_app_region name##_region = { \
+	const struct z_app_region name##_region = { \
 		.bss_start = &Z_APP_BSS_START(name), \
 		.bss_size = (size_t) &Z_APP_BSS_SIZE(name) \
 	}; \


### PR DESCRIPTION
These are read-only structures used to clear the various
BSS regions. Mark as constant data.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>