### PR TITLE
boards: arm: stm32f3_disco: enable PWM

### DIFF
--- a/boards/arm/stm32f3_disco/doc/index.rst
+++ b/boards/arm/stm32f3_disco/doc/index.rst
@@ -98,6 +98,9 @@ features:
 +-----------+------------+-------------------------------------+
 | IWDG      | on-chip    | Independent WatchDoG                |
 +-----------+------------+-------------------------------------+
+| PWM       | on-chip    | pwm                                 |
++-----------+------------+-------------------------------------+
+
 
 Other hardware features are not yet supported on Zephyr porting.
 
@@ -148,6 +151,7 @@ Default Zephyr Peripheral Mapping:
 - LD8 : PE14
 - LD9 : PE12
 - LD10 : PE13
+- PWM : PA8
 
 System Clock
 ============

--- a/boards/arm/stm32f3_disco/pinmux.c
+++ b/boards/arm/stm32f3_disco/pinmux.c
@@ -54,6 +54,9 @@ static const struct pin_config pinconf[] = {
 	{STM32_PIN_PD0, STM32F3_PINMUX_FUNC_PD0_CAN1_RX},
 	{STM32_PIN_PD1, STM32F3_PINMUX_FUNC_PD1_CAN1_TX},
 #endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(pwm1), okay) && CONFIG_PWM
+	{ STM32_PIN_PA8, STM32F3_PINMUX_FUNC_PA8_PWM1_CH1},
+#endif
 };
 
 static int pinmux_stm32_init(struct device *port)

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -145,3 +145,10 @@
 &iwdg {
 	status = "okay";
 };
+
+&timers1 {
+	status = "okay";
+	pwm1: pwm {
+		status = "okay";
+	};
+};

--- a/boards/arm/stm32f3_disco/stm32f3_disco.yaml
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.yaml
@@ -17,3 +17,4 @@ supported:
   - lsm303dlhc
   - nvs
   - can
+  - pwm


### PR DESCRIPTION
boards: arm: stm32f3_disco: enable PWM

Tested with tests/drivers/pwm/pwm_api/
(requires https://github.com/zephyrproject-rtos/zephyr/pull/27204)
and with oscillo.
