### PR TITLE
[DNM] WIP: Testing cache fixes in MCUBOOT

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -22,6 +22,9 @@ manifest:
     - name: upstream
       url-base: https://github.com/zephyrproject-rtos
 
+    - name: mcuboot
+      url-base: https://github.com/JuulLabs-OSS
+
   #
   # Please add items below based on alphabetical order
   projects:
@@ -93,7 +96,8 @@ manifest:
       revision: 9638398d3c319074ae3878035138ef8a76001e5b
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: 480421999ec2d8d2a20091e4f3a0393db04de5c4
+      remote: mcuboot
+      revision: pull/787/head
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 5051f9d900bbb194a23d4ce80f3c6dc6d6780cc2


### PR DESCRIPTION
MCUBOOT fails on Cortex M7 because of cache problems. The purpose of this PR is to test a fix for this problem using the Zephyr CI, before it can be merged into MCUBOOT upstream.

**This PR aim to test feature which has to be contributed in mucboot upstream**