### PR TITLE
boards: shields: add support for buydisplay 2.8" TFT touch display 

### DIFF
--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/Kconfig.defconfig
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/Kconfig.defconfig
@@ -1,0 +1,61 @@
+# Copyright (c) 2020 Teslabs Engineering S.L.
+# SPDX-License-Identifier: Apache-2.0
+
+if SHIELD_BUYDISPLAY_2_8_TFT_TOUCH_ARDUINO
+
+if DISPLAY
+
+config SPI
+	default y
+
+config ILI9340
+	default y
+
+if KSCAN
+
+config I2C
+	default y
+
+config KSCAN_FT5336
+	default y
+
+# NOTE: Enable if IRQ line is available (requires to solder jumper)
+config KSCAN_FT5336_INTERRUPT
+	default n
+
+config KSCAN_INIT_PRIORITY
+	default 60
+
+endif # KSCAN
+
+if LVGL
+
+config LVGL_DISPLAY_DEV_NAME
+	default "DISPLAY"
+
+config LVGL_HOR_RES_MAX
+	default 320
+
+config LVGL_VER_RES_MAX
+	default 240
+
+config LVGL_VDB_SIZE
+	default 64
+
+config LVGL_BITS_PER_PIXEL
+	default 24
+
+config KSCAN
+	default y
+
+config LVGL_POINTER_KSCAN
+	default y
+
+config LVGL_POINTER_KSCAN_DEV_NAME
+	default "TOUCH"
+
+endif # LVGL
+
+endif # DISPLAY
+
+endif # SHIELD_BUYDISPLAY_2_8_TFT_TOUCH_ARDUINO

--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/Kconfig.shield
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2020 Teslabs Engineering S.L.
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_BUYDISPLAY_2_8_TFT_TOUCH_ARDUINO
+	def_bool $(shields_list_contains,buydisplay_2_8_tft_touch_arduino)

--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/boards/nrf52840dk_nrf52840.overlay
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2020 Teslabs Engineering S.L.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* NOTE: spi1 MISO pin is used by the display for the cmd/data line */
+&spi1 {
+	status = "disabled";
+};

--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/buydisplay_2_8_tft_touch_arduino.overlay
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/buydisplay_2_8_tft_touch_arduino.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Teslabs Engineering S.L.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&arduino_spi {
+	status = "okay";
+	cs-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>; /* D9 */
+
+	ili9340@0 {
+		compatible = "ilitek,ili9340";
+		label = "DISPLAY";
+		spi-max-frequency = <25000000>;
+		reg = <0>;
+		cmd-data-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>; /* D7 */
+		reset-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
+	};
+};
+
+&arduino_i2c {
+	ft5336@38 {
+		compatible = "focaltech,ft5336";
+		reg = <0x38>;
+		label = "TOUCH";
+		/* Uncomment if IRQ line is available (requires to solder jumper) */
+		/* int-gpios = <&arduino_header 11 GPIO_ACTIVE_LOW>; */ /* D5 */
+	};
+};

--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/doc/index.rst
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/doc/index.rst
@@ -1,0 +1,77 @@
+.. _buydisplay_2_8_tft_touch_arduino:
+
+Buydisplay 2.8" TFT Touch Shield with Arduino adapter
+#####################################################
+
+Overview
+********
+
+The Buydisplay 2.8" TFT Touch Shield has a resolution of 320x240
+pixels and is based on the ILI9341 controller. This shield comes with
+a capacitive FT6206 controller touchscreen. The Arduino adapter is
+required to use this shield.
+
+More information about the shield and Arduino adapter can be found at
+the `Buydisplay 2.8" TFT Touch Shield website`_ and
+`Arduino adapter website`_.
+
+Pin Assignments
+===============
+
++-----------------------+---------------------------------------------+
+| Shield Connector Pin  | Function                                    |
++=======================+=============================================+
+| D5                    | Touch Controller IRQ (see note below)       |
++-----------------------+---------------------------------------------+
+| D7                    | ILI9341 DC       (Data/Command)             |
++-----------------------+---------------------------------------------+
+| D10                   | ILI9341 Reset                               |
++-----------------------+---------------------------------------------+
+| D9                    | ILI9341 SPI CSn                             |
++-----------------------+---------------------------------------------+
+| D11                   | SPI MOSI         (Serial Data Input)        |
++-----------------------+---------------------------------------------+
+| D12                   | SPI MISO         (Serial Data Out)          |
++-----------------------+---------------------------------------------+
+| D13                   | SPI SCK          (Serial Clock Input)       |
++-----------------------+---------------------------------------------+
+| SDA                   | FT6206 SDA                                  |
++-----------------------+---------------------------------------------+
+| SCL                   | FT6206 SCL                                  |
++-----------------------+---------------------------------------------+
+
+.. note::
+   Touch controller IRQ line is not connected by default. You will need
+   to solder the ``5 INT`` jumper to use it. You will also need to
+   adjust driver configuration and its Device Tree entry to make use of
+   it.
+
+Requirements
+************
+
+This shield can only be used with a board which provides a configuration
+for Arduino connectors and defines node aliases for SPI and GPIO interfaces
+(see :ref:`shields` for more details).
+
+Programming
+***********
+
+Set ``-DSHIELD=buydisplay_2_8_tft_touch_arduino`` when you invoke
+``west build``. For example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/gui/lvgl
+   :board: nrf52840dk_nrf52840
+   :shield: buydisplay_2_8_tft_touch_arduino
+   :goals: build
+
+References
+**********
+
+.. target-notes::
+
+.. _Buydisplay 2.8" TFT Touch Shield website:
+   https://www.buydisplay.com/2-8-inch-tft-touch-shield-for-arduino-w-capacitive-touch-screen-module
+
+.. _Arduino adapter website:
+   https://www.buydisplay.com/arduino-shield-for-tft-lcd-with-ili9341-controller-and-arduino-due-mega-uno

--- a/samples/display/lvgl/README.rst
+++ b/samples/display/lvgl/README.rst
@@ -19,6 +19,7 @@ Display shield and a board which provides a configuration
 for Arduino connectors, for example:
 
 - :ref:`adafruit_2_8_tft_touch_v2` and :ref:`nrf52840dk_nrf52840`
+- :ref:`buydisplay_2_8_tft_touch_arduino` and :ref:`nrf52840dk_nrf52840`
 - :ref:`ssd1306_128_shield` and :ref:`frdm_k64f`
 
 or a simulated display environment in a native Posix application:

--- a/samples/display/lvgl/sample.yaml
+++ b/samples/display/lvgl/sample.yaml
@@ -26,3 +26,7 @@ tests:
     build_only: true
     platform_allow: native_posix_64
     tags: samples display gui
+  sample.display.buydisplay_2_8_tft_touch_arduino:
+    platform_allow: nrf52840dk_nrf52840
+    extra_args: SHIELD=buydisplay_2_8_tft_touch_arduino
+    tags: shield


### PR DESCRIPTION
Add support for the Buydisplay 2.8" TFT touch display shield for Arduino.