### PR TITLE
scripts: sanitycheck: import edtlib

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -63,6 +63,7 @@ if not ZEPHYR_BASE:
 
 # This is needed to load edt.pickle files.
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts", "dts"))
+import edtlib  # pylint: disable=unused-import
 
 hw_map_local = threading.Lock()
 report_lock = threading.Lock()


### PR DESCRIPTION
This is a cargo-culted attempt to make an error observed in poorly
understood CI circumstances go away when loading edt.pickle, by making
edtlib visible in sys.modules before loading the pickle file.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>