### PR TITLE
toolchain: mwdt: add some compile options to reduce warning

### DIFF
--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -31,6 +31,7 @@ set_compiler_property(PROPERTY warning_base
                       -Wno-main-return-type
                       -Wno-unaligned-pointer-conversion
                       -Wno-incompatible-pointer-types-discards-qualifiers
+                      -Wno-typedef-redefinition
 )
 
 check_set_compiler_property(APPEND PROPERTY warning_base -Wno-pointer-sign)


### PR DESCRIPTION
When compile zephyr project with arcmwdt toolchain, there are some harmless but noisy compiling warnings,
add some compile options:
`-Wno-typedef-redefinition` 

to reduce warning.

```
warning: redefinition of typedef 'k_tid_t' is a C11 feature [-Wtypedef-redefinition]
```
