### PR TITLE
samples: drivers: jesd216: check return value of flash_sfdp_read()

### DIFF
--- a/samples/drivers/jesd216/src/main.c
+++ b/samples/drivers/jesd216/src/main.c
@@ -241,6 +241,13 @@ void main(void)
 	} u;
 	const struct jesd216_sfdp_header *hp = &u.sfdp;
 	int rc = flash_sfdp_read(dev, 0, u.raw, sizeof(u.raw));
+
+	if (rc != 0) {
+		printf("Read SFDP not supported: device not JESD216-compliant "
+		       "(err %d)\n", rc);
+		return;
+	}
+
 	uint32_t magic = jesd216_sfdp_magic(hp);
 
 	if (magic != JESD216_SFDP_MAGIC) {


### PR DESCRIPTION
Check the return value of flash_sfdp_read() and print error message if not successful.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>