### PR TITLE
cmake: zephyr_module.py working directory when listing modules

### DIFF
--- a/cmake/zephyr_module.cmake
+++ b/cmake/zephyr_module.cmake
@@ -37,6 +37,7 @@ if(WEST OR ZEPHYR_MODULES)
     --kconfig-out ${KCONFIG_MODULES_FILE}
     --cmake-out ${CMAKE_BINARY_DIR}/zephyr_modules.txt
     --settings-out ${ZEPHYR_SETTINGS_FILE}
+    WORKING_DIRECTORY ${ZEPHYR_BASE}
     ERROR_VARIABLE
     zephyr_module_error_text
     RESULT_VARIABLE


### PR DESCRIPTION
Fixes: #27237

This commit fixes an issue when `zephyr_module.py` was executed outside
a west workspace.
This would happen when build an out-of-tree (out-of-workspace)
application, in which case the current west workspace would be unknown.

This is now changed, so that execution of `zephyr_module.py` will be
done in the current Zephyr base.
This ensures that the west workspace that holds the current Zephyr will
be the same workspace used for west list, and hence solve fix the issue.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>