### PR TITLE
mgmt: smp: shell: initialize SMP before feeding with received bytes

### DIFF
--- a/include/mgmt/mcumgr/smp_shell.h
+++ b/include/mgmt/mcumgr/smp_shell.h
@@ -48,6 +48,16 @@ bool smp_shell_rx_byte(struct smp_shell_data *data, uint8_t byte);
  */
 void smp_shell_process(struct smp_shell_data *data);
 
+/**
+ * @brief Initializes SMP transport over shell.
+ *
+ * This function should be called before feeding SMP transport with received
+ * data.
+ *
+ * @return 0 on success
+ */
+int smp_shell_init(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/shell/shell_uart.h
+++ b/include/shell/shell_uart.h
@@ -10,9 +10,7 @@
 #include <shell/shell.h>
 #include <sys/ring_buffer.h>
 #include <sys/atomic.h>
-#ifdef CONFIG_MCUMGR_SMP_SHELL
 #include "mgmt/mcumgr/smp_shell.h"
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/subsys/mgmt/mcumgr/smp_shell.c
+++ b/subsys/mgmt/mcumgr/smp_shell.c
@@ -155,14 +155,10 @@ static int smp_shell_tx_pkt(struct zephyr_smp_transport *zst,
 	return rc;
 }
 
-static int smp_shell_init(struct device *dev)
+int smp_shell_init(void)
 {
-	ARG_UNUSED(dev);
-
 	zephyr_smp_transport_init(&smp_shell_transport, smp_shell_tx_pkt,
 				  smp_shell_get_mtu, NULL, NULL);
 
 	return 0;
 }
-
-SYS_INIT(smp_shell_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -275,6 +275,10 @@ static int enable_shell_uart(struct device *arg)
 		return -ENODEV;
 	}
 
+	if (IS_ENABLED(CONFIG_MCUMGR_SMP_SHELL)) {
+		smp_shell_init();
+	}
+
 	shell_init(&shell_uart, dev, true, log_backend, level);
 
 	return 0;


### PR DESCRIPTION
So far SMP shell transport was initialized in APPLICATION run level, but
shell over UART was initialized in POST_KERNEL. This could end up in
situation when received frames were scheduled for further processing in
SMP layer, when it was not initialized yet.

This ends up with following error when running on nrf52 platform:
```
[00:00:01.426,361] <err> os: ***** MPU FAULT *****
[00:00:01.426,391] <err> os:   Instruction Access Violation
[00:00:01.426,391] <err> os: r0/a1:  0x00000000  r1/a2:  0x00000004  r2/a3:  0x00009cb9
[00:00:01.426,391] <err> os: r3/a4:  0x44f7df40 r12/ip:  0x00000080 r14/lr:  0x00033201
[00:00:01.426,391] <err> os:  xpsr:  0x60000000
[00:00:01.426,422] <err> os: Faulting instruction address (r15/pc): 0x44f7df40
[00:00:01.426,422] <err> os: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
[00:00:01.426,422] <err> os: Current thread: 0x200021e0 (shell_uart)
[00:00:02.382,446] <err> os: Halting system
```

Export smp_shell_init() function declaration and call it before shell is
initialized with all its receive data handlers. This prevents situation
when data is scheduled for processing in SMP layer, when that one is not
ready yet.