### PR TITLE
net: openthread: radio: Added sleep to tx as hw radio cap.

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -159,7 +159,8 @@ static enum ieee802154_hw_caps nrf5_get_capabilities(struct device *dev)
 {
 	return IEEE802154_HW_FCS | IEEE802154_HW_FILTER |
 	       IEEE802154_HW_CSMA | IEEE802154_HW_2_4_GHZ |
-	       IEEE802154_HW_TX_RX_ACK | IEEE802154_HW_ENERGY_SCAN;
+	       IEEE802154_HW_TX_RX_ACK | IEEE802154_HW_ENERGY_SCAN |
+	       IEEE802154_HW_SLEEP_TO_TX;
 }
 
 static int nrf5_cca(struct device *dev)

--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -36,6 +36,7 @@ enum ieee802154_hw_caps {
 	IEEE802154_HW_SUB_GHZ	  = BIT(6), /* Sub-GHz radio supported */
 	IEEE802154_HW_ENERGY_SCAN = BIT(7), /* Energy scan supported */
 	IEEE802154_HW_TXTIME	  = BIT(8), /* TX at specified time supported */
+	IEEE802154_HW_SLEEP_TO_TX = BIT(9), /* TX directly from sleep supported */
 };
 
 enum ieee802154_filter_type {

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -538,7 +538,12 @@ otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aPacket)
 
 	__ASSERT_NO_MSG(aPacket == &sTransmitFrame);
 
-	if (sState == OT_RADIO_STATE_RECEIVE) {
+	enum ieee802154_hw_caps radio_caps;
+
+	radio_caps = radio_api->get_capabilities(radio_dev);
+
+	if ((sState == OT_RADIO_STATE_RECEIVE) ||
+		(radio_caps & IEEE802154_HW_SLEEP_TO_TX)) {
 		if (run_tx_task(aInstance) == 0) {
 			error = OT_ERROR_NONE;
 		}
@@ -616,6 +621,10 @@ otRadioCaps otPlatRadioGetCaps(otInstance *aInstance)
 
 	if (radio_caps & IEEE802154_HW_TX_RX_ACK) {
 		caps |= OT_RADIO_CAPS_ACK_TIMEOUT;
+	}
+
+	if (radio_caps & IEEE802154_HW_SLEEP_TO_TX) {
+		caps |= OT_RADIO_CAPS_SLEEP_TO_TX;
 	}
 
 	return caps;

--- a/tests/subsys/openthread/radio_test.c
+++ b/tests/subsys/openthread/radio_test.c
@@ -149,7 +149,7 @@ static enum ieee802154_hw_caps get_capabilities(struct device *dev)
 
 	return IEEE802154_HW_FCS | IEEE802154_HW_2_4_GHZ |
 	       IEEE802154_HW_TX_RX_ACK | IEEE802154_HW_FILTER |
-	       IEEE802154_HW_ENERGY_SCAN;
+	       IEEE802154_HW_ENERGY_SCAN | IEEE802154_HW_SLEEP_TO_TX;
 }
 
 static enum ieee802154_hw_caps get_capabilities_caps_mock(struct device *dev)
@@ -672,6 +672,11 @@ static void test_get_caps_test(void)
 	zassert_equal(otPlatRadioGetCaps(ot), OT_RADIO_CAPS_ACK_TIMEOUT,
 		      "Incorrect capabilities returned.");
 
+	ztest_returns_value(get_capabilities_caps_mock,
+			    IEEE802154_HW_SLEEP_TO_TX);
+	zassert_equal(otPlatRadioGetCaps(ot), OT_RADIO_CAPS_SLEEP_TO_TX,
+		      "Incorrect capabilities returned.");
+
 	/* all at once */
 	ztest_returns_value(
 		get_capabilities_caps_mock,
@@ -679,11 +684,11 @@ static void test_get_caps_test(void)
 			IEEE802154_HW_FILTER | IEEE802154_HW_CSMA |
 			IEEE802154_HW_2_4_GHZ | IEEE802154_HW_TX_RX_ACK |
 			IEEE802154_HW_SUB_GHZ | IEEE802154_HW_ENERGY_SCAN |
-			IEEE802154_HW_TXTIME);
+			IEEE802154_HW_TXTIME | IEEE802154_HW_SLEEP_TO_TX);
 	zassert_equal(
 		otPlatRadioGetCaps(ot),
 		OT_RADIO_CAPS_CSMA_BACKOFF | OT_RADIO_CAPS_ENERGY_SCAN |
-			OT_RADIO_CAPS_ACK_TIMEOUT,
+			OT_RADIO_CAPS_ACK_TIMEOUT | OT_RADIO_CAPS_SLEEP_TO_TX,
 		"Incorrect capabilities returned.");
 
 	rapi.get_capabilities = get_capabilities;


### PR DESCRIPTION
OT_RADIO_CAPS_SLEEP_TO_TX was added as a radio capability
for ieee802154 radio. Waiting on RX state before transmission
is alternative condition to OT_RADIO_CAPS_SLEEP_TO_TX support
as it was a result of OpenThread architecture and is actually
not needed in the Zephyr. Such change lets to start transmission
faster and lower SED device power consumption in active state
about 30%.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>