### PR TITLE
arm: mcux (RT1060 EVK) fix USB fail when using on-chip memory, fix #27268

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/aarch32/cortex_m/mpu/arm_mpu.c
@@ -323,6 +323,10 @@ static int arm_mpu_init(const struct device *arg)
 
 	arm_core_mpu_disable();
 
+#if defined(CONFIG_NOCACHE_MEMORY)
+	SCB_CleanInvalidateDCache();
+#endif
+
 	/* Architecture-specific configuration */
 	mpu_init();
 


### PR DESCRIPTION
Adds the couple SCB_DisableDcache & SCB_EnableDcache when
config the non-cache area

Signed-off-by: Crist Xu <crist.xu@nxp.com>