### PR TITLE
samples: intel_s1000: fix timeout variable 

### DIFF
--- a/samples/boards/intel_s1000_crb/dmic/src/dmic_sample.c
+++ b/samples/boards/intel_s1000_crb/dmic/src/dmic_sample.c
@@ -99,7 +99,7 @@ static void dmic_receive(void)
 
 	while (frame_counter++ < FRAMES_PER_ITERATION) {
 		ret = dmic_read(dmic_device, 0, (void **)&mic_in_buf, &size,
-				K_FOREVER);
+				SYS_FOREVER_MS);
 		if (ret) {
 			LOG_ERR("dmic_read failed %d", ret);
 		} else {


### PR DESCRIPTION
Fix timeout vairable on sample that was missed.