### PR TITLE
drivers: led_strip: APA102 use CS flags from devicetree

### DIFF
--- a/drivers/led_strip/apa102.c
+++ b/drivers/led_strip/apa102.c
@@ -105,13 +105,10 @@ static int apa102_init(const struct device *dev)
 		return -ENODEV;
 	}
 	data->cs_ctl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
+	data->cs_ctl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
 	data->cs_ctl.delay = 0;
 
 	data->cfg.cs = &data->cs_ctl;
-
-	gpio_pin_configure(data->cs_ctl.gpio_dev, data->cs_ctl.gpio_pin,
-			   GPIO_OUTPUT_INACTIVE |
-			   DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0));
 #endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
 
 	return 0;


### PR DESCRIPTION
The pull request:
drivers: SPI: Adds CS flags from devicetree #26269
missed out on the APA102 led_strip driver, most likely due to the driver not utilising the chip select signal until:
drivers: led_strip: Add support for external SPI CS on APA102 LED strips #25310

Signed-off-by: Roman Vaughan <nzsmartie@gmail.com>