### PR TITLE
boards: arm: adafruit_feather_nrf52840: add support for QSPI flash 

### DIFF
--- a/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
+++ b/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
@@ -89,6 +89,26 @@
 	miso-pin = <15>;
 };
 
+&qspi {
+	status = "okay";
+	sck-pin = <19>;
+	io-pins = <17>, <22>, <23>, <21>;
+	csn-pins = <20>;
+	gd25q16: gd25q16@0 {
+		compatible = "nordic,qspi-nor";
+		reg = <0>;
+		writeoc = "pp4io";
+		readoc = "read4io";
+		sck-frequency = <16000000>;
+		label = "GD25Q16";
+		jedec-id = [c8 40 15];
+		size = <16777216>;
+		has-dpd;
+		t-enter-dpd = <20000>;
+		t-exit-dpd = <20000>;
+	};
+};
+
 &flash0 {
 	/*
 	 * For more information, see:

--- a/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
+++ b/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
@@ -82,6 +82,7 @@
 };
 
 &spi1 {
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <14>;
 	mosi-pin = <13>;

--- a/samples/drivers/spi_flash/boards/adafruit_feather_nrf52840.conf
+++ b/samples/drivers/spi_flash/boards/adafruit_feather_nrf52840.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2020 Teslabs Engineering S.L.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_NORDIC_QSPI_NOR=y


### PR DESCRIPTION
Add DT entry for the embedded QSPI NOR flash (GD25Q16) in the Adafruit
nRF52840 feather. Also added support for the spi_flash sample, which has
been used to verify the device.

NOTE: Device seems to fail when using high clock frequencies (e.g. maximum
QSPI frequency). It may be due to PCB layout issues.