### PR TITLE
kernel: Compile out thread-related functionality when disabled

### DIFF
--- a/doc/reference/kernel/memory/heap.rst
+++ b/doc/reference/kernel/memory/heap.rst
@@ -9,6 +9,13 @@ dynamically allocate memory.
 Synchronized Heap Allocator
 ***************************
 
+Enabling the allocator
+======================
+
+The synchronized heap allocator can be enabled and disabled using the
+:option:`CONFIG_KERNEL_HEAP` Kconfig option. When enabled, all heaps defined
+with the :c:macro:`K_HEAP_DEFINE` are initalized automatically at boot time.
+
 Creating a Heap
 ===============
 

--- a/doc/reference/kernel/memory/pools.rst
+++ b/doc/reference/kernel/memory/pools.rst
@@ -116,6 +116,14 @@ needed.
 Implementation
 **************
 
+Enabling the functionality
+==========================
+
+Kernel memory pools can be enabled and disabled using the
+:option:`CONFIG_KERNEL_MEM_POOL` Kconfig option. When enabled, all memory
+pools defined with the :c:macro:`K_MEM_POOL_DEFINE` are initalized
+automatically at boot time.
+
 Defining a Memory Pool
 ======================
 

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -8,7 +8,6 @@ add_library(kernel
   fatal.c
   idle.c
   init.c
-  kheap.c
   mailbox.c
   mem_slab.c
   mempool.c
@@ -39,6 +38,7 @@ set_target_properties(
 target_sources_ifdef(CONFIG_STACK_CANARIES        kernel PRIVATE compiler_stack_protect.c)
 target_sources_ifdef(CONFIG_SYS_CLOCK_EXISTS      kernel PRIVATE timeout.c timer.c)
 target_sources_ifdef(CONFIG_ATOMIC_OPERATIONS_C   kernel PRIVATE atomic_c.c)
+target_sources_ifdef(CONFIG_KERNEL_HEAP           kernel PRIVATE kheap.c)
 target_sources_if_kconfig(                        kernel PRIVATE mmu.c)
 target_sources_if_kconfig(                        kernel PRIVATE poll.c)
 

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -43,7 +43,7 @@ target_sources_if_kconfig(                        kernel PRIVATE mmu.c)
 target_sources_if_kconfig(                        kernel PRIVATE poll.c)
 
 if(${CONFIG_MEM_POOL_HEAP_BACKEND})
-else()
+elseif(${CONFIG_KERNEL_MEM_POOL})
   target_sources(kernel PRIVATE mempool_sys.c)
 endif()
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -466,10 +466,19 @@ config KERNEL_HEAP
 	  including the ability to use K_HEAP_DEFINE and all of the
 	  k_heap_*() functions.
 
+config KERNEL_MEM_POOL
+	bool "Enable the kernel's memory pools"
+	default y
+	depends on MULTITHREADING
+	help
+	  This option enables the kernel's implementation of memory pools,
+	  including the ability to use K_MEM_POOL_DEFINE and all of the
+	  k_mem_pool_*() functions.
+
 config MEM_POOL_HEAP_BACKEND
 	bool "Use k_heap as the backend for k_mem_pool"
 	default y
-	depends on KERNEL_HEAP
+	depends on KERNEL_HEAP && KERNEL_MEM_POOL
 	help
 	  This selects a backend implementation for k_mem_pool based
 	  on the sys_heap abstraction instead of the legacy

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -457,9 +457,19 @@ config NUM_PIPE_ASYNC_MSGS
 	  Setting this option to 0 disables support for asynchronous
 	  pipe messages.
 
+config KERNEL_HEAP
+	bool "Enable the kernel's heap"
+	default y
+	depends on MULTITHREADING
+	help
+	  This option enables the kernel's implementation of a heap,
+	  including the ability to use K_HEAP_DEFINE and all of the
+	  k_heap_*() functions.
+
 config MEM_POOL_HEAP_BACKEND
 	bool "Use k_heap as the backend for k_mem_pool"
 	default y
+	depends on KERNEL_HEAP
 	help
 	  This selects a backend implementation for k_mem_pool based
 	  on the sys_heap abstraction instead of the legacy

--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -45,6 +45,7 @@ __weak void k_sys_fatal_error_handler(unsigned int reason,
 }
 /* LCOV_EXCL_STOP */
 
+#if defined(CONFIG_MULTITHREADING)
 static const char *thread_name_get(struct k_thread *thread)
 {
 	const char *thread_name = k_thread_name_get(thread);
@@ -55,6 +56,7 @@ static const char *thread_name_get(struct k_thread *thread)
 
 	return thread_name;
 }
+#endif
 
 static const char *reason_to_str(unsigned int reason)
 {
@@ -97,7 +99,9 @@ void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 	 * appropriate.
 	 */
 	unsigned int key = arch_irq_lock();
+#if defined(CONFIG_MULTITHREADING)
 	struct k_thread *thread = k_current_get();
+#endif
 
 	/* sanitycheck looks for the "ZEPHYR FATAL ERROR" string, don't
 	 * change it without also updating sanitycheck
@@ -117,8 +121,10 @@ void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 	}
 #endif
 
+#if defined(CONFIG_MULTITHREADING)
 	LOG_ERR("Current thread: %p (%s)", thread,
 		log_strdup(thread_name_get(thread)));
+#endif
 
 	k_sys_fatal_error_handler(reason, esf);
 
@@ -176,5 +182,7 @@ void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 	}
 
 	arch_irq_unlock(key);
+#if defined(CONFIG_MULTITHREADING)
 	k_thread_abort(thread);
+#endif
 }


### PR DESCRIPTION
When CONFIG_MULTITHREADING is disabled it is not possible to use the
kernel heap nor it is possible to get the name of the current thread.
Conditionally compile out the code in this case.

This saves 1KB of flash (3.5KB -> 2.5KB) in samples/basic/minimal when
compiled with:

west build -b reel_board -t rom_report samples/basic/minimal/ --
-DCONF_FILE="common.conf no-mt.conf no-timers.conf arm.conf"

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>