### PR TITLE
Misc code fixes for LLVM support

### DIFF
--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -31,6 +31,7 @@ FUNC_NORETURN void arch_system_halt(unsigned int reason)
 }
 #endif
 
+#ifdef CONFIG_THREAD_STACK_INFO
 static inline uintptr_t esf_get_sp(const z_arch_esf_t *esf)
 {
 #ifdef CONFIG_X86_64
@@ -39,7 +40,9 @@ static inline uintptr_t esf_get_sp(const z_arch_esf_t *esf)
 	return esf->esp;
 #endif
 }
+#endif
 
+#ifdef CONFIG_EXCEPTION_DEBUG
 static inline uintptr_t esf_get_code(const z_arch_esf_t *esf)
 {
 #ifdef CONFIG_X86_64
@@ -48,6 +51,7 @@ static inline uintptr_t esf_get_code(const z_arch_esf_t *esf)
 	return esf->errorCode;
 #endif
 }
+#endif
 
 #ifdef CONFIG_THREAD_STACK_INFO
 bool z_x86_check_stack_bounds(uintptr_t addr, size_t size, uint16_t cs)

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -666,6 +666,7 @@ __aligned(PTABLES_ALIGN) struct x86_page_tables z_x86_user_ptables;
 
 extern char z_shared_kernel_page_start[];
 
+#ifdef CONFIG_X86_KPTI
 static inline bool is_within_system_ram(uintptr_t addr)
 {
 #ifdef CONFIG_X86_64
@@ -676,6 +677,7 @@ static inline bool is_within_system_ram(uintptr_t addr)
 		(addr < (PHYS_RAM_ADDR + PHYS_RAM_SIZE));
 #endif
 }
+#endif
 
 /* Ignored bit posiition at all levels */
 #define IGNORED		BIT64(11)

--- a/lib/os/mempool.c
+++ b/lib/os/mempool.c
@@ -56,13 +56,16 @@ static void clear_alloc_bit(struct sys_mem_pool_base *p, int level, int bn)
 	*word &= ~(1<<bit);
 }
 
-static inline bool alloc_bit_is_set(struct sys_mem_pool_base *p, int level, int bn)
+#ifdef CONFIG_ASSERT
+static inline bool alloc_bit_is_set(struct sys_mem_pool_base *p,
+				    int level, int bn)
 {
 	uint32_t *word;
 	int bit = get_bit_ptr(p, level, bn, &word);
 
 	return (*word >> bit) & 1;
 }
+#endif
 
 /* Returns all four of the allocated bits for the specified blocks
  * "partners" in the bottom 4 bits of the return value


### PR DESCRIPTION
found while building with llvm/clang.
- lib: mempool: alloc_bit_is_set is used only with asserts
- arch: x86: guard some functions based on usage