### PR TITLE
manifest: mcuboot update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -93,7 +93,7 @@ manifest:
       revision: 9638398d3c319074ae3878035138ef8a76001e5b
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: 480421999ec2d8d2a20091e4f3a0393db04de5c4
+      revision: a5d79cf8ccb2c71e68ef32a71d6a2716e831d12e
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 5051f9d900bbb194a23d4ce80f3c6dc6d6780cc2


### PR DESCRIPTION
Fixed build issue for multiple CONF_FILEs.

Introduces patch: https://github.com/zephyrproject-rtos/mcuboot/pull/32

fixes:
>Hi @nvlsianpu , After zephyrproject-rtos/mcuboot@bdcfc85 I can't even build MCUboot for disco_l475_iot1. The commit message doesn't explain if there are something that should be done on my environment to allow build.

noticed in https://github.com/zephyrproject-rtos/zephyr/issues/25010

fixes #28307

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>