### PR TITLE
drivers: sensor: refactor the lsm6dsl DeviceTree setup 

### DIFF
--- a/drivers/sensor/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.c
@@ -816,11 +816,20 @@ static int lsm6dsl_init(struct device *dev)
 	COND_CODE_1(DT_INST_ON_BUS(n, spi), (lsm6dsl_spi_init),		       \
 		    (lsm6dsl_i2c_init))
 
+#define LSM6DSL_SPI_CFG(n)
+
+#define LSM6DSL_I2C_CFG(n) .i2c.dev_addr = DT_INST_REG_ADDR(n)
+
+#define LSM6DSL_COMM_CFG(n)						       \
+	COND_CODE_1(DT_INST_ON_BUS(n, spi), (LSM6DSL_SPI_CFG(n)),	       \
+		    (LSM6DSL_I2C_CFG(n)))
+
 #define LSM6DSL_DEVICE(n)						       \
 	static struct lsm6dsl_data lsm6dsl_data_##n;			       \
 	static const struct lsm6dsl_config lsm6dsl_config_##n = {	       \
 		.comm_master_dev_name = DT_INST_BUS_LABEL(n),		       \
 		.comm_init = LSM6DSL_COMM_INIT(n),			       \
+		LSM6DSL_COMM_CFG(n),					       \
 	};								       \
 	DEVICE_AND_API_INIT(lsm6dsl_##n, DT_INST_LABEL(n), lsm6dsl_init,       \
 			    &lsm6dsl_data_##n, &lsm6dsl_config_##n,	       \

--- a/drivers/sensor/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.c
@@ -818,16 +818,13 @@ static int lsm6dsl_init(struct device *dev)
 		.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(n),	       \
 	}
 
-#define LSM6DSL_SPI_CS_IF_CONFIG(n)					       \
-	COND_CODE_1(DT_INST_SPI_DEV_HAS_CS_GPIOS(n),			       \
-		    (LSM6DSL_SPI_CS_CONFIG(n)), ())
-
 #define LSM6DSL_SPI_CS_REF(n)						       \
 	COND_CODE_1(DT_INST_SPI_DEV_HAS_CS_GPIOS(n), (&lsm6dsl_cs_ctrl_##n),   \
 		    (NULL))
 
 #define LSM6DSL_SPI_CONFIG(n)						       \
-	LSM6DSL_SPI_CS_IF_CONFIG(n);					       \
+	IF_ENABLED(DT_INST_SPI_DEV_HAS_CS_GPIOS(n),			       \
+		   (LSM6DSL_SPI_CS_CONFIG(n)));				       \
 	static const struct spi_config lsm6dsl_spi_config_##n = {	       \
 		.frequency = DT_INST_PROP(n, spi_max_frequency),	       \
 		.operation =						       \
@@ -837,38 +834,46 @@ static int lsm6dsl_init(struct device *dev)
 		.cs = LSM6DSL_SPI_CS_REF(n),				       \
 	}
 
-#define LSM6DSL_COMM_CONFIG(n)						       \
+#define LSM6DSL_BUS_CONFIG(n)						       \
 	COND_CODE_1(DT_INST_ON_BUS(n, spi), (LSM6DSL_SPI_CONFIG(n)), ())
 
 #define LSM6DSL_SPI_GPIO_NAME(n)					       \
 	COND_CODE_1(DT_INST_SPI_DEV_HAS_CS_GPIOS(n),			       \
 		    (DT_INST_SPI_DEV_CS_GPIOS_LABEL(n)), (NULL))
 
-#define LSM6DSL_SPI_CFG(n)						       \
+#define LSM6DSL_SPI_INIT(n)						       \
+	.comm_init = lsm6dsl_spi_init,					       \
 	.spi.spi_conf = &lsm6dsl_spi_config_##n,			       \
 	.spi.gpio_name = LSM6DSL_SPI_GPIO_NAME(n)
 
-#define LSM6DSL_I2C_CFG(n) .i2c.dev_addr = DT_INST_REG_ADDR(n)
+#define LSM6DSL_I2C_INIT(n)						       \
+	.comm_init = lsm6dsl_i2c_init,					       \
+	.i2c.dev_addr = DT_INST_REG_ADDR(n)
 
-#define LSM6DSL_COMM_CFG(n)						       \
-	COND_CODE_1(DT_INST_ON_BUS(n, spi), (LSM6DSL_SPI_CFG(n)),	       \
-		    (LSM6DSL_I2C_CFG(n)))
+#define LSM6DSL_BUS_INIT(n)						       \
+	COND_CODE_1(DT_INST_ON_BUS(n, spi), (LSM6DSL_SPI_INIT(n)),	       \
+		    (LSM6DSL_I2C_INIT(n)))
 
-#define LSM6DSL_COMM_INIT(n)						       \
-	COND_CODE_1(DT_INST_ON_BUS(n, spi), (lsm6dsl_spi_init),		       \
-		    (lsm6dsl_i2c_init))
+#if defined(CONFIG_LSM6DSL_TRIGGER)
+#define LSM6DSL_TRIGGER_INIT(n)						       \
+	.trigger_name = DT_INST_GPIO_LABEL(n, irq_gpios),		       \
+	.trigger_pin = DT_INST_GPIO_PIN(n, irq_gpios),			       \
+	.trigger_flags = DT_INST_GPIO_FLAGS(n, irq_gpios),
+#else
+#define LSM6DSL_TRIGGER_INIT(n)
+#endif
 
 #define LSM6DSL_DEVICE(n)						       \
 	static struct lsm6dsl_data lsm6dsl_data_##n;			       \
-	LSM6DSL_COMM_CONFIG(n);						       \
+	LSM6DSL_BUS_CONFIG(n);						       \
 	static const struct lsm6dsl_config lsm6dsl_config_##n = {	       \
 		.comm_master_dev_name = DT_INST_BUS_LABEL(n),		       \
-		.comm_init = LSM6DSL_COMM_INIT(n),			       \
-		LSM6DSL_COMM_CFG(n),					       \
+		LSM6DSL_BUS_INIT(n),					       \
+		LSM6DSL_TRIGGER_INIT(n)					       \
 	};								       \
 	DEVICE_AND_API_INIT(lsm6dsl_##n, DT_INST_LABEL(n), lsm6dsl_init,       \
 			    &lsm6dsl_data_##n, &lsm6dsl_config_##n,	       \
 			    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,	       \
-			    &lsm6dsl_api_funcs)
+			    &lsm6dsl_api_funcs);
 
-DT_INST_FOREACH_STATUS_OKAY(LSM6DSL_DEVICE);
+DT_INST_FOREACH_STATUS_OKAY(LSM6DSL_DEVICE)

