### PR TITLE
arm: tz: secure_entry_functions.ld: Fix NSC_ALIGN redefinition

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/tz/secure_entry_functions.ld
+++ b/arch/arm/core/aarch32/cortex_m/tz/secure_entry_functions.ld
@@ -19,12 +19,13 @@
 #if CONFIG_ARM_NSC_REGION_BASE_ADDRESS != 0
 	#define NSC_ALIGN . = ABSOLUTE(CONFIG_ARM_NSC_REGION_BASE_ADDRESS)
 #else
-	#define NSC_ALIGN . = ALIGN(4)
+	/* The ARM SAU requires regions to be 32-byte-aligned. */
+	#define NSC_ALIGN . = ALIGN(32)
 #endif /* CONFIG_ARM_NSC_REGION_BASE_ADDRESS */
 #endif /* !NSC_ALIGN */
 
 #ifndef NSC_ALIGN_END
-	#define NSC_ALIGN_END . = ALIGN(4)
+	#define NSC_ALIGN_END . = ALIGN(32)
 #endif
 
 SECTION_PROLOGUE(.gnu.sgstubs,,)

--- a/arch/arm/core/aarch32/cortex_m/tz/secure_entry_functions.ld
+++ b/arch/arm/core/aarch32/cortex_m/tz/secure_entry_functions.ld
@@ -7,9 +7,11 @@
 /* nRF-specific defines. */
 #if defined(CONFIG_CPU_HAS_NRF_IDAU) && CONFIG_ARM_NSC_REGION_BASE_ADDRESS == 0
 	/* This SOC needs the NSC region to be at the end of an SPU region. */
+	#define __NSC_ALIGN (ALIGN(CONFIG_NRF_SPU_FLASH_REGION_SIZE) \
+			- MAX(32, (1 << LOG2CEIL(__sg_size))))
 	#define NSC_ALIGN \
-		. = ALIGN(CONFIG_NRF_SPU_FLASH_REGION_SIZE) \
-			- (1 << LOG2CEIL(__sg_size))
+		. =  (__NSC_ALIGN + ((ABSOLUTE(.) > __NSC_ALIGN) \
+				? CONFIG_NRF_SPU_FLASH_REGION_SIZE : 0))
 	#define NSC_ALIGN_END . = ALIGN(CONFIG_NRF_SPU_FLASH_REGION_SIZE)
 #endif /* CONFIG_CPU_HAS_NRF_IDAU && CONFIG_ARM_NSC_REGION_BASE_ADDRESS != 0 */
 

--- a/arch/arm/core/aarch32/cortex_m/tz/secure_entry_functions.ld
+++ b/arch/arm/core/aarch32/cortex_m/tz/secure_entry_functions.ld
@@ -5,20 +5,21 @@
  */
 
 /* nRF-specific defines. */
-#ifdef CONFIG_CPU_HAS_NRF_IDAU
+#if defined(CONFIG_CPU_HAS_NRF_IDAU) && CONFIG_ARM_NSC_REGION_BASE_ADDRESS == 0
 	/* This SOC needs the NSC region to be at the end of an SPU region. */
 	#define NSC_ALIGN \
 		. = ALIGN(CONFIG_NRF_SPU_FLASH_REGION_SIZE) \
 			- (1 << LOG2CEIL(__sg_size))
 	#define NSC_ALIGN_END . = ALIGN(CONFIG_NRF_SPU_FLASH_REGION_SIZE)
-#endif /* CONFIG_CPU_HAS_NRF_IDAU */
+#endif /* CONFIG_CPU_HAS_NRF_IDAU && CONFIG_ARM_NSC_REGION_BASE_ADDRESS != 0 */
 
-
+#ifndef NSC_ALIGN
 #if CONFIG_ARM_NSC_REGION_BASE_ADDRESS != 0
 	#define NSC_ALIGN . = ABSOLUTE(CONFIG_ARM_NSC_REGION_BASE_ADDRESS)
-#elif !defined(NSC_ALIGN)
+#else
 	#define NSC_ALIGN . = ALIGN(4)
 #endif /* CONFIG_ARM_NSC_REGION_BASE_ADDRESS */
+#endif /* !NSC_ALIGN */
 
 #ifndef NSC_ALIGN_END
 	#define NSC_ALIGN_END . = ALIGN(4)


### PR DESCRIPTION
Allow CONFIG_ARM_NSC_REGION_BASE_ADDRESS to override the nRF-specific
logic for alignment.

Fixes #27544

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>