### PR TITLE
testsuite: fix unittest cross-language flags

### DIFF
--- a/subsys/testsuite/unittest.cmake
+++ b/subsys/testsuite/unittest.cmake
@@ -45,8 +45,10 @@ else()
 
 if(M64_MODE)
 set (CMAKE_C_FLAGS "-m64")
+set (CMAKE_CXX_FLAGS "-m64")
 else()
 set (CMAKE_C_FLAGS "-m32") #deprecated on macOS
+set (CMAKE_CXX_FLAGS "-m32") #deprecated on macOS
 endif(M64_MODE)
 
 endif()

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -1,9 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Work around apparent inconsistency in C and C++ object machine configuration
-string(PREPEND CMAKE_C_FLAGS   "-m32 ")
-string(PREPEND CMAKE_CXX_FLAGS "-m32 ")
-
 project(util)
 set(SOURCES main.c maincxx.cxx ../../../lib/os/dec.c)
 find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})


### PR DESCRIPTION
Unit tests may include C++ code, so ensure the compiler flags are
consistent to avoid link errors.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>