### PR TITLE
code-guideline: Tag name should be a unique identifier

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -208,7 +208,7 @@ struct device {
 	void * const data;
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 	/** Power Management function */
-	int (*device_pm_control)(struct device *device, uint32_t command,
+	int (*device_pm_control)(struct device *dev, uint32_t command,
 				 void *context, device_pm_cb cb, void *arg);
 	/** Pointer to device instance power management data */
 	struct device_pm * const pm;
@@ -374,7 +374,7 @@ int device_pm_control_nop(struct device *unused_device,
  * Called by the application or power management service to let the device do
  * required operations when moving to the required power state
  * Note that devices may support just some of the device power states
- * @param device Pointer to device structure of the driver instance.
+ * @param dev Pointer to device structure of the driver instance.
  * @param device_power_state Device power state to be set
  * @param cb Callback function to notify device power status
  * @param arg Caller passed argument to callback function
@@ -382,11 +382,11 @@ int device_pm_control_nop(struct device *unused_device,
  * @retval 0 If successful in queuing the request or changing the state.
  * @retval Errno Negative errno code if failure. Callback will not be called.
  */
-static inline int device_set_power_state(struct device *device,
+static inline int device_set_power_state(struct device *dev,
 					 uint32_t device_power_state,
 					 device_pm_cb cb, void *arg)
 {
-	return device->device_pm_control(device,
+	return dev->device_pm_control(dev,
 					 DEVICE_PM_SET_POWER_STATE,
 					 &device_power_state, cb, arg);
 }
@@ -398,16 +398,16 @@ static inline int device_set_power_state(struct device *device,
  * power state at any time. This state will be one of the defined
  * power states allowed for the devices in that system
  *
- * @param device pointer to device structure of the driver instance.
+ * @param dev pointer to device structure of the driver instance.
  * @param device_power_state Device power state to be filled by the device
  *
  * @retval 0 If successful.
  * @retval Errno Negative errno code if failure.
  */
-static inline int device_get_power_state(struct device *device,
+static inline int device_get_power_state(struct device *dev,
 					 uint32_t *device_power_state)
 {
-	return device->device_pm_control(device,
+	return dev->device_pm_control(dev,
 					 DEVICE_PM_GET_POWER_STATE,
 					 device_power_state,
 					 NULL, NULL);

--- a/include/init.h
+++ b/include/init.h
@@ -51,12 +51,12 @@ struct init_entry {
 	struct device *dev;
 };
 
-void z_sys_init_run_level(int32_t level);
+void z_sys_init_run_level(int32_t _level);
 
 /* A counter is used to avoid issues when two or more system devices
  * are declared in the same C file with the same init function.
  */
-#define Z_SYS_NAME(init_fn) _CONCAT(_CONCAT(sys_init_, init_fn), __COUNTER__)
+#define Z_SYS_NAME(_init_fn) _CONCAT(_CONCAT(sys_init_, _init_fn), __COUNTER__)
 
 /**
  * @def Z_INIT_ENTRY_DEFINE
@@ -69,25 +69,25 @@ void z_sys_init_run_level(int32_t level);
  * not be used directly, use relevant macro such as SYS_INIT() or
  * DEVICE_AND_API_INIT() instead.
  *
- * @param entry_name Init entry name. It is the name this instance exposes to
+ * @param _entry_name Init entry name. It is the name this instance exposes to
  * the system.
  *
- * @param init_fn Address to the init function of the entry.
+ * @param _init_fn Address to the init function of the entry.
  *
- * @param device A device driver instance pointer or NULL
+ * @param _device A device driver instance pointer or NULL
  *
- * @param level The initialization level at which configuration
+ * @param _level The initialization level at which configuration
  * occurs.  See SYS_INIT().
  *
  * @param prio The initialization priority of the object, relative to
  * other objects of the same initialization level. See SYS_INIT().
  */
-#define Z_INIT_ENTRY_DEFINE(entry_name, init_fn, device, level, prio)	\
+#define Z_INIT_ENTRY_DEFINE(_entry_name, _init_fn, _device, _level, _prio)	\
 	static const Z_DECL_ALIGN(struct init_entry)			\
-		_CONCAT(__init_, entry_name) __used			\
-	__attribute__((__section__(".init_" #level STRINGIFY(prio)))) = { \
-		.init = (init_fn),					\
-		.dev = (device),					\
+		_CONCAT(__init_, _entry_name) __used			\
+	__attribute__((__section__(".init_" #_level STRINGIFY(_prio)))) = { \
+		.init = (_init_fn),					\
+		.dev = (_device),					\
 	}
 
 /**
@@ -99,9 +99,9 @@ void z_sys_init_run_level(int32_t level);
  *
  * @details This macro lets you run a function at system boot.
  *
- * @param init_fn Pointer to the boot function to run
+ * @param _init_fn Pointer to the boot function to run
  *
- * @param level The initialization level at which configuration occurs.
+ * @param _level The initialization level at which configuration occurs.
  * Must be one of the following symbols, which are listed in the order
  * they are performed by the kernel:
  * \n
@@ -124,7 +124,7 @@ void z_sys_init_run_level(int32_t level);
  * that need automatic configuration. These objects can use all services
  * provided by the kernel during configuration.
  *
- * @param prio The initialization priority of the object, relative to
+ * @param _prio The initialization priority of the object, relative to
  * other objects of the same initialization level. Specified as an integer
  * value in the range 0 to 99; lower values indicate earlier initialization.
  * Must be a decimal integer literal without leading zeroes or sign (e.g. 32),
@@ -132,8 +132,8 @@ void z_sys_init_run_level(int32_t level);
  * expressions are *not* permitted
  * (e.g. CONFIG_KERNEL_INIT_PRIORITY_DEFAULT + 5).
  */
-#define SYS_INIT(init_fn, level, prio)					\
-	Z_INIT_ENTRY_DEFINE(Z_SYS_NAME(init_fn), init_fn, NULL, level, prio)
+#define SYS_INIT(_init_fn, _level, _prio)					\
+	Z_INIT_ENTRY_DEFINE(Z_SYS_NAME(_init_fn), _init_fn, NULL, _level, _prio)
 
 #ifdef __cplusplus
 }

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -5037,25 +5037,25 @@ struct k_poll_event {
 	};
 };
 
-#define K_POLL_EVENT_INITIALIZER(event_type, event_mode, event_obj) \
+#define K_POLL_EVENT_INITIALIZER(_event_type, _event_mode, _event_obj) \
 	{ \
 	.poller = NULL, \
-	.type = event_type, \
+	.type = _event_type, \
 	.state = K_POLL_STATE_NOT_READY, \
-	.mode = event_mode, \
+	.mode = _event_mode, \
 	.unused = 0, \
-	.obj = event_obj, \
+	.obj = _event_obj, \
 	}
 
-#define K_POLL_EVENT_STATIC_INITIALIZER(event_type, event_mode, event_obj, \
+#define K_POLL_EVENT_STATIC_INITIALIZER(_event_type, _event_mode, _event_obj, \
 					event_tag) \
 	{ \
 	.tag = event_tag, \
-	.type = event_type, \
+	.type = _event_type, \
 	.state = K_POLL_STATE_NOT_READY, \
-	.mode = event_mode, \
+	.mode = _event_mode, \
 	.unused = 0, \
-	.obj = event_obj, \
+	.obj = _event_obj, \
 	}
 
 /**

--- a/include/sys/device_mmio.h
+++ b/include/sys/device_mmio.h
@@ -204,18 +204,18 @@ struct z_device_mmio_rom {
 #define DEVICE_MMIO_ROM		struct z_device_mmio_rom _mmio
 
 /**
- * @def DEVICE_MMIO_ROM_PTR(device)
+ * @def DEVICE_MMIO_ROM_PTR(dev)
  *
  * Return a pointer to the ROM-based storage area for a device's MMIO
  * information. This macro will not work properly if the ROM storage
  * was omitted from the config struct declaration, and should not
  * be used in this case.
  *
- * @param device device instance object
+ * @param dev device instance object
  * @retval struct device_mmio_rom * pointer to storage location
  */
-#define DEVICE_MMIO_ROM_PTR(device) \
-	((struct z_device_mmio_rom *)((device)->config))
+#define DEVICE_MMIO_ROM_PTR(dev) \
+	((struct z_device_mmio_rom *)((dev)->config))
 
 /**
  * @def DEVICE_MMIO_ROM_INIT(node_id)
@@ -253,21 +253,21 @@ struct z_device_mmio_rom {
  * one of the DEVICE_CACHE_* macros. Unused bits are reserved for future
  * expansion.
  *
- * @param device Device object instance
+ * @param dev Device object instance
  * @param flags cache mode flags
  */
 #ifdef DEVICE_MMIO_IS_IN_RAM
-#define DEVICE_MMIO_MAP(device, flags) \
-	device_map(DEVICE_MMIO_RAM_PTR(device), \
-		   DEVICE_MMIO_ROM_PTR(device)->phys_addr, \
-		   DEVICE_MMIO_ROM_PTR(device)->size, \
+#define DEVICE_MMIO_MAP(dev, flags) \
+	device_map(DEVICE_MMIO_RAM_PTR(dev), \
+		   DEVICE_MMIO_ROM_PTR(dev)->phys_addr, \
+		   DEVICE_MMIO_ROM_PTR(dev)->size, \
 		   (flags))
 #else
-#define DEVICE_MMIO_MAP(device, flags) do { } while (0)
+#define DEVICE_MMIO_MAP(dev, flags) do { } while (0)
 #endif
 
 /**
- * @def DEVICE_MMIO_GET(device)
+ * @def DEVICE_MMIO_GET(dev)
  *
  * @brief Obtain the MMIO address for a device
  *
@@ -282,13 +282,13 @@ struct z_device_mmio_rom {
  * This is for drivers which have exactly one MMIO region.
  * A call must have been made to device_map() in the driver init function.
  *
- * @param device Device object
+ * @param dev Device object
  * @return mm_reg_t  linear address of the MMIO region
  */
 #ifdef DEVICE_MMIO_IS_IN_RAM
-#define DEVICE_MMIO_GET(device)	(*DEVICE_MMIO_RAM_PTR(device))
+#define DEVICE_MMIO_GET(dev)	(*DEVICE_MMIO_RAM_PTR(dev))
 #else
-#define DEVICE_MMIO_GET(device)	(DEVICE_MMIO_ROM_PTR(device)->addr)
+#define DEVICE_MMIO_GET(dev)	(DEVICE_MMIO_ROM_PTR(dev)->addr)
 #endif
 /** @} */
 
@@ -340,19 +340,19 @@ struct z_device_mmio_rom {
 
 #ifdef DEVICE_MMIO_IS_IN_RAM
 /**
- * @def DEVICE_MMIO_NAMED_RAM_PTR(device, name)
+ * @def DEVICE_MMIO_NAMED_RAM_PTR(dev, name)
  *
  * @brief Return a pointer to the RAM storage for a device's named MMIO address
  *
  * This macro requires that the macro DEV_DATA is locally defined and returns
  * a properly typed pointer to the particular dev_data struct for this driver.
  *
- * @param device device instance object
+ * @param dev device instance object
  * @param name Member name within dev_data
  * @retval mm_reg_t  pointer to storage location
  */
-#define DEVICE_MMIO_NAMED_RAM_PTR(device, name) \
-		(&(DEV_DATA(device)->name))
+#define DEVICE_MMIO_NAMED_RAM_PTR(dev, name) \
+		(&(DEV_DATA(dev)->name))
 #endif /* DEVICE_MMIO_IS_IN_RAM */
 
 /**
@@ -391,7 +391,7 @@ struct z_device_mmio_rom {
 #define DEVICE_MMIO_NAMED_ROM(name) struct z_device_mmio_rom name
 
 /**
- * @def DEVICE_MMIO_NAMED_ROM_PTR(device, name)
+ * @def DEVICE_MMIO_NAMED_ROM_PTR(dev, name)
  *
  * Return a pointer to the ROM-based storage area for a device's MMIO
  * information.
@@ -400,11 +400,11 @@ struct z_device_mmio_rom {
  * a properly typed pointer to the particular config struct for this
  * driver.
  *
- * @param device device instance object
+ * @param dev device instance object
  * @param name Member name within config
  * @retval struct device_mmio_rom * pointer to storage location
  */
-#define DEVICE_MMIO_NAMED_ROM_PTR(device, name) (&(DEV_CFG(device)->name))
+#define DEVICE_MMIO_NAMED_ROM_PTR(dev, name) (&(DEV_CFG(dev)->name))
 
 /**
  * @def DEVICE_MMIO_NAMED_ROM_INIT(name, node_id)
@@ -434,7 +434,7 @@ struct z_device_mmio_rom {
 	.name = Z_DEVICE_MMIO_ROM_INITIALIZER(node_id)
 
 /**
- * @def DEVICE_MMIO_NAMED_MAP(device, name, flags)
+ * @def DEVICE_MMIO_NAMED_MAP(dev, name, flags)
  *
  * @brief Set up memory for a named MMIO region
  *
@@ -456,23 +456,23 @@ struct z_device_mmio_rom {
  * one of the DEVICE_CACHE_* macros. Unused bits are reserved for future
  * expansion.
  *
- * @param device Device object
+ * @param dev Device object
  * @param name Member name for MMIO information, as declared with
  *             DEVICE_MMIO_NAMED_RAM/DEVICE_MMIO_NAMED_ROM
  * @param flags One of the DEVICE_CACHE_* caching modes
  */
 #ifdef DEVICE_MMIO_IS_IN_RAM
-#define DEVICE_MMIO_NAMED_MAP(device, name, flags) \
-	device_map(DEVICE_MMIO_NAMED_RAM_PTR((device), name), \
-		   (DEVICE_MMIO_NAMED_ROM_PTR((device), name)->phys_addr), \
-		   (DEVICE_MMIO_NAMED_ROM_PTR((device), name)->size), \
+#define DEVICE_MMIO_NAMED_MAP(dev, name, flags) \
+	device_map(DEVICE_MMIO_NAMED_RAM_PTR((dev), name), \
+		   (DEVICE_MMIO_NAMED_ROM_PTR((dev), name)->phys_addr), \
+		   (DEVICE_MMIO_NAMED_ROM_PTR((dev), name)->size), \
 		   (flags))
 #else
-#define DEVICE_MMIO_NAMED_MAP(device, name, flags) do { } while (0)
+#define DEVICE_MMIO_NAMED_MAP(dev, name, flags) do { } while (0)
 #endif
 
 /**
- * @def DEVICE_MMIO_NAMED_GET(device, name)
+ * @def DEVICE_MMIO_NAMED_GET(dev, name)
  *
  * @brief Obtain a named MMIO address for a device
  *
@@ -487,17 +487,17 @@ struct z_device_mmio_rom {
  *
  * @see DEVICE_MMIO_GET
  *
- * @param device Device object
+ * @param dev Device object
  * @param name Member name for MMIO information, as declared with
  *             DEVICE_MMIO_NAMED_RAM/DEVICE_MMIO_NAMED_ROM
  * @return mm_reg_t  linear address of the MMIO region
  */
 #ifdef DEVICE_MMIO_IS_IN_RAM
-#define DEVICE_MMIO_NAMED_GET(device, name) \
-		(*DEVICE_MMIO_NAMED_RAM_PTR((device), name))
+#define DEVICE_MMIO_NAMED_GET(dev, name) \
+		(*DEVICE_MMIO_NAMED_RAM_PTR((dev), name))
 #else
-#define DEVICE_MMIO_NAMED_GET(device, name) \
-		((DEVICE_MMIO_NAMED_ROM_PTR((device), name))->addr)
+#define DEVICE_MMIO_NAMED_GET(dev, name) \
+		((DEVICE_MMIO_NAMED_ROM_PTR((dev), name))->addr)
 #endif /* DEVICE_MMIO_IS_IN_RAM */
 
 /** @} */

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -420,17 +420,17 @@ int net_config_init(const char *app_info, uint32_t flags,
 	return net_config_init_by_iface(NULL, app_info, flags, timeout);
 }
 
-int net_config_init_app(struct device *device, const char *app_info)
+int net_config_init_app(struct device *dev, const char *app_info)
 {
 	struct net_if *iface = NULL;
 	uint32_t flags = 0U;
 	int ret;
 
-	if (device) {
-		iface = net_if_lookup_by_dev(device);
+	if (dev) {
+		iface = net_if_lookup_by_dev(dev);
 		if (iface == NULL) {
 			NET_WARN("No interface for device %p, using default",
-				 device);
+				 dev);
 		}
 	}
 
@@ -485,9 +485,9 @@ int net_config_init_app(struct device *device, const char *app_info)
 }
 
 #if defined(CONFIG_NET_CONFIG_AUTO_INIT)
-static int init_app(struct device *device)
+static int init_app(struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	(void)net_config_init_app(NULL, "Initializing network");
 


### PR DESCRIPTION
Following are the changes to variable names that are matching with tag names (Rule 5.7 violations)

In kernel.h, event_type is matching with a tag name in lib/os/onoff.c. Added a _ prefix to event_type and
also to the macro argument names.

In userspace.c, *dyn_obj is matching with the tag name dyn_obj in the file itslef. Changed it to dyn

In device.h, device_mmio.h, init.h and init.c, changed the *device to dev. Except for one instance
in init.h.

Signed-off-by: Spoorthy Priya Yerabolu <spoorthy.priya.yerabolu@intel.com>