### PR TITLE
kernel/timeout: ensure next_timeout() returns non-negative number

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -73,7 +73,8 @@ static int32_t next_timeout(void)
 {
 	struct _timeout *to = first();
 	int32_t ticks_elapsed = elapsed();
-	int32_t ret = to == NULL ? MAX_WAIT : MAX(0, to->dticks - ticks_elapsed);
+	int32_t ret = to == NULL ? MAX_WAIT :
+		MAX(0, (int32_t)(to->dticks - ticks_elapsed));
 
 #ifdef CONFIG_TIMESLICING
 	if (_current_cpu->slice_ticks && _current_cpu->slice_ticks < ret) {


### PR DESCRIPTION
For the MAX() operation to be performed correctly so that a zero
timeout is returned when a timeout is in the past, both of its
parameters should be signed, for otherwise 'to->dticks - ticks_elapsed'
would always be treated as greater than or equal to 0 in an unsigned
comparison. Let's cast the second parameter accordingly.

Fixes #28414

Signed-off-by: Vincent Wan <vwan@ti.com>