### PR TITLE
toolchain: gcc: Fix fallthrough attribute for old versions

### DIFF
--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -166,8 +166,13 @@ do {                                                                    \
 #endif /* !CONFIG_XIP */
 
 #ifndef __fallthrough
+#if __GNUC__ >= 7
 #define __fallthrough        __attribute__((fallthrough))
+#else
+#define __fallthrough
+#endif	/* __GNUC__ >= 7 */
 #endif
+
 #ifndef __packed
 #define __packed        __attribute__((__packed__))
 #endif


### PR DESCRIPTION
fallthrough attribute was introduced in gcc 7. For older versions the
macro is empty to avoid the follow warnning:

~/zephyrproject/zephyr/lib/os/printk.c:268:5: warning: empty declaration
     __fallthrough;

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>