### PR TITLE
sanitycheck: do not report parent test

### DIFF
--- a/scripts/sanity_chk/harness.py
+++ b/scripts/sanity_chk/harness.py
@@ -27,6 +27,7 @@ class Harness:
         self.record = None
         self.recording = []
         self.fieldnames = []
+        self.ztest = False
 
     def configure(self, instance):
         config = instance.testcase.harness_config
@@ -129,6 +130,7 @@ class Test(Harness):
         if match and match.group(2):
             name = "{}.{}".format(self.id, match.group(3))
             self.tests[name] = match.group(1)
+            self.ztest = True
 
         if self.RUN_PASSED in line:
             if self.fault:
@@ -143,10 +145,11 @@ class Test(Harness):
             if self.FAULT in line:
                 self.fault = True
 
-        if self.state == "passed":
-            self.tests[self.id] = "PASS"
-        else:
-            self.tests[self.id] = "FAIL"
+        if not self.ztest and self.state:
+            if self.state == "passed":
+                self.tests[self.id] = "PASS"
+            else:
+                self.tests[self.id] = "FAIL"
 
         if self.GCOV_START in line:
             self.capture_coverage = True


### PR DESCRIPTION
Fix the case where we have no ztest test_* testcases and reports were
missed. This now makes sure we do not report the parent testcase when
there are individual test_* results.

Fixes #27765