### PR TITLE
Bluetooth: controller: nRF53: Use SWI instead of EGU

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/swi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/swi.h
@@ -18,6 +18,8 @@
 
 #elif defined(CONFIG_SOC_SERIES_NRF53X)
 
+#if defined(CONFIG_BOARD_NRF5340DK_NRF5340_CPUNET)
+
 #define HAL_SWI_RADIO_IRQ  SWI2_IRQn
 #define HAL_SWI_WORKER_IRQ RTC0_IRQn
 
@@ -27,7 +29,22 @@
 #else
 #define HAL_SWI_JOB_IRQ    SWI3_IRQn
 #endif
+
+#elif defined(CONFIG_BOARD_NRF5340PDK_NRF5340_CPUNET)
+
+#define HAL_SWI_RADIO_IRQ  EGU0_IRQn
+#define HAL_SWI_WORKER_IRQ RTC0_IRQn
+
+#if !defined(CONFIG_BT_CTLR_LOW_LAT) && \
+	(CONFIG_BT_CTLR_ULL_HIGH_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
+#define HAL_SWI_JOB_IRQ    HAL_SWI_WORKER_IRQ
+#else
+#error "Use an unused IRQ line to implement a second SW IRQ."
 #endif
+
+#endif /* CONFIG_BOARD_NRF5340PDK_NRF5340_CPUNET */
+
+#endif /* CONFIG_SOC_SERIES_NRF53X */
 
 static inline void hal_swi_init(void)
 {

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/swi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/swi.h
@@ -6,12 +6,6 @@
 
 #if defined(CONFIG_SOC_SERIES_NRF51X) || defined(CONFIG_SOC_COMPATIBLE_NRF52X)
 
-static inline void hal_swi_init(void)
-{
-	/* No platform-specific initialization required. */
-}
-
-/* Split architecture uses max. two SWI */
 #define HAL_SWI_RADIO_IRQ  SWI4_IRQn
 #define HAL_SWI_WORKER_IRQ RTC0_IRQn
 
@@ -22,44 +16,28 @@ static inline void hal_swi_init(void)
 #define HAL_SWI_JOB_IRQ    SWI5_IRQn
 #endif
 
-static inline void hal_swi_lll_pend(void)
-{
-	NVIC_SetPendingIRQ(HAL_SWI_RADIO_IRQ);
-}
-
-static inline void hal_swi_worker_pend(void)
-{
-	NVIC_SetPendingIRQ(HAL_SWI_WORKER_IRQ);
-}
-
-static inline void hal_swi_job_pend(void)
-{
-	NVIC_SetPendingIRQ(HAL_SWI_JOB_IRQ);
-}
-
 #elif defined(CONFIG_SOC_SERIES_NRF53X)
+
+#define HAL_SWI_RADIO_IRQ  SWI2_IRQn
+#define HAL_SWI_WORKER_IRQ RTC0_IRQn
+
+#if !defined(CONFIG_BT_CTLR_LOW_LAT) && \
+	(CONFIG_BT_CTLR_ULL_HIGH_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
+#define HAL_SWI_JOB_IRQ    HAL_SWI_WORKER_IRQ
+#else
+#define HAL_SWI_JOB_IRQ    SWI3_IRQn
+#endif
+#endif
 
 static inline void hal_swi_init(void)
 {
 	/* No platform-specific initialization required. */
 }
 
-/* Split architecture uses max. two SWI */
-#define HAL_SWI_RADIO_IRQ     EGU0_IRQn
-#define HAL_SWI_WORKER_IRQ    RTC0_IRQn
-
-#if !defined(CONFIG_BT_CTLR_LOW_LAT) && \
-	(CONFIG_BT_CTLR_ULL_HIGH_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
-#define HAL_SWI_JOB_IRQ    HAL_SWI_WORKER_IRQ
-
 static inline void hal_swi_lll_pend(void)
 {
 	NVIC_SetPendingIRQ(HAL_SWI_RADIO_IRQ);
 }
-
-#else
-#error "We need to use an unused IRQ line to implement a second SW IRQ. "
-#endif
 
 static inline void hal_swi_worker_pend(void)
 {
@@ -70,5 +48,3 @@ static inline void hal_swi_job_pend(void)
 {
 	NVIC_SetPendingIRQ(HAL_SWI_JOB_IRQ);
 }
-
-#endif /* CONFIG_SOC_SERIES_NRF53X */


### PR DESCRIPTION
nRF5340 does have SWI peripheral, hence use it instead of
the single available EGU peripheral. Use of SWI will allow
controller's LLL, ULL_HIGH and ULL_LOW execution context to
be independently configured to different interrupt priority
levels.

When ULL_HIGH priority equals ULL_LOW priority, only SWI2
is used by controller. Otherwise, SWI3 is used for ULL_LOW.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>