### PR TITLE
drivers: clk_ctrl: npcx: fixed 'line length exceeds 80 columns' warning.

### DIFF
--- a/drivers/clock_control/clock_control_npcx.c
+++ b/drivers/clock_control/clock_control_npcx.c
@@ -154,7 +154,7 @@ const struct npcx_pcc_config pcc_config = {
 	.base_pmc  = DT_INST_REG_ADDR_BY_NAME(0, pmc),
 };
 
-DEVICE_AND_API_INIT(npcx_cdcg, NPCX_CLOCK_CONTROL_NAME,
+DEVICE_AND_API_INIT(npcx_cdcg, NPCX_CLK_CTRL_NAME,
 		    &npcx_clock_control_init,
 		    NULL, &pcc_config,
 		    PRE_KERNEL_1,

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -291,7 +291,7 @@ static int uart_npcx_init(const struct device *dev)
 	const struct uart_npcx_config *config = DRV_CONFIG(dev);
 	const struct uart_npcx_data *data = DRV_DATA(dev);
 	struct uart_reg *inst = HAL_INSTANCE(dev);
-	const struct device *clk_dev = device_get_binding(NPCX_CLOCK_CONTROL_NAME);
+	const struct device *clk_dev = device_get_binding(NPCX_CLK_CTRL_NAME);
 	uint32_t uart_rate;
 
 	/* Turn on device clock first */

--- a/soc/arm/nuvoton_npcx/common/soc_clock.h
+++ b/soc/arm/nuvoton_npcx/common/soc_clock.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 /* Common clock control device name for all NPCX series */
-#define NPCX_CLOCK_CONTROL_NAME "npcx-cc"
+#define NPCX_CLK_CTRL_NAME "npcx-cc"
 
 /**
  * @brief NPCX clock configuration structure


### PR DESCRIPTION
It's a minor PR to fix 'line length exceeds 80 columns' warning by shortening the clock controller device name directly.
During reviewing the [PR 24873](https://github.com/zephyrproject-rtos/zephyr/pull/24873/files), I browsed what it did by searching 'npcx' in 'File Changed' tab and found nothing. It might contain too many changes and hide them automatically. I will notice it next time.