### PR TITLE
usb: Fix USB GetStatus(Device) request handling

### DIFF
--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -712,6 +712,10 @@ static bool usb_handle_std_device_req(struct usb_setup_packet *setup,
 		data[0] = 0U;
 		data[1] = 0U;
 
+		if (IS_ENABLED(CONFIG_USB_SELF_POWERED)) {
+			data[0] |= DEVICE_STATUS_SELF_POWERED;
+		}
+
 		if (IS_ENABLED(CONFIG_USB_DEVICE_REMOTE_WAKEUP)) {
 			data[0] |= (usb_dev.remote_wakeup ?
 				    DEVICE_STATUS_REMOTE_WAKEUP : 0);


### PR DESCRIPTION
The device returns 2 bytes for GetStatus(Device) request.
If the device is self-powered then it shall respond with
bit 0 set to 1 when responding to GetStatus(Device) req.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>

Closes: #27958