### PR TITLE
boards: Fix obsolete link to flash partition doc

### DIFF
--- a/boards/arm/degu_evk/degu_evk.dts
+++ b/boards/arm/degu_evk/degu_evk.dts
@@ -108,7 +108,7 @@
 &flash0 {
 	/*
 	 * For more information, see:
-	 * http://docs.zephyrproject.org/latest/devices/dts/flash_partitions.html
+	 * https://docs.zephyrproject.org/latest/reference/devicetree/index.html#fixed-flash-partitions
 	 */
 	partitions {
 		compatible = "fixed-partitions";

--- a/boards/arm/frdm_k22f/frdm_k22f.dts
+++ b/boards/arm/frdm_k22f/frdm_k22f.dts
@@ -147,7 +147,7 @@ arduino_spi: &spi0 {
 &flash0 {
 	/*
 	 * For more information, see:
-	 * http://docs.zephyrproject.org/latest/devices/dts/flash_partitions.html
+	 * https://docs.zephyrproject.org/latest/reference/devicetree/index.html#fixed-flash-partitions
 	 */
 	partitions {
 		compatible = "fixed-partitions";

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
@@ -128,7 +128,7 @@
 &flash0 {
 	/*
 	 * For more information, see:
-	 * http://docs.zephyrproject.org/latest/devices/dts/flash_partitions.html
+	 * https://docs.zephyrproject.org/latest/reference/devicetree/index.html#fixed-flash-partitions
 	 */
 	partitions {
 		compatible = "fixed-partitions";

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -102,7 +102,7 @@
 &flash0 {
 	/*
 	 * For more information, see:
-	 * http://docs.zephyrproject.org/devices/dts/flash_partitions.html
+	 * https://docs.zephyrproject.org/latest/reference/devicetree/index.html#fixed-flash-partitions
 	 */
 	partitions {
 		compatible = "fixed-partitions";

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -115,7 +115,7 @@
 &flash0 {
 	/*
 	 * For more information, see:
-	 * http://docs.zephyrproject.org/latest/devices/dts/flash_partitions.html
+	 * https://docs.zephyrproject.org/latest/reference/devicetree/index.html#fixed-flash-partitions
 	 */
 	partitions {
 		compatible = "fixed-partitions";


### PR DESCRIPTION
"flash_partitions" page in doc disappeared.
Replace by what seems the closest equivalent.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>