### PR TITLE
build: Fix usage of hardcoded zephyr.{elf,bin,hex}

### DIFF
--- a/boards/arm/lpcxpresso11u68/CMakeLists.txt
+++ b/boards/arm/lpcxpresso11u68/CMakeLists.txt
@@ -3,6 +3,6 @@
 set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
   # Insert checksum (verified by the bootloader) into the zephyr.bin
   # and zephyr.hex images.
-  COMMAND lpc_checksum -f hex ${CMAKE_BINARY_DIR}/zephyr/zephyr.hex
-  COMMAND lpc_checksum -f bin ${CMAKE_BINARY_DIR}/zephyr/zephyr.bin
+  COMMAND lpc_checksum -f hex ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_HEX_NAME}
+  COMMAND lpc_checksum -f bin ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
   )

--- a/boards/arm/mps2_an521/CMakeLists.txt
+++ b/boards/arm/mps2_an521/CMakeLists.txt
@@ -59,7 +59,7 @@ if (CONFIG_BUILD_WITH_TFM)
 			 ${ADD_S_IMAGE_MIN_VER}
 			 ${ADD_SECURITY_COUNTER_NS}
 			 -H 0x400
-			 ${CMAKE_BINARY_DIR}/zephyr/zephyr.bin
+			 ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
 			 ${CMAKE_BINARY_DIR}/zephyr_ns_signed.bin
 
 		#Create concatenated binary image from the two independently signed binary file

--- a/boards/arm/v2m_musca_b1/CMakeLists.txt
+++ b/boards/arm/v2m_musca_b1/CMakeLists.txt
@@ -38,7 +38,7 @@ if (CONFIG_BUILD_WITH_TFM)
 		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/assemble.py
 		ARGS --layout ${PREPROCESSED_FILE}.c
 			-s ${CMAKE_BINARY_DIR}/tfm/install/outputs/MUSCA_B1/tfm_s.bin
-			-n ${CMAKE_BINARY_DIR}/zephyr/zephyr.bin
+			-n ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
 			-o ${CMAKE_BINARY_DIR}/tfm_full.bin
 
 		#Sign concatenated binary image with default public key in mcuboot folder

--- a/samples/subsys/ipc/ipm_mcux/CMakeLists.txt
+++ b/samples/subsys/ipc/ipm_mcux/CMakeLists.txt
@@ -18,7 +18,7 @@ ExternalProject_Add(
   ipm_mcux_remote
   SOURCE_DIR ${APPLICATION_SOURCE_DIR}/remote
   INSTALL_COMMAND ""      # This particular build system has no install command
-  BUILD_BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/ipm_mcux_remote-prefix/src/ipm_mcux_remote-build/zephyr/zephyr.bin"
+  BUILD_BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/ipm_mcux_remote-prefix/src/ipm_mcux_remote-build/zephyr/${KERNEL_BIN_NAME}"
 )
 
 project(ipm_mcux)

--- a/samples/subsys/ipc/ipm_mcux/prj.conf
+++ b/samples/subsys/ipc/ipm_mcux/prj.conf
@@ -2,6 +2,6 @@ CONFIG_PRINTK=y
 CONFIG_IPM=y
 CONFIG_IPM_MCUX=y
 CONFIG_SLAVE_CORE_MCUX=y
-CONFIG_SLAVE_IMAGE_MCUX="${ZEPHYR_BINARY_DIR}/../ipm_mcux_remote-prefix/src/ipm_mcux_remote-build/zephyr/zephyr.bin"
+CONFIG_SLAVE_IMAGE_MCUX="${ZEPHYR_BINARY_DIR}/../ipm_mcux_remote-prefix/src/ipm_mcux_remote-build/zephyr/${KERNEL_BIN_NAME}"
 CONFIG_TIMESLICE_SIZE=1
 CONFIG_MAIN_STACK_SIZE=2048

--- a/samples/subsys/ipc/openamp/CMakeLists.txt
+++ b/samples/subsys/ipc/openamp/CMakeLists.txt
@@ -37,7 +37,7 @@ ExternalProject_Add(
   INSTALL_COMMAND ""      # This particular build system has no install command
   CMAKE_CACHE_ARGS -DBOARD:STRING=${BOARD_REMOTE}
   CMAKE_CACHE_ARGS -DDTC_OVERLAY_FILE:STRING=${DTC_OVERLAY_FILE}
-  BUILD_BYPRODUCTS "${REMOTE_ZEPHYR_DIR}/zephyr.bin"
+  BUILD_BYPRODUCTS "${REMOTE_ZEPHYR_DIR}/${KERNEL_BIN_NAME}"
   # NB: Do we need to pass on more CMake variables?
   BUILD_ALWAYS True
 )

--- a/samples/subsys/ipc/openamp/boards/lpcxpresso54114_m4.conf
+++ b/samples/subsys/ipc/openamp/boards/lpcxpresso54114_m4.conf
@@ -1,3 +1,3 @@
 CONFIG_IPM_MCUX=y
 CONFIG_SLAVE_CORE_MCUX=y
-CONFIG_SLAVE_IMAGE_MCUX="${ZEPHYR_BINARY_DIR}/../openamp_remote-prefix/src/openamp_remote-build/zephyr/zephyr.bin"
+CONFIG_SLAVE_IMAGE_MCUX="${ZEPHYR_BINARY_DIR}/../openamp_remote-prefix/src/openamp_remote-build/zephyr/${KERNEL_BIN_NAME}"

--- a/soc/xtensa/intel_apl_adsp/common/bootloader.cmake
+++ b/soc/xtensa/intel_apl_adsp/common/bootloader.cmake
@@ -19,7 +19,7 @@ add_custom_target(
   DEPENDS base_module
   DEPENDS ${ZEPHYR_FINAL_EXECUTABLE}
   COMMAND ${CMAKE_OBJCOPY} --dump-section .data=mod-apl.bin $<TARGET_FILE:base_module>
-  COMMAND ${CMAKE_OBJCOPY} --add-section .module=mod-apl.bin --set-section-flags .module=load,readonly ${CMAKE_BINARY_DIR}/zephyr/zephyr.elf ${CMAKE_BINARY_DIR}/zephyr/zephyr.elf.mod
+  COMMAND ${CMAKE_OBJCOPY} --add-section .module=mod-apl.bin --set-section-flags .module=load,readonly ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME} ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}.mod
   )
 
 add_custom_target(


### PR DESCRIPTION
Its possible to rename the executable we build via the Kconfig symbol
CONFIG_KERNEL_BIN_NAME.  So we really should use ${KERNEL_ELF_NAME},
${KERNEL_BIN_NAME} and ${KERNEL_HEX_NAME} variables instead of hardcoded
zephyr.elf, zephyr.bin, and zephyr.elf.

This fixes an build issue with
tests/misc/test_build/buildsystem.kconfig.utf8_in_values on
up_squared_adsp and lpcxpresso11u68 platforms.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>