### PR TITLE
lib: os: ring_buffer: Allow using full buffer capacity

### DIFF
--- a/doc/reference/kernel/other/ring_buffers.rst
+++ b/doc/reference/kernel/other/ring_buffers.rst
@@ -103,9 +103,6 @@ shouldn't be needed.
 Internal Operation
 ==================
 
-The ring buffer always maintains an empty 32-bit word (byte in bytes mode) in
-its data buffer to allow it to distinguish between empty and full states.
-
 If the size of the data buffer is a power of two, the ring buffer
 uses efficient masking operations instead of expensive modulo operations
 when enqueuing and dequeuing data items. This option is applicable only for


### PR DESCRIPTION
Previously, ring buffer had capacity of provided buffer size - 1. This
trick was used to distinguish between empty and full states. It had one
drawback: ring buffer could not be used as a pool of equal sized buffers
(using ring_buf_put_claim and ring_buf_get_claim).
Reworked internals to use dedicated flag to distintuish between empty and
full. After this rework, buffer has one byte more capacity so in terms of
RAM usage there is no difference. Simple performance tests shows even
slight improvement (negligible).

Updated tests to reflect increased capacity and added test to check if
it is possible to continuesly allocated 2 buffers of half ring buffer
size.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>