### PR TITLE
dts/Kconfig: Remove HAS_DTS_I2C

### DIFF
--- a/drivers/eeprom/Kconfig
+++ b/drivers/eeprom/Kconfig
@@ -37,7 +37,7 @@ config EEPROM_AT2X
 
 config EEPROM_AT24
 	bool "Atmel AT24 (and compatible) I2C EEPROM support"
-	depends on (I2C && HAS_DTS_I2C)
+	depends on I2C
 	select EEPROM_AT2X
 	help
 	  Enable support for Atmel AT24 (and compatible) I2C EEPROMs.

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -8,7 +8,6 @@
 #
 menuconfig I2C
 	bool "I2C Drivers"
-	select HAS_DTS_I2C
 	help
 	  Enable I2C Driver Configuration
 

--- a/drivers/kscan/Kconfig.ft5336
+++ b/drivers/kscan/Kconfig.ft5336
@@ -4,7 +4,7 @@
 
 menuconfig KSCAN_FT5336
 	bool "FT5XX6/FT6XX6 capacitive touch panel driver"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C
 	help
 	  Enable driver for multiple Focaltech capacitive touch panel
 	  controllers. This driver should support FT5x06, FT5606, FT5x16,

--- a/drivers/led/Kconfig.ht16k33
+++ b/drivers/led/Kconfig.ht16k33
@@ -3,7 +3,7 @@
 
 menuconfig HT16K33
 	bool "HT16K33 LED driver"
-	depends on (I2C && HAS_DTS_I2C)
+	depends on I2C
 	help
 	  Enable LED driver for HT16K33.
 

--- a/drivers/sensor/adt7420/Kconfig
+++ b/drivers/sensor/adt7420/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig ADT7420
 	bool "ADT7420 Temperature Sensor"
-	depends on I2C && HAS_DTS_I2C && HAS_DTS_GPIO
+	depends on I2C && HAS_DTS_GPIO
 	help
 	  Enable the driver for Analog Devices ADT7420 High-Accuracy
 	  16-bit Digital I2C Temperature Sensors.

--- a/drivers/sensor/adxl372/Kconfig
+++ b/drivers/sensor/adxl372/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig ADXL372
 	bool "ADXL372 Three Axis High-g I2C/SPI accelerometer"
-	depends on (I2C && HAS_DTS_I2C) || SPI
+	depends on I2C || SPI
 	help
 	  Enable driver for ADXL372 Three-Axis Digital Accelerometers.
 

--- a/drivers/sensor/ams_iAQcore/Kconfig
+++ b/drivers/sensor/ams_iAQcore/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig AMS_IAQ_CORE
 	bool "iAQ-core Digital VOC sensor"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C
 	help
 	  Enable driver for iAQ-core Digital VOC sensor.
 

--- a/drivers/sensor/apds9960/Kconfig
+++ b/drivers/sensor/apds9960/Kconfig
@@ -4,7 +4,7 @@
 
 menuconfig APDS9960
 	bool "APDS9960 Sensor"
-	depends on I2C && HAS_DTS_I2C && HAS_DTS_GPIO
+	depends on I2C && HAS_DTS_GPIO
 	help
 	  Enable driver for APDS9960 sensors.
 

--- a/drivers/sensor/bq274xx/Kconfig
+++ b/drivers/sensor/bq274xx/Kconfig
@@ -4,6 +4,6 @@
 
 config BQ274XX
 	bool "BQ274xx Fuel Gauge"
-	depends on (I2C && HAS_DTS_I2C)
+	depends on I2C
 	help
 	  Enable I2C-based driver for BQ274xx Fuel Gauge.

--- a/drivers/sensor/ccs811/Kconfig
+++ b/drivers/sensor/ccs811/Kconfig
@@ -7,7 +7,7 @@
 
 menuconfig CCS811
 	bool "CCS811 Digital Gas Sensor"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C
 	help
 	  Enable driver for CCS811 Gas sensors.
 

--- a/drivers/sensor/ens210/Kconfig
+++ b/drivers/sensor/ens210/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig ENS210
 	bool "ENS210 Digital Temperature and Humidity sensor"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C
 	help
 	  Enable driver for ENS210 Digital Temperature and Humidity sensor.
 if ENS210

--- a/drivers/sensor/fxas21002/Kconfig
+++ b/drivers/sensor/fxas21002/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig FXAS21002
 	bool "FXAS21002 gyroscope driver"
