### PR TITLE
tracing: swap: bug fix and enhancement for ARC

### DIFF
--- a/arch/arc/core/fast_irq.S
+++ b/arch/arc/core/fast_irq.S
@@ -273,6 +273,13 @@ _firq_switch_from_coop:
 	pop_s r0 /* status32 into r0 */
 	sr r0, [_ARC_V2_STATUS32_P0]
 
+#ifdef CONFIG_TRACING
+	push_s blink
+
+	bl sys_trace_thread_switched_in
+
+	pop_s blink
+#endif
 	rtie
 
 .balign 4
@@ -287,5 +294,12 @@ _firq_switch_from_firq:
 	sr ilink, [_ARC_V2_STATUS32_P0]
 	ld ilink, [sp, -8] /* pc into ilink */
 
+#ifdef CONFIG_TRACING
+	push_s blink
+
+	bl sys_trace_thread_switched_in
+
+	pop_s blink
+#endif
 	/* LP registers are already restored, just switch back to bank 0 */
 	rtie

--- a/arch/arc/core/regular_irq.S
+++ b/arch/arc/core/regular_irq.S
@@ -309,6 +309,13 @@ _rirq_switch_from_coop:
 	 */
 	st_s r13, [sp, ___isf_t_r13_OFFSET]
 
+#ifdef CONFIG_TRACING
+	push_s blink
+
+	bl sys_trace_thread_switched_in
+
+	pop_s blink
+#endif
 	/* stack now has the IRQ stack frame layout, pointing to sp */
 	/* rtie will pop the rest from the stack */
 	rtie
@@ -319,5 +326,12 @@ _rirq_switch_from_rirq:
 
 	_set_misc_regs_irq_switch_from_irq
 
+#ifdef CONFIG_TRACING
+	push_s blink
+
+	bl sys_trace_thread_switched_in
+
+	pop_s blink
+#endif
 _rirq_no_switch:
 	rtie

--- a/arch/arc/core/switch.S
+++ b/arch/arc/core/switch.S
@@ -132,6 +132,13 @@ _switch_return_from_coop:
 
 	pop_s blink
 #endif /* CONFIG_EXECUTION_BENCHMARKING */
+#ifdef CONFIG_TRACING
+	push_s blink
+
+	bl sys_trace_thread_switched_in
+
+	pop_s blink
+#endif
 	j_s [blink]
 
 
@@ -160,5 +167,12 @@ _switch_return_from_firq:
 	sjli SJLI_CALL_ARC_SECURE
 #else
 	sr r3, [_ARC_V2_AUX_IRQ_ACT]
+#endif
+#ifdef CONFIG_TRACING
+	push_s blink
+
+	bl sys_trace_thread_switched_in
+
+	pop_s blink
 #endif
 	rtie

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -117,7 +117,7 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 		wait_for_switch(new_thread);
 		arch_switch(new_thread->switch_handle,
 			     &old_thread->switch_handle);
-		sys_trace_thread_switched_in();
+
 	}
 
 	if (is_spinlock) {

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -825,6 +825,7 @@ struct k_thread *z_get_next_ready_thread(void)
 /* Just a wrapper around _current = xxx with tracing */
 static inline void set_current(struct k_thread *new_thread)
 {
+	sys_trace_thread_switched_out();
 	_current_cpu->current = new_thread;
 }
 
@@ -858,7 +859,10 @@ void *z_get_next_switch_handle(void *interrupted)
 		}
 	}
 #else
-	set_current(z_get_next_ready_thread());
+	struct k_thread *thread = z_get_next_ready_thread();
+	if (_current != thread) {
+		set_current(thread);
+	}
 #endif
 
 	wait_for_switch(_current);


### PR DESCRIPTION
Describe in #27771 cpu_stats profiling function doesn’t work as expected. we need to do some fixes.

For regular context switch: 
move switched_in into the arch context switch assembly code, 
which will correctly record the switched_in information.

For irq context switch: 
add switched_in/switched_out for context switch in irq exit.

Fixes: #27771 