### PR TITLE
samples: derives/peci can't run at EVB board

### DIFF
--- a/samples/drivers/peci/sample.yaml
+++ b/samples/drivers/peci/sample.yaml
@@ -2,6 +2,9 @@ sample:
   name: PECI driver  sample
 tests:
   sample.drivers.peci:
+    # theoretically EVB can be connected to Intel RVP as well,
+    # but HW setup is not documented, hence qualifying as unsupported.
+    platform_exclude: mec15xxevb_assy6853
     tags: drivers
     harness: console
     harness_config:

--- a/tests/kernel/device/testcase.yaml
+++ b/tests/kernel/device/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   tags: device userspace
+  platform_exclude: mec15xxevb_assy6853
   integration_platforms:
     - native_posix
 tests:


### PR DESCRIPTION
Add a tag at sample.yaml to exclude the platform mec15xxevb_assy6853
because of unsupported. Fixes #27576. https://github.com/zephyrproject-rtos/zephyr/issues/27363

Signed-off-by: Ningx Zhao <ningx.zhao@intel.com>