### PR TITLE
tests/kernel/gen_isr_table: extend coverage to Cortex-M Baseline

### DIFF
--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -43,6 +43,13 @@ extern uint32_t _irq_vector_table[];
  * the test, so that it does not try to use some unavailable ones.
  */
 #define TEST_NUM_IRQS	33
+#elif defined(CONFIG_SOC_STM32G071XX)
+/* In STM32G071XX limit the number of interrupts reported to
+ * the test, so that it does not try to use some of the IRQs
+ * at the end of the vector table that are already used by
+ * the board.
+ */
+#define TEST_NUM_IRQS	30
 #else
 #define TEST_NUM_IRQS	CONFIG_NUM_IRQS
 #endif
@@ -66,7 +73,8 @@ static volatile int trigger_check[TRIG_CHECK_SIZE];
 
 void trigger_irq(int irq)
 {
-#if defined(CONFIG_SOC_TI_LM3S6965_QEMU)
+#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) || \
+	defined(CONFIG_SOC_TI_LM3S6965_QEMU)
 	/* QEMU does not simulate the STIR register: this is a workaround */
 	NVIC_SetPendingIRQ(irq);
 #else

--- a/tests/kernel/gen_isr_table/testcase.yaml
+++ b/tests/kernel/gen_isr_table/testcase.yaml
@@ -5,9 +5,10 @@ tests:
         cc26x2r1_launchxl
     filter: CONFIG_GEN_ISR_TABLES and CONFIG_ARMV7_M_ARMV8_M_MAINLINE
     tags: interrupt isr_table
-  arch.interrupt.arc:
+  arch.interrupt.gen_isr_table.arc:
     arch_whitelist: arc
     filter: CONFIG_RGF_NUM_BANKS > 1
     extra_configs:
       - CONFIG_ARC_FIRQ_STACK=y
       - CONFIG_TEST_HW_STACK_PROTECTION=n
+    tags: interrupt isr_table

--- a/tests/kernel/gen_isr_table/testcase.yaml
+++ b/tests/kernel/gen_isr_table/testcase.yaml
@@ -1,5 +1,9 @@
 tests:
-  arch.interrupt.gen_isr_table:
+  arch.interrupt.gen_isr_table.arm_baseline:
+    platform_whitelist: bbc_microbit atsamr21_xpro nrf51dk_nrf51422 nucleo_g071rb qemu_cortex_m0
+    filter: CONFIG_GEN_ISR_TABLES and CONFIG_ARMV6_M_ARMV8_M_BASELINE
+    tags: interrupt isr_table
+  arch.interrupt.gen_isr_table.arm_mainline:
     platform_exclude: nucleo_f103rb olimexino_stm32 stm32_min_dev_black
         stm32_min_dev_blue usb_kw24d512 v2m_beetle cc1352r1_launchxl
         cc26x2r1_launchxl


### PR DESCRIPTION
Tested with Baseline platforms:
- qemu_cortex_m0
- nrf51dk
- atsamr21_xpro
- nucleo_g071rb

So I follow the principle in #27030 and whitelist these platforms, for now, so the Baseline Cortex-M is covered for this kernel test, on a few platforms, including QEMU.

Fixes #22975 