### PR TITLE
Revert "doc: release: 2.4: note behavior change in device_get_binding"

### DIFF
--- a/doc/releases/release-notes-2.4.rst
+++ b/doc/releases/release-notes-2.4.rst
@@ -82,13 +82,6 @@ API Changes
   const qualifier loss on ISRs, all ISRs now take a ``const *void`` as a
   paremeter as well.
 
-* Formerly ``device_get_binding()`` would return the device pointer if
-  invoked before the corresponding device was initialized.  As of this
-  release it only returns the pointer if the device successfully
-  initialized.  A behavior change can be observed if initialization for
-  a device fetches (but does not use) the pointer for a device it
-  depends on before that device has been initialized.
-
 * The ``_gatt_`` and ``_GATT_`` infixes have been removed for the HRS, DIS
   and BAS APIs and the Kconfig options.
 


### PR DESCRIPTION
This reverts commit 6dde16d9f85a54c04d0c8f24813e959814aef76d.

The original behavior has been restored for this release.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>