### PR TITLE
tests/posix/fs: Fix close of bad file descriptor

### DIFF
--- a/tests/posix/fs/src/test_fs_open_flags.c
+++ b/tests/posix/fs/src/test_fs_open_flags.c
@@ -22,6 +22,7 @@ static int test_file_open_flags(void)
 	fd = open(THE_FILE, 0);
 	if (fd >= 0 || errno != ENOENT) {
 		TC_PRINT("Expected fail; fd = %d, errno = %d\n", fd, errno);
+		close(fd);
 		return TC_FAIL;
 	}
 
@@ -29,12 +30,14 @@ static int test_file_open_flags(void)
 	fd = open(THE_FILE, O_RDONLY);
 	if (fd >= 0 || errno != ENOENT) {
 		TC_PRINT("Expected fail; fd = %d, errno = %d\n", fd, errno);
+		close(fd);
 		return TC_FAIL;
 	}
 	TC_PRINT("Open on non-existent file, flags = O_WRONLY\n");
 	fd = open(THE_FILE, O_WRONLY);
 	if (fd >= 0 || errno != ENOENT) {
 		TC_PRINT("Expected fail; fd = %d, errno = %d\n", fd, errno);
+		close(fd);
 		return TC_FAIL;
 	}
 
@@ -42,6 +45,7 @@ static int test_file_open_flags(void)
 	fd = open(THE_FILE, O_RDWR);
 	if (fd >= 0 || errno != ENOENT) {
 		TC_PRINT("Expected fail; fd = %d, errno = %d\n", fd, errno);
+		close(fd);
 		return TC_FAIL;
 	}
 	/* end 1 */

--- a/tests/posix/fs/src/test_fs_open_flags.c
+++ b/tests/posix/fs/src/test_fs_open_flags.c
@@ -51,7 +51,6 @@ static int test_file_open_flags(void)
 	fd = open(THE_FILE, O_CREAT | O_WRONLY);
 	if (fd < 0) {
 		TC_PRINT("Expected success; fd = %d, errno = %d\n", fd, errno);
-		close(fd);
 		return TC_FAIL;
 	}
 


### PR DESCRIPTION
Two commits that fix Coverity issues:
[Coverity CID :211586] Resource leak in tests/posix/fs/src/test_fs_open_flags.c #27328
[Coverity CID :211585] Argument cannot be negative in tests/posix/fs/src/test_fs_open_flags.c #27327

