### PR TITLE
net: tcp2: compile out net_tcp_init() in tcp2.h for non-native stacks

### DIFF
--- a/subsys/net/ip/tcp2.h
+++ b/subsys/net/ip/tcp2.h
@@ -117,7 +117,11 @@ struct net_tcp_hdr *net_tcp_input(struct net_pkt *pkt,
 
 /* No ops, provided for compatibility with the old TCP */
 
+#if defined(CONFIG_NET_NATIVE_TCP)
 void net_tcp_init(void);
+#else
+#define net_tcp_init(...)
+#endif
 int net_tcp_update_recv_wnd(struct net_context *context, int32_t delta);
 int net_tcp_queue_data(struct net_context *context, struct net_pkt *pkt);
 int net_tcp_finalize(struct net_pkt *pkt);


### PR DESCRIPTION
For platforms using non-native stacks, net_tcp_init() should be
compiled out, similar to how it is done in tcp_internal.h.

Fixes #27463

Signed-off-by: Vincent Wan <vwan@ti.com>