### PR TITLE
doc: releases: 2.4: note SPI gpio CS active level config change

### DIFF
--- a/doc/releases/release-notes-2.4.rst
+++ b/doc/releases/release-notes-2.4.rst
@@ -249,6 +249,13 @@ Drivers and Sensors
 
 * SPI
 
+  * The SPI driver subsystem has been updated to use the flags specified
+    in the cs-gpios devicetree properties rather than the
+    SPI_CS_ACTIVE_LOW/HIGH configuration options.  Devicetree files that
+    specify 0 for this field will probably need to be updated to specify
+    GPIO_ACTIVE_LOW.  SPI_CS_ACTIVE_LOW/HIGH are still used for chip
+    selects that are not specified by a cs-gpios property.
+
 
 * Timer
 


### PR DESCRIPTION
#26269 changed the SPI drivers to use the devicetree content to detect active level, rather than the `SPI_CS_ACTIVE_(HIGH|LOW)` control structure options.  #26684 and other commits updated all the in-tree drivers.

The release notes should have been updated to document this breaking change back when some of those PRs were approved, but that wasn't caught, so fix it now.