### PR TITLE
CMSIS RTOS v1: Clear Signals flag when a event is rised

### DIFF
--- a/lib/cmsis_rtos_v1/cmsis_signal.c
+++ b/lib/cmsis_rtos_v1/cmsis_signal.c
@@ -157,7 +157,11 @@ osEvent osSignalWait(int32_t signals, uint32_t millisec)
 
 	/* Clear signal flags as the thread is ready now */
 	key = irq_lock();
-	thread_def->signal_results &= ~(signals);
+	if (signals) {
+		thread_def->signal_results &= ~(signals);
+	} else {
+		thread_def->signal_results = 0;
+	}
 	irq_unlock(key);
 
 	return evt;


### PR DESCRIPTION
Hi, 

this PR should fix a issue on CMSIS RTOS v1 compatibility layer regarding signals handling: according to [CMSIS API](https://www.keil.com/pack/doc/CMSIS/RTOS/html/group__CMSIS__RTOS__SignalMgmt.html#ga38860acda96df47da6923348d96fc4c9) **osSignalWait** function called with 0, as signals argument , means *wait for any signals*.
Here https://github.com/zephyrproject-rtos/zephyr/blob/dc48999ee16322e25ede16531c2132a4aa785b29/lib/cmsis_rtos_v1/cmsis_signal.c#L156-L162
all previously set signals are indeed reported but the signals set doing `&= ~(signals)` is never reset. 
So when *any* signal is requested (osSignalWait called with **0**) all reported signals should be cleared.
