### PR TITLE
ci: make test_file.txt a build artifact for debug

### DIFF
--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -49,6 +49,10 @@ fi
 mv sanity-out/sanitycheck.xml sanitycheck-${BUILDKITE_JOB_ID}.xml
 buildkite-agent artifact upload sanitycheck-${BUILDKITE_JOB_ID}.xml
 
+
+# Upload test_file to get list of tests that are build/run
+buildkite-agent artifact upload test_file.txt
+
 # ccache stats
 echo "--- ccache stats at finish"
 ccache -s

--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -269,7 +269,7 @@ if [ -n "$main_ci" ]; then
 	tail -n +2 test_file_1.txt > test_file_1_in.txt
 	cat test_file_3.txt test_file_2_in.txt test_file_1_in.txt > test_file.txt
 
-	cat test_file.txt
+	buildkite-agent artifact upload test_file.txt
 
 	echo "+++ run sanitycheck"
 


### PR DESCRIPTION
Rather that echo'ng the test_file.txt to the console, lets just upload
it as a buildkite artifact.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>