### PR TITLE
subsys: random: Warning when using test config

### DIFF
--- a/subsys/random/CMakeLists.txt
+++ b/subsys/random/CMakeLists.txt
@@ -7,6 +7,13 @@ zephyr_library()
 zephyr_library_sources_ifdef(CONFIG_USERSPACE           rand32_handlers.c)
 endif()
 
+if (CONFIG_TEST_RANDOM_GENERATOR)
+  message(WARNING "
+    Warning: CONFIG_TEST_RANDOM_GENERATOR is not a truly random generator.
+    This capability is not secure and it is provided for testing purposes only.
+    Use it carefully.")
+endif()
+
 zephyr_library_sources_ifdef(CONFIG_TIMER_RANDOM_GENERATOR          rand32_timer.c)
 zephyr_library_sources_ifdef(CONFIG_XOROSHIRO_RANDOM_GENERATOR      rand32_xoroshiro128.c)
 zephyr_library_sources_ifdef(CONFIG_CTR_DRBG_CSPRNG_GENERATOR 		rand32_ctr_drbg.c)


### PR DESCRIPTION
Generates a warning message when building with
CONFIG_TEST_RANDOM_GENERATOR. The purpose is inform that this is not
secure and should not used in production.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>