-	depends on I2C && HAS_DTS_I2C && HAS_DTS_GPIO
+	depends on I2C && HAS_DTS_GPIO
 	help
 	  Enable driver for the FXAS21002 gyroscope
 

--- a/drivers/sensor/fxos8700/Kconfig
+++ b/drivers/sensor/fxos8700/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig FXOS8700
 	bool "FXOS8700 accelerometer/magnetometer driver"
-	depends on I2C && HAS_DTS_I2C && HAS_DTS_GPIO
+	depends on I2C && HAS_DTS_GPIO
 	help
 	  Enable driver for the FXOS8700 accelerometer/magnetometer.
 	  The driver also supports MMA8451Q, MMA8652FC and MMA8653FC

--- a/drivers/sensor/hts221/Kconfig
+++ b/drivers/sensor/hts221/Kconfig
@@ -3,7 +3,7 @@
 
 menuconfig HTS221
 	bool "HTS221 temperature and humidity sensor"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C
 	help
 	  Enable driver for HTS221 I2C-based temperature and humidity sensor.
 

--- a/drivers/sensor/iis2dh/Kconfig
+++ b/drivers/sensor/iis2dh/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig IIS2DH
 	bool "IIS2DH I2C/SPI accelerometer sensor driver"
-	depends on (I2C && HAS_DTS_I2C) || SPI
+	depends on I2C || SPI
 	select HAS_STMEMSC
 	select USE_STDC_IIS2DH
 	help

--- a/drivers/sensor/iis2dlpc/Kconfig
+++ b/drivers/sensor/iis2dlpc/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig IIS2DLPC
 	bool "IIS2DLPC I2C/SPI accelerometer sensor driver"
-	depends on (I2C && HAS_DTS_I2C) || SPI
+	depends on I2C || SPI
 	select HAS_STMEMSC
 	select USE_STDC_IIS2DLPC
 	help

--- a/drivers/sensor/iis2mdc/Kconfig
+++ b/drivers/sensor/iis2mdc/Kconfig
@@ -3,7 +3,7 @@
 
 menuconfig IIS2MDC
 	bool "IIS2MDC Magnetometer"
-	depends on (I2C && HAS_DTS_I2C) || SPI
+	depends on I2C || SPI
 	select HAS_STMEMSC
 	select USE_STDC_IIS2MDC
 	help

--- a/drivers/sensor/ism330dhcx/Kconfig
+++ b/drivers/sensor/ism330dhcx/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig ISM330DHCX
 	bool "ISM330DHCX I2C/SPI accelerometer and gyroscope Chip"
-	depends on (I2C && HAS_DTS_I2C) || SPI
+	depends on I2C || SPI
 	select HAS_STMEMSC
 	select USE_STDC_ISM330DHCX
 	help

--- a/drivers/sensor/lis2dh/Kconfig
+++ b/drivers/sensor/lis2dh/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig LIS2DH
 	bool "LIS2DH Three Axis Accelerometer"
-	depends on (I2C && HAS_DTS_I2C) || SPI
+	depends on I2C || SPI
 	help
 	  Enable SPI/I2C-based driver for LIS2DH, LIS3DH, LSM303DLHC,
 	  LIS2DH12, LSM303AGR triaxial accelerometer sensors.

--- a/drivers/sensor/lis2ds12/Kconfig
+++ b/drivers/sensor/lis2ds12/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig LIS2DS12
 	bool "LIS2DS12 I2C/SPI accelerometer sensor driver"
-	depends on (I2C && HAS_DTS_I2C) || SPI
+	depends on I2C || SPI
 	help
 	  Enable driver for LIS2DS12 accelerometer sensor driver
 

--- a/drivers/sensor/lis2dw12/Kconfig
+++ b/drivers/sensor/lis2dw12/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig LIS2DW12
 	bool "LIS2DW12 I2C/SPI accelerometer sensor driver"
-	depends on (I2C && HAS_DTS_I2C) || SPI
+	depends on I2C || SPI
 	select HAS_STMEMSC
 	select USE_STDC_LIS2DW12
 	help

--- a/drivers/sensor/lis2mdl/Kconfig
+++ b/drivers/sensor/lis2mdl/Kconfig
@@ -3,7 +3,7 @@
 
 menuconfig LIS2MDL
 	bool "LIS2MDL Magnetometer"
