### PR TITLE
tests: kernel: fatal: minor #ifdef guard fix

### DIFF
--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -349,8 +349,6 @@ void test_fatal(void)
 	check_stack_overflow(stack_hw_overflow, K_FP_REGS);
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 
-#endif /* CONFIG_HW_STACK_PROTECTION */
-
 #ifdef CONFIG_USERSPACE
 
 	TC_PRINT("test stack HW-based overflow - user 1\n");
@@ -374,6 +372,8 @@ void test_fatal(void)
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 
 #endif /* CONFIG_USERSPACE */
+
+#endif /* CONFIG_HW_STACK_PROTECTION */
 
 #endif /* !CONFIG_ARCH_POSIX */
 }


### PR DESCRIPTION
HW Stack protection is required to successfully run the
stack overflow-related tests, so guard all these tests
inside #ifdef CONFIG_HW_STACK_PROTECTION. Otherwise this
test-suite fails for platforms that implement USERSPACE
but do not have HW_STACK_PROTECTION capability.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>