### PR TITLE
python3: add check_compliance package requirements

### DIFF
--- a/scripts/requirements-compliance.txt
+++ b/scripts/requirements-compliance.txt
@@ -1,0 +1,6 @@
+# COMPLIANCE: required by the compliance scripts
+
+# used by ci/check_compliance
+python-magic
+junitparser
+pylint

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -3,3 +3,4 @@
 -r requirements-doc.txt
 -r requirements-run-test.txt
 -r requirements-extras.txt
+-r requirements-compliance.txt


### PR DESCRIPTION
Running check_compliance on a PR before submitting it can avert
embarrassing mistakes.  Ensure the packages needed to do so are
installed along with all the others.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>