### PR TITLE
dts: stm32g4: Fix clock enable and add pinmux for PWM8

### DIFF
--- a/drivers/pinmux/stm32/pinmux_stm32g4x.h
+++ b/drivers/pinmux/stm32/pinmux_stm32g4x.h
@@ -120,11 +120,15 @@
 
 #define STM32G4X_PINMUX_FUNC_PA14_I2C1_SDA                                     \
 	(STM32_PINMUX_ALT_FUNC_4 | STM32_OPENDRAIN_PULLUP)
+#define STM32G4X_PINMUX_FUNC_PA14_PWM8_CH2                                     \
+	(STM32_PINMUX_ALT_FUNC_5 | STM32_PUSHPULL_NOPULL)
 #define STM32G4X_PINMUX_FUNC_PA14_USART2_TX                                    \
 	(STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)
 
 #define STM32G4X_PINMUX_FUNC_PA15_PWM2_CH1                                     \
 	(STM32_PINMUX_ALT_FUNC_1 | STM32_PUSHPULL_NOPULL)
+#define STM32G4X_PINMUX_FUNC_PA15_PWM8_CH1                                     \
+	(STM32_PINMUX_ALT_FUNC_2 | STM32_PUSHPULL_NOPULL)
 #define STM32G4X_PINMUX_FUNC_PA15_I2C1_SCL                                     \
 	(STM32_PINMUX_ALT_FUNC_4 | STM32_OPENDRAIN_PULLUP)
 #define STM32G4X_PINMUX_FUNC_PA15_SPI1_NSS                                     \
@@ -176,6 +180,8 @@
 
 #define STM32G4X_PINMUX_FUNC_PB6_PWM4_CH1                                      \
 	(STM32_PINMUX_ALT_FUNC_2 | STM32_PUSHPULL_NOPULL)
+#define STM32G4X_PINMUX_FUNC_PB6_PWM8_CH1                                      \
+	(STM32_PINMUX_ALT_FUNC_5 | STM32_PUSHPULL_NOPULL)
 #define STM32G4X_PINMUX_FUNC_PB6_USART1_TX                                     \
 	(STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)
 
@@ -198,6 +204,8 @@
 	(STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)
 #define STM32G4X_PINMUX_FUNC_PB8_FDCAN1_RX                                     \
 	(STM32_PINMUX_ALT_FUNC_9 | STM32_PUSHPULL_NOPULL)
+#define STM32G4X_PINMUX_FUNC_PB8_PWM8_CH2                                      \
+	(STM32_PINMUX_ALT_FUNC_10 | STM32_PUSHPULL_NOPULL)
 
 #define STM32G4X_PINMUX_FUNC_PB9_PWM4_CH4                                      \
 	(STM32_PINMUX_ALT_FUNC_2 | STM32_PUSHPULL_NOPULL)
@@ -207,6 +215,8 @@
 	(STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)
 #define STM32G4X_PINMUX_FUNC_PB9_FDCAN1_TX                                     \
 	(STM32_PINMUX_ALT_FUNC_9 | STM32_PUSHPULL_NOPULL)
+#define STM32G4X_PINMUX_FUNC_PB9_PWM8_CH3                                      \
+	(STM32_PINMUX_ALT_FUNC_10 | STM32_PUSHPULL_NOPULL)
 
 #define STM32G4X_PINMUX_FUNC_PB10_PWM2_CH3                                     \
 	(STM32_PINMUX_ALT_FUNC_1 | STM32_PUSHPULL_NOPULL)
@@ -283,17 +293,25 @@
 
 #define STM32G4X_PINMUX_FUNC_PC6_PWM3_CH1                                      \
 	(STM32_PINMUX_ALT_FUNC_2 | STM32_PUSHPULL_NOPULL)
+#define STM32G4X_PINMUX_FUNC_PC6_PWM8_CH1                                      \
+	(STM32_PINMUX_ALT_FUNC_4 | STM32_PUSHPULL_NOPULL)
 
 #define STM32G4X_PINMUX_FUNC_PC7_PWM3_CH2                                      \
 	(STM32_PINMUX_ALT_FUNC_2 | STM32_PUSHPULL_NOPULL)
+#define STM32G4X_PINMUX_FUNC_PC7_PWM8_CH2                                      \
+	(STM32_PINMUX_ALT_FUNC_4 | STM32_PUSHPULL_NOPULL)
 
 #define STM32G4X_PINMUX_FUNC_PC8_PWM3_CH3                                      \
 	(STM32_PINMUX_ALT_FUNC_2 | STM32_PUSHPULL_NOPULL)
+#define STM32G4X_PINMUX_FUNC_PC8_PWM8_CH3                                      \
+	(STM32_PINMUX_ALT_FUNC_4 | STM32_PUSHPULL_NOPULL)
 #define STM32G4X_PINMUX_FUNC_PC8_I2C3_SCL                                      \
 	(STM32_PINMUX_ALT_FUNC_8 | STM32_OPENDRAIN_PULLUP)
 
 #define STM32G4X_PINMUX_FUNC_PC9_PWM3_CH4                                      \
 	(STM32_PINMUX_ALT_FUNC_2 | STM32_PUSHPULL_NOPULL)
+#define STM32G4X_PINMUX_FUNC_PC9_PWM8_CH4                                      \
+	(STM32_PINMUX_ALT_FUNC_4 | STM32_PUSHPULL_NOPULL)
 #define STM32G4X_PINMUX_FUNC_PC9_I2C3_SDA                                      \
 	(STM32_PINMUX_ALT_FUNC_8 | STM32_OPENDRAIN_PULLUP)
 
@@ -320,6 +338,8 @@
 #define STM32G4X_PINMUX_FUNC_PD0_FDCAN1_RX                                     \
 	(STM32_PINMUX_ALT_FUNC_9 | STM32_PUSHPULL_NOPULL)
 
+#define STM32G4X_PINMUX_FUNC_PD1_PWM8_CH4                                      \
+	(STM32_PINMUX_ALT_FUNC_4 | STM32_PUSHPULL_NOPULL)
 #define STM32G4X_PINMUX_FUNC_PD1_FDCAN1_TX                                     \
 	(STM32_PINMUX_ALT_FUNC_9 | STM32_PUSHPULL_NOPULL)
 

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -395,7 +395,7 @@
 		timers8: timers@40013400 {
 			compatible = "st,stm32-timers";
 			reg = <0x40013400 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00004000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00002000>;
 			interrupts = <43 0>, <44 0>, <45 0>, <46 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			status = "disabled";


### PR DESCRIPTION
Reference: [hal_stm32/stm32cube/stm32g4xx/soc/stm32g431xx.h](https://github.com/zephyrproject-rtos/hal_stm32/blob/cea57f86d3ade46c0b99dab32b2ac63435ed0693/stm32cube/stm32g4xx/soc/stm32g431xx.h#L7822)

