### PR TITLE
tests: fix list usage in @details section

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/src/inherit.c
+++ b/tests/kernel/mem_protect/mem_protect/src/inherit.c
@@ -155,7 +155,8 @@ void parent_handler(void *p1, void *p2, void *p3)
 /**
  * @brief Test child thread inherits parent's thread resource pool
  *
- * @details - Create a resource pool res_pool for the parent thread.
+ * @details
+ * - Create a resource pool res_pool for the parent thread.
  * - Then special system call ret_resource_pool_ptr() returns pointer
  *   to the resource pool of the current thread.
  * - Call it in the parent_handler() and in the child_handler()

--- a/tests/kernel/mem_protect/mem_protect/src/kobject.c
+++ b/tests/kernel/mem_protect/mem_protect/src/kobject.c
@@ -532,7 +532,8 @@ static void new_thread_from_user_child(void *p1, void *p2, void *p3)
 /**
  * @brief Test thread create from a user thread and check permissions
  *
- * @details - Test user thread can create new thread.
+ * @details
+ * - Test user thread can create new thread.
  * - Verify that given thread and thread stack permissions to the user thread,
  *   allow to create new user thread.
  * - Veify that new created user thread have access to its own thread object


### PR DESCRIPTION
Adding the first list item in the same line as @details, creates a list with a single item inside a paragraph, and another list with the remaining items. What is wanted here is to have a single list with all items, so the first item needs to be in a new line.