### PR TITLE
dts: remove incorrect use of device_type property

### DIFF
--- a/boards/arc/nsim/nsim.dtsi
+++ b/boards/arc/nsim/nsim.dtsi
@@ -38,14 +38,12 @@
 	};
 
 	iccm0: iccm@ICCM_ADDR {
-		device_type = "memory";
 		compatible = "arc,iccm";
 		reg = <DT_ADDR(ICCM_ADDR) ICCM_SIZE>;
 	};
 
 	dccm0: dccm@DCCM_ADDR {
 		compatible = "arc,dccm";
-		device_type = "memory";
 		reg = <DT_ADDR(DCCM_ADDR) DCCM_SIZE>;
 	};
 

--- a/boards/arc/nsim/nsim_sem.dts
+++ b/boards/arc/nsim/nsim_sem.dts
@@ -15,13 +15,11 @@
 	compatible = "snps,nsim_sem";
 
 	iccm0: iccm@0 {
-		device_type = "memory";
 		compatible = "arc,iccm";
 		reg = <0x0 0x40000>;
 	};
 
 	dccm0: dccm@80000000 {
-		device_type = "memory";
 		compatible = "arc,dccm";
 		reg = <0x80000000 0x40000>;
 	};

--- a/boards/arm/nrf9160_innblue21/nrf9160_innblue21_common.dts
+++ b/boards/arm/nrf9160_innblue21/nrf9160_innblue21_common.dts
@@ -195,13 +195,11 @@
 / {
 	/* SRAM allocated and used by the BSD library */
 	sram0_bsd: memory@20010000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 
 	/* SRAM allocated to the Non-Secure image */
 	sram0_ns: memory@20020000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 };

--- a/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dts
+++ b/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dts
@@ -207,13 +207,11 @@
 / {
 	/* SRAM allocated and used by the BSD library */
 	sram0_bsd: memory@20010000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 
 	/* SRAM allocated to the Non-Secure image */
 	sram0_ns: memory@20020000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 };

--- a/dts/arc/emsdp.dtsi
+++ b/dts/arc/emsdp.dtsi
@@ -30,13 +30,11 @@
 	};
 
 	iccm0: iccm@60000000 {
-		device_type = "memory";
 		compatible = "arc,iccm";
 		reg = <0x60000000 0x20000>;
 	};
 
 	dccm0: dccm@80000000 {
-		device_type = "memory";
 		compatible = "arc,dccm";
 		reg = <0x80000000 0x20000>;
 	};

--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -33,7 +33,6 @@
 
 	soc {
 		sram0: memory@20000000 {
-			device_type = "memory";
 			compatible = "mmio-sram";
 		};
 

--- a/dts/arm/nordic/nrf5340_cpuappns.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns.dtsi
@@ -35,7 +35,6 @@
 
 	soc {
 		sram0: memory@20000000 {
-			device_type = "memory";
 			compatible = "mmio-sram";
 		};
 

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -52,7 +52,6 @@
 
 	soc {
 		sram1: memory@21000000 {
-			device_type = "memory";
 			compatible = "mmio-sram";
 		};
 

--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -61,7 +61,6 @@
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 0x10000>;
 	};

--- a/dts/arm/silabs/efm32gg11b.dtsi
+++ b/dts/arm/silabs/efm32gg11b.dtsi
@@ -26,7 +26,6 @@
 	};
 
 	sram0: memory@20000000 {
-	       device_type = "memory";
 	       compatible = "mmio-sram";
 	};
 

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -25,12 +25,10 @@
 	};
 
 	retram: memory0@0 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x00000000 DT_SIZE_K(64)>;
 	};
 	mcusram: memory1@10000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x10000000 DT_SIZE_K(320)>;
 	};

--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -34,7 +34,6 @@
 	};
 
 	sram0: memory@3ffb0000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x3FFB0000 0x50000>;
 	};

--- a/dts/xtensa/intel/intel_apl_adsp.dtsi
+++ b/dts/xtensa/intel/intel_apl_adsp.dtsi
@@ -27,13 +27,11 @@
 	};
 
 	sram0: memory@be000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0xbe000000 DT_SIZE_K(512)>;
 	};
 
 	sram1: memory@be800000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0xbe800000 DT_SIZE_K(128)>;
 	};

--- a/dts/xtensa/intel/intel_s1000.dtsi
+++ b/dts/xtensa/intel/intel_s1000.dtsi
@@ -26,13 +26,11 @@
 	};
 
 	sram0: memory@be000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0xbe000000 DT_SIZE_M(4)>;
 	};
 
 	sram1: memory@be800000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0xbe800000 DT_SIZE_K(64)>;
 	};


### PR DESCRIPTION
For true mmio-sram, arc,iccm, arc,dccm nodes we should not be setting
device_type = "memory".  This should be used for true DRAM regions of
memory and not on SoC SRAMs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>