### PR TITLE
usb: bluetooth: Resume ACL transfer after suspend

### DIFF
--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -230,6 +230,8 @@ static void bluetooth_status_cb(struct usb_cfg_data *cfg,
 		break;
 	case USB_DC_RESUME:
 		LOG_DBG("USB device resumed");
+		/* Resume reading */
+		acl_read_cb(bluetooth_ep_data[HCI_OUT_EP_IDX].ep_addr, 0, NULL);
 		break;
 	case USB_DC_SOF:
 		break;


### PR DESCRIPTION
This pr fixes the problem that Zephyr hci_usb sample could not survive 
Suspend->Resume cycle from Host.

When device receives USB Suspend event, ACL transfer is canceled. Previously
ACL transfer was not resumed after host cleared the Suspend state and that
caused ACL data to be dropped in USB subsystem and not delivered to HCI driver.

Fix is to call acl_read_cb to resume USB transfer for ACL data.