### PR TITLE
subsys: power: decouple device power management and specific board

### DIFF
--- a/subsys/power/Kconfig
+++ b/subsys/power/Kconfig
@@ -92,5 +92,9 @@ config DEVICE_POWER_MANAGEMENT
 	  like turning off device clocks and peripherals. The device drivers
 	  may also save and restore states in these hook functions.
 
+config PM_MAX_DEVICES
+	int "Max number of devices support power management"
+	depends on DEVICE_POWER_MANAGEMENT
+	default 15
 
 endmenu

--- a/subsys/power/device.c
+++ b/subsys/power/device.c
@@ -21,37 +21,24 @@ LOG_MODULE_DECLARE(power);
  * to build the device list based on devices power
  * and clock domain dependencies.
  */
+
+__weak const char *const z_pm_core_devices[] = {
 #if defined(CONFIG_SOC_FAMILY_NRF)
-#define MAX_PM_DEVICES	15
-static const char *const core_devices[] = {
 	"CLOCK",
 	"sys_clock",
 	"UART_0",
-};
 #elif defined(CONFIG_SOC_SERIES_CC13X2_CC26X2)
-#define MAX_PM_DEVICES	15
-static const char *const core_devices[] = {
 	"sys_clock",
 	"UART_0",
-};
 #elif defined(CONFIG_SOC_SERIES_KINETIS_K6X)
-#define MAX_PM_DEVICES		1
-static const char *const core_devices[] = {
 	DT_LABEL(DT_INST(0, nxp_kinetis_ethernet)),
-};
 #elif defined(CONFIG_NET_TEST)
-#define MAX_PM_DEVICES		1
-static const char *const core_devices[] = {
 	"",
-};
 #elif defined(CONFIG_SOC_SERIES_STM32L4X) || defined(CONFIG_SOC_SERIES_STM32WBX)
-#define MAX_PM_DEVICES	1
-static const char *const core_devices[] = {
 	"sys_clock",
-};
-#else
-#error "Add SoC's core devices list for PM"
 #endif
+	NULL
+};
 
 /* Ordinal of sufficient size to index available devices. */
 typedef uint16_t device_idx_t;
@@ -65,7 +52,7 @@ static const struct device *all_devices;
 /* Indexes into all_devices for devices that support pm,
  * in dependency order (later may depend on earlier).
  */
-static device_idx_t pm_devices[MAX_PM_DEVICES];
+static device_idx_t pm_devices[CONFIG_PM_MAX_DEVICES];
 
 /* Number of devices that support pm */
 static device_idx_t num_pm;
@@ -149,7 +136,7 @@ void sys_pm_resume_devices(void)
 void sys_pm_create_device_list(void)
 {
 	size_t count = z_device_get_all_static(&all_devices);
-	device_idx_t pmi;
+	device_idx_t pmi, core_dev;
 
 	/*
 	 * Create an ordered list of devices that will be suspended.
@@ -160,9 +147,15 @@ void sys_pm_create_device_list(void)
 	__ASSERT_NO_MSG(count <= DEVICE_IDX_MAX);
 
 	/* Reserve initial slots for core devices. */
-	num_pm = ARRAY_SIZE(core_devices);
+	core_dev = 0;
+	while (z_pm_core_devices[core_dev]) {
+		core_dev++;
+	}
 
-	for (pmi = 0; (pmi < count) && (num_pm < MAX_PM_DEVICES); pmi++) {
+	num_pm = core_dev;
+	__ASSERT_NO_MSG(num_pm <= CONFIG_PM_MAX_DEVICES);
+
+	for (pmi = 0; pmi < count; pmi++) {
 		device_idx_t cdi = 0;
 		const struct device *dev = &all_devices[pmi];
 
@@ -174,8 +167,8 @@ void sys_pm_create_device_list(void)
 		/* Check if the device is a core device, which has a
 		 * reserved slot.
 		 */
-		while (cdi < ARRAY_SIZE(core_devices)) {
-			if (strcmp(dev->name, core_devices[cdi]) == 0) {
+		while (z_pm_core_devices[cdi]) {
+			if (strcmp(dev->name, z_pm_core_devices[cdi]) == 0) {
 				pm_devices[cdi] = pmi;
 				break;
 			}
@@ -183,7 +176,7 @@ void sys_pm_create_device_list(void)
 		}
 
 		/* Append the device if it doesn't have a reserved slot. */
-		if (cdi == ARRAY_SIZE(core_devices)) {
+		if (cdi == core_dev) {
 			pm_devices[num_pm++] = pmi;
 		}
 	}


### PR DESCRIPTION
When try to enable CONFIG_DEVICE_POWER_MANAGEMENT for a board,
the #error directive in subsys/power/device.c requires that
"MAX_PM_DEVICE" and "core_devices[]" must be defined exactly in that
file, or a compile error will come up.
For flexibility, this patch move "MAX_PM_DEVICE" to Kconfig and define
a weak version of "core_devices[]", so any board or SOC can define
these varibles in their own module.

Signed-off-by: Meng xianglin <xianglinx.meng@intel.com>

Fixes #28099