### PR TITLE
boards: posix: native_posix: Add radio module built with BabbleSim

### DIFF
--- a/boards/posix/native_posix/CMakeLists.txt
+++ b/boards/posix/native_posix/CMakeLists.txt
@@ -15,12 +15,14 @@ zephyr_library_sources(
 	cmdline_common.c
 	cmdline.c
 	hw_counter.c
-	)
+)
 
 zephyr_library_include_directories(
   ${ZEPHYR_BASE}/kernel/include
   ${ZEPHYR_BASE}/arch/posix/include
-  )
+)
+
+add_subdirectory_ifdef(CONFIG_USE_BABBLESIM bs_radio)
 
 if(CONFIG_HAS_SDL)
 	find_package(PkgConfig REQUIRED)
@@ -34,6 +36,7 @@ endif()
 zephyr_ld_options(
   -lm
 )
+
 
 # Override the C standard used for compilation to C 2011
 # This is due to some tests using _Static_assert which is a 2011 feature, but

--- a/boards/posix/native_posix/Kconfig
+++ b/boards/posix/native_posix/Kconfig
@@ -25,4 +25,10 @@ config HAS_SDL
 	help
 	  This option specifies that the target board has SDL support
 
+config USE_BABBLESIM
+	bool "Enable BabbleSim support"
+	help
+	  When selected the bs_radio peripheral will be enabled and compiled
+	  against BabbleSim lib2G4PhyComv1 library.
+
 endif

--- a/boards/posix/native_posix/bs_radio/CMakeLists.txt
+++ b/boards/posix/native_posix/bs_radio/CMakeLists.txt
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
+    message(FATAL_ERROR "This board requires the BabbleSim simulator. Please set\
+ the  environment variable BSIM_COMPONENTS_PATH to point to its components \
+ folder. More information can be found in\
+ https://babblesim.github.io/folder_structure_and_env.html")
+endif()
+
+if (NOT DEFINED ENV{BSIM_OUT_PATH})
+    message(FATAL_ERROR "This board requires the BabbleSim simulator. Please set\
+ the environment variable BSIM_OUT_PATH to point to the folder where the\
+ simulator is compiled to. More information can be found in\
+ https://babblesim.github.io/folder_structure_and_env.html")
+endif()
+
+zephyr_library_include_directories(
+  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  $ENV{BSIM_COMPONENTS_PATH}/libRandv2/src/
+  $ENV{BSIM_COMPONENTS_PATH}/ext_2G4_libPhyComv1/src/
+  $ENV{ZEPHYR_BASE}/boards/posix/native_posix/
+)
+
+zephyr_library_sources(bs_radio.c
+  					   bs_radio_argparse.c)
+set(bsim_lib_path $ENV{BSIM_OUT_PATH}/lib)
+
+if (DEFINED CONFIG_BOARD_NATIVE_POSIX_64BIT)
+  zephyr_library_import(bsim_libUtilv1	  ${bsim_lib_path}/libUtilv1.a)
+  zephyr_library_import(bsim_libPhyComv1    ${bsim_lib_path}/libPhyComv1.a)
+  zephyr_library_import(bsim_lib2G4PhyComv1 ${bsim_lib_path}/lib2G4PhyComv1.a)
+  zephyr_library_import(bsim_libRandv2      ${bsim_lib_path}/libRandv2.a)
+else()
+  zephyr_library_import(bsim_libUtilv1	  ${bsim_lib_path}/libUtilv1.32.a)
+  zephyr_library_import(bsim_libPhyComv1    ${bsim_lib_path}/libPhyComv1.32.a)
+  zephyr_library_import(bsim_lib2G4PhyComv1 ${bsim_lib_path}/lib2G4PhyComv1.32.a)
+  zephyr_library_import(bsim_libRandv2      ${bsim_lib_path}/libRandv2.32.a)
+endif()

