### PR TITLE
Revert "cmake: combine nsim and mdb for emulation"

### DIFF
--- a/boards/arc/nsim/board.cmake
+++ b/boards/arc/nsim/board.cmake
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
+
+if(${CONFIG_SOC_NSIM_HS_SMP})
+set(EMU_PLATFORM mdb)
+else()
 set(EMU_PLATFORM nsim)
+endif()
 
 if(NOT CONFIG_SOC_NSIM_HS_SMP)
 board_set_flasher_ifnset(arc-nsim)

--- a/boards/arc/nsim/nsim_hs_smp.yaml
+++ b/boards/arc/nsim/nsim_hs_smp.yaml
@@ -1,7 +1,7 @@
 identifier: nsim_hs_smp
 name: Multi-core HS nSIM simulator
 type: mcu
-simulation: nsim
+simulation: mdb
 arch: arc
 toolchain:
   - zephyr

--- a/cmake/emu/mdb.cmake
+++ b/cmake/emu/mdb.cmake
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+
+find_program(
+  MDB
+  mdb
+  )
+
+if(${CONFIG_SOC_NSIM_HS_SMP})
+ set(MDB_ARGS mdb_hs_smp.args)
+endif()
+
+add_custom_target(run
+  COMMAND
+  ${MDB} -pset=1 -psetname=core0 -prop=ident=0x00000050 -cmpd=soc
+  @${BOARD_DIR}/support/${MDB_ARGS} ${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME} &&
+  ${MDB} -pset=2 -psetname=core1 -prop=ident=0x00000150 -cmpd=soc
+  @${BOARD_DIR}/support/${MDB_ARGS} ${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME} &&
+  NSIM_MULTICORE=1 ${MDB} -multifiles=core0,core1 -cmpd=soc -run -cl
+  DEPENDS ${logical_target_for_zephyr_elf}
+  WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
+  USES_TERMINAL
+  )

--- a/cmake/emu/nsim.cmake
+++ b/cmake/emu/nsim.cmake
@@ -1,27 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-if(${CONFIG_SOC_NSIM_HS_SMP})
-# mdb is required to run nsim multicore targets
-find_program(
-  MDB
-  mdb
-  )
 
-if(${CONFIG_SOC_NSIM_HS_SMP})
- set(MDB_ARGS mdb_hs_smp.args)
-endif()
-
-add_custom_target(run
-  COMMAND
-  ${MDB} -pset=1 -psetname=core0 -prop=ident=0x00000050 -cmpd=soc
-  @${BOARD_DIR}/support/${MDB_ARGS} ${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME} &&
-  ${MDB} -pset=2 -psetname=core1 -prop=download=2 -prop=ident=0x00000150 -cmpd=soc
-  @${BOARD_DIR}/support/${MDB_ARGS} ${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME} &&
-  NSIM_MULTICORE=1 ${MDB} -multifiles=core0,core1 -cmpd=soc -run -cl
-  DEPENDS ${logical_target_for_zephyr_elf}
-  WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
-  USES_TERMINAL
-  )
-else()
 find_program(
   NSIM
   nsimdrv
@@ -56,4 +34,3 @@ add_custom_target(debugserver
   WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
   USES_TERMINAL
   )
-endif()


### PR DESCRIPTION
This patch is breaking all users who have access to 'nsimdrv'
but not 'mdb'.

This reverts commit 6f6fddf7e9c43e226a57ce5a77e22641bf3bb61c.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>