### PR TITLE
cmake: c++ compiler flag exclusion, -Werror=implicit-int

### DIFF
--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -104,7 +104,7 @@ check_set_compiler_property(PROPERTY warning_extended
                             -Wno-tautological-compare
 )
 
-set_compiler_property(PROPERTY warning_error_implicit_int -Werror=implicit-int)
+check_set_compiler_property(PROPERTY warning_error_implicit_int -Werror=implicit-int)
 
 set_compiler_property(PROPERTY warning_error_misra_sane -Werror=vla)
 

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -91,7 +91,7 @@ check_set_compiler_property(APPEND PROPERTY warning_dw_3
 
 set_compiler_property(PROPERTY warning_extended -Wno-unused-but-set-variable)
 
-set_compiler_property(PROPERTY warning_error_implicit_int -Werror=implicit-int)
+check_set_compiler_property(PROPERTY warning_error_implicit_int -Werror=implicit-int)
 
 set_compiler_property(PROPERTY warning_error_misra_sane -Werror=vla)
 


### PR DESCRIPTION
Fixes: #28097

The compiler warning flag `-Werror=implicit-int` was added using
`set_compiler_property()` which will always add the compiler flag if the
compiler flag supports it.

This has been changed to `check_set_compiler_property()` which will
check if the flag is among the list of `CXX_EXCLUDED_OPTIONS`, and only
adds the flag if both the compiler supports it, and it is not an
excluded option.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>