--- a/boards/posix/native_posix/bs_radio/bs_radio.c
+++ b/boards/posix/native_posix/bs_radio/bs_radio.c
@@ -1,0 +1,539 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <hw_models_top.h>
+#include <soc.h>
+#include <posix_board_if.h>
+#include "bs_radio.h"
+#include "bs_types.h"
+#include "bs_tracing.h"
+#include "bs_utils.h"
+#include "bs_pc_2G4.h"
+#include "bs_radio_argparse.h"
+
+#define RADIO_BUF_SIZE (128)
+#define RADIO_BPS (1000000)
+#define RADIO_SAMPLING_INTERVAL (1200)
+#define RADIO_TX_INTERVAL (1)
+
+/* This is needed to bypass address check when using BabbleSim phy_2G4 */
+#define IEEE802154_PHYADDRESS (0xDEAD)
+
+struct radio_config {
+	p2G4_freq_t frequency;
+	p2G4_power_t tx_power;
+};
+
+enum bs_radio_states {
+	RADIO_STATE_RX_IDLE,
+	RADIO_STATE_RX,
+	RADIO_STATE_TX_PREPARE,
+	RADIO_STATE_TX,
+};
+
+uint64_t bs_radio_timer;
+
+static uint64_t last_phy_sync_time;
+static enum bs_radio_states radio_state;
+static struct radio_config radio_config;
+static uint8_t rx_buf[RADIO_BUF_SIZE];
+static uint8_t ongoing_tx_buf[RADIO_BUF_SIZE];
+p2G4_rx_done_t rx_done_s;
+static bool radio_is_running;
+static uint8_t radio_eui64[8];
+
+static bs_radio_event_cb_t radio_event_cb;
+
+static p2G4_rx_t ongoing_rx = {
+	.phy_address = IEEE802154_PHYADDRESS,
+	.radio_params = {
+		.modulation = P2G4_MOD_BLE,
+	},
+	.antenna_gain = 0,
+	.sync_threshold = 100,
+	.header_threshold = 100,
+	.pream_and_addr_duration = 0,
+	.header_duration = 0,
+	.bps = RADIO_BPS,
+	.abort = {NEVER, NEVER},
+};
+
+static p2G4_tx_t ongoing_tx = {
+	.start_time = NEVER,
+	.end_time = NEVER,
+	.phy_address = IEEE802154_PHYADDRESS,
+	.radio_params = {
+		.modulation = P2G4_MOD_BLE,
+	},
+	.packet_size = 0,
+	.abort = {NEVER, NEVER}
+};
+
+static int radio_receive(uint32_t scan_duration, uint64_t *end_time);
+static uint64_t packet_bitlen(uint32_t packet_len, uint64_t bps);
+static void radio_start_tx(uint64_t tx_start_time, uint64_t *end_time);
+static void fill_eui64(void);
+
+/**
+ * Initialize the communication with BabbleSim.
+ */
+void bs_radio_init(void)
+{
+	struct bs_radio_args *args;
+
+	bs_radio_timer = NEVER;
+	radio_state = RADIO_STATE_RX_IDLE;
+	radio_config.frequency = 0;
+	radio_config.tx_power = 0;
+	radio_is_running = false;
+	memset(rx_buf, 0, RADIO_BUF_SIZE);
+	memset(ongoing_tx_buf, 0, RADIO_BUF_SIZE);
+
+	args = bs_radio_argparse_get();
+	if (args->is_bsim) {
+		int initcom_err = p2G4_dev_initcom_c(
+			args->device_nbr, args->s_id, args->p_id, NULL);
+
+		if (initcom_err) {
+			bs_trace_warning(
+				"Failed to initialize communication with %s\n",
+				args->p_id);
+		}
+
+		fill_eui64();
+	}
+}
+
+/**
+ * Closes the connection with BabbleSim.
+ */
+void bs_radio_deinit(void)
+{
+	p2G4_dev_disconnect_c();
+}
+
+/**
+ * Starts waiting for an incoming reception.
+ */
+void bs_radio_start(bs_radio_event_cb_t event_cb)
+{
+	if (!bs_radio_argparse_get()->is_bsim) {
+		return;
+	}
+
+	if (!event_cb) {
+		bs_trace_error("Event callback cannot be NULL!\n");
+		return;
+	}
+
+	radio_is_running = true;
+	radio_event_cb = event_cb;
+	bs_radio_timer = hwm_get_time() + RADIO_SAMPLING_INTERVAL;
+	hwm_find_next_timer();
+}
+
+/**
+ * Stops all ongoing operations.
+ */
+void bs_radio_stop(void)
+{
+	if (!bs_radio_argparse_get()->is_bsim) {
+		return;
+	}
+
+	radio_is_running = false;
+	radio_state = RADIO_STATE_RX_IDLE;
+	bs_radio_timer = NEVER;
+
+	hwm_find_next_timer();
+}
+
+/**
+ * Set the channel that radio operates on.s
+ *
+ * Arguments:
+ * channel      - the channel that radio will operate on
+ *
+ * Returns:
+ * 0            -  Success
+ * negative     -  Channel couldn't be set (radio is busy)
+ */
+int bs_radio_channel_set(uint16_t channel)
+{
+	if (radio_state != RADIO_STATE_RX_IDLE) {
+		bs_trace_warning(
+			"Frequency can't be set during an ongoing operation\n");
+		return -1;
+	}
+
+	/* 11 - 26 channels, incrementing 5MHz each */
+	channel = ((channel - 10) * 5);
+	channel <<= 8;
+	channel &= 0xFF00;
+	radio_config.frequency = channel;
+
+	return 0;
+}
+
+uint16_t bs_radio_channel_get(void)
+{
+	uint16_t channel;
+
+	channel = (radio_config.frequency >> 8) & 0xFF;
+	channel /= 5;
+	channel += 10;
+
+	return channel;
+}
+
+/**
+ * Set the transmissing power.
+ *
+ * Arguments:
+ * power_dBm    -    The value of tx power expressed in dBm
+ *
+ * Returns:
+ * 0            -    Success
+ * negative     -    The power couldn't be set (radio is busy)
+ */
+int bs_radio_tx_power_set(int8_t power_dBm)
+{
+	if (radio_state != RADIO_STATE_RX_IDLE) {
+		bs_trace_warning("TX Power can't be set during "
+				 "ongoing operation\n");
+		return -1;
+	}
+
+	((uint8_t *)&radio_config.tx_power)[1] = power_dBm;
+	((uint8_t *)&radio_config.tx_power)[0] = 0;
+
+	return 0;
+}
+
+/** Returns current setting of tx power */
+int8_t bs_radio_tx_power_get(void)
+{
+	return (radio_config.tx_power >> 8) & 0xFF;
+}
+
+/**
+ * Perform RSSI sensing.
+ *
+ * The result is returned by a callback bs_radio_event_cb_t either as
+ * BS_RADIO_EVENT_RSSI_DONE or BS_RADIO_EVENT_RSSI_FAILED.
+ * The function will fail when it's called in the middle of ongoing
+ * transmission.
+ *
+ * Returns:
+ * 0            - rssi can be sensed
+ * negative     - rssi cannot be sensed
+ */
+int bs_radio_rssi(uint64_t duration_us)
+{
+	bs_trace_warning("%s not supported\n", __func__);
+	return -ENOTSUP;
+}
+
+/**
+ * Performs fsm transitions.
+ *
+ * By default (and most often) BS Radio remains
+ * in BS_RADIO_RX_IDLE state.
+ *
+ * Transition to other state can be invoked by
+ * either calling bs_radio_tx() function or by
+ * start of data reception.
+ *
+ * Note that when BS Radio is in BS_RADIO_TX state
+ * it cannot perform transition to BS_RADIO_RX unless
+ * ongoing transmittion is finished.
+ *
+ * Similarly, when BS Radio remains in BS_RADIO_RX state
+ * it cannot start transmitting unless reception is finished.
+ */
+void bs_radio_triggered(void)
+{
+	static uint64_t last_rx_try_end;
+	static uint64_t last_tx_end;
+	uint64_t current_time;
+
+	if (!radio_is_running) {
+		bs_radio_timer = NEVER;
+		return;
+	}
+
+	current_time = hwm_get_time();
+
+	switch (radio_state) {
+	case RADIO_STATE_RX_IDLE: {
+		int ret =
+			radio_receive(packet_bitlen(RADIO_BUF_SIZE, RADIO_BPS),
+				      &last_rx_try_end);
+
+		if (ret == 0) {
+			radio_state = RADIO_STATE_RX;
+			bs_radio_timer = last_rx_try_end;
+		} else {
+			radio_state = RADIO_STATE_RX_IDLE;
+			bs_radio_timer = last_rx_try_end + 1;
+		}
+		break;
+	}
+	case RADIO_STATE_RX:
+		if (current_time >= last_rx_try_end) {
+			/* Now we can say that the data is received */
+			struct bs_radio_event_data rx_event_data = {
+				.type = BS_RADIO_EVENT_RX_DONE,
+				.rx_done = { .psdu = rx_buf,
+					     .rssi = rx_done_s.rssi.RSSI >> 16,
+					     .timestamp = current_time }
+			};
+
+			radio_state = RADIO_STATE_RX_IDLE;
+			bs_radio_timer = current_time + RADIO_SAMPLING_INTERVAL;
+			last_rx_try_end = NEVER;
+
+			radio_event_cb(&rx_event_data);
+			memset(rx_buf, 0, RADIO_BUF_SIZE);
+		} else {
+			bs_trace_warning(
+				"Bad state, it shouldn't have happened\n");
+			radio_state = RADIO_STATE_RX_IDLE;
+			bs_radio_timer = NEVER;
+		}
+		break;
+	case RADIO_STATE_TX_PREPARE:
+		if (last_phy_sync_time <= current_time) {
+			radio_start_tx(current_time + RADIO_TX_INTERVAL,
+				       &last_tx_end);
+			radio_state = RADIO_STATE_TX;
+			bs_radio_timer = last_tx_end;
+		} else {
+			bs_radio_timer = last_phy_sync_time;
+		}
+		break;
+	case RADIO_STATE_TX:
+		if (current_time >= last_tx_end) {
+			/* Now we can say that the data was sent */
+			struct bs_radio_event_data tx_event_data = {
+				.type = BS_RADIO_EVENT_TX_DONE,
+			};
+			radio_event_cb(&tx_event_data);
+			memset(ongoing_tx_buf, 0, RADIO_BUF_SIZE);
+
+			radio_state = RADIO_STATE_RX_IDLE;
+			last_tx_end = NEVER;
+			bs_radio_timer = current_time + RADIO_TX_INTERVAL;
+		} else {
+			bs_trace_warning(
+				"Bad state, it shouldn't have happened\n");
+			radio_state = RADIO_STATE_RX_IDLE;
+			bs_radio_timer = NEVER;
+		}
+		break;
+	default:
+		break;
+	}
+}
+
+/**
+ * Starts the transmission.
+ *
+ * If the device is not currently receiving or transmitting,
+ * it will send data. Otherwise it will return with error.
+ *
+ * Arguments:
+ * data         - the data to send - data[0] is the length of following data
+ * cca          - (unused) set whether to perform cca or not
+ *
+ * Returns:
+ * 0            - data successfully sent
+ * negative     - data couldn't be sent
+ */
+int bs_radio_tx(uint8_t *data, bool cca)
+{
+	if (!bs_radio_argparse_get()->is_bsim) {
+		return -EFAULT;
+	}
+
+	if (!radio_is_running) {
+		bs_trace_warning(0, "Radio was not started\n");
+		return -EINVAL;
+	}
+
+	if ((data == NULL) || radio_state == RADIO_STATE_RX) {
+		bs_trace_warning(0, "Radio is now receiving\n");
+		return -EBUSY;
+	}
+
+	if ((radio_state == RADIO_STATE_TX) ||
+	    (radio_state == RADIO_STATE_TX_PREPARE)) {
+		bs_trace_warning(0, "Radio is now transmitting\n");
+		return -EBUSY;
+	}
+
+	radio_state = RADIO_STATE_TX_PREPARE;
+	memcpy(ongoing_tx_buf, data, data[0] + 1);
+
+	bs_radio_timer = hwm_get_time() + RADIO_TX_INTERVAL;
+	hwm_find_next_timer();
+
+	return 0;
+}
+
+/**
+ * Performs cca.
+ *
+ * CCA result is returned by a bs_radio_event_cb_t call with the status of
+ * either BS_RADIO_EVENT_CCA_DONE or BS_RADIO_EVENT_CCA_FAILED.
+ *
+ * Returns:
+ * 0            -       Success (cca will be performed)
+ * negative     -       CCA cannot be performed (radio is busy)
+ */
+int bs_radio_cca(void)
+{
+	int cca_result;
+
+	if (radio_state == RADIO_STATE_RX) {
+		cca_result = -EBUSY;
+	} else if (radio_state == RADIO_STATE_TX ||
+		   radio_state == RADIO_STATE_TX_PREPARE) {
+		cca_result = -EIO;
+	} else {
+		cca_result = 0;
+	}
+
+	return cca_result;
+}
+
+/**
+ * Returns the eui64.
+ *
+ * The address is generated based on BabbleSim device id in given simulation.
+ * Meaning command line parameter "-d". Every device in a given simulation
+ * has different mac, but can have the same across different simulations
+ * if run with the same id.
+ *
+ * Arguments:
+ * mac [out]   -   Pointer to copy the eui64 - can't be NULL
+ */
+void bs_radio_get_mac(uint8_t *mac)
+{
+	if (mac == NULL) {
+		bs_trace_error("%s - mac cannot be NULL");
+		return;
+	}
+
+	memcpy(mac, radio_eui64, 8);
+}
+
+/* Private functions */
+
+/**
+ * Attempt data reception. Blocks until data is received.
+ * Function will succeed when device received pream + address match
+ * from the phy.
+ *
+ * Return 0 if reception succeded, -1 otherwise.
+ *
+ * Arguments:
+ * scan_duration - The time of scanning in us. Note that function will
+ *                 block for scan_duration or until receives something
+ * end_time[out] - If function succeded this is the time when reception
+ *                 finishes.
+ *
+ * Returns:
+ * 0             - Data received successfully
+ * negative      - No data to receive
+ */
+static int radio_receive(uint32_t scan_duration, uint64_t *end_time)
+{
+	int ret;
+	uint8_t *frame = NULL;
+
+	ongoing_rx.radio_params.center_freq = radio_config.frequency;
+
+	ongoing_rx.pream_and_addr_duration = packet_bitlen(2, RADIO_BPS);
+	ongoing_rx.header_duration = 0;
+
+	ongoing_rx.start_time = hwm_get_time();
+	ongoing_rx.scan_duration = scan_duration;
+
+	rx_done_s.status = P2G4_RXSTATUS_NOSYNC;
+	rx_done_s.packet_size = 0;
+
+	ret = p2G4_dev_req_rx_c_b(&ongoing_rx, &rx_done_s, &frame, 0, NULL);
+	*end_time = rx_done_s.end_time;
+	last_phy_sync_time = rx_done_s.end_time;
+
+	if ((ret >= 0) && (rx_done_s.packet_size > 0)) {
+		memcpy(rx_buf + 1, frame, rx_done_s.packet_size);
+		rx_buf[0] = rx_done_s.packet_size;
+		free(frame);
+		return 0;
+	}
+
+	free(frame);
+	return -1;
+}
+
+/**
+ * Send data from ongoing_tx_buf
+ *
+ * Arguments:
+ * start_time     - When the transmission will start
+ * end_time [out] - When the transmission finished
+ */
+static void radio_start_tx(uint64_t tx_start_time, uint64_t *end_time)
+{
+	p2G4_tx_done_t tx_done_s;
+	int result;
+
+	ongoing_tx.radio_params.center_freq = radio_config.frequency;
+	ongoing_tx.power_level = radio_config.tx_power;
+	ongoing_tx.packet_size = ongoing_tx_buf[0];
+	ongoing_tx.start_time = tx_start_time;
+	ongoing_tx.end_time = ongoing_tx.start_time +
+			      packet_bitlen(ongoing_tx_buf[0], RADIO_BPS);
+
+	result = p2G4_dev_req_tx_c_b(&ongoing_tx, ongoing_tx_buf + 1,
+				     &tx_done_s);
+
+	*end_time = ongoing_tx.end_time;
+	last_phy_sync_time = ongoing_tx.end_time;
+}
+
+/* Calculate the time in air of a number of bytes */
+static uint64_t packet_bitlen(uint32_t packet_len, uint64_t bps)
+{
+	uint64_t bits_per_us = bps / 1000000;
+
+	return (packet_len * 8) / bits_per_us;
+}
+
+/* Generate MAC address using BabbleSim device's id */
+static void fill_eui64(void)
+{
+	struct bs_radio_args *args = bs_radio_argparse_get();
+
+	radio_eui64[7] = 0xf4;
+	radio_eui64[6] = 0xce;
+	radio_eui64[5] = 0x36;
+	radio_eui64[4] = 0x43;
+	radio_eui64[3] = 0xe3;
+	radio_eui64[2] = 0x82;
+	radio_eui64[1] = (uint8_t)((args->device_nbr >> 8));
+	radio_eui64[0] = (uint8_t)(args->device_nbr);
+}
+
+NATIVE_TASK(bs_radio_argparse_add_options, PRE_BOOT_1, 1);
+NATIVE_TASK(bs_radio_argparse_validate, PRE_BOOT_2, 2);

