### PR TITLE
buildkite: Increase timeout

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ steps:
       ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
       ZEPHYR_SDK_INSTALL_DIR: "/opt/sdk/zephyr-sdk-0.11.3"
     parallelism: 20
-    timeout_in_minutes: 120
+    timeout_in_minutes: 180
     retry:
       manual: true
     plugins:


### PR DESCRIPTION
Some jobs require more than 120 minutes to complete.
But 180 appears to be long enough.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>