-	depends on (I2C && HAS_DTS_I2C) || SPI
+	depends on I2C || SPI
 	select HAS_STMEMSC
 	select USE_STDC_LIS2MDL
 	help

--- a/drivers/sensor/lis3mdl/Kconfig
+++ b/drivers/sensor/lis3mdl/Kconfig
@@ -3,7 +3,7 @@
 
 menuconfig LIS3MDL
 	bool "LIS3MDL magnetometer"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C
 	help
 	  Enable driver for LIS3MDL I2C-based magnetometer.
 

--- a/drivers/sensor/lps22hb/Kconfig
+++ b/drivers/sensor/lps22hb/Kconfig
@@ -3,7 +3,7 @@
 
 menuconfig LPS22HB
 	bool "LPS22HB pressure and temperature"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C
 	help
 	  Enable driver for LPS22HB I2C-based pressure and temperature
 	  sensor.

--- a/drivers/sensor/lps22hh/Kconfig
+++ b/drivers/sensor/lps22hh/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig LPS22HH
 	bool "LPS22HH pressure and temperature"
-	depends on (I2C && HAS_DTS_I2C) || SPI
+	depends on I2C || SPI
 	select HAS_STMEMSC
 	select USE_STDC_LPS22HH
 	help

--- a/drivers/sensor/lps25hb/Kconfig
+++ b/drivers/sensor/lps25hb/Kconfig
@@ -3,7 +3,7 @@
 
 menuconfig LPS25HB
 	bool "LPS25HB pressure and temperature"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C
 	help
 	  Enable driver for LPS25HB I2C-based pressure and temperature
 	  sensor.

--- a/drivers/sensor/lsm6ds0/Kconfig
+++ b/drivers/sensor/lsm6ds0/Kconfig
@@ -6,7 +6,7 @@
 
 menuconfig LSM6DS0
 	bool "LSM6DS0 I2C accelerometer and gyroscope Chip"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C
 	help
 	  Enable driver for LSM6DS0 I2C-based accelerometer and gyroscope
 	  sensor.

--- a/drivers/sensor/lsm6dsl/Kconfig
+++ b/drivers/sensor/lsm6dsl/Kconfig
@@ -6,7 +6,7 @@
 
 menuconfig LSM6DSL
 	bool "LSM6DSL I2C/SPI accelerometer and gyroscope Chip"
-	depends on (I2C && HAS_DTS_I2C) || SPI
+	depends on I2C || SPI
 	help
 	  Enable driver for LSM6DSL accelerometer and gyroscope
 	  sensor.

--- a/drivers/sensor/lsm6dso/Kconfig
+++ b/drivers/sensor/lsm6dso/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig LSM6DSO
 	bool "LSM6DSO I2C/SPI accelerometer and gyroscope Chip"
-	depends on (I2C && HAS_DTS_I2C) || SPI
+	depends on I2C || SPI
 	select HAS_STMEMSC
 	select USE_STDC_LSM6DSO
 	help

--- a/drivers/sensor/lsm9ds0_gyro/Kconfig
+++ b/drivers/sensor/lsm9ds0_gyro/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig LSM9DS0_GYRO
 	bool "LSM9DS0 I2C gyroscope Chip"
-	depends on (I2C && HAS_DTS_I2C)
+	depends on I2C
 	help
 	  Enable driver for LSM9DS0 I2C-based gyroscope sensor.
 

--- a/drivers/sensor/lsm9ds0_mfd/Kconfig
+++ b/drivers/sensor/lsm9ds0_mfd/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig LSM9DS0_MFD
 	bool "LSM9DS0 I2C accelerometer, magnetometer and temperature sensor chip"
-	depends on (I2C && HAS_DTS_I2C)
+	depends on I2C
 	help
 	  Enable driver for LSM9DS0 I2C-based MFD sensor.
 

--- a/drivers/sensor/max17055/Kconfig
+++ b/drivers/sensor/max17055/Kconfig
@@ -4,7 +4,7 @@
 
 config MAX17055
 	bool "MAX17055 Fuel Gauge"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C
 	help
 	  Enable I2C-based driver for MAX17055 Fuel Gauge. This driver supports
 	  reading various sensor settings including charge level percentage,

--- a/drivers/sensor/max30101/Kconfig
+++ b/drivers/sensor/max30101/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig MAX30101
 	bool "MAX30101 Pulse Oximeter and Heart Rate Sensor"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C
 
 if MAX30101
 

