### PR TITLE
pyocd --pack support for nucleo boards

### DIFF
--- a/boards/arm/nucleo_g071rb/board.cmake
+++ b/boards/arm/nucleo_g071rb/board.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-board_runner_args(pyocd "--target=stm32g071rb")
+board_runner_args(pyocd "--target=stm32g071rbtx")
 board_runner_args(pyocd "--flash-opt=-O reset_type=hw")
 board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 

--- a/boards/arm/nucleo_g071rb/doc/index.rst
+++ b/boards/arm/nucleo_g071rb/doc/index.rst
@@ -144,6 +144,7 @@ the following pyocd command:
 
 .. code-block:: console
 
+   $ pyocd pack --update
    $ pyocd pack --install stm32g071rb
 
 Note:

--- a/boards/arm/nucleo_g431rb/doc/index.rst
+++ b/boards/arm/nucleo_g431rb/doc/index.rst
@@ -195,6 +195,7 @@ the following pyocd command:
 
 .. code-block:: console
 
+   $ pyocd pack --update
    $ pyocd pack --install stm32g431rb
 
 Note:

--- a/boards/arm/nucleo_g474re/doc/index.rst
+++ b/boards/arm/nucleo_g474re/doc/index.rst
@@ -195,6 +195,7 @@ the following pyocd command:
 
 .. code-block:: console
 
+   $ pyocd pack --update
    $ pyocd pack --install stm32g474re
 
 Note:

--- a/boards/arm/nucleo_l552ze_q/doc/nucleol552ze_q.rst
+++ b/boards/arm/nucleo_l552ze_q/doc/nucleol552ze_q.rst
@@ -240,6 +240,7 @@ the following pyocd command:
 
 .. code-block:: console
 
+   $ pyocd pack --update
    $ pyocd pack --install stm32l552ze
 
 Nucleo L552ZE Q board includes an ST-LINK/V2-1 embedded debug tool

--- a/boards/arm/nucleo_wb55rg/doc/nucleo_wb55rg.rst
+++ b/boards/arm/nucleo_wb55rg/doc/nucleo_wb55rg.rst
@@ -250,6 +250,7 @@ the following pyocd command:
 
 .. code-block:: console
 
+   $ pyocd pack --update
    $ pyocd pack --install stm32wb55rg
 
 

--- a/boards/arm/stm32g0316_disco/doc/index.rst
+++ b/boards/arm/stm32g0316_disco/doc/index.rst
@@ -95,6 +95,7 @@ the following pyocd command:
 
 .. code-block:: console
 
+   $ pyocd pack --update
    $ pyocd pack --install stm32g031j6
 
 Flashing an application to the STM32G0316-DISCO


### PR DESCRIPTION
-Fix pyocd command for nucleo_g071rb board
-Recommand use of --pack update command before pack --install