### PR TITLE
Bluetooth: GATT: Fix usage of bt_gatt_foreach_attr_type

### DIFF
--- a/doc/releases/release-notes-2.4.rst
+++ b/doc/releases/release-notes-2.4.rst
@@ -85,6 +85,11 @@ API Changes
 * The ``_gatt_`` and ``_GATT_`` infixes have been removed for the HRS, DIS
   and BAS APIs and the Kconfig options.
 
+* ``<include/bluetooth/gatt.h>`` callback :c:func:`bt_gatt_attr_func_t` used by
+  :c:func:`bt_gatt_foreach_attr` and :c:func:`bt_gatt_foreach_attr_type` has
+  been changed to always pass the original pointer of attributes along with its
+  resolved handle.
+
 Deprecated in this release
 ==========================
 

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -339,12 +339,14 @@ enum {
  *  @brief Attribute iterator callback.
  *
  *  @param attr Attribute found.
+ *  @param handle Attribute handle found.
  *  @param user_data Data given.
  *
  *  @return BT_GATT_ITER_CONTINUE if should continue to the next attribute.
  *  @return BT_GATT_ITER_STOP to stop.
  */
 typedef uint8_t (*bt_gatt_attr_func_t)(const struct bt_gatt_attr *attr,
+				       uint16_t handle,
 				       void *user_data);
 
 /** @brief Attribute iterator by type.

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -394,6 +394,15 @@ static inline void bt_gatt_foreach_attr(uint16_t start_handle, uint16_t end_hand
  */
 struct bt_gatt_attr *bt_gatt_attr_next(const struct bt_gatt_attr *attr);
 
+/** @brief Get Attribute handle.
+ *
+ *  @param attr Attribute object.
+ *
+ *  @return Handle of the corresponding attribute or zero if the attribute
+ *          could not be found.
+ */
+uint16_t bt_gatt_attr_get_handle(const struct bt_gatt_attr *attr);
+
 /** @brief Get the handle of the characteristic value descriptor.
  *
  * @param attr A Characteristic Attribute

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1278,6 +1278,13 @@ static uint16_t find_static_attr(const struct bt_gatt_attr *attr)
 	uint16_t handle = 1;
 
 	Z_STRUCT_SECTION_FOREACH(bt_gatt_service_static, static_svc) {
+		/* Skip ahead if start is not within service attributes array */
+		if ((attr < &static_svc->attrs[0]) ||
+		    (attr > &static_svc->attrs[static_svc->attr_count - 1])) {
+			handle += static_svc->attr_count;
+			continue;
+		}
+
 		for (size_t i = 0; i < static_svc->attr_count; i++, handle++) {
 			if (attr == &static_svc->attrs[i]) {
 				return handle;

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -659,7 +659,8 @@ static struct db_stats {
 	uint16_t ccc_count;
 } stats;
 
-static uint8_t print_attr(const struct bt_gatt_attr *attr, void *user_data)
+static uint8_t print_attr(const struct bt_gatt_attr *attr, uint16_t handle,
+			  void *user_data)
 {
 	const struct shell *shell = user_data;
 	char str[BT_UUID_STR_LEN];
@@ -682,7 +683,7 @@ static uint8_t print_attr(const struct bt_gatt_attr *attr, void *user_data)
 
 	bt_uuid_to_str(attr->uuid, str, sizeof(str));
 	shell_print(shell, "attr %p handle 0x%04x uuid %s perm 0x%02x",
-		    attr, attr->handle, str, attr->perm);
+		    attr, handle, str, attr->perm);
 
 	return BT_GATT_ITER_CONTINUE;
 }
@@ -1007,7 +1008,8 @@ static int cmd_metrics(const struct shell *shell, size_t argc, char *argv[])
 }
 #endif /* CONFIG_BT_GATT_DYNAMIC_DB */
 
-static uint8_t get_cb(const struct bt_gatt_attr *attr, void *user_data)
+static uint8_t get_cb(const struct bt_gatt_attr *attr, uint16_t handle,
+		      void *user_data)
 {
 	struct shell *shell = user_data;
 	uint8_t buf[256];
@@ -1056,7 +1058,8 @@ struct set_data {
 	int err;
 };
 
-static uint8_t set_cb(const struct bt_gatt_attr *attr, void *user_data)
+static uint8_t set_cb(const struct bt_gatt_attr *attr, uint16_t handle,
+		      void *user_data)
 {
 	struct set_data *data = user_data;
 	uint8_t buf[256];

--- a/tests/bluetooth/gatt/src/main.c
+++ b/tests/bluetooth/gatt/src/main.c
@@ -136,7 +136,8 @@ void test_gatt_unregister(void)
 		     "Test service unregister failed");
 }
 
-static uint8_t count_attr(const struct bt_gatt_attr *attr, void *user_data)
+static uint8_t count_attr(const struct bt_gatt_attr *attr, uint16_t handle,
+			  void *user_data)
 {
 	uint16_t *count = user_data;
 
@@ -145,7 +146,8 @@ static uint8_t count_attr(const struct bt_gatt_attr *attr, void *user_data)
 	return BT_GATT_ITER_CONTINUE;
 }
 
-static uint8_t find_attr(const struct bt_gatt_attr *attr, void *user_data)
+static uint8_t find_attr(const struct bt_gatt_attr *attr, uint16_t handle,
+			 void *user_data)
 {
 	const struct bt_gatt_attr **tmp = user_data;
 

--- a/tests/bluetooth/tester/src/gatt.c
+++ b/tests/bluetooth/tester/src/gatt.c
@@ -1814,7 +1814,8 @@ struct get_attrs_foreach_data {
 	uint8_t count;
 };
 
-static uint8_t get_attrs_rp(const struct bt_gatt_attr *attr, void *user_data)
+static uint8_t get_attrs_rp(const struct bt_gatt_attr *attr, uint16_t handle,
+			    void *user_data)
 {
 	struct get_attrs_foreach_data *foreach = user_data;
 	struct gatt_attr *gatt_attr;
@@ -1825,7 +1826,7 @@ static uint8_t get_attrs_rp(const struct bt_gatt_attr *attr, void *user_data)
 	}
 
 	gatt_attr = net_buf_simple_add(foreach->buf, sizeof(*gatt_attr));
-	gatt_attr->handle = sys_cpu_to_le16(attr->handle);
+	gatt_attr->handle = sys_cpu_to_le16(handle);
 	gatt_attr->permission = attr->perm;
 
 	if (attr->uuid->type == BT_UUID_TYPE_16) {
@@ -1902,7 +1903,8 @@ static uint8_t err_to_att(int err)
 	return BT_ATT_ERR_UNLIKELY;
 }
 
-static uint8_t get_attr_val_rp(const struct bt_gatt_attr *attr, void *user_data)
+static uint8_t get_attr_val_rp(const struct bt_gatt_attr *attr, uint16_t handle,
+			       void *user_data)
 {
 	struct net_buf_simple *buf = user_data;
 	struct gatt_get_attribute_value_rp *rp;


### PR DESCRIPTION
bt_gatt_foreach_attr_type make use of stack variable to store static
service attributes so the handle could be resolved (as static services
are read-only), but code such as bt_gatt_indicate and bt_gatt_notify
use it out of scope when an UUID is provided.