### PR TITLE
samples: subsys: mgmt: smp_svr: doc fix

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
@@ -149,8 +149,8 @@ To sign the sample image we built in a previous step:
 
     west sign -t imgtool -- --key bootloader/mcuboot/root-rsa-2048.pem
 
-The above command creates an image file called :file:`zephyr.signed.bin` in the
-build directory.
+The above command creates signed image files called :file:`zephyr.signed.bin` and
+:file:`zephyr.signed.hex` in the build directory.
 
 For more information on image signing and ``west sign``, see the :ref:`west-sign`
 documentation.
@@ -158,7 +158,7 @@ documentation.
 Flashing the sample image
 *************************
 
-Upload the :file:`zephyr.signed.bin` file from the previous to image slot-0 of your
+Upload the :file:`zephyr.signed.hex` file from the previous to image slot-0 of your
 board.  The location of image slot-0 varies by board, as described in
 :ref:`mcuboot_partitions`.
 
@@ -168,7 +168,7 @@ the image.
 
 .. code-block:: console
 
-    west flash --bin-file build/zephyr/zephyr.signed.bin
+    west flash --hex-file build/zephyr/zephyr.signed.hex
 
 We need to explicity specify the *signed* image file, otherwise the non-signed version
 will be used and the image wont be runnable.

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -116,7 +116,7 @@ def kobject_to_enum(kobj):
     return "K_OBJ_%s" % name.upper()
 
 subsystems = [
-    # Editing the list is deprecated, add the __subsystem sentinal to your driver
+    # Editing the list is deprecated, add the __subsystem sentinel to your driver
     # api declaration instead. e.x.
     #
     # __subsystem struct my_driver_api {


### PR DESCRIPTION
Specify hex file when flashing image.

If bin file is specified west will use non signed hex file and mcuboot
fails to boot primary image with:
"Image in the primary slot is not valid".

Signed-off-by: Nick Ward <nix.ward@gmail.com>