### PR TITLE
[DNM] west.yml: Snapshot update of mcumgr from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -92,7 +92,7 @@ manifest:
       revision: d52aff5065ab5995f785877a834112461ff93526
       path: bootloader/mcuboot
     - name: mcumgr
-      revision: 898a5a7f5224be8345e58eca3b9a84389ed61d15
+      revision: pull/26/head
       path: modules/lib/mcumgr
     - name: net-tools
       revision: 1c4fdba512b268033a4cf926bddd323866c3261a


### PR DESCRIPTION
This commit updates mcumgr with latest snapshot from the upstream.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

Snapshot reviewed here: https://github.com/zephyrproject-rtos/mcumgr/pull/26

**Update**: For the regression tests to pass, changes to fs API are required, that have been reviewed here: https://github.com/zephyrproject-rtos/zephyr/pull/26305, so the snapshot update this commit has been applied on top of the fs API review and will be merged with it.