### PR TITLE
Bluetooth: Call bt_recv from priority higher that TX thread.

### DIFF
--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -494,7 +494,7 @@ static int bt_ipm_open(void)
 	k_thread_create(&ipm_rx_thread_data, ipm_rx_stack,
 			K_KERNEL_STACK_SIZEOF(ipm_rx_stack),
 			(k_thread_entry_t)bt_ipm_rx_thread, NULL, NULL, NULL,
-			K_PRIO_COOP(CONFIG_BT_RX_PRIO - 1),
+			K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO),
 			0, K_NO_WAIT);
 
 	/* Take BLE out of reset */

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -506,7 +506,7 @@ static int bt_spi_open(void)
 	k_thread_create(&spi_rx_thread_data, spi_rx_stack,
 			K_KERNEL_STACK_SIZEOF(spi_rx_stack),
 			(k_thread_entry_t)bt_spi_rx_thread, NULL, NULL, NULL,
-			K_PRIO_COOP(CONFIG_BT_RX_PRIO - 1),
+			K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO),
 			0, K_NO_WAIT);
 
 	/* Take BLE out of reset */

--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -189,7 +189,7 @@ static int uc_open(void)
 	k_thread_create(&rx_thread_data, rx_thread_stack,
 			K_KERNEL_STACK_SIZEOF(rx_thread_stack),
 			rx_thread, NULL, NULL, NULL,
-			K_PRIO_COOP(CONFIG_BT_RX_PRIO - 1),
+			K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO),
 			0, K_NO_WAIT);
 
 	BT_DBG("returning");

--- a/subsys/bluetooth/common/dummy.c
+++ b/subsys/bluetooth/common/dummy.c
@@ -18,16 +18,15 @@
  * transaction violations in ATT and SMP protocols.
  */
 BUILD_ASSERT(CONFIG_BT_HCI_TX_PRIO < CONFIG_BT_RX_PRIO);
-#endif
 
-#if defined(CONFIG_BT_CTLR)
-/* The Bluetooth Controller's priority receive thread priority shall be higher
- * than the Bluetooth Host's Tx and the Controller's receive thread priority.
+/* The Bluetooth subsystem requires that higher priority events shall be given
+ * in a priority higher than the Bluetooth Host's Tx and the Controller's
+ * receive thread priority.
  * This is required in order to dispatch Number of Completed Packets event
  * before any new data arrives on a connection to the Host threads.
  */
-BUILD_ASSERT(CONFIG_BT_CTLR_RX_PRIO < CONFIG_BT_HCI_TX_PRIO);
-#endif /* CONFIG_BT_CTLR */
+BUILD_ASSERT(CONFIG_BT_DRIVER_RX_HIGH_PRIO < CONFIG_BT_HCI_TX_PRIO);
+#endif /* defined(CONFIG_BT_HCI_HOST) */
 
 /* Immediate logging is not supported with the software-based Link Layer
  * since it introduces ISR latency due to outputting log messages with

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -61,13 +61,6 @@ config BT_CTLR_RX_PRIO_STACK_SIZE
 	int "High priority Rx thread stack size" if !SOC_COMPATIBLE_NRF
 	default 448
 
-config BT_CTLR_RX_PRIO
-	# Hidden option for Controller's Co-Operative high priority Rx thread
-	# priority.
-	int
-	default 6
-
-
 config BT_CTLR_SETTINGS
 	bool "Settings System"
 	depends on SETTINGS

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -501,7 +501,7 @@ static int hci_driver_open(void)
 	k_thread_create(&prio_recv_thread_data, prio_recv_thread_stack,
 			K_KERNEL_STACK_SIZEOF(prio_recv_thread_stack),
 			prio_recv_thread, NULL, NULL, NULL,
-			K_PRIO_COOP(CONFIG_BT_CTLR_RX_PRIO), 0, K_NO_WAIT);
+			K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO), 0, K_NO_WAIT);
 	k_thread_name_set(&prio_recv_thread_data, "BT RX pri");
 
 	k_thread_create(&recv_thread_data, recv_thread_stack,

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -159,6 +159,11 @@ config BT_RX_PRIO
 	depends on BT_HCI_HOST || BT_RECV_IS_RX_THREAD
 	default 8
 
+config BT_DRIVER_RX_HIGH_PRIO
+	# Hidden option for Co-Operative HCI driver RX thread priority
+	int
+	default 6
+
 if BT_HCI_HOST
 
 config BT_HOST_CRYPTO


### PR DESCRIPTION
A build assert in dummy.c lists the following requirement:
[...] receive thread priority shall be higher than the Bluetooth
Host's Tx and the Controller's receive thread priority.
This is required in order to dispatch Number of Completed Packets
event before any new data arrives on a connection to the Host threads.

The drivers uses a priority that is equal to the Host TX thread,
and since they don't use the CONFIG define that is only available
to the controller then this BUILD_ASSERT will not catch the
requirement.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>