### PR TITLE
doc: bluetooth: Add a new controller listing

### DIFF
--- a/doc/guides/bluetooth/bluetooth-qual.rst
+++ b/doc/guides/bluetooth/bluetooth-qual.rst
@@ -57,6 +57,11 @@ Controller qualifications
      - Qualifying Company
      - Compatible Hardware
 
+   * - 2.2.x
+     - `QDID 150092 <https://launchstudio.bluetooth.com/ListingDetails/108089>`__
+     - Nordic Semiconductor
+     - nRF52x
+
    * - 1.14.x
      - `QDID 135679 <https://launchstudio.bluetooth.com/ListingDetails/90777>`__
      - Nordic Semiconductor


### PR DESCRIPTION
Add a new listing for the Zephyr BLE Controller. This applies to the Nordic
nRF52 series and Zephyr version 2.2.x.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>