### PR TITLE
samples: jesd16: multiple fixes

### DIFF
--- a/samples/drivers/jesd216/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/drivers/jesd216/boards/nrf52840dk_nrf52840.overlay
@@ -13,7 +13,7 @@
 
 &spi2 {
 	status = "okay";
-	cs-gpios = <&gpio0 17 0>, <&gpio1 5 0>;
+	cs-gpios = <&gpio0 17 GPIO_ACTIVE_LOW>, <&gpio1 5 GPIO_ACTIVE_LOW>;
 	mx25r64: mx25r6435f@0 {
 		status = "okay";
 		compatible = "jedec,spi-nor";

--- a/samples/drivers/jesd216/src/main.c
+++ b/samples/drivers/jesd216/src/main.c
@@ -249,10 +249,10 @@ void main(void)
 	}
 
 	printf("%s: SFDP v %u.%u AP %x with %u PH\n", dev->name,
-		hp->rev_major, hp->rev_minor, hp->access, hp->nph);
+		hp->rev_major, hp->rev_minor, hp->access, 1 + hp->nph);
 
 	const struct jesd216_param_header *php = hp->phdr;
-	const struct jesd216_param_header *phpe = php + MIN(decl_nph, hp->nph);
+	const struct jesd216_param_header *phpe = php + MIN(decl_nph, 1 + hp->nph);
 
 	while (php != phpe) {
 		uint16_t id = jesd216_param_id(php);


### PR DESCRIPTION
GPIO CSn active level transitioned from default active-low to devicetree defined since the last time this sample was verified, requiring the flags parameter in devicetree to be updated.

Also correct misinterpretation of the NPH header which was causing the basic flash parameters table to not be displayed when it was the only table provided.