### PR TITLE
i2c_nrfx_twim: rework to support legacy device drivers without a concat buffer

### DIFF
--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -75,8 +75,9 @@ static int i2c_nrfx_twim_transfer(struct device *dev, struct i2c_msg *msgs,
 			     != (msgs[i].flags & I2C_MSG_READ)));
 
 		if ((concat_len != 0) || !last_or_non_concatenable) {
-			if (msgs[i].len > concat_buf_size) {
-				LOG_ERR("Concatenation buffer is too small");
+			if ((concat_len + msgs[i].len) > concat_buf_size) {
+				LOG_ERR("concat-buf overflow: %u + %u > %u",
+					concat_len, msgs[i].len, concat_buf_size);
 				return -ENOSPC;
 			}
 			if (!(msgs[i].flags & I2C_MSG_READ)) {

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -310,10 +310,10 @@ static int twim_nrfx_pm_control(struct device *dev, uint32_t ctrl_command,
 #define I2C_FREQUENCY(idx)						       \
 	I2C_NRFX_TWIM_FREQUENCY(DT_PROP(I2C(idx), clock_frequency))
 
-#define CONCAT_BUF_SIZE(idx) DT_PROP(I2C(idx), concat_buf_size)
+#define CONCAT_BUF_SIZE(idx) DT_PROP(I2C(idx), zephyr_concat_buf_size)
 
 #define I2C_CONCAT_BUF(idx)						       \
-	COND_CODE_1(DT_NODE_HAS_PROP(I2C(idx), concat_buf_size),	       \
+	COND_CODE_1(DT_NODE_HAS_PROP(I2C(idx), zephyr_concat_buf_size),	       \
 	(.concat_buf = twim_##idx##_concat_buf,				       \
 	.concat_buf_size = CONCAT_BUF_SIZE(idx),), ())
 
@@ -327,7 +327,7 @@ static int twim_nrfx_pm_control(struct device *dev, uint32_t ctrl_command,
 			    nrfx_isr, nrfx_twim_##idx##_irq_handler, 0);       \
 		return init_twim(dev);					       \
 	}								       \
-	COND_CODE_1(DT_NODE_HAS_PROP(I2C(idx), concat_buf_size),	       \
+	COND_CODE_1(DT_NODE_HAS_PROP(I2C(idx), zephyr_concat_buf_size),	       \
 	(static uint8_t twim_##idx##_concat_buf[CONCAT_BUF_SIZE(idx)];),       \
 	())								       \
 									       \

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -78,7 +78,8 @@ static int i2c_nrfx_twim_transfer(struct device *dev, struct i2c_msg *msgs,
 			if ((concat_len + msgs[i].len) > concat_buf_size) {
 				LOG_ERR("concat-buf overflow: %u + %u > %u",
 					concat_len, msgs[i].len, concat_buf_size);
-				return -ENOSPC;
+				ret = -ENOSPC;
+				break;
 			}
 			if (!(msgs[i].flags & I2C_MSG_READ)) {
 				memcpy(concat_buf + concat_len,

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -67,12 +67,13 @@ static int i2c_nrfx_twim_transfer(struct device *dev, struct i2c_msg *msgs,
 			break;
 		}
 
-		/* Merge this fragment with the next if it's not the last
-		 * fragment, this one doesn't end a bus transaction, the next
-		 * one doesn't start a bus transaction, and the direction of
-		 * the next fragment is the same as this one.
+		/* Merge this fragment with the next if we have a buffer, this
+		 * isn't the last fragment, it doesn't end a bus transaction,
+		 * the next one doesn't start a bus transaction, and the
+		 * direction of the next fragment is the same as this one.
 		 */
-		bool concat_next = ((i + 1) < num_msgs)
+		bool concat_next = (concat_buf_size > 0)
+			&& ((i + 1) < num_msgs)
 			&& !(msgs[i].flags & I2C_MSG_STOP)
 			&& !(msgs[i + 1].flags & I2C_MSG_RESTART)
 			&& ((msgs[i].flags & I2C_MSG_READ)

--- a/dts/bindings/i2c/nordic,nrf-twim.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twim.yaml
@@ -13,5 +13,10 @@ properties:
         required: false
         description:
             If concatenation buffer size is set, then multiple messages in the
-            same direction, will be concatenated into single transfers as long
+            same direction will be concatenated into single transfers as long
             as there is space in buffer and no restart or stop flag is set.
+
+            This property must be provided when interacting with devices like
+            the SSD1306 display that cannot tolerate a repeated start and
+            address appearing on the bus between message fragments.  For many
+            devices a concatenation buffer is not necessary.

--- a/dts/bindings/i2c/nordic,nrf-twim.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twim.yaml
@@ -8,7 +8,7 @@ compatible: "nordic,nrf-twim"
 include: nordic,nrf-twi-common.yaml
 
 properties:
-    concat-buf-size:
+    zephyr,concat-buf-size:
         type: int
         required: false
         description:


### PR DESCRIPTION
After much further investigation, I've confirmed that there are devices like SSD1306 and (per Google) some NXP sensors that can't tolerate the presence of unnecessary repeated start and address signals on the I2C bus within an active transaction.

I've also determined that other devices do tolerate them, and were broken by #25867 requiring that a buffer be provided, but not actually providing it in existing boards.

The description of the property added in #25867 specifies that concatenation is performed only if a buffer is provided.  This allows for a rework that restores the previous behavior (with repeated starts injected) for scatter/gather transactions for TWIM, while allow a solution that supports devices that can't tolerate these signals.

So what we have here is a series of patches that fix a buffer overrun in the original patch, improve diagnostics, rework the logic so I could understand it, enabling me to relax the check to fix #27547, and rename the property to be in line with the naming conventions for driver configuration devicetree properties that has been codified in #27624.

With this I've verified that reel_board:

* runs without error on its mesh_badge sample without having to have a concatenation buffer assigned;
* fails (correctly) with a buffer of 2 bytes
* succeeds (correctly) with a buffer of 3 bytes

I've verified that nrf52840dk_nrf52840 reconfigured for TWIM on arduino_i2c and with an SSD1306 128x64 display attached:
* fails to function without diagnostic if no concatenation buffer is assigned (the previous behavior)
* fails (correctly) with this diagnostic when a 1024 byte buffer is assigned:

        <err> i2c_nrfx_twim: concat-buf overflow: 1 + 1024 > 1024

* works (correct) when a 1025 byte buffer is assigned.

Hopefully this will be acceptable to all parties.

Fixes #27547