### PR TITLE
soc: ti_simplelink: build power.c when device PM is enabled

### DIFF
--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/CMakeLists.txt
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/CMakeLists.txt
@@ -6,3 +6,4 @@ zephyr_sources(soc.c)
 zephyr_sources(ccfg.c)
 
 zephyr_library_sources_ifdef(CONFIG_SYS_POWER_MANAGEMENT    power.c)
+zephyr_library_sources_ifdef(CONFIG_DEVICE_POWER_MANAGEMENT   power.c)


### PR DESCRIPTION
On CC13x2/CC26x2, power.c should be built when either system or device
power management is enabled. Currently it is only doing so for the
former.

Fixes #27392

Signed-off-by: Vincent Wan <vwan@ti.com>