### PR TITLE
x86: increment default page pool pages

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -191,7 +191,7 @@ config X86_MMU
 
 config X86_MMU_PAGE_POOL_PAGES
 	int "Number of pages to reserve for building page tables"
-	default 16
+	default 17
 	depends on X86_MMU
 	help
 	  Building page tables at boot requires a pool of free memory pages


### PR DESCRIPTION
With the current identity mapping scheme a new test requires
some more memory to be set aside here.

In production this parameter gets turned per-board, and
the pending paging code overhaul in #27001 significantly
relaxes this as driver I/O mappings are no longer sparse.

Fixes a runtime failure in tests/kernel/device on
qemu_x86_64 that somehow slipped past CI.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>