### PR TITLE
tests: spinlock: fix occasional crash

### DIFF
--- a/tests/kernel/spinlock/src/main.c
+++ b/tests/kernel/spinlock/src/main.c
@@ -147,7 +147,7 @@ void test_spinlock_mutual_exclusion(void)
 	struct k_spinlock lock_runtime;
 	unsigned int irq_key;
 
-	lock_runtime.locked = 0;
+	(void)memset(&lock_runtime, 0, sizeof(lock_runtime));
 
 	key = k_spin_lock(&lock_runtime);
 


### PR DESCRIPTION
lock_runtime is a stack variable whose contents could be completely
garbage, but only the 'locked' member was zeroed. zero the whole
thing to prevent spurious "recursive spinlock" errors from occasionally
popping up as the validation framework gets confused from garbage
data in the other members of this data structure.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>