### PR TITLE
sensor: fxos8700: implement magnetic vector magnitude function

### DIFF
--- a/drivers/sensor/fxos8700/Kconfig
+++ b/drivers/sensor/fxos8700/Kconfig
@@ -209,6 +209,42 @@ config FXOS8700_MOTION_INT1
 	help
 	  Say Y to route motion interrupt to INT1 pin. Say N to route to INT2 pin.
 
+menuconfig FXOS8700_MAG_VECM
+	bool "Magnetic vector-magnitude detection"
+	help
+	  Enable magnetic vector-magnitude detection
+
+if FXOS8700_MAG_VECM
+
+config FXOS8700_MAG_VECM_INT1
+	bool "Magnetic vector-magnitude interrupt to INT1 pin"
+	help
+	  Say Y to route magnetic vector-magnitude interrupt to INT1 pin.
+	  Say N to route to INT2 pin.
+
+config FXOS8700_MAG_VECM_CFG
+	hex "Magnetic vector-magnitude configuration register"
+	range 0 0x7f
+	default 0x4e
+
+config FXOS8700_MAG_VECM_THS_MSB
+	hex "Magnetic vector-magnitude threshold configuration register"
+	range 0 0x7f
+	default 0x00
+	help
+	  Seven most significant bits of 15-bit unsigned magnetic
+	  vector-magnitude threshold. Resolution is 0.1 Î¼T/LSB.
+
+config FXOS8700_MAG_VECM_THS_LSB
+	hex "Magnetic vector-magnitude threshold configuration register"
+	range 0 0xff
+	default 0x5a
+	help
+	  Eight least significant bits of 15-bit unsigned magnetic
+	  vector-magnitude threshold. Resolution is 0.1 Î¼T/LSB.
+
+endif # FXOS8700_MAG_VECM
+
 endif # FXOS8700_TRIGGER
 
 endif # FXOS8700

--- a/drivers/sensor/fxos8700/fxos8700.c
+++ b/drivers/sensor/fxos8700/fxos8700.c
@@ -586,6 +586,11 @@ static const struct fxos8700_config fxos8700_config = {
 	.pulse_ltcy = CONFIG_FXOS8700_PULSE_LTCY,
 	.pulse_wind = CONFIG_FXOS8700_PULSE_WIND,
 #endif
+#ifdef CONFIG_FXOS8700_MAG_VECM
+	.mag_vecm_cfg = CONFIG_FXOS8700_MAG_VECM_CFG,
+	.mag_vecm_ths[0] = CONFIG_FXOS8700_MAG_VECM_THS_MSB,
+	.mag_vecm_ths[1] = CONFIG_FXOS8700_MAG_VECM_THS_LSB,
+#endif
 };
 
 static struct fxos8700_data fxos8700_data;

--- a/drivers/sensor/fxos8700/fxos8700.h
+++ b/drivers/sensor/fxos8700/fxos8700.h
@@ -34,6 +34,10 @@
 #define FXOS8700_REG_TEMP			0x51
 #define FXOS8700_REG_M_CTRLREG1			0x5b
 #define FXOS8700_REG_M_CTRLREG2			0x5c
+#define FXOS8700_REG_M_INT_SRC			0x5e
+#define FXOS8700_REG_M_VECM_CFG			0x69
+#define FXOS8700_REG_M_VECM_THS_MSB		0x6a
+#define FXOS8700_REG_M_VECM_THS_LSB		0x6b
 
 /* Devices that are compatible with this driver: */
 #define WHOAMI_ID_MMA8451			0x1A
@@ -42,6 +46,8 @@
 #define WHOAMI_ID_FXOS8700			0xC7
 
 #define FXOS8700_DRDY_MASK			(1 << 0)
+#define FXOS8700_MAG_VECM_INT1_MASK		(1 << 0)
+#define FXOS8700_VECM_MASK			(1 << 1)
 #define FXOS8700_MOTION_MASK			(1 << 2)
 #define FXOS8700_PULSE_MASK			(1 << 3)
 
@@ -119,6 +125,11 @@ enum fxos8700_channel {
 	FXOS8700_CHANNEL_MAGN_Z,
 };
 
