### PR TITLE
tests: kernel: mem_map: Explicitly cast function pointer to (void *)

### DIFF
--- a/tests/kernel/mem_protect/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/mem_map/src/main.c
@@ -100,7 +100,7 @@ void test_z_mem_map_exec(void)
 	z_mem_map(&mapped_rw, (uintptr_t)test_page,
 		  sizeof(test_page), BASE_FLAGS | K_MEM_PERM_RW);
 
-	memcpy(mapped_rw, &transplanted_function, CONFIG_MMU_PAGE_SIZE);
+	memcpy(mapped_rw, (void *)&transplanted_function, CONFIG_MMU_PAGE_SIZE);
 
 	/* Now map with execution enabled and try to run the copied fn */
 	z_mem_map(&mapped_exec, (uintptr_t)test_page,


### PR DESCRIPTION
To make Coverity happy.

Coverity-CID: 212956
Fixes: #27837.

Signed-off-by: Wentong Wu <wentong.wu@intel.com>