### PR TITLE
Bluetooth: host: fix build break if enable oob legacy pair only

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -9016,7 +9016,8 @@ int bt_le_oob_get_local(uint8_t id, struct bt_le_oob *oob)
 		bt_addr_le_copy(&oob->addr, &bt_dev.id_addr[id]);
 	}
 
-	if (IS_ENABLED(CONFIG_BT_SMP)) {
+	if (IS_ENABLED(CONFIG_BT_SMP) &&
+	    !IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
 		err = bt_smp_le_oob_generate_sc_data(&oob->le_sc_data);
 		if (err) {
 			return err;


### PR DESCRIPTION
Bluetooth: host: fix build break if enable oob legacy pair only 

enable CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY:

In function `bt_le_oob_get_local':
subsys/bluetooth/host/hci_core.c:8878:
		undefined reference to `bt_smp_le_oob_generate_sc_data'

Signed-off-by: chao an <anchao@xiaomi.com>