### PR TITLE
sys: onoff: support clients using synchronous transitions

### DIFF
--- a/doc/reference/resource_management/index.rst
+++ b/doc/reference/resource_management/index.rst
@@ -74,5 +74,15 @@ with onoff_monitor_register().  Notification of changes are provided
 before issuing completion notifications associated with the new
 state.
 
+.. note::
+
+   A generic API may be implemented by multiple drivers where the common
+   case is asynchronous.  The on-off client structure may be an
+   appropriate solution for the generic API.  Where drivers that can
+   guarantee synchronous context-independent transitions a driver may
+   use :c:type:`onoff_sync_service` and its supporting API rather than
+   :c:type:`onoff_manager`, with only a small reduction in functionality
+   (primarily no support for the monitor API).
+
 .. doxygengroup:: resource_mgmt_onoff_apis
    :project: Zephyr

--- a/include/sys/onoff.h
+++ b/include/sys/onoff.h
@@ -229,7 +229,7 @@ struct onoff_client;
  *
  * These functions may be invoked from any context including
  * pre-kernel, ISR, or cooperative or pre-emptible threads.
- * Compatible functions must be isr-callable and non-suspendable.
+ * Compatible functions must be isr-ok and not sleep.
  *
  * @param mgr the manager for which the operation was initiated.
  *
