### PR TITLE
Zephyr module variables in Kconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,38 +455,18 @@ add_subdirectory(subsys)
 add_subdirectory(drivers)
 
 # Include zephyr modules generated CMake file.
-if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)
-	file(STRINGS ${CMAKE_BINARY_DIR}/zephyr_modules.txt ZEPHYR_MODULES_TXT
-		ENCODING UTF-8)
-  set(module_names)
-
-  foreach(module ${ZEPHYR_MODULES_TXT})
-    # Match "<name>":"<path>" for each line of file, each corresponding to
-    # one module. The use of quotes is required due to CMake not supporting
-    # lazy regexes (it supports greedy only).
-    string(REGEX REPLACE "\"(.*)\":\".*\"" "\\1" module_name ${module})
-    string(REGEX REPLACE "\".*\":\"(.*)\"" "\\1" module_path ${module})
-
-    list(APPEND module_names ${module_name})
-
-    string(TOUPPER ${module_name} MODULE_NAME_UPPER)
-    set(ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR ${module_path})
-    set(ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR ${module_path} PARENT_SCOPE)
-  endforeach()
-
-  foreach(module_name ${module_names})
-    # Note the second, binary_dir parameter requires the added
-    # subdirectory to have its own, local cmake target(s). If not then
-    # this binary_dir is created but stays empty. Object files land in
-    # the main binary dir instead.
-    # https://cmake.org/pipermail/cmake/2019-June/069547.html
-    string(TOUPPER ${module_name} MODULE_NAME_UPPER)
-    set(ZEPHYR_CURRENT_MODULE_DIR ${ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR})
-    add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR} ${CMAKE_BINARY_DIR}/modules/${module_name})
-  endforeach()
-  # Done processing modules, clear ZEPHYR_CURRENT_MODULE_DIR.
-  set(ZEPHYR_CURRENT_MODULE_DIR)
-endif()
+foreach(module_name ${ZEPHYR_MODULE_NAMES})
+  # Note the second, binary_dir parameter requires the added
+  # subdirectory to have its own, local cmake target(s). If not then
+  # this binary_dir is created but stays empty. Object files land in
+  # the main binary dir instead.
+  # https://cmake.org/pipermail/cmake/2019-June/069547.html
+  string(TOUPPER ${module_name} MODULE_NAME_UPPER)
+  set(ZEPHYR_CURRENT_MODULE_DIR ${ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR})
+  add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR} ${CMAKE_BINARY_DIR}/modules/${module_name})
+endforeach()
+# Done processing modules, clear ZEPHYR_CURRENT_MODULE_DIR.
+set(ZEPHYR_CURRENT_MODULE_DIR)
 
 set(syscall_list_h   ${CMAKE_CURRENT_BINARY_DIR}/include/generated/syscall_list.h)
 set(syscalls_json    ${CMAKE_CURRENT_BINARY_DIR}/misc/generated/syscalls.json)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -462,11 +462,15 @@ foreach(module_name ${ZEPHYR_MODULE_NAMES})
   # the main binary dir instead.
   # https://cmake.org/pipermail/cmake/2019-June/069547.html
   string(TOUPPER ${module_name} MODULE_NAME_UPPER)
-  set(ZEPHYR_CURRENT_MODULE_DIR ${ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR})
-  add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR} ${CMAKE_BINARY_DIR}/modules/${module_name})
+  if(NOT ${ZEPHYR_${MODULE_NAME_UPPER}_CMAKE_DIR} STREQUAL "")
+    set(ZEPHYR_CURRENT_MODULE_DIR ${ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR})
+    set(ZEPHYR_CURRENT_CMAKE_DIR ${ZEPHYR_${MODULE_NAME_UPPER}_CMAKE_DIR})
+    add_subdirectory(${ZEPHYR_CURRENT_CMAKE_DIR} ${CMAKE_BINARY_DIR}/modules/${module_name})
+  endif()
 endforeach()
-# Done processing modules, clear ZEPHYR_CURRENT_MODULE_DIR.
+# Done processing modules, clear ZEPHYR_CURRENT_MODULE_DIR and ZEPHYR_CURRENT_CMAKE_DIR.
 set(ZEPHYR_CURRENT_MODULE_DIR)
+set(ZEPHYR_CURRENT_CMAKE_DIR)
 
 set(syscall_list_h   ${CMAKE_CURRENT_BINARY_DIR}/include/generated/syscall_list.h)
 set(syscalls_json    ${CMAKE_CURRENT_BINARY_DIR}/misc/generated/syscalls.json)

