### PR TITLE
net: ppp: select RING_BUFFER via Kconfig

### DIFF
--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -8,6 +8,7 @@ menuconfig NET_PPP
 	bool "Point-to-point (PPP) UART based driver"
 	depends on NET_L2_PPP
 	depends on NET_NATIVE
+	select RING_BUFFER
 	select UART_MUX if GSM_MUX
 
 if NET_PPP


### PR DESCRIPTION
PPP implementation uses ring_buffer API, but RING_BUFFER Kconfig option
was not selected so far. This resulted in linker errors about undefined
reference to `ring_buf_get_claim' and 'ring_buf_put'.

Add missing RING_BUFFER selection via Kconfig, so PPP driver is properly
built.