### PR TITLE
usb: Do not check usb_dev.configured in is_dev_configured()

### DIFF
--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -694,7 +694,7 @@ static bool usb_set_interface(uint8_t iface, uint8_t alt_setting)
  */
 static bool is_device_configured(void)
 {
-	return (usb_dev.configured && usb_dev.configuration);
+	return (usb_dev.configuration != 0);
 }
 
 /*


### PR DESCRIPTION
Flag name usb_dev.configured is misleading as it does not
mean the device is configured. This flag indicates whenever
endpoints for the device were enabled. For all classes
except for audio endpoints are enabled on set_configuration
request. This sets the configured flag true. For Audio this
will never happen as what enables audio endpoints is
set_interface request. Without this patch audio samples
will STALL all interface requests.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>

Fixes the bug I introduced in #27969