### PR TITLE
net: mqtt: use zsock_ functions

### DIFF
--- a/drivers/wifi/simplelink/simplelink_sockets.c
+++ b/drivers/wifi/simplelink/simplelink_sockets.c
@@ -25,12 +25,6 @@ LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 #include "sockets_internal.h"
 #include "tls_internal.h"
 
-/* Need these for POLLIN, POLLOUT, MSG_PEEK, etc. */
-#if defined(CONFIG_POSIX_API)
-#include "posix/poll.h"
-#include "posix/sys/socket.h"
-#endif
-
 #define FAILED (-1)
 
 /* Increment by 1 to make sure we do not store the value of 0, which has
@@ -577,10 +571,10 @@ static int simplelink_poll(struct zsock_pollfd *fds, int nfds, int msecs)
 				goto exit;
 			}
 		}
-		if (fds[i].events & POLLIN) {
+		if (fds[i].events & ZSOCK_POLLIN) {
 			SL_SOCKET_FD_SET(sd, &rfds);
 		}
-		if (fds[i].events & POLLOUT) {
+		if (fds[i].events & ZSOCK_POLLOUT) {
 			SL_SOCKET_FD_SET(sd, &wfds);
 		}
 		if (sd > max_sd) {
@@ -600,10 +594,10 @@ static int simplelink_poll(struct zsock_pollfd *fds, int nfds, int msecs)
 					ENOTSUP);
 				sd = OBJ_TO_SD(obj);
 				if (SL_SOCKET_FD_ISSET(sd, &rfds)) {
-					fds[i].revents |= POLLIN;
+					fds[i].revents |= ZSOCK_POLLIN;
 				}
 				if (SL_SOCKET_FD_ISSET(sd, &wfds)) {
-					fds[i].revents |= POLLOUT;
+					fds[i].revents |= ZSOCK_POLLOUT;
 				}
 			}
 		}
@@ -856,9 +850,9 @@ static int handle_recv_flags(int sd, int flags, bool set, int *nb_enabled)
 	SlSocklen_t optlen = sizeof(SlSockNonblocking_t);
 	SlSockNonblocking_t enableOption;
 
-	if (flags & MSG_PEEK) {
+	if (flags & ZSOCK_MSG_PEEK) {
 		retval = ENOTSUP;
-	} else if (flags & MSG_DONTWAIT) {
+	} else if (flags & ZSOCK_MSG_DONTWAIT) {
 		if (set) {
 			/* Get previous state, to restore later: */
 			sl_GetSockOpt(sd, SL_SOL_SOCKET, SL_SO_NONBLOCKING,

--- a/samples/net/cloud/mqtt_azure/src/main.c
+++ b/samples/net/cloud/mqtt_azure/src/main.c
@@ -34,7 +34,7 @@ static struct sockaddr socks5_proxy;
 #endif
 
 /* Socket Poll */
-static struct pollfd fds[1];
+static struct zsock_pollfd fds[1];
 static int nfds;
 
 static bool mqtt_connected;
@@ -50,8 +50,8 @@ static struct net_mgmt_event_callback l4_mgmt_cb;
 #endif
 
 #if defined(CONFIG_DNS_RESOLVER)
-static struct addrinfo hints;
-static struct addrinfo *haddr;
+static struct zsock_addrinfo hints;
+static struct zsock_addrinfo *haddr;
 #endif
 
 static K_SEM_DEFINE(mqtt_start, 0, 1);
@@ -108,7 +108,7 @@ static int wait(int timeout)
 		return rc;
 	}
 
