### PR TITLE
kernel: mandate that SRAM is identity mapped

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -530,43 +530,17 @@ config SRAM_REGION_PERMISSIONS
 	  If not enabled, all SRAM mappings will allow supervisor mode to
 	  read, write, and execute. User mode support requires this.
 
-config KERNEL_VM_BASE
-	hex "Base virtual address for the kernel"
-	default SRAM_BASE_ADDRESS if X86 # TODO remove once x86 is linked properly
-	default 0xFFFF800000000000 if 64BIT
+config KERNEL_VM_SIZE
+	hex "Size of kernel address space in bytes"
 	default 0xC0000000
 	help
-	  Define the base virtual memory address for the core kernel. There will
-	  be a permemant mapping of all RAM starting at this virtual address,
-	  with any unused space up to the KERNEL_VM_LIMIT available for memory
-	  mappings. This denotes the start of the RAM mapping and may not be
-	  the base address of the kernel itself, but the offset of the kernel here
-	  will be the same as the offset from the beginning of physical memory
-	  where it was loaded.
+	  Size of the kernel's address space. Constraining this helps control
+	  how much total memory can be used for page tables.
 
-	  The value here must have similar alignment to the base physical address,
-	  such that the same page tables can be mapped to the top-level paging
-	  structure entries for the virtual and physical address.
-
-	  It is valid to set this to SRAM_BASE_ADDRESS, in which case RAM will
-	  be identity-mapped. Otherwise, the SRAM and KERNEL_VM regions must
-	  not overlap.
-
-	  The default for 64-bit presumes a 48-bit canonical address space.
-
-config KERNEL_VM_LIMIT
-	hex "Upper bound on kernel address space"
-	default 0xFFFFFFFFFFFFFFFF if 64BIT
-	default 0xFFFFFFFF
-	help
-	  Inclusive upper bound on the virtual memory area reserved for the kernel.
-	  No mappings will be made past this point. Constraining this helps control
-	  how much memory is used for page tables.
-
-	  The area defined by KERNEL_VM_BASE to KERNEL_VM_LIMIT must have enough
-	  room to map system RAM, plus any driver mappings. Further mappings
-	  may be made at runtime depending on configuration options (such as
-	  memory-mapping stacks, VDSO pages, etc).
+	  The area defined by SRAM_BASE_ADDRESS to SRAM_BASE_ADDRESS +
+	  KERNEL_VM_SIZE must have enough room to map system RAM, plus any driver
+	  mappings. Further mappings may be made at runtime depending on
+	  configuration options (such as memory-mapping stacks, VDSO pages, etc).
 
 endif   # MMU
 

--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -173,7 +173,7 @@ static inline uintptr_t get_cr3(const z_arch_esf_t *esf)
 
 static inline pentry_t *get_ptables(const z_arch_esf_t *esf)
 {
-	return z_mem_virt_addr(get_cr3(esf));
+	return (pentry_t *)get_cr3(esf);
 }
 
 #ifdef CONFIG_X86_64

--- a/arch/x86/core/ia32/crt0.S
+++ b/arch/x86/core/ia32/crt0.S
@@ -16,7 +16,6 @@
 #include <kernel_arch_data.h>
 #include <arch/cpu.h>
 #include <arch/x86/multiboot.h>
-#include <sys/mem_manage.h>
 
 	/* exports (private APIs) */
 
@@ -42,55 +41,7 @@
 	GTEXT(_sys_resume_from_deep_sleep)
 #endif
 
