### PR TITLE
drivers: ethernet: remove stray expression

### DIFF
--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -600,8 +600,6 @@ static int enc424j600_init(const struct device *dev)
 	uint8_t retries = ENC424J600_DEFAULT_NUMOF_RETRIES;
 	uint16_t tmp;
 
-	context->dev;
-
 	/* SPI config */
 	context->spi_cfg.operation = SPI_WORD_SET(8);
 	context->spi_cfg.frequency = config->spi_freq;


### PR DESCRIPTION
An unnecessary expression that doesn't compile was inadvertently
introduced in the device constification PR.  Remove it.

Fixes #28032