### PR TITLE
west: hal_nxp: Fix USB_DEVICE_CONFIG_ENDPOINTS definition

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -98,7 +98,7 @@ manifest:
       revision: 1c4fdba512b268033a4cf926bddd323866c3261a
       path: tools/net-tools
     - name: hal_nxp
-      revision: a501b0477ceceaa0abcba4e1fea0f64bbe8b6bae
+      revision: e13b23c06850530c6c34208905d58e7a6a12cdd5
       path: modules/hal/nxp
     - name: open-amp
       revision: 724f7e2a4519d7e1d40ef330042682dea950c991


### PR DESCRIPTION
The define for USB_DEVICE_CONFIG_ENDPOINTS erroneously divided
the DTS value for number of USB endpoints by 2.

Signed-off-by: David Leach <david.leach@nxp.com>

Depends on zephyrproject-rtos/hal_nxp#54