### PR TITLE
usb: use kernel stacks

### DIFF
--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -38,9 +38,9 @@ static K_FIFO_DEFINE(tx_queue);
 #define BLUETOOTH_INT_EP_MPS            MIN(BT_BUF_RX_SIZE, USB_MAX_FS_INT_MPS)
 
 /* HCI RX/TX threads */
-static K_THREAD_STACK_DEFINE(rx_thread_stack, CONFIG_BT_HCI_TX_STACK_SIZE);
+static K_KERNEL_STACK_DEFINE(rx_thread_stack, CONFIG_BT_HCI_TX_STACK_SIZE);
 static struct k_thread rx_thread_data;
-static K_THREAD_STACK_DEFINE(tx_thread_stack, 512);
+static K_KERNEL_STACK_DEFINE(tx_thread_stack, 512);
 static struct k_thread tx_thread_data;
 
 struct usb_bluetooth_config {
@@ -350,14 +350,14 @@ static int bluetooth_init(struct device *dev)
 	}
 
 	k_thread_create(&rx_thread_data, rx_thread_stack,
-			K_THREAD_STACK_SIZEOF(rx_thread_stack),
+			K_KERNEL_STACK_SIZEOF(rx_thread_stack),
 			(k_thread_entry_t)hci_rx_thread, NULL, NULL, NULL,
 			K_PRIO_COOP(8), 0, K_NO_WAIT);
 
 	k_thread_name_set(&rx_thread_data, "usb_bt_rx");
 
 	k_thread_create(&tx_thread_data, tx_thread_stack,
-			K_THREAD_STACK_SIZEOF(tx_thread_stack),
+			K_KERNEL_STACK_SIZEOF(tx_thread_stack),
 			(k_thread_entry_t)hci_tx_thread, NULL, NULL, NULL,
 			K_PRIO_COOP(8), 0, K_NO_WAIT);
 

--- a/subsys/usb/class/bt_h4.c
+++ b/subsys/usb/class/bt_h4.c
@@ -35,9 +35,9 @@ static K_FIFO_DEFINE(tx_queue);
 #define BT_H4_BULK_EP_MPS               MIN(BT_BUF_TX_SIZE, USB_MAX_FS_BULK_MPS)
 
 /* HCI RX/TX threads */
-static K_THREAD_STACK_DEFINE(rx_thread_stack, 512);
+static K_KERNEL_STACK_DEFINE(rx_thread_stack, 512);
 static struct k_thread rx_thread_data;
-static K_THREAD_STACK_DEFINE(tx_thread_stack, 512);
+static K_KERNEL_STACK_DEFINE(tx_thread_stack, 512);
 static struct k_thread tx_thread_data;
 
 struct usb_bt_h4_config {
@@ -234,14 +234,14 @@ static int bt_h4_init(struct device *dev)
 	}
 
 	k_thread_create(&rx_thread_data, rx_thread_stack,
-			K_THREAD_STACK_SIZEOF(rx_thread_stack),
+			K_KERNEL_STACK_SIZEOF(rx_thread_stack),
 			(k_thread_entry_t)hci_rx_thread, NULL, NULL, NULL,
 			K_PRIO_COOP(8), 0, K_NO_WAIT);
 
 	k_thread_name_set(&rx_thread_data, "usb_bt_h4_rx");
 
 	k_thread_create(&tx_thread_data, tx_thread_stack,
-			K_THREAD_STACK_SIZEOF(tx_thread_stack),
+			K_KERNEL_STACK_SIZEOF(tx_thread_stack),
 			(k_thread_entry_t)hci_tx_thread, NULL, NULL, NULL,
 			K_PRIO_COOP(8), 0, K_NO_WAIT);
 

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -52,7 +52,7 @@ LOG_MODULE_REGISTER(usb_msc);
 #define MAX_PACKET	CONFIG_MASS_STORAGE_BULK_EP_MPS
 
 #define BLOCK_SIZE	512
-#define DISK_THREAD_STACK_SZ	512
+#define DISK_KERNEL_STACK_SZ	512
 #define DISK_THREAD_PRIO	-5
 
 #define THREAD_OP_READ_QUEUED		1
@@ -104,7 +104,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_mass_config mass_cfg = {
 };
 
 static volatile int thread_op;
-static K_THREAD_STACK_DEFINE(mass_thread_stack, DISK_THREAD_STACK_SZ);
+static K_KERNEL_STACK_DEFINE(mass_thread_stack, DISK_KERNEL_STACK_SZ);
 static struct k_thread mass_thread_data;
 static struct k_sem disk_wait_sem;
 static volatile uint32_t defered_wr_sz;
@@ -988,7 +988,7 @@ static int mass_storage_init(struct device *dev)
 
 	/* Start a thread to offload disk ops */
 	k_thread_create(&mass_thread_data, mass_thread_stack,
-			DISK_THREAD_STACK_SZ,
+			DISK_KERNEL_STACK_SZ,
 			(k_thread_entry_t)mass_thread_main, NULL, NULL, NULL,
 			DISK_THREAD_PRIO, 0, K_NO_WAIT);
 

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -41,7 +41,7 @@ static struct k_fifo rndis_cmd_queue;
 /*
  * Stack for cmd thread
  */
-static K_THREAD_STACK_DEFINE(cmd_stack, 2048);
+static K_KERNEL_STACK_DEFINE(cmd_stack, 2048);
 static struct k_thread cmd_thread_data;
 
 struct usb_rndis_config {
@@ -1090,7 +1090,7 @@ static int rndis_init(struct device *arg)
 	usb_register_os_desc(&os_desc);
 
 	k_thread_create(&cmd_thread_data, cmd_stack,
-			K_THREAD_STACK_SIZEOF(cmd_stack),
+			K_KERNEL_STACK_SIZEOF(cmd_stack),
 			(k_thread_entry_t)cmd_thread,
 			NULL, NULL, NULL, K_PRIO_COOP(8), 0, K_NO_WAIT);
 


### PR DESCRIPTION
These threads don't run in user mode. Save some memory
if userspace is enabled.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>