### PR TITLE
lib: os: ring_buffer: Extend ring_buf_put_finish and ring_buf_get_finish

### DIFF
--- a/doc/releases/release-notes-2.4.rst
+++ b/doc/releases/release-notes-2.4.rst
@@ -72,6 +72,9 @@ API Changes
   To maintain original behaviour within user code, two argument invocations
   should be converted to pass a third argument ``FS_O_CREATE | FS_O_RDWR``.
 
+* :c:func:`ring_buf_put_finish` and :c:func:`ring_buf_get_finish` have one more
+  argument ``unclaim``. Set ``unclaim`` to true for legacy behavior.
+
 Deprecated in this release
 ==========================
 

--- a/drivers/console/uart_mux.c
+++ b/drivers/console/uart_mux.c
@@ -181,7 +181,7 @@ static void uart_mux_rx_work(struct k_work *work)
 
 	gsm_mux_recv_buf(uart_mux->mux, data, len);
 
-	ret = ring_buf_get_finish(uart_mux->rx_ringbuf, len);
+	ret = ring_buf_get_finish(uart_mux->rx_ringbuf, len, false);
 	if (ret < 0) {
 		LOG_DBG("Cannot flush ring buffer (%d)", ret);
 	}
@@ -215,7 +215,7 @@ static void uart_mux_tx_work(struct k_work *work)
 
 	(void)gsm_dlci_send(dev_data->dlci, data, len);
 
-	ring_buf_get_finish(dev_data->tx_ringbuf, len);
+	ring_buf_get_finish(dev_data->tx_ringbuf, len, false);
 }
 
 static int uart_mux_init(struct device *dev)

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -662,7 +662,7 @@ static int ppp_consume_ringbuf(struct ppp_driver_context *ppp)
 		}
 	} while (--tmp);
 
-	ret = ring_buf_get_finish(&ppp->rx_ringbuf, len);
+	ret = ring_buf_get_finish(&ppp->rx_ringbuf, len, false);
 	if (ret < 0) {
 		LOG_DBG("Cannot flush ring buffer (%d)", ret);
 	}

--- a/subsys/logging/log_backend_rb.c
+++ b/subsys/logging/log_backend_rb.c
@@ -49,7 +49,8 @@ static void trace(const uint8_t *data, size_t length)
 		/* Remove oldest entry */
 		ring_buf_get_claim(&ringbuf, &dummy,
 				   CONFIG_LOG_BACKEND_RB_SLOT_SIZE);
-		ring_buf_get_finish(&ringbuf, CONFIG_LOG_BACKEND_RB_SLOT_SIZE);
+		ring_buf_get_finish(&ringbuf, CONFIG_LOG_BACKEND_RB_SLOT_SIZE,
+				    true);
 	}
 
 	ring_buf_put_claim(&ringbuf, (uint8_t **)&t,
@@ -70,7 +71,7 @@ static void trace(const uint8_t *data, size_t length)
 
 	SOC_DCACHE_FLUSH((void *)region, CONFIG_LOG_BACKEND_RB_SLOT_SIZE);
 
-	ring_buf_put_finish(&ringbuf, CONFIG_LOG_BACKEND_RB_SLOT_SIZE);
+	ring_buf_put_finish(&ringbuf, CONFIG_LOG_BACKEND_RB_SLOT_SIZE, true);
 }
 
 static int char_out(uint8_t *data, size_t length, void *ctx)

--- a/subsys/net/lib/openthread/platform/uart.c
+++ b/subsys/net/lib/openthread/platform/uart.c
@@ -67,7 +67,7 @@ static void uart_rx_handle(struct device *dev)
 			}
 
 			int err = ring_buf_put_finish(
-				ot_uart.rx_ringbuf, rd_len);
+				ot_uart.rx_ringbuf, rd_len, true);
 			(void)err;
 			__ASSERT_NO_MSG(err == 0);
 		} else {
@@ -132,7 +132,7 @@ void platformUartProcess(otInstance *aInstance)
 		otPlatUartReceived(data, len);
 		err = ring_buf_get_finish(
 				ot_uart.rx_ringbuf,
-				len);
+				len, true);
 		(void)err;
 		__ASSERT_NO_MSG(err == 0);
 	}

