### PR TITLE
manifest: hal_microchip: Add eSPI SAF support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
       revision: b4d31f33238713a568e23618845702fadd67386f
       path: modules/hal/nuvoton
     - name: hal_microchip
-      revision: aad89bf0531a30dcd6c87e4065f1b973fb31c11f
+      revision: a1ec761014740a08699720298dd37ad4da360840
       path: modules/hal/microchip
     - name: hal_silabs
       revision: 78da967feeac0d51219ef733cc3ccf643336589f


### PR DESCRIPTION
Add eSPI SAF support to MEC15xx including SAF
changes to eSPI and QMSPI.

Signed-off-by: Scott Worley <scott.worley@microchip.com>