### PR TITLE
[RFC] Initial support for cache handling when doing SPI/DMA on STM32F7

### DIFF
--- a/drivers/spi/Kconfig.stm32
+++ b/drivers/spi/Kconfig.stm32
@@ -24,6 +24,19 @@ config SPI_STM32_DMA
 	  Enable the SPI DMA mode for SPI instances
 	  that enable dma channels in their device tree node.
 
+config SPI_STM32_UNALIGNED_DMA
+	bool "STM32 MCU SPI Unaligned DMA Support"
+	depends on SPI_STM32_DMA
+	depends on CPU_CORTEX_M7
+	help
+	  Support unaligned DMA buffer. When DMA buffers are not aligned on
+	  cache line boundaries, or there size is not a multiple of the
+	  the cache line size, the SPI driver will use a temporary buffer
+	  that is correctly aligned, so the user doesn't have to care
+	  about it. This of course comes with the cost of an extra memcpy
+	  so if the user is sure the SPI buffers are all correctly aligned
+	  the option can be disabled.
+
 config SPI_STM32_USE_HW_SS
 	bool "STM32 Hardware Slave Select support"
 	default y

--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -39,6 +39,12 @@ struct stream {
 	bool src_addr_increment;
 	bool dst_addr_increment;
 	int fifo_threshold;
+#if CONFIG_SPI_STM32_UNALIGNED_DMA
+	uint8_t dma_aligned_buffer[__SCB_DCACHE_LINE_SIZE]
+					__aligned(__SCB_DCACHE_LINE_SIZE);
+#else /* CONFIG_SPI_STM32_UNALIGNED_DMA */
+	uint32_t dma_dummy_buffer;
+#endif /* CONFIG_SPI_STM32_UNALIGNED_DMA */
 };
 #endif
 
@@ -49,6 +55,10 @@ struct spi_stm32_data {
 	volatile uint32_t status_flags;
 	struct stream dma_rx;
 	struct stream dma_tx;
+#if CONFIG_SPI_STM32_UNALIGNED_DMA
+	uint8_t *dma_rx_buffer;
+	size_t dma_rx_buffer_len;
+#endif /* CONFIG_SPI_STM32_UNALIGNED_DMA */
 #endif
 };
 


### PR DESCRIPTION
This commit adds support for using non-cache-line aligned memory buffers when doing SPI-DMA. The concept could also be used when doing SPI-DMA from memory that can not be accessed by the DMA controller like CCM.

RFC: both cache and non-dma-ble memory could use the same double-buffering, maybe some more generic solution can be created?