### PR TITLE
dts: x86: cleanup memory node

### DIFF
--- a/boards/x86/acrn/acrn.dts
+++ b/boards/x86/acrn/acrn.dts
@@ -8,7 +8,7 @@
 
 #include <mem.h>
 
-#define DT_SRAM_SIZE	DT_SIZE_K(8192)
+#define DT_DRAM_SIZE	DT_SIZE_K(8192)
 
 #include <ia32.dtsi>
 
@@ -22,7 +22,7 @@
 	};
 
 	chosen {
-		zephyr,sram = &sram0;
+		zephyr,sram = &dram0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 	};

--- a/boards/x86/gpmrb/gpmrb.dts
+++ b/boards/x86/gpmrb/gpmrb.dts
@@ -8,7 +8,7 @@
 
 #include <mem.h>
 
-#define DT_SRAM_SIZE		DT_SIZE_M(2048)
+#define DT_DRAM_SIZE		DT_SIZE_M(2048)
 
 #include <apollo_lake.dtsi>
 
@@ -17,7 +17,7 @@
 	compatible = "intel,apollo_lake";
 
 	chosen {
-		zephyr,sram = &sram0;
+		zephyr,sram = &dram0;
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
 		zephyr,bt-uart = &uart1;

--- a/boards/x86/minnowboard/minnowboard.dts
+++ b/boards/x86/minnowboard/minnowboard.dts
@@ -4,7 +4,7 @@
 
 #include <mem.h>
 
-#define DT_SRAM_SIZE		DT_SIZE_M(2048)
+#define DT_DRAM_SIZE		DT_SIZE_M(2048)
 
 #include <atom.dtsi>
 
@@ -18,7 +18,7 @@
 	};
 
 	chosen {
-		zephyr,sram = &sram0;
+		zephyr,sram = &dram0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-uart = &uart1;

--- a/boards/x86/qemu_x86/qemu_x86.dts
+++ b/boards/x86/qemu_x86/qemu_x86.dts
@@ -4,7 +4,7 @@
 
 #include <mem.h>
 
-#define DT_SRAM_SIZE		DT_SIZE_K(4096)
+#define DT_DRAM_SIZE		DT_SIZE_K(4096)
 #define DT_FLASH_SIZE		DT_SIZE_K(4096)
 
 #include <ia32.dtsi>
@@ -25,7 +25,7 @@
 	};
 
 	chosen {
-		zephyr,sram = &sram0;
+		zephyr,sram = &dram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;

--- a/boards/x86/up_squared/up_squared.dts
+++ b/boards/x86/up_squared/up_squared.dts
@@ -8,7 +8,7 @@
 
 #include <mem.h>
 
-#define DT_SRAM_SIZE		DT_SIZE_M(2048)
+#define DT_DRAM_SIZE		DT_SIZE_M(2048)
 
 #include <apollo_lake.dtsi>
 
@@ -17,7 +17,7 @@
 	compatible = "intel,apollo_lake";
 
 	chosen {
-		zephyr,sram = &sram0;
+		zephyr,sram = &dram0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-uart = &uart1;

--- a/boards/x86/up_squared/up_squared_32.dts
+++ b/boards/x86/up_squared/up_squared_32.dts
@@ -8,7 +8,7 @@
 
 #include <mem.h>
 
-#define DT_SRAM_SIZE		DT_SIZE_M(2048)
+#define DT_DRAM_SIZE		DT_SIZE_M(2048)
 
 #include <apollo_lake.dtsi>
 
@@ -17,7 +17,7 @@
 	compatible = "intel,apollo_lake";
 
 	chosen {
-		zephyr,sram = &sram0;
+		zephyr,sram = &dram0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-uart = &uart1;

--- a/dts/x86/apollo_lake.dtsi
+++ b/dts/x86/apollo_lake.dtsi
@@ -22,10 +22,9 @@
 
 	};
 
-	sram0: memory@0 {
+	dram0: memory@0 {
 		device_type = "memory";
-		compatible = "mmio-sram";
-		reg = <0x0 DT_SRAM_SIZE>;
+		reg = <0x0 DT_DRAM_SIZE>;
 	};
 
 	intc: ioapic@fec00000  {

--- a/dts/x86/atom.dtsi
+++ b/dts/x86/atom.dtsi
@@ -19,10 +19,9 @@
 		};
 	};
 
-	sram0: memory@0 {
+	dram0: memory@0 {
 		device_type = "memory";
-		compatible = "mmio-sram";
-		reg = <0x0 DT_SRAM_SIZE>;
+		reg = <0x0 DT_DRAM_SIZE>;
 	};
 
 	intc: ioapic@fec00000  {

--- a/dts/x86/ia32.dtsi
+++ b/dts/x86/ia32.dtsi
@@ -27,10 +27,9 @@
 		#interrupt-cells = <3>;
 	};
 
-	sram0: memory@0 {
+	dram0: memory@0 {
 		device_type = "memory";
-		compatible = "mmio-sram";
-		reg = <0x0 DT_SRAM_SIZE>;
+		reg = <0x0 DT_DRAM_SIZE>;
 	};
 
 	soc {


### PR DESCRIPTION
* Rename DT_SRAM_SIZE to DT_DRAM_SIZE since that is more correct
* Remove mmio-sram compatible since that is not correct for DRAM.
* Rename node label from sram0 to dram0

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>