### PR TITLE
CMSIS RTOS v1: Fix Signal handling behaviour

### DIFF
--- a/lib/cmsis_rtos_v1/cmsis_thread.c
+++ b/lib/cmsis_rtos_v1/cmsis_thread.c
@@ -80,13 +80,15 @@ osThreadId osThreadCreate(const osThreadDef_t *thread_def, void *arg)
 	atomic_dec((atomic_t *)&thread_def->instances);
 	stk_ptr = thread_def->stack_mem;
 	prio = cmsis_to_zephyr_priority(thread_def->tpriority);
-	k_thread_custom_data_set((void *)thread_def);
 
 	tid = k_thread_create(&cm_thread[thread_def->instances],
 			stk_ptr[thread_def->instances], stacksz,
 			(k_thread_entry_t)zephyr_thread_wrapper,
 			(void *)arg, NULL, thread_def->pthread,
-			prio, 0, K_NO_WAIT);
+			prio, 0, K_FOREVER);
+
+	tid->custom_data = (void *)thread_def;
+	k_thread_start(tid);
 
 	return ((osThreadId)tid);
 }

--- a/tests/portability/cmsis_rtos_v1/src/main.c
+++ b/tests/portability/cmsis_rtos_v1/src/main.c
@@ -24,6 +24,7 @@ extern void test_signal_events_no_wait(void);
 extern void test_signal_events_timeout(void);
 extern void test_signal_events_signalled(void);
 extern void test_signal_events_isr(void);
+extern void test_signal_events_reverse(void);
 
 void test_main(void)
 {
@@ -43,6 +44,7 @@ void test_main(void)
 			ztest_unit_test(test_signal_events_no_wait),
 			ztest_unit_test(test_signal_events_timeout),
 			ztest_unit_test(test_signal_events_signalled),
-			ztest_unit_test(test_signal_events_isr));
+			ztest_unit_test(test_signal_events_isr),
+			ztest_unit_test(test_signal_events_reverse));
 	ztest_run_test_suite(test_cmsis_apis);
 }


### PR DESCRIPTION
This commit fixes #27279
The custom_data of a thread was wrongly assigned to the thread who was
spawning a new thread by calling osThreadCreate and not to the new one.
A new config option is introduced: CONFIG_THREAD_CUSTOM_DATA_NO_INIT.
With this option custom_data on k_thread struct is not reset when
k_thread_create is called (custom_data is not initialized to NULL): so another thread can set
custom_data before actually launching a new thread.
CONFIG_CMSIS_RTOS_V1 now depends also on
CONFIG_THREAD_CUSTOM_DATA_NO_INIT.

As i wrote in #27279, this is my first "ride" with Zephyr so my knowledge is a bit limited: probably there are a lot of better way to fix it.

Also related to CMSIS there is #27301