### PR TITLE
drivers: display: Added Sharp memory display drivers.

### DIFF
--- a/boards/shields/ls0xx_generic/Kconfig.defconfig
+++ b/boards/shields/ls0xx_generic/Kconfig.defconfig
@@ -1,0 +1,48 @@
+# Copyright (c) 2020 Rohit Gujarathi
+# SPDX-License-Identifier: Apache-2.0
+
+if SHIELD_LS013B7DH03
+
+if DISPLAY
+
+config SPI
+	default y
+
+config LS0XX
+	default y
+
+if LVGL
+
+config LVGL_DISPLAY_DEV_NAME
+	string "Display device name"
+	default "LS0XX"
+
+config LVGL_HOR_RES
+	int "Horizantal resolution"
+	default 128
+
+config LVGL_VER_RES
+	int "Vertical resolution"
+	default 128
+
+config LVGL_VDB_SIZE
+	int "Display buffer percentage"
+	default 16
+
+config LVGL_DPI
+	int "Dots per inch"
+	default 150
+
+config LVGL_BITS_PER_PIXEL
+	int "Number of bits per pixel"
+	default 1
+
+choice LVGL_COLOR_DEPTH
+	default LVGL_COLOR_DEPTH_1
+endchoice
+
+endif # LVGL
+
+endif # DISPLAY
+
+endif # SHIELD_LS013B7DH03

--- a/boards/shields/ls0xx_generic/Kconfig.shield
+++ b/boards/shields/ls0xx_generic/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2020 Rohit Gujarathi
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_LS013B7DH03
+	def_bool $(shields_list_contains,ls013b7dh03)

--- a/boards/shields/ls0xx_generic/doc/index.rst
+++ b/boards/shields/ls0xx_generic/doc/index.rst
@@ -1,0 +1,116 @@
+.. _ls0xx_generic_shield:
+
+Sharp memory display generic shield
+#########################################
+
+Overview
+********
+
+This is a generic shield for Sharp memory pixel LCD. It supports
+displays of LS0XX type. These displays have an SPI interface and
+few other pins. Note that the SCS is active high for this display.
+The DISP pin controls whether to display memory
+contents or show all white pixels, this can be connected
+directly to VDD, to always display memory contents. There is
+an EXTCOMIN pin which can be configured to control the VCOM.
+
+Sharp memory displays require toggling the VCOM signal periodically
+to prevent a DC bias ocurring in the panel. The DC bias can damage
+the LCD and reduce the life. This signal must be supplied
+from either serial input (sw) or an external signal on the
+EXTCOMIN pin. The driver can do this internally
+`CONFIG_LS0XX_VCOM_DRIVER` =y (default) else user can handle it in
+application code `CONFIG_LS0XX_VCOM_DRIVER` =n.
+
+CONFIG_LS0XX_VCOM_DRIVER=y
+  Driver will handle VCOM toggling. User can control method of toggling
+  using `CONFIG_LS0XX_VCOM_EXTERNAL`.
+
+CONFIG_LS0XX_VCOM_EXTERNAL=n
+  This is the default option.
+  VCOM is toggled through serial input by software.
+  EXTMODE pin is connected to VSS
+  Important: User has to make sure `display_write` is called periodically
+  for toggling VCOM. If there is no data to update then buf can
+  be set to NULL then only VCOM will be toggled.
+
+CONFIG_LS0XX_VCOM_EXTERNAL=y
+  VCOM is toggled using external signal EXTCOMIN.
+  EXTMODE pin is connected to VDD
+  Important: Driver will start a thread which will
+  toggle the EXTCOMIN pin every 500ms. There is no
+  dependency on user.
+
+Pins Assignment of the Generic Sharp memory Display Shield
+==========================================================
+
++---------------+---------------------------------------------------------+
+| Pin           | Function                                                |
++===============+=========================================================+
+| SCS           | Serial Slave Select                                     |
++---------------+---------------------------------------------------------+
+| SI            | Serial Data Input                                       |
++---------------+---------------------------------------------------------+
+| SCLK          | Serial Clock Input                                      |
++---------------+---------------------------------------------------------+
+| EXTCOMIN      | VCOM Inversion Polarity Input (VCOM can be controlled   |
+|               | through SW)                                             |
++---------------+---------------------------------------------------------+
+| DISP          | Display ON/OFF switching signal (Can be connected       |
+|               | directly to VDD)                                        |
++---------------+---------------------------------------------------------+
+| EXTMODE       | COM Inversion Selection                                 |
++---------------+---------------------------------------------------------+
+
+
+Current supported displays
+==========================
+
+Following displays are supported but shield only exists
+for LS013B7DH03. Other shields can be added by using the LS013B7DH03 as
+a reference and changing the width, height, etc configurations.
+
+LS012B7DD01
+LS012B7DD06
+LS013B7DH03
+LS013B7DH05
+LS013B7DH06
+LS027B7DH01A
+LS032B7DD02
+LS044Q7DH01
+
++----------------------+------------------------------+
+| Display              | Shield Designation           |
+|                      |                              |
++======================+==============================+
+| LS013B7DH03          | ls013b7dh03                  |
++----------------------+------------------------------+
+
+Requirements
+************
+
+This shield can only be used with a board that provides a configuration
+for Arduino connectors and defines node aliases for SPI and GPIO interfaces
+(see :ref:`shields` for more details).
+
+Programming
+***********
+
+Set ``-DSHIELD=ls013b7dh03`` when you invoke ``west build``. For example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/gui/lvgl
+   :board: nrf52840dk_nrf52840
+   :shield: ls013b7dh03
+   :goals: build
+
+References
+**********
+
+.. target-notes::
+
+.. _LS013B7DH03 Datasheet:
+   https://www.mouser.com/datasheet/2/365/LS013B7DH03%20SPEC_SMA-224806.pdf
+
+.. _Sharp memory display app note:
+   https://www.sharpsde.com/fileadmin/products/Displays/2016_SDE_App_Note_for_Memory_LCD_programming_V1.3.pdf

