### PR TITLE
sanitycheck: set selected_plaforms for --test-only

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -978,6 +978,7 @@ def main():
         suite.selected_platforms = set(p.platform.name for p in suite.instances.values())
     elif options.test_only:
         suite.load_from_file(last_run, filter_status=['skipped'])
+        suite.selected_platforms = set(p.platform.name for p in suite.instances.values())
     else:
         discards = suite.apply_filters(
             build_only=options.build_only,


### PR DESCRIPTION
When running with --test-only we get:

Traceback (most recent call last):
  File "./scripts/sanitycheck", line 1168, in <module>
    main()
  File "./scripts/sanitycheck", line 1160, in main
    options.only_failed)
  File "scripts/sanity_chk/sanitylib.py", line 2543, in save_reports
    self.xunit_report(filename + ".xml", full_report=False, append=only_failed)
  File "scripts/sanity_chk/sanitylib.py", line 3220, in xunit_report
    return fails, passes, errors, skips
UnboundLocalError: local variable 'fails' referenced before assignment

This is due to the fact that selected_platforms was not set.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>