### PR TITLE
doc: guides: portability: fix misspellings in POSIX C LANG table

### DIFF
--- a/doc/guides/portability/posix.rst
+++ b/doc/guides/portability/posix.rst
@@ -283,23 +283,23 @@ This is implemented as part of the minimal C library available in Zephyr.
     snprintf(),+
     sprintf(),+
     srand(),
-    canf(),
+    sscanf(),
     strcat(),+
     strchr(),+
     strcmp(),+
     strcoll(),
     strcpy(),+
-    trcspn(),
+    strcspn(),
     strerror(),
     strerror_r(),
     strftime(),
     strlen(),+
-    trncat(),+
+    strncat(),+
     strncmp(),+
     strncpy(),+
     strpbrk(),
     strrchr(),+
-    trspn(),
+    strspn(),
     strstr(),+
     strtod(),
     strtof(),
@@ -309,14 +309,14 @@ This is implemented as part of the minimal C library available in Zephyr.
     strtol(),+
     strtold(),
     strtoll(),
-    trtoul(),+
+    strtoul(),+
     strtoull(),
     strtoumax(),
     strxfrm(),
     time(),+
     tolower(),+
     toupper(),+
-    tzname,
+    tzname(),
     tzset(),
     va_arg(),
     va_copy(),


### PR DESCRIPTION
Fix various missing letters and inconsistent parentheses.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>