### PR TITLE
Allow immediate logging with software-based BT LL

### DIFF
--- a/subsys/bluetooth/common/dummy.c
+++ b/subsys/bluetooth/common/dummy.c
@@ -29,12 +29,22 @@ BUILD_ASSERT(CONFIG_BT_HCI_TX_PRIO < CONFIG_BT_RX_PRIO);
 BUILD_ASSERT(CONFIG_BT_CTLR_RX_PRIO < CONFIG_BT_HCI_TX_PRIO);
 #endif /* CONFIG_BT_CTLR */
 
-/* Immediate logging is not supported with the software-based Link Layer
- * since it introduces ISR latency due to outputting log messages with
- * interrupts disabled.
+#if (defined(CONFIG_LOG_BACKEND_RTT) &&                     \
+     (defined(CONFIG_SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL) || \
+      defined(CONFIG_LOG_BACKEND_RTT_MODE_BLOCK))) ||       \
+    defined(CONFIG_LOG_BACKEND_NET) ||                      \
+    defined(CONFIG_LOG_IMMEDIATE_CLEAN_OUTPUT)
+#define INCOMPATIBLE_IMMEDIATE_LOG_BACKEND 1
+#endif
+
+/* Immediate logging on most backend is not supported
+ * with the software-based Link Layer since it introduces ISR latency
+ * due to outputting log messages with interrupts disabled.
  */
 #if !defined(CONFIG_TEST) && !defined(CONFIG_ARCH_POSIX) && \
-	defined(CONFIG_BT_LL_SW_SPLIT)
-BUILD_ASSERT(!IS_ENABLED(CONFIG_LOG_IMMEDIATE), "Immediate logging not "
+    defined(CONFIG_BT_LL_SW_SPLIT) &&                       \
+    defined(INCOMPATIBLE_IMMEDIATE_LOG_BACKEND)
+BUILD_ASSERT(!IS_ENABLED(CONFIG_LOG_IMMEDIATE), "Immediate logging "
+	     "on selected backend(s) not "
 	     "supported with the software Link Layer");
 #endif


### PR DESCRIPTION
Some immediate logging configuration are compatible with software-base Link Layer since they do not deactivate interrupts. Currently only one configuration is supported:
* RTT back-end in drop mode and no clean output

Some other back-end might me also compatible