### PR TITLE
tests: net: af_packet: Fix the test when run in fast hw

### DIFF
--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -220,8 +220,14 @@ static void test_packet_sockets_dgram(void)
 	setblocking(sock2, false);
 	memset(&src, 0, sizeof(src));
 
-	ret = recvfrom(sock2, data_to_receive, sizeof(data_to_receive), 0,
-		       (struct sockaddr *)&src, &addrlen);
+	errno = 0;
+
+	do {
+		ret = recvfrom(sock2, data_to_receive, sizeof(data_to_receive),
+			       0, (struct sockaddr *)&src, &addrlen);
+		k_msleep(10);
+	} while (ret < 0 && errno == EAGAIN);
+
 	zassert_equal(ret, sizeof(data_to_send),
 		      "Cannot receive all data (%d vs %zd) (%d)",
 		      ret, sizeof(data_to_send), -errno);
@@ -244,8 +250,15 @@ static void test_packet_sockets_dgram(void)
 	zassert_equal(errno, EAGAIN, "Wrong errno (%d)", errno);
 
 	memset(&src, 0, sizeof(src));
-	ret = recvfrom(sock2, data_to_receive, sizeof(data_to_receive), 0,
-		       (struct sockaddr *)&src, &addrlen);
+
+	errno = 0;
+
+	do {
+		ret = recvfrom(sock2, data_to_receive, sizeof(data_to_receive),
+			       0, (struct sockaddr *)&src, &addrlen);
+		k_msleep(10);
+	} while (ret < 0 && errno == EAGAIN);
+
 	zassert_equal(ret, sizeof(data_to_send), "Cannot receive all data (%d)",
 		      -errno);
 }


### PR DESCRIPTION
If the recvfrom() in the test returns EAGAIN, try again in order
to make sure that we have really received the data.

Fixes #27963

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>