### PR TITLE
doc: reference: overview: bump EEPROM API to unstable

### DIFF
--- a/doc/reference/overview.rst
+++ b/doc/reference/overview.rst
@@ -105,7 +105,7 @@ current :ref:`stability level <api_lifecycle>`.
      - 2.3
 
    * - :ref:`eeprom_api`
-     - Experimental
+     - Unstable
      - 2.1
      - 2.1
 


### PR DESCRIPTION
The EEPROM API, which was introduced in Zephyr v2.1.0 and has not seen any changes since, has multiple implementations supporting a wide variety of EEPROM backends (SPI, I2C, on-chip, simulator).

Bump the EEPROM API from "experimental" to "unstable" according to the Zephyr API lifecycle process.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>