### PR TITLE
samples: jesd216: minor cleanup

### DIFF
--- a/samples/drivers/jesd216/README.rst
+++ b/samples/drivers/jesd216/README.rst
@@ -28,7 +28,7 @@ Sample Output
 
 .. code-block:: console
 
-   MX25R8035F: SFDP v 1.6 AP ff with 2 PH
+   MX25R8035F: SFDP v 1.6 AP ff with 3 PH
    PH0: ff00 rev 1.6: 16 DW @ 30
    Summary of BFP content:
    DTR Clocking not supported
@@ -44,7 +44,7 @@ Sample Output
    ET1: instr 20h for 4096 By; typ 48 ms, max 384 ms
    ET2: instr 52h for 32768 By; typ 240 ms, max 1920 ms
    ET3: instr D8h for 65536 By; typ 480 ms, max 3840 ms
-   Chip erase: typ 5120 ms, max 30720 ms
+   Chip erase: typ 6144 ms, max 36864 ms
    Byte program: type 32 + 1 * B us, max 192 + 6 * B us
    Page program: typ 896 us, max 5376 us
    Page size: 256 By
@@ -60,5 +60,9 @@ Sample Output
    PH1: ffc2 rev 1.0: 4 DW @ 110
    sfdp-ffc2 = [
            00 36 50 16  9d f9 c0 64  fe cf ff ff  ff ff ff ff
+           ];
+   PH2: ff84 rev 1.0: 2 DW @ c0
+   sfdp-ff84 = [
+           00 00 f0 ff  ff ff ff ff
            ];
    jedec-id = [c2 28 14];

--- a/samples/drivers/jesd216/src/main.c
+++ b/samples/drivers/jesd216/src/main.c
@@ -259,7 +259,7 @@ void main(void)
 		uint32_t addr = jesd216_param_addr(php);
 
 		printf("PH%u: %04x rev %u.%u: %u DW @ %x\n",
-		       (php - hp->phdr), id, php->rev_major, php->rev_minor,
+		       (uint32_t)(php - hp->phdr), id, php->rev_major, php->rev_minor,
 		       php->len_dw, addr);
 
 		uint32_t dw[php->len_dw];


### PR DESCRIPTION
Fix a Coverity issue  and update the sample to demonstrate the output after a recent fix.

No, I don't know why the chip erase time changed: my best guess is the captured output was not updated after the calculation code was fixed before the feature was merged.

Closes #27643