### PR TITLE
lib: fdtable: fix reference counting in z_reserve_fd()

### DIFF
--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -147,6 +147,7 @@ int z_reserve_fd(void)
 	fd = _find_fd_entry();
 	if (fd >= 0) {
 		/* Mark entry as used, z_finalize_fd() will fill it in. */
+		(void)z_fd_ref(fd);
 		fdtable[fd].obj = NULL;
 		fdtable[fd].vtable = NULL;
 	}
@@ -171,7 +172,6 @@ void z_finalize_fd(int fd, void *obj, const struct fd_op_vtable *vtable)
 #endif
 	fdtable[fd].obj = obj;
 	fdtable[fd].vtable = vtable;
-	(void)z_fd_ref(fd);
 }
 
 void z_free_fd(int fd)


### PR DESCRIPTION
The new fd entry should be reserved by incrementing its reference count
in z_reserve_fd() instead of z_finalize_fd() in order to avoid having
the same one being returned in a concurrent call. If for some reason
the fd is not finalized after z_reserve_fd() is called, it can be
freed via z_free_fd(), which would decrement the reference count.

Fixes #27721

Signed-off-by: Vincent Wan <vwan@ti.com>