### PR TITLE
soc: arm: mchp: Add switch to configure JTAG pins

### DIFF
--- a/boards/arm/mec1501modular_assy6885/pinmux.c
+++ b/boards/arm/mec1501modular_assy6885/pinmux.c
@@ -98,6 +98,30 @@ static void i2c_pinmux(struct pinmux_ports_t *p, uint8_t port_sel)
 	}
 }
 
+static void configure_debug_interface(void)
+{
+	/* No debug support */
+	ECS_REGS->DEBUG_CTRL = 0;
+	ECS_REGS->ETM_CTRL = 0;
+
+#ifdef CONFIG_SOC_MEC1501_DEBUG_WITHOUT_TRACING
+	/* Release JTAG TDI and JTAG TDO pins so they can be
+	 * controlled by their respective PCR register (UART2).
+	 * For more details see table 44-1
+	 */
+	ECS_REGS->DEBUG_CTRL = (MCHP_ECS_DCTRL_DBG_EN |
+				MCHP_ECS_DCTRL_MODE_SWD);
+#elif defined(CONFIG_SOC_MEC1501_DEBUG_AND_TRACING)
+	#if defined(CONFIG_SOC_MEC1501_DEBUG_AND_ETM_TRACING)
+	#pragma error "TRACE DATA are not exposed in HW connector"
+	#elif defined(CONFIG_SOC_MEC1501_DEBUG_AND_SWV_TRACING)
+		ECS_REGS->DEBUG_CTRL = (MCHP_ECS_DCTRL_DBG_EN |
+				MCHP_ECS_DCTRL_MODE_SWD_SWV);
+	#endif /* CONFIG_SOC_MEC1501_DEBUG_AND_TRACING */
+
+#endif /* CONFIG_SOC_MEC1501_DEBUG_WITHOUT_TRACING */
+}
+
 static int board_pinmux_init(struct device *dev)
 {
 	ARG_UNUSED(dev);
@@ -141,12 +165,8 @@ static int board_pinmux_init(struct device *dev)
 #ifdef CONFIG_SOC_MEC1501_VTR3_1_8V
 	ECS_REGS->GPIO_BANK_PWR |= MCHP_ECS_VTR3_LVL_18;
 #endif
-	/* Release JTAG TDI and JTAG TDO pins so they can be
-	 * controlled by their respective PCR register (UART2).
-	 * For more details see table 44-1
-	 */
-	ECS_REGS->DEBUG_CTRL = (MCHP_ECS_DCTRL_DBG_EN |
-				MCHP_ECS_DCTRL_MODE_SWD);
+
+	configure_debug_interface();
 
 	/* Configure pins that are not GPIOS by default */
 #ifdef CONFIG_SOC_MEC1501_VCI_PINS_AS_GPIOS
@@ -190,10 +210,12 @@ static int board_pinmux_init(struct device *dev)
 
 	/* ADC pin muxes, ADC00 - ADC07 */
 	/* Note, by default ETM is enabled ADC00-ADC03 are not available */
+#ifndef CONFIG_SOC_MEC1501_DEBUG_AND_ETM_TRACING
 	pinmux_pin_set(porte, MCHP_GPIO_200, MCHP_GPIO_CTRL_MUX_F1);
 	pinmux_pin_set(porte, MCHP_GPIO_201, MCHP_GPIO_CTRL_MUX_F1);
 	pinmux_pin_set(porte, MCHP_GPIO_202, MCHP_GPIO_CTRL_MUX_F1);
 	pinmux_pin_set(porte, MCHP_GPIO_203, MCHP_GPIO_CTRL_MUX_F1);
+#endif
 	pinmux_pin_set(porte, MCHP_GPIO_204, MCHP_GPIO_CTRL_MUX_F1);
 	pinmux_pin_set(porte, MCHP_GPIO_205, MCHP_GPIO_CTRL_MUX_F1);
 	pinmux_pin_set(porte, MCHP_GPIO_206, MCHP_GPIO_CTRL_MUX_F1);

--- a/boards/arm/mec15xxevb_assy6853/pinmux.c
+++ b/boards/arm/mec15xxevb_assy6853/pinmux.c
@@ -98,6 +98,32 @@ static void i2c_pinmux(struct pinmux_ports_t *p, uint8_t port_sel)
 	}
 }
 
