### PR TITLE
modules: hal_nordic: Prevent implicit-fallthrough warnings

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: 4420ac72664b8be0b8630e2bd8cf76367c62d228
+      revision: 4be2a1eadc99511e0271b6de6e0be459a4cf0cef
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262


### PR DESCRIPTION
Update the hal_nordic module revision, to prevent implicit-fallthrough
warnings reported in sanitycheck.

https://github.com/zephyrproject-rtos/hal_nordic/pull/52 needs to go in first.