### PR TITLE
tests: Bluetooth: bsim_test_advx: Fix adv_type parameter

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
@@ -301,7 +301,7 @@ static void test_advx_main(void)
 
 	printk("Starting non-conn non-scan without aux 1M advertising...");
 	evt_prop = EVT_PROP_TXP;
-	adv_type = 0x05; /* Adv. Ext. */
+	adv_type = 0x07; /* Adv. Ext. */
 	phy_p = ADV_PHY_1M;
 	phy_s = ADV_PHY_2M;
 	err = ll_adv_params_set(handle, evt_prop, ADV_INTERVAL, adv_type,


### PR DESCRIPTION
The value of adv_type shall be 0x07 for extended advertising, it will
be converted to 0x05 inside ll_adv_params_set after some checks.

This did not cause any issues with tests since input parameters in
already implemented test cases do not test any code that was skipped
by invalid parameter, however obvious one side-effect is that phy_p
would be always set to 1M regardless of input parameter so any test
case using Coded on primary would fail.

Signed-off-by: Andrzej Kaczmarek <andrzej.kaczmarek@codecoup.pl>