### PR TITLE
sanitycheck: mark arc simulation smp systems as mdb

### DIFF
--- a/boards/arc/nsim/nsim_hs_smp.yaml
+++ b/boards/arc/nsim/nsim_hs_smp.yaml
@@ -1,7 +1,7 @@
 identifier: nsim_hs_smp
 name: Multi-core HS nSIM simulator
 type: mcu
-simulation: nsim
+simulation: mdb
 arch: arc
 toolchain:
   - zephyr

--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -1639,11 +1639,15 @@ class TestInstance(DisablePyTestCollectionMixin):
 
         runnable = bool(self.testcase.type == "unit" or \
                         self.platform.type == "native" or \
-                        self.platform.simulation in ["nsim", "renode", "qemu"] or \
+                        self.platform.simulation in ["mdb", "nsim", "renode", "qemu"] or \
                         device_testing)
 
         if self.platform.simulation == "nsim":
             if not find_executable("nsimdrv"):
+                runnable = False
+
+        if self.platform.simulation == "mdb":
+            if not find_executable("mdb"):
                 runnable = False
 
         if self.platform.simulation == "renode":


### PR DESCRIPTION
This changes back smp simulation systems to require mdb.