### PR TITLE
drivers: clock_control: nrf: Change CLOCK_CONTROL_NRF_FORCE_ALT

### DIFF
--- a/drivers/clock_control/Kconfig.nrf
+++ b/drivers/clock_control/Kconfig.nrf
@@ -13,8 +13,7 @@ config CLOCK_CONTROL_NRF_FORCE_ALT
 menuconfig CLOCK_CONTROL_NRF
 	bool "NRF Clock controller support"
 	depends on SOC_COMPATIBLE_NRF
-	depends on !CLOCK_CONTROL_NRF_FORCE_ALT
-	select NRFX_CLOCK
+	select NRFX_CLOCK if !CLOCK_CONTROL_NRF_FORCE_ALT
 	default y
 	help
 	  Enable support for the Nordic Semiconductor nRFxx series SoC clock
@@ -56,7 +55,7 @@ endchoice
 
 config CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION
 	bool "Enable LF clock calibration"
-	depends on !SOC_SERIES_NRF91X
+	depends on !SOC_SERIES_NRF91X && !CLOCK_CONTROL_NRF_FORCE_ALT
 	default n if BOARD_NRF5340PDK_NRF5340_CPUAPP || BOARD_NRF5340PDK_NRF5340_CPUAPPNS
 	default y if CLOCK_CONTROL_NRF_K32SRC_RC
 	help


### PR DESCRIPTION
Previously when CLOCK_CONTROL_NRF_FORCE_ALT was set alternative clock
control implementation was provided. Changing to include the driver but
provide alternative nrfx_clock implementation.

Additionally, disable calibration when CLOCK_CONTROL_NRF_FORCE_ALT is set.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>