### PR TITLE
lib: updatehub: Fix out-of-bounds access and add flash_img_init return value check

### DIFF
--- a/lib/updatehub/updatehub.c
+++ b/lib/updatehub/updatehub.c
@@ -501,7 +501,11 @@ static enum updatehub_response install_update(void)
 		goto cleanup;
 	}
 
-	flash_img_init(&ctx.flash_ctx);
+	if (flash_img_init(&ctx.flash_ctx)) {
+		LOG_ERR("Unable init flash");
+		ctx.code_status = UPDATEHUB_FLASH_INIT_ERROR;
+		goto cleanup;
+	}
 
 	ctx.downloaded_size = 0;
 	updatehub_blk_set(UPDATEHUB_BLK_ATTEMPT, 0);

--- a/lib/updatehub/updatehub.c
+++ b/lib/updatehub/updatehub.c
@@ -216,11 +216,16 @@ static bool start_coap_client(void)
 
 static void cleanup_connection(void)
 {
+	int i;
+
 	if (close(ctx.sock) < 0) {
 		LOG_ERR("Could not close the socket");
 	}
 
-	memset(&ctx.fds[1], 0, sizeof(ctx.fds[1]));
+	for (i = 0; i < ctx.nfds; i++) {
+		memset(&ctx.fds[i], 0, sizeof(ctx.fds[i]));
+	}
+
 	ctx.nfds = 0;
 	ctx.sock = 0;
 }
@@ -737,6 +742,8 @@ enum updatehub_response updatehub_probe(void)
 		ctx.code_status = UPDATEHUB_METADATA_ERROR;
 		goto error;
 	}
+
+	ctx.nfds = 0;
 
 	if (!start_coap_client()) {
 		ctx.code_status = UPDATEHUB_NETWORKING_ERROR;


### PR DESCRIPTION
The flash_img_int return value is not checked for fail conditions. This can result on useless download attempts once image will not be properly recorded. Add return value check and on error execute default treatment.
Fixes #26992.

The struct pollfd context variable is not proper initialized and index is out-of-bounds. Adjusts index to be inside scope boundary.
Fixes #26993.

CC: @otavio