### PR TITLE
dts: riscv: Fix a label in litex-vexriscv DTS

### DIFF
--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -61,7 +61,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
-		timer0: serial@e0002800 {
+		timer0: timer@e0002800 {
 			compatible = "litex,timer0";
 			interrupt-parent = <&intc0>;
 			interrupts = <1 0>;


### PR DESCRIPTION
This commit fixes a wrong "serial@e0002800" label
in riscv32-litex-vexriscv.dtsi.