### PR TITLE
cmake: Set TOOLCHAIN_ARCH based on OS_PLATFORM

### DIFF
--- a/cmake/toolchain/zephyr/host-tools.cmake
+++ b/cmake/toolchain/zephyr/host-tools.cmake
@@ -12,7 +12,7 @@ set(MINIMUM_REQUIRED_SDK_VERSION 0.11.3)
 
 # This is the minimum required version for Zephyr to work (Old style)
 set(REQUIRED_SDK_VER 0.11.1)
-set(TOOLCHAIN_ARCH x86_64)
+cmake_host_system_information(RESULT TOOLCHAIN_ARCH QUERY OS_PLATFORM)
 
 set_ifndef(ZEPHYR_TOOLCHAIN_VARIANT $ENV{ZEPHYR_TOOLCHAIN_VARIANT} "")
 set_ifndef(ZEPHYR_SDK_INSTALL_DIR   $ENV{ZEPHYR_SDK_INSTALL_DIR} "")


### PR DESCRIPTION
To support a host environment of aarch64 (arm64) or x86_64 set
TOOLCHAIN_ARCH based on what OS_PLATFORM reports (which Linux will be
result of 'uname -m').

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>