### PR TITLE
Bluetooth: GATT: Unregister CCC when unregistering services

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -309,6 +309,10 @@ struct bt_gatt_cpf {
  *  macros such as BT_GATT_PRIMARY_SERVICE, BT_GATT_CHARACTERISTIC,
  *  BT_GATT_DESCRIPTOR, etc.
  *
+ *  When using :option:`CONFIG_BT_SETTINGS` then all services that should have
+ *  bond configuration loaded, i.e. CCC values, must be registered before
+ *  calling @ref settings_load.
+ *
  *  When using :option:`CONFIG_BT_GATT_CACHING` and :option:`CONFIG_BT_SETTINGS`
  *  then all services that should be included in the GATT Database Hash
  *  calculation should be added before calling @ref settings_load.

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -947,6 +947,13 @@ static void sc_process(struct k_work *work)
 	atomic_set_bit(sc->flags, SC_INDICATE_PENDING);
 }
 
+static void clear_ccc_cfg(struct bt_gatt_ccc_cfg *cfg)
+{
+	bt_addr_le_copy(&cfg->peer, BT_ADDR_LE_ANY);
+	cfg->id = 0U;
+	cfg->value = 0U;
+}
+
 #if defined(CONFIG_BT_SETTINGS_CCC_STORE_ON_WRITE)
 static struct gatt_ccc_store {
 	struct bt_conn *conn_list[CONFIG_BT_MAX_CONN];
@@ -1440,13 +1447,6 @@ struct bt_gatt_attr *bt_gatt_attr_next(const struct bt_gatt_attr *attr)
 	bt_gatt_foreach_attr(handle + 1, handle + 1, find_next, &next);
 
 	return next;
-}
-
-static void clear_ccc_cfg(struct bt_gatt_ccc_cfg *cfg)
-{
-	bt_addr_le_copy(&cfg->peer, BT_ADDR_LE_ANY);
-	cfg->id = 0U;
-	cfg->value = 0U;
 }
 
 static struct bt_gatt_ccc_cfg *find_ccc_cfg(const struct bt_conn *conn,


### PR DESCRIPTION
Fix issue with bt_gatt_service_unregister not clearing CCC information.

If the service is unregistered while an unbonded peer is connected and
subscribed then this CCC would be restored again when registering the
service even if the peer is now disconnected.

If the service is unregistered with bonded peers CCCs stored in settings
then this value would never be cleared. If the service is registered
again then the peer would receive a service changed for this service,
but it's CCC value would still be enabled.

Fixes: #26924

