### PR TITLE
sys: byteorder: Fix sys_get_be48/le48 and add missing tests

### DIFF
--- a/include/sys/byteorder.h
+++ b/include/sys/byteorder.h
@@ -421,7 +421,7 @@ static inline uint32_t sys_get_be32(const uint8_t src[4])
  */
 static inline uint64_t sys_get_be48(const uint8_t src[6])
 {
-	return ((uint64_t)sys_get_be32(&src[0]) << 32) | sys_get_be16(&src[4]);
+	return ((uint64_t)sys_get_be32(&src[0]) << 16) | sys_get_be16(&src[4]);
 }
 
 /**
@@ -496,7 +496,7 @@ static inline uint32_t sys_get_le32(const uint8_t src[4])
  */
 static inline uint64_t sys_get_le48(const uint8_t src[6])
 {
-	return ((uint64_t)sys_get_le32(&src[2]) << 32) | sys_get_le16(&src[0]);
+	return ((uint64_t)sys_get_le32(&src[2]) << 16) | sys_get_le16(&src[0]);
 }
 
 /**

--- a/tests/kernel/common/src/byteorder.c
+++ b/tests/kernel/common/src/byteorder.c
@@ -184,6 +184,45 @@ void test_sys_put_be32(void)
 }
 
 /**
+ * @brief Test sys_get_be24() functionality
+ *
+ * @details Test if sys_get_be24() correctly handles endianness.
+ *
+ * @see sys_get_be24()
+ */
+void test_sys_get_be24(void)
+{
+	uint32_t val = 0xf0e1d2, tmp;
+	uint8_t buf[] = {
+		0xf0, 0xe1, 0xd2
+	};
+
+	tmp = sys_get_be24(buf);
+
+	zassert_equal(tmp, val, "sys_get_be24() failed");
+}
+
+/**
+ * @brief Test sys_put_be24() functionality
+ *
+ * @details Test if sys_put_be24() correctly handles endianness.
+ *
+ * @see sys_put_be24()
+ */
+void test_sys_put_be24(void)
+{
+	uint64_t val = 0xf0e1d2;
+	uint8_t buf[] = {
+		0xf0, 0xe1, 0xd2
+	};
+	uint8_t tmp[sizeof(buf)];
+
+	sys_put_be24(val, tmp);
+
+	zassert_mem_equal(tmp, buf, sizeof(buf), "sys_put_be24() failed");
+}
+
+/**
  * @brief Test sys_get_be16() functionality
  *
  * @details Test if sys_get_be16() correctly handles endianness.
@@ -259,6 +298,45 @@ void test_sys_put_le16(void)
 	sys_put_le16(val, tmp);
 
 	zassert_mem_equal(tmp, buf, sizeof(uint16_t), "sys_put_le16() failed");
+}
+
+/**
+ * @brief Test sys_get_le24() functionality
+ *
+ * @details Test if sys_get_le24() correctly handles endianness.
+ *
+ * @see sys_get_le24()
+ */
+void test_sys_get_le24(void)
+{
+	uint32_t val = 0xf0e1d2, tmp;
+	uint8_t buf[] = {
+		0xd2, 0xe1, 0xf0
+	};
+
+	tmp = sys_get_le24(buf);
+
+	zassert_equal(tmp, val, "sys_get_le24() failed");
+}
+
+/**
+ * @brief Test sys_put_le24() functionality
+ *
+ * @details Test if sys_put_le24() correctly handles endianness.
+ *
+ * @see sys_put_le24()
+ */
+void test_sys_put_le24(void)
+{
+	uint64_t val = 0xf0e1d2;
+	uint8_t buf[] = {
+		0xd2, 0xe1, 0xf0
+	};
+	uint8_t tmp[sizeof(uint32_t)];
+
+	sys_put_le24(val, tmp);
+
+	zassert_mem_equal(tmp, buf, sizeof(buf), "sys_put_le24() failed");
 }
 
 /**

--- a/tests/kernel/common/src/byteorder.c
+++ b/tests/kernel/common/src/byteorder.c
@@ -107,6 +107,44 @@ void test_sys_put_be64(void)
 }
 
 /**
+ * @brief Test sys_get_be48() functionality
+ *
+ * @details Test if sys_get_be48() correctly handles endianness.
+ *
+ * @see sys_get_be48()
+ */
+void test_sys_get_be48(void)
+{
+	uint64_t val = 0xf0e1d2c3b4a5, tmp;
+	uint8_t buf[] = {
+		0xf0, 0xe1, 0xd2, 0xc3, 0xb4, 0xa5
+	};
+
+	tmp = sys_get_be48(buf);
+
+	zassert_equal(tmp, val, "sys_get_be64() failed");
+}
+
+/**
+ * @brief Test sys_put_be48() functionality
+ *
+ * @details Test if sys_put_be48() correctly handles endianness.
+ *
+ * @see sys_put_be48()
+ */
+void test_sys_put_be48(void)
+{
+	uint64_t val = 0xf0e1d2c3b4a5;
+	uint8_t buf[] = {
+		0xf0, 0xe1, 0xd2, 0xc3, 0xb4, 0xa5
+	};
+	uint8_t tmp[sizeof(buf)];
+
+	sys_put_be48(val, tmp);
+	zassert_mem_equal(tmp, buf, sizeof(buf), "sys_put_be48() failed");
+}
+
+/**
  * @brief Test sys_get_be32() functionality
  *
  * @details Test if sys_get_be32() correctly handles endianness.
@@ -260,6 +298,45 @@ void test_sys_put_le32(void)
 	sys_put_le32(val, tmp);
 
 	zassert_mem_equal(tmp, buf, sizeof(uint32_t), "sys_put_le32() failed");
+}
+
+/**
+ * @brief Test sys_get_le48() functionality
+ *
+ * @details Test if sys_get_le48() correctly handles endianness.
+ *
+ * @see sys_get_le48()
+ */
+void test_sys_get_le48(void)
+{
+	uint64_t val = 0xf0e1d2c3b4a5, tmp;
+	uint8_t buf[] = {
+		0xa5, 0xb4, 0xc3, 0xd2, 0xe1, 0xf0
+	};
+
+	tmp = sys_get_le48(buf);
+
+	zassert_equal(tmp, val, "sys_get_le48() failed");
+}
+
+/**
+ * @brief Test sys_put_le48() functionality
+ *
+ * @details Test if sys_put_le48() correctly handles endianness.
+ *
+ * @see sys_put_le48()
+ */
+void test_sys_put_le48(void)
+{
+	uint64_t val = 0xf0e1d2c3b4a5;
+	uint8_t buf[] = {
+		0xa5, 0xb4, 0xc3, 0xd2, 0xe1, 0xf0
+	};
+	uint8_t tmp[sizeof(uint64_t)];
+
+	sys_put_le48(val, tmp);
+
+	zassert_mem_equal(tmp, buf, sizeof(buf), "sys_put_le48() failed");
 }
 
 /**

--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -18,10 +18,14 @@ extern void test_sys_get_be48(void);
 extern void test_sys_put_be48(void);
 extern void test_sys_get_be32(void);
 extern void test_sys_put_be32(void);
+extern void test_sys_get_be24(void);
+extern void test_sys_put_be24(void);
 extern void test_sys_get_be16(void);
 extern void test_sys_put_be16(void);
 extern void test_sys_get_le16(void);
 extern void test_sys_put_le16(void);
+extern void test_sys_get_le24(void);
+extern void test_sys_put_le24(void);
 extern void test_sys_get_le32(void);
 extern void test_sys_put_le32(void);
 extern void test_sys_get_le48(void);
@@ -114,10 +118,14 @@ void test_main(void)
 			 ztest_unit_test(test_sys_put_be48),
 			 ztest_unit_test(test_sys_get_be32),
 			 ztest_unit_test(test_sys_put_be32),
+			 ztest_unit_test(test_sys_get_be24),
+			 ztest_unit_test(test_sys_put_be24),
 			 ztest_unit_test(test_sys_get_be16),
 			 ztest_unit_test(test_sys_put_be16),
 			 ztest_unit_test(test_sys_get_le16),
 			 ztest_unit_test(test_sys_put_le16),
+			 ztest_unit_test(test_sys_get_le24),
+			 ztest_unit_test(test_sys_put_le24),
 			 ztest_unit_test(test_sys_get_le32),
 			 ztest_unit_test(test_sys_put_le32),
 			 ztest_unit_test(test_sys_get_le48),

--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -14,6 +14,8 @@ extern void test_byteorder_memcpy_swap(void);
 extern void test_byteorder_mem_swap(void);
 extern void test_sys_get_be64(void);
 extern void test_sys_put_be64(void);
+extern void test_sys_get_be48(void);
+extern void test_sys_put_be48(void);
 extern void test_sys_get_be32(void);
 extern void test_sys_put_be32(void);
 extern void test_sys_get_be16(void);
@@ -22,6 +24,8 @@ extern void test_sys_get_le16(void);
 extern void test_sys_put_le16(void);
 extern void test_sys_get_le32(void);
 extern void test_sys_put_le32(void);
+extern void test_sys_get_le48(void);
+extern void test_sys_put_le48(void);
 extern void test_sys_get_le64(void);
 extern void test_sys_put_le64(void);
 extern void test_atomic(void);
@@ -106,6 +110,8 @@ void test_main(void)
 			 ztest_unit_test(test_byteorder_mem_swap),
 			 ztest_unit_test(test_sys_get_be64),
 			 ztest_unit_test(test_sys_put_be64),
+			 ztest_unit_test(test_sys_get_be48),
+			 ztest_unit_test(test_sys_put_be48),
 			 ztest_unit_test(test_sys_get_be32),
 			 ztest_unit_test(test_sys_put_be32),
 			 ztest_unit_test(test_sys_get_be16),
@@ -114,6 +120,8 @@ void test_main(void)
 			 ztest_unit_test(test_sys_put_le16),
 			 ztest_unit_test(test_sys_get_le32),
 			 ztest_unit_test(test_sys_put_le32),
+			 ztest_unit_test(test_sys_get_le48),
+			 ztest_unit_test(test_sys_put_le48),
 			 ztest_unit_test(test_sys_get_le64),
 			 ztest_unit_test(test_sys_put_le64),
 			 ztest_user_unit_test(test_atomic),


### PR DESCRIPTION
The functions `sys_get_be48/le48` contain an incorrect shift that introduces two bytes of 0x00 in the middle of the 48-bit integer stored within an uint64_t. I split the fix into one commit, and added tests for the missing `sys_get/put` functions to the common test case within the kernel test suite.