### PR TITLE
Nrf5340 fix board enable cpunet help text and usage

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/Kconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig
@@ -37,10 +37,11 @@ config BOARD_ENABLE_CPUNET
 	  as a consequence will power up the Network MCU during system boot.
 	  Additionally, the option allocates GPIO pins that will be used by UARTE
 	  of the Network MCU.
-	  Note: The non-secure image can only be started by the secure firmware,
-	  so when this option is used with the non-secure version of the board,
-	  the application needs to take into consideration, that the secure firmware
-	  may already have started the Network MCU.
+	  Note: GPIO pin allocation can only be configured by the secure Application
+	  MCU firmware, so when this option is used with the non-secure version of
+	  the board, the application needs to take into consideration, that the
+	  secure firmware image must already have configured GPIO allocation for the
+	  Network MCU.
 	default y if (BT || NET_L2_IEEE802154)
 
 endif # BOARD_NRF5340PDK_NRF5340_CPUAPP || BOARD_NRF5340PDK_NRF5340_CPUAPPNS || BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPPNS

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpunet_reset.c
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpunet_reset.c
@@ -76,6 +76,13 @@ static int remoteproc_mgr_boot(struct device *dev)
 	remoteproc_mgr_config();
 #endif /* !CONFIG_TRUSTED_EXECUTION_NONSECURE */
 
+#if !defined(CONFIG_TRUSTED_EXECUTION_SECURE)
+	/*
+	 * Building Zephyr with CONFIG_TRUSTED_EXECUTION_SECURE=y implies
+	 * building also a Non-Secure image. The Non-Secure image will, in
+	 * this case do the remainder of actions to properly configure and
+	 * boot the Network MCU.
+	 */
 #if defined(SHM_BASE_ADDRESS) && (SHM_BASE_ADDRESS != 0)
 
 	/* Initialize inter-processor shared memory block to zero. It is
@@ -89,6 +96,7 @@ static int remoteproc_mgr_boot(struct device *dev)
 	NRF_RESET->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Release;
 
 	LOG_DBG("Network MCU released.");
+#endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */
 
 	return 0;
 }


### PR DESCRIPTION
Clarifying and correcting some thing in the usage of config BOARD_ENABLE_CPUNET option.

Fixes #24147

Summarizing the usage of BOARD_ENABLE_CPUNET

- if building a firmware without TrustZone awarness (TRUSTED_EXECUTION_SECURE=n, TRUSTED_EXECUTION_NONSECURE=n), then all actions in remoteproc_mgr_config are needed
- if building a strictly Secure firmware (TRUSTED_EXECUTION_SECURE=y), only the GPIO assignment is needed
- if building a strictly Non-Secure firmware (TRUSTED_EXECUTION_NONSECURE=y), only the shared mem initialization and the RESET are needed.

scenarios
- Trustzone-aware applications in Zephyr: BOARD_ENABLE_CPUNET to be enabled in both S and NS builds
- TrustZone-aware application (Zephyr + TFM): BOARD_ENABLE_CPUNET to be enabled in Zephyr and the GPIOs to be configured in TF-M
- Non-aware TrustZone builds: BORAD_ENABLE_CPUNET to be enabled in the single APP MCU image