### PR TITLE
gcov: Add coverage support for arc nsim platforms

### DIFF
--- a/boards/arc/nsim/Kconfig.board
+++ b/boards/arc/nsim/Kconfig.board
@@ -6,6 +6,7 @@
 config BOARD_NSIM
 	bool "ARC nSIM simulator"
 	depends on SOC_NSIM
+	select HAS_COVERAGE_SUPPORT
 	help
 	  The DesignWare ARC nSIM board is a virtual board based on
 	  the ARC nSIM simulator. It demonstrates the ARC core features

--- a/boards/arc/nsim/arc_mpu_regions.c
+++ b/boards/arc/nsim/arc_mpu_regions.c
@@ -14,6 +14,15 @@
  * All regions not listed here are shared by secure world and normal world.
  */
 static struct arc_mpu_region mpu_regions[] = {
+
+#if defined(CONFIG_COVERAGE_GCOV) && defined(CONFIG_USERSPACE)
+	/* Region Coverage */
+	MPU_REGION_ENTRY("COVERAGE",
+			 (uint32_t)&(__gcov_bss_start),
+			 (uint32_t)&__gcov_bss_size,
+			 REGION_IO_ATTR),
+#endif /* CONFIG_COVERAGE_GCOV && CONFIG_USERSPACE */
+
 #if DT_REG_SIZE(DT_INST(0, arc_iccm)) > 0
 	/* Region ICCM */
 	MPU_REGION_ENTRY("ICCM",

--- a/boards/arc/nsim/nsim.dtsi
+++ b/boards/arc/nsim/nsim.dtsi
@@ -14,7 +14,7 @@
 #endif
 
 #ifndef ICCM_SIZE
-#define ICCM_SIZE DT_SIZE_K(512)
+#define ICCM_SIZE DT_SIZE_K(1024)
 #endif
 
 #ifndef DCCM_ADDR
@@ -22,7 +22,7 @@
 #endif
 
 #ifndef DCCM_SIZE
-#define DCCM_SIZE DT_SIZE_K(512)
+#define DCCM_SIZE DT_SIZE_K(1024)
 #endif
 
 / {

--- a/boards/arc/nsim/support/mdb_em.args
+++ b/boards/arc/nsim/support/mdb_em.args
@@ -48,10 +48,10 @@
 	-dcache_feature=2
 	-icache=16384,32,2,a
 	-icache_feature=2
-	-dccm_size=0x80000
+	-dccm_size=0x100000
 	-dccm_base=0x80000000
 	-dccm_interleave
-	-iccm0_size=0x80000
+	-iccm0_size=0x100000
 	-iccm0_base=0x00000000
 	-Xpct_counters=8
 	-dmac

--- a/boards/arc/nsim/support/nsim_em.props
+++ b/boards/arc/nsim/support/nsim_em.props
@@ -55,10 +55,10 @@
 	nsim_isa_dc_feature_level=2
 	icache=16384,32,2,a
 	nsim_isa_ic_feature_level=2
-	dccm_size=0x80000
+	dccm_size=0x100000
 	dccm_base=0x80000000
 	nsim_isa_dccm_interleave=1
-	iccm0_size=0x80000
+	iccm0_size=0x100000
 	iccm0_base=0x00000000
 	nsim_isa_pct_counters=8
 	nsim_isa_dmac_option=1

--- a/subsys/testsuite/coverage/coverage_ram.ld
+++ b/subsys/testsuite/coverage/coverage_ram.ld
@@ -64,10 +64,13 @@ __gcov_bss_size = __gcov_bss_end - __gcov_bss_start;
 SECTION_PROLOGUE(_GCOV_BSS_SECTION_NAME, (NOLOAD),)
 {
 	MPU_MIN_SIZE_ALIGN
-	. = ALIGN(4);
 	__gcov_bss_start = .;
 	*(".bss.__gcov0.*");
+#ifdef CONFIG_USERSPACE
+	. = ALIGN(1 << LOG2CEIL(. - __gcov_bss_start));
+#else
 	MPU_MIN_SIZE_ALIGN
+#endif
 	__gcov_bss_end = .;
 }GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 


### PR DESCRIPTION
1. When enable coverage, BinaryHandler time will increases, and we can't estimate this time, so I refer to QEMUHandler.
2. When proc finished output log, the `proc.stdout.readline()` will hang up forever, so I create another thread to run `proc.stdout.readline()` and set a timeout to stop it. 