### PR TITLE
random: rand32_ctr_drbg: Fix missed device constify change

### DIFF
--- a/subsys/random/rand32_ctr_drbg.c
+++ b/subsys/random/rand32_ctr_drbg.c
@@ -37,7 +37,7 @@ static mbedtls_ctr_drbg_context ctr_ctx;
 
 static int ctr_drbg_entropy_func(void *ctx, unsigned char *buf, size_t len)
 {
-	return entropy_get_entropy(ctx, (void *)buf, len);
+	return entropy_get_entropy(entropy_driver, (void *)buf, len);
 }
 
 #elif defined(CONFIG_TINYCRYPT)
@@ -69,7 +69,7 @@ static int ctr_drbg_initialize(void)
 
 	ret = mbedtls_ctr_drbg_seed(&ctr_ctx,
 				    ctr_drbg_entropy_func,
-				    entropy_driver,
+				    NULL,
 				    drbg_seed,
 				    sizeof(drbg_seed));
 


### PR DESCRIPTION
Device constify PR missed changes needed within the mbedtls conditional code.

Fixes #28033

Signed-off-by: David Leach <david.leach@nxp.com>