### PR TITLE
drivers: i2c: Add a dump routine

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -184,6 +184,7 @@
 /drivers/hwinfo/                          @alexanderwachter
 /drivers/i2c/*litex*                      @mateusz-holenko @kgugala @pgielda
 /drivers/i2s/i2s_ll_stm32*                @avisconti
+/drivers/i2c/i2c_common.c                 @sjg20
 /drivers/i2c/i2c_shell.c                  @nashif
 /drivers/ieee802154/                      @jukkar @tbursztyka
 /drivers/ieee802154/ieee802154_rf2xx*     @jukkar @tbursztyka @nandojve

--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 zephyr_library()
 
+zephyr_library_sources(i2c_common.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_SHELL		i2c_shell.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_BITBANG		i2c_bitbang.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_CC13XX_CC26XX		i2c_cc13xx_cc26xx.c)

--- a/drivers/i2c/i2c_common.c
+++ b/drivers/i2c/i2c_common.c
@@ -1,0 +1,30 @@
+/*
+ * Logging of I2C messages
+ *
+ * Copyright 2020 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+
+#include <drivers/i2c.h>
+
+#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
+#include <logging/log.h>
+LOG_MODULE_REGISTER(i2c);
+
+void i2c_dump_msgs(const char *name, const struct i2c_msg *msgs,
+		   uint8_t num_msgs, uint16_t addr)
+{
+	LOG_DBG("I2C msg: %s, addr=%x", name, addr);
+	for (unsigned int i = 0; i < num_msgs; i++) {
+		const struct i2c_msg *msg = &msgs[i];
+
+		LOG_DBG("   %c len=%02x: ",
+			msg->flags & I2C_MSG_READ ? 'R' : 'W', msg->len);
+		if (!(msg->flags & I2C_MSG_READ)) {
+			LOG_HEXDUMP_DBG(msg->buf, msg->len, "contents:");
+		}
+	}
+}

--- a/include/drivers/i2c.h
+++ b/include/drivers/i2c.h
@@ -628,6 +628,31 @@ static inline int i2c_reg_update_byte(struct device *dev, uint8_t dev_addr,
 	return i2c_reg_write_byte(dev, dev_addr, reg_addr, new_value);
 }
 
+/**
+ * @brief Dump out an I2C message
+ *
+ * Dumps out a list of I2C messages. For any that are writes (W), the data is
+ * displayed in hex.
+ *
+ * It looks something like this (with name "testing"):
+ *
+ * D: I2C msg: testing, addr=56
+ * D:    W len=01:
+ * D: contents:
+ * D: 06                      |.
+ * D:    W len=0e:
+ * D: contents:
+ * D: 00 01 02 03 04 05 06 07 |........
+ * D: 08 09 0a 0b 0c 0d       |......
+ *
+ * @param name Name of this dump, displayed at the top.
+ * @param msgs Array of messages to dump.
+ * @param num_msgs Number of messages to dump.
+ * @param addr Address of the I2C target device.
+ */
+void i2c_dump_msgs(const char *name, const struct i2c_msg *msgs,
+		   uint8_t num_msgs, uint16_t addr);
+
 struct i2c_client_config {
 	char *i2c_master;
 	uint16_t i2c_addr;


### PR DESCRIPTION
Add a function to dump out a set of I2C messages. It uses debug logging
so it only useful for debugging.
