### PR TITLE
drivers: flash: nrf: Fix regression with BT_CTLR_LOW_LAT option

### DIFF
--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -416,10 +416,14 @@ static void time_slot_callback_abort(uint32_t ticks_at_expire, uint32_t remainde
 static void time_slot_callback_prepare(uint32_t ticks_at_expire, uint32_t remainder,
 				       uint16_t lazy, void *context)
 {
+#if defined(CONFIG_BT_CTLR_LOW_LAT)
+	time_slot_callback_abort(ticks_at_expire, remainder, lazy, context);
+#else /* !CONFIG_BT_CTLR_LOW_LAT */
 	time_slot_delay(ticks_at_expire,
 			HAL_TICKER_US_TO_TICKS(FLASH_RADIO_ABORT_DELAY_US),
 			time_slot_callback_abort,
 			context);
+#endif /* CONFIG_BT_CTLR_LOW_LAT */
 }
 
 static int work_in_time_slice(struct flash_op_desc *p_flash_op_desc)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -754,7 +754,7 @@ static void mfy_ticker_job_idle_get(void *param)
 
 	/* Ticker Job Silence */
 	ret = ticker_job_idle_get(TICKER_INSTANCE_ID_CTLR,
-				  TICKER_USER_ID_LLL,
+				  TICKER_USER_ID_ULL_LOW,
 				  ticker_op_job_disable, NULL);
 	LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
 		  (ret == TICKER_STATUS_BUSY));


### PR DESCRIPTION
Fix a regression that caused flashing on nRF51x Series to stall
the Bluetooth low energy controller and flashing under
BT_CTLR_LOW_LAT option.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>