### PR TITLE
kernel: syscalls: ignore coding violation of redefined log vars

### DIFF
--- a/cmake/compiler/gcc/target_warnings.cmake
+++ b/cmake/compiler/gcc/target_warnings.cmake
@@ -12,6 +12,13 @@ macro(toolchain_cc_warning_base)
     -Wno-main
   )
 
+  # Need to ignore Coverity related pragmas in macros,
+  # as _Pragma("GCC diagnostics ...") inside those macros
+  # has no effects.
+  zephyr_compile_options(
+    -Wno-unknown-pragmas
+  )
+
 if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "9.1.0")
   zephyr_compile_options(
     # FIXME: Remove once #16587 is fixed

--- a/include/syscall_handler.h
+++ b/include/syscall_handler.h
@@ -311,7 +311,12 @@ extern int z_user_string_copy(char *dst, const char *src, size_t maxlen);
 #define Z_SYSCALL_VERIFY_MSG(expr, fmt, ...) ({ \
 	bool expr_copy = !(expr); \
 	if (expr_copy) { \
+		_Pragma("coverity compliance block deviate \
+			'MISRA C-2012 Rule 5.3' \
+			'LOG_MODULE_DECLARE() re-defines variables'"); \
 		LOG_MODULE_DECLARE(os); \
+		_Pragma("coverity compliance end_block \
+			'MISRA C-2012 Rule 5.3'"); \
 		LOG_ERR("syscall %s failed check: " fmt, \
 			__func__, ##__VA_ARGS__); \
 	} \


### PR DESCRIPTION
MISRA-C Rule 5.3 states that identifiers in inner scope should
not hide identifiers in outer scope. In Z_SYSCALL_VERIFY_MSG(),
it explicitly declare log module via LOG_MODULE_DECLARE() with
brackets. This raises a coding violation if a log module has
already been declared outside. In order to keep the logging
functionality in there, hint to Coverity to ignore rule 5.3
for those re-declared variables as the following LOG_ERR()
requires all these variables to work correctly.

Note that "--ignore-deviated-findings" needs to be passed to
cov-analyze for _Pragma() to have effect.

Another note is that "-Wno-unknown-pragmas" is needed so
GCC won't complain the Coverity pragmas. However, _Pragma()
inside the macro has no effect unless "-no-integrated-cpp"
is passed to GCC. This separates the preprocessing and
compiling into two steps which lengthens the build time.
Hence, "-Wno-unknown-pragmas" is used instead.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>