### PR TITLE
Bluetooth: controller: Prevent incorrect lazy_current increment

### DIFF
--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -825,6 +825,11 @@ void ticker_worker(void *param)
 		ticker_id_head = ticker->next;
 		must_expire_skip = 0U;
 
+		/* Skip if not scheduled to execute */
+		if (((ticker->req - ticker->ack) & 0xff) != 1U) {
+			continue;
+		}
+
 #if !defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
 		/* Check if node has slot reservation and resolve any collision
 		 * with other ticker nodes
@@ -872,10 +877,6 @@ void ticker_worker(void *param)
 		}
 #endif /* CONFIG_BT_TICKER_EXT */
 #endif /* !CONFIG_BT_TICKER_COMPATIBILITY_MODE */
-		/* Skip if not scheduled to execute */
-		if (((ticker->req - ticker->ack) & 0xff) != 1U) {
-			continue;
-		}
 
 		/* Scheduled timeout is acknowledged to be complete */
 		ticker->ack--;


### PR DESCRIPTION
Prevent redundant collision resolves and potential incorrect and harmful
increment of lazy_current.

During collision scenarios with high CPU load, the ticker_worker may be
called a second time before the ticker_job gets to run. This will cause
ticker operations on the previosly expired node (expected), and in some
cases increment lazy_current, even though the node was not sceduled to
execute via the req/ack mechanism.

By moving the request check before collision resolve, CPU time is saved,
and lazy_current will not incorrectly be incremented if node is in
collision.

The problem may be seen as a connection suddenly not receiving packets,
or MIC error on master, because the event counter goes out of sync.

Signed-off-by: Morten Priess <mtpr@oticon.com>

Fixes issue #27887