### PR TITLE
west: Ignore projects without path

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -224,7 +224,7 @@ def main():
         from west.util import WestNotFound
         try:
             manifest = Manifest.from_file()
-            projects = [p.posixpath for p in manifest.get_projects([])]
+            projects = [p.posixpath for p in manifest.get_projects([]) if p.posixpath is not None]
         except WestNotFound:
             # Only accept WestNotFound, meaning we are not in a west
             # workspace. Such setup is allowed, as west may be installed


### PR DESCRIPTION
Manifest projects enumeration can contains object without path. For
example ManifestProject instance does not have path. This patch allows
to ignore such objects.

Signed-off-by: Pavel Král <pavel.kral@omsquare.com>