### PR TITLE
cmake: export build flags to external build systems excluding SHELL tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1322,11 +1322,6 @@ add_subdirectory(cmake/flash)
 add_subdirectory(cmake/usage)
 add_subdirectory(cmake/reports)
 
-add_subdirectory_ifdef(
-  CONFIG_MAKEFILE_EXPORTS
-  cmake/makefile_exports
-  )
-
 if(NOT CONFIG_TEST)
 if(CONFIG_ASSERT AND (NOT CONFIG_FORCE_NO_ASSERT))
   message(WARNING "__ASSERT() statements are globally ENABLED")
@@ -1370,3 +1365,9 @@ endif()
 # Note, the compile flags are moved, but the system include is still present here.
 zephyr_compile_options($<TARGET_PROPERTY:compiler,nostdinc>)
 target_include_directories(zephyr_interface SYSTEM INTERFACE $<TARGET_PROPERTY:compiler,nostdinc_include>)
+
+# Finally export all build flags from Zephyr
+add_subdirectory_ifdef(
+  CONFIG_MAKEFILE_EXPORTS
+  cmake/makefile_exports
+  )

--- a/cmake/makefile_exports/CMakeLists.txt
+++ b/cmake/makefile_exports/CMakeLists.txt
@@ -1,6 +1,11 @@
 # Copyright (c) 2020 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+
+zephyr_get_compile_options_for_lang(ASM ASM_compile_options)
+zephyr_get_compile_options_for_lang(C C_compile_options)
+zephyr_get_compile_options_for_lang(CXX CXX_compile_options)
+
 set(exports
   "
 CC = ${CMAKE_C_COMPILER}
@@ -11,7 +16,7 @@ AS = ${CMAKE_AS}
 AR = ${CMAKE_AR}
 NM = ${CMAKE_NM}
 GDB = ${CMAKE_GDB}
-Z_CFLAGS = -I$<JOIN:$<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>, -I> -isystem $<JOIN:$<TARGET_PROPERTY:zephyr_interface,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>, -isystem > -D$<JOIN:$<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_DEFINITIONS>, -D> $<JOIN:$<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS>, >
+Z_CFLAGS = -I$<JOIN:$<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>, -I> -isystem $<JOIN:$<TARGET_PROPERTY:zephyr_interface,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>, -isystem > -D$<JOIN:$<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_DEFINITIONS>, -D> $<$<COMPILE_LANGUAGE:ASM>:${ASM_compile_options}> $<$<COMPILE_LANGUAGE:C>:${C_compile_options}> $<$<COMPILE_LANGUAGE:CXX>:${CXX_compile_options}>
 "
   )
 


### PR DESCRIPTION
Fixes: #28230

The introduction of CMake SHELL prefix in compile options to avoid
symbol de-duplication caused the build flag export feature to fail.

The export itself works, but unfortunately CMake only strips `SHELL`
prefix for its own compiler invocation, and not when exporting the build
flags.

This causes `SHELL` to be present in the Makefile.exports.\<language\>
files, leading to problems in external build systems.

This is fixed by using `zephyr_get_compile_options_for_lang()` that
strips `SHELL` and use the returned value for the export handling.

To ensure all compile options has been defined, then the inclusion of
`cmake/makefile_exports` has been moved to the end of
`zephyr/CMakeLists.txt` file.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>