### PR TITLE
arm: systick: default CORTEX_M_SYSTICK based on dts

### DIFF
--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -120,9 +120,16 @@ config ARM_ARCH_TIMER
 	  timer which provides per-cpu timers attached to a GIC to deliver its
 	  per-processor interrupts via PPIs.
 
+DT_COMPAT_ARM_V6M_SYSTICK := arm,armv6m-systick
+DT_COMPAT_ARM_V7M_SYSTICK := arm,armv7m-systick
+DT_COMPAT_ARM_V8M_SYSTICK := arm,armv8m-systick
+
 config CORTEX_M_SYSTICK
 	bool "Cortex-M SYSTICK timer"
 	depends on CPU_CORTEX_M_HAS_SYSTICK
+	default $(dt_compat_enabled,$(DT_COMPAT_ARM_V6M_SYSTICK)) || \
+		$(dt_compat_enabled,$(DT_COMPAT_ARM_V7M_SYSTICK)) || \
+		$(dt_compat_enabled,$(DT_COMPAT_ARM_V8M_SYSTICK))
 	select TICKLESS_CAPABLE
 	help
 	  This module implements a kernel device driver for the Cortex-M processor

--- a/dts/arm/armv6-m.dtsi
+++ b/dts/arm/armv6-m.dtsi
@@ -20,7 +20,6 @@
 		systick: timer@e000e010 {
 			compatible = "arm,armv6m-systick";
 			reg = <0xe000e010 0x10>;
-			status = "disabled";
 		};
 	};
 };

--- a/dts/arm/armv7-m.dtsi
+++ b/dts/arm/armv7-m.dtsi
@@ -20,7 +20,6 @@
 		systick: timer@e000e010 {
 			compatible = "arm,armv7m-systick";
 			reg = <0xe000e010 0x10>;
-			status = "disabled";
 		};
 	};
 };

--- a/dts/arm/armv8-m.dtsi
+++ b/dts/arm/armv8-m.dtsi
@@ -20,7 +20,6 @@
 		systick: timer@e000e010 {
 			compatible = "arm,armv8m-systick";
 			reg = <0xe000e010 0x10>;
-			status = "disabled";
 		};
 	};
 };

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -424,3 +424,7 @@
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };
+
+&systick {
+	status = "disabled";
+};

--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -95,3 +95,7 @@
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };
+
+&systick {
+	status = "disabled";
+};

--- a/dts/arm/nordic/nrf5340_cpuappns.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns.dtsi
@@ -63,3 +63,7 @@
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };
+
+&systick {
+	status = "disabled";
+};

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -248,3 +248,7 @@
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };
+
+&systick {
+	status = "disabled";
+};

--- a/dts/arm/nordic/nrf5_common.dtsi
+++ b/dts/arm/nordic/nrf5_common.dtsi
@@ -8,3 +8,7 @@
 		label = "SW_PWM";
 	};
 };
+
+&systick {
+	status = "disabled";
+};

--- a/dts/arm/nordic/nrf9160.dtsi
+++ b/dts/arm/nordic/nrf9160.dtsi
@@ -94,3 +94,7 @@
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };
+
+&systick {
+	status = "disabled";
+};

--- a/dts/arm/nordic/nrf9160ns.dtsi
+++ b/dts/arm/nordic/nrf9160ns.dtsi
@@ -60,3 +60,7 @@
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };
+
+&systick {
+	status = "disabled";
+};

--- a/dts/arm/ti/cc13x2_cc26x2.dtsi
+++ b/dts/arm/ti/cc13x2_cc26x2.dtsi
@@ -131,3 +131,7 @@
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };
+
+&systick {
+	status = "disabled";
+};


### PR DESCRIPTION
Use setting from devicetree to drive the default setting for
CORTEX_M_SYSTICK.  We update the dts files to default systick to be
enabled since the major of cortex-m platforms utilize it by default
(except on Nordic SoCs in which we default to disabled).

Fixes #25299

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>