### PR TITLE
revert recent changes to spi_context function

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -345,7 +345,15 @@ bool spi_context_rx_buf_on(struct spi_context *ctx)
 
 static inline size_t spi_context_longest_current_buf(struct spi_context *ctx)
 {
-	return ctx->tx_len > ctx->rx_len ? ctx->tx_len : ctx->rx_len;
+	if (!ctx->tx_len) {
+		return ctx->rx_len;
+	} else if (!ctx->rx_len) {
+		return ctx->tx_len;
+	} else if (ctx->tx_len < ctx->rx_len) {
+		return ctx->tx_len;
+	}
+
+	return ctx->rx_len;
 }
 
 static inline size_t spi_context_total_tx_len(struct spi_context *ctx)

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -343,6 +343,11 @@ bool spi_context_rx_buf_on(struct spi_context *ctx)
 	return !!(ctx->rx_buf && ctx->rx_len);
 }
 
+/*
+ * Returns the maximum length of a transfer for which all currently active
+ * directions have a continuous buffer, i.e. the maximum SPI transfer that
+ * can be done with DMA that handles only non-scattered buffers.
+ */
 static inline size_t spi_context_longest_current_buf(struct spi_context *ctx)
 {
 	if (!ctx->tx_len) {

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -343,22 +343,6 @@ bool spi_context_rx_buf_on(struct spi_context *ctx)
 	return !!(ctx->rx_buf && ctx->rx_len);
 }
 
-/*
- * Returns the maximum length of a transfer for which all currently active
- * directions have a continuous buffer, i.e. the maximum SPI transfer that
- * can be done with DMA that handles only non-scattered buffers.
- */
-static inline size_t spi_context_max_continuous_chunk(struct spi_context *ctx)
-{
-	if (!ctx->tx_len) {
-		return ctx->rx_len;
-	} else if (!ctx->rx_len) {
-		return ctx->tx_len;
-	}
-
-	return MIN(ctx->tx_len, ctx->rx_len);
-}
-
 static inline size_t spi_context_longest_current_buf(struct spi_context *ctx)
 {
 	return ctx->tx_len > ctx->rx_len ? ctx->tx_len : ctx->rx_len;

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -142,7 +142,7 @@ static void transfer_next_chunk(const struct device *dev)
 	struct spi_context *ctx = &dev_data->ctx;
 	int error = 0;
 
-	size_t chunk_len = spi_context_max_continuous_chunk(ctx);
+	size_t chunk_len = spi_context_longest_current_buf(ctx);
 
 	if (chunk_len > 0) {
 		nrfx_spi_xfer_desc_t xfer;

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -160,7 +160,7 @@ static void transfer_next_chunk(const struct device *dev)
 	struct spi_context *ctx = &dev_data->ctx;
 	int error = 0;
 
-	size_t chunk_len = spi_context_max_continuous_chunk(ctx);
+	size_t chunk_len = spi_context_longest_current_buf(ctx);
 
 	if (chunk_len > 0) {
 		nrfx_spim_xfer_desc_t xfer;

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -112,7 +112,7 @@ static void prepare_for_transfer(const struct device *dev)
 	struct spi_context *ctx = &dev_data->ctx;
 	int status;
 
-	size_t buf_len = spi_context_max_continuous_chunk(ctx);
+	size_t buf_len = spi_context_longest_current_buf(ctx);
 
 	if (buf_len > 0) {
 		nrfx_err_t result;


### PR DESCRIPTION
I'm proposing this to revert #28393 and #27781.

#27781 changed the behavior of a function to match what its name implied.  This caused #28317 since Nordic SPIM relied on the original behavior.

#28393 fixed that issue by adding a new function with the original behavior and using it for Nordic SPIM.  While this fixes Nordic, the function is also used in litespi, oc_simple, sifive, and xlnx_axi_quadspi drivers.

There is no justification in #27781 for the change other than the apparent discrepancy between the name and the behavior.  No faulty behavior was associated with the existing implementation.

Thus it seems the appropriate solution is to revert both, but add the documentation to the existing function (without renaming it) to explain what "longest" means.