### PR TITLE
doc: document various best practices and expectations

### DIFF
--- a/doc/guides/design_guidelines.rst
+++ b/doc/guides/design_guidelines.rst
@@ -1,0 +1,66 @@
+.. _design_guidelines:
+
+API Design Guidelines
+#####################
+
+Zephyr development and evolution is a group effort, and to simplify
+maintenance and enhancements there are some general policies that should
+be followed when developing a new capability or interface.
+
+Using Callbacks
+***************
+
+Many APIs involve passing a callback as a parameter or as a member of a
+configuration structure.  The following policies should be followed when
+specifying the signature of a callback:
+
+* The first parameter should be a pointer to the object most closely
+  associated with the callback.  In the case of device drivers this
+  would be ``struct device *dev``.  For library functions it may be a
+  pointer to another object that was referenced when the callback was
+  provided.
+
+* The next parameter(s) should be additional information specific to the
+  callback invocation, such as a channel identifier, new status value,
+  and/or a message pointer followed by the message length.
+
+* The final parameter should be a ``void *user_data`` pointer carrying
+  context that allows a shared callback function to locate additional
+  material necessary to process the callback.
+
+An exception to providing ``user_data`` as the last parameter may be
+allowed when the callback itself was provided through a structure that
+will be embedded in another structure.  An example of such a case is
+:c:type:`gpio_callback`, normally defined within a data structure
+specific to the code that also defines the callback function.  In those
+cases further context can accessed by the callback indirectly by
+:c:macro:`CONTAINER_OF`.
+
+Examples
+========
+
+* The requirements of :c:type:`k_timer_expiry_t` invoked when a system
+  timer alarm fires are satisfied by::
+
+    void handle_timeout(struct k_timer *timer)
+    { ... }
+
+  The assumption here, as with :c:type:`gpio_callback`, is that the
+  timer is embedded in a structure reachable from
+  :c:macro:`CONTAINER_OF` that can provide additional context to the
+  callback.
+
+* The requirements of :c:type:`counter_alarm_callback_t` invoked when a
+  counter device alarm fires are satisfied by::
+
+    void handle_alarm(struct device *dev,
+                      uint8_t chan_id,
+		      uint32_t ticks,
+		      void *user_data)
+    { ... }
+
+  This provides more complete useful information, including which
+  counter channel timed-out and the counter value at which the timeout
+  occurred, as well as user context which may or may not be the
+  :c:type:`counter_alarm_cfg` used to register the callback, depending
+  on user needs.

--- a/doc/guides/design_guidelines.rst
+++ b/doc/guides/design_guidelines.rst
@@ -64,3 +64,40 @@ Examples
   occurred, as well as user context which may or may not be the
   :c:type:`counter_alarm_cfg` used to register the callback, depending
   on user needs.
+
+Conditional Data and APIs
+*************************
+
+APIs and libraries may provide features that are expensive in RAM or
+code size but are optional in the sense that some applications can be
+implemented without them.  Examples of such feature include
+:option:`capturing a timestamp <CONFIG_CAN_RX_TIMESTAMP>` or
+:option:`providing an alternative interface <CONFIG_SPI_ASYNC>`.  The
+developer in coordination with the community must determine whether
+enabling the features is to be controllable through a Kconfig option.
+
+In the case where a feature is determined to be optional the following
+practices should be followed.
+
+* Any data that is accessed only when the feature is enabled should be
+  conditionally included via ``#ifdef CONFIG_MYFEATURE`` in the
+  structure or union declaration.  This reduces memory use for
+  applications that don't need the capability.
+* Function declarations that are available only when the option is
+  enabled should be provided unconditionally.  Add a note in the
+  description that the function is available only when the specified
+  feature is enabled, referencing the required Kconfig symbol by name.
+  (In cases where the function is used but not enabled a link-time error
+  will be generated.)
+* Where code specific to the feature is isolated in a source file that
+  has no other content that file should be conditionally included in
+  ``CMakeLists.txt``::
+
+    zephyr_sources_ifdef(CONFIG_MYFEATURE foo_funcs.c)
+* Where code specific to the feature is part of a source file that has
+  other content the feature-specific code should be conditionally
+  processed using ``#ifdef CONFIG_MYFEATURE``.
+
+The Kconfig flag used to enable the feature should be added to the
+``PREDEFINED`` variable in :file:`doc/zephyr.doxyfile.in` to ensure the
+conditional API and functions appear in generated documentation.

--- a/doc/guides/dts/dt-vs-kconfig.rst
+++ b/doc/guides/dts/dt-vs-kconfig.rst
@@ -53,6 +53,13 @@ instance.
 
 There are **exceptions** to these rules:
 
+* Because Kconfig is unable to flexibly control some instance-specific driver
+  configuration parameters, such as the size of an internal buffer, these
+  options may be defined in devicetree.  However, to make clear that they are
+  specific to Zephyr drivers and not hardware description or configuration these
+  properties should be prefixed with ``zephyr,``,
+  e.g. ``zephyr,random-mac-address`` in the common Ethernet devicetree
+  properties.
 * Devicetree's ``chosen`` keyword, which allows the user to select a specific
   instance of a hardware device to be used for a particular purpose. An example
   of this is selecting a particular UART for use as the system's console.

--- a/doc/guides/dts/dt-vs-kconfig.rst
+++ b/doc/guides/dts/dt-vs-kconfig.rst
@@ -45,11 +45,14 @@ supporting both the Bluetooth Low Energy and 802.15.4 wireless technologies.
 * Kconfig should determine which **software features** should be built for the
   radio, such as selecting a BLE or 802.15.4 protocol stack.
 
-There are two noteworthy **exceptions** to these rules:
+As another example, Kconfig options that formerly enabled a particular
+instance of a driver (that is itself enabled by Kconfig) have been
+removed.  The devices are selected individually using devicetree's
+:ref:`status <dt-important-props>` keyword on the corresponding hardware
+instance.
+
+There are **exceptions** to these rules:
 
 * Devicetree's ``chosen`` keyword, which allows the user to select a specific
   instance of a hardware device to be used for a particular purpose. An example
   of this is selecting a particular UART for use as the system's console.
-* Devicetree's ``status`` keyword, which allows the user to enable or disable a
-  particular instance of a hardware device. This takes precedence over related
-  Kconfig options which serve a similar purpose.

--- a/doc/guides/index.rst
+++ b/doc/guides/index.rst
@@ -11,6 +11,7 @@ User and Developer Guides
    bluetooth/index.rst
    build/index
    coding_guidelines/index
+   design_guidelines.rst
    c_library
    ../README.rst
    documentation/index


### PR DESCRIPTION
This records the consensus from some recent API telecon discussions related to devicetree hardware vs software configuration, callback design, and how to ensure documentation is generated for conditional capabilities.

Closes #11976.