### PR TITLE
net: tcp2: Fix connection close seq values

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1308,7 +1308,8 @@ int net_tcp_put(struct net_context *context)
 	if (conn && conn->state == TCP_ESTABLISHED) {
 		k_mutex_lock(&conn->lock, K_FOREVER);
 
-		tcp_out(conn, FIN | ACK);
+		tcp_out_ext(conn, FIN | ACK, NULL,
+			    conn->seq + conn->unacked_len);
 		conn_seq(conn, + 1);
 
 		conn_state(conn, TCP_FIN_WAIT_1);


### PR DESCRIPTION
When connection is closed and we send ACK flag, use proper seq
values so that any data that is still in flight will get acked too.
Currently this assumes that window is still open.

Fixes #27876

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>