### PR TITLE
edtlib: add lookup table for nodes from their dependency ordinals

### DIFF
--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -132,6 +132,10 @@ class EDT:
       A collections.OrderedDict that maps a node label to the node with
       that label.
 
+    dep_ord2node:
+      A collections.OrderedDict that maps an ordinal to the node with
+      that dependency ordinal.
+
     chosen_nodes:
       A collections.OrderedDict that maps the properties defined on the
       devicetree's /chosen node to their values. 'chosen' is indexed by
@@ -519,6 +523,7 @@ class EDT:
         # Initialize node lookup tables (LUTs).
 
         self.label2node = OrderedDict()
+        self.dep_ord2node = OrderedDict()
         self.compat2enabled = defaultdict(list)
         self.compat2nodes = defaultdict(list)
         self.compat2okay = defaultdict(list)
@@ -535,6 +540,10 @@ class EDT:
 
                 if node.status == "okay":
                     self.compat2okay[compat].append(node)
+
+        for nodeset in self.scc_order:
+            node = nodeset[0]
+            self.dep_ord2node[node.dep_ordinal] = node
 
     def _check_binding(self, binding, binding_path):
         # Does sanity checking on 'binding'. Only takes 'self' for the sake of

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -149,6 +149,16 @@ class EDT:
     bindings_dirs:
       The bindings directory paths passed to __init__()
 
+    scc_order:
+      A list of lists of Nodes. All elements of each list
+      depend on each other, and the Nodes in any list do not depend
+      on any Node in a subsequent list. Each list defines a Strongly
+      Connected Component (SCC) of the graph.
+
+      For an acyclic graph each list will be a singleton. Cycles
+      will be represented by lists with multiple nodes. Cycles are
+      not expected to be present in devicetree graphs.
+
     The standard library's pickle module can be used to marshal and
     unmarshal EDT objects.
     """
@@ -207,9 +217,8 @@ class EDT:
 
         self._init_compat2binding(bindings_dirs)
         self._init_nodes()
+        self._init_graph()
         self._init_luts()
-
-        self._define_order()
 
         # Drop the reference to the open warn file. This is necessary
         # to make this object pickleable, but also allows it to get
@@ -261,26 +270,20 @@ class EDT:
         return "<EDT for '{}', binding directories '{}'>".format(
             self.dts_path, self.bindings_dirs)
 
+    @property
     def scc_order(self):
-        """
-        Returns a list of lists of Nodes where all elements of each list
-        depend on each other, and the Nodes in any list do not depend
-        on any Node in a subsequent list.  Each list defines a Strongly
-        Connected Component (SCC) of the graph.
-
-        For an acyclic graph each list will be a singleton.  Cycles
-        will be represented by lists with multiple nodes.  Cycles are
-        not expected to be present in devicetree graphs.
-        """
         try:
             return self._graph.scc_order()
         except Exception as e:
             raise EDTError(e)
 
-    def _define_order(self):
+    def _init_graph(self):
         # Constructs a graph of dependencies between Node instances,
-        # then calculates a partial order over the dependencies.  The
-        # algorithm supports detecting dependency loops.
+        # which is usable for computing a partial order over the dependencies.
+        # The algorithm supports detecting dependency loops.
+        #
+        # Actually computing the SCC order is lazily deferred to the
+        # first time the scc_order property is read.
 
         self._graph = Graph()
 
@@ -305,11 +308,6 @@ class EDT:
             # generates.
             for intr in node.interrupts:
                 self._graph.add_edge(node, intr.controller)
-
-        # Calculate an order that ensures no node is before any node
-        # it depends on.  This sets the dep_ordinal field in each
-        # Node.
-        self.scc_order()
 
     def _init_compat2binding(self, bindings_dirs):
         # Creates self._compat2binding. This is a dictionary that maps

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -155,7 +155,7 @@ Directories with bindings:
 Nodes in dependency order (ordinal and path):
 """
 
-    for scc in edt.scc_order():
+    for scc in edt.scc_order:
         if len(scc) > 1:
             err("cycle in devicetree involving "
                 + ", ".join(node.path for node in scc))

