### PR TITLE
drivers: dma : stm32 with dmamux has a special offset

### DIFF
--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -36,6 +36,9 @@ struct dma_stm32_config {
 	bool support_m2m;
 	uint32_t base;
 	uint32_t max_streams;
+#ifdef CONFIG_DMAMUX_STM32
+	uint8_t offset; /* position in the list of dmamux channel list */
+#endif
 	struct dma_stm32_stream *streams;
 };
 

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -311,6 +311,7 @@
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x1>;
 			st,mem2mem;
 			dma-requests = <7>;
+			dma-offset = <0>;
 			status = "disabled";
 			label = "DMA_1";
 		};
@@ -323,6 +324,7 @@
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x2>;
 			st,mem2mem;
 			dma-requests = <7>;
+			dma-offset = <7>;
 			status = "disabled";
 			label = "DMA_2";
 		};

--- a/dts/bindings/dma/st,stm32-dma.yaml
+++ b/dts/bindings/dma/st,stm32-dma.yaml
@@ -93,6 +93,16 @@ properties:
       type: boolean
       description: If the DMA controller V1 supports memory to memory transfer
 
+    dma-offset:
+      type: int
+      required: false
+      description: >
+        offset in the table of channels when mapping to a DMAMUX
+        for 1st dma instance, offset is 0,
+        for 2nd dma instance, offset is the nb of dma channels of the 1st dma,
+        for 3rd dma instance, offset is the nb of dma channels of the 2nd dma
+        plus the nb of dma channels of the 1st dma instance, etc.
+
     "#dma-cells":
       const: 4
 


### PR DESCRIPTION
This new offset value in the dma config device tree is made to build the table of dma mux_channels with a dmamux.
In case of DMAMUX, for each dma instance, the mux channel must reflect, thanks to this _offset_, the position of each dma channel in the table of dmamux channels.

For the stm32wb55 soc which has 2 dma instances of 7 channels each plus a dmamux of 14 channels, the DMAMUX is used with DMA1 and DMA2:
. DMAMUX channels **0** to 6 are connected to DMA1 channels 1 to 7
. DMAMUX channels **7** to 13 are connected to DMA2 channels 1 to 7
In this example the offset for the DMA1 table is **0**, offset for the DMA2 table is **7**

This PR completes the PR #28182

Signed-off-by: Francois Ramu <francois.ramu@st.com>