### PR TITLE
cdc_acm: fix C++ issues with header and document dependency

### DIFF
--- a/include/drivers/uart/cdc_acm.h
+++ b/include/drivers/uart/cdc_acm.h
@@ -16,6 +16,10 @@
 
 #include <device.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /**
  * @typedef cdc_dte_rate_callback_t
  * @brief A function that is called when the USB host changes the baud
@@ -30,6 +34,9 @@ typedef void (*cdc_dte_rate_callback_t)(struct device *dev, uint32_t rate);
  *
  * The callback is invoked when the USB host changes the baud rate.
  *
+ * @note This function is available only when
+ * CONFIG_CDC_ACM_DTE_RATE_CALLBACK_SUPPORT is enabled.
+ *
  * @param dev	    CDC ACM device structure.
  * @param callback  Event handler.
  *
@@ -37,5 +44,9 @@ typedef void (*cdc_dte_rate_callback_t)(struct device *dev, uint32_t rate);
  */
 int cdc_acm_dte_rate_callback_set(struct device *dev,
 				  cdc_dte_rate_callback_t callback);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_UART_CDC_ACM_H_ */


### PR DESCRIPTION
The header was missing the language linkage wrapper that allows the
driver-specific function to be located from C++.

Also it helps the poor user to be informed that the function is only
available when a special Kconfig option is set.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>