### PR TITLE
sanitycheck: remove verbose log message

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -3065,7 +3065,6 @@ class TestSuite(DisablePyTestCollectionMixin):
                         elif instance.results[k] == 'SKIP':
                             skips += 1
                         else:
-                            logger.info(f"result is {instance.results[k]} for {k}, counting as failure")
                             fails += 1
                 else:
                     if instance.status in ["error", "failed", "timeout"]:


### PR DESCRIPTION
This was added for debugging and was left in the script by mistake.