### PR TITLE
samples: canbus: isotpfix: Add testing fixture

### DIFF
--- a/samples/subsys/canbus/isotp/sample.yaml
+++ b/samples/subsys/canbus/isotp/sample.yaml
@@ -9,3 +9,4 @@ tests:
       type: one_line
       regex:
         - "(.*)Got 248 bytes in total"
+      fixture: fixture_can_two_boards


### PR DESCRIPTION
Add a fixture since we need at least two boards connected for this test
to run correctly w/real hardware.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>