### PR TITLE
tests: net: af_packet: Fix running in real hw

### DIFF
--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -119,8 +119,15 @@ struct user_data {
 static void iface_cb(struct net_if *iface, void *user_data)
 {
 	struct user_data *ud = user_data;
+	struct net_linkaddr *link_addr;
 
 	if (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET)) {
+		return;
+	}
+
+	link_addr = net_if_get_link_addr(iface);
+	if (memcmp(link_addr->addr, lladdr1, sizeof(lladdr1)) != 0 &&
+	    memcmp(link_addr->addr, lladdr2, sizeof(lladdr2)) != 0) {
 		return;
 	}
 


### PR DESCRIPTION
The tests were failing when run on those boards that had
physical Ethernet support. In that case there were three Ethernet
interfaces, two simulated ones for testing, and the third one
was provided by the board. This extra Ethernet interface caused
the test to fail as the test was sending data to wrong interface.

Fixes #27238
Fixes #26568

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>