### PR TITLE
tests: lib: sprintf: bypass unpassable test with glibc fortify feature

### DIFF
--- a/tests/lib/sprintf/src/main.c
+++ b/tests/lib/sprintf/src/main.c
@@ -489,7 +489,6 @@ void test_snprintf(void)
 
 void test_sprintf_misc(void)
 {
-	int count;
 	char buffer[100];
 
 	/*******************/
@@ -497,6 +496,9 @@ void test_sprintf_misc(void)
 	zassert_false((strcmp(buffer, DEADBEEF_PTR_STR) != 0),
 		      "sprintf(%%p).  Expected '%s', got '%s'", DEADBEEF_PTR_STR, buffer);
 	/*******************/
+#if ((_FORTIFY_SOURCE - 0) < 2)
+	int count;
+
 	sprintf(buffer, "test data %n test data", &count);
 	zassert_false((count != 10), "sprintf(%%n).  Expected count to be %d, not %d",
 		      10, count);
@@ -504,7 +506,7 @@ void test_sprintf_misc(void)
 	zassert_false((strcmp(buffer, "test data  test data") != 0),
 		      "sprintf(%%p).  Expected '%s', got '%s'",
 		      "test data  test data", buffer);
-
+#endif
 	/*******************/
 	sprintf(buffer, "%*d", 10, 1234);
 	zassert_true((strcmp(buffer, "      1234") == 0),


### PR DESCRIPTION
When an application is build with `-D_FORTIFY_SOURCE=2` with glibc the use of %n in format specifiers that live in writable sections is rejected with an abort.  The intent is to prevent code injection attacks.

Bypass the test if it appears the environment will cause this failure to occur.

Note: The check is not supposed to occur if the format string is in unwritable memory, however the obvious ways of storing it there like:

    static const char *const fmt_pct_n = "test data %n test data";

still produce the diagnostic.

Closes #27847