### PR TITLE
drivers: fix socket close() implementations for socket offloading

### DIFF
--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -1205,8 +1205,9 @@ static int offload_socket(int family, int type, int proto)
 	return ret;
 }
 
-static int offload_close(struct modem_socket *sock)
+static int offload_close(void *obj)
 {
+	struct modem_socket *sock = (struct modem_socket *)obj;
 	char buf[sizeof("AT+USOCL=#\r")];
 	int ret;
 
@@ -1451,11 +1452,6 @@ static ssize_t offload_sendto(void *obj, const void *buf, size_t len,
 
 	errno = 0;
 	return ret;
-}
-
-static int offload_close(void *obj)
-{
-	return offload_close((struct modem_socket *)obj);
 }
 
 static int offload_ioctl(void *obj, unsigned int request, va_list args)

--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -350,8 +350,9 @@ static ssize_t eswifi_socket_recvfrom(void *obj, void *buf, size_t len,
 	return eswifi_socket_recv(obj, buf, len, flags);
 }
 
-static int eswifi_socket_close(int sock)
+static int eswifi_socket_close(void *obj)
 {
+	int sock = OBJ_TO_SD(obj);
 	struct eswifi_off_socket *socket;
 	struct net_pkt *pkt;
 	int ret;
@@ -497,11 +498,6 @@ static int eswifi_socket_create(int family, int type, int proto)
 					&eswifi_socket_fd_op_vtable);
 
 	return fd;
-}
-
-static int eswifi_socket_close(void *obj)
-{
-	return eswifi_socket_close(sd);
 }
 
 static int eswifi_socket_ioctl(void *obj, unsigned int request, va_list args)

--- a/drivers/wifi/simplelink/simplelink_sockets.c
+++ b/drivers/wifi/simplelink/simplelink_sockets.c
@@ -281,8 +281,9 @@ exit:
 	return retval;
 }
 
-static int simplelink_close(int sd)
+static int simplelink_close(void *obj)
 {
+	int sd = OBJ_TO_SD(obj);
 	int retval;
 
 	retval = sl_Close(sd);
@@ -1122,11 +1123,6 @@ static int simplelink_fcntl(int sd, int cmd, va_list args)
 
 exit:
 	return retval;
-}
-
-static int simplelink_close(void *obj)
-{
-	return simplelink_close(sd);
 }
 
 static int simplelink_ioctl(void *obj, unsigned int request, va_list args)


### PR DESCRIPTION
PR #27485 introduced new implementations for close() that do not build
correctly. This commit fixes the problem by re-implementing them.

Fixes #27587

Signed-off-by: Vincent Wan <vwan@ti.com>