### PR TITLE
SoC: nrf53 and nrf91: fix partition sizes

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -128,18 +128,18 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x0000C000>;
+			reg = <0x00000000 0x00010000>;
 		};
-		slot0_partition: partition@c000 {
+		slot0_partition: partition@10000 {
 			label = "image-0";
 		};
-		slot0_ns_partition: partition@3e000 {
+		slot0_ns_partition: partition@50000 {
 			label = "image-0-nonsecure";
 		};
-		slot1_partition: partition@7e000 {
+		slot1_partition: partition@80000 {
 			label = "image-1";
 		};
-		slot1_ns_partition: partition@b0000 {
+		slot1_ns_partition: partition@c0000 {
 			label = "image-1-nonsecure";
 		};
 		scratch_partition: partition@f0000 {

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_partition_conf.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_partition_conf.dts
@@ -22,19 +22,19 @@
  */
 
 &slot0_partition {
-	reg = <0x0000c000 0x30000>;
+	reg = <0x00010000 0x40000>;
 };
 
 &slot0_ns_partition {
-	reg = <0x0003e000 0x40000>;
+	reg = <0x00050000 0x30000>;
 };
 
 &slot1_partition {
-	reg = <0x0007e000 0x30000>;
+	reg = <0x00080000 0x40000>;
 };
 
 &slot1_ns_partition {
-	reg = <0x000b0000 0x40000>;
+	reg = <0x000c0000 0x30000>;
 };
 
 /* Default SRAM planning when building for nRF5340 with

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuappns.yaml
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuappns.yaml
@@ -7,7 +7,7 @@ toolchain:
   - xtools
   - zephyr
 ram: 384
-flash: 256
+flash: 192
 supported:
   - i2c
   - pwm

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpuappns.yaml
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpuappns.yaml
@@ -7,7 +7,7 @@ toolchain:
   - xtools
   - zephyr
 ram: 384
-flash: 256
+flash: 192
 supported:
   - i2c
   - pwm

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -154,18 +154,18 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0xc000>;
+			reg = <0x00000000 0x10000>;
 		};
-		slot0_partition: partition@c000 {
+		slot0_partition: partition@10000 {
 			label = "image-0";
 		};
-		slot0_ns_partition: partition@3e000 {
+		slot0_ns_partition: partition@50000 {
 			label = "image-0-nonsecure";
 		};
-		slot1_partition: partition@7e000 {
+		slot1_partition: partition@80000 {
 			label = "image-1";
 		};
-		slot1_ns_partition: partition@b0000 {
+		slot1_ns_partition: partition@c0000 {
 			label = "image-1-nonsecure";
 		};
 		scratch_partition: partition@f0000 {

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_partition_conf.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_partition_conf.dts
@@ -22,19 +22,19 @@
  */
 
 &slot0_partition {
-	reg = <0x0000c000 0x30000>;
+	reg = <0x00010000 0x40000>;
 };
 
 &slot0_ns_partition {
-	reg = <0x0003e000 0x40000>;
+	reg = <0x00050000 0x30000>;
 };
 
 &slot1_partition {
-	reg = <0x0007e000 0x30000>;
+	reg = <0x00080000 0x40000>;
 };
 
 &slot1_ns_partition {
-	reg = <0x000b0000 0x40000>;
+	reg = <0x000c0000 0x30000>;
 };
 
 /* Default SRAM planning when building for nRF9160 with

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160ns.yaml
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160ns.yaml
@@ -7,7 +7,7 @@ toolchain:
   - xtools
   - zephyr
 ram: 128
-flash: 256
+flash: 192
 supported:
   - i2c
   - pwm


### PR DESCRIPTION
The work in https://github.com/zephyrproject-rtos/zephyr/pull/25874 has changed the starting addresses for the non-secure slot flash partitions for Nordic official DK boards with Cortex-M33 MCUs with TrustZone-m capability.

The new offsets of non-secure flash partitions do not comply with the requirements of the Nordic IDAU (SPU) and need a re-alignment. This PR fixes this for nRF53 and nRF91 (only the Nordic DK)