### PR TITLE
samples: net: sockets: Fix for multicast handling

### DIFF
--- a/samples/net/sockets/coap_server/src/coap-server.c
+++ b/samples/net/sockets/coap_server/src/coap-server.c
@@ -20,6 +20,9 @@ LOG_MODULE_REGISTER(net_coap_server_sample, LOG_LEVEL_DBG);
 #include <net/coap_link_format.h>
 
 #include "net_private.h"
+#if defined(CONFIG_NET_IPV6)
+#include "ipv6.h"
+#endif
 
 #define MAX_COAP_MSG_LEN 256
 
@@ -64,9 +67,9 @@ static bool join_coap_multicast_group(void)
 		.sin6_family = AF_INET6,
 		.sin6_addr = ALL_NODES_LOCAL_COAP_MCAST,
 		.sin6_port = htons(MY_COAP_PORT) };
-	struct net_if_mcast_addr *mcast;
 	struct net_if_addr *ifaddr;
 	struct net_if *iface;
+	int ret;
 
 	iface = net_if_get_default();
 	if (!iface) {
@@ -91,9 +94,10 @@ static bool join_coap_multicast_group(void)
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
 
-	mcast = net_if_ipv6_maddr_add(iface, &mcast_addr.sin6_addr);
-	if (!mcast) {
-		LOG_ERR("Could not add multicast address to interface\n");
+	ret = net_ipv6_mld_join(iface, &mcast_addr.sin6_addr);
+	if (ret < 0) {
+		LOG_ERR("Cannot join %s IPv6 multicast group (%d)",
+			log_strdup(net_sprint_ipv6_addr(&mcast_addr.sin6_addr)), ret);
 		return false;
 	}
 


### PR DESCRIPTION
This topic was discussed in previous PR https://github.com/zephyrproject-rtos/zephyr/pull/28235
After adding Multicast group filtering (commit b7b73d0) server should execute
net_ipv6_mld_join() to accept multicast CoAP messages.

Signed-off-by: Eug Krashtan <eug.krashtan@gmail.com>