### PR TITLE
Fix ztest mock parameter count issue

### DIFF
--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -64,7 +64,7 @@ config ZTEST_MOCKING
 
 config ZTEST_PARAMETER_COUNT
 	int "Count of parameters or return values reserved"
-	default 1
+	default 10
 	depends on ZTEST_MOCKING
 	help
 	  Maximum amount of concurrent return values / expected parameters.

--- a/subsys/testsuite/ztest/include/ztest_mock.h
+++ b/subsys/testsuite/ztest/include/ztest_mock.h
@@ -55,24 +55,24 @@
 /**
  * @brief Tell function @a func to expect the data @a data for @a param
  *
- * When using ztest_check_expected_data(), tell that the data ponted by @a param
- * should be same as data at @a data.
- * Only data pointer is stored by this function so it must still be valid when
- * ztest_check_expected_data is called.
+ * When using ztest_check_expected_data(), the data pointed to by
+ * @a param should be same @a data in this function. Only data pointer is stored
+ * by this function, so it must still be valid when ztest_check_expected_data is
+ * called.
  *
  * @param func Function in question
  * @param param Parameter for which the data should be set
  * @param data pointer for the data for parameter @a param
  */
 #define ztest_expect_data(func, param, data)                                   \
-	z_ztest_expect_data(STRINGIFY(func), STRINGIFY(param), (data))
+	z_ztest_expect_data(STRINGIFY(func), STRINGIFY(param), (void *)(data))
 
 /**
  * @brief If data pointed by @a param don't match the data set by
  * ztest_expect_data(), fail the test
  *
- * This will first check that does @a param have a value to be expected, and
- * then checks whether the data pointed by parameter are equal to expected data.
+ * This will first check that @a param is expected to be null or non-null and
+ * then check whether the data pointed by parameter is equal to expected data.
  * If either of these checks fail, the current test will fail. This
  * must be called from the called function.
  *
@@ -80,8 +80,8 @@
  * @param length Length of the data to compare
  */
 #define ztest_check_expected_data(param, length)                               \
-	z_ztest_check_expected_data(__func__, STRINGIFY(param), (param),       \
-				    (length))
+	z_ztest_check_expected_data(__func__, STRINGIFY(param),                \
+				    (void *)(param), (length))
 
 /**
  * @brief Tell @a func that it should return @a value

--- a/subsys/testsuite/ztest/src/ztest_mock.c
+++ b/subsys/testsuite/ztest/src/ztest_mock.c
@@ -239,12 +239,12 @@ void z_ztest_check_expected_data(const char *fn, const char *name, void *data,
 		PRINT("%s:%s received null pointer\n", fn, name);
 		ztest_test_fail();
 	} else if (data == NULL && expected != NULL) {
-		PRINT("%s:%s received data fhile expected null pointer\n", fn,
+		PRINT("%s:%s received data while expected null pointer\n", fn,
 		      name);
 		ztest_test_fail();
 	} else if (data != NULL) {
 		if (memcmp(data, expected, length) != 0) {
-			PRINT("%s:%s data provided dont match\n", fn, name);
+			PRINT("%s:%s data provided don't match\n", fn, name);
 			ztest_test_fail();
 		}
 	}


### PR DESCRIPTION
If you tried to use more mock parameters than was set in the CONFIG_ZTEST_PARAMETER_COUNT, you would get an "unrelated" memory access violation in your test somewhere.

This PR
 - Fixes the out of bound array access
 - Cleans up comments and error strings
 - Cleans up prototype usage of ztest_expect_data to not required caller to cast to `void *`
 - Increases the default `CONFIG_ZTEST_PARAMETER_COUNT` from 1 to 10 when mocking is enabled (still guarded by `CONFIG_ZTEST_MOCKING`)