### PR TITLE
sanitycheck: error on duplicate board identifiers

### DIFF
--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.yaml
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-identifier: lpcxpresso55s69_cpu0
+identifier: lpcxpresso55s69_cpu1
 name: NXP LPCXpresso55S69
 type: mcu
 arch: arm

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.yaml
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.yaml
@@ -10,6 +10,7 @@ type: mcu
 arch: arm
 ram: 64
 flash: 256
+sanitycheck: false
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/xtensa/odroid_go/odroid_go.yaml
+++ b/boards/xtensa/odroid_go/odroid_go.yaml
@@ -1,4 +1,4 @@
-identifier: esp32
+identifier: odroid-go
 name: ODROID-GO
 type: mcu
 arch: xtensa

--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -2600,6 +2600,9 @@ class TestSuite(DisablePyTestCollectionMixin):
                 try:
                     platform = Platform()
                     platform.load(file)
+                    if platform.name in [p.name for p in self.platforms]:
+                        logger.error(f"Duplicate platform {platform.name} in {file}")
+                        raise Exception(f"Duplicate platform identifier {platform.name} found")
                     if platform.sanitycheck:
                         self.platforms.append(platform)
                         if platform.default:


### PR DESCRIPTION
2 boards had duplicate identifiers, fix those and add a check in sanitycheck to error when such issues are found.