### PR TITLE
tests: clock_control: Check return error

### DIFF
--- a/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
+++ b/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
@@ -200,7 +200,11 @@ static bool async_capable(const char *dev_name, clock_control_subsys_t subsys)
 		/* pend util clock is started */
 	}
 
-	clock_control_off(dev, subsys);
+	err = clock_control_off(dev, subsys);
+	if (err < 0) {
+		printk("clock_control_off failed %d", err);
+		return false;
+	}
 
 	return true;
 }


### PR DESCRIPTION
clock_control_off returns a negative value on error. Check it properly.

Fixes #27329

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>