### PR TITLE
Bluetooth: Mesh: configurable advertiser stack size

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -195,6 +195,14 @@ config BT_MESH_ADV_BUF_COUNT
 	  be at least three more advertising buffers than the maximum
 	  supported outgoing segment count (BT_MESH_TX_SEG_MAX).
 
+config BT_MESH_ADV_STACK_SIZE
+	int "Mesh advertiser thread stack size"
+	default 1024 if BT_HOST_CRYPTO
+	default 768
+	help
+	  NOTE: This is an advanced setting and should not be changed unless
+	  absolutely necessary
+
 config BT_MESH_IVU_DIVIDER
 	int "Divider for IV Update state refresh timer"
 	default 4

--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -45,15 +45,9 @@
 #define ADV_INT_DEFAULT_MS 100
 #define ADV_INT_FAST_MS    20
 
-#if defined(CONFIG_BT_HOST_CRYPTO)
-#define ADV_STACK_SIZE 1024
-#else
-#define ADV_STACK_SIZE 768
-#endif
-
 static K_FIFO_DEFINE(adv_queue);
 static struct k_thread adv_thread_data;
-static K_THREAD_STACK_DEFINE(adv_thread_stack, ADV_STACK_SIZE);
+static K_THREAD_STACK_DEFINE(adv_thread_stack, CONFIG_BT_MESH_ADV_STACK_SIZE);
 
 NET_BUF_POOL_DEFINE(adv_buf_pool, CONFIG_BT_MESH_ADV_BUF_COUNT,
 		    BT_MESH_ADV_DATA_SIZE, BT_MESH_ADV_USER_DATA_SIZE, NULL);


### PR DESCRIPTION
Bluetooth: Mesh: configurable advertiser stack size

Add a configurable Kconfig option for advertiser thread stack size