### PR TITLE
kernel: Remove supported size comments from HEAP_MEM_POOL_SIZE

### DIFF
--- a/doc/reference/kernel/memory/heap.rst
+++ b/doc/reference/kernel/memory/heap.rst
@@ -124,7 +124,9 @@ The size of the heap memory pool is specified using the
 :option:`CONFIG_HEAP_MEM_POOL_SIZE` configuration option.
 
 By default, the heap memory pool size is zero bytes. This value instructs
-the kernel not to define the heap memory pool object.
+the kernel not to define the heap memory pool object. The maximum size is limited
+by the amount of available memory in the system. The project build will fail in
+the link stage if the size specified can not be supported.
 
 Allocating Memory
 =================

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -473,9 +473,9 @@ config HEAP_MEM_POOL_SIZE
 	default 1024 if POSIX_MQUEUE
 	help
 	  This option specifies the size of the heap memory pool used when
-	  dynamically allocating memory using k_malloc(). Supported values
-	  are: 256, 1024, 4096, and 16384. A size of zero means that no
-	  heap memory pool is defined.
+	  dynamically allocating memory using k_malloc(). The maximum size of
+	  the memory pool is only limited to available memory. A size of zero
+	  means that no heap memory pool is defined.
 
 config HEAP_MEM_POOL_MIN_SIZE
 	int "The smallest blocks in the heap memory pool (in bytes)"


### PR DESCRIPTION
The mempool implementation doesn't require specific sizes and can support
arbitrary sizes up to the limit of available memory. The Kconfig documentation
on this configuration was confusing users.

Fixes #20418

Signed-off-by: David Leach <david.leach@nxp.com>