### PR TITLE
lib: gui: lvgl: fixes for display rotation support

### DIFF
--- a/lib/gui/lvgl/lvgl.c
+++ b/lib/gui/lvgl/lvgl.c
@@ -225,11 +225,21 @@ static bool lvgl_pointer_kscan_read(lv_indev_drv_t *drv, lv_indev_data_t *data)
 	}
 
 	if (IS_ENABLED(CONFIG_LVGL_POINTER_KSCAN_INVERT_X)) {
-		prev.point.x = cap.x_resolution - prev.point.x;
+		if (cap.current_orientation == DISPLAY_ORIENTATION_NORMAL ||
+		    cap.current_orientation == DISPLAY_ORIENTATION_ROTATED_180) {
+			prev.point.x = cap.x_resolution - prev.point.x;
+		} else {
+			prev.point.x = cap.y_resolution - prev.point.x;
+		}
 	}
 
 	if (IS_ENABLED(CONFIG_LVGL_POINTER_KSCAN_INVERT_Y)) {
-		prev.point.y = cap.y_resolution - prev.point.y;
+		if (cap.current_orientation == DISPLAY_ORIENTATION_NORMAL ||
+		    cap.current_orientation == DISPLAY_ORIENTATION_ROTATED_180) {
+			prev.point.y = cap.y_resolution - prev.point.y;
+		} else {
+			prev.point.y = cap.x_resolution - prev.point.y;
+		}
 	}
 
 	/* rotate touch point to match display rotation */
@@ -237,8 +247,8 @@ static bool lvgl_pointer_kscan_read(lv_indev_drv_t *drv, lv_indev_data_t *data)
 		lv_coord_t x;
 
 		x = prev.point.x;
-		prev.point.x = cap.y_resolution - prev.point.y;
-		prev.point.y = x;
+		prev.point.x = prev.point.y;
+		prev.point.y = cap.y_resolution - x;
 	} else if (cap.current_orientation == DISPLAY_ORIENTATION_ROTATED_180) {
 		prev.point.x = cap.x_resolution - prev.point.x;
 		prev.point.y = cap.y_resolution - prev.point.y;
@@ -246,8 +256,8 @@ static bool lvgl_pointer_kscan_read(lv_indev_drv_t *drv, lv_indev_data_t *data)
 		lv_coord_t x;
 
 		x = prev.point.x;
-		prev.point.x = prev.point.y;
-		prev.point.y = cap.x_resolution - x;
+		prev.point.x = cap.x_resolution - prev.point.y;
+		prev.point.y = x;
 	}
 
 	*data = prev;


### PR DESCRIPTION
When rotation is 90 or 270 degrees X and Y resolution values will also be swapped, so we need to take that into account