### PR TITLE
drivers: i2c: nordic increase timeout to 500 ms

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -12,7 +12,7 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(i2c_nrfx_twi, CONFIG_I2C_LOG_LEVEL);
 
-#define I2C_TRANSFER_TIMEOUT_MSEC		K_MSEC(100)
+#define I2C_TRANSFER_TIMEOUT_MSEC		K_MSEC(500)
 
 struct i2c_nrfx_twi_data {
 	struct k_sem transfer_sync;

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -13,7 +13,7 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(i2c_nrfx_twim, CONFIG_I2C_LOG_LEVEL);
 
-#define I2C_TRANSFER_TIMEOUT_MSEC		K_MSEC(100)
+#define I2C_TRANSFER_TIMEOUT_MSEC		K_MSEC(500)
 
 struct i2c_nrfx_twim_data {
 	struct k_sem transfer_sync;


### PR DESCRIPTION
The 100 ms hard-coded timeout is too small to complete the transfer of 1025 bytes of SSD1306 data at 100 kHz.  Increase it to 500 ms to match STM32 policy and fix this problem.

Closes #26990

See additional explanation at: https://github.com/zephyrproject-rtos/zephyr/issues/26990#issuecomment-679108313