### PR TITLE
soc: arm: stm32f0: Add additional UARTs.

### DIFF
--- a/dts/arm/st/f0/stm32f030Xc.dtsi
+++ b/dts/arm/st/f0/stm32f030Xc.dtsi
@@ -29,5 +29,47 @@
 			status = "disabled";
 			label = "SPI_2";
 		};
+
+		/*
+		 * USARTs 3-6 share the same IRQ on stm32f030Xc devices. This
+		 * configuration is not currently supported, so at most one of
+		 * these may be enabled at a time. Enabling more than one will
+		 * result in a build failure.
+		 */
+		usart3: serial@40004800 {
+			compatible = "st,stm32-usart", "st,stm32-uart";
+			reg = <0x40004800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00040000>;
+			interrupts = <29 0>;
+			status = "disabled";
+			label = "UART_3";
+		};
+
+		usart4: serial@40004c00 {
+			compatible = "st,stm32-usart", "st,stm32-uart";
+			reg = <0x40004c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00080000>;
+			interrupts = <29 0>;
+			status = "disabled";
+			label = "UART_4";
+		};
+
+		usart5: serial@40005000 {
+			compatible = "st,stm32-usart", "st,stm32-uart";
+			reg = <0x40005000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00100000>;
+			interrupts = <29 0>;
+			status = "disabled";
+			label = "UART_5";
+		};
+
+		usart6: serial@40011400 {
+			compatible = "st,stm32-usart", "st,stm32-uart";
+			reg = <0x40011400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000020>;
+			interrupts = <29 0>;
+			status = "disabled";
+			label = "UART_6";
+		};
 	};
 };


### PR DESCRIPTION
Add support for UARTs 3-6 to the stm32f030xc SoC. These additional UARTs
share a single interrupt line, so only one may be enabled at a time.

Note that these UARTs suffer from the same problem as #26874 