### PR TITLE
drivers: gpio_pca95xx: add interrupt support for gpio expander

### DIFF
--- a/drivers/gpio/Kconfig.pca95xx
+++ b/drivers/gpio/Kconfig.pca95xx
@@ -15,3 +15,11 @@ config GPIO_PCA95XX_INIT_PRIORITY
 	depends on GPIO_PCA95XX
 	help
 	  Device driver initialization priority.
+
+config GPIO_PCA95XX_INTERRUPT
+	bool "PCA95xxx gpio interrupt support"
+	depends on GPIO_PCA95XX
+	help
+	  Enable interrupt support on gpio expander.
+	  This device can't supply interrupts with the reliability that
+	  most other interrupt-supporting drivers provide.

--- a/dts/bindings/gpio/nxp,pca95xx.yaml
+++ b/dts/bindings/gpio/nxp,pca95xx.yaml
@@ -11,6 +11,13 @@ properties:
     label:
       required: true
 
+    int-gpios:
+      type: phandle-array
+      required: false
+      description: |
+        This property specifies the connection for INT, signal to
+        low when interrput is raised.
+
     has-pud:
       type: boolean
       required: false


### PR DESCRIPTION
pca95xx provides interrupt functionality for all the gpio pins muxed
to INT line active low. Add driver support for interrupt over gpio
expander.

Signed-off-by: Saravanan Sekar <saravanan@linumiz.com>