### PR TITLE
[DNM] drivers: clock_control: nrf: Update driver to use nrfx_clock and nrfx_power

### DIFF
--- a/boards/posix/nrf52_bsim/Kconfig.board
+++ b/boards/posix/nrf52_bsim/Kconfig.board
@@ -14,6 +14,11 @@ config BOARD_NRF52_BSIM
 	# of it), so that the corresponding driver becomes available (see
 	# dependencies of the ENTROPY_NRF5_RNG option).
 	select HAS_HW_NRF_RNG
+	# Do the same for the CLOCK and POWER peripherals, so that the nrfx
+	# drivers for them can be used.
+	select HAS_HW_NRF_CLOCK
+	select HAS_HW_NRF_POWER
+	select HAS_NRFX
 	help
 	  Will produce a console Linux process which can be executed natively.
 	  It needs the BabbleSim simulator both in compile time and to execute

--- a/drivers/clock_control/Kconfig.nrf
+++ b/drivers/clock_control/Kconfig.nrf
@@ -14,6 +14,8 @@ menuconfig CLOCK_CONTROL_NRF
 	bool "NRF Clock controller support"
 	depends on SOC_COMPATIBLE_NRF
 	depends on !CLOCK_CONTROL_NRF_FORCE_ALT
+	select NRFX_CLOCK
+	select NRFX_POWER
 	default y
 	help
 	  Enable support for the Nordic Semiconductor nRFxx series SoC clock

--- a/drivers/clock_control/nrf_clock_calibration.c
+++ b/drivers/clock_control/nrf_clock_calibration.c
@@ -7,7 +7,7 @@
 #include <drivers/clock_control.h>
 #include "nrf_clock_calibration.h"
 #include <drivers/clock_control/nrf_clock_control.h>
-#include <hal/nrf_clock.h>
+#include <nrfx_clock.h>
 #include <logging/log.h>
 #include <stdlib.h>
 
@@ -109,7 +109,7 @@ static void start_hw_cal(void)
 		*(volatile uint32_t *)0x40000C34 = 0x00000002;
 	}
 
-	nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_CAL);
+	nrfx_clock_calibration_start();
 	calib_skip_cnt = CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP;
 }
 
@@ -164,19 +164,6 @@ static void cal_hf_callback(struct onoff_manager *mgr,
 	} else {
 		k_work_submit(&temp_measure_work);
 	}
-}
-
-static void on_hw_cal_done(void)
-{
-	/* Workaround for Errata 192 */
-	if (IS_ENABLED(CONFIG_SOC_SERIES_NRF52X)) {
-		*(volatile uint32_t *)0x40000C34 = 0x00000000;
-	}
-
-	total_cnt++;
-	LOG_DBG("Calibration done.");
-
-	start_cycle();
 }
 
 /* Convert sensor value to 0.25'C units. */
@@ -249,12 +236,6 @@ static inline struct device *temp_device(void)
 
 void z_nrf_clock_calibration_init(struct onoff_manager *onoff_mgrs)
 {
-	/* Anomaly 36: After watchdog timeout reset, CPU lockup reset, soft
-	 * reset, or pin reset EVENTS_DONE and EVENTS_CTTO are not reset.
-	 */
-	nrf_clock_event_clear(NRF_CLOCK, NRF_CLOCK_EVENT_DONE);
-	nrf_clock_int_enable(NRF_CLOCK, NRF_CLOCK_INT_DONE_MASK);
-
 	mgrs = onoff_mgrs;
 	total_cnt = 0;
 	total_skips_cnt = 0;
@@ -298,12 +279,12 @@ void z_nrf_clock_calibration_lfclk_stopped(void)
 	LOG_DBG("Calibration stopped");
 }
 
-void z_nrf_clock_calibration_isr(void)
+void z_nrf_clock_calibration_done_handler(void)
 {
-	if (nrf_clock_event_check(NRF_CLOCK, NRF_CLOCK_EVENT_DONE)) {
-		nrf_clock_event_clear(NRF_CLOCK, NRF_CLOCK_EVENT_DONE);
-		on_hw_cal_done();
-	}
+	total_cnt++;
+	LOG_DBG("Calibration done.");
+
+	start_cycle();
 }
 
 int z_nrf_clock_calibration_count(void)

