### PR TITLE
kernel: sched: robustness enhancements

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -303,9 +303,9 @@ void k_sched_time_slice_set(int32_t slice, int prio)
 static inline int sliceable(struct k_thread *thread)
 {
 	return is_preempt(thread)
+		&& !z_is_thread_prevented_from_running(thread)
 		&& !z_is_prio_higher(thread->base.prio, slice_max_prio)
-		&& !z_is_idle_thread_object(thread)
-		&& !z_is_thread_timeout_active(thread);
+		&& !z_is_idle_thread_object(thread);
 }
 
 /* Called out of each timer interrupt */


### PR DESCRIPTION
Cover cases where data nominally protected by `sched_spinlock` like `thread->base.thread_state` were being accessed unlocked.

- Hold `sched_spinlock` during `z_thread_timeout()`
- Hold `sched_spinlock` during `z_time_slice()`
- Make sure a thread is runnable before `z_time_slice()` puts it on the back of the priority queue
- Use `sched_spinlock` in `z_tick_sleep()` instead of a local lock

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/27533

Please review commit messages.