### PR TITLE
stm32h7 add entropy generator support

### DIFF
--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
@@ -63,3 +63,7 @@
 &mac {
 	status = "okay";
 };
+
+&rng {
+	status = "okay";
+};

--- a/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.series
@@ -16,4 +16,11 @@ config DMA_STM32_V1
 	default y
 	depends on DMA_STM32
 
+if ENTROPY_GENERATOR
+
+config ENTROPY_STM32_RNG
+	default y
+
+endif # ENTROPY_GENERATOR
+
 endif # SOC_SERIES_STM32H7X

--- a/soc/arm/st_stm32/stm32h7/soc.h
+++ b/soc/arm/st_stm32/stm32h7/soc.h
@@ -76,6 +76,10 @@
 #include <stm32h7xx_ll_tim.h>
 #endif /* CONFIG_PWM_STM32 */
 
+#ifdef CONFIG_ENTROPY_STM32_RNG
+#include <stm32h7xx_ll_rng.h>
+#endif /* CONFIG_ENTROPY_STM32_RNG */
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F7_SOC_H7_ */


### PR DESCRIPTION
Adds entropy generator support and removes explicit fulllibc support.

This PR needed for #27373