### PR TITLE
cmake: toolchain: fix unsupported warnings for C++ builds

### DIFF
--- a/cmake/compiler/gcc/target_warnings.cmake
+++ b/cmake/compiler/gcc/target_warnings.cmake
@@ -114,4 +114,5 @@ endmacro()
 list(APPEND CXX_EXCLUDED_OPTIONS
   -Werror=implicit-int
   -Wold-style-definition
+  -Wno-pointer-sign
   )


### PR DESCRIPTION
Compile with `arm-none-eabi-g++` (10.2.0 with `-std=c++17`) generates a
warning for every C++ source file:
`cc1plus: warning: command-line option '-Wno-pointer-sign' is valid for C/ObjC but not for C++`

Get rid of those warnings by adding `-Wno-pointer-sign` to the list of excluded CXX options.