### PR TITLE
board: arc: fix nsim_em7d_v22 identifier

### DIFF
--- a/boards/arc/nsim/nsim_em7d_v22.yaml
+++ b/boards/arc/nsim/nsim_em7d_v22.yaml
@@ -1,4 +1,4 @@
-identifier: nsim_em_em7d_v22
+identifier: nsim_em7d_v22
 name: EM Nsim simulator
 type: mcu
 simulation: nsim


### PR DESCRIPTION
Use correct identifier..

nsim_em_em7d_v22 -> nsim_em7d_v22