### PR TITLE
 Bluetooth: Mesh: Fix tx seg buffer with NULL pointer reference

### DIFF
--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -532,6 +532,8 @@ static int send_seg(struct bt_mesh_net_tx *net_tx, struct net_buf_simple *sdu,
 
 		BT_DBG("seg %u: %s", seg_o, bt_hex(buf, len));
 
+		tx->seg[seg_o] = buf;
+
 		if (IS_ENABLED(CONFIG_BT_MESH_FRIEND)) {
 			enum bt_mesh_friend_pdu_type type;
 
@@ -552,11 +554,11 @@ static int send_seg(struct bt_mesh_net_tx *net_tx, struct net_buf_simple *sdu,
 				 * out through the Friend Queue.
 				 */
 				k_mem_slab_free(&segs, &buf);
-				continue;
+				tx->seg[seg_o] = NULL;
 			}
+
 		}
 
-		tx->seg[seg_o] = buf;
 	}
 
 	/* This can happen if segments only went into the Friend Queue */


### PR DESCRIPTION
Bluetooth: Mesh: Fix tx seg buffer with NULL pointer reference

Fix tx seg buffer with NULL pointer reference if enable mesh friendly

Signed-off-by: chao an <anchao@xiaomi.com>