### PR TITLE
Bluetooth: Mesh: Move labels to transport

### DIFF
--- a/subsys/bluetooth/mesh/foundation.h
+++ b/subsys/bluetooth/mesh/foundation.h
@@ -129,10 +129,6 @@ void bt_mesh_heartbeat(uint16_t src, uint16_t dst, uint8_t hops, uint16_t feat);
 
 void bt_mesh_attention(struct bt_mesh_model *model, uint8_t time);
 
-struct label *get_label(uint16_t index);
-
-uint8_t *bt_mesh_label_uuid_get(uint16_t addr);
-
 struct bt_mesh_hb_pub *bt_mesh_hb_pub_get(void);
 void bt_mesh_hb_pub_disable(void);
 struct bt_mesh_cfg_srv *bt_mesh_cfg_get(void);

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -361,7 +361,7 @@ static int unseg_app_sdu_unpack(struct bt_mesh_friend *frnd,
 	meta->crypto.aszmic = 0;
 
 	if (BT_MESH_ADDR_IS_VIRTUAL(meta->crypto.dst)) {
-		meta->crypto.ad = bt_mesh_label_uuid_get(meta->crypto.dst);
+		meta->crypto.ad = bt_mesh_va_label_get(meta->crypto.dst);
 		if (!meta->crypto.ad) {
 			return -ENOENT;
 		}

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -169,9 +169,7 @@ void bt_mesh_reset(void)
 	k_delayed_work_cancel(&bt_mesh.ivu_timer);
 
 	bt_mesh_cfg_reset();
-
-	bt_mesh_rx_reset();
-	bt_mesh_tx_reset();
+	bt_mesh_trans_reset();
 	bt_mesh_app_keys_reset();
 	bt_mesh_net_keys_reset();
 

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -652,7 +652,7 @@ static int va_set(const char *name, size_t len_rd,
 		  settings_read_cb read_cb, void *cb_arg)
 {
 	struct va_val va;
-	struct label *lab;
+	struct bt_mesh_va *lab;
 	uint16_t index;
 	int err;
 
@@ -679,7 +679,7 @@ static int va_set(const char *name, size_t len_rd,
 		return 0;
 	}
 
-	lab = get_label(index);
+	lab = bt_mesh_va_get(index);
 	if (lab == NULL) {
 		BT_WARN("Out of labels buffers");
 		return -ENOBUFS;
@@ -1803,17 +1803,18 @@ static void store_pending_mod(struct bt_mesh_model *mod,
 #define IS_VA_DEL(_label)	((_label)->ref == 0)
 static void store_pending_va(void)
 {
-	struct label *lab;
+	struct bt_mesh_va *lab;
 	struct va_val va;
 	char path[18];
 	uint16_t i;
 	int err;
 
-	for (i = 0; (lab = get_label(i)) != NULL; i++) {
-		if (!atomic_test_and_clear_bit(lab->flags,
-					       BT_MESH_VA_CHANGED)) {
+	for (i = 0; (lab = bt_mesh_va_get(i)) != NULL; i++) {
+		if (!lab->changed) {
 			continue;
 		}
+
+		lab->changed = 0U;
 
 		snprintk(path, sizeof(path), "bt/mesh/Va/%x", i);
 

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -122,6 +122,8 @@ static struct seg_rx {
 
 K_MEM_SLAB_DEFINE(segs, BT_MESH_APP_SEG_SDU_MAX, CONFIG_BT_MESH_SEG_BUFS, 4);
 
+static struct bt_mesh_va virtual_addrs[CONFIG_BT_MESH_LABEL_COUNT];
+
 static uint16_t hb_sub_dst = BT_MESH_ADDR_UNASSIGNED;
 
 void bt_mesh_set_hb_sub_dst(uint16_t addr)
@@ -648,7 +650,7 @@ int bt_mesh_trans_send(struct bt_mesh_net_tx *tx, struct net_buf_simple *msg,
 	}
 
 	if (BT_MESH_ADDR_IS_VIRTUAL(tx->ctx->addr)) {
-		crypto.ad = bt_mesh_label_uuid_get(tx->ctx->addr);
+		crypto.ad = bt_mesh_va_label_get(tx->ctx->addr);
 	}
 
 	err = bt_mesh_app_encrypt(key, &crypto, msg);
@@ -732,7 +734,7 @@ static int sdu_recv(struct bt_mesh_net_rx *rx, uint8_t hdr, uint8_t aszmic,
 	}
 
 	if (BT_MESH_ADDR_IS_VIRTUAL(rx->ctx.recv_dst)) {
-		ctx.crypto.ad = bt_mesh_label_uuid_get(rx->ctx.recv_dst);
+		ctx.crypto.ad = bt_mesh_va_label_get(rx->ctx.recv_dst);
 	}
 
 	rx->ctx.app_idx = bt_mesh_app_key_find(ctx.crypto.dev_key, AID(&hdr),
@@ -1577,18 +1579,31 @@ void bt_mesh_rx_reset(void)
 	for (i = 0; i < ARRAY_SIZE(seg_rx); i++) {
 		seg_rx_reset(&seg_rx[i], true);
 	}
-
-	bt_mesh_rpl_clear();
 }
 
-void bt_mesh_tx_reset(void)
+void bt_mesh_trans_reset(void)
 {
 	int i;
+
+	bt_mesh_rx_reset();
 
 	BT_DBG("");
 
 	for (i = 0; i < ARRAY_SIZE(seg_tx); i++) {
 		seg_tx_reset(&seg_tx[i]);
+	}
+
+	for (i = 0; i < ARRAY_SIZE(virtual_addrs); i++) {
+		if (virtual_addrs[i].ref) {
+			virtual_addrs[i].ref = 0U;
+			virtual_addrs[i].changed = 1U;
+		}
+	}
+
+	bt_mesh_rpl_clear();
+
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		bt_mesh_store_label();
 	}
 }
 
@@ -1655,4 +1670,119 @@ int bt_mesh_heartbeat_send(const struct bt_mesh_send_cb *cb, void *cb_data)
 
 	return bt_mesh_ctl_send(&tx, TRANS_CTL_OP_HEARTBEAT, &hb, sizeof(hb),
 				cb, cb_data);
+}
+
+struct bt_mesh_va *bt_mesh_va_get(uint16_t index)
+{
+	if (index >= ARRAY_SIZE(virtual_addrs)) {
+		return NULL;
+	}
+
+	return &virtual_addrs[index];
+}
+
+static inline void va_store(struct bt_mesh_va *store)
+{
+	store->changed = 1U;
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		bt_mesh_store_label();
+	}
+}
+
+uint8_t bt_mesh_va_add(uint8_t uuid[16], uint16_t *addr)
+{
+	struct bt_mesh_va *va = NULL;
+	int err;
+
+	for (int i = 0; i < ARRAY_SIZE(virtual_addrs); i++) {
+		if (!virtual_addrs[i].ref) {
+			if (!va) {
+				va = &virtual_addrs[i];
+			}
+
+			continue;
+		}
+
+		if (!memcmp(uuid, virtual_addrs[i].uuid,
+			    ARRAY_SIZE(virtual_addrs[i].uuid))) {
+			*addr = virtual_addrs[i].addr;
+			virtual_addrs[i].ref++;
+			va_store(&virtual_addrs[i]);
+			return STATUS_SUCCESS;
+		}
+	}
+
+	if (!va) {
+		return STATUS_INSUFF_RESOURCES;
+	}
+
+	memcpy(va->uuid, uuid, ARRAY_SIZE(va->uuid));
+	err = bt_mesh_virtual_addr(uuid, &va->addr);
+	if (err) {
+		va->addr = BT_MESH_ADDR_UNASSIGNED;
+		return STATUS_UNSPECIFIED;
+	}
+
+	va->ref = 1;
+	va_store(va);
+
+	return STATUS_SUCCESS;
+}
+
+uint8_t bt_mesh_va_del(uint8_t uuid[16], uint16_t *addr)
+{
+	struct bt_mesh_va *va = NULL;
+
+	for (int i = 0; i < ARRAY_SIZE(virtual_addrs); i++) {
+		if (virtual_addrs[i].ref &&
+		    !memcmp(uuid, virtual_addrs[i].uuid,
+			    ARRAY_SIZE(virtual_addrs[i].uuid))) {
+			va = &virtual_addrs[i];
+			break;
+		}
+	}
+
+	if (!va) {
+		return STATUS_CANNOT_REMOVE;
+	}
+
+	va->ref--;
+	if (addr) {
+		*addr = va->addr;
+	}
+
+	va_store(va);
+	return STATUS_SUCCESS;
+}
+
+struct bt_mesh_va *bt_mesh_va_find(uint8_t uuid[16])
+{
+	for (int i = 0; i < ARRAY_SIZE(virtual_addrs); i++) {
+		if (virtual_addrs[i].ref &&
+		    !memcmp(uuid, virtual_addrs[i].uuid,
+			    ARRAY_SIZE(virtual_addrs[i].uuid))) {
+			return &virtual_addrs[i];
+		}
+	}
+
+	return NULL;
+}
+
+uint8_t *bt_mesh_va_label_get(uint16_t addr)
+{
+	int i;
+
+	BT_DBG("addr 0x%04x", addr);
+
+	for (i = 0; i < ARRAY_SIZE(virtual_addrs); i++) {
+		if (virtual_addrs[i].ref && virtual_addrs[i].addr == addr) {
+			BT_DBG("Found Label UUID for 0x%04x: %s", addr,
+			       bt_hex(virtual_addrs[i].uuid, 16));
+			return virtual_addrs[i].uuid;
+		}
+	}
+
+	BT_WARN("No matching Label UUID for 0x%04x", addr);
+
+	return NULL;
 }

--- a/subsys/bluetooth/mesh/transport.h
+++ b/subsys/bluetooth/mesh/transport.h
@@ -79,12 +79,18 @@ struct bt_mesh_ctl_friend_sub_confirm {
 	uint8_t xact;
 } __packed;
 
+struct bt_mesh_va {
+	uint16_t ref:15,
+		 changed:1;
+	uint16_t addr;
+	uint8_t  uuid[16];
+};
+
 void bt_mesh_set_hb_sub_dst(uint16_t addr);
 
 bool bt_mesh_tx_in_progress(void);
 
 void bt_mesh_rx_reset(void);
-void bt_mesh_tx_reset(void);
 
 int bt_mesh_ctl_send(struct bt_mesh_net_tx *tx, uint8_t ctl_op, void *data,
 		     size_t data_len, const struct bt_mesh_send_cb *cb,
@@ -107,4 +113,16 @@ int bt_mesh_trans_recv(struct net_buf_simple *buf, struct bt_mesh_net_rx *rx);
 
 void bt_mesh_trans_init(void);
 
+void bt_mesh_trans_reset(void);
+
 int bt_mesh_heartbeat_send(const struct bt_mesh_send_cb *cb, void *cb_data);
+
+struct bt_mesh_va *bt_mesh_va_get(uint16_t index);
+
+struct bt_mesh_va *bt_mesh_va_find(uint8_t uuid[16]);
+
+uint8_t bt_mesh_va_add(uint8_t uuid[16], uint16_t *addr);
+
+uint8_t bt_mesh_va_del(uint8_t uuid[16], uint16_t *addr);
+
+uint8_t *bt_mesh_va_label_get(uint16_t addr);


### PR DESCRIPTION
Moves the virtual address labels to the transport layer, disconnecting
them from the configuration server.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>