### PR TITLE
net: openthread: Allow use of custom mbedtls

### DIFF
--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -22,6 +22,15 @@ menuconfig NET_L2_OPENTHREAD
 	select REBOOT
 	select ENTROPY_GENERATOR
 
+	imply NET_UDP
+	imply NET_IPV6
+	imply NET_CONFIG_NEED_IPV6
+
+if NET_L2_OPENTHREAD
+
+config OPENTHREAD_MBEDTLS
+	bool "Enable built-in mbedtls for use with OpenThread"
+	default y
 	select MBEDTLS
 	select MBEDTLS_ENABLE_HEAP
 	select MBEDTLS_CIPHER_AES_ENABLED
@@ -31,12 +40,22 @@ menuconfig NET_L2_OPENTHREAD
 	select MBEDTLS_MAC_CMAC_ENABLED
 	select MBEDTLS_CIPHER
 	select MBEDTLS_MD
+	select MBEDTLS_TLS_VERSION_1_2 if OPENTHREAD_COMMISSIONER || OPENTHREAD_JOINER
+	select MBEDTLS_DTLS if OPENTHREAD_COMMISSIONER || OPENTHREAD_JOINER
+	select MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED if OPENTHREAD_COMMISSIONER || OPENTHREAD_JOINER
+	select MBEDTLS_ECP_DP_SECP256R1_ENABLED if OPENTHREAD_COMMISSIONER || OPENTHREAD_JOINER
+	select MBEDTLS_ECP_NIST_OPTIM if OPENTHREAD_COMMISSIONER || OPENTHREAD_JOINER
+	select MBEDTLS_SSL_EXPORT_KEYS if OPENTHREAD_COMMISSIONER || OPENTHREAD_JOINER
+	select MBEDTLS_CTR_DRBG_ENABLED if OPENTHREAD_COMMISSIONER || OPENTHREAD_JOINER
+	select MBEDTLS_HMAC_DRBG_ENABLED if OPENTHREAD_COMMISSIONER || OPENTHREAD_JOINER
 
-	imply NET_UDP
-	imply NET_IPV6
-	imply NET_CONFIG_NEED_IPV6
-
-if NET_L2_OPENTHREAD
+config OPENTHREAD_MBEDTLS_TARGET
+	string "mbedtls target name"
+	default "mbedTLS"
+	help
+	  This option allows to specify custom mbedtls CMake target name for
+	  openthread. This is sometimes needed to utilize hardware cryptography
+	  acceleration.
 
 choice OPENTHREAD_IMPLEMENTATION
 	prompt "OpenThread Selection"
@@ -50,18 +69,6 @@ config OPENTHREAD_SOURCES
 	  Build Zephyrs OpenThread port from sources.
 
 endchoice
-
-config OPENTHREAD_DTLS
-	# Hidden option to enable DTLS support in OpenThread
-	bool
-	select MBEDTLS_TLS_VERSION_1_2
-	select MBEDTLS_DTLS
-	select MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
-	select MBEDTLS_ECP_DP_SECP256R1_ENABLED
-	select MBEDTLS_ECP_NIST_OPTIM
-	select MBEDTLS_SSL_EXPORT_KEYS
-	select MBEDTLS_CTR_DRBG_ENABLED
-	select MBEDTLS_HMAC_DRBG_ENABLED
 
 config OPENTHREAD_PLAT
 	bool
@@ -207,7 +214,6 @@ config OPENTHREAD_DIAG
 
 config OPENTHREAD_COMMISSIONER
 	bool "Commissioner functions support"
-	select OPENTHREAD_DTLS
 	help
 	  Enable commissioner capability in OpenThread stack. Note, that DTLS
 	  handshake used in the commissioning procedure requires a larger
@@ -216,7 +222,6 @@ config OPENTHREAD_COMMISSIONER
 
 config OPENTHREAD_JOINER
 	bool "Joiner functions support"
-	select OPENTHREAD_DTLS
 	help
 	  Enable joiner capability in OpenThread stack. Note, that DTLS
 	  handshake used in the commissioning procedure requires a larger

--- a/west.yml
+++ b/west.yml
@@ -107,7 +107,7 @@ manifest:
       revision: 170a2579dd890f78f5056f0959cdb9c9bea259a1
       path: modules/lib/loramac-node
     - name: openthread
-      revision: a0a7e20213aba98d18f50cd52008f9dbffd1bc5c
+      revision: 168248677cacbf9cc5e0c94b8f0682259cfd5f40
       path: modules/lib/openthread
     - name: segger
       revision: 6fcf61606d6012d2c44129edc033f59331e268bc


### PR DESCRIPTION
To allow hardware crypto acceleration custom mbedtls library needs to be
prepared. However current implementation forces the default library to
be used.
This patch allows not using the default library and passing custom
mbedtls target to use with openthread.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>