### PR TITLE
sanitycheck: support --filter to limit number of tests built

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -470,9 +470,19 @@ Artificially long but functional example:
         "--test-only", action="store_true",
         help="""Only run device tests with current artifacts, do not build
              the code""")
+
     parser.add_argument(
         "--cmake-only", action="store_true",
         help="Only run cmake, do not build or run.")
+
+    parser.add_argument(
+        "--filter", choices=['buildable', 'runnable'],
+        default='buildable',
+        help="""Filter tests to be built and executed. By default everything is
+        built and if a test is runnable (emulation or a connected device), it
+        is run. This option allows for example to only build tests that can
+        actually be run. Runnable is a subset of buildable.""")
+
 
     parser.add_argument(
         "-M", "--runtime-artifact-cleanup", action="store_true",
@@ -1004,7 +1014,6 @@ def main():
         suite.selected_platforms = set(p.platform.name for p in suite.instances.values())
     else:
         discards = suite.apply_filters(
-            build_only=options.build_only,
             enable_slow=options.enable_slow,
             platform=options.platform,
             exclude_platform=options.exclude_platform,
@@ -1015,7 +1024,7 @@ def main():
             all=options.all,
             emulation_only=options.emulation_only,
             run_individual_tests=run_individual_tests,
-            device_testing=options.device_testing,
+            runnable=(options.device_testing or options.filter == 'runnable'),
             force_platform=options.force_platform
 
         )

--- a/scripts/tests/sanitycheck/test_data/testcases/tests/test_a/test_data.yaml
+++ b/scripts/tests/sanitycheck/test_data/testcases/tests/test_a/test_data.yaml
@@ -1,6 +1,7 @@
 tests:
   test_a.check_1:
     tags: test_a
+    build_only: True
   test_a.check_2:
     extra_args: CONF_FILE="test.conf"
     tags: test_a

--- a/scripts/tests/sanitycheck/test_testinstance.py
+++ b/scripts/tests/sanitycheck/test_testinstance.py
@@ -43,12 +43,12 @@ def test_check_build_or_run(class_testsuite, monkeypatch, all_testcases_dict, pl
     testcase.slow = slow
 
     testinstance = TestInstance(testcase, platform, class_testsuite.outdir)
-    run = testinstance.check_build_or_run(build_only, slow, device_testing, fixture)
-    b, r = expected
+    run = testinstance.check_runnable(slow, device_testing, fixture)
+    _, r = expected
     assert run == r
 
     monkeypatch.setattr("os.name", "nt")
-    run = testinstance.check_build_or_run()
+    run = testinstance.check_runnable()
     assert not run
 
 TESTDATA_2 = [

--- a/scripts/tests/sanitycheck/test_testinstance.py
+++ b/scripts/tests/sanitycheck/test_testinstance.py
@@ -43,14 +43,13 @@ def test_check_build_or_run(class_testsuite, monkeypatch, all_testcases_dict, pl
     testcase.slow = slow
 
     testinstance = TestInstance(testcase, platform, class_testsuite.outdir)
-    testinstance.check_build_or_run(build_only, slow, device_testing, fixture)
+    run = testinstance.check_build_or_run(build_only, slow, device_testing, fixture)
     b, r = expected
-    assert testinstance.build_only == b
-    assert testinstance.run == r
+    assert run == r
 
     monkeypatch.setattr("os.name", "nt")
-    testinstance.check_build_or_run()
-    assert testinstance.build_only and not testinstance.run
+    run = testinstance.check_build_or_run()
+    assert not run
 
 TESTDATA_2 = [
     (True, True, True, ["demo_board_2"], "native", '\nCONFIG_COVERAGE=y\nCONFIG_COVERAGE_DUMP=y\nCONFIG_ASAN=y\nCONFIG_UBSAN=y'),

--- a/scripts/tests/sanitycheck/test_testsuite_class.py
+++ b/scripts/tests/sanitycheck/test_testsuite_class.py
@@ -221,7 +221,7 @@ def test_apply_filters_part1(class_testsuite, all_testcases_dict, platforms_list
     assert all(x in list(discards.values()) for x in [expected_discards])
 
 TESTDATA_PART2 = [
-    ("device_testing", "True", "Not runnable on device"),
+    ("runnable", "True", "Not runnable on device"),
     ("exclude_tag", ['test_a'], "Command line testcase exclude filter"),
     ("run_individual_tests", ['scripts/tests/sanitycheck/test_data/testcases/tests/test_a/test_a.check_1'], "Testcase name filter"),
     ("arch", ['arm_test'], "Command line testcase arch filter"),
@@ -236,13 +236,22 @@ def test_apply_filters_part2(class_testsuite, all_testcases_dict,
     Part 2 : Response of apply_filters function (discard dictionary) have
              appropriate values according to the filters
     """
+
     class_testsuite.platforms = platforms_list
     class_testsuite.testcases = all_testcases_dict
-    kwargs = {extra_filter : extra_filter_value,
-              "exclude_platform" : ['demo_board_1'], "platform" : ['demo_board_2']}
+    kwargs = {
+        extra_filter : extra_filter_value,
+        "exclude_platform" : [
+            'demo_board_1'
+            ],
+        "platform" : [
+            'demo_board_2'
+            ]
+        }
     discards = class_testsuite.apply_filters(**kwargs)
-    assert type(list(discards.keys())[0]).__name__ == "TestInstance"
-    assert list(dict.fromkeys(discards.values())) == [expected_discards]
+    assert discards
+    for d in discards.values():
+        assert d == expected_discards
 
 
 TESTDATA_PART3 = [


### PR DESCRIPTION
Use --filter=runnable for example to limit the tests being built to those
which actually can run on a device or a emulation platform.

Fixes #27211