-.macro install_page_tables
-#ifdef CONFIG_X86_MMU
-	/* Enable paging. If virtual memory is enabled, the instruction pointer
-	 * is currently at a physical address. There is an identity mapping
-	 * for all RAM, plus a virtual mapping of RAM starting at
-	 * CONFIG_KERNEL_VM_BASE using the same paging structures.
-	 *
-	 * Until we enable these page tables, only physical memory addresses
-	 * work.
-	 */
-	movl $Z_MEM_PHYS_ADDR(z_x86_kernel_ptables), %eax
-	movl %eax, %cr3
-
-#ifdef CONFIG_X86_PAE
-	/* Enable PAE */
-	movl %cr4, %eax
-	orl $CR4_PAE, %eax
-	movl %eax, %cr4
-
-	/* IA32_EFER NXE bit set */
-	movl $0xC0000080, %ecx
-	rdmsr
-	orl $0x800, %eax
-	wrmsr
-#endif /* CONFIG_X86_PAE */
-
-	/* Enable paging (CR0.PG, bit 31) / write protect (CR0.WP, bit 16) */
-	movl %cr0, %eax
-	orl $(CR0_PG | CR0_WP), %eax
-	movl %eax, %cr0
-
-#if CONFIG_KERNEL_VM_BASE != CONFIG_SRAM_BASE_ADDRESS
-	/* Jump to a virtual address, which works because the identity and
-	 * virtual mappings both are to the same physical address.
-	 */
-	lea vm_enter, %eax
-	jmp *%eax
-vm_enter:
-	/* We are now executing in virtual memory. We'll un-map the identity
-	 * mappings later once we are in the C domain
-	 */
-#endif /* CONFIG_KERNEL_VM_BASE != CONFIG_SRAM_BASE_ADDRESS */
-#endif /* CONFIG_X86_MMU */
-.endm
-
 SECTION_FUNC(TEXT_START, __start)
-#ifndef CONFIG_XIP
-	install_page_tables
-#endif /* CONFIG_XIP */
 
 #include "../common.S"
 
@@ -249,11 +200,6 @@ __csSet:
 
 	call	_x86_data_copy
 #endif /* CONFIG_USERSPACE */
-
-	/* Have to do this here, the page tables aren't loaded into RAM
-	 * until after the data copy
-	 */
-	install_page_tables
 #endif /* CONFIG_XIP */
 
 	/*
@@ -282,6 +228,30 @@ __csSet:
 	ltr %ax
 #endif
 	lidt	z_x86_idt		/* load 32-bit operand size IDT */
+
+#ifdef CONFIG_X86_MMU
+	/* Install page tables */
+	movl $z_x86_kernel_ptables, %eax
+	movl %eax, %cr3
+
+#ifdef CONFIG_X86_PAE
+	/* Enable PAE */
+	movl %cr4, %eax
+	orl $CR4_PAE, %eax
+	movl %eax, %cr4
+
+	/* IA32_EFER NXE bit set */
+	movl $0xC0000080, %ecx
+	rdmsr
+	orl $0x800, %eax
+	wrmsr
+#endif /* CONFIG_X86_PAE */
+
+	/* Enable paging (CR0.PG, bit 31) / write protect (CR0.WP, bit 16) */
+	movl %cr0, %eax
+	orl $(CR0_PG | CR0_WP), %eax
+	movl %eax, %cr0
+#endif /* CONFIG_X86_MMU */
 
 #ifdef CONFIG_LOAPIC
 	/* For BSP, cpu_number is 0 */

--- a/arch/x86/core/ia32/fatal.c
+++ b/arch/x86/core/ia32/fatal.c
@@ -151,7 +151,7 @@ struct task_state_segment _df_tss = {
 	.es = DATA_SEG,
 	.ss = DATA_SEG,
 	.eip = (uint32_t)df_handler_top,
-	.cr3 = Z_MEM_PHYS_ADDR((uint32_t)&z_x86_kernel_ptables)
+	.cr3 = (uint32_t)&z_x86_kernel_ptables
 };
 
 static __used void df_handler_bottom(void)
@@ -199,7 +199,7 @@ static FUNC_NORETURN __used void df_handler_top(void)
 	_main_tss.es = DATA_SEG;
 	_main_tss.ss = DATA_SEG;
 	_main_tss.eip = (uint32_t)df_handler_bottom;
