### PR TITLE
board: stm32_min_dev: Fix LED0 connection inversion

### DIFF
--- a/boards/arm/stm32_min_dev/stm32_min_dev_black.dts
+++ b/boards/arm/stm32_min_dev/stm32_min_dev_black.dts
@@ -13,7 +13,7 @@
 
 	leds {
 		led: led {
-			gpios = <&gpiob 12 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpiob 12 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/boards/arm/stm32_min_dev/stm32_min_dev_blue.dts
+++ b/boards/arm/stm32_min_dev/stm32_min_dev_blue.dts
@@ -13,7 +13,7 @@
 
 	leds {
 		led: led {
-			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 };


### PR DESCRIPTION
The on-board LED of the blue and black variants of these boards have LED
logic inverted. This was never observed as most of the time, the LED was
used as a blinky. Fix this by setting its DT bindings to active low.

Signed-off-by: Siddharth Chandrasekaran <siddharth@embedjournal.com>