### PR TITLE
boards: arduino_due: Enable internal pullup on uart rx line

### DIFF
--- a/boards/arm/arduino_due/arduino_due.dts
+++ b/boards/arm/arduino_due/arduino_due.dts
@@ -52,3 +52,7 @@
 	status = "okay";
 	current-speed = <115200>;
 };
+
+&pa8a_uart_urxd {
+	bias-pull-up;
+};


### PR DESCRIPTION
This PR enables the internal pull-up resistor on the uart rx line to the onboard serial chip. This fixes #21754.

Additional information:
[Compare ArduinoCore-sam library](https://github.com/arduino/ArduinoCore-sam/commit/89caaafa20398560a6f13e75749fbe6b0addb15e)