### PR TITLE
boards: arm: Fix incorrect Kconfig dependencies for FXOS8700_DRDY_INT1

### DIFF
--- a/boards/arm/frdm_k82f/Kconfig.defconfig
+++ b/boards/arm/frdm_k82f/Kconfig.defconfig
@@ -32,7 +32,7 @@ endif # FXOS8700
 
 config FXOS8700_DRDY_INT1
 	default y
-	depends on FXOS8700
+	depends on FXOS8700_TRIGGER
 
 if PINMUX_MCUX
 

--- a/boards/arm/frdm_kw41z/Kconfig.defconfig
+++ b/boards/arm/frdm_kw41z/Kconfig.defconfig
@@ -33,7 +33,7 @@ endif # PINMUX_MCUX
 
 config FXOS8700_DRDY_INT1
 	default y
-	depends on FXOS8700
+	depends on FXOS8700_TRIGGER
 
 config SPI_0
 	default y

--- a/boards/arm/warp7_m4/Kconfig.defconfig
+++ b/boards/arm/warp7_m4/Kconfig.defconfig
@@ -10,7 +10,7 @@ config BOARD
 
 config FXOS8700_DRDY_INT1
 	default y
-	depends on FXOS8700
+	depends on FXOS8700_TRIGGER
 
 config FXAS21002_DRDY_INT1
 	default y

--- a/boards/arm/warp7_m4/Kconfig.defconfig
+++ b/boards/arm/warp7_m4/Kconfig.defconfig
@@ -14,7 +14,7 @@ config FXOS8700_DRDY_INT1
 
 config FXAS21002_DRDY_INT1
 	default y
-	depends on FXAS21002
+	depends on FXAS21002_TRIGGER
 
 if !XIP
 config FLASH_SIZE


### PR DESCRIPTION
The fxos8700 sensor driver defines the Kconfig symbol FXOS8700_DRDY_INT1
to depend on FXOS8700_TRIGGER, but several board defconfigs were
incorrectly overriding it to depend on FXOS8700.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>