### PR TITLE
Winc1500 shield

### DIFF
--- a/boards/arm/frdm_k64f/pinmux.c
+++ b/boards/arm/frdm_k64f/pinmux.c
@@ -155,6 +155,13 @@ static int frdm_k64f_pinmux_init(struct device *dev)
 		       PORT_PCR_PE_MASK | PORT_PCR_PS_MASK);
 #endif
 
+#if CONFIG_SHIELD_ADAFRUIT_WINC1500
+	/* IRQ, ENable, RST */
+	pinmux_pin_set(portc,  3, PORT_PCR_MUX(kPORT_MuxAsGpio));
+	pinmux_pin_set(portc,  2, PORT_PCR_MUX(kPORT_MuxAsGpio));
+	pinmux_pin_set(porta,  2, PORT_PCR_MUX(kPORT_MuxAsGpio));
+#endif
+
 	return 0;
 }
 

--- a/boards/shields/adafruit_winc1500/Kconfig.defconfig
+++ b/boards/shields/adafruit_winc1500/Kconfig.defconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 Kim Bøndergaard <kim.bondergaard@prevas.dk>, Prevas A/S
+# SPDX-License-Identifier: Apache-2.0
+
+if SHIELD_ADAFRUIT_WINC1500
+
+if NETWORKING
+
+config SPI
+	default y
+
+config WIFI_WINC1500
+	default y
+
+config WIFI
+	default y
+
+endif #NETWORKING
+
+endif # SHIELD_ADAFRUIT_WINC1500

--- a/boards/shields/adafruit_winc1500/Kconfig.shield
+++ b/boards/shields/adafruit_winc1500/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2020 Kim Bøndergaard <kim.bondergaard@prevas.dk>, Prevas A/S
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_ADAFRUIT_WINC1500
+	def_bool $(shields_list_contains,adafruit_winc1500)

--- a/boards/shields/adafruit_winc1500/adafruit_winc1500.overlay
+++ b/boards/shields/adafruit_winc1500/adafruit_winc1500.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2020 Kim Bøndergaard, <kim.bondergaard@prevas.dk>, Prevas A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&arduino_spi {
+	status = "okay";
+	cs-gpios = <&arduino_header 16 0>;			/* D10 */
+
+	winc1500@0 {
+		status = "ok";
+		compatible = "atmel,winc1500";
+		reg = <0x0>;
+		label = "winc1500";
+		spi-max-frequency = <4000000>;
+		irq-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>;	/* D7 */
+		reset-gpios = <&arduino_header 11 GPIO_ACTIVE_LOW>;	/* D5 */
+		enable-gpios = <&arduino_header 12 0>;			/* D6 */
+	};
+};

--- a/boards/shields/adafruit_winc1500/doc/index.rst
+++ b/boards/shields/adafruit_winc1500/doc/index.rst
@@ -1,0 +1,70 @@
+.. _adafruit_winc1500:
+
+Adafruit WINC1500 Wifi Shield
+#############################
+
+Overview
+********
+
+The Adafruit WINC1500 Wifi shield is an Arduino
+compatible shield based on the ATWINC1500 wifi controller
+from Microchip.
+The shield also provides a micro SD card socket
+
+The SD card socket is currently not supported
+
+More information about the shield can be found
+at the `Adafruit WINC1500 website`_.
+
+Pins Assignment of the Adafruit WINC1500 WiFi Shield
+====================================================
+
++-----------------------+---------------------------------------------+
+| Shield Connector Pin  | Function                                    |
++=======================+=============================================+
+| D4                    | MicroSD SPI CSn  (Not supported)            |
++-----------------------+---------------------------------------------+
+| D5                    | WINC1500 RST     (/Reset of winc1500)       |
++-----------------------+---------------------------------------------+
+| D6 (b)                | WINC1500 EN      (Enable of winc1500)       |
++-----------------------+---------------------------------------------+
+| D7                    | WINC1500 IRQ     (IRQ from winc1500)        |
++-----------------------+---------------------------------------------+
+| D10                   | WINC1500 SPI CSn                            |
++-----------------------+---------------------------------------------+
+| D11 (a)               | SPI MOSI         (Serial Data Input)        |
++-----------------------+---------------------------------------------+
+| D12 (a)               | SPI MISO         (Serial Data Out)          |
++-----------------------+---------------------------------------------+
+| D13 (a)               | SPI SCK          (Serial Clock Input)       |
++-----------------------+---------------------------------------------+
+
+The pins marked (a) must be jumpered to the SPI port at the shield
+To enable low power support, wire the pin marked (b) to the En connector
+at the shield
+
+Requirements
+************
+
+This shield can only be used with a board which provides a configuration
+for Arduino connectors and defines node aliases for SPI and GPIO interfaces
+(see :ref:`shields` for more details).
+
+Programming
+***********
+
+Set ``-DSHIELD=adafruit_winc1500`` when you invoke ``west build``. For example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/net/wifi
+   :board: frdm_k64f
+   :shield: adafruit_winc1500
+   :goals: build
+
+References
+**********
+
+.. target-notes::
+
+.. _Adafruit WINC1500 website:
+   https://learn.adafruit.com/adafruit-winc1500-wifi-shield-for-arduino


### PR DESCRIPTION
Support for the Adafruit WINC1500 Wifi shield. 

It can be tested using samples/net/wifi on board frdm_k64f

west build -b frdm_k64f  zephyr/samples/net/wifi --  -DSHIELD=adafruit_winc1500
west flash --runner jlink

Notice the required jumpers (solderings) at the shield