### PR TITLE
Revert "posix: linker: Wrap rodata and rwdata in sections."

### DIFF
--- a/include/arch/posix/linker.ld
+++ b/include/arch/posix/linker.ld
@@ -22,37 +22,22 @@
 SECTIONS
  {
 
-	SECTION_PROLOGUE(romstart_snippet,,)
-	{
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-rom-start.ld>
-	}
 
 #include <linker/common-rom.ld>
-
-	SECTION_PROLOGUE(rodata_snippet,,)
-	{
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-rodata.ld>
-	}
-} INSERT AFTER .rodata;
-
-SECTIONS
-  {
-
-	SECTION_DATA_PROLOGUE(data_snippet,,)
-	{
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-rwdata.ld>
-	}
 
 #include <linker/common-ram.ld>
 
@@ -63,13 +48,12 @@ SECTIONS
 
 #include <arch/posix/native_tasks.ld>
 
-	SECTION_DATA_PROLOGUE(noinit_snippet,,)
-	{
+ __data_ram_end = .;
+
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-noinit.ld>
-	}
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.


### PR DESCRIPTION
This reverts commit b51eeb03f4a3c2b6ece78d2c79d336c90587f4cf.

The linker script is now putting read-only material in writable
segments, which causes glib with -D_FORTIFY_SOURCE=2 to abort.

Fixes #27847