### PR TITLE
net: l2: ppp: refactor option negotiation

### DIFF
--- a/include/net/ppp.h
+++ b/include/net/ppp.h
@@ -326,22 +326,6 @@ struct ppp_fsm {
 	uint8_t ack_received : 1;
 };
 
-/** PPP configuration options */
-struct ppp_option_pkt {
-	/** Option value */
-	struct net_pkt_cursor value;
-
-	/** Option type */
-	union {
-		enum lcp_option_type lcp;
-		enum ipcp_option_type ipcp;
-		enum ipv6cp_option_type ipv6cp;
-	} type;
-
-	/** Option length */
-	uint8_t len;
-};
-
 #define PPP_MY_OPTION_ACKED	BIT(0)
 #define PPP_MY_OPTION_REJECTED	BIT(1)
 

--- a/include/net/ppp.h
+++ b/include/net/ppp.h
@@ -404,12 +404,6 @@ struct ppp_context {
 		/** Options that peer want to request */
 		struct lcp_options peer_options;
 
-		/** Options that we accepted */
-		struct lcp_options my_accepted;
-
-		/** Options that peer accepted */
-		struct lcp_options peer_accepted;
-
 		/** Magic-Number value */
 		uint32_t magic;
 	} lcp;
@@ -424,12 +418,6 @@ struct ppp_context {
 
 		/** Options that peer want to request */
 		struct ipcp_options peer_options;
-
-		/** Options that we accepted */
-		struct ipcp_options my_accepted;
-
-		/** Options that peer accepted */
-		struct ipcp_options peer_accepted;
 
 		/** My options runtime data */
 		struct ppp_my_option_data my_options_data[IPCP_NUM_MY_OPTIONS];
@@ -446,12 +434,6 @@ struct ppp_context {
 
 		/** Options that peer want to request */
 		struct ipv6cp_options peer_options;
-
-		/** Options that we accepted */
-		struct ipv6cp_options my_accepted;
-
-		/** Options that peer accepted */
-		struct ipv6cp_options peer_accepted;
 
 		/** My options runtime data */
 		struct ppp_my_option_data my_options_data[IPV6CP_NUM_MY_OPTIONS];

--- a/include/net/ppp.h
+++ b/include/net/ppp.h
@@ -241,7 +241,7 @@ struct ppp_fsm {
 		int (*config_info_req)(struct ppp_fsm *fsm,
 				       struct net_pkt *pkt,
 				       uint16_t length,
-				       struct net_buf **buf);
+				       struct net_pkt *ret_pkt);
 
 		/** Reject Configuration Information */
 		int (*config_info_rej)(struct ppp_fsm *fsm,

--- a/include/net/ppp.h
+++ b/include/net/ppp.h
@@ -212,6 +212,9 @@ enum ipv6cp_option_type {
 typedef void (*net_ppp_lcp_echo_reply_cb_t)(void *user_data,
 					    size_t user_data_len);
 
+struct ppp_my_option_data;
+struct ppp_my_option_info;
+
 /**
  * Generic PPP Finite State Machine
  */
@@ -278,6 +281,17 @@ struct ppp_fsm {
 						    struct net_pkt *pkt);
 	} cb;
 
+	struct {
+		/** Options information */
+		const struct ppp_my_option_info *info;
+
+		/** Options negotiation data */
+		struct ppp_my_option_data *data;
+
+		/** Number of negotiated options */
+		size_t count;
+	} my_options;
+
 	/** Option bits */
 	uint32_t flags;
 
@@ -328,6 +342,13 @@ struct ppp_option_pkt {
 	uint8_t len;
 };
 
+#define PPP_MY_OPTION_ACKED	BIT(0)
+#define PPP_MY_OPTION_REJECTED	BIT(1)
+
+struct ppp_my_option_data {
+	uint32_t flags;
+};
+
 struct lcp_options {
 	/** Magic number */
 	uint32_t magic;
@@ -346,10 +367,14 @@ struct ipcp_options {
 	struct in_addr dns2_address;
 };
 
+#define IPCP_NUM_MY_OPTIONS	3
+
 struct ipv6cp_options {
 	/** Interface identifier */
 	uint8_t iid[PPP_INTERFACE_IDENTIFIER_LEN];
 };
+
+#define IPV6CP_NUM_MY_OPTIONS	1
 
 /** PPP L2 context specific to certain network interface */
 struct ppp_context {
@@ -405,6 +430,9 @@ struct ppp_context {
 
 		/** Options that peer accepted */
 		struct ipcp_options peer_accepted;
+
+		/** My options runtime data */
+		struct ppp_my_option_data my_options_data[IPCP_NUM_MY_OPTIONS];
 	} ipcp;
 #endif
 
@@ -424,6 +452,9 @@ struct ppp_context {
 
 		/** Options that peer accepted */
 		struct ipv6cp_options peer_accepted;
+
+		/** My options runtime data */
+		struct ppp_my_option_data my_options_data[IPV6CP_NUM_MY_OPTIONS];
 	} ipv6cp;
 #endif
 

--- a/include/net/ppp.h
+++ b/include/net/ppp.h
@@ -337,23 +337,6 @@ struct lcp_options {
 
 	/** Maximum Receive Unit value */
 	uint16_t mru;
-
-	/* Flags what to negotiate */
-
-	/** Negotiate MRU */
-	uint16_t negotiate_mru : 1;
-
-	/** Negotiate */
-	uint16_t negotiate_async_map :1;
-
-	/** Negotiate HDLC protocol field compression*/
-	uint16_t negotiate_proto_compression :1;
-
-	/** Negotiate HDLC address/control field compression */
-	uint16_t negotiate_addr_compression :1;
-
-	/** Negotiate magic number */
-	uint16_t negotiate_magic :1;
 };
 
 struct ipcp_options {

--- a/include/net/ppp.h
+++ b/include/net/ppp.h
@@ -226,7 +226,7 @@ struct ppp_fsm {
 				       uint16_t length);
 
 		/** Add Configuration Information */
-		struct net_buf *(*config_info_add)(struct ppp_fsm *fsm);
+		struct net_pkt *(*config_info_add)(struct ppp_fsm *fsm);
 
 		/** Length of Configuration Information */
 		int  (*config_info_len)(struct ppp_fsm *fsm);

--- a/subsys/net/l2/ppp/Kconfig
+++ b/subsys/net/l2/ppp/Kconfig
@@ -56,11 +56,6 @@ config NET_L2_PPP_MAX_OPTIONS
 	  How many options we support. This is used to allocate space for
 	  each option. The default (8) is a reasonably small value.
 
-config NET_L2_PPP_OPTION_MRU_NEG
-	bool "Negotiate MRU option if needed"
-	help
-	  Try to negotiate with peer for MRU (MTU) for the link.
-
 config NET_L2_PPP_OPTION_DNS_USE
 	bool "Use negotiated DNS servers"
 	depends on DNS_RESOLVER

--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -463,6 +463,7 @@ static void ipcp_init(struct ppp_context *ctx)
 	ctx->ipcp.fsm.cb.config_info_add = ipcp_config_info_add;
 	ctx->ipcp.fsm.cb.config_info_req = ipcp_config_info_req;
 	ctx->ipcp.fsm.cb.config_info_nack = ipcp_config_info_nack;
+	ctx->ipcp.fsm.cb.config_info_rej = ppp_my_options_parse_conf_rej;
 }
 
 PPP_PROTOCOL_REGISTER(IPCP, PPP_IPCP,

--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -83,7 +83,8 @@ static int ipcp_config_info_req(struct ppp_fsm *fsm,
 	memset(options, 0, sizeof(options));
 	memset(nack_options, 0, sizeof(nack_options));
 
-	ret = ppp_parse_options(fsm, pkt, length, options, ARRAY_SIZE(options));
+	ret = ppp_parse_options_array(fsm, pkt, length, options,
+				      ARRAY_SIZE(options));
 	if (ret < 0) {
 		return -EINVAL;
 	}
@@ -259,8 +260,8 @@ static int ipcp_config_info_nack(struct ppp_fsm *fsm,
 
 	memset(nack_options, 0, sizeof(nack_options));
 
-	ret = ppp_parse_options(fsm, pkt, length, nack_options,
-				ARRAY_SIZE(nack_options));
+	ret = ppp_parse_options_array(fsm, pkt, length, nack_options,
+				      ARRAY_SIZE(nack_options));
 	if (ret < 0) {
 		return -EINVAL;
 	}

--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -107,15 +107,14 @@ static int ipcp_config_info_req(struct ppp_fsm *fsm,
 	struct ppp_option_pkt options[MAX_IPCP_OPTIONS];
 	struct ppp_option_pkt nack_options[MAX_IPCP_OPTIONS];
 	enum ppp_packet_type code;
-	enum net_verdict verdict;
+	int ret;
 	int i;
 
 	memset(options, 0, sizeof(options));
 	memset(nack_options, 0, sizeof(nack_options));
 
-	verdict = ppp_parse_options(fsm, pkt, length, options,
-				    ARRAY_SIZE(options));
-	if (verdict != NET_OK) {
+	ret = ppp_parse_options(fsm, pkt, length, options, ARRAY_SIZE(options));
+	if (ret < 0) {
 		return -EINVAL;
 	}
 
@@ -340,15 +339,14 @@ static int ipcp_config_info_nack(struct ppp_fsm *fsm,
 	struct ppp_context *ctx = CONTAINER_OF(fsm, struct ppp_context,
 					       ipcp.fsm);
 	struct ppp_option_pkt nack_options[MAX_IPCP_OPTIONS];
-	enum net_verdict verdict;
 	int i, ret, address_option_idx = -1;
 	struct in_addr addr, *dst_addr;
 
 	memset(nack_options, 0, sizeof(nack_options));
 
-	verdict = ppp_parse_options(fsm, pkt, length, nack_options,
-				    ARRAY_SIZE(nack_options));
-	if (verdict != NET_OK) {
+	ret = ppp_parse_options(fsm, pkt, length, nack_options,
+				ARRAY_SIZE(nack_options));
+	if (ret < 0) {
 		return -EINVAL;
 	}
 

--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -100,10 +100,9 @@ out_of_mem:
 static int ipcp_config_info_req(struct ppp_fsm *fsm,
 				struct net_pkt *pkt,
 				uint16_t length,
-				struct net_buf **ret_buf)
+				struct net_pkt *ret_pkt)
 {
 	int nack_idx = 0, address_option_idx = -1;
-	struct net_buf *buf = NULL;
 	struct ppp_option_pkt options[MAX_IPCP_OPTIONS];
 	struct ppp_option_pkt nack_options[MAX_IPCP_OPTIONS];
 	enum ppp_packet_type code;
@@ -152,43 +151,19 @@ static int ipcp_config_info_req(struct ppp_fsm *fsm,
 	}
 
 	if (nack_idx > 0) {
-		struct net_buf *nack_buf;
-
 		code = PPP_CONFIGURE_REJ;
 
-		/* Create net_buf containing options that are not accepted */
+		/* Fill ret_pkt with options that are not accepted */
 		for (i = 0; i < MIN(nack_idx, ARRAY_SIZE(nack_options)); i++) {
-			bool added;
-
-			nack_buf = ppp_get_net_buf(buf, nack_options[i].len);
-			if (!nack_buf) {
-				goto bail_out;
-			}
-
-			if (!buf) {
-				buf = nack_buf;
-			}
-
-			added = append_to_buf(nack_buf,
-					      &nack_options[i].type.ipcp, 1);
-			if (!added) {
-				goto bail_out;
-			}
-
-			added = append_to_buf(nack_buf, &nack_options[i].len,
-					      1);
-			if (!added) {
-				goto bail_out;
-			}
+			net_pkt_write_u8(ret_pkt, nack_options[i].type.ipcp);
+			net_pkt_write_u8(ret_pkt, nack_options[i].len);
 
 			/* If there is some data, copy it to result buf */
 			if (nack_options[i].value.pos) {
-				added = append_to_buf(nack_buf,
-						nack_options[i].value.pos,
-						nack_options[i].len - 1 - 1);
-				if (!added) {
-					goto bail_out;
-				}
+				net_pkt_cursor_restore(pkt,
+						       &nack_options[i].value);
+				net_pkt_copy(ret_pkt, pkt,
+					     nack_options[i].len - 1 - 1);
 			}
 		}
 	} else {
@@ -232,9 +207,6 @@ static int ipcp_config_info_req(struct ppp_fsm *fsm,
 		}
 
 		if (addr.s_addr) {
-			bool added;
-			uint8_t val;
-
 			/* The address is the remote address, we then need
 			 * to figure out what our address should be.
 			 *
@@ -242,43 +214,15 @@ static int ipcp_config_info_req(struct ppp_fsm *fsm,
 			 *   - check that the IP address can be accepted
 			 */
 
-			buf = ppp_get_net_buf(NULL, IP_ADDRESS_OPTION_LEN);
-			if (!buf) {
-				goto bail_out;
-			}
+			net_pkt_write_u8(ret_pkt, IPCP_OPTION_IP_ADDRESS);
+			net_pkt_write_u8(ret_pkt, IP_ADDRESS_OPTION_LEN);
 
-			val = IPCP_OPTION_IP_ADDRESS;
-			added = append_to_buf(buf, &val, sizeof(val));
-			if (!added) {
-				goto bail_out;
-			}
-
-			val = IP_ADDRESS_OPTION_LEN;
-			added = append_to_buf(buf, &val, sizeof(val));
-			if (!added) {
-				goto bail_out;
-			}
-
-			added = append_to_buf(buf, (uint8_t *)&addr.s_addr,
-					      sizeof(addr.s_addr));
-			if (!added) {
-				goto bail_out;
-			}
+			net_pkt_write(ret_pkt, &addr.s_addr,
+				      sizeof(addr.s_addr));
 		}
 	}
 
-	if (buf) {
-		*ret_buf = buf;
-	}
-
 	return code;
-
-bail_out:
-	if (buf) {
-		net_buf_unref(buf);
-	}
-
-	return -ENOMEM;
 }
 
 static void ipcp_set_dns_servers(struct ppp_fsm *fsm)

--- a/subsys/net/l2/ppp/ipv6cp.c
+++ b/subsys/net/l2/ppp/ipv6cp.c
@@ -97,15 +97,14 @@ static int ipv6cp_config_info_req(struct ppp_fsm *fsm,
 	struct ppp_option_pkt options[MAX_IPV6CP_OPTIONS];
 	struct ppp_option_pkt nack_options[MAX_IPV6CP_OPTIONS];
 	enum ppp_packet_type code;
-	enum net_verdict verdict;
+	int ret;
 	int i;
 
 	memset(options, 0, sizeof(options));
 	memset(nack_options, 0, sizeof(nack_options));
 
-	verdict = ppp_parse_options(fsm, pkt, length, options,
-				    ARRAY_SIZE(options));
-	if (verdict != NET_OK) {
+	ret = ppp_parse_options(fsm, pkt, length, options, ARRAY_SIZE(options));
+	if (ret < 0) {
 		return -EINVAL;
 	}
 
@@ -271,13 +270,12 @@ static int ipv6cp_config_info_ack(struct ppp_fsm *fsm,
 	struct ppp_option_pkt nack_options[MAX_IPV6CP_OPTIONS];
 	uint8_t iface_id[PPP_INTERFACE_IDENTIFIER_LEN];
 	int i, ret, iface_id_option_idx = -1;
-	enum net_verdict verdict;
 
 	memset(nack_options, 0, sizeof(nack_options));
 
-	verdict = ppp_parse_options(fsm, pkt, length, nack_options,
-				    ARRAY_SIZE(nack_options));
-	if (verdict != NET_OK) {
+	ret = ppp_parse_options(fsm, pkt, length, nack_options,
+				ARRAY_SIZE(nack_options));
+	if (ret < 0) {
 		return -EINVAL;
 	}
 

--- a/subsys/net/l2/ppp/ipv6cp.c
+++ b/subsys/net/l2/ppp/ipv6cp.c
@@ -436,6 +436,7 @@ static void ipv6cp_init(struct ppp_context *ctx)
 	ctx->ipv6cp.fsm.cb.finished = ipv6cp_finished;
 	ctx->ipv6cp.fsm.cb.proto_reject = ipv6cp_proto_reject;
 	ctx->ipv6cp.fsm.cb.config_info_ack = ipv6cp_config_info_ack;
+	ctx->ipv6cp.fsm.cb.config_info_rej = ppp_my_options_parse_conf_rej;
 	ctx->ipv6cp.fsm.cb.config_info_add = ipv6cp_config_info_add;
 	ctx->ipv6cp.fsm.cb.config_info_req = ipv6cp_config_info_req;
 }

--- a/subsys/net/l2/ppp/ipv6cp.c
+++ b/subsys/net/l2/ppp/ipv6cp.c
@@ -76,7 +76,8 @@ static int ipv6cp_config_info_req(struct ppp_fsm *fsm,
 	memset(options, 0, sizeof(options));
 	memset(nack_options, 0, sizeof(nack_options));
 
-	ret = ppp_parse_options(fsm, pkt, length, options, ARRAY_SIZE(options));
+	ret = ppp_parse_options_array(fsm, pkt, length, options,
+				      ARRAY_SIZE(options));
 	if (ret < 0) {
 		return -EINVAL;
 	}
@@ -190,8 +191,8 @@ static int ipv6cp_config_info_ack(struct ppp_fsm *fsm,
 
 	memset(nack_options, 0, sizeof(nack_options));
 
-	ret = ppp_parse_options(fsm, pkt, length, nack_options,
-				ARRAY_SIZE(nack_options));
+	ret = ppp_parse_options_array(fsm, pkt, length, nack_options,
+				      ARRAY_SIZE(nack_options));
 	if (ret < 0) {
 		return -EINVAL;
 	}

--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -80,15 +80,14 @@ static int lcp_config_info_req(struct ppp_fsm *fsm,
 	struct ppp_option_pkt nack_options[MAX_LCP_OPTIONS];
 	struct net_buf *nack = NULL;
 	enum ppp_packet_type code;
-	enum net_verdict verdict;
 	int i, nack_idx = 0;
+	int ret;
 
 	memset(options, 0, sizeof(options));
 	memset(nack_options, 0, sizeof(nack_options));
 
-	verdict = ppp_parse_options(fsm, pkt, length, options,
-				    ARRAY_SIZE(options));
-	if (verdict != NET_OK) {
+	ret = ppp_parse_options(fsm, pkt, length, options, ARRAY_SIZE(options));
+	if (ret < 0) {
 		return -EINVAL;
 	}
 

--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -258,13 +258,6 @@ static void lcp_init(struct ppp_context *ctx)
 	ctx->lcp.fsm.cb.finished = lcp_finished;
 	ctx->lcp.fsm.cb.proto_extension = lcp_handle_ext;
 	ctx->lcp.fsm.cb.config_info_req = lcp_config_info_req;
-
-	ctx->lcp.my_options.negotiate_proto_compression = false;
-	ctx->lcp.my_options.negotiate_addr_compression = false;
-	ctx->lcp.my_options.negotiate_async_map = false;
-	ctx->lcp.my_options.negotiate_magic = false;
-	ctx->lcp.my_options.negotiate_mru =
-		IS_ENABLED(CONFIG_NET_L2_PPP_OPTION_MRU_NEG) ? true : false;
 }
 
 PPP_PROTOCOL_REGISTER(LCP, PPP_LCP,

--- a/subsys/net/l2/ppp/options.c
+++ b/subsys/net/l2/ppp/options.c
@@ -18,51 +18,6 @@ LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 
 #define ALLOC_TIMEOUT K_MSEC(100)
 
-struct ppp_parse_option_array_data {
-	int idx;
-	struct ppp_option_pkt *options;
-	int options_len;
-};
-
-static int ppp_parse_option_array_elem(struct net_pkt *pkt, uint8_t code,
-				       uint8_t len, void *user_data)
-{
-	struct ppp_parse_option_array_data *parse_data = user_data;
-	struct ppp_option_pkt *options = parse_data->options;
-	int options_len = parse_data->options_len;
-	int idx = parse_data->idx;
-
-	if (idx >= options_len) {
-		NET_DBG("Cannot insert options (max %d)", options_len);
-		return -ENOMEM;
-	}
-
-	options[idx].type.lcp = code;
-	options[idx].len = len;
-
-	if (len > 0) {
-		/* There is an option value here */
-		net_pkt_cursor_backup(pkt, &options[idx].value);
-	}
-
-	parse_data->idx++;
-
-	return 0;
-}
-
-int ppp_parse_options_array(struct ppp_fsm *fsm, struct net_pkt *pkt,
-			    uint16_t length, struct ppp_option_pkt options[],
-			    int options_len)
-{
-	struct ppp_parse_option_array_data parse_data = {
-		.options = options,
-		.options_len = options_len,
-	};
-
-	return ppp_parse_options(fsm, pkt, length, ppp_parse_option_array_elem,
-				 &parse_data);
-}
-
 int ppp_parse_options(struct ppp_fsm *fsm, struct net_pkt *pkt,
 		      uint16_t length,
 		      int (*parse)(struct net_pkt *pkt, uint8_t code,

--- a/subsys/net/l2/ppp/options.c
+++ b/subsys/net/l2/ppp/options.c
@@ -77,29 +77,3 @@ int ppp_parse_options(struct ppp_fsm *fsm, struct net_pkt *pkt, uint16_t length,
 
 	return 0;
 }
-
-struct net_buf *ppp_get_net_buf(struct net_buf *root_buf, uint8_t len)
-{
-	struct net_buf *tmp;
-
-	if (root_buf) {
-		tmp = net_buf_frag_last(root_buf);
-
-		if (len > net_buf_tailroom(tmp)) {
-			tmp = net_pkt_get_reserve_tx_data(ALLOC_TIMEOUT);
-			if (tmp) {
-				net_buf_frag_add(root_buf, tmp);
-			}
-		}
-
-		return tmp;
-
-	}
-
-	tmp = net_pkt_get_reserve_tx_data(ALLOC_TIMEOUT);
-	if (tmp) {
-		return tmp;
-	}
-
-	return NULL;
-}

--- a/subsys/net/l2/ppp/options.c
+++ b/subsys/net/l2/ppp/options.c
@@ -18,12 +18,61 @@ LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 
 #define ALLOC_TIMEOUT K_MSEC(100)
 
-int ppp_parse_options(struct ppp_fsm *fsm, struct net_pkt *pkt, uint16_t length,
-		      struct ppp_option_pkt options[], int options_len)
+struct ppp_parse_option_array_data {
+	int idx;
+	struct ppp_option_pkt *options;
+	int options_len;
+};
+
+static int ppp_parse_option_array_elem(struct net_pkt *pkt, uint8_t code,
+				       uint8_t len, void *user_data)
+{
+	struct ppp_parse_option_array_data *parse_data = user_data;
+	struct ppp_option_pkt *options = parse_data->options;
+	int options_len = parse_data->options_len;
+	int idx = parse_data->idx;
+
+	if (idx >= options_len) {
+		NET_DBG("Cannot insert options (max %d)", options_len);
+		return -ENOMEM;
+	}
+
+	options[idx].type.lcp = code;
+	options[idx].len = len;
+
+	if (len > 0) {
+		/* There is an option value here */
+		net_pkt_cursor_backup(pkt, &options[idx].value);
+	}
+
+	parse_data->idx++;
+
+	return 0;
+}
+
+int ppp_parse_options_array(struct ppp_fsm *fsm, struct net_pkt *pkt,
+			    uint16_t length, struct ppp_option_pkt options[],
+			    int options_len)
+{
+	struct ppp_parse_option_array_data parse_data = {
+		.options = options,
+		.options_len = options_len,
+	};
+
+	return ppp_parse_options(fsm, pkt, length, ppp_parse_option_array_elem,
+				 &parse_data);
+}
+
+int ppp_parse_options(struct ppp_fsm *fsm, struct net_pkt *pkt,
+		      uint16_t length,
+		      int (*parse)(struct net_pkt *pkt, uint8_t code,
+				   uint8_t len, void *user_data),
+		      void *user_data)
 {
 	int remaining = length, pkt_remaining;
-	uint8_t opt_type, opt_len;
-	int ret, idx = 0;
+	uint8_t opt_type, opt_len, opt_val_len;
+	int ret;
+	struct net_pkt_cursor cursor;
 
 	pkt_remaining = net_pkt_remaining_data(pkt);
 	if (remaining != pkt_remaining) {
@@ -47,28 +96,23 @@ int ppp_parse_options(struct ppp_fsm *fsm, struct net_pkt *pkt, uint16_t length,
 			return -EBADMSG;
 		}
 
-		if (idx >= options_len) {
-			NET_DBG("Cannot insert options (max %d)", options_len);
-			return -ENOMEM;
+		opt_val_len = opt_len - sizeof(opt_type) - sizeof(opt_len);
+
+		net_pkt_cursor_backup(pkt, &cursor);
+
+		NET_DBG("[%s/%p] option %s (%d) len %d", fsm->name, fsm,
+			ppp_option2str(fsm->protocol, opt_type), opt_type,
+			opt_len);
+
+		ret = parse(pkt, opt_type, opt_val_len, user_data);
+		if (ret < 0) {
+			return ret;
 		}
 
-		options[idx].type.lcp = opt_type;
-		options[idx].len = opt_len;
+		net_pkt_cursor_restore(pkt, &cursor);
 
-		NET_DBG("[%s/%p] %s option %s (%d) len %d", fsm->name, fsm,
-			"Recv", ppp_option2str(fsm->protocol, opt_type),
-			opt_type, opt_len);
-
-		if (opt_len > 2) {
-			/* There is an option value here */
-			net_pkt_cursor_backup(pkt, &options[idx].value);
-		}
-
-		net_pkt_skip(pkt,
-			     opt_len - sizeof(opt_type) - sizeof(opt_len));
+		net_pkt_skip(pkt, opt_val_len);
 		remaining -= opt_len;
-
-		idx++;
 	}
 
 	if (remaining < 0) {

--- a/subsys/net/l2/ppp/ppp_internal.h
+++ b/subsys/net/l2/ppp/ppp_internal.h
@@ -44,6 +44,8 @@ struct ppp_packet {
 /** Max number of IPV6CP options */
 #define MAX_IPV6CP_OPTIONS 1
 
+#define PPP_BUF_ALLOC_TIMEOUT	K_MSEC(100)
+
 /** Protocol handler information. */
 struct ppp_protocol_handler {
 	/** Protocol init function */
@@ -112,7 +114,8 @@ void ppp_change_state_debug(struct ppp_fsm *fsm, enum ppp_state new_state,
 			    const char *caller, int line);
 #endif
 
-struct net_buf *ppp_get_net_buf(struct net_buf *root_buf, uint8_t len);
+struct ppp_context *ppp_fsm_ctx(struct ppp_fsm *fsm);
+struct net_if *ppp_fsm_iface(struct ppp_fsm *fsm);
 int ppp_send_pkt(struct ppp_fsm *fsm, struct net_if *iface,
 		 enum ppp_packet_type type, uint8_t id,
 		 void *data, uint32_t data_len);

--- a/subsys/net/l2/ppp/ppp_internal.h
+++ b/subsys/net/l2/ppp/ppp_internal.h
@@ -165,9 +165,6 @@ enum net_verdict ppp_fsm_recv_discard_req(struct ppp_fsm *fsm,
 					  struct net_pkt *pkt);
 
 const struct ppp_protocol_handler *ppp_lcp_get(void);
-int ppp_parse_options_array(struct ppp_fsm *fsm, struct net_pkt *pkt,
-			    uint16_t length, struct ppp_option_pkt options[],
-			    int options_len);
 int ppp_parse_options(struct ppp_fsm *fsm, struct net_pkt *pkt,
 		      uint16_t length,
 		      int (*parse)(struct net_pkt *pkt, uint8_t code,

--- a/subsys/net/l2/ppp/ppp_internal.h
+++ b/subsys/net/l2/ppp/ppp_internal.h
@@ -141,11 +141,8 @@ enum net_verdict ppp_fsm_recv_discard_req(struct ppp_fsm *fsm,
 					  struct net_pkt *pkt);
 
 const struct ppp_protocol_handler *ppp_lcp_get(void);
-enum net_verdict ppp_parse_options(struct ppp_fsm *fsm,
-				   struct net_pkt *pkt,
-				   uint16_t length,
-				   struct ppp_option_pkt options[],
-				   int options_len);
+int ppp_parse_options(struct ppp_fsm *fsm, struct net_pkt *pkt, uint16_t length,
+		      struct ppp_option_pkt options[], int options_len);
 
 void ppp_link_established(struct ppp_context *ctx, struct ppp_fsm *fsm);
 void ppp_link_terminated(struct ppp_context *ctx);

--- a/subsys/net/l2/ppp/ppp_internal.h
+++ b/subsys/net/l2/ppp/ppp_internal.h
@@ -162,3 +162,42 @@ void ppp_network_up(struct ppp_context *ctx, int proto);
 void ppp_network_down(struct ppp_context *ctx, int proto);
 void ppp_network_done(struct ppp_context *ctx, int proto);
 void ppp_network_all_down(struct ppp_context *ctx);
+
+struct ppp_my_option_info {
+	uint8_t code;
+	int (*conf_req_add)(struct ppp_context *ctx, struct net_pkt *pkt);
+	int (*conf_ack_handle)(struct ppp_context *ctx, struct net_pkt *pkt,
+			       uint8_t oplen);
+	int (*conf_nak_handle)(struct ppp_context *ctx, struct net_pkt *pkt,
+			       uint8_t oplen);
+};
+
+#define PPP_MY_OPTION(_code, _req_add, _handle_ack, _handle_nak)	\
+	{								\
+		.code = _code,						\
+		.conf_req_add = _req_add,				\
+		.conf_ack_handle = _handle_ack,				\
+		.conf_nak_handle = _handle_nak,				\
+	}
+
+struct net_pkt *ppp_my_options_add(struct ppp_fsm *fsm, size_t packet_len);
+
+int ppp_my_options_parse_conf_ack(struct ppp_fsm *fsm,
+				  struct net_pkt *pkt,
+				  uint16_t length);
+
+int ppp_my_options_parse_conf_nak(struct ppp_fsm *fsm,
+				  struct net_pkt *pkt,
+				  uint16_t length);
+
+int ppp_my_options_parse_conf_rej(struct ppp_fsm *fsm,
+				  struct net_pkt *pkt,
+				  uint16_t length);
+
+uint32_t ppp_my_option_flags(struct ppp_fsm *fsm, uint8_t code);
+
+static inline bool ppp_my_option_is_acked(struct ppp_fsm *fsm,
+					  uint8_t code)
+{
+	return ppp_my_option_flags(fsm, code) & PPP_MY_OPTION_ACKED;
+}

--- a/subsys/net/l2/ppp/ppp_internal.h
+++ b/subsys/net/l2/ppp/ppp_internal.h
@@ -72,6 +72,27 @@ struct ppp_protocol_handler {
 	uint16_t protocol;
 };
 
+struct ppp_peer_option_info {
+	uint8_t code;
+	int (*parse)(struct ppp_fsm *fsm, struct net_pkt *pkt,
+		     void *user_data);
+};
+
+#define PPP_PEER_OPTION(_code, _parse)		\
+	{					\
+		.code = _code,			\
+		.parse = _parse,		\
+	}
+
+int ppp_config_info_req(struct ppp_fsm *fsm,
+			struct net_pkt *pkt,
+			uint16_t length,
+			struct net_pkt *ret_pkt,
+			enum ppp_protocol_type protocol,
+			const struct ppp_peer_option_info *options_info,
+			size_t num_options_info,
+			void *user_data);
+
 #define PPP_PROTO_GET_NAME(proto_name)		\
 	(ppp_protocol_handler_##proto_name)
 

--- a/subsys/net/l2/ppp/ppp_internal.h
+++ b/subsys/net/l2/ppp/ppp_internal.h
@@ -144,8 +144,14 @@ enum net_verdict ppp_fsm_recv_discard_req(struct ppp_fsm *fsm,
 					  struct net_pkt *pkt);
 
 const struct ppp_protocol_handler *ppp_lcp_get(void);
-int ppp_parse_options(struct ppp_fsm *fsm, struct net_pkt *pkt, uint16_t length,
-		      struct ppp_option_pkt options[], int options_len);
+int ppp_parse_options_array(struct ppp_fsm *fsm, struct net_pkt *pkt,
+			    uint16_t length, struct ppp_option_pkt options[],
+			    int options_len);
+int ppp_parse_options(struct ppp_fsm *fsm, struct net_pkt *pkt,
+		      uint16_t length,
+		      int (*parse)(struct net_pkt *pkt, uint8_t code,
+				   uint8_t len, void *user_data),
+		      void *user_data);
 
 void ppp_link_established(struct ppp_context *ctx, struct ppp_fsm *fsm);
 void ppp_link_terminated(struct ppp_context *ctx);

--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -21,8 +21,6 @@ LOG_MODULE_REGISTER(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 #include "ppp_stats.h"
 #include "ppp_internal.h"
 
-#define BUF_ALLOC_TIMEOUT K_MSEC(100)
-
 static const struct ppp_protocol_handler *ppp_lcp;
 
 static void ppp_update_rx_stats(struct net_if *iface,


### PR DESCRIPTION
Use net_pkt API instead of net_buf API to simplify implementation of option negotiation. That way it is much easier to append data to packets. Additionally we start to support packets across multiple net_bufs, which was not the case yet.

Refactor PPP option negotiation to have generic code for handling option negotiation and remembering which options were acked/rejected. Allow specific FSM instance (e.g. IPCP, IPV6CP) to provide option specific callbacks (when request or response is created). Assume that all supported "my options" are optional by default, so allow peer to send Conf-Rej for them. This for example allows to make PPP compatible with peers that do not support DNS1 and DNS2 options.

Prepare Conf-Rej reply automatically for all options peer has requested, but which we do not support. Do that in `fsm.c`, so  IPCP/IPV6CP implementation doesn't need to manually reply to such Conf-Req packets.

Also do some cleanups of unused code / structure members, just to make implementation a little bit smaller.

Code was tested with `pppd /dev/pts/X +ipv6 local noauth nodefaultroute nodetach debug silent 192.0.2.2:192.0.2.1` (so `novj noccp noaccomp nomp` were dropped compared to net-tools `loop-pppd.sh` script):
```
17:08:36.385071 rcvd [LCP ConfReq id=0x1]
17:08:36.385100 sent [LCP ConfReq id=0x1 <asyncmap 0x0> <magic 0x65b3c372> <pcomp> <accomp>]
17:08:36.385108 sent [LCP ConfAck id=0x1]
17:08:36.386920 rcvd [LCP ConfRej id=0x1 <asyncmap 0x0> <magic 0x65b3c372> <pcomp> <accomp>]
17:08:36.386936 sent [LCP ConfReq id=0x2]
17:08:36.388161 rcvd [LCP ConfAck id=0x2]
17:08:36.388182 sent [LCP EchoReq id=0x0 magic=0x0]
17:08:36.388229 sent [CCP ConfReq id=0x1 <deflate 15> <deflate(old#) 15> <bsd v1 15>]
17:08:36.388244 sent [IPCP ConfReq id=0x1 <compress VJ 0f 01> <addr 192.0.2.2>]
17:08:36.388255 sent [IPV6CP ConfReq id=0x1 <addr fe80::b10f:1e1d:b578:5599>]
17:08:36.388264 rcvd [IPCP ConfReq id=0x1 <addr 0.0.0.0> <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
17:08:36.388275 sent [IPCP ConfRej id=0x1 <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
17:08:36.388591 rcvd [IPV6CP ConfReq id=0x1 <addr fe80::0000:5eff:fe00:531d>]
17:08:36.388610 sent [IPV6CP ConfAck id=0x1 <addr fe80::0000:5eff:fe00:531d>]
17:08:36.389029 rcvd [LCP ProtRej id=0x1 80 fd 01 01 00 0f 1a 04 78 00 18 04 78 00 15]
17:08:36.389044 Protocol-Reject for 'Compression Control Protocol' (0x80fd) received
17:08:36.390325 rcvd [LCP EchoRep id=0x0 magic=0x0]
17:08:36.390365 rcvd [IPCP ConfRej id=0x1 <compress VJ 0f 01>]
17:08:36.390381 sent [IPCP ConfReq id=0x2 <addr 192.0.2.2>]
17:08:36.390424 rcvd [IPV6CP ConfAck id=0x1 <addr fe80::b10f:1e1d:b578:5599>]
17:08:36.390568 local  LL address fe80::b10f:1e1d:b578:5599
17:08:36.390585 remote LL address fe80::0000:5eff:fe00:531d
17:08:36.390810 Script /etc/ppp/ipv6-up started (pid 98593)
17:08:36.390828 rcvd [IPCP ConfReq id=0x2 <addr 0.0.0.0>]
17:08:36.390836 sent [IPCP ConfNak id=0x2 <addr 192.0.2.1>]
17:08:36.392634 Script /etc/ppp/ipv6-up finished (pid 98593), status = 0x0
17:08:36.396747 rcvd [IPCP ConfAck id=0x2 <addr 192.0.2.2>]
17:08:36.396865 rcvd [IPCP ConfReq id=0x3 <addr 192.0.2.1>]
17:08:36.396886 sent [IPCP ConfAck id=0x3 <addr 192.0.2.1>]
17:08:36.398111 Cannot determine ethernet address for proxy ARP
17:08:36.398133 local  IP address 192.0.2.2
17:08:36.398140 remote IP address 192.0.2.1
17:08:36.398300 Script /etc/ppp/ip-up started (pid 98595)
17:08:36.399808 Script /etc/ppp/ip-up finished (pid 98595), status = 0x0
```