### PR TITLE
Bluetooth: Mesh: Move Replay Protect to seperate module

### DIFF
--- a/subsys/bluetooth/host/testing.c
+++ b/subsys/bluetooth/host/testing.c
@@ -12,6 +12,7 @@
 #if defined(CONFIG_BT_MESH)
 #include "mesh/net.h"
 #include "mesh/lpn.h"
+#include "mesh/rpl.h"
 #include "mesh/transport.h"
 #endif /* CONFIG_BT_MESH */
 

--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -9,6 +9,7 @@ zephyr_library_sources_ifdef(CONFIG_BT_MESH
     beacon.c
     net.c
     transport.c
+    rpl.c
     crypto.c
     access.c
     cfg_srv.c

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -589,6 +589,12 @@ config BT_MESH_DEBUG_NET
 	  Use this option to enable Network layer debug logs for the
 	  Bluetooth Mesh functionality.
 
+config BT_MESH_DEBUG_RPL
+	bool "Replay protection list debug"
+	help
+	  Use this option to enable Replay protection list debug logs
+	  for the Bluetooth Mesh functionality.
+
 config BT_MESH_DEBUG_TRANS
 	bool "Transport layer debug"
 	help

--- a/subsys/bluetooth/mesh/cdb.c
+++ b/subsys/bluetooth/mesh/cdb.c
@@ -15,6 +15,7 @@
 
 #include "mesh.h"
 #include "net.h"
+#include "rpl.h"
 #include "settings.h"
 
 struct bt_mesh_cdb bt_mesh_cdb = {

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -27,6 +27,7 @@
 #include "mesh.h"
 #include "adv.h"
 #include "net.h"
+#include "rpl.h"
 #include "lpn.h"
 #include "transport.h"
 #include "crypto.h"

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -24,6 +24,7 @@
 #include "adv.h"
 #include "prov.h"
 #include "net.h"
+#include "rpl.h"
 #include "beacon.h"
 #include "lpn.h"
 #include "friend.h"

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -27,6 +27,7 @@
 #include "adv.h"
 #include "mesh.h"
 #include "net.h"
+#include "rpl.h"
 #include "lpn.h"
 #include "friend.h"
 #include "proxy.h"
@@ -559,30 +560,6 @@ bool bt_mesh_kr_update(struct bt_mesh_subnet *sub, uint8_t new_kr, bool new_key)
 	return false;
 }
 
-void bt_mesh_rpl_reset(void)
-{
-	int i;
-
-	/* Discard "old old" IV Index entries from RPL and flag
-	 * any other ones (which are valid) as old.
-	 */
-	for (i = 0; i < ARRAY_SIZE(bt_mesh.rpl); i++) {
-		struct bt_mesh_rpl *rpl = &bt_mesh.rpl[i];
-
-		if (rpl->src) {
-			if (rpl->old_iv) {
-				(void)memset(rpl, 0, sizeof(*rpl));
-			} else {
-				rpl->old_iv = true;
-			}
-
-			if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-				bt_mesh_store_rpl(rpl);
-			}
-		}
-	}
-}
-
 #if defined(CONFIG_BT_MESH_IV_UPDATE_TEST)
 void bt_mesh_iv_update_test(bool enable)
 {
@@ -658,7 +635,7 @@ bool bt_mesh_net_iv_update(uint32_t iv_index, bool iv_update)
 
 		if (iv_index > bt_mesh.iv_index + 1) {
 			BT_WARN("Performing IV Index Recovery");
-			(void)memset(bt_mesh.rpl, 0, sizeof(bt_mesh.rpl));
+			bt_mesh_rpl_clear();
 			bt_mesh.iv_index = iv_index;
 			bt_mesh.seq = 0U;
 			goto do_update;

--- a/subsys/bluetooth/mesh/net.h
+++ b/subsys/bluetooth/mesh/net.h
@@ -74,15 +74,6 @@ struct bt_mesh_subnet {
 	} keys[2];
 };
 
-struct bt_mesh_rpl {
-	uint16_t src;
-	bool  old_iv;
-#if defined(CONFIG_BT_SETTINGS)
-	bool  store;
-#endif
-	uint32_t seq;
-};
-
 #if defined(CONFIG_BT_MESH_FRIEND)
 #define FRIEND_SEG_RX CONFIG_BT_MESH_FRIEND_SEG_RX
 #define FRIEND_SUB_LIST_SIZE CONFIG_BT_MESH_FRIEND_SUB_LIST_SIZE
@@ -257,8 +248,6 @@ struct bt_mesh_net {
 	struct bt_mesh_app_key app_keys[CONFIG_BT_MESH_APP_KEY_COUNT];
 
 	struct bt_mesh_subnet sub[CONFIG_BT_MESH_SUBNET_COUNT];
-
-	struct bt_mesh_rpl rpl[CONFIG_BT_MESH_CRPL];
 };
 
 /* Network interface */
@@ -317,8 +306,6 @@ bool bt_mesh_kr_update(struct bt_mesh_subnet *sub, uint8_t new_kr, bool new_key)
 void bt_mesh_net_revoke_keys(struct bt_mesh_subnet *sub);
 
 int bt_mesh_net_beacon_update(struct bt_mesh_subnet *sub);
-
-void bt_mesh_rpl_reset(void);
 
 bool bt_mesh_net_iv_update(uint32_t iv_index, bool iv_update);
 

--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -29,6 +29,7 @@
 #include "adv.h"
 #include "mesh.h"
 #include "net.h"
+#include "rpl.h"
 #include "beacon.h"
 #include "access.h"
 #include "foundation.h"

--- a/subsys/bluetooth/mesh/proxy.c
+++ b/subsys/bluetooth/mesh/proxy.c
@@ -22,6 +22,7 @@
 #include "mesh.h"
 #include "adv.h"
 #include "net.h"
+#include "rpl.h"
 #include "transport.h"
 #include "prov.h"
 #include "beacon.h"

--- a/subsys/bluetooth/mesh/rpl.c
+++ b/subsys/bluetooth/mesh/rpl.c
@@ -1,0 +1,175 @@
+/*  Bluetooth Mesh */
+
+/*
+ * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2020 Lingao Meng
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <string.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <sys/atomic.h>
+#include <sys/util.h>
+#include <sys/byteorder.h>
+
+#include <net/buf.h>
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/conn.h>
+#include <bluetooth/mesh.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_MESH_DEBUG_RPL)
+#define LOG_MODULE_NAME bt_mesh_rpl
+#include "common/log.h"
+
+#include "mesh.h"
+#include "adv.h"
+#include "net.h"
+#include "rpl.h"
+#include "settings.h"
+
+static struct bt_mesh_rpl replay_list[CONFIG_BT_MESH_CRPL];
+
+void bt_mesh_rpl_update(struct bt_mesh_rpl *rpl,
+		struct bt_mesh_net_rx *rx)
+{
+	rpl->src = rx->ctx.addr;
+	rpl->seq = rx->seq;
+	rpl->old_iv = rx->old_iv;
+
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		bt_mesh_store_rpl(rpl);
+	}
+}
+
+/* Check the Replay Protection List for a replay attempt. If non-NULL match
+ * parameter is given the RPL slot is returned but it is not immediately
+ * updated (needed for segmented messages), whereas if a NULL match is given
+ * the RPL is immediately updated (used for unsegmented messages).
+ */
+bool bt_mesh_rpl_check(struct bt_mesh_net_rx *rx,
+		struct bt_mesh_rpl **match)
+{
+	int i;
+
+	/* Don't bother checking messages from ourselves */
+	if (rx->net_if == BT_MESH_NET_IF_LOCAL) {
+		return false;
+	}
+
+	/* The RPL is used only for the local node */
+	if (!rx->local_match) {
+		return false;
+	}
+
+	for (i = 0; i < ARRAY_SIZE(replay_list); i++) {
+		struct bt_mesh_rpl *rpl = &replay_list[i];
+
+		/* Empty slot */
+		if (!rpl->src) {
+			if (match) {
+				*match = rpl;
+			} else {
+				bt_mesh_rpl_update(rpl, rx);
+			}
+
+			return false;
+		}
+
+		/* Existing slot for given address */
+		if (rpl->src == rx->ctx.addr) {
+			if (rx->old_iv && !rpl->old_iv) {
+				return true;
+			}
+
+			if ((!rx->old_iv && rpl->old_iv) ||
+			    rpl->seq < rx->seq) {
+				if (match) {
+					*match = rpl;
+				} else {
+					bt_mesh_rpl_update(rpl, rx);
+				}
+
+				return false;
+			} else {
+				return true;
+			}
+		}
+	}
+
+	BT_ERR("RPL is full!");
+	return true;
+}
+
+void bt_mesh_rpl_clear(void)
+{
+	BT_DBG("");
+
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		bt_mesh_clear_rpl();
+	} else {
+		(void)memset(replay_list, 0, sizeof(replay_list));
+	}
+}
+
+struct bt_mesh_rpl *bt_mesh_rpl_find(uint16_t src)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(replay_list); i++) {
+		if (replay_list[i].src == src) {
+			return &replay_list[i];
+		}
+	}
+
+	return NULL;
+}
+
+struct bt_mesh_rpl *bt_mesh_rpl_alloc(uint16_t src)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(replay_list); i++) {
+		if (!replay_list[i].src) {
+			replay_list[i].src = src;
+			return &replay_list[i];
+		}
+	}
+
+	return NULL;
+}
+
+void bt_mesh_rpl_foreach(bt_mesh_rpl_func_t func, void *user_data)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(replay_list); i++) {
+		func(&replay_list[i], user_data);
+	}
+}
+
+void bt_mesh_rpl_reset(void)
+{
+	int i;
+
+	/* Discard "old old" IV Index entries from RPL and flag
+	 * any other ones (which are valid) as old.
+	 */
+	for (i = 0; i < ARRAY_SIZE(replay_list); i++) {
+		struct bt_mesh_rpl *rpl = &replay_list[i];
+
+		if (rpl->src) {
+			if (rpl->old_iv) {
+				(void)memset(rpl, 0, sizeof(*rpl));
+			} else {
+				rpl->old_iv = true;
+			}
+
+			if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+				bt_mesh_store_rpl(rpl);
+			}
+		}
+	}
+}

