### PR TITLE
Add ISR replace functionality

### DIFF
--- a/include/arch/arc/v2/irq.h
+++ b/include/arch/arc/v2/irq.h
@@ -54,6 +54,11 @@ extern void z_irq_spurious(const void *unused);
 	z_irq_priority_set(irq_p, priority_p, flags_p); \
 }
 
+#define ARCH_IRQ_REPLACE_ISR(irq, new_func) \
+({ \
+	Z_ISR_REPLACE(irq, new_func); \
+})
+
 /**
  * Configure a 'direct' static interrupt.
  *

--- a/include/arch/arm/aarch32/irq.h
+++ b/include/arch/arm/aarch32/irq.h
@@ -111,6 +111,11 @@ extern void z_arm_interrupt_init(void);
 	z_arm_irq_priority_set(irq_p, priority_p, flags_p); \
 }
 
+#define ARCH_IRQ_REPLACE_ISR(irq, new_func) \
+({ \
+	Z_ISR_REPLACE(irq, new_func); \
+})
+
 #define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
 { \
 	Z_ISR_DECLARE(irq_p, ISR_FLAG_DIRECT, isr_p, NULL); \

--- a/include/arch/arm/aarch64/irq.h
+++ b/include/arch/arm/aarch64/irq.h
@@ -88,6 +88,11 @@ extern void z_arm64_interrupt_init(void);
 	z_arm64_irq_priority_set(irq_p, priority_p, flags_p); \
 }
 
+#define ARCH_IRQ_REPLACE_ISR(irq, new_func) \
+({ \
+	Z_ISR_REPLACE(irq, new_func); \
+})
+
 #define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
 { \
 	Z_ISR_DECLARE(irq_p, ISR_FLAG_DIRECT, isr_p, NULL); \

--- a/include/arch/nios2/arch.h
+++ b/include/arch/nios2/arch.h
@@ -44,6 +44,11 @@ extern "C" {
 	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
 }
 
+#define ARCH_IRQ_REPLACE_ISR(irq, new_func) \
+({ \
+	Z_ISR_REPLACE(irq, new_func); \
+})
+
 extern void z_irq_spurious(const void *unused);
 
 static ALWAYS_INLINE unsigned int arch_irq_lock(void)

--- a/include/arch/riscv/arch.h
+++ b/include/arch/riscv/arch.h
@@ -298,6 +298,11 @@ void z_irq_spurious(const void *unused);
 }
 #endif
 
+#define ARCH_IRQ_REPLACE_ISR(irq, new_func) \
+({ \
+	Z_ISR_REPLACE(irq, new_func); \
+})
+
 /*
  * use atomic instruction csrrc to lock global irq
  * csrrc: atomic read and clear bits in CSR register

--- a/include/arch/x86/ia32/arch.h
+++ b/include/arch/x86/ia32/arch.h
@@ -219,6 +219,11 @@ typedef struct s_isrList {
 				   (flags_p)); \
 }
 
+#define ARCH_IRQ_REPLACE_ISR(irq, new_func) \
+({ \
+	Z_ISR_REPLACE(irq, new_func); \
+})
+
 /* Direct interrupts won't work as expected with KPTI turned on, because
  * all non-user accessible pages in the page table are marked non-present.
  * It's likely possible to add logic to ARCH_ISR_DIRECT_HEADER/FOOTER to do

--- a/include/arch/x86/intel64/arch.h
+++ b/include/arch/x86/intel64/arch.h
@@ -138,4 +138,9 @@ struct x86_ssf {
  */
 #define ARCH_DYMANIC_OBJ_K_THREAD_ALIGNMENT	16
 
+#define ARCH_IRQ_REPLACE_ISR(irq, new_func) \
+({ \
+	Z_ISR_REPLACE(irq, new_func); \
+})
+
 #endif /* ZEPHYR_INCLUDE_ARCH_X86_INTEL64_ARCH_H_ */

--- a/include/arch/xtensa/arch.h
+++ b/include/arch/xtensa/arch.h
@@ -51,6 +51,11 @@ extern void z_irq_priority_set(uint32_t irq, uint32_t prio, uint32_t flags);
 	Z_ISR_DECLARE(irq_p, flags_p, isr_p, isr_param_p); \
 }
 
+#define ARCH_IRQ_REPLACE_ISR(irq, new_func) \
+({ \
+	Z_ISR_REPLACE(irq, new_func); \
+})
+
 /* Spurious interrupt handler. Throws an error if called */
 extern void z_irq_spurious(const void *unused);
 

