### PR TITLE
boards: arm: nucleo_h743zi: add rng support

### DIFF
--- a/boards/arm/nucleo_h743zi/doc/index.rst
+++ b/boards/arm/nucleo_h743zi/doc/index.rst
@@ -113,6 +113,8 @@ features:
 +-----------+------------+-------------------------------------+
 | ADC       | on-chip    | adc                                 |
 +-----------+------------+-------------------------------------+
+| RNG       | on-chip    | True Random number generator        |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
@@ -81,3 +81,7 @@
 &adc1_2 {
 	status = "okay";
 };
+
+&rng {
+	status = "okay";
+};

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -176,7 +176,8 @@ static int entropy_stm32_rng_init(struct device *dev)
 	 *  Linear Feedback Shift Register
 	 */
 	 LL_RCC_SetRNGClockSource(LL_RCC_RNG_CLKSOURCE_PLLSAI1);
-#elif defined(RCC_HSI48_SUPPORT)
+#elif defined(RCC_CR2_HSI48ON) || defined(RCC_CR_HSI48ON) \
+	|| defined(RCC_CRRCR_HSI48ON)
 
 #if CONFIG_SOC_SERIES_STM32L0X
 	/* We need SYSCFG to control VREFINT, so make sure it is clocked */


### PR DESCRIPTION
Add RNG support to nucleo_h743zi board.

Passed on following tests:
* tests/drivers/entropy/api
* samples/drivers/entropy