### PR TITLE
net: if: IPv6 RS network interface check invalid

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1074,7 +1074,7 @@ static void rs_timeout(struct k_work *work)
 			}
 		}
 
-		if (!iface) {
+		if (iface) {
 			NET_DBG("RS no respond iface %p count %d",
 				iface, ipv6->rs_count);
 			if (ipv6->rs_count < RS_COUNT) {


### PR DESCRIPTION
The network interface check was invalid when IPv6 Router
Solicitation message was timeout and interface was not found.
This is highly unlikely but needs to be checked properly.

Fixes #27145
Coverity-CID: 211511

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>