### PR TITLE
OSDP - Don't use TEST_RANDOM_GENERATOR

### DIFF
--- a/subsys/mgmt/osdp/Kconfig
+++ b/subsys/mgmt/osdp/Kconfig
@@ -12,7 +12,6 @@ menuconfig OSDP
 	select SERIAL_SUPPORT_INTERRUPT
 	select UART_INTERRUPT_DRIVEN
 	select ENTROPY_GENERATOR
-	select TEST_RANDOM_GENERATOR
 	help
 	  Add support for Open Supervised Device Protocol (OSDP)
 

--- a/subsys/mgmt/osdp/Kconfig
+++ b/subsys/mgmt/osdp/Kconfig
@@ -11,7 +11,6 @@ menuconfig OSDP
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	select UART_INTERRUPT_DRIVEN
-	select ENTROPY_GENERATOR
 	help
 	  Add support for Open Supervised Device Protocol (OSDP)
 

--- a/subsys/mgmt/osdp/Kconfig
+++ b/subsys/mgmt/osdp/Kconfig
@@ -8,9 +8,7 @@ menuconfig OSDP
 	bool "Open Supervised Device Protocol (OSDP) driver"
 	select RING_BUFFER
 	select SERIAL
-	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
-	select UART_INTERRUPT_DRIVEN
 	help
 	  Add support for Open Supervised Device Protocol (OSDP)
 


### PR DESCRIPTION
- Do not use TEST_RANDOM_GENERATOR
- Do not select unecessarily ENTROPY_GENERATOR
- Do not select wrong SERIAL options