### PR TITLE
mbedtls: Bump to 2.16.8

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -90,7 +90,7 @@ manifest:
       revision: 928b61c7c8ef5f770f10e6fd36d4fea0cf375b5e
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: 8046c56542f8db737b1d35b9c21b3bd9a5db6d1b
+      revision: aef137b1af8aa7a0f43345c82459254b8832262e
       path: modules/crypto/mbedtls
     - name: mcuboot
       revision: 480421999ec2d8d2a20091e4f3a0393db04de5c4


### PR DESCRIPTION
Update mbedTLS version.

https://github.com/zephyrproject-rtos/mbedtls/pull/15

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>