### PR TITLE
drivers: dma: dmamux init needs k_malloc

### DIFF
--- a/drivers/dma/Kconfig.stm32
+++ b/drivers/dma/Kconfig.stm32
@@ -39,11 +39,4 @@ config DMA_STM32_SHARED_IRQS
 	help
 	  Enable shared IRQ support on devices where channels share 1 IRQ.
 
-if DMAMUX_STM32
-
-config HEAP_MEM_POOL_SIZE
-	default 1024
-
-endif # DMAMUX_STM32
-
 endif # DMA_STM32

--- a/soc/arm/st_stm32/common/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/common/Kconfig.defconfig.series
@@ -75,6 +75,10 @@ if DMA
 config DMA_STM32
 	default y
 
+config HEAP_MEM_POOL_SIZE
+	default 1024
+	depends on DMAMUX_STM32
+
 endif # DMA
 
 endif # SOC_FAMILY_STM32


### PR DESCRIPTION
The dmamux requires HEAP size definition, so that k_malloc
is valid. The HEAP size config is defined in the common for
any stm32 soc instead of specific to dma Kconfig

Fixes #28049

Signed-off-by: Francois Ramu <francois.ramu@st.com>