### PR TITLE
arch: arm: aarch64: remove non-applicable linker section

### DIFF
--- a/include/arch/arm/aarch64/scripts/linker.ld
+++ b/include/arch/arm/aarch64/scripts/linker.ld
@@ -311,29 +311,6 @@ SECTIONS
 
     /DISCARD/ : { *(.note.GNU-stack) }
 
-#if defined(CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS)
-
-#if CONFIG_ARM_NSC_REGION_BASE_ADDRESS != 0
-    #define NSC_ALIGN . = ABSOLUTE(CONFIG_ARM_NSC_REGION_BASE_ADDRESS)
-#else
-    #define NSC_ALIGN . = ALIGN(4)
-#endif
-
-    #define NSC_ALIGN_END . = ALIGN(4)
-
-    SECTION_PROLOGUE(.gnu.sgstubs,,)
-    {
-        NSC_ALIGN;
-        __sg_start = .;
-        /* No input section necessary, since the Secure Entry Veneers are
-           automatically placed after the .gnu.sgstubs output section. */
-    } GROUP_LINK_IN(ROMABLE_REGION)
-    __sg_end = .;
-    __sg_size = __sg_end - __sg_start;
-    NSC_ALIGN_END;
-    __nsc_size = . - __sg_start;
-
-#endif /* CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS */
 
     /* Must be last in romable region */
     SECTION_PROLOGUE(.last_section,(NOLOAD),)


### PR DESCRIPTION
The non-secure callable functions' section is only applicable
to Cortex-M with TrustZone-M extension. Remove it from AARC64
linker script. (CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCTIONS
is only enabled for Cortex-M so this is a no-op, but still, it
is a useful cleanup.)

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>