### PR TITLE
include/posix: incorporate toolchain-provided time.h header

### DIFF
--- a/include/posix/time.h
+++ b/include/posix/time.h
@@ -6,6 +6,11 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_TIME_H_
 #define ZEPHYR_INCLUDE_POSIX_TIME_H_
 
+/* Read standard header.  This may find <posix/time.h> since they
+ * refer to the same file when include/posix is in the search path.
+ */
+#include <time.h>
+
 #ifdef CONFIG_NEWLIB_LIBC
 /* Kludge to support outdated newlib version as used in SDK 0.10 for Xtensa */
 #include <newlib.h>
@@ -101,4 +106,9 @@ int nanosleep(const struct timespec *rqtp, struct timespec *rmtp);
 #include <syscalls/time.h>
 #endif /* CONFIG_ARCH_POSIX */
 
+#else /* ZEPHYR_INCLUDE_POSIX_TIME_H_ */
+/* Read the toolchain header when <posix/time.h> finds itself on the
+ * first attempt.
+ */
+#include_next <time.h>
 #endif /* ZEPHYR_INCLUDE_POSIX_TIME_H_ */

--- a/samples/posix/gettimeofday/README.rst
+++ b/samples/posix/gettimeofday/README.rst
@@ -7,10 +7,11 @@ Overview
 ********
 
 This sample application demonstrates using the POSIX gettimeofday()
-function to display the absolute wall clock time every second. At
-system startup, the current time is queried using the SNTP networking
-protocol, enabled by setting the :option:`CONFIG_NET_CONFIG_CLOCK_SNTP_INIT`
-and :option:`CONFIG_NET_CONFIG_SNTP_INIT_SERVER` options.
+function to display the absolute wall clock time and local time every
+second. At system startup, the current time is queried using the SNTP
+networking protocol, enabled by setting the
+:option:`CONFIG_NET_CONFIG_CLOCK_SNTP_INIT` and
+:option:`CONFIG_NET_CONFIG_SNTP_INIT_SERVER` options.
 
 Requirements
 ************

--- a/samples/posix/gettimeofday/src/main.c
+++ b/samples/posix/gettimeofday/src/main.c
@@ -16,6 +16,9 @@ int main(void)
 
 	while (1) {
 		int res = gettimeofday(&tv, NULL);
+		time_t now = time(NULL);
+		struct tm tm;
+		localtime_r(&now, &tm);
 
 		if (res < 0) {
 			printf("Error in gettimeofday(): %d\n", errno);
@@ -23,8 +26,9 @@ int main(void)
 		}
 
 		printf("gettimeofday(): HI(tv_sec)=%d, LO(tv_sec)=%d, "
-		       "tv_usec=%d\n", (unsigned int)(tv.tv_sec >> 32),
-		       (unsigned int)tv.tv_sec, (unsigned int)tv.tv_usec);
+		       "tv_usec=%d\n\t%s\n", (unsigned int)(tv.tv_sec >> 32),
+		       (unsigned int)tv.tv_sec, (unsigned int)tv.tv_usec,
+		       asctime(&tm));
 		sleep(1);
 	}
 }


### PR DESCRIPTION
Some of what's supposed to be in <time.h> was lost because this header attempts to define everything using more primitive include files. Instead incorporate the contents from the toolchain-provided header. Any gaps should be picked up by the legacy content present in this file, which should not conflict with the toolchain header.

An updated test confirms the problematic API is now available to Zephyr.

Closes #24730.

(This solution, which addresses a blocking problem for a Nordic-based project, has been discussed in https://github.com/zephyrproject-rtos/zephyr/issues/24730#issuecomment-620653206.  The potential follow-up cleanup is not being addressed here.)