### PR TITLE
Tracing: Various fixes and optimizations

### DIFF
--- a/arch/arc/core/isr_wrapper.S
+++ b/arch/arc/core/isr_wrapper.S
@@ -279,7 +279,7 @@ SECTION_FUNC(TEXT, _isr_demux)
 	bl read_timer_start_of_isr
 #endif
 
-#if defined(CONFIG_TRACING)
+#if defined(CONFIG_TRACING_ISR)
 	bl sys_trace_isr_enter
 #endif
 	/* cannot be done before this point because we must be able to run C */
@@ -309,7 +309,7 @@ irq_hint_handled:
 	jl_s.d [r1]
 	ld_s r0, [r0] /* delay slot: ISR parameter into r0  */
 
-#ifdef CONFIG_TRACING_ISR
+#if defined(CONFIG_TRACING_ISR)
 	bl sys_trace_isr_exit
 #endif
 

--- a/arch/arm/core/aarch64/swap_helper.S
+++ b/arch/arm/core/aarch64/swap_helper.S
@@ -35,7 +35,7 @@ GTEXT(z_arm64_context_switch)
 SECTION_FUNC(TEXT, z_arm64_context_switch)
 #ifdef CONFIG_TRACING
 	stp	xzr, x30, [sp, #-16]!
-	bl	sys_trace_thread_switched_in
+	bl	sys_trace_thread_switched_out
 	ldp	xzr, x30, [sp], #16
 #endif
 	/* load _kernel into x0 and current k_thread into x1 */
@@ -79,7 +79,7 @@ SECTION_FUNC(TEXT, z_arm64_context_switch)
 
 #ifdef CONFIG_TRACING
 	stp	xzr, x30, [sp, #-16]!
-	bl	sys_trace_thread_switched_out
+	bl	sys_trace_thread_switched_in
 	ldp	xzr, x30, [sp], #16
 #endif
 

--- a/arch/nios2/core/swap.S
+++ b/arch/nios2/core/swap.S
@@ -13,7 +13,6 @@ GTEXT(arch_swap)
 GTEXT(z_thread_entry_wrapper)
 
 /* imports */
-GTEXT(sys_trace_thread_switched_in)
 GTEXT(_k_neg_eagain)
 
 /* unsigned int arch_swap(unsigned int key)
@@ -22,7 +21,7 @@ GTEXT(_k_neg_eagain)
  */
 SECTION_FUNC(exception.other, arch_swap)
 
-#ifdef CONFIG_EXECUTION_BENCHMARKING
+#if defined(CONFIG_EXECUTION_BENCHMARKING) || defined(CONFIG_TRACING)
 	/* Get a reference to _kernel in r10 */
 	movhi r10, %hi(_kernel)
 	ori   r10, r10, %lo(_kernel)
@@ -35,7 +34,11 @@ SECTION_FUNC(exception.other, arch_swap)
 	stw ra,  _thread_offset_to_ra(r11)
 	stw sp,  _thread_offset_to_sp(r11)
 
+#if CONFIG_TRACING
+	call sys_trace_thread_switched_out
+#elif CONFIG_EXECUTION_BENCHMARKING
 	call read_timer_start_of_swap
+#endif
 	/* Get a reference to _kernel in r10 */
 	movhi r10, %hi(_kernel)
 	ori   r10, r10, %lo(_kernel)
@@ -49,6 +52,7 @@ SECTION_FUNC(exception.other, arch_swap)
 	ldw sp,  _thread_offset_to_sp(r11)
 
 #endif
+
 	/* Get a reference to _kernel in r10 */
 	movhi r10, %hi(_kernel)
 	ori   r10, r10, %lo(_kernel)
@@ -83,13 +87,6 @@ SECTION_FUNC(exception.other, arch_swap)
 	ori   r5, r5, %lo(_k_neg_eagain)
 	ldw   r4, (r5)
 	stw   r4, _thread_offset_to_retval(r11)
-
-#if CONFIG_TRACING
-	call sys_trace_thread_switched_in
-	/* restore caller-saved r10 */
-	movhi r10, %hi(_kernel)
-	ori   r10, r10, %lo(_kernel)
-#endif
 
 	/* get cached thread to run */
 	ldw   r2, _kernel_offset_to_ready_q_cache(r10)
@@ -142,7 +139,7 @@ no_unlock:
 	wrctl status, r3
 #endif
 
-#ifdef CONFIG_EXECUTION_BENCHMARKING
+#if defined(CONFIG_EXECUTION_BENCHMARKING) || defined(CONFIG_TRACING)
 	/* Get a reference to _kernel in r10 */
 	movhi r10, %hi(_kernel)
 	ori   r10, r10, %lo(_kernel)
@@ -154,7 +151,11 @@ no_unlock:
 	stw ra,  _thread_offset_to_ra(r11)
 	stw sp,  _thread_offset_to_sp(r11)
 
+#if CONFIG_TRACING
+	call sys_trace_thread_switched_in
+#elif CONFIG_EXECUTION_BENCHMARKING
 	call read_timer_end_of_swap
+#endif
 
 	/* Get a reference to _kernel in r10 */
 	movhi r10, %hi(_kernel)

--- a/arch/posix/core/swap.c
+++ b/arch/posix/core/swap.c
@@ -30,6 +30,9 @@ int arch_swap(unsigned int key)
 	 * and so forth.  But we do not need to do so because we use posix
 	 * threads => those are all nicely kept by the native OS kernel
 	 */
+#if CONFIG_TRACING
+	sys_trace_thread_switched_out();
+#endif
 	_current->callee_saved.key = key;
 	_current->callee_saved.retval = -EAGAIN;
 
@@ -47,6 +50,9 @@ int arch_swap(unsigned int key)
 
 
 	_current = _kernel.ready_q.cache;
+#if CONFIG_TRACING
+	sys_trace_thread_switched_in();
+#endif
 
 	/*
 	 * Here a "real" arch would load all processor registers for the thread

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -371,7 +371,7 @@ on_thread_stack:
 
 reschedule:
 #if CONFIG_TRACING
-	call sys_trace_thread_switched_in
+	call sys_trace_thread_switched_out
 #endif
 	/* Get reference to _kernel */
 	la t0, _kernel
@@ -525,6 +525,9 @@ skip_load_fp_caller_saved_benchmark:
 
 	/* Release stack space */
 	addi sp, sp, __z_arch_esf_t_SIZEOF
+#endif
+#if CONFIG_TRACING
+	call sys_trace_thread_switched_in
 #endif
 
 no_reschedule:

--- a/arch/x86/core/ia32/intstub.S
+++ b/arch/x86/core/ia32/intstub.S
@@ -129,19 +129,6 @@ SECTION_FUNC(TEXT, _interrupt_enter)
 	 */
 	pushl	%edi
 
-
-#if defined(CONFIG_TRACING_ISR)
-
-	/* Save these as we are using to keep track of isr and isr_param */
-	pushl	%eax
-	pushl	%edx
-
-	call	sys_trace_isr_enter
-
-	popl	%edx
-	popl	%eax
-#endif
-
 	/* load %ecx with &_kernel */
 
 	movl	$_kernel, %ecx
@@ -192,6 +179,16 @@ alreadyOnIntStack:
 	pop %eax
 #endif
 
+
+#if defined(CONFIG_TRACING_ISR)
+	/* Save these as we are using to keep track of isr and isr_param */
+	pushl	%eax
+	pushl	%edx
+	call	sys_trace_isr_enter
+	popl	%edx
+	popl	%eax
+#endif
+
 #ifdef CONFIG_NESTED_INTERRUPTS
 	sti			/* re-enable interrupts */
 #endif
@@ -201,6 +198,12 @@ alreadyOnIntStack:
 	addl	$0x4, %esp
 #ifdef CONFIG_NESTED_INTERRUPTS
 	cli			/* disable interrupts again */
+#endif
+
+#if defined(CONFIG_TRACING_ISR)
+	pushl	%eax
+	call	sys_trace_isr_exit
+	popl	%eax
 #endif
 
 	xorl	%eax, %eax
@@ -221,7 +224,6 @@ alreadyOnIntStack:
 	movl	$_kernel, %ecx
 	decl	_kernel_offset_to_nested(%ecx)	/* dec interrupt nest count */
 	jne	nestedInterrupt                 /* 'iret' if nested case */
-
 
 #ifdef CONFIG_PREEMPT_ENABLED
 	movl	_kernel_offset_to_current(%ecx), %edx

--- a/arch/x86/core/ia32/swap.S
+++ b/arch/x86/core/ia32/swap.S
@@ -87,6 +87,13 @@ SECTION_FUNC(TEXT, arch_swap)
 	pop %edx
 	pop %eax
 #endif
+
+
+#if defined(CONFIG_TRACING)
+	pushl	%eax
+	call	sys_trace_thread_switched_out
+	popl	%eax
+#endif
 	/*
 	 * Push all non-volatile registers onto the stack; do not copy
 	 * any of these registers into the k_thread.  Only the 'esp' register
@@ -116,13 +123,6 @@ SECTION_FUNC(TEXT, arch_swap)
 
 	movl	_kernel_offset_to_current(%edi), %edx
 	movl	%esp, _thread_offset_to_esp(%edx)
-
-#ifdef CONFIG_TRACING
-	/* Register the context switch */
-	push %edx
-	call	sys_trace_thread_switched_in
-	pop %edx
-#endif
 	movl	_kernel_offset_to_ready_q_cache(%edi), %eax
 
 	/*
@@ -363,6 +363,11 @@ CROHandlingDone:
 	pushl arch_timing_swap_start
 	popl arch_timing_value_swap_temp
 time_read_not_needed:
+#endif
+#if defined(CONFIG_TRACING)
+	pushl	%eax
+	call	sys_trace_thread_switched_in
+	popl	%eax
 #endif
 	ret
 

--- a/arch/xtensa/core/xtensa-asm2-util.S
+++ b/arch/xtensa/core/xtensa-asm2-util.S
@@ -228,6 +228,9 @@ xtensa_switch:
 #ifdef CONFIG_EXECUTION_BENCHMARKING
 	call4 read_timer_end_of_swap
 #endif
+#ifdef CONFIG_TRACING
+	call4 sys_trace_thread_switched_in
+#endif
 	j _restore_context
 _switch_restore_pc:
 	retw

--- a/include/arch/arc/v2/irq.h
+++ b/include/arch/arc/v2/irq.h
@@ -35,6 +35,10 @@ extern void z_arc_firq_stack_set(void);
 extern void arch_irq_enable(unsigned int irq);
 extern void arch_irq_disable(unsigned int irq);
 extern int arch_irq_is_enabled(unsigned int irq);
+#ifdef CONFIG_TRACING_ISR
+extern void sys_trace_isr_enter(void);
+extern void sys_trace_isr_exit(void);
+#endif
 
 extern void _irq_exit(void);
 extern void z_irq_priority_set(unsigned int irq, unsigned int prio,
@@ -92,8 +96,8 @@ extern void z_irq_spurious(void *unused);
 
 static inline void arch_isr_direct_header(void)
 {
-#ifdef CONFIG_TRACING
-	z_sys_trace_isr_enter();
+#ifdef CONFIG_TRACING_ISR
+	sys_trace_isr_enter();
 #endif
 }
 
@@ -104,8 +108,8 @@ static inline void arch_isr_direct_footer(int maybe_swap)
 	    z_arc_v2_aux_reg_read(_ARC_V2_AUX_IRQ_HINT)) {
 		z_arc_v2_aux_reg_write(_ARC_V2_AUX_IRQ_HINT, 0);
 	}
-#ifdef CONFIG_TRACING
-	z_sys_trace_isr_exit();
+#ifdef CONFIG_TRACING_ISR
+	sys_trace_isr_exit();
 #endif
 }
 

--- a/include/tracing/tracing.h
+++ b/include/tracing/tracing.h
@@ -50,16 +50,19 @@
 
 /**
  * @brief Called when setting priority of a thread
+ * @param thread Thread structure
  */
 #define sys_trace_thread_priority_set(thread)
 
 /**
  * @brief Called when a thread is being created
+ * @param thread Thread structure
  */
 #define sys_trace_thread_create(thread)
 
 /**
  * @brief Called when a thread is being aborted
+ * @param thread Thread structure
  *
  */
 #define sys_trace_thread_abort(thread)
@@ -132,6 +135,41 @@
  */
 #define sys_trace_idle()
 
+/**
+ * @brief Trace initialisation of a Semaphore
+ * @param sem Semaphore object
+ */
+#define sys_trace_semaphore_init(sem)
+
+/**
+ * @brief Trace taking a Semaphore
+ * @param sem Semaphore object
+ */
+#define sys_trace_semaphore_take(sem)
+
+/**
+ * @brief Trace giving a Semaphore
+ * @param sem Semaphore object
+ */
+#define sys_trace_semaphore_give(sem)
+
+/**
+ * @brief Trace initialisation of a Mutex
+ * @param mutex  Mutex object
+ */
+#define sys_trace_mutex_init(mutex)
+
+/**
+ * @brief Trace locking a Mutex
+ * @param mutex Mutex object
+ */
+#define sys_trace_mutex_lock(mutex)
+
+/**
+ * @brief Trace unlocking a Mutex
+ * @param mutex Mutex object
+ */
+#define sys_trace_mutex_unlock(mutex)
 /**
  * @}
  */

--- a/include/tracing/tracing.h
+++ b/include/tracing/tracing.h
@@ -17,6 +17,7 @@
 #define SYS_TRACE_ID_SEMA_INIT               (4u + SYS_TRACE_ID_OFFSET)
 #define SYS_TRACE_ID_SEMA_GIVE               (5u + SYS_TRACE_ID_OFFSET)
 #define SYS_TRACE_ID_SEMA_TAKE               (6u + SYS_TRACE_ID_OFFSET)
+#define SYS_TRACE_ID_SLEEP                   (7u + SYS_TRACE_ID_OFFSET)
 
 #ifdef CONFIG_SEGGER_SYSTEMVIEW
 #include "tracing_sysview.h"

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -97,7 +97,6 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 #endif
 
 	if (new_thread != old_thread) {
-		sys_trace_thread_switched_out();
 #ifdef CONFIG_TIMESLICING
 		z_reset_time_slice();
 #endif
@@ -113,6 +112,7 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 			z_smp_release_global_lock(new_thread);
 		}
 #endif
+		sys_trace_thread_switched_out();
 		_current_cpu->current = new_thread;
 		wait_for_switch(new_thread);
 		arch_switch(new_thread->switch_handle,
@@ -155,13 +155,7 @@ static inline int z_swap_irqlock(unsigned int key)
 {
 	int ret;
 	z_check_stack_sentinel();
-#ifndef CONFIG_ARM
-	sys_trace_thread_switched_out();
-#endif
 	ret = arch_swap(key);
-#ifndef CONFIG_ARM
-	sys_trace_thread_switched_in();
-#endif
 	return ret;
 }
 

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -73,7 +73,7 @@ int z_impl_k_mutex_init(struct k_mutex *mutex)
 	mutex->owner = NULL;
 	mutex->lock_count = 0U;
 
-	sys_trace_void(SYS_TRACE_ID_MUTEX_INIT);
+	sys_trace_mutex_init(mutex);
 
 	z_waitq_init(&mutex->wait_q);
 
@@ -124,7 +124,7 @@ int z_impl_k_mutex_lock(struct k_mutex *mutex, k_timeout_t timeout)
 
 	__ASSERT(!arch_is_in_isr(), "mutexes cannot be used inside ISRs");
 
-	sys_trace_void(SYS_TRACE_ID_MUTEX_LOCK);
+	sys_trace_mutex_lock(mutex);
 	key = k_spin_lock(&lock);
 
 	if (likely((mutex->lock_count == 0U) || (mutex->owner == _current))) {
@@ -233,7 +233,7 @@ int z_impl_k_mutex_unlock(struct k_mutex *mutex)
 	 */
 	__ASSERT_NO_MSG(mutex->lock_count > 0U);
 
-	sys_trace_void(SYS_TRACE_ID_MUTEX_UNLOCK);
+	sys_trace_mutex_unlock(mutex);
 	z_sched_lock();
 
 	LOG_DBG("mutex %p lock_count: %d", mutex, mutex->lock_count);

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1220,6 +1220,7 @@ int32_t z_impl_k_sleep(k_timeout_t timeout)
 	k_ticks_t ticks;
 
 	__ASSERT(!arch_is_in_isr(), "");
+	sys_trace_void(SYS_TRACE_ID_SLEEP);
 
 	if (K_TIMEOUT_EQ(timeout, K_FOREVER)) {
 		k_thread_suspend(_current);
@@ -1233,6 +1234,7 @@ int32_t z_impl_k_sleep(k_timeout_t timeout)
 #endif
 
 	ticks = z_tick_sleep(ticks);
+	sys_trace_end_call(SYS_TRACE_ID_SLEEP);
 	return k_ticks_to_ms_floor64(ticks);
 }
 

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -69,9 +69,9 @@ int z_impl_k_sem_init(struct k_sem *sem, unsigned int initial_count,
 		return -EINVAL;
 	}
 
-	sys_trace_void(SYS_TRACE_ID_SEMA_INIT);
 	sem->count = initial_count;
 	sem->limit = limit;
+	sys_trace_semaphore_init(sem);
 	z_waitq_init(&sem->wait_q);
 #if defined(CONFIG_POLL)
 	sys_dlist_init(&sem->poll_events);
@@ -107,9 +107,10 @@ static inline void handle_poll_events(struct k_sem *sem)
 void z_impl_k_sem_give(struct k_sem *sem)
 {
 	k_spinlock_key_t key = k_spin_lock(&lock);
-	struct k_thread *thread = z_unpend_first_thread(&sem->wait_q);
+	struct k_thread *thread;
 
-	sys_trace_void(SYS_TRACE_ID_SEMA_GIVE);
+	sys_trace_semaphore_give(sem);
+	thread = z_unpend_first_thread(&sem->wait_q);
 
 	if (thread != NULL) {
 		arch_thread_return_value_set(thread, 0);
@@ -119,8 +120,8 @@ void z_impl_k_sem_give(struct k_sem *sem)
 		handle_poll_events(sem);
 	}
 
-	sys_trace_end_call(SYS_TRACE_ID_SEMA_GIVE);
 	z_reschedule(&lock, key);
+	sys_trace_end_call(SYS_TRACE_ID_SEMA_GIVE);
 }
 
 #ifdef CONFIG_USERSPACE
@@ -139,8 +140,8 @@ int z_impl_k_sem_take(struct k_sem *sem, k_timeout_t timeout)
 	__ASSERT(((arch_is_in_isr() == false) ||
 		  K_TIMEOUT_EQ(timeout, K_NO_WAIT)), "");
 
-	sys_trace_void(SYS_TRACE_ID_SEMA_TAKE);
 	k_spinlock_key_t key = k_spin_lock(&lock);
+	sys_trace_semaphore_take(sem);
 
 	if (likely(sem->count > 0U)) {
 		sem->count--;

--- a/samples/subsys/tracing/src/tracing_string_format_test.c
+++ b/samples/subsys/tracing/src/tracing_string_format_test.c
@@ -92,3 +92,33 @@ void sys_trace_end_call(unsigned int id)
 {
 	TRACING_STRING("%s %d\n", __func__, __LINE__);
 }
+
+void sys_trace_semaphore_init(struct k_sem *sem)
+{
+	TRACING_STRING("%s %d\n", __func__, __LINE__);
+}
+
+void sys_trace_semaphore_take(struct k_sem *sem)
+{
+	TRACING_STRING("%s %d\n", __func__, __LINE__);
+}
+
+void sys_trace_semaphore_give(struct k_sem *sem)
+{
+	TRACING_STRING("%s %d\n", __func__, __LINE__);
+}
+
+void sys_trace_mutex_init(struct k_mutex *mutex)
+{
+	TRACING_STRING("%s %d\n", __func__, __LINE__);
+}
+
+void sys_trace_mutex_lock(struct k_mutex *mutex)
+{
+	TRACING_STRING("%s %d\n", __func__, __LINE__);
+}
+
+void sys_trace_mutex_unlock(struct k_mutex *mutex)
+{
+	TRACING_STRING("%s %d\n", __func__, __LINE__);
+}

--- a/scripts/tracing/parse_ctf.py
+++ b/scripts/tracing/parse_ctf.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2020 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Script to parse CTF data and print to the screen in a custom and colorful
+format.
+
+Generate trace using samples/subsys/tracing for example:
+
+    west build -b qemu_x86 samples/subsys/tracing  -t run \
+      -- -DCONF_FILE=prj_uart_ctf.conf
+
+    mkdir ctf
+    cp build/channel0_0 ctf/
+    cp subsys/tracing/ctf/tsdl/metadata ctf/
+    ./scripts/tracing/parse_ctf.py -t ctf
+"""
+
+import sys
+import datetime
+from colorama import Fore
+import argparse
+try:
+    import bt2
+except ImportError:
+    sys.exit("Missing dependency: You need to install python bindings of babletrace.")
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+            description=__doc__,
+            formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("-t", "--trace",
+            required=True,
+            help="tracing data (directory with metadata and trace file)")
+    args = parser.parse_args()
+    return args
+
+def main():
+    args = parse_args()
+
+    msg_it = bt2.TraceCollectionMessageIterator(args.trace)
+    last_event_ns_from_origin = None
+    timeline = []
+
+    def get_thread(name):
+        for t in timeline:
+            if t.get('name', None) == name and t.get('in', 0 ) != 0 and not t.get('out', None):
+                return t
+        return {}
+
+    for msg in msg_it:
+
+        if not isinstance(msg, bt2._EventMessageConst):
+            continue
+
+        ns_from_origin = msg.default_clock_snapshot.ns_from_origin
+        event = msg.event
+        # Compute the time difference since the last event message.
+        diff_s = 0
+
+        if last_event_ns_from_origin is not None:
+            diff_s = (ns_from_origin - last_event_ns_from_origin) / 1e9
+
+        dt = datetime.datetime.fromtimestamp(ns_from_origin / 1e9)
+
+        if event.name in [
+                'thread_switched_out',
+                'thread_switched_in',
+                'thread_pending',
+                'thread_ready',
+                'thread_resume',
+                'thread_suspend',
+                'thread_create',
+                'thread_abort'
+                ]:
+
+            cpu = event.payload_field.get("cpu", None)
+            thread_id = event.payload_field.get("thread_id", None)
+            thread_name = event.payload_field.get("name", None)
+
+            th = {}
+            if event.name in ['thread_switched_out', 'thread_switched_in'] and cpu is not None:
+                cpu_string = f"(cpu: {cpu})"
+            else:
+                cpu_string = ""
+
+            if thread_name:
+                print(f"{dt} (+{diff_s:.6f} s): {event.name}: {thread_name} {cpu_string}")
+            elif thread_id:
+                print(f"{dt} (+{diff_s:.6f} s): {event.name}: {thread_id} {cpu_string}")
+            else:
+                print(f"{dt} (+{diff_s:.6f} s): {event.name}")
+
+            if event.name in ['thread_switched_out', 'thread_switched_in']:
+                if thread_name:
+                    th = get_thread(thread_name)
+                    if not th:
+                        th['name'] = thread_name
+                else:
+                    th = get_thread(thread_id)
+                    if not th:
+                        th['name'] = thread_id
+
+                if event.name in ['thread_switched_out']:
+                    th['out'] = ns_from_origin
+                    tin = th.get('in', None)
+                    tout = th.get('out', None)
+                    if tout is not None and tin is not None:
+                        diff = (tout - tin)
+                        th['runtime'] = diff
+                elif event.name in ['thread_switched_in']:
+                    th['in'] = ns_from_origin
+
+                    timeline.append(th)
+
+        elif event.name in ['thread_info']:
+            stack_size = event.payload_field['stack_size']
+            print(f"{dt} (+{diff_s:.6f} s): {event.name} (Stack size: {stack_size})")
+        elif event.name in ['start_call', 'end_call']:
+            if event.payload_field['id'] == 39:
+                c = Fore.GREEN
+            elif event.payload_field['id'] in [37, 38]:
+                c = Fore.CYAN
+            else:
+                c = Fore.YELLOW
+            print(c + f"{dt} (+{diff_s:.6f} s): {event.name} {event.payload_field['id']}" + Fore.RESET)
+        elif event.name in ['semaphore_init', 'semaphore_take', 'semaphore_give']:
+            c = Fore.CYAN
+            print(c + f"{dt} (+{diff_s:.6f} s): {event.name} ({event.payload_field['id']})" + Fore.RESET)
+        elif event.name in ['mutex_init', 'mutex_take', 'mutex_give']:
+            c = Fore.MAGENTA
+            print(c + f"{dt} (+{diff_s:.6f} s): {event.name} ({event.payload_field['id']})" + Fore.RESET)
+
+        else:
+            print(f"{dt} (+{diff_s:.6f} s): {event.name}")
+
+        last_event_ns_from_origin = ns_from_origin
+
+if __name__=="__main__":
+    main()

--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -145,7 +145,7 @@ choice
 config TRACING_BACKEND_UART
 	bool "Enable UART backend"
 	depends on UART_CONSOLE
-	depends on TRACING_ASYNC
+
 	help
 	  Use UART to output tracing data.
 

--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -168,6 +168,48 @@ void sys_trace_void(unsigned int id)
 	ctf_top_void(id);
 }
 
+void sys_trace_semaphore_init(struct k_sem *sem)
+{
+	ctf_top_semaphore_init(
+		(uint32_t)(uintptr_t)sem
+		);
+}
+
+void sys_trace_semaphore_take(struct k_sem *sem)
+{
+	ctf_top_semaphore_take(
+		(uint32_t)(uintptr_t)sem
+		);
+}
+
+void sys_trace_semaphore_give(struct k_sem *sem)
+{
+	ctf_top_semaphore_give(
+		(uint32_t)(uintptr_t)sem
+		);
+}
+
+void sys_trace_mutex_init(struct k_mutex *mutex)
+{
+	ctf_top_mutex_init(
+		(uint32_t)(uintptr_t)mutex
+		);
+}
+
+void sys_trace_mutex_lock(struct k_mutex *mutex)
+{
+	ctf_top_mutex_lock(
+		(uint32_t)(uintptr_t)mutex
+		);
+}
+
+void sys_trace_mutex_unlock(struct k_mutex *mutex)
+{
+	ctf_top_mutex_unlock(
+		(uint32_t)(uintptr_t)mutex
+		);
+}
+
 void sys_trace_end_call(unsigned int id)
 {
 	ctf_top_end_call(id);

--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -9,40 +9,55 @@
 #include <kernel_internal.h>
 #include <ctf_top.h>
 
+
+static void _get_thread_name(struct k_thread *thread,
+			     ctf_bounded_string_t *name)
+{
+	const char *tname = k_thread_name_get(thread);
+
+	if (tname != NULL && tname[0] != '\0') {
+		strncpy(name->buf, tname, sizeof(name->buf));
+		/* strncpy may not always null-terminate */
+		name->buf[sizeof(name->buf) - 1] = 0;
+	}
+}
+
 void sys_trace_thread_switched_out(void)
 {
-	struct k_thread *thread = k_current_get();
+	ctf_bounded_string_t name = { "" };
+	struct k_thread *thread;
 
-	ctf_top_thread_switched_out((uint32_t)(uintptr_t)thread);
+	thread = k_current_get();
+	_get_thread_name(thread, &name);
+
+	ctf_top_thread_switched_out((uint32_t)(uintptr_t)thread, name);
 }
 
 void sys_trace_thread_switched_in(void)
 {
-	struct k_thread *thread = k_current_get();
+	struct k_thread *thread;
+	ctf_bounded_string_t name = { "" };
 
-	ctf_top_thread_switched_in((uint32_t)(uintptr_t)thread);
+	thread = k_current_get();
+	_get_thread_name(thread, &name);
+
+	ctf_top_thread_switched_in((uint32_t)(uintptr_t)thread, name);
 }
 
 void sys_trace_thread_priority_set(struct k_thread *thread)
 {
+	ctf_bounded_string_t name = { "" };
+
+	_get_thread_name(thread, &name);
 	ctf_top_thread_priority_set((uint32_t)(uintptr_t)thread,
-				    thread->base.prio);
+				    thread->base.prio, name);
 }
 
 void sys_trace_thread_create(struct k_thread *thread)
 {
-	ctf_bounded_string_t name = { "Unnamed thread" };
+	ctf_bounded_string_t name = { "" };
 
-#if defined(CONFIG_THREAD_NAME)
-	const char *tname = k_thread_name_get(thread);
-
-	if (tname != NULL) {
-		strncpy(name.buf, tname, sizeof(name.buf));
-		/* strncpy may not always null-terminate */
-		name.buf[sizeof(name.buf) - 1] = 0;
-	}
-#endif
-
+	_get_thread_name(thread, &name);
 	ctf_top_thread_create(
 		(uint32_t)(uintptr_t)thread,
 		thread->base.prio,
@@ -52,6 +67,7 @@ void sys_trace_thread_create(struct k_thread *thread)
 #if defined(CONFIG_THREAD_STACK_INFO)
 	ctf_top_thread_info(
 		(uint32_t)(uintptr_t)thread,
+		name,
 		thread->stack_info.start,
 		thread->stack_info.size
 		);
@@ -60,34 +76,55 @@ void sys_trace_thread_create(struct k_thread *thread)
 
 void sys_trace_thread_abort(struct k_thread *thread)
 {
-	ctf_top_thread_abort((uint32_t)(uintptr_t)thread);
+	ctf_bounded_string_t name = { "" };
+
+	_get_thread_name(thread, &name);
+	ctf_top_thread_abort((uint32_t)(uintptr_t)thread, name);
 }
 
 void sys_trace_thread_suspend(struct k_thread *thread)
 {
-	ctf_top_thread_suspend((uint32_t)(uintptr_t)thread);
+	ctf_bounded_string_t name = { "" };
+
+	_get_thread_name(thread, &name);
+	ctf_top_thread_suspend((uint32_t)(uintptr_t)thread, name);
 }
 
 void sys_trace_thread_resume(struct k_thread *thread)
 {
-	ctf_top_thread_resume((uint32_t)(uintptr_t)thread);
+	ctf_bounded_string_t name = { "" };
+
+	_get_thread_name(thread, &name);
+
+	ctf_top_thread_resume((uint32_t)(uintptr_t)thread, name);
 }
 
 void sys_trace_thread_ready(struct k_thread *thread)
 {
-	ctf_top_thread_ready((uint32_t)(uintptr_t)thread);
+	ctf_bounded_string_t name = { "" };
+
+	_get_thread_name(thread, &name);
+
+	ctf_top_thread_ready((uint32_t)(uintptr_t)thread, name);
 }
 
 void sys_trace_thread_pend(struct k_thread *thread)
 {
-	ctf_top_thread_pend((uint32_t)(uintptr_t)thread);
+	ctf_bounded_string_t name = { "" };
+
+	_get_thread_name(thread, &name);
+	ctf_top_thread_pend((uint32_t)(uintptr_t)thread, name);
 }
 
 void sys_trace_thread_info(struct k_thread *thread)
 {
 #if defined(CONFIG_THREAD_STACK_INFO)
+	ctf_bounded_string_t name = { "" };
+
+	_get_thread_name(thread, &name);
 	ctf_top_thread_info(
 		(uint32_t)(uintptr_t)thread,
+		name,
 		thread->stack_info.start,
 		thread->stack_info.size
 		);
@@ -96,20 +133,14 @@ void sys_trace_thread_info(struct k_thread *thread)
 
 void sys_trace_thread_name_set(struct k_thread *thread)
 {
-#if defined(CONFIG_THREAD_NAME)
-	ctf_bounded_string_t name = { "Unnamed thread" };
-	const char *tname = k_thread_name_get(thread);
+	ctf_bounded_string_t name = { "" };
 
-	if (tname != NULL) {
-		strncpy(name.buf, tname, sizeof(name.buf));
-		/* strncpy may not always null-terminate */
-		name.buf[sizeof(name.buf) - 1] = 0;
-	}
+	_get_thread_name(thread, &name);
 	ctf_top_thread_name_set(
 		(uint32_t)(uintptr_t)thread,
 		name
 		);
-#endif
+
 }
 
 void sys_trace_isr_enter(void)

--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -93,27 +93,37 @@ typedef struct {
 } ctf_bounded_string_t;
 
 
-static inline void ctf_top_thread_switched_out(uint32_t thread_id)
+static inline void ctf_top_thread_switched_out(
+	uint32_t thread_id,
+	ctf_bounded_string_t name)
 {
 	CTF_EVENT(
 		CTF_LITERAL(uint8_t, CTF_EVENT_THREAD_SWITCHED_OUT),
-		thread_id
+		thread_id,
+		name
 		);
 }
 
-static inline void ctf_top_thread_switched_in(uint32_t thread_id)
+static inline void ctf_top_thread_switched_in(
+	uint32_t thread_id,
+	ctf_bounded_string_t name)
 {
 	CTF_EVENT(
 		CTF_LITERAL(uint8_t, CTF_EVENT_THREAD_SWITCHED_IN),
-		thread_id
+		thread_id,
+		name
 		);
 }
 
-static inline void ctf_top_thread_priority_set(uint32_t thread_id, int8_t prio)
+static inline void ctf_top_thread_priority_set(
+	uint32_t thread_id,
+	int8_t prio,
+	ctf_bounded_string_t name)
 {
 	CTF_EVENT(
 		CTF_LITERAL(uint8_t, CTF_EVENT_THREAD_PRIORITY_SET),
 		thread_id,
+		name,
 		prio
 		);
 }
@@ -131,48 +141,64 @@ static inline void ctf_top_thread_create(
 		);
 }
 
-static inline void ctf_top_thread_abort(uint32_t thread_id)
+static inline void ctf_top_thread_abort(
+	uint32_t thread_id,
+	ctf_bounded_string_t name)
 {
 	CTF_EVENT(
 		CTF_LITERAL(uint8_t, CTF_EVENT_THREAD_ABORT),
-		thread_id
+		thread_id,
+		name
 		);
 }
 
-static inline void ctf_top_thread_suspend(uint32_t thread_id)
+static inline void ctf_top_thread_suspend(
+	uint32_t thread_id,
+	ctf_bounded_string_t name)
 {
 	CTF_EVENT(
 		CTF_LITERAL(uint8_t, CTF_EVENT_THREAD_SUSPEND),
-		thread_id
+		thread_id,
+		name
 		);
 }
 
-static inline void ctf_top_thread_resume(uint32_t thread_id)
+static inline void ctf_top_thread_resume(
+	uint32_t thread_id,
+	ctf_bounded_string_t name)
 {
 	CTF_EVENT(
 		CTF_LITERAL(uint8_t, CTF_EVENT_THREAD_RESUME),
-		thread_id
+		thread_id,
+		name
 		);
 }
 
-static inline void ctf_top_thread_ready(uint32_t thread_id)
+static inline void ctf_top_thread_ready(
+	uint32_t thread_id,
+	ctf_bounded_string_t name)
 {
 	CTF_EVENT(
 		CTF_LITERAL(uint8_t, CTF_EVENT_THREAD_READY),
-		thread_id
+		thread_id,
+		name
 		);
 }
 
-static inline void ctf_top_thread_pend(uint32_t thread_id)
+static inline void ctf_top_thread_pend(
+	uint32_t thread_id,
+	ctf_bounded_string_t name)
 {
 	CTF_EVENT(
 		CTF_LITERAL(uint8_t, CTF_EVENT_THREAD_PENDING),
-		thread_id
+		thread_id,
+		name
 		);
 }
 
 static inline void ctf_top_thread_info(
 	uint32_t thread_id,
+	ctf_bounded_string_t name,
 	uint32_t stack_base,
 	uint32_t stack_size
 	)
@@ -180,6 +206,7 @@ static inline void ctf_top_thread_info(
 	CTF_EVENT(
 		CTF_LITERAL(uint8_t, CTF_EVENT_THREAD_INFO),
 		thread_id,
+		name,
 		stack_base,
 		stack_size
 		);

--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -44,7 +44,8 @@
 #ifdef CONFIG_TRACING_CTF_TIMESTAMP
 #define CTF_EVENT(...)							    \
 	{								    \
-		const uint32_t tstamp = k_cycle_get_32();			    \
+		const uint32_t tstamp = k_cyc_to_ns_floor64(		    \
+				k_cycle_get_32());			    \
 									    \
 		CTF_GATHER_FIELDS(tstamp, __VA_ARGS__)			    \
 	}

--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -84,7 +84,13 @@ typedef enum {
 	CTF_EVENT_ISR_EXIT_TO_SCHEDULER =  0x22,
 	CTF_EVENT_IDLE                  =  0x30,
 	CTF_EVENT_ID_START_CALL         =  0x41,
-	CTF_EVENT_ID_END_CALL           =  0x42
+	CTF_EVENT_ID_END_CALL           =  0x42,
+	CTF_EVENT_SEMAPHORE_INIT		=  0x43,
+	CTF_EVENT_SEMAPHORE_GIVE		=  0x44,
+	CTF_EVENT_SEMAPHORE_TAKE		=  0x45,
+	CTF_EVENT_MUTEX_INIT			=  0x46,
+	CTF_EVENT_MUTEX_LOCK			=  0x47,
+	CTF_EVENT_MUTEX_UNLOCK			=  0x48,
 } ctf_event_t;
 
 
@@ -265,6 +271,54 @@ static inline void ctf_top_end_call(uint32_t id)
 	CTF_EVENT(
 		CTF_LITERAL(uint8_t, CTF_EVENT_ID_END_CALL),
 		id
+		);
+}
+
+static inline void ctf_top_semaphore_init(uint32_t sem_id)
+{
+	CTF_EVENT(
+		CTF_LITERAL(uint8_t, CTF_EVENT_SEMAPHORE_INIT),
+		sem_id
+		);
+}
+
+static inline void ctf_top_semaphore_take(uint32_t sem_id)
+{
+	CTF_EVENT(
+		CTF_LITERAL(uint8_t, CTF_EVENT_SEMAPHORE_TAKE),
+		sem_id
+		);
+}
+
+static inline void ctf_top_semaphore_give(uint32_t sem_id)
+{
+	CTF_EVENT(
+		CTF_LITERAL(uint8_t, CTF_EVENT_SEMAPHORE_GIVE),
+		sem_id
+		);
+}
+
+static inline void ctf_top_mutex_init(uint32_t mutex_id)
+{
+	CTF_EVENT(
+		CTF_LITERAL(uint8_t, CTF_EVENT_MUTEX_INIT),
+		mutex_id
+		);
+}
+
+static inline void ctf_top_mutex_lock(uint32_t mutex_id)
+{
+	CTF_EVENT(
+		CTF_LITERAL(uint8_t, CTF_EVENT_MUTEX_LOCK),
+		mutex_id
+		);
+}
+
+static inline void ctf_top_mutex_unlock(uint32_t mutex_id)
+{
+	CTF_EVENT(
+		CTF_LITERAL(uint8_t, CTF_EVENT_MUTEX_UNLOCK),
+		mutex_id
 		);
 }
 

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -32,6 +32,12 @@ void sys_trace_isr_exit_to_scheduler(void);
 void sys_trace_idle(void);
 void sys_trace_void(unsigned int id);
 void sys_trace_end_call(unsigned int id);
+void sys_trace_semaphore_init(struct k_sem *sem);
+void sys_trace_semaphore_take(struct k_sem *sem);
+void sys_trace_semaphore_give(struct k_sem *sem);
+void sys_trace_mutex_init(struct k_mutex *mutex);
+void sys_trace_mutex_lock(struct k_mutex *mutex);
+void sys_trace_mutex_unlock(struct k_mutex *mutex);
 
 #ifdef __cplusplus
 }

--- a/subsys/tracing/ctf/tsdl/metadata
+++ b/subsys/tracing/ctf/tsdl/metadata
@@ -167,3 +167,51 @@ event {
 		call_id id;
 	};
 };
+
+event {
+	name = semaphore_init;
+	id = 0x43;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = semaphore_take;
+	id = 0x45;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = semaphore_give;
+	id = 0x44;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = mutex_init;
+	id = 0x46;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = mutex_lock;
+	id = 0x47;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = mutex_unlock;
+	id = 0x48;
+	fields := struct {
+		uint32_t id;
+	};
+};

--- a/subsys/tracing/ctf/tsdl/metadata
+++ b/subsys/tracing/ctf/tsdl/metadata
@@ -11,7 +11,8 @@ typealias enum : uint32_t {
 	MUTEX_LOCK = 35,
 	SEMA_INIT = 36,
 	SEMA_GIVE = 37,
-	SEMA_TAKE = 38
+	SEMA_TAKE = 38,
+	SLEEP = 39
 } := call_id;
 
 struct event_header {

--- a/subsys/tracing/ctf/tsdl/metadata
+++ b/subsys/tracing/ctf/tsdl/metadata
@@ -35,6 +35,7 @@ event {
 	id = 0x10;
 	fields := struct {
 		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
 	};
 };
 
@@ -43,6 +44,7 @@ event {
 	id = 0x11;
 	fields := struct {
 		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
 	};
 };
 
@@ -52,6 +54,7 @@ event {
 	fields := struct {
 		uint32_t thread_id;
 		int8_t prio;
+		ctf_bounded_string_t name[20];
 	};
 
 };
@@ -70,6 +73,7 @@ event {
 	id = 0x14;
 	fields := struct {
 		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
 	};
 };
 
@@ -78,6 +82,7 @@ event {
 	id = 0x15;
 	fields := struct {
 		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
 	};
 };
 
@@ -86,6 +91,7 @@ event {
 	id = 0x16;
 	fields := struct {
 		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
 	};
 };
 event {
@@ -93,6 +99,7 @@ event {
         id = 0x17;
         fields := struct {
                 uint32_t thread_id;
+				ctf_bounded_string_t name[20];
         };
 };
 
@@ -101,6 +108,7 @@ event {
 	id = 0x18;
 	fields := struct {
 		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
 	};
 };
 
@@ -109,6 +117,7 @@ event {
 	id = 0x19;
 	fields := struct {
 		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
 		uint32_t stack_base;
 		uint32_t stack_size;
 	};

--- a/subsys/tracing/include/tracing_cpu_stats.h
+++ b/subsys/tracing/include/tracing_cpu_stats.h
@@ -44,6 +44,12 @@ void cpu_stats_reset_counters(void);
 
 #define sys_trace_void(id)
 #define sys_trace_end_call(id)
+#define sys_trace_semaphore_init(sem)
+#define sys_trace_semaphore_take(sem)
+#define sys_trace_semaphore_give(sem)
+#define sys_trace_mutex_init(mutex)
+#define sys_trace_mutex_lock(mutex)
+#define sys_trace_mutex_unlock(mutex)
 
 #ifdef __cplusplus
 }

--- a/subsys/tracing/include/tracing_test.h
+++ b/subsys/tracing/include/tracing_test.h
@@ -31,7 +31,12 @@ void sys_trace_isr_exit_to_scheduler(void);
 void sys_trace_idle(void);
 void sys_trace_void(unsigned int id);
 void sys_trace_end_call(unsigned int id);
-
+void sys_trace_semaphore_init(struct k_sem *sem);
+void sys_trace_semaphore_take(struct k_sem *sem);
+void sys_trace_semaphore_give(struct k_sem *sem);
+void sys_trace_mutex_init(struct k_mutex *mutex);
+void sys_trace_mutex_lock(struct k_mutex *mutex);
+void sys_trace_mutex_unlock(struct k_mutex *mutex);
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/tracing/sysview/sysview.c
+++ b/subsys/tracing/sysview/sysview.c
@@ -62,6 +62,44 @@ void sys_trace_idle(void)
 	SEGGER_SYSVIEW_OnIdle();
 }
 
+
+void sys_trace_semaphore_init(struct k_sem *sem)
+{
+	SEGGER_SYSVIEW_RecordU32(
+		SYS_TRACE_ID_SEMA_INIT, (uint32_t)(uintptr_t)sem);
+}
+
+void sys_trace_semaphore_take(struct k_sem *sem)
+{
+	SEGGER_SYSVIEW_RecordU32(
+		SYS_TRACE_ID_SEMA_TAKE, (uint32_t)(uintptr_t)sem);
+}
+
+void sys_trace_semaphore_give(struct k_sem *sem)
+{
+	SEGGER_SYSVIEW_RecordU32(
+		SYS_TRACE_ID_SEMA_GIVE, (uint32_t)(uintptr_t)sem);
+}
+
+void sys_trace_mutex_init(struct k_mutex *mutex)
+{
+	SEGGER_SYSVIEW_RecordU32(
+		SYS_TRACE_ID_MUTEX_INIT, (uint32_t)(uintptr_t)mutex);
+}
+
+void sys_trace_mutex_lock(struct k_mutex *mutex)
+{
+	SEGGER_SYSVIEW_RecordU32(
+		SYS_TRACE_ID_MUTEX_LOCK, (uint32_t)(uintptr_t)mutex);
+}
+
+void sys_trace_mutex_unlock(struct k_mutex *mutex)
+{
+	SEGGER_SYSVIEW_RecordU32(
+		SYS_TRACE_ID_MUTEX_UNLOCK, (uint32_t)(uintptr_t)mutex);
+}
+
+
 static void send_task_list_cb(void)
 {
 	struct k_thread *thread;

--- a/subsys/tracing/sysview/tracing_sysview.h
+++ b/subsys/tracing/sysview/tracing_sysview.h
@@ -18,6 +18,12 @@ void sys_trace_isr_enter(void);
 void sys_trace_isr_exit(void);
 void sys_trace_isr_exit_to_scheduler(void);
 void sys_trace_idle(void);
+void sys_trace_semaphore_init(struct k_sem *sem);
+void sys_trace_semaphore_take(struct k_sem *sem);
+void sys_trace_semaphore_give(struct k_sem *sem);
+void sys_trace_mutex_init(struct k_mutex *mutex);
+void sys_trace_mutex_lock(struct k_mutex *mutex);
+void sys_trace_mutex_unlock(struct k_mutex *mutex);
 
 #define sys_trace_thread_priority_set(thread)
 


### PR DESCRIPTION
- Align all trace points for switching thread in/out on all architectures
- trace mutex/semaphore using dedicated calls
- ztest: set thread name
- trace k_sleep