### PR TITLE
drivers: eeprom: reduce priority of at2x initialization

### DIFF
--- a/drivers/eeprom/Kconfig
+++ b/drivers/eeprom/Kconfig
@@ -49,6 +49,11 @@ config EEPROM_AT25
 	help
 	  Enable support for Atmel AT25 (and compatible) SPI EEPROMs.
 
+config EEPROM_AT2X_INIT_PRIORITY
+	int "AT2X EEPROM init priority"
+	default 75
+	depends on EEPROM_AT2X
+
 source "drivers/eeprom/Kconfig.lpc11u6x"
 source "drivers/eeprom/Kconfig.stm32"
 

--- a/drivers/eeprom/eeprom_at2x.c
+++ b/drivers/eeprom/eeprom_at2x.c
@@ -605,7 +605,7 @@ static const struct eeprom_driver_api eeprom_at2x_api = {
 			    DT_LABEL(INST_DT_AT2X(n, t)), \
 			    &eeprom_at2x_init, &eeprom_at##t##_data_##n, \
 			    &eeprom_at##t##_config_##n, POST_KERNEL, \
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+			    CONFIG_EEPROM_AT2X_INIT_PRIORITY, \
 			    &eeprom_at2x_api)
 
 #define EEPROM_AT24_DEVICE(n) EEPROM_AT2X_DEVICE(n, 24)


### PR DESCRIPTION
The default priority for I2C controller initialization is POST_KERNEL 60 (SPI 70), while the default priority for device configuration is POST_KERNEL 50.  Thus the EEPROM is being initialized before its controller.  While for this driver that wouldn't be an issue recent changes mean the device lookup returns NULL before the device is initialized.

Change the AT2X priority to 90 which matches the default sensor init priority (most sensor devices are children of I2C or SPI buses).

Relates to #27985 and fixes a buildkite error in #27977.