### PR TITLE
lib: posix: eventfd: general eventfd improvements

### DIFF
--- a/lib/posix/eventfd.c
+++ b/lib/posix/eventfd.c
@@ -5,14 +5,16 @@
  */
 
 #include <zephyr.h>
-
+#include <wait_q.h>
 #include <posix/sys/eventfd.h>
-
 #include <net/socket.h>
+#include <ksched.h>
 
 struct eventfd {
-	struct k_sem read_sem;
-	struct k_sem write_sem;
+	struct k_poll_signal read_sig;
+	struct k_poll_signal write_sig;
+	struct k_spinlock lock;
+	_wait_q_t wait_q;
 	eventfd_t cnt;
 	int flags;
 };
@@ -25,16 +27,27 @@ static int eventfd_poll_prepare(struct eventfd *efd,
 				struct k_poll_event **pev,
 				struct k_poll_event *pev_end)
 {
-	ARG_UNUSED(efd);
-
 	if (pfd->events & ZSOCK_POLLIN) {
 		if (*pev == pev_end) {
 			errno = ENOMEM;
 			return -1;
 		}
 
-		(*pev)->obj = &efd->read_sem;
-		(*pev)->type = K_POLL_TYPE_SEM_AVAILABLE;
+		(*pev)->obj = &efd->read_sig;
+		(*pev)->type = K_POLL_TYPE_SIGNAL;
+		(*pev)->mode = K_POLL_MODE_NOTIFY_ONLY;
+		(*pev)->state = K_POLL_STATE_NOT_READY;
+		(*pev)++;
+	}
+
+	if (pfd->events & ZSOCK_POLLOUT) {
+		if (*pev == pev_end) {
+			errno = ENOMEM;
+			return -1;
+		}
+
+		(*pev)->obj = &efd->write_sig;
+		(*pev)->type = K_POLL_TYPE_SIGNAL;
 		(*pev)->mode = K_POLL_MODE_NOTIFY_ONLY;
 		(*pev)->state = K_POLL_STATE_NOT_READY;
 		(*pev)++;
@@ -49,13 +62,16 @@ static int eventfd_poll_update(struct eventfd *efd,
 {
 	ARG_UNUSED(efd);
 
-	if (pfd->events & ZSOCK_POLLOUT) {
-		pfd->revents |= ZSOCK_POLLOUT;
-	}
-
 	if (pfd->events & ZSOCK_POLLIN) {
 		if ((*pev)->state != K_POLL_STATE_NOT_READY) {
 			pfd->revents |= ZSOCK_POLLIN;
+		}
+		(*pev)++;
+	}
+
+	if (pfd->events & ZSOCK_POLLOUT) {
+		if ((*pev)->state != K_POLL_STATE_NOT_READY) {
+			pfd->revents |= ZSOCK_POLLOUT;
 		}
 		(*pev)++;
 	}
@@ -66,36 +82,55 @@ static int eventfd_poll_update(struct eventfd *efd,
 static ssize_t eventfd_read_op(void *obj, void *buf, size_t sz)
 {
 	struct eventfd *efd = obj;
-	eventfd_t count;
-	int ret;
+	int result = 0;
+	eventfd_t count = 0;
+	struct k_spinlock_key key;
 
 	if (sz < sizeof(eventfd_t)) {
 		errno = EINVAL;
 		return -1;
 	}
 
-	ret = k_sem_take(&efd->read_sem,
-			 (efd->flags & EFD_NONBLOCK) ? K_NO_WAIT : K_FOREVER);
+	for (;;) {
+		key = k_spin_lock(&efd->lock);
+		if ((efd->flags & EFD_NONBLOCK) && efd->cnt == 0) {
+			result = EAGAIN;
+			break;
+		} else if (efd->cnt == 0) {
+			z_pend_curr(&efd->lock, key, &efd->wait_q, K_FOREVER);
+		} else {
+			count = (efd->flags & EFD_SEMAPHORE) ? 1 : efd->cnt;
+			efd->cnt -= count;
+			if (efd->cnt == 0) {
+				k_poll_signal_reset(&efd->read_sig);
+			}
+			k_poll_signal_raise(&efd->write_sig, 0);
+			break;
+		}
+	}
+	if (z_unpend_all(&efd->wait_q) != 0) {
+		z_reschedule(&efd->lock, key);
+	} else {
+		k_spin_unlock(&efd->lock, key);
+	}
 
-	if (ret < 0) {
-		errno = EAGAIN;
+	if (result != 0) {
+		errno = result;
 		return -1;
 	}
 
-	count = (efd->flags & EFD_SEMAPHORE) ? 1 : efd->cnt;
-	efd->cnt -= count;
 	*(eventfd_t *)buf = count;
-	k_sem_give(&efd->write_sem);
 
 	return sizeof(eventfd_t);
 }
 
 static ssize_t eventfd_write_op(void *obj, const void *buf, size_t sz)
 {
-	eventfd_t count;
-	int ret = 0;
-
 	struct eventfd *efd = obj;
+	int result = 0;
+	eventfd_t count;
+	bool overflow;
+	struct k_spinlock_key key;
 
 	if (sz < sizeof(eventfd_t)) {
 		errno = EINVAL;
@@ -109,22 +144,36 @@ static ssize_t eventfd_write_op(void *obj, const void *buf, size_t sz)
 		return -1;
 	}
 
-	if (UINT64_MAX - count <= efd->cnt) {
-		if (efd->flags & EFD_NONBLOCK) {
-			ret = -EAGAIN;
+	if (count == 0) {
+		return sizeof(eventfd_t);
+	}
+
+	for (;;) {
+		key = k_spin_lock(&efd->lock);
+		overflow = UINT64_MAX - count <= efd->cnt;
+		if ((efd->flags & EFD_NONBLOCK) && overflow) {
+			result = EAGAIN;
+			break;
+		} else if (overflow) {
+			z_pend_curr(&efd->lock, key, &efd->wait_q, K_FOREVER);
 		} else {
-			ret = k_sem_take(&efd->write_sem, K_FOREVER);
+			efd->cnt += count;
+			if (efd->cnt == (UINT64_MAX - 1)) {
+				k_poll_signal_reset(&efd->write_sig);
+			}
+			k_poll_signal_raise(&efd->read_sig, 0);
+			break;
 		}
 	}
-
-	if (ret < 0) {
-		errno = -ret;
-		return -1;
+	if (z_unpend_all(&efd->wait_q) != 0) {
+		z_reschedule(&efd->lock, key);
+	} else {
+		k_spin_unlock(&efd->lock, key);
 	}
 
-	efd->cnt += count;
-	if (count) {
-		k_sem_give(&efd->read_sem);
+	if (result != 0) {
+		errno = result;
+		return -1;
 	}
 
 	return sizeof(eventfd_t);
@@ -200,7 +249,8 @@ static const struct fd_op_vtable eventfd_fd_vtable = {
 int eventfd(unsigned int initval, int flags)
 {
 	struct eventfd *efd = NULL;
-	int i, fd;
+	int fd = -1;
+	int i;
 
 	if (flags & ~EFD_FLAGS_SET) {
 		errno = EINVAL;
@@ -208,12 +258,6 @@ int eventfd(unsigned int initval, int flags)
 	}
 
 	k_mutex_lock(&eventfd_mtx, K_FOREVER);
-
-	fd = z_reserve_fd();
-	if (fd < 0) {
-		k_mutex_unlock(&eventfd_mtx);
-		return -1;
-	}
 
 	for (i = 0; i < ARRAY_SIZE(efds); ++i) {
 		if (!(efds[i].flags & EFD_IN_USE)) {
@@ -223,20 +267,30 @@ int eventfd(unsigned int initval, int flags)
 	}
 
 	if (efd == NULL) {
-		z_free_fd(fd);
 		errno = ENOMEM;
-		k_mutex_unlock(&eventfd_mtx);
-		return -1;
+		goto exit_mtx;
+	}
+
+	fd = z_reserve_fd();
+	if (fd < 0) {
+		goto exit_mtx;
 	}
 
 	efd->flags = EFD_IN_USE | flags;
-	efd->cnt = 0;
-	k_sem_init(&efd->read_sem, 0, 1);
-	k_sem_init(&efd->write_sem, 0, UINT32_MAX);
+	efd->cnt = initval;
+
+	k_poll_signal_init(&efd->write_sig);
+	k_poll_signal_init(&efd->read_sig);
+	z_waitq_init(&efd->wait_q);
+
+	if (initval != 0) {
+		k_poll_signal_raise(&efd->read_sig, 0);
+	}
+	k_poll_signal_raise(&efd->write_sig, 0);
 
 	z_finalize_fd(fd, efd, &eventfd_fd_vtable);
 
+exit_mtx:
 	k_mutex_unlock(&eventfd_mtx);
-
 	return fd;
 }

--- a/tests/posix/eventfd/src/main.c
+++ b/tests/posix/eventfd/src/main.c
@@ -8,23 +8,27 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <errno.h>
-#include <pthread.h>
-
-#ifndef PTHREAD_STACK_MIN
-#define PTHREAD_STACK_MIN 0
-#endif
-
 #include <net/socket.h>
-
 #include <poll.h>
-
 #include <sys/eventfd.h>
 
-#define EVENTFD_STACK_SIZE	(1024 + CONFIG_TEST_EXTRA_STACKSIZE + \
-				 PTHREAD_STACK_MIN)
+#define TESTVAL 10
 
-K_THREAD_STACK_DEFINE(eventfd_stack, EVENTFD_STACK_SIZE);
-static pthread_t eventfd_thread;
+static int is_blocked(int fd, short *event)
+{
+	struct pollfd pfd;
+	int ret;
+
+	pfd.fd = fd;
+	pfd.events = *event;
+
+	ret = poll(&pfd, 1, 0);
+	zassert_true(ret >= 0, "poll failed %d", ret);
+
+	*event = pfd.revents;
+
+	return ret == 0;
+}
 
 static void test_eventfd(void)
 {
@@ -37,14 +41,25 @@ static void test_eventfd(void)
 
 static void test_eventfd_read_nonblock(void)
 {
-	eventfd_t val;
+	eventfd_t val = 0;
 	int fd, ret;
 
 	fd = eventfd(0, EFD_NONBLOCK);
 	zassert_true(fd >= 0, "fd == %d", fd);
 
 	ret = eventfd_read(fd, &val);
-	zassert_true(ret == -1, "read ret %d", ret);
+	zassert_true(ret == -1, "read unset ret %d", ret);
+	zassert_true(errno == EAGAIN, "errno %d", errno);
+
+	ret = eventfd_write(fd, TESTVAL);
+	zassert_true(ret == 0, "write ret %d", ret);
+
+	ret = eventfd_read(fd, &val);
+	zassert_true(ret == 0, "read set ret %d", ret);
+	zassert_true(val == TESTVAL, "red set val %d", val);
+
+	ret = eventfd_read(fd, &val);
+	zassert_true(ret == -1, "read subsequent ret %d val %d", ret, val);
 	zassert_true(errno == EAGAIN, "errno %d", errno);
 
 	close(fd);
@@ -105,101 +120,149 @@ static void test_eventfd_poll_timeout(void)
 	close(fd);
 }
 
-struct test_thread_data {
-	int fd;
-	struct k_sem written_twice;
-};
-
-static void *test_thread_wait_and_write(void *arg)
+static void eventfd_poll_unset_common(int fd)
 {
-	struct test_thread_data *d = arg;
-	int fd = d->fd;
+	eventfd_t val = 0;
+	short event;
 	int ret;
 
-	k_sleep(K_MSEC(500));
+	event = POLLIN;
+	ret = is_blocked(fd, &event);
+	zassert_equal(ret, 1, "eventfd not blocked with initval == 0");
 
-	ret = eventfd_write(fd, 10);
-	zassert_true(ret == 0, "write ret %d", ret);
+	ret = eventfd_write(fd, TESTVAL);
+	zassert_equal(ret, 0, "write ret %d", ret);
 
-	ret = eventfd_write(fd, 10);
-	zassert_true(ret == 0, "write ret %d", ret);
+	event = POLLIN;
+	ret = is_blocked(fd, &event);
+	zassert_equal(ret, 0, "eventfd blocked after write");
+	zassert_equal(event, POLLIN, "POLLIN not set");
 
-	k_sem_give(&d->written_twice);
+	ret = eventfd_write(fd, TESTVAL);
+	zassert_equal(ret, 0, "write ret %d", ret);
 
-	k_sleep(K_MSEC(1500));
+	ret = eventfd_read(fd, &val);
+	zassert_equal(ret, 0, "read ret %d", ret);
+	zassert_equal(val, 2*TESTVAL, "val == %d, expected %d", val, TESTVAL);
 
-	ret = eventfd_write(fd, 5);
-	zassert_true(ret == 0, "write ret %d", ret);
+	/* eventfd shall block on subsequent reads */
 
-	return NULL;
+	event = POLLIN;
+	ret = is_blocked(fd, &event);
+	zassert_equal(ret, 1, "eventfd not blocked after read");
 }
 
-static void test_eventfd_poll_event(void)
+static void test_eventfd_unset_poll_event_block(void)
 {
-	struct sched_param schedparam;
-	pthread_attr_t attr;
-	struct pollfd pfd;
-	eventfd_t val;
-	struct test_thread_data d;
+	int fd;
+
+	fd = eventfd(0, 0);
+	zassert_true(fd >= 0, "fd == %d", fd);
+
+	eventfd_poll_unset_common(fd);
+
+	close(fd);
+}
+
+static void test_eventfd_unset_poll_event_nonblock(void)
+{
+	int fd;
+
+	fd = eventfd(0, EFD_NONBLOCK);
+	zassert_true(fd >= 0, "fd == %d", fd);
+
+	eventfd_poll_unset_common(fd);
+
+	close(fd);
+}
+
+static void eventfd_poll_set_common(int fd)
+{
+	eventfd_t val = 0;
+	short event;
+	int ret;
+
+	event = POLLIN;
+	ret = is_blocked(fd, &event);
+	zassert_equal(ret, 0, "eventfd is blocked with initval != 0");
+
+	ret = eventfd_read(fd, &val);
+	zassert_equal(ret, 0, "read ret %d", ret);
+	zassert_equal(val, TESTVAL, "val == %d", val);
+
+	event = POLLIN;
+	ret = is_blocked(fd, &event);
+	zassert_equal(ret, 1, "eventfd is not blocked after read");
+}
+
+static void test_eventfd_set_poll_event_block(void)
+{
+	int fd;
+
+	fd = eventfd(TESTVAL, 0);
+	zassert_true(fd >= 0, "fd == %d", fd);
+
+	eventfd_poll_set_common(fd);
+
+	close(fd);
+}
+
+static void test_eventfd_set_poll_event_nonblock(void)
+{
+	int fd;
+
+	fd = eventfd(TESTVAL, EFD_NONBLOCK);
+	zassert_true(fd >= 0, "fd == %d", fd);
+
+	eventfd_poll_set_common(fd);
+
+	close(fd);
+}
+
+static void test_eventfd_overflow(void)
+{
+	short event;
+	int fd, ret;
+
+	fd = eventfd(0, EFD_NONBLOCK);
+	zassert_true(fd >= 0, "fd == %d", fd);
+
+	event = POLLOUT;
+	ret = is_blocked(fd, &event);
+	zassert_equal(ret, 0, "eventfd write blocked with initval == 0");
+
+	ret = eventfd_write(fd, UINT64_MAX);
+	zassert_equal(ret, -1, "fd == %d", fd);
+	zassert_equal(errno, EINVAL, "did not get EINVAL");
+
+	ret = eventfd_write(fd, UINT64_MAX-1);
+	zassert_equal(ret, 0, "fd == %d", fd);
+
+	event = POLLOUT;
+	ret = is_blocked(fd, &event);
+	zassert_equal(ret, 1, "eventfd write not blocked with cnt == UINT64_MAX-1");
+
+	ret = eventfd_write(fd, 1);
+	zassert_equal(ret, -1, "fd == %d", fd);
+	zassert_equal(errno, EAGAIN, "did not get EINVAL");
+
+	close(fd);
+}
+
+static void test_eventfd_zero_shall_not_unblock(void)
+{
+	short event;
 	int fd, ret;
 
 	fd = eventfd(0, 0);
 	zassert_true(fd >= 0, "fd == %d", fd);
 
-	ret = pthread_attr_init(&attr);
-	zassert_true(ret == 0, "pthread_attr_init ret %d", ret);
+	ret = eventfd_write(fd, 0);
+	zassert_equal(ret, 0, "fd == %d", fd);
 
-	ret = pthread_attr_setschedpolicy(&attr, SCHED_FIFO);
-	zassert_true(ret == 0, "pthread_attr_setschedpolicy ret %d", ret);
-
-	schedparam.sched_priority = 1;
-	ret = pthread_attr_setschedparam(&attr, &schedparam);
-	zassert_true(ret == 0, "pthread_attr_setschedparam ret %d", ret);
-
-	ret = pthread_attr_setstack(&attr, eventfd_stack, EVENTFD_STACK_SIZE);
-	zassert_true(ret == 0, "pthread_attr_setstack ret %d", ret);
-
-	d.fd = fd;
-	k_sem_init(&d.written_twice, 0, 1);
-
-	ret = pthread_create(&eventfd_thread, &attr, test_thread_wait_and_write,
-			     &d);
-	zassert_true(ret == 0, "pthread_create ret %d", ret);
-
-	pfd.fd = fd;
-	pfd.events = POLLIN;
-
-	TC_PRINT("Waiting for first event\n");
-
-	ret = poll(&pfd, 1, 3000);
-	zassert_true(ret == 1, "poll ret %d %d", ret, pfd.revents);
-	zassert_equal(pfd.revents, POLLIN, "POLLIN not set");
-
-	k_sem_take(&d.written_twice, K_FOREVER);
-
-	TC_PRINT("Reading two events\n");
-
-	ret = eventfd_read(fd, &val);
-	zassert_true(ret == 0, "read ret %d", ret);
-	zassert_true(val == 20, "val == %d", val);
-
-	TC_PRINT("Waiting 1s for event after 1.5s (should timeout)\n");
-
-	ret = poll(&pfd, 1, 1000);
-	zassert_true(ret == 0, "poll ret %d %d", ret, pfd.revents);
-	zassert_equal(pfd.revents, 0, "POLLIN set");
-
-	TC_PRINT("Waiting 3s for event after 0.5s (should succeed)\n");
-
-	ret = poll(&pfd, 1, 3000);
-	zassert_true(ret == 1, "poll ret %d %d", ret, pfd.revents);
-	zassert_equal(pfd.revents, POLLIN, "POLLIN not set");
-
-	TC_PRINT("Reading last event\n");
-
-	ret = eventfd_read(fd, &val);
-	zassert_true(ret == 0, "read ret %d", ret);
-	zassert_true(val == 5, "val == %d", val);
+	event = POLLIN;
+	ret = is_blocked(fd, &event);
+	zassert_equal(ret, 1, "eventfd unblocked by zero");
 
 	close(fd);
 }
@@ -211,7 +274,12 @@ void test_main(void)
 				ztest_unit_test(test_eventfd_read_nonblock),
 				ztest_unit_test(test_eventfd_write_then_read),
 				ztest_unit_test(test_eventfd_poll_timeout),
-				ztest_unit_test(test_eventfd_poll_event)
+				ztest_unit_test(test_eventfd_unset_poll_event_block),
+				ztest_unit_test(test_eventfd_unset_poll_event_nonblock),
+				ztest_unit_test(test_eventfd_set_poll_event_block),
+				ztest_unit_test(test_eventfd_set_poll_event_nonblock),
+				ztest_unit_test(test_eventfd_overflow),
+				ztest_unit_test(test_eventfd_zero_shall_not_unblock)
 				);
 	ztest_run_test_suite(test_eventfd);
 }


### PR DESCRIPTION
The eventfd implementation suffers from various shortcomings.
and it is not thread safe.

This commit addresses the following aspects of eventfd:
* make read and write atomic in respect to each other
* POLLIN after creating eventfd with initval != 0 shall be set
* blocking and nonblocking modes shall have the same effect on poll()
* add support for POLLOUT

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>