### PR TITLE
tests: usb: add fixture requirement

### DIFF
--- a/samples/subsys/usb/console/sample.yaml
+++ b/samples/subsys/usb/console/sample.yaml
@@ -4,3 +4,6 @@ tests:
   sample.usb.console:
     depends_on: usb_device usb_cdc
     tags: usb
+    harness: console
+    harness_config:
+      fixture: fixture_usb_cdc


### PR DESCRIPTION
The test for this sample requires a usb connection to a secondary port,
output is not captured on the default usb port.

Fixes #28154