### PR TITLE
tests: arch: arm: improve filtering to fix several issues with platforms that shall not run these tests

### DIFF
--- a/tests/arch/arm/arm_interrupt/testcase.yaml
+++ b/tests/arch/arm/arm_interrupt/testcase.yaml
@@ -4,11 +4,14 @@ common:
   arch_allow: arm
 tests:
   arch.interrupt.arm:
+    filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
   arch.interrupt.no_optimizations:
+    filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
     extra_configs:
       - CONFIG_NO_OPTIMIZATIONS=y
       - CONFIG_IDLE_STACK_SIZE=512
       - CONFIG_MAIN_STACK_SIZE=1024
   arch.interrupt.extra_exception_info:
+    filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
     extra_configs:
       - CONFIG_EXTRA_EXCEPTION_INFO=y

--- a/tests/arch/arm/arm_interrupt/testcase.yaml
+++ b/tests/arch/arm/arm_interrupt/testcase.yaml
@@ -1,19 +1,14 @@
+common:
+  filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
+  tags: arm interrupt ignore_faults
+  arch_allow: arm
 tests:
   arch.interrupt.arm:
-    filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
-    tags: arm interrupt ignore_faults
-    arch_allow: arm
   arch.interrupt.no_optimizations:
-    filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
-    tags: arm interrupt ignore_faults
-    arch_allow: arm
     extra_configs:
       - CONFIG_NO_OPTIMIZATIONS=y
       - CONFIG_IDLE_STACK_SIZE=512
       - CONFIG_MAIN_STACK_SIZE=1024
   arch.interrupt.extra_exception_info:
-    filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
-    tags: arm interrupt ignore_faults
-    arch_allow: arm
     extra_configs:
       - CONFIG_EXTRA_EXCEPTION_INFO=y

--- a/tests/arch/arm/arm_irq_advanced_features/testcase.yaml
+++ b/tests/arch/arm/arm_irq_advanced_features/testcase.yaml
@@ -1,9 +1,8 @@
+common:
+  filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
+  tags: arm interrupt
+  arch_allow: arm
 tests:
   arch.arm.irq_advanced_features:
-    filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
-    tags: arm interrupt
-    arch_allow: arm
   arch.arm.irq_advanced_features.secure_fw:
     filter: CONFIG_TRUSTED_EXECUTION_SECURE
-    tags: arm interrupt
-    arch_allow: arm

--- a/tests/arch/arm/arm_irq_advanced_features/testcase.yaml
+++ b/tests/arch/arm/arm_irq_advanced_features/testcase.yaml
@@ -4,5 +4,6 @@ common:
   arch_allow: arm
 tests:
   arch.arm.irq_advanced_features:
+    filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
   arch.arm.irq_advanced_features.secure_fw:
     filter: CONFIG_TRUSTED_EXECUTION_SECURE

--- a/tests/arch/arm/arm_irq_vector_table/testcase.yaml
+++ b/tests/arch/arm/arm_irq_vector_table/testcase.yaml
@@ -1,5 +1,6 @@
+common:
+  filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
+  tags: arm interrupt vector_table
+  arch_allow: arm
 tests:
   arch.interrupt.arm.irq_vector_table:
-    filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
-    tags: arm interrupt vector_table
-    arch_allow: arm

--- a/tests/arch/arm/arm_irq_vector_table/testcase.yaml
+++ b/tests/arch/arm/arm_irq_vector_table/testcase.yaml
@@ -4,3 +4,4 @@ common:
   arch_allow: arm
 tests:
   arch.interrupt.arm.irq_vector_table:
+    filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE

--- a/tests/arch/arm/arm_no_multithreading/testcase.yaml
+++ b/tests/arch/arm/arm_no_multithreading/testcase.yaml
@@ -1,6 +1,7 @@
+common:
+  filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
+  tags: arm
+  arch_allow: arm
 tests:
   arch.arm.no_multithreading:
-    filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
-    tags: arm
-    arch_allow: arm
     platform_exclude: degu_evk

--- a/tests/arch/arm/arm_no_multithreading/testcase.yaml
+++ b/tests/arch/arm/arm_no_multithreading/testcase.yaml
@@ -4,4 +4,5 @@ common:
   arch_allow: arm
 tests:
   arch.arm.no_multithreading:
+    filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
     platform_exclude: degu_evk

--- a/tests/arch/arm/arm_thread_swap/testcase.yaml
+++ b/tests/arch/arm/arm_thread_swap/testcase.yaml
@@ -4,18 +4,20 @@ common:
   arch_allow: arm
 tests:
   arch.arm.swap.common:
+    filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
   arch.arm.swap.common.no_optimizations:
+    filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
     extra_configs:
       - CONFIG_NO_OPTIMIZATIONS=y
       - CONFIG_IDLE_STACK_SIZE=512
     min_flash: 192
   arch.arm.swap.common.fpu_sharing:
-    filter: CONFIG_ARMV7_M_ARMV8_M_FP
+    filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE and CONFIG_ARMV7_M_ARMV8_M_FP
     extra_configs:
       - CONFIG_FPU=y
       - CONFIG_FPU_SHARING=y
   arch.arm.swap.common.fpu_sharing.no_optimizations:
-    filter: CONFIG_ARMV7_M_ARMV8_M_FP
+    filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE and CONFIG_ARMV7_M_ARMV8_M_FP
     extra_configs:
       - CONFIG_FPU=y
       - CONFIG_FPU_SHARING=y

--- a/tests/arch/arm/arm_thread_swap/testcase.yaml
+++ b/tests/arch/arm/arm_thread_swap/testcase.yaml
@@ -1,30 +1,24 @@
+common:
+  filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
+  tags: arm
+  arch_allow: arm
 tests:
   arch.arm.swap.common:
-    arch_allow: arm
-    filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
-    tags: arm
   arch.arm.swap.common.no_optimizations:
-    arch_allow: arm
-    filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
     extra_configs:
       - CONFIG_NO_OPTIMIZATIONS=y
       - CONFIG_IDLE_STACK_SIZE=512
-    tags: arm
     min_flash: 192
   arch.arm.swap.common.fpu_sharing:
-    arch_allow: arm
     filter: CONFIG_ARMV7_M_ARMV8_M_FP
     extra_configs:
       - CONFIG_FPU=y
       - CONFIG_FPU_SHARING=y
-    tags: arm
   arch.arm.swap.common.fpu_sharing.no_optimizations:
-    arch_allow: arm
     filter: CONFIG_ARMV7_M_ARMV8_M_FP
     extra_configs:
       - CONFIG_FPU=y
       - CONFIG_FPU_SHARING=y
       - CONFIG_NO_OPTIMIZATIONS=y
       - CONFIG_IDLE_STACK_SIZE=512
-    tags: arm
     min_flash: 192


### PR DESCRIPTION
- Do some cleaning in the .yml files for tests/arch/arm
- Do not attempt to run or build the tests for strictly non-secure platform configurations.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/28294