### PR TITLE
net: tcp2: Make sure all incoming data is given to app at eof

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1181,6 +1181,12 @@ next_state:
 			break;
 		} else if (th && FL(&fl, ==, (FIN | ACK | PSH),
 				    th_seq(th) == conn->ack)) {
+			if (len) {
+				if (tcp_data_get(conn, pkt) < 0) {
+					break;
+				}
+			}
+
 			conn_ack(conn, + len + 1);
 			tcp_out(conn, FIN | ACK);
 			next = TCP_LAST_ACK;


### PR DESCRIPTION
When the connection is terminated, make sure that any pending
data is feed to the application.

Fixes #28057

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>