### PR TITLE
boards: faze: should not be declared as a default test platform

### DIFF
--- a/boards/arm/faze/faze.yaml
+++ b/boards/arm/faze/faze.yaml
@@ -19,5 +19,3 @@ supported:
   - i2c
   - pinmux
   - serial
-testing:
-  default: true


### PR DESCRIPTION
This was probably added by mistake, this is not a default  platform that
needs to build every single test we have on each PR.