### PR TITLE
sanitycheck: coverage improvements

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -3350,7 +3350,7 @@ class Lcov(CoverageTool):
         self.ignores.append('*' + pattern + '*')
 
     def add_ignore_directory(self, pattern):
-        self.ignores.append(pattern + '/*')
+        self.ignores.append('*/' + pattern + '/*')
 
     def _generate(self, outdir, coveragelog):
         coveragefile = os.path.join(outdir, "coverage.info")
@@ -3403,7 +3403,7 @@ class Gcovr(CoverageTool):
         self.ignores.append('.*' + pattern + '.*')
 
     def add_ignore_directory(self, pattern):
-        self.ignores.append(pattern + '/.*')
+        self.ignores.append(".*/" + pattern + '/.*')
 
     @staticmethod
     def _interleave_list(prefix, list):

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -693,6 +693,9 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
     parser.add_argument("--coverage-tool", choices=['lcov', 'gcovr'], default='lcov',
                         help="Tool to use to generate coverage report.")
 
+    parser.add_argument("--coverage-basedir", default=ZEPHYR_BASE,
+                        help="Base source directory for coverage report.")
+
     return parser.parse_args()
 
 
@@ -1136,7 +1139,7 @@ def main():
         logger.info("Generating coverage files...")
         coverage_tool = CoverageTool.factory(options.coverage_tool)
         coverage_tool.gcov_tool = options.gcov_tool
-        coverage_tool.base_dir = ZEPHYR_BASE
+        coverage_tool.base_dir = os.path.abspath(options.coverage_basedir)
         coverage_tool.add_ignore_file('generated')
         coverage_tool.add_ignore_directory('tests')
         coverage_tool.add_ignore_directory('samples')


### PR DESCRIPTION
Add `--coverage-basedir BASEDIR` argument, which can be used to specify
source code base directory other than default Zephyr root directory.

Match any directory in ignored path hierarchy, similar how file is matched
currently. That way sanitycheck can be executed from outside of Zephyr
source code directory and still respect ignored directories list.

Both improvements are very helpful for Zephyr based application code 
unit testing.