### PR TITLE
drivers: dma: stm32: fixes spi_loopback on nucleo_wb55rg

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -594,8 +594,8 @@ static int dma_stm32_init(const struct device *dev)
 	config->config_irq(dev);
 
 #ifdef CONFIG_DMAMUX_STM32
-	int offset = ((dev == device_get_binding((const char *)"DMA_1"))
-			? 0 : config->max_streams);
+	int offset = (strncmp(dev->name, "DMA_1", 5)
+			? config->max_streams : 0);
 #endif /* CONFIG_DMAMUX_STM32 */
 
 	for (uint32_t i = 0; i < config->max_streams; i++) {

--- a/drivers/dma/dma_stm32_v2.c
+++ b/drivers/dma/dma_stm32_v2.c
@@ -144,15 +144,15 @@ void dma_stm32_clear_te(DMA_TypeDef *DMAx, uint32_t id)
 		LL_DMA_ClearFlag_TE3,
 		LL_DMA_ClearFlag_TE4,
 		LL_DMA_ClearFlag_TE5,
-#if defined(LL_DMA_IFCR_CTEF6)
+#if defined(LL_DMA_IFCR_CTEIF6)
 		LL_DMA_ClearFlag_TE6,
-#if defined(LL_DMA_IFCR_CTEF7)
+#if defined(LL_DMA_IFCR_CTEIF7)
 		LL_DMA_ClearFlag_TE7,
-#if defined(LL_DMA_IFCR_CTEF8)
+#if defined(LL_DMA_IFCR_CTEIF8)
 		LL_DMA_ClearFlag_TE8,
-#endif /* LL_DMA_IFCR_CTEF6 */
-#endif /* LL_DMA_IFCR_CTEF7 */
-#endif /* LL_DMA_IFCR_CTEF8 */
+#endif /* LL_DMA_IFCR_CTEIF6 */
+#endif /* LL_DMA_IFCR_CTEIF7 */
+#endif /* LL_DMA_IFCR_CTEIF8 */
 	};
 
 	__ASSERT_NO_MSG(id < ARRAY_SIZE(func));


### PR DESCRIPTION
2 commits:
* drivers: dma: dma_stm32: can't use device_get_binding() during init
* drivers: dma: dma_stm32_v2: typo in compilation switch

Fixes #28184