### PR TITLE
dts: arc: emsdp: Cleanup PSRAM use of device_type = "memory"

### DIFF
--- a/dts/arc/emsdp.dtsi
+++ b/dts/arc/emsdp.dtsi
@@ -39,8 +39,8 @@
 		reg = <0x80000000 0x20000>;
 	};
 
+	/* this is (Psuedo SRAM), so treat it like mmio-sram */
 	sram0: memory@10000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x10000000 0x1000000>;
 	};


### PR DESCRIPTION
Remove the device_type = "memory" property from the PSRAM node.  We make
the slightly arbitrary distinction of using 'mmio-sram' compatible for
memories that don't need some kinda of dram style configuration or may
be on die.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>