### PR TITLE
tests: benchmark: Fix footprint testcase.yaml to use arch_allow

### DIFF
--- a/tests/benchmarks/footprints/testcase.yaml
+++ b/tests/benchmarks/footprints/testcase.yaml
@@ -5,6 +5,6 @@ tests:
   benchmark.kernel.footprints.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_args: CONF_FILE=prj_userspace.conf
-    arch_whitelist: x86 arm arc
+    arch_allow: x86 arm arc
     tags: benchmark userspace
     build_only: true


### PR DESCRIPTION
Fixes the footprint testcase.yaml to use arch_allow instead of
arch_whitelist.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>