### PR TITLE
tests: portability/cmsis_rtos_v2: skip up_squared

### DIFF
--- a/tests/portability/cmsis_rtos_v2/testcase.yaml
+++ b/tests/portability/cmsis_rtos_v2/testcase.yaml
@@ -1,6 +1,9 @@
 tests:
   portability.cmsis_rtos_v2:
-    platform_exclude: qemu_x86_64 m2gl025_miv
+    # qemu_x86_64 and up_squared need bigger stack
+    # but CMSIS limits the stack size, resulting
+    # in stack overflow.
+    platform_exclude: qemu_x86_64 m2gl025_miv up_squared
     tags: cmsis_rtos
     min_ram: 32
     min_flash: 34


### PR DESCRIPTION
The up_squared board suffers the same issue as qemu_x86_64
where a bigger stack is needed but CMSIS has a limit on
how big the stack can be. This results in stack overflow
on one of the test.

Also, the thread API tests are not designed with SMP in mind.
The osThreadGetCount() would return a value smaller than
expected. This function only counts queued threads, where with
SMP, there are more CPUs running threads and thus fewer queued
ones.

So exclude up_squared from the test.

Fixes #27571

Signed-off-by: Daniel Leung <daniel.leung@intel.com>