### PR TITLE
dts/arm/st/f1: Add support for F103xG

### DIFF
--- a/dts/arm/st/f1/stm32f103Xe.dtsi
+++ b/dts/arm/st/f1/stm32f103Xe.dtsi
@@ -128,6 +128,27 @@
 			};
 		};
 
+		adc2: adc@40012800 {
+			compatible = "st,stm32-adc";
+			reg = <0x40012800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000400>;
+			/* Shares vector with ADC1 */
+			interrupts = <18 0>;
+			status = "disabled";
+			label = "ADC_2";
+			#io-channel-cells = <1>;
+		};
+
+		adc3: adc@40013c00 {
+			compatible = "st,stm32-adc";
+			reg = <0x40013c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00008000>;
+			interrupts = <47 0>;
+			status = "disabled";
+			label = "ADC_3";
+			#io-channel-cells = <1>;
+		};
+
 		timers8: timers@40013400 {
 			compatible = "st,stm32-timers";
 			reg = <0x40013400 0x400>;

--- a/dts/arm/st/f1/stm32f103Xg.dtsi
+++ b/dts/arm/st/f1/stm32f103Xg.dtsi
@@ -1,0 +1,141 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2020 Google, LLC
+ *
+ * SoC device tree include for STM32F103xG SoCs
+ * where 'x' is replaced for specific SoCs like {R,V,Z}
+ */
+
+#include <mem.h>
+#include <st/f1/stm32f103Xe.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(96)>;
+	};
+
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				/* Note that there are actually two banks of
+				 * flash (512KB each) and two flash controllers.
+				 * This matters if you're doing in-application
+				 * flash programming and you need the
+				 * read-while-write capabilities, but is
+				 * otherwise a non-issue.
+				 */
+				reg = <0x08000000 DT_SIZE_K(1024)>;
+				erase-block-size = <DT_SIZE_K(2)>;
+			};
+		};
+
+		timers9: timers@40014c00 {
+			compatible = "st,stm32-timers";
+			reg = <0x40014c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00080000>;
+			/* Shared with TIM1_BRK */
+			interrupts = <24 0>;
+			status = "disabled";
+			label = "TIMERS_9";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <10000>;
+				label = "PWM_9";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers10: timers@40015000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40015000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00100000>;
+			/* Shared with TIM1_UP */
+			interrupts = <25 0>;
+			status = "disabled";
+			label = "TIMERS_10";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <10000>;
+				label = "PWM_10";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers11: timers@40015400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40015400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00200000>;
+			/* Shared with TIM1_TRG_COM */
+			interrupts = <26 0>;
+			status = "disabled";
+			label = "TIMERS_11";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <10000>;
+				label = "PWM_11";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers12: timers@40001800 {
+			compatible = "st,stm32-timers";
+			reg = <0x40001800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000040>;
+			/* Shared with TIM8_BRK */
+			interrupts = <43 0>;
+			status = "disabled";
+			label = "TIMERS_12";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <10000>;
+				label = "PWM_12";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers13: timers@40001c00 {
+			compatible = "st,stm32-timers";
+			reg = <0x40001c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000080>;
+			/* Shared with TIM8_UP */
+			interrupts = <44 0>;
+			status = "disabled";
+			label = "TIMERS_13";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <10000>;
+				label = "PWM_13";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers14: timers@40002000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40002000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000100>;
+			/* Shared with TIM8_TRG_COM */
+			interrupts = <45 0>;
+			status = "disabled";
+			label = "TIMERS_14";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <10000>;
+				label = "PWM_14";
+				#pwm-cells = <3>;
+			};
+		};
+
+	};
+};


### PR DESCRIPTION
Add a dtsi file for the F103xG chips, which have 1 MB of flash,
96 KB of ram, and several extra peripherals including ADC3 and
TIM9/10/11/12/13/14.

Signed-off-by: Paul Fagerburg <pfagerburg@google.com>