### PR TITLE
arc: Fix for undefined shift behavior (CID 211523)

### DIFF
--- a/arch/arc/core/mpu/arc_mpu_v2_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_v2_internal.h
@@ -29,19 +29,19 @@
 static inline void _region_init(uint32_t index, uint32_t region_addr, uint32_t size,
 				uint32_t region_attr)
 {
-	uint8_t bits = find_msb_set(size) - 1;
-
 	index = index * 2U;
 
-	if (bits < ARC_FEATURE_MPU_ALIGNMENT_BITS) {
-		bits = ARC_FEATURE_MPU_ALIGNMENT_BITS;
-	}
-
-	if ((1 << bits) < size) {
-		bits++;
-	}
-
 	if (size > 0) {
+		uint8_t bits = find_msb_set(size) - 1;
+
+		if (bits < ARC_FEATURE_MPU_ALIGNMENT_BITS) {
+			bits = ARC_FEATURE_MPU_ALIGNMENT_BITS;
+		}
+
+		if ((1 << bits) < size) {
+			bits++;
+		}
+
 		region_attr &= ~(AUX_MPU_RDP_SIZE_MASK);
 		region_attr |= AUX_MPU_RDP_REGION_SIZE(bits);
 		region_addr |= AUX_MPU_RDB_VALID_MASK;


### PR DESCRIPTION
find_msb_set() can return 0, resulting in a undefined shift of 255 bits.
Fixes #27319

Signed-off-by: Ruud Derwig <Ruud.Derwig@synopsys.com>