### PR TITLE
MAINTAINERS: remove bogus path for i2c

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -506,7 +506,6 @@ Documentation:
         - drivers/i2c/
         - dts/bindings/i2c/
         - include/drivers/i2c.h
-        - include/drivers/i2c/
     labels:
         - "area: I2C"
 

--- a/scripts/ci/sanitycheck_ignore.txt
+++ b/scripts/ci/sanitycheck_ignore.txt
@@ -16,6 +16,7 @@
 .mailmap
 .uncrustify.cfg
 CODEOWNERS
+MAINTAINERS.yml
 LICENSE
 Makefile
 tests/*


### PR DESCRIPTION
include/drivers/i2c/ does not exist in the tree.