### PR TITLE
tests: drivers: spi: loopback: run SPI loopback test in sanitycheck

### DIFF
--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -1,7 +1,10 @@
+common:
+  depends_on: spi
+  tags: drivers spi
 tests:
-  drivers.spi:
-    depends_on: spi
-    tags: drivers spi
+  drivers.spi.loopback:
     harness: ztest
     harness_config:
       fixture: spi_loopback
+  driver.spi.loopback.internal:
+    filter: CONFIG_SPI_LOOPBACK_MODE_LOOP


### PR DESCRIPTION
Run the SPI loopback test in sanitycheck if the board supports internal loopback mode.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>