### PR TITLE
net: tcp2: Lock connection when running from work queue

### DIFF
--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -524,6 +524,10 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 		src_port = proto_hdr->udp->src_port;
 		dst_port = proto_hdr->udp->dst_port;
 	} else if (IS_ENABLED(CONFIG_NET_TCP) && proto == IPPROTO_TCP) {
+		if (proto_hdr->tcp == NULL) {
+			return NET_DROP;
+		}
+
 		src_port = proto_hdr->tcp->src_port;
 		dst_port = proto_hdr->tcp->dst_port;
 	} else if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET)) {

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -178,7 +178,12 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 	struct net_linkaddr *lladdr;
 	sa_family_t family;
 
-	if (hdr == NULL) {
+	/* This expects that the Ethernet header is in the first net_buf
+	 * fragment. This is a safe expectation here as it would not make
+	 * any sense to split the Ethernet header to two net_buf's by the
+	 * Ethernet driver.
+	 */
+	if (hdr == NULL || pkt->buffer->len < hdr_len) {
 		goto drop;
 	}
 

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -174,9 +174,15 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 	struct ethernet_context *ctx = net_if_l2_data(iface);
 	struct net_eth_hdr *hdr = NET_ETH_HDR(pkt);
 	uint8_t hdr_len = sizeof(struct net_eth_hdr);
-	uint16_t type = ntohs(hdr->type);
+	uint16_t type;
 	struct net_linkaddr *lladdr;
 	sa_family_t family;
+
+	if (hdr == NULL) {
+		goto drop;
+	}
+
+	type = ntohs(hdr->type);
 
 	if (net_eth_is_vlan_enabled(ctx, iface) &&
 	    type == NET_ETH_PTYPE_VLAN &&


### PR DESCRIPTION
We run various TCP function from work queue. Make sure the
connection lock is taken before accessing the connection.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>

Possible fix to #28587 