### PR TITLE
kernel, tracing, logging: avoid identifier collisions

### DIFF
--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -548,7 +548,7 @@ int z_pipe_put_internal(struct k_pipe *pipe, struct k_pipe_async *async_desc,
 		 * Lock interrupts and unlock the scheduler before
 		 * manipulating the writers wait_q.
 		 */
-		k_spinlock_key_t key = k_spin_lock(&pipe->lock);
+		k_spinlock_key_t key2 = k_spin_lock(&pipe->lock);
 		z_sched_unlock_no_reschedule();
 
 		async_desc->desc.buffer = data + num_bytes_written;
@@ -557,7 +557,7 @@ int z_pipe_put_internal(struct k_pipe *pipe, struct k_pipe_async *async_desc,
 
 		z_pend_thread((struct k_thread *) &async_desc->thread,
 			     &pipe->wait_q.writers, K_FOREVER);
-		z_reschedule(&pipe->lock, key);
+		z_reschedule(&pipe->lock, key2);
 		return 0;
 	}
 #endif
@@ -573,9 +573,9 @@ int z_pipe_put_internal(struct k_pipe *pipe, struct k_pipe_async *async_desc,
 		 * Lock interrupts and unlock the scheduler before
 		 * manipulating the writers wait_q.
 		 */
-		k_spinlock_key_t key = k_spin_lock(&pipe->lock);
+		k_spinlock_key_t key2 = k_spin_lock(&pipe->lock);
 		z_sched_unlock_no_reschedule();
-		(void)z_pend_curr(&pipe->lock, key,
+		(void)z_pend_curr(&pipe->lock, key2,
 				 &pipe->wait_q.writers, timeout);
 	} else {
 		k_sched_unlock();
@@ -725,10 +725,10 @@ int z_impl_k_pipe_get(struct k_pipe *pipe, void *data, size_t bytes_to_read,
 
 	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
 		_current->base.swap_data = &pipe_desc;
-		k_spinlock_key_t key = k_spin_lock(&pipe->lock);
+		k_spinlock_key_t key2 = k_spin_lock(&pipe->lock);
 
 		z_sched_unlock_no_reschedule();
-		(void)z_pend_curr(&pipe->lock, key,
+		(void)z_pend_curr(&pipe->lock, key2,
 				 &pipe->wait_q.readers, timeout);
 	} else {
 		k_sched_unlock();

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -63,11 +63,11 @@ void z_smp_release_global_lock(struct k_thread *thread)
 #if CONFIG_MP_NUM_CPUS > 1
 static FUNC_NORETURN void smp_init_top(void *arg)
 {
-	atomic_t *start_flag = arg;
+	atomic_t *cpu_start_flag = arg;
 	struct k_thread dummy_thread;
 
 	/* Wait for the signal to begin scheduling */
-	while (!atomic_get(start_flag)) {
+	while (!atomic_get(cpu_start_flag)) {
 	}
 
 	z_dummy_thread_init(&dummy_thread);

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -194,12 +194,13 @@ int32_t z_get_next_timeout_expiry(void)
 	return ret;
 }
 
-void z_set_timeout_expiry(int32_t ticks, bool idle)
+void z_set_timeout_expiry(int32_t ticks, bool is_idle)
 {
 	LOCKED(&timeout_lock) {
-		int next = next_timeout();
-		bool sooner = (next == K_TICKS_FOREVER) || (ticks < next);
-		bool imminent = next <= 1;
+		int next_to = next_timeout();
+		bool sooner = (next_to == K_TICKS_FOREVER)
+			      || (ticks < next_to);
+		bool imminent = next_to <= 1;
 
 		/* Only set new timeouts when they are sooner than
 		 * what we have.  Also don't try to set a timeout when
@@ -212,7 +213,7 @@ void z_set_timeout_expiry(int32_t ticks, bool idle)
 		 * in.
 		 */
 		if (!imminent && (sooner || IS_ENABLED(CONFIG_SMP))) {
-			z_clock_set_timeout(ticks, idle);
+			z_clock_set_timeout(ticks, is_idle);
 		}
 	}
 }

--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -227,16 +227,16 @@ void *sys_heap_alloc(struct sys_heap *heap, size_t bytes)
 	}
 
 	struct z_heap *h = heap->heap;
-	size_t chunksz = bytes_to_chunksz(h, bytes);
-	chunkid_t c = alloc_chunk(h, chunksz);
+	size_t chunk_sz = bytes_to_chunksz(h, bytes);
+	chunkid_t c = alloc_chunk(h, chunk_sz);
 	if (c == 0) {
 		return NULL;
 	}
 
 	/* Split off remainder if any */
-	if (chunk_size(h, c) > chunksz) {
-		split_chunks(h, c, c + chunksz);
-		free_list_add(h, c + chunksz);
+	if (chunk_size(h, c) > chunk_sz) {
+		split_chunks(h, c, c + chunk_sz);
+		free_list_add(h, c + chunk_sz);
 	}
 
 	set_chunk_used(h, c, true);

--- a/subsys/logging/log_backend_native_posix.c
+++ b/subsys/logging/log_backend_native_posix.c
@@ -55,7 +55,7 @@ static int char_out(uint8_t *data, size_t length, void *ctx)
 	return length;
 }
 
-LOG_OUTPUT_DEFINE(log_output, char_out, buf, sizeof(buf));
+LOG_OUTPUT_DEFINE(log_output_posix, char_out, buf, sizeof(buf));
 
 static void put(const struct log_backend *const backend,
 		struct log_msg *msg)
@@ -74,7 +74,7 @@ static void put(const struct log_backend *const backend,
 		flags |= LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
 	}
 
-	log_output_msg_process(&log_output, msg, flags);
+	log_output_msg_process(&log_output_posix, msg, flags);
 
 	log_msg_put(msg);
 
@@ -82,14 +82,14 @@ static void put(const struct log_backend *const backend,
 
 static void panic(struct log_backend const *const backend)
 {
-	log_output_flush(&log_output);
+	log_output_flush(&log_output_posix);
 }
 
 static void dropped(const struct log_backend *const backend, uint32_t cnt)
 {
 	ARG_UNUSED(backend);
 
-	log_output_dropped_process(&log_output, cnt);
+	log_output_dropped_process(&log_output_posix, cnt);
 }
 
 static void sync_string(const struct log_backend *const backend,
@@ -108,7 +108,8 @@ static void sync_string(const struct log_backend *const backend,
 	}
 
 	key = irq_lock();
-	log_output_string(&log_output, src_level, timestamp, fmt, ap, flags);
+	log_output_string(&log_output_posix, src_level,
+			  timestamp, fmt, ap, flags);
 	irq_unlock(key);
 }
 
@@ -128,7 +129,7 @@ static void sync_hexdump(const struct log_backend *const backend,
 	}
 
 	key = irq_lock();
-	log_output_hexdump(&log_output, src_level, timestamp,
+	log_output_hexdump(&log_output_posix, src_level, timestamp,
 			metadata, data, length, flags);
 	irq_unlock(key);
 }

--- a/subsys/logging/log_backend_net.c
+++ b/subsys/logging/log_backend_net.c
@@ -29,7 +29,7 @@ LOG_MODULE_REGISTER(log_backend_net, CONFIG_LOG_DEFAULT_LEVEL);
 #define MAX_HOSTNAME_LEN NET_IPV4_ADDR_LEN
 #endif
 
-static char hostname[MAX_HOSTNAME_LEN + 1];
+static char dev_hostname[MAX_HOSTNAME_LEN + 1];
 
 static uint8_t output_buf[CONFIG_LOG_BACKEND_NET_MAX_BUF_SIZE];
 static bool net_init_done;
@@ -73,7 +73,7 @@ fail:
 	return length;
 }
 
-LOG_OUTPUT_DEFINE(log_output, line_out, output_buf, sizeof(output_buf));
+LOG_OUTPUT_DEFINE(log_output_net, line_out, output_buf, sizeof(output_buf));
 
 static int do_net_init(void)
 {
@@ -111,7 +111,7 @@ static int do_net_init(void)
 	}
 
 	if (IS_ENABLED(CONFIG_NET_HOSTNAME_ENABLE)) {
-		(void)strncpy(hostname, net_hostname_get(), MAX_HOSTNAME_LEN);
+		(void)strncpy(dev_hostname, net_hostname_get(), MAX_HOSTNAME_LEN);
 
 	} else if (IS_ENABLED(CONFIG_NET_IPV6) &&
 		   server_addr.sa_family == AF_INET6) {
@@ -120,7 +120,7 @@ static int do_net_init(void)
 		src = net_if_ipv6_select_src_addr(
 			NULL, &net_sin6(&server_addr)->sin6_addr);
 		if (src) {
-			net_addr_ntop(AF_INET6, src, hostname,
+			net_addr_ntop(AF_INET6, src, dev_hostname,
 				      MAX_HOSTNAME_LEN);
 
 			net_ipaddr_copy(&local_addr6.sin6_addr, src);
@@ -140,7 +140,7 @@ static int do_net_init(void)
 		net_ipaddr_copy(&local_addr4.sin_addr,
 				&ipv4->unicast[0].address.in_addr);
 
-		net_addr_ntop(AF_INET, &local_addr4.sin_addr, hostname,
+		net_addr_ntop(AF_INET, &local_addr4.sin_addr, dev_hostname,
 			      MAX_HOSTNAME_LEN);
 	} else {
 	unknown:
@@ -164,8 +164,8 @@ static int do_net_init(void)
 
 	net_context_setup_pools(ctx, get_tx_slab, get_data_pool);
 
-	log_output_ctx_set(&log_output, ctx);
-	log_output_hostname_set(&log_output, hostname);
+	log_output_ctx_set(&log_output_net, ctx);
+	log_output_hostname_set(&log_output_net, dev_hostname);
 
 	return 0;
 }
@@ -183,7 +183,7 @@ static void send_output(const struct log_backend *const backend,
 
 	log_msg_get(msg);
 
-	log_output_msg_process(&log_output, msg,
+	log_output_msg_process(&log_output_net, msg,
 			       LOG_OUTPUT_FLAG_FORMAT_SYSLOG |
 			       LOG_OUTPUT_FLAG_TIMESTAMP |
 			(IS_ENABLED(CONFIG_LOG_BACKEND_NET_SYST_ENABLE) ?
@@ -229,7 +229,8 @@ static void sync_string(const struct log_backend *const backend,
 	}
 
 	key = irq_lock();
-	log_output_string(&log_output, src_level, timestamp, fmt, ap, flags);
+	log_output_string(&log_output_net, src_level,
+			  timestamp, fmt, ap, flags);
 	irq_unlock(key);
 }
 

--- a/subsys/logging/log_backend_rb.c
+++ b/subsys/logging/log_backend_rb.c
@@ -81,9 +81,9 @@ static int char_out(uint8_t *data, size_t length, void *ctx)
 }
 
 /* magic and log id takes space */
-static uint8_t buf[CONFIG_LOG_BACKEND_RB_SLOT_SIZE - 4];
+static uint8_t rb_log_buf[CONFIG_LOG_BACKEND_RB_SLOT_SIZE - 4];
 
-LOG_OUTPUT_DEFINE(log_output, char_out, buf, sizeof(buf));
+LOG_OUTPUT_DEFINE(log_output_rb, char_out, rb_log_buf, sizeof(rb_log_buf));
 
 static void put(const struct log_backend *const backend,
 		struct log_msg *msg)
@@ -96,21 +96,21 @@ static void put(const struct log_backend *const backend,
 		flags |= LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
 	}
 
-	log_output_msg_process(&log_output, msg, flags);
+	log_output_msg_process(&log_output_rb, msg, flags);
 
 	log_msg_put(msg);
 }
 
 static void panic(struct log_backend const *const backend)
 {
-	log_output_flush(&log_output);
+	log_output_flush(&log_output_rb);
 }
 
 static void dropped(const struct log_backend *const backend, uint32_t cnt)
 {
 	ARG_UNUSED(backend);
 
-	log_output_dropped_process(&log_output, cnt);
+	log_output_dropped_process(&log_output_rb, cnt);
 }
 
 static void sync_string(const struct log_backend *const backend,
@@ -125,7 +125,8 @@ static void sync_string(const struct log_backend *const backend,
 	}
 
 	key = irq_lock();
-	log_output_string(&log_output, src_level, timestamp, fmt, ap, flags);
+	log_output_string(&log_output_rb, src_level,
+			  timestamp, fmt, ap, flags);
 	irq_unlock(key);
 }
 
@@ -141,7 +142,7 @@ static void sync_hexdump(const struct log_backend *const backend,
 	}
 
 	key = irq_lock();
-	log_output_hexdump(&log_output, src_level, timestamp,
+	log_output_hexdump(&log_output_rb, src_level, timestamp,
 			   metadata, data, length, flags);
 	irq_unlock(key);
 }

--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -225,8 +225,9 @@ static int data_out_block_mode(uint8_t *data, size_t length, void *ctx)
 	return ((ret == 0) && host_present) ? 0 : length;
 }
 
-LOG_OUTPUT_DEFINE(log_output, IS_ENABLED(CONFIG_LOG_BACKEND_RTT_MODE_BLOCK) ?
-		  data_out_block_mode : data_out_drop_mode,
+LOG_OUTPUT_DEFINE(log_output_rtt,
+		  IS_ENABLED(CONFIG_LOG_BACKEND_RTT_MODE_BLOCK) ?
+			  data_out_block_mode : data_out_drop_mode,
 		  char_buf, sizeof(char_buf));
 
 static void put(const struct log_backend *const backend,
@@ -235,7 +236,7 @@ static void put(const struct log_backend *const backend,
 	uint32_t flag = IS_ENABLED(CONFIG_LOG_BACKEND_RTT_SYST_ENABLE) ?
 		LOG_OUTPUT_FLAG_FORMAT_SYST : 0;
 
-	log_backend_std_put(&log_output, flag, msg);
+	log_backend_std_put(&log_output_rtt, flag, msg);
 }
 
 static void log_backend_rtt_cfg(void)
@@ -258,14 +259,14 @@ static void log_backend_rtt_init(void)
 static void panic(struct log_backend const *const backend)
 {
 	panic_mode = true;
-	log_backend_std_panic(&log_output);
+	log_backend_std_panic(&log_output_rtt);
 }
 
 static void dropped(const struct log_backend *const backend, uint32_t cnt)
 {
 	ARG_UNUSED(backend);
 
-	log_backend_std_dropped(&log_output, cnt);
+	log_backend_std_dropped(&log_output_rtt, cnt);
 }
 
 static void sync_string(const struct log_backend *const backend,
@@ -275,7 +276,7 @@ static void sync_string(const struct log_backend *const backend,
 	uint32_t flag = IS_ENABLED(CONFIG_LOG_BACKEND_RTT_SYST_ENABLE) ?
 		LOG_OUTPUT_FLAG_FORMAT_SYST : 0;
 
-	log_backend_std_sync_string(&log_output, flag, src_level,
+	log_backend_std_sync_string(&log_output_rtt, flag, src_level,
 				    timestamp, fmt, ap);
 }
 
@@ -286,7 +287,7 @@ static void sync_hexdump(const struct log_backend *const backend,
 	uint32_t flag = IS_ENABLED(CONFIG_LOG_BACKEND_RTT_SYST_ENABLE) ?
 		LOG_OUTPUT_FLAG_FORMAT_SYST : 0;
 
-	log_backend_std_sync_hexdump(&log_output, flag, src_level,
+	log_backend_std_sync_hexdump(&log_output_rtt, flag, src_level,
 				     timestamp, metadata, data, length);
 }
 

--- a/subsys/logging/log_backend_spinel.c
+++ b/subsys/logging/log_backend_spinel.c
@@ -20,7 +20,7 @@ static bool panic_mode;
 
 static int write(uint8_t *data, size_t length, void *ctx);
 
-LOG_OUTPUT_DEFINE(log_output, write, char_buf, sizeof(char_buf));
+LOG_OUTPUT_DEFINE(log_output_spinel, write, char_buf, sizeof(char_buf));
 
 static inline bool is_panic_mode(void)
 {
@@ -33,7 +33,7 @@ static void put(const struct log_backend *const backend,
 	/* prevent adding CRLF, which may crash spinel decoding */
 	uint32_t flag = LOG_OUTPUT_FLAG_CRLF_NONE;
 
-	log_backend_std_put(&log_output, flag, msg);
+	log_backend_std_put(&log_output_spinel, flag, msg);
 }
 
 static void sync_string(const struct log_backend *const backend,
@@ -43,7 +43,7 @@ static void sync_string(const struct log_backend *const backend,
 	/* prevent adding CRLF, which may crash spinel decoding */
 	uint32_t flag = LOG_OUTPUT_FLAG_CRLF_NONE;
 
-	log_backend_std_sync_string(&log_output, flag, src_level,
+	log_backend_std_sync_string(&log_output_spinel, flag, src_level,
 				    timestamp, fmt, ap);
 }
 
@@ -55,7 +55,7 @@ static void sync_hexdump(const struct log_backend *const backend,
 	/* prevent adding CRLF, which may crash spinel decoding */
 	uint32_t flag = LOG_OUTPUT_FLAG_CRLF_NONE;
 
-	log_backend_std_sync_hexdump(&log_output, flag, src_level,
+	log_backend_std_sync_hexdump(&log_output_spinel, flag, src_level,
 				     timestamp, metadata, data, length);
 }
 
@@ -74,7 +74,7 @@ static void dropped(const struct log_backend *const backend, uint32_t cnt)
 {
 	ARG_UNUSED(backend);
 
-	log_backend_std_dropped(&log_output, cnt);
+	log_backend_std_dropped(&log_output_spinel, cnt);
 }
 
 static int write(uint8_t *data, size_t length, void *ctx)

--- a/subsys/logging/log_backend_swo.c
+++ b/subsys/logging/log_backend_swo.c
@@ -63,7 +63,7 @@ static int char_out(uint8_t *data, size_t length, void *ctx)
 	return length;
 }
 
-LOG_OUTPUT_DEFINE(log_output, char_out, buf, sizeof(buf));
+LOG_OUTPUT_DEFINE(log_output_swo, char_out, buf, sizeof(buf));
 
 static void log_backend_swo_put(const struct log_backend *const backend,
 		struct log_msg *msg)
@@ -71,7 +71,7 @@ static void log_backend_swo_put(const struct log_backend *const backend,
 	uint32_t flag = IS_ENABLED(CONFIG_LOG_BACKEND_SWO_SYST_ENABLE) ?
 		LOG_OUTPUT_FLAG_FORMAT_SYST : 0;
 
-	log_backend_std_put(&log_output, flag, msg);
+	log_backend_std_put(&log_output_swo, flag, msg);
 }
 
 static void log_backend_swo_init(void)
@@ -108,7 +108,7 @@ static void dropped(const struct log_backend *const backend, uint32_t cnt)
 {
 	ARG_UNUSED(backend);
 
-	log_backend_std_dropped(&log_output, cnt);
+	log_backend_std_dropped(&log_output_swo, cnt);
 }
 
 static void log_backend_swo_sync_string(const struct log_backend *const backend,
@@ -118,7 +118,7 @@ static void log_backend_swo_sync_string(const struct log_backend *const backend,
 	uint32_t flag = IS_ENABLED(CONFIG_LOG_BACKEND_SWO_SYST_ENABLE) ?
 		LOG_OUTPUT_FLAG_FORMAT_SYST : 0;
 
-	log_backend_std_sync_string(&log_output, flag, src_level,
+	log_backend_std_sync_string(&log_output_swo, flag, src_level,
 				    timestamp, fmt, ap);
 }
 
@@ -130,7 +130,7 @@ static void log_backend_swo_sync_hexdump(
 	uint32_t flag = IS_ENABLED(CONFIG_LOG_BACKEND_SWO_SYST_ENABLE) ?
 		LOG_OUTPUT_FLAG_FORMAT_SYST : 0;
 
-	log_backend_std_sync_hexdump(&log_output, flag, src_level,
+	log_backend_std_sync_hexdump(&log_output_swo, flag, src_level,
 				     timestamp, metadata, data, length);
 }
 

--- a/subsys/logging/log_backend_uart.c
+++ b/subsys/logging/log_backend_uart.c
@@ -24,9 +24,9 @@ static int char_out(uint8_t *data, size_t length, void *ctx)
 	return length;
 }
 
-static uint8_t buf;
+static uint8_t uart_output_buf;
 
-LOG_OUTPUT_DEFINE(log_output, char_out, &buf, 1);
+LOG_OUTPUT_DEFINE(log_output_uart, char_out, &uart_output_buf, 1);
 
 static void put(const struct log_backend *const backend,
 		struct log_msg *msg)
@@ -34,7 +34,7 @@ static void put(const struct log_backend *const backend,
 	uint32_t flag = IS_ENABLED(CONFIG_LOG_BACKEND_UART_SYST_ENABLE) ?
 		LOG_OUTPUT_FLAG_FORMAT_SYST : 0;
 
-	log_backend_std_put(&log_output, flag, msg);
+	log_backend_std_put(&log_output_uart, flag, msg);
 }
 
 static void log_backend_uart_init(void)
@@ -44,19 +44,19 @@ static void log_backend_uart_init(void)
 	dev = device_get_binding(CONFIG_UART_CONSOLE_ON_DEV_NAME);
 	assert(dev);
 
-	log_output_ctx_set(&log_output, dev);
+	log_output_ctx_set(&log_output_uart, dev);
 }
 
 static void panic(struct log_backend const *const backend)
 {
-	log_backend_std_panic(&log_output);
+	log_backend_std_panic(&log_output_uart);
 }
 
 static void dropped(const struct log_backend *const backend, uint32_t cnt)
 {
 	ARG_UNUSED(backend);
 
-	log_backend_std_dropped(&log_output, cnt);
+	log_backend_std_dropped(&log_output_uart, cnt);
 }
 
 static void sync_string(const struct log_backend *const backend,
@@ -66,7 +66,7 @@ static void sync_string(const struct log_backend *const backend,
 	uint32_t flag = IS_ENABLED(CONFIG_LOG_BACKEND_UART_SYST_ENABLE) ?
 		LOG_OUTPUT_FLAG_FORMAT_SYST : 0;
 
-	log_backend_std_sync_string(&log_output, flag, src_level,
+	log_backend_std_sync_string(&log_output_uart, flag, src_level,
 				    timestamp, fmt, ap);
 }
 
@@ -77,7 +77,7 @@ static void sync_hexdump(const struct log_backend *const backend,
 	uint32_t flag = IS_ENABLED(CONFIG_LOG_BACKEND_UART_SYST_ENABLE) ?
 		LOG_OUTPUT_FLAG_FORMAT_SYST : 0;
 
-	log_backend_std_sync_hexdump(&log_output, flag, src_level,
+	log_backend_std_sync_hexdump(&log_output_uart, flag, src_level,
 				     timestamp, metadata, data, length);
 }
 

--- a/subsys/logging/log_backend_xtensa_sim.c
+++ b/subsys/logging/log_backend_xtensa_sim.c
@@ -18,7 +18,7 @@
 #define CHAR_BUF_SIZE (IS_ENABLED(CONFIG_LOG_IMMEDIATE) ? \
 		1 : CONFIG_LOG_BACKEND_XTENSA_OUTPUT_BUFFER_SIZE)
 
-static uint8_t buf[CHAR_BUF_SIZE];
+static uint8_t xtensa_log_buf[CHAR_BUF_SIZE];
 
 static int char_out(uint8_t *data, size_t length, void *ctx)
 {
@@ -34,32 +34,33 @@ static int char_out(uint8_t *data, size_t length, void *ctx)
 	return length;
 }
 
-LOG_OUTPUT_DEFINE(log_output, char_out, buf, sizeof(buf));
+LOG_OUTPUT_DEFINE(log_output_xsim, char_out,
+		  xtensa_log_buf, sizeof(xtensa_log_buf));
 
 static void put(const struct log_backend *const backend,
 		struct log_msg *msg)
 {
-	log_backend_std_put(&log_output, 0, msg);
+	log_backend_std_put(&log_output_xsim, 0, msg);
 
 }
 
 static void panic(struct log_backend const *const backend)
 {
-	log_backend_std_panic(&log_output);
+	log_backend_std_panic(&log_output_xsim);
 }
 
 static void dropped(const struct log_backend *const backend, uint32_t cnt)
 {
 	ARG_UNUSED(backend);
 
-	log_backend_std_dropped(&log_output, cnt);
+	log_backend_std_dropped(&log_output_xsim, cnt);
 }
 
 static void sync_string(const struct log_backend *const backend,
 		     struct log_msg_ids src_level, uint32_t timestamp,
 		     const char *fmt, va_list ap)
 {
-	log_backend_std_sync_string(&log_output, 0, src_level,
+	log_backend_std_sync_string(&log_output_xsim, 0, src_level,
 				    timestamp, fmt, ap);
 }
 
@@ -67,7 +68,7 @@ static void sync_hexdump(const struct log_backend *const backend,
 			 struct log_msg_ids src_level, uint32_t timestamp,
 			 const char *metadata, const uint8_t *data, uint32_t length)
 {
-	log_backend_std_sync_hexdump(&log_output, 0, src_level,
+	log_backend_std_sync_hexdump(&log_output_xsim, 0, src_level,
 				     timestamp, metadata, data, length);
 }
 

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -760,13 +760,14 @@ uint32_t z_impl_log_filter_set(struct log_backend const *const backend,
 		uint32_t *filters = log_dynamic_filters_get(src_id);
 
 		if (backend == NULL) {
-			struct log_backend const *backend;
+			struct log_backend const *iter_backend;
 			uint32_t max = 0U;
 			uint32_t current;
 
 			for (int i = 0; i < log_backend_count_get(); i++) {
-				backend = log_backend_get(i);
-				current = log_filter_set(backend, domain_id,
+				iter_backend = log_backend_get(i);
+				current = log_filter_set(iter_backend,
+							 domain_id,
 							 src_id, level);
 				max = MAX(current, max);
 			}

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -229,9 +229,9 @@ static void color_print(const struct log_output *log_output,
 			bool color, bool start, uint32_t level)
 {
 	if (color) {
-		const char *color = start && (colors[level] != NULL) ?
+		const char *log_color = start && (colors[level] != NULL) ?
 				colors[level] : LOG_COLOR_CODE_DEFAULT;
-		print_formatted(log_output, "%s", color);
+		print_formatted(log_output, "%s", log_color);
 	}
 }
 

--- a/subsys/tracing/tracing_backend_uart.c
+++ b/subsys/tracing/tracing_backend_uart.c
@@ -14,7 +14,7 @@
 #include <tracing_buffer.h>
 #include <tracing_backend.h>
 
-static struct device *dev;
+static struct device *tracing_uart_dev;
 
 #ifdef CONFIG_TRACING_HANDLE_HOST_CMD
 static void uart_isr(struct device *dev)
@@ -62,28 +62,29 @@ static void tracing_backend_uart_output(
 		uint8_t *data, uint32_t length)
 {
 	for (uint32_t i = 0; i < length; i++) {
-		uart_poll_out(dev, data[i]);
+		uart_poll_out(tracing_uart_dev, data[i]);
 	}
 }
 
 static void tracing_backend_uart_init(void)
 {
-	dev = device_get_binding(CONFIG_TRACING_BACKEND_UART_NAME);
-	__ASSERT(dev, "uart backend binding failed");
+	tracing_uart_dev =
+		device_get_binding(CONFIG_TRACING_BACKEND_UART_NAME);
+	__ASSERT(tracing_uart_dev, "uart backend binding failed");
 
 #ifdef CONFIG_TRACING_HANDLE_HOST_CMD
-	uart_irq_rx_disable(dev);
-	uart_irq_tx_disable(dev);
+	uart_irq_rx_disable(tracing_uart_dev);
+	uart_irq_tx_disable(tracing_uart_dev);
 
-	uart_irq_callback_set(dev, uart_isr);
+	uart_irq_callback_set(tracing_uart_dev, uart_isr);
 
-	while (uart_irq_rx_ready(dev)) {
+	while (uart_irq_rx_ready(tracing_uart_dev)) {
 		uint8_t c;
 
-		uart_fifo_read(dev, &c, 1);
+		uart_fifo_read(tracing_uart_dev, &c, 1);
 	}
 
-	uart_irq_rx_enable(dev);
+	uart_irq_rx_enable(tracing_uart_dev);
 #endif
 }
 


### PR DESCRIPTION
MISRA-C Rule 5.3 states that identifiers in inner scope should not hide identifiers in outer scope. So rename those identifiers.