### PR TITLE
storage: flash_map: Fix checking unsigned for negative value

### DIFF
--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -281,8 +281,8 @@ int flash_area_check_int_sha256(const struct flash_area *fa,
 	int pos;
 	int rc;
 
-	if (!fa || !fac || !fac->match || !fac->rbuf ||
-	    fac->clen <= 0 || fac->off < 0 || fac->rblen <= 0) {
+	if (fa == NULL || fac == NULL || fac->match == NULL ||
+	    fac->rbuf == NULL || fac->clen == 0 || fac->rblen == 0) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
The unsigned size_t type variables have been checked for having
negative values.

Fixes #28171, Coverity-CID: 214224

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>