### PR TITLE
UART RTT devicetree & async support

### DIFF
--- a/drivers/serial/Kconfig.rtt
+++ b/drivers/serial/Kconfig.rtt
@@ -11,8 +11,11 @@ menuconfig UART_RTT
 
 if UART_RTT
 
+# Workaround for not being able to have commas in macro arguments
+DT_COMPAT_SEGGER_RTT_UART  := segger,rtt-uart
+
 config UART_RTT_0
-	bool "Enable UART on RTT channel 0"
+	def_bool $(dt_nodelabel_has_compat,rtt0,$(DT_COMPAT_SEGGER_RTT_UART))
 	depends on SEGGER_RTT_MAX_NUM_UP_BUFFERS >= 1 && SEGGER_RTT_MAX_NUM_DOWN_BUFFERS >= 1
 	depends on SEGGER_RTT_MODE_NO_BLOCK_SKIP
 	select SERIAL_HAS_DRIVER
@@ -21,82 +24,28 @@ config UART_RTT_0
 	  Enable UART on (default) RTT channel 0. Default channel has to be configured in non-blocking skip mode.
 
 config UART_RTT_1
-	bool "Enable UART on RTT channel 1"
+	def_bool $(dt_nodelabel_has_compat,rtt1,$(DT_COMPAT_SEGGER_RTT_UART))
 	depends on SEGGER_RTT_MAX_NUM_UP_BUFFERS >= 2 && SEGGER_RTT_MAX_NUM_DOWN_BUFFERS >= 2
 	select SERIAL_HAS_DRIVER
 	select UART_RTT_DRIVER
 	help
 	  Enable UART on RTT channel 1
 
-if UART_RTT_1
-
-config UART_RTT_1_TX_BUFFER_SIZE
-	int "Size of RTT_1 TX buffer (up to host)"
-	range 1 65535
-	default 1024
-	help
-	  Size of the RTT up buffer for UART 1 transmission.
-
-config UART_RTT_1_RX_BUFFER_SIZE
-	int "Size of RTT_1 RX buffer (down from host)"
-	range 1 65535
-	default 16
-	help
-	  Size of the RTT down buffer for UART 1 reception.
-
-endif
-
 config UART_RTT_2
-	bool "Enable UART on RTT channel 2"
+	def_bool $(dt_nodelabel_has_compat,rtt2,$(DT_COMPAT_SEGGER_RTT_UART))
 	depends on SEGGER_RTT_MAX_NUM_UP_BUFFERS >= 3 && SEGGER_RTT_MAX_NUM_DOWN_BUFFERS >= 3
 	select SERIAL_HAS_DRIVER
 	select UART_RTT_DRIVER
 	help
 	  Enable UART on RTT channel 2
 
-if UART_RTT_2
-
-config UART_RTT_2_TX_BUFFER_SIZE
-	int "Size of RTT_2 TX buffer (up to host)"
-	range 1 65535
-	default 1024
-	help
-	  Size of the RTT up buffer for UART 2 transmission.
-
-config UART_RTT_2_RX_BUFFER_SIZE
-	int "Size of RTT_2 RX buffer (down from host)"
-	range 1 65535
-	default 16
-	help
-	  Size of the RTT down buffer for UART 2 reception.
-
-endif
-
 config UART_RTT_3
-	bool "Enable UART on RTT channel 3"
+	def_bool $(dt_nodelabel_has_compat,rtt3,$(DT_COMPAT_SEGGER_RTT_UART))
 	depends on SEGGER_RTT_MAX_NUM_UP_BUFFERS >= 4 && SEGGER_RTT_MAX_NUM_DOWN_BUFFERS >= 4
 	select SERIAL_HAS_DRIVER
 	select UART_RTT_DRIVER
 	help
 	  Enable UART on RTT channel 3
-
-if UART_RTT_3
-
-config UART_RTT_3_TX_BUFFER_SIZE
-	int "Size of RTT_3 TX buffer (up to host)"
-	range 1 65535
-	default 1024
-	help
-	  Size of the RTT up buffer for UART 3 transmission.
-
-config UART_RTT_3_RX_BUFFER_SIZE
-	int "Size of RTT_3 RX buffer (down from host)"
-	range 1 65535
-	default 16
-	help
-	  Size of the RTT down buffer for UART 3 reception.
-
-endif
 
 config UART_RTT_DRIVER
 	bool

--- a/dts/bindings/serial/segger,rtt-uart.yaml
+++ b/dts/bindings/serial/segger,rtt-uart.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2020, CSIRO.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Segger RTT UART
+
+compatible: "segger,rtt-uart"
+
+include: uart-controller.yaml
+
+properties:
+    tx-buffer-size:
+      type: int
+      default: 1024
+      description: |
+        Size of the RTT up buffer for transmission
+        Not used for RTT channel 0 as channel 0 is initialized at compile time,
+        see SEGGER_RTT_BUFFER_SIZE_UP.
+      required: false
+
+    rx-buffer-size:
+      type: int
+      default: 16
+      description: |
+        Size of the RTT down buffer for reception
+        Not used for RTT channel 0 as channel 0 is initialized at compile time,
+        see SEGGER_RTT_BUFFER_SIZE_DOWN.
+      required: false

--- a/tests/drivers/uart/uart_async_api/boards/segger_rtt.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/segger_rtt.overlay
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/ {
+	chosen {
+		zephyr,console = &rtt0;
+	};
+
+	rtt0: rtt_chan0 {
+		compatible = "segger,rtt-uart";
+		label = "rtt_chan0";
+		status = "okay";
+	};
+
+	rtt1: rtt_chan1 {
+		compatible = "segger,rtt-uart";
+		label = "rtt_chan1";
+		status = "okay";
+	};
+
+	rtt2: rtt_chan2 {
+		compatible = "segger,rtt-uart";
+		label = "rtt_chan2";
+		status = "okay";
+	};
+
+	rtt3: rtt_chan3 {
+		compatible = "segger,rtt-uart";
+		label = "rtt_chan3";
+		status = "okay";
+	};
+};

--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -3,3 +3,11 @@ tests:
     tags: drivers
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_ASYNC
     harness: keyboard
+  drivers.uart.uart_async_api.rtt:
+    tags: drivers
+    filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_HAS_SEGGER_RTT
+    extra_args: DTC_OVERLAY_FILE=boards/segger_rtt.overlay
+    extra_configs:
+      - CONFIG_USE_SEGGER_RTT=y
+      - CONFIG_UART_RTT=y
+    build_only: true


### PR DESCRIPTION
Switches instantiation of the `uart_rtt` driver from Kconfig symbols to devicetree nodes.
Adds `CONFIG_UART_ASYNC_API` support to the driver, which eliminates hard faults when the RTT backend is used with async functions. Because asynchronous reception is not possible, only the TX path is implemented.

There are no in tree users of the previous `CONFIG_UART_RTT_*` symbols, so there are no tests validating the new behavior. The commit message contains an example of the devicetree nodes required to instantiate driver instances.