### PR TITLE
west.yml: hal_ti: add SlNetSock modules

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -77,7 +77,7 @@ manifest:
       revision: cea57f86d3ade46c0b99dab32b2ac63435ed0693
       path: modules/hal/stm32
     - name: hal_ti
-      revision: aabc6a04a8e871cbb01e02c22bb409f68001dc64
+      revision: pull/20/head
       path: modules/hal/ti
     - name: libmetal
       revision: 87e9e7f2c5b4e238236fe703db61ba23e48dc2ef


### PR DESCRIPTION
Add SlNetSock modules taken from TI CC32xx SimpleLink SDK 4.10.00.07.

This PR is contingent on #24873 being merged first, as this would also bring in changes from https://github.com/zephyrproject-rtos/hal_ti/pull/19 that would break the build until device instances are truly constant.