### PR TITLE
Coding guideline: small fixes

### DIFF
--- a/drivers/timer/apic_timer.c
+++ b/drivers/timer/apic_timer.c
@@ -217,6 +217,8 @@ int z_clock_driver_init(struct device *device)
 {
 	uint32_t val;
 
+	ARG_UNUSED(device);
+
 	val = x86_read_loapic(LOAPIC_TIMER_CONFIG);	/* set divider */
 	val &= ~DCR_DIVIDER_MASK;
 	val |= DCR_DIVIDER;

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -151,6 +151,8 @@ void z_clock_isr(void *arg)
 
 int z_clock_driver_init(struct device *device)
 {
+	ARG_UNUSED(device);
+
 	NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
 	last_load = CYC_PER_TICK - 1;
 	overflow_cyc = 0U;

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -121,6 +121,8 @@ int z_clock_driver_init(struct device *device)
 	extern int z_clock_hw_cycles_per_sec;
 	uint32_t hz;
 
+	ARG_UNUSED(device);
+
 	DEVICE_MMIO_TOPLEVEL_MAP(hpet_regs, K_MEM_CACHE_NONE);
 
 	IRQ_CONNECT(DT_INST_IRQN(0),

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -81,6 +81,8 @@ static void timer_isr(void *arg)
 
 int z_clock_driver_init(struct device *device)
 {
+	ARG_UNUSED(device);
+
 	IRQ_CONNECT(RISCV_MACHINE_TIMER_IRQ, 0, timer_isr, NULL, 0);
 	last_count = mtime();
 	set_mtimecmp(last_count + CYC_PER_TICK);

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -25,6 +25,8 @@ void __weak z_clock_isr(void *arg)
 
 int __weak z_clock_driver_init(struct device *device)
 {
+	ARG_UNUSED(device);
+
 	return 0;
 }
 

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -59,6 +59,8 @@ static void ccompare_isr(void *arg)
 
 int z_clock_driver_init(struct device *device)
 {
+	ARG_UNUSED(device);
+
 	IRQ_CONNECT(TIMER_IRQ, 0, ccompare_isr, 0, 0);
 	set_ccompare(ccount() + CYC_PER_TICK);
 	irq_enable(TIMER_IRQ);

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -752,9 +752,8 @@ void ll_rx_dequeue(void)
 
 #if defined(CONFIG_BT_CTLR_USER_EXT)
 	case NODE_RX_TYPE_USER_START ... NODE_RX_TYPE_USER_END:
-#endif /* CONFIG_BT_CTLR_USER_EXT */
-
 		__fallthrough;
+#endif /* CONFIG_BT_CTLR_USER_EXT */
 
 	/* Ensure that at least one 'case' statement is present for this
 	 * code block.


### PR DESCRIPTION
- Fix a compilation error with a fallthrough case
- Explicitly mark a variable as unused