### PR TITLE
dts/arm/st: Keep systick disabled by default

### DIFF
--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -378,3 +378,7 @@
 &nvic {
 	arm,num-irq-priority-bits = <4>;
 };
+
+&systick {
+	status = "disabled";
+};

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -364,3 +364,7 @@
 &nvic {
 	arm,num-irq-priority-bits = <4>;
 };
+
+&systick {
+	status = "disabled";
+};


### PR DESCRIPTION
Change #28199 introduced systick configuration from device tree.
For now this should not be used on platforms that support alternate
tick source, as this is the case on l4 and wb series with LPTIM.
Until dts allows to configure lptim from dts, keep systick disabled
by default on these platforms.

Fixes #28280

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>