### PR TITLE
samples: adxl362: Fix building sample with sanitycheck

### DIFF
--- a/samples/sensor/adxl362/sample.yaml
+++ b/samples/sensor/adxl362/sample.yaml
@@ -5,4 +5,5 @@ tests:
   sample.sensor.adxl362:
     harness: sensor
     tags: sensors
-    depends_on: spi adxl362
+    depends_on: spi
+    platform_whitelist: nrf52dk_nrf52832


### PR DESCRIPTION
Tweak sample.yaml so we at least build this sample on one platform.

Fixes #16790

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>