### PR TITLE
kernel: Deprecate Single Thread mode (CONFIG_MULTITHREADING=n)

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -50,6 +50,10 @@ if(${CONFIG_KERNEL_MEM_POOL})
   endif()
 endif()
 
+if(NOT CONFIG_MULTITHREADING)
+  message(WARNING "Single threaded mode (CONFIG_MULTITHREADING=n) is deprecated")
+endif()
+
 # The last 2 files inside the target_sources_ifdef should be
 # userspace_handler.c and userspace.c. If not the linker would complain.
 # This order has to be maintained. Any new file should be placed

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -10,9 +10,11 @@ module-str = kernel
 source "subsys/logging/Kconfig.template.log_config"
 
 config MULTITHREADING
-	bool "Multi-threading"
+	bool "Multi-threading (DEPRECATED)"
 	default y
 	help
+	  Disabling this option is DEPRECATED.
+
 	  If disabled, only the main thread is available, so a main() function
 	  must be provided. Interrupts are available. Kernel objects will most
 	  probably not behave as expected, especially with regards to pending,
@@ -22,6 +24,11 @@ config MULTITHREADING
 	  Many drivers and subsystems will not work with this option
 	  set to 'n'; disable only when you REALLY know what you are
 	  doing.
+
+if !MULTITHREADING
+comment "*** WARNING ***"
+comment "Single threaded mode (MULTITHREADING option disabled) is deprecated"
+endif
 
 config NUM_COOP_PRIORITIES
 	int "Number of coop priorities" if MULTITHREADING

--- a/samples/hello_world/prj.conf
+++ b/samples/hello_world/prj.conf
@@ -1,1 +1,2 @@
 # nothing here
+CONFIG_MULTITHREADING=n


### PR DESCRIPTION
Deprecate the Kconfig option for the time being. Unless a contributor
volunteers to take over the work to maintain the option, it will be
removed after 2 releases.

Relates to #27415.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>