### PR TITLE
net: buf: fix designated initializer order

### DIFF
--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -840,24 +840,24 @@ struct net_buf_pool {
 #if defined(CONFIG_NET_BUF_POOL_USAGE)
 #define NET_BUF_POOL_INITIALIZER(_pool, _alloc, _bufs, _count, _destroy) \
 	{                                                                    \
-		.alloc = _alloc,                                             \
 		.free = Z_LIFO_INITIALIZER(_pool.free),                     \
-		.__bufs = _bufs,                                             \
 		.buf_count = _count,                                         \
 		.uninit_count = _count,                                      \
 		.avail_count = _count,                                       \
-		.destroy = _destroy,                                         \
 		.name = STRINGIFY(_pool),                                    \
+		.destroy = _destroy,                                         \
+		.alloc = _alloc,                                             \
+		.__bufs = _bufs,                                             \
 	}
 #else
 #define NET_BUF_POOL_INITIALIZER(_pool, _alloc, _bufs, _count, _destroy)     \
 	{                                                                    \
-		.alloc = _alloc,                                             \
 		.free = Z_LIFO_INITIALIZER(_pool.free),                     \
-		.__bufs = _bufs,                                             \
 		.buf_count = _count,                                         \
 		.uninit_count = _count,                                      \
 		.destroy = _destroy,                                         \
+		.alloc = _alloc,                                             \
+		.__bufs = _bufs,                                             \
 	}
 #endif /* CONFIG_NET_BUF_POOL_USAGE */
 


### PR DESCRIPTION
Compile with `arm-none-eabi-g++` (10.2.0) fails with:
`error: designator order for field 'net_buf_pool::free' does not match declaration order in 'net_buf_pool'`
because C++ doesn't support out-of-order designated initializers.