### PR TITLE
Openthread build flags

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -1746,3 +1746,30 @@ Relative paths are only allowed with `-D${ARGV1}=<path>`")
     set(${ARGV1} ${${ARGV1}} PARENT_SCOPE)
   endif()
 endfunction()
+
+# Usage:
+#   zephyr_get_targets(<directory> <types> <targets>)
+#
+# Get build targets for a given directory and sub-directories.
+#
+# This functions will traverse the build tree, starting from <directory>.
+# It will read the `BUILDSYSTEM_TARGETS` for each directory in the build tree
+# and return the build types matching the <types> list.
+# Example of types: OBJECT_LIBRARY, STATIC_LIBRARY, INTERFACE_LIBRARY, UTILITY.
+#
+# returns a list of targets in <targets> matching the required <types>.
+function(zephyr_get_targets directory types targets)
+    get_property(sub_directories DIRECTORY ${directory} PROPERTY SUBDIRECTORIES)
+    get_property(dir_targets DIRECTORY ${directory} PROPERTY BUILDSYSTEM_TARGETS)
+    foreach(dir_target ${dir_targets})
+      get_property(target_type TARGET ${dir_target} PROPERTY TYPE)
+      if(${target_type} IN_LIST types)
+        list(APPEND ${targets} ${dir_target})
+      endif()
+    endforeach()
+
+    foreach(directory ${sub_directories})
+        zephyr_get_targets(${directory} "${types}" ${targets})
+    endforeach()
+    set(${targets} ${${targets}} PARENT_SCOPE)
+endfunction()

--- a/west.yml
+++ b/west.yml
@@ -111,7 +111,7 @@ manifest:
       revision: 3f545d76a2e6d1db83a470ccdb5bebd1f484e137
       path: modules/lib/loramac-node
     - name: openthread
-      revision: f23165fde96ae8bd710b08c6d77879465ed92cac
+      revision: 7854c687bf23ce509a65d118cbea0c7011a89a1e
       path: modules/lib/openthread
     - name: segger
       revision: 874d9e9696b00c09f9eeefe839028dc25fe44983


### PR DESCRIPTION
Fixes: #28197

Update openthread to build flag changes for fixing #28197.

see https://github.com/zephyrproject-rtos/openthread/pull/29

It also introduces `zephyr_get_targets()` that allows fetching of build target from a directory and down.
This is useful when including external modules where only libraries
required by Zephyr should be built, and remove the need of setting build flags on openthread libraries not used by Zephyr.

This has the positive side effect of reducing the number of build steps and build time significantly.

Before, 780 steps:
`time ninja -Cbuild`
```
[708/708] Linking CXX executable zephyr/zephyr.elf
135.08user 30.24system 0:46.21elapsed 357%CPU
```

After, 480 steps:
`time ninja -Cbuild`
```
[480/480] Linking CXX executable zephyr/zephyr.elf
84.02user 18.92system 0:30.72elapsed 335%CPU
```
