### PR TITLE
Add overlays useful for MCUBoot testing

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
@@ -119,6 +119,18 @@ Zephyr. The ``smp_svr`` sample comes in different flavours.
             -- \
             -DOVERLAY_CONFIG='overlay-serial.conf;overlay-fs.conf'
 
+   .. group-tab:: Shell
+
+      To build the shell sample:
+
+      .. code-block:: console
+
+         west build \
+            -b frdm_k64f \
+            samples/subsys/mgmt/mcumgr/smp_svr \
+            -- \
+            -DOVERLAY_CONFIG='overlay-shell.conf'
+
    .. group-tab:: UDP
 
       The UDP transport for SMP supports both IPv4 and IPv6.
@@ -187,6 +199,13 @@ send a string to the remote target device and have it echo it back:
       .. code-block:: console
 
          sudo mcumgr --conntype ble --connstring ctlr_name=hci0,peer_name='Zephyr' echo hello
+         hello
+
+   .. group-tab:: Shell
+
+      .. code-block:: console
+
+         mcumgr --conntype serial --connstring "/dev/ttyACM0,baud=115200" echo hello
          hello
 
    .. group-tab:: UDP

--- a/samples/subsys/mgmt/mcumgr/smp_svr/overlay-shell.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/overlay-shell.conf
@@ -1,0 +1,2 @@
+# Enable the shell mcumgr transport.
+CONFIG_MCUMGR_SMP_SHELL=y


### PR DESCRIPTION
Add an overlay to the `smp_svr` sample that includes only the shell transport for mcumgr, without bringing in BLE as well. This can be used as an alternative for the serial transport; The shell transport works correctly on `frdm_k64f` which I am using for testing mcumgr. I believe I used to use `overlay-serial.conf` with nRF5x boards (but can't remember for sure), but that overlay does not work with the `frdm_k64f`; not sure if this is a bug and I have not tried to debug the reason.