### PR TITLE
drivers: i2c: fix STM32 implicit-fallthrough warning

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -350,6 +350,7 @@ static inline void handle_rxne(struct device *dev)
 		case 2:
 			LL_I2C_AcknowledgeNextData(i2c, LL_I2C_NACK);
 			LL_I2C_EnableBitPOS(i2c);
+			__fallthrough;
 		case 3:
 			/*
 			 * 2-byte, 3-byte reception and for N-2, N-1,


### PR DESCRIPTION
drivers: i2c: fix STM32 implicit-fallthrough warning

Fall through is intentional,
so make sure compiler doesn't raise warning.