--- a/drivers/sensor/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.c
@@ -92,7 +92,7 @@ static inline int lsm6dsl_reboot(struct device *dev)
 {
 	struct lsm6dsl_data *data = dev->driver_data;
 
-	if (data->hw_tf->update_reg(data, LSM6DSL_REG_CTRL3_C,
+	if (data->hw_tf->update_reg(dev, LSM6DSL_REG_CTRL3_C,
 				    LSM6DSL_MASK_CTRL3_C_BOOT,
 				    1 << LSM6DSL_SHIFT_CTRL3_C_BOOT) < 0) {
 		return -EIO;
@@ -108,7 +108,7 @@ static int lsm6dsl_accel_set_fs_raw(struct device *dev, uint8_t fs)
 {
 	struct lsm6dsl_data *data = dev->driver_data;
 
-	if (data->hw_tf->update_reg(data,
+	if (data->hw_tf->update_reg(dev,
 				    LSM6DSL_REG_CTRL1_XL,
 				    LSM6DSL_MASK_CTRL1_XL_FS_XL,
 				    fs << LSM6DSL_SHIFT_CTRL1_XL_FS_XL) < 0) {
@@ -124,7 +124,7 @@ static int lsm6dsl_accel_set_odr_raw(struct device *dev, uint8_t odr)
 {
 	struct lsm6dsl_data *data = dev->driver_data;
 
-	if (data->hw_tf->update_reg(data,
+	if (data->hw_tf->update_reg(dev,
 				    LSM6DSL_REG_CTRL1_XL,
 				    LSM6DSL_MASK_CTRL1_XL_ODR_XL,
 				    odr << LSM6DSL_SHIFT_CTRL1_XL_ODR_XL) < 0) {
@@ -141,14 +141,14 @@ static int lsm6dsl_gyro_set_fs_raw(struct device *dev, uint8_t fs)
 	struct lsm6dsl_data *data = dev->driver_data;
 
 	if (fs == GYRO_FULLSCALE_125) {
-		if (data->hw_tf->update_reg(data,
+		if (data->hw_tf->update_reg(dev,
 					LSM6DSL_REG_CTRL2_G,
 					LSM6DSL_MASK_CTRL2_FS125,
 					1 << LSM6DSL_SHIFT_CTRL2_FS125) < 0) {
 			return -EIO;
 		}
 	} else {
-		if (data->hw_tf->update_reg(data,
+		if (data->hw_tf->update_reg(dev,
 					LSM6DSL_REG_CTRL2_G,
 					LSM6DSL_MASK_CTRL2_G_FS_G,
 					fs << LSM6DSL_SHIFT_CTRL2_G_FS_G) < 0) {
@@ -163,7 +163,7 @@ static int lsm6dsl_gyro_set_odr_raw(struct device *dev, uint8_t odr)
 {
 	struct lsm6dsl_data *data = dev->driver_data;
 
-	if (data->hw_tf->update_reg(data,
+	if (data->hw_tf->update_reg(dev,
 				    LSM6DSL_REG_CTRL2_G,
 				    LSM6DSL_MASK_CTRL2_G_ODR_G,
 				    odr << LSM6DSL_SHIFT_CTRL2_G_ODR_G) < 0) {
@@ -319,7 +319,7 @@ static int lsm6dsl_sample_fetch_accel(struct device *dev)
 	struct lsm6dsl_data *data = dev->driver_data;
 	uint8_t buf[6];
 
-	if (data->hw_tf->read_data(data, LSM6DSL_REG_OUTX_L_XL,
+	if (data->hw_tf->read_data(dev, LSM6DSL_REG_OUTX_L_XL,
 				   buf, sizeof(buf)) < 0) {
 		LOG_DBG("failed to read sample");
 		return -EIO;
@@ -340,7 +340,7 @@ static int lsm6dsl_sample_fetch_gyro(struct device *dev)
 	struct lsm6dsl_data *data = dev->driver_data;
 	uint8_t buf[6];
 
-	if (data->hw_tf->read_data(data, LSM6DSL_REG_OUTX_L_G,
+	if (data->hw_tf->read_data(dev, LSM6DSL_REG_OUTX_L_G,
 				   buf, sizeof(buf)) < 0) {
 		LOG_DBG("failed to read sample");
 		return -EIO;
@@ -362,7 +362,7 @@ static int lsm6dsl_sample_fetch_temp(struct device *dev)
 	struct lsm6dsl_data *data = dev->driver_data;
 	uint8_t buf[2];
 
-	if (data->hw_tf->read_data(data, LSM6DSL_REG_OUT_TEMP_L,
+	if (data->hw_tf->read_data(dev, LSM6DSL_REG_OUT_TEMP_L,
 				   buf, sizeof(buf)) < 0) {
 		LOG_DBG("failed to read sample");
 		return -EIO;
@@ -714,7 +714,7 @@ static int lsm6dsl_init_chip(struct device *dev)
 		return -EIO;
 	}
 
-	if (data->hw_tf->read_reg(data, LSM6DSL_REG_WHO_AM_I, &chip_id) < 0) {
+	if (data->hw_tf->read_reg(dev, LSM6DSL_REG_WHO_AM_I, &chip_id) < 0) {
 		LOG_DBG("failed reading chip id");
 		return -EIO;
 	}
@@ -750,7 +750,7 @@ static int lsm6dsl_init_chip(struct device *dev)
 		return -EIO;
 	}
 
-	if (data->hw_tf->update_reg(data,
+	if (data->hw_tf->update_reg(dev,
 				LSM6DSL_REG_FIFO_CTRL5,
 				LSM6DSL_MASK_FIFO_CTRL5_FIFO_MODE,
 				0 << LSM6DSL_SHIFT_FIFO_CTRL5_FIFO_MODE) < 0) {
@@ -758,7 +758,7 @@ static int lsm6dsl_init_chip(struct device *dev)
 		return -EIO;
 	}
 
-	if (data->hw_tf->update_reg(data,
+	if (data->hw_tf->update_reg(dev,
 				    LSM6DSL_REG_CTRL3_C,
 				    LSM6DSL_MASK_CTRL3_C_BDU |
 				    LSM6DSL_MASK_CTRL3_C_BLE |

--- a/drivers/sensor/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.c
@@ -812,11 +812,41 @@ static int lsm6dsl_init(struct device *dev)
 	return 0;
 }
 
-#define LSM6DSL_COMM_INIT(n)						       \
-	COND_CODE_1(DT_INST_ON_BUS(n, spi), (lsm6dsl_spi_init),		       \
-		    (lsm6dsl_i2c_init))
+#define LSM6DSL_SPI_CS_CONFIG(n)					       \
+	static struct spi_cs_control lsm6dsl_cs_ctrl_##n = {		       \
+		.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(n),		       \
+		.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(n),	       \
+	}
 
-#define LSM6DSL_SPI_CFG(n)
+#define LSM6DSL_SPI_CS_IF_CONFIG(n)					       \
+	COND_CODE_1(DT_INST_SPI_DEV_HAS_CS_GPIOS(n),			       \
+		    (LSM6DSL_SPI_CS_CONFIG(n)), ())
+
+#define LSM6DSL_SPI_CS_REF(n)						       \
+	COND_CODE_1(DT_INST_SPI_DEV_HAS_CS_GPIOS(n), (&lsm6dsl_cs_ctrl_##n),   \
+		    (NULL))
+
+#define LSM6DSL_SPI_CONFIG(n)						       \
+	LSM6DSL_SPI_CS_IF_CONFIG(n);					       \
+	static const struct spi_config lsm6dsl_spi_config_##n = {	       \
+		.frequency = DT_INST_PROP(n, spi_max_frequency),	       \
+		.operation =						       \
+			(SPI_OP_MODE_MASTER | SPI_MODE_CPOL | SPI_MODE_CPHA |  \
+			 SPI_WORD_SET(8) | SPI_LINES_SINGLE),		       \
+		.slave = DT_INST_REG_ADDR(n),				       \
+		.cs = LSM6DSL_SPI_CS_REF(n),				       \
+	}
+
+#define LSM6DSL_COMM_CONFIG(n)						       \
+	COND_CODE_1(DT_INST_ON_BUS(n, spi), (LSM6DSL_SPI_CONFIG(n)), ())
+
+#define LSM6DSL_SPI_GPIO_NAME(n)					       \
+	COND_CODE_1(DT_INST_SPI_DEV_HAS_CS_GPIOS(n),			       \
+		    (DT_INST_SPI_DEV_CS_GPIOS_LABEL(n)), (NULL))
+
+#define LSM6DSL_SPI_CFG(n)						       \
+	.spi.spi_conf = &lsm6dsl_spi_config_##n,			       \
+	.spi.gpio_name = LSM6DSL_SPI_GPIO_NAME(n)
 
 #define LSM6DSL_I2C_CFG(n) .i2c.dev_addr = DT_INST_REG_ADDR(n)
 
@@ -824,8 +854,13 @@ static int lsm6dsl_init(struct device *dev)
 	COND_CODE_1(DT_INST_ON_BUS(n, spi), (LSM6DSL_SPI_CFG(n)),	       \
 		    (LSM6DSL_I2C_CFG(n)))
 
+#define LSM6DSL_COMM_INIT(n)						       \
+	COND_CODE_1(DT_INST_ON_BUS(n, spi), (lsm6dsl_spi_init),		       \
+		    (lsm6dsl_i2c_init))
+
 #define LSM6DSL_DEVICE(n)						       \
 	static struct lsm6dsl_data lsm6dsl_data_##n;			       \
+	LSM6DSL_COMM_CONFIG(n);						       \
 	static const struct lsm6dsl_config lsm6dsl_config_##n = {	       \
 		.comm_master_dev_name = DT_INST_BUS_LABEL(n),		       \
 		.comm_init = LSM6DSL_COMM_INIT(n),			       \

--- a/drivers/sensor/lsm6dsl/lsm6dsl.h
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.h
@@ -616,6 +616,11 @@ struct lsm6dsl_config {
 			const char *gpio_name;
 		} spi;
 	};
+#if defined(CONFIG_LSM6DSL_TRIGGER)
+	const char *trigger_name;
+	uint16_t trigger_pin;
+	uint16_t trigger_flags;
+#endif
 };
 
 struct lsm6dsl_data;
@@ -663,6 +668,7 @@ struct lsm6dsl_data {
 #ifdef CONFIG_LSM6DSL_TRIGGER
 	struct device *gpio;
 	struct gpio_callback gpio_cb;
+	struct device *dev;
 
 	struct sensor_trigger data_ready_trigger;
 	sensor_trigger_handler_t data_ready_handler;
@@ -673,7 +679,6 @@ struct lsm6dsl_data {
 	struct k_sem gpio_sem;
 #elif defined(CONFIG_LSM6DSL_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;
-	struct device *dev;
 #endif
 
 #endif /* CONFIG_LSM6DSL_TRIGGER */

--- a/drivers/sensor/lsm6dsl/lsm6dsl.h
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.h
@@ -14,6 +14,7 @@
 #include <drivers/sensor.h>
 #include <zephyr/types.h>
 #include <drivers/gpio.h>
+#include <drivers/spi.h>
 #include <sys/util.h>
 
 #define LSM6DSL_REG_FUNC_CFG_ACCESS			0x01
@@ -610,6 +611,10 @@ struct lsm6dsl_config {
 		struct {
 			uint16_t dev_addr;
 		} i2c;
+		struct {
+			const struct spi_config *spi_conf;
+			const char *gpio_name;
+		} spi;
 	};
 };
 

--- a/drivers/sensor/lsm6dsl/lsm6dsl.h
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.h
@@ -606,6 +606,11 @@
 struct lsm6dsl_config {
 	const char *comm_master_dev_name;
 	int (*comm_init)(struct device *dev);
+	union {
+		struct {
+			uint16_t dev_addr;
+		} i2c;
+	};
 };
 
 struct lsm6dsl_data;

--- a/drivers/sensor/lsm6dsl/lsm6dsl.h
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.h
@@ -611,13 +611,13 @@ struct lsm6dsl_config {
 struct lsm6dsl_data;
 
 struct lsm6dsl_transfer_function {
-	int (*read_data)(struct lsm6dsl_data *data, uint8_t reg_addr,
+	int (*read_data)(struct device *dev, uint8_t reg_addr,
 			 uint8_t *value, uint8_t len);
-	int (*write_data)(struct lsm6dsl_data *data, uint8_t reg_addr,
+	int (*write_data)(struct device *dev, uint8_t reg_addr,
 			  uint8_t *value, uint8_t len);
-	int (*read_reg)(struct lsm6dsl_data *data, uint8_t reg_addr,
+	int (*read_reg)(struct device *dev, uint8_t reg_addr,
 			uint8_t *value);
-	int (*update_reg)(struct lsm6dsl_data *data, uint8_t reg_addr,
+	int (*update_reg)(struct device *dev, uint8_t reg_addr,
 			  uint8_t mask, uint8_t value);
 };
 

--- a/drivers/sensor/lsm6dsl/lsm6dsl.h
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.h
@@ -604,7 +604,8 @@
 #endif
 
 struct lsm6dsl_config {
-	char *comm_master_dev_name;
+	const char *comm_master_dev_name;
+	int (*comm_init)(struct device *dev);
 };
 
 struct lsm6dsl_data;

--- a/drivers/sensor/lsm6dsl/lsm6dsl_i2c.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_i2c.c
@@ -7,17 +7,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT st_lsm6dsl
-
 #include <string.h>
 #include <drivers/i2c.h>
 #include <logging/log.h>
 
 #include "lsm6dsl.h"
-
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
-
-static uint16_t lsm6dsl_i2c_slave_addr = DT_INST_REG_ADDR(0);
 
 LOG_MODULE_DECLARE(LSM6DSL, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -25,8 +19,9 @@ static int lsm6dsl_i2c_read_data(struct device *dev, uint8_t reg_addr,
 				 uint8_t *value, uint8_t len)
 {
 	struct lsm6dsl_data *data = dev->driver_data;
+	const struct lsm6dsl_config *config = dev->config_info;
 
-	return i2c_burst_read(data->comm_master, lsm6dsl_i2c_slave_addr,
+	return i2c_burst_read(data->comm_master, config->i2c.dev_addr,
 			      reg_addr, value, len);
 }
 
@@ -34,8 +29,9 @@ static int lsm6dsl_i2c_write_data(struct device *dev, uint8_t reg_addr,
 				  uint8_t *value, uint8_t len)
 {
 	struct lsm6dsl_data *data = dev->driver_data;
+	const struct lsm6dsl_config *config = dev->config_info;
 
-	return i2c_burst_write(data->comm_master, lsm6dsl_i2c_slave_addr,
+	return i2c_burst_write(data->comm_master, config->i2c.dev_addr,
 			       reg_addr, value, len);
 }
 
@@ -43,8 +39,9 @@ static int lsm6dsl_i2c_read_reg(struct device *dev, uint8_t reg_addr,
 				uint8_t *value)
 {
 	struct lsm6dsl_data *data = dev->driver_data;
+	const struct lsm6dsl_config *config = dev->config_info;
 
-	return i2c_reg_read_byte(data->comm_master, lsm6dsl_i2c_slave_addr,
+	return i2c_reg_read_byte(data->comm_master, config->i2c.dev_addr,
 				 reg_addr, value);
 }
 
@@ -52,8 +49,9 @@ static int lsm6dsl_i2c_update_reg(struct device *dev, uint8_t reg_addr,
 				  uint8_t mask, uint8_t value)
 {
 	struct lsm6dsl_data *data = dev->driver_data;
+	const struct lsm6dsl_config *config = dev->config_info;
 
-	return i2c_reg_update_byte(data->comm_master, lsm6dsl_i2c_slave_addr,
+	return i2c_reg_update_byte(data->comm_master, config->i2c.dev_addr,
 				   reg_addr, mask, value);
 }
 
@@ -72,4 +70,3 @@ int lsm6dsl_i2c_init(struct device *dev)
 
 	return 0;
 }
-#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */

--- a/drivers/sensor/lsm6dsl/lsm6dsl_i2c.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_i2c.c
@@ -21,30 +21,38 @@ static uint16_t lsm6dsl_i2c_slave_addr = DT_INST_REG_ADDR(0);
 
 LOG_MODULE_DECLARE(LSM6DSL, CONFIG_SENSOR_LOG_LEVEL);
 
-static int lsm6dsl_i2c_read_data(struct lsm6dsl_data *data, uint8_t reg_addr,
+static int lsm6dsl_i2c_read_data(struct device *dev, uint8_t reg_addr,
 				 uint8_t *value, uint8_t len)
 {
+	struct lsm6dsl_data *data = dev->driver_data;
+
 	return i2c_burst_read(data->comm_master, lsm6dsl_i2c_slave_addr,
 			      reg_addr, value, len);
 }
 
-static int lsm6dsl_i2c_write_data(struct lsm6dsl_data *data, uint8_t reg_addr,
+static int lsm6dsl_i2c_write_data(struct device *dev, uint8_t reg_addr,
 				  uint8_t *value, uint8_t len)
 {
+	struct lsm6dsl_data *data = dev->driver_data;
+
 	return i2c_burst_write(data->comm_master, lsm6dsl_i2c_slave_addr,
 			       reg_addr, value, len);
 }
 
-static int lsm6dsl_i2c_read_reg(struct lsm6dsl_data *data, uint8_t reg_addr,
+static int lsm6dsl_i2c_read_reg(struct device *dev, uint8_t reg_addr,
 				uint8_t *value)
 {
+	struct lsm6dsl_data *data = dev->driver_data;
+
 	return i2c_reg_read_byte(data->comm_master, lsm6dsl_i2c_slave_addr,
 				 reg_addr, value);
 }
 
-static int lsm6dsl_i2c_update_reg(struct lsm6dsl_data *data, uint8_t reg_addr,
+static int lsm6dsl_i2c_update_reg(struct device *dev, uint8_t reg_addr,
 				  uint8_t mask, uint8_t value)
 {
+	struct lsm6dsl_data *data = dev->driver_data;
+
 	return i2c_reg_update_byte(data->comm_master, lsm6dsl_i2c_slave_addr,
 				   reg_addr, mask, value);
 }

--- a/drivers/sensor/lsm6dsl/lsm6dsl_shub.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_shub.c
@@ -34,7 +34,7 @@ LOG_MODULE_DECLARE(LSM6DSL, CONFIG_SENSOR_LOG_LEVEL);
 #define LSM6DSL_EMBEDDED_SLVX_THREE_SENS 0x20
 #define LSM6DSL_EMBEDDED_SLV0_WRITE_IDLE 0x07
 
-static int lsm6dsl_shub_write_slave_reg(struct lsm6dsl_data *data,
+static int lsm6dsl_shub_write_slave_reg(struct device *dev,
 					uint8_t slv_addr, uint8_t slv_reg,
 					uint8_t *value, uint16_t len);
 
@@ -53,15 +53,16 @@ static int lsm6dsl_shub_write_slave_reg(struct lsm6dsl_data *data,
 #define LIS2MDL_OFF_CANC          0x02
 #define LIS2MDL_SENSITIVITY       1500
 
-static int lsm6dsl_lis2mdl_init(struct lsm6dsl_data *data, uint8_t i2c_addr)
+static int lsm6dsl_lis2mdl_init(struct device *dev, uint8_t i2c_addr)
 {
+	struct lsm6dsl_data *data = dev->driver_data;
 	uint8_t mag_cfg[2];
 
 	data->magn_sensitivity = LIS2MDL_SENSITIVITY;
 
 	/* sw reset device */
 	mag_cfg[0] = LIS2MDL_SW_RESET;
-	lsm6dsl_shub_write_slave_reg(data, i2c_addr,
+	lsm6dsl_shub_write_slave_reg(dev, i2c_addr,
 				     LIS2MDL_CFG_REG_A, mag_cfg, 1);
 
 	k_sleep(K_MSEC(10)); /* turn-on time in ms */
@@ -69,7 +70,7 @@ static int lsm6dsl_lis2mdl_init(struct lsm6dsl_data *data, uint8_t i2c_addr)
 	/* configure mag */
 	mag_cfg[0] = LIS2MDL_ODR_10HZ;
 	mag_cfg[1] = LIS2MDL_OFF_CANC;
-	lsm6dsl_shub_write_slave_reg(data, i2c_addr,
+	lsm6dsl_shub_write_slave_reg(dev, i2c_addr,
 				     LIS2MDL_CFG_REG_A, mag_cfg, 2);
 
 	return 0;
@@ -89,20 +90,20 @@ static int lsm6dsl_lis2mdl_init(struct lsm6dsl_data *data, uint8_t i2c_addr)
 #define LPS22HB_LPF_EN            0x08
 #define LPS22HB_BDU_EN            0x02
 
-static int lsm6dsl_lps22hb_init(struct lsm6dsl_data *data, uint8_t i2c_addr)
+static int lsm6dsl_lps22hb_init(struct device *dev, uint8_t i2c_addr)
 {
 	uint8_t baro_cfg[2];
 
 	/* sw reset device */
 	baro_cfg[0] = LPS22HB_SW_RESET;
-	lsm6dsl_shub_write_slave_reg(data, i2c_addr,
+	lsm6dsl_shub_write_slave_reg(dev, i2c_addr,
 				     LPS22HB_CTRL_REG2, baro_cfg, 1);
 
 	k_sleep(K_MSEC(1)); /* turn-on time in ms */
 
 	/* configure device */
 	baro_cfg[0] = LPS22HB_ODR_10HZ | LPS22HB_LPF_EN | LPS22HB_BDU_EN;
-	lsm6dsl_shub_write_slave_reg(data, i2c_addr,
+	lsm6dsl_shub_write_slave_reg(dev, i2c_addr,
 				     LPS22HB_CTRL_REG1, baro_cfg, 1);
 
 	return 0;
@@ -116,7 +117,7 @@ static struct lsm6dsl_shub_sens_list {
 	uint8_t wai_val;
 	uint8_t out_data_addr;
 	uint8_t out_data_len;
-	int (*dev_init)(struct lsm6dsl_data *data, uint8_t i2c_addr);
+	int (*dev_init)(struct device *dev, uint8_t i2c_addr);
 } lsm6dsl_shub_sens_list[] = {
 #ifdef CONFIG_LSM6DSL_EXT0_LIS2MDL
 	{
@@ -145,19 +146,21 @@ static struct lsm6dsl_shub_sens_list {
 
 static uint8_t ext_i2c_addr;
 
-static inline void lsm6dsl_shub_wait_completed(struct lsm6dsl_data *data)
+static inline void lsm6dsl_shub_wait_completed(struct device *dev)
 {
+	struct lsm6dsl_data *data = dev->driver_data;
 	uint16_t freq;
 
 	freq = (data->accel_freq == 0U) ? 26 : data->accel_freq;
 	k_msleep((2000U / freq) + 1);
 }
 
-static inline void lsm6dsl_shub_embedded_en(struct lsm6dsl_data *data, bool on)
+static inline void lsm6dsl_shub_embedded_en(struct device *dev, bool on)
 {
+	struct lsm6dsl_data *data = dev->driver_data;
 	uint8_t func_en = (on) ? 0x1 : 0x0;
 
-	data->hw_tf->update_reg(data, LSM6DSL_REG_FUNC_CFG_ACCESS,
+	data->hw_tf->update_reg(dev, LSM6DSL_REG_FUNC_CFG_ACCESS,
 				LSM6DSL_MASK_FUNC_CFG_EN,
 				func_en << LSM6DSL_SHIFT_FUNC_CFG_EN);
 
@@ -165,78 +168,84 @@ static inline void lsm6dsl_shub_embedded_en(struct lsm6dsl_data *data, bool on)
 }
 
 #ifdef LSM6DSL_DEBUG
-static int lsm6dsl_read_embedded_reg(struct lsm6dsl_data *data,
+static int lsm6dsl_read_embedded_reg(struct device *dev,
 				     uint8_t reg_addr, uint8_t *value, int len)
 {
-	lsm6dsl_shub_embedded_en(data, true);
+	lsm6dsl_shub_embedded_en(dev, true);
 
-	if (data->hw_tf->read_data(data, reg_addr, value, len) < 0) {
+	if (data->hw_tf->read_data(dev, reg_addr, value, len) < 0) {
 		LOG_DBG("failed to read external reg: %02x", reg_addr);
-		lsm6dsl_shub_embedded_en(data, false);
+		lsm6dsl_shub_embedded_en(dev, false);
 		return -EIO;
 	}
 
-	lsm6dsl_shub_embedded_en(data, false);
+	lsm6dsl_shub_embedded_en(dev, false);
 
 	return 0;
 }
 #endif
 
-static int lsm6dsl_shub_write_embedded_regs(struct lsm6dsl_data *data,
+static int lsm6dsl_shub_write_embedded_regs(struct device *dev,
 					    uint8_t reg_addr,
 					    uint8_t *value, uint8_t len)
 {
-	lsm6dsl_shub_embedded_en(data, true);
+	struct lsm6dsl_data *data = dev->driver_data;
 
-	if (data->hw_tf->write_data(data, reg_addr, value, len) < 0) {
+	lsm6dsl_shub_embedded_en(dev, true);
+
+	if (data->hw_tf->write_data(dev, reg_addr, value, len) < 0) {
 		LOG_DBG("failed to write external reg: %02x", reg_addr);
-		lsm6dsl_shub_embedded_en(data, false);
+		lsm6dsl_shub_embedded_en(dev, false);
 		return -EIO;
 	}
 
-	lsm6dsl_shub_embedded_en(data, false);
+	lsm6dsl_shub_embedded_en(dev, false);
 
 	return 0;
 }
 
-static void lsm6dsl_shub_enable(struct lsm6dsl_data *data)
+static void lsm6dsl_shub_enable(struct device *dev)
 {
+	struct lsm6dsl_data *data = dev->driver_data;
+
 	/* Enable Digital Func */
-	data->hw_tf->update_reg(data, LSM6DSL_REG_CTRL10_C,
+	data->hw_tf->update_reg(dev, LSM6DSL_REG_CTRL10_C,
 				LSM6DSL_MASK_CTRL10_C_FUNC_EN,
 				1 << LSM6DSL_SHIFT_CTRL10_C_FUNC_EN);
 
 	/* Enable Accel @26hz */
 	if (!data->accel_freq) {
-		data->hw_tf->update_reg(data,
+		data->hw_tf->update_reg(dev,
 				    LSM6DSL_REG_CTRL1_XL,
 				    LSM6DSL_MASK_CTRL1_XL_ODR_XL,
 				    2 << LSM6DSL_SHIFT_CTRL1_XL_ODR_XL);
 	}
 
 	/* Enable Sensor Hub */
-	data->hw_tf->update_reg(data, LSM6DSL_REG_MASTER_CONFIG,
+	data->hw_tf->update_reg(dev, LSM6DSL_REG_MASTER_CONFIG,
 				LSM6DSL_MASK_MASTER_CONFIG_MASTER_ON,
 				1 << LSM6DSL_SHIFT_MASTER_CONFIG_MASTER_ON);
 }
 
-static void lsm6dsl_shub_disable(struct lsm6dsl_data *data)
+static void lsm6dsl_shub_disable(struct device *dev)
 {
+	struct lsm6dsl_data *data = dev->driver_data;
+
 	/* Disable Sensor Hub */
-	data->hw_tf->update_reg(data, LSM6DSL_REG_MASTER_CONFIG,
+	data->hw_tf->update_reg(dev, LSM6DSL_REG_MASTER_CONFIG,
 				LSM6DSL_MASK_MASTER_CONFIG_MASTER_ON,
 				0 << LSM6DSL_SHIFT_MASTER_CONFIG_MASTER_ON);
 
 	/* Disable Accel */
 	if (!data->accel_freq) {
-		data->hw_tf->update_reg(data,
+		data->hw_tf->update_reg(dev,
 				    LSM6DSL_REG_CTRL1_XL,
 				    LSM6DSL_MASK_CTRL1_XL_ODR_XL,
 				    0 << LSM6DSL_SHIFT_CTRL1_XL_ODR_XL);
 	}
 
 	/* Disable Digital Func */
-	data->hw_tf->update_reg(data, LSM6DSL_REG_CTRL10_C,
+	data->hw_tf->update_reg(dev, LSM6DSL_REG_CTRL10_C,
 				LSM6DSL_MASK_CTRL10_C_FUNC_EN,
 				0 << LSM6DSL_SHIFT_CTRL10_C_FUNC_EN);
 }
@@ -244,35 +253,36 @@ static void lsm6dsl_shub_disable(struct lsm6dsl_data *data)
 /*
  * use SLV0 for generic read to slave device
  */
-static int lsm6dsl_shub_read_slave_reg(struct lsm6dsl_data *data,
+static int lsm6dsl_shub_read_slave_reg(struct device *dev,
 				       uint8_t slv_addr, uint8_t slv_reg,
 				       uint8_t *value, uint16_t len)
 {
+	struct lsm6dsl_data *data = dev->driver_data;
 	uint8_t slave[3];
 
 	slave[0] = (slv_addr << 1) | LSM6DSL_EMBEDDED_SLVX_READ;
 	slave[1] = slv_reg;
 	slave[2] = (len & 0x7);
 
-	if (lsm6dsl_shub_write_embedded_regs(data, LSM6DSL_EMBEDDED_SLV0_ADDR,
+	if (lsm6dsl_shub_write_embedded_regs(dev, LSM6DSL_EMBEDDED_SLV0_ADDR,
 					     slave, 3) < 0) {
 		LOG_DBG("error writing embedded reg");
 		return -EIO;
 	}
 
 	/* turn SH on */
-	lsm6dsl_shub_enable(data);
-	lsm6dsl_shub_wait_completed(data);
-	data->hw_tf->read_data(data, LSM6DSL_REG_SENSORHUB1, value, len);
+	lsm6dsl_shub_enable(dev);
+	lsm6dsl_shub_wait_completed(dev);
+	data->hw_tf->read_data(dev, LSM6DSL_REG_SENSORHUB1, value, len);
 
-	lsm6dsl_shub_disable(data);
+	lsm6dsl_shub_disable(dev);
 	return 0;
 }
 
 /*
  * use SLV0 to configure slave device
  */
-static int lsm6dsl_shub_write_slave_reg(struct lsm6dsl_data *data,
+static int lsm6dsl_shub_write_slave_reg(struct device *dev,
 					uint8_t slv_addr, uint8_t slv_reg,
 					uint8_t *value, uint16_t len)
 {
@@ -283,7 +293,7 @@ static int lsm6dsl_shub_write_slave_reg(struct lsm6dsl_data *data,
 		slv_cfg[0] = (slv_addr << 1) & ~LSM6DSL_EMBEDDED_SLVX_READ;
 		slv_cfg[1] = slv_reg + cnt;
 
-		if (lsm6dsl_shub_write_embedded_regs(data,
+		if (lsm6dsl_shub_write_embedded_regs(dev,
 						     LSM6DSL_EMBEDDED_SLV0_ADDR,
 						     slv_cfg, 2) < 0) {
 			LOG_DBG("error writing embedded reg");
@@ -291,7 +301,7 @@ static int lsm6dsl_shub_write_slave_reg(struct lsm6dsl_data *data,
 		}
 
 		slv_cfg[0] = value[cnt];
-		if (lsm6dsl_shub_write_embedded_regs(data,
+		if (lsm6dsl_shub_write_embedded_regs(dev,
 					LSM6DSL_EMBEDDED_SLV0_DATAWRITE,
 					slv_cfg, 1) < 0) {
 			LOG_DBG("error writing embedded reg");
@@ -299,9 +309,9 @@ static int lsm6dsl_shub_write_slave_reg(struct lsm6dsl_data *data,
 		}
 
 		/* turn SH on */
-		lsm6dsl_shub_enable(data);
-		lsm6dsl_shub_wait_completed(data);
-		lsm6dsl_shub_disable(data);
+		lsm6dsl_shub_enable(dev);
+		lsm6dsl_shub_wait_completed(dev);
+		lsm6dsl_shub_disable(dev);
 
 		cnt++;
 	}
@@ -310,7 +320,7 @@ static int lsm6dsl_shub_write_slave_reg(struct lsm6dsl_data *data,
 	slv_cfg[0] = LSM6DSL_EMBEDDED_SLV0_WRITE_IDLE;
 	slv_cfg[1] = lsm6dsl_shub_sens_list[0].wai_addr;
 	slv_cfg[2] = LSM6DSL_EMBEDDED_SLVX_THREE_SENS;
-	if (lsm6dsl_shub_write_embedded_regs(data,
+	if (lsm6dsl_shub_write_embedded_regs(dev,
 					     LSM6DSL_EMBEDDED_SLV0_ADDR,
 					     slv_cfg, 3) < 0) {
 		LOG_DBG("error writing embedded reg");
@@ -327,7 +337,7 @@ static int lsm6dsl_shub_write_slave_reg(struct lsm6dsl_data *data,
  *  - SLAVE 1: used as data read channel to slave device
  *  - SLAVE 2: used for generic reads while data channel is enabled
  */
-static int lsm6dsl_shub_set_data_channel(struct lsm6dsl_data *data)
+static int lsm6dsl_shub_set_data_channel(struct device *dev)
 {
 	uint8_t slv_cfg[3];
 	uint8_t slv_i2c_addr = lsm6dsl_shub_sens_list[0].i2c_addr[ext_i2c_addr];
@@ -336,7 +346,7 @@ static int lsm6dsl_shub_set_data_channel(struct lsm6dsl_data *data)
 	slv_cfg[0] = LSM6DSL_EMBEDDED_SLV0_WRITE_IDLE;
 	slv_cfg[1] = lsm6dsl_shub_sens_list[0].wai_addr;
 	slv_cfg[2] = LSM6DSL_EMBEDDED_SLVX_THREE_SENS;
-	if (lsm6dsl_shub_write_embedded_regs(data,
+	if (lsm6dsl_shub_write_embedded_regs(dev,
 					     LSM6DSL_EMBEDDED_SLV0_ADDR,
 					     slv_cfg, 3) < 0) {
 		LOG_DBG("error writing embedded reg");
@@ -347,7 +357,7 @@ static int lsm6dsl_shub_set_data_channel(struct lsm6dsl_data *data)
 	slv_cfg[0] = (slv_i2c_addr << 1) | LSM6DSL_EMBEDDED_SLVX_READ;
 	slv_cfg[1] = lsm6dsl_shub_sens_list[0].out_data_addr;
 	slv_cfg[2] = lsm6dsl_shub_sens_list[0].out_data_len;
-	if (lsm6dsl_shub_write_embedded_regs(data,
+	if (lsm6dsl_shub_write_embedded_regs(dev,
 					     LSM6DSL_EMBEDDED_SLV1_ADDR,
 					     slv_cfg, 3) < 0) {
 		LOG_DBG("error writing embedded reg");
@@ -355,8 +365,8 @@ static int lsm6dsl_shub_set_data_channel(struct lsm6dsl_data *data)
 	}
 
 	/* turn SH on */
-	lsm6dsl_shub_enable(data);
-	lsm6dsl_shub_wait_completed(data);
+	lsm6dsl_shub_enable(dev);
+	lsm6dsl_shub_wait_completed(dev);
 
 	return 0;
 }
@@ -365,14 +375,13 @@ int lsm6dsl_shub_read_external_chip(struct device *dev, uint8_t *buf, uint8_t le
 {
 	struct lsm6dsl_data *data = dev->driver_data;
 
-	data->hw_tf->read_data(data, LSM6DSL_REG_SENSORHUB1, buf, len);
+	data->hw_tf->read_data(dev, LSM6DSL_REG_SENSORHUB1, buf, len);
 
 	return 0;
 }
 
 int lsm6dsl_shub_init_external_chip(struct device *dev)
 {
-	struct lsm6dsl_data *data = dev->driver_data;
 	uint8_t i;
 	uint8_t chip_id = 0U;
 	uint8_t slv_i2c_addr;
@@ -390,7 +399,7 @@ int lsm6dsl_shub_init_external_chip(struct device *dev)
 			continue;
 		}
 
-		if (lsm6dsl_shub_read_slave_reg(data, slv_i2c_addr,
+		if (lsm6dsl_shub_read_slave_reg(dev, slv_i2c_addr,
 						slv_wai_addr,
 						&chip_id, 1) < 0) {
 			LOG_DBG("failed reading external chip id");
@@ -409,9 +418,9 @@ int lsm6dsl_shub_init_external_chip(struct device *dev)
 	ext_i2c_addr = i;
 
 	/* init external device */
-	lsm6dsl_shub_sens_list[0].dev_init(data, slv_i2c_addr);
+	lsm6dsl_shub_sens_list[0].dev_init(dev, slv_i2c_addr);
 
-	lsm6dsl_shub_set_data_channel(data);
+	lsm6dsl_shub_set_data_channel(dev);
 
 	return 0;
 }

--- a/drivers/sensor/lsm6dsl/lsm6dsl_spi.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_spi.c
@@ -34,9 +34,10 @@ static struct spi_config lsm6dsl_spi_conf = {
 	.cs        = SPI_CS,
 };
 
-static int lsm6dsl_raw_read(struct lsm6dsl_data *data, uint8_t reg_addr,
+static int lsm6dsl_raw_read(struct device *dev, uint8_t reg_addr,
 			    uint8_t *value, uint8_t len)
 {
+	struct lsm6dsl_data *data = dev->driver_data;
 	struct spi_config *spi_cfg = &lsm6dsl_spi_conf;
 	uint8_t buffer_tx[2] = { reg_addr | LSM6DSL_SPI_READ, 0 };
 	const struct spi_buf tx_buf = {
@@ -74,9 +75,10 @@ static int lsm6dsl_raw_read(struct lsm6dsl_data *data, uint8_t reg_addr,
 	return 0;
 }
 
-static int lsm6dsl_raw_write(struct lsm6dsl_data *data, uint8_t reg_addr,
+static int lsm6dsl_raw_write(struct device *dev, uint8_t reg_addr,
 			     uint8_t *value, uint8_t len)
 {
+	struct lsm6dsl_data *data = dev->driver_data;
 	struct spi_config *spi_cfg = &lsm6dsl_spi_conf;
 	uint8_t buffer_tx[1] = { reg_addr & ~LSM6DSL_SPI_READ };
 	const struct spi_buf tx_buf[2] = {
@@ -106,33 +108,33 @@ static int lsm6dsl_raw_write(struct lsm6dsl_data *data, uint8_t reg_addr,
 	return 0;
 }
 
-static int lsm6dsl_spi_read_data(struct lsm6dsl_data *data, uint8_t reg_addr,
+static int lsm6dsl_spi_read_data(struct device *dev, uint8_t reg_addr,
 				 uint8_t *value, uint8_t len)
 {
-	return lsm6dsl_raw_read(data, reg_addr, value, len);
+	return lsm6dsl_raw_read(dev, reg_addr, value, len);
 }
 
-static int lsm6dsl_spi_write_data(struct lsm6dsl_data *data, uint8_t reg_addr,
+static int lsm6dsl_spi_write_data(struct device *dev, uint8_t reg_addr,
 				  uint8_t *value, uint8_t len)
 {
-	return lsm6dsl_raw_write(data, reg_addr, value, len);
+	return lsm6dsl_raw_write(dev, reg_addr, value, len);
 }
 
-static int lsm6dsl_spi_read_reg(struct lsm6dsl_data *data, uint8_t reg_addr,
+static int lsm6dsl_spi_read_reg(struct device *dev, uint8_t reg_addr,
 				uint8_t *value)
 {
-	return lsm6dsl_raw_read(data, reg_addr, value, 1);
+	return lsm6dsl_raw_read(dev, reg_addr, value, 1);
 }
 
-static int lsm6dsl_spi_update_reg(struct lsm6dsl_data *data, uint8_t reg_addr,
+static int lsm6dsl_spi_update_reg(struct device *dev, uint8_t reg_addr,
 				  uint8_t mask, uint8_t value)
 {
 	uint8_t tmp_val;
 
-	lsm6dsl_raw_read(data, reg_addr, &tmp_val, 1);
+	lsm6dsl_raw_read(dev, reg_addr, &tmp_val, 1);
 	tmp_val = (tmp_val & ~mask) | (value & mask);
 
-	return lsm6dsl_raw_write(data, reg_addr, &tmp_val, 1);
+	return lsm6dsl_raw_write(dev, reg_addr, &tmp_val, 1);
 }
 
 static const struct lsm6dsl_transfer_function lsm6dsl_spi_transfer_fn = {

--- a/drivers/sensor/lsm6dsl/lsm6dsl_trigger.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_trigger.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT st_lsm6dsl
-
 #include <device.h>
 #include <drivers/i2c.h>
 #include <sys/__assert.h>
@@ -17,21 +15,24 @@
 
 LOG_MODULE_DECLARE(LSM6DSL, CONFIG_SENSOR_LOG_LEVEL);
 
-static inline void setup_irq(struct lsm6dsl_data *drv_data,
+static inline void setup_irq(struct device *dev,
 			     bool enable)
 {
+	struct lsm6dsl_data *drv_data = dev->driver_data;
+	const struct lsm6dsl_config *const config = dev->config_info;
 	unsigned int flags = enable
 		? GPIO_INT_EDGE_TO_ACTIVE
 		: GPIO_INT_DISABLE;
 
-	gpio_pin_interrupt_configure(drv_data->gpio,
-				     DT_INST_GPIO_PIN(0, irq_gpios),
+	gpio_pin_interrupt_configure(drv_data->gpio, config->trigger_pin,
 				     flags);
 }
 
-static inline void handle_irq(struct lsm6dsl_data *drv_data)
+static inline void handle_irq(struct device *dev)
 {
-	setup_irq(drv_data, false);
+	struct lsm6dsl_data *drv_data = dev->driver_data;
+
+	setup_irq(dev, false);
 
 #if defined(CONFIG_LSM6DSL_TRIGGER_OWN_THREAD)
 	k_sem_give(&drv_data->gpio_sem);
@@ -45,10 +46,11 @@ int lsm6dsl_trigger_set(struct device *dev,
 			sensor_trigger_handler_t handler)
 {
 	struct lsm6dsl_data *drv_data = dev->driver_data;
+	const struct lsm6dsl_config *const config = dev->config_info;
 
 	__ASSERT_NO_MSG(trig->type == SENSOR_TRIG_DATA_READY);
 
-	setup_irq(drv_data, false);
+	setup_irq(dev, false);
 
 	drv_data->data_ready_handler = handler;
 	if (handler == NULL) {
@@ -57,9 +59,9 @@ int lsm6dsl_trigger_set(struct device *dev,
 
 	drv_data->data_ready_trigger = *trig;
 
-	setup_irq(drv_data, true);
-	if (gpio_pin_get(drv_data->gpio, DT_INST_GPIO_PIN(0, irq_gpios)) > 0) {
-		handle_irq(drv_data);
+	setup_irq(dev, true);
+	if (gpio_pin_get(drv_data->gpio, config->trigger_pin) > 0) {
+		handle_irq(dev);
 	}
 
 	return 0;
@@ -73,7 +75,7 @@ static void lsm6dsl_gpio_callback(struct device *dev,
 
 	ARG_UNUSED(pins);
 
-	handle_irq(drv_data);
+	handle_irq(drv_data->dev);
 }
 
 static void lsm6dsl_thread_cb(void *arg)
@@ -86,7 +88,7 @@ static void lsm6dsl_thread_cb(void *arg)
 					     &drv_data->data_ready_trigger);
 	}
 
-	setup_irq(drv_data, true);
+	setup_irq(dev, true);
 }
 
 #ifdef CONFIG_LSM6DSL_TRIGGER_OWN_THREAD
@@ -117,21 +119,22 @@ static void lsm6dsl_work_cb(struct k_work *work)
 int lsm6dsl_init_interrupt(struct device *dev)
 {
 	struct lsm6dsl_data *drv_data = dev->driver_data;
+	const struct lsm6dsl_config *const config = dev->config_info;
 
 	/* setup data ready gpio interrupt */
-	drv_data->gpio = device_get_binding(DT_INST_GPIO_LABEL(0, irq_gpios));
+	drv_data->gpio = device_get_binding(config->trigger_name);
 	if (drv_data->gpio == NULL) {
 		LOG_ERR("Cannot get pointer to %s device.",
-			    DT_INST_GPIO_LABEL(0, irq_gpios));
+			config->trigger_name);
 		return -EINVAL;
 	}
 
-	gpio_pin_configure(drv_data->gpio, DT_INST_GPIO_PIN(0, irq_gpios),
-			   GPIO_INPUT | DT_INST_GPIO_FLAGS(0, irq_gpios));
+	gpio_pin_configure(drv_data->gpio, config->trigger_pin,
+			   GPIO_INPUT | config->trigger_flags);
 
 	gpio_init_callback(&drv_data->gpio_cb,
 			   lsm6dsl_gpio_callback,
-			   BIT(DT_INST_GPIO_PIN(0, irq_gpios)));
+			   BIT(config->trigger_pin));
 
 	if (gpio_add_callback(drv_data->gpio, &drv_data->gpio_cb) < 0) {
 		LOG_ERR("Could not set gpio callback.");
@@ -162,7 +165,7 @@ int lsm6dsl_init_interrupt(struct device *dev)
 	drv_data->dev = dev;
 #endif
 
-	setup_irq(drv_data, true);
+	setup_irq(dev, true);
 
 	return 0;
 }

--- a/drivers/sensor/lsm6dsl/lsm6dsl_trigger.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_trigger.c
@@ -139,7 +139,7 @@ int lsm6dsl_init_interrupt(struct device *dev)
 	}
 
 	/* enable data-ready interrupt */
-	if (drv_data->hw_tf->update_reg(drv_data,
+	if (drv_data->hw_tf->update_reg(dev,
 			       LSM6DSL_REG_INT1_CTRL,
 			       LSM6DSL_MASK_INT1_CTRL_DRDY_XL |
 			       LSM6DSL_MASK_INT1_CTRL_DRDY_G,


### PR DESCRIPTION
Refactor the lsm6dsl driver to be multi-instance by storing any device specific information in the config.

This is a prelude to adding support for the similar lsm6ds3 used on the Arduino Nano 33 IOT.  The same multi-instance support will be used for another instance with a different DT_COMPAT.

