### PR TITLE
tests: verify the time complexity of dlist

### DIFF
--- a/tests/benchmarks/data_structure_perf/dlist_perf/src/dlist_perf.c
+++ b/tests/benchmarks/data_structure_perf/dlist_perf/src/dlist_perf.c
@@ -173,12 +173,95 @@ void test_dlist_for_each(void)
 	zassert_true(count == 2, "SYS_DLIST_ITERATE_FROM_NODE failed");
 }
 
+/**
+ * @brief Test that access the 'head' and 'tail' in constant time
+ *
+ * @details Defined a double list and append several nodes.
+ * defined two pointers---'head','tail'.No matter how many nodes
+ * dlist have, get head and tail from the dlist directly.the time
+ * complexity of accessing head and tail is O(1).
+ *
+ * @ingroup lib_dlist_tests
+ */
+void test_dlist_peak_head_tail(void)
+{
+	sys_dlist_t list;
+	sys_dnode_t node[10];
+	sys_dnode_t *head, *tail;
+
+	sys_dlist_init(&list);
+
+	for (int i = 0; i < ARRAY_SIZE(node); i++) {
+		sys_dlist_append(&list, &node[i]);
+	}
+
+	/* Get 'head' node directly, the time complexity is O(1) */
+	head = list.head;
+	zassert_true(head == &node[0],
+			"dlist can't access 'head' in constant time");
+
+	/* Get 'tail' node directly, the time complexity is O(1) */
+	tail = list.tail;
+	zassert_true(tail == &node[ARRAY_SIZE(node) - 1],
+			"dlist can't access 'tail' in constant time");
+}
+
+/**
+ * @brief Test that insert or remove operates in constant time
+ *
+ * @details Defined a double list and append several nodes that
+ * a node has two pointers 'pre' and 'next' in pointer area.
+ * And define a node to be ready for inserting or removing,
+ * 'insert' and 'remove' are the operations with fixed steps and
+ * no matter the size of a dlist.
+ * Verify that the operations are running in constant time by
+ * proving the time complexity is O(1).
+ *
+ * @ingroup lib_dlist_tests
+ */
+void test_dlist_insert_and_remove(void)
+{
+	sys_dlist_t list;
+	sys_dlist_t node[10];
+
+	sys_dlist_init(&list);
+
+	for (int i = 0; i < ARRAY_SIZE(node); i++) {
+		sys_dlist_append(&list, &node[i]);
+	}
+
+	sys_dnode_t node_ins, *insert_at = &node[ARRAY_SIZE(node)/2];
+	sys_dnode_t *insert_node = &node_ins;
+
+	/* Insert a node and steps are fixed,the time complexity is O(1) */
+	insert_node->prev = insert_at->prev;
+	insert_node->next = insert_at;
+	insert_at->prev->next = insert_node;
+	insert_at->prev = insert_node;
+	/*Check if the node is inserted successfully*/
+	zassert_true(insert_node == sys_dlist_peek_prev(&list,
+		&node[ARRAY_SIZE(node)/2]), "dlist can't insert a node in constant time");
+	zassert_true(insert_node == sys_dlist_peek_next(&list,
+		&node[ARRAY_SIZE(node)/2 - 1]), "dlist can't insert a node in constant time");
+
+	/* Remove a node and steps are fixed,the time complexity is O(1) */
+	insert_node->prev->next = insert_node->next;
+	insert_node->next->prev = insert_node->prev;
+	/*Check if the node is removed successfully*/
+	zassert_true(insert_node != sys_dlist_peek_prev(&list,
+		&node[ARRAY_SIZE(node)/2]), "dlist can't insert a node in constant time");
+	zassert_true(insert_node != sys_dlist_peek_next(&list,
+		&node[ARRAY_SIZE(node)/2 - 1]), "dlist can't remove a node in constant time");
+}
+
 /* ztest main entry */
 void test_main(void)
 {
 	ztest_test_suite(test_dlist,
 			ztest_unit_test(test_dlist_container),
-			ztest_unit_test(test_dlist_for_each)
+			ztest_unit_test(test_dlist_for_each),
+			ztest_unit_test(test_dlist_peak_head_tail),
+			ztest_unit_test(test_dlist_insert_and_remove)
 			);
 	ztest_run_test_suite(test_dlist);
 }


### PR DESCRIPTION
Add two test cases to verify the operations of accessing
head,tail,insert and remove in constant time by proving the time
complexity of the operations are O(1).




Signed-off-by: Ningx Zhao <ningx.zhao@intel.com>