### PR TITLE
gsm_ppp start/stop

### DIFF
--- a/drivers/console/gsm_mux.c
+++ b/drivers/console/gsm_mux.c
@@ -1500,6 +1500,22 @@ int gsm_mux_send(struct gsm_mux *mux, uint8_t dlci_address,
 	return gsm_mux_send_data_msg(mux, true, dlci, FT_UIH, buf, size);
 }
 
+void gsm_mux_detach(struct gsm_mux *mux)
+{
+	struct gsm_dlci *dlci;
+
+	for (int i = 0; i < ARRAY_SIZE(dlcis); i++) {
+		dlci = &dlcis[i];
+
+		if (mux != dlci->mux || !dlci->in_use) {
+			continue;
+		}
+
+		dlci->in_use = false;
+		sys_slist_prepend(&dlci_free_entries, &dlci->node);
+	}
+}
+
 void gsm_mux_init(void)
 {
 	int i;

--- a/drivers/console/gsm_mux.h
+++ b/drivers/console/gsm_mux.h
@@ -36,3 +36,4 @@ int gsm_dlci_create(struct gsm_mux *mux,
 		    struct gsm_dlci **dlci);
 int gsm_dlci_send(struct gsm_dlci *dlci, const uint8_t *buf, size_t size);
 int gsm_dlci_id(struct gsm_dlci *dlci);
+void gsm_mux_detach(struct gsm_mux *mux);

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -12,6 +12,7 @@ LOG_MODULE_REGISTER(modem_gsm, CONFIG_MODEM_LOG_LEVEL);
 #include <sys/ring_buffer.h>
 #include <sys/util.h>
 #include <net/ppp.h>
+#include <drivers/gsm_ppp.h>
 #include <drivers/uart.h>
 #include <drivers/console/uart_mux.h>
 
@@ -750,5 +751,5 @@ static int gsm_init(const struct device *device)
 	return 0;
 }
 
