### PR TITLE
OSDP Kconfig enhancements

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -846,6 +846,17 @@ MCU Manager:
     labels:
         - "area: mcumgr"
 
+OSDP:
+    status: maintained
+    collaborators:
+        - cbsiddharth
+    files:
+        - subsys/mgmt/osdp/
+        - include/mgmt/osdp.h
+        - samples/subsys/mgmt/osdp/
+    labels:
+        - "area: OSDP"
+
 Native POSIX and POSIX arch:
     status: maintained
     maintainers:

--- a/subsys/mgmt/osdp/Kconfig
+++ b/subsys/mgmt/osdp/Kconfig
@@ -14,6 +14,18 @@ menuconfig OSDP
 
 if OSDP
 
+choice
+	prompt "OSDP Mode of Operation"
+	config OSDP_MODE_PD
+		bool "Configure OSDP in Peripheral Device mode"
+		help
+		  Configure this device to operate as a PD (Peripheral Device)
+	config OSDP_MODE_CP
+		bool "Configure OSDP in Control Panel mode"
+		help
+		  Configure this device to operate as a CP (Control Panel)
+endchoice
+
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_OSDP_UART := zephyr,osdp-uart
 
@@ -55,19 +67,6 @@ config OSDP_PACKET_TRACE
 	help
 	  Prints bytes sent/received over OSDP to console for debugging.
 	  LOG_HEXDUMP_DBG() is used to achieve this and can be very verbose.
-
-choice
-	prompt "OSDP Mode of Operation"
-	default OSDP_MODE_PD
-	config OSDP_MODE_CP
-		bool "Configure OSDP in Control Panel mode"
-		help
-		  Configure this device to operate as a CP (Control Panel)
-	config OSDP_MODE_PD
-		bool "Configure OSDP in Peripheral Device mode"
-		help
-		  Configure this device to operate as a PD (Peripheral Device)
-endchoice
 
 if OSDP_MODE_PD
 source "subsys/mgmt/osdp/Kconfig.pd"

--- a/subsys/mgmt/osdp/Kconfig
+++ b/subsys/mgmt/osdp/Kconfig
@@ -7,8 +7,8 @@
 menuconfig OSDP
 	bool "Open Supervised Device Protocol (OSDP) driver"
 	select RING_BUFFER
-	select SERIAL
-	select SERIAL_SUPPORT_INTERRUPT
+	imply SERIAL_SUPPORT_INTERRUPT
+	imply UART_INTERRUPT_DRIVEN
 	help
 	  Add support for Open Supervised Device Protocol (OSDP)
 


### PR DESCRIPTION
- Make CP/PD mode selection as first entry in Kconfig
- Change `select SERIAL` to `imply SERIAL_SUPPORT_INTERRUPT`
- Add MAINTAINERS.yml entry for OSDP

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/28114

CC: @erwango 