--- a/drivers/sensor/mpr/Kconfig
+++ b/drivers/sensor/mpr/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig MPR
 	bool "MPR pressure sensor"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C
 	help
 	  Enable driver for MPR pressure sensor.
 

--- a/drivers/sensor/ms5837/Kconfig
+++ b/drivers/sensor/ms5837/Kconfig
@@ -5,6 +5,6 @@
 
 config MS5837
 	bool "MS5837 pressure and temperature sensor"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C
 	help
 	  Enable driver for MS5837 pressure and temperature sensor.

--- a/drivers/sensor/opt3001/Kconfig
+++ b/drivers/sensor/opt3001/Kconfig
@@ -5,6 +5,6 @@
 
 config OPT3001
 	bool "OPT3001 Light Sensor"
-	depends on (I2C && HAS_DTS_I2C)
+	depends on I2C
 	help
 	  Enable driver for OPT3001 light sensors.

--- a/drivers/sensor/si7006/Kconfig
+++ b/drivers/sensor/si7006/Kconfig
@@ -3,6 +3,6 @@
 
 config SI7006
 	bool "Si7006 Temperature and Humidity Sensor"
-	depends on (I2C && HAS_DTS_I2C)
+	depends on I2C
 	help
 	  Enable I2C-based driver for Si7006 Temperature and Humidity Sensor.

--- a/drivers/sensor/si7055/Kconfig
+++ b/drivers/sensor/si7055/Kconfig
@@ -4,7 +4,7 @@
 
 menuconfig SI7055
 	bool "Si7055 Temperature Sensor"
-	depends on (I2C && HAS_DTS_I2C)
+	depends on I2C
 	help
 	  Enable I2C-based driver for Si7055 Temperature Sensor.
 

--- a/drivers/sensor/si7060/Kconfig
+++ b/drivers/sensor/si7060/Kconfig
@@ -5,6 +5,6 @@
 
 config SI7060
 	bool "SI7060 Temperature Sensor"
-	depends on (I2C && HAS_DTS_I2C)
+	depends on I2C
 	help
 	  Enable driver for SI7060 temperature sensors.

--- a/drivers/sensor/stts751/Kconfig
+++ b/drivers/sensor/stts751/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig STTS751
 	bool "STTS751 temperature sensor"
-	depends on (I2C && HAS_DTS_I2C)
+	depends on I2C
 	select HAS_STMEMSC
 	select USE_STDC_STTS751
 	help

--- a/drivers/sensor/ti_hdc/Kconfig
+++ b/drivers/sensor/ti_hdc/Kconfig
@@ -5,6 +5,6 @@
 
 config TI_HDC
 	bool "Texas Instruments Temperature and Humidity Sensor (e.g. HDC1008)"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C
 	help
 	  Enable driver for TI temperature and humidity sensors.

--- a/drivers/sensor/tmp116/Kconfig
+++ b/drivers/sensor/tmp116/Kconfig
@@ -5,6 +5,6 @@
 
 config TMP116
 	bool "TMP116 Temperature Sensor"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C
 	help
 	  Enable driver for TMP116 temperature sensor.

--- a/drivers/sensor/vcnl4040/Kconfig
+++ b/drivers/sensor/vcnl4040/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig VCNL4040
 	bool "VCNL4040 Proximity and Ambient Light Sensor"
-	depends on I2C && HAS_DTS_I2C && HAS_DTS_GPIO
+	depends on I2C && HAS_DTS_GPIO
 	help
 	  Enable driver for VCNL4040 sensors.
 

--- a/drivers/sensor/vl53l0x/Kconfig
+++ b/drivers/sensor/vl53l0x/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig VL53L0X
 	bool "VL53L0X time of flight sensor"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C
 	select HAS_STLIB
 	help
 	  Enable driver for VL53L0X I2C-based time of flight sensor.

--- a/dts/Kconfig
+++ b/dts/Kconfig
@@ -13,13 +13,6 @@ config HAS_DTS_GPIO
 	  This option specifies that the target platform supports device tree
 	  configuration for GPIO.
 
-config HAS_DTS_I2C
-	bool
-	depends on HAS_DTS
-	help
-	  This option specifies that the target platform supports device tree
-	  configuration for I2c.
-
 config HAS_DTS_WDT
 	bool
 	depends on HAS_DTS


### PR DESCRIPTION
HAS_DTS_I2C is now selected by I2C and
always used as I2C && HAS_DTS_I2C.

It could then be purely removed.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>