### PR TITLE
cmake: extend support for conf file and board overlays

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -452,6 +452,30 @@ if(CONF_FILE)
   # CONF_FILE has either been specified on the cmake CLI or is already
   # in the CMakeCache.txt. This has precedence over the environment
   # variable CONF_FILE and the default prj.conf
+
+  # In order to support a `prj_<name>.conf pattern for auto inclusion of board
+  # overlays, then we must first ensure only a single conf file is provided.
+  string(REPLACE " " ";" CONF_FILE_AS_LIST "${CONF_FILE}")
+  list(LENGTH CONF_FILE_AS_LIST CONF_FILE_LENGTH)
+  if(${CONF_FILE_LENGTH} EQUAL 1)
+    # Need the file name to look for match.
+    # Need path in order to check if it is absolute.
+    get_filename_component(CONF_FILE_NAME ${CONF_FILE} NAME)
+    get_filename_component(CONF_FILE_DIR ${CONF_FILE} DIRECTORY)
+    if(${CONF_FILE} MATCHES "prj_(.*).conf")
+      if(NOT IS_ABSOLUTE ${CONF_FILE_DIR})
+        set(CONF_FILE_DIR ${APPLICATION_SOURCE_DIR}/${CONF_FILE_DIR})
+      endif()
+      if(EXISTS ${CONF_FILE_DIR}/boards/${BOARD}_${CMAKE_MATCH_1}.conf)
+        list(APPEND CONF_FILE ${CONF_FILE_DIR}/boards/${BOARD}_${CMAKE_MATCH_1}.conf)
+      endif()
+    endif()
+  endif()
+elseif(CACHED_CONF_FILE)
+  # Cached conf file is present.
+  # That value has precedence over anything else than a new
+  # `cmake -DCONF_FILE=<file>` invocation.
+  set(CONF_FILE ${CACHED_CONF_FILE})
 elseif(DEFINED ENV{CONF_FILE})
   set(CONF_FILE $ENV{CONF_FILE})
 
@@ -469,10 +493,13 @@ elseif(EXISTS   ${APPLICATION_SOURCE_DIR}/prj.conf)
   set(CONF_FILE ${APPLICATION_SOURCE_DIR}/prj.conf)
 endif()
 
-set(CONF_FILE ${CONF_FILE} CACHE STRING "If desired, you can build the application using\
+set(CACHED_CONF_FILE ${CONF_FILE} CACHE STRING "If desired, you can build the application using\
 the configuration settings specified in an alternate .conf file using this parameter. \
 These settings will override the settings in the application’s .config file or its default .conf file.\
-Multiple files may be listed, e.g. CONF_FILE=\"prj1.conf prj2.conf\"")
+Multiple files may be listed, e.g. CONF_FILE=\"prj1.confi;prj2.conf\" \
+The CACHED_CONF_FILE is internal Zephyr variable used between CMake runs. \
+To change CONF_FILE, use the CONF_FILE variable.")
+unset(CONF_FILE CACHE)
 
 if(ZEPHYR_EXTRA_MODULES)
   # ZEPHYR_EXTRA_MODULES has either been specified on the cmake CLI or is

--- a/doc/guides/kconfig/setting.rst
+++ b/doc/guides/kconfig/setting.rst
@@ -141,19 +141,25 @@ The application configuration can come from the sources below. By default,
    merged and used as the application configuration. ``CONF_FILE`` can be set
    in various ways:
 
-   1. In :file:`CMakeLists.txt`, before including :file:`boilerplate.cmake`
+   1. In :file:`CMakeLists.txt`, before calling ``find_package(Zephyr)``
 
    2. By passing ``-DCONF_FILE=<conf file(s)>``, either directly or via ``west``
 
    3. From the CMake variable cache
 
-2. Otherwise, :file:`prj_<BOARD>.conf` is used if it exists in the application
+2. Otherwise if ``CONF_FILE`` is set, and a single configuration file of the
+   form :file:`prj_<build>.conf` is used, then if file
+   :file:`boards/<BOARD>_<build>.conf` exists in same folder as file
+   :file:`prj_<build>.conf`, the result of merging :file:`prj_<build>.conf` and
+   :file:`boards/<BOARD>_<build>.conf` is used.
+
+3. Otherwise, :file:`prj_<BOARD>.conf` is used if it exists in the application
    directory.
 
-3. Otherwise, if :file:`boards/<BOARD>.conf` exists in the application
+4. Otherwise, if :file:`boards/<BOARD>.conf` exists in the application
    directory, the result of merging it with :file:`prj.conf` is used.
 
-4. Otherwise, :file:`prj.conf` is used if it exists in the application
+5. Otherwise, :file:`prj.conf` is used if it exists in the application
    directory
 
 If a symbol is assigned both in :file:`<BOARD>_defconfig` and in the


### PR DESCRIPTION
Fixes: #27934

This commit introduces additional naming support of config files.

It is now possible to create a config file of the form
`prj_<build>.conf` and automatically have a corresponding
`boards/<BOARD>_<build>.conf` config file merged.

As example, one can create a structure as:
```
|-- prj.conf
|-- prj_debug.conf
|-- boards
      |-- nrf52840dk_nrf52840.conf
      |-- nrf52840dk_nrf52840_debug.conf
```

when building: (existing behavior)
`cmake -DBOARD=nrf52840dk_nrf52840 ...`
prj.conf is merged with nrf52840dk_nrf52840.conf

when building: (new behavior)
`cmake -DBOARD=nrf52840dk_nrf52840 -DCONF_FILE=prj_debug.conf ...`
prj_debug.conf is merged with nrf52840dk_nrf52840_debug.conf

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>