### PR TITLE
arch: arm: Export vector table symbols with GDATA instead of GTEXT

### DIFF
--- a/arch/arm/core/aarch32/cortex_a_r/vector_table.h
+++ b/arch/arm/core/aarch32/cortex_a_r/vector_table.h
@@ -29,7 +29,7 @@
 #include <sys/util.h>
 
 GTEXT(__start)
-GTEXT(_vector_table)
+GDATA(_vector_table)
 
 GTEXT(z_arm_nmi)
 GTEXT(z_arm_undef_instruction)

--- a/arch/arm/core/aarch32/cortex_m/vector_table.h
+++ b/arch/arm/core/aarch32/cortex_m/vector_table.h
@@ -28,7 +28,7 @@
 #include <sys/util.h>
 
 GTEXT(__start)
-GTEXT(_vector_table)
+GDATA(_vector_table)
 
 GTEXT(z_arm_reset)
 GTEXT(z_arm_nmi)

--- a/arch/arm/core/aarch32/irq_relay.S
+++ b/arch/arm/core/aarch32/irq_relay.S
@@ -74,4 +74,4 @@ SECTION_FUNC(vector_relay_table, __vector_relay_table)
 	.word __vector_relay_handler
 	.endr
 
-GTEXT(__vector_relay_table)
+GDATA(__vector_relay_table)

--- a/arch/arm/core/aarch64/vector_table.h
+++ b/arch/arm/core/aarch64/vector_table.h
@@ -27,7 +27,7 @@
 #include <linker/sections.h>
 
 GTEXT(__start)
-GTEXT(_vector_table)
+GDATA(_vector_table)
 GTEXT(_isr_wrapper)
 
 #else /* _ASMLANGUAGE */


### PR DESCRIPTION
_vector_table and __vector_relay_table symbols were exported with GTEXT
(i.e. as functions). That resulted in bit[0] being incorrectly set in
the addresses they represent (for functions this bit set to 1 specifies
execution in Thumb state).
This commit corrects this by switching to exporting these objects as
objects, i.e. with GDATA.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>