### PR TITLE
samples: shell: fs: require keyboard harness

### DIFF
--- a/samples/subsys/shell/fs/sample.yaml
+++ b/samples/subsys/shell/fs/sample.yaml
@@ -3,4 +3,6 @@ sample:
   name: FS shell
 tests:
   sample.filesystem.shell:
+    tags: shell filesystem
+    harness: keyboard
     platform_allow: reel_board


### PR DESCRIPTION
The test for this sample requires special setup and keyboard
interactivity.

Fixes #28153