### PR TITLE
posix: expose getsockname() and sendmsg()

### DIFF
--- a/include/posix/sys/socket.h
+++ b/include/posix/sys/socket.h
@@ -73,6 +73,12 @@ static inline ssize_t sendto(int sock, const void *buf, size_t len, int flags,
 	return zsock_sendto(sock, buf, len, flags, dest_addr, addrlen);
 }
 
+static inline ssize_t sendmsg(int sock, const struct msghdr *message,
+			      int flags)
+{
+	return zsock_sendmsg(sock, message, flags);
+}
+
 static inline ssize_t recvfrom(int sock, void *buf, size_t max_len, int flags,
 			       struct sockaddr *src_addr, socklen_t *addrlen)
 {
@@ -89,6 +95,12 @@ static inline int setsockopt(int sock, int level, int optname,
 			     const void *optval, socklen_t optlen)
 {
 	return zsock_setsockopt(sock, level, optname, optval, optlen);
+}
+
+static inline int getsockname(int sock, struct sockaddr *addr,
+			      socklen_t *addrlen)
+{
+	return zsock_getsockname(sock, addr, addrlen);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
There exist zsock_ counterparts of the two mentioned
functions, but they were not exposed in the Zephyr POSIX API
(CONFIG_POSIX_API=y). This commit fills the gap.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>