### PR TITLE
arch: arm: cortex_m: cleanup SW_VECTOR_RELAY_CLIENT dependencies

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/Kconfig
+++ b/arch/arm/core/aarch32/cortex_m/Kconfig
@@ -139,6 +139,7 @@ config CPU_CORTEX_M_HAS_PROGRAMMABLE_FAULT_PRIOS
 
 config CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP
 	bool
+	depends on ARMV6_M_ARMV8_M_BASELINE
 	help
 	  This option signifies the Cortex-M0 has some mechanisms that can map
 	  the vector table to SRAM
@@ -281,7 +282,7 @@ config SW_VECTOR_RELAY
 config SW_VECTOR_RELAY_CLIENT
 	bool "Enable Software Vector Relay (client)"
 	default y if BOOTLOADER_MCUBOOT
-	depends on ARMV6_M_ARMV8_M_BASELINE && !(CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP || CPU_CORTEX_M_HAS_VTOR)
+	depends on !(CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP || CPU_CORTEX_M_HAS_VTOR)
 	help
 	  Another image has enabled SW_VECTOR_RELAY, and will be forwarding
 	  exceptions and HW interrupts to this image. Enable this option to make


### PR DESCRIPTION
CPU Cortex-M implies Mainline Cortex-M, therfore, the dependency
on ARMV6_M_ARMV8_M_BASELINE is redundant and can be removed. The
change in this commit is a no-op.

We also add the ARMV6_M_ARMV8_M_BASELINE dependency on option
CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP to make sure it cannot be
selected for non Cortex-M Baseline SoCs (at least, not without
a warning).

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Related to #28289 but does not fix it. It is just an enhancement for now.