### PR TITLE
Bluetooth: Mesh: Remove bt_mesh_net_start to decoupling layers.

### DIFF
--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -24,6 +24,7 @@
 #include "adv.h"
 #include "prov.h"
 #include "net.h"
+#include "subnet.h"
 #include "app_keys.h"
 #include "rpl.h"
 #include "beacon.h"
@@ -344,7 +345,35 @@ static void model_start(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 
 int bt_mesh_start(void)
 {
-	bt_mesh_net_start();
+	if (bt_mesh_beacon_get() == BT_MESH_BEACON_ENABLED) {
+		bt_mesh_beacon_enable();
+	} else {
+		bt_mesh_beacon_disable();
+	}
+
+	if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY) &&
+	    bt_mesh_gatt_proxy_get() != BT_MESH_GATT_PROXY_NOT_SUPPORTED) {
+		bt_mesh_proxy_gatt_enable();
+		bt_mesh_adv_update();
+	}
+
+	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER)) {
+		bt_mesh_lpn_init();
+	} else {
+		bt_mesh_scan_enable();
+	}
+
+	if (IS_ENABLED(CONFIG_BT_MESH_FRIEND)) {
+		bt_mesh_friend_init();
+	}
+
+	if (IS_ENABLED(CONFIG_BT_MESH_PROV)) {
+		struct bt_mesh_subnet *sub = bt_mesh_subnet_next(NULL);
+		uint16_t addr = bt_mesh_primary_addr();
+
+		bt_mesh_prov_complete(sub->net_idx, addr);
+	}
+
 	bt_mesh_model_foreach(model_start, NULL);
 
 	return 0;

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -830,38 +830,6 @@ static void ivu_refresh(struct k_work *work)
 	}
 }
 
-void bt_mesh_net_start(void)
-{
-	if (bt_mesh_beacon_get() == BT_MESH_BEACON_ENABLED) {
-		bt_mesh_beacon_enable();
-	} else {
-		bt_mesh_beacon_disable();
-	}
-
-	if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY) &&
-	    bt_mesh_gatt_proxy_get() != BT_MESH_GATT_PROXY_NOT_SUPPORTED) {
-		bt_mesh_proxy_gatt_enable();
-		bt_mesh_adv_update();
-	}
-
-	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER)) {
-		bt_mesh_lpn_init();
-	} else {
-		bt_mesh_scan_enable();
-	}
-
-	if (IS_ENABLED(CONFIG_BT_MESH_FRIEND)) {
-		bt_mesh_friend_init();
-	}
-
-	if (IS_ENABLED(CONFIG_BT_MESH_PROV)) {
-		struct bt_mesh_subnet *sub = bt_mesh_subnet_next(NULL);
-		uint16_t addr = bt_mesh_primary_addr();
-
-		bt_mesh_prov_complete(sub->net_idx, addr);
-	}
-}
-
 void bt_mesh_net_init(void)
 {
 	k_delayed_work_init(&bt_mesh.ivu_timer, ivu_refresh);

--- a/subsys/bluetooth/mesh/net.h
+++ b/subsys/bluetooth/mesh/net.h
@@ -270,8 +270,6 @@ void bt_mesh_net_loopback_clear(uint16_t net_idx);
 
 uint32_t bt_mesh_next_seq(void);
 
-void bt_mesh_net_start(void);
-
 void bt_mesh_net_init(void);
 void bt_mesh_net_header_parse(struct net_buf_simple *buf,
 			      struct bt_mesh_net_rx *rx);


### PR DESCRIPTION
Remove `bt_mesh_net_start` to decoupling layers.

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>