### PR TITLE
doc: provide guidance on recommended settings back end

### DIFF
--- a/doc/reference/settings/index.rst
+++ b/doc/reference/settings/index.rst
@@ -22,6 +22,11 @@ and from a string type.
 For an example of the settings subsystem refer to
 :ref:`the sample <settings_subsys_sample>`.
 
+.. note::
+
+   As of Zephyr release 2.1 the recommended backend for non-filesystem
+   storage is :ref:`NVS <nvs_api>`.
+
 Handlers
 ********
 

--- a/doc/reference/storage/fcb/fcb.rst
+++ b/doc/reference/storage/fcb/fcb.rst
@@ -7,6 +7,12 @@ Flash circular buffer provides an abstraction through which you can treat
 flash like a FIFO. You append entries to the end, and read data from the
 beginning.
 
+.. note::
+
+   As of Zephyr release 2.1 the :ref:`NVS <nvs_api>` storage API is
+   recommended over FCB for use as a back-end for the :ref:`settings API
+   <settings_api>`.
+
 Description
 ***********
 


### PR DESCRIPTION
Zephyr release 2.1 changed the default settings back end from FCB to
NVS in all Bluetooth samples for performance and reliability reasons.
Update the settings documentation to provide a clue to developers
trying to decide which to use.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>