### PR TITLE
Fix issue with Z_GENLIST_FOR_EACH_NODE

### DIFF
--- a/include/sys/list_gen.h
+++ b/include/sys/list_gen.h
@@ -12,7 +12,8 @@
 #include <sys/util.h>
 
 #define Z_GENLIST_FOR_EACH_NODE(__lname, __l, __sn)			\
-	for (__sn = sys_ ## __lname ## _peek_head(__l); __sn != NULL;	\
+	for (__sn = sys_ ## __lname ## _peek_head(__l);		\
+		 (sys_ ## __lname ## _peek_head(__l) != sys_ ## __lname ## _peek_next(__sn) && __sn != NULL);	\
 	     __sn = sys_ ## __lname ## _peek_next(__sn))
 
 


### PR DESCRIPTION
This issue is observed with respect to  pthread_setspecific and pthread_getspecific APIs.
When a key is not found in specified list, `SYS_SLIST_FOR_EACH_NODE` enters infinite loop.

This change adds a condition in for loop to check if pointer to next node points to start of the list.