### PR TITLE
Bluetooth: Mesh: Heartbeat period starts at tx

### DIFF
--- a/subsys/bluetooth/mesh/lpn.c
+++ b/subsys/bluetooth/mesh/lpn.c
@@ -248,7 +248,7 @@ static void clear_friendship(bool force, bool disable)
 	lpn->groups_changed = 1U;
 
 	if (cfg->hb_pub.feat & BT_MESH_FEAT_LOW_POWER) {
-		bt_mesh_heartbeat_send();
+		(void)bt_mesh_heartbeat_send(NULL, NULL);
 	}
 
 	if (disable) {
@@ -966,7 +966,7 @@ int bt_mesh_lpn_friend_update(struct bt_mesh_net_rx *rx,
 		BT_INFO("Friendship established with 0x%04x", lpn->frnd);
 
 		if (cfg->hb_pub.feat & BT_MESH_FEAT_LOW_POWER) {
-			bt_mesh_heartbeat_send();
+			(void)bt_mesh_heartbeat_send(NULL, NULL);
 		}
 
 		if (lpn_cb) {

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1859,7 +1859,7 @@ void bt_mesh_rpl_clear(void)
 	(void)memset(bt_mesh.rpl, 0, sizeof(bt_mesh.rpl));
 }
 
-void bt_mesh_heartbeat_send(void)
+int bt_mesh_heartbeat_send(const struct bt_mesh_send_cb *cb, void *cb_data)
 {
 	struct bt_mesh_cfg_srv *cfg = bt_mesh_cfg_get();
 	uint16_t feat = 0U;
@@ -1882,7 +1882,7 @@ void bt_mesh_heartbeat_send(void)
 
 	/* Do nothing if heartbeat publication is not enabled */
 	if (cfg->hb_pub.dst == BT_MESH_ADDR_UNASSIGNED) {
-		return;
+		return 0;
 	}
 
 	hb.init_ttl = cfg->hb_pub.ttl;
@@ -1907,8 +1907,8 @@ void bt_mesh_heartbeat_send(void)
 
 	BT_DBG("InitTTL %u feat 0x%04x", cfg->hb_pub.ttl, feat);
 
-	bt_mesh_ctl_send(&tx, TRANS_CTL_OP_HEARTBEAT, &hb, sizeof(hb),
-			 NULL, NULL);
+	return bt_mesh_ctl_send(&tx, TRANS_CTL_OP_HEARTBEAT, &hb, sizeof(hb),
+				cb, cb_data);
 }
 
 int bt_mesh_app_key_get(const struct bt_mesh_subnet *subnet, uint16_t app_idx,

--- a/subsys/bluetooth/mesh/transport.h
+++ b/subsys/bluetooth/mesh/transport.h
@@ -101,7 +101,7 @@ void bt_mesh_trans_init(void);
 
 void bt_mesh_rpl_clear(void);
 
-void bt_mesh_heartbeat_send(void);
+int bt_mesh_heartbeat_send(const struct bt_mesh_send_cb *cb, void *cb_data);
 
 int bt_mesh_app_key_get(const struct bt_mesh_subnet *subnet, uint16_t app_idx,
 			uint16_t addr, const uint8_t **key, uint8_t *aid);


### PR DESCRIPTION
Starts the periodic heartbeat publish period at the end of the
publication, instead of at the ordering time. This ensures that the
heartbeat period doesn't get shortened by other enqueued messages.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>