### PR TITLE
Bluetooth: Mesh: Add Option config unprov beacon interval

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -30,10 +30,10 @@ config BT_MESH_PB_ADV
 	  the advertising bearer.
 
 config BT_MESH_UNPROV_BEACON_INT
-	int "The interval (in seconds) to send the unprovisioned beacon"
+	int
+	prompt "The interval (in seconds) to send the unprovisioned beacon" if BT_MESH_PB_ADV
 	default 5
 	range 1 10
-	depends on BT_MESH_PB_ADV
 	help
 	  This option specifies the interval (in seconds) at which the
 	  device sends unprovisioned beacon.

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -29,6 +29,15 @@ config BT_MESH_PB_ADV
 	  Enable this option to allow the device to be provisioned over
 	  the advertising bearer.
 
+config BT_MESH_UNPROV_BEACON_INT
+	int "The interval (in seconds) to send the unprovisioned beacon"
+	default 5
+	range 1 10
+	depends on BT_MESH_PB_ADV
+	help
+	  This option specifies the interval (in seconds) at which the
+	  device sends unprovisioned beacon.
+
 config BT_MESH_PROVISIONER
 	bool "Provisioner support"
 	select BT_MESH_PROV
@@ -428,6 +437,7 @@ config BT_MESH_LPN_GROUPS
 	default 8
 	help
 	  Maximum number of groups that the LPN can subscribe to.
+
 endif # BT_MESH_LOW_POWER
 
 config BT_MESH_FRIEND

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -438,6 +438,12 @@ config BT_MESH_LPN_GROUPS
 	help
 	  Maximum number of groups that the LPN can subscribe to.
 
+config BT_MESH_LPN_SUB_ALL_NODES_ADDR
+	bool "Automatically subscribe all nodes address"
+	help
+	  Automatically subscribe all nodes address when friendship
+	  established.
+
 endif # BT_MESH_LOW_POWER
 
 config BT_MESH_FRIEND
@@ -469,12 +475,6 @@ config BT_MESH_FRIEND_SUB_LIST_SIZE
 	help
 	  Size of the Subscription List that can be supported by a
 	  Friend node for a Low Power node.
-
-config BT_MESH_LPN_SUB_ALL_NODES_ADDR
-	bool "Automatically subscribe all nodes address"
-	help
-	  Automatically subscribe all nodes address when friendship
-	  established.
 
 config BT_MESH_FRIEND_LPN_COUNT
 	int "Number of supported LPN nodes"


### PR DESCRIPTION
1 Add Option to specifies the second interval when device
send Unprovisioned Beacon.

2 Move BT_MESH_LPN_SUB_ALL_NODES_ADDR to LPN subgroup.

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>