### PR TITLE
Bluetooth: controller: fixing error re. all zero chmap in conn-ind

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -67,8 +67,6 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	uint16_t interval;
 	uint8_t chan_sel;
 
-	((struct lll_adv *)ftr->param)->conn = NULL;
-
 	adv = ((struct lll_adv *)ftr->param)->hdr.parent;
 	conn = lll->hdr.parent;
 
@@ -87,6 +85,9 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	if ((lll->data_chan_hop < 5) || (lll->data_chan_hop > 16)) {
 		return;
 	}
+
+	((struct lll_adv *)ftr->param)->conn = NULL;
+
 	interval = sys_le16_to_cpu(pdu_adv->connect_ind.interval);
 	lll->interval = interval;
 	lll->latency = sys_le16_to_cpu(pdu_adv->connect_ind.latency);


### PR DESCRIPTION
When a connect indication contains a channel map of all zeros, the adv->conn is left NULL'ed after return and next connect attempt leads to a crash.

This was identified via the Sweyntooth test suite - executing the script re. issue 6.14 towards an Oticon target.

Signed-off-by: Erik Brockhoff <erbr@oticon.com>