### PR TITLE
drivers: espi: xec: Fix unintended eSPI frequency override whenever default IO mode is changed

### DIFF
--- a/drivers/espi/espi_mchp_xec.c
+++ b/drivers/espi/espi_mchp_xec.c
@@ -241,8 +241,8 @@ static int espi_xec_configure(struct device *dev, struct espi_cfg *cfg)
 	}
 
 	if (iomode != cur_iomode) {
-		cap1 &= ~MCHP_ESPI_GBL_CAP1_IO_MODE_MASK0 <<
-			MCHP_ESPI_GBL_CAP1_IO_MODE_POS;
+		cap1 &= ~(MCHP_ESPI_GBL_CAP1_IO_MODE_MASK0 <<
+			MCHP_ESPI_GBL_CAP1_IO_MODE_POS);
 		cap1 |= (iomode << MCHP_ESPI_GBL_CAP1_IO_MODE_POS);
 	}
 

--- a/samples/drivers/espi/src/main.c
+++ b/samples/drivers/espi/src/main.c
@@ -31,8 +31,9 @@ LOG_MODULE_DECLARE(espi, CONFIG_ESPI_LOG_LEVEL);
 #define MAX_FLASH_REQUEST     64u
 #define TARGET_FLASH_REGION   0x72000ul
 
-/* 20 MHz */
-#define MIN_ESPI_FREQ         20u
+#define ESPI_FREQ_20MHZ       20u
+#define ESPI_FREQ_25MHZ       25u
+#define ESPI_FREQ_66MHZ       66u
 
 #define K_WAIT_DELAY          100u
 
@@ -191,9 +192,9 @@ int espi_init(void)
 	 * 20MHz frequency and only logical channel 0 and 1 are supported
 	 */
 	struct espi_cfg cfg = {
-		ESPI_IO_MODE_SINGLE_LINE,
-		ESPI_CHANNEL_VWIRE | ESPI_CHANNEL_PERIPHERAL,
-		MIN_ESPI_FREQ,
+		.io_caps = ESPI_IO_MODE_SINGLE_LINE,
+		.channel_caps = ESPI_CHANNEL_VWIRE | ESPI_CHANNEL_PERIPHERAL,
+		.max_freq = ESPI_FREQ_20MHZ,
 	};
 
 	/* If eSPI driver supports additional capabilities use them */
@@ -202,6 +203,8 @@ int espi_init(void)
 #endif
 #ifdef CONFIG_ESPI_FLASH_CHANNEL
 	cfg.channel_caps |= ESPI_CHANNEL_FLASH;
+	cfg.io_caps |= ESPI_IO_MODE_QUAD_LINES;
+	cfg.max_freq = ESPI_FREQ_25MHZ;
 #endif
 
 	ret = espi_config(espi_dev, &cfg);


### PR DESCRIPTION
Default eSPI frequency 20MHz is used whenever Quad IO mode is advertised.
This due to incorrect register update whenever IO mode is different than default.

Update sample code to use valid non-default eSPI frequency such as 25MHz

![image](https://user-images.githubusercontent.com/16172078/90938052-ff9c1f80-e3bc-11ea-90e7-adb09cfb8c72.png)




