### PR TITLE
Start QEMU emulation in EL3

### DIFF
--- a/arch/arm/core/aarch64/Kconfig
+++ b/arch/arm/core/aarch64/Kconfig
@@ -26,13 +26,6 @@ config CPU_CORTEX_A72
 	help
 	  This option signifies the use of a Cortex-A72 CPU
 
-config SWITCH_TO_EL1
-	bool "Switch to EL1 at boot"
-	default y
-	help
-	  This option indicates that we want to switch to EL1 at boot. Only
-	  switching to EL1 from EL3 is supported.
-
 config NUM_IRQS
 	int
 

--- a/arch/arm/core/aarch64/fatal.c
+++ b/arch/arm/core/aarch64/fatal.c
@@ -162,36 +162,17 @@ void z_arm64_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 	if (reason != K_ERR_SPURIOUS_IRQ) {
 		__asm__ volatile("mrs %0, CurrentEL" : "=r" (el));
 
-		switch (GET_EL(el)) {
-		case MODE_EL1:
+		if (GET_EL(el) != MODE_EL0) {
 			__asm__ volatile("mrs %0, esr_el1" : "=r" (esr));
 			__asm__ volatile("mrs %0, far_el1" : "=r" (far));
 			__asm__ volatile("mrs %0, elr_el1" : "=r" (elr));
-			break;
-		case MODE_EL2:
-			__asm__ volatile("mrs %0, esr_el2" : "=r" (esr));
-			__asm__ volatile("mrs %0, far_el2" : "=r" (far));
-			__asm__ volatile("mrs %0, elr_el2" : "=r" (elr));
-			break;
-		case MODE_EL3:
-			__asm__ volatile("mrs %0, esr_el3" : "=r" (esr));
-			__asm__ volatile("mrs %0, far_el3" : "=r" (far));
-			__asm__ volatile("mrs %0, elr_el3" : "=r" (elr));
-			break;
-		default:
-			/* Just to keep the compiler happy */
-			esr = elr = far = 0;
-			break;
-		}
 
-		if (GET_EL(el) != MODE_EL0) {
 			LOG_ERR("ESR_ELn: 0x%016llx", esr);
 			LOG_ERR("FAR_ELn: 0x%016llx", far);
 			LOG_ERR("ELR_ELn: 0x%016llx", elr);
 
 			print_EC_cause(esr);
 		}
-
 	}
 
 	if (esf != NULL) {

--- a/arch/arm/core/aarch64/macro_priv.inc
+++ b/arch/arm/core/aarch64/macro_priv.inc
@@ -43,19 +43,8 @@
 	 * Store SPSR_ELn and ELR_ELn. This is needed to support nested
 	 * exception handlers
 	 */
-	switch_el \xreg0, 3f, 2f, 1f
-3:
-	mrs	\xreg1, spsr_el3
-	mrs	\xreg2, elr_el3
-	b	0f
-2:
-	mrs	\xreg1, spsr_el2
-	mrs	\xreg2, elr_el2
-	b	0f
-1:
 	mrs	\xreg1, spsr_el1
 	mrs	\xreg2, elr_el1
-0:
 	stp	\xreg1, \xreg2, [sp, #-16]!
 .endm
 
@@ -77,19 +66,9 @@
 	 * exception handlers
 	 */
 	ldp	\xreg0, \xreg1, [sp], #16
-	switch_el \xreg2, 3f, 2f, 1f
-3:
-	msr	spsr_el3, \xreg0
-	msr	elr_el3, \xreg1
-	b	0f
-2:
-	msr	spsr_el2, \xreg0
-	msr	elr_el2, \xreg1
-	b	0f
-1:
 	msr	spsr_el1, \xreg0
 	msr	elr_el1, \xreg1
-0:
+
 	/*
 	 * In x30 we can have:
 	 *

--- a/arch/arm/core/aarch64/reset.S
+++ b/arch/arm/core/aarch64/reset.S
@@ -120,26 +120,8 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 	eret
 
 2:
-	/* Initialize VBAR */
-	msr	vbar_el2, x19
-
-	/* SError, IRQ and FIQ routing enablement in EL2 */
-	mrs	x0, hcr_el2
-	orr	x0, x0, #(HCR_EL2_FMO | HCR_EL2_IMO | HCR_EL2_AMO)
-	msr	hcr_el2, x0
-
-	/* Disable access trapping in EL2 for NEON/FP */
-	msr	cptr_el2, xzr
-
-	/*
-	 * Enable the instruction cache, stack pointer and data access
-	 * alignment checks.
-	 */
-	mov	x1, #(SCTLR_I_BIT | SCTLR_A_BIT | SCTLR_SA_BIT)
-	mrs	x0, sctlr_el2
-	orr	x0, x0, x1
-	msr	sctlr_el2, x0
-	b	0f
+	/* Booting from EL2 is not supported */
+	b	.
 
 1:
 	/* Initialize VBAR */

--- a/arch/arm/core/aarch64/reset.S
+++ b/arch/arm/core/aarch64/reset.S
@@ -88,7 +88,6 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 	/* Platform specific configurations needed in EL3 */
 	bl	z_arch_el3_plat_init
 
-#ifdef CONFIG_SWITCH_TO_EL1
 	/*
 	* Zephyr entry happened in EL3. Do EL3 specific init before
 	* dropping to lower EL.
@@ -119,17 +118,6 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 	adr	x0, 1f
 	msr	elr_el3, x0
 	eret
-#endif
-	/*
-	 * Enable the instruction cache, stack pointer and data access
-	 * alignment checks.
-	 */
-	mov	x1, #(SCTLR_I_BIT | SCTLR_A_BIT | SCTLR_SA_BIT)
-	mrs	x0, sctlr_el3
-	orr	x0, x0, x1
-	msr	sctlr_el3, x0
-	isb
-	b	0f
 
 2:
 	/* Initialize VBAR */

--- a/arch/arm/core/aarch64/switch.S
+++ b/arch/arm/core/aarch64/switch.S
@@ -97,19 +97,9 @@ SECTION_FUNC(TEXT, z_thread_entry_wrapper)
 	 * arch_new_thread()
 	 */
 	ldp	x0, x1, [sp], #16
-	switch_el x3, 3f, 2f, 1f
-3:
-	msr	spsr_el3, x0
-	msr	elr_el3, x1
-	b	0f
-2:
-	msr	spsr_el2, x0
-	msr	elr_el2, x1
-	b	0f
-1:
 	msr	spsr_el1, x0
 	msr	elr_el1, x1
-0:
+
 	/*
 	 * z_thread_entry_wrapper is called for every new thread upon the return
 	 * of arch_swap() or ISR. Its address, as well as its input function
@@ -140,16 +130,7 @@ GTEXT(z_arm64_svc)
 SECTION_FUNC(TEXT, z_arm64_svc)
 	z_arm64_enter_exc x2, x3, x4
 
-	switch_el x1, 3f, 2f, 1f
-3:
-	mrs	x0, esr_el3
-	b	0f
-2:
-	mrs	x0, esr_el2
-	b	0f
-1:
 	mrs	x0, esr_el1
-0:
 	lsr	x1, x0, #26
 
 	cmp	x1, #0x15 /* 0x15 = SVC */

--- a/boards/arm/qemu_cortex_a53/board.cmake
+++ b/boards/arm/qemu_cortex_a53/board.cmake
@@ -8,6 +8,6 @@ set(QEMU_CPU_TYPE_${ARCH} cortex-a53)
 set(QEMU_FLAGS_${ARCH}
   -cpu ${QEMU_CPU_TYPE_${ARCH}}
   -nographic
-  -machine virt
+  -machine virt,secure=on
   )
 board_set_debugger_ifnset(qemu)


### PR DESCRIPTION
QEMU support for EL3 is mature enough that we can start directly from EL3 and drop to EL1 in the reset routine. Remove also the legacy SWITCH_TO_EL1 because there is no need to have Zephyr running at EL3.

This makes the emulation also closer to what happens on real hardware where the CPU starts usually from EL3.