### PR TITLE
Using wildcard in CoAP resources description

### DIFF
--- a/doc/reference/networking/coap.rst
+++ b/doc/reference/networking/coap.rst
@@ -76,6 +76,24 @@ responsibility to either reply or act according to CoAP request.
     coap_handle_request(&request, resources, options, opt_num,
                         client_addr, client_addr_len);
 
+If :option:`CONFIG_COAP_URI_WILDCARD` enabled, server may accept multiple resources
+using MQTT-like wildcard style:
+
+- the plus symbol represents a single-level wild card in the path;
+- the hash symbol represents the multi-level wild card in the path.
+
+.. code-block:: c
+
+    static const char * const led_set[] = { "led","+","set", NULL };
+    static const char * const btn_get[] = { "button","#", NULL };
+    static const char * const no_wc[] = { "test","+1", NULL };
+
+It accepts /led/0/set, led/1234/set, led/any/set, /button/door/1, /test/+1,
+but returns -ENOENT for /led/1, /test/21, /test/1.
+
+This option is enabled by default, disable it to avoid unexpected behaviour
+with resource path like '/some_resource/+/#'.
+
 CoAP Client
 ===========
 

--- a/samples/net/sockets/coap_server/src/coap-server.c
+++ b/samples/net/sockets/coap_server/src/coap-server.c
@@ -1201,6 +1201,12 @@ static const char * const test_path[] = { "test", NULL };
 
 static const char * const segments_path[] = { "seg1", "seg2", "seg3", NULL };
 
+#if defined(CONFIG_COAP_URI_WILDCARD)
+static const char * const wildcard1_path[] = { "wild1", "+", "wild3", NULL };
+
+static const char * const wildcard2_path[] = { "wild2", "#", NULL };
+#endif /* CONFIG_COAP_URI_WILDCARD */
+
 static const char * const query_path[] = { "query", NULL };
 
 static const char * const separate_path[] = { "separate", NULL };
@@ -1240,6 +1246,14 @@ static struct coap_resource resources[] = {
 	{ .get = piggyback_get,
 	  .path = segments_path,
 	},
+#if defined(CONFIG_COAP_URI_WILDCARD)
+	{ .get = piggyback_get,
+	  .path = wildcard1_path,
+	},
+	{ .get = piggyback_get,
+	  .path = wildcard2_path,
+	},
+#endif /* CONFIG_COAP_URI_WILDCARD */
 	{ .get = query_get,
 	  .path = query_path,
 	},

--- a/subsys/net/lib/coap/Kconfig
+++ b/subsys/net/lib/coap/Kconfig
@@ -59,6 +59,13 @@ config COAP_INIT_ACK_TIMEOUT_MS
 	help
 	  This value is used as a base value to retry pending CoAP packets.
 
+config COAP_URI_WILDCARD
+	bool "Enable wildcards in CoAP resource path"
+	default y
+	help
+	  This option enables MQTT-style wildcards in path. Disable it if
+	  resource path may contain plus or hash symbol.
+
 module = COAP
 module-dep = NET_LOG
 module-str = Log level for CoAP

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -763,6 +763,17 @@ static bool uri_path_eq(const struct coap_packet *cpkt,
 			continue;
 		}
 
+		if (IS_ENABLED(CONFIG_COAP_URI_WILDCARD) && strlen(path[j]) == 1) {
+			if (*path[j] == '+') {
+				/* Single-level wildcard */
+				j++;
+				continue;
+			} else if (*path[j] == '#') {
+				/* Multi-level wildcard */
+				return true;
+			}
+		}
+
 		if (options[i].len != strlen(path[j])) {
 			return false;
 		}


### PR DESCRIPTION
Use MQTT style wildcard in 'struct coap_resource' path description:
- the plus symbol represents a single-level wild card in the path;
- the hash symbol represents the multi-level wild card in the path.

This change keeps compatibility with RFC 7252 but allows handling multiple requests in single function like

    PUT /led/0
    PUT /led/1


