### PR TITLE
build: support passing preprocessor flags to DTS processing

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -140,6 +140,7 @@ if(SUPPORTS_DTS)
     ${DTC_INCLUDE_FLAG_FOR_DTS}  # include the DTS source and overlays
     ${NOSYSDEF_CFLAG}
     -D__DTS__
+    ${DTS_EXTRA_CPPFLAGS}
     -P
     -E   # Stop after preprocessing
     -MD  # Generate a dependency file as a side-effect

--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -783,6 +783,20 @@ You can also define the variable in the application :file:`CMakeLists.txt`
 file. Make sure to do so **before** pulling in the Zephyr boilerplate with
 ``find_package(Zephyr ...)``.
 
+Devicetree source are passed through the C preprocessor, so you can
+include files that can be located in a ``DTS_ROOT`` directory.  By
+convention devicetree include files have a ``.dtsi`` extension.
+
+You can also use the preprocessor to control the content of a devicetree
+file, by specifying directives through the ``DTS_EXTRA_CPPFLAGS`` CMake
+Cache variable:
+
+.. zephyr-app-commands::
+   :tool: all
+   :board: <board name>
+   :gen-args: -DDTS_EXTRA_CPPFLAGS=-DTEST_ENABLE_FEATURE
+   :goals: build
+   :compact:
 
 Application Debugging
 *********************

--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -587,11 +587,11 @@ again.
 .. _application_debugging:
 .. _custom_board_definition:
 
-Custom Board, DeviceTree and SOC Definitions
+Custom Board, Devicetree and SOC Definitions
 ********************************************
 
 In cases where the board or platform you are developing for is not yet
-supported by Zephyr, you can add board, DeviceTree and SOC definitions
+supported by Zephyr, you can add board, Devicetree and SOC definitions
 to your application without having to add them to the Zephyr tree.
 
 The structure needed to support out-of-tree board and SOC development
@@ -752,10 +752,10 @@ Zephyr boilerplate with ``find_package(Zephyr ...)``.
 
 .. _dts_root:
 
-DeviceTree Definitions
+Devicetree Definitions
 ======================
 
-DeviceTree directory trees are found in ``APPLICATION_SOURCE_DIR``,
+Devicetree directory trees are found in ``APPLICATION_SOURCE_DIR``,
 ``BOARD_DIR``, and ``ZEPHYR_BASE``, but additional trees, or DTS_ROOTs,
 can be added by creating this directory tree::
 


### PR DESCRIPTION
In some cases it's useful to use the C preprocessor to control the content of a devicetree file.  A specific use case is in testing, where different combinations of node properties must be checked (see #27360).  Provide a mechanism to allow arbitrary preprocessor flags to be passed through CMake to affect the devicetree content.