### PR TITLE
Bluetooth: controller: Add support for scannable ext adv instance

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -164,6 +164,12 @@ config BT_CTLR_ADV_SYNC_SET
 	help
 	  Maximum supported periodic advertising sets.
 
+config BT_CTRL_ADV_ADI_IN_SCAN_RSP
+	bool "Include ADI in AUX_SCAN_RSP PDU"
+	depends on BT_BROADCASTER && BT_CTLR_ADV_EXT
+	help
+	  Enable ADI field in AUX_SCAN_RSP PDU
+
 config BT_CTLR_SCAN_AUX_SET
 	int "LE Extended Scanning Auxiliary Sets"
 	depends on BT_OBSERVER && BT_CTLR_ADV_EXT

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -9,6 +9,7 @@
 #include <zephyr.h>
 #include <soc.h>
 #include <sys/byteorder.h>
+#include <bluetooth/hci.h>
 
 #include "hal/cpu.h"
 #include "hal/ccm.h"
@@ -26,9 +27,12 @@
 #include "lll_chan.h"
 #include "lll_adv.h"
 #include "lll_adv_aux.h"
+#include "lll_filter.h"
 
 #include "lll_internal.h"
+#include "lll_tim_internal.h"
 #include "lll_adv_internal.h"
+#include "lll_prof_internal.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_lll_adv_aux
@@ -38,6 +42,12 @@
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *prepare_param);
 static void abort_cb(struct lll_prepare_param *prepare_param, void *param);
