### PR TITLE
Bluetooth: controller: Fix cond. compilation for broadcaster

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -896,6 +896,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 			return BT_HCI_ERR_HW_FAILURE;
 		}
 	}
+#endif /* CONFIG_BT_PERIPHERAL */
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	if (ll_adv_cmds_is_ext()) {
@@ -932,10 +933,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 		node_rx_adv_term->hdr.link = (void *)link_adv_term;
 		adv->lll.node_rx_adv_term = (void *)node_rx_adv_term;
 	}
-#endif  /* CONFIG_BT_CTLR_ADV_EXT */
-#endif /* CONFIG_BT_PERIPHERAL */
 
-#if defined(CONFIG_BT_CTLR_ADV_EXT)
 	const uint8_t phy = lll->phy_p;
 
 	adv->event_counter = 0;


### PR DESCRIPTION
Fix conditional compilation for extended advertising
without peripheral support.

This fixes missing initialization of buffer for generating
advertising terminate event.

Fixes #28325.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>