### PR TITLE
HTS221: Check for drdy_gpio defs into DTS

### DIFF
--- a/drivers/sensor/hts221/hts221.c
+++ b/drivers/sensor/hts221/hts221.c
@@ -106,7 +106,7 @@ static int hts221_read_conversion_data(const struct device *dev)
 }
 
 static const struct sensor_driver_api hts221_driver_api = {
-#if CONFIG_HTS221_TRIGGER
+#if HTS221_TRIGGER_ENABLED
 	.trigger_set = hts221_trigger_set,
 #endif
 	.sample_fetch = hts221_sample_fetch,
@@ -168,11 +168,13 @@ int hts221_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-#ifdef CONFIG_HTS221_TRIGGER
+#if HTS221_TRIGGER_ENABLED
 	if (hts221_init_interrupt(dev) < 0) {
 		LOG_ERR("Failed to initialize interrupt.");
 		return -EIO;
 	}
+#else
+	LOG_INF("Cannot enable trigger without drdy-gpios");
 #endif
 
 	return 0;
@@ -182,11 +184,11 @@ static struct hts221_data hts221_driver;
 static const struct hts221_config hts221_cfg = {
 	.i2c_bus = DT_INST_BUS_LABEL(0),
 	.i2c_addr = DT_INST_REG_ADDR(0),
-#ifdef CONFIG_HTS221_TRIGGER
+#if HTS221_TRIGGER_ENABLED
 	.drdy_pin = DT_INST_GPIO_PIN(0, drdy_gpios),
 	.drdy_flags = DT_INST_GPIO_FLAGS(0, drdy_gpios),
 	.drdy_controller = DT_INST_GPIO_LABEL(0, drdy_gpios),
-#endif /* CONFIG_HTS221_TRIGGER */
+#endif /* HTS221_TRIGGER_ENABLED */
 };
 
 DEVICE_AND_API_INIT(hts221, DT_INST_LABEL(0), hts221_init,

--- a/drivers/sensor/hts221/hts221.h
+++ b/drivers/sensor/hts221/hts221.h
@@ -12,6 +12,9 @@
 #include <zephyr/types.h>
 #include <drivers/gpio.h>
 
+#define HTS221_TRIGGER_ENABLED (DT_INST_NODE_HAS_PROP(0, drdy_gpios) && \
+				IS_ENABLED(CONFIG_HTS221_TRIGGER))
+
 #define HTS221_AUTOINCREMENT_ADDR	BIT(7)
 
 #define HTS221_REG_WHO_AM_I		0x0F
@@ -42,7 +45,7 @@ struct hts221_data {
 	int16_t t0_out;
 	int16_t t1_out;
 
-#ifdef CONFIG_HTS221_TRIGGER
+#if HTS221_TRIGGER_ENABLED
 	const struct device *dev;
 	const struct device *drdy_dev;
 	struct gpio_callback drdy_cb;
@@ -58,20 +61,20 @@ struct hts221_data {
 	struct k_work work;
 #endif
 
-#endif /* CONFIG_HTS221_TRIGGER */
+#endif /* HTS221_TRIGGER_ENABLED */
 };
 
 struct hts221_config {
 	const char *i2c_bus;
 	uint16_t i2c_addr;
-#ifdef CONFIG_HTS221_TRIGGER
+#if HTS221_TRIGGER_ENABLED
 	gpio_pin_t drdy_pin;
 	gpio_flags_t drdy_flags;
 	const char *drdy_controller;
-#endif /* CONFIG_HTS221_TRIGGER */
+#endif /* HTS221_TRIGGER_ENABLED */
 };
 
-#ifdef CONFIG_HTS221_TRIGGER
+#if HTS221_TRIGGER_ENABLED
 int hts221_trigger_set(const struct device *dev,
 			const struct sensor_trigger *trig,
 			sensor_trigger_handler_t handler);

--- a/drivers/sensor/hts221/hts221_trigger.c
+++ b/drivers/sensor/hts221/hts221_trigger.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT st_hts221
+
 #include <device.h>
 #include <drivers/i2c.h>
 #include <sys/__assert.h>
@@ -13,6 +15,7 @@
 #include <logging/log.h>
 #include "hts221.h"
 
+#if HTS221_TRIGGER_ENABLED
 LOG_MODULE_DECLARE(HTS221, CONFIG_SENSOR_LOG_LEVEL);
 
 static inline void setup_drdy(const struct device *dev,
@@ -163,3 +166,4 @@ int hts221_init_interrupt(const struct device *dev)
 
 	return 0;
 }
+#endif /* HTS221_TRIGGER_ENABLED */


### PR DESCRIPTION
Added the gpio for HTS221 drdy in Device Tree.
Fix #28443

Built only, not tested.
Issue here is because HTS221 has been added in build_all trigger file, but the gpio drdy was not provided in disco_l475_iot1 device tree.
I have not tested it on the board itself, I can do tomorrow if required. Please review also the schematic, I
may have an older one. Thanks!

EDIT:
Totally changed the fix. Instead of defining the drdy_gpios in DTS (it is a not required option) I check it in the hts221 driver itself before using the generated macro.