### PR TITLE
soc: silabs_exx32: add missing ifs to Kconfig.defconfig

### DIFF
--- a/soc/arm/silabs_exx32/Kconfig.defconfig
+++ b/soc/arm/silabs_exx32/Kconfig.defconfig
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if SOC_FAMILY_EXX32
+
 source "soc/arm/silabs_exx32/*/Kconfig.defconfig.series"
 
 config SOC_GECKO_EMU
 	default y
 	depends on SYS_POWER_MANAGEMENT
+
+endif


### PR DESCRIPTION
This file is setting Kconfig options even when it is not the chosen
SoC. I noticed this because without this patch, CONFIG_SOC_GECKO_EMU=y
when building for an unrelated board with SYS_POWER_MANAGEMENT=y.

Hide any subtrees in this file when the EXX32 family isn't selected.
