### PR TITLE
tests: add check return value in futex_wake()

### DIFF
--- a/tests/kernel/mem_protect/futex/src/main.c
+++ b/tests/kernel/mem_protect/futex/src/main.c
@@ -473,10 +473,12 @@ void futex_wait_wake(void *p1, void *p2, void *p3)
 void futex_wake(void *p1, void *p2, void *p3)
 {
 	int32_t atomic_ret_val;
+	int32_t ret_value;
 
 	k_futex_wake(&simple_futex, false);
 
-	k_futex_wait(&simple_futex, 13, K_FOREVER);
+	ret_value = k_futex_wait(&simple_futex, 13, K_FOREVER);
+	zassert_equal(ret_value, 0, NULL);
 
 	/* Test user can write to the futex value
 	 * Use assertion to verify substraction correctness


### PR DESCRIPTION
Inside function futex_wake() result of   k_futex_wait() is not checked.
Coverity-CID: 211508
Fixes: #27149

Signed-off-by: Maksim Masalski maksim.masalski@intel.com