### PR TITLE
Make LiteX CSR accessors more versatile

### DIFF
--- a/drivers/gpio/gpio_litex.c
+++ b/drivers/gpio/gpio_litex.c
@@ -83,7 +83,7 @@ static int gpio_litex_init(struct device *dev)
 	const struct gpio_litex_cfg *gpio_config = DEV_GPIO_CFG(dev);
 
 	/* each 4-byte register is able to handle 8 GPIO pins */
-	if (gpio_config->nr_gpios > (gpio_config->reg_size / 4) * 8) {
+	if (gpio_config->nr_gpios > (gpio_config->reg_size * 8)) {
 		LOG_ERR("%s", LITEX_LOG_REG_SIZE_NGPIOS_MISMATCH);
 		return -EINVAL;
 	}
@@ -223,7 +223,7 @@ static const struct gpio_driver_api gpio_litex_driver_api = {
 	static const struct gpio_litex_cfg gpio_litex_cfg_##n = { \
 		.reg_addr = \
 		(volatile uint32_t *) DT_INST_REG_ADDR(n), \
-		.reg_size = DT_INST_REG_SIZE(n), \
+		.reg_size = DT_INST_REG_SIZE(n) / 4, \
 		.nr_gpios = DT_INST_PROP(n, ngpios), \
 		.port_is_output = DT_INST_PROP(n, port_is_output), \
 	}; \

--- a/soc/riscv/litex-vexriscv/soc.h
+++ b/soc/riscv/litex-vexriscv/soc.h
@@ -10,6 +10,9 @@
 #include "../riscv-privilege/common/soc_common.h"
 #include <devicetree.h>
 
+#define LITEX_SUBREG_SIZE          0x1
+#define LITEX_SUBREG_SIZE_BIT      (LITEX_SUBREG_SIZE * 8)
+
 /* lib-c hooks required RAM defined variables */
 #define RISCV_RAM_BASE              DT_REG_ADDR(DT_INST(0, mmio_sram))
 #define RISCV_RAM_SIZE              DT_REG_SIZE(DT_INST(0, mmio_sram))
@@ -67,32 +70,27 @@ static inline void litex_write32(unsigned int value, unsigned long addr)
 	sys_write8(value, addr + 0xC);
 }
 
-/* `reg_size` is assumed to be a multiple of 4 */
 static inline void litex_write(volatile uint32_t *reg, uint32_t reg_size, uint32_t val)
 {
-	uint32_t shifted_data;
+	uint32_t shifted_data, i;
 	volatile uint32_t *reg_addr;
-	uint32_t subregs = reg_size / 4;
 
-	for (int i = 0; i < subregs; ++i) {
-		shifted_data = val >> ((subregs - i - 1) * 8);
+	for (i = 0; i < reg_size; ++i) {
+		shifted_data = val >> ((reg_size - i - 1) *
+					LITEX_SUBREG_SIZE_BIT);
 		reg_addr = ((volatile uint32_t *) reg) + i;
 		*(reg_addr) = shifted_data;
 	}
 }
 
-/* `reg_size` is assumed to be a multiple of 4 */
 static inline uint32_t litex_read(volatile uint32_t *reg, uint32_t reg_size)
 {
-	uint32_t shifted_data;
-	volatile uint32_t *reg_addr;
-	uint32_t result = 0;
-	uint32_t subregs = reg_size / 4;
+	uint32_t shifted_data, i, result = 0;
 
-	for (int i = 0; i < subregs; ++i) {
-		reg_addr = ((volatile uint32_t *) reg) + i;
-		shifted_data = *(reg_addr);
-		result |= (shifted_data << ((subregs - i - 1) * 8));
+	for (i = 0; i < reg_size; ++i) {
+		shifted_data = *(reg + i) << ((reg_size - i - 1) *
+						LITEX_SUBREG_SIZE_BIT);
+		result |= shifted_data;
 	}
 
 	return result;


### PR DESCRIPTION
This modifies LiteX CSR accesors by removing the limitation for the `reg_size` argument to be a multiple of 4 and adapts the existing drivers to this change.