### PR TITLE
soc: arm: atmel_sam: Add support for pinctrl flags

### DIFF
--- a/dts/bindings/pinctrl/atmel,sam-pinctrl.yaml
+++ b/dts/bindings/pinctrl/atmel,sam-pinctrl.yaml
@@ -20,3 +20,18 @@ child-binding:
     properties:
       "atmel,pins":
         type: phandle-array
+
+      bias-pull-up:
+        required: false
+        type: boolean
+        description: pull up the pin
+
+      bias-pull-down:
+        required: false
+        type: boolean
+        description: pull down the pin
+
+      drive-open-drain:
+        required: false
+        type: boolean
+        description: drive with open drain

--- a/soc/arm/atmel_sam/common/atmel_sam_dt.h
+++ b/soc/arm/atmel_sam/common/atmel_sam_dt.h
@@ -36,13 +36,24 @@
 #define ATMEL_SAM_PIN_PERIPH(inst, i) \
 	DT_PHA(NODE_ID_FROM_PINCTRL_0(inst, i), atmel_pins, peripheral)
 
+/* Helper function for ATMEL_SAM_PIN_FLAGS */
+#define ATMEL_SAM_PIN_FLAG(inst, i, flag) \
+	DT_PROP(NODE_ID_FROM_PINCTRL_0(inst, i), flag)
+
+/* Convert DT flags to SoC flags */
+#define ATMEL_SAM_PIN_FLAGS(inst, i) \
+	(ATMEL_SAM_PIN_FLAG(inst, i, bias_pull_up) << SOC_GPIO_PULLUP_POS | \
+	 ATMEL_SAM_PIN_FLAG(inst, i, bias_pull_down) << SOC_GPIO_PULLUP_POS | \
+	 ATMEL_SAM_PIN_FLAG(inst, i, drive_open_drain) << SOC_GPIO_OPENDRAIN_POS)
+
 /* Construct a soc_gpio_pin element for pin cfg */
 #define ATMEL_SAM_DT_PIN(inst, idx)				\
 	{							\
 		1 << ATMEL_SAM_PIN(inst, idx),			\
 		(Pio *)ATMEL_SAM_PIN_TO_PIO_REG_ADDR(inst, idx),\
 		ATMEL_SAM_PIN_2_PIO_PERIPH_ID(inst, idx),	\
-		ATMEL_SAM_PIN_PERIPH(inst, idx) << 16		\
+		ATMEL_SAM_PIN_PERIPH(inst, idx) << 16 |		\
+		ATMEL_SAM_PIN_FLAGS(inst, idx)			\
 	}
 
 /* Get the number of pins for pinctrl-0 */

--- a/soc/arm/atmel_sam/common/soc_gpio.h
+++ b/soc/arm/atmel_sam/common/soc_gpio.h
@@ -24,9 +24,12 @@
 
 #define SOC_GPIO_DEFAULT                (0)
 
-#define SOC_GPIO_PULLUP                 (1 << 0)
-#define SOC_GPIO_PULLDOWN               (1 << 1)
-#define SOC_GPIO_OPENDRAIN              (1 << 2)
+#define SOC_GPIO_PULLUP_POS		(0)
+#define SOC_GPIO_PULLUP                 (1 << SOC_GPIO_PULLUP_POS)
+#define SOC_GPIO_PULLDOWN_POS		(1)
+#define SOC_GPIO_PULLDOWN               (1 << SOC_GPIO_PULLDOWN_POS)
+#define SOC_GPIO_OPENDRAIN_POS		(2)
+#define SOC_GPIO_OPENDRAIN              (1 << SOC_GPIO_OPENDRAIN_POS)
 
 /* Bit field: SOC_GPIO_IN_FILTER */
 #define SOC_GPIO_IN_FILTER_POS          3


### PR DESCRIPTION
Add devicetree support to specify bias-pull-up, bias-pull-down, and
drive-open-drain for pin configuration.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>