### PR TITLE
settings: disallow modifying the content of a static subtree name

### DIFF
--- a/include/settings/settings.h
+++ b/include/settings/settings.h
@@ -129,7 +129,7 @@ struct settings_handler {
  */
 struct settings_handler_static {
 
-	char *name;
+	const char *name;
 	/**< Name of subtree. */
 
 	int (*h_get)(const char *key, char *val, int val_len_max);


### PR DESCRIPTION
Another instance related to #26953.

There may be value in being able to rename a subtree, but there is no
identified need to be able modify the text of an assigned subtree.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>