### PR TITLE
kernel: avoid implementation-defined behavior in timeout calculation

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -73,7 +73,8 @@ static int32_t next_timeout(void)
 {
 	struct _timeout *to = first();
 	int32_t ticks_elapsed = elapsed();
-	int32_t ret = to == NULL ? MAX_WAIT : MAX(0, to->dticks - ticks_elapsed);
+	int32_t ret = to == NULL ? MAX_WAIT
+		: MIN(MAX_WAIT, MAX(0, to->dticks - ticks_elapsed));
 
 #ifdef CONFIG_TIMESLICING
 	if (_current_cpu->slice_ticks && _current_cpu->slice_ticks < ret) {


### PR DESCRIPTION
When to->dticks is an int64_t it may happen that the calculated remaining time is a value that cannot be exactly represented in the destination int32_t, producing an implementation-defined result which can include a signal (interrupt).  Cap the maximum delay to the largest value suported by the int32_t result.

See also: https://github.com/zephyrproject-rtos/zephyr/pull/28416#discussion_r489050815

Fixes #26354