### PR TITLE
scripts: modules: Fix initialization of variable

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -197,6 +197,8 @@ def main():
             # workspace. Such setup is allowed, as west may be installed
             # but the project is not required to use west.
             projects = []
+    else:
+        projects = args.modules.copy()
 
     projects += args.extra_modules
     extra_modules = set(args.extra_modules)


### PR DESCRIPTION
The projects variable needs to be initialized with the list of modules
provided via cmd-line arguments.

This is a regression introduced by
ef3c5e551676278ccc1f42ecb572838144c5e33a.

Fixes #26948.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>