### PR TITLE
doc: shields: H1 heading was missing for mikroe_eth_click

### DIFF
--- a/boards/shields/mikroe_eth_click/doc/index.rst
+++ b/boards/shields/mikroe_eth_click/doc/index.rst
@@ -1,5 +1,8 @@
 .. _mikroe_eth_click:
 
+MikroElektronika ETH Click
+##########################
+
 Overview
 ********
 


### PR DESCRIPTION
Because the H1 heading was not set in mikroe_eth_click index.rst
file, the shields listing page was listing H2 headings for this
shield.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>