### PR TITLE
samples: nrf: onoff_level_lighting_vnd_app: fix build with mcumgr

### DIFF
--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/sample.yaml
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/sample.yaml
@@ -5,3 +5,8 @@ tests:
     platform_whitelist: nrf52840dk_nrf52840
     tags: bluetooth
     harness: bluetooth
+  sample.bluetooth.mesh.onoff_level_lighting_vnd.mcumgr:
+    platform_whitelist: nrf52840dk_nrf52840
+    tags: bluetooth
+    harness: bluetooth
+    extra_args: OVERLAY_CONFIG="prj_smp_svr.conf"

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/main.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/main.c
@@ -16,7 +16,7 @@
 #include "transition.h"
 
 #if defined(CONFIG_MCUMGR)
-#include <mgmt/smp_bt.h>
+#include <mgmt/mcumgr/smp_bt.h>
 #include "smp_svr.h"
 #endif
 

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/smp_svr.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/smp_svr.c
@@ -9,8 +9,8 @@
 #include <bluetooth/conn.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/gatt.h>
-#include <mgmt/buf.h>
-#include <mgmt/smp_bt.h>
+#include <mgmt/mcumgr/buf.h>
+#include <mgmt/mcumgr/smp_bt.h>
 #include <stats/stats.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
There is an optional mcumgr enabled prj_smp_svr.conf configuration
file. Using it results in following errors:

  .../src/smp_svr.c:12:10: fatal error: mgmt/buf.h: No such file or \
  directory
     12 | #include <mgmt/buf.h>
        |

Fix include paths to keep sample buildable with mcumgr enabled.

Enable also build with prj_smp_svr.conf config, so future failures
can be detected by sanitycheck.

Fixes: c200b1c5e634 ("mgmt: Move mcumgr into its own folder")