### PR TITLE
Revert "compiler: gcc: Add warning option to spot poblematic switches"

### DIFF
--- a/cmake/compiler/gcc/target_warnings.cmake
+++ b/cmake/compiler/gcc/target_warnings.cmake
@@ -12,12 +12,6 @@ macro(toolchain_cc_warning_base)
     -Wno-main
   )
 
-if(CMAKE_C_COMPILER_VERSION VERSION_GREATER "7.1.0")
-  zephyr_compile_options(
-    -Wimplicit-fallthrough=2
-    )
-endif()
-
 if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "9.1.0")
   zephyr_compile_options(
     # FIXME: Remove once #16587 is fixed


### PR DESCRIPTION
This reverts commit 680f401ef25af30fe33127db0269f3a060f705cf.

3rd party code in modules is failing due to this enforcment. We need a
away to exclude module code to support such options.

Revert for now while we figure out a way to exclude 3rd party code.