### PR TITLE
Bluetooth: controller: Improve LE Scan Request Received event support

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -3747,7 +3747,6 @@ static void le_scan_req_received(struct pdu_data *pdu_data,
 	struct pdu_adv *adv = (void *)pdu_data;
 	struct bt_hci_evt_le_scan_req_received *sep;
 
-	/* TODO: fill handle when Adv Ext. feature is implemented. */
 
 	if (!(event_mask & BT_EVT_MASK_LE_META_EVENT) ||
 	    !(le_event_mask & BT_EVT_MASK_LE_SCAN_REQ_RECEIVED)) {
@@ -3755,7 +3754,7 @@ static void le_scan_req_received(struct pdu_data *pdu_data,
 		uint8_t handle;
 		int8_t rssi;
 
-		handle = 0U;
+		handle = node_rx->hdr.handle & 0xff;
 		addr.type = adv->tx_addr;
 		memcpy(&addr.a.val[0], &adv->scan_req.scan_addr[0],
 		       sizeof(bt_addr_t));
@@ -3770,7 +3769,7 @@ static void le_scan_req_received(struct pdu_data *pdu_data,
 	}
 
 	sep = meta_evt(buf, BT_HCI_EVT_LE_SCAN_REQ_RECEIVED, sizeof(*sep));
-	sep->handle = 0U;
+	sep->handle = node_rx->hdr.handle & 0xff;
 	sep->addr.type = adv->tx_addr;
 	memcpy(&sep->addr.a.val[0], &adv->scan_req.scan_addr[0],
 	       sizeof(bt_addr_t));

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -128,7 +128,7 @@ bool lll_adv_scan_req_check(struct lll_adv *lll, struct pdu_adv *sr,
 
 #if defined(CONFIG_BT_CTLR_SCAN_REQ_NOTIFY)
 int lll_adv_scan_req_report(struct lll_adv *lll, struct pdu_adv *pdu_adv_rx,
-			    uint8_t rssi_ready)
+			    uint8_t rl_idx, uint8_t rssi_ready)
 {
 	struct node_rx_pdu *node_rx;
 	struct pdu_adv *pdu_adv;
@@ -153,6 +153,9 @@ int lll_adv_scan_req_report(struct lll_adv *lll, struct pdu_adv *pdu_adv_rx,
 
 	node_rx->hdr.rx_ftr.rssi = (rssi_ready) ? (radio_rssi_get() & 0x7f) :
 						  0x7f;
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+	node_rx->hdr.rx_ftr.rl_idx = rl_idx;
+#endif
 
 	ull_rx_put(node_rx->hdr.link, node_rx);
 	ull_rx_sched();
@@ -716,7 +719,8 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 			uint32_t err;
 
 			/* Generate the scan request event */
-			err = lll_adv_scan_req_report(lll, pdu_rx, rssi_ready);
+			err = lll_adv_scan_req_report(lll, pdu_rx, rl_idx,
+						      rssi_ready);
 			if (err) {
 				/* Scan Response will not be transmitted */
 				return err;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -711,7 +711,7 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 
 #if defined(CONFIG_BT_CTLR_SCAN_REQ_NOTIFY)
 		if (!IS_ENABLED(CONFIG_BT_CTLR_ADV_EXT) ||
-		    0 /* TODO: extended adv. scan req notification enabled */) {
+		    lll->scan_req_notify) {
 			uint32_t err;
 
 			/* Generate the scan request event */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -127,7 +127,8 @@ bool lll_adv_scan_req_check(struct lll_adv *lll, struct pdu_adv *sr,
 }
 
 #if defined(CONFIG_BT_CTLR_SCAN_REQ_NOTIFY)
-int lll_adv_scan_req_report(struct pdu_adv *pdu_adv_rx, uint8_t rssi_ready)
+int lll_adv_scan_req_report(struct lll_adv *lll, struct pdu_adv *pdu_adv_rx,
+			    uint8_t rssi_ready)
 {
 	struct node_rx_pdu *node_rx;
 	struct pdu_adv *pdu_adv;
@@ -141,7 +142,7 @@ int lll_adv_scan_req_report(struct pdu_adv *pdu_adv_rx, uint8_t rssi_ready)
 
 	/* Prepare the report (scan req) */
 	node_rx->hdr.type = NODE_RX_TYPE_SCAN_REQ;
-	node_rx->hdr.handle = 0xffff;
+	node_rx->hdr.handle = ull_adv_lll_handle_get(lll);
 
 	/* Make a copy of PDU into Rx node (as the received PDU is in the
 	 * scratch buffer), and save the RSSI value.
@@ -715,7 +716,7 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 			uint32_t err;
 
 			/* Generate the scan request event */
-			err = lll_adv_scan_req_report(pdu_rx, rssi_ready);
+			err = lll_adv_scan_req_report(lll, pdu_rx, rssi_ready);
 			if (err) {
 				/* Scan Response will not be transmitted */
 				return err;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.h
@@ -68,6 +68,10 @@ struct lll_adv {
 	uint8_t phy_s:3;
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 
+#if defined(CONFIG_BT_CTLR_SCAN_REQ_NOTIFY)
+	uint8_t scan_req_notify:1;
+#endif
+
 #if defined(CONFIG_BT_HCI_MESH_EXT)
 	uint8_t is_mesh:1;
 #endif /* CONFIG_BT_HCI_MESH_EXT */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_internal.h
@@ -77,5 +77,5 @@ bool lll_adv_scan_req_check(struct lll_adv *lll, struct pdu_adv *sr,
 
 #if defined(CONFIG_BT_CTLR_SCAN_REQ_NOTIFY)
 int lll_adv_scan_req_report(struct lll_adv *lll, struct pdu_adv *pdu_adv_rx,
-			    uint8_t rssi_ready);
+			    uint8_t rl_idx, uint8_t rssi_ready);
 #endif

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_internal.h
@@ -74,3 +74,7 @@ lll_adv_sync_data_curr_get(struct lll_adv_sync *lll)
 bool lll_adv_scan_req_check(struct lll_adv *lll, struct pdu_adv *sr,
 			    uint8_t tx_addr, uint8_t *addr,
 			    uint8_t devmatch_ok, uint8_t *rl_idx);
+
+#if defined(CONFIG_BT_CTLR_SCAN_REQ_NOTIFY)
+int lll_adv_scan_req_report(struct pdu_adv *pdu_adv_rx, uint8_t rssi_ready);
+#endif

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_internal.h
@@ -76,5 +76,6 @@ bool lll_adv_scan_req_check(struct lll_adv *lll, struct pdu_adv *sr,
 			    uint8_t devmatch_ok, uint8_t *rl_idx);
 
 #if defined(CONFIG_BT_CTLR_SCAN_REQ_NOTIFY)
-int lll_adv_scan_req_report(struct pdu_adv *pdu_adv_rx, uint8_t rssi_ready);
+int lll_adv_scan_req_report(struct lll_adv *lll, struct pdu_adv *pdu_adv_rx,
+			    uint8_t rssi_ready);
 #endif

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -257,6 +257,10 @@ uint8_t ll_adv_params_set(uint16_t interval, uint8_t adv_type,
 	adv->lll.chan_map = chan_map;
 	adv->lll.filter_policy = filter_policy;
 
+#if defined(CONFIG_BT_CTLR_SCAN_REQ_NOTIFY)
+	adv->lll.scan_req_notify = sreq;
+#endif
+
 	/* update the "current" primary adv data */
 	pdu = lll_adv_data_peek(&adv->lll);
 #if defined(CONFIG_BT_CTLR_ADV_EXT)


### PR DESCRIPTION
Couple of fixes to improve LE Scan Request Received support. It can now be enabled via HCI command and will use proper advertising set handle.