### PR TITLE
drivers: flash: stm32wb: Fix build error

### DIFF
--- a/drivers/flash/flash_stm32wbx.c
+++ b/drivers/flash/flash_stm32wbx.c
@@ -20,7 +20,9 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 
 #include "flash_stm32.h"
 #include "stm32_hsem.h"
+#if defined(CONFIG_BT)
 #include "shci.h"
+#endif
 
 #define STM32WBX_PAGE_SHIFT	12
 


### PR DESCRIPTION
When building flash shell sample we get:

flash_stm32wbx.c:23:10: fatal error: shci.h: No such file or directory
   23 | #include "shci.h"

Fix this by adding ifdef protection around inclusion of shci.h.

Fixes #28036

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>