### PR TITLE
nrfjprog.py: Fail if hex file has UICR data and no --erase

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -32,7 +32,7 @@ jobs:
         pip3 install setuptools
         pip3 install -r scripts/requirements-doc.txt
         pip3 install west>=0.6.2
-        pip3 install pyelftools canopen progress
+        pip3 install pyelftools canopen progress intelhex
 
     - name: west setup
       run: |

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -55,7 +55,7 @@ jobs:
     - name: install pytest
       run: |
         pip3 install wheel
-        pip3 install pytest west pyelftools canopen progress mypy
+        pip3 install pytest west pyelftools canopen progress mypy intelhex
     - name: run pytest-win
       if: runner.os == 'Windows'
       run: |


### PR DESCRIPTION
Inspect the hex file with intelhex, and fail if the hex file has any
contents in the UICR area(s).
family == 'NRF52' still always does --sectoranduicrerase, but this
option is not available on other families.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>