### PR TITLE
soc: nxp_imx: Set entry to _vector_start in boot header

### DIFF
--- a/soc/arm/nxp_imx/rt/soc.c
+++ b/soc/arm/nxp_imx/rt/soc.c
@@ -9,6 +9,7 @@
 #include <init.h>
 #include <soc.h>
 #include <linker/sections.h>
+#include <linker/linker-defs.h>
 #include <fsl_clock.h>
 #include <arch/cpu.h>
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
@@ -85,7 +86,7 @@ const __imx_boot_data_section BOOT_DATA_T boot_data = {
 
 const __imx_boot_ivt_section ivt image_vector_table = {
 	.hdr = IVT_HEADER,
-	.entry = CONFIG_FLASH_BASE_ADDRESS + CONFIG_ROM_START_OFFSET,
+	.entry = (uint32_t) _vector_start,
 	.reserved1 = IVT_RSVD,
 #ifdef CONFIG_DEVICE_CONFIGURATION_DATA
 	.dcd = (uint32_t) dcd_data,


### PR DESCRIPTION
Commit e80e655b01317458c5a85c38413f2cc4dbce1dc6 introduced linker script
enforcement of Cortex-M vector table alignment. Update the i.MX RT boot
header to account for the possibility that the vector table may not be
placed at the address CONFIG_FLASH_BASE_ADDRESS +
CONFIG_ROM_START_OFFSET anymore.

For example, the RT1060 vector table has 176 entries and therefore must
be aligned to 0x400 bytes. If CONFIG_FLASH_BASE_ADDRESS=0x60000000 and
CONFIG_ROM_START_OFFSET=0x2200, the linker script will place the vector
table at 0x60002400 instead of 0x60002200.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Related to #27380

cc: @armandciejak 