### PR TITLE
edtlib: support inferring binding from node content

### DIFF
--- a/doc/guides/dts/bindings.rst
+++ b/doc/guides/dts/bindings.rst
@@ -11,8 +11,9 @@ particular devicetree are useful to :ref:`device drivers <device_model_api>` or
 
 *Devicetree bindings* provide the other half of this information. Zephyr
 devicetree bindings are YAML files in a custom format (Zephyr does not use the
-dt-schema tools used by the Linux kernel). The build system uses bindings
-when generating code for :ref:`dt-from-c`.
+dt-schema tools used by the Linux kernel). With one exception in
+:ref:`dt-inferred-bindings` the build system uses bindings when generating
+code for :ref:`dt-from-c`.
 
 .. _dt-binding-compat:
 
@@ -73,3 +74,32 @@ Below is a template that shows the Zephyr bindings file syntax. It is stored in
 
 .. literalinclude:: ../../../dts/binding-template.yaml
    :language: yaml
+
+.. _dt-inferred-bindings:
+
+Inferred bindings
+*****************
+
+For sample code and applications it can be inconvenient to define a devicetree
+binding when only a few simple properties are needed, such as the identify of
+a GPIO for an application task.  The devicetree syntax allows inference of a
+binding for properties based on the value observed.  This inference is
+supported only for the ``/zephyr,user`` node.  The properties referenced can
+be accessed through the standard devicetree macros,
+e.g. ``DT_PROP(DT_PATH(zephyr_user), bytes)``.
+
+.. code-block:: DTS
+
+   / {
+	zephyr,user {
+		boolean;
+		bytes = [81 82 83];
+		number = <23>;
+		numbers = <1>, <2>, <3>;
+		string = "text";
+		strings = "a", "b", "c";
+		handle = <&gpio0>;
+		handles = <&gpio0>, <&gpio1>;
+		signal-gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+	};
+   };

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -39,7 +39,8 @@ def main():
                          # Suppress this warning if it's suppressed in dtc
                          warn_reg_unit_address_mismatch=
                              "-Wno-simple_bus_reg" not in args.dtc_flags,
-                         default_prop_types=True)
+                         default_prop_types=True,
+                         infer_binding_for_paths=["/zephyr,user"])
     except edtlib.EDTError as e:
         sys.exit(f"devicetree error: {e}")
 
@@ -178,9 +179,15 @@ Node's generated path identifier: DT_{node.z_path_id}
 """
 
     if node.matching_compat:
-        s += f"""
+        if node.binding_path:
+            s += f"""
 Binding (compatible = {node.matching_compat}):
   {relativize(node.binding_path)}
+"""
+        else:
+            s += f"""
+Binding (compatible = {node.matching_compat}):
+  No yaml (bindings inferred from properties)
 """
 
     s += f"\nDependency Ordinal: {node.dep_ordinal}\n"

--- a/scripts/dts/gen_legacy_defines.py
+++ b/scripts/dts/gen_legacy_defines.py
@@ -121,9 +121,15 @@ Devicetree node:
   {node.path}
 """
     if node.matching_compat:
-        s += f"""
+        if node.binding_path:
+            s += f"""
 Binding (compatible = {node.matching_compat}):
   {relativize(node.binding_path)}
+"""
+        else:
+            s += f"""
+Binding (compatible = {node.matching_compat}):
+  No yaml (bindings inferred from properties)
 """
     else:
         s += "\nNo matching binding.\n"

--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -362,6 +362,22 @@
 	};
 
 	//
+	// zephyr,user binding inference
+	//
+
+	zephyr,user {
+		boolean;
+		bytes = [81 82 83];
+		number = <23>;
+		numbers = <1>, <2>, <3>;
+		string = "text";
+		strings = "a", "b", "c";
+		handle = <&{/props/ctrl-1}>;
+		phandles = <&{/props/ctrl-1}>, <&{/props/ctrl-2}>;
+		phandle-array-foos = <&{/props/ctrl-2} 1 2>;
+	};
+
+	//
 	// For testing that neither 'include: [foo.yaml, bar.yaml]' nor
 	// 'include: [bar.yaml, foo.yaml]' causes errors when one of the files
 	// has 'required: true' and the other 'required: false'

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -216,6 +216,18 @@ warning: unit address and first address in 'reg' (0x30000000200000001) don't mat
                  r"OrderedDict([('int', <Property, name: int, type: int, value: 123>), ('array', <Property, name: array, type: array, value: [1, 2, 3]>), ('uint8-array', <Property, name: uint8-array, type: uint8-array, value: b'\x89\xab\xcd'>), ('string', <Property, name: string, type: string, value: 'hello'>), ('string-array', <Property, name: string-array, type: string-array, value: ['hello', 'there']>), ('default-not-used', <Property, name: default-not-used, type: int, value: 234>)])")
 
     #
+    # Test binding inference
+    #
+
+    verify_streq(edt.get_node("/zephyr,user").props, r"OrderedDict()")
+
+    edt = edtlib.EDT("test.dts", ["test-bindings"], warnings,
+                     infer_binding_for_paths=["/zephyr,user"])
+
+    verify_streq(edt.get_node("/zephyr,user").props,
+                 r"OrderedDict([('boolean', <Property, name: boolean, type: boolean, value: True>), ('bytes', <Property, name: bytes, type: uint8-array, value: b'\x81\x82\x83'>), ('number', <Property, name: number, type: int, value: 23>), ('numbers', <Property, name: numbers, type: array, value: [1, 2, 3]>), ('string', <Property, name: string, type: string, value: 'text'>), ('strings', <Property, name: strings, type: string-array, value: ['a', 'b', 'c']>), ('handle', <Property, name: handle, type: phandle, value: <Node /props/ctrl-1 in 'test.dts', binding test-bindings/phandle-array-controller-1.yaml>>), ('phandles', <Property, name: phandles, type: phandles, value: [<Node /props/ctrl-1 in 'test.dts', binding test-bindings/phandle-array-controller-1.yaml>, <Node /props/ctrl-2 in 'test.dts', binding test-bindings/phandle-array-controller-2.yaml>]>), ('phandle-array-foos', <Property, name: phandle-array-foos, type: phandle-array, value: [<ControllerAndData, controller: <Node /props/ctrl-2 in 'test.dts', binding test-bindings/phandle-array-controller-2.yaml>, data: OrderedDict([('one', 1), ('two', 2)])>]>)])")
+
+    #
     # Test having multiple directories with bindings, with a different .dts file
     #
 


### PR DESCRIPTION
Clean up of devicetree tooling removed generation of information present in devicetree in nodes that have no `compatible`, or for extra properties not defined by a binding.  Discussion proposed that these properties should be allowed, but only in a defined node `/zephyr,user`. For that node infer bindings based on the presence of properties.

Fixes: #25945
Supersedes: #18544, #15020