### PR TITLE
shell: kconfig: Clarify dependency of UART option from DTS

### DIFF
--- a/subsys/shell/Kconfig.backends
+++ b/subsys/shell/Kconfig.backends
@@ -37,6 +37,9 @@ config UART_SHELL_ON_DEV_NAME
 	help
 	  This option specifies the name of UART device to be used for the
 	  SHELL UART backend.
+	  In case when DTS is enabled (HAS_DTS), the default value is
+	  set from DTS chosen node 'zephyr,shell-uart' but can be overridden
+	  here.
 
 # Internal config to enable UART interrupts if supported.
 config SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN


### PR DESCRIPTION
This commit adds comment clarifying how does DTS chosen node,
'zephyr,shell-uart', impacts default value of option assigning UART
port to the shell.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>