### PR TITLE
drivers: pcie: endpoint: fix ISR prototype

### DIFF
--- a/drivers/pcie/endpoint/pcie_ep_bcm_iproc.c
+++ b/drivers/pcie/endpoint/pcie_ep_bcm_iproc.c
@@ -260,9 +260,8 @@ static int iproc_pcie_register_reset_cb(const struct device *dev,
 }
 
 #if DT_INST_IRQ_HAS_NAME(0, perst)
-static void iproc_pcie_perst(void *arg)
+static void iproc_pcie_perst(const struct device *dev)
 {
-	const struct device *dev = arg;
 	struct iproc_pcie_ep_ctx *ctx = dev->data;
 	void *reset_data;
 	uint32_t data;
@@ -282,9 +281,8 @@ static void iproc_pcie_perst(void *arg)
 #endif
 
 #if DT_INST_IRQ_HAS_NAME(0, perst_inband)
-static void iproc_pcie_hot_reset(void *arg)
+static void iproc_pcie_hot_reset(const struct device *dev)
 {
-	const struct device *dev = arg;
 	struct iproc_pcie_ep_ctx *ctx = dev->data;
 	void *reset_data;
 	uint32_t data;


### PR DESCRIPTION
Two optional ISR handlers need the void *arg converted to const struct
device *dev.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>