### PR TITLE
doc: fix incorrectness in multiple overlay files description

### DIFF
--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -251,7 +251,8 @@ should know about.
    3 ways (in order of precedence):
 
    * As a parameter to the ``west build`` or ``cmake`` invocation via the
-     ``-D`` command-line switch
+     ``-D`` command-line switch. If you have multiple overlay files, you should
+     use quotations, ``"file1.overlay;file2.overlay"``
    * As :ref:`env_vars`.
    * As a ``set(<VARIABLE> <VALUE>)`` statement in your :file:`CMakeLists.txt`
 
@@ -273,7 +274,7 @@ should know about.
   See :ref:`initial-conf` for more information.
 
 * :makevar:`DTC_OVERLAY_FILE`: One or more devicetree overlay files to use.
-  Multiple files can be separated with spaces or semicolons.
+  Multiple files can be separated with semicolons.
   See :ref:`set-devicetree-overlays` for examples and :ref:`devicetree-intro`
   for information about devicetree and Zephyr.
 

--- a/doc/guides/dts/howtos.rst
+++ b/doc/guides/dts/howtos.rst
@@ -177,7 +177,7 @@ are included in that order by the C preprocessor.
 Here are some ways to set it:
 
 1. on the cmake build command line
-   (``-DDTC_OVERLAY_FILE=file1.overlay;file2.overlay``)
+   (``-DDTC_OVERLAY_FILE="file1.overlay;file2.overlay"``)
 #. with the CMake ``set()`` command in the application ``CMakeLists.txt``,
    before including zephyr's :file:`boilerplate.cmake` file
 #. using a ``DTC_OVERLAY_FILE`` environment variable (deprecated)


### PR DESCRIPTION
In Github issue #27548 I found out that documentation has
incorrectness. I made fix and described how correctly provide multiple
overlay files for west and cmake. For both of them necessary to use
quotations. After that, necessary to make one more change if you have
multiple files in quotations. For west necessary to separate multiple
files using spaces and for cmake to separate multiple files necessary
to use semicolons.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>