### PR TITLE
bluetooth: controller: BT_CTLR_CONN_RSSI as a shared controller opt

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -51,9 +51,11 @@ config BT_CTLR_DTM_HCI_SUPPORT
 config BT_CTLR_SMI_SUPPORT
 	bool
 
+config BT_CTLR_CONN_RSSI_SUPPORT
+	bool
+
 config BT_CTLR
 	bool "Bluetooth Controller"
-	select BT_CTLR_CONN_RSSI if BT_CONN && BT_HCI_RAW
 	help
 	  Enables support for SoC native controller implementations.
 
@@ -351,6 +353,13 @@ config BT_CTLR_MIN_USED_CHAN
 	help
 	  Enable support for Bluetooth 5.0 Minimum Number of Used Channels
 	  Procedure in the Controller.
+
+config BT_CTLR_CONN_RSSI
+	bool "Connection RSSI"
+	depends on BT_CTLR_CONN_RSSI_SUPPORT
+	default y if BT_HCI_RAW
+	help
+	  Enable connection RSSI measurement.
 
 endif # BT_CONN
 

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -27,6 +27,7 @@ config BT_LLL_VENDOR_NORDIC
 	select BT_CTLR_CHAN_SEL_2_SUPPORT
 	select BT_CTLR_MIN_USED_CHAN_SUPPORT
 	select BT_CTLR_DTM_HCI_SUPPORT
+	select BT_CTLR_CONN_RSSI_SUPPORT
 
 	select BT_CTLR_XTAL_ADVANCED_SUPPORT
 	select BT_CTLR_SCHED_ADVANCED_SUPPORT
@@ -380,11 +381,6 @@ config BT_CTLR_TX_RETRY_DISABLE
 	  latencies by one connection interval as the next attempt to send a PDU
 	  would happen in the next connection event instead of repeated retries
 	  in the current connection event.
-
-config BT_CTLR_CONN_RSSI
-	bool "Connection RSSI"
-	help
-	  Enable connection RSSI measurement.
 
 config BT_CTLR_CONN_RSSI_EVENT
 	bool "Connection RSSI event"


### PR DESCRIPTION
Use a helper config BT_CTLR_CONN_RSSI_SUPPORT so that it is only
enabled when supported by the controller.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>