### PR TITLE
userspace: memory domain policy adjustments and ARC/ARM bugfix

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -43,6 +43,7 @@ config X86
 	select ARCH_HAS_CUSTOM_SWAP_TO_MAIN if !X86_64
 	select ARCH_SUPPORTS_COREDUMP
 	select CPU_HAS_MMU
+	select ARCH_MEM_DOMAIN_SYNCHRONOUS_API if USERSPACE
 	help
 	  x86 architecture
 

--- a/arch/arc/core/mpu/arc_core_mpu.c
+++ b/arch/arc/core/mpu/arc_core_mpu.c
@@ -38,13 +38,7 @@ int arch_mem_domain_max_partitions_get(void)
 void arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 				      uint32_t partition_id)
 {
-	if (_current->mem_domain_info.mem_domain != domain) {
-		return;
-	}
-
-	arc_core_mpu_disable();
-	arc_core_mpu_remove_mem_partition(domain, partition_id);
-	arc_core_mpu_enable();
+	/* No-op on this architecture */
 }
 
 /*
@@ -52,13 +46,7 @@ void arch_mem_domain_partition_remove(struct k_mem_domain *domain,
  */
 void arch_mem_domain_thread_add(struct k_thread *thread)
 {
-	if (_current != thread) {
-		return;
-	}
-
-	arc_core_mpu_disable();
-	arc_core_mpu_configure_mem_domain(thread);
-	arc_core_mpu_enable();
+	/* No-op on this architecture */
 }
 
 /*
@@ -66,13 +54,7 @@ void arch_mem_domain_thread_add(struct k_thread *thread)
  */
 void arch_mem_domain_destroy(struct k_mem_domain *domain)
 {
-	if (_current->mem_domain_info.mem_domain != domain) {
-		return;
-	}
-
-	arc_core_mpu_disable();
-	arc_core_mpu_remove_mem_domain(domain);
-	arc_core_mpu_enable();
+	/* No-op on this architecture */
 }
 
 void arch_mem_domain_partition_add(struct k_mem_domain *domain,
@@ -83,11 +65,7 @@ void arch_mem_domain_partition_add(struct k_mem_domain *domain,
 
 void arch_mem_domain_thread_remove(struct k_thread *thread)
 {
-	if (_current != thread) {
-		return;
-	}
-
-	arch_mem_domain_destroy(thread->mem_domain_info.mem_domain);
+	/* No-op on this architecture */
 }
 
 /*

--- a/arch/arc/core/mpu/arc_core_mpu.c
+++ b/arch/arc/core/mpu/arc_core_mpu.c
@@ -33,42 +33,6 @@ int arch_mem_domain_max_partitions_get(void)
 }
 
 /*
- * Reset MPU region for a single memory partition
- */
-void arch_mem_domain_partition_remove(struct k_mem_domain *domain,
-				      uint32_t partition_id)
-{
-	/* No-op on this architecture */
-}
-
-/*
- * Configure MPU memory domain
- */
-void arch_mem_domain_thread_add(struct k_thread *thread)
-{
-	/* No-op on this architecture */
-}
-
-/*
- * Destroy MPU regions for the mem domain
- */
-void arch_mem_domain_destroy(struct k_mem_domain *domain)
-{
-	/* No-op on this architecture */
-}
-
-void arch_mem_domain_partition_add(struct k_mem_domain *domain,
-				   uint32_t partition_id)
-{
-	/* No-op on this architecture */
-}
-
-void arch_mem_domain_thread_remove(struct k_thread *thread)
-{
-	/* No-op on this architecture */
-}
-
-/*
  * Validate the given buffer is user accessible or not
  */
 int arch_buffer_validate(void *addr, size_t size, int write)

--- a/arch/arm/core/aarch32/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/aarch32/cortex_m/mpu/arm_core_mpu.c
@@ -323,33 +323,6 @@ int arch_mem_domain_max_partitions_get(void)
 	return ARM_CORE_MPU_MAX_DOMAIN_PARTITIONS_GET(available_regions);
 }
 
-void arch_mem_domain_thread_add(struct k_thread *thread)
-{
-	/* No-op on this architecture */
-}
-
-void arch_mem_domain_destroy(struct k_mem_domain *domain)
-{
-	/* No-op on this architecture */
-}
-
-void arch_mem_domain_partition_remove(struct k_mem_domain *domain,
-				      uint32_t partition_id)
-{
-	/* No-op on this architecture */
-}
-
-void arch_mem_domain_partition_add(struct k_mem_domain *domain,
-				   uint32_t partition_id)
-{
-	/* No-op on this architecture */
-}
-
-void arch_mem_domain_thread_remove(struct k_thread *thread)
-{
-	/* No-op on this architecture */
-}
-
 int arch_buffer_validate(void *addr, size_t size, int write)
 {
 	return arm_core_mpu_buffer_validate(addr, size, write);

--- a/arch/arm/core/aarch32/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/aarch32/cortex_m/mpu/arm_core_mpu.c
@@ -325,62 +325,18 @@ int arch_mem_domain_max_partitions_get(void)
 
 void arch_mem_domain_thread_add(struct k_thread *thread)
 {
-	if (_current != thread) {
-		return;
-	}
-
-	/* Request to configure memory domain for a thread.
-	 * This triggers re-programming of the entire dynamic
-	 * memory map.
-	 */
-	z_arm_configure_dynamic_mpu_regions(thread);
+	/* No-op on this architecture */
 }
 
 void arch_mem_domain_destroy(struct k_mem_domain *domain)
 {
-	/* This function will reset the access permission configuration
-	 * of the active partitions of the memory domain.
-	 */
-	int i;
-	struct k_mem_partition partition;
-
-	if (_current->mem_domain_info.mem_domain != domain) {
-		return;
-	}
-
-	/* Partitions belonging to the memory domain will be reset
-	 * to default (Privileged RW, Unprivileged NA) permissions.
-	 */
-	k_mem_partition_attr_t reset_attr = K_MEM_PARTITION_P_RW_U_NA;
-
-	for (i = 0; i < CONFIG_MAX_DOMAIN_PARTITIONS; i++) {
-		partition = domain->partitions[i];
-		if (partition.size == 0U) {
-			/* Zero size indicates a non-existing
-			 * memory partition.
-			 */
-			continue;
-		}
-		arm_core_mpu_mem_partition_config_update(&partition,
-			&reset_attr);
-	}
+	/* No-op on this architecture */
 }
 
 void arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 				      uint32_t partition_id)
 {
-	/* Request to remove a partition from a memory domain.
-	 * This resets the access permissions of the partition
-	 * to default (Privileged RW, Unprivileged NA).
-	 */
-	k_mem_partition_attr_t reset_attr = K_MEM_PARTITION_P_RW_U_NA;
-
-	if (_current->mem_domain_info.mem_domain != domain) {
-		return;
-	}
-
-	arm_core_mpu_mem_partition_config_update(
-		&domain->partitions[partition_id], &reset_attr);
+	/* No-op on this architecture */
 }
 
 void arch_mem_domain_partition_add(struct k_mem_domain *domain,
@@ -391,11 +347,7 @@ void arch_mem_domain_partition_add(struct k_mem_domain *domain,
 
 void arch_mem_domain_thread_remove(struct k_thread *thread)
 {
-	if (_current != thread) {
-		return;
-	}
-
-	arch_mem_domain_destroy(thread->mem_domain_info.mem_domain);
+	/* No-op on this architecture */
 }
 
 int arch_buffer_validate(void *addr, size_t size, int write)

--- a/arch/arm/core/aarch32/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/aarch32/cortex_m/mpu/arm_mpu.c
@@ -217,7 +217,8 @@ void arm_core_mpu_mem_partition_config_update(
 		break;
 	}
 	__ASSERT(reg_index != get_num_regions(),
-		 "Memory domain partition not found\n");
+		 "Memory domain partition %p size %zu not found\n",
+		 (void *)partition->start, partition->size);
 
 	/* Modify the permissions */
 	partition->attr = *new_attr;

--- a/doc/guides/porting/arch.rst
+++ b/doc/guides/porting/arch.rst
@@ -786,11 +786,23 @@ details:
   number of regions for a memory domain. MMU systems have an unlimited amount,
   MPU systems have constraints on this.
 
-* :cpp:func:`arch_mem_domain_partition_remove()` Remove a partition from
-  a memory domain if the currently executing thread was part of that domain.
+Some architectures may need to update software memory management structures
+or modify hardware registers on another CPU when memory domain APIs are invoked.
+If so, CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API must be selected by the
+architecture and some additional APIs must be implemented. This is common
+on MMU systems and uncommon on MPU systems:
 
-* :cpp:func:`arch_mem_domain_destroy()` Reset the thread's memory domain
-  configuration
+* :cpp:func:`arch_mem_domain_thread_add()`
+
+* :cpp:func:`arch_mem_domain_thread_remove()`
+
+* :cpp:func:`arch_mem_domain_partition_add()`
+
+* :cpp:func:`arch_mem_domain_partition_remove()`
+
+* :cpp:func:`arch_mem_domain_destroy()`
+
+Please see the doxygen documentation of these APIs for details.
 
 In addition to implementing these APIs, there are some other tasks as well:
 

--- a/include/app_memory/mem_domain.h
+++ b/include/app_memory/mem_domain.h
@@ -189,10 +189,12 @@ extern void k_mem_domain_add_thread(struct k_mem_domain *domain,
 /**
  * @brief Remove a thread from its memory domain.
  *
- * Remove a thread from its memory domain.
+ * Remove a thread from its memory domain. It will be reassigned to the
+ * default memory domain.
  *
  * @param thread ID of thread going to be removed from its memory domain.
  */
+__deprecated
 extern void k_mem_domain_remove_thread(k_tid_t thread);
 
 /** @} */

--- a/include/app_memory/mem_domain.h
+++ b/include/app_memory/mem_domain.h
@@ -92,6 +92,18 @@ struct k_mem_domain {
 	struct arch_mem_domain arch;
 #endif /* CONFIG_ARCH_MEM_DOMAIN_DATA */
 };
+
+/**
+ * Default memory domain
+ *
+ * All threads are a member of some memory domain, even if running in
+ * supervisor mode. Threads belong to this default memory domain if they
+ * haven't been added to or inherited membership from some other domain.
+ *
+ * This memory domain has the z_libc_partition partition for the C library
+ * added to it if exists.
+ */
+extern struct k_mem_domain k_mem_domain_default;
 #else
 /* To support use of IS_ENABLED for the APIs below */
 struct k_mem_domain;
@@ -164,7 +176,8 @@ extern void k_mem_domain_remove_partition(struct k_mem_domain *domain,
 /**
  * @brief Add a thread into a memory domain.
  *
- * Add a thread into a memory domain.
+ * Add a thread into a memory domain. It will be removed from whatever
+ * memory domain it previously belonged to.
  *
  * @param domain The memory domain that the thread is going to be added into.
  * @param thread ID of thread going to be added into the memory domain.

--- a/include/app_memory/mem_domain.h
+++ b/include/app_memory/mem_domain.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <sys/dlist.h>
+#include <toolchain.h>
 
 /* Forward declaration */
 struct k_thread;
@@ -118,6 +119,7 @@ extern void k_mem_domain_init(struct k_mem_domain *domain, uint8_t num_parts,
  *
  * @param domain The memory domain to be destroyed.
  */
+__deprecated
 extern void k_mem_domain_destroy(struct k_mem_domain *domain);
 
 /**

--- a/include/sys/arch_interface.h
+++ b/include/sys/arch_interface.h
@@ -540,6 +540,7 @@ int arch_mem_domain_max_partitions_get(void);
 int arch_mem_domain_init(struct k_mem_domain *domain);
 #endif /* CONFIG_ARCH_MEM_DOMAIN_DATA */
 
+#ifdef CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API
 /**
  * @brief Add a thread to a memory domain (arch-specific)
  *
@@ -606,6 +607,7 @@ void arch_mem_domain_partition_add(struct k_mem_domain *domain,
  * @param domain The memory domain structure which needs to be deleted.
  */
 void arch_mem_domain_destroy(struct k_mem_domain *domain);
+#endif /* CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API */
 
 /**
  * @brief Check memory region permissions

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -709,6 +709,35 @@ config ARCH_MEM_DOMAIN_DATA
 
 	  Typical uses might be a set of page tables for that memory domain.
 
+config ARCH_MEM_DOMAIN_SYNCHRONOUS_API
+	bool
+	depends on USERSPACE
+	help
+	  This hidden option is selected by the target architecture if
+	  modifying a memory domain's partitions at runtime, or changing
+	  a memory domain's thread membership requires synchronous calls
+	  into the architecture layer.
+
+	  If enabled, the architecture layer must implement the following
+	  APIs:
+
+	  arch_mem_domain_thread_add
+	  arch_mem_domain_thread_remove
+	  arch_mem_domain_partition_remove
+	  arch_mem_domain_partition_add
+	  arch_mem_domain_destroy
+
+	  It's important to note that although supervisor threads can be
+	  members of memory domains, they have no implications on supervisor
+	  thread access to memory. Memory domain APIs may only be invoked from
+	  supervisor mode.
+
+	  For these reasons, on uniprocessor systems unless memory access
+	  policy is managed in separate software constructions like page
+	  tables, these APIs don't need to be implemented as the underlying
+	  memory management hardware will be reprogrammed on context switch
+	  anyway.
+
 menu "SMP Options"
 
 config USE_SWITCH

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -197,7 +197,7 @@ static inline void z_dummy_thread_init(struct k_thread *dummy_thread)
 	dummy_thread->stack_info.size = 0U;
 #endif
 #ifdef CONFIG_USERSPACE
-	dummy_thread->mem_domain_info.mem_domain = 0;
+	dummy_thread->mem_domain_info.mem_domain = &k_mem_domain_default;
 #endif
 
 	_current_cpu->current = dummy_thread;

--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -146,7 +146,9 @@ void k_mem_domain_destroy(struct k_mem_domain *domain)
 
 	key = k_spin_lock(&lock);
 
+#ifdef CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API
 	arch_mem_domain_destroy(domain);
+#endif
 
 	SYS_DLIST_FOR_EACH_NODE_SAFE(&domain->mem_domain_q, node, next_node) {
 		struct k_thread *thread =
@@ -190,7 +192,9 @@ void k_mem_domain_add_partition(struct k_mem_domain *domain,
 
 	domain->num_partitions++;
 
+#ifdef CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API
 	arch_mem_domain_partition_add(domain, p_idx);
+#endif
 	k_spin_unlock(&lock, key);
 }
 
@@ -218,7 +222,9 @@ void k_mem_domain_remove_partition(struct k_mem_domain *domain,
 	LOG_DBG("remove partition base %lx size %zu from domain %p\n",
 		part->start, part->size, domain);
 
+#ifdef CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API
 	arch_mem_domain_partition_remove(domain, p_idx);
+#endif
 
 	/* A zero-sized partition denotes it's a free partition */
 	domain->partitions[p_idx].size = 0U;
@@ -240,7 +246,9 @@ void k_mem_domain_add_thread(struct k_mem_domain *domain, k_tid_t thread)
 		LOG_DBG("remove thread %p from memory domain %p\n",
 			thread, thread->mem_domain_info.mem_domain);
 		sys_dlist_remove(&thread->mem_domain_info.mem_domain_q_node);
+#ifdef CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API
 		arch_mem_domain_thread_remove(thread);
+#endif
 	}
 
 	LOG_DBG("add thread %p to domain %p\n", thread, domain);
@@ -248,7 +256,9 @@ void k_mem_domain_add_thread(struct k_mem_domain *domain, k_tid_t thread)
 			 &thread->mem_domain_info.mem_domain_q_node);
 	thread->mem_domain_info.mem_domain = domain;
 
+#ifdef CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API
 	arch_mem_domain_thread_add(thread);
+#endif
 
 	k_spin_unlock(&lock, key);
 }

--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -181,6 +181,9 @@ void k_mem_domain_add_partition(struct k_mem_domain *domain,
 	__ASSERT(p_idx < max_partitions,
 		 "no free partition slots available");
 
+	LOG_DBG("add partition base %lx size %zu to domain %p\n",
+		part->start, part->size, domain);
+
 	domain->partitions[p_idx].start = part->start;
 	domain->partitions[p_idx].size = part->size;
 	domain->partitions[p_idx].attr = part->attr;
@@ -212,6 +215,9 @@ void k_mem_domain_remove_partition(struct k_mem_domain *domain,
 
 	__ASSERT(p_idx < max_partitions, "no matching partition found");
 
+	LOG_DBG("remove partition base %lx size %zu from domain %p\n",
+		part->start, part->size, domain);
+
 	arch_mem_domain_partition_remove(domain, p_idx);
 
 	/* A zero-sized partition denotes it's a free partition */
@@ -231,9 +237,13 @@ void k_mem_domain_add_thread(struct k_mem_domain *domain, k_tid_t thread)
 
 	key = k_spin_lock(&lock);
 	if (thread->mem_domain_info.mem_domain != NULL) {
+		LOG_DBG("remove thread %p from memory domain %p\n",
+			thread, thread->mem_domain_info.mem_domain);
 		sys_dlist_remove(&thread->mem_domain_info.mem_domain_q_node);
 		arch_mem_domain_thread_remove(thread);
 	}
+
+	LOG_DBG("add thread %p to domain %p\n", thread, domain);
 	sys_dlist_append(&domain->mem_domain_q,
 			 &thread->mem_domain_info.mem_domain_q_node);
 	thread->mem_domain_info.mem_domain = domain;

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -537,7 +537,6 @@ char *z_setup_new_thread(struct k_thread *new_thread,
 	z_object_init(new_thread);
 	z_object_init(stack);
 	new_thread->stack_obj = stack;
-	new_thread->mem_domain_info.mem_domain = NULL;
 	new_thread->syscall_frame = NULL;
 
 	/* Any given thread has access to itself */
@@ -601,10 +600,9 @@ char *z_setup_new_thread(struct k_thread *new_thread,
 #endif
 #ifdef CONFIG_USERSPACE
 	/* New threads inherit any memory domain membership by the parent */
-	if (_current->mem_domain_info.mem_domain != NULL) {
-		k_mem_domain_add_thread(_current->mem_domain_info.mem_domain,
-					new_thread);
-	}
+	new_thread->mem_domain_info.mem_domain = NULL;
+	k_mem_domain_add_thread(_current->mem_domain_info.mem_domain,
+				new_thread);
 
 	if ((options & K_INHERIT_PERMS) != 0U) {
 		z_thread_perms_inherit(_current, new_thread);

--- a/subsys/testsuite/ztest/include/ztest_test.h
+++ b/subsys/testsuite/ztest/include/ztest_test.h
@@ -169,7 +169,6 @@ __syscall void z_test_1cpu_stop(void);
 #define ZTEST_BMEM	K_APP_BMEM(ztest_mem_partition)
 #define ZTEST_SECTION	K_APP_DMEM_SECTION(ztest_mem_partition)
 extern struct k_mem_partition ztest_mem_partition;
-extern struct k_mem_domain ztest_mem_domain;
 #else
 #define ZTEST_DMEM
 #define ZTEST_BMEM

--- a/tests/crypto/mbedtls/src/main.c
+++ b/tests/crypto/mbedtls/src/main.c
@@ -13,7 +13,7 @@ extern void test_mbedtls(void);
 void test_main(void)
 {
 #ifdef CONFIG_USERSPACE
-	k_mem_domain_add_partition(&ztest_mem_domain, &k_mbedtls_partition);
+	k_mem_domain_add_partition(&k_mem_domain_default, &k_mbedtls_partition);
 #endif
 	ztest_test_suite(test_mbedtls_fn,
 		ztest_user_unit_test(test_mbedtls));

--- a/tests/kernel/mem_protect/mem_protect/src/inherit.c
+++ b/tests/kernel/mem_protect/mem_protect/src/inherit.c
@@ -104,7 +104,6 @@ void test_permission_inheritance(void *p1, void *p2, void *p3)
 			  ARRAY_SIZE(inherit_memory_partition_array),
 			  inherit_memory_partition_array);
 
-	k_mem_domain_remove_thread(k_current_get());
 	parent_tid = k_current_get();
 	k_mem_domain_add_thread(&inherit_mem_domain, parent_tid);
 

--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -24,7 +24,6 @@ extern void test_mem_domain_add_partitions_invalid(void);
 extern void test_mem_domain_add_partitions_simple(void);
 extern void test_mem_domain_remove_partitions_simple(void);
 extern void test_mem_domain_remove_partitions(void);
-extern void test_mem_domain_remove_thread(void);
 extern void test_kobject_access_grant(void);
 extern void test_syscall_invalid_kobject(void);
 extern void test_thread_without_kobject_permission(void);
@@ -66,7 +65,6 @@ void test_main(void)
 			 ztest_unit_test(test_mem_domain_add_partitions_simple),
 			 ztest_unit_test(test_mem_domain_remove_partitions_simple),
 			 ztest_unit_test(test_mem_domain_remove_partitions),
-			 ztest_unit_test(test_mem_domain_remove_thread),
 			 ztest_unit_test(test_mark_thread_exit_uninitialized),
 			 ztest_unit_test(test_kobject_access_grant),
 			 ztest_unit_test(test_syscall_invalid_kobject),

--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -25,7 +25,6 @@ extern void test_mem_domain_add_partitions_simple(void);
 extern void test_mem_domain_remove_partitions_simple(void);
 extern void test_mem_domain_remove_partitions(void);
 extern void test_mem_domain_remove_thread(void);
-extern void test_mem_domain_destroy(void);
 extern void test_kobject_access_grant(void);
 extern void test_syscall_invalid_kobject(void);
 extern void test_thread_without_kobject_permission(void);
@@ -68,7 +67,6 @@ void test_main(void)
 			 ztest_unit_test(test_mem_domain_remove_partitions_simple),
 			 ztest_unit_test(test_mem_domain_remove_partitions),
 			 ztest_unit_test(test_mem_domain_remove_thread),
-			 ztest_unit_test(test_mem_domain_destroy),
 			 ztest_unit_test(test_mark_thread_exit_uninitialized),
 			 ztest_unit_test(test_kobject_access_grant),
 			 ztest_unit_test(test_syscall_invalid_kobject),

--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -104,7 +104,6 @@ static void mem_domain_test_1(void *tc_number, void *p2, void *p3)
 {
 	if ((uintptr_t)tc_number == 1U) {
 		mem_domain_buf[0] = 10U;
-		k_mem_domain_remove_thread(k_current_get());
 		k_mem_domain_add_thread(&mem_domain_mem_domain,
 					k_current_get());
 	}
@@ -189,7 +188,6 @@ void test_mem_domain_partitions_user_rw(void)
 			  ARRAY_SIZE(mem_domain_memory_partition_array),
 			  mem_domain_memory_partition_array);
 
-	k_mem_domain_remove_thread(k_current_get());
 	k_mem_domain_add_thread(&mem_domain_mem_domain,
 				k_current_get());
 
@@ -230,7 +228,6 @@ void test_mem_domain_partitions_user_ro(void)
 	k_mem_domain_init(&mem_domain1,
 			  ARRAY_SIZE(mem_domain_memory_partition_array1),
 			  mem_domain_memory_partition_array1);
-	k_mem_domain_remove_thread(k_current_get());
 
 	k_mem_domain_add_thread(&mem_domain1, k_current_get());
 
@@ -248,7 +245,6 @@ void test_mem_domain_partitions_supervisor_rw(void)
 	k_mem_domain_init(&mem_domain_mem_domain,
 			  ARRAY_SIZE(mem_domain_memory_partition_array1),
 			  mem_domain_memory_partition_array1);
-	k_mem_domain_remove_thread(k_current_get());
 
 	k_mem_domain_add_thread(&mem_domain_mem_domain, k_current_get());
 
@@ -354,8 +350,6 @@ void test_mem_domain_add_partitions_invalid(void *p1, void *p2, void *p3)
 	uint8_t max_partitions = (uint8_t)arch_mem_domain_max_partitions_get() - 1;
 	uint8_t index;
 
-	k_mem_domain_remove_thread(k_current_get());
-
 	mem_domain_init();
 	k_mem_domain_init(&mem_domain_tc3_mem_domain,
 			  1,
@@ -367,15 +361,13 @@ void test_mem_domain_add_partitions_invalid(void *p1, void *p2, void *p3)
 					   [index]);
 
 	}
-	/* The next add_thread and remove_thread is done so that the
+	/* The next add_thread is done so that the
 	 * memory domain for mem_domain_tc3_mem_domain partitions are
 	 * initialized. Because the pages/regions will not be configuired for
 	 * the partitions in mem_domain_tc3_mem_domain when do a add_partition.
 	 */
 	k_mem_domain_add_thread(&mem_domain_tc3_mem_domain,
 				k_current_get());
-
-	k_mem_domain_remove_thread(k_current_get());
 
 	/* configure a different memory domain for the current thread. */
 	k_mem_domain_add_thread(&mem_domain_mem_domain,
@@ -429,7 +421,6 @@ void test_mem_domain_add_partitions_simple(void *p1, void *p2, void *p3)
 
 	}
 
-	k_mem_domain_remove_thread(k_current_get());
 	k_mem_domain_add_thread(&mem_domain_tc3_mem_domain,
 				k_current_get());
 
@@ -460,7 +451,6 @@ static void mem_domain_for_user_tc5(void *p1, void *p2, void *p3)
  */
 void test_mem_domain_remove_partitions_simple(void *p1, void *p2, void *p3)
 {
-	k_mem_domain_remove_thread(k_current_get());
 	k_mem_domain_add_thread(&mem_domain_tc3_mem_domain,
 				k_current_get());
 
@@ -502,7 +492,6 @@ static void mem_domain_test_6_2(void *p1, void *p2, void *p3)
  */
 void test_mem_domain_remove_partitions(void *p1, void *p2, void *p3)
 {
-	k_mem_domain_remove_thread(k_current_get());
 	k_mem_domain_add_thread(&mem_domain_tc3_mem_domain,
 				k_current_get());
 
@@ -528,40 +517,4 @@ void test_mem_domain_remove_partitions(void *p1, void *p2, void *p3)
 			-1, K_USER | K_INHERIT_PERMS, K_NO_WAIT);
 
 	k_thread_join(&mem_domain_6_tid, K_FOREVER);
-}
-/****************************************************************************/
-
-static void mem_domain_for_user_tc7(void *p1, void *p2, void *p3)
-{
-	set_fault_valid(true);
-
-	/* will generate a fault */
-	mem_domain_tc3_part4[0] = 10U;
-	zassert_unreachable(ERROR_STR);
-}
-
-/**
- * @brief Test removal of a thread from the memory domain.
- *
- * @details Till now all the test suite would have tested add thread.
- * this ensures that remove is working correctly.
- *
- * @ingroup kernel_memprotect_tests
- *
- * @see k_mem_domain_remove_thread()
- */
-void test_mem_domain_remove_thread(void *p1, void *p2, void *p3)
-{
-	k_mem_domain_remove_thread(k_current_get());
-
-	k_mem_domain_add_thread(&mem_domain_tc3_mem_domain,
-				k_current_get());
-
-
-	k_mem_domain_remove_thread(k_current_get());
-	k_mem_domain_add_thread(&k_mem_domain_default, k_current_get());
-
-	k_thread_user_mode_enter(mem_domain_for_user_tc7,
-				 NULL, NULL, NULL);
-
 }

--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -559,7 +559,7 @@ void test_mem_domain_remove_thread(void *p1, void *p2, void *p3)
 
 
 	k_mem_domain_remove_thread(k_current_get());
-	k_mem_domain_add_thread(&ztest_mem_domain, k_current_get());
+	k_mem_domain_add_thread(&k_mem_domain_default, k_current_get());
 
 	k_thread_user_mode_enter(mem_domain_for_user_tc7,
 				 NULL, NULL, NULL);

--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -565,35 +565,3 @@ void test_mem_domain_remove_thread(void *p1, void *p2, void *p3)
 				 NULL, NULL, NULL);
 
 }
-/****************************************************************************/
-
-/**
- * @brief Test memory domain destroy, which removes all thread assignments to it
- *
- * @details Test k_mem_domain_destroy API
- *
- * @ingroup kernel_memprotect_tests
- *
- * @see k_mem_domain_add_thread(), k_mem_domain_destroy()
- * */
-void test_mem_domain_destroy(void)
-{
-	k_mem_domain_init(&mem_domain1,
-			  ARRAY_SIZE(mem_domain_memory_partition_array1),
-			  mem_domain_memory_partition_array1);
-	k_mem_domain_remove_thread(k_current_get());
-
-	k_mem_domain_add_thread(&mem_domain1, k_current_get());
-
-	k_tid_t tid = k_current_get();
-
-	if (tid->mem_domain_info.mem_domain == &mem_domain1) {
-		k_mem_domain_destroy(&mem_domain1);
-
-		zassert_true(tid->mem_domain_info.mem_domain !=
-			     &mem_domain1, "The thread has reference to"
-			     " memory domain which is already destroyed");
-	} else {
-		zassert_unreachable("k_mem_domain_add_thread() failed");
-	}
-}

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -651,9 +651,6 @@ static void test_access_other_memdomain(void)
 	 */
 
 	k_mem_domain_init(&dom1, ARRAY_SIZE(parts), parts);
-
-	/* remove current thread from domain dom0 and add to dom1 */
-	k_mem_domain_remove_thread(k_current_get());
 	k_mem_domain_add_thread(&dom1, k_current_get());
 
 	/* Create user mode thread */
@@ -708,9 +705,6 @@ static void test_domain_add_thread_drop_to_user(void)
 
 	expect_fault = false;
 	k_mem_domain_init(&add_thread_drop_dom, ARRAY_SIZE(parts), parts);
-	k_mem_domain_remove_thread(k_current_get());
-
-	k_sleep(K_MSEC(1));
 	k_mem_domain_add_thread(&add_thread_drop_dom, k_current_get());
 
 	k_thread_user_mode_enter(user_half, NULL, NULL, NULL);
@@ -729,33 +723,10 @@ static void test_domain_add_part_drop_to_user(void)
 
 	expect_fault = false;
 	k_mem_domain_init(&add_part_drop_dom, ARRAY_SIZE(parts), parts);
-	k_mem_domain_remove_thread(k_current_get());
 	k_mem_domain_add_thread(&add_part_drop_dom, k_current_get());
 
 	k_sleep(K_MSEC(1));
 	k_mem_domain_add_partition(&add_part_drop_dom, &access_part);
-
-	k_thread_user_mode_enter(user_half, NULL, NULL, NULL);
-}
-
-/* Show that self-removing from a memory domain and then dropping to user
- * mode faults as expected.
- *
- * @ingroup kernel_memprotect_tests
- */
-static void test_domain_remove_thread_drop_to_user(void)
-{
-	struct k_mem_partition *parts[] = {&part0, &access_part,
-					   &ztest_mem_partition};
-
-	expect_fault = true;
-	expected_reason = K_ERR_CPU_EXCEPTION;
-	k_mem_domain_init(&remove_thread_drop_dom, ARRAY_SIZE(parts), parts);
-	k_mem_domain_remove_thread(k_current_get());
-	k_mem_domain_add_thread(&remove_thread_drop_dom, k_current_get());
-
-	k_sleep(K_MSEC(1));
-	k_mem_domain_remove_thread(k_current_get());
 
 	k_thread_user_mode_enter(user_half, NULL, NULL, NULL);
 }
@@ -774,7 +745,6 @@ static void test_domain_remove_part_drop_to_user(void)
 	expect_fault = true;
 	expected_reason = K_ERR_CPU_EXCEPTION;
 	k_mem_domain_init(&remove_part_drop_dom, ARRAY_SIZE(parts), parts);
-	k_mem_domain_remove_thread(k_current_get());
 	k_mem_domain_add_thread(&remove_part_drop_dom, k_current_get());
 
 	k_sleep(K_MSEC(1));
@@ -820,9 +790,6 @@ static void test_domain_add_thread_context_switch(void)
 
 	expect_fault = false;
 	k_mem_domain_init(&add_thread_ctx_dom, ARRAY_SIZE(parts), parts);
-	k_mem_domain_remove_thread(k_current_get());
-
-	k_sleep(K_MSEC(1));
 	k_mem_domain_add_thread(&add_thread_ctx_dom, k_current_get());
 
 	spawn_user();
@@ -839,33 +806,10 @@ static void test_domain_add_part_context_switch(void)
 
 	expect_fault = false;
 	k_mem_domain_init(&add_part_ctx_dom, ARRAY_SIZE(parts), parts);
-	k_mem_domain_remove_thread(k_current_get());
 	k_mem_domain_add_thread(&add_part_ctx_dom, k_current_get());
 
 	k_sleep(K_MSEC(1));
 	k_mem_domain_add_partition(&add_part_ctx_dom, &access_part);
-
-	spawn_user();
-}
-
-/* Show that self-removing from a memory domain and then switching to another
- * user thread in the same domain faults as expected.
- *
- * @ingroup kernel_memprotect_tests
- */
-static void test_domain_remove_thread_context_switch(void)
-{
-	struct k_mem_partition *parts[] = {&part0, &access_part,
-					   &ztest_mem_partition};
-
-	expect_fault = true;
-	expected_reason = K_ERR_CPU_EXCEPTION;
-	k_mem_domain_init(&remove_thread_ctx_dom, ARRAY_SIZE(parts), parts);
-	k_mem_domain_remove_thread(k_current_get());
-	k_mem_domain_add_thread(&remove_thread_ctx_dom, k_current_get());
-
-	k_sleep(K_MSEC(1));
-	k_mem_domain_remove_thread(k_current_get());
 
 	spawn_user();
 }
@@ -885,7 +829,6 @@ static void test_domain_remove_part_context_switch(void)
 	expect_fault = true;
 	expected_reason = K_ERR_CPU_EXCEPTION;
 	k_mem_domain_init(&remove_part_ctx_dom, ARRAY_SIZE(parts), parts);
-	k_mem_domain_remove_thread(k_current_get());
 	k_mem_domain_add_thread(&remove_part_ctx_dom, k_current_get());
 
 	k_sleep(K_MSEC(1));
@@ -1087,7 +1030,6 @@ void test_main(void)
 	struct k_mem_partition *parts[] = {&part0, &part1,
 		&ztest_mem_partition};
 
-	k_mem_domain_remove_thread(k_current_get());
 	k_mem_domain_init(&dom0, ARRAY_SIZE(parts), parts);
 	k_mem_domain_add_thread(&dom0, k_current_get());
 
@@ -1131,11 +1073,9 @@ void test_main(void)
 			 ztest_unit_test(test_domain_add_thread_drop_to_user),
 			 ztest_unit_test(test_domain_add_part_drop_to_user),
 			 ztest_unit_test(test_domain_remove_part_drop_to_user),
-			 ztest_unit_test(test_domain_remove_thread_drop_to_user),
 			 ztest_unit_test(test_domain_add_thread_context_switch),
 			 ztest_unit_test(test_domain_add_part_context_switch),
 			 ztest_unit_test(test_domain_remove_part_context_switch),
-			 ztest_unit_test(test_domain_remove_thread_context_switch),
 			 ztest_user_unit_test(test_unimplemented_syscall),
 			 ztest_user_unit_test(test_bad_syscall),
 			 ztest_user_unit_test(test_oops_panic),

--- a/tests/kernel/mutex/sys_mutex/src/main.c
+++ b/tests/kernel/mutex/sys_mutex/src/main.c
@@ -424,12 +424,12 @@ void test_main(void)
 	k_thread_access_grant(k_current_get(),
 			      &thread_12_thread_data, &thread_12_stack_area);
 
-	k_mem_domain_add_thread(&ztest_mem_domain, THREAD_05);
-	k_mem_domain_add_thread(&ztest_mem_domain, THREAD_06);
-	k_mem_domain_add_thread(&ztest_mem_domain, THREAD_07);
-	k_mem_domain_add_thread(&ztest_mem_domain, THREAD_08);
-	k_mem_domain_add_thread(&ztest_mem_domain, THREAD_09);
-	k_mem_domain_add_thread(&ztest_mem_domain, THREAD_11);
+	k_mem_domain_add_thread(&k_mem_domain_default, THREAD_05);
+	k_mem_domain_add_thread(&k_mem_domain_default, THREAD_06);
+	k_mem_domain_add_thread(&k_mem_domain_default, THREAD_07);
+	k_mem_domain_add_thread(&k_mem_domain_default, THREAD_08);
+	k_mem_domain_add_thread(&k_mem_domain_default, THREAD_09);
+	k_mem_domain_add_thread(&k_mem_domain_default, THREAD_11);
 #endif
 	rv = sys_mutex_lock(&not_my_mutex, K_NO_WAIT);
 	if (rv != 0) {

--- a/tests/kernel/threads/thread_init/src/main.c
+++ b/tests/kernel/threads/thread_init/src/main.c
@@ -209,8 +209,8 @@ void test_main(void)
 	k_thread_access_grant(k_current_get(), &thread_preempt, &stack_preempt,
 			      &start_sema, &end_sema);
 #ifdef CONFIG_USERSPACE
-	k_mem_domain_add_thread(&ztest_mem_domain, T_KDEFINE_COOP_THREAD);
-	k_mem_domain_add_thread(&ztest_mem_domain, T_KDEFINE_PREEMPT_THREAD);
+	k_mem_domain_add_thread(&k_mem_domain_default, T_KDEFINE_COOP_THREAD);
+	k_mem_domain_add_thread(&k_mem_domain_default, T_KDEFINE_PREEMPT_THREAD);
 #endif
 
 	ztest_test_suite(thread_init,


### PR DESCRIPTION
This PR:

- Deprecates `k_mem_domain_destroy()`, it lacks use-cases
- Implements a new policy that all threads are a member of a memory domain. A default memory domain `k_mem_domain_default` is introduced for threads that would otherwise have this be `NULL`, such as the main thread. The primary motivation for this is MMU systems where page tables will be maintained at the memory domain level. This domain has the C library partition added by default.
- ztest now just uses the default domain instead of defining its own.
- `k_mem_domain_add_thread()` no longer explodes if the target thread was already a member of some other domain. Instead, it is removed from the old domain first.
- With threads now always being a member of a memory domain, deprecate `k_mem_domain_remove_thread()`. Meanwhile, this is now equivalent to adding the thread to the default domain.
- Uniprocessor ARM and ARC don't actually need to implement the `arch_mem_domain_*` APIs. Remove the implementations (which were causing problems in some corner cases) and add a Kconfig `CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API` to indicate whether these are needed or not.
- Improve some assertions and debug messages.
- Documentation updates to reflect the above changes.

Please review the individual commit messages for more details about these changes.