### PR TITLE
Support relative path from application source dir

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -305,14 +305,17 @@ set(CACHED_SHIELD ${SHIELD} CACHE STRING "Selected shield")
 
 # 'BOARD_ROOT' is a prioritized list of directories where boards may
 # be found. It always includes ${ZEPHYR_BASE} at the lowest priority.
+zephyr_file(APPLICATION_ROOT BOARD_ROOT)
 list(APPEND BOARD_ROOT ${ZEPHYR_BASE})
 
 # 'SOC_ROOT' is a prioritized list of directories where socs may be
 # found. It always includes ${ZEPHYR_BASE}/soc at the lowest priority.
+zephyr_file(APPLICATION_ROOT SOC_ROOT)
 list(APPEND SOC_ROOT ${ZEPHYR_BASE})
 
 # 'ARCH_ROOT' is a prioritized list of directories where archs may be
 # found. It always includes ${ZEPHYR_BASE} at the lowest priority.
+zephyr_file(APPLICATION_ROOT ARCH_ROOT)
 list(APPEND ARCH_ROOT ${ZEPHYR_BASE})
 
 if(DEFINED SHIELD)

--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -35,6 +35,8 @@ if(DEFINED DTS_COMMON_OVERLAYS)
   message(FATAL_ERROR "DTS_COMMON_OVERLAYS is no longer supported. Use DTC_OVERLAY_FILE instead.")
 endif()
 
+zephyr_file(APPLICATION_ROOT DTS_ROOT)
+
 # 'DTS_ROOT' is a list of directories where a directory tree with DT
 # files may be found. It always includes the application directory,
 # the board directory, and ${ZEPHYR_BASE}.

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -1681,3 +1681,65 @@ function(generate_unique_target_name_from_filename filename target_name)
 
   set(${target_name} gen_${x}_${unique_chars} PARENT_SCOPE)
 endfunction()
+
+# Usage:
+#   zephyr_file(<mode> <arg> ...)
+#
+# Zephyr file function extension.
+# This function currently support the following <modes>
+#
+# APPLICATION_ROOT <path>: Check all paths in provided variable, and convert
+#                          those paths that are defined with `-D<path>=<val>`
+#                          to absolute path, relative from `APPLICATION_SOURCE_DIR`
+#                          Issue an error for any relative path not specified
+#                          by user with `-D<path>`
+#
+# returns an updated list of absolute paths
+function(zephyr_file)
+  set(options APPLICATION_ROOT)
+  cmake_parse_arguments(FILE "${options}" "" "" ${ARGN})
+  if(NOT FILE_APPLICATION_ROOT)
+    message(FATAL_ERROR "No <mode> given to `zephyr_file(<mode> <args>...)` function,\n \
+Please provide one of following: APPLICATION_ROOT")
+  endif()
+
+  if(FILE_APPLICATION_ROOT)
+    if(NOT (${ARGC} EQUAL 2))
+      math(EXPR ARGC "${ARGC} - 1")
+      message(FATAL_ERROR "zephyr_file(APPLICATION_ROOT <path-variable>) takes exactly 1 argument, ${ARGC} were given")
+    endif()
+
+    # Note: user can do: `-D<var>=<relative-path>` and app can at same
+    # time specify `list(APPEND <var> <abs-path>)`
+    # Thus need to check and update only CACHED variables (-D<var>).
+    set(CACHED_PATH $CACHE{${ARGV1}})
+    foreach(path ${CACHED_PATH})
+      # The cached variable is relative path, i.e. provided by `-D<var>` or
+      # `set(<var> CACHE)`, so let's update current scope variable to absolute
+      # path from  `APPLICATION_SOURCE_DIR`.
+      if(NOT IS_ABSOLUTE ${path})
+        set(abs_path ${APPLICATION_SOURCE_DIR}/${path})
+        list(FIND ${ARGV1} ${path} index)
+        if(NOT ${index} LESS 0)
+          list(REMOVE_AT ${ARGV1} ${index})
+          list(INSERT ${ARGV1} ${index} ${abs_path})
+        endif()
+      endif()
+    endforeach()
+
+    # Now all cached relative paths has been updated.
+    # Let's check if anyone uses relative path as scoped variable, and fail
+    foreach(path ${${ARGV1}})
+      if(NOT IS_ABSOLUTE ${path})
+        message(FATAL_ERROR
+"Relative path encountered in scoped variable: ${ARGV1}, value=${path}\n \
+Please adjust any `set(${ARGV1} ${path})` or `list(APPEND ${ARGV1} ${path})`\n \
+to absolute path using `\${CMAKE_CURRENT_SOURCE_DIR}/${path}` or similar. \n \
+Relative paths are only allowed with `-D${ARGV1}=<path>`")
+      endif()
+    endforeach()
+
+    # This updates the provided argument in parent scope (callers scope)
+    set(${ARGV1} ${${ARGV1}} PARENT_SCOPE)
+  endif()
+endfunction()

