### PR TITLE
doc: release: 2.4: add ARM DesignStart FPGA related release notes

### DIFF
--- a/doc/releases/release-notes-2.4.rst
+++ b/doc/releases/release-notes-2.4.rst
@@ -172,17 +172,20 @@ Boards & SoC Support
 
 * Added support for these SoC series:
 
+  * ARM Cortex-M1/M3 DesignStart FPGA
 
 * Added support for these ARM boards:
 
   * nRF21540 Devkit (nrf21540dk_nrf52840).
-
+  * ARM Cortex-M1/M3 DesignStart FPGA reference designs running on the Digilent
+    Arty A7 development board
 
 * Made these changes in other boards
 
 
 * Added support for these following shields:
 
+  * ARM Ltd. V2C-DAPLink
 
 Drivers and Sensors
 *******************
@@ -260,6 +263,7 @@ Drivers and Sensors
 
 * GPIO
 
+  * Added driver for the Xilinx AXI GPIO IP
 
 * Hardware Info
 
@@ -329,6 +333,7 @@ Drivers and Sensors
 
 * Serial
 
+  * Added driver for the Xilinx UART Lite IP
 
 * SPI
 
@@ -339,6 +344,7 @@ Drivers and Sensors
     GPIO_ACTIVE_LOW.  SPI_CS_ACTIVE_LOW/HIGH are still used for chip
     selects that are not specified by a cs-gpios property.
 
+  * Added driver for the Xilinx AXI Quad SPI IP
 
 * Timer
 


### PR DESCRIPTION
Add release notes covering the various ARM DesignStart FPGA related additions in Zephyr v2.4.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>