### PR TITLE
ARC: MWDT: drop redundant stack checking

### DIFF
--- a/cmake/compiler/arcmwdt/target.cmake
+++ b/cmake/compiler/arcmwdt/target.cmake
@@ -36,5 +36,6 @@ foreach(isystem_include_dir ${NOSTDINC})
   list(APPEND isystem_include_flags -isystem "\"${isystem_include_dir}\"")
 endforeach()
 
-# common compile options, no copyright msg, little-endian, no small data
-list(APPEND TOOLCHAIN_C_FLAGS -Hnocopyr -HL -Hnosdata)
+# common compile options, no copyright msg, little-endian, no small data,
+# no MWDT stack checking
+list(APPEND TOOLCHAIN_C_FLAGS -Hnocopyr -HL -Hnosdata -Hoff=Stackcheck_alloca)

--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -206,16 +206,6 @@ SECTIONS {
 	__kernel_ram_end = .;
 	__kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
 
-#ifdef __MWDT_LINKER_CMD__
-/* mwdt requires _fstack, _estack which will be used in _stkchk.
- * _stkchk is inserted by mwdt automatically, if _fstack, _estack is not
- * set correctly, the  brk_s instruction will be called
- * here, we use a trick to deceive the compiler.
- */
-	_fstack = _image_ram_start;
-	_estack = .;
-#endif /* __MWDT_LINKER_CMD__ */
-
 	GROUP_END(RAMABLE_REGION)
 
 /* Located in generated directory. This file is populated by the


### PR DESCRIPTION
MWDT toolchain has Stackcheck_alloca option enabled by default. So it adds extra stack checking in addition to Zephyr's stack checking.

As it is completely redundant let's drop it.