### PR TITLE
drivers: serial: Fix UART callback call in lpc11u6x driver

### DIFF
--- a/drivers/serial/uart_lpc11u6x.c
+++ b/drivers/serial/uart_lpc11u6x.c
@@ -336,7 +336,7 @@ static void lpc11u6x_uart0_isr(void *arg)
 	struct lpc11u6x_uart0_data *data = DEV_DATA(dev);
 
 	if (data->cb) {
-		data->cb(data->cb_data);
+		data->cb(dev, data->cb_data);
 	}
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
@@ -760,7 +760,7 @@ static void lpc11u6x_uartx_isr(struct device *dev)
 	struct lpc11u6x_uartx_data *data = DEV_DATA(dev);
 
 	if (data->cb) {
-		data->cb(data->cb_data);
+		data->cb(dev, data->cb_data);
 	}
 }
 


### PR DESCRIPTION
struct device * as well as void * are necessary now.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>