### PR TITLE
cmake: Ignore LDFLAGS and AFLAGS from environment

### DIFF
--- a/cmake/generic_toolchain.cmake
+++ b/cmake/generic_toolchain.cmake
@@ -11,7 +11,7 @@ if(NOT TOOLCHAIN_ROOT)
 endif()
 
 # Don't inherit compiler flags from the environment
-foreach(var CFLAGS CXXFLAGS CPPFLAGS)
+foreach(var AFLAGS CFLAGS CXXFLAGS CPPFLAGS LDFLAGS)
   if(DEFINED ENV{${var}})
     message(WARNING "The environment variable '${var}' was set to $ENV{${var}},
 but Zephyr ignores flags from the environment. Use 'cmake -DEXTRA_${var}=$ENV{${var}}' instead.")


### PR DESCRIPTION
Zephyr does not use CFLAGS, CXXFLAGS, CPPFLAGS if they are defined in the environment but provides the option to pass them via extra cmake flags.

The option is also for seen to pass AFLAGS and LDFLAGS as extra cmake flags but both of them are not ignored if they are defined in the environment which could lead to unexpected behaviour.

As such lineup the behaviour between all the flags and ignore them, and generate a warning, if they are defined in the environment.

Note that I encountered a linking issue due to the fact that LDFLAGS, amongst others, was defined in my environment and not ignored by zephyr.