-DEVICE_INIT(gsm_ppp, "modem_gsm", gsm_init, &gsm, NULL, POST_KERNEL,
+DEVICE_INIT(gsm_ppp, GSM_MODEM_DEVICE_NAME, gsm_init, &gsm, NULL, POST_KERNEL,
 	    CONFIG_MODEM_GSM_INIT_PRIORITY);

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -60,6 +60,8 @@ static struct gsm_modem {
 	const struct device *at_dev;
 	const struct device *control_dev;
 
+	struct net_if *iface;
+
 	bool mux_enabled : 1;
 	bool mux_setup_done : 1;
 	bool setup_done : 1;
@@ -290,18 +292,39 @@ static int gsm_setup_mccmno(struct gsm_modem *gsm)
 	return ret;
 }
 
+static struct net_if *ppp_net_if(void)
+{
+	return net_if_get_first_by_type(&NET_L2_GET_NAME(PPP));
+}
+
 static void set_ppp_carrier_on(struct gsm_modem *gsm)
 {
-	const struct device *ppp_dev = device_get_binding(CONFIG_NET_PPP_DRV_NAME);
-	const struct ppp_api *api;
+	static const struct ppp_api *api;
+	const struct device *ppp_dev =
+		device_get_binding(CONFIG_NET_PPP_DRV_NAME);
+	struct net_if *iface = gsm->iface;
+	int ret;
 
 	if (!ppp_dev) {
-		LOG_ERR("Cannot find PPP %s!", "device");
+		LOG_ERR("Cannot find PPP %s!", CONFIG_NET_PPP_DRV_NAME);
 		return;
 	}
 
-	api = (const struct ppp_api *)ppp_dev->api;
-	api->start(ppp_dev);
+	if (!api) {
+		api = (const struct ppp_api *)ppp_dev->api;
+
+		/* For the first call, we want to call ppp_start()... */
+		ret = api->start(ppp_dev);
+		if (ret) {
+			LOG_ERR("ppp start returned %d", ret);
+		}
+	} else {
+		/* ...but subsequent calls should be to ppp_enable() */
+		ret = net_if_l2(iface)->enable(iface, true);
+		if (ret) {
+			LOG_ERR("ppp l2 enable returned %d", ret);
+		}
+	}
 }
 
 static void gsm_finalize_connection(struct gsm_modem *gsm)
@@ -316,7 +339,7 @@ static void gsm_finalize_connection(struct gsm_modem *gsm)
 				     "AT", &gsm->sem_response,
 				     GSM_CMD_AT_TIMEOUT);
 		if (ret < 0) {
-			LOG_DBG("modem setup returned %d, %s",
+			LOG_ERR("modem setup returned %d, %s",
 				ret, "retrying...");
 			(void)k_delayed_work_submit(&gsm->gsm_configure_work,
 						    K_SECONDS(1));
@@ -357,13 +380,6 @@ static void gsm_finalize_connection(struct gsm_modem *gsm)
 	}
 
 	gsm->setup_done = true;
-
-	/* If we are not muxing, the modem interface and gsm_rx() thread is not
-	 * needed as PPP will handle the incoming traffic internally.
-	 */
-	if (!IS_ENABLED(CONFIG_GSM_MUX)) {
-		k_thread_abort(&gsm_rx_thread);
-	}
 
 	set_ppp_carrier_on(gsm);
 
@@ -476,14 +492,24 @@ static void mux_setup(struct k_work *work)
 	const struct device *uart = device_get_binding(CONFIG_MODEM_GSM_UART_NAME);
 	int ret;
 
+	/* We need to call this to reactivate mux ISR. Note: This is only called
+	 * after re-initing gsm_ppp.
+	 */
+	if (IS_ENABLED(CONFIG_GSM_MUX) &&
+	    gsm->ppp_dev && gsm->state == STATE_CONTROL_CHANNEL) {
+		uart_mux_enable(gsm->ppp_dev);
+	}
+
 	switch (gsm->state) {
 	case STATE_CONTROL_CHANNEL:
 		/* Get UART device. There is one dev / DLCI */
-		gsm->control_dev = uart_mux_alloc();
 		if (gsm->control_dev == NULL) {
-			LOG_DBG("Cannot get UART mux for %s channel",
-				"control");
-			goto fail;
+			gsm->control_dev = uart_mux_alloc();
+			if (gsm->control_dev == NULL) {
+				LOG_DBG("Cannot get UART mux for %s channel",
+					"control");
+				goto fail;
+			}
 		}
 
 		gsm->state = STATE_PPP_CHANNEL;
@@ -496,10 +522,13 @@ static void mux_setup(struct k_work *work)
 		break;
 
 	case STATE_PPP_CHANNEL:
-		gsm->ppp_dev = uart_mux_alloc();
 		if (gsm->ppp_dev == NULL) {
-			LOG_DBG("Cannot get UART mux for %s channel", "PPP");
-			goto fail;
+			gsm->ppp_dev = uart_mux_alloc();
+			if (gsm->ppp_dev == NULL) {
+				LOG_DBG("Cannot get UART mux for %s channel",
+					"PPP");
+				goto fail;
+			}
 		}
 
 		gsm->state = STATE_AT_CHANNEL;
@@ -512,10 +541,13 @@ static void mux_setup(struct k_work *work)
 		break;
 
 	case STATE_AT_CHANNEL:
-		gsm->at_dev = uart_mux_alloc();
 		if (gsm->at_dev == NULL) {
-			LOG_DBG("Cannot get UART mux for %s channel", "AT");
-			goto fail;
+			gsm->at_dev = uart_mux_alloc();
+			if (gsm->at_dev == NULL) {
+				LOG_DBG("Cannot get UART mux for %s channel",
+					"AT");
+				goto fail;
+			}
 		}
 
 		gsm->state = STATE_DONE;
@@ -588,6 +620,9 @@ static void gsm_configure(struct k_work *work)
 			gsm->mux_enabled = true;
 		} else {
 			gsm->mux_enabled = false;
+			(void)k_delayed_work_submit(&gsm->gsm_configure_work,
+						    K_NO_WAIT);
+			return;
 		}
 
 		LOG_DBG("GSM muxing %s", gsm->mux_enabled ? "enabled" :
@@ -606,6 +641,39 @@ static void gsm_configure(struct k_work *work)
 	}
 
 	gsm_finalize_connection(gsm);
+}
+
+void gsm_ppp_start(const struct device *device)
+{
+	struct gsm_modem *gsm = device->data;
+
+	/* Re-init underlying UART comms */
+	int r = modem_iface_uart_init_dev(&gsm->context.iface,
+					  CONFIG_MODEM_GSM_UART_NAME);
+	if (r) {
+		LOG_ERR("modem_iface_uart_init returned %d", r);
+		return;
+	}
+
+	k_delayed_work_init(&gsm->gsm_configure_work, gsm_configure);
+	(void)k_delayed_work_submit(&gsm->gsm_configure_work, K_NO_WAIT);
+}
+
+void gsm_ppp_stop(const struct device *device)
+{
+	struct gsm_modem *gsm = device->data;
+	struct net_if *iface = gsm->iface;
+
+	net_if_l2(iface)->enable(iface, false);
+
+	if (IS_ENABLED(CONFIG_GSM_MUX)) {
+		/* Lower mux_enabled flag to trigger re-sending AT+CMUX etc */
+		gsm->mux_enabled = false;
+
+		if (gsm->ppp_dev) {
+			uart_mux_disable(gsm->ppp_dev);
+		}
+	}
 }
 
 static int gsm_init(const struct device *device)
