### PR TITLE
k_thread_abort() cleanups and ARM latency fix

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/thread_abort.c
+++ b/arch/arm/core/aarch32/cortex_m/thread_abort.c
@@ -24,8 +24,6 @@
 #include <wait_q.h>
 #include <sys/__assert.h>
 
-extern void z_thread_single_abort(struct k_thread *thread);
-
 void z_impl_k_thread_abort(k_tid_t thread)
 {
 	z_thread_single_abort(thread);

--- a/arch/arm/core/aarch32/cortex_m/thread_abort.c
+++ b/arch/arm/core/aarch32/cortex_m/thread_abort.c
@@ -28,10 +28,6 @@ extern void z_thread_single_abort(struct k_thread *thread);
 
 void z_impl_k_thread_abort(k_tid_t thread)
 {
-	unsigned int key;
-
-	key = irq_lock();
-
 	__ASSERT(!(thread->base.user_options & K_ESSENTIAL),
 		 "essential thread aborted");
 
@@ -53,11 +49,10 @@ void z_impl_k_thread_abort(k_tid_t thread)
 			 */
 			SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;
 		} else {
-			(void)z_swap_irqlock(key);
-			CODE_UNREACHABLE;
+			z_swap_unlocked();
 		}
 	}
 
 	/* The abort handler might have altered the ready queue. */
-	z_reschedule_irqlock(key);
+	z_reschedule_unlocked();
 }

--- a/arch/arm/core/aarch32/cortex_m/thread_abort.c
+++ b/arch/arm/core/aarch32/cortex_m/thread_abort.c
@@ -28,11 +28,7 @@ extern void z_thread_single_abort(struct k_thread *thread);
 
 void z_impl_k_thread_abort(k_tid_t thread)
 {
-	__ASSERT(!(thread->base.user_options & K_ESSENTIAL),
-		 "essential thread aborted");
-
 	z_thread_single_abort(thread);
-	z_thread_monitor_exit(thread);
 
 	if (_current == thread) {
 		if (arch_is_in_isr()) {

--- a/arch/posix/core/posix_core.c
+++ b/arch/posix/core/posix_core.c
@@ -477,9 +477,6 @@ void posix_abort_thread(int thread_idx)
 
 
 #if defined(CONFIG_ARCH_HAS_THREAD_ABORT)
-
-extern void z_thread_single_abort(struct k_thread *thread);
-
 void z_impl_k_thread_abort(k_tid_t thread)
 {
 	unsigned int key;

--- a/arch/posix/core/posix_core.c
+++ b/arch/posix/core/posix_core.c
@@ -493,11 +493,7 @@ void z_impl_k_thread_abort(k_tid_t thread)
 
 	key = irq_lock();
 
-	__ASSERT(!(thread->base.user_options & K_ESSENTIAL),
-		 "essential thread aborted");
-
 	z_thread_single_abort(thread);
-	z_thread_monitor_exit(thread);
 
 	if (_current == thread) {
 		if (tstatus->aborted == 0) { /* LCOV_EXCL_BR_LINE */

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -63,6 +63,7 @@ void z_sched_abort(struct k_thread *thread);
 void z_sched_ipi(void);
 void z_sched_start(struct k_thread *thread);
 void z_ready_thread(struct k_thread *thread);
+void z_thread_single_abort(struct k_thread *thread);
 
 static inline void z_pend_curr_unlocked(_wait_q_t *wait_q, k_timeout_t timeout)
 {

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -479,6 +479,9 @@ static _wait_q_t *pended_on(struct k_thread *thread)
 
 void z_thread_single_abort(struct k_thread *thread)
 {
+	__ASSERT(!(thread->base.user_options & K_ESSENTIAL),
+		 "essential thread aborted");
+
 	if (thread->fn_abort != NULL) {
 		thread->fn_abort();
 	}
@@ -554,6 +557,7 @@ void z_thread_single_abort(struct k_thread *thread)
 	}
 
 	sys_trace_thread_abort(thread);
+	z_thread_monitor_exit(thread);
 }
 
 static void unready_thread(struct k_thread *thread)

--- a/kernel/thread_abort.c
+++ b/kernel/thread_abort.c
@@ -22,8 +22,6 @@
 #include <sys/__assert.h>
 #include <syscall_handler.h>
 
-extern void z_thread_single_abort(struct k_thread *thread);
-
 #if !defined(CONFIG_ARCH_HAS_THREAD_ABORT)
 void z_impl_k_thread_abort(k_tid_t thread)
 {

--- a/kernel/thread_abort.c
+++ b/kernel/thread_abort.c
@@ -27,11 +27,7 @@ extern void z_thread_single_abort(struct k_thread *thread);
 #if !defined(CONFIG_ARCH_HAS_THREAD_ABORT)
 void z_impl_k_thread_abort(k_tid_t thread)
 {
-	__ASSERT((thread->base.user_options & K_ESSENTIAL) == 0U,
-		 "essential thread aborted");
-
 	z_thread_single_abort(thread);
-	z_thread_monitor_exit(thread);
 
 	/* If we're in an interrupt handler, we reschedule on the way out
 	 * anyway, nothing needs to be done here.


### PR DESCRIPTION
- Move some copypasta in `k_thread_abort()` implementations to `z_thread_single_abort()`, which now has a prototype in ksched.h
- Document and clarify what's going on in the ARM implementation and why it is different
- Don't lock interrupts in the ARM implementation, improving latency, since the vanilla implementation doesn't do it