### PR TITLE
scripts: Increased minimal pyelftools version

### DIFF
--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -4,7 +4,7 @@
 # part of the recommended workflow
 
 # used by various build scripts
-pyelftools>=0.24
+pyelftools>=0.26
 
 # used by dts generation to parse binding YAMLs, also used by
 # sanitycheck to parse YAMLs


### PR DESCRIPTION
Increased minimal pyelftools version to 0.26 else scripts/footprint/size_report will fail to import LocationExpr from elftools.dwarf.locationlists.

This issue was encountered by running `ninja rom_report` to collect rom usage data for LVGL V7 in an already set up virtual environment that had version 0.24 of pyelftools installed.
