### PR TITLE
subsys/testsuite: Add an assert for a zero return code

### DIFF
--- a/subsys/testsuite/ztest/include/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/ztest_assert.h
@@ -117,6 +117,14 @@ static inline void z_zassert(bool cond,
 					      msg, ##__VA_ARGS__)
 
 /**
+ * @brief Assert that @a cond is 0 (success)
+ * @param cond Condition to check
+ * @param msg Optional message to print if the assertion fails
+ */
+#define zassert_ok(cond, msg, ...) zassert(!(cond), #cond " is non-zero", \
+					      msg, ##__VA_ARGS__)
+
+/**
  * @brief Assert that @a ptr is NULL
  * @param ptr Pointer to compare
  * @param msg Optional message to print if the assertion fails


### PR DESCRIPTION
Many functions signal success by returning a return code of zero. Add
an assertion for this.

Some functions can return a positive value to indicate success, where
they want to convey some information. This is not handled by this
assert function.

Signed-off-by: Simon Glass <sjg@chromium.org>