### PR TITLE
West sign cleanups

### DIFF
--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -93,47 +93,8 @@ get_property(RUNNERS GLOBAL PROPERTY ZEPHYR_RUNNERS)
 #
 # Everything is marked with FORCE so that re-running CMake updates the
 # configuration if the board files change.
-#
-# TODO: drop the hack in sign.py that uses cached_runner_config to
-# guess the .bin and .hex files, then delete the cache variables.
 if(RUNNERS)
   create_runners_yaml(${RUNNERS})
-
-  set(ZEPHYR_RUNNERS ${RUNNERS} CACHE INTERNAL "Available runners")
-
-  # Runner configuration. This is provided to all runners, and is
-  # distinct from the free-form arguments provided by e.g.
-  # board_runner_args().
-  #
-  # Always applicable:
-  set(ZEPHYR_RUNNER_CONFIG_BOARD_DIR "${BOARD_DIR}"
-    CACHE STRING "Board definition directory" FORCE)
-  set(ZEPHYR_RUNNER_CONFIG_KERNEL_ELF "${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME}"
-    CACHE STRING "Path to kernel image in ELF format" FORCE)
-  get_property(HEX_FILES_TO_MERGE GLOBAL PROPERTY HEX_FILES_TO_MERGE)
-  if(HEX_FILES_TO_MERGE)
-    set(ZEPHYR_RUNNER_CONFIG_KERNEL_HEX "${PROJECT_BINARY_DIR}/${MERGED_HEX_NAME}"
-      CACHE STRING "Path to merged image in Intel Hex format" FORCE)
-  else()
-    set(ZEPHYR_RUNNER_CONFIG_KERNEL_HEX "${PROJECT_BINARY_DIR}/${KERNEL_HEX_NAME}"
-      CACHE STRING "Path to kernel image in Intel Hex format" FORCE)
-  endif()
-  set(ZEPHYR_RUNNER_CONFIG_KERNEL_BIN "${PROJECT_BINARY_DIR}/${KERNEL_BIN_NAME}"
-    CACHE STRING "Path to kernel image as raw binary" FORCE)
-  # Not always applicable, but so often needed that they're provided
-  # by default: (TODO: clean this up)
-  if(DEFINED CMAKE_GDB)
-    set(ZEPHYR_RUNNER_CONFIG_GDB "${CMAKE_GDB}"
-      CACHE STRING "Path to GDB binary, if applicable" FORCE)
-  endif()
-  if(DEFINED OPENOCD)
-    set(ZEPHYR_RUNNER_CONFIG_OPENOCD "${OPENOCD}"
-      CACHE STRING "Path to openocd binary, if applicable" FORCE)
-  endif()
-  if(DEFINED OPENOCD_DEFAULT_PATH)
-    set(ZEPHYR_RUNNER_CONFIG_OPENOCD_SEARCH "${OPENOCD_DEFAULT_PATH}"
-      CACHE STRING "Path to add to openocd search path, if applicable" FORCE)
-  endif()
 
   # Runner-specific command line arguments obtained from the board's
   # build scripts, the application's scripts, etc.
@@ -144,14 +105,6 @@ if(RUNNERS)
     set(ZEPHYR_RUNNER_ARGS_${runner_id} ${runner_args} CACHE STRING
       "Runner-specific arguments for ${runner}" FORCE)
   endforeach()
-endif()
-if(BOARD_FLASH_RUNNER)
-  set(ZEPHYR_BOARD_FLASH_RUNNER ${BOARD_FLASH_RUNNER} CACHE STRING
-    "Default runner for flashing binaries" FORCE)
-endif()
-if(BOARD_DEBUG_RUNNER)
-  set(ZEPHYR_BOARD_DEBUG_RUNNER ${BOARD_DEBUG_RUNNER} CACHE STRING
-    "Default runner for debugging" FORCE)
 endif()
 
 if(DEFINED ENV{WEST_DIR} AND NOT WEST_DIR)

--- a/doc/guides/debugging/probes.rst
+++ b/doc/guides/debugging/probes.rst
@@ -192,13 +192,13 @@ Using Segger J-Link
 Once STLink is flashed with SEGGER FW and J-Link GDB server is installed on your
 host computer, you can flash and debug as follows:
 
-Use CMake with ``-DZEPHYR_BOARD_FLASH_RUNNER=jlink`` to change the default OpenOCD
+Use CMake with ``-DBOARD_FLASH_RUNNER=jlink`` to change the default OpenOCD
 runner to J-Link. Alternatively, you might add the following line to your
 application ``CMakeList.txt`` file.
 
   .. code-block:: cmake
 
