### PR TITLE
[POC] include: Add support for deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1387,6 +1387,26 @@ if(CONFIG_SOC_DEPRECATED_RELEASE)
   )
 endif()
 
+# Deprecated list of Kconfig values
+#
+# Add Kconfig items that are marked as deprecated the list below to generate
+# a build warning to the user. When the deprecation process is completed and
+# the feature/config is removed from the code base, the warning below can be
+# removed as well.
+#
+# if(CONFIG_somevalue)
+#   message(WARNING "
+#       Warning: << some meaningful warning message with Kconfig value>>"
+#   )
+# endif()
+#
+if(CONFIG_NET_TCP1)
+  message(WARNING "
+      WARNING: Legacy NET_TCP1 is being deprecated in favor of NET_TCP2"
+  )
+endif()
+# End of deprecated Kconfig values
+
 # In CMake projects, 'CMAKE_BUILD_TYPE' usually determines the
 # optimization flag, but in Zephyr it is determined through
 # Kconfig. Here we give a warning when there is a mismatch between the

--- a/include/deprecated.h
+++ b/include/deprecated.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DEPRECATED_H_
+#define ZEPHYR_INCLUDE_DEPRECATED_H_
+/*
+ * Add Kconfig items that are marked as deprecated the list below to generate
+ * a build warning to the user. When the deprecation process is completed and
+ * the feature/config is removed from the code base, the warning below can be
+ * removed as well.
+ */
+
+#ifdef CONFIG_NET_TCP1
+/*
+ * Please move your applications to NET_TCP2 (already the default) as NET_TCP1
+ * will be removed from the code base on release x.x
+ */
+#warning Legacy TCP stack is being deprecated in favor of NET_TCP2
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DEPRECATED_H_ */

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -18,6 +18,7 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <toolchain.h>
+#include <deprecated.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Add support to display a build warning when using Kconfig flags that
are deprecated and scheduled for removal.

Signed-off-by: David Leach <david.leach@nxp.com>