### PR TITLE
CODEOWNERS: Add reviewers on stm32 components

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -44,6 +44,7 @@
 /soc/arm/qemu_cortex_a53/                 @carlocaione
 /soc/arm/silabs_exx32/efr32mg21/          @l-alfred
 /soc/arm/st_stm32/                        @erwango
+/soc/arm/st_stm32/*/power.c               @FRASTM
 /soc/arm/st_stm32/stm32f4/                @idlethread
 /soc/arm/st_stm32/stm32mp1/               @arnopo
 /soc/arm/ti_simplelink/cc13x2_cc26x2/     @bwitherspoon
@@ -91,7 +92,7 @@
 /boards/arm/mps2_an385/                   @fvincenzo
 /boards/arm/msp_exp432p401r_launchxl/     @Mani-Sadhasivam
 /boards/arm/nrf*/                         @carlescufi @lemrey @ioannisg
-/boards/arm/nucleo*/                      @erwango
+/boards/arm/nucleo*/                      @erwango, @ABOSTM, @FRASTM
 /boards/arm/nucleo_f401re/                @idlethread
 /boards/arm/nuvoton_pfm_m487/             @ssekar15
 /boards/arm/qemu_cortex_a53/              @carlocaione
@@ -107,9 +108,9 @@
 /boards/arm/sensortile_box/               @avisconti
 /boards/arm/steval_fcu001v1/              @Navin-Sankar
 /boards/arm/stm32l1_disco/                @karlp
-/boards/arm/stm32*_disco/                 @erwango
+/boards/arm/stm32*_disco/                 @erwango, @ABOSTM, @FRASTM
 /boards/arm/stm32f3_disco/                @ydamigos
-/boards/arm/stm32*_eval/                  @erwango
+/boards/arm/stm32*_eval/                  @erwango, @ABOSTM, @FRASTM
 /boards/common/                           @mbolivar-nordic
 /boards/deprecated.cmake                  @tejlmand
 /boards/nios2/                            @wentongwu
@@ -142,7 +143,7 @@
 /drivers/debug/                           @nashif
 /drivers/*/*cc13xx_cc26xx*                @bwitherspoon
 /drivers/*/*mcux*                         @MaureenHelm
-/drivers/*/*stm32*                        @erwango
+/drivers/*/*stm32*                        @erwango, @ABOSTM, @FRASTM
 /drivers/*/*native_posix*                 @aescolar @daor-oti
 /drivers/*/*lpc11u6x*			  @mbittan @simonguinot
 /drivers/adc/                             @anangl
@@ -164,7 +165,7 @@
 /drivers/dac/                             @martinjaeger
 /drivers/dma/*dw*                         @tbursztyka
 /drivers/dma/*sam0*                       @Sizurka
-/drivers/dma/dma_stm32*                   @cybertale
+/drivers/dma/dma_stm32*                   @cybertale, @lowlander
 /drivers/dma/*pl330*                      @raveenp
 /drivers/eeprom/                          @henrikbrixandersen
 /drivers/eeprom/eeprom_stm32.c            @KwonTae-young
@@ -173,6 +174,7 @@
 /drivers/entropy/*litex*                  @mateusz-holenko @kgugala @pgielda
 /drivers/espi/                            @albertofloyd @franciscomunoz @scottwcpg
 /drivers/ethernet/                        @jukkar @tbursztyka @pfalcon
+/drivers/ethernet/*stm32*                 @Nukersson, @lochej
 /drivers/flash/                           @nashif @nvlsianpu
 /drivers/flash/*nrf*                      @nvlsianpu
 /drivers/flash/*spi_nor*                  @pabigot
@@ -217,6 +219,7 @@
 /drivers/ps2/                             @albertofloyd @franciscomunoz @scottwcpg
 /drivers/pwm/*litex*                      @mateusz-holenko @kgugala @pgielda
 /drivers/pwm/*sam0*                       @nzmichaelh
+/drivers/pwm/*stm32*                      @gmarull
 /drivers/sensor/                          @MaureenHelm
 /drivers/sensor/ams_iAQcore/              @alexanderwachter
 /drivers/sensor/ens210/                   @alexanderwachter
@@ -257,6 +260,7 @@
 /drivers/timer/xlnx_psttc_timer*          @wjliang @stephanosio
 /drivers/timer/cc13x2_cc26x2_rtc_timer.c  @vanti
 /drivers/timer/cavs_timer.c               @dcpleung
+/drivers/timer/stm32_lptim_timer.c        @FRASTM
 /drivers/usb/                             @jfischer-phytec-iot @finikorg
 /drivers/usb/device/usb_dc_stm32.c        @ydamigos @loicpoulain
 /drivers/video/                           @loicpoulain

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -170,12 +170,9 @@
 /drivers/eeprom/eeprom_stm32.c            @KwonTae-young
 /drivers/entropy/*rv32m1*                 @MaureenHelm
 /drivers/entropy/*gecko*                  @chrta
-/drivers/espi/                            @albertofloyd @franciscomunoz @scottwcpg
-/drivers/ps2/                             @albertofloyd @franciscomunoz @scottwcpg
-/drivers/kscan/                           @albertofloyd @franciscomunoz @scottwcpg
-/drivers/peci/                            @albertofloyd @franciscomunoz @scottwcpg
-/drivers/ethernet/                        @jukkar @tbursztyka @pfalcon
 /drivers/entropy/*litex*                  @mateusz-holenko @kgugala @pgielda
+/drivers/espi/                            @albertofloyd @franciscomunoz @scottwcpg
+/drivers/ethernet/                        @jukkar @tbursztyka @pfalcon
 /drivers/flash/                           @nashif @nvlsianpu
 /drivers/flash/*nrf*                      @nvlsianpu
 /drivers/flash/*spi_nor*                  @pabigot
@@ -207,14 +204,17 @@
 /drivers/ipm/ipm_nrfx_ipc.c               @masz-nordic @ioannisg
 /drivers/ipm/ipm_nrfx_ipc.h               @masz-nordic @ioannisg
 /drivers/ipm/ipm_stm32_ipcc.c             @arnopo
+/drivers/kscan/                           @albertofloyd @franciscomunoz @scottwcpg
 /drivers/led/                             @Mani-Sadhasivam
 /drivers/led_strip/                       @mbolivar-nordic
 /drivers/lora/                            @Mani-Sadhasivam
 /drivers/modem/                           @mike-scott
 /drivers/pcie/                            @andrewboie
+/drivers/peci/                            @albertofloyd @franciscomunoz @scottwcpg
 /drivers/pinmux/stm32/                    @idlethread
 /drivers/pinmux/*hsdk*                    @iriszzw
 /drivers/pinmux/*npcx*                    @MulinChao
+/drivers/ps2/                             @albertofloyd @franciscomunoz @scottwcpg
 /drivers/pwm/*litex*                      @mateusz-holenko @kgugala @pgielda
 /drivers/pwm/*sam0*                       @nzmichaelh
 /drivers/sensor/                          @MaureenHelm


### PR DESCRIPTION
Based on recent contributions, add reviewers on some STM32 components.