### PR TITLE
NUCLEO-H745ZI-Q add ethernet driver support for Cortex-M4

### DIFF
--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m4.dts
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m4.dts
@@ -10,13 +10,13 @@
 #include "nucleo_h745zi_q.dtsi"
 
 / {
-	model = "STMicroelectronics STM32H745ZI-NUCLEO board";
-	compatible = "st,stm32h745zi-nucleo", "st,stm32h745";
+	model = "STMicroelectronics STM32H745ZI-Q-NUCLEO board";
+	compatible = "st,stm32h745zi-q-nucleo", "st,stm32h745";
 
 	/* HW resources belonging to CM4 */
 	chosen {
-		/* zephyr,console = &uart8; */
-		/* zephyr,shell-uart = &uart8; */
+		zephyr,console = &uart8;
+		zephyr,shell-uart = &uart8;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;
 	};
@@ -28,5 +28,5 @@
 
 &uart8 {
 	current-speed = <115200>;
-	/* status = "okay"; */
+	status = "okay";
 };

--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m4.yaml
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m4.yaml
@@ -6,13 +6,13 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 128
+ram: 288
 flash: 1024
 supported:
   - arduino_gpio
   - gpio
+  - netif:eth
 testing:
   ignore_tags:
     - mpu
     - nfc
-    - net

--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
@@ -13,7 +13,7 @@
 	model = "STMicroelectronics STM32H745ZI-Q-NUCLEO board";
 	compatible = "st,stm32h745zi-q-nucleo", "st,stm32h745";
 
-	/* HW resources are split between CM7/CM4 */
+	/* HW resources belonging to CM7 */
 	chosen {
 		zephyr,console = &usart3;
 		zephyr,shell-uart = &usart3;


### PR DESCRIPTION
Adding ETH driver support for Cortex-M4 core on NUCLEO-H745ZI-Q board.