### PR TITLE
arch: arc: archs using ATOMIC_OPERATIONS_C

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -23,7 +23,10 @@ config CPU_ARCEM
 config CPU_ARCHS
 	bool "ARC HS cores"
 	select CPU_ARCV2
-	select ATOMIC_OPERATIONS_BUILTIN
+	# FIXME: ATOMIC_OPERATIONS_BUILTIN still has some problem in arcmwdt
+	# toolchain, so choosing ATOMIC_OPERATIONS_C instead.
+	select ATOMIC_OPERATIONS_C if "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "arcmwdt"
+	select ATOMIC_OPERATIONS_BUILTIN if "$(ZEPHYR_TOOLCHAIN_VARIANT)" != "arcmwdt"
 	help
 	  This option signifies the use of an ARC HS CPU
 


### PR DESCRIPTION
ATOMIC_OPERATIONS_BUILTIN still has some problem in mwdt toolchain,
mwdt builtin atomic_nand() function will get wrong result.
https://github.com/zephyrproject-rtos/zephyr/blob/a06884a4e67835e57452eda348a2b77e159d4777/tests/kernel/common/src/atomic.c#L134-L138
So choosing ATOMIC_OPERATIONS_C instead.