--- a/boards/posix/native_posix/bs_radio/bs_radio.h
+++ b/boards/posix/native_posix/bs_radio/bs_radio.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _BS_RADIO_H
+#define _BS_RADIO_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "bs_radio_argparse.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern struct bs_radio_args bs_radio_args;
+
+enum bs_radio_event_types {
+	/** On reception success */
+	BS_RADIO_EVENT_RX_DONE,
+
+	/** On reception failure */
+	BS_RADIO_EVENT_RX_FAILED,
+
+	/** On transmission success */
+	BS_RADIO_EVENT_TX_DONE,
+
+	/** On transmittion failure */
+	BS_RADIO_EVENT_TX_FAILED,
+
+	/** On CCA success */
+	BS_RADIO_EVENT_CCA_DONE,
+
+	/** On CCA failure */
+	BS_RADIO_EVENT_CCA_FAILED,
+
+	/** On energy measurement success */
+	BS_RADIO_EVENT_RSSI_DONE,
+
+	/** On energy measurement failure */
+	BS_RADIO_EVENT_RSSI_FAILED
+};
+
+struct bs_radio_event_data {
+	enum bs_radio_event_types type;
+	union {
+		struct {
+			/** Received data starts at psdu+1, psdu[0] holds the
+			 * len of packet
+			 */
+			uint8_t *psdu;
+			int8_t rssi;
+			uint32_t timestamp;
+		} rx_done;
+
+		struct {
+			uint16_t rssi;
+		} energy_done;
+	};
+};
+
+typedef void (*bs_radio_event_cb_t)(struct bs_radio_event_data *);
+
+/* HW Models API */
+void bs_radio_init(void);
+void bs_radio_triggered(void);
+void bs_radio_deinit(void);
+
+/* User API */
+void bs_radio_start(bs_radio_event_cb_t event_cb);
+void bs_radio_stop(void);
+
+int bs_radio_tx(uint8_t *data, bool cca);
+int bs_radio_rssi(uint64_t duration_us);
+
+int bs_radio_cca(void);
+int bs_radio_channel_set(uint16_t channel);
+uint16_t bs_radio_channel_get(void);
+int bs_radio_tx_power_set(int8_t power_dBm);
+int8_t bs_radio_tx_power_get(void);
+
+void bs_radio_get_mac(uint8_t *mac);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _BS_RADIO_H */

