### PR TITLE
build: Fix usage of hardcoded zephyr.{elf,bin,hex} on faze board

### DIFF
--- a/boards/arm/faze/CMakeLists.txt
+++ b/boards/arm/faze/CMakeLists.txt
@@ -7,6 +7,6 @@
 set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
   # Insert checksum (verified by the bootloader) into the zephyr.bin
   # and zephyr.hex images.
-  COMMAND lpc_checksum -f hex ${CMAKE_BINARY_DIR}/zephyr/zephyr.hex
-  COMMAND lpc_checksum -f bin ${CMAKE_BINARY_DIR}/zephyr/zephyr.bin
+  COMMAND lpc_checksum -f hex ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_HEX_NAME}
+  COMMAND lpc_checksum -f bin ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
   )


### PR DESCRIPTION
Make similar fix for faze board to use ${KERNEL_BIN_NAME} and
${KERNEL_HEX_NAME} variables as its possible to rename the executable
binary via CONFIG_KERNEL_BIN_NAME.

This fixes tests/misc/test_build/buildsystem.kconfig.utf8_in_values

Fixes #28013

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>