### PR TITLE
drivers: usb_dc_nrfx: Enable and properly initialize nrfx_power driver

### DIFF
--- a/drivers/clock_control/Kconfig.nrf
+++ b/drivers/clock_control/Kconfig.nrf
@@ -15,7 +15,6 @@ menuconfig CLOCK_CONTROL_NRF
 	depends on SOC_COMPATIBLE_NRF
 	depends on !CLOCK_CONTROL_NRF_FORCE_ALT
 	select NRFX_CLOCK
-	select NRFX_POWER
 	default y
 	help
 	  Enable support for the Nordic Semiconductor nRFxx series SoC clock

--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -53,8 +53,8 @@ menuconfig USB_NRFX
 	depends on HAS_HW_NRF_USBD
 	select USB_DEVICE_DRIVER
 	select NRFX_USBD
+	select NRFX_POWER
 	select USB_DEVICE_DISABLE_ZLP_EPIN_HANDLING
-	select NRFX_USBREG if SOC_SERIES_NRF53X
 	help
 	  nRF USB Device Controller Driver
 

--- a/modules/Kconfig.nordic
+++ b/modules/Kconfig.nordic
@@ -167,6 +167,9 @@ config NRFX_PDM
 config NRFX_POWER
 	bool "Enable POWER driver"
 	depends on HAS_HW_NRF_POWER
+	# On SoCs featuring the USBREG peripheral, the POWER driver uses
+	# internally the USBREG driver.
+	select NRFX_USBREG if HAS_HW_NRF_USBREG
 
 config NRFX_PPI
 	bool "Enable PPI allocator"

--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -186,16 +186,17 @@ typedef void (*vth)(void); /* Vector Table Handler */
  * Note: qemu_cortex_m0 uses TIMER0 to implement system timer.
  */
 void rtc_nrf_isr(void);
-void nrfx_clock_irq_handler(void);
+void nrfx_power_clock_irq_handler(void);
 #if defined(CONFIG_SOC_SERIES_NRF51X) || defined(CONFIG_SOC_SERIES_NRF52X)
 #if defined(CONFIG_BOARD_QEMU_CORTEX_M0)
 void timer0_nrf_isr(void);
 vth __irq_vector_table _irq_vector_table[] = {
-	nrfx_clock_irq_handler, 0, 0, 0, 0, 0, 0, 0, timer0_nrf_isr, isr0, isr1, isr2
+	nrfx_power_clock_irq_handler, 0, 0, 0, 0, 0, 0, 0,
+	timer0_nrf_isr, isr0, isr1, isr2
 };
 #else
 vth __irq_vector_table _irq_vector_table[] = {
-	nrfx_clock_irq_handler,
+	nrfx_power_clock_irq_handler,
 	isr0, isr1, isr2,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	rtc_nrf_isr
@@ -204,14 +205,14 @@ vth __irq_vector_table _irq_vector_table[] = {
 #elif defined(CONFIG_SOC_SERIES_NRF53X) || defined(CONFIG_SOC_SERIES_NRF91X)
 #ifndef CONFIG_SOC_NRF5340_CPUNET
 vth __irq_vector_table _irq_vector_table[] = {
-	0, 0, 0, 0, 0, nrfx_clock_irq_handler, 0, 0,
+	0, 0, 0, 0, 0, nrfx_power_clock_irq_handler, 0, 0,
 	isr0, isr1, isr2,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	rtc_nrf_isr
 };
 #else
 vth __irq_vector_table _irq_vector_table[] = {
-	0, 0, 0, 0, 0, nrfx_clock_irq_handler, 0, 0,
+	0, 0, 0, 0, 0, nrfx_power_clock_irq_handler, 0, 0,
 	isr0, isr1, isr2,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	rtc_nrf_isr


### PR DESCRIPTION
This is a follow-up to commit 701e9befe4c8ae10009a56de281d1326bb022eb8.

The NRFX_POWER Kconfig option should be enabled together with USB_NRFX,
not with CLOCK_CONTROL_NRF, as the USB driver is the actual user of
the nrfx POWER driver.

This patch adds also missing initialization of the nrfx POWER driver
and refactors a bit the usb_init() function introduced in the commit
mentioned above, so that it does not redefine the DT_DRV_COMPAT macro
and uses for conditional compilation the same Kconfig option that is
the dependency of NRFX_USBREG.

As a prerequisite, a missing dependency in 'modules/Kconfig.nordic' is added.