### PR TITLE
soc: arc: Increase cpu frequency for nsim_hs_smp

### DIFF
--- a/soc/arc/snps_nsim/Kconfig.defconfig.hs_smp
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.hs_smp
@@ -16,7 +16,8 @@ config RGF_NUM_BANKS
 	default 2
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 500000
+        # SMP simulation is slower than single core, 1 Mhz seems reasonable match with wallclock
+	default 1000000
 
 config HARVARD
 	default y


### PR DESCRIPTION
0.5 Mhz with 100 ticks per sec leaves 5000 cycles per tick,
which broke some tests that assumed more work within 1 tick.
Set to 1 Mhz: balance multi-core simulation speed and tick duration.

Fixes #27943

Signed-off-by: Ruud Derwig <Ruud.Derwig@synopsys.com>