### PR TITLE
tests: add filter for some tests using newlib

### DIFF
--- a/samples/boards/intel_s1000_crb/i2s/sample.yaml
+++ b/samples/boards/intel_s1000_crb/i2s/sample.yaml
@@ -1,3 +1,5 @@
+common:
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 sample:
   name: I2S Audio Sample
 tests:

--- a/samples/drivers/counter/maxim_ds3231/sample.yaml
+++ b/samples/drivers/counter/maxim_ds3231/sample.yaml
@@ -1,3 +1,5 @@
+common:
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 sample:
   name: Maxim DS3231 RTC
 tests:

--- a/samples/net/cloud/google_iot_mqtt/sample.yaml
+++ b/samples/net/cloud/google_iot_mqtt/sample.yaml
@@ -4,3 +4,4 @@ sample:
 common:
   tags: net mqtt cloud
   harness: net
+  filter: TOOLCHAIN_HAS_NEWLIB == 1

--- a/samples/net/cloud/mqtt_azure/sample.yaml
+++ b/samples/net/cloud/mqtt_azure/sample.yaml
@@ -1,3 +1,5 @@
+common:
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 sample:
   description: MQTT sample app to Azure cloud
   name: mqtt-azure

--- a/samples/net/sockets/coap_client/sample.yaml
+++ b/samples/net/sockets/coap_client/sample.yaml
@@ -1,3 +1,5 @@
+common:
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 sample:
   description: TBD
   name: TBD

--- a/samples/net/sockets/coap_server/sample.yaml
+++ b/samples/net/sockets/coap_server/sample.yaml
@@ -1,3 +1,5 @@
+common:
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 sample:
   description: TBD
   name: TBD

--- a/samples/net/sockets/echo/sample.yaml
+++ b/samples/net/sockets/echo/sample.yaml
@@ -4,6 +4,7 @@ sample:
 common:
   harness: net
   depends_on: netif
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 tests:
   sample.net.sockets.echo:
     tags: net socket

--- a/samples/net/sockets/echo_async_select/sample.yaml
+++ b/samples/net/sockets/echo_async_select/sample.yaml
@@ -6,6 +6,7 @@ common:
   harness: net
   platform_allow: qemu_x86
   tags: net socket
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 tests:
   sample.net.sockets.echo_async_select:
     extra_configs:

--- a/samples/net/sockets/echo_client/sample.yaml
+++ b/samples/net/sockets/echo_client/sample.yaml
@@ -47,11 +47,13 @@ tests:
     slow: true
     tags: net openthread
     platform_allow: nrf52840dk_nrf52840
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
   sample.net.sockets.echo_client.kw41z_openthread:
     extra_args: OVERLAY_CONFIG="overlay-ot.conf"
     slow: true
     tags: net openthread
     platform_allow: frdm_kw41z
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
   sample.net.sockets.echo_client.userspace:
     extra_args: CONFIG_USERSPACE=y OVERLAY_CONFIG="overlay-e1000.conf"
     platform_allow: qemu_x86

--- a/samples/net/sockets/echo_server/sample.yaml
+++ b/samples/net/sockets/echo_server/sample.yaml
@@ -59,11 +59,13 @@ tests:
     slow: true
     tags: net openthread
     platform_allow: nrf52840dk_nrf52840
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
   sample.net.sockets.echo_server.kw41z_openthread:
     extra_args: OVERLAY_CONFIG="overlay-ot.conf"
     slow: true
     tags: net openthread
     platform_allow: frdm_kw41z
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
   sample.net.sockets.echo_server.e1000:
     extra_args: OVERLAY_CONFIG="overlay-e1000.conf"
     tags: net

--- a/samples/net/sockets/sntp_client/sample.yaml
+++ b/samples/net/sockets/sntp_client/sample.yaml
@@ -5,6 +5,7 @@ common:
   harness: net
   platform_allow: qemu_x86
   tags: net
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 tests:
   sample.net.sockets.sntp_client:
     extra_configs:

