### PR TITLE
boards: mimxrt1050/60/64: Warning on CONFIG_DISPLAY usage

### DIFF
--- a/boards/arm/mimxrt1050_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1050_evk/CMakeLists.txt
@@ -7,3 +7,9 @@
 zephyr_library()
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)
+
+if (CONFIG_DISPLAY)
+message(WARNING "
+CONFIG_DISPLAY: Running this firmware on a board without a display may damage the board
+")
+endif()

--- a/boards/arm/mimxrt1060_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1060_evk/CMakeLists.txt
@@ -7,3 +7,9 @@
 zephyr_library()
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)
+
+if (CONFIG_DISPLAY)
+message(WARNING "
+CONFIG_DISPLAY: Running this firmware on a board without a display may damage the board
+")
+endif()

--- a/boards/arm/mimxrt1064_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1064_evk/CMakeLists.txt
@@ -7,3 +7,9 @@
 zephyr_library()
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)
+
+if (CONFIG_DISPLAY)
+message(WARNING "
+CONFIG_DISPLAY: Running this firmware on a board without a display may damage the board
+")
+endif()


### PR DESCRIPTION
Display a build warning when creating firmware with CONFIG_DISPLAY
enabled that running the firmware on a board without a display
may damage the board.

Signed-off-by: David Leach <david.leach@nxp.com>