+static void configure_debug_interface(void)
+{
+	/* No debug support */
+	ECS_REGS->DEBUG_CTRL = 0;
+	ECS_REGS->ETM_CTRL = 0;
+
+#ifdef CONFIG_SOC_MEC1501_DEBUG_WITHOUT_TRACING
+	/* Release JTAG TDI and JTAG TDO pins so they can be
+	 * controlled by their respective PCR register (UART2).
+	 * For more details see table 44-1
+	 */
+	ECS_REGS->DEBUG_CTRL = (MCHP_ECS_DCTRL_DBG_EN |
+				MCHP_ECS_DCTRL_MODE_SWD);
+#elif defined(CONFIG_SOC_MEC1501_DEBUG_AND_TRACING)
+	#if defined(CONFIG_SOC_MEC1501_DEBUG_AND_ETM_TRACING)
+		ECS_REGS->ETM_CTRL = MCHP_ECS_ETM_CTRL_EN;
+		ECS_REGS->DEBUG_CTRL = (MCHP_ECS_DCTRL_DBG_EN |
+				MCHP_ECS_DCTRL_MODE_SWD);
+	#elif defined(CONFIG_SOC_MEC1501_DEBUG_AND_SWV_TRACING)
+		ECS_REGS->DEBUG_CTRL = (MCHP_ECS_DCTRL_DBG_EN |
+				MCHP_ECS_DCTRL_MODE_SWD_SWV);
+	#endif /* CONFIG_SOC_MEC1501_DEBUG_AND_TRACING */
+
+#endif /* CONFIG_SOC_MEC1501_DEBUG_WITHOUT_TRACING */
+}
+
 static int board_pinmux_init(struct device *dev)
 {
 	ARG_UNUSED(dev);
@@ -141,12 +167,8 @@ static int board_pinmux_init(struct device *dev)
 #ifdef CONFIG_SOC_MEC1501_VTR3_1_8V
 	ECS_REGS->GPIO_BANK_PWR |= MCHP_ECS_VTR3_LVL_18;
 #endif
-	/* Release JTAG TDI and JTAG TDO pins so they can be
-	 * controlled by their respective PCR register (UART2).
-	 * For more details see table 44-1
-	 */
-	ECS_REGS->DEBUG_CTRL = (MCHP_ECS_DCTRL_DBG_EN |
-				MCHP_ECS_DCTRL_MODE_SWD);
+
+	configure_debug_interface();
 
 	/* Configure pins that are not GPIOS by default */
 #ifdef CONFIG_SOC_MEC1501_VCI_PINS_AS_GPIOS
@@ -178,10 +200,12 @@ static int board_pinmux_init(struct device *dev)
 
 	/* ADC pin muxes, ADC00 - ADC07 */
 	/* Note, by default ETM is enabled ADC00-ADC03 are not available */
+#ifndef CONFIG_SOC_MEC1501_DEBUG_AND_ETM_TRACING
 	pinmux_pin_set(porte, MCHP_GPIO_200, MCHP_GPIO_CTRL_MUX_F1);
 	pinmux_pin_set(porte, MCHP_GPIO_201, MCHP_GPIO_CTRL_MUX_F1);
 	pinmux_pin_set(porte, MCHP_GPIO_202, MCHP_GPIO_CTRL_MUX_F1);
 	pinmux_pin_set(porte, MCHP_GPIO_203, MCHP_GPIO_CTRL_MUX_F1);
+#endif
 	pinmux_pin_set(porte, MCHP_GPIO_204, MCHP_GPIO_CTRL_MUX_F1);
 	pinmux_pin_set(porte, MCHP_GPIO_205, MCHP_GPIO_CTRL_MUX_F1);
 	pinmux_pin_set(porte, MCHP_GPIO_206, MCHP_GPIO_CTRL_MUX_F1);

--- a/soc/arm/microchip_mec/mec1501/Kconfig.soc
+++ b/soc/arm/microchip_mec/mec1501/Kconfig.soc
@@ -78,23 +78,48 @@ config SOC_MEC1501_VCI_PINS_AS_GPIOS
 	  design.
 
 choice
-	prompt "Select JTAG configuration"
-	default SOC_MEC1501_NO_JTAG_SUPPORT
-
-config SOC_MEC1501_NO_JTAG_SUPPORT
-	bool "Disable JTAG support"
+	prompt "MEC1501 debug interface general configuration"
+	default SOC_MEC1501_DEBUG_WITHOUT_TRACING
+	depends on SOC_SERIES_MEC1501X
 	help
-	  JTAG TRACE pins will be used as GPIOs or ADC.
+	  Select Debug SoC interface support for MEC15xx SoC family
 
-config SOC_MEC1501_ENABLE_JTAG_SUPPORT
-	bool "JTAG support enable without tracing capabilies"
-	help
-	  JTAG TRACE pins will be used as GPIOs or ADC.
+	config SOC_MEC1501_DEBUG_DISABLED
+		bool "Disable debug support"
+		help
+		  Debug port is disabled, JTAG/SWD cannot be enabled. JTAG_RST#
+		  pin is ignored. All other JTAG pins can be used as GPIOs
+		  or other non-JTAG alternate functions.
 
-config SOC_MEC1501_ENABLE_JTAG_AND_TRACING
-	bool "JTAG support enable without tracing capabilies"
-	help
-	  JTAG TRACE pins will be used as in trace mode.
+	config SOC_MEC1501_DEBUG_WITHOUT_TRACING
+		bool "Debug support via Serial wire debug"
+		help
+		  JTAG port in SWD mode. UART2 and ADC00-03 can be used.
+
+	config SOC_MEC1501_DEBUG_AND_TRACING
+		bool "Debug support via Serial wire debug with tracing enabled"
+		help
+		  JTAG port is enabled in SWD mode. Refer to tracing options
+		  to see if ADC00-03 can be used or not.
 
 endchoice
 
+choice
+	prompt "MEC1501 debug interface trace configuration"
+	default SOC_MEC1501_DEBUG_AND_ETM_TRACING
+	depends on SOC_MEC1501_DEBUG_AND_TRACING
+	help
+	  Select tracing mode for debug interface
+
+	config SOC_MEC1501_DEBUG_AND_ETM_TRACING
+		bool "Debug support via Serial wire debug"
+		help
+		  JTAG port in SWD mode and SWV as tracing method.
+		  UART2 can be used, but ADC00-03 cannot.
+
+	config SOC_MEC1501_DEBUG_AND_SWV_TRACING
+		bool "debug support via Serial Wire Debug and Viewer"
+		help
+		  JTAG port in SWD mode and SWV as tracing method.
+		  UART2 cannot be used. ADC00-03 can be used.
+endchoice

--- a/soc/arm/microchip_mec/mec1501/Kconfig.soc
+++ b/soc/arm/microchip_mec/mec1501/Kconfig.soc
@@ -76,3 +76,25 @@ config SOC_MEC1501_VCI_PINS_AS_GPIOS
 	  By default these pins are not GPIOs, but HW controlled.
 	  Set this if VCI pin block HW logic is not required in the board
 	  design.
+
+choice
+	prompt "Select JTAG configuration"
+	default SOC_MEC1501_NO_JTAG_SUPPORT
+
+config SOC_MEC1501_NO_JTAG_SUPPORT
+	bool "Disable JTAG support"
+	help
+	  JTAG TRACE pins will be used as GPIOs or ADC.
+
+config SOC_MEC1501_ENABLE_JTAG_SUPPORT
+	bool "JTAG support enable without tracing capabilies"
+	help
+	  JTAG TRACE pins will be used as GPIOs or ADC.
+
+config SOC_MEC1501_ENABLE_JTAG_AND_TRACING
+	bool "JTAG support enable without tracing capabilies"
+	help
+	  JTAG TRACE pins will be used as in trace mode.
+
+endchoice
+


### PR DESCRIPTION
Currently JTAG debug is enabled by default and all ADC pins are configured as ADC.
In some designs is desirable to disable JTAG functionality and ADC pins 0-3 cannot be used with tracing.

Fixing this by introducing KConfig following switches.

1) No debug interface. Free all JTAG pins for other functions.
2) Debug enabled without tracing. (SWD). Free TRACEDATA pins so more ADC channels can be used
3) Debug enabled with tracing. (SWD). 

