### PR TITLE
lib: posix: nanosleep: fix nanosleep for sub microsecond durations

### DIFF
--- a/tests/posix/common/src/main.c
+++ b/tests/posix/common/src/main.c
@@ -27,10 +27,13 @@ extern void test_nanosleep_req_is_rem(void);
 extern void test_nanosleep_n1_0(void);
 extern void test_nanosleep_0_n1(void);
 extern void test_nanosleep_n1_n1(void);
-extern void test_nanosleep_0_1000000000(void);
 extern void test_nanosleep_0_1(void);
+extern void test_nanosleep_0_1001(void);
+extern void test_nanosleep_0_1000000000(void);
 extern void test_nanosleep_0_500000000(void);
 extern void test_nanosleep_1_0(void);
+extern void test_nanosleep_1_1(void);
+extern void test_nanosleep_1_1001(void);
 
 void test_main(void)
 {
@@ -55,9 +58,12 @@ void test_main(void)
 			ztest_unit_test(test_nanosleep_n1_0),
 			ztest_unit_test(test_nanosleep_0_n1),
 			ztest_unit_test(test_nanosleep_n1_n1),
-			ztest_unit_test(test_nanosleep_0_1000000000),
+			ztest_unit_test(test_nanosleep_0_1),
+			ztest_unit_test(test_nanosleep_0_1001),
 			ztest_unit_test(test_nanosleep_0_500000000),
-			ztest_unit_test(test_nanosleep_1_0)
+			ztest_unit_test(test_nanosleep_1_0),
+			ztest_unit_test(test_nanosleep_1_1),
+			ztest_unit_test(test_nanosleep_1_1001)
 			);
 	ztest_run_test_suite(posix_apis);
 }


### PR DESCRIPTION
We must round up to the nearest microsecond in order to fulfill the nanosleep(2) API requirement of sleeping for *at least* that many nanoseconds.
    
Also, switching to k_usleep() rather than k_busy_wait() as instrumentation using k_cycle_get_32() seems to be less reliable for very small time sclaes.
    
Fixes #28483
