### PR TITLE
boards: arm: nucleo_l152re: fix openOCD issue to acces bank2

### DIFF
--- a/boards/arm/nucleo_l152re/support/openocd.cfg
+++ b/boards/arm/nucleo_l152re/support/openocd.cfg
@@ -1,4 +1,15 @@
-source [find board/st_nucleo_l1.cfg]
+# TODO: Once official oepnOCD fix merged and available in zephyr:
+#       http://openocd.zylin.com/#/c/5829/
+#       revert to board/st_nucleo_l1.cfg
+# source [find board/st_nucleo_l1.cfg]
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32l1x_dual_bank.cfg]
+
+reset_config srst_only
 
 $_TARGETNAME configure -event gdb-attach {
         echo "Debugger attaching: halting execution"


### PR DESCRIPTION
boards: arm: nucleo_l152re: fix openOCD issue to access bank2

There is a bug in OpenOCD which prevent to flash the bank2
of nucleo_l152re: http://openocd.zylin.com/#/c/5829/
Waiting for official fix, here is a workaround.
TODO: To be reverted once official fix is merged and available in
Zephyr.

Note: tests/lib/cmsis_dsp/transform/libraries.cmsis_dsp.transform.rf32
fails because the binary code is big enough to overflow bank1 and thus required to be partially flashed in bank2.