### PR TITLE
[backport v2.3] lib: updatehub: Fix possible deref an uninitialized ptr

### DIFF
--- a/lib/updatehub/updatehub.c
+++ b/lib/updatehub/updatehub.c
@@ -644,8 +644,8 @@ static void probe_cb(char *metadata, size_t metadata_size)
 enum updatehub_response updatehub_probe(void)
 {
 	struct probe request;
-	struct resp_probe_some_boards metadata_some_boards;
-	struct resp_probe_any_boards metadata_any_boards;
+	struct resp_probe_some_boards metadata_some_boards = { 0 };
+	struct resp_probe_any_boards metadata_any_boards = { 0 };
 
 	char *metadata = k_malloc(MAX_DOWNLOAD_DATA);
 	char *metadata_copy = k_malloc(MAX_DOWNLOAD_DATA);
@@ -731,6 +731,12 @@ enum updatehub_response updatehub_probe(void)
 			goto cleanup;
 		}
 
+		if (metadata_any_boards.objects_len != 2) {
+			LOG_ERR("Could not parse json");
+			ctx.code_status = UPDATEHUB_METADATA_ERROR;
+			goto cleanup;
+		}
+
 		sha256size = strlen(
 			metadata_any_boards.objects[1].objects.sha256sum) + 1;
 
@@ -745,6 +751,12 @@ enum updatehub_response updatehub_probe(void)
 		       SHA256_HEX_DIGEST_SIZE);
 		update_info.image_size = metadata_any_boards.objects[1].objects.size;
 	} else {
+		if (metadata_some_boards.objects_len != 2) {
+			LOG_ERR("Could not parse json");
+			ctx.code_status = UPDATEHUB_METADATA_ERROR;
+			goto cleanup;
+		}
+
 		if (!is_compatible_hardware(&metadata_some_boards)) {
 			LOG_ERR("Incompatible hardware");
 			ctx.code_status =

--- a/samples/net/updatehub/prj.conf
+++ b/samples/net/updatehub/prj.conf
@@ -14,6 +14,7 @@ CONFIG_NET_DHCPV4=y
 #Optional if you would like test on the your server
 CONFIG_SHELL=y
 CONFIG_UPDATEHUB_SHELL=y
+CONFIG_SHELL_STACK_SIZE=6144
 
 # Debug helpers
 CONFIG_LOG=y


### PR DESCRIPTION
There are several references to objects[1] at updatehub_probe function. The structures are decoded from json, and have a maximum length of 2. However, if the returned json only has a single element in this array, this objects[1] value will be uninitialized. Because the structure contains pointers, these will be uninitialized, causing the code to reference uninitialized memory as pointers.

Add zeroing memory before passing it to the JSON API and do check if objects_len field is two.

This backport apply:
#27865

and fixes:
#27718

Signed-off-by: Gerson Fernando Budke <gerson.budke@ossystems.com.br>

CC @otavio