### PR TITLE
MAINTAINERS: Fix errors reported by get_maintainer.py

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -340,7 +340,7 @@ Documentation:
         - drivers/can/
         - dts/bindings/can/
         - include/drivers/can.h
-        - samples/drivers/CAN/
+        - samples/drivers/can/
         - tests/drivers/can/
     labels:
         - "area: CAN"
@@ -805,7 +805,7 @@ Little FS:
     files:
         - subsys/fs/Kconfig.littlefs
         - subsys/fs/littlefs_fs.c
-        - tests/subsys/fs/littlefs
+        - tests/subsys/fs/littlefs/
     description: >-
        Little FS
 


### PR DESCRIPTION
There are two issues in MAINTAINERS.yml.

tests/subsys/fs/littlefs/ specified under Little FS doesn't have the
trailing slash (/).

The commit 0eaa495ccbe1a7c4680fd637c38042fa0c6df7a9 renamed
samples/drivers/CAN to can but MAINTAINERS.yml wasn't.

Signed-off-by: Yasushi SHOJI <yasushi.shoji@gmail.com>