### PR TITLE
samples: shell: fs: fix partition reg

### DIFF
--- a/samples/subsys/shell/fs/boards/particle_xenon.overlay
+++ b/samples/subsys/shell/fs/boards/particle_xenon.overlay
@@ -25,7 +25,7 @@
 			reg = <0x00200000 0x00004000>;
 		};
 		/* A bigger partition for something else. */
-		partition@220000 {
+		partition@204000 {
 			label = "scratch";
 			reg = <0x00204000 0x001fc000>;
 		};


### PR DESCRIPTION
A change to the previous partition resulted in the unit address being
inconsistent with the reg property.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>