### PR TITLE
x86_64: Fix memory access size for locore EOI

### DIFF
--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -695,7 +695,7 @@ irq_dispatch:
 	wrmsr
 #else /* xAPIC */
 	movq z_loapic_regs, %rdx
-	movq %rax, LOAPIC_EOI(%rdx)
+	movl %eax, LOAPIC_EOI(%rdx)
 #endif /* CONFIG_X2APIC */
 
 	movq %gs:__x86_tss64_t_cpu_OFFSET, %rsi


### PR DESCRIPTION
Newer QEMU (5.1) hangs / timeouts on a number of tests on x86_64.  In
debugging the issue this is related to a fix in QEMU 5.1 that
validates memory region access.  QEMU has the APIC region only allowing
1 to 4 byte access.  64-bit access is treated as an error.

Change the APIC EOI access in locore.S back to just doing a 32-bit
access.

Fixes #28453

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>