### PR TITLE
doc: west: troubleshoot no west on PATH on windows

### DIFF
--- a/doc/guides/west/troubleshooting.rst
+++ b/doc/guides/west/troubleshooting.rst
@@ -5,6 +5,48 @@ Troubleshooting West
 
 This page covers common issues with west and how to solve them.
 
+"'west' is not recognized as an internal or external command, operable program or batch file.'
+**********************************************************************************************
+
+On Windows, this means that either west is not installed, or your :envvar:`PATH`
+environment variable does not contain the directory where pip installed
+:file:`west.exe`.
+
+First, make sure you've installed west; see :ref:`west-install`. Then try
+running ``west`` from a new ``cmd.exe`` window. If that still doesn't work,
+keep reading.
+
+You need to find the directory containing :file:`west.exe`, then add it to your
+:envvar:`PATH`. (This :envvar:`PATH` change should have been done for you when
+you installed Python and pip, so ordinarily you should not need to follow these
+steps.)
+
+Run this command in ``cmd.exe``::
+
+  pip3 show west
+
+Then:
+
+#. Look for a line in the output that looks like ``Location:
+   C:\foo\python\python38\lib\site-packages``. The exact location
+   will be different on your computer.
+#. Look for a file named ``west.exe`` in the ``scripts`` directory
+   ``C:\foo\python\python38\scripts``.
+
+   .. important::
+
+      Notice how ``lib\site-packages`` in the ``pip3 show`` output was changed
+      to ``scripts``!
+#. If you see ``west.exe`` in the ``scripts`` directory, add the full path to
+   ``scripts`` to your :envvar:`PATH` using a command like this::
+
+     setx PATH "%PATH%;C:\foo\python\python38\scripts"
+
+   **Do not just copy/paste this command**. The ``scripts`` directory location
+   will be different on your system.
+#. Close your ``cmd.exe`` window and open a new one. You should be able to run
+   ``west``.
+
 "Error: unexpected keyword argument 'requires_workspace'"
 *********************************************************
 


### PR DESCRIPTION
Depending on how people set up their Python, west might not be on
PATH.

I'd like to have a special-purpose step by step guide for how to
handle this in the documentation to save support time when this
happens. I think it's worth special casing since west is the first
runnable program that pip installs onto a new user's system when
they're following the GSG.
