### PR TITLE
drivers: modem: Get the IMSI and ICCID from the SIM

### DIFF
--- a/drivers/modem/Kconfig
+++ b/drivers/modem/Kconfig
@@ -124,6 +124,15 @@ config MODEM_SHELL
 	  Activate shell module that provides modem utilities like
 	  sending a command to the modem UART.
 
+config MODEM_SIM_NUMBERS
+	bool "Enable querying the SIM for IMSI and ICCID"
+	depends on MODEM_SHELL
+	default y
+	help
+	  Query the SIM card for the IMSI and ICCID identifiers. This
+	  can be disabled if the application does not use a SIM.
+
+
 source "drivers/modem/Kconfig.ublox-sara-r4"
 source "drivers/modem/Kconfig.wncm14a2a"
 source "drivers/modem/Kconfig.gsm"

--- a/drivers/modem/modem_context.h
+++ b/drivers/modem/modem_context.h
@@ -62,6 +62,10 @@ struct modem_context {
 	char *data_model;
 	char *data_revision;
 	char *data_imei;
+#if defined(CONFIG_MODEM_SIM_NUMBERS)
+	char *data_imsi;
+	char *data_iccid;
+#endif
 	int   data_rssi;
 
 	/* pin config */

--- a/drivers/modem/modem_receiver.h
+++ b/drivers/modem/modem_receiver.h
@@ -32,7 +32,11 @@ struct mdm_receiver_context {
 	char *data_manufacturer;
 	char *data_model;
 	char *data_revision;
+#if defined(CONFIG_MODEM_SIM_NUMBERS)
 	char *data_imei;
+	char *data_imsi;
+#endif
+	char *data_iccid;
 	int   data_rssi;
 };
 

--- a/drivers/modem/modem_shell.c
+++ b/drivers/modem/modem_shell.c
@@ -63,12 +63,20 @@ static int cmd_modem_list(const struct shell *shell, size_t argc,
 				"\tModel:        %s\n"
 				"\tRevision:     %s\n"
 				"\tIMEI:         %s\n"
+#if defined(CONFIG_MODEM_SIM_NUMBERS)
+				"\tIMSI:         %s\n"
+				"\tICCID:        %s\n"
+#endif
 				"\tRSSI:         %d\n", i,
 			       UART_DEV_NAME(mdm_ctx),
 			       mdm_ctx->data_manufacturer,
 			       mdm_ctx->data_model,
 			       mdm_ctx->data_revision,
 			       mdm_ctx->data_imei,
+#if defined(CONFIG_MODEM_SIM_NUMBERS)
+			       mdm_ctx->data_imsi,
+			       mdm_ctx->data_iccid,
+#endif
 			       mdm_ctx->data_rssi);
 		}
 	}


### PR DESCRIPTION
This adds an option to query the modem for the SIM's IMSI and ICCID
numbers, just like the modem's IMEI is queried today. This requires
the SIM to be present, which might not be the case for all
applications, so it can be disabled.

Signed-off-by: Göran Weinholt <goran.weinholt@endian.se>
Signed-off-by: Benjamin Lindqvist <benjamin.lindqvist@endian.se>