### PR TITLE
nrfjprog.py: Fix snr globbing to allow leading 0s

### DIFF
--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -59,7 +59,8 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
                                     tool_opt=args.tool_opt)
 
     def ensure_snr(self):
-        self.snr = self.get_board_snr(self.snr or "*")
+        if not self.snr or "*" in self.snr:
+            self.snr = self.get_board_snr(self.snr or "*")
 
     def get_boards(self):
         snrs = self.check_output(['nrfjprog', '--ids'])

--- a/scripts/west_commands/tests/test_nrfjprog.py
+++ b/scripts/west_commands/tests/test_nrfjprog.py
@@ -220,7 +220,7 @@ TEST_CASES = [(f, sr, snr, e)
               for e in (False, True)]
 
 def get_board_snr_patch(glob):
-    return TEST_DEF_SNR if glob == "*" else TEST_OVR_SNR
+    return TEST_DEF_SNR
 
 def require_patch(program):
     assert program == 'nrfjprog'
@@ -258,7 +258,7 @@ def test_nrfjprog_init(cc, get_snr, req, test_case, runner_config):
     if snr is None:
         get_snr.assert_called_once_with('*')
     else:
-        get_snr.assert_called_once_with(snr)
+        get_snr.assert_not_called()
 
 @pytest.mark.parametrize('test_case', TEST_CASES, ids=id_fn)
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
@@ -289,4 +289,4 @@ def test_nrfjprog_create(cc, get_snr, req, test_case, runner_config):
     if snr is None:
         get_snr.assert_called_once_with('*')
     else:
-        get_snr.assert_called_once_with(snr)
+        get_snr.assert_not_called()


### PR DESCRIPTION
This is needed for sanitycheck hardware maps which take the serial
number directly from USB metadata.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>