### PR TITLE
drivers: nrf: Added config option for OUI.

### DIFF
--- a/drivers/ieee802154/Kconfig
+++ b/drivers/ieee802154/Kconfig
@@ -39,6 +39,24 @@ config IEEE802154_RDEV
 	help
 	  PHY is a ranging-capable device (RDEV)
 
+config IEEE802154_VENDOR_OUI_ENABLE
+	bool "Enables setting Vendor Organizationally Unique Identifier"
+	help
+	  This option enables setting custom vendor
+	  OUI using IEEE802154_VENDOR_OUI. After enabling,
+	  user is obliged to set IEEE802154_VENDOR_OUI value,
+	  as this option has no default value.
+
+if IEEE802154_VENDOR_OUI_ENABLE
+
+config IEEE802154_VENDOR_OUI
+	int "Vendor Organizationally Unique Identifier"
+	help
+	  Custom vendor OUI, which makes 24 most-significant
+	  bits of MAC address
+
+endif # IEEE802154_VENDOR_OUI_ENABLE
+
 source "drivers/ieee802154/Kconfig.cc2520"
 
 source "drivers/ieee802154/Kconfig.kw41z"


### PR DESCRIPTION
Support for defining vendor specific OUI (Organizationally
Unique Identifier) was added.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>