### PR TITLE
drivers: net: slip: Allow slip to co-exist with other interfaces

### DIFF
--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -395,7 +395,7 @@ static void slip_iface_init(struct net_if *iface)
 	struct slip_context *slip = net_if_get_device(iface)->data;
 	struct net_linkaddr *ll_addr;
 
-#if defined(CONFIG_NET_L2_ETHERNET)
+#if defined(CONFIG_SLIP_TAP) && defined(CONFIG_NET_L2_ETHERNET)
 	ethernet_init(iface);
 #endif
 


### PR DESCRIPTION
This commit fixes the following issue:
When using slip without TAP, i.e. CONFIG_SLIP_TAP=n (default), while
another ethernet interface is enabled and sets CONFIG_NET_L2_ETHERNET=y.

This causes ethernet_init() to be wrongly called with struct dummy_api
instead of struct ethernet_api.
ethernet_init() expects struct ethernet_api (by cast), so we end up
with the get_capabilities field pointing to garbage!
Actually, as we are using the dummy api, we don't need to call
ethernet_init() at all.

Sole dependency on CONFIG_NET_L2_ETHERNET is wrong because it
can be enabled by another interface.

Signed-off-by: David Komel <a8961713@gmail.com>