### PR TITLE
tests: net: dns_packet: Disable Ethernet when test is run

### DIFF
--- a/tests/net/lib/dns_packet/prj.conf
+++ b/tests/net/lib/dns_packet/prj.conf
@@ -1,6 +1,7 @@
 # required for htons
 CONFIG_NETWORKING=y
 CONFIG_NET_TEST=y
+CONFIG_NET_L2_ETHERNET=n
 
 # native IP stack support
 CONFIG_ENTROPY_GENERATOR=y


### PR DESCRIPTION
The test was failing when run in sam_e70_xplained board.
Because the test does not use any network packet TX/RX functionality,
disable Ethernet support so that when run in a board with network
capabilities, the network interface is not created.

Fixes #28000

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>