### PR TITLE
scripts: series-push-hook: Fix behavior after rebase

### DIFF
--- a/scripts/series-push-hook.sh
+++ b/scripts/series-push-hook.sh
@@ -22,15 +22,9 @@ then
 	# Handle delete
 	:
 else
-	if [ "$remote_sha" = $z40 ]
-	then
-		# New branch, examine all commits since $remote/master
-		base_commit=`git rev-parse $remote/master`
-		range="$base_commit..$local_sha"
-	else
-		# Update to existing branch, examine new commits
-		range="$remote_sha..$local_sha"
-	fi
+	# At each (forced) push, examine all commits since $remote/master
+	base_commit=`git rev-parse $remote/master`
+	range="$base_commit..$local_sha"
 
 	echo "Perform check patch"
 	${ZEPHYR_BASE}/scripts/checkpatch.pl --git $range


### PR DESCRIPTION
Avoids parsing the whole "before to now" commits after rebase.
Now, we just parse all commits since first commit of the branch
compared to master, each timer either at first push, forced push,
forced push after rebase.

Fixes #28509

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>