### PR TITLE
tracing: add feature for analysing post-mortem

### DIFF
--- a/doc/guides/tracing/index.rst
+++ b/doc/guides/tracing/index.rst
@@ -111,7 +111,11 @@ supported in Zephyr).
 To enable tracing support with `SEGGER SystemView`_ add the configuration option
 :option:`CONFIG_SEGGER_SYSTEMVIEW` to your project configuration file and set
 it to *y*. For example, this can be added to the
-:ref:`synchronization_sample` to visualize fast switching between threads::
+:ref:`synchronization_sample` to visualize fast switching between threads.
+SystemView can also be used for post-mortem tracing, which can be enabled with
+`CONFIG_SEGGER_SYSVIEW_POST_MORTEM_MODE`. In this mode, a debugger can
+be attached after the system has crashed using ``west attach`` after which the
+latest data from the internal RAM buffer can be loaded into SystemView::
 
     CONFIG_STDOUT_CONSOLE=y
     # enable to use thread names
@@ -119,6 +123,8 @@ it to *y*. For example, this can be added to the
     CONFIG_SEGGER_SYSTEMVIEW=y
     CONFIG_USE_SEGGER_RTT=y
     CONFIG_TRACING=y
+    # enable for post-mortem tracing
+    CONFIG_SEGGER_SYSVIEW_POST_MORTEM_MODE=n
 
 
 .. figure:: segger_systemview.png

--- a/subsys/tracing/sysview/Kconfig
+++ b/subsys/tracing/sysview/Kconfig
@@ -12,4 +12,8 @@ config SEGGER_SYSVIEW_RTT_BUFFER_SIZE
 	depends on SEGGER_SYSTEMVIEW
 	default 4096
 
+config SEGGER_SYSVIEW_POST_MORTEM_MODE
+	bool "Enable post-mortem mode for SystemView"
+	depends on SEGGER_SYSTEMVIEW
+
 endif


### PR DESCRIPTION
This commit adds a Kconfig option for enabling post-mortem mode of SystemView.
This is useful for debugging crashes that occur after a longer period of time.

Additional PR for the segger module can be found here: https://github.com/zephyrproject-rtos/segger/pull/4

Signed-off-by: Mattia Fiumara <mattia.fiumara@bgrid.com>