### PR TITLE
lib: gui: lvgl: add support for kscan axes swap and inversion

### DIFF
--- a/boards/shields/adafruit_2_8_tft_touch_v2/Kconfig.defconfig
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/Kconfig.defconfig
@@ -54,6 +54,9 @@ config LVGL_POINTER_KSCAN
 config LVGL_POINTER_KSCAN_DEV_NAME
 	default "FT5336"
 
+config LVGL_POINTER_KSCAN_INVERT_X
+	default y
+
 endif # LVGL
 
 endif # DISPLAY

--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/Kconfig.defconfig
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/Kconfig.defconfig
@@ -54,6 +54,9 @@ config LVGL_POINTER_KSCAN
 config LVGL_POINTER_KSCAN_DEV_NAME
 	default "TOUCH"
 
+config LVGL_POINTER_KSCAN_INVERT_X
+	default y
+
 endif # LVGL
 
 endif # DISPLAY

--- a/lib/gui/lvgl/Kconfig.input
+++ b/lib/gui/lvgl/Kconfig.input
@@ -24,6 +24,24 @@ config LVGL_POINTER_KSCAN_MSGQ_COUNT
 	help
 	  Maximum number of items in the keyboard scan message queue.
 
+config LVGL_POINTER_KSCAN_SWAP_XY
+	bool "Swap keyboard scan X,Y axes"
+	help
+	  Swap keyboard scan X,Y axes. This option can be used to align keyboard
+	  scan coordinates with the display.
+
+config LVGL_POINTER_KSCAN_INVERT_X
+	bool "Invert keyboard scan X axis"
+	help
+	  Invert keyboard scan X axis. This option can be used to align keyboard
+	  scan coordinates with the display.
+
+config LVGL_POINTER_KSCAN_INVERT_Y
+	bool "Invert keyboard scan Y axis"
+	help
+	  Invert keyboard scan Y axis. This option can be used to align keyboard
+	  scan coordinates with the display.
+
 endif # LVGL_POINTER_KSCAN
 
 config LVGL_INDEV_DEF_READ_PERIOD

--- a/lib/gui/lvgl/lvgl.c
+++ b/lib/gui/lvgl/lvgl.c
@@ -195,16 +195,41 @@ static void lvgl_pointer_kscan_callback(const struct device *dev,
 
 static bool lvgl_pointer_kscan_read(lv_indev_drv_t *drv, lv_indev_data_t *data)
 {
+	lv_disp_t *disp;
+	const struct device *disp_dev;
+	struct display_capabilities cap;
+	lv_indev_data_t curr;
+
 	static lv_indev_data_t prev = {
 		.point.x = 0,
 		.point.y = 0,
 		.state = LV_INDEV_STATE_REL,
 	};
 
-	lv_indev_data_t curr;
-
 	if (k_msgq_get(&kscan_msgq, &curr, K_NO_WAIT) == 0) {
 		prev = curr;
+	}
+
+	disp = lv_disp_get_default();
+	disp_dev = disp->driver.user_data;
+
+	display_get_capabilities(disp_dev, &cap);
+
+	/* adjust kscan coordinates */
+	if (IS_ENABLED(CONFIG_LVGL_POINTER_KSCAN_SWAP_XY)) {
+		lv_coord_t x;
+
+		x = prev.point.x;
+		prev.point.x = prev.point.y;
+		prev.point.y = x;
+	}
+
+	if (IS_ENABLED(CONFIG_LVGL_POINTER_KSCAN_INVERT_X)) {
+		prev.point.x = cap.x_resolution - prev.point.x;
+	}
+
+	if (IS_ENABLED(CONFIG_LVGL_POINTER_KSCAN_INVERT_Y)) {
+		prev.point.y = cap.y_resolution - prev.point.y;
 	}
 
 	*data = prev;

--- a/lib/gui/lvgl/lvgl.c
+++ b/lib/gui/lvgl/lvgl.c
@@ -232,6 +232,24 @@ static bool lvgl_pointer_kscan_read(lv_indev_drv_t *drv, lv_indev_data_t *data)
 		prev.point.y = cap.y_resolution - prev.point.y;
 	}
 
+	/* rotate touch point to match display rotation */
+	if (cap.current_orientation == DISPLAY_ORIENTATION_ROTATED_90) {
+		lv_coord_t x;
+
+		x = prev.point.x;
+		prev.point.x = cap.y_resolution - prev.point.y;
+		prev.point.y = x;
+	} else if (cap.current_orientation == DISPLAY_ORIENTATION_ROTATED_180) {
+		prev.point.x = cap.x_resolution - prev.point.x;
+		prev.point.y = cap.y_resolution - prev.point.y;
+	} else if (cap.current_orientation == DISPLAY_ORIENTATION_ROTATED_270) {
+		lv_coord_t x;
+
+		x = prev.point.x;
+		prev.point.x = prev.point.y;
+		prev.point.y = cap.x_resolution - x;
+	}
+
 	*data = prev;
 
 	return k_msgq_num_used_get(&kscan_msgq) > 0;


### PR DESCRIPTION
Add new Kconfig options to allow kscan axes swap and inversion. These options are useful to align display and touch frame of reference.

NOTE: If a touch API is ever introduced these options could be moved there (DT).

Fixes #28202