### PR TITLE
[WIP] drivers: can: stm32: Add dual port and dual FIFO support

### DIFF
--- a/drivers/can/Kconfig.stm32
+++ b/drivers/can/Kconfig.stm32
@@ -16,7 +16,7 @@ config CAN_MAX_FILTER
 	int "Maximum number of concurrent active filters"
 	depends on CAN_STM32
 	default 5
-	range 1 56
+	range 1 112
 	help
 	  Defines the array size of the callback/msgq pointers.
 	  Must be at least the size of concurrent reads.

--- a/drivers/can/can_stm32.h
+++ b/drivers/can/can_stm32.h
@@ -14,10 +14,27 @@
 #define DEV_CFG(dev) \
 	((const struct can_stm32_config *const)(dev)->config)
 
-#define BIT_SEG_LENGTH(cfg) ((cfg)->prop_ts1 + (cfg)->ts2 + 1)
+/*
+ * The STM32 HAL has no define for the number of banks, but it
+ * does have a struct CAN_TypeDef with an array member that has the
+ * length of the number of filters (28 on the F4).
+ * We use this array to calculate the number of filter banks the
+ * CPU supports
+ */
+#define CAN_STM32_FILTER_BANK_COUNT \
+	(sizeof(((const CAN_TypeDef *)0)->sFilterRegister) \
+	 / sizeof(CAN_FilterRegister_TypeDef))
 
-#define CAN_NUMBER_OF_FILTER_BANKS (14)
-#define CAN_MAX_NUMBER_OF_FILTERS (CAN_NUMBER_OF_FILTER_BANKS * 4)
+/* Every bank can hold 4 std ids, 2 ext ids, 2 std masks, or 1 ext mask
+ * So the max number of filters is the bank count times 4
+ */
+#define CAN_STM32_FILTER_COUNT (CAN_STM32_FILTER_BANK_COUNT * 4U)
+
+#define CAN_STM32_SHARED_PORT_COUNT 2U
+#define CAN_STM32_FIFO_COUNT 2U
+#define CAN_STM32_FILTER_TYPE_COUNT 4U
+
+#define BIT_SEG_LENGTH(cfg) ((cfg)->prop_ts1 + (cfg)->ts2 + 1U)
 
 #define CAN_FIRX_STD_IDE_POS   (3U)
 #define CAN_FIRX_STD_RTR_POS   (4U)
@@ -28,17 +45,6 @@
 #define CAN_FIRX_EXT_STD_ID_POS (21U)
 #define CAN_FIRX_EXT_EXT_ID_POS (3U)
 
-#define CAN_BANK_IS_EMPTY(usage, bank_nr) (((usage >> ((bank_nr) * 4)) & 0x0F) == 0x0F)
-#define CAN_BANK_IN_LIST_MODE(can, bank) ((can)->FM1R & (1U << (bank)))
-#define CAN_BANK_IN_32BIT_MODE(can, bank) ((can)->FS1R & (1U << (bank)))
-#define CAN_IN_16BIT_LIST_MODE(can, bank) (CAN_BANK_IN_LIST_MODE(can, bank) && \
-					   !CAN_BANK_IN_32BIT_MODE(can, bank))
-#define CAN_IN_16BIT_MASK_MODE(can, bank) (!CAN_BANK_IN_LIST_MODE(can, bank) &&	\
-					   !CAN_BANK_IN_32BIT_MODE(can, bank))
-#define CAN_IN_32BIT_LIST_MODE(can, bank) (CAN_BANK_IN_LIST_MODE(can, bank) && \
-					   CAN_BANK_IN_32BIT_MODE(can, bank))
-#define CAN_IN_32BIT_MASK_MODE(can, bank) (!CAN_BANK_IN_LIST_MODE(can, bank) &&	\
-					   CAN_BANK_IN_32BIT_MODE(can, bank))
 struct can_mailbox {
 	can_tx_callback_t tx_callback;
 	void *callback_arg;
@@ -46,13 +52,29 @@ struct can_mailbox {
 	uint32_t error_flags;
 };
 
+struct can_stm32_filter_data {
+	const struct device *can_dev[CAN_STM32_SHARED_PORT_COUNT];
+	uint8_t filter_map[CAN_STM32_FILTER_COUNT];
+	uint8_t map_offset[CAN_STM32_SHARED_PORT_COUNT][CAN_STM32_FIFO_COUNT];
+};
 
 /* number = FSCx | FMBx */
 enum can_filter_type {
-	CAN_FILTER_STANDARD_MASKED = 0,
-	CAN_FILTER_STANDARD = 1,
-	CAN_FILTER_EXTENDED_MASKED = 2,
-	CAN_FILTER_EXTENDED = 3
+	CAN_FILTER_STANDARD_MASKED = 0U,
+	CAN_FILTER_STANDARD = 1U,
+	CAN_FILTER_EXTENDED_MASKED = 2U,
+	CAN_FILTER_EXTENDED = 3U
+};
+
+struct can_stm32_filter {
+	can_rx_callback_t rx_cb;
+	void *cb_arg;
+
+	uint32_t filter_id;
+	uint32_t filter_mask;
+
+	uint8_t fifo_nr:1;
+	uint8_t filter_type:2;
 };
 
 struct can_stm32_data {
@@ -61,16 +83,16 @@ struct can_stm32_data {
 	struct can_mailbox mb0;
 	struct can_mailbox mb1;
 	struct can_mailbox mb2;
-	uint64_t filter_usage;
-	can_rx_callback_t rx_cb[CONFIG_CAN_MAX_FILTER];
-	void *cb_arg[CONFIG_CAN_MAX_FILTER];
+	struct can_stm32_filter filters[CONFIG_CAN_MAX_FILTER];
 	can_state_change_isr_t state_change_isr;
 };
 
 struct can_stm32_config {
 	CAN_TypeDef *can;   /*!< CAN Registers*/
-	CAN_TypeDef *master_can;   /*!< CAN Registers for shared filter */
+	CAN_TypeDef *master_can; /*!< CAN Registers for shared filter */
+	struct can_stm32_filter_data *shared_filter_data;
 	uint32_t bus_speed;
+	uint8_t port_nr;
 	uint8_t sjw;
 	uint8_t prop_ts1;
 	uint8_t ts2;


### PR DESCRIPTION
Add support to use CAN1 and CAN2 at the same time.

Since the (needed) filters are shared between CAN1 and CAN2 special care must be taken when changing them. This locking
is done via a global mutex.

Both ports have 2 Rx FIFO's, but since the CAN API does not yet support passing that information at the moment even filters use FIFO0 and odd filters use FIFO1.

Since the STM32 CAN hardware is a bit weird when it comes to filters (upto 4 filters share 1 filter bank) it is rather confusing how to map the filter_nr that the hardware generates for every received frame to the zephyr filter callback.

The driver has one index array, that maps the hardware filter nr to the zephyr filter nr. When setting up the filters the array is divided into 4 parts, CAN1-FIFO0, CAN1-FIFO1, CAN2-FIFO0, CAN2-FIFO1. The drivers stores the offsets, and since the IRQ handler knows for which port and FIFO it is called it can add the hardware filter nr (which are independed for each port and FIFO)
to the stored offset, and use that to index the mapping array and find the correct callback.

This means most work is done at setup time (when adding the callbacks) and less work is done in the IRQ handler.

Tested on a custom STM32F407 board with two 500kbit/s CAN ports.
