### PR TITLE
usb: Configurable transfer buffers

### DIFF
--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -56,6 +56,14 @@ config USB_COMPOSITE_DEVICE
 	help
 	  Enable composite USB device driver.
 
+config USB_MAX_NUM_TRANSFERS
+    int "Set number of USB transfer data buffers"
+    range 1 32
+    default 4
+    help
+        Allocates buffers used for parallel transfers. Increase this number
+        according to USB devices count.
+
 config USB_REQUEST_BUFFER_SIZE
 	int "Set buffer size for Standard, Class and Vendor request handlers"
 	range 256 65536 if USB_DEVICE_NETWORK_RNDIS

--- a/subsys/usb/usb_transfer.c
+++ b/subsys/usb/usb_transfer.c
@@ -13,8 +13,6 @@
 
 LOG_MODULE_REGISTER(usb_transfer, CONFIG_USB_DEVICE_LOG_LEVEL);
 
-#define MAX_NUM_TRANSFERS           4 /** Max number of parallel transfers */
-
 struct usb_transfer_sync_priv {
 	int tsize;
 	struct k_sem sem;
@@ -43,7 +41,8 @@ struct usb_transfer_data {
 	unsigned int flags;
 };
 
-static struct usb_transfer_data ut_data[MAX_NUM_TRANSFERS];
+/** Max number of parallel transfers */
+static struct usb_transfer_data ut_data[CONFIG_USB_MAX_NUM_TRANSFERS];
 
 /* Transfer management */
 static struct usb_transfer_data *usb_ep_get_transfer(uint8_t ep)


### PR DESCRIPTION
This patch removes the hard-coded number of transfer buffers and allows
you to increase the number of transfer buffers when multiple USB
devices are used.

Signed-off-by: Pavel Král <pavel.kral@omsquare.com>