### PR TITLE
usb: clock_control: Fix symbol when getting mgr for HFCLK

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1342,7 +1342,7 @@ int usb_dc_attach(void)
 	k_mutex_init(&ctx->drv_lock);
 	ctx->hfxo_mgr =
 		z_nrf_clock_control_get_onoff(
-			COND_CODE_1(NRF_CLOCK_HAS_HFCLK192,
+			COND_CODE_1(NRF_CLOCK_HAS_HFCLK192M,
 				    (CLOCK_CONTROL_NRF_SUBSYS_HF192M),
 				    (CLOCK_CONTROL_NRF_SUBSYS_HF)));
 


### PR DESCRIPTION
When getting a hfxo manager for USB sybsystem incorrect symbol
was checked. This lead to always enabling HFCLK, even for nRF5340
which needs HFCLK192M.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>