### PR TITLE
net: l2: ppp: lcp: do not force STOPPED state after Adminitrative Close

### DIFF
--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -161,8 +161,6 @@ static void lcp_close(struct ppp_context *ctx, const uint8_t *reason)
 		ppp_change_phase(ctx, PPP_TERMINATE);
 	}
 
-	ppp_change_state(&ctx->lcp.fsm, PPP_STOPPED);
-
 	ppp_fsm_close(&ctx->lcp.fsm, reason);
 }
 


### PR DESCRIPTION
State Transition Table [1] specifies that Administrative Close should
result in CLOSING state. This is not respected in case of LCP, as
STOPPED state was forced in lcp_close().

Don't force going into STOPPED state in lcp_close() and rely on
ppp_fsm_close() to move to CLOSING state instead.

This patch fixes overall Adminitrative Close procedure and allows to
move back into fully operating PPP connection once again after
Adminitrative Open.

[1] https://tools.ietf.org/html/rfc1661#section-4.1

Tested with `pppd` **before** this patch:
```
[00:00:02.400,000] <dbg> net_l2_ppp.ppp_change_phase_debug: (sysworkq): [0x0013a600] phase RUNNING (4) => TERMINATE (5) (lcp_close():161)
[00:00:02.400,000] <dbg> net_l2_ppp.ppp_change_state_debug: (sysworkq): [LCP/0x0013a640] state OPENED (9) => STOPPED (3) (lcp_close():164)
[00:00:02.400,000] <dbg> net_l2_ppp.validate_state_transition: (sysworkq): Invalid state transition: OPENED (9) => STOPPED (3)
[00:00:02.400,000] <dbg> net_l2_ppp.ppp_fsm_close: (sysworkq): [LCP/0x0013a640] Current state STOPPED (3)
[00:00:02.400,000] <dbg> net_l2_ppp.ppp_change_state_debug: (sysworkq): [LCP/0x0013a640] state STOPPED (3) => CLOSED (2) (ppp_fsm_close():254)
```

**after** this patch:
```
[00:00:06.090,000] <dbg> net_l2_ppp.ppp_change_phase_debug: (sysworkq): [0x0013a600] phase RUNNING (4) => TERMINATE (5) (lcp_close():161)
[00:00:06.090,000] <dbg> net_l2_ppp.ppp_fsm_close: (sysworkq): [LCP/0x0013a640] Current state OPENED (9)
[00:00:06.090,000] <dbg> net_l2_ppp.ppp_fsm_lower_down: (sysworkq): [IPCP/0x0013a704] Current state OPENED (9)
[00:00:06.090,000] <dbg> net_l2_ppp.ppp_change_state_debug: (sysworkq): [IPCP/0x0013a704] state OPENED (9) => STARTING (1) (ppp_fsm_lower_down():292)
[00:00:06.090,000] <dbg> net_l2_ppp.ppp_network_down: (sysworkq): [0x0013a600] Proto IPv4 (0x0021) down (1)
[00:00:06.090,000] <dbg> net_l2_ppp.ppp_fsm_close: (sysworkq): [IPCP/0x0013a704] Current state STARTING (1)
[00:00:06.090,000] <dbg> net_l2_ppp.ppp_change_state_debug: (sysworkq): [IPCP/0x0013a704] state STARTING (1) => INITIAL (0) (ppp_fsm_close():250)
[00:00:06.090,000] <dbg> net_l2_ppp.ppp_fsm_lower_down: (sysworkq): [IPV6CP/0x0013a7d0] Current state OPENED (9)
[00:00:06.090,000] <dbg> net_l2_ppp.ppp_change_state_debug: (sysworkq): [IPV6CP/0x0013a7d0] state OPENED (9) => STARTING (1) (ppp_fsm_lower_down():292)
[00:00:06.090,000] <dbg> net_l2_ppp.ppp_network_down: (sysworkq): [0x0013a600] Proto IPv6 (0x0057) down (0)
[00:00:06.090,000] <dbg> net_l2_ppp.ipv6cp_down: (sysworkq): [IPV6CP/0x0013a7d0] Peer fe80::110f:8558:cefa:7c85 [11:0F:85:58:CE:FA:7C:85] removed from nbr cache
[00:00:06.090,000] <dbg> net_l2_ppp.ppp_fsm_close: (sysworkq): [IPV6CP/0x0013a7d0] Current state STARTING (1)
[00:00:06.090,000] <dbg> net_l2_ppp.ppp_change_state_debug: (sysworkq): [IPV6CP/0x0013a7d0] state STARTING (1) => INITIAL (0) (ppp_fsm_close():250)
[00:00:06.090,000] <dbg> net_l2_ppp.ppp_fsm_lower_down: (sysworkq): [PAP/0x0013a88c] Current state OPENED (9)
[00:00:06.090,000] <dbg> net_l2_ppp.ppp_change_state_debug: (sysworkq): [PAP/0x0013a88c] state OPENED (9) => STARTING (1) (ppp_fsm_lower_down():292)
[00:00:06.090,000] <dbg> net_l2_ppp.ppp_change_phase_debug: (sysworkq): [0x0013a600] phase TERMINATE (5) => DEAD (0) (ppp_link_down():138)
[00:00:06.090,000] <dbg> net_l2_ppp.ppp_change_phase_debug: (sysworkq): [0x0013a600] phase DEAD (0) => ESTABLISH (1) (lcp_down():177)
[00:00:06.090,000] <dbg> net_l2_ppp.ppp_send_pkt: (sysworkq): [LCP/0x0013a640] Sending 6 bytes pkt 0x0024a198 (options len 20)
[00:00:06.090,000] <dbg> net_l2_ppp.ppp_change_state_debug: (sysworkq): [LCP/0x0013a640] state OPENED (9) => CLOSING (4) (terminate():225)
[00:00:06.100,000] <dbg> net_l2_ppp.ppp_fsm_input: (rx_workq): [LCP/0x0013a640] LCP Terminate-Ack (6) id 2 payload len 0
[00:00:06.100,000] <dbg> net_l2_ppp.fsm_recv_terminate_ack: (rx_workq): [LCP/0x0013a640] Current state CLOSING (4)
[00:00:06.100,000] <dbg> net_l2_ppp.ppp_change_state_debug: (rx_workq): [LCP/0x0013a640] state CLOSING (4) => CLOSED (2) (fsm_recv_terminate_ack():938)
[00:00:06.100,000] <dbg> net_l2_ppp.ppp_change_phase_debug: (rx_workq): [0x0013a600] phase ESTABLISH (1) => DEAD (0) (ppp_link_terminated():123)
[00:00:06.100,000] <dbg> net_l2_ppp.ppp_link_terminated: (rx_workq): [0x0013a600] Link terminated
```