### PR TITLE
arm64: Move out Broadcom code from reset

### DIFF
--- a/arch/arm/core/aarch64/arm_mmu.c
+++ b/arch/arm/core/aarch64/arm_mmu.c
@@ -409,7 +409,7 @@ static void enable_mmu_el1(unsigned int flags)
 	__asm__ volatile("mrs %0, sctlr_el1" : "=r" (val));
 	__asm__ volatile("msr sctlr_el1, %0"
 			:
-			: "r" (val | SCTLR_M_BIT | SCTLR_C_BIT)
+			: "r" (val | SCTLR_M | SCTLR_C)
 			: "memory", "cc");
 
 	/* Ensure the MMU enable takes effect immediately */
@@ -439,7 +439,7 @@ static int arm_mmu_init(const struct device *arg)
 
 	/* Ensure that MMU is already not enabled */
 	__asm__ volatile("mrs %0, sctlr_el1" : "=r" (val));
-	__ASSERT((val & SCTLR_M_BIT) == 0, "MMU is already enabled\n");
+	__ASSERT((val & SCTLR_M) == 0, "MMU is already enabled\n");
 
 	MMU_DEBUG("xlat tables:\n");
 	MMU_DEBUG("base table(L%d): %p, %d entries\n", XLAT_TABLE_BASE_LEVEL,

--- a/arch/arm/core/aarch64/reset.S
+++ b/arch/arm/core/aarch64/reset.S
@@ -63,7 +63,7 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 	isb
 
 	/* Initialize sctlr_el3 to reset value */
-	mov_imm	x1, SCTLR_EL3_RES1
+	mov_imm	x1, (SCTLR_EL3_RES1 | SCTLR_EIS | SCTLR_EOS)
 	mrs     x0, sctlr_el3
 	orr	x0, x0, x1
 	msr	sctlr_el3, x0
@@ -101,7 +101,10 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 	msr	actlr_el3, x0
 
 	/* Initialize sctlr_el1 to reset value */
-	mov_imm	x0, SCTLR_EL1_RES1
+	mov_imm	x0, (SCTLR_EL1_LSMAOE | SCTLR_EL1_nTLSMD)
+	orr	x0, x0, #(SCTLR_EL1_SPAN | SCTLR_EIS)
+	orr	x0, x0, #(SCTLR_EL1_TSCXT)
+	orr	x0, x0, #(SCTLR_EOS)
 	msr	sctlr_el1, x0
 
 	/* Disable EA/IRQ/FIQ routing to EL3 and set EL1 to AArch64 */
@@ -124,7 +127,7 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 	 * Enable the instruction cache, stack pointer and data access
 	 * alignment checks.
 	 */
-	mov	x1, #(SCTLR_I_BIT | SCTLR_A_BIT | SCTLR_SA_BIT)
+	mov	x1, #(SCTLR_I | SCTLR_A | SCTLR_SA)
 	mrs	x0, sctlr_el3
 	orr	x0, x0, x1
 	msr	sctlr_el3, x0
@@ -147,7 +150,7 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 	 * Enable the instruction cache, stack pointer and data access
 	 * alignment checks.
 	 */
-	mov	x1, #(SCTLR_I_BIT | SCTLR_A_BIT | SCTLR_SA_BIT)
+	mov	x1, #(SCTLR_I | SCTLR_A | SCTLR_SA)
 	mrs	x0, sctlr_el2
 	orr	x0, x0, x1
 	msr	sctlr_el2, x0
@@ -164,7 +167,7 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 	/*
 	 * Enable the instruction cache and el1 stack alignment check.
 	 */
-	mov	x1, #(SCTLR_I_BIT | SCTLR_SA_BIT)
+	mov	x1, #(SCTLR_I | SCTLR_SA)
 	mrs	x0, sctlr_el1
 	orr	x0, x0, x1
 	msr	sctlr_el1, x0

--- a/arch/arm/core/aarch64/reset.S
+++ b/arch/arm/core/aarch64/reset.S
@@ -62,13 +62,6 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 	msr	vbar_el3, x19
 	isb
 
-	/* Initialize sctlr_el3 to reset value */
-	mov_imm	x1, (SCTLR_EL3_RES1 | SCTLR_EIS | SCTLR_EOS)
-	mrs     x0, sctlr_el3
-	orr	x0, x0, x1
-	msr	sctlr_el3, x0
-	isb
-
 	/* SError, IRQ and FIQ routing enablement in EL3 */
 	mrs	x0, scr_el3
 	orr	x0, x0, #(SCR_EL3_IRQ | SCR_EL3_FIQ | SCR_EL3_EA)
@@ -93,19 +86,6 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 	* Zephyr entry happened in EL3. Do EL3 specific init before
 	* dropping to lower EL.
 	*/
-	/* Enable access control configuration from lower EL */
-	mrs	x0, actlr_el3
-	orr     x0, x0, #(ACTLR_EL3_L2ACTLR | ACTLR_EL3_L2ECTLR \
-			 | ACTLR_EL3_L2CTLR)
-	orr     x0, x0, #(ACTLR_EL3_CPUACTLR | ACTLR_EL3_CPUECTLR)
-	msr	actlr_el3, x0
-
-	/* Initialize sctlr_el1 to reset value */
-	mov_imm	x0, (SCTLR_EL1_LSMAOE | SCTLR_EL1_nTLSMD)
-	orr	x0, x0, #(SCTLR_EL1_SPAN | SCTLR_EIS)
-	orr	x0, x0, #(SCTLR_EL1_TSCXT)
-	orr	x0, x0, #(SCTLR_EOS)
-	msr	sctlr_el1, x0
 
 	/* Disable EA/IRQ/FIQ routing to EL3 and set EL1 to AArch64 */
 	mov	x0, xzr

