### PR TITLE
drivers: serial: nrfx: disable before setting pin config

### DIFF
--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -969,6 +969,8 @@ static int uart_nrfx_init(struct device *dev)
 {
 	int err;
 
+	nrf_uart_disable(uart0_addr);
+
 	/* Setting default height state of the TX PIN to avoid glitches
 	 * on the line during peripheral activation/deactivation.
 	 */

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1268,6 +1268,7 @@ static int uarte_instance_init(struct device *dev,
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 	struct uarte_nrfx_data *data = get_dev_data(dev);
 
+	nrf_uarte_disable(uarte);
 
 	nrf_gpio_pin_write(config->pseltxd, 1);
 	nrf_gpio_cfg_output(config->pseltxd);


### PR DESCRIPTION
Per the nrf9160 datasheet, UARTE must be disabled prior to configuring
PSEL.TXD, PSEL.RXD, PSEL.CTS, and/or PSEL.RTS.  This also ensures that
any prior running code, such as a bootloader, which leaves the UART
enabled will not prevent the Zephyr application from changing the
configuration.

Fixes #27080

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>