### PR TITLE
sanitycheck: Allow to pass command with argument to ser_pty

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -575,7 +575,7 @@ class DeviceHandler(Handler):
             master, slave = pty.openpty()
 
             try:
-                ser_pty_process = subprocess.Popen(serial_pty, stdout=master, stdin=master, stderr=master)
+                ser_pty_process = subprocess.Popen(re.split(',| ', serial_pty), stdout=master, stdin=master, stderr=master)
             except subprocess.CalledProcessError as error:
                 logger.error("Failed to run subprocess {}, error {}".format(serial_pty, error.output))
                 return


### PR DESCRIPTION
By default, subprocess.Popen commands are supplied as a list of strings.
Using split() allows to use command with arguments, for example it is
possible to use following:
```
sanitycheck ... --device-serial-pty="set_ambient read_terminal.py"  ...
```
or

```
sanitycheck ... --device-serial-pty="set_ambient,read_terminal.py"  ...
```