### PR TITLE
Bluetooth: host: per_adv_sync auto scan fixed for central role

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4303,15 +4303,13 @@ int bt_le_scan_update(bool fast_scan)
 
 		conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
 					       BT_CONN_CONNECT_SCAN);
-		if (!conn) {
-			return 0;
+		if (conn) {
+			atomic_set_bit(bt_dev.flags, BT_DEV_SCAN_FILTER_DUP);
+
+			bt_conn_unref(conn);
+
+			return start_passive_scan(fast_scan);
 		}
-
-		atomic_set_bit(bt_dev.flags, BT_DEV_SCAN_FILTER_DUP);
-
-		bt_conn_unref(conn);
-
-		return start_passive_scan(fast_scan);
 	}
 
 #if defined(CONFIG_BT_PER_ADV_SYNC)


### PR DESCRIPTION
If `CONFIG_BT_CENTRAL` was enabled and the device was not scanning
or connected, then `bt_le_per_adv_sync_create` would not start
scanning for periodic advertisers.

Signed-off-by: Emil Gydesen <emil_gydesen@bose.com>