### PR TITLE
lib: posix: sem_wait: unchecked return value while taking semaphore (coverity)

### DIFF
--- a/lib/posix/semaphore.c
+++ b/lib/posix/semaphore.c
@@ -139,6 +139,7 @@ int sem_trywait(sem_t *semaphore)
  */
 int sem_wait(sem_t *semaphore)
 {
-	k_sem_take(semaphore, K_FOREVER);
+	/* With K_FOREVER, may return only success. */
+	(void)k_sem_take(semaphore, K_FOREVER);
 	return 0;
 }


### PR DESCRIPTION
According to the Coverity message value while taking
semaphore wasn't checked. Add check as it was made
in function above in the code.

Fixes #27146

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>