### PR TITLE
linker: Move devices section to ROM exclusively

### DIFF
--- a/include/linker/common-ram.ld
+++ b/include/linker/common-ram.ld
@@ -40,19 +40,8 @@
 #define DEVICE_BUSY_BITFIELD()
 #endif
 
-	SECTION_DATA_PROLOGUE(devices,,)
+	SECTION_DATA_PROLOGUE(devices_data,,)
 	{
-		/* link in devices objects, which are tied to the init ones;
-		 * the objects are thus sorted the same way as their init
-		 * object parent see include/device.h
-		 */
-		__device_start = .;
-		CREATE_OBJ_LEVEL(device, PRE_KERNEL_1)
-		CREATE_OBJ_LEVEL(device, PRE_KERNEL_2)
-		CREATE_OBJ_LEVEL(device, POST_KERNEL)
-		CREATE_OBJ_LEVEL(device, APPLICATION)
-		CREATE_OBJ_LEVEL(device, SMP)
-		__device_end = .;
 		DEVICE_INIT_STATUS_BITFIELD()
 		DEVICE_BUSY_BITFIELD()
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -17,6 +17,21 @@
 		__init_end = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
+	SECTION_PROLOGUE(devices,,)
+	{
+		/* link in devices objects, which are tied to the init ones;
+		 * the objects are thus sorted the same way as their init
+		 * object parent see include/device.h
+		 */
+		__device_start = .;
+		CREATE_OBJ_LEVEL(device, PRE_KERNEL_1)
+		CREATE_OBJ_LEVEL(device, PRE_KERNEL_2)
+		CREATE_OBJ_LEVEL(device, POST_KERNEL)
+		CREATE_OBJ_LEVEL(device, APPLICATION)
+		CREATE_OBJ_LEVEL(device, SMP)
+		__device_end = .;
+	} GROUP_LINK_IN(ROMABLE_REGION)
+
 #if defined(CONFIG_GEN_SW_ISR_TABLE) && !defined(CONFIG_DYNAMIC_INTERRUPTS)
 	SECTION_PROLOGUE(sw_isr_table,,)
 	{


### PR DESCRIPTION
Currently, it's up to the linker to decide whether devices sections should land on ram or rom. So far, it's always landing on ROM since all device instances became constant.

This patch unequivocally moves the devices section to ROM.

And then troubles happen... On some arch it just breaks. (As CI will show)
Though, before that patch the section was on ROM already.

I did not have time yet to dissect an bogus ELF to see what is the actual issue. (probably an alignment issue)