--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -48,6 +48,17 @@ endif()
 # separated list instead.
 string(REPLACE ";" "?" DTS_ROOT_BINDINGS "${DTS_ROOT_BINDINGS}")
 
+# Export each `ZEPHYR_<module>_MODULE_DIR` to Kconfig.
+# This allows Kconfig files to refer relative from a modules root as:
+# source "$(ZEPHYR_FOO_MODULE_DIR)/Kconfig"
+foreach(module_name ${ZEPHYR_MODULE_NAMES})
+  string(TOUPPER ${module_name} MODULE_NAME_UPPER)
+  list(APPEND
+       ZEPHYR_KCONFIG_MODULES_DIR
+       "ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR=${ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR}"
+  )
+endforeach()
+
 # A list of common environment settings used when invoking Kconfig during CMake
 # configure time or menuconfig and related build target.
 set(COMMON_KCONFIG_ENV_SETTINGS
@@ -64,6 +75,8 @@ set(COMMON_KCONFIG_ENV_SETTINGS
   KCONFIG_BINARY_DIR=${KCONFIG_BINARY_DIR}
   TOOLCHAIN_KCONFIG_DIR=${TOOLCHAIN_KCONFIG_DIR}
   EDT_PICKLE=${EDT_PICKLE}
+  # Export all Zephyr modules to Kconfig
+  ${ZEPHYR_KCONFIG_MODULES_DIR}
 )
 
 # Allow out-of-tree users to add their own Kconfig python frontend

--- a/cmake/zephyr_module.cmake
+++ b/cmake/zephyr_module.cmake
@@ -59,6 +59,24 @@ if(WEST OR ZEPHYR_MODULES)
     endforeach()
   endif()
 
+  if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)
+    file(STRINGS ${CMAKE_BINARY_DIR}/zephyr_modules.txt ZEPHYR_MODULES_TXT
+         ENCODING UTF-8)
+    set(ZEPHYR_MODULE_NAMES)
+
+    foreach(module ${ZEPHYR_MODULES_TXT})
+      # Match "<name>":"<path>" for each line of file, each corresponding to
+      # one module. The use of quotes is required due to CMake not supporting
+      # lazy regexes (it supports greedy only).
+      string(REGEX REPLACE "\"(.*)\":\".*\"" "\\1" module_name ${module})
+      string(REGEX REPLACE "\".*\":\"(.*)\"" "\\1" module_path ${module})
+
+      list(APPEND ZEPHYR_MODULE_NAMES ${module_name})
+
+      string(TOUPPER ${module_name} MODULE_NAME_UPPER)
+      set(ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR ${module_path})
+    endforeach()
+  endif()
 else()
 
   file(WRITE ${KCONFIG_MODULES_FILE}

--- a/cmake/zephyr_module.cmake
+++ b/cmake/zephyr_module.cmake
@@ -68,13 +68,15 @@ if(WEST OR ZEPHYR_MODULES)
       # Match "<name>":"<path>" for each line of file, each corresponding to
       # one module. The use of quotes is required due to CMake not supporting
       # lazy regexes (it supports greedy only).
-      string(REGEX REPLACE "\"(.*)\":\".*\"" "\\1" module_name ${module})
-      string(REGEX REPLACE "\".*\":\"(.*)\"" "\\1" module_path ${module})
+      string(REGEX REPLACE "\"(.*)\":\".*\":\".*\"" "\\1" module_name ${module})
+      string(REGEX REPLACE "\".*\":\"(.*)\":\".*\"" "\\1" module_path ${module})
+      string(REGEX REPLACE "\".*\":\".*\":\"(.*)\"" "\\1" cmake_path ${module})
 
       list(APPEND ZEPHYR_MODULE_NAMES ${module_name})
 
       string(TOUPPER ${module_name} MODULE_NAME_UPPER)
       set(ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR ${module_path})
+      set(ZEPHYR_${MODULE_NAME_UPPER}_CMAKE_DIR ${cmake_path})
     endforeach()
   endif()
 else()

--- a/cmake/zephyr_module.cmake
+++ b/cmake/zephyr_module.cmake
@@ -75,8 +75,14 @@ if(WEST OR ZEPHYR_MODULES)
       list(APPEND ZEPHYR_MODULE_NAMES ${module_name})
 
       string(TOUPPER ${module_name} MODULE_NAME_UPPER)
-      set(ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR ${module_path})
-      set(ZEPHYR_${MODULE_NAME_UPPER}_CMAKE_DIR ${cmake_path})
+      if(NOT ${MODULE_NAME_UPPER} STREQUAL CURRENT)
+        set(ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR ${module_path})
+        set(ZEPHYR_${MODULE_NAME_UPPER}_CMAKE_DIR ${cmake_path})
+      else()
+        message(FATAL_ERROR "Found Zephyr module named: ${module_name}\n\
+${MODULE_NAME_UPPER} is a restricted name for Zephyr modules as it is used for \
+\${ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR} CMake variable.")
+      endif()
     endforeach()
   endif()
 else()

--- a/doc/guides/modules.rst
+++ b/doc/guides/modules.rst
@@ -75,6 +75,60 @@ module:
      cmake: .
      kconfig: Kconfig
 
+
+Build system integration
+========================
+
+When a module has a :file:`module.yml` file, it will automatically be included into
+the Zephyr build system. The path to the module is then accessible through Kconfig
+and CMake variables.
+
+In both Kconfig and CMake, the variable ``ZEPHYR_<module-name>_MODULE_DIR``
+contains the absolute path to the module.
+
+In CMake, ``ZEPHYR_<module-name>_CMAKE_DIR`` contains the
+absolute path to the directory containing the :file:`CMakeLists.txt` file that
+is included into CMake build system. This variable's value is empty if the
+module.yml file does not specify a CMakeLists.txt.
+
+To read these variables for a Zephyr module named ``foo``:
+
+- In CMake: use ``${ZEPHYR_FOO_MODULE_DIR}`` for the module's top level directory, and ``${ZEPHYR_FOO_CMAKE_DIR}`` for the directory containing its :file:`CMakeLists.txt`
+- In Kconfig: use ``$(ZEPHYR_FOO_MODULE_DIR)`` for the module's top level directory
+
+Notice how a lowercase module name ``foo`` is capitalized to ``FOO``
+in both CMake and Kconfig.
+
+These variables can also be used to test whether a given module exists.
+For example, to verify that ``foo`` is the name of a Zephyr module:
+
+.. code-block:: cmake
+
+  if(ZEPHYR_FOO_MODULE_DIR)
+    # Do something if FOO exists.
+  endif()
+
+In Kconfig, the variable may be used to find additional files to include.
+For example, to include the file :file:`some/Kconfig` in module ``foo``:
+
+.. code-block:: kconfig
+
+  source "$(ZEPHYR_FOO_MODULE_DIR)/some/Kconfig"
+
+During CMake processing of each Zephyr module, the following two variables are
+also available:
+
+- the current module's top level directory: ``${ZEPHYR_CURRENT_MODULE_DIR}``
+- the current module's :file:`CMakeLists.txt` directory: ``${ZEPHYR_CURRENT_CMAKE_DIR}``
+
+This removes the need for a Zephyr module to know its own name during CMake
+processing. The module can source additional CMake files using these ``CURRENT``
+variables. For example:
+
+.. code-block:: cmake
+
+  include(${ZEPHYR_CURRENT_MODULE_DIR}/cmake/code.cmake)
+
 .. _modules_build_settings:
 
 Build settings

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -135,12 +135,14 @@ def process_cmake(module, meta):
     cmake_path = os.path.join(module, cmake_setting or 'zephyr')
     cmake_file = os.path.join(cmake_path, 'CMakeLists.txt')
     if os.path.isfile(cmake_file):
-        return('\"{}\":\"{}\"\n'
+        return('\"{}\":\"{}\":\"{}\"\n'
                .format(module_path.name,
+                       module_path.as_posix(),
                        Path(cmake_path).resolve().as_posix()))
     else:
-        return ""
-
+        return('\"{}\":\"{}\":\"\"\n'
+               .format(module_path.name,
+                       module_path.as_posix()))
 
 def process_settings(module, meta):
     section = meta.get('build', dict())
@@ -174,7 +176,6 @@ def process_kconfig(module, meta):
                                          .resolve().as_posix())
     else:
         return ""
-
 
 def process_sanitycheck(module, meta):
 

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -129,16 +129,18 @@ def process_cmake(module, meta):
     cmake_setting = section.get('cmake', None)
     if not validate_setting(cmake_setting, module, 'CMakeLists.txt'):
         sys.exit('ERROR: "cmake" key in {} has folder value "{}" which '
-                    'does not contain a CMakeLists.txt file.'
-                    .format(module_yml.as_posix(), cmake_setting))
+                 'does not contain a CMakeLists.txt file.'
+                 .format(module_yml.as_posix(), cmake_setting))
 
     cmake_path = os.path.join(module, cmake_setting or 'zephyr')
     cmake_file = os.path.join(cmake_path, 'CMakeLists.txt')
     if os.path.isfile(cmake_file):
         return('\"{}\":\"{}\"\n'
-                        .format(module_path.name, Path(cmake_path).resolve().as_posix()))
+               .format(module_path.name,
+                       Path(cmake_path).resolve().as_posix()))
     else:
         return ""
