### PR TITLE
Bluetooth: SMP: Reject legacy pairing early in SC only mode

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -3861,6 +3861,11 @@ static uint8_t smp_security_request(struct bt_smp *smp, struct net_buf *buf)
 		auth = req->auth_req & BT_SMP_AUTH_MASK;
 	}
 
+	if (IS_ENABLED(CONFIG_BT_SMP_SC_PAIR_ONLY) &&
+	    !(auth & BT_SMP_AUTH_SC)) {
+		return BT_SMP_ERR_AUTH_REQUIREMENTS;
+	}
+
 	if (IS_ENABLED(CONFIG_BT_BONDING_REQUIRED) &&
 	    !(bondable && (auth & BT_SMP_AUTH_BONDING))) {
 		/* Reject security req if not both intend to bond */


### PR DESCRIPTION
Reject the security request immediately when receiving a security
request that does not support LE Secury Connections pairing.
This would have been rejected during the pairing procedure, but
PTS testing expects the security request to be rejected.

Ref: GAP/SEC/SEM/BV-29-C

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>