### PR TITLE
cmake: put elf files for Qemu in ZEPHYR_BINARY_DIR

### DIFF
--- a/cmake/emu/qemu.cmake
+++ b/cmake/emu/qemu.cmake
@@ -244,7 +244,7 @@ if(CONFIG_X86_64)
     ${CMAKE_OBJCOPY}
     -O elf32-i386
     $<TARGET_FILE:${logical_target_for_zephyr_elf}>
-    ${CMAKE_BINARY_DIR}/zephyr-qemu.elf
+    ${ZEPHYR_BINARY_DIR}/zephyr-qemu.elf
     DEPENDS ${logical_target_for_zephyr_elf}
     )
 
@@ -257,8 +257,8 @@ if(CONFIG_X86_64)
     COMMAND
     ${CMAKE_OBJCOPY}
     -j .locore
-    ${CMAKE_BINARY_DIR}/zephyr-qemu.elf
-    ${CMAKE_BINARY_DIR}/zephyr-qemu-locore.elf
+    ${ZEPHYR_BINARY_DIR}/zephyr-qemu.elf
+    ${ZEPHYR_BINARY_DIR}/zephyr-qemu-locore.elf
     2>&1 | grep -iv \"empty loadable segment detected\" || true
     DEPENDS qemu_image_target
     )
@@ -267,8 +267,8 @@ if(CONFIG_X86_64)
     COMMAND
     ${CMAKE_OBJCOPY}
     -R .locore
-    ${CMAKE_BINARY_DIR}/zephyr-qemu.elf
-    ${CMAKE_BINARY_DIR}/zephyr-qemu-main.elf
+    ${ZEPHYR_BINARY_DIR}/zephyr-qemu.elf
+    ${ZEPHYR_BINARY_DIR}/zephyr-qemu-main.elf
     2>&1 | grep -iv \"empty loadable segment detected\" || true
     DEPENDS qemu_image_target
     )
@@ -278,10 +278,10 @@ if(CONFIG_X86_64)
     DEPENDS qemu_locore_image_target qemu_main_image_target
     )
 
-  set(QEMU_KERNEL_FILE "${CMAKE_BINARY_DIR}/zephyr-qemu-locore.elf")
+  set(QEMU_KERNEL_FILE "${ZEPHYR_BINARY_DIR}/zephyr-qemu-locore.elf")
 
   list(APPEND QEMU_EXTRA_FLAGS
-    "-device;loader,file=${CMAKE_BINARY_DIR}/zephyr-qemu-main.elf"
+    "-device;loader,file=${ZEPHYR_BINARY_DIR}/zephyr-qemu-main.elf"
     )
 endif()
 


### PR DESCRIPTION
The ELF files were placed in ${CMAKE_BINARY_DIR} when all other ELF
files are actually in ${CMAKE_BINARY_DIR}/zephyr, so keep things consistent
and in one place.