### PR TITLE
settings: avoid null pointer invocation in runtime read

### DIFF
--- a/subsys/settings/src/settings_runtime.c
+++ b/subsys/settings/src/settings_runtime.c
@@ -49,6 +49,10 @@ int settings_runtime_get(const char *name, void *data, size_t len)
 		return -EINVAL;
 	}
 
+	if (!ch->h_get) {
+		return -ENOTSUP;
+	}
+
 	return ch->h_get(name_key, data, len);
 }
 


### PR DESCRIPTION
If a setting read is attempted from a store that doesn't support
reading return an error rather than faulting.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>