### PR TITLE
tests: adding test cases for counter RTC on nucleo_g071 or g4xx boards

### DIFF
--- a/boards/arm/nucleo_g071rb/doc/index.rst
+++ b/boards/arm/nucleo_g071rb/doc/index.rst
@@ -100,6 +100,8 @@ The Zephyr nucleo_g071rb board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | CLOCK     | on-chip    | reset and clock control             |
 +-----------+------------+-------------------------------------+
+| COUNTER   | on-chip    | rtc                                 |
++-----------+------------+-------------------------------------+
 | WATCHDOG  | on-chip    | independent watchdog                |
 +-----------+------------+-------------------------------------+
 | PWM       | on-chip    | pwm                                 |

--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
@@ -49,6 +49,10 @@
 	status = "okay";
 };
 
+&rtc {
+	status = "okay";
+};
+
 &iwdg {
 	status = "okay";
 };

--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.yaml
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.yaml
@@ -16,6 +16,7 @@ supported:
   - gpio
   - i2c
   - spi
+  - counter
   - watchdog
   - pwm
   - dac

--- a/boards/arm/nucleo_g431rb/doc/index.rst
+++ b/boards/arm/nucleo_g431rb/doc/index.rst
@@ -117,6 +117,8 @@ The Zephyr nucleo_g431rb board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | DAC       | on-chip    | dac                                 |
 +-----------+------------+-------------------------------------+
+| COUNTER   | on-chip    | rtc                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/arm/nucleo_g474re/doc/index.rst
+++ b/boards/arm/nucleo_g474re/doc/index.rst
@@ -119,6 +119,8 @@ The Zephyr nucleo_g474re board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | ADC       | on-chip    | adc                                 |
 +-----------+------------+-------------------------------------+
+| COUNTER   | on-chip    | rtc                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/drivers/clock_control/clock_stm32g0.c
+++ b/drivers/clock_control/clock_stm32g0.c
@@ -42,7 +42,8 @@ void config_pll_init(LL_UTILS_PLLInitTypeDef *pllinit)
  */
 void config_enable_default_clocks(void)
 {
-	/* Do nothing */
+	/* Enable the power interface clock */
+	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
 }
 
 /**

--- a/drivers/clock_control/clock_stm32g4.c
+++ b/drivers/clock_control/clock_stm32g4.c
@@ -46,11 +46,11 @@ void config_pll_init(LL_UTILS_PLLInitTypeDef *pllinit)
  */
 void config_enable_default_clocks(void)
 {
-#ifdef CONFIG_CLOCK_STM32_LSE
-	/* LSE belongs to the back-up domain, enable access.*/
-
 	/* Enable the power interface clock */
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+
+#ifdef CONFIG_CLOCK_STM32_LSE
+	/* LSE belongs to the back-up domain, enable access.*/
 
 	/* Set the DBP bit in the Power control register 1 (PWR_CR1) */
 	LL_PWR_EnableBkUpAccess();

--- a/drivers/counter/Kconfig.stm32_rtc
+++ b/drivers/counter/Kconfig.stm32_rtc
@@ -12,7 +12,7 @@ menuconfig COUNTER_RTC_STM32
 	select USE_STM32_LL_EXTI
 	help
 	  Build RTC driver for STM32 SoCs.
-	  Tested on STM32 F0, F2, F3, F4, L1, L4, F7, G4, H7 series
+	  Tested on STM32 F0, F2, F3, F4, L1, L4, F7, G0, G4, H7 series
 
 if COUNTER_RTC_STM32
 

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -36,6 +36,8 @@ LOG_MODULE_REGISTER(counter_rtc_stm32, CONFIG_COUNTER_LOG_LEVEL);
 
 #if defined(CONFIG_SOC_SERIES_STM32L4X)
 #define RTC_EXTI_LINE	LL_EXTI_LINE_18
+#elif defined(CONFIG_SOC_SERIES_STM32G0X)
+#define RTC_EXTI_LINE	LL_EXTI_LINE_19
 #elif defined(CONFIG_SOC_SERIES_STM32F4X) \
 	|| defined(CONFIG_SOC_SERIES_STM32F0X) \
 	|| defined(CONFIG_SOC_SERIES_STM32F2X) \
@@ -274,6 +276,8 @@ void rtc_stm32_isr(const struct device *dev)
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X) && defined(CONFIG_CPU_CORTEX_M4)
 	LL_C2_EXTI_ClearFlag_0_31(RTC_EXTI_LINE);
+#elif defined(CONFIG_SOC_SERIES_STM32G0X)
+	LL_EXTI_ClearRisingFlag_0_31(RTC_EXTI_LINE);
 #else
 	LL_EXTI_ClearFlag_0_31(RTC_EXTI_LINE);
 #endif

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -111,6 +111,16 @@
 			};
 		};
 
+		rtc: rtc@40002800 {
+			compatible = "st,stm32-rtc";
+			reg = <0x40002800 0x400>;
+			interrupts = <2 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000400>;
+			prescaler = <32768>;
+			status = "disabled";
+			label = "RTC_0";
+		};
+
 		iwdg: watchdog@40003000 {
 			compatible = "st,stm32-watchdog";
 			reg = <0x40003000 0x400>;

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -486,7 +486,7 @@
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;
 			interrupts = <41 0>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000400>;
 			prescaler = <32768>;
 			status = "disabled";
 			label = "RTC_0";


### PR DESCRIPTION
This patch enables the RTC as counter feature so that the testcase tests/drivers/counter/counter_basic_api
can run on the nucleo_g071rb board from STMicroelectronics
can run on the nucleo_g474re or nucleo_g431rb board from STMicroelectronics

$ west build -p auto -b nucleo_gxxx tests/drivers/counter/counter_basic_api/

Signed-off-by: Francois Ramu francois.ramu@st.com