### PR TITLE
kconfig: hide option for mcuboot support if image is mcuboot

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -382,10 +382,16 @@ config BOOTLOADER_SRAM_SIZE
 	  - Zephyr is a !XIP image, which implicitly assumes existence of a
 	  bootloader that loads the Zephyr !XIP image onto SRAM.
 
+config MCUBOOT
+	bool
+	help
+	  Hidden option used to indicate that the current image is MCUBoot
+
 config BOOTLOADER_MCUBOOT
 	bool "MCUboot bootloader support"
 	select USE_DT_CODE_PARTITION
 	imply INIT_ARCH_HW_AT_BOOT if ARCH_SUPPORTS_ARCH_HW_INIT
+	depends on !MCUBOOT
 	help
 	  This option signifies that the target uses MCUboot as a bootloader,
 	  or in other words that the image is to be chain-loaded by MCUboot.


### PR DESCRIPTION
Don't show the option for MCUBoot bootloader support
when the image being built is MCUBoot itself.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>