--- a/subsys/shell/shell_history.c
+++ b/subsys/shell/shell_history.c
@@ -116,7 +116,7 @@ static bool remove_from_tail(struct shell_history *history)
 
 	total_len = offsetof(struct shell_history_item, data) +
 			h_item->len + h_item->padding;
-	ring_buf_get_finish(history->ring_buf, total_len);
+	ring_buf_get_finish(history->ring_buf, total_len, true);
 
 	return true;
 }
@@ -171,7 +171,7 @@ void shell_history_put(struct shell_history *history, uint8_t *line, size_t len)
 						   (uint8_t **)&h_item, total_len);
 			if (claim2_len == total_len) {
 				ring_buf_put_finish(history->ring_buf,
-						    claim_len);
+						    claim_len, true);
 				padding += claim_len;
 				claim_len = total_len;
 			}
@@ -179,11 +179,13 @@ void shell_history_put(struct shell_history *history, uint8_t *line, size_t len)
 
 		if (claim_len == total_len) {
 			add_to_head(history, h_item, line, len, padding);
-			ring_buf_put_finish(history->ring_buf, claim_len);
+			ring_buf_put_finish(history->ring_buf,
+					    claim_len,
+					    true);
 			break;
 		}
 
-		ring_buf_put_finish(history->ring_buf, 0);
+		ring_buf_put_finish(history->ring_buf, 0, true);
 		if (remove_from_tail(history) == false) {
 			__ASSERT_NO_MSG(ring_buf_is_empty(history->ring_buf));
 			/* if history is empty reset ring buffer. Even when

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -67,7 +67,7 @@ static void uart_rx_handle(struct device *dev,
 			}
 #endif /* CONFIG_MCUMGR_SMP_SHELL */
 			int err = ring_buf_put_finish(sh_uart->rx_ringbuf,
-						      rd_len);
+						      rd_len, true);
 			(void)err;
 			__ASSERT_NO_MSG(err == 0);
 		} else {
@@ -102,7 +102,7 @@ static void uart_tx_handle(struct device *dev, const struct shell_uart *sh_uart)
 				 sh_uart->tx_ringbuf->size);
 	if (len) {
 		len = uart_fifo_fill(dev, data, len);
-		err = ring_buf_get_finish(sh_uart->tx_ringbuf, len);
+		err = ring_buf_get_finish(sh_uart->tx_ringbuf, len, true);
 		__ASSERT_NO_MSG(err == 0);
 	} else {
 		uart_irq_tx_disable(dev);

--- a/subsys/tracing/tracing_buffer.c
+++ b/subsys/tracing/tracing_buffer.c
@@ -24,7 +24,7 @@ uint32_t tracing_buffer_put_claim(uint8_t **data, uint32_t size)
 
 int tracing_buffer_put_finish(uint32_t size)
 {
-	return ring_buf_put_finish(&tracing_ring_buf, size);
+	return ring_buf_put_finish(&tracing_ring_buf, size, true);
 }
 
 uint32_t tracing_buffer_put(uint8_t *data, uint32_t size)
@@ -39,7 +39,7 @@ uint32_t tracing_buffer_get_claim(uint8_t **data, uint32_t size)
 
 int tracing_buffer_get_finish(uint32_t size)
 {
-	return ring_buf_get_finish(&tracing_ring_buf, size);
+	return ring_buf_get_finish(&tracing_ring_buf, size, true);
 }
 
 uint32_t tracing_buffer_get(uint8_t *data, uint32_t size)

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -335,7 +335,7 @@ static void tx_work_handler(struct k_work *work)
 	usb_transfer(ep, data, len, USB_TRANS_WRITE,
 		     cdc_acm_write_cb, dev_data);
 
-	ring_buf_get_finish(dev_data->tx_ringbuf, len);
+	ring_buf_get_finish(dev_data->tx_ringbuf, len, true);
 }
 
 static void cdc_acm_read_cb(uint8_t ep, int size, void *priv)


### PR DESCRIPTION
Extended finishing calls with partial argument. Legacy behavior is
kept with partial flag set to false. Setting partial flag to true
indicates that only partial portion of claimed buffer is finished.

Fixes #27258.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>