### PR TITLE
usb: CDC_ACM do not (re)set irq flags internally.

### DIFF
--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -404,8 +404,6 @@ static void cdc_acm_reset_port(struct cdc_acm_dev_data_t *dev_data)
 	dev_data->suspended = false;
 	dev_data->rx_ready = false;
 	dev_data->tx_ready = false;
-	dev_data->tx_irq_ena = false;
-	dev_data->rx_irq_ena = false;
 	dev_data->line_coding = (struct cdc_acm_line_coding)
 				CDC_ACM_DEFAULT_BAUDRATE;
 	dev_data->serial_state = 0;
@@ -440,8 +438,6 @@ static void cdc_acm_do_cb(struct cdc_acm_dev_data_t *dev_data,
 		}
 		dev_data->configured = true;
 		dev_data->tx_ready = true;
-		dev_data->tx_irq_ena = true;
-		dev_data->rx_irq_ena = true;
 		break;
 	case USB_DC_DISCONNECTED:
 		LOG_INF("Device disconnected");


### PR DESCRIPTION
Both `tx_irq_ena` and `rx_irq_ena` flags shall not be set or reset
within the CDC_ACM class. Those flags shall be used by actual user
of the CDC_ACM class allowing the CDC to receive/transmit data.

Both `rx/tx_irq_ena` flags are intended to be used to control USB serial device (CDC_ACM)
from application perspective, the class itself shall not update those under any condition.

Fixes: #27727
If mcumgr uses cdc_acm as serial backend the device will hang in `uart_mcumgr_isr()`
because the `rx_irq_ena` was always true.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>