### PR TITLE
tests: tests/kernel/device modify yaml config

### DIFF
--- a/tests/kernel/device/testcase.yaml
+++ b/tests/kernel/device/testcase.yaml
@@ -1,6 +1,5 @@
 common:
   tags: device userspace
-  platform_exclude: mec15xxevb_assy6853
   integration_platforms:
     - native_posix
 tests:
@@ -8,5 +7,6 @@ tests:
     tags: device
   kernel.device.pm:
     tags: device
+    platform_exclude: mec15xxevb_assy6853
     extra_configs:
       - CONFIG_DEVICE_POWER_MANAGEMENT=y


### PR DESCRIPTION
Modify platform_exclude tag from common tag into kernel.device.pm
because kernel.device can run on the mec15xxevb_assy6853 board, hence, it shouldn't be excluded.
see https://github.com/zephyrproject-rtos/zephyr/issues/27363

Signed-off-by: Ningx Zhao <ningx.zhao@intel.com>