@@ -671,9 +739,13 @@ static int gsm_init(const struct device *device)
 			gsm, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
 	k_thread_name_set(&gsm_rx_thread, "gsm_rx");
 
-	k_delayed_work_init(&gsm->gsm_configure_work, gsm_configure);
+	gsm->iface = ppp_net_if();
+	if (!gsm->iface) {
+		LOG_ERR("Couldn't find ppp net_if!");
+		return -ENODEV;
+	}
 
-	(void)k_delayed_work_submit(&gsm->gsm_configure_work, K_NO_WAIT);
+	gsm_ppp_start(device);
 
 	return 0;
 }

--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -554,7 +554,8 @@ int modem_cmd_handler_setup_cmds(struct modem_iface *iface,
 		}
 
 		if (ret < 0) {
-			LOG_ERR("command %s ret:%d", log_strdup(cmds[i].send_cmd), ret);
+			LOG_ERR("command %s ret:%d",
+				log_strdup(cmds[i].send_cmd), ret);
 			break;
 		}
 	}

--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -554,7 +554,7 @@ int modem_cmd_handler_setup_cmds(struct modem_iface *iface,
 		}
 
 		if (ret < 0) {
-			LOG_ERR("command %s ret:%d", cmds[i].send_cmd, ret);
+			LOG_ERR("command %s ret:%d", log_strdup(cmds[i].send_cmd), ret);
 			break;
 		}
 	}

--- a/drivers/modem/modem_iface_uart.c
+++ b/drivers/modem/modem_iface_uart.c
@@ -125,6 +125,18 @@ static int modem_iface_uart_read(struct modem_iface *iface,
 	return 0;
 }
 
+static bool mux_is_active(struct modem_iface *iface)
+{
+	bool active = false;
+
+#if defined(CONFIG_UART_MUX_DEVICE_NAME)
+	const char *mux_name = CONFIG_UART_MUX_DEVICE_NAME;
+	active = (mux_name == iface->dev->name);
+#endif /* CONFIG_UART_MUX_DEVICE_NAME */
+
+	return active;
+}
+
 static int modem_iface_uart_write(struct modem_iface *iface,
 				  const uint8_t *buf, size_t size)
 {
@@ -136,9 +148,18 @@ static int modem_iface_uart_write(struct modem_iface *iface,
 		return 0;
 	}
 
-	do {
-		uart_poll_out(iface->dev, *buf++);
-	} while (--size);
+	/* If we're using gsm_mux, We don't want to use poll_out because sending
+	 * one byte at a time causes each byte to get wrapped in muxing headers.
+	 * But we can safely call uart_fifo_fill outside of ISR context when
+	 * muxing because uart_mux implements it in software.
+	 */
+	if (mux_is_active(iface)) {
+		uart_fifo_fill(iface->dev, buf, size);
+	} else {
+		do {
+			uart_poll_out(iface->dev, *buf++);
+		} while (--size);
+	}
 
 	return 0;
 }

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -847,7 +847,7 @@ static int ppp_start(const struct device *dev)
 			return -EINVAL;
 		}
 
