### PR TITLE
samples: mec15xx: disable power mgnt on EVB board

### DIFF
--- a/samples/boards/mec15xxevb_assy6853/power_management/README.rst
+++ b/samples/boards/mec15xxevb_assy6853/power_management/README.rst
@@ -29,4 +29,10 @@ Sample output
    Wake from Deep Sleep
    ResumeBBBAA
 
-note:: The values shown above might differ.
+note:: The values shown above might differ. And
+regarding the sample (ignoring the latency and cycle counts),
+this is expected behavior. It runs 4 sets of scenarios,
+each repeating 5 times. So you will see repeating messages. After all these,
+it simply idles with nothing to do. But it's not suitable for sanitycheck tool,
+because a timeout error will be met when running this testcase.
+So necessary to skip sample if using sanitycheck testing.

--- a/samples/boards/mec15xxevb_assy6853/power_management/sample.yaml
+++ b/samples/boards/mec15xxevb_assy6853/power_management/sample.yaml
@@ -2,5 +2,5 @@ sample:
   name: MEC150x board sample power management tests
 tests:
   sample.board.mec15xxevb_assy6853:
-    platform_allow: mec15xxevb_assy6853
+    skip: True
     tags: board


### PR DESCRIPTION
Distable power management on MEC15xx board in daily testing,
because timeout will be met, when using sanitycheck tool to run.
fixed issue https://github.com/zephyrproject-rtos/zephyr/issues/28150
Fix for #29330 

Signed-off-by: Ningx Zhao <ningx.zhao@intel.com>