### PR TITLE
ci: Add a debug out of what tests we are going to build

### DIFF
--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -269,6 +269,8 @@ if [ -n "$main_ci" ]; then
 	tail -n +2 test_file_1.txt > test_file_1_in.txt
 	cat test_file_3.txt test_file_2_in.txt test_file_1_in.txt > test_file.txt
 
+	cat test_file.txt
+
 	echo "+++ run sanitycheck"
 
 	# Run a subset of tests based on matrix size


### PR DESCRIPTION
Add a cat of the test_file.txt so we can see exactly what tests are
expected to be built and run.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>