### PR TITLE
tests: mem_pool: Remove useless specifier on function declaration

### DIFF
--- a/tests/kernel/mem_pool/mem_pool_api/src/test_mpool.h
+++ b/tests/kernel/mem_pool/mem_pool_api/src/test_mpool.h
@@ -15,6 +15,6 @@
 #define BLK_NUM_MAX 2
 #define BLK_ALIGN BLK_SIZE_MIN
 
-extern void tmpool_alloc_free(void *data);
+void tmpool_alloc_free(void *data);
 
 #endif /*__TEST_MPOOL_H__*/


### PR DESCRIPTION
'extern' seems useless there, removing it. This was flagging as an error
on some board.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>