### PR TITLE
shell: Fix uart_rx_handle byte processing when ring buffer full 

### DIFF
--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -41,6 +41,14 @@ static void uart_rx_handle(struct device *dev,
 
 		if (len > 0) {
 			rd_len = uart_fifo_read(dev, data, len);
+
+			/* If there is any new data to be either taken into
+			 * ring buffer or consumed by the SMP, signal the
+			 * shell_thread.
+			 */
+			if (rd_len > 0) {
+				new_data = true;
+			}
 #ifdef CONFIG_MCUMGR_SMP_SHELL
 			/* Divert bytes from shell handling if it is
 			 * part of an mcumgr frame.
@@ -55,15 +63,11 @@ static void uart_rx_handle(struct device *dev,
 			}
 
 			rd_len -= i;
-			new_data = true;
+
 			if (rd_len) {
 				for (uint32_t j = 0; j < rd_len; j++) {
 					data[j] = data[i + j];
 				}
-			}
-#else
-			if (rd_len > 0) {
-				new_data = true;
 			}
 #endif /* CONFIG_MCUMGR_SMP_SHELL */
 			int err = ring_buf_put_finish(sh_uart->rx_ringbuf,
@@ -81,7 +85,7 @@ static void uart_rx_handle(struct device *dev,
 			/* If successful in getting byte from the fifo, try
 			 * feeding it to SMP as a part of mcumgr frame.
 			 */
-			if (rd_len != 0 &&
+			if ((rd_len != 0) &&
 			    smp_shell_rx_byte(&sh_uart->ctrl_blk->smp, dummy)) {
 				new_data = true;
 			}

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -78,10 +78,13 @@ static void uart_rx_handle(struct device *dev,
 
 			rd_len = uart_fifo_read(dev, &dummy, 1);
 #ifdef CONFIG_MCUMGR_SMP_SHELL
-			/* Divert this byte from shell handling if it
-			 * is part of an mcumgr frame.
+			/* If successful in getting byte from the fifo, try
+			 * feeding it to SMP as a part of mcumgr frame.
 			 */
-			smp_shell_rx_byte(&sh_uart->ctrl_blk->smp, dummy);
+			if (rd_len != 0 &&
+			    smp_shell_rx_byte(&sh_uart->ctrl_blk->smp, dummy)) {
+				new_data = true;
+			}
 #endif /* CONFIG_MCUMGR_SMP_SHELL */
 		}
 	} while (rd_len && (rd_len == len));


### PR DESCRIPTION
In case when shell ring buffer gets full the data may still be taken
from the UART fifo, byte by byte, and accepted by the SMP back-end,
if the back-end has been enabled.

Unfortunately the uart_rx_handle failed to check if it has been
successfull in reading a byte from the fifo, before passing it to
the SMP for processing, which could lead to processing random stack data
as a part of an SMP frame.

Additinally, when the SMP would have accepted the byte,
the uart_rx_handle would fail to signal shell_thread, that the SMP has
internally buffered data that could be processed.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>