### PR TITLE
drivers: use node IDs for DEVICE_MMIO.*_INIT

### DIFF
--- a/doc/reference/drivers/index.rst
+++ b/doc/reference/drivers/index.rst
@@ -327,7 +327,7 @@ Then when the particular instance is declared:
   }
 
   const static struct my_driver_config my_driver_config_0 = {
-        DEVICE_MMIO_ROM_INIT(0),
+        DEVICE_MMIO_ROM_INIT(DT_DRV_INST(0)),
         .config_func = my_driver_config_irq_0
   }
 
@@ -467,7 +467,7 @@ is made within the init function:
    }
 
    const static struct my_driver_config my_driver_config_0 = {
-      DEVICE_MMIO_ROM_INIT(DT_INST(...)),
+      DEVICE_MMIO_ROM_INIT(DT_DRV_INST(...)),
       ...
    }
 
@@ -527,8 +527,8 @@ For example:
 
    const static struct my_driver_config my_driver_config_0 = {
       ...
-      DEVICE_MMIO_NAMED_ROM_INIT(courge, DT_INST(...)),
-      DEVICE_MMIO_NAMED_ROM_INIT(grault, DT_INST(...)),
+      DEVICE_MMIO_NAMED_ROM_INIT(courge, DT_DRV_INST(...)),
+      DEVICE_MMIO_NAMED_ROM_INIT(grault, DT_DRV_INST(...)),
       ...
    }
 
@@ -561,7 +561,7 @@ for example:
 
 .. code-block:: C
 
-   DEVICE_MMIO_TOPLEVEL_STATIC(my_regs, DT_INST(..));
+   DEVICE_MMIO_TOPLEVEL_STATIC(my_regs, DT_DRV_INST(..));
 
    void some_init_code(...)
    {

--- a/drivers/gpio/gpio_intel_apl.c
+++ b/drivers/gpio/gpio_intel_apl.c
@@ -557,7 +557,7 @@ static const struct gpio_intel_apl_config				\
 	.common = {							\
 		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),	\
 	},								\
-	DEVICE_MMIO_NAMED_ROM_INIT(reg_base, n),			\
+	DEVICE_MMIO_NAMED_ROM_INIT(reg_base, DT_DRV_INST(n)),			\
 	.pin_offset = DT_INST_PROP(n, pin_offset),			\
 	.num_pins = DT_INST_PROP(n, ngpios),				\
 };									\

