### PR TITLE
net: Separate net_pkt priority from traffic class

### DIFF
--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -203,12 +203,10 @@ struct net_pkt {
 #endif
 	};
 
-#if NET_TC_COUNT > 1
 	/** Network packet priority, can be left out in which case packet
 	 * is not prioritised.
 	 */
 	uint8_t priority;
-#endif
 
 #if defined(CONFIG_NET_VLAN)
 	/* VLAN TCI (Tag Control Information). This contains the Priority
@@ -673,7 +671,6 @@ static inline void net_pkt_set_ipv6_fragment_id(struct net_pkt *pkt,
 }
 #endif /* CONFIG_NET_IPV6_FRAGMENT */
 
-#if NET_TC_COUNT > 1
 static inline uint8_t net_pkt_priority(struct net_pkt *pkt)
 {
 	return pkt->priority;
@@ -684,15 +681,6 @@ static inline void net_pkt_set_priority(struct net_pkt *pkt,
 {
 	pkt->priority = priority;
 }
-#else /* NET_TC_COUNT == 1 */
-static inline uint8_t net_pkt_priority(struct net_pkt *pkt)
-{
-	return 0;
-}
-
-#define net_pkt_set_priority(...)
-
-#endif /* NET_TC_COUNT > 1 */
 
 #if defined(CONFIG_NET_VLAN)
 static inline uint16_t net_pkt_vlan_tag(struct net_pkt *pkt)

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1202,10 +1202,22 @@ static struct net_pkt *pkt_alloc(struct k_mem_slab *slab, k_timeout_t timeout)
 		net_pkt_set_ipv6_next_hdr(pkt, 255);
 	}
 
+#if IS_ENABLED(CONFIG_NET_TX_DEFAULT_PRIORITY)
+#define TX_DEFAULT_PRIORITY CONFIG_NET_TX_DEFAULT_PRIORITY
+#else
+#define TX_DEFAULT_PRIORITY 0
+#endif
+
+#if IS_ENABLED(CONFIG_NET_RX_DEFAULT_PRIORITY)
+#define RX_DEFAULT_PRIORITY CONFIG_NET_RX_DEFAULT_PRIORITY
+#else
+#define RX_DEFAULT_PRIORITY 0
+#endif
+
 	if (&tx_pkts == slab) {
-		net_pkt_set_priority(pkt, CONFIG_NET_TX_DEFAULT_PRIORITY);
+		net_pkt_set_priority(pkt, TX_DEFAULT_PRIORITY);
 	} else if (&rx_pkts == slab) {
-		net_pkt_set_priority(pkt, CONFIG_NET_RX_DEFAULT_PRIORITY);
+		net_pkt_set_priority(pkt, RX_DEFAULT_PRIORITY);
 	}
 
 	if (IS_ENABLED(CONFIG_NET_PKT_RXTIME_STATS) ||


### PR DESCRIPTION
User can always set the network packet priority as it is not
related to traffic class.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>