### PR TITLE
west: runners: jlink: add support for -nogui 1 command line parameter

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -564,7 +564,7 @@ class ZephyrBinaryRunner(abc.ABC):
             return
         subprocess.check_call(cmd)
 
-    def check_output(self, cmd):
+    def check_output(self, cmd, **kwargs):
         '''Subclass subprocess.check_output() wrapper.
 
         Subclasses should use this method to run command in a
@@ -574,7 +574,7 @@ class ZephyrBinaryRunner(abc.ABC):
         self._log_cmd(cmd)
         if _DRY_RUN:
             return b''
-        return subprocess.check_output(cmd)
+        return subprocess.check_output(cmd, **kwargs)
 
     def popen_ignore_int(self, cmd):
         '''Spawn a child command, ensuring it ignores SIGINT.


### PR DESCRIPTION
Add support for the J-Link Commander "-NoGui 1" command line parameter in the West J-Link runner.

This command line parameter suppresses GUI dialogs (except for license dialogs) in J-Link Commander starting from v6.80.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>