### PR TITLE
Bluetooth: host: Fixed warning when legacy adv support disabled

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -866,7 +866,7 @@ static void adv_update_rpa(struct bt_le_ext_adv *adv, void *data)
 
 static void le_update_private_addr(void)
 {
-	struct bt_le_ext_adv *adv;
+	struct bt_le_ext_adv *adv = NULL;
 	bool adv_enabled = false;
 	uint8_t id = BT_ID_DEFAULT;
 	int err;
@@ -919,7 +919,7 @@ static void le_update_private_addr(void)
 		return;
 	}
 
-	if (adv_enabled) {
+	if (adv && adv_enabled) {
 		set_le_adv_enable_legacy(adv, true);
 	}
 


### PR DESCRIPTION
If CONFIG_BT_EXT_ADV was enabled but
CONFIG_BT_EXT_ADV_LEGACY_SUPPORT was disabled and
CONFIG_NO_OPTIMIZATIONS was enabled, then there was a
maybe-initialized warning. Fixed by adding additional
checks.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>