### PR TITLE
samples: nvs: Do full chip erase when flashing

### DIFF
--- a/samples/subsys/nvs/CMakeLists.txt
+++ b/samples/subsys/nvs/CMakeLists.txt
@@ -1,6 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
+
+macro(app_set_runner_args)
+  board_runner_args(dfu-util "--dfuse-modifiers=force:mass-erase")
+  board_runner_args(pyocd "--erase")
+  board_runner_args(nrfjprog "--erase")
+endmacro()
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nvs)
 


### PR DESCRIPTION
Add for various flash runners (pyocd, nrfjprog, and dfu-util) to do a
full chip erase.  This is needed for the sample to pass in sanitycheck
on real hardware.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>