### PR TITLE
Bluetooth: Mesh: Fix RPL not check by proxy configuration

### DIFF
--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -569,6 +569,10 @@ void bt_mesh_rpl_reset(void)
 			} else {
 				rpl->old_iv = true;
 			}
+
+			if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+				bt_mesh_store_rpl(rpl);
+			}
 		}
 	}
 }

--- a/subsys/bluetooth/mesh/proxy.c
+++ b/subsys/bluetooth/mesh/proxy.c
@@ -22,6 +22,7 @@
 #include "mesh.h"
 #include "adv.h"
 #include "net.h"
+#include "transport.h"
 #include "prov.h"
 #include "beacon.h"
 #include "foundation.h"
@@ -278,6 +279,14 @@ static void proxy_cfg(struct bt_mesh_proxy_client *client)
 				 &rx, &buf);
 	if (err) {
 		BT_ERR("Failed to decode Proxy Configuration (err %d)", err);
+		return;
+	}
+
+	rx.local_match = 1U;
+
+	if (bt_mesh_rpl_check(&rx, NULL)) {
+		BT_WARN("Replay: src 0x%04x dst 0x%04x seq 0x%06x",
+			rx.ctx.addr, rx.ctx.recv_dst, rx.seq);
 		return;
 	}
 

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -692,7 +692,7 @@ static void update_rpl(struct bt_mesh_rpl *rpl, struct bt_mesh_net_rx *rx)
  * updated (needed for segmented messages), whereas if a NULL match is given
  * the RPL is immediately updated (used for unsegmented messages).
  */
-static bool is_replay(struct bt_mesh_net_rx *rx, struct bt_mesh_rpl **match)
+bool bt_mesh_rpl_check(struct bt_mesh_net_rx *rx, struct bt_mesh_rpl **match)
 {
 	int i;
 
@@ -1225,7 +1225,7 @@ static int trans_unseg(struct net_buf_simple *buf, struct bt_mesh_net_rx *rx,
 		return -EINVAL;
 	}
 
-	if (is_replay(rx, NULL)) {
+	if (bt_mesh_rpl_check(rx, NULL)) {
 		BT_WARN("Replay: src 0x%04x dst 0x%04x seq 0x%06x",
 			rx->ctx.addr, rx->ctx.recv_dst, rx->seq);
 		return -EINVAL;
@@ -1517,7 +1517,7 @@ static int trans_seg(struct net_buf_simple *buf, struct bt_mesh_net_rx *net_rx,
 		return -EINVAL;
 	}
 
-	if (is_replay(net_rx, &rpl)) {
+	if (bt_mesh_rpl_check(net_rx, &rpl)) {
 		BT_WARN("Replay: src 0x%04x dst 0x%04x seq 0x%06x",
 			net_rx->ctx.addr, net_rx->ctx.recv_dst, net_rx->seq);
 		return -EINVAL;

--- a/subsys/bluetooth/mesh/transport.h
+++ b/subsys/bluetooth/mesh/transport.h
@@ -101,6 +101,8 @@ void bt_mesh_trans_init(void);
 
 void bt_mesh_rpl_clear(void);
 
+bool bt_mesh_rpl_check(struct bt_mesh_net_rx *rx, struct bt_mesh_rpl **match);
+
 int bt_mesh_heartbeat_send(const struct bt_mesh_send_cb *cb, void *cb_data);
 
 int bt_mesh_app_key_get(const struct bt_mesh_subnet *subnet, uint16_t app_idx,


### PR DESCRIPTION
Fixes proxy configuration not check by replay.
Fixes secure beacon iv update not store new RPL.

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>