### PR TITLE
Soc: arm: Fix SDRAM linker section size for i.mx rt

### DIFF
--- a/soc/arm/nxp_imx/rt/linker.ld
+++ b/soc/arm/nxp_imx/rt/linker.ld
@@ -13,7 +13,7 @@ MEMORY
         OCRAM  (wx) : ORIGIN = DT_REG_ADDR(DT_NODELABEL(ocram)), LENGTH = DT_REG_SIZE(DT_NODELABEL(ocram))
 #endif
 #if (DT_REG_SIZE(DT_NODELABEL(sdram0)) > 0) && !defined(CONFIG_DATA_SEMC)
-        SDRAM  (wx) : ORIGIN = DT_REG_ADDR(DT_NODELABEL(sdram0)), LENGTH = DT_REG_ADDR(DT_NODELABEL(sdram0))
+        SDRAM  (wx) : ORIGIN = DT_REG_ADDR(DT_NODELABEL(sdram0)), LENGTH = DT_REG_SIZE(DT_NODELABEL(sdram0))
 #endif
 #if (DT_REG_SIZE(DT_INST(0, nxp_imx_dtcm)) > 0) && !defined(CONFIG_DATA_DTCM)
         DTCM    (wx) : ORIGIN = DT_REG_ADDR(DT_INST(0, nxp_imx_dtcm)), LENGTH = DT_REG_SIZE(DT_INST(0, nxp_imx_dtcm))


### PR DESCRIPTION
Change DT_REG_REG ==> DT_REG_SIZE for the SDRAM node

Signed-off-by: Crist Xu <crist.xu@nxp.com>