### PR TITLE
boards: arm: Add entropy dts chosen node for lpcxpresso55s69_cpu1

### DIFF
--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.dts
@@ -20,6 +20,7 @@
 	chosen {
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash0;
+		zephyr,entropy = &rng;
 	};
 };
 

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.yaml
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.yaml
@@ -10,7 +10,6 @@ type: mcu
 arch: arm
 ram: 64
 flash: 256
-sanitycheck: false
 toolchain:
   - zephyr
   - gnuarmemb


### PR DESCRIPTION
Adds an entropy dts chosen node for the lpcxpresso55s69_cpu1 board
configuration. Commit 5083038 added
this for the _cpu0 and _ns board configurations, but missed the _cpu1
board configuration.

Fixes sanitycheck build errors for network socket samples.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #27880