### PR TITLE
actions: add backporting bot

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,16 @@
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    runs-on: ubuntu-18.04
+    name: Backport
+    steps:
+      - name: Backport
+        uses: zephyrproject-rtos/action-backport@v1.1.99
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
With new event 'pull_request_target' it is now possible to run the
backporting action that we used to have in the past as a Github app.

Use labels for backporting as before.

See https://github.com/tibdex/backport for more details.