### PR TITLE
Fixed bugs in per_adv_sync shell commands

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1366,17 +1366,11 @@ static int cmd_per_adv_data(const struct shell *shell, size_t argc,
 
 #if defined(CONFIG_BT_PER_ADV_SYNC)
 static struct bt_le_per_adv_sync *per_adv_syncs[CONFIG_BT_PER_ADV_SYNC_MAX];
-static struct bt_le_per_adv_sync *selected_per_adv_sync;
 
 static void per_adv_sync_sync_cb(struct bt_le_per_adv_sync *sync,
 				 struct bt_le_per_adv_sync_synced_info *info)
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
-
-	if (selected_per_adv_sync != sync) {
-		shell_error(ctx_shell, "Invalid per adv sync object");
-		return;
-	}
 
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	shell_print(ctx_shell, "PER_ADV_SYNC[%u]: [DEVICE]: %s synced, "
@@ -1391,15 +1385,9 @@ static void per_adv_sync_terminated_cb(
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	if (selected_per_adv_sync != sync) {
-		shell_error(ctx_shell, "Invalid per adv sync object");
-		return;
-	}
-
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	shell_print(ctx_shell, "PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated",
 		    bt_le_per_adv_sync_get_index(sync), le_addr);
-	selected_per_adv_sync = NULL;
 }
 
 static void per_adv_sync_recv_cb(
@@ -1408,11 +1396,6 @@ static void per_adv_sync_recv_cb(
 	struct net_buf_simple *buf)
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
-
-	if (selected_per_adv_sync != sync) {
-		shell_error(ctx_shell, "Invalid per adv sync object");
-		return;
-	}
 
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	shell_print(ctx_shell, "PER_ADV_SYNC[%u]: [DEVICE]: %s, tx_power %i, "

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1433,12 +1433,12 @@ static int cmd_per_adv_sync_create(const struct shell *shell, size_t argc,
 	int err;
 	struct bt_le_per_adv_sync_param create_params = { 0 };
 	uint32_t options = 0;
-	struct bt_le_per_adv_sync *free_per_adv_sync = NULL;
+	struct bt_le_per_adv_sync **free_per_adv_sync = NULL;
 	int i = 0;
 
 	for (i = 0; i < ARRAY_SIZE(per_adv_syncs); i++) {
 		if (per_adv_syncs[i] == NULL) {
-			free_per_adv_sync = per_adv_syncs[i];
+			free_per_adv_sync = &per_adv_syncs[i];
 			break;
 		}
 	}
@@ -1495,7 +1495,7 @@ static int cmd_per_adv_sync_create(const struct shell *shell, size_t argc,
 	create_params.options = options;
 
 	err = bt_le_per_adv_sync_create(&create_params, &per_adv_sync_cb,
-					&free_per_adv_sync);
+					free_per_adv_sync);
 	if (err) {
 		shell_error(shell, "Per adv sync failed (%d)", err);
 	} else {


### PR DESCRIPTION
Some per_adv_sync shell commands did not behave as intended, due to some last-minute changes to the functions which were untested. 