### PR TITLE
Periodic Advertising Sync explicit scan and term fixes

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -7186,10 +7186,6 @@ int bt_le_per_adv_sync_create(const struct bt_le_per_adv_sync_param *param,
 		return -EINVAL;
 	}
 
-	if (atomic_test_bit(bt_dev.flags, BT_DEV_EXPLICIT_SCAN)) {
-		return -EBUSY;
-	}
-
 	per_adv_sync = per_adv_sync_new();
 	if (!per_adv_sync) {
 		return -ENOMEM;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4683,16 +4683,14 @@ static void le_per_adv_sync_lost(struct net_buf *buf)
 	term_info.addr = &per_adv_sync->addr;
 	term_info.sid = per_adv_sync->sid;
 
-	/* Clearing bit before callback, so the caller will be able to restart
+	/* Deleting before callback, so the caller will be able to restart
 	 * sync in the callback
 	 */
-	atomic_clear_bit(per_adv_sync->flags, BT_PER_ADV_SYNC_SYNCED);
+	per_adv_sync_delete(per_adv_sync);
 
 	if (per_adv_sync->cb && per_adv_sync->cb->term) {
 		per_adv_sync->cb->term(per_adv_sync, &term_info);
 	}
-
-	per_adv_sync_delete(per_adv_sync);
 }
 #endif /* defined(CONFIG_BT_PER_ADV_SYNC) */
 #endif /* defined(CONFIG_BT_EXT_ADV) */


### PR DESCRIPTION
It is now possible to create a PA sync while explicitly scanning, and create PA sync in the termination (`term`) callback. 