### PR TITLE
net: l2: ppp: Kconfig option and macro cleanups

### DIFF
--- a/subsys/net/l2/ppp/Kconfig
+++ b/subsys/net/l2/ppp/Kconfig
@@ -48,14 +48,6 @@ config NET_L2_PPP_MAX_NACK_LOOPS
 	help
 	  How many times to accept NACK loops.
 
-config NET_L2_PPP_MAX_OPTIONS
-	int "Maximum number of options supported"
-	default 8
-	range 0 16
-	help
-	  How many options we support. This is used to allocate space for
-	  each option. The default (8) is a reasonably small value.
-
 config NET_L2_PPP_OPTION_DNS_USE
 	bool "Use negotiated DNS servers"
 	depends on DNS_RESOLVER

--- a/subsys/net/l2/ppp/ppp_internal.h
+++ b/subsys/net/l2/ppp/ppp_internal.h
@@ -35,9 +35,6 @@ struct ppp_packet {
 /** Max Configure-Request transmissions */
 #define MAX_CONFIGURE_REQ CONFIG_NET_L2_PPP_MAX_CONFIGURE_REQ_RETRANSMITS
 
-/** Max number of LCP options */
-#define MAX_LCP_OPTIONS CONFIG_NET_L2_PPP_MAX_OPTIONS
-
 /** Max number of IPCP options */
 #define MAX_IPCP_OPTIONS 4
 

--- a/subsys/net/l2/ppp/ppp_internal.h
+++ b/subsys/net/l2/ppp/ppp_internal.h
@@ -35,12 +35,6 @@ struct ppp_packet {
 /** Max Configure-Request transmissions */
 #define MAX_CONFIGURE_REQ CONFIG_NET_L2_PPP_MAX_CONFIGURE_REQ_RETRANSMITS
 
-/** Max number of IPCP options */
-#define MAX_IPCP_OPTIONS 4
-
-/** Max number of IPV6CP options */
-#define MAX_IPV6CP_OPTIONS 1
-
 #define PPP_BUF_ALLOC_TIMEOUT	K_MSEC(100)
 
 /** Protocol handler information. */

--- a/subsys/net/l2/ppp/ppp_internal.h
+++ b/subsys/net/l2/ppp/ppp_internal.h
@@ -26,9 +26,6 @@ struct ppp_packet {
 	uint16_t length;
 } __packed;
 
-/** Timeout in milliseconds */
-#define PPP_TIMEOUT K_SECONDS(3)
-
 /** Max Terminate-Request transmissions */
 #define MAX_TERMINATE_REQ  CONFIG_NET_L2_PPP_MAX_TERMINATE_REQ_RETRANSMITS
 


### PR DESCRIPTION
Drop `CONFIG_NET_L2_PPP_MAX_OPTIONS` option, as it is no longer used. Remove also unused `MAX_IPCP_OPTIONS` `MAX_IPV6CP_OPTIONS` and `PPP_TIMEOUT`.