### PR TITLE
i2s: cavs: cast device struct to void ptr for DMA user data

### DIFF
--- a/drivers/i2s/i2s_cavs.c
+++ b/drivers/i2s/i2s_cavs.c
@@ -63,7 +63,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 				.source_burst_length = CAVS_I2S_DMA_BURST_SIZE,\
 				.dest_burst_length = CAVS_I2S_DMA_BURST_SIZE,\
 				.dma_callback = i2s_dma_tx_callback,	\
-				.user_data = I2S_DEVICE_OBJECT(i2s_id),\
+				.user_data = (void *)I2S_DEVICE_OBJECT(i2s_id),\
 				.complete_callback_en = 1,	\
 				.error_callback_en = 1,		\
 				.block_count = 1,		\
@@ -79,7 +79,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 				.source_burst_length = CAVS_I2S_DMA_BURST_SIZE,\
 				.dest_burst_length = CAVS_I2S_DMA_BURST_SIZE,\
 				.dma_callback = i2s_dma_rx_callback,\
-				.user_data = I2S_DEVICE_OBJECT(i2s_id),\
+				.user_data = (void *)I2S_DEVICE_OBJECT(i2s_id),\
 				.complete_callback_en = 1,	\
 				.error_callback_en = 1,		\
 				.block_count = 1,		\


### PR DESCRIPTION
In the I2S CAVS driver, the DMA user data simply points to
the device struct. However, after the change to const-ify device
struct, this causes warnings from compiler because the user_data
assignment would discard the const qualifier. The user_data is
being used to point back to the device struct, and the DMA
callbacks are already casting the user data argument into
a const device struct. So it's a simple fix by casting
the device pointer to void pointer at device creation.

Fixes #28016

Signed-off-by: Daniel Leung <daniel.leung@intel.com>