### PR TITLE
samples: add missing sample.yaml files

### DIFF
--- a/samples/boards/intel_s1000_crb/dmic/sample.yaml
+++ b/samples/boards/intel_s1000_crb/dmic/sample.yaml
@@ -1,0 +1,6 @@
+sample:
+  name: DMIC Audio Sample
+tests:
+  sample.board.intel_s1000_crb.dmic:
+    platform_allow: intel_s1000_crb
+    tags: dmic

--- a/samples/subsys/mgmt/osdp/sample.yaml
+++ b/samples/subsys/mgmt/osdp/sample.yaml
@@ -1,0 +1,10 @@
+sample:
+  description: OSDP Sample
+  name: osdp
+tests:
+  sample.mgmt.osdp:
+    tags: osdp
+    filter: dt_compat_enabled_with_alias("gpio-leds", "led0") and CONFIG_SERIAL
+    harness: osdp
+    integration_platforms:
+      - frdm_k64f


### PR DESCRIPTION
Some samples were without sample.yaml. This adds
them.

Fixes #27813

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>