+/* FXOS8700 specific triggers */
+enum fxos_trigger_type {
+	FXOS8700_TRIG_M_VECM,
+};
+
 struct fxos8700_config {
 	char *i2c_name;
 #ifdef CONFIG_FXOS8700_TRIGGER
@@ -143,6 +154,10 @@ struct fxos8700_config {
 	uint8_t pulse_ltcy;
 	uint8_t pulse_wind;
 #endif
+#ifdef CONFIG_FXOS8700_MAG_VECM
+	uint8_t mag_vecm_cfg;
+	uint8_t mag_vecm_ths[2];
+#endif
 };
 
 struct fxos8700_data {
@@ -160,6 +175,9 @@ struct fxos8700_data {
 #endif
 #ifdef CONFIG_FXOS8700_MOTION
 	sensor_trigger_handler_t motion_handler;
+#endif
+#ifdef CONFIG_FXOS8700_MAG_VECM
+	sensor_trigger_handler_t m_vecm_handler;
 #endif
 #ifdef CONFIG_FXOS8700_TRIGGER_OWN_THREAD
 	K_THREAD_STACK_MEMBER(thread_stack, CONFIG_FXOS8700_THREAD_STACK_SIZE);

--- a/drivers/sensor/fxos8700/fxos8700_trigger.c
+++ b/drivers/sensor/fxos8700/fxos8700_trigger.c
@@ -116,6 +116,24 @@ static int fxos8700_handle_motion_int(struct device *dev)
 }
 #endif
 
+#ifdef CONFIG_FXOS8700_MAG_VECM
+static int fxos8700_handle_m_vecm_int(struct device *dev)
+{
+	struct fxos8700_data *data = dev->driver_data;
+
+	struct sensor_trigger m_vecm_trig = {
+		.type = FXOS8700_TRIG_M_VECM,
+		.chan = SENSOR_CHAN_MAGN_XYZ,
+	};
+
+	if (data->m_vecm_handler) {
+		data->m_vecm_handler(dev, &m_vecm_trig);
+	}
+
+	return 0;
+}
+#endif
+
 static void fxos8700_handle_int(void *arg)
 {
 	struct device *dev = (struct device *)arg;
@@ -123,6 +141,7 @@ static void fxos8700_handle_int(void *arg)
 	struct fxos8700_data *data = dev->driver_data;
 	uint8_t int_source;
 
+	/* Interrupt status register */
 	k_sem_take(&data->sem, K_FOREVER);
 
 	if (i2c_reg_read_byte(data->i2c, config->i2c_address,
@@ -145,6 +164,23 @@ static void fxos8700_handle_int(void *arg)
 #ifdef CONFIG_FXOS8700_MOTION
 	if (int_source & FXOS8700_MOTION_MASK) {
 		fxos8700_handle_motion_int(dev);
+	}
+#endif
+#ifdef CONFIG_FXOS8700_MAG_VECM
+	/* Magnetometer interrupt source register */
+	k_sem_take(&data->sem, K_FOREVER);
+
+	if (i2c_reg_read_byte(data->i2c, config->i2c_address,
+			      FXOS8700_REG_M_INT_SRC,
+			      &int_source)) {
+		LOG_ERR("Could not read magnetometer interrupt source");
+		int_source = 0U;
+	}
+
+	k_sem_give(&data->sem);
+
+	if (int_source & FXOS8700_VECM_MASK) {
+		fxos8700_handle_m_vecm_int(dev);
 	}
 #endif
 
@@ -209,6 +245,12 @@ int fxos8700_trigger_set(struct device *dev,
 	case SENSOR_TRIG_DELTA:
 		mask = FXOS8700_MOTION_MASK;
 		data->motion_handler = handler;
+		break;
+#endif
+#ifdef CONFIG_FXOS8700_MAG_VECM
+	case FXOS8700_TRIG_M_VECM:
+		mask = FXOS8700_VECM_MASK;
+		data->m_vecm_handler = handler;
 		break;
 #endif
 	default:
@@ -330,6 +372,43 @@ static int fxos8700_motion_init(struct device *dev)
 }
 #endif
 
+#ifdef CONFIG_FXOS8700_MAG_VECM
+static int fxos8700_m_vecm_init(struct device *dev)
+{
+	const struct fxos8700_config *config = dev->config_info;
+	struct fxos8700_data *data = dev->driver_data;
+	uint8_t m_vecm_cfg = config->mag_vecm_cfg;
+
+	/* Route the interrupt to INT1 pin */
+#if CONFIG_FXOS8700_MAG_VECM_INT1
+	m_vecm_cfg |= FXOS8700_MAG_VECM_INT1_MASK;
+#endif
+
+	/* Set magnetic vector-magnitude function */
+	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+			       FXOS8700_REG_M_VECM_CFG, m_vecm_cfg)) {
+		LOG_ERR("Could not set magnetic vector-magnitude function");
+		return -EIO;
+	}
+
+	/* Set magnetic vector-magnitude function threshold values:
+	 * handle both MSB and LSB registers
+	 */
+	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+			       FXOS8700_REG_M_VECM_THS_MSB, config->mag_vecm_ths[0])) {
+		LOG_ERR("Could not set magnetic vector-magnitude function threshold MSB value");
+		return -EIO;
+	}
+
+	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+			       FXOS8700_REG_M_VECM_THS_LSB, config->mag_vecm_ths[1])) {
+		LOG_ERR("Could not set magnetic vector-magnitude function threshold LSB value");
+		return -EIO;
+	}
+
+	return 0;
+}
+#endif
 
 int fxos8700_trigger_init(struct device *dev)
 {
@@ -375,6 +454,12 @@ int fxos8700_trigger_init(struct device *dev)
 #ifdef CONFIG_FXOS8700_MOTION
 	if (fxos8700_motion_init(dev)) {
 		LOG_ERR("Could not configure motion");
+		return -EIO;
+	}
+#endif
+#ifdef CONFIG_FXOS8700_MAG_VECM
+	if (fxos8700_m_vecm_init(dev)) {
+		LOG_ERR("Could not configure magnetic vector-magnitude");
 		return -EIO;
 	}
 #endif


### PR DESCRIPTION
The magnetometer vector-magnitude function will generate an interrupt
when magnitude is greater than specified threshold value. The user
may program the threshold value to establish the conditions needed
to detect a magnetic vector-magnitude change event. Depending on the
values chosen for the reference values, this function may be
configured to detect a magnetic field magnitude that is above
a preset threshold (with reference values = 0), or a change in magnitude
between two magnetic vectors greater than the preset threshold
(with reference values non-zero).

Default configuration of M_VECM_CFG register (address 0x69) is 0x4e.

Signed-off-by: Matija Tudan <mtudan@mobilisis.hr>