+
 
 def process_settings(module, meta):
     section = meta.get('build', dict())
@@ -154,6 +156,7 @@ def process_settings(module, meta):
 
     return out_text
 
+
 def process_kconfig(module, meta):
     section = meta.get('build', dict())
     module_path = PurePath(module)
@@ -162,15 +165,16 @@ def process_kconfig(module, meta):
     kconfig_setting = section.get('kconfig', None)
     if not validate_setting(kconfig_setting, module):
         sys.exit('ERROR: "kconfig" key in {} has value "{}" which does '
-                    'not point to a valid Kconfig file.'
-                    .format(module_yml, kconfig_setting))
-
+                 'not point to a valid Kconfig file.'
+                 .format(module_yml, kconfig_setting))
 
     kconfig_file = os.path.join(module, kconfig_setting or 'zephyr/Kconfig')
     if os.path.isfile(kconfig_file):
-        return 'osource "{}"\n\n'.format(Path(kconfig_file).resolve().as_posix())
+        return 'osource "{}"\n\n'.format(Path(kconfig_file)
+                                         .resolve().as_posix())
     else:
         return ""
+
 
 def process_sanitycheck(module, meta):
 
@@ -182,12 +186,14 @@ def process_sanitycheck(module, meta):
     for pth in tests + samples:
         if pth:
             dir = os.path.join(module, pth)
