### PR TITLE
tests: drivers: pwm: pwm_api: add support of STM32 boards

### DIFF
--- a/tests/drivers/pwm/pwm_api/src/test_pwm.c
+++ b/tests/drivers/pwm/pwm_api/src/test_pwm.c
@@ -38,6 +38,10 @@
 #define PWM_DEV_NAME DT_LABEL(DT_ALIAS(pwm_2))
 #elif DT_NODE_HAS_STATUS(DT_ALIAS(pwm_3), okay)
 #define PWM_DEV_NAME DT_LABEL(DT_ALIAS(pwm_3))
+
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_pwm)
+#define PWM_DEV_NAME DT_LABEL(DT_INST(0, st_stm32_pwm))
+
 #else
 #error "Define a PWM device"
 #endif
@@ -65,6 +69,8 @@
 #define DEFAULT_PWM_PORT DT_PROP(DT_ALIAS(pwm_0), ch0_pin)
 #elif defined CONFIG_BOARD_ADAFRUIT_ITSYBITSY_M4_EXPRESS
 #define DEFAULT_PWM_PORT 2 /* TCC1/WO[2] on PA18 (D7) */
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_pwm)
+#define DEFAULT_PWM_PORT 1
 #else
 #define DEFAULT_PWM_PORT 0
 #endif

--- a/tests/drivers/pwm/pwm_api/testcase.yaml
+++ b/tests/drivers/pwm/pwm_api/testcase.yaml
@@ -4,5 +4,6 @@ tests:
     filter: dt_alias_exists("pwm-0") or
             dt_alias_exists("pwm-1") or
             dt_alias_exists("pwm-2") or
-            dt_alias_exists("pwm-3")
+            dt_alias_exists("pwm-3") or
+            dt_compat_enabled("st,stm32-pwm")
     depends_on: pwm


### PR DESCRIPTION
Add generic support of STM32 boards to tests/drivers/pwm/pwm_api

Passed on automatic test bench on following boards: 
nucleo_f746zg, nucleo_wb55rg, nucleo_g474re, nucleo_l4r5zi, nucleo_f429zi, nucleo_f103rb, disco_l475_iot1

