### PR TITLE
doc: kernel: clarify object limits

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -565,4 +565,5 @@
 /tests/subsys/shell/                      @jakub-uC @nordic-krch
 # Get all docs reviewed
 *.rst                                     @nashif
+/doc/reference/kernel/                    @andrewboie @andyross @nashif
 *posix*.rst                               @aescolar @daor-oti

--- a/doc/reference/kernel/data_passing/fifos.rst
+++ b/doc/reference/kernel/data_passing/fifos.rst
@@ -14,8 +14,8 @@ to add and remove data items of any size.
 Concepts
 ********
 
-Any number of FIFOs can be defined. Each FIFO is referenced
-by its memory address.
+Any number of FIFOs can be defined (limited only by available RAM). Each FIFO is
+referenced by its memory address.
 
 A FIFO has the following key properties:
 

--- a/doc/reference/kernel/data_passing/lifos.rst
+++ b/doc/reference/kernel/data_passing/lifos.rst
@@ -14,8 +14,8 @@ to add and remove data items of any size.
 Concepts
 ********
 
-Any number of LIFOs can be defined. Each LIFO is referenced
-by its memory address.
+Any number of LIFOs can be defined (limited only by available RAM). Each LIFO is
+referenced by its memory address.
 
 A LIFO has the following key properties:
 

--- a/doc/reference/kernel/data_passing/mailboxes.rst
+++ b/doc/reference/kernel/data_passing/mailboxes.rst
@@ -15,8 +15,8 @@ synchronously or asynchronously.
 Concepts
 ********
 
-Any number of mailboxes can be defined. Each mailbox is referenced
-by its memory address.
+Any number of mailboxes can be defined (limited only by available RAM). Each
+mailbox is referenced by its memory address.
 
 A mailbox has the following key properties:
 

--- a/doc/reference/kernel/data_passing/message_queues.rst
+++ b/doc/reference/kernel/data_passing/message_queues.rst
@@ -14,8 +14,8 @@ fixed-size data items.
 Concepts
 ********
 
-Any number of message queues can be defined. Each message queue is referenced
-by its memory address.
+Any number of message queues can be defined (limited only by available RAM).
+Each message queue is referenced by its memory address.
 
 A message queue has the following key properties:
 

--- a/doc/reference/kernel/data_passing/pipes.rst
+++ b/doc/reference/kernel/data_passing/pipes.rst
@@ -17,8 +17,8 @@ Concepts
 The pipe can be configured with a ring buffer which holds data that has been
 sent but not yet received; alternatively, the pipe may have no ring buffer.
 
-Any number of pipes can be defined. Each pipe is referenced by its memory
-address.
+Any number of pipes can be defined (limited only by available RAM). Each pipe is
+referenced by its memory address.
 
 A pipe has the following key property:
 

--- a/doc/reference/kernel/data_passing/stacks.rst
+++ b/doc/reference/kernel/data_passing/stacks.rst
@@ -14,8 +14,8 @@ to add and remove a limited number of integer data values.
 Concepts
 ********
 
-Any number of stacks can be defined. Each stack is referenced
-by its memory address.
+Any number of stacks can be defined (limited only by available RAM). Each stack
+is referenced by its memory address.
 
 A stack has the following key properties:
 

--- a/doc/reference/kernel/memory/pools.rst
+++ b/doc/reference/kernel/memory/pools.rst
@@ -30,8 +30,8 @@ while limiting memory fragmentation concerns.
 Concepts
 ********
 
-Any number of memory pools can be defined. Each memory pool is referenced
-by its memory address.
+Any number of memory pools can be defined (limited only by available RAM). Each
+memory pool is referenced by its memory address.
 
 A memory pool has the following key properties:
 

--- a/doc/reference/kernel/memory/slabs.rst
+++ b/doc/reference/kernel/memory/slabs.rst
@@ -16,8 +16,8 @@ and avoiding memory fragmentation concerns.
 Concepts
 ********
 
-Any number of memory slabs can be defined. Each memory slab is referenced
-by its memory address.
+Any number of memory slabs can be defined (limited only by available RAM). Each
+memory slab is referenced by its memory address.
 
 A memory slab has the following key properties:
 

