### PR TITLE
net: openthread: radio: Removed retranssmisions from radio caps.

### DIFF
--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -611,8 +611,7 @@ otRadioCaps otPlatRadioGetCaps(otInstance *aInstance)
 	}
 
 	if (radio_caps & IEEE802154_HW_CSMA) {
-		caps |= OT_RADIO_CAPS_CSMA_BACKOFF |
-			OT_RADIO_CAPS_TRANSMIT_RETRIES;
+		caps |= OT_RADIO_CAPS_CSMA_BACKOFF;
 	}
 
 	if (radio_caps & IEEE802154_HW_TX_RX_ACK) {

--- a/tests/subsys/openthread/radio_test.c
+++ b/tests/subsys/openthread/radio_test.c
@@ -659,9 +659,7 @@ static void test_get_caps_test(void)
 
 	/* proper mapping */
 	ztest_returns_value(get_capabilities_caps_mock, IEEE802154_HW_CSMA);
-	zassert_equal(otPlatRadioGetCaps(ot),
-		      OT_RADIO_CAPS_TRANSMIT_RETRIES |
-			      OT_RADIO_CAPS_CSMA_BACKOFF,
+	zassert_equal(otPlatRadioGetCaps(ot), OT_RADIO_CAPS_CSMA_BACKOFF,
 		      "Incorrect capabilities returned.");
 
 	ztest_returns_value(get_capabilities_caps_mock,
@@ -684,8 +682,8 @@ static void test_get_caps_test(void)
 			IEEE802154_HW_TXTIME);
 	zassert_equal(
 		otPlatRadioGetCaps(ot),
-		OT_RADIO_CAPS_TRANSMIT_RETRIES | OT_RADIO_CAPS_CSMA_BACKOFF |
-			OT_RADIO_CAPS_ENERGY_SCAN | OT_RADIO_CAPS_ACK_TIMEOUT,
+		OT_RADIO_CAPS_CSMA_BACKOFF | OT_RADIO_CAPS_ENERGY_SCAN |
+			OT_RADIO_CAPS_ACK_TIMEOUT,
 		"Incorrect capabilities returned.");
 
 	rapi.get_capabilities = get_capabilities;


### PR DESCRIPTION
Zephyr platform does not support MAC retransmissions on its own,
so OT_RADIO_CAPS_TRANSMIT_RETRIES capability was removed.
It should not be enabled basing on IEEE802154_HW_CSMA support,
as these are quite seperate features. Current implementation
assumes that platform performs retransmissions on its own,
what is not provided and leads to lack of MAC retransmissions.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>