### PR TITLE
doc: releases: add notes on core dump for v2.4 release

### DIFF
--- a/doc/releases/release-notes-2.4.rst
+++ b/doc/releases/release-notes-2.4.rst
@@ -609,6 +609,17 @@ Libraries / Subsystems
   In 2.3 extra arguments caused a fault.  Now the shell will report that the
   command cannot be processed.
 
+* Debug:
+
+  * Core Dump:
+
+    * Added the ability to do core dump when fatal error is encountered.
+      This allows dumping the CPU registers and memory content for offline
+      debugging.
+    * Cortex-M, x86, and x86-64 are supported in this release.
+    * A data output backend utilizing the logging subsystem is introduced
+      in this release.
+
 HALs
 ****
 


### PR DESCRIPTION
This adds a few lines regarding core dump in the v2.4 release
notes.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>