### PR TITLE
net: openthread: fix initialization with link raw enabled

### DIFF
--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -432,9 +432,7 @@ static int openthread_init(struct net_if *iface)
 		otNcpInit(ot_context->instance);
 	}
 
-	if (!IS_ENABLED(CONFIG_OPENTHREAD_RAW)) {
-		otIp6SetEnabled(ot_context->instance, true);
-	}
+	otIp6SetEnabled(ot_context->instance, true);
 
 	if (!IS_ENABLED(CONFIG_OPENTHREAD_NCP)) {
 		otIp6SetReceiveFilterEnabled(ot_context->instance, true);


### PR DESCRIPTION
Fix the OpenThread initialization to prevent the IPv6 interface to be enabled when `CONFIG_OPENTHREAD_RAW` is set.
