### PR TITLE
Bluetooth: host: Fix periodic advertising delete

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4667,8 +4667,8 @@ static void le_per_adv_sync_lost(struct net_buf *buf)
 {
 	struct bt_hci_evt_le_per_adv_sync_lost *evt =
 		(struct bt_hci_evt_le_per_adv_sync_lost *)buf->data;
-	struct bt_le_per_adv_sync *per_adv_sync;
 	struct bt_le_per_adv_sync_term_info term_info;
+	struct bt_le_per_adv_sync *per_adv_sync;
 
 	per_adv_sync = get_per_adv_sync(sys_le16_to_cpu(evt->handle));
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4534,7 +4534,6 @@ static void le_adv_ext_report(struct net_buf *buf)
 static void per_adv_sync_delete(struct bt_le_per_adv_sync *per_adv_sync)
 {
 	atomic_clear(per_adv_sync->flags);
-	per_adv_sync->cb = NULL; /* disable callbacks */
 }
 
 static struct bt_le_per_adv_sync *get_pending_per_adv_sync(void)


### PR DESCRIPTION
Fix periodic advertising delete implementation, to backup
the callback structure before deleting the instance so
that the application's terminate callback is called
thereafter.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>