### PR TITLE
tests: mem_protect: fix two issues

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/src/common.c
+++ b/tests/kernel/mem_protect/mem_protect/src/common.c
@@ -14,7 +14,6 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 	if (valid_fault) {
 		printk("fatal error expected as part of test case\n");
 		valid_fault = false; /* reset back to normal */
-		ztest_test_pass();
 	} else {
 		printk("fatal error was unexpected, aborting\n");
 		k_fatal_halt(reason);

--- a/tests/kernel/mem_protect/mem_protect/src/inherit.c
+++ b/tests/kernel/mem_protect/mem_protect/src/inherit.c
@@ -98,7 +98,7 @@ static void test_thread_1_for_SU(void *p1, void *p2, void *p3)
  * @see k_mem_domain_init(), k_mem_domain_add_thread(),
  * k_thread_access_grant()
  */
-void test_permission_inheritance(void *p1, void *p2, void *p3)
+void test_permission_inheritance(void)
 {
 	k_mem_domain_init(&inherit_mem_domain,
 			  ARRAY_SIZE(inherit_memory_partition_array),
@@ -169,7 +169,7 @@ void parent_handler(void *p1, void *p2, void *p3)
  *
  * @see k_thread_resource_pool_assign()
  */
-void test_inherit_resource_pool(void *p1, void *p2, void *p3)
+void test_inherit_resource_pool(void)
 {
 	k_sem_reset(&sync_sem);
 	k_thread_create(&parent_thr, parent_thr_stack,

--- a/tests/kernel/mem_protect/mem_protect/src/kobject.c
+++ b/tests/kernel/mem_protect/mem_protect/src/kobject.c
@@ -38,7 +38,7 @@ static void kobject_access_grant_user_part(void *p1, void *p2, void *p3)
  *
  * @see k_thread_access_grant(), k_thread_user_mode_enter()
  */
-void test_kobject_access_grant(void *p1, void *p2, void *p3)
+void test_kobject_access_grant(void)
 {
 	set_fault_valid(false);
 
@@ -74,7 +74,7 @@ static void syscall_invalid_kobject_user_part(void *p1, void *p2, void *p3)
  *
  * @see k_thread_access_grant()
  */
-void test_syscall_invalid_kobject(void *p1, void *p2, void *p3)
+void test_syscall_invalid_kobject(void)
 {
 	set_fault_valid(false);
 
@@ -105,7 +105,7 @@ static void thread_without_kobject_permission_user_part(void *p1, void *p2,
  *
  * @see k_thread_access_grant(), k_thread_user_mode_enter()
  */
-void test_thread_without_kobject_permission(void *p1, void *p2, void *p3)
+void test_thread_without_kobject_permission(void)
 {
 	set_fault_valid(false);
 
@@ -136,7 +136,7 @@ static void kobject_revoke_access_user_part(void *p1, void *p2, void *p3)
  *
  * @see k_thread_access_grant(), k_object_access_revoke()
  */
-void test_kobject_revoke_access(void *p1, void *p2, void *p3)
+void test_kobject_revoke_access(void)
 {
 	set_fault_valid(false);
 
@@ -186,7 +186,7 @@ static void kobject_grant_access_extra_entry(void *p1, void *p2, void *p3)
  *
  * @see k_thread_access_grant()
  */
-void test_kobject_grant_access_kobj(void *p1, void *p2, void *p3)
+void test_kobject_grant_access_kobj(void)
 {
 	set_fault_valid(false);
 
@@ -232,7 +232,7 @@ static void grant_access_kobj_invalid_child(void *p1, void *p2, void *p3)
  *
  * @see k_thread_access_grant()
  */
-void test_kobject_grant_access_kobj_invalid(void *p1, void *p2, void *p3)
+void test_kobject_grant_access_kobj_invalid(void)
 {
 	set_fault_valid(false);
 
@@ -266,7 +266,7 @@ static void release_from_user_child(void *p1, void *p2, void *p3)
  *
  * @see k_thread_access_grant(), k_object_release()
  */
-void test_kobject_release_from_user(void *p1, void *p2, void *p3)
+void test_kobject_release_from_user(void)
 {
 	set_fault_valid(false);
 
@@ -303,7 +303,7 @@ static void access_all_grant_child_take(void *p1, void *p2, void *p3)
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_kobject_access_all_grant(void *p1, void *p2, void *p3)
+void test_kobject_access_all_grant(void)
 {
 	set_fault_valid(false);
 
@@ -351,7 +351,7 @@ static void residual_permissions_child_fail(void *p1, void *p2, void *p3)
  *
  * @see k_thread_access_grant()
  */
-void test_thread_has_residual_permissions(void *p1, void *p2, void *p3)
+void test_thread_has_residual_permissions(void)
 {
 	set_fault_valid(false);
 
@@ -386,7 +386,7 @@ void test_thread_has_residual_permissions(void *p1, void *p2, void *p3)
  * @see k_object_access_grant(), k_object_access_revoke(),
  * z_object_find()
  */
-void test_kobject_access_grant_to_invalid_thread(void *p1, void *p2, void *p3)
+void test_kobject_access_grant_to_invalid_thread(void)
 {
 	static struct k_thread uninit_thread;
 
@@ -407,7 +407,7 @@ void test_kobject_access_grant_to_invalid_thread(void *p1, void *p2, void *p3)
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_kobject_access_invalid_kobject(void *p1, void *p2, void *p3)
+void test_kobject_access_invalid_kobject(void)
 {
 	set_fault_valid(true);
 
@@ -425,8 +425,7 @@ void test_kobject_access_invalid_kobject(void *p1, void *p2, void *p3)
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_access_kobject_without_init_access(void *p1,
-					     void *p2, void *p3)
+void test_access_kobject_without_init_access(void)
 {
 	set_fault_valid(true);
 
@@ -451,8 +450,7 @@ static void without_init_with_access_child(void *p1, void *p2, void *p3)
  *
  * @see k_thread_access_grant()
  */
-void test_access_kobject_without_init_with_access(void *p1,
-						  void *p2, void *p3)
+void test_access_kobject_without_init_with_access(void)
 {
 	set_fault_valid(false);
 
@@ -495,7 +493,7 @@ static void reinitialize_thread_kobj_child(void *p1, void *p2, void *p3)
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_kobject_reinitialize_thread_kobj(void *p1, void *p2, void *p3)
+void test_kobject_reinitialize_thread_kobj(void)
 {
 	set_fault_valid(false);
 
@@ -541,7 +539,7 @@ static void new_thread_from_user_child(void *p1, void *p2, void *p3)
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_create_new_thread_from_user(void *p1, void *p2, void *p3)
+void test_create_new_thread_from_user(void)
 {
 	set_fault_valid(false);
 
@@ -591,7 +589,7 @@ static void new_user_thrd_child_with_in_use_stack(void *p1, void *p2, void *p3)
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_new_user_thread_with_in_use_stack_obj(void *p1, void *p2, void *p3)
+void test_new_user_thread_with_in_use_stack_obj(void)
 {
 	set_fault_valid(false);
 
@@ -635,8 +633,7 @@ static void from_user_no_access_stack_child_entry(void *p1, void *p2, void *p3)
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_create_new_thread_from_user_no_access_stack(void *p1,
-						      void *p2, void *p3)
+void test_create_new_thread_from_user_no_access_stack(void)
 {
 	set_fault_valid(false);
 
@@ -680,8 +677,7 @@ static void from_user_invalid_stacksize_child(void *p1, void *p2, void *p3)
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_create_new_thread_from_user_invalid_stacksize(void *p1,
-							void *p2, void *p3)
+void test_create_new_thread_from_user_invalid_stacksize(void)
 {
 	set_fault_valid(false);
 
@@ -698,8 +694,7 @@ void test_create_new_thread_from_user_invalid_stacksize(void *p1,
 	k_thread_join(&child_thread, K_FOREVER);
 }
 #else
-void test_create_new_thread_from_user_invalid_stacksize(void *p1,
-							void *p2, void *p3)
+void test_create_new_thread_from_user_invalid_stacksize(void)
 {
 	ztest_test_skip();
 }
@@ -736,8 +731,7 @@ static void user_huge_stacksize_child(void *p1, void *p2, void *p3)
  * @ingroup kernel_memprotect_tests
  */
 
-void test_create_new_thread_from_user_huge_stacksize(void *p1,
-						     void *p2, void *p3)
+void test_create_new_thread_from_user_huge_stacksize(void)
 {
 	set_fault_valid(false);
 
@@ -755,8 +749,7 @@ void test_create_new_thread_from_user_huge_stacksize(void *p1,
 	k_thread_join(&child_thread, K_FOREVER);
 }
 #else
-void test_create_new_thread_from_user_huge_stacksize(void *p1,
-						     void *p2, void *p3)
+void test_create_new_thread_from_user_huge_stacksize(void)
 {
 	ztest_test_skip();
 }
@@ -792,7 +785,7 @@ static void supervisor_from_user_child(void *p1, void *p2, void *p3)
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_create_new_supervisor_thread_from_user(void *p1, void *p2, void *p3)
+void test_create_new_supervisor_thread_from_user(void)
 {
 	set_fault_valid(false);
 
@@ -836,7 +829,7 @@ static void essential_thread_from_user_child(void *p1, void *p2, void *p3)
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_create_new_essential_thread_from_user(void *p1, void *p2, void *p3)
+void test_create_new_essential_thread_from_user(void)
 {
 	set_fault_valid(false);
 
@@ -882,7 +875,7 @@ static void higher_prio_from_user_child(void *p1, void *p2, void *p3)
  * @ingroup kernel_memprotect_tests
  */
 
-void test_create_new_higher_prio_thread_from_user(void *p1, void *p2, void *p3)
+void test_create_new_higher_prio_thread_from_user(void)
 {
 	set_fault_valid(false);
 
@@ -929,7 +922,7 @@ static void invalid_prio_from_user_child(void *p1, void *p2, void *p3)
  * @ingroup kernel_memprotect_tests
  */
 
-void test_create_new_invalid_prio_thread_from_user(void *p1, void *p2, void *p3)
+void test_create_new_invalid_prio_thread_from_user(void)
 {
 	set_fault_valid(false);
 

--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -14,41 +14,6 @@
 #include <stdlib.h>
 #include "mem_protect.h"
 
-extern void test_permission_inheritance(void);
-extern void test_mem_domain_valid_access(void);
-extern void test_mem_domain_invalid_access(void);
-extern void test_mem_domain_partitions_user_rw(void);
-extern void test_mem_domain_partitions_user_ro(void);
-extern void test_mem_domain_partitions_supervisor_rw(void);
-extern void test_mem_domain_add_partitions_invalid(void);
-extern void test_mem_domain_add_partitions_simple(void);
-extern void test_mem_domain_remove_partitions_simple(void);
-extern void test_mem_domain_remove_partitions(void);
-extern void test_kobject_access_grant(void);
-extern void test_syscall_invalid_kobject(void);
-extern void test_thread_without_kobject_permission(void);
-extern void test_kobject_revoke_access(void);
-extern void test_kobject_grant_access_kobj(void);
-extern void test_kobject_grant_access_kobj_invalid(void);
-extern void test_kobject_release_from_user(void);
-extern void test_kobject_access_all_grant(void);
-extern void test_thread_has_residual_permissions(void);
-extern void test_kobject_access_grant_to_invalid_thread(void);
-extern void test_kobject_access_invalid_kobject(void);
-extern void test_access_kobject_without_init_access(void);
-extern void test_access_kobject_without_init_with_access(void);
-extern void test_kobject_reinitialize_thread_kobj(void);
-extern void test_create_new_thread_from_user(void);
-extern void test_new_user_thread_with_in_use_stack_obj(void);
-extern void test_create_new_thread_from_user_no_access_stack(void);
-extern void test_create_new_thread_from_user_invalid_stacksize(void);
-extern void test_create_new_thread_from_user_huge_stacksize(void);
-extern void test_create_new_supervisor_thread_from_user(void);
-extern void test_create_new_essential_thread_from_user(void);
-extern void test_create_new_higher_prio_thread_from_user(void);
-extern void test_create_new_invalid_prio_thread_from_user(void);
-extern void test_inherit_resource_pool(void);
-extern void test_mark_thread_exit_uninitialized(void);
 
 void test_main(void)
 {

--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -120,7 +120,7 @@ static void mem_domain_test_1(void *tc_number, void *p2, void *p3)
  *
  * @see k_mem_domain_init()
  */
-void test_mem_domain_valid_access(void *p1, void *p2, void *p3)
+void test_mem_domain_valid_access(void)
 {
 	uintptr_t tc_number = 1U;
 
@@ -145,7 +145,7 @@ void test_mem_domain_valid_access(void *p1, void *p2, void *p3)
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_mem_domain_invalid_access(void *p1, void *p2, void *p3)
+void test_mem_domain_invalid_access(void)
 {
 	uintptr_t tc_number = 2U;
 
@@ -342,7 +342,7 @@ static void mem_domain_for_user_tc3(void *max_partitions, void *p2, void *p3)
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_mem_domain_add_partitions_invalid(void *p1, void *p2, void *p3)
+void test_mem_domain_add_partitions_invalid(void)
 {
 	/* Subtract one since the domain is initialized with one partition
 	 * already present.
@@ -404,7 +404,7 @@ static void mem_domain_for_user_tc4(void *max_partitions, void *p2, void *p3)
  * @see k_mem_domain_init(), k_mem_domain_add_partition(),
  * k_mem_domain_add_thread(), k_thread_user_mode_enter()
  */
-void test_mem_domain_add_partitions_simple(void *p1, void *p2, void *p3)
+void test_mem_domain_add_partitions_simple(void)
 {
 
 	uint8_t max_partitions = (uint8_t)arch_mem_domain_max_partitions_get();
@@ -450,7 +450,7 @@ static void mem_domain_for_user_tc5(void *p1, void *p2, void *p3)
  * @see k_mem_domain_remove_partition(),
  * k_mem_domain_add_thread(), k_thread_user_mode_enter()
  */
-void test_mem_domain_remove_partitions_simple(void *p1, void *p2, void *p3)
+void test_mem_domain_remove_partitions_simple(void)
 {
 	k_mem_domain_add_thread(&mem_domain_tc3_mem_domain,
 				k_current_get());
@@ -491,7 +491,7 @@ static void mem_domain_test_6_2(void *p1, void *p2, void *p3)
  *
  * @see k_mem_domain_remove_partition()
  */
-void test_mem_domain_remove_partitions(void *p1, void *p2, void *p3)
+void test_mem_domain_remove_partitions(void)
 {
 	uint8_t max_partitions = (uint8_t)arch_mem_domain_max_partitions_get();
 

--- a/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
@@ -10,6 +10,42 @@
 #include <string.h>
 #include <stdlib.h>
 
+extern void test_permission_inheritance(void);
+extern void test_mem_domain_valid_access(void);
+extern void test_mem_domain_invalid_access(void);
+extern void test_mem_domain_partitions_user_rw(void);
+extern void test_mem_domain_partitions_user_ro(void);
+extern void test_mem_domain_partitions_supervisor_rw(void);
+extern void test_mem_domain_add_partitions_invalid(void);
+extern void test_mem_domain_add_partitions_simple(void);
+extern void test_mem_domain_remove_partitions_simple(void);
+extern void test_mem_domain_remove_partitions(void);
+extern void test_kobject_access_grant(void);
+extern void test_syscall_invalid_kobject(void);
+extern void test_thread_without_kobject_permission(void);
+extern void test_kobject_revoke_access(void);
+extern void test_kobject_grant_access_kobj(void);
+extern void test_kobject_grant_access_kobj_invalid(void);
+extern void test_kobject_release_from_user(void);
+extern void test_kobject_access_all_grant(void);
+extern void test_thread_has_residual_permissions(void);
+extern void test_kobject_access_grant_to_invalid_thread(void);
+extern void test_kobject_access_invalid_kobject(void);
+extern void test_access_kobject_without_init_access(void);
+extern void test_access_kobject_without_init_with_access(void);
+extern void test_kobject_reinitialize_thread_kobj(void);
+extern void test_create_new_thread_from_user(void);
+extern void test_new_user_thread_with_in_use_stack_obj(void);
+extern void test_create_new_thread_from_user_no_access_stack(void);
+extern void test_create_new_thread_from_user_invalid_stacksize(void);
+extern void test_create_new_thread_from_user_huge_stacksize(void);
+extern void test_create_new_supervisor_thread_from_user(void);
+extern void test_create_new_essential_thread_from_user(void);
+extern void test_create_new_higher_prio_thread_from_user(void);
+extern void test_create_new_invalid_prio_thread_from_user(void);
+extern void test_inherit_resource_pool(void);
+extern void test_mark_thread_exit_uninitialized(void);
+
 /* Flag needed to figure out if the fault was expected or not. */
 extern volatile bool valid_fault;
 


### PR DESCRIPTION
This fixes two very subtle problems with the mem_protect test.

The first is that this tests was calling `ztest_test_pass()` out of a fatal exception handler for a child thread. On an SMP system, this could cause the next test case to immediately start on another CPU before the child thread self-exits. If the next test tried to recycle the child thread object, the kernel goes haywire. Fixes a very rare crash on x86_64 (and other SMP systems). This could simply be removed since the ztest thread is joining on the child threads anyway.

The second fixes a problem where the implementations of the test functions had the wrong prototype. The extern prototypes in another C file (?? why not a header?) *were* correct (otherwise the setup of the test suite would have caught it) and we had a mismatch. This on x86 fooled the compiler into thinking the stack frame was laid out in a way that wasn't true if it tried to chain execution with `jmp` to the last function in the test case instead of calling it and then issuing `ret`, since x86 marshals arguments on the stack and not registers.

Debugging the latter issue was the engineering equivalent of slowly going insane staring at assembly code and stack contents, wondering if the compiler was bugged