### PR TITLE
riscv: Fix passing -mabi/-march to linker

### DIFF
--- a/cmake/compiler/gcc/target_riscv.cmake
+++ b/cmake/compiler/gcc/target_riscv.cmake
@@ -31,4 +31,9 @@ if(CONFIG_COMPRESSED_ISA)
 endif()
 
 list(APPEND TOOLCHAIN_C_FLAGS -mabi=${riscv_mabi} -march=${riscv_march})
-list(APPEND TOOLCHAIN_LD_FLAGS -mabi=${riscv_mabi} -march=${riscv_march})
+
+# Since TOOLCHAIN_LD_FLAGS eventually gets passed to zephyr_check_compiler_flag
+# we need to treat -mabi/-march as a single option.  Otherwise
+# zephyr_check_compiler_flag will fail on RISC-V since they options are
+# expected to be set together.
+list(APPEND TOOLCHAIN_LD_FLAGS "-mabi=${riscv_mabi} -march=${riscv_march}")


### PR DESCRIPTION
TOOLCHAIN_LD_FLAGS gets passed to zephyr_ld_options() that will call
zephyr_check_compiler_flag().  Current zephyr_check_compiler_flag()
fails on RISC-V for -mabi/-march as the compiler expects them to be
set together.  To make this work we quote them together so they'll
get treated as a single option rather than two distinct options.

Doing the same for TOOLCHAIN_C_FLAGS isn't required and actually
doesn't work because target_compile_options will end up keeping
the quoting.

Fixes #28456

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>