### PR TITLE
arm64: tracing: Fix double tracing

### DIFF
--- a/arch/arm/core/aarch64/switch.S
+++ b/arch/arm/core/aarch64/switch.S
@@ -32,14 +32,6 @@ GDATA(_kernel)
 
 GTEXT(z_arm64_context_switch)
 SECTION_FUNC(TEXT, z_arm64_context_switch)
-#ifdef CONFIG_TRACING
-	stp	x0, x1, [sp, #-16]!
-	stp	xzr, x30, [sp, #-16]!
-	bl	sys_trace_thread_switched_out
-	ldp	xzr, x30, [sp], #16
-	ldp	x0, x1, [sp], #16
-#endif
-
 	/* addr of callee-saved regs in thread in x2 */
 	ldr	x2, =_thread_offset_to_callee_saved
 	add	x2, x2, x1


### PR DESCRIPTION
Small patch to fix the double tracing of the thread being swapped out. The thread swapped out is already being traced at:
https://github.com/zephyrproject-rtos/zephyr/blob/master/kernel/sched.c#L832 and https://github.com/zephyrproject-rtos/zephyr/blob/master/kernel/include/kswap.h#L110