### PR TITLE
sanitycheck: fix only_tags usage

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -2840,7 +2840,7 @@ class TestSuite(DisablePyTestCollectionMixin):
                     discards[instance] = "Excluded tags per platform (exclude_tags)"
                     continue
 
-                if not tc.tags or (plat.only_tags and tc.tags - set(plat.only_tags)):
+                if plat.only_tags and not set(plat.only_tags) & tc.tags:
                     discards[instance] = "Excluded tags per platform (only_tags)"
                     continue
 


### PR DESCRIPTION
We have been doing an AND comparison instead of an OR. AND does exclude
way to many testcases where multiple tags are being used.