--- a/scripts/dts/gen_legacy_defines.py
+++ b/scripts/dts/gen_legacy_defines.py
@@ -98,7 +98,7 @@ Directories with bindings:
 Nodes in dependency order (ordinal and path):
 """
 
-    for scc in edt.scc_order():
+    for scc in edt.scc_order:
         if len(scc) > 1:
             err("cycle in devicetree involving "
                 + ", ".join(node.path for node in scc))

--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -242,22 +242,23 @@
 		uint8-array = [ 12 34 ];
 		string = "foo";
 		string-array = "foo", "bar", "baz";
-		phandle-ref = < &{/props/ctrl-1} >;
-		phandle-refs = < &{/props/ctrl-1} &{/props/ctrl-2} >;
-		phandle-array-foos = < &{/props/ctrl-1} 1 &{/props/ctrl-2} 2 3 >;
-		foo-gpios = < &{/props/ctrl-1} 1 >;
-		path = &{/props/ctrl-1};
+		phandle-ref = < &{/ctrl-1} >;
+		phandle-refs = < &{/ctrl-1} &{/ctrl-2} >;
+		phandle-array-foos = < &{/ctrl-1} 1 &{/ctrl-2} 2 3 >;
+		foo-gpios = < &{/ctrl-1} 1 >;
+		path = &{/ctrl-1};
+	};
 
-		ctrl-1 {
-			compatible = "phandle-array-controller-1";
-			#phandle-array-foo-cells = <1>;
-			#gpio-cells = <1>;
-		};
 
-		ctrl-2 {
-			compatible = "phandle-array-controller-2";
-			#phandle-array-foo-cells = <2>;
-		};
+	ctrl-1 {
+		compatible = "phandle-array-controller-1";
+		#phandle-array-foo-cells = <1>;
+		#gpio-cells = <1>;
+	};
+
+	ctrl-2 {
+		compatible = "phandle-array-controller-2";
+		#phandle-array-foo-cells = <2>;
 	};
 
 	//
@@ -372,9 +373,9 @@
 		numbers = <1>, <2>, <3>;
 		string = "text";
 		strings = "a", "b", "c";
-		handle = <&{/props/ctrl-1}>;
-		phandles = <&{/props/ctrl-1}>, <&{/props/ctrl-2}>;
-		phandle-array-foos = <&{/props/ctrl-2} 1 2>;
+		handle = <&{/ctrl-1}>;
+		phandles = <&{/ctrl-1}>, <&{/ctrl-2}>;
+		phandle-array-foos = <&{/ctrl-2} 1 2>;
 	};
 
 	//

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -192,19 +192,19 @@ def test_props():
         "<Property, name: string-array, type: string-array, value: ['foo', 'bar', 'baz']>"
 
     assert str(edt.get_node("/props").props["phandle-ref"]) == \
-        f"<Property, name: phandle-ref, type: phandle, value: <Node /props/ctrl-1 in 'test.dts', binding {filenames[1]}>>"
+        f"<Property, name: phandle-ref, type: phandle, value: <Node /ctrl-1 in 'test.dts', binding {filenames[1]}>>"
 
     assert str(edt.get_node("/props").props["phandle-refs"]) == \
-        f"<Property, name: phandle-refs, type: phandles, value: [<Node /props/ctrl-1 in 'test.dts', binding {filenames[1]}>, <Node /props/ctrl-2 in 'test.dts', binding {filenames[2]}>]>"
+        f"<Property, name: phandle-refs, type: phandles, value: [<Node /ctrl-1 in 'test.dts', binding {filenames[1]}>, <Node /ctrl-2 in 'test.dts', binding {filenames[2]}>]>"
 
     assert str(edt.get_node("/props").props["phandle-array-foos"]) == \
-        f"<Property, name: phandle-array-foos, type: phandle-array, value: [<ControllerAndData, controller: <Node /props/ctrl-1 in 'test.dts', binding {filenames[1]}>, data: OrderedDict([('one', 1)])>, <ControllerAndData, controller: <Node /props/ctrl-2 in 'test.dts', binding {filenames[2]}>, data: OrderedDict([('one', 2), ('two', 3)])>]>"
+        f"<Property, name: phandle-array-foos, type: phandle-array, value: [<ControllerAndData, controller: <Node /ctrl-1 in 'test.dts', binding {filenames[1]}>, data: OrderedDict([('one', 1)])>, <ControllerAndData, controller: <Node /ctrl-2 in 'test.dts', binding {filenames[2]}>, data: OrderedDict([('one', 2), ('two', 3)])>]>"
 
     assert str(edt.get_node("/props").props["foo-gpios"]) == \
-        f"<Property, name: foo-gpios, type: phandle-array, value: [<ControllerAndData, controller: <Node /props/ctrl-1 in 'test.dts', binding {filenames[1]}>, data: OrderedDict([('gpio-one', 1)])>]>"
+        f"<Property, name: foo-gpios, type: phandle-array, value: [<ControllerAndData, controller: <Node /ctrl-1 in 'test.dts', binding {filenames[1]}>, data: OrderedDict([('gpio-one', 1)])>]>"
 
     assert str(edt.get_node("/props").props["path"]) == \
-        f"<Property, name: path, type: path, value: <Node /props/ctrl-1 in 'test.dts', binding {filenames[1]}>>"
+        f"<Property, name: path, type: path, value: <Node /ctrl-1 in 'test.dts', binding {filenames[1]}>>"
 
 def test_nexus():
     '''Test <prefix>-map via gpio-map (the most common case).'''
@@ -234,7 +234,7 @@ def test_binding_inference():
                  for i in range(1, 3)}
 
     assert str(edt.get_node("/zephyr,user").props) == \
-        rf"OrderedDict([('boolean', <Property, name: boolean, type: boolean, value: True>), ('bytes', <Property, name: bytes, type: uint8-array, value: b'\x81\x82\x83'>), ('number', <Property, name: number, type: int, value: 23>), ('numbers', <Property, name: numbers, type: array, value: [1, 2, 3]>), ('string', <Property, name: string, type: string, value: 'text'>), ('strings', <Property, name: strings, type: string-array, value: ['a', 'b', 'c']>), ('handle', <Property, name: handle, type: phandle, value: <Node /props/ctrl-1 in 'test.dts', binding {filenames[1]}>>), ('phandles', <Property, name: phandles, type: phandles, value: [<Node /props/ctrl-1 in 'test.dts', binding {filenames[1]}>, <Node /props/ctrl-2 in 'test.dts', binding {filenames[2]}>]>), ('phandle-array-foos', <Property, name: phandle-array-foos, type: phandle-array, value: [<ControllerAndData, controller: <Node /props/ctrl-2 in 'test.dts', binding {filenames[2]}>, data: OrderedDict([('one', 1), ('two', 2)])>]>)])"
+        rf"OrderedDict([('boolean', <Property, name: boolean, type: boolean, value: True>), ('bytes', <Property, name: bytes, type: uint8-array, value: b'\x81\x82\x83'>), ('number', <Property, name: number, type: int, value: 23>), ('numbers', <Property, name: numbers, type: array, value: [1, 2, 3]>), ('string', <Property, name: string, type: string, value: 'text'>), ('strings', <Property, name: strings, type: string-array, value: ['a', 'b', 'c']>), ('handle', <Property, name: handle, type: phandle, value: <Node /ctrl-1 in 'test.dts', binding {filenames[1]}>>), ('phandles', <Property, name: phandles, type: phandles, value: [<Node /ctrl-1 in 'test.dts', binding {filenames[1]}>, <Node /ctrl-2 in 'test.dts', binding {filenames[2]}>]>), ('phandle-array-foos', <Property, name: phandle-array-foos, type: phandle-array, value: [<ControllerAndData, controller: <Node /ctrl-2 in 'test.dts', binding {filenames[2]}>, data: OrderedDict([('one', 1), ('two', 2)])>]>)])"
 
 def test_multi_bindings():
     '''Test having multiple directories with bindings'''


### PR DESCRIPTION
Reworked version of https://github.com/zephyrproject-rtos/zephyr/commit/f2c0e648c0baa4679e4335514114dac26c699881.

Taken from / needed by #26616.