### PR TITLE
DT accessors with defaults + default flags to 0

### DIFF
--- a/drivers/led_strip/apa102.c
+++ b/drivers/led_strip/apa102.c
@@ -12,24 +12,6 @@
 #include <drivers/gpio.h>
 #include <sys/util.h>
 
-/*
- * Devicetree helper macros which gets the 'flags' cell from a 'cs_gpios'
- * property on the spi bus, or returns 0 if the property has no 'flags' cell.
- *
- * Hopefully these helpers will be removed once #25827 is resolved.
- */
-#define HAS_FLAGS(spi_dev, spi_reg)					\
-	DT_PHA_HAS_CELL_AT_IDX(spi_dev, cs_gpios, spi_reg, flags)
-
-#define INST_SPI_DEV_CS_GPIOS_HAS_FLAGS(node)			\
-	HAS_FLAGS(DT_BUS(node), DT_REG_ADDR(node))
-
-#define FLAGS_OR_ZERO(inst)						\
-	COND_CODE_1(							\
-		INST_SPI_DEV_CS_GPIOS_HAS_FLAGS(DT_DRV_INST(inst)),	\
-		(DT_INST_SPI_DEV_CS_GPIOS_FLAGS(inst)),			\
-		(0x0))
-
 struct apa102_data {
 	struct device *spi;
 	struct spi_config cfg;
@@ -128,7 +110,8 @@ static int apa102_init(struct device *dev)
 	data->cfg.cs = &data->cs_ctl;
 
 	gpio_pin_configure(data->cs_ctl.gpio_dev, data->cs_ctl.gpio_pin,
-			   GPIO_OUTPUT_INACTIVE | FLAGS_OR_ZERO(0));
+			   GPIO_OUTPUT_INACTIVE |
+			   DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0));
 #endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
 
 	return 0;

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -1368,14 +1368,12 @@
 #define DT_INST_PROP(inst, prop) DT_PROP(DT_DRV_INST(inst), prop)
 
 /**
- * @brief Get a DT_DRV_COMPAT element value in an array property
+ * @brief Get a DT_DRV_COMPAT property length
  * @param inst instance number
  * @param prop lowercase-and-underscores property name
- * @param idx the index to get
- * @return a representation of the idx-th element of the property
+ * @return logical length of the property
  */
-#define DT_INST_PROP_BY_IDX(inst, prop, idx) \
-	DT_PROP_BY_IDX(DT_DRV_INST(inst), prop, idx)
+#define DT_INST_PROP_LEN(inst, prop) DT_PROP_LEN(DT_DRV_INST(inst), prop)
 
 /**
  * @brief Is index "idx" valid for an array type property
@@ -1390,12 +1388,14 @@
 	DT_PROP_HAS_IDX(DT_DRV_INST(inst), prop, idx)
 
 /**
- * @brief Get a DT_DRV_COMPAT property length
+ * @brief Get a DT_DRV_COMPAT element value in an array property
  * @param inst instance number
  * @param prop lowercase-and-underscores property name
- * @return logical length of the property
+ * @param idx the index to get
+ * @return a representation of the idx-th element of the property
  */