-     set(ZEPHYR_BOARD_FLASH_RUNNER jlink)
+     set(BOARD_FLASH_RUNNER jlink)
 
 If you use West (Zephyr's meta-tool) you can modify the default runner using
 the ``--runner`` (or ``-r``) option.

--- a/scripts/west_commands/zephyr_ext_common.py
+++ b/scripts/west_commands/zephyr_ext_common.py
@@ -10,6 +10,7 @@ commands which specifically execute runners.'''
 
 import os
 from pathlib import Path
+import re
 
 from west import log
 from west.commands import WestCommand
@@ -47,6 +48,68 @@ class Forceable(WestCommand):
         if not (cond or self.args.force):
             log.err(msg)
             log.die('refusing to proceed without --force due to above error')
+
+
+def load_dot_config(path):
+    '''Load a Kconfig .config output file in 'path' and return a dict
+    from symbols set in that file to their values.
+
+    This parser:
+
+    - respects the usual "# CONFIG_FOO is not set" --> CONFIG_FOO=n
+      semantics
+    - converts decimal or hexadecimal integer literals to ints
+    - strips quotes around strings
+    '''
+
+    # You might think it would be easier to create a new
+    # kconfiglib.Kconfig object and use its load_config() method to
+    # parse the file instead.
+    #
+    # Beware, traveler: that way lies madness.
+    #
+    # Zephyr's Kconfig files rely heavily on environment variables to
+    # manage user-configurable directory locations, and recreating
+    # that state turns out to be a surprisingly fragile process. It's
+    # not just 'srctree'; there are various others and they change
+    # randomly as features get merged.
+    #
+    # Nor will pickling the Kconfig object come to your aid. It's a
+    # deeply recursive data structure which requires a very high
+    # system recursion limit (100K frames seems to do it) and contains
+    # references to un-pickle-able values in its attributes.
+    #
+    # It's easier and in fact more robust to rely on the fact that the
+    # .config file contents are just a strictly formatted Makefile
+    # fragment with some extra "is not set" semantics.
+
+    opt_value = re.compile('^(?P<option>CONFIG_[A-Za-z0-9_]+)=(?P<value>.*)$')
+    not_set = re.compile('^# (?P<option>CONFIG_[A-Za-z0-9_]+) is not set$')
+
+    with open(path, 'r') as f:
+        lines = f.readlines()
+
+    ret = {}
+    for line in lines:
+        match = opt_value.match(line)
+        if match:
+            value = match.group('value')
+            if value.startswith('"') and value.endswith('"'):
+                value = value[1:-1]
+            else:
+                try:
+                    base = 16 if value.startswith('0x') else 10
+                    value = int(value, base=base)
+                except ValueError:
+                    pass
+
+            ret[match.group('option')] = value
+
+        match = not_set.match(line)
+        if match:
+            ret[match.group('option')] = 'n'
+
+    return ret
 
 
 def cached_runner_config(build_dir, cache):

--- a/scripts/west_commands/zephyr_ext_common.py
+++ b/scripts/west_commands/zephyr_ext_common.py
@@ -15,8 +15,6 @@ import re
 from west import log
 from west.commands import WestCommand
 
-from runners.core import RunnerConfig
-
 # This relies on this file being zephyr/scripts/foo/bar.py.
 # If you move this file, you'll break it, so be careful.
 THIS_ZEPHYR = Path(__file__).parent.parent.parent
@@ -110,19 +108,3 @@ def load_dot_config(path):
             ret[match.group('option')] = 'n'
 
     return ret
-
-
-def cached_runner_config(build_dir, cache):
-    '''Parse the RunnerConfig from a build directory and CMake Cache.'''
-    board_dir = cache['ZEPHYR_RUNNER_CONFIG_BOARD_DIR']
-    elf_file = cache.get('ZEPHYR_RUNNER_CONFIG_KERNEL_ELF')
-    hex_file = cache.get('ZEPHYR_RUNNER_CONFIG_KERNEL_HEX')
-    bin_file = cache.get('ZEPHYR_RUNNER_CONFIG_KERNEL_BIN')
-    gdb = cache.get('ZEPHYR_RUNNER_CONFIG_GDB')
-    openocd = cache.get('ZEPHYR_RUNNER_CONFIG_OPENOCD')
-    openocd_search = cache.get('ZEPHYR_RUNNER_CONFIG_OPENOCD_SEARCH')
-
-    return RunnerConfig(build_dir, board_dir,
-                        elf_file, hex_file, bin_file,
-                        gdb=gdb, openocd=openocd,
-                        openocd_search=openocd_search)


### PR DESCRIPTION
Clean out some CMake cache variables that were used before runners.yaml was introduced in Zephyr v2.2 by updating their only user (west sign) to do something else instead.