### PR TITLE
doc: release: Add highlights and NXP-related release notes

### DIFF
--- a/doc/releases/release-notes-2.4.rst
+++ b/doc/releases/release-notes-2.4.rst
@@ -9,6 +9,17 @@ We are pleased to announce the release of Zephyr RTOS version 2.4.0.
 
 Major enhancements with this release include:
 
+* Introduced initial support for virtual memory management.
+
+* Added Bluetooth host support for periodic advertisement and isochronous
+  channels.
+
+* Enabled the new TCP stack, TCP2, by default. This stack was introduced in
+  Zephyr v2.1.0 to improve network protocol testability with open source tools.
+
+* Introduced a new toolchain abstraction with initial implementations for GCC
+  and LLVM/Clang, and groundwork for future support of commercial toolchains.
+
 * Moved to using C99 integer types and deprecate Zephyr integer types.  The
   Zephyr types can be enabled by Kconfig DEPRECATED_ZEPHYR_INT_TYPES option.
 

--- a/doc/releases/release-notes-2.4.rst
+++ b/doc/releases/release-notes-2.4.rst
@@ -233,6 +233,7 @@ Boards & SoC Support
 * Added support for these SoC series:
 
   * ARM Cortex-M1/M3 DesignStart FPGA
+  * NXP i.MX RT685, i.MX8M Mini, and LPC11U6x
 
 * Made these changes in other SoC series:
 
@@ -245,6 +246,7 @@ Boards & SoC Support
   * ARM Cortex-M1/M3 DesignStart FPGA reference designs running on the Digilent
     Arty A7 development board
   * nRF21540 Devkit (nrf21540dk_nrf52840).
+  * NXP i.MX RT685 EVK, i.MX8M Mini EVK, LPCXpresso LPC11U68
   * OLIMEX-STM32-H103
   * ST B_L4S5I_IOT01A Discovery kit
   * ST NUCLEO-H745ZI-Q
@@ -256,6 +258,7 @@ Boards & SoC Support
   * b_l072z_lrwan1: Added flash, LoRa, USB, EEPROM, RNG
   * nucleo_l552ze_q: Added non secure target and TFM support
   * STM32 boards: Enabled MPU on all boards with at least 64K flash
+  * lpcxpresso55s69: Added TFM support
 
 * Added support for these following shields:
 
@@ -289,6 +292,7 @@ Drivers and Sensors
   * STM32: Various changes including Flash latency wait states computation,
     configuration option additions for H7 series, and fixes on F0/F3 PREDIV1
     support
+  * Added LPC11U6X driver.
 
 * Console
 
@@ -296,6 +300,7 @@ Drivers and Sensors
 * Counter
 
   * STM32: Added support on F0/F2 series
+  * Added MCUX PIT counter driver for Kinetis K6x and K8x SoCs.
 
 * Crypto
 
@@ -314,6 +319,8 @@ Drivers and Sensors
 
   * STM32: Number of changes including k_malloc removal, driver piority init
     increase, get_status API addition and various cleanups.
+  * Added MCUX EDMA driver for i.MX RT and Kinetis K6x SoCs.
+  * Added MCUX LPC driver for LPC and i.MX RT6xx SoCs.
 
 * EEPROM
 
@@ -354,6 +361,7 @@ Drivers and Sensors
 * GPIO
 
   * Added driver for the Xilinx AXI GPIO IP
+  * Added LPC11U6X driver.
 
 * Hardware Info
 
@@ -371,6 +379,7 @@ Drivers and Sensors
 
   * STM32: V1: Reset i2c device on read/write error
   * STM32: V2: Added dts configurable Timing option
+  * Fixed MCUX LPI2C driver transfer status after NACK.
 
 * I2S
 
@@ -411,6 +420,7 @@ Drivers and Sensors
 
 * Pinmux
 
+  * Added LPC11U6X driver.
 
 * PS/2
 
@@ -427,6 +437,9 @@ Drivers and Sensors
 * Serial
 
   * Added driver for the Xilinx UART Lite IP
+  * Added NXP IUART driver for i.MX8M Mini.
+  * Implemented uart_config_get API in MCUX UART driver
+  * Added LPC11U6X driver.
 
 * SPI
 
@@ -438,6 +451,8 @@ Drivers and Sensors
     selects that are not specified by a cs-gpios property.
   * Added driver for the Xilinx AXI Quad SPI IP
   * STM32: Various fixes around DMA mode.
+  * Extended MCUX Flexcomm driver to support slave mode.
+  * Added optional delays to MCUX DSPI and LPSPI drivers.
 
 * Timer
 
@@ -461,6 +476,8 @@ Drivers and Sensors
 
 
 * Watchdog
+
+  * Added MCUX WWDT driver for LPC SoCs.
 
 
 * WiFi


### PR DESCRIPTION
- Fills in the highlights section for the 2.4.0 release notes.
- Adds 2.4.0 release notes for NXP SoCs, boards, and drivers.
