### PR TITLE
shell: Make shell UART backend initialization priority configurable

### DIFF
--- a/subsys/shell/Kconfig.backends
+++ b/subsys/shell/Kconfig.backends
@@ -21,6 +21,14 @@ config SHELL_BACKEND_SERIAL
 
 if SHELL_BACKEND_SERIAL
 
+config SHELL_BACKEND_SERIAL_INIT_PRIORITY
+	int "Initialization priority"
+	default 0
+	range 0 99
+	help
+	  Initialization priority for UART backend. This must be bigger than
+	  the initialization priority of the used serial device.
+
 config SHELL_PROMPT_UART
 	string "Displayed prompt name"
 	default "uart:~$ "

--- a/subsys/shell/Kconfig.backends
+++ b/subsys/shell/Kconfig.backends
@@ -1,4 +1,4 @@
-# Shell badckends configuration options
+# Shell backends configuration options
 
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -297,7 +297,8 @@ static int enable_shell_uart(const struct device *arg)
 
 	return 0;
 }
-SYS_INIT(enable_shell_uart, POST_KERNEL, 0);
+SYS_INIT(enable_shell_uart, POST_KERNEL,
+	 CONFIG_SHELL_BACKEND_SERIAL_INIT_PRIORITY);
 
 const struct shell *shell_backend_uart_get_ptr(void)
 {


### PR DESCRIPTION
Closes: #28331

Configurable initialization priority is useful when using CDC ACM
serial device, for example.

Signed-off-by: Ievgenii Meshcheriakov <ievgenii.meshcheriakov@nordicsemi.no>