@@ -489,7 +489,7 @@ int onoff_reset(struct onoff_manager *mgr,
  *
  * These functions may be invoked from any context including
  * pre-kernel, ISR, or cooperative or pre-emptible threads.
- * Compatible functions must be isr-callable and non-suspendable.
+ * Compatible functions must be isr-ok and not sleep.
  *
  * The callback is permitted to unregister itself from the manager,
  * but must not register or unregister any other monitors.

--- a/include/sys/onoff.h
+++ b/include/sys/onoff.h
@@ -231,7 +231,8 @@ struct onoff_client;
  * pre-kernel, ISR, or cooperative or pre-emptible threads.
  * Compatible functions must be isr-ok and not sleep.
  *
- * @param mgr the manager for which the operation was initiated.
+ * @param mgr the manager for which the operation was initiated.  This may be
+ * null if the on-off service uses synchronous transitions.
  *
  * @param cli the client structure passed to the function that
  * initiated the operation.
@@ -559,6 +560,81 @@ int onoff_monitor_register(struct onoff_manager *mgr,
  */
 int onoff_monitor_unregister(struct onoff_manager *mgr,
 			     struct onoff_monitor *mon);
+
+/**
+ * @brief State used when a driver uses the on-off service API for synchronous
+ * operations.
+ *
+ * This is useful when a subsystem API uses the on-off API to support
+ * asynchronous operations but the transitions required by a
+ * particular driver are isr-ok and not sleep.  It serves as a
+ * substitute for #onoff_manager, with locking and persisted state
+ * updates supported by onoff_sync_lock() and onoff_sync_finalize().
+ */
+struct onoff_sync_service {
+	/* Mutex protection for other fields. */
+	struct k_spinlock lock;
+
+	/* Negative is error, non-negative is reference count. */
+	int32_t count;
+};
+
+/**
+ * @brief Lock a synchronous onoff service and provide its state.
+ *
+ * @note If an error state is returned it is the caller's responsibility to
+ * decide whether to preserve it (finalize with the same error state) or clear
+ * the error (finalize with a non-error result).
+ *
+ * @param srv pointer to the synchronous service state.
+ *
+ * @param keyp pointer to where the lock key should be stored
+ *
+ * @return negative if the service is in an error state, otherwise the
+ * number of active requests at the time the lock was taken.  The lock
+ * is held on return regardless of whether a negative state is
+ * returned.
+ */
+int onoff_sync_lock(struct onoff_sync_service *srv,
+		    k_spinlock_key_t *keyp);
+
+/**
+ * @brief Process the completion of a transition in a synchronous
+ * service and release lock.
+ *
+ * This function updates the service state on the @p res and @p on parameters
+ * then releases the lock.  If @p cli is not null it finalizes the client
+ * notification using @p res.
+ *
+ * If the service was in an error state when locked, and @p res is non-negative
+ * when finalized, the count is reset to zero before completing finalization.
+ *
+ * @param srv pointer to the synchronous service state
+ *
+ * @param key the key returned by the preceding invocation of onoff_sync_lock().
+ *
+ * @param cli pointer to the onoff client through which completion
+ * information is returned.  If a null pointer is passed only the
+ * state of the service is updated.  For compatibility with the
+ * behavior of callbacks used with the manager API @p cli must be null
+ * when @p on is false (the manager does not support callbacks when
+ * turning off devices).
+ *
+ * @param res the result of the transition.  A negative value places the service
+ * into an error state.  A non-negative value increments or decrements the
+ * reference count as specified by @p on.
+ *
+ * @param on Only when @p res is non-negative, the service reference count will
+ * be incremented if@p on is @c true, and decremented if @p on is @c false.
+ *
+ * @return negative if the service is left or put into an error state, otherwise
+ * the number of active requests at the time the lock was released.
+ */
+int onoff_sync_finalize(struct onoff_sync_service *srv,
+			 k_spinlock_key_t key,
+			 struct onoff_client *cli,
+			 int res,
+			 bool on);
 
 /** @} */
 

--- a/tests/lib/onoff/src/main.c
+++ b/tests/lib/onoff/src/main.c
@@ -51,6 +51,8 @@ static void check_trans(uint32_t idx,
 		      idx, xp->res, res, tag);
 }
 
+static struct onoff_manager *callback_srv;
+static struct onoff_client *callback_cli;
 static uint32_t callback_state;
 static int callback_res;
 static onoff_client_callback callback_fn;
@@ -62,6 +64,8 @@ static void callback(struct onoff_manager *srv,
 {
 	onoff_client_callback cb = callback_fn;
 
+	callback_srv = srv;
+	callback_cli = cli;
 	callback_state = state;
 	callback_res = res;
 	callback_fn = NULL;
@@ -215,13 +219,18 @@ static void reset_cli(void)
 	sys_notify_init_callback(&cli.notify, callback);
 }
 
+static void reset_callback(void)
+{
+	callback_state = -1;
+	callback_res = 0;
+	callback_fn = NULL;
+}
+
 static void setup_test(void)
 {
 	int rc;
 
-	callback_state = -1;
-	callback_res = 0;
-	callback_fn = NULL;
+	reset_callback();
 	reset_transit_state(&start_state);
 	reset_transit_state(&stop_state);
 	reset_transit_state(&reset_state);
@@ -383,6 +392,10 @@ static void test_basic_sync(void)
 	zassert_equal(srv.refs, 1U,
 		      "req refs: %u", srv.refs);
 	check_result(start_state.retval, "req");
+	zassert_equal(callback_srv, &srv,
+		      "callback wrong srv");
+	zassert_equal(callback_cli, &cli,
+		      "callback wrong cli");
 	check_callback(ONOFF_STATE_ON, start_state.retval,
 		       "req");
 	zassert_equal(ntrans, 2U,
@@ -1039,6 +1052,134 @@ static void test_cancel_or_release(void)
 		   "trans off");
 }
 
+static void test_sync_basic(void)
+{
+	struct onoff_sync_service srv = {};
+	struct k_spinlock_key key;
+	int res = 5;
+	int rc;
+
+	reset_cli();
+
+	rc = onoff_sync_lock(&srv, &key);
+	zassert_equal(rc, 0,
+		      "init req");
+
+	rc = onoff_sync_finalize(&srv, key, &cli, res, true);
+	zassert_equal(rc, 1,
+		      "req count");
+	zassert_equal(callback_srv, NULL,
+		      "sync cb srv");
+	zassert_equal(callback_cli, &cli,
+		      "sync cb cli");
+	check_callback(ONOFF_STATE_ON, res, "sync req");
+
+	reset_cli();
+	reset_callback();
+
+	rc = onoff_sync_lock(&srv, &key);
+	zassert_equal(rc, 1,
+		      "init rel");
+
+	++res;
+	rc = onoff_sync_finalize(&srv, key, &cli, res, true);
+	zassert_equal(rc, 2,
+		      "req2 count");
+	check_callback(ONOFF_STATE_ON, res, "sync req2");
+
+	reset_cli();
+
+	rc = onoff_sync_lock(&srv, &key);
+	zassert_equal(rc, 2,
+		      "init rel");
+
+	rc = onoff_sync_finalize(&srv, key, NULL, res, false);
+	zassert_equal(rc, 1,
+		      "rel count");
+
+	reset_cli();
+
+	rc = onoff_sync_lock(&srv, &key);
+	zassert_equal(rc, 1,
+		      "init rel2");
+
+	rc = onoff_sync_finalize(&srv, key, NULL, res, false);
+	zassert_equal(rc, 0,
+		      "rel2 count");
+
+	/* Extra release is caught and diagnosed.  May not happen with
+	 * onoff manager, but we can/should do it for sync.
+	 */
+	reset_cli();
+
+	rc = onoff_sync_lock(&srv, &key);
+	zassert_equal(rc, 0,
+		      "init rel2");
+
+	rc = onoff_sync_finalize(&srv, key, NULL, res, false);
+	zassert_equal(rc, -1,
+		      "rel-1 count");
+
+	/* Error state is visible to next lock. */
+	reset_cli();
+	reset_callback();
+
+	rc = onoff_sync_lock(&srv, &key);
+	zassert_equal(rc, -1,
+		      "init req");
+}
+
+static void test_sync_error(void)
+{
+	struct onoff_sync_service srv = {};
+	struct k_spinlock_key key;
+	int res = -EPERM;
+	int rc;
+
+	reset_cli();
+	reset_callback();
+
+	rc = onoff_sync_lock(&srv, &key);
+	zassert_equal(rc, 0,
+		      "init req");
+
+	rc = onoff_sync_finalize(&srv, key, &cli, res, true);
+
+	zassert_equal(rc, res,
+		      "err final");
+	zassert_equal(srv.count, res,
+		      "srv err count");
+	zassert_equal(callback_srv, NULL,
+		      "sync cb srv");
+	zassert_equal(callback_cli, &cli,
+		      "sync cb cli");
+	check_callback(ONOFF_STATE_ERROR, res, "err final");
+
+	/* Error is visible to next operation (the value is the
+	 * negative count)
+	 */
+
+	reset_cli();
+	reset_callback();
+
+	rc = onoff_sync_lock(&srv, &key);
+	zassert_equal(rc, -1,
+		      "init req");
+
+	/* Error is cleared by non-negative finalize result */
+	res = 3;
+	rc = onoff_sync_finalize(&srv, key, &cli, res, true);
+
+	zassert_equal(rc, 1,
+		      "req count %d", rc);
+	check_callback(ONOFF_STATE_ON, res, "sync req");
+
+	rc = onoff_sync_lock(&srv, &key);
+	zassert_equal(rc, 1,
+		      "init rel");
+}
+
+
 void test_main(void)
 {
 	k_sem_init(&isr_sync, 0, 1);
@@ -1067,6 +1208,9 @@ void test_main(void)
 			 ztest_unit_test(test_error),
 			 ztest_unit_test(test_cancel_req),
 			 ztest_unit_test(test_cancel_delayed_req),
-			 ztest_unit_test(test_cancel_or_release));
+			 ztest_unit_test(test_cancel_or_release),
+			 ztest_unit_test(test_sync_basic),
+			 ztest_unit_test(test_sync_error));
+
 	ztest_run_test_suite(onoff_api);
 }


### PR DESCRIPTION
*The use case for this is in #27360 where it allows simplified handling of GPIO-controlled regulators when an on-SoC GPIO is used with no start/stop delays.*

The on-off manager infrastructure is designed to support robust asynchronous transition between binary states where multiple clients may be initiating a transition from any context.  The actual transition is performed using a manager that tracks the current state and pending operations.  Requests are initiated by passing a reference to an onoff_client object that holds client state including the notification mechanism.

This API may be used in subsystems where the transitions for a particular driver are always synchronous and isr-ok, e.g. setting a SoC-controlled GPIO.  In this situation the full on-off manager infrastructure is wasteful.  All we need is a record of the service state: off, active count, or error.

Add a data structure and an API that can be used to replace the onoff manager functionality in a situation where all transitions are isr-ok and synchronous while retaining compatible behavior from the client perspective.
