### PR TITLE
net: ip: Bugfix for multicast filtering

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1733,6 +1733,7 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_add(struct net_if *iface,
 		}
 
 		ipv6->mcast[i].is_used = true;
+		ipv6->mcast[i].is_joined = true;
 		ipv6->mcast[i].address.family = AF_INET6;
 		memcpy(&ipv6->mcast[i].address.in6_addr, addr, 16);
 


### PR DESCRIPTION
Multicast group filtering (commit b7b73d0) checks value mcast.is_joined,
which left uninitialized during net_if_ipv6_maddr_add()
After adding mcast address to interface, default behavior should accept
all mcast packets with this dst address

Signed-off-by: Eug Krashtan <eug.krashtan@gmail.com>