### PR TITLE
drivers/flash/nrf_qspi_nor: corrects write-block-size to 4B

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -43,7 +43,7 @@ struct qspi_nor_config {
 LOG_MODULE_REGISTER(qspi_nor, CONFIG_FLASH_LOG_LEVEL);
 
 static const struct flash_parameters qspi_flash_parameters = {
-	.write_block_size = 1,
+	.write_block_size = 4,
 	.erase_value = 0xff,
 };
 


### PR DESCRIPTION
The driver is able to write with 32-bits word alignment of size
and offset, apart form sub-word writes for which it can write
part of word to aligned offset (which is a hack).

fixes #26729

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>