### PR TITLE
build: imgtool integration for MCUboot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1284,6 +1284,11 @@ if(CONFIG_BUILD_OUTPUT_EXE)
     )
 endif()
 
+# Generate and use MCUboot related artifacts as needed.
+if(CONFIG_BOOTLOADER_MCUBOOT)
+  include(${CMAKE_CURRENT_LIST_DIR}/cmake/mcuboot.cmake)
+endif()
+
 get_property(extra_post_build_commands
   GLOBAL PROPERTY
   extra_post_build_commands

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -398,6 +398,55 @@ config BOOTLOADER_MCUBOOT
 	      (or Armv8-M baseline) targets with no built-in vector relocation
 	      mechanisms
 
+if BOOTLOADER_MCUBOOT
+
+config MCUBOOT_SIGNATURE_KEY_FILE
+	string "Path to the mcuboot signing key file"
+	default ""
+	help
+	  The file contains a key pair whose public half is verified
+	  by your target's MCUboot image. The file is in PEM format.
+
+	  If set to a non-empty value, the build system tries to
+	  sign the final binaries using a 'west sign -t imgtool' command.
+	  The signed binaries are placed in the build directory
+	  at zephyr/zephyr.signed.bin and zephyr/zephyr.signed.hex.
+
+	  The file names can be customized with CONFIG_KERNEL_BIN_NAME.
+	  The existence of bin and hex files depends on CONFIG_BUILD_OUTPUT_BIN
+	  and CONFIG_BUILD_OUTPUT_HEX.
+
+	  This option should contain an absolute path to the same file
+	  as the BOOT_SIGNATURE_KEY_FILE option in your MCUboot
+	  .config. (The MCUboot config option is used for the MCUboot
+	  bootloader image; this option is for your application which
+	  is to be loaded by MCUboot. The MCUboot config option can be
+	  a relative path from the MCUboot repository root; this option's
+	  behavior is undefined for relative paths.)
+
+	  If left empty, you must sign the Zephyr binaries manually.
+
+config MCUBOOT_EXTRA_IMGTOOL_ARGS
+	string "Extra arguments to pass to imgtool"
+	default ""
+	help
+	  If CONFIG_MCUBOOT_SIGNATURE_KEY_FILE is a non-empty string,
+	  you can use this option to pass extra options to imgtool.
+	  For example, you could set this to "--version 1.2".
+
+config MCUBOOT_GENERATE_CONFIRMED_IMAGE
+	bool "Also generate a confirmed image"
+	help
+	  The signed and confirmed binaries are placed in the build directory
+	  at zephyr/zephyr.signed.confirmed.bin and
+	  zephyr/zephyr.signed.confirmed.hex.
+
+	  The file names can be customized with CONFIG_KERNEL_BIN_NAME.
+	  The existence of bin and hex files depends on CONFIG_BUILD_OUTPUT_BIN
+	  and CONFIG_BUILD_OUTPUT_HEX.
+
+endif # BOOTLOADER_MCUBOOT
+
 config BOOTLOADER_ESP_IDF
 	bool "ESP-IDF bootloader support"
 	depends on SOC_ESP32

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -618,6 +618,8 @@ endif()
 #
 # Currently used properties:
 # - COMPILES_OPTIONS: Used by application memory partition feature
+# - ${TARGET}_DEPENDENCIES: additional dependencies for targets that need them
+#   like flash (FLASH_DEPENDENCIES), debug (DEBUG_DEPENDENCIES), etc.
 add_custom_target(zephyr_property_target)
 
 # "app" is a CMake library containing all the application code and is

--- a/cmake/host-tools.cmake
+++ b/cmake/host-tools.cmake
@@ -57,5 +57,13 @@ find_program(
   bossac
   )
 
+# imgtool is an optional dependency (the build may also fall back to
+# scripts/imgtool.py in the mcuboot repository if that's present in
+# some cases)
+find_program(
+  IMGTOOL
+  imgtool
+  )
+
 # TODO: Should we instead find one qemu binary for each ARCH?
 # TODO: This will probably need to be re-organized when there exists more than one SDK.

--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -1,0 +1,134 @@
+# Copyright (c) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# This file includes extra build system logic that is enabled when
+# CONFIG_BOOTLOADER_MCUBOOT=y.
+#
+# It builds signed binaries using imgtool as a post-processing step
+# after zephyr/zephyr.elf is created in the build directory.
+#
+# Since this file is brought in via include(), we do the work in a
+# function to avoid polluting the top-level scope.
+
+function(zephyr_mcuboot_tasks)
+  set(keyfile "${CONFIG_MCUBOOT_SIGNATURE_KEY_FILE}")
+
+  # Check for misconfiguration.
+  if("${keyfile}" STREQUAL "")
+    # No signature key file, no signed binaries. No error, though:
+    # this is the documented behavior.
+    return()
+  endif()
+
+  if(NOT WEST)
+    # This feature requires west.
+    message(FATAL_ERROR "Can't sign images for MCUboot: west not found. To fix, install west and ensure it's on PATH.")
+  endif()
+
+  if(NOT IS_ABSOLUTE "${keyfile}")
+    # Relative paths are relative to 'west topdir'.
+    set(keyfile "${WEST_TOPDIR}/${keyfile}")
+    set(keyfile_relative TRUE)
+  else()
+    set(keyfile_relative FALSE)
+  endif()
+
+  if(NOT EXISTS "${keyfile}")
+    if(keyfile_relative)
+      set(relative_msg " Note: relative paths are relative to the west workspace topdir \"${WEST_TOPDIR}\".")
+    else()
+      set(relative_msg "")
+    endif()
+    message(FATAL_ERROR "Can't sign images for MCUboot: CONFIG_MCUBOOT_SIGNATURE_KEY_FILE=\"${CONFIG_MCUBOOT_SIGNATURE_KEY_FILE}\" not found.${relative_msg}")
+  elseif(NOT (CONFIG_BUILD_OUTPUT_BIN OR CONFIG_BUILD_OUTPUT_HEX))
+    message(FATAL_ERROR "Can't sign images for MCUboot: Neither CONFIG_BUILD_OUTPUT_BIN nor CONFIG_BUILD_OUTPUT_HEX is enabled, so there's nothing to sign.")
+  endif()
+
+  # Find imgtool. Even though west is installed, imgtool might not be.
+  # The user may also have a custom manifest which doesn't include
+  # MCUboot.
+  #
+  # Therefore, go with an explicitly installed imgtool first, falling
+  # back on mcuboot/scripts/imgtool.py.
+  if(IMGTOOL)
+    set(imgtool_path "${IMGTOOL}")
+  elseif(DEFINED ZEPHYR_MCUBOOT_MODULE_DIR)
+    set(IMGTOOL_PY "${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts/imgtool.py")
+    if(EXISTS "${IMGTOOL_PY}")
+      set(imgtool_path "${IMGTOOL_PY}")
+    endif()
+  endif()
+
+  # No imgtool, no signed binaries.
+  if(NOT DEFINED imgtool_path)
+    message(FATAL_ERROR "Can't sign images for MCUboot: can't find imgtool. To fix, install imgtool with pip3, or add the mcuboot repository to the west manifest and ensure it has a scripts/imgtool.py file.")
+    return()
+  endif()
+
+  # Basic 'west sign' command and output format independent arguments.
+  set(west_sign ${WEST} sign --quiet --tool imgtool
+    --tool-path "${imgtool_path}"
+    --build-dir "${APPLICATION_BINARY_DIR}")
+
+  # Arguments to imgtool.
+  if(NOT CONFIG_MCUBOOT_EXTRA_IMGTOOL_ARGS STREQUAL "")
+    # Separate extra arguments into the proper format for adding to
+    # extra_post_build_commands.
+    #
+    # Use UNIX_COMMAND syntax for uniform results across host
+    # platforms.
+    separate_arguments(imgtool_extra UNIX_COMMAND ${CONFIG_MCUBOOT_EXTRA_IMGTOOL_ARGS})
+  else()
+    set(imgtool_extra)
+  endif()
+  set(imgtool_args -- --key "${keyfile}" ${imgtool_extra})
+
+  # Extensionless prefix of any output file.
+  set(output ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME})
+
+  # List of additional build byproducts.
+  set(byproducts)
+
+  # 'west sign' arguments for confirmed and unconfirmed images.
+  set(unconfirmed_args)
+  set(confirmed_args)
+
+  # Set up .bin outputs.
+  if(CONFIG_BUILD_OUTPUT_BIN)
+    list(APPEND unconfirmed_args --bin --sbin ${output}.signed.bin)
+    list(APPEND byproducts ${output}.signed.bin)
+
+    if(CONFIG_MCUBOOT_GENERATE_CONFIRMED_IMAGE)
+      list(APPEND confirmed_args --bin --sbin ${output}.signed.confirmed.bin)
+      list(APPEND byproducts ${output}.signed.confirmed.bin)
+    endif()
+  endif()
+
+  # Set up .hex outputs.
+  if(CONFIG_BUILD_OUTPUT_HEX)
+    list(APPEND unconfirmed_args --hex --shex ${output}.signed.hex)
+    list(APPEND byproducts ${output}.signed.hex)
+
+    if(CONFIG_MCUBOOT_GENERATE_CONFIRMED_IMAGE)
+      list(APPEND confirmed_args --hex --shex ${output}.signed.confirmed.hex)
+      list(APPEND byproducts ${output}.signed.confirmed.hex)
+    endif()
+  endif()
+
+  # Add the west sign calls and their byproducts to the post-processing
+  # steps for zephyr.elf.
+  #
+  # CMake guarantees that multiple COMMANDs given to
+  # add_custom_command() are run in order, so adding the 'west sign'
+  # calls to the "extra_post_build_commands" property ensures they run
+  # after the commands which generate the unsigned versions.
+  set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
+    ${west_sign} ${unconfirmed_args} ${imgtool_args})
+  if(confirmed_args)
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
+      ${west_sign} ${confirmed_args} ${imgtool_args} --confirm)
+  endif()
+  set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts ${byproducts})
+endfunction()
+
+zephyr_mcuboot_tasks()

