### PR TITLE
Update Breathe and use new options to improve documentation 

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -520,6 +520,7 @@ breathe_domain_by_extension = {
     "h": "c",
     "c": "c",
 }
+breathe_separate_member_pages = True
 
 # Qualifiers to a function are causing Sphihx/Breathe to warn about
 # Error when parsing function declaration and more.  This is a list

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -223,6 +223,7 @@ TAB_SIZE               = 8
 ALIASES                = "rst=\verbatim embed:rst:leading-asterisk" \
                          "endrst=\endverbatim"
 
+ALIASES += option{1}="\verbatim embed:rst:inline :option:`\1` \endverbatim"
 ALIASES += req{1}="\ref ZEPH_\1 \"ZEPH-\1\" "
 ALIASES += satisfy{1}="\xrefitem satisfy \"Satisfies requirement\" \"Requirement Implementation\" \1"
 ALIASES += verify{1}="\xrefitem verify \"Verifies requirement\" \"Requirement Verification\" \1"

--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -37,11 +37,12 @@ extern "C" {
  * @{
  */
 
-/** @def BT_ID_DEFAULT
+/**
+ * @def BT_ID_DEFAULT
  *
- *  Convenience macro for specifying the default identity. This helps
- *  make the code more readable, especially when only one identity is
- *  supported.
+ * Convenience macro for specifying the default identity. This helps
+ * make the code more readable, especially when only one identity is
+ * supported.
  */
 #define BT_ID_DEFAULT 0
 
@@ -70,206 +71,219 @@ struct bt_le_ext_adv_scanned_info {
 };
 
 struct bt_le_ext_adv_cb {
-	/** @brief The advertising set has finished sending adv data.
+	/**
+	 * @brief The advertising set has finished sending adv data.
 	 *
-	 *  This callback notifies the application that the advertising set has
-	 *  finished sending advertising data.
-	 *  The advertising set can either have been stopped by a timeout or
-	 *  because the specified number of advertising events has been reached.
+	 * This callback notifies the application that the advertising set has
+	 * finished sending advertising data.
+	 * The advertising set can either have been stopped by a timeout or
+	 * because the specified number of advertising events has been reached.
 	 *
-	 *  @param adv  The advertising set object.
-	 *  @param info Information about the sent event.
+	 * @param adv  The advertising set object.
+	 * @param info Information about the sent event.
 	 */
 	void (*sent)(struct bt_le_ext_adv *adv,
 		     struct bt_le_ext_adv_sent_info *info);
 
-	/** @brief The advertising set has accepted a new connection.
+	/**
+	 * @brief The advertising set has accepted a new connection.
 	 *
-	 *  This callback notifies the application that the advertising set has
-	 *  accepted a new connection.
+	 * This callback notifies the application that the advertising set has
+	 * accepted a new connection.
 	 *
-	 *  @param adv  The advertising set object.
-	 *  @param info Information about the connected event.
+	 * @param adv  The advertising set object.
+	 * @param info Information about the connected event.
 	 */
 	void (*connected)(struct bt_le_ext_adv *adv,
 			  struct bt_le_ext_adv_connected_info *info);
 
-	/** @brief The advertising set has sent scan response data.
+	/**
+	 * @brief The advertising set has sent scan response data.
 	 *
-	 *  This callback notifies the application that the advertising set has
-	 *  has received a Scan Request packet, and has sent a Scan Response
-	 *  packet.
+	 * This callback notifies the application that the advertising set has
+	 * has received a Scan Request packet, and has sent a Scan Response
+	 * packet.
 	 *
-	 *  @param adv  The advertising set object.
-	 *  @param addr Information about the scanned event.
+	 * @param adv  The advertising set object.
+	 * @param addr Information about the scanned event.
 	 */
 	void (*scanned)(struct bt_le_ext_adv *adv,
 			struct bt_le_ext_adv_scanned_info *info);
 };
 
-/** @typedef bt_ready_cb_t
- *  @brief Callback for notifying that Bluetooth has been enabled.
+/**
+ * @typedef bt_ready_cb_t
+ * @brief Callback for notifying that Bluetooth has been enabled.
  *
- *  @param err zero on success or (negative) error code otherwise.
+ * @param err zero on success or (negative) error code otherwise.
  */
 typedef void (*bt_ready_cb_t)(int err);
 
-/** @brief Enable Bluetooth
+/**
+ * @brief Enable Bluetooth
  *
- *  Enable Bluetooth. Must be the called before any calls that
- *  require communication with the local Bluetooth hardware.
+ * Enable Bluetooth. Must be the called before any calls that
+ * require communication with the local Bluetooth hardware.
  *
- *  @param cb Callback to notify completion or NULL to perform the
- *  enabling synchronously.
+ * @param cb Callback to notify completion or NULL to perform the
+ * enabling synchronously.
  *
- *  @return Zero on success or (negative) error code otherwise.
+ * @return Zero on success or (negative) error code otherwise.
  */
 int bt_enable(bt_ready_cb_t cb);
 
-/** @brief Set Bluetooth Device Name
+/**
+ * @brief Set Bluetooth Device Name
  *
- *  Set Bluetooth GAP Device Name.
+ * Set Bluetooth GAP Device Name.
  *
- *  @param name New name
+ * @param name New name
  *
- *  @return Zero on success or (negative) error code otherwise.
+ * @return Zero on success or (negative) error code otherwise.
  */
 int bt_set_name(const char *name);
 
-/** @brief Get Bluetooth Device Name
+/**
+ * @brief Get Bluetooth Device Name
  *
- *  Get Bluetooth GAP Device Name.
+ * Get Bluetooth GAP Device Name.
  *
- *  @return Bluetooth Device Name
+ * @return Bluetooth Device Name
  */
 const char *bt_get_name(void);
 
-/** @brief Set the local Identity Address
+/**
+ * @brief Set the local Identity Address
  *
- *  Allows setting the local Identity Address from the application.
- *  This API must be called before calling bt_enable(). Calling it at any
- *  other time will cause it to fail. In most cases the application doesn't
- *  need to use this API, however there are a few valid cases where
- *  it can be useful (such as for testing).
+ * Allows setting the local Identity Address from the application.
+ * This API must be called before calling bt_enable(). Calling it at any
+ * other time will cause it to fail. In most cases the application doesn't
+ * need to use this API, however there are a few valid cases where
+ * it can be useful (such as for testing).
  *
- *  At the moment, the given address must be a static random address. In the
- *  future support for public addresses may be added.
+ * At the moment, the given address must be a static random address. In the
+ * future support for public addresses may be added.
  *
- *  @return Zero on success or (negative) error code otherwise.
+ * @return Zero on success or (negative) error code otherwise.
  */
 int bt_set_id_addr(const bt_addr_le_t *addr);
 
-/** @brief Get the currently configured identities.
+/**
+ * @brief Get the currently configured identities.
  *
- *  Returns an array of the currently configured identity addresses. To
- *  make sure all available identities can be retrieved, the number of
- *  elements in the @a addrs array should be CONFIG_BT_ID_MAX. The identity
- *  identifier that some APIs expect (such as advertising parameters) is
- *  simply the index of the identity in the @a addrs array.
+ * Returns an array of the currently configured identity addresses. To
+ * make sure all available identities can be retrieved, the number of
+ * elements in the @a addrs array should be CONFIG_BT_ID_MAX. The identity
+ * identifier that some APIs expect (such as advertising parameters) is
+ * simply the index of the identity in the @a addrs array.
  *
- *  @note Deleted identities may show up as BT_LE_ADDR_ANY in the returned
- *  array.
+ * @note Deleted identities may show up as BT_LE_ADDR_ANY in the returned
+ * array.
  *
- *  @param addrs Array where to store the configured identities.
- *  @param count Should be initialized to the array size. Once the function
- *               returns it will contain the number of returned identities.
+ * @param addrs Array where to store the configured identities.
+ * @param count Should be initialized to the array size. Once the function
+ *              returns it will contain the number of returned identities.
  */
 void bt_id_get(bt_addr_le_t *addrs, size_t *count);
 
-/** @brief Create a new identity.
+/**
+ * @brief Create a new identity.
  *
- *  Create a new identity using the given address and IRK. This function
- *  can be called before calling bt_enable(), in which case it can be used
- *  to override the controller's public address (in case it has one). However,
- *  the new identity will only be stored persistently in flash when this API
- *  is used after bt_enable(). The reason is that the persistent settings
- *  are loaded after bt_enable() and would therefore cause potential conflicts
- *  with the stack blindly overwriting what's stored in flash. The identity
- *  will also not be written to flash in case a pre-defined address is
- *  provided, since in such a situation the app clearly has some place it got
- *  the address from and will be able to repeat the procedure on every power
- *  cycle, i.e. it would be redundant to also store the information in flash.
+ * Create a new identity using the given address and IRK. This function
+ * can be called before calling bt_enable(), in which case it can be used
+ * to override the controller's public address (in case it has one). However,
+ * the new identity will only be stored persistently in flash when this API
+ * is used after bt_enable(). The reason is that the persistent settings
+ * are loaded after bt_enable() and would therefore cause potential conflicts
+ * with the stack blindly overwriting what's stored in flash. The identity
+ * will also not be written to flash in case a pre-defined address is
+ * provided, since in such a situation the app clearly has some place it got
+ * the address from and will be able to repeat the procedure on every power
+ * cycle, i.e. it would be redundant to also store the information in flash.
  *
- *  If the application wants to have the stack randomly generate identities
- *  and store them in flash for later recovery, the way to do it would be
- *  to first initialize the stack (using bt_enable), then call settings_load(),
- *  and after that check with bt_id_get() how many identities were recovered.
- *  If an insufficient amount of identities were recovered the app may then
- *  call bt_id_create() to create new ones.
+ * If the application wants to have the stack randomly generate identities
+ * and store them in flash for later recovery, the way to do it would be
+ * to first initialize the stack (using bt_enable), then call settings_load(),
+ * and after that check with bt_id_get() how many identities were recovered.
+ * If an insufficient amount of identities were recovered the app may then
+ * call bt_id_create() to create new ones.
  *
- *  @param addr Address to use for the new identity. If NULL or initialized
- *              to BT_ADDR_LE_ANY the stack will generate a new static
- *              random address for the identity and copy it to the given
- *              parameter upon return from this function (in case the
- *              parameter was non-NULL).
- *  @param irk  Identity Resolving Key (16 bytes) to be used with this
- *              identity. If set to all zeroes or NULL, the stack will
- *              generate a random IRK for the identity and copy it back
- *              to the parameter upon return from this function (in case
- *              the parameter was non-NULL). If privacy
- *              :option:`CONFIG_BT_PRIVACY` is not enabled this parameter must
- *              be NULL.
+ * @param addr Address to use for the new identity. If NULL or initialized
+ *             to BT_ADDR_LE_ANY the stack will generate a new static
+ *             random address for the identity and copy it to the given
+ *             parameter upon return from this function (in case the
+ *             parameter was non-NULL).
+ * @param irk  Identity Resolving Key (16 bytes) to be used with this
+ *             identity. If set to all zeroes or NULL, the stack will
+ *             generate a random IRK for the identity and copy it back
+ *             to the parameter upon return from this function (in case
+ *             the parameter was non-NULL). If privacy
+ *             @option{CONFIG_BT_PRIVACY} is not enabled this parameter must
+ *             be NULL.
  *
- *  @return Identity identifier (>= 0) in case of success, or a negative
- *          error code on failure.
+ * @return Identity identifier (>= 0) in case of success, or a negative
+ *         error code on failure.
  */
 int bt_id_create(bt_addr_le_t *addr, uint8_t *irk);
 
-/** @brief Reset/reclaim an identity for reuse.
+/**
+ * @brief Reset/reclaim an identity for reuse.
  *
- *  The semantics of the @a addr and @a irk parameters of this function
- *  are the same as with bt_id_create(). The difference is the first
- *  @a id parameter that needs to be an existing identity (if it doesn't
- *  exist this function will return an error). When given an existing
- *  identity this function will disconnect any connections created using it,
- *  remove any pairing keys or other data associated with it, and then create
- *  a new identity in the same slot, based on the @a addr and @a irk
- *  parameters.
+ * The semantics of the @a addr and @a irk parameters of this function
+ * are the same as with bt_id_create(). The difference is the first
+ * @a id parameter that needs to be an existing identity (if it doesn't
+ * exist this function will return an error). When given an existing
+ * identity this function will disconnect any connections created using it,
+ * remove any pairing keys or other data associated with it, and then create
+ * a new identity in the same slot, based on the @a addr and @a irk
+ * parameters.
  *
- *  @note the default identity (BT_ID_DEFAULT) cannot be reset, i.e. this
- *  API will return an error if asked to do that.
+ * @note the default identity (BT_ID_DEFAULT) cannot be reset, i.e. this
+ * API will return an error if asked to do that.
  *
- *  @param id   Existing identity identifier.
- *  @param addr Address to use for the new identity. If NULL or initialized
- *              to BT_ADDR_LE_ANY the stack will generate a new static
- *              random address for the identity and copy it to the given
- *              parameter upon return from this function (in case the
- *              parameter was non-NULL).
- *  @param irk  Identity Resolving Key (16 bytes) to be used with this
- *              identity. If set to all zeroes or NULL, the stack will
- *              generate a random IRK for the identity and copy it back
- *              to the parameter upon return from this function (in case
- *              the parameter was non-NULL). If privacy
- *              :option:`CONFIG_BT_PRIVACY` is not enabled this parameter must
- *              be NULL.
+ * @param id   Existing identity identifier.
+ * @param addr Address to use for the new identity. If NULL or initialized
+ *             to BT_ADDR_LE_ANY the stack will generate a new static
+ *             random address for the identity and copy it to the given
+ *             parameter upon return from this function (in case the
+ *             parameter was non-NULL).
+ * @param irk  Identity Resolving Key (16 bytes) to be used with this
+ *             identity. If set to all zeroes or NULL, the stack will
+ *             generate a random IRK for the identity and copy it back
+ *             to the parameter upon return from this function (in case
+ *             the parameter was non-NULL). If privacy
+ *             @option{CONFIG_BT_PRIVACY} is not enabled this parameter must
+ *             be NULL.
  *
- *  @return Identity identifier (>= 0) in case of success, or a negative
- *          error code on failure.
+ * @return Identity identifier (>= 0) in case of success, or a negative
+ *         error code on failure.
  */
 int bt_id_reset(uint8_t id, bt_addr_le_t *addr, uint8_t *irk);
 
-/** @brief Delete an identity.
+/**
+ * @brief Delete an identity.
  *
- *  When given a valid identity this function will disconnect any connections
- *  created using it, remove any pairing keys or other data associated with
- *  it, and then flag is as deleted, so that it can not be used for any
- *  operations. To take back into use the slot the identity was occupying the
- *  bt_id_reset() API needs to be used.
+ * When given a valid identity this function will disconnect any connections
+ * created using it, remove any pairing keys or other data associated with
+ * it, and then flag is as deleted, so that it can not be used for any
+ * operations. To take back into use the slot the identity was occupying the
+ * bt_id_reset() API needs to be used.
  *
- *  @note the default identity (BT_ID_DEFAULT) cannot be deleted, i.e. this
- *  API will return an error if asked to do that.
+ * @note the default identity (BT_ID_DEFAULT) cannot be deleted, i.e. this
+ * API will return an error if asked to do that.
  *
- *  @param id   Existing identity identifier.
+ * @param id   Existing identity identifier.
  *
- *  @return 0 in case of success, or a negative error code on failure.
+ * @return 0 in case of success, or a negative error code on failure.
  */
 int bt_id_delete(uint8_t id);
 
-/** @brief Bluetooth data.
+/**
+ * @brief Bluetooth data.
  *
- *  Description of different data types that can be encoded into
- *  advertising data. Used to form arrays that are passed to the
- *  bt_le_adv_start() function.
+ * Description of different data types that can be encoded into
+ * advertising data. Used to form arrays that are passed to the
+ * bt_le_adv_start() function.
  */
 struct bt_data {
 	uint8_t type;
@@ -277,14 +291,15 @@ struct bt_data {
 	const uint8_t *data;
 };
 
-/** @brief Helper to declare elements of bt_data arrays
+/**
+ * @brief Helper to declare elements of bt_data arrays
  *
- *  This macro is mainly for creating an array of struct bt_data
- *  elements which is then passed to e.g. @ref bt_le_adv_start().
+ * This macro is mainly for creating an array of struct bt_data
+ * elements which is then passed to e.g. @ref bt_le_adv_start().
  *
- *  @param _type Type of advertising data field
- *  @param _data Pointer to the data field payload
- *  @param _data_len Number of bytes behind the _data pointer
+ * @param _type Type of advertising data field
+ * @param _data Pointer to the data field payload
+ * @param _data_len Number of bytes behind the _data pointer
  */
 #define BT_DATA(_type, _data, _data_len) \
 	{ \
@@ -293,13 +308,14 @@ struct bt_data {
 		.data = (const uint8_t *)(_data), \
 	}
 
-/** @brief Helper to declare elements of bt_data arrays
+/**
+ * @brief Helper to declare elements of bt_data arrays
  *
- *  This macro is mainly for creating an array of struct bt_data
- *  elements which is then passed to e.g. @ref bt_le_adv_start().
+ * This macro is mainly for creating an array of struct bt_data
+ * elements which is then passed to e.g. @ref bt_le_adv_start().
  *
- *  @param _type Type of advertising data field
- *  @param _bytes Variable number of single-byte parameters
+ * @param _type Type of advertising data field
+ * @param _bytes Variable number of single-byte parameters
  */
 #define BT_DATA_BYTES(_type, _bytes...) \
 	BT_DATA(_type, ((uint8_t []) { _bytes }), \
@@ -310,62 +326,67 @@ enum {
 	/** Convenience value when no options are specified. */
 	BT_LE_ADV_OPT_NONE = 0,
 
-	/** @brief Advertise as connectable.
+	/**
+	 * @brief Advertise as connectable.
 	 *
-	 *  Advertise as connectable. If not connectable then the type of
-	 *  advertising is determined by providing scan response data.
-	 *  The advertiser address is determined by the type of advertising
-	 *  and/or enabling privacy :option:`CONFIG_BT_PRIVACY`.
+	 * Advertise as connectable. If not connectable then the type of
+	 * advertising is determined by providing scan response data.
+	 * The advertiser address is determined by the type of advertising
+	 * and/or enabling privacy @option{CONFIG_BT_PRIVACY}.
 	 */
 	BT_LE_ADV_OPT_CONNECTABLE = BIT(0),
 
-	/** @brief Advertise one time.
+	/**
+	 * @brief Advertise one time.
 	 *
-	 *  Don't try to resume connectable advertising after a connection.
-	 *  This option is only meaningful when used together with
-	 *  BT_LE_ADV_OPT_CONNECTABLE. If set the advertising will be stopped
-	 *  when bt_le_adv_stop() is called or when an incoming (slave)
-	 *  connection happens. If this option is not set the stack will
-	 *  take care of keeping advertising enabled even as connections
-	 *  occur.
-	 *  If Advertising directed or the advertiser was started with
-	 *  @ref bt_le_ext_adv_start then this behavior is the default behavior
-	 *  and this flag has no effect.
+	 * Don't try to resume connectable advertising after a connection.
+	 * This option is only meaningful when used together with
+	 * BT_LE_ADV_OPT_CONNECTABLE. If set the advertising will be stopped
+	 * when bt_le_adv_stop() is called or when an incoming (slave)
+	 * connection happens. If this option is not set the stack will
+	 * take care of keeping advertising enabled even as connections
+	 * occur.
+	 * If Advertising directed or the advertiser was started with
+	 * @ref bt_le_ext_adv_start then this behavior is the default behavior
+	 * and this flag has no effect.
 	 */
 	BT_LE_ADV_OPT_ONE_TIME = BIT(1),
 
-	/** @brief Advertise using identity address.
+	/**
+	 * @brief Advertise using identity address.
 	 *
-	 *  Advertise using the identity address as the advertiser address.
-	 *  @warning This will compromise the privacy of the device, so care
-	 *           must be taken when using this option.
-	 *  @note The address used for advertising will not be the same as
-	 *         returned by @ref bt_le_oob_get_local, instead @ref bt_id_get
-	 *         should be used to get the LE address.
+	 * Advertise using the identity address as the advertiser address.
+	 * @warning This will compromise the privacy of the device, so care
+	 *          must be taken when using this option.
+	 * @note The address used for advertising will not be the same as
+	 *        returned by @ref bt_le_oob_get_local, instead @ref bt_id_get
+	 *        should be used to get the LE address.
 	 */
 	BT_LE_ADV_OPT_USE_IDENTITY = BIT(2),
 
 	/** Advertise using GAP device name */
 	BT_LE_ADV_OPT_USE_NAME = BIT(3),
 
-	/** @brief Low duty cycle directed advertising.
+	/**
+	 * @brief Low duty cycle directed advertising.
 	 *
-	 *  Use low duty directed advertising mode, otherwise high duty mode
-	 *  will be used.
+	 * Use low duty directed advertising mode, otherwise high duty mode
+	 * will be used.
 	 */
 	BT_LE_ADV_OPT_DIR_MODE_LOW_DUTY = BIT(4),
 
-	/** @brief Directed advertising to privacy-enabled peer.
+	/**
+	 * @brief Directed advertising to privacy-enabled peer.
 	 *
-	 *  Enable use of Resolvable Private Address (RPA) as the target address
-	 *  in directed advertisements when :option:`CONFIG_BT_PRIVACY` is not
-	 *  enabled.
-	 *  This is required if the remote device is privacy-enabled and
-	 *  supports address resolution of the target address in directed
-	 *  advertisement.
-	 *  It is the responsibility of the application to check that the remote
-	 *  device supports address resolution of directed advertisements by
-	 *  reading its Central Address Resolution characteristic.
+	 * Enable use of Resolvable Private Address (RPA) as the target address
+	 * in directed advertisements when @option{CONFIG_BT_PRIVACY} is not
+	 * enabled.
+	 * This is required if the remote device is privacy-enabled and
+	 * supports address resolution of the target address in directed
+	 * advertisement.
+	 * It is the responsibility of the application to check that the remote
+	 * device supports address resolution of directed advertisements by
+	 * reading its Central Address Resolution characteristic.
 	 */
 	BT_LE_ADV_OPT_DIR_ADDR_RPA = BIT(5),
 
@@ -381,100 +402,109 @@ enum {
 	 */
 	BT_LE_ADV_OPT_NOTIFY_SCAN_REQ = BIT(8),
 
-	/** @brief Support scan response data.
+	/**
+	 * @brief Support scan response data.
 	 *
-	 *  When used together with @ref BT_LE_ADV_OPT_EXT_ADV then this option
-	 *  cannot be used together with the @ref BT_LE_ADV_OPT_CONNECTABLE
-	 *  option.
-	 *  When used together with @ref BT_LE_ADV_OPT_EXT_ADV then scan
-	 *  response data must be set.
+	 * When used together with @ref BT_LE_ADV_OPT_EXT_ADV then this option
+	 * cannot be used together with the @ref BT_LE_ADV_OPT_CONNECTABLE
+	 * option.
+	 * When used together with @ref BT_LE_ADV_OPT_EXT_ADV then scan
+	 * response data must be set.
 	 */
 	BT_LE_ADV_OPT_SCANNABLE = BIT(9),
 
-	/** @brief Advertise with extended advertising.
+	/**
+	 * @brief Advertise with extended advertising.
 	 *
-	 *  This options enables extended advertising in the advertising set.
-	 *  In extended advertising the advertising set will send a small header
-	 *  packet on the three primary advertising channels. This small header
-	 *  points to the advertising data packet that will be sent on one of
-	 *  the 37 secondary advertising channels.
-	 *  The advertiser will send primary advertising on LE 1M PHY, and
-	 *  secondary advertising on LE 2M PHY.
-	 *  Connections will be established on LE 2M PHY.
+	 * This options enables extended advertising in the advertising set.
+	 * In extended advertising the advertising set will send a small header
+	 * packet on the three primary advertising channels. This small header
+	 * points to the advertising data packet that will be sent on one of
+	 * the 37 secondary advertising channels.
+	 * The advertiser will send primary advertising on LE 1M PHY, and
+	 * secondary advertising on LE 2M PHY.
+	 * Connections will be established on LE 2M PHY.
 	 *
-	 *  Without this option the advertiser will send advertising data on the
-	 *  three primary advertising channels.
+	 * Without this option the advertiser will send advertising data on the
+	 * three primary advertising channels.
 	 *
-	 *  @note Enabling this option requires extended advertising support in
-	 *        the peer devices scanning for advertisement packets.
+	 * @note Enabling this option requires extended advertising support in
+	 *       the peer devices scanning for advertisement packets.
 	 */
 	BT_LE_ADV_OPT_EXT_ADV = BIT(10),
 
-	/** @brief Disable use of LE 2M PHY on the secondary advertising
-	 *  channel.
+	/**
+	 * @brief Disable use of LE 2M PHY on the secondary advertising
+	 * channel.
 	 *
-	 *  Disabling the use of LE 2M PHY could be necessary if scanners don't
-	 *  support the LE 2M PHY.
-	 *  The advertiser will send primary advertising on LE 1M PHY, and
-	 *  secondary advertising on LE 1M PHY.
-	 *  Connections will be established on LE 1M PHY.
+	 * Disabling the use of LE 2M PHY could be necessary if scanners don't
+	 * support the LE 2M PHY.
+	 * The advertiser will send primary advertising on LE 1M PHY, and
+	 * secondary advertising on LE 1M PHY.
+	 * Connections will be established on LE 1M PHY.
 	 *
-	 *  @note Cannot be set if BT_LE_ADV_OPT_CODED is set.
+	 * @note Cannot be set if BT_LE_ADV_OPT_CODED is set.
 	 *
-	 *  @note Requires @ref BT_LE_ADV_OPT_EXT_ADV.
+	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV.
 	 */
 	BT_LE_ADV_OPT_NO_2M = BIT(11),
 
-	/** @brief Advertise on the LE Coded PHY (Long Range).
+	/**
+	 * @brief Advertise on the LE Coded PHY (Long Range).
 	 *
-	 *  The advertiser will send both primary and secondary advertising
-	 *  on the LE Coded PHY. This gives the advertiser increased range with
-	 *  the trade-off of lower data rate and higher power consumption.
-	 *  Connections will be established on LE Coded PHY.
+	 * The advertiser will send both primary and secondary advertising
+	 * on the LE Coded PHY. This gives the advertiser increased range with
+	 * the trade-off of lower data rate and higher power consumption.
+	 * Connections will be established on LE Coded PHY.
 	 *
-	 *  @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
+	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
 	 */
 	BT_LE_ADV_OPT_CODED = BIT(12),
 
-	/** @brief Advertise without a device address (identity or RPA).
+	/**
+	 * @brief Advertise without a device address (identity or RPA).
 	 *
-	 *  @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
+	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
 	 */
 	BT_LE_ADV_OPT_ANONYMOUS = BIT(13),
 
-	/** @brief Advertise with transmit power.
+	/**
+	 * @brief Advertise with transmit power.
 	 *
-	 *  @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
+	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
 	 */
 	BT_LE_ADV_OPT_USE_TX_POWER = BIT(14),
 };
 
 /** LE Advertising Parameters. */
 struct bt_le_adv_param {
-	/** @brief Local identity.
+	/**
+	 * @brief Local identity.
 	 *
-	 *  @note When extended advertising :option:`CONFIG_BT_EXT_ADV` is not
-	 *        enabled or not supported by the controller it is not possible
-	 *        to scan and advertise simultaneously using two different
-	 *        random addresses.
+	 * @note When extended advertising @option{CONFIG_BT_EXT_ADV} is not
+	 *       enabled or not supported by the controller it is not possible
+	 *       to scan and advertise simultaneously using two different
+	 *       random addresses.
 	 *
-	 *  @note It is not possible to have multiple connectable advertising
-	 *        sets advertising simultaneously using different identities.
+	 * @note It is not possible to have multiple connectable advertising
+	 *       sets advertising simultaneously using different identities.
 	 */
 	uint8_t  id;
 
-	/** @brief Advertising Set Identifier, valid range 0x00 - 0x0f.
+	/**
+	 * @brief Advertising Set Identifier, valid range 0x00 - 0x0f.
 	 *
-	 *  @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
+	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
 	 **/
 	uint8_t  sid;
 
-	/** @brief Secondary channel maximum skip count.
+	/**
+	 * @brief Secondary channel maximum skip count.
 	 *
-	 *  Maximum advertising events the advertiser can skip before it must
-	 *  send advertising data on the secondary advertising channel.
+	 * Maximum advertising events the advertiser can skip before it must
+	 * send advertising data on the secondary advertising channel.
 	 *
-	 *  @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
+	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
 	 */
 	uint8_t  secondary_max_skip;
 
@@ -487,17 +517,18 @@ struct bt_le_adv_param {
 	/** Maximum Advertising Interval (N * 0.625) */
 	uint32_t interval_max;
 
-	/** @brief Directed advertising to peer
+	/**
+	 * @brief Directed advertising to peer
 	 *
-	 *  When this parameter is set the advertiser will send directed
-	 *  advertising to the remote device.
+	 * When this parameter is set the advertiser will send directed
+	 * advertising to the remote device.
 	 *
-	 *  The advertising type will either be high duty cycle, or low duty
-	 *  cycle if the BT_LE_ADV_OPT_DIR_MODE_LOW_DUTY option is enabled.
+	 * The advertising type will either be high duty cycle, or low duty
+	 * cycle if the BT_LE_ADV_OPT_DIR_MODE_LOW_DUTY option is enabled.
 	 *
-	 *  In case of connectable high duty cycle if the connection could not
-	 *  be established within the timeout the connected() callback will be
-	 *  called with the status set to @ref BT_HCI_ERR_ADV_TIMEOUT.
+	 * In case of connectable high duty cycle if the connection could not
+	 * be established within the timeout the connected() callback will be
+	 * called with the status set to @ref BT_HCI_ERR_ADV_TIMEOUT.
 	 */
 	const bt_addr_le_t *peer;
 };
@@ -508,9 +539,10 @@ enum {
 	/** Convenience value when no options are specified. */
 	BT_LE_PER_ADV_OPT_NONE = 0,
 
-	/** @brief Advertise with transmit power.
+	/**
+	 * @brief Advertise with transmit power.
 	 *
-	 *  @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
+	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
 	 */
 	BT_LE_PER_ADV_OPT_USE_TX_POWER = BIT(1),
 };
@@ -526,13 +558,14 @@ struct bt_le_per_adv_param {
 	uint32_t options;
 };
 
-/** @brief Initialize advertising parameters
+/**
+ * @brief Initialize advertising parameters
  *
- *  @param _options   Advertising Options
- *  @param _int_min   Minimum advertising interval
- *  @param _int_max   Maximum advertising interval
- *  @param _peer      Peer address, set to NULL for undirected advertising or
- *                    address of peer for directed advertising.
+ * @param _options   Advertising Options
+ * @param _int_min   Minimum advertising interval
+ * @param _int_max   Maximum advertising interval
+ * @param _peer      Peer address, set to NULL for undirected advertising or
+ *                   address of peer for directed advertising.
  */
 #define BT_LE_ADV_PARAM_INIT(_options, _int_min, _int_max, _peer) \
 { \
@@ -545,13 +578,14 @@ struct bt_le_per_adv_param {
 	.peer = (_peer), \
 }
 
-/** @brief Helper to declare advertising parameters inline
+/**
+ * @brief Helper to declare advertising parameters inline
  *
- *  @param _options   Advertising Options
- *  @param _int_min   Minimum advertising interval
- *  @param _int_max   Maximum advertising interval
- *  @param _peer      Peer address, set to NULL for undirected advertising or
- *                    address of peer for directed advertising.
+ * @param _options   Advertising Options
+ * @param _int_min   Minimum advertising interval
+ * @param _int_max   Maximum advertising interval
+ * @param _peer      Peer address, set to NULL for undirected advertising or
+ *                   address of peer for directed advertising.
  */
 #define BT_LE_ADV_PARAM(_options, _int_min, _int_max, _peer) \
 	((struct bt_le_adv_param[]) { \
@@ -585,11 +619,12 @@ struct bt_le_per_adv_param {
 					     BT_GAP_ADV_FAST_INT_MIN_2, \
 					     BT_GAP_ADV_FAST_INT_MAX_2, NULL)
 
-/** Helper to declare periodic advertising parameters inline
+/**
+ * Helper to declare periodic advertising parameters inline
  *
- *  @param _int_min     Minimum periodic advertising interval
- *  @param _int_max     Maximum periodic advertising interval
- *  @param _options     Periodic advertising properties bitfield.
+ * @param _int_min     Minimum periodic advertising interval
+ * @param _int_max     Maximum periodic advertising interval
+ * @param _options     Periodic advertising properties bitfield.
  */
 #define BT_LE_PER_ADV_PARAM_INIT(_int_min, _int_max, _options) \
 { \
@@ -598,11 +633,12 @@ struct bt_le_per_adv_param {
 	.options = (_options), \
 }
 
-/** Helper to declare periodic advertising parameters inline
+/**
+ * Helper to declare periodic advertising parameters inline
  *
- *  @param _int_min     Minimum periodic advertising interval
- *  @param _int_max     Maximum periodic advertising interval
- *  @param _options     Periodic advertising properties bitfield.
+ * @param _int_min     Minimum periodic advertising interval
+ * @param _int_max     Maximum periodic advertising interval
+ * @param _options     Periodic advertising properties bitfield.
  */
 #define BT_LE_PER_ADV_PARAM(_int_min, _int_max, _options) \
 	((struct bt_le_per_adv_param[]) { \
@@ -613,192 +649,204 @@ struct bt_le_per_adv_param {
 						  BT_GAP_ADV_SLOW_INT_MAX, \
 						  BT_LE_PER_ADV_OPT_NONE)
 
-/** @brief Start advertising
+/**
+ * @brief Start advertising
  *
- *  Set advertisement data, scan response data, advertisement parameters
- *  and start advertising.
+ * Set advertisement data, scan response data, advertisement parameters
+ * and start advertising.
  *
- *  When the advertisement parameter peer address has been set the advertising
- *  will be directed to the peer. In this case advertisement data and scan
- *  response data parameters are ignored. If the mode is high duty cycle
- *  the timeout will be @ref BT_GAP_ADV_HIGH_DUTY_CYCLE_MAX_TIMEOUT.
+ * When the advertisement parameter peer address has been set the advertising
+ * will be directed to the peer. In this case advertisement data and scan
+ * response data parameters are ignored. If the mode is high duty cycle
+ * the timeout will be @ref BT_GAP_ADV_HIGH_DUTY_CYCLE_MAX_TIMEOUT.
  *
- *  @param param Advertising parameters.
- *  @param ad Data to be used in advertisement packets.
- *  @param ad_len Number of elements in ad
- *  @param sd Data to be used in scan response packets.
- *  @param sd_len Number of elements in sd
+ * @param param Advertising parameters.
+ * @param ad Data to be used in advertisement packets.
+ * @param ad_len Number of elements in ad
+ * @param sd Data to be used in scan response packets.
+ * @param sd_len Number of elements in sd
  *
- *  @return Zero on success or (negative) error code otherwise.
- *  @return -ENOMEM No free connection objects available for connectable
- *                  advertiser.
- *  @return -ECONNREFUSED When connectable advertising is requested and there
- *                        is already maximum number of connections established
- *                        in the controller.
- *                        This error code is only guaranteed when using Zephyr
- *                        controller, for other controllers code returned in
- *                        this case may be -EIO.
+ * @return Zero on success or (negative) error code otherwise.
+ * @return -ENOMEM No free connection objects available for connectable
+ *                 advertiser.
+ * @return -ECONNREFUSED When connectable advertising is requested and there
+ *                       is already maximum number of connections established
+ *                       in the controller.
+ *                       This error code is only guaranteed when using Zephyr
+ *                       controller, for other controllers code returned in
+ *                       this case may be -EIO.
  */
 int bt_le_adv_start(const struct bt_le_adv_param *param,
 		    const struct bt_data *ad, size_t ad_len,
 		    const struct bt_data *sd, size_t sd_len);
 
-/** @brief Update advertising
+/**
+ * @brief Update advertising
  *
- *  Update advertisement and scan response data.
+ * Update advertisement and scan response data.
  *
- *  @param ad Data to be used in advertisement packets.
- *  @param ad_len Number of elements in ad
- *  @param sd Data to be used in scan response packets.
- *  @param sd_len Number of elements in sd
+ * @param ad Data to be used in advertisement packets.
+ * @param ad_len Number of elements in ad
+ * @param sd Data to be used in scan response packets.
+ * @param sd_len Number of elements in sd
  *
- *  @return Zero on success or (negative) error code otherwise.
+ * @return Zero on success or (negative) error code otherwise.
  */
 int bt_le_adv_update_data(const struct bt_data *ad, size_t ad_len,
 			  const struct bt_data *sd, size_t sd_len);
 
-/** @brief Stop advertising
+/**
+ * @brief Stop advertising
  *
- *  Stops ongoing advertising.
+ * Stops ongoing advertising.
  *
- *  @return Zero on success or (negative) error code otherwise.
+ * @return Zero on success or (negative) error code otherwise.
  */
 int bt_le_adv_stop(void);
 
-/** @brief Create advertising set.
+/**
+ * @brief Create advertising set.
  *
- *  Create a new advertising set and set advertising parameters.
- *  Advertising parameters can be updated with @ref bt_le_ext_adv_update_param.
+ * Create a new advertising set and set advertising parameters.
+ * Advertising parameters can be updated with @ref bt_le_ext_adv_update_param.
  *
- *  @param[in] param Advertising parameters.
- *  @param[in] cb    Callback struct to notify about advertiser activity. Can be
- *                   NULL. Must point to valid memory during the lifetime of the
- *                   advertising set.
- *  @param[out] adv  Valid advertising set object on success.
+ * @param[in] param Advertising parameters.
+ * @param[in] cb    Callback struct to notify about advertiser activity. Can be
+ *                  NULL. Must point to valid memory during the lifetime of the
+ *                  advertising set.
+ * @param[out] adv  Valid advertising set object on success.
  *
- *  @return Zero on success or (negative) error code otherwise.
+ * @return Zero on success or (negative) error code otherwise.
  */
 int bt_le_ext_adv_create(const struct bt_le_adv_param *param,
 			 const struct bt_le_ext_adv_cb *cb,
 			 struct bt_le_ext_adv **adv);
 
 struct bt_le_ext_adv_start_param {
-	/** @brief Advertiser timeout (N * 10 ms).
+	/**
+	 * @brief Advertiser timeout (N * 10 ms).
 	 *
-	 *  Application will be notified by the advertiser sent callback.
-	 *  Set to zero for no timeout.
+	 * Application will be notified by the advertiser sent callback.
+	 * Set to zero for no timeout.
 	 *
-	 *  When using high duty cycle directed connectable advertising then
-	 *  this parameters must be set to a non-zero value less than or equal
-	 *  to the maximum of @ref BT_GAP_ADV_HIGH_DUTY_CYCLE_MAX_TIMEOUT.
+	 * When using high duty cycle directed connectable advertising then
+	 * this parameters must be set to a non-zero value less than or equal
+	 * to the maximum of @ref BT_GAP_ADV_HIGH_DUTY_CYCLE_MAX_TIMEOUT.
 	 *
-	 *  If privacy :option:`CONFIG_BT_PRIVACY` is enabled then the timeout
-	 *  must be less than :option:`CONFIG_BT_RPA_TIMEOUT`.
+	 * If privacy @option{CONFIG_BT_PRIVACY} is enabled then the timeout
+	 * must be less than @option{CONFIG_BT_RPA_TIMEOUT}.
 	 */
 	uint16_t timeout;
-	/** @brief Number of advertising events.
+	/**
+	 * @brief Number of advertising events.
 	 *
-	 *  Application will be notified by the advertiser sent callback.
-	 *  Set to zero for no limit.
+	 * Application will be notified by the advertiser sent callback.
+	 * Set to zero for no limit.
 	 */
 	uint8_t  num_events;
 };
 
-/** @brief Start advertising with the given advertising set
+/**
+ * @brief Start advertising with the given advertising set
  *
- *  If the advertiser is limited by either the timeout or number of advertising
- *  events the application will be notified by the advertiser sent callback once
- *  the limit is reached.
- *  If the advertiser is limited by both the timeout and the number of
- *  advertising events then the limit that is reached first will stop the
- *  advertiser.
+ * If the advertiser is limited by either the timeout or number of advertising
+ * events the application will be notified by the advertiser sent callback once
+ * the limit is reached.
+ * If the advertiser is limited by both the timeout and the number of
+ * advertising events then the limit that is reached first will stop the
+ * advertiser.
  *
- *  @param adv    Advertising set object.
- *  @param param  Advertise start parameters.
+ * @param adv    Advertising set object.
+ * @param param  Advertise start parameters.
  */
 int bt_le_ext_adv_start(struct bt_le_ext_adv *adv,
 			struct bt_le_ext_adv_start_param *param);
 
-/** @brief Stop advertising with the given advertising set
+/**
+ * @brief Stop advertising with the given advertising set
  *
- *  Stop advertising with a specific advertising set. When using this function
- *  the advertising sent callback will not be called.
+ * Stop advertising with a specific advertising set. When using this function
+ * the advertising sent callback will not be called.
  *
- *  @param adv Advertising set object.
+ * @param adv Advertising set object.
  *
- *  @return Zero on success or (negative) error code otherwise.
+ * @return Zero on success or (negative) error code otherwise.
  */
 int bt_le_ext_adv_stop(struct bt_le_ext_adv *adv);
 
-/** @brief Set an advertising set's advertising or scan response data.
+/**
+ * @brief Set an advertising set's advertising or scan response data.
  *
- *  Set advertisement data or scan response data. If the advertising set is
- *  currently advertising then the advertising data will be updated in
- *  subsequent advertising events.
+ * Set advertisement data or scan response data. If the advertising set is
+ * currently advertising then the advertising data will be updated in
+ * subsequent advertising events.
  *
- *  When both @ref BT_LE_ADV_OPT_EXT_ADV and @ref BT_LE_ADV_OPT_SCANNABLE are
- *  enabled then advertising data is ignored.
- *  When @ref BT_LE_ADV_OPT_SCANNABLE is not enabled then scan response data is
- *  ignored.
+ * When both @ref BT_LE_ADV_OPT_EXT_ADV and @ref BT_LE_ADV_OPT_SCANNABLE are
+ * enabled then advertising data is ignored.
+ * When @ref BT_LE_ADV_OPT_SCANNABLE is not enabled then scan response data is
+ * ignored.
  *
- *  If the advertising set has been configured to send advertising data on the
- *  primary advertising channels then the maximum data length is
- *  @ref BT_GAP_ADV_MAX_ADV_DATA_LEN bytes.
- *  If the advertising set has been configured for extended advertising,
- *  then the maximum data length is defined by the controller with the maximum
- *  possible of @ref BT_GAP_ADV_MAX_EXT_ADV_DATA_LEN bytes.
+ * If the advertising set has been configured to send advertising data on the
+ * primary advertising channels then the maximum data length is
+ * @ref BT_GAP_ADV_MAX_ADV_DATA_LEN bytes.
+ * If the advertising set has been configured for extended advertising,
+ * then the maximum data length is defined by the controller with the maximum
+ * possible of @ref BT_GAP_ADV_MAX_EXT_ADV_DATA_LEN bytes.
  *
- *  @note Not all scanners support extended data length advertising data.
+ * @note Not all scanners support extended data length advertising data.
  *
- *  @note When updating the advertising data while advertising the advertising
- *        data and scan response data length must be smaller or equal to what
- *        can be fit in a single advertising packet. Otherwise the
- *        advertiser must be stopped.
+ * @note When updating the advertising data while advertising the advertising
+ *       data and scan response data length must be smaller or equal to what
+ *       can be fit in a single advertising packet. Otherwise the
+ *       advertiser must be stopped.
  *
- *  @param adv     Advertising set object.
- *  @param ad      Data to be used in advertisement packets.
- *  @param ad_len  Number of elements in ad
- *  @param sd      Data to be used in scan response packets.
- *  @param sd_len  Number of elements in sd
+ * @param adv     Advertising set object.
+ * @param ad      Data to be used in advertisement packets.
+ * @param ad_len  Number of elements in ad
+ * @param sd      Data to be used in scan response packets.
+ * @param sd_len  Number of elements in sd
  *
- *  @return Zero on success or (negative) error code otherwise.
+ * @return Zero on success or (negative) error code otherwise.
  */
 int bt_le_ext_adv_set_data(struct bt_le_ext_adv *adv,
 			   const struct bt_data *ad, size_t ad_len,
 			   const struct bt_data *sd, size_t sd_len);
 
-/** @brief Update advertising parameters.
+/**
+ * @brief Update advertising parameters.
  *
- *  Update the advertising parameters. The function will return an error if the
- *  advertiser set is currently advertising. Stop the advertising set before
- *  calling this function.
+ * Update the advertising parameters. The function will return an error if the
+ * advertiser set is currently advertising. Stop the advertising set before
+ * calling this function.
  *
- *  @param adv   Advertising set object.
- *  @param param Advertising parameters.
+ * @param adv   Advertising set object.
+ * @param param Advertising parameters.
  *
- *  @return Zero on success or (negative) error code otherwise.
+ * @return Zero on success or (negative) error code otherwise.
  */
 int bt_le_ext_adv_update_param(struct bt_le_ext_adv *adv,
 			       const struct bt_le_adv_param *param);
 
-/** @brief Delete advertising set.
+/**
+ * @brief Delete advertising set.
  *
- *  Delete advertising set. This will free up the advertising set and make it
- *  possible to create a new advertising set.
+ * Delete advertising set. This will free up the advertising set and make it
+ * possible to create a new advertising set.
  *
- *  @return Zero on success or (negative) error code otherwise.
+ * @return Zero on success or (negative) error code otherwise.
  */
 int bt_le_ext_adv_delete(struct bt_le_ext_adv *adv);
 
-/** @brief Get array index of an advertising set.
+/**
+ * @brief Get array index of an advertising set.
  *
- *  This function is used to map bt_adv to index of an array of
- *  advertising sets. The array has CONFIG_BT_EXT_ADV_MAX_ADV_SET elements.
+ * This function is used to map bt_adv to index of an array of
+ * advertising sets. The array has CONFIG_BT_EXT_ADV_MAX_ADV_SET elements.
  *
- *  @param adv Advertising set.
+ * @param adv Advertising set.
  *
- *  @return Index of the advertising set object.
- *  The range of the returned value is 0..CONFIG_BT_EXT_ADV_MAX_ADV_SET-1
+ * @return Index of the advertising set object.
+ * The range of the returned value is 0..CONFIG_BT_EXT_ADV_MAX_ADV_SET-1
  */
 uint8_t bt_le_ext_adv_get_index(struct bt_le_ext_adv *adv);
 
@@ -811,86 +859,92 @@ struct bt_le_ext_adv_info {
 	int8_t                     tx_power;
 };
 
-/** @brief Get advertising set info
+/**
+ * @brief Get advertising set info
  *
- *  @param adv Advertising set object
- *  @param info Advertising set info object
+ * @param adv Advertising set object
+ * @param info Advertising set info object
  *
- *  @return Zero on success or (negative) error code on failure.
+ * @return Zero on success or (negative) error code on failure.
  */
 int bt_le_ext_adv_get_info(const struct bt_le_ext_adv *adv,
 			   struct bt_le_ext_adv_info *info);
 
-/** @typedef bt_le_scan_cb_t
- *  @brief Callback type for reporting LE scan results.
+/**
+ * @typedef bt_le_scan_cb_t
+ * @brief Callback type for reporting LE scan results.
  *
- *  A function of this type is given to the bt_le_scan_start() function
- *  and will be called for any discovered LE device.
+ * A function of this type is given to the bt_le_scan_start() function
+ * and will be called for any discovered LE device.
  *
- *  @param addr Advertiser LE address and type.
- *  @param rssi Strength of advertiser signal.
- *  @param adv_type Type of advertising response from advertiser.
- *  @param buf Buffer containing advertiser data.
+ * @param addr Advertiser LE address and type.
+ * @param rssi Strength of advertiser signal.
+ * @param adv_type Type of advertising response from advertiser.
+ * @param buf Buffer containing advertiser data.
  */
 typedef void bt_le_scan_cb_t(const bt_addr_le_t *addr, int8_t rssi,
 			     uint8_t adv_type, struct net_buf_simple *buf);
 
-/** @brief Set or update the periodic advertising parameters.
+/**
+ * @brief Set or update the periodic advertising parameters.
  *
- *  The periodic advertising parameters can only be set or updated on an
- *  extended advertisement set which is neither scannable, connectable nor
- *  anonymous.
+ * The periodic advertising parameters can only be set or updated on an
+ * extended advertisement set which is neither scannable, connectable nor
+ * anonymous.
  *
- *  @param adv   Advertising set object.
- *  @param param Advertising parameters.
+ * @param adv   Advertising set object.
+ * @param param Advertising parameters.
  *
- *  @return Zero on success or (negative) error code otherwise.
+ * @return Zero on success or (negative) error code otherwise.
  */
 int bt_le_per_adv_set_param(struct bt_le_ext_adv *adv,
 			    const struct bt_le_per_adv_param *param);
 
-/** @brief Set or update the periodic advertising data.
+/**
+ * @brief Set or update the periodic advertising data.
  *
- *  The periodic advertisement data can only be set or updated on an
- *  extended advertisement set which is neither scannable, connectable nor
- *  anonymous.
+ * The periodic advertisement data can only be set or updated on an
+ * extended advertisement set which is neither scannable, connectable nor
+ * anonymous.
  *
- *  @param adv       Advertising set object.
- *  @param ad        Advertising data.
- *  @param ad_len    Advertising data length.
+ * @param adv       Advertising set object.
+ * @param ad        Advertising data.
+ * @param ad_len    Advertising data length.
  *
- *  @return          Zero on success or (negative) error code otherwise.
+ * @return          Zero on success or (negative) error code otherwise.
  */
 int bt_le_per_adv_set_data(const struct bt_le_ext_adv *adv,
 			   const struct bt_data *ad, size_t ad_len);
 
-/** @brief Starts periodic advertising.
+/**
+ * @brief Starts periodic advertising.
  *
- *  Enabling the periodic advertising can be done independently of extended
- *  advertising, but both periodic advertising and extended advertising
- *  shall be enabled before any periodic advertising data is sent. The
- *  periodic advertising and extended advertising can be enabled in any order.
+ * Enabling the periodic advertising can be done independently of extended
+ * advertising, but both periodic advertising and extended advertising
+ * shall be enabled before any periodic advertising data is sent. The
+ * periodic advertising and extended advertising can be enabled in any order.
  *
- *  Once periodic advertising has been enabled, it will continue advertising
- *  until @ref bt_le_per_adv_stop() has been called, or if the advertising set
- *  is deleted by @ref bt_le_ext_adv_delete(). Calling @ref bt_le_ext_adv_stop()
- *  will not stop the periodic advertising.
+ * Once periodic advertising has been enabled, it will continue advertising
+ * until @ref bt_le_per_adv_stop() has been called, or if the advertising set
+ * is deleted by @ref bt_le_ext_adv_delete(). Calling @ref bt_le_ext_adv_stop()
+ * will not stop the periodic advertising.
  *
- *  @param adv      Advertising set object.
+ * @param adv      Advertising set object.
  *
- *  @return         Zero on success or (negative) error code otherwise.
+ * @return         Zero on success or (negative) error code otherwise.
  */
 int bt_le_per_adv_start(struct bt_le_ext_adv *adv);
 
-/** @brief Stops periodic advertising.
+/**
+ * @brief Stops periodic advertising.
  *
- *  Disabling the periodic advertising can be done independently of extended
- *  advertising. Disabling periodic advertising will not disable extended
- *  advertising.
+ * Disabling the periodic advertising can be done independently of extended
+ * advertising. Disabling periodic advertising will not disable extended
+ * advertising.
  *
- *  @param adv      Advertising set object.
+ * @param adv      Advertising set object.
  *
- *  @return         Zero on success or (negative) error code otherwise.
+ * @return         Zero on success or (negative) error code otherwise.
  */
 int bt_le_per_adv_stop(struct bt_le_ext_adv *adv);
 
@@ -934,37 +988,40 @@ struct bt_le_per_adv_sync_recv_info {
 };
 
 struct bt_le_per_adv_sync_cb {
-	/** @brief The periodic advertising has been successfully synced.
+	/**
+	 * @brief The periodic advertising has been successfully synced.
 	 *
-	 *  This callback notifies the application that the periodic advertising
-	 *  set has been successfully synced, and will now start to
-	 *  receive periodic advertising reports.
+	 * This callback notifies the application that the periodic advertising
+	 * set has been successfully synced, and will now start to
+	 * receive periodic advertising reports.
 	 *
-	 *  @param sync The periodic advertising sync object.
-	 *  @param info Information about the sync event.
+	 * @param sync The periodic advertising sync object.
+	 * @param info Information about the sync event.
 	 */
 	void (*synced)(struct bt_le_per_adv_sync *sync,
 		       struct bt_le_per_adv_sync_synced_info *info);
 
-	/** @brief The periodic advertising sync has been terminated.
+	/**
+	 * @brief The periodic advertising sync has been terminated.
 	 *
-	 *  This callback notifies the application that the periodic advertising
-	 *  sync has been terminated, either by local request, remote request or
-	 *  because due to missing data, e.g. by being out of range or sync.
+	 * This callback notifies the application that the periodic advertising
+	 * sync has been terminated, either by local request, remote request or
+	 * because due to missing data, e.g. by being out of range or sync.
 	 *
-	 *  @param sync  The periodic advertising sync object.
+	 * @param sync  The periodic advertising sync object.
 	 */
 	void (*term)(struct bt_le_per_adv_sync *sync,
 		     const struct bt_le_per_adv_sync_term_info *info);
 
-	/** @brief Periodic advertising data received.
+	/**
+	 * @brief Periodic advertising data received.
 	 *
-	 *  This callback notifies the application of an periodic advertising
-	 *  report.
+	 * This callback notifies the application of an periodic advertising
+	 * report.
 	 *
-	 *  @param sync  The advertising set object.
-	 *  @param info  Information about the periodic advertising event.
-	 *  @param buf   Buffer containing the periodic advertising data.
+	 * @param sync  The advertising set object.
+	 * @param info  Information about the periodic advertising event.
+	 * @param buf   Buffer containing the periodic advertising data.
 	 */
 	void (*recv)(struct bt_le_per_adv_sync *sync,
 		     const struct bt_le_per_adv_sync_recv_info *info,
@@ -976,16 +1033,18 @@ enum {
 	/** Convenience value when no options are specified. */
 	BT_LE_PER_ADV_SYNC_OPT_NONE = 0,
 
-	/** @brief Use the periodic advertising list to sync with advertiser
+	/**
+	 * @brief Use the periodic advertising list to sync with advertiser
 	 *
-	 *  When this option is set, the address and SID of the parameters
-	 *  are ignored.
+	 * When this option is set, the address and SID of the parameters
+	 * are ignored.
 	 */
 	BT_LE_PER_ADV_SYNC_OPT_USE_PER_ADV_LIST = BIT(0),
 
-	/** @brief Disables periodic advertising reports
+	/**
+	 * @brief Disables periodic advertising reports
 	 *
-	 *  No advertisement reports will be handled until enabled.
+	 * No advertisement reports will be handled until enabled.
 	 */
 	BT_LE_PER_ADV_SYNC_OPT_REPORTING_INITIALLY_DISABLED = BIT(1),
 
@@ -1003,74 +1062,81 @@ enum {
 };
 
 struct bt_le_per_adv_sync_param {
-	/** @brief Periodic Advertiser Address
+	/**
+	 * @brief Periodic Advertiser Address
 	 *
-	 *  Only valid if not using the periodic advertising list
+	 * Only valid if not using the periodic advertising list
 	 */
 	bt_addr_le_t addr;
 
-	/** @brief Advertiser SID
+	/**
+	 * @brief Advertiser SID
 	 *
-	 *  Only valid if not using the periodic advertising list
+	 * Only valid if not using the periodic advertising list
 	 */
 	uint8_t sid;
 
 	/** Bit-field of periodic advertising sync options. */
 	uint32_t options;
 
-	/** @brief Maximum event skip
+	/**
+	 * @brief Maximum event skip
 	 *
-	 *  Maximum number of periodic advertising events that can be
-	 *  skipped after a successful receive
+	 * Maximum number of periodic advertising events that can be
+	 * skipped after a successful receive
 	 */
 	uint16_t skip;
 
-	/** @brief Synchronization timeout (N * 10 ms)
+	/**
+	 * @brief Synchronization timeout (N * 10 ms)
 	 *
-	 *  Synchronization timeout for the periodic advertising sync.
-	 *  Range 0x000A to 0x4000 (100 ms to 163840 ms)
+	 * Synchronization timeout for the periodic advertising sync.
+	 * Range 0x000A to 0x4000 (100 ms to 163840 ms)
 	 */
 	uint16_t timeout;
 };
 
-/** @brief Get array index of an periodic advertising sync object.
+/**
+ * @brief Get array index of an periodic advertising sync object.
  *
- *  This function is get the index of an array of periodic advertising sync
- *  objects. The array has CONFIG_BT_PER_ADV_SYNC_MAX elements.
+ * This function is get the index of an array of periodic advertising sync
+ * objects. The array has CONFIG_BT_PER_ADV_SYNC_MAX elements.
  *
- *  @param per_adv_sync The periodic advertising sync object.
+ * @param per_adv_sync The periodic advertising sync object.
  *
- *  @return Index of the periodic advertising sync object.
- *  The range of the returned value is 0..CONFIG_BT_PER_ADV_SYNC_MAX-1
+ * @return Index of the periodic advertising sync object.
+ * The range of the returned value is 0..CONFIG_BT_PER_ADV_SYNC_MAX-1
  */
 uint8_t bt_le_per_adv_sync_get_index(struct bt_le_per_adv_sync *per_adv_sync);
 
-/** @brief Create a periodic advertising sync object.
+/**
+ * @brief Create a periodic advertising sync object.
  *
- *  Create a periodic advertising sync object that can try to synchronize
- *  to periodic advertising reports from an advertiser. Scan shall either be
- *  disabled or extended scan shall be enabled.
+ * Create a periodic advertising sync object that can try to synchronize
+ * to periodic advertising reports from an advertiser. Scan shall either be
+ * disabled or extended scan shall be enabled.
  *
- *  @param[in] param     Periodic advertising sync parameters.
- *  @param[in] cb        Periodic advertising callbacks.
- *  @param[out] out_sync Periodic advertising sync object on.
+ * @param[in] param     Periodic advertising sync parameters.
+ * @param[in] cb        Periodic advertising callbacks.
+ * @param[out] out_sync Periodic advertising sync object on.
  *
- *  @return Zero on success or (negative) error code otherwise.
+ * @return Zero on success or (negative) error code otherwise.
  */
 int bt_le_per_adv_sync_create(const struct bt_le_per_adv_sync_param *param,
 			      const struct bt_le_per_adv_sync_cb *cb,
 			      struct bt_le_per_adv_sync **out_sync);
 
-/** @brief Delete periodic advertising sync.
+/**
+ * @brief Delete periodic advertising sync.
  *
- *  Delete the periodic advertising sync object. Can be called regardless of the
- *  state of the sync. If the syncing is currently syncing, the syncing is
- *  cancelled. If the sync has been established, it is terminated. The
- *  periodic advertising sync object will be invalidated afterwards.
+ * Delete the periodic advertising sync object. Can be called regardless of the
+ * state of the sync. If the syncing is currently syncing, the syncing is
+ * cancelled. If the sync has been established, it is terminated. The
+ * periodic advertising sync object will be invalidated afterwards.
  *
- *  @param per_adv_sync The periodic advertising sync object.
+ * @param per_adv_sync The periodic advertising sync object.
  *
- *  @return Zero on success or (negative) error code otherwise.
+ * @return Zero on success or (negative) error code otherwise.
  */
 int bt_le_per_adv_sync_delete(struct bt_le_per_adv_sync *per_adv_sync);
 
@@ -1087,9 +1153,10 @@ enum {
 	/** Enable scan on coded PHY (Long Range).*/
 	BT_LE_SCAN_OPT_CODED = BIT(2),
 
-	/** @brief Disable scan on 1M phy.
+	/**
+	 * @brief Disable scan on 1M phy.
 	 *
-	 *  @note Requires @ref BT_LE_SCAN_OPT_CODED.
+	 * @note Requires @ref BT_LE_SCAN_OPT_CODED.
 	 */
 	BT_LE_SCAN_OPT_NO_1M = BIT(3),
 
@@ -1126,32 +1193,36 @@ struct bt_le_scan_param {
 	/** Scan window (N * 0.625 ms) */
 	uint16_t window;
 
-	/** @brief Scan timeout (N * 10 ms)
+	/**
+	 * @brief Scan timeout (N * 10 ms)
 	 *
-	 *  Application will be notified by the scan timeout callback.
-	 *  Set zero to disable timeout.
+	 * Application will be notified by the scan timeout callback.
+	 * Set zero to disable timeout.
 	 */
 	uint16_t timeout;
 
-	/** @brief Scan interval LE Coded PHY (N * 0.625 MS)
+	/**
+	 * @brief Scan interval LE Coded PHY (N * 0.625 MS)
 	 *
-	 *  Set zero to use same as LE 1M PHY scan interval.
+	 * Set zero to use same as LE 1M PHY scan interval.
 	 */
 	uint16_t interval_coded;
 
-	/** @brief Scan window LE Coded PHY (N * 0.625 MS)
+	/**
+	 * @brief Scan window LE Coded PHY (N * 0.625 MS)
 	 *
-	 *  Set zero to use same as LE 1M PHY scan window.
+	 * Set zero to use same as LE 1M PHY scan window.
 	 */
 	uint16_t window_coded;
 };
 
 /** LE advertisement packet information */
 struct bt_le_scan_recv_info {
-	/** @brief Advertiser LE address and type.
+	/**
+	 * @brief Advertiser LE address and type.
 	 *
-	 *  If advertiser is anonymous then this address will be
-	 *  @ref BT_ADDR_LE_ANY.
+	 * If advertiser is anonymous then this address will be
+	 * @ref BT_ADDR_LE_ANY.
 	 */
 	const bt_addr_le_t *addr;
 
@@ -1187,10 +1258,11 @@ struct bt_le_scan_recv_info {
 /** Listener context for (LE) scanning. */
 struct bt_le_scan_cb {
 
-	/** @brief Advertisement packet received callback.
+	/**
+	 * @brief Advertisement packet received callback.
 	 *
-	 *  @param info Advertiser packet information.
-	 *  @param buf  Buffer containing advertiser data.
+	 * @param info Advertiser packet information.
+	 * @param buf  Buffer containing advertiser data.
 	 */
 	void (*recv)(const struct bt_le_scan_recv_info *info,
 		     struct net_buf_simple *buf);
@@ -1201,13 +1273,14 @@ struct bt_le_scan_cb {
 	sys_snode_t node;
 };
 
-/** @brief Initialize scan parameters
+/**
+ * @brief Initialize scan parameters
  *
- *  @param _type     Scan Type, BT_LE_SCAN_TYPE_ACTIVE or
- *                   BT_LE_SCAN_TYPE_PASSIVE.
- *  @param _options  Scan options
- *  @param _interval Scan Interval (N * 0.625 ms)
- *  @param _window   Scan Window (N * 0.625 ms)
+ * @param _type     Scan Type, BT_LE_SCAN_TYPE_ACTIVE or
+ *                  BT_LE_SCAN_TYPE_PASSIVE.
+ * @param _options  Scan options
+ * @param _interval Scan Interval (N * 0.625 ms)
+ * @param _window   Scan Window (N * 0.625 ms)
  */
 #define BT_LE_SCAN_PARAM_INIT(_type, _options, _interval, _window) \
 { \
@@ -1220,13 +1293,14 @@ struct bt_le_scan_cb {
 	.window_coded = 0, \
 }
 
-/** @brief Helper to declare scan parameters inline
+/**
+ * @brief Helper to declare scan parameters inline
  *
- *  @param _type     Scan Type, BT_LE_SCAN_TYPE_ACTIVE or
- *                   BT_LE_SCAN_TYPE_PASSIVE.
- *  @param _options  Scan options
- *  @param _interval Scan Interval (N * 0.625 ms)
- *  @param _window   Scan Window (N * 0.625 ms)
+ * @param _type     Scan Type, BT_LE_SCAN_TYPE_ACTIVE or
+ *                  BT_LE_SCAN_TYPE_PASSIVE.
+ * @param _options  Scan options
+ * @param _interval Scan Interval (N * 0.625 ms)
+ * @param _window   Scan Window (N * 0.625 ms)
  */
 #define BT_LE_SCAN_PARAM(_type, _options, _interval, _window) \
 	((struct bt_le_scan_param[]) { \
@@ -1239,122 +1313,131 @@ struct bt_le_scan_cb {
 					   BT_GAP_SCAN_FAST_INTERVAL, \
 					   BT_GAP_SCAN_FAST_WINDOW)
 
-/** @brief Helper macro to enable passive scanning to discover new devices.
+/**
+ * @brief Helper macro to enable passive scanning to discover new devices.
  *
- *  This macro should be used if information required for device identification
- *  (e.g., UUID) are known to be placed in Advertising Data.
+ * This macro should be used if information required for device identification
+ * (e.g., UUID) are known to be placed in Advertising Data.
  */
 #define BT_LE_SCAN_PASSIVE BT_LE_SCAN_PARAM(BT_LE_SCAN_TYPE_PASSIVE, \
 					    BT_LE_SCAN_OPT_FILTER_DUPLICATE, \
 					    BT_GAP_SCAN_FAST_INTERVAL, \
 					    BT_GAP_SCAN_FAST_WINDOW)
 
-/** @brief Start (LE) scanning
+/**
+ * @brief Start (LE) scanning
  *
- *  Start LE scanning with given parameters and provide results through
- *  the specified callback.
+ * Start LE scanning with given parameters and provide results through
+ * the specified callback.
  *
- *  @note The LE scanner by default does not use the Identity Address of the
- *        local device when :option:`CONFIG_BT_PRIVACY` is disabled. This is to
- *        prevent the active scanner from disclosing the identity information
- *        when requesting additional information from advertisers.
- *        In order to enable directed advertiser reports then
- *        :option:`CONFIG_BT_SCAN_WITH_IDENTITY` must be enabled.
+ * @note The LE scanner by default does not use the Identity Address of the
+ *       local device when @option{CONFIG_BT_PRIVACY} is disabled. This is to
+ *       prevent the active scanner from disclosing the identity information
+ *       when requesting additional information from advertisers.
+ *       In order to enable directed advertiser reports then
+ *       @option{CONFIG_BT_SCAN_WITH_IDENTITY} must be enabled.
  *
- *  @param param Scan parameters.
- *  @param cb Callback to notify scan results. May be NULL if callback
- *            registration through @ref bt_le_scan_cb_register is preferred.
+ * @param param Scan parameters.
+ * @param cb Callback to notify scan results. May be NULL if callback
+ *           registration through @ref bt_le_scan_cb_register is preferred.
  *
- *  @return Zero on success or error code otherwise, positive in case of
- *          protocol error or negative (POSIX) in case of stack internal error.
+ * @return Zero on success or error code otherwise, positive in case of
+ *         protocol error or negative (POSIX) in case of stack internal error.
  */
 int bt_le_scan_start(const struct bt_le_scan_param *param, bt_le_scan_cb_t cb);
 
-/** @brief Stop (LE) scanning.
+/**
+ * @brief Stop (LE) scanning.
  *
- *  Stops ongoing LE scanning.
+ * Stops ongoing LE scanning.
  *
- *  @return Zero on success or error code otherwise, positive in case of
- *          protocol error or negative (POSIX) in case of stack internal error.
+ * @return Zero on success or error code otherwise, positive in case of
+ *         protocol error or negative (POSIX) in case of stack internal error.
  */
 int bt_le_scan_stop(void);
 
-/** @brief Register scanner packet callbacks.
+/**
+ * @brief Register scanner packet callbacks.
  *
- *  Adds the callback structure to the list of callback structures that monitors
- *  scanner activity.
+ * Adds the callback structure to the list of callback structures that monitors
+ * scanner activity.
  *
- *  This callback will be called for all scanner activity, regardless of what
- *  API was used to start the scanner.
+ * This callback will be called for all scanner activity, regardless of what
+ * API was used to start the scanner.
  *
- *  @param cb Callback struct. Must point to static memory.
+ * @param cb Callback struct. Must point to static memory.
  */
 void bt_le_scan_cb_register(struct bt_le_scan_cb *cb);
 
-/** @brief Add device (LE) to whitelist.
+/**
+ * @brief Add device (LE) to whitelist.
  *
- *  Add peer device LE address to the whitelist.
+ * Add peer device LE address to the whitelist.
  *
- *  @note The whitelist cannot be modified when an LE role is using
- *  the whitelist, i.e advertiser or scanner using a whitelist or automatic
- *  connecting to devices using whitelist.
+ * @note The whitelist cannot be modified when an LE role is using
+ * the whitelist, i.e advertiser or scanner using a whitelist or automatic
+ * connecting to devices using whitelist.
  *
- *  @param addr Bluetooth LE identity address.
+ * @param addr Bluetooth LE identity address.
  *
- *  @return Zero on success or error code otherwise, positive in case of
- *          protocol error or negative (POSIX) in case of stack internal error.
+ * @return Zero on success or error code otherwise, positive in case of
+ *         protocol error or negative (POSIX) in case of stack internal error.
  */
 int bt_le_whitelist_add(const bt_addr_le_t *addr);
 
-/** @brief Remove device (LE) from whitelist.
+/**
+ * @brief Remove device (LE) from whitelist.
  *
- *  Remove peer device LE address from the whitelist.
+ * Remove peer device LE address from the whitelist.
  *
- *  @note The whitelist cannot be modified when an LE role is using
- *  the whitelist, i.e advertiser or scanner using a whitelist or automatic
- *  connecting to devices using whitelist.
+ * @note The whitelist cannot be modified when an LE role is using
+ * the whitelist, i.e advertiser or scanner using a whitelist or automatic
+ * connecting to devices using whitelist.
  *
- *  @param addr Bluetooth LE identity address.
+ * @param addr Bluetooth LE identity address.
  *
- *  @return Zero on success or error code otherwise, positive in case of
- *          protocol error or negative (POSIX) in case of stack internal error.
+ * @return Zero on success or error code otherwise, positive in case of
+ *         protocol error or negative (POSIX) in case of stack internal error.
  */
 int bt_le_whitelist_rem(const bt_addr_le_t *addr);
 
-/** @brief Clear whitelist.
+/**
+ * @brief Clear whitelist.
  *
- *  Clear all devices from the whitelist.
+ * Clear all devices from the whitelist.
  *
- *  @note The whitelist cannot be modified when an LE role is using
- *  the whitelist, i.e advertiser or scanner using a whitelist or automatic
- *  connecting to devices using whitelist.
+ * @note The whitelist cannot be modified when an LE role is using
+ * the whitelist, i.e advertiser or scanner using a whitelist or automatic
+ * connecting to devices using whitelist.
  *
- *  @return Zero on success or error code otherwise, positive in case of
- *          protocol error or negative (POSIX) in case of stack internal error.
+ * @return Zero on success or error code otherwise, positive in case of
+ *         protocol error or negative (POSIX) in case of stack internal error.
  */
 int bt_le_whitelist_clear(void);
 
-/** @brief Set (LE) channel map.
+/**
+ * @brief Set (LE) channel map.
  *
  * @param chan_map Channel map.
  *
- *  @return Zero on success or error code otherwise, positive in case of
- *          protocol error or negative (POSIX) in case of stack internal error.
+ * @return Zero on success or error code otherwise, positive in case of
+ *         protocol error or negative (POSIX) in case of stack internal error.
  */
 int bt_le_set_chan_map(uint8_t chan_map[5]);
 
-/** @brief Helper for parsing advertising (or EIR or OOB) data.
+/**
+ * @brief Helper for parsing advertising (or EIR or OOB) data.
  *
- *  A helper for parsing the basic data types used for Extended Inquiry
- *  Response (EIR), Advertising Data (AD), and OOB data blocks. The most
- *  common scenario is to call this helper on the advertising data
- *  received in the callback that was given to bt_le_scan_start().
+ * A helper for parsing the basic data types used for Extended Inquiry
+ * Response (EIR), Advertising Data (AD), and OOB data blocks. The most
+ * common scenario is to call this helper on the advertising data
+ * received in the callback that was given to bt_le_scan_start().
  *
- *  @param ad        Advertising data as given to the bt_le_scan_cb_t callback.
- *  @param func      Callback function which will be called for each element
- *                   that's found in the data. The callback should return
- *                   true to continue parsing, or false to stop parsing.
- *  @param user_data User data to be passed to the callback.
+ * @param ad        Advertising data as given to the bt_le_scan_cb_t callback.
+ * @param func      Callback function which will be called for each element
+ *                  that's found in the data. The callback should return
+ *                  true to continue parsing, or false to stop parsing.
+ * @param user_data User data to be passed to the callback.
  */
 void bt_data_parse(struct net_buf_simple *ad,
 		   bool (*func)(struct bt_data *data, void *user_data),
@@ -1380,57 +1463,59 @@ struct bt_le_oob {
 	struct bt_le_oob_sc_data le_sc_data;
 };
 
-/** @brief Get local LE Out of Band (OOB) information.
+/**
+ * @brief Get local LE Out of Band (OOB) information.
  *
- *  This function allows to get local information that are useful for
- *  Out of Band pairing or connection creation.
+ * This function allows to get local information that are useful for
+ * Out of Band pairing or connection creation.
  *
- *  If privacy :option:`CONFIG_BT_PRIVACY` is enabled this will result in
- *  generating new Resolvable Private Address (RPA) that is valid for
- *  :option:`CONFIG_BT_RPA_TIMEOUT` seconds. This address will be used for
- *  advertising started by @ref bt_le_adv_start, active scanning and
- *  connection creation.
+ * If privacy @option{CONFIG_BT_PRIVACY} is enabled this will result in
+ * generating new Resolvable Private Address (RPA) that is valid for
+ * @option{CONFIG_BT_RPA_TIMEOUT} seconds. This address will be used for
+ * advertising started by @ref bt_le_adv_start, active scanning and
+ * connection creation.
  *
- *  @note If privacy is enabled the RPA cannot be refreshed in the following
- *        cases:
- *        - Creating a connection in progress, wait for the connected callback.
- *       In addition when extended advertising :option:`CONFIG_BT_EXT_ADV` is
- *       not enabled or not supported by the controller:
- *        - Advertiser is enabled using a Random Static Identity Address for a
- *          different local identity.
- *        - The local identity conflicts with the local identity used by other
- *          roles.
+ * @note If privacy is enabled the RPA cannot be refreshed in the following
+ *       cases:
+ *       - Creating a connection in progress, wait for the connected callback.
+ *      In addition when extended advertising @option{CONFIG_BT_EXT_ADV} is
+ *      not enabled or not supported by the controller:
+ *       - Advertiser is enabled using a Random Static Identity Address for a
+ *         different local identity.
+ *       - The local identity conflicts with the local identity used by other
+ *         roles.
  *
- *  @param[in]  id  Local identity, in most cases BT_ID_DEFAULT.
- *  @param[out] oob LE OOB information
+ * @param[in]  id  Local identity, in most cases BT_ID_DEFAULT.
+ * @param[out] oob LE OOB information
  *
- *  @return Zero on success or error code otherwise, positive in case of
- *          protocol error or negative (POSIX) in case of stack internal error.
+ * @return Zero on success or error code otherwise, positive in case of
+ *         protocol error or negative (POSIX) in case of stack internal error.
  */
 int bt_le_oob_get_local(uint8_t id, struct bt_le_oob *oob);
 
-/** @brief Get local LE Out of Band (OOB) information.
+/**
+ * @brief Get local LE Out of Band (OOB) information.
  *
- *  This function allows to get local information that are useful for
- *  Out of Band pairing or connection creation.
+ * This function allows to get local information that are useful for
+ * Out of Band pairing or connection creation.
  *
- *  If privacy :option:`CONFIG_BT_PRIVACY` is enabled this will result in
- *  generating new Resolvable Private Address (RPA) that is valid for
- *  :option:`CONFIG_BT_RPA_TIMEOUT` seconds. This address will be used by the
- *  advertising set.
+ * If privacy @option{CONFIG_BT_PRIVACY} is enabled this will result in
+ * generating new Resolvable Private Address (RPA) that is valid for
+ * @option{CONFIG_BT_RPA_TIMEOUT} seconds. This address will be used by the
+ * advertising set.
  *
- *  @note When generating OOB information for multiple advertising set all
- *        OOB information needs to be generated at the same time.
+ * @note When generating OOB information for multiple advertising set all
+ *       OOB information needs to be generated at the same time.
  *
- *  @note If privacy is enabled the RPA cannot be refreshed in the following
- *        cases:
- *        - Creating a connection in progress, wait for the connected callback.
+ * @note If privacy is enabled the RPA cannot be refreshed in the following
+ *       cases:
+ *       - Creating a connection in progress, wait for the connected callback.
  *
- *  @param[in]  adv The advertising set object
- *  @param[out] oob LE OOB information
+ * @param[in]  adv The advertising set object
+ * @param[out] oob LE OOB information
  *
- *  @return Zero on success or error code otherwise, positive in case
- *  of protocol error or negative (POSIX) in case of stack internal error.
+ * @return Zero on success or error code otherwise, positive in case
+ * of protocol error or negative (POSIX) in case of stack internal error.
  */
 int bt_le_ext_adv_oob_get_local(struct bt_le_ext_adv *adv,
 				struct bt_le_oob *oob);
@@ -1453,16 +1538,17 @@ struct bt_br_discovery_result {
 	uint8_t eir[240];
 };
 
-/** @typedef bt_br_discovery_cb_t
- *  @brief Callback type for reporting BR/EDR discovery (inquiry)
- *         results.
+/**
+ * @typedef bt_br_discovery_cb_t
+ * @brief Callback type for reporting BR/EDR discovery (inquiry)
+ *        results.
  *
- *  A callback of this type is given to the bt_br_discovery_start()
- *  function and will be called at the end of the discovery with
- *  information about found devices populated in the results array.
+ * A callback of this type is given to the bt_br_discovery_start()
+ * function and will be called at the end of the discovery with
+ * information about found devices populated in the results array.
  *
- *  @param results Storage used for discovery results
- *  @param count Number of valid discovery results.
+ * @param results Storage used for discovery results
+ * @param count Number of valid discovery results.
  */
 typedef void bt_br_discovery_cb_t(struct bt_br_discovery_result *results,
 				  size_t count);
@@ -1478,33 +1564,35 @@ struct bt_br_discovery_param {
 	bool limited;
 };
 
-/** @brief Start BR/EDR discovery
+/**
+ * @brief Start BR/EDR discovery
  *
- *  Start BR/EDR discovery (inquiry) and provide results through the specified
- *  callback. When bt_br_discovery_cb_t is called it indicates that discovery
- *  has completed. If more inquiry results were received during session than
- *  fits in provided result storage, only ones with highest RSSI will be
- *  reported.
+ * Start BR/EDR discovery (inquiry) and provide results through the specified
+ * callback. When bt_br_discovery_cb_t is called it indicates that discovery
+ * has completed. If more inquiry results were received during session than
+ * fits in provided result storage, only ones with highest RSSI will be
+ * reported.
  *
- *  @param param Discovery parameters.
- *  @param results Storage for discovery results.
- *  @param count Number of results in storage. Valid range: 1-255.
- *  @param cb Callback to notify discovery results.
+ * @param param Discovery parameters.
+ * @param results Storage for discovery results.
+ * @param count Number of results in storage. Valid range: 1-255.
+ * @param cb Callback to notify discovery results.
  *
- *  @return Zero on success or error code otherwise, positive in case
- *  of protocol error or negative (POSIX) in case of stack internal error
+ * @return Zero on success or error code otherwise, positive in case
+ * of protocol error or negative (POSIX) in case of stack internal error
  */
 int bt_br_discovery_start(const struct bt_br_discovery_param *param,
 			  struct bt_br_discovery_result *results, size_t count,
 			  bt_br_discovery_cb_t cb);
 
-/** @brief Stop BR/EDR discovery.
+/**
+ * @brief Stop BR/EDR discovery.
  *
- *  Stops ongoing BR/EDR discovery. If discovery was stopped by this call
- *  results won't be reported
+ * Stops ongoing BR/EDR discovery. If discovery was stopped by this call
+ * results won't be reported
  *
- *  @return Zero on success or error code otherwise, positive in case of
- *          protocol error or negative (POSIX) in case of stack internal error.
+ * @return Zero on success or error code otherwise, positive in case of
+ *         protocol error or negative (POSIX) in case of stack internal error.
  */
 int bt_br_discovery_stop(void);
 
@@ -1513,44 +1601,48 @@ struct bt_br_oob {
 	bt_addr_t addr;
 };
 
-/** @brief Get BR/EDR local Out Of Band information
+/**
+ * @brief Get BR/EDR local Out Of Band information
  *
- *  This function allows to get local controller information that are useful
- *  for Out Of Band pairing or connection creation process.
+ * This function allows to get local controller information that are useful
+ * for Out Of Band pairing or connection creation process.
  *
- *  @param oob Out Of Band information
+ * @param oob Out Of Band information
  */
 int bt_br_oob_get_local(struct bt_br_oob *oob);
 
-/** @def BT_ADDR_STR_LEN
+/**
+ * @def BT_ADDR_STR_LEN
  *
- *  @brief Recommended length of user string buffer for Bluetooth address
+ * @brief Recommended length of user string buffer for Bluetooth address
  *
- *  @details The recommended length guarantee the output of address
- *  conversion will not lose valuable information about address being
- *  processed.
+ * @details The recommended length guarantee the output of address
+ * conversion will not lose valuable information about address being
+ * processed.
  */
 #define BT_ADDR_STR_LEN 18
 
-/** @def BT_ADDR_LE_STR_LEN
+/**
+ * @def BT_ADDR_LE_STR_LEN
  *
- *  @brief Recommended length of user string buffer for Bluetooth LE address
+ * @brief Recommended length of user string buffer for Bluetooth LE address
  *
- *  @details The recommended length guarantee the output of address
- *  conversion will not lose valuable information about address being
- *  processed.
+ * @details The recommended length guarantee the output of address
+ * conversion will not lose valuable information about address being
+ * processed.
  */
 #define BT_ADDR_LE_STR_LEN 30
 
-/** @brief Converts binary Bluetooth address to string.
+/**
+ * @brief Converts binary Bluetooth address to string.
  *
- *  @param addr Address of buffer containing binary Bluetooth address.
- *  @param str Address of user buffer with enough room to store formatted
- *  string containing binary address.
- *  @param len Length of data to be copied to user string buffer. Refer to
- *  BT_ADDR_STR_LEN about recommended value.
+ * @param addr Address of buffer containing binary Bluetooth address.
+ * @param str Address of user buffer with enough room to store formatted
+ * string containing binary address.
+ * @param len Length of data to be copied to user string buffer. Refer to
+ * BT_ADDR_STR_LEN about recommended value.
  *
- *  @return Number of successfully formatted bytes from binary address.
+ * @return Number of successfully formatted bytes from binary address.
  */
 static inline int bt_addr_to_str(const bt_addr_t *addr, char *str, size_t len)
 {
@@ -1559,15 +1651,16 @@ static inline int bt_addr_to_str(const bt_addr_t *addr, char *str, size_t len)
 			addr->val[2], addr->val[1], addr->val[0]);
 }
 
-/** @brief Converts binary LE Bluetooth address to string.
+/**
+ * @brief Converts binary LE Bluetooth address to string.
  *
- *  @param addr Address of buffer containing binary LE Bluetooth address.
- *  @param str Address of user buffer with enough room to store
- *  formatted string containing binary LE address.
- *  @param len Length of data to be copied to user string buffer. Refer to
- *  BT_ADDR_LE_STR_LEN about recommended value.
+ * @param addr Address of buffer containing binary LE Bluetooth address.
+ * @param str Address of user buffer with enough room to store
+ * formatted string containing binary LE address.
+ * @param len Length of data to be copied to user string buffer. Refer to
+ * BT_ADDR_LE_STR_LEN about recommended value.
  *
- *  @return Number of successfully formatted bytes from binary address.
+ * @return Number of successfully formatted bytes from binary address.
  */
 static inline int bt_addr_le_to_str(const bt_addr_le_t *addr, char *str,
 				    size_t len)
@@ -1597,59 +1690,64 @@ static inline int bt_addr_le_to_str(const bt_addr_le_t *addr, char *str,
 			addr->a.val[2], addr->a.val[1], addr->a.val[0], type);
 }
 
-/** @brief Convert Bluetooth address from string to binary.
+/**
+ * @brief Convert Bluetooth address from string to binary.
  *
- *  @param[in]  str   The string representation of a Bluetooth address.
- *  @param[out] addr  Address of buffer to store the Bluetooth address
+ * @param[in]  str   The string representation of a Bluetooth address.
+ * @param[out] addr  Address of buffer to store the Bluetooth address
  *
- *  @return Zero on success or (negative) error code otherwise.
+ * @return Zero on success or (negative) error code otherwise.
  */
 int bt_addr_from_str(const char *str, bt_addr_t *addr);
 
-/** @brief Convert LE Bluetooth address from string to binary.
+/**
+ * @brief Convert LE Bluetooth address from string to binary.
  *
- *  @param[in]  str   The string representation of an LE Bluetooth address.
- *  @param[in]  type  The string representation of the LE Bluetooth address
- *                    type.
- *  @param[out] addr  Address of buffer to store the LE Bluetooth address
+ * @param[in]  str   The string representation of an LE Bluetooth address.
+ * @param[in]  type  The string representation of the LE Bluetooth address
+ *                   type.
+ * @param[out] addr  Address of buffer to store the LE Bluetooth address
  *
- *  @return Zero on success or (negative) error code otherwise.
+ * @return Zero on success or (negative) error code otherwise.
  */
 int bt_addr_le_from_str(const char *str, const char *type, bt_addr_le_t *addr);
 
-/** @brief Enable/disable set controller in discoverable state.
+/**
+ * @brief Enable/disable set controller in discoverable state.
  *
- *  Allows make local controller to listen on INQUIRY SCAN channel and responds
- *  to devices making general inquiry. To enable this state it's mandatory
- *  to first be in connectable state.
+ * Allows make local controller to listen on INQUIRY SCAN channel and responds
+ * to devices making general inquiry. To enable this state it's mandatory
+ * to first be in connectable state.
  *
- *  @param enable Value allowing/disallowing controller to become discoverable.
+ * @param enable Value allowing/disallowing controller to become discoverable.
  *
- *  @return Negative if fail set to requested state or requested state has been
- *          already set. Zero if done successfully.
+ * @return Negative if fail set to requested state or requested state has been
+ *         already set. Zero if done successfully.
  */
 int bt_br_set_discoverable(bool enable);
 
-/** @brief Enable/disable set controller in connectable state.
+/**
+ * @brief Enable/disable set controller in connectable state.
  *
- *  Allows make local controller to be connectable. It means the controller
- *  start listen to devices requests on PAGE SCAN channel. If disabled also
- *  resets discoverability if was set.
+ * Allows make local controller to be connectable. It means the controller
+ * start listen to devices requests on PAGE SCAN channel. If disabled also
+ * resets discoverability if was set.
  *
- *  @param enable Value allowing/disallowing controller to be connectable.
+ * @param enable Value allowing/disallowing controller to be connectable.
  *
- *  @return Negative if fail set to requested state or requested state has been
- *          already set. Zero if done successfully.
+ * @return Negative if fail set to requested state or requested state has been
+ *         already set. Zero if done successfully.
  */
 int bt_br_set_connectable(bool enable);
 
-/** @brief Clear pairing information.
+/**
+ * @brief Clear pairing information.
  *
- *  @param id    Local identity (mostly just BT_ID_DEFAULT).
- *  @param addr  Remote address, NULL or BT_ADDR_LE_ANY to clear all remote
- *               devices.
+ * @param id    Local identity (mostly just BT_ID_DEFAULT).
+ * @param addr  Remote address, NULL or BT_ADDR_LE_ANY to clear all remote
+ *              devices.
  *
- *  @return 0 on success or negative error value on failure.
+ * @return 0 on success or negative error value on failure.
  */
 int bt_unpair(uint8_t id, const bt_addr_le_t *addr);
 
@@ -1659,11 +1757,12 @@ struct bt_bond_info {
 	bt_addr_le_t addr;
 };
 
-/** @brief Iterate through all existing bonds.
+/**
+ * @brief Iterate through all existing bonds.
  *
- *  @param id         Local identity (mostly just BT_ID_DEFAULT).
- *  @param func       Function to call for each bond.
- *  @param user_data  Data to pass to the callback function.
+ * @param id         Local identity (mostly just BT_ID_DEFAULT).
+ * @param func       Function to call for each bond.
+ * @param user_data  Data to pass to the callback function.
  */
 void bt_foreach_bond(uint8_t id, void (*func)(const struct bt_bond_info *info,
 					   void *user_data),

--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -343,7 +343,7 @@ struct bt_conn_br_remote_info {
 /** @brief Connection Remote Info Structure
  *
  *  @note The version, manufacturer and subversion fields will only contain
- *        valid data if :option:`CONFIG_BT_REMOTE_VERSION` is enabled.
+ *        valid data if @option{CONFIG_BT_REMOTE_VERSION} is enabled.
  */
 struct bt_conn_remote_info {
 	/** Connection Type */
@@ -382,7 +382,7 @@ int bt_conn_get_info(const struct bt_conn *conn, struct bt_conn_info *info);
  *  @param remote_info Connection remote info object.
  *
  *  @note In order to retrieve the remote version (version, manufacturer
- *  and subversion) :option:`CONFIG_BT_REMOTE_VERSION` must be enabled
+ *  and subversion) @option{CONFIG_BT_REMOTE_VERSION} must be enabled
  *
  *  @note The remote information is exchanged directly after the connection has
  *  been established. The application can be notified about when the remote
@@ -483,7 +483,7 @@ struct bt_conn_le_create_param {
 
 	/** @brief Connection initiation timeout (N * 10 MS)
 	 *
-	 *  Set zero to use the default :option:`CONFIG_BT_CREATE_CONN_TIMEOUT`
+	 *  Set zero to use the default @option{CONFIG_BT_CREATE_CONN_TIMEOUT}
 	 *  timeout.
 	 *
 	 *  @note Unused in @ref bt_conn_create_auto_le
@@ -708,10 +708,10 @@ typedef enum __packed {
  *  This function may return error if the pairing procedure has already been
  *  initiated by the local device or the peer device.
  *
- *  @note When :option:`CONFIG_BT_SMP_SC_ONLY` is enabled then the security
+ *  @note When @option{CONFIG_BT_SMP_SC_ONLY} is enabled then the security
  *        level will always be level 4.
  *
- *  @note When :option:`CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY` is enabled then the
+ *  @note When @option{CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY} is enabled then the
  *        security level will always be level 3.
  *
  *  @param conn Connection object.
@@ -798,7 +798,7 @@ struct bt_conn_cb {
 	 *    @ref bt_conn_create_le was canceled either by the user through
 	 *    @ref bt_conn_disconnect or by the timeout in the host through
 	 *    @ref bt_conn_le_create_param timeout parameter, which defaults to
-	 *    :option:`CONFIG_BT_CREATE_CONN_TIMEOUT` seconds.
+	 *    @option{CONFIG_BT_CREATE_CONN_TIMEOUT} seconds.
 	 *  - @p BT_HCI_ERR_ADV_TIMEOUT High duty cycle directed connectable
 	 *    advertiser started by @ref bt_le_adv_start failed to be connected
 	 *    within the timeout.
@@ -817,7 +817,7 @@ struct bt_conn_cb {
 	 *  available.
 	 *  To avoid this issue it is recommended to either start connectable
 	 *  advertise or create a new connection using @ref k_work_submit or
-	 *  increase :option:`CONFIG_BT_MAX_CONN`.
+	 *  increase @option{CONFIG_BT_MAX_CONN}.
 	 *
 	 *  @param conn Connection object.
 	 *  @param reason HCI reason for the disconnection.

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -306,11 +306,11 @@ struct bt_gatt_cpf {
  *  macros such as BT_GATT_PRIMARY_SERVICE, BT_GATT_CHARACTERISTIC,
  *  BT_GATT_DESCRIPTOR, etc.
  *
- *  When using :option:`CONFIG_BT_SETTINGS` then all services that should have
+ *  When using @option{CONFIG_BT_SETTINGS} then all services that should have
  *  bond configuration loaded, i.e. CCC values, must be registered before
  *  calling @ref settings_load.
  *
- *  When using :option:`CONFIG_BT_GATT_CACHING` and :option:`CONFIG_BT_SETTINGS`
+ *  When using @option{CONFIG_BT_GATT_CACHING} and @option{CONFIG_BT_SETTINGS}
  *  then all services that should be included in the GATT Database Hash
  *  calculation should be added before calling @ref settings_load.
  *  All services registered after settings_load will trigger a new database hash

--- a/include/fs/littlefs.h
+++ b/include/fs/littlefs.h
@@ -57,15 +57,15 @@ struct fs_littlefs {
  * values are consistent with littlefs requirements.
  *
  * @note If you use a non-default configuration for cache size, you
- * must also select :option:`CONFIG_FS_LITTLEFS_FC_MEM_POOL` to relax
+ * must also select @option{CONFIG_FS_LITTLEFS_FC_MEM_POOL} to relax
  * the size constraints on per-file cache allocations.
  *
  * @param name the name for the structure.  The defined object has
  * file scope.
- * @param read_sz see :option:`CONFIG_FS_LITTLEFS_READ_SIZE`
- * @param prog_sz see :option:`CONFIG_FS_LITTLEFS_PROG_SIZE`
- * @param cache_sz see :option:`CONFIG_FS_LITTLEFS_CACHE_SIZE`
- * @param lookahead_sz see :option:`CONFIG_FS_LITTLEFS_LOOKAHEAD_SIZE`
+ * @param read_sz see @option{CONFIG_FS_LITTLEFS_READ_SIZE}
+ * @param prog_sz see @option{CONFIG_FS_LITTLEFS_PROG_SIZE}
+ * @param cache_sz see @option{CONFIG_FS_LITTLEFS_CACHE_SIZE}
+ * @param lookahead_sz see @option{CONFIG_FS_LITTLEFS_LOOKAHEAD_SIZE}
  */
 #define FS_LITTLEFS_DECLARE_CUSTOM_CONFIG(name, read_sz, prog_sz, cache_sz, lookahead_sz) \
 	static uint8_t __aligned(4) name ## _read_buffer[cache_sz];			  \

--- a/include/fs/littlefs.h
+++ b/include/fs/littlefs.h
@@ -49,7 +49,7 @@ struct fs_littlefs {
  * object.
  *
  * To define an instance for the Kconfig defaults, use
- * :cpp:func:`FS_LITTLEFS_DECLARE_DEFAULT_CONFIG`.
+ * :c:macro:`FS_LITTLEFS_DECLARE_DEFAULT_CONFIG`.
  *
  * To completely control file system configuration the application can
  * directly define and initialize a :c:type:`struct fs_littlefs`

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -670,7 +670,7 @@ typedef void (*k_thread_user_cb_t)(const struct k_thread *thread,
  * @param user_cb Pointer to the user callback function.
  * @param user_data Pointer to user data.
  *
- * @note CONFIG_THREAD_MONITOR must be set for this function
+ * @note @option{CONFIG_THREAD_MONITOR} must be set for this function
  * to be effective.
  * @note This API uses @ref k_spin_lock to protect the _kernel.threads
  * list which means creation of new threads and terminations of existing
@@ -689,7 +689,7 @@ extern void k_thread_foreach(k_thread_user_cb_t user_cb, void *user_data);
  * @param user_cb Pointer to the user callback function.
  * @param user_data Pointer to user data.
  *
- * @note CONFIG_THREAD_MONITOR must be set for this function
+ * @note @option{CONFIG_THREAD_MONITOR} must be set for this function
  * to be effective.
  * @note This API uses @ref k_spin_lock only when accessing the _kernel.threads
  * queue elements. It unlocks it during user callback function processing.
@@ -751,8 +751,8 @@ extern void k_thread_foreach_unlocked(
  *
  * @details
  * Indicates that the thread being created should inherit all kernel object
- * permissions from the thread that created it. No effect if CONFIG_USERSPACE
- * is not enabled.
+ * permissions from the thread that created it. No effect if
+ * @option{CONFIG_USERSPACE} is not enabled.
  */
 #define K_INHERIT_PERMS (BIT(3))
 
@@ -879,8 +879,8 @@ static inline void k_thread_resource_pool_assign(struct k_thread *thread,
  *
  * Some hardware may prevent inspection of a stack buffer currently in use.
  * If this API is called from supervisor mode, on the currently running thread,
- * on a platform which selects CONFIG_NO_UNUSED_STACK_INSPECTION, an error
- * will be generated.
+ * on a platform which selects @option{CONFIG_NO_UNUSED_STACK_INSPECTION}, an
+ * error will be generated.
  *
  * @param thread Thread to inspect stack information
  * @param unused_ptr Output parameter, filled in with the unused stack space
@@ -964,9 +964,10 @@ static inline int32_t k_msleep(int32_t ms)
  *
  * This function is unlikely to work as expected without kernel tuning.
  * In particular, because the lower bound on the duration of a sleep is
- * the duration of a tick, CONFIG_SYS_CLOCK_TICKS_PER_SEC must be adjusted
- * to achieve the resolution desired. The implications of doing this must
- * be understood before attempting to use k_usleep(). Use with caution.
+ * the duration of a tick, @option{CONFIG_SYS_CLOCK_TICKS_PER_SEC} must be
+ * adjusted to achieve the resolution desired. The implications of doing
+ * this must be understood before attempting to use k_usleep(). Use with
+ * caution.
  *
  * @param us Number of microseconds to sleep.
  *
@@ -1239,11 +1240,8 @@ __syscall void k_thread_priority_set(k_tid_t thread, int prio);
  * above this call, which is simply input to the priority selection
  * logic.
  *
- * @note
- *    @rst
- *    You should enable :option:`CONFIG_SCHED_DEADLINE` in your project
- *    configuration.
- *    @endrst
+ * @note You should enable @option{CONFIG_SCHED_DEADLINE} in your project
+ * configuration.
  *
  * @param thread A thread on which to set the deadline
  * @param deadline A time delta, in cycle units
@@ -1259,11 +1257,8 @@ __syscall void k_thread_deadline_set(k_tid_t thread, int deadline);
  * After this returns, the thread will no longer be schedulable on any
  * CPUs.  The thread must not be currently runnable.
  *
- * @note
- *    @rst
- *    You should enable :option:`CONFIG_SCHED_DEADLINE` in your project
- *    configuration.
- *    @endrst
+ * @note You should enable @option{CONFIG_SCHED_DEADLINE} in your project
+ * configuration.
  *
  * @param thread Thread to operate upon
  * @return Zero on success, otherwise error code
@@ -1276,11 +1271,8 @@ int k_thread_cpu_mask_clear(k_tid_t thread);
  * After this returns, the thread will be schedulable on any CPU.  The
  * thread must not be currently runnable.
  *
- * @note
- *    @rst
- *    You should enable :option:`CONFIG_SCHED_DEADLINE` in your project
- *    configuration.
- *    @endrst
+ * @note You should enable @option{CONFIG_SCHED_DEADLINE} in your project
+ * configuration.
  *
  * @param thread Thread to operate upon
  * @return Zero on success, otherwise error code
@@ -1292,11 +1284,8 @@ int k_thread_cpu_mask_enable_all(k_tid_t thread);
  *
  * The thread must not be currently runnable.
  *
- * @note
- *    @rst
- *    You should enable :option:`CONFIG_SCHED_DEADLINE` in your project
- *    configuration.
- *    @endrst
+ * @note You should enable @option{CONFIG_SCHED_DEADLINE} in your project
+ * configuration.
  *
  * @param thread Thread to operate upon
  * @param cpu CPU index
@@ -1309,11 +1298,8 @@ int k_thread_cpu_mask_enable(k_tid_t thread, int cpu);
  *
  * The thread must not be currently runnable.
  *
- * @note
- *    @rst
- *    You should enable :option:`CONFIG_SCHED_DEADLINE` in your project
- *    configuration.
- *    @endrst
+ * @note You should enable @option{CONFIG_SCHED_DEADLINE} in your project
+ * configuration.
  *
  * @param thread Thread to operate upon
  * @param cpu CPU index
@@ -1509,8 +1495,8 @@ __syscall void *k_thread_custom_data_get(void);
 /**
  * @brief Set current thread name
  *
- * Set the name of the thread to be used when THREAD_MONITOR is enabled for
- * tracing and debugging.
+ * Set the name of the thread to be used when @option{CONFIG_THREAD_MONITOR}
+ * is enabled for tracing and debugging.
  *
  * @param thread_id Thread to set name, or NULL to set the current thread
  * @param value Name string
@@ -2050,7 +2036,7 @@ static inline void *z_impl_k_timer_user_data_get(struct k_timer *timer)
  * @brief Get system uptime, in system ticks.
  *
  * This routine returns the elapsed time since the system booted, in
- * ticks (c.f. :option:`CONFIG_SYS_CLOCK_TICKS_PER_SEC`), which is the
+ * ticks (c.f. @option{CONFIG_SYS_CLOCK_TICKS_PER_SEC}), which is the
  * fundamental unit of resolution of kernel timekeeping.
  *
  * @return Current uptime in ticks.
@@ -2064,11 +2050,9 @@ __syscall int64_t k_uptime_ticks(void);
  * in milliseconds.
  *
  * @note
- *    @rst
  *    While this function returns time in milliseconds, it does
  *    not mean it has millisecond resolution. The actual resolution depends on
- *    :option:`CONFIG_SYS_CLOCK_TICKS_PER_SEC` config option.
- *    @endrst
+ *    @option{CONFIG_SYS_CLOCK_TICKS_PER_SEC} config option.
  *
  * @return Current uptime in milliseconds.
  */
@@ -2081,8 +2065,8 @@ static inline int64_t k_uptime_get(void)
  * @brief Enable clock always on in tickless kernel
  *
  * Deprecated.  This does nothing (it was always just a hint).  This
- * functionality has been migrated to the SYSTEM_CLOCK_SLOPPY_IDLE
- * kconfig.
+ * functionality has been migrated to the
+ * @option{CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE} config option.
  *
  * @retval prev_status Previous status of always on flag
  */
@@ -2100,8 +2084,8 @@ __deprecated static inline int k_enable_sys_clock_always_on(void)
  * @brief Disable clock always on in tickless kernel
  *
  * Deprecated.  This does nothing (it was always just a hint).  This
- * functionality has been migrated to the SYS_CLOCK_SLOPPY_IDLE
- * kconfig.
+ * functionality has been migrated to the
+ * @option{CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE} config option.
  */
 /* LCOV_EXCL_START */
 __deprecated static inline void k_disable_sys_clock_always_on(void)
@@ -2124,11 +2108,9 @@ __deprecated static inline void k_disable_sys_clock_always_on(void)
  * interrupt blocking and 64-bit math.
  *
  * @note
- *    @rst
  *    While this function returns time in milliseconds, it does
  *    not mean it has millisecond resolution. The actual resolution depends on
- *    :option:`CONFIG_SYS_CLOCK_TICKS_PER_SEC` config option
- *    @endrst
+ *    @option{CONFIG_SYS_CLOCK_TICKS_PER_SEC} config option
  *
  * @return The low 32 bits of the current uptime, in milliseconds.
  */
@@ -4764,7 +4746,7 @@ void k_heap_free(struct k_heap *h, void *mem);
  * If the pool is to be accessed outside the module where it is defined, it
  * can be declared via
  *
- * @note When CONFIG_MEM_POOL_HEAP_BACKEND is enabled, the k_mem_pool
+ * @note When @option{CONFIG_MEM_POOL_HEAP_BACKEND} is enabled, the k_mem_pool
  * API is implemented on top of a k_heap, which is a more general
  * purpose allocator which does not make the same promises about
  * splitting or alignment detailed above.  Blocks will be aligned only

--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -571,10 +571,8 @@ int mqtt_client_set_proxy(struct mqtt_client *client,
  * @note Default protocol revision used for connection request is 3.1.1. Please
  *       set client.protocol_version = MQTT_VERSION_3_1_0 to use protocol 3.1.0.
  * @note
- *       @rst
- *          Please modify :option:`CONFIG_MQTT_KEEPALIVE` time to override
- *          default of 1 minute.
- *       @endrst
+ *       Please modify @option{CONFIG_MQTT_KEEPALIVE} time to override default
+ *       of 1 minute.
  */
 int mqtt_connect(struct mqtt_client *client);
 

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -904,11 +904,8 @@ void shell_help(const struct shell *shell);
 
  *
  * @param[in] shell	Pointer to the shell instance.
- *			@rst
- *			It can be NULL when
- *			the :option:`CONFIG_SHELL_BACKEND_DUMMY` option is
- *			enabled.
- *			@endrst
+ *			It can be NULL when the
+ *			@option{CONFIG_SHELL_BACKEND_DUMMY} option is enabled.
  * @param[in] cmd	Command to be executed.
  *
  * @returns		Result of the execution

--- a/include/sys/notify.h
+++ b/include/sys/notify.h
@@ -280,10 +280,8 @@ static inline void sys_notify_init_spinwait(struct sys_notify *notify)
  * reinitialized before it can be re-used.
  *
  * @note
- *   @rst
- *   This capability is available only when :option:`CONFIG_POLL` is
+ *   This capability is available only when @option{CONFIG_POLL} is
  *   selected.
- *   @endrst
  *
  * @param notify pointer to the notification configuration object.
  *

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,6 +1,6 @@
 # DOC: used to generate docs
 
-breathe>=4.20.0
+breathe>=4.21.0
 docutils>=0.16
 sphinx>=3.2.0,<4.0
 sphinx_rtd_theme


### PR DESCRIPTION
This PR updates Breathe to 4.21.0 to bring in a few interesting features that improve the generated documentation.

A new `separate_member_pages` config option that patches issues in the Doxygen XML generated when SEPARATE_MEMBER_PAGES option is YES. This fixes around 650 broken references (based on my grep foo!).

A new rST verbatim mode that allows producing inline elements is used to create a Doxygen `@option`  ALIAS that can be used to for adding Kconfig symbols in this format: `@option{KCONFIG_FOO}`. Those can be added inline in the documentation header and will have proper references added when producing the documentation.