### PR TITLE
Bluetooth: GATT: Handle bt/ccc setting with CCC lazy loading

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -4277,6 +4277,11 @@ next:
 static int ccc_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 		   void *cb_arg)
 {
+	if (IS_ENABLED(CONFIG_BT_SETTINGS_CCC_LAZY_LOADING)) {
+		/* Only load CCCs on demand */
+		return 0;
+	}
+
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		struct ccc_store ccc_store[CCC_STORE_MAX];
 		struct ccc_load load;
@@ -4334,10 +4339,7 @@ static int ccc_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 	return 0;
 }
 
-#if !IS_ENABLED(CONFIG_BT_SETTINGS_CCC_LAZY_LOADING)
-/* Only register the ccc_set settings handler when not loading on-demand */
 SETTINGS_STATIC_HANDLER_DEFINE(bt_ccc, "bt/ccc", NULL, ccc_set, NULL, NULL);
-#endif /* CONFIG_BT_SETTINGS_CCC_LAZY_LOADING */
 
 static int ccc_set_direct(const char *key, size_t len, settings_read_cb read_cb,
 			  void *cb_arg, void *param)


### PR DESCRIPTION
When lazy loading of CCCs are enabled there is no settings set handler
register for the 'bt/ccc' key, this means that the settings set handler
for 'bt' key is called instead. This handler does not know what to do
for the 'ccc' subkey, and returns -ENOENT for the entry.
This results in an error message logged by the settings subsystem.
  "E: set-value failure. key: bt/ccc/f8c39e2f98210 error(-2)"

Fix this by providing an empty handler for the 'bt/ccc' key when
Lazy Loading feature is enabled.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>