### PR TITLE
manifest: synchronize mcuboot up to upstream 5a6e181

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -89,7 +89,7 @@ manifest:
       path: modules/crypto/mbedtls
       revision: 4bf099f1254332d16dcd931ccea0a88d24a7d3c7
     - name: mcuboot
-      revision: 813d29ca7ce2aeb388d945f7889e6711b97c33c7
+      revision: 0f2c585552a888b990abd2d5b699b57fe946d5fc
       path: bootloader/mcuboot
     - name: mcumgr
       revision: cfe5eb98a9493017448846fd1a44a9340bd0a22f


### PR DESCRIPTION
synchronized mcuboot up to
https://github.com/zephyrproject-rtos/mcuboot/pull/29/commits/5a6e181

Fix kramdown CVE-2020-14001
boot: zephyr: allow to use project-private key
boot: Support for nrf52840 with ecc keys and cryptocell

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>