### PR TITLE
tests: gpio_api_1pin: fix failing test on reel_board

### DIFF
--- a/tests/drivers/gpio/gpio_api_1pin/src/test_config.c
+++ b/tests/drivers/gpio/gpio_api_1pin/src/test_config.c
@@ -118,6 +118,7 @@ void test_gpio_pin_configure_push_pull(void)
 	 */
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_INPUT);
 	zassert_equal(ret, 0, "Failed to configure the pin as an input");
+	k_busy_wait(TEST_GPIO_MAX_RISE_FALL_TIME_US);
 
 	int pin_in_val;
 


### PR DESCRIPTION
Need to add a rise/fall delay after configuring the pin as an input,
due to a long RC time constant on LED1 circuit.

Fixes #27820