### PR TITLE
Bluetooth: GATT: Allow application to restore subscription without resubscribing

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -1430,8 +1430,8 @@ struct bt_gatt_subscribe_params {
  *  this callback. Notification callback with NULL data will not be called if
  *  subscription was removed by this method.
  *
- *  @note This procedure is asynchronous therefore the parameters need to
- *  remains valid while it is active.
+ *  @note Notifications are asynchronous therefore the parameters need to
+ *        remain valid while subscribed.
  *
  *  @param conn Connection object.
  *  @param params Subscribe parameters.

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -1441,6 +1441,25 @@ struct bt_gatt_subscribe_params {
 int bt_gatt_subscribe(struct bt_conn *conn,
 		      struct bt_gatt_subscribe_params *params);
 
+/** @brief Resubscribe Attribute Value Notification subscription
+ *
+ *  Resubscribe to Attribute Value Notification when already subscribed from a
+ *  previous connection. The GATT server will remember subscription from
+ *  previous connections when bonded, so resubscribing can be done without
+ *  performing a new subscribe procedure after a power cycle.
+ *
+ *  @note Notifications are asynchronous therefore the parameters need to
+ *        remain valid while subscribed.
+ *
+ *  @param id     Local identity (in most cases BT_ID_DEFAULT).
+ *  @param peer   Remote address.
+ *  @param params Subscribe parameters.
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_gatt_resubscribe(uint8_t id, const bt_addr_le_t *peer,
+			     struct bt_gatt_subscribe_params *params);
+
 /** @brief Unsubscribe Attribute Value Notification
  *
  *  This procedure unsubscribe to value notification using the Client

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -39,7 +39,7 @@
 #define DEVICE_NAME		CONFIG_BT_DEVICE_NAME
 #define DEVICE_NAME_LEN		(sizeof(DEVICE_NAME) - 1)
 
-static uint8_t selected_id = BT_ID_DEFAULT;
+uint8_t selected_id = BT_ID_DEFAULT;
 const struct shell *ctx_shell;
 
 #if defined(CONFIG_BT_CONN)


### PR DESCRIPTION
Allow the application to add subscription without resubscribing.
This is needed for persistent bonds that can go to deep sleep and
turn of the RAM or power-cycle.
In this case the application as a GATT client must have a way to add
the subscription callbacks back to the stack before the GATT server
sends notifications.
This should preferable be able to be done before even connecting
since the notifications can arrive immediately after connecting to
the peer.
The stack cannot persist this on it's own since it must remember the
function pointers for the callback functions. Storing these in
persistent storage would not be compatible with a Device Firmware
Upgrade (DFU) solution.

Fixes: #21798
