### PR TITLE
cmake: improved handling of CONF_FILE cached variable

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -469,7 +469,11 @@ please check your installation. ARCH roots searched: \n\
 ${ARCH_ROOT}")
 endif()
 
-if(CONF_FILE)
+if(DEFINED CONF_FILE)
+  # This ensures that CACHE{CONF_FILE} will be set correctly to current scope
+  # variable CONF_FILE. An already current scope variable will stay the same.
+  set(CONF_FILE ${CONF_FILE})
+
   # CONF_FILE has either been specified on the cmake CLI or is already
   # in the CMakeCache.txt. This has precedence over the environment
   # variable CONF_FILE and the default prj.conf


### PR DESCRIPTION
Fixes: #28134

Minor fix for correctly testing if CONF_FILE variable is defined, and
if it is defined, then a current scope variable will be set with same
name. For a variable that is already present in current scope this has
no effect, but a cached variable (such as one provided with -DCONF_FILE)
will now have both a current scope and cached definition.
This ensures that current scope CONF_FILE will continue to be defined
even when the cached variable is cleared later.

Clearing of the cached variable ensures correct detection if user later
re-invokes CMake with a new -DCONF_FILE value.

The cached version is cleared in favor of the CACHED_CONF_FILE
that is used between automatically triggered CMake runs (through ninja).

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>