### PR TITLE
storage/flash_map: add `get erase byte value API

### DIFF
--- a/include/storage/flash_map.h
+++ b/include/storage/flash_map.h
@@ -245,6 +245,17 @@ int flash_area_has_driver(const struct flash_area *fa);
  */
 const struct device *flash_area_get_device(const struct flash_area *fa);
 
+/**
+ * Get the value expected to be read when accessing any erased
+ * flash byte.
+ * This API is compatible with the MCUBoot's porting layer.
+ *
+ * @param fa Flash area.
+ *
+ * @return Byte value of erase memory.
+ */
+uint8_t flash_area_erased_val(const struct flash_area *fa);
+
 #define FLASH_AREA_LABEL_EXISTS(label) \
 	DT_HAS_FIXED_PARTITION_LABEL(label)
 

--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -206,15 +206,6 @@ static int boot_flag_decode(uint8_t flag)
 }
 
 /* TODO: this function should be moved to flash_area api in future */
-uint8_t flash_area_erased_val(const struct flash_area *fa)
-{
-	#define ERASED_VAL 0xff
-
-	(void)fa;
-	return ERASED_VAL;
-}
-
-/* TODO: this function should be moved to flash_area api in future */
 int flash_area_read_is_empty(const struct flash_area *fa, uint32_t off,
 	void *dst, uint32_t len)
 {

--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -270,6 +270,15 @@ const struct device *flash_area_get_device(const struct flash_area *fa)
 	return device_get_binding(fa->fa_dev_name);
 }
 
+uint8_t flash_area_erased_val(const struct flash_area *fa)
+{
+	const struct flash_parameters *param;
+
+	param = flash_get_parameters(device_get_binding(fa->fa_dev_name));
+
+	return param->erase_value;
+}
+
 #if defined(CONFIG_FLASH_AREA_CHECK_INTEGRITY)
 int flash_area_check_int_sha256(const struct flash_area *fa,
 				const struct flash_area_check *fac)

--- a/tests/subsys/storage/flash_map/src/main.c
+++ b/tests/subsys/storage/flash_map/src/main.c
@@ -158,9 +158,28 @@ void test_flash_area_check_int_sha256(void)
 	flash_area_close(fa);
 }
 
+void test_flash_area_erased_val(void)
+{
+	const struct flash_parameters *param;
+	const struct flash_area *fa;
+	uint8_t val;
+	int rc;
+
+	rc = flash_area_open(FLASH_AREA_ID(image_1), &fa);
+	zassert_true(rc == 0, "flash_area_open() fail");
+
+	val = flash_area_erased_val(fa);
+
+	param = flash_get_parameters(device_get_binding(fa->fa_dev_name));
+
+	zassert_equal(param->erase_value, val,
+		      "value different than the flash erase value");
+}
+
 void test_main(void)
 {
 	ztest_test_suite(test_flash_map,
+			 ztest_unit_test(test_flash_area_erased_val),
 			 ztest_unit_test(test_flash_area_get_sectors),
 			 ztest_unit_test(test_flash_area_check_int_sha256)
 			);

--- a/west.yml
+++ b/west.yml
@@ -93,7 +93,7 @@ manifest:
       revision: aef137b1af8aa7a0f43345c82459254b8832262e
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: e64c5f00d67cf858d1fdead7135f5d61de2a4c68
+      revision: c71d2186077f9fd5f6d1aa53ee3f09dc41ce78f6
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 5051f9d900bbb194a23d4ce80f3c6dc6d6780cc2


### PR DESCRIPTION
Added flash_area_erased_val() function for get value of erased
byte of memory which is under flash area.

~~Added flash_area_read_is_empty() function for reads data and check if
read data was erased.~~

These functions already exist in MCUBoot and zephyr dfu subsystem
which makes simultaneous usage of both impossible.

In the same time the mcuboot's function is made __weak for backward compatibility.
- [x] https://github.com/JuulLabs-OSS/mcuboot/pull/851
- [x] inherited by the zephyr-fork: https://github.com/zephyrproject-rtos/mcuboot/pull/38