--- a/doc/reference/kernel/other/atomic.rst
+++ b/doc/reference/kernel/other/atomic.rst
@@ -13,7 +13,7 @@ by threads and ISRs in an uninterruptible manner.
 Concepts
 ********
 
-Any number of atomic variables can be defined.
+Any number of atomic variables can be defined (limited only by available RAM).
 
 Using the kernel's atomic APIs to manipulate an atomic variable
 guarantees that the desired operation occurs correctly,

--- a/doc/reference/kernel/other/interrupts.rst
+++ b/doc/reference/kernel/other/interrupts.rst
@@ -16,8 +16,8 @@ Thread execution resumes only once all ISR work has been completed.
 Concepts
 ********
 
-Any number of ISRs can be defined, subject to the constraints imposed
-by underlying hardware.
+Any number of ISRs can be defined (limited only by available RAM), subject to
+the constraints imposed by underlying hardware.
 
 An ISR has the following key properties:
 

--- a/doc/reference/kernel/other/ring_buffers.rst
+++ b/doc/reference/kernel/other/ring_buffers.rst
@@ -21,8 +21,8 @@ first-in-first-out order. Two content data modes are supported:
 Concepts
 ********
 
-Any number of ring buffers can be defined. Each ring buffer is referenced
-by its memory address.
+Any number of ring buffers can be defined (limited only by available RAM). Each
+ring buffer is referenced by its memory address.
 
 A ring buffer has the following key properties:
 

--- a/doc/reference/kernel/synchronization/mutexes.rst
+++ b/doc/reference/kernel/synchronization/mutexes.rst
@@ -15,8 +15,8 @@ access to the resource.
 Concepts
 ********
 
-Any number of mutexes can be defined. Each mutex is referenced by its memory
-address.
+Any number of mutexes can be defined (limited only by available RAM). Each mutex
+is referenced by its memory address.
 
 A mutex has the following key properties:
 

--- a/doc/reference/kernel/synchronization/semaphores.rst
+++ b/doc/reference/kernel/synchronization/semaphores.rst
@@ -13,8 +13,8 @@ counting semaphore.
 Concepts
 ********
 
-Any number of semaphores can be defined. Each semaphore is referenced
-by its memory address.
+Any number of semaphores can be defined (limited only by available RAM). Each
+semaphore is referenced by its memory address.
 
 A semaphore has the following key properties:
 

--- a/doc/reference/kernel/threads/index.rst
+++ b/doc/reference/kernel/threads/index.rst
@@ -13,8 +13,9 @@ independently executable threads of instructions.
 A :dfn:`thread` is a kernel object that is used for application processing
 that is too lengthy or too complex to be performed by an ISR.
 
-Any number of threads can be defined by an application. Each thread is
-referenced by a :dfn:`thread id` that is assigned when the thread is spawned.
+Any number of threads can be defined by an application (limited only by
+available RAM). Each thread is referenced by a :dfn:`thread id` that is assigned
+when the thread is spawned.
 
 A thread has the following key properties:
 

--- a/doc/reference/kernel/threads/workqueue.rst
+++ b/doc/reference/kernel/threads/workqueue.rst
@@ -13,8 +13,8 @@ calling the function specified by the work item. A workqueue is typically
 used by an ISR or a high-priority thread to offload non-urgent processing
 to a lower-priority thread so it does not impact time-sensitive processing.
 
-Any number of workqueues can be defined. Each workqueue is referenced by its
-memory address.
+Any number of workqueues can be defined (limited only by available RAM). Each
+workqueue is referenced by its memory address.
 
 A workqueue has the following key properties:
 

--- a/doc/reference/kernel/timing/timers.rst
+++ b/doc/reference/kernel/timing/timers.rst
@@ -16,8 +16,8 @@ to read its status.
 Concepts
 ********
 
-Any number of timers can be defined. Each timer is referenced by its
-memory address.
+Any number of timers can be defined (limited only by available RAM). Each timer
+is referenced by its memory address.
 
 A timer has the following key properties:
 


### PR DESCRIPTION
Clarify that while any number of kernel objects can be created, there is
a limit which is set by the available RAM.