### PR TITLE
drivers: watchdog: cmsdk: Rename wdog_cmsdk_apb_enable to wdog_cmsdk_apb_setup

### DIFF
--- a/drivers/watchdog/Kconfig.cmsdk_apb
+++ b/drivers/watchdog/Kconfig.cmsdk_apb
@@ -10,3 +10,12 @@ config WDOG_CMSDK_APB
 	help
 	  Enable CMSDK APB Watchdog (WDOG_CMSDK_APB) Driver for ARM
 	  family of MCUs.
+
+config WDOG_CMSDK_APB_START_AT_BOOT
+	bool "Start Watchdog during boot"
+	depends on WDOG_CMSDK_APB
+	help
+	  Enable this setting to allow WDOG to be automatically started
+	  during device initialization. Note that once WDOG is started
+	  it must be reloaded before the counter reaches 0, otherwise
+	  the MCU will be reset.

--- a/drivers/watchdog/wdt_cmsdk_apb.c
+++ b/drivers/watchdog/wdt_cmsdk_apb.c
@@ -193,7 +193,7 @@ static int wdog_cmsdk_apb_init(const struct device *dev)
 #endif
 
 #ifdef CONFIG_WDOG_CMSDK_APB_START_AT_BOOT
-	wdog_cmsdk_apb_enable(dev);
+	wdog_cmsdk_apb_setup(dev, 0);
 #endif
 
 	return 0;

--- a/drivers/watchdog/wdt_cmsdk_apb.c
+++ b/drivers/watchdog/wdt_cmsdk_apb.c
@@ -192,6 +192,10 @@ static int wdog_cmsdk_apb_init(const struct device *dev)
 	z_NmiHandlerSet(wdog_cmsdk_apb_isr);
 #endif
 
+#ifdef CONFIG_WDOG_CMSDK_APB_START_AT_BOOT
+	wdog_cmsdk_apb_enable(dev);
+#endif
+
 	return 0;
 }
 


### PR DESCRIPTION
Rename `wdog_cmsdk_apb_enable` to `wdog_cmsdk_apb_setup`,
this API is supposed to be called during driver probe based on
`CONFIG_WDOG_CMSDK_APB_START_AT_BOOT` (enabled by default).

Fixes: 03c7d9b ("drivers: wdog: Update CMSDK Wdog driver")