### PR TITLE
hardening: remove the empty lines

### DIFF
--- a/scripts/kconfig/hardened.csv
+++ b/scripts/kconfig/hardened.csv
@@ -83,4 +83,3 @@ THREAD_MONITOR,n,experimental
 THREAD_NAME,n,experimental
 UART_ASYNC_API,n,experimental
 MCUMGR_CMD_FS_MGMT,n
-


### PR DESCRIPTION
This extra empty line broke the "ninja hardenconfig" on my machine with Python 3.7.5, it complains:
"
File "/home/zephyrproject/zephyr/scripts/kconfig/hardenconfig.py", line 46, in compare_with_hardened_conf
name = row[0]
IndexError: list index out of range
FAILED: CMakeFiles/hardenconfig
"
The csv.reader read this empty line and gets an empty list which will not be successfully "de-referenced". I'm not sure if it's a good idea to add some extra check in the compare_with_hardened_conf(kconf, hardened_kconf_filename) function, like "if len(row) > 1", but removing the empty line here should help make the "out-of-box" experience better for first time users when trying out "ninja hardenconfig".