### PR TITLE
tests: threads: mark cpu_mask skipped where it does not run

### DIFF
--- a/tests/kernel/threads/thread_apis/src/test_threads_cpu_mask.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_cpu_mask.c
@@ -85,5 +85,7 @@ void test_threads_cpu_mask(void)
 
 		k_thread_abort(thread);
 	}
+#else
+	ztest_test_skip();
 #endif
 }


### PR DESCRIPTION
Mark as skipped if cpu_mask is not supported.