-#define DT_INST_PROP_LEN(inst, prop) DT_PROP_LEN(DT_DRV_INST(inst), prop)
+#define DT_INST_PROP_BY_IDX(inst, prop, idx) \
+	DT_PROP_BY_IDX(DT_DRV_INST(inst), prop, idx)
 
 /**
  * @brief Get a DT_DRV_COMPAT instance's "label" property

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -469,6 +469,23 @@
 #define DT_PROP_BY_IDX(node_id, prop, idx) DT_PROP(node_id, prop##_IDX_##idx)
 
 /**
+ * @brief Like DT_PROP(), but with a fallback to default_value
+ *
+ * If the value exists, this expands to DT_PROP(node_id, prop).
+ * The default_value parameter is not expanded in this case.
+ *
+ * Otherwise, this expands to default_value.
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param default_value a fallback value to expand to
+ * @return the property's value or default_value
+ */
+#define DT_PROP_OR(node_id, prop, default_value) \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, prop), \
+		    (DT_PROP(node_id, prop)), (default_value))
+
+/**
  * @brief Equivalent to DT_PROP(node_id, label)
  *
  * This is a convenience for the Zephyr device API, which uses label
@@ -630,6 +647,30 @@
 	DT_PROP(node_id, pha##_IDX_##idx##_VAL_##cell)
 
 /**
+ * @brief Like DT_PHA_BY_IDX(), but with a fallback to default_value.
+ *
+ * If the value exists, this expands to DT_PHA_BY_IDX(node_id, pha,
+ * idx, cell). The default_value parameter is not expanded in this
+ * case.
+ *
+ * Otherwise, this expands to default_value.
+ *
+ * @param node_id node identifier
+ * @param pha lowercase-and-underscores property with type "phandle-array"
+ * @param idx logical index into "pha"
+ * @param cell lowercase-and-underscores cell name within the specifier
+ *             at "pha" index "idx"
+ * @param default_value a fallback value to expand to
+ * @return the cell's value or "default_value"
+ */
+#define DT_PHA_BY_IDX_OR(node_id, pha, idx, cell, default_value) \
+	DT_PROP_OR(node_id, pha##_IDX_##idx##_VAL_##cell, default_value)
+/* Implementation note: the _IDX_##idx##_VAL_##cell##_EXISTS
+ * macros are defined, so it's safe to use DT_PROP_OR() here, because
+ * that uses an IS_ENABLED() on the _EXISTS macro.
+ */
+
+/**
  * @brief Equivalent to DT_PHA_BY_IDX(node_id, pha, 0, cell)
  * @param node_id node identifier
  * @param pha lowercase-and-underscores property with type "phandle-array"
@@ -637,6 +678,23 @@
  * @return the cell's value
  */
 #define DT_PHA(node_id, pha, cell) DT_PHA_BY_IDX(node_id, pha, 0, cell)
+
+/**
+ * @brief Like DT_PHA(), but with a fallback to default_value
+ *
+ * If the value exists, this expands to DT_PHA(node_id, pha, cell).
+ * The default_value parameter is not expanded in this case.
+ *
+ * Otherwise, this expands to default_value.
+ *
+ * @param node_id node identifier
+ * @param pha lowercase-and-underscores property with type "phandle-array"
+ * @param cell lowercase-and-underscores cell name
+ * @param default_value a fallback value to expand to
+ * @return the cell's value or default_value
+ */
+#define DT_PHA_OR(node_id, pha, cell, default_value) \
+	DT_PHA_BY_IDX_OR(node_id, pha, 0, cell, default_value)
 
 /**
  * @brief Get a value within a phandle-array specifier by name
@@ -674,6 +732,28 @@
  */
 #define DT_PHA_BY_NAME(node_id, pha, name, cell) \
 	DT_PROP(node_id, pha##_NAME_##name##_VAL_##cell)
+
+/**
+ * @brief Like DT_PHA_BY_NAME(), but with a fallback to default_value
+ *
+ * If the value exists, this expands to DT_PHA_BY_NAME(node_id, pha,
+ * name, cell). The default_value parameter is not expanded in this case.
+ *
+ * Otherwise, this expands to default_value.
+ *
+ * @param node_id node identifier
+ * @param pha lowercase-and-underscores property with type "phandle-array"
+ * @param name lowercase-and-underscores name of a specifier in "pha"
+ * @param cell lowercase-and-underscores cell name in the named specifier
+ * @param default_value a fallback value to expand to
+ * @return the cell's value or default_value
+ */
+#define DT_PHA_BY_NAME_OR(node_id, pha, name, cell, default_value) \
+	DT_PROP_OR(node_id, pha##_NAME_##name##_VAL_##cell, default_value)
+/* Implementation note: the _NAME_##name##_VAL_##cell##_EXISTS
+ * macros are defined, so it's safe to use DT_PROP_OR() here, because
+ * that uses an IS_ENABLED() on the _EXISTS macro.
+ */
 
 /**
  * @brief Get a phandle's node identifier from a phandle array by name
@@ -1398,6 +1478,16 @@
 	DT_PROP_BY_IDX(DT_DRV_INST(inst), prop, idx)
 
 /**
+ * @brief Like DT_INST_PROP(), but with a fallback to default_value
+ * @param inst instance number
+ * @param prop lowercase-and-underscores property name
+ * @param default_value a fallback value to expand to
+ * @return DT_INST_PROP(inst, prop) or default_value
+ */
+#define DT_INST_PROP_OR(inst, prop, default_value) \
+	DT_PROP_OR(DT_DRV_INST(inst), prop, default_value)
+
+/**
  * @brief Get a DT_DRV_COMPAT instance's "label" property
  * @param inst instance number
  * @return instance's label property value
@@ -1441,6 +1531,18 @@
 	DT_PHA_BY_IDX(DT_DRV_INST(inst), pha, idx, cell)
 
 /**
+ * @brief Like DT_INST_PHA_BY_IDX(), but with a fallback to default_value
+ * @param inst instance number
+ * @param pha lowercase-and-underscores property with type "phandle-array"
+ * @param idx logical index into the property "pha"
+ * @param cell binding's cell name within the specifier at index "idx"
+ * @param default_value a fallback value to expand to
+ * @return DT_INST_PHA_BY_IDX(inst, pha, idx, cell) or default_value
+ */
+#define DT_INST_PHA_BY_IDX_OR(inst, pha, idx, cell, default_value) \
+	DT_PHA_BY_IDX_OR(DT_DRV_INST(inst), pha, idx, cell, default_value)
+
+/**
  * @brief Get a DT_DRV_COMPAT instance's phandle-array specifier value
  * Equivalent to DT_INST_PHA_BY_IDX(inst, pha, 0, cell)
  * @param inst instance number
@@ -1449,6 +1551,17 @@
  * @return the cell value
  */
 #define DT_INST_PHA(inst, pha, cell) DT_INST_PHA_BY_IDX(inst, pha, 0, cell)
+
+/**
+ * @brief Like DT_INST_PHA(), but with a fallback to default_value
+ * @param inst instance number
+ * @param pha lowercase-and-underscores property with type "phandle-array"
+ * @param cell binding's cell name for the specifier at "pha" index 0
+ * @param default_value a fallback value to expand to
+ * @return DT_INST_PHA(inst, pha, cell) or default_value
+ */
+#define DT_INST_PHA_OR(inst, pha, cell, default_value) \
+	DT_INST_PHA_BY_IDX_OR(inst, pha, 0, cell, default_value)
 
 /**
  * @brief Get a DT_DRV_COMPAT instance's value within a phandle-array
@@ -1461,6 +1574,18 @@
  */
 #define DT_INST_PHA_BY_NAME(inst, pha, name, cell) \
 	DT_PHA_BY_NAME(DT_DRV_INST(inst), pha, name, cell)
+
+/**
+ * @brief Like DT_INST_PHA_BY_NAME(), but with a fallback to default_value
+ * @param inst instance number
+ * @param pha lowercase-and-underscores property with type "phandle-array"
+ * @param name lowercase-and-underscores name of a specifier in "pha"
+ * @param cell binding's cell name for the named specifier
+ * @param default_value a fallback value to expand to
+ * @return DT_INST_PHA_BY_NAME(inst, pha, name, cell) or default_value
+ */
+#define DT_INST_PHA_BY_NAME_OR(inst, pha, name, cell, default_value) \
+	DT_PHA_BY_NAME_OR(DT_DRV_INST(inst), pha, name, cell, default_value)
 
 /**
  * @brief Get a DT_DRV_COMPAT instance's phandle node identifier from a

--- a/include/devicetree/gpio.h
+++ b/include/devicetree/gpio.h
@@ -129,8 +129,10 @@ extern "C" {
 /**
  * @brief Get a GPIO specifier's flags cell at an index
  *
- * This macro only works for GPIO specifiers with cells named "flags".
- * Refer to the node's binding to check if necessary.
+ * This macro expects GPIO specifiers with cells named "flags".
+ * If there is no "flags" cell in the GPIO specifier, zero is returned.
+ * Refer to the node's binding to check specifier cell names if necessary.
+ *
  * Example devicetree fragment:
  *
  *     gpio1: gpio@... {
@@ -163,18 +165,18 @@ extern "C" {
  * @param gpio_pha lowercase-and-underscores GPIO property with
  *        type "phandle-array"
  * @param idx logical index into "gpio_pha"
- * @return the flags cell value at index "idx"
+ * @return the flags cell value at index "idx", or zero if there is none
  * @see DT_PHA_BY_IDX()
  */
 #define DT_GPIO_FLAGS_BY_IDX(node_id, gpio_pha, idx) \
-	DT_PHA_BY_IDX(node_id, gpio_pha, idx, flags)
+	DT_PHA_BY_IDX_OR(node_id, gpio_pha, idx, flags, 0)
 
 /**
  * @brief Equivalent to DT_GPIO_FLAGS_BY_IDX(node_id, gpio_pha, 0)
  * @param node_id node identifier
  * @param gpio_pha lowercase-and-underscores GPIO property with
  *        type "phandle-array"
- * @return the flags cell value at index 0
+ * @return the flags cell value at index 0, or zero if there is none
  * @see DT_GPIO_FLAGS_BY_IDX()
  */
 #define DT_GPIO_FLAGS(node_id, gpio_pha) \
@@ -233,7 +235,7 @@ extern "C" {
  * @param gpio_pha lowercase-and-underscores GPIO property with
  *        type "phandle-array"
  * @param idx logical index into "gpio_pha"
- * @return the flags cell value at index "idx"
+ * @return the flags cell value at index "idx", or zero if there is none
  * @see DT_GPIO_FLAGS_BY_IDX()
  */
 #define DT_INST_GPIO_FLAGS_BY_IDX(inst, gpio_pha, idx) \
@@ -244,7 +246,7 @@ extern "C" {
  * @param inst DT_DRV_COMPAT instance number
  * @param gpio_pha lowercase-and-underscores GPIO property with
  *        type "phandle-array"
- * @return the flags cell value at index 0
+ * @return the flags cell value at index 0, or zero if there is none
  * @see DT_INST_GPIO_FLAGS_BY_IDX()
  */
 #define DT_INST_GPIO_FLAGS(inst, gpio_pha) \

--- a/include/devicetree/pwms.h
+++ b/include/devicetree/pwms.h
@@ -291,40 +291,44 @@ extern "C" {
 /**
  * @brief Get a PWM specifier's flags cell value at an index
  *
- * This macro only works for PWM specifiers with cells named "flags".
- * Refer to the node's binding to check if necessary.
+ * This macro expects PWM specifiers with cells named "flags".
+ * If there is no "flags" cell in the PWM specifier, zero is returned.
+ * Refer to the node's binding to check specifier cell names if necessary.
  *
  * This is equivalent to DT_PWMS_CELL_BY_IDX(node_id, idx, flags).
  *
  * @param node_id node identifier for a node with a pwms property
  * @param idx logical index into pwms property
- * @return the flags cell value at index "idx"
+ * @return the flags cell value at index "idx", or zero if there is none
  * @see DT_PWMS_CELL_BY_IDX()
  */
 #define DT_PWMS_FLAGS_BY_IDX(node_id, idx) \
-	DT_PWMS_CELL_BY_IDX(node_id, idx, flags)
+	DT_PHA_BY_IDX_OR(node_id, pwms, idx, flags, 0)
 
 /**
  * @brief Get a PWM specifier's flags cell value by name
  *
- * This macro only works for PWM specifiers with cells named "flags".
- * Refer to the node's binding to check if necessary.
+ * This macro expects PWM specifiers with cells named "flags".
+ * If there is no "flags" cell in the PWM specifier, zero is returned.
+ * Refer to the node's binding to check specifier cell names if necessary.
  *
- * This is equivalent to DT_PWMS_CELL_BY_NAME(node_id, name, flags).
+ * This is equivalent to DT_PWMS_CELL_BY_NAME(node_id, name, flags) if
+ * there is a flags cell, but expands to zero if there is none.
  *
  * @param node_id node identifier for a node with a pwms property
  * @param name lowercase-and-underscores name of a pwms element
  *             as defined by the node's pwm-names property
- * @return the flags cell value in the specifier at the named element
+ * @return the flags cell value in the specifier at the named element,
+ *         or zero if there is none
  * @see DT_PWMS_CELL_BY_NAME()
  */
 #define DT_PWMS_FLAGS_BY_NAME(node_id, name) \
-	DT_PWMS_CELL_BY_NAME(node_id, name, flags)
+	DT_PHA_BY_NAME_OR(node_id, pwms, name, flags, 0)
 
 /**
  * @brief Equivalent to DT_PWMS_FLAGS_BY_IDX(node_id, 0)
  * @param node_id node identifier for a node with a pwms property
- * @return the flags cell value at index 0
+ * @return the flags cell value at index 0, or zero if there is none
  * @see DT_PWMS_FLAGS_BY_IDX()
  */
 #define DT_PWMS_FLAGS(node_id) DT_PWMS_FLAGS_BY_IDX(node_id, 0)
@@ -454,7 +458,7 @@ extern "C" {
  * @brief Equivalent to DT_INST_PWMS_CELL_BY_IDX(inst, idx, flags)
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into pwms property
- * @return the flags cell value at index "idx"
+ * @return the flags cell value at index "idx", or zero if there is none
  * @see DT_INST_PWMS_CELL_BY_IDX()
  */
 #define DT_INST_PWMS_FLAGS_BY_IDX(inst, idx) \
@@ -465,7 +469,8 @@ extern "C" {
  * @param inst DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a pwms element
  *             as defined by the node's pwm-names property
- * @return the flags cell value in the specifier at the named element
+ * @return the flags cell value in the specifier at the named element,
+ *         or zero if there is none
  * @see DT_INST_PWMS_CELL_BY_NAME()
  */
 #define DT_INST_PWMS_FLAGS_BY_NAME(inst, name) \
@@ -474,7 +479,7 @@ extern "C" {
 /**
  * @brief Equivalent to DT_INST_PWMS_FLAGS_BY_IDX(inst, 0)
  * @param inst DT_DRV_COMPAT instance number
- * @return the flags cell value at index 0
+ * @return the flags cell value at index 0, or zero if there is none
  * @see DT_INST_PWMS_FLAGS_BY_IDX()
  */
 #define DT_INST_PWMS_FLAGS(inst) DT_INST_PWMS_FLAGS_BY_IDX(inst, 0)

--- a/include/devicetree/spi.h
+++ b/include/devicetree/spi.h
@@ -190,9 +190,6 @@ extern "C" {
 /**
  * @brief Get a SPI device's chip select GPIO flags
  *
- * It's an error if the GPIO specifier for spi_dev's entry in its
- * bus node's cs-gpios property has no flags cell.
- *
  * Example devicetree fragment:
  *
  *     spi1: spi@... {
@@ -208,8 +205,12 @@ extern "C" {
  *
  *     DT_SPI_DEV_CS_GPIOS_FLAGS(DT_NODELABEL(a)) // GPIO_ACTIVE_LOW
  *
+ * If the GPIO specifier for spi_dev's entry in its bus node's
+ * cs-gpios property has no flags cell, this expands to zero.
+ *
  * @param spi_dev a SPI device node identifier
- * @return flags value of spi_dev's chip select GPIO specifier
+ * @return flags value of spi_dev's chip select GPIO specifier, or
+ *         zero if there is one
  */
 #define DT_SPI_DEV_CS_GPIOS_FLAGS(spi_dev) \
 	DT_GPIO_FLAGS_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR(spi_dev))
@@ -246,7 +247,8 @@ extern "C" {
 /**
  * @brief DT_SPI_DEV_CS_GPIOS_FLAGS(DT_DRV_INST(inst)).
  * @param inst DT_DRV_COMPAT instance number
- * @return flags value of the instance's chip select GPIO specifier
+ * @return flags value of the instance's chip select GPIO specifier,
+ *         or zero if there is none
  * @see DT_SPI_DEV_CS_GPIOS_FLAGS()
  */
 #define DT_INST_SPI_DEV_CS_GPIOS_FLAGS(inst) \

--- a/samples/basic/blinky_pwm/src/main.c
+++ b/samples/basic/blinky_pwm/src/main.c
@@ -16,20 +16,10 @@
 
 #define PWM_LED0_NODE	DT_ALIAS(pwm_led0)
 
-/*
- * Devicetree helper macro which gets the 'flags' cell from the node's
- * pwms property, or returns 0 if the property has no 'flags' cell.
- */
-
-#define FLAGS_OR_ZERO(node)						\
-	COND_CODE_1(DT_PHA_HAS_CELL(node, pwms, flags),		\
-		    (DT_PWMS_FLAGS(node)),				\
-		    (0))
-
 #if DT_NODE_HAS_STATUS(PWM_LED0_NODE, okay)
 #define PWM_LABEL	DT_PWMS_LABEL(PWM_LED0_NODE)
 #define PWM_CHANNEL	DT_PWMS_CHANNEL(PWM_LED0_NODE)
-#define PWM_FLAGS	FLAGS_OR_ZERO(PWM_LED0_NODE)
+#define PWM_FLAGS	DT_PWMS_FLAGS(PWM_LED0_NODE)
 #else
 #error "Unsupported board: pwm-led0 devicetree alias is not defined"
 #define PWM_LABEL	""

--- a/samples/basic/button/src/main.c
+++ b/samples/basic/button/src/main.c
@@ -15,16 +15,6 @@
 #define SLEEP_TIME_MS	1
 
 /*
- * Devicetree helper macro which gets the 'flags' cell from a 'gpios'
- * property, or returns 0 if the property has no 'flags' cell.
- */
-
-#define FLAGS_OR_ZERO(node)						\
-	COND_CODE_1(DT_PHA_HAS_CELL(node, gpios, flags),		\
-		    (DT_GPIO_FLAGS(node, gpios)),			\
-		    (0))
-
-/*
  * Get button configuration from the devicetree sw0 alias.
  *
  * At least a GPIO device and pin number must be provided. The 'flags'
@@ -36,7 +26,7 @@
 #if DT_NODE_HAS_STATUS(SW0_NODE, okay)
 #define SW0_GPIO_LABEL	DT_GPIO_LABEL(SW0_NODE, gpios)
 #define SW0_GPIO_PIN	DT_GPIO_PIN(SW0_NODE, gpios)
-#define SW0_GPIO_FLAGS	(GPIO_INPUT | FLAGS_OR_ZERO(SW0_NODE))
+#define SW0_GPIO_FLAGS	(GPIO_INPUT | DT_GPIO_FLAGS(SW0_NODE, gpios))
 #else
 #error "Unsupported board: sw0 devicetree alias is not defined"
 #define SW0_GPIO_LABEL	""
@@ -107,7 +97,7 @@ void main(void)
 #if DT_NODE_HAS_STATUS(LED0_NODE, okay) && DT_NODE_HAS_PROP(LED0_NODE, gpios)
 #define LED0_GPIO_LABEL	DT_GPIO_LABEL(LED0_NODE, gpios)
 #define LED0_GPIO_PIN	DT_GPIO_PIN(LED0_NODE, gpios)
-#define LED0_GPIO_FLAGS	(GPIO_OUTPUT | FLAGS_OR_ZERO(LED0_NODE))
+#define LED0_GPIO_FLAGS	(GPIO_OUTPUT | DT_GPIO_FLAGS(LED0_NODE, gpios))
 #endif
 
 #ifdef LED0_GPIO_LABEL

--- a/samples/basic/fade_led/src/main.c
+++ b/samples/basic/fade_led/src/main.c
@@ -16,20 +16,10 @@
 
 #define PWM_LED0_NODE	DT_ALIAS(pwm_led0)
 
-/*
- * Devicetree helper macro which gets the 'flags' cell from the node's
- * pwms property, or returns 0 if the property has no 'flags' cell.
- */
-
-#define FLAGS_OR_ZERO(node)						\
-	COND_CODE_1(DT_PHA_HAS_CELL(node, pwms, flags),		\
-		    (DT_PWMS_FLAGS(node)),				\
-		    (0))
-
 #if DT_NODE_HAS_STATUS(PWM_LED0_NODE, okay)
 #define PWM_LABEL	DT_PWMS_LABEL(PWM_LED0_NODE)
 #define PWM_CHANNEL	DT_PWMS_CHANNEL(PWM_LED0_NODE)
-#define PWM_FLAGS	FLAGS_OR_ZERO(PWM_LED0_NODE)
+#define PWM_FLAGS	DT_PWMS_FLAGS(PWM_LED0_NODE)
 #else
 #error "Unsupported board: pwm-led0 devicetree alias is not defined"
 #define PWM_LABEL	""

--- a/samples/basic/rgb_led/src/main.c
+++ b/samples/basic/rgb_led/src/main.c
@@ -14,16 +14,6 @@
 #include <drivers/pwm.h>
 
 /*
- * Devicetree helper macro which gets the 'flags' cell from a 'pwms'
- * property, or returns 0 if the property has no 'flags' cell.
- */
-
-#define FLAGS_OR_ZERO(node)						\
-	COND_CODE_1(DT_PHA_HAS_CELL(node, pwms, flags),			\
-		    (DT_PWMS_FLAGS(node)),				\
-		    (0))
-
-/*
  * Extract devicetree configuration.
  */
 
@@ -34,7 +24,7 @@
 #if DT_NODE_HAS_STATUS(RED_NODE, okay)
 #define RED_LABEL	DT_PWMS_LABEL(RED_NODE)
 #define RED_CHANNEL	DT_PWMS_CHANNEL(RED_NODE)
-#define RED_FLAGS	FLAGS_OR_ZERO(RED_NODE)
+#define RED_FLAGS	DT_PWMS_FLAGS(RED_NODE)
 #else
 #error "Unsupported board: red-pwm-led devicetree alias is not defined"
 #define RED_LABEL	""
@@ -45,7 +35,7 @@
 #if DT_NODE_HAS_STATUS(GREEN_NODE, okay)
 #define GREEN_LABEL	DT_PWMS_LABEL(GREEN_NODE)
 #define GREEN_CHANNEL	DT_PWMS_CHANNEL(GREEN_NODE)
-#define GREEN_FLAGS	FLAGS_OR_ZERO(GREEN_NODE)
+#define GREEN_FLAGS	DT_PWMS_FLAGS(GREEN_NODE)
 #else
 #error "Unsupported board: green-pwm-led devicetree alias is not defined"
 #define GREEN_LABEL	""
@@ -56,7 +46,7 @@
 #if DT_NODE_HAS_STATUS(BLUE_NODE, okay)
 #define BLUE_LABEL	DT_PWMS_LABEL(BLUE_NODE)
 #define BLUE_CHANNEL	DT_PWMS_CHANNEL(BLUE_NODE)
-#define BLUE_FLAGS	FLAGS_OR_ZERO(BLUE_NODE)
+#define BLUE_FLAGS	DT_PWMS_FLAGS(BLUE_NODE)
 #else
 #error "Unsupported board: blue-pwm-led devicetree alias is not defined"
 #define BLUE_LABEL	""

--- a/samples/basic/threads/src/main.c
+++ b/samples/basic/threads/src/main.c
@@ -20,16 +20,6 @@
 #define LED0_NODE DT_ALIAS(led0)
 #define LED1_NODE DT_ALIAS(led1)
 
-/*
- * Devicetree helper macro which gets the 'flags' cell from a 'gpios'
- * property, or returns 0 if the property has no 'flags' cell.
- */
-
-#define FLAGS_OR_ZERO(node)						\
-	COND_CODE_1(DT_PHA_HAS_CELL(node, gpios, flags),		\
-		    (DT_GPIO_FLAGS(node, gpios)),			\
-		    (0))
-
 struct printk_data_t {
 	void *fifo_reserved; /* 1st word reserved for use by fifo */
 	uint32_t led;
@@ -90,7 +80,7 @@ void blink0(void)
 		.gpio_dev_name = DT_GPIO_LABEL(LED0_NODE, gpios),
 		.gpio_pin_name = DT_LABEL(LED0_NODE),
 		.gpio_pin = DT_GPIO_PIN(LED0_NODE, gpios),
-		.gpio_flags = GPIO_OUTPUT | FLAGS_OR_ZERO(LED0_NODE),
+		.gpio_flags = GPIO_OUTPUT | DT_GPIO_FLAGS(LED0_NODE, gpios),
 #else
 #error "Unsupported board: led0 devicetree alias is not defined"
 #endif
@@ -106,7 +96,7 @@ void blink1(void)
 		.gpio_dev_name = DT_GPIO_LABEL(LED1_NODE, gpios),
 		.gpio_pin_name = DT_LABEL(LED1_NODE),
 		.gpio_pin = DT_GPIO_PIN(LED1_NODE, gpios),
-		.gpio_flags = GPIO_OUTPUT | FLAGS_OR_ZERO(LED1_NODE),
+		.gpio_flags = GPIO_OUTPUT | DT_GPIO_FLAGS(LED1_NODE, gpios),
 #else
 #error "Unsupported board: led1 devicetree alias is not defined"
 #endif

--- a/samples/subsys/usb/hid-cdc/src/main.c
+++ b/samples/subsys/usb/hid-cdc/src/main.c
@@ -17,17 +17,12 @@
 #define LOG_LEVEL LOG_LEVEL_DBG
 LOG_MODULE_REGISTER(main);
 
-#define FLAGS_OR_ZERO(node)						\
-	COND_CODE_1(DT_PHA_HAS_CELL(node, gpios, flags),		\
-		    (DT_GPIO_FLAGS(node, gpios)),			\
-		    (0))
-
 #define SW0_NODE DT_ALIAS(sw0)
 
 #if DT_NODE_HAS_STATUS(SW0_NODE, okay)
 #define PORT0		DT_GPIO_LABEL(SW0_NODE, gpios)
 #define PIN0		DT_GPIO_PIN(SW0_NODE, gpios)
-#define PIN0_FLAGS	FLAGS_OR_ZERO(SW0_NODE)
+#define PIN0_FLAGS	DT_GPIO_FLAGS(SW0_NODE, gpios)
 #else
 #error "Unsupported board: sw0 devicetree alias is not defined"
 #define PORT0		""
@@ -40,7 +35,7 @@ LOG_MODULE_REGISTER(main);
 #if DT_NODE_HAS_STATUS(SW1_NODE, okay)
 #define PORT1		DT_GPIO_LABEL(SW1_NODE, gpios)
 #define PIN1		DT_GPIO_PIN(SW1_NODE, gpios)
-#define PIN1_FLAGS	FLAGS_OR_ZERO(SW1_NODE)
+#define PIN1_FLAGS	DT_GPIO_FLAGS(SW1_NODE, gpios)
 #endif
 
 #define SW2_NODE DT_ALIAS(sw2)
@@ -48,7 +43,7 @@ LOG_MODULE_REGISTER(main);
 #if DT_NODE_HAS_STATUS(SW2_NODE, okay)
 #define PORT2		DT_GPIO_LABEL(SW2_NODE, gpios)
 #define PIN2		DT_GPIO_PIN(SW2_NODE, gpios)
-#define PIN2_FLAGS	FLAGS_OR_ZERO(SW2_NODE)
+#define PIN2_FLAGS	DT_GPIO_FLAGS(SW2_NODE, gpios)
 #endif
 
 #define SW3_NODE DT_ALIAS(sw3)
@@ -56,7 +51,7 @@ LOG_MODULE_REGISTER(main);
 #if DT_NODE_HAS_STATUS(SW3_NODE, okay)
 #define PORT3		DT_GPIO_LABEL(SW3_NODE, gpios)
 #define PIN3		DT_GPIO_PIN(SW3_NODE, gpios)
-#define PIN3_FLAGS	FLAGS_OR_ZERO(SW3_NODE)
+#define PIN3_FLAGS	DT_GPIO_FLAGS(SW3_NODE, gpios)
 #endif
 
 /* Event FIFO */

--- a/samples/subsys/usb/hid-mouse/src/main.c
+++ b/samples/subsys/usb/hid-mouse/src/main.c
@@ -14,17 +14,12 @@
 #define LOG_LEVEL LOG_LEVEL_DBG
 LOG_MODULE_REGISTER(main);
 
-#define FLAGS_OR_ZERO(node)						\
-	COND_CODE_1(DT_PHA_HAS_CELL(node, gpios, flags),		\
-		    (DT_GPIO_FLAGS(node, gpios)),			\
-		    (0))
-
 #define SW0_NODE DT_ALIAS(sw0)
 
 #if DT_NODE_HAS_STATUS(SW0_NODE, okay)
 #define PORT0		DT_GPIO_LABEL(SW0_NODE, gpios)
 #define PIN0		DT_GPIO_PIN(SW0_NODE, gpios)
-#define PIN0_FLAGS	FLAGS_OR_ZERO(SW0_NODE)
+#define PIN0_FLAGS	DT_GPIO_FLAGS(SW0_NODE, gpios)
 #else
 #error "Unsupported board: sw0 devicetree alias is not defined"
 #define PORT0		""
@@ -37,7 +32,7 @@ LOG_MODULE_REGISTER(main);
 #if DT_NODE_HAS_STATUS(SW1_NODE, okay)
 #define PORT1		DT_GPIO_LABEL(SW1_NODE, gpios)
 #define PIN1		DT_GPIO_PIN(SW1_NODE, gpios)
-#define PIN1_FLAGS	FLAGS_OR_ZERO(SW1_NODE)
+#define PIN1_FLAGS	DT_GPIO_FLAGS(SW1_NODE, gpios)
 #endif
 
 #define SW2_NODE DT_ALIAS(sw2)
@@ -45,7 +40,7 @@ LOG_MODULE_REGISTER(main);
 #if DT_NODE_HAS_STATUS(SW2_NODE, okay)
 #define PORT2		DT_GPIO_LABEL(SW2_NODE, gpios)
 #define PIN2		DT_GPIO_PIN(SW2_NODE, gpios)
-#define PIN2_FLAGS	FLAGS_OR_ZERO(SW2_NODE)
+#define PIN2_FLAGS	DT_GPIO_FLAGS(SW2_NODE, gpios)
 #endif
 
 #define SW3_NODE DT_ALIAS(sw3)
@@ -53,7 +48,7 @@ LOG_MODULE_REGISTER(main);
 #if DT_NODE_HAS_STATUS(SW3_NODE, okay)
 #define PORT3		DT_GPIO_LABEL(SW3_NODE, gpios)
 #define PIN3		DT_GPIO_PIN(SW3_NODE, gpios)
-#define PIN3_FLAGS	FLAGS_OR_ZERO(SW3_NODE)
+#define PIN3_FLAGS	DT_GPIO_FLAGS(SW3_NODE, gpios)
 #endif
 
 #define LED0_NODE DT_ALIAS(led0)

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -19,6 +19,25 @@
 #define TEST_IRQ	DT_NODELABEL(test_irq)
 #define TEST_TEMP	DT_NODELABEL(test_temp_sensor)
 
+#define TEST_I2C_DEV DT_PATH(test, i2c_11112222, test_i2c_dev_10)
+#define TEST_I2C_BUS DT_BUS(TEST_I2C_DEV)
+
+#define TEST_SPI DT_NODELABEL(test_spi)
+
+#define TEST_SPI_DEV_0 DT_PATH(test, spi_33334444, test_spi_dev_0)
+#define TEST_SPI_BUS_0 DT_BUS(TEST_SPI_DEV_0)
+
+#define TEST_SPI_DEV_1 DT_PATH(test, spi_33334444, test_spi_dev_1)
+#define TEST_SPI_BUS_1 DT_BUS(TEST_SPI_DEV_1)
+
+#define TEST_SPI_NO_CS DT_NODELABEL(test_spi_no_cs)
+#define TEST_SPI_DEV_NO_CS DT_NODELABEL(test_spi_no_cs)
+
+#define TA_HAS_COMPAT(compat) DT_NODE_HAS_COMPAT(TEST_ARRAYS, compat)
+
+#define TO_STRING(x) TO_STRING_(x)
+#define TO_STRING_(x) #x
+
 static void test_path_props(void)
 {
 	zassert_true(!strcmp(DT_LABEL(TEST_DEADBEEF), "TEST_GPIO_1"),
@@ -182,8 +201,6 @@ static void test_has_nodelabel(void)
 		      "TEST_NODELABEL_ALLCAPS");
 }
 
-#define TA_HAS_COMPAT(compat) DT_NODE_HAS_COMPAT(TEST_ARRAYS, compat)
-
 static void test_has_compat(void)
 {
 	unsigned int compats;
@@ -221,20 +238,6 @@ static void test_has_status(void)
 	zassert_equal(DT_NODE_HAS_STATUS(DT_NODELABEL(disabled_gpio), okay),
 		      0, "vnd,disabled-compat not okay");
 }
-
-#define TEST_I2C_DEV DT_PATH(test, i2c_11112222, test_i2c_dev_10)
-#define TEST_I2C_BUS DT_BUS(TEST_I2C_DEV)
-
-#define TEST_SPI DT_NODELABEL(test_spi)
-
-#define TEST_SPI_DEV_0 DT_PATH(test, spi_33334444, test_spi_dev_0)
-#define TEST_SPI_BUS_0 DT_BUS(TEST_SPI_DEV_0)
-
-#define TEST_SPI_DEV_1 DT_PATH(test, spi_33334444, test_spi_dev_1)
-#define TEST_SPI_BUS_1 DT_BUS(TEST_SPI_DEV_1)
-
-#define TEST_SPI_NO_CS DT_NODELABEL(test_spi_no_cs)
-#define TEST_SPI_DEV_NO_CS DT_NODELABEL(test_spi_no_cs)
 
 static void test_bus(void)
 {
@@ -1118,9 +1121,6 @@ static void test_pwms(void)
 	zassert_equal(DT_INST_PWMS_FLAGS(0), 3, "pwm channel");
 }
 
-#define TO_STRING(x) TO_STRING_(x)
-#define TO_STRING_(x) #x
-
 static void test_macro_names(void)
 {
 	/* white box */
@@ -1142,6 +1142,9 @@ static void test_macro_names(void)
 
 	zassert_true(!strcmp(TO_STRING(CHILD_NODE_ID), TO_STRING(FULL_PATH_ID)),
 		     "child");
+
+#undef CHILD_NODE_ID
+#undef FULL_PATH_ID
 }
 
 static int a[] = DT_PROP(TEST_ARRAYS, a);


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/25827 

Add generic accessors for devicetree property values which accept defaults, and then use them to make all DT_FOO_FLAGS() APIs just return 0 if there are no flags set in the DT.

CC @NZSmartie 