### PR TITLE
Bluetooth: L2CAP: Elevate security level

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2663,7 +2663,11 @@ static void bt_att_encrypt_change(struct bt_l2cap_chan *chan,
 	 * outstanding request about security failure.
 	 */
 	if (hci_status) {
-		att_handle_rsp(att_chan, NULL, 0, BT_ATT_ERR_AUTHENTICATION);
+		if (att_chan->req) {
+			att_handle_rsp(att_chan, NULL, 0,
+				       BT_ATT_ERR_AUTHENTICATION);
+		}
+
 		return;
 	}
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1071,9 +1071,12 @@ uint8_t bt_conn_enc_key_size(struct bt_conn *conn)
 	return 0;
 }
 
-void bt_conn_security_changed(struct bt_conn *conn, enum bt_security_err err)
+void bt_conn_security_changed(struct bt_conn *conn, uint8_t hci_err,
+			      enum bt_security_err err)
 {
 	struct bt_conn_cb *cb;
+
+	bt_l2cap_security_changed(conn, hci_err);
 
 	for (cb = callback_list; cb; cb = cb->_next) {
 		if (cb->security_changed) {

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -264,7 +264,8 @@ void bt_conn_identity_resolved(struct bt_conn *conn);
 
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_BREDR)
 /* Notify higher layers that connection security changed */
-void bt_conn_security_changed(struct bt_conn *conn, enum bt_security_err err);
+void bt_conn_security_changed(struct bt_conn *conn, uint8_t hci_err,
+			      enum bt_security_err err);
 #endif /* CONFIG_BT_SMP || CONFIG_BT_BREDR */
 
 /* Prepare a PDU to be sent over a connection */

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3685,7 +3685,8 @@ static void auth_complete(struct net_buf *buf)
 			 * Inform layers above HCI about non-zero authentication
 			 * status to make them able cleanup pending jobs.
 			 */
-			bt_l2cap_encrypt_change(conn, evt->status);
+			bt_conn_security_changed(conn, evt->status,
+						 security_err_get(evt->status));
 		}
 		reset_pairing(conn);
 	} else {
@@ -4134,8 +4135,8 @@ static void hci_encrypt_change(struct net_buf *buf)
 
 	if (evt->status) {
 		reset_pairing(conn);
-		bt_l2cap_encrypt_change(conn, evt->status);
-		bt_conn_security_changed(conn, security_err_get(evt->status));
+		bt_conn_security_changed(conn, evt->status,
+					 security_err_get(evt->status));
 		bt_conn_unref(conn);
 		return;
 	}
@@ -4179,8 +4180,7 @@ static void hci_encrypt_change(struct net_buf *buf)
 #endif /* CONFIG_BT_BREDR */
 	reset_pairing(conn);
 
-	bt_l2cap_encrypt_change(conn, evt->status);
-	bt_conn_security_changed(conn, BT_SECURITY_ERR_SUCCESS);
+	bt_conn_security_changed(conn, evt->status, BT_SECURITY_ERR_SUCCESS);
 
 	bt_conn_unref(conn);
 }
@@ -4203,8 +4203,8 @@ static void hci_encrypt_key_refresh_complete(struct net_buf *buf)
 
 	if (evt->status) {
 		reset_pairing(conn);
-		bt_l2cap_encrypt_change(conn, evt->status);
-		bt_conn_security_changed(conn, security_err_get(evt->status));
+		bt_conn_security_changed(conn, evt->status,
+					 security_err_get(evt->status));
 		bt_conn_unref(conn);
 		return;
 	}
@@ -4231,8 +4231,7 @@ static void hci_encrypt_key_refresh_complete(struct net_buf *buf)
 #endif /* CONFIG_BT_BREDR */
 
 	reset_pairing(conn);
-	bt_l2cap_encrypt_change(conn, evt->status);
-	bt_conn_security_changed(conn, BT_SECURITY_ERR_SUCCESS);
+	bt_conn_security_changed(conn, evt->status, BT_SECURITY_ERR_SUCCESS);
 	bt_conn_unref(conn);
 }
 #endif /* CONFIG_BT_SMP || CONFIG_BT_BREDR */

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -545,7 +545,7 @@ static void l2cap_le_encrypt_change(struct bt_l2cap_chan *chan, uint8_t status)
 
 void bt_l2cap_encrypt_change(struct bt_conn *conn, uint8_t hci_status)
 {
-	struct bt_l2cap_chan *chan;
+	struct bt_l2cap_chan *chan, *next;
 
 	if (IS_ENABLED(CONFIG_BT_BREDR) &&
 	    conn->type == BT_CONN_TYPE_BR) {
@@ -553,7 +553,7 @@ void bt_l2cap_encrypt_change(struct bt_conn *conn, uint8_t hci_status)
 		return;
 	}
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&conn->channels, chan, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&conn->channels, chan, next, node) {
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 		l2cap_le_encrypt_change(chan, hci_status);
 #endif

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -2361,6 +2361,20 @@ static int l2cap_le_connect(struct bt_conn *conn, struct bt_l2cap_le_chan *ch,
 
 	ch->chan.psm = psm;
 
+	if (conn->sec_level < ch->chan.required_sec_level) {
+		int err;
+
+		err = bt_conn_set_security(conn, ch->chan.required_sec_level);
+		if (err) {
+			return err;
+		}
+
+		atomic_set_bit(ch->chan.status,
+			       BT_L2CAP_STATUS_ENCRYPT_PENDING);
+
+		return 0;
+	}
+
 	return l2cap_le_conn_req(ch);
 }
 

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -551,7 +551,7 @@ fail:
 }
 #endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
 
