### PR TITLE
Fix compilation error with SDL kscan driver

### DIFF
--- a/drivers/kscan/kscan_sdl.c
+++ b/drivers/kscan/kscan_sdl.c
@@ -87,7 +87,7 @@ static int sdl_disable_callback(const struct device *dev)
 
 static int sdl_init(const struct device *dev)
 {
-	struct sdl_data *data = dev->driver_data;
+	struct sdl_data *data = dev->data;
 
 	data->dev = dev;
 

--- a/samples/display/lvgl/sample.yaml
+++ b/samples/display/lvgl/sample.yaml
@@ -22,3 +22,7 @@ tests:
     platform_allow: nrf52840dk_nrf52840
     extra_args: SHIELD=waveshare_epaper_gdeh029a1
     tags: shield
+  sample.display.lvgl.sdl:
+    build_only: true
+    platform_allow: native_posix_64
+    tags: samples display gui


### PR DESCRIPTION
Member `driver_data`  in `struct device`was renamed to `data` but SDL Kscan driver was not updated.

Further added `native_posix_64` board the lvgl sample.yaml file to make sure that SDL Kscan driver is at least build in CI 