### PR TITLE
github: labeler: Fix dts/ folder matching

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -25,8 +25,7 @@
 "area: C Library":
   - "lib/libc/**/*"
 "area: Devicetree":
-  - "dts/**/*"
-  - "!dts/bindings/**/*"
+  - any: ["dts/**/*", "!dts/bindings/**/*"]
   - "**/*.dts"
   - "**/*.dtsi"
   - "include/devicetree.h"


### PR DESCRIPTION
Use the syntax described in:
https://github.com/actions/labeler#common-examples

in order to rewrite the matching expression for the dts/ folder.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>