### PR TITLE
tests: benchmarks: data_structure_perf: rbtree: uninitialized field

### DIFF
--- a/tests/benchmarks/data_structure_perf/rbtree_perf/src/rbtree_perf.c
+++ b/tests/benchmarks/data_structure_perf/rbtree_perf/src/rbtree_perf.c
@@ -53,6 +53,8 @@ void test_rbtree_container(void)
 	struct container_node tree_node[10];
 
 	test_tree_l.lessthan_fn = node_lessthan;
+	test_tree_l.root = NULL;
+
 	for (uint32_t i = 0; i < ARRAY_SIZE(tree_node); i++) {
 		tree_node[i].value = i;
 		rb_insert(&test_tree_l, &tree_node[i].node);


### PR DESCRIPTION
tests: benchmarks: data_structure_perf: rbtree: uninitialized field

Initialize root field to NULL, so that 'test_tree_l.roo.max_depth'
will be assigned a valid value in function rb_insert().

Fixes #28139