### PR TITLE
drivers: eth_enc424j600: initialize device pointer

### DIFF
--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -600,6 +600,8 @@ static int enc424j600_init(const struct device *dev)
 	uint8_t retries = ENC424J600_DEFAULT_NUMOF_RETRIES;
 	uint16_t tmp;
 
+	context->dev = dev;
+
 	/* SPI config */
 	context->spi_cfg.operation = SPI_WORD_SET(8);
 	context->spi_cfg.frequency = config->spi_freq;


### PR DESCRIPTION
Initialize device pointer in driver's context.

It was not done quite right in commit a1708cf2f209
("drivers: ethernet: Fix device instance const qualifier loss"),
and then completely removed in commit 113d9274ea8d
("drivers: ethernet: remove stray expression")'