### PR TITLE
sanitycheck: fix footprint reports

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -2423,7 +2423,7 @@ class TestSuite(DisablePyTestCollectionMixin):
                                ("rom_size", int, True)]
 
         if not os.path.exists(filename):
-            logger.info("Cannot compare metrics, %s not found" % filename)
+            logger.error("Cannot compare metrics, %s not found" % filename)
             return []
 
         results = []
@@ -2453,12 +2453,12 @@ class TestSuite(DisablePyTestCollectionMixin):
                                 lower_better))
         return results
 
-    def misc_reports(self, report, show_footprint, all_deltas,
-                     footprint_threshold, last_metrics):
-
+    def footprint_reports(self, report, show_footprint, all_deltas,
+                          footprint_threshold, last_metrics):
         if not report:
             return
 
+        logger.debug("running footprint_reports")
         deltas = self.compare_metrics(report)
         warnings = 0
         if deltas and show_footprint:
@@ -2467,9 +2467,11 @@ class TestSuite(DisablePyTestCollectionMixin):
                                        (delta > 0 and not lower_better)):
                     continue
 
-                percentage = (float(delta) / float(value - delta))
-                if not all_deltas and (percentage <
-                                       (footprint_threshold / 100.0)):
+                percentage = 0
+                if value > delta:
+                    percentage = (float(delta) / float(value - delta))
+
+                if not all_deltas and (percentage < (footprint_threshold / 100.0)):
                     continue
 
                 logger.info("{:<25} {:<60} {}{}{}: {} {:<+4}, is now {:6} {:+.2%}".format(
@@ -2494,7 +2496,7 @@ class TestSuite(DisablePyTestCollectionMixin):
                               str(instance.metrics.get("unrecognized", []))))
                 failed += 1
 
-            if instance.metrics['handler_time']:
+            if instance.metrics.get('handler_time', None):
                 run += 1
 
         if self.total_tests and self.total_tests != self.total_skipped:

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -700,11 +700,18 @@ def main():
     start_time = time.time()
 
     options = parse_arguments()
-
+    previous_results = None
     # Cleanup
     if options.no_clean or options.only_failed or options.test_only:
         if os.path.exists(options.outdir):
             print("Keeping artifacts untouched")
+    elif options.last_metrics:
+        ls = os.path.join(options.outdir, "sanitycheck.csv")
+        if os.path.exists(ls):
+            with open(ls, "r") as fp:
+                previous_results = fp.read()
+        else:
+            sys.exit(f"Can't compare metrics with non existing file {ls}")
     elif os.path.exists(options.outdir):
         if options.clobber_output:
             print("Deleting output directory {}".format(options.outdir))
@@ -717,7 +724,12 @@ def main():
                     shutil.move(options.outdir, new_out)
                     break
 
+    previous_results_file = None
     os.makedirs(options.outdir, exist_ok=True)
+    if options.last_metrics and previous_results:
+        previous_results_file = os.path.join(options.outdir, "baseline.csv")
+        with open(previous_results_file, "w") as fp:
+            fp.write(previous_results)
 
     # create file handler which logs even debug messages
     if options.log_file:
@@ -1113,8 +1125,20 @@ def main():
         if retries == 0 or suite.total_failed == suite.total_errors:
             break
 
-    suite.misc_reports(options.compare_report, options.show_footprint,
-                       options.all_deltas, options.footprint_threshold, options.last_metrics)
+
+    # figure out which report to use for size comparison
+    if options.compare_report:
+        report_to_use = options.compare_report
+    elif options.last_metrics:
+        report_to_use = previous_results_file
+    else:
+        report_to_use = suite.RELEASE_DATA
+
+    suite.footprint_reports(report_to_use,
+                            options.show_footprint,
+                            options.all_deltas,
+                            options.footprint_threshold,
+                            options.last_metrics)
 
     suite.duration = time.time() - start_time
     suite.update_counting()


### PR DESCRIPTION
By default show reports based on last release. Fix a few other issues
where we had 0 values and were dividing by zero.