-            out += '-T\n{}\n'.format(PurePath(os.path.abspath(dir)).as_posix())
+            out += '-T\n{}\n'.format(PurePath(os.path.abspath(dir))
+                                     .as_posix())
 
     for pth in boards:
         if pth:
             dir = os.path.join(module, pth)
-            out += '--board-root\n{}\n'.format(PurePath(os.path.abspath(dir)).as_posix())
+            out += '--board-root\n{}\n'.format(PurePath(os.path.abspath(dir))
+                                               .as_posix())
 
     return out
 
@@ -201,7 +207,8 @@ def main():
                         help="""File to write with resulting KConfig import
                              statements.""")
     parser.add_argument('--sanitycheck-out',
-                        help="""File to write with resulting sanitycheck parameters.""")
+                        help="""File to write with resulting sanitycheck
+                             parameters.""")
     parser.add_argument('--cmake-out',
                         help="""File to write with resulting <name>:<path>
                              values to use for including in CMake""")
@@ -218,7 +225,8 @@ def main():
     args = parser.parse_args()
 
     if args.modules is None:
-        # West is imported here, as it is optional (and thus maybe not installed)
+        # West is imported here, as it is optional
+        # (and thus maybe not installed)
         # if user is providing a specific modules list.
         from west.manifest import Manifest
         from west.util import WestNotFound
@@ -311,6 +319,7 @@ def main():
     if args.sanitycheck_out:
         with open(args.sanitycheck_out, 'w', encoding="utf-8") as fp:
             fp.write(sanitycheck)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
With the introduction of https://github.com/zephyrproject-rtos/zephyr/pull/26715 it became apparent that downstream users of Zephyr were dependent on `SOC_DIR` variable in Kconfig.

Because of this, and to align Kconfig and CMake Zephyr module variables between Kconfig and CMake, then this PR proposes to export `ZEPHYR_<module>_MODULE_DIR` to Kconfig.

In CMake today, if module `FOO` is part of Zephyr, then the following is possible in CMake:
```
include(${ZEPHYR_FOO_MODULE_DIR}/myfile.cmake)
```

with this PR, the similar is now possible in Kconfig:
```
source "$(ZEPHYR_FOO_MODULE_DIR)/Kconfig.myfile"
```

This means that users who previously did:
```
source "$(SOC_DIR)/$(ARCH)/Kconfig.mysoc"
```

can now do:
```
source "$(ZEPHYR_MYSOC_MODULE_DIR)/soc/$(ARCH)/Kconfig.mysoc"
```
if the repo `MYSOC` is also a Zephyr module.

--------

Edit: Based on comments, then additional commits has been added that does general clean-up of CMake/python code related to Zephyr modules.