### PR TITLE
net: includes: Fix indentation in header files

### DIFF
--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -119,7 +119,7 @@ struct net_buf_simple {
 #define NET_BUF_SIMPLE(_size)                        \
 	((struct net_buf_simple *)(&(struct {        \
 		struct net_buf_simple buf;           \
-		uint8_t data[_size];                    \
+		uint8_t data[_size];                 \
 	}) {                                         \
 		.buf.size = _size,                   \
 	}))
@@ -790,7 +790,8 @@ struct net_buf {
 };
 
 struct net_buf_data_cb {
-	uint8_t * (*alloc)(struct net_buf *buf, size_t *size, k_timeout_t timeout);
+	uint8_t * (*alloc)(struct net_buf *buf, size_t *size,
+			   k_timeout_t timeout);
 	uint8_t * (*ref)(struct net_buf *buf, uint8_t *data);
 	void   (*unref)(struct net_buf *buf, uint8_t *data);
 };
@@ -840,7 +841,7 @@ struct net_buf_pool {
 #if defined(CONFIG_NET_BUF_POOL_USAGE)
 #define NET_BUF_POOL_INITIALIZER(_pool, _alloc, _bufs, _count, _destroy) \
 	{                                                                    \
-		.free = Z_LIFO_INITIALIZER(_pool.free),                     \
+		.free = Z_LIFO_INITIALIZER(_pool.free),                      \
 		.buf_count = _count,                                         \
 		.uninit_count = _count,                                      \
 		.avail_count = _count,                                       \
@@ -852,7 +853,7 @@ struct net_buf_pool {
 #else
 #define NET_BUF_POOL_INITIALIZER(_pool, _alloc, _bufs, _count, _destroy)     \
 	{                                                                    \
-		.free = Z_LIFO_INITIALIZER(_pool.free),                     \
+		.free = Z_LIFO_INITIALIZER(_pool.free),                      \
 		.buf_count = _count,                                         \
 		.uninit_count = _count,                                      \
 		.destroy = _destroy,                                         \
@@ -935,10 +936,10 @@ extern const struct net_buf_data_cb net_buf_fixed_cb;
  */
 #define NET_BUF_POOL_FIXED_DEFINE(_name, _count, _data_size, _destroy)        \
 	static struct net_buf net_buf_##_name[_count] __noinit;               \
-	static uint8_t __noinit net_buf_data_##_name[_count][_data_size];        \
+	static uint8_t __noinit net_buf_data_##_name[_count][_data_size];     \
 	static const struct net_buf_pool_fixed net_buf_fixed_##_name = {      \
 		.data_size = _data_size,                                      \
-		.data_pool = (uint8_t *)net_buf_data_##_name,                    \
+		.data_pool = (uint8_t *)net_buf_data_##_name,                 \
 	};                                                                    \
 	static const struct net_buf_data_alloc net_buf_fixed_alloc_##_name = {\
 		.cb = &net_buf_fixed_cb,                                      \

--- a/include/net/coap.h
+++ b/include/net/coap.h
@@ -313,7 +313,8 @@ uint16_t coap_header_get_id(const struct coap_packet *cpkt);
  * @return data pointer and length if payload exists
  *         NULL pointer and length set to 0 in case there is no payload
  */
-const uint8_t *coap_packet_get_payload(const struct coap_packet *cpkt, uint16_t *len);
+const uint8_t *coap_packet_get_payload(const struct coap_packet *cpkt,
+				       uint16_t *len);
 
 /**
  * @brief Parses the CoAP packet in data, validating it and

--- a/include/net/ethernet_mgmt.h
+++ b/include/net/ethernet_mgmt.h
@@ -184,7 +184,8 @@ static inline void ethernet_mgmt_raise_vlan_enabled_event(struct net_if *iface,
  * @param tag VLAN tag which is disabled.
  */
 #if defined(CONFIG_NET_L2_ETHERNET_MGMT)
-void ethernet_mgmt_raise_vlan_disabled_event(struct net_if *iface, uint16_t tag);
+void ethernet_mgmt_raise_vlan_disabled_event(struct net_if *iface,
+					     uint16_t tag);
 #else
 static inline void ethernet_mgmt_raise_vlan_disabled_event(struct net_if *iface,
 							   uint16_t tag)

--- a/include/net/lldp.h
+++ b/include/net/lldp.h
@@ -189,7 +189,8 @@ int net_lldp_config(struct net_if *iface, const struct net_lldpdu *lldpdu);
  *
  * @return 0 if ok, <0 if error
  */
-int net_lldp_config_optional(struct net_if *iface, const uint8_t *tlv, size_t len);
+int net_lldp_config_optional(struct net_if *iface, const uint8_t *tlv,
+			     size_t len);
 
 /**
  * @brief Initialize LLDP engine.

--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -134,7 +134,8 @@ struct lwm2m_ctx {
  * @return Callback returns a pointer to the data buffer or NULL for failure.
  */
 typedef void *(*lwm2m_engine_get_data_cb_t)(uint16_t obj_inst_id,
-					    uint16_t res_id, uint16_t res_inst_id,
+					    uint16_t res_id,
+					    uint16_t res_inst_id,
 					    size_t *data_len);
 
 /**
@@ -784,8 +785,8 @@ int lwm2m_engine_set_res_data(char *pathstr, void *data_ptr, uint16_t data_len,
  *
  * @return 0 for success or negative in case of error.
  */
-int lwm2m_engine_get_res_data(char *pathstr, void **data_ptr, uint16_t *data_len,
-			      uint8_t *data_flags);
+int lwm2m_engine_get_res_data(char *pathstr, void **data_ptr,
+			      uint16_t *data_len, uint8_t *data_flags);
 
 /**
  * @brief Create a resource instance

--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -716,8 +716,8 @@ static inline void net_if_stop_rs(struct net_if *iface)
  * @brief Set a network interface's link address
  *
  * @param iface Pointer to a network interface structure
- * @param addr A pointer to a uint8_t buffer representing the address. The buffer
- *             must remain valid throughout interface lifetime.
+ * @param addr A pointer to a uint8_t buffer representing the address.
+ *             The buffer must remain valid throughout interface lifetime.
  * @param len length of the address buffer
  * @param type network bearer type of this link address
  *

--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -166,14 +166,14 @@ typedef size_t socklen_t;
 /** Socket address struct for IPv6. */
 struct sockaddr_in6 {
 	sa_family_t		sin6_family;   /* AF_INET6               */
-	uint16_t			sin6_port;     /* Port number            */
+	uint16_t		sin6_port;     /* Port number            */
 	struct in6_addr		sin6_addr;     /* IPv6 address           */
 	uint8_t			sin6_scope_id; /* interfaces for a scope */
 };
 
 struct sockaddr_in6_ptr {
 	sa_family_t		sin6_family;   /* AF_INET6               */
-	uint16_t			sin6_port;     /* Port number            */
+	uint16_t		sin6_port;     /* Port number            */
 	struct in6_addr		*sin6_addr;    /* IPv6 address           */
 	uint8_t			sin6_scope_id; /* interfaces for a scope */
 };
@@ -181,35 +181,35 @@ struct sockaddr_in6_ptr {
 /** Socket address struct for IPv4. */
 struct sockaddr_in {
 	sa_family_t		sin_family;    /* AF_INET      */
-	uint16_t			sin_port;      /* Port number  */
+	uint16_t		sin_port;      /* Port number  */
 	struct in_addr		sin_addr;      /* IPv4 address */
 };
 
 struct sockaddr_in_ptr {
 	sa_family_t		sin_family;    /* AF_INET      */
-	uint16_t			sin_port;      /* Port number  */
+	uint16_t		sin_port;      /* Port number  */
 	struct in_addr		*sin_addr;     /* IPv4 address */
 };
 
 /** Socket address struct for packet socket. */
 struct sockaddr_ll {
 	sa_family_t sll_family;   /* Always AF_PACKET        */
-	uint16_t       sll_protocol; /* Physical-layer protocol */
+	uint16_t    sll_protocol; /* Physical-layer protocol */
 	int         sll_ifindex;  /* Interface number        */
-	uint16_t       sll_hatype;   /* ARP hardware type       */
-	uint8_t        sll_pkttype;  /* Packet type             */
-	uint8_t        sll_halen;    /* Length of address       */
-	uint8_t        sll_addr[8];  /* Physical-layer address  */
+	uint16_t    sll_hatype;   /* ARP hardware type       */
+	uint8_t     sll_pkttype;  /* Packet type             */
+	uint8_t     sll_halen;    /* Length of address       */
+	uint8_t     sll_addr[8];  /* Physical-layer address  */
 };
 
 struct sockaddr_ll_ptr {
 	sa_family_t sll_family;   /* Always AF_PACKET        */
-	uint16_t       sll_protocol; /* Physical-layer protocol */
+	uint16_t    sll_protocol; /* Physical-layer protocol */
 	int         sll_ifindex;  /* Interface number        */
-	uint16_t       sll_hatype;   /* ARP hardware type       */
-	uint8_t        sll_pkttype;  /* Packet type             */
-	uint8_t        sll_halen;    /* Length of address       */
-	uint8_t        *sll_addr;    /* Physical-layer address  */
+	uint16_t    sll_hatype;   /* ARP hardware type       */
+	uint8_t     sll_pkttype;  /* Packet type             */
+	uint8_t     sll_halen;    /* Length of address       */
+	uint8_t     *sll_addr;    /* Physical-layer address  */
 };
 
 struct sockaddr_can_ptr {
@@ -260,11 +260,11 @@ struct cmsghdr {
 #if !defined(CMSG_NXTHDR)
 #define CMSG_NXTHDR(msghdr, cmsg)					 \
 	(((cmsg) == NULL) ? CMSG_FIRSTHDR(msghdr) :			 \
-	 (((uint8_t *)(cmsg) + ALIGN_H((cmsg)->cmsg_len)	+		 \
+	 (((uint8_t *)(cmsg) + ALIGN_H((cmsg)->cmsg_len) +		 \
 	   ALIGN_D(sizeof(struct cmsghdr)) >				 \
 	   (uint8_t *)((msghdr)->msg_control) + (msghdr)->msg_controllen) ? \
 	  NULL :							 \
-	  (struct cmsghdr *)((uint8_t *)(cmsg) +				 \
+	  (struct cmsghdr *)((uint8_t *)(cmsg) +			 \
 			     ALIGN_H((cmsg)->cmsg_len))))
 #endif
 
@@ -415,8 +415,8 @@ enum net_priority {
 struct net_tuple {
 	struct net_addr *remote_addr;  /**< IPv6/IPv4 remote address */
 	struct net_addr *local_addr;   /**< IPv6/IPv4 local address  */
-	uint16_t remote_port;             /**< UDP/TCP remote port      */
-	uint16_t local_port;              /**< UDP/TCP local port       */
+	uint16_t remote_port;          /**< UDP/TCP remote port      */
+	uint16_t local_port;           /**< UDP/TCP local port       */
 	enum net_ip_protocol ip_proto; /**< IP protocol              */
 };
 

--- a/include/net/net_mgmt.h
+++ b/include/net/net_mgmt.h
@@ -221,7 +221,8 @@ void net_mgmt_del_event_callback(struct net_mgmt_event_callback *cb);
 void net_mgmt_event_notify_with_info(uint32_t mgmt_event, struct net_if *iface,
 				     void *info, size_t length);
 
-static inline void net_mgmt_event_notify(uint32_t mgmt_event, struct net_if *iface)
+static inline void net_mgmt_event_notify(uint32_t mgmt_event,
+					 struct net_if *iface)
 {
 	net_mgmt_event_notify_with_info(mgmt_event, iface, NULL, 0);
 }

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -184,9 +184,10 @@ struct net_pkt {
 	};
 
 #if defined(CONFIG_NET_TCP)
-	uint8_t tcp_first_msg     : 1; /* Is this the first time this pkt is sent,
-				     * or is this a resend of a TCP segment.
-				     */
+	uint8_t tcp_first_msg     : 1; /* Is this the first time this pkt is
+					* sent, or is this a resend of a TCP
+					* segment.
+					*/
 #endif
 
 	union {
@@ -478,7 +479,8 @@ static inline uint8_t net_pkt_ipv6_next_hdr(struct net_pkt *pkt)
 	return pkt->ipv6_next_hdr;
 }
 
-static inline void net_pkt_set_ipv6_next_hdr(struct net_pkt *pkt, uint8_t next_hdr)
+static inline void net_pkt_set_ipv6_next_hdr(struct net_pkt *pkt,
+					     uint8_t next_hdr)
 {
 	pkt->ipv6_next_hdr = next_hdr;
 }
@@ -536,7 +538,8 @@ static inline uint8_t net_pkt_ipv6_next_hdr(struct net_pkt *pkt)
 	return 0;
 }
 
-static inline void net_pkt_set_ipv6_next_hdr(struct net_pkt *pkt, uint8_t next_hdr)
+static inline void net_pkt_set_ipv6_next_hdr(struct net_pkt *pkt,
+					     uint8_t next_hdr)
 {
 	ARG_UNUSED(pkt);
 	ARG_UNUSED(next_hdr);

--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -123,7 +123,7 @@ struct zsock_pollfd {
 /** @} */
 
 /* Valid values for TLS_PEER_VERIFY option */
-#define TLS_PEER_VERIFY_NONE 0 /**< Peer verification disabled. */
+#define TLS_PEER_VERIFY_NONE 0     /**< Peer verification disabled. */
 #define TLS_PEER_VERIFY_OPTIONAL 1 /**< Peer verification optional. */
 #define TLS_PEER_VERIFY_REQUIRED 2 /**< Peer verification required. */
 

--- a/include/net/trickle.h
+++ b/include/net/trickle.h
@@ -51,19 +51,18 @@ typedef void (*net_trickle_cb_t)(struct net_trickle *trickle,
  * only via the Trickle API.
  */
 struct net_trickle {
-	uint32_t Imin;		/* Min interval size in ms */
-	uint8_t Imax;		/* Max number of doublings */
-	uint8_t k;			/* Redundancy constant */
+	uint32_t Imin;		/**< Min interval size in ms */
+	uint8_t Imax;		/**< Max number of doublings */
+	uint8_t k;		/**< Redundancy constant */
 
-	uint32_t I;		/* Current interval size */
-	uint32_t Istart;		/* Start of the interval in ms */
-	uint8_t c;			/* Consistency counter */
+	uint32_t I;		/**< Current interval size */
+	uint32_t Istart;	/**< Start of the interval in ms */
+	uint8_t c;		/**< Consistency counter */
 
-	uint32_t Imax_abs;		/* Max interval size in ms (not doublings)
-				 */
+	uint32_t Imax_abs;	/**< Max interval size in ms (not doublings) */
 
 	struct k_delayed_work timer;
-	net_trickle_cb_t cb;	/* Callback to be called when timer expires */
+	net_trickle_cb_t cb;	/**< Callback to be called when timer expires */
 	void *user_data;
 };
 

--- a/include/net/websocket.h
+++ b/include/net/websocket.h
@@ -169,7 +169,8 @@ int websocket_send_msg(int ws_sock, const uint8_t *payload, size_t payload_len,
  * @return <0 if error, >=0 amount of bytes received
  */
 int websocket_recv_msg(int ws_sock, uint8_t *buf, size_t buf_len,
-		       uint32_t *message_type, uint64_t *remaining, int32_t timeout);
+		       uint32_t *message_type, uint64_t *remaining,
+		       int32_t timeout);
 
 /**
  * @brief Close websocket.


### PR DESCRIPTION
The indentation went wrong when the integer types was changed
from the type "u8_t" to type "uint8_t". This changed the length
of the type and caused the code to look bad in places.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>