### PR TITLE
net: tcp2: zeroing conn after removing from slist

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -326,9 +326,9 @@ static int tcp_conn_unref(struct tcp *conn)
 
 	k_delayed_work_cancel(&conn->timewait_timer);
 
-	memset(conn, 0, sizeof(*conn));
-
 	sys_slist_find_and_remove(&tcp_conns, (sys_snode_t *)conn);
+
+	memset(conn, 0, sizeof(*conn));
 
 	k_mem_slab_free(&tcp_conns_slab, (void **)&conn);
 


### PR DESCRIPTION
Bugfix: in tcp_conn_unref(), the conn was zeroed before removing it from the connection list (tcp_conns).
Zeroing conn, results in zeroing its 'next' member,
which in effect removes all its following connections referred to in tcp_conns linked list.
The solution is to move the memset() after sys_slist_find_and_remove().

Signed-off-by: David D <a8961713@gmail.com>