### PR TITLE
cmake: support absolute path in zephyr_code_relocate() function

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -1012,9 +1012,12 @@ endfunction(zephyr_linker_sources)
 # Helper function for CONFIG_CODE_DATA_RELOCATION
 # Call this function with 2 arguments file and then memory location
 function(zephyr_code_relocate file location)
+  if(NOT IS_ABSOLUTE ${file})
+    set(file ${CMAKE_CURRENT_SOURCE_DIR}/${file})
+  endif()
   set_property(TARGET code_data_relocation_target
     APPEND PROPERTY COMPILE_DEFINITIONS
-    "${location}:${CMAKE_CURRENT_SOURCE_DIR}/${file}")
+    "${location}:${file}")
 endfunction()
 
 # Usage:


### PR DESCRIPTION
Fixes: #27288

The Zephyr CMake function `zephyr_code_relocate()` would treat any file
argument as relative to `CMAKE_CURRENT_SOURCE_DIR` even if an absolute
path is provided.

A file with absolute path would thus become
`${CMAKE_CURRENT_SOURCE_DIR}/<absolute-path>/<file>` which leads to a
non existing file.

This is fixed by checking if path argument is a relative path, and only
use `CMAKE_CURRENT_SOURCE_DIR` in such case.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>