### PR TITLE
arch: arm: mpu: Removal of include path pollution

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/mpu/CMakeLists.txt
+++ b/arch/arm/core/aarch32/cortex_m/mpu/CMakeLists.txt
@@ -5,8 +5,3 @@ zephyr_library()
 zephyr_library_sources(                             arm_core_mpu.c)
 zephyr_library_sources_ifdef(CONFIG_CPU_HAS_ARM_MPU arm_mpu.c)
 zephyr_library_sources_ifdef(CONFIG_CPU_HAS_NXP_MPU nxp_mpu.c)
-
-zephyr_library_include_directories(
-  .
-  ../../../include/cortex_m
-)

--- a/arch/arm/core/aarch32/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/aarch32/cortex_m/mpu/arm_mpu.c
@@ -68,10 +68,10 @@ static inline uint8_t get_num_regions(void)
 	defined(CONFIG_CPU_CORTEX_M3) || \
 	defined(CONFIG_CPU_CORTEX_M4) || \
 	defined(CONFIG_CPU_CORTEX_M7)
-#include <arm_mpu_v7_internal.h>
+#include "arm_mpu_v7_internal.h"
 #elif defined(CONFIG_CPU_CORTEX_M23) || \
 	defined(CONFIG_CPU_CORTEX_M33)
-#include <arm_mpu_v8_internal.h>
+#include "arm_mpu_v8_internal.h"
 #else
 #error "Unsupported ARM CPU"
 #endif


### PR DESCRIPTION
Removes unnecessary and incorrect directories from include path.

Signed-off-by: Pavel Král <pavel.kral@omsquare.com>