### PR TITLE
gcov: Add coverage support for arc qemu platform

### DIFF
--- a/arch/arc/core/CMakeLists.txt
+++ b/arch/arc/core/CMakeLists.txt
@@ -2,6 +2,10 @@
 
 zephyr_library()
 
+if(CONFIG_COVERAGE)
+  toolchain_cc_coverage()
+endif()
+
 zephyr_library_sources(
   thread.c
   thread_entry_wrapper.S

--- a/boards/arc/qemu_arc/Kconfig.board
+++ b/boards/arc/qemu_arc/Kconfig.board
@@ -6,3 +6,4 @@ config BOARD_QEMU_ARC
 	bool "ARC QEMU for EM & HS cores"
 	depends on SOC_QEMU_ARC
 	select QEMU_TARGET
+	select HAS_COVERAGE_SUPPORT

--- a/subsys/testsuite/coverage/coverage_ram.ld
+++ b/subsys/testsuite/coverage/coverage_ram.ld
@@ -45,3 +45,18 @@ SECTION_PROLOGUE(_GCOV_BSS_SECTION_NAME, (NOLOAD),)
 __gcov_bss_num_words = ((__gcov_bss_end - __gcov_bss_start) >> 2);
 __gcov_bss_size = __gcov_bss_end - __gcov_bss_start;
 #endif
+
+#ifdef CONFIG_ARC
+SECTION_PROLOGUE(_GCOV_BSS_SECTION_NAME, (NOLOAD),)
+{
+	MPU_MIN_SIZE_ALIGN
+	. = ALIGN(4);
+	__gcov_bss_start = .;
+	*(".bss.__gcov0.*");
+	MPU_MIN_SIZE_ALIGN
+	__gcov_bss_end = .;
+}GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+
+__gcov_bss_num_words = ((__gcov_bss_end - __gcov_bss_start) >> 2);
+__gcov_bss_size = __gcov_bss_end - __gcov_bss_start;
+#endif


### PR DESCRIPTION
* add toolchain abstraction for coverage
* add select HAS_COVERAGE_SUPPORT to kconfig
* port gcov linker code to CKake for arc

Signed-off-by: Jingru Wang <jingru@synopsys.com>