### PR TITLE
mgmt: smp: shell: remove useless data->end member

### DIFF
--- a/include/mgmt/mcumgr/smp_shell.h
+++ b/include/mgmt/mcumgr/smp_shell.h
@@ -23,7 +23,6 @@ struct smp_shell_data {
 	bool cmd_rdy;
 	atomic_t esc_state;
 	uint32_t cur;
-	uint32_t end;
 };
 
 /**

--- a/subsys/mgmt/mcumgr/smp_shell.c
+++ b/subsys/mgmt/mcumgr/smp_shell.c
@@ -96,18 +96,17 @@ bool smp_shell_rx_byte(struct smp_shell_data *data, uint8_t byte)
 	 * The received byte is part of an mcumgr command.  Process the byte
 	 * and return true to indicate that shell should ignore it.
 	 */
-	if (data->cur + data->end < sizeof(data->mcumgr_buff) - 1) {
+	if (data->cur < sizeof(data->mcumgr_buff) - 1) {
 		data->mcumgr_buff[data->cur++] = byte;
 	}
 	if (mcumgr_state == SMP_SHELL_MCUMGR_STATE_PAYLOAD && byte == '\n') {
-		data->mcumgr_buff[data->cur + data->end] = '\0';
+		data->mcumgr_buff[data->cur] = '\0';
 		data->cmd_rdy = true;
 		atomic_clear_bit(&data->esc_state, ESC_MCUMGR_PKT_1);
 		atomic_clear_bit(&data->esc_state, ESC_MCUMGR_PKT_2);
 		atomic_clear_bit(&data->esc_state, ESC_MCUMGR_FRAG_1);
 		atomic_clear_bit(&data->esc_state, ESC_MCUMGR_FRAG_2);
 		data->cur = 0U;
-		data->end = 0U;
 	}
 
 	return true;


### PR DESCRIPTION
Value of this member was never assigned, so it was always 0. Remove it
to simplify code a little bit.

Split from #27023 to merge faster, as requested by @de-nordic.