### PR TITLE
ci: create symlinks to each project repo

### DIFF
--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -37,9 +37,15 @@ git log -n 5 --oneline --decorate --abbrev=12
 
 # Setup module cache
 cd /workdir
-ln -s /var/lib/buildkite-agent/zephyr-module-cache/modules
-ln -s /var/lib/buildkite-agent/zephyr-module-cache/tools
-ln -s /var/lib/buildkite-agent/zephyr-module-cache/bootloader
+for dir in modules tools bootloader
+do
+   for repo in `cd /var/lib/buildkite-agent/zephyr-module-cache/$dir; find . -name .git -type d -prune|sed 's|/\.git||g'`
+   do
+      folder=`dirname $repo`
+      mkdir -p $dir/$folder
+      ln -s /var/lib/buildkite-agent/zephyr-module-cache/$dir/$repo $dir/$repo
+   done
+done
 cd /workdir/zephyr
 
 export JOB_NUM=$((${BUILDKITE_PARALLEL_JOB}+1))


### PR DESCRIPTION
With west 0.8.0 it is ensured that manifest path-prefix cannot be used
to escape the west workspace.

This results in the zephyr module cache optimization to not work.

By creating individual project links to cached repo, and
https://github.com/zephyrproject-rtos/west/pull/439
then it is possible to use symlinks for project optimization and still
ensure manifest files cannot escape the west workspace.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

-----

Fixes: https://github.com/zephyrproject-rtos/west/issues/437
Together with: https://github.com/zephyrproject-rtos/west/pull/439