### PR TITLE
samples: Add fixtures for samples interacting with keyboard and mouse

### DIFF
--- a/samples/drivers/kscan/README.rst
+++ b/samples/drivers/kscan/README.rst
@@ -14,9 +14,13 @@ Building and Running
 ********************
 
 The sample can be built and executed on boards supporting a Keyboard Matrix.
-Please connect a Keyboard Matrix to exercise the functionality. You need to
-obtain the right keymap from the vendor because they vary across different
-manufactures.
+It requires a correct fixture setup. Please connect a Keyboard Matrix to
+exercise the functionality (you need to obtain the right keymap from the vendor
+because they vary across different manufactures).
+For the correct execution of that sample in sanitycheck, add into boards's
+map-file next fixture settings::
+
+      - fixture: fixture_connect_keyboard
 
 Sample output
 =============

--- a/samples/drivers/kscan/sample.yaml
+++ b/samples/drivers/kscan/sample.yaml
@@ -9,4 +9,5 @@ tests:
         ordered: true
         regex:
             - "kb data(.*)"
+        fixture: fixture_connect_keyboard
     depends_on: kscan

--- a/samples/drivers/ps2/README.rst
+++ b/samples/drivers/ps2/README.rst
@@ -14,7 +14,12 @@ Building and Running
 ********************
 
 The sample can be built and executed on boards supporting PS/2.
-Please connect a PS/2 mouse in order to exercise the functionality.
+It requires a correct fixture setup. Please connect a PS/2 mouse in order to
+exercise the functionality.
+For the correct execution of that sample in sanitycheck, add into boards's
+map-file next fixture settings::
+
+      - fixture: fixture_connect_mouse
 
 Sample output
 =============

--- a/samples/drivers/ps2/sample.yaml
+++ b/samples/drivers/ps2/sample.yaml
@@ -9,4 +9,5 @@ tests:
         ordered: true
         regex:
             - "mb data(.*)"
+        fixture: fixture_connect_mouse
     depends_on: ps2


### PR DESCRIPTION
Two samples require interacting with keyboard and mouse, and that
means necessary to provide correct fixture before run of that samples
in sanitycheck system. To skip or run the sample according to the
provided fixture in map-file necessary to add fixture definitions
into sample.yaml files
Fixes #28146 
Fixes #28149 
Fixes #24700

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>