### PR TITLE
ci: retry failed west update

### DIFF
--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -29,7 +29,7 @@ if [ -n "${DAILY_BUILD}" ]; then
    SANITYCHECK_OPTIONS=" --inline-logs -N --build-only --all --retry-failed 3 -v "
    echo "--- DAILY BUILD"
    west init -l .
-   west update 1> west.update.log
+   west update 1> west.update.log || west update 1> west.update-2.log
    west forall -c 'git reset --hard HEAD'
    source zephyr-env.sh
    ./scripts/sanitycheck --subset ${JOB_NUM}/${BUILDKITE_PARALLEL_JOB_COUNT} ${SANITYCHECK_OPTIONS}


### PR DESCRIPTION
Transient network errors may cause west update to fail. Retry it in
case that happens. Updates for projects which are already up to date
won't hit the network.