### PR TITLE
nrfx_spi_nrfx : Fix SPI assert and busy error

### DIFF
--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -279,7 +279,6 @@ static int init_spi(const struct device *dev)
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 	dev_data->pm_state = DEVICE_PM_ACTIVE_STATE;
 #endif
-	spi_context_unlock_unconditionally(&dev_data->ctx);
 
 	return 0;
 }
@@ -361,7 +360,9 @@ static int spi_nrfx_pm_control(const struct device *dev,
 	{								       \
 		IRQ_CONNECT(DT_IRQN(SPI(idx)), DT_IRQ(SPI(idx), priority),     \
 			    nrfx_isr, nrfx_spi_##idx##_irq_handler, 0);	       \
-		return init_spi(dev);					       \
+		int err = init_spi(dev);				       \
+		spi_context_unlock_unconditionally(&get_dev_data(dev)->ctx);   \
+		return err;					       	       \
 	}								       \
 	static struct spi_nrfx_data spi_##idx##_data = {		       \
 		SPI_CONTEXT_INIT_LOCK(spi_##idx##_data, ctx),		       \

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -321,7 +321,6 @@ static int init_spim(const struct device *dev)
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 	data->pm_state = DEVICE_PM_ACTIVE_STATE;
 #endif
-	spi_context_unlock_unconditionally(&data->ctx);
 
 	return 0;
 }
@@ -412,7 +411,9 @@ static int spim_nrfx_pm_control(const struct device *dev,
 		IRQ_CONNECT(NRFX_IRQ_NUMBER_GET(NRF_SPIM##idx),		       \
 			    DT_IRQ(SPIM(idx), priority),		       \
 			    nrfx_isr, nrfx_spim_##idx##_irq_handler, 0);       \
-		return init_spim(dev);					       \
+		int err = init_spim(dev);				       \
+		spi_context_unlock_unconditionally(&get_dev_data(dev)->ctx);   \
+		return err;						       \
 	}								       \
 	static struct spi_nrfx_data spi_##idx##_data = {		       \
 		SPI_CONTEXT_INIT_LOCK(spi_##idx##_data, ctx),		       \


### PR DESCRIPTION
This commit fixes these behaviors when several SPI devices are used simultaneously : 
**spi_nrfx_spi: Update exceeds current buffer**

**assertion "p_cb->state != NRFX_DRV_STATE_UNINITIALIZED" failed: file <file_path>, line 351, function: nrfx_spi_xfer
exit**

I am currently on Zephyr 2.2, I didn't see any fix for this in the newest commits but maybe I have missed something.

Here is the explanation : due to a semaphore unlock in spi_init, when we configure or transfer bytes we are exposed to competitive access.
Little summary of transceive function :
- **take lock**
- spi_init ← **_lock_release_unconditionnaly_**
- spi_configure
- spi_transfer
- spi_uninit
- **lock_release**
