### PR TITLE
tests: posix: common: remove sub-microsecond nanosleep test

### DIFF
--- a/tests/posix/common/src/main.c
+++ b/tests/posix/common/src/main.c
@@ -56,7 +56,6 @@ void test_main(void)
 			ztest_unit_test(test_nanosleep_0_n1),
 			ztest_unit_test(test_nanosleep_n1_n1),
 			ztest_unit_test(test_nanosleep_0_1000000000),
-			ztest_unit_test(test_nanosleep_0_1),
 			ztest_unit_test(test_nanosleep_0_500000000),
 			ztest_unit_test(test_nanosleep_1_0)
 			);

--- a/tests/posix/common/src/nanosleep.c
+++ b/tests/posix/common/src/nanosleep.c
@@ -216,17 +216,6 @@ static void common(const uint32_t s, uint32_t ns)
 	/* TODO: Upper bounds check when hr timers are available */
 }
 
-/** sleep for 1ns */
-void test_nanosleep_0_1(void)
-{
-	if (IS_ENABLED(CONFIG_QEMU_TARGET)) {
-		/* QEMU target tick adjustment fails for 1 ns durations */
-		ztest_test_skip();
-	} else {
-		common(0, 1);
-	}
-}
-
 /** sleep for 500000000ns */
 void test_nanosleep_0_500000000(void)
 {


### PR DESCRIPTION
Beyond the complexities of tick resolution on QEMU, this test is invalid because POSIX nanosleep as currently implemented uses k_busy_wait(ns / 1000) which means it's measuring the duration of k_busy_wait(0) in cycles, which has no reasonable relation to 1 ns regardless of tolerance.

Fixes #28394.