### PR TITLE
tests: settings: Fix unchecked return value

### DIFF
--- a/tests/subsys/settings/littlefs/src/settings_setup_littlefs.c
+++ b/tests/subsys/settings/littlefs/src/settings_setup_littlefs.c
@@ -26,7 +26,7 @@ void config_setup_littlefs(void)
 	rc = flash_area_open(FLASH_AREA_ID(littlefs_dev), &fap);
 	zassert_true(rc == 0, "opening flash area for erase [%d]\n", rc);
 
-	flash_area_erase(fap, fap->fa_off, fap->fa_size);
+	rc = flash_area_erase(fap, fap->fa_off, fap->fa_size);
 	zassert_true(rc == 0, "erasing flash area [%d]\n", rc);
 
 	rc = fs_mount(&littlefs_mnt);


### PR DESCRIPTION
A value returned by flash_area_erase has not been checked.

Fixes #25728
Coverity-CID: 210050

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>