### PR TITLE
Network packet timing statistics

### DIFF
--- a/doc/guides/networking/net-stack-architecture.rst
+++ b/doc/guides/networking/net-stack-architecture.rst
@@ -3,6 +3,12 @@
 Network Stack Architecture
 ##########################
 
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   net_pkt_processing_stats.rst
+
 The Zephyr network stack is a native network stack specifically designed
 for Zephyr OS. It consists of layers, each meant to provide certain services
 to other layers. Network stack functionality is highly configurable via Kconfig
@@ -156,3 +162,10 @@ one :ref:`thread <threads_v2>` to another.
 These :ref:`threads <threads_v2>` might run in different contexts
 (:ref:`kernel <kernel_api>` vs. :ref:`userspace <usermode_api>`) and with different
 :ref:`priorities <scheduling_v2>`.
+
+
+Network packet processing statistics
+************************************
+
+See information about network processing statistics
+:ref:`here <net_pkt_processing_stats>`.

--- a/doc/guides/networking/net_pkt_processing_stats.rst
+++ b/doc/guides/networking/net_pkt_processing_stats.rst
@@ -1,0 +1,84 @@
+.. _net_pkt_processing_stats:
+
+Network Packet Processing Statistics
+####################################
+
+.. contents::
+    :local:
+    :depth: 2
+
+This page describes how to get information about network packet processing
+statistics inside network stack.
+
+Network stack contains infrastructure to figure out how long the network packet
+processing takes either in sending or receiving path. There are two Kconfig
+options that control this. For transmit (TX) path the option is called
+:option:`CONFIG_NET_PKT_TXTIME_STATS` and for receive (RX) path the options is
+called :option:`CONFIG_NET_PKT_RXTIME_STATS`. Note that for TX, all kind of
+network packet statistics is collected. For RX, only UDP, TCP or raw packet
+type network packet statistics is collected.
+
+After enabling these options, the :ref:`net stats <net_shell>` network shell
+command will show this information:
+
+.. code-block:: console
+
+   Avg TX net_pkt (11484) time 67 us
+   Avg RX net_pkt (11474) time 43 us
+
+.. note::
+
+   The values above and below are from emulated qemu_x86 board and UDP traffic
+
+The TX time tells how long it took for network packet from its creation to
+when it was sent to the network. The RX time tells the time from its creation
+to when it was passed to the application. The values are in microseconds. The
+statistics will be collected per traffic class if there are more than one
+transmit or receive queues defined in the system. These are controlled by
+:option:`CONFIG_NET_TC_TX_COUNT` and :option:`CONFIG_NET_TC_RX_COUNT` options.
+
+If you enable :option:`CONFIG_NET_PKT_TXTIME_STATS_DETAIL` or
+:option:`CONFIG_NET_PKT_RXTIME_STATS_DETAIL` options, then additional
+information for TX or RX network packets are collected when the network packet
+traverses the IP stack.
+
+After enabling these options, the :ref:`net stats <net_shell>` will show
+this information:
+
+.. code-block:: console
+
+   Avg TX net_pkt (18902) time 63 us    [0->22->15->23=60 us]
+   Avg RX net_pkt (18892) time 42 us    [0->9->6->11->13=39 us]
+
+The numbers inside the brackets contain information how many microseconds it
+took for a network packet to go from previous state to next.
+
+In the TX example above, the values are averages over **18902** packets and
+contain this information:
+
+* Packet was created by application so the time is **0**.
+* Packet is about to be placed to transmit queue. The time it took from network
+  packet creation to this state, is **22** microseconds in this example.
+* The correct TX thread is invoked, and the packet is read from the transmit
+  queue. It took **15** microseconds from previous state.
+* The network packet was just sent and the network stack is about to free the
+  network packet. It took **23** microseconds from previous state.
+* In total it took on average **60** microseconds to get the network packet
+  sent. The value **63** tells also the same information, but is calculated
+  differently so there is slight difference because of rounding errors.
+
+In the RX example above, the values are averages over **18892** packets and
+contain this information:
+
+* Packet was created network device driver so the time is **0**.
+* Packet is about to be placed to receive queue. The time it took from network
+  packet creation to this state, is **9** microseconds in this example.
+* The correct RX thread is invoked, and the packet is read from the receive
+  queue. It took **6** microseconds from previous state.
+* The network packet is then processed and placed to correct socket queue.
+  It took **11** microseconds from previous state.
+* The last value tells how long it took from there to the application. Here
+  the value is **13** microseconds.
+* In total it took on average **39** microseconds to get the network packet
+  sent. The value **42** tells also the same information, but is calculated
+  differently so there is slight difference because of rounding errors.

