### PR TITLE
Bluetooth: L2CAP: Document behavior of alloc_buf

### DIFF
--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -219,7 +219,8 @@ struct bt_l2cap_chan_ops {
 	/** @brief Channel alloc_buf callback
 	 *
 	 *  If this callback is provided the channel will use it to allocate
-	 *  buffers to store incoming data.
+	 *  buffers to store incoming data. Channels that requires segmentation
+	 *  must set this callback.
 	 *
 	 *  @param chan The channel requesting a buffer.
 	 *


### PR DESCRIPTION
Channel that requires segmentation must set alloc_buf in order for the
stack to be able to reassemble segments of an SDU.

If this happens at runtime warn the user and truncate the MTU to
force segmentation to be disabled.

Fixed #28384

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>