### PR TITLE
sanitycheck: fix --coverage-tool gcovr

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -3265,7 +3265,7 @@ class CoverageTool:
         if tool == 'lcov':
             t =  Lcov()
         elif tool == 'gcovr':
-            t =  Lcov()
+            t =  Gcovr()
         else:
             logger.error("Unsupported coverage tool specified: {}".format(tool))
             return None


### PR DESCRIPTION
Currently '--coverage-tool gcovr' results in using lcov. Fix that to use
gcovr, as requested by user.

Fixes: f6462a3a8c61 ("sanitycheck: get rid of global VERBOSE")