### PR TITLE
sanitycheck: do not expect results from build_only instances

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -3195,6 +3195,7 @@ class TestSuite(DisablePyTestCollectionMixin):
         with open(filename, 'wb') as report:
             report.write(result)
 
+        return fails, passes, errors, skips
 
     def csv_report(self, filename):
         with open(filename, "wt") as csvfile:

--- a/scripts/tests/sanitycheck/test_reporting_testsuite.py
+++ b/scripts/tests/sanitycheck/test_reporting_testsuite.py
@@ -99,23 +99,11 @@ def test_xunit_report(class_testsuite, test_data,
     inst2.status = "skipped"
 
     filename = test_data + "sanitycheck.xml"
-    class_testsuite.xunit_report(filename)
+    fails, passes, errors, skips = class_testsuite.xunit_report(filename)
     assert os.path.exists(filename)
 
     filesize = os.path.getsize(filename)
     assert filesize != 0
-
-    fails, passes, errors, skips = 0, 0, 0, 0
-    for instance in class_testsuite.instances.values():
-        if instance.status in ["failed", "timeout"]:
-            if instance.reason in ['build_error', 'handler_crash']:
-                errors += 1
-            else:
-                fails += 1
-        elif instance.status == 'skipped':
-            skips += 1
-        else:
-            passes += 1
 
     tree = ET.parse(filename)
     assert int(tree.findall('testsuite')[0].attrib["skip"]) == int(skips)


### PR DESCRIPTION
instances that do not run will have no results (beside the fact they
built successfully), so log those as such.