+static void isr_tx(void *param);
+static void isr_rx(void *param);
+static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
+			     uint8_t devmatch_ok, uint8_t devmatch_id,
+			     uint8_t irkmatch_ok, uint8_t irkmatch_id,
+			     uint8_t rssi_ready);
 
 int lll_adv_aux_init(void)
 {
@@ -164,9 +174,35 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	/* Set the Radio Tx Packet */
 	radio_pkt_tx_set(sec_pdu);
 
-	/* TODO: Based on adv_mode switch to Rx, if needed */
-	radio_isr_set(lll_isr_done, lll);
-	radio_switch_complete_and_disable();
+	/* Switch to Rx if connectable or scannable */
+	if (pri_com_hdr->adv_mode & (BT_HCI_LE_ADV_PROP_CONN |
+				     BT_HCI_LE_ADV_PROP_SCAN)) {
+
+		struct pdu_adv *scan_pdu;
+
+		scan_pdu = lll_adv_scan_rsp_latest_get(lll_adv, &upd);
+
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+		if (upd) {
+			/* Copy the address from the adv packet we will send
+			 * into the scan response.
+			 */
+			memcpy(&scan_pdu->adv_ext_ind.ext_hdr_adi_adv_data[1],
+			       &sec_pdu->adv_ext_ind.ext_hdr_adi_adv_data[1],
+			       BDADDR_SIZE);
+		}
+#else
+		ARG_UNUSED(scan_pdu);
+		ARG_UNUSED(upd);
+#endif /* !CONFIG_BT_CTLR_PRIVACY */
+
+		radio_isr_set(isr_tx, lll);
+		radio_tmr_tifs_set(EVENT_IFS_US);
+		radio_switch_complete_and_rx(phy_s);
+	} else {
+		radio_isr_set(lll_isr_done, lll);
+		radio_switch_complete_and_disable();
+	}
 
 #if defined(BT_CTLR_ADV_EXT_PBACK)
 	start_us = 1000;
@@ -239,4 +275,216 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 	LL_ASSERT(err >= 0);
 
 	lll_done(param);
+}
+
+static void isr_tx(void *param)
+{
+	struct lll_adv_aux *lll_aux = param;
+	struct lll_adv *lll = lll_aux->adv;
+	uint32_t hcto;
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_latency_capture();
+	}
+
+	/* Clear radio tx status and events */
+	lll_isr_tx_status_reset();
+
+	/* setup tIFS switching */
+	radio_tmr_tifs_set(EVENT_IFS_US);
+	radio_switch_complete_and_tx(lll->phy_s, 0, lll->phy_s, 0);
+
+	radio_pkt_rx_set(radio_pkt_scratch_get());
+	/* assert if radio packet ptr is not set and radio started rx */
+	LL_ASSERT(!radio_is_ready());
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_cputime_capture();
+	}
+
+	radio_isr_set(isr_rx, param);
+
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+	if (ull_filter_lll_rl_enabled()) {
+		uint8_t count, *irks = ull_filter_lll_irks_get(&count);
+
+		radio_ar_configure(count, irks);
+	}
+#endif /* CONFIG_BT_CTLR_PRIVACY */
+
+	/* +/- 2us active clock jitter, +1 us hcto compensation */
+	hcto = radio_tmr_tifs_base_get() + EVENT_IFS_US + 4 + 1;
+	hcto += radio_rx_chain_delay_get(lll->phy_s, 1);
+	hcto += addr_us_get(0);
+	hcto -= radio_tx_chain_delay_get(lll->phy_s, 0);
+	radio_tmr_hcto_configure(hcto);
+
+	/* capture end of CONNECT_IND PDU, used for calculating first
+	 * slave event.
+	 */
+	radio_tmr_end_capture();
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_SCAN_REQ_RSSI) ||
+	    IS_ENABLED(CONFIG_BT_CTLR_CONN_RSSI)) {
+		radio_rssi_measure();
+	}
+
+#if defined(CONFIG_BT_CTLR_GPIO_LNA_PIN)
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		/* PA/LNA enable is overwriting packet end used in ISR
+		 * profiling, hence back it up for later use.
+		 */
+		lll_prof_radio_end_backup();
+	}
+
+	radio_gpio_lna_setup();
+	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + EVENT_IFS_US - 4 -
+				 radio_tx_chain_delay_get(0, 0) -
+				 CONFIG_BT_CTLR_GPIO_LNA_OFFSET);
+#endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		/* NOTE: as scratch packet is used to receive, it is safe to
+		 * generate profile event using rx nodes.
+		 */
+		lll_prof_send();
+	}
+}
+
+static void isr_rx(void *param)
+{
+	uint8_t trx_done;
+	uint8_t crc_ok;
+	uint8_t devmatch_ok;
+	uint8_t devmatch_id;
+	uint8_t irkmatch_ok;
+	uint8_t irkmatch_id;
+	uint8_t rssi_ready;
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_latency_capture();
+	}
+
+	/* Read radio status and events */
+	trx_done = radio_is_done();
+	if (trx_done) {
+		crc_ok = radio_crc_is_valid();
+		devmatch_ok = radio_filter_has_match();
+		devmatch_id = radio_filter_match_get();
+		irkmatch_ok = radio_ar_has_match();
+		irkmatch_id = radio_ar_match_get();
+		rssi_ready = radio_rssi_is_ready();
+	} else {
+		crc_ok = devmatch_ok = irkmatch_ok = rssi_ready = 0U;
+		devmatch_id = irkmatch_id = 0xFF;
+	}
+
+	/* Clear radio status and events */
+	lll_isr_status_reset();
+
+	/* No Rx */
+	if (!trx_done) {
+		goto isr_rx_do_close;
+	}
+
+	if (crc_ok) {
+		int err;
+
+		err = isr_rx_pdu(param, devmatch_ok, devmatch_id,
+				 irkmatch_ok, irkmatch_id, rssi_ready);
+		if (!err) {
+			if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+				lll_prof_send();
+			}
+
+			return;
+		}
+	}
+
+isr_rx_do_close:
+	radio_isr_set(lll_isr_done, param);
+	radio_disable();
+}
+
+static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
+			     uint8_t devmatch_ok, uint8_t devmatch_id,
+			     uint8_t irkmatch_ok, uint8_t irkmatch_id,
+			     uint8_t rssi_ready)
+{
+	struct pdu_adv *pdu_rx, *pdu_adv, *pdu_aux;
+	struct lll_adv *lll = lll_aux->adv;
+	uint8_t tx_addr;
+	uint8_t *addr;
+	uint8_t upd;
+
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+	/* An IRK match implies address resolution enabled */
+	uint8_t rl_idx = irkmatch_ok ? ull_filter_lll_rl_irk_idx(irkmatch_id) :
+				    FILTER_IDX_NONE;
+#else
+	uint8_t rl_idx = FILTER_IDX_NONE;
+#endif /* CONFIG_BT_CTLR_PRIVACY */
+
+	pdu_rx = (void *)radio_pkt_scratch_get();
+	pdu_adv = lll_adv_data_curr_get(lll);
+	pdu_aux = lll_adv_aux_data_latest_get(lll_aux, &upd);
+
+	if (pdu_adv->type == PDU_ADV_TYPE_EXT_IND) {
+		/* AdvA is placed at 2nd byte of ext hdr data */
+		addr = &pdu_aux->adv_ext_ind.ext_hdr_adi_adv_data[1];
+		tx_addr = pdu_aux->tx_addr;
+	} else {
+		addr = pdu_adv->adv_ind.addr;
+		tx_addr = pdu_adv->tx_addr;
+	}
+
+	if ((pdu_rx->type == PDU_ADV_TYPE_AUX_SCAN_REQ) &&
+	    (pdu_rx->len == sizeof(struct pdu_adv_scan_req)) &&
+	    lll_adv_scan_req_check(lll, pdu_rx, tx_addr, addr, devmatch_ok,
+				   &rl_idx)) {
+		radio_isr_set(lll_isr_done, lll);
+		radio_switch_complete_and_disable();
+		radio_pkt_tx_set(lll_adv_scan_rsp_curr_get(lll));
+
+		/* assert if radio packet ptr is not set and radio started tx */
+		LL_ASSERT(!radio_is_ready());
+
+		if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+			lll_prof_cputime_capture();
+		}
+
+#if defined(CONFIG_BT_CTLR_SCAN_REQ_NOTIFY)
+		if (lll->scan_req_notify) {
+			uint32_t err;
+
+			/* Generate the scan request event */
+			err = lll_adv_scan_req_report(lll, pdu_rx, rl_idx,
+						      rssi_ready);
+			if (err) {
+				/* Scan Response will not be transmitted */
+				return err;
+			}
+		}
+#endif /* CONFIG_BT_CTLR_SCAN_REQ_NOTIFY */
+
+#if defined(CONFIG_BT_CTLR_GPIO_PA_PIN)
+		if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+			/* PA/LNA enable is overwriting packet end used in ISR
+			 * profiling, hence back it up for later use.
+			 */
+			lll_prof_radio_end_backup();
+		}
+
+		radio_gpio_pa_setup();
+		radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() +
+					 EVENT_IFS_US -
+					 radio_rx_chain_delay_get(0, 0) -
+					 CONFIG_BT_CTLR_GPIO_PA_OFFSET);
+#endif /* CONFIG_BT_CTLR_GPIO_PA_PIN */
+		return 0;
+	}
+
+	/* TODO: add handling for AUX_CONNECT_REQ */
+
+	return -EINVAL;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -482,7 +482,7 @@ uint8_t ll_adv_params_set(uint16_t interval, uint8_t adv_type,
 		if (pri_hdr->aux_ptr) {
 			uint8_t err;
 
-			err = ull_adv_aux_hdr_set_clear(adv, 0, 0, NULL);
+			err = ull_adv_aux_hdr_set_clear(adv, 0, 0, NULL, NULL);
 			if (err) {
 				/* TODO: cleanup? */
 				return err;
@@ -1139,7 +1139,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 					/* Add sync_info into auxiliary PDU */
 					ret = ull_adv_aux_hdr_set_clear(adv,
 						ULL_ADV_PDU_HDR_FIELD_SYNC_INFO,
-						0, NULL);
+						0, NULL, NULL);
 					if (ret) {
 						return ret;
 					}

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -233,6 +233,14 @@ uint8_t ll_adv_params_set(uint16_t interval, uint8_t adv_type,
 				return BT_HCI_ERR_INVALID_PARAM;
 			}
 
+#if (CONFIG_BT_CTLR_ADV_AUX_SET == 0)
+			/* Connectable or scannable requires aux */
+			if (evt_prop & (BT_HCI_LE_ADV_PROP_CONN |
+					BT_HCI_LE_ADV_PROP_SCAN)) {
+				return BT_HCI_ERR_MEM_CAPACITY_EXCEEDED;
+			}
+#endif
+
 			adv_type = 0x05; /* PDU_ADV_TYPE_EXT_IND in */
 					 /* pdu_adv_type array. */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -342,6 +342,12 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	pri_hdr_prev = *pri_hdr;
 	pri_dptr_prev = (uint8_t *)pri_hdr + sizeof(*pri_hdr);
 
+	/* Advertising data are not supported by scannable instances */
+	if ((sec_hdr_add_fields & ULL_ADV_PDU_HDR_FIELD_AD_DATA) &&
+	    (pri_com_hdr_prev->adv_mode & BT_HCI_LE_ADV_PROP_SCAN)) {
+		return BT_HCI_ERR_INVALID_PARAM;
+	}
+
 	/* Get reference to new primary PDU data buffer */
 	pri_pdu = lll_adv_data_alloc(lll, &pri_idx);
 	pri_pdu->type = pri_pdu_prev->type;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -412,7 +412,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	/* AdvA flag */
 	/* NOTE: as we will use auxiliary packet, we remove AdvA in
 	 * primary channel. i.e. Do nothing to not add AdvA in the primary
-	 * PDU.
+	 * PDU. Connectable or scannable advertising always has AdvA in aux.
 	 */
 	if (pri_hdr_prev.adv_addr) {
 		pri_dptr_prev += BDADDR_SIZE;
@@ -422,6 +422,9 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 
 		/* NOTE: AdvA is filled at enable */
 		sec_pdu->tx_addr = pri_pdu->tx_addr;
+	} else if (pri_com_hdr->adv_mode) {
+		sec_hdr->adv_addr = 1;
+		sec_pdu->tx_addr = adv->own_addr_type & 0x1;
 	}
 	pri_pdu->tx_addr = 0U;
 	pri_pdu->rx_addr = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -160,18 +160,18 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, uint8_t len,
 			    uint8_t const *const data)
 {
-	struct ll_adv_set *adv;
+	struct pdu_adv_com_ext_adv *sr_com_hdr;
 	struct pdu_adv *pri_pdu_prev;
+	struct pdu_adv_hdr *sr_hdr;
+	struct pdu_adv *sr_prev;
+	struct pdu_adv *aux_pdu;
+	struct ll_adv_set *adv;
+	struct pdu_adv *sr_pdu;
 	struct lll_adv *lll;
-
-	/* op param definitions:
-	 * 0x00 - Intermediate fragment of fragmented extended advertising data
-	 * 0x01 - First fragment of fragmented extended advertising data
-	 * 0x02 - Last fragemnt of fragemented extended advertising data
-	 * 0x03 - Complete extended advertising data
-	 * 0x04 - Unchanged data (just update the advertising data)
-	 * All other values, Reserved for future use
-	 */
+	uint8_t ext_hdr_len;
+	uint8_t *sr_dptr;
+	uint8_t idx;
+	uint8_t err;
 
 	/* TODO: handle other op values */
 	if ((op != BT_HCI_LE_EXT_ADV_OP_COMPLETE_DATA) &&
@@ -195,14 +195,65 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 		return ull_scan_rsp_set(adv, len, data);
 	}
 
-	/* FIXME: Workaround to not fail when no data is supplied */
-	if (!len) {
-		return 0;
+	LL_ASSERT(lll->aux);
+	aux_pdu = lll_adv_aux_data_peek(lll->aux);
+	sr_prev = lll_adv_scan_rsp_peek(lll);
+
+	/* Update scan response PDU fields. */
+	sr_pdu = lll_adv_scan_rsp_alloc(lll, &idx);
+	sr_pdu->type = PDU_ADV_TYPE_AUX_SCAN_RSP;
+	sr_pdu->rfu = 0;
+	sr_pdu->chan_sel = 0;
+	sr_pdu->tx_addr = aux_pdu->tx_addr;
+	sr_pdu->rx_addr = 0;
+	sr_pdu->len = 0;
+
+	sr_com_hdr = &sr_pdu->adv_ext_ind;
+	sr_hdr = (void *)&sr_com_hdr->ext_hdr_adi_adv_data[0];
+	sr_dptr = (void *)sr_hdr;
+
+	/* Flags */
+	/* TODO: include ADI (optional) */
+	*sr_dptr = 0;
+	sr_hdr->adv_addr = 1;
+	sr_dptr++;
+
+	/* AdvA */
+	memcpy(sr_dptr, &sr_prev->adv_ext_ind.ext_hdr_adi_adv_data[1],
+	       BDADDR_SIZE);
+	sr_dptr += BDADDR_SIZE;
+
+	/* ADI */
+	/* TODO: add support ((optional) */
+
+	/* Check if data will fit in remaining space */
+	/* TODO: need aux_chain_ind support */
+	ext_hdr_len = sr_dptr - &sr_com_hdr->ext_hdr_adi_adv_data[0];
+	if (sizeof(sr_com_hdr->ext_hdr_adi_adv_data) -
+	    sr_com_hdr->ext_hdr_len < len) {
+		return BT_HCI_ERR_PACKET_TOO_LONG;
 	}
 
-	/* TODO: Populate extended scan response data */
+	/* Copy data */
+	memcpy(sr_dptr, data, len);
+	sr_dptr += len;
 
-	return BT_HCI_ERR_CMD_DISALLOWED;
+	/* Finish Common ExtAdv Payload header */
+	sr_com_hdr->adv_mode = 0;
+	sr_com_hdr->ext_hdr_len = ext_hdr_len;
+
+	/* Finish PDU */
+	sr_pdu->len = sr_dptr - &sr_pdu->payload[0];
+
+	/* Trigger DID update */
+	err = ull_adv_aux_hdr_set_clear(adv, 0, 0, NULL);
+	if (err) {
+		return err;
+	}
+
+	lll_adv_scan_rsp_enqueue(&adv->lll, idx);
+
+	return 0;
 }
 
 uint16_t ll_adv_aux_max_data_length_get(void)

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -192,12 +192,26 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 	 */
 	pri_pdu_prev = lll_adv_data_peek(lll);
 	if (pri_pdu_prev->type != PDU_ADV_TYPE_EXT_IND) {
+		if ((op != BT_HCI_LE_EXT_ADV_OP_COMPLETE_DATA) || (len > 31)) {
+			return BT_HCI_ERR_INVALID_PARAM;
+		}
 		return ull_scan_rsp_set(adv, len, data);
+	}
+
+	/* Can only set complete data and cannot discard data on enabled set */
+	if (adv->is_enabled && ((op != BT_HCI_LE_EXT_ADV_OP_COMPLETE_DATA) ||
+				(len == 0))) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
 	LL_ASSERT(lll->aux);
 	aux_pdu = lll_adv_aux_data_peek(lll->aux);
 	sr_prev = lll_adv_scan_rsp_peek(lll);
+
+	/* Can only discard data on non-scannable instances */
+	if (!(aux_pdu->adv_ext_ind.adv_mode & BT_HCI_LE_ADV_PROP_SCAN) && len) {
+		return BT_HCI_ERR_INVALID_PARAM;
+	}
 
 	/* Update scan response PDU fields. */
 	sr_pdu = lll_adv_scan_rsp_alloc(lll, &idx);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -118,7 +118,7 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 	*val_ptr++ = len;
 	*((uint32_t *)val_ptr) = (uint32_t)data;
 	err = ull_adv_aux_hdr_set_clear(adv, ULL_ADV_PDU_HDR_FIELD_AD_DATA,
-					0, value);
+					0, value, NULL);
 	if (err) {
 		return err;
 	}
@@ -260,7 +260,7 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 	sr_pdu->len = sr_dptr - &sr_pdu->payload[0];
 
 	/* Trigger DID update */
-	err = ull_adv_aux_hdr_set_clear(adv, 0, 0, NULL);
+	err = ull_adv_aux_hdr_set_clear(adv, 0, 0, NULL, NULL);
 	if (err) {
 		return err;
 	}
@@ -366,7 +366,7 @@ int ull_adv_aux_reset(void)
 uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 				  uint16_t sec_hdr_add_fields,
 				  uint16_t sec_hdr_rem_fields,
-				  void *value)
+				  void *value, struct pdu_adv_adi *adi)
 {
 	struct pdu_adv_com_ext_adv *pri_com_hdr, *pri_com_hdr_prev;
 	struct pdu_adv_com_ext_adv *sec_com_hdr, *sec_com_hdr_prev;
@@ -688,6 +688,10 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 
 		pri_adi->did = sys_cpu_to_le16(did);
 		sec_adi->did = sys_cpu_to_le16(did);
+
+		if (adi) {
+			*adi = *pri_adi;
+		}
 	}
 
 	/* No CTEInfo field in primary channel PDU */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -86,7 +86,7 @@ void ull_adv_aux_offset_get(struct ll_adv_set *adv);
 uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 				  uint16_t sec_hdr_add_fields,
 				  uint16_t sec_hdr_rem_fields,
