### PR TITLE
 logging: net: Modify ipv4 init code, so it compiles if ipv4 is disabled

### DIFF
--- a/samples/net/syslog_net/sample.yaml
+++ b/samples/net/syslog_net/sample.yaml
@@ -12,3 +12,16 @@ tests:
   sample.net.syslog.without_timefuncs:
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
+  sample.net.syslog.ipv4_only:
+    extra_configs:
+      - CONFIG_NET_IPV6=n
+      - CONFIG_NET_CONFIG_NEED_IPV6=n
+      - CONFIG_NET_CONFIG_MY_IPV6_ADDR=""
+      - CONFIG_NET_CONFIG_PEER_IPV6_ADDR=""
+      - CONFIG_LOG_BACKEND_NET_SERVER="192.0.2.1:514"
+  sample.net.syslog.ipv6_only:
+    extra_configs:
+      - CONFIG_NET_IPV4=n
+      - CONFIG_NET_CONFIG_NEED_IPV4=n
+      - CONFIG_NET_CONFIG_MY_IPV4_ADDR=""
+      - CONFIG_NET_CONFIG_PEER_IPV4_ADDR=""

--- a/subsys/logging/log_backend_net.c
+++ b/subsys/logging/log_backend_net.c
@@ -130,18 +130,20 @@ static int do_net_init(void)
 
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 		   server_addr.sa_family == AF_INET) {
-		struct net_if_ipv4 *ipv4;
-		struct net_if *iface;
+		const struct in_addr *src;
 
-		iface = net_if_ipv4_select_src_iface(
-					&net_sin(&server_addr)->sin_addr);
-		ipv4 = iface->config.ip.ipv4;
+		src = net_if_ipv4_select_src_addr(
+				  NULL, &net_sin(&server_addr)->sin_addr);
 
-		net_ipaddr_copy(&local_addr4.sin_addr,
-				&ipv4->unicast[0].address.in_addr);
+		if (src) {
+			net_addr_ntop(AF_INET, src, dev_hostname,
+				      MAX_HOSTNAME_LEN);
 
-		net_addr_ntop(AF_INET, &local_addr4.sin_addr, dev_hostname,
-			      MAX_HOSTNAME_LEN);
+			net_ipaddr_copy(&local_addr4.sin_addr, src);
+		} else {
+			goto unknown;
+		}
+
 	} else {
 	unknown:
 		DBG("Cannot setup local context\n");


### PR DESCRIPTION
In addition ipv4-only and ipv6-only configurations added to the logger sample to ensure that this issue does not occur again.

This fixes #27428

Tested on the nucleo_f429zi with ipv6 and ipv4 (DHCP).