### PR TITLE
drivers/entropy: stm32: fix error erasing

### DIFF
--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -120,8 +120,10 @@ static int random_byte_get(void)
 	if ((LL_RNG_IsActiveFlag_DRDY(entropy_stm32_rng_data.rng) == 1)) {
 		if (entropy_stm32_got_error(entropy_stm32_rng_data.rng)) {
 			retval = -EIO;
+		} else {
+			retval = LL_RNG_ReadRandData32(
+						    entropy_stm32_rng_data.rng);
 		}
-		retval = LL_RNG_ReadRandData32(entropy_stm32_rng_data.rng);
 	}
 
 	irq_unlock(key);


### PR DESCRIPTION
"unused value" issue reported by Coverity (CID: 214211).
This is actually a true bug as reported error is erased
and not taken into account.

Fixes:  #28166