### PR TITLE
logging: fix immediate logging with multiple backends

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -391,8 +391,12 @@ void log_generic(struct log_msg_ids src_level, const char *fmt, va_list ap,
 			backend = log_backend_get(i);
 
 			if (log_backend_is_active(backend)) {
+				va_list ap_tmp;
+
+				va_copy(ap_tmp, ap);
 				log_backend_put_sync_string(backend, src_level,
-						     timestamp, fmt, ap);
+						     timestamp, fmt, ap_tmp);
+				va_end(ap_tmp);
 			}
 		}
 	} else {


### PR DESCRIPTION
va_list was initialized once and passed to log_backend_put_sync_string()
for each logging backend. State of such va_list was changed in each
execution, resulting in different va_list state to be passed for
consecutive log_backend_put_sync_string() calls. This results in
undefined behavior and program crashes.

Use va_copy() to copy va_list state to temporary variable for each
logging backend and keep original va_list untouched. Pass such temporary
state to log_backend_put_sync_string() to make sure state for all
consecutive calls does not change.