### PR TITLE
cmake: extend target_ld_options() to support grouping of flags

### DIFF
--- a/cmake/compiler/gcc/target_riscv.cmake
+++ b/cmake/compiler/gcc/target_riscv.cmake
@@ -31,4 +31,4 @@ if(CONFIG_COMPRESSED_ISA)
 endif()
 
 list(APPEND TOOLCHAIN_C_FLAGS -mabi=${riscv_mabi} -march=${riscv_march})
-list(APPEND TOOLCHAIN_LD_FLAGS -mabi=${riscv_mabi} -march=${riscv_march})
+list(APPEND TOOLCHAIN_LD_FLAGS NO_SPLIT -mabi=${riscv_mabi} -march=${riscv_march})

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -253,6 +253,9 @@ function(zephyr_get_parse_args return_dict)
     if(x STREQUAL STRIP_PREFIX)
       set(${return_dict}_STRIP_PREFIX 1 PARENT_SCOPE)
     endif()
+    if(x STREQUAL NO_SPLIT)
+      set(${return_dict}_NO_SPLIT 1 PARENT_SCOPE)
+    endif()
   endforeach()
 endfunction()
 
@@ -1381,15 +1384,26 @@ function(target_cc_option_fallback target scope option1 option2)
 endfunction()
 
 function(target_ld_options target scope)
+  zephyr_get_parse_args(args ${ARGN})
+  list(REMOVE_ITEM ARGN NO_SPLIT)
+
   foreach(option ${ARGN})
-    string(MAKE_C_IDENTIFIER check${option} check)
+    if(args_NO_SPLIT)
+      set(option ${ARGN})
+    endif()
+    string(JOIN "" check_identifier "check" ${option})
+    string(MAKE_C_IDENTIFIER ${check_identifier} check)
 
     set(SAVED_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
-    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${option}")
+    string(JOIN " " CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS} ${option})
     zephyr_check_compiler_flag(C "" ${check})
     set(CMAKE_REQUIRED_FLAGS ${SAVED_CMAKE_REQUIRED_FLAGS})
 
     target_link_libraries_ifdef(${check} ${target} ${scope} ${option})
+
+    if(args_NO_SPLIT)
+      break()
+    endif()
   endforeach()
 endfunction()
 

--- a/cmake/linker/ld/target_base.cmake
+++ b/cmake/linker/ld/target_base.cmake
@@ -12,6 +12,9 @@ macro(toolchain_ld_base)
   # LINKERFLAGPREFIX comes from linker/ld/target.cmake
   zephyr_ld_options(
     ${TOOLCHAIN_LD_FLAGS}
+  )
+
+  zephyr_ld_options(
     ${LINKERFLAGPREFIX},--gc-sections
     ${LINKERFLAGPREFIX},--build-id=none
   )


### PR DESCRIPTION
Fixes #28456

This commit extends `target_ld_options()` with a NO_SPLIT flag.

Specifying `NO_SPLIT` will ensure that all linker flags will be applied
together when testing the compiler and linker.
This allows a caller to ensure that flags are tested together.

This fixes the RISC-V case where the flags `-mabi` and `-march` were
omitted because they were tested individually.

Note, the update of `target_ld_options()` will allow the same flag on
`zephyr_ld_options()`

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>