### PR TITLE
soc: arm: st_stm32: stm32mp1: enable HSEM clock on init

### DIFF
--- a/soc/arm/st_stm32/stm32mp1/soc.c
+++ b/soc/arm/st_stm32/stm32mp1/soc.c
@@ -39,6 +39,9 @@ static int stm32m4_init(struct device *arg)
 
 	irq_unlock(key);
 
+	/*HW semaphore Clock enable*/
+	LL_AHB3_GRP1_EnableClock(LL_AHB3_GRP1_PERIPH_HSEM);
+
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	SystemCoreClock = 209000000;
 


### PR DESCRIPTION
Most drivers make use of the HW semaphore (see `stm32_gpio.c`), but the
HSEM clock isn't currently setup on the MCU side. This means we rely on
the MPU to enable this clock, which is an unsafe bet: the OS running on
the MPU may not have support for HSEM, or it might enter sleep state,
which will disable the clock. As a consequence, firmwares loaded from
the MPU running this OS will block on the first `z_stm32_hsem_lock()`
call.

As it is required to run anything on the MCU core, we shouldn't assume
the HSEM clock is already active when booting and enable it in the SoC
init, the same way it is done for the STM32H7.