### PR TITLE
docs: gsg: add missing python3-psutil dependency

### DIFF
--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -87,8 +87,8 @@ need one.
 
          sudo dnf group install "Development Tools" "C Development Tools and Libraries"
          dnf install git cmake ninja-build gperf ccache dfu-util dtc wget \
-           python3-pip python3-tkinter xz file glibc-devel.i686 libstdc++-devel.i686 \
-           SDL2-devel
+           python3-psutil python3-pip python3-tkinter xz file \
+           glibc-devel.i686 libstdc++-devel.i686 SDL2-devel
 
    .. group-tab:: Clear Linux
 


### PR DESCRIPTION
Fedora Linux distro might not have a python3-psutil package
installed by default. Lack of package causes error for
running qemu using sanitycheck which is needed for some
tests.

Fixes #27081

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>