### PR TITLE
net: openthread: platform: Removed double-buffering in UART send.

### DIFF
--- a/subsys/net/lib/openthread/platform/uart.c
+++ b/subsys/net/lib/openthread/platform/uart.c
@@ -29,7 +29,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include "platform-zephyr.h"
 
 struct openthread_uart {
-	struct ring_buf *tx_ringbuf;
 	struct ring_buf *rx_ringbuf;
 	struct device *dev;
 	atomic_t tx_busy;
@@ -37,10 +36,8 @@ struct openthread_uart {
 };
 
 #define OT_UART_DEFINE(_name, _ringbuf_size) \
-	RING_BUF_DECLARE(_name##_tx_ringbuf, _ringbuf_size); \
 	RING_BUF_DECLARE(_name##_rx_ringbuf, _ringbuf_size); \
 	static struct openthread_uart _name = { \
-		.tx_ringbuf = &_name##_tx_ringbuf, \
 		.rx_ringbuf = &_name##_rx_ringbuf, \
 	}
 
@@ -49,6 +46,8 @@ OT_UART_DEFINE(ot_uart, CONFIG_OPENTHREAD_NCP_UART_RING_BUFFER_SIZE);
 #define RX_FIFO_SIZE 128
 
 static bool is_panic_mode;
+static const uint8_t *write_buffer;
+static uint16_t write_length;
 
 static void uart_rx_handle(void)
 {
@@ -92,17 +91,12 @@ static void uart_rx_handle(void)
 static void uart_tx_handle(void)
 {
 	uint32_t len;
-	const uint8_t *data;
 
-	len = ring_buf_get_claim(ot_uart.tx_ringbuf, (uint8_t **)&data,
-				 ot_uart.tx_ringbuf->size);
-	if (len) {
-		int err;
-
-		len = uart_fifo_fill(ot_uart.dev, data, len);
-		err = ring_buf_get_finish(ot_uart.tx_ringbuf, len);
-		(void)err;
-		__ASSERT_NO_MSG(err == 0);
+	if (write_length) {
+		len = uart_fifo_fill(ot_uart.dev, write_buffer,
+				     write_length);
+		write_buffer += len;
+		write_length -= len;
 	} else {
 		uart_irq_tx_disable(ot_uart.dev);
 		ot_uart.tx_busy = 0;
@@ -199,15 +193,28 @@ otError otPlatUartEnable(void)
 
 otError otPlatUartDisable(void)
 {
-	/* TODO: uninit UART */
-	LOG_WRN("%s not implemented.", __func__);
-	return OT_ERROR_NOT_IMPLEMENTED;
+#ifdef CONFIG_OPENTHREAD_NCP_SPINEL_ON_UART_ACM
+	int ret = usb_disable();
+
+	if (ret) {
+		LOG_WRN("Failed to disable USB (%d)", ret);
+	}
+#endif
+
+	uart_irq_tx_disable(ot_uart.dev);
+	uart_irq_rx_disable(ot_uart.dev);
+	return OT_ERROR_NONE;
 };
 
 
 otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 {
-	size_t cnt = ring_buf_put(ot_uart.tx_ringbuf, aBuf, aBufLength);
+	if (aBuf == NULL) {
+		return OT_ERROR_FAILED;
+	}
+
+	write_buffer = aBuf;
+	write_length = aBufLength;
 
 	if (atomic_set(&(ot_uart.tx_busy), 1) == 0) {
 		if (is_panic_mode) {
@@ -220,31 +227,18 @@ otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 		}
 	}
 
-	if (cnt == aBufLength) {
-		return OT_ERROR_NONE;
-	} else {
-		return OT_ERROR_BUSY;
-	}
+	return OT_ERROR_NONE;
 };
 
 otError otPlatUartFlush(void)
 {
-	uint32_t len;
-	const uint8_t *data;
 	otError result = OT_ERROR_NONE;
 
-	do {
-		len = ring_buf_get_claim(ot_uart.tx_ringbuf, (uint8_t **)&data,
-					 ot_uart.tx_ringbuf->size);
-
-		if (len) {
-			for (size_t i = 0; i < len; i++) {
-				uart_poll_out(ot_uart.dev, data[i]);
-			}
-
-			ring_buf_get_finish(ot_uart.rx_ringbuf, len);
+	if (write_length) {
+		for (size_t i = 0; i < write_length; i++) {
+			uart_poll_out(ot_uart.dev, *(write_buffer+i));
 		}
-	} while (len);
+	}
 
 	ot_uart.tx_busy = 0;
 	atomic_set(&(ot_uart.tx_finished), 1);


### PR DESCRIPTION
Putting data to local buffer before transmission was removed to optimize operation.
Local buffering was not needed, as passed buffer cannot be modified until sending is finished.

Signed-off-by: Kamil Kasperczyk kamil.kasperczyk@nordicsemi.no