### PR TITLE
boards: nordic: Turn hardware stack protection on by default

### DIFF
--- a/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840_defconfig
+++ b/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840_defconfig
@@ -7,6 +7,9 @@ CONFIG_BOARD_NRF21540DK_NRF52840=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
 # Enable RTT
 CONFIG_USE_SEGGER_RTT=y
 

--- a/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820_defconfig
+++ b/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820_defconfig
@@ -7,6 +7,9 @@ CONFIG_BOARD_NRF52833DK_NRF52820=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
 # Enable RTT
 CONFIG_USE_SEGGER_RTT=y
 

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833_defconfig
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833_defconfig
@@ -7,6 +7,9 @@ CONFIG_BOARD_NRF52833DK_NRF52833=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
 # Enable RTT
 CONFIG_USE_SEGGER_RTT=y
 

--- a/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811_defconfig
+++ b/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811_defconfig
@@ -9,6 +9,9 @@ CONFIG_BOARD_NRF52840DK_NRF52811=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
 # Enable UART
 CONFIG_SERIAL=y
 

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840_defconfig
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840_defconfig
@@ -7,6 +7,9 @@ CONFIG_BOARD_NRF52840DK_NRF52840=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
 # Enable RTT
 CONFIG_USE_SEGGER_RTT=y
 

--- a/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840_defconfig
+++ b/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840_defconfig
@@ -7,6 +7,9 @@ CONFIG_BOARD_NRF52840DONGLE_NRF52840=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
 # enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805_defconfig
+++ b/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805_defconfig
@@ -7,6 +7,9 @@ CONFIG_BOARD_NRF52DK_NRF52805=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
 # Enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810_defconfig
+++ b/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810_defconfig
@@ -7,6 +7,9 @@ CONFIG_BOARD_NRF52DK_NRF52810=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
 # enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832_defconfig
+++ b/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832_defconfig
@@ -7,6 +7,9 @@ CONFIG_BOARD_NRF52DK_NRF52832=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
 # Enable RTT
 CONFIG_USE_SEGGER_RTT=y
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp_defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp_defconfig
@@ -7,6 +7,9 @@ CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
 # Enable TrustZone-M
 CONFIG_ARM_TRUSTZONE_M=y
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuappns_defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuappns_defconfig
@@ -7,6 +7,9 @@ CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPPNS=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
 # Enable TrustZone-M
 CONFIG_ARM_TRUSTZONE_M=y
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet_defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet_defconfig
@@ -7,6 +7,9 @@ CONFIG_BOARD_NRF5340DK_NRF5340_CPUNET=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
 # enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpuapp_defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpuapp_defconfig
@@ -9,6 +9,9 @@ CONFIG_NRF5340_CPUAPP_ERRATUM19=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
 # Enable TrustZone-M
 CONFIG_ARM_TRUSTZONE_M=y
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpuappns_defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpuappns_defconfig
@@ -7,6 +7,9 @@ CONFIG_BOARD_NRF5340PDK_NRF5340_CPUAPPNS=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
 # Enable TrustZone-M
 CONFIG_ARM_TRUSTZONE_M=y
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpunet_defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpunet_defconfig
@@ -7,6 +7,9 @@ CONFIG_BOARD_NRF5340PDK_NRF5340_CPUNET=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
 # enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840_defconfig
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840_defconfig
@@ -7,6 +7,9 @@ CONFIG_BOARD_NRF9160DK_NRF52840=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
 # enable uart driver
 CONFIG_SERIAL=y
 CONFIG_UART_NRFX=y

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_defconfig
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_defconfig
@@ -7,6 +7,9 @@ CONFIG_BOARD_NRF9160DK_NRF9160=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
 # Enable TrustZone-M
 CONFIG_ARM_TRUSTZONE_M=y
 

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160ns_defconfig
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160ns_defconfig
@@ -7,6 +7,9 @@ CONFIG_BOARD_NRF9160DK_NRF9160NS=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
 # Enable TrustZone-M
 CONFIG_ARM_TRUSTZONE_M=y
 

--- a/boards/arm/thingy52_nrf52832/thingy52_nrf52832_defconfig
+++ b/boards/arm/thingy52_nrf52832/thingy52_nrf52832_defconfig
@@ -7,6 +7,9 @@ CONFIG_BOARD_THINGY52_NRF52832=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
 # enable GPIO
 CONFIG_GPIO=y
 


### PR DESCRIPTION

In all Nordic boards that contain ICs that support hardware stack
protection, turn it on by default so that we detect
stack overflows easier.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>