### PR TITLE
doc: ext: link-roles: allow non-default baseurl

### DIFF
--- a/doc/extensions/zephyr/link-roles.py
+++ b/doc/extensions/zephyr/link-roles.py
@@ -9,6 +9,10 @@ from __future__ import unicode_literals
 import re
 from docutils import nodes
 from local_util import run_cmd_get_output
+try:
+    from west.manifest import Manifest as WestManifest
+except ImportError:
+    WestManifest = None
 
 
 def get_github_rev():
@@ -22,8 +26,17 @@ def get_github_rev():
 def setup(app):
     rev = get_github_rev()
 
-    # links to files or folders on the GitHub
-    baseurl = 'https://github.com/zephyrproject-rtos/zephyr'
+    # try to get url from West; this adds compatibility with repos
+    # located elsewhere
+    if WestManifest is not None:
+        baseurl = WestManifest.from_file().get_projects(['zephyr'])[0].url
+    else:
+        baseurl = None
+
+    # or fallback to default
+    if baseurl is None:
+        baseurl = 'https://github.com/zephyrproject-rtos/zephyr'
+
     app.add_role('zephyr_file', autolink('{}/blob/{}/%s'.format(baseurl, rev)))
     app.add_role('zephyr_raw', autolink('{}/raw/{}/%s'.format(baseurl, rev)))
 


### PR DESCRIPTION
Link roles, aka :zephyr_file: and :zephyr_raw: use a repo's git describe information to create links but the baseurl is fixed to the upstream repo. This breaks links created in repos that are forks located somewhere else.

This commits tries to get the baseurl from west if available so it will work correctly for forks. If fallbacks to the upstream repo if no information can be gathered by West, or West is not available.