--- a/samples/net/syslog_net/sample.yaml
+++ b/samples/net/syslog_net/sample.yaml
@@ -7,12 +7,14 @@ sample:
   name: syslog_net
 tests:
   sample.net.syslog.with_timefuncs:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
   sample.net.syslog.without_timefuncs:
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
   sample.net.syslog.ipv4_only:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NET_IPV6=n
       - CONFIG_NET_CONFIG_NEED_IPV6=n
@@ -20,6 +22,7 @@ tests:
       - CONFIG_NET_CONFIG_PEER_IPV6_ADDR=""
       - CONFIG_LOG_BACKEND_NET_SERVER="192.0.2.1:514"
   sample.net.syslog.ipv6_only:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NET_IPV4=n
       - CONFIG_NET_CONFIG_NEED_IPV4=n

--- a/samples/sensor/dht/sample.yaml
+++ b/samples/sensor/dht/sample.yaml
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+common:
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 sample:
   name: DHT Sensor Sample
 tests:

--- a/samples/sensor/grove_light/sample.yaml
+++ b/samples/sensor/grove_light/sample.yaml
@@ -1,3 +1,5 @@
+common:
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 sample:
   name: Grove Light Sensor
 tests:

--- a/samples/sensor/grove_temperature/sample.yaml
+++ b/samples/sensor/grove_temperature/sample.yaml
@@ -1,3 +1,5 @@
+common:
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 sample:
   name: Grove Temperature Sensor
 tests:

--- a/samples/subsys/mgmt/hawkbit/sample.yaml
+++ b/samples/subsys/mgmt/hawkbit/sample.yaml
@@ -1,3 +1,5 @@
+common:
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 sample:
   description: Hawkbit Firmware Over-the-Air (FOTA)
   name: hawkbit

--- a/tests/application_development/libcxx/testcase.yaml
+++ b/tests/application_development/libcxx/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 tests:
   application_development.cpp.libcxx:
     platform_exclude: qemu_x86_coverage

