### PR TITLE
tracing: swap: bug fix and enhancement for ARC

### DIFF
--- a/arch/arc/core/fast_irq.S
+++ b/arch/arc/core/fast_irq.S
@@ -306,6 +306,16 @@ _firq_return_from_coop:
 	or.nz r0, r0, _ARC_V2_STATUS32_IE
 	sr r0, [_ARC_V2_STATUS32_P0]
 
+#ifdef CONFIG_TRACING
+	push_s blink
+	push_s r2
+
+	bl sys_trace_thread_switched_in
+	
+	pop_s r2
+	pop_s blink
+#endif
+
 	ld r0, [r2, _thread_offset_to_return_value]
 	rtie
 
@@ -319,6 +329,13 @@ _firq_return_from_firq:
 	sr ilink, [_ARC_V2_STATUS32_P0]
 	ld ilink, [sp, -8] /* pc into ilink */
 
+#ifdef CONFIG_TRACING
+	push_s blink
+
+	bl sys_trace_thread_switched_in
+
+	pop_s blink
+#endif
 	/* LP registers are already restored, just switch back to bank 0 */
 	rtie
 

--- a/arch/arc/core/regular_irq.S
+++ b/arch/arc/core/regular_irq.S
@@ -255,6 +255,13 @@ _rirq_return_from_coop:
 .balign 4
 _rirq_return_from_firq:
 _rirq_return_from_rirq:
+#ifdef CONFIG_TRACING
+	push_s blink
+
+	bl sys_trace_thread_switched_in
+
+	pop_s blink
+#endif
 _rirq_no_reschedule:
 
 	rtie

--- a/arch/arc/core/swap.S
+++ b/arch/arc/core/swap.S
@@ -176,6 +176,16 @@ return_loc:
 	pop_s r3    /* status32 into r3 */
 	kflag r3    /* write status32 */
 
+#ifdef CONFIG_TRACING
+	push_s blink
+	push_s r1
+
+	bl sys_trace_thread_switched_in
+
+	pop_s r1
+	pop_s blink
+#endif
+
 	j_s.d [blink] /* always execute delay slot */
 	seti r1       /* delay slot */
 
@@ -206,6 +216,13 @@ _swap_return_from_firq:
 	sr r3, [_ARC_V2_AUX_IRQ_ACT]
 
 _swap_already_in_irq:
+#ifdef CONFIG_TRACING
+	push_s blink
+
+	bl sys_trace_thread_switched_in
+
+	pop_s blink
+#endif
 	rtie
 
 .balign 4
@@ -226,6 +243,13 @@ _return_from_exc:
 	sr ilink, [_ARC_V2_ERSTATUS]
 	add_s sp, sp, ___isf_t_status32_OFFSET - ___isf_t_pc_OFFSET + 4
 
+#ifdef CONFIG_TRACING
+	push_s blink
+
+	bl sys_trace_thread_switched_in
+
+	pop_s blink
+#endif
 	rtie
 
 

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -126,7 +126,7 @@ static inline int z_swap_irqlock(unsigned int key)
 #endif
 #endif
 	ret = __swap(key);
-#ifndef CONFIG_ARM
+#if !defined(CONFIG_ARM) && !defined(CONFIG_ARC)
 #ifdef CONFIG_TRACING
 	sys_trace_thread_switched_in();
 #endif


### PR DESCRIPTION
Describe in #27771 cpu_stats profiling function doesn’t work as expected. we need to do some fixes.

For regular context switch:
move switched_in into the arch context switch assembly code,
which will correctly record the switched_in information.

For irq context switch:
add switched_in/switched_out for context switch in irq exit.

Fixes: #27771