### PR TITLE
net: socket: Add locking to prevent concurrent access

### DIFF
--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -274,6 +274,13 @@ __net_socket struct net_context {
 		struct k_fifo accept_q;
 	};
 
+	struct {
+		/** Condition variable used when receiving data */
+		struct k_condvar recv;
+
+		/** Mutex used by condition variable */
+		struct k_mutex *lock;
+	} cond;
 #endif /* CONFIG_NET_SOCKETS */
 
 #if defined(CONFIG_NET_OFFLOAD)

--- a/include/sys/fdtable.h
+++ b/include/sys/fdtable.h
@@ -96,10 +96,15 @@ void *z_get_fd_obj(int fd, const struct fd_op_vtable *vtable, int err);
  *
  * @param fd File descriptor previously returned by z_reserve_fd()
  * @param vtable A pointer to a pointer variable to store the vtable
+ * @param lock An optional pointer to a pointer variable to store the mutex
+ *        preventing concurrent descriptor access. The lock is not taken,
+ *        it is just returned for the caller to use if necessary. Pass NULL
+ *        if the lock is not needed by the caller.
  *
  * @return Object pointer or NULL, with errno set
  */
-void *z_get_fd_obj_and_vtable(int fd, const struct fd_op_vtable **vtable);
+void *z_get_fd_obj_and_vtable(int fd, const struct fd_op_vtable **vtable,
+			      struct k_mutex **lock);
 
 /**
  * @brief Call ioctl vmethod on an object using varargs.
@@ -141,6 +146,7 @@ enum {
 	ZFD_IOCTL_POLL_PREPARE,
 	ZFD_IOCTL_POLL_UPDATE,
 	ZFD_IOCTL_POLL_OFFLOAD,
+	ZFD_IOCTL_SET_LOCK,
 };
 
 #ifdef __cplusplus

--- a/tests/lib/fdtable/src/main.c
+++ b/tests/lib/fdtable/src/main.c
@@ -15,7 +15,9 @@
 static struct k_thread fd_thread;
 static int shared_fd;
 
-#define VTABLE_INIT ((const struct fd_op_vtable *)1)
+static struct fd_op_vtable fd_vtable = { 0 };
+
+#define VTABLE_INIT (&fd_vtable)
 
 K_THREAD_STACK_DEFINE(fd_thread_stack, CONFIG_ZTEST_STACKSIZE +
 		      CONFIG_TEST_EXTRA_STACKSIZE);
@@ -60,7 +62,7 @@ void test_z_get_fd_obj(void)
 	zassert_is_null(obj, "obj not is NULL");
 
 	obj = (void *)1;
-	vtable = (const struct fd_op_vtable *)1;
+	vtable = NULL;
 
 	/* This will set obj and vtable properly */
 	z_finalize_fd(fd, obj, vtable);

--- a/tests/lib/fdtable/src/main.c
+++ b/tests/lib/fdtable/src/main.c
@@ -37,7 +37,8 @@ void test_z_get_fd_obj_and_vtable(void)
 	zassert_true(fd >= 0, "fd < 0");
 
 	int *obj;
-	obj = z_get_fd_obj_and_vtable(fd, &vtable); /* function being tested */
+	obj = z_get_fd_obj_and_vtable(fd, &vtable,
+				      NULL); /* function being tested */
 
 	zassert_is_null(obj, "obj is not NULL");
 
@@ -85,14 +86,14 @@ void test_z_finalize_fd(void)
 	int fd = z_reserve_fd();
 	zassert_true(fd >= 0, NULL);
 
-	int *obj = z_get_fd_obj_and_vtable(fd, &vtable);
+	int *obj = z_get_fd_obj_and_vtable(fd, &vtable, NULL);
 
 	const struct fd_op_vtable *original_vtable = vtable;
 	int *original_obj = obj;
 
 	z_finalize_fd(fd, obj, vtable); /* function being tested */
 
-	obj = z_get_fd_obj_and_vtable(fd, &vtable);
+	obj = z_get_fd_obj_and_vtable(fd, &vtable, NULL);
 
 	zassert_equal_ptr(obj, original_obj, "obj is different after finalizing");
 	zassert_equal_ptr(vtable, original_vtable, "vtable is different after finalizing");
@@ -108,7 +109,7 @@ void test_z_alloc_fd(void)
 	int fd = z_alloc_fd(obj, vtable); /* function being tested */
 	zassert_true(fd >= 0, NULL);
 
-	obj = z_get_fd_obj_and_vtable(fd, &vtable);
+	obj = z_get_fd_obj_and_vtable(fd, &vtable, NULL);
 
 	zassert_equal_ptr(obj, NULL, "obj is different after allocating");
 	zassert_equal_ptr(vtable, NULL, "vtable is different after allocating");
@@ -125,7 +126,7 @@ void test_z_free_fd(void)
 
 	z_free_fd(fd); /* function being tested */
 
-	int *obj = z_get_fd_obj_and_vtable(fd, &vtable);
+	int *obj = z_get_fd_obj_and_vtable(fd, &vtable, NULL);
 
 	zassert_equal_ptr(obj, NULL, "obj is not NULL after freeing");
 }
@@ -136,14 +137,14 @@ static void test_cb(void *fd_ptr)
 	const struct fd_op_vtable *vtable;
 	int *obj;
 
-	obj = z_get_fd_obj_and_vtable(fd, &vtable);
+	obj = z_get_fd_obj_and_vtable(fd, &vtable, NULL);
 
 	zassert_not_null(obj, "obj is null");
 	zassert_not_null(vtable, "vtable is null");
 
 	z_free_fd(fd);
 
-	obj = z_get_fd_obj_and_vtable(fd, &vtable);
+	obj = z_get_fd_obj_and_vtable(fd, &vtable, NULL);
 	zassert_is_null(obj, "obj is still there");
 	zassert_equal(errno, EBADF, "fd was found");
 }
@@ -167,7 +168,7 @@ void test_z_fd_multiple_access(void)
 	k_thread_join(&fd_thread, K_FOREVER);
 
 	/* should be null since freed in the other thread */
-	obj = z_get_fd_obj_and_vtable(shared_fd, &vtable);
+	obj = z_get_fd_obj_and_vtable(shared_fd, &vtable, NULL);
 	zassert_is_null(obj, "obj is still there");
 	zassert_equal(errno, EBADF, "fd was found");
 }


### PR DESCRIPTION
The BSD API calls were not thread safe. Add locking to fix this.

Fixes #27032

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>