### PR TITLE
tests: latency_measure: move timing_init() earlier

### DIFF
--- a/tests/benchmarks/latency_measure/src/main.c
+++ b/tests/benchmarks/latency_measure/src/main.c
@@ -32,14 +32,14 @@ void test_thread(void *arg1, void *arg2, void *arg3)
 {
 	uint32_t freq;
 
+	timing_init();
+
 	bench_test_init();
 
 	freq = timing_freq_get_mhz();
 
 	TC_START("Time Measurement");
 	TC_PRINT("Timing results: Clock frequency: %u MHz\n", freq);
-
-	timing_init();
 
 	thread_switch_yield();
 


### PR DESCRIPTION
Move the call to timing_init() earlier before function call
to get frequency. Some arch/SoC/board require initialization
before there is a valid frequency value. Or else the printed
value would not be useful.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>