### PR TITLE
drivers: clock: stm32f7 needs power over-drive to reach 216Mhz

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -327,6 +327,20 @@ static int stm32_clock_control_init(struct device *dev)
 	stm32_clock_switch_to_hsi(LL_RCC_SYSCLK_DIV_1);
 	LL_RCC_PLL_Disable();
 
+#ifdef CONFIG_SOC_SERIES_STM32F7X
+	 /* Assuming we stay on Power Scale default value: Power Scale 1 */
+	 if (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC > 180000000) {
+		 LL_PWR_EnableOverDriveMode();
+		 while (LL_PWR_IsActiveFlag_OD() != 1) {
+		 /* Wait for OverDrive mode ready */
+		 }
+		 LL_PWR_EnableOverDriveSwitching();
+		 while (LL_PWR_IsActiveFlag_ODSW() != 1) {
+		 /* Wait for OverDrive switch ready */
+		 }
+	 }
+#endif
+
 #ifdef CONFIG_CLOCK_STM32_PLL_Q_DIVISOR
 	MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLQ,
 		   CONFIG_CLOCK_STM32_PLL_Q_DIVISOR

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -35,6 +35,7 @@
 #include <stm32f7xx_ll_bus.h>
 #include <stm32f7xx_ll_rcc.h>
 #include <stm32f7xx_ll_system.h>
+#include <stm32f7xx_ll_pwr.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
 #ifdef CONFIG_SERIAL_HAS_DRIVER


### PR DESCRIPTION
drivers: clock: stm32f7 needs power over-drive to reach 216Mhz

Assuming we stay on default Power Scale 1,
overdrive is required when System Core Clock frequency is higher
than 180MHz

Fixes #27792