### PR TITLE
Bluetooth: Mesh: Store Krp phase after krp value changed

### DIFF
--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -2836,6 +2836,11 @@ static void krp_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	    phase == BT_MESH_KR_PHASE_2) {
 		sub->kr_phase = BT_MESH_KR_PHASE_2;
 		sub->kr_flag = 1;
+		if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		    BT_DBG("Storing krp phase persistently");
+		    bt_mesh_store_subnet(sub);
+		}
+
 		bt_mesh_net_beacon_update(sub);
 	} else if ((sub->kr_phase == BT_MESH_KR_PHASE_1 ||
 		    sub->kr_phase == BT_MESH_KR_PHASE_2) &&
@@ -2845,6 +2850,7 @@ static void krp_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		    IS_ENABLED(CONFIG_BT_MESH_FRIEND)) {
 			friend_cred_refresh(ctx->net_idx);
 		}
+
 		sub->kr_phase = BT_MESH_KR_NORMAL;
 		sub->kr_flag = 0;
 		bt_mesh_net_beacon_update(sub);

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -521,6 +521,11 @@ bool bt_mesh_kr_update(struct bt_mesh_subnet *sub, uint8_t new_kr, bool new_key)
 		if (sub->kr_phase == BT_MESH_KR_PHASE_1) {
 			BT_DBG("Phase 1 -> Phase 2");
 			sub->kr_phase = BT_MESH_KR_PHASE_2;
+			if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+				BT_DBG("Storing krp phase persistently");
+				bt_mesh_store_subnet(sub);
+			}
+
 			return true;
 		}
 	} else {
@@ -545,6 +550,7 @@ bool bt_mesh_kr_update(struct bt_mesh_subnet *sub, uint8_t new_kr, bool new_key)
 			    IS_ENABLED(CONFIG_BT_MESH_FRIEND)) {
 				friend_cred_refresh(sub->net_idx);
 			}
+
 			sub->kr_phase = BT_MESH_KR_NORMAL;
 			return true;
 		}


### PR DESCRIPTION
Store krp phase persistently when this value has been changed.

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>