### PR TITLE
usb: nrf: Fix for remote wake up request.

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1127,6 +1127,9 @@ static void usbd_event_handler(nrfx_usbd_evt_t const *const p_event)
 		break;
 	case NRFX_USBD_EVT_WUREQ:
 		LOG_DBG("RemoteWU initiated");
+		evt.evt_type = USBD_EVT_POWER;
+		evt.evt.pwr_evt.state = USBD_RESUMED;
+		put_evt = true;
 		break;
 	case NRFX_USBD_EVT_RESET:
 		evt.evt_type = USBD_EVT_RESET;


### PR DESCRIPTION
Short explanation of remote wake up:

The device has a possibility to wake up the HOST by sending
the wake up request. The request must be previously
explicitly enabled by the HOST just before the SUSPEND.

The HOST enables the remote wake up functionality by sending
SET_FEATURE request with remote wake up flag set to 1.
This ususally happens just before the device is suspended.

About this PR:
When the device decides to wake up the HOST it sends proper request.
Nordic USB HW is creating an event when the request has been sent.

The Zephyr USB device stack must proerly react to this event and
change the state of the device from SUSPENDED. For example if the
device was previously in CONFIGURED state it will remain CONFIGURED.
For state changes refer to Chapter 9.1.1 form USB 2.0 specification.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>