### PR TITLE
Bluetooth: controller: Fix TxAdd setting in auxiliary PDU

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -482,7 +482,10 @@ uint8_t ll_adv_params_set(uint16_t interval, uint8_t adv_type,
 		if (pri_hdr->aux_ptr) {
 			uint8_t err;
 
-			err = ull_adv_aux_hdr_set_clear(adv, 0, 0, NULL, NULL);
+			err = ull_adv_aux_hdr_set_clear(adv,
+							ULL_ADV_PDU_HDR_FIELD_ADVA,
+							0, &own_addr_type,
+							NULL);
 			if (err) {
 				/* TODO: cleanup? */
 				return err;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -48,6 +48,7 @@ uint8_t ull_scan_rsp_set(struct ll_adv_set *adv, uint8_t len,
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 
+#define ULL_ADV_PDU_HDR_FIELD_ADVA      BIT(0)
 #define ULL_ADV_PDU_HDR_FIELD_SYNC_INFO BIT(5)
 #define ULL_ADV_PDU_HDR_FIELD_AD_DATA   BIT(8)
 


### PR DESCRIPTION
This fixes https://github.com/zephyrproject-rtos/zephyr/issues/28090

When controller is built with extended advertising support but without
LL Privacy build fails due to issue with code that sets TxAdd in aux
PDU:
```
.../ll_sw/ull_adv_aux.c: In function 'ull_adv_aux_hdr_set_clear':
.../ll_sw/ull_adv_aux.c:502:25: error: 'struct ll_adv_set' has no member named 'own_addr_type'
  502 |   sec_pdu->tx_addr = adv->own_addr_type & 0x1;
      |
```
We need own_addr_type value if an advertising set with aux but without
AD is created since we cannot get TxAdd value from other PDU.

ull_adv_aux_hdr_set_clear() can now be called with a flag to explicitly
set AdvA field and pass own_addr_type in 'value' parameter. This allows
to set proper TxAdd when creating new advertising set.

On aux updates, we use TxAdd from other PDU:
- if primary PDU has AdvA, we use TxAdd from that PDU
- if previous secundary PDU has AdvA, we use TxAdd from that PDU
In other case we just return an unpsecified error since this should not
happen in any valid scenario.