### PR TITLE
ci: Bump timeout for daily build to 3.5 hours

### DIFF
--- a/.buildkite/daily.yml
+++ b/.buildkite/daily.yml
@@ -5,7 +5,7 @@ steps:
       ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
       ZEPHYR_SDK_INSTALL_DIR: "/opt/sdk/zephyr-sdk-0.11.3"
     parallelism: 120
-    timeout_in_minutes: 150
+    timeout_in_minutes: 210
     retry:
       manual: true
     plugins:


### PR DESCRIPTION
In an attempt to get the daily builds to complete, but the timeout for
them to 3.5 hours.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>