--- a/cmake/west.cmake
+++ b/cmake/west.cmake
@@ -1,60 +1,92 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# west is an optional dependency
-find_program(
-  WEST
-  west
+# west is an optional dependency. We need to run west using the same
+# Python interpreter as everything else, though, so we play some extra
+# tricks.
+
+# When west runs cmake, it sets WEST_PYTHON to its interpreter. If
+# it's defined, we assume west is installed. We do these checks here
+# instead of in the failure paths below to avoid CMake warnings about
+# WEST_PYTHON not being used.
+if(DEFINED WEST_PYTHON)
+  # Cut out any symbolic links, e.g. python3.x -> python
+  get_filename_component(west_realpath ${WEST_PYTHON} REALPATH)
+  get_filename_component(python_realpath ${PYTHON_EXECUTABLE} REALPATH)
+
+  # If realpaths differ from the variables we're using, add extra
+  # diagnostics.
+  if(NOT ("${west_realpath}" STREQUAL "${WEST_PYTHON}"))
+    set(west_realpath_msg " (real path ${west_realpath})")
+  else()
+    set(west_realpath_msg "")
+  endif()
+  if(NOT ("${python_realpath}" STREQUAL "${PYTHON_EXECUTABLE}"))
+    set(python_realpath_msg " (real path ${python_realpath})")
+  else()
+    set(python_realpath_msg "")
+  endif()
+endif()
+
+execute_process(
+  COMMAND
+  ${PYTHON_EXECUTABLE}
+  -c
+  "import west.version; print(west.version.__version__, end='')"
+  OUTPUT_VARIABLE west_version
+  ERROR_VARIABLE west_version_err
+  RESULT_VARIABLE west_version_output_result
   )
-if(${WEST} STREQUAL WEST-NOTFOUND)
-  unset(WEST)
-else()
-  # If west is found, make sure its version matches the minimum
-  # required one.
-  set(MIN_WEST_VERSION 0.7.1)
-  execute_process(
-    COMMAND
-    ${PYTHON_EXECUTABLE}
-    -c
-    "import west.version; print(west.version.__version__, end='')"
-    OUTPUT_VARIABLE west_version
-    RESULT_VARIABLE west_version_output_result
-    )
 
-  if(WEST_PYTHON)
-    get_filename_component(WEST_PYTHON ${WEST_PYTHON} ABSOLUTE)
-    if(NOT (${WEST_PYTHON} STREQUAL ${PYTHON_EXECUTABLE}))
-      set(PYTHON_EXECUTABLE_OUT_OF_SYNC "\nNote:\n\
-  The Python version used by west is:  ${WEST_PYTHON}\n\
-  The Python version used by CMake is: ${PYTHON_EXECUTABLE}\n\
-  This might be correct, but please verify your installation.")
+if(west_version_output_result)
+  if(DEFINED WEST_PYTHON)
+    if(NOT (${west_realpath} STREQUAL ${python_realpath}))
+      set(PYTHON_EXECUTABLE_OUT_OF_SYNC "\nOr verify these installations:\n\
+  The Python version used by west is:  ${WEST_PYTHON}${west_realpath_msg}\n\
+  The Python version used by CMake is: ${PYTHON_EXECUTABLE}${python_realpath_msg}")
     endif()
-  endif()
 
-  if(west_version_output_result)
-    message(FATAL_ERROR "Unable to import west.version from '${PYTHON_EXECUTABLE}'\n\
-  Please install with:\n\
-      ${PYTHON_EXECUTABLE} -m pip install west\
-  ${PYTHON_EXECUTABLE_OUT_OF_SYNC}")
+    message(FATAL_ERROR "Unable to import west.version from '${PYTHON_EXECUTABLE}':\n${west_version_err}\
+Please install with:\n\
+    ${PYTHON_EXECUTABLE} -m pip install west\
+${PYTHON_EXECUTABLE_OUT_OF_SYNC}")
+  else()
+    # WEST_PYTHON is undefined and we couldn't import west. That's
+    # fine; it's optional.
+    set(WEST WEST-NOTFOUND)
   endif()
+else()
+  # We can import west from PYTHON_EXECUTABLE and have its version.
 
+  # Make sure its version matches the minimum required one.
+  set(MIN_WEST_VERSION 0.7.1)
   if(${west_version} VERSION_LESS ${MIN_WEST_VERSION})
-    message(FATAL_ERROR "The detected west version is unsupported.\n\
-  The version was found to be ${west_version}:\n\
-    ${item}\n\
-  But the minimum supported version is ${MIN_WEST_VERSION}\n\
+    message(FATAL_ERROR "The detected west version, ${west_version}, is unsupported.\n\
+  The minimum supported version is ${MIN_WEST_VERSION}.\n\
   Please upgrade with:\n\
       ${PYTHON_EXECUTABLE} -m pip install --upgrade west\
   ${PYTHON_EXECUTABLE_OUT_OF_SYNC}\n")
   endif()
 
-  # Just output information for a single version. This will still work
-  # even after output is one line.
-  message(STATUS "Found west: ${WEST} (found suitable version \"${west_version}\", minimum required is \"${MIN_WEST_VERSION}\")")
+  # Set WEST to a COMMAND prefix as if it were a find_program()
+  # result.
+  #
+  # From west 0.8 forward, you can run 'python -m west' to run
+  # the command line application.
+  set(WEST_MODULE west)
+  if(${west_version} VERSION_LESS 0.8)
+    # In west 0.7.x, this wasn't supported yet, but it happens to be
+    # possible to run 'python -m west.app.main'.
+    string(APPEND WEST_MODULE .app.main)
+  endif()
+  set(WEST ${PYTHON_EXECUTABLE} -m ${WEST_MODULE})
+
+  # Print information about the west module we're relying on. This
+  # will still work even after output is one line.
+  message(STATUS "Found west (found suitable version \"${west_version}\", minimum required is \"${MIN_WEST_VERSION}\")")
 
   execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c
-    "import pathlib; from west.util import west_topdir; print(pathlib.Path(west_topdir()).as_posix())"
-    OUTPUT_VARIABLE  WEST_TOPDIR
+    COMMAND ${WEST} topdir
+    OUTPUT_VARIABLE WEST_TOPDIR
     OUTPUT_STRIP_TRAILING_WHITESPACE
     WORKING_DIRECTORY ${ZEPHYR_BASE}
     )


### PR DESCRIPTION
In https://github.com/zephyrproject-rtos/zephyr/issues/22562#issuecomment-654421847 and following comments, we discuss how to make it easier to build zephyr applications to be chain-loaded by MCUboot. In short, we agreed on auto-generating signed binaries, provided sufficient information about how to generate them is available in .config.

This PR implements that.

If accepted, I will write a follow-up PR that teaches `west flash` to use the signed binaries by default. This will probably involve finally deprecating the `--elf-file`, `--hex-file`, and `--bin-file` runner options and just loading the default locations from `build/zephyr/.config`, with enough wiggle room to override those defaults when MCUboot is in use.

We can leave an escape hatch for user-supplied files using the `--file` option we've discussed adding support for.

The first four patches are just cleanups I noticed along the way and prep work. (@finikorg, I hope you will ACK the rimage changes to support `west sign --quiet`).

The last patch is the main one.

How I am testing, for reference:

```
west build -b nrf52840dk_nrf52840 -s bootloader/mcuboot/boot/zephyr -d build-mcuboot
west flash -d build-mcuboot

west build -b nrf52840dk_nrf52840 -s zephyr/samples/hello_world -- \
   -DCONFIG_BOOTLOADER_MCUBOOT=y \
   -DCONFIG_MCUBOOT_SIGNATURE_KEY_FILE=\"/home/mbolivar/zp/bootloader/mcuboot/root-rsa-2048.pem\"

# My board's default flash runner supports --hex-file.
west flash --hex-file build/zephyr/zephyr.signed.hex
```

