### PR TITLE
kernel: timer: update API for const correctness

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1826,7 +1826,10 @@ typedef void (*k_timer_expiry_t)(struct k_timer *timer);
  * @brief Timer stop function type.
  *
  * A timer's stop function is executed if the timer is stopped prematurely.
- * The function runs in the context of the thread that stops the timer.
+ * The function runs in the context of call that stops the timer.  As
+ * k_timer_stop() can be invoked from an ISR, the stop function must be
+ * callable from interrupt context (isr-ok).
+ *
  * The stop function is optional, and is only invoked if the timer has been
  * initialized with one.
  *

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1052,8 +1052,8 @@ __syscall void k_thread_abort(k_tid_t thread);
  */
 __syscall void k_thread_start(k_tid_t thread);
 
-extern k_ticks_t z_timeout_expires(struct _timeout *timeout);
-extern k_ticks_t z_timeout_remaining(struct _timeout *timeout);
+extern k_ticks_t z_timeout_expires(const struct _timeout *timeout);
+extern k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
 
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2018,9 +2018,9 @@ static inline void z_impl_k_timer_user_data_set(struct k_timer *timer,
  *
  * @return The user data.
  */
-__syscall void *k_timer_user_data_get(struct k_timer *timer);
+__syscall void *k_timer_user_data_get(const struct k_timer *timer);
 
-static inline void *z_impl_k_timer_user_data_get(struct k_timer *timer)
+static inline void *z_impl_k_timer_user_data_get(const struct k_timer *timer)
 {
 	return timer->user_data;
 }

--- a/include/timeout_q.h
+++ b/include/timeout_q.h
@@ -32,7 +32,7 @@ void z_add_timeout(struct _timeout *to, _timeout_func_t fn,
 
 int z_abort_timeout(struct _timeout *to);
 
-static inline bool z_is_inactive_timeout(struct _timeout *t)
+static inline bool z_is_inactive_timeout(const struct _timeout *t)
 {
 	return !sys_dnode_is_linked(&t->node);
 }
@@ -58,7 +58,7 @@ int32_t z_get_next_timeout_expiry(void);
 
 void z_set_timeout_expiry(int32_t ticks, bool idle);
 
-k_ticks_t z_timeout_remaining(struct _timeout *timeout);
+k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
 
 #else
 

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -143,7 +143,7 @@ int z_abort_timeout(struct _timeout *to)
 }
 
 /* must be locked */
-static k_ticks_t timeout_rem(struct _timeout *timeout)
+static k_ticks_t timeout_rem(const struct _timeout *timeout)
 {
 	k_ticks_t ticks = 0;
 
@@ -161,7 +161,7 @@ static k_ticks_t timeout_rem(struct _timeout *timeout)
 	return ticks - elapsed();
 }
 
-k_ticks_t z_timeout_remaining(struct _timeout *timeout)
+k_ticks_t z_timeout_remaining(const struct _timeout *timeout)
 {
 	k_ticks_t ticks = 0;
 
@@ -172,7 +172,7 @@ k_ticks_t z_timeout_remaining(struct _timeout *timeout)
 	return ticks;
 }
 
-k_ticks_t z_timeout_expires(struct _timeout *timeout)
+k_ticks_t z_timeout_expires(const struct _timeout *timeout)
 {
 	k_ticks_t ticks = 0;
 

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -256,7 +256,7 @@ static inline k_ticks_t z_vrfy_k_timer_expires_ticks(struct k_timer *timer)
 }
 #include <syscalls/k_timer_expires_ticks_mrsh.c>
 
-static inline void *z_vrfy_k_timer_user_data_get(struct k_timer *timer)
+static inline void *z_vrfy_k_timer_user_data_get(const struct k_timer *timer)
 {
 	Z_OOPS(Z_SYSCALL_OBJ(timer, K_OBJ_TIMER));
 	return z_impl_k_timer_user_data_get(timer);


### PR DESCRIPTION
API that takes timeout-related structures but doesn't change data in them is updated to const-qualify the underlying object, allowing information to be retrieved from contexts where the containing object is immutable.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>