--- a/subsys/bluetooth/mesh/rpl.h
+++ b/subsys/bluetooth/mesh/rpl.h
@@ -1,0 +1,30 @@
+/*  Bluetooth Mesh */
+
+/*
+ * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2020 Lingao Meng
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+struct bt_mesh_rpl {
+	uint16_t src;
+	bool  old_iv;
+#if defined(CONFIG_BT_SETTINGS)
+	bool  store;
+#endif
+	uint32_t seq;
+};
+
+typedef void (*bt_mesh_rpl_func_t)(struct bt_mesh_rpl *rpl,
+					void *user_data);
+
+void bt_mesh_rpl_reset(void);
+bool bt_mesh_rpl_check(struct bt_mesh_net_rx *rx,
+			struct bt_mesh_rpl **match);
+void bt_mesh_rpl_clear(void);
+struct bt_mesh_rpl *bt_mesh_rpl_find(uint16_t src);
+struct bt_mesh_rpl *bt_mesh_rpl_alloc(uint16_t src);
+void bt_mesh_rpl_foreach(bt_mesh_rpl_func_t func, void *user_data);
+void bt_mesh_rpl_update(struct bt_mesh_rpl *rpl,
+			struct bt_mesh_net_rx *rx);

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -24,6 +24,7 @@
 /* Private includes for raw Network & Transport layer access */
 #include "mesh.h"
 #include "net.h"
+#include "rpl.h"
 #include "transport.h"
 #include "foundation.h"
 #include "settings.h"

--- a/subsys/bluetooth/mesh/transport.h
+++ b/subsys/bluetooth/mesh/transport.h
@@ -99,10 +99,6 @@ int bt_mesh_trans_recv(struct net_buf_simple *buf, struct bt_mesh_net_rx *rx);
 
 void bt_mesh_trans_init(void);
 
-void bt_mesh_rpl_clear(void);
-
-bool bt_mesh_rpl_check(struct bt_mesh_net_rx *rx, struct bt_mesh_rpl **match);
-
 int bt_mesh_heartbeat_send(const struct bt_mesh_send_cb *cb, void *cb_data);
 
 int bt_mesh_app_key_get(const struct bt_mesh_subnet *subnet, uint16_t app_idx,


### PR DESCRIPTION
Move RPL to seperate module, and remove it in `bt_mesh`
structure.

~~Fixes proxy configuration not check by replay.~~
~~Fixes secure beacon iv update not store new RPL.~~

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>