### PR TITLE
samples: subsys: Add sdhc fixture to fat_fs sample

### DIFF
--- a/samples/subsys/fs/fat_fs/sample.yaml
+++ b/samples/subsys/fs/fat_fs/sample.yaml
@@ -5,5 +5,8 @@ common:
 tests:
   sample.filesystem.fat_fs:
     depends_on: sdhc
+    harness: console
+    harness_config:
+      fixture: fixture_sdhc
   sample.filesystem.fat_fs.overlay:
     platform_allow: nrf52840_blip


### PR DESCRIPTION
Adds a fixture to the fat_fs sample so it only runs on boards that have
an sdhc card inserted.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #28256