### PR TITLE
boards: arm: arty: note which boards can use the pre-built bitstream

### DIFF
--- a/boards/arm/arty/doc/index.rst
+++ b/boards/arm/arty/doc/index.rst
@@ -133,6 +133,12 @@ or:
         pld load 0 m3_for_arty_a7_reference.bit;\
         shutdown"
 
+.. note::
+
+   The pre-built FPGA bitstream only works for Arty boards equipped with an
+   Artix-35T FPGA. For other Arty variants (e.g. the Arty A7-100) the bitstream
+   must be rebuilt.
+
 Next, build and flash applications as usual (see :ref:`build_an_application` and
 :ref:`application_run` for more details).
 


### PR DESCRIPTION
Add a note on which Arty boards can be programmed with the pre-built FPGA bitstream.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>