### PR TITLE
i2c: nrfx_twim: Revert "drivers: nrf: Add concatenation buffer to i2c nrfx TWIM driver."

### DIFF
--- a/dts/bindings/i2c/nordic,nrf-twim.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twim.yaml
@@ -6,12 +6,3 @@ description: Nordic nRF family TWIM (TWI master with EasyDMA)
 compatible: "nordic,nrf-twim"
 
 include: nordic,nrf-twi-common.yaml
-
-properties:
-    concat-buf-size:
-        type: int
-        required: false
-        description:
-            If concatenation buffer size is set, then multiple messages in the
-            same direction, will be concatenated into single transfers as long
-            as there is space in buffer and no restart or stop flag is set.


### PR DESCRIPTION
#25867 broke working multi-part I2C transactions on boards that don't provide a concatenation buffer; see #27547.

The failure in that issue is a result of a two-message write transaction with the first fragment having one byte and the second fragment two bytes.  The logic in #25867 determines that the two messages are concatenable, then aborts because there isn't room for the first message since the added `concat-buf-size` property has not been set.  Prior to the patch the two-part write would have succeeded, with an implicit restart added by the hardware before the second fragment.

The logic in the patch is opaque, and there's no record of exactly what problem it's intended to solve.  The incomplete description of how flags like `I2C_MSG_RESTART` are intended to be interpreted contributes to the confusion (it appears that if an explicit request to restart were in the flags to the second fragment the transaction might have succeeded, though by not merging the two fragments).

The logic also appears to reject transactions once concatenation has been initiated if the full length of the transaction will not fit, rather than catenating only the pieces that fit.

Absent clarity of implementation and intent the simplest approach is to revert the patch.

Fixes #27547