--- a/boards/posix/native_posix/bs_radio/bs_radio_argparse.c
+++ b/boards/posix/native_posix/bs_radio/bs_radio_argparse.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include <cmdline.h>
+#include <arch/posix/posix_soc_if.h>
+#include "bs_radio_argparse.h"
+
+static struct bs_radio_args bs_args;
+
+void bs_radio_argparse_add_options(void)
+{
+	static struct args_struct_t bs_options[] = {
+		{ false, false, false, "d", "device_number", 'u',
+		  (void *)&bs_args.device_nbr, NULL,
+		  "Device number (for this phy)" },
+		{ false, false, false, "s", "s_id", 's', (void *)&bs_args.s_id,
+		  NULL, "String which uniquely identifies the simulation" },
+		{ false, false, false, "p", "p_id", 's', (void *)&bs_args.p_id,
+		  NULL,
+		  "(2G4) String which uniquely identifies the phy inside the "
+		  "simulation" },
+		{ false, false, true, "bsim", "bsim", 'b',
+		  (void *)&bs_args.is_bsim, NULL,
+		  "Enable BabbleSim to simulate radio activity" },
+		ARG_TABLE_ENDMARKER
+	};
+
+	native_add_command_line_opts(bs_options);
+}
+
+void bs_radio_argparse_validate(void)
+{
+	bool p_id_set = bs_args.p_id != NULL;
+	bool s_id_set = bs_args.s_id != NULL;
+	bool dev_nbr_set = bs_args.device_nbr != -1;
+
+	if (bs_args.is_bsim) {
+		if (!p_id_set || !s_id_set || !dev_nbr_set) {
+			posix_print_warning(
+				"%s%s%snot set. It must be set prior to run the "
+				"simulation\n\n",
+				!p_id_set ? "[p_id] " : "",
+				!s_id_set ? "[s_id] " : "",
+				!dev_nbr_set ? "[device_number] " : "");
+		}
+	} else if (p_id_set || s_id_set || dev_nbr_set) {
+		posix_print_warning(
+			"%s%s%sset, but will not take any effect, "
+			"because app is not running with BabbleSim.\n"
+			"It can be enabled with -bsim option.\n\n",
+			p_id_set ? "[p_id] " : "", s_id_set ? "[s_id] " : "",
+			dev_nbr_set ? "[device_number] " : "");
+	}
+}
+
+struct bs_radio_args *bs_radio_argparse_get(void)
+{
+	return &bs_args;
+}

