### PR TITLE
scripts: west build: default build.pristine to auto

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -150,7 +150,7 @@ class Build(Forceable):
             pristine = args.pristine
         else:
             # Load the pristine={auto, always, never} configuration value
-            pristine = config_get('pristine', 'never')
+            pristine = config_get('pristine', 'auto')
             if pristine not in ['auto', 'always', 'never']:
                 log.wrn(
                     'treating unknown build.pristine value "{}" as "never"'.


### PR DESCRIPTION
I've repeatedly seen that people are not aware of the existence of
this configuration option.

I've been using build.pristine=auto daily for years and never had any
problems. I've also asked around on Slack a couple of times over
various points to see if anybody objects to making this change. Nobody
has, so let's just turn it on by default.

(Details on available build configuration options are in https://docs.zephyrproject.org/latest/guides/west/build-flash-debug.html#configuration-options)