### PR TITLE
drivers: winc1500: Fix signed/unsigned comparison

### DIFF
--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -298,19 +298,21 @@ static int winc1500_get(sa_family_t family,
 			struct net_context **context)
 {
 	struct socket_data *sd;
+	SOCKET sock;
 
 	if (family != AF_INET) {
 		LOG_ERR("Only AF_INET is supported!");
 		return -1;
 	}
 
-	(*context)->offload_context = (void *)(sint32)socket(family, type, 0);
-	if ((*context)->offload_context < 0) {
+	sock = socket(family, type, 0);
+	if (sock < 0) {
 		LOG_ERR("socket error!");
 		return -1;
 	}
 
-	sd = &w1500_data.socket_data[(int)(*context)->offload_context];
+	(*context)->offload_context = (void *)(intptr_t)sock;
+	sd = &w1500_data.socket_data[sock];
 
 	k_sem_init(&sd->wait_sem, 0, 1);
 


### PR DESCRIPTION
The value from socket() was directly assigned to offload_context, which
was treated as a unsigned integer when compared. This prevented the
following if statement from catching any errors, leading to random RAM
access. This is fixed by using an intermediate with the same type as the
return value, which is then assigned to offload_context after error
checking.

Signed-off-by: Abram Early <abram.early@gmail.com>