### PR TITLE
drivers: eswifi: Remove unused variable in ioctl routine

### DIFF
--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -502,8 +502,6 @@ static int eswifi_socket_create(int family, int type, int proto)
 
 static int eswifi_socket_ioctl(void *obj, unsigned int request, va_list args)
 {
-	int sd = OBJ_TO_SD(obj);
-
 	switch (request) {
 	case ZFD_IOCTL_POLL_PREPARE:
 		return -EXDEV;


### PR DESCRIPTION
Variable "sd" is no longer referenced after refactoring in 2ed6b6a8ed.
It caused warning-as-error when building using sanitycheck, e.g. in CI.
This is 2nd fixed of the above refactor, after eb9a18432.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>