### PR TITLE
net: openthread: Fix bugs detected during Coverity SCA.

### DIFF
--- a/subsys/net/l2/openthread/openthread_utils.c
+++ b/subsys/net/l2/openthread/openthread_utils.c
@@ -32,7 +32,8 @@ static bool is_mesh_local(struct openthread_context *context,
 	const otMeshLocalPrefix *ml_prefix =
 				otThreadGetMeshLocalPrefix(context->instance);
 
-	return (memcmp(address, ml_prefix->m8, sizeof(ml_prefix)) == 0);
+	return ml_prefix ? (memcmp(address, ml_prefix->m8, sizeof(ml_prefix)) == 0) :
+			   false;
 }
 
 int pkt_list_add(struct openthread_context *context, struct net_pkt *pkt)
@@ -180,6 +181,7 @@ void add_ipv6_addr_to_ot(struct openthread_context *context)
 			break;
 		}
 	}
+	i = i < 0 ? 0 : i;
 
 	ipv6->unicast[i].is_mesh_local = is_mesh_local(
 			context, ipv6->unicast[i].address.in6_addr.s6_addr);

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -105,11 +105,6 @@ static void reset_pending_event(enum pending_events event)
 	atomic_clear_bit(pending_events, event);
 }
 
-static inline void clear_pending_events(void)
-{
-	atomic_clear(pending_events);
-}
-
 void energy_detected(struct device *dev, int16_t max_ed)
 {
 	if (dev == radio_dev) {
@@ -279,7 +274,8 @@ static void openthread_handle_received_frame(otInstance *instance,
 {
 	otRadioFrame recv_frame;
 
-	recv_frame.mPsdu = net_buf_frag_last(pkt->buffer)->data;
+	recv_frame.mPsdu = net_buf_frag_last(pkt->buffer) ?
+			   net_buf_frag_last(pkt->buffer)->data : NULL;
 	/* Length inc. CRC. */
 	recv_frame.mLength = net_buf_frags_len(pkt->buffer);
 	recv_frame.mChannel = platformRadioChannelGet(instance);


### PR DESCRIPTION
Performed static code analysis using Coverity detected some bugs,
which were fixed in this commit.
List of detected bugs:
* radio.c
  - l.108 - clear_pending_events function was declared
  but never referenced
  - l.277 - dereferencing "net_buf_frag_last((*pkt).buffer)",
  which is known to be "NULL"
* openthread_utils.c
  - l.35 - dereferencing a pointer that might be "NULL"
  - l.185 - using index "i" (which may evaluate to -1).

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>