### PR TITLE
drivers/spi: spi_context_longest_current_buf fix

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -345,15 +345,7 @@ bool spi_context_rx_buf_on(struct spi_context *ctx)
 
 static inline size_t spi_context_longest_current_buf(struct spi_context *ctx)
 {
-	if (!ctx->tx_len) {
-		return ctx->rx_len;
-	} else if (!ctx->rx_len) {
-		return ctx->tx_len;
-	} else if (ctx->tx_len < ctx->rx_len) {
-		return ctx->tx_len;
-	}
-
-	return ctx->rx_len;
+	return ctx->tx_len > ctx->rx_len ? ctx->tx_len : ctx->rx_len;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
spi_context_longest_current_buf must return max buffer len.
Also remove redundant check

Signed-off-by: Ilya Averyanov <a1ien.n3t@gmail.com>