### PR TITLE
tests: tinycrypt_hmac_prng: exclude MEC1501-based boards

### DIFF
--- a/tests/crypto/tinycrypt_hmac_prng/testcase.yaml
+++ b/tests/crypto/tinycrypt_hmac_prng/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   crypto.tinycrypt.hmac_prng:
     tags: tinycrypt crypto sha256 hmac prng
+    platform_exclude: mec15xxevb_assy6853 mec1501modular_assy6885
     integration_platforms:
       - native_posix


### PR DESCRIPTION
MEC1501 SoC has 256KB of SRAM, but it is split into 224/32KB
for code and data, as each partition is optimized for
the access pattern. There the DTS only specifies 32KB as
data ram. The tinycrypt_hmac_prng test requires 40KB for
ztest stack. This obviously won't fit so exclude the boards
based on MEC1501 from the test.

Fixes #27572

Signed-off-by: Daniel Leung <daniel.leung@intel.com>