### PR TITLE
drivers: ethernet: stm32: add name to rx thread

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -591,6 +591,8 @@ static int eth_initialize(struct device *dev)
 			K_PRIO_COOP(CONFIG_ETH_STM32_HAL_RX_THREAD_PRIO),
 			0, K_NO_WAIT);
 
+	k_thread_name_set(&dev_data->rx_thread, "stm_eth");
+
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 	for (uint32_t i = 0; i < ETH_RX_DESC_CNT; i++) {
 		hal_ret = HAL_ETH_DescAssignMemory(heth, i, dma_rx_buffer[i],


### PR DESCRIPTION
Give a name to the rx thread so it can be more easily identified in tracers like SystemView.

This also works around bug #27592, but it isn't a real fix for that bug.
