### PR TITLE
Fix shell fault when too many arguments in the command were provided

### DIFF
--- a/doc/releases/release-notes-2.4.rst
+++ b/doc/releases/release-notes-2.4.rst
@@ -508,6 +508,12 @@ Libraries / Subsystems
 * Tracing:
   * Tracing backed API now checks if init function exists prio to calling it.
 
+* Shell:
+  * Change behavior when more than ``CONFIG_SHELL_ARGC_MAX`` arguments
+  are passed.  Before 2.3 extra arguments were joined to the last  argument.
+  In 2.3 extra arguments caused a fault.  Now the shell will report that the
+  command cannot be processed.
+
 HALs
 ****
 

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -62,8 +62,6 @@ config SHELL_ARGC_MAX
 	default 12
 	help
 	  Maximum number of arguments that can build a command.
-	  If command is composed of more than defined, argument SHELL_ARGC_MAX
-	  and following are passed as one argument in the string.
 
 config SHELL_WILDCARD
 	bool "Enable wildcard support in shell"

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -194,8 +194,6 @@ char shell_make_argv(size_t *argc, const char **argv, char *cmd, uint8_t max_arg
 		quote = make_argv(&cmd, c);
 	} while (true);
 
-	argv[*argc] = 0;
-
 	return quote;
 }
 

--- a/tests/shell/src/main.c
+++ b/tests/shell/src/main.c
@@ -370,6 +370,23 @@ static void test_raw_arg(void)
 	test_shell_execute_cmd("test_cmd_raw_arg", 0);
 	test_shell_execute_cmd("select test_cmd_raw_arg", 0);
 	test_shell_execute_cmd("aaa \"\" bbb", 0);
+	shell_set_root_cmd(NULL);
+}
+
+static int cmd_dummy(const struct shell *shell, size_t argc, char **argv)
+{
+	return 0;
+}
+
+SHELL_CMD_REGISTER(dummy, NULL, NULL, cmd_dummy);
+
+static void test_max_argc(void)
+{
+	BUILD_ASSERT(CONFIG_SHELL_ARGC_MAX == 12,
+		     "Unexpected test configuration.");
+
+	test_shell_execute_cmd("dummy 1 2 3 4 5 6 7 8 9 10 11", 0);
+	test_shell_execute_cmd("dummy 1 2 3 4 5 6 7 8 9 10 11 12", -ENOEXEC);
 }
 
 void test_main(void)
@@ -386,7 +403,8 @@ void test_main(void)
 			ztest_unit_test(test_shell_wildcards_dynamic),
 			ztest_unit_test(test_shell_fprintf),
 			ztest_unit_test(test_set_root_cmd),
-			ztest_unit_test(test_raw_arg)
+			ztest_unit_test(test_raw_arg),
+			ztest_unit_test(test_max_argc)
 			);
 
 	/* Let the shell backend initialize. */


### PR DESCRIPTION
Added fix and test case.

Fixes #28108.