### PR TITLE
arm: AArch64: Save the callee-saved register directly into SP

### DIFF
--- a/arch/arm/core/aarch64/swap_helper.S
+++ b/arch/arm/core/aarch64/swap_helper.S
@@ -38,6 +38,14 @@ SECTION_FUNC(TEXT, z_arm64_context_switch)
 	bl	sys_trace_thread_switched_in
 	ldp	xzr, x30, [sp], #16
 #endif
+	/* Store rest of process context including x30 */
+	stp	x19, x20, [sp, #-16]!
+	stp	x21, x22, [sp, #-16]!
+	stp	x23, x24, [sp, #-16]!
+	stp	x25, x26, [sp, #-16]!
+	stp	x27, x28, [sp, #-16]!
+	stp	x29, x30, [sp, #-16]!
+
 	/* load _kernel into x1 and current k_thread into x2 */
 	ldr	x1, =_kernel
 	ldr	x2, [x1, #_kernel_offset_to_current]
@@ -45,14 +53,6 @@ SECTION_FUNC(TEXT, z_arm64_context_switch)
 	/* addr of callee-saved regs in thread in x0 */
 	ldr	x0, =_thread_offset_to_callee_saved
 	add	x0, x0, x2
-
-	/* Store rest of process context including x30 */
-	stp	x19, x20, [x0], #16
-	stp	x21, x22, [x0], #16
-	stp	x23, x24, [x0], #16
-	stp	x25, x26, [x0], #16
-	stp	x27, x28, [x0], #16
-	stp	x29, x30, [x0], #16
 
 	/* Save the current SP */
 	mov	x6, sp
@@ -66,16 +66,16 @@ SECTION_FUNC(TEXT, z_arm64_context_switch)
 	ldr	x0, =_thread_offset_to_callee_saved
 	add	x0, x0, x2
 
-	/* Restore x19-x29 plus x30 */
-	ldp	x19, x20, [x0], #16
-	ldp	x21, x22, [x0], #16
-	ldp	x23, x24, [x0], #16
-	ldp	x25, x26, [x0], #16
-	ldp	x27, x28, [x0], #16
-	ldp	x29, x30, [x0], #16
-
 	ldr	x6, [x0]
 	mov	sp, x6
+
+	/* Restore x19-x29 plus x30 */
+	ldp	x29, x30, [sp], #16
+	ldp	x27, x28, [sp], #16
+	ldp	x25, x26, [sp], #16
+	ldp	x23, x24, [sp], #16
+	ldp	x21, x22, [sp], #16
+	ldp	x19, x20, [sp], #16
 
 #ifdef CONFIG_TRACING
 	stp	xzr, x30, [sp, #-16]!

--- a/arch/arm/include/aarch64/stack.h
+++ b/arch/arm/include/aarch64/stack.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Stack helpers for AArch64 Cortex-A CPUs
+ *
+ * Stack helper functions.
+ */
+
+#ifndef ZEPHYR_ARCH_ARM_INCLUDE_AARCH64_STACK_H_
+#define ZEPHYR_ARCH_ARM_INCLUDE_AARCH64_STACK_H_
+
+#ifdef _ASMLANGUAGE
+
+/* nothing */
+
+#else
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct _callee_saved_stack {
+	uint64_t x29, x30;
+	uint64_t x27, x28;
+	uint64_t x25, x26;
+	uint64_t x23, x24;
+	uint64_t x21, x22;
+	uint64_t x19, x20;
+};
+
+typedef struct _callee_saved_stack _callee_saved_stack_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ASMLANGUAGE */
+
+#endif /* ZEPHYR_ARCH_ARM_INCLUDE_AARCH64_STACK_H_ */

--- a/arch/arm/include/kernel_arch_data.h
+++ b/arch/arm/include/kernel_arch_data.h
@@ -31,6 +31,7 @@
 #include <aarch32/cortex_r/stack.h>
 #include <aarch32/cortex_r/exc.h>
 #elif defined(CONFIG_CPU_CORTEX_A)
+#include <aarch64/stack.h>
 #include <aarch64/exc.h>
 #endif
 

--- a/include/arch/arm/aarch64/thread.h
+++ b/include/arch/arm/aarch64/thread.h
@@ -23,18 +23,6 @@
 #include <zephyr/types.h>
 
 struct _callee_saved {
-	uint64_t x19;
-	uint64_t x20;
-	uint64_t x21;
-	uint64_t x22;
-	uint64_t x23;
-	uint64_t x24;
-	uint64_t x25;
-	uint64_t x26;
-	uint64_t x27;
-	uint64_t x28;
-	uint64_t x29; /* FP */
-	uint64_t x30; /* LR */
 	uint64_t sp;
 };
 


### PR DESCRIPTION
This PR is taken out from an old discussion at #22877. I still think this is a change worth to have especially because soon I'll be start working again on the switch to the new arch_switch().