### PR TITLE
drivers: video: mcux_csi: Fix compile error

### DIFF
--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -419,7 +419,7 @@ static struct video_mcux_csi_data video_mcux_csi_data_0;
 
 static int video_mcux_csi_init_0(const struct device *dev)
 {
-	struct video_mcux_csi_data *data = dev->driver_data;
+	struct video_mcux_csi_data *data = dev->data;
 
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
 		    video_mcux_csi_isr, NULL, 0);


### PR DESCRIPTION
Fix compile errors of the form:

video_mcux_csi.c: In function 'video_mcux_csi_init_0':
video_mcux_csi.c:422:40: error: 'const struct device' has no member
				 named 'driver_data'
  422 |  struct video_mcux_csi_data *data = dev->driver_data;
      |                                        ^~

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>