### PR TITLE
samples: flash_shell: Fix overwriting return value

### DIFF
--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -372,11 +372,11 @@ free_buffers:
 	k_free(before_data);
 	k_free(after_data);
 
-	ret = flash_write_protection_set(flash_device, true);
-	if (ret) {
+	int ret1 = flash_write_protection_set(flash_device, true);
+	if (ret1) {
 		PR_ERROR(shell, "Failed to enable flash protection (err: %d)."
-				"\n", ret);
-		return ret;
+				"\n", ret1);
+		return ret1;
 	}
 
 	return ret;


### PR DESCRIPTION
Value of ret has been overwritten by flash_write_protection_set
before it could be returned from do_write_unaligned, which could
lead to reporting success when error code should have been returned.

Fixes zephyrproject-rtos#27641, Coverity-CID: 212142
Fixes zephyrproject-rtos#27642, Coverity-CID: 212143

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>