### PR TITLE
canbus: use kernel stacks

### DIFF
--- a/subsys/canbus/canopen/CO_driver.c
+++ b/subsys/canbus/canopen/CO_driver.c
@@ -17,7 +17,7 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(canopen_driver);
 
-K_THREAD_STACK_DEFINE(canopen_tx_workq_stack,
+K_KERNEL_STACK_DEFINE(canopen_tx_workq_stack,
 		      CONFIG_CANOPEN_TX_WORKQUEUE_STACK_SIZE);
 
 struct k_work_q canopen_tx_workq;
@@ -468,7 +468,7 @@ static int canopen_init(struct device *dev)
 	ARG_UNUSED(dev);
 
 	k_work_q_start(&canopen_tx_workq, canopen_tx_workq_stack,
-		       K_THREAD_STACK_SIZEOF(canopen_tx_workq_stack),
+		       K_KERNEL_STACK_SIZEOF(canopen_tx_workq_stack),
 		       CONFIG_CANOPEN_TX_WORKQUEUE_PRIORITY);
 
 	k_work_init(&canopen_tx_queue.work, canopen_tx_retry);

--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -39,7 +39,7 @@ NET_BUF_POOL_VAR_DEFINE(isotp_tx_pool, CONFIG_ISOTP_TX_BUF_COUNT,
 			CONFIG_ISOTP_BUF_TX_DATA_POOL_SIZE, NULL);
 #endif
 
-K_THREAD_STACK_DEFINE(tx_stack, CONFIG_ISOTP_WORKQ_STACK_SIZE);
+K_KERNEL_STACK_DEFINE(tx_stack, CONFIG_ISOTP_WORKQ_STACK_SIZE);
 static struct k_work_q isotp_workq;
 
 static void receive_state_machine(struct isotp_recv_ctx *ctx);
@@ -1263,7 +1263,7 @@ static int isotp_workq_init(struct device *dev)
 	LOG_DBG("Starting workqueue");
 	k_work_q_start(&isotp_workq,
 		       tx_stack,
-		       K_THREAD_STACK_SIZEOF(tx_stack),
+		       K_KERNEL_STACK_SIZEOF(tx_stack),
 		       CONFIG_ISOTP_WORKQUEUE_PRIO);
 	k_thread_name_set(&isotp_workq.thread, "isotp_work");
 


### PR DESCRIPTION
These threads don't run in user mode, save some memory
if userspace is enabled.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>