### PR TITLE
kernel: work_q: ignore coding violation of requiring...

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3381,7 +3381,12 @@ static inline void k_work_submit(struct k_work *work)
 static inline int k_delayed_work_submit(struct k_delayed_work *work,
 					k_timeout_t delay)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#pragma coverity compliance fp "MISRA C-2012 Directive 4.7" \
+			       "No need to check return value here"
 	return k_delayed_work_submit_to_queue(&k_sys_work_q, work, delay);
+#pragma GCC diagnostic pop
 }
 
 /**


### PR DESCRIPTION
...checking return value where it is a simply pass-through.

MISRA-C Directive 4.7 requires checking the return value from
functions. But in k_delayed_work_submit(), the return value can
be passed directly back to caller with the need to check it
within the function. So hint to Coverity that it is not a coding
violation. Note that "--ignore-deviated-findings" needs to be
passed to cov-analyze for #pragma to have effect.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>