### PR TITLE
west: Add a board-reset command

### DIFF
--- a/boards/common/pyocd.board.cmake
+++ b/boards/common/pyocd.board.cmake
@@ -2,4 +2,5 @@
 
 board_set_flasher_ifnset(pyocd)
 board_set_debugger_ifnset(pyocd)
+board_set_resetter_ifnset(pyocd)
 board_finalize_runner_args(pyocd "--dt-flash=y")

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -621,8 +621,8 @@ endfunction()
 # manages the runners.
 
 function(_board_check_runner_type type) # private helper
-  if (NOT (("${type}" STREQUAL "FLASH") OR ("${type}" STREQUAL "DEBUG")))
-    message(FATAL_ERROR "invalid type ${type}; should be FLASH or DEBUG")
+  if (NOT (("${type}" STREQUAL "FLASH") OR ("${type}" STREQUAL "DEBUG") OR ("${type}" STREQUAL "RESET")))
+    message(FATAL_ERROR "invalid type ${type}; should be FLASH, DEBUG or RESET")
   endif()
 endfunction()
 
@@ -670,6 +670,11 @@ macro(board_set_debugger runner)
   board_set_runner(DEBUG ${runner})
 endmacro()
 
+# A convenience macro for board_set_runner(RESET ${runner}).
+macro(board_set_resetter runner)
+  board_set_runner(RESET ${runner})
+endmacro()
+
 # A convenience macro for board_set_runner_ifnset(FLASH ${runner}).
 macro(board_set_flasher_ifnset runner)
   board_set_runner_ifnset(FLASH ${runner})
@@ -678,6 +683,11 @@ endmacro()
 # A convenience macro for board_set_runner_ifnset(DEBUG ${runner}).
 macro(board_set_debugger_ifnset runner)
   board_set_runner_ifnset(DEBUG ${runner})
+endmacro()
+
+# A convenience macro for board_set_runner_ifnset(RESET ${runner}).
+macro(board_set_resetter_ifnset runner)
+  board_set_runner_ifnset(RESET ${runner})
 endmacro()
 
 # This function is intended for board.cmake files and application

--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -80,6 +80,10 @@ function(create_runners_yaml)
     runners_yaml_append("\n# Default debug runner if --runner is not given.")
     runners_yaml_append("debug-runner: ${BOARD_DEBUG_RUNNER}")
   endif()
+  if(DEFINED BOARD_RESET_RUNNER)
+    runners_yaml_append("\n# Default reset runner if --runner is not given.")
+    runners_yaml_append("reset-runner: ${BOARD_RESET_RUNNER}")
+  endif()
 
   # Sets up common runner configuration values.
   runners_yaml_append_config()
@@ -133,7 +137,7 @@ endif()
 
 # Generate the flash, debug, debugserver, attach targets within the build
 # system itself.
-foreach(target flash debug debugserver attach)
+foreach(target flash debug debugserver attach reset)
   if(target STREQUAL flash)
     set(comment "Flashing ${BOARD}")
   elseif(target STREQUAL debug)
@@ -147,6 +151,8 @@ foreach(target flash debug debugserver attach)
     endif()
   elseif(target STREQUAL attach)
     set(comment "Debugging ${BOARD}")
+  elseif(target STREQUAL reset)
+    set(comment "Reseting ${BOARD}")
   endif()
   string(TOUPPER ${target} TARGET_UPPER)
 

--- a/scripts/west-commands.yml
+++ b/scripts/west-commands.yml
@@ -25,6 +25,11 @@ west-commands:
       - name: flash
         class: Flash
         help: flash and run a binary on a board
+  - file: scripts/west_commands/board-reset.py
+    commands:
+      - name: board-reset
+        class: BoardReset
+        help: reset a board
   - file: scripts/west_commands/debug.py
     commands:
       - name: debug

--- a/scripts/west_commands/board-reset.py
+++ b/scripts/west_commands/board-reset.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2018 Open Source Foundries Limited.
+# Copyright 2019 Foundries.io
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''west "board-reset" command'''
+
+from west.commands import WestCommand
+
+from run_common import add_parser_common, do_run_common
+
+
+class BoardReset(WestCommand):
+
+    def __init__(self):
+        super(BoardReset, self).__init__(
+            'board-reset',
+            # Keep this in sync with the string in west-commands.yml.
+            'reset a board',
+            "Reset a board.",
+            accepts_unknown_args=True)
+        self.runner_key = 'reset-runner'  # in runners.yaml
+
+    def do_add_parser(self, parser_adder):
+        return add_parser_common(self, parser_adder)
+
+    def do_run(self, my_args, runner_args):
+        do_run_common(self, my_args, runner_args)

--- a/scripts/west_commands/runners/pyocd.py
+++ b/scripts/west_commands/runners/pyocd.py
@@ -64,7 +64,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach'},
+        return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach', 'board-reset'},
                           flash_addr=True, erase=True)
 
     @classmethod
@@ -124,6 +124,8 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
         self.require(self.pyocd)
         if command == 'flash':
             self.flash(**kwargs)
+        elif command == 'board-reset':
+            self.boardreset(**kwargs)
         else:
             self.debug_debugserver(command, **kwargs)
 
@@ -156,6 +158,19 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
                [fname])
 
         self.logger.info('Flashing file: {}'.format(fname))
+        self.check_call(cmd)
+
+    def boardreset(self, **kwargs):
+        cmd = ([self.pyocd] +
+               ['commander'] +
+               ['-c', 'reset'] +
+               self.daparg_args +
+               self.target_args +
+               self.board_args +
+               self.frequency_args +
+               self.tool_opt_args)
+
+        self.logger.info('Resetting')
         self.check_call(cmd)
 
     def log_gdbserver_message(self):


### PR DESCRIPTION
Add support for 'west reset' which will reset a board if supported by
the runner.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>