### PR TITLE
Bluetooth: controller: Update scan request handling for ext adv

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -59,11 +59,8 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 			     uint8_t devmatch_ok, uint8_t devmatch_id,
 			     uint8_t irkmatch_ok, uint8_t irkmatch_id,
 			     uint8_t rssi_ready);
-static inline bool isr_rx_sr_check(struct lll_adv *lll, struct pdu_adv *adv,
-				   struct pdu_adv *sr, uint8_t devmatch_ok,
-				   uint8_t *rl_idx);
-static inline bool isr_rx_sr_adva_check(struct pdu_adv *adv,
-					struct pdu_adv *sr);
+static bool isr_rx_sr_adva_check(uint8_t tx_addr, uint8_t *addr,
+				 struct pdu_adv *sr);
 
 #if defined(CONFIG_BT_CTLR_SCAN_REQ_NOTIFY)
 static inline int isr_rx_sr_report(struct pdu_adv *pdu_adv_rx,
@@ -113,6 +110,24 @@ void lll_adv_prepare(void *param)
 
 	err = lll_prepare(is_abort_cb, abort_cb, prepare_cb, 0, p);
 	LL_ASSERT(!err || err == -EINPROGRESS);
+}
+
+bool lll_adv_scan_req_check(struct lll_adv *lll, struct pdu_adv *sr,
+			    uint8_t tx_addr, uint8_t *addr,
+			    uint8_t devmatch_ok, uint8_t *rl_idx)
+{
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+	return ((((lll->filter_policy & 0x01) == 0) &&
+		 ull_filter_lll_rl_addr_allowed(sr->tx_addr,
+						sr->scan_req.scan_addr,
+						rl_idx)) ||
+		(((lll->filter_policy & 0x01) != 0) &&
+		 (devmatch_ok || ull_filter_lll_irk_whitelisted(*rl_idx)))) &&
+		isr_rx_sr_adva_check(tx_addr, addr, sr);
+#else
+	return (((lll->filter_policy & 0x01) == 0U) || devmatch_ok) &&
+		isr_rx_sr_adva_check(tx_addr, addr, sr);
+#endif /* CONFIG_BT_CTLR_PRIVACY */
 }
 
 static int init_reset(void)
@@ -631,6 +646,8 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 			     uint8_t rssi_ready)
 {
 	struct pdu_adv *pdu_rx, *pdu_adv;
+	uint8_t tx_addr;
+	uint8_t *addr;
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	/* An IRK match implies address resolution enabled */
@@ -643,10 +660,14 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 	pdu_rx = (void *)radio_pkt_scratch_get();
 	pdu_adv = lll_adv_data_curr_get(lll);
 
+	addr = pdu_adv->adv_ind.addr;
+	tx_addr = pdu_adv->tx_addr;
+
 	if ((pdu_rx->type == PDU_ADV_TYPE_SCAN_REQ) &&
 	    (pdu_rx->len == sizeof(struct pdu_adv_scan_req)) &&
 	    (pdu_adv->type != PDU_ADV_TYPE_DIRECT_IND) &&
-	    isr_rx_sr_check(lll, pdu_adv, pdu_rx, devmatch_ok, &rl_idx)) {
+	    lll_adv_scan_req_check(lll, pdu_rx, tx_addr, addr, devmatch_ok,
+				    &rl_idx)) {
 		radio_isr_set(isr_done, lll);
 		radio_switch_complete_and_disable();
 		radio_pkt_tx_set(lll_adv_scan_rsp_curr_get(lll));
@@ -760,29 +781,11 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 	return -EINVAL;
 }
 
-static inline bool isr_rx_sr_check(struct lll_adv *lll, struct pdu_adv *adv,
-				   struct pdu_adv *sr, uint8_t devmatch_ok,
-				   uint8_t *rl_idx)
+static bool isr_rx_sr_adva_check(uint8_t tx_addr, uint8_t *addr,
+				 struct pdu_adv *sr)
 {
-#if defined(CONFIG_BT_CTLR_PRIVACY)
-	return ((((lll->filter_policy & 0x01) == 0) &&
-		 ull_filter_lll_rl_addr_allowed(sr->tx_addr,
-						sr->scan_req.scan_addr,
-						rl_idx)) ||
-		(((lll->filter_policy & 0x01) != 0) &&
-		 (devmatch_ok || ull_filter_lll_irk_whitelisted(*rl_idx)))) &&
-		isr_rx_sr_adva_check(adv, sr);
-#else
-	return (((lll->filter_policy & 0x01) == 0U) || devmatch_ok) &&
-		isr_rx_sr_adva_check(adv, sr);
-#endif /* CONFIG_BT_CTLR_PRIVACY */
-}
-
-static inline bool isr_rx_sr_adva_check(struct pdu_adv *adv,
-					struct pdu_adv *sr)
-{
-	return (adv->tx_addr == sr->rx_addr) &&
-		!memcmp(adv->adv_ind.addr, sr->scan_req.adv_addr, BDADDR_SIZE);
+	return (tx_addr == sr->rx_addr) &&
+		!memcmp(addr, sr->scan_req.adv_addr, BDADDR_SIZE);
 }
 
 #if defined(CONFIG_BT_CTLR_SCAN_REQ_NOTIFY)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_internal.h
@@ -70,3 +70,7 @@ lll_adv_sync_data_curr_get(struct lll_adv_sync *lll)
 }
 #endif /* CONFIG_BT_CTLR_ADV_PERIODIC */
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
+
+bool lll_adv_scan_req_check(struct lll_adv *lll, struct pdu_adv *sr,
+			    uint8_t tx_addr, uint8_t *addr,
+			    uint8_t devmatch_ok, uint8_t *rl_idx);


### PR DESCRIPTION
AdvA in extended advertising PDUs is put at different offset than in
legacy PDUs thus it's better to let caller calculate and pass AdvA and
TxAdd explicitly. This way we won't need to check whether scan request
was on legacy or extended PDU every time.

Signed-off-by: Andrzej Kaczmarek <andrzej.kaczmarek@codecoup.pl>