### PR TITLE
boards: doc update for cc32xx and cc13x2/cc26x2 boards

### DIFF
--- a/boards/arm/cc1352r1_launchxl/doc/index.rst
+++ b/boards/arm/cc1352r1_launchxl/doc/index.rst
@@ -128,6 +128,31 @@ Before flashing or debugging ensure the RESET, TMS, TCK, TDO, and TDI jumpers
 are in place. Also place jumpers on the the TXD and RXD signals for a serial
 console using the XDS110 application serial port.
 
+Prerequisites:
+==============
+
+#. Ensure the XDS-110 emulation firmware on the board is updated.
+
+   Download and install the latest `XDS-110 emulation package`_.
+
+   Follow these `xds110 firmware update directions
+   <http://software-dl.ti.com/ccs/esd/documents/xdsdebugprobes/emu_xds110.html#updating-the-xds110-firmware>`_
+
+   Note that the emulation package install may place the xdsdfu utility
+   in ``<install_dir>/ccs_base/common/uscif/xds110/``.
+
+#. Install OpenOCD
+
+   You can obtain OpenOCD by following these
+   :ref:`installing the latest Zephyr SDK instructions <zephyr_sdk>`.
+
+   After the installation, add the directory containing the OpenOCD executable
+   to your environment's PATH variable. For example, use this command in Linux:
+
+   .. code-block:: console
+
+      export PATH=$ZEPHYR_SDK_INSTALL_DIR/sysroots/x86_64-pokysdk-linux/usr/bin/openocd:$PATH
+
 Flashing
 ========
 
@@ -212,3 +237,6 @@ CC1352R1 LaunchPad Quick Start Guide:
 
 .. _TI CC13x2 / CC26x2 Technical Reference Manual:
    http://www.ti.com/lit/pdf/swcu185
+
+..  _XDS-110 emulation package:
+   http://processors.wiki.ti.com/index.php/XDS_Emulation_Software_Package#XDS_Emulation_Software_.28emupack.29_Download

--- a/boards/arm/cc26x2r1_launchxl/doc/index.rst
+++ b/boards/arm/cc26x2r1_launchxl/doc/index.rst
@@ -134,6 +134,31 @@ Before flashing or debugging ensure the RESET, TMS, TCK, TDO, and TDI jumpers
 are in place. Also place jumpers on the the TXD and RXD signals for a serial
 console using the XDS110 application serial port.
 
+Prerequisites:
+==============
+
+#. Ensure the XDS-110 emulation firmware on the board is updated.
+
+   Download and install the latest `XDS-110 emulation package`_.
+
+   Follow these `xds110 firmware update directions
+   <http://software-dl.ti.com/ccs/esd/documents/xdsdebugprobes/emu_xds110.html#updating-the-xds110-firmware>`_
+
+   Note that the emulation package install may place the xdsdfu utility
+   in ``<install_dir>/ccs_base/common/uscif/xds110/``.
+
+#. Install OpenOCD
+
+   You can obtain OpenOCD by following these
+   :ref:`installing the latest Zephyr SDK instructions <zephyr_sdk>`.
+
+   After the installation, add the directory containing the OpenOCD executable
+   to your environment's PATH variable. For example, use this command in Linux:
+
+   .. code-block:: console
+
+      export PATH=$ZEPHYR_SDK_INSTALL_DIR/sysroots/x86_64-pokysdk-linux/usr/bin/openocd:$PATH
+
 Flashing
 ========
 
@@ -224,3 +249,6 @@ CC26X2R1 LaunchPad Quick Start Guide:
 
 .. _TI CC13x2 / CC26x2 Technical Reference Manual:
    http://www.ti.com/lit/pdf/swcu185
+
+..  _XDS-110 emulation package:
+   http://processors.wiki.ti.com/index.php/XDS_Emulation_Software_Package#XDS_Emulation_Software_.28emupack.29_Download

--- a/boards/arm/cc3220sf_launchxl/doc/index.rst
+++ b/boards/arm/cc3220sf_launchxl/doc/index.rst
@@ -214,7 +214,7 @@ To see program output from UART0, connect a separate terminal window:
 
 Then press the reset button (SW1) on the board to run the program.
 
-When using OpenOCD from Zephyr SDK 0.10.3 to flash the device, you may notice
+When using OpenOCD from Zephyr SDK to flash the device, you may notice
 the program hangs when starting the network processor on the device, if the
 program uses it. There is a known issue with how that version of OpenOCD
 resets the network processor. You would need to manually hit the reset button
@@ -290,11 +290,6 @@ example.
 
 See the document `Simplelink Wi-Fi Certificates Handling`_ for details on
 using the TI UniFlash tool for certificate programming.
-
-Limitations
-***********
-- While the hardware supports it, IPv6 has yet to be fully implemented
-  in the SimpleLink Wi-Fi device driver in Zephyr.
 
 References
 **********

--- a/boards/arm/cc3235sf_launchxl/doc/index.rst
+++ b/boards/arm/cc3235sf_launchxl/doc/index.rst
@@ -214,7 +214,7 @@ To see program output from UART0, connect a separate terminal window:
 
 Then press the reset button (SW1) on the board to run the program.
 
-When using OpenOCD from Zephyr SDK 0.10.2 to flash the device, you may notice
+When using OpenOCD from Zephyr SDK to flash the device, you may notice
 the program hangs when starting the network processor on the device, if the
 program uses it. There is a known issue with how that version of OpenOCD
 resets the network processor. You would need to manually hit the reset button


### PR DESCRIPTION
Updating docs in anticipation of Zephyr 2.4 release.

Signed-off-by: Vincent Wan <vwan@ti.com>