### PR TITLE
cmake: Fix generated header file dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -570,7 +570,7 @@ add_custom_target(${SYSCALL_LIST_H_TARGET} DEPENDS ${syscall_list_h})
 add_custom_target(${PARSE_SYSCALLS_TARGET}
   DEPENDS
   ${syscalls_json}
-  ${subsys_jsonstruct_tags_json}
+  ${struct_tags_json}
   )
 
 # 64-bit systems do not require special handling of 64-bit system call
@@ -643,7 +643,7 @@ target_include_directories(${OFFSETS_LIB} PRIVATE
   ${ARCH_DIR}/${ARCH}/include
   )
 target_link_libraries(${OFFSETS_LIB} zephyr_interface)
-add_dependencies(     ${OFFSETS_LIB}
+add_dependencies(zephyr_interface
   ${SYSCALL_LIST_H_TARGET}
   ${DRIVER_VALIDATION_H_TARGET}
   ${KOBJ_TYPES_H_TARGET}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,9 +566,12 @@ add_custom_command(
   DEPENDS ${syscalls_subdirs_trigger} ${PARSE_SYSCALLS_HEADER_DEPENDS}
   )
 
-add_custom_target(${SYSCALL_LIST_H_TARGET} DEPENDS             ${syscall_list_h})
+add_custom_target(${SYSCALL_LIST_H_TARGET} DEPENDS ${syscall_list_h})
 add_custom_target(${PARSE_SYSCALLS_TARGET}
-	          DEPENDS ${syscalls_json} ${struct_tags_json})
+  DEPENDS
+  ${syscalls_json}
+  ${subsys_jsonstruct_tags_json}
+  )
 
 # 64-bit systems do not require special handling of 64-bit system call
 # parameters or return values, indicate this to the system call boilerplate
@@ -594,7 +597,6 @@ add_custom_command(OUTPUT include/generated/syscall_dispatch.c ${syscall_list_h}
   ${SYSCALL_SPLIT_TIMEOUT_ARG}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS ${PARSE_SYSCALLS_TARGET}
-  ${syscalls_json}
   )
 
 # This is passed into all calls to the gen_kobject_list.py script.
@@ -612,7 +614,6 @@ add_custom_command(
   DEPENDS
   ${ZEPHYR_BASE}/scripts/gen_kobject_list.py
   ${PARSE_SYSCALLS_TARGET}
-  ${struct_tags_json}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 add_custom_target(${DRIVER_VALIDATION_H_TARGET} DEPENDS ${DRV_VALIDATION})


### PR DESCRIPTION
Fix race condition in build when creating libraries in application and
depending on zephyr_interface.

lib/CMakeLists.txt:
```
    add_library(lib STATIC src/lib.c)
    zephyr_append_cmake_library(lib)
    target_link_libraries(lib PUBLIC zephyr_interface)
```
Gives following error message:
```
  from path/src/lib.c:6:
  zephyr/include/syscall.h:11:10: fatal error: syscall_list.h: \
  	No such file or directory
     11 | #include <syscall_list.h>
        |          ^~~~~~~~~~~~~~~~
  compilation terminated.
  [13/165] Generating include/generated/syscall_dispatch.c, \
  	include/generated/syscall_list.h
```