### PR TITLE
tests: mem_protect: add a test case of adding memory partition

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -76,6 +76,7 @@ void test_main(void)
 		ztest_unit_test(test_create_new_higher_prio_thread_from_user),
 		ztest_unit_test(test_create_new_invalid_prio_thread_from_user),
 		ztest_unit_test(test_mark_thread_exit_uninitialized),
+		ztest_unit_test(test_mem_part_assert_add_overmax),
 		ztest_user_unit_test(test_kobject_init_error),
 		ztest_unit_test(test_alloc_kobjects),
 		ztest_unit_test(test_thread_alloc_out_of_idx),

--- a/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
@@ -53,6 +53,7 @@ extern void test_create_new_higher_prio_thread_from_user(void);
 extern void test_create_new_invalid_prio_thread_from_user(void);
 extern void test_mark_thread_exit_uninitialized(void);
 extern void test_mem_part_overlap(void);
+extern void test_mem_part_assert_add_overmax(void);
 extern void test_kobject_access_grant_error(void);
 extern void test_kobject_access_grant_error_user(void);
 extern void test_kobject_access_grant_error_user_null(void);


### PR DESCRIPTION
Add a test case to validate when adding a new partition into a memory
domain with over its maximum specified limit number, an assertion
failure happens.


Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>