### PR TITLE
samples: littlefs: Add configuration for nucleo_f429zi

### DIFF
--- a/samples/subsys/fs/littlefs/boards/nucleo_f429zi.conf
+++ b/samples/subsys/fs/littlefs/boards/nucleo_f429zi.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2020 Linaro Limited.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Need this when storage is on flash
+CONFIG_MPU_ALLOW_FLASH_WRITE=y

--- a/samples/subsys/fs/littlefs/boards/nucleo_f429zi.overlay
+++ b/samples/subsys/fs/littlefs/boards/nucleo_f429zi.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 Linaro Limited.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* LittleFS expects at least 2 flash sectors with a constant erase size. */
+/* For STM32F2/F4/F7 series, it means that at least 2 sectors of the same */
+/* size should be made available for storage partition. */
+
+/* Applied to stm32f429zi used without bootloader, the only solution is */
+/* to allocate the 2 consecutive 256Kb sectors. */
+/* To make it working on nucleo_f429zi, it means that default partitions */
+/* should be arranged as follows: */
+
+/* Delete existing partitions that needs to be modified */
+/delete-node/ &storage_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+
+&flash0 {
+	partitions {
+
+		/* This partition is only needed to satisfy main file */
+		/* chosen { zephyr,code-partition = &slot0_partition; } */
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 0x00010000>;
+		};
+
+		/* storage image slot: 2 x 256KB sectors */
+		storage_partition: partition@20000 {
+			label = "storage";
+			reg = <0x00020000 0x00080000>;
+		};
+	};
+};


### PR DESCRIPTION
To match littlefs expectations on available storage flash sectors
and stm32f4 flash block specifics, provide a specific configuration
that allows to allocate 2 similar size sectors to storage.
Additionally, allow MPU RWX access to flash memory.

Fixes #28309

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>