### PR TITLE
settings: disallow modifying the content of a subtree name

### DIFF
--- a/include/settings/settings.h
+++ b/include/settings/settings.h
@@ -63,7 +63,7 @@ typedef ssize_t (*settings_read_cb)(void *cb_arg, void *data, size_t len);
  */
 struct settings_handler {
 
-	char *name;
+	const char *name;
 	/**< Name of subtree. */
 
 	int (*h_get)(const char *key, char *val, int val_len_max);


### PR DESCRIPTION
There may be value in being able to rename a subtree, but there is no
identified need to be able modify the text of an assigned subtree
name.

Fixes #26953