### PR TITLE
subsys/fs: Make FAT FS formatting on mount optional

### DIFF
--- a/include/fs/fs.h
+++ b/include/fs/fs.h
@@ -71,6 +71,11 @@ enum {
 	FS_TYPE_EXTERNAL_BASE,
 };
 
+/** Flag prevents formatting device if requested file system not found */
+#define FS_MOUNT_FLAG_NO_FORMAT BIT(0)
+/** Flag makes mounted file system read-only */
+#define FS_MOUNT_FLAG_READ_ONLY BIT(1)
+
 /**
  * @brief File system mount info structure
  *
@@ -81,6 +86,7 @@ enum {
  * @param storage_dev Pointer to backend storage device
  * @param mountp_len Length of Mount point string
  * @param fs Pointer to File system interface of the mount point
+ * @param flags Mount flags
  */
 struct fs_mount_t {
 	sys_dnode_t node;
@@ -91,6 +97,7 @@ struct fs_mount_t {
 	/* fields filled by file system core */
 	size_t mountp_len;
 	const struct fs_file_system_t *fs;
+	uint8_t flags;
 };
 
 /**
@@ -173,6 +180,9 @@ struct fs_statvfs {
  *
  * @retval 0 on success;
  * @retval -EINVAL when a bad file name is given;
+ * @retval -EROFS when opening read-only file for write, or attempting to
+ *	   create a file on a system that has been mounted with the
+ *	   FS_MOUNT_FLAG_READ_ONLY flag;
  * @retval -ENOENT when the file path is not possible (bad mount point);
  * @retval <0 an other negative errno code, depending on a file system back-end.
  */
@@ -198,6 +208,8 @@ int fs_close(struct fs_file_t *zfp);
  * @param path Path to the file or directory to delete
  *
  * @retval 0 on success;
+ * @retval -EROFS if file is read-only, or when file system has been mounted
+ *	   with the FS_MOUNT_FLAG_READ_ONLY flag;
  * @retval -ENOTSUP when not implemented by underlying file system driver;
  * @retval <0 an other negative errno code on error.
  */
@@ -407,7 +419,9 @@ int fs_closedir(struct fs_dir_t *zdp);
  * @retval 0 on success;
  * @retval -ENOENT when file system type has not been registered;
  * @retval -ENOTSUP when not supported by underlying file system driver;
- * @retval <0 a other negative errno code on error.
+ * @retval -EROFS if system requires formatting but @c FS_MOUNT_FLAG_READ_ONLY
+ *	   has been set;
+ * @retval <0 an other negative errno code on error.
  */
 int fs_mount(struct fs_mount_t *mp);
 

--- a/include/fs/fs.h
+++ b/include/fs/fs.h
@@ -198,7 +198,8 @@ int fs_close(struct fs_file_t *zfp);
  * @param path Path to the file or directory to delete
  *
  * @retval 0 on success;
- * @retval <0 a negative errno code on error.
+ * @retval -ENOTSUP when not implemented by underlying file system driver;
+ * @retval <0 an other negative errno code on error.
  */
 int fs_unlink(const char *path);
 
@@ -220,7 +221,8 @@ int fs_unlink(const char *path);
  * @param to The destination path
  *
  * @retval 0 on success;
- * @retval <0 a negative errno code on error.
+ * @retval -ENOTSUP when not implemented by underlying file system driver;
+ * @retval <0 an other negative errno code on error.
  */
 int fs_rename(const char *from, const char *to);
 
@@ -255,7 +257,8 @@ ssize_t fs_read(struct fs_file_t *zfp, void *ptr, size_t size);
  * @param size Number of bytes to be written
  *
  * @retval >=0 a number of bytes written, on success;
- * @retval <0 a negative errno code on error.
+ * @retval -ENOTSUP when not implemented by underlying file system driver;
+ * @retval <0 an other negative errno code on error.
  */
 ssize_t fs_write(struct fs_file_t *zfp, const void *ptr, size_t size);
 
@@ -309,7 +312,8 @@ off_t fs_tell(struct fs_file_t *zfp);
  * @param length New size of the file in bytes
  *
  * @retval 0 on success;
- * @retval <0 a negative errno code on error.
+ * @retval -ENOTSUP when not implemented by underlying file system driver;
+ * @retval <0 an other negative errno code on error.
  */
 int fs_truncate(struct fs_file_t *zfp, off_t length);
 
@@ -337,7 +341,8 @@ int fs_sync(struct fs_file_t *zfp);
  * @param path Path to the directory to create
  *
  * @retval 0 on success;
- * @retval <0 a negative errno code on error
+ * @retval -ENOTSUP when not implemented by underlying file system driver;
+ * @retval <0 an other negative errno code on error
  */
 int fs_mkdir(const char *path);
 
@@ -464,7 +469,8 @@ int fs_stat(const char *path, struct fs_dirent *entry);
  * statistics
  *
  * @retval 0 on success;
- * @retval <0 negative errno code on error.
+ * @retval -ENOTSUP when not implemented by underlying file system driver;
+ * @retval <0 an other negative errno code on error.
  */
 int fs_statvfs(const char *path, struct fs_statvfs *stat);
 

--- a/subsys/fs/Kconfig.fatfs
+++ b/subsys/fs/Kconfig.fatfs
@@ -14,6 +14,18 @@ if FAT_FILESYSTEM_ELM
 menu "ELM FAT file system settings"
 	visible if FAT_FILESYSTEM_ELM
 
+config FS_FATFS_READ_ONLY
+	bool "Read-only support for all volumes"
+	help
+	  The option excludes write code from ELM FAT file system driver;
+	  when selected, it no longer will be possible to write data on
+	  the FAT FS.
+	  If write support is not needed, enabling this flag will slightly
+	  reduce application size.
+	  This option translates to _FS_READONLY within ELM FAT file system
+	  driver; it enables exclusion, from compilation, of write supporting
+	  code.
+
 config FS_FATFS_MKFS
 	bool
 	help

--- a/subsys/fs/Kconfig.fatfs
+++ b/subsys/fs/Kconfig.fatfs
@@ -14,6 +14,23 @@ if FAT_FILESYSTEM_ELM
 menu "ELM FAT file system settings"
 	visible if FAT_FILESYSTEM_ELM
 
+config FS_FATFS_MKFS
+	bool
+	help
+	  This option translates to _USE_MKFS within ELM FAT file system
+	  driver; it enables additional code that is required for formatting
+	  volumes to ELM FAT.
+
+config FS_FATFS_MOUNT_MKFS
+	bool "Allow formatting volume when mounting fails"
+	default y
+	select FS_FATFS_MKFS
+	help
+	  This option adds code that allows fs_mount to attempt to format
+	  a volume if no file system is found.
+	  If formatting is not needed, disabling this flag will slightly
+	  reduce application size.
+
 config FS_FATFS_EXFAT
 	bool "Enable exFAT support"
 	select FS_FATFS_LFN

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -122,17 +122,23 @@ static int fatfs_close(struct fs_file_t *zfp)
 
 static int fatfs_unlink(struct fs_mount_t *mountp, const char *path)
 {
-	FRESULT res;
+	int res = -ENOTSUP;
 
+#if !defined(CONFIG_FS_FATFS_READ_ONLY)
 	res = f_unlink(&path[1]);
 
-	return translate_error(res);
+	res = translate_error(res);
+#endif
+
+	return res;
 }
 
 static int fatfs_rename(struct fs_mount_t *mountp, const char *from,
 			const char *to)
 {
-	FRESULT res;
+	int res = -ENOTSUP;
+
+#if !defined(CONFIG_FS_FATFS_READ_ONLY)
 	FILINFO fno;
 
 	/* Check if 'to' path exists; remove it if it does */
@@ -144,7 +150,10 @@ static int fatfs_rename(struct fs_mount_t *mountp, const char *from,
 	}
 
 	res = f_rename(&from[1], &to[1]);
-	return translate_error(res);
+	res = translate_error(res);
+#endif
+
+	return res;
 }
 
 static ssize_t fatfs_read(struct fs_file_t *zfp, void *ptr, size_t size)
@@ -162,9 +171,12 @@ static ssize_t fatfs_read(struct fs_file_t *zfp, void *ptr, size_t size)
 
 static ssize_t fatfs_write(struct fs_file_t *zfp, const void *ptr, size_t size)
 {
-	FRESULT res = FR_OK;
+	int res = -ENOTSUP;
+
+#if !defined(CONFIG_FS_FATFS_READ_ONLY)
 	unsigned int bw;
 	off_t pos = f_size((FIL *)zfp->filep);
+	res = FR_OK;
 
 	/* FA_APPEND flag means that file has been opened for append.
 	 * The FAT FS write does not support the POSIX append semantics,
@@ -180,10 +192,13 @@ static ssize_t fatfs_write(struct fs_file_t *zfp, const void *ptr, size_t size)
 	}
 
 	if (res != FR_OK) {
-		return translate_error(res);
+		res = translate_error(res);
+	} else {
+		res = bw;
 	}
+#endif
 
-	return bw;
+	return res;
 }
 
 static int fatfs_seek(struct fs_file_t *zfp, off_t offset, int whence)
@@ -221,7 +236,9 @@ static off_t fatfs_tell(struct fs_file_t *zfp)
 
 static int fatfs_truncate(struct fs_file_t *zfp, off_t length)
 {
-	FRESULT res = FR_OK;
+	int res = -ENOTSUP;
+
+#if !defined(CONFIG_FS_FATFS_READ_ONLY)
 	off_t cur_length = f_size((FIL *)zfp->filep);
 
 	/* f_lseek expands file if new position is larger than file size */
@@ -262,25 +279,33 @@ static int fatfs_truncate(struct fs_file_t *zfp, off_t length)
 		}
 	}
 
