### PR TITLE
cmake: warn user if CPPFLAGS is set as environment setting

### DIFF
--- a/cmake/generic_toolchain.cmake
+++ b/cmake/generic_toolchain.cmake
@@ -11,7 +11,7 @@ if(NOT TOOLCHAIN_ROOT)
 endif()
 
 # Don't inherit compiler flags from the environment
-foreach(var CFLAGS CXXFLAGS)
+foreach(var CFLAGS CXXFLAGS CPPFLAGS)
   if(DEFINED ENV{${var}})
     message(WARNING "The environment variable '${var}' was set to $ENV{${var}},
 but Zephyr ignores flags from the environment. Use 'cmake -DEXTRA_${var}=$ENV{${var}}' instead.")


### PR DESCRIPTION
Zephyr doesn't use CFLAGS, CXXFLAGS, and CPPFLAGS if they are defined
in environment.

In case user defines CFLAGS or CXXFLAGS in environment, then a warning
message is printed, however CPPFLAGS does not raise a warning.

CPPFLAGS is updated to follow the principle of CFLAGS and CXXFLAGS.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

This is followup to this PR: https://github.com/zephyrproject-rtos/zephyr/pull/9764
