### PR TITLE
doc: net: Add note about socket API thread safe status

### DIFF
--- a/doc/reference/networking/sockets.rst
+++ b/doc/reference/networking/sockets.rst
@@ -146,6 +146,11 @@ Secure sockets offer the following options for socket management:
 API Reference
 *************
 
+Note that current socket API implementation is not thread safe and caller
+should not do socket operations to same socket from multiple threads unless
+protected by a mutex, semaphore or similar.
+
+
 BSD Sockets
 ===========
 


### PR DESCRIPTION
Currently the socket API is not thread safe so mention this in
socket API documentation. The plan is to add locks in 2.5 release.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>