### PR TITLE
Code guideline small fixes

### DIFF
--- a/lib/os/hex.c
+++ b/lib/os/hex.c
@@ -28,7 +28,7 @@ int hex2char(uint8_t x, char *c)
 {
 	if (x <= 9) {
 		*c = x + '0';
-	} else  if (x >= 10 && x <= 15) {
+	} else  if (x <= 15) {
 		*c = x - 10 + 'a';
 	} else {
 		return -EINVAL;

--- a/lib/os/work_q.c
+++ b/lib/os/work_q.c
@@ -49,7 +49,7 @@ void k_work_q_user_start(struct k_work_q *work_q, k_thread_stack_t *stack,
 	 * domain configuration of the caller
 	 */
 	k_thread_create(&work_q->thread, stack, stack_size, z_work_q_main,
-			work_q, 0, 0, prio, K_USER | K_INHERIT_PERMS,
+			work_q, NULL, NULL, prio, K_USER | K_INHERIT_PERMS,
 			K_FOREVER);
 	k_object_access_grant(&work_q->queue, &work_q->thread);
 	k_thread_name_set(&work_q->thread, WORKQUEUE_THREAD_NAME);


### PR DESCRIPTION
Small fixes picked from #18346

 - Use NULL instead of 0 for pointer 
 - Remove constant unecessary expression in an else statement