### PR TITLE
samples: canbus: canopen: fix argument to CO_delete()

### DIFF
--- a/samples/subsys/canbus/canopen/src/main.c
+++ b/samples/subsys/canbus/canopen/src/main.c
@@ -296,6 +296,6 @@ void main(void)
 
 	LOG_INF("Resetting device");
 
-	CO_delete(CAN_INTERFACE);
+	CO_delete(&can);
 	sys_reboot(SYS_REBOOT_COLD);
 }


### PR DESCRIPTION
The CANopenNode stack function CO_delete() takes a void *CANdriverState argument. This maps to a pointer to a struct canopen_context in Zephyr.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>