### PR TITLE
drivers: modem: adding support for power control for gsm ppp driver

### DIFF
--- a/drivers/modem/gsm_ppp.h
+++ b/drivers/modem/gsm_ppp.h
@@ -1,0 +1,27 @@
+/** @file
+ * @brief Modem GSM PPP header file.
+ *
+ * Generic modem ppp initialization, restart
+ */
+
+/*
+ * Copyright (c) 2020-2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_MODEM_MODEM_GSM_PPP_H_
+#define ZEPHYR_INCLUDE_DRIVERS_MODEM_MODEM_GSM_PPP_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void gsm_ppp_restart(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_MODEM_MODEM_GSM_PPP_H_ */

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -875,6 +875,8 @@ static int ppp_stop(struct device *dev)
 
 	net_ppp_carrier_off(context->iface);
 
+	atomic_set(&context->modem_init_done, false);
+
 	return 0;
 }
 


### PR DESCRIPTION
This PR address the support of power control mechanism
of modem with GSM PPP driver.The switch on and off
mechanism for modem is left for users of GSM PPP driver.
The driver has been tested with echo_client app with
SARA U201 modem.
The PR address #27622 and #27611
Signed-off-by: Tahir Akram <mtahirbutt@hotmail.com>