### PR TITLE
drivers: serial: native_posix: Add example using gnome-terminal

### DIFF
--- a/drivers/serial/Kconfig.native_posix
+++ b/drivers/serial/Kconfig.native_posix
@@ -66,5 +66,7 @@ config NATIVE_UART_AUTOATTACH_DEFAULT_CMD
 	  This is only applicable if the UART_0 is configured to use its own
 	  PTY with NATIVE_UART_0_ON_OWN_PTY.
 	  The 2nd UART will not be affected by this option.
+	  If you are using GNOME, then you can use this command string
+	  'gnome-terminal -- screen %s'
 
 endif # UART_NATIVE_POSIX


### PR DESCRIPTION
While working with native_posix, I got annoyed with xterm and its weirdness. The gnome-terminal worked better for me. So adding an example how to use gnome-terminal when launching a new terminal for attaching the UART.
