### PR TITLE
shell: fix possible deadlock in shell_fprintf

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -541,8 +541,9 @@ struct shell_flags {
 	uint32_t tx_rdy      :1;
 	uint32_t mode_delete :1; /*!< Operation mode of backspace key */
 	uint32_t history_exit:1; /*!< Request to exit history mode */
-	uint32_t cmd_ctx	  :1; /*!< Shell is executing command */
+	uint32_t cmd_ctx     :1; /*!< Shell is executing command */
 	uint32_t last_nl     :8; /*!< Last received new line character */
+	uint32_t print_noinit:1; /*!< Print request from not initialized shell*/
 };
 
 BUILD_ASSERT((sizeof(struct shell_flags) == sizeof(uint32_t)),

--- a/include/shell/shell_dummy.h
+++ b/include/shell/shell_dummy.h
@@ -50,12 +50,19 @@ const struct shell *shell_backend_dummy_get_ptr(void);
  *
  * The returned data is always followed by a nul character at position *sizep
  *
- * @param shell		Shell pointer
- * @param sizep		Returns size of data in shell buffer
+ * @param shell	Shell pointer
+ * @param sizep	Returns size of data in shell buffer
  * @returns pointer to buffer containing shell output
  */
 const char *shell_backend_dummy_get_output(const struct shell *shell,
 					   size_t *sizep);
+
+/**
+ * @brief Clears the output buffer in the shell backend.
+ *
+ * @param shell	Shell pointer
+ */
+void shell_backend_dummy_clear_output(const struct shell *shell);
 
 #ifdef __cplusplus
 }

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1215,8 +1215,10 @@ void shell_thread(void *shell_handle, void *arg_log_backend,
 			     K_FOREVER);
 
 		if (err != 0) {
+			k_mutex_lock(&shell->ctx->wr_mtx, K_FOREVER);
 			shell_internal_fprintf(shell, SHELL_ERROR,
 					       "Shell thread error: %d", err);
+			k_mutex_unlock(&shell->ctx->wr_mtx);
 			return;
 		}
 
@@ -1287,13 +1289,16 @@ int shell_start(const struct shell *shell)
 		return -ENOTSUP;
 	}
 
+	k_mutex_lock(&shell->ctx->wr_mtx, K_FOREVER);
+
 	if (IS_ENABLED(CONFIG_SHELL_VT100_COLORS)) {
 		shell_vt100_color_set(shell, SHELL_NORMAL);
 	}
 
 	shell_raw_fprintf(shell->fprintf_ctx, "\n\n");
-
 	state_set(shell, SHELL_STATE_ACTIVE);
+
+	k_mutex_unlock(&shell->ctx->wr_mtx);
 
 	return 0;
 }

--- a/subsys/shell/shell_dummy.c
+++ b/subsys/shell/shell_dummy.c
@@ -114,12 +114,19 @@ const struct shell *shell_backend_dummy_get_ptr(void)
 const char *shell_backend_dummy_get_output(const struct shell *shell,
 					   size_t *sizep)
 {
-	struct shell_dummy *sh_dummy;
+	struct shell_dummy *sh_dummy = (struct shell_dummy *)shell->iface->ctx;
 
-	sh_dummy = (struct shell_dummy *)shell->iface->ctx;
 	sh_dummy->buf[sh_dummy->len] = '\0';
 	*sizep = sh_dummy->len;
 	sh_dummy->len = 0;
 
 	return sh_dummy->buf;
+}
+
+void shell_backend_dummy_clear_output(const struct shell *shell)
+{
+	struct shell_dummy *sh_dummy = (struct shell_dummy *)shell->iface->ctx;
+
+	sh_dummy->buf[0] = '\0';
+	sh_dummy->len = 0;
 }

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -151,6 +151,16 @@ static inline void flag_last_nl_set(const struct shell *shell, uint8_t val)
 	shell->ctx->internal.flags.last_nl = val;
 }
 
+static inline bool flag_print_noinit_get(const struct shell *shell)
+{
+	return shell->ctx->internal.flags.print_noinit == 1 ? true : false;
+}
+
+static inline void flag_print_noinit_set(const struct shell *shell, bool val)
+{
+	shell->ctx->internal.flags.print_noinit = val ? 1 : 0;
+}
+
 void shell_op_cursor_vert_move(const struct shell *shell, int32_t delta);
 void shell_op_cursor_horiz_move(const struct shell *shell, int32_t delta);
 

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -68,7 +68,7 @@ static inline void shell_putc(const struct shell *shell, char ch)
 
 static inline bool flag_insert_mode_get(const struct shell *shell)
 {
-	return ((shell->ctx->internal.flags.insert_mode == 1) ? true : false);
+	return shell->ctx->internal.flags.insert_mode == 1;
 }
 
 static inline void flag_insert_mode_set(const struct shell *shell, bool val)
