### PR TITLE
logging: net: Make autostart of backend configurable

### DIFF
--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -541,6 +541,16 @@ config LOG_BACKEND_NET_SYST_ENABLE
 	help
 	  When enabled backend is using networking to output syst format logs.
 
+config LOG_BACKEND_NET_AUTOSTART
+	bool "Automatically start networking backend"
+	default y if NET_CONFIG_NEED_IPV4 || NET_CONFIG_NEED_IPV6
+	help
+	  When enabled automatically start the networking backend on
+	  application start. If no routes to the logging server are available
+	  on application startup, this must be set to n and the backend must be
+	  started by the application later on. Otherwise the logging
+	  thread might block.
+
 endif # LOG_BACKEND_NET
 
 config LOG_BACKEND_RB

--- a/subsys/logging/log_backend_net.c
+++ b/subsys/logging/log_backend_net.c
@@ -252,7 +252,8 @@ const struct log_backend_api log_backend_net_api = {
 /* Note that the backend can be activated only after we have networking
  * subsystem ready so we must not start it immediately.
  */
-LOG_BACKEND_DEFINE(log_backend_net, log_backend_net_api, true);
+LOG_BACKEND_DEFINE(log_backend_net, log_backend_net_api,
+		   IS_ENABLED(CONFIG_LOG_BACKEND_NET_AUTOSTART));
 
 const struct log_backend *log_backend_net_get(void)
 {


### PR DESCRIPTION
In certain application configuration the networking log backend must not
be started, when the application starts. Starting it must be delayed
until routes to the logging server are established.

This commit introduces a new Kconfig setting to be able to control that
behaviour.

Fixes #27464

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>