### PR TITLE
x86: misc pedantic linker fixups

### DIFF
--- a/arch/x86/core/memmap.c
+++ b/arch/x86/core/memmap.c
@@ -13,7 +13,9 @@ struct x86_memmap_exclusion x86_memmap_exclusions[] = {
 #ifdef CONFIG_X86_64
 	{ "locore", _locore_start, _locore_end },
 #endif
+#ifdef CONFIG_XIP
 	{ "rom", _image_rom_start, _image_rom_end },
+#endif
 	{ "ram", _image_ram_start, _image_ram_end },
 #ifdef CONFIG_USERSPACE
 	{ "app_smem", _app_smem_start, _app_smem_end },

--- a/include/arch/x86/ia32/linker.ld
+++ b/include/arch/x86/ia32/linker.ld
@@ -87,9 +87,9 @@ SECTIONS
 #ifdef CONFIG_XIP
 	_image_rom_start = PHYS_LOAD_ADDR;
 #endif
-	_image_text_start = PHYS_LOAD_ADDR;
 	SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
 	{
+	_image_text_start = .;
 
 /* Located in generated directory. This file is populated by calling
  * zephyr_linker_sources(ROM_START ...). This typically contains the vector

--- a/include/arch/x86/ia32/linker.ld
+++ b/include/arch/x86/ia32/linker.ld
@@ -127,13 +127,6 @@ SECTIONS
 	*(".rodata.*")
 	*(.gnu.linkonce.r.*)
 
-#ifdef CONFIG_X86_MMU
-	. = ALIGN(4);
-	_mmu_region_list_start = .;
-	KEEP(*("._mmu_region.static.*"))
-	_mmu_region_list_end = .;
-#endif /* CONFIG_X86_MMU */
-
 #ifndef CONFIG_DYNAMIC_INTERRUPTS
 	. = ALIGN(8);
 	_idt_base_address = .;

--- a/include/arch/x86/ia32/linker.ld
+++ b/include/arch/x86/ia32/linker.ld
@@ -84,7 +84,9 @@ SECTIONS
 
 	. = ALIGN(8);
 
+#ifdef CONFIG_XIP
 	_image_rom_start = PHYS_LOAD_ADDR;
+#endif
 	_image_text_start = PHYS_LOAD_ADDR;
 	SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
 	{
@@ -162,9 +164,11 @@ SECTIONS
 
 	MMU_PAGE_ALIGN
 	/* ROM ends here, position counter will now be in RAM areas */
+#ifdef CONFIG_XIP
 	_image_rom_end = .;
 	_image_rom_size = _image_rom_end - _image_rom_start;
-	_image_rodata_end = _image_rom_end;
+#endif
+	_image_rodata_end = .;
 	_image_rodata_size = _image_rodata_end - _image_rodata_start;
 	GROUP_END(ROMABLE_REGION)
 	/*

--- a/include/arch/x86/intel64/linker.ld
+++ b/include/arch/x86/intel64/linker.ld
@@ -29,7 +29,7 @@ SECTIONS
 	 * ... there is no 16-bit code yet, but there will be when we add SMP.
 	 */
 
-	.locore 0x8000 : ALIGN(16)
+	.locore : ALIGN(16)
 	{
 	_locore_start = .;
 	*(.locore)
@@ -72,7 +72,7 @@ SECTIONS
 
 	MMU_PAGE_ALIGN
 	_lodata_end = .;
-	}
+	} > LOCORE
 
 	_locore_size = _lorodata_start - _locore_start;
 	_lorodata_size = _lodata_start - _lorodata_start;

--- a/include/arch/x86/memory.ld
+++ b/include/arch/x86/memory.ld
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2011-2014, Wind River Systems, Inc.
+ * Copyright (c) 2019-2020 Intel Corp.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file Directives for linker MEMORY regions for all x86
+ *
+ * By default, the kernel is linked at its physical address and all addresses
+ * are in RAM.
+ *
+ * If CONFIG_XIP is enabled, then another MEMORY region is declared for ROM,
+ * and this is where the Zephyr image is booted from. The linker LMAs and VMAs
+ * are set up, such that read/write data/bss have their VMA addresses
+ * in RAM and are copied from flash at boot. Text/rodata linked in-place in
+ * flash.
+ */
+
+#ifndef ARCH_X86_MEMORY_LD
+#define ARCH_X86_MEMORY_LD
+
+#include <autoconf.h>
+#include <devicetree.h>
+
+/* Bounds of physical RAM from DTS */
+#define PHYS_RAM_ADDR		DT_REG_ADDR(DT_CHOSEN(zephyr_sram))
+#define PHYS_RAM_SIZE		DT_REG_SIZE(DT_CHOSEN(zephyr_sram))
+
+#define KERNEL_BASE_ADDR  (PHYS_RAM_ADDR + CONFIG_X86_KERNEL_OFFSET)
+#define KERNEL_RAM_SIZE   (PHYS_RAM_SIZE - CONFIG_X86_KERNEL_OFFSET)
+
+#ifdef CONFIG_XIP
+  /* "ROM" is flash, we leave rodata and text there and just copy in data.
+   * Board-level DTS must specify a flash region that doesn't overlap with
+   * sram0, so that DT_PHYS_LOAD_ADDR is set.
+   */
+  #define FLASH_ROM_SIZE      DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
+  #define PHYS_LOAD_ADDR      DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
+#endif
+
+MEMORY
+    {
+#if defined(CONFIG_XIP)
+    /* Address range where the kernel will be installed on a flash part (XIP),
+     * or copied into physical RAM by a loader (MMU)
+     */
+    ROM (rx)        : ORIGIN = PHYS_LOAD_ADDR, LENGTH = FLASH_ROM_SIZE
+#endif
+    /* Linear address range to link the kernel. If non-XIP, everything is
+     * linked in this space. Otherwise, rodata and text are linked at their
+     * physical ROM locations
+     */
+    RAM (wx)        : ORIGIN = KERNEL_BASE_ADDR, LENGTH = KERNEL_RAM_SIZE
+
+#ifndef CONFIG_X86_64
+    /*
+     * Fake memory area for build-time IDT generation data
+     *
+     * It doesn't matter where this region goes as it is stripped from the
+     * final ELF image. The address doesn't even have to be valid on the
+     * target. However, it shouldn't overlap any other regions.
+     */
+
+    IDT_LIST        : ORIGIN = 0xFFFF1000, LENGTH = 2K
+#endif /* !CONFIG_X86_64 */
+    }
+#endif /* ARCH_X86_MEMORY_LD */

--- a/include/arch/x86/memory.ld
+++ b/include/arch/x86/memory.ld
@@ -40,6 +40,14 @@
   #define PHYS_LOAD_ADDR      DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
 #endif
 
+#ifdef CONFIG_X86_64
+/* Locore must be addressable by real mode and so cannot extend past 64K.
+ * Skip reserved stuff in the first page
+ */
+#define LOCORE_BASE         0x1000
+#define LOCORE_SIZE         (0x10000 - LOCORE_BASE)
+#endif
+
 MEMORY
     {
 #if defined(CONFIG_XIP)
@@ -54,9 +62,13 @@ MEMORY
      */
     RAM (wx)        : ORIGIN = KERNEL_BASE_ADDR, LENGTH = KERNEL_RAM_SIZE
 
-#ifndef CONFIG_X86_64
+#ifdef CONFIG_X86_64
+    /* Special low-memory area for bootstrapping other CPUs from real mode */
+    LOCORE (wx)     : ORIGIN = LOCORE_BASE, LENGTH = LOCORE_SIZE
+#else
     /*
-     * Fake memory area for build-time IDT generation data
+     * On 32-bit x86, fake memory area for build-time IDT generation data.
+     * 64-bit doesn't use this, interrupts are all manaaged at runtime.
      *
      * It doesn't matter where this region goes as it is stripped from the
      * final ELF image. The address doesn't even have to be valid on the

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -79,7 +79,7 @@
 	Z_ITERABLE_SECTION_ROM(z_object_assignment, 4)
 #endif
 
-	SECTION_PROLOGUE(app_shmem_regions,,)
+	SECTION_DATA_PROLOGUE(app_shmem_regions,,)
 	{
 		__app_shmem_regions_start = .;
 		KEEP(*(SORT(.app_regions.*)));

--- a/soc/x86/apollo_lake/linker.ld
+++ b/soc/x86/apollo_lake/linker.ld
@@ -5,28 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <autoconf.h>
-#include <devicetree.h>
-
-#define PHYS_RAM_ADDR		DT_REG_ADDR(DT_CHOSEN(zephyr_sram))
-#define PHYS_RAM_SIZE		DT_REG_SIZE(DT_CHOSEN(zephyr_sram))
-
-#define KERNEL_BASE_ADDR    (PHYS_RAM_ADDR + CONFIG_X86_KERNEL_OFFSET)
-#define KERNEL_RAM_SIZE     (PHYS_RAM_SIZE - CONFIG_X86_KERNEL_OFFSET)
-#define PHYS_LOAD_ADDR		KERNEL_BASE_ADDR
-
-MEMORY
-    {
-    RAM (wx)        : ORIGIN = KERNEL_BASE_ADDR, LENGTH = KERNEL_RAM_SIZE
-
-    /*
-     * It doesn't matter where this region goes as it is stripped from the
-     * final ELF image. The address doesn't even have to be valid on the
-     * target. However, it shouldn't overlap any other regions.
-     */
-
-    IDT_LIST        : ORIGIN = 2K, LENGTH = 2K
-    }
+#include <arch/x86/memory.ld>
 
 #ifdef CONFIG_X86_64
 #include <arch/x86/intel64/linker.ld>

--- a/soc/x86/atom/linker.ld
+++ b/soc/x86/atom/linker.ld
@@ -4,45 +4,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @file
- * @brief Linker command/script file
- *
- * This is the linker script for both standard images and XIP images.
- */
-
-#include <autoconf.h>
-#include <devicetree.h>
-
-
-/* physical address where the kernel is loaded */
-/* physical address of RAM */
-#define PHYS_RAM_ADDR		DT_REG_ADDR(DT_CHOSEN(zephyr_sram))
-#define PHYS_RAM_SIZE		DT_REG_SIZE(DT_CHOSEN(zephyr_sram))
-
-#define KERNEL_BASE_ADDR (PHYS_RAM_ADDR + CONFIG_X86_KERNEL_OFFSET)
-#define KERNEL_RAM_SIZE  (PHYS_RAM_SIZE - CONFIG_X86_KERNEL_OFFSET)
-
-#ifdef CONFIG_XIP
-  #define PHYS_LOAD_ADDR	DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
-#else  /* !CONFIG_XIP */
-  #define PHYS_LOAD_ADDR	KERNEL_BASE_ADDR
-#endif /* CONFIG_XIP */
-
-MEMORY
-    {
-#ifdef CONFIG_XIP
-    ROM (rx)        : ORIGIN = PHYS_LOAD_ADDR, LENGTH = DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
-#endif /* CONFIG_XIP */
-    RAM (wx)        : ORIGIN = KERNEL_BASE_ADDR, LENGTH = KERNEL_RAM_SIZE
-
-    /*
-     * It doesn't matter where this region goes as it is stripped from the
-     * final ELF image. The address doesn't even have to be valid on the
-     * target. However, it shouldn't overlap any other regions.
-     */
-
-    IDT_LIST        : ORIGIN = 2K, LENGTH = 2K
-    }
-
+#include <arch/x86/memory.ld>
 #include <arch/x86/ia32/linker.ld>

--- a/soc/x86/ia32/linker.ld
+++ b/soc/x86/ia32/linker.ld
@@ -4,48 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @file
- * @brief Linker command/script file
- *
- * This is the linker script for both standard images and XIP images.
- *
- * If XIP is turned on, board-level DTS must specify a flash region
- * that doesn't overlap with sram0, so that DT_PHYS_LOAD_ADDR is set.
- */
-
-#include <autoconf.h>
-#include <devicetree.h>
-
-/* physical address where the kernel is loaded */
-/* physical address of RAM */
-#define PHYS_RAM_ADDR		DT_REG_ADDR(DT_CHOSEN(zephyr_sram))
-#define PHYS_RAM_SIZE		DT_REG_SIZE(DT_CHOSEN(zephyr_sram))
-
-#define KERNEL_BASE_ADDR (PHYS_RAM_ADDR + CONFIG_X86_KERNEL_OFFSET)
-#define KERNEL_RAM_SIZE  (PHYS_RAM_SIZE - CONFIG_X86_KERNEL_OFFSET)
-
-#ifdef CONFIG_XIP
-  #define PHYS_LOAD_ADDR	DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
-#else  /* !CONFIG_XIP */
-  #define PHYS_LOAD_ADDR	KERNEL_BASE_ADDR
-#endif /* CONFIG_XIP */
-
-MEMORY
-    {
-#ifdef CONFIG_XIP
-    ROM (rx)        : ORIGIN = PHYS_LOAD_ADDR, LENGTH = DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
-#endif /* CONFIG_XIP */
-    RAM (wx)        : ORIGIN = KERNEL_BASE_ADDR, LENGTH = KERNEL_RAM_SIZE
-
-    /*
-     * It doesn't matter where this region goes as it is stripped from the
-     * final ELF image. The address doesn't even have to be valid on the
-     * target. However, it shouldn't overlap any other regions.
-     */
-
-    IDT_LIST        : ORIGIN = 0xFFFF1000, LENGTH = 2K
-    }
+#include <arch/x86/memory.ld>
 
 #ifdef CONFIG_X86_64
 #include <arch/x86/intel64/linker.ld>


### PR DESCRIPTION
This is really just some cleanup and none of these are known to be causing problems (although some of them did when experimenting with virtual linking of the kernel).

- Fix section declaration for app_shmem_regions
- Consolidate SOC-level linker.ld for x86
- Remove dead mmu_region_list code from 32-bit linker script
- Set _image_text_start to a linear address
- Add a proper MEMORY region for 64-bit's locore

Please review individual commit messages.