### PR TITLE
drivers: lora: run TimerIrqHandler() from system workqueue

### DIFF
--- a/drivers/lora/hal_common.c
+++ b/drivers/lora/hal_common.c
@@ -10,11 +10,18 @@
 
 static uint32_t saved_time;
 
+static void timer_work_handle(struct k_work *work)
+{
+	TimerIrqHandler();
+}
+
+K_WORK_DEFINE(timer_work, timer_work_handle);
+
 static void timer_callback(struct k_timer *_timer)
 {
 	ARG_UNUSED(_timer);
 
-	TimerIrqHandler();
+	k_work_submit(&timer_work);
 }
 
 K_TIMER_DEFINE(lora_timer, timer_callback, NULL);


### PR DESCRIPTION
TimerIrqHandler() implementation calls functions which communicate over
SPI. This is forbidden from interrupt context, so submit a work to
system workqueue from which TimerIrqHandler() will be called.

This patch fixes issues like this below on nrf52840 + sx1276:
```
  uart:~$ lora test_cw 868000000 4 1
  <err> sx1276: Unable to read address: 0x6
  <err> os: ***** MPU FAULT *****
  <err> os:   Data Access Violation
  <err> os:   MMFAR Address: 0x0
  <err> os: r0/a1:  0x200004d0  r1/a2:  0x00000000  r2/a3:  0x00000000
  <err> os: r3/a4:  0x20000300 r12/ip:  0x20000ea0 r14/lr:  0x0000d8b7
  <err> os:  xpsr:  0x01000221
  <err> os: Faulting instruction address (r15/pc): 0x00009c18
  <err> os: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
  <err> os: Fault during interrupt handling
  <err> os: Current thread: 0x200004b8 (idle 00)
  <err> os: Halting system
```