### PR TITLE
usb: allow application to set callback after devices enable USB

### DIFF
--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -231,6 +231,12 @@ int usb_deconfig(void);
  * before invoking this, so that any data or events on the bus are processed
  * correctly by the associated class handling code.
  *
+ * @note This function may be invoked multiple times.  Only the first invocation
+ * will cause the USB core subsystem to be enabled.  Subsequent invocations may
+ * add a callback if one had not already been assigned.  If a callback is added
+ * after the initial call it will be invoked only for new status changes: the
+ * status at the point the callback was installed is not provided.
+ *
  * @param[in] status_cb Callback registered by user to notify
  *                      about USB device controller state.
  *


### PR DESCRIPTION
I'm just going to toss this one out there: it's not a complete fix, but it meets the core need.

Some devices enable the USB infrastructure without a callback before the application is given a chance to provide a callback.  Allow usb_enable() to be invoked multiple times with only the first enabling USB, but subsequent ones allowed to specify a status callback if none has been installed.

Fixes #27071