### PR TITLE
segger: update to version v3.12

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -110,7 +110,7 @@ manifest:
       revision: d216ec32cdb78ec873689234f710b3c9bb096bcd
       path: modules/lib/openthread
     - name: segger
-      revision: 6fcf61606d6012d2c44129edc033f59331e268bc
+      revision: pull/3/head
       path: modules/debug/segger
     - name: tinycbor
       path: modules/lib/tinycbor


### PR DESCRIPTION
Update to major version v3.12.

The most significant enhancement is the addition of real-time data acquisition
via UAR­T or TCP/IP. Any system with UART or TCP/IP connection, typically
Ethernet, can now be monitored and verified.

See https://github.com/zephyrproject-rtos/segger/pull/3