### PR TITLE
net: mqtt: Prevent double CONNACK event notification on server reject

### DIFF
--- a/subsys/net/lib/mqtt/mqtt_rx.c
+++ b/subsys/net/lib/mqtt/mqtt_rx.c
@@ -42,6 +42,8 @@ static int mqtt_handle_packet(struct mqtt_client *client,
 						MQTT_CONNECTION_ACCEPTED) {
 				/* Set state. */
 				MQTT_SET_STATE(client, MQTT_STATE_CONNECTED);
+			} else {
+				err_code = -ECONNREFUSED;
 			}
 
 			evt.result = evt.param.connack.return_code;


### PR DESCRIPTION
Currently, the application could receive a duplicate CONNACK event, in
case the server rejected the connection at MQTT level (with an error
code provided with CONNACK message). A subsequent connection close (with
`mqtt_abort` for instance) would produce the duplicate event.

Fix this by reporting back to the MQTT engine, that the connection was
refused, so it can close the connection rightaway. Rework the event
notification logic, so that DISCONNECT event instead of a duplicate
CONNACK event is notified in that case.

Also, prevent the MQTT engine from notyfing DISCONNECT event in case of
socket errors during initial connection phase (i. e. before
`mqtt_connect` function finished).

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>