### PR TITLE
board: update rt6xx series sram mapping

### DIFF
--- a/dts/arm/nxp/nxp_rt6xx.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx.dtsi
@@ -11,8 +11,8 @@
 
 / {
 	soc {
-		sram: sram@30000000 {
-			ranges = <0x20000000 0x30000000 0x480000>;
+		sram: sram@30018000 {
+			ranges = <0x20180000 0x30180000 0x300000>;
 		};
 
 		peripheral: peripheral@50000000 {

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -38,9 +38,9 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
-	sram0: memory@20000000 {
+	sram0: memory@20180000 {
 		compatible = "mmio-sram";
-		reg = <0x20000000 DT_SIZE_K(4608)>;
+		reg = <0x20180000 DT_SIZE_K(3072)>;
 	};
 };
 

--- a/dts/arm/nxp/nxp_rt6xx_ns.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_ns.dtsi
@@ -6,8 +6,8 @@
 
 / {
 	soc {
-		sram: sram@20000000 {
-			ranges = <0x20000000 0x20000000 0x480000>;
+		sram: sram@20180000 {
+			ranges = <0x20180000 0x20180000 0x300000>;
 		};
 
 		peripheral: peripheral@40000000 {


### PR DESCRIPTION
update rt6xx series sram mapping to skip 0x180000,
reserved for DSP usage.

this fixes tests/subsys/debug/coredump for this board

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>