### PR TITLE
run custom pre_script before open the serial port and add argument --pre-script in sanitycheck scrpit for it

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -631,6 +631,13 @@ class DeviceHandler(Handler):
         else:
             command = [self.generator_cmd, "-C", self.build_dir, "flash"]
 
+        pre_script = hardware.get('pre_script')
+        post_flash_script = hardware.get('post_flash_script')
+        post_script = hardware.get('post_script')
+
+        if pre_script:
+            self.run_custom_script(pre_script, 30)
+
         try:
             ser = serial.Serial(
                 serial_device,
@@ -661,13 +668,6 @@ class DeviceHandler(Handler):
         harness.configure(self.instance)
         read_pipe, write_pipe = os.pipe()
         start_time = time.time()
-
-        pre_script = hardware.get('pre_script')
-        post_flash_script = hardware.get('post_flash_script')
-        post_script = hardware.get('post_script')
-
-        if pre_script:
-            self.run_custom_script(pre_script, 30)
 
         t = threading.Thread(target=self.monitor_serial, daemon=True,
                              args=(ser, read_pipe, harness))

--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -3507,14 +3507,15 @@ class HardwareMap:
         self.detected = []
         self.connected_hardware = []
 
-    def load_device_from_cmdline(self, serial, platform, is_pty):
+    def load_device_from_cmdline(self, serial, platform, pre_script, is_pty):
         device = {
             "serial": None,
             "platform": platform,
             "serial_pty": None,
             "counter": 0,
             "available": True,
-            "connected": True
+            "connected": True,
+            "pre_script": pre_script
         }
 
         if is_pty:

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -615,6 +615,11 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
                         for testing on hardware that is listed in the file.
                         """)
 
+    parser.add_argument("--pre-script",
+                        help="""specify a pre script. This will be executed
+                        before device handler open serial port and invoke runner.
+                        """)
+
     parser.add_argument(
         "--west-flash", nargs='?', const=[],
         help="""Uses west instead of ninja or make to flash when running with
@@ -862,10 +867,12 @@ def main():
                 if options.device_serial:
                     hwm.load_device_from_cmdline(options.device_serial,
                                                  options.platform[0],
+                                                 options.pre_script,
                                                  False)
                 else:
                     hwm.load_device_from_cmdline(options.device_serial_pty,
                                                  options.platform[0],
+                                                 options.pre_script,
                                                  True)
 
                 suite.connected_hardware = hwm.connected_hardware


### PR DESCRIPTION
In some cases it might be a good idea to reset the board for real to make sure it is completely recovered from some failed state (simple re-loading of the application binary or even Elf file contents doesn't affect most of internal CPU states so doesn't help in recovery, see #25022 & #26665). And so we may want to utilize some external utility which triggers the hard reset (in case of ARC boards it is https://github.com/foss-for-synopsys-dwc-arc-processors/rff-ftdi-reset). So we need to have a way to execute an external command before each and every test.

Now given we already have quite some call-backs we try to use them before re-inventing the wheel. And pre_script seem to be a good option with just on minor note - it is called after serial port gets open. And while in some cases it might be OK if serial port on the board is not affected by the board's reset, if it is affected we'll be losing connection on reset (and that's the case with ARC boards BTW as the FTDI USB-to-Serial IC is also wired to the reset signal on most of the boards). That said we just move invocation of pre_script before opening the serial port and everything should be good now.

Currently, pre_script can only get from hardware.map file. just like: `./scripts/sanitycheck  --hardware-map xxx.map`, and set pre_script in xxx.map file. It's not convenient, so we add argument --pre-script to specify a pre script. This will be executed before device handler open serial port and invoke runner.

Fixes #25022 & Fixes #26665
