### PR TITLE
mgmt: smp: shell: refactor to use net_buf and allow to use multiple receive buffers

### DIFF
--- a/include/mgmt/mcumgr/smp_shell.h
+++ b/include/mgmt/mcumgr/smp_shell.h
@@ -17,12 +17,14 @@
 extern "C" {
 #endif
 
+#define SMP_SHELL_RX_BUF_SIZE	127
+
 /** @brief Data used by SMP shell */
 struct smp_shell_data {
-	char mcumgr_buff[128];
-	bool cmd_rdy;
+	struct net_buf_pool *buf_pool;
+	struct k_fifo buf_ready;
+	struct net_buf *buf;
 	atomic_t esc_state;
-	uint32_t cur;
 };
 
 /**

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -263,15 +263,23 @@ config MCUMGR_SMP_SHELL
 	  Enables handling of SMP commands received over shell.  This allows
 	  the shell to be use for both mcumgr commands and shell commands.
 
+if MCUMGR_SMP_SHELL
+
 config MCUMGR_SMP_SHELL_MTU
 	int "Shell SMP MTU"
 	default 256
-	depends on MCUMGR_SMP_SHELL
 	help
 	  Maximum size of SMP frames sent and received over shell.  This value
 	  must satisfy the following relation:
 	  MCUMGR_SMP_SHELL_MTU <= MCUMGR_BUF_SIZE + 2
 
+config MCUMGR_SMP_SHELL_RX_BUF_COUNT
+	int "Shell SMP RX buffer count"
+	default 2
+	help
+	  Number of buffers used for receiving SMP fragments over shell.
+
+endif # MCUMGR_SMP_SHELL
 
 config MCUMGR_SMP_UART
 	bool "UART mcumgr SMP transport"

--- a/subsys/mgmt/mcumgr/smp_shell.c
+++ b/subsys/mgmt/mcumgr/smp_shell.c
@@ -22,6 +22,9 @@
 #include "shell/shell.h"
 #include "shell/shell_uart.h"
 
+#include <logging/log.h>
+LOG_MODULE_REGISTER(smp_shell);
+
 static struct zephyr_smp_transport smp_shell_transport;
 
 static struct mcumgr_serial_rx_ctxt smp_shell_rx_ctxt;
@@ -101,6 +104,9 @@ size_t smp_shell_rx_bytes(struct smp_shell_data *data, const uint8_t *bytes,
 		} else if (mcumgr_state == SMP_SHELL_MCUMGR_STATE_HEADER &&
 			   !data->buf) {
 			data->buf = net_buf_alloc(data->buf_pool, K_NO_WAIT);
+			if (!data->buf) {
+				LOG_WRN("Failed to alloc SMP buf");
+			}
 		}
 
 		if (data->buf && net_buf_tailroom(data->buf) > 0) {

--- a/subsys/mgmt/mcumgr/smp_shell.c
+++ b/subsys/mgmt/mcumgr/smp_shell.c
@@ -98,23 +98,26 @@ size_t smp_shell_rx_bytes(struct smp_shell_data *data, const uint8_t *bytes,
 
 		if (mcumgr_state == SMP_SHELL_MCUMGR_STATE_NONE) {
 			break;
+		} else if (mcumgr_state == SMP_SHELL_MCUMGR_STATE_HEADER &&
+			   !data->buf) {
+			data->buf = net_buf_alloc(data->buf_pool, K_NO_WAIT);
 		}
 
-		if (data->cur < sizeof(data->mcumgr_buff) - 1) {
-			data->mcumgr_buff[data->cur] = byte;
-			++data->cur;
+		if (data->buf && net_buf_tailroom(data->buf) > 0) {
+			net_buf_add_u8(data->buf, byte);
 		}
 
 		/* Newline in payload means complete frame */
 		if (mcumgr_state == SMP_SHELL_MCUMGR_STATE_PAYLOAD &&
 		    byte == '\n') {
-			data->mcumgr_buff[data->cur] = '\0';
-			data->cmd_rdy = true;
+			if (data->buf) {
+				net_buf_put(&data->buf_ready, data->buf);
+				data->buf = NULL;
+			}
 			atomic_clear_bit(&data->esc_state, ESC_MCUMGR_PKT_1);
 			atomic_clear_bit(&data->esc_state, ESC_MCUMGR_PKT_2);
 			atomic_clear_bit(&data->esc_state, ESC_MCUMGR_FRAG_1);
 			atomic_clear_bit(&data->esc_state, ESC_MCUMGR_FRAG_2);
-			data->cur = 0U;
 		}
 
 		++consumed;
@@ -125,21 +128,22 @@ size_t smp_shell_rx_bytes(struct smp_shell_data *data, const uint8_t *bytes,
 
 void smp_shell_process(struct smp_shell_data *data)
 {
-	if (data->cmd_rdy) {
-		data->cmd_rdy = false;
-		struct net_buf *nb;
-		int line_len;
+	struct net_buf *buf;
+	struct net_buf *nb;
 
-		/* Strip the trailing newline. */
-		line_len = strlen(data->mcumgr_buff) - 1;
-
-		nb = mcumgr_serial_process_frag(&smp_shell_rx_ctxt,
-						data->mcumgr_buff,
-						line_len);
-		if (nb != NULL) {
-			zephyr_smp_rx_req(&smp_shell_transport, nb);
-		}
+	buf = net_buf_get(&data->buf_ready, K_NO_WAIT);
+	if (!buf) {
+		return;
 	}
+
+	nb = mcumgr_serial_process_frag(&smp_shell_rx_ctxt,
+					buf->data,
+					buf->len);
+	if (nb != NULL) {
+		zephyr_smp_rx_req(&smp_shell_transport, nb);
+	}
+
+	net_buf_unref(buf);
 }
 
 static uint16_t smp_shell_get_mtu(const struct net_buf *nb)

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -20,8 +20,8 @@ LOG_MODULE_REGISTER(shell_uart);
 #endif
 
 #ifdef CONFIG_MCUMGR_SMP_SHELL
-NET_BUF_POOL_DEFINE(smp_shell_rx_pool, 1, SMP_SHELL_RX_BUF_SIZE,
-		    0, NULL);
+NET_BUF_POOL_DEFINE(smp_shell_rx_pool, CONFIG_MCUMGR_SMP_SHELL_RX_BUF_COUNT,
+		    SMP_SHELL_RX_BUF_SIZE, 0, NULL);
 #endif /* CONFIG_MCUMGR_SMP_SHELL */
 
 SHELL_UART_DEFINE(shell_transport_uart,

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -8,6 +8,7 @@
 #include <drivers/uart.h>
 #include <init.h>
 #include <logging/log.h>
+#include <net/buf.h>
 
 #define LOG_MODULE_NAME shell_uart
 LOG_MODULE_REGISTER(shell_uart);
@@ -17,6 +18,11 @@ LOG_MODULE_REGISTER(shell_uart);
 #else
 #define RX_POLL_PERIOD K_NO_WAIT
 #endif
+
+#ifdef CONFIG_MCUMGR_SMP_SHELL
+NET_BUF_POOL_DEFINE(smp_shell_rx_pool, 1, SMP_SHELL_RX_BUF_SIZE,
+		    0, NULL);
+#endif /* CONFIG_MCUMGR_SMP_SHELL */
 
 SHELL_UART_DEFINE(shell_transport_uart,
 		  CONFIG_SHELL_BACKEND_SERIAL_TX_RING_BUFFER_SIZE,
@@ -168,6 +174,11 @@ static int init(const struct shell_transport *transport,
 	sh_uart->ctrl_blk->dev = (const struct device *)config;
 	sh_uart->ctrl_blk->handler = evt_handler;
 	sh_uart->ctrl_blk->context = context;
+
+#ifdef CONFIG_MCUMGR_SMP_SHELL
+	sh_uart->ctrl_blk->smp.buf_pool = &smp_shell_rx_pool;
+	k_fifo_init(&sh_uart->ctrl_blk->smp.buf_ready);
+#endif
 
 	if (IS_ENABLED(CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN)) {
 		uart_irq_init(sh_uart);


### PR DESCRIPTION
Refactor SMP fragment receive implementation to use net_buf for storing received data. This allows to have multiple buffers simulatenously and move those buffers between 3 different stages:
1) waiting for use in net_buf pool,
2) in use by interrupt handler, with partly received data in it,
3) waiting for processing in thread.

More details are in each commit description. This PR basically solves highly probably race condition between filling up whole received fragment and processing it. So far there was no mechanism that prevented overwriting already received fragment with new bytes. The only reason why this was not reproducible so far is the 20ms sleep in mcumgr implementation here: https://github.com/apache/mynewt-newtmgr/blob/11e8797b2df44c21ccca4fe9a9a35169ac19aec7/nmxact/nmserial/serial_xport.go#L279. After playing a bit with timeouts it seems like with 10ms and nrf52840 based board there is a big problem to transfer big files (e.g. ~200k with image upload command). First of all this means that on another platform 20ms might not be enough. Second thing is that removing this 20ms timeout completely from mcumgr (which is possible after this PR) will roughly double data transfer speed (e.g. during firmware upgrade).