### PR TITLE
arm and x86: add include guard for offset files

### DIFF
--- a/arch/arm/core/offsets/offsets_aarch32.c
+++ b/arch/arm/core/offsets/offsets_aarch32.c
@@ -22,6 +22,9 @@
  * completeness.
  */
 
+#ifndef _ARM_OFFSETS_INC_
+#define _ARM_OFFSETS_INC_
+
 #include <kernel.h>
 #include <kernel_arch_data.h>
 #include <kernel_offsets.h>
@@ -88,3 +91,5 @@ GEN_ABSOLUTE_SYM(_K_THREAD_NO_FLOAT_SIZEOF, sizeof(struct k_thread) -
 #else
 GEN_ABSOLUTE_SYM(_K_THREAD_NO_FLOAT_SIZEOF, sizeof(struct k_thread));
 #endif
+
+#endif /* _ARM_OFFSETS_INC_ */

--- a/arch/arm/core/offsets/offsets_aarch64.c
+++ b/arch/arm/core/offsets/offsets_aarch64.c
@@ -22,8 +22,13 @@
  * completeness.
  */
 
+#ifndef _ARM_OFFSETS_INC_
+#define _ARM_OFFSETS_INC_
+
 #include <kernel.h>
 #include <kernel_arch_data.h>
 #include <kernel_offsets.h>
 
 GEN_OFFSET_SYM(_thread_arch_t, swap_return_value);
+
+#endif /* _ARM_OFFSETS_INC_ */

--- a/arch/x86/core/offsets/ia32_offsets.c
+++ b/arch/x86/core/offsets/ia32_offsets.c
@@ -24,6 +24,9 @@
 
 /* list of headers that define whose structure offsets will be generated */
 
+#ifndef _X86_OFFSETS_INC_
+#define _X86_OFFSETS_INC_
+
 #include <arch/x86/mmustructs.h>
 
 #if defined(CONFIG_LAZY_FPU_SHARING)
@@ -66,3 +69,5 @@ GEN_OFFSET_SYM(z_arch_esf_t, eflags);
 /* size of the MMU_REGION structure. Used by linker scripts */
 
 GEN_ABSOLUTE_SYM(__MMU_REGION_SIZEOF, sizeof(struct mmu_region));
+
+#endif /* _X86_OFFSETS_INC_ */

--- a/arch/x86/core/offsets/intel64_offsets.c
+++ b/arch/x86/core/offsets/intel64_offsets.c
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef _X86_OFFSETS_INC_
+#define _X86_OFFSETS_INC_
+
 GEN_OFFSET_SYM(_callee_saved_t, rsp);
 GEN_OFFSET_SYM(_callee_saved_t, rbp);
 GEN_OFFSET_SYM(_callee_saved_t, rbx);
@@ -50,3 +53,5 @@ GEN_OFFSET_SYM(x86_cpuboot_t, arg);
 GEN_OFFSET_SYM(x86_cpuboot_t, ptables);
 #endif /* CONFIG_X86_MMU */
 GEN_ABSOLUTE_SYM(__X86_CPUBOOT_SIZEOF, sizeof(x86_cpuboot_t));
+
+#endif /* _X86_OFFSETS_INC_ */


### PR DESCRIPTION
MISRA-C directive 4.10 requires that files being included must prevent itself from being included more than once. So add include guards to the offset files, even though they are C source files.
