### PR TITLE
arch: arm: Fix undefined symbol reference

### DIFF
--- a/arch/arm/core/aarch32/cortex_a_r/vector_table.S
+++ b/arch/arm/core/aarch32/cortex_a_r/vector_table.S
@@ -23,5 +23,9 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
 	ldr pc, =z_arm_prefetch_abort    /* prefetch abort offset  0xc */
 	ldr pc, =z_arm_data_abort        /* data abort     offset 0x10 */
 	nop				 /*                offset 0x14 */
+#ifdef CONFIG_GEN_SW_ISR_TABLE
 	ldr pc, =_isr_wrapper		 /* IRQ            offset 0x18 */
+#else
+	ldr pc, =z_irq_spurious
+#endif
 	ldr pc, =z_arm_nmi               /* FIQ            offset 0x1c */

--- a/arch/arm/core/aarch64/vector_table.S
+++ b/arch/arm/core/aarch64/vector_table.S
@@ -82,7 +82,12 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
 
 	/* Current EL with SPx / IRQ */
 	.align 7
-	b	_isr_wrapper
+
+#ifdef CONFIG_GEN_SW_ISR_TABLE
+	b 	_isr_wrapper
+#else
+	b	z_irq_spurious
+#endif
 
 	/* Current EL with SPx / FIQ */
 	.align 7

--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -326,6 +326,9 @@ void main(void)
 #endif
 #endif /* CONFIG_GEN_SW_ISR_TABLE */
 	rv = TC_PASS;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-label"
 done:
 	TC_END_RESULT(rv);
 	TC_END_REPORT(rv);

--- a/tests/kernel/gen_isr_table/testcase.yaml
+++ b/tests/kernel/gen_isr_table/testcase.yaml
@@ -9,6 +9,12 @@ tests:
         cc26x2r1_launchxl olimex_stm32_h103
     filter: CONFIG_GEN_ISR_TABLES and CONFIG_ARMV7_M_ARMV8_M_MAINLINE
     tags: interrupt isr_table
+  arch.interrupt.gen_isr_table.disabled:
+    arch_allow: arm
+    extra_configs:
+      - CONFIG_GEN_ISR_TABLES=n
+    tags: interrupt isr_table
+    build_only: true
   arch.interrupt.gen_isr_table.arc:
     arch_allow: arc
     filter: CONFIG_RGF_NUM_BANKS > 1


### PR DESCRIPTION
_isr_wrapper is not defined when building with
CONFIG_GEN_SW_ISR_TABLE = n.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>