### PR TITLE
kconfig: Move FAT FS options closer to enable

### DIFF
--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -28,27 +28,6 @@ config FAT_FILESYSTEM_ELM
 	help
 	  Use the ELM FAT File system implementation.
 
-config FILE_SYSTEM_LITTLEFS
-	bool "LittleFS file system support"
-	depends on FLASH_MAP
-	depends on FLASH_PAGE_LAYOUT
-	help
-	  Enables LittleFS file system support.
-
-config FILE_SYSTEM_SHELL
-	bool "Enable file system shell"
-	depends on SHELL
-	depends on HEAP_MEM_POOL_SIZE > 0
-	help
-	  This shell provides basic browsing of the contents of the
-	  file system.
-
-config FUSE_FS_ACCESS
-	bool "Enable FUSE based access to file system partitions"
-	depends on ARCH_POSIX
-	help
-	  Expose file system partitions to the host system through FUSE.
-
 menu "FatFs Settings"
 	visible if FAT_FILESYSTEM_ELM
 
@@ -130,6 +109,28 @@ config FS_FATFS_CODEPAGE
 	  950 - Traditional Chinese (DBCS)
 
 endmenu
+
+config FILE_SYSTEM_LITTLEFS
+	bool "LittleFS file system support"
+	depends on FLASH_MAP
+	depends on FLASH_PAGE_LAYOUT
+	help
+	  Enables LittleFS file system support.
+
+config FILE_SYSTEM_SHELL
+	bool "Enable file system shell"
+	depends on SHELL
+	depends on HEAP_MEM_POOL_SIZE > 0
+	help
+	  This shell provides basic browsing of the contents of the
+	  file system.
+
+config FUSE_FS_ACCESS
+	bool "Enable FUSE based access to file system partitions"
+	depends on ARCH_POSIX
+	help
+	  Expose file system partitions to the host system through FUSE.
+
 
 source "subsys/fs/Kconfig.littlefs"
 


### PR DESCRIPTION
When FAT FS option is enabled, then the FAT FS sub-menu will appear
next to it, instead of appearing far down the list.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>