### PR TITLE
net: Drop incoming packet if there is no data in it

### DIFF
--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -900,6 +900,11 @@ static inline uint8_t *net_pkt_ip_data(struct net_pkt *pkt)
 	return pkt->frags->data;
 }
 
+static inline bool net_pkt_is_empty(struct net_pkt *pkt)
+{
+	return !pkt->buffer || !net_pkt_data(pkt) || pkt->buffer->len == 0;
+}
+
 static inline struct net_linkaddr *net_pkt_lladdr_src(struct net_pkt *pkt)
 {
 	return &pkt->lladdr_src;

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -382,7 +382,7 @@ int net_recv_data(struct net_if *iface, struct net_pkt *pkt)
 		return -EINVAL;
 	}
 
-	if (!pkt->frags) {
+	if (net_pkt_is_empty(pkt)) {
 		return -ENODATA;
 	}
 


### PR DESCRIPTION
If the network driver for some reason did not set the data in
the network packet properly, then just drop it as we cannot do
anything with just plain net_pkt.

Fixes #28131

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>