-void bt_l2cap_encrypt_change(struct bt_conn *conn, uint8_t hci_status)
+void bt_l2cap_security_changed(struct bt_conn *conn, uint8_t hci_status)
 {
 	struct bt_l2cap_chan *chan, *next;
 

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -512,6 +512,8 @@ static int l2cap_ecred_conn_req(struct bt_l2cap_chan **chan, int channels)
 
 static void l2cap_le_encrypt_change(struct bt_l2cap_chan *chan, uint8_t status)
 {
+	int err;
+
 	/* Skip channels that are not pending waiting for encryption */
 	if (!atomic_test_and_clear_bit(chan->status,
 				       BT_L2CAP_STATUS_ENCRYPT_PENDING)) {
@@ -519,9 +521,7 @@ static void l2cap_le_encrypt_change(struct bt_l2cap_chan *chan, uint8_t status)
 	}
 
 	if (status) {
-		bt_l2cap_chan_remove(chan->conn, chan);
-		bt_l2cap_chan_del(chan);
-		return;
+		goto fail;
 	}
 
 	if (chan->ident) {
@@ -539,7 +539,15 @@ static void l2cap_le_encrypt_change(struct bt_l2cap_chan *chan, uint8_t status)
 	}
 
 	/* Retry to connect */
-	l2cap_le_conn_req(BT_L2CAP_LE_CHAN(chan));
+	err = l2cap_le_conn_req(BT_L2CAP_LE_CHAN(chan));
+	if (err) {
+		goto fail;
+	}
+
+	return;
+fail:
+	bt_l2cap_chan_remove(chan->conn, chan);
+	bt_l2cap_chan_del(chan);
 }
 #endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
 
@@ -2348,6 +2356,8 @@ void bt_l2cap_init(void)
 static int l2cap_le_connect(struct bt_conn *conn, struct bt_l2cap_le_chan *ch,
 			    uint16_t psm)
 {
+	int err;
+
 	if (psm < L2CAP_LE_PSM_FIXED_START || psm > L2CAP_LE_PSM_DYN_END) {
 		return -EINVAL;
 	}
@@ -2362,11 +2372,9 @@ static int l2cap_le_connect(struct bt_conn *conn, struct bt_l2cap_le_chan *ch,
 	ch->chan.psm = psm;
 
 	if (conn->sec_level < ch->chan.required_sec_level) {
-		int err;
-
 		err = bt_conn_set_security(conn, ch->chan.required_sec_level);
 		if (err) {
-			return err;
+			goto fail;
 		}
 
 		atomic_set_bit(ch->chan.status,
@@ -2375,7 +2383,17 @@ static int l2cap_le_connect(struct bt_conn *conn, struct bt_l2cap_le_chan *ch,
 		return 0;
 	}
 
-	return l2cap_le_conn_req(ch);
+	err = l2cap_le_conn_req(ch);
+	if (err) {
+		goto fail;
+	}
+
+	return 0;
+
+fail:
+	bt_l2cap_chan_remove(conn, &ch->chan);
+	bt_l2cap_chan_del(&ch->chan);
+	return err;
 }
 
 static int l2cap_ecred_init(struct bt_conn *conn,

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1311,6 +1311,8 @@ static void le_disconn_req(struct bt_l2cap *l2cap, uint8_t ident,
 
 static int l2cap_change_security(struct bt_l2cap_le_chan *chan, uint16_t err)
 {
+	struct bt_conn *conn = chan->chan.conn;
+	bt_security_t sec;
 	int ret;
 
 	if (atomic_test_bit(chan->chan.status,
@@ -1320,18 +1322,19 @@ static int l2cap_change_security(struct bt_l2cap_le_chan *chan, uint16_t err)
 
 	switch (err) {
 	case BT_L2CAP_LE_ERR_ENCRYPTION:
-		if (chan->chan.required_sec_level >= BT_SECURITY_L2) {
+		if (conn->sec_level >= BT_SECURITY_L2) {
 			return -EALREADY;
 		}
-		chan->chan.required_sec_level = BT_SECURITY_L2;
+
+		sec = BT_SECURITY_L2;
 		break;
 	case BT_L2CAP_LE_ERR_AUTHENTICATION:
-		if (chan->chan.required_sec_level < BT_SECURITY_L2) {
-			chan->chan.required_sec_level = BT_SECURITY_L2;
-		} else if (chan->chan.required_sec_level < BT_SECURITY_L3) {
-			chan->chan.required_sec_level = BT_SECURITY_L3;
-		} else if (chan->chan.required_sec_level < BT_SECURITY_L4) {
-			chan->chan.required_sec_level = BT_SECURITY_L4;
+		if (conn->sec_level < BT_SECURITY_L2) {
+			sec = BT_SECURITY_L2;
+		} else if (conn->sec_level < BT_SECURITY_L3) {
+			sec = BT_SECURITY_L3;
+		} else if (conn->sec_level < BT_SECURITY_L4) {
+			sec = BT_SECURITY_L4;
 		} else {
 			return -EALREADY;
 		}
@@ -1340,8 +1343,7 @@ static int l2cap_change_security(struct bt_l2cap_le_chan *chan, uint16_t err)
 		return -EINVAL;
 	}
 
-	ret = bt_conn_set_security(chan->chan.conn,
-				   chan->chan.required_sec_level);
+	ret = bt_conn_set_security(chan->chan.conn, sec);
 	if (ret < 0) {
 		return ret;
 	}

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -292,7 +292,7 @@ void bt_l2cap_chan_set_state(struct bt_l2cap_chan *chan,
  * Notify L2CAP channels of a change in encryption state passing additionally
  * HCI status of performed security procedure.
  */
-void bt_l2cap_encrypt_change(struct bt_conn *conn, uint8_t hci_status);
+void bt_l2cap_security_changed(struct bt_conn *conn, uint8_t hci_status);
 
 /* Prepare an L2CAP PDU to be sent over a connection */
 struct net_buf *bt_l2cap_create_pdu_timeout(struct net_buf_pool *pool,

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -1835,7 +1835,8 @@ static void smp_pairing_complete(struct bt_smp *smp, uint8_t status)
 		}
 
 		if (!atomic_test_bit(smp->flags, SMP_FLAG_KEYS_DISTR)) {
-			bt_conn_security_changed(smp->chan.chan.conn, auth_err);
+			bt_conn_security_changed(smp->chan.chan.conn, status,
+						 auth_err);
 		}
 
 		if (bt_auth && bt_auth->pairing_failed) {
@@ -2778,9 +2779,8 @@ bool bt_smp_request_ltk(struct bt_conn *conn, uint64_t rand, uint16_t ediv, uint
 		/* Notify higher level that security failed if security was
 		 * initiated by slave.
 		 */
-		bt_conn_security_changed(smp->chan.chan.conn,
+		bt_conn_security_changed(conn, BT_HCI_ERR_PIN_OR_KEY_MISSING,
 					 BT_SECURITY_ERR_PIN_OR_KEY_MISSING);
-
 	}
 
 	smp_reset(smp);

--- a/subsys/bluetooth/shell/l2cap.c
+++ b/subsys/bluetooth/shell/l2cap.c
@@ -292,9 +292,17 @@ static int cmd_connect(const struct shell *shell, size_t argc, char *argv[])
 
 	psm = strtoul(argv[1], NULL, 16);
 
+	if (argc > 2) {
+		int sec;
+
+		sec = *argv[2] - '0';
+
+		l2ch_chan.ch.chan.required_sec_level = sec;
+	}
+
 	err = bt_l2cap_chan_connect(default_conn, &l2ch_chan.ch.chan, psm);
 	if (err < 0) {
-		shell_error(shell, "Unable to connect to psm %u (err %u)", psm,
+		shell_error(shell, "Unable to connect to psm %u (err %d)", psm,
 			    err);
 	} else {
 		shell_print(shell, "L2CAP connection pending");
@@ -420,7 +428,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(whitelist_cmds,
 );
 
 SHELL_STATIC_SUBCMD_SET_CREATE(l2cap_cmds,
-	SHELL_CMD_ARG(connect, NULL, "<psm>", cmd_connect, 2, 0),
+	SHELL_CMD_ARG(connect, NULL, "<psm> [sec_level]", cmd_connect, 2, 1),
 	SHELL_CMD_ARG(disconnect, NULL, HELP_NONE, cmd_disconnect, 1, 0),
 	SHELL_CMD_ARG(metrics, NULL, "<value on, off>", cmd_metrics, 2, 0),
 	SHELL_CMD_ARG(recv, NULL, "[delay (in miliseconds)", cmd_recv, 1, 1),


### PR DESCRIPTION
Elevate the security level of the connection when the l2cap channel
connect request is denied with encryption or authentication error
code.
The l2cap channel required_sec_level was used, but this is not
correct as this is set by the user of the API. This resulted in
the call to bt_conn_set_security seeing that the current security
level was already set, decide there is nothing to be done and return
success.

Fixes: #27220

Elevate the security level before sending the connection request if
the application has set a required security level on the channel.
