### PR TITLE
Bluetooth: Move implementation of hci_driver.h exposed functions

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -108,52 +108,13 @@ static void le_conn_complete(struct pdu_data *pdu_data, uint16_t handle,
 			     struct net_buf *buf);
 #endif /* CONFIG_BT_CONN */
 
-void hci_evt_create(struct net_buf *buf, uint8_t evt, uint8_t len)
+static void hci_evt_create(struct net_buf *buf, uint8_t evt, uint8_t len)
 {
 	struct bt_hci_evt_hdr *hdr;
 
 	hdr = net_buf_add(buf, sizeof(*hdr));
 	hdr->evt = evt;
 	hdr->len = len;
-}
-
-struct net_buf *bt_hci_evt_create(uint8_t evt, uint8_t len)
-{
-	struct net_buf *buf;
-
-	buf = bt_buf_get_evt(evt, false, K_FOREVER);
-	hci_evt_create(buf, evt, len);
-
-	return buf;
-}
-
-struct net_buf *bt_hci_cmd_complete_create(uint16_t op, uint8_t plen)
-{
-	struct net_buf *buf;
-	struct bt_hci_evt_cmd_complete *cc;
-
-	buf = bt_hci_evt_create(BT_HCI_EVT_CMD_COMPLETE, sizeof(*cc) + plen);
-
-	cc = net_buf_add(buf, sizeof(*cc));
-	cc->ncmd = 1U;
-	cc->opcode = sys_cpu_to_le16(op);
-
-	return buf;
-}
-
-struct net_buf *bt_hci_cmd_status_create(uint16_t op, uint8_t status)
-{
-	struct net_buf *buf;
-	struct bt_hci_evt_cmd_status *cs;
-
-	buf = bt_hci_evt_create(BT_HCI_EVT_CMD_STATUS, sizeof(*cs));
-
-	cs = net_buf_add(buf, sizeof(*cs));
-	cs->status = status;
-	cs->ncmd = 1U;
-	cs->opcode = sys_cpu_to_le16(op);
-
-	return buf;
 }
 
 void *hci_cmd_complete(struct net_buf **buf, uint8_t plen)

--- a/subsys/bluetooth/controller/hci/hci_internal.h
+++ b/subsys/bluetooth/controller/hci/hci_internal.h
@@ -48,5 +48,3 @@ uint8_t hci_vendor_read_static_addr(struct bt_hci_vs_static_addr addrs[],
 void hci_vendor_read_key_hierarchy_roots(uint8_t ir[16], uint8_t er[16]);
 int hci_vendor_cmd_handle_common(uint16_t ocf, struct net_buf *cmd,
 			     struct net_buf **evt);
-void *hci_cmd_complete(struct net_buf **buf, uint8_t plen);
-void hci_evt_create(struct net_buf *buf, uint8_t evt, uint8_t len);

--- a/subsys/bluetooth/host/CMakeLists.txt
+++ b/subsys/bluetooth/host/CMakeLists.txt
@@ -3,7 +3,7 @@
 zephyr_library()
 zephyr_library_link_libraries(subsys__bluetooth)
 
-zephyr_library_sources_ifdef(CONFIG_BT_HCI_RAW          hci_raw.c)
+zephyr_library_sources_ifdef(CONFIG_BT_HCI_RAW          hci_raw.c hci_common.c)
 zephyr_library_sources_ifdef(CONFIG_BT_DEBUG_MONITOR    monitor.c)
 zephyr_library_sources_ifdef(CONFIG_BT_TINYCRYPT_ECC    hci_ecc.c)
 zephyr_library_sources_ifdef(CONFIG_BT_A2DP             a2dp.c)
@@ -30,6 +30,7 @@ if(CONFIG_BT_HCI_HOST)
   zephyr_library_sources(
     uuid.c
     hci_core.c
+    hci_common.c
     )
   zephyr_library_sources_ifdef(
     CONFIG_BT_HOST_CRYPTO

--- a/subsys/bluetooth/host/hci_common.c
+++ b/subsys/bluetooth/host/hci_common.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <sys/byteorder.h>
+#include <drivers/bluetooth/hci_driver.h>
+
+struct net_buf *bt_hci_evt_create(uint8_t evt, uint8_t len)
+{
+	struct bt_hci_evt_hdr *hdr;
+	struct net_buf *buf;
+
+	buf = bt_buf_get_evt(evt, false, K_FOREVER);
+
+	hdr = net_buf_add(buf, sizeof(*hdr));
+	hdr->evt = evt;
+	hdr->len = len;
+
+	return buf;
+}
+
+struct net_buf *bt_hci_cmd_complete_create(uint16_t op, uint8_t plen)
+{
+	struct net_buf *buf;
+	struct bt_hci_evt_cmd_complete *cc;
+
+	buf = bt_hci_evt_create(BT_HCI_EVT_CMD_COMPLETE, sizeof(*cc) + plen);
+
+	cc = net_buf_add(buf, sizeof(*cc));
+	cc->ncmd = 1U;
+	cc->opcode = sys_cpu_to_le16(op);
+
+	return buf;
+}
+
+struct net_buf *bt_hci_cmd_status_create(uint16_t op, uint8_t status)
+{
+	struct net_buf *buf;
+	struct bt_hci_evt_cmd_status *cs;
+
+	buf = bt_hci_evt_create(BT_HCI_EVT_CMD_STATUS, sizeof(*cs));
+
+	cs = net_buf_add(buf, sizeof(*cs));
+	cs->status = status;
+	cs->ncmd = 1U;
+	cs->opcode = sys_cpu_to_le16(op);
+
+	return buf;
+}


### PR DESCRIPTION
Move implementation of hci_driver.h exposed functions to a common file.
The functions exposed by hci_driver.h header file is implemented in
either hci_core.c, or hci_raw.c. But since these functions would be
identical for both implementations have them in a new file that is
included for both.

Fixes: #27118