### PR TITLE
tests: adding test cases for counter RTC on nucleo_l152 board

### DIFF
--- a/boards/arm/nucleo_l152re/doc/index.rst
+++ b/boards/arm/nucleo_l152re/doc/index.rst
@@ -88,6 +88,8 @@ The Zephyr nucleo_l152re board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | WATCHDOG  | on-chip    | independent watchdog                |
 +-----------+------------+-------------------------------------+
+| COUNTER   | on-chip    | rtc                                 |
++-----------+------------+-------------------------------------+
 | ADC       | on-chip    | ADC Controller                      |
 +-----------+------------+-------------------------------------+
 | DAC       | on-chip    | DAC Controller                      |

--- a/boards/arm/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.dts
@@ -59,6 +59,10 @@
 	status = "okay";
 };
 
+&rtc {
+	status = "okay";
+};
+
 &adc1 {
 	status = "okay";
 };

--- a/boards/arm/nucleo_l152re/nucleo_l152re.yaml
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.yaml
@@ -15,5 +15,6 @@ supported:
   - i2c
   - uart
   - watchdog
+  - counter
   - adc
   - dac

--- a/drivers/counter/Kconfig.stm32_rtc
+++ b/drivers/counter/Kconfig.stm32_rtc
@@ -13,7 +13,7 @@ menuconfig COUNTER_RTC_STM32
 	select REQUIRES_FULL_LIBC
 	help
 	  Build RTC driver for STM32 SoCs.
-	  Tested on STM32 F0, F2, F3, F4, L4, F7, G4, H7 series
+	  Tested on STM32 F0, F2, F3, F4, L1, L4, F7, G4, H7 series
 
 choice COUNTER_RTC_STM32_CLOCK_SRC
 	bool "RTC clock source"


### PR DESCRIPTION
This patch enables the RTC as counter feature so that the testcase tests/drivers/counter/counter_basic_api
can run on this nucleo_l152re board from STMicroelectronics

$ west build -p auto -b nucleo_l152re tests/drivers/counter/counter_basic_api/

Signed-off-by: Francois Ramu francois.ramu@st.com