### PR TITLE
Bluetooth: controller: consistent HCI error messages

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -265,7 +265,7 @@ uint8_t ll_conn_update(uint16_t handle, uint8_t cmd, uint8_t status, uint16_t in
 
 	conn = ll_connected_get(handle);
 	if (!conn) {
-		return BT_HCI_ERR_CMD_DISALLOWED;
+		return BT_HCI_ERR_UNKNOWN_CONN_ID;
 	}
 
 	if (!cmd) {
@@ -345,7 +345,7 @@ uint8_t ll_chm_get(uint16_t handle, uint8_t *chm)
 
 	conn = ll_connected_get(handle);
 	if (!conn) {
-		return BT_HCI_ERR_CMD_DISALLOWED;
+		return BT_HCI_ERR_UNKNOWN_CONN_ID;
 	}
 
 	/* Iterate until we are sure the ISR did not modify the value while
@@ -366,7 +366,7 @@ uint8_t ll_terminate_ind_send(uint16_t handle, uint8_t reason)
 
 	conn = ll_connected_get(handle);
 	if (!conn) {
-		return BT_HCI_ERR_CMD_DISALLOWED;
+		return BT_HCI_ERR_UNKNOWN_CONN_ID;
 	}
 
 	conn->llcp_terminate.reason_own = reason;
@@ -382,7 +382,7 @@ uint8_t ll_feature_req_send(uint16_t handle)
 
 	conn = ll_connected_get(handle);
 	if (!conn) {
-		return BT_HCI_ERR_CMD_DISALLOWED;
+		return BT_HCI_ERR_UNKNOWN_CONN_ID;
 	}
 
 	if (conn->llcp_feature.req != conn->llcp_feature.ack) {
@@ -400,7 +400,7 @@ uint8_t ll_version_ind_send(uint16_t handle)
 
 	conn = ll_connected_get(handle);
 	if (!conn) {
-		return BT_HCI_ERR_CMD_DISALLOWED;
+		return BT_HCI_ERR_UNKNOWN_CONN_ID;
 	}
 
 	if (conn->llcp_version.req != conn->llcp_version.ack) {
@@ -560,7 +560,7 @@ uint8_t ll_rssi_get(uint16_t handle, uint8_t *rssi)
 
 	conn = ll_connected_get(handle);
 	if (!conn) {
-		return BT_HCI_ERR_CMD_DISALLOWED;
+		return BT_HCI_ERR_UNKNOWN_CONN_ID;
 	}
 
 	*rssi = conn->lll.rssi_latest;


### PR DESCRIPTION
Return BT_HCI_ERR_INVALID_CONN_ID if an invalid handle is
given by the HCI; currently sometimes BT_HCI_ERR_CMD_DISALLOWED
is returned

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>