### PR TITLE
tests: dac_loopback: Exclude building on arduino_zero

### DIFF
--- a/tests/drivers/dac/dac_loopback/testcase.yaml
+++ b/tests/drivers/dac/dac_loopback/testcase.yaml
@@ -3,3 +3,4 @@ common:
 tests:
   drivers.dac:
     depends_on: dac
+    platform_exclude: arduino_zero


### PR DESCRIPTION
The test isn't supported on arduino_zero currently so don't try and
build it there.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>