### PR TITLE
Bluetooth: Mesh: Silence proxy not connected log

### DIFF
--- a/subsys/bluetooth/mesh/pb_gatt.c
+++ b/subsys/bluetooth/mesh/pb_gatt.c
@@ -99,7 +99,7 @@ int bt_mesh_pb_gatt_close(struct bt_conn *conn)
 	BT_DBG("conn %p", conn);
 
 	if (link.conn != conn) {
-		BT_ERR("Not connected");
+		BT_DBG("Not connected");
 		return -ENOTCONN;
 	}
 


### PR DESCRIPTION
When performing node reset over a proxy connection, the disconnection is
asynchronous, and will finish after the reset callback goes to the
application. If the application restarts provisioning in this callback,
the disconnected-event is triggered after PB GATT is reactivated, and
this error is printed without any faults actually occurring.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>