### PR TITLE
shields: Modify overlay file order

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -356,17 +356,6 @@ foreach(root ${BOARD_ROOT})
       list(GET shields_refs_list ${_idx} s_path)
       get_filename_component(s_dir ${s_path} DIRECTORY)
 
-      # if shield config flag is on, add shield overlay to the shield overlays
-      # list and dts_fixup file to the shield fixup file
-      list(APPEND
-        shield_dts_files
-        ${shield_dir}/${s_path}
-        )
-      list(APPEND
-        shield_dts_fixups
-        ${shield_dir}/${s_dir}/dts_fixup.h
-        )
-
       # search for shield/boards/board.overlay file
       if(EXISTS ${shield_dir}/${s_dir}/boards/${BOARD}.overlay)
         # add shield/board overlay to the shield overlays list
@@ -384,6 +373,17 @@ foreach(root ${BOARD_ROOT})
           ${shield_dir}/${s_dir}/boards/${s}/${BOARD}.overlay
           )
       endif()
+
+      # if shield config flag is on, add shield overlay to the shield overlays
+      # list and dts_fixup file to the shield fixup file
+      list(APPEND
+        shield_dts_files
+        ${shield_dir}/${s_path}
+        )
+      list(APPEND
+        shield_dts_fixups
+        ${shield_dir}/${s_dir}/dts_fixup.h
+        )
 
       # search for shield/shield.conf file
       if(EXISTS ${shield_dir}/${s_dir}/${s}.conf)


### PR DESCRIPTION
Shield overlay file has to be taken into account after board overlay file.

ex: When a new node need to be created for a specific board (in
 boards/shields/shield_name/boards/board_name/*.overlay) and used by the
shield (in boards/shields/*.overlay), the order of the overlay files is
important

Signed-off-by: Ismael Fillonneau <ismael.fillonneau@stimio.fr>