### PR TITLE
Stm32 i2c timing option

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -289,8 +289,22 @@ static void i2c_stm32_irq_config_func_##name(struct device *dev)	\
 
 #endif /* CONFIG_I2C_STM32_INTERRUPT */
 
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2)
+#define DEFINE_TIMINGS(name)						\
+	static const uint32_t i2c_timings_##name[] =			\
+		DT_PROP_OR(DT_NODELABEL(name), timings, {});
+#define USE_TIMINGS(name)						\
+	.timings = (const struct i2c_config_timing *) i2c_timings_##name, \
+	.n_timings = ARRAY_SIZE(i2c_timings_##name),
+#else /* V2 */
+#define DEFINE_TIMINGS(name)
+#define USE_TIMINGS(name)
+#endif /* V2 */
+
 #define STM32_I2C_INIT(name)						\
 STM32_I2C_IRQ_HANDLER_DECL(name);					\
+									\
+DEFINE_TIMINGS(name)							\
 									\
 static const struct i2c_stm32_config i2c_stm32_cfg_##name = {		\
 	.i2c = (I2C_TypeDef *)DT_REG_ADDR(DT_NODELABEL(name)),		\
@@ -300,6 +314,7 @@ static const struct i2c_stm32_config i2c_stm32_cfg_##name = {		\
 	},								\
 	STM32_I2C_IRQ_HANDLER_FUNCTION(name)				\
 	.bitrate = DT_PROP(DT_NODELABEL(name), clock_frequency),	\
+	USE_TIMINGS(name)						\
 };									\
 									\
 static struct i2c_stm32_data i2c_stm32_dev_data_##name;			\

--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -11,6 +11,20 @@
 
 typedef void (*irq_config_func_t)(struct device *port);
 
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2)
+/**
+ * @brief structure to convey optional i2c timings settings
+ */
+struct i2c_config_timing {
+	/* i2c peripheral clock in Hz */
+	uint32_t periph_clock;
+	/* i2c bus speed in Hz */
+	uint32_t i2c_speed;
+	/* I2C_TIMINGR register value of i2c v2 peripheral */
+	uint32_t timing_setting;
+};
+#endif
+
 struct i2c_stm32_config {
 #ifdef CONFIG_I2C_STM32_INTERRUPT
 	irq_config_func_t irq_config_func;
@@ -18,6 +32,10 @@ struct i2c_stm32_config {
 	struct stm32_pclken pclken;
 	I2C_TypeDef *i2c;
 	uint32_t bitrate;
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2)
+	const struct i2c_config_timing *timings;
+	size_t n_timings;
+#endif
 };
 
 struct i2c_stm32_data {

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -602,6 +602,20 @@ int stm32_i2c_configure_timing(struct device *dev, uint32_t clock)
 	uint32_t presc = 1U;
 	uint32_t timing = 0U;
 
+	/*  Look for an adequate preset timing value */
+	for (uint32_t i = 0; i < cfg->n_timings; i++) {
+		const struct i2c_config_timing *preset = &cfg->timings[i];
+		uint32_t speed = i2c_map_dt_bitrate(preset->i2c_speed);
+
+		if ((I2C_SPEED_GET(speed) == I2C_SPEED_GET(data->dev_config))
+		   && (preset->periph_clock == clock)) {
+			/*  Found a matching periph clock and i2c speed */
+			LL_I2C_SetTiming(i2c, preset->timing_setting);
+			return 0;
+		}
+	}
+
+	/* No preset timing was provided, let's dynamically configure */
 	switch (I2C_SPEED_GET(data->dev_config)) {
 	case I2C_SPEED_STANDARD:
 		i2c_h_min_time = 4000U;

--- a/dts/bindings/i2c/st,stm32-i2c-v2.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v2.yaml
@@ -13,3 +13,28 @@ properties:
 
     interrupts:
       required: true
+
+    timings:
+        type: array
+        required: false
+        description: |
+            An optional table of pre-computed i2c timing values with the
+            matching clock configuration.
+
+            Precise timings values for a given Hardware can be pre-computed
+            with a tool like STM32CubeMX or directly from I2C_TIMINGR register
+            description.
+
+            Because timing value is valid for a given I2C peripheral clock
+            frequency and target I2C bus clock, each timing value must be
+            provided with the matching configuration.
+
+            The resulting table entries should look like <periph_clock
+            clock-frequency timing>
+
+            For example timings could be defined as
+
+                timings = <64000000 I2C_BITRATE_STANDARD 0x10707DBC>,
+                          <64000000 I2C_BITRATE_FAST 0x00603D56>,
+                          <56000000 I2C_BITRATE_STANDARD 0x10606DA4>,
+                          <56000000 I2C_BITRATE_FAST 0x00501D63>;


### PR DESCRIPTION
This change offers an additional option for configuring the exact timing of I2C V2 peripherals of STM32s.

The timing computation can either be left to the simple algorithm already in place in the driver, or can be computed through SW tools like STM32CubeMX and provided as an entry in a board's Device Tree file. 

This would look like:
```
 &i2c1 {
 	status = "okay";
	clock-frequency = <I2C_BITRATE_FAST>;
	timing = <0x10C01C20>;
 };
```