### PR TITLE
lib: os: printk: fix printing unsigned 32-bit integers

### DIFF
--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -247,6 +247,8 @@ void z_vprintk(out_func_t out, void *ctx, const char *fmt, va_list ap)
 						break;
 					}
 					d = (printk_val_t) lld;
+				} else if (*fmt == 'u') {
+					d = va_arg(ap, unsigned int);
 				} else {
 					d = va_arg(ap, int);
 				}


### PR DESCRIPTION
The vararg extraction for unmodified integers always used int, which
sign extends when assigned to the printk_val_t.  Avoid the sign
extension for unsigned values.

(Discovered on a restored mimxrt1060-evk where the button application does this:
```
** Booting Zephyr OS build v2.4.0-rc1-37-gc6cf8d167367  ***                    
Set up button at GPIO_5 pin 0                                                   
Set up LED at GPIO_1 pin 9                                                      
Press the button                                                                
Button pressed at 1071352780 0                                                  
Button pressed at 1491613270 0                                                  
Button pressed at 1767581435 0                                                  
Button pressed at 1996706734 0                                                  
Button pressed at 18446744071842653220 0                                        
Button pressed at 18446744072345013115 0                                        
Button pressed at 18446744072528196900 0                                        
Button pressed at 18446744072707922320 0                                        
Button pressed at 18446744072895729756 0                                        
Button pressed at 18446744073185610073 0                                        
Button pressed at 18446744073274967140 0                                        
Button pressed at 18446744073574241357 0                                        
Button pressed at 222448882 0                                                   
Button pressed at 570581486 0                                                   
Button pressed at 782411752 0                                                   
```
)