### PR TITLE
test: thread_stack: relax ram requirement

### DIFF
--- a/tests/kernel/threads/thread_stack/testcase.yaml
+++ b/tests/kernel/threads/thread_stack/testcase.yaml
@@ -1,9 +1,9 @@
 tests:
   kernel.threads.thread_stack:
     tags: kernel security userspace ignore_faults
-    min_ram: 36
+    min_ram: 16
   kernel.threads.armv8m_mpu_stack_guard:
-    min_ram: 36
+    min_ram: 16
     extra_args: CONF_FILE=prj_armv8m_mpu_stack_guard.conf
     filter: CONFIG_ARM_MPU and CONFIG_ARMV8_M_MAINLINE
     arch_allow: arm


### PR DESCRIPTION
Possibly copypasta, or improvements to the test, either way
this test doesn't use that much RAM especially if memory
protection isn't active.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>