### PR TITLE
dts: remove incorrect use of mmio-sram compatible

### DIFF
--- a/boards/arc/qemu_arc/qemu_arc.dtsi
+++ b/boards/arc/qemu_arc/qemu_arc.dtsi
@@ -24,6 +24,7 @@
 		#interrupt-cells = <2>;
 	};
 
+	/* We are carving out of DRAM for a pseudo flash and sram region */
 	flash0: flash@80000000 {
 		compatible = "soc-nv-flash";
 		reg = <0x80000000 DT_FLASH_SIZE>;
@@ -31,7 +32,6 @@
 
 	sram0: sram@80400000 {
 		device_type = "memory";
-		compatible = "mmio-sram";
 		reg = <0x80400000 DT_SRAM_SIZE>;
 	};
 

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -25,7 +25,6 @@
 	sdram0: memory@80000000 {
 		/* ISSI IS42S16160J-6TLI */
 		device_type = "memory";
-		compatible = "mmio-sram";
 		reg = <0x80000000 0x2000000>;
 	};
 

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -26,7 +26,6 @@
 	sdram0: memory@80000000 {
 		/* Micron MT48LC16M16A2B4-6AIT:G */
 		device_type = "memory";
-		compatible = "mmio-sram";
 		reg = <0x80000000 0x2000000>;
 	};
 

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -26,7 +26,6 @@
 	sdram0: memory@80000000 {
 		/* Micron MT48LC16M16A2B4-6AIT:G */
 		device_type = "memory";
-		compatible = "mmio-sram";
 		reg = <0x80000000 0x2000000>;
 	};
 

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -27,7 +27,6 @@
 	sdram0: memory@80000000 {
 		/* Micron MT48LC16M16A2B4-6AIT:G */
 		device_type = "memory";
-		compatible = "mmio-sram";
 		reg = <0x80000000 0x2000000>;
 	};
 

--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -26,7 +26,6 @@
 	sdram0: memory@80000000 {
 		/* Micron MT48LC16M16A2B4-6AIT:G */
 		device_type = "memory";
-		compatible = "mmio-sram";
 		reg = <0x80000000 0x2000000>;
 	};
 

--- a/boards/riscv/litex_vexriscv/litex_vexriscv.dts
+++ b/boards/riscv/litex_vexriscv/litex_vexriscv.dts
@@ -19,7 +19,6 @@
 
 	ram0: memory@40000000 {
 		device_type = "memory";
-		compatible = "mmio-sram";
 		reg = <0x40000000 0x10000000>;
 	};
 };

--- a/dts/arc/arc_hsdk.dtsi
+++ b/dts/arc/arc_hsdk.dtsi
@@ -63,7 +63,6 @@
 
 		ddr0: memory@90000000 {
 			device_type = "memory";
-			compatible = "mmio-sram";
 			reg = <0x90000000 0x50000000>;
 		};
 

--- a/dts/arc/emsk.dtsi
+++ b/dts/arc/emsk.dtsi
@@ -42,7 +42,6 @@
 
 		ddr0: memory@10000000 {
 			device_type = "memory";
-			compatible = "mmio-sram";
 			reg = <0x10000000 0x8000000>;
 		};
 

--- a/dts/arm/broadcom/valkyrie.dtsi
+++ b/dts/arm/broadcom/valkyrie.dtsi
@@ -29,7 +29,6 @@
 	soc {
 		sram0: memory@400000 {
 			device_type = "memory";
-			compatible = "mmio-sram";
 			reg = <0x00400000 0x30000>;
 		};
 

--- a/dts/arm/broadcom/viper-common.dtsi
+++ b/dts/arm/broadcom/viper-common.dtsi
@@ -8,7 +8,6 @@
 	soc {
 		sram0: memory@400000 {
 			device_type = "memory";
-			compatible = "mmio-sram";
 			reg = <0x00400000 0x80000>;
 		};
 


### PR DESCRIPTION
For memory that is truly device_type = "memory" we should not have a
mmio-sram compatible.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>