### PR TITLE
boards: nrf52840dongle: Enable serial conditionally

### DIFF
--- a/boards/arm/nrf52840dongle_nrf52840/Kconfig.defconfig
+++ b/boards/arm/nrf52840dongle_nrf52840/Kconfig.defconfig
@@ -32,6 +32,13 @@ config USB_NRFX
 config USB_DEVICE_STACK
 	default y
 
+# Enable UART driver, needed for CDC ACM
+config SERIAL
+	default USB_CDC_ACM
+
+config UART_INTERRUPT_DRIVEN
+	default USB_CDC_ACM
+
 endif # USB
 
 config BT_CTLR

--- a/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840_defconfig
+++ b/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840_defconfig
@@ -10,10 +10,6 @@ CONFIG_ARM_MPU=y
 # enable GPIO
 CONFIG_GPIO=y
 
-# Enable UART driver, needed for CDC ACM
-CONFIG_SERIAL=y
-CONFIG_UART_INTERRUPT_DRIVEN=y
-
 # enable console
 CONFIG_CONSOLE=y
 


### PR DESCRIPTION
Do not force SERIAL and UART_INTERRUPT_DRIVEN unconditionally.

Fixes #22892.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>