### PR TITLE
drivers: i2c: document "slave" API

### DIFF
--- a/doc/guides/coding_guidelines/index.rst
+++ b/doc/guides/coding_guidelines/index.rst
@@ -824,6 +824,8 @@ their documentation from being generated. Their absence also prevents use of
 ``if (IS_ENABLED(CONFIG_FOO)) {}`` as an alternative to preprocessor
 conditionals when the code path should change based on the selected options.
 
+.. _coding_guideline_inclusive_language:
+
 Rule A.2: Inclusive Language
 ============================
 

--- a/doc/guides/coding_guidelines/index.rst
+++ b/doc/guides/coding_guidelines/index.rst
@@ -918,6 +918,8 @@ Related GitHub Issues and Pull Requests are tagged with the `Inclusive Language 
        terminology is confirmed by a public announcement or updated
        specification.
 
+       See `Zephyr issue 27033`_.
+
    * - :ref:`i2s_api`
      - * ``master / slave`` => TBD
      -
@@ -941,3 +943,4 @@ Related GitHub Issues and Pull Requests are tagged with the `Inclusive Language 
 .. _I2C Specification: https://www.nxp.com/docs/en/user-guide/UM10204.pdf
 .. _Bluetooth Appropriate Language Mapping Tables: https://btprodspecificationrefs.blob.core.windows.net/language-mapping/Appropriate_Language_Mapping_Table.pdf
 .. _OSHWA Resolution to Redefine SPI Signal Names: https://www.oshwa.org/a-resolution-to-redefine-spi-signal-names/
+.. _Zephyr issue 27033: https://github.com/zephyrproject-rtos/zephyr/issues/27033

--- a/doc/reference/overview.rst
+++ b/doc/reference/overview.rst
@@ -157,6 +157,11 @@ current :ref:`stability level <api_lifecycle>`.
      - 1.0
      - 2.4
 
+   * - :ref:`i2c-slave-api`
+     - Experimental
+     - 1.12
+     - 1.12
+
    * - :ref:`i2s_api`
      - Stable
      - 1.9

--- a/doc/reference/peripherals/i2c.rst
+++ b/doc/reference/peripherals/i2c.rst
@@ -1,11 +1,56 @@
 .. _i2c_api:
 
-
 I2C
 ####
 
 Overview
 ********
