### PR TITLE
samples: exclude mec15xxevb_assy6853 in espi sample when sanitycheck

### DIFF
--- a/samples/drivers/espi/README.rst
+++ b/samples/drivers/espi/README.rst
@@ -20,6 +20,12 @@ Building and Running
 
 The sample can be built and executed on boards supporting eSPI.
 Any pins required for minimum eSPI handshake should be configured.
+Sample requires a correct harness and fixture setup.
+Please connect an eSPI device to the testing board.
+After that for the correct execution of that sample in sanitycheck, add into
+boards's map-file next fixture settings::
+
+      - fixture: espi_device_connect
 
 Sample output
 =============

--- a/samples/drivers/espi/sample.yaml
+++ b/samples/drivers/espi/sample.yaml
@@ -9,6 +9,7 @@ tests:
     depends_on: espi
     harness: console
     harness_config:
+        fixture: espi_device_connect
         type: multi_line
         ordered: true
         regex:
@@ -43,4 +44,3 @@ tests:
             - "espi: Postcode fe"
             - "espi: Postcode 7f"
             - "espi: eSPI sample completed"
-    depends_on: espi


### PR DESCRIPTION
ESPI is supported in MEC15 chips but similar to PECI, I2C, eSPI bus
testing requires another device to act as eSPI host.
While this sample can be run in EVB the HW connection to a eSPI host
(Intel RVP) is not documented/supported.

Mark as not supported in that HW only in Modular card
(which setup is documented)

Also remove duplicate definition of the "depends_on: espi"
in the end of the sample.yaml file

Fixes #28148 

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>