### PR TITLE
code-guideline: Warning about implicit fallthrough in switch() satements

### DIFF
--- a/cmake/compiler/gcc/target_warnings.cmake
+++ b/cmake/compiler/gcc/target_warnings.cmake
@@ -12,6 +12,12 @@ macro(toolchain_cc_warning_base)
     -Wno-main
   )
 
+if(CMAKE_C_COMPILER_VERSION VERSION_GREATER "7.1.0")
+  zephyr_compile_options(
+    -Wimplicit-fallthrough=2
+    )
+endif()
+
 if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "9.1.0")
   zephyr_compile_options(
     # FIXME: Remove once #16587 is fixed

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -587,17 +587,17 @@ static void mcux_flexcan_transfer_callback(CAN_Type *base,
 
 	switch (status) {
 	case kStatus_FLEXCAN_UnHandled:
-		/* fallthrough */
+		__fallthrough;
 	case kStatus_FLEXCAN_ErrorStatus:
 		mcux_flexcan_transfer_error_status(dev, result);
 		break;
 	case kStatus_FLEXCAN_TxSwitchToRx:
-		/* fallthrough */
+		__fallthrough;
 	case kStatus_FLEXCAN_TxIdle:
 		mcux_flexcan_transfer_tx_idle(dev, result);
 		break;
 	case kStatus_FLEXCAN_RxOverflow:
-		/* fallthrough */
+		__fallthrough;
 	case kStatus_FLEXCAN_RxIdle:
 		mcux_flexcan_transfer_rx_idle(dev, result);
 		break;

--- a/drivers/eeprom/eeprom_at2x.c
+++ b/drivers/eeprom/eeprom_at2x.c
@@ -384,10 +384,10 @@ static int eeprom_at25_read(struct device *dev, off_t offset, void *buf,
 	switch (config->addr_width) {
 	case 24:
 		*paddr++ = offset >> 16;
-		/* Fallthrough */
+		__fallthrough;
 	case 16:
 		*paddr++ = offset >> 8;
-		/* Fallthrough */
+		__fallthrough;
 	case 8:
 		*paddr++ = offset;
 		break;
@@ -450,10 +450,10 @@ static int eeprom_at25_write(struct device *dev, off_t offset,
 	switch (config->addr_width) {
 	case 24:
 		*paddr++ = offset >> 16;
-		/* Fallthrough */
+		__fallthrough;
 	case 16:
 		*paddr++ = offset >> 8;
-		/* Fallthrough */
+		__fallthrough;
 	case 8:
 		*paddr++ = offset;
 		break;

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -310,7 +310,7 @@ static int i2c_dw_setup(struct device *dev, uint16_t slave_address)
 
 		break;
 	case I2C_SPEED_FAST:
-		/* fall through */
+		__fallthrough;
 	case I2C_SPEED_FAST_PLUS:
 		LOG_DBG("I2C: speed set to FAST or FAST_PLUS");
 		regs->ic_fs_scl_lcnt = dw->lcnt;
@@ -531,7 +531,7 @@ static int i2c_dw_runtime_configure(struct device *dev, uint32_t config)
 		dw->hcnt = value;
 		break;
 	case I2C_SPEED_FAST:
-		/* fall through */
+		__fallthrough;
 	case I2C_SPEED_FAST_PLUS:
 		/*
 		 * Following the directions on DW spec page 59, IC_FS_SCL_LCNT

--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -940,7 +940,7 @@ int32_t stm32_i2c_msg_read(struct device *dev, struct i2c_msg *msg,
 
 			/* Set NACK before reading N-2 byte*/
 			LL_I2C_AcknowledgeNextData(i2c, LL_I2C_NACK);
-		/* Fall through */
+			__fallthrough;
 		default:
 			len--;
 			*buf = LL_I2C_ReceiveData8(i2c);

--- a/drivers/i2c/i2c_lpc11u6x.c
+++ b/drivers/i2c/i2c_lpc11u6x.c
@@ -237,12 +237,12 @@ static void lpc11u6x_i2c_isr(void *arg)
 		if (!transfer->nr_msgs) {
 			transfer->status = LPC11U6X_I2C_STATUS_OK;
 		}
-		/* fallthrough */
+		__fallthrough;
 	case LPC11U6X_I2C_MASTER_RX_DAT_ACK:
 		transfer->curr_buf[0] = i2c->dat;
 		transfer->curr_buf++;
 		transfer->curr_len--;
-		/* fallthrough */
+		__fallthrough;
 	case LPC11U6X_I2C_MASTER_RX_ADR_ACK:
 		if (transfer->curr_len <= 1) {
 			clear |= LPC11U6X_I2C_CONTROL_AA;

--- a/drivers/led/lp3943.c
+++ b/drivers/led/lp3943.c
@@ -62,14 +62,14 @@ static int lp3943_get_led_reg(uint32_t *led, uint8_t *reg)
 	case 0:
 	case 1:
 	case 2:
-		/* Fall through */
+		__fallthrough;
 	case 3:
 		*reg = LP3943_LS0;
 		break;
 	case 4:
 	case 5:
 	case 6:
-		/* Fall through */
+		__fallthrough;
 	case 7:
 		*reg = LP3943_LS1;
 		*led -= 4U;
@@ -77,7 +77,7 @@ static int lp3943_get_led_reg(uint32_t *led, uint8_t *reg)
 	case 8:
 	case 9:
 	case 10:
-		/* Fall through */
+		__fallthrough;
 	case 11:
 		*reg = LP3943_LS2;
 		*led -= 8U;
@@ -85,7 +85,7 @@ static int lp3943_get_led_reg(uint32_t *led, uint8_t *reg)
 	case 12:
 	case 13:
 	case 14:
-		/* Fall through */
+		__fallthrough;
 	case 15:
 		*reg = LP3943_LS3;
 		*led -= 12U;

--- a/drivers/sensor/adt7420/adt7420.c
+++ b/drivers/sensor/adt7420/adt7420.c
@@ -84,7 +84,7 @@ static int adt7420_attr_set(struct device *dev,
 		return 0;
 	case SENSOR_ATTR_UPPER_THRESH:
 		reg = ADT7420_REG_T_HIGH_MSB;
-		/* Fallthrough */
+		__fallthrough;
 	case SENSOR_ATTR_LOWER_THRESH:
 		if (!reg) {
 			reg = ADT7420_REG_T_LOW_MSB;

--- a/drivers/serial/uart_lpc11u6x.c
+++ b/drivers/serial/uart_lpc11u6x.c
@@ -124,7 +124,8 @@ static int lpc11u6x_uart0_configure(struct device *dev,
 		flags |= LPC11U6X_UART0_LCR_PARTIY_ENABLE |
 			LPC11U6X_UART0_LCR_PARTIY_EVEN;
 		break;
-	case UART_CFG_PARITY_MARK: /* fallthrough */
+	case UART_CFG_PARITY_MARK:
+		__fallthrough;
 	case UART_CFG_PARITY_SPACE:
 		return -ENOTSUP;
 	default:
@@ -539,7 +540,8 @@ static int lpc11u6x_uartx_configure(struct device *dev,
 	case UART_CFG_PARITY_EVEN:
 		flags |= LPC11U6X_UARTX_CFG_PARITY_EVEN;
 		break;
-	case UART_CFG_PARITY_MARK: /* fallthrough */
+	case UART_CFG_PARITY_MARK:
+		__fallthrough;
 	case UART_CFG_PARITY_SPACE:
 		return -ENOTSUP;
 	default:
@@ -562,7 +564,8 @@ static int lpc11u6x_uartx_configure(struct device *dev,
 	}
 
 	switch (cfg->data_bits) {
-	case UART_CFG_DATA_BITS_5: /* fallthrough */
+	case UART_CFG_DATA_BITS_5:
+		__fallthrough;
 	case UART_CFG_DATA_BITS_6:
 		return -ENOTSUP;
 	case UART_CFG_DATA_BITS_7:

--- a/include/drivers/bluetooth/hci_driver.h
+++ b/include/drivers/bluetooth/hci_driver.h
@@ -66,7 +66,7 @@ static inline uint8_t bt_hci_evt_get_flags(uint8_t evt)
 #if defined(CONFIG_BT_CONN)
 	case BT_HCI_EVT_NUM_COMPLETED_PACKETS:
 	case BT_HCI_EVT_DATA_BUF_OVERFLOW:
-		/* fallthrough */
+		__fallthrough;
 #endif /* defined(CONFIG_BT_CONN) */
 	case BT_HCI_EVT_CMD_COMPLETE:
 	case BT_HCI_EVT_CMD_STATUS:

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -165,6 +165,9 @@ do {                                                                    \
 			__attribute__((long_call, section(".ramfunc")))
 #endif /* !CONFIG_XIP */
 
+#ifndef __fallthrough
+#define __fallthrough        __attribute__((fallthrough))
+#endif
 #ifndef __packed
 #define __packed        __attribute__((__packed__))
 #endif

--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -259,7 +259,7 @@ static void *lexer_json(struct lexer *lexer)
 				return lexer_number;
 			}
 
-			/* fallthrough */
+			__fallthrough;
 		default:
 			if (isspace(chr)) {
 				ignore(lexer);
@@ -343,7 +343,7 @@ static int obj_next(struct json_obj *json,
 			return -EINVAL;
 		}
 
-		/* fallthrough */
+		__fallthrough;
 	case JSON_TOK_STRING:
 		kv->key = token.start;
 		kv->key_len = (size_t)(token.end - token.start);

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -197,7 +197,7 @@ void z_vprintk(out_func_t out, void *ctx, const char *fmt, va_list ap)
 					padding = PAD_ZERO_BEFORE;
 					goto still_might_format;
 				}
-				/* Fall through */
+				__fallthrough;
 			case '1':
 			case '2':
 			case '3':
@@ -206,7 +206,6 @@ void z_vprintk(out_func_t out, void *ctx, const char *fmt, va_list ap)
 			case '6':
 			case '7':
 			case '8':
-				/* Fall through */
 			case '9':
 				if (min_width < 0) {
 					min_width = *fmt - '0';
@@ -266,7 +265,7 @@ void z_vprintk(out_func_t out, void *ctx, const char *fmt, va_list ap)
 				/* left-pad pointers with zeros */
 				padding = PAD_ZERO_BEFORE;
 				min_width = sizeof(void *) * 2;
-				/* Fall through */
+				__fallthrough;
 			case 'x':
 			case 'X': {
 				printk_val_t x;

--- a/samples/bluetooth/peripheral_esp/src/main.c
+++ b/samples/bluetooth/peripheral_esp/src/main.c
@@ -190,14 +190,14 @@ static ssize_t read_temp_trigger_setting(struct bt_conn *conn,
 	switch (sensor->condition) {
 	/* Operand N/A */
 	case ESS_TRIGGER_INACTIVE:
-		/* fallthrough */
+		__fallthrough;
 	case ESS_VALUE_CHANGED:
 		return bt_gatt_attr_read(conn, attr, buf, len, offset,
 					 &sensor->condition,
 					 sizeof(sensor->condition));
 	/* Seconds */
 	case ESS_FIXED_TIME_INTERVAL:
-		/* fallthrough */
+		__fallthrough;
 	case ESS_NO_LESS_THAN_SPECIFIED_TIME: {
 			struct es_trigger_setting_seconds rp;
 

--- a/samples/boards/bbc_microbit/pong/src/ble.c
+++ b/samples/boards/bbc_microbit/pong/src/ble.c
@@ -312,7 +312,7 @@ void ble_cancel_connect(void)
 		break;
 	case BLE_CONNECT_CREATE:
 		ble_state = BLE_CONNECT_CANCEL;
-		/* Intentional fall-through */
+		__fallthrough;
 	case BLE_CONNECTED:
 		connect_canceled = true;
 		k_delayed_work_submit(&ble_work, K_NO_WAIT);

--- a/samples/net/zperf/src/zperf_tcp_receiver.c
+++ b/samples/net/zperf/src/zperf_tcp_receiver.c
@@ -65,7 +65,7 @@ static void tcp_received(struct net_context *context,
 		zperf_reset_session_stats(session);
 		session->start_time = k_cycle_get_32();
 		session->state = STATE_ONGOING;
-		/* fall through */
+		__fallthrough;
 	case STATE_ONGOING:
 		session->counter++;
 

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -4466,7 +4466,7 @@ uint8_t hci_get_class(struct node_rx_pdu *node_rx)
 		case NODE_RX_TYPE_REPORT:
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-			/* fallthrough */
+			__fallthrough;
 		case NODE_RX_TYPE_EXT_1M_REPORT:
 		case NODE_RX_TYPE_EXT_2M_REPORT:
 		case NODE_RX_TYPE_EXT_CODED_REPORT:
@@ -4498,7 +4498,7 @@ uint8_t hci_get_class(struct node_rx_pdu *node_rx)
 #endif /* CONFIG_BT_HCI_MESH_EXT */
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-			/* fallthrough */
+			__fallthrough;
 		case NODE_RX_TYPE_EXT_ADV_TERMINATE:
 			return HCI_CLASS_EVT_REQUIRED;
 #endif /* CONFIG_BT_CTLR_ADV_EXT */

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -232,7 +232,7 @@ static inline struct net_buf *process_node(struct node_rx_pdu *node_rx)
 		case HCI_CLASS_EVT_LLCP:
 			/* for conn-related events, only pend is relevant */
 			hbuf_count = 1;
-			/* fallthrough */
+			__fallthrough;
 		case HCI_CLASS_ACL_DATA:
 			if (pend || !hbuf_count) {
 				sys_slist_append(&hbuf_pend, (void *)node_rx);

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -746,7 +746,7 @@ void ll_rx_dequeue(void)
 	case NODE_RX_TYPE_USER_START ... NODE_RX_TYPE_USER_END:
 #endif /* CONFIG_BT_CTLR_USER_EXT */
 
-	/* fall through */
+		__fallthrough;
 
 	/* Ensure that at least one 'case' statement is present for this
 	 * code block.
@@ -848,7 +848,7 @@ void ll_rx_mem_release(void **node_rx)
 			}
 		}
 
-		/* passthrough */
+		__fallthrough;
 		case NODE_RX_TYPE_DC_PDU:
 #endif /* CONFIG_BT_CONN */
 
@@ -857,7 +857,7 @@ void ll_rx_mem_release(void **node_rx)
 #endif /* CONFIG_BT_OBSERVER */
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-			/* fallthrough */
+			__fallthrough;
 		case NODE_RX_TYPE_EXT_1M_REPORT:
 		case NODE_RX_TYPE_EXT_2M_REPORT:
 		case NODE_RX_TYPE_EXT_CODED_REPORT:

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -441,7 +441,7 @@ uint32_t ll_length_req_send(uint16_t handle, uint16_t tx_octets, uint16_t tx_tim
 #endif /* CONFIG_BT_CTLR_PHY */
 				return 0;
 			}
-			/* pass through */
+			__fallthrough;
 		default:
 			return BT_HCI_ERR_CMD_DISALLOWED;
 		}
@@ -4923,7 +4923,7 @@ static inline void ctrl_tx_pre_ack(struct ll_conn *conn,
 		if (!conn->lll.role) {
 			break;
 		}
-		/* fallthrough */
+		__fallthrough;
 
 	case PDU_DATA_LLCTRL_TYPE_ENC_REQ:
 	case PDU_DATA_LLCTRL_TYPE_ENC_RSP:
@@ -5027,7 +5027,7 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 		    PDU_DATA_LLCTRL_TYPE_ENC_REQ) {
 			break;
 		}
-		/* Pass through */
+		__fallthrough;
 
 	case PDU_DATA_LLCTRL_TYPE_REJECT_IND:
 		/* resume data packet rx and tx */
@@ -5100,7 +5100,7 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 #if defined(CONFIG_BT_CTLR_PHY)
 	case PDU_DATA_LLCTRL_TYPE_PHY_REQ:
 		conn->llcp_phy.state = LLCP_PHY_STATE_RSP_WAIT;
-		/* fall through */
+		__fallthrough;
 
 	case PDU_DATA_LLCTRL_TYPE_PHY_RSP:
 		if (conn->lll.role) {

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -2073,7 +2073,7 @@ static inline void ticker_job_op_inquire(struct ticker_instance *instance,
 					uop->params.slot_get.ticker_id,
 					uop->params.slot_get.ticks_current,
 					uop->params.slot_get.ticks_to_expire);
-		/* Fall-through */
+		__fallthrough;
 	case TICKER_USER_OP_TYPE_IDLE_GET:
 		uop->status = TICKER_STATUS_SUCCESS;
 		fp_op_func = uop->fp_op_func;

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -3408,7 +3408,7 @@ int bt_gatt_discover(struct bt_conn *conn,
 		     !bt_uuid_cmp(params->uuid, BT_UUID_GATT_CHRC))) {
 			return -EINVAL;
 		}
-	 /* Fallthrough. */
+		__fallthrough;
 	case BT_GATT_DISCOVER_ATTRIBUTE:
 		return gatt_find_info(conn, params);
 	default:

--- a/subsys/bluetooth/host/hci_raw.c
+++ b/subsys/bluetooth/host/hci_raw.c
@@ -125,7 +125,7 @@ struct net_buf *bt_buf_get_tx(enum bt_buf_type type, k_timeout_t timeout,
 			size--;
 			break;
 		}
-	/* Fallthrough */
+		__fallthrough;
 	default:
 		BT_ERR("Invalid type: %u", type);
 		return NULL;

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1532,6 +1532,7 @@ static void le_conn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 			return;
 		}
 		bt_l2cap_chan_remove(conn, &chan->chan);
+		__fallthrough;
 	default:
 		bt_l2cap_chan_del(&chan->chan);
 	}
@@ -1929,7 +1930,7 @@ static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 			le_conn_param_update_req(l2cap, hdr->ident, buf);
 			break;
 		}
-	/* Fall-through */
+		__fallthrough;
 	default:
 		BT_WARN("Unknown L2CAP PDU code 0x%02x", hdr->code);
 		l2cap_send_reject(chan->conn, hdr->ident,

--- a/subsys/bluetooth/host/rfcomm.c
+++ b/subsys/bluetooth/host/rfcomm.c
@@ -809,7 +809,7 @@ static int rfcomm_dlc_close(struct bt_rfcomm_dlc *dlc)
 		if (dlc->role == BT_RFCOMM_ROLE_ACCEPTOR) {
 			rfcomm_send_dm(dlc->session, dlc->dlci);
 		}
-		/* Fall Through */
+		__fallthrough;
 	case BT_RFCOMM_STATE_INIT:
 		rfcomm_dlc_drop(dlc);
 		break;

--- a/subsys/bluetooth/host/ssp.c
+++ b/subsys/bluetooth/host/ssp.c
@@ -458,7 +458,7 @@ void hci_evt_link_key_notify(struct net_buf *buf)
 		break;
 	case BT_LK_AUTH_COMBINATION_P192:
 		conn->br.link_key->flags |= BT_LINK_KEY_AUTHENTICATED;
-		/* fall through */
+		__fallthrough;
 	case BT_LK_UNAUTH_COMBINATION_P192:
 		/* Mark no-bond so that link-key is removed on disconnection */
 		if (ssp_get_auth(conn) < BT_HCI_DEDICATED_BONDING) {
@@ -469,7 +469,7 @@ void hci_evt_link_key_notify(struct net_buf *buf)
 		break;
 	case BT_LK_AUTH_COMBINATION_P256:
 		conn->br.link_key->flags |= BT_LINK_KEY_AUTHENTICATED;
-		/* fall through */
+		__fallthrough;
 	case BT_LK_UNAUTH_COMBINATION_P256:
 		conn->br.link_key->flags |= BT_LINK_KEY_SC;
 

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -2210,7 +2210,7 @@ static void net_key_update(struct bt_mesh_model *model,
 			send_net_key_status(model, ctx, idx, STATUS_SUCCESS);
 			return;
 		}
-		/* fall through */
+		__fallthrough;
 	case BT_MESH_KR_PHASE_2:
 	case BT_MESH_KR_PHASE_3:
 		send_net_key_status(model, ctx, idx, STATUS_CANNOT_UPDATE);

--- a/subsys/bluetooth/mesh/lpn.c
+++ b/subsys/bluetooth/mesh/lpn.c
@@ -749,7 +749,7 @@ static void lpn_timeout(struct k_work *work)
 		if (IS_ENABLED(CONFIG_BT_MESH_LPN_ESTABLISHMENT)) {
 			bt_mesh_scan_disable();
 		}
-		/* fall through */
+		__fallthrough;
 	case BT_MESH_LPN_ENABLED:
 		send_friend_req(lpn);
 		break;

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -531,6 +531,7 @@ bool bt_mesh_kr_update(struct bt_mesh_subnet *sub, uint8_t new_kr, bool new_key)
 		 *
 		 * Intentional fall-through.
 		 */
+			__fallthrough;
 		case BT_MESH_KR_PHASE_2:
 			BT_DBG("KR Phase 0x%02x -> Normal", sub->kr_phase);
 			bt_mesh_net_revoke_keys(sub);

--- a/subsys/canbus/canopen/canopen_program.c
+++ b/subsys/canbus/canopen/canopen_program.c
@@ -266,7 +266,7 @@ static CO_SDO_abortCode_t canopen_odf_1f51(CO_ODF_arg_t *odf_arg)
 		ab = canopen_program_cmd_confirm();
 		break;
 	case PROGRAM_CTRL_RESET:
-		/* Fallthrough */
+		__fallthrough;
 	default:
 		LOG_DBG("unsupported command '%d'", cmd);
 		ab = CO_SDO_AB_INVALID_VALUE;

--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -298,7 +298,7 @@ static void receive_state_machine(struct isotp_recv_ctx *ctx)
 
 		ctx->wft = ISOTP_WFT_FIRST;
 		ctx->state = ISOTP_RX_STATE_TRY_ALLOC;
-		/* FALLTHROUGH */
+		__fallthrough;
 	case ISOTP_RX_STATE_TRY_ALLOC:
 		LOG_DBG("SM try to allocate");
 		z_abort_timeout(&ctx->timeout);
@@ -309,7 +309,7 @@ static void receive_state_machine(struct isotp_recv_ctx *ctx)
 		}
 
 		ctx->state = ISOTP_RX_STATE_SEND_FC;
-		/* FALLTHROUGH */
+		__fallthrough;
 	case ISOTP_RX_STATE_SEND_FC:
 		LOG_DBG("SM send CTS FC frame");
 		receive_send_fc(ctx, ISOTP_PCI_FS_CTS);
@@ -333,7 +333,7 @@ static void receive_state_machine(struct isotp_recv_ctx *ctx)
 		LOG_ERR("Sent %d wait frames. Giving up to alloc now",
 			ctx->wft);
 		receive_report_error(ctx, ISOTP_N_BUFFER_OVERFLW);
-		/* FALLTHROUGH */
+		__fallthrough;
 	case ISOTP_RX_STATE_ERR:
 		LOG_DBG("SM ERR state. err nr: %d", ctx->error_nr);
 		z_abort_timeout(&ctx->timeout);
@@ -346,7 +346,7 @@ static void receive_state_machine(struct isotp_recv_ctx *ctx)
 		net_buf_unref(ctx->buf);
 		ctx->buf = NULL;
 		ctx->state = ISOTP_RX_STATE_RECYCLE;
-		/* FALLTHROUGH */
+		__fallthrough;
 	case ISOTP_RX_STATE_RECYCLE:
 		LOG_DBG("SM recycle context for next message");
 		ctx->buf = net_buf_alloc_fixed(&isotp_rx_sf_ff_pool, K_NO_WAIT);
@@ -360,7 +360,7 @@ static void receive_state_machine(struct isotp_recv_ctx *ctx)
 		sys_slist_find_and_remove(&global_ctx.ff_sf_alloc_list,
 					  &ctx->alloc_node);
 		ctx->state = ISOTP_RX_STATE_WAIT_FF_SF;
-		/* FALLTHROUGH */
+		__fallthrough;
 	case ISOTP_RX_STATE_UNBOUND:
 		break;
 
@@ -1044,7 +1044,7 @@ static void send_state_machine(struct isotp_send_ctx *ctx)
 
 	case ISOTP_TX_ERR:
 		LOG_DBG("SM error");
-		/* FALLTHROUGH */
+		__fallthrough;
 	case ISOTP_TX_WAIT_FIN:
 		if (ctx->filter_id >= 0) {
 			can_detach(ctx->can_dev, ctx->filter_id);

--- a/subsys/mgmt/osdp/src/osdp_pd.c
+++ b/subsys/mgmt/osdp/src/osdp_pd.c
@@ -581,7 +581,7 @@ void osdp_update(struct osdp *ctx)
 			pd_decode_command(pd, pd->rx_buf, pd->rx_buf_len);
 		}
 		pd->pd_state = OSDP_PD_STATE_SEND_REPLY;
-		/* FALLTHRU */
+		__fallthrough;
 	case OSDP_PD_STATE_SEND_REPLY:
 		if (pd_send_reply(pd) == -1) {
 			pd->pd_state = OSDP_PD_STATE_ERR;

--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -533,7 +533,7 @@ static uint32_t dhcph4_manage_timers(struct net_if *iface, int64_t timeout)
 		break;
 	case NET_DHCPV4_INIT:
 		dhcpv4_enter_selecting(iface);
-		/* Fall through, as discover msg needs to be sent */
+		__fallthrough;
 	case NET_DHCPV4_SELECTING:
 		/* Failed to get OFFER message, send DISCOVER again */
 		return dhcpv4_send_discover(iface);
@@ -1147,7 +1147,7 @@ void net_dhcpv4_stop(struct net_if *iface)
 			NET_DBG("Failed to remove addr from iface");
 		}
 
-		/* Fall through */
+		__fallthrough;
 	case NET_DHCPV4_INIT:
 	case NET_DHCPV4_SELECTING:
 	case NET_DHCPV4_REQUESTING:

--- a/subsys/net/ip/ipv4_autoconf.c
+++ b/subsys/net/ip/ipv4_autoconf.c
@@ -195,7 +195,7 @@ static void ipv4_autoconf_send(struct net_if_ipv4_autoconf *ipv4auto)
 			ipv4_autoconf_send_probe(ipv4auto);
 			break;
 		}
-	/* passthrough */
+		__fallthrough;
 	case NET_IPV4_AUTOCONF_ANNOUNCE:
 		if (ipv4auto->announce_cnt <=
 		    (IPV4_AUTOCONF_ANNOUNCE_NUM - 1)) {

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -154,7 +154,7 @@ static inline bool ipv6_drop_on_unknown_option(struct net_pkt *pkt,
 			break;
 		}
 
-		/* passthrough */
+		__fallthrough;
 	case 0x80:
 		net_icmpv6_send_error(pkt, NET_ICMPV6_PARAM_PROBLEM,
 				      NET_ICMPV6_PARAM_PROB_OPTION,

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -1490,6 +1490,7 @@ static void ipv6_nd_reachable_timeout(struct k_work *work)
 				data->state);
 
 			/* Intentionally continuing to probe state */
+			__fallthrough;
 
 		case NET_IPV6_NBR_STATE_PROBE:
 			if (data->ns_count >= MAX_UNICAST_SOLICIT) {

--- a/subsys/net/l2/ethernet/gptp/gptp_md.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_md.c
@@ -612,7 +612,7 @@ static void gptp_md_pdelay_req_state_machine(int port)
 
 	case GPTP_PDELAY_REQ_INITIAL_SEND_REQ:
 		gptp_md_start_pdelay_req(port);
-		/* Fallthrough. */
+		__fallthrough;
 
 	case GPTP_PDELAY_REQ_SEND_REQ:
 		if (state->tx_pdelay_req_ptr) {

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -435,7 +435,7 @@ static void gptp_mi_pss_rcv_state_machine(int port)
 		k_timer_stop(&state->rcv_sync_receipt_timeout_timer);
 		state->rcv_sync_receipt_timeout_timer_expired = false;
 
-		/* Fallthrough. */
+		__fallthrough;
 	case GPTP_PSS_RCV_RECEIVED_SYNC:
 		if (state->rcvd_md_sync) {
 			state->rcvd_md_sync = false;
@@ -541,7 +541,7 @@ static void gptp_mi_pss_send_state_machine(int port)
 			break;
 		}
 
-		/* Fallthrough. */
+		__fallthrough;
 	case GPTP_PSS_SEND_SEND_MD_SYNC:
 		if (state->rcvd_pss_sync) {
 			gptp_mi_pss_store_last_pss(port);
@@ -566,7 +566,7 @@ static void gptp_mi_pss_send_state_machine(int port)
 
 		gptp_mi_pss_send_md_sync_send(port);
 
-		/* Fallthrough. */
+		__fallthrough;
 	case GPTP_PSS_SEND_SET_SYNC_RECEIPT_TIMEOUT:
 		/* Test conditions have been slightly rearranged compared to
 		 * their definitions in the standard in order not to test
@@ -1446,7 +1446,7 @@ static void gptp_mi_port_announce_information_state_machine(int port)
 					  GPTP_PA_INFO_POST_DISABLED);
 		k_timer_stop(&state->ann_rcpt_expiry_timer);
 		state->ann_expired = true;
-		/* Fallthrough. */
+		__fallthrough;
 
 	case GPTP_PA_INFO_POST_DISABLED:
 		if (port_ds->ptt_port_enabled && port_ds->as_capable) {
@@ -1515,7 +1515,7 @@ static void gptp_mi_port_announce_information_state_machine(int port)
 				GPTP_PA_INFO_REPEATED_MASTER_PORT);
 			break;
 		case GPTP_RCVD_INFO_INFERIOR_MASTER_INFO:
-			/* Fallthrough. */
+			__fallthrough;
 		case GPTP_RCVD_INFO_OTHER_INFO:
 			gptp_change_pa_info_state(port, state,
 				GPTP_PA_INFO_INFERIOR_MASTER_OR_OTHER_PORT);
@@ -1551,7 +1551,7 @@ static void gptp_mi_port_announce_information_state_machine(int port)
 		bmca_data->info_is = GPTP_INFO_IS_RECEIVED;
 		CLEAR_SELECTED(global_ds, port);
 		SET_RESELECT(global_ds, port);
-		/* Fallthrough. */
+		__fallthrough;
 
 	case GPTP_PA_INFO_REPEATED_MASTER_PORT:
 		k_timer_stop(&state->ann_rcpt_expiry_timer);
@@ -1560,7 +1560,7 @@ static void gptp_mi_port_announce_information_state_machine(int port)
 			      K_MSEC(gptp_uscaled_ns_to_timer_ms(
 				  &bmca_data->ann_rcpt_timeout_time_interval)),
 			      K_NO_WAIT);
-		/* Fallthrough. */
+		__fallthrough;
 
 	case GPTP_PA_INFO_INFERIOR_MASTER_OR_OTHER_PORT:
 		if (bmca_data->rcvd_announce_ptr != NULL) {
@@ -1904,7 +1904,7 @@ static void gptp_mi_port_role_selection_state_machine(void)
 
 		/* Be sure to enter the "if" statement immediately after. */
 		GPTP_GLOBAL_DS()->reselect_array = ~0;
-		/* Fallthrough. */
+		__fallthrough;
 
 	case GPTP_PR_SELECTION_ROLE_SELECTION:
 		if (GPTP_GLOBAL_DS()->reselect_array != 0) {
@@ -1949,7 +1949,7 @@ static void gptp_mi_port_announce_transmit_state_machine(int port)
 	switch (state->state) {
 	case GPTP_PA_TRANSMIT_INIT:
 		bmca_data->new_info = true;
-		/* Fallthrough. */
+		__fallthrough;
 
 	case GPTP_PA_TRANSMIT_IDLE:
 		k_timer_stop(&state->ann_send_periodic_timer);
@@ -1960,7 +1960,7 @@ static void gptp_mi_port_announce_transmit_state_machine(int port)
 			      K_NO_WAIT);
 
 		state->state = GPTP_PA_TRANSMIT_POST_IDLE;
-		/* Fallthrough. */
+		__fallthrough;
 
 	case GPTP_PA_TRANSMIT_POST_IDLE:
 		if (IS_SELECTED(global_ds, port) &&

--- a/subsys/net/l2/ieee802154/ieee802154_frame.c
+++ b/subsys/net/l2/ieee802154/ieee802154_frame.c
@@ -297,12 +297,12 @@ validate_mac_command(struct ieee802154_mpdu *mpdu, uint8_t *buf, uint8_t *length
 		break;
 	case IEEE802154_CFI_ASSOCIATION_RESPONSE:
 		len += IEEE802154_CMD_ASSOC_RES_LENGTH;
-		/* Fall through */
+		__fallthrough;
 	case IEEE802154_CFI_DISASSOCIATION_NOTIFICATION:
 		if (c->cfi == IEEE802154_CFI_DISASSOCIATION_NOTIFICATION) {
 			len += IEEE802154_CMD_DISASSOC_NOTE_LENGTH;
 		}
-		/* Fall through */
+		__fallthrough;
 	case IEEE802154_CFI_PAN_ID_CONLICT_NOTIFICATION:
 		ar = 1U;
 		comp = 1U;
@@ -785,7 +785,7 @@ static inline bool cfi_to_fs_settings(enum ieee802154_cfi cfi,
 		fs->fc.ar = 1U;
 		fs->fc.pan_id_comp = 1U;
 
-		/* Fall through for common src/dst addr mode handling */
+		__fallthrough;
 	case IEEE802154_CFI_ASSOCIATION_REQUEST:
 		fs->fc.src_addr_mode = IEEE802154_ADDR_MODE_EXTENDED;
 

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1155,27 +1155,27 @@ void dns_init_resolver(void)
 #if DNS_SERVER_COUNT > 4
 	case 5:
 		dns_servers[4] = CONFIG_DNS_SERVER5;
-		/* fallthrough */
+		__fallthrough;
 #endif
 #if DNS_SERVER_COUNT > 3
 	case 4:
 		dns_servers[3] = CONFIG_DNS_SERVER4;
-		/* fallthrough */
+		__fallthrough;
 #endif
 #if DNS_SERVER_COUNT > 2
 	case 3:
 		dns_servers[2] = CONFIG_DNS_SERVER3;
-		/* fallthrough */
+		__fallthrough;
 #endif
 #if DNS_SERVER_COUNT > 1
 	case 2:
 		dns_servers[1] = CONFIG_DNS_SERVER2;
-		/* fallthrough */
+		__fallthrough;
 #endif
 #if DNS_SERVER_COUNT > 0
 	case 1:
 		dns_servers[0] = CONFIG_DNS_SERVER1;
-		/* fallthrough */
+		__fallthrough;
 #endif
 	case 0:
 		break;

--- a/subsys/net/lib/http/http_parser.c
+++ b/subsys/net/lib/http/http_parser.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
+#include <toolchain.h>
 
 #ifndef ULLONG_MAX
 # define ULLONG_MAX ((uint64_t) -1) /* 2^64-1 */
@@ -1569,7 +1570,7 @@ reexecute:
 				break;
 			}
 
-		/* FALLTHROUGH */
+			__fallthrough;
 
 		case s_header_value_start: {
 			MARK(header_value);
@@ -1858,6 +1859,7 @@ reexecute:
 
 				case 2:
 					parser->upgrade = 1U;
+					__fallthrough;
 
 				case 1:
 					parser->flags |= F_SKIPBODY;

--- a/subsys/net/lib/http/http_parser_url.c
+++ b/subsys/net/lib/http/http_parser_url.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <limits.h>
 #include <net/http_parser_url.h>
+#include <toolchain.h>
 
 #ifndef BIT_AT
 # define BIT_AT(a, i)                                                \
@@ -200,7 +201,7 @@ enum state parse_url_char(enum state s, const char ch)
 			return s_dead;
 		}
 
-	/* FALLTHROUGH */
+		__fallthrough;
 	case s_req_server_start:
 	case s_req_server:
 		if (ch == '/') {
@@ -322,7 +323,7 @@ http_parse_host_char(enum http_host_state s, const char ch)
 			return s_http_host;
 		}
 
-	/* FALLTHROUGH */
+		__fallthrough;
 	case s_http_host_v6_end:
 		if (ch == ':') {
 			return s_http_host_port_start;
@@ -335,7 +336,7 @@ http_parse_host_char(enum http_host_state s, const char ch)
 			return s_http_host_v6_end;
 		}
 
-	/* FALLTHROUGH */
+		__fallthrough;
 	case s_http_host_v6_start:
 		if (IS_HEX(ch) || ch == ':' || ch == '.') {
 			return s_http_host_v6;
@@ -351,7 +352,7 @@ http_parse_host_char(enum http_host_state s, const char ch)
 			return s_http_host_v6_end;
 		}
 
-	/* FALLTHROUGH */
+		__fallthrough;
 	case s_http_host_v6_zone_start:
 		/* RFC 6874 Zone ID consists of 1*( unreserved / pct-encoded) */
 		if (IS_ALPHANUM(ch) || ch == '%' || ch == '.' || ch == '-' ||
@@ -501,8 +502,8 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
 
 		case s_req_server_with_at:
 			found_at = 1;
+			__fallthrough;
 
-		/* FALLTROUGH */
 		case s_req_server:
 			uf = UF_HOST;
 			break;

--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -235,7 +235,7 @@ static int json_next_token(struct lwm2m_input_context *in,
 				break;
 			}
 
-			/* fallthrough */
+			__fallthrough;
 
 		default:
 			json_add_char(in, fd);

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1627,7 +1627,7 @@ static ssize_t recvfrom_dtls_server(struct net_context *ctx, void *buf,
 		switch (ret) {
 		case MBEDTLS_ERR_SSL_TIMEOUT:
 			(void)mbedtls_ssl_close_notify(&ctx->tls->ssl);
-			/* fallthrough */
+			__fallthrough;
 
 		case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY:
 		case MBEDTLS_ERR_SSL_CLIENT_RECONNECT:

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -999,8 +999,7 @@ static void state_collect(const struct shell *shell)
 			case '4': /* END Button in ESC[n~ mode */
 				receive_state_change(shell,
 						SHELL_RECEIVE_TILDE_EXP);
-				/* fall through */
-				/* no break */
+				__fallthrough;
 			case 'F': /* END Button in VT100 mode */
 				shell_op_cursor_end_move(shell);
 				break;
@@ -1008,8 +1007,7 @@ static void state_collect(const struct shell *shell)
 			case '1': /* HOME Button in ESC[n~ mode */
 				receive_state_change(shell,
 						SHELL_RECEIVE_TILDE_EXP);
-				/* fall through */
-				/* no break */
+				__fallthrough;
 			case 'H': /* HOME Button in VT100 mode */
 				shell_op_cursor_home_move(shell);
 				break;
@@ -1017,8 +1015,7 @@ static void state_collect(const struct shell *shell)
 			case '2': /* INSERT Button in ESC[n~ mode */
 				receive_state_change(shell,
 						SHELL_RECEIVE_TILDE_EXP);
-				/* fall through */
-				/* no break */
+				__fallthrough;
 			case 'L': {/* INSERT Button in VT100 mode */
 				bool status = flag_insert_mode_get(shell);
 				flag_insert_mode_set(shell, !status);

--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -199,8 +199,7 @@ static void put(const struct log_backend *const backend, struct log_msg *msg)
 		break;
 
 	case SHELL_LOG_BACKEND_DISABLED:
-		/* fall through */
-		/* no break */
+		__fallthrough;
 	default:
 		/* Discard message. */
 		log_msg_put(msg);

--- a/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
+++ b/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
@@ -122,7 +122,7 @@ static void tmbox_put(struct k_mbox *pmbox)
 		k_mbox_put(pmbox, &mmsg, K_FOREVER);
 		break;
 	case PUT_GET_BUFFER:
-	/*fall through*/
+		__fallthrough;
 	case TARGET_SOURCE_THREAD_BUFFER:
 		/**TESTPOINT: mbox sync put buffer*/
 		mmsg.info = PUT_GET_BUFFER;
@@ -146,7 +146,7 @@ static void tmbox_put(struct k_mbox *pmbox)
 		k_sem_take(&sync_sema, K_FOREVER);
 		break;
 	case ASYNC_PUT_GET_BLOCK:
-	/*fall through*/
+		__fallthrough;
 	case TARGET_SOURCE_THREAD_BLOCK:
 		/**TESTPOINT: mbox async put mem block*/
 		mmsg.info = ASYNC_PUT_GET_BLOCK;
@@ -317,7 +317,7 @@ static void tmbox_get(struct k_mbox *pmbox)
 		zassert_equal(mmsg.size, 0, NULL);
 		break;
 	case PUT_GET_BUFFER:
-	/*fall through*/
+		__fallthrough;
 	case TARGET_SOURCE_THREAD_BUFFER:
 		/**TESTPOINT: mbox sync get buffer*/
 		mmsg.size = sizeof(rxdata);
@@ -347,7 +347,7 @@ static void tmbox_get(struct k_mbox *pmbox)
 			     NULL);
 		break;
 	case ASYNC_PUT_GET_BLOCK:
-	/*fall through*/
+		__fallthrough;
 	case TARGET_SOURCE_THREAD_BLOCK:
 		/**TESTPOINT: mbox async get mem block*/
 		mmsg.size = MAIL_LEN;

--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -346,7 +346,7 @@ int join_scenario(enum control_method m)
 		break;
 	case OTHER_ABORT_TIMEOUT:
 		timeout = K_MSEC(JOIN_TIMEOUT_MS);
-		/* Fall through */
+		__fallthrough;
 	case OTHER_ABORT:
 		printk("ztest_thread: create control_thread\n");
 		k_thread_create(&control_thread, control_stack, STACK_SIZE,


### PR DESCRIPTION
Option -Wimplicit-fallthrough as the name suggests raises a warning when
there is an implicit fallthrough in a switch clause. This warning does
not happen when the last statement is a return or a call to a function
declared with noreturn attribute.

This flag helps to enforce two MISRA-C rules (not completely), 16.1 and
16.3