### PR TITLE
Bluetooth: Bugfix - correct UUID defines

### DIFF
--- a/include/bluetooth/uuid.h
+++ b/include/bluetooth/uuid.h
@@ -964,7 +964,7 @@ struct bt_uuid_128 {
  *  @brief OTS Object Size Characteristic
  */
 #define BT_UUID_OTS_SIZE \
-	BT_UUID_DECLARE_16(BT_UUID_OTS_SIZE)
+	BT_UUID_DECLARE_16(BT_UUID_OTS_SIZE_VAL)
 /** @def BT_UUID_OTS_FIRST_CREATED_VAL
  *  @brief OTS Object First-Created Characteristic UUID value
  */
@@ -1126,7 +1126,7 @@ struct bt_uuid_128 {
 #define BT_UUID_FTP_VAL               0x000a
 #define BT_UUID_FTP                   BT_UUID_DECLARE_16(BT_UUID_FTP_VAL)
 #define BT_UUID_HTTP_VAL              0x000c
-#define BT_UUID_HTTP                  BT_UUID_DECLARE_16(BT_UUID_HTTP)
+#define BT_UUID_HTTP                  BT_UUID_DECLARE_16(BT_UUID_HTTP_VAL)
 #define BT_UUID_BNEP_VAL              0x000f
 #define BT_UUID_BNEP                  BT_UUID_DECLARE_16(BT_UUID_BNEP_VAL)
 #define BT_UUID_UPNP_VAL              0x0010


### PR DESCRIPTION
This fixes an error introduced in commit
9b2e9eda89e8c52f51b666488152d5b0a3378f0f

It seems that in a couple of instances, the "_VAL" suffix was
forgotten.  One of these broke the le-audio build.

Signed-off-by: Asbjørn Sæbø <asbjorn.sabo@nordicsemi.no>