### PR TITLE
Bluetooth: controller: Make RX prio thread stack configurable

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -59,7 +59,7 @@ config BT_CTLR_TIFS_HW_SUPPORT
 
 config BT_CTLR_RX_PRIO_STACK_SIZE
 	# Controller's Co-Operative high priority Rx thread stack size.
-	int "High priority Rx thread stack size" if !SOC_COMPATIBLE_NRF
+	int "High priority Rx thread stack size"
 	default 448
 
 config BT_CTLR_SETTINGS


### PR DESCRIPTION
Now that CONFIG_BT_CTLR_RX_PRIO_STACK_SIZE defines a stack size, allow
for it to be configurable from a .conf file just like the rest of the
threads in Bluetooth.

Fixes #27768.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>