### PR TITLE
net: l2: ppp: fsm: change state before sending Conf-Req

### DIFF
--- a/subsys/net/l2/ppp/fsm.c
+++ b/subsys/net/l2/ppp/fsm.c
@@ -303,8 +303,8 @@ void ppp_fsm_open(struct ppp_fsm *fsm)
 
 	switch (fsm->state) {
 	case PPP_CLOSED:
-		fsm_send_configure_req(fsm, false);
 		ppp_change_state(fsm, PPP_REQUEST_SENT);
+		fsm_send_configure_req(fsm, false);
 		break;
 
 	case PPP_CLOSING:


### PR DESCRIPTION
There was a race condition when ppp_fsm_open() was called in CLOSED
state. Conf-Req was sent first, then state was changed to
REQUEST_SENT. In the meantime however we have already received Conf-Req
to which we responded with Term-Ack.

Change state before sending Conf-Req, so we handle Conf-Req from peer
properly instead of dropping it.

This is pppd behavior **before** this change:
```
17:18:40.414411 rcvd [LCP ConfReq id=0x1]
17:18:40.414440 sent [LCP ConfReq id=0x1 <asyncmap 0x0> <magic 0x90185a96> <pcomp> <accomp>]
17:18:40.414447 sent [LCP ConfAck id=0x1]
17:18:40.416073 rcvd [LCP TermAck id=0x1]
17:18:40.416089 rcvd [LCP TermAck id=0x1]
17:18:43.417497 sent [LCP ConfReq id=0x1 <asyncmap 0x0> <magic 0x90185a96> <pcomp> <accomp>]
17:18:43.421722 rcvd [LCP ConfRej id=0x1 <asyncmap 0x0> <magic 0x90185a96> <pcomp> <accomp>]
17:18:43.421750 sent [LCP ConfReq id=0x2]
17:18:43.421772 rcvd [LCP ConfReq id=0x1]
17:18:43.421779 sent [LCP ConfAck id=0x1]
17:18:43.421933 rcvd [LCP ConfAck id=0x2]
17:18:43.421949 sent [LCP EchoReq id=0x0 magic=0x0]
17:18:43.421995 sent [CCP ConfReq id=0x1 <deflate 15> <deflate(old#) 15> <bsd v1 15>]
17:18:43.422006 sent [IPCP ConfReq id=0x1 <compress VJ 0f 01> <addr 192.0.2.2>]
17:18:43.422023 sent [IPV6CP ConfReq id=0x1 <addr fe80::05c2:ec16:79de:fee7>]
17:18:43.423343 rcvd [LCP ProtRej id=0x1 80 fd 01 01 00 0f 1a 04 78 00 18 04 78 00 15]
17:18:43.423359 Protocol-Reject for 'Compression Control Protocol' (0x80fd) received
17:18:43.423728 rcvd [IPCP ConfReq id=0x1 <addr 0.0.0.0> <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
17:18:43.423745 sent [IPCP ConfRej id=0x1 <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
17:18:43.423752 rcvd [IPV6CP ConfReq id=0x1 <addr fe80::0000:5eff:fe00:53fe>]
17:18:43.423758 sent [IPV6CP ConfAck id=0x1 <addr fe80::0000:5eff:fe00:53fe>]
17:18:43.423776 rcvd [LCP EchoRep id=0x0 magic=0x0]
17:18:43.424027 rcvd [IPCP ConfRej id=0x1 <compress VJ 0f 01>]
17:18:43.424042 sent [IPCP ConfReq id=0x2 <addr 192.0.2.2>]
17:18:43.425412 rcvd [IPV6CP ConfAck id=0x1 <addr fe80::05c2:ec16:79de:fee7>]
17:18:43.425562 local  LL address fe80::05c2:ec16:79de:fee7
17:18:43.425578 remote LL address fe80::0000:5eff:fe00:53fe
17:18:43.425844 Script /etc/ppp/ipv6-up started (pid 104247)
17:18:43.425860 rcvd [IPCP ConfAck id=0x2 <addr 192.0.2.2>]
17:18:43.427735 Script /etc/ppp/ipv6-up finished (pid 104247), status = 0x0
```

This is pppd behavior **after** this change:
```
17:19:19.871713 rcvd [LCP ConfReq id=0x1]
17:19:19.871742 sent [LCP ConfReq id=0x1 <asyncmap 0x0> <magic 0x2b1ca961> <pcomp> <accomp>]
17:19:19.871750 sent [LCP ConfAck id=0x1]
17:19:19.873785 rcvd [LCP ConfRej id=0x1 <asyncmap 0x0> <magic 0x2b1ca961> <pcomp> <accomp>]
17:19:19.873801 sent [LCP ConfReq id=0x2]
17:19:19.875289 rcvd [LCP ConfAck id=0x2]
17:19:19.875305 sent [LCP EchoReq id=0x0 magic=0x0]
17:19:19.875344 sent [CCP ConfReq id=0x1 <deflate 15> <deflate(old#) 15> <bsd v1 15>]
17:19:19.875352 sent [IPCP ConfReq id=0x1 <compress VJ 0f 01> <addr 192.0.2.2>]
17:19:19.875359 sent [IPV6CP ConfReq id=0x1 <addr fe80::74b0:b0a3:bc1d:f7ef>]
17:19:19.875374 rcvd [IPCP ConfReq id=0x1 <addr 0.0.0.0> <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
17:19:19.875381 sent [IPCP ConfRej id=0x1 <ms-dns1 0.0.0.0> <ms-dns2 0.0.0.0>]
17:19:19.876190 rcvd [LCP ProtRej id=0x1 80 fd 01 01 00 0f 1a 04 78 00 18 04 78 00 15]
17:19:19.876205 Protocol-Reject for 'Compression Control Protocol' (0x80fd) received
17:19:19.876566 rcvd [IPV6CP ConfReq id=0x1 <addr fe80::0000:5eff:fe00:531a>]
17:19:19.876581 sent [IPV6CP ConfAck id=0x1 <addr fe80::0000:5eff:fe00:531a>]
17:19:19.876589 rcvd [LCP EchoRep id=0x0 magic=0x0]
17:19:19.876749 rcvd [IPCP ConfRej id=0x1 <compress VJ 0f 01>]
17:19:19.876764 sent [IPCP ConfReq id=0x2 <addr 192.0.2.2>]
17:19:19.881948 rcvd [IPV6CP ConfAck id=0x1 <addr fe80::74b0:b0a3:bc1d:f7ef>]
17:19:19.882082 local  LL address fe80::74b0:b0a3:bc1d:f7ef
17:19:19.882101 remote LL address fe80::0000:5eff:fe00:531a
17:19:19.882425 Script /etc/ppp/ipv6-up started (pid 104451)
17:19:19.882455 rcvd [IPCP ConfAck id=0x2 <addr 192.0.2.2>]
17:19:19.884342 Script /etc/ppp/ipv6-up finished (pid 104451), status = 0x0
```