### PR TITLE
drivers: espi:  Add support for eSPI slaves with long initialization

### DIFF
--- a/drivers/espi/Kconfig
+++ b/drivers/espi/Kconfig
@@ -44,11 +44,24 @@ config ESPI_AUTOMATIC_WARNING_ACKNOWLEDGE
 	bool "Automatic acknowledge for eSPI HOST warnings"
 	default y
 	depends on ESPI_VWIRE_CHANNEL
+	depends on ESPI_SLAVE
 	help
 	  Enable automatic acknowledge from eSPI slave towards eSPI host
 	  whenever it receives suspend or reset warning.
 	  If this is disabled, it means the app wants to be give the opportunity
 	  to prepare for either HOST suspend or reset.
+
+config ESPI_AUTOMATIC_BOOT_DONE_ACKNOWLEDGE
+	bool "Automatic acknowledge slave boot status"
+	default y
+	depends on ESPI_VWIRE_CHANNEL
+	depends on ESPI_SLAVE
+	help
+	  Enable automatic acknowledge of slave basic configuration been
+	  completed by sending a virtual wire message to the eSPI master.
+	  This depends on SPI boot configuration. It could be either very
+	  early in the flow after the VW channel is configured. Or it could be
+	  until flash channel is configured.
 
 config ESPI_OOB_CHANNEL
 	bool "eSPI Out-of-band channel"
@@ -91,11 +104,6 @@ config ESPI_PERIPHERAL_HOST_IO_PVT_PORT_NUM
 	  the private channel. Please ensure the Host code is configured to use
 	  the same port. Also, ensure the port number selected doesn't clash
 	  with the existing ports (like 80, 92, 62 etc).
-
-config ESPI_PERIPHERAL_PORT_92
-	bool "Legacy Port 92 peripheral"
-	help
-	  Enables legacy Port 92 over eSPI peripheral channel.
 
 config ESPI_PERIPHERAL_DEBUG_PORT_80
 	bool "Debug Port 80 peripheral"


### PR DESCRIPTION
Add Kconfig switch to disable automatic eSPI slave boot acknowledge.

This allows to satisfy both eSPI slave cases.
1) Simple application where a lot is driven by the driver (default)
2) Application that perform many lengthy operations before ready to perform any eSPI handshake with eSPI master.

Sometimes required for eSPI SAF boot configuration.
