### PR TITLE
drivers: wifi: eswifi: Coverity fix

### DIFF
--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -75,7 +75,6 @@ static inline int __parse_ssid(char *str, char *ssid)
 static void __parse_scan_res(char *str, struct wifi_scan_result *res)
 {
 	int field = 0;
-	int ret;
 
 	/* fmt => #001,"SSID",MACADDR,RSSI,BITRATE,MODE,SECURITY,BAND,CHANNEL */
 

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -177,13 +177,13 @@ struct eswifi_dev *eswifi_by_iface_idx(uint8_t iface)
 
 static int __parse_ipv4_address(char *str, char *ssid, uint8_t ip[4])
 {
-	unsigned int byte = -1;
+	int byte = -1;
 
 	/* fmt => [JOIN   ] SSID,192.168.2.18,0,0 */
 	while (*str && byte < 4) {
 		if (byte == -1) {
 			if (!strncmp(str, ssid, strlen(ssid))) {
-				byte = 0U;
+				byte = 0;
 				str += strlen(ssid);
 			}
 			str++;


### PR DESCRIPTION
- Fix #27326 (dead code in parse_ipv4)
- Fix non used variable fix