-	return translate_error(res);
+	res = translate_error(res);
+#endif
+
+	return res;
 }
 
 static int fatfs_sync(struct fs_file_t *zfp)
 {
-	FRESULT res = FR_OK;
+	int res = -ENOTSUP;
 
+#if !defined(CONFIG_FS_FATFS_READ_ONLY)
 	res = f_sync(zfp->filep);
-
-	return translate_error(res);
+	res = translate_error(res);
+#endif
+	return res;
 }
 
 static int fatfs_mkdir(struct fs_mount_t *mountp, const char *path)
 {
-	FRESULT res;
+	int res = -ENOTSUP;
 
+#if !defined(CONFIG_FS_FATFS_READ_ONLY)
 	res = f_mkdir(&path[1]);
+	res = translate_error(res);
+#endif
 
-	return translate_error(res);
+	return res;
 }
 
 static int fatfs_opendir(struct fs_dir_t *zdp, const char *path)
@@ -355,8 +380,9 @@ static int fatfs_stat(struct fs_mount_t *mountp,
 static int fatfs_statvfs(struct fs_mount_t *mountp,
 			 const char *path, struct fs_statvfs *stat)
 {
+	int res = -ENOTSUP;
+#if !defined(CONFIG_FS_FATFS_READ_ONLY)
 	FATFS *fs;
-	FRESULT res;
 
 	res = f_getfree(&mountp->mnt_point[1], &stat->f_bfree, &fs);
 	if (res != FR_OK) {
@@ -371,7 +397,9 @@ static int fatfs_statvfs(struct fs_mount_t *mountp,
 	stat->f_frsize = fs->csize * stat->f_bsize;
 	stat->f_blocks = (fs->n_fatent - 2);
 
-	return translate_error(res);
+	res = translate_error(res);
+#endif
+	return res;
 }
 
 static int fatfs_mount(struct fs_mount_t *mountp)

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -410,7 +410,8 @@ static int fatfs_mount(struct fs_mount_t *mountp)
 
 #if defined(CONFIG_FS_FATFS_MOUNT_MKFS)
 	/* If no file system found then create one */
-	if (res == FR_NO_FILESYSTEM) {
+	if (res == FR_NO_FILESYSTEM &&
+	    !(mountp->flags & FS_MOUNT_FLAG_NO_FORMAT)) {
 		uint8_t work[_MAX_SS];
 
 		res = f_mkfs(&mountp->mnt_point[1],

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -380,6 +380,7 @@ static int fatfs_mount(struct fs_mount_t *mountp)
 
 	res = f_mount((FATFS *)mountp->fs_data, &mountp->mnt_point[1], 1);
 
+#if defined(CONFIG_FS_FATFS_MOUNT_MKFS)
 	/* If no file system found then create one */
 	if (res == FR_NO_FILESYSTEM) {
 		uint8_t work[_MAX_SS];
@@ -391,6 +392,7 @@ static int fatfs_mount(struct fs_mount_t *mountp)
 					&mountp->mnt_point[1], 1);
 		}
 	}
+#endif /* CONFIG_FS_FATFS_MOUNT_MKFS */
 
 	__ASSERT((res == FR_OK), "FS init failed (%d)", translate_error(res));
 

--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -150,6 +150,10 @@ int fs_open(struct fs_file_t *zfp, const char *file_name, fs_mode_t flags)
 	}
 
 	zfp->mp = mp;
+	if (((mp->flags & FS_MOUNT_FLAG_READ_ONLY) != 0) &&
+	    (flags & FS_O_CREATE || flags & FS_O_WRITE)) {
+		return -EROFS;
+	}
 
 	CHECKIF(zfp->mp->fs->open == NULL) {
 		return -ENOTSUP;
@@ -473,6 +477,10 @@ int fs_mkdir(const char *abs_path)
 		return rc;
 	}
 
+	if (mp->flags & FS_MOUNT_FLAG_READ_ONLY) {
+		return -EROFS;
+	}
+
 	CHECKIF(mp->fs->mkdir == NULL) {
 		return -ENOTSUP;
 	}
@@ -500,6 +508,10 @@ int fs_unlink(const char *abs_path)
 	if (rc < 0) {
 		LOG_ERR("%s:mount point not found!!", __func__);
 		return rc;
+	}
+
+	if (mp->flags & FS_MOUNT_FLAG_READ_ONLY) {
+		return -EROFS;
 	}
 
 	CHECKIF(mp->fs->unlink == NULL) {
@@ -530,6 +542,10 @@ int fs_rename(const char *from, const char *to)
 	if (rc < 0) {
 		LOG_ERR("%s:mount point not found!!", __func__);
 		return rc;
+	}
+
+	if (mp->flags & FS_MOUNT_FLAG_READ_ONLY) {
+		return -EROFS;
 	}
 
 	/* Make sure both files are mounted on the same path */

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -677,7 +677,7 @@ static int littlefs_mount(struct fs_mount_t *mountp)
 
 	/* Mount it, formatting if needed. */
 	ret = lfs_mount(&fs->lfs, &fs->cfg);
-	if (ret < 0) {
+	if (ret < 0 && !(mountp->flags & FS_MOUNT_FLAG_NO_FORMAT)) {
 		LOG_WRN("can't mount (LFS %d); formatting", ret);
 		ret = lfs_format(&fs->lfs, &fs->cfg);
 		if (ret < 0) {

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -677,14 +677,22 @@ static int littlefs_mount(struct fs_mount_t *mountp)
 
 	/* Mount it, formatting if needed. */
 	ret = lfs_mount(&fs->lfs, &fs->cfg);
-	if (ret < 0 && !(mountp->flags & FS_MOUNT_FLAG_NO_FORMAT)) {
+	if (ret < 0 &&
+	    (mountp->flags & FS_MOUNT_FLAG_NO_FORMAT) == 0) {
 		LOG_WRN("can't mount (LFS %d); formatting", ret);
-		ret = lfs_format(&fs->lfs, &fs->cfg);
-		if (ret < 0) {
-			LOG_ERR("format failed (LFS %d)", ret);
-			ret = lfs_to_errno(ret);
+		if ((mountp->flags & FS_MOUNT_FLAG_READ_ONLY) == 0) {
+			ret = lfs_format(&fs->lfs, &fs->cfg);
+			if (ret < 0) {
+				LOG_ERR("format failed (LFS %d)", ret);
+				ret = lfs_to_errno(ret);
+				goto out;
+			}
+		} else {
+			LOG_ERR("can not format read-only system");
+			ret = -EROFS;
 			goto out;
 		}
+
 		ret = lfs_mount(&fs->lfs, &fs->cfg);
 		if (ret < 0) {
 			LOG_ERR("remount after format failed (LFS %d)", ret);

--- a/tests/subsys/fs/fat_fs_api/src/main.c
+++ b/tests/subsys/fs/fat_fs_api/src/main.c
@@ -17,6 +17,8 @@ void test_main(void)
 			 ztest_unit_test(test_fat_dir),
 			 ztest_unit_test(test_fat_fs),
 			 ztest_unit_test(test_fat_rename),
-			 ztest_unit_test(test_fs_open_flags));
+			 ztest_unit_test(test_fs_open_flags),
+			 ztest_unit_test(test_fat_unmount),
+			 ztest_unit_test(test_fat_mount_rd_only));
 	ztest_run_test_suite(fat_fs_basic_test);
 }

--- a/tests/subsys/fs/fat_fs_api/src/test_fat.h
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016 Intel Corporation.
+ * Copyright (c) 2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,7 +25,9 @@ extern const char test_str[];
 int check_file_dir_exists(const char *path);
 
 void test_fat_mount(void);
+void test_fat_unmount(void);
 void test_fat_file(void);
 void test_fat_dir(void);
 void test_fat_fs(void);
 void test_fat_rename(void);
+void test_fat_mount_rd_only(void);

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_mount.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_mount.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Intel Corporation.
+ * Copyright (c) 2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -18,6 +19,38 @@ static struct fs_mount_t fatfs_mnt = {
 	.fs_data = &fat_fs,
 };
 
+static int test_mount_no_format(void)
+{
+	int ret = 0;
+
+	fatfs_mnt.flags = FS_MOUNT_FLAG_NO_FORMAT;
+	ret = fs_mount(&fatfs_mnt);
+
+	if (ret >= 0) {
+		TC_PRINT("Expected failure\n");
+		return TC_FAIL;
+	}
+	fatfs_mnt.flags = 0;
+
+	return TC_PASS;
+}
+
+static int test_mount_rd_only_no_sys(void)
+{
+	int ret = 0;
+
+	fatfs_mnt.flags = FS_MOUNT_FLAG_READ_ONLY;
+	ret = fs_mount(&fatfs_mnt);
+
+	if (ret >= 0) {
+		TC_PRINT("Expected failure\n");
+		return TC_FAIL;
+	}
+	fatfs_mnt.flags = 0;
+
+	return TC_PASS;
+}
+
 static int test_mount(void)
 {
 	int res;
@@ -31,7 +64,21 @@ static int test_mount(void)
 	return TC_PASS;
 }
 
+static int test_unmount(void)
+{
+	return (fs_unmount(&fatfs_mnt) >= 0 ? TC_PASS : TC_FAIL);
+}
+
+void test_fat_unmount(void)
+{
+	zassert_true(test_unmount() == TC_PASS, NULL);
+}
+
 void test_fat_mount(void)
 {
+	zassert_false(test_unmount() == TC_PASS, NULL);
+	zassert_true(test_mount_no_format() == TC_PASS, NULL);
+	zassert_true(test_mount_rd_only_no_sys() == TC_PASS, NULL);
 	zassert_true(test_mount() == TC_PASS, NULL);
+	zassert_false(test_mount() == TC_PASS, NULL);
 }

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_rd_only_mount.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_rd_only_mount.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#include "test_fat.h"
+#include <ff.h>
+
+/* FatFs work area */
+static FATFS fat_fs;
+
+/* mounting info */
+static struct fs_mount_t fatfs_mnt = {
+	.type = FS_FATFS,
+	.mnt_point = FATFS_MNTP,
+	.fs_data = &fat_fs,
+};
+
+static void test_prepare(void)
+{
+	struct fs_file_t fs;
+
+	zassert_equal(fs_mount(&fatfs_mnt), 0, NULL);
+	zassert_equal(fs_open(&fs, "/NAND:/testfile.txt", FS_O_CREATE),
+		      0, NULL);
+	zassert_equal(fs_close(&fs), 0, NULL);
+	zassert_equal(fs_unmount(&fatfs_mnt), 0, NULL);
+}
+
+static void test_unmount(void)
+{
+	zassert_true(fs_unmount(&fatfs_mnt) >= 0, NULL);
+}
+
+static void test_ops_on_rd(void)
+{
+	struct fs_file_t fs;
+	int ret;
+	/* Check fs operation on volume mounted with FS_MOUNT_FLAG_READ_ONLY */
+	fatfs_mnt.flags = FS_MOUNT_FLAG_READ_ONLY;
+	TC_PRINT("Mount as read-only\n");
+	ret = fs_mount(&fatfs_mnt);
+	zassert_equal(ret, 0, "Expected success", ret);
+
+	/* Attempt creating new file */
+	ret = fs_open(&fs, "/NAND:/nosome", FS_O_CREATE);
+	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	ret = fs_mkdir("/NAND:/another");
+	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	ret = fs_rename("/NAND:/testfile.txt", "/NAND:/bestfile.txt");
+	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	ret = fs_unlink("/NAND:/testfile.txt");
+	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	ret = fs_open(&fs, "/NAND:/testfile.txt", FS_O_RDWR);
+	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	ret = fs_open(&fs, "/NAND:/testfile.txt", FS_O_READ);
+	zassert_equal(ret, 0, "Expected success", ret);
+	fs_close(&fs);
+}
+
+void test_fat_mount_rd_only(void)
+{
+	test_prepare();
+	test_ops_on_rd();
+	test_unmount();
+}

--- a/tests/subsys/fs/fs_api/src/main.c
+++ b/tests/subsys/fs/fs_api/src/main.c
@@ -86,7 +86,8 @@ void test_main(void)
 			 ztest_unit_test(test_file_rename),
 			 ztest_unit_test(test_file_stat),
 			 ztest_unit_test(test_file_unlink),
-			 ztest_unit_test_setup_teardown(test_unmount,
+			 ztest_unit_test(test_unmount),
+			 ztest_unit_test_setup_teardown(test_mount_flags,
 							dummy_setup,
 							fs_teardown)
 			 );

--- a/tests/subsys/fs/fs_api/src/test_fs.h
+++ b/tests/subsys/fs/fs_api/src/test_fs.h
@@ -49,4 +49,5 @@ void test_file_rename(void);
 void test_file_stat(void);
 void test_file_unlink(void);
 void test_unmount(void);
+void test_mount_flags(void);
 #endif

--- a/tests/subsys/fs/fs_api/src/test_fs_mount_flags.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_mount_flags.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include "test_fs.h"
+
+static struct test_fs_data test_data;
+
+static struct fs_mount_t mp = {
+		.type = TEST_FS_1,
+		.mnt_point = TEST_FS_MNTP,
+		.fs_data = &test_data,
+};
+
+void test_mount_flags(void)
+{
+	int ret = 0;
+	struct fs_file_t fs = { 0 };
+
+	/* Format volume and add some files/dirs to check read-only flag */
+	mp.flags = 0;
+	ret = fs_mount(&mp);
+	TC_PRINT("Mount to prepare tests\n");
+	zassert_equal(ret, 0, "Expected success", ret);
+	TC_PRINT("Create some file\n");
+	ret = fs_open(&fs, TEST_FS_MNTP"/some", FS_O_CREATE);
+	zassert_equal(ret, 0, "Expected success", ret);
+	fs_close(&fs);
+	TC_PRINT("Create other directory\n");
+	zassert_equal(ret, 0, "Expected success", ret);
+	ret = fs_mkdir(TEST_FS_MNTP"/other");
+	fs_unmount(&mp);
+
+	/* Check fs operation on volume mounted with FS_MOUNT_FLAG_READ_ONLY */
+	mp.flags = FS_MOUNT_FLAG_READ_ONLY;
+	TC_PRINT("Mount as read-only\n");
+	ret = fs_mount(&mp);
+	zassert_equal(ret, 0, "Expected success", ret);
+
+	/* Attempt creating new file */
+	ret = fs_open(&fs, TEST_FS_MNTP"/nosome", FS_O_CREATE);
+	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	ret = fs_mkdir(TEST_FS_MNTP"/another");
+	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	ret = fs_rename(TEST_FS_MNTP"/some", TEST_FS_MNTP"/nosome");
+	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	ret = fs_unlink(TEST_FS_MNTP"/some");
+	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	ret = fs_open(&fs, TEST_FS_MNTP"/other", FS_O_CREATE);
+	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	ret = fs_open(&fs, TEST_FS_MNTP"/some", FS_O_RDWR);
+	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	ret = fs_open(&fs, TEST_FS_MNTP"/some", FS_O_READ);
+	zassert_equal(ret, 0, "Expected success", ret);
+	fs_close(&fs);
+	fs_unmount(&mp);
+}

--- a/tests/subsys/fs/littlefs/src/main.c
+++ b/tests/subsys/fs/littlefs/src/main.c
@@ -23,7 +23,8 @@ void test_main(void)
 			 ztest_unit_test(test_lfs_basic),
 			 ztest_unit_test(test_lfs_dirops),
 			 ztest_unit_test(test_lfs_perf),
-			 ztest_unit_test(test_fs_open_flags_lfs)
+			 ztest_unit_test(test_fs_open_flags_lfs),
+			 ztest_unit_test(test_fs_mount_flags)
 			 );
 	ztest_run_test_suite(littlefs_test);
 }

--- a/tests/subsys/fs/littlefs/src/testfs_mount_flags.c
+++ b/tests/subsys/fs/littlefs/src/testfs_mount_flags.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include <fs/littlefs.h>
+#include "testfs_tests.h"
+#include "testfs_lfs.h"
+
+static void cleanup(struct fs_mount_t *mp)
+{
+	TC_PRINT("Clean %s\n", mp->mnt_point);
+
+	zassert_equal(testfs_lfs_wipe_partition(mp), TC_PASS,
+		      "Failed to clean partition");
+}
+
+void test_fs_mount_flags(void)
+{
+	/* Using smallest partition for this tests as they do not write
+	 * a lot of data, basically they just check flags.
+	 */
+	struct fs_mount_t *mp = &testfs_small_mnt;
+	int ret = 0;
+	struct fs_file_t fs;
+
+	cleanup(mp);
+
+	/* Test FS_MOUNT_FLAG_NO_FORMAT flag */
+	mp->flags |= FS_MOUNT_FLAG_NO_FORMAT;
+	ret = fs_mount(mp);
+	TC_PRINT("Mount unformatted with FS_MOUNT_FLAG_NO_FORMAT set\n");
+	zassert_false(ret == 0, "Expected failure", ret);
+
+	/* Test FS_MOUNT_FLAG_READ_ONLY on non-formatted volume*/
+	mp->flags = FS_MOUNT_FLAG_READ_ONLY;
+	ret = fs_mount(mp);
+	TC_PRINT("Mount unformatted with FS_MOUNT_FLAG_READ_ONLY set\n");
+	zassert_false(ret == 0, "Expected failure", ret);
+
+	/* Format volume and add some files/dirs to check read-only flag */
+	mp->flags = 0;
+	ret = fs_mount(mp);
+	TC_PRINT("Mount again to format volume\n");
+	zassert_equal(ret, 0, "Expected success", ret);
+	TC_PRINT("Create some file\n");
+	ret = fs_open(&fs, "/sml/some", FS_O_CREATE);
+	zassert_equal(ret, 0, "Expected success", ret);
+	fs_close(&fs);
+	TC_PRINT("Create other directory\n");
+	zassert_equal(ret, 0, "Expected success", ret);
+	ret = fs_mkdir("/sml/other");
+	fs_unmount(mp);
+
+	/* Check fs operation on volume mounted with FS_MOUNT_FLAG_READ_ONLY */
+	mp->flags = FS_MOUNT_FLAG_READ_ONLY;
+	TC_PRINT("Mount as read-only\n");
+	ret = fs_mount(mp);
+	zassert_equal(ret, 0, "Expected success", ret);
+
+	/* Attempt creating new file */
+	ret = fs_open(&fs, "/sml/nosome", FS_O_CREATE);
+	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	ret = fs_mkdir("/sml/another");
+	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	ret = fs_rename("/sml/some", "/sml/nosome");
+	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	ret = fs_unlink("/sml/some");
+	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	ret = fs_open(&fs, "/sml/other", FS_O_CREATE);
+	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	ret = fs_open(&fs, "/sml/some", FS_O_RDWR);
+	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	ret = fs_open(&fs, "/sml/some", FS_O_READ);
+	zassert_equal(ret, 0, "Expected success", ret);
+	fs_close(&fs);
+	fs_unmount(mp);
+}

--- a/tests/subsys/fs/littlefs/src/testfs_tests.h
+++ b/tests/subsys/fs/littlefs/src/testfs_tests.h
@@ -27,4 +27,7 @@ void test_lfs_perf(void);
 /* Test fs_open flags */
 void test_fs_open_flags_lfs(void);
 
+/* Test fs_mount flags */
+void test_fs_mount_flags(void);
+
 #endif /* _ZEPHYR_TESTS_SUBSYS_FS_LITTLEFS_TESTFS_TESTS_H_ */

--- a/west.yml
+++ b/west.yml
@@ -47,7 +47,7 @@ manifest:
       revision: 6835bfc741bf15e98fb7971293913f770df6081f
       path: modules/hal/esp-idf
     - name: fatfs
-      revision: 13697783bf653dfdf17c57129ce8e181634e5970
+      revision: 1d1fcc725aa1cb3c32f366e0c53d7490d0fe1109
       path: modules/fs/fatfs
     - name: hal_cypress
       revision: a12d92816a53a521d79cefcf5c38b9dc8a4fed6e


### PR DESCRIPTION
The fs_mount, for FAT file system, would attempt to format storage device
when mounting fails with "No System" error.  This may not always be
desired and this commit allows to choose whether formatting will be
performed in such case.

~~The FS_FATFS_MOUNT_FORMATS_WHEN_NO_FS Kconfig option, that controls this
behaviour, has been defaulted to "yes" to maintain compatibility with
previous versions.~~
The `FS_FATFS_MOUNT_MKFS` Kconfig option has been added to exclude code that formats volume when expected FAT FS.
The `FS_FATFS_READ_ONLY` Kconfig option has been added to exclude functions that perform write operations from compilation.

New field  `flags` in `fs_mount_t` structure has been added that allows to provide mount flags. Two new flags have been defined:
-  `FS_MOUNT_FLAG_NO_FORMAT` that prevents `fs_mount` from formatting the volume when no system is found
- `FS_MOUNT_FLAG_READ_ONLY` that mounts file system as read-only

TODO: 
- [x]  Make FATFS formatting optional per mount point;  
- [x]  Make it possible to turn off formatting, at compile time, when it is not needed by device to save some ROM space;
- [x]  Fix error codes returned by fs_mount (partially done here #28643)
- [x]  Fix documentation (partially done here https://github.com/zephyrproject-rtos/zephyr/pull/28643)
- [x]  Tests for new FS_MOUNT_FLAG_* flags.

SUPPORTS: https://github.com/zephyrproject-rtos/zephyr/pull/28320#issuecomment-719992771

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>