### PR TITLE
Assembly cleanup for ARM64

### DIFF
--- a/arch/arm/core/aarch64/isr_wrapper.S
+++ b/arch/arm/core/aarch64/isr_wrapper.S
@@ -36,10 +36,10 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 	z_arm64_enter_exc
 
 	/* ++(_kernel->nested) to be checked by arch_is_in_isr() */
-	ldr	x1, =_kernel
-	ldr	x2, [x1, #_kernel_offset_to_nested]
-	add	x2, x2, #1
-	str	x2, [x1, #_kernel_offset_to_nested]
+	ldr	x0, =_kernel
+	ldr	x1, [x0, #_kernel_offset_to_nested]
+	add	x1, x1, #1
+	str	x1, [x0, #_kernel_offset_to_nested]
 
 #ifdef CONFIG_TRACING
 	bl	sys_trace_isr_enter
@@ -80,18 +80,18 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 #endif
 
 	/* --(_kernel->nested) */
-	ldr	x1, =_kernel
-	ldr	x2, [x1, #_kernel_offset_to_nested]
-	sub	x2, x2, #1
-	str	x2, [x1, #_kernel_offset_to_nested]
+	ldr	x0, =_kernel
+	ldr	x1, [x0, #_kernel_offset_to_nested]
+	sub	x1, x1, #1
+	str	x1, [x0, #_kernel_offset_to_nested]
 
-	cmp	x2, #0
+	cmp	x1, #0
 	bne	exit
 
 	/* Check if we need to context switch */
-	ldr	x2, [x1, #_kernel_offset_to_current]
-	ldr	x3, [x1, #_kernel_offset_to_ready_q_cache]
-	cmp	x2, x3
+	ldr	x1, [x0, #_kernel_offset_to_current]
+	ldr	x2, [x0, #_kernel_offset_to_ready_q_cache]
+	cmp	x1, x2
 	beq	exit
 
 	/* Switch thread */

--- a/arch/arm/core/aarch64/isr_wrapper.S
+++ b/arch/arm/core/aarch64/isr_wrapper.S
@@ -33,7 +33,7 @@ GDATA(_sw_isr_table)
 
 GTEXT(_isr_wrapper)
 SECTION_FUNC(TEXT, _isr_wrapper)
-	z_arm64_enter_exc
+	z_arm64_enter_exc x0, x1, x2
 
 	/* ++(_kernel->nested) to be checked by arch_is_in_isr() */
 	ldr	x0, =_kernel
@@ -108,5 +108,5 @@ exit:
 #ifdef CONFIG_STACK_SENTINEL
 	bl	z_check_stack_sentinel
 #endif
-	z_arm64_exit_exc
+	z_arm64_exit_exc x0, x1, x2
 

--- a/arch/arm/core/aarch64/macro_priv.inc
+++ b/arch/arm/core/aarch64/macro_priv.inc
@@ -43,7 +43,7 @@
 	 * Store SPSR_ELn and ELR_ELn. This is needed to support nested
 	 * exception handlers
 	 */
-	switch_el x3, 3f, 2f, 1f
+	switch_el x2, 3f, 2f, 1f
 3:
 	mrs	x0, spsr_el3
 	mrs	x1, elr_el3
@@ -77,7 +77,7 @@
 	 * exception handlers
 	 */
 	ldp	x0, x1, [sp], #16
-	switch_el x3, 3f, 2f, 1f
+	switch_el x2, 3f, 2f, 1f
 3:
 	msr	spsr_el3, x0
 	msr	elr_el3, x1

--- a/arch/arm/core/aarch64/macro_priv.inc
+++ b/arch/arm/core/aarch64/macro_priv.inc
@@ -19,7 +19,7 @@
  * @return N/A
  */
 
-.macro z_arm64_enter_exc
+.macro z_arm64_enter_exc xreg0, xreg1, xreg2
 	/*
 	 * Two things can happen:
 	 *
@@ -43,20 +43,20 @@
 	 * Store SPSR_ELn and ELR_ELn. This is needed to support nested
 	 * exception handlers
 	 */
-	switch_el x2, 3f, 2f, 1f
+	switch_el \xreg0, 3f, 2f, 1f
 3:
-	mrs	x0, spsr_el3
-	mrs	x1, elr_el3
+	mrs	\xreg1, spsr_el3
+	mrs	\xreg2, elr_el3
 	b	0f
 2:
-	mrs	x0, spsr_el2
-	mrs	x1, elr_el2
+	mrs	\xreg1, spsr_el2
+	mrs	\xreg2, elr_el2
 	b	0f
 1:
-	mrs	x0, spsr_el1
-	mrs	x1, elr_el1
+	mrs	\xreg1, spsr_el1
+	mrs	\xreg2, elr_el1
 0:
-	stp	x0, x1, [sp, #-16]!
+	stp	\xreg1, \xreg2, [sp, #-16]!
 .endm
 
 /**
@@ -71,24 +71,24 @@
  * @return N/A
  */
 
-.macro z_arm64_exit_exc
+.macro z_arm64_exit_exc xreg0, xreg1, xreg2
 	/*
 	 * Restore SPSR_ELn and ELR_ELn. This is needed to support nested
 	 * exception handlers
 	 */
-	ldp	x0, x1, [sp], #16
-	switch_el x2, 3f, 2f, 1f
+	ldp	\xreg0, \xreg1, [sp], #16
+	switch_el \xreg2, 3f, 2f, 1f
 3:
-	msr	spsr_el3, x0
-	msr	elr_el3, x1
+	msr	spsr_el3, \xreg0
+	msr	elr_el3, \xreg1
 	b	0f
 2:
-	msr	spsr_el2, x0
-	msr	elr_el2, x1
+	msr	spsr_el2, \xreg0
+	msr	elr_el2, \xreg1
 	b	0f
 1:
-	msr	spsr_el1, x0
-	msr	elr_el1, x1
+	msr	spsr_el1, \xreg0
+	msr	elr_el1, \xreg1
 0:
 	/*
 	 * In x30 we can have:

--- a/arch/arm/core/aarch64/swap_helper.S
+++ b/arch/arm/core/aarch64/swap_helper.S
@@ -152,7 +152,7 @@ SECTION_FUNC(TEXT, z_thread_entry_wrapper)
 
 GTEXT(z_arm64_svc)
 SECTION_FUNC(TEXT, z_arm64_svc)
-	z_arm64_enter_exc
+	z_arm64_enter_exc x0, x1, x2
 
 	switch_el x1, 3f, 2f, 1f
 3:
@@ -208,7 +208,7 @@ context_switch:
 	bl	z_arm64_context_switch
 
 exit:
-	z_arm64_exit_exc
+	z_arm64_exit_exc x0, x1, x2
 
 inv:
 	mov	x0, #0 /* K_ERR_CPU_EXCEPTION */

--- a/arch/arm/core/aarch64/swap_helper.S
+++ b/arch/arm/core/aarch64/swap_helper.S
@@ -38,44 +38,44 @@ SECTION_FUNC(TEXT, z_arm64_context_switch)
 	bl	sys_trace_thread_switched_in
 	ldp	xzr, x30, [sp], #16
 #endif
-	/* load _kernel into x1 and current k_thread into x2 */
-	ldr	x1, =_kernel
-	ldr	x2, [x1, #_kernel_offset_to_current]
+	/* load _kernel into x0 and current k_thread into x1 */
+	ldr	x0, =_kernel
+	ldr	x1, [x0, #_kernel_offset_to_current]
 
-	/* addr of callee-saved regs in thread in x0 */
-	ldr	x0, =_thread_offset_to_callee_saved
-	add	x0, x0, x2
+	/* addr of callee-saved regs in thread in x2 */
+	ldr	x2, =_thread_offset_to_callee_saved
+	add	x2, x2, x1
 
 	/* Store rest of process context including x30 */
-	stp	x19, x20, [x0], #16
-	stp	x21, x22, [x0], #16
-	stp	x23, x24, [x0], #16
-	stp	x25, x26, [x0], #16
-	stp	x27, x28, [x0], #16
-	stp	x29, x30, [x0], #16
+	stp	x19, x20, [x2], #16
+	stp	x21, x22, [x2], #16
+	stp	x23, x24, [x2], #16
+	stp	x25, x26, [x2], #16
+	stp	x27, x28, [x2], #16
+	stp	x29, x30, [x2], #16
 
 	/* Save the current SP */
-	mov	x6, sp
-	str	x6, [x0]
+	mov	x1, sp
+	str	x1, [x2]
 
 	/* fetch the thread to run from the ready queue cache */
-	ldr	x2, [x1, #_kernel_offset_to_ready_q_cache]
-	str	x2, [x1, #_kernel_offset_to_current]
+	ldr	x1, [x0, #_kernel_offset_to_ready_q_cache]
+	str	x1, [x0, #_kernel_offset_to_current]
 
-	/* addr of callee-saved regs in thread in x0 */
-	ldr	x0, =_thread_offset_to_callee_saved
-	add	x0, x0, x2
+	/* addr of callee-saved regs in thread in x2 */
+	ldr	x2, =_thread_offset_to_callee_saved
+	add	x2, x2, x1
 
 	/* Restore x19-x29 plus x30 */
-	ldp	x19, x20, [x0], #16
-	ldp	x21, x22, [x0], #16
-	ldp	x23, x24, [x0], #16
-	ldp	x25, x26, [x0], #16
-	ldp	x27, x28, [x0], #16
-	ldp	x29, x30, [x0], #16
+	ldp	x19, x20, [x2], #16
+	ldp	x21, x22, [x2], #16
+	ldp	x23, x24, [x2], #16
+	ldp	x25, x26, [x2], #16
+	ldp	x27, x28, [x2], #16
+	ldp	x29, x30, [x2], #16
 
-	ldr	x6, [x0]
-	mov	sp, x6
+	ldr	x1, [x2]
+	mov	sp, x1
 
 #ifdef CONFIG_TRACING
 	stp	xzr, x30, [sp, #-16]!
@@ -154,7 +154,7 @@ GTEXT(z_arm64_svc)
 SECTION_FUNC(TEXT, z_arm64_svc)
 	z_arm64_enter_exc
 
-	switch_el x3, 3f, 2f, 1f
+	switch_el x1, 3f, 2f, 1f
 3:
 	mrs	x0, esr_el3
 	b	0f
@@ -170,38 +170,38 @@ SECTION_FUNC(TEXT, z_arm64_svc)
 	bne	inv
 
 	/* Demux the SVC call */
-	and	x2, x0, #0xff
-	cmp	x2, #_SVC_CALL_CONTEXT_SWITCH
+	and	x1, x0, #0xff
+	cmp	x1, #_SVC_CALL_CONTEXT_SWITCH
 	beq	context_switch
 
 #ifdef CONFIG_IRQ_OFFLOAD
-	cmp	x2, #_SVC_CALL_IRQ_OFFLOAD
+	cmp	x1, #_SVC_CALL_IRQ_OFFLOAD
 	beq	offload
 	b	inv
 offload:
 	/* ++(_kernel->nested) to be checked by arch_is_in_isr() */
-	ldr	x1, =_kernel
-	ldr	x2, [x1, #_kernel_offset_to_nested]
-	add	x2, x2, #1
-	str	x2, [x1, #_kernel_offset_to_nested]
+	ldr	x0, =_kernel
+	ldr	x1, [x0, #_kernel_offset_to_nested]
+	add	x1, x1, #1
+	str	x1, [x0, #_kernel_offset_to_nested]
 
 	bl	z_irq_do_offload
 
 	/* --(_kernel->nested) */
-	ldr	x1, =_kernel
-	ldr	x2, [x1, #_kernel_offset_to_nested]
-	sub	x2, x2, #1
-	str	x2, [x1, #_kernel_offset_to_nested]
+	ldr	x0, =_kernel
+	ldr	x1, [x0, #_kernel_offset_to_nested]
+	sub	x1, x1, #1
+	str	x1, [x0, #_kernel_offset_to_nested]
 	b	exit
 #endif
 	b	inv
 
 context_switch:
 	/* Check if we need to context switch */
-	ldr	x1, =_kernel
-	ldr	x2, [x1, #_kernel_offset_to_current]
-	ldr	x3, [x1, #_kernel_offset_to_ready_q_cache]
-	cmp	x2, x3
+	ldr	x0, =_kernel
+	ldr	x1, [x0, #_kernel_offset_to_current]
+	ldr	x2, [x0, #_kernel_offset_to_ready_q_cache]
+	cmp	x1, x2
 	beq	exit
 
 	/* Switch thread */
@@ -211,8 +211,8 @@ exit:
 	z_arm64_exit_exc
 
 inv:
-	mov	x1, sp
 	mov	x0, #0 /* K_ERR_CPU_EXCEPTION */
+	mov	x1, sp
 	b	z_arm64_fatal_error
 
 GTEXT(z_arm64_call_svc)

--- a/arch/arm/core/aarch64/vector_table.S
+++ b/arch/arm/core/aarch64/vector_table.S
@@ -90,7 +90,7 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
 
 	/* Current EL with SPx / SError */
 	.align 7
-	z_arm64_enter_exc
+	z_arm64_enter_exc x0, x1, x2
 
 	mov	x1, sp
 	mov	x0, #0 /* K_ERR_CPU_EXCEPTION */


### PR DESCRIPTION
Two commits:
- The first one is just a cleanup commit to rework a bit how registers are used. Hopefully now the registers allocation makes a bit more sense.
- The second one is a rework of two macros. This is useful when we do not want to clobber some volatile registers.