--- a/cmake/generic_toolchain.cmake
+++ b/cmake/generic_toolchain.cmake
@@ -9,6 +9,7 @@ if(NOT TOOLCHAIN_ROOT)
     set(TOOLCHAIN_ROOT ${ZEPHYR_BASE})
   endif()
 endif()
+zephyr_file(APPLICATION_ROOT TOOLCHAIN_ROOT)
 
 # Don't inherit compiler flags from the environment
 foreach(var CFLAGS CXXFLAGS CPPFLAGS)
@@ -47,7 +48,7 @@ if("${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "zephyr")
   set(TOOLCHAIN_HOME ${HOST_TOOLS_HOME})
 endif()
 
-set(TOOLCHAIN_ROOT ${TOOLCHAIN_ROOT} CACHE STRING "Zephyr toolchain root")
+set(TOOLCHAIN_ROOT ${TOOLCHAIN_ROOT} CACHE STRING "Zephyr toolchain root" FORCE)
 assert(TOOLCHAIN_ROOT "Zephyr toolchain root path invalid: please set the TOOLCHAIN_ROOT-variable")
 
 # Set cached ZEPHYR_TOOLCHAIN_VARIANT.

--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -22,6 +22,7 @@ foreach(root ${SOC_ROOT})
 endforeach()
 
 if(KCONFIG_ROOT)
+  zephyr_file(APPLICATION_ROOT KCONFIG_ROOT)
   # KCONFIG_ROOT has either been specified as a CMake variable or is
   # already in the CMakeCache.txt. This has precedence.
 elseif(EXISTS   ${APPLICATION_SOURCE_DIR}/Kconfig)

--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -673,6 +673,12 @@ You can also define the ``BOARD_ROOT`` variable in the application
 :file:`CMakeLists.txt` file. Make sure to do so **before** pulling in the Zephyr
 boilerplate with ``find_package(Zephyr ...)``.
 
+.. note::
+
+   When specifying ``BOARD_ROOT`` in a CMakeLists.txt, then an absolute path must
+   be provided, for example ``list(APPEND BOARD_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/<extra-board-root>``.
+   When using ``-DBOARD_ROOT=<board-root>`` both absolute and relative paths can
+   be used. Relative paths are treated relatively to the application directory.
 
 SOC Definitions
 ===============
@@ -750,6 +756,13 @@ Or you can define the ``SOC_ROOT`` variable in the application
 :file:`CMakeLists.txt` file. Make sure to do so **before** pulling in the
 Zephyr boilerplate with ``find_package(Zephyr ...)``.
 
+.. note::
+
+   When specifying ``SOC_ROOT`` in a CMakeLists.txt, then an absolute path must
+   be provided, for example ``list(APPEND SOC_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/<extra-soc-root>``.
+   When using ``-DSOC_ROOT=<soc-root>`` both absolute and relative paths can be
+   used. Relative paths are treated relatively to the application directory.
+
 .. _dts_root:
 
 Devicetree Definitions
@@ -782,6 +795,13 @@ its location through the ``DTS_ROOT`` CMake Cache variable:
 You can also define the variable in the application :file:`CMakeLists.txt`
 file. Make sure to do so **before** pulling in the Zephyr boilerplate with
 ``find_package(Zephyr ...)``.
+
+.. note::
+
+   When specifying ``DTS_ROOT`` in a CMakeLists.txt, then an absolute path must
+   be provided, for example ``list(APPEND DTS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/<extra-dts-root>``.
+   When using ``-DDTS_ROOT=<dts-root>`` both absolute and relative paths can be
+   used. Relative paths are treated relatively to the application directory.
 
 Devicetree source are passed through the C preprocessor, so you can
 include files that can be located in a ``DTS_ROOT`` directory.  By


### PR DESCRIPTION
Fixes: #23825

Today, BOARD, SOC, ARCH, DTS, KCONFIG, and TOOLCHAIN_ROOT can be
specified by users or through other CMake files.

It is not clear if relative paths are permitted and/or from where a
relative path is constructed.

Inside CMake, it is very easy to specify `${ZEPHYR_BASE}`,
`${CMAKE_CURRENT_SOURCE_DIR}`, or similar, thus there is no reason to
use relative path inside CMake, as it easy can lead to discussion on
relative to what.

For users manually invoking CMake using, `cmake ... <app-dir>` it is
nice to have to possibility to specify a relative path.
For this purpose, relative path are considered relative to the
`APPLICATION_SOURCE_DIR`.

This commit updates:
- BOARD_ROOT
- SOC_ROOT
- ARCH_ROOT
- DTS_ROOT
- KCONFIG_ROOT
- TOOLCHAIN_ROOT

to allow paths relative to `APPLICATION_SOURCE_DIR` when specified with
`-D<type>_ROOT=<relative-path>`

To support consistent behavior a `zephyr_file()` extension command has been introduced.
This commands examines a path list for relative paths, and convert relative paths
provided with `-D<path>` into absolute paths, starting from `APPLICATION_SOURCE_DIR`.
