### PR TITLE
Bluetooth: controller: Scanning with unreserved window

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -413,6 +413,14 @@ config BT_CTLR_SCAN_INDICATION
 	help
 	  Generate events indicating on air scanner events.
 
+config BT_CTLR_SCAN_UNRESERVED
+	bool "Unreserved scan window"
+	depends on BT_OBSERVER
+	default y if BT_MESH
+	help
+	  Scanner will not use time space reservation for scan window when in
+	  continuous scan mode.
+
 config BT_MAYFLY_YIELD_AFTER_CALL
 	bool "Yield from mayfly thread after first call"
 	default y

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -294,10 +294,14 @@ uint8_t ull_scan_enable(struct ll_scan_set *scan)
 			(lll->ticks_window +
 			 HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US));
 	} else {
-		scan->evt.ticks_slot =
-			(ticks_interval -
-			 HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US));
-		lll->ticks_window = 0;
+		if (IS_ENABLED(CONFIG_BT_CTLR_SCAN_UNRESERVED)) {
+			scan->evt.ticks_slot = 0U;
+		} else {
+			scan->evt.ticks_slot = ticks_interval -
+				HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
+		}
+
+		lll->ticks_window = 0U;
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {


### PR DESCRIPTION
Added a Kconfig option to enable scanner with unreserved
scan window when in continuous scan mode. This will permit
scanner to be always pre-empted by other roles, making it
the lowest in priority when it comes to using the radio.

Fixes #27414.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>


Before:
![image](https://user-images.githubusercontent.com/6350656/92371492-f4a2f800-f0fb-11ea-94a7-1e192dbf7a05.png)

After:
![image](https://user-images.githubusercontent.com/6350656/92371852-73983080-f0fc-11ea-8bde-e8e5caf94fd4.png)

