### PR TITLE
kernel: sched: bug fix for trace and monitor

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -554,10 +554,9 @@ void z_thread_single_abort(struct k_thread *thread)
 			arch_thread_return_value_set(waiter, 0);
 			ready_thread(waiter);
 		}
+		sys_trace_thread_abort(thread);
+		z_thread_monitor_exit(thread);
 	}
-
-	sys_trace_thread_abort(thread);
-	z_thread_monitor_exit(thread);
 }
 
 static void unready_thread(struct k_thread *thread)


### PR DESCRIPTION
sys_trace_thread_abort and z_thread_monitor_exit in
z_thread_single_abort also need to be protected by
sched_spinlock, otherwise when after the spinlock
release, if there is an pending interrupt, it will cause an
sched in the interrrupt exit, and those trace and monitor
function will never reach.