### PR TITLE
logging: Fix holding coherence of log levels in Spinel backend.

### DIFF
--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -442,32 +442,6 @@ config LOG_BACKEND_SPINEL_BUFFER_SIZE
 	help
 	  Specify reserved size of up-buffer used for logger output.
 
-choice
-	prompt "Spinel backend log level"
-	help
-	  This option selects log level for Spinel backend stack.
-
-config LOG_BACKEND_SPINEL_LEVEL_CRITICAL
-	bool "Critical"
-config LOG_BACKEND_SPINEL_LEVEL_WARNING
-	bool "Warning"
-config LOG_BACKEND_SPINEL_LEVEL_NOTE
-	bool "Note"
-config LOG_BACKEND_SPINEL_LEVEL_INFO
-	bool "Info"
-config LOG_BACKEND_SPINEL_LEVEL_DEBUG
-	bool "Debug"
-endchoice
-
-config LOG_BACKEND_SPINEL_LEVEL
-	int
-	default 1 if LOG_BACKEND_SPINEL_LEVEL_CRITICAL
-	default 2 if LOG_BACKEND_SPINEL_LEVEL_WARNING
-	default 3 if LOG_BACKEND_SPINEL_LEVEL_NOTE
-	default 4 if LOG_BACKEND_SPINEL_LEVEL_INFO
-	default 5 if LOG_BACKEND_SPINEL_LEVEL_DEBUG
-	default 0
-
 endif # LOG_BACKEND_SPINEL
 
 config LOG_BACKEND_NATIVE_POSIX


### PR DESCRIPTION
LOG_BACKEND_SPINEL_LEVEL turned out to be useless and was removed.
Also changes to keep coherence between Zephyr log level and OT log
level added by otPlatLog() were introduced.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>