-	rc = poll(fds, nfds, timeout);
+	rc = zsock_poll(fds, nfds, timeout);
 	if (rc < 0) {
 		LOG_ERR("poll error: %d", errno);
 		return -errno;
@@ -128,7 +128,7 @@ static void broker_init(void)
 	net_ipaddr_copy(&broker4->sin_addr,
 			&net_sin(haddr->ai_addr)->sin_addr);
 #else
-	inet_pton(AF_INET, SERVER_ADDR, &broker4->sin_addr);
+	zsock_inet_pton(AF_INET, SERVER_ADDR, &broker4->sin_addr);
 #endif
 
 #if defined(CONFIG_SOCKS)
@@ -136,7 +136,7 @@ static void broker_init(void)
 
 	proxy4->sin_family = AF_INET;
 	proxy4->sin_port = htons(SOCKS5_PROXY_PORT);
-	inet_pton(AF_INET, SOCKS5_PROXY_ADDR, &proxy4->sin_addr);
+	zsock_inet_pton(AF_INET, SOCKS5_PROXY_ADDR, &proxy4->sin_addr);
 #endif
 }
 
@@ -398,8 +398,8 @@ static int get_mqtt_broker_addrinfo(void)
 		hints.ai_socktype = SOCK_STREAM;
 		hints.ai_protocol = 0;
 
