### PR TITLE
net: config: Fix missing error log when timeout happens

### DIFF
--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -402,7 +402,7 @@ int net_config_init(const char *app_info, uint32_t flags, int32_t timeout)
 		k_sem_take(&waiter, K_MSEC(loop));
 	}
 
-	if (!count && timeout) {
+	if (count == -1 && timeout > 0) {
 		NET_ERR("Timeout while waiting network %s", "setup");
 		return -ETIMEDOUT;
 	}


### PR DESCRIPTION
The timeout log error message condition in wrong. When the timeout
happens the "count == -1" and the condition is invalid.
