### PR TITLE
Bluetooth: host: Elevate security to L4 when SC only is enabled

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -705,6 +705,12 @@ typedef enum __packed {
  *  This function may return error if the pairing procedure has already been
  *  initiated by the local device or the peer device.
  *
+ *  @note When :option:`CONFIG_BT_SMP_SC_ONLY` is enabled then the security
+ *        level will always be level 4.
+ *
+ *  @note When :option:`CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY` is enabled then the
+ *        security level will always be level 3.
+ *
  *  @param conn Connection object.
  *  @param sec Requested security level.
  *

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1135,14 +1135,12 @@ int bt_conn_set_security(struct bt_conn *conn, bt_security_t sec)
 		return -ENOTCONN;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_SMP_SC_ONLY) &&
-	    sec < BT_SECURITY_L4) {
-		return -EOPNOTSUPP;
+	if (IS_ENABLED(CONFIG_BT_SMP_SC_ONLY)) {
+		sec = BT_SECURITY_L4;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY) &&
-	    sec > BT_SECURITY_L3) {
-		return -EOPNOTSUPP;
+	if (IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
+		sec = BT_SECURITY_L3;
 	}
 
 	/* nothing to do */


### PR DESCRIPTION
Elevate connections always to security mode 1 level 4 when
Secure Connections Only Mode has been enabled in the Security Manager.
    
Elevate connections always to security mode 1 level 3 when
Legacy pairing with OOB only has been enabled in the Security Manager.

Fixes: #27338