-				  void *value);
+				  void *value, struct pdu_adv_adi *adi);
 
 /* helper function to calculate common ext adv payload header length */
 static inline uint8_t

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -198,7 +198,7 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 		/* Remove sync_info from auxiliary PDU */
 		err = ull_adv_aux_hdr_set_clear(adv, 0,
 						ULL_ADV_PDU_HDR_FIELD_SYNC_INFO,
-						NULL);
+						NULL, NULL);
 		if (err) {
 			return err;
 		}
@@ -239,7 +239,7 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 		/* Add sync_info into auxiliary PDU */
 		err = ull_adv_aux_hdr_set_clear(adv,
 						ULL_ADV_PDU_HDR_FIELD_SYNC_INFO,
-						0, NULL);
+						0, NULL, NULL);
 		if (err) {
 			return err;
 		}


### PR DESCRIPTION
Note: this uses code that will be added in https://github.com/zephyrproject-rtos/zephyr/pull/26895 thus it also includes commits from that PR - those should be ignored in this PR.

This allows to configure scannable advertising instance, set advertising data (no data fragmentation yet) and enable it. Scanner will receive proper scan response data on extended advertising instance.

AUX_SCAN_RSP does not have TxPower field included since Core spec mandates to include this field in at least one PDU in extended advertising event - we already include it in AUX_ADV_IND so it's enough.
Optionally, AUX_SCAN_RSP can include ADI field - this is configurable via Kconfig since this is an optional field