### PR TITLE
subsys/fs/fatfs: Add kconfig option for enabling exFAT support

### DIFF
--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -52,6 +52,12 @@ config FUSE_FS_ACCESS
 menu "FatFs Settings"
 	visible if FAT_FILESYSTEM_ELM
 
+config FS_FATFS_EXFAT
+	bool "Enable exFAT support"
+	select FS_FATFS_LFN
+	help
+	  Enable the exFAT format support for FatFs.
+
 config FS_FATFS_NUM_FILES
 	int "Maximum number of opened files"
 	default 4

--- a/west.yml
+++ b/west.yml
@@ -47,7 +47,7 @@ manifest:
       revision: 6835bfc741bf15e98fb7971293913f770df6081f
       path: modules/hal/esp-idf
     - name: fatfs
-      revision: 9ee6b9b9511151d0d64a74d532d39c6f2bbd4f16
+      revision: 13697783bf653dfdf17c57129ce8e181634e5970
       path: modules/fs/fatfs
     - name: hal_cypress
       revision: a12d92816a53a521d79cefcf5c38b9dc8a4fed6e


### PR DESCRIPTION
Expose the exFAT support option to Kconfig, so developer can enable/disable the exFAT support on FatFs through Kconfig, no need to touch ffconf.h.

Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>