### PR TITLE
drivers/bluetooth: ipm_stm32wb.c: Increase RX thread stack size

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -102,7 +102,7 @@ endif # BT_SPI
 config BT_STM32_IPM_RX_STACK_SIZE
 	int "STM32 IPM stack size for RX thread"
 	depends on BT_STM32_IPM
-	default 256
+	default 512
 
 config BT_RPMSG_NRF53
 	bool "nRF53 configuration of RPMsg"


### PR DESCRIPTION
Stack overflows where seen in heavy logging conditions since printk
modifications that increased "slightly" RAM consumption
(973487fdad1b72e7aaeb95c0330b9fa4a5831026).

Increase RX Thread stack size to avoid these overflows.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>