### PR TITLE
drivers: eth: Fix return value if we run out of bufs in TX

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -207,7 +207,7 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 #endif /* CONFIG_SOC_SERIES_STM32H7X */
 
 	if (net_pkt_read(pkt, dma_buffer, total_len)) {
-		res = -EIO;
+		res = -ENOBUFS;
 		goto error;
 	}
 


### PR DESCRIPTION
The correct return value is -ENOBUFS if we run out of network
buffers when sending the packets.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>