-		rc = getaddrinfo(CONFIG_SAMPLE_CLOUD_AZURE_HOSTNAME, "8883",
-				 &hints, &haddr);
+		rc = zsock_getaddrinfo(CONFIG_SAMPLE_CLOUD_AZURE_HOSTNAME, "8883",
+				       &hints, &haddr);
 		if (rc == 0) {
 			LOG_INF("DNS resolved for %s:%d",
 			CONFIG_SAMPLE_CLOUD_AZURE_HOSTNAME,

--- a/samples/net/mqtt_publisher/src/main.c
+++ b/samples/net/mqtt_publisher/src/main.c
@@ -50,7 +50,7 @@ static APP_BMEM struct sockaddr_storage broker;
 static APP_BMEM struct sockaddr socks5_proxy;
 #endif
 
-static APP_BMEM struct pollfd fds[1];
+static APP_BMEM struct zsock_pollfd fds[1];
 static APP_BMEM int nfds;
 
 static APP_BMEM bool connected;
@@ -130,7 +130,7 @@ static int wait(int timeout)
 	int ret = 0;
 
 	if (nfds > 0) {
-		ret = poll(fds, nfds, timeout);
+		ret = zsock_poll(fds, nfds, timeout);
 		if (ret < 0) {
 			LOG_ERR("poll error: %d", errno);
 		}
@@ -269,27 +269,27 @@ static void broker_init(void)
 
 	broker6->sin6_family = AF_INET6;
 	broker6->sin6_port = htons(SERVER_PORT);
-	inet_pton(AF_INET6, SERVER_ADDR, &broker6->sin6_addr);
+	zsock_inet_pton(AF_INET6, SERVER_ADDR, &broker6->sin6_addr);
 
 #if defined(CONFIG_SOCKS)
 	struct sockaddr_in6 *proxy6 = (struct sockaddr_in6 *)&socks5_proxy;
 
 	proxy6->sin6_family = AF_INET6;
 	proxy6->sin6_port = htons(SOCKS5_PROXY_PORT);
-	inet_pton(AF_INET6, SOCKS5_PROXY_ADDR, &proxy6->sin6_addr);
+	zsock_inet_pton(AF_INET6, SOCKS5_PROXY_ADDR, &proxy6->sin6_addr);
 #endif
 #else
 	struct sockaddr_in *broker4 = (struct sockaddr_in *)&broker;
 
 	broker4->sin_family = AF_INET;
 	broker4->sin_port = htons(SERVER_PORT);
-	inet_pton(AF_INET, SERVER_ADDR, &broker4->sin_addr);
+	zsock_inet_pton(AF_INET, SERVER_ADDR, &broker4->sin_addr);
 #if defined(CONFIG_SOCKS)
 	struct sockaddr_in *proxy4 = (struct sockaddr_in *)&socks5_proxy;
 
 	proxy4->sin_family = AF_INET;
 	proxy4->sin_port = htons(SOCKS5_PROXY_PORT);
-	inet_pton(AF_INET, SOCKS5_PROXY_ADDR, &proxy4->sin_addr);
+	zsock_inet_pton(AF_INET, SOCKS5_PROXY_ADDR, &proxy4->sin_addr);
 #endif
 #endif
 }

--- a/subsys/net/lib/mqtt/Kconfig
+++ b/subsys/net/lib/mqtt/Kconfig
@@ -6,7 +6,6 @@
 config MQTT_LIB
 	bool "Socket MQTT Library Support"
 	select NET_SOCKETS
-	select NET_SOCKETS_POSIX_NAMES
 	help
 	  Enable the Zephyr MQTT Library
 

--- a/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
@@ -24,8 +24,8 @@ int mqtt_client_tls_connect(struct mqtt_client *client)
 	struct mqtt_sec_config *tls_config = &client->transport.tls.config;
 	int ret;
 
-	client->transport.tls.sock = socket(broker->sa_family,
-					    SOCK_STREAM, IPPROTO_TLS_1_2);
+	client->transport.tls.sock = zsock_socket(broker->sa_family,
+						  SOCK_STREAM, IPPROTO_TLS_1_2);
 	if (client->transport.tls.sock < 0) {
 		return -errno;
 	}
@@ -44,35 +44,35 @@ int mqtt_client_tls_connect(struct mqtt_client *client)
 	}
 #endif
 	/* Set secure socket options. */
-	ret = setsockopt(client->transport.tls.sock, SOL_TLS, TLS_PEER_VERIFY,
-			 &tls_config->peer_verify,
-			 sizeof(tls_config->peer_verify));
+	ret = zsock_setsockopt(client->transport.tls.sock, SOL_TLS, TLS_PEER_VERIFY,
+			       &tls_config->peer_verify,
+			       sizeof(tls_config->peer_verify));
 	if (ret < 0) {
 		goto error;
 	}
 
 	if (tls_config->cipher_list != NULL && tls_config->cipher_count > 0) {
-		ret = setsockopt(client->transport.tls.sock, SOL_TLS,
-				 TLS_CIPHERSUITE_LIST, tls_config->cipher_list,
-				 sizeof(int) * tls_config->cipher_count);
+		ret = zsock_setsockopt(client->transport.tls.sock, SOL_TLS,
+				       TLS_CIPHERSUITE_LIST, tls_config->cipher_list,
+				       sizeof(int) * tls_config->cipher_count);
 		if (ret < 0) {
 			goto error;
 		}
 	}
 
 	if (tls_config->sec_tag_list != NULL && tls_config->sec_tag_count > 0) {
-		ret = setsockopt(client->transport.tls.sock, SOL_TLS,
-				 TLS_SEC_TAG_LIST, tls_config->sec_tag_list,
-				 sizeof(sec_tag_t) * tls_config->sec_tag_count);
+		ret = zsock_setsockopt(client->transport.tls.sock, SOL_TLS,
+				       TLS_SEC_TAG_LIST, tls_config->sec_tag_list,
+				       sizeof(sec_tag_t) * tls_config->sec_tag_count);
 		if (ret < 0) {
 			goto error;
 		}
 	}
 
 	if (tls_config->hostname) {
-		ret = setsockopt(client->transport.tls.sock, SOL_TLS,
-				 TLS_HOSTNAME, tls_config->hostname,
-				 strlen(tls_config->hostname));
+		ret = zsock_setsockopt(client->transport.tls.sock, SOL_TLS,
+				       TLS_HOSTNAME, tls_config->hostname,
+				       strlen(tls_config->hostname));
 		if (ret < 0) {
 			goto error;
 		}
@@ -84,8 +84,8 @@ int mqtt_client_tls_connect(struct mqtt_client *client)
 		peer_addr_size = sizeof(struct sockaddr_in);
 	}
 
-	ret = connect(client->transport.tls.sock, client->broker,
-		      peer_addr_size);
+	ret = zsock_connect(client->transport.tls.sock, client->broker,
+			    peer_addr_size);
 	if (ret < 0) {
 		goto error;
 	}
@@ -94,7 +94,7 @@ int mqtt_client_tls_connect(struct mqtt_client *client)
 	return 0;
 
 error:
-	(void)close(client->transport.tls.sock);
+	(void) zsock_close(client->transport.tls.sock);
 	return -errno;
 }
 
