### PR TITLE
drivers: sensor: lis2dh: make the driver multi-instance

### DIFF
--- a/drivers/sensor/lis2dh/lis2dh.h
+++ b/drivers/sensor/lis2dh/lis2dh.h
@@ -15,27 +15,16 @@
 #include <drivers/sensor.h>
 #include <string.h>
 
-#define LIS2DH_BUS_ADDRESS		DT_INST_REG_ADDR(0)
-#define LIS2DH_BUS_DEV_NAME		DT_INST_BUS_LABEL(0)
-
 #define LIS2DH_REG_WAI			0x0f
 #define LIS2DH_CHIP_ID			0x33
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 #include <drivers/spi.h>
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
 
-#define LIS2DH_SPI_READ_BIT		BIT(7)
-#define LIS2DH_SPI_AUTOINC		BIT(6)
-#define LIS2DH_SPI_ADDR_MASK		BIT_MASK(6)
-
-/* LIS2DH supports only SPI mode 0, word size 8 bits, MSB first */
-#define LIS2DH_SPI_CFG			SPI_WORD_SET(8)
-
-#elif DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 #include <drivers/i2c.h>
-#else
-#error "define bus type (I2C/SPI)"
-#endif
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */
 
 #define LIS2DH_AUTOINCREMENT_ADDR	BIT(7)
 
@@ -197,20 +186,27 @@ union lis2dh_sample {
 	} __packed;
 };
 
-struct lis2dh_config {
-	char *bus_name;
-	int (*bus_init)(const struct device *dev);
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
-	uint16_t i2c_slv_addr;
-#elif DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+struct lis2dh_spi_cfg {
 	struct spi_config spi_conf;
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	const char *gpio_cs_port;
-	uint8_t cs_gpio;
-	uint8_t cs_gpio_flags;
-#endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
+	const char *cs_gpios_label;
+};
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
 
+union lis2dh_bus_cfg {
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+	uint16_t i2c_slv_addr;
+#endif
+
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+	const struct lis2dh_spi_cfg *spi_cfg;
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
+};
+
+struct lis2dh_config {
+	const char *bus_name;
+	int (*bus_init)(const struct device *dev);
+	const union lis2dh_bus_cfg bus_cfg;
 };
 
 struct lis2dh_transfer_function {
@@ -255,9 +251,10 @@ struct lis2dh_data {
 #endif
 
 #endif /* CONFIG_LIS2DH_TRIGGER */
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
+
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 	struct spi_cs_control cs_ctrl;
-#endif /* DT_SPI_DEV_HAS_CS_GPIOS(DT_INST(0, st_lis2mdl)) */
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
 };
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)