--- a/include/irq.h
+++ b/include/irq.h
@@ -49,6 +49,23 @@ extern "C" {
 	ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p)
 
 /**
+ * @brief Replace default interrupt handler.
+ *
+ * This routine replaces default interrupt handler for an IRQ.
+ *
+ * @warning
+ * This functionalty only replaces ISR function, so to make it work
+ * correctly, the IRQ_CONNECT must be invoked also for target IRQ.
+ *
+ * @param irq_p IRQ line number.
+ * @param new_func_p Address of new interrupt service routine.
+ *
+ * @return New interrupt vector assigned to this interrupt.
+ */
+#define IRQ_REPLACE_ISR(irq_p, new_func_p) \
+	ARCH_IRQ_REPLACE_ISR(irq_p, new_func_p)
+
+/**
  * Configure a dynamic interrupt.
  *
  * Use this instead of IRQ_CONNECT() if arguments cannot be known at build time.

--- a/include/sw_isr_table.h
+++ b/include/sw_isr_table.h
@@ -57,6 +57,7 @@ struct _isr_list {
 
 /** This interrupt gets put directly in the vector table */
 #define ISR_FLAG_DIRECT BIT(0)
+#define ISR_FLAG_REPLACE_ISR BIT(1)
 
 #define _MK_ISR_NAME(x, y) __MK_ISR_NAME(x, y)
 #define __MK_ISR_NAME(x, y) __isr_ ## x ## _irq_ ## y
@@ -69,6 +70,11 @@ struct _isr_list {
 	static Z_DECL_ALIGN(struct _isr_list) Z_GENERIC_SECTION(.intList) \
 		__used _MK_ISR_NAME(func, __COUNTER__) = \
 			{irq, flags, (void *)&func, (const void *)param}
+
+#define Z_ISR_REPLACE(irq, new_func) \
+	static Z_DECL_ALIGN(struct _isr_list) Z_GENERIC_SECTION(.intList) \
+		__used _MK_ISR_NAME(new_func, __COUNTER__) = \
+			{irq, ISR_FLAG_REPLACE_ISR, &new_func, NULL}
 
 #define IRQ_TABLE_SIZE (CONFIG_NUM_IRQS - CONFIG_GEN_IRQ_START_VECTOR)
 

--- a/soc/arm/quicklogic_eos_s3/CMakeLists.txt
+++ b/soc/arm/quicklogic_eos_s3/CMakeLists.txt
@@ -3,4 +3,5 @@
 
 zephyr_sources(
   soc.c
+  irq_handlers.c
   )

--- a/soc/arm/quicklogic_eos_s3/irq_handlers.c
+++ b/soc/arm/quicklogic_eos_s3/irq_handlers.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+#include <arch/cpu.h>
+#include <init.h>
+#include <device.h>
+#include <soc.h>
+
+#ifdef CONFIG_UART_PL011
+extern void pl011_isr(void *arg);
+
+void pl011_isr_wrapper(void *arg)
+{
+	pl011_isr(arg);
+	EOSS3_ClearPendingIRQ(Uart_IRQn);
+}
+#endif
+
+static int register_irq_wrappers(const struct device *arg)
+{
+#ifdef CONFIG_UART_PL011
+#if DT_NUM_IRQS(DT_INST(0, arm_pl011)) == 1
+	IRQ_REPLACE_ISR(DT_IRQN(DT_N_S_soc_S_uart_40010000),
+			pl011_isr_wrapper);
+#else
+#error "EOS-S3 has only 1 UART peripheral and 1 common IRQ"
+#endif
+#endif
+	return 0;
+}
+
+SYS_INIT(register_irq_wrappers, PRE_KERNEL_1, 0);

--- a/soc/arm/quicklogic_eos_s3/soc.h
+++ b/soc/arm/quicklogic_eos_s3/soc.h
@@ -54,4 +54,19 @@ void eos_s3_lock_disable(void);
 
 int eos_s3_io_mux(uint32_t pad_nr, uint32_t pad_cfg);
 
+#undef NVIC_DisableIRQ
+#undef NVIC_EnableIRQ
+#undef NVIC_ClearPendingIRQ
+
+#define WIC_GPIO_IRQ_BASE (5UL)
+#define WIC_OTHER_IRQ_BASE (6UL)
+
+void EOSS3_DisableIRQ(IRQn_Type IRQn);
+void EOSS3_EnableIRQ(IRQn_Type IRQn);
+void EOSS3_ClearPendingIRQ(IRQn_Type IRQn);
+
+#define NVIC_DisableIRQ		EOSS3_DisableIRQ
+#define NVIC_EnableIRQ		EOSS3_EnableIRQ
+#define NVIC_ClearPendingIRQ	EOSS3_ClearPendingIRQ
+
 #endif /* _SOC__H_ */


### PR DESCRIPTION
This PR introduces a new functionality to the IRQ interface called `IRQ_REPLACE_ISR`. The replace feature can be used when there is a need to add additional operations in already existing ISR e.g. due to an additional interrupt controller. The solution assumes that the original ISR is wrapped with another function which can execute custom logic. The replacement procedure: `original ISR -> wrapper function` is done in `gen_isr_tables.py` at the very end of the ISR tables generation process.

This suggestion stems from the fact that we have not seen similar solutions in Zephyr, and we need it to enable the EOS S3 interrupt system to play nicely with existing generic drivers (in this case: PL011 UART).