### PR TITLE
soc: arm: stm32[l4|wb]: fix power state exit

### DIFF
--- a/soc/arm/st_stm32/stm32l4/power.c
+++ b/soc/arm/st_stm32/stm32l4/power.c
@@ -93,6 +93,7 @@ void _sys_pm_power_state_exit_post_ops(enum power_states state)
 	case SYS_POWER_STATE_SLEEP_3:
 #endif /* CONFIG_HAS_SYS_POWER_STATE_SLEEP_3 */
 		LL_LPM_DisableSleepOnExit();
+		LL_LPM_EnableSleep();
 		break;
 #endif /* CONFIG_SYS_POWER_SLEEP_STATES */
 	default:

--- a/soc/arm/st_stm32/stm32wb/power.c
+++ b/soc/arm/st_stm32/stm32wb/power.c
@@ -93,6 +93,7 @@ void _sys_pm_power_state_exit_post_ops(enum power_states state)
 	case SYS_POWER_STATE_SLEEP_3:
 #endif /* CONFIG_HAS_SYS_POWER_STATE_SLEEP_3 */
 		LL_LPM_DisableSleepOnExit();
+		LL_LPM_EnableSleep();
 		break;
 #endif /* CONFIG_SYS_POWER_SLEEP_STATES */
 	default:


### PR DESCRIPTION
When we wake-up of deep sleep power state, we want to disable it.
Otherwise, when the cpu will go next to idle mode during a
SYS_POWER_STATE_ACTIVE, it will go into deep sleep mode
instead of a sleep mode.

fixes: #26896

Signed-off-by: Julien D'Ascenzio <jdascenzio@paratronic.fr>