### PR TITLE
boards: arc: nsim: fix yaml identifier for nsim_em_em7d_v22

### DIFF
--- a/boards/arc/nsim/nsim_em7d_v22.yaml
+++ b/boards/arc/nsim/nsim_em7d_v22.yaml
@@ -1,4 +1,4 @@
-identifier: nsim_em
+identifier: nsim_em_em7d_v22
 name: EM Nsim simulator
 type: mcu
 simulation: nsim


### PR DESCRIPTION
fix yaml identifier for nsim_em_em7d_v22 configuration
