### PR TITLE
CODEOWNERS: Add reviewers on Synopsys metaware toolchain

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -133,6 +133,7 @@
 /boards/xtensa/odroid_go/                 @ydamigos
 # All cmake related files
 /cmake/                                   @tejlmand @nashif
+/cmake/*/arcmwdt/                         @abrodkin @evgeniy-paltsev @tejlmand
 /CMakeLists.txt                           @tejlmand @nashif
 /doc/                                     @dbkinder
 /doc/guides/coccinelle.rst                @himanshujha199640 @JuliaLawall


### PR DESCRIPTION
Adding Synopsys developers as reviewers on arcmwdt components.

As discussed during last Toolchain WG meeting, this PR adds @evgeniy-paltsev and @abrodkin to the CODEOWNERS file for Synopsys metaware related changes.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>