### PR TITLE
cmake: mcuboot: confirmed images needs to be padded

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -435,10 +435,10 @@ config MCUBOOT_EXTRA_IMGTOOL_ARGS
 	  For example, you could set this to "--version 1.2".
 
 config MCUBOOT_GENERATE_CONFIRMED_IMAGE
-	bool "Also generate a confirmed image"
+	bool "Also generate a padded, confirmed image"
 	help
-	  The signed and confirmed binaries are placed in the build directory
-	  at zephyr/zephyr.signed.confirmed.bin and
+	  The signed, padded, and confirmed binaries are placed in the build
+	  directory at zephyr/zephyr.signed.confirmed.bin and
 	  zephyr/zephyr.signed.confirmed.hex.
 
 	  The file names can be customized with CONFIG_KERNEL_BIN_NAME.

--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -126,7 +126,7 @@ function(zephyr_mcuboot_tasks)
     ${west_sign} ${unconfirmed_args} ${imgtool_args})
   if(confirmed_args)
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
-      ${west_sign} ${confirmed_args} ${imgtool_args} --confirm)
+      ${west_sign} ${confirmed_args} ${imgtool_args} --pad --confirm)
   endif()
   set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts ${byproducts})
 endfunction()


### PR DESCRIPTION
Add --pad to imgtool.py command line arguments when generating confirmed
images, otherwise the image contains no trailer magic for writing the
confirmed status.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>