### PR TITLE
ci: buildkite: exit on errors

### DIFF
--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -2,6 +2,7 @@
 # Copyright (c) 2020 Linaro Limited
 #
 # SPDX-License-Identifier: Apache-2.0
+set -e
 
 echo "--- run $0"
 


### PR DESCRIPTION
Whenever we have an error in the script, exit immediately and avoid
confusing unrelated messages about disk space and such.