### PR TITLE
cmake: fix zephyr_get_system_include_directories_for_lang() function

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -217,7 +217,7 @@ function(zephyr_get_system_include_directories_for_lang lang i)
 
   process_flags(${lang} flags output_list)
   string(REPLACE ";" "$<SEMICOLON>" genexp_output_list "${output_list}")
-  set(result_output_list "-isystem$<JOIN:${genexp_output_list}, -isystem>")
+  set(result_output_list "$<$<BOOL:${genexp_output_list}>:-isystem$<JOIN:${genexp_output_list}, -isystem>>")
 
   set(${i} ${result_output_list} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
This commit fixes the zephyr_get_system_include_directories_for_lang()
function in the event that no system include directories are specified
for Zephyr interface.

This fixes an issue where the value returned by this function is
`-isystem` with no directory.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

-----

Fixes an issue discovered here: https://github.com/micropython/micropython/pull/6445