### PR TITLE
x86_64: fix size to init stack at boot

### DIFF
--- a/arch/x86/core/intel64/cpu.c
+++ b/arch/x86/core/intel64/cpu.c
@@ -86,6 +86,8 @@ struct x86_cpuboot x86_cpuboot[] = {
 		.gs_base = &tss0,
 		.sp = (uint64_t) z_interrupt_stacks[0] +
 			Z_KERNEL_STACK_SIZE_ADJUST(CONFIG_ISR_STACK_SIZE),
+		.stack_size =
+			Z_KERNEL_STACK_SIZE_ADJUST(CONFIG_ISR_STACK_SIZE),
 		.fn = z_x86_prep_c,
 	},
 #if CONFIG_MP_NUM_CPUS > 1
@@ -120,6 +122,7 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 	uint8_t apic_id = x86_cpu_loapics[cpu_num];
 
 	x86_cpuboot[cpu_num].sp = (uint64_t) Z_KERNEL_STACK_BUFFER(stack) + sz;
+	x86_cpuboot[cpu_num].stack_size = sz;
 	x86_cpuboot[cpu_num].fn = fn;
 	x86_cpuboot[cpu_num].arg = arg;
 

--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -204,8 +204,9 @@ enter_code64:
 #ifdef CONFIG_INIT_STACKS
 	movq $0xAAAAAAAAAAAAAAAA, %rax
 	movq %rsp, %rdi
-	subq $CONFIG_ISR_STACK_SIZE, %rdi
-	movq $(CONFIG_ISR_STACK_SIZE >> 3), %rcx
+	subq __x86_cpuboot_t_stack_size_OFFSET(%rbp), %rdi
+	movq __x86_cpuboot_t_stack_size_OFFSET(%rbp), %rcx
+	shr $3, %rcx /* moving 8 bytes a time, so fewer repeats */
 	rep stosq
 #endif
 

--- a/arch/x86/core/offsets/intel64_offsets.c
+++ b/arch/x86/core/offsets/intel64_offsets.c
@@ -47,6 +47,7 @@ GEN_OFFSET_SYM(x86_cpuboot_t, ready);
 GEN_OFFSET_SYM(x86_cpuboot_t, tr);
 GEN_OFFSET_SYM(x86_cpuboot_t, gs_base);
 GEN_OFFSET_SYM(x86_cpuboot_t, sp);
+GEN_OFFSET_SYM(x86_cpuboot_t, stack_size);
 GEN_OFFSET_SYM(x86_cpuboot_t, fn);
 GEN_OFFSET_SYM(x86_cpuboot_t, arg);
 GEN_ABSOLUTE_SYM(__X86_CPUBOOT_SIZEOF, sizeof(x86_cpuboot_t));

--- a/arch/x86/include/intel64/kernel_arch_data.h
+++ b/arch/x86/include/intel64/kernel_arch_data.h
@@ -23,6 +23,7 @@ struct x86_cpuboot {
 	uint16_t tr;		/* selector for task register */
 	struct x86_tss64 *gs_base; /* Base address for GS segment */
 	uint64_t sp;		/* initial stack pointer */
+	size_t stack_size;	/* size of stack */
 	arch_cpustart_t fn;	/* kernel entry function */
 	void *arg;		/* argument for above function */
 };


### PR DESCRIPTION
The boot code of x86_64 initializes the stack (if enabled)
with a hard-coded size for the ISR stack. However,
the stack being used does not have to be the ISR stack,
and can be any defined stacks. So pass in the actual size
of the stack so the stack can be initialized properly.

Fixes #21843

Signed-off-by: Daniel Leung <daniel.leung@intel.com>