+
+.. note::
+
+   Zephyr recognizes the need to change the terms "master" and "slave"
+   used in the current `I2C Specification <i2c-specification>`_.  This
+   will be done when the conditions identified in
+   :ref:`coding_guideline_inclusive_language` have been met.  Existing
+   documentation, data structures, functions, and value symbols in code
+   are likely to change at that point.
+
+`I2C <i2c-specification>`_ (Inter-Integrated Circuit, pronounced "eye
+squared see") is a commonly-used two-signal shared peripheral interface
+bus.  Many system-on-chip solutions provide controllers that communicate
+on an I2C bus.  Devices on the bus can operate in two roles: as a
+"master" that initiates transactions and controls the clock, or as a
+"slave" that responds to transaction commands.  A I2C controller on a
+given SoC will generally support the master role, and some will also
+support the slave mode.  Zephyr has API for both roles.
+
+.. _i2c-master-api:
+
+I2C Master API
+==============
+
+Zephyr's I2C master API is used when an I2C peripheral controls the bus,
+in particularly the start and stop conditions and the clock.  This is
+the most common mode, used to interact with I2C devices like sensors and
+serial memory.
+
+This API is supported in all in-tree I2C peripheral drivers and is
+considered stable.
+
+.. _i2c-slave-api:
+
+I2C Slave API
+================
+
+Zephyr's I2C slave API is used when an I2C peripheral responds to
+transactions initiated by a different controller on the bus.  It might
+be used for a Zephyr application with transducer roles that are
+controlled by another device such as a host processor.
+
+This API is supported in very few in-tree I2C peripheral drivers.  The
+API is considered experimental, as it is not compatible with the
+capabilities of all I2C peripherals supported in master mode.
+
 
 Configuration Options
 *********************
@@ -19,3 +64,6 @@ API Reference
 
 .. doxygengroup:: i2c_interface
    :project: Zephyr
+
+.. _i2c-specification:
+   https://www.nxp.com/docs/en/user-guide/UM10204.pdf

--- a/drivers/i2c/i2c_litex.c
+++ b/drivers/i2c/i2c_litex.c
@@ -110,8 +110,6 @@ static int i2c_litex_transfer(const struct device *dev,  struct i2c_msg *msgs,
 static const struct i2c_driver_api i2c_litex_driver_api = {
 	.configure         = i2c_litex_configure,
 	.transfer          = i2c_litex_transfer,
-	.slave_register    = NULL,
-	.slave_unregister  = NULL,
 };
 
 /* Device Instantiation */

--- a/tests/drivers/i2c/i2c_slave_api/README.txt
+++ b/tests/drivers/i2c/i2c_slave_api/README.txt
@@ -1,16 +1,19 @@
 I2C Slave API test
 ##################
 
+.. note:
+   See :ref:`coding_guideline_inclusive_language` for information about
+   plans to change the terminology used in this API.
+
 This test verifies I2C slave driver implementations using two I2C
 controllers on a common bus.  The test is supported by a test-specific
-driver that simulates an EEPROM with an I2C bus follower ("slave")
-interface.  Data is pre-loaded into the simulated devices outside the
-I2C API, and the Zephyr application issues commands to one controller
-that are responded to by the simulated EEPROM connected through the
-other controller.
+driver that simulates an EEPROM with an I2C bus slave interface.  Data
+is pre-loaded into the simulated devices outside the I2C API, and the
+Zephyr application issues commands to one controller that are responded
+to by the simulated EEPROM connected through the other controller.
 
 This test was originally designed for I2C controllers that support both
-leader and follower behavior simultaneously.  This is not true of all
+master and slave behavior simultaneously.  This is not true of all
 I2C controllers, so this behavior is now opt-in using
 CONFIG_APP_DUAL_ROLE_I2C.  However, the devicetree still must provide a
 second EEPROM just to identify the bus.
@@ -19,13 +22,14 @@ In slightly more detail the test has these phases:
 
 * Use API specific to the simulated EEPROM to pre-populate the simulated
   devices with device-specific content.
-* Register a simulated EEPROM as a I2C follower device on a bus.  If
+* Register a simulated EEPROM as a I2C slave device on a bus.  If
   CONFIG_APP_DUAL_ROLE_I2C is selected, register both.
-* Issue commands on one bus controller (operating as the bus leader
-  (master)) and verify that the data supplied by the other controller
-  (as bus follower) match the expected values given the content known to
-  be present on the simulated device.  If CONFIG_APP_DUAL_ROLE_I2C is
-  selected, do this with the roles reversed.
+
+* Issue commands on one bus controller (operating as the bus master) and
+  verify that the data supplied by the other controller (slave) match
+  the expected values given the content known to be present on the
+  simulated device.  If CONFIG_APP_DUAL_ROLE_I2C is selected, do this
+  with the roles reversed.
 
 Transfer of commands from one bus controller to the other is
 accomplished by hardware through having the SCL (and SDA) signals

--- a/tests/drivers/i2c/i2c_slave_api/common/Kconfig
+++ b/tests/drivers/i2c/i2c_slave_api/common/Kconfig
@@ -16,4 +16,4 @@ config I2C_VIRTUAL_NAME
 	depends on I2C_VIRTUAL
 
 config APP_DUAL_ROLE_I2C
-	bool "Enable test with combined leader/follower behavior"
+	bool "Enable test with combined master/slave behavior"

--- a/tests/drivers/i2c/i2c_slave_api/src/main.c
+++ b/tests/drivers/i2c/i2c_slave_api/src/main.c
@@ -175,7 +175,7 @@ void test_eeprom_slave(void)
 		zassert_equal(ret, 0, "Failed to program EEPROM %s", label_1);
 	}
 
-	/* Attach each EEPROM to its owning bus as a follower device. */
+	/* Attach each EEPROM to its owning bus as a slave device. */
 	ret = i2c_slave_driver_register(eeprom_0);
 	zassert_equal(ret, 0, "Failed to register EEPROM %s", label_0);
 
@@ -184,14 +184,14 @@ void test_eeprom_slave(void)
 		zassert_equal(ret, 0, "Failed to register EEPROM %s", label_1);
 	}
 
-	/* The simulated EP0 is configured to be accessed as a follower device
+	/* The simulated EP0 is configured to be accessed as a slave device
 	 * at addr_0 on i2c_0 and should expose eeprom_0_data.  The validation
-	 * uses i2c_1 as a bus leader to access this device, which works because
+	 * uses i2c_1 as a bus master to access this device, which works because
 	 * i2c_0 and i2_c have their SDA (SCL) pins shorted (they are on the
-	 * same physical bus).  Thus in these calls i2c_1 is a leader device
-	 * operating on the follower address addr_0.
+	 * same physical bus).  Thus in these calls i2c_1 is a master device
+	 * operating on the slave address addr_0.
 	 *
-	 * Similarly validation of EP1 uses i2c_0 as a leader with addr_1 and
+	 * Similarly validation of EP1 uses i2c_0 as a master with addr_1 and
 	 * eeprom_1_data for validation.
 	 */
 	ret = run_full_read(i2c_1, addr_0, eeprom_0_data);


### PR DESCRIPTION
Document the API used for I2C slave devices.  Fill out the peripheral documentation with a reference to the I2C specification, a short summary of the roles of I2C devices, and a note on language used.  Remove some stubs from drivers that don't implement the slave API.  The focus of the PR is documenting the existing following API, not documenting the I2C subsystem as a whole.

The PR includes a change that distinguishes the slave API as Experimental in the API stability table, as it is not satisfactory and has limited support.  See also #27675.

The documented behavior is derived primarily from the LPC11U6X implementation, as the STM32 implementation generally ignores return values.  There may be errors in the description, and there are certainly gaps in the existing driver implementations.

Updated 2021-02-06 to revert to "master/slave" terminology in conformance to [the coding guidelines](https://docs.zephyrproject.org/latest/guides/coding_guidelines/index.html?highlight=inclusive#rule-a-2-inclusive-language).

Fixes #27879
References #27033
