### PR TITLE
drivers: counter: stm32: Allow disabling backup domain reset

### DIFF
--- a/drivers/counter/Kconfig.stm32_rtc
+++ b/drivers/counter/Kconfig.stm32_rtc
@@ -73,3 +73,9 @@ config COUNTER_RTC_STM32_LSE_BYPASS
 	depends on COUNTER_RTC_STM32_CLOCK_LSE
 	help
 	  Enable LSE bypass
+
+config COUNTER_RTC_STM32_BACKUP_DOMAIN_RESET
+	bool "Do backup domain reset"
+	default y
+	help
+	  Force a backup domain reset on startup

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -289,8 +289,11 @@ static int rtc_stm32_init(struct device *dev)
 	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 
 	LL_PWR_EnableBkUpAccess();
+
+#if defined(CONFIG_COUNTER_RTC_STM32_BACKUP_DOMAIN_RESET)
 	LL_RCC_ForceBackupDomainReset();
 	LL_RCC_ReleaseBackupDomainReset();
+#endif
 
 #if defined(CONFIG_COUNTER_RTC_STM32_CLOCK_LSI)
 


### PR DESCRIPTION
Allow the disabling of reseting of the backup domain. This gives
the possibility to keep the content of the 20 backup registers
and use them to store information that survives a reboot.

Signed-off-by: Erwin Rol <erwin@erwinrol.com>