### PR TITLE
i2c_litex: Fix generating START condition

### DIFF
--- a/drivers/i2c/i2c_bitbang.c
+++ b/drivers/i2c/i2c_bitbang.c
@@ -96,9 +96,9 @@ static void i2c_start(struct i2c_bitbang *context)
 		 */
 		i2c_set_scl(context, 0);
 		i2c_delay(context->delays[T_LOW]);
-		i2c_set_scl(context, 1);
-		i2c_delay(context->delays[T_SU_STA]);
 	}
+	i2c_set_scl(context, 1);
+	i2c_delay(context->delays[T_SU_STA]);
 	i2c_set_sda(context, 0);
 	i2c_delay(context->delays[T_HD_STA]);
 


### PR DESCRIPTION
This fixes the generation of START condition,
by forcing the SCL signal to go high before going low.