@@ -78,7 +78,7 @@ static inline void flag_insert_mode_set(const struct shell *shell, bool val)
 
 static inline bool flag_use_colors_get(const struct shell *shell)
 {
-	return shell->ctx->internal.flags.use_colors == 1 ? true : false;
+	return shell->ctx->internal.flags.use_colors == 1;
 }
 
 static inline void flag_use_colors_set(const struct shell *shell, bool val)
@@ -88,7 +88,7 @@ static inline void flag_use_colors_set(const struct shell *shell, bool val)
 
 static inline bool flag_echo_get(const struct shell *shell)
 {
-	return shell->ctx->internal.flags.echo == 1 ? true : false;
+	return shell->ctx->internal.flags.echo == 1;
 }
 
 static inline void flag_echo_set(const struct shell *shell, bool val)
@@ -98,12 +98,12 @@ static inline void flag_echo_set(const struct shell *shell, bool val)
 
 static inline bool flag_processing_get(const struct shell *shell)
 {
-	return shell->ctx->internal.flags.processing == 1 ? true : false;
+	return shell->ctx->internal.flags.processing == 1;
 }
 
 static inline bool flag_tx_rdy_get(const struct shell *shell)
 {
-	return shell->ctx->internal.flags.tx_rdy == 1 ? true : false;
+	return shell->ctx->internal.flags.tx_rdy == 1;
 }
 
 static inline void flag_tx_rdy_set(const struct shell *shell, bool val)
@@ -113,7 +113,7 @@ static inline void flag_tx_rdy_set(const struct shell *shell, bool val)
 
 static inline bool flag_mode_delete_get(const struct shell *shell)
 {
-	return shell->ctx->internal.flags.mode_delete == 1 ? true : false;
+	return shell->ctx->internal.flags.mode_delete == 1;
 }
 
 static inline void flag_mode_delete_set(const struct shell *shell, bool val)
@@ -123,7 +123,7 @@ static inline void flag_mode_delete_set(const struct shell *shell, bool val)
 
 static inline bool flag_history_exit_get(const struct shell *shell)
 {
-	return shell->ctx->internal.flags.history_exit == 1 ? true : false;
+	return shell->ctx->internal.flags.history_exit == 1;
 }
 
 static inline void flag_history_exit_set(const struct shell *shell, bool val)
@@ -133,7 +133,7 @@ static inline void flag_history_exit_set(const struct shell *shell, bool val)
 
 static inline bool flag_cmd_ctx_get(const struct shell *shell)
 {
-	return shell->ctx->internal.flags.cmd_ctx == 1 ? true : false;
+	return shell->ctx->internal.flags.cmd_ctx == 1;
 }
 
 static inline void flag_cmd_ctx_set(const struct shell *shell, bool val)
@@ -153,7 +153,7 @@ static inline void flag_last_nl_set(const struct shell *shell, uint8_t val)
 
 static inline bool flag_print_noinit_get(const struct shell *shell)
 {
-	return shell->ctx->internal.flags.print_noinit == 1 ? true : false;
+	return shell->ctx->internal.flags.print_noinit == 1;
 }
 
 static inline void flag_print_noinit_set(const struct shell *shell, bool val)

--- a/tests/shell/src/main.c
+++ b/tests/shell/src/main.c
@@ -327,7 +327,7 @@ static void test_shell_fprintf(void)
 	zassert_not_null(shell, "Failed to get shell");
 
 	/* Clear the output buffer */
-	shell_backend_dummy_get_output(shell, &size);
+	shell_backend_dummy_clear_output(shell);
 
 	shell_fprintf(shell, SHELL_VT100_COLOR_DEFAULT, "testing %d %s %c",
 		      1, "2", '3');
@@ -388,6 +388,9 @@ void test_main(void)
 			ztest_unit_test(test_set_root_cmd),
 			ztest_unit_test(test_raw_arg)
 			);
+
+	/* Let the shell backend initialize. */
+	k_msleep(20);
 
 	ztest_run_test_suite(shell_test_suite);
 }


### PR DESCRIPTION
Disable shell print functions if the shell is not initialized.

Fixes #27161

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordisemi.no>