### PR TITLE
modules: mbedtls: Allow to enable server name indication option

### DIFF
--- a/modules/Kconfig.tls-generic
+++ b/modules/Kconfig.tls-generic
@@ -340,4 +340,10 @@ config MBEDTLS_USER_CONFIG_FILE
 	  User config file that can contain mbedTLS configs that were not
 	  covered by the generic config file.
 
+config MBEDTLS_SERVER_NAME_INDICATION
+	bool "Enable support for RFC 6066 server name indication (SNI) in SSL"
+	help
+	  Enable this to support RFC 6066 server name indication (SNI) in SSL.
+	  This requires that MBEDTLS_X509_CRT_PARSE_C is also set.
+
 endmenu

--- a/west.yml
+++ b/west.yml
@@ -90,7 +90,7 @@ manifest:
       revision: 928b61c7c8ef5f770f10e6fd36d4fea0cf375b5e
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: 9638398d3c319074ae3878035138ef8a76001e5b
+      revision: 8046c56542f8db737b1d35b9c21b3bd9a5db6d1b
       path: modules/crypto/mbedtls
     - name: mcuboot
       revision: 480421999ec2d8d2a20091e4f3a0393db04de5c4


### PR DESCRIPTION
Allow user to enable RFC 6066 server name indication (SNI) in SSL.

Fixes #27783

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>