### PR TITLE
drivers: usb_dc_nrfx: clear write/read flags after ep_disable

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1660,6 +1660,11 @@ int usb_dc_ep_disable(const uint8_t ep)
 
 	nrfx_usbd_ep_disable(ep_addr_to_nrfx(ep));
 	ep_ctx->cfg.en = false;
+	ep_ctx->read_pending = false;
+	ep_ctx->write_in_progress = false;
+	ep_ctx->buf.data = ep_ctx->buf.block.data;
+	ep_ctx->buf.curr = ep_ctx->buf.data;
+	ep_ctx->buf.len  = 0U;
 
 	return 0;
 }


### PR DESCRIPTION
If a loaded endpoint was disabled and then reconfigured,
it is not possible to start an IN transfer and
usb_dc_ep_write() returns -EAGAIN.

Clear write/read operations flags after endpoint is disabled.