### PR TITLE
tests: initializing rbtree and its node

### DIFF
--- a/tests/benchmarks/data_structure_perf/rbtree_perf/src/rbtree_perf.c
+++ b/tests/benchmarks/data_structure_perf/rbtree_perf/src/rbtree_perf.c
@@ -52,9 +52,10 @@ void test_rbtree_container(void)
 	struct rbnode *foreach_node;
 	struct container_node tree_node[10];
 
-	test_tree_l.lessthan_fn = node_lessthan;
-	test_tree_l.root = NULL;
+	(void)memset(&test_tree_l, 0, sizeof(test_tree_l));
+	(void)memset(tree_node, 0, sizeof(tree_node));
 
+	test_tree_l.lessthan_fn = node_lessthan;
 	for (uint32_t i = 0; i < ARRAY_SIZE(tree_node); i++) {
 		tree_node[i].value = i;
 		rb_insert(&test_tree_l, &tree_node[i].node);


### PR DESCRIPTION
add  initializing rbtree and its node to fix the issue https://github.com/zephyrproject-rtos/zephyr/issues/28175

Signed-off-by: Ningx Zhao <ningx.zhao@intel.com>

Fixes #28175 