### PR TITLE
scripts: west_commands: handle EOFError in nrfjprog.py

### DIFF
--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -111,7 +111,10 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
         p = 'Please select one with desired serial number (1-{}): '.format(
                 len(snrs))
         while True:
-            value = input(p)
+            try:
+                value = input(p)
+            except EOFError:
+                sys.exit(0)
             try:
                 value = int(value)
             except ValueError:


### PR DESCRIPTION
We should simply exit if the user hits control-D during the prompt.