--- a/drivers/sensor/lis2dh/lis2dh_i2c.c
+++ b/drivers/sensor/lis2dh/lis2dh_i2c.c
@@ -26,7 +26,7 @@ static int lis2dh_i2c_read_data(const struct device *dev, uint8_t reg_addr,
 	struct lis2dh_data *data = dev->data;
 	const struct lis2dh_config *cfg = dev->config;
 
-	return i2c_burst_read(data->bus, cfg->i2c_slv_addr,
+	return i2c_burst_read(data->bus, cfg->bus_cfg.i2c_slv_addr,
 			      reg_addr | LIS2DH_AUTOINCREMENT_ADDR,
 			      value, len);
 }
@@ -37,7 +37,7 @@ static int lis2dh_i2c_write_data(const struct device *dev, uint8_t reg_addr,
 	struct lis2dh_data *data = dev->data;
 	const struct lis2dh_config *cfg = dev->config;
 
-	return i2c_burst_write(data->bus, cfg->i2c_slv_addr,
+	return i2c_burst_write(data->bus, cfg->bus_cfg.i2c_slv_addr,
 			       reg_addr | LIS2DH_AUTOINCREMENT_ADDR,
 			       value, len);
 }
@@ -49,7 +49,7 @@ static int lis2dh_i2c_read_reg(const struct device *dev, uint8_t reg_addr,
 	const struct lis2dh_config *cfg = dev->config;
 
 	return i2c_reg_read_byte(data->bus,
-				 cfg->i2c_slv_addr,
+				 cfg->bus_cfg.i2c_slv_addr,
 				 reg_addr, value);
 }
 
@@ -60,7 +60,7 @@ static int lis2dh_i2c_write_reg(const struct device *dev, uint8_t reg_addr,
 	const struct lis2dh_config *cfg = dev->config;
 
 	return i2c_reg_write_byte(data->bus,
-				  cfg->i2c_slv_addr,
+				  cfg->bus_cfg.i2c_slv_addr,
 				  reg_addr, value);
 }
 
@@ -71,7 +71,7 @@ static int lis2dh_i2c_update_reg(const struct device *dev, uint8_t reg_addr,
 	const struct lis2dh_config *cfg = dev->config;
 
 	return i2c_reg_update_byte(data->bus,
-				   cfg->i2c_slv_addr,
+				   cfg->bus_cfg.i2c_slv_addr,
 				   reg_addr, mask, value);
 }
 

--- a/drivers/sensor/lis2dh/lis2dh_spi.c
+++ b/drivers/sensor/lis2dh/lis2dh_spi.c
@@ -18,12 +18,20 @@
 
 LOG_MODULE_DECLARE(lis2dh, CONFIG_SENSOR_LOG_LEVEL);
 
+
+#define LIS2DH_SPI_READ_BIT		BIT(7)
+#define LIS2DH_SPI_AUTOINC		BIT(6)
+#define LIS2DH_SPI_ADDR_MASK		BIT_MASK(6)
+
+/* LIS2DH supports only SPI mode 0, word size 8 bits, MSB first */
+#define LIS2DH_SPI_CFG			SPI_WORD_SET(8)
+
 static int lis2dh_raw_read(const struct device *dev, uint8_t reg_addr,
 			    uint8_t *value, uint8_t len)
 {
 	struct lis2dh_data *data = dev->data;
 	const struct lis2dh_config *cfg = dev->config;
-	const struct spi_config *spi_cfg = &cfg->spi_conf;
+	const struct spi_config *spi_cfg = &cfg->bus_cfg.spi_cfg->spi_conf;
 	uint8_t buffer_tx[2] = { reg_addr | LIS2DH_SPI_READ_BIT, 0 };
 	const struct spi_buf tx_buf = {
 			.buf = buffer_tx,
@@ -69,7 +77,7 @@ static int lis2dh_raw_write(const struct device *dev, uint8_t reg_addr,
 {
 	struct lis2dh_data *data = dev->data;
 	const struct lis2dh_config *cfg = dev->config;
-	const struct spi_config *spi_cfg = &cfg->spi_conf;
+	const struct spi_config *spi_cfg = &cfg->bus_cfg.spi_cfg->spi_conf;
 	uint8_t buffer_tx[1] = { reg_addr & ~LIS2DH_SPI_READ_BIT };
 	const struct spi_buf tx_buf[2] = {
 		{
@@ -150,26 +158,24 @@ static const struct lis2dh_transfer_function lis2dh_spi_transfer_fn = {
 int lis2dh_spi_init(const struct device *dev)
 {
 	struct lis2dh_data *data = dev->data;
+	const struct lis2dh_config *cfg = dev->config;
+	const struct lis2dh_spi_cfg *spi_cfg = cfg->bus_cfg.spi_cfg;
 
 	data->hw_tf = &lis2dh_spi_transfer_fn;
 
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	const struct lis2dh_config *cfg = dev->config;
+	if (spi_cfg->cs_gpios_label != NULL) {
 
-	/* handle SPI CS thru GPIO if it is the case */
-	data->cs_ctrl.gpio_dev = device_get_binding(cfg->gpio_cs_port);
-	if (!data->cs_ctrl.gpio_dev) {
-		LOG_ERR("Unable to get GPIO SPI CS device");
-		return -ENODEV;
+		/* handle SPI CS thru GPIO if it is the case */
+		data->cs_ctrl.gpio_dev =
+			    device_get_binding(spi_cfg->cs_gpios_label);
+		if (!data->cs_ctrl.gpio_dev) {
+			LOG_ERR("Unable to get GPIO SPI CS device");
+			return -ENODEV;
+		}
+
+		LOG_DBG("SPI GPIO CS configured on %s:%u",
+			spi_cfg->cs_gpios_label, data->cs_ctrl.gpio_pin);
 	}
-
-	data->cs_ctrl.gpio_pin = cfg->cs_gpio;
-	data->cs_ctrl.gpio_dt_flags = cfg->cs_gpio_flags;
-	data->cs_ctrl.delay = 0;
-
-	LOG_DBG("SPI GPIO CS configured on %s:%u",
-		cfg->gpio_cs_port, cfg->cs_gpio);
-#endif
 
 	return 0;
 }


### PR DESCRIPTION
Make this driver multi-instance and use the new API.
Fixes #27753.

Tested on x_nucleo_iks01a3 shield for both I2C and SPI. I used two different shields where the DIL24 was configured for I2C (first shield) and SPI (second shield).