### PR TITLE
modules: hal_nordic: Update nrfx to version 2.3.0

### DIFF
--- a/modules/Kconfig.nordic
+++ b/modules/Kconfig.nordic
@@ -88,6 +88,10 @@ config NRFX_CLOCK
 	bool "Enable CLOCK driver"
 	depends on HAS_HW_NRF_CLOCK
 
+config NRFX_CLOCK_LFXO_TWO_STAGE_ENABLED
+	bool "Enable two stage start sequence of the low frequency clock"
+	depends on NRFX_CLOCK
+
 config NRFX_COMP
 	bool "Enable COMP driver"
 	depends on HAS_HW_NRF_COMP

--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: b69c5a7c25007fbc111a0cbda6e2a6a945a6ae9a
+      revision: 4420ac72664b8be0b8630e2bd8cf76367c62d228
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262


### PR DESCRIPTION
This PR updates the hal_nordic module revision, to switch to nrfx 2.3.0
and adds new configuration option to enable two stage LFCLK start
sequence.

Signed-off-by: Karol Lasończyk <karol.lasonczyk@nordicsemi.no>

~~zephyrproject-rtos/hal_nordic#50 needs to go in first.~~