### PR TITLE
bluetooth: controller: add name to TX power choice

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -164,7 +164,7 @@ config BT_CTLR_TX_BUFFER_SIZE
 	  Maximum is set to 251 due to implementation limitations (use of
 	  uint8_t for length field in PDU buffer structure).
 
-choice
+choice BT_CTLR_TX_PWR
 	prompt "Tx Power"
 	default BT_CTLR_TX_PWR_0
 	help


### PR DESCRIPTION
Add a name to the Kconfig choice that selects the controller TX power.
This allows board `*.defconfig` files to change the default TX power
as their certifications warrant. For example:

```
choice BT_CTLR_TX_PWR
	default BT_CTLR_TX_PWR_PLUS_4
endchoice
```

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>