### PR TITLE
sanitycheck: Fix xml testsuite attribute skipped

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -3109,21 +3109,21 @@ class TestSuite(DisablePyTestCollectionMixin):
                     eleTestsuite = ts[0]
                     eleTestsuite.attrib['failures'] = "%d" % fails
                     eleTestsuite.attrib['errors'] = "%d" % errors
-                    eleTestsuite.attrib['skip'] = "%d" % skips
+                    eleTestsuite.attrib['skipped'] = "%d" % skips
                 else:
                     logger.info(f"Did not find any existing results for {p}")
                     eleTestsuite = ET.SubElement(eleTestsuites, 'testsuite',
                                 name=run, time="%f" % duration,
                                 tests="%d" % (total),
                                 failures="%d" % fails,
-                                errors="%d" % (errors), skip="%s" % (skips))
+                                errors="%d" % (errors), skipped="%s" % (skips))
 
             else:
                 eleTestsuite = ET.SubElement(eleTestsuites, 'testsuite',
                                              name=run, time="%f" % duration,
                                              tests="%d" % (total),
                                              failures="%d" % fails,
-                                             errors="%d" % (errors), skip="%s" % (skips))
+                                             errors="%d" % (errors), skipped="%s" % (skips))
 
             for _, instance in inst.items():
                 if full_report:

--- a/scripts/tests/sanitycheck/test_reporting_testsuite.py
+++ b/scripts/tests/sanitycheck/test_reporting_testsuite.py
@@ -106,7 +106,7 @@ def test_xunit_report(class_testsuite, test_data,
     assert filesize != 0
 
     tree = ET.parse(filename)
-    assert int(tree.findall('testsuite')[0].attrib["skip"]) == int(skips)
+    assert int(tree.findall('testsuite')[0].attrib["skipped"]) == int(skips)
     assert int(tree.findall('testsuite')[0].attrib["failures"]) == int(fails)
     assert int(tree.findall('testsuite')[0].attrib["errors"]) == int(errors)
     assert int(tree.findall('testsuite')[0].attrib["tests"]) == int(passes+fails+skips+errors)


### PR DESCRIPTION
In the junit output the attribute containing the number of skipped tests
must be named "skipped" instead of "skip".
See e.g. https://github.com/junit-team/junit5/blob/main/platform-tests/
src/test/resources/jenkins-junit.xsd#L95

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>