### PR TITLE
tests: x86/pagetables: skip table dumping if large memory

### DIFF
--- a/tests/arch/x86/pagetables/src/main.c
+++ b/tests/arch/x86/pagetables/src/main.c
@@ -139,7 +139,15 @@ void test_null_map(void)
  */
 void test_dump_ptables(void)
 {
+#if CONFIG_SRAM_SIZE > (32 << 10)
+	/*
+	 * Takes too long to dump page table, so skip dumping
+	 * if memory size is larger than 32MB.
+	 */
+	ztest_test_skip();
+#else
 	z_x86_dump_page_tables(z_x86_page_tables_get());
+#endif
 }
 
 void test_main(void)


### PR DESCRIPTION
For boards with (relatively) large memory, the test which dumps
page tables takes a long time to finish. The default timeout of
sanitycheck is not enough for those boards. UP Squared board is
such a board. So limits to pagetable dumping to boards with
less than 32MB.

Fixes #28548

Signed-off-by: Daniel Leung <daniel.leung@intel.com>