### PR TITLE
dts: arm: Add STM32F412xE chip definition

### DIFF
--- a/dts/arm/st/f4/stm32f412Xe.dtsi
+++ b/dts/arm/st/f4/stm32f412Xe.dtsi
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/f4/stm32f412.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(256)>;
+	};
+
+	soc {
+		flash-controller@40023c00 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(512)>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
New dtsi file for STM32F412xE  chips