### PR TITLE
Bluetooth: GATT: Remove wrong documentation for GATT write callback

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -125,9 +125,6 @@ struct bt_gatt_attr {
 
 	/** @brief Attribute write callback
 	 *
-	 *  The callback can also be used locally to read the contents of the
-	 *  attribute in which case no connection will be set.
-	 *
 	 *  @param conn   The connection that is requesting to write
 	 *  @param attr   The attribute that's being written
 	 *  @param buf    Buffer with the data to write


### PR DESCRIPTION
Remove paragraph in documentation of GATT write callback which is
clearly wrong and was meant for the read callback.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>