### PR TITLE
runners: bossac: use the built-in BOSSA reset if present

### DIFF
--- a/scripts/west_commands/runners/bossac.py
+++ b/scripts/west_commands/runners/bossac.py
@@ -108,13 +108,6 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
 
         self.require(self.bossac)
 
-        if platform.system() == 'Linux':
-            self.require('stty')
-            cmd_stty = ['stty', '-F', self.port, 'raw', 'ispeed', '1200',
-                        'ospeed', '1200', 'cs8', '-cstopb', 'ignpar', 'eol', '255',
-                        'eof', '255']
-            self.check_call(cmd_stty)
-
         cmd_flash = [self.bossac, '-p', self.port, '-R', '-e', '-w', '-v',
                      '-b', self.cfg.bin_file]
 
@@ -122,5 +115,14 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
 
         if offset:
             cmd_flash += ['-o', '%s' % offset]
+
+        if self.supports('--arduino-erase'):
+            cmd_flash += ['--arduino-erase']
+        else:
+            self.require('stty')
+            cmd_stty = ['stty', '-F', self.port, 'raw', 'ispeed', '1200',
+                        'ospeed', '1200', 'cs8', '-cstopb', 'ignpar', 'eol', '255',
+                        'eof', '255']
+            self.check_call(cmd_stty)
 
         self.check_call(cmd_flash)

--- a/scripts/west_commands/runners/bossac.py
+++ b/scripts/west_commands/runners/bossac.py
@@ -64,10 +64,13 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
         """Run bossac --help and return the output as a list of lines"""
         self.require(self.bossac)
         try:
-            self.check_output([self.bossac, '--help'])
-            return []
+            # BOSSA > 1.9.1 returns OK
+            out = self.check_output([self.bossac, '--help']).decode()
         except subprocess.CalledProcessError as ex:
-            return ex.output.decode().split('\n')
+            # BOSSA <= 1.9.1 returns an error
+            out = ex.output.decode()
+
+        return out.split('\n')
 
     def supports(self, flag):
         """Check if bossac supports a flag by searching the help"""

--- a/scripts/west_commands/tests/test_bossac.py
+++ b/scripts/west_commands/tests/test_bossac.py
@@ -69,7 +69,7 @@ def test_bossac_init(cc, req, supports, runner_config):
 
 @patch('runners.bossac.BossacBinaryRunner.supports', return_value=True)
 @patch('runners.core.BuildConfiguration._init')
-@patch('runners.core.ZephyrBinaryRunner.get_flash_address',
+@patch('runners.bossac.BossacBinaryRunner.get_flash_offset',
        return_value=None)
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
@@ -86,7 +86,7 @@ def test_bossac_create(cc, req, gfa, bcfg, supports, runner_config):
 
 @patch('runners.bossac.BossacBinaryRunner.supports', return_value=True)
 @patch('runners.core.BuildConfiguration._init')
-@patch('runners.core.ZephyrBinaryRunner.get_flash_address',
+@patch('runners.bossac.BossacBinaryRunner.get_flash_offset',
        return_value=TEST_FLASH_ADDRESS)
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
@@ -105,7 +105,7 @@ def test_bossac_create_with_offset(cc, req, gfa, bcfg, supports,
 
 @patch('runners.bossac.BossacBinaryRunner.supports', return_value=True)
 @patch('runners.core.BuildConfiguration._init')
-@patch('runners.core.ZephyrBinaryRunner.get_flash_address',
+@patch('runners.bossac.BossacBinaryRunner.get_flash_offset',
        return_value=TEST_FLASH_ADDRESS)
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')


### PR DESCRIPTION
Depends on #26866 landing.  Leaving as draft until then.

The latest BOSSA 1.9.1+git can directly reset the board and, as a bonus, fixes the enumeration problem where a board would reset and appear on a different ttyACM port.

Detect if BOSSA supports --arduino-reset and use it if it does.

@galak this should be the last change in my BOSSA series.  Once this lands a 'west flash' will just work without a manual reset or re-enumeration problems.