### PR TITLE
Bluetooth: host: Support fragmented L2CAP header

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -886,6 +886,7 @@ void bt_conn_reset_rx_state(struct bt_conn *conn)
 
 void bt_conn_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 {
+	uint16_t acl_total_len;
 	/* Make sure we notify any pending TX callbacks before processing
 	 * new data for this connection.
 	 */
@@ -955,8 +956,7 @@ void bt_conn_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 		return;
 	}
 
-	const struct bt_l2cap_hdr *hdr = (struct bt_l2cap_hdr *)conn->rx->data;
-	const uint16_t acl_total_len = sys_le16_to_cpu(hdr->len) + sizeof(*hdr);
+	acl_total_len = sys_get_le16(buf->data) + sizeof(struct bt_l2cap_hdr);
 
 	if (conn->rx->len < acl_total_len) {
 		/* L2CAP frame not complete. */

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -909,9 +909,7 @@ void bt_conn_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 
 		BT_DBG("First, len %u final %u", buf->len,
 		       (buf->len < sizeof(uint16_t)) ?
-		       0 :
-		       sys_le16_to_cpu(
-			       ((struct bt_l2cap_hdr *)buf->data)->len));
+		       0 : sys_get_le16(buf->data));
 
 		conn->rx = buf;
 		break;

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -956,7 +956,7 @@ void bt_conn_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 		return;
 	}
 
-	acl_total_len = sys_get_le16(buf->data) + sizeof(struct bt_l2cap_hdr);
+	acl_total_len = sys_get_le16(conn->rx->data) + sizeof(struct bt_l2cap_hdr);
 
 	if (conn->rx->len < acl_total_len) {
 		/* L2CAP frame not complete. */

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -137,8 +137,7 @@ struct bt_conn {
 	uint8_t			err;
 
 	bt_conn_state_t		state;
-
-	uint16_t		        rx_len;
+	uint16_t rx_len;
 	struct net_buf		*rx;
 
 	/* Sent but not acknowledged TX packets with a callback */


### PR DESCRIPTION
Fixes: #26900.

A controller may fragment an L2CAP SDUs in any way it sees fit,
including fragmenting the L2CAP header. Likewise, the receiving
controller may send the fragmented header as ACL data to the host.

The Zephyr host assumed that a `BT_ACL_START` was at least 2 bytes long,
and consequently read the two-byte length field from the buffer without
length checks.

This commit allows the `BT_ACL_START` to be less than two bytes,
updating the `conn->rx_len` onces the `BT_ACL_CONT` with the remaining
part of the length field has been received.

Signed-off-by: Thomas Stenersen <thomas.stenersen@nordicsemi.no>