### PR TITLE
drivers: bluetooth: hci_spi: fix init priority

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -85,6 +85,10 @@ config BT_UART_ON_DEV_NAME
 
 if BT_SPI
 
+config BT_SPI_INIT_PRIORITY
+	int "BT SPI init priority"
+	default 75
+
 config BT_BLUENRG_ACI
 	bool "Enable ACI message with with BlueNRG-based devices"
 	help

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -568,4 +568,4 @@ static int bt_spi_init(const struct device *unused)
 	return 0;
 }
 
-SYS_INIT(bt_spi_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(bt_spi_init, POST_KERNEL, CONFIG_BT_SPI_INIT_PRIORITY);


### PR DESCRIPTION
Fixes #28275 by adding bluetooth HCI spi driver priority lower
(75 instead of 50) than SPI (70) to avoid device_get_binding
to return NULL because the device was not initialized.

Signed-off-by: Jeremy LOCHE <lochejeremy@gmail.com>