### PR TITLE
Boards nrf5340dk fix net num mpu regs

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpunet.dts
@@ -5,7 +5,7 @@
  */
 
 /dts-v1/;
-#include <nordic/nrf5340_cpunet_qkaa.dtsi>
+#include <nordic/nrf5340_cpunet_qkaa_eng_a.dtsi>
 
 / {
 	model = "Nordic NRF5340 PDK NRF5340 Network";

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -28,7 +28,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <16>;
 			};
 		};
 	};

--- a/dts/arm/nordic/nrf5340_cpunet_qkaa_eng_a.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet_qkaa_eng_a.dtsi
@@ -16,7 +16,7 @@
 };
 
 &mpu {
-	arm,num-mpu-regions = <8>;
+	arm,num-mpu-regions = <16>;
 };
 
 / {


### PR DESCRIPTION
When we introduced the support for nRF5340 DK, we did not add a separate .dtsi header to reflect that the number of MPU regions are different compared to the PDK, _also_ for the NETWORK MCU. This PR fixes this.

Fixes #27613