### PR TITLE
boards: mec1501modular: build without image gen tool

### DIFF
--- a/boards/arm/mec1501modular_assy6885/CMakeLists.txt
+++ b/boards/arm/mec1501modular_assy6885/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
     set(EVERGLADES_SPI_GEN_FILENAME everglades_spi_gen.exe)
   endif()
 
-  find_file(EVERGLADES_SPI_GEN_FINDFILE ${EVERGLADES_SPI_GEN_FILENAME})
+  find_file(EVERGLADES_SPI_GEN_FINDFILE ${EVERGLADES_SPI_GEN_FILENAME} NO_DEFAULT_PATH)
   if(EVERGLADES_SPI_GEN_FINDFILE STREQUAL EVERGLADES_SPI_GEN_FINDFILE-NOTFOUND)
     message(WARNING "Microchip SPI Image Generation tool (${EVERGLADES_SPI_GEN_FILENAME}) is not available. SPI Image will not be generated.")
   else()


### PR DESCRIPTION
Do not quit if there is no image generation tool, just report the issue
and continue. Happens on MacOS where there is no tool for generation the
SPI image.