### PR TITLE
boards: arm: lpcxpresso55s16: reset soc after loading via jlink

### DIFF
--- a/boards/arm/lpcxpresso55s16/board.cmake
+++ b/boards/arm/lpcxpresso55s16/board.cmake
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-board_runner_args(jlink "--device=LPC55S16")
+board_runner_args(jlink "--device=LPC55S16" "--reset-after-load")
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Reset the LPC55S16 after loading data to the flash via Segger J-Link (previously, the new firmware was not booted until the reset button on the board was pressed).

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>