### PR TITLE
net: lwm2m: Fix FOTA Pull firmware transfer when Package URI is empty

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -247,7 +247,10 @@ static int package_uri_write_cb(uint16_t obj_inst_id, uint16_t res_id,
 
 	if (state == STATE_IDLE) {
 		lwm2m_firmware_set_update_result(RESULT_DEFAULT);
-		lwm2m_firmware_start_transfer(package_uri);
+
+		if (data_len > 0) {
+			lwm2m_firmware_start_transfer(package_uri);
+		}
 	} else if (state == STATE_DOWNLOADED && data_len == 0U) {
 		/* reset to state idle and result default */
 		lwm2m_firmware_set_update_result(RESULT_DEFAULT);


### PR DESCRIPTION
Fix for a problem in current lwm2m firmware object implementation. If empty string is sent to Package URI while object's state machine is already in STATE_IDLE, object will reset State and Update Result and begin transfer. From OMA specification:

> Writing an empty string to Package URI Resource or setting the Package Resource to NULL (‘\0’), resets the Firmware Update State Machine: the State Resource value is set to Idle and the Update Result Resource value is set to 0.

Reset part is fine, but transfer should not begin when an empty string is received (it's a special case for resetting state machine).