--- a/boards/shields/ls0xx_generic/ls013b7dh03.overlay
+++ b/boards/shields/ls0xx_generic/ls013b7dh03.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2020 Rohit Gujarathi
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&arduino_spi {
+	status = "okay";
+
+	ls0xx@0 {
+		compatible = "sharp,ls0xx";
+		label = "LS0XX";
+		spi-max-frequency = <2000000>;
+		reg = <0>;
+		width = <128>;
+		height = <128>;
+		scs-gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
+		extcomin-gpios = <&gpio0 22 GPIO_ACTIVE_HIGH>; /* optional */
+		disp-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>; /* optional */
+	};
+};

--- a/drivers/display/CMakeLists.txt
+++ b/drivers/display/CMakeLists.txt
@@ -10,6 +10,7 @@ zephyr_sources_ifdef(CONFIG_FRAMEBUF_DISPLAY	display_framebuf.c)
 zephyr_sources_ifdef(CONFIG_ILI9340		display_ili9340.c)
 zephyr_sources_ifdef(CONFIG_ST7789V		display_st7789v.c)
 zephyr_sources_ifdef(CONFIG_GD7965		gd7965.c)
+zephyr_sources_ifdef(CONFIG_LS0XX		ls0xx.c)
 
 zephyr_sources_ifdef(CONFIG_MICROBIT_DISPLAY
 	mb_display.c

--- a/drivers/display/Kconfig
+++ b/drivers/display/Kconfig
@@ -24,6 +24,7 @@ source "drivers/display/Kconfig.ssd16xx"
 source "drivers/display/Kconfig.st7789v"
 source "drivers/display/Kconfig.gd7965"
 source "drivers/display/Kconfig.dummy"
+source "drivers/display/Kconfig.ls0xx"
 
 config FRAMEBUF_DISPLAY
 	# Hidden, selected by client drivers.

--- a/drivers/display/Kconfig.ls0xx
+++ b/drivers/display/Kconfig.ls0xx
@@ -1,0 +1,30 @@
+# Sharp memory display controller configuration options
+
+# Copyright (c) 2020 Rohit Gujarathi
+# SPDX-License-Identifier: Apache-2.0
+
+config LS0XX
+	bool "LS0XX memory display controller driver"
+	depends on SPI
+	help
+	  Enable driver for sharp memory display series LS0XXX7DXXX
+
+config LS0XX_VCOM_DRIVER
+	bool "VCOM toggling is handled by driver"
+	depends on LS0XX
+	default y if LS0XX
+	help
+	  VCOM will be toggled by driver based on LS0XX_EXTMODE_SERIAL, else
+	  user has to handle toggling. If LS0XX_VCOM_DRIVER=n and
+	  using serial mode then user has to handle contention between
+	  SPI transfers for write and VCOM toggle cmd.
+
+config LS0XX_VCOM_EXTERNAL
+	bool "Use EXTCOMIN pin for toggling VCOM in sharp memory LCD"
+	depends on LS0XX && LS0XX_VCOM_DRIVER
+	default n if LS0XX
+	help
+	  If 'n', control VCOM from software by toggling the M1 bit.
+	  Connect EXTMODE to VSS. If set to 'y' then VCOM is
+	  controlled using EXTCOMIN pin which is to be defined
+	  in the devicetree. Connect EXTMODE to VDD.

--- a/drivers/display/ls0xx.c
+++ b/drivers/display/ls0xx.c
@@ -1,0 +1,501 @@
+/*
+ * Copyright (c) 2020 Rohit Gujarathi
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT   sharp_ls0xx
+
+#define LOG_LEVEL CONFIG_DISPLAY_LOG_LEVEL
+#include <logging/log.h>
+LOG_MODULE_REGISTER(ls0xx);
+
+#include <string.h>
+#include <device.h>
+#include <drivers/display.h>
+#include <init.h>
+#include <drivers/gpio.h>
+#include <drivers/spi.h>
+#include <sys/byteorder.h>
+
+/* Supports LS012B7DD01, LS012B7DD06, LS013B7DH03, LS013B7DH05
+ * LS013B7DH06, LS027B7DH01A, LS032B7DD02, LS044Q7DH01
+ */
+
+/* Note:
+ * -> high/1 means white, low/0 means black
+ * -> Display expects LSB first
+ * -> If devicetree contains DISP pin then it will be set to high
+ *      during initialization.
+ * -> Sharp memory displays require toggling the VCOM signal periodically
+ *      to prevent a DC bias ocurring in the panel. The DC bias can damage
+ *      the LCD and reduce the life. This signal must be supplied
+ *      from either serial input (sw) or an external signal on the
+ *      EXTCOMIN pin. The driver can do this internally
+ *      (CONFIG_LS0XX_VCOM_DRIVER=y) else user can handle it in
+ *      application code (CONFIG_LS0XX_VCOM_DRIVER=n).
+ *      Source:
+ * https://www.sharpsde.com/fileadmin/products/Displays/2016_SDE_App_Note_for_Memory_LCD_programming_V1.3.pdf
+ * -> If CONFIG_LS0XX_VCOM_DRIVER=y then driver can partially or completely
+ *      handle VCOM toggling. User can control method of toggling
+ *      using CONFIG_LS0XX_VCOM_EXTERNAL.
+ * -> VCOM is toggled through serial input by software by default
+ *      CONFIG_LS0XX_VCOM_EXTERNAL=n
+ *      EXTMODE pin is connected to VSS
+ *      Important: User has to make sure .write is called periodically
+ *      for toggling VCOM. If there is no data to update then buf can
+ *      be set to NULL then only VCOM will be toggled.
+ * -> To control VCOM using external signal EXTCOMIN, set
+ *      CONFIG_LS0XX_VCOM_EXTERNAL=y
+ *      EXTMODE pin is connected to VDD
+ *      Important: Driver will start a thread which will
+ *      toggle the EXTCOMIN pin every 500ms. There is no
+ *      dependency on user.
+ * -> line_buf format for each row.
+ * +-------------------+-------------------+----------------+
+ * | line num (8 bits) | data (WIDTH bits) | dummy (8 bits) |
+ * +-------------------+-------------------+----------------+
+ */
+
+#define LS0XX_SCS_PIN             DT_INST_GPIO_PIN(0, scs_gpios)
+#define LS0XX_SCS_CNTRL           DT_INST_GPIO_LABEL(0, scs_gpios)
+
+#if DT_INST_NODE_HAS_PROP(0, disp_gpios)
+	#define LS0XX_DISP_PIN        DT_INST_GPIO_PIN(0, disp_gpios)
+	#define LS0XX_DISP_CNTRL      DT_INST_GPIO_LABEL(0, disp_gpios)
+#endif
+
+#if defined(CONFIG_LS0XX_VCOM_DRIVER)
+	#if defined(CONFIG_LS0XX_VCOM_EXTERNAL) && DT_INST_NODE_HAS_PROP(0, extcomin_gpios)
+		#define LS0XX_EXTCOMIN_PIN    DT_INST_GPIO_PIN(0, extcomin_gpios)
+		#define LS0XX_EXTCOMIN_CNTRL  DT_INST_GPIO_LABEL(0, extcomin_gpios)
+	#endif
+#endif
+
+#define LS0XX_PANEL_WIDTH         DT_INST_PROP(0, width)
+#define LS0XX_PANEL_HEIGHT        DT_INST_PROP(0, height)
+
+#define LS0XX_PIXELS_PER_BYTE     8U
+/* Adding 2 for the line number and dummy byte */
+#define LS0XX_BYTES_PER_LINE      ((LS0XX_PANEL_WIDTH/LS0XX_PIXELS_PER_BYTE)+2)
+
+#define LS0XX_BIT_WRITECMD        0x01
+#define LS0XX_BIT_VCOM            0x02
+#define LS0XX_BIT_CLEAR           0x04
+
+static uint8_t line_buf[LS0XX_BYTES_PER_LINE];
+
+static struct spi_buf tx_buf;
+static struct spi_buf_set buf_set = {.buffers = &tx_buf, .count = 1};
+
+struct ls0xx_data {
+	struct device *scs;
+#if defined(LS0XX_DISP_CNTRL)
+	struct device *disp;
+#endif
+#if defined(LS0XX_EXTCOMIN_CNTRL)
+	struct device *extcomin;
+#endif
+	struct device *spi_dev;
+	struct spi_config spi_config;
+};
+static uint8_t extcomin_bit;
+
+#if defined(CONFIG_LS0XX_VCOM_DRIVER)
+
+#if defined(CONFIG_LS0XX_VCOM_EXTERNAL)
+#if !defined(LS0XX_EXTCOMIN_CNTRL)
+#error "CONFIG_LS0XX_VCOM_EXTERNAL is 'y' but \
+extcomin-gpios is not present in devicetree"
+#endif /* LS0XX_EXTCOMIN_CNTRL */
+#define LS0XX_EXTCOMIN_BIT 0x00
+#else
+#define LS0XX_EXTCOMIN_BIT extcomin_bit
+#endif /* CONFIG_LS0XX_VCOM_EXTERNAL */
+
+#if defined(CONFIG_LS0XX_VCOM_EXTERNAL)
+/**
+ * @brief Toggle VCOM to avoid DC bias
+ *
+ * @details This API will toggle either the EXTCOMIN pin
+ *          or the M1 bit in serial comm to toggle VCOM
+ *
+ * @param driver Pointer to the display driver
+ */
+static void ls0xx_vcom_toggle(void *a, void *b, void *c)
+{
+	struct ls0xx_data *driver = (struct ls0xx_data *)a;
+
+	while (1) {
+		gpio_pin_toggle(driver->extcomin, LS0XX_EXTCOMIN_PIN);
+		k_msleep(10);
+		gpio_pin_toggle(driver->extcomin, LS0XX_EXTCOMIN_PIN);
+		k_msleep(500);
+	}
+}
+
+/* Driver will handle VCOM toggling */
+K_THREAD_STACK_DEFINE(vcom_toggle_stack, 256);
+struct k_thread vcom_toggle_thread;
+#endif /* CONFIG_LS0XX_VCOM_EXTERNAL */
+
+#else
+#define LS0XX_EXTCOMIN_BIT 0x00
+#endif /* CONFIG_LS0XX_VCOM_DRIVER */
+
+/**
+ * @brief Display memory contents of the display
+ *
+ * @details Display memory contents, ie actual image data
+ *          During initialization DISP pin will be set high
+ *
+ * @param dev Pointer to the display device
+ */
+static int ls0xx_blanking_off(const struct device *dev)
+{
+#if defined(LS0XX_DISP_CNTRL)
+	struct ls0xx_data *driver = dev->data;
+
+	return gpio_pin_set(driver->disp, LS0XX_DISP_PIN, 1);
+#else
+	LOG_ERR("Unsupported");
+	return -ENOTSUP;
+#endif
+}
+
+/**
+ * @brief Display becomes completely white
+ *
+ * @details Displays complete white while but the
+ *          memory contents are retained
+ *
+ * @param dev Pointer to the display device
+ */
+static int ls0xx_blanking_on(const struct device *dev)
+{
+#if defined(LS0XX_DISP_CNTRL)
+	struct ls0xx_data *driver = dev->data;
+
+	return gpio_pin_set(driver->disp, LS0XX_DISP_PIN, 0);
+#else
+	LOG_ERR("Unsupported");
+	return -ENOTSUP;
+#endif
+}
+
+/**
+ * @brief Clear the internal memory of the display
+ *
+ * @details Clear the display memory and the frame_buf
+ *          setting it to all white
+ *
+ * @param dev Pointer to the display device
+ */
+static int ls0xx_clear(const struct device *dev)
+{
+	struct ls0xx_data *driver = dev->data;
+	int err;
+	uint8_t clear_cmd[2] = {LS0XX_BIT_CLEAR | LS0XX_EXTCOMIN_BIT, 0};
+
+	tx_buf.len = sizeof(uint16_t);
+	tx_buf.buf = &clear_cmd;
+
+	gpio_pin_set(driver->scs, LS0XX_SCS_PIN, 1);
+	err = spi_write(driver->spi_dev, &driver->spi_config, &buf_set);
+	gpio_pin_set(driver->scs, LS0XX_SCS_PIN, 0);
+
+	return err;
+}
+
+/**
+ * @brief Send required lines to the LCD
+ *
+ * @details Update the display by sending num_lines
+ *          starting from start_line.
+ *
+ * @param dev Pointer to the display device
+ * @param start_line Starting line number, starts with 1
+ *                   corresponds to Y co-ordinate + 1
+ * @param num_lines Number of lines ie height to update
+ * @param buf  Buffer containing data to write
+ */
+#if defined(__GNUC__)
+	__attribute__((optimize("O3")))
+#endif
+static int ls0xx_update_display(const struct device *dev,
+								uint16_t start_line,
+								uint16_t num_lines,
+								const uint8_t *buf)
+{
+	struct ls0xx_data *driver = dev->data;
+
+	int err;
+	uint8_t write_cmd;
+	uint16_t currentline;
+
+	LOG_DBG("Lines %d to %d", start_line, start_line+num_lines-1);
+
+	gpio_pin_set(driver->scs, LS0XX_SCS_PIN, 1);
+
+	write_cmd = LS0XX_BIT_WRITECMD | LS0XX_EXTCOMIN_BIT;
+	extcomin_bit = LS0XX_EXTCOMIN_BIT ? 0x00 : LS0XX_BIT_VCOM;
+	tx_buf.len = sizeof(uint8_t);
+	tx_buf.buf =  &write_cmd;
+	err = spi_write(driver->spi_dev, &driver->spi_config, &buf_set);
+
+	if (buf != NULL) {
+		/* Send each line to the screen including
+		 * the line number and dummy bits
+		 */
+		tx_buf.len = sizeof(uint8_t)*LS0XX_BYTES_PER_LINE;
+		tx_buf.buf = &line_buf[0];
+		for (currentline = start_line; currentline <= start_line+num_lines-1; currentline++) {
+			line_buf[0] = currentline;
+			memcpy(&line_buf[1], buf, LS0XX_PANEL_WIDTH/LS0XX_PIXELS_PER_BYTE);
+			buf += LS0XX_PANEL_WIDTH/LS0XX_PIXELS_PER_BYTE;
+			err |= spi_write(driver->spi_dev, &driver->spi_config, &buf_set);
+		}
+
+		/* Send another trailing 8 bits for the last line
+		 * These can be any bits, it does not matter
+		 * just reusing the write_cmd buffer
+		 */
+		tx_buf.len = sizeof(uint8_t);
+		tx_buf.buf =  &write_cmd;
+		err |= spi_write(driver->spi_dev, &driver->spi_config, &buf_set);
+	}
+	gpio_pin_set(driver->scs, LS0XX_SCS_PIN, 0);
+
+	return err;
+}
+
+/**
+ * @brief Write to the display at given co-ordinates
+ *
+ * @details Write buffer to the display.
+ *          Buffer width should be a multiple of 8
+ *
+ *          If CONFIG_LS0XX_VCOM_DRIVER=y and CONFIG_LS0XX_VCOM_EXTERNAL=n
+ *          and buffer is set to NULL, or height/width is 0 then
+ *          only VCOM will be toggled
+ *
+ * @param dev  Pointer to the display device
+ * @param x    X co-ordinate
+ * @param y    Y co-ordinate
+ * @param desc display_buffer_descriptor struct
+ * @param buf  Buffer containing data to write
+ */
+static int ls0xx_write(const struct device *dev, const uint16_t x,
+					   const uint16_t y,
+					   const struct display_buffer_descriptor *desc,
+					   const void *buf)
+{
+
+	LOG_DBG("X: %d, Y: %d, W: %d, H: %d", x, y, desc->width, desc->height);
+
+	if (buf == NULL) {
+#if defined(CONFIG_LS0XX_VCOM_DRIVER) && defined(CONFIG_LS0XX_VCOM_EXTERNAL)
+		LOG_ERR("Display buffer is not available");
+		return -EINVAL;
+#endif
+	}
+
+	if (desc->width != LS0XX_PANEL_WIDTH) {
+		LOG_ERR("Width not a multiple of %d", LS0XX_PANEL_WIDTH);
+		return -EINVAL;
+	}
+
+	if (desc->pitch != desc->width) {
+		LOG_ERR("Unsupported mode");
+		return -ENOTSUP;
+	}
+
+	if ((y + desc->height) > LS0XX_PANEL_HEIGHT) {
+		LOG_ERR("Buffer out of bounds (height)");
+		return -EINVAL;
+	}
+
+	if ((x + desc->width) > LS0XX_PANEL_WIDTH) {
+		LOG_ERR("Buffer out of bounds (width)");
+		return -EINVAL;
+	}
+
+	/* Adding 1 since displays line numbering on the display
+	 * start with 1
+	 */
+	return ls0xx_update_display(dev, y+1, desc->height, buf);
+}
+
+static int ls0xx_read(const struct device *dev, const uint16_t x,
+					  const uint16_t y,
+					  const struct display_buffer_descriptor *desc,
+					  void *buf)
+{
+	LOG_ERR("not supported");
+	return -ENOTSUP;
+}
+
+static void *ls0xx_get_framebuffer(const struct device *dev)
+{
+	LOG_ERR("not supported");
+	return NULL;
+}
+
+static int ls0xx_set_brightness(const struct device *dev,
+								const uint8_t brightness)
+{
+	LOG_WRN("not supported");
+	return -ENOTSUP;
+}
+
+static int ls0xx_set_contrast(const struct device *dev, uint8_t contrast)
+{
+	LOG_WRN("not supported");
+	return -ENOTSUP;
+}
+
+/**
+ * @brief Get display capabilities
+ *
+ * @details Get display capabilities
+ *
+ * @param dev  Pointer to the display device
+ * @param caps Pointer to display_capabilities struct
+ *             this struct will be populated with the
+ *             capabilities
+ */
+static void ls0xx_get_capabilities(const struct device *dev,
+								   struct display_capabilities *caps)
+{
+	memset(caps, 0, sizeof(struct display_capabilities));
+	caps->x_resolution = LS0XX_PANEL_WIDTH;
+	caps->y_resolution = LS0XX_PANEL_HEIGHT;
+	caps->supported_pixel_formats = PIXEL_FORMAT_MONO01;
+	caps->current_pixel_format = PIXEL_FORMAT_MONO01;
+	caps->screen_info = SCREEN_INFO_MONO_MSB_FIRST
+						| SCREEN_INFO_ALIGNMENT_RESTRICTED;
+	/* Minimum update is of a line */
+	caps->x_alignment = LS0XX_PANEL_WIDTH-1;
+	caps->y_alignment = 0;
+}
+
+static int ls0xx_set_orientation(const struct device *dev,
+								 const enum display_orientation orientation)
+{
+	LOG_ERR("Unsupported");
+	return -ENOTSUP;
+}
+
+/**
+ * @brief Set pixel format
+ *
+ * @details Set displays pixel format.
+ *          This display is black on white
+ *
+ * @param dev Pointer to the display device
+ * @param pf  Pixel format to set display to
+ *            Only PIXEL_FORMAT_MONO01 is
+ *            supported
+ */
+static int ls0xx_set_pixel_format(const struct device *dev,
+								  const enum display_pixel_format pf)
+{
+	if (pf == PIXEL_FORMAT_MONO01) {
+		return 0;
+	}
+
+	LOG_ERR("not supported");
+	return -ENOTSUP;
+}
+
+/**
+ * @brief Initialize the display
+ *
+ * @details Initialize the display
+ *          Configure the SPI interface options
+ *          Configure GPIO pins for SCS
+ *          Configure DISP and EXTCOMIN pins if defined
+ *          Set DISP pin to OUTPUT_HIGH if defined
+ *          Clear the display and framebuffer
+ *          Write all white pixels to the display
+ *          else it shows random data
+ *
+ * @param dev Pointer to the display device
+ */
+static int ls0xx_init(struct device *dev)
+{
+
+	struct ls0xx_data *driver = dev->data;
+
+	driver->spi_dev = device_get_binding(DT_INST_BUS_LABEL(0));
+	if (driver->spi_dev == NULL) {
+		LOG_ERR("Could not get SPI device for LS0XX");
+		return -EIO;
+	}
+
+	driver->spi_config.frequency = DT_INST_PROP(0, spi_max_frequency);
+	driver->spi_config.operation = SPI_OP_MODE_MASTER | SPI_WORD_SET(8);
+	driver->spi_config.slave = 0;
+	driver->spi_config.operation |= SPI_TRANSFER_LSB;
+	driver->spi_config.cs = NULL;
+
+	driver->scs = device_get_binding(LS0XX_SCS_CNTRL);
+	if (driver->scs == NULL) {
+		LOG_ERR("Could not get SCS pin port for LS0XX");
+		return -EIO;
+	}
+
+	gpio_pin_configure(driver->scs, LS0XX_SCS_PIN, GPIO_OUTPUT_INACTIVE);
+
+#if defined(LS0XX_DISP_CNTRL)
+	driver->disp = device_get_binding(LS0XX_DISP_CNTRL);
+	if (driver->disp == NULL) {
+		LOG_ERR("Could not get DISP pin port for LS0XX");
+		return -EIO;
+	}
+	LOG_INF("Configuring DISP pin to OUTPUT_HIGH");
+	gpio_pin_configure(driver->disp, LS0XX_DISP_PIN, GPIO_OUTPUT_HIGH);
+#endif
+
+#if defined(CONFIG_LS0XX_VCOM_DRIVER) && defined(CONFIG_LS0XX_VCOM_EXTERNAL)
+	driver->extcomin = device_get_binding(LS0XX_EXTCOMIN_CNTRL);
+	if (driver->extcomin == NULL) {
+		LOG_ERR("Could not get EXTCOMIN pin port for LS0XX");
+		return -EIO;
+	}
+	LOG_INF("Configuring EXTCOMIN pin");
+	gpio_pin_configure(driver->extcomin, LS0XX_EXTCOMIN_PIN,
+					   GPIO_OUTPUT_LOW);
+
+	/* Start thread for toggling VCOM */
+	k_tid_t vcom_toggle_tid = k_thread_create(&vcom_toggle_thread,
+							  vcom_toggle_stack,
+							  K_THREAD_STACK_SIZEOF(vcom_toggle_stack),
+							  ls0xx_vcom_toggle,
+							  driver, NULL, NULL,
+							  3, 0, K_NO_WAIT);
+	k_thread_name_set(vcom_toggle_tid, "ls0xx_vcom");
+#endif /* CONFIG_LS0XX_VCOM_DRIVER && CONFIG_LS0XX_VCOM_EXTERNAL*/
+
+	return ls0xx_clear(dev);
+}
+
+static struct ls0xx_data ls0xx_driver;
+
+static struct display_driver_api ls0xx_driver_api = {
+	.blanking_on = ls0xx_blanking_on,
+	.blanking_off = ls0xx_blanking_off,
+	.write = ls0xx_write,
+	.read = ls0xx_read,
+	.get_framebuffer = ls0xx_get_framebuffer,
+	.set_brightness = ls0xx_set_brightness,
+	.set_contrast = ls0xx_set_contrast,
+	.get_capabilities = ls0xx_get_capabilities,
+	.set_pixel_format = ls0xx_set_pixel_format,
+	.set_orientation = ls0xx_set_orientation,
+};
+
+DEVICE_AND_API_INIT(ls0xx, DT_INST_LABEL(0), ls0xx_init,
+					&ls0xx_driver, NULL,
+					POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
+					&ls0xx_driver_api);

--- a/dts/bindings/display/sharp,ls0xx.yaml
+++ b/dts/bindings/display/sharp,ls0xx.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2020, Rohit Gujarathi
+# SPDX-License-Identifier: Apache-2.0
+
+description: Sharp memory display controller
+
+compatible: "sharp,ls0xx"
+
+include: spi-device.yaml
+
+properties:
+    height:
+      type: int
+      required: true
+      description: Height in pixel of the panel driven by the controller
+
+    width:
+      type: int
+      required: true
+      description: Width in pixel of the panel driven by the controller
+
+    scs-gpios:
+      type: phandle-array
+      required: true
+      description: SCS pin
+
+        The SCS pin is the SPI chip select pin of sharp memory display.
+        It is active high.
+
+    extcomin-gpios:
+      type: phandle-array
+      required: false
+      description: EXTCOMIN pin
+
+        The EXTCOMIN pin is where a square pulse should be given
+
+    disp-gpios:
+      type: phandle-array
+      required: false
+      description: DISPLAY pin
+
+        The DISPLAY pin controls if the LCD displays memory contents or
+        white screen

--- a/include/drivers/display.h
+++ b/include/drivers/display.h
@@ -63,6 +63,10 @@ enum display_screen_info {
 	 * Screen has two alternating ram buffers
 	 */
 	SCREEN_INFO_DOUBLE_BUFFER	= BIT(3),
+	/**
+	 * Screen has minimum x or y pixel alignment contraint.
+	 */
+	SCREEN_INFO_ALIGNMENT_RESTRICTED	= BIT(4),
 };
 
 /**
@@ -99,6 +103,15 @@ enum display_orientation {
  * @var enum display_orientation display_capabilities::current_orientation
  * Current display orientation
  *
+ * @var uint16_t display_capabilities::x_alignment
+ * Minimum update contraint in the x-direction-1.
+ * if 8 pixels then value should be 7
+ * 0 means no contraint
+ *
+ * @var uint16_t display_capabilities::y_alignment
+ * Minimum update contraint in the y-direction-1.
+ * if 8 pixels then value should be 7
+ * 0 mean no contraint
  */
 struct display_capabilities {
 	uint16_t x_resolution;
@@ -107,6 +120,8 @@ struct display_capabilities {
 	uint32_t screen_info;
 	enum display_pixel_format current_pixel_format;
 	enum display_orientation current_orientation;
+	uint16_t x_alignment;
+	uint16_t y_alignment;
 };
 
 /**

--- a/lib/gui/lvgl/lvgl_display_mono.c
+++ b/lib/gui/lvgl/lvgl_display_mono.c
@@ -85,11 +85,23 @@ void lvgl_rounder_cb_mono(struct _disp_drv_t *disp_drv,
 
 	display_get_capabilities(display_dev, &cap);
 
-	if (cap.screen_info & SCREEN_INFO_MONO_VTILED) {
-		area->y1 &= ~0x7;
-		area->y2 |= 0x7;
+	if (cap.screen_info & SCREEN_INFO_ALIGNMENT_RESTRICTED) {
+		if (area->x1 != 0) {
+			area->x1 &= ~cap.x_alignment;
+			area->x2 |= cap.x_alignment;
+		}
+
+		if (area->y1 != 0) {
+			area->y1 &= ~cap.y_alignment;
+			area->y2 |= cap.y_alignment;
+		}
 	} else {
-		area->x1 &= ~0x7;
-		area->x2 |= 0x7;
+		if (cap.screen_info & SCREEN_INFO_MONO_VTILED) {
+			area->y1 &= ~0x7;
+			area->y2 |= 0x7;
+		} else {
+			area->x1 &= ~0x7;
+			area->x2 |= 0x7;
+		}
 	}
 }


### PR DESCRIPTION
Added support for sharp memory displays of the series LS0XX.

This driver supports following displays
LS012B7DD01 
LS012B7DD06 
LS013B7DH03 -> Tested
LS013B7DH05 
LS013B7DH06 
LS027B7DH01A 
LS032B7DD02
LS044Q7DH01

The following devicetree configuration is an example:

```
 &spi1 {
     compatible = "nordic,nrf-spim";
     status = "okay";
     sck-pin = <13>;
     mosi-pin = <15>;
     miso-pin = <24>;
 
     ls0xx@0 {
         compatible = "sharp,ls0xx";
         label = "LS0XX";
         spi-max-frequency = <2000000>;
         reg = <0>;
         width = <128>;
         height = <128>;
         scs-gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
         extcomin-gpios = <&gpio0 22 GPIO_ACTIVE_HIGH>;
         disp-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
     };
 };
```
extcomin-gpios and disp-gpios are optional.
- If `disp-gpios` is provided then that GPIO (here GPIO0 29) Will be set to high during initialization and can be controlled using the blanking APIs.
- If `extcomin-gpios` is provided and `LS0XX_EXTMODE_SERIAL=n` then EXTCOMIN pin will be used for toggling VCOM.

The following LVGL options work for me

```
 CONFIG_DISPLAY=y
 CONFIG_SPI=y
 CONFIG_LS0XX=y
 
 CONFIG_LVGL_COLOR_DEPTH_1=y
 CONFIG_LVGL_BITS_PER_PIXEL=1
 CONFIG_LVGL_HOR_RES=128
 CONFIG_LVGL_VER_RES=128
 CONFIG_LVGL_DPI=150
 CONFIG_LVGL_VDB_SIZE=16
```


