### PR TITLE
drivers: clock_control: nrf: Add support for clk192m

### DIFF
--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -231,6 +231,18 @@ static void hfclk_stop(void)
 	nrfx_clock_hfclk_stop();
 }
 
+#if NRF_CLOCK_HAS_HFCLK192M
+static void hfclk192m_start(void)
+{
+	nrfx_clock_start(NRF_CLOCK_DOMAIN_HFCLK192M);
+}
+
+static void hfclk192m_stop(void)
+{
+	nrfx_clock_stop(NRF_CLOCK_DOMAIN_HFCLK192M);
+}
+#endif
+
 static uint32_t *get_hf_flags(void)
 {
 	struct nrf_clock_control_data *data = DEVICE_GET(clock_nrf)->data;
@@ -568,7 +580,14 @@ static const struct nrf_clock_control_config config = {
 			.start = lfclk_start,
 			.stop = lfclk_stop,
 			IF_ENABLED(CONFIG_LOG, (.name = "lfclk",))
-		}
+		},
+#if NRF_CLOCK_HAS_HFCLK192M
+		[CLOCK_CONTROL_NRF_TYPE_HFCLK192M] = {
+			.start = hfclk192m_start,
+			.stop = hfclk192m_stop,
+			IF_ENABLED(CONFIG_LOG, (.name = "hfclk192m",))
+		},
+#endif
 	}
 };
 

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1341,7 +1341,10 @@ int usb_dc_attach(void)
 	k_work_init(&ctx->usb_work, usbd_work_handler);
 	k_mutex_init(&ctx->drv_lock);
 	ctx->hfxo_mgr =
-		z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
+		z_nrf_clock_control_get_onoff(
+			COND_CODE_1(NRF_CLOCK_HAS_HFCLK192,
+				    (CLOCK_CONTROL_NRF_SUBSYS_HF192M),
+				    (CLOCK_CONTROL_NRF_SUBSYS_HF)));
 
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
 		    nrfx_isr, nrfx_usbd_irq_handler, 0);

--- a/include/drivers/clock_control/nrf_clock_control.h
+++ b/include/drivers/clock_control/nrf_clock_control.h
@@ -19,6 +19,9 @@
 enum clock_control_nrf_type {
 	CLOCK_CONTROL_NRF_TYPE_HFCLK,
 	CLOCK_CONTROL_NRF_TYPE_LFCLK,
+#if NRF_CLOCK_HAS_HFCLK192M
+	CLOCK_CONTROL_NRF_TYPE_HFCLK192M,
+#endif
 	CLOCK_CONTROL_NRF_TYPE_COUNT
 };
 
@@ -29,6 +32,8 @@ enum clock_control_nrf_type {
 	((clock_control_subsys_t)CLOCK_CONTROL_NRF_TYPE_HFCLK)
 #define CLOCK_CONTROL_NRF_SUBSYS_LF \
 	((clock_control_subsys_t)CLOCK_CONTROL_NRF_TYPE_LFCLK)
+#define CLOCK_CONTROL_NRF_SUBSYS_HF192M \
+	((clock_control_subsys_t)CLOCK_CONTROL_NRF_TYPE_HFCLK192M)
 
 /** @brief LF clock start modes. */
 enum nrf_lfclk_start_mode {


### PR DESCRIPTION
Add support for 192M clock. Modified usb driver to use hf192m clock source for nrf53.