--- a/boards/posix/native_posix/bs_radio/bs_radio_argparse.h
+++ b/boards/posix/native_posix/bs_radio/bs_radio_argparse.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _BS_RADIO_ARGPARSE_H
+#define _BS_RADIO_ARGPARSE_H
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bs_radio_args {
+	char *s_id;
+	char *p_id;
+	unsigned int device_nbr;
+	bool is_bsim;
+};
+
+void bs_radio_argparse_add_options(void);
+struct bs_radio_args *bs_radio_argparse_get(void);
+void bs_radio_argparse_validate(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _BS_RADIO_ARGPARSE */

--- a/boards/posix/native_posix/doc/index.rst
+++ b/boards/posix/native_posix/doc/index.rst
@@ -581,6 +581,11 @@ The following peripherals are currently provided with this board:
 
   The flash content can be accessed from the host system, as explained in the
   `Host based flash access`_ section.
+**Radio**
+    An optional radio peripheral can be compiled for emulation with
+    native_posix. The connectivity between devices is provided with
+    `BabbleSim`_, a physical layer simulator. For more information refer to the
+    section `Radio physical layer simulation`_.
 
 UART
 ****
@@ -618,6 +623,76 @@ option ``-attach_uart_cmd=<"cmd">``. Where the default command is given by
 :option:`CONFIG_NATIVE_UART_AUTOATTACH_DEFAULT_CMD`.
 Note that the default command assumes both ``xterm`` and ``screen`` are
 installed in the system.
+
+Radio physical layer simulation
+*******************************
+
+The native_posix board can simulate a physical layer for sending radio packets
+using a radio module. This module can be enabled with the
+:option:`CONFIG_USE_BABBLESIM` during compilation.
+
+.. note::
+    The radio simulation currently does not fully support the physical layer of
+    IEEE 802.15.4 standard. See `Technical limitations`_ for details.
+
+The connectivity between devices is provided with `BabbleSim`_, a physical
+layer simulator. The simulation allows you to set up communication between
+several devices, choose transmission frequency, and complete transmission
+flawlessly. You can also configure the simulation to include different
+environment conditions, for example radio noise.
+
+From the higher layer perspective, this simulation does not differ from the
+real case scenario. It offers all advantages of the native_posix board,
+including deterministic, repeatable runs, and resilience to time differences.
+BabbleSim's radio simulation features are similar to :ref:`nrf52_bsim`'s, but
+more generic, because it does not emulate any specific hardware.
+
+Implementation details
+======================
+
+During the compilation using the native_posix board with
+:option:`CONFIG_USE_BABBLESIM` enabled, the build system will link against
+BabbleSim libraries. By default this option is disabled.
+
+Radio setup
+-----------
+
+To set up the radio stack physical layer simulation, complete the following steps:
+
+#. Enable the :option:`CONFIG_USE_BABBLESIM` Kconfig option.
+#. Build BabbleSim by following steps described in its `building manual`_.
+#. Define the following environment variables to point to the BabbleSim installation
+
+.. code-block:: console
+
+  $ export BSIM_OUT_PATH=${HOME}/bsim/
+  $ export BSIM_COMPONENTS_PATH=${HOME}/bsim/components/
+
+To run the binary with with BabbleSim, provide the following arguments
+
+.. code-block:: console
+
+  $ ./zephyr.elf -bsim -d=<device-index> -s=<simulation-name> -p=<phy-name>
+
+The simulation of the physical layer (phy) can be run as described in `BabbleSim's example`_.
+
+Technical limitations
+=====================
+
+The native_posix simulation of the radio stack physical layer has the same :ref:`limitations <native_important_limitations>` as the board.
+
+Additionally, the simulation does not currently include a specific physical layer that could be used for 802.15.4.
+Instead, it uses the Bluetooth layer, which leads to several inconsistencies:
+
+* Link Quality of a received packet cannot be read.
+* The data rate is limited to 1 Mb/s (instead of 250 kb/s).
+
+The physical layer access is made through a workaround, where all devices in this simulation have the same addresses.
+Bluetooth layer checks these addresses when sending or receiving packets.
+
+.. _`BabbleSim`: https://babblesim.github.io/
+.. _`BabbleSim's example`: https://babblesim.github.io/example_2g4.html
+.. _`building manual`: https://babblesim.github.io/building.html
 
 Subsystems backends
 *******************

--- a/boards/posix/native_posix/hw_models_top.c
+++ b/boards/posix/native_posix/hw_models_top.c
@@ -19,6 +19,7 @@
 #include "irq_ctrl.h"
 #include "posix_board_if.h"
 #include "hw_counter.h"
+#include "bs_radio/bs_radio.h"
 #include <arch/posix/posix_soc_if.h>
 #include "posix_arch_internal.h"
 #include "sdl_events.h"
@@ -32,6 +33,11 @@ static uint64_t end_of_time = NEVER; /* When will this device stop */
 extern uint64_t hw_timer_timer; /* When should this timer_model be called */
 extern uint64_t irq_ctrl_timer;
 extern uint64_t hw_counter_timer;
+
+#ifdef CONFIG_USE_BABBLESIM
+extern uint64_t bs_radio_timer;
+#endif /*CONFIG_USE_BABBLESIM */
+
 #ifdef CONFIG_HAS_SDL
 extern uint64_t sdl_event_timer;
 #endif
@@ -40,6 +46,9 @@ static enum {
 	HWTIMER = 0,
 	IRQCNT,
 	HW_COUNTER,
+#ifdef CONFIG_USE_BABBLESIM
+	BS_RADIO,
+#endif /* CONFIG_USE_BABBLESIM */
 #ifdef CONFIG_HAS_SDL
 	SDLEVENTTIMER,
 #endif
@@ -51,6 +60,9 @@ static uint64_t *Timer_list[NUMBER_OF_TIMERS] = {
 	&hw_timer_timer,
 	&irq_ctrl_timer,
 	&hw_counter_timer,
+#ifdef CONFIG_USE_BABBLESIM
+	&bs_radio_timer,
+#endif /* CONFIG_USE_BABBLESIM */
 #ifdef CONFIG_HAS_SDL
 	&sdl_event_timer,
 #endif
@@ -156,6 +168,11 @@ void hwm_main_loop(void)
 		case HW_COUNTER:
 			hw_counter_triggered();
 			break;
+#ifdef CONFIG_USE_BABBLESIM
+		case BS_RADIO:
+			bs_radio_triggered();
+			break;
+#endif
 #ifdef CONFIG_HAS_SDL
 		case SDLEVENTTIMER:
 			sdl_handle_events();
@@ -201,6 +218,9 @@ void hwm_init(void)
 {
 	hwm_set_sig_handler();
 	hwtimer_init();
+#if CONFIG_USE_BABBLESIM
+	bs_radio_init();
+#endif /* CONFIG_USE_BABBLESIM */
 	hw_counter_init();
 	hw_irq_ctrl_init();
 


### PR DESCRIPTION
Adds generic bs_radio peripheral, which is intended for simulating
networking stacks and wireless connectivity. It requires BabbleSim-
physical layer simulator (https://github.com/BabbleSim).
The extension works similar to nrf52_bsim, but it doesn't emulate any
specific hardware.

Signed-off-by: Filip Zajdel <filip.zajdel@nordicsemi.no>