### PR TITLE
bluetooth: controller: ll_sw: preserve TX power

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -570,9 +570,6 @@ uint8_t ll_adv_enable(uint8_t enable)
 	}
 
 	lll = &adv->lll;
-#if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL)
-	lll->tx_pwr_lvl = RADIO_TXP_DEFAULT;
-#endif /* CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL */
 
 	pdu_adv = lll_adv_data_peek(lll);
 	pdu_scan = lll_adv_scan_rsp_peek(lll);
@@ -1499,6 +1496,11 @@ void ull_adv_done(struct node_rx_event_done *done)
 
 static int init_reset(void)
 {
+#if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL) && \
+	!defined(CONFIG_BT_CTLR_ADV_EXT)
+	ll_adv[0].lll.tx_pwr_lvl = RADIO_TXP_DEFAULT;
+#endif /* CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL && !CONFIG_BT_CTLR_ADV_EXT */
+
 	return 0;
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -275,10 +275,6 @@ uint8_t ull_scan_enable(struct ll_scan_set *scan)
 	lll->init_addr_type = scan->own_addr_type;
 	ll_addr_get(lll->init_addr_type, lll->init_addr);
 
-#if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL)
-	lll->tx_pwr_lvl = RADIO_TXP_DEFAULT;
-#endif /* CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL */
-
 	ull_hdr_init(&scan->ull);
 	lll_hdr_init(lll, scan);
 
@@ -471,6 +467,11 @@ uint32_t ull_scan_filter_pol_get(uint8_t handle)
 
 static int init_reset(void)
 {
+#if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL) && \
+	!defined(CONFIG_BT_CTLR_ADV_EXT)
+	ll_scan[0].lll.tx_pwr_lvl = RADIO_TXP_DEFAULT;
+#endif /* CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL && !CONFIG_BT_CTLR_ADV_EXT */
+
 	return 0;
 }
 


### PR DESCRIPTION
Preserve the TX power set with the `BT_HCI_OP_VS_WRITE_TX_POWER_LEVEL`
command for advertising and scanning procedures. As the TX power is no
longer overwritten on procedure start, the TX powers can now be set
before starting the procedure. This eliminates the chance for the first
transmissions to use the default TX power instead of the request TX
power.

Similar changes are not made to the connection advertising powers as
changing the TX power for a connection to device A should not change
the TX power for a future connection to device B using the same
`struct lll_adv` instance.

Fixes #27921.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>