### PR TITLE
drivers: serial: nrf_uarte: Remove counters reset from rx_enable

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -542,21 +542,12 @@ static int uarte_nrfx_rx_enable(struct device *dev, uint8_t *buf, size_t len,
 				int32_t timeout)
 {
 	struct uarte_nrfx_data *data = get_dev_data(dev);
-	const struct uarte_nrfx_config *cfg = get_dev_config(dev);
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 
 	if (nrf_uarte_rx_pin_get(uarte) == NRF_UARTE_PSEL_DISCONNECTED) {
 		__ASSERT(false, "TX only UARTE instance");
 		return -ENOTSUP;
 	}
-
-	if (hw_rx_counting_enabled(data)) {
-		nrfx_timer_clear(&cfg->timer);
-	} else {
-		data->async->rx_cnt.cnt = 0;
-	}
-	data->async->rx_total_byte_cnt = 0;
-	data->async->rx_total_user_byte_cnt = 0;
 
 	data->async->rx_timeout = timeout;
 	data->async->rx_timeout_slab =


### PR DESCRIPTION
uart_rx_enable might be called after reception is stopped by lack
of buffers with flow control enabled. In that case there is a couple
of bytes kept in the HW FIFO. When HW TIMER is used for byte counting,
it is using RXDRDY event to count bytes. RXDRDY event is generated when
byte is received in RXD. RXD is the head of HW FIFO. When DMA ends and
ENDRX event is generated, transmitter still transmits until RTS line goes
high and transmitter reacts to it and stops transmitting. First byte
received after ENDRX lands in RXD (and generates RXDRDY event), next
by goes to RXD+1 (does not generate RXRDY event).
    
RXDRDY event after ENDRX is counted by the TIMER. If TIMER is reset
before restarting RX this byte is lost in the calculation. Because of
that byte counters cannot be reset before enabling RX thus move to
initialization. It applies only to HW counting but to keep it consistent
resetting was moved for both modes.


Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>