### PR TITLE
tests: devicetree: legacy_api: Exclude test on pinnacle_100_dvk

### DIFF
--- a/tests/lib/devicetree/legacy_api/testcase.yaml
+++ b/tests/lib/devicetree/legacy_api/testcase.yaml
@@ -5,3 +5,4 @@ tests:
     # will mostly likely be the fastest.
     integration_platforms:
       - native_posix
+    platform_exclude:  pinnacle_100_dvk


### PR DESCRIPTION
The pinnacle_100_dvk board fails this test, but it was added after the
legacy DTS supprot was deprecated so we will just exclude the board
from being built on this test.

Fixes #28480

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>