### PR TITLE
test: add filters to save test time for kernel tests

### DIFF
--- a/tests/kernel/mem_protect/userspace/testcase.yaml
+++ b/tests/kernel/mem_protect/userspace/testcase.yaml
@@ -1,6 +1,7 @@
 tests:
   kernel.memory_protection.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE
+    min_ram: 34
     tags: kernel security userspace ignore_faults
   kernel.memory_protection.userspace.gap_filling.arc:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS

--- a/tests/kernel/sched/schedule_api/testcase.yaml
+++ b/tests/kernel/sched/schedule_api/testcase.yaml
@@ -3,19 +3,23 @@ tests:
     filter: not CONFIG_SCHED_MULTIQ
     extra_configs:
       - CONFIG_TIMESLICING=y
+    min_ram: 36
     tags: kernel threads sched userspace
   kernel.scheduler.no_timeslicing:
     filter: not CONFIG_SCHED_MULTIQ
     extra_configs:
       - CONFIG_TIMESLICING=n
+    min_ram: 36
     tags: kernel threads sched userspace
   kernel.scheduler.multiq:
     extra_args: CONF_FILE=prj_multiq.conf
     extra_configs:
       - CONFIG_TIMESLICING=y
+    min_ram: 36
     tags: kernel threads sched userspace
   kernel.scheduler.multiq_no_timeslicing:
     extra_args: CONF_FILE=prj_multiq.conf
     extra_configs:
       - CONFIG_TIMESLICING=n
+    min_ram: 36
     tags: kernel threads sched userspace


### PR DESCRIPTION
some platform does not have enough SRAM
so use filter to skip the build check.

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>