--- a/tests/benchmarks/cmsis_dsp/basicmath/testcase.yaml
+++ b/tests/benchmarks/cmsis_dsp/basicmath/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   benchmark.cmsis_dsp.basicmath:
-    filter: CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M
+    filter: (CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1
     integration_platforms:
       - frdm_k64f
       - sam_e70_xplained

--- a/tests/lib/cmsis_dsp/basicmath/testcase.yaml
+++ b/tests/lib/cmsis_dsp/basicmath/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   libraries.cmsis_dsp.basicmath:
-    filter: CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M
+    filter: (CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1
     integration_platforms:
       - frdm_k64f
       - sam_e70_xplained

--- a/tests/lib/cmsis_dsp/bayes/testcase.yaml
+++ b/tests/lib/cmsis_dsp/bayes/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   libraries.cmsis_dsp.bayes:
-    filter: CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M
+    filter: (CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1
     integration_platforms:
       - frdm_k64f
       - sam_e70_xplained

--- a/tests/lib/cmsis_dsp/complexmath/testcase.yaml
+++ b/tests/lib/cmsis_dsp/complexmath/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   libraries.cmsis_dsp.complexmath:
-    filter: CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M
+    filter: (CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1
     integration_platforms:
       - frdm_k64f
       - sam_e70_xplained

--- a/tests/lib/cmsis_dsp/distance/testcase.yaml
+++ b/tests/lib/cmsis_dsp/distance/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   libraries.cmsis_dsp.distance:
-    filter: CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M
+    filter: (CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1
     integration_platforms:
       - frdm_k64f
       - sam_e70_xplained

--- a/tests/lib/cmsis_dsp/fastmath/testcase.yaml
+++ b/tests/lib/cmsis_dsp/fastmath/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   libraries.cmsis_dsp.fastmath:
-    filter: CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M
+    filter: (CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1
     integration_platforms:
       - frdm_k64f
       - sam_e70_xplained

--- a/tests/lib/cmsis_dsp/filtering/testcase.yaml
+++ b/tests/lib/cmsis_dsp/filtering/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  filter: CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M
+  filter: (CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1
   integration_platforms:
     - frdm_k64f
     - sam_e70_xplained

--- a/tests/lib/cmsis_dsp/matrix/testcase.yaml
+++ b/tests/lib/cmsis_dsp/matrix/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  filter: CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M
+  filter: (CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1
   integration_platforms:
     - frdm_k64f
     - sam_e70_xplained

--- a/tests/lib/cmsis_dsp/statistics/testcase.yaml
+++ b/tests/lib/cmsis_dsp/statistics/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   libraries.cmsis_dsp.statistics:
-    filter: CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M
+    filter: (CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1
     integration_platforms:
       - frdm_k64f
       - sam_e70_xplained

--- a/tests/lib/cmsis_dsp/support/testcase.yaml
+++ b/tests/lib/cmsis_dsp/support/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   libraries.cmsis_dsp.support:
-    filter: CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M
+    filter: (CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1
     integration_platforms:
       - frdm_k64f
       - sam_e70_xplained

--- a/tests/lib/cmsis_dsp/svm/testcase.yaml
+++ b/tests/lib/cmsis_dsp/svm/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   libraries.cmsis_dsp.svm:
-    filter: CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M
+    filter: (CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1
     integration_platforms:
       - frdm_k64f
       - sam_e70_xplained

--- a/tests/lib/cmsis_dsp/transform/testcase.yaml
+++ b/tests/lib/cmsis_dsp/transform/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  filter: CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M
+  filter: (CONFIG_CPU_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1
   integration_platforms:
     - frdm_k64f
     - sam_e70_xplained

--- a/tests/lib/gui/lvgl/testcase.yaml
+++ b/tests/lib/gui/lvgl/testcase.yaml
@@ -3,6 +3,7 @@ tests:
     tags: display gui
     platform_allow: native_posix
   libraries.gui.lvgl.dynamic.heap.libc:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
     tags: display gui
     platform_allow: native_posix
     extra_configs:

--- a/tests/lib/mem_alloc/testcase.yaml
+++ b/tests/lib/mem_alloc/testcase.yaml
@@ -15,3 +15,4 @@ tests:
     extra_args: CONF_FILE=prj_newlibnano.conf
     toolchain_allow: gnuarmemb
     tags: clib newlib userspace
+    filter: TOOLCHAIN_HAS_NEWLIB == 1

--- a/tests/net/lib/coap/testcase.yaml
+++ b/tests/net/lib/coap/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 tests:
   net.coap.simple:
     min_ram: 16

--- a/tests/net/socket/getaddrinfo/testcase.yaml
+++ b/tests/net/socket/getaddrinfo/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 tests:
   net.socket.get_addr_info:
     min_ram: 21

--- a/tests/net/socket/getnameinfo/testcase.yaml
+++ b/tests/net/socket/getnameinfo/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 tests:
   net.socket.get_name_info:
     min_ram: 21

--- a/tests/net/socket/misc/testcase.yaml
+++ b/tests/net/socket/misc/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 tests:
   net.socket.misc:
     min_ram: 21

--- a/tests/net/socket/select/testcase.yaml
+++ b/tests/net/socket/select/testcase.yaml
@@ -2,6 +2,7 @@ common:
   depends_on: netif
   min_ram: 21
   tags: net socket userspace
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 tests:
   net.socket.select:
     extra_configs:

--- a/tests/net/socket/socketpair/testcase.yaml
+++ b/tests/net/socket/socketpair/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   tags: net socket userspace
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 tests:
   net.socket.socketpair:
     min_ram: 21

--- a/tests/net/socket/tcp/testcase.yaml
+++ b/tests/net/socket/tcp/testcase.yaml
@@ -2,6 +2,7 @@ common:
   depends_on: netif
   min_ram: 32
   tags: net socket userspace
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 tests:
   net.socket.tcp:
     extra_configs:

--- a/tests/net/socket/udp/testcase.yaml
+++ b/tests/net/socket/udp/testcase.yaml
@@ -2,6 +2,7 @@ common:
   depends_on: netif
   tags: net socket udp
   min_ram: 21
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 tests:
   net.socket.udp:
     extra_configs:

--- a/tests/subsys/jwt/testcase.yaml
+++ b/tests/subsys/jwt/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
 tests:
   libraries.encoding.jwt:
     min_ram: 96


### PR DESCRIPTION
some tests configured with `CONFIG_NEWLIB_LIBC=y`, 
it's better to add a filter `filter: TOOLCHAIN_HAS_NEWLIB == 1`
in those tests yaml file.