### PR TITLE
drivers: spi: nrfx: Restore recently changed spi_context function

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -343,6 +343,22 @@ bool spi_context_rx_buf_on(struct spi_context *ctx)
 	return !!(ctx->rx_buf && ctx->rx_len);
 }
 
+/*
+ * Returns the maximum length of a transfer for which all currently active
+ * directions have a continuous buffer, i.e. the maximum SPI transfer that
+ * can be done with DMA that handles only non-scattered buffers.
+ */
+static inline size_t spi_context_max_continuous_chunk(struct spi_context *ctx)
+{
+	if (!ctx->tx_len) {
+		return ctx->rx_len;
+	} else if (!ctx->rx_len) {
+		return ctx->tx_len;
+	}
+
+	return MIN(ctx->tx_len, ctx->rx_len);
+}
+
 static inline size_t spi_context_longest_current_buf(struct spi_context *ctx)
 {
 	return ctx->tx_len > ctx->rx_len ? ctx->tx_len : ctx->rx_len;

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -142,7 +142,7 @@ static void transfer_next_chunk(const struct device *dev)
 	struct spi_context *ctx = &dev_data->ctx;
 	int error = 0;
 
-	size_t chunk_len = spi_context_longest_current_buf(ctx);
+	size_t chunk_len = spi_context_max_continuous_chunk(ctx);
 
 	if (chunk_len > 0) {
 		nrfx_spi_xfer_desc_t xfer;

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -160,7 +160,7 @@ static void transfer_next_chunk(const struct device *dev)
 	struct spi_context *ctx = &dev_data->ctx;
 	int error = 0;
 
-	size_t chunk_len = spi_context_longest_current_buf(ctx);
+	size_t chunk_len = spi_context_max_continuous_chunk(ctx);
 
 	if (chunk_len > 0) {
 		nrfx_spim_xfer_desc_t xfer;

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -112,7 +112,7 @@ static void prepare_for_transfer(const struct device *dev)
 	struct spi_context *ctx = &dev_data->ctx;
 	int status;
 
-	size_t buf_len = spi_context_longest_current_buf(ctx);
+	size_t buf_len = spi_context_max_continuous_chunk(ctx);
 
 	if (buf_len > 0) {
 		nrfx_err_t result;


### PR DESCRIPTION
Function spi_context_longest_current_buf() has been introduced in
commit ddef35c1daf2baea67924c7f186476bb39511888 for the purpose of
getting the longest possible (potentially partial) SPI transfer
for which all currently active directions have a continuous buffer.
Such transfer can be done with taking advantage of a DMA that cannot
use scattered buffers (and this is the case for nRF SPI drivers with
which this function has been introduced).
Unfortunately, because of its inadequate name, later on this function
has been incorrectly used in other SPI drivers for getting the longer
of TX/RX buffers. And commit afc480f12b88c3fd78889ddc97e0e202b11b3c89
recently "fixed" the implementation of this function, assumably to
adjust it to those incorrect uses, but this way it has also broken
the nRF SPI drivers.
Instead of restoring the original implementation of the function in
question, this commit adds a new one with functionality equivalent
to that original but with a hopefully less misleading name, and this
function is used in the nRF SPI drivers.

Fixes #28317.