### PR TITLE
hardening: remove the empty line

### DIFF
--- a/scripts/kconfig/hardened.csv
+++ b/scripts/kconfig/hardened.csv
@@ -83,4 +83,3 @@ THREAD_MONITOR,n,experimental
 THREAD_NAME,n,experimental
 UART_ASYNC_API,n,experimental
 MCUMGR_CMD_FS_MGMT,n
-


### PR DESCRIPTION
The extra empty line broke the "ninja hardenconfig" on my machine with 
Python 3.7.5, it complains:

"
... ...
File "/home/zephyrproject/zephyr/scripts/kconfig/hardenconfig.py",
line 46, in compare_with_hardened_conf

name = row[0]
IndexError: list index out of range
FAILED: CMakeFiles/hardenconfig
"

The csv.reader reads this empty line and gets an empty list which will 
not be successfully "de-referenced".  Remove it to improve the 
out-of-box experience when pepople try out the hardening options.

Signed-off-by: Wenbo Yang <wenbo.yangcn@gmail.com>