### PR TITLE
samples: net: echo*: Increase stack size

### DIFF
--- a/samples/net/sockets/echo/prj.conf
+++ b/samples/net/sockets/echo/prj.conf
@@ -1,5 +1,6 @@
 # General config
 CONFIG_NEWLIB_LIBC=y
+CONFIG_MAIN_STACK_SIZE=1200
 
 # Networking config
 CONFIG_NETWORKING=y

--- a/samples/net/sockets/echo_async/prj.conf
+++ b/samples/net/sockets/echo_async/prj.conf
@@ -1,5 +1,6 @@
 # General config
 CONFIG_NEWLIB_LIBC=y
+CONFIG_MAIN_STACK_SIZE=1200
 
 # Networking config
 CONFIG_NETWORKING=y


### PR DESCRIPTION
Increase stack size to 1200 for echo and echo_async sample apps
(following a similar increase done to echo_async_select previously).
With default stack size, the apps no longer run (crash QEMU) with
Zephyr 2.4-pre.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>