-	_main_tss.cr3 = z_mem_phys_addr(&z_x86_kernel_ptables);
+	_main_tss.cr3 = (uint32_t)(&z_x86_kernel_ptables);
 	_main_tss.eflags = 0U;
 
 	/* NT bit is set in EFLAGS so we will task switch back to _main_tss

--- a/arch/x86/core/ia32/userspace.S
+++ b/arch/x86/core/ia32/userspace.S
@@ -50,7 +50,7 @@ SECTION_FUNC(TEXT, z_x86_trampoline_to_kernel)
 	pushl	%edi
 
 	/* Switch to kernel page table */
-	movl	$Z_MEM_PHYS_ADDR(z_x86_kernel_ptables), %esi
+	movl	$z_x86_kernel_ptables, %esi
 	movl	%esi, %cr3
 
 	/* Save old trampoline stack pointer in %edi */
@@ -155,7 +155,7 @@ SECTION_FUNC(TEXT, z_x86_syscall_entry_stub)
 	pushl	%edi
 
 	/* Switch to kernel page table */
-	movl	$Z_MEM_PHYS_ADDR(z_x86_kernel_ptables), %esi
+	movl	$z_x86_kernel_ptables, %esi
 	movl	%esi, %cr3
 
 	/* Save old trampoline stack pointer in %edi */

--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -49,7 +49,7 @@
 	clts
 
 	/* Page tables created at build time by gen_mmu.py */
-	movl $Z_MEM_PHYS_ADDR(z_x86_kernel_ptables), %eax
+	movl $z_x86_kernel_ptables, %eax
 	movl %eax, %cr3
 
 	set_efer
@@ -70,7 +70,7 @@
 	movq %rax, %cr4
 	clts
 
-	movq $Z_MEM_PHYS_ADDR(z_x86_kernel_ptables), %rax
+	movq $z_x86_kernel_ptables, %rax
 	movq %rax, %cr3
 
 	set_efer

--- a/arch/x86/core/intel64/userspace.S
+++ b/arch/x86/core/intel64/userspace.S
@@ -84,7 +84,7 @@ z_x86_syscall_entry_stub:
 
 	/* Load kernel's page table */
 	pushq	%rax
-	movq	$Z_MEM_PHYS_ADDR(z_x86_kernel_ptables), %rax
+	movq	$z_x86_kernel_ptables, %rax
 	movq	%rax, %cr3
 	popq	%rax
 	movq	$0, -8(%rsp)	/* Delete stashed RAX data */

--- a/arch/x86/core/prep_c.c
+++ b/arch/x86/core/prep_c.c
@@ -26,10 +26,6 @@ FUNC_NORETURN void z_x86_prep_c(void *arg)
 	z_x86_early_serial_init();
 #endif
 
-#ifdef CONFIG_MMU
-	z_x86_mmu_init();
-#endif
-
 #ifdef CONFIG_X86_64
 	x86_64_irq_init();
 #endif

--- a/arch/x86/core/userspace.c
+++ b/arch/x86/core/userspace.c
@@ -100,7 +100,7 @@ void *z_x86_userspace_prepare_thread(struct k_thread *thread)
 		z_x86_thread_pt_init(thread);
 		initial_entry = drop_to_user;
 	} else {
-		thread->arch.ptables = z_mem_phys_addr(&z_x86_kernel_ptables);
+		thread->arch.ptables = (uintptr_t)&z_x86_kernel_ptables;
 		initial_entry = z_thread_entry;
 	}
 

--- a/arch/x86/include/x86_mmu.h
+++ b/arch/x86/include/x86_mmu.h
@@ -141,7 +141,7 @@ static inline uintptr_t z_x86_cr3_get(void)
 /* Return the virtual address of the page tables installed in this CPU in CR3 */
 static inline pentry_t *z_x86_page_tables_get(void)
 {
-	return z_mem_virt_addr(z_x86_cr3_get());
+	return (pentry_t *)z_x86_cr3_get();
 }
 
 /* Kernel's page table. This is in CR3 for all supervisor threads.
@@ -153,12 +153,9 @@ extern pentry_t z_x86_kernel_ptables;
 static inline pentry_t *z_x86_thread_page_tables_get(struct k_thread *thread)
 {
 #ifdef CONFIG_USERSPACE
-	return z_mem_virt_addr(thread->arch.ptables);
+	return (pentry_t *)(thread->arch.ptables);
 #else
 	return &z_x86_kernel_ptables;
 #endif
 }
-
-/* Early-boot paging setup tasks, called from prep_c */
-void z_x86_mmu_init(void);
 #endif /* ZEPHYR_ARCH_X86_INCLUDE_X86_MMU_H */

