### PR TITLE
drivers: Bluetooth: rpmsg: Add missing BT_QUIRK_NO_AUTO_DLE

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -130,3 +130,16 @@ config BT_RPMSG_NRF53_RX_PRIO
 	default 8
 
 endif # BT_RPMSG_NRF53
+
+config BT_DRIVER_QUIRK_NO_AUTO_DLE
+	bool "Host auto-initiated Data Length Update quirk"
+	depends on BT_AUTO_DATA_LEN_UPDATE
+	default y if BT_RPMSG_NRF53
+	help
+	  Enable the quirk wherein BT Host stack will auto-initiate Data Length
+	  Update procedure for new connections for controllers that do not
+	  auto-initiate the procedure if the default data length parameters are
+	  not equal to the initial parameters.
+
+	  This has to be enabled when the BLE controller connected is Zephyr
+	  open source controller.

--- a/drivers/bluetooth/hci/rpmsg.c
+++ b/drivers/bluetooth/hci/rpmsg.c
@@ -198,6 +198,9 @@ static const struct bt_hci_driver drv = {
 	.open		= bt_rpmsg_open,
 	.send		= bt_rpmsg_send,
 	.bus		= BT_HCI_DRIVER_BUS_IPM,
+#if defined(BT_DRIVER_QUIRK_NO_AUTO_DLE)
+	.quirks         = BT_QUIRK_NO_AUTO_DLE,
+#endif
 };
 
 static int bt_rpmsg_init(const struct device *unused)


### PR DESCRIPTION
Add BT_QUIRK_NO_AUTO_DLE quirk option for HCI rpmsg driver
when the Zephyr open source BLE controller is used.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>