### PR TITLE
boards: nrf52_bsim: Use simplified nrf_bsim_models

### DIFF
--- a/boards/posix/nrf52_bsim/board_soc.h
+++ b/boards/posix/nrf52_bsim/board_soc.h
@@ -28,9 +28,8 @@
 #include <stddef.h>
 #include "irq.h"
 #include "irq_sources.h"
-#include "NRF_regs.h"
+#include <nrfx.h>
 #include "cmsis.h"
-#include "nrf_soc_if.h"
 
 #define OFFLOAD_SW_IRQ SWI0_EGU0_IRQn
 

--- a/boards/posix/nrf52_bsim/cmsis.h
+++ b/boards/posix/nrf52_bsim/cmsis.h
@@ -22,10 +22,21 @@ extern "C" {
  * - ARM Instruction Synchronization Barrier
  * - ARM No Operation
  */
-static inline void __DMB(void) {}
-static inline void __DSB(void) {}
-static inline void __ISB(void) {}
-static inline void __NOP(void) {}
+#ifndef __DMB
+#define __DMB()
+#endif
+
+#ifndef __DSB
+#define __DSB()
+#endif
+
+#ifndef __ISB
+#define __ISB()
+#endif
+
+#ifndef __NOP
+#define __NOP()
+#endif
 
 #ifdef __cplusplus
 }

--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: 0f4ff90fbf8137086e2f9c1b78a6fc2aa5ef731f
+      revision: fc12f5e2b47cf143254234c05f9ecbdb603a7101
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262
@@ -130,7 +130,7 @@ manifest:
       revision: 957d46bc3ce0d5f628f0d525196bb4db207672ee
     - name: nrf_hw_models
       path: modules/bsim_hw_models/nrf_hw_models
-      revision: f86079a7333968f0ba71fe1266e241295a4e9943
+      revision: 71a8a9ef086d57ff5f3974138b0951f24c2017ad
     - name: hal_xtensa
       revision: e7a57d0c252f9c5f3cab9d5ceadda8753cacee5b
       path: modules/hal/xtensa


### PR DESCRIPTION
The simplified bsim implementation reuses nrfx directly instead
of using manually modified header files.

It requires nrfx_glue.h to include a header which redefines the defines from nrfx and nRF MDK which are not valid when compiling for simulated hardware.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>

The PR uses the original BabbleSim remote to test that it integrates as expected. See https://github.com/BabbleSim/ext_NRF52_hw_models/pull/13.
Another PR has been created for the zephyr downstream of BabbleSim. Before merging this PR, the manifest file must be updated to use this remote. See https://github.com/zephyrproject-rtos/nrf_hw_models/pull/3

Requires https://github.com/zephyrproject-rtos/hal_nordic/pull/53.