### PR TITLE
samples: mgmt: updatehub: Fix gen privkey inc

### DIFF
--- a/samples/subsys/mgmt/updatehub/CMakeLists.txt
+++ b/samples/subsys/mgmt/updatehub/CMakeLists.txt
@@ -13,6 +13,8 @@ project(updatehub)
 target_sources(app PRIVATE src/main.c)
 
 if(CONFIG_UPDATEHUB_DTLS)
+    set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated/)
+
     foreach(inc_file
             servercert.der
             privkey.der

--- a/samples/subsys/mgmt/updatehub/sample.yaml
+++ b/samples/subsys/mgmt/updatehub/sample.yaml
@@ -1,13 +1,21 @@
 sample:
   description: UpdateHub enterprise-grade Firmware Over-the-Air (FOTA)
   name: UpdateHub
+common:
+  harness: net
+  tags: net wifi updatehub
+  depends_on: netif
+  build_only: true
+  platform_whitelist: frdm_k64f
 tests:
   sample.net.updatehub:
-    harness: net
-    tags: net wifi
-    depends_on: netif
-    build_only: true
-    platform_whitelist: frdm_k64f sam_v71_xult
+    extra_configs:
+      - CONFIG_UPDATEHUB_PRODUCT_UID="e4d37cfe6ec48a2d069cc0bbb8b078677e9a0d8df3a027c4d8ea131130c4265f"
+      - CONFIG_UPDATEHUB_POLL_INTERVAL=1
+      - CONFIG_UPDATEHUB_CE=y
+      - CONFIG_UPDATEHUB_SERVER="10.5.3.67"
+  sample.net.updatehub.dtls:
+    extra_args: OVERLAY_CONFIG="overlay-dtls.conf"
     extra_configs:
       - CONFIG_UPDATEHUB_PRODUCT_UID="e4d37cfe6ec48a2d069cc0bbb8b078677e9a0d8df3a027c4d8ea131130c4265f"
       - CONFIG_UPDATEHUB_POLL_INTERVAL=1


### PR DESCRIPTION
When try build updatehub using overlay-dtls.conf system fail with cannot create privkey.der.inc file, permission denied.  Add missing gen_dir cmake definition. Update updatehub sample test config to run missing dtls build test.

Signed-off-by: Gerson Fernando Budke <gerson.budke@ossystems.com.br>