### PR TITLE
tests: posix: common: fix test for cross-clock equality

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -26,7 +26,6 @@
   - "lib/libc/**/*"
 "area: Devicetree":
   - "dts/**/*"
-  - "!dts/bindings/**/*"
   - "**/*.dts"
   - "**/*.dtsi"
   - "include/devicetree.h"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -25,7 +25,8 @@
 "area: C Library":
   - "lib/libc/**/*"
 "area: Devicetree":
-  - any: ["dts/**/*", "!dts/bindings/**/*"]
+  - "dts/**/*"
+  - "!dts/bindings/**/*"
   - "**/*.dts"
   - "**/*.dtsi"
   - "include/devicetree.h"

--- a/tests/posix/common/src/clock.c
+++ b/tests/posix/common/src/clock.c
@@ -52,6 +52,7 @@ void test_posix_realtime(void)
 	 */
 
 	int ret;
+	uint32_t uptime;
 	struct timespec rts, mts;
 	struct timeval tv;
 
@@ -64,11 +65,15 @@ void test_posix_realtime(void)
 	k_usleep(1);
 
 	printk("POSIX clock set APIs\n");
-	ret = clock_gettime(CLOCK_MONOTONIC, &mts);
-	zassert_equal(ret, 0, "Fail to get monotonic clock");
+	do {
+		uptime = k_uptime_get_32();
 
-	ret = clock_gettime(CLOCK_REALTIME, &rts);
-	zassert_equal(ret, 0, "Fail to get realtime clock");
+		ret = clock_gettime(CLOCK_MONOTONIC, &mts);
+		zassert_equal(ret, 0, "Fail to get monotonic clock");
+
+		ret = clock_gettime(CLOCK_REALTIME, &rts);
+		zassert_equal(ret, 0, "Fail to get realtime clock");
+	} while (uptime != k_uptime_get_32());
 
 	zassert_equal(rts.tv_sec, mts.tv_sec, "Seconds not equal");
 	zassert_equal(rts.tv_nsec, mts.tv_nsec, "Nanoseconds not equal");


### PR DESCRIPTION
Distinct reads of the clock are not guaranteed to be equal to the resolution of the clock.  Since the clock source is the a millsecond-resolution uptime clock just do this in a loop until a case is found where the system clock didn't advance during the POSIX clock reads.

Fixes #25453