### PR TITLE
samples: net: azure: Avoid negative array index write

### DIFF
--- a/samples/net/cloud/mqtt_azure/src/main.c
+++ b/samples/net/cloud/mqtt_azure/src/main.c
@@ -249,8 +249,9 @@ static void mqtt_event_handler(struct mqtt_client *const client,
 					data,
 					len >= sizeof(data) - 1 ?
 					sizeof(data) - 1 : len);
-			if (bytes_read < 0 && bytes_read != -EAGAIN) {
-				LOG_ERR("failure to read payload");
+			if (bytes_read < 0) {
+				LOG_ERR("failure to read payload (%d)",
+					bytes_read);
 				break;
 			}
 


### PR DESCRIPTION
If the mqtt_read_publish_payload() returns <0 value, then do
not use that value when accessing the data array.

Fixes: #25775
Coverity-CID: 210075

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>