### PR TITLE
doc: release: 2.4: add sensor_attr_get() in release notes

### DIFF
--- a/doc/releases/release-notes-2.4.rst
+++ b/doc/releases/release-notes-2.4.rst
@@ -410,6 +410,8 @@ Drivers and Sensors
 
 * Sensor
 
+  * Added API function ``sensor_attr_get()`` for getting a sensor's
+    attribute.
   * Added support for wsen-itds Accel Sensor.
 
 


### PR DESCRIPTION
Mention the recently added sensor_attr_get() API function in the release notes for v2.4.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>