### PR TITLE
tests: drivers: gpio: gpio_basic_api: add some STM32 boards overlay

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f091rc.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f091rc.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2020 STMicroelectronics.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test,gpio_basic_api";
+		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
+		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
+	};
+};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f429zi.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_f429zi.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2020 STMicroelectronics.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test,gpio_basic_api";
+		out-gpios = <&arduino_header 6 0>; /* Arduino D0 */
+		in-gpios = <&arduino_header 7 0>;  /* Arduino D1 */
+	};
+};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_g474re.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_g474re.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2020 STMicroelectronics.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test,gpio_basic_api";
+		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
+		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
+	};
+};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_l073rz.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_l073rz.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2020 STMicroelectronics.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test,gpio_basic_api";
+		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
+		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
+	};
+};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_l152re.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_l152re.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2020 STMicroelectronics.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test,gpio_basic_api";
+		out-gpios = <&arduino_header 4 0>; /* Arduino A4 */
+		in-gpios = <&arduino_header 5 0>;  /* Arduino A5 */
+	};
+};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_l4r5zi.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_l4r5zi.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2020 STMicroelectronics.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test,gpio_basic_api";
+		out-gpios = <&arduino_header 6 0>; /* Arduino D0 */
+		in-gpios = <&arduino_header 7 0>;  /* Arduino D1 */
+	};
+};

--- a/tests/drivers/gpio/gpio_basic_api/boards/stm32f3_disco.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/stm32f3_disco.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2020 STMicroelectronics.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test,gpio_basic_api";
+		out-gpios = <&gpioc 6 0>;
+		in-gpios = <&gpioc 7 0>;
+	};
+};


### PR DESCRIPTION
tests: drivers: gpio: gpio_basic_api: add some STM32 boards overlay

Add overlay for boards:
* nucleo_f429zi
* nucleo_g474re
* nucleo_l152re
* nucleo_l4r5zi
* stm32f3_disco
* nucleo_f091rc
* nucleo_l073rz

Signed-off-by: Alexandre Bourdiol <alexandre.bourdiol@st.com>