### PR TITLE
tracing: Add user-definable tracing interface

### DIFF
--- a/doc/guides/tracing/index.rst
+++ b/doc/guides/tracing/index.rst
@@ -140,6 +140,24 @@ and exits (only distinguishes between idle thread, non idle thread and scheduler
 Enable this format with the :option:`CONFIG_TRACING_CPU_STATS` option.
 
 
+User-Defined Tracing
+====================
+
+This tracing format allows the user to define functions to perform any work desired
+when a task is switched in or out, when an interrupt is entered or exited, and when the cpu
+is idle.
+
+The following functions can be defined by the user::
+
+  void user_sys_trace_thread_switched_in(struct k_thread *thread)
+  void user_sys_trace_thread_switched_out(struct k_thread *thread)
+  void user_sys_trace_isr_enter(void)
+  void user_sys_trace_isr_exit(void)
+  void user_sys_trace_idle(void)
+
+Enable this format with the :option:`CONFIG_TRACING_USER` option.
+
+
 Transport Backends
 ******************
 

--- a/include/tracing/tracing.h
+++ b/include/tracing/tracing.h
@@ -30,6 +30,9 @@
 #elif defined CONFIG_TRACING_TEST
 #include "tracing_test.h"
 
+#elif defined CONFIG_TRACING_USER
+#include "tracing_user.h"
+
 #else
 
 /**

--- a/subsys/tracing/CMakeLists.txt
+++ b/subsys/tracing/CMakeLists.txt
@@ -6,6 +6,11 @@ zephyr_sources_ifdef(
   )
 
 zephyr_sources_ifdef(
+  CONFIG_TRACING_USER
+  tracing_user.c
+  )
+
+zephyr_sources_ifdef(
   CONFIG_TRACING_CORE
   tracing_buffer.c
   tracing_core.c

--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -60,6 +60,11 @@ config TRACING_TEST
 	  Enable tracing for testing kinds of format purpose. It must
 	  implement the tracing hooks defined in tracing_test.h
 
+config TRACING_USER
+	bool "Tracing using user-defined functions"
+	help
+	  Use user-defined functions for tracing task switching and irqs
+
 endchoice
 
 

--- a/subsys/tracing/include/tracing_user.h
+++ b/subsys/tracing/include/tracing_user.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020 Lexmark International, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _TRACE_USER_H
+#define _TRACE_USER_H
+#include <kernel.h>
+#include <kernel_structs.h>
+#include <init.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void user_sys_trace_thread_switched_in(struct k_thread *thread);
+void user_sys_trace_thread_switched_out(struct k_thread *thread);
+void user_sys_trace_isr_enter(void);
+void user_sys_trace_isr_exit(void);
+void user_sys_trace_idle(void);
+
+void sys_trace_thread_switched_in(void);
+void sys_trace_thread_switched_out(void);
+void sys_trace_isr_enter(void);
+void sys_trace_isr_exit(void);
+void sys_trace_idle(void);
+
+#define sys_trace_isr_exit_to_scheduler()
+
+#define sys_trace_thread_priority_set(thread)
+#define sys_trace_thread_info(thread)
+#define sys_trace_thread_create(thread)
+#define sys_trace_thread_abort(thread)
+#define sys_trace_thread_suspend(thread)
+#define sys_trace_thread_resume(thread)
+#define sys_trace_thread_ready(thread)
+#define sys_trace_thread_pend(thread)
+#define sys_trace_thread_name_set(thread)
+
+#define sys_trace_void(id)
+#define sys_trace_end_call(id)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _TRACE_USER_H */

--- a/subsys/tracing/tracing_user.c
+++ b/subsys/tracing/tracing_user.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020 Lexmark International, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <tracing_user.h>
+#include <sys/printk.h>
+#include <kernel_internal.h>
+#include <ksched.h>
+
+static int nested_interrupts;
+
+void __weak user_sys_trace_thread_switched_in(struct k_thread *thread) {}
+void __weak user_sys_trace_thread_switched_out(struct k_thread *thread) {}
+void __weak user_sys_trace_isr_enter(void) {}
+void __weak user_sys_trace_isr_exit(void) {}
+void __weak user_sys_trace_idle(void) {}
+
+void sys_trace_thread_switched_in(void)
+{
+	int key = irq_lock();
+
+	__ASSERT_NO_MSG(nested_interrupts == 0);
+
+	user_sys_trace_thread_switched_in(k_current_get());
+
+	irq_unlock(key);
+}
+
+void sys_trace_thread_switched_out(void)
+{
+	int key = irq_lock();
+
+	__ASSERT_NO_MSG(nested_interrupts == 0);
+
+	user_sys_trace_thread_switched_out(k_current_get());
+
+	irq_unlock(key);
+}
+
+void sys_trace_isr_enter(void)
+{
+	int key = irq_lock();
+
+	if (nested_interrupts == 0) {
+		user_sys_trace_isr_enter();
+	}
+	nested_interrupts++;
+	irq_unlock(key);
+}
+
+void sys_trace_isr_exit(void)
+{
+	int key = irq_lock();
+
+	nested_interrupts--;
+	if (nested_interrupts == 0) {
+		user_sys_trace_isr_exit();
+	}
+	irq_unlock(key);
+}
+
+void sys_trace_idle(void)
+{
+	user_sys_trace_idle();
+}


### PR DESCRIPTION
Create a new tracing option TRACING_USER that allows
the user to define certain user_sys_trace_... functions
to perform whatever work desired for tracing when
tasks are swiched in/out, during isr enter/exit, and when
cpu is idle.

This infrastructure can be useful for plugging into
locally defined tracing tools or any user-specific
debugging environment.

Signed-off-by: Nicholas Lowell <nlowell@lexmark.com>