### PR TITLE
sanitycheck: Fix test cases names

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -1524,7 +1524,7 @@ Tests should reference the category and subsystem with a dot as a separator.
                 for match in _matches:
                     if not match.decode().startswith("test_"):
                         warnings = "Found a test that does not start with test_"
-                matches = [match.decode().replace("test_", "") for match in _matches]
+                matches = [match.decode().replace("test_", "", 1) for match in _matches]
                 return matches, warnings
 
     def scan_path(self, path):

--- a/scripts/tests/sanitycheck/test_testinstance.py
+++ b/scripts/tests/sanitycheck/test_testinstance.py
@@ -114,7 +114,7 @@ def test_get_unique_exception(testcase_root, workdir, name, exception):
         assert unique == exception
 
 TESTDATA_5 = [
-    ("testcases/tests/test_ztest.c", None, ['a', 'c', 'unit_a', 'newline', 'aa', 'user', 'last']),
+    ("testcases/tests/test_ztest.c", None, ['a', 'c', 'unit_a', 'newline', 'test_test_aa', 'user', 'last']),
     ("testcases/tests/test_a/test_ztest_error.c", "Found a test that does not start with test_", ['1a', '1c', '2a', '2b']),
     ("testcases/tests/test_a/test_ztest_error_1.c", "found invalid #ifdef, #endif in ztest_test_suite()", ['unit_1a', 'unit_1b', 'Unit_1c']),
 ]
@@ -131,7 +131,7 @@ def test_scan_file(test_data, test_file, expected_warnings, expected_subcases):
 
 
 TESTDATA_6 = [
-    ("testcases/tests", ['a', 'c', 'unit_a', 'newline', 'aa', 'user', 'last']),
+    ("testcases/tests", ['a', 'c', 'unit_a', 'newline', 'test_test_aa', 'user', 'last']),
     ("testcases/tests/test_a", ['unit_1a', 'unit_1b', 'Unit_1c', '1a', '1c', '2a', '2b']),
 ]
 


### PR DESCRIPTION
This commit limits the removal of `test_` from test case name
to only the first occurance. There are test cases with `test_`
also in the middle of their names and removing it couses mismatches
between extracted testcases and the names obtained when passing

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>