### PR TITLE
manifest: hal_nordic: Update nrf_802514 clock contorl

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: cb9e75ebfea8a8312678b2359c6b41b051a95177
+      revision: 8139a8445900ddbf495f65de21ddeab31ac97951
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262


### PR DESCRIPTION
Align with changes in Zephyr to use onoff API instead of clock_control
for clock management.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>