### PR TITLE
drivers: clock_control: stm32h7 fix high frequency setting

### DIFF
--- a/drivers/clock_control/Kconfig.stm32h7
+++ b/drivers/clock_control/Kconfig.stm32h7
@@ -5,6 +5,17 @@
 
 if SOC_SERIES_STM32H7X
 
+# Oscillator clocks configuration options
+
+config CLOCK_STM32_HSI_DIVISOR
+	int "HSI Divisor"
+	depends on CLOCK_STM32_PLL_SRC_HSI || CLOCK_STM32_SYSCLK_SRC_HSI
+	default 1
+	range 1 8
+	help
+	  HSI Divisor to divide HSI base frequency value
+	  allowed values: 1, 2, 4, 8
+
 # Bus clocks configuration options
 
 config CLOCK_STM32_D1CPRE

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -91,7 +91,7 @@ static int32_t get_vco_input_range(uint32_t pllsrc_clock, uint32_t divm)
 {
 	const uint32_t input_freq = pllsrc_clock/divm;
 
-	__ASSERT(input_freq < 1000000UL || input_freq > 16000000UL,
+	__ASSERT(input_freq >= 1000000UL && input_freq <= 16000000UL,
 			"PLL1 VCO frequency input range out of range");
 
 	if (1000000UL <= input_freq && input_freq <= 2000000UL) {
@@ -365,7 +365,7 @@ static int stm32_clock_control_init(struct device *dev)
 			pllsrc_clock,
 			CONFIG_CLOCK_STM32_PLL_M_DIVISOR);
 
-	__ASSERT(vco_input_range == -ERANGE, "PLL VCO input frequency out of range. Should be from 1 to 16 MHz");
+	__ASSERT(vco_input_range != -ERANGE, "PLL VCO input frequency out of range. Should be from 1 to 16 MHz");
 
 	vco_output_range = get_vco_output_range(vco_input_range);
 

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -398,13 +398,24 @@ static int stm32_clock_control_init(struct device *dev)
 	/* PLL will stay in reset state configuration */
 #endif /* CONFIG_CLOCK_STM32_PLL_SRC_* */
 
+
+	/* Preset the prescalers prior to chosing SYSCLK */
+	/* Prevents APB clock to go over limits */
+	/* Set buses (Sys,AHB, APB1, APB2 & APB4) prescalers */
+	LL_RCC_SetSysPrescaler(sysclk_prescaler(CONFIG_CLOCK_STM32_D1CPRE));
+	LL_RCC_SetAHBPrescaler(ahb_prescaler(CONFIG_CLOCK_STM32_HPRE));
+	LL_RCC_SetAPB1Prescaler(apb1_prescaler(CONFIG_CLOCK_STM32_D2PPRE1));
+	LL_RCC_SetAPB2Prescaler(apb2_prescaler(CONFIG_CLOCK_STM32_D2PPRE2));
+	LL_RCC_SetAPB3Prescaler(apb3_prescaler(CONFIG_CLOCK_STM32_D1PPRE));
+	LL_RCC_SetAPB4Prescaler(apb4_prescaler(CONFIG_CLOCK_STM32_D3PPRE));
+
+
 #if defined(CONFIG_CLOCK_STM32_SYSCLK_SRC_PLL)
 
 	/* Enable PLL*/
 	LL_RCC_PLL1_Enable();
 	while (LL_RCC_PLL1_IsReady() != 1) {
 	}
-
 
 	/* Set PLL1 as System Clock Source */
 	LL_RCC_SetSysClkSource(LL_RCC_SYS_CLKSOURCE_PLL1);
@@ -448,14 +459,6 @@ static int stm32_clock_control_init(struct device *dev)
 	}
 
 #endif /* CLOCK_STM32_SYSCLK_SRC */
-
-	/* Set buses (Sys,AHB, APB1, APB2 & APB4) prescalers */
-	LL_RCC_SetSysPrescaler(sysclk_prescaler(CONFIG_CLOCK_STM32_D1CPRE));
-	LL_RCC_SetAHBPrescaler(ahb_prescaler(CONFIG_CLOCK_STM32_HPRE));
-	LL_RCC_SetAPB1Prescaler(apb1_prescaler(CONFIG_CLOCK_STM32_D2PPRE1));
-	LL_RCC_SetAPB2Prescaler(apb2_prescaler(CONFIG_CLOCK_STM32_D2PPRE2));
-	LL_RCC_SetAPB3Prescaler(apb3_prescaler(CONFIG_CLOCK_STM32_D1PPRE));
-	LL_RCC_SetAPB4Prescaler(apb4_prescaler(CONFIG_CLOCK_STM32_D3PPRE));
 
 	/* Set FLASH latency */
 	/* AXI clock is SYSCLK / HPRE */


### PR DESCRIPTION
Fixes #27212 by setting the APBx dividers to maximum
prior to configuring the PLL as clock source.

**Fix related updates:**
They are then set to correct values once the PLL
has been configured.

Prevents going over the limits of APBx clocks when
choosing the PLL as system clock source for
high frequencies (close to 480MHz) which crashes
the MCU clock system.

**Reliability and coherence updates:**
Flash latency setting has been reworked to comply
with the adviced method from STM32 reference manuals
and align with common stm32 method.

**UX updates:**
Preprocessor guard system prevents the user from 
choosing invalid clock configurations.

**HSI divider support** is now added for STM32H7 series
and fully integrated in the clock check procedures.
Configurable with:
**CONFIG_CLOCK_STM32_HSI_DIVISOR** set to 1 by default 
to not break existing boards configurations.

Signed-off-by: Jeremy LOCHE <lochejeremy@gmail.com>