### PR TITLE
RT600: Fix IOCON setting

### DIFF
--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -75,11 +75,19 @@ static int gpio_mcux_lpc_configure(struct device *dev, gpio_pin_t pin,
 		return -ENOTSUP;
 	}
 
+#ifdef IOPCTL
+	IOPCTL_Type *pinmux_base = config->pinmux_base;
+	uint32_t *pinconfig = (uint32_t *)&(pinmux_base->PIO[port][pin]);
+
+	/*
+	 * Enable input buffer for both input and output pins, it costs
+	 * nothing and allows values to be read back.
+	 */
+	*pinconfig |= IOPCTL_PIO_INBUF_EN;
+#endif
+
 	if (flags & (GPIO_PULL_UP | GPIO_PULL_DOWN)) {
 #ifdef IOPCTL
-		IOPCTL_Type *pinmux_base = config->pinmux_base;
-		uint32_t *pinconfig = (uint32_t *)&(pinmux_base->PIO[port][pin]);
-
 		*pinconfig |= IOPCTL_PIO_PUPD_EN;
 		if ((flags & GPIO_PULL_UP) != 0) {
 			*pinconfig |= IOPCTL_PIO_PULLUP_EN;

--- a/tests/drivers/gpio/gpio_basic_api/boards/mimxrt685_evk_cm33.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/mimxrt685_evk_cm33.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2020, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test,gpio_basic_api";
+		out-gpios = <&gpio0 5 0>; /* Arduino A0 */
+		in-gpios  = <&gpio0 6 0>; /* Arduino A1 */
+	};
+};


### PR DESCRIPTION
Enable input buffer for both input and output pins

Signed-off-by: Mahesh Mahadevan <mahesh.mahadevan@nxp.com>