--- a/include/arch/arm/aarch64/cpu.h
+++ b/include/arch/arm/aarch64/cpu.h
@@ -23,16 +23,21 @@
 #define SPSR_MODE_EL1H		(0x5)
 
 #define SCTLR_EL3_RES1		(BIT(29) | BIT(28) | BIT(23) | \
-				BIT(22) | BIT(18) | BIT(16) | \
-				BIT(11) | BIT(5) | BIT(4))
+				 BIT(18) | BIT(16) | BIT(5)  | \
+				 BIT(4))
 
-#define SCTLR_EL1_RES1		(BIT(29) | BIT(28) | BIT(23) | \
-				BIT(22) | BIT(20) | BIT(11))
-#define SCTLR_M_BIT		BIT(0)
-#define SCTLR_A_BIT		BIT(1)
-#define SCTLR_C_BIT		BIT(2)
-#define SCTLR_SA_BIT		BIT(3)
-#define SCTLR_I_BIT		BIT(12)
+#define SCTLR_M			BIT(0)
+#define SCTLR_A			BIT(1)
+#define SCTLR_C			BIT(2)
+#define SCTLR_SA		BIT(3)
+#define SCTLR_EOS		BIT(11)
+#define SCTLR_I			BIT(12)
+#define SCTLR_EIS		BIT(22)
+
+#define SCTLR_EL1_TSCXT		BIT(20)
+#define SCTLR_EL1_SPAN		BIT(23)
+#define SCTLR_EL1_nTLSMD	BIT(28)
+#define SCTLR_EL1_LSMAOE	BIT(29)
 
 #define CPACR_EL1_FPEN_NOTRAP	(0x3 << 20)
 

--- a/soc/arm/bcm_vk/viper/plat_core.S
+++ b/soc/arm/bcm_vk/viper/plat_core.S
@@ -20,6 +20,19 @@ GTEXT(plat_l2_init)
 
 SECTION_FUNC(TEXT, z_arch_el3_plat_init)
 
+	mov_imm	x1, (SCTLR_EL3_RES1 | SCTLR_EIS | SCTLR_EOS)
+	mrs	x0, sctlr_el3
+	orr	x0, x0, x1
+	msr	sctlr_el3, x0
+	isb
+
+	/* Initialize SCTLR_EL1 to reset value */
+	mov_imm	x0, (SCTLR_EL1_LSMAOE | SCTLR_EL1_nTLSMD)
+	orr	x0, x0, #(SCTLR_EL1_SPAN | SCTLR_EIS)
+	orr	x0, x0, #(SCTLR_EL1_TSCXT)
+	orr	x0, x0, #(SCTLR_EOS)
+	msr	sctlr_el1, x0
+
 	mov	x20, x30
 	/* Enable GIC v3 system interface */
 	mov_imm	x0, (ICC_SRE_ELx_DFB | ICC_SRE_ELx_DIB | \
@@ -33,9 +46,15 @@ SECTION_FUNC(TEXT, z_arch_el3_plat_init)
 
 
 SECTION_FUNC(TEXT,plat_l2_init)
-	/*
-	 * Set L2 Auxiliary Control Register of Cortex-A72
-	 */
+	/* Set L2 Auxiliary Control Register of Cortex-A72 */
+
+	/* Enable access control configuration from lower EL */
+	mrs	x0, actlr_el3
+	orr	x0, x0, #(ACTLR_EL3_L2ACTLR | ACTLR_EL3_L2ECTLR | \
+			  ACTLR_EL3_L2CTLR)
+	orr	x0, x0, #(ACTLR_EL3_CPUACTLR | ACTLR_EL3_CPUECTLR)
+	msr	actlr_el3, x0
+
 	/* Disable cluster coherency */
 	mrs	x0, CORTEX_A72_L2ACTLR_EL1
 	orr	x0, x0, #CORTEX_A72_L2ACTLR_DISABLE_ACE_SH_OR_CHI


### PR DESCRIPTION
@sandeepbrcm @Abhishek-brcm 

The reset code is polluted by some code that is not really generic but probably needed for the Broadcom boards. To keep the reset routine as general as possible it's better to move this code to the soc initialization code.