### PR TITLE
drivers: modem: adding power control support for offload modem

### DIFF
--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -1798,6 +1798,11 @@ error:
 	return ret;
 }
 
+void restart_modem_offload(void)
+{
+	modem_reset();
+}
+
 NET_DEVICE_OFFLOAD_INIT(modem_sara, CONFIG_MODEM_UBLOX_SARA_R4_NAME,
 			modem_init, device_pm_control_nop, &mdata, NULL,
 			CONFIG_MODEM_UBLOX_SARA_R4_INIT_PRIORITY, &api_funcs,

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -1798,9 +1798,28 @@ error:
 	return ret;
 }
 
-void restart_modem_offload(void)
+void modem_offload_start(const struct device *device)
 {
 	modem_reset();
+
+	struct modem_data *mdm = device->data;
+
+	struct net_if *iface = mdm->net_iface;
+
+	net_if_flag_set(iface, NET_IF_UP);
+
+	net_mgmt_event_notify(NET_EVENT_IF_UP, iface);
+}
+
+void modem_offload_stop(const struct device *device)
+{
+	struct modem_data *mdm = device->data;
+
+	struct net_if *iface = mdm->net_iface;
+
+	net_if_flag_clear(iface, NET_IF_UP);
+
+	net_mgmt_event_notify(NET_EVENT_IF_DOWN, iface);
 }
 
 NET_DEVICE_OFFLOAD_INIT(modem_sara, CONFIG_MODEM_UBLOX_SARA_R4_NAME,

--- a/drivers/modem/ublox-sara-r4.h
+++ b/drivers/modem/ublox-sara-r4.h
@@ -1,30 +1,13 @@
-/** @file
- * @brief Modem socket header file.
- *
- * Generic modem driver heeader file
- */
-
 /*
  * Copyright (c) 2020-2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_DRIVERS_MODEM_MODEM_UBLOX_SARA_r4_H_
-#define ZEPHYR_INCLUDE_DRIVERS_MODEM_MODEM_UBLOX_SARA_r4_H_
+#ifndef UBLOX_SARA_r4_H_
+#define UBLOX_SARA_r4_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-/* This function is called from the main application in order to
- * make the modem ready for application data when the modem is powered
- * off.
- */
-void restart_modem_offload(void);
+void modem_offload_start(const struct device *device);
+void modem_offload_stop(const struct device *device);
 
-#ifdef __cplusplus
-}
-#endif
-
-
-#endif /* ZEPHYR_INCLUDE_DRIVERS_MODEM_MODEM_SOCKET_H_ */
+#endif /* UBLOX_SARA_r4_H_ */

--- a/drivers/modem/ublox-sara-r4.h
+++ b/drivers/modem/ublox-sara-r4.h
@@ -1,0 +1,30 @@
+/** @file
+ * @brief Modem socket header file.
+ *
+ * Generic modem driver heeader file
+ */
+
+/*
+ * Copyright (c) 2020-2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_MODEM_MODEM_UBLOX_SARA_r4_H_
+#define ZEPHYR_INCLUDE_DRIVERS_MODEM_MODEM_UBLOX_SARA_r4_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/* This function is called from the main application in order to
+ * make the modem ready for application data when the modem is powered
+ * off.
+ */
+void restart_modem_offload(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_MODEM_MODEM_SOCKET_H_ */


### PR DESCRIPTION
Signed-off-by: Tahir Akram <mtahirbutt@hotmail.com>

This PR addresses the support for power control for offload modem.
The way to power off and on modem is left for users of this drivers.
The driver has been tested with echo_client app with SARA U201 modem.