### PR TITLE
boards: arm: mec15xx: Remove unnecessary property from SPI config.

### DIFF
--- a/boards/arm/mec1501modular_assy6885/support/spi_cfg.txt
+++ b/boards/arm/mec1501modular_assy6885/support/spi_cfg.txt
@@ -34,6 +34,5 @@ FwEntryAddress = 0
 UseECDSA = false
 ECDSAPrivKeyFile = ecprivkey001.pem
 ECDSAPrivKeyPassword = ECPRIVKEY001
-ECDSAPubKeyFile = ecpubkey001_crt.pem
 FwEncrypt = false
 AesGenECPubKeyFile = ecpubkey002_crt.pem

--- a/boards/arm/mec15xxevb_assy6853/support/spi_cfg.txt
+++ b/boards/arm/mec15xxevb_assy6853/support/spi_cfg.txt
@@ -34,6 +34,5 @@ FwEntryAddress = 0
 UseECDSA = false
 ECDSAPrivKeyFile = ecprivkey001.pem
 ECDSAPrivKeyPassword = ECPRIVKEY001
-ECDSAPubKeyFile = ecpubkey001_crt.pem
 FwEncrypt = false
 AesGenECPubKeyFile = ecpubkey002_crt.pem


### PR DESCRIPTION
Remove unnecessary SPI layout property in SPI layout config.

This works fine with old and new SPI generator tools

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>