### PR TITLE
cmake: dts overlay file with mixed separator style support

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -66,7 +66,11 @@ endif()
 if(SUPPORTS_DTS)
   if(DTC_OVERLAY_FILE)
     # Convert from space-separated files into file list
-    string(REPLACE " " ";" DTC_OVERLAY_FILE_AS_LIST ${DTC_OVERLAY_FILE})
+    string(REPLACE " " ";" DTC_OVERLAY_FILE_RAW_LIST ${DTC_OVERLAY_FILE})
+    foreach(file ${DTC_OVERLAY_FILE_RAW_LIST})
+      file(TO_CMAKE_PATH "${file}" cmake_path_file)
+      list(APPEND DTC_OVERLAY_FILE_AS_LIST ${cmake_path_file})
+    endforeach()
     list(APPEND
       dts_files
       ${DTC_OVERLAY_FILE_AS_LIST}


### PR DESCRIPTION
Fixes: #26112

All file paths provided on the list of overlay files are converted to
CMake style paths.

This ensures that even paths with mixed style `\` and `/` on Windows are
treated correctly. This fixes the issue where the deps file created
would cause ninja to re-invoke CMake in an endless loop on windows.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>