### PR TITLE
mgmt: smp: Change smp_shell_rx_byte to process data in bulk

### DIFF
--- a/include/mgmt/mcumgr/smp_shell.h
+++ b/include/mgmt/mcumgr/smp_shell.h
@@ -26,17 +26,19 @@ struct smp_shell_data {
 };
 
 /**
- * @brief Attempts to process a received byte as part of an SMP frame.
+ * @brief Attempt to process received bytes as part of an SMP frame.
  *
- * This function should be called with every received byte.
+ * Called to scan buffer from the beginning and consume all bytes that are
+ * part of SMP frame until frame or buffer ends.
  *
  * @param data SMP shell transfer data.
- * @param byte The byte just received.
+ * @param bytes Buffer with bytes to process
+ * @param size Number of bytes to process
  *
- * @return true if the command being received is an mcumgr frame; false if it
- *		is a plain shell command.
+ * @return number of bytes consumed by the SMP
  */
-bool smp_shell_rx_byte(struct smp_shell_data *data, uint8_t byte);
+size_t smp_shell_rx_bytes(struct smp_shell_data *data, const uint8_t *bytes,
+			  size_t size);
 
 /**
  * @brief Processes SMP data and executes command if full frame was received.

--- a/subsys/mgmt/mcumgr/smp_shell.c
+++ b/subsys/mgmt/mcumgr/smp_shell.c
@@ -82,34 +82,41 @@ static int read_mcumgr_byte(struct smp_shell_data *data, uint8_t byte)
 	return SMP_SHELL_MCUMGR_STATE_NONE;
 }
 
-bool smp_shell_rx_byte(struct smp_shell_data *data, uint8_t byte)
+size_t smp_shell_rx_bytes(struct smp_shell_data *data, const uint8_t *bytes,
+			  size_t size)
 {
-	int mcumgr_state;
+	size_t consumed = 0;		/* Number of bytes consumed by SMP */
 
-	mcumgr_state = read_mcumgr_byte(data, byte);
-	if (mcumgr_state == SMP_SHELL_MCUMGR_STATE_NONE) {
-		/* Not an mcumgr command; let the shell process the byte. */
-		return false;
+	/* Process all bytes that are accepted as SMP commands. */
+	while (size != consumed) {
+		uint8_t byte = bytes[consumed];
+		int mcumgr_state = read_mcumgr_byte(data, byte);
+
+		if (mcumgr_state == SMP_SHELL_MCUMGR_STATE_NONE) {
+			break;
+		}
+
+		if (data->cur < sizeof(data->mcumgr_buff) - 1) {
+			data->mcumgr_buff[data->cur] = byte;
+			++data->cur;
+		}
+
+		/* Newline in payload means complete frame */
+		if (mcumgr_state == SMP_SHELL_MCUMGR_STATE_PAYLOAD &&
+		    byte == '\n') {
+			data->mcumgr_buff[data->cur] = '\0';
+			data->cmd_rdy = true;
+			atomic_clear_bit(&data->esc_state, ESC_MCUMGR_PKT_1);
+			atomic_clear_bit(&data->esc_state, ESC_MCUMGR_PKT_2);
+			atomic_clear_bit(&data->esc_state, ESC_MCUMGR_FRAG_1);
+			atomic_clear_bit(&data->esc_state, ESC_MCUMGR_FRAG_2);
+			data->cur = 0U;
+		}
+
+		++consumed;
 	}
 
-	/*
-	 * The received byte is part of an mcumgr command.  Process the byte
-	 * and return true to indicate that shell should ignore it.
-	 */
-	if (data->cur < sizeof(data->mcumgr_buff) - 1) {
-		data->mcumgr_buff[data->cur++] = byte;
-	}
-	if (mcumgr_state == SMP_SHELL_MCUMGR_STATE_PAYLOAD && byte == '\n') {
-		data->mcumgr_buff[data->cur] = '\0';
-		data->cmd_rdy = true;
-		atomic_clear_bit(&data->esc_state, ESC_MCUMGR_PKT_1);
-		atomic_clear_bit(&data->esc_state, ESC_MCUMGR_PKT_2);
-		atomic_clear_bit(&data->esc_state, ESC_MCUMGR_FRAG_1);
-		atomic_clear_bit(&data->esc_state, ESC_MCUMGR_FRAG_2);
-		data->cur = 0U;
-	}
-
-	return true;
+	return consumed;
 }
 
 void smp_shell_process(struct smp_shell_data *data)

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -34,6 +34,9 @@ static void uart_rx_handle(struct device *dev,
 	uint32_t len;
 	uint32_t rd_len;
 	bool new_data = false;
+#ifdef CONFIG_MCUMGR_SMP_SHELL
+	struct smp_shell_data *const smp = &sh_uart->ctrl_blk->smp;
+#endif
 
 	do {
 		len = ring_buf_put_claim(sh_uart->rx_ringbuf, &data,
@@ -53,14 +56,7 @@ static void uart_rx_handle(struct device *dev,
 			/* Divert bytes from shell handling if it is
 			 * part of an mcumgr frame.
 			 */
-			size_t i;
-
-			for (i = 0; i < rd_len; i++) {
-				if (!smp_shell_rx_byte(&sh_uart->ctrl_blk->smp,
-						       data[i])) {
-					break;
-				}
-			}
+			size_t i = smp_shell_rx_bytes(smp, data, rd_len);
 
 			rd_len -= i;
 
@@ -86,7 +82,7 @@ static void uart_rx_handle(struct device *dev,
 			 * feeding it to SMP as a part of mcumgr frame.
 			 */
 			if ((rd_len != 0) &&
-			    smp_shell_rx_byte(&sh_uart->ctrl_blk->smp, dummy)) {
+			    (smp_shell_rx_bytes(smp, &dummy, 1) == 1)) {
 				new_data = true;
 			}
 #endif /* CONFIG_MCUMGR_SMP_SHELL */


### PR DESCRIPTION
The smp_shell_rx_byte has been renamed to smp_shell_rx_bytes and now
accepts data buffer pointer and its size as parameters. Return value
has been changed to size_t and represents number of bytes processed from
the given buffer.

The change has been done to more efficiently serve most common scenario
when the function is called in loop to process buffer, byte by byte.
Previously such operation required passing each byte separately,
with the change the function will work directly on source buffer reducing
number of calls and byte copy operations.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>