### PR TITLE
guideline: Add flags to enforce some guideline rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,14 @@ if(CONFIG_MISRA_SANE)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:${CPP_MISRA_SANE_FLAG}>)
 endif()
 
+# This is intend to be temporary. Once we have fixed the violations that
+# prevents build Zephyr, these flags shall be part of the default flags.
+if(CONFIG_CODING_GUIDELINE_CHECK)
+  # @Intent: Obtain toolchain compiler flags relating to coding guideline
+  toolchain_cc_warning_error_coding_guideline_check(CC_CODING_GUIDELINE_CHECK_FLAG)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:${CC_CODING_GUIDELINE_CHECK_FLAG}>)
+endif()
+
 # @Intent: Set compiler specific macro inclusion of AUTOCONF_H
 toolchain_cc_imacros(${AUTOCONF_H})
 

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -171,6 +171,12 @@ endmenu
 
 menu "Compiler Options"
 
+config CODING_GUIDELINE_CHECK
+	bool "Enforce coding guideline rules"
+	help
+	  Use available compiler flags to check coding guideline rules during
+	  the build.
+
 config NATIVE_APPLICATION
 	bool "Build as a native host application"
 	help

--- a/cmake/compiler/clang/target_warnings.cmake
+++ b/cmake/compiler/clang/target_warnings.cmake
@@ -116,6 +116,14 @@ macro(toolchain_cc_cpp_warning_error_misra_sane dest_var_name)
   set_ifndef(${dest_var_name} "-Werror=vla")
 endmacro()
 
+macro(toolchain_cc_warning_error_coding_guideline_check dest_var_name)
+  if (NOT ${dest_var_name})
+    set(${dest_var_name}
+      -Wvla
+      )
+  endif()
+endmacro()
+
 # List the warnings that are not supported for C++ compilations
 
 list(APPEND CXX_EXCLUDED_OPTIONS

--- a/cmake/compiler/clang/target_warnings.cmake
+++ b/cmake/compiler/clang/target_warnings.cmake
@@ -122,6 +122,7 @@ macro(toolchain_cc_warning_error_coding_guideline_check dest_var_name)
       -Wvla
       -Wimplicit-fallthrough
       -Wconversion
+      -Woverride-init
       )
   endif()
 endmacro()

--- a/cmake/compiler/clang/target_warnings.cmake
+++ b/cmake/compiler/clang/target_warnings.cmake
@@ -120,6 +120,7 @@ macro(toolchain_cc_warning_error_coding_guideline_check dest_var_name)
   if (NOT ${dest_var_name})
     set(${dest_var_name}
       -Wvla
+      -Wimplicit-fallthrough
       )
   endif()
 endmacro()

--- a/cmake/compiler/clang/target_warnings.cmake
+++ b/cmake/compiler/clang/target_warnings.cmake
@@ -121,6 +121,7 @@ macro(toolchain_cc_warning_error_coding_guideline_check dest_var_name)
     set(${dest_var_name}
       -Wvla
       -Wimplicit-fallthrough
+      -Wconversion
       )
   endif()
 endmacro()

--- a/cmake/compiler/gcc/target_warnings.cmake
+++ b/cmake/compiler/gcc/target_warnings.cmake
@@ -114,6 +114,7 @@ macro(toolchain_cc_warning_error_coding_guideline_check dest_var_name)
     set(${dest_var_name}
       -Wvla
       -Wimplicit-fallthrough=2
+      -Wconversion
       )
   endif()
 endmacro()

--- a/cmake/compiler/gcc/target_warnings.cmake
+++ b/cmake/compiler/gcc/target_warnings.cmake
@@ -109,6 +109,14 @@ macro(toolchain_cc_cpp_warning_error_misra_sane dest_var_name)
   set_ifndef(${dest_var_name} "-Werror=vla")
 endmacro()
 
+macro(toolchain_cc_warning_error_coding_guideline_check dest_var_name)
+  if (NOT ${dest_var_name})
+    set(${dest_var_name}
+      -Wvla
+      )
+  endif()
+endmacro()
+
 # List the warnings that are not supported for C++ compilations
 
 list(APPEND CXX_EXCLUDED_OPTIONS

--- a/cmake/compiler/gcc/target_warnings.cmake
+++ b/cmake/compiler/gcc/target_warnings.cmake
@@ -113,6 +113,7 @@ macro(toolchain_cc_warning_error_coding_guideline_check dest_var_name)
   if (NOT ${dest_var_name})
     set(${dest_var_name}
       -Wvla
+      -Wimplicit-fallthrough=2
       )
   endif()
 endmacro()

--- a/cmake/compiler/gcc/target_warnings.cmake
+++ b/cmake/compiler/gcc/target_warnings.cmake
@@ -115,6 +115,7 @@ macro(toolchain_cc_warning_error_coding_guideline_check dest_var_name)
       -Wvla
       -Wimplicit-fallthrough=2
       -Wconversion
+      -Woverride-init
       )
   endif()
 endmacro()


### PR DESCRIPTION
These flags will spot violations to Zephyr's codeguideline. Though as they are currently breaking the build, they are under a `MISRA_SANE` option and are disabled by default. The flags enforce (partially) rules:
9.4, 10.4, 10.5, 10.6, 10.7, 10.8, 16.1 and 16.3