### PR TITLE
net: l2: ppp: ip{,v6}cp: remove network address in ip{,v6}cp_down

### DIFF
--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -481,6 +481,10 @@ static void ipcp_down(struct ppp_fsm *fsm)
 	struct ppp_context *ctx = CONTAINER_OF(fsm, struct ppp_context,
 					       ipcp.fsm);
 
+	if (ctx->is_ipcp_up) {
+		net_if_ipv4_addr_rm(ctx->iface, &ctx->ipcp.my_options.address);
+	}
+
 	memset(&ctx->ipcp.my_options.address, 0,
 	       sizeof(ctx->ipcp.my_options.address));
 	memset(&ctx->ipcp.my_options.dns1_address, 0,

--- a/subsys/net/l2/ppp/ipv6cp.c
+++ b/subsys/net/l2/ppp/ipv6cp.c
@@ -444,6 +444,7 @@ static void ipv6cp_down(struct ppp_fsm *fsm)
 	struct ppp_context *ctx = CONTAINER_OF(fsm, struct ppp_context,
 					       ipv6cp.fsm);
 	struct net_linkaddr peer_lladdr;
+	struct in6_addr my_addr;
 	struct in6_addr peer_addr;
 	int ret;
 
@@ -454,6 +455,10 @@ static void ipv6cp_down(struct ppp_fsm *fsm)
 	ctx->is_ipv6cp_up = false;
 
 	ppp_network_down(ctx, PPP_IPV6);
+
+	/* Remove my address */
+	setup_iid_address(ctx->ipv6cp.my_options.iid, &my_addr);
+	net_if_ipv6_addr_rm(ctx->iface, &my_addr);
 
 	/* Remove peer from neighbor table */
 	setup_iid_address(ctx->ipv6cp.peer_options.iid, &peer_addr);


### PR DESCRIPTION
Make sure IPv{4,6} address is removed from network interface in IP{,V6}CP
protocol down handler. This makes sure that application can receive
high-level notification about missing network connection.