--- a/drivers/i2c/i2c_dw_port_x.h
+++ b/drivers/i2c/i2c_dw_port_x.h
@@ -9,7 +9,7 @@
 static void i2c_config_@NUM@(struct device *port);
 
 static const struct i2c_dw_rom_config i2c_config_dw_@NUM@ = {
-	DEVICE_MMIO_ROM_INIT(@NUM@),
+	DEVICE_MMIO_ROM_INIT(DT_DRV_INST(@NUM@)),
 	.config_func = i2c_config_@NUM@,
 	.bitrate = DT_INST_PROP(@NUM@, clock_frequency),
 

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -64,7 +64,7 @@
 #include <drivers/interrupt_controller/loapic.h> /* public API declarations and registers */
 #include "intc_ioapic_priv.h"
 
-DEVICE_MMIO_TOPLEVEL_STATIC(ioapic_regs, 0);
+DEVICE_MMIO_TOPLEVEL_STATIC(ioapic_regs, DT_DRV_INST(0));
 
 #define IOAPIC_REG DEVICE_MMIO_TOPLEVEL_GET(ioapic_regs)
 #define BITS_PER_IRQ  4

--- a/drivers/serial/uart_ns16550_port_x.h
+++ b/drivers/serial/uart_ns16550_port_x.h
@@ -17,7 +17,7 @@ static const struct uart_ns16550_device_config uart_ns16550_dev_cfg_@NUM@ = {
 #ifdef UART_NS16550_ACCESS_IOPORT
 	.port = DT_INST_REG_ADDR(@NUM@),
 #elif !DT_INST_PROP(@NUM@, pcie)
-	DEVICE_MMIO_ROM_INIT(@NUM@),
+	DEVICE_MMIO_ROM_INIT(DT_DRV_INST(@NUM@)),
 #endif
 	.sys_clk_freq = DT_INST_PROP(@NUM@, clock_frequency),
 

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -12,7 +12,7 @@
 
 #include <dt-bindings/interrupt-controller/intel-ioapic.h>
 
-DEVICE_MMIO_TOPLEVEL_STATIC(hpet_regs, 0);
+DEVICE_MMIO_TOPLEVEL_STATIC(hpet_regs, DT_DRV_INST(0));
 
 #define HPET_REG32(off) (*(volatile uint32_t *)(long)			\
 			 (DEVICE_MMIO_TOPLEVEL_GET(hpet_regs) + (off)))

--- a/include/sys/device_mmio.h
+++ b/include/sys/device_mmio.h
@@ -55,10 +55,10 @@ struct z_device_mmio_rom {
 	size_t size;
 };
 
-#define Z_DEVICE_MMIO_ROM_INITIALIZER(instance) \
+#define Z_DEVICE_MMIO_ROM_INITIALIZER(node_id) \
 	{ \
-		.phys_addr = DT_INST_REG_ADDR(instance), \
-		.size = DT_INST_REG_SIZE(instance) \
+		.phys_addr = DT_REG_ADDR(node_id), \
+		.size = DT_REG_SIZE(node_id) \
 	}
 
 /**
@@ -106,9 +106,9 @@ struct z_device_mmio_rom {
 	mm_reg_t addr;
 };
 
-#define Z_DEVICE_MMIO_ROM_INITIALIZER(instance) \
+#define Z_DEVICE_MMIO_ROM_INITIALIZER(node_id) \
 	{ \
-		.addr = DT_INST_REG_ADDR(instance) \
+		.addr = DT_REG_ADDR(node_id) \
 	}
 #endif /* DEVICE_MMIO_IS_IN_RAM */
 #endif /* !_ASMLANGUAGE */
@@ -167,7 +167,7 @@ struct z_device_mmio_rom {
  * This is useful for the target MMIO address location when using
  * device_map() directly.
  *
- * @param device device instance object
+ * @param device device node_id object
  * @retval mm_reg_t  pointer to storage location
  */
 #define DEVICE_MMIO_RAM_PTR(device)	(mm_reg_t *)((device)->data)
@@ -218,27 +218,27 @@ struct z_device_mmio_rom {
 	((struct z_device_mmio_rom *)((device)->config))
 
 /**
- * @def DEVICE_MMIO_ROM_INIT(instance)
+ * @def DEVICE_MMIO_ROM_INIT(node_id)
  *
  * @brief Initialize a DEVICE_MMIO_ROM member
  *
  * Initialize MMIO-related information within a specific instance of
  * a device config struct, using information from DTS.
  *
- * Example for an instance of a driver belonging to the "foo" subsystem:
+ * Example for a driver belonging to the "foo" subsystem:
  *
  * struct foo_config my_config = {
- *	DEVICE_MMIO_ROM_INIT(instance),
+ *	DEVICE_MMIO_ROM_INIT(DT_DRV_INST(...)),
  *	.baz = 2;
  *	...
  * }
  *
  * @see DEVICE_MMIO_ROM()
  *
- * @param instance DTS instance
+ * @param node_id DTS node_id
  */
-#define DEVICE_MMIO_ROM_INIT(instance) \
-	._mmio = Z_DEVICE_MMIO_ROM_INITIALIZER(instance)
+#define DEVICE_MMIO_ROM_INIT(node_id) \
+	._mmio = Z_DEVICE_MMIO_ROM_INITIALIZER(node_id)
 
 /**
  * @def DEVICE_MMIO_MAP(device, flags)
@@ -407,7 +407,7 @@ struct z_device_mmio_rom {
 #define DEVICE_MMIO_NAMED_ROM_PTR(device, name) (&(DEV_CFG(device)->name))
 
 /**
- * @def DEVICE_MMIO_NAMED_ROM_INIT(name, instance)
+ * @def DEVICE_MMIO_NAMED_ROM_INIT(name, node_id)
  *
  * @brief Initialize a named DEVICE_MMIO_NAMED_ROM member
  *
@@ -419,8 +419,8 @@ struct z_device_mmio_rom {
  *
  * struct foo_config my_config = {
  *	bar = 7;
- *	DEVICE_MMIO_NAMED_ROM_INIT(courge, instance);
- *	DEVICE_MMIO_NAMED_ROM_INIT(grault, instance);
+ *	DEVICE_MMIO_NAMED_ROM_INIT(courge, DT_DRV_INST(...));
+ *	DEVICE_MMIO_NAMED_ROM_INIT(grault, DT_DRV_INST(...));
  *	baz = 2;
  *	...
  * }
@@ -428,10 +428,10 @@ struct z_device_mmio_rom {
  * @see DEVICE_MMIO_NAMED_ROM()
  *
  * @param name Member name within config for the MMIO region
- * @param instance DTS instance
+ * @param node_id DTS node identifier
  */
-#define DEVICE_MMIO_NAMED_ROM_INIT(name, instance) \
-	.name = Z_DEVICE_MMIO_ROM_INITIALIZER(instance)
+#define DEVICE_MMIO_NAMED_ROM_INIT(name, node_id) \
+	.name = Z_DEVICE_MMIO_ROM_INITIALIZER(node_id)
 
 /**
  * @def DEVICE_MMIO_NAMED_MAP(device, name, flags)
@@ -523,7 +523,7 @@ struct z_device_mmio_rom {
  #define Z_TOPLEVEL_RAM_NAME(name) _CONCAT(z_mmio_ram__, name)
 
 /**
- * @def DEVICE_MMIO_TOPLEVEL(name, instance)
+ * @def DEVICE_MMIO_TOPLEVEL(name, node_id)
  *
  * @brief Declare top-level storage for MMIO information, global scope
  *
@@ -535,17 +535,17 @@ struct z_device_mmio_rom {
  * other C files, using DEVICE_MMIO_TOPLEVEL_DECLARE.
  *
  * @param name Base symbol name
- * @param instance Device-tree instance for this region
+ * @param node_id Device-tree node identifier for this region
  */
 #ifdef DEVICE_MMIO_IS_IN_RAM
-#define DEVICE_MMIO_TOPLEVEL(name, instance) \
+#define DEVICE_MMIO_TOPLEVEL(name, node_id) \
 	mm_reg_t Z_TOPLEVEL_RAM_NAME(name); \
 	const struct z_device_mmio_rom Z_TOPLEVEL_ROM_NAME(name) = \
-		Z_DEVICE_MMIO_ROM_INITIALIZER(instance)
+		Z_DEVICE_MMIO_ROM_INITIALIZER(node_id)
 #else
-#define DEVICE_MMIO_TOPLEVEL(name, instance) \
+#define DEVICE_MMIO_TOPLEVEL(name, node_id) \
 	const struct z_device_mmio_rom Z_TOPLEVEL_ROM_NAME(name) = \
-		Z_DEVICE_MMIO_ROM_INITIALIZER(instance)
+		Z_DEVICE_MMIO_ROM_INITIALIZER(node_id)
 #endif /* DEVICE_MMIO_IS_IN_RAM */
 
 /**
@@ -572,7 +572,7 @@ struct z_device_mmio_rom {
 #endif /* DEVICE_MMIO_IS_IN_RAM */
 
 /**
- * @def  DEVICE_MMIO_TOPLEVEL_STATIC(name, instance)
+ * @def  DEVICE_MMIO_TOPLEVEL_STATIC(name, node_id)
  *
  * @brief Declare top-level storage for MMIO information, static scope
  *
@@ -583,17 +583,17 @@ struct z_device_mmio_rom {
  * The scope of this declaration is static.
  *
  * @param name Name of the top-level MMIO region
- * @param instance Device-tree instance for this region
+ * @param node_id Device-tree node identifier for this region
  */
 #ifdef DEVICE_MMIO_IS_IN_RAM
-#define DEVICE_MMIO_TOPLEVEL_STATIC(name, instance) \
+#define DEVICE_MMIO_TOPLEVEL_STATIC(name, node_id) \
 	static mm_reg_t Z_TOPLEVEL_RAM_NAME(name); \
 	static const struct z_device_mmio_rom Z_TOPLEVEL_ROM_NAME(name) = \
-		Z_DEVICE_MMIO_ROM_INITIALIZER(instance)
+		Z_DEVICE_MMIO_ROM_INITIALIZER(node_id)
 #else
-#define DEVICE_MMIO_TOPLEVEL_STATIC(name, instance) \
+#define DEVICE_MMIO_TOPLEVEL_STATIC(name, node_id) \
 	static const struct z_device_mmio_rom Z_TOPLEVEL_ROM_NAME(name) = \
-		Z_DEVICE_MMIO_ROM_INITIALIZER(instance)
+		Z_DEVICE_MMIO_ROM_INITIALIZER(node_id)
 #endif /* DEVICE_MMIO_IS_IN_RAM */
 
 #ifdef DEVICE_MMIO_IS_IN_RAM

--- a/tests/kernel/device/src/mmio.c
+++ b/tests/kernel/device/src/mmio.c
@@ -25,7 +25,7 @@ struct foo_single_config_info {
 };
 
 const struct foo_single_config_info foo0_config = {
-	DEVICE_MMIO_ROM_INIT(0),
+	DEVICE_MMIO_ROM_INIT(DT_DRV_INST(0)),
 };
 
 int foo_single_init(struct device *device)
@@ -114,8 +114,8 @@ struct foo_mult_config_info {
 };
 
 const struct foo_mult_config_info foo12_config = {
-	DEVICE_MMIO_NAMED_ROM_INIT(courge, 1),
-	DEVICE_MMIO_NAMED_ROM_INIT(grault, 2)
+	DEVICE_MMIO_NAMED_ROM_INIT(courge, DT_DRV_INST(1)),
+	DEVICE_MMIO_NAMED_ROM_INIT(grault, DT_DRV_INST(2))
 };
 
 #define DEV_DATA(dev)	((struct foo_mult_dev_data *)((dev)->data))
@@ -194,8 +194,8 @@ void test_mmio_multiple(void)
 /*
  * Not using driver model, toplevel definition
  */
-DEVICE_MMIO_TOPLEVEL(foo3, 3);
-DEVICE_MMIO_TOPLEVEL_STATIC(foo4, 4);
+DEVICE_MMIO_TOPLEVEL(foo3, DT_DRV_INST(3));
+DEVICE_MMIO_TOPLEVEL_STATIC(foo4, DT_DRV_INST(4));
 
 /**
  * @brief Test DEVICE_MMIO_TOPLEVEL_* macros


### PR DESCRIPTION
There is nothing wrong with instance numbers and they are
recommended for use whenever possible, but this is an API
design problem because it's not always possible to get nodes
by instance number; in some cases, drivers need to get node
identifiers from node labels, for example.

Change these APIs (which are not yet in any Zephyr release)
to take node IDs instead of instance IDs.

Fixes: #26984

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>