### PR TITLE
hardening: Deal with empty lines in csvfile

### DIFF
--- a/scripts/kconfig/hardenconfig.py
+++ b/scripts/kconfig/hardenconfig.py
@@ -42,15 +42,16 @@ def compare_with_hardened_conf(kconf, hardened_kconf_filename):
     with open(hardened_kconf_filename) as csvfile:
         csvreader = csv.reader(csvfile)
         for row in csvreader:
-            name = row[0]
-            recommended = row[1]
-            try:
-                symbol = kconf.syms[name]
-                current = symbol.str_value
-            except KeyError:
-                symbol = None
-                current = None
-            options.append(Option(name=name, current=current,
+            if len(row) > 1:
+                name = row[0]
+                recommended = row[1]
+                try:
+                    symbol = kconf.syms[name]
+                    current = symbol.str_value
+                except KeyError:
+                    symbol = None
+                    current = None
+                options.append(Option(name=name, current=current,
                                   recommended=recommended, symbol=symbol))
     return options
 


### PR DESCRIPTION
The extra empty line broke the "ninja hardenconfig" on my machine with Python 3.7.5, it complains:
"
File "/home/zephyrproject/zephyr/scripts/kconfig/hardenconfig.py", line 46, in compare_with_hardened_conf
name = row[0]
IndexError: list index out of range
FAILED: CMakeFiles/hardenconfig
"
The csv.reader read this empty line and gets an empty list which will not be successfully "de-referenced". I'm not sure if it's a good idea to add some extra check here.