### PR TITLE
ARM64: Remove new thread entry wrapper and cleanup

### DIFF
--- a/arch/arm/core/aarch64/isr_wrapper.S
+++ b/arch/arm/core/aarch64/isr_wrapper.S
@@ -111,13 +111,6 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 	/* Switch thread */
 	bl	z_arm64_context_switch
 
-	/* We return here in two cases:
-	 *
-	 * - The ISR was taken and no context switch was performed.
-	 * - A context-switch was performed during the ISR in the past and now
-	 *   the thread has been switched in again and we return here from the
-	 *   ret in z_arm64_context_switch() because x30 was saved and restored.
-	 */
 exit:
 #ifdef CONFIG_STACK_SENTINEL
 	bl	z_check_stack_sentinel

--- a/arch/arm/core/aarch64/isr_wrapper.S
+++ b/arch/arm/core/aarch64/isr_wrapper.S
@@ -36,10 +36,7 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 	z_arm64_enter_exc x0, x1, x2
 
 	/* ++(_kernel->nested) to be checked by arch_is_in_isr() */
-	ldr	x0, =_kernel
-	ldr	x1, [x0, #_kernel_offset_to_nested]
-	add	x1, x1, #1
-	str	x1, [x0, #_kernel_offset_to_nested]
+	inc_nest_counter x0, x1
 
 #ifdef CONFIG_TRACING
 	bl	sys_trace_isr_enter
@@ -80,10 +77,7 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 #endif
 
 	/* --(_kernel->nested) */
-	ldr	x0, =_kernel
-	ldr	x1, [x0, #_kernel_offset_to_nested]
-	sub	x1, x1, #1
-	str	x1, [x0, #_kernel_offset_to_nested]
+	dec_nest_counter x0, x1
 
 	cmp	x1, #0
 	bne	exit

--- a/arch/arm/core/aarch64/macro_priv.inc
+++ b/arch/arm/core/aarch64/macro_priv.inc
@@ -101,6 +101,32 @@
 	eret
 .endm
 
+/**
+ * @brief Increment nested counter
+ *
+ * @return N/A
+ */
+
+.macro inc_nest_counter xreg0, xreg1
+	ldr	\xreg0, =_kernel
+	ldr	\xreg1, [\xreg0, #_kernel_offset_to_nested]
+	add	\xreg1, \xreg1, #1
+	str	\xreg1, [\xreg0, #_kernel_offset_to_nested]
+.endm
+
+/**
+ * @brief Decrement nested counter
+ *
+ * @return N/A
+ */
+
+.macro dec_nest_counter xreg0, xreg1
+	ldr	\xreg0, =_kernel
+	ldr	\xreg1, [\xreg0, #_kernel_offset_to_nested]
+	sub	\xreg1, \xreg1, #1
+	str	\xreg1, [\xreg0, #_kernel_offset_to_nested]
+.endm
+
 #endif /* _ASMLANGUAGE */
 
 #endif /* _MACRO_PRIV_INC_ */

--- a/arch/arm/core/aarch64/switch.S
+++ b/arch/arm/core/aarch64/switch.S
@@ -103,18 +103,12 @@ SECTION_FUNC(TEXT, z_arm64_svc)
 	b	inv
 offload:
 	/* ++(_kernel->nested) to be checked by arch_is_in_isr() */
-	ldr	x0, =_kernel
-	ldr	x1, [x0, #_kernel_offset_to_nested]
-	add	x1, x1, #1
-	str	x1, [x0, #_kernel_offset_to_nested]
+	inc_nest_counter x0, x1
 
 	bl	z_irq_do_offload
 
 	/* --(_kernel->nested) */
-	ldr	x0, =_kernel
-	ldr	x1, [x0, #_kernel_offset_to_nested]
-	sub	x1, x1, #1
-	str	x1, [x0, #_kernel_offset_to_nested]
+	dec_nest_counter x0, x1
 	b	exit
 #endif
 	b	inv

--- a/arch/arm/core/aarch64/switch.S
+++ b/arch/arm/core/aarch64/switch.S
@@ -42,7 +42,7 @@ SECTION_FUNC(TEXT, z_arm64_context_switch)
 	stp	x23, x24, [x2], #16
 	stp	x25, x26, [x2], #16
 	stp	x27, x28, [x2], #16
-	stp	x29, x30, [x2], #16
+	stp	x29, xzr, [x2], #16
 
 	/* Save the current SP */
 	mov	x1, sp
@@ -52,13 +52,13 @@ SECTION_FUNC(TEXT, z_arm64_context_switch)
 	ldr	x2, =_thread_offset_to_callee_saved
 	add	x2, x2, x0
 
-	/* Restore x19-x29 plus x30 */
+	/* Restore x19-x29 */
 	ldp	x19, x20, [x2], #16
 	ldp	x21, x22, [x2], #16
 	ldp	x23, x24, [x2], #16
 	ldp	x25, x26, [x2], #16
 	ldp	x27, x28, [x2], #16
-	ldp	x29, x30, [x2], #16
+	ldp	x29, xzr, [x2], #16
 
 	ldr	x1, [x2]
 	mov	sp, x1
@@ -69,54 +69,10 @@ SECTION_FUNC(TEXT, z_arm64_context_switch)
 	ldp	xzr, x30, [sp], #16
 #endif
 
-	/* We restored x30 from the process stack. There are three possible
-	 * cases:
-	 *
-	 * - We return to z_arm64_svc() when swapping in a thread that was
-	 *   swapped out by z_arm64_svc() before jumping into
-	 *   z_arm64_exit_exc()
-	 * - We return to _isr_wrapper() when swapping in a thread that was
-	 *   swapped out by _isr_wrapper() before jumping into
-	 *   z_arm64_exit_exc()
-	 * - We return (jump) into z_thread_entry_wrapper() for new threads
-	 *   (see thread.c)
-	 */
+	/* Return to z_arm64_svc() or _isr_wrapper() */
 	ret
 
 /**
- *
- * @brief Entry wrapper for new threads
- *
- * @return N/A
- */
-
-GTEXT(z_thread_entry_wrapper)
-SECTION_FUNC(TEXT, z_thread_entry_wrapper)
-	/*
-	 * Restore SPSR_ELn and ELR_ELn saved in the temporary stack by
-	 * arch_new_thread()
-	 */
-	ldp	x0, x1, [sp], #16
-	msr	spsr_el1, x0
-	msr	elr_el1, x1
-
-	/*
-	 * z_thread_entry_wrapper is called for every new thread upon the return
-	 * of arch_swap() or ISR. Its address, as well as its input function
-	 * arguments thread_entry_t, void *, void *, void * are restored from
-	 * the thread stack (see thread.c).
-	 * In this case, thread_entry_t, * void *, void * and void * are stored
-	 * in registers x0, x1, x2 and x3. These registers are used as arguments
-	 * to function z_thread_entry.
-	 */
-	ldp	x0, x1, [sp], #16
-	ldp	x2, x3, [sp], #16
-
-	/* ELR_ELn was set in thread.c to z_thread_entry() */
-	eret
-
-/**
- *
  * @brief Service call handler
  *
  * The service call (SVC) is used in the following occasions:

--- a/include/arch/arm/aarch64/thread.h
+++ b/include/arch/arm/aarch64/thread.h
@@ -34,7 +34,7 @@ struct _callee_saved {
 	uint64_t x27;
 	uint64_t x28;
 	uint64_t x29; /* FP */
-	uint64_t x30; /* LR */
+	uint64_t xzr;
 	uint64_t sp;
 };
 


### PR DESCRIPTION
Three commits aiming at reducing and simplifying the assembly code and the context switch routines. Most importantly we are removing the new thread entry wrapper code using instead the general code for context switch. To do that we have to slightly modify the initial stack frame.

We are also introducing a couple of new macros and give a better name to the save / restore context macros.