### PR TITLE
aarch64: work around QEMU 'wfi' issue

### DIFF
--- a/arch/arm/core/aarch64/CMakeLists.txt
+++ b/arch/arm/core/aarch64/CMakeLists.txt
@@ -8,7 +8,6 @@ if (CONFIG_COVERAGE)
 endif ()
 
 zephyr_library_sources(
-  cpu_idle.S
   fatal.c
   irq_init.c
   irq_manage.c
@@ -18,6 +17,15 @@ zephyr_library_sources(
   thread.c
   vector_table.S
 )
+
+# Workaround aarch64 QEMU not responding to host OS signals
+# during 'wfi'.
+# See https://github.com/zephyrproject-rtos/sdk-ng/issues/255
+if (CONFIG_SOC_QEMU_CORTEX_A53)
+  zephyr_library_sources(cpu_idle_qemu.c)
+else ()
+  zephyr_library_sources(cpu_idle.S)
+endif ()
 
 zephyr_library_sources_ifdef(CONFIG_GEN_SW_ISR_TABLE isr_wrapper.S)
 zephyr_library_sources_ifdef(CONFIG_IRQ_OFFLOAD irq_offload.c)

--- a/arch/arm/core/aarch64/cpu_idle_qemu.c
+++ b/arch/arm/core/aarch64/cpu_idle_qemu.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /**
+  * @file
+  *
+  * @brief Workaround aarch64 QEMU not responding to host OS signals
+  * during 'wfi'.
+  * See https://github.com/zephyrproject-rtos/sdk-ng/issues/255
+  */
+
+#include <arch/cpu.h>
+
+void arch_cpu_idle(void)
+{
+	/* Do nothing but unconditionally unlock interrupts and return to the
+	 * caller.
+	 */
+
+	__asm__ volatile("msr daifclr, %0\n\t"
+			 : : "i" (DAIFSET_IRQ)
+			 : "memory", "cc");
+}
+
+void arch_cpu_atomic_idle(unsigned int key)
+{
+	/* Do nothing but restore IRQ state */
+	arch_irq_unlock(key);
+}

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -91,9 +91,13 @@
 #endif
 
 /* Cortex-M1, Nios II, and RISCV without CONFIG_RISCV_HAS_CPU_IDLE
- * do have a power saving instruction, so k_cpu_idle() returns immediately
+ * do have a power saving instruction, so k_cpu_idle() returns immediately.
+ *
+ * Includes workaround on QEMU aarch64, see
+ * https://github.com/zephyrproject-rtos/sdk-ng/issues/255
  */
 #if !defined(CONFIG_CPU_CORTEX_M1) && !defined(CONFIG_NIOS2) && \
+    !defined(CONFIG_SOC_QEMU_CORTEX_A53) && \
 	(!defined(CONFIG_RISCV) || defined(CONFIG_RISCV_HAS_CPU_IDLE))
 #define HAS_POWERSAVE_INSTRUCTION
 #endif


### PR DESCRIPTION
Work around an issue where the emulator ignores host OS
signals when inside a `wfi` instruction.

This should be reverted once this has been addressed in the
AARCH64 build of QEMU in the SDK.

See https://github.com/zephyrproject-rtos/sdk-ng/issues/255

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>