### PR TITLE
Enable Civetweb WebSocket Support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -41,7 +41,7 @@ manifest:
       revision: da9a2df574094f52d87a03f6393928bdc7dce17c
       path: tools/ci-tools
     - name: civetweb
-      revision: 99129c5efc907ea613c4b73ccff07581feb58a7a
+      revision: e6903b80c09d17cd1a8bb32e40080005558aad29
       path: modules/lib/civetweb
     - name: esp-idf
       revision: 6835bfc741bf15e98fb7971293913f770df6081f


### PR DESCRIPTION
Updates civetweb revision in west.yml (please provide `west update` in your `/zephyrproject` repository)

This PR adds newest civetweb with WebSocket support to the Zephyr.

Needed by following PR's: #28323 #28376

Only one line were changed!