### PR TITLE
net: lwm2m: use defines for message id and token generation

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -939,7 +939,7 @@ int lwm2m_init_message(struct lwm2m_message *msg)
 	 * msg->tkl == 0 is for a new TOKEN
 	 * msg->tkl == LWM2M_MSG_TOKEN_LEN_SKIP means dont set
 	 */
-	if (msg->tkl == 0U) {
+	if (msg->tkl == LWM2M_MSG_TOKEN_GENERATE_NEW) {
 		tokenlen = 0U;
 		token = coap_next_token();
 	} else if (msg->token && msg->tkl != LWM2M_MSG_TOKEN_LEN_SKIP) {
@@ -949,7 +949,7 @@ int lwm2m_init_message(struct lwm2m_message *msg)
 
 	r = coap_packet_init(&msg->cpkt, msg->msg_data, sizeof(msg->msg_data),
 			     1, msg->type, tokenlen, token, msg->code,
-			     (msg->mid > 0 ? msg->mid : coap_next_id()));
+			     (msg->mid == LWM2M_MSG_ID_GENERATE_NEW ? coap_next_id() : msg->mid));
 	if (r < 0) {
 		LOG_ERR("coap packet init error (err:%d)", r);
 		goto cleanup;
@@ -3973,7 +3973,7 @@ static int generate_notify_message(struct observe_node *obs,
 
 	msg->type = COAP_TYPE_CON;
 	msg->code = COAP_RESPONSE_CODE_CONTENT;
-	msg->mid = 0U;
+	msg->mid = LWM2M_MSG_ID_GENERATE_NEW;
 	msg->token = obs->token;
 	msg->tkl = obs->tkl;
 	msg->reply_cb = notify_message_reply_cb;

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -35,8 +35,14 @@
 #define NOTIFY_OBSERVER(o, i, r)	lwm2m_notify_observer(o, i, r)
 #define NOTIFY_OBSERVER_PATH(path)	lwm2m_notify_observer_path(path)
 
+/* Use this value to generate new token */
+#define LWM2M_MSG_TOKEN_GENERATE_NEW 0U
+
 /* Use this value to skip token generation */
 #define LWM2M_MSG_TOKEN_LEN_SKIP	0xFF
+
+/* Use this value to generate a new message id */
+#define LWM2M_MSG_ID_GENERATE_NEW   0U
 
 /* length of time in milliseconds to wait for buffer allocations */
 #define BUF_ALLOC_TIMEOUT K_SECONDS(1)

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -84,7 +84,7 @@ static int transfer_request(struct coap_block_context *ctx,
 
 	msg->type = COAP_TYPE_CON;
 	msg->code = COAP_METHOD_GET;
-	msg->mid = 0U;
+	msg->mid = LWM2M_MSG_ID_GENERATE_NEW;
 	msg->token = token;
 	msg->tkl = tkl;
 	msg->reply_cb = reply_cb;

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -549,7 +549,7 @@ static int sm_do_bootstrap_reg(void)
 
 	msg->type = COAP_TYPE_CON;
 	msg->code = COAP_METHOD_POST;
-	msg->mid = 0U;
+	msg->mid = LWM2M_MSG_ID_GENERATE_NEW;
 	msg->reply_cb = do_bootstrap_reply_cb;
 	msg->message_timeout_cb = do_bootstrap_reg_timeout_cb;
 
@@ -629,7 +629,7 @@ static int sm_send_registration(bool send_obj_support_data,
 
 	msg->type = COAP_TYPE_CON;
 	msg->code = COAP_METHOD_POST;
-	msg->mid = 0U;
+	msg->mid = LWM2M_MSG_ID_GENERATE_NEW;
 	msg->reply_cb = reply_cb;
 	msg->message_timeout_cb = timeout_cb;
 
@@ -821,7 +821,7 @@ static int sm_do_deregister(void)
 
 	msg->type = COAP_TYPE_CON;
 	msg->code = COAP_METHOD_DELETE;
-	msg->mid = 0U;
+	msg->mid = LWM2M_MSG_ID_GENERATE_NEW;
 	msg->reply_cb = do_deregister_reply_cb;
 	msg->message_timeout_cb = do_deregister_timeout_cb;
 


### PR DESCRIPTION
message id 0 and token 0 have special semantics in the lwm2m engine,
they are used to request generation of new id, mark them as such.