@@ -105,8 +105,8 @@ int mqtt_client_tls_write(struct mqtt_client *client, const uint8_t *data,
 	int ret;
 
 	while (offset < datalen) {
-		ret = send(client->transport.tls.sock, data + offset,
-			   datalen - offset, 0);
+		ret = zsock_send(client->transport.tls.sock, data + offset,
+				 datalen - offset, 0);
 		if (ret < 0) {
 			return -errno;
 		}
@@ -122,7 +122,7 @@ int mqtt_client_tls_write_msg(struct mqtt_client *client,
 {
 	int ret;
 
-	ret = sendmsg(client->transport.tls.sock, message, 0);
+	ret = zsock_sendmsg(client->transport.tls.sock, message, 0);
 	if (ret < 0) {
 		return -errno;
 	}
@@ -137,10 +137,10 @@ int mqtt_client_tls_read(struct mqtt_client *client, uint8_t *data, uint32_t buf
 	int ret;
 
 	if (!shall_block) {
-		flags |= MSG_DONTWAIT;
+		flags |= ZSOCK_MSG_DONTWAIT;
 	}
 
-	ret = recv(client->transport.tls.sock, data, buflen, flags);
+	ret = zsock_recv(client->transport.tls.sock, data, buflen, flags);
 	if (ret < 0) {
 		return -errno;
 	}
@@ -153,7 +153,7 @@ int mqtt_client_tls_disconnect(struct mqtt_client *client)
 	int ret;
 
 	MQTT_TRC("Closing socket %d", client->transport.tls.sock);
-	ret = close(client->transport.tls.sock);
+	ret = zsock_close(client->transport.tls.sock);
 	if (ret < 0) {
 		return -errno;
 	}

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1790,7 +1790,7 @@ static int ztls_poll_update_ctx(struct tls_context *ctx,
 	return ret;
 }
 
-static inline int ztls_poll_offload(struct pollfd *fds, int nfds, int timeout)
+static inline int ztls_poll_offload(struct zsock_pollfd *fds, int nfds, int timeout)
 {
 	int fd_backup[CONFIG_NET_SOCKETS_POLL_MAX];
 	const struct fd_op_vtable *vtable;
@@ -2059,7 +2059,7 @@ static int tls_sock_bind_vmeth(void *obj, const struct sockaddr *addr,
 {
 	struct tls_context *ctx = obj;
 
-	return bind(ctx->sock, addr, addrlen);
+	return zsock_bind(ctx->sock, addr, addrlen);
 }
 
 static int tls_sock_connect_vmeth(void *obj, const struct sockaddr *addr,

--- a/tests/net/lib/mqtt_publisher/src/test_mqtt_publish.c
+++ b/tests/net/lib/mqtt_publisher/src/test_mqtt_publish.c
@@ -27,7 +27,7 @@ static uint8_t rx_buffer[BUFFER_SIZE];
 static uint8_t tx_buffer[BUFFER_SIZE];
 static struct mqtt_client client_ctx;
 static struct sockaddr broker;
-static struct pollfd fds[1];
+static struct zsock_pollfd fds[1];
 static int nfds;
 static bool connected;
 
@@ -38,13 +38,13 @@ static void broker_init(void)
 
 	broker6->sin6_family = AF_INET6;
 	broker6->sin6_port = htons(SERVER_PORT);
-	inet_pton(AF_INET6, SERVER_ADDR, &broker6->sin6_addr);
+	zsock_inet_pton(AF_INET6, SERVER_ADDR, &broker6->sin6_addr);
 #else
 	struct sockaddr_in *broker4 = net_sin(&broker);
 
 	broker4->sin_family = AF_INET;
 	broker4->sin_port = htons(SERVER_PORT);
-	inet_pton(AF_INET, SERVER_ADDR, &broker4->sin_addr);
+	zsock_inet_pton(AF_INET, SERVER_ADDR, &broker4->sin_addr);
 #endif
 }
 
@@ -66,7 +66,7 @@ static void clear_fds(void)
 static void wait(int timeout)
 {
 	if (nfds > 0) {
-		if (poll(fds, nfds, timeout) < 0) {
+		if (zsock_poll(fds, nfds, timeout) < 0) {
 			TC_PRINT("poll error: %d\n", errno);
 		}
 	}

--- a/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
+++ b/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
@@ -23,7 +23,7 @@ static uint8_t rx_buffer[BUFFER_SIZE];
 static uint8_t tx_buffer[BUFFER_SIZE];
 static struct mqtt_client client_ctx;
 static struct sockaddr broker;
-static struct pollfd fds[1];
+static struct zsock_pollfd fds[1];
 static int nfds;
 static bool connected;
 static int payload_left;
@@ -64,13 +64,13 @@ static void broker_init(void)
 
 	broker6->sin6_family = AF_INET6;
 	broker6->sin6_port = htons(SERVER_PORT);
-	inet_pton(AF_INET6, SERVER_ADDR, &broker6->sin6_addr);
+	zsock_inet_pton(AF_INET6, SERVER_ADDR, &broker6->sin6_addr);
 #else
 	struct sockaddr_in *broker4 = net_sin(&broker);
 
 	broker4->sin_family = AF_INET;
 	broker4->sin_port = htons(SERVER_PORT);
-	inet_pton(AF_INET, SERVER_ADDR, &broker4->sin_addr);
+	zsock_inet_pton(AF_INET, SERVER_ADDR, &broker4->sin_addr);
 #endif
 }
 
@@ -92,7 +92,7 @@ static void clear_fds(void)
 static void wait(int timeout)
 {
 	if (nfds > 0) {
-		if (poll(fds, nfds, timeout) < 0) {
+		if (zsock_poll(fds, nfds, timeout) < 0) {
 			TC_PRINT("poll error: %d\n", errno);
 		}
 	}

--- a/tests/net/lib/mqtt_subscriber/src/test_mqtt_subscribe.c
+++ b/tests/net/lib/mqtt_subscriber/src/test_mqtt_subscribe.c
@@ -23,7 +23,7 @@ static uint8_t rx_buffer[BUFFER_SIZE];
 static uint8_t tx_buffer[BUFFER_SIZE];
 static struct mqtt_client client_ctx;
 static struct sockaddr broker;
-static struct pollfd fds[1];
+static struct zsock_pollfd fds[1];
 static int nfds;
 static bool connected;
 
@@ -34,13 +34,13 @@ static void broker_init(void)
 
 	broker6->sin6_family = AF_INET6;
 	broker6->sin6_port = htons(SERVER_PORT);
-	inet_pton(AF_INET6, SERVER_ADDR, &broker6->sin6_addr);
+	zsock_inet_pton(AF_INET6, SERVER_ADDR, &broker6->sin6_addr);
 #else
 	struct sockaddr_in *broker4 = net_sin(&broker);
 
 	broker4->sin_family = AF_INET;
 	broker4->sin_port = htons(SERVER_PORT);
-	inet_pton(AF_INET, SERVER_ADDR, &broker4->sin_addr);
+	zsock_inet_pton(AF_INET, SERVER_ADDR, &broker4->sin_addr);
 #endif
 }
 
@@ -62,7 +62,7 @@ static void clear_fds(void)
 static void wait(int timeout)
 {
 	if (nfds > 0) {
-		if (poll(fds, nfds, timeout) < 0) {
+		if (zsock_poll(fds, nfds, timeout) < 0) {
 			TC_PRINT("poll error: %d\n", errno);
 		}
 	}


### PR DESCRIPTION
Using zephyr's internals zsock_ calls make mqtt library more compatible,
now it does not depend on NET_SOCKETS_POSIX_NAMES.

Signed-off-by: Jan Pohanka <xhpohanka@gmail.com>