--- a/drivers/clock_control/nrf_clock_calibration.h
+++ b/drivers/clock_control/nrf_clock_calibration.h
@@ -20,11 +20,11 @@ extern "C" {
 void z_nrf_clock_calibration_init(struct onoff_manager *mgrs);
 
 /**
- * @brief Calibration interrupts handler
+ * @brief Calibration done handler
  *
- * Must be called from clock interrupt context.
+ * Must be called from clock event handler.
  */
-void z_nrf_clock_calibration_isr(void);
+void z_nrf_clock_calibration_done_handler(void);
 
 /**
  * @brief Notify calibration module about LF clock start

--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -54,6 +54,7 @@ menuconfig USB_NRFX
 	select USB_DEVICE_DRIVER
 	select NRFX_USBD
 	select USB_DEVICE_DISABLE_ZLP_EPIN_HANDLING
+	select NRFX_USBREG if SOC_SERIES_NRF53X
 	help
 	  nRF USB Device Controller Driver
 

--- a/include/drivers/clock_control/nrf_clock_control.h
+++ b/include/drivers/clock_control/nrf_clock_control.h
@@ -80,10 +80,6 @@ enum nrf_lfclk_start_mode {
 #define CLOCK_CONTROL_NRF_K32SRC_ACCURACY 7
 #endif
 
-#if defined(CONFIG_USB_NRFX)
-void nrf5_power_usb_power_int_enable(bool enable);
-#endif
-
 /** @brief Force LF clock calibration. */
 void z_nrf_clock_calibration_force_start(void);
 

--- a/soc/arm/nordic_nrf/nrf51/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.soc
@@ -11,12 +11,14 @@ config SOC_NRF51822_QFAA
 	bool "NRF51822_QFAA"
 	select HAS_HW_NRF_ADC
 	select HAS_HW_NRF_CCM
+	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_ECB
 	select HAS_HW_NRF_GPIO0
 	select HAS_HW_NRF_GPIOTE
 	select HAS_HW_NRF_LPCOMP
 	select HAS_HW_NRF_MPU
 	select HAS_HW_NRF_QDEC
+	select HAS_HW_NRF_POWER
 	select HAS_HW_NRF_PPI
 	select HAS_HW_NRF_RNG
 	select HAS_HW_NRF_RTC0
@@ -37,12 +39,14 @@ config SOC_NRF51822_QFAB
 	bool "NRF51822_QFAB"
 	select HAS_HW_NRF_ADC
 	select HAS_HW_NRF_CCM
+	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_ECB
 	select HAS_HW_NRF_GPIO0
 	select HAS_HW_NRF_GPIOTE
 	select HAS_HW_NRF_LPCOMP
 	select HAS_HW_NRF_MPU
 	select HAS_HW_NRF_QDEC
+	select HAS_HW_NRF_POWER
 	select HAS_HW_NRF_PPI
 	select HAS_HW_NRF_RNG
 	select HAS_HW_NRF_RTC0
@@ -63,12 +67,14 @@ config SOC_NRF51822_QFAC
 	bool "NRF51822_QFAC"
 	select HAS_HW_NRF_ADC
 	select HAS_HW_NRF_CCM
+	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_ECB
 	select HAS_HW_NRF_GPIO0
 	select HAS_HW_NRF_GPIOTE
 	select HAS_HW_NRF_LPCOMP
 	select HAS_HW_NRF_MPU
 	select HAS_HW_NRF_QDEC
+	select HAS_HW_NRF_POWER
 	select HAS_HW_NRF_PPI
 	select HAS_HW_NRF_RNG
 	select HAS_HW_NRF_RTC0

--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -186,16 +186,16 @@ typedef void (*vth)(void); /* Vector Table Handler */
  * Note: qemu_cortex_m0 uses TIMER0 to implement system timer.
  */
 void rtc_nrf_isr(void);
-void nrf_power_clock_isr(void);
+void nrfx_clock_irq_handler(void);
 #if defined(CONFIG_SOC_SERIES_NRF51X) || defined(CONFIG_SOC_SERIES_NRF52X)
 #if defined(CONFIG_BOARD_QEMU_CORTEX_M0)
 void timer0_nrf_isr(void);
 vth __irq_vector_table _irq_vector_table[] = {
-	nrf_power_clock_isr, 0, 0, 0, 0, 0, 0, 0, timer0_nrf_isr, isr0, isr1, isr2
+	nrfx_clock_irq_handler, 0, 0, 0, 0, 0, 0, 0, timer0_nrf_isr, isr0, isr1, isr2
 };
 #else
 vth __irq_vector_table _irq_vector_table[] = {
-	nrf_power_clock_isr,
+	nrfx_clock_irq_handler,
 	isr0, isr1, isr2,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	rtc_nrf_isr
@@ -204,14 +204,14 @@ vth __irq_vector_table _irq_vector_table[] = {
 #elif defined(CONFIG_SOC_SERIES_NRF53X) || defined(CONFIG_SOC_SERIES_NRF91X)
 #ifndef CONFIG_SOC_NRF5340_CPUNET
 vth __irq_vector_table _irq_vector_table[] = {
-	0, 0, 0, 0, 0, nrf_power_clock_isr, 0, 0,
+	0, 0, 0, 0, 0, nrfx_clock_irq_handler, 0, 0,
 	isr0, isr1, isr2,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	rtc_nrf_isr
 };
 #else
 vth __irq_vector_table _irq_vector_table[] = {
-	0, 0, 0, 0, 0, nrf_power_clock_isr, 0, 0,
+	0, 0, 0, 0, 0, nrfx_clock_irq_handler, 0, 0,
 	isr0, isr1, isr2,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	rtc_nrf_isr

--- a/tests/bluetooth/ll_settings/prj.conf
+++ b/tests/bluetooth/ll_settings/prj.conf
@@ -13,3 +13,7 @@ CONFIG_BT_CTLR_SETTINGS=y
 CONFIG_BT_CTLR_VERSION_SETTINGS=y
 CONFIG_BT_CTLR_COMPANY_ID=0x5F1
 CONFIG_BT_CTLR_SUBVERSION_NUMBER=0xFFFF
+
+# Needed only to prevent the switch-unreachable warning from being generated
+# for the `__fallthrough;` statement in function ll_rx_dequeue() in ull.c.
+CONFIG_BT_OBSERVER=y

--- a/west.yml
+++ b/west.yml
@@ -21,6 +21,8 @@ manifest:
   remotes:
     - name: upstream
       url-base: https://github.com/zephyrproject-rtos
+    - name: BabbleSim
+      url-base: https://github.com/BabbleSim
 
   #
   # Please add items below based on alphabetical order
@@ -56,7 +58,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: 4420ac72664b8be0b8630e2bd8cf76367c62d228
+      revision: pull/51/head
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262
@@ -125,8 +127,10 @@ manifest:
       path: modules/debug/mipi-sys-t
       revision: 957d46bc3ce0d5f628f0d525196bb4db207672ee
     - name: nrf_hw_models
+      remote: BabbleSim
+      repo-path: ext_NRF52_hw_models
       path: modules/bsim_hw_models/nrf_hw_models
-      revision: 9e594dace1af29252903938064b8ecb1b8b77678
+      revision: pull/12/head
     - name: hal_xtensa
       revision: e7a57d0c252f9c5f3cab9d5ceadda8753cacee5b
       path: modules/hal/xtensa


### PR DESCRIPTION
A draft PR based on https://github.com/zephyrproject-rtos/zephyr/pull/27422, to test if the approach proposed in https://github.com/zephyrproject-rtos/zephyr/pull/27422#issuecomment-672755626 is feasible and acceptable.