### PR TITLE
drivers: eeprom_slave: add const qualifier to read-only data

### DIFF
--- a/drivers/i2c/slave/eeprom_slave.c
+++ b/drivers/i2c/slave/eeprom_slave.c
@@ -40,7 +40,7 @@ struct i2c_eeprom_slave_config {
 #define DEV_DATA(dev)							\
 	((struct i2c_eeprom_slave_data * const)(dev)->driver_data)
 
-int eeprom_slave_program(struct device *dev, uint8_t *eeprom_data,
+int eeprom_slave_program(struct device *dev, const uint8_t *eeprom_data,
 			 unsigned int length)
 {
 	struct i2c_eeprom_slave_data *data = dev->driver_data;

--- a/include/drivers/i2c/slave/eeprom.h
+++ b/include/drivers/i2c/slave/eeprom.h
@@ -29,7 +29,7 @@
  * @retval 0 If successful.
  * @retval -EINVAL Invalid data size
  */
-int eeprom_slave_program(struct device *dev, uint8_t *eeprom_data,
+int eeprom_slave_program(struct device *dev, const uint8_t *eeprom_data,
 			 unsigned int length);
 
 /**


### PR DESCRIPTION
The EEPROM device doesn't mutate the source data it's given, so update
the API signature to reflect this fact.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>