--- a/include/sys/device_mmio.h
+++ b/include/sys/device_mmio.h
@@ -88,7 +88,7 @@ static inline void device_map(mm_reg_t *virt_addr, uintptr_t phys_addr,
 	/* Pass along flags and add that we want supervisor mode
 	 * read-write access.
 	 */
-	k_mem_map((uint8_t **)virt_addr, phys_addr, size,
+	z_mem_map((uint8_t **)virt_addr, phys_addr, size,
 		  flags | K_MEM_PERM_RW);
 #else
 	ARG_UNUSED(size);

--- a/include/sys/mem_manage.h
+++ b/include/sys/mem_manage.h
@@ -84,7 +84,7 @@ extern "C" {
  * @param size Size of the memory region
  * @param flags Caching mode and access flags, see K_MAP_* macros
  */
-void k_mem_map(uint8_t **linear_addr, uintptr_t phys_addr, size_t size,
+void z_mem_map(uint8_t **linear_addr, uintptr_t phys_addr, size_t size,
 	       uint32_t flags);
 
 /**

--- a/include/sys/mem_manage.h
+++ b/include/sys/mem_manage.h
@@ -38,26 +38,6 @@
 /** Region will be accessible to user mode (normally supervisor-only) */
 #define K_MEM_PERM_USER		BIT(5)
 
-/*
- * This is the offset to subtract from a virtual address mapped in the
- * kernel's permanent mapping of RAM, to obtain its physical address.
- *
- *     virt_addr - Z_VM_OFFSET = phys_addr
- *
- * This only works for virtual addresses within the interval
- * [CONFIG_KERNEL_VM_BASE, CONFIG_KERNEL_VM_BASE + (CONFIG_SRAM_SIZE * 1024)).
- *
- * These macros are intended for assembly, linker code, and static initializers.
- * Use with care.
- */
-#ifdef CONFIG_MMU
-#define Z_MEM_VM_OFFSET	(CONFIG_KERNEL_VM_BASE - CONFIG_SRAM_BASE_ADDRESS)
-#else
-#define Z_MEM_VM_OFFSET	0
-#endif
-#define Z_MEM_PHYS_ADDR(virt)	((virt) - Z_MEM_VM_OFFSET)
-#define Z_MEM_VIRT_ADDR(phys)	((phys) + Z_MEM_VM_OFFSET)
-
 #ifndef _ASMLANGUAGE
 #include <stdint.h>
 #include <stddef.h>
@@ -122,38 +102,6 @@ void k_mem_map(uint8_t **linear_addr, uintptr_t phys_addr, size_t size,
  */
 size_t k_mem_region_align(uintptr_t *aligned_addr, size_t *aligned_size,
 			  uintptr_t addr, size_t size, size_t align);
-
-/* Just like Z_MEM_PHYS_ADDR() but with type safety and assertions */
-static inline uintptr_t z_mem_phys_addr(void *virt)
-{
-	uintptr_t addr = (uintptr_t)virt;
-
-#ifdef CONFIG_MMU
-	__ASSERT((addr >= CONFIG_KERNEL_VM_BASE) &&
-		 (addr < (CONFIG_KERNEL_VM_BASE + (CONFIG_SRAM_SIZE * 1024UL))),
-		 "address %p not in permanent mappings", virt);
-#else
-	/* Should be identity-mapped */
-	__ASSERT((addr >= CONFIG_SRAM_BASE_ADDRESS) &&
-		 (addr < (CONFIG_SRAM_BASE_ADDRESS +
-			  (CONFIG_SRAM_SIZE * 1024UL))),
-		 "physical address 0x%lx not in RAM",
-		 (unsigned long)addr);
-#endif /* CONFIG_MMU */
-
-	return Z_MEM_PHYS_ADDR(addr);
-}
-
-/* Just like Z_MEM_VIRT_ADDR() but with type safety and assertions */
-static inline void *z_mem_virt_addr(uintptr_t phys)
-{
-	__ASSERT((phys >= CONFIG_SRAM_BASE_ADDRESS) &&
-		 (phys < (CONFIG_SRAM_BASE_ADDRESS +
-			  (CONFIG_SRAM_SIZE * 1024UL))),
-		 "physical address 0x%lx not in RAM", (unsigned long)phys);
-
-	return (void *)Z_MEM_VIRT_ADDR(phys);
-}
 
 #ifdef __cplusplus
 }

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -244,7 +244,7 @@ static inline bool arch_is_in_isr(void);
  * This API is part of infrastructure still under development and may
  * change.
  *
- * @see k_mem_map()
+ * @see z_mem_map()
  *
  * @param dest Page-aligned Destination virtual address to map
  * @param addr Page-aligned Source physical address to map

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -47,7 +47,7 @@ static struct k_spinlock mm_lock;
 
  /* Current position for memory mappings in kernel memory.
   * At the moment, all kernel memory mappings are permanent.
-  * k_mem_map() mappings start at the end of the address space, and grow
+  * z_mem_map() mappings start at the end of the address space, and grow
   * downward.
   *
   * TODO: If we ever encounter a board with RAM in high enough memory
@@ -81,7 +81,7 @@ size_t k_mem_region_align(uintptr_t *aligned_addr, size_t *aligned_size,
 	return addr_offset;
 }
 
-void k_mem_map(uint8_t **virt_addr, uintptr_t phys_addr, size_t size,
+void z_mem_map(uint8_t **virt_addr, uintptr_t phys_addr, size_t size,
 	       uint32_t flags)
 {
 	uintptr_t aligned_addr, addr_offset;

--- a/tests/arch/x86/pagetables/src/main.c
+++ b/tests/arch/x86/pagetables/src/main.c
@@ -16,7 +16,7 @@
 #include <x86_mmu.h>
 #include <linker/linker-defs.h>
 
-#define VM_BASE		((uint8_t *)CONFIG_KERNEL_VM_BASE)
+#define VM_BASE		((uint8_t *)CONFIG_SRAM_BASE_ADDRESS)
 #define VM_LIMIT	(VM_BASE + KB((size_t)CONFIG_SRAM_SIZE))
 
 #ifdef CONFIG_X86_64

--- a/tests/kernel/mem_protect/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/mem_map/src/main.c
@@ -32,7 +32,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 }
 
 
-/* k_mem_map() doesn't have alignment requirements, any oddly-sized buffer
+/* z_mem_map() doesn't have alignment requirements, any oddly-sized buffer
  * can get mapped. This will span two pages.
  */
 #define BUF_SIZE	5003
@@ -43,7 +43,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_k_mem_map_rw(void)
+void test_z_mem_map_rw(void)
 {
 	uint8_t *mapped_rw, *mapped_ro;
 	uint8_t *buf = test_page + BUF_OFFSET;
@@ -51,7 +51,7 @@ void test_k_mem_map_rw(void)
 	expect_fault = false;
 
 	/* Map in a page that allows writes */
-	k_mem_map(&mapped_rw, (uintptr_t)buf,
+	z_mem_map(&mapped_rw, (uintptr_t)buf,
 		  BUF_SIZE, BASE_FLAGS | K_MEM_PERM_RW);
 
 	/* Initialize buf with some bytes */
@@ -60,7 +60,7 @@ void test_k_mem_map_rw(void)
 	}
 
 	/* Map again this time only allowing reads */
-	k_mem_map(&mapped_ro, (uintptr_t)buf,
+	z_mem_map(&mapped_ro, (uintptr_t)buf,
 		  BUF_SIZE, BASE_FLAGS);
 
 	/* Check that the mapped area contains the expected data. */
@@ -88,7 +88,7 @@ static void transplanted_function(bool *executed)
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_k_mem_map_exec(void)
+void test_z_mem_map_exec(void)
 {
 	uint8_t *mapped_rw, *mapped_exec, *mapped_ro;
 	bool executed = false;
@@ -97,13 +97,13 @@ void test_k_mem_map_exec(void)
 	expect_fault = false;
 
 	/* Map with write permissions and copy the function into the page */
-	k_mem_map(&mapped_rw, (uintptr_t)test_page,
+	z_mem_map(&mapped_rw, (uintptr_t)test_page,
 		  sizeof(test_page), BASE_FLAGS | K_MEM_PERM_RW);
 
 	memcpy(mapped_rw, &transplanted_function, CONFIG_MMU_PAGE_SIZE);
 
 	/* Now map with execution enabled and try to run the copied fn */
-	k_mem_map(&mapped_exec, (uintptr_t)test_page,
+	z_mem_map(&mapped_exec, (uintptr_t)test_page,
 		  sizeof(test_page), BASE_FLAGS | K_MEM_PERM_EXEC);
 
 	func = (void (*)(bool *executed))mapped_exec;
@@ -111,7 +111,7 @@ void test_k_mem_map_exec(void)
 	zassert_true(executed, "function did not execute");
 
 	/* Now map without execution and execution should now fail */
-	k_mem_map(&mapped_ro, (uintptr_t)test_page,
+	z_mem_map(&mapped_ro, (uintptr_t)test_page,
 		  sizeof(test_page), BASE_FLAGS);
 
 	func = (void (*)(bool *executed))mapped_ro;
@@ -122,7 +122,7 @@ void test_k_mem_map_exec(void)
 	ztest_test_fail();
 }
 #else
-void test_k_mem_map_exec(void)
+void test_z_mem_map_exec(void)
 {
 	ztest_test_skip();
 }
@@ -133,17 +133,17 @@ void test_k_mem_map_exec(void)
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_k_mem_map_side_effect(void)
+void test_z_mem_map_side_effect(void)
 {
 	uint8_t *mapped;
 
 	expect_fault = false;
 
-	/* k_mem_map() is supposed to always create fresh mappings.
+	/* z_mem_map() is supposed to always create fresh mappings.
 	 * Show that by mapping test_page to an RO region, we can still
 	 * modify test_page.
 	 */
-	k_mem_map(&mapped, (uintptr_t)test_page,
+	z_mem_map(&mapped, (uintptr_t)test_page,
 		  sizeof(test_page), BASE_FLAGS);
 
 	/* Should NOT fault */
@@ -160,9 +160,9 @@ void test_k_mem_map_side_effect(void)
 void test_main(void)
 {
 	ztest_test_suite(test_mem_map,
-			ztest_unit_test(test_k_mem_map_rw),
-			ztest_unit_test(test_k_mem_map_exec),
-			ztest_unit_test(test_k_mem_map_side_effect)
+			ztest_unit_test(test_z_mem_map_rw),
+			ztest_unit_test(test_z_mem_map_exec),
+			ztest_unit_test(test_z_mem_map_side_effect)
 			);
 	ztest_run_test_suite(test_mem_map);
 }

--- a/tests/kernel/mem_protect/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/mem_map/src/main.c
@@ -51,7 +51,7 @@ void test_k_mem_map_rw(void)
 	expect_fault = false;
 
 	/* Map in a page that allows writes */
-	k_mem_map(&mapped_rw, Z_MEM_PHYS_ADDR((uintptr_t)buf),
+	k_mem_map(&mapped_rw, (uintptr_t)buf,
 		  BUF_SIZE, BASE_FLAGS | K_MEM_PERM_RW);
 
 	/* Initialize buf with some bytes */
@@ -60,7 +60,7 @@ void test_k_mem_map_rw(void)
 	}
 
 	/* Map again this time only allowing reads */
-	k_mem_map(&mapped_ro, Z_MEM_PHYS_ADDR((uintptr_t)buf),
+	k_mem_map(&mapped_ro, (uintptr_t)buf,
 		  BUF_SIZE, BASE_FLAGS);
 
 	/* Check that the mapped area contains the expected data. */
@@ -97,13 +97,13 @@ void test_k_mem_map_exec(void)
 	expect_fault = false;
 
 	/* Map with write permissions and copy the function into the page */
-	k_mem_map(&mapped_rw, Z_MEM_PHYS_ADDR((uintptr_t)test_page),
+	k_mem_map(&mapped_rw, (uintptr_t)test_page,
 		  sizeof(test_page), BASE_FLAGS | K_MEM_PERM_RW);
 
 	memcpy(mapped_rw, &transplanted_function, CONFIG_MMU_PAGE_SIZE);
 
 	/* Now map with execution enabled and try to run the copied fn */
-	k_mem_map(&mapped_exec, Z_MEM_PHYS_ADDR((uintptr_t)test_page),
+	k_mem_map(&mapped_exec, (uintptr_t)test_page,
 		  sizeof(test_page), BASE_FLAGS | K_MEM_PERM_EXEC);
 
 	func = (void (*)(bool *executed))mapped_exec;
@@ -111,7 +111,7 @@ void test_k_mem_map_exec(void)
 	zassert_true(executed, "function did not execute");
 
 	/* Now map without execution and execution should now fail */
-	k_mem_map(&mapped_ro, Z_MEM_PHYS_ADDR((uintptr_t)test_page),
+	k_mem_map(&mapped_ro, (uintptr_t)test_page,
 		  sizeof(test_page), BASE_FLAGS);
 
 	func = (void (*)(bool *executed))mapped_ro;
@@ -143,7 +143,7 @@ void test_k_mem_map_side_effect(void)
 	 * Show that by mapping test_page to an RO region, we can still
 	 * modify test_page.
 	 */
-	k_mem_map(&mapped, Z_MEM_PHYS_ADDR((uintptr_t)test_page),
+	k_mem_map(&mapped, (uintptr_t)test_page,
 		  sizeof(test_page), BASE_FLAGS);
 
 	/* Should NOT fault */

--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -16,7 +16,7 @@
 #define FAULTY_ADDRESS 0x0FFFFFFF
 #elif CONFIG_MMU
 /* Just past the permanent RAM mapping should be a non-present page */
-#define FAULTY_ADDRESS (CONFIG_KERNEL_VM_BASE + (CONFIG_SRAM_SIZE * 1024UL))
+#define FAULTY_ADDRESS (CONFIG_SRAM_BASE_ADDRESS + (CONFIG_SRAM_SIZE * 1024UL))
 #else
 #define FAULTY_ADDRESS 0xFFFFFFF0
 #endif


### PR DESCRIPTION
With a plan for MMU support now in place for LTS2 (see #27819) we are not planning on having a split user/kernel address space.

Because of this, we can simplify some aspects of memory management. System RAM is now always identity mapped at boot.

We no longer require any virtual-to-physical translation for page tables, and can remove the dual-mapping logic from the page table generation script since we won't need to transition the instruction pointer off of physical addresses.

CONFIG_KERNEL_VM_BASE and CONFIG_KERNEL_VM_LIMIT have been removed. The kernel's address space always starts at CONFIG_SRAM_BASE_ADDRESS, of a fixed size specified by CONFIG_KERNEL_VM_SIZE. A large default of 3GB is provided for the address space size.

Driver MMIOs and other uses of k_mem_map() are still virtually mapped, and the later introduction of demand paging will result in only a subset of system RAM being a fixed identity mapping instead of all of it. But we don't have any need for the kernel itself to be linked anywhere other than its physical address.

For now, `k_mem_map()` is demoted to a private API `z_mem_map()` as we don't have application-facing uses for it at this time. This API has never been in an official release and is not subject to the deprecation process.

Should we ever change our minds about a split address space, the old code is in the git history and can be restored.

We can also in the future promote `z_mem_map()` back to public if we desire, but it's best to keep private for now as the API itself may undergo some changes in the next release.