### PR TITLE
net: l2: ppp: don't move back to NETWORK state when link goes down

### DIFF
--- a/subsys/net/l2/ppp/link.c
+++ b/subsys/net/l2/ppp/link.c
@@ -131,8 +131,6 @@ void ppp_link_down(struct ppp_context *ctx)
 		return;
 	}
 
-	ppp_change_phase(ctx, PPP_NETWORK);
-
 	ppp_network_all_down(ctx);
 
 	ppp_change_phase(ctx, PPP_DEAD);


### PR DESCRIPTION
PPP Phase Diagram [1] allows only one way phase change. In current
implementation there is an additional RUNNING phase, which is entered
just after NETWORK phase.

Prevent going back from RUNNING to NETWORK phase when Term-Req was
received, as this is meaningless for overall PPP operation and violates
PPP Phase Diagram property of having one way direction change.

This change also improves Adminitrative Close handling (calling
lcp_close()). This request results in moving into TERMINATE phase. Then
LCP is put down (by calling lcp_down()) and then ppp_link_down() is
called, which so far (before this patch) resulted in moving back to
NETWORK and then to DEAD. Right now (after this patch) we move directly
from TERMINATE to DEAD phase, which is exactly how [1] specifies it.

[1] https://tools.ietf.org/html/rfc1661#section-3.2