### PR TITLE
tests: lib: fdtable: Fix missing check on returned fd

### DIFF
--- a/tests/lib/fdtable/src/main.c
+++ b/tests/lib/fdtable/src/main.c
@@ -158,6 +158,7 @@ void test_z_fd_multiple_access(void)
 	void *obj = (void *)vtable;
 
 	shared_fd = z_reserve_fd();
+	zassert_true(shared_fd >= 0, "fd < 0");
 
 	z_finalize_fd(shared_fd, obj, vtable);
 


### PR DESCRIPTION
Missing check on returned descriptor.

Fixes #27644
Coverity-CID: 212141

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>