### PR TITLE
 Bluetooth: controller: Resolve AdvA in extended adv PDUs 

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1200,6 +1200,8 @@ void radio_ar_status_reset(void)
 
 	NRF_AAR->ENABLE = (AAR_ENABLE_ENABLE_Disabled << AAR_ENABLE_ENABLE_Pos) &
 			  AAR_ENABLE_ENABLE_Msk;
+
+	hal_radio_nrf_ppi_channels_disable(BIT(HAL_TRIGGER_AAR_PPI));
 }
 
 uint32_t radio_ar_has_match(void)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1255,7 +1255,7 @@ void radio_ar_resolve(uint8_t *addr)
 	NRF_AAR->EVENTS_RESOLVED = 0;
 	NRF_AAR->EVENTS_NOTRESOLVED = 0;
 
-	NRF_AAR->TASKS_START = 1;
+	nrf_aar_task_trigger(NRF_AAR, NRF_AAR_TASK_START);
 
 	nrf_aar_int_enable(NRF_AAR, AAR_INTENSET_END_Msk);
 	while (NRF_AAR->EVENTS_END == 0) {

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1169,20 +1169,51 @@ uint32_t radio_ccm_mic_is_valid(void)
 
 static uint8_t MALIGN(4) _aar_scratch[3];
 
-void radio_ar_configure(uint32_t nirk, void *irk)
+void radio_ar_configure(uint32_t nirk, void *irk, uint8_t flags)
 {
+	uint32_t addrptr;
+	uint8_t bcc;
+	uint8_t phy;
+
+	/* Flags provide hint on how to setup AAR:
+	 * ....Xb - legacy PDU
+	 * ...X.b - extended PDU
+	 * XXX..b = RX PHY
+	 * 00000b = default case mapped to 00101b (legacy, 1M)
+	 *
+	 * If neither legacy not extended bit is set, legacy PDU is selected for
+	 * 1M PHY and extended PDU otherwise.
+	 */
+
+	phy = flags >> 2;
+
+	/* Check if extended PDU or non-1M and not legacy PDU */
+	if (IS_ENABLED(CONFIG_BT_CTLR_ADV_EXT) &&
+	    ((flags & BIT(1)) || (!(flags & BIT(0)) && (phy > BIT(0))))) {
+		addrptr = NRF_RADIO->PACKETPTR + 1;
+		bcc = 80;
+	} else {
+		addrptr = NRF_RADIO->PACKETPTR - 1;
+		bcc = 64;
+	}
+
+	/* For Coded PHY adjust for CI and TERM1 */
+	if (IS_ENABLED(CONFIG_BT_CTLR_PHY_CODED) && (phy == BIT(2))) {
+		bcc += 5;
+	}
+
 	NRF_AAR->ENABLE = (AAR_ENABLE_ENABLE_Enabled << AAR_ENABLE_ENABLE_Pos) &
 			  AAR_ENABLE_ENABLE_Msk;
 	NRF_AAR->NIRK = nirk;
 	NRF_AAR->IRKPTR = (uint32_t)irk;
-	NRF_AAR->ADDRPTR = (uint32_t)NRF_RADIO->PACKETPTR - 1;
+	NRF_AAR->ADDRPTR = addrptr;
 	NRF_AAR->SCRATCHPTR = (uint32_t)&_aar_scratch[0];
 
 	NRF_AAR->EVENTS_END = 0;
 	NRF_AAR->EVENTS_RESOLVED = 0;
 	NRF_AAR->EVENTS_NOTRESOLVED = 0;
 
-	radio_bc_configure(64);
+	radio_bc_configure(bcc);
 	radio_bc_status_reset();
 
 	hal_trigger_aar_ppi_config();

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
@@ -98,7 +98,7 @@ void *radio_ccm_tx_pkt_set(struct ccm *ccm, void *pkt);
 uint32_t radio_ccm_is_done(void);
 uint32_t radio_ccm_mic_is_valid(void);
 
-void radio_ar_configure(uint32_t nirk, void *irk);
+void radio_ar_configure(uint32_t nirk, void *irk, uint8_t flags);
 uint32_t radio_ar_match_get(void);
 void radio_ar_status_reset(void);
 uint32_t radio_ar_has_match(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
@@ -102,3 +102,4 @@ void radio_ar_configure(uint32_t nirk, void *irk, uint8_t flags);
 uint32_t radio_ar_match_get(void);
 void radio_ar_status_reset(void);
 uint32_t radio_ar_has_match(void);
+void radio_ar_resolve(uint8_t *addr);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -405,7 +405,7 @@ static void isr_tx(void *param)
 	if (ull_filter_lll_rl_enabled()) {
 		uint8_t count, *irks = ull_filter_lll_irks_get(&count);
 
-		radio_ar_configure(count, irks);
+		radio_ar_configure(count, irks, 0);
 	}
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -296,7 +296,7 @@ static void isr_tx(void *param)
 	if (ull_filter_lll_rl_enabled()) {
 		uint8_t count, *irks = ull_filter_lll_irks_get(&count);
 
-		radio_ar_configure(count, irks);
+		radio_ar_configure(count, irks, (lll->phy_s << 2) | BIT(0));
 	}
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -196,7 +196,11 @@ static int prepare_cb(struct lll_prepare_param *p)
 				       filter->addr_type_bitmask,
 				       (uint8_t *)filter->bdaddr);
 
-		radio_ar_configure(count, irks);
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+		radio_ar_configure(count, irks, (lll->phy << 2));
+#else
+		radio_ar_configure(count, irks, 0);
+#endif
 	} else
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
@@ -461,6 +465,7 @@ isr_rx_do_close:
 
 static void isr_tx(void *param)
 {
+	struct lll_scan *lll = param;
 	struct node_rx_pdu *node_rx;
 	uint32_t hcto;
 
@@ -482,7 +487,12 @@ static void isr_tx(void *param)
 	if (ull_filter_lll_rl_enabled()) {
 		uint8_t count, *irks = ull_filter_lll_irks_get(&count);
 
-		radio_ar_configure(count, irks);
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+		radio_ar_configure(count, irks, (lll->phy << 2));
+#else
+		ARG_UNUSED(lll);
+		radio_ar_configure(count, irks, 0);
+#endif
 	}
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
@@ -534,7 +544,12 @@ static void isr_common_done(void *param)
 	if (ull_filter_lll_rl_enabled()) {
 		uint8_t count, *irks = ull_filter_lll_irks_get(&count);
 
-		radio_ar_configure(count, irks);
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+		radio_ar_configure(count, irks, (lll->phy << 2));
+#else
+		ARG_UNUSED(lll);
+		radio_ar_configure(count, irks, 0);
+#endif
 	}
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 


### PR DESCRIPTION
This allow to resolve AdvA in extended advertising PDUs, i.e. ADV_EXT_IND, AUX_ADV_IND, AUX_SCAN_RSP and AUX_CONNECT_RSP. Since offset of AdvA is different depending on PDU type (legacy vs.
extended) and PHY used (uncoded vs. coded), there's a bit more setup required.

When configuring AR, caller will provide a hint (channel and PHY) to radio driver on how to setup AR. The driver will assume extended PDU if non-1M or secondary channel is used and legacy PDU otherwise. Since it's possible that on 1M on primary we can still receive both legacy and extended PDUs, if the latter is received AR is triggered manually to resolve AdvA properly.