### PR TITLE
Fix: fixed issue on mimxrt1050_evk

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -327,8 +327,12 @@ static void eth_mcux_phy_event(struct eth_context *context)
 					  kENET_MiiReadValidFrame);
 			context->link_up = link_up;
 			context->phy_state = eth_mcux_phy_state_read_duplex;
-			net_eth_carrier_on(context->iface);
-			k_sleep(USEC_PER_MSEC);
+
+			/* Network interface might be NULL at this point */
+			if (context->iface) {
+				net_eth_carrier_on(context->iface);
+				k_sleep(USEC_PER_MSEC);
+			}
 		} else if (!link_up && context->link_up) {
 			LOG_INF("Link down");
 			context->link_up = link_up;


### PR DESCRIPTION
Fixed that sometimes it will fail to run /tests/net/iface on
mimxrt1050_evk board.
More details see github issue https://github.com/zephyrproject-rtos/zephyr/issues/23210

Signed-off-by: Ningx Zhao <ningx.zhao@intel.com>