### PR TITLE
net: mqtt: Fix clean_session flag docstring

### DIFF
--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -522,7 +522,7 @@ struct mqtt_client {
 	uint8_t will_retain : 1;
 
 	/** Clean session flag indicating a fresh (1) or a retained session (0).
-	 *  Default is 1.
+	 *  Default is CONFIG_MQTT_CLEAN_SESSION.
 	 */
 	uint8_t clean_session : 1;
 };


### PR DESCRIPTION
The default value of clean_session flag was made configurable in
commit 0fd16f8b7852369f836e39dc85dbd729cd761468 but the docstring was
not updated.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>