### PR TITLE
soc: arm: st_stm32: stm32f0: take into account SW_VECTOR_RELAY

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/Kconfig
+++ b/arch/arm/core/aarch32/cortex_m/Kconfig
@@ -139,6 +139,7 @@ config CPU_CORTEX_M_HAS_PROGRAMMABLE_FAULT_PRIOS
 
 config CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP
 	bool
+	depends on ARMV6_M_ARMV8_M_BASELINE
 	help
 	  This option signifies the Cortex-M0 has some mechanisms that can map
 	  the vector table to SRAM
@@ -280,8 +281,8 @@ config SW_VECTOR_RELAY
 
 config SW_VECTOR_RELAY_CLIENT
 	bool "Enable Software Vector Relay (client)"
-	default y if BOOTLOADER_MCUBOOT
-	depends on ARMV6_M_ARMV8_M_BASELINE && !(CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP || CPU_CORTEX_M_HAS_VTOR)
+	default y if BOOTLOADER_MCUBOOT && !CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP
+	depends on !CPU_CORTEX_M_HAS_VTOR
 	help
 	  Another image has enabled SW_VECTOR_RELAY, and will be forwarding
 	  exceptions and HW interrupts to this image. Enable this option to make

--- a/soc/arm/st_stm32/stm32f0/soc.c
+++ b/soc/arm/st_stm32/stm32f0/soc.c
@@ -16,6 +16,9 @@
 #include <linker/linker-defs.h>
 #include <string.h>
 
+#if defined(CONFIG_SW_VECTOR_RELAY) || defined(CONFIG_SW_VECTOR_RELAY_CLIENT)
+extern void *_vector_table_pointer;
+#endif
 
 /**
  * @brief Relocate vector table to SRAM.
@@ -29,6 +32,11 @@
  * A zephyr image that is a bootloader does not have to relocate the
  * vector table.
  *
+ * Alternatively both switches SW_VECTOR_RELAY (for Bootloader image) and
+ * SW_VECTOR_RELAY_CLIENT (for image loaded by a bootloader) can be used to
+ * adds a vector table relay handler and a vector relay table, to relay
+ * interrupts based on a vector table pointer.
+ *
  * Replaces the default function from prep_c.c.
  *
  * @note Zephyr applications that will not be loaded by a bootloader should
@@ -36,7 +44,9 @@
  */
 void relocate_vector_table(void)
 {
-#ifndef CONFIG_IS_BOOTLOADER
+#if defined(CONFIG_SW_VECTOR_RELAY) || defined(CONFIG_SW_VECTOR_RELAY_CLIENT)
+	_vector_table_pointer = _vector_start;
+#elif !defined(CONFIG_IS_BOOTLOADER)
 	extern char _ram_vector_start[];
 
 	size_t vector_size = (size_t)_vector_end - (size_t)_vector_start;


### PR DESCRIPTION
soc: arm: st_stm32: stm32f0: take into account SW_VECTOR_RELAY

This STM32 serie redefines function relocate_vector_table()
It should take into account features:
SW_VECTOR_RELAY and SW_VECTOR_RELAY_CLIENT

fixes #28289

Signed-off-by: Alexandre Bourdiol <alexandre.bourdiol@st.com>