### PR TITLE
drivers/sensor/lsm6dsl: Fix read/write bus API in shub code

### DIFF
--- a/drivers/sensor/lsm6dsl/lsm6dsl_shub.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_shub.c
@@ -34,7 +34,7 @@ LOG_MODULE_DECLARE(LSM6DSL, CONFIG_SENSOR_LOG_LEVEL);
 #define LSM6DSL_EMBEDDED_SLVX_THREE_SENS 0x20
 #define LSM6DSL_EMBEDDED_SLV0_WRITE_IDLE 0x07
 
-static int lsm6dsl_shub_write_slave_reg(struct lsm6dsl_data *data,
+static int lsm6dsl_shub_write_slave_reg(const struct device *dev,
 					uint8_t slv_addr, uint8_t slv_reg,
 					uint8_t *value, uint16_t len);
 
@@ -53,15 +53,16 @@ static int lsm6dsl_shub_write_slave_reg(struct lsm6dsl_data *data,
 #define LIS2MDL_OFF_CANC          0x02
 #define LIS2MDL_SENSITIVITY       1500
 
-static int lsm6dsl_lis2mdl_init(struct lsm6dsl_data *data, uint8_t i2c_addr)
+static int lsm6dsl_lis2mdl_init(const struct device *dev, uint8_t i2c_addr)
 {
+	struct lsm6dsl_data *data = dev->data;
 	uint8_t mag_cfg[2];
 
 	data->magn_sensitivity = LIS2MDL_SENSITIVITY;
 
 	/* sw reset device */
 	mag_cfg[0] = LIS2MDL_SW_RESET;
-	lsm6dsl_shub_write_slave_reg(data, i2c_addr,
+	lsm6dsl_shub_write_slave_reg(dev, i2c_addr,
 				     LIS2MDL_CFG_REG_A, mag_cfg, 1);
 
 	k_sleep(K_MSEC(10)); /* turn-on time in ms */
@@ -69,7 +70,7 @@ static int lsm6dsl_lis2mdl_init(struct lsm6dsl_data *data, uint8_t i2c_addr)
 	/* configure mag */
 	mag_cfg[0] = LIS2MDL_ODR_10HZ;
 	mag_cfg[1] = LIS2MDL_OFF_CANC;
-	lsm6dsl_shub_write_slave_reg(data, i2c_addr,
+	lsm6dsl_shub_write_slave_reg(dev, i2c_addr,
 				     LIS2MDL_CFG_REG_A, mag_cfg, 2);
 
 	return 0;
@@ -89,20 +90,20 @@ static int lsm6dsl_lis2mdl_init(struct lsm6dsl_data *data, uint8_t i2c_addr)
 #define LPS22HB_LPF_EN            0x08
 #define LPS22HB_BDU_EN            0x02
 
-static int lsm6dsl_lps22hb_init(struct lsm6dsl_data *data, uint8_t i2c_addr)
+static int lsm6dsl_lps22hb_init(const struct device *dev, uint8_t i2c_addr)
 {
 	uint8_t baro_cfg[2];
 
 	/* sw reset device */
 	baro_cfg[0] = LPS22HB_SW_RESET;
-	lsm6dsl_shub_write_slave_reg(data, i2c_addr,
+	lsm6dsl_shub_write_slave_reg(dev, i2c_addr,
 				     LPS22HB_CTRL_REG2, baro_cfg, 1);
 
 	k_sleep(K_MSEC(1)); /* turn-on time in ms */
 
 	/* configure device */
 	baro_cfg[0] = LPS22HB_ODR_10HZ | LPS22HB_LPF_EN | LPS22HB_BDU_EN;
-	lsm6dsl_shub_write_slave_reg(data, i2c_addr,
+	lsm6dsl_shub_write_slave_reg(dev, i2c_addr,
 				     LPS22HB_CTRL_REG1, baro_cfg, 1);
 
 	return 0;
@@ -116,7 +117,7 @@ static struct lsm6dsl_shub_sens_list {
 	uint8_t wai_val;
 	uint8_t out_data_addr;
 	uint8_t out_data_len;
-	int (*dev_init)(struct lsm6dsl_data *data, uint8_t i2c_addr);
+	int (*dev_init)(const struct device *dev, uint8_t i2c_addr);
 } lsm6dsl_shub_sens_list[] = {
 #ifdef CONFIG_LSM6DSL_EXT0_LIS2MDL
 	{
@@ -145,19 +146,21 @@ static struct lsm6dsl_shub_sens_list {
 
 static uint8_t ext_i2c_addr;
 
-static inline void lsm6dsl_shub_wait_completed(struct lsm6dsl_data *data)
+static inline void lsm6dsl_shub_wait_completed(const struct device *dev)
 {
+	struct lsm6dsl_data *data = dev->data;
 	uint16_t freq;
 
 	freq = (data->accel_freq == 0U) ? 26 : data->accel_freq;
 	k_msleep((2000U / freq) + 1);
 }
 
-static inline void lsm6dsl_shub_embedded_en(struct lsm6dsl_data *data, bool on)
+static inline void lsm6dsl_shub_embedded_en(const struct device *dev, bool on)
 {
+	struct lsm6dsl_data *data = dev->data;
 	uint8_t func_en = (on) ? 0x1 : 0x0;
 
-	data->hw_tf->update_reg(data, LSM6DSL_REG_FUNC_CFG_ACCESS,
+	data->hw_tf->update_reg(dev, LSM6DSL_REG_FUNC_CFG_ACCESS,
 				LSM6DSL_MASK_FUNC_CFG_EN,
 				func_en << LSM6DSL_SHIFT_FUNC_CFG_EN);
 
@@ -165,78 +168,84 @@ static inline void lsm6dsl_shub_embedded_en(struct lsm6dsl_data *data, bool on)
 }
 
 #ifdef LSM6DSL_DEBUG
-static int lsm6dsl_read_embedded_reg(struct lsm6dsl_data *data,
+static int lsm6dsl_read_embedded_reg(const struct device *dev,
 				     uint8_t reg_addr, uint8_t *value, int len)
 {
-	lsm6dsl_shub_embedded_en(data, true);
+	struct lsm6dsl_data *data = dev->data;
+	lsm6dsl_shub_embedded_en(dev, true);
 
-	if (data->hw_tf->read_data(data, reg_addr, value, len) < 0) {
+	if (data->hw_tf->read_data(dev, reg_addr, value, len) < 0) {
 		LOG_DBG("failed to read external reg: %02x", reg_addr);
-		lsm6dsl_shub_embedded_en(data, false);
+		lsm6dsl_shub_embedded_en(dev, false);
 		return -EIO;
 	}
 
-	lsm6dsl_shub_embedded_en(data, false);
+	lsm6dsl_shub_embedded_en(dev, false);
 
 	return 0;
 }
 #endif
 
-static int lsm6dsl_shub_write_embedded_regs(struct lsm6dsl_data *data,
+static int lsm6dsl_shub_write_embedded_regs(const struct device *dev,
 					    uint8_t reg_addr,
 					    uint8_t *value, uint8_t len)
 {
-	lsm6dsl_shub_embedded_en(data, true);
+	struct lsm6dsl_data *data = dev->data;
+	lsm6dsl_shub_embedded_en(dev, true);
 
-	if (data->hw_tf->write_data(data, reg_addr, value, len) < 0) {
+	if (data->hw_tf->write_data(dev, reg_addr, value, len) < 0) {
 		LOG_DBG("failed to write external reg: %02x", reg_addr);
-		lsm6dsl_shub_embedded_en(data, false);
+		lsm6dsl_shub_embedded_en(dev, false);
 		return -EIO;
 	}
 
-	lsm6dsl_shub_embedded_en(data, false);
+	lsm6dsl_shub_embedded_en(dev, false);
 
 	return 0;
 }
 
-static void lsm6dsl_shub_enable(struct lsm6dsl_data *data)
+static void lsm6dsl_shub_enable(const struct device *dev)
 {
+	struct lsm6dsl_data *data = dev->data;
+
 	/* Enable Digital Func */
-	data->hw_tf->update_reg(data, LSM6DSL_REG_CTRL10_C,
+	data->hw_tf->update_reg(dev, LSM6DSL_REG_CTRL10_C,
 				LSM6DSL_MASK_CTRL10_C_FUNC_EN,
 				1 << LSM6DSL_SHIFT_CTRL10_C_FUNC_EN);
 
 	/* Enable Accel @26hz */
 	if (!data->accel_freq) {
-		data->hw_tf->update_reg(data,
+		data->hw_tf->update_reg(dev,
 				    LSM6DSL_REG_CTRL1_XL,
 				    LSM6DSL_MASK_CTRL1_XL_ODR_XL,
 				    2 << LSM6DSL_SHIFT_CTRL1_XL_ODR_XL);
 	}
 
 	/* Enable Sensor Hub */
-	data->hw_tf->update_reg(data, LSM6DSL_REG_MASTER_CONFIG,
+	data->hw_tf->update_reg(dev, LSM6DSL_REG_MASTER_CONFIG,
 				LSM6DSL_MASK_MASTER_CONFIG_MASTER_ON,
 				1 << LSM6DSL_SHIFT_MASTER_CONFIG_MASTER_ON);
 }
 
-static void lsm6dsl_shub_disable(struct lsm6dsl_data *data)
+static void lsm6dsl_shub_disable(const struct device *dev)
 {
+	struct lsm6dsl_data *data = dev->data;
+
 	/* Disable Sensor Hub */
-	data->hw_tf->update_reg(data, LSM6DSL_REG_MASTER_CONFIG,
+	data->hw_tf->update_reg(dev, LSM6DSL_REG_MASTER_CONFIG,
 				LSM6DSL_MASK_MASTER_CONFIG_MASTER_ON,
 				0 << LSM6DSL_SHIFT_MASTER_CONFIG_MASTER_ON);
 
 	/* Disable Accel */
 	if (!data->accel_freq) {
-		data->hw_tf->update_reg(data,
+		data->hw_tf->update_reg(dev,
 				    LSM6DSL_REG_CTRL1_XL,
 				    LSM6DSL_MASK_CTRL1_XL_ODR_XL,
 				    0 << LSM6DSL_SHIFT_CTRL1_XL_ODR_XL);
 	}
 
 	/* Disable Digital Func */
-	data->hw_tf->update_reg(data, LSM6DSL_REG_CTRL10_C,
+	data->hw_tf->update_reg(dev, LSM6DSL_REG_CTRL10_C,
 				LSM6DSL_MASK_CTRL10_C_FUNC_EN,
 				0 << LSM6DSL_SHIFT_CTRL10_C_FUNC_EN);
 }
@@ -244,35 +253,36 @@ static void lsm6dsl_shub_disable(struct lsm6dsl_data *data)
 /*
  * use SLV0 for generic read to slave device
  */
-static int lsm6dsl_shub_read_slave_reg(struct lsm6dsl_data *data,
+static int lsm6dsl_shub_read_slave_reg(const struct device *dev,
 				       uint8_t slv_addr, uint8_t slv_reg,
 				       uint8_t *value, uint16_t len)
 {
+	struct lsm6dsl_data *data = dev->data;
 	uint8_t slave[3];
 
 	slave[0] = (slv_addr << 1) | LSM6DSL_EMBEDDED_SLVX_READ;
 	slave[1] = slv_reg;
 	slave[2] = (len & 0x7);
 
-	if (lsm6dsl_shub_write_embedded_regs(data, LSM6DSL_EMBEDDED_SLV0_ADDR,
+	if (lsm6dsl_shub_write_embedded_regs(dev, LSM6DSL_EMBEDDED_SLV0_ADDR,
 					     slave, 3) < 0) {
 		LOG_DBG("error writing embedded reg");
 		return -EIO;
 	}
 
 	/* turn SH on */
-	lsm6dsl_shub_enable(data);
-	lsm6dsl_shub_wait_completed(data);
-	data->hw_tf->read_data(data, LSM6DSL_REG_SENSORHUB1, value, len);
+	lsm6dsl_shub_enable(dev);
+	lsm6dsl_shub_wait_completed(dev);
+	data->hw_tf->read_data(dev, LSM6DSL_REG_SENSORHUB1, value, len);
 
-	lsm6dsl_shub_disable(data);
+	lsm6dsl_shub_disable(dev);
 	return 0;
 }
 
 /*
  * use SLV0 to configure slave device
  */
-static int lsm6dsl_shub_write_slave_reg(struct lsm6dsl_data *data,
+static int lsm6dsl_shub_write_slave_reg(const struct device *dev,
 					uint8_t slv_addr, uint8_t slv_reg,
 					uint8_t *value, uint16_t len)
 {
@@ -283,7 +293,7 @@ static int lsm6dsl_shub_write_slave_reg(struct lsm6dsl_data *data,
 		slv_cfg[0] = (slv_addr << 1) & ~LSM6DSL_EMBEDDED_SLVX_READ;
 		slv_cfg[1] = slv_reg + cnt;
 
-		if (lsm6dsl_shub_write_embedded_regs(data,
+		if (lsm6dsl_shub_write_embedded_regs(dev,
 						     LSM6DSL_EMBEDDED_SLV0_ADDR,
 						     slv_cfg, 2) < 0) {
 			LOG_DBG("error writing embedded reg");
@@ -291,7 +301,7 @@ static int lsm6dsl_shub_write_slave_reg(struct lsm6dsl_data *data,
 		}
 
 		slv_cfg[0] = value[cnt];
-		if (lsm6dsl_shub_write_embedded_regs(data,
+		if (lsm6dsl_shub_write_embedded_regs(dev,
 					LSM6DSL_EMBEDDED_SLV0_DATAWRITE,
 					slv_cfg, 1) < 0) {
 			LOG_DBG("error writing embedded reg");
@@ -299,9 +309,9 @@ static int lsm6dsl_shub_write_slave_reg(struct lsm6dsl_data *data,
 		}
 
 		/* turn SH on */
-		lsm6dsl_shub_enable(data);
-		lsm6dsl_shub_wait_completed(data);
-		lsm6dsl_shub_disable(data);
+		lsm6dsl_shub_enable(dev);
+		lsm6dsl_shub_wait_completed(dev);
+		lsm6dsl_shub_disable(dev);
 
 		cnt++;
 	}
@@ -310,7 +320,7 @@ static int lsm6dsl_shub_write_slave_reg(struct lsm6dsl_data *data,
 	slv_cfg[0] = LSM6DSL_EMBEDDED_SLV0_WRITE_IDLE;
 	slv_cfg[1] = lsm6dsl_shub_sens_list[0].wai_addr;
 	slv_cfg[2] = LSM6DSL_EMBEDDED_SLVX_THREE_SENS;
-	if (lsm6dsl_shub_write_embedded_regs(data,
+	if (lsm6dsl_shub_write_embedded_regs(dev,
 					     LSM6DSL_EMBEDDED_SLV0_ADDR,
 					     slv_cfg, 3) < 0) {
 		LOG_DBG("error writing embedded reg");
@@ -327,7 +337,7 @@ static int lsm6dsl_shub_write_slave_reg(struct lsm6dsl_data *data,
  *  - SLAVE 1: used as data read channel to slave device
  *  - SLAVE 2: used for generic reads while data channel is enabled
  */
-static int lsm6dsl_shub_set_data_channel(struct lsm6dsl_data *data)
+static int lsm6dsl_shub_set_data_channel(const struct device *dev)
 {
 	uint8_t slv_cfg[3];
 	uint8_t slv_i2c_addr = lsm6dsl_shub_sens_list[0].i2c_addr[ext_i2c_addr];
@@ -336,7 +346,7 @@ static int lsm6dsl_shub_set_data_channel(struct lsm6dsl_data *data)
 	slv_cfg[0] = LSM6DSL_EMBEDDED_SLV0_WRITE_IDLE;
 	slv_cfg[1] = lsm6dsl_shub_sens_list[0].wai_addr;
 	slv_cfg[2] = LSM6DSL_EMBEDDED_SLVX_THREE_SENS;
-	if (lsm6dsl_shub_write_embedded_regs(data,
+	if (lsm6dsl_shub_write_embedded_regs(dev,
 					     LSM6DSL_EMBEDDED_SLV0_ADDR,
 					     slv_cfg, 3) < 0) {
 		LOG_DBG("error writing embedded reg");
@@ -347,7 +357,7 @@ static int lsm6dsl_shub_set_data_channel(struct lsm6dsl_data *data)
 	slv_cfg[0] = (slv_i2c_addr << 1) | LSM6DSL_EMBEDDED_SLVX_READ;
 	slv_cfg[1] = lsm6dsl_shub_sens_list[0].out_data_addr;
 	slv_cfg[2] = lsm6dsl_shub_sens_list[0].out_data_len;
-	if (lsm6dsl_shub_write_embedded_regs(data,
+	if (lsm6dsl_shub_write_embedded_regs(dev,
 					     LSM6DSL_EMBEDDED_SLV1_ADDR,
 					     slv_cfg, 3) < 0) {
 		LOG_DBG("error writing embedded reg");
@@ -355,8 +365,8 @@ static int lsm6dsl_shub_set_data_channel(struct lsm6dsl_data *data)
 	}
 
 	/* turn SH on */
-	lsm6dsl_shub_enable(data);
-	lsm6dsl_shub_wait_completed(data);
+	lsm6dsl_shub_enable(dev);
+	lsm6dsl_shub_wait_completed(dev);
 
 	return 0;
 }
@@ -366,14 +376,13 @@ int lsm6dsl_shub_read_external_chip(const struct device *dev, uint8_t *buf,
 {
 	struct lsm6dsl_data *data = dev->data;
 
-	data->hw_tf->read_data(data, LSM6DSL_REG_SENSORHUB1, buf, len);
+	data->hw_tf->read_data(dev, LSM6DSL_REG_SENSORHUB1, buf, len);
 
 	return 0;
 }
 
 int lsm6dsl_shub_init_external_chip(const struct device *dev)
 {
-	struct lsm6dsl_data *data = dev->data;
 	uint8_t i;
 	uint8_t chip_id = 0U;
 	uint8_t slv_i2c_addr;
@@ -391,7 +400,7 @@ int lsm6dsl_shub_init_external_chip(const struct device *dev)
 			continue;
 		}
 
-		if (lsm6dsl_shub_read_slave_reg(data, slv_i2c_addr,
+		if (lsm6dsl_shub_read_slave_reg(dev, slv_i2c_addr,
 						slv_wai_addr,
 						&chip_id, 1) < 0) {
 			LOG_DBG("failed reading external chip id");
@@ -410,9 +419,9 @@ int lsm6dsl_shub_init_external_chip(const struct device *dev)
 	ext_i2c_addr = i;
 
 	/* init external device */
-	lsm6dsl_shub_sens_list[0].dev_init(data, slv_i2c_addr);
+	lsm6dsl_shub_sens_list[0].dev_init(dev, slv_i2c_addr);
 
-	lsm6dsl_shub_set_data_channel(data);
+	lsm6dsl_shub_set_data_channel(dev);
 
 	return 0;
 }


### PR DESCRIPTION
The ce0cc3a7 commit (lsm6dsl: make the driver multi-instance) changes
all bus API signature, which now requires a "const struct device *dev"
and not a "struct lsm6dsl_data *data". By mistake the shub part was
left unchanged. Fix: #28565

Not tested yet!
I just built it and verified it is compiling properly.
I would like to test it on x_nucleo_iks01a2 shield, but I require to extend the current available
sample. For the moment just take a look at it and see if I have done any mistake.

For the moment it is a DNM. I do not think the shub will have any problem. So, we may want to
skip the test if v2.4.0 has to be released soon.

EDIT:
Removed the DNM!
Tested on x_nucleo_iks01a2 shield in shub mode. Tested both LIS2MDL and LPS22HB sensors connected in shub mode.
The shield and sample changes will be provided in a separated commit as some documentation change is required.