### PR TITLE
Bluetooth: Mesh: Check Fred_cred when Model Publish Set

### DIFF
--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -1040,6 +1040,11 @@ static void mod_pub_set(struct bt_mesh_model *model,
 		goto send_status;
 	}
 
+	if (!IS_ENABLED(CONFIG_BT_MESH_LOW_POWER) && cred_flag) {
+		status = STATUS_FEAT_NOT_SUPP;
+		goto send_status;
+	}
+
 	status = _mod_pub_set(mod, pub_addr, pub_app_idx, cred_flag, pub_ttl,
 			      pub_period, retransmit, true);
 
@@ -1226,6 +1231,11 @@ static void mod_pub_va_set(struct bt_mesh_model *model,
 	if (!mod) {
 		pub_addr = 0U;
 		status = STATUS_INVALID_MODEL;
+		goto send_status;
+	}
+
+	if (!IS_ENABLED(CONFIG_BT_MESH_LOW_POWER) && cred_flag) {
+		status = STATUS_FEAT_NOT_SUPP;
 		goto send_status;
 	}
 


### PR DESCRIPTION
The CredentialFlag cannot be set to 1 since the node
does not support low power feature as defined by
spec 4.4.1.2.7 Model Publication state.

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>