### PR TITLE
dts: stm32h7: Fix number of mpu regions

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -32,7 +32,7 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
+				arm,num-mpu-regions = <16>;
 			};
 		};
 	};


### PR DESCRIPTION
On stm32h7 series, there are up to 16 mpu regions.


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>