-		LOG_DBG("Initializing PPP to use %s", dev_name);
+		LOG_INF("Initializing PPP to use %s", dev_name);
 
 		context->dev = device_get_binding(dev_name);
 		if (!context->dev) {
@@ -874,7 +874,7 @@ static int ppp_stop(const struct device *dev)
 	struct ppp_driver_context *context = dev->data;
 
 	net_ppp_carrier_off(context->iface);
-
+	context->modem_init_done = false;
 	return 0;
 }
 

--- a/include/drivers/console/uart_mux.h
+++ b/include/drivers/console/uart_mux.h
@@ -128,6 +128,25 @@ typedef void (*uart_mux_cb_t)(const struct device *uart,
  */
 void uart_mux_foreach(uart_mux_cb_t cb, void *user_data);
 
+/**
+ * @brief Disable the mux.
+ *
+ * @details Disable does not re-instate whatever ISRs and configs were present
+ * before the mux was enabled. This must be done by the user.
+ *
+ * @param dev UART mux device pointer
+ */
+void uart_mux_disable(const struct device *dev);
+
+/**
+ * @brief Enable the mux.
+ *
+ * @details Enables the correct ISRs for the UART mux.
+ *
+ * @param dev UART mux device pointer
+ */
+void uart_mux_enable(const struct device *dev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/drivers/gsm_ppp.h
+++ b/include/drivers/gsm_ppp.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2020 Endian Technologies AB
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef GSM_PPP_H_
+#define GSM_PPP_H_
+
+
+/** @cond INTERNAL_HIDDEN */
+struct device;
+void gsm_ppp_start(const struct device *device);
+void gsm_ppp_stop(const struct device *device);
+/** @endcond */
+
+#endif /* GSM_PPP_H_ */

--- a/include/drivers/gsm_ppp.h
+++ b/include/drivers/gsm_ppp.h
@@ -7,6 +7,7 @@
 #ifndef GSM_PPP_H_
 #define GSM_PPP_H_
 
+#define GSM_MODEM_DEVICE_NAME "modem_gsm"
 
 /** @cond INTERNAL_HIDDEN */
 struct device;

--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -349,8 +349,10 @@ static void ipcp_down(struct ppp_fsm *fsm)
 	struct ppp_context *ctx = CONTAINER_OF(fsm, struct ppp_context,
 					       ipcp.fsm);
 
-	if (ctx->is_ipcp_up) {
-		net_if_ipv4_addr_rm(ctx->iface, &ctx->ipcp.my_options.address);
+	/* Ensure address is always removed if it exists */
+	if (ctx->ipcp.my_options.address.s_addr) {
+		(void)net_if_ipv4_addr_rm(
+			ctx->iface, &ctx->ipcp.my_options.address);
 	}
 
 	memset(&ctx->ipcp.my_options.address, 0,
@@ -365,10 +367,6 @@ static void ipcp_down(struct ppp_fsm *fsm)
 	}
 
 	ctx->is_ipcp_up = false;
-
-	if (!net_if_ipv4_addr_rm(ctx->iface, &ctx->ipcp.my_options.address)) {
-		NET_ERR("Failed removing address");
-	}
 
 	ppp_network_down(ctx, PPP_IP);
 }


### PR DESCRIPTION
PR for comments only at this stage. It's probably valid to remark on how we're exposing start/stop publically, but currently I'm mainly interested in program flow for `gsm_ppp.c` regarding start/stop. I've attempted to separate the "init" procedure from the "start" procedure. I.e. it should be possible to do:

```
gsm_ppp_stop(gsm_mdm);
my_modem_reset();
gsm_ppp_start(gsm_mdm);
```

without state desynchronization between modem driver and actual modem. It seems most stuff in `gsm_ppp.c` is fine as it is, but `mux_setup()` tries to allocate new UART contexts etc which looks dangerous. But you need both `mux_enable()` and `mux_setup()` to run after a modem reset, it's just that `mux_setup` needs to be more reentrant. 

Surely I'm missing stuff tho, for instance synchronizing with `gsm_rx` thread. Thoughts @pfl @jukkar  ?

Note: This is super WIP-y. I have NOT tested this yet. 