### PR TITLE
lib: openthread: allow passing multiple libraries as mbedtls

### DIFF
--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -172,13 +172,12 @@ config OPENTHREAD_MBEDTLS
 	select MBEDTLS_HMAC_DRBG_ENABLED if OPENTHREAD_COMMISSIONER || OPENTHREAD_JOINER
 	select MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED if OPENTHREAD_ECDSA
 
-config OPENTHREAD_MBEDTLS_TARGET
-	string "mbedtls target name"
+config OPENTHREAD_MBEDTLS_LIB_NAME
+	string "mbedtls lib name"
 	default "mbedTLS"
 	help
-	  This option allows to specify custom mbedtls CMake target name for
-	  openthread. This is sometimes needed to utilize hardware cryptography
-	  acceleration.
+	  This option allows to specify one or more mbedtls library files to be
+	  linked with OpenThread. Separate multiple values with space " ".
 
 menuconfig OPENTHREAD_NCP
 	bool "Network Co-Processor"

--- a/west.yml
+++ b/west.yml
@@ -107,7 +107,7 @@ manifest:
       revision: 170a2579dd890f78f5056f0959cdb9c9bea259a1
       path: modules/lib/loramac-node
     - name: openthread
-      revision: 656802a76acd2920b74ee4d49363f70aeb3b9621
+      revision: f23165fde96ae8bd710b08c6d77879465ed92cac
       path: modules/lib/openthread
     - name: segger
       revision: 874d9e9696b00c09f9eeefe839028dc25fe44983


### PR DESCRIPTION
Some implementation consist of multiple libraries to be linked instead
of one. Added possibility to pass multiple libraries. Additionally
renamed the config name as it was stateing something different than it
does.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>