### PR TITLE
doc: fix typos in variable names

### DIFF
--- a/include/fs/fcb.h
+++ b/include/fs/fcb.h
@@ -31,7 +31,7 @@ extern "C" {
 /**
  * @defgroup fcb_data_structures Flash Circular Buffer Data Structures
  * @ingroup fcb
- *
+ * @{
  */
 
 #define FCB_MAX_LEN	(CHAR_MAX | CHAR_MAX << 7) /**< Max length of element */

--- a/include/fs/fcb.h
+++ b/include/fs/fcb.h
@@ -31,7 +31,7 @@ extern "C" {
 /**
  * @defgroup fcb_data_structures Flash Circular Buffer Data Structures
  * @ingroup fcb
- * @{
+ *
  */
 
 #define FCB_MAX_LEN	(CHAR_MAX | CHAR_MAX << 7) /**< Max length of element */
@@ -148,7 +148,7 @@ int fcb_init(int f_area_id, struct fcb *fcb);
  * Appends an entry to circular buffer.
  *
  * When writing the
- * contents for the entry, use loc->fl_sector and loc->fl_data_off with
+ * contents for the entry, use loc->fe_sector and loc->fe_data_off with
  * flash_area_write() to fcb flash_area.
  * When you're finished, call fcb_append_finish() with loc as argument.
  *


### PR DESCRIPTION
there are no fields fl_sector nor fl_data_off. in struct fcb_entry. fl must be changed to fe, based on:

```
struct fcb_entry {
	struct flash_sector *fe_sector;
	/**< Pointer to info about sector where data are placed */

	uint32_t fe_elem_off;
	/**< Offset from the start of the sector to beginning of element. */

	uint32_t fe_data_off;
	/**< Offset from the start of the sector to the start of element. */

	uint16_t fe_data_len; /**< Size of data area in fcb entry*/
};
```