--- a/include/net/net_core.h
+++ b/include/net/net_core.h
@@ -57,6 +57,13 @@ extern "C" {
 
 #define NET_ASSERT(cond, ...) __ASSERT(cond, "" __VA_ARGS__)
 
+/* This needs to be here in order to avoid circular include dependency */
+#if defined(CONFIG_NET_PKT_TXTIME_STATS_DETAIL)
+#if !defined(NET_PKT_DETAIL_STATS_COUNT)
+#define NET_PKT_DETAIL_STATS_COUNT 3
+#endif
+#endif /* CONFIG_NET_PKT_TXTIME_STATS_DETAIL */
+
 /** @endcond */
 
 struct net_buf;

--- a/include/net/net_core.h
+++ b/include/net/net_core.h
@@ -57,12 +57,27 @@ extern "C" {
 
 #define NET_ASSERT(cond, ...) __ASSERT(cond, "" __VA_ARGS__)
 
-/* This needs to be here in order to avoid circular include dependency */
-#if defined(CONFIG_NET_PKT_TXTIME_STATS_DETAIL)
+/* This needs to be here in order to avoid circular include dependency between
+ * net_pkt.h and net_if.h
+ */
+#if defined(CONFIG_NET_PKT_TXTIME_STATS_DETAIL) || \
+	defined(CONFIG_NET_PKT_RXTIME_STATS_DETAIL)
 #if !defined(NET_PKT_DETAIL_STATS_COUNT)
+#if defined(CONFIG_NET_PKT_TXTIME_STATS_DETAIL)
+
+#if defined(CONFIG_NET_PKT_RXTIME_STATS_DETAIL)
+#define NET_PKT_DETAIL_STATS_COUNT 4
+#else
 #define NET_PKT_DETAIL_STATS_COUNT 3
-#endif
+#endif /* CONFIG_NET_PKT_RXTIME_STATS_DETAIL */
+
+#else
+#define NET_PKT_DETAIL_STATS_COUNT 4
 #endif /* CONFIG_NET_PKT_TXTIME_STATS_DETAIL */
+
+#endif /* !NET_PKT_DETAIL_STATS_COUNT */
+#endif /* CONFIG_NET_PKT_TXTIME_STATS_DETAIL ||
+	  CONFIG_NET_PKT_RXTIME_STATS_DETAIL */
 
 /** @endcond */
 

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -116,7 +116,8 @@ struct net_pkt {
 			/** Timestamp if available. */
 			struct net_ptp_time timestamp;
 
-#if defined(CONFIG_NET_PKT_TXTIME_STATS_DETAIL)
+#if defined(CONFIG_NET_PKT_TXTIME_STATS_DETAIL) || \
+	defined(CONFIG_NET_PKT_RXTIME_STATS_DETAIL)
 			/** Collect extra statistics for net_pkt processing
 			 * from various points in the IP stack. See networking
 			 * documentation where these points are located and how
@@ -126,7 +127,8 @@ struct net_pkt {
 				uint32_t stat[NET_PKT_DETAIL_STATS_COUNT];
 				int count;
 			} detail;
-#endif /* CONFIG_NET_PKT_TXTIME_STATS_DETAIL */
+#endif /* CONFIG_NET_PKT_TXTIME_STATS_DETAIL ||
+	  CONFIG_NET_PKT_RXTIME_STATS_DETAIL */
 		};
 #endif /* CONFIG_NET_PKT_TIMESTAMP */
 #if defined(CONFIG_NET_PKT_TXTIME)
@@ -843,7 +845,8 @@ static inline void net_pkt_set_txtime(struct net_pkt *pkt, uint64_t txtime)
 }
 #endif /* CONFIG_NET_PKT_TXTIME */
 
-#if defined(CONFIG_NET_PKT_TXTIME_STATS_DETAIL)
+#if defined(CONFIG_NET_PKT_TXTIME_STATS_DETAIL) || \
+	defined(CONFIG_NET_PKT_RXTIME_STATS_DETAIL)
 static inline uint32_t *net_pkt_stats_tick(struct net_pkt *pkt)
 {
 	return pkt->detail.stat;
@@ -872,6 +875,7 @@ static ALWAYS_INLINE void net_pkt_set_stats_tick(struct net_pkt *pkt,
 }
 
 #define net_pkt_set_tx_stats_tick(pkt, tick) net_pkt_set_stats_tick(pkt, tick)
+#define net_pkt_set_rx_stats_tick(pkt, tick) net_pkt_set_stats_tick(pkt, tick)
 #else
 static inline uint32_t *net_pkt_stats_tick(struct net_pkt *pkt)
 {
@@ -899,7 +903,9 @@ static inline void net_pkt_set_stats_tick(struct net_pkt *pkt, uint32_t tick)
 }
 
 #define net_pkt_set_tx_stats_tick(pkt, tick)
-#endif /* CONFIG_NET_PKT_TXTIME_STATS_DETAIL */
+#define net_pkt_set_rx_stats_tick(pkt, tick)
+#endif /* CONFIG_NET_PKT_TXTIME_STATS_DETAIL ||
+	  CONFIG_NET_PKT_RXTIME_STATS_DETAIL */
 
 static inline size_t net_pkt_get_len(struct net_pkt *pkt)
 {

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -97,46 +97,33 @@ struct net_pkt {
 	struct net_if *orig_iface; /* Original network interface */
 #endif
 
-	/* We do not support combination of TXTIME and TXTIME_STATS as the
-	 * same variable is shared in net_pkt.h
-	 */
-#if defined(CONFIG_NET_PKT_TXTIME) && defined(CONFIG_NET_PKT_TXTIME_STATS)
-#error \
-"Cannot define both CONFIG_NET_PKT_TXTIME and CONFIG_NET_PKT_TXTIME_STATS"
-#endif
-
-#if defined(CONFIG_NET_PKT_TIMESTAMP) || defined(CONFIG_NET_PKT_TXTIME) || \
-				defined(CONFIG_NET_PKT_RXTIME_STATS) || \
-				defined(CONFIG_NET_PKT_TXTIME_STATS)
-	union {
 #if defined(CONFIG_NET_PKT_TIMESTAMP) || \
 				defined(CONFIG_NET_PKT_RXTIME_STATS) ||	\
 				defined(CONFIG_NET_PKT_TXTIME_STATS)
-		struct {
-			/** Timestamp if available. */
-			struct net_ptp_time timestamp;
+	struct {
+		/** Timestamp if available. */
+		struct net_ptp_time timestamp;
 
 #if defined(CONFIG_NET_PKT_TXTIME_STATS_DETAIL) || \
 	defined(CONFIG_NET_PKT_RXTIME_STATS_DETAIL)
-			/** Collect extra statistics for net_pkt processing
-			 * from various points in the IP stack. See networking
-			 * documentation where these points are located and how
-			 * to interpret the results.
-			 */
-			struct {
-				uint32_t stat[NET_PKT_DETAIL_STATS_COUNT];
-				int count;
-			} detail;
+		/** Collect extra statistics for net_pkt processing
+		 * from various points in the IP stack. See networking
+		 * documentation where these points are located and how
+		 * to interpret the results.
+		 */
+		struct {
+			uint32_t stat[NET_PKT_DETAIL_STATS_COUNT];
+			int count;
+		} detail;
 #endif /* CONFIG_NET_PKT_TXTIME_STATS_DETAIL ||
 	  CONFIG_NET_PKT_RXTIME_STATS_DETAIL */
-		};
-#endif /* CONFIG_NET_PKT_TIMESTAMP */
-#if defined(CONFIG_NET_PKT_TXTIME)
-		/** Network packet TX time in the future (in nanoseconds) */
-		uint64_t txtime;
-#endif /* CONFIG_NET_PKT_TXTIME */
 	};
-#endif /* CONFIG_NET_PKT_TIMESTAMP || CONFIG_NET_PKT_TXTIME */
+#endif /* CONFIG_NET_PKT_TIMESTAMP */
+
+#if defined(CONFIG_NET_PKT_TXTIME)
+	/** Network packet TX time in the future (in nanoseconds) */
+	uint64_t txtime;
+#endif /* CONFIG_NET_PKT_TXTIME */
 
 	/** Reference counter */
 	atomic_t atomic_ref;

--- a/include/net/net_stats.h
+++ b/include/net/net_stats.h
@@ -224,6 +224,10 @@ struct net_stats_rx_time {
 struct net_stats_tc {
 	struct {
 		struct net_stats_tx_time tx_time;
+#if defined(CONFIG_NET_PKT_TXTIME_STATS_DETAIL)
+		struct net_stats_tx_time
+				tx_time_detail[NET_PKT_DETAIL_STATS_COUNT];
+#endif
 		net_stats_t pkts;
 		net_stats_t bytes;
 		uint8_t priority;
@@ -314,6 +318,11 @@ struct net_stats {
 					defined(CONFIG_NET_PKT_TXTIME_STATS)
 	/** Network packet TX time statistics */
 	struct net_stats_tx_time tx_time;
+
+#if defined(CONFIG_NET_PKT_TXTIME_STATS_DETAIL)
+	/** Network packet TX time detail statistics */
+	struct net_stats_tx_time tx_time_detail[NET_PKT_DETAIL_STATS_COUNT];
+#endif
 #endif
 
 #if defined(CONFIG_NET_PKT_RXTIME_STATS)

--- a/include/net/net_stats.h
+++ b/include/net/net_stats.h
@@ -235,6 +235,10 @@ struct net_stats_tc {
 
 	struct {
 		struct net_stats_rx_time rx_time;
+#if defined(CONFIG_NET_PKT_RXTIME_STATS_DETAIL)
+		struct net_stats_rx_time
+				rx_time_detail[NET_PKT_DETAIL_STATS_COUNT];
+#endif
 		net_stats_t pkts;
 		net_stats_t bytes;
 		uint8_t priority;
@@ -322,6 +326,10 @@ struct net_stats {
 #if defined(CONFIG_NET_PKT_TXTIME_STATS_DETAIL)
 	/** Network packet TX time detail statistics */
 	struct net_stats_tx_time tx_time_detail[NET_PKT_DETAIL_STATS_COUNT];
+#endif
+#if defined(CONFIG_NET_PKT_RXTIME_STATS_DETAIL)
+	/** Network packet RX time detail statistics */
+	struct net_stats_tx_time rx_time_detail[NET_PKT_DETAIL_STATS_COUNT];
 #endif
 #endif
 

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -717,18 +717,16 @@ config NET_PKT_TXTIME_STATS
 	bool "Enable network packet TX time statistics"
 	select NET_PKT_TIMESTAMP
 	select NET_STATISTICS
-	depends on (NET_UDP || NET_TCP || NET_SOCKETS_PACKET) && !NET_PKT_TXTIME && NET_NATIVE
+	depends on (NET_UDP || NET_TCP || NET_SOCKETS_PACKET) && NET_NATIVE
 	help
 	  Enable network packet TX time statistics support. This is used to
 	  calculate how long on average it takes for a packet to travel from
 	  application to just before it is sent to network. The TX timing
 	  information can then be seen in network interface statistics in
 	  net-shell.
-	  The RX calculation is done only for UDP or TCP packets, but for TX
-	  we do not know the protocol so the TX packet timing is done for all
-	  network protocol packets.
-	  Note that CONFIG_NET_PKT_TXTIME cannot be set at the same time
-	  because net_pkt shares the time variable for statistics and TX time.
+	  The RX calculation is done only for UDP, TCP or RAW packets,
+	  but for TX we do not know the protocol so the TX packet timing is
+	  done for all network protocol packets.
 
 config NET_PKT_TXTIME_STATS_DETAIL
 	bool "Get extra transmit detail statistics in TX path"

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -694,7 +694,7 @@ config NET_PKT_RXTIME_STATS
 	bool "Enable network packet RX time statistics"
 	select NET_PKT_TIMESTAMP
 	select NET_STATISTICS
-	depends on (NET_UDP || NET_TCP)
+	depends on (NET_UDP || NET_TCP || NET_SOCKETS_PACKET) && NET_NATIVE
 	help
 	  Enable network packet RX time statistics support. This is used to
 	  calculate how long on average it takes for a packet to travel from
@@ -702,6 +702,16 @@ config NET_PKT_RXTIME_STATS
 	  timing information can then be seen in network interface statistics
 	  in net-shell.
 	  The RX statistics are only calculated for UDP and TCP packets.
+
+config NET_PKT_RXTIME_STATS_DETAIL
+	bool "Get extra receive detail statistics in RX path"
+	depends on NET_PKT_RXTIME_STATS
+	help
+	  Store receive statistics detail information in certain key points
+	  in RX path. This is very special configuration and will increase
+	  the size of net_pkt so in typical cases you should not enable it.
+	  The extra statistics can be seen in net-shell using "net stats"
+	  command.
 
 config NET_PKT_TXTIME_STATS
 	bool "Enable network packet TX time statistics"

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -707,7 +707,7 @@ config NET_PKT_TXTIME_STATS
 	bool "Enable network packet TX time statistics"
 	select NET_PKT_TIMESTAMP
 	select NET_STATISTICS
-	depends on (NET_UDP || NET_TCP) && !NET_PKT_TXTIME
+	depends on (NET_UDP || NET_TCP || NET_SOCKETS_PACKET) && !NET_PKT_TXTIME && NET_NATIVE
 	help
 	  Enable network packet TX time statistics support. This is used to
 	  calculate how long on average it takes for a packet to travel from
@@ -719,6 +719,16 @@ config NET_PKT_TXTIME_STATS
 	  network protocol packets.
 	  Note that CONFIG_NET_PKT_TXTIME cannot be set at the same time
 	  because net_pkt shares the time variable for statistics and TX time.
+
+config NET_PKT_TXTIME_STATS_DETAIL
+	bool "Get extra transmit detail statistics in TX path"
+	depends on NET_PKT_TXTIME_STATS
+	help
+	  Store receive statistics detail information in certain key points
+	  in TX path. This is very special configuration and will increase
+	  the size of net_pkt so in typical cases you should not enable it.
+	  The extra statistics can be seen in net-shell using "net stats"
+	  command.
 
 config NET_PROMISCUOUS_MODE
 	bool "Enable promiscuous mode support [EXPERIMENTAL]"

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -350,6 +350,8 @@ static void process_rx_packet(struct k_work *work)
 
 	pkt = CONTAINER_OF(work, struct net_pkt, work);
 
+	net_pkt_set_rx_stats_tick(pkt, k_cycle_get_32());
+
 	net_rx(net_pkt_iface(pkt), pkt);
 }
 

--- a/subsys/net/ip/net_stats.h
+++ b/subsys/net/ip/net_stats.h
@@ -334,6 +334,24 @@ static inline void net_stats_update_tx_time(struct net_if *iface,
 #define net_stats_update_tx_time(iface, start_time, end_time)
 #endif /* (TIMESTAMP || NET_PKT_TXTIME_STATS) && NET_STATISTICS */
 
+#if defined(CONFIG_NET_PKT_TXTIME_STATS_DETAIL)
+static inline void net_stats_update_tx_time_detail(struct net_if *iface,
+						   uint32_t detail_stat[])
+{
+	int i;
+
+	for (i = 0; i < NET_PKT_DETAIL_STATS_COUNT; i++) {
+		UPDATE_STAT(iface,
+			    stats.tx_time_detail[i].sum +=
+			    k_cyc_to_ns_floor64(detail_stat[i]) / 1000);
+		UPDATE_STAT(iface,
+			    stats.tx_time_detail[i].count += 1);
+	}
+}
+#else
+#define net_stats_update_tx_time_detail(iface, detail_stat)
+#endif /* NET_PKT_TXTIME_STATS_DETAIL */
+
 #if defined(CONFIG_NET_PKT_RXTIME_STATS) && defined(CONFIG_NET_STATISTICS)
 static inline void net_stats_update_rx_time(struct net_if *iface,
 					    uint32_t start_time,
@@ -388,6 +406,28 @@ static inline void net_stats_update_tc_tx_time(struct net_if *iface,
 #else
 #define net_stats_update_tc_tx_time(iface, tc, start_time, end_time)
 #endif /* (NET_CONTEXT_TIMESTAMP || NET_PKT_TXTIME_STATS) && NET_STATISTICS */
+
+#if defined(CONFIG_NET_PKT_TXTIME_STATS_DETAIL)
+static inline void net_stats_update_tc_tx_time_detail(struct net_if *iface,
+						      uint8_t priority,
+						      uint32_t detail_stat[])
+{
+	int tc = net_tx_priority2tc(priority);
+	int i;
+
+	for (i = 0; i < NET_PKT_DETAIL_STATS_COUNT; i++) {
+		UPDATE_STAT(iface,
+			    stats.tc.sent[tc].tx_time_detail[i].sum +=
+			    k_cyc_to_ns_floor64(detail_stat[i]) / 1000);
+		UPDATE_STAT(iface,
+			    stats.tc.sent[tc].tx_time_detail[i].count += 1);
+	}
+
+	net_stats_update_tx_time_detail(iface, detail_stat);
+}
+#else
+#define net_stats_update_tc_tx_time_detail(iface, tc, detail_stat)
+#endif /* CONFIG_NET_PKT_TXTIME_STATS_DETAIL */
 
 #if defined(CONFIG_NET_PKT_RXTIME_STATS) && defined(CONFIG_NET_STATISTICS) \
 	&& defined(CONFIG_NET_NATIVE)
@@ -448,6 +488,19 @@ static inline void net_stats_update_tc_tx_time(struct net_if *iface,
 #else
 #define net_stats_update_tc_tx_time(iface, priority, start_time, end_time)
 #endif /* (NET_CONTEXT_TIMESTAMP || NET_PKT_TXTIME_STATS) && NET_STATISTICS */
+
+#if defined(CONFIG_NET_PKT_TXTIME_STATS_DETAIL)
+static inline void net_stats_update_tc_tx_time_detail(struct net_if *iface,
+						      uint8_t pkt_priority,
+						      uint32_t detail_stat[])
+{
+	ARG_UNUSED(pkt_priority);
+
+	net_stats_update_tx_time_detail(iface, detail_stat);
+}
+#else
+#define net_stats_update_tc_tx_time_detail(iface, pkt_priority, detail_stat)
+#endif /* CONFIG_NET_PKT_TXTIME_STATS_DETAIL */
 
 #if defined(CONFIG_NET_PKT_RXTIME_STATS) && defined(CONFIG_NET_STATISTICS) \
 	&& defined(CONFIG_NET_NATIVE)

--- a/subsys/net/ip/net_tc.c
+++ b/subsys/net/ip/net_tc.c
@@ -44,6 +44,8 @@ bool net_tc_submit_to_tx_queue(uint8_t tc, struct net_pkt *pkt)
 
 void net_tc_submit_to_rx_queue(uint8_t tc, struct net_pkt *pkt)
 {
+	net_pkt_set_rx_stats_tick(pkt, k_cycle_get_32());
+
 	k_work_submit_to_queue(&rx_classes[tc].work_q, net_pkt_work(pkt));
 }
 

--- a/subsys/net/ip/net_tc.c
+++ b/subsys/net/ip/net_tc.c
@@ -35,6 +35,8 @@ bool net_tc_submit_to_tx_queue(uint8_t tc, struct net_pkt *pkt)
 		return false;
 	}
 
+	net_pkt_set_tx_stats_tick(pkt, k_cycle_get_32());
+
 	k_work_submit_to_queue(&tx_classes[tc].work_q, net_pkt_work(pkt));
 
 	return true;

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -245,6 +245,20 @@ static void tcp_retry_expired(struct k_work *work)
 			return;
 		}
 
+		if (IS_ENABLED(CONFIG_NET_PKT_TXTIME_STATS)) {
+			/* If we have enabled net_pkt TXTIME statistics, and we
+			 * about to re-send already sent net_pkt, then reset
+			 * the net_pkt start time as otherwise the TX average
+			 * will be wrong (as it would be calculated from when
+			 * the packet was created).
+			 */
+			struct net_ptp_time tp = {
+				.nanosecond = k_cycle_get_32(),
+			};
+
+			net_pkt_set_timestamp(pkt, &tp);
+		}
+
 		net_pkt_set_queued(pkt, true);
 		net_pkt_set_tcp_1st_msg(pkt, false);
 

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -344,6 +344,8 @@ static void zsock_received_cb(struct net_context *ctx,
 		net_context_update_recv_wnd(ctx, -net_pkt_remaining_data(pkt));
 	}
 
+	net_pkt_set_rx_stats_tick(pkt, k_cycle_get_32());
+
 	k_fifo_put(&ctx->recv_q, pkt);
 }
 
@@ -851,6 +853,36 @@ error:
 	return ret;
 }
 
+void net_socket_update_tc_rx_time(struct net_pkt *pkt, uint32_t end_tick)
+{
+	net_pkt_set_rx_stats_tick(pkt, end_tick);
+
+	net_stats_update_tc_rx_time(net_pkt_iface(pkt),
+				    net_pkt_priority(pkt),
+				    net_pkt_timestamp(pkt)->nanosecond,
+				    end_tick);
+
+	if (IS_ENABLED(CONFIG_NET_PKT_TXTIME_STATS_DETAIL)) {
+		uint32_t val, prev = net_pkt_timestamp(pkt)->nanosecond;
+		int i;
+
+		for (i = 0; i < net_pkt_stats_tick_count(pkt); i++) {
+			if (!net_pkt_stats_tick(pkt)[i]) {
+				break;
+			}
+
+			val = net_pkt_stats_tick(pkt)[i] - prev;
+			prev = net_pkt_stats_tick(pkt)[i];
+			net_pkt_stats_tick(pkt)[i] = val;
+		}
+
+		net_stats_update_tc_rx_time_detail(
+			net_pkt_iface(pkt),
+			net_pkt_priority(pkt),
+			net_pkt_stats_tick(pkt));
+	}
+}
+
 static inline ssize_t zsock_recv_dgram(struct net_context *ctx,
 				       void *buf,
 				       size_t max_len,
@@ -922,10 +954,10 @@ static inline ssize_t zsock_recv_dgram(struct net_context *ctx,
 		goto fail;
 	}
 
-	net_stats_update_tc_rx_time(net_pkt_iface(pkt),
-				    net_pkt_priority(pkt),
-				    net_pkt_timestamp(pkt)->nanosecond,
-				    k_cycle_get_32());
+	if (IS_ENABLED(CONFIG_NET_PKT_RXTIME_STATS) &&
+	    !(flags & ZSOCK_MSG_PEEK)) {
+		net_socket_update_tc_rx_time(pkt, k_cycle_get_32());
+	}
 
 	if (!(flags & ZSOCK_MSG_PEEK)) {
 		net_pkt_unref(pkt);
@@ -1015,11 +1047,10 @@ static inline ssize_t zsock_recv_stream(struct net_context *ctx,
 					sock_set_eof(ctx);
 				}
 
-				net_stats_update_tc_rx_time(
-					net_pkt_iface(pkt),
-					net_pkt_priority(pkt),
-					net_pkt_timestamp(pkt)->nanosecond,
-					k_cycle_get_32());
+				if (IS_ENABLED(CONFIG_NET_PKT_RXTIME_STATS)) {
+					net_socket_update_tc_rx_time(
+						pkt, k_cycle_get_32());
+				}
 
 				net_pkt_unref(pkt);
 			}

--- a/subsys/net/lib/sockets/sockets_internal.h
+++ b/subsys/net/lib/sockets/sockets_internal.h
@@ -26,6 +26,8 @@ static inline uintptr_t sock_get_flag(struct net_context *ctx, uintptr_t mask)
 	return POINTER_TO_UINT(ctx->socket_data) & mask;
 }
 
+void net_socket_update_tc_rx_time(struct net_pkt *pkt, uint32_t end_tick);
+
 #define sock_is_eof(ctx) sock_get_flag(ctx, SOCK_EOF)
 #define sock_set_eof(ctx) sock_set_flag(ctx, SOCK_EOF, SOCK_EOF)
 #define sock_is_nonblock(ctx) sock_get_flag(ctx, SOCK_NONBLOCK)

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -236,10 +236,11 @@ ssize_t zpacket_recvfrom_ctx(struct net_context *ctx, void *buf, size_t max_len,
 		return -1;
 	}
 
-	net_stats_update_tc_rx_time(net_pkt_iface(pkt),
-				    net_pkt_priority(pkt),
-				    net_pkt_timestamp(pkt)->nanosecond,
-				    k_cycle_get_32());
+
+	if (IS_ENABLED(CONFIG_NET_PKT_RXTIME_STATS) &&
+	    !(flags & ZSOCK_MSG_PEEK)) {
+		net_socket_update_tc_rx_time(pkt, k_cycle_get_32());
+	}
 
 	if (!(flags & ZSOCK_MSG_PEEK)) {
 		net_pkt_unref(pkt);


### PR DESCRIPTION
This adds infrastructure to measure how long it takes for a network packet to pass the network stack. It is also possible to collect TX/RX statistics from various key points in the network stack.