### PR TITLE
sys: util: cast input of KB() to size_t for large number

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -280,7 +280,12 @@ uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value);
 #endif /* !_ASMLANGUAGE */
 
 /** @brief Number of bytes in @p x kibibytes */
+#ifdef _LINKER
+/* This is used in linker scripts so need to avoid type casting there */
 #define KB(x) ((x) << 10)
+#else
+#define KB(x) (((size_t)x) << 10)
+#endif
 /** @brief Number of bytes in @p x mebibytes */
 #define MB(x) (KB(x) << 10)
 /** @brief Number of bytes in @p x gibibytes */


### PR DESCRIPTION
Numbers in C macros are treated as signed integer. This causes
issues when using macro KB(x). If the result is larger than
(2^31 - 1), it is treated as a negative number downstream.
For example, the RAM size of up_squared is 2GB. The result of
KB(CONFIG_SRAM_SIZE) should be 2147483648, but due to being
casted as signed, the result is instead -2147483648. Any
calculations using this would be incorrectly. Fix it by
casting x in KB(x) to size_t first.

Fixes #27164

Signed-off-by: Daniel Leung <daniel.leung@intel.com>