### PR TITLE
Civetweb sample - show board name

### DIFF
--- a/samples/net/sockets/civetweb/CMakeLists.txt
+++ b/samples/net/sockets/civetweb/CMakeLists.txt
@@ -3,6 +3,6 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(hello_world)
+project(civetweb)
 
 target_sources(app PRIVATE src/main.c src/libc_extensions.c)

--- a/samples/net/sockets/civetweb/src/main.c
+++ b/samples/net/sockets/civetweb/src/main.c
@@ -89,6 +89,7 @@ int system_info_handler(struct mg_connection *conn, void *cbdata)
 	mg_printf(conn, "<li>host os - %s</li>\n", info.os);
 	mg_printf(conn, "<li>server - civetweb %s</li>\n", info.version);
 	mg_printf(conn, "<li>compiler - %s</li>\n", info.compiler);
+	mg_printf(conn, "<li>board - %s</li>\n", CONFIG_BOARD);
 	mg_printf(conn, "</ul>\n");
 
 	mg_printf(conn, "</body></html>\n");


### PR DESCRIPTION
This PR mades following changes to `samples/net/sockets/civetweb`:

1. changes project name to meaningful one
2. shows board name on system info page

Especially 2nd change could be helpful in debugging the SoC's with multiple CPU's like STM32H745 or either some NXP's, because the board name can be seen clearly within the sample.