### PR TITLE
Bluetooth: controller: Fix premature connection event close 

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -385,6 +385,18 @@ config BT_CTLR_TX_RETRY_DISABLE
 	  would happen in the next connection event instead of repeated retries
 	  in the current connection event.
 
+config BT_CTLR_FORCE_MD_COUNT
+	int "Forced MD bit count"
+	range 0 255
+	default 0
+	help
+	  No. of times to force MD bit to be set in Tx PDU after a successful
+	  transmission of non-empty PDU.
+
+	  This will prolong the connection event to from being closed in cases
+	  where applications want to send data in same connection event but are
+	  slow in providing new Tx data.
+
 config BT_CTLR_CONN_RSSI_EVENT
 	bool "Connection RSSI event"
 	depends on BT_CTLR_CONN_RSSI

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -385,6 +385,11 @@ config BT_CTLR_TX_RETRY_DISABLE
 	  would happen in the next connection event instead of repeated retries
 	  in the current connection event.
 
+config BT_CTLR_THROUGHPUT
+	bool "Measure incoming Tx throughput"
+	help
+	  Measure incoming Tx throughput and log the results.
+
 config BT_CTLR_FORCE_MD_COUNT
 	int "Forced MD bit count"
 	range 0 255

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -391,8 +391,9 @@ config BT_CTLR_THROUGHPUT
 	  Measure incoming Tx throughput and log the results.
 
 config BT_CTLR_FORCE_MD_COUNT
-	int "Forced MD bit count"
+	int "Forced MD bit count" if !BT_CTLR_FORCE_MD_AUTO
 	range 0 255
+	default 1 if BT_CTLR_FORCE_MD_AUTO
 	default 0
 	help
 	  No. of times to force MD bit to be set in Tx PDU after a successful
@@ -401,6 +402,14 @@ config BT_CTLR_FORCE_MD_COUNT
 	  This will prolong the connection event to from being closed in cases
 	  where applications want to send data in same connection event but are
 	  slow in providing new Tx data.
+
+config BT_CTLR_FORCE_MD_AUTO
+	bool "Forced MD bit automatic calculation"
+	select BT_CTLR_THROUGHPUT
+	default y if BT_HCI_RAW
+	help
+	  Force MD bit in transmitted PDU based on runtime incoming transmit
+	  data throughput.
 
 config BT_CTLR_CONN_RSSI_EVENT
 	bool "Connection RSSI event"

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -111,7 +111,9 @@ struct evt_hdr {
 };
 
 struct ull_hdr {
-	uint8_t ref; /* Number of ongoing (between Prepare and Done) events */
+	uint8_t volatile ref;  /* Number of ongoing (between Prepare and Done)
+				* events
+				*/
 	void (*disabled_cb)(void *param);
 	void *disabled_param;
 };

--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -122,10 +122,12 @@ struct lll_conn {
 
 int lll_conn_init(void);
 int lll_conn_reset(void);
+void lll_conn_flush(uint16_t handle, struct lll_conn *lll);
 
 uint8_t lll_conn_sca_local_get(void);
 uint32_t lll_conn_ppm_local_get(void);
 uint32_t lll_conn_ppm_get(uint8_t sca);
+
 void lll_conn_prepare_reset(void);
 void lll_conn_abort_cb(struct lll_prepare_param *prepare_param, void *param);
 void lll_conn_isr_rx(void *param);
@@ -133,7 +135,7 @@ void lll_conn_isr_tx(void *param);
 void lll_conn_rx_pkt_set(struct lll_conn *lll);
 void lll_conn_tx_pkt_set(struct lll_conn *lll, struct pdu_data *pdu_data_tx);
 void lll_conn_pdu_tx_prep(struct lll_conn *lll, struct pdu_data **pdu_data_tx);
-void lll_conn_flush(uint16_t handle, struct lll_conn *lll);
+uint8_t lll_conn_force_md_cnt_set(uint8_t force_md_cnt);
 
 extern void ull_conn_lll_ack_enqueue(uint16_t handle, struct node_tx *tx);
 extern uint16_t ull_conn_lll_max_tx_octets_get(struct lll_conn *lll);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -53,6 +53,12 @@ static uint8_t mic_state;
 
 #if defined(CONFIG_BT_CTLR_FORCE_MD_COUNT) && \
 	(CONFIG_BT_CTLR_FORCE_MD_COUNT > 0)
+#if defined(CONFIG_BT_CTLR_FORCE_MD_AUTO)
+static uint8_t force_md_cnt_reload;
+#define BT_CTLR_FORCE_MD_COUNT force_md_cnt_reload
+#else
+#define BT_CTLR_FORCE_MD_COUNT CONFIG_BT_CTLR_FORCE_MD_COUNT
+#endif
 static uint8_t force_md_cnt;
 
 #define FORCE_MD_CNT_INIT() \
@@ -73,7 +79,7 @@ static uint8_t force_md_cnt;
 		do { \
 			if (force_md_cnt || \
 			    (trx_cnt >= ((CONFIG_BT_CTLR_TX_BUFFERS) - 1))) { \
-				force_md_cnt = CONFIG_BT_CTLR_FORCE_MD_COUNT; \
+				force_md_cnt = BT_CTLR_FORCE_MD_COUNT; \
 			} \
 		} while (0)
 
@@ -592,6 +598,18 @@ void lll_conn_pdu_tx_prep(struct lll_conn *lll, struct pdu_data **pdu_data_tx)
 
 	*pdu_data_tx = p;
 }
+
+#if defined(CONFIG_BT_CTLR_FORCE_MD_AUTO)
+uint8_t lll_conn_force_md_cnt_set(uint8_t force_md_cnt)
+{
+	uint8_t previous;
+
+	previous = force_md_cnt_reload;
+	force_md_cnt_reload = force_md_cnt;
+
+	return previous;
+}
+#endif /* CONFIG_BT_CTLR_FORCE_MD_AUTO */
 
 static int init_reset(void)
 {

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -75,6 +75,11 @@ int lll_conn_reset(void)
 	return 0;
 }
 
+void lll_conn_flush(uint16_t handle, struct lll_conn *lll)
+{
+	/* Nothing to be flushed */
+}
+
 uint8_t lll_conn_sca_local_get(void)
 {
 	return CLOCK_CONTROL_NRF_K32SRC_ACCURACY;
@@ -783,9 +788,4 @@ static struct pdu_data *empty_tx_enqueue(struct lll_conn *lll)
 	}
 
 	return p;
-}
-
-void lll_conn_flush(uint16_t handle, struct lll_conn *lll)
-{
-	/* Nothing to be flushed */
 }

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -209,6 +209,7 @@ void lll_conn_isr_rx(void *param)
 
 	/* Decide on event continuation and hence Radio Shorts to use */
 	is_done = is_done || ((crc_ok) && (pdu_data_rx->md == 0) &&
+			      (pdu_data_tx->md == 0) &&
 			      (pdu_data_tx->len == 0));
 
 	if (is_done) {

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1133,7 +1133,7 @@ int ull_disable(void *lll)
 	hdr->disabled_param = &sem;
 	hdr->disabled_cb = disabled_cb;
 
-	if (!hdr->ref) {
+	if (!ull_ref_get(hdr)) {
 		return ULL_STATUS_SUCCESS;
 	}
 
@@ -1857,11 +1857,11 @@ static inline void rx_demux_event_done(memq_link_t *link,
 	}
 
 	/* Decrement prepare reference */
-	LL_ASSERT(ull_hdr->ref);
+	LL_ASSERT(ull_ref_get(ull_hdr));
 	ull_ref_dec(ull_hdr);
 
 	/* If disable initiated, signal the semaphore */
-	if (!ull_hdr->ref && ull_hdr->disabled_cb) {
+	if (!ull_ref_get(ull_hdr) && ull_hdr->disabled_cb) {
 		ull_hdr->disabled_cb(ull_hdr->disabled_param);
 	}
 }

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1526,24 +1526,14 @@ static inline void rx_demux_conn_tx_ack(uint8_t ack_last, uint16_t handle,
 #if !defined(CONFIG_BT_CTLR_LOW_LAT_ULL)
 	do {
 #endif /* CONFIG_BT_CTLR_LOW_LAT_ULL */
-		struct ll_conn *conn;
-
 		/* Dequeue node */
 		ull_conn_ack_dequeue();
 
 		/* Process Tx ack */
-		conn = ull_conn_tx_ack(handle, link, node_tx);
+		ull_conn_tx_ack(handle, link, node_tx);
 
 		/* Release link mem */
 		ull_conn_link_tx_release(link);
-
-		/* De-mux 1 tx node from FIFO */
-		ull_conn_tx_demux(1);
-
-		/* Enqueue towards LLL */
-		if (conn) {
-			ull_conn_tx_lll_enqueue(conn, 1);
-		}
 
 		/* check for more rx ack */
 		link = ull_conn_ack_by_last_peek(ack_last, &handle, &node_tx);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1640,21 +1640,6 @@ static void ticker_stop_cb(uint32_t ticks_at_expire, uint32_t remainder,
 	uint8_t handle;
 	uint32_t ret;
 
-#if 0
-	/* NOTE: abort the event, so as to permit ticker_job execution, if
-	 *       disabled inside events.
-	 */
-	if (adv->ull.ref) {
-		static memq_link_t _link;
-		static struct mayfly _mfy = {0, 0, &_link, NULL, lll_disable};
-
-		_mfy.param = &adv->lll;
-		ret = mayfly_enqueue(TICKER_USER_ID_ULL_HIGH,
-				     TICKER_USER_ID_LLL, 0, &_mfy);
-		LL_ASSERT(!ret);
-	}
-#endif
-
 	handle = ull_adv_handle_get(adv);
 	LL_ASSERT(handle < BT_CTLR_ADV_SET);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1675,7 +1675,7 @@ static void ticker_op_stop_cb(uint32_t status, void *param)
 	adv = param;
 	hdr = &adv->ull;
 	mfy.param = &adv->lll;
-	if (hdr->ref) {
+	if (ull_ref_get(hdr)) {
 		LL_ASSERT(!hdr->disabled_cb);
 		hdr->disabled_param = mfy.param;
 		hdr->disabled_cb = disabled_cb;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
@@ -33,7 +33,6 @@ memq_link_t *ull_conn_ack_peek(uint8_t *ack_last, uint16_t *handle,
 memq_link_t *ull_conn_ack_by_last_peek(uint8_t last, uint16_t *handle,
 				       struct node_tx **tx);
 void *ull_conn_ack_dequeue(void);
-struct ll_conn *ull_conn_tx_ack(uint16_t handle, memq_link_t *link,
-				struct node_tx *tx);
+void ull_conn_tx_ack(uint16_t handle, memq_link_t *link, struct node_tx *tx);
 uint8_t ull_conn_llcp_req(void *conn);
 void ull_conn_upd_curr_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/ull_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_internal.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+static inline uint8_t ull_ref_get(struct ull_hdr *hdr)
+{
+	return hdr->ref;
+}
+
 static inline uint8_t ull_ref_inc(struct ull_hdr *hdr)
 {
 	return ++hdr->ref;

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -752,11 +752,11 @@ void ull_master_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t
 	ref = ull_ref_inc(&conn->ull);
 	LL_ASSERT(ref);
 
-	/* De-mux 1 tx node from FIFO */
-	ull_conn_tx_demux(1);
+	/* De-mux 2 tx node from FIFO, sufficient to be able to set MD bit */
+	ull_conn_tx_demux(2);
 
 	/* Enqueue towards LLL */
-	ull_conn_tx_lll_enqueue(conn, 1);
+	ull_conn_tx_lll_enqueue(conn, 2);
 
 	/* Append timing parameters */
 	p.ticks_at_expire = ticks_at_expire;


### PR DESCRIPTION
Fixes the following:
1. Fix premature connection event close due to the new Tx buffers not being de-multiplexed and routed to connection's Lower Link Layer context when they arrive while being inside the connection's radio event.

2. Fix central role event prepare to demux and enqueue two Tx buffers so that MD bit can be set correctly.

3. Add force MD bit feature wherein connection events can be extended to match the rate at which applications provide new Tx data.
MD bit in Tx PDUs is forced on if there has been CONFIG_BT_CTLR_TX_BUFFERS count number times Tx/Rx happened in a connection event. The assumption here is, if controller's tx buffers are full, it is probable that the application would send more Tx data during the connection event, and keeping the connection event alive will help improve overall throughput.

4. Added feature to in-system measure incoming Tx throughput.

5. Added automatic runtime calculation of Forced MD bit count based on incoming Tx buffer throughput.

Fixes #27981.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>