### PR TITLE
cleanup of work queue APIs and behavior

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3339,15 +3339,12 @@ extern int k_delayed_work_submit_to_queue(struct k_work_q *work_q,
  *
  * @note Can be called by ISRs.
  *
- * @note The result of calling this on a k_delayed_work item that has
- * not been submitted (i.e. before the return of the
- * k_delayed_work_submit_to_queue() call) is undefined.
- *
  * @param work Address of delayed work item.
  *
  * @retval 0 Work item countdown canceled.
- * @retval -EINVAL Work item is being processed.
- * @retval -EALREADY Work item has already been completed.
+ * @retval -EINPROGRESS Work item is pending but has not been started.
+ * @retval -EINVAL Work item was never submitted, or has been started and
+ * may or may not have completed.
  */
 extern int k_delayed_work_cancel(struct k_delayed_work *work);
 

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3074,7 +3074,7 @@ struct k_work {
 struct k_delayed_work {
 	struct k_work work;
 	struct _timeout timeout;
-	struct k_work_q *work_q;
+	struct k_work_q *work_q; /* null if not scheduled */
 };
 
 struct k_work_poll {

--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -132,12 +132,12 @@ done:
 
 int k_delayed_work_cancel(struct k_delayed_work *work)
 {
-	if (!work->work_q) {
-		return -EINVAL;
-	}
-
 	k_spinlock_key_t key = k_spin_lock(&lock);
-	int ret = work_cancel(work);
+	int ret = z_abort_timeout(&work->timeout);
+
+	if (ret != 0) {
+		ret = k_work_pending(&work->work) ? -EINPROGRESS : -EINVAL;
+	}
 
 	k_spin_unlock(&lock, key);
 	return ret;

--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -41,9 +41,11 @@ static void work_timeout(struct _timeout *t)
 {
 	struct k_delayed_work *w = CONTAINER_OF(t, struct k_delayed_work,
 						   timeout);
+	struct k_work_q *wq = w->work_q;
 
 	/* submit work to workqueue */
-	k_work_submit_to_queue(w->work_q, &w->work);
+	w->work_q = NULL;
+	k_work_submit_to_queue(wq, &w->work);
 }
 
 void k_delayed_work_init(struct k_delayed_work *work, k_work_handler_t handler)

--- a/tests/kernel/workq/work_queue_api/src/main.c
+++ b/tests/kernel/workq/work_queue_api/src/main.c
@@ -268,16 +268,9 @@ static void twork_resubmit(void *data)
 
 	k_delayed_work_submit_to_queue(work_q, &new_work, K_NO_WAIT);
 
-	/* This is done to test a neagtive case when k_delayed_work_cancel()
-	 * fails in k_delayed_work_submit_to_queue API. Removing work from it
-	 * queue make sure that k_delayed_work_cancel() fails when the Work is
-	 * resubmitted.
-	 */
-	k_queue_remove(&(new_work.work_q->queue), &(new_work.work));
-
 	zassert_equal(k_delayed_work_submit_to_queue(work_q, &new_work,
 				K_NO_WAIT),
-				-EINVAL, NULL);
+				0, NULL);
 
 	k_sem_give(&sync_sema);
 }

--- a/tests/kernel/workq/work_queue_api/src/main.c
+++ b/tests/kernel/workq/work_queue_api/src/main.c
@@ -377,7 +377,7 @@ static void tdelayed_work_cancel(const void *data)
 			     NULL);
 		/**TESTPOINT: delayed work cancel when pending*/
 		ret = k_delayed_work_cancel(&delayed_work[1]);
-		zassert_equal(ret, 0, NULL);
+		zassert_equal(ret, -EINPROGRESS, NULL);
 		k_sem_give(&sync_sema);
 		/*wait for completed work_sleepy and delayed_work[1]*/
 		k_sleep(TIMEOUT);
@@ -387,7 +387,7 @@ static void tdelayed_work_cancel(const void *data)
 					NULL);
 		/**TESTPOINT: delayed work cancel when completed*/
 		ret = k_delayed_work_cancel(&delayed_work_sleepy);
-		zassert_not_equal(ret, 0, NULL);
+		zassert_equal(ret, -EINVAL, NULL);
 	}
 	/*work items not cancelled: delayed_work[1], delayed_work_sleepy*/
 }
@@ -1077,7 +1077,7 @@ void test_cancel_processed_work_item(void)
 	/**TESTPOINT: try to delay already processed work item*/
 	ret = k_delayed_work_cancel(&work_item_delayed);
 
-	zassert_true(ret == -EALREADY, NULL);
+	zassert_true(ret == -EINVAL, NULL);
 	k_sleep(TIMEOUT);
 }
 


### PR DESCRIPTION
Superseded by #29618

After reviewing the existing work queue API I believe much of the complexity arises because k_delayed_work attempted to remove items from the work queue after they'd become pending.  This "feature" actually causes problems beyond making it hard to know the status of a cancelled item: it violates the expectation of core `k_work_submit_to_queue()` that the priority (position) of already pending work item is not affected if it is resubmitted.

Consequently I'm proposing the set of patches in this PR as a solution to #27356.  There is still no reliable way to determine whether a work item has been completed, but without introducing locks or complex atomic bits the only way to do that is to have the handler itself mark completion, as is done in a patch that cleans up the only in-tree use of the `k_delayed_work_cancel()` return value (in the Bluetooth GATT cache infrastructure).

Bugs fixed:

* Fix failures when a `k_delayed_work` item moves between different queues.
* Fix several race conditions in `k_delayed_work_cancel()` that make the return value inconsistent.

API changes:

* Remove undocumented behavior that `k_delayed_work_cancel()` would remove a work item from the work queue if its timeout had been reached.  The documented behavior requires that cancelling in this stage be diagnosed as an error, and is more compatible with  non-delayed k_work capability.
* Correct the documented return values of `k_delayed_work_cancel()` to reflect the actual distinguishable states and use better values.
* Change and clarify that `k_delayed_work_submit_to_queue()` with a `K_NO_WAIT` as a delay is functionally equivalent to invoking `k_work_submit_to_queue()` on the work member directly.  This makes resubmission consistent with the documented behavior of `k_delayed_work_cancel()` and `k_work_submit_to_queue()` by keeping the work item from being repeatedly moved to the end of the queue.  These changes eliminate `-EALREADY` as a potential return value from `k_delayed_work_submit_to_queue()`.
