### PR TITLE
At45 dts sector size

### DIFF
--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -39,8 +39,6 @@ LOG_MODULE_REGISTER(spi_flash_at45, CONFIG_FLASH_LOG_LEVEL);
 /* - Buffer and Page Size Configuration, "Power of 2" binary page size */
 #define CMD_BINARY_PAGE_SIZE	{ 0x3D, 0x2A, 0x80, 0xA6 }
 
-#define AT45_SECTOR_SIZE	0x10000UL
-
 #define STATUS_REG_LSB_RDY_BUSY_BIT	0x80
 #define STATUS_REG_LSB_PAGE_SIZE_BIT	0x01
 
@@ -70,6 +68,7 @@ struct spi_flash_at45_config {
 	struct flash_pages_layout pages_layout;
 #endif
 	uint32_t chip_size;
+	uint32_t sector_size;
 	uint16_t block_size;
 	uint16_t page_size;
 	uint16_t t_enter_dpd; /* in microseconds */
@@ -449,12 +448,12 @@ static int spi_flash_at45_erase(struct device *dev, off_t offset, size_t size)
 		err = perform_chip_erase(dev);
 	} else {
 		while (size) {
-			if (is_erase_possible(AT45_SECTOR_SIZE,
+			if (is_erase_possible(cfg->sector_size,
 					      offset, size)) {
 				err = perform_erase_op(dev, CMD_SECTOR_ERASE,
 						       offset);
-				offset += AT45_SECTOR_SIZE;
-				size   -= AT45_SECTOR_SIZE;
+				offset += cfg->sector_size;
+				size   -= cfg->sector_size;
 			} else if (is_erase_possible(cfg->block_size,
 						     offset, size)) {
 				err = perform_erase_op(dev, CMD_BLOCK_ERASE,
@@ -684,6 +683,7 @@ static const struct flash_driver_api spi_flash_at45_api = {
 				.pages_size  = DT_INST_PROP(idx, page_size), \
 			},))						     \
 		.chip_size   = INST_##idx##_BYTES,			     \
+		.sector_size = DT_INST_PROP(idx, sector_size),		     \
 		.block_size  = DT_INST_PROP(idx, block_size),		     \
 		.page_size   = DT_INST_PROP(idx, page_size),		     \
 		.t_enter_dpd = ceiling_fraction(			     \

--- a/dts/bindings/mtd/atmel,at45.yaml
+++ b/dts/bindings/mtd/atmel,at45.yaml
@@ -18,6 +18,11 @@ properties:
     required: true
     description: Flash capacity in bits.
 
+  sector-size:
+    type: int
+    required: true
+    description: Flash sector size in bytes.
+
   block-size:
     type: int
     required: true

--- a/samples/drivers/spi_flash_at45/nrf9160dk_nrf9160.overlay
+++ b/samples/drivers/spi_flash_at45/nrf9160dk_nrf9160.overlay
@@ -17,6 +17,7 @@
 		label = "DATAFLASH_0";
 		jedec-id = [1f 24 00];
 		size = <4194304>;
+		sector-size = <65536>;
 		block-size = <2048>;
 		page-size = <256>;
 		enter-dpd-delay = <2000>;
@@ -30,6 +31,7 @@
 		label = "DATAFLASH_1";
 		jedec-id = [1f 27 01];
 		size = <33554432>;
+		sector-size = <65536>;
 		block-size = <4096>;
 		page-size = <512>;
 		use-udpd;


### PR DESCRIPTION
Current driver implementation uses hardcoded constant `AT45_SECTOR_SIZE` which is valid for only a subset of at45 flash memories. Coincidentally, both devices used in sample have sector size which matches the defined number (64K). This results in some nasty behavior when used with another at45 memory which doesn't have sector size equal to `0x10000` (e.g. at45db161e has sector size 128KB).

This PR fixes the issue by introducing new property `sector_size` in device tree binding as there are already block and page size there. This makes most sense as different at45 memories have different sizes and they should be defined in device tree.

```yaml
at45db161e@0 {
    compatible = "atmel,at45";
    reg = <0>;
    spi-max-frequency = <8500000>;
    label = "DATAFLASH_1";
    jedec-id = [1f 26 00];
    size = <16777216>;
    sector-size = <131072>;
    block-size = <4096>;
    page-size = <512>;
    use-udpd;
    enter-dpd-delay = <1000>;
    exit-dpd-delay = <180000>;
};
```
