### PR TITLE
Bluetooth: Mesh: Config client net_key_del

### DIFF
--- a/doc/reference/bluetooth/mesh/shell.rst
+++ b/doc/reference/bluetooth/mesh/shell.rst
@@ -387,6 +387,14 @@ The Configuration Client uses the general messages parameters set by ``mesh dst`
 	Get a list of known network key indexes.
 
 
+``mesh net-key-del <NetKeyIndex>``
+----------------------------------------
+
+	Delete a network key from the target node.
+
+	* ``NetKeyIndex``: The network key index to delete.
+
+
 ``mesh app-key-add <NetKeyIndex> <AppKeyIndex> [val]``
 ------------------------------------------------------
 

--- a/include/bluetooth/mesh/cfg_cli.h
+++ b/include/bluetooth/mesh/cfg_cli.h
@@ -226,6 +226,18 @@ int bt_mesh_cfg_net_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_id
 int bt_mesh_cfg_net_key_get(uint16_t net_idx, uint16_t addr, uint16_t *keys,
 			    size_t *key_cnt);
 
+/** @brief Delete a network key from the target node.
+ *
+ *  @param net_idx     Network index to encrypt with.
+ *  @param addr        Target node address.
+ *  @param key_net_idx Network key index.
+ *  @param status      Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_net_key_del(uint16_t net_idx, uint16_t addr,
+			    uint16_t key_net_idx, uint8_t *status);
+
 /** @brief Add an application key to the target node.
  *
  *  @param net_idx     Network index to encrypt with.

--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -1044,6 +1044,45 @@ int bt_mesh_cfg_net_key_get(uint16_t net_idx, uint16_t addr, uint16_t *keys,
 	return cli_wait();
 }
 
+int bt_mesh_cfg_net_key_del(uint16_t net_idx, uint16_t addr,
+			    uint16_t key_net_idx, uint8_t *status)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NET_KEY_DEL, 2);
+	struct bt_mesh_msg_ctx ctx = {
+		.net_idx = net_idx,
+		.app_idx = BT_MESH_KEY_DEV_REMOTE,
+		.addr = addr,
+		.send_ttl = BT_MESH_TTL_DEFAULT,
+	};
+	struct net_key_param param = {
+		.status = status,
+		.net_idx = key_net_idx,
+	};
+	int err;
+
+	err = cli_prepare(&param, OP_NET_KEY_STATUS);
+	if (err) {
+		return err;
+	}
+
+	bt_mesh_model_msg_init(&msg, OP_NET_KEY_DEL);
+	net_buf_simple_add_le16(&msg, key_net_idx);
+
+	err = bt_mesh_model_send(cli->model, &ctx, &msg, NULL, NULL);
+	if (err) {
+		BT_ERR("model_send() failed (err %d)", err);
+		cli_reset();
+		return err;
+	}
+
+	if (!status) {
+		cli_reset();
+		return 0;
+	}
+
+	return cli_wait();
+}
+
 int bt_mesh_cfg_app_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
 			    uint16_t key_app_idx, const uint8_t app_key[16],
 			    uint8_t *status)

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -1035,6 +1035,31 @@ static int cmd_net_key_get(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 }
 
+static int cmd_net_key_del(const struct shell *shell, size_t argc, char *argv[])
+{
+	uint16_t key_net_idx;
+	uint8_t status;
+	int err;
+
+	key_net_idx = strtoul(argv[1], NULL, 0);
+
+	err = bt_mesh_cfg_net_key_del(net.net_idx, net.dst, key_net_idx,
+				      &status);
+	if (err) {
+		shell_print(shell, "Unable to send NetKeyDel (err %d)", err);
+		return 0;
+	}
+
+	if (status) {
+		shell_print(shell, "NetKeyDel failed with status 0x%02x",
+			    status);
+	} else {
+		shell_print(shell, "NetKey 0x%03x deleted", key_net_idx);
+	}
+
+	return 0;
+}
+
 static int cmd_app_key_add(const struct shell *shell, size_t argc, char *argv[])
 {
 	uint8_t key_val[16];
@@ -2574,6 +2599,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(mesh_cmds,
 	SHELL_CMD_ARG(net-key-add, NULL, "<NetKeyIndex> [val]", cmd_net_key_add,
 		      2, 1),
 	SHELL_CMD_ARG(net-key-get, NULL, NULL, cmd_net_key_get, 1, 0),
+	SHELL_CMD_ARG(net-key-del, NULL, "<NetKeyIndex>", cmd_net_key_del, 2,
+		      0),
 	SHELL_CMD_ARG(app-key-add, NULL, "<NetKeyIndex> <AppKeyIndex> [val]",
 		      cmd_app_key_add, 3, 1),
 	SHELL_CMD_ARG(app-key-get, NULL, "<NetKeyIndex>", cmd_app_key_get, 2,


### PR DESCRIPTION
Adds a Config Client API for deleting netkeys on the target node, with
matching shell command.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>