### PR TITLE
net: openthread: add kconfigs to change values in zephyr port

### DIFF
--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -217,6 +217,12 @@ config OPENTHREAD_NCP_VENDOR_HOOK_SOURCE
 	help
 	  Provides path to compile ncp vendor hook file inside NCP component.
 
+config OPENTHREAD_NCP_BUFFER_SIZE
+	int "The size of the NCP buffers"
+	default 2048
+	help
+	  The size of the NCP buffers.
+
 endif # OPENTHREAD_NCP
 
 config OPENTHREAD_PLATFORM_INFO
@@ -234,5 +240,24 @@ config OPENTHREAD_CUSTOM_PARAMETERS
 	  options to the OpenThread build system. Separate multiple values with
 	  space " ", for example:
 	  "OPENTHREAD_CONFIG_JOINER_ENABLE=1 OPENTHREAD_CONFIG_JOINER_MAX_CANDIDATES=3"
+
+config OPENTHREAD_NUM_MESSAGE_BUFFERS
+	int "The number of message buffers in the buffer pool"
+	default 128
+	help
+	  "The number of message buffers in the buffer pool."
+
+config OPENTHREAD_MAX_STATECHANGE_HANDLERS
+	int "The maximum number of state-changed callback handlers"
+	default 2
+	help
+	  The maximum number of state-changed callback handlers
+	  set using otSetStateChangedCallback.
+
+config OPENTHREAD_TMF_ADDRESS_CACHE_ENTRIES
+	int "The number of EID-to-RLOC cache entries"
+	default 20
+	help
+	  The number of EID-to-RLOC cache entries.
 
 endif # NET_L2_OPENTHREAD

--- a/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
+++ b/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
@@ -13,6 +13,7 @@
 #ifndef OPENTHREAD_CORE_ZEPHYR_CONFIG_H_
 #define OPENTHREAD_CORE_ZEPHYR_CONFIG_H_
 
+#include <autoconf.h>
 #include <devicetree.h>
 #include <toolchain.h>
 
@@ -22,7 +23,7 @@
  * The number of message buffers in the buffer pool.
  *
  */
-#define OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS                   128
+#define OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS                   CONFIG_OPENTHREAD_NUM_MESSAGE_BUFFERS
 
 /**
  * @def OPENTHREAD_CONFIG_MAX_STATECHANGE_HANDLERS
@@ -31,7 +32,7 @@
  * (set using `otSetStateChangedCallback()`).
  *
  */
-#define OPENTHREAD_CONFIG_MAX_STATECHANGE_HANDLERS              2
+#define OPENTHREAD_CONFIG_MAX_STATECHANGE_HANDLERS              CONFIG_OPENTHREAD_MAX_STATECHANGE_HANDLERS
 
 /**
  * @def OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_ENTRIES
@@ -39,7 +40,7 @@
  * The number of EID-to-RLOC cache entries.
  *
  */
-#define OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_ENTRIES             20
+#define OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_ENTRIES             CONFIG_OPENTHREAD_TMF_ADDRESS_CACHE_ENTRIES
 
 /**
  * @def OPENTHREAD_CONFIG_LOG_PREPEND_LEVEL
@@ -144,7 +145,7 @@
  * The size of the NCP buffers.
  *
  */
-#define OPENTHREAD_CONFIG_NCP_BUFFER_SIZE 2048
+#define OPENTHREAD_CONFIG_NCP_BUFFER_SIZE CONFIG_OPENTHREAD_NCP_BUFFER_SIZE
 
 /**
  * @def OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION


### PR DESCRIPTION
This commit adds additional Kconfigs that allow for changing
configuration values for the Zephyr port in OpenThread.

Those values are:
- number of the internal OT message buffers
- number of the